### PR TITLE
pfblockerng: split multi-IP alias addresses in pfb_collect_localip (#782)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10513,15 +10513,35 @@ function pfb_collect_localip() {
 		$pfb_local[] = $onetoone['source']['address'];
 	}
 
-	// Convert any 'Firewall Aliases' to IP address format
-	$aliases = config_get_path('aliases/alias', []);
-	if (is_array($aliases)) {
-		for ($cnt = 0; $cnt <= count($pfb_local); $cnt++) {
-			foreach ($aliases as $i=> $alias) {
-				if (isset($alias['name']) && isset($pfb_local[$cnt])) {
-					if ($alias['name'] == $pfb_local[$cnt]) {
-						$pfb_local[$cnt] = $alias['address'];
-					}
+	// Convert any 'Firewall Aliases' to IP address format.
+	// A multi-entry alias's stored 'address' is a SPACE-SEPARATED string (e.g.
+	// '10.0.0.1 10.0.0.2') -- replacing the matched $pfb_local entry with that
+	// string verbatim leaves ONE unmatchable compound key once $pfb_local is
+	// array_flip()ed below (#782). Split each matched alias's address and
+	// classify every member individually: a plain IP becomes its own entry (so
+	// it gets its own flipped key), a CIDR goes to $pfb_localsub (matched via
+	// pfb_local_ip()), and anything else (hostname, port, nested alias name) is
+	// dropped silently.
+	$pfb_alias_addrs = array();
+	foreach (config_get_path('aliases/alias', []) as $alias) {
+		if (is_array($alias) && isset($alias['name'])) {
+			$pfb_alias_addrs[$alias['name']] = (string) ($alias['address'] ?? '');
+		}
+	}
+	if (!empty($pfb_alias_addrs)) {
+		foreach ($pfb_local as $cnt => $entry) {
+			if (!array_key_exists($entry, $pfb_alias_addrs)) {
+				continue;
+			}
+			unset($pfb_local[$cnt]);
+			foreach (preg_split('/\s+/', trim($pfb_alias_addrs[$entry])) as $member) {
+				if ($member === '') {
+					continue;
+				}
+				if (is_ipaddr($member)) {
+					$pfb_local[] = $member;
+				} elseif (is_subnet($member)) {
+					$pfb_localsub[] = $member;
 				}
 			}
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10530,7 +10530,11 @@ function pfb_collect_localip() {
 	}
 	if (!empty($pfb_alias_addrs)) {
 		foreach ($pfb_local as $cnt => $entry) {
-			if (!array_key_exists($entry, $pfb_alias_addrs)) {
+			// A malformed config value (e.g. an array-typed NAT target) must not
+			// abort the walk: array_key_exists() throws a TypeError on a non-scalar
+			// key under PHP 8. Leave it in place for the later array_flip() to
+			// warn-and-drop, matching pre-#782 tolerance.
+			if (!is_string($entry) || !array_key_exists($entry, $pfb_alias_addrs)) {
 				continue;
 			}
 			unset($pfb_local[$cnt]);

--- a/tests/php/CollectLocalIpAliasTest.php
+++ b/tests/php/CollectLocalIpAliasTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_collect_localip() — Firewall Alias -> IP address conversion (issue #782).
+ *
+ * pfSense stores a multi-entry alias's 'address' as a SPACE-SEPARATED string
+ * (e.g. '10.0.0.1 10.0.0.2'). Before the fix, an $pfb_local entry that matched
+ * an alias name was replaced with that compound string VERBATIM; once
+ * $pfb_local is array_flip()ed at the end of pfb_collect_localip(), the whole
+ * compound string becomes ONE unmatchable key. pfb_remove_states() and
+ * pfb_daemon_filterlog() then check isset($pfb_local[$s_ip]) against a single
+ * member IP, which can never match the compound key — so a local IP behind a
+ * multi-entry alias (a NAT target, a VIP, a gateway) is never spared by the
+ * kill-states / Reports "local host" exclusion.
+ *
+ * Scenario: Firewall-Alias conversion in pfb_collect_localip()
+ *   Background:
+ *     Given the alias-conversion block reads config 'aliases/alias' and, for
+ *           every $pfb_local entry whose value equals an alias name, must
+ *           replace it with each of the alias's SPLIT, INDIVIDUALLY CLASSIFIED
+ *           members (plain IP -> its own $pfb_local entry; CIDR -> $pfb_localsub;
+ *           anything else -> dropped) rather than the raw compound string.
+ *
+ *   Case A (the bug — MUST fail before the fix, pass after):
+ *     Given a NAT rule target set to alias name 'Multi_Hosts' whose stored
+ *           address is '203.0.113.10 203.0.113.20'
+ *     When  pfb_collect_localip() is called
+ *     Then  BOTH member IPs are recognised as local (isset in the flipped
+ *           $pfb_local)
+ *     And   the compound string '203.0.113.10 203.0.113.20' is NOT itself a
+ *           $pfb_local key
+ *
+ *   Case B (CIDR member of a mixed alias):
+ *     Given alias 'Multi_Cidr' = '198.51.100.0/28 203.0.113.50'
+ *     Then  a host inside the CIDR (198.51.100.5) is recognised as local via
+ *           pfb_local_ip($host, $pfb_localsub), the plain IP member is its own
+ *           $pfb_local key, and the CIDR string itself is never a $pfb_local key
+ *
+ *   Case C (non-IP members dropped):
+ *     Given alias 'Multi_Bad' = 'example.org 8080' (a hostname and a bare port)
+ *     Then  neither member appears as a $pfb_local key and nothing bogus lands
+ *           in $pfb_localsub
+ *
+ *   Case D (regression guard — green before AND after):
+ *     Given a single-IP alias 'Single_Host' = '203.0.113.99'
+ *     Then  it still resolves to that one IP as a $pfb_local key
+ *
+ *   Case E (regression guard — entries that are not an alias name):
+ *     Given a NAT rule target of a plain IP '192.0.2.7' (matches no alias name)
+ *     Then  it passes through unchanged and is recognised as local
+ */
+#[CoversFunction('pfb_collect_localip')]
+#[CoversFunction('pfb_local_ip')]
+final class CollectLocalIpAliasTest extends TestCase
+{
+	/** Saved $GLOBALS state to restore after each test. */
+	private bool $hadConfig = false;
+	private array $savedConfig = [];
+
+	protected function setUp(): void
+	{
+		$this->hadConfig   = array_key_exists('config', $GLOBALS);
+		$this->savedConfig = $GLOBALS['config'] ?? [];
+
+		// Minimal config: no interfaces/VIPs contributing noise, one NAT rule
+		// per test case, and the alias table under test.
+		$GLOBALS['config'] = [
+			'interfaces' => [],
+			'virtualip'  => ['vip' => []],
+			'nat'        => ['rule' => [], 'onetoone' => []],
+			'aliases'    => [
+				'alias' => [
+					['name' => 'Multi_Hosts',  'address' => '203.0.113.10 203.0.113.20'],
+					['name' => 'Multi_Cidr',   'address' => '198.51.100.0/28 203.0.113.50'],
+					['name' => 'Multi_Bad',    'address' => 'example.org 8080'],
+					['name' => 'Single_Host',  'address' => '203.0.113.99'],
+				],
+			],
+		];
+
+		$GLOBALS['pfb_test_configured_ipv6'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->savedConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+		unset($GLOBALS['pfb_test_configured_ipv6']);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case A — multi-IP alias (the bug: fails before fix, passes after)
+	// -------------------------------------------------------------------------
+
+	public function testMultiIpAliasMembersAreEachRecognisedAsLocal(): void
+	{
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => 'Multi_Hosts'],
+		];
+
+		[$pfb_local, $pfb_localsub] = pfb_collect_localip();
+
+		$this->assertArrayHasKey(
+			'203.0.113.10',
+			$pfb_local,
+			sprintf(
+				"Alias member 203.0.113.10 (from 'Multi_Hosts' = '203.0.113.10 203.0.113.20') "
+				. "must be recognised as local.\npfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$this->assertArrayHasKey(
+			'203.0.113.20',
+			$pfb_local,
+			sprintf(
+				"Alias member 203.0.113.20 (from 'Multi_Hosts' = '203.0.113.10 203.0.113.20') "
+				. "must be recognised as local.\npfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$this->assertArrayNotHasKey(
+			'203.0.113.10 203.0.113.20',
+			$pfb_local,
+			sprintf(
+				"The RAW compound alias address must never survive as a single \$pfb_local key "
+				. "-- it can never match an individual member IP once flipped.\npfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case B — mixed alias: CIDR member + plain-IP member
+	// -------------------------------------------------------------------------
+
+	public function testMixedAliasCidrMemberIsRecognisedViaLocalSubnetAndPlainIpAsKey(): void
+	{
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => 'Multi_Cidr'],
+		];
+
+		[$pfb_local, $pfb_localsub] = pfb_collect_localip();
+
+		$host = '198.51.100.5';
+		$this->assertTrue(
+			pfb_local_ip($host, $pfb_localsub),
+			sprintf(
+				"Host %s inside alias CIDR member 198.51.100.0/28 must be recognised as local "
+				. "via pfb_localsub.\npfb_localsub: %s",
+				$host,
+				implode(', ', $pfb_localsub)
+			)
+		);
+		$this->assertArrayHasKey(
+			'203.0.113.50',
+			$pfb_local,
+			sprintf(
+				"Plain-IP alias member 203.0.113.50 must be its own \$pfb_local key.\n"
+				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$this->assertArrayNotHasKey(
+			'198.51.100.0/28',
+			$pfb_local,
+			"The CIDR member string itself must never appear as a \$pfb_local key "
+			. "(it belongs in \$pfb_localsub, matched by value via ip_in_subnet)."
+		);
+		$this->assertArrayNotHasKey(
+			'198.51.100.0/28 203.0.113.50',
+			$pfb_local,
+			"The raw compound alias address must never survive as a single \$pfb_local key."
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case C — non-IP alias members are dropped silently
+	// -------------------------------------------------------------------------
+
+	public function testNonIpAliasMembersAreDroppedSilently(): void
+	{
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => 'Multi_Bad'],
+		];
+
+		[$pfb_local, $pfb_localsub] = pfb_collect_localip();
+
+		$this->assertArrayNotHasKey(
+			'example.org',
+			$pfb_local,
+			sprintf(
+				"Hostname alias member 'example.org' must be dropped, never a \$pfb_local key.\n"
+				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$this->assertArrayNotHasKey(
+			'8080',
+			$pfb_local,
+			sprintf(
+				"Bare-port alias member '8080' must be dropped, never a \$pfb_local key.\n"
+				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$this->assertNotContains(
+			'example.org',
+			$pfb_localsub,
+			"Hostname alias member must not leak into \$pfb_localsub either."
+		);
+		$this->assertNotContains(
+			'8080',
+			$pfb_localsub,
+			"Bare-port alias member must not leak into \$pfb_localsub either."
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case D — single-IP alias (regression guard, green before AND after)
+	// -------------------------------------------------------------------------
+
+	public function testSingleIpAliasStillResolvesToThatIp(): void
+	{
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => 'Single_Host'],
+		];
+
+		[$pfb_local, ] = pfb_collect_localip();
+
+		$this->assertArrayHasKey(
+			'203.0.113.99',
+			$pfb_local,
+			sprintf(
+				"A single-IP alias must still resolve to that one IP as a \$pfb_local key.\n"
+				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case E — entry matching no alias name passes through unchanged
+	// -------------------------------------------------------------------------
+
+	public function testNatTargetNotMatchingAnyAliasNamePassesThroughUnchanged(): void
+	{
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => '192.0.2.7'],
+		];
+
+		[$pfb_local, ] = pfb_collect_localip();
+
+		$this->assertArrayHasKey(
+			'192.0.2.7',
+			$pfb_local,
+			sprintf(
+				"A NAT target IP matching no alias name must pass through unchanged and be "
+				. "recognised as local.\npfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+	}
+}

--- a/tests/php/CollectLocalIpAliasTest.php
+++ b/tests/php/CollectLocalIpAliasTest.php
@@ -53,6 +53,24 @@ use PHPUnit\Framework\TestCase;
  *   Case E (regression guard — entries that are not an alias name):
  *     Given a NAT rule target of a plain IP '192.0.2.7' (matches no alias name)
  *     Then  it passes through unchanged and is recognised as local
+ *
+ *   Case F (IPv6 members classify exactly like IPv4 ones):
+ *     Given alias 'V6_Hosts' = '2001:db8::1 2001:db8:1::/64'
+ *     Then  the plain IPv6 member is its own $pfb_local key and a host inside
+ *           the IPv6 CIDR member is recognised via $pfb_localsub
+ *
+ *   Case G (empty / whitespace-only alias address is dropped safely):
+ *     Given alias 'Empty_Alias' whose stored address is only whitespace
+ *     Then  pfb_collect_localip() returns without error and neither an empty
+ *           key nor the alias name itself survives in $pfb_local
+ *
+ *   Case H (malformed non-string entry must not fatal — MUST fail before the
+ *           is_string() guard, pass after):
+ *     Given a NAT rule whose 'target' is an ARRAY (corrupted / hand-edited
+ *           config.xml), a shape the pre-#782 code tolerated with only an
+ *           array_flip() warning
+ *     Then  pfb_collect_localip() completes without a TypeError and the other
+ *           collected entries are unaffected
  */
 #[CoversFunction('pfb_collect_localip')]
 #[CoversFunction('pfb_local_ip')]
@@ -79,6 +97,8 @@ final class CollectLocalIpAliasTest extends TestCase
 					['name' => 'Multi_Cidr',   'address' => '198.51.100.0/28 203.0.113.50'],
 					['name' => 'Multi_Bad',    'address' => 'example.org 8080'],
 					['name' => 'Single_Host',  'address' => '203.0.113.99'],
+					['name' => 'V6_Hosts',     'address' => '2001:db8::1 2001:db8:1::/64'],
+					['name' => 'Empty_Alias',  'address' => '   '],
 				],
 			],
 		];
@@ -264,6 +284,118 @@ final class CollectLocalIpAliasTest extends TestCase
 			sprintf(
 				"A NAT target IP matching no alias name must pass through unchanged and be "
 				. "recognised as local.\npfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case F — IPv6 alias members classify exactly like IPv4 ones
+	// -------------------------------------------------------------------------
+
+	public function testIpv6AliasMembersSplitAndClassifyLikeIpv4(): void
+	{
+		// Guards a future refactor that special-cases IPv4 (e.g. dotted-quad
+		// detection instead of the generic is_ipaddr()/is_subnet() calls): the
+		// split/classify path must stay address-family agnostic.
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => 'V6_Hosts'],
+		];
+
+		[$pfb_local, $pfb_localsub] = pfb_collect_localip();
+
+		$this->assertArrayHasKey(
+			'2001:db8::1',
+			$pfb_local,
+			sprintf(
+				"Plain IPv6 alias member 2001:db8::1 must be its own \$pfb_local key.\n"
+				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$host = '2001:db8:1::abcd';
+		$this->assertTrue(
+			pfb_local_ip($host, $pfb_localsub),
+			sprintf(
+				"Host %s inside IPv6 alias CIDR member 2001:db8:1::/64 must be recognised "
+				. "as local via pfb_localsub.\npfb_localsub: %s",
+				$host,
+				implode(', ', $pfb_localsub)
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case G — empty / whitespace-only alias address dropped safely
+	// -------------------------------------------------------------------------
+
+	public function testWhitespaceOnlyAliasAddressIsDroppedWithoutError(): void
+	{
+		// Guards the empty-member skip in the split loop: a whitespace-only
+		// address must produce no key at all (not '', not the alias name).
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => 'Empty_Alias'],
+		];
+
+		[$pfb_local, $pfb_localsub] = pfb_collect_localip();
+
+		$this->assertArrayNotHasKey(
+			'',
+			$pfb_local,
+			sprintf(
+				"A whitespace-only alias address must never yield an empty \$pfb_local key.\n"
+				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$this->assertArrayNotHasKey(
+			'Empty_Alias',
+			$pfb_local,
+			sprintf(
+				"The matched alias NAME must be consumed, not left behind as a key.\n"
+				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$this->assertNotContains(
+			'',
+			$pfb_localsub,
+			"A whitespace-only alias address must not leak an empty \$pfb_localsub entry."
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case H — malformed non-string entry must not fatal (#461-style tolerance)
+	// -------------------------------------------------------------------------
+
+	public function testArrayTypedNatTargetDoesNotFatalTheAliasWalk(): void
+	{
+		// Scenario: array_key_exists() throws a TypeError on a non-scalar key
+		//           under PHP 8, so the alias walk must skip non-string entries.
+		//
+		// Given  a NAT rule whose 'target' is an ARRAY (corrupted / hand-edited
+		//        config.xml) alongside a well-formed alias-name target
+		// When   pfb_collect_localip() runs
+		// Then   it completes without a TypeError (pre-guard: uncaught TypeError
+		//        'Cannot access offset of type array on array' — FAILS)
+		//        AND the well-formed alias target still resolves normally.
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => ['192.0.2.1', '192.0.2.2']],
+			['target' => 'Single_Host'],
+		];
+
+		// When: a fatal TypeError would abort here (suppress the array_flip()
+		// warning the tolerated stray entry triggers, same as pre-#782 code).
+		[$pfb_local, ] = @pfb_collect_localip();
+
+		// Then: reaching the assertion proves no TypeError; the sibling
+		// well-formed alias target must still have been resolved.
+		$this->assertArrayHasKey(
+			'203.0.113.99',
+			$pfb_local,
+			sprintf(
+				"An array-typed NAT target must be skipped (pre-#782 tolerance), leaving "
+				. "the well-formed alias target resolved.\npfb_local keys: %s",
 				implode(', ', array_keys($pfb_local))
 			)
 		);


### PR DESCRIPTION
Fixes #782

## Problem

In `pfb_collect_localip()`, a `$pfb_local` entry matching a firewall alias name was replaced with `$alias['address']` verbatim. pfSense stores a multi-entry alias's address as a **space-separated string**, so after the later `array_flip()` the compound string became a single unmatchable key — `isset($pfb_local[$s_ip])` in `pfb_remove_states()` (and the filterlog local/remote classification) could never match an individual member IP. Local hosts behind a multi-entry NAT/VIP/gateway alias were therefore never spared by the kill-states exclusion.

Pre-existing bug, independent of the map-shape fix in #780 (flagged by its adversarial review and the ADR-53 Phase 7 investigation).

## Fix

Rewrite the alias-conversion block: build a name→address lookup, split each matched alias's address on whitespace, and classify every member individually:

- plain IP → its own `$pfb_local` entry (own flipped key);
- CIDR → `$pfb_localsub` (matched via `pfb_local_ip()`);
- anything else (hostname, port, nested alias name) → dropped.

Entries matching no alias name pass through unchanged.

## Tests

New `tests/php/CollectLocalIpAliasTest.php` (5 cases, BDD-style):

- **A** — multi-IP alias: both member IPs recognised, compound string not a key (**fails pre-fix**: `Failed asserting that an array has the key '203.0.113.10'`, keys showed `203.0.113.10 203.0.113.20`);
- **B** — mixed alias: CIDR member reaches `$pfb_localsub`, plain IP gets its own key (**fails pre-fix**);
- **C** — non-IP members (hostname, port) dropped;
- **D** — single-IP alias still resolves (regression guard);
- **E** — non-alias entry passes through unchanged (regression guard).

Gates: `php -l` clean, full PHPUnit green (1973 tests, 15962 assertions), PHPCS clean. PHPStan could not run in this sandbox (dist-only download blocked); CI covers it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxvQpCm9Dg7W4dTPxSYEuK)_