### PR TITLE
pfblockerng: over-engineering cleanup backlog (#563)

### DIFF
--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -58,6 +58,8 @@ import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pfb_pkg import zstd_compress
+
 # --------------------------------------------------------------------------- #
 # Small FreeBSD-ports Makefile evaluator
 #
@@ -1151,7 +1153,14 @@ def write_pkg(b: Build, out_path: Path, compression: str) -> None:
 
         out_path.write_bytes(lzma.compress(tar_bytes, preset=6))
     else:
-        out_path.write_bytes(_zstd_compress(tar_bytes))
+        out_path.write_bytes(
+            zstd_compress(
+                tar_bytes,
+                BuildError,
+                "zstd compression needs the `zstd` binary or the python `zstandard` "
+                "module (brew install zstd / apt install zstd), or pass --compression xz",
+            )
+        )
 
 
 def _add_meta(tf: tarfile.TarFile, name: str, data: bytes) -> None:
@@ -1162,23 +1171,6 @@ def _add_meta(tf: tarfile.TarFile, name: str, data: bytes) -> None:
     ti.uname, ti.gname = "root", "wheel"
     ti.mtime = 0
     tf.addfile(ti, io.BytesIO(data))
-
-
-def _zstd_compress(data: bytes) -> bytes:
-    try:
-        import zstandard
-
-        return zstandard.ZstdCompressor(level=19).compress(data)
-    except ImportError:
-        pass
-    zstd = shutil.which("zstd")
-    if not zstd:
-        raise BuildError(
-            "zstd compression needs the `zstd` binary or the python `zstandard` "
-            "module (brew install zstd / apt install zstd), or pass --compression xz"
-        )
-    p = subprocess.run([zstd, "-q", "-19", "-c"], input=data, stdout=subprocess.PIPE, check=True)
-    return p.stdout
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -105,7 +105,7 @@ import tempfile
 from collections.abc import Callable
 from pathlib import Path
 
-from pfb_pkg import PkgError, pkg_version_sort_key, read_compact_manifest
+from pfb_pkg import PkgError, pkg_version_sort_key, read_compact_manifest, zstd_compress
 
 # --------------------------------------------------------------------------- #
 # Catalog descriptor (meta.conf / meta) — byte-identical to real `pkg repo`.
@@ -243,22 +243,6 @@ def _data_blob(objs: list[dict]) -> bytes:
 # --------------------------------------------------------------------------- #
 
 
-def _zstd_compress(data: bytes) -> bytes:
-    try:
-        import zstandard
-
-        return zstandard.ZstdCompressor(level=19).compress(data)
-    except ImportError:
-        pass
-    zstd = shutil.which("zstd")
-    if not zstd:
-        raise BuildRepoError(
-            "zstd compression needs the `zstd` binary or the python `zstandard` module "
-            "(brew install zstd / apt install zstd)"
-        )
-    return subprocess.run([zstd, "-q", "-19", "-c"], input=data, stdout=subprocess.PIPE, check=True).stdout
-
-
 def _tar_one(member_name: str, data: bytes) -> bytes:
     raw = io.BytesIO()
     with tarfile.open(fileobj=raw, mode="w", format=tarfile.USTAR_FORMAT) as tf:
@@ -274,7 +258,14 @@ def _tar_one(member_name: str, data: bytes) -> bytes:
 
 
 def write_zstd_tar(member_name: str, data: bytes, out_path: Path) -> None:
-    out_path.write_bytes(_zstd_compress(_tar_one(member_name, data)))
+    out_path.write_bytes(
+        zstd_compress(
+            _tar_one(member_name, data),
+            BuildRepoError,
+            "zstd compression needs the `zstd` binary or the python `zstandard` module "
+            "(brew install zstd / apt install zstd)",
+        )
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/image-lib.sh
+++ b/scripts/image-lib.sh
@@ -1,8 +1,79 @@
 # image-lib.sh — shared helpers for image-publish.sh and image-upgrade.sh so the
 # two produce BYTE-CONSISTENT GHCR artifacts for a given (type, version). Sourced,
-# never executed. Keeping the type table, the tag rule and the `oras push` in one
-# place is what guarantees an upgrade-and-publish equals a manual publish.
+# never executed. Keeping the type table, the tag rule, the `oras push` AND the
+# Proxmox/KVM-host SSH plumbing (env defaults, --proxmox target split, the `px`
+# remote-or-local runner, GHCR login) in one place is what guarantees an
+# upgrade-and-publish equals a manual publish, and that the two scripts' remote
+# access never drifts apart.
 # shellcheck shell=sh
+
+# log/warn/die are defined by the SOURCING script before it sources this file;
+# image_ghcr_login() below calls log(), which is safe because a sourced function
+# only runs later, once the caller's shell already has log() defined.
+
+# image_px_defaults — set the Proxmox/KVM-host SSH-coordinate defaults from their
+# env-var fallbacks. Call before parsing --proxmox*/--remote-tmpdir options,
+# which then override these via plain assignment.
+image_px_defaults() {
+    PX_HOST="${PROXMOX_SSH_HOST:-}"
+    PX_USER="${PROXMOX_SSH_USER:-root}"
+    PX_PORT="${PROXMOX_SSH_PORT:-22}"
+    PX_KEY="${PROXMOX_SSH_KEY:-}"
+    # REMOTE_TMPDIR is consumed by the sourcing script, not here.
+    # shellcheck disable=SC2034
+    REMOTE_TMPDIR="${PROXMOX_TMPDIR:-/tmp}"
+}
+
+# image_px_target_split — if PX_TARGET ("[USER@]HOST", set by a --proxmox
+# option) is non-empty, split it into PX_USER/PX_HOST; a no-op otherwise (the
+# locally-run case, where PX_HOST stays whatever image_px_defaults left it).
+# Call once option parsing is done.
+image_px_target_split() {
+    if [ -n "${PX_TARGET:-}" ]; then
+        case "$PX_TARGET" in
+            *@*) PX_USER="${PX_TARGET%@*}"; PX_HOST="${PX_TARGET#*@}" ;;
+            *)   PX_HOST="$PX_TARGET" ;;
+        esac
+    fi
+}
+
+# image_px_ssh_opts — derive the ssh(1) option WORDS PX_PORT_OPT/PX_KEY_OPT from
+# PX_PORT/PX_KEY. Intentionally unquoted at use (word-split into separate ssh
+# args); safe here since port/key never contain spaces. Call after PX_REMOTE is
+# known to be set (px() and, in image-upgrade.sh, ssh_guest() both read these).
+image_px_ssh_opts() {
+    PX_PORT_OPT=""; [ -n "$PX_PORT" ] && PX_PORT_OPT="-p $PX_PORT"
+    PX_KEY_OPT="";  [ -n "$PX_KEY" ]  && PX_KEY_OPT="-i $PX_KEY"
+    # A shell function's exit status is its last command's; unlike the same
+    # "[ -n ... ] && assign" line at top level, under `set -e` a FUNCTION CALL
+    # returning non-zero (PX_PORT/PX_KEY empty is the common case) would abort
+    # the sourcing script. Force success explicitly.
+    return 0
+}
+
+# px CMD — run CMD on the Proxmox/KVM host (over SSH, using PX_REMOTE/PX_USER/
+# PX_HOST/PX_PORT_OPT/PX_KEY_OPT) or locally when no remote host was given.
+# stdin/stdout pass through, so it composes with pipes/redirection (e.g.
+# `px "cat file" > local` or `... | px "cat > f"`).
+px() {
+    if [ "$PX_REMOTE" -eq 1 ]; then
+        # shellcheck disable=SC2086
+        ssh -o BatchMode=yes -o ConnectTimeout=10 $PX_PORT_OPT $PX_KEY_OPT \
+            "${PX_USER}@${PX_HOST}" "$1"
+    else
+        sh -c "$1"
+    fi
+}
+
+# image_ghcr_login — non-interactive `oras login ghcr.io`, iff both
+# SMOKE_GHCR_TOKEN and SMOKE_GHCR_USER are set; a no-op otherwise (an
+# already-authenticated local oras config is left alone).
+image_ghcr_login() {
+    if [ -n "${SMOKE_GHCR_TOKEN:-}" ] && [ -n "${SMOKE_GHCR_USER:-}" ]; then
+        log "logging in to ghcr.io as $SMOKE_GHCR_USER"
+        printf '%s' "$SMOKE_GHCR_TOKEN" | oras login ghcr.io -u "$SMOKE_GHCR_USER" --password-stdin
+    fi
+}
 
 # image_type_fields TYPE — validate TYPE and set, for the caller, the derived
 # image-shaped fields. Returns non-zero on an unknown type (caller decides how to

--- a/scripts/image-publish.sh
+++ b/scripts/image-publish.sh
@@ -121,13 +121,10 @@ DESCRIPTION=""
 QCOW_NAME=""
 
 # Proxmox SSH coordinates (env fallbacks; --proxmox overrides).
-PX_HOST="${PROXMOX_SSH_HOST:-}"
-PX_USER="${PROXMOX_SSH_USER:-root}"
-PX_PORT="${PROXMOX_SSH_PORT:-22}"
-PX_KEY="${PROXMOX_SSH_KEY:-}"
-REMOTE_TMPDIR="${PROXMOX_TMPDIR:-/tmp}"
+image_px_defaults
 
 while [ $# -gt 0 ]; do
+    # shellcheck disable=SC2034 # PX_* are consumed by the sourced image-lib.sh helpers
     case "$1" in
         --proxmox)         PX_TARGET="$2"; shift 2 ;;
         --proxmox-port)    PX_PORT="$2"; shift 2 ;;
@@ -154,12 +151,7 @@ while [ $# -gt 0 ]; do
 done
 
 # --proxmox [USER@]HOST splits an optional user from the host.
-if [ -n "${PX_TARGET:-}" ]; then
-    case "$PX_TARGET" in
-        *@*) PX_USER="${PX_TARGET%@*}"; PX_HOST="${PX_TARGET#*@}" ;;
-        *)   PX_HOST="$PX_TARGET" ;;
-    esac
-fi
+image_px_target_split
 
 # --print-identity needs only a VM id; a version tag is required for a real publish.
 [ "$PRINT_IDENTITY" -eq 1 ] || [ -n "$VERSION" ] || die "missing <version> (e.g. 2.8.1, or v1 for civm); or use --print-identity"
@@ -208,20 +200,7 @@ PX_REMOTE=0
 [ -n "$PX_HOST" ] && PX_REMOTE=1
 
 # ssh option words (intentionally unquoted at use; no spaces in port/key).
-PX_PORT_OPT=""; [ -n "$PX_PORT" ] && PX_PORT_OPT="-p $PX_PORT"
-PX_KEY_OPT="";  [ -n "$PX_KEY" ]  && PX_KEY_OPT="-i $PX_KEY"
-
-# px CMD — run CMD on the Proxmox host (over SSH, or locally). stdin/stdout pass
-# through, so it streams (e.g.  px "cat file" > local  and  ... | px "cat > f").
-px() {
-    if [ "$PX_REMOTE" -eq 1 ]; then
-        # shellcheck disable=SC2086
-        ssh -o BatchMode=yes -o ConnectTimeout=10 $PX_PORT_OPT $PX_KEY_OPT \
-            "${PX_USER}@${PX_HOST}" "$1"
-    else
-        sh -c "$1"
-    fi
-}
+image_px_ssh_opts
 
 # print_vm_identity QMCFG — print every NIC's MAC + the SMBIOS UUID from a
 # `qm config <vmid>` dump. These feed the fixed-MAC-series + SMBIOS-UUID secrets
@@ -265,10 +244,7 @@ if [ "$PRINT_IDENTITY" -eq 1 ]; then
 fi
 
 # Optional non-interactive GHCR login (local oras).
-if [ -n "${SMOKE_GHCR_TOKEN:-}" ] && [ -n "${SMOKE_GHCR_USER:-}" ]; then
-    log "logging in to ghcr.io as $SMOKE_GHCR_USER"
-    printf '%s' "$SMOKE_GHCR_TOKEN" | oras login ghcr.io -u "$SMOKE_GHCR_USER" --password-stdin
-fi
+image_ghcr_login
 
 # Refuse to clobber an existing tag unless --force (old tags are kept).
 if [ "$FORCE" -eq 0 ] && oras manifest fetch "${IMAGE}:${VERSION}" >/dev/null 2>&1; then

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -159,11 +159,7 @@ KEEP=0
 FORCE=0
 
 # Proxmox SSH coordinates (env fallbacks; --proxmox overrides).
-PX_HOST="${PROXMOX_SSH_HOST:-}"
-PX_USER="${PROXMOX_SSH_USER:-root}"
-PX_PORT="${PROXMOX_SSH_PORT:-22}"
-PX_KEY="${PROXMOX_SSH_KEY:-}"
-REMOTE_TMPDIR="${PROXMOX_TMPDIR:-/tmp}"
+image_px_defaults
 
 # The non-interactive pfSense upgrade command. NOTE: confirm the exact flags for
 # the running CE release during the Phase-1 spike (ADR-04 §6 flags this) — `yes |`
@@ -176,6 +172,7 @@ UPGRADE_CMD='yes | /usr/local/sbin/pfSense-upgrade -d'
 HEALTH_TIMEOUT=300
 
 while [ $# -gt 0 ]; do
+    # shellcheck disable=SC2034 # PX_* are consumed by the sourced image-lib.sh helpers
     case "$1" in
         --proxmox)         PX_TARGET="$2"; shift 2 ;;
         --proxmox-port)    PX_PORT="$2"; shift 2 ;;
@@ -203,12 +200,7 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "${PX_TARGET:-}" ]; then
-    case "$PX_TARGET" in
-        *@*) PX_USER="${PX_TARGET%@*}"; PX_HOST="${PX_TARGET#*@}" ;;
-        *)   PX_HOST="$PX_TARGET" ;;
-    esac
-fi
+image_px_target_split
 
 [ -n "$FROM" ] || die "missing --from <current-version>"
 [ -n "$GUEST_KEY" ] || die "missing --ssh-key (or set SMOKE_SSH_KEY)"
@@ -253,19 +245,7 @@ PX_REMOTE=0
 [ -n "$PX_HOST" ] && PX_REMOTE=1
 
 # ssh option words (intentionally unquoted at use; no spaces in port/key).
-PX_PORT_OPT=""; [ -n "$PX_PORT" ] && PX_PORT_OPT="-p $PX_PORT"
-PX_KEY_OPT="";  [ -n "$PX_KEY" ]  && PX_KEY_OPT="-i $PX_KEY"
-
-# px CMD — run CMD on the KVM host (over SSH, or locally); stdin/stdout stream.
-px() {
-    if [ "$PX_REMOTE" -eq 1 ]; then
-        # shellcheck disable=SC2086
-        ssh -o BatchMode=yes -o ConnectTimeout=10 $PX_PORT_OPT $PX_KEY_OPT \
-            "${PX_USER}@${PX_HOST}" "$1"
-    else
-        sh -c "$1"
-    fi
-}
+image_px_ssh_opts
 
 # ssh_guest — reach the VM's forwarded :22. When driving a remote Proxmox host we
 # jump THROUGH it (ProxyCommand -W), so the guest key stays on this machine and
@@ -318,10 +298,7 @@ QEMU_BIN=$(px "command -v qemu-system-x86_64 || command -v kvm" 2>/dev/null | he
 px "command -v qemu-img >/dev/null 2>&1" || die "qemu-img not found on the KVM host"
 px "test -e /dev/kvm" || warn "/dev/kvm not present on the KVM host — the guest will be very slow under TCG"
 
-if [ -n "${SMOKE_GHCR_TOKEN:-}" ] && [ -n "${SMOKE_GHCR_USER:-}" ]; then
-    log "logging in to ghcr.io as $SMOKE_GHCR_USER"
-    printf '%s' "$SMOKE_GHCR_TOKEN" | oras login ghcr.io -u "$SMOKE_GHCR_USER" --password-stdin
-fi
+image_ghcr_login
 
 LOCAL_DIR=$(mktemp -d)
 REMOTE_DIR=$(px "mkdir -p '$REMOTE_TMPDIR' && mktemp -d -p '$REMOTE_TMPDIR'" | tr -d '\r')

--- a/scripts/pfb_pkg.py
+++ b/scripts/pfb_pkg.py
@@ -46,6 +46,22 @@ def zstd_decompress(data: bytes) -> bytes:
         return subprocess.run([zstd, "-dc"], input=data, stdout=subprocess.PIPE, check=True).stdout
 
 
+def zstd_compress(data: bytes, err_cls: type[Exception], err_msg: str) -> bytes:
+    """Compress a zstd frame at level 19. Prefers the `zstandard` module, falls
+    back to the `zstd` binary; raises err_cls(err_msg) if neither is available
+    (each caller owns its own error class + message)."""
+    try:
+        import zstandard
+
+        return zstandard.ZstdCompressor(level=19).compress(data)
+    except ImportError:
+        pass
+    zstd = shutil.which("zstd")
+    if not zstd:
+        raise err_cls(err_msg)
+    return subprocess.run([zstd, "-q", "-19", "-c"], input=data, stdout=subprocess.PIPE, check=True).stdout
+
+
 def read_compact_manifest(pkg_path: str | Path) -> dict:
     """Return the +COMPACT_MANIFEST JSON object of a .pkg (pure Python, no libpkg)."""
     pkg_path = Path(pkg_path)

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -3445,22 +3445,6 @@ class ParsedEntry:
 
 
 @dataclass
-class DnsblEntry:
-    """A normalised, classified blocklist entry ready to load into the matcher dicts.
-
-    ``cls`` is ``DNSBL_CLASS_DATA`` (exact) or ``DNSBL_CLASS_ZONE`` (wildcard); ``key``
-    is the registrable parent for a ZONE or the exact domain for DATA.
-    """
-
-    kind: str
-    cls: str
-    key: str
-    feed: str
-    group: str
-    log: str
-
-
-@dataclass
 class BuildResult:
     """The structure-set build() returns -- decision-equivalent to the loader
     contract (RESULTS/01_Results.txt SS1f). All dicts are FRESH (no module global

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -31,6 +31,7 @@ import select
 import sys
 import time
 from collections.abc import Callable, Iterable, Iterator
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -2238,18 +2239,10 @@ def is_unknown(x: Any) -> Any:
     return x
 
 
-class _NullLock:
-    def __enter__(self) -> Any:
-        return self
-
-    def __exit__(self, *exc: Any) -> bool:
-        return False
-
-
 # All connection access is serialized by _db_lock; connections are opened with
 # check_same_thread=False so the DB worker and the synchronous fallback (init,
 # tests) can share them safely under the lock.
-_db_lock: Any = threading.Lock() if pfb.get("mod_threading") else _NullLock()
+_db_lock: Any = threading.Lock() if pfb.get("mod_threading") else nullcontext()
 _db_conns: dict[int, Any] = {}
 
 PFB_DB_QUEUE_MAXSIZE = 5000
@@ -5336,7 +5329,7 @@ class _LruCache:
     def __init__(self, maxsize: int = 0) -> None:
         self.maxsize = maxsize
         self._d: OrderedDict[str, Any] = OrderedDict()
-        self._lock: Any = threading.Lock() if pfb.get("mod_threading") else _NullLock()
+        self._lock: Any = threading.Lock() if pfb.get("mod_threading") else nullcontext()
 
     def get(self, key: str, default: Any = None) -> Any:
         with self._lock:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -960,7 +960,6 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["regex_cap"] = False
     pfb["regex_warn_ms"] = REGEX_WARN_MS_DEFAULT
     pfb["regex_evict_ms"] = REGEX_EVICT_MS_DEFAULT
-    pfb["whiteDB"] = False
     pfb["gpListDB"] = False
     pfb["noAAAADB"] = False
     pfb["python_idn"] = False

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -17983,27 +17983,23 @@ function pfblockerng_sync_on_changes() {
 }
 
 
-/* Do the actual XMLRPC sync */
-function pfblockerng_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout) {
-	global $g;
-	$success = TRUE;
-
-	// Take care of IPv6 literal address
-	if (is_ipaddrv6($sync_to_ip)) {
-		$sync_to_ip = "[{$sync_to_ip}]";
-	}
-
+/*
+ * Bare 'installedpackages/*' section names synced between XMLRPC nodes.
+ * $include_interfaces adds the General/IP/DNSBL "Tab Customizations"
+ * sections ahead of the always-synced list.
+ */
+function pfblockerng_sync_sections($include_interfaces) {
 	$sections = [];
 
-	// If User Disabled, remove 'General/IP/DNSBL Tab Customizations' from Sync
-	if (config_get_path('installedpackages/pfblockerngsync/config/0/syncinterfaces') != 'on') {
+	if ($include_interfaces) {
 		$sections = array_merge($sections, [
 			'pfblockerng',
 			'pfblockerngipsettings',
 			'pfblockerngdnsblsettings'
 		]);
 	}
-	$sections = array_merge($sections, [
+
+	return array_merge($sections, [
 		'pfblockernglistsv4',
 		'pfblockernglistsv6',
 		'pfblockerngreputation',
@@ -18021,6 +18017,20 @@ function pfblockerng_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $p
 		'pfblockerngglobal',
 		'pfblockerngsafesearch'
 	]);
+}
+
+/* Do the actual XMLRPC sync */
+function pfblockerng_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout) {
+	global $g;
+	$success = TRUE;
+
+	// Take care of IPv6 literal address
+	if (is_ipaddrv6($sync_to_ip)) {
+		$sync_to_ip = "[{$sync_to_ip}]";
+	}
+
+	// If User Disabled, remove 'General/IP/DNSBL Tab Customizations' from Sync
+	$sections = pfblockerng_sync_sections(config_get_path('installedpackages/pfblockerngsync/config/0/syncinterfaces') != 'on');
 
 	/* xml will hold the sections to sync */
 	$xml = array();
@@ -18063,31 +18073,10 @@ function pfblockerng_plugin_xmlrpc_send() {
 		'installedpackages/pfblockerngsync/config/0/varsynconchanges'
 	];
 	// If User Disabled, remove 'General/IP/DNSBL Tab Customizations' from Sync
-	if (config_get_path('installedpackages/pfblockerngsync/config/0/syncinterfaces') != 'on') {
-		$section_paths_temp = array_merge($section_paths_temp, [
-			'installedpackages/pfblockerng',
-			'installedpackages/pfblockerngipsettings',
-			'installedpackages/pfblockerngdnsblsettings'
-		]);
+	$sections = pfblockerng_sync_sections(config_get_path('installedpackages/pfblockerngsync/config/0/syncinterfaces') != 'on');
+	foreach ($sections as $section) {
+		$section_paths_temp[] = "installedpackages/{$section}";
 	}
-	$section_paths_temp = array_merge($section_paths_temp, [
-		'installedpackages/pfblockernglistsv4',
-		'installedpackages/pfblockernglistsv6',
-		'installedpackages/pfblockerngreputation',
-		'installedpackages/pfblockerngtopspammers',
-		'installedpackages/pfblockerngafrica',
-		'installedpackages/pfblockerngantarctica',
-		'installedpackages/pfblockerngasia',
-		'installedpackages/pfblockerngeurope',
-		'installedpackages/pfblockerngnorthamerica',
-		'installedpackages/pfblockerngoceania',
-		'installedpackages/pfblockerngsouthamerica',
-		'installedpackages/pfblockerngproxyandsatellite',
-		'installedpackages/pfblockerngdnsbl',
-		'installedpackages/pfblockerngblacklist',
-		'installedpackages/pfblockerngglobal',
-		'installedpackages/pfblockerngsafesearch'
-	]);
 
 	$section_paths = [];
 	foreach ($section_paths_temp as $path) {
@@ -18106,27 +18095,10 @@ function pfblockerng_plugin_xmlrpc_recv($new_sections) {
 		return [];
 	}
 
-	$section_paths = [
-		'installedpackages/pfblockerng',
-		'installedpackages/pfblockerngipsettings',
-		'installedpackages/pfblockerngdnsblsettings',
-		'installedpackages/pfblockernglistsv4',
-		'installedpackages/pfblockernglistsv6',
-		'installedpackages/pfblockerngreputation',
-		'installedpackages/pfblockerngtopspammers',
-		'installedpackages/pfblockerngafrica',
-		'installedpackages/pfblockerngantarctica',
-		'installedpackages/pfblockerngasia',
-		'installedpackages/pfblockerngeurope',
-		'installedpackages/pfblockerngnorthamerica',
-		'installedpackages/pfblockerngoceania',
-		'installedpackages/pfblockerngsouthamerica',
-		'installedpackages/pfblockerngproxyandsatellite',
-		'installedpackages/pfblockerngdnsbl',
-		'installedpackages/pfblockerngblacklist',
-		'installedpackages/pfblockerngglobal',
-		'installedpackages/pfblockerngsafesearch'
-	];
+	$section_paths = [];
+	foreach (pfblockerng_sync_sections(TRUE) as $section) {
+		$section_paths[] = "installedpackages/{$section}";
+	}
 
 	$ret = [
 		'xmlrpc_recv_result' => FALSE

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -441,6 +441,42 @@ function pfb_remove_managed_obj(string $section, string $marker, ?callable $guar
 	return $removed;
 }
 
+// Shared interface-allowlist + exception-alias validation for the DNSBL settings POST
+// forms — DNS Redirect and DoT/DoQ Block apply identical rules, differing only in the
+// $label prefix on each error message.
+// Returns an array of validation error messages (empty = all inputs valid).
+function pfb_validate_redirect_exclude_alias(
+	string $label,
+	array $posted_ifaces,
+	array $valid_iface_list,
+	string $posted_alias
+): array {
+	$errors = [];
+	foreach ($posted_ifaces as $iface) {
+		if (!in_array($iface, $valid_iface_list, TRUE)) {
+			$errors[] = "{$label}: Invalid interface selection: " .
+				htmlspecialchars((string) $iface, ENT_QUOTES);
+		}
+	}
+	if ($posted_alias !== '') {
+		if (!is_validaliasname($posted_alias)) {
+			$errors[] = "{$label}: Invalid exception alias name: " .
+				htmlspecialchars($posted_alias, ENT_QUOTES);
+		} elseif (str_starts_with($posted_alias, PFB_MANAGED_FILTER_PFX)) {
+			$errors[] = "{$label}: Exception alias must not be a pfBlockerNG-managed (" .
+				PFB_MANAGED_FILTER_PFX . '*) alias: ' . htmlspecialchars($posted_alias, ENT_QUOTES);
+		} elseif (pfb_alias_type($posted_alias) === NULL) {
+			$errors[] = "{$label}: Exception alias does not exist: " .
+				htmlspecialchars($posted_alias, ENT_QUOTES) .
+				' (create it under Firewall > Aliases first)';
+		} elseif (!pfb_exclude_alias_exists($posted_alias)) {
+			$errors[] = "{$label}: Exception alias must be an address alias usable in " .
+				'firewall rules (port aliases are not allowed): ' . htmlspecialchars($posted_alias, ENT_QUOTES);
+		}
+	}
+	return $errors;
+}
+
 // Validate the DNS-redirect fields submitted via the DNSBL settings POST form.
 // Each interface name is checked against the allow-list; the exception alias is
 // validated by is_validaliasname() when non-empty.
@@ -450,30 +486,7 @@ function pfb_validate_dns_redirect_post(
 	array $valid_iface_list,
 	string $posted_alias
 ): array {
-	$errors = [];
-	foreach ($posted_ifaces as $iface) {
-		if (!in_array($iface, $valid_iface_list, TRUE)) {
-			$errors[] = 'DNS Redirect: Invalid interface selection: ' .
-				htmlspecialchars((string) $iface, ENT_QUOTES);
-		}
-	}
-	if ($posted_alias !== '') {
-		if (!is_validaliasname($posted_alias)) {
-			$errors[] = 'DNS Redirect: Invalid exception alias name: ' .
-				htmlspecialchars($posted_alias, ENT_QUOTES);
-		} elseif (str_starts_with($posted_alias, PFB_MANAGED_FILTER_PFX)) {
-			$errors[] = 'DNS Redirect: Exception alias must not be a pfBlockerNG-managed (' .
-				PFB_MANAGED_FILTER_PFX . '*) alias: ' . htmlspecialchars($posted_alias, ENT_QUOTES);
-		} elseif (pfb_alias_type($posted_alias) === NULL) {
-			$errors[] = 'DNS Redirect: Exception alias does not exist: ' .
-				htmlspecialchars($posted_alias, ENT_QUOTES) .
-				' (create it under Firewall > Aliases first)';
-		} elseif (!pfb_exclude_alias_exists($posted_alias)) {
-			$errors[] = 'DNS Redirect: Exception alias must be an address alias usable in ' .
-				'firewall rules (port aliases are not allowed): ' . htmlspecialchars($posted_alias, ENT_QUOTES);
-		}
-	}
-	return $errors;
+	return pfb_validate_redirect_exclude_alias('DNS Redirect', $posted_ifaces, $valid_iface_list, $posted_alias);
 }
 
 // The two valid dispositions for a DoT/DoQ block rule. 'reject' is the default
@@ -499,29 +512,7 @@ function pfb_validate_dot_block_post(
 	string $posted_alias,
 	string $posted_action = PFB_DOT_BLOCK_ACTION_DEFAULT
 ): array {
-	$errors = [];
-	foreach ($posted_ifaces as $iface) {
-		if (!in_array($iface, $valid_iface_list, TRUE)) {
-			$errors[] = 'DoT/DoQ Block: Invalid interface selection: ' .
-				htmlspecialchars((string) $iface, ENT_QUOTES);
-		}
-	}
-	if ($posted_alias !== '') {
-		if (!is_validaliasname($posted_alias)) {
-			$errors[] = 'DoT/DoQ Block: Invalid exception alias name: ' .
-				htmlspecialchars($posted_alias, ENT_QUOTES);
-		} elseif (str_starts_with($posted_alias, PFB_MANAGED_FILTER_PFX)) {
-			$errors[] = 'DoT/DoQ Block: Exception alias must not be a pfBlockerNG-managed (' .
-				PFB_MANAGED_FILTER_PFX . '*) alias: ' . htmlspecialchars($posted_alias, ENT_QUOTES);
-		} elseif (pfb_alias_type($posted_alias) === NULL) {
-			$errors[] = 'DoT/DoQ Block: Exception alias does not exist: ' .
-				htmlspecialchars($posted_alias, ENT_QUOTES) .
-				' (create it under Firewall > Aliases first)';
-		} elseif (!pfb_exclude_alias_exists($posted_alias)) {
-			$errors[] = 'DoT/DoQ Block: Exception alias must be an address alias usable in ' .
-				'firewall rules (port aliases are not allowed): ' . htmlspecialchars($posted_alias, ENT_QUOTES);
-		}
-	}
+	$errors = pfb_validate_redirect_exclude_alias('DoT/DoQ Block', $posted_ifaces, $valid_iface_list, $posted_alias);
 	if (!in_array($posted_action, ['block', 'reject'], TRUE)) {
 		$errors[] = 'DoT/DoQ Block: Invalid rule action: ' .
 			htmlspecialchars($posted_action, ENT_QUOTES);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1197,12 +1197,8 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 		case PFB_FILTER_FILE_MIME_COMPARE:
 			// Validate mime-type
 			// $input [0] path/file, [1] mime-type to be validated against
-			if (isset($retval)) {
-				unset($retval);
-			}
-			if (isset($output)) {
-				unset($output);
-			}
+			unset($retval);
+			unset($output);
 			if (!file_exists($input[0])) {
 				pfb_logger("{$header} Invalid Mime-type (file missing): [" .  htmlspecialchars($input[0]) . "|" . htmlspecialchars($input[1]) . "]", 2);
 				return FALSE;
@@ -1220,12 +1216,8 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			// The probed path ($input[1]) is escapeshellarg()'d at the sink below,
 			// so callers need not pre-escape it.
 
-			if (isset($retval)) {
-				unset($retval);
-			}
-			if (isset($output)) {
-				unset($output);
-			}
+			unset($retval);
+			unset($output);
 			if (!file_exists($input[1])) {
 				pfb_logger("{$header} Downloaded file not found: [" .  htmlspecialchars($input[0]) . "|" . htmlspecialchars($input[1]) . "]", 2);
 				return FALSE;
@@ -1276,12 +1268,8 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			// $input [0] path/file (legacy, unused), [1] path/file [2] URL
 			// The probed path ($input[1]) is escapeshellarg()'d at the sink below,
 			// so callers need not pre-escape it.
-			if (isset($retval)) {
-				unset($retval);
-			}
-			if (isset($output)) {
-				unset($output);
-			}
+			unset($retval);
+			unset($output);
 			if (!file_exists($input[1])) {
 				pfb_logger("{$header} Downloaded file not found: [" .  htmlspecialchars($input[0]) . "|" . htmlspecialchars($input[1]) . "]", 2);
 				return FALSE;
@@ -8192,9 +8180,7 @@ function find_reported_header($ip, $pfbfolder, $geoip=FALSE) {
 			}
 		}
 
-		if (isset($result)) {
-			unset($result);
-		}
+		unset($result);
 
 		// Determine which CIDR alerted the IP address
 		if (!empty($cidrs)) {
@@ -8226,9 +8212,7 @@ function find_reported_header($ip, $pfbfolder, $geoip=FALSE) {
 		}
 	}
 
-	if (isset($result)) {
-		unset($result);
-	}
+	unset($result);
 	return array('Unknown', 'Unknown');
 }
 
@@ -9188,9 +9172,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 
 	if (file_exists($file_download) && ($http_status == '200' || $http_status == '221' || $http_status == '226')) {
 
-		if (isset($retval)) {
-			unset($retval);
-		}
+		unset($retval);
 
 		// Validate File Mime-type
 		$file_type = pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download');
@@ -12433,13 +12415,8 @@ function pfb_dnsbl_lastevent($p_group, $p_entry, $p_details) {
 	// Collect or update existing row
 	if (!empty($final)) {
 
-		// Only collect lastevent entry
-		if (empty($p_group)) {
-			;
-		}
-
-		// Update lastevent entry
-		else {
+		// Update lastevent entry (no-op when $p_group is empty -- only collect lastevent entry)
+		if (!empty($p_group)) {
 			$db_update = "UPDATE lastevent SET groupname=:p_group, entry=:p_entry, details=:p_details WHERE row = 0";
 		}
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12770,16 +12770,6 @@ function pfBlockerNG_clearip() {
 	global $pfb;
 
 	exec("{$pfb['pfctl']} -z 2>&1");
-
-	/* TODO: Clear only pfB counters
-	$pfb_tables = array();
-	exec("{$pfb['pfctl']} -sTables | {$pfb['grep']} 'pfB_' 2>&1", $pfb_tables);
-	if (!empty($pfb_tables)) {
-		foreach ($pfb_tables as $table) {
-			exec("{$pfb['pfctl']} -t {$table} -T zero");
-		}
-	}
-	*/
 }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10908,8 +10908,7 @@ function pfb_content_hash($path_or_data, $is_file = TRUE) {
 		if (!is_string($path_or_data) || !file_exists($path_or_data)) {
 			return FALSE;
 		}
-		$digest = @hash_file('xxh128', $path_or_data);
-		return ($digest !== FALSE) ? $digest : FALSE;
+		return @hash_file('xxh128', $path_or_data);
 	}
 	return hash('xxh128', (string) $path_or_data);
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9472,7 +9472,6 @@ function pfb_download_failure($alias, $header, $pfbfolder, $list_url, $format, $
 			// Determine if Firewall/IPS/DNSBL is blocking download.
 			$data = parse_url("{$list_url}");
 
-			$validate_list = array();
 			if (is_ipaddr($data['host'])) {
 				$validate_list = array(array('type' => 'IP', 'data' => $data['host']));
 			} else {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6203,6 +6203,35 @@ function pfb_unbound_py_flip_sentinel() {
 }
 
 
+// Poll (bounded) an applied-generation/sequence marker file until its first line
+// parses as an integer >= $target, or $timeout_s elapses. Shared by
+// pfb_unbound_py_wait_applied() (the ADR-10 reload-watcher handshake) and
+// pfb_unbound_py_wait_control_applied() (the control-channel watcher). 200 ms
+// poll interval; returns TRUE once applied, FALSE on timeout.
+function pfb_unbound_py_wait_marker($path, $target, $timeout_s) {
+	$target = (int) $target;
+	$deadline = microtime(TRUE) + (float) $timeout_s;
+
+	do {
+		if (file_exists($path)) {
+			$raw = @file_get_contents($path);
+			if ($raw !== FALSE) {
+				$first = strtok($raw, "\n");
+				if ($first !== FALSE) {
+					$first = trim($first);
+					if ($first !== '' && ctype_digit($first) && (int) $first >= $target) {
+						return TRUE;
+					}
+				}
+			}
+		}
+		usleep(200000);	// 200 ms between polls
+	} while (microtime(TRUE) < $deadline);
+
+	return FALSE;
+}
+
+
 // ADR-10: wait (bounded) for the reload-watcher to APPLY a published generation.
 // After flipping the sentinel to $gen, PHP blocks here until the watcher writes a value
 // >= $gen to the applied marker (/var/unbound/pfb_py_reload.applied), so the data fast
@@ -6216,27 +6245,7 @@ function pfb_unbound_py_flip_sentinel() {
 function pfb_unbound_py_wait_applied($gen, $timeout_s = 30) {
 	global $pfb;
 
-	$gen = (int) $gen;
-	$applied = "{$pfb['dnsbldir']}/pfb_py_reload.applied";
-	$deadline = microtime(TRUE) + (float) $timeout_s;
-
-	do {
-		if (file_exists($applied)) {
-			$raw = @file_get_contents($applied);
-			if ($raw !== FALSE) {
-				$first = strtok($raw, "\n");
-				if ($first !== FALSE) {
-					$first = trim($first);
-					if ($first !== '' && ctype_digit($first) && (int) $first >= $gen) {
-						return TRUE;
-					}
-				}
-			}
-		}
-		usleep(200000);	// 200 ms between polls
-	} while (microtime(TRUE) < $deadline);
-
-	return FALSE;
+	return pfb_unbound_py_wait_marker("{$pfb['dnsbldir']}/pfb_py_reload.applied", $gen, $timeout_s);
 }
 
 
@@ -6248,27 +6257,7 @@ function pfb_unbound_py_wait_applied($gen, $timeout_s = 30) {
 function pfb_unbound_py_wait_control_applied($seq, $timeout_s = 5) {
 	global $pfb;
 
-	$seq     = (int) $seq;
-	$applied  = "{$pfb['dnsbldir']}/pfb_py_control.applied";
-	$deadline = microtime(TRUE) + (float) $timeout_s;
-
-	do {
-		if (file_exists($applied)) {
-			$raw = @file_get_contents($applied);
-			if ($raw !== FALSE) {
-				$first = strtok($raw, "\n");
-				if ($first !== FALSE) {
-					$first = trim($first);
-					if ($first !== '' && ctype_digit($first) && (int) $first >= $seq) {
-						return TRUE;
-					}
-				}
-			}
-		}
-		usleep(200000);	// 200 ms between polls
-	} while (microtime(TRUE) < $deadline);
-
-	return FALSE;
+	return pfb_unbound_py_wait_marker("{$pfb['dnsbldir']}/pfb_py_control.applied", $seq, $timeout_s);
 }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6736,10 +6736,10 @@ function pfb_unbound_python_sources($feeds) {
 }
 
 
-// ADR-06: Update only the manifest's config.user_whitelist in place (used by the
-// alerts "add to whitelist" button, which changes the suppression config without a
-// full feed re-enumeration). The query-time whiteDB is rebuilt from this on reload.
-function pfb_unbound_python_sources_whitelist() {
+// ADR-06: patch a single scalar key of the manifest's config section in place
+// (shared by the whitelist/unlock in-place patchers below), without a full
+// feed re-enumeration. The query-time whiteDB is rebuilt from this on reload.
+function pfb_unbound_python_sources_patch($key, $values) {
 	global $pfb;
 
 	if (!file_exists($pfb['unbound_py_sources'])) {
@@ -6759,7 +6759,7 @@ function pfb_unbound_python_sources_whitelist() {
 	if (!isset($manifest['config']) || !is_array($manifest['config'])) {
 		$manifest['config'] = array();
 	}
-	$manifest['config']['user_whitelist'] = pfb_dnsbl_whitelist_lines();
+	$manifest['config'][$key] = $values;
 
 	$json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 	if ($json !== FALSE) {
@@ -6771,6 +6771,14 @@ function pfb_unbound_python_sources_whitelist() {
 }
 
 
+// ADR-06: Update only the manifest's config.user_whitelist in place (used by the
+// alerts "add to whitelist" button, which changes the suppression config without a
+// full feed re-enumeration). The query-time whiteDB is rebuilt from this on reload.
+function pfb_unbound_python_sources_whitelist() {
+	return pfb_unbound_python_sources_patch('user_whitelist', pfb_dnsbl_whitelist_lines());
+}
+
+
 // ADR-06 (#51): update ONLY the manifest's config.user_unlock in place, recomputed
 // from the live temporary-unlock store (pfb_dnsbl_unlock_lines). Mirrors
 // pfb_unbound_python_sources_whitelist(): the alerts Lock/Unlock icon toggles the
@@ -6779,34 +6787,7 @@ function pfb_unbound_python_sources_whitelist() {
 // reload (pfb_reload_unbound) does NOT delete the store, so store and manifest stay in
 // step; a full update/Force/Cron is the only thing that clears both.
 function pfb_unbound_python_sources_unlock() {
-	global $pfb;
-
-	if (!file_exists($pfb['unbound_py_sources'])) {
-		return FALSE;
-	}
-
-	$json = @file_get_contents($pfb['unbound_py_sources']);
-	if ($json === FALSE) {
-		return FALSE;
-	}
-
-	$manifest = json_decode($json, TRUE);
-	if (!is_array($manifest)) {
-		return FALSE;
-	}
-
-	if (!isset($manifest['config']) || !is_array($manifest['config'])) {
-		$manifest['config'] = array();
-	}
-	$manifest['config']['user_unlock'] = pfb_dnsbl_unlock_lines();
-
-	$json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-	if ($json !== FALSE) {
-		// ADR-10 P5: atomic publish (the sentinel flip is driven by the reload).
-		return pfb_unbound_py_atomic_write($pfb['unbound_py_sources'], $json);
-	}
-
-	return FALSE;
+	return pfb_unbound_python_sources_patch('user_unlock', pfb_dnsbl_unlock_lines());
 }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12744,23 +12744,21 @@ function convert_feeds_json() {
 function pfb_alerts_default_page() {
 	global $pfb;
 
+	$valid_views = [
+		'dnsbl_stat',
+		'dnsbl_reply_stat',
+		'ip_block_stat',
+		'ip_permit_stat',
+		'ip_match_stat',
+		'reply',
+		'unified'
+	];
+
 	if (isset($pfb['config_global']) &&
 	    isset($pfb['config_global']['pfbpageload'])) {
-		switch($pfb['config_global']['pfbpageload']) {
-			case 'dnsbl_stat':
-				return '?view=dnsbl_stat';
-			case 'dnsbl_reply_stat':
-				return '?view=dnsbl_reply_stat';
-			case 'ip_block_stat':
-				return '?view=ip_block_stat';
-			case 'ip_permit_stat':
-				return '?view=ip_permit_stat';
-			case 'ip_match_stat':
-				return '?view=ip_match_stat';
-			case 'reply':
-				return '?view=reply';
-			case 'unified':
-				return '?view=unified';
+		$view = $pfb['config_global']['pfbpageload'];
+		if (in_array($view, $valid_views, TRUE)) {
+			return "?view={$view}";
 		}
 	}
 	return '';

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1819,6 +1819,25 @@ function pfb_log_should_reset(string $schedule, string $last_key, int $now_ts): 
 // ---------------------------------------------------------------------------
 
 /**
+ * pfb_syslog_escape — escape a single value for syslog key=value emission:
+ * strip newlines, then quote if needed. Shared by pfb_syslog_format_ip() and
+ * pfb_syslog_format_dnsbl() (ADR-38).
+ *
+ * @param string $v  Raw value.
+ * @return string    Escaped/quoted value.
+ */
+function pfb_syslog_escape(string $v): string
+{
+	// Strip embedded newlines to keep the message single-line.
+	$v = str_replace(["\r\n", "\r", "\n"], ' ', $v);
+	// Quote if the value contains space, '=', or '"'.
+	if (strpos($v, ' ') !== FALSE || strpos($v, '=') !== FALSE || strpos($v, '"') !== FALSE) {
+		$v = '"' . str_replace('"', '\\"', $v) . '"';
+	}
+	return $v;
+}
+
+/**
  * pfb_syslog_format_ip — format an IP security event as a key=value string.
  *
  * @param array<string,string> $fields  Associative array of event fields.
@@ -1832,54 +1851,34 @@ function pfb_syslog_format_ip(array $fields): string
 	// Sentinels treated as "absent" for optional fields.
 	static $absent_sentinels = ['', 'Unknown', 'Unk', 'null'];
 
-	/**
-	 * Escape a single value: strip newlines, then quote if needed.
-	 *
-	 * @param string $v  Raw value.
-	 * @return string    Escaped/quoted value.
-	 */
-	$escape = static function (string $v): string {
-		// Strip embedded newlines to keep the message single-line.
-		$v = str_replace(["\r\n", "\r", "\n"], ' ', $v);
-		// Quote if the value contains space, '=', or '"'.
-		if (strpos($v, ' ') !== FALSE || strpos($v, '=') !== FALSE || strpos($v, '"') !== FALSE) {
-			$v = '"' . str_replace('"', '\\"', $v) . '"';
-		}
-		return $v;
-	};
-
-	$get = static function (string $key) use ($fields): string {
-		return $fields[$key] ?? '';
-	};
-
 	$parts = [];
 
 	// Required fields — always emitted.
-	$parts[] = 'act='   . $escape($get('act'));
-	$parts[] = 'dir='   . $escape($get('dir'));
-	$parts[] = 'if='    . $escape($get('if'));
-	$parts[] = 'proto=' . $escape($get('proto'));
-	$parts[] = 'src='   . $escape($get('src'));
-	$parts[] = 'dst='   . $escape($get('dst'));
+	$parts[] = 'act='   . pfb_syslog_escape($fields['act'] ?? '');
+	$parts[] = 'dir='   . pfb_syslog_escape($fields['dir'] ?? '');
+	$parts[] = 'if='    . pfb_syslog_escape($fields['if'] ?? '');
+	$parts[] = 'proto=' . pfb_syslog_escape($fields['proto'] ?? '');
+	$parts[] = 'src='   . pfb_syslog_escape($fields['src'] ?? '');
+	$parts[] = 'dst='   . pfb_syslog_escape($fields['dst'] ?? '');
 
 	// Optional integer-ish fields — omit when empty.
-	$sport = $get('sport');
+	$sport = $fields['sport'] ?? '';
 	if ($sport !== '') {
-		$parts[] = 'sport=' . $escape($sport);
+		$parts[] = 'sport=' . pfb_syslog_escape($sport);
 	}
-	$dport = $get('dport');
+	$dport = $fields['dport'] ?? '';
 	if ($dport !== '') {
-		$parts[] = 'dport=' . $escape($dport);
+		$parts[] = 'dport=' . pfb_syslog_escape($dport);
 	}
 
 	// Required IP version.
-	$parts[] = 'ipver=' . $escape($get('ipver'));
+	$parts[] = 'ipver=' . pfb_syslog_escape($fields['ipver'] ?? '');
 
 	// Optional enrichment fields — omit when empty or a known absent-sentinel.
 	foreach (['geoip', 'alias', 'feed', 'host', 'asn'] as $key) {
-		$val = $get($key);
+		$val = $fields[$key] ?? '';
 		if (!in_array($val, $absent_sentinels, TRUE)) {
-			$parts[] = $key . '=' . $escape($val);
+			$parts[] = $key . '=' . pfb_syslog_escape($val);
 		}
 	}
 
@@ -1928,44 +1927,24 @@ function pfb_syslog_format_ip(array $fields): string
  */
 function pfb_syslog_format_dnsbl(array $fields): string
 {
-	/**
-	 * Escape a single value: strip newlines, then quote if needed.
-	 *
-	 * @param string $v  Raw value.
-	 * @return string    Escaped/quoted value.
-	 */
-	$escape = static function (string $v): string {
-		// Strip embedded newlines to keep the message single-line.
-		$v = str_replace(["\r\n", "\r", "\n"], ' ', $v);
-		// Quote if the value contains space, '=', or '"'.
-		if (strpos($v, ' ') !== FALSE || strpos($v, '=') !== FALSE || strpos($v, '"') !== FALSE) {
-			$v = '"' . str_replace('"', '\\"', $v) . '"';
-		}
-		return $v;
-	};
-
-	$get = static function (string $key) use ($fields): string {
-		return $fields[$key] ?? '';
-	};
-
 	$parts   = [];
 	$parts[] = 'act=dnsbl';
-	$parts[] = 'qname='  . $escape($get('q_name'));
-	$parts[] = 'qip='    . $escape($get('q_ip'));
-	$parts[] = 'qtype='  . $escape($get('q_type'));
+	$parts[] = 'qname='  . pfb_syslog_escape($fields['q_name'] ?? '');
+	$parts[] = 'qip='    . pfb_syslog_escape($fields['q_ip'] ?? '');
+	$parts[] = 'qtype='  . pfb_syslog_escape($fields['q_type'] ?? '');
 
 	// Optional fields — omit the token entirely when the value is ''.
-	$group = $get('group');
+	$group = $fields['group'] ?? '';
 	if ($group !== '') {
-		$parts[] = 'group=' . $escape($group);
+		$parts[] = 'group=' . pfb_syslog_escape($group);
 	}
-	$feed = $get('feed');
+	$feed = $fields['feed'] ?? '';
 	if ($feed !== '') {
-		$parts[] = 'feed=' . $escape($feed);
+		$parts[] = 'feed=' . pfb_syslog_escape($feed);
 	}
 
-	$parts[] = 'btype=' . $escape($get('b_type'));
-	$parts[] = 'eval='  . $escape($get('b_eval'));
+	$parts[] = 'btype=' . pfb_syslog_escape($fields['b_type'] ?? '');
+	$parts[] = 'eval='  . pfb_syslog_escape($fields['b_eval'] ?? '');
 
 	return implode(' ', $parts);
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1853,30 +1853,38 @@ function pfb_syslog_format_ip(array $fields): string
 
 	$parts = [];
 
-	// Required fields — always emitted.
-	$parts[] = 'act='   . pfb_syslog_escape($fields['act'] ?? '');
-	$parts[] = 'dir='   . pfb_syslog_escape($fields['dir'] ?? '');
-	$parts[] = 'if='    . pfb_syslog_escape($fields['if'] ?? '');
-	$parts[] = 'proto=' . pfb_syslog_escape($fields['proto'] ?? '');
-	$parts[] = 'src='   . pfb_syslog_escape($fields['src'] ?? '');
-	$parts[] = 'dst='   . pfb_syslog_escape($fields['dst'] ?? '');
+	// Required fields — always emitted. Cast to string: a caller may pass a
+	// non-string scalar (e.g. FALSE), and pfb_syslog_escape()'s string param
+	// would silently coerce it at the call boundary anyway — cast here too
+	// for uniformity with the optional-field sites below.
+	$parts[] = 'act='   . pfb_syslog_escape((string) ($fields['act'] ?? ''));
+	$parts[] = 'dir='   . pfb_syslog_escape((string) ($fields['dir'] ?? ''));
+	$parts[] = 'if='    . pfb_syslog_escape((string) ($fields['if'] ?? ''));
+	$parts[] = 'proto=' . pfb_syslog_escape((string) ($fields['proto'] ?? ''));
+	$parts[] = 'src='   . pfb_syslog_escape((string) ($fields['src'] ?? ''));
+	$parts[] = 'dst='   . pfb_syslog_escape((string) ($fields['dst'] ?? ''));
 
-	// Optional integer-ish fields — omit when empty.
-	$sport = $fields['sport'] ?? '';
+	// Optional integer-ish fields — omit when empty. Cast BEFORE the '' check
+	// so a non-string scalar (e.g. FALSE) compares/escapes as its coerced
+	// string form, not its raw type.
+	$sport = (string) ($fields['sport'] ?? '');
 	if ($sport !== '') {
 		$parts[] = 'sport=' . pfb_syslog_escape($sport);
 	}
-	$dport = $fields['dport'] ?? '';
+	$dport = (string) ($fields['dport'] ?? '');
 	if ($dport !== '') {
 		$parts[] = 'dport=' . pfb_syslog_escape($dport);
 	}
 
 	// Required IP version.
-	$parts[] = 'ipver=' . pfb_syslog_escape($fields['ipver'] ?? '');
+	$parts[] = 'ipver=' . pfb_syslog_escape((string) ($fields['ipver'] ?? ''));
 
 	// Optional enrichment fields — omit when empty or a known absent-sentinel.
+	// Cast BEFORE the in_array() sentinel check: a non-string scalar (e.g.
+	// FALSE) must coerce to '' first so it matches the '' sentinel, exactly
+	// as the retired $get() closure's `: string` return type did.
 	foreach (['geoip', 'alias', 'feed', 'host', 'asn'] as $key) {
-		$val = $fields[$key] ?? '';
+		$val = (string) ($fields[$key] ?? '');
 		if (!in_array($val, $absent_sentinels, TRUE)) {
 			$parts[] = $key . '=' . pfb_syslog_escape($val);
 		}
@@ -1927,24 +1935,28 @@ function pfb_syslog_format_ip(array $fields): string
  */
 function pfb_syslog_format_dnsbl(array $fields): string
 {
+	// Cast every extraction to string: a caller may pass a non-string scalar
+	// (e.g. FALSE), and the '' emptiness check below must see its coerced
+	// string form — exactly as the retired $get() closure's `: string`
+	// return type did.
 	$parts   = [];
 	$parts[] = 'act=dnsbl';
-	$parts[] = 'qname='  . pfb_syslog_escape($fields['q_name'] ?? '');
-	$parts[] = 'qip='    . pfb_syslog_escape($fields['q_ip'] ?? '');
-	$parts[] = 'qtype='  . pfb_syslog_escape($fields['q_type'] ?? '');
+	$parts[] = 'qname='  . pfb_syslog_escape((string) ($fields['q_name'] ?? ''));
+	$parts[] = 'qip='    . pfb_syslog_escape((string) ($fields['q_ip'] ?? ''));
+	$parts[] = 'qtype='  . pfb_syslog_escape((string) ($fields['q_type'] ?? ''));
 
 	// Optional fields — omit the token entirely when the value is ''.
-	$group = $fields['group'] ?? '';
+	$group = (string) ($fields['group'] ?? '');
 	if ($group !== '') {
 		$parts[] = 'group=' . pfb_syslog_escape($group);
 	}
-	$feed = $fields['feed'] ?? '';
+	$feed = (string) ($fields['feed'] ?? '');
 	if ($feed !== '') {
 		$parts[] = 'feed=' . pfb_syslog_escape($feed);
 	}
 
-	$parts[] = 'btype=' . pfb_syslog_escape($fields['b_type'] ?? '');
-	$parts[] = 'eval='  . pfb_syslog_escape($fields['b_eval'] ?? '');
+	$parts[] = 'btype=' . pfb_syslog_escape((string) ($fields['b_type'] ?? ''));
+	$parts[] = 'eval='  . pfb_syslog_escape((string) ($fields['b_eval'] ?? ''));
 
 	return implode(' ', $parts);
 }

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -698,11 +698,7 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 	if ($type == 'blacklist') {
 		print "{$pfb_return}";
 	} else {
-		if ($pfb_error) {
-			return FALSE;
-		} else {
-			return TRUE;
-		}
+		return !$pfb_error;
 	}
 }
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -44,21 +44,30 @@ $pfbmaxtable	= $pfb['aglobal']['pfbmaxtable']	!= ''	? $pfb['aglobal']['pfbmaxtab
 $pfbreplytypes	= explode(',', $pfb['aglobal']['pfbreplytypes'])?: array();
 $pfbreplyrec	= explode(',', $pfb['aglobal']['pfbreplyrec'])	?: array();
 
-// Unified Log - Light Theme
-$pfb['uniblock']	= $pfb['aglobal']['uniblock']		?: '#FFF9C4';
-$pfb['unipermit']	= $pfb['aglobal']['unipermit']		?: '#80CBC4';
-$pfb['unimatch']	= $pfb['aglobal']['unimatch']		?: '#B3E5FC';
-$pfb['unidnsbl']	= $pfb['aglobal']['unidnsbl']		?: '#EF9A9A';
-$pfb['uniupstream']	= ($pfb['aglobal']['uniupstream'] ?? '')	?: '#CE93D8';
-$pfb['unireply']	= $pfb['aglobal']['unireply']		?: '#E8E8E8';
+// Unified Log - Light/Dark Theme colour keys: one registry drives the read defaults, the
+// save loops, and the render loops below. 'upstream' reads with null-coalescing because it
+// was added after the rest -- an existing config predating it lacks the key, so a plain
+// `?:` would warn on the missing offset; the other keys have always been present.
+$uni_defaults = array(
+	'block'    => array('light_default' => '#FFF9C4', 'dark_default' => '#83791D', 'light_help' => 'IP Block Event color',       'dark_help' => 'IP Block Event color',       'gated' => FALSE, 'safe_read' => FALSE),
+	'permit'   => array('light_default' => '#80CBC4', 'dark_default' => '#3B8780', 'light_help' => 'IP Permit Event color',      'dark_help' => 'IP Permit Event color',      'gated' => FALSE, 'safe_read' => FALSE),
+	'match'    => array('light_default' => '#B3E5FC', 'dark_default' => '#42809D', 'light_help' => 'IP Match Event color',       'dark_help' => 'IP Match Event color',       'gated' => FALSE, 'safe_read' => FALSE),
+	'dnsbl'    => array('light_default' => '#EF9A9A', 'dark_default' => '#E84E4E', 'light_help' => 'DNSBL Block Event color',    'dark_help' => 'DNSBL Block Event color',    'gated' => TRUE,  'safe_read' => FALSE),
+	'upstream' => array('light_default' => '#CE93D8', 'dark_default' => '#9C27B0', 'light_help' => 'Upstream Block Event color', 'dark_help' => 'Upstream Block Event color', 'gated' => TRUE,  'safe_read' => TRUE),
+	'reply'    => array('light_default' => '#E8E8E8', 'dark_default' => '#54585E', 'light_help' => 'DNS Reply Event color (Resolver only)', 'dark_help' => 'DNS Reply Event color', 'gated' => TRUE, 'safe_read' => FALSE),
+);
 
-// Unified Log - Dark Theme
-$pfb['uniblock2']	= $pfb['aglobal']['uniblock2']		?: '#83791D';
-$pfb['unipermit2']	= $pfb['aglobal']['unipermit2']		?: '#3B8780';	
-$pfb['unimatch2']	= $pfb['aglobal']['unimatch2']		?: '#42809D';
-$pfb['unidnsbl2']	= $pfb['aglobal']['unidnsbl2']		?: '#E84E4E';
-$pfb['uniupstream2']	= ($pfb['aglobal']['uniupstream2'] ?? '')	?: '#9C27B0';
-$pfb['unireply2']	= $pfb['aglobal']['unireply2']		?: '#54585E';
+foreach ($uni_defaults as $u_type => $u_cfg) {
+	$u_light = "uni{$u_type}";
+	$u_dark  = "uni{$u_type}2";
+	if ($u_cfg['safe_read']) {
+		$pfb[$u_light]	= ($pfb['aglobal'][$u_light] ?? '')	?: $u_cfg['light_default'];
+		$pfb[$u_dark]	= ($pfb['aglobal'][$u_dark] ?? '')	?: $u_cfg['dark_default'];
+	} else {
+		$pfb[$u_light]	= $pfb['aglobal'][$u_light]		?: $u_cfg['light_default'];
+		$pfb[$u_dark]	= $pfb['aglobal'][$u_dark]		?: $u_cfg['dark_default'];
+	}
+}
 
 $pfbchartcnt	= $pfb['aglobal']['pfbchartcnt']		?: '24';
 $pfbchartstyle	= $pfb['aglobal']['pfbchartstyle']		?: 'twotone';
@@ -536,17 +545,15 @@ if (isset($_POST) && !empty($_POST)) {
 			}
 		}
 
-		// Unified Log - Light Theme Hex settings
-		foreach (array('uniblock' => '#FFF9C4', 'unipermit' => '#80CBC4', 'unimatch' => '#B3E5FC', 'unidnsbl' => '#EF9A9A', 'uniupstream' => '#CE93D8', 'unireply' => '#E8E8E8') as $h_type => $h_default) {
-			if (isset($_POST[$h_type]) && !empty($_POST[$h_type])) {
-				$pfb['aglobal'][$h_type] = pfb_filter($_POST[$h_type], PFB_FILTER_HEX_COLOR, 'alerts hex', $h_default);
-			} else {
-				$pfb['aglobal'][$h_type] = $h_default;
-			}
+		// Unified Log - Light/Dark Theme Hex settings
+		$uni_hex_fields = array();
+		foreach ($uni_defaults as $u_type => $u_cfg) {
+			$uni_hex_fields["uni{$u_type}"] = $u_cfg['light_default'];
 		}
-
-		// Unified Log - Dark Theme Hex settings
-		foreach (array('uniblock2' => '#83791D', 'unipermit2' => '#3B8780', 'unimatch2' => '#42809D', 'unidnsbl2' => '#E84E4E', 'uniupstream2' => '#9C27B0', 'unireply2' => '#54585E') as $h_type => $h_default) {
+		foreach ($uni_defaults as $u_type => $u_cfg) {
+			$uni_hex_fields["uni{$u_type}2"] = $u_cfg['dark_default'];
+		}
+		foreach ($uni_hex_fields as $h_type => $h_default) {
 			if (isset($_POST[$h_type]) && !empty($_POST[$h_type])) {
 				$pfb['aglobal'][$h_type] = pfb_filter($_POST[$h_type], PFB_FILTER_HEX_COLOR, 'alerts hex', $h_default);
 			} else {
@@ -3594,130 +3601,40 @@ if (pfb_cfg_toggle_read($pfb['dnsbl']) === PfbToggle::On) {
 }
 $section->add($group);
 
+$uni_dnsbl_on = pfb_cfg_toggle_read($pfb['dnsbl']) === PfbToggle::On;
+
 $group = new Form_Group('Unified Log: Light Background Theme. Enter \'none\' to disable.');
-$group->add(new Form_Input(
-	'uniblock',
-	'',
-	'text',
-	$pfb['uniblock'],
-	['placeholder' => '#FFF9C4']
-))->setHelp('IP Block Event color')
-  ->setAttribute('style', "background: {$pfb['uniblock']}")
-  ->setWidth(2);
-
-$group->add(new Form_Input(
-	'unipermit',
-	'',
-	'text',
-	$pfb['unipermit'],
-	['placeholder' => '#80CBC4']
-))->setHelp('IP Permit Event color')
-  ->setAttribute('style', "background: {$pfb['unipermit']}")
-  ->setWidth(2);
-
-$group->add(new Form_Input(
-	'unimatch',
-	'',
-	'text',
-	$pfb['unimatch'],
-	['placeholder' => '#B3E5FC']
-))->setHelp('IP Match Event color')
-  ->setAttribute('style', "background: {$pfb['unimatch']}")
-  ->setWidth(2);
-
-if (pfb_cfg_toggle_read($pfb['dnsbl']) === PfbToggle::On) {
+foreach ($uni_defaults as $u_type => $u_cfg) {
+	if ($u_cfg['gated'] && !$uni_dnsbl_on) {
+		continue;
+	}
+	$u_key = "uni{$u_type}";
 	$group->add(new Form_Input(
-		'unidnsbl',
+		$u_key,
 		'',
 		'text',
-		$pfb['unidnsbl'],
-		['placeholder' => '#EF9A9A']
-	))->setHelp('DNSBL Block Event color')
-	  ->setAttribute('style', "background: {$pfb['unidnsbl']}")
-	  ->setWidth(2);
-
-	$group->add(new Form_Input(
-		'uniupstream',
-		'',
-		'text',
-		$pfb['uniupstream'],
-		['placeholder' => '#CE93D8']
-	))->setHelp('Upstream Block Event color')
-	  ->setAttribute('style', "background: {$pfb['uniupstream']}")
-	  ->setWidth(2);
-
-	$group->add(new Form_Input(
-		'unireply',
-		'',
-		'text',
-		$pfb['unireply'],
-		['placeholder' => '#E8E8E8']
-	))->setHelp('DNS Reply Event color (Resolver only)')
-	  ->setAttribute('style', "background: {$pfb['unireply']}")
+		$pfb[$u_key],
+		['placeholder' => $u_cfg['light_default']]
+	))->setHelp($u_cfg['light_help'])
+	  ->setAttribute('style', "background: {$pfb[$u_key]}")
 	  ->setWidth(2);
 }
 $section->add($group);
 
 $group = new Form_Group('Unified Log: Dark Background Theme. Enter \'none\' to disable.');
-$group->add(new Form_Input(
-	'uniblock2',
-	'',
-	'text',
-	$pfb['uniblock2'],
-	['placeholder' => '#83791D']
-))->setHelp('IP Block Event color')
-  ->setAttribute('style', "background: {$pfb['uniblock2']}; color: white;")
-  ->setWidth(2);
-
-$group->add(new Form_Input(
-	'unipermit2',
-	'',
-	'text',
-	$pfb['unipermit2'],
-	['placeholder' => '#3B8780']
-))->setHelp('IP Permit Event color')
-  ->setAttribute('style', "background: {$pfb['unipermit2']}; color: white;")
-  ->setWidth(2);
-
-$group->add(new Form_Input(
-	'unimatch2',
-	'',
-	'text',
-	$pfb['unimatch2'],
-	['placeholder' => '#42809D']
-))->setHelp('IP Match Event color')
-  ->setAttribute('style', "background: {$pfb['unimatch2']}; color: white;")
-  ->setWidth(2);
-
-if (pfb_cfg_toggle_read($pfb['dnsbl']) === PfbToggle::On) {
+foreach ($uni_defaults as $u_type => $u_cfg) {
+	if ($u_cfg['gated'] && !$uni_dnsbl_on) {
+		continue;
+	}
+	$u_key = "uni{$u_type}2";
 	$group->add(new Form_Input(
-		'unidnsbl2',
+		$u_key,
 		'',
 		'text',
-		$pfb['unidnsbl2'],
-		['placeholder' => '#E84E4E']
-	))->setHelp('DNSBL Block Event color')
-	  ->setAttribute('style', "background: {$pfb['unidnsbl2']}; color: white;")
-	  ->setWidth(2);
-
-	$group->add(new Form_Input(
-		'uniupstream2',
-		'',
-		'text',
-		$pfb['uniupstream2'],
-		['placeholder' => '#9C27B0']
-	))->setHelp('Upstream Block Event color')
-	  ->setAttribute('style', "background: {$pfb['uniupstream2']}; color: white;")
-	  ->setWidth(2);
-
-	$group->add(new Form_Input(
-		'unireply2',
-		'',
-		'text',
-		$pfb['unireply2'],
-		['placeholder' => '#54585E']
-	))->setHelp('DNS Reply Event color')
-	  ->setAttribute('style', "background: {$pfb['unireply2']}; color: white;")
+		$pfb[$u_key],
+		['placeholder' => $u_cfg['dark_default']]
+	))->setHelp($u_cfg['dark_help'])
+	  ->setAttribute('style', "background: {$pfb[$u_key]}; color: white;")
 	  ->setWidth(2);
 }
 $section->add($group);

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -4963,13 +4963,6 @@ if (pfb_cfg_toggle_read($alertrefresh) === PfbToggle::On) {
 	}
 }
 
-function pfb_cmp($a, $b) {
-	if ($a == $b) {
-		return 0;
-	}
-	return ($a < $b) ? 1 : -1;
-}
-
 function pie_block($summary, $stat_type, $sumlines, $numsegments, $segcolors) {
 
 ?>
@@ -4987,7 +4980,7 @@ var pieChart_<?=$stat_type?> = new d3pie("pieChart_<?=$stat_type?>", {
 		"sortOrder": "value-asc",
 		"content": [
 <?php
-	uasort($summary, 'pfb_cmp');
+	uasort($summary, fn($a, $b) => $b <=> $a);
 	$k = array_keys($summary);
 	$numentries = 0;
 	for ($i = 0; $i < ($numsegments-1); $i++) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -382,8 +382,7 @@ $section->addInput(new Form_Select(
 	'blacklist_lang',
 	gettext('Language'),
 	$pconfig['blacklist_lang'],
-	['EN' => 'English', 'DE' => 'German', 'FR' => 'French', 'IT' => 'Italian',
-	'NL' => 'Dutch', 'PT' => 'Portuguese', 'ES' => 'Spanish', 'RU' => 'Russian']
+	$options_blacklist_lang
 ))->setHelp('Default: <strong>English</strong><br />
 	Select the language setting. Not all languages have been fully translated.')
   ->setAttribute('style', 'width: auto');
@@ -392,7 +391,7 @@ $section->addInput(new Form_Select(
 	'blacklist_freq',
 	gettext('Update Frequency'),
 	$pconfig['blacklist_freq'],
-	['Never' => 'Never', 'EveryDay' => 'Once a day (Random hour)', 'Weekly' => 'Weekly (Sunday)']
+	$options_blacklist_freq
 ))->setHelp('Default: <strong>Never</strong><br />
 	Select how often the Blacklist database(s) will be downloaded.')
   ->setAttribute('style', 'width: auto');
@@ -401,7 +400,7 @@ $section->addInput(new Form_Select(
 	'blacklist_logging',
 	'Logging',
 	$pconfig['blacklist_logging'],
-	['enabled' => 'Enabled', 'disabled' => 'Disabled']
+	$options_blacklist_logging
 ))->setHelp("Default: <strong>Enabled</strong><br />
 	When 'Enabled', Domains are sinkholed to the DNSBL VIP and logged via the DNSBL Web Server.<br />
 	When 'Disabled', '0.0.0.0' will be used instead of the DNSBL VIP.<br />

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -315,11 +315,11 @@ if (!empty($action) && isset($gtype) && isset($rowid)) {
 	exit;
 }
 
-$pgtype = 'IP'; $l_pgtype = 'ip';
+$pgtype = 'IP';
 $pg_url = '/pfblockerng/pfblockerng_category.php?type=ipv4';
 
 if ($gtype == 'dnsbl') {
-	$pgtype = 'DNSBL'; $l_pgtype = 'dnsbl';
+	$pgtype = 'DNSBL';
 	$pg_url = '/pfblockerng/pfblockerng_dnsbl.php';
 }
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -1315,7 +1315,6 @@ $section->addInput(new Form_StaticText(
 ));
 
 // Add 'Change state' and 'Add Row' buttons
-$btnadd = '';
 $btnadd = new Form_Button(
 	'addrow',
 	'Add',
@@ -1609,7 +1608,6 @@ $section->addInput(new Form_StaticText(
 
 if ($gtype == 'ipv4') {
 
-	$list = array('Disabled' => 'Disabled') + array_combine(range(1, 17, 1), range(1, 17, 1));
 	$section->addInput(new Form_Select(
 		'suppression_cidr',
 		'Suppression CIDR Limit',

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -331,11 +331,11 @@ if (($action == 'add' || $action == 'addgroup') && !empty($atype) && !isset($_PO
 	}
 }
 
-$pgtype = 'IP'; $l_pgtype = 'ip';
+$pgtype = 'IP';
 $pg_url = '/pfblockerng/pfblockerng_category.php?type=ipv4';
 
 if ($gtype == 'dnsbl') {
-	$pgtype = 'DNSBL'; $l_pgtype = 'dnsbl';
+	$pgtype = 'DNSBL';
 	$pg_url = '/pfblockerng/pfblockerng_dnsbl.php';
 }
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -2835,9 +2835,12 @@ $group->add(new Form_Checkbox(
 		. 'Keeps clients on the local DNS resolver so DNSBL stays effective.<br />'
 		. 'The firewall itself is always exempt. Does not cover DoH/DoT/DoQ traffic (use the DoH/DoT/DoQ Blocking section below for that).');
 
-// [ ADR-36 ] Build the quick-fill interface union (inbound + outbound from IP settings).
-// These are the pfBlockerNG firewall-rule interfaces; the quick-fill populates the
-// DNS Redirect select to match that set with one click.
+// [ ADR-36/37 ] Build the quick-fill interface union (inbound + outbound from IP settings).
+// These are the pfBlockerNG firewall-rule interfaces; the quick-fill populates the DNS
+// Redirect AND DoT/DoQ Block selects to match that set with one click. $options_dnsbl_redir_int
+// and $options_dnsbl_dot_block_int are both aliases of $options_dnsbl_interface (identical
+// interface list), so this one computed set/JSON serves both sections -- see the DoT/DoQ
+// Block section below, which reuses it via a JS alias instead of recomputing it.
 $pfb_ipconfig_raw = config_get_path('installedpackages/pfblockerngipsettings/config/0', []);
 $pfb_redir_fill_ifaces = array_unique(array_filter(array_merge(
 	array_filter(array_map('trim', explode(',', $pfb_ipconfig_raw['inbound_interface'] ?? ''))),
@@ -2873,7 +2876,7 @@ $group->add(new Form_Select(
 	TRUE
 ))->setAttribute('style', 'width: auto')
   ->setAttribute('size', $options_dnsbl_interface_cnt);
-$group->setHelp('<a href="#" id="pfb_redir_fill" onclick="pfb_redir_fill_interfaces(); return false;">'
+$group->setHelp('<a href="#" id="pfb_redir_fill" onclick="pfb_fill_interfaces(\'dnsbl_redir_int\', pfb_redir_fill_ifaces); return false;">'
 	. 'Fill from IP Interfaces</a> — select the union of pfBlockerNG Inbound + Outbound interfaces.');
 $section->add($group);
 
@@ -2908,16 +2911,9 @@ $group->add(new Form_Checkbox(
 		. 'The exception alias must exist at '
 		. '<a href="/firewall_aliases.php" target="_blank">Firewall &gt; Aliases</a> before use.');
 
-// [ ADR-37 ] Build the quick-fill interface union (inbound + outbound from IP settings).
-// Reuses the same $pfb_ipconfig_raw already fetched for the ADR-36 DNS Redirect block above.
-$pfb_dot_block_fill_ifaces = array_unique(array_filter(array_merge(
-	array_filter(array_map('trim', explode(',', $pfb_ipconfig_raw['inbound_interface'] ?? ''))),
-	array_filter(array_map('trim', explode(',', $pfb_ipconfig_raw['outbound_interface'] ?? '')))
-)));
-// Restrict to only interfaces present in the DoT/DoQ Block option list.
-$pfb_dot_block_fill_ifaces = array_values(array_intersect($pfb_dot_block_fill_ifaces, array_keys($options_dnsbl_dot_block_int)));
-$pfb_dot_block_fill_json   = json_encode($pfb_dot_block_fill_ifaces);
-
+// [ ADR-37 ] Quick-fill interface union -- identical to the ADR-36 DNS Redirect fill above
+// ($options_dnsbl_dot_block_int is the same interface list as $options_dnsbl_redir_int), so
+// this section's "Fill" button reuses that already-computed set via a JS alias (see below).
 $group->add(new Form_Select(
 	'dnsbl_dot_block_int',
 	NULL,
@@ -2926,7 +2922,7 @@ $group->add(new Form_Select(
 	TRUE
 ))->setAttribute('style', 'width: auto')
   ->setAttribute('size', $options_dnsbl_interface_cnt);
-$group->setHelp('<a href="#" id="pfb_dot_block_fill" onclick="pfb_dot_block_fill_interfaces(); return false;">'
+$group->setHelp('<a href="#" id="pfb_dot_block_fill" onclick="pfb_fill_interfaces(\'dnsbl_dot_block_int\', pfb_dot_block_fill_ifaces); return false;">'
 	. 'Fill from IP Interfaces</a> — select the union of pfBlockerNG Inbound + Outbound interfaces.');
 $section->add($group);
 
@@ -3549,28 +3545,19 @@ function pfb_redir_exclude_autocomplete() {
 		.on('focus', function() { $(this).autocomplete('search', $(this).val()); });
 }
 
-// [ ADR-36 ] DNS Redirect quick-fill: union of pfBlockerNG Inbound + Outbound interfaces.
-// When clicked, selects those interfaces in the dnsbl_redir_int multi-select.
+// [ ADR-36/37 ] Quick-fill: union of pfBlockerNG Inbound + Outbound interfaces, shared by the
+// DNS Redirect and DoT/DoQ Block sections (same underlying interface list -- ADR-37 aliases
+// the ADR-36 set here rather than recomputing it server-side).
 var pfb_redir_fill_ifaces = <?=$pfb_redir_fill_json?>;
+var pfb_dot_block_fill_ifaces = pfb_redir_fill_ifaces;
 
-function pfb_redir_fill_interfaces() {
+function pfb_fill_interfaces(selectName, fillSet) {
 	// Set the multi-select to exactly the fill set (deselects the rest). .val([...]) is the
 	// reliable jQuery idiom for a <select multiple>; trigger('change') notifies any listeners.
 	// NOTE: a pfSense multi-select renders id (and name) as "<field>[]", so the bracket-free
-	// id selector "#dnsbl_redir_int" matches nothing — target it by name instead (this is why
-	// the button previously appeared to do nothing).
-	$('select[name="dnsbl_redir_int[]"]').val(pfb_redir_fill_ifaces).trigger('change');
-}
-
-// [ ADR-37 ] DoT/DoQ Block quick-fill: union of pfBlockerNG Inbound + Outbound interfaces.
-// When clicked, selects those interfaces in the dnsbl_dot_block_int multi-select.
-var pfb_dot_block_fill_ifaces = <?=$pfb_dot_block_fill_json?>;
-
-function pfb_dot_block_fill_interfaces() {
-	// Set the multi-select to exactly the fill set (deselects the rest). .val([...]) is the
-	// reliable jQuery idiom for a <select multiple>; trigger('change') notifies any listeners.
-	// Same bracketed-id caveat as the DNS Redirect fill above — select by name, not "#id".
-	$('select[name="dnsbl_dot_block_int[]"]').val(pfb_dot_block_fill_ifaces).trigger('change');
+	// id selector "#<field>" matches nothing — target it by name instead (this is why the
+	// button previously appeared to do nothing).
+	$('select[name="' + selectName + '[]"]').val(fillSet).trigger('change');
 }
 
 // [ ADR-13 ] Address(es) the package would auto-create for the selected interface, so

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -72,41 +72,25 @@ $pconfig['pfb_hour']			= $pfb['gconfig']['pfb_hour']				?: 0;
 $pconfig['pfb_dailystart']		= $pfb['gconfig']['pfb_dailystart']			?: 0;
 $pconfig['skipfeed']			= $pfb['gconfig']['skipfeed']				?: 0;
 
-$pconfig['log_max_log']			= $pfb['gconfig']['log_max_log']			?: 20000;
-$pconfig['log_max_errlog']		= $pfb['gconfig']['log_max_errlog']			?: 20000;
-$pconfig['log_max_extraslog']		= $pfb['gconfig']['log_max_extraslog']			?: 20000;
-$pconfig['log_max_ip_blocklog']		= $pfb['gconfig']['log_max_ip_blocklog']		?: 20000;
-$pconfig['log_max_ip_permitlog']	= $pfb['gconfig']['log_max_ip_permitlog']		?: 20000;
-$pconfig['log_max_ip_matchlog']		= $pfb['gconfig']['log_max_ip_matchlog']		?: 20000;
-$pconfig['log_max_dnslog']		= $pfb['gconfig']['log_max_dnslog']			?: 20000;
-$pconfig['log_max_dnsbl_parse_err']	= $pfb['gconfig']['log_max_dnsbl_parse_err']		?: 20000;
-$pconfig['log_max_dnsreplylog']		= $pfb['gconfig']['log_max_dnsreplylog']		?: 20000;
-$pconfig['log_max_unilog']		= $pfb['gconfig']['log_max_unilog']			?: 20000;
+// Flat list of per-log suffixes shared by the log_max_*/log_rotate_*/log_reset_keep_* key
+// families below (read here, saved further down) and their validation loops -- one source of
+// truth for the per-log key set, in the same order as $log_types further down the file.
+$log_suffixes = array('log', 'errlog', 'extraslog', 'ip_blocklog', 'ip_permitlog', 'ip_matchlog', 'dnslog', 'dnsbl_parse_err', 'dnsreplylog', 'unilog');
+
+foreach ($log_suffixes as $log_suffix) {
+	$pconfig['log_max_' . $log_suffix]	= $pfb['gconfig']['log_max_' . $log_suffix]	?: 20000;
+}
 
 // ADR-30: per-log rotation schedule. Read via PfbConfig::read so the registered
 // default ('off') is applied when the key is absent (new install / upgrade).
-$pconfig['log_rotate_log']		= PfbConfig::read('log_rotate_log');
-$pconfig['log_rotate_errlog']		= PfbConfig::read('log_rotate_errlog');
-$pconfig['log_rotate_extraslog']	= PfbConfig::read('log_rotate_extraslog');
-$pconfig['log_rotate_ip_blocklog']	= PfbConfig::read('log_rotate_ip_blocklog');
-$pconfig['log_rotate_ip_permitlog']	= PfbConfig::read('log_rotate_ip_permitlog');
-$pconfig['log_rotate_ip_matchlog']	= PfbConfig::read('log_rotate_ip_matchlog');
-$pconfig['log_rotate_dnslog']		= PfbConfig::read('log_rotate_dnslog');
-$pconfig['log_rotate_dnsbl_parse_err']	= PfbConfig::read('log_rotate_dnsbl_parse_err');
-$pconfig['log_rotate_dnsreplylog']	= PfbConfig::read('log_rotate_dnsreplylog');
-$pconfig['log_rotate_unilog']		= PfbConfig::read('log_rotate_unilog');
+foreach ($log_suffixes as $log_suffix) {
+	$pconfig['log_rotate_' . $log_suffix]	= PfbConfig::read('log_rotate_' . $log_suffix);
+}
 
 // ADR-30 amendment: lines to keep on scheduled reset. Default '0' (clear fully).
-$pconfig['log_reset_keep_log']			= PfbConfig::read('log_reset_keep_log');
-$pconfig['log_reset_keep_errlog']		= PfbConfig::read('log_reset_keep_errlog');
-$pconfig['log_reset_keep_extraslog']		= PfbConfig::read('log_reset_keep_extraslog');
-$pconfig['log_reset_keep_ip_blocklog']		= PfbConfig::read('log_reset_keep_ip_blocklog');
-$pconfig['log_reset_keep_ip_permitlog']		= PfbConfig::read('log_reset_keep_ip_permitlog');
-$pconfig['log_reset_keep_ip_matchlog']		= PfbConfig::read('log_reset_keep_ip_matchlog');
-$pconfig['log_reset_keep_dnslog']		= PfbConfig::read('log_reset_keep_dnslog');
-$pconfig['log_reset_keep_dnsbl_parse_err']	= PfbConfig::read('log_reset_keep_dnsbl_parse_err');
-$pconfig['log_reset_keep_dnsreplylog']		= PfbConfig::read('log_reset_keep_dnsreplylog');
-$pconfig['log_reset_keep_unilog']		= PfbConfig::read('log_reset_keep_unilog');
+foreach ($log_suffixes as $log_suffix) {
+	$pconfig['log_reset_keep_' . $log_suffix]	= PfbConfig::read('log_reset_keep_' . $log_suffix);
+}
 
 // ADR-38: syslog export toggle. Read via PfbConfig::read so registered default applies.
 // log_syslog uses the PfbToggle adapter — extract the scalar .value for pfb_cfg_toggle_read().
@@ -181,13 +165,8 @@ if ($_POST) {
 
 		// ADR-30: validate per-log rotation schedule selects. Handled separately to
 		// avoid extending the ${"options_$s_option"} lookup with unknown variable names.
-		$log_rotate_keys = array(
-			'log_rotate_log', 'log_rotate_errlog', 'log_rotate_extraslog',
-			'log_rotate_ip_blocklog', 'log_rotate_ip_permitlog', 'log_rotate_ip_matchlog',
-			'log_rotate_dnslog', 'log_rotate_dnsbl_parse_err',
-			'log_rotate_dnsreplylog', 'log_rotate_unilog',
-		);
-		foreach ($log_rotate_keys as $rkey) {
+		foreach ($log_suffixes as $log_suffix) {
+			$rkey = 'log_rotate_' . $log_suffix;
 			if (is_array($_POST[$rkey])) {
 				$_POST[$rkey] = 'off';
 			} elseif (!array_key_exists($_POST[$rkey], $options_log_rotate)) {
@@ -196,13 +175,8 @@ if ($_POST) {
 		}
 
 		// ADR-30 amendment: validate per-log keep-lines fields (non-negative integer string).
-		$log_reset_keep_keys = array(
-			'log_reset_keep_log', 'log_reset_keep_errlog', 'log_reset_keep_extraslog',
-			'log_reset_keep_ip_blocklog', 'log_reset_keep_ip_permitlog', 'log_reset_keep_ip_matchlog',
-			'log_reset_keep_dnslog', 'log_reset_keep_dnsbl_parse_err',
-			'log_reset_keep_dnsreplylog', 'log_reset_keep_unilog',
-		);
-		foreach ($log_reset_keep_keys as $kkey) {
+		foreach ($log_suffixes as $log_suffix) {
+			$kkey = 'log_reset_keep_' . $log_suffix;
 			$v = $_POST[$kkey] ?? '0';
 			if (is_array($v) || !ctype_digit((string) $v)) {
 				$_POST[$kkey] = '0';
@@ -240,42 +214,21 @@ if ($_POST) {
 				unset($pfb['gconfig']['log_maxlines']);
 			}
 
-			$pfb['gconfig']['log_max_log']			= $_POST['log_max_log']				?: 20000;
-			$pfb['gconfig']['log_max_errlog']		= $_POST['log_max_errlog']			?: 20000;
-			$pfb['gconfig']['log_max_extraslog']		= $_POST['log_max_extraslog']			?: 20000;
-			$pfb['gconfig']['log_max_ip_blocklog']		= $_POST['log_max_ip_blocklog']			?: 20000;
-			$pfb['gconfig']['log_max_ip_permitlog']		= $_POST['log_max_ip_permitlog']		?: 20000;
-			$pfb['gconfig']['log_max_ip_matchlog']		= $_POST['log_max_ip_matchlog']			?: 20000;
-			$pfb['gconfig']['log_max_dnslog']		= $_POST['log_max_dnslog']			?: 20000;
-			$pfb['gconfig']['log_max_dnsbl_parse_err']	= $_POST['log_max_dnsbl_parse_err']		?: 20000;
-			$pfb['gconfig']['log_max_dnsreplylog']		= $_POST['log_max_dnsreplylog']			?: 20000;
-			$pfb['gconfig']['log_max_unilog']		= $_POST['log_max_unilog']			?: 20000;
+			foreach ($log_suffixes as $log_suffix) {
+				$pfb['gconfig']['log_max_' . $log_suffix]	= $_POST['log_max_' . $log_suffix]	?: 20000;
+			}
 
 			// ADR-30: persist per-log rotation schedules. Values have already been validated
 			// above. Written into $pfb['gconfig'] so the writeSection() call below includes
 			// them in the section; PfbConfig::write would be overwritten by writeSection.
-			$pfb['gconfig']['log_rotate_log']		= $_POST['log_rotate_log']		?: 'off';
-			$pfb['gconfig']['log_rotate_errlog']		= $_POST['log_rotate_errlog']		?: 'off';
-			$pfb['gconfig']['log_rotate_extraslog']		= $_POST['log_rotate_extraslog']	?: 'off';
-			$pfb['gconfig']['log_rotate_ip_blocklog']	= $_POST['log_rotate_ip_blocklog']	?: 'off';
-			$pfb['gconfig']['log_rotate_ip_permitlog']	= $_POST['log_rotate_ip_permitlog']	?: 'off';
-			$pfb['gconfig']['log_rotate_ip_matchlog']	= $_POST['log_rotate_ip_matchlog']	?: 'off';
-			$pfb['gconfig']['log_rotate_dnslog']		= $_POST['log_rotate_dnslog']		?: 'off';
-			$pfb['gconfig']['log_rotate_dnsbl_parse_err']	= $_POST['log_rotate_dnsbl_parse_err']	?: 'off';
-			$pfb['gconfig']['log_rotate_dnsreplylog']	= $_POST['log_rotate_dnsreplylog']	?: 'off';
-			$pfb['gconfig']['log_rotate_unilog']		= $_POST['log_rotate_unilog']		?: 'off';
+			foreach ($log_suffixes as $log_suffix) {
+				$pfb['gconfig']['log_rotate_' . $log_suffix]	= $_POST['log_rotate_' . $log_suffix]	?: 'off';
+			}
 
 			// ADR-30 amendment: persist per-log keep-lines (validated above; default '0').
-			$pfb['gconfig']['log_reset_keep_log']			= $_POST['log_reset_keep_log']			?: '0';
-			$pfb['gconfig']['log_reset_keep_errlog']		= $_POST['log_reset_keep_errlog']		?: '0';
-			$pfb['gconfig']['log_reset_keep_extraslog']		= $_POST['log_reset_keep_extraslog']		?: '0';
-			$pfb['gconfig']['log_reset_keep_ip_blocklog']		= $_POST['log_reset_keep_ip_blocklog']		?: '0';
-			$pfb['gconfig']['log_reset_keep_ip_permitlog']		= $_POST['log_reset_keep_ip_permitlog']		?: '0';
-			$pfb['gconfig']['log_reset_keep_ip_matchlog']		= $_POST['log_reset_keep_ip_matchlog']		?: '0';
-			$pfb['gconfig']['log_reset_keep_dnslog']		= $_POST['log_reset_keep_dnslog']		?: '0';
-			$pfb['gconfig']['log_reset_keep_dnsbl_parse_err']	= $_POST['log_reset_keep_dnsbl_parse_err']	?: '0';
-			$pfb['gconfig']['log_reset_keep_dnsreplylog']		= $_POST['log_reset_keep_dnsreplylog']		?: '0';
-			$pfb['gconfig']['log_reset_keep_unilog']		= $_POST['log_reset_keep_unilog']		?: '0';
+			foreach ($log_suffixes as $log_suffix) {
+				$pfb['gconfig']['log_reset_keep_' . $log_suffix]	= $_POST['log_reset_keep_' . $log_suffix]	?: '0';
+			}
 
 			// ADR-38: persist syslog export toggle. Written into $pfb['gconfig'] so the
 			// writeSection() call below includes it; a bare PfbConfig::write() before

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -210,9 +210,7 @@ if ($_POST) {
 			$pfb['gconfig']['skipfeed']			= $_POST['skipfeed']				?: 0;
 
 			// Remove old Line Limit setting
-			if (isset($pfb['gconfig']['log_maxlines'])) {
-				unset($pfb['gconfig']['log_maxlines']);
-			}
+			unset($pfb['gconfig']['log_maxlines']);
 
 			foreach ($log_suffixes as $log_suffix) {
 				$pfb['gconfig']['log_max_' . $log_suffix]	= $_POST['log_max_' . $log_suffix]	?: 20000;

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -103,9 +103,7 @@ $input_errors = array();
 if ($_POST) {
 	if (isset($_POST['save'])) {
 
-		if (isset($savemsg)) {
-			unset($savemsg);
-		}
+		unset($savemsg);
 
 		// Validate Select field options
 		$select_options = array(	'asn_reporting'		=> 'disabled',

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -468,12 +468,6 @@ $form->addGlobal(new Form_Input('action', 'action', 'hidden', ''));
 $form->addGlobal(new Form_Input('load', 'load', 'hidden', ''));
 $form->addGlobal(new Form_Input('file', 'file', 'hidden', ''));
 
-$form->addGlobal(new Form_Input('fileStatus', 'fileStatus', 'hidden', ''));
-$form->addGlobal(new Form_Input('fileStatusBox', 'fileStatusBox', 'hidden', ''));
-$form->addGlobal(new Form_Input('filePathBox', 'filePathBox', 'hidden', ''));
-$form->addGlobal(new Form_Input('fbTarget', 'fbTarget', 'hidden', ''));
-$form->addGlobal(new Form_Input('fileRefreshBtn', 'fileRefreshBtn', 'hidden', ''));
-
 print($form);
 ?>
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -154,12 +154,6 @@ $pfb_logtypes = array(	'defaultlogs'	=> array('name'		=> 'Log Files',
 						'download'	=> TRUE,
 						'clear'		=> FALSE
 						),
-			'unbound'	=> array('name'		=> 'DNSBL Unbound mode',
-						'ext'		=> array('pfb_dnsbl.conf'),
-						'logdir'	=> "{$pfb['dnsbldir']}/",
-						'download'	=> TRUE,
-						'clear'		=> FALSE
-						),
 			'python'	=> array('name'		=> 'DNSBL mode',
 						'ext'		=> array('pfb_py*.txt'),
 						'logdir'	=> "{$pfb['dnsbldir']}/",
@@ -185,8 +179,6 @@ $pfb_logtypes = array(	'defaultlogs'	=> array('name'		=> 'Log Files',
 						'clear'		=> TRUE
 						)
 		);
-
-unset($pfb_logtypes['unbound']);
 
 // Dynamically add any configured DNSBL Categeory Feeds
 if ($pfb['blconfig'] &&

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -58,13 +58,8 @@ function getlogs($logdir, $log_extentions = array('log')) {
 	}
 
 	// Convert to filenames only
-	if (count($log_filenames) > 0) {
-		$log_totalfiles = count($log_filenames);
-		for ($cnt = 0; $cnt < $log_totalfiles; $cnt++) {
-			$log_filenames[$cnt] = basename($log_filenames[$cnt]);
-		}
-	}
-	
+	$log_filenames = array_map('basename', $log_filenames);
+
 	asort($log_filenames);
 	return $log_filenames;
 }

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -931,7 +931,6 @@ function pfBlockerNG_get_header($mode='') {
 // Update table contents
 function pfBlockerNG_get_table($mode='', $pfb_table) {
 	global $pfb;
-	$counter = 0; $dcounter = 1; $response = '';
 
 	if (!empty($pfb_table)) {
 
@@ -984,7 +983,7 @@ function pfBlockerNG_get_table($mode='', $pfb_table) {
 			}
 
 			if ($mode == 'js') {
-				print $response = "{$alias_html}||{$values['count']}||{$packets}||{$values['update']}||{$values['img']}\n";
+				print "{$alias_html}||{$values['count']}||{$packets}||{$values['update']}||{$values['img']}\n";
 			}
 			else {
 				print ("<tr>

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -208,54 +208,6 @@ if ($_POST) {
 }
 
 
-// Sort widget table according to user configuration
-function pfbsort(&$array, $subkey, $sort_ascending) {
-	if (empty($array)) {
-		return;
-	}
-
-	if (count($array)) {
-		$temp_array[key($array)] = array_shift($array);
-	}
-
-	foreach ($array as $key => $val) {
-		$offset = 0;
-		$found = FALSE;
-
-		foreach ($temp_array as $tmp_key => $tmp_val) {
-			if (!$found) {
-				switch($subkey) {
-					case 'alias':
-						(strtolower($key) > strtolower($tmp_key)) ? $found = TRUE : $found = FALSE;
-						break;
-					case 'update':
-						(strtotime($val[$subkey]) > strtotime($tmp_val[$subkey])) ? $found = TRUE : $found = FALSE;
-						break;
-					default:
-						(strtolower($val[$subkey]) > strtolower($tmp_val[$subkey])) ? $found = TRUE : $found = FALSE;
-						break;
-				}
-			}
-			if ($found) {
-				$temp_array = array_merge((array)array_slice($temp_array, 0, $offset), array($key => $val), array_slice($temp_array, $offset));
-			}
-			$offset++;
-		}
-
-		if (!$found) {
-			$temp_array = array_merge($temp_array, array($key => $val));
-		}
-	}
-
-	if (!$sort_ascending) {
-		$array = array_reverse($temp_array);
-	} else {
-		$array = $temp_array;
-	}
-	return;
-}
-
-
 // Decide whether a pfB alias must be hidden from the dashboard widget.
 //
 //   - pfB_DNSBL_VIPs       : the DNSBL sinkhole VIP table, not a feed list.
@@ -453,22 +405,33 @@ function pfBlockerNG_update_table() {
 
 	// Sort tables per sort customization
 	if ($pfb['sortcolumn'] != 'none') {
-		if ($pfb['sortdir'] == 'asc') {
-			if ($pfb['sortmix'] == 'on') {
-				$pfb_table = array_merge($pfb_table, $pfb_dtable);
-				pfbsort($pfb_table, $pfb['sortcolumn'], FALSE);
-			} else {
-				pfbsort($pfb_table, $pfb['sortcolumn'], FALSE);
-				pfbsort($pfb_dtable, $pfb['sortcolumn'], FALSE);
+		$sortkey = $pfb['sortcolumn'];
+		$ascending = ($pfb['sortdir'] == 'asc');
+
+		// Descending compare (by key for 'alias', else by the $sortkey value column);
+		// ascending is simply the reverse -- string keys survive array_reverse() untouched.
+		$sort_table = static function (&$table) use ($sortkey, $ascending) {
+			if (empty($table)) {
+				return;
 			}
+			if ($sortkey === 'alias') {
+				uksort($table, fn($a, $b) => strtolower($b) <=> strtolower($a));
+			} elseif ($sortkey === 'update') {
+				uasort($table, fn($a, $b) => strtotime($b[$sortkey]) <=> strtotime($a[$sortkey]));
+			} else {
+				uasort($table, fn($a, $b) => strtolower($b[$sortkey]) <=> strtolower($a[$sortkey]));
+			}
+			if ($ascending) {
+				$table = array_reverse($table);
+			}
+		};
+
+		if ($pfb['sortmix'] == 'on') {
+			$pfb_table = array_merge($pfb_table, $pfb_dtable);
+			$sort_table($pfb_table);
 		} else {
-			if ($pfb['sortmix'] == 'on') {
-				$pfb_table = array_merge($pfb_table, $pfb_dtable);
-				pfbsort($pfb_table, $pfb['sortcolumn'], TRUE);
-			} else {
-				pfbsort($pfb_table, $pfb['sortcolumn'], TRUE);
-				pfbsort($pfb_dtable, $pfb['sortcolumn'], TRUE);
-			}
+			$sort_table($pfb_table);
+			$sort_table($pfb_dtable);
 		}
 	}
 

--- a/src/usr/local/www/wizards/pfblockerng_wizard.inc
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.inc
@@ -228,7 +228,7 @@ ZXRnYXRlLmNvbQ0K
 
 	// Selected Alias/Groups to add to default installation
 	$new = array();
-	$new['pfblockernglistsv4']		= $new['pfblockerngdnsbl'] = $new['pfblockerngdnsbl'] = array();
+	$new['pfblockernglistsv4']		= $new['pfblockerngdnsbl'] = array();
 	$new['pfblockernglistsv4']['PRI1']	= $feed_info_raw['ipv4']['PRI1'];
 	$new['pfblockerngdnsbl']['ADs_Basic']	= $feed_info_raw['dnsbl']['ADs_Basic'];
 

--- a/tests/php/AlertsDefaultPageTest.php
+++ b/tests/php/AlertsDefaultPageTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin the Alerts-tab "default GET request" whitelist built by
+ * pfb_alerts_default_page(). Reads $pfb['config_global']['pfbpageload'] and
+ * maps it to '?view=<name>' for a fixed whitelist of 7 known views; anything
+ * else (an unknown value, or the key/section absent entirely) falls back to
+ * the plain '' default.
+ *
+ * Coverage mandate (CLAUDE.md): every whitelisted view, plus the unknown and
+ * absent-input branches.
+ */
+#[CoversFunction('pfb_alerts_default_page')]
+final class AlertsDefaultPageTest extends TestCase
+{
+	/** Saved $GLOBALS['pfb'], restored in tearDown. */
+	private mixed $savedPfb = null;
+	private bool $hadPfb = false;
+
+	protected function setUp(): void
+	{
+		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
+		$this->savedPfb = $GLOBALS['pfb'] ?? null;
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->savedPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+	}
+
+	/**
+	 * Each whitelisted view maps to its own '?view=<name>' query string.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public static function whitelistedViewsProvider(): array
+	{
+		return [
+			'dnsbl_stat'       => ['dnsbl_stat'],
+			'dnsbl_reply_stat' => ['dnsbl_reply_stat'],
+			'ip_block_stat'    => ['ip_block_stat'],
+			'ip_permit_stat'   => ['ip_permit_stat'],
+			'ip_match_stat'    => ['ip_match_stat'],
+			'reply'            => ['reply'],
+			'unified'          => ['unified'],
+		];
+	}
+
+	#[DataProvider('whitelistedViewsProvider')]
+	public function testWhitelistedViewProducesQueryString(string $view): void
+	{
+		$GLOBALS['pfb'] = ['config_global' => ['pfbpageload' => $view]];
+
+		$this->assertSame("?view={$view}", pfb_alerts_default_page());
+	}
+
+	/**
+	 * An unrecognized view name falls back to the '' default — never echoed
+	 * back unfiltered into the query string.
+	 */
+	public function testUnknownViewFallsBackToDefault(): void
+	{
+		$GLOBALS['pfb'] = ['config_global' => ['pfbpageload' => 'not_a_real_view']];
+
+		$this->assertSame('', pfb_alerts_default_page());
+	}
+
+	/**
+	 * No 'pfbpageload' key set at all (fresh page load) falls back to ''.
+	 */
+	public function testAbsentPfbpageloadFallsBackToDefault(): void
+	{
+		$GLOBALS['pfb'] = ['config_global' => []];
+
+		$this->assertSame('', pfb_alerts_default_page());
+	}
+
+	/**
+	 * No 'config_global' section at all falls back to ''.
+	 */
+	public function testAbsentConfigGlobalFallsBackToDefault(): void
+	{
+		$GLOBALS['pfb'] = [];
+
+		$this->assertSame('', pfb_alerts_default_page());
+	}
+}

--- a/tests/php/SyncSectionsTest.php
+++ b/tests/php/SyncSectionsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin the XMLRPC sync section list built by pfblockerng_sync_sections().
+ *
+ * The function replaces two formerly-inlined copies of this same list (in
+ * pfblockerng_do_xmlrpc_sync() and pfblockerng_plugin_xmlrpc_send()) — this
+ * test pins the section names + fixed order so a future edit to one call
+ * site can't silently drift from the other.
+ *
+ * Coverage mandate (CLAUDE.md): both branches of the include_interfaces flag.
+ */
+#[CoversFunction('pfblockerng_sync_sections')]
+final class SyncSectionsTest extends TestCase
+{
+	/**
+	 * $include_interfaces = FALSE returns exactly the 16 non-interface
+	 * sections, in the documented fixed order.
+	 */
+	public function testExcludesInterfaceSectionsWhenFalse(): void
+	{
+		$this->assertSame(
+			[
+				'pfblockernglistsv4',
+				'pfblockernglistsv6',
+				'pfblockerngreputation',
+				'pfblockerngtopspammers',
+				'pfblockerngafrica',
+				'pfblockerngantarctica',
+				'pfblockerngasia',
+				'pfblockerngeurope',
+				'pfblockerngnorthamerica',
+				'pfblockerngoceania',
+				'pfblockerngsouthamerica',
+				'pfblockerngproxyandsatellite',
+				'pfblockerngdnsbl',
+				'pfblockerngblacklist',
+				'pfblockerngglobal',
+				'pfblockerngsafesearch',
+			],
+			pfblockerng_sync_sections(FALSE)
+		);
+	}
+
+	/**
+	 * $include_interfaces = TRUE prepends the 3 interface sections ahead of
+	 * the same 16 non-interface sections.
+	 */
+	public function testPrependsInterfaceSectionsWhenTrue(): void
+	{
+		$this->assertSame(
+			[
+				'pfblockerng',
+				'pfblockerngipsettings',
+				'pfblockerngdnsblsettings',
+				'pfblockernglistsv4',
+				'pfblockernglistsv6',
+				'pfblockerngreputation',
+				'pfblockerngtopspammers',
+				'pfblockerngafrica',
+				'pfblockerngantarctica',
+				'pfblockerngasia',
+				'pfblockerngeurope',
+				'pfblockerngnorthamerica',
+				'pfblockerngoceania',
+				'pfblockerngsouthamerica',
+				'pfblockerngproxyandsatellite',
+				'pfblockerngdnsbl',
+				'pfblockerngblacklist',
+				'pfblockerngglobal',
+				'pfblockerngsafesearch',
+			],
+			pfblockerng_sync_sections(TRUE)
+		);
+	}
+}

--- a/tests/php/SyslogFormatTest.php
+++ b/tests/php/SyslogFormatTest.php
@@ -394,6 +394,38 @@ final class SyslogFormatTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
+	// Non-string scalar input — coerced before the sentinel check
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A non-string scalar (FALSE) for an optional enrichment field must be
+	 * coerced to '' BEFORE the absent-sentinel check, so it is treated as
+	 * empty and the key is omitted entirely — never emitted as 'geoip='.
+	 *
+	 * Scenario:
+	 *   Given geoip = FALSE (not a string).
+	 *   When  pfb_syslog_format_ip($fields).
+	 *   Then  the output contains no 'geoip=' token at all.
+	 */
+	public function testGeoipFalseBooleanIsCoercedAndOmitted(): void
+	{
+		$fields = [
+			'act'   => 'block',
+			'dir'   => 'in',
+			'if'    => 'em0',
+			'proto' => 'TCP',
+			'src'   => '198.51.100.30',
+			'dst'   => '10.0.0.30',
+			'ipver' => '4',
+			'geoip' => FALSE,
+		];
+
+		$result = pfb_syslog_format_ip($fields);
+
+		$this->assertStringNotContainsString('geoip=', $result, "geoip=FALSE must coerce to '' and be omitted");
+	}
+
+	// -----------------------------------------------------------------------
 	// Key order is fixed
 	// -----------------------------------------------------------------------
 

--- a/tests/php/UnifiedFormatTest.php
+++ b/tests/php/UnifiedFormatTest.php
@@ -150,6 +150,33 @@ final class UnifiedFormatTest extends TestCase
 	}
 
 	/**
+	 * A non-string scalar (FALSE) for 'group' must be coerced to '' BEFORE
+	 * the '' emptiness check, so it is treated as empty and omitted entirely
+	 * — never emitted as 'group='.
+	 *
+	 * Scenario:
+	 *   Given group = FALSE (not a string).
+	 *   When  pfb_syslog_format_dnsbl($fields).
+	 *   Then  the output contains no 'group=' token at all.
+	 */
+	public function testDnsblGroupFalseBooleanIsCoercedAndOmitted(): void
+	{
+		$fields = [
+			'q_name' => 'ads.example.com',
+			'q_ip'   => '10.0.0.5',
+			'q_type' => 'A',
+			'group'  => FALSE,
+			'feed'   => 'EasyList',
+			'b_type' => 'VIP',
+			'b_eval' => 'ads.example.com',
+		];
+
+		$result = pfb_syslog_format_dnsbl($fields);
+
+		$this->assertStringNotContainsString('group=', $result, "group=FALSE must coerce to '' and be omitted");
+	}
+
+	/**
 	 * A value containing a space is double-quoted.
 	 *
 	 * Scenario:

--- a/tests/php/WidgetSortTableTest.php
+++ b/tests/php/WidgetSortTableTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin the widget dashboard table-sort rewrite: pfbsort() (a manual insertion
+ * sort) -> uasort()/uksort() (issue #563 simplification), inside the
+ * $sort_table closure defined in pfBlockerNG_update_table()
+ * (src/usr/local/www/widgets/widgets/pfblockerng.widget.php).
+ *
+ * Both the CURRENT $sort_table closure (extracted live from the shipped widget
+ * source, like the eval-extraction in WidgetAliasHiddenTest.php) and the OLD
+ * pfbsort() (copied verbatim from `git show origin/devel:src/usr/local/www/
+ * widgets/widgets/pfblockerng.widget.php`, renamed to avoid a symbol clash --
+ * see ORACLE_PFBSORT_SOURCE) are loaded off-appliance and run side-by-side
+ * against the same fixture inputs, so a real behavioural divergence between
+ * old and new fails HERE rather than shipping silently.
+ *
+ * pfbsort()'s own $sort_ascending flag is INVERTED relative to the new
+ * closure's $ascending: devel's `sortdir == 'asc'` branch calls
+ * pfbsort($table, $col, FALSE) (FALSE takes the array_reverse() path, which is
+ * what actually produces ascending output), and the `else` (descending) branch
+ * calls it with TRUE. So :meth:`assertMatchesOracle` below always passes
+ * `!$ascending` to the oracle to compensate -- verified empirically (every
+ * fixture in this file) to reproduce the exact devel order.
+ *
+ * Coverage mandate (CLAUDE.md): the value-column branch (incl. a tie, both
+ * sort directions), the 'alias' key-sort branch (case-insensitive, both
+ * directions), the 'update' strtotime branch (incl. one malformed date), and
+ * the empty/single-element edge cases.
+ */
+#[CoversFunction('pfBlockerNG_update_table')]
+final class WidgetSortTableTest extends TestCase
+{
+	// Copied VERBATIM from `git show origin/devel:src/usr/local/www/widgets/widgets/pfblockerng.widget.php`
+	// (the pfbsort() function pre-#563), function renamed to avoid colliding with
+	// any production symbol. This is the ORACLE the new closure must match.
+	private const ORACLE_PFBSORT_SOURCE = <<<'PHP'
+	function pfbsort_devel_oracle(&$array, $subkey, $sort_ascending) {
+		if (empty($array)) {
+			return;
+		}
+
+		if (count($array)) {
+			$temp_array[key($array)] = array_shift($array);
+		}
+
+		foreach ($array as $key => $val) {
+			$offset = 0;
+			$found = FALSE;
+
+			foreach ($temp_array as $tmp_key => $tmp_val) {
+				if (!$found) {
+					switch($subkey) {
+						case 'alias':
+							(strtolower($key) > strtolower($tmp_key)) ? $found = TRUE : $found = FALSE;
+							break;
+						case 'update':
+							(strtotime($val[$subkey]) > strtotime($tmp_val[$subkey])) ? $found = TRUE : $found = FALSE;
+							break;
+						default:
+							(strtolower($val[$subkey]) > strtolower($tmp_val[$subkey])) ? $found = TRUE : $found = FALSE;
+							break;
+					}
+				}
+				if ($found) {
+					$temp_array = array_merge((array)array_slice($temp_array, 0, $offset), array($key => $val), array_slice($temp_array, $offset));
+				}
+				$offset++;
+			}
+
+			if (!$found) {
+				$temp_array = array_merge($temp_array, array($key => $val));
+			}
+		}
+
+		if (!$sort_ascending) {
+			$array = array_reverse($temp_array);
+		} else {
+			$array = $temp_array;
+		}
+		return;
+	}
+	PHP;
+
+	public static function setUpBeforeClass(): void
+	{
+		if (!function_exists('pfbsort_devel_oracle')) {
+			eval(self::ORACLE_PFBSORT_SOURCE);
+		}
+
+		if (!function_exists('pfb_widget_sort_table_new')) {
+			$src = file_get_contents(
+				dirname(__DIR__, 2) . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php'
+			);
+			if ($src === false) {
+				throw new RuntimeException('test bootstrap: failed to read pfblockerng.widget.php');
+			}
+			// Extract the $sort_table closure assignment VERBATIM (2-tab indent through
+			// its matching 2-tab-indented closing "};") and wrap it in a standalone
+			// function taking $sortkey/$ascending as parameters -- the closure's own
+			// `use ($sortkey, $ascending)` captures those same names from the wrapper's
+			// scope exactly as it would from pfBlockerNG_update_table()'s.
+			if (!preg_match('/\$sort_table = static function.*?\n\t\t\};/s', $src, $m)) {
+				throw new RuntimeException('test bootstrap: $sort_table closure not found in widget source');
+			}
+			eval('function pfb_widget_sort_table_new($sortkey, $ascending) { ' . $m[0] . ' return $sort_table; }');
+		}
+	}
+
+	/**
+	 * Run both the new closure and the devel oracle against the same fixture and
+	 * assert they produce IDENTICAL order (keys AND values, in sequence).
+	 *
+	 * @param array<string,array<string,mixed>> $fixture
+	 */
+	private function assertMatchesOracle(array $fixture, string $sortkey, bool $ascending): void
+	{
+		$new = $fixture;
+		$sort = pfb_widget_sort_table_new($sortkey, $ascending);
+		$sort($new);
+
+		$old = $fixture;
+		pfbsort_devel_oracle($old, $sortkey, !$ascending);
+
+		$this->assertSame(
+			$old,
+			$new,
+			"new \$sort_table('{$sortkey}', ascending=" . ($ascending ? 'true' : 'false') . ') '
+				. 'diverges from the devel pfbsort() oracle'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// (1) Default value-column branch ('count'), including a tie.
+	// -----------------------------------------------------------------------
+
+	/** @return array<string,array<string,mixed>> */
+	private function countFixtureWithTie(): array
+	{
+		return [
+			'pfB_a' => ['count' => 10, 'update' => '2024-01-01'],
+			'pfB_b' => ['count' => 5,  'update' => '2024-01-02'],
+			'pfB_c' => ['count' => 5,  'update' => '2024-01-03'],
+			'pfB_d' => ['count' => 20, 'update' => '2024-01-04'],
+		];
+	}
+
+	public function testValueColumnDescendingKeepsTieInsertionOrder(): void
+	{
+		$table = $this->countFixtureWithTie();
+		$sort = pfb_widget_sort_table_new('count', FALSE);
+		$sort($table);
+
+		// PHP 8's uasort() is stable: the tied pair (pfB_b, pfB_c, both count=5)
+		// keeps its original relative order in the descending build.
+		$this->assertSame(['pfB_d', 'pfB_a', 'pfB_b', 'pfB_c'], array_keys($table), 'descending order with a stable tie');
+		$this->assertMatchesOracle($this->countFixtureWithTie(), 'count', FALSE);
+	}
+
+	public function testValueColumnAscendingReversesTiesToo(): void
+	{
+		$table = $this->countFixtureWithTie();
+		$sort = pfb_widget_sort_table_new('count', TRUE);
+		$sort($table);
+
+		// Ascending is array_reverse() of the descending build, so the tied pair's
+		// order is ALSO reversed (pfB_c before pfB_b) -- proving ascending is a real
+		// reverse of descending, not an independently-stable ascending sort.
+		$this->assertSame(['pfB_c', 'pfB_b', 'pfB_a', 'pfB_d'], array_keys($table), 'ascending reverses tie order too');
+		$this->assertMatchesOracle($this->countFixtureWithTie(), 'count', TRUE);
+	}
+
+	// -----------------------------------------------------------------------
+	// (2) 'alias' key-sort branch, case-insensitive, both directions.
+	// -----------------------------------------------------------------------
+
+	/** @return array<string,array<string,mixed>> */
+	private function mixedCaseAliasFixture(): array
+	{
+		return [
+			'pfB_Zulu'  => ['count' => 1, 'update' => '2024-01-01'],
+			'pfb_alpha' => ['count' => 2, 'update' => '2024-01-02'],
+			'PFB_Mike'  => ['count' => 3, 'update' => '2024-01-03'],
+		];
+	}
+
+	public function testAliasKeySortDescendingIsCaseInsensitive(): void
+	{
+		$table = $this->mixedCaseAliasFixture();
+		$sort = pfb_widget_sort_table_new('alias', FALSE);
+		$sort($table);
+
+		// Case-folded descending: Zulu > Mike > alpha, regardless of the keys' own case.
+		$this->assertSame(['pfB_Zulu', 'PFB_Mike', 'pfb_alpha'], array_keys($table));
+		$this->assertMatchesOracle($this->mixedCaseAliasFixture(), 'alias', FALSE);
+	}
+
+	public function testAliasKeySortAscendingIsCaseInsensitive(): void
+	{
+		$table = $this->mixedCaseAliasFixture();
+		$sort = pfb_widget_sort_table_new('alias', TRUE);
+		$sort($table);
+
+		$this->assertSame(['pfb_alpha', 'PFB_Mike', 'pfB_Zulu'], array_keys($table));
+		$this->assertMatchesOracle($this->mixedCaseAliasFixture(), 'alias', TRUE);
+	}
+
+	// -----------------------------------------------------------------------
+	// (3) 'update' branch via strtotime(), including one malformed date.
+	// -----------------------------------------------------------------------
+
+	/** @return array<string,array<string,mixed>> */
+	private function updateFixtureWithMalformedDate(): array
+	{
+		return [
+			// strtotime('not-a-date') === FALSE; the comparator still runs (PHP's
+			// bool<=>int juggling), matching whatever the devel oracle does with it.
+			'pfB_a' => ['count' => 1, 'update' => '2024-01-01'],
+			'pfB_b' => ['count' => 2, 'update' => 'not-a-date'],
+			'pfB_c' => ['count' => 3, 'update' => '2024-06-01'],
+		];
+	}
+
+	public function testUpdateColumnSortDescendingWithMalformedDate(): void
+	{
+		$table = $this->updateFixtureWithMalformedDate();
+		$sort = pfb_widget_sort_table_new('update', FALSE);
+		$sort($table);
+
+		$this->assertSame(['pfB_c', 'pfB_a', 'pfB_b'], array_keys($table));
+		$this->assertMatchesOracle($this->updateFixtureWithMalformedDate(), 'update', FALSE);
+	}
+
+	public function testUpdateColumnSortAscendingWithMalformedDate(): void
+	{
+		$table = $this->updateFixtureWithMalformedDate();
+		$sort = pfb_widget_sort_table_new('update', TRUE);
+		$sort($table);
+
+		$this->assertSame(['pfB_b', 'pfB_a', 'pfB_c'], array_keys($table));
+		$this->assertMatchesOracle($this->updateFixtureWithMalformedDate(), 'update', TRUE);
+	}
+
+	// -----------------------------------------------------------------------
+	// (4) Empty and single-element tables.
+	// -----------------------------------------------------------------------
+
+	public function testEmptyTableSortIsNoop(): void
+	{
+		$table = [];
+		$sort = pfb_widget_sort_table_new('count', TRUE);
+		$sort($table);
+
+		$this->assertSame([], $table, 'sorting an empty table must stay an empty array');
+	}
+
+	public function testSingleElementTableSortIsNoop(): void
+	{
+		$single = ['pfB_only' => ['count' => 42, 'update' => '2024-05-05']];
+		$table = $single;
+		$sort = pfb_widget_sort_table_new('count', TRUE);
+		$sort($table);
+
+		$this->assertSame($single, $table, 'sorting a single-element table must not change it');
+	}
+}

--- a/tests/php/WidgetSortTableTest.php
+++ b/tests/php/WidgetSortTableTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,8 +30,13 @@ use PHPUnit\Framework\TestCase;
  * sort directions), the 'alias' key-sort branch (case-insensitive, both
  * directions), the 'update' strtotime branch (incl. one malformed date), and
  * the empty/single-element edge cases.
+ *
+ * No #[CoversFunction] attribute: the sort closure lives inside
+ * pfBlockerNG_update_table() in the widget file, which the PHPUnit bootstrap
+ * never loads — the tests exercise a source-extracted copy of the closure, so
+ * there is no loadable coverage target (an attribute here fails the CI
+ * --coverage-text run with "not a valid target for code coverage").
  */
-#[CoversFunction('pfBlockerNG_update_table')]
 final class WidgetSortTableTest extends TestCase
 {
 	// Copied VERBATIM from `git show origin/devel:src/usr/local/www/widgets/widgets/pfblockerng.widget.php`

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -583,13 +583,13 @@ def test_fill_buttons_populate_interface_selects(
     interface multi-selects from the Inbound∪Outbound union — the reported "clicking
     Fill did nothing" bug, on both mirrored sections.
 
-    ``pfb_redir_fill_interfaces()`` / ``pfb_dot_block_fill_interfaces()``
-    (pfblockerng_dnsbl.php) set the multi-select via ``.val(fill_set).trigger('change')``,
-    targeting it **by name** (``select[name="…[]"]``) because a pfSense multi-select's id
-    carries the ``[]`` suffix — the bracket-free ``#id`` the code used before matched
-    nothing, which is why the button did nothing. Seeds inbound/outbound = lan so both
-    fill unions are the non-empty set {lan}; restores the original interface config in
-    teardown.
+    The shared ``pfb_fill_interfaces(selectName, fillSet)`` helper (pfblockerng_dnsbl.php),
+    called by both buttons' ``onclick`` with their own select name + fill-set variable, sets
+    the multi-select via ``.val(fillSet).trigger('change')``, targeting it **by name**
+    (``select[name="…[]"]``) because a pfSense multi-select's id carries the ``[]`` suffix —
+    the bracket-free ``#id`` the code used before matched nothing, which is why the button did
+    nothing. Seeds inbound/outbound = lan so both fill unions are the non-empty set {lan};
+    restores the original interface config in teardown.
     """
     page = browser_page
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -696,12 +696,15 @@ def test_dnsbl_redir_exception_and_fill_fields_render(webui: WebUI, php_error_lo
         'name="dnsbl_dot_block_exclude"',
         "pfb_redir_exclude_autocomplete",
         "pfb_alias_names",
-        # (3) The fill rewrite — the canonical .val([...]) form (not the old .prop() loop),
-        # AND the bracketed-name selectors: a pfSense multi-select renders id/name as
-        # "<field>[]", so the fill must target it by name, not the broken bracket-free "#id".
-        ".val(pfb_redir_fill_ifaces)",
-        'select[name="dnsbl_redir_int[]"]',
-        'select[name="dnsbl_dot_block_int[]"]',
+        # (3) The fill rewrite — now a single shared pfb_fill_interfaces(selectName, fillSet)
+        # helper: the canonical .val([...]).trigger('change') form (not the old .prop() loop),
+        # the bracketed-name selector built from the passed-in selectName (a pfSense
+        # multi-select renders id/name as "<field>[]", so the fill must target it by name, not
+        # the broken bracket-free "#id"), and both onclick call sites wiring the two buttons.
+        ".val(fillSet).trigger('change')",
+        "select[name=\"' + selectName + '[]\"]",
+        "pfb_fill_interfaces('dnsbl_redir_int', pfb_redir_fill_ifaces)",
+        "pfb_fill_interfaces('dnsbl_dot_block_int', pfb_dot_block_fill_ifaces)",
     ):
         assert needle in body, f"DNSBL page is missing the redirect/fill marker {needle!r}"
 
@@ -804,6 +807,54 @@ def test_dnsbl_group_policy_section_renders_above_dns_redirect(
         f"'DNSBL Group Policy' section (id 'Python_Group_Policy', pos {gp_pos}) must render "
         f"above 'DNS Redirect' (pos {redir_pos})"
     )
+
+
+# The DNSBL master-enable toggle -- gates the 'dnsbl'/'upstream'/'reply' rows of the alerts
+# page's $uni_defaults Unified-Log colour registry (pfblockerng_alerts.php). Off by default on
+# a fresh install, so test_alerts_unified_log_colour_fields_render turns it on for its GET (and
+# always restores whatever it read first, so a pre-existing 'on' round-trips as a no-op).
+CFG_PFB_DNSBL = "installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl"
+
+
+def test_alerts_unified_log_colour_fields_render(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:
+    """The Alerts page's Unified-Log colour fields — built by looping over the $uni_defaults
+    registry (one pass per light/dark theme) — render cleanly, including the DNSBL-gated rows.
+
+    Asserts the always-present 'block' row (``name="uniblock"``/``"uniblock2"``) AND, with the
+    DNSBL master toggle turned on for this GET, the gated 'reply' row (``name="unireply2"``)
+    plus its light-only help asymmetry (``'(Resolver only)'`` — the light help text differs from
+    the dark help text only for this one row) — so a regression in the loop rewrite (a dropped
+    row, a missing gate, or a lost help-text override) is caught at the render tier.
+    """
+    original = helpers.config_get(smoke_vm, CFG_PFB_DNSBL)
+    helpers.php_eval(
+        smoke_vm,
+        f"config_set_path('{CFG_PFB_DNSBL}', 'on');\n"
+        "write_config('pfBlockerNG smoke: enable DNSBL for the alerts unified-log render check');\n"
+        "echo 'OK';",
+    )
+    try:
+        path = "/pfblockerng/pfblockerng_alerts.php"
+        resp = webui.get(path)
+        result = evaluate_render(path, resp.status_code, resp.text, ("Alert Settings",))
+        assert result.ok, f"Alerts render oracle failed: {result.detail}"
+        body = resp.text
+        for needle in (
+            'name="uniblock"',
+            'name="uniblock2"',
+            'name="unireply2"',
+            "(Resolver only)",
+        ):
+            assert needle in body, f"Alerts page is missing the unified-log colour marker {needle!r}"
+    finally:
+        helpers.php_eval(
+            smoke_vm,
+            f"config_set_path('{CFG_PFB_DNSBL}', '{original}');\n"
+            "write_config('pfBlockerNG smoke: restore DNSBL toggle');\n"
+            "echo 'OK';",
+        )
 
 
 def test_feeds_custom_panel_heading_renders(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -104,9 +104,8 @@ def make_pkg(
         tf2.size = len(payload)
         tf2.mode = 0o555
         tf.addfile(tf2, io.BytesIO(payload))
-    import pfb_pkg
 
-    path.write_bytes(pfb_pkg.zstd_compress(raw.getvalue(), brp.BuildRepoError, "zstd unavailable"))
+    path.write_bytes(brp.zstd_compress(raw.getvalue(), brp.BuildRepoError, "zstd unavailable"))
     return manifest
 
 

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -104,7 +104,9 @@ def make_pkg(
         tf2.size = len(payload)
         tf2.mode = 0o555
         tf.addfile(tf2, io.BytesIO(payload))
-    path.write_bytes(brp._zstd_compress(raw.getvalue()))
+    import pfb_pkg
+
+    path.write_bytes(pfb_pkg.zstd_compress(raw.getvalue(), brp.BuildRepoError, "zstd unavailable"))
     return manifest
 
 


### PR DESCRIPTION
Implements the actionable items of the over-engineering cleanup backlog (#563), after re-verifying every item against current `devel` (the audit's anchors were stale in places). 30 behaviour-preserving commits, one per item; net ≈ −480 lines across `src/` and `scripts/`.

## Verification-first

All ~30 items were re-checked against current `devel` before any edit:

- **Already fixed on `devel` (no action, noted for the tracking issue):** the `threads` module global (90b828ce, #714), the duplicate `pfblockerng_reputation.php` priv entry (51c54d14, #707), and the `pfb_open_sqlite()` `'stats'`/`'lastclear'` lead (#713 bug 10, now test-guarded).
- **Narrowed:** the DNS-Redirect/DoT validators are no longer byte-identical (DoT gained an action-validation block) — merged the shared portion, kept the extra block; `general.php`'s render side was already merged (#489) — only read/save/validation blocks remained; the `if/else FALSE/TRUE` tail exists once, not twice.
- **"Verify before cutting" section:** all confirmed load-bearing (ADR-40 oracle, ADR-29 contract helpers, cross-repo retention consumer, ADR-12 `runhooks` aid, spec-pinned zstd/bz2 fallbacks) and left as designed; the four dev-convenience deletions were declined by the maintainer.

## What changed (by batch)

- **PHP core (`pfblockerng.inc`, `pfblockerng_extra.inc`):** XML-RPC sync section list deduped into `pfblockerng_sync_sections()`; whitelist/unlock manifest patchers, the two Unbound marker-poll loops, and the DNS-Redirect/DoT alias validation each merged behind a shared helper (public names kept as thin wrappers — tests pin them); `pfb_alerts_default_page()` switch → whitelist array; dead commented-out `pfctl` experiment, no-op ternary, dead inits, `isset()`-before-`unset()` guards, and an empty `if` branch removed; the byte-identical syslog `$escape` closures hoisted to `pfb_syslog_escape()` (ADR-38 output pinned byte-for-byte by `SyslogFormatTest`/`UnifiedFormatTest`, both green).
- **Web UI (`www/`):** the 12 Unified-Log colour `Form_Input` blocks + twin parse/save loops collapsed into one `$uni_defaults` array (rendered names/placeholders/help/styles proven byte-identical across 6 config states, including the two pre-existing asymmetries); `general.php` log read/save/validation driven off one suffix list (field names unchanged — Tier A pins them); `log.php` duplicate-id hidden inputs, built-then-unset `'unbound'` logtype, and the `basename` loop cleaned; dead `$l_pgtype`/`$btnadd`/`$list` removed; `blacklist.php` selects reuse the existing `$options_blacklist_*` arrays; the ADR-36/37 interface-fill arrays + JS deduped (both JS globals and button ids preserved — the Tier B fill test passes unedited); wizard triple-assign fixed.
- **Widget:** hand-rolled `pfbsort()` insertion sort replaced with `uasort()`/`uksort()` (PHP ≥ 8.0 stable sorts; the ascending-case tie-order quirk is deliberately preserved via the same `array_reverse()` step — do not "fix" it further); write-only counters dropped.
- **Python (`pfb_unbound.py`):** unused `DnsblEntry` dataclass deleted; `_NullLock` → `contextlib.nullcontext()` (stdlib, chroot-safe); duplicate `whiteDB` init dropped.
- **Dev scripts:** `_zstd_compress` deduped into `pfb_pkg.zstd_compress(data, err_cls, err_msg)` (each builder keeps its exact error class/message; the direct test reference updated to the new location); the Proxmox/SSH/GHCR plumbing shared between `image-upgrade.sh`/`image-publish.sh` moved into `image-lib.sh` (`image_px_defaults`/`image_px_target_split`/`image_px_ssh_opts`/`px`/`image_ghcr_login`).

## Reviewer notes

- `image_px_ssh_opts()` ends with an explicit `return 0`: the original top-level `[ -n "$PX_KEY" ] && PX_KEY_OPT=…` was `set -e`-exempt as a raw AND-OR list, but as a function's last statement its falsy status would abort every no-key run. Non-obvious; easy to second-guess without this context.
- No test pins `pfbsort()` and no shellspec covers the `image-*.sh` scripts; verification there = full suites + `sh -n`/`shellcheck --severity=info` + a functional trace of each extracted helper's exit status under `set -e`.

## Gates

`python -m pytest` 2105 passed / 4 skipped · `vendor/bin/phpunit` 2047 tests, 16114 assertions, 0 failures · `phpstan` clean · `phpcs` clean · `ruff check` + `ruff format --check` clean · `sh -n` + `shellcheck --severity=info` clean on all touched shell.

Fixes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfJUsCQkpFZxXufncGUS2f
