### PR TITLE
pfblockerng: resolve nested alias references in pfb_collect_localip

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10520,7 +10520,9 @@ function pfb_collect_localip() {
 	// array_flip()ed below (#782). Split each matched alias's address and
 	// classify every member individually: a plain IP becomes its own entry (so
 	// it gets its own flipped key), a CIDR goes to $pfb_localsub (matched via
-	// pfb_local_ip()), and anything else (hostname, port, nested alias name) is
+	// pfb_local_ip()), a member that is itself an alias NAME expands in place
+	// (pfSense nested aliases, #784 -- breadth-first, depth-capped so a
+	// reference cycle terminates), and anything else (hostname, port) is
 	// dropped silently.
 	$pfb_alias_addrs = array();
 	foreach (config_get_path('aliases/alias', []) as $alias) {
@@ -10538,15 +10540,26 @@ function pfb_collect_localip() {
 				continue;
 			}
 			unset($pfb_local[$cnt]);
-			foreach (preg_split('/\s+/', trim($pfb_alias_addrs[$entry])) as $member) {
-				if ($member === '') {
-					continue;
+			$members = preg_split('/\s+/', trim($pfb_alias_addrs[$entry]));
+			// Depth 10 >> the pfSense GUI's practical nesting; a cycle just
+			// re-expands until the cap and dedups in the final array_flip().
+			for ($depth = 0; !empty($members) && $depth < 10; $depth++) {
+				$nested = array();
+				foreach ($members as $member) {
+					if ($member === '') {
+						continue;
+					}
+					if (is_ipaddr($member)) {
+						$pfb_local[] = $member;
+					} elseif (is_subnet($member)) {
+						$pfb_localsub[] = $member;
+					} elseif (array_key_exists($member, $pfb_alias_addrs)) {
+						$nested = array_merge(
+							$nested, preg_split('/\s+/', trim($pfb_alias_addrs[$member]))
+						);
+					}
 				}
-				if (is_ipaddr($member)) {
-					$pfb_local[] = $member;
-				} elseif (is_subnet($member)) {
-					$pfb_localsub[] = $member;
-				}
+				$members = $nested;
 			}
 		}
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10521,9 +10521,10 @@ function pfb_collect_localip() {
 	// classify every member individually: a plain IP becomes its own entry (so
 	// it gets its own flipped key), a CIDR goes to $pfb_localsub (matched via
 	// pfb_local_ip()), a member that is itself an alias NAME expands in place
-	// (pfSense nested aliases, #784 -- breadth-first, depth-capped so a
-	// reference cycle terminates), and anything else (hostname, port) is
-	// dropped silently.
+	// (pfSense nested aliases, #784 -- visited-set walk: each distinct alias
+	// expands at most once, so cycles/self-references terminate and a wide
+	// alias-of-aliases tree costs work linear in config size), and anything
+	// else (hostname, port) is dropped silently.
 	$pfb_alias_addrs = array();
 	foreach (config_get_path('aliases/alias', []) as $alias) {
 		if (is_array($alias) && isset($alias['name'])) {
@@ -10540,26 +10541,23 @@ function pfb_collect_localip() {
 				continue;
 			}
 			unset($pfb_local[$cnt]);
+			$pfb_alias_seen = array($entry => TRUE);
 			$members = preg_split('/\s+/', trim($pfb_alias_addrs[$entry]));
-			// Depth 10 >> the pfSense GUI's practical nesting; a cycle just
-			// re-expands until the cap and dedups in the final array_flip().
-			for ($depth = 0; !empty($members) && $depth < 10; $depth++) {
-				$nested = array();
-				foreach ($members as $member) {
-					if ($member === '') {
-						continue;
-					}
-					if (is_ipaddr($member)) {
-						$pfb_local[] = $member;
-					} elseif (is_subnet($member)) {
-						$pfb_localsub[] = $member;
-					} elseif (array_key_exists($member, $pfb_alias_addrs)) {
-						$nested = array_merge(
-							$nested, preg_split('/\s+/', trim($pfb_alias_addrs[$member]))
-						);
+			while (!empty($members)) {
+				$member = array_shift($members);
+				if ($member === '') {
+					continue;
+				}
+				if (is_ipaddr($member)) {
+					$pfb_local[] = $member;
+				} elseif (is_subnet($member)) {
+					$pfb_localsub[] = $member;
+				} elseif (array_key_exists($member, $pfb_alias_addrs) && !isset($pfb_alias_seen[$member])) {
+					$pfb_alias_seen[$member] = TRUE;
+					foreach (preg_split('/\s+/', trim($pfb_alias_addrs[$member])) as $sub_member) {
+						$members[] = $sub_member;
 					}
 				}
-				$members = $nested;
 			}
 		}
 	}

--- a/tests/php/CollectLocalIpAliasTest.php
+++ b/tests/php/CollectLocalIpAliasTest.php
@@ -80,9 +80,16 @@ use PHPUnit\Framework\TestCase;
  *     J: referencing alias listed BEFORE the referenced one — order must not
  *        matter (the pre-#782 code resolved one level only in this ordering,
  *        by accident)
- *     K: a two-alias reference CYCLE terminates (depth cap) and still yields
+ *     K: a two-alias reference CYCLE terminates (visited set) and still yields
  *        both aliases' IP members
  *     L: a three-level chain resolves through every level
+ *
+ *   Cases M–N (visited-set walk, #786 adversarial review):
+ *     M: a chain DEEPER than the interim implementation's depth cap of 10
+ *        resolves fully — the visited set makes any cap unnecessary, so depth
+ *        is unbounded for legitimate chains (fails on the depth-capped code)
+ *     N: an alias that references ITSELF terminates immediately and still
+ *        yields its literal IP members
  */
 #[CoversFunction('pfb_collect_localip')]
 #[CoversFunction('pfb_local_ip')]
@@ -573,6 +580,79 @@ final class CollectLocalIpAliasTest extends TestCase
 			sprintf(
 				"Chain_L1 -> Chain_L2 -> Chain_L3 must resolve to the leaf IP.\n"
 				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case M — chain deeper than any depth cap resolves fully (#786 review:
+	// fails on the interim depth-capped implementation)
+	// -------------------------------------------------------------------------
+
+	public function testNestedAliasChainDeeperThanTenLevelsResolves(): void
+	{
+		// Given: a 12-level alias chain Deep_L1 -> ... -> Deep_L12 -> leaf IP.
+		// The visited-set walk expands each distinct alias exactly once, so
+		// legitimate depth is unbounded (a depth-capped walk truncated at 10
+		// and silently lost the leaf).
+		$chain = [];
+		for ($i = 1; $i < 12; $i++) {
+			$chain[] = ['name' => "Deep_L{$i}", 'address' => 'Deep_L' . ($i + 1)];
+		}
+		$chain[] = ['name' => 'Deep_L12', 'address' => '203.0.113.96'];
+		$GLOBALS['config']['aliases']['alias'] = array_merge(
+			$GLOBALS['config']['aliases']['alias'], $chain
+		);
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => 'Deep_L1'],
+		];
+
+		[$pfb_local, ] = pfb_collect_localip();
+
+		$this->assertArrayHasKey(
+			'203.0.113.96',
+			$pfb_local,
+			sprintf(
+				"A 12-level alias chain must resolve to the leaf IP — legitimate depth "
+				. "is unbounded under the visited-set walk.\npfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case N — direct self-reference terminates and keeps literal members (#786)
+	// -------------------------------------------------------------------------
+
+	public function testSelfReferencingAliasTerminatesAndKeepsLiteralMembers(): void
+	{
+		// Given: an alias whose address references its own name alongside a
+		// literal IP. The visited set (seeded with the outer entry) skips the
+		// self-edge immediately; reaching the assertions proves termination.
+		$GLOBALS['config']['aliases']['alias'][] = [
+			'name' => 'Self_Ref', 'address' => 'Self_Ref 203.0.113.97',
+		];
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => 'Self_Ref'],
+		];
+
+		[$pfb_local, ] = pfb_collect_localip();
+
+		$this->assertArrayHasKey(
+			'203.0.113.97',
+			$pfb_local,
+			sprintf(
+				"The self-referencing alias's literal IP member must still be collected.\n"
+				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$this->assertArrayNotHasKey(
+			'Self_Ref',
+			$pfb_local,
+			sprintf(
+				"The alias NAME must never survive as a \$pfb_local key.\npfb_local keys: %s",
 				implode(', ', array_keys($pfb_local))
 			)
 		);

--- a/tests/php/CollectLocalIpAliasTest.php
+++ b/tests/php/CollectLocalIpAliasTest.php
@@ -71,6 +71,18 @@ use PHPUnit\Framework\TestCase;
  *           array_flip() warning
  *     Then  pfb_collect_localip() completes without a TypeError and the other
  *           collected entries are unaffected
+ *
+ *   Cases I–L (nested alias references resolve transitively, issue #784 —
+ *              I/J/K/L MUST fail before the transitive expansion, pass after):
+ *     I: referenced alias listed BEFORE the referencing one (pfSense's typical
+ *        config.xml order) — members behind the nested name are collected,
+ *        including a CIDR member routed to $pfb_localsub
+ *     J: referencing alias listed BEFORE the referenced one — order must not
+ *        matter (the pre-#782 code resolved one level only in this ordering,
+ *        by accident)
+ *     K: a two-alias reference CYCLE terminates (depth cap) and still yields
+ *        both aliases' IP members
+ *     L: a three-level chain resolves through every level
  */
 #[CoversFunction('pfb_collect_localip')]
 #[CoversFunction('pfb_local_ip')]
@@ -99,6 +111,20 @@ final class CollectLocalIpAliasTest extends TestCase
 					['name' => 'Single_Host',  'address' => '203.0.113.99'],
 					['name' => 'V6_Hosts',     'address' => '2001:db8::1 2001:db8:1::/64'],
 					['name' => 'Empty_Alias',  'address' => '   '],
+					// #784 nested-alias fixtures. Referenced-first order (pfSense's
+					// typical config.xml layout):
+					['name' => 'Inner_Hosts',  'address' => '203.0.113.60 198.51.100.32/28'],
+					['name' => 'Outer_Ref',    'address' => 'Inner_Hosts 203.0.113.70'],
+					// Referencing-first order:
+					['name' => 'Outer_First',  'address' => 'Inner_Last'],
+					['name' => 'Inner_Last',   'address' => '203.0.113.80'],
+					// Reference cycle:
+					['name' => 'Cycle_A',      'address' => 'Cycle_B 203.0.113.90'],
+					['name' => 'Cycle_B',      'address' => 'Cycle_A 203.0.113.91'],
+					// Three-level chain:
+					['name' => 'Chain_L1',     'address' => 'Chain_L2'],
+					['name' => 'Chain_L2',     'address' => 'Chain_L3'],
+					['name' => 'Chain_L3',     'address' => '203.0.113.95'],
 				],
 			],
 		];
@@ -396,6 +422,157 @@ final class CollectLocalIpAliasTest extends TestCase
 			sprintf(
 				"An array-typed NAT target must be skipped (pre-#782 tolerance), leaving "
 				. "the well-formed alias target resolved.\npfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case I — nested alias, referenced-first ordering (#784: fails before fix)
+	// -------------------------------------------------------------------------
+
+	public function testNestedAliasReferencedFirstResolvesMembersAndCidr(): void
+	{
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => 'Outer_Ref'],
+		];
+
+		[$pfb_local, $pfb_localsub] = pfb_collect_localip();
+
+		$this->assertArrayHasKey(
+			'203.0.113.60',
+			$pfb_local,
+			sprintf(
+				"IP member behind nested alias 'Inner_Hosts' must be collected as local.\n"
+				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$host = '198.51.100.35';
+		$this->assertTrue(
+			pfb_local_ip($host, $pfb_localsub),
+			sprintf(
+				"Host %s inside nested alias CIDR member 198.51.100.32/28 must be recognised "
+				. "via pfb_localsub.\npfb_localsub: %s",
+				$host,
+				implode(', ', $pfb_localsub)
+			)
+		);
+		$this->assertArrayHasKey(
+			'203.0.113.70',
+			$pfb_local,
+			sprintf(
+				"The referencing alias's own direct IP member must still be collected.\n"
+				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$this->assertArrayNotHasKey(
+			'Inner_Hosts',
+			$pfb_local,
+			sprintf(
+				"The nested alias NAME must be consumed by expansion, never left as a key.\n"
+				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case J — nested alias, referencing-first ordering (#784: fails before fix)
+	// -------------------------------------------------------------------------
+
+	public function testNestedAliasReferencingFirstResolvesRegardlessOfOrder(): void
+	{
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => 'Outer_First'],
+		];
+
+		[$pfb_local, ] = pfb_collect_localip();
+
+		$this->assertArrayHasKey(
+			'203.0.113.80',
+			$pfb_local,
+			sprintf(
+				"Nested resolution must not depend on aliases/alias ordering: 'Outer_First' "
+				. "is stored before the 'Inner_Last' it references.\npfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$this->assertArrayNotHasKey(
+			'Inner_Last',
+			$pfb_local,
+			sprintf(
+				"The nested alias NAME must be consumed by expansion, never left as a key.\n"
+				. "pfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Case K — reference cycle terminates, both members collected (#784)
+	// -------------------------------------------------------------------------
+
+	public function testNestedAliasCycleTerminatesAndCollectsBothMembers(): void
+	{
+		// Given: Cycle_A references Cycle_B and vice versa. The depth cap must
+		// terminate the expansion (reaching the assertions proves it) while both
+		// aliases' IP members are still collected.
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => 'Cycle_A'],
+		];
+
+		[$pfb_local, ] = pfb_collect_localip();
+
+		$this->assertArrayHasKey(
+			'203.0.113.90',
+			$pfb_local,
+			sprintf(
+				"Cycle_A's direct IP member must be collected.\npfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		$this->assertArrayHasKey(
+			'203.0.113.91',
+			$pfb_local,
+			sprintf(
+				"Cycle_B's IP member (reachable only through the cycle edge) must be "
+				. "collected.\npfb_local keys: %s",
+				implode(', ', array_keys($pfb_local))
+			)
+		);
+		foreach (['Cycle_A', 'Cycle_B'] as $name) {
+			$this->assertArrayNotHasKey(
+				$name,
+				$pfb_local,
+				sprintf(
+					"Alias NAME '%s' must never survive as a \$pfb_local key.\npfb_local keys: %s",
+					$name,
+					implode(', ', array_keys($pfb_local))
+				)
+			);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Case L — three-level chain resolves through every level (#784)
+	// -------------------------------------------------------------------------
+
+	public function testNestedAliasThreeLevelChainResolves(): void
+	{
+		$GLOBALS['config']['nat']['rule'] = [
+			['target' => 'Chain_L1'],
+		];
+
+		[$pfb_local, ] = pfb_collect_localip();
+
+		$this->assertArrayHasKey(
+			'203.0.113.95',
+			$pfb_local,
+			sprintf(
+				"Chain_L1 -> Chain_L2 -> Chain_L3 must resolve to the leaf IP.\n"
+				. "pfb_local keys: %s",
 				implode(', ', array_keys($pfb_local))
 			)
 		);


### PR DESCRIPTION
## What

Follow-up to #783 (issue #782): in the alias-conversion block of `pfb_collect_localip()`, a member of a matched alias that is itself an **alias name** (pfSense nested aliases) fell into the dropped bucket, so hosts behind a nested reference were never collected as local — and the kill-states / Reports local-host exclusions never spared them.

## Changes

- Expand alias-name members **breadth-first** against the prebuilt name→address map (`$pfb_alias_addrs`), so resolution is independent of `aliases/alias` ordering.
- **Depth cap 10** guards reference cycles: a cycle just re-expands until the cap and the final `array_flip()` dedups repeated members. Well above the GUI's practical nesting depth.
- Classification per member is unchanged (IP → `$pfb_local`, CIDR → `$pfb_localsub`, other junk dropped).

## Tests

Four new cases in `CollectLocalIpAliasTest` (red→green verified against pre-fix source — all four **failed before**, pass after):

- Case I — referenced-first ordering (pfSense's typical config.xml layout), including a CIDR member behind the nested name.
- Case J — referencing-first ordering (order must not matter; the pre-#782 code only ever resolved one level by accident in this ordering).
- Case K — a two-alias reference cycle terminates and still collects both aliases' IP members.
- Case L — a three-level chain resolves through every level.

Gates: `php -l`, PHPUnit (1982 tests OK), PHPStan (`--memory-limit=2G`), PHPCS all clean.

Fixes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG