### PR TITLE
tests/smoke: dump diagnostics on fixture arrange failures too

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1514,12 +1514,27 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]) -> 
     setattr(item, f"_rep_{rep.when}", rep)
 
 
+def _failure_report(node: pytest.Item) -> pytest.TestReport | None:
+    """The report that proves this test failed, or None if it did not fail.
+
+    Call-phase report first; when absent, fall back to the setup report (issue #777):
+    a fixture that raises during arrange means the test never reaches its call phase,
+    so ``_rep_call`` is never stashed — without the fallback an arrange failure got no
+    diagnostics at all. A setup SKIP (e.g. SMOKE_PKG unset) has ``failed == False`` and
+    correctly returns None.
+    """
+    rep = getattr(node, "_rep_call", None)
+    if rep is None:
+        rep = getattr(node, "_rep_setup", None)
+    return rep if rep is not None and rep.failed else None
+
+
 @pytest.fixture(autouse=True)
 def _dump_vm_on_failure(request: pytest.FixtureRequest) -> Iterator[None]:
-    """If a VM-backed case failed, print pfSense/Unbound/pfBlockerNG state."""
+    """If a VM-backed case failed — in its body OR in a fixture arrange — print
+    pfSense/Unbound/pfBlockerNG state."""
     yield
-    rep = getattr(request.node, "_rep_call", None)
-    if rep is None or not rep.failed:
+    if _failure_report(request.node) is None:
         return
     # The mock DNS query log — what reached the upstream, READ not inferred.
     stub = request.node.funcargs.get("stub_dns")

--- a/tests/test_fixture_teardown_contract.py
+++ b/tests/test_fixture_teardown_contract.py
@@ -1,9 +1,9 @@
-"""Pin the pytest contracts the mfs_var pre-reboot failure dump relies on (issue #774).
+"""Pin the failure-diagnostics contracts of the smoke suite's dump machinery.
 
-``tests/smoke/test_smoke_tick.py``'s ``mfs_var`` fixture captures failure-time
-diagnostics in its own teardown, BEFORE its revert reboot wipes the MFS /var — instead
-of leaving it to the autouse ``_dump_vm_on_failure``. That design is only correct if two
-pytest behaviours hold:
+Issue #774: ``tests/smoke/test_smoke_tick.py``'s ``mfs_var`` fixture captures
+failure-time diagnostics in its own teardown, BEFORE its revert reboot wipes the MFS
+/var — instead of leaving it to the autouse ``_dump_vm_on_failure``. That design is
+only correct if two pytest behaviours hold:
 
 1. A fixture requested by the test finalizes BEFORE an autouse fixture of the same scope
    (reverse setup order — autouse sets up first), so the autouse dump runs post-reboot,
@@ -11,13 +11,25 @@ pytest behaviours hold:
 2. The ``pytest_runtest_makereport`` hookwrapper's stashed ``_rep_call`` is already
    readable inside fixture teardowns, so the requested fixture can see the failure.
 
