### PR TITLE
pfblockerng: dedupe the Permit-Whitelist icon render logic (#798)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2820,6 +2820,41 @@ function pfb_dnsbl_feed_group_cell(string $prev_feed, string $cur_feed, string $
 	return "{$cur_feed}<br /><small>{$cur_group}</small>";
 }
 
+/**
+ * Render the Permit-Whitelist trash-can icon markup when $host is covered by
+ * one of the given ipwhitelist alias lists, else return NULL.
+ *
+ * Shared by both Alerts icon call sites that need this lookup (issue #798):
+ * the Suppression-icon gate's whitelist sub-path, and the standalone IP
+ * Whitelist Icon fallback. The NULL return also replaces the old $pfb_found
+ * flag as the caller's "not found" signal -- $pfb_found was left undefined
+ * (PHP 8 E_WARNING on read) whenever $wlists was empty.
+ */
+function pfb_whitelist_trash_icon($wlists, $host, $vtype, $h_host, $h_eval_ip) {
+	if (empty($wlists)) {
+		return NULL;
+	}
+
+	foreach ($wlists as $atype => $permit_list) {
+		if (!isset($permit_list['data'][$host])) {
+			continue;
+		}
+
+		$w_line = rtrim($permit_list['data'][$host], "\x00..\x1F");
+		$supp_ip_txt = "Note:&emsp;The following IPv{$vtype} address is in a Permit Alias:\n\n"
+				. "Permitted IP:&emsp;[ " . pfb_hsc($w_line) . " ]\n"
+				. "Evaluated IP:&emsp;[ {$h_eval_ip} ]\n"
+				. "IP Aliasname:&emsp;[ " . pfb_hsc($atype) . " ]\n\n"
+
+				. "To remove this IP from the Whitelist, press 'OK'";
+
+		return '<i class="fa-solid fa-trash-can no-confirm icon-pointer" id="DNSBLWT|' . 'delete_ipwhitelist|' . $h_host
+				. '|' . pfb_hsc($atype) . '" title="' . $supp_ip_txt . '"></i>';
+	}
+
+	return NULL;
+}
+
 
 // Function to convert IP Logs (ip_block, ip_permit and ip_match).log -> Reports Tab
 function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
