### PR TITLE
pfblockerng: drop reserved classes under Suppression + IPv6 CIDR floor

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8013,7 +8013,7 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 		// multicast, CGN (RFC 6598), benchmarking (RFC 2544) and the deprecated
 		// 6to4 relay anycast prefix routable; explicit checks close that gap
 		// (issue #760). Judged on the address only, same as the filter above -
-		// the CIDR span is not inspected.
+		// the CIDR span is not inspected (issue #760 §4).
 		$long = ip2long($ip_final);
 		if ($long !== FALSE && (
 			($long & 0xffffff00) === 0xc0000200 ||	// 192.0.2.0/24 documentation
@@ -8086,7 +8086,9 @@ function sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr = 'Disabled') {
 
 		// The filter flags above keep documentation (2001:db8::/32), multicast
 		// (ff00::/8) and the NAT64 well-known prefix (64:ff9b::/96) routable;
-		// explicit prefix checks close that gap (issue #760).
+		// explicit prefix checks close that gap (issue #760). Judged on the
+		// address part only, same as the filter above -- the CIDR span is not
+		// inspected (issue #760 §4).
 		$bin = inet_pton($s_ip);
 		if ($bin !== FALSE && (
 			substr($bin, 0, 4) === "\x20\x01\x0d\xb8" ||					// 2001:db8::/32 documentation

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8070,8 +8070,10 @@ function sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr = 'Disabled') {
 
 		// Advanced IPv6 Tunable (Set CIDR Block size limit) (issue #760 §3).
 		// A /0 was already clamped above (mask stays '0', never > 0, so this
-		// guard never double-clamps it); a mask the guard doesn't match (e.g.
-		// an invalid >128 value) is left for validate_ipv6() downstream.
+		// guard never double-clamps it). All three feed call sites gate on
+		// validate_ipv6() BEFORE calling this function, so $mask is already
+		// 0-128 here; the ctype_digit()/range checks are defensive redundancy
+		// for any direct caller that skips that guard.
 		if ($pfbcidr != 'Disabled' && $mask !== '' && ctype_digit($mask) && (int)$mask > 0 && (int)$mask < (int)$pfbcidr) {
 			pfb_logger("\n  Suppression CIDR Limit: {$s_ip}/{$mask}", 1);
 			$ipaddr = $s_ip;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7937,7 +7937,9 @@ function pfblockerng_top1m() {
 
 // Function to remove any leading zeros in octets and to exclude private/reserved addresses.
 // A downloaded feed's explicit /0 is clamped to a single host and logged (issue #744);
-// a custom list's /0 is honored as written.
+// a custom list's /0 is honored as written. Under Suppression, also drops documentation
+// (RFC 5737), multicast, CGN (RFC 6598), benchmarking (RFC 2544) and the deprecated 6to4
+// relay anycast space that PHP's filter flags leave routable (issue #760).
 function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 	global $pfb;
 
@@ -8006,6 +8008,24 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 		if (!filter_var($ip_final, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== FALSE) {
 			return;
 		}
+
+		// FILTER_FLAG_NO_PRIV_RANGE|NO_RES_RANGE keep documentation (RFC 5737),
+		// multicast, CGN (RFC 6598), benchmarking (RFC 2544) and the deprecated
+		// 6to4 relay anycast prefix routable; explicit checks close that gap
+		// (issue #760). Judged on the address only, same as the filter above -
+		// the CIDR span is not inspected.
+		$long = ip2long($ip_final);
+		if ($long !== FALSE && (
+			($long & 0xffffff00) === 0xc0000200 ||	// 192.0.2.0/24 documentation
+			($long & 0xffffff00) === 0xc6336400 ||	// 198.51.100.0/24 documentation
+			($long & 0xffffff00) === 0xcb007100 ||	// 203.0.113.0/24 documentation
+			($long & 0xf0000000) === 0xe0000000 ||	// 224.0.0.0/4 multicast
+			($long & 0xffc00000) === 0x64400000 ||	// 100.64.0.0/10 CGN
+			($long & 0xfffe0000) === 0xc6120000 ||	// 198.18.0.0/15 benchmarking
+			($long & 0xffffff00) === 0xc0586300	// 192.88.99.0/24 6to4 relay anycast
+		)) {
+			return;
+		}
 	}
 
 	// '!== '' (not !empty()): empty('0') is TRUE, which silently collapsed a
@@ -8021,6 +8041,11 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 // addresses from loaded block lists when Suppression is enabled. A downloaded
 // feed's explicit /0 is clamped to a single host (issue #744); otherwise the
 // entry is returned unchanged when kept, nothing (dropped) when excluded.
+// Also drops documentation (RFC 3849), multicast and the NAT64 well-known
+// prefix (RFC 6052), which the PHP filter flags leave routable (issue #760).
+// These are explicit prefix checks rather than another filter flag, so the
+// behaviour is independent of PHP's patch level (the RFC 6890 refactor in
+// PHP 8.3.16/8.4.3 moved 2001:db8::/32 between filter sets).
 function sanitize_ipaddr_v6($ipaddr, $custom) {
 	global $pfb;
 
@@ -8045,6 +8070,18 @@ function sanitize_ipaddr_v6($ipaddr, $custom) {
 		// IPv4-mapped and the reserved set (mirrors inc:7118-7119).
 		if (!filter_var($s_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) ||
 		    !filter_var($s_ip, FILTER_CALLBACK, array('options' => 'FILTER_FLAG_NO_LOOPBACK_RANGE'))) {
+			return;
+		}
+
+		// The filter flags above keep documentation (2001:db8::/32), multicast
+		// (ff00::/8) and the NAT64 well-known prefix (64:ff9b::/96) routable;
+		// explicit prefix checks close that gap (issue #760).
+		$bin = inet_pton($s_ip);
+		if ($bin !== FALSE && (
+			substr($bin, 0, 4) === "\x20\x01\x0d\xb8" ||					// 2001:db8::/32 documentation
+			substr($bin, 0, 1) === "\xff" ||								// ff00::/8 multicast
+			substr($bin, 0, 12) === "\x00\x64\xff\x9b" . str_repeat("\x00", 8)	// 64:ff9b::/96 NAT64
+		)) {
 			return;
 		}
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8045,8 +8045,10 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 // prefix (RFC 6052), which the PHP filter flags leave routable (issue #760).
 // These are explicit prefix checks rather than another filter flag, so the
 // behaviour is independent of PHP's patch level (the RFC 6890 refactor in
-// PHP 8.3.16/8.4.3 moved 2001:db8::/32 between filter sets).
-function sanitize_ipaddr_v6($ipaddr, $custom) {
+// PHP 8.3.16/8.4.3 moved 2001:db8::/32 between filter sets). $pfbcidr is the
+// per-category Advanced "Suppression CIDR Limit" floor (issue #760 §3), the
+// v6 sibling of sanitize_ipaddr()'s $pfbcidr.
+function sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr = 'Disabled') {
 	global $pfb;
 
 	// Extract the address part (before '/' for a CIDR like 'fc00::/7')
@@ -8065,6 +8067,15 @@ function sanitize_ipaddr_v6($ipaddr, $custom) {
 
 	// Exclude private/reserved IPs (bypass exclusion for custom lists)
 	if ($pfb['supp'] == 'on' && !$custom) {
+
+		// Advanced IPv6 Tunable (Set CIDR Block size limit) (issue #760 §3).
+		// A /0 was already clamped above (mask stays '0', never > 0, so this
+		// guard never double-clamps it); a mask the guard doesn't match (e.g.
+		// an invalid >128 value) is left for validate_ipv6() downstream.
+		if ($pfbcidr != 'Disabled' && $mask !== '' && ctype_digit($mask) && (int)$mask > 0 && (int)$mask < (int)$pfbcidr) {
+			pfb_logger("\n  Suppression CIDR Limit: {$s_ip}/{$mask}", 1);
+			$ipaddr = $s_ip;
+		}
 
 		// Drop ULA (fc00::/7), link-local (fe80::/10), loopback (::1),
 		// IPv4-mapped and the reserved set (mirrors inc:7118-7119).
@@ -16175,7 +16186,13 @@ function sync_package_pfblockerng($cron='') {
 						if (isset($list['suppression_cidr']) && $list['suppression_cidr'] != 'Disabled' && is_numeric($list['suppression_cidr'])) {
 							$pfbcidr = "{$list['suppression_cidr']}";
 						}
-						
+
+						// IPv6 Advanced Tunables (issue #760 §3)
+						$pfbcidr_v6 = 'Disabled';
+						if (isset($list['suppression_cidr_v6']) && $list['suppression_cidr_v6'] != 'Disabled' && is_numeric($list['suppression_cidr_v6'])) {
+							$pfbcidr_v6 = "{$list['suppression_cidr_v6']}";
+						}
+
 						// cURL Source Interface (sets CURLOPT_INTERFACE)
 						$srcint = $list['srcint'] ?: FALSE;
 
@@ -16499,7 +16516,7 @@ function sync_package_pfblockerng($cron='') {
 												}
 
 												if (validate_ipv6($line)) {
-													$parsed = sanitize_ipaddr_v6($line, $custom);
+													$parsed = sanitize_ipaddr_v6($line, $custom, $pfbcidr_v6);
 													if (!empty($parsed)) {
 														$ip_data .= $parsed . "\n";
 													}
@@ -16520,7 +16537,7 @@ function sync_package_pfblockerng($cron='') {
 													foreach ($a_cidr as $cidr) {
 														if (!empty($cidr)) {
 															if (validate_ipv6($cidr)) {
-																$parsed = sanitize_ipaddr_v6($cidr, $custom);
+																$parsed = sanitize_ipaddr_v6($cidr, $custom, $pfbcidr_v6);
 																if (!empty($parsed)) {
 																	$ip_data .= $parsed . "\n";
 																}
@@ -16557,7 +16574,7 @@ function sync_package_pfblockerng($cron='') {
 												// Workaround to skip cloudflare error pages
 												if (strpos($oline, 'cf-footer-item') === FALSE) {
 													if (validate_ipv6($match)) {
-														$parsed = sanitize_ipaddr_v6($match, $custom);
+														$parsed = sanitize_ipaddr_v6($match, $custom, $pfbcidr_v6);
 														if (!empty($parsed)) {
 															$ip_data .= $parsed . "\n";
 														}

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -899,7 +899,7 @@ else {
 		$pconfig['agateway_out']	= $rowdata[$rowid]['agateway_out'];
 
 		$pconfig['suppression_cidr']	= $rowdata[$rowid]['suppression_cidr'];
-		$pconfig['suppression_cidr_v6']	= $rowdata[$rowid]['suppression_cidr_v6'];
+		$pconfig['suppression_cidr_v6']	= $rowdata[$rowid]['suppression_cidr_v6'] ?? 'Disabled';
 		$pconfig['whois_convert']	= $rowdata[$rowid]['whois_convert'];
 	}
 	else {

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -449,6 +449,7 @@ $options_logging	= [	'enabled'	=> 'DNSBL WebServer/VIP',
 $options_row_action	= [ 'Deny' => 'Deny', 'Permit' => 'Permit' ];
 
 $options_suppression_cidr	= [ 'Disabled' => 'Disabled' ] + array_combine(range(1, 17, 1), range(1, 17, 1));
+$options_suppression_cidr_v6	= [ 'Disabled' => 'Disabled' ] + array_combine(range(1, 64, 1), range(1, 64, 1));
 
 $interfaces_list		= get_configured_interface_list_by_realif();
 $src_interfaces			= array('lo0' => 'Localhost');
@@ -492,6 +493,7 @@ if ($_POST && isset($_POST['save'])) {
 					'order'			=> 'default',
 					'logging'		=> 'Enabled',
 					'suppression_cidr'	=> 'Disabled',
+					'suppression_cidr_v6'	=> 'Disabled',
 					'srcint'		=> '',
 					'script_pre'		=> '',
 					'script_post'		=> ''
@@ -528,6 +530,11 @@ if ($_POST && isset($_POST['save'])) {
 	// Validate CIDR Limit
 	if ($gtype == 'ipv4') {
 		if ($_POST['suppression_cidr'] != 'Disabled' && !ctype_digit($_POST['suppression_cidr'])) {
+			$input_errors[] = 'Advanced Tunable - Suppression CIDR Limit invalid';
+		}
+	}
+	if ($gtype == 'ipv6') {
+		if ($_POST['suppression_cidr_v6'] != 'Disabled' && !ctype_digit($_POST['suppression_cidr_v6'])) {
 			$input_errors[] = 'Advanced Tunable - Suppression CIDR Limit invalid';
 		}
 	}
@@ -775,6 +782,9 @@ if ($_POST && isset($_POST['save'])) {
 			config_set_path("installedpackages/{$conf_type}/config/{$rowid}/agateway_out", $_POST['agateway_out'] ?: 'default');
 
 			config_set_path("installedpackages/{$conf_type}/config/{$rowid}/suppression_cidr", $_POST['suppression_cidr'] ?: 'Disabled');
+			if ($gtype == 'ipv6') {
+				config_set_path("installedpackages/{$conf_type}/config/{$rowid}/suppression_cidr_v6", $_POST['suppression_cidr_v6'] ?: 'Disabled');
+			}
 			config_set_path("installedpackages/{$conf_type}/config/{$rowid}/whois_convert", pfb_filter($_POST['whois_convert'], PFB_FILTER_ON_OFF, 'Category_edit'));
 		}
 		else {
@@ -889,6 +899,7 @@ else {
 		$pconfig['agateway_out']	= $rowdata[$rowid]['agateway_out'];
 
 		$pconfig['suppression_cidr']	= $rowdata[$rowid]['suppression_cidr'];
+		$pconfig['suppression_cidr_v6']	= $rowdata[$rowid]['suppression_cidr_v6'];
 		$pconfig['whois_convert']	= $rowdata[$rowid]['whois_convert'];
 	}
 	else {
@@ -1605,6 +1616,18 @@ if ($gtype == 'ipv4') {
 		$pconfig['suppression_cidr'],
 		$options_suppression_cidr
 	))->setHelp('When suppression is enabled, this option will limit the CIDR block for this entire IPv4 Alias'
+		. '(Excluding the Custom List IP addresses)<br />Default: <strong>Disabled</strong> (No CIDR limit)')
+	  ->setAttribute('style', 'width: auto');
+}
+
+if ($gtype == 'ipv6') {
+
+	$section->addInput(new Form_Select(
+		'suppression_cidr_v6',
+		'Suppression CIDR Limit',
+		$pconfig['suppression_cidr_v6'],
+		$options_suppression_cidr_v6
+	))->setHelp('When suppression is enabled, this option will limit the CIDR block for this entire IPv6 Alias'
 		. '(Excluding the Custom List IP addresses)<br />Default: <strong>Disabled</strong> (No CIDR limit)')
 	  ->setAttribute('style', 'width: auto');
 }

--- a/tests/php/SanitizeIpaddrTest.php
+++ b/tests/php/SanitizeIpaddrTest.php
@@ -256,4 +256,18 @@ final class SanitizeIpaddrTest extends TestCase
 		$GLOBALS['pfb']['supp'] = 'on';
 		$this->assertSame('0.0.0.0/0', sanitize_ipaddr('0.0.0.0/0', true, 24));
 	}
+
+	// --- Interplay with the issue #760 documentation-range drop ---------------
+	//
+	// The floor clamp runs before the reserved/private filter, but it only
+	// rewrites $mask -- the filter still judges the untouched address. So a
+	// documentation-range CIDR under a floor is DROPPED entirely, not survived
+	// as a clamped single host: the #760 drop wins over the floor clamp, same
+	// interplay as the v6 sibling (SanitizeIpaddrV6Test::
+	// testDocumentationRangeCidrStillDroppedUnderFloor).
+	public function testDocumentationRangeCidrStillDroppedUnderFloor(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr('192.0.2.0/24', false, 28));
+	}
 }

--- a/tests/php/SanitizeIpaddrTest.php
+++ b/tests/php/SanitizeIpaddrTest.php
@@ -59,7 +59,9 @@ final class SanitizeIpaddrTest extends TestCase
 	public function testSuppressionKeepsPublicIp(): void
 	{
 		$GLOBALS['pfb']['supp'] = 'on';
-		$this->assertSame('192.0.2.5', sanitize_ipaddr('192.0.2.5/32', false, 'Disabled'));
+		// 192.0.2.5 (RFC 5737 documentation space) no longer qualifies as
+		// "public" under issue #760 — use a genuinely routable address.
+		$this->assertSame('1.1.1.1', sanitize_ipaddr('1.1.1.1/32', false, 'Disabled'));
 	}
 
 	public function testSuppressionDropsPrivateIp(): void
@@ -84,8 +86,70 @@ final class SanitizeIpaddrTest extends TestCase
 	public function testAdvancedCidrFloorClampsToSlash32(): void
 	{
 		$GLOBALS['pfb']['supp'] = 'on';
-		// mask 8 < floor 24 -> clamped to /32 (public TEST-NET-2 survives the filter).
-		$this->assertSame('198.51.100.0/32', sanitize_ipaddr('198.51.100.0/8', false, 24));
+		// mask 8 < floor 24 -> clamped to /32 (public address survives the filter).
+		// 198.51.100.0 (TEST-NET-2) would no longer survive under issue #760, so
+		// this exemplar uses a genuinely routable /8.
+		$this->assertSame('1.1.1.0/32', sanitize_ipaddr('1.1.1.0/8', false, 24));
+	}
+
+	// --- Additional reserved classes dropped under Suppression (issue #760) ---
+	//
+	// FILTER_FLAG_NO_PRIV_RANGE|NO_RES_RANGE keep documentation, multicast,
+	// CGN, benchmarking and the deprecated 6to4 relay anycast prefix
+	// routable; sanitize_ipaddr() explicitly drops these under Suppression,
+	// judged on the address part only — the CIDR span is not inspected.
+
+	public function testSuppressionDropsDocumentationRange(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr('192.0.2.5/32', false, 'Disabled'), 'documentation (RFC 5737) is dropped');
+	}
+
+	// CIDR-form pin: the network address of a documentation /24 is judged the
+	// same as a bare host — the mask itself is never inspected.
+	public function testSuppressionDropsDocumentationRangeCidr(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr('198.51.100.0/24', false, 'Disabled'), 'documentation (RFC 5737) is dropped');
+	}
+
+	public function testSuppressionDropsMulticastRange(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr('224.0.0.1/32', false, 'Disabled'), 'multicast (224.0.0.0/4) is dropped');
+	}
+
+	public function testSuppressionDropsCgnRange(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr('100.64.0.1/32', false, 'Disabled'), 'CGN (RFC 6598) is dropped');
+	}
+
+	public function testSuppressionDropsBenchmarkingRange(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr('198.18.0.1/32', false, 'Disabled'), 'benchmarking (RFC 2544) is dropped');
+	}
+
+	public function testSuppressionDrops6to4RelayRange(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr('192.88.99.1/32', false, 'Disabled'), '6to4 relay anycast (deprecated) is dropped');
+	}
+
+	// Suppression off keeps the same documentation-range address — proves the
+	// new drop is gated on Suppression, not an unconditional block.
+	public function testSuppressionOffKeepsDocumentationRange(): void
+	{
+		$this->assertSame('192.0.2.5', sanitize_ipaddr('192.0.2.5/32', false, 'Disabled'));
+	}
+
+	// A custom list bypasses the new drop, same as every other suppressed
+	// class.
+	public function testCustomListBypassesSuppressionForDocumentationRange(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertSame('192.0.2.5', sanitize_ipaddr('192.0.2.5/32', true, 'Disabled'));
 	}
 
 	// --- RFC 4632-invalid prefix lengths are dropped, never rewritten (#719) ---
@@ -162,11 +226,12 @@ final class SanitizeIpaddrTest extends TestCase
 	// The /0 is clamped to a host up front, so under suppression it no longer
 	// slips past the Advanced CIDR floor as an "empty" mask — the result is
 	// the same single host, not an unclamped /0. Regression PIN (same
-	// accidental end-state as above, now deliberate).
+	// accidental end-state as above, now deliberate). Uses a genuinely
+	// routable address (198.51.100.x would now be dropped under issue #760).
 	public function testFeedSlashZeroUnderSuppressionCidrFloorStillSingleHost(): void
 	{
 		$GLOBALS['pfb']['supp'] = 'on';
-		$this->assertSame('198.51.100.7', sanitize_ipaddr('198.51.100.7/0', false, 24));
+		$this->assertSame('1.1.1.7', sanitize_ipaddr('1.1.1.7/0', false, 24));
 	}
 
 	// Interaction PIN: a feed 0.0.0.0/0 under suppression is clamped to the

--- a/tests/php/SanitizeIpaddrV6Test.php
+++ b/tests/php/SanitizeIpaddrV6Test.php
@@ -179,4 +179,76 @@ final class SanitizeIpaddrV6Test extends TestCase
 		$GLOBALS['pfb']['supp'] = 'on';
 		$this->assertSame('::/0', sanitize_ipaddr_v6('::/0', true));
 	}
+
+	// --- Suppression CIDR floor (issue #760 §3) -------------------------------
+	//
+	// $pfbcidr is the per-category Advanced "Suppression CIDR Limit": under
+	// Suppression, a downloaded feed's CIDR narrower than the floor is clamped
+	// to a single host (bare address, no mask -- loads as /128), the v6 sibling
+	// of sanitize_ipaddr()'s Advanced IPv4 Tunable floor.
+
+	public function testAdvancedCidrFloorClampsToSingleHost(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		// mask 32 < floor 48 -> clamped to a bare host (public address survives
+		// the reserved/private filter).
+		$this->assertSame('2606:4700:4700::', sanitize_ipaddr_v6('2606:4700:4700::/32', false, 48));
+	}
+
+	// The paired branch: a mask AT OR ABOVE the floor is kept, mask intact --
+	// proves the floor is a real threshold, not an unconditional clamp.
+	public function testMaskAtOrAboveFloorKeptUnchanged(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertSame('2606:4700:4700::/48', sanitize_ipaddr_v6('2606:4700:4700::/48', false, 48));
+		$this->assertSame('2606:4700:4700::/64', sanitize_ipaddr_v6('2606:4700:4700::/64', false, 48));
+	}
+
+	// Floor 'Disabled' (the default) never clamps, regardless of mask width.
+	public function testFloorDisabledKeepsWideMaskUnchanged(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertSame('2606:4700:4700::/32', sanitize_ipaddr_v6('2606:4700:4700::/32', false, 'Disabled'));
+	}
+
+	// Suppression OFF bypasses the floor entirely, even when one is configured --
+	// the floor is a sub-clause of the Suppression block, not a standalone check.
+	public function testSuppressionOffBypassesFloor(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'off';
+		$this->assertSame('2606:4700:4700::/32', sanitize_ipaddr_v6('2606:4700:4700::/32', false, 48));
+	}
+
+	// A custom list bypasses the floor, same as every other Suppression sub-check.
+	public function testCustomListBypassesFloor(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertSame('2606:4700:4700::/32', sanitize_ipaddr_v6('2606:4700:4700::/32', true, 48));
+	}
+
+	// --- Floor is the cause (assert before-state, then flip) ------------------
+
+	public function testFloorTogglesClampOfTheSameCidr(): void
+	{
+		// Given the floor Disabled, a narrow mask is KEPT (before-state).
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertSame('2606:4700:4700::/32', sanitize_ipaddr_v6('2606:4700:4700::/32', false, 'Disabled'));
+
+		// When a floor narrower than the mask is set, the SAME entry is now
+		// CLAMPED -- so green proves the floor caused the change.
+		$this->assertSame('2606:4700:4700::', sanitize_ipaddr_v6('2606:4700:4700::/32', false, 48));
+	}
+
+	// --- Interplay with the issue #760 documentation-range drop ---------------
+	//
+	// The floor clamp runs before the reserved/private filter, but it only
+	// rewrites $ipaddr -- the filter judges $s_ip (the address part), which is
+	// untouched by the clamp. So a documentation-range CIDR under a floor is
+	// still DROPPED entirely: the #760 drop wins over the floor clamp, it does
+	// not survive as a clamped single host.
+	public function testDocumentationRangeCidrStillDroppedUnderFloor(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertNull(sanitize_ipaddr_v6('2001:db8::1/16', false, 24));
+	}
 }

--- a/tests/php/SanitizeIpaddrV6Test.php
+++ b/tests/php/SanitizeIpaddrV6Test.php
@@ -65,31 +65,47 @@ final class SanitizeIpaddrV6Test extends TestCase
 	// --- Classes the PHP filter flags do NOT drop (issue #760) ---------------
 	//
 	// FILTER_FLAG_NO_PRIV_RANGE|NO_RES_RANGE keep documentation
-	// (2001:db8::/32), multicast (ff00::/8) and NAT64 (64:ff9b::/96) space —
-	// the same permissiveness as the v4 flags (192.0.2.0/24 and 224.0.0.0/4
-	// are kept too). These pin today's behaviour; dropping these classes is a
-	// policy decision tracked in issue #760 and would flip these tests.
+	// (2001:db8::/32), multicast (ff00::/8) and NAT64 (64:ff9b::/96) space
+	// routable — the same permissiveness as the v4 flags (192.0.2.0/24 and
+	// 224.0.0.0/4 are kept too). Issue #760 resolved the policy: sanitize_
+	// ipaddr_v6() now drops these classes explicitly under Suppression via
+	// direct prefix checks rather than another filter flag, so the behaviour
+	// is independent of PHP's patch level (the RFC 6890 refactor in PHP
+	// 8.3.16/8.4.3 moved 2001:db8::/32 between filter sets — irrelevant here
+	// since these prefixes are no longer judged through filter_var()).
 
-	// 2001:db8::/32 is non-reserved only since PHP 8.3.16/8.4.3 (php-src
-	// GH-16944, the RFC 6890 range refactor); an older 8.3.x patch level
-	// DROPS it — a failure here on a stale toolchain is a PHP patch-floor
-	// problem, not a #760 policy change.
-	public function testSuppressionKeepsDocumentationRange(): void
+	public function testSuppressionDropsDocumentationRange(): void
 	{
 		$GLOBALS['pfb']['supp'] = 'on';
-		$this->assertSame('2001:db8::1', sanitize_ipaddr_v6('2001:db8::1', false), 'documentation (RFC 3849) is kept');
+		$this->assertNull(sanitize_ipaddr_v6('2001:db8::1', false), 'documentation (RFC 3849) is dropped');
 	}
 
-	public function testSuppressionKeepsMulticastRange(): void
+	public function testSuppressionDropsMulticastRange(): void
 	{
 		$GLOBALS['pfb']['supp'] = 'on';
-		$this->assertSame('ff02::1', sanitize_ipaddr_v6('ff02::1', false), 'multicast (ff00::/8) is kept');
+		$this->assertNull(sanitize_ipaddr_v6('ff02::1', false), 'multicast (ff00::/8) is dropped');
 	}
 
-	public function testSuppressionKeepsNat64Range(): void
+	public function testSuppressionDropsNat64Range(): void
 	{
 		$GLOBALS['pfb']['supp'] = 'on';
-		$this->assertSame('64:ff9b::1', sanitize_ipaddr_v6('64:ff9b::1', false), 'NAT64 (RFC 6052) is kept');
+		$this->assertNull(sanitize_ipaddr_v6('64:ff9b::1', false), 'NAT64 (RFC 6052) is dropped');
+	}
+
+	// Suppression off keeps the same documentation-range address — proves the
+	// new drop is gated on Suppression, not an unconditional block.
+	public function testSuppressionOffKeepsDocumentationRange(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'off';
+		$this->assertSame('2001:db8::1', sanitize_ipaddr_v6('2001:db8::1', false));
+	}
+
+	// A custom list bypasses the new drop, same as every other suppressed
+	// class.
+	public function testCustomListBypassesSuppressionForDocumentationRange(): void
+	{
+		$GLOBALS['pfb']['supp'] = 'on';
+		$this->assertSame('2001:db8::1', sanitize_ipaddr_v6('2001:db8::1', true));
 	}
 
 	// --- Suppression toggle is the cause (assert before-state, then flip) ----

--- a/tests/smoke/fixtures/README.md
+++ b/tests/smoke/fixtures/README.md
@@ -16,9 +16,11 @@ checkbox ON (`tests/smoke/test_smoke_suppression.py`) must NOT use RFC
 5737/3849/2544/6598 (or any other reserved-class) address — `sanitize_ipaddr()`/
 `sanitize_ipaddr_v6()` drop those classes unconditionally whenever Suppression is
 on, which would silently empty the fixture before it ever reached the pf table.
-Those fixtures use public, non-reserved space instead (arbitrary octets/hextets
-under real resolver/GUA blocks, e.g. `9.9.9.9`, `2606:4700::/32` — chosen only as
-inert content, never dialed); see the "IP suppression..." sections below.
+Those fixtures use public, non-reserved space instead — arbitrary octets/hextets
+(e.g. `81.169.0.0/16`, `2606:4700::/32`), chosen only as inert content, never
+dialed, and never a literal with harness meaning elsewhere in this suite (e.g.
+`1.1.1.1`/`1.0.0.1`, the smoke image's baked DNS-forwarder default) or a
+well-known public resolver address; see the "IP suppression..." sections below.
 
 Line shapes match the real parsers — IP `auto` in `pfblockerng.inc`
 (`~:10410-10560`), DNSBL plain/hosts/ABP in `pfb_unbound.py`
@@ -92,7 +94,7 @@ the HTTP-fetch contract Part C already covers.
 
 | File | Contents | Purpose |
 | --- | --- | --- |
-| `ip_suppress_v4.txt` | `1.1.0.0/16` (public, non-reserved) + two well-separated public bare hosts (`9.9.9.9`, `8.8.8.8`) | Containing-range carve (a `/32`/`/24` suppression carves the `/16`), plus whole-token bare-host removal |
+| `ip_suppress_v4.txt` | `81.169.0.0/16` (public, non-reserved) + two well-separated public bare hosts (`83.246.7.7`, `82.165.5.5`) | Containing-range carve (a `/32`/`/24` suppression carves the `/16`), plus whole-token bare-host removal |
 | `ip_suppress_v6.txt` | `2606:4700:53::/64` (public, non-reserved) + two well-separated public bare hosts (`2606:4700:99::10`, `2606:4700:aa::20`) | Same shape, IPv6 (`/128` suppression carves the `/64`) |
 
 The bare hosts are deliberately non-adjacent to each other and to the CIDR block: iprange's
@@ -113,7 +115,7 @@ drop (§1) and the per-category IPv6 CIDR floor `suppression_cidr_v6` (§3).
 | `ip_suppress_reserved_v6.txt` | One public entry (`2606:4700:7777::1111`) + one each of documentation (`2001:db8::1`), multicast (`ff02::1`), NAT64 (`64:ff9b::1`) | Proves the public entry loads while every reserved class is dropped outright |
 | `ip_suppress_cidr_floor_v6.txt` | A network-aligned public `/48` (`2606:4700:aaaa::/48`) + a separate bare host (`2606:4700:bbbb::99`) | Proves a floor narrower than the feed's mask clamps the `/48` to its bare base address, leaving the sibling host untouched |
 
-The v4 companion for the reserved-class test (`1.1.1.1` public + `100.64.0.1` CGN) is a
+The v4 companion for the reserved-class test (`82.165.5.5` public + `100.64.0.1` CGN) is a
 two-line inline body written directly by the test (mirrors the Scenario B companion above) --
 not a committed fixture, since it needs no documentation beyond the test itself.
 

--- a/tests/smoke/fixtures/README.md
+++ b/tests/smoke/fixtures/README.md
@@ -11,6 +11,15 @@ files use `uuid-<hex>.com` names. Per the smoke-domain rule, DNSBL fixtures NEVE
 use RFC-6761 TLDs (`.test`/`.example`/`.invalid` — Unbound's built-in local-zones
 shadow them) and NEVER HSTS-preload names (HSTS forces a VIP block to NULL).
 
+**Exception (issue #760):** a fixture exercised under the global Suppression
+checkbox ON (`tests/smoke/test_smoke_suppression.py`) must NOT use RFC
+5737/3849/2544/6598 (or any other reserved-class) address — `sanitize_ipaddr()`/
+`sanitize_ipaddr_v6()` drop those classes unconditionally whenever Suppression is
+on, which would silently empty the fixture before it ever reached the pf table.
+Those fixtures use public, non-reserved space instead (arbitrary octets/hextets
+under real resolver/GUA blocks, e.g. `9.9.9.9`, `2606:4700::/32` — chosen only as
+inert content, never dialed); see the "IP suppression..." sections below.
+
 Line shapes match the real parsers — IP `auto` in `pfblockerng.inc`
 (`~:10410-10560`), DNSBL plain/hosts/ABP in `pfb_unbound.py`
 (`parse` / `parse_abp`, `~:2675-2900`). A leading `#` (IP, DNSBL plain/hosts) or
@@ -83,14 +92,30 @@ the HTTP-fetch contract Part C already covers.
 
 | File | Contents | Purpose |
 | --- | --- | --- |
-| `ip_suppress_v4.txt` | `198.18.0.0/16` (RFC 2544) + two well-separated RFC 5737 bare hosts (`203.0.113.60`, `198.51.100.77`) | Containing-range carve (a `/32`/`/24` suppression carves the `/16`), plus whole-token bare-host removal |
-| `ip_suppress_v6.txt` | `2001:db8:53::/64` (RFC 3849) + two well-separated RFC 3849 bare hosts (`2001:db8:99::10`, `2001:db8:aa::20`) | Same shape, IPv6 (`/128` suppression carves the `/64`) |
+| `ip_suppress_v4.txt` | `1.1.0.0/16` (public, non-reserved) + two well-separated public bare hosts (`9.9.9.9`, `8.8.8.8`) | Containing-range carve (a `/32`/`/24` suppression carves the `/16`), plus whole-token bare-host removal |
+| `ip_suppress_v6.txt` | `2606:4700:53::/64` (public, non-reserved) + two well-separated public bare hosts (`2606:4700:99::10`, `2606:4700:aa::20`) | Same shape, IPv6 (`/128` suppression carves the `/64`) |
 
 The bare hosts are deliberately non-adjacent to each other and to the CIDR block: iprange's
 minimal-CIDR aggregation would otherwise merge two adjacent addresses into one covering entry,
 which would throw off the exact covering-CIDR-count assertions (`/16 - /32 = 16`,
 `/64 - /128 = 64`, `/16 - /24 = 8` -- ADR-53 §1.2, mathematically invariant regardless of the
-hole's exact position within its container).
+hole's exact position within its container). Public (not RFC 5737/3849/2544) space is used
+throughout, per the issue #760 exception above.
+
+## IP reserved-class / CIDR-floor fixtures (issue #760, `IpCase`, `test_smoke_suppression.py`)
+
+Scenarios D/E of the same module -- a THIRD Suppression-gated mechanism, distinct from the
+carve engine above: `sanitize_ipaddr()`/`sanitize_ipaddr_v6()`'s unconditional reserved-class
+drop (§1) and the per-category IPv6 CIDR floor `suppression_cidr_v6` (§3).
+
+| File | Contents | Purpose |
+| --- | --- | --- |
+| `ip_suppress_reserved_v6.txt` | One public entry (`2606:4700:7777::1111`) + one each of documentation (`2001:db8::1`), multicast (`ff02::1`), NAT64 (`64:ff9b::1`) | Proves the public entry loads while every reserved class is dropped outright |
+| `ip_suppress_cidr_floor_v6.txt` | A network-aligned public `/48` (`2606:4700:aaaa::/48`) + a separate bare host (`2606:4700:bbbb::99`) | Proves a floor narrower than the feed's mask clamps the `/48` to its bare base address, leaving the sibling host untouched |
+
+The v4 companion for the reserved-class test (`1.1.1.1` public + `100.64.0.1` CGN) is a
+two-line inline body written directly by the test (mirrors the Scenario B companion above) --
+not a committed fixture, since it needs no documentation beyond the test itself.
 
 ## Omitted formats (and why)
 

--- a/tests/smoke/fixtures/ip_suppress_cidr_floor_v6.txt
+++ b/tests/smoke/fixtures/ip_suppress_cidr_floor_v6.txt
@@ -1,0 +1,7 @@
+# issue #760 §3 smoke fixture: v6 Suppression CIDR floor (suppression_cidr_v6)
+# (tests/smoke/test_smoke_suppression.py, Scenario E). Wide public /48 --
+# the floor-clamp target (network-aligned: the first 48 bits are exactly
+# 2606:4700:aaaa).
+2606:4700:aaaa::/48
+# Separate bare host, in a different /48 -- untouched by the floor.
+2606:4700:bbbb::99

--- a/tests/smoke/fixtures/ip_suppress_reserved_v6.txt
+++ b/tests/smoke/fixtures/ip_suppress_reserved_v6.txt
@@ -1,0 +1,10 @@
+# issue #760 §1 smoke fixture: reserved-class exclusion under Suppression ON
+# (tests/smoke/test_smoke_suppression.py, Scenario D). Public (non-reserved)
+# entry -- must load.
+2606:4700:7777::1111
+# Documentation (RFC 3849, 2001:db8::/32) -- dropped.
+2001:db8::1
+# Multicast (ff00::/8) -- dropped.
+ff02::1
+# NAT64 well-known prefix (RFC 6052, 64:ff9b::/96) -- dropped.
+64:ff9b::1

--- a/tests/smoke/fixtures/ip_suppress_v4.txt
+++ b/tests/smoke/fixtures/ip_suppress_v4.txt
@@ -5,12 +5,14 @@
 # ON), never RFC 5737/2544 documentation/benchmarking space either --
 # sanitize_ipaddr() now drops those unconditionally under Suppression, which
 # would silently empty this fixture before it ever reached the pf table. Public,
-# non-reserved space instead (arbitrary octets, chosen only as inert content --
-# never dialed).
-1.1.0.0/16
-# Bare hosts (public, non-reserved -- Quad9 / Google resolvers), deliberately
-# far apart from each other and from the /16 above -- iprange's minimal-CIDR
+# non-reserved space instead (arbitrary RIPE-block octets, chosen only as inert
+# content -- never dialed, and never a harness-meaningful or well-known-resolver
+# literal: 1.1.1.1/1.0.0.1 is the smoke image's baked DNS-forwarder default
+# (tests/smoke/helpers.py's set_unbound_forwarding), so it was moved off again.
+81.169.0.0/16
+# Bare hosts (public, non-reserved, no resolver meaning), deliberately far
+# apart from each other and from the /16 above -- iprange's minimal-CIDR
 # aggregation would merge two ADJACENT hosts into one covering CIDR, which
 # would break the exact covering-CIDR-count assertions these tests pin.
-9.9.9.9
-8.8.8.8
+83.246.7.7
+82.165.5.5

--- a/tests/smoke/fixtures/ip_suppress_v4.txt
+++ b/tests/smoke/fixtures/ip_suppress_v4.txt
@@ -1,10 +1,16 @@
-# ADR-53 smoke fixture: RFC 2544 benchmarking /16 -- the containing-range
-# carve target (tests/smoke/test_smoke_suppression.py). Never RFC 1918 (the
-# killstates/private-exclusion path would otherwise eat it).
-198.18.0.0/16
-# Bare hosts (RFC 5737 documentation ranges), deliberately far apart from each
-# other and from the /16 above -- iprange's minimal-CIDR aggregation would
-# merge two ADJACENT hosts into one covering CIDR, which would break the
-# exact covering-CIDR-count assertions these tests pin.
-203.0.113.60
-198.51.100.77
+# ADR-53 smoke fixture: the containing-range carve target
+# (tests/smoke/test_smoke_suppression.py). Never RFC 1918 (the
+# killstates/private-exclusion path would otherwise eat it) and, since issue
+# #760 (every test in this module runs with the global Suppression checkbox
+# ON), never RFC 5737/2544 documentation/benchmarking space either --
+# sanitize_ipaddr() now drops those unconditionally under Suppression, which
+# would silently empty this fixture before it ever reached the pf table. Public,
+# non-reserved space instead (arbitrary octets, chosen only as inert content --
+# never dialed).
+1.1.0.0/16
+# Bare hosts (public, non-reserved -- Quad9 / Google resolvers), deliberately
+# far apart from each other and from the /16 above -- iprange's minimal-CIDR
+# aggregation would merge two ADJACENT hosts into one covering CIDR, which
+# would break the exact covering-CIDR-count assertions these tests pin.
+9.9.9.9
+8.8.8.8

--- a/tests/smoke/fixtures/ip_suppress_v6.txt
+++ b/tests/smoke/fixtures/ip_suppress_v6.txt
@@ -1,8 +1,13 @@
-# ADR-53 smoke fixture: RFC 3849 documentation /64 -- the containing-range
-# carve target (tests/smoke/test_smoke_suppression.py).
-2001:db8:53::/64
-# Bare v6 hosts (RFC 3849), in separate prefixes from the /64 above and from
-# each other -- avoids any iprange/engine-side adjacency merge so the
-# covering-CIDR-count assertions stay exact.
-2001:db8:99::10
-2001:db8:aa::20
+# ADR-53 smoke fixture: the containing-range carve target
+# (tests/smoke/test_smoke_suppression.py). Since issue #760 (every test in this
+# module runs with the global Suppression checkbox ON), never RFC 3849
+# documentation space -- sanitize_ipaddr_v6() now drops it unconditionally
+# under Suppression, which would silently empty this fixture before it ever
+# reached the pf table. Public, non-reserved space instead (arbitrary hextets
+# under a real GUA /32, chosen only as inert content -- never dialed).
+2606:4700:53::/64
+# Bare v6 hosts (public, non-reserved), in separate prefixes from the /64
+# above and from each other -- avoids any iprange/engine-side adjacency merge
+# so the covering-CIDR-count assertions stay exact.
+2606:4700:99::10
+2606:4700:aa::20

--- a/tests/smoke/test_smoke_suppression.py
+++ b/tests/smoke/test_smoke_suppression.py
@@ -27,6 +27,14 @@ Scenario H. Scenario B below still injects a companion v4 Deny alias alongside
 the v6 target -- now exercising the MIXED-family case (both families active
 in the same pass), not working around the fixed bug.
 
+Scenarios D and E cover a THIRD mechanism gated by the same Suppression checkbox
+(``$pfb['supp'] == 'on'``) but otherwise unrelated to the carve engines above --
+``sanitize_ipaddr()``/``sanitize_ipaddr_v6()``'s per-line reserved-class drop and
+the per-category IPv6 CIDR floor (issue #760 §1/§3). They reuse this module's
+``deployed_vm``/``_clean_suppression`` infra (the Suppression checkbox + the
+``IpCase``/``inject_ip_lists`` plumbing) rather than a new module, since that
+infra is exactly what they need and duplicating it would buy nothing.
+
 DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke`` in
 pyproject.toml). Run via the smoke workflow or locally::
 
@@ -55,8 +63,18 @@ DENYDIR = f"{h.PFB_DBDIR}/deny"
 # The two bare hosts each fixture carries, in both notations iprange/the v6
 # engine may render a lone covering host (bare, or explicitly masked) -- used
 # to filter "untouched sibling" lines out of a covering-CIDR count.
-V4_BARE_HOSTS = ("203.0.113.60", "198.51.100.77")
-V6_BARE_HOSTS = ("2001:db8:99::10", "2001:db8:aa::20")
+#
+# NOTE (issue #760): these used to be RFC 5737/3849 documentation addresses, matching
+# the smoke-fixture convention (tests/smoke/fixtures/README.md). Every test in this
+# module runs with the global Suppression checkbox ON (``_set_suppression``), and
+# issue #760 §1 made ``sanitize_ipaddr()``/``sanitize_ipaddr_v6()`` drop documentation
+# space UNCONDITIONALLY whenever Suppression is on -- so RFC 5737/3849 fixture data
+# would now be silently dropped before ever reaching the pf table, breaking every
+# BEFORE-state assertion in this module. Switched to public, non-reserved space
+# (Cloudflare/Google/Quad9 exemplar addresses) instead; ``ip_suppress_v4.txt`` /
+# ``ip_suppress_v6.txt`` were updated to match (see their in-file comments).
+V4_BARE_HOSTS = ("9.9.9.9", "8.8.8.8")
+V6_BARE_HOSTS = ("2606:4700:99::10", "2606:4700:aa::20")
 
 
 @pytest.fixture(scope="module")
@@ -79,7 +97,7 @@ def deployed_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
 def _set_suppression(vm: SmokeVM, *, v4: list[str] | None = None, v6: list[str] | None = None) -> None:
     """Enable the master "Enable Suppression" toggle and set BOTH customlists.
 
-    ``v4``/``v6`` are raw textarea lines (e.g. ``"198.18.3.4/32"``) -- every
+    ``v4``/``v6`` are raw textarea lines (e.g. ``"1.1.3.4/32"``) -- every
     suppression line MUST carry an explicit mask: ``pfb_validate_suppression_line``
     rejects a bare host (``is_subnetv4()``/``is_subnetv6()`` both require
     ``/bits``). ``None``/empty clears that family's list. Same base64/CRLF
@@ -114,6 +132,27 @@ def _wipe_suppression(vm: SmokeVM) -> None:
         raise AssertionError(
             "wipe of v4suppression/v6suppression did not take -- expected both empty, "
             f"got v4suppression={v4_after!r} v6suppression={v6_after!r}"
+        )
+
+
+def _set_suppression_cidr_v6(vm: SmokeVM, value: str) -> None:
+    """Set the per-category ``suppression_cidr_v6`` floor (issue #760 §3) on the SINGLE
+    v6 list-group the module's own ``h.inject()``/``h.inject_ip_lists()`` just wrote
+    (index 0 -- both write a fresh single-element list-group array per family root, so
+    this always targets the right row without a lookup). ``value`` is a mask-width
+    string (``'1'``..``'64'``) or ``'Disabled'``.
+    """
+    snippet = (
+        f"$lists = config_get_path({h._php_str(h.CFG_IP_V6_LISTS)}, array());\n"
+        f"$lists[0]['suppression_cidr_v6'] = {h._php_str(value)};\n"
+        f"config_set_path({h._php_str(h.CFG_IP_V6_LISTS)}, $lists);\n"
+        "write_config('pfBlockerNG smoke: issue #760 v6 CIDR floor');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"_set_suppression_cidr_v6 failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
         )
 
 
@@ -170,7 +209,7 @@ def test_suppression_v4_carves_containing_range_spares_sibling(deployed_vm: Smok
     live-loaded /16 down to covering CIDRs -- ADR-53 §4.1's headline acceptance
     requirement, proven via the update-time path.
 
-    Given: the v4 fixture feed (``198.18.0.0/16`` + two bare hosts) is loaded
+    Given: the v4 fixture feed (``1.1.0.0/16`` + two bare hosts) is loaded
     as a Deny list; suppression is enabled but empty; a settling update runs.
 
     When: v4suppression is set to the target host's exact /32 and a second
@@ -190,8 +229,8 @@ def test_suppression_v4_carves_containing_range_spares_sibling(deployed_vm: Smok
     # ("10.0.3.4" inside "10.0.0.0/16" -> 16 covering CIDRs incl. ".0.0/23" and
     # ".128.0/17") -- the covering-CIDR count/shape is invariant to the network
     # prefix, so this grounds the assertions below in an already-proven result.
-    target = "198.18.3.4"
-    sibling = "203.0.113.60"
+    target = "1.1.3.4"
+    sibling = "9.9.9.9"
     host_entry = f"{target}/32"
 
     h.inject(deployed_vm, spec)
@@ -228,8 +267,8 @@ def test_suppression_v4_carves_containing_range_spares_sibling(deployed_vm: Smok
         "expected 16 covering-CIDR entries for a /16 minus a /32 (ADR-53 §1.2's "
         f"measured bound); got {len(carved)}: {carved}\nfull member file ({len(lines)} lines): {lines}"
     )
-    assert "198.18.0.0/23" in carved and "198.18.128.0/17" in carved, (
-        "expected representative covering CIDRs '198.18.0.0/23' and '198.18.128.0/17' "
+    assert "1.1.0.0/23" in carved and "1.1.128.0/17" in carved, (
+        "expected representative covering CIDRs '1.1.0.0/23' and '1.1.128.0/17' "
         f"(the same relative shape as the real-iprange-verified 10.0.0.0/16-10.0.3.4 vector); got {carved}"
     )
 
@@ -248,7 +287,7 @@ def test_suppression_v6_carves_containing_range_spares_sibling(deployed_vm: Smok
     exercise the mixed-family case (see the module docstring: this used to be a
     workaround for a v6-only $pfb['supp_update'] gating bug, now fixed).
 
-    Given: the v6 fixture feed (``2001:db8:53::/64`` + two bare hosts) is
+    Given: the v6 fixture feed (``2606:4700:53::/64`` + two bare hosts) is
     loaded as a Deny list, alongside the v4 companion; suppression enabled but
     empty; a settling update runs.
 
@@ -266,11 +305,11 @@ def test_suppression_v6_carves_containing_range_spares_sibling(deployed_vm: Smok
     feed_url = h.write_local_feed(deployed_vm, "smoke_adr53_v6b.txt", feed_body)
     v6spec = h.IpCase(aliasname="adr53v6b", feed_url=feed_url, header="adr53v6b", family="v6")
 
-    companion_url = h.write_local_feed(deployed_vm, "smoke_adr53_v6companion.txt", "203.0.113.90\n")
+    companion_url = h.write_local_feed(deployed_vm, "smoke_adr53_v6companion.txt", "5.5.5.5\n")
     companion_spec = h.IpCase(aliasname="adr53v6bcompanion", feed_url=companion_url, header="adr53v6bcompanion")
 
-    target = "2001:db8:53::42"
-    sibling = "2001:db8:99::10"
+    target = "2606:4700:53::42"
+    sibling = "2606:4700:99::10"
     host_entry = f"{target}/128"
 
     h.inject_ip_lists(deployed_vm, [companion_spec, v6spec])
@@ -330,9 +369,9 @@ def test_suppression_v4_bare_host_removed(deployed_vm: SmokeVM) -> None:
     feed_body = (FIXTURES_DIR / "ip_suppress_v4.txt").read_text()
     feed_url = h.write_local_feed(deployed_vm, "smoke_adr53_v4c1.txt", feed_body)
     spec = h.IpCase(aliasname="adr53v4c1", feed_url=feed_url, header="adr53v4c1")
-    inside_16 = "198.18.3.4"
-    removed_host = "198.51.100.77"
-    kept_host = "203.0.113.60"
+    inside_16 = "1.1.3.4"
+    removed_host = "8.8.8.8"
+    kept_host = "9.9.9.9"
     host_entry = f"{removed_host}/32"
 
     h.inject(deployed_vm, spec)
@@ -359,7 +398,7 @@ def test_suppression_v4_bare_host_removed(deployed_vm: SmokeVM) -> None:
 
     lines = _member_lines(deployed_vm, f"{spec.header}_v4")
     assert len(lines) == 2, f"expected exactly 2 member-file lines (untouched /16 + surviving bare host); got {lines}"
-    assert "198.18.0.0/16" in lines, f"expected the untouched /16 line verbatim (never carved); got {lines}"
+    assert "1.1.0.0/16" in lines, f"expected the untouched /16 line verbatim (never carved); got {lines}"
     assert _has_entry(lines, kept_host), f"expected the surviving bare host {kept_host}; got {lines}"
     assert not _has_entry(lines, removed_host), f"expected {removed_host} removed; got {lines}"
 
@@ -383,9 +422,9 @@ def test_suppression_v4_subnet_mask_carves_at_granularity(deployed_vm: SmokeVM) 
     feed_body = (FIXTURES_DIR / "ip_suppress_v4.txt").read_text()
     feed_url = h.write_local_feed(deployed_vm, "smoke_adr53_v4c2.txt", feed_body)
     spec = h.IpCase(aliasname="adr53v4c2", feed_url=feed_url, header="adr53v4c2")
-    hole_ip = "198.18.5.9"
-    sibling_ip = "198.18.9.9"
-    hole_subnet = "198.18.5.0/24"
+    hole_ip = "1.1.5.9"
+    sibling_ip = "1.1.9.9"
+    hole_subnet = "1.1.5.0/24"
 
     h.inject(deployed_vm, spec)
     h.reload(deployed_vm, "updateip", wait_unbound=False)
@@ -413,3 +452,123 @@ def test_suppression_v4_subnet_mask_carves_at_granularity(deployed_vm: SmokeVM) 
         f"prefix-length-difference bound the shellspec proves for /24-/32=8); got {len(carved)}: {carved}\n"
         f"full member file ({len(lines)} lines): {lines}"
     )
+
+
+# --------------------------------------------------------------------------- #
+# Scenario D -- reserved-class entries never reach the pf table (issue #760 §1)
+# --------------------------------------------------------------------------- #
+
+
+def test_suppression_drops_reserved_classes_keeps_public(deployed_vm: SmokeVM) -> None:
+    """Under Suppression, a feed's RESERVED-CLASS entries (documentation, multicast,
+    NAT64, CGN) are dropped OUTRIGHT at parse time -- issue #760 §1's "IPv6
+    suppression is thinner" gap. Unlike Scenarios A-C, this is not the
+    suppression-LIST carve engine: ``sanitize_ipaddr()``/``sanitize_ipaddr_v6()``
+    (``pfblockerng.inc`` ~8018-8028 v4, ~8090-8097 v6) drop these classes
+    unconditionally whenever Suppression is on, with no suppression-list entry
+    needed.
+
+    Given: a v6 feed mixing one public (non-reserved) entry with a documentation
+    (2001:db8::1), a multicast (ff02::1) and a NAT64 (64:ff9b::1) entry, plus a
+    companion v4 feed mixing one public entry with a CGN (100.64.0.1) entry;
+    Suppression is enabled with both suppression lists empty (this module's
+    default) -- these are unconditional drops, not suppression-list carves.
+
+    When: a force update loads both feeds in one pass.
+
+    Then: each family's public entry IS in its pf table (proves the feed
+    genuinely loaded -- a false pass otherwise); every reserved-class entry is
+    ABSENT from its table.
+    """
+    v6_body = (FIXTURES_DIR / "ip_suppress_reserved_v6.txt").read_text()
+    v6_url = h.write_local_feed(deployed_vm, "smoke_issue760_reserved_v6.txt", v6_body)
+    v6spec = h.IpCase(aliasname="issue760resv6", feed_url=v6_url, header="issue760resv6", family="v6")
+
+    # Trivial inline v4 companion (not a committed fixture -- mirrors Scenario B's
+    # companion alias): pins the v4 side of the same drop (issue #760 §1) cheaply.
+    v4_url = h.write_local_feed(deployed_vm, "smoke_issue760_reserved_v4.txt", "1.1.1.1\n100.64.0.1\n")
+    v4spec = h.IpCase(aliasname="issue760resv4", feed_url=v4_url, header="issue760resv4")
+
+    public_v6 = "2606:4700:7777::1111"
+    dropped_v6 = ("2001:db8::1", "ff02::1", "64:ff9b::1")
+    public_v4 = "1.1.1.1"
+    dropped_v4 = "100.64.0.1"
+
+    h.inject_ip_lists(deployed_vm, [v4spec, v6spec])
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    members_v6 = h.wait_pfctl_table(deployed_vm, v6spec.alias)
+    assert members_v6, f"pf table {v6spec.alias} never populated after the update"
+    members_v4 = h.wait_pfctl_table(deployed_vm, v4spec.alias)
+    assert members_v4, f"pf table {v4spec.alias} never populated after the update"
+
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, v6spec.alias, public_v6)
+    assert matched, f"expected the public v6 entry {public_v6} to load into {v6spec.alias}; pfctl said: {raw!r}"
+    for ip in dropped_v6:
+        matched, raw = h.pfctl_table_test_raw(deployed_vm, v6spec.alias, ip)
+        assert not matched, f"expected reserved-class {ip} to be DROPPED from {v6spec.alias}; pfctl said: {raw!r}"
+
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, v4spec.alias, public_v4)
+    assert matched, f"expected the public v4 entry {public_v4} to load into {v4spec.alias}; pfctl said: {raw!r}"
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, v4spec.alias, dropped_v4)
+    assert not matched, f"expected CGN entry {dropped_v4} to be DROPPED from {v4spec.alias}; pfctl said: {raw!r}"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario E -- v6 Suppression CIDR floor clamps a wide range (issue #760 §3)
+# --------------------------------------------------------------------------- #
+
+
+def test_suppression_cidr_v6_floor_clamps_wide_cidr_to_bare_host(deployed_vm: SmokeVM) -> None:
+    """The per-category IPv6 "Suppression CIDR Limit" (``suppression_cidr_v6``,
+    issue #760 §3) clamps a feed CIDR narrower than the floor down to a bare
+    host -- never a silent full-range load -- while an unrelated host entry is
+    left untouched.
+
+    Given: a v6 feed with a network-aligned /48 (``2606:4700:aaaa::/48``) and a
+    separate bare host (``2606:4700:bbbb::99``) in a different /48; Suppression
+    is enabled (module default) with ``suppression_cidr_v6`` left at its absent
+    default (``Disabled``) for the settling update.
+
+    When: BEFORE -- the floor is absent, so the /48 loads as-is (an address
+    inside it matches). AFTER -- ``suppression_cidr_v6`` is set to 56 (wider
+    than the feed's /48) and a second update runs.
+
+    Then: the address that matched inside the /48 no longer matches (the range
+    collapsed); the /48's own base address now matches as a BARE host (clamped,
+    no prefix span -- never a 2^80-host explosion); the sibling host is
+    unaffected throughout.
+    """
+    feed_body = (FIXTURES_DIR / "ip_suppress_cidr_floor_v6.txt").read_text()
+    feed_url = h.write_local_feed(deployed_vm, "smoke_issue760_cidrfloor_v6.txt", feed_body)
+    spec = h.IpCase(aliasname="issue760cidrv6", feed_url=feed_url, header="issue760cidrv6", family="v6")
+
+    inside_cidr = "2606:4700:aaaa::1234"
+    cidr_base = "2606:4700:aaaa::"
+    sibling = "2606:4700:bbbb::99"
+
+    h.inject(deployed_vm, spec)
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    # BEFORE: the floor is absent (Disabled) -- the /48 loads unclamped.
+    members = h.wait_pfctl_table(deployed_vm, spec.alias)
+    assert members, f"pf table {spec.alias} never populated after the settling update"
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, inside_cidr)
+    assert matched, f"expected {inside_cidr} (inside the un-floored /48) to MATCH {spec.alias}; pfctl said: {raw!r}"
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, sibling)
+    assert matched, f"expected {sibling} to MATCH {spec.alias} before the floor is set; pfctl said: {raw!r}"
+
+    # WHEN: set the floor above the feed's /48, then re-run.
+    _set_suppression_cidr_v6(deployed_vm, "56")
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    # THEN: the /48 collapsed to its bare base address -- the wide span no longer matches...
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, inside_cidr)
+    assert not matched, (
+        f"expected {inside_cidr} to NO LONGER match {spec.alias} once the /48 is floor-clamped; pfctl said: {raw!r}"
+    )
+    # ...but the clamped bare host itself is still loaded (never silently dropped outright).
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, cidr_base)
+    assert matched, f"expected the clamped bare host {cidr_base} to STILL match {spec.alias}; pfctl said: {raw!r}"
+    matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, sibling)
+    assert matched, f"expected {sibling} to remain unaffected by the CIDR floor; pfctl said: {raw!r}"

--- a/tests/smoke/test_smoke_suppression.py
+++ b/tests/smoke/test_smoke_suppression.py
@@ -71,9 +71,14 @@ DENYDIR = f"{h.PFB_DBDIR}/deny"
 # space UNCONDITIONALLY whenever Suppression is on -- so RFC 5737/3849 fixture data
 # would now be silently dropped before ever reaching the pf table, breaking every
 # BEFORE-state assertion in this module. Switched to public, non-reserved space
-# (Cloudflare/Google/Quad9 exemplar addresses) instead; ``ip_suppress_v4.txt`` /
-# ``ip_suppress_v6.txt`` were updated to match (see their in-file comments).
-V4_BARE_HOSTS = ("9.9.9.9", "8.8.8.8")
+# instead; ``ip_suppress_v4.txt`` / ``ip_suppress_v6.txt`` were updated to match (see
+# their in-file comments). The v4 side was migrated a SECOND time off
+# ``1.1.0.0/16``/``1.1.1.1``/``8.8.8.8``/``9.9.9.9`` -- 1.1.1.1/1.0.0.1 is the smoke
+# image's baked DNS-forwarder default (``helpers.py``'s ``set_unbound_forwarding``), a
+# self-inflicted landmine for a module that sets real Deny_Both rules against that
+# space -- to boring RIPE-block addresses with no harness meaning and no well-known-
+# resolver overlap.
+V4_BARE_HOSTS = ("83.246.7.7", "82.165.5.5")
 V6_BARE_HOSTS = ("2606:4700:99::10", "2606:4700:aa::20")
 
 
@@ -97,7 +102,7 @@ def deployed_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
 def _set_suppression(vm: SmokeVM, *, v4: list[str] | None = None, v6: list[str] | None = None) -> None:
     """Enable the master "Enable Suppression" toggle and set BOTH customlists.
 
-    ``v4``/``v6`` are raw textarea lines (e.g. ``"1.1.3.4/32"``) -- every
+    ``v4``/``v6`` are raw textarea lines (e.g. ``"81.169.3.4/32"``) -- every
     suppression line MUST carry an explicit mask: ``pfb_validate_suppression_line``
     rejects a bare host (``is_subnetv4()``/``is_subnetv6()`` both require
     ``/bits``). ``None``/empty clears that family's list. Same base64/CRLF
@@ -209,7 +214,7 @@ def test_suppression_v4_carves_containing_range_spares_sibling(deployed_vm: Smok
     live-loaded /16 down to covering CIDRs -- ADR-53 §4.1's headline acceptance
     requirement, proven via the update-time path.
 
-    Given: the v4 fixture feed (``1.1.0.0/16`` + two bare hosts) is loaded
+    Given: the v4 fixture feed (``81.169.0.0/16`` + two bare hosts) is loaded
     as a Deny list; suppression is enabled but empty; a settling update runs.
 
     When: v4suppression is set to the target host's exact /32 and a second
@@ -229,8 +234,8 @@ def test_suppression_v4_carves_containing_range_spares_sibling(deployed_vm: Smok
     # ("10.0.3.4" inside "10.0.0.0/16" -> 16 covering CIDRs incl. ".0.0/23" and
     # ".128.0/17") -- the covering-CIDR count/shape is invariant to the network
     # prefix, so this grounds the assertions below in an already-proven result.
-    target = "1.1.3.4"
-    sibling = "9.9.9.9"
+    target = "81.169.3.4"
+    sibling = "83.246.7.7"
     host_entry = f"{target}/32"
 
     h.inject(deployed_vm, spec)
@@ -267,8 +272,8 @@ def test_suppression_v4_carves_containing_range_spares_sibling(deployed_vm: Smok
         "expected 16 covering-CIDR entries for a /16 minus a /32 (ADR-53 §1.2's "
         f"measured bound); got {len(carved)}: {carved}\nfull member file ({len(lines)} lines): {lines}"
     )
-    assert "1.1.0.0/23" in carved and "1.1.128.0/17" in carved, (
-        "expected representative covering CIDRs '1.1.0.0/23' and '1.1.128.0/17' "
+    assert "81.169.0.0/23" in carved and "81.169.128.0/17" in carved, (
+        "expected representative covering CIDRs '81.169.0.0/23' and '81.169.128.0/17' "
         f"(the same relative shape as the real-iprange-verified 10.0.0.0/16-10.0.3.4 vector); got {carved}"
     )
 
@@ -369,9 +374,9 @@ def test_suppression_v4_bare_host_removed(deployed_vm: SmokeVM) -> None:
     feed_body = (FIXTURES_DIR / "ip_suppress_v4.txt").read_text()
     feed_url = h.write_local_feed(deployed_vm, "smoke_adr53_v4c1.txt", feed_body)
     spec = h.IpCase(aliasname="adr53v4c1", feed_url=feed_url, header="adr53v4c1")
-    inside_16 = "1.1.3.4"
-    removed_host = "8.8.8.8"
-    kept_host = "9.9.9.9"
+    inside_16 = "81.169.3.4"
+    removed_host = "82.165.5.5"
+    kept_host = "83.246.7.7"
     host_entry = f"{removed_host}/32"
 
     h.inject(deployed_vm, spec)
@@ -398,7 +403,7 @@ def test_suppression_v4_bare_host_removed(deployed_vm: SmokeVM) -> None:
 
     lines = _member_lines(deployed_vm, f"{spec.header}_v4")
     assert len(lines) == 2, f"expected exactly 2 member-file lines (untouched /16 + surviving bare host); got {lines}"
-    assert "1.1.0.0/16" in lines, f"expected the untouched /16 line verbatim (never carved); got {lines}"
+    assert "81.169.0.0/16" in lines, f"expected the untouched /16 line verbatim (never carved); got {lines}"
     assert _has_entry(lines, kept_host), f"expected the surviving bare host {kept_host}; got {lines}"
     assert not _has_entry(lines, removed_host), f"expected {removed_host} removed; got {lines}"
 
@@ -422,9 +427,9 @@ def test_suppression_v4_subnet_mask_carves_at_granularity(deployed_vm: SmokeVM) 
     feed_body = (FIXTURES_DIR / "ip_suppress_v4.txt").read_text()
     feed_url = h.write_local_feed(deployed_vm, "smoke_adr53_v4c2.txt", feed_body)
     spec = h.IpCase(aliasname="adr53v4c2", feed_url=feed_url, header="adr53v4c2")
-    hole_ip = "1.1.5.9"
-    sibling_ip = "1.1.9.9"
-    hole_subnet = "1.1.5.0/24"
+    hole_ip = "81.169.5.9"
+    sibling_ip = "81.169.9.9"
+    hole_subnet = "81.169.5.0/24"
 
     h.inject(deployed_vm, spec)
     h.reload(deployed_vm, "updateip", wait_unbound=False)
@@ -486,12 +491,12 @@ def test_suppression_drops_reserved_classes_keeps_public(deployed_vm: SmokeVM) -
 
     # Trivial inline v4 companion (not a committed fixture -- mirrors Scenario B's
     # companion alias): pins the v4 side of the same drop (issue #760 §1) cheaply.
-    v4_url = h.write_local_feed(deployed_vm, "smoke_issue760_reserved_v4.txt", "1.1.1.1\n100.64.0.1\n")
+    v4_url = h.write_local_feed(deployed_vm, "smoke_issue760_reserved_v4.txt", "82.165.5.5\n100.64.0.1\n")
     v4spec = h.IpCase(aliasname="issue760resv4", feed_url=v4_url, header="issue760resv4")
 
     public_v6 = "2606:4700:7777::1111"
     dropped_v6 = ("2001:db8::1", "ff02::1", "64:ff9b::1")
-    public_v4 = "1.1.1.1"
+    public_v4 = "82.165.5.5"
     dropped_v4 = "100.64.0.1"
 
     h.inject_ip_lists(deployed_vm, [v4spec, v6spec])

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -53,6 +53,7 @@ CATEGORY_PAGE = "/pfblockerng/pfblockerng_category_edit.php"
 # config roots the save handler writes (mirrors $conf_type in the PHP).
 CFG_DNSBL = "installedpackages/pfblockerngdnsbl/config"
 CFG_IPV4 = "installedpackages/pfblockernglistsv4/config"
+CFG_IPV6 = "installedpackages/pfblockernglistsv6/config"
 
 # Generous POST timeout: the save only write_config()s (no reload / no egress),
 # but pfSsh.php-backed config reads around it can run long on a busy box.
@@ -710,6 +711,123 @@ def test_ipv4_invert_toggles_persist_with_alias_native(
 
     finally:
         _del_rowid(vm, CFG_IPV4, rowid)
+
+
+# --------------------------------------------------------------------------- #
+# IPv6 alias: the issue-#760 §3 "Suppression CIDR Limit" select persists and
+# reloads, and is genuinely gtype-gated (v6-only, never rendered on the v4 page;
+# the v4-only sibling field never rendered on the v6 page).
+# --------------------------------------------------------------------------- #
+
+
+def _ipv6_payload(rowid: int, aliasname: str, **overrides: str) -> dict[str, str]:
+    """A complete IPv6 alias save payload (one Disabled placeholder row).
+
+    Mirrors ``_ipv4_payload``: IPv6 shares the same Advanced In/Out fields (the
+    save handler's ``if ($gtype == 'ipv4' || $gtype == 'ipv6')`` block writes
+    both ``suppression_cidr`` -- unconditionally, the v4-only field -- and the
+    new issue-#760 §3 ``suppression_cidr_v6`` -- gated ``if ($gtype ==
+    'ipv6')``). Both are supplied here, same "every field the handler reads
+    gets a value" convention as ``_ipv4_payload``'s own placeholder-row fields.
+    """
+    payload = {
+        "type": "ipv6",
+        "rowid": str(rowid),
+        "aliasname": aliasname,
+        "description": "smoke ipv6 category-edit",
+        "action": "Deny_Both",
+        "cron": "Never",
+        "dow": "",
+        "sort": "sort",
+        "aliaslog": "enabled",
+        "stateremoval": "enabled",
+        "autoproto_in": "any",
+        "agateway_in": "default",
+        "autoproto_out": "any",
+        "agateway_out": "default",
+        "suppression_cidr": "Disabled",
+        "suppression_cidr_v6": "Disabled",
+        "srcint": "",
+        "script_pre": "",
+        "script_post": "",
+        "custom": "",
+        "format-0": "auto",
+        "state-0": "Disabled",
+        "url-0": "",
+        "header-0": "",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_ipv6_suppression_cidr_select_persists_and_reloads(
+    webui: "WebUI",
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """The issue-#760 §3 IPv6 Suppression CIDR Limit select round-trips.
+
+    Scenario: saving an IPv6 alias with ``suppression_cidr_v6`` at its
+    documented default persists it, flipping to a numeric floor persists AND
+    reloads selected, and restoring to the default round-trips back. The field
+    is v6-only (gtype-gated in render/validation/save), so the reloaded v6 page
+    must never render the v4-only ``suppression_cidr`` select, and the v4 page
+    must never render this new v6-only select.
+
+    Given:
+        The target IPv6 rowid is free (``suppression_cidr_v6`` reads '').
+    When:
+        A valid Deny_Both alias is saved with ``suppression_cidr_v6='Disabled'``
+        (the documented default, asserted first), then re-saved with
+        ``suppression_cidr_v6='32'`` (a real transition), then restored to
+        ``'Disabled'`` (the reverse transition).
+    Then:
+        - config.xml holds each value in turn -- each POST CAUSED the change.
+        - The reloaded v6 edit page renders '32' as the selected option.
+        - The v6 page never renders a 'suppression_cidr' <select> (v4-only);
+          the v4 page never renders a 'suppression_cidr_v6' <select> (v6-only)
+          -- the gating is real, not accidental.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_IPV6)
+    cfg = f"{CFG_IPV6}/{rowid}/suppression_cidr_v6"
+    try:
+        # BEFORE: free slot, no value stored (the save must CAUSE it).
+        assert helpers.config_get(vm, cfg) == "", f"ipv6 rowid {rowid} not free (suppression_cidr_v6 already set)"
+
+        # Create the alias at the documented default.
+        _post_form(webui, _ipv6_payload(rowid, "smokeip6cidr", suppression_cidr_v6="Disabled"))
+        assert helpers.config_get(vm, cfg) == "Disabled", "suppression_cidr_v6 not stored as 'Disabled'"
+
+        # WHEN: a real transition to a numeric floor.
+        _post_form(webui, _ipv6_payload(rowid, "smokeip6cidr", suppression_cidr_v6="32"))
+        assert helpers.config_get(vm, cfg) == "32", "suppression_cidr_v6 not persisted as '32'"
+
+        # THEN: the reloaded v6 edit page renders '32' selected, and the field
+        # is genuinely gtype-gated both ways.
+        reload_resp = webui.get(CATEGORY_PAGE, params={"type": "ipv6", "rowid": str(rowid)})
+        assert not looks_like_login_page(reload_resp.text), (
+            "category GET (reload) returned the login form (session lost)"
+        )
+        body = reload_resp.text
+        assert 'name="suppression_cidr_v6"' in body, "reloaded v6 form has no suppression_cidr_v6 select"
+        assert _option_selected(body, "32"), (
+            "reloaded v6 form did not render suppression_cidr_v6 option '32' as selected"
+        )
+        assert 'name="suppression_cidr"' not in body, (
+            "v6 edit page must not render the v4-only 'suppression_cidr' select"
+        )
+
+        v4_resp = webui.get(CATEGORY_PAGE, params={"type": "ipv4"})
+        assert not looks_like_login_page(v4_resp.text), "v4 category GET returned the login form (session lost)"
+        assert 'name="suppression_cidr_v6"' not in v4_resp.text, (
+            "v4 edit page must not render the v6-only 'suppression_cidr_v6' select"
+        )
+
+        # Restore to the default (the reverse transition).
+        _post_form(webui, _ipv6_payload(rowid, "smokeip6cidr", suppression_cidr_v6="Disabled"))
+        assert helpers.config_get(vm, cfg) == "Disabled", "suppression_cidr_v6 not restored to 'Disabled'"
+    finally:
+        _del_rowid(vm, CFG_IPV6, rowid)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -782,10 +782,15 @@ def test_ipv6_suppression_cidr_select_persists_and_reloads(
         ``'Disabled'`` (the reverse transition).
     Then:
         - config.xml holds each value in turn -- each POST CAUSED the change.
-        - The reloaded v6 edit page renders '32' as the selected option.
+        - The reloaded v6 edit page renders '32' as the selected option, with no
+          PHP error in the body.
         - The v6 page never renders a 'suppression_cidr' <select> (v4-only);
-          the v4 page never renders a 'suppression_cidr_v6' <select> (v6-only)
-          -- the gating is real, not accidental.
+          the v4 page (re-opened on an EXISTING row, so the shared GET-render
+          block actually reads that row's absent 'suppression_cidr_v6' key)
+          never renders a 'suppression_cidr_v6' <select> (v6-only) and stays
+          free of PHP errors -- pins the review fix for the undefined-array-key
+          Warning that an unguarded read of a v6-only key would raise on a v4
+          row (`?? 'Disabled'` in the GET-render block).
     """
     vm = smoke_vm
     rowid = _free_rowid(vm, CFG_IPV6)
@@ -809,6 +814,8 @@ def test_ipv6_suppression_cidr_select_persists_and_reloads(
             "category GET (reload) returned the login form (session lost)"
         )
         body = reload_resp.text
+        for bad in ("Fatal error", "Parse error", "Warning", "Notice", "Uncaught"):
+            assert bad not in body, f"reloaded v6 edit page contains PHP error: {bad!r}"
         assert 'name="suppression_cidr_v6"' in body, "reloaded v6 form has no suppression_cidr_v6 select"
         assert _option_selected(body, "32"), (
             "reloaded v6 form did not render suppression_cidr_v6 option '32' as selected"
@@ -817,11 +824,24 @@ def test_ipv6_suppression_cidr_select_persists_and_reloads(
             "v6 edit page must not render the v4-only 'suppression_cidr' select"
         )
 
-        v4_resp = webui.get(CATEGORY_PAGE, params={"type": "ipv4"})
-        assert not looks_like_login_page(v4_resp.text), "v4 category GET returned the login form (session lost)"
-        assert 'name="suppression_cidr_v6"' not in v4_resp.text, (
-            "v4 edit page must not render the v6-only 'suppression_cidr_v6' select"
-        )
+        # v4-page symmetry: re-open an EXISTING v4 row (not a blank/new-row
+        # form) so the shared GET-render block actually reads that row's
+        # 'suppression_cidr_v6' key -- absent on every v4 row, since the save
+        # handler only ever writes it for gtype=='ipv6'. Pre-fix, this read
+        # was unconditional (no `?? 'Disabled'`), so PHP emits an undefined-
+        # array-key Warning on every existing-row v4 edit.
+        v4_rowid = _free_rowid(vm, CFG_IPV4)
+        try:
+            _post_form(webui, _ipv4_payload(v4_rowid, "smokeip4sym", action="Deny_Both"))
+            v4_resp = webui.get(CATEGORY_PAGE, params={"type": "ipv4", "rowid": str(v4_rowid)})
+            assert not looks_like_login_page(v4_resp.text), "v4 category GET returned the login form (session lost)"
+            for bad in ("Fatal error", "Parse error", "Warning", "Notice", "Uncaught"):
+                assert bad not in v4_resp.text, f"existing-row v4 edit page contains PHP error: {bad!r}"
+            assert 'name="suppression_cidr_v6"' not in v4_resp.text, (
+                "v4 edit page must not render the v6-only 'suppression_cidr_v6' select"
+            )
+        finally:
+            _del_rowid(vm, CFG_IPV4, v4_rowid)
 
         # Restore to the default (the reverse transition).
         _post_form(webui, _ipv6_payload(rowid, "smokeip6cidr", suppression_cidr_v6="Disabled"))

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -155,6 +155,10 @@ PAGE_TABLE: tuple[Page, ...] = (
     # category_edit.php: default IP view AND the DNSBL view; Form_Section('Advanced Tuneables') is unique to it.
     Page("category_edit_ip", "/pfblockerng/pfblockerng_category_edit.php?type=ipv4", ("Advanced Tuneables",)),
     Page("category_edit_dnsbl", "/pfblockerng/pfblockerng_category_edit.php?type=dnsbl", ("Advanced Tuneables",)),
+    # ?type=ipv6 renders the issue-#760 §3 "Suppression CIDR Limit" select block (gated
+    # `if ($gtype == 'ipv6')`, a code path the ipv4/dnsbl entries above never exercise) --
+    # this entry guards it against a PHP render regression.
+    Page("category_edit_ipv6", "/pfblockerng/pfblockerng_category_edit.php?type=ipv6", ("Advanced Tuneables",)),
     # threats.php REQUIRES a host/domain/port param -- with none it print_info_box()es and exit()s
     # before rendering $pgtitle. A syntactically-valid param renders the lookup page chrome; the
     # threat links it draws are <a href> only (no server-side network call), so it stays hermetic.


### PR DESCRIPTION
Fixes #760

Closes the two actionable gaps left open after ADR-53 (§2) and PR #775 (test comment), per the maintainer's scope/policy decision on the issue.

## §1 — explicit reserved-class drops (both families)

`sanitize_ipaddr()` / `sanitize_ipaddr_v6()` delegated the reserved-space exclusion entirely to PHP's `FILTER_FLAG_NO_PRIV_RANGE|NO_RES_RANGE`, which keep documentation, multicast, NAT64/CGN, benchmarking and 6to4-relay space (and whose membership is PHP-patch-dependent — the RFC 6890 refactor in PHP 8.3.16/8.4.3 moved `2001:db8::/32` between sets). Under Suppression, downloaded feeds (custom lists keep their bypass) now also drop, via explicit integer/binary prefix checks:

| Family | Classes dropped |
| ------ | --------------- |
| IPv4 | documentation `192.0.2.0/24` + `198.51.100.0/24` + `203.0.113.0/24`, multicast `224.0.0.0/4`, CGN `100.64.0.0/10` (RFC 6598), benchmarking `198.18.0.0/15` (RFC 2544), 6to4 relay `192.88.99.0/24` |
| IPv6 | documentation `2001:db8::/32` (RFC 3849), multicast `ff00::/8`, NAT64 `64:ff9b::/96` (RFC 6052) |

The `SanitizeIpaddrV6Test` pins added by PR #775 for exactly this decision are flipped from keeps to drops (red→green verified both ways).

## §3 — IPv6 Suppression CIDR floor

New per-category Advanced tunable `suppression_cidr_v6` (Disabled | 1–64, default Disabled), the v6 sibling of `suppression_cidr`: with Suppression on, a downloaded feed's CIDR wider than the floor is clamped to its bare host (loads as /128) and logged, mirroring the v4 clamp-to-/32. Wired through `sanitize_ipaddr_v6()` (new optional `$pfbcidr` param) at all three v6 feed call sites; category-edit UI gains the select gated to `?type=ipv6` in render/validation/save.

## §4 — documented as a known limitation

The exclusion judges the address part of a CIDR only (a wide public-based range whose span covers reserved space passes). This matches the v4 side, is contrived in practice, and is now noted in both functions' comments; no span-intersection check is added.

## Tests

- **PHPUnit**: per-class drop tests both families + suppression-off / custom-list branch coverage; floor clamp/at-floor/Disabled/off/custom/transition/interplay cases. Red→green proven for every behaviour change (9 failures on pre-§1 code, 2 on pre-§3 code).
- **UI Tier A**: `pfblockerng_category_edit.php?type=ipv6` added to the render sweep (the `$gtype=='ipv6'` render branch was previously unswept).
- **UI Tier B**: `test_ipv6_suppression_cidr_select_persists_and_reloads` — default → set → save → reload → persisted, plus gtype-gating symmetry pins.
- **Live-VM smoke**: two new cases in the suppression module — reserved-class entries never reach the pf table (public entry loads, dropped classes absent) and the v6 floor clamps a `/48` to its bare host across a force update (transition-style, before-state asserted).

## Deliberate side effect — suppression smoke fixture migration

Every test in `test_smoke_suppression.py` runs with the global Suppression checkbox ON, and §1 drops documentation/benchmarking space unconditionally under that toggle — so the module's existing RFC 5737/3849/2544 fixtures would have been silently emptied before reaching the pf table, failing their before-state assertions on the next live run. The fixtures and hardcoded literals were migrated to public, non-reserved space (same shapes, prefix math and covering-CIDR counts unchanged; `tests/smoke/fixtures/README.md` records the exception). This is required by the behaviour change, not scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVWLiFeaGYpg178rFMeo7P