-If either contract changes in a future pytest, this test goes red and flags that the
-tick failure diagnostics are silently broken again.
+Issue #777: a fixture that raises during ARRANGE means the test never reaches its call
+phase, so ``_rep_call`` is never stashed — the failure signal is then the SETUP report.
+``_failure_report`` in ``tests/smoke/conftest.py`` owns that call-then-setup fallback;
+its branches are pinned here against the real function, and the pytest contract it
+relies on (``_rep_setup`` stashed + readable at autouse teardown when arrange fails) is
+pinned by its own pytester case.
+
+If any contract changes in a future pytest, this test goes red and flags that the
+smoke failure diagnostics are silently broken again.
 """
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
+
+from tests.smoke.conftest import _failure_report
 
 pytest_plugins = ["pytester"]
 
@@ -72,3 +84,75 @@ def test_requested_fixture_finalizes_first_and_sees_the_failure_report(pytester:
             "*AUTOUSE-TEARDOWN failed=True*",
         ]
     )
+
+
+_SETUP_FAIL_TESTFILE = """
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def dump_on_failure(request):
+    yield
+    rep_call = getattr(request.node, "_rep_call", None)
+    rep_setup = getattr(request.node, "_rep_setup", None)
+    print(
+        f"AUTOUSE-TEARDOWN call_absent={rep_call is None} "
+        f"setup_failed={getattr(rep_setup, 'failed', None)}"
+    )
+
+
+@pytest.fixture
+def arrange_fails():
+    raise RuntimeError("deliberate arrange failure")
+    yield
+
+
+def test_never_reaches_call(arrange_fails):
+    pass
+"""
+
+
+def test_arrange_failure_stashes_a_readable_setup_report(pytester: pytest.Pytester) -> None:
+    """Fixture raises during arrange: no call report, but _rep_setup.failed is readable (issue #777)."""
+    pytester.makeconftest(_CONFTEST)
+    pytester.makepyfile(_SETUP_FAIL_TESTFILE)
+
+    result = pytester.runpytest("-s", "-q")
+
+    result.stdout.fnmatch_lines(["*AUTOUSE-TEARDOWN call_absent=True setup_failed=True*"])
+
+
+def _node(**reps: Any) -> Any:
+    """A minimal stand-in for a pytest node carrying stashed phase reports."""
+    return SimpleNamespace(**reps)
+
+
+def _rep(*, failed: bool = False, skipped: bool = False) -> Any:
+    return SimpleNamespace(failed=failed, skipped=skipped)
+
+
+def test_failure_report_call_failure_wins() -> None:
+    """A failed call phase is the failure signal (the pre-#777 behaviour, preserved)."""
+    rep = _rep(failed=True)
+    assert _failure_report(_node(_rep_call=rep)) is rep
+
+
+def test_failure_report_passed_call_is_no_failure() -> None:
+    """A passed call phase means no dump — even if setup was somehow also stashed."""
+    assert _failure_report(_node(_rep_call=_rep(failed=False), _rep_setup=_rep(failed=True))) is None
+
+
+def test_failure_report_arrange_failure_falls_back_to_setup() -> None:
+    """No call report + failed setup = a fixture arrange failure ⇒ dump (issue #777)."""
+    rep = _rep(failed=True)
+    assert _failure_report(_node(_rep_setup=rep)) is rep
+
+
+def test_failure_report_arrange_skip_is_no_failure() -> None:
+    """A setup SKIP (e.g. SMOKE_PKG unset) must not trigger a dump — failed is False."""
+    assert _failure_report(_node(_rep_setup=_rep(skipped=True))) is None
+
+
+def test_failure_report_no_reports_is_no_failure() -> None:
+    """No stashed reports at all (nothing ran) ⇒ no dump."""
+    assert _failure_report(_node()) is None


### PR DESCRIPTION
## Summary

Fixes #777 (surfaced by the adversarial review on PR #776): a fixture that raises during **arrange** means the test never reaches its call phase, so `_rep_call` is never stashed — and `_dump_vm_on_failure` gated on it alone. An arrange failure (e.g. `mfs_var`'s engage reload/reboot failing) therefore produced **no VM diagnostics at all** — only the raised exception text.

## Changes

- `tests/smoke/conftest.py` — extract the failure gate into `_failure_report(node)`: the call-phase report wins; when absent, fall back to the **setup** report (`_rep_setup.failed`). A setup **skip** (e.g. `SMOKE_PKG` unset) has `failed == False` and stays a non-failure, so the routine skip path never dumps. `_dump_vm_on_failure` now consumes the predicate, covering arrange failures suite-wide (not just `mfs_var`).
- `tests/test_fixture_teardown_contract.py` — two additions:
  - a pytester case pinning the pytest contract the fallback relies on: when a fixture raises during arrange, the autouse teardown still runs, sees `_rep_call` absent, and can read `_rep_setup.failed=True` (verified empirically before building — including that a fixture `pytest.skip` yields `skipped=True, failed=False`);
  - branch coverage of the **real** `_failure_report` (imported from `tests.smoke.conftest`, which imports cleanly off-VM): call-failed → report; call-passed → None (even with a failed setup stashed); no-call + setup-failed → report (the #777 fix); setup-skip → None; no reports → None.

## Testing

- **Red→green proven**: with `_failure_report` temporarily reverted to call-only semantics, `test_failure_report_arrange_failure_falls_back_to_setup` fails (`assert None is namespace(failed=True…)`); with the fix it passes. The other six stay green in both states (they pin preserved behaviour).
- Full unit suite: 2097 passed, 4 skipped. `ruff` / `mypy tests/` clean.
- Live-VM validation: tick smoke dispatch from this branch exercises the reworked autouse gate's pass path on every test (`_failure_report` returns None → no dump).

Fixes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3aGLFmd8VeHoa9zZ7j5af