### PR TITLE
tests/smoke: capture failure-time diagnostics before mfs_var's teardown reboot

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1528,6 +1528,12 @@ def _dump_vm_on_failure(request: pytest.FixtureRequest) -> Iterator[None]:
         for entry in stub.queries():
             print(f"  {entry['client']:>15}  {entry['type']:<5} {entry['name']}")
         print("========== END STUB DNS UPSTREAM ==========")
+    # A fixture (tick's mfs_var) may have already captured failure-time state pre-teardown,
+    # BEFORE its revert reboot wiped the MFS /var (issue #774). This autouse dump finalizes
+    # after that fixture, so a second dump here would show the post-reboot state and mislead
+    # the post-mortem — keep the (host-side) stub log above, skip the VM dump.
+    if getattr(request.node, "_pfb_failure_dumped", False):
+        return
     vm = request.node.funcargs.get("deployed_vm") or request.node.funcargs.get("smoke_vm")
     # Some deployed_vm fixtures yield a (pfSense, civm) tuple in the two-VM topology;
     # dump_diagnostics wants the pfSense SmokeVM, so unwrap to the first element.

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -4258,6 +4258,12 @@ def dump_diagnostics(vm: SmokeVM) -> None:
         ("pf rules (pfB_/DNSBL refs)", "/sbin/pfctl -sr 2>/dev/null | grep -iE 'pfB_|DNSBL' || true"),
         ("/var/db/pfblockerng listing", "ls -lR /var/db/pfblockerng 2>/dev/null | head -80 || true"),
         (
+            # The listing above shows only presence/size; the tick (ADR-43) failures need
+            # the actual per-job next_due values as they were at failure time.
+            "due-ledger content (pfb_due_ledger.json)",
+            "cat /var/db/pfblockerng/pfb_due_ledger.json 2>/dev/null || echo '(absent)'",
+        ),
+        (
             # Target unbound.conf only — a recursive grep over /var/unbound is slow
             # (large python data files) and timed out. Include the forward config.
             "unbound.conf: forward/local-data/access",

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -280,7 +280,7 @@ def test_tick_wiped_ledger_jittered(deployed_vm: SmokeVM):
 
 
 @pytest.fixture
-def mfs_var(deployed_vm: SmokeVM) -> Iterator[SmokeVM]:
+def mfs_var(deployed_vm: SmokeVM, request: pytest.FixtureRequest) -> Iterator[SmokeVM]:
     """Arrange test_tick_reboot_persists_ledger's documented Background: MFS /var.
 
     ``set_ramdisk`` only flips the ``use_mfs_tmpvar`` config flag; the reload that follows
@@ -313,12 +313,27 @@ def mfs_var(deployed_vm: SmokeVM) -> Iterator[SmokeVM]:
     try:
         yield vm
     finally:
+        # Failure-time capture FIRST (issue #774): the revert reboot below wipes the MFS
+        # /var this test ran on, and the autouse _dump_vm_on_failure finalizes only AFTER
+        # this fixture (reverse setup order — pinned by test_fixture_teardown_contract.py),
+        # i.e. post-reboot, when that state is already gone. Dump here, pre-reboot, and
+        # flag the node so the autouse dump doesn't print a second, post-reboot snapshot.
+        rep = getattr(request.node, "_rep_call", None)
+        if rep is not None and rep.failed:
+            print("\n[smoke] mfs_var: failure-time diagnostics BEFORE the teardown reboot (issue #774)")
+            h.dump_diagnostics(vm)
+            request.node._pfb_failure_dumped = True  # type: ignore[attr-defined]
         # Best-effort, mirrors test_smoke_boot_reload's deployed_vm teardown: never mask
-        # the test result on cleanup failure. The reboot here is REQUIRED (not optional) —
-        # without it the running /var stays MFS and pollutes every module that runs next.
+        # the test result on cleanup failure.
         try:
             h.set_ramdisk(vm, False)
             h.reload(vm, "update")
+        except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the test result
+            print(f"[smoke] mfs_var ramdisk-off teardown failed (non-fatal): {exc}")
+        # Own try (matches the #765 sibling teardowns): a flaky reload must not skip the
+        # reboot — the one step that actually clears the running MFS /var once the flag is
+        # off. Without it /var stays MFS and pollutes every module that runs next.
+        try:
             h.reboot_vm(vm)
         except Exception as exc:  # noqa: BLE001 -- teardown cleanup, never mask the test result
             print(f"[smoke] mfs_var teardown reboot failed (non-fatal): {exc}")

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -320,9 +320,15 @@ def mfs_var(deployed_vm: SmokeVM, request: pytest.FixtureRequest) -> Iterator[Sm
         # flag the node so the autouse dump doesn't print a second, post-reboot snapshot.
         rep = getattr(request.node, "_rep_call", None)
         if rep is not None and rep.failed:
-            print("\n[smoke] mfs_var: failure-time diagnostics BEFORE the teardown reboot (issue #774)")
-            h.dump_diagnostics(vm)
-            request.node._pfb_failure_dumped = True  # type: ignore[attr-defined]
+            # Own try: dump_diagnostics is best-effort by contract, but a future probe
+            # that raises here would skip the ramdisk revert AND the reboot below — a
+            # worse leak than the one #774 fixes. Guard like the sibling steps.
+            try:
+                print("\n[smoke] mfs_var: failure-time diagnostics BEFORE the teardown reboot (issue #774)")
+                h.dump_diagnostics(vm)
+                request.node._pfb_failure_dumped = True  # type: ignore[attr-defined]
+            except Exception as exc:  # noqa: BLE001 -- pre-revert diagnostics, never mask the test result
+                print(f"[smoke] mfs_var pre-reboot diagnostics failed (non-fatal): {exc}")
         # Best-effort, mirrors test_smoke_boot_reload's deployed_vm teardown: never mask
         # the test result on cleanup failure.
         try:

--- a/tests/test_fixture_teardown_contract.py
+++ b/tests/test_fixture_teardown_contract.py
@@ -62,12 +62,13 @@ def test_requested_fixture_finalizes_first_and_sees_the_failure_report(pytester:
 
     result = pytester.runpytest("-s", "-q")
 
-    out = result.stdout.str()
-    assert "MFS-TEARDOWN failed=True" in out, f"requested-fixture teardown did not see the failed report:\n{out}"
-    assert "AUTOUSE-TEARDOWN failed=True" in out, f"autouse teardown did not see the failed report:\n{out}"
-    mfs_pos = out.index("MFS-TEARDOWN failed=True")
-    autouse_pos = out.index("AUTOUSE-TEARDOWN failed=True")
-    assert mfs_pos < autouse_pos, (
-        "expected the requested fixture (mfs_var-style) to finalize BEFORE the autouse dump "
-        f"(reverse setup order); actual output order:\n{out}"
+    # fnmatch_lines asserts the lines occur IN THIS ORDER (with full-output diagnostics
+    # on mismatch): the requested fixture (mfs_var-style) finalizes before the autouse
+    # dump, and both saw failed=True — the two contracts under pin. Wildcards keep the
+    # match robust against pytest's progress-marker interleaving under -s.
+    result.stdout.fnmatch_lines(
+        [
+            "*MFS-TEARDOWN failed=True*",
+            "*AUTOUSE-TEARDOWN failed=True*",
+        ]
     )

--- a/tests/test_fixture_teardown_contract.py
+++ b/tests/test_fixture_teardown_contract.py
@@ -1,0 +1,73 @@
+"""Pin the pytest contracts the mfs_var pre-reboot failure dump relies on (issue #774).
+
+``tests/smoke/test_smoke_tick.py``'s ``mfs_var`` fixture captures failure-time
+diagnostics in its own teardown, BEFORE its revert reboot wipes the MFS /var — instead
+of leaving it to the autouse ``_dump_vm_on_failure``. That design is only correct if two
+pytest behaviours hold:
+
+1. A fixture requested by the test finalizes BEFORE an autouse fixture of the same scope
+   (reverse setup order — autouse sets up first), so the autouse dump runs post-reboot,
+   too late.
+2. The ``pytest_runtest_makereport`` hookwrapper's stashed ``_rep_call`` is already
+   readable inside fixture teardowns, so the requested fixture can see the failure.
+
+If either contract changes in a future pytest, this test goes red and flags that the
+tick failure diagnostics are silently broken again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+_CONFTEST = """
+import pytest
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    rep = outcome.get_result()
+    setattr(item, f"_rep_{rep.when}", rep)
+"""
+
+_TESTFILE = """
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def dump_on_failure(request):
+    yield
+    rep = getattr(request.node, "_rep_call", None)
+    print(f"AUTOUSE-TEARDOWN failed={getattr(rep, 'failed', None)}")
+
+
+@pytest.fixture
+def mfs_like(request):
+    yield
+    rep = getattr(request.node, "_rep_call", None)
+    print(f"MFS-TEARDOWN failed={getattr(rep, 'failed', None)}")
+
+
+def test_fails(mfs_like):
+    raise AssertionError("deliberate failure to exercise the teardown path")
+"""
+
+
+def test_requested_fixture_finalizes_first_and_sees_the_failure_report(pytester: pytest.Pytester) -> None:
+    """mfs_var-style teardown runs before the autouse dump and can read the failed report."""
+    pytester.makeconftest(_CONFTEST)
+    pytester.makepyfile(_TESTFILE)
+
+    result = pytester.runpytest("-s", "-q")
+
+    out = result.stdout.str()
+    assert "MFS-TEARDOWN failed=True" in out, f"requested-fixture teardown did not see the failed report:\n{out}"
+    assert "AUTOUSE-TEARDOWN failed=True" in out, f"autouse teardown did not see the failed report:\n{out}"
+    mfs_pos = out.index("MFS-TEARDOWN failed=True")
+    autouse_pos = out.index("AUTOUSE-TEARDOWN failed=True")
+    assert mfs_pos < autouse_pos, (
+        "expected the requested fixture (mfs_var-style) to finalize BEFORE the autouse dump "
+        f"(reverse setup order); actual output order:\n{out}"
+    )


### PR DESCRIPTION
## Summary

Fixes #774 — and the defect is worse than filed: the issue assumed the autouse `_dump_vm_on_failure` prints live diagnostics before `mfs_var`'s teardown reboot. Empirically it does not — an autouse fixture sets up before a requested fixture of the same scope, so it finalizes after it (reverse setup order). On a failure of `test_tick_reboot_persists_ledger`, both the module-end tarball and the live failure dump therefore ran post-reboot, after the MFS /var (logs, `/var/db/pfblockerng`, the due-ledger) was already wiped: failure-time state loss was total.

## Changes

- `tests/smoke/test_smoke_tick.py` — `mfs_var` captures `h.dump_diagnostics(vm)` in its own teardown, pre-reboot, when the test failed, and flags the node (`_pfb_failure_dumped`) so the autouse dump does not print a second, post-reboot (misleading) VM snapshot. The teardown reboot also moves to its own `try`, matching the #765 siblings (PR #772): a flaky reload must not skip the leak-closing reboot.
- `tests/smoke/conftest.py` — `_dump_vm_on_failure` skips the VM dump when the flag is set (the host-side stub-DNS log still prints).
- `tests/smoke/helpers.py` — `dump_diagnostics` gains a due-ledger content probe (`pfb_due_ledger.json`); the existing listing probe shows only presence/size, not the `next_due` values a tick failure post-mortem needs.
- `tests/test_fixture_teardown_contract.py` — pins the two pytest contracts the pre-reboot dump relies on: requested-fixture teardown runs before the autouse teardown, and the `pytest_runtest_makereport`-stashed `_rep_call` is readable at fixture teardown. If a future pytest changes either, this goes red instead of the diagnostics silently regressing again.

## Testing

- New contract test: `python -m pytest tests/test_fixture_teardown_contract.py` — 1 passed (behaviour-preserving oracle; it pins the mechanism the fix depends on — the failure-dump path itself only executes on a live-VM test failure, which a green CI run cannot exercise by construction).
- Full unit suite: 2085 passed, 4 skipped. `ruff` / `mypy tests/` clean.
- Live-VM validation: selective smoke dispatch of the tick module from this branch (pass path — proves the reworked teardown still tears down cleanly).

Fixes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3aGLFmd8VeHoa9zZ7j5af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure diagnostics during smoke tests so only the most relevant VM state is captured after a reboot-related failure.
  * Added extra diagnostic output for ledger-related issues, making it easier to investigate tick/persistence problems.
  * Made teardown handling more resilient so diagnostic collection does not hide the original test failure.

* **Tests**
  * Added a contract test to verify fixture teardown ordering and failure-report access during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->