### PR TITLE
pfblockerng: cap DNSBL match keys at the queryable bound (63-char label / 253 total) (#753)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -3932,15 +3932,34 @@ def parse(format_hint: str, line: str) -> ParsedEntry | None:
     return ParsedEntry(kind=DNSBL_KIND_BLOCK, value=token, feed="", group="", log="")
 
 
+def _dnsbl_within_wire_caps(host: str) -> bool:
+    """True iff ``host`` can be encoded in a DNS query (#753): <= 253 chars total
+    (the RFC 1035 presentation cap, undotted) and every label <= 63. The domain
+    charset is ASCII-only, so chars == octets. Shared by ``normalise()`` and the
+    ``reconcile()`` regex fold so the caps live in one place."""
+    return len(host) <= 253 and all(len(label) <= 63 for label in host.split("."))
+
+
 def normalise(value: str) -> str | None:
     """Lower-case + PFB_FILTER_DOMAIN domain-shape gate (inc:1138-1150).
 
     Returns the validated, lower-cased domain or ``None`` when the token is not a
     valid domain (which is how stray non-domain entries -- including any IP that
     slipped past parse() -- are dropped without ever reaching the dicts).
+
+    Length caps mirror the PHP gate at the queryable bound (#753): every label
+    <= 63 chars, whole name <= 253 chars (``_dnsbl_within_wire_caps``; the RFC
+    1035 presentation cap, applied after the trailing dot is stripped -- the
+    same names PHP's ``strlen < 255`` accepts in dotted form, PR #752). PHP also
+    tolerates a bare 254-char undotted name (an inert sanity-cap artefact,
+    pinned by PR #752); this gate rejects it as unqueryable. Every entry gated
+    here becomes an exact or wildcard match key, and a name that cannot be
+    encoded in a DNS query could never match a lookup -- rejecting it keeps
+    unreachable dead weight out of the block dicts. The ``reconcile()`` regex
+    fold applies the same caps to a domain-literal regex key.
     """
     host = value.strip().strip(".").lower()
-    if "." not in host:
+    if "." not in host or not _dnsbl_within_wire_caps(host):
         return None
     for label in host.split("."):
         if not label or label[0] == "-" or label[-1] == "-":
@@ -4224,8 +4243,15 @@ def reconcile(
                     result.block_regex_irreducible.append(regex_rule)
                 continue
             # Reducible -> fold to a domain rule (zero per-query cost).
-            result.reduced += 1
             wildcard, domain = reduced
+            # #753: the folded literal is an exact/wildcard match KEY -- apply
+            # the same wire caps normalise() applies to its ||host^ twin. An
+            # over-cap key can never match a queryable qname, so drop the rule
+            # outright (keeping it as a compiled regex would pay per-query cost
+            # for a pattern that can never match).
+            if not _dnsbl_within_wire_caps(domain):
+                continue
+            result.reduced += 1
         elif r.target == RULE_TARGET_DOMAIN:
             wildcard, domain = r.wildcard, r.key_or_pattern
         else:  # pragma: no cover - defensive; parse_abp only emits domain/regex

--- a/tests/test_adr06_build_module.py
+++ b/tests/test_adr06_build_module.py
@@ -234,6 +234,25 @@ class TestNormalise:
         assert pfb_unbound.normalise("_dmarc.example.com") == "_dmarc.example.com"
         assert pfb_unbound.normalise("trailing_.example.com") == "trailing_.example.com"
 
+    def test_length_caps_reject_unqueryable_names(self) -> None:
+        # #753: normalise() enforces the PHP PFB_FILTER_DOMAIN length caps at the
+        # queryable bound. Every entry it gates becomes an exact or wildcard match
+        # key, and a name with a >63-char label or >253 chars total cannot be
+        # encoded in a DNS query -- it could never match a lookup, so rejecting it
+        # keeps unreachable dead weight out of the block dicts.
+        # Label cap: 63 is the longest legal label; 64 is unencodable.
+        assert pfb_unbound.normalise("a" * 63 + ".com") == "a" * 63 + ".com"
+        assert pfb_unbound.normalise("a" * 64 + ".com") is None
+        # Total cap: 253 is the longest queryable presentation; 254 is not.
+        name_253 = ".".join(["b" * 61] * 4) + "." + "b" * 5
+        name_254 = ".".join(["b" * 61] * 4) + "." + "b" * 6
+        assert (len(name_253), len(name_254)) == (253, 254)
+        assert pfb_unbound.normalise(name_253) == name_253
+        assert pfb_unbound.normalise(name_254) is None
+        # Dotted (FQDN) form of a max-length name still passes: the trailing dot
+        # is stripped BEFORE the cap, mirroring PHP's 254-char dotted accept (#752).
+        assert pfb_unbound.normalise(name_253 + ".") == name_253
+
 
 # --------------------------------------------------------------------------- #
 # classify()

--- a/tests/test_adr07_reconcile.py
+++ b/tests/test_adr07_reconcile.py
@@ -260,6 +260,24 @@ class TestRegexReduction:
         assert len(res.allow_regex_irreducible) == 1
         assert res.block_regex_irreducible == []
 
+    def test_unqueryable_folded_key_is_dropped(self) -> None:
+        # #753: a reducible regex folds to an exact/wildcard match KEY, so the
+        # wire caps apply to the folded key exactly as normalise() applies them
+        # to its ||host^ twin -- an over-cap key (>63-char label / >253 total)
+        # can never match a queryable qname. The rule is dropped outright, NOT
+        # kept as a compiled regex (that would pay per-query cost for a pattern
+        # that can never match).
+        long_label = "a" * 64
+        res = _reconcile(
+            [
+                f"/^(.+\\.)?{long_label}\\.com$/",
+                f"@@/^{long_label}\\.net$/",
+            ]
+        )
+        assert res.block_domains == [] and res.allow_domains == []
+        assert res.block_regex_irreducible == [] and res.allow_regex_irreducible == []
+        assert res.reduced == 0
+
     def test_reduction_matches_oracle_and_spike(self) -> None:
         spike = _spike()
         for inner in (


### PR DESCRIPTION
Fixes #753

## Verdict: align — cap DNSBL match keys at the queryable bound

#753 flagged that `normalise()` (the Python `PFB_FILTER_DOMAIN` mirror gating the DNSBL feed pipeline) enforces none of the PHP gate's length caps and asked: document the divergence as deliberate, or align. Maintainer decision on review: **align** — every affected entry becomes an exact or wildcard match key, and a name that cannot be encoded in a DNS query can never match a lookup, so keeping such entries is pure dead weight in the block dicts. (This supersedes the leniency lean from #724: an overlong "bad-actor domain" is unqueryable at the wire level, so rejecting it loses no blocking coverage.)

Scope, verified against the code:

- The caps live in one shared predicate, `_dnsbl_within_wire_caps()`, applied at **both** exact/wildcard key producers:
  - `normalise()` — all 5 call sites (ABP `||domain^` / `@@||domain^` wildcards, hosts/plain wildcards, permit-feed whiteDB allows, and the plain block path into `classify()` → zone/data dicts);
  - the `reconcile()` **regex fold** — a domain-literal regex (`/^host\.com$/`) folds to the same kind of key and previously bypassed the gate entirely (caught by the adversarial review). An over-cap folded key drops the rule outright — decision-identical, and cheaper than keeping a compiled regex that can never match.
- **Irreducible regex rules are unaffected**, per the decision's exact-and-wildcard-only scope.
- `classify()` never truncates an overlong name into a shorter queryable key (every ZONE key is the whole domain), so nothing queryable is lost by rejecting at the gates.
- **Practical effect is the ABP path**: plain/CSV feed lines are already capped by PHP's own `pfb_filter($line, PFB_FILTER_DOMAIN, 'DNSBL_Download')` at ingestion (`pfblockerng.inc:~14975`) before they reach the manifest, while ABP-format and inline `||`/`@@||` lines are written **verbatim** (deliberately skipping `pfb_filter()`), leaving the Python gates as their only filter. This change closes exactly that hole, making the length gate uniform across formats.

## Change

- `_dnsbl_within_wire_caps()`: label ≤ 63 chars, whole name ≤ 253 chars (post-strip — the RFC 1035 presentation cap; the same names PHP's `strlen < 255` accepts in dotted form, PR #752; PHP's bare-254 undotted tolerance is an inert sanity-cap artefact this gate deliberately rejects).
- `normalise()` delegates to the predicate; the `reconcile()` fold drops rules whose folded key fails it.
- Tests, each proven red on pre-change code / green after:
  - `TestNormalise.test_length_caps_reject_unqueryable_names` — both sides of each branch: 63-char label accepted / 64 rejected; 253 total accepted / 254 rejected; dotted (FQDN) max-length form still accepted.
  - `TestRegexReduction.test_unqueryable_folded_key_is_dropped` — an over-cap folded block AND allow regex produce no domain rule, no irreducible-regex fallback, and no `reduced` count.

Gates: full pytest suite 2093 passed / 4 skipped; `ruff check` + `ruff format --check` + `mypy tests/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016atQbcuVhafvo7SHvWkxdK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain handling to reject names that can’t be represented in a DNS query, including overly long labels and total lengths.
  * Prevented certain reduced regex entries from being kept when their resulting domain key would be too long to query.
  * Reduced the chance of unreachable entries appearing in matching lists.

* **Tests**
  * Added coverage for length-based domain validation and for dropping unqueryable reduced keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->