@@ -3069,32 +3104,15 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		if ($supp_match === NULL) {
 
 			// Check if host is in a Permit Whitelist Alias
-			if ($clists['ipwhitelist' . $vtype]) {
-				$pfb_found = FALSE;
-				foreach ($clists['ipwhitelist' . $vtype] as $atype => $permit_list) {
-					if (isset($permit_list['data'][$host])) {
-						$w_line = rtrim($permit_list['data'][$host], "\x00..\x1F");
-						$pfb_found = TRUE;
-						break;
-					}
-				}
+			$supp_ip_wl = pfb_whitelist_trash_icon($clists['ipwhitelist' . $vtype], $host, $vtype, $h_host, $h_eval_ip);
 
-				// Host found in a Permit Whitelist Alias
-				if ($pfb_found) {
-					$supp_ip_txt = "Note:&emsp;The following IPv{$vtype} address is in a Permit Alias:\n\n"
-							. "Permitted IP:&emsp;[ " . pfb_hsc($w_line) . " ]\n"
-							. "Evaluated IP:&emsp;[ {$h_eval_ip} ]\n"
-							. "IP Aliasname:&emsp;[ " . pfb_hsc($atype) . " ]\n\n"
-
-							. "To remove this IP from the Whitelist, press 'OK'";
-
-					$supp_ip = '<i class="fa-solid fa-trash-can no-confirm icon-pointer" id="DNSBLWT|' . 'delete_ipwhitelist|' . $h_host
-							. '|' . pfb_hsc($atype) . '" title="' . $supp_ip_txt . '"></i>';
-				}
+			// Host found in a Permit Whitelist Alias
+			if ($supp_ip_wl !== NULL) {
+				$supp_ip = $supp_ip_wl;
 			}
 
 			// Add Suppression/Whitelist Icon
-			if (!$pfb_found) {
+			if ($supp_ip_wl === NULL) {
 				$permit_option = '';
 				if ($clists['ipwhitelist' . $vtype]) {
 					$permit_option = '|' . implode('|', $clists['ipwhitelist' . $vtype]['options']);
@@ -3157,25 +3175,10 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	if (!($rtype == 'Block' && !$pfb_geoip) && !$mask_suppression) {
 		if ($clists['ipwhitelist' . $vtype]) {
 
-			$pfb_found = FALSE;
-			foreach ($clists['ipwhitelist' . $vtype] as $atype => $permit_list) {
-				if (isset($permit_list['data'][$host])) {
-					$w_line = rtrim($permit_list['data'][$host], "\x00..\x1F");
-					$pfb_found = TRUE;
-					break;
-				}
-			}
+			$supp_ip_wl = pfb_whitelist_trash_icon($clists['ipwhitelist' . $vtype], $host, $vtype, $h_host, $h_eval_ip);
 
-			if ($pfb_found) {
-				$supp_ip_txt = "Note:&emsp;The following IPv{$vtype} address is in a Permit Alias:\n\n"
-						. "Permitted IP:&emsp;[ " . pfb_hsc($w_line) . " ]\n"
-						. "Evaluated IP:&emsp;[ {$h_eval_ip} ]\n"
-						. "IP Aliasname:&emsp;[ " . pfb_hsc($atype) . " ]\n\n"
-
-						. "To remove this IP from the Whitelist, press 'OK'";
-
-				$supp_ip = '<i class="fa-solid fa-trash-can no-confirm icon-pointer" id="DNSBLWT|' . 'delete_ipwhitelist|' . $h_host
-						. '|' . pfb_hsc($atype) . '" title="' . $supp_ip_txt . '"></i>';
+			if ($supp_ip_wl !== NULL) {
+				$supp_ip = $supp_ip_wl;
 			}
 			else {
 				$supp_ip_txt  = "Note:&emsp;The following IPv{$vtype} was blocked:\n\n"

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2830,7 +2830,7 @@ function pfb_dnsbl_feed_group_cell(string $prev_feed, string $cur_feed, string $
  * flag as the caller's "not found" signal -- $pfb_found was left undefined
  * (PHP 8 E_WARNING on read) whenever $wlists was empty.
  */
-function pfb_whitelist_trash_icon($wlists, $host, $vtype, $h_host, $h_eval_ip) {
+function pfb_whitelist_trash_icon(array $wlists, string $host, int $vtype, string $h_host, string $h_eval_ip): ?string {
 	if (empty($wlists)) {
 		return NULL;
 	}

--- a/tests/php/WhitelistTrashIconTest.php
+++ b/tests/php/WhitelistTrashIconTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin pfb_whitelist_trash_icon() (issue #798): the shared "host in a Permit
+ * Whitelist Alias -> trash-can icon" lookup extracted from convert_ip_log()'s
+ * two duplicated blocks. Direct coverage matters because the empty-list
+ * branch — the one whose NULL return replaces the old undefined $pfb_found
+ * flag (PHP 8 E_WARNING) — is unreachable through the live Alerts page: the
+ * customlist collection always seeds a default 'options' entry, so only a
+ * unit test can prove it.
+ *
+ * The function under test is loaded off-appliance via the same eval-extract
+ * technique as AlertsFeedMatchCellGroupingTest: the alerts page source is
+ * read, require_once() lines stripped, and only the function block eval'd.
+ */
+#[CoversFunction('pfb_whitelist_trash_icon')]
+final class WhitelistTrashIconTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		if (function_exists('pfb_whitelist_trash_icon')) {
+			return;
+		}
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('failed to read pfblockerng_alerts.php');
+		}
+		$src = preg_replace('/^\s*require_once\(.*\);\s*$/m', '', $src);
+		$start = strpos($src, "\nfunction ");
+		$end   = strpos($src, "\n\$pgtitle = ");
+		if ($start === false || $end === false || $end <= $start) {
+			throw new RuntimeException('could not locate the function block in pfblockerng_alerts.php');
+		}
+		eval("\n" . substr($src, $start + 1, $end - $start - 1));
+	}
+
+	/**
+	 * The empty-list branch: NULL, with no PHP warning — this is the branch
+	 * that replaces the old undefined-$pfb_found read, and it is unreachable
+	 * via the live page (see the class docblock).
+	 */
+	public function testEmptyWhitelistArrayReturnsNull(): void
+	{
+		$this->assertNull(pfb_whitelist_trash_icon([], '10.0.0.1', 4, '10.0.0.1', '10.0.0.0/24'));
+	}
+
+	/**
+	 * An options-only array (the collection's always-seeded default when no
+	 * Permit alias is configured) has no 'data' rows — no match, no warning.
+	 */
+	public function testOptionsOnlyArrayReturnsNull(): void
+	{
+		$wlists = ['options' => ['Create new pfB_Whitelist_v4']];
+
+		$this->assertNull(pfb_whitelist_trash_icon($wlists, '10.0.0.1', 4, '10.0.0.1', '10.0.0.0/24'));
+	}
+
+	public function testHostNotInAnyAliasReturnsNull(): void
+	{
+		$wlists = [
+			'pfB_Whitelist_v4' => ['data' => ['192.0.2.1' => "192.0.2.1\r\n"]],
+			'options' => ['pfB_Whitelist_v4'],
+		];
+
+		$this->assertNull(pfb_whitelist_trash_icon($wlists, '10.0.0.1', 4, '10.0.0.1', '10.0.0.0/24'));
+	}
+
+	/**
+	 * A covered host yields the exact trash-can markup both retired blocks
+	 * emitted: DNSBLWT|delete_ipwhitelist id carrying the ENCODED host + alias
+	 * name, and the tooltip carrying the raw customlist line + evaluated IP.
+	 */
+	public function testCoveredHostRendersTrashIconWithAliasAndLine(): void
+	{
+		$wlists = [
+			'pfB_Whitelist_v4' => ['data' => ['192.0.2.7' => "192.0.2.7 # office\r\n"]],
+			'options' => ['pfB_Whitelist_v4'],
+		];
+
+		$icon = pfb_whitelist_trash_icon($wlists, '192.0.2.7', 4, '192.0.2.7', '192.0.2.0/24');
+
+		$this->assertNotNull($icon);
+		$this->assertStringContainsString('id="DNSBLWT|delete_ipwhitelist|192.0.2.7|pfB_Whitelist_v4"', $icon);
+		$this->assertStringContainsString('fa-trash-can', $icon);
+		$this->assertStringContainsString('Permitted IP:&emsp;[ 192.0.2.7 # office ]', $icon);
+		$this->assertStringContainsString('Evaluated IP:&emsp;[ 192.0.2.0/24 ]', $icon);
+		$this->assertStringContainsString('IPv4 address is in a Permit Alias', $icon);
+	}
+
+	/**
+	 * First matching alias wins (same order the retired blocks' break gave);
+	 * a non-matching alias earlier in the array is skipped, not fatal.
+	 */
+	public function testFirstMatchingAliasWins(): void
+	{
+		$wlists = [
+			'pfB_Other_v4' => ['data' => ['192.0.2.1' => "192.0.2.1\r\n"]],
+			'pfB_First_v4' => ['data' => ['192.0.2.7' => "192.0.2.7\r\n"]],
+			'pfB_Second_v4' => ['data' => ['192.0.2.7' => "192.0.2.7 # dup\r\n"]],
+			'options' => ['pfB_Other_v4', 'pfB_First_v4', 'pfB_Second_v4'],
+		];
+
+		$icon = pfb_whitelist_trash_icon($wlists, '192.0.2.7', 6, '192.0.2.7', '192.0.2.7/32');
+
+		$this->assertNotNull($icon);
+		$this->assertStringContainsString('|pfB_First_v4"', $icon);
+		$this->assertStringContainsString('IPv6 address is in a Permit Alias', $icon);
+	}
+}

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -54,6 +54,10 @@ CFG_TLDEXCLUSION = "installedpackages/pfblockerngdnsblsettings/config/0/tldexclu
 CFG_V4SUPPRESSION = "installedpackages/pfblockerngipsettings/config/0/v4suppression"
 CFG_V6SUPPRESSION = "installedpackages/pfblockerngipsettings/config/0/v6suppression"
 
+# The dynamic per-row IPv4 alias list the alerts `$clists['ipwhitelist4']`
+# collection reads Permit aliases from (alerts.php:170-251).
+CFG_IPV4_LISTS = "installedpackages/pfblockernglistsv4/config"
+
 
 def _csrf(webui: WebUI) -> str:
     """GET the alerts page and return its freshly-injected ``__csrf_magic`` token.
@@ -1012,6 +1016,250 @@ def test_alerts_rows_render_suppress_icons_for_v6_and_broad_v4(
             f"config_set_path('{supp_master_path}', '{original_master}');\n"
             f"config_set_path('{CFG_V4SUPPRESSION}', '{original_supp}');\n"
             "write_config('pfBlockerNG smoke: restore suppression for icon test');\n"
+            "echo 'OK';",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Issue #798 dedup oracle: convert_ip_log() renders the "Permit Whitelist icon"
+# via TWO byte-for-byte duplicated blocks -- the Suppression-icon gate's
+# whitelist sub-path (alerts.php:3072-3094, reached only for a Block row not
+# covered by any Suppression entry) and the standalone fallback gate a few
+# lines down (alerts.php:3157-3202, reached by every OTHER row -- Permit,
+# Match, GeoIP -- since a Block row is excluded from it per the comment at
+# alerts.php:3153-3156). Issue #798's step 2 extracts the shared "is $host in
+# a Permit alias -> trash-can, else '+'" logic into one helper; THIS test is
+# the behaviour-preserving ORACLE (CLAUDE.md test-mandate exception: pins the
+# CURRENT rendering, deliberately not red->green, and must stay green both
+# before and after the extraction).
+# --------------------------------------------------------------------------- #
+
+
+def _free_list_rowid(vm: helpers.SmokeVM, cfg_root: str) -> int:
+    """Return a free numeric index under a pfblockernglistsv{4,6}/config root.
+
+    Mirrors ``test_category_edit.py``'s ``_free_rowid``: ``max(existing numeric
+    keys) + 1`` via the config API, so the seeded alias slot never clobbers a
+    row another suite (or an earlier case) left behind.
+    """
+    pre = (
+        f"$c = config_get_path({helpers._php_str(cfg_root)}, array());\n"
+        "$max = -1;\n"
+        "foreach (array_keys($c) as $k) { if (is_numeric($k) && (int)$k > $max) { $max = (int)$k; } }\n"
+        "$free = $max + 1;"
+    )
+    return int(helpers._php_read_scalar(vm, pre, "$free"))
+
+
+def _del_list_row(vm: helpers.SmokeVM, cfg_root: str, rowid: int) -> None:
+    """Delete ``{cfg_root}/{rowid}`` -- cleanup of the alias slot this test created."""
+    snippet = (
+        f"config_del_path({helpers._php_str(f'{cfg_root}/{rowid}')});\n"
+        "write_config('pfBlockerNG smoke: drop #798 whitelist-icon oracle alias row');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_del_list_row({cfg_root}/{rowid}) failed: rc={result.returncode} {result.stdout!r}")
+
+
+def test_alerts_rows_render_whitelist_icons_oracle(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Pin both duplicated Permit-Whitelist icon paths in convert_ip_log() (issue #798).
+
+    Scenario: refactor oracle for the #798 dedup -- both duplicated blocks must
+    keep rendering identically across the extraction.
+
+    Background: a Permit v4 alias (``Wlorc798``, action containing ``Permit``) has
+    one customlist host, ``203.0.113.77``. Master IP Suppression is ON and
+    ``203.0.113.77`` is in no Suppression list, so the Suppression-icon gate falls
+    into its whitelist sub-path (alerts.php:3072-3094). A second host,
+    ``203.0.113.88``, is NOT in the alias's customlist.
+
+    The fallback block's ``$supp_ip`` is only ever PRINTED for ``$rtype ==
+    'Block'`` rows (the icon assembly at alerts.php:3218-3234 drops it for
+    Permit/Match rows), so the only row class whose icons the fallback gate
+    (``!(Block && !geoip) && !$mask_suppression``) visibly renders is a
+    **GeoIP Block row** with an eval mask outside {/32, /24, /25-/31} -- that
+    is what pins path (b).
+
+    Given: neither icon marker is rendered before the synthetic rows exist.
+    When:
+        (a) a synthetic Block ``ip_block.log`` row for ``203.0.113.77`` (listed in
+            a deny-folder feed file, so it is never "Not listed!") is appended,
+            with master Suppression ON and the host in no Suppression list.
+        (b) a synthetic GeoIP Block ``ip_block.log`` row (alias ``pfB_Europe_v4``
+            -- the continent prefix makes ``$pfb_geoip`` TRUE, which excludes the
+            row from the Suppression-icon gate) for ``203.0.113.88``, evaluated
+            against a ``/23`` (so ``$mask_suppression``/``$mask_unlock`` are both
+            FALSE and the row reaches the FALLBACK gate), listed in a GeoIP
+            continent-folder feed file, is appended.
+    Then:
+        (a) the trash-can un-whitelist icon renders for ``203.0.113.77`` --
+            ``DNSBLWT|delete_ipwhitelist|203.0.113.77`` (the Suppression gate's
+            whitelist sub-path, alerts.php:3091-3093).
+        (b) the "+" whitelist icon renders for ``203.0.113.88`` --
+            ``PFBIPWHITE|203.0.113.88`` (the standalone fallback gate,
+            alerts.php:3197-3199).
+
+    Both id strings, and the condition each path needs (host present vs. absent
+    in a Permit alias's customlist), are exactly what step 2's helper extraction
+    must preserve for this test to stay green.
+
+    Cleanup (``finally``, order-independent): the log is truncated back to its
+    original size, the seeded deny/GeoIP feed files are removed, the seeded
+    Permit alias config row is deleted, and Suppression (master + v4 list) is
+    restored to its original value.
+    """
+    vm = smoke_vm
+
+    trash_host = "203.0.113.77"  # RFC 5737 TEST-NET-3 -- IN the seeded Permit alias
+    plus_host = "203.0.113.88"  # same block, NOT in the seeded Permit alias
+
+    ts = time.strftime("%b %d %H:%M:%S")  # e.g. "Jun 18 12:00:00"
+    # ip_block.log CSV format (21 fields, see the suppress-icon
+    # test above): ts,rule,real_iface,friendly_iface,action,ipv,proto_id,proto,
+    # src_ip,dst_ip,src_port,dst_port,dir,geoip,alias,ip_eval,feed,rhost,chost,asn,dup
+    block_csv = (
+        f"{ts},100,em0,WAN,block,4,6,TCP,"
+        f"{trash_host},10.0.0.10,12345,443,"
+        "in,US,pfB_798AliasDeny_v4,"
+        f"{trash_host}/32,pfB_798BlockFeed_v4,Unknown,Unknown,Unknown,+\n"
+    )
+    geo_csv = (
+        f"{ts},100,em0,WAN,block,4,6,TCP,"
+        f"{plus_host},10.0.0.11,12345,443,"
+        "in,US,pfB_Europe_v4,"
+        "203.0.113.0/23,798GeoFeed,Unknown,Unknown,Unknown,+\n"
+    )
+
+    ip_block_log = helpers.IP_BLOCK_LOG
+    deny_feed = "/var/db/pfblockerng/deny/pfB_798BlockFeed_v4.txt"
+    # GeoIP rows re-validate against $pfb['ccdir'] (alerts.php: $folder for
+    # $pfb_geoip), filtered by the row's feed column + '.txt'.
+    geo_feed = "/usr/local/share/GeoIP/cc/798GeoFeed.txt"
+    supp_master_path = "installedpackages/pfblockerngipsettings/config/0/suppression"
+
+    original_master = helpers.config_get(vm, supp_master_path)
+    original_v4supp = helpers.config_get(vm, CFG_V4SUPPRESSION)
+
+    rowid = _free_list_rowid(vm, CFG_IPV4_LISTS)
+    base = f"{CFG_IPV4_LISTS}/{rowid}"
+    permit_row = {
+        "aliasname": "Wlorc798",
+        "action": "Permit",
+        "custom": helpers._b64_textarea([trash_host]),
+    }
+
+    # ip_block.log is created lazily -- guarantee it (and its dir) exists
+    # idempotently before appending.
+    ensure_result = vm.ssh(f"mkdir -p {ip_block_log.rsplit('/', 1)[0]} && touch {ip_block_log}", timeout=15)
+    assert ensure_result.returncode == 0, (
+        f"Failed to ensure {ip_block_log!r} exists before mutation: "
+        f"rc={ensure_result.returncode}, stderr={ensure_result.stderr!r}"
+    )
+    block_size_result = vm.ssh("stat", "-f", "%z", ip_block_log, timeout=15)
+    assert block_size_result.returncode == 0, (
+        f"Failed to stat {ip_block_log!r} before mutation: rc={block_size_result.returncode}, "
+        f"stderr={block_size_result.stderr!r}"
+    )
+    original_block_size = block_size_result.stdout.strip()
+
+    try:
+        # GIVEN: master Suppression ON, host NOT in any Suppression list
+        # (v4suppression blanked so pfb_ip_suppressed_match() cannot accidentally
+        # cover trash_host), and one Permit alias whose ONLY customlist entry is
+        # trash_host.
+        setup_result = helpers.php_eval(
+            vm,
+            f"config_set_path('{supp_master_path}', 'on');\n"
+            f"config_set_path('{CFG_V4SUPPRESSION}', '');\n"
+            f"config_set_path({helpers._php_str(base)}, {helpers._php_kv_array(permit_row)});\n"
+            "write_config('pfBlockerNG smoke: seed #798 whitelist-icon oracle');\n"
+            "echo 'OK';",
+        )
+        assert setup_result.returncode == 0 and "OK" in setup_result.stdout, (
+            f"Failed to seed the #798 whitelist-icon oracle: rc={setup_result.returncode}, "
+            f"stdout={setup_result.stdout!r}"
+        )
+
+        # GIVEN: both rows' evaluated IPs exist in their folder feed files (the
+        # suppress-icon test's docstring NB applies here too: convert_ip_log()
+        # re-validates every row against the on-disk feeds and strips the icon
+        # from a "Not listed!" row; the GeoIP row validates against ccdir).
+        seed_result = vm.ssh(
+            f"mkdir -p /var/db/pfblockerng/deny /usr/local/share/GeoIP/cc && "
+            f"printf '{trash_host}/32\\n' > {deny_feed} && "
+            f"printf '203.0.113.0/23\\n' > {geo_feed}",
+            timeout=15,
+        )
+        assert seed_result.returncode == 0, (
+            f"Failed to seed deny/GeoIP feed files: rc={seed_result.returncode}, stderr={seed_result.stderr!r}"
+        )
+
+        # BEFORE (no false pass): neither icon marker is present yet.
+        pre = webui.get(ALERTS_PAGE)
+        assert not looks_like_login_page(pre.text), "alerts page GET returned login form before mutation (session lost)"
+        for marker in (f"DNSBLWT|delete_ipwhitelist|{trash_host}", f"PFBIPWHITE|{plus_host}"):
+            assert marker not in pre.text, f"Precondition failed: {marker!r} already present before the synthetic rows"
+
+        # WHEN: append the synthetic Block + GeoIP-Block rows and GET the
+        # Alerts page (both ride ip_block.log; the GeoIP row's alias prefix is
+        # what routes it to the fallback gate).
+        append_result = subprocess.run(
+            vm.ssh_argv("tee", "-a", ip_block_log),
+            input=block_csv + geo_csv,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        assert append_result.returncode == 0, (
+            f"Failed to append synthetic lines to {ip_block_log!r}: "
+            f"rc={append_result.returncode}, stderr={append_result.stderr!r}"
+        )
+
+        resp = webui.get(ALERTS_PAGE)
+        assert not looks_like_login_page(resp.text), (
+            "alerts page GET returned login form (session lost before whitelist-icon oracle)"
+        )
+        html_body = resp.text
+
+        # THEN (a): the Suppression-icon gate's whitelist sub-path
+        # (alerts.php:3072-3094) -- trash_host is covered by the Permit alias ->
+        # trash-can un-whitelist icon.
+        assert f"DNSBLWT|delete_ipwhitelist|{trash_host}" in html_body, (
+            f"trash-can un-whitelist icon missing for {trash_host!r} -- the Suppression-icon "
+            "gate's whitelist sub-path (alerts.php:3072-3094) did not render; "
+            f"nearby body excerpt: {html_body[:200]!r}"
+        )
+        # THEN (b): the standalone fallback gate (alerts.php:3157-3202) --
+        # plus_host is NOT covered by any Permit alias -> "+" whitelist icon.
+        assert f"PFBIPWHITE|{plus_host}" in html_body, (
+            f"'+' whitelist icon missing for {plus_host!r} -- the fallback gate "
+            f"(alerts.php:3157-3202) did not render; nearby body excerpt: {html_body[:200]!r}"
+        )
+    finally:
+        truncate_block = subprocess.run(
+            vm.ssh_argv("/usr/bin/truncate", "-s", original_block_size, ip_block_log),
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        assert truncate_block.returncode == 0, (
+            f"Failed to restore {ip_block_log!r} to size={original_block_size!r}: "
+            f"rc={truncate_block.returncode}, stderr={truncate_block.stderr!r}"
+        )
+        vm.ssh(f"rm -f {deny_feed} {geo_feed}", timeout=15)
+        _del_list_row(vm, CFG_IPV4_LISTS, rowid)
+        helpers.php_eval(
+            vm,
+            f"config_set_path('{supp_master_path}', '{original_master}');\n"
+            f"config_set_path('{CFG_V4SUPPRESSION}', '{original_v4supp}');\n"
+            "write_config('pfBlockerNG smoke: restore suppression for #798 whitelist-icon oracle');\n"
             "echo 'OK';",
         )
 

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -1021,17 +1021,17 @@ def test_alerts_rows_render_suppress_icons_for_v6_and_broad_v4(
 
 
 # --------------------------------------------------------------------------- #
-# Issue #798 dedup oracle: convert_ip_log() renders the "Permit Whitelist icon"
-# via TWO byte-for-byte duplicated blocks -- the Suppression-icon gate's
-# whitelist sub-path (alerts.php:3072-3094, reached only for a Block row not
-# covered by any Suppression entry) and the standalone fallback gate a few
-# lines down (alerts.php:3157-3202, reached by every OTHER row -- Permit,
-# Match, GeoIP -- since a Block row is excluded from it per the comment at
-# alerts.php:3153-3156). Issue #798's step 2 extracts the shared "is $host in
-# a Permit alias -> trash-can, else '+'" logic into one helper; THIS test is
-# the behaviour-preserving ORACLE (CLAUDE.md test-mandate exception: pins the
-# CURRENT rendering, deliberately not red->green, and must stay green both
-# before and after the extraction).
+# Issue #798 dedup oracle: convert_ip_log() rendered the "Permit Whitelist
+# icon" via TWO byte-for-byte duplicated blocks -- the Suppression-icon gate's
+# whitelist sub-path ("Check if host is in a Permit Whitelist Alias", reached
+# only for a Block row not covered by any Suppression entry) and the
+# standalone "IP Whitelist Icon" fallback block below it (reached by every
+# OTHER row -- Permit, Match, GeoIP -- since a Block/non-GeoIP row is excluded
+# from it per its own gate comment). Issue #798 extracts the shared "is $host
+# in a Permit alias -> trash-can" logic into pfb_whitelist_trash_icon(); THIS
+# test is the behaviour-preserving ORACLE (CLAUDE.md test-mandate exception:
+# pins the CURRENT rendering, deliberately not red->green, and must stay green
+# both before and after the extraction).
 # --------------------------------------------------------------------------- #
 
 
@@ -1075,11 +1075,11 @@ def test_alerts_rows_render_whitelist_icons_oracle(
     Background: a Permit v4 alias (``Wlorc798``, action containing ``Permit``) has
     one customlist host, ``203.0.113.77``. Master IP Suppression is ON and
     ``203.0.113.77`` is in no Suppression list, so the Suppression-icon gate falls
-    into its whitelist sub-path (alerts.php:3072-3094). A second host,
-    ``203.0.113.88``, is NOT in the alias's customlist.
+    into its whitelist sub-path. A second host, ``203.0.113.88``, is NOT in the
+    alias's customlist.
 
     The fallback block's ``$supp_ip`` is only ever PRINTED for ``$rtype ==
-    'Block'`` rows (the icon assembly at alerts.php:3218-3234 drops it for
+    'Block'`` rows (convert_ip_log()'s icon assembly drops it for
     Permit/Match rows), so the only row class whose icons the fallback gate
     (``!(Block && !geoip) && !$mask_suppression``) visibly renders is a
     **GeoIP Block row** with an eval mask outside {/32, /24, /25-/31} -- that
@@ -1099,10 +1099,9 @@ def test_alerts_rows_render_whitelist_icons_oracle(
     Then:
         (a) the trash-can un-whitelist icon renders for ``203.0.113.77`` --
             ``DNSBLWT|delete_ipwhitelist|203.0.113.77`` (the Suppression gate's
-            whitelist sub-path, alerts.php:3091-3093).
+            whitelist sub-path, via ``pfb_whitelist_trash_icon()``).
         (b) the "+" whitelist icon renders for ``203.0.113.88`` --
-            ``PFBIPWHITE|203.0.113.88`` (the standalone fallback gate,
-            alerts.php:3197-3199).
+            ``PFBIPWHITE|203.0.113.88`` (the fallback block's else-branch).
 
     Both id strings, and the condition each path needs (host present vs. absent
     in a Permit alias's customlist), are exactly what step 2's helper extraction
@@ -1227,19 +1226,18 @@ def test_alerts_rows_render_whitelist_icons_oracle(
         )
         html_body = resp.text
 
-        # THEN (a): the Suppression-icon gate's whitelist sub-path
-        # (alerts.php:3072-3094) -- trash_host is covered by the Permit alias ->
-        # trash-can un-whitelist icon.
+        # THEN (a): the Suppression-icon gate's whitelist sub-path -- trash_host
+        # is covered by the Permit alias -> trash-can un-whitelist icon.
         assert f"DNSBLWT|delete_ipwhitelist|{trash_host}" in html_body, (
             f"trash-can un-whitelist icon missing for {trash_host!r} -- the Suppression-icon "
-            "gate's whitelist sub-path (alerts.php:3072-3094) did not render; "
+            "gate's whitelist sub-path (pfb_whitelist_trash_icon()) did not render; "
             f"nearby body excerpt: {html_body[:200]!r}"
         )
-        # THEN (b): the standalone fallback gate (alerts.php:3157-3202) --
+        # THEN (b): the standalone 'IP Whitelist Icon' fallback block --
         # plus_host is NOT covered by any Permit alias -> "+" whitelist icon.
         assert f"PFBIPWHITE|{plus_host}" in html_body, (
-            f"'+' whitelist icon missing for {plus_host!r} -- the fallback gate "
-            f"(alerts.php:3157-3202) did not render; nearby body excerpt: {html_body[:200]!r}"
+            f"'+' whitelist icon missing for {plus_host!r} -- the IP Whitelist Icon fallback "
+            f"block did not render; nearby body excerpt: {html_body[:200]!r}"
         )
     finally:
         truncate_block = subprocess.run(


### PR DESCRIPTION
Fixes #798.

Extracts the duplicated "host in a Permit Whitelist Alias → trash-can icon" lookup + markup in `convert_ip_log()` into one helper, `pfb_whitelist_trash_icon()`, used by both twin blocks (the Suppression-icon gate's whitelist sub-path and the standalone IP Whitelist fallback). The divergent per-block "+" branches (`PFBIPSUP` combo vs `PFBIPWHITE`) deliberately stay per-block.

The helper's NULL/non-NULL return replaces the old `$pfb_found` flag, killing the undefined-variable read (PHP 8 E_WARNING) that occurred whenever no Permit alias list existed.

Behaviour-preserving refactor, proven by a two-dispatch oracle per the test mandate: `test_alerts_rows_render_whitelist_icons_oracle` (new, Tier B) pins both duplicated paths — the Block-row trash icon and the GeoIP-Block-row fallback "+" (the only row class whose fallback icon is actually printed; Permit/Match rows compute but never render it) — and ran green on the live VM **before** the refactor (commit with the test alone) and **after** it, alongside the #796 suppress-icon test as a same-region cross-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3aGLFmd8VeHoa9zZ7j5af