### PR TITLE
Fix the six round-1 substitute-review findings (issue #729)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3441,13 +3441,18 @@ function pfb_print_pending_changes_box(bool $on_update_page = FALSE): void {
 }
 
 /*
- * Append the "Software" tab to a page's $tab_array — ONLY on an our-repo build
- * (pfb_software_provenance_ok()). Shared by every pfBlockerNG page so the tab is
- * consistently present (our build) or absent (Netgate build) across the GUI.
- * Call immediately before display_top_tabs(); $active marks it the current tab.
+ * Append the "Software" tab to a page's $tab_array — ONLY when BOTH hold: an our-repo build
+ * (pfb_software_provenance_ok()) AND the viewer holds the Package Manager "Installed" privilege
+ * (isAllowedPage('pkg_mgr_installed.php')) — the SAME secondary gate pfblockerng_software.php
+ * itself enforces (issue #485), so a user without that priv never sees a tab that dead-ends at
+ * /index.php. $provenance_ok is injectable for off-box unit tests (the real predicate reads
+ * on-appliance state); NULL (the production default) reads it. Shared by every pfBlockerNG page
+ * so the tab is consistently present or absent across the GUI. Call immediately before
+ * display_top_tabs(); $active marks it the current tab.
  */
-function pfb_software_add_tab(array &$tab_array, bool $active = FALSE): void {
-	if (pfb_software_provenance_ok()) {
+function pfb_software_add_tab(array &$tab_array, bool $active = FALSE, ?bool $provenance_ok = null): void {
+	$provenance_ok = $provenance_ok ?? pfb_software_provenance_ok();
+	if ($provenance_ok && isAllowedPage('pkg_mgr_installed.php')) {
 		$tab_array[] = array(gettext('Software'), $active, '/pfblockerng/pfblockerng_software.php');
 	}
 }

--- a/tests/php/SoftwareAddTabTest.php
+++ b/tests/php/SoftwareAddTabTest.php
@@ -18,6 +18,12 @@ use PHPUnit\Framework\TestCase;
  * off-box). The privilege gate has no seam — every case goes through the real isAllowedPage()
  * call, controlled by its double via $GLOBALS['pfb_test_allowed_pages'] (absent key = allowed),
  * so the tests prove the production code actually calls isAllowedPage().
+ *
+ * Documented out-of-CI limitation: the live restricted-user leg (a GUI session holding the
+ * pfBlockerNG priv but not pkg_mgr_installed, asserting the tab absent) is not automatable —
+ * the WebUI harness logs in as admin only (uid-0 short-circuits isAllowedPage), and building
+ * non-admin user provisioning/login is disproportionate here. This class pins the branch
+ * off-box; the admin-visible/provenance tab behaviour stays pinned by the Tier-A UI tests.
  */
 #[CoversFunction('pfb_software_add_tab')]
 final class SoftwareAddTabTest extends TestCase
@@ -63,7 +69,10 @@ final class SoftwareAddTabTest extends TestCase
 	 * "Installed" privilege (isAllowedPage('pkg_mgr_installed.php') === false via its double),
 	 * When the tab is built,
 	 * Then the Software tab is NOT appended — it must never dead-end at /index.php.
-	 * FAILS on pre-fix code (provenance alone used to be sufficient).
+	 * Red/green evidence: with the $provenance_ok seam in place, removing the isAllowedPage()
+	 * clause makes this test FAIL (proven at the gate). Against the literal pre-fix two-param
+	 * signature the extra arg is ignored and the off-box provenance predicate already withholds
+	 * the tab, so there the pre-fix red is carried by testProvenanceOkAndPageAllowedAppendsTab.
 	 */
 	public function testProvenanceOkButPageNotAllowedDoesNotAppendTab(): void
 	{

--- a/tests/php/SoftwareAddTabTest.php
+++ b/tests/php/SoftwareAddTabTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #729 (origin PR #527) — pfb_software_add_tab() previously appended the "Software" tab
+ * on provenance alone, while pfblockerng_software.php itself enforces a SECONDARY PRIVILEGE
+ * GATE (issue #485: isAllowedPage('pkg_mgr_installed.php')). A user with the pfBlockerNG page
+ * priv but without the Package Manager "Installed" priv saw the tab, clicked it, and silently
+ * bounced to /index.php. The fix requires BOTH gates before the tab is appended.
+ *
+ * $provenance_ok is the function's injectable seam (mirrors the $io pattern in
+ * pfb_software_update_check): NULL falls through to the real pfb_software_provenance_ok(),
+ * an explicit bool bypasses it (the real predicate reads on-appliance state, unreachable
+ * off-box). The privilege gate has no seam — every case goes through the real isAllowedPage()
+ * call, controlled by its double via $GLOBALS['pfb_test_allowed_pages'] (absent key = allowed),
+ * so the tests prove the production code actually calls isAllowedPage().
+ */
+#[CoversFunction('pfb_software_add_tab')]
+final class SoftwareAddTabTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		$GLOBALS['pfb_test_allowed_pages'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['pfb_test_allowed_pages']);
+	}
+
+	private function hasSoftwareTab(array $tab_array): bool
+	{
+		foreach ($tab_array as $tab) {
+			if (($tab[2] ?? null) === '/pfblockerng/pfblockerng_software.php') {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Given an our-repo build AND a user holding the Package Manager "Installed" privilege,
+	 * When the tab is built,
+	 * Then the Software tab is appended.
+	 */
+	public function testProvenanceOkAndPageAllowedAppendsTab(): void
+	{
+		$tab_array = [];
+		$this->assertFalse($this->hasSoftwareTab($tab_array), 'before: no tab yet');
+
+		// Page priv rides the isAllowedPage() double's default (absent key = allowed).
+		pfb_software_add_tab($tab_array, false, true);
+
+		$this->assertTrue($this->hasSoftwareTab($tab_array), 'after: tab appended when both gates pass');
+	}
+
+	/**
+	 * THE FIX — Given an our-repo build (provenance OK) but a user WITHOUT the Package Manager
+	 * "Installed" privilege (isAllowedPage('pkg_mgr_installed.php') === false via its double),
+	 * When the tab is built,
+	 * Then the Software tab is NOT appended — it must never dead-end at /index.php.
+	 * FAILS on pre-fix code (provenance alone used to be sufficient).
+	 */
+	public function testProvenanceOkButPageNotAllowedDoesNotAppendTab(): void
+	{
+		$GLOBALS['pfb_test_allowed_pages']['pkg_mgr_installed.php'] = false;
+
+		$tab_array = [];
+		$this->assertFalse($this->hasSoftwareTab($tab_array), 'before: no tab yet');
+
+		pfb_software_add_tab($tab_array, false, true);
+
+		$this->assertFalse($this->hasSoftwareTab($tab_array), 'after: tab withheld without the Package Manager priv');
+	}
+
+	/**
+	 * Existing behaviour pinned — Given a NON our-repo build (provenance not OK), even with the
+	 * Package Manager privilege granted,
+	 * When the tab is built,
+	 * Then the Software tab is NOT appended (a Netgate/sideloaded install never shows it).
+	 */
+	public function testProvenanceNotOkDoesNotAppendTab(): void
+	{
+		$tab_array = [];
+		$this->assertFalse($this->hasSoftwareTab($tab_array), 'before: no tab yet');
+
+		pfb_software_add_tab($tab_array, false, false);
+
+		$this->assertFalse($this->hasSoftwareTab($tab_array), 'after: tab withheld on a non-our-repo build');
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -456,6 +456,18 @@ if (!function_exists('get_dnsavailable')) {
 	}
 }
 
+if (!function_exists('isAllowedPage')) {
+	// pfSense pfsense-utils.inc: TRUE when the current user may reach $page (honours the
+	// admin uid-0 short-circuit + 'page-all' wildcard — see pfblockerng_software.php's
+	// SECONDARY PRIVILEGE GATE comment, issue #485). Tests seed
+	// $GLOBALS['pfb_test_allowed_pages'] (page => bool); an absent key defaults to TRUE so
+	// every pre-existing test (none of which cares about this priv) is unaffected.
+	function isAllowedPage($page) {
+		$map = $GLOBALS['pfb_test_allowed_pages'] ?? [];
+		return (bool) ($map[$page] ?? true);
+	}
+}
+
 // --- pfb_collect_localip() doubles ---
 //
 // These support testing the local-IP collection logic off-appliance.

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -1138,19 +1138,46 @@ def _feed_log_count(vm: SmokeVM, header: str, phrase: str, *, timeout: float = 3
         return 0
 
 
-def _pin_cron_due(vm: SmokeVM) -> None:
-    """Set pfb_reuse='' and pfb_dailystart=date('G') on the guest so an EveryDay feed is due."""
+def _pin_cron_due(vm: SmokeVM) -> int:
+    """Set pfb_reuse='' and pfb_dailystart=date('G') on the guest so an EveryDay feed is due.
+
+    Returns the guest's wall-clock hour (0-23) pinned into ``pfb_dailystart``, echoed back
+    atomically with the write. Callers that later run ``cron`` should fast-guard against an
+    hour rollover between this pin and the cron run (see :func:`_guest_hour`) — if the
+    wall clock ticked over, the EveryDay feed is no longer due and a "not re-ingested"
+    assertion would misread that as a change-detector regression.
+    """
+    sentinel_open, sentinel_close = "<<<HOUR>>>", "<<<END>>>"
     snippet = (
         f"$g = config_get_path({h._php_str(h.CFG_GLOBAL)}, array());\n"  # noqa: SLF001
         "$g['pfb_reuse'] = '';\n"
-        "$g['pfb_dailystart'] = date('G');\n"
+        "$hour = date('G');\n"
+        "$g['pfb_dailystart'] = $hour;\n"
         f"config_set_path({h._php_str(h.CFG_GLOBAL)}, $g);\n"  # noqa: SLF001
         "write_config('pfBlockerNG smoke #538: due cron');\n"
-        "echo 'OK';"
+        f"echo 'OK' . '{sentinel_open}' . $hour . '{sentinel_close}';"
     )
     res = h.php_eval(vm, snippet)
-    if res.returncode != 0 or "OK" not in res.stdout:
+    if res.returncode != 0 or "OK" not in res.stdout or sentinel_open not in res.stdout:
         raise RuntimeError(f"_pin_cron_due failed: rc={res.returncode} {res.stderr!r} {res.stdout!r}")
+    raw = res.stdout.split(sentinel_open, 1)[1].split(sentinel_close, 1)[0]
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"_pin_cron_due: could not parse pinned hour from {res.stdout!r}") from exc
+
+
+def _guest_hour(vm: SmokeVM) -> int:
+    """Read the guest's CURRENT wall-clock hour (0-23) via ``date('G')``, delimited."""
+    sentinel_open, sentinel_close = "<<<HOUR>>>", "<<<END>>>"
+    res = h.php_eval(vm, f"echo '{sentinel_open}' . date('G') . '{sentinel_close}';")
+    if sentinel_open not in res.stdout or sentinel_close not in res.stdout:
+        raise RuntimeError(f"_guest_hour: no delimited value in output: {res.stdout!r} {res.stderr!r}")
+    raw = res.stdout.split(sentinel_open, 1)[1].split(sentinel_close, 1)[0]
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"_guest_hour: could not parse hour from {res.stdout!r}") from exc
 
 
 def _bump_feed_mtime(
@@ -1321,7 +1348,7 @@ def test_cron_skips_unchanged_local_feed(deployed_vm: SmokeVM, client_vm: SmokeV
         # No mtime manipulation is needed: detection is hash-based (ADR-42 Phase 2).
 
         # Pin pfb_reuse=off and dailystart=now.
-        _pin_cron_due(deployed_vm)
+        pinned_hour = _pin_cron_due(deployed_vm)
 
         # Capture baselines BEFORE cron. With an unchanged feed the cron takes the noupdates
         # path (sync feed-loop skipped), so the reliable positive signal is the DETECTOR verdict
@@ -1331,6 +1358,18 @@ def test_cron_skips_unchanged_local_feed(deployed_vm: SmokeVM, client_vm: SmokeV
 
         # WHEN — cron.
         h.reload(deployed_vm, "cron")
+
+        # THEN (fast guard) — the guest hour must still match the pinned hour. Unlike the
+        # changed-feed sibling (test_cron_detects_changed_local_feed), this unchanged/noupdates
+        # path logs no "[ header ]" marker to fast-guard on, so guard on the wall clock itself:
+        # a rollover between _pin_cron_due and this cron means the EveryDay feed was never due,
+        # and the "no re-ingest" assertions below would prove nothing about the change detector.
+        hour_after = _guest_hour(deployed_vm)
+        assert hour_after == pinned_hour, (
+            f"guest hour rolled over between _pin_cron_due ({pinned_hour}) and cron "
+            f"({hour_after}) — the EveryDay feed was not due this run; this proves nothing "
+            f"about the change detector, re-run"
+        )
 
         # THEN — no new "Downloading update" (reuse held — feed not re-ingested).
         dl_after = _feed_log_count(deployed_vm, header, "Downloading update")
@@ -1411,12 +1450,24 @@ def test_cron_skips_local_feed_with_bumped_mtime_but_same_content(deployed_vm: S
         _bump_feed_mtime(deployed_vm, feed_path, orig_path, advance="0200")
 
         # Pin pfb_reuse=off and dailystart=now (just before cron).
-        _pin_cron_due(deployed_vm)
+        pinned_hour = _pin_cron_due(deployed_vm)
         notreq_before = h.count_log_marker(deployed_vm, h.PFB_LOG, "Update not required")
         dl_before = _feed_log_count(deployed_vm, header, "Downloading update")
 
         # WHEN — cron (the genuine detector path).
         h.reload(deployed_vm, "cron")
+
+        # THEN (fast guard) — the guest hour must still match the pinned hour. This
+        # unchanged-content path (like its `test_cron_skips_unchanged_local_feed` sibling) logs
+        # no "[ header ]" marker to fast-guard on, so guard on the wall clock itself: a rollover
+        # between _pin_cron_due and this cron means the EveryDay feed was never due, and the
+        # "Update not required" assertion below would prove nothing about the change detector.
+        hour_after = _guest_hour(deployed_vm)
+        assert hour_after == pinned_hour, (
+            f"guest hour rolled over between _pin_cron_due ({pinned_hour}) and cron "
+            f"({hour_after}) — the EveryDay feed was not due this run; this proves nothing "
+            f"about the change detector, re-run"
+        )
 
         # THEN — hash confirms no content change: "Update not required" appeared, no download.
         # (ADR-42 Phase 2: the old "mtime changed, content identical" marker no longer exists;

--- a/tests/smoke/test_smoke_lan_rule_preserve.py
+++ b/tests/smoke/test_smoke_lan_rule_preserve.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 
 import json
 import os
-import time
 from collections.abc import Iterator
 
 import pytest
@@ -72,9 +71,6 @@ DUMMY_IP = "203.0.113.200"  # RFC 5737 TEST-NET-3, always-in alias so the rule i
 
 # The user LAN pass rule description pfSense bakes into fresh images.
 DEFAULT_ALLOW_LAN_DESCR = "Default allow LAN to any"
-
-# Brief settle after reload for pf table + filter state to stabilise.
-SETTLE_SECS = 2.0
 
 
 # --------------------------------------------------------------------------- #
@@ -232,6 +228,11 @@ def _run_two_reload_cycle(
     are dropped during the cycle (the pass_order bug, observable as early as reload #1 depending
     on install-time syncs); after the fix they survive both snapshots.
 
+    ``reload()`` triggers ``filter_configure()`` ASYNCHRONOUSLY (``send_event``), so a one-shot
+    config.xml/pfctl read right after it races the apply (same class as #483's misdiagnosis).
+    ``h.apply_filter_sync()`` blocks on the synchronous rc entrypoint instead, so the read that
+    follows is authoritative.
+
     Returns three rule snapshots for the caller's assertions.
     """
     rules_before = _get_filter_rules(vm)
@@ -239,13 +240,13 @@ def _run_two_reload_cycle(
     # Reload #1: build the alias.
     h.force_ip_refetch(vm, f"{FEED_HEADER}_v4")
     h.reload(vm, "update", timeout=timeout)
-    time.sleep(SETTLE_SECS)
+    h.apply_filter_sync(vm)
     rules_after_r1 = _get_filter_rules(vm)
 
     # Reload #2: this is when the pre-fix code drops user LAN rules.
     h.force_ip_refetch(vm, f"{FEED_HEADER}_v4")
     h.reload(vm, "update", timeout=timeout)
-    time.sleep(SETTLE_SECS)
+    h.apply_filter_sync(vm)
     rules_after_r2 = _get_filter_rules(vm)
 
     return rules_before, rules_after_r1, rules_after_r2

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -483,17 +483,27 @@ def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: Smok
         daemon_running = "pfblockerng.inc filterlog" in ps.stdout
         pfctl = vm.ssh("/sbin/pfctl", "-t", "pfB_pfb_syslog_iptest_v4", "-T", "show", timeout=30)
         alias_populated = TEST_IP_BLOCK_DST in pfctl.stdout
+        # An unpopulated alias or a dead filterlog daemon are NOT benign preconditions to skip
+        # past -- this un-xfailed leg (ADR-38 A2.4) exists specifically to catch those two
+        # regression classes (a failed IP feed reload / a crashed export daemon), so both fold
+        # into the same hard failure instead of turning a target regression into a green skip.
         if not alias_populated:
-            pytest.skip(
+            precondition = (
                 f"IP block alias pfB_pfb_syslog_iptest_v4 not populated with {TEST_IP_BLOCK_RANGE} "
-                f"— IP feed reload may have failed. pfctl: {pfctl.stdout!r}"
+                "— IP feed reload likely failed"
             )
-        if not daemon_running:
-            pytest.skip(f"filterlog daemon not running — cannot exercise the IP syslog path (ps: {ps.stdout[:400]!r})")
+        elif not daemon_running:
+            precondition = "filterlog daemon not running — the pfBlockerNG export daemon died"
+        else:
+            precondition = "none — daemon running and alias populated"
         raise AssertionError(
             f"No new IP-block export record after connection to {TEST_IP_BLOCK_DST}.\n"
             f"  expected a new line in {PFB_SYSLOG_LOG} with one of {list(IP_ACT_TOKENS)!r}\n"
+            f"  actual:   no matching line found\n"
             f"  daemon_running={daemon_running} alias_populated={alias_populated}\n"
+            f"  precondition broken: {precondition}\n"
+            f"  ps: {ps.stdout[:400]!r}\n"
+            f"  pfctl: {pfctl.stdout!r}\n"
             f"  {syslog_export_state_snapshot(vm)}"
         )
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1218,11 +1218,22 @@ def test_log_settings_section_redesign_render(webui: WebUI, php_error_log_guard:
       (ABSENT: old design, before/after evidence). ``php_error_log_guard`` enrolls this GET
       in the module-level no-growth sweep.
 
-    Source-inspection proof of fail-before/pass-after:
+    Source-inspection proof of fail-before/pass-after (verified against
+    ``pfblockerng_general.php`` ~lines 445-478 in this worktree):
     - PRESENT markers ("rolling cap", "discards that period", "cushion for remote log
-      shippers", ">Max lines<", ">Schedule<", ">Keep lines<") exist ONLY in the new
-      PHP code (the intro ``Form_StaticText`` and header ``Form_Group`` rows); they are
-      absent from ``origin/devel``, so the test FAILS on the old code and PASSES after.
+      shippers") come from the intro ``Form_StaticText`` — one column-purpose ``<ul>``,
+      absent from ``origin/devel``.
+    - PRESENT markers (the full header-cell markup
+      ``form-control-static hidden-xs"><strong>Max lines</strong>`` / Schedule / Keep
+      lines) come ONLY from the per-category header ``Form_Group`` rows
+      (``Form_StaticText('', '<p class="form-control-static hidden-xs"><strong>...
+      </strong></p>')``). A bare ``>Max lines<`` substring is NOT sufficient: the intro
+      ``<ul>`` also renders ``<li><strong>Max lines</strong> &mdash; ...`` (no
+      ``hidden-xs``, no ``form-control-static``), so it satisfies the old bare needle
+      even with every header row deleted — the full markup needle only matches the
+      header cell. (The ``pfb-loghdr`` class is NOT asserted for the same reason: its
+      name also appears in the intro's ``<style>`` block, so it can't prove a header
+      row rendered.)
     - ABSENT markers ("</strong> Log", "Unified Log") exist ONLY in the old
       ``setHelp("Default: <strong>20000<br />{$descr}</strong> Log")`` calls and the old
       ``'Unified Log'`` key; they are absent from the new code, so the test PASSES after
@@ -1241,9 +1252,17 @@ def test_log_settings_section_redesign_render(webui: WebUI, php_error_log_guard:
     ):
         assert needle in body, f"Log Settings intro wording {needle!r} missing — redesign intro not rendered"
 
-    # PRESENT: column headers (emitted by the per-category header Form_Group rows).
-    for needle in (">Max lines<", ">Schedule<", ">Keep lines<"):
-        assert needle in body, f"Log Settings column header {needle!r} missing — header rows not rendered"
+    # PRESENT: the per-category header Form_Group rows. A bare ">Max lines<" substring is
+    # ALSO satisfied by the intro <ul> ("<li><strong>Max lines</strong> ...") — dropping every
+    # header row entirely would still pass that needle. Assert the full header-cell HTML
+    # instead — the intro carries neither "hidden-xs" nor "form-control-static". (Don't
+    # assert the "pfb-loghdr" class: its name also appears in the intro's <style> block.)
+    for needle in (
+        'form-control-static hidden-xs"><strong>Max lines</strong>',
+        'form-control-static hidden-xs"><strong>Schedule</strong>',
+        'form-control-static hidden-xs"><strong>Keep lines</strong>',
+    ):
+        assert needle in body, f"Log Settings header cell {needle!r} missing — header rows not rendered"
 
     # PRESENT: field names spanning all four categories — no control dropped.
     for field_name in (

--- a/tests/test_adr10_watcher.py
+++ b/tests/test_adr10_watcher.py
@@ -263,10 +263,15 @@ class _Harness:
         # P._snapshot may not be swapped yet. The swap is done by production code on a
         # module-level variable we cannot signal from here, so this stays a poll -- but
         # with a loud timeout assertion (safety-guard, never a silent return; issue #456).
+        # Check-then-deadline order (#729/#551): the swap may land during the final sleep,
+        # after the last check but before the deadline expires -- always re-check once more
+        # right before giving up, or that in-flight swap reads as a false "never swapped".
         deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
+        while True:
             if P._snapshot is not old:
                 return
+            if time.monotonic() >= deadline:
+                break
             time.sleep(0.005)
         raise AssertionError(
             "wait_snapshot_changed timed out after {:.1f}s: P._snapshot was never swapped "
@@ -304,6 +309,18 @@ class TestHarnessWaiterDiagnostics:
         P._snapshot = old
         with pytest.raises(AssertionError, match=r"wait_snapshot_changed timed out"):
             h.wait_snapshot_changed(old, timeout=0.1)
+
+    def test_wait_snapshot_changed_returns_when_swap_lands_at_deadline(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # #729/#551: a swap that lands during the FINAL sleep (after the last check, before
+        # the deadline expires) must still be observed, not read as a false "never swapped".
+        # timeout=0.0 makes the deadline already-expired at call time, so the loop's ONLY
+        # chance to see the swap is the check-before-give-up -- this is what the old
+        # check-then-sleep-then-recheck-deadline ordering skipped.
+        h = _Harness(tmp_path, monkeypatch)
+        old = _snapshot(tag="old.example.com", counts=0)
+        new = _snapshot(tag="new.example.com", counts=1)
+        P._snapshot = new  # the swap already landed before the waiter is even called.
+        h.wait_snapshot_changed(old, timeout=0.0)  # must return, not raise.
 
 
 class TestWatcherLoop:


### PR DESCRIPTION
Fixes #729 — the remaining round-1 backlog of the substitute review (findings re-verified still present on current `devel` before fixing). One commit per finding.

## Fixes

- **#527 — dead Software tab for limited users** (`pfblockerng.inc`): `pfb_software_add_tab()` now requires `isAllowedPage('pkg_mgr_installed.php')` in addition to provenance — the same secondary gate `pfblockerng_software.php` enforces (issue #485) — so a user without the Package Manager "Installed" privilege no longer sees a tab that dead-ends at `/index.php`. New `SoftwareAddTabTest` covers all three branches (red-before/green-after proven for the privilege branch); `isAllowedPage` added to the pfSense doubles.
- **#515 — Tier-A header assertions satisfied by the intro text** (`tests/smoke/ui/test_render_smoke.py`): the bare `>Max lines<`-style needles were substrings of the intro `<ul>` too, so deleting every header row stayed green. Needles now anchor to the full header-cell markup (`form-control-static hidden-xs"><strong>…`), which the intro cannot satisfy. (`pfb-loghdr` is deliberately not asserted — its name also appears in the intro's `<style>` block.)
- **#539 — one-shot pfctl read races the async filter apply** (`tests/smoke/test_smoke_lan_rule_preserve.py`): the fixed 2 s settle sleeps are replaced with `helpers.apply_filter_sync()` (blocking `rc.filter_configure_sync`), making the subsequent one-shot reads authoritative — same race class as the #483 misdiagnosis, and removes a no-fixed-wait violation (issue #456).
- **#529 — syslog export leg skips-as-green on its target regressions** (`tests/smoke/test_syslog_export.py`): an unpopulated IP alias or a dead filterlog daemon now fail hard (with the precondition named and full diagnostics) instead of `pytest.skip()` — those are exactly the regression classes the un-xfailed ADR-38 A2.4 leg exists to catch.
- **#541 — missing hour-rollover guard** (`tests/smoke/test_smoke_feeds.py`): both cron-skip tests (`test_cron_skips_unchanged_local_feed` and the bumped-mtime sibling) now fast-guard on the pinned guest hour after the cron run. The changed-feed sibling's `[ header ]` guard (451bf3c) does not transfer — the unchanged/noupdates path logs no header — so the guard compares `_pin_cron_due()`'s returned hour against the post-cron guest hour and fails with an explicit "not due (hour rollover), re-run" message instead of a false change-detector diagnosis.
- **#551 — waiter raises false "never swapped" at deadline** (`tests/test_adr10_watcher.py`): `wait_snapshot_changed` now re-checks the snapshot once more before giving up (check-then-deadline order), so a swap landing during the final 5 ms sleep is observed. New red/green test pins it (`timeout=0` with the swap already landed raised on the old code).

## Validation

- Unit suites green: pytest 2100 passed, PHPUnit 2027 tests / 16085 assertions; ruff, mypy, PHPStan, PHPCS, `php -l` all clean.
- Red-before/green-after proven independently for the two behaviour changes with off-box coverage (#551, #527).
- The four smoke/UI modules are dispatch-only; a selective smoke + UI (`ui_render`) dispatch on this branch validates them live (results linked in a PR comment before merge).
- Documented out-of-CI limitation: the #527 limited-user leg (tab absent for a non-admin) is not automatable in the UI tiers — the harness logs in as admin only, for whom `isAllowedPage` is always true. The privilege branch is pinned off-box by `SoftwareAddTabTest`; existing Tier-A software-tab tests keep pinning the admin-visible/provenance behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG