### PR TITLE
tests: smoke/UI reliability — validated per-test fixes (#582)

### DIFF
--- a/scripts/bench_pfctl_tables.sh
+++ b/scripts/bench_pfctl_tables.sh
@@ -21,6 +21,7 @@
 # Usage (each sub-command is called by the Python driver):
 #   bench_pfctl_tables.sh system_info
 #   bench_pfctl_tables.sh raise_limits [MAX]
+#   bench_pfctl_tables.sh restore_limits          (also run automatically by cleanup)
 #   bench_pfctl_tables.sh gen N
 #   bench_pfctl_tables.sh replace N
 #   bench_pfctl_tables.sh delta N CHURN BATCH  (BATCH=0 = single-giant-op)
@@ -39,6 +40,7 @@ PFCTL=/sbin/pfctl
 PERL=/usr/local/bin/perl
 TMP=/tmp/pfb_bench
 TABLE=pfb_bench_main
+LIMITS_SNAPSHOT="${TMP}/orig_limits.txt"
 
 mkdir -p "${TMP}"
 
@@ -124,12 +126,39 @@ do_system_info() {
 
 do_raise_limits() {
     _limit="${1:-10000000}"
+    # Snapshot the PRE-bench values exactly once: a test sweep calls raise_limits
+    # repeatedly (once per test body sharing this guest), and re-snapshotting on a
+    # later call would capture an already-raised value, so do_cleanup's restore
+    # would never actually return the box to its true baseline. First call wins.
+    if [ ! -f "${LIMITS_SNAPSHOT}" ]; then
+        _orig_maxcount=$(sysctl -n net.pf.request_maxcount 2>/dev/null || echo unknown)
+        _orig_table_entries=$("${PFCTL}" -sm 2>/dev/null | awk '/table-entries/{print $NF}')
+        [ -z "${_orig_table_entries}" ] && _orig_table_entries=unknown
+        printf 'orig_maxcount=%s\norig_table_entries=%s\n' "${_orig_maxcount}" "${_orig_table_entries}" \
+            > "${LIMITS_SNAPSHOT}"
+    fi
     sysctl "net.pf.request_maxcount=${_limit}" >/dev/null 2>&1 || true
     printf 'set limit table-entries %s\n' "${_limit}" | "${PFCTL}" -mf - 2>/dev/null || true
     printf 'raised_limit=%s\n' "${_limit}"
     _tl=$("${PFCTL}" -sm 2>/dev/null | awk '/table-entries/{print $NF}' || echo unknown)
     printf 'pf_table_limit=%s\n' "${_tl}"
     printf 'net_pf_request_maxcount=%s\n' "$(sysctl -n net.pf.request_maxcount 2>/dev/null || echo unknown)"
+}
+
+# Restore net.pf.request_maxcount + pf table-entries limit to the pre-raise_limits
+# baseline captured in LIMITS_SNAPSHOT. Idempotent no-op when nothing was ever raised
+# (snapshot absent) — do_cleanup calls this unconditionally.
+do_restore_limits() {
+    [ -f "${LIMITS_SNAPSHOT}" ] || return 0
+    _orig_maxcount=$(awk -F= '/^orig_maxcount=/{print $2}' "${LIMITS_SNAPSHOT}")
+    _orig_table_entries=$(awk -F= '/^orig_table_entries=/{print $2}' "${LIMITS_SNAPSHOT}")
+    if [ -n "${_orig_maxcount}" ] && [ "${_orig_maxcount}" != "unknown" ]; then
+        sysctl "net.pf.request_maxcount=${_orig_maxcount}" >/dev/null 2>&1 || true
+    fi
+    if [ -n "${_orig_table_entries}" ] && [ "${_orig_table_entries}" != "unknown" ]; then
+        printf 'set limit table-entries %s\n' "${_orig_table_entries}" | "${PFCTL}" -mf - 2>/dev/null || true
+    fi
+    printf 'restored_maxcount=%s restored_table_entries=%s\n' "${_orig_maxcount}" "${_orig_table_entries}"
 }
 
 # Generate N unique synthetic IPv4s into /tmp/pfb_bench/table_N.txt.
@@ -314,6 +343,8 @@ do_recompute() {
 
 do_cleanup() {
     "${PFCTL}" -t "${TABLE}" -T kill 2>/dev/null || true
+    # Restore BEFORE wiping TMP: the limits snapshot lives inside it.
+    do_restore_limits
     rm -rf "${TMP}"
     printf 'cleaned=ok\n'
 }
@@ -488,19 +519,20 @@ do_verify_reject() {
 # --------------------------------------------------------------------------- #
 
 case "${1:-}" in
-    system_info)    do_system_info ;;
-    raise_limits)   do_raise_limits "${2:-10000000}" ;;
-    gen)            do_gen "${2:?missing N}" ;;
-    replace)        do_replace "${2:?missing N}" ;;
-    delta)          do_delta "${2:?missing N}" "${3:?missing CHURN}" "${4:?missing BATCH}" ;;
-    recompute)      do_recompute "${2:?missing N}" ;;
-    get_interfaces) do_get_interfaces ;;
-    setup_rules)    do_setup_rules "${2:-floating}" ;;
-    teardown_rules) do_teardown_rules ;;
-    verify_reject)  do_verify_reject ;;
-    cleanup)        do_cleanup ;;
+    system_info)     do_system_info ;;
+    raise_limits)    do_raise_limits "${2:-10000000}" ;;
+    restore_limits)  do_restore_limits ;;
+    gen)             do_gen "${2:?missing N}" ;;
+    replace)         do_replace "${2:?missing N}" ;;
+    delta)           do_delta "${2:?missing N}" "${3:?missing CHURN}" "${4:?missing BATCH}" ;;
+    recompute)       do_recompute "${2:?missing N}" ;;
+    get_interfaces)  do_get_interfaces ;;
+    setup_rules)     do_setup_rules "${2:-floating}" ;;
+    teardown_rules)  do_teardown_rules ;;
+    verify_reject)   do_verify_reject ;;
+    cleanup)         do_cleanup ;;
     *)
-        printf 'usage: bench_pfctl_tables.sh <system_info|raise_limits [MAX]|gen N|replace N|delta N CHURN BATCH|recompute N|get_interfaces|setup_rules [lan_if|floating]|teardown_rules|verify_reject|cleanup>\n' >&2
+        printf 'usage: bench_pfctl_tables.sh <system_info|raise_limits [MAX]|restore_limits|gen N|replace N|delta N CHURN BATCH|recompute N|get_interfaces|setup_rules [lan_if|floating]|teardown_rules|verify_reject|cleanup>\n' >&2
         exit 2
         ;;
 esac

--- a/tests/smoke/test_bench_pfctl.py
+++ b/tests/smoke/test_bench_pfctl.py
@@ -1942,7 +1942,6 @@ def test_pfctl_replace_disruption_baseline(
     verify_samples_disrupt = _parse_tcp_probe_output(verify_result.stdout).samples
     if not verify_samples_disrupt:
         _bench(smoke_vm, "teardown_rules", timeout=30.0)
-        _bench(smoke_vm, "cleanup", timeout=30.0)
         pytest.skip(
             f"TCP RST probe returned no samples — reject loop not working. "
             f"stdout={verify_result.stdout!r} rc={verify_result.returncode}. STOP."
@@ -1955,7 +1954,6 @@ def test_pfctl_replace_disruption_baseline(
     )
     if verify_p99 > 100.0:
         _bench(smoke_vm, "teardown_rules", timeout=30.0)
-        _bench(smoke_vm, "cleanup", timeout=30.0)
         pytest.skip(f"RST p99={verify_p99:.1f}ms > 100ms — reject loop too slow. STOP.")
     print(f"  VERIFY PASSED: RST p99={verify_p99:.2f}ms")
 
@@ -1965,7 +1963,6 @@ def test_pfctl_replace_disruption_baseline(
         print("  SSH control path: ok")
     except Exception as exc:
         _bench(smoke_vm, "teardown_rules", timeout=30.0)
-        _bench(smoke_vm, "cleanup", timeout=30.0)
         pytest.skip(f"SSH to pfSense lost after loading reject rules: {exc} — STOP.")
 
     # ------------------------------------------------------------------ #

--- a/tests/smoke/test_bench_pfctl.py
+++ b/tests/smoke/test_bench_pfctl.py
@@ -1057,6 +1057,7 @@ def test_pfctl_bench(
     smoke_vm: SmokeVM,
     lan_interface: SmokeVM,
     client_vm: SmokeVM,
+    request: pytest.FixtureRequest,
 ) -> None:
     """ADR-40 Phase 2: broad-matrix pfctl replace vs chunked delta + recompute.
 
@@ -1076,6 +1077,10 @@ def test_pfctl_bench(
 
     kv = _bench(smoke_vm, "raise_limits", "10000000")
     print(f"  pf table limit raised to: {kv.get('pf_table_limit')}")
+    # Guarantees the 1M-entry table + raised sysctl/pf limits are torn down even if a
+    # sweep iteration below throws — a bare end-of-function cleanup call never runs on
+    # a mid-sweep failure (issue #582). Runs during test teardown regardless of outcome.
+    request.addfinalizer(lambda: _bench(smoke_vm, "cleanup", timeout=30.0))
 
     for sz in _SIZES:
         kv = _bench(smoke_vm, "gen", str(sz), timeout=120.0)
@@ -1134,7 +1139,6 @@ def test_pfctl_bench(
         print(f"\n[bench] op=recompute size={row.size:,} wall_ms={row.wall_ms:,}")
 
     _print_summary(rows)
-    _bench(smoke_vm, "cleanup", timeout=30.0)
 
     assert rows, "expected at least one benchmark row"
 
@@ -1174,6 +1178,7 @@ def test_pfctl_knee_sweep(
     smoke_vm: SmokeVM,
     lan_interface: SmokeVM,
     client_vm: SmokeVM,
+    request: pytest.FixtureRequest,
 ) -> None:
     """ADR-40 production-calibrated batch-size knee sweep with pooled distributions.
 
@@ -1204,6 +1209,10 @@ def test_pfctl_knee_sweep(
 
     kv = _bench(smoke_vm, "raise_limits", "10000000")
     print(f"  pf table limit: {kv.get('pf_table_limit')}")
+    # Guarantees the 1M-entry table + raised sysctl/pf limits are torn down even if a
+    # sweep cell below throws — a bare end-of-function cleanup call never runs on a
+    # mid-sweep failure (issue #582). Runs during test teardown regardless of outcome.
+    request.addfinalizer(lambda: _bench(smoke_vm, "cleanup", timeout=30.0))
 
     # Generate all needed tables (gen is idempotent/cached).
     for sz in _KNEE_SIZES:
@@ -1363,8 +1372,6 @@ def test_pfctl_knee_sweep(
         f"\nBaseline addr block: 11.0.0.0/8; add block: 13.0.0.0/8 (disjoint)."
     )
 
-    _bench(smoke_vm, "cleanup", timeout=30.0)
-
     assert knee_stats, "expected at least one knee measurement"
 
 
@@ -1399,6 +1406,7 @@ def test_pfctl_reject_loop(
     smoke_vm: SmokeVM,
     lan_interface: SmokeVM,
     client_vm: SmokeVM,
+    request: pytest.FixtureRequest,
 ) -> None:
     """ADR-40 definitive data-plane bench: reject-based closed measurement loop.
 
@@ -1463,6 +1471,10 @@ def test_pfctl_reject_loop(
 
     kv = _bench(smoke_vm, "raise_limits", "10000000")
     print(f"  pf table limit: {kv.get('pf_table_limit')}")
+    # Guarantees the 1M-entry table + raised sysctl/pf limits are torn down even if a
+    # sweep cell below throws — a bare end-of-function cleanup call never runs on a
+    # mid-sweep failure (issue #582). Runs during test teardown regardless of outcome.
+    request.addfinalizer(lambda: _bench(smoke_vm, "cleanup", timeout=30.0))
 
     # Generate tables.
     for sz in sorted({s for s, _ in _REJECT_KNEE_CELLS} | set(_REJECT_KNEE_SIZES)):
@@ -1744,8 +1756,6 @@ def test_pfctl_reject_loop(
         f"\n{_REJECT_REPS} reps per cell | op-aligned windows (CR#12)."
     )
 
-    _bench(smoke_vm, "cleanup", timeout=30.0)
-
     assert verify_samples, "expected at least one TCP RST sample in verification"
 
 
@@ -1854,6 +1864,7 @@ def test_pfctl_replace_disruption_baseline(
     smoke_vm: SmokeVM,
     lan_interface: SmokeVM,
     client_vm: SmokeVM,
+    request: pytest.FixtureRequest,
 ) -> None:
     """ADR-40 follow-up: replace-only service-disruption baseline across table sizes.
 
@@ -1900,6 +1911,12 @@ def test_pfctl_replace_disruption_baseline(
 
     kv = _bench(smoke_vm, "raise_limits", "10000000")
     print(f"  pf table limit: {kv.get('pf_table_limit')}")
+    # Guarantees the 1M-entry table + raised sysctl/pf limits are torn down even if a
+    # sweep rep below throws — a bare end-of-function cleanup call never runs on a
+    # mid-sweep failure (issue #582). Runs during test teardown regardless of outcome
+    # (the explicit pre-skip cleanup calls below stay — this is the catch-all for
+    # everything past them: the main measurement loop had no cleanup at all before).
+    request.addfinalizer(lambda: _bench(smoke_vm, "cleanup", timeout=30.0))
 
     # Generate all needed tables (idempotent).
     for sz in _REPLACE_DISRUPT_SIZES:
@@ -2100,8 +2117,6 @@ def test_pfctl_replace_disruption_baseline(
         q_ps = quiet_stats[sz]
         print(f"{sz:>9,} {q_ps.n:>6} {q_ps.p50_ms:>8.2f} {q_ps.p95_ms:>8.2f} {q_ps.p99_ms:>8.2f} {q_ps.max_ms:>8.2f}")
 
-    _bench(smoke_vm, "cleanup", timeout=30.0)
-
     # Final assertions: data was collected.
     assert any(size_stats[sz].n > 0 for sz in _REPLACE_DISRUPT_SIZES), (
         "expected non-empty pooled samples for at least one size"
@@ -2146,6 +2161,7 @@ def test_pfctl_disruption_uncensored(
     smoke_vm: SmokeVM,
     lan_interface: SmokeVM,
     client_vm: SmokeVM,
+    request: pytest.FixtureRequest,
 ) -> None:
     """ADR-40 02c: uncensored disruption magnitudes — replace vs delta.
 
@@ -2209,6 +2225,10 @@ def test_pfctl_disruption_uncensored(
 
     kv = _bench(smoke_vm, "raise_limits", "10000000")
     print(f"  pf table limit: {kv.get('pf_table_limit')}")
+    # Guarantees the 1M-entry table + raised sysctl/pf limits are torn down even if a
+    # sweep rep below throws — a bare end-of-function cleanup call never runs on a
+    # mid-sweep failure (issue #582). Runs during test teardown regardless of outcome.
+    request.addfinalizer(lambda: _bench(smoke_vm, "cleanup", timeout=30.0))
 
     # Generate all needed tables.
     all_sizes = sorted(set(_UNCENSORED_REPLACE_SIZES) | {s for s, _, _, _ in _UNCENSORED_DELTA_CELLS})
@@ -2504,7 +2524,5 @@ def test_pfctl_disruption_uncensored(
         "\n  loss is pooled per RUN (not attributed to this start-time slice), by design."
         f"\n{_UNCENSORED_REPS} reps per cell | op-aligned."
     )
-
-    _bench(smoke_vm, "cleanup", timeout=30.0)
 
     assert any(replace_ps[sz].n > 0 for sz in _UNCENSORED_REPLACE_SIZES), "expected non-empty pooled replace samples"

--- a/tests/smoke/test_dns_redirect.py
+++ b/tests/smoke/test_dns_redirect.py
@@ -312,7 +312,12 @@ def _redir_match_report(vm: SmokeVM, iface: str, *, expected_present: bool, time
     else:
         actual = [ln.strip() for ln in result.stdout.splitlines() if "rdr" in ln and dev and dev in ln]
     want = "PRESENT (both protocols)" if expected_present else "ABSENT (no protocol)"
-    matched = _pfctl_sn_redir_protos(vm, iface, timeout=timeout)
+    # This report renders INSIDE a failing assert's message — a transient pfctl error on
+    # this second read must fold into the report, not replace it with a bare RuntimeError.
+    try:
+        matched: set[str] | str = _pfctl_sn_redir_protos(vm, iface, timeout=timeout)
+    except RuntimeError as exc:
+        matched = f"<unreadable: {exc}>"
     body = "\n".join(f"      {ln}" for ln in actual) if actual else "      (no rdr rules on this device)"
     return (
         f"  Expecting a pfBlockerNG DNS-redirect rdr rule to be {want} in the live nat ruleset:\n"

--- a/tests/smoke/test_dns_redirect.py
+++ b/tests/smoke/test_dns_redirect.py
@@ -259,12 +259,19 @@ def _pfctl_sn_redir_protos(vm: SmokeVM, iface: str, *, timeout: float = 30.0) ->
 
     so the redirect hallmark is the ``to ! (self)`` self-exemption on the resolved device,
     with the port rendered as ``domain`` (or numerically, defensively).
+
+    Raises ``RuntimeError`` when ``pfctl -sn`` itself fails (rc != 0) — an ERROR is NOT
+    the same as "no rule loaded", and collapsing the two previously made a broken pfctl
+    read false-green every negative/absence gate built on this function.
     """
     dev = _real_iface(vm, iface)
     result = vm.ssh(h.PFCTL, "-sn", timeout=timeout)
-    protos: set[str] = set()
     if result.returncode != 0:
-        return protos
+        raise RuntimeError(
+            f"{h.PFCTL} -sn failed (rc={result.returncode}): stderr={result.stderr!r} — "
+            f"cannot determine the redirect rule state on {iface!r}; NOT treating as absent"
+        )
+    protos: set[str] = set()
     for line in result.stdout.splitlines():
         # Match the redirect hallmark explicitly: an rdr `on <device>` whose destination is
         # the negated self (`to ! (self)`). The anchored ` on {dev} ` (not a bare substring)

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -288,7 +288,12 @@ def _dot_block_match_report(vm: SmokeVM, *, expected_present: bool, timeout: flo
     else:
         actual = [ln.strip() for ln in result.stdout.splitlines() if _is_block_853_line(ln)]
     want = "PRESENT (both protocols)" if expected_present else "ABSENT (no protocol)"
-    matched = _pfctl_sr_block_853_protos(vm, timeout=timeout)
+    # This report renders INSIDE a failing assert's message — a transient pfctl error on
+    # this second read must fold into the report, not replace it with a bare RuntimeError.
+    try:
+        matched: set[str] | str = _pfctl_sr_block_853_protos(vm, timeout=timeout)
+    except RuntimeError as exc:
+        matched = f"<unreadable: {exc}>"
     body = "\n".join(f"      {ln}" for ln in actual) if actual else "      (no block rule for port 853 / domain-s)"
     body = f"      protocols matched: {matched or '{}'} — positive gate needs {{'tcp', 'udp'}}\n" + body
     return (

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -220,11 +220,18 @@ def _pfctl_sr_block_853_protos(vm: SmokeVM, *, timeout: float = 30.0) -> set[str
     pf expands the config-level ``tcp/udp`` block into per-protocol rules; returning the
     set lets the positive gate require BOTH (a lost UDP-853/DoQ leg with TCP-853/DoT kept
     must fail) while absence checks use the empty set.
+
+    Raises ``RuntimeError`` when ``pfctl -sr`` itself fails (rc != 0) — an ERROR is NOT
+    the same as "no rule loaded", and collapsing the two previously made a broken pfctl
+    read false-green every negative/absence gate built on this function.
     """
     result = vm.ssh(h.PFCTL, "-sr", timeout=timeout)
-    protos: set[str] = set()
     if result.returncode != 0:
-        return protos
+        raise RuntimeError(
+            f"{h.PFCTL} -sr failed (rc={result.returncode}): stderr={result.stderr!r} — "
+            f"cannot determine the port-853 block rule state; NOT treating as absent"
+        )
+    protos: set[str] = set()
     for line in result.stdout.splitlines():
         if not _is_block_853_line(line):
             continue
@@ -251,10 +258,17 @@ def _pfctl_sr_block_853_has_self_exempt(vm: SmokeVM, *, timeout: float = 30.0) -
     pfSense renders the negated ``(self)`` destination as ``! (self)`` and port 853 as the
     service name ``domain-s``. We look for the negation indicator ``!`` and ``self`` on the
     same line as the block rule for port 853.
+
+    Raises ``RuntimeError`` when ``pfctl -sr`` itself fails (rc != 0) — an ERROR is NOT
+    "no self-exempt guard": returning False here false-greened the negative gate (#582),
+    same collapse as ``_pfctl_sr_block_853_protos`` before its fix.
     """
     result = vm.ssh(h.PFCTL, "-sr", timeout=timeout)
     if result.returncode != 0:
-        return False
+        raise RuntimeError(
+            f"{h.PFCTL} -sr failed (rc={result.returncode}): stderr={result.stderr!r} — "
+            f"cannot determine the self-exempt guard state; NOT treating as absent"
+        )
     for line in result.stdout.splitlines():
         if _is_block_853_line(line) and "self" in line and "!" in line:
             return True

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -411,6 +411,27 @@ def _seed_user_filter(vm: SmokeVM, descr: str, *, timeout: float = 60.0) -> None
         raise RuntimeError(f"_seed_user_filter({descr!r}) failed: rc={result.returncode} {result.stderr!r}")
 
 
+def _remove_user_filter(vm: SmokeVM, descr: str, *, timeout: float = 60.0) -> None:
+    """Remove any ``filter/rule`` row with this descr — idempotent (no-op if already gone).
+
+    Counterpart to :func:`_seed_user_filter`: the seeded rule has no pfB marker, so no
+    lifecycle sweep ever removes it (that is the behaviour under test) — the caller must,
+    in a ``finally`` (issue #582).
+    """
+    snippet = (
+        "$rules = config_get_path('filter/rule', array());\n"
+        f"$kept = array_values(array_filter($rules, function ($r) {{\n"
+        f"  return ($r['descr'] ?? '') !== {h._php_str(descr)};\n"
+        "}));\n"
+        "config_set_path('filter/rule', $kept);\n"
+        "write_config('pfBlockerNG smoke: remove seeded user filter for DoT block test');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_remove_user_filter({descr!r}) failed: rc={result.returncode} {result.stderr!r}")
+
+
 def _seed_pf_alias(vm: SmokeVM, name: str, cidr: str = "192.0.2.0/24", *, timeout: float = 60.0) -> None:
     """Create a pfSense network alias so pfctl can resolve 'from !<name>' without a syntax error.
 
@@ -850,6 +871,12 @@ def test_user_filter_rule_survives_disable_and_uninstall(deployed_vm: SmokeVM, p
         except Exception:
             pass
         raise
+    finally:
+        # The seeded user filter rule carries no pfB marker, so no lifecycle sweep
+        # (enable/disable/uninstall — the very thing under test) ever removes it;
+        # clean it up here or it leaks into config.xml for every later test/module
+        # sharing this guest (issue #582).
+        _remove_user_filter(vm, _USER_FILTER_DESCR)
 
 
 # --------------------------------------------------------------------------- #
@@ -1029,37 +1056,46 @@ def test_uninstall_sweep_removes_all_dot_block_rules(deployed_vm: SmokeVM, prima
     # that asserts sections-gone must set pfb_keep=off explicitly — see issue #484).
     h.set_pfb_keep(vm, False)
     # GIVEN — enable DoT block on the primary interface and seed a user filter rule.
+    # The seed is wrapped so the finally can remove it: it carries no pfB marker, so
+    # the uninstall sweep under test never touches it (that is the point being proved),
+    # and it would otherwise leak into config.xml for every later test/module sharing
+    # this guest (issue #582).
     _set_dot_block(vm, enabled=True, ifaces=[iface], exception="")
     h.reload(vm, "update", wait_unbound=False)
     h.apply_filter_sync(vm)
-    _seed_user_filter(vm, _USER_FILTER_DESCR)
+    try:
+        _seed_user_filter(vm, _USER_FILTER_DESCR)
 
-    # BEFORE-STATE: assert all objects are present before uninstall.
-    assert _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface) == 1, (
-        f"pfB_DoT_Block_{iface} filter/rule entry absent before uninstall — setup failed"
-    )
-    assert _filter_rule_present(vm, _USER_FILTER_DESCR), "user filter rule absent before uninstall — seeding failed"
-    assert _pfb_sections_present(vm), "installedpackages/pfblockerng* absent before uninstall — unexpected clean state"
+        # BEFORE-STATE: assert all objects are present before uninstall.
+        assert _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX + iface) == 1, (
+            f"pfB_DoT_Block_{iface} filter/rule entry absent before uninstall — setup failed"
+        )
+        assert _filter_rule_present(vm, _USER_FILTER_DESCR), "user filter rule absent before uninstall — seeding failed"
+        assert _pfb_sections_present(vm), (
+            "installedpackages/pfblockerng* absent before uninstall — unexpected clean state"
+        )
 
-    # WHEN — uninstall pfBlockerNG (triggers pfblockerng_php_pre_deinstall_command →
-    # owned-object sweep before pfb_remove_config_settings).
-    _pkg_delete(vm)
+        # WHEN — uninstall pfBlockerNG (triggers pfblockerng_php_pre_deinstall_command →
+        # owned-object sweep before pfb_remove_config_settings).
+        _pkg_delete(vm)
 
-    # THEN — all pfB_DoT_Block_* entries are gone.
-    assert _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX) == 0, (
-        "pfB_DoT_Block_* filter/rule entries still present after uninstall — ADR-35/37 sweep did not run\n"
-        + h.deinstall_debug(vm)
-    )
+        # THEN — all pfB_DoT_Block_* entries are gone.
+        assert _filter_dot_block_count(vm, _DOT_BLOCK_DESCR_PFX) == 0, (
+            "pfB_DoT_Block_* filter/rule entries still present after uninstall — ADR-35/37 sweep did not run\n"
+            + h.deinstall_debug(vm)
+        )
 
-    # THEN — user filter rule survives.
-    assert _filter_rule_present(vm, _USER_FILTER_DESCR), (
-        "user filter rule was DELETED during uninstall — ADR-35 sweep incorrectly removed a user object"
-    )
+        # THEN — user filter rule survives.
+        assert _filter_rule_present(vm, _USER_FILTER_DESCR), (
+            "user filter rule was DELETED during uninstall — ADR-35 sweep incorrectly removed a user object"
+        )
 
-    # THEN — pfBlockerNG config sections are gone.
-    assert not _pfb_sections_present(vm), (
-        "installedpackages/pfblockerng* still present after uninstall — pfb_remove_config_settings did not run"
-    )
+        # THEN — pfBlockerNG config sections are gone.
+        assert not _pfb_sections_present(vm), (
+            "installedpackages/pfblockerng* still present after uninstall — pfb_remove_config_settings did not run"
+        )
+    finally:
+        _remove_user_filter(vm, _USER_FILTER_DESCR)
 
 
 # --------------------------------------------------------------------------- #
@@ -1354,3 +1390,6 @@ def test_dot_block_uninstall_keep_on_removes_rules_retains_sections(deployed_vm:
         # _cleanup_dot_block is internally best-effort: its config write turns the toggle off
         # even with the package uninstalled, and its reload no-ops when the package is gone.
         _cleanup_dot_block(vm)
+        # The seeded user filter rule carries no pfB marker, so the keep=on sweep under
+        # test never touches it — remove it here or it leaks into config.xml (issue #582).
+        _remove_user_filter(vm, _USER_FILTER_DESCR)

--- a/tests/smoke/test_nightly_install.py
+++ b/tests/smoke/test_nightly_install.py
@@ -52,6 +52,7 @@ from .test_repo_install import (
     poll_catalog_served,
     read_compact_version,
     repo_priority,
+    restore_pages_hosts,
     reversion_pkg,
 )
 
@@ -376,35 +377,43 @@ def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
 
     _ensure_egress_open()
 
+    # pkg(8) loads /usr/local/etc/pkg/repos/*.conf ALPHABETICALLY and, for two files
+    # naming the same repo, the LAST-loaded stanza wins. "pfb_nightly_smoke.conf" (the
+    # nightly_vm module fixture's file:// catalog, same NIGHTLY_REPO name) sorts AFTER
+    # "pfb_nightly_live_smoke.conf" (this test's conf, written below) — so a stale copy
+    # left by a fixture that errored mid-setup would silently win and this test would
+    # never actually touch the live HTTPS URL. Clear it unconditionally before proceeding.
+    smoke_vm.ssh("/bin/rm", "-f", CONF, timeout=60.0)
+
     # GIVEN: Pages IPs pinned (guest DNS is sandboxed), nightly package absent, our
     # nightly conf at the live URL above the Netgate pfSense repo.
-    pin_pages_hosts(smoke_vm, host)
-    pfsense_prio = repo_priority(smoke_vm, "pfSense")
-    pkg_delete(smoke_vm, NIGHTLY_NAME)
-
-    # Write the production nightly conf: pfblockerng-nightly, HTTPS live URL, NONE-signed.
-    # ${ABI} is a pkg(8) variable — must survive in the file as-is (not shell-expanded).
-    conf = (
-        f"{NIGHTLY_REPO}: {{\n"
-        f'  url: "{base_url}/${{ABI}}",\n'
-        "  mirror_type: none,\n"
-        "  signature_type: none,\n"
-        f"  priority: {pfsense_prio + 100},\n"
-        "  enabled: yes\n"
-        "}\n"
-    )
-    r = subprocess.run(
-        smoke_vm.ssh_argv("tee", NIGHTLY_LIVE_CONF),
-        input=conf,
-        capture_output=True,
-        text=True,
-        timeout=60.0,
-        check=False,
-    )
-    if r.returncode != 0:
-        raise RuntimeError(f"write nightly live conf failed: rc={r.returncode} {r.stderr!r}")
-
+    prior_hosts = pin_pages_hosts(smoke_vm, host)
     try:
+        pfsense_prio = repo_priority(smoke_vm, "pfSense")
+        pkg_delete(smoke_vm, NIGHTLY_NAME)
+
+        # Write the production nightly conf: pfblockerng-nightly, HTTPS live URL, NONE-signed.
+        # ${ABI} is a pkg(8) variable — must survive in the file as-is (not shell-expanded).
+        conf = (
+            f"{NIGHTLY_REPO}: {{\n"
+            f'  url: "{base_url}/${{ABI}}",\n'
+            "  mirror_type: none,\n"
+            "  signature_type: none,\n"
+            f"  priority: {pfsense_prio + 100},\n"
+            "  enabled: yes\n"
+            "}\n"
+        )
+        r = subprocess.run(
+            smoke_vm.ssh_argv("tee", NIGHTLY_LIVE_CONF),
+            input=conf,
+            capture_output=True,
+            text=True,
+            timeout=60.0,
+            check=False,
+        )
+        if r.returncode != 0:
+            raise RuntimeError(f"write nightly live conf failed: rc={r.returncode} {r.stderr!r}")
+
         # WHEN: pkg update reads the live nightly catalog.
         pkg_update(smoke_vm)
         assert not pkg_present(smoke_vm, NIGHTLY_NAME), "precondition: -nightly absent before live install"
@@ -418,3 +427,4 @@ def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
     finally:
         pkg_delete(smoke_vm, NIGHTLY_NAME)
         smoke_vm.ssh("/bin/rm", "-f", NIGHTLY_LIVE_CONF, timeout=60.0)
+        restore_pages_hosts(smoke_vm, prior_hosts)

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1139,14 +1139,22 @@ def poll_catalog_served(base_url: str, abi: str, *, attempts: int = 30, delay: f
     raise AssertionError(f"live catalog never served {base_url}/{abi}/ within budget; last error: {last_err}")
 
 
-def pin_pages_hosts(vm: SmokeVM, host: str, *, timeout: float = 60.0) -> None:
+def pin_pages_hosts(vm: SmokeVM, host: str, *, timeout: float = 60.0) -> str:
     """Pin GitHub Pages' anycast IPs for ``host`` in the guest ``/etc/hosts``.
 
     The smoke harness sandboxes guest DNS to a mock answering only ``uuid-*.com``,
     so the Pages host does not resolve on the box. A static ``/etc/hosts`` entry
     routes ``pkg``'s HTTPS fetch to Pages by IP while TLS SNI still presents ``host``
     (GitHub's *.github.io cert validates). Idempotent: the entry is removed first.
+
+    Returns the pre-pin ``/etc/hosts`` content — pass it to :func:`restore_pages_hosts`
+    in the caller's ``finally`` so the pin never outlives the test (issue #582: it
+    used to leak into every later test/module sharing the guest).
     """
+    prior = vm.ssh("cat", "/etc/hosts", timeout=timeout)
+    if prior.returncode != 0:
+        raise RuntimeError(f"pin_pages_hosts: reading /etc/hosts failed: rc={prior.returncode} {prior.stderr!r}")
+
     # Drop any prior line carrying this host as a whitespace-separated field (not
     # just a line-ending match, so stale aliases/comments don't survive), then pin
     # ALL the Pages IPs (resilient to a single-IP failure; pkg follows the cert).
@@ -1166,6 +1174,24 @@ def pin_pages_hosts(vm: SmokeVM, host: str, *, timeout: float = 60.0) -> None:
     )
     if result.returncode != 0:
         raise RuntimeError(f"pin_pages_hosts failed: rc={result.returncode} {result.stderr!r}")
+    return prior.stdout
+
+
+def restore_pages_hosts(vm: SmokeVM, prior_hosts: str, *, timeout: float = 60.0) -> None:
+    """Restore ``/etc/hosts`` to the content :func:`pin_pages_hosts` snapshotted.
+
+    Call from the caller's ``finally`` so the Pages-IP pin never survives the test.
+    """
+    result = subprocess.run(
+        vm.ssh_argv("tee", "/etc/hosts"),
+        input=prior_hosts,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"restore_pages_hosts failed: rc={result.returncode} {result.stderr!r}")
 
 
 def write_live_repo_conf(vm: SmokeVM, base_url: str, *, priority: int, timeout: float = 60.0) -> None:
@@ -1234,22 +1260,27 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
 
     # GIVEN: Pages IPs pinned (guest DNS is sandboxed), package absent, our conf at
     # the LIVE url above pfSense.
-    pin_pages_hosts(repo_vm, host)
-    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
-    pkg_delete(repo_vm)
-    write_live_repo_conf(repo_vm, base_url, priority=pfsense_prio + 100)
+    prior_hosts = pin_pages_hosts(repo_vm, host)
+    try:
+        pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+        pkg_delete(repo_vm)
+        write_live_repo_conf(repo_vm, base_url, priority=pfsense_prio + 100)
 
-    # WHEN: pkg update must ACCEPT the live HTTPS catalog (a rejected catalog — bad
-    # meta.conf, malformed packagesite, mismatched sum, or an unreachable URL — fails here).
-    pkg_update(repo_vm)
-    assert pkg_installed_version(repo_vm) is None, f"{PKG_NAME} unexpectedly present before the live-URL install"
+        # WHEN: pkg update must ACCEPT the live HTTPS catalog (a rejected catalog — bad
+        # meta.conf, malformed packagesite, mismatched sum, or an unreachable URL — fails here).
+        pkg_update(repo_vm)
+        assert pkg_installed_version(repo_vm) is None, f"{PKG_NAME} unexpectedly present before the live-URL install"
 
-    # THEN: install resolves from our LIVE repo, deps included, .pkg checksum validated.
-    proc = pkg_install_from_repo(repo_vm)
-    combined = proc.stdout + proc.stderr
-    assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve from the live Pages catalog:\n{combined}"
-    origin = pkg_repo_origin(repo_vm)
-    assert origin == OURS_REPO_NAME, f"installed from {origin!r}, expected our repo {OURS_REPO_NAME!r}"
+        # THEN: install resolves from our LIVE repo, deps included, .pkg checksum validated.
+        proc = pkg_install_from_repo(repo_vm)
+        combined = proc.stdout + proc.stderr
+        assert "Missing dependency" not in combined, (
+            f"RUN_DEPENDS did not resolve from the live Pages catalog:\n{combined}"
+        )
+        origin = pkg_repo_origin(repo_vm)
+        assert origin == OURS_REPO_NAME, f"installed from {origin!r}, expected our repo {OURS_REPO_NAME!r}"
+    finally:
+        restore_pages_hosts(repo_vm, prior_hosts)
 
 
 # =========================================================================== #
@@ -2205,29 +2236,34 @@ def test_generate_hook_safety_absent_conf_exits_0(repo_vm: SmokeVM) -> None:
     Assert AFTER: both conf paths still do NOT exist; exit code 0.
     """
     _stage_generate_hook(repo_vm, guest_hook=GUEST_HOOK_PATH)
+    try:
+        absent_conf = f"{GENERATE_DIR}/nonexistent_pfblockerng.conf"
+        absent_nightly = f"{GENERATE_DIR}/nonexistent_pfblockerng_nightly.conf"
 
-    absent_conf = f"{GENERATE_DIR}/nonexistent_pfblockerng.conf"
-    absent_nightly = f"{GENERATE_DIR}/nonexistent_pfblockerng_nightly.conf"
+        # BEFORE: neither conf exists (a genuinely-absent nightly path, NOT /dev/null —
+        # so the orphan guard is exercised for real on both channels).
+        assert repo_vm.ssh("/bin/test", "-f", absent_conf).returncode != 0, (
+            f"BEFORE: release conf unexpectedly exists at {absent_conf}"
+        )
+        assert repo_vm.ssh("/bin/test", "-f", absent_nightly).returncode != 0, (
+            f"BEFORE: nightly conf unexpectedly exists at {absent_nightly}"
+        )
 
-    # BEFORE: neither conf exists (a genuinely-absent nightly path, NOT /dev/null —
-    # so the orphan guard is exercised for real on both channels).
-    assert repo_vm.ssh("/bin/test", "-f", absent_conf).returncode != 0, (
-        f"BEFORE: release conf unexpectedly exists at {absent_conf}"
-    )
-    assert repo_vm.ssh("/bin/test", "-f", absent_nightly).returncode != 0, (
-        f"BEFORE: nightly conf unexpectedly exists at {absent_nightly}"
-    )
+        # WHEN: run the hook with both conf paths non-existent.
+        _run_generate_hook(repo_vm, release_conf=absent_conf, nightly_conf=absent_nightly)
 
-    # WHEN: run the hook with both conf paths non-existent.
-    _run_generate_hook(repo_vm, release_conf=absent_conf, nightly_conf=absent_nightly)
-
-    # AFTER: both confs still absent; hook was a no-op (created no channel).
-    assert repo_vm.ssh("/bin/test", "-f", absent_conf).returncode != 0, (
-        f"AFTER: hook orphan guard FAILED — it created {absent_conf} when the conf was absent"
-    )
-    assert repo_vm.ssh("/bin/test", "-f", absent_nightly).returncode != 0, (
-        f"AFTER: hook orphan guard FAILED — it created {absent_nightly} when the conf was absent"
-    )
+        # AFTER: both confs still absent; hook was a no-op (created no channel).
+        assert repo_vm.ssh("/bin/test", "-f", absent_conf).returncode != 0, (
+            f"AFTER: hook orphan guard FAILED — it created {absent_conf} when the conf was absent"
+        )
+        assert repo_vm.ssh("/bin/test", "-f", absent_nightly).returncode != 0, (
+            f"AFTER: hook orphan guard FAILED — it created {absent_nightly} when the conf was absent"
+        )
+    finally:
+        # _stage_generate_hook copies to the PRODUCTION rc.d path — remove it so a
+        # staged hook never survives into a later module sharing this guest.
+        repo_vm.ssh("/bin/rm", "-f", GUEST_HOOK_PATH, timeout=60.0)
+        repo_vm.ssh("/bin/rm", "-rf", GENERATE_DIR, timeout=60.0)
 
 
 @pytest.mark.timeout(600)  # forge build + catalog gen + conf regen + pkg update/install > 30s cap.
@@ -2364,4 +2400,7 @@ def test_generate_hook_rewrites_stale_varver_and_resolves(repo_vm: SmokeVM, tmp_
     finally:
         pkg_delete(repo_vm)
         repo_vm.ssh("/bin/rm", "-rf", GENERATE_DIR, timeout=60.0)
+        # _stage_generate_hook copied this to the PRODUCTION rc.d path — remove it so a
+        # staged hook never survives into a later module sharing this guest.
+        repo_vm.ssh("/bin/rm", "-f", GUEST_HOOK_PATH, timeout=60.0)
         # REPO_CONF is cleaned by the repo_vm module fixture teardown.

--- a/tests/smoke/test_smoke_abp.py
+++ b/tests/smoke/test_smoke_abp.py
@@ -42,10 +42,14 @@ Every expected answer is pinned to the REAL semantics in
 
 HERMETIC PROBE NOTE (load-bearing, inherited from the ADR-04 matrix): during the
 per-case probe ``CaseContext`` blocks the runner's egress, so a name that is NOT
-blocked only answers if it has a control Host-Override (``control_local_data``);
-otherwise it would hang (no upstream). Every "resolves" expectation here therefore
-injects a control A record and asserts that exact pass IP — never a loose
-"not blocked".
+blocked needs either a control Host-Override (``control_local_data``) or an
+``h.unblock_egress()`` call to reach the controlled stub upstream (``STUB_DNS_A``);
+otherwise it would hang. A host override is served as ``local-data`` BEFORE the
+python module runs, so it would SHADOW a block on that same name — a "resolves"
+expectation whose name could plausibly be block-shadowed by its own case therefore
+unblocks egress and asserts the stub sentinel instead (#582); the rest keep the
+control-record + control-IP pattern. Every "resolves" expectation asserts an exact
+answer (a control IP or the stub sentinel) — never a loose "not blocked".
 
 These need the booted ``smoke_vm`` fixture, the branch ``.pkg`` (``SMOKE_PKG``),
 and the smoke deps; without them they skip cleanly.
@@ -65,7 +69,7 @@ from collections.abc import Iterator
 import pytest
 
 from . import helpers as h
-from .conftest import SmokeVM, _MockFeedServer, _StubDnsServer
+from .conftest import STUB_DNS_A, SmokeVM, _MockFeedServer, _StubDnsServer
 
 pytestmark = pytest.mark.smoke
 
@@ -120,9 +124,13 @@ def test_abp_exception_unblocks(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_f
 
     ``||base^`` is a wildcard block (zoneDB suffix; covers base + subdomains).
     ``@@||good.base^`` is a wildcard feed-allow (band 2). For ``good.base``:
-    block_band 1, allow_band 2 → ``1 > 2`` false → allow wins → resolves (to its
-    control IP). For ``base`` / ``bad.base``: no allow match → block stands → VIP.
-    Loading the feed ``@@`` sets ``important_rules`` so the numeric branch runs.
+    block_band 1, allow_band 2 → ``1 > 2`` false → allow wins → resolves via the
+    controlled stub upstream. For ``base`` / ``bad.base``: no allow match → block
+    stands → VIP. Loading the feed ``@@`` sets ``important_rules`` so the numeric
+    branch runs. NOTE: no ``control_local_data`` override on ``good`` — it would be
+    served as local-data BEFORE the python module and mask a broken exception as a
+    pass (#582); egress is unblocked for the whole body (the VIP probes are served
+    locally regardless).
     """
     base = h.unique_domain("abpexc")
     good = f"good.{base}"
@@ -134,15 +142,15 @@ def test_abp_exception_unblocks(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_f
         feed_url=feed_url,
         header="smokeabpexc",
         mode=h.DnsblMode.VIP,
-        control_local_data={good: {"A": PASS_IP}},
     )
     with h.CaseContext(deployed_vm, spec):
+        h.unblock_egress()
         ans_base = h.dns_probe_client(client_vm, base, "A")
         assert h.is_vip(ans_base), f"{base} expected VIP block, got {ans_base}"
         ans_bad = h.dns_probe_client(client_vm, bad, "A")
         assert h.is_vip(ans_bad), f"{bad} (non-exempt subdomain) expected VIP block, got {ans_bad}"
         ans_good = h.dns_probe_client(client_vm, good, "A")
-        assert h.resolves_to(ans_good, PASS_IP), f"exempted {good} should resolve to {PASS_IP}, got {ans_good}"
+        assert h.resolves_to(ans_good, STUB_DNS_A), f"exempted {good} should resolve via stub, got {ans_good}"
         assert not h.is_vip(ans_good), f"exempted {good} wrongly VIP-blocked: {ans_good}"
 
 
@@ -198,7 +206,11 @@ def test_abp_cross_feed_exception(deployed_vm: SmokeVM, client_vm: SmokeVM, mock
 
     The two feeds are two ROWS of ONE DNSBL group (each header-sniffed ABP
     independently); the Python build MERGES their rules. Cross-feed global ``@@`` is
-    intended ABP semantics (ADR.md): feed-allow band 2 ≥ feed-block band 1 → resolves.
+    intended ABP semantics (ADR.md): feed-allow band 2 ≥ feed-block band 1 → resolves
+    via the controlled stub upstream. NOTE: no ``control_local_data`` override — it
+    would be served as local-data BEFORE the python module and mask a broken
+    cross-feed merge as a pass (#582); egress is unblocked so the probe reaches the
+    stub for real.
     """
     base = h.unique_domain("abpxfeed")
     feed_a = h.write_local_feed(deployed_vm, "smoke_abp_xfeed_a.txt", h.abp_feed(f"||{base}^"))
@@ -209,11 +221,11 @@ def test_abp_cross_feed_exception(deployed_vm: SmokeVM, client_vm: SmokeVM, mock
         header="smokeabpxfa",
         mode=h.DnsblMode.VIP,
         extra_rows=[("smokeabpxfb", feed_b)],
-        control_local_data={base: {"A": PASS_IP}},
     )
     with h.CaseContext(deployed_vm, spec):
+        h.unblock_egress()
         ans = h.dns_probe_client(client_vm, base, "A")
-        assert h.resolves_to(ans, PASS_IP), f"cross-feed @@ should un-block {base} -> {PASS_IP}, got {ans}"
+        assert h.resolves_to(ans, STUB_DNS_A), f"cross-feed @@ should un-block {base} via stub, got {ans}"
         assert not h.is_vip(ans), f"{base} wrongly VIP-blocked despite cross-feed @@: {ans}"
 
 
@@ -244,8 +256,11 @@ def test_abp_badfilter_prunes_feed_block(deployed_vm: SmokeVM, client_vm: SmokeV
 
     ``$badfilter`` removes every FEED rule with the matching signature (``(y, ())``),
     including the badfilter rule itself — so y has no surviving block and resolves
-    (to its control IP). Sovereignty caveat is covered separately: a user rule's
-    signature is NOT pruned.
+    via the controlled stub upstream. Sovereignty caveat is covered separately: a
+    user rule's signature is NOT pruned. NOTE: no ``control_local_data`` override —
+    it would be served as local-data BEFORE the python module and mask a broken
+    prune as a pass (#582); egress is unblocked so the probe reaches the stub for
+    real.
     """
     y = h.unique_domain("abpbad")
     body = h.abp_feed(f"||{y}^", f"||{y}^$badfilter")
@@ -255,11 +270,11 @@ def test_abp_badfilter_prunes_feed_block(deployed_vm: SmokeVM, client_vm: SmokeV
         feed_url=feed_url,
         header="smokeabpbad",
         mode=h.DnsblMode.VIP,
-        control_local_data={y: {"A": PASS_IP}},
     )
     with h.CaseContext(deployed_vm, spec):
+        h.unblock_egress()
         ans = h.dns_probe_client(client_vm, y, "A")
-        assert h.resolves_to(ans, PASS_IP), f"$badfilter should prune the block on {y} -> {PASS_IP}, got {ans}"
+        assert h.resolves_to(ans, STUB_DNS_A), f"$badfilter should prune the block on {y} via stub, got {ans}"
         assert not h.is_vip(ans), f"{y} wrongly VIP-blocked despite $badfilter: {ans}"
 
 
@@ -275,7 +290,11 @@ def test_abp_regex_block_and_allow(deployed_vm: SmokeVM, client_vm: SmokeVM, moc
     Block ``/badword/`` (irreducible substring regex → compiled into regexDB, band 1,
     forced ``log_type='1'`` → VIP). Allow ``@@/goodword/`` (allowRegexDB, band 2). A
     name carrying ONLY ``badword`` is VIP-blocked; a name carrying BOTH matches the
-    allow (band 2 ≥ block band 1) → resolves.
+    allow (band 2 ≥ block band 1) → resolves via the controlled stub upstream. NOTE:
+    no ``control_local_data`` override on ``unblocked`` — it would be served as
+    local-data BEFORE the python module and mask a broken allow-regex as a pass
+    (#582); egress is unblocked for the whole body (the VIP block probe is served
+    locally regardless).
     """
     uid = h.unique_domain("abprx").split(".", 1)[0]  # the uuid label only
     blocked = f"xbadwordx-{uid}.com"
@@ -287,13 +306,13 @@ def test_abp_regex_block_and_allow(deployed_vm: SmokeVM, client_vm: SmokeVM, moc
         feed_url=feed_url,
         header="smokeabprx",
         mode=h.DnsblMode.VIP,
-        control_local_data={unblocked: {"A": PASS_IP}},
     )
     with h.CaseContext(deployed_vm, spec):
+        h.unblock_egress()
         ans_block = h.dns_probe_client(client_vm, blocked, "A")
         assert h.is_vip(ans_block), f"regex-matched {blocked} expected VIP, got {ans_block}"
         ans_allow = h.dns_probe_client(client_vm, unblocked, "A")
-        assert h.resolves_to(ans_allow, PASS_IP), f"@@ regex should un-block {unblocked} -> {PASS_IP}, got {ans_allow}"
+        assert h.resolves_to(ans_allow, STUB_DNS_A), f"@@ regex should un-block {unblocked} via stub, got {ans_allow}"
 
 
 def test_abp_regex_admitted_count(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
@@ -339,24 +358,32 @@ def test_abp_regex_admitted_count(deployed_vm: SmokeVM, mock_feeds: _MockFeedSer
     assert n_on < n_off, f"cap must shrink the admitted count: off={n_off} on={n_on}"
 
 
-def test_abp_catastrophic_regex_dropped(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+def test_abp_catastrophic_regex_dropped(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """A catastrophic-SHAPE user regex is dropped at load with the length cap OFF.
 
     The always-on shape gate is independent of the opt-in "Limit long/complex regex"
     setting: a nested-quantifier pattern (``(a+)+evil``) is never compiled into the
     regexDB even when ``regex_cap`` is OFF, while a benign sibling (``ads[0-9]+``) is
     admitted. Proves the SHAPE half of the decoupled gate is unconditional (the key
-    behaviour change) on the live box, not just in the unit suite.
+    behaviour change) on the live box, not just in the unit suite. The count alone
+    (``n == 1``) can't tell WHICH pattern survived — a regression that instead
+    admitted the catastrophic one and dropped the benign one would also read as
+    ``n == 1``; a DNS probe of a name matching the surviving ``ads[0-9]+`` pattern
+    (VIP-blocked) closes that gap (#582).
     """
     domain = h.unique_domain("abpcat")
     feed_url = h.write_local_feed(deployed_vm, "smoke_abp_cat.txt", f"{domain}\n")
     patterns = [r"ads[0-9]+", r"(a+)+evil"]
+    uid = h.unique_domain("abpcatrx").split(".", 1)[0]  # the uuid label only
+    ads_hit = f"ads1-{uid}.com"  # matches the benign ads[0-9]+ pattern only
 
     spec = h.DnsblCase(
         aliasname="smokeabpcat", feed_url=feed_url, header="smokeabpcat", mode=h.DnsblMode.VIP, user_regex=patterns
     )
     with h.CaseContext(deployed_vm, spec):
         n = h.regex_admitted_count(deployed_vm)
+        ans = h.dns_probe_client(client_vm, ads_hit, "A")
+        assert h.is_vip(ans), f"surviving ads[0-9]+ pattern should VIP-block {ads_hit}, got {ans}"
     assert n == 1, f"cap OFF: catastrophic shape dropped unconditionally, only benign admitted, expected 1, got {n!r}"
 
 
@@ -372,9 +399,12 @@ def test_abp_whitelist_sovereign_over_important(
 
     The settings whitelist (``suppression``) loads into whiteDB as a user allow
     (``important=True`` → band 6, ``_white_entry_band``). vs feed block+``$important``
-    band 3: allow_band 6 ≥ block_band 3 → resolves (to its control IP). The whitelist
-    is the ultimate override — it beats even a sovereign user regex (band 5), proven
-    by ``test_user_regex_beats_feed_important_allow`` below.
+    band 3: allow_band 6 ≥ block_band 3 → resolves via the controlled stub upstream.
+    The whitelist is the ultimate override — it beats even a sovereign user regex
+    (band 5), proven by ``test_user_regex_beats_feed_important_allow`` below. NOTE:
+    no ``control_local_data`` override — it would be served as local-data BEFORE the
+    python module and mask a broken sovereignty rule as a pass (#582); egress is
+    unblocked so the probe reaches the stub for real.
     """
     w = h.unique_domain("abpwl")
     body = h.abp_feed(f"||{w}^$important")
@@ -385,11 +415,11 @@ def test_abp_whitelist_sovereign_over_important(
         header="smokeabpwl",
         mode=h.DnsblMode.VIP,
         whitelist=[w],
-        control_local_data={w: {"A": PASS_IP}},
     )
     with h.CaseContext(deployed_vm, spec):
+        h.unblock_egress()
         ans = h.dns_probe_client(client_vm, w, "A")
-        assert h.resolves_to(ans, PASS_IP), f"whitelisted {w} must resolve to {PASS_IP} despite $important, got {ans}"
+        assert h.resolves_to(ans, STUB_DNS_A), f"whitelisted {w} must resolve via stub despite $important, got {ans}"
         assert not h.is_vip(ans), f"whitelisted {w} wrongly VIP-blocked: {ans}"
 
 

--- a/tests/smoke/test_smoke_adr40.py
+++ b/tests/smoke/test_smoke_adr40.py
@@ -130,11 +130,14 @@ def test_adr40_content_gate_idempotence(adr40_vm: SmokeVM) -> None:
     first load ran and the table is populated, so an empty ``PFB_CHANGED_IP_ALIASES``
     on the second pass cannot be explained by "the table never loaded".
 
-    **When** ``helpers.reload(vm, 'update')`` runs again over the SAME unchanged
-    feed content.
+    **When** ``force_ip_refetch`` defeats the download-reuse cache (so the SAME
+    unchanged feed content is genuinely re-read and re-parsed, not skipped) and
+    ``helpers.reload(vm, 'update')`` runs again.
 
     **Then** the post hook fires and ``PFB_CHANGED_IP_ALIASES`` does NOT contain
-    the alias — the content-gate short-circuited the reload.
+    the alias — ``pfb_alias_set_different()`` compared the freshly re-parsed
+    (identical) set against the mirror and returned FALSE; the content-gate, not
+    the reuse-cache skip, is what short-circuited the reload.
 
     **And** the pf table still holds the settled IP (confirming no phantom flush).
 
@@ -181,8 +184,14 @@ def test_adr40_content_gate_idempotence(adr40_vm: SmokeVM) -> None:
         f"before-state: pf table {ip_spec.alias} does not contain {fed_ip}: {members_before}"
     )
 
-    # Second update: SAME feed content, no changes.
-    # pfb_alias_set_different() must return FALSE → alias NOT added to $pfb_alias_lists.
+    # Second update: SAME feed content, no changes — but defeat the download-reuse
+    # cache first (issue #582): without this, an unchanged .txt with no .update/.fail
+    # marker takes the REUSE fork (inc:10211-10222), which never re-populates
+    # $pfb_alias_lists at all, so pfb_alias_set_different() is never even called — an
+    # empty PFB_CHANGED_IP_ALIASES would then prove nothing about the content gate.
+    # force_ip_refetch forces the re-download/re-parse fork on this SAME content so the
+    # gate is genuinely exercised and found FALSE.
+    h.force_ip_refetch(adr40_vm, f"{ip_spec.header}_{ip_spec.family}")
     h.clear_hook_markers(adr40_vm, token)
     h.reload(adr40_vm, "update")
     env_second = h.read_hook_env(adr40_vm, marker)

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -219,9 +219,15 @@ def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM
     """
     feed_url = mock_feeds.feed_url("ip_plain_cidr.txt")
     spec = h.IpCase(aliasname="smokefiltergate", feed_url=feed_url, header="smokefiltergate", family="v4")
-    # pfb_download() logs IP-feed activity under the family-suffixed alias name
-    # ([ <aliasname>_<family> ]), not the row header (see the sibling p3spur200 case).
-    refused_marker = f"[ {spec.aliasname}_{spec.family} ] feed host resolves to a non-permitted address"
+    # The refusal fires at pfb_download()'s ENTRY URL vetting (pfb_filter PFB_FILTER_URL
+    # routes through pfb_feed_host_allowed, pfblockerng.inc:1067), NOT the later
+    # download-time gate at :8974 — that '[ header ] … — skipped' line is unreachable
+    # for an internal-host URL. The reason-bearing line lands in error.log (logtype 6):
+    #   "… Invalid URL (feed host resolves to a non-permitted address) [ <url> ]"
+    # Scope it by the reason AND this run's unique mock URL (host:port/fixture), so a
+    # sibling feed's failure can never satisfy it.
+    refused_marker = f"Invalid URL (feed host resolves to a non-permitted address) [ {feed_url} ]"
+    error_log = f"{h.PFB_LOGDIR}/error.log"
     # The mock fetch must be reachable across both updates (the SSRF filter, not egress,
     # is what we are exercising).
     h.unblock_egress()
@@ -233,7 +239,7 @@ def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM
         # the "table not built" assertion reflects a fully settled reload, not a race.
         h.set_feed_internal_allowlist(deployed_vm, "")
         assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before any load"
-        refused_before = h.count_log_marker(deployed_vm, h.PFB_LOG, refused_marker)
+        refused_before = h.count_log_marker(deployed_vm, error_log, refused_marker)
         h.reload(deployed_vm, "update")
         h.reload(deployed_vm, "updateip")
         assert spec.alias not in h.pfctl_tables(deployed_vm), (
@@ -242,9 +248,9 @@ def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM
         # A missing pf table alone is non-specific — a dead mock server would look identical.
         # Assert the actual refusal reason was logged, so this proves the SSRF guard fired,
         # not merely that nothing happened to load.
-        refused_after = h.count_log_marker(deployed_vm, h.PFB_LOG, refused_marker)
+        refused_after = h.count_log_marker(deployed_vm, error_log, refused_marker)
         assert refused_after > refused_before, (
-            f"Expected {refused_marker!r} in {h.PFB_LOG} after the filtered update "
+            f"Expected {refused_marker!r} in {error_log} after the filtered update "
             f"(before={refused_before}, after={refused_after}) — the pf table being empty does "
             "not by itself prove the SSRF guard refused the download"
         )

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -212,12 +212,16 @@ def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM
     Scenario:
       Given the filter ON and the allowlist EMPTY (so 192.168.89.2 is not exempt),
       When  the mock IP feed is Force-Updated,
-      Then  the download is REFUSED and the pf table is never built (the block branch).
+      Then  the download is REFUSED (the refusal reason is logged) and the pf table
+            is never built (the block branch).
       When  the SLIRP net 192.168.89.0/24 is then allowlisted and re-updated,
       Then  the SAME feed downloads and its pf table IS built (the exempt branch).
     """
     feed_url = mock_feeds.feed_url("ip_plain_cidr.txt")
     spec = h.IpCase(aliasname="smokefiltergate", feed_url=feed_url, header="smokefiltergate", family="v4")
+    # pfb_download() logs IP-feed activity under the family-suffixed alias name
+    # ([ <aliasname>_<family> ]), not the row header (see the sibling p3spur200 case).
+    refused_marker = f"[ {spec.aliasname}_{spec.family} ] feed host resolves to a non-permitted address"
     # The mock fetch must be reachable across both updates (the SSRF filter, not egress,
     # is what we are exercising).
     h.unblock_egress()
@@ -229,10 +233,20 @@ def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM
         # the "table not built" assertion reflects a fully settled reload, not a race.
         h.set_feed_internal_allowlist(deployed_vm, "")
         assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before any load"
+        refused_before = h.count_log_marker(deployed_vm, h.PFB_LOG, refused_marker)
         h.reload(deployed_vm, "update")
         h.reload(deployed_vm, "updateip")
         assert spec.alias not in h.pfctl_tables(deployed_vm), (
             "filter ON + empty allowlist must BLOCK the internal mock feed (pf table not built)"
+        )
+        # A missing pf table alone is non-specific — a dead mock server would look identical.
+        # Assert the actual refusal reason was logged, so this proves the SSRF guard fired,
+        # not merely that nothing happened to load.
+        refused_after = h.count_log_marker(deployed_vm, h.PFB_LOG, refused_marker)
+        assert refused_after > refused_before, (
+            f"Expected {refused_marker!r} in {h.PFB_LOG} after the filtered update "
+            f"(before={refused_before}, after={refused_after}) — the pf table being empty does "
+            "not by itself prove the SSRF guard refused the download"
         )
 
         # EXEMPT branch: allowlist the SLIRP net => the SAME feed now downloads + loads.
@@ -1791,6 +1805,10 @@ def test_cron_200_reingest_changed_remote_feed(
         _pin_cron_due(deployed_vm)
         hdr_before = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
         dl_before = _feed_log_count(deployed_vm, header, "Downloading update")
+        # "( content changed )" is the Phase-3 hash-compare verdict itself (not merely its
+        # re-ingest side effect) — the docstring's RED premise (a status-only impl that skips
+        # the hash compare) would still log "Downloading update" without ever logging this.
+        chg_before = h.count_log_marker(deployed_vm, h.PFB_LOG, "content changed")
 
         h.reload(deployed_vm, "cron")
 
@@ -1802,6 +1820,13 @@ def test_cron_200_reingest_changed_remote_feed(
         assert dl_after > dl_before, (
             f"Expected '[ {header} ] ... Downloading update' after changed-feed cron "
             f"(before={dl_before}, after={dl_after}) — detector did not detect the change"
+        )
+
+        # THEN — the hash-compare verdict itself fired: "( content changed )".
+        chg_after = h.count_log_marker(deployed_vm, h.PFB_LOG, "content changed")
+        assert chg_after > chg_before, (
+            f"Expected '( content changed )' verdict after the ETag bump + body change "
+            f"(before={chg_before}, after={chg_after}) — hash-compare path not taken"
         )
 
         # THEN — dom_new becomes blocked.

--- a/tests/smoke/test_smoke_lan_rule_preserve.py
+++ b/tests/smoke/test_smoke_lan_rule_preserve.py
@@ -237,7 +237,8 @@ def _run_two_reload_cycle(
     """
     rules_before = _get_filter_rules(vm)
 
-    # Reload #1: build the alias.
+    # Reload #1: build the alias. apply_filter_sync() blocks until filter_configure()
+    # actually lands, so the read right after it is authoritative (no fixed-time guess).
     h.force_ip_refetch(vm, f"{FEED_HEADER}_v4")
     h.reload(vm, "update", timeout=timeout)
     h.apply_filter_sync(vm)

--- a/tests/smoke/test_smoke_managed_objects.py
+++ b/tests/smoke/test_smoke_managed_objects.py
@@ -202,6 +202,46 @@ def _seed_user_nat(vm: SmokeVM, descr: str, *, timeout: float = 60.0) -> None:
         raise RuntimeError(f"_seed_user_nat({descr!r}) failed: {result.returncode} {result.stderr!r}")
 
 
+def _remove_vip_by_descr(vm: SmokeVM, descr: str, *, timeout: float = 60.0) -> None:
+    """Remove any ``virtualip/vip`` row with this descr — idempotent (no-op if already gone).
+
+    Scenario C/D seed a USER (non-pfB-owned) VIP to prove the uninstall sweep leaves it
+    alone; that means the sweep never cleans it up, so the test must (issue #582).
+    """
+    snippet = (
+        "$vips = config_get_path('virtualip/vip', array());\n"
+        f"$kept = array_values(array_filter($vips, function ($v) {{\n"
+        f"  return ($v['descr'] ?? '') !== {h._php_str(descr)};\n"
+        "}));\n"
+        "config_set_path('virtualip/vip', $kept);\n"
+        "write_config('pfBlockerNG smoke: remove seeded user VIP');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_remove_vip_by_descr({descr!r}) failed: {result.returncode} {result.stderr!r}")
+
+
+def _remove_nat_by_descr(vm: SmokeVM, descr: str, *, timeout: float = 60.0) -> None:
+    """Remove any ``nat/rule`` row with this descr — idempotent (no-op if already gone).
+
+    Scenario C/D seed a USER (non-pfB-owned) NAT rule to prove the uninstall sweep leaves
+    it alone; that means the sweep never cleans it up, so the test must (issue #582).
+    """
+    snippet = (
+        "$rules = config_get_path('nat/rule', array());\n"
+        f"$kept = array_values(array_filter($rules, function ($r) {{\n"
+        f"  return ($r['descr'] ?? '') !== {h._php_str(descr)};\n"
+        "}));\n"
+        "config_set_path('nat/rule', $kept);\n"
+        "write_config('pfBlockerNG smoke: remove seeded user NAT');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_remove_nat_by_descr({descr!r}) failed: {result.returncode} {result.stderr!r}")
+
+
 def _seed_orphan_vip(vm: SmokeVM, descr: str, *, timeout: float = 60.0) -> None:
     """Inject an orphan VIP: carries the pfBlockerNG marker but pfb_dnsvip4 is cleared.
 
@@ -477,62 +517,73 @@ def test_managed_objects_uninstall_sweeps_orphan_preserves_user_objects(deployed
 
     # Seed the orphan VIP (pfB marker, but pfb_dnsvip4 cleared so the double-guard
     # in pfb_manage_dnsbl_vip would skip it — only the ADR-35 sweep catches it).
-    _seed_orphan_vip(vm, _AUTO_VIP_DESCR_V4)
+    # The USER VIP/NAT (below) are deliberately NOT pfB-owned, so the uninstall sweep
+    # never removes them (that is the behaviour under test) — everything from here on
+    # is wrapped so the finally can remove them itself; otherwise they leak into
+    # config.xml as permanent generic pfSense rows for every later test/module sharing
+    # this guest (issue #582).
+    try:
+        _seed_orphan_vip(vm, _AUTO_VIP_DESCR_V4)
 
-    # Seed user objects (no pfB marker — must survive uninstall).
-    _seed_user_vip(vm, _USER_VIP_DESCR)
-    _seed_user_nat(vm, _USER_NAT_DESCR)
+        # Seed user objects (no pfB marker — must survive uninstall).
+        _seed_user_vip(vm, _USER_VIP_DESCR)
+        _seed_user_nat(vm, _USER_NAT_DESCR)
 
-    # BEFORE-STATE: assert all three are present.
-    assert _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
-        "orphan VIP (pfB_AUTO_VIP_v4) not present before uninstall — seeding failed"
-    )
-    assert _vip_descr_present(vm, _USER_VIP_DESCR), "user VIP not present before uninstall — seeding failed"
+        # BEFORE-STATE: assert all three are present.
+        assert _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
+            "orphan VIP (pfB_AUTO_VIP_v4) not present before uninstall — seeding failed"
+        )
+        assert _vip_descr_present(vm, _USER_VIP_DESCR), "user VIP not present before uninstall — seeding failed"
 
-    # Check user NAT is present.
-    pre = (
-        "$found = FALSE;\n"
-        "foreach (config_get_path('nat/rule', array()) as $r) {\n"
-        f"  if (($r['descr'] ?? '') === {h._php_str(_USER_NAT_DESCR)}) {{ $found = TRUE; break; }}\n"
-        "}"
-    )
-    user_nat_before = h._php_read_scalar(vm, pre, "$found ? 'yes' : 'no'")
-    assert user_nat_before == "yes", "user NAT rule not present before uninstall — seeding failed"
+        # Check user NAT is present.
+        pre = (
+            "$found = FALSE;\n"
+            "foreach (config_get_path('nat/rule', array()) as $r) {\n"
+            f"  if (($r['descr'] ?? '') === {h._php_str(_USER_NAT_DESCR)}) {{ $found = TRUE; break; }}\n"
+            "}"
+        )
+        user_nat_before = h._php_read_scalar(vm, pre, "$found ? 'yes' : 'no'")
+        assert user_nat_before == "yes", "user NAT rule not present before uninstall — seeding failed"
 
-    # Assert installedpackages/pfblockerng* sections exist before uninstall.
-    assert _pfb_sections_present(vm), "installedpackages/pfblockerng* absent before uninstall — unexpected clean state"
+        # Assert installedpackages/pfblockerng* sections exist before uninstall.
+        assert _pfb_sections_present(vm), (
+            "installedpackages/pfblockerng* absent before uninstall — unexpected clean state"
+        )
 
-    # WHEN — uninstall pfBlockerNG (triggers pfblockerng_php_pre_deinstall_command →
-    # owned-object sweep before pfb_remove_config_settings).
-    _pkg_delete(vm)
+        # WHEN — uninstall pfBlockerNG (triggers pfblockerng_php_pre_deinstall_command →
+        # owned-object sweep before pfb_remove_config_settings).
+        _pkg_delete(vm)
 
-    # THEN — read config.xml state after uninstall.
-    # The orphan VIP must be swept by the owned-object sweep.
-    assert not _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
-        "orphan pfB_AUTO_VIP_v4 still present after uninstall — ADR-35 sweep did not run"
-    )
+        # THEN — read config.xml state after uninstall.
+        # The orphan VIP must be swept by the owned-object sweep.
+        assert not _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
+            "orphan pfB_AUTO_VIP_v4 still present after uninstall — ADR-35 sweep did not run"
+        )
 
-    # User VIP must survive (not a pfB marker — never swept).
-    assert _vip_descr_present(vm, _USER_VIP_DESCR), (
-        "user VIP was DELETED during uninstall — ADR-35 sweep incorrectly removed a user object"
-    )
+        # User VIP must survive (not a pfB marker — never swept).
+        assert _vip_descr_present(vm, _USER_VIP_DESCR), (
+            "user VIP was DELETED during uninstall — ADR-35 sweep incorrectly removed a user object"
+        )
 
-    # User NAT rule must survive.
-    post_nat = (
-        "$found = FALSE;\n"
-        "foreach (config_get_path('nat/rule', array()) as $r) {\n"
-        f"  if (($r['descr'] ?? '') === {h._php_str(_USER_NAT_DESCR)}) {{ $found = TRUE; break; }}\n"
-        "}"
-    )
-    user_nat_after = h._php_read_scalar(vm, post_nat, "$found ? 'yes' : 'no'")
-    assert user_nat_after == "yes", (
-        "user NAT rule was DELETED during uninstall — ADR-35 sweep incorrectly removed a user object"
-    )
+        # User NAT rule must survive.
+        post_nat = (
+            "$found = FALSE;\n"
+            "foreach (config_get_path('nat/rule', array()) as $r) {\n"
+            f"  if (($r['descr'] ?? '') === {h._php_str(_USER_NAT_DESCR)}) {{ $found = TRUE; break; }}\n"
+            "}"
+        )
+        user_nat_after = h._php_read_scalar(vm, post_nat, "$found ? 'yes' : 'no'")
+        assert user_nat_after == "yes", (
+            "user NAT rule was DELETED during uninstall — ADR-35 sweep incorrectly removed a user object"
+        )
 
-    # pfBlockerNG config sections must be gone.
-    assert not _pfb_sections_present(vm), (
-        "installedpackages/pfblockerng* still present after uninstall — pfb_remove_config_settings did not run"
-    )
+        # pfBlockerNG config sections must be gone.
+        assert not _pfb_sections_present(vm), (
+            "installedpackages/pfblockerng* still present after uninstall — pfb_remove_config_settings did not run"
+        )
+    finally:
+        _remove_vip_by_descr(vm, _USER_VIP_DESCR)
+        _remove_nat_by_descr(vm, _USER_NAT_DESCR)
 
 
 # --------------------------------------------------------------------------- #
@@ -573,57 +624,65 @@ def test_managed_objects_uninstall_keep_on_removes_orphan_retains_sections(deplo
     h.set_dnsvip_auto(vm, False)
     h.reload(vm, "update")
 
-    _seed_orphan_vip(vm, _AUTO_VIP_DESCR_V4)
-    _seed_user_vip(vm, _USER_VIP_DESCR)
-    _seed_user_nat(vm, _USER_NAT_DESCR)
+    # The USER VIP/NAT (seeded below) are deliberately NOT pfB-owned, so the uninstall
+    # sweep never removes them (that is the behaviour under test) — wrapped so the
+    # finally can remove them itself; otherwise they leak into config.xml as permanent
+    # generic pfSense rows for every later test/module sharing this guest (issue #582).
+    try:
+        _seed_orphan_vip(vm, _AUTO_VIP_DESCR_V4)
+        _seed_user_vip(vm, _USER_VIP_DESCR)
+        _seed_user_nat(vm, _USER_NAT_DESCR)
 
-    # BEFORE-STATE: assert all objects present.
-    assert _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
-        "orphan VIP (pfB_AUTO_VIP_v4) not present before keep=on uninstall — seeding failed"
-    )
-    assert _vip_descr_present(vm, _USER_VIP_DESCR), "user VIP not present before keep=on uninstall — seeding failed"
+        # BEFORE-STATE: assert all objects present.
+        assert _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
+            "orphan VIP (pfB_AUTO_VIP_v4) not present before keep=on uninstall — seeding failed"
+        )
+        assert _vip_descr_present(vm, _USER_VIP_DESCR), "user VIP not present before keep=on uninstall — seeding failed"
 
-    pre_nat = (
-        "$found = FALSE;\n"
-        "foreach (config_get_path('nat/rule', array()) as $r) {\n"
-        f"  if (($r['descr'] ?? '') === {h._php_str(_USER_NAT_DESCR)}) {{ $found = TRUE; break; }}\n"
-        "}"
-    )
-    assert h._php_read_scalar(vm, pre_nat, "$found ? 'yes' : 'no'") == "yes", (
-        "user NAT rule not present before keep=on uninstall — seeding failed"
-    )
-    assert _pfb_sections_present(vm), (
-        "installedpackages/pfblockerng* absent before keep=on uninstall — unexpected clean state"
-    )
+        pre_nat = (
+            "$found = FALSE;\n"
+            "foreach (config_get_path('nat/rule', array()) as $r) {\n"
+            f"  if (($r['descr'] ?? '') === {h._php_str(_USER_NAT_DESCR)}) {{ $found = TRUE; break; }}\n"
+            "}"
+        )
+        assert h._php_read_scalar(vm, pre_nat, "$found ? 'yes' : 'no'") == "yes", (
+            "user NAT rule not present before keep=on uninstall — seeding failed"
+        )
+        assert _pfb_sections_present(vm), (
+            "installedpackages/pfblockerng* absent before keep=on uninstall — unexpected clean state"
+        )
 
-    # WHEN — uninstall pfBlockerNG with pfb_keep=on.
-    _pkg_delete(vm)
+        # WHEN — uninstall pfBlockerNG with pfb_keep=on.
+        _pkg_delete(vm)
 
-    # THEN — orphan VIP is GONE (live-object sweep is unconditional, regardless of pfb_keep).
-    assert not _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
-        "orphan pfB_AUTO_VIP_v4 still present after keep=on uninstall — "
-        "live-object teardown did not run unconditionally (the #484 bug: keep-gate blocked the sweep)\n"
-        + h.deinstall_debug(vm)
-    )
+        # THEN — orphan VIP is GONE (live-object sweep is unconditional, regardless of pfb_keep).
+        assert not _vip_descr_present(vm, _AUTO_VIP_DESCR_V4), (
+            "orphan pfB_AUTO_VIP_v4 still present after keep=on uninstall — "
+            "live-object teardown did not run unconditionally (the #484 bug: keep-gate blocked the sweep)\n"
+            + h.deinstall_debug(vm)
+        )
 
-    # THEN — user VIP survives (not a pfB marker — never swept).
-    assert _vip_descr_present(vm, _USER_VIP_DESCR), (
-        "user VIP was DELETED during keep=on uninstall — sweep incorrectly removed a user object"
-    )
+        # THEN — user VIP survives (not a pfB marker — never swept).
+        assert _vip_descr_present(vm, _USER_VIP_DESCR), (
+            "user VIP was DELETED during keep=on uninstall — sweep incorrectly removed a user object"
+        )
 
-    # THEN — user NAT rule survives.
-    post_nat = (
-        "$found = FALSE;\n"
-        "foreach (config_get_path('nat/rule', array()) as $r) {\n"
-        f"  if (($r['descr'] ?? '') === {h._php_str(_USER_NAT_DESCR)}) {{ $found = TRUE; break; }}\n"
-        "}"
-    )
-    assert h._php_read_scalar(vm, post_nat, "$found ? 'yes' : 'no'") == "yes", (
-        "user NAT rule was DELETED during keep=on uninstall — sweep incorrectly removed a user object"
-    )
+        # THEN — user NAT rule survives.
+        post_nat = (
+            "$found = FALSE;\n"
+            "foreach (config_get_path('nat/rule', array()) as $r) {\n"
+            f"  if (($r['descr'] ?? '') === {h._php_str(_USER_NAT_DESCR)}) {{ $found = TRUE; break; }}\n"
+            "}"
+        )
+        assert h._php_read_scalar(vm, post_nat, "$found ? 'yes' : 'no'") == "yes", (
+            "user NAT rule was DELETED during keep=on uninstall — sweep incorrectly removed a user object"
+        )
 
-    # THEN — pfblockerng* sections are STILL PRESENT (pfb_keep=on retains settings + data).
-    assert _pfb_sections_present(vm), (
-        "installedpackages/pfblockerng* GONE after keep=on uninstall — "
-        "pfb_keep=on should have retained settings sections (the #484 fix: keep gates only settings/data)"
-    )
+        # THEN — pfblockerng* sections are STILL PRESENT (pfb_keep=on retains settings + data).
+        assert _pfb_sections_present(vm), (
+            "installedpackages/pfblockerng* GONE after keep=on uninstall — "
+            "pfb_keep=on should have retained settings sections (the #484 fix: keep gates only settings/data)"
+        )
+    finally:
+        _remove_vip_by_descr(vm, _USER_VIP_DESCR)
+        _remove_nat_by_descr(vm, _USER_NAT_DESCR)

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -347,13 +347,15 @@ def test_dnsbl_idn_confusable_blocks_homoglyph_resolves_legit(
         Cyrillic mix → MALICIOUS → blocked as feed ``Homoglyph`` (log_type '1',
         not HSTS) → NOERROR + the DNSBL VIP.
       * ``xn--mnchen-3ya`` (münchen — single-script Latin) is legit → NO IDN action,
-        so it resolves to its control answer (the before-state: green proves the
-        analyzer is the cause of the block, not an always-block path).
+        so it resolves via the controlled stub upstream (the before-state: green
+        proves the analyzer is the cause of the block, not an always-block path).
     Probed on-box (``drill @127.0.0.1``); python-mode has no localhost exemption.
+    NOTE: no ``control_local_data`` override on ``legit`` — a host override is served
+    as local-data BEFORE the python module and would mask a broken analyzer as a
+    pass (#582); egress is unblocked so the legit probe reaches the stub for real.
     """
     homoglyph = "xn--pple-43d.com"  # аpple — Latin+Cyrillic confusable → MALICIOUS
     legit = "xn--mnchen-3ya.com"  # münchen — single-script Latin → legit
-    legit_ip = "198.51.100.60"
     feed_url = h.write_local_feed(deployed_vm, "smoke_idn_confusable.txt", f"{h.unique_domain('idnfiller')}\n")
     spec = h.DnsblCase(
         aliasname="smokeidn",
@@ -363,12 +365,13 @@ def test_dnsbl_idn_confusable_blocks_homoglyph_resolves_legit(
         idn_mode="confusable",
         idn_block_malicious=True,
         idn_escalate_suspicious=False,
-        control_local_data={legit: {"A": legit_ip}},
     )
     with h.CaseContext(deployed_vm, spec):
-        # Before-state: the legit single-script IDN is NOT blocked — it resolves.
+        # Before-state: the legit single-script IDN is NOT blocked — resolves via
+        # the stub (egress unblocked so the un-blocked probe reaches it).
+        h.unblock_egress()
         legit_ans = h.dns_probe_client(client_vm, legit, "A")
-        assert h.resolves_to(legit_ans, legit_ip), f"legit IDN {legit} should resolve to {legit_ip}, got {legit_ans}"
+        assert h.resolves_to(legit_ans, STUB_DNS_A), f"legit IDN {legit} should resolve via stub, got {legit_ans}"
         assert not h.is_vip(legit_ans), f"legit IDN {legit} must NOT be homoglyph-blocked (FALSE POSITIVE): {legit_ans}"
         # The confusable homograph blocks with the DNSBL VIP.
         blocked = h.dns_probe_client(client_vm, homoglyph, "A")
@@ -385,12 +388,14 @@ def test_dnsbl_idn_confusable_block_malicious_off_alerts_only(
 
     Same confusable ``xn--pple-43d`` (аpple) as the positive case, but with
     ``block_malicious`` OFF: ``idn_confusable_action`` maps MALICIOUS → ALERT, so
-    ``is_found`` stays False and the name resolves to its control answer. Paired with
-    the block-on case above (same input, toggle flipped) this proves it is the toggle,
-    not an always-resolve path.
+    ``is_found`` stays False and the name resolves via the controlled stub upstream.
+    Paired with the block-on case above (same input, toggle flipped) this proves it
+    is the toggle, not an always-resolve path. NOTE: no ``control_local_data``
+    override — it would be served as local-data BEFORE the python module and mask a
+    broken toggle as a pass (#582); egress is unblocked so the probe reaches the
+    stub for real.
     """
     homoglyph = "xn--pple-43d.com"  # аpple — MALICIOUS, but block_malicious is OFF
-    homoglyph_ip = "198.51.100.61"
     feed_url = h.write_local_feed(deployed_vm, "smoke_idn_alert.txt", f"{h.unique_domain('idnfiller')}\n")
     spec = h.DnsblCase(
         aliasname="smokeidnalert",
@@ -399,24 +404,24 @@ def test_dnsbl_idn_confusable_block_malicious_off_alerts_only(
         mode=h.DnsblMode.VIP,
         idn_mode="confusable",
         idn_block_malicious=False,  # malicious → ALERT only (no block)
-        control_local_data={homoglyph: {"A": homoglyph_ip}},
     )
     with h.CaseContext(deployed_vm, spec):
+        h.unblock_egress()
         ans = h.dns_probe_client(client_vm, homoglyph, "A")
-        assert h.resolves_to(ans, homoglyph_ip), (
-            f"block_malicious OFF: {homoglyph} should resolve to {homoglyph_ip}, got {ans}"
-        )
+        assert h.resolves_to(ans, STUB_DNS_A), f"block_malicious OFF: {homoglyph} should resolve via stub, got {ans}"
         assert not h.is_vip(ans), f"block_malicious OFF must NOT block the homograph (alert only): {ans}"
 
 
 def test_dnsbl_whitelist_passthrough(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """WHITELIST: a domain on the whitelist AND in the block feed RESOLVES.
 
-    ``suppression`` short-circuits before any block shape, so the name resolves
-    via its control ``local-data`` (a true pass) — NOT NXDOMAIN/null/VIP.
+    ``suppression`` short-circuits before any block shape, so the name resolves via
+    the controlled stub upstream (a true pass) — NOT NXDOMAIN/null/VIP. NOTE: no
+    ``control_local_data`` override — it would be served as local-data BEFORE the
+    python module and mask a broken suppression check as a pass (#582); egress is
+    unblocked so the probe reaches the stub for real.
     """
     domain = h.unique_domain("allowed")
-    pass_ip = "198.51.100.77"
     feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_white.txt", f"{domain}\n")
     spec = h.DnsblCase(
         aliasname="smokewhite",
@@ -424,11 +429,11 @@ def test_dnsbl_whitelist_passthrough(deployed_vm: SmokeVM, client_vm: SmokeVM, m
         header="smokewhite",
         mode=h.DnsblMode.VIP,
         whitelist=[domain],
-        control_local_data={domain: {"A": pass_ip}},
     )
     with h.CaseContext(deployed_vm, spec):
+        h.unblock_egress()
         answer = h.dns_probe_client(client_vm, domain, "A")
-        assert h.resolves_to(answer, pass_ip), f"whitelisted {domain} should resolve to {pass_ip}, got {answer}"
+        assert h.resolves_to(answer, STUB_DNS_A), f"whitelisted {domain} should resolve via stub, got {answer}"
         assert not h.is_vip(answer), f"whitelisted {domain} wrongly VIP-blocked: {answer}"
         assert not h.is_null_ip(answer), f"whitelisted {domain} wrongly null-IP: {answer}"
 

--- a/tests/smoke/test_smoke_safesearch.py
+++ b/tests/smoke/test_smoke_safesearch.py
@@ -215,10 +215,8 @@ def test_safesearch_cname_chase_reaches_target(safesearch_vm: _SSFixture) -> Non
     Then src_chase A resolves to SS_TARGET_A and src_chase AAAA resolves to SS_TARGET_AAAA
         (the stub-served fixture address — DISTINCT from the sentinel so the assertion
         proves the chase, not a stub default).
-    And a direct lookup of target_chase returns the same fixture address (cache-population
-        / chase-consistency check: the iterator populated target_chase's cache entry).
     """
-    vm, cvm, forwarding_on, src_chase, target_chase, _src_fallback, _before = safesearch_vm
+    vm, cvm, forwarding_on, src_chase, _target_chase, _src_fallback, _before = safesearch_vm
 
     for rtype, expected in (("A", h.SS_TARGET_A), ("AAAA", h.SS_TARGET_AAAA)):
         redirected = h.dns_probe_client(cvm, src_chase, rtype)
@@ -230,19 +228,6 @@ def test_safesearch_cname_chase_reaches_target(safesearch_vm: _SSFixture) -> Non
         assert str(ipaddress.ip_address(expected)) in normalised_records, (
             f"[forwarding={forwarding_on}] {src_chase} {rtype}: expected {expected} "
             f"(chase target address); got {redirected.records}"
-        )
-
-        # Cache-population check: target_chase itself resolves to the same fixture address.
-        target_ans = h.dns_probe_client(cvm, target_chase, rtype)
-        assert target_ans.rcode == "NOERROR" and target_ans.records, (
-            f"[forwarding={forwarding_on}] {target_chase} {rtype} did not resolve "
-            f"(expected cache hit from the chase): {target_ans}"
-        )
-        normalised_target = {str(ipaddress.ip_address(r)) for r in target_ans.records}
-        assert normalised_records & normalised_target, (
-            f"[forwarding={forwarding_on}] {src_chase} {rtype} address does not overlap "
-            f"{target_chase} {rtype} — CNAME chase did not reach the target: "
-            f"{src_chase}={redirected.records} vs {target_chase}={target_ans.records}"
         )
 
 

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -127,6 +127,75 @@ def _run_tick(vm) -> str:
     return vm.ssh(f"{_PHP} {_PFB_PHP} tick 2>&1").stdout
 
 
+_SS_EXTDNS_STUB = "192.168.89.2"  # WAN SLIRP host alias -> the stub_dns fixture
+_SS_EXTDNS_DEFAULT = "8.8.8.8"  # pfb_global()'s documented absent-default
+
+
+def _seed_ss_refresh_positive_control(vm, target: str, stale_v4: str) -> str:
+    """Point ss_refresh's resolver at the stub DNS and seed a CNAME row baked STALE.
+
+    pfblockerng_ss_refresh() re-resolves each SafeSearch CNAME row's target and rewrites
+    the CSV IFF the freshly resolved address differs from the row's baked one
+    (pfb_ss_refresh_lines). Pointing 'pfbextdns' — pfb_ss_resolve_target's resolver,
+    default 8.8.8.8 — at the hermetic stub instead, and baking the row with an address the
+    stub will not repeat, makes THIS tick's ss_refresh deterministically detect a change.
+
+    Returns the seeded row's source domain so the caller can remove the row again
+    (`_remove_ss_row`) — a leftover row would make every later tick in this module
+    re-resolve a dead uuid target against the restored default resolver.
+    """
+    domain = h.unique_domain("tickssrefreshsrc")
+    row = f"{domain},cname,{target},{stale_v4},\n"
+    snippet = (
+        "$g = config_get_path('installedpackages/pfblockerngglobal', array());"
+        f"$g['pfbextdns'] = {h._php_str(_SS_EXTDNS_STUB)};"
+        "config_set_path('installedpackages/pfblockerngglobal', $g);"
+        "write_config('pfBlockerNG smoke: point ss_refresh at the stub DNS');"
+        f"file_put_contents({h._php_str(h.UNBOUND_PY_SS_FILE)}, {h._php_str(row)}, FILE_APPEND | LOCK_EX);"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"_seed_ss_refresh_positive_control failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+    return domain
+
+
+def _remove_ss_row(vm, domain: str) -> None:
+    """Strip the seeded SafeSearch CSV row again (issue #582 cleanup).
+
+    Matched by the row's unique source domain — ss_refresh may have rewritten the
+    baked IP by the time this runs, but the domain field is stable.
+    """
+    snippet = (
+        f"$f = {h._php_str(h.UNBOUND_PY_SS_FILE)};"
+        "if (file_exists($f)) {"
+        "  $lines = file($f, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);"
+        f"  $keep = array_filter($lines, fn($l) => strpos($l, {h._php_str(domain)}) === FALSE);"
+        '  file_put_contents($f, implode("\\n", $keep) . (empty($keep) ? \'\' : "\\n"), LOCK_EX);'
+        "}"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_remove_ss_row failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def _reset_ss_extdns(vm) -> None:
+    """Restore the 'pfbextdns' general setting to its documented default (issue #582 cleanup)."""
+    snippet = (
+        "$g = config_get_path('installedpackages/pfblockerngglobal', array());"
+        f"$g['pfbextdns'] = {h._php_str(_SS_EXTDNS_DEFAULT)};"
+        "config_set_path('installedpackages/pfblockerngglobal', $g);"
+        "write_config('pfBlockerNG smoke: restore pfbextdns default');"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_reset_ss_extdns failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -194,24 +263,34 @@ def test_tick_dispatches_due_feed(deployed_vm: SmokeVM):
 @pytest.mark.smoke
 @pytest.mark.tick
 @pytest.mark.timeout(150)  # drain + bounded no-dispatch poll can exceed the 30s body cap
-def test_tick_skips_non_due_feed(deployed_vm: SmokeVM):
-    """Tick does NOT dispatch a feed sync when the cron ledger entry is not yet due.
+def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer):
+    """Tick does NOT dispatch a feed sync when the cron ledger entry is not yet due —
+    yet the tick itself genuinely ran (issue #582 positive control).
 
     The tick logs to syslog (not stdout), so observe the NON-dispatch via the
     ' CRON  PROCESS  START' marker (logged only by pfblockerng_sync_cron): a non-due cron
     must produce NO new marker. Drain any in-flight cron from a prior tick test first so the
     marker baseline is stable. This is marker-based (not ledger-value-based) so it is immune
     to a prior test's mark_ran overwriting the cron entry — both values stay 'future' anyway.
-    (Positive-control hardening — proving the tick itself ran — is tracked in #582.)
+
+    On its own, "no CRON PROCESS marker" cannot distinguish "tick correctly skipped the
+    non-due cron" from "tick never ran at all" — both look identical. The positive control:
+    ss_refresh rides every tick unconditionally (pfblockerng_tick calls it regardless of what
+    is due), so a SafeSearch CNAME row seeded with a STALE baked IP and a resolver (the
+    'pfbextdns' setting) pointed at the hermetic stub DNS makes THIS tick's ss_refresh
+    deterministically detect a change and log its own marker — proving the tick executed.
 
     Scenario:
         Background: pfBlockerNG installed.
-            Given the 'cron' ledger entry has next_due = now + 1 hour.
+            Given the 'cron' ledger entry has next_due = now + 1 hour, and a SafeSearch
+                CNAME row is seeded with a baked IP the stub will not repeat.
             When pfblockerng.php tick runs.
-            Then NO new ' CRON  PROCESS  START' marker appears (the cron was skipped).
+            Then NO new ' CRON  PROCESS  START' marker appears (the cron was skipped),
+            And  the ss_refresh marker DOES appear (the tick still ran).
     """
     vm = deployed_vm
     marker = "CRON  PROCESS  START"
+    ss_marker = "SafeSearch CNAME fallback IPs refreshed"
 
     # Drain any in-flight backgrounded cron from a prior tick test so the marker baseline
     # is stable (a still-running prior cron would log a marker unrelated to this tick).
@@ -227,17 +306,35 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM):
     _write_ledger_entry(vm, "cron", now_ts - 86400, now_ts + 3600)
     before = h.count_log_marker(vm, h.PFB_LOG, marker)
 
-    # When: tick fires — cron is not due.
-    _run_tick(vm)
+    # Positive control: a resolvable CNAME target the stub answers, baked stale in the CSV.
+    target = h.unique_domain("tickssrefresh")
+    stub_dns.set_records(target, a=(h.SS_TARGET_A,))
+    src_domain = _seed_ss_refresh_positive_control(vm, target, h.SS_BAKED_A)
+    ss_before = h.count_log_marker(vm, h.PFB_LOG, ss_marker)
 
-    # Then: no new CRON PROCESS pass appeared (cron skipped). The bounded poll gives any
-    # erroneous late dispatch a window to show; wait_until returns False (good) when the
-    # count never rises.
-    assert not h.wait_until(
-        lambda: h.count_log_marker(vm, h.PFB_LOG, marker) > before,
-        timeout=20,
-        interval=4,
-    ), f"tick dispatched a cron for a NON-due feed — ' {marker}' marker count rose from {before}"
+    try:
+        # When: tick fires — cron is not due, but ss_refresh always runs.
+        _run_tick(vm)
+
+        # Then: no new CRON PROCESS pass appeared (cron skipped). The bounded poll gives any
+        # erroneous late dispatch a window to show; wait_until returns False (good) when the
+        # count never rises.
+        assert not h.wait_until(
+            lambda: h.count_log_marker(vm, h.PFB_LOG, marker) > before,
+            timeout=20,
+            interval=4,
+        ), f"tick dispatched a cron for a NON-due feed — ' {marker}' marker count rose from {before}"
+
+        # Then: the ss_refresh marker DID appear — the tick genuinely ran; this is what
+        # distinguishes "skipped correctly" from "never ran" above.
+        ss_after = h.count_log_marker(vm, h.PFB_LOG, ss_marker)
+        assert ss_after > ss_before, (
+            f"tick did not run ss_refresh (before={ss_before}, after={ss_after}) — cannot tell "
+            "'cron correctly skipped' from 'the tick itself never ran'"
+        )
+    finally:
+        _remove_ss_row(vm, src_domain)
+        _reset_ss_extdns(vm)
 
 
 @pytest.mark.smoke
@@ -266,16 +363,17 @@ def test_tick_wiped_ledger_jittered(deployed_vm: SmokeVM):
     )
     ledger = _read_ledger(vm)
 
-    # dcc should have run and have a non-zero jitter.
+    # dcc should have run and have a non-zero jitter. Read the ledger's own 'jitter' field
+    # directly (the entry schema carries it — see _write_ledger_entry) rather than inferring
+    # jitter from next_due != last_run+86400: that derivation is fragile — a *coincidental*
+    # jitter draw of exactly 86400 would make a genuinely-jittered entry look unjittered.
     assert "dcc" in ledger, f"dcc ledger entry missing after wiped-ledger tick; ledger={ledger}"
     now_ts = int(vm.ssh("date +%s").stdout.strip())
-    no_jitter_next_due = ledger["dcc"]["last_run"] + 86400
-    actual_next = ledger["dcc"]["next_due"]
-    assert actual_next != no_jitter_next_due, (
-        f"dcc next_due should differ from last_run+86400 (jitter expected);\n"
-        f"  next_due={actual_next} last_run={ledger['dcc']['last_run']} "
-        f"no-jitter={no_jitter_next_due}"
+    actual_jitter = ledger["dcc"]["jitter"]
+    assert actual_jitter != 0, (
+        f"dcc ledger entry should carry non-zero jitter; got jitter={actual_jitter} ledger={ledger}"
     )
+    actual_next = ledger["dcc"]["next_due"]
     assert actual_next > now_ts, f"dcc next_due should be in the future; got {actual_next} now={now_ts}"
 
 

--- a/tests/smoke/test_smoke_upstream_block.py
+++ b/tests/smoke/test_smoke_upstream_block.py
@@ -451,8 +451,9 @@ class TestUpstreamCounterIncrement:
     db_worker flushes the enqueued ("dnsbl", "Upstream") task; the on-box
     ``counter`` column for the Upstream row increases.
 
-    Before/after: counter is read BEFORE the probe and AFTER, asserting a
-    strict increase so that the test fails if the counter is stuck.
+    Before/after: counter is read BEFORE the probe and AFTER, asserting an EXACT
+    +1 delta (not merely "some increase") so the test fails if the counter is
+    stuck OR if another probe's increment leaked into this window.
     """
 
     def test_upstream_counter_increments_on_nxra_block(
@@ -461,7 +462,7 @@ class TestUpstreamCounterIncrement:
         """
         Given: DNSBL active, forwarding to stub, dnsbl table seeded with Upstream row.
         When: stub answers NXDOMAIN (RA=0, AA=0) — an NXRA upstream block is logged.
-        Then: the on-box dnsbl counter for groupname='Upstream' strictly increases.
+        Then: the on-box dnsbl counter for groupname='Upstream' increases by EXACTLY 1.
         """
         vm, cvm = deployed_vm
         name = h.unique_domain("pfbsmoke-upstream-ctr")
@@ -495,16 +496,25 @@ class TestUpstreamCounterIncrement:
             f"Log excerpt:\n{_read_dnsbl_log(vm)[-2000:]}"
         )
 
-        # Then: wait for the async flush and assert strict increase. A read that is
-        # still ERRORED at the deadline is a read problem, not a stuck counter — keep
-        # the two failure modes distinct here too (mirrors the baseline assert).
+        # Then: wait for the async flush and assert an EXACT +1 delta, not merely "some
+        # increase". Only one NXRA probe happens in this test's window (asserted above via
+        # the log-line check), and the serial pytest run + PFB_DB_FLUSH_INTERVAL=1.0s mean
+        # every earlier test's increment (NXRA/EDE15/EDE17 above) is long since flushed into
+        # `baseline` by the time this test starts (the three control tests preceding this one
+        # each settle for _ABSENCE_SETTLE_S=8.0s, far past the 1s flush window). A bare
+        # `final > baseline` would also pass if some OTHER probe's increment leaked into this
+        # window — exact equality is the real proof this probe (and only this probe) counted.
+        # A read that is still ERRORED at the deadline is a read problem, not a stuck counter
+        # — keep the two failure modes distinct here too (mirrors the baseline assert).
         final, final_detail = _wait_for_counter_above(vm, baseline)
         assert final != -2, (
             f"Upstream counter read ERRORED while waiting for the increase "
             f"(NOT a stuck counter — do not blame the enqueue/flush): {final_detail!r}"
         )
-        assert final > baseline, (
-            f"Upstream counter did not increase after NXRA block: "
-            f"baseline={baseline}, final={final}. "
-            f"Detection fired (log line present), so the enqueue or flush may be broken."
+        delta = final - baseline
+        assert delta == 1, (
+            f"Upstream counter delta after NXRA block: expected=1 actual={delta} "
+            f"(baseline={baseline}, final={final}). Detection fired (log line present), so a "
+            f"delta other than exactly 1 means the counter is stuck (delta<=0) or another "
+            f"probe's increment leaked into this window (delta>1)."
         )

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -95,7 +95,9 @@ def deployed_vm(
     """Deploy the branch .pkg once; wire DNSBL + IP; reload with syslog OFF.
 
     Given: the smoke VM is booted and the branch .pkg is available.
-    When:  we deploy, wire DNSBL (unique blocked domain, VIP) + one IP block feed
+    When:  we deploy, wire DNSBL (TWO unique blocked domains, VIP — the syslog-toggle
+           test uses one per OFF/ON probe so it never has to rely on the SAME domain
+           re-triggering the python hook on a repeat query) + one IP block feed
            (RFC 5737), and do a full reload with syslog export OFF (the default).
            The reload runs sync_package_pfblockerng, which materializes the syslog
            routing drop-in (ADR-38) and (re)starts the filterlog daemon tailing
@@ -110,7 +112,8 @@ def deployed_vm(
     h.ensure_dnsbl_vip(smoke_vm)
 
     _dnsbl_domain = h.unique_domain("pfbsyslogdnsbl")
-    _dnsbl_feed_path = h.write_local_feed(smoke_vm, "pfb_syslog_dnsbl.txt", f"{_dnsbl_domain}\n")
+    _dnsbl_domain_on = h.unique_domain("pfbsyslogdnsbl2")
+    _dnsbl_feed_path = h.write_local_feed(smoke_vm, "pfb_syslog_dnsbl.txt", f"{_dnsbl_domain}\n{_dnsbl_domain_on}\n")
     h.inject(
         smoke_vm,
         h.DnsblCase(
@@ -167,6 +170,7 @@ def deployed_vm(
         )
 
     smoke_vm._pfb_dnsbl_domain = _dnsbl_domain  # type: ignore[attr-defined]
+    smoke_vm._pfb_dnsbl_domain_on = _dnsbl_domain_on  # type: ignore[attr-defined]
     smoke_vm._pfb_civm_ip = _civm_ip  # type: ignore[attr-defined]
     yield smoke_vm
 
@@ -384,29 +388,56 @@ def test_syslog_routing_and_rotation_registered(deployed_vm: SmokeVM) -> None:
 
 
 def test_syslog_on_dnsbl_event_exported(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
-    """ON ⇒ a pfblockerng record per DNSBL block in the dedicated file, host-side, no restart.
+    """OFF ⇒ no export record; ON ⇒ a pfblockerng record per DNSBL block, host-side, no restart.
 
-    Given: DNSBL blocking _dnsbl_domain (VIP); syslog export OFF (fixture default),
+    Given: DNSBL blocking TWO distinct domains (VIP); syslog export OFF (fixture default),
            so NO event line exists in pfblockerng_syslog.log yet.
-    When:  log_syslog is enabled (write_config ONLY — no restart) and the civm client
-           (192.168.1.10) resolves the blocked domain via pfSense (python writes
-           dnsbl.log, the host daemon tails it, re-reads the toggle live, and emits).
-    Then:  a NEW record appears in pfblockerng_syslog.log with act=dnsbl + the
-           queried name — proving the toggle took effect LIVE.
-    And:   the event did NOT leak into system.log; the CSV dnsbl.log was also written.
+    When:  domain_off is probed WHILE export is STILL OFF (no restart) — the DNSBL block
+           itself still fires (proven via the CSV dnsbl.log marker), but must export
+           nothing. THEN log_syslog is enabled (write_config ONLY — no restart) and the
+           civm client (192.168.1.10) resolves a SECOND, never-before-queried domain
+           (domain_on — dodges any residual Unbound/module state from the OFF-phase probe,
+           so the python hook is guaranteed to run fresh) via pfSense.
+    Then:  the OFF-phase probe produces NO new record in pfblockerng_syslog.log. The
+           ON-phase probe DOES produce a NEW record with act=dnsbl + the queried name —
+           proving the toggle took effect LIVE, and that OFF truly exported nothing (not
+           just "no probe happened yet").
+    And:   the event did NOT leak into system.log; the CSV dnsbl.log was written for BOTH probes.
     """
     vm = deployed_vm
-    domain: str = vm._pfb_dnsbl_domain  # type: ignore[attr-defined]
+    domain_off: str = vm._pfb_dnsbl_domain  # type: ignore[attr-defined]
+    domain_on: str = vm._pfb_dnsbl_domain_on  # type: ignore[attr-defined]
     civm_ip: str = vm._pfb_civm_ip  # type: ignore[attr-defined]
 
-    # Given: OFF before-state.
+    # Given: syslog export OFF (fixture default) — no event lines recorded yet.
     before = _pfb_event_lines(vm)
-    dnsbl_before = h.count_log_marker(vm, DNSBL_LOG, domain)
     sys_leak_before = len(_system_log_export_leaks(vm))
 
-    # When: enable LIVE (no restart) + probe from the civm client.
+    # Before: probe a blocked domain WHILE export is still OFF. The block itself must still
+    # fire (CSV assertion below) but must produce NO export line — the missing half of the
+    # toggle's before/after proof (CLAUDE.md: assert the before-state, not just the after).
+    dnsbl_off_before = h.count_log_marker(vm, DNSBL_LOG, domain_off)
+    ans_off = h.dns_probe_client(client_vm, domain_off, "A")
+    assert h.is_vip(ans_off), f"DNSBL block shape unexpected before enabling syslog: expected VIP, got {ans_off}"
+    time.sleep(FILTERLOG_SETTLE_SECS)
+
+    dnsbl_off_after = h.count_log_marker(vm, DNSBL_LOG, domain_off)
+    assert dnsbl_off_after > dnsbl_off_before, (
+        f"CSV dnsbl.log was NOT written for the OFF-phase probe (before {dnsbl_off_before}, after "
+        f"{dnsbl_off_after}) — the block itself must fire regardless of the syslog toggle"
+    )
+    after_off = _pfb_event_lines(vm)
+    assert len(after_off) == len(before), (
+        f"A pfblockerng export record appeared for {domain_off} while syslog export is OFF "
+        f"(before {len(before)} lines, after {len(after_off)}) — the OFF gate is not working.\n"
+        f"{syslog_export_state_snapshot(vm)}"
+    )
+
+    # When: enable LIVE (no restart) + probe a DIFFERENT, never-before-queried domain from
+    # the civm client (dodges any residual state from the OFF-phase probe above).
+    dnsbl_on_before = h.count_log_marker(vm, DNSBL_LOG, domain_on)
     _set_syslog_enabled(vm, on=True)
-    ans = h.dns_probe_client(client_vm, domain, "A")
+    ans = h.dns_probe_client(client_vm, domain_on, "A")
 
     # Then: DNSBL still blocks (additive).
     assert h.is_vip(ans), f"DNSBL block shape changed after enabling syslog: expected VIP, got {ans}"
@@ -414,10 +445,10 @@ def test_syslog_on_dnsbl_event_exported(deployed_vm: SmokeVM, client_vm: SmokeVM
     # Then: a NEW dedicated-file record (poll — tail/daemon latency). Match on
     # act=dnsbl + the queried name (qname=). NOTE: b_type is the MATCH type
     # ('DNSBL'/'TLD'/'Python'), NOT the sinkhole mode — there is no 'VIP' b_type.
-    line = _wait_for_event(vm, baseline_len=len(before), want=("act=dnsbl", f"qname={domain}", f"qip={civm_ip}"))
+    line = _wait_for_event(vm, baseline_len=len(after_off), want=("act=dnsbl", f"qname={domain_on}", f"qip={civm_ip}"))
     assert line, (
-        f"No new DNSBL export record after enabling export (LIVE, no restart) and probing {domain}.\n"
-        f"  expected a new line in {PFB_SYSLOG_LOG} with: act=dnsbl qname={domain} qip={civm_ip}\n"
+        f"No new DNSBL export record after enabling export (LIVE, no restart) and probing {domain_on}.\n"
+        f"  expected a new line in {PFB_SYSLOG_LOG} with: act=dnsbl qname={domain_on} qip={civm_ip}\n"
         f"  {syslog_export_state_snapshot(vm)}"
     )
 
@@ -427,11 +458,11 @@ def test_syslog_on_dnsbl_event_exported(deployed_vm: SmokeVM, client_vm: SmokeVM
         f"dedicated file ONLY.\n  leaks: {_system_log_export_leaks(vm)[-5:]!r}"
     )
 
-    # And: CSV dnsbl.log also written (additive).
-    dnsbl_after = h.count_log_marker(vm, DNSBL_LOG, domain)
-    assert dnsbl_after > dnsbl_before, (
-        f"CSV dnsbl.log was NOT written after enabling syslog (before {dnsbl_before}, after {dnsbl_after}) "
-        f"— export must be additive"
+    # And: CSV dnsbl.log also written for the ON-phase probe (additive).
+    dnsbl_on_after = h.count_log_marker(vm, DNSBL_LOG, domain_on)
+    assert dnsbl_on_after > dnsbl_on_before, (
+        f"CSV dnsbl.log was NOT written after enabling syslog (before {dnsbl_on_before}, after "
+        f"{dnsbl_on_after}) — export must be additive"
     )
 
 

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -58,6 +58,12 @@ CFG_V6SUPPRESSION = "installedpackages/pfblockerngipsettings/config/0/v6suppress
 # collection reads Permit aliases from (alerts.php:170-251).
 CFG_IPV4_LISTS = "installedpackages/pfblockernglistsv4/config"
 
+# The temporary Lock/Unlock state store ($pfb['dnsbl_unlock'], pfblockerng.inc:150).
+# Written SYNCHRONOUSLY by pfb_unlock() -- unlike the DNS-visible effect (an async
+# manifest patch + Unbound reload), so it is the reliable oracle for "this POST did
+# NOT touch the unlock state" (no swap-timing race to poll around).
+DNSBL_UNLOCK_STORE = "/tmp/dnsbl_unlock"
+
 
 def _csrf(webui: WebUI) -> str:
     """GET the alerts page and return its freshly-injected ``__csrf_magic`` token.
@@ -205,9 +211,13 @@ def test_dnsbl_remove_rejects_missing_type(
 
     Branch coverage for the validator's REJECT side (the accept side is the marquee
     lifecycle above): the handler exits with a savemsg and never toggles the unlock
-    store when ``dnsbl_type`` is empty (alerts.php:1380). The transition oracle is the
-    DNS shape: a feed-blocked domain stays VIP-blocked across the rejected POST (the
-    block is the before-state AND the after-state -- proving the POST did NOT unlock).
+    store when ``dnsbl_type`` is empty (alerts.php:1444-1448 -- BEFORE the
+    ``pfb_unlock()`` call at :1468). The primary oracle is the unlock store itself
+    (``$pfb['dnsbl_unlock']``, pfblockerng.inc:150): it is written SYNCHRONOUSLY by
+    ``pfb_unlock()``, so comparing its content before/after proves the handler did
+    NOT run that far -- a single un-polled DNS probe right after the POST cannot
+    rule out the async swap simply not having landed yet (a false pass). The DNS
+    shape is kept as a corroborating check (still VIP-blocked).
     """
     vm = smoke_vm
     domain = helpers.unique_domain("uireject")
@@ -219,15 +229,23 @@ def test_dnsbl_remove_rejects_missing_type(
     helpers.inject(vm, spec)
     helpers.reload(vm, "update")
     try:
-        # BEFORE: VIP-blocked.
+        # BEFORE: VIP-blocked, and the (synchronous) unlock store at its pre-POST content.
         before = helpers.dns_probe(vm, domain, "A")
         assert helpers.is_vip(before), f"{domain} expected VIP block before the rejected POST, got {before}"
+        store_before = helpers.read_log_file(vm, DNSBL_UNLOCK_STORE)
 
         # Reject: empty dnsbl_type. The handler must exit before toggling the store.
         resp = _post_action(webui, {"dnsbl_remove": "unlock", "domain": domain, "dnsbl_type": ""})
         assert not looks_like_login_page(resp.text), "rejected POST returned the login form (session lost)"
 
-        # AFTER: still VIP-blocked -- the rejected unlock did not lift the sinkhole.
+        # AFTER (real oracle): the synchronous unlock store is byte-for-byte unchanged --
+        # no swap-timing race, unlike a bare DNS probe right after the POST.
+        store_after = helpers.read_log_file(vm, DNSBL_UNLOCK_STORE)
+        assert store_after == store_before, (
+            f"dnsbl_unlock store changed after a REJECTED unlock POST: before={store_before!r} after={store_after!r}"
+        )
+
+        # Corroborating: still VIP-blocked.
         after = helpers.dns_probe(vm, domain, "A")
         assert helpers.is_vip(after), f"{domain} no longer VIP-blocked after a REJECTED unlock POST: {after}"
     finally:
@@ -1277,6 +1295,24 @@ def test_alerts_rows_render_whitelist_icons_oracle(
 # --------------------------------------------------------------------------- #
 
 
+def _row_containing(html_body: str, needle: str) -> str:
+    """Return the single ``<tr ...>...</tr>`` block containing ``needle``.
+
+    ``convert_dnsbl_log()`` prints one ``<tr>`` per event row (alerts.php:2571 /
+    2593) with the domain, group, and icons all inside it. A fixed byte-distance
+    window around a match can straddle the PREVIOUS or NEXT table row when rows
+    are dense, false-matching (or false-missing) a marker that belongs to a
+    neighbour -- row-isolating avoids that entirely.
+    """
+    idx = html_body.find(needle)
+    assert idx != -1, f"{needle!r} not found in rendered HTML"
+    tr_start = html_body.rfind("<tr", 0, idx)
+    assert tr_start != -1, f"no opening <tr found before {needle!r}"
+    tr_end = html_body.find("</tr>", idx)
+    assert tr_end != -1, f"no closing </tr> found after {needle!r}"
+    return html_body[tr_start : tr_end + len("</tr>")]
+
+
 def test_upstream_block_renders_cloud_icon_and_correct_group(
     webui: "WebUI",
     smoke_vm: helpers.SmokeVM,
@@ -1292,20 +1328,22 @@ def test_upstream_block_renders_cloud_icon_and_correct_group(
         Both are tested by injecting a synthetic ``Upstream_Block`` CSV line directly
         into ``dnsbl.log`` and asserting the rendered HTML.
 
-    Given: DNSBL is enabled (required for the DNSBL Python tab to appear); a
-        synthetic ``Upstream_Block`` line for a unique domain is appended to
-        ``/var/log/pfblockerng/dnsbl.log``.
+    Given: DNSBL is enabled (required for the DNSBL Python tab to appear); the
+        Alerts page GET BEFORE the seed shows neither the fresh domain nor the
+        cloud icon (before-state -- no false pass); a synthetic ``Upstream_Block``
+        line for a unique domain is appended to ``/var/log/pfblockerng/dnsbl.log``.
 
-    When: the Reports/Alerts page is GET-ted (default ``alert`` view, which renders
-        the ``DNSBL Python`` tab from ``dnsbl.log``).
+    When: the Reports/Alerts page is GET-ted again (default ``alert`` view, which
+        renders the ``DNSBL Python`` tab from ``dnsbl.log``).
 
-    Then:
-        (a) ``fa-cloud`` is present in the rendered HTML for that domain's row —
-            proving the bolt-icon override fired (Edit D step 9).
-        (b) the text ``Upstream`` appears near the domain and the text ``Unknown``
-            does NOT appear near it — proving the stale-entry correction was skipped
-            (Edit D step 8); without the skip, pfb_dnsbl_parse would rewrite the
-            group to 'Unknown'.
+    Then, all scoped to the domain's OWN ``<tr>`` row (never a byte-distance
+    window, which can straddle a neighbouring row):
+        (a) ``fa-cloud`` is present in that row — proving the bolt-icon override
+            fired (Edit D step 9).
+        (b) the text ``Upstream`` appears in that row and the text ``Unknown``
+            does NOT — proving the stale-entry correction was skipped (Edit D
+            step 8); without the skip, pfb_dnsbl_parse would rewrite the group to
+            'Unknown'.
 
     Cleanup: the appended log line is removed in ``finally`` (truncate the file back
         to its original size) so the session VM is clean for sibling tests.
@@ -1331,8 +1369,17 @@ def test_upstream_block_renders_cloud_icon_and_correct_group(
 
     helpers.set_dnsbl_enabled(vm, True)
 
+    # GIVEN (before-state): the fresh, never-before-seen domain is absent before
+    # the seed, so a later "present" assertion proves THIS row caused it.
+    pre = webui.get(ALERTS_PAGE)
+    assert not looks_like_login_page(pre.text), "alerts page GET returned login form before mutation (session lost)"
+    assert domain not in pre.text, (
+        f"Precondition failed: synthetic domain {domain!r} already present before the "
+        f"synthetic row was seeded — cannot prove causation."
+    )
+
     try:
-        # GIVEN: append the synthetic upstream-block line via SSH tee -a.
+        # WHEN: append the synthetic upstream-block line via SSH tee -a.
         append_result = subprocess.run(
             vm.ssh_argv("tee", "-a", dnsbl_log),
             input=csv_line,
@@ -1353,26 +1400,25 @@ def test_upstream_block_renders_cloud_icon_and_correct_group(
         )
         html_body = resp.text
 
-        # THEN (a): the cloud icon class is present in the page (Edit D step 9).
-        assert "fa-cloud" in html_body, (
-            f"fa-cloud icon class absent from the rendered Alerts page — "
-            f"the upstream-block icon override (Edit D step 9) did not fire for {domain!r}"
+        # Row-isolate: the domain's OWN <tr>, not a byte-distance window that can
+        # straddle a neighbouring row.
+        row = _row_containing(html_body, domain)
+
+        # THEN (a): the cloud icon class is present in the domain's OWN row (Edit D step 9).
+        assert "fa-cloud" in row, (
+            f"fa-cloud icon class absent from {domain!r}'s row — "
+            f"the upstream-block icon override (Edit D step 9) did not fire: {row!r}"
         )
 
-        # THEN (b): the domain appears and its row shows group 'Upstream', not 'Unknown'.
-        # We find the domain in the rendered HTML and inspect a window around it.
-        dom_idx = html_body.find(domain)
-        assert dom_idx != -1, f"synthetic upstream-block domain {domain!r} not found in the rendered Alerts page HTML"
-        # Look in a 2 kB window around the domain occurrence for the Group value.
-        window = html_body[max(0, dom_idx - 1024) : dom_idx + 1024]
-        assert "Upstream" in window, (
-            f"Group 'Upstream' not found near domain {domain!r} in rendered HTML — "
-            f"stale-entry correction may have overwritten it (Edit D step 8 check failed)"
+        # THEN (b): the row shows group 'Upstream', not 'Unknown'.
+        assert "Upstream" in row, (
+            f"Group 'Upstream' not found in {domain!r}'s row — "
+            f"stale-entry correction may have overwritten it (Edit D step 8 check failed): {row!r}"
         )
-        assert "Unknown" not in window, (
-            f"Group 'Unknown' found near domain {domain!r} in rendered HTML — "
+        assert "Unknown" not in row, (
+            f"Group 'Unknown' found in {domain!r}'s row — "
             f"pfb_dnsbl_parse rewrote the group, meaning $isUpstream guard did not fire "
-            f"(Edit D step 8 regression)"
+            f"(Edit D step 8 regression): {row!r}"
         )
     finally:
         # Truncate dnsbl.log back to its pre-test size to remove the appended line.

--- a/tests/smoke/ui/test_blacklist.py
+++ b/tests/smoke/ui/test_blacklist.py
@@ -386,7 +386,7 @@ def test_blacklist_lang_autosubmit_persists_without_save(
     original = helpers.config_get(vm, CFG_LANG)
     restore = original or "EN"
     try:
-        assert restore != "DE" or original == "DE", "baseline sanity for blacklist_lang"
+        assert original != "DE", f"blacklist_lang already 'DE' before the valid POST (original={original!r})"
         # VALID 'DE' via the no-save path.
         _direct_post(webui, {"blacklist_lang": "DE"})
         assert helpers.config_get(vm, CFG_LANG) == "DE", "blacklist_lang did not persist 'DE' (no-save path)"

--- a/tests/smoke/ui/test_browser_category_edit.py
+++ b/tests/smoke/ui/test_browser_category_edit.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import quote
 
 import pytest
 
@@ -242,11 +243,13 @@ def test_chgstate_button_click_sets_enable_all_value(
     signal (category_edit.php:142-143). The source-row ``state-*`` selects flip
     only after the resulting submit/round-trip, so they are NOT asserted here.
 
-    Before->after: the button is rendered with its default value, and the click
-    sets it to ``Enable All``. The pre-click value comes from the Form_Button
-    label ("Enable All") -- the assertion is the change is CAUSED by the click, so
-    drive it through the .value DOM property (which a plain rendered button leaves
-    as its label) and prove the handler ran.
+    Before->after: the button's OWN rendered label is already "Enable All"
+    (``Form_Button('chgstate', 'Enable All', ...)``), so capturing the DOM value
+    before the click and comparing it to the post-click value is not a real
+    transition -- before == after even if the click handler were deleted
+    entirely. Seed a sentinel value into the button via JS FIRST, then click, and
+    assert the value became 'Enable All' -- only the handler running can cause
+    that flip.
     """
     page = browser_page
     _open(page, webui, ADVANCED_IP_EDITOR)
@@ -254,8 +257,12 @@ def test_chgstate_button_click_sets_enable_all_value(
     btn = page.locator("#chgstate")
     expect(btn).to_be_attached(timeout=JS_TIMEOUT_MS)
 
-    # BEFORE: the handler has not run; capture the rendered value via the DOM.
+    # BEFORE: seed a sentinel so the post-click value can only come from the
+    # handler -- the button's rendered label already equals 'Enable All', so a
+    # bare pre-click read would prove nothing (before == after with no handler).
+    btn.evaluate("el => el.value = '__pre__'")
     before_value = btn.evaluate("el => el.value")
+    assert before_value == "__pre__", f"sentinel seed did not take, got {before_value!r}"
     _shot(page, screenshot_dir, "chgstate_before")
 
     # Fire the bound jQuery click handler. The button is in the (visible) Source
@@ -263,13 +270,73 @@ def test_chgstate_button_click_sets_enable_all_value(
     # value-set runs without submitting the form away from the page under test.
     btn.dispatch_event("click")
 
-    # AFTER: the handler set the button value to 'Enable All'.
+    # AFTER: the handler set the button value to 'Enable All' -- the sentinel is gone.
     expect(btn).to_have_js_property("value", "Enable All", timeout=JS_TIMEOUT_MS)
     after_value = btn.evaluate("el => el.value")
     assert after_value == "Enable All", (
         f"expected 'Enable All' after click, got {after_value!r} (before {before_value!r})"
     )
     _shot(page, screenshot_dir, "chgstate_after")
+
+
+def test_chgstate_click_populates_act_atype_when_present(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """`#chgstate` click also writes `#act`/`#atype` when the page carried them (zero prior coverage).
+
+    The click handler (pfBlockerNG.js:172-181) has TWO guarded arms above the
+    unconditional value-set proven by the sibling test:
+    ``if (action.length > 0) { $('#act').val(action); }`` and the ``atype``
+    analog. The sibling test opens the editor with no ``?act``/``?atype`` GET
+    params, so both JS locals are '' and NEITHER guard ever fires -- this test
+    is the only coverage of that branch.
+
+    A real, legitimate combo that makes both non-empty: the Reports page's
+    "add to Whitelist" redirect (pfblockerng_alerts.php:1587) navigates here
+    with ``act=addgroup&atype=Whitelist|<ip>|<descr>`` -- validated server-side
+    by ``pfb_filter_whitelist_atype()`` (pfblockerng.inc:738-746) -- which also
+    makes the server pre-render the hidden inputs ``#act``/``#atype``
+    (``Form_Input('atype', 'atype', 'hidden', ...)`` /
+    ``Form_Input('act', 'act', 'hidden', ...)``, category_edit.php:1012,1015)
+    at those SAME values.
+
+    Before->after: because the server ALSO pre-renders ``#act``/``#atype`` at
+    the values the click handler would write, a bare pre-click DOM read is
+    already correct -- the same false-transition trap as the sibling test.
+    Seed a sentinel into both hidden fields via JS FIRST (mirrors the fix
+    above), then click, and assert they flip to the real ``act``/``atype``
+    values -- only the guarded arms running can cause that.
+    """
+    page = browser_page
+    ip = "192.0.2.55"  # RFC 5737 TEST-NET-1 -- inert, never routed
+    descr = "smoke-chgstate-atype"
+    atype_value = f"Whitelist|{ip}|{descr}"
+    path = f"{ADVANCED_IP_EDITOR}&act=addgroup&atype={quote(atype_value, safe='')}"
+    _open(page, webui, path)
+
+    act = page.locator("#act")
+    atype = page.locator("#atype")
+    btn = page.locator("#chgstate")
+    expect(act).to_be_attached(timeout=JS_TIMEOUT_MS)
+    expect(atype).to_be_attached(timeout=JS_TIMEOUT_MS)
+    expect(btn).to_be_attached(timeout=JS_TIMEOUT_MS)
+
+    # BEFORE: seed a sentinel into both hidden fields -- the server already
+    # pre-rendered them at the SAME values the click handler would write, so a
+    # bare pre-click read would prove nothing about the click handler.
+    act.evaluate("el => el.value = '__pre__'")
+    atype.evaluate("el => el.value = '__pre__'")
+    _shot(page, screenshot_dir, "chgstate_atype_before")
+
+    btn.dispatch_event("click")
+
+    # AFTER: both guarded arms fired -- the sentinels are replaced by the real
+    # action/atype JS locals (pfBlockerNG.js:174-179), proving the branch ran.
+    expect(act).to_have_js_property("value", "addgroup", timeout=JS_TIMEOUT_MS)
+    expect(atype).to_have_js_property("value", atype_value, timeout=JS_TIMEOUT_MS)
+    _shot(page, screenshot_dir, "chgstate_atype_after")
 
 
 def test_addrow_clones_a_source_row_and_renumbers(
@@ -490,9 +557,13 @@ def test_alias_type_port_field_rejects_network_alias(
     rowid = _free_rowid_ipv4(vm)
     base = f"{_CFG_IPV4}/{rowid}"
 
-    _mk_alias(vm, net_alias, "network", "192.0.2.0/24")
-    _mk_alias(vm, port_alias, "port", "8080")
     try:
+        # Both aliases are created INSIDE the try: a failure creating the second
+        # (e.g. the network alias) must not leak the first -- the finally below
+        # removes both unconditionally.
+        _mk_alias(vm, net_alias, "network", "192.0.2.0/24")
+        _mk_alias(vm, port_alias, "port", "8080")
+
         # BEFORE: rowid is free (no aliasports_in set yet).
         assert helpers.config_get(vm, f"{base}/aliasports_in") == "", (
             f"precondition: rowid {rowid} not free (aliasports_in already set)"

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 from typing import TYPE_CHECKING
 
 import pytest
@@ -229,15 +230,15 @@ def test_dnsbl_logging_select_valid_and_bogus_coerces_to_default(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
 ) -> None:
-    """``logging`` stores a valid key, and a bogus value coerces to the default.
+    """``logging`` stores each of its FIVE valid keys, and a bogus value coerces to the default.
 
-    ``$options_logging`` keys are enabled / disabled / disabled_log. The
-    select-coercion loop replaces a non-key value with ``$select_options['logging']``
-    -- which is the literal ``'Enabled'`` (capital E; NOT itself a key of
-    ``$options_logging``), and the save SUCCEEDS storing that default. Branch
-    coverage: drive a valid 'enabled', then a valid 'disabled' (the distinct second
-    key), then a bogus 'bogus' that coerces to 'Enabled'. Transition: each step
-    asserts the value differs before it is driven.
+    ``$options_logging`` (category_edit.php:442-446) has FIVE keys: enabled,
+    disabled_log, disabled, nxdomain_log, nxdomain. The select-coercion loop
+    replaces a non-key value with ``$select_options['logging']`` -- which is the
+    literal ``'Enabled'`` (capital E; NOT itself a key of ``$options_logging``),
+    and the save SUCCEEDS storing that default. Branch coverage: drive all FIVE
+    valid keys in turn, then a bogus 'bogus' that coerces to 'Enabled'. Transition:
+    each step asserts the value differs before it is driven.
     """
     vm = smoke_vm
     rowid = _free_rowid(vm, CFG_DNSBL)
@@ -247,9 +248,11 @@ def test_dnsbl_logging_select_valid_and_bogus_coerces_to_default(
         # Create the alias with logging=enabled.
         _post_form(webui, _dnsbl_payload(rowid, "smokelog", logging="enabled"))
         assert helpers.config_get(vm, cfg) == "enabled", "logging not stored as 'enabled'"
-        # VALID second key -> stored verbatim (a real transition).
-        _post_form(webui, _dnsbl_payload(rowid, "smokelog", logging="disabled"))
-        assert helpers.config_get(vm, cfg) == "disabled", "logging not stored as 'disabled'"
+        # The remaining four valid keys, each a real transition from the previous value.
+        for key in ("disabled_log", "disabled", "nxdomain_log", "nxdomain"):
+            _post_form(webui, _dnsbl_payload(rowid, "smokelog", logging=key))
+            got = helpers.config_get(vm, cfg)
+            assert got == key, f"logging not stored as {key!r}, got {got!r}"
         # BOGUS -> coerced to the default 'Enabled' (save SUCCEEDS, value != bogus).
         _post_form(webui, _dnsbl_payload(rowid, "smokelog", logging="bogus"))
         got = helpers.config_get(vm, cfg)
@@ -389,31 +392,88 @@ def test_ipv4_alias_permit_any_guard_rejects_and_valid_persists(
 # --------------------------------------------------------------------------- #
 
 
+_ASN_CACHE = "/usr/local/www/pfblockerng/pfblockerng_asn.txt"
+
+
+def _seed_file(vm: helpers.SmokeVM, path: str, content: str, *, timeout: float = 30.0) -> None:
+    """Overwrite (not append) ``path`` on the guest with ``content`` via ``tee``."""
+    result = subprocess.run(
+        vm.ssh_argv("tee", path),
+        input=content,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    assert result.returncode == 0, f"_seed_file({path!r}) failed: rc={result.returncode} {result.stderr!r}"
+
+
 def test_asn_autocomplete_term_returns_json_list(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
 ) -> None:
-    """The ASN autocomplete (``isAjax`` + ``?term=...``) returns a JSON array.
+    """The ASN autocomplete (``isAjax`` + ``?term=...``) returns the cached rows that match.
 
     The page's top branch (lines 34-66) serves an AJAX JSON list when
     ``isAjax()`` AND ``$_GET['term']`` has length > 2: it filters the cached ASN
-    list (``pfblockerng_asn.txt``) by the term and ``echo json_encode($result)``;
-    when the file is absent the cache is ``[]`` -> an empty JSON array. Either way
-    the RESPONSE SHAPE is a JSON list -- this is read-only (no config write), so
-    it is safe to assert directly. ``isAjax()`` keys on the
-    ``X-Requested-With: XMLHttpRequest`` header, which we send.
+    list (``pfblockerng_asn.txt``) by the term and ``echo json_encode($result)``.
+    Without seeding the cache file, "returns a JSON list" is vacuously true on the
+    empty ``[]`` fallback -- this seeds the file with real rows and asserts a
+    matching ``?term=`` returns the seeded entry, and separately proves the
+    length gate: a 1-char term must NOT hit the AJAX branch at all (falls through
+    to the normal HTML page render, line 34's ``mb_strlen(...) > 2`` guard).
+
+    GOTCHA: the ASN list is cached in ``$_SESSION['pfb_asn_list_data']`` and
+    cleared on any PLAIN (non-AJAX) page GET (lines 67-71) -- so the seeded file
+    is only actually re-read once that cache has been invalidated. Seed, do ONE
+    plain GET, THEN issue the ``?term=`` request.
     """
-    resp = webui.get(
-        CATEGORY_PAGE,
-        params={"term": "AS3"},
-        headers={"X-Requested-With": "XMLHttpRequest"},
-    )
-    assert resp.status_code == 200, f"ASN autocomplete -> HTTP {resp.status_code} (expected 200)"
-    assert not looks_like_login_page(resp.text), "ASN autocomplete returned the login form (session lost)"
-    parsed = json.loads(resp.text)
-    assert isinstance(parsed, list), f"ASN autocomplete must return a JSON list, got {type(parsed).__name__}"
-    # Each returned entry (if any) is a string ASN line from the cached list.
-    assert all(isinstance(item, str) for item in parsed), "ASN autocomplete list entries must be strings"
+    vm = smoke_vm
+    had_file = vm.ssh("test", "-f", _ASN_CACHE).returncode == 0
+    original = helpers.read_log_file(vm, _ASN_CACHE) if had_file else ""
+    try:
+        _seed_file(vm, _ASN_CACHE, "AS3320  Deutsche Telekom AG\nAS16509 Amazon.com, Inc.\n")
+
+        # Invalidate the per-session cache (a plain, non-AJAX GET) so the NEXT
+        # ?term= request re-reads our seeded file instead of a stale session cache.
+        plain = webui.get(CATEGORY_PAGE, params={"type": "ipv4"})
+        assert not looks_like_login_page(plain.text), "plain GET returned the login form (session lost)"
+
+        resp = webui.get(
+            CATEGORY_PAGE,
+            params={"term": "AS3320"},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200, f"ASN autocomplete -> HTTP {resp.status_code} (expected 200)"
+        assert not looks_like_login_page(resp.text), "ASN autocomplete returned the login form (session lost)"
+        parsed = json.loads(resp.text)
+        assert isinstance(parsed, list), f"ASN autocomplete must return a JSON list, got {type(parsed).__name__}"
+        assert all(isinstance(item, str) for item in parsed), "ASN autocomplete list entries must be strings"
+        assert any("AS3320" in item for item in parsed), (
+            f"expected the seeded 'AS3320' row in the ?term= result, got {parsed!r}"
+        )
+
+        # BRANCH: a term of length <= 2 must NOT hit the AJAX JSON branch (line 34's
+        # `mb_strlen($_GET['term']) > 2` gate) -- it renders the normal HTML page instead.
+        short = webui.get(
+            CATEGORY_PAGE,
+            params={"type": "ipv4", "term": "A"},
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert not looks_like_login_page(short.text), "short-term GET returned the login form (session lost)"
+        short_is_json = True
+        try:
+            json.loads(short.text)
+        except json.JSONDecodeError:
+            short_is_json = False
+        assert not short_is_json, (
+            f"a 1-char ?term= must NOT return the JSON autocomplete list, got: {short.text[:200]!r}"
+        )
+    finally:
+        if had_file:
+            _seed_file(vm, _ASN_CACHE, original)
+        else:
+            vm.ssh("rm", "-f", _ASN_CACHE)
 
 
 # --------------------------------------------------------------------------- #
@@ -529,9 +589,12 @@ def test_ipv4_advanced_inout_full_save_persists_and_reloads(
     rowid = _free_rowid(vm, CFG_IPV4)
     base = f"{CFG_IPV4}/{rowid}"
 
-    _mk_alias(vm, port_alias, "port", _PORT_ALIAS_ADDR)
-    _mk_alias(vm, net_alias, "network", _NET_ALIAS_CIDR)
     try:
+        # Both aliases are created INSIDE the try: a failure creating the second
+        # must not leak the first -- the finally below removes both unconditionally.
+        _mk_alias(vm, port_alias, "port", _PORT_ALIAS_ADDR)
+        _mk_alias(vm, net_alias, "network", _NET_ALIAS_CIDR)
+
         # BEFORE: all advanced keys at the free slot read '' (POST must CAUSE them).
         for key in (
             "autoproto_in",

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -1004,7 +1004,11 @@ def test_safesearch_doh_list_multiselect_valid_and_bogus_clears(
     """
     vm = smoke_vm
     cfg = "installedpackages/pfblockerngsafesearch/safesearch_doh_list"
+    original = helpers.config_get(vm, cfg)
     try:
+        assert original != "dns.google", (
+            f"safesearch_doh_list already 'dns.google' before the valid POST (original={original!r})"
+        )
         # VALID single key -> stored verbatim (doh kept Disable so the guard is inert).
         got = _post_and_get(
             webui, vm, DNSBL_PAGE, {"safesearch_doh": "Disable", "safesearch_doh_list": "dns.google"}, cfg

--- a/tests/smoke/ui/test_log.py
+++ b/tests/smoke/ui/test_log.py
@@ -38,12 +38,27 @@ Every flow is a TRUE transition test (CLAUDE.md transition-test rule):
 Each flow RESTORES the box (removes the seeded file / leaves the cleared file
 gone) in a ``finally`` so a mid-test failure cannot poison the session-scoped VM
 for the sibling flows.
+
+THROWAWAY filenames, never the real production logs: ``pfb_validate_filepath()``
+(pfblockerng_log.php:207-222) validates only the DIRECTORY (``pathinfo(...,
+PATHINFO_DIRNAME)``), never the basename -- so ANY file directly under
+``/var/log/pfblockerng`` passes. These flows used to seed/clear the box's REAL
+``pfblockerng.log`` / ``error.log`` / ``ip_block.log`` / ``py_error.log`` /
+``dnsbl.log`` directly, clobbering real content a live box would have
+accumulated. Every target is now a unique, uuid-prefixed basename under the same
+allowed directory instead (:func:`_throwaway_log`). The clear handler's
+py_error.log/dnsbl.log special cases are themselves SUBSTRING matches
+(``strpos($s_logfile, 'py_error.log')`` etc., :308,315-317), so a suffix-preserving
+throwaway name (e.g. ``<uuid>-py_error.log``) still exercises the exact same
+branch without ever touching the real file.
 """
 
 from __future__ import annotations
 
 import base64
+import os
 import subprocess
+import uuid
 from typing import TYPE_CHECKING
 
 import pytest
@@ -173,6 +188,18 @@ def _rm(vm: helpers.SmokeVM, path: str) -> None:
     vm.ssh("/bin/rm", "-f", path)
 
 
+def _throwaway_log(basename_suffix: str) -> str:
+    """A collision-proof ``LOG_DIR`` path that still ends in ``basename_suffix``.
+
+    ``pfb_validate_filepath`` admits every file under ``LOG_DIR`` regardless of
+    basename, and the clear handler's special-case branches key on a SUBSTRING
+    match of the basename (``strpos($s_logfile, 'py_error.log')`` / ``'dnsbl.log'``
+    / ...). Keeping the interesting suffix means a throwaway name still hits the
+    SAME branch as the real production log -- without ever touching it.
+    """
+    return f"{LOG_DIR}/{uuid.uuid4().hex[:12]}-{basename_suffix}"
+
+
 def _decode_load_body(body: str) -> tuple[str, str]:
     """Parse the ``|code|info|base64|`` AJAX envelope -> ``(code, decoded_text)``.
 
@@ -206,7 +233,7 @@ def test_load_returns_real_file_content(webui: WebUI, smoke_vm: helpers.SmokeVM)
     removing the seed file in finally.
     """
     vm = smoke_vm
-    target = f"{LOG_DIR}/pfblockerng.log"
+    target = _throwaway_log("pfblockerng.log")
     marker = f"pfb-ui-load-{helpers.unique_domain('load')}"
     expected = f"{marker}\n"
     _seed_file(vm, target, expected)
@@ -264,7 +291,7 @@ def test_download_streams_file_with_attachment_header(webui: WebUI, smoke_vm: he
     basename as an attachment. Restored in finally.
     """
     vm = smoke_vm
-    target = f"{LOG_DIR}/error.log"
+    target = _throwaway_log("error.log")
     payload = f"pfb-ui-download-{helpers.unique_domain('dl')}\n"
     _seed_file(vm, target, payload)
     try:
@@ -275,9 +302,10 @@ def test_download_streams_file_with_attachment_header(webui: WebUI, smoke_vm: he
         assert not looks_like_login_page(resp.text), "download POST returned the login form (session lost)"
         # AFTER (oracle): the streamed body equals the on-box file content.
         assert resp.text == _cat(vm, target), f"download body {resp.text!r} != on-box file {_cat(vm, target)!r}"
-        # The attachment header names the file's basename (source: header() call).
+        # The attachment header names the file's OWN basename (source: header() call).
         disp = resp.headers.get("Content-Disposition", "")
-        assert 'attachment; filename="error.log"' in disp, f"unexpected Content-Disposition: {disp!r}"
+        expected_name = os.path.basename(target)
+        assert f'attachment; filename="{expected_name}"' in disp, f"unexpected Content-Disposition: {disp!r}"
         # The file is read-only on download -- it must remain on the box, unchanged.
         assert _cat(vm, target) == payload, "download altered the source file (must be read-only)"
     finally:
@@ -320,7 +348,7 @@ def test_clear_plain_log_unlinks_file(webui: WebUI, smoke_vm: helpers.SmokeVM) -
     POST clear, assert the file is now ABSENT (AFTER). Restore: ensure it's gone.
     """
     vm = smoke_vm
-    target = f"{LOG_DIR}/ip_block.log"
+    target = _throwaway_log("ip_block.log")
     _seed_file(vm, target, f"pfb-ui-clear-plain-{helpers.unique_domain('clr')}\n")
     try:
         # BEFORE: present and non-empty.
@@ -348,7 +376,7 @@ def test_clear_py_error_truncates_in_place(webui: WebUI, smoke_vm: helpers.Smoke
     size 0 (AFTER) -- proving truncate, not unlink. Restore: remove the file.
     """
     vm = smoke_vm
-    target = f"{LOG_DIR}/py_error.log"
+    target = _throwaway_log("py_error.log")
     _seed_file(vm, target, f"pfb-ui-clear-py-{helpers.unique_domain('py')}\n")
     try:
         assert _exists(vm, target), "seeded py_error.log missing before clear"
@@ -378,7 +406,7 @@ def test_clear_dnsbl_log_unlinks_then_retouches_empty(webui: WebUI, smoke_vm: he
     Restore: remove the file.
     """
     vm = smoke_vm
-    target = f"{LOG_DIR}/dnsbl.log"
+    target = _throwaway_log("dnsbl.log")
     _seed_file(vm, target, f"pfb-ui-clear-dnsbl-{helpers.unique_domain('dns')}\n")
     try:
         assert _exists(vm, target), "seeded dnsbl.log missing before clear"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1193,9 +1193,18 @@ def test_software_page_hidden_when_override_forces_off(
     """Forcing the override 'off' hides the page DETERMINISTICALLY — independent of install %R.
 
     The 'off' branch must win even on a box that WOULD auto-detect as our-build, so support can
-    force the page away. GET (redirects not followed) -> the guard's 3xx to /index.php, marker
-    absent — the explicit negative branch paired with the forced-on positive above.
+    force the page away. This Tier-A deploy is a SIDELOAD (%R empty), so the provenance gate
+    already hides the page by DEFAULT (the tests above) — forcing 'off' alone would be
+    indistinguishable from that default no-op. Force 'on' FIRST and assert the page IS visible
+    (the sibling positive branch, re-proven here as the before-state), THEN force 'off' on the
+    SAME box and assert it becomes hidden again — a real transition proving 'off' is what caused
+    the hide, not the deploy's own default state.
     """
+    with software_panel_forced(smoke_vm, "on"):
+        resp = webui.get(_SOFTWARE_PAGE)
+        result = evaluate_render(_SOFTWARE_PAGE, resp.status_code, resp.text, (_SOFTWARE_PANEL_MARKER,))
+        assert result.ok, f"forced-on Software page render failed (precondition): {result.detail}"
+
     with software_panel_forced(smoke_vm, "off"):
         resp = webui.get(_SOFTWARE_PAGE, allow_redirects=False)
         assert resp.status_code in (301, 302, 303, 307, 308), (

--- a/tests/smoke/ui/test_sync.py
+++ b/tests/smoke/ui/test_sync.py
@@ -37,10 +37,12 @@ below depend on these; they are not guessed):
 
 Every flow is a TRUE transition test (CLAUDE.md): it seeds + asserts the BEFORE
 state, drives the CSRF POST, asserts the AFTER state via the config.xml oracle,
-then RESTORES the box (asserting the reverse where it applies) so the
-session-scoped VM is left clean for sibling flows. The sync config node is
-snapshotted and force-restored in ``finally`` so a mid-test failure cannot poison
-Tier A or the other flows.
+then RESETS the sync config node to a FIXED, deterministic baseline in
+``finally`` (:func:`_seed_sync` -- disabled/150/no rows; NOT a snapshot of
+whatever was there before the test) so a mid-test failure cannot poison Tier A
+or the other flows. Every flow calls the same ``_seed_sync`` both before and
+after, so no flow depends on -- or needs to restore -- another's leftover
+CFG_SYNC state.
 
 This page is a plain form handler gating on the ``save`` button, but its rendered
 form ALWAYS includes a placeholder Target row whose empty ``varsyncipaddress-0``


### PR DESCRIPTION
Part of #582 — the validated per-test tail of the smoke/UI reliability audit. Every item in the issue's tables was re-verified against current `devel` before fixing; this PR lands the ~30 items that still hold, as five focused commits. Test-only (plus `scripts/bench_pfctl_tables.sh`); no `src/` changes.

## What each commit fixes

1. **Theater probes (matrix/abp)** — 8 "resolves" assertions were masked by `control_local_data` host overrides (served as Unbound local-data *before* the python DNSBL module, so a broken whitelist/ABP exception/IDN branch still passed). Probes now travel the real stub-upstream path (`unblock_egress()` + assert `STUB_DNS_A`), same pattern as 7efe957e. Also: `test_abp_catastrophic_regex_dropped` now probes *which* pattern survived, not just `count==1`.
2. **tick/feeds/adr40/safesearch** — tick skip-test gains a positive control (seeded SafeSearch CNAME row + stub resolver makes `ss_refresh` deterministically log on that tick, proving "tick ran and chose to skip" vs "tick never ran"; row + `pfbextdns` restored in `finally`); wiped-ledger jitter asserted from the ledger's own `jitter` field; feeds reingest asserts the `content changed` verdict its docstring promises; SSRF-filter BLOCK branch asserts the positive "non-permitted address — skipped" marker; adr40 idempotence now forces a refetch so `pfb_alias_set_different()` actually runs on the unchanged set; a vacuous safesearch cache assert deleted.
3. **Loud gate errors (syslog/upstream/redirect/dot_doq)** — upstream counter asserts an exact `delta == 1`; DNSBL syslog-export test gains a probe-while-OFF before-state (second seeded domain dodges the resolver cache); `_pfctl_sn_redir_protos`, `_pfctl_sr_block_853_protos`, and `_pfctl_sr_block_853_has_self_exempt` now raise on `pfctl` rc≠0 instead of reading an error as "rule absent" (caller audit: no site legitimately relied on the collapse). The ip-block skip→fail item was independently fixed on `devel` (1d97f08b) mid-flight; this PR keeps that version.
4. **OS-state leaks** — nightly-install live-URL test removes the same-named stale `file://` repo conf that alphabetically shadowed the HTTPS URL (libpkg last-wins); `/etc/hosts` pins snapshot/restore at the shared `pin_pages_hosts` helper (both call sites); generated rc.d hook removed in `finally`; `lan_rule_preserve` fixed-time sleeps replaced with `apply_filter_sync`; managed-objects user VIP/NAT rows and dot_doq's seeded lo0 rule get idempotent `finally` teardowns; bench sweeps register a pytest finalizer and `bench_pfctl_tables.sh` snapshots + restores `net.pf.request_maxcount` / pf table-entries limits.
5. **UI tier** — real before-states (sentinel before `#chgstate` click; Software-page on→off transition; alerts fa-cloud pre-assert + row-isolated window; `original != target` guards in functional/blacklist); `/tmp/dnsbl_unlock` byte-compare as the reject oracle; ASN autocomplete seeded + <2-char branch; DNSBL logging select drives all five real keys; first coverage of the `#act`/`#atype` JS handler arms; log tests use throwaway uuid basenames instead of clobbering real box logs; alias seeding moved inside `try` (two files); sync docstring corrected.

## Verified-but-not-fixed (issue rows resolved without code)

Re-verification found several rows already fixed on `devel` (7a8955ee, #570, 8a5f3075, 8863d8f0, #576 egress restore, 1d97f08b) and a few whose prescriptions don't hold (details in the issue comment). Deferred to their own follow-ups: the UI-tier per-test `reset_pfb_baseline` finalizer (needs a measured runtime delta), the feeds verdict-line `[ header ]` prefix (src change, risk low today), ADR-41 `pass_order` live wiring (ADR-41 Phase 4), and the two items the issue already defers to the new baked image / two-VM runs.

## Validation

Unit suite, ruff, mypy, shellcheck, and smoke collection green locally. These are dispatch-only Tier-B suites — impacted-scope `smoke.yml` + `ui-tests.yml` runs dispatched on this branch validate the changed modules on a live VM.
