### PR TITLE
pfblockerng: Alerts un-suppress ADR-53 parity (any mask + IPv6) + text alignment (#422)

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -508,7 +508,17 @@ jobs:
           # Build argv via set -- so --filter rides as ONE quoted arg.
           set -- --paths tests/smoke/ui -m "${MARKER}" --timeout 300
           [ -n "${PYTEST_FILTER:-}" ] && set -- "$@" --filter "${PYTEST_FILTER}"
-          sh scripts/run-smoke.sh "$@"
+          rc=0
+          sh scripts/run-smoke.sh "$@" || rc=$?
+          # pytest exit 5 = the impacted/-k selection contains no test carrying
+          # this tier's marker — an empty (valid) selection, not a failure. An
+          # impacted dispatch whose changed modules hold only e2e tests would
+          # otherwise fail every browser-tier leg on "no tests ran".
+          if [ "$rc" -eq 5 ]; then
+            echo "No tests selected for marker ${MARKER} under this scope/filter — empty selection, success."
+            rc=0
+          fi
+          exit "$rc"
 
       # ADR-24: runner-side scrub of the Plus secret identity from the diagnostics
       # BEFORE upload. For a non-CE (Plus) image: drop ONLY the QEMU CONSOLE

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -895,6 +895,17 @@ never run for it. Covered by `tests/smoke/ui/test_alerts.py`'s
 in `tests/smoke/test_smoke_suppression.py` and is a genuinely different code path, not duplicate
 coverage.
 
+**Alerts un-suppress + row icons (issue #422 follow-up).** The trash-can revert (`delete_ip`)
+matches the covering suppression entry prefix-aware via `pfb_ip_suppressed_match()`
+(`pfblockerng_extra.inc` — longest prefix wins; also drives the suppressed-row icon detection),
+removes exactly that entry (either family, any mask) and `pfctl -T add`s it back — the union of
+the re-added entry with any covering CIDRs a live punch left behind equals the original coverage,
+and the next reload rebuilds the canonical set. The legacy 255-sibling-host revert loop is gone
+(nothing produces exploded state any more; pre-ADR-53 leftovers self-heal on the next reload).
+The `entry_delete` gate validates `PFB_FILTER_IP` (both families), and the Alerts suppression
+icons render for any Block/non-GeoIP row — v6 and broader-than-`/24` v4 rows included; the
+unlock-icon eligibility is deliberately unchanged.
+
 **Tests.** Off-appliance: `tests/shell/pfblockerng_suppress_spec.sh` (real-`iprange` shellspec —
 the exact `/16 − /32 = 16` / `/24 − /32 = 8` vectors the smoke module's assertions are grounded
 in), `tests/php/V6CidrSubtractTest.php` (the pure-PHP engine, incl. the `/64 − /128 = 64` vector),

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3162,11 +3162,19 @@ function pfb_ip_suppressed(string $ip, array $entries): bool
  * un-suppress ('delete_ip') handler (which entry to remove + re-add) and the
  * suppressed-row icon detection in the Alerts render loop.
  *
- * Skip/strip/containment rules are bit-identical to pfb_ip_suppressed()
- * (that function is now a one-line wrapper around this one) -- no new
- * normalisation. When both a bare host and a broader containing CIDR cover
- * $ip, the host-specific entry wins (mirrors the old /32-before-/24
- * precedence); a tie in prefix length keeps the first-seen entry.
+ * Skip/strip rules are identical to the pre-#422 pfb_ip_suppressed() (that
+ * function is now a one-line wrapper around this one). One deliberate
+ * tolerance on top: a bare host (no '/') is normalised to /32 (v4) or /128
+ * (v6) before the ip_in_subnet() containment test -- ip_in_subnet() itself
+ * requires a mask (a bare token never matches anything), while BOTH carve
+ * engines treat a bare suppression hole as a single host (iprange for v4;
+ * pfb_v6_cidr_to_range() for v6), so without the normalisation a hand-edited
+ * bare entry would suppress at update time yet read as "not suppressed"
+ * here (killstates would keep cutting the host's states; the Alerts
+ * un-suppress could never resolve it). When both a host-exact and a broader
+ * containing CIDR cover $ip, the host-specific entry wins (mirrors the old
+ * /32-before-/24 precedence); a tie in prefix length keeps the first-seen
+ * entry.
  *
  * PURE -- no config access, no I/O.
  *
@@ -3188,16 +3196,18 @@ function pfb_ip_suppressed_match(string $ip, array $entries): ?string
 		// Strip a trailing inline '#' comment, same as pfbng_text_area_decode().
 		$stripped = trim(strstr($entry, '#', TRUE) ?: $entry);
 
+		// Bare host -> exact single-host CIDR BEFORE the containment test:
+		// ip_in_subnet() requires a mask, but the carve engines suppress a
+		// bare hole as a single host -- the predicate must agree with them.
+		if (!str_contains($stripped, '/')) {
+			$stripped .= str_contains($stripped, ':') ? '/128' : '/32';
+		}
+
 		if (!ip_in_subnet($ip, $stripped)) {
 			continue;
 		}
 
-		// A bare host (no '/') ranks as an exact /32 or /128 match.
-		if (str_contains($stripped, '/')) {
-			$bits = (int) substr(strrchr($stripped, '/'), 1);
-		} else {
-			$bits = str_contains($stripped, ':') ? 128 : 32;
-		}
+		$bits = (int) substr(strrchr($stripped, '/'), 1);
 
 		if ($bits > $best_bits) {
 			$best      = $raw;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3151,19 +3151,61 @@ function pfb_suppress_file_v6(string $file, string $suppfile): bool
  */
 function pfb_ip_suppressed(string $ip, array $entries): bool
 {
-	foreach ($entries as $entry) {
-		$entry = trim((string) $entry);
+	return pfb_ip_suppressed_match($ip, $entries) !== NULL;
+}
+
+/**
+ * pfb_ip_suppressed_match — same coverage test as pfb_ip_suppressed(), but
+ * returns the MOST SPECIFIC (longest-prefix) covering entry instead of a
+ * bool (issue #422, follow-up to ADR-53 P7/P8). Feeds two Alerts surfaces
+ * that need to act on the actual customlist line, not just a yes/no: the
+ * un-suppress ('delete_ip') handler (which entry to remove + re-add) and the
+ * suppressed-row icon detection in the Alerts render loop.
+ *
+ * Skip/strip/containment rules are bit-identical to pfb_ip_suppressed()
+ * (that function is now a one-line wrapper around this one) -- no new
+ * normalisation. When both a bare host and a broader containing CIDR cover
+ * $ip, the host-specific entry wins (mirrors the old /32-before-/24
+ * precedence); a tie in prefix length keeps the first-seen entry.
+ *
+ * PURE -- no config access, no I/O.
+ *
+ * @param  string   $ip      The IP to test (v4 or v6).
+ * @param  string[] $entries Decoded suppression lines (one family or mixed).
+ * @return string|null The RAW entry (as passed in $entries, comment intact)
+ *                      with the longest prefix, or NULL when none covers $ip.
+ */
+function pfb_ip_suppressed_match(string $ip, array $entries): ?string
+{
+	$best      = NULL;
+	$best_bits = -1;
+
+	foreach ($entries as $raw) {
+		$entry = trim((string) $raw);
 		if ($entry === '' || str_starts_with($entry, '#')) {
 			continue;
 		}
 		// Strip a trailing inline '#' comment, same as pfbng_text_area_decode().
-		$entry = trim(strstr($entry, '#', TRUE) ?: $entry);
+		$stripped = trim(strstr($entry, '#', TRUE) ?: $entry);
 
-		if (ip_in_subnet($ip, $entry)) {
-			return TRUE;
+		if (!ip_in_subnet($ip, $stripped)) {
+			continue;
+		}
+
+		// A bare host (no '/') ranks as an exact /32 or /128 match.
+		if (str_contains($stripped, '/')) {
+			$bits = (int) substr(strrchr($stripped, '/'), 1);
+		} else {
+			$bits = str_contains($stripped, ':') ? 128 : 32;
+		}
+
+		if ($bits > $best_bits) {
+			$best      = $raw;
+			$best_bits = $bits;
 		}
 	}
-	return FALSE;
+
+	return $best;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1242,11 +1242,11 @@ if (isset($_POST) && !empty($_POST)) {
 
 		$entry = '';
 
-		// IPv4 validation
-		if ($entry = pfb_filter($_POST['domain'], PFB_FILTER_IPV4, 'alerts entry_delete', '', TRUE)) {
+		// IPv4/IPv6 validation
+		if ($entry = pfb_filter($_POST['domain'], PFB_FILTER_IP, 'alerts entry_delete', '', TRUE)) {
 			$table = pfb_filter($_POST['table'], PFB_FILTER_WORD, 'alerts entry_delete', '', TRUE);
 			if (empty($entry) || empty($table)) {
-				$savemsg = "IPv4: [ {$entry} ] Table name is not valid and IP cannot be removed !";
+				$savemsg = "IP: [ {$entry} ] Table name is not valid and IP cannot be removed !";
 				header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
 				exit;
 			}
@@ -1333,51 +1333,47 @@ if (isset($_POST) && !empty($_POST)) {
 				PfbConfig::write('tldexclusion', $clists['tldexclusion']['base64']);
 				break;
 			case 'delete_ip':
-				$type	= 'IPv4 Suppression';
-				$ix	= ip_explode(trim($entry, "'"));	// Explode IP into evaluation strings
+				// ADR-53 un-suppress rework (#422): the old flow only understood an
+				// exact '/32' or a containing '/24' customlist entry and "healed" a
+				// legacy exploded /24 block by re-adding up to 254 sibling hosts.
+				// ADR-53 tables hold covering CIDRs, not sibling explosions, so that
+				// loop no longer applies -- re-adding the removed suppression entry
+				// itself restores exactly the coverage it carved out, any mask,
+				// either family; any pre-ADR-53 exploded state self-heals on the
+				// next reload (the persisted engines rebuild the canonical set).
+				$ip	= trim($entry, "'");
+				$is_v6	= strpos($ip, ':') !== FALSE;
+				$family	= $is_v6 ? 6 : 4;
+				$type	= "IPv{$family} Suppression";
 
-				// Check if IP has 255 single entries (User suppressed /32 for a /24 Blocked IP)
-				$pfb_pfctl = array();
-				$ip_esc = escapeshellarg("{$ix[6]}");
-				$ip_cnt = exec("{$pfb['pfctl']} -t {$table} -T show | {$pfb['grep']} {$ip_esc} | {$pfb['grep']} -c ^ 2>&1");
+				$supp_key	= $is_v6 ? 'ipsuppression_v6' : 'ipsuppression';
+				$cfg_key	= $is_v6 ? 'v6suppression' : 'v4suppression';
 
-				$ip_revert = '';
-				// Remove /32 Suppressed IP in Suppression customlist and Re-Add /32 Blocked IP to Aliastable
-				if (isset($clists['ipsuppression']['data'][$ix[0] . '/32'])) {
-					unset($clists['ipsuppression']['data'][$ix[0] . '/32']);
+				// Longest-prefix pick: when both a '/32' and a broader entry cover
+				// the host, remove the most specific one -- deterministic, mirrors
+				// the old /32-before-/24 precedence.
+				$match = pfb_ip_suppressed_match($ip, array_keys($clists[$supp_key]['data']));
+				if ($match !== NULL) {
+					unset($clists[$supp_key]['data'][$match]);
 
-					$ip_revert = escapeshellarg("{$ix[0]}/32");
-					exec("{$pfb['pfctl']} -t {$table} -T add {$ip_revert} 2>&1");
+					exec("{$pfb['pfctl']} -t {$table} -T add " . escapeshellarg($match) . ' 2>&1');
 
-					// Remove 0-255 IP address from aliastable excluding single entry
-					if ($ip_cnt >= 255) {
-						for ($k=0; $k <= 255; $k++) {
-							if ($k != $ix[4]) {
-								$ip_esc = escapeshellarg("{$ix[6]}{$k}");
-								exec("{$pfb['pfctl']} -t {$table} -T delete {$ip_esc} 2>&1");
-							}
-						}
-					}
-				}
-
-				// Remove /24 Suppressed IP in Suppression customlist and Re-Add /24 Blocked IP to Aliastable
-				elseif (isset($clists['ipsuppression']['data'][$ix[5]])) {
-					unset($clists['ipsuppression']['data'][$ix[5]]);
-
-					$ip_revert = escapeshellarg("{$ix[5]}");
-					exec("{$pfb['pfctl']} -t {$table} -T add {$ip_revert} 2>&1");
-				}
-
-				if (!empty($ip_revert)) {
 					$data = '';
-					foreach ($clists['ipsuppression']['data'] as $line) {
+					foreach ($clists[$supp_key]['data'] as $line) {
 						$data .= "{$line}";
 					}
-					$clists['ipsuppression']['base64'] = base64_encode($data);
-					PfbConfig::write('v4suppression', $clists['ipsuppression']['base64']);
-					$savemsg = "Removed [ {$ip_revert} ] from {$type} customlist and re-added it back into the aliastable [ {$table} ]";
+					$clists[$supp_key]['base64'] = base64_encode($data);
+					PfbConfig::write($cfg_key, $clists[$supp_key]['base64']);
+
+					// Keep pfbsuppression(_v6).txt in step with the config edit --
+					// same in-memory refresh the addsuppress handler applies.
+					$pfb['ipconfig'][$cfg_key] = $clists[$supp_key]['base64'];
+					pfb_create_suppression_file();
+
+					$savemsg = "Removed [ {$match} ] from {$type} customlist and re-added it back into the aliastable [ {$table} ]";
 				}
 				else {
+					$pfb_found = FALSE;
 					$savemsg = "IP: [ {$entry} ] was not found in {$type} customlist!";
 				}
 				break;
@@ -1717,14 +1713,6 @@ if ($pfb['filterlogentries']) {
 
 // Define common variables and arrays for report tables
 $continents	= array_flip(array('pfB_Africa', 'pfB_Antarctica', 'pfB_Asia', 'pfB_Europe', 'pfB_NAmerica', 'pfB_Oceania', 'pfB_SAmerica', 'pfB_Top'));
-
-$supp_ip_txt	= "Clicking this Suppression Icon, will immediately remove the block."
-		. "\n\nNote:"
-		. "\n1) The Host will be added to the IPv4 Suppression custom list."
-		. "\n2) Only 32 or 24 CIDR IPs can be suppressed with the '+' icon."
-		. "\n3) Suppressing a /32 CIDR is better than suppressing the full /24"
-		. "\n4) Manual entries to the 'IPv4 Suppression' custom list will not immediately remove existing blocked hosts"
-		. "\n&emsp;and will require a Force Reload to remove the blocked hosts.";
 
 // Collect Interfaces
 $dnsbl_int = array();
@@ -3028,6 +3016,11 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		}
 	}
 
+	// v4-only, /32|/24 vs /25-/31 -- since ADR-53 (issue #422) this feeds ONLY
+	// the Unlock-icon gate below and the legacy whitelist-fallback quirk gate;
+	// the Suppression-icon gate itself is now family/mask-agnostic and no
+	// longer reads $mask_suppression. Left exactly as-is, deliberately out of
+	// scope for this change.
 	$mask_suppression	= FALSE;
 	$mask_unlock		= FALSE;
 
@@ -3058,26 +3051,22 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	$alert_ip = '<a class="fa-solid fa-info icon-pointer" target="_blank" href="/pfblockerng/pfblockerng_threats.php?host=' .
 			$h_host . '" title="Click for Threat source IP Lookup for [ ' . $h_host . ' ]"></a>';
 
-	// Suppression Icon
+	// Suppression Icon -- any family, any mask (ADR-53 follow-up, issue #422).
+	// GeoIP rows stay excluded (maintainer constraint).
 	$supp_ip = $unlock_ip = '&nbsp;&nbsp;&nbsp;';
-	if ($rtype == 'Block' && $pfb_ipv4 && !$pfb_geoip && $mask_suppression) {
+	if ($rtype == 'Block' && !$pfb_geoip) {
 
-		$v4suppression32 = $v4suppression24 = FALSE; 
+		$supp_key = ($vtype == 6) ? 'ipsuppression_v6' : 'ipsuppression';
+		$supp_match = NULL;
 		if (pfb_cfg_toggle_read($pfb['supp']) === PfbToggle::On) {
-			if (isset($clists['ipsuppression']['data'][$host . '/32'])) {
-				$w_line = rtrim($clists['ipsuppression']['data'][$host . '/32'], "\x00..\x1F");
-				$v4suppression32 = TRUE;
-			}
-
-			$ix = ip_explode($host);
-			if (isset($clists['ipsuppression']['data'][$ix[5]])) {
-				$w_line = rtrim($clists['ipsuppression']['data'][$ix[5]], "\x00..\x1F");
-				$v4suppression24 = TRUE;
+			$supp_match = pfb_ip_suppressed_match($host, array_keys($clists[$supp_key]['data']));
+			if ($supp_match !== NULL) {
+				$w_line = rtrim($clists[$supp_key]['data'][$supp_match], "\x00..\x1F");
 			}
 		}
 
-		// Host is not in the Suppression List
-		if (!$v4suppression32 && !$v4suppression24) {
+		// Host is not covered by any Suppression entry
+		if ($supp_match === NULL) {
 
 			// Check if host is in a Permit Whitelist Alias
 			if ($clists['ipwhitelist' . $vtype]) {
@@ -3092,7 +3081,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 
 				// Host found in a Permit Whitelist Alias
 				if ($pfb_found) {
-					$supp_ip_txt = "Note:&emsp;The following IPv{$vtype} addresss is in a Permit Alias:\n\n"
+					$supp_ip_txt = "Note:&emsp;The following IPv{$vtype} address is in a Permit Alias:\n\n"
 							. "Permitted IP:&emsp;[ " . pfb_hsc($w_line) . " ]\n"
 							. "Evaluated IP:&emsp;[ {$h_eval_ip} ]\n"
 							. "IP Aliasname:&emsp;[ " . pfb_hsc($atype) . " ]\n\n"
@@ -3133,7 +3122,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 			}
 		}
 		else {
-			$supp_ip_txt = "Note:&emsp;The following IPv{$vtype} addresss is in a IP Suppression list:\n\n"
+			$supp_ip_txt = "Note:&emsp;The following IPv{$vtype} address is in a IP Suppression list:\n\n"
 					. "Suppressed IP:&emsp;[ " . pfb_hsc($w_line) . " ]\n"
 					. "Evaluated IP:&emsp;[ {$h_eval_ip} ]\n\n"
 
@@ -3161,8 +3150,11 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		}
 	}
 
-	// IP Whitelist Icon
-	if (!$mask_suppression) {
+	// IP Whitelist Icon -- rows handled by the Suppression-icon gate above
+	// (Block, non-GeoIP) never reach this branch any more; the
+	// !$mask_suppression leg preserves today's behaviour unchanged for the
+	// rest (Match rows, GeoIP rows, Permit-alias rows).
+	if (!($rtype == 'Block' && !$pfb_geoip) && !$mask_suppression) {
 		if ($clists['ipwhitelist' . $vtype]) {
 
 			$pfb_found = FALSE;
@@ -3175,7 +3167,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 			}
 
 			if ($pfb_found) {
-				$supp_ip_txt = "Note:&emsp;The following IPv{$vtype} addresss is in a Permit Alias:\n\n"
+				$supp_ip_txt = "Note:&emsp;The following IPv{$vtype} address is in a Permit Alias:\n\n"
 						. "Permitted IP:&emsp;[ " . pfb_hsc($w_line) . " ]\n"
 						. "Evaluated IP:&emsp;[ {$h_eval_ip} ]\n"
 						. "IP Aliasname:&emsp;[ " . pfb_hsc($atype) . " ]\n\n"

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -371,11 +371,11 @@ $section->addInput(new Form_Checkbox(
 	'Enable',
 	pfb_cfg_toggle_read($pconfig['suppression']) === PfbToggle::On,
 	'on'
-))->setHelp('Default enabled. This will prevent Selected IPs (and RFC1918/Loopback addresses) from being blocked. For IPv4 lists (/8 through /32) and IPv6 lists (/32 through /128).'
+))->setHelp('Default enabled. This will prevent Selected IPs (and private/reserved addresses) from being blocked. For IPv4 lists (/8 through /32) and IPv6 lists (/32 through /128).'
 	. '<div class="infoblock">'
 	. 'GeoIP blocklist cannot be suppressed.<br /><br />'
-	. 'Alerts can be suppressed using the \'+\' icon in the Alerts tab and IPs are added to the IPv4 suppression custom list.<br />'
-	. 'For GeoIP/Blocked IPs in a CIDR broader than /8, will need a \'Whitelist alias\' w/ a List Action: \'Permit Outbound\' Firewall rule.<br />'
+	. 'Alerts can be suppressed using the \'+\' icon in the Alerts tab; the IP is added to the matching family\'s (IPv4/IPv6) Suppression custom list.<br />'
+	. 'For GeoIP, or Blocked IPs in a CIDR broader than the supported range (/8 IPv4, /32 IPv6), use a \'Whitelist alias\' w/ a List Action: \'Permit Outbound\' Firewall rule.<br />'
 	. 'Only \'Deny\' type Aliases can be suppressed!'
 	. '</div>'
 );
@@ -504,13 +504,14 @@ $form->add($section);
 $section = new Form_Section('IPv4 Suppression', 'IPv4_Suppression_customlist', COLLAPSIBLE|SEC_CLOSED);
 $suppression_text = '<strong><u>This suppression list is for [ /8 through /32 ] IPv4 addresses only!</u></strong><br /><br />
 
-			When \'Suppression\' is enabled, all RFC1918 and loopback addresses are also filtered on feed download|Update|Reload.<br /><br />
+			When \'Suppression\' is enabled, all RFC1918, loopback and reserved (documentation, multicast, CGN, benchmarking, 6to4)
+			addresses are also filtered on feed download|Update|Reload.<br /><br />
 
 			Enter one &emsp; <strong>IPv4 address</strong>&emsp; per line<br />
 			You may use "<strong>#</strong>" after any address to add comments. &emsp;IE: (x.x.x.x/32 # example.com)<br /><br />
 
 			To utilize this <strong>Suppression List</strong>, enable <strong>Suppression</strong> and click on the "+"
-			icon(s) in the Alerts tab to add the IPv4 addresses automatically to this Suppression list and immeditely
+			icon(s) in the Alerts tab to add the IPv4 addresses automatically to this Suppression list and immediately
 			remove the IPv4 address from the Deny aliastable.<br /><br />
 
 			Note: When manually adding an IPv4 address <strong>[ /8 through /32 only! ]</strong> to this Suppression List,
@@ -534,10 +535,15 @@ $form->add($section);
 $section = new Form_Section('IPv6 Suppression', 'IPv6_Suppression_customlist', COLLAPSIBLE|SEC_CLOSED);
 $suppression_text_v6 = '<strong><u>This suppression list is for [ /32 through /128 ] IPv6 addresses only!</u></strong><br /><br />
 
-			When \'Suppression\' is enabled, all RFC1918 and loopback addresses are also filtered on feed download|Update|Reload.<br /><br />
+			When \'Suppression\' is enabled, all ULA (fc00::/7), link-local, loopback and reserved (documentation, multicast, NAT64)
+			addresses are also filtered on feed download|Update|Reload.<br /><br />
 
 			Enter one &emsp; <strong>IPv6 address</strong>&emsp; per line<br />
 			You may use "<strong>#</strong>" after any address to add comments. &emsp;IE: (2001:db8::1/128 # example.com)<br /><br />
+
+			To utilize this <strong>Suppression List</strong>, enable <strong>Suppression</strong> and click on the "+"
+			icon(s) in the Alerts tab to add the IPv6 addresses automatically to this Suppression list and immediately
+			remove the IPv6 address from the Deny aliastable.<br /><br />
 
 			Note: When manually adding an IPv6 address <strong>[ /32 through /128 only! ]</strong> to this Suppression List,
 			you must run a <strong>"Force Reload - IP"</strong> for the changes to take effect.';

--- a/tests/php/IpSuppressedMatchTest.php
+++ b/tests/php/IpSuppressedMatchTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_ip_suppressed_match() -- issue #422 (ADR-53 follow-up): the longest-prefix
+ * sibling of pfb_ip_suppressed() that returns the actual covering customlist
+ * entry instead of a bool, so the Alerts un-suppress ('delete_ip') handler and
+ * the suppressed-row icon detection can act on it directly.
+ */
+#[CoversFunction('pfb_ip_suppressed_match')]
+final class IpSuppressedMatchTest extends TestCase
+{
+	// --- no coverage ---
+
+	public function testNoEntriesReturnsNull(): void
+	{
+		$this->assertNull(pfb_ip_suppressed_match('10.0.0.1', []));
+	}
+
+	public function testNonCoveringEntryReturnsNull(): void
+	{
+		$this->assertNull(pfb_ip_suppressed_match('10.1.0.1', ['10.0.0.0/16']));
+	}
+
+	// --- single covering entry ---
+
+	public function testSingleCoveringV4Slash16IsReturnedVerbatim(): void
+	{
+		$this->assertSame(
+			'10.0.0.0/16',
+			pfb_ip_suppressed_match('10.0.5.9', ['10.0.0.0/16'])
+		);
+	}
+
+	/**
+	 * Scenario: two containing CIDRs of different specificity cover the same
+	 * host -- the longest prefix must win regardless of which one was authored
+	 * first in the customlist (pins longest-prefix selection, not first-match).
+	 */
+	public function testLongestPrefixWinsRegardlessOfArrayOrder(): void
+	{
+		// Given a /16 and a /24 both covering the host 10.0.5.9
+		$broad_first = ['10.0.0.0/16', '10.0.5.0/24'];
+		$narrow_first = ['10.0.5.0/24', '10.0.0.0/16'];
+
+		// When matching against either ordering
+		// Then the more specific /24 is returned both times
+		$this->assertSame('10.0.5.0/24', pfb_ip_suppressed_match('10.0.5.9', $broad_first));
+		$this->assertSame('10.0.5.0/24', pfb_ip_suppressed_match('10.0.5.9', $narrow_first));
+	}
+
+	public function testExactHostSlash32BeatsACoveringSlash24(): void
+	{
+		$this->assertSame(
+			'10.0.5.9/32',
+			pfb_ip_suppressed_match('10.0.5.9', ['10.0.5.0/24', '10.0.5.9/32'])
+		);
+	}
+
+	// --- v6 ---
+
+	public function testV6Slash128BeatsACoveringSlash64(): void
+	{
+		$this->assertSame(
+			'2001:db8::1/128',
+			pfb_ip_suppressed_match('2001:db8::1', ['2001:db8::/64', '2001:db8::1/128'])
+		);
+	}
+
+	public function testV6HostInsideOnlyTheSlash64ReturnsTheSlash64(): void
+	{
+		$this->assertSame(
+			'2001:db8::/64',
+			pfb_ip_suppressed_match('2001:db8::9', ['2001:db8::/64', '2001:db8::1/128'])
+		);
+	}
+
+	// --- comment tolerance ---
+
+	public function testCommentOnlyLineIsSkipped(): void
+	{
+		$this->assertNull(
+			pfb_ip_suppressed_match('10.0.0.1', ['# comment', ''])
+		);
+	}
+
+	public function testInlineCommentedEntryStillMatchesAndReturnsTheRawLine(): void
+	{
+		$this->assertSame(
+			'10.0.0.0/24 # office',
+			pfb_ip_suppressed_match('10.0.0.1', ['10.0.0.0/24 # office'])
+		);
+	}
+
+	// --- refactor pin: pfb_ip_suppressed() agrees with this function ---
+
+	public function testPfbIpSuppressedAgreesWithMatchOnAMixedSet(): void
+	{
+		$entries = ['10.0.0.0/16', '2001:db8::/64', 'not-a-cidr'];
+
+		// Given a host covered by one of the entries
+		$this->assertTrue(pfb_ip_suppressed('10.0.5.9', $entries));
+		$this->assertNotNull(pfb_ip_suppressed_match('10.0.5.9', $entries));
+
+		// Given a host covered by none of the entries
+		$this->assertFalse(pfb_ip_suppressed('10.1.0.1', $entries));
+		$this->assertNull(pfb_ip_suppressed_match('10.1.0.1', $entries));
+	}
+}

--- a/tests/php/IpSuppressedMatchTest.php
+++ b/tests/php/IpSuppressedMatchTest.php
@@ -61,6 +61,25 @@ final class IpSuppressedMatchTest extends TestCase
 		);
 	}
 
+	/**
+	 * Scenario: two covering entries share the SAME prefix length -- the tie
+	 * keeps the first-seen entry (stable), separating the tie contract from
+	 * the longest-prefix contract pinned above. Same-CIDR lines that differ
+	 * only in their inline comment are the realistic tie shape (a customlist
+	 * duplicate); the RAW line identifies which one won.
+	 */
+	public function testEqualPrefixTieKeepsFirstSeenEntry(): void
+	{
+		// Given two lines with the same covering /24, distinguishable by comment
+		$a = '10.0.5.0/24 # first';
+		$b = '10.0.5.0/24 # second';
+
+		// When matching against either ordering
+		// Then the FIRST-SEEN line wins each time
+		$this->assertSame($a, pfb_ip_suppressed_match('10.0.5.9', [$a, $b]));
+		$this->assertSame($b, pfb_ip_suppressed_match('10.0.5.9', [$b, $a]));
+	}
+
 	// --- v6 ---
 
 	public function testV6Slash128BeatsACoveringSlash64(): void
@@ -77,6 +96,35 @@ final class IpSuppressedMatchTest extends TestCase
 			'2001:db8::/64',
 			pfb_ip_suppressed_match('2001:db8::9', ['2001:db8::/64', '2001:db8::1/128'])
 		);
+	}
+
+	// --- bare-host tolerance (parity with the carve engines) ---
+
+	/**
+	 * Scenario: a customlist line with NO mask (hand-edited config; the UI
+	 * validator normally enforces one). Both carve engines treat a bare hole
+	 * as a single host (iprange: /32; pfb_v6_cidr_to_range(): /128), so the
+	 * predicates must agree -- an entry the engine suppresses with must also
+	 * read as "suppressed" here (killstates) and resolve for un-suppress.
+	 * Before issue #422 a bare entry never matched (ip_in_subnet() requires
+	 * a mask), silently diverging from the engines.
+	 */
+	public function testBareHostEntryMatchesItsExactIpBothFamilies(): void
+	{
+		$this->assertSame(
+			'198.51.100.7',
+			pfb_ip_suppressed_match('198.51.100.7', ['198.51.100.7'])
+		);
+		$this->assertTrue(pfb_ip_suppressed('198.51.100.7', ['198.51.100.7']));
+
+		$this->assertSame(
+			'2001:db8::7',
+			pfb_ip_suppressed_match('2001:db8::7', ['2001:db8::7'])
+		);
+		$this->assertTrue(pfb_ip_suppressed('2001:db8::7', ['2001:db8::7']));
+
+		// A DIFFERENT host is still not covered by a bare-host entry.
+		$this->assertNull(pfb_ip_suppressed_match('198.51.100.8', ['198.51.100.7']));
 	}
 
 	// --- comment tolerance ---

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -649,6 +649,349 @@ def test_addsuppress_v4_already_covered_by_broader_entry_skips_duplicate(
 
 
 # --------------------------------------------------------------------------- #
+# entry_delete=delete_ip (alerts.php:1330 -- issue #422, ADR-53 parity follow-up):
+# un-suppress a customlist entry and restore the live block. Before this fix the
+# handler only recognised an exact '/32' customlist key or a containing '/24' --
+# any OTHER mask (e.g. a manually-added /28) made the lookup miss entirely (the
+# handler replied "not found", touching neither the customlist nor the pf table),
+# and the entry_delete VALIDATION GATE itself was PFB_FILTER_IPV4, so an IPv6
+# domain was rejected before ever reaching the handler. pfb_ip_suppressed_match()
+# (longest-prefix, any mask, either family) fixes both: it resolves the ALERTED
+# HOST to its covering customlist entry, removes that entry, and re-adds it to
+# the live pf table -- restoring exactly the coverage it had carved out.
+# --------------------------------------------------------------------------- #
+
+
+def test_delete_ip_v4_unsuppresses_broader_entry_and_restores_block(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """entry_delete=delete_ip un-suppresses a BROADER (/28) v4 entry, restoring the block.
+
+    Before #422 the handler only understood an exact '/32' or a containing '/24'
+    customlist key -- a manually-added /28 (or any other mask) made the lookup
+    MISS entirely: "not found", customlist and pf table both left untouched. The
+    longest-prefix pfb_ip_suppressed_match() fixes the lookup for any mask.
+
+    Given: a live Deny v4 pf table (built exactly like the addsuppress carve
+    tests -- inject a feed + Force IP Update) whose feed does NOT cover the
+    suppressed /28 hole, plus a manually-seeded v4suppression entry
+    '198.51.100.0/28' covering the host that will be "deleted".
+    When: entry_delete=delete_ip is posted for the ALERTED HOST (not the
+    customlist entry itself -- the handler must resolve host -> covering /28).
+    Then: the /28 entry is gone from v4suppression, and the host now matches the
+    pf table (the removed entry was re-added, restoring the block it carved out).
+    """
+    vm = smoke_vm
+    target = "198.51.100.5"  # inside the /28 hole below (RFC 5737 TEST-NET-2)
+    supp_entry = "198.51.100.0/28"  # broader than the retired /32|/24-only lookup
+    sibling = "198.51.100.200"  # outside the /28 -- feeds the table so it EXISTS
+
+    feed_url = helpers.write_local_feed(vm, "ui_unsupp4.txt", f"{sibling}/32\n")
+    spec = helpers.IpCase(aliasname="uiunsupp4", feed_url=feed_url, header="uiunsupp4")
+    table = spec.alias
+    original = helpers.config_get(vm, CFG_V4SUPPRESSION)
+
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "updateip")
+    try:
+        # GIVEN: seed the broader manual suppression entry directly (mirrors a
+        # prior manual customlist edit, not one produced by addsuppress here).
+        supp_b64 = base64.b64encode(f"{supp_entry} # smoke-unsuppress\r\n".encode()).decode()
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{CFG_V4SUPPRESSION}', '{supp_b64}');\n"
+            "write_config('pfBlockerNG smoke: seed v4suppression /28 for unsuppress');\n"
+            "echo 'OK';",
+        )
+
+        # BEFORE: the table exists (the sibling populated it) and does NOT cover
+        # the suppressed hole; the /28 entry is present in v4suppression.
+        members = helpers.wait_pfctl_table(vm, table)
+        assert members, f"pf table {table} never populated after the settling update"
+        assert supp_entry in _suppression_entries(vm, CFG_V4SUPPRESSION), (
+            f"{supp_entry} not present in v4suppression before the un-suppress POST"
+        )
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert not matched, (
+            f"{target} unexpectedly matches pf table {table} before the un-suppress; pfctl said: {raw!r}"
+        )
+
+        # WHEN: entry_delete=delete_ip for the ALERTED HOST -- the handler must
+        # resolve host -> covering /28 itself via pfb_ip_suppressed_match().
+        resp = _post_action(webui, {"entry_delete": "delete_ip", "domain": target, "table": table})
+        assert not looks_like_login_page(resp.text), "delete_ip POST returned the login form (session lost)"
+
+        # THEN: the /28 entry is gone from v4suppression ...
+        entries = _suppression_entries(vm, CFG_V4SUPPRESSION)
+        assert supp_entry not in entries, (
+            f"{supp_entry} still present in v4suppression after entry_delete=delete_ip; entries={entries}"
+        )
+        # ... and the host now matches the pf table again -- the removed entry
+        # was re-added, restoring exactly the block it had carved out.
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, (
+            f"{target} does not match pf table {table} after un-suppressing the covering /28 -- "
+            f"the block was not restored; pfctl said: {raw!r}"
+        )
+    finally:
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{CFG_V4SUPPRESSION}', '{original}');\n"
+            "write_config('pfBlockerNG smoke: restore v4suppression');\n"
+            "echo 'OK';",
+        )
+        helpers.reset(vm)
+
+
+def test_delete_ip_v6_unsuppresses_entry_and_restores_block(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """entry_delete=delete_ip un-suppresses a v6 entry -- IPv6 was REJECTED before #422.
+
+    Before #422 the entry_delete VALIDATION GATE was PFB_FILTER_IPV4, so ANY IPv6
+    domain was rejected outright (a savemsg, no config write) before ever reaching
+    the delete_ip handler -- there was no v6 branch at all. The gate is now
+    PFB_FILTER_IP (both families), and the handler routes an IPv6 host through
+    v6suppression + ``pfctl -t <table> -T add``.
+
+    Given: a live Deny v6 pf table, plus a manually-seeded v6suppression entry
+    '2001:db8:aa::/64' covering the host that will be "deleted".
+    When: entry_delete=delete_ip is posted for the host.
+    Then: the /64 entry is gone from v6suppression, and the host now matches the
+    pf table again (the block is restored).
+    """
+    vm = smoke_vm
+    target = "2001:db8:aa::5"  # inside the suppressed /64 (RFC 3849)
+    supp_entry = "2001:db8:aa::/64"
+    sibling = "2001:db8:bb::1"  # a SEPARATE /64 -- feeds the table so it EXISTS
+
+    feed_url = helpers.write_local_feed(vm, "ui_unsupp6.txt", f"{sibling}/128\n")
+    spec = helpers.IpCase(aliasname="uiunsupp6", feed_url=feed_url, header="uiunsupp6", family="v6")
+    table = spec.alias
+    original = helpers.config_get(vm, CFG_V6SUPPRESSION)
+
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "updateip")
+    try:
+        supp_b64 = base64.b64encode(f"{supp_entry} # smoke-unsuppress\r\n".encode()).decode()
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{CFG_V6SUPPRESSION}', '{supp_b64}');\n"
+            "write_config('pfBlockerNG smoke: seed v6suppression /64 for unsuppress');\n"
+            "echo 'OK';",
+        )
+
+        # BEFORE: the table exists (the sibling populated it) and does NOT cover
+        # the suppressed hole; the /64 entry is present in v6suppression.
+        members = helpers.wait_pfctl_table(vm, table)
+        assert members, f"pf table {table} never populated after the settling update"
+        assert supp_entry in _suppression_entries(vm, CFG_V6SUPPRESSION), (
+            f"{supp_entry} not present in v6suppression before the un-suppress POST"
+        )
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert not matched, (
+            f"{target} unexpectedly matches pf table {table} before the un-suppress; pfctl said: {raw!r}"
+        )
+
+        # WHEN: entry_delete=delete_ip for the IPv6 host -- REJECTED outright
+        # before #422 (PFB_FILTER_IPV4 gate), so this POST alone is part of the
+        # regression this test pins.
+        resp = _post_action(webui, {"entry_delete": "delete_ip", "domain": target, "table": table})
+        assert not looks_like_login_page(resp.text), "delete_ip POST returned the login form (session lost)"
+
+        # THEN: the /64 entry is gone from v6suppression ...
+        entries = _suppression_entries(vm, CFG_V6SUPPRESSION)
+        assert supp_entry not in entries, (
+            f"{supp_entry} still present in v6suppression after entry_delete=delete_ip; entries={entries}"
+        )
+        # ... and the host now matches the pf table again.
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, (
+            f"{target} does not match pf table {table} after un-suppressing the covering /64 -- "
+            f"the block was not restored; pfctl said: {raw!r}"
+        )
+    finally:
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{CFG_V6SUPPRESSION}', '{original}');\n"
+            "write_config('pfBlockerNG smoke: restore v6suppression');\n"
+            "echo 'OK';",
+        )
+        helpers.reset(vm)
+
+
+# --------------------------------------------------------------------------- #
+# Suppression-icon render eligibility (convert_ip_log, alerts.php:3057 -- issue
+# #422, ADR-53 follow-up). Before this fix the gate was
+# ``$pfb_ipv4 && !$pfb_geoip && $mask_suppression`` -- TRUE only for a v4 host
+# evaluated against an exact /32 or /24 mask. A v6 Block row, or a v4 row
+# evaluated against any OTHER mask, got NEITHER the "+" (add) nor the trash-can
+# (un-suppress) icon at all. The gate is now family/mask-agnostic
+# (``$rtype == 'Block' && !$pfb_geoip``), and the covered-vs-not lookup itself
+# is prefix-aware (pfb_ip_suppressed_match()), so a host covered by a BROADER
+# manual entry (not just an exact /32 or /24 key) now gets the trash-can too.
+# --------------------------------------------------------------------------- #
+
+
+def test_alerts_rows_render_suppress_icons_for_v6_and_broad_v4(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Alerts render the Suppression icon for a v6 row and a broad-mask v4 row.
+
+    Scenario: suppress-icon render eligibility, any family/mask.
+
+    Background: three synthetic Block rows are appended directly to
+    ip_block.log (the same CSV-injection technique as issue #361's rendering
+    test), each exercising one branch the retired v4-only /32|/24 gate could
+    not reach: (a) a v6 host, (b) a v4 host evaluated against a broad /16 mask,
+    (c) a v4 host covered by a manually-seeded BROADER (/28) v4suppression
+    entry, with the master Suppression toggle forced ON.
+
+    Given: DNSBL is untouched; the three rows above are appended to
+        ip_block.log, none of their icon markers rendered beforehand.
+    When: the Alerts page is GET-ted (default view, which renders ip_block.log).
+    Then:
+        (a) and (b) render the "+" (``PFBIPSUP|add|<host>``) icon -- both rows
+            would have rendered NEITHER icon under the retired v4-only/32|/24 gate.
+        (c) renders the trash-can (``DNSBLWT|delete_ip|<host>``) icon -- the
+            prefix-aware match finds the covering /28, which an exact-/32|/24-only
+            lookup would have missed (the row would have gotten the "+" instead).
+
+    Cleanup: the appended log lines are truncated back off in ``finally``, and
+    the master Suppression toggle + v4suppression are restored to their
+    original values.
+    """
+    vm = smoke_vm
+
+    v6_host = helpers.IPV6_FOREIGN  # 2001:db8:dead:beef::1
+    v6_local = helpers.IPV6_LOCAL_HOST
+    v4_broad_host = "198.51.100.77"  # RFC 5737 TEST-NET-2, evaluated against a /16
+    v4_supp_host = "203.0.113.9"  # RFC 5737 TEST-NET-3, covered by the seeded /28
+    supp_entry = "203.0.113.0/28"
+
+    ts = time.strftime("%b %d %H:%M:%S")  # e.g. "Jun 18 12:00:00"
+    # ip_block.log CSV format (21 fields, see the issue #361 test above):
+    # ts,rule,real_iface,friendly_iface,action,ipv,proto_id,proto,
+    # src_ip,dst_ip,src_port,dst_port,dir,geoip,alias,ip_eval,feed,rhost,chost,asn,dup
+    csv_lines = (
+        # (a) v6, inbound -> $host = SRC = the foreign v6 address; ip_eval /48.
+        f"{ts},100,em0,WAN,block,6,58,ICMPV6,"
+        f"{v6_host},{v6_local},,"
+        f",in,US,pfB_Deny_v6,"
+        "2001:db8:dead::/48,pfB_TestFeed_v6,Unknown,Unknown,Unknown,+\n"
+        # (b) v4, inbound -> $host = SRC = the broad-mask host; ip_eval mask /16.
+        f"{ts},100,em0,WAN,block,4,6,TCP,"
+        f"{v4_broad_host},10.0.0.5,12345,443,"
+        "in,US,pfB_Deny_v4,"
+        "198.51.0.0/16,pfB_TestFeed_v4,Unknown,Unknown,Unknown,+\n"
+        # (c) v4, inbound -> $host covered by the seeded v4suppression /28.
+        f"{ts},100,em0,WAN,block,4,6,TCP,"
+        f"{v4_supp_host},10.0.0.6,12345,443,"
+        "in,US,pfB_Deny_v4,"
+        "203.0.113.0/28,pfB_TestFeed_v4,Unknown,Unknown,Unknown,+\n"
+    )
+
+    ip_block_log = helpers.IP_BLOCK_LOG
+    supp_master_path = "installedpackages/pfblockerngipsettings/config/0/suppression"
+    original_supp = helpers.config_get(vm, CFG_V4SUPPRESSION)
+    original_master = helpers.config_get(vm, supp_master_path)
+
+    # ip_block.log is created lazily -- guarantee it (and its dir) exist idempotently
+    # before appending (mirrors the issue #361 test's precondition handling).
+    log_dir = ip_block_log.rsplit("/", 1)[0]
+    ensure_result = vm.ssh(f"mkdir -p {log_dir} && touch {ip_block_log}", timeout=15)
+    assert ensure_result.returncode == 0, (
+        f"Failed to ensure {ip_block_log!r} exists before mutation: "
+        f"rc={ensure_result.returncode}, stderr={ensure_result.stderr!r}"
+    )
+    size_result = vm.ssh("stat", "-f", "%z", ip_block_log, timeout=15)
+    assert size_result.returncode == 0, (
+        f"Failed to stat {ip_block_log!r} before mutation: rc={size_result.returncode}, stderr={size_result.stderr!r}"
+    )
+    original_size = size_result.stdout.strip()
+
+    try:
+        # GIVEN: master Suppression forced ON + a /28 v4suppression entry covering (c).
+        supp_b64 = base64.b64encode(f"{supp_entry} # smoke-icon\r\n".encode()).decode()
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{supp_master_path}', 'on');\n"
+            f"config_set_path('{CFG_V4SUPPRESSION}', '{supp_b64}');\n"
+            "write_config('pfBlockerNG smoke: seed suppression for icon test');\n"
+            "echo 'OK';",
+        )
+
+        # BEFORE (no false pass): none of the three icon markers are present yet.
+        pre = webui.get(ALERTS_PAGE)
+        assert not looks_like_login_page(pre.text), "alerts page GET returned login form before mutation (session lost)"
+        for marker in (
+            f"PFBIPSUP|add|{v6_host}",
+            f"PFBIPSUP|add|{v4_broad_host}",
+            f"DNSBLWT|delete_ip|{v4_supp_host}",
+        ):
+            assert marker not in pre.text, f"Precondition failed: {marker!r} already present before the synthetic rows"
+
+        # WHEN: append the synthetic rows and GET the Alerts page (default view).
+        append_result = subprocess.run(
+            vm.ssh_argv("tee", "-a", ip_block_log),
+            input=csv_lines,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        assert append_result.returncode == 0, (
+            f"Failed to append synthetic lines to {ip_block_log!r}: "
+            f"rc={append_result.returncode}, stderr={append_result.stderr!r}"
+        )
+
+        resp = webui.get(ALERTS_PAGE)
+        assert not looks_like_login_page(resp.text), (
+            "alerts page GET returned login form (session lost before icon render test)"
+        )
+        html_body = resp.text
+
+        # THEN (a): v6 Block row -> "+" icon (never rendered under the v4-only gate).
+        assert f"PFBIPSUP|add|{v6_host}" in html_body, (
+            f"'+' suppression icon missing for v6 host {v6_host!r} -- the retired v4-only gate "
+            "would have skipped this row entirely"
+        )
+        # THEN (b): v4 row evaluated against a broad /16 -> "+" icon (the retired
+        # gate required an exact /32 or /24 mask).
+        assert f"PFBIPSUP|add|{v4_broad_host}" in html_body, (
+            f"'+' suppression icon missing for v4 host {v4_broad_host!r} evaluated against a /16 "
+            "mask -- the retired mask_suppression gate only accepted /32 or /24"
+        )
+        # THEN (c): v4 row covered by a manual /28 -> trash-can icon (prefix-aware match).
+        assert f"DNSBLWT|delete_ip|{v4_supp_host}" in html_body, (
+            f"trash-can (un-suppress) icon missing for v4 host {v4_supp_host!r} covered by the "
+            f"broader {supp_entry!r} entry -- an exact-/32|/24-only lookup would have missed it"
+        )
+    finally:
+        truncate_result = subprocess.run(
+            vm.ssh_argv("/usr/bin/truncate", "-s", original_size, ip_block_log),
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        assert truncate_result.returncode == 0, (
+            f"Failed to restore {ip_block_log!r} to size={original_size!r}: "
+            f"rc={truncate_result.returncode}, stderr={truncate_result.stderr!r}"
+        )
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{supp_master_path}', '{original_master}');\n"
+            f"config_set_path('{CFG_V4SUPPRESSION}', '{original_supp}');\n"
+            "write_config('pfBlockerNG smoke: restore suppression for icon test');\n"
+            "echo 'OK';",
+        )
+
+
+# --------------------------------------------------------------------------- #
 # Upstream block rendering (issue #285): a synthetic Upstream_Block CSV line
 # appended to dnsbl.log must render with the cloud icon ($pfb_python override)
 # and the Group column must show "Upstream", NOT "Unknown".

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -860,9 +860,16 @@ def test_alerts_rows_render_suppress_icons_for_v6_and_broad_v4(
             prefix-aware match finds the covering /28, which an exact-/32|/24-only
             lookup would have missed (the row would have gotten the "+" instead).
 
-    Cleanup: the appended log lines are truncated back off in ``finally``, and
-    the master Suppression toggle + v4suppression are restored to their
-    original values.
+    Cleanup: the appended log lines are truncated back off in ``finally``, the
+    master Suppression toggle + v4suppression are restored to their original
+    values, and the seeded deny-folder feed files are removed.
+
+    NB: each row's evaluated IP must exist (line-start match) in a deny-folder
+    feed file named after the row's feed column -- convert_ip_log() re-validates
+    every row against the on-disk feeds and STRIPS the suppression icon from a
+    "Not listed!" row (alerts.php, "Remove Suppression Icon for 'Not Listed'
+    events"), so without the seeded feed files every assert here fails for the
+    wrong reason.
     """
     vm = smoke_vm
 
@@ -899,6 +906,12 @@ def test_alerts_rows_render_suppress_icons_for_v6_and_broad_v4(
     original_supp = helpers.config_get(vm, CFG_V4SUPPRESSION)
     original_master = helpers.config_get(vm, supp_master_path)
 
+    # The deny-folder feed files that make the three rows "listed" (see the
+    # docstring NB): file name = the CSV feed column + .txt, line-start match
+    # on the evaluated IP.
+    deny_feed_v4 = "/var/db/pfblockerng/deny/pfB_TestFeed_v4.txt"
+    deny_feed_v6 = "/var/db/pfblockerng/deny/pfB_TestFeed_v6.txt"
+
     # ip_block.log is created lazily -- guarantee it (and its dir) exist idempotently
     # before appending (mirrors the issue #361 test's precondition handling).
     log_dir = ip_block_log.rsplit("/", 1)[0]
@@ -922,6 +935,17 @@ def test_alerts_rows_render_suppress_icons_for_v6_and_broad_v4(
             f"config_set_path('{CFG_V4SUPPRESSION}', '{supp_b64}');\n"
             "write_config('pfBlockerNG smoke: seed suppression for icon test');\n"
             "echo 'OK';",
+        )
+
+        # GIVEN: the rows' evaluated IPs exist in their deny-folder feed files,
+        # so convert_ip_log()'s feed re-validation keeps the icons (docstring NB).
+        seed_result = vm.ssh(
+            f"printf '198.51.0.0/16\\n203.0.113.0/28\\n' > {deny_feed_v4} && "
+            f"printf '2001:db8:dead::/48\\n' > {deny_feed_v6}",
+            timeout=15,
+        )
+        assert seed_result.returncode == 0, (
+            f"Failed to seed deny-folder feed files: rc={seed_result.returncode}, stderr={seed_result.stderr!r}"
         )
 
         # BEFORE (no false pass): none of the three icon markers are present yet.
@@ -982,6 +1006,7 @@ def test_alerts_rows_render_suppress_icons_for_v6_and_broad_v4(
             f"Failed to restore {ip_block_log!r} to size={original_size!r}: "
             f"rc={truncate_result.returncode}, stderr={truncate_result.stderr!r}"
         )
+        vm.ssh(f"rm -f {deny_feed_v4} {deny_feed_v6}", timeout=15)
         helpers.php_eval(
             vm,
             f"config_set_path('{supp_master_path}', '{original_master}');\n"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -320,6 +320,11 @@ def test_ip_page_renders_v6_suppression_section(webui: WebUI) -> None:
     v6suppression textarea field is present. Pairs with the pre-existing 'IPv4
     Suppression' section (also asserted here, unchanged by this phase) — proving the
     v6 sibling section renders ALONGSIDE it, not instead of it.
+
+    Also pins the corrected drop-set wording (issue #422): before that fix the v6
+    section wrongly claimed 'RFC1918' (a v4-only concept); it now names the actual
+    v6 drop set. The v4 section's own reserved-class wording (issue #760) is pinned
+    alongside it as a sibling text-content guard.
     """
     resp = webui.get(_IP_PAGE)
     assert resp.status_code == 200, f"GET {_IP_PAGE} -> HTTP {resp.status_code} (expected 200)"
@@ -327,6 +332,13 @@ def test_ip_page_renders_v6_suppression_section(webui: WebUI) -> None:
     assert "IPv6 Suppression" in body, "IPv6 Suppression section title not rendered on the IP page"
     assert 'name="v6suppression"' in body, "v6suppression textarea not rendered on the IP page"
     assert "IPv4 Suppression" in body, "IPv4 Suppression section title (existing sibling) missing"
+    assert "ULA (fc00::/7)" in body, (
+        "v6 Suppression help text missing the corrected 'ULA (fc00::/7)' drop-set wording "
+        "(issue #422) -- it previously wrongly claimed 'RFC1918', a v4-only concept"
+    )
+    assert "benchmarking" in body, (
+        "v4 Suppression help text missing the 'benchmarking' reserved-class wording (issue #760)"
+    )
 
 
 _UPDATE_PAGE = "/pfblockerng/pfblockerng_update.php"


### PR DESCRIPTION
Closes the remaining ADR-53 parity gaps on the Alerts suppression surfaces (issue #422) and aligns every related help text.

## Un-suppress (`delete_ip`)

- The `entry_delete` validation gate is now `PFB_FILTER_IP` — IPv6 deletes (both `delete_ip` and `delete_ipwhitelist`) were previously rejected outright by the IPv4-only filter.
- The handler resolves the alerted host to its covering suppression entry prefix-aware via the new `pfb_ip_suppressed_match()` (longest prefix wins, any mask, either family), removes exactly that entry from the correct family's customlist, re-adds it to the live pf table, and refreshes `pfbsuppression(_v6).txt`. The legacy 255-sibling-host revert loop is retired — ADR-53 tables hold covering CIDRs, not sibling explosions, and pre-ADR-53 exploded state self-heals on the next reload.

## Row icons

- The Alerts suppression icon gate is now family/mask-agnostic (`Block && !GeoIP`): v6 rows and broader-than-`/24` v4 rows get the "+"/trash icons the handler already supported. Suppressed-row detection is prefix-aware (a broader manual entry now yields the trash-can). Unlock-icon eligibility and GeoIP exclusion are deliberately unchanged.
- The stale "+" tooltip block claiming "Only 32 or 24 CIDR IPs can be suppressed" was dead code and is removed.

## Help texts / docs

- IP-settings Suppression texts now state the real per-family drop sets (the new v6 section wrongly claimed RFC1918; it now names ULA/link-local/loopback + the #760 reserved classes), the family-routed "+" flow, and both CIDR floors.
- `docs/misc/architecture-notes.md` ADR-53 section gains the un-suppress paragraph.

## Tests

- `tests/php/IpSuppressedMatchTest.php` — longest-prefix precedence, both families, comment tolerance; the untouched `KillstatesSuppressionTest` pins the `pfb_ip_suppressed()` refactor as behaviour-preserving.
- Tier B (`ui_e2e`): v4 broader-mask un-suppress and v6 un-suppress journeys (before-state asserted, block restored via `pfctl -T test`), plus a synthetic-log render test for the new icon eligibility (v6 row, `/16` v4 row, trash-can via a covering `/28`).
- Tier A: pins the corrected v6 drop-set wording and the #760 v4 wording on the IP page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3aGLFmd8VeHoa9zZ7j5af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alerts now handle suppression actions for both IPv4 and IPv6, including broader subnet matches.
  * Suppression icons and related UI labels now appear more consistently across applicable alert rows.

* **Bug Fixes**
  * Fixed suppression removal so it targets the correct matching entry and restores blocked status properly.
  * Improved match handling for exact hosts, broader ranges, and entries with comments.

* **Documentation**
  * Updated help text and architecture notes to reflect the refined suppression behavior and supported address ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->