### PR TITLE
pfblockerng: keep killstates $pfb_local an IP-keyed set end-to-end

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10236,7 +10236,11 @@ function pfb_remove_states() {
 	$data		= pfb_filterrules();
 	$pfb_int	= $data['int'] ?: array();
 
-	// Collect local IPs
+	// Collect local IPs. $pfb_local is an IP-keyed set (isset() lookups) END-TO-END:
+	// pfb_collect_localip() already returns that shape, and plain lists are folded in
+	// via array_fill_keys(). No trailing array_flip(array_unique()) dedup -- issue #769:
+	// re-flipping the already-flipped map turned its keys back into integers, so the
+	// isset($pfb_local[$s_ip]) exclusion below could never match those entries.
 	$data = pfb_collect_localip();
 	if (!empty($data[0])) {
 		$pfb_local = array_merge($pfb_local, $data[0]);
@@ -10246,12 +10250,7 @@ function pfb_remove_states() {
 	// Collect DNS servers to suppress
 	$pfb_dnsservers = get_dns_servers();
 	if (!empty($pfb_dnsservers)) {
-		$pfb_local = array_merge($pfb_local, $pfb_dnsservers);
-	}
-
-	// Remove any duplicate IPs
-	if (!empty($pfb_local)) {
-		$pfb_local = array_flip(array_unique($pfb_local));
+		$pfb_local = array_merge($pfb_local, array_fill_keys($pfb_dnsservers, 0));
 	}
 
 	// Collect any 'Permit' Customlist IPs to suppress

--- a/tests/php/PfbRemoveStatesTest.php
+++ b/tests/php/PfbRemoveStatesTest.php
@@ -567,37 +567,65 @@ final class PfbRemoveStatesTest extends TestCase
 	}
 
 	/**
-	 * Scenario (#769) — a local IP collected by pfb_collect_localip() spares its state.
+	 * Scenario (#769) — local IPs collected by pfb_collect_localip() spare their
+	 * states, both families.
 	 *
 	 * Given: a NAT rule whose target is the (public, otherwise-killable)
-	 *        198.51.100.44 — pfb_collect_localip() folds NAT targets into its
-	 *        IP-keyed local map — plus a table-matched victim state alongside it.
+	 *        198.51.100.44 and a bare-address v6 VIP 3fff::44 — pfb_collect_localip()
+	 *        folds both into its IP-keyed local map — plus a table-matched victim
+	 *        state per family.
 	 * When:  pfb_remove_states() runs.
-	 * Then:  the victim is killed (proves the pass ran) and the local IP is NOT.
-	 *        FAILS pre-fix: the "Remove any duplicate IPs" step re-flipped the
-	 *        already-flipped local map (array_flip(array_unique())), turning its
-	 *        IP keys back into integers, so isset($pfb_local[$s_ip]) never matched.
+	 * Then:  both victims are killed (proves the pass ran) and neither local IP is.
+	 *        FAILS pre-fix (both families): the "Remove any duplicate IPs" step
+	 *        re-flipped the already-flipped local map (array_flip(array_unique())),
+	 *        turning its IP keys back into integers, so isset($pfb_local[$s_ip])
+	 *        never matched.
 	 */
-	public function test_local_ip_from_collect_localip_spares_state_others_still_killed(): void
+	public function test_local_ips_from_collect_localip_spare_states_both_families_others_still_killed(): void
 	{
-		$local = '198.51.100.44';
+		$local4 = '198.51.100.44';
+		$local6 = '3fff::44';
+
+		// Precondition (not theater): the v6 fixture must be PUBLIC to this PHP's
+		// filter, or the v6 branch under test is never reached.
+		$this->assertNotFalse(
+			filter_var($local6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE),
+			"{$local6} must validate as public IPv6 under NO_PRIV|NO_RES on this PHP — pick a different fixture address"
+		);
 
 		$this->seedConfig();
-		$GLOBALS['config']['nat']['rule'] = [['target' => $local]];
-		$this->seedStates($this->v4State($local), $this->v4State(self::V4_VICTIM, 54322));
-		$this->seedTableMatches($local, self::V4_VICTIM);
+		$GLOBALS['config']['nat']['rule'] = [['target' => $local4]];
+		// Bare-address VIP (no subnet_bits) rides pfb_collect_localip()'s is_ipaddr() branch.
+		$GLOBALS['config']['virtualip']['vip'] = [['subnet' => $local6]];
+		$this->seedStates(
+			$this->v4State($local4),
+			$this->v4State(self::V4_VICTIM, 54322),
+			$this->v6State($local6),
+			$this->v6State(self::V6_VICTIM)
+		);
+		$this->seedTableMatches($local4, self::V4_VICTIM, $local6, self::V6_VICTIM);
 
 		$kills = $this->runRemoveStates();
 
 		$this->assertStringContainsString(
 			self::V4_VICTIM,
 			$kills,
-			'the non-local ' . self::V4_VICTIM . " must be killed (proves the pass ran) — kill log was:\n{$kills}"
+			'the non-local ' . self::V4_VICTIM . " must be killed (proves the v4 pass ran) — kill log was:\n{$kills}"
+		);
+		$this->assertStringContainsString(
+			self::V6_VICTIM,
+			$kills,
+			'the non-local ' . self::V6_VICTIM . " must be killed (proves the v6 pass ran) — kill log was:\n{$kills}"
 		);
 		$this->assertStringNotContainsString(
-			$local,
+			$local4,
 			$kills,
-			"the pfb_collect_localip()-sourced {$local} must be excluded from clearing — kill log was:\n{$kills}"
+			"the pfb_collect_localip()-sourced {$local4} must be excluded from clearing — kill log was:\n{$kills}"
+		);
+		$this->assertStringNotContainsString(
+			$local6,
+			$kills,
+			"the pfb_collect_localip()-sourced {$local6} must be excluded from clearing — kill log was:\n{$kills}"
 		);
 	}
 

--- a/tests/php/PfbRemoveStatesTest.php
+++ b/tests/php/PfbRemoveStatesTest.php
@@ -565,4 +565,98 @@ final class PfbRemoveStatesTest extends TestCase
 			"{$outside} lies outside the suppressed range and must be killed — kill log was:\n{$kills}"
 		);
 	}
+
+	/**
+	 * Scenario (#769) — a local IP collected by pfb_collect_localip() spares its state.
+	 *
+	 * Given: a NAT rule whose target is the (public, otherwise-killable)
+	 *        198.51.100.44 — pfb_collect_localip() folds NAT targets into its
+	 *        IP-keyed local map — plus a table-matched victim state alongside it.
+	 * When:  pfb_remove_states() runs.
+	 * Then:  the victim is killed (proves the pass ran) and the local IP is NOT.
+	 *        FAILS pre-fix: the "Remove any duplicate IPs" step re-flipped the
+	 *        already-flipped local map (array_flip(array_unique())), turning its
+	 *        IP keys back into integers, so isset($pfb_local[$s_ip]) never matched.
+	 */
+	public function test_local_ip_from_collect_localip_spares_state_others_still_killed(): void
+	{
+		$local = '198.51.100.44';
+
+		$this->seedConfig();
+		$GLOBALS['config']['nat']['rule'] = [['target' => $local]];
+		$this->seedStates($this->v4State($local), $this->v4State(self::V4_VICTIM, 54322));
+		$this->seedTableMatches($local, self::V4_VICTIM);
+
+		$kills = $this->runRemoveStates();
+
+		$this->assertStringContainsString(
+			self::V4_VICTIM,
+			$kills,
+			'the non-local ' . self::V4_VICTIM . " must be killed (proves the pass ran) — kill log was:\n{$kills}"
+		);
+		$this->assertStringNotContainsString(
+			$local,
+			$kills,
+			"the pfb_collect_localip()-sourced {$local} must be excluded from clearing — kill log was:\n{$kills}"
+		);
+	}
+
+	/**
+	 * Scenario (#769, regression pin) — configured DNS servers spare their states,
+	 * both families.
+	 *
+	 * Given: get_dns_servers() returning a v4 and a v6 server (both public,
+	 *        table-matched, with live states), plus a table-matched victim per
+	 *        family.
+	 * When:  pfb_remove_states() runs.
+	 * Then:  both victims are killed, neither DNS server is. Deliberately green
+	 *        pre-fix too (the plain DNS list happened to survive the old re-flip
+	 *        with IP keys) — this pins the accidental-working side so the #769
+	 *        shape normalisation (array_fill_keys, no re-flip) cannot regress it.
+	 */
+	public function test_dns_server_states_spared_both_families_others_still_killed(): void
+	{
+		$dns4 = '198.51.100.53';
+		$dns6 = '3fff::53';
+
+		// Precondition (not theater): the v6 fixture must be PUBLIC to this PHP's
+		// filter, or the v6 branch under test is never reached.
+		$this->assertNotFalse(
+			filter_var($dns6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE),
+			"{$dns6} must validate as public IPv6 under NO_PRIV|NO_RES on this PHP — pick a different fixture address"
+		);
+
+		$this->seedConfig();
+		$GLOBALS['pfb_test_dns_servers'] = [$dns4, $dns6];
+		$this->seedStates(
+			$this->v4State($dns4),
+			$this->v4State(self::V4_VICTIM, 54322),
+			$this->v6State($dns6),
+			$this->v6State(self::V6_VICTIM)
+		);
+		$this->seedTableMatches($dns4, self::V4_VICTIM, $dns6, self::V6_VICTIM);
+
+		$kills = $this->runRemoveStates();
+
+		$this->assertStringContainsString(
+			self::V4_VICTIM,
+			$kills,
+			'the non-DNS ' . self::V4_VICTIM . " must be killed (proves the v4 pass ran) — kill log was:\n{$kills}"
+		);
+		$this->assertStringContainsString(
+			self::V6_VICTIM,
+			$kills,
+			'the non-DNS ' . self::V6_VICTIM . " must be killed (proves the v6 pass ran) — kill log was:\n{$kills}"
+		);
+		$this->assertStringNotContainsString(
+			$dns4,
+			$kills,
+			"the configured DNS server {$dns4} must be excluded from clearing — kill log was:\n{$kills}"
+		);
+		$this->assertStringNotContainsString(
+			$dns6,
+			$kills,
+			"the configured DNS server {$dns6} must be excluded from clearing — kill log was:\n{$kills}"
+		);
+	}
 }


### PR DESCRIPTION
## What

`pfb_remove_states()` built its local-IP/DNS-server exclusion map `$pfb_local` through a "Remove any duplicate IPs" step — `array_flip(array_unique($pfb_local))` — that double-flips already-hashmap-shaped input: `pfb_collect_localip()` returns an **already-flipped** `IP => position` map, so the re-flip turned its keys back into integers and the exclusion lookup `isset($pfb_local[$s_ip])` could never match those entries. The kill-states pass could therefore drop states belonging to local interface / NAT / VIP addresses. DNS servers (a plain list from `get_dns_servers()`) only survived by accident — the re-flip happened to flip them *into* the correct shape.

## Changes

- Keep `$pfb_local` an **IP-keyed set end-to-end**: `pfb_collect_localip()`'s map is merged as-is, and the DNS-server list is folded in via `array_fill_keys()`.
- Drop the trailing `array_flip(array_unique())` dedup entirely — `isset()` lookups need no dedup, and string-key merges dedup by overwrite.

## Tests

Two new cases in the existing `PfbRemoveStatesTest` fake-pfctl harness (red→green verified by stashing the src change):

- `test_local_ip_from_collect_localip_spares_state_others_still_killed` — a NAT-target local IP's state is spared while a sibling victim is killed (**failed pre-fix**: the kill log showed `-k 198.51.100.44` — the local IP's state was killed).
- `test_dns_server_states_spared_both_families_others_still_killed` — v4 + v6 DNS servers spared, victims killed. Deliberately green pre-fix too: it pins the accidentally-working DNS half so the shape normalisation cannot regress it (documented in the test docblock).

Gates: `php -l`, PHPUnit (1970 tests OK), PHPStan (`--memory-limit=2G`, no errors), PHPCS all clean.

Found while implementing ADR-53 Phase 7; empirical traces in `.ADRs/ADR_53_IP_Suppression_Set_Subtraction/RESULTS/07_Results.txt`.

Fixes #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG