### PR TITLE
tests/ui: drop the unsatisfiable pkg_mgr_installed.php body assert (#791)

### DIFF
--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1043,7 +1043,8 @@ def test_software_actions_link_to_package_manager(
           actionable ``pkg_mgr_install.php?mode=reinstallpkg&pkg=…`` link — the href, not just CSS,
           is the gate (an anchor's ``disabled``/``aria-disabled`` are advisory only);
       And the page carries NO in-page pkg machinery — no ``?ajax=tail`` poller, no ``pfb_output``
-          textarea, no old ``pkg_mgr_installed.php`` redirect;
+          textarea (the old post-uninstall ``pkg_mgr_installed.php`` redirect was POST-only
+          machinery, so it has no GET-observable trace to assert on — see #791);
       And the clean render oracle (200, no Fatal/Warning/Notice, marker present) holds.
 
     Fail-before / pass-after: the pre-#684 page ran ``pkg`` from a detached daemon and tailed it via
@@ -1089,10 +1090,12 @@ def test_software_actions_link_to_package_manager(
             "Uninstall must NOT route through the removed ?do=uninstall handler (#697)"
         )
 
-        # The in-page pkg machinery is gone entirely.
+        # The in-page pkg machinery is gone entirely. Do NOT assert `/pkg_mgr_installed.php`
+        # absent from the body: pfSense's System menu (head.inc) always carries that href for an
+        # admin on EVERY page, and the old post-uninstall redirect it meant to catch was printed
+        # only on the POST uninstall-success path — never in a GET body (#791).
         assert "?ajax=tail" not in body, "Software page must no longer host the ?ajax=tail poller"
         assert 'name="pfb_output"' not in body, "Software page must no longer render the pfb_output textarea"
-        assert "/pkg_mgr_installed.php" not in body, "the old post-uninstall redirect target must be gone"
 
         # (B) Seed a newer cached 'latest' → update available → the Update href becomes the actionable
         #     reinstallpkg link (the ON branch of the availability gate). 99.0.0 > any real installed

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1043,8 +1043,8 @@ def test_software_actions_link_to_package_manager(
           actionable ``pkg_mgr_install.php?mode=reinstallpkg&pkg=…`` link — the href, not just CSS,
           is the gate (an anchor's ``disabled``/``aria-disabled`` are advisory only);
       And the page carries NO in-page pkg machinery — no ``?ajax=tail`` poller, no ``pfb_output``
-          textarea (the old post-uninstall ``pkg_mgr_installed.php`` redirect was POST-only
-          machinery, so it has no GET-observable trace to assert on — see #791);
+          textarea (the historical post-uninstall redirects were POST-only machinery, so they
+          left no GET-observable trace to assert on — see #791);
       And the clean render oracle (200, no Fatal/Warning/Notice, marker present) holds.
 
     Fail-before / pass-after: the pre-#684 page ran ``pkg`` from a detached daemon and tailed it via
@@ -1092,8 +1092,8 @@ def test_software_actions_link_to_package_manager(
 
         # The in-page pkg machinery is gone entirely. Do NOT assert `/pkg_mgr_installed.php`
         # absent from the body: pfSense's System menu (head.inc) always carries that href for an
-        # admin on EVERY page, and the old post-uninstall redirect it meant to catch was printed
-        # only on the POST uninstall-success path — never in a GET body (#791).
+        # admin on EVERY page, and no pfBlockerNG GET body ever carried that string — the
+        # historical post-uninstall redirects were POST-only machinery (#791).
         assert "?ajax=tail" not in body, "Software page must no longer host the ?ajax=tail poller"
         assert 'name="pfb_output"' not in body, "Software page must no longer render the pfb_output textarea"
 


### PR DESCRIPTION
Fixes #791.

## What

Drops the `assert "/pkg_mgr_installed.php" not in body` check from `test_software_actions_link_to_package_manager` and documents why in place. The sibling machinery asserts (`?ajax=tail`, `pfb_output`) stay — they are the real GET-observable pins of the #684/#697 rework.

## Why — not a product regression

The investigation corrected the issue's premise:

- The `/pkg_mgr_installed.php` occurrence in the body is **pfSense's own System menu** ("Package Manager", emitted unconditionally by `head.inc` and privilege-filtered via `isAllowedPage()`). The UI suite logs in as `admin`, who is always allowed, so the href is present on **every** pfSense page — the body-wide absence assertion can never hold.
- The "old post-uninstall redirect" the assertion meant to catch (`pfb_software_reload('/pkg_mgr_installed.php')`) printed its `<script>` **only on the POST uninstall-success path** — it never appeared in a GET body, so the assertion also had no fail-before power on the old page.
- There is **no regression window**: the nightly `schedule` runs only the functional + browser tiers (render is the per-PR/dispatch tier), so the 2026-07-03 nightly never ran this test. The test had never been executed on a live render leg before 2026-07-03 18:28Z (PR #685 had no `ui-tests.yml` dispatch on its branch; subsequent render legs ran narrowed selections). Its first-ever live executions (ADR-53 dispatches, PR #785's runs, the devel probe) all failed on exactly this assertion; every other assertion in the test passes, so the Software-page rework itself is intact on `devel`.

## Validation

- Fail-before: the assertion is red on `devel` — run [28695073492](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28695073492) (single-test render probe).
- Pass-after: single-test render dispatch on this branch (link in comments once green).
- `ruff check` / `ruff format --check` / `mypy tests/` / `python -m pytest` (2099 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVWLiFeaGYpg178rFMeo7P
