### PR TITLE
www: move DNSBL Group Policy panel above the DNS Redirect section

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -2795,9 +2795,9 @@ $section->addInput(new Form_Checkbox(
 
 $form->add($section);
 
-// DNSBL Group Policy section — placed directly below DNSBL Configuration (which holds
-// its enable checkbox) and above the encrypted-DNS sections. The pfb_gp checkbox JS
-// toggles this section's visibility by its 'Python_Group_Policy' id.
+// DNSBL Group Policy section — placed directly below the main 'DNSBL' section (which
+// holds its pfb_gp enable checkbox) and above the encrypted-DNS sections. The pfb_gp
+// checkbox JS toggles this section's visibility by its 'Python_Group_Policy' id.
 $section = new Form_Section('DNSBL Group Policy', 'Python_Group_Policy', COLLAPSIBLE|SEC_CLOSED);
 $section->addInput(new Form_StaticText(
 	NULL,

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -2795,6 +2795,29 @@ $section->addInput(new Form_Checkbox(
 
 $form->add($section);
 
+// DNSBL Group Policy section — placed directly below DNSBL Configuration (which holds
+// its enable checkbox) and above the encrypted-DNS sections. The pfb_gp checkbox JS
+// toggles this section's visibility by its 'Python_Group_Policy' id.
+$section = new Form_Section('DNSBL Group Policy', 'Python_Group_Policy', COLLAPSIBLE|SEC_CLOSED);
+$section->addInput(new Form_StaticText(
+	NULL,
+	'This is a preliminary DNSBL Group Policy configuration that will bypass DNSBL for the defined LAN IPs. (No Subnets allowed)'));
+
+$section->addInput(new Form_Textarea(
+	'pfb_gp_bypass_list',
+	'Bypass IPs',
+	$pconfig['pfb_gp_bypass_list']
+))->removeClass('form-control')
+  ->addClass('row-fluid col-sm-12')
+  ->setAttribute('columns', '90')
+  ->setAttribute('rows', '15')
+  ->setAttribute('wrap', 'off')
+  ->setAttribute('style', 'background:#fafafa; width: 100%')
+  ->setHelp('Enter the Local LAN IPs (one per line) that will bypass DNSBL Blocking.<br />'
+		. 'Changes to this option will require a Force Update to take effect.');
+
+$form->add($section);
+
 // [ ADR-36 ] DNS Redirect section — placed above the DoH/DoT/DoQ Blocking section.
 // Redirects outbound port-53 DNS traffic on the selected interfaces to the
 // firewall's own resolver. DoH/DoT bypass is NOT covered.
@@ -2960,26 +2983,6 @@ $section->addInput(new Form_Select(
 ))->setHelp('Select the DoH/DoT/DoQ providers to block.')
   ->setAttribute('style', 'width: auto')
   ->setAttribute('size', '20');
-
-$form->add($section);
-
-$section = new Form_Section('DNSBL Group Policy', 'Python_Group_Policy', COLLAPSIBLE|SEC_CLOSED);
-$section->addInput(new Form_StaticText(
-	NULL,
-	'This is a preliminary DNSBL Group Policy configuration that will bypass DNSBL for the defined LAN IPs. (No Subnets allowed)'));
-
-$section->addInput(new Form_Textarea(
-	'pfb_gp_bypass_list',
-	'Bypass IPs',
-	$pconfig['pfb_gp_bypass_list']
-))->removeClass('form-control')
-  ->addClass('row-fluid col-sm-12')
-  ->setAttribute('columns', '90')
-  ->setAttribute('rows', '15')
-  ->setAttribute('wrap', 'off')
-  ->setAttribute('style', 'background:#fafafa; width: 100%')
-  ->setHelp('Enter the Local LAN IPs (one per line) that will bypass DNSBL Blocking.<br />'
-		. 'Changes to this option will require a Force Update to take effect.');
 
 $form->add($section);
 

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -13,23 +13,20 @@ this file covers the OTHER inline handlers, each gating a separate collapsible
 section by ``.show()``/``.hide()`` on the section's OUTER panel div (whose id is
 the second ``Form_Section`` constructor arg). The JS under test is READ-ONLY
 reference (no ``src/`` change); the exact selectors/behaviours are taken from the
-page's inline script (line numbers are pfblockerng_dnsbl.php):
+page's inline script — referenced symbolically (handler / checkbox / section id)
+so the references cannot rot as pfblockerng_dnsbl.php grows (issue #788):
 
-* ``enable_python_regex()`` (3099-3105, bound to ``#pfb_regex`` click at
-  3151-3154 and run on load at 3154): when ``#pfb_regex`` is CHECKED it
-  ``.show()``s the ``Python_regex_list`` section (``Form_Section`` id at 2502),
-  UNCHECKED it ``.hide()``s it.
-* ``enable_python_noaaaa()`` (3107-3113, bound at 3156-3159): ``#pfb_noaaaa``
-  gates the ``Python_noaaaa_list`` section (id at 2524).
-* ``enable_python_gp()`` (3115-3121, bound at 3161-3164): ``#pfb_gp`` gates the
-  ``Python_Group_Policy`` section (id at 2474).
-* ``enable_tld()`` (3067-3075, bound at 3136-3139): ``#pfb_tld`` gates BOTH the
-  ``TLD_Exclusion`` (id at 2802) and ``TLD_BW_list`` (id at 2827) sections at
-  once.
-* ``enable_dnsblip()`` (3123-3133, bound to ``#action`` click at 3166-3169): the
-  ``#action`` List-Action select being non-``Disabled`` ``.show()``s BOTH the
-  ``advinboundsettings`` and ``advoutboundsettings`` sections (ids built at
-  2909); ``Disabled`` ``.hide()``s them.
+* ``enable_python_regex()`` (bound to ``#pfb_regex`` click and run once on
+  load): when ``#pfb_regex`` is CHECKED it ``.show()``s the
+  ``Python_regex_list`` section, UNCHECKED it ``.hide()``s it.
+* ``enable_python_noaaaa()``: ``#pfb_noaaaa`` gates the ``Python_noaaaa_list``
+  section.
+* ``enable_python_gp()``: ``#pfb_gp`` gates the ``Python_Group_Policy`` section.
+* ``enable_tld()``: ``#pfb_tld`` gates BOTH the ``TLD_Exclusion`` and
+  ``TLD_BW_list`` sections at once.
+* ``enable_dnsblip()`` (bound to ``#action`` click): the ``#action`` List-Action
+  select being non-``Disabled`` ``.show()``s BOTH the ``advinboundsettings`` and
+  ``advoutboundsettings`` sections; ``Disabled`` ``.hide()``s them.
 
 All five gating controls default OFF on a fresh box (``pfb_regex``/``pfb_noaaaa``/
 ``pfb_gp``/``pfb_tld`` default ``''`` -> unchecked; ``action`` defaults
@@ -253,11 +250,11 @@ def test_action_select_toggles_advanced_firewall_sections(
 ) -> None:
     """`#action` != `Disabled` shows the Advanced In/Outbound firewall sections.
 
-    ``enable_dnsblip()`` (pfblockerng_dnsbl.php:3123-3133), bound to the
-    ``#action`` List-Action select's click (3166-3169) and run on load: a
-    non-``Disabled`` value ``.show()``s BOTH ``advinboundsettings`` and
-    ``advoutboundsettings``; ``Disabled`` ``.hide()``s them. The select defaults
-    ``Disabled`` (3124 / $pconfig default), so the on-load pass leaves both
+    ``enable_dnsblip()`` (pfblockerng_dnsbl.php), bound to the ``#action``
+    List-Action select's click and run on load: a non-``Disabled`` value
+    ``.show()``s BOTH ``advinboundsettings`` and ``advoutboundsettings``;
+    ``Disabled`` ``.hide()``s them. The select defaults ``Disabled``
+    ($pconfig default), so the on-load pass leaves both
     sections hidden -- the asserted BEFORE state. The handler reads the select
     VALUE, so we ``select_option`` then fire the bound ``click`` to run it (a
     ``<select>`` change does not raise ``click``); both branches are exercised.

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -753,15 +753,15 @@ def test_dnsbl_group_policy_section_renders_above_dns_redirect(
 ) -> None:
     """The collapsible DNSBL Group Policy panel renders ABOVE the DNS Redirect section.
 
-    The panel was moved up next to the DNSBL Configuration section (which holds its
+    The panel was moved up next to the main 'DNSBL' section (which holds its pfb_gp
     enable checkbox) instead of sitting below the encrypted-DNS sections. This is a
     structural/positional change, so the order of the section markup in the rendered
     HTML is the oracle.
 
     The oracle keys on the section's unique ``Python_Group_Policy`` id, NOT the
     'DNSBL Group Policy' text — that text also appears as the enable-checkbox label
-    inside DNSBL Configuration (always above DNS Redirect), so matching it would pass
-    on the pre-change page too.
+    inside the main 'DNSBL' section (which is always above DNS Redirect), so matching
+    it would pass on the pre-change page too.
 
     Pins the change: pre-change the Group Policy section markup appeared BELOW the
     'DNS Redirect' section heading (so this assertion fails); post-change it appears

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -748,6 +748,40 @@ def test_dnsbl_encrypted_dns_sections_order(webui: WebUI, php_error_log_guard: P
     )
 
 
+def test_dnsbl_group_policy_section_renders_above_dns_redirect(
+    webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:
+    """The collapsible DNSBL Group Policy panel renders ABOVE the DNS Redirect section.
+
+    The panel was moved up next to the DNSBL Configuration section (which holds its
+    enable checkbox) instead of sitting below the encrypted-DNS sections. This is a
+    structural/positional change, so the order of the section markup in the rendered
+    HTML is the oracle.
+
+    The oracle keys on the section's unique ``Python_Group_Policy`` id, NOT the
+    'DNSBL Group Policy' text — that text also appears as the enable-checkbox label
+    inside DNSBL Configuration (always above DNS Redirect), so matching it would pass
+    on the pre-change page too.
+
+    Pins the change: pre-change the Group Policy section markup appeared BELOW the
+    'DNS Redirect' section heading (so this assertion fails); post-change it appears
+    above it.
+    """
+    path = "/pfblockerng/pfblockerng_dnsbl.php"
+    resp = webui.get(path)
+    result = evaluate_render(path, resp.status_code, resp.text, ("DNSBL Configuration",))
+    assert result.ok, f"DNSBL render oracle failed: {result.detail}"
+    body = resp.text
+    gp_pos = body.find("Python_Group_Policy")
+    redir_pos = body.find("DNS Redirect")
+    assert gp_pos != -1, "DNSBL page is missing the 'Python_Group_Policy' Group Policy section id"
+    assert redir_pos != -1, "DNSBL page is missing the 'DNS Redirect' section heading"
+    assert gp_pos < redir_pos, (
+        f"'DNSBL Group Policy' section (id 'Python_Group_Policy', pos {gp_pos}) must render "
+        f"above 'DNS Redirect' (pos {redir_pos})"
+    )
+
+
 def test_feeds_custom_panel_heading_renders(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """The second Feeds panel — the one listing user-configured feeds that don't match the
     predefined catalog — is headed "Custom Feeds", not the former "Unknown user defined Feeds".


### PR DESCRIPTION
## Change

Move the collapsible **DNSBL Group Policy** panel (`Python_Group_Policy`, `COLLAPSIBLE|SEC_CLOSED`) on the DNSBL settings page so it renders directly below **DNSBL Configuration** (which holds its enable checkbox) and above the **DNS Redirect** section, instead of below the encrypted-DNS sections. Pure block move — no field, help-text, or behaviour changes. The `pfb_gp` visibility JS selects the panel by its id, so the move is position-independent.

## Tests

New Tier A `ui_render` test `test_dnsbl_group_policy_section_renders_above_dns_redirect` (mirrors the existing `test_dnsbl_encrypted_dns_sections_order` pattern): asserts the section markup position precedes the `DNS Redirect` heading in the rendered HTML. The oracle keys on the unique `Python_Group_Policy` section id rather than the section-title text, because "DNSBL Group Policy" also appears as the enable-checkbox label inside DNSBL Configuration (always above DNS Redirect) and would false-pass pre-change. Pre-change the section markup renders below DNS Redirect, so the assertion fails; post-change it passes.

Gates: `php -l` clean, PHPCS clean, ruff + `ruff format` + mypy clean.

## Branch-name note

The session's push policy pins this environment to the `claude/gh-issue-782-d62nvk` branch, which was minted for issue #782 (already merged). The branch was restarted from the latest `devel` for this unrelated UI change, so the name does not match the content.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxvQpCm9Dg7W4dTPxSYEuK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Moved the DNSBL Group Policy panel higher on the DNSBL settings page so it now appears before the DNS Redirect section and related encrypted-DNS options.
  * Improved page layout consistency to make the DNSBL configuration easier to find and review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->