### PR TITLE
ADR-48: standardised download-validation reject logging + Python entry-reject accounting

### DIFF
--- a/.ADRs/ADR_48_Download_Validation_Logging/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_48_Download_Validation_Logging/RESULTS/01_Results.txt
@@ -1,0 +1,149 @@
+================================================================================
+PHASE 1 RESULTS — Pure pfb_validate_log_line() formatter + pfb_validate_log() wrapper
+ADR-48, Phase 1 of 4
+================================================================================
+
+SIGNATURES + LOCATION
+
+Both land in src/usr/local/pkg/pfblockerng/pfblockerng.inc, at the end of the
+pure-helper block, right after pfb_archive_missing_tool() and right before
+pfb_filter():
+
+  function pfb_validate_log_line(string $feed, string $stage, string $reason, string $detail = ''): string
+      — line 864
+
+  function pfb_validate_log(string $feed, string $stage, string $reason, string $detail = '', int $level = 2): void
+      — line 894
+
+pfb_validate_log_line() is pure (string in, string out, no I/O, no globals; the
+four values are escaped via a single array_map over an inline closure — no new
+named helper). pfb_validate_log() is a one-line wrapper: it calls
+pfb_validate_log_line() then pfb_logger($line, $level).
+
+CANONICAL LINE FORMAT
+
+  \npfb_validate: REJECT feed=<feed> stage=<stage> reason=<reason> detected=<detail>
+
+Leading "\n" is part of the return value (matches the pfb_logger() caller
+convention — pfb_logger() itself emits no newline). Example (all four keys
+ALWAYS present, empty detail still prints `detected=`):
+
+  pfb_validate_log_line('pfB_Feed1', 'mime', 'invalid-mime', 'application/x-msi')
+  => "\npfb_validate: REJECT feed=pfB_Feed1 stage=mime reason=invalid-mime detected=application/x-msi"
+
+  pfb_validate_log_line('F', 'mime', 'r')   // detail omitted
+  => "\npfb_validate: REJECT feed=F stage=mime reason=r detected="
+
+ESCAPING ORDER (applied to EACH of the four values independently — feed, stage,
+reason, detail — same code path for all four; IMPORTANT for Phase 2 and Phase 3's
+smoke greps, which must match the RENDERED (escaped) form, not the raw input):
+
+  1. every control byte in [\x00-\x1F\x7F] is replaced with a SINGLE space
+     (per-byte, not collapsed — implemented as preg_replace('/[\x00-\x1F\x7F]/', ' ', $v));
+     this runs FIRST so a raw "\n"/"\r"/NUL in attacker-influenced file(1) output
+     can never forge or split the greppable line.
+  2. htmlspecialchars() is applied to the result (PHP 8.3 default flags:
+     ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 — escapes & < > " ').
+
+Worked example (the oracle's hostile-detail case):
+  input detail:  "app\x00lication/zip\nfake pfb_validate: REJECT x <b>&"
+  after step 1:  "app lication/zip fake pfb_validate: REJECT x <b>&"
+  after step 2:  "app lication/zip fake pfb_validate: REJECT x &lt;b&gt;&amp;"
+  → single line, no embedded "\n": the "fake pfb_validate: REJECT" text rides
+    inside detected= as inert text, never as its own greppable entry.
+
+RED -> GREEN EVIDENCE
+
+Red (pre-change code — inc edit stashed via `git stash push -- src/.../pfblockerng.inc`,
+both new test files present):
+
+  $ vendor/bin/phpunit --filter 'PfbValidateLogLineTest|PfbValidateLogTest'
+  ...
+  1) PfbValidateLogLineTest::testCanonicalLineForStageMime
+  Error: Call to undefined function pfb_validate_log_line()
+  ... (same error repeated for all 12 PfbValidateLogLineTest cases)
+  13) PfbValidateLogTest::testDefaultLevelWritesBothPfbLogAndErrorLog
+  Error: Call to undefined function pfb_validate_log_line()
+  14) PfbValidateLogTest::testLevelOneWritesPfbLogOnlyNotErrorLog
+  Error: Call to undefined function pfb_validate_log_line()
+
+  ERRORS!
+  Tests: 14, Assertions: 12, Errors: 14.
+
+Green (post-change code — `git stash pop` restores the inc edit):
+
+  $ vendor/bin/phpunit --filter 'PfbValidateLogLineTest|PfbValidateLogTest'
+  ..............                                                    14 / 14 (100%)
+  OK (14 tests, 29 assertions)
+
+GATE SUMMARY
+
+- vendor/bin/phpunit (full suite)              -> OK, 2049 tests, 16122 assertions,
+                                                   4 pre-existing skips (unrelated:
+                                                   an environment-dependent VFS-mtime
+                                                   test that only reproduces on Linux/CI).
+- php -l pfblockerng.inc                       -> "No syntax errors detected"
+                                                   (pre-existing E_DEPRECATED notices
+                                                   on 4 unrelated legacy functions,
+                                                   untouched by this phase).
+- vendor/bin/phpstan analyse --memory-limit=1G -> "[OK] No errors"
+                                                   (default 128M worker limit crashed
+                                                   the parallel run in this sandbox —
+                                                   an environment artifact, not a code
+                                                   issue; raised via CLI flag only, no
+                                                   repo config changed).
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> clean (no output).
+
+SCOPE — git diff --stat:
+  src/usr/local/pkg/pfblockerng/pfblockerng.inc | 33 +++++++++++++++++++++++++++
+  1 file changed, 33 insertions(+)
+  (+ 2 new untracked test files: tests/php/PfbValidateLogLineTest.php,
+    tests/php/PfbValidateLogTest.php)
+No call site touched — pfb_filter(), pfb_download(), pfb_logger() are unchanged.
+Zero behaviour change for any existing code path (both new functions are unused
+as of this commit; nothing calls them yet).
+
+SELF-REVIEW (done before this handoff)
+- Both helpers sit in the pure-helper block, same doc-comment style as their
+  siblings (pfb_mime_normalise, pfb_archive_probe, etc.).
+- pfb_validate_log_line() is pure — no pfb_logger() call inside it; only
+  pfb_validate_log() calls pfb_logger().
+- Every stage token in the vocabulary (mime, structural, inner, member,
+  plaintext, entries) has its own exact-string oracle test.
+- The hostile-detail case covers all three required classes in one value: a NUL
+  byte, an embedded "\n", and HTML metacharacters (<, >, &) — plus an explicit
+  substr_count($result, "\n") === 1 assertion proving the single-line invariant.
+  Hostile feed/reason/stage each get their own one-case test (same code path).
+- The wrapper test proves level routing both ways: level 2 (default) writes to
+  BOTH pfB log and error log; level 1 writes to pfB log only and asserts the
+  error log stays EMPTY (not just "didn't check it") — a real before/after
+  transition assertion, not a single-ended check.
+
+COMMIT
+  52d6262f is the pre-existing tip (ADR text authoring). This phase's commit:
+  3006fcc8 — "pfblockerng: add canonical download-validation reject formatter (ADR-48 P1)"
+
+PUSH
+  Pushed directly to adr/48-download-validation-logging (no PR — Phase 1 of 4,
+  more phases follow on the same branch; the PR opens once the ADR's
+  implementation phases are complete, per the worktree + rebase-only-PR flow).
+
+WATCH-OUT FOR PHASE 2
+- pfb_logger() substitutes the literal token "NOW" wherever it appears in a
+  message. The canonical line built by pfb_validate_log_line() does not contain
+  that token by construction, but raw file(1) output passed as `detail` could
+  in principle contain the substring "NOW" (e.g. as part of a MIME string or
+  path). This is ACCEPTED, not special-cased — matches the ADR's explicit
+  instruction not to special-case it. Phase 2 should be aware that in the rare
+  case detail contains "NOW", pfb_logger()'s substitution will still fire on it
+  (same behaviour as every other existing pfb_logger() caller).
+- Phase 2 emits through pfb_validate_log() at the existing reject sites (MIME
+  gate, live inner-class checks, the four ADR-45 structural-probe sites). Smoke
+  greps in Phase 3 must match the RENDERED (escaped) form of feed/stage/reason/
+  detail, not the raw pre-escape values — see the escaping order above.
+- The §2 fork resolution (option a): pfb_filter()'s two reject sites need an
+  opt-in by-ref out-param carrying the raw detail + exit code so the
+  pfb_download() call site (which has $header and the stage in scope) can emit
+  the canonical line; callers that don't opt in keep pfb_filter()'s existing
+  ad-hoc message unchanged. Phase 2 owns designing that out-param; Phase 1 does
+  not touch pfb_filter() at all.

--- a/.ADRs/ADR_48_Download_Validation_Logging/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_48_Download_Validation_Logging/RESULTS/02_Results.txt
@@ -1,0 +1,221 @@
+================================================================================
+PHASE 2 RESULTS — Wire the existing reject sites through pfb_validate_log()
+ADR-48, Phase 2 of 4
+================================================================================
+
+FINAL pfb_filter() SIGNATURE
+
+  function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FALSE, &$reject_detail=NULL)
+
+$reject_detail is an optional by-ref out-param, active ONLY in the
+PFB_FILTER_FILE_MIME / PFB_FILTER_FILE_MIME_COMPRESSED reject paths (§2 fork,
+option (a)). A caller that pre-sets it to array() opts in: on rejection
+pfb_filter() fills it with array('mime_raw' => ..., 'mime' => ..., 'retval' =>
+...) and SUPPRESSES its own legacy pfb_logger() call. A caller that leaves it
+NULL (the default — every call elsewhere in the codebase) gets the exact
+legacy in-filter message, byte-identical to pre-Phase-2 behaviour.
+
+OPTED-IN CALLER MAP (all 5 live pfb_download() FILE_MIME* call sites)
+
+  site (pfblockerng.inc)                          | stage | reason
+  -------------------------------------------------|-------|----------------------------
+  outer MIME gate (post-download)                  | mime  | mime_not_allowed
+  gzip `file -bZ` compressed peek                  | inner | compressed_mime_not_allowed
+  bzip2 `file -bZ` compressed peek                 | inner | compressed_mime_not_allowed
+  ZIP post-extraction PFB_FILTER_FILE_MIME re-run  | inner | inner_mime_not_allowed
+  7z `file -bZ` compressed peek                    | inner | compressed_mime_not_allowed
+
+Detail string at every site: "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}"
+(raw file(1)/`-bZ` output + exit code, unescaped — pfb_validate_log_line()
+escapes once, internally).
+
+Plus 4 ADR-45 structural-probe swaps (stage=structural, reason=probe_failed,
+detail = "{$file_type} " . basename($file_download)) at the gzip/bzip2/zip/7z
+corrupt-archive checks in pfb_download() — same level (2), same
+unlink_if_exists()+return FALSE logic, message only.
+
+LEFT UNTOUCHED (per §2 fork resolution / ACTION PLAN step 5):
+  - 7z missing-tool reject (pfb_archive_missing_tool() branch) — stays its
+    ad-hoc "install 7-Zip" message; a tooling failure, not a content verdict.
+  - The commented-out (dead) ZIP inner-content PFB_FILTER_FILE_MIME_COMPRESSED
+    block inside pfb_download()'s ZIP branch — still 5-arg, still dead code,
+    not executed.
+
+STEP 2 — ENUMERATION OF ALL PFB_FILTER_FILE_MIME[_COMPRESSED] CALLERS
+  $ grep -rn 'PFB_FILTER_FILE_MIME\b\|PFB_FILTER_FILE_MIME_COMPRESSED\b' src/
+  Every call site is inside src/usr/local/pkg/pfblockerng/pfblockerng.inc; no
+  other file (pfblockerng.php, list_scripts/, www/) references either
+  constant. Within pfblockerng.inc, the only call sites are the 5 live
+  pfb_download() sites above (all opted in) + the 1 dead commented-out block
+  (left as-is). NO non-opted FILE_MIME/FILE_MIME_COMPRESSED caller exists
+  anywhere in the tree — nothing to record as a follow-up candidate.
+
+RENDERED CANONICAL LINES (for Phase 3's smoke greps — match these EXACTLY,
+including the escaped form; a raw '/' is NOT escaped by htmlspecialchars(),
+but '&', '<', '>', '"', '\'' are)
+
+  Outer MIME gate (e.g. mime_raw="application/x-msdownload", retval=0):
+    \npfb_validate: REJECT feed=<feed> stage=mime reason=mime_not_allowed detected=application/x-msdownload rc=0
+
+  ZIP post-extraction re-run (e.g. mime_raw="application/x-executable"):
+    \npfb_validate: REJECT feed=<feed> stage=inner reason=inner_mime_not_allowed detected=application/x-executable rc=0
+
+  Compressed peeks — gz/bz2/7z (e.g. mime_raw="application/x-dosexec"):
+    \npfb_validate: REJECT feed=<feed> stage=inner reason=compressed_mime_not_allowed detected=application/x-dosexec rc=0
+
+  Structural probes — gz/bz2/zip/7z (e.g. file_type="application/gzip",
+  file_download basename="pfB_Feed1.gz"):
+    \npfb_validate: REJECT feed=<feed> stage=structural reason=probe_failed detected=application/gzip pfB_Feed1.gz
+
+  If any mime_raw/file_type/basename value carries '&'/'<'/'>'/'"'/'\'' (rare,
+  attacker-influenced file(1) output), it renders once-escaped
+  (&amp;/&lt;/&gt;/&quot;/&#039;) per pfb_validate_log_line()'s contract —
+  never double-escaped (pinned by testStructuralStageCallSiteShapeIsSinglyEscapedInSink
+  below). A raw '/' in a mime string or path is NOT touched by
+  htmlspecialchars() — matches Phase 1's escaping-order note.
+
+TEST COVERAGE
+
+New tests/php/PfbFilterRejectDetailTest.php (7 methods total across both
+files — 4 here + 1 added to PfbValidateLogTest.php below — see RED->GREEN):
+  - testNonOptedCallerKeepsLegacyMessage (FILE_MIME) — back-compat pin: the
+    plain 4-5-arg call still rejects AND still writes the exact legacy
+    message.
+  - testOptedInCallerSuppressesLegacyMessageAndFillsDetail (FILE_MIME) —
+    pre-set $reject_detail=array(); rejects, fills mime_raw/mime/retval,
+    legacy message ABSENT from the sink.
+  - testCompressedNonOptedCallerKeepsLegacyMessage /
+    testCompressedOptedInCallerSuppressesLegacyMessageAndFillsDetail — same
+    pair for FILE_MIME_COMPRESSED (`file -bZ`); each guarded by
+    skipIfHostLacksDashZSemantics() (markTestSkipped if the host's -bZ output
+    for the PDF fixture ever differs — mirrors the wiring-test template).
+
+Fixture: a real on-disk PDF ("%PDF-1.4\n"), which file(1) reliably reports as
+application/pdf on this host (empirically verified — a bare PNG/EXE magic
+alone reads as application/octet-stream here, which would instead exercise
+the octet-stream structural-probe RECOVERY branch, not the plain allow-list
+reject this test targets). The tests' allow-list contains only text/plain, so
+application/pdf always fails the gate deterministically, without hitting the
+hostname exceptions (text/x-asm, ipinfo.io octet-stream).
+
+Extended tests/php/PfbValidateLogTest.php with
+testStructuralStageCallSiteShapeIsSinglyEscapedInSink: pfb_download() itself
+is not off-appliance unit-testable (curl/exec), so this test calls
+pfb_validate_log() directly with the EXACT detail-construction expression the
+four structural call sites use — "{$file_type} " . basename($file_download) —
+fed a raw (unescaped) '&', and asserts the sink shows '&amp;' exactly once
+(never '&amp;amp;'). Proves the call sites pass raw values straight through
+and pfb_validate_log_line() is the sole escaper. Phase 3 smoke covers the
+true end-to-end four lines on the live VM (as instructed — not faked here).
+
+RED -> GREEN EVIDENCE (out-param contract)
+
+Red (pre-Phase-2 code — `git stash push -- src/.../pfblockerng.inc`, both new
+test additions present; the 5-arg pfb_filter() signature silently ignores a
+6th call-site argument, so the opted-in calls still run but $reject_detail is
+never bound/filled):
+
+  $ vendor/bin/phpunit --filter 'PfbFilterRejectDetailTest|PfbValidateLogTest::testStructuralStageCallSiteShapeIsSinglyEscapedInSink'
+  .F.F.                                                               5 / 5 (100%)
+  1) PfbFilterRejectDetailTest::testOptedInCallerSuppressesLegacyMessageAndFillsDetail
+  mime_raw must carry the raw file(1) output
+  Failed asserting that null is identical to 'application/pdf'.
+  2) PfbFilterRejectDetailTest::testCompressedOptedInCallerSuppressesLegacyMessageAndFillsDetail
+  mime_raw must carry the raw file(1) -bZ output
+  Failed asserting that null is identical to 'application/pdf'.
+  FAILURES!
+  Tests: 5, Assertions: 22, Failures: 2.
+
+  (The 2 non-opted back-compat tests + the structural sink test correctly
+  PASS red — they pin pre-existing/Phase-1 behaviour, not this phase's
+  change; only the 2 opted-in tests are red for the exact reason Phase 2
+  fixes: the out-param contract does not exist yet.)
+
+Green (post-Phase-2 code — `git stash pop`):
+
+  $ vendor/bin/phpunit --filter 'PfbFilterRejectDetailTest|PfbValidateLogTest'
+  .......                                                             7 / 7 (100%)
+  OK (7 tests, 44 assertions)
+
+GATE SUMMARY
+
+- vendor/bin/phpunit (full suite)              -> OK, 2054 tests, 16150 assertions,
+                                                   4 pre-existing skips (same
+                                                   environment-dependent VFS-mtime
+                                                   skip as Phase 1; +5 tests vs
+                                                   Phase 1's 2049).
+- php -l pfblockerng.inc                       -> "No syntax errors detected"
+                                                   (same 4 pre-existing
+                                                   E_DEPRECATED notices as
+                                                   Phase 1, untouched by this
+                                                   phase).
+- vendor/bin/phpstan analyse --memory-limit=1G -> "[OK] No errors".
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> clean (no output); PFBL-01
+                                                   (RequirePfbFilter) unaffected
+                                                   — no new exec/json_encode/
+                                                   path-build sites added.
+
+SCOPE — git diff --stat:
+  src/usr/local/pkg/pfblockerng/pfblockerng.inc | 63 ++++++++++++++++++++++-----
+  tests/php/PfbValidateLogTest.php              | 40 +++++++++++++++++
+  2 files changed, 91 insertions(+), 12 deletions(-)
+  (+ 1 new untracked test file: tests/php/PfbFilterRejectDetailTest.php)
+No sink, level, or reject DECISION changed anywhere — every site still
+returns FALSE / unlinks exactly as before; only message construction moved.
+
+SELF-REVIEW (done before this handoff, against the phase prompt's checklist)
+- Out-param fills BOTH mime branches (FILE_MIME + FILE_MIME_COMPRESSED),
+  same array shape (mime_raw/mime/retval) in each.
+- Legacy messages suppressed ONLY when is_array($reject_detail) — i.e. only
+  for opted-in callers; verified both ways by the paired non-opted/opted-in
+  tests (before-state assertion built in, not just the final state).
+- All 5 pfb_download() FILE_MIME* call sites opted in with the correct stage
+  token: mime (outer gate) vs inner (ZIP re-run + 3 compressed peeks) — no
+  site uses the wrong token.
+- Four structural swaps done (gzip/bzip2/zip/7z), all stage=structural,
+  reason=probe_failed, same level (2), same unlink+return logic.
+- 7z missing-tool reject and the dead commented-out ZIP inner block are
+  byte-identical to Phase 1 (confirmed via diff — neither appears in the
+  changeset).
+- No double-escaping: every pfb_validate_log() call at every site passes RAW
+  values (mime_raw, file_type, basename) with no caller-side
+  htmlspecialchars() — pinned by testStructuralStageCallSiteShapeIsSinglyEscapedInSink
+  (asserts a single '&amp;', never '&amp;amp;').
+- Non-opted back-compat pinned for both FILE_MIME and FILE_MIME_COMPRESSED —
+  the plain call shape used by every un-migrated caller (there are none left
+  to migrate; see the step-2 enumeration above) is byte-identical to
+  pre-Phase-2 behaviour.
+- Scope clean: only pfblockerng.inc + tests touched; no exec/sink/level
+  changes; git diff --stat matches the EXPECTED RESULT.
+
+COMMIT
+  f25ccc58 is the pre-existing tip (Phase 1, hash after rebase onto
+  origin/devel). This phase lands as the single following commit on
+  adr/48-download-validation-logging: "pfblockerng: wire
+  download-validation rejects through pfb_validate_log() (ADR-48 P2)"
+  (see `git log -1` on the pushed branch tip for the exact hash — this
+  handoff is part of that same commit's tree, so embedding its own final
+  hash here is self-referential).
+
+PUSH
+  Pushed directly to adr/48-download-validation-logging (Phase 2 of 4; the PR
+  opens once all implementation phases land, per the worktree + rebase-only-PR
+  flow).
+
+WATCH-OUT FOR PHASE 3
+- Smoke MUST grep the ESCAPED rendering, not the raw pre-escape value: a
+  detected= value with '/' is unescaped (mime strings, filenames render
+  as-is), but '&' → '&amp;', '<' → '&lt;', '>' → '&gt;', '"' → '&quot;',
+  '\'' → '&#039;' per pfb_validate_log_line()'s htmlspecialchars() step (this
+  is unlikely to fire in practice for the wired sites — mime types and
+  basenames rarely carry these bytes — but a forced fixture designed to
+  probe it must grep the escaped form).
+- The five rendered-line templates above (mime/inner ×3/structural) are the
+  exact grep targets; `reason=` is now a fixed vocabulary
+  (mime_not_allowed / compressed_mime_not_allowed / inner_mime_not_allowed /
+  probe_failed) — match on `reason=` too, not just `stage=`, to disambiguate
+  the three `stage=inner` sites from each other if needed.
+- `rc=<retval>` rides inside `detected=` (not a separate key) — a smoke grep
+  matching only up to the mime string must account for the trailing
+  " rc=<N>" suffix on the mime/inner lines (absent on the structural lines,
+  which instead carry a trailing basename).

--- a/.ADRs/ADR_48_Download_Validation_Logging/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_48_Download_Validation_Logging/RESULTS/03_Results.txt
@@ -1,0 +1,196 @@
+================================================================================
+PHASE 3 RESULTS — Live-VM smoke: canonical reject line per wired stage
+ADR-48, Phase 3 of 4
+================================================================================
+
+SCOPE — TEST-ONLY, no src/ change.
+
+  git diff --stat:
+    tests/smoke/test_smoke_feeds.py | 281 ++++++++++++++++++++++++++++++++++
+    1 file changed, 281 insertions(+)
+
+No fixture files added — every stage is forced with fixtures/patterns already
+proven in the repo (see "NEW FIXTURES" below for why none were needed).
+
+NEW TESTS — one per wired stage + the healthy-feed guard
+
+All four live in tests/smoke/test_smoke_feeds.py, in a new "ADR-48" section
+appended after the existing ADR-45 7z block (end of file). Each is
+self-encapsulated (its own CaseContext, its own delta baseline — no ordering
+dependence on any sibling test) and delta-based (count the marker BEFORE the
+case's own Force Update, again AFTER, inside the CaseContext block, assert on
+the delta — never a global "count == 0").
+
+1. test_validate_log_structural_reject_line
+   Stage: structural. Fixture: fixtures/archive_corrupt.gz (existing ADR-45
+   corpus — FreeBSD-verified on-box file(1) verdict "application/gzip";
+   fixtures/README.md "Archive corpus"). The truncated gzip fails
+   pfb_validate_archive() (gunzip -t), same trigger as the existing
+   test_corrupt_gzip_rejected — this test adds ONLY the new log-line
+   assertion on top. detected= is deterministic from the header we choose:
+   "{file_type} " . basename($file_download), and $file_download's basename
+   is always "{header}.raw" (pfb_download() builds
+   $file_dwn = "{pfborig}/{header}" then appends ".raw" — confirmed by
+   reading pfblockerng.inc:14722/16390 + 8926). No on-box guard needed —
+   gzip-truncation corruption is deterministic across platforms (gunzip -t
+   is not a libmagic-classification question), matching the existing sibling
+   test's own lack of a guard.
+   Marker: "pfb_validate: REJECT feed=adr48stc stage=structural
+   reason=probe_failed detected=application/gzip adr48stc.raw"
+
+2. test_validate_log_mime_reject_line
+   Stage: mime. Fixture: fixtures/archive_junk_octet.bin (existing ADR-45
+   corpus — pure NUL/control bytes, FreeBSD-verified as
+   application/octet-stream, not archive-recoverable by
+   pfb_octet_recover_type() — same trigger as the existing
+   test_junk_octet_stream_rejected). The reject falls through to the OUTER
+   MIME gate (pfblockerng.inc:9298-9302): mime_raw=application/octet-stream,
+   retval=0 (file(1) itself succeeds; only the allow-list check fails).
+   Carries the SAME on-box guard as its ADR-45 sibling (skip, not fail, if
+   this box's file(1) does not report octet-stream for these exact bytes).
+   Marker: "pfb_validate: REJECT feed=adr48mim stage=mime
+   reason=mime_not_allowed detected=application/octet-stream rc=0"
+
+3. test_validate_log_inner_reject_line
+   Stage: inner — exercises the POST-EXTRACTION ZIP re-run sub-path
+   specifically (pfblockerng.inc:9459-9463), NOT the pre-extraction
+   compressed-peek sub-path (which only applies to the gz/bz2/7z branches,
+   per RESULTS/02_Results.txt's caller map — zip has no compressed-peek
+   call site). Built INLINE (io.BytesIO + zipfile.ZipFile, exactly like the
+   healthy test_zip_feed_imports / ADR-44 tests) rather than a committed
+   fixture: a valid zip is trivially cross-platform-portable (any zipfile
+   writer's output is a valid archive bsdtar reads fine on FreeBSD too — the
+   FreeBSD-sensitivity in this repo's corpus is specifically about CORRUPT
+   archives and octet-stream MIME misclassification, neither of which
+   applies to a plain valid container). The zip wraps one entry containing
+   the exact "%PDF-1.4\n" byte string tests/php/PfbFilterRejectDetailTest.php
+   already uses off-appliance (that test's own docblock records: file(1)
+   reliably reports application/pdf for it, whereas a BARE PNG/EXE magic
+   alone was found to read as application/octet-stream on that dev host —
+   confirmed independently on this session's own macOS host too via a local
+   `file --mime-type` probe: "%PDF-1.4\n" → application/pdf, a proper
+   hand-built valid PNG → image/png, but bare "MZ..." → octet-stream). The
+   entry has no comma bytes, so pfb_download()'s extraction pipe
+   (tar -xOf | sed 's/,[[:space:]]/; /g' | tr ',' '\n') passes it through
+   byte-for-byte. An ON-BOX GUARD (_box_mime_type on the raw entry bytes)
+   skips (not fails) the test if this box's file(1) does not report
+   application/pdf for them — the same "verify, don't assume" discipline the
+   ADR-45 octet-stream guards already use, applied here because FreeBSD
+   libmagic behaviour for less-common magics has already surprised this repo
+   once (README's image/x-tga note).
+   Marker: "pfb_validate: REJECT feed=adr48inr stage=inner
+   reason=inner_mime_not_allowed detected=application/pdf rc=0"
+
+4. test_validate_log_healthy_feed_no_spurious_reject
+   Reuses the Phase-4 ip_plain_cidr.txt fixture (already the KILL-GATE
+   healthy-load fixture for test_ip_http_feed_loads). Delta baseline is the
+   GENERIC "pfb_validate: REJECT" marker (module-wide on purpose — proves
+   nothing NEW appeared during this case's own Force Update window,
+   regardless of what any earlier test already logged; never depends on run
+   order). Asserts the member loads (genuine success, not "didn't crash")
+   AND the reject-marker count is unchanged across the case.
+
+DIAGNOSTICS (CLAUDE.md expected-vs-actual mandate)
+
+Every assertion above prints the expected condition next to the actual
+before/after counts. On a FAILING delta assertion specifically, the failure
+message additionally embeds the actual last-5 "pfb_validate:" lines found in
+the live pfB log (`_recent_validate_lines()`, new module-local helper) — the
+real log excerpt, not just a number. This helper is called ONLY from inside
+the failing `if not (...): raise AssertionError(...)` branch (never from an
+`assert`'s message expression, which Python evaluates unconditionally even on
+the passing path — that would cost an extra SSH round-trip on every green
+run).
+
+NEW FIXTURES: NONE.
+
+Every stage reuses an EXISTING FreeBSD-verified ADR-45 corpus fixture
+(archive_corrupt.gz, archive_junk_octet.bin) except the inner-stage test,
+which builds its zip INLINE (matching the established
+test_zip_feed_imports / ADR-44 precedent for VALID archives — only CORRUPT/
+octet-stream-classification fixtures need FreeBSD-side commitment in this
+repo, per fixtures/README.md's own rationale). Nothing new to verify on-box
+beyond the existing guards already built in (the on-box MIME/PDF guards
+above skip cleanly if a given box's file(1) ever disagrees).
+
+PYTEST -K FILTER (covers all 4 new tests; "validate_log" is a unique
+substring — grep-confirmed no other test name in the suite contains it):
+
+    python -m pytest tests/smoke/test_smoke_feeds.py -k validate_log -m smoke --override-ini="addopts="
+
+Collection-confirmed off-box: 4/38 selected, 34 deselected, no import errors.
+
+VERIFICATION (off-box)
+
+- python -m pytest tests/smoke/test_smoke_feeds.py --collect-only
+  --override-ini="addopts=" -> 38 tests collected (34 pre-existing + 4 new),
+  no import errors.
+- python -m pytest tests/smoke/test_smoke_feeds.py -k validate_log
+  --collect-only --override-ini="addopts=" -> 4/38 selected exactly the 4
+  new tests.
+- python -m pytest (full unit suite) -> 2105 passed, 4 skipped (unchanged
+  skip set — pre-existing, unrelated to this phase).
+- ruff check tests/smoke/test_smoke_feeds.py -> All checks passed.
+- ruff format --check tests/smoke/test_smoke_feeds.py -> clean (one
+  reformat applied and re-verified during this phase — two f-strings that
+  exceeded the line-length target were rewrapped by `ruff format`).
+- mypy tests/ -> Success: no issues found in 66 source files.
+
+SELF-REVIEW (done before this handoff, against the phase prompt's checklist)
+
+- One test per wired stage (structural/mime/inner) + the healthy-feed guard —
+  exactly 4 new tests, no more no less.
+- Delta-based log assertions with an asserted before-state in every case
+  (alias-absence "Given" + the marker-count "before" captured prior to the
+  Force Update, matching the existing test_7z_missing_binary_rejected idiom
+  already established in this same file).
+- Fixture rules honoured: two stages reuse the committed FreeBSD-verified
+  ADR-45 corpus; the inner stage builds a plain VALID zip inline (no FreeBSD
+  risk — only corrupt/octet-stream fixtures need on-box commitment here);
+  no new fixture file added, so fixtures/README.md needed no new row.
+- Docstrings state the red-on-pre-ADR-48 intent explicitly for all three
+  reject-line tests (the pre-Phase-2 ad-hoc message contains no
+  "pfb_validate: REJECT" substring, so the assertion is unsatisfiable on that
+  code — a genuine red->green pin, not a test that was already green).
+- Diagnostics print expected-vs-actual (before/after counts) on every
+  assertion, PLUS the actual live log excerpt on a failing delta assertion
+  specifically (lazy-evaluated, no cost on the passing path).
+- Self-encapsulated: each test uses its own unique header/alias
+  (adr48stc/adr48mim/adr48inr/adr48hlt) and its own CaseContext; no test
+  reads another test's marker or relies on run order (the healthy-feed
+  guard's generic marker is explicitly module-wide BY DESIGN — it only
+  reads a DELTA across its own window, so prior tests' lines are inert).
+- git diff --stat matches the phase prompt's EXPECTED RESULT (tests/smoke/*
+  only; no fixture changes were needed).
+
+COMMIT
+  ba98106d — "tests/smoke: assert canonical pfb_validate REJECT line per
+  wired stage (ADR-48 P3)". NOTE: origin/devel advanced between Phase 2's
+  push and this phase's start (unrelated Suppression/Alerts work, PRs
+  #422/#796), so this commit was created on the prior Phase-1/2 tip
+  (c00fed30) and then the branch was rebased onto the fresh origin/devel —
+  a clean linear replay (no conflicts; the intervening commits touched
+  unrelated files). The rebase replayed Phase 1/2 too, so their hashes moved:
+  Phase 1 is now 499cd8c0 (was f25ccc58), Phase 2 is now a2e140a5 (was
+  c00fed30) — content unchanged, only the parent commit differs.
+
+PUSH
+  Pushed directly to adr/48-download-validation-logging (Phase 3 of 4; the PR
+  opens once Phase 4 lands too, per the worktree + rebase-only-PR flow).
+
+NOTE FOR THE ORCHESTRATOR
+
+Fan-out green (CE + Plus) on the filter above is the Accepted gate for
+Phases 1-3 (ADR.md §7's live-VM requirement: "a forced MIME / inner rejection
+emits the canonical line with the raw file(1) output; no healthy feed logs a
+spurious REJECT" — all four assertions map 1:1 onto that sentence). Suggested
+dispatch:
+
+    gh workflow run smoke.yml -f scope=full \
+      -f pytest_filter="validate_log"
+
+(or `-f scope=impacted` once this branch merges to devel, since selective
+dispatch auto-derives the changed-module filter from tests/smoke/test_smoke_feeds.py).
+Phase 4 (Python-side entry-reject accounting, issue #789) lands after with its
+own smoke leg and its own PHPUnit/pytest oracle gates — it is a SEPARATE
+acceptance track per ADR.md §6/§7 and does not block this phase's fan-out.

--- a/.ADRs/ADR_48_Download_Validation_Logging/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_48_Download_Validation_Logging/RESULTS/04_Results.txt
@@ -1,0 +1,403 @@
+================================================================================
+PHASE 4 RESULTS — Python-side per-entry reject accounting (issue #789)
+ADR-48, Phase 4 of 4
+================================================================================
+
+SCOPE — git diff --stat (Phase 4's own changes only):
+  src/usr/local/pkg/pfblockerng/pfb_unbound.py  | 160 +++++++++++++++++++++++---
+  src/usr/local/pkg/pfblockerng/pfblockerng.inc |  36 ++++++
+  tests/smoke/test_smoke_feeds.py               | 153 ++++++++++++++++++++++++
+  tests/test_adr06_build_module.py              | 136 ++++++++++++++++++++++
+  tests/test_adr07_reconcile.py                 |  17 ++-
+  tests/test_adr10_swap.py                      |  53 ++++++++-
+  tests/test_branch_coverage_gaps.py            |  50 ++++++++
+  7 files changed, 584 insertions(+), 21 deletions(-)
+  (+ 1 new untracked test file: tests/php/PfbEmitEntryRejectStatsTest.php)
+
+TALLY PLUMBING MAP
+
+Classified verdict (the reusable primitive both buckets come from):
+  _normalise_verdict(value) -> (domain, None) on accept; (None, 'shape') or
+  (None, 'wire_cap') on reject. Body extracted from normalise() (pfb_unbound.py
+  ~L3990-4013); normalise() is now a 2-line wrapper (`domain, _ =
+  _normalise_verdict(value); return domain`) — public contract byte-identical,
+  pinned by the untouched pre-existing TestNormalise suite.
+  Bucket split (matches the ADR-48 04-prompt's mapping of the old compound test):
+    "." not in host                         -> 'shape'
+    not _dnsbl_within_wire_caps(host)        -> 'wire_cap'
+    empty/edge-hyphen label, bad char        -> 'shape'
+
+Tally container + helper:
+  RejectTally = dict[tuple[str, str], dict[str, int]]   (keyed (feed, group))
+  _tally_reject(tally, feed, group, bucket) -> tally.setdefault((feed, group),
+  {"shape": 0, "wire_cap": 0})[bucket] += 1 — the one place that does the
+  defaulting; no class (a plain dict never grows past these two RESOLVED keys).
+
+Gate site -> bucket map:
+  build() permit path (pfb_unbound.py ~L4871, was normalise(entry.value))
+    -> _normalise_verdict + _tally_reject(rejects, feed, group, bucket) on reject.
+  build() plain path (pfb_unbound.py ~L4924, was normalise(entry.value))
+    -> same transform; proves the non-ABP path counts too, not just ABP.
+  parse_abp() — 3 domain-target reject sites, one per KEEP shape (anchor
+  ~L3816, hosts ~L3853, bare domain ~L3875) — each: `dom, bucket =
+  _normalise_verdict(...); if dom is None: if tally is not None and bucket is
+  not None: _tally_reject(tally, feed, group, bucket); return None`.
+  ``tally`` is a new optional kwonly param (default None) — a caller that
+  omits it gets the BYTE-IDENTICAL pre-Phase-4 return value (purity untouched,
+  pinned by the pre-existing TestPurity suite).
+  reconcile() — the #753 wire-cap FOLD-DROP (pfb_unbound.py ~L4322, `if not
+  _dnsbl_within_wire_caps(domain): continue`) -> always 'wire_cap' (a
+  well-shaped regex reduced to a domain-literal key that is simply too long to
+  query). New optional `tally` param (default None), same non-kwonly-but-
+  defaulted shape as the other two.
+
+  Fold-drop PROVENANCE choice (the prompt's open question): the drop sits
+  inside `for r in survivors:` — reconcile() processes ONE originating Rule
+  per iteration, and the wire-cap check runs BEFORE any same-key dict merge
+  (data_db[key]=.../zone_db[key]=... happens later, per-r, not as a batched
+  dedup pass). So there is no "folded key aggregates several feeds" case to
+  disambiguate at this line — every fold-drop already has exactly one
+  r.feed/r.group in scope, and that is what gets tallied. Documented inline
+  in reconcile()'s docstring.
+
+  build() wires all four sites: creates `rejects: RejectTally = {}` once,
+  passes `tally=rejects` into both parse_abp() call sites (whole-feed ABP +
+  the ADR-21 per-line-in-plain-feed path) and into `reconcile(abp_rules,
+  tlds, exclusion, tally=rejects)`, and counts directly at its own two
+  normalise() call sites (permit, plain). Returns `BuildResult(...,
+  rejects=rejects)`.
+
+ARTIFACT SCHEMA + BOTH-SIDE PATHS
+
+  Python (chroot-relative bare name, set in init_standard beside pfb_py_count):
+    pfb["pfb_py_reject_stats"] = "pfb_py_reject_stats.json"
+  PHP (host-absolute twin, beside unbound_py_count):
+    $pfb['unbound_py_reject_stats'] = '/var/unbound/pfb_py_reject_stats.json'
+
+  dnsbl_emit_reject_stats(stats_path, rejects) -> bool (pfb_unbound.py, sibling
+  of dnsbl_emit_count()): writes a JSON array of ONLY nonzero-total rows —
+    [{"feed": <str>, "group": <str>, "shape": <int>, "wire_cap": <int>}, ...]
+  sorted by (feed, group) for stable output. Atomic temp+os.replace, copying
+  the `_reload_write_applied` pattern (tmp -> write -> flush -> fsync ->
+  os.replace; OSError -> stderr + best-effort tmp cleanup, never raises). An
+  EMPTY tally still writes literal "[]" so PHP can tell "ran, zero rejects"
+  from "no artifact at all" (fresh boot / an old python module).
+
+  Called from BOTH dnsbl_emit_count() call sites:
+    - init (~L1410, inside `if build_result is not None:`): unconditional
+      `pfb["pfb_py_reject_stats"]` access — the key is always set a few lines
+      earlier in the SAME function, so no guard needed.
+    - rebuild_and_swap() (~L5270, the no-restart reload path, `if
+      emit_counts:` block): guarded with `pfb.get("pfb_py_reject_stats")` —
+      NOT a bare index. rebuild_and_swap() is unit-tested directly
+      (test_adr10_swap.py / test_adr10_watcher.py / test_adr10_concurrency.py)
+      against a bare, hand-built `pfb` dict that never seeds this key, so a
+      bare `pfb["pfb_py_reject_stats"]` would have KeyError'd every one of
+      those pre-existing tests. The `.get()` guard keeps them green with ZERO
+      changes (verified — see GATE SUMMARY) while still exercising the real
+      call in two NEW tests that seed the key explicitly (see TEST COVERAGE).
+    Snapshot (the reload-path bundle) gained the same `rejects` field
+    (default `{}` via field(default_factory=dict)) so rebuild_and_swap() can
+    read `new_snapshot.rejects` — populated from `build_result.rejects` in
+    `_build_swap_snapshot()`. `_init_build_snapshot()`'s Snapshot is built
+    with `emit_counts=False` (init keeps its own inline count emits, per the
+    pre-existing comment there), so its `rejects` field is never read —
+    intentionally left at the dataclass default rather than plumbed, since
+    doing so would be dead code.
+  BuildResult also gained `rejects: RejectTally = field(default_factory=dict)`.
+
+  PHP: pfb_emit_entry_reject_stats(string $path): void (pfblockerng.inc,
+  right after pfb_validate_log() — same ADR-48 feature area as Phases 1-2):
+    @file_get_contents -> FALSE/'' -> return (missing/unreadable, silent).
+    json_decode(..., TRUE) -> not is_array -> return (corrupt/non-array JSON,
+      silent — covers `[]` too: that decodes to an empty PHP array, the
+      foreach below just never iterates, same silent-no-lines outcome).
+    Per entry: skip if not array or 'feed' absent; else for each of
+      ('shape', 'wire_cap'), if (int)$entry[$bucket] > 0:
+      pfb_validate_log($feed, 'entries', $bucket, (string) $count).
+    Never `write_config()`/config-gateway related (pure log read+emit); no
+    PFBL-01/PHPCS scope hit (no exec/json_encode-write/dynamic-path-build).
+  Wired in pfb_update_unbound() right after the existing "loaded entries"
+  completion log (`$loaded_cnt = trim(...file_get_contents($pfb
+  ['unbound_py_count'])...)`), BEFORE `pfb_unbound_clear_work_files()` — the
+  exact slot the Phase-4 prompt named (its "~L7899"/"~L7904" anchors had
+  shifted to ~L7993/~L7998 on the current tree; verified by grep before
+  editing, per the phase prompt's own warning about pfblockerng.inc drift).
+
+RED -> GREEN EVIDENCE
+
+Red (pre-Phase-4 code — `git stash push -- src/usr/local/pkg/pfblockerng/pfb_unbound.py
+src/usr/local/pkg/pfblockerng/pfblockerng.inc`; every new/changed test file left
+in place):
+
+  $ .venv/bin/python -m pytest tests/test_adr06_build_module.py \
+      -k "TestEntryRejectTally or TestSkipClassesTallyZero or TestNormaliseVerdictBucket" -q
+  ...
+  AttributeError: 'BuildResult' object has no attribute 'rejects'
+  (x3 — the two TestEntryRejectTally cases + TestSkipClassesTallyZero)
+  ... AttributeError: module 'pfb_unbound' has no attribute '_normalise_verdict'
+  (x7 — every TestNormaliseVerdictBucket case)
+  10 failed, 42 deselected
+
+  $ .venv/bin/python -m pytest tests/test_adr07_reconcile.py \
+      -k test_unqueryable_folded_key_is_dropped -q
+  TypeError: reconcile() got an unexpected keyword argument 'tally'
+  1 failed, 47 deselected
+
+  $ .venv/bin/python -m pytest tests/test_branch_coverage_gaps.py -k TestEmitRejectStats -q
+  ImportError: cannot import name 'dnsbl_emit_reject_stats' from 'pfb_unbound'
+  1 error during collection (whole module fails to import)
+
+  $ .venv/bin/python -m pytest tests/test_adr10_swap.py \
+      -k "test_emit_counts_true_also_reemits_reject_stats_when_path_set or \
+          test_emit_counts_true_skips_reject_stats_when_path_absent" -q
+  TypeError: Snapshot.__init__() got an unexpected keyword argument 'rejects'
+  2 failed, 13 deselected
+
+  $ vendor/bin/phpunit --filter PfbEmitEntryRejectStatsTest
+  Error: Call to undefined function pfb_emit_entry_reject_stats()
+  (x5 — every test method)
+  ERRORS! Tests: 5, Assertions: 28, Errors: 5.
+
+Green (post-Phase-4 code — `git stash pop`):
+
+  $ .venv/bin/python -m pytest -q
+  ======================= 2122 passed, 4 skipped in 36.09s =======================
+
+  $ vendor/bin/phpunit
+  OK, but some tests were skipped!
+  Tests: 2071, Assertions: 16206, Skipped: 4.   (same 4 pre-existing VFS-mtime skips)
+
+GATE SUMMARY
+
+- python -m pytest (full suite)                -> 2122 passed, 4 skipped
+                                                   (Phase 3 baseline 2105 + 4 +
+                                                   13 new this phase = 2122;
+                                                   the +13 unrelated to the +4
+                                                   comes from intervening devel
+                                                   commits that landed between
+                                                   Phase 3 and this phase, per
+                                                   `git fetch` — see PUSH below).
+- ruff check .                                 -> All checks passed!
+- ruff format --check .                        -> clean (2 files auto-reformatted
+                                                   during this phase — a
+                                                   too-long parse_abp() call and
+                                                   an f-string assert message —
+                                                   both re-verified clean after).
+- python -m mypy tests/                        -> Success: no issues found in
+                                                   66 source files (one fix
+                                                   needed: a `list.append(...)
+                                                   or True` spy lambda tripped
+                                                   mypy's func-returns-value
+                                                   check — replaced with a
+                                                   named function).
+- vendor/bin/phpunit (full suite)              -> OK, 2071 tests, 16206
+                                                   assertions, 4 pre-existing
+                                                   skips (same VFS-mtime skip).
+- php -l pfblockerng.inc                       -> "No syntax errors detected"
+                                                   (same pre-existing
+                                                   E_DEPRECATED notices,
+                                                   untouched by this phase).
+- vendor/bin/phpstan analyse --memory-limit=1G -> [OK] No errors.
+- vendor/bin/phpcs --standard=phpcs.xml.dist src/ -> clean (no output).
+- python -m pytest tests/smoke/test_smoke_feeds.py --collect-only
+  --override-ini="addopts=" -> 40 tests collected (38 pre-existing + 2 new),
+  no import errors.
+- python -m pytest tests/smoke/test_smoke_feeds.py -k validate_log
+  --collect-only --override-ini="addopts=" -> 6/40 selected: the 4
+  Phase-3 tests + the 2 new Phase-4 tests (same filter substring covers
+  both phases — no new -k needed).
+
+PYTEST -K FILTER for the new smoke tests (orchestrator dispatch — same
+substring Phase 3's handoff already recorded, still unique and still covers
+exactly the ADR-48 tests, now 6 instead of 4):
+
+    python -m pytest tests/smoke/test_smoke_feeds.py -k validate_log -m smoke --override-ini="addopts="
+
+The two Phase-4-only tests, if narrower dispatch is wanted:
+
+    python -m pytest tests/smoke/test_smoke_feeds.py -k "entries_reject or healthy_abp_feed" -m smoke --override-ini="addopts="
+
+TEST COVERAGE — WHAT EACH NEW TEST PROVES
+
+Python (pytest):
+- tests/test_adr06_build_module.py::TestNormaliseVerdictBucket — 7 cases,
+  direct `_normalise_verdict()` bucket assertions: accept -> (domain, None);
+  no-dot / edge-hyphen / empty-label / bad-char -> 'shape'; over-label-cap /
+  over-total-cap -> 'wire_cap'. Branch coverage per CLAUDE.md (every reject
+  class from the pre-existing TestNormalise gets its bucket pinned here too).
+- tests/test_adr06_build_module.py::TestEntryRejectTally — an ABP feed with
+  EXACTLY 2 shape + 2 wire-cap rejectable lines among one healthy accepted
+  entry -> `result.rejects == {("RejFeed","RejGroup"): {"shape":2,
+  "wire_cap":2}}` (also asserts the accepted entry landed in data_db/zone_db,
+  not the tally); a plain-format feed with 1 shape reject -> proves the
+  NON-ABP path counts too, not just ABP.
+  NOTE ON A DELIBERATE DEVIATION: the phase prompt says "extend
+  test_adr06_build_module.py using its _run_build helpers" — `_run_build()`
+  there loads a FIXED golden-fixture manifest/config (tuned for the ADR-06
+  decision-oracle corpus), which gives no clean way to pin an EXACT N/M reject
+  count without either mutating that shared fixture (risking every other
+  golden-oracle test in the file) or auditing its full byte content by hand.
+  Instead this test builds its OWN small in-memory manifest + `lambda raw:
+  [...]` line_reader — the exact idiom `TestBuildBranches` in
+  test_branch_coverage_gaps.py already established for build()-level branch
+  tests. Still lands in test_adr06_build_module.py (the letter of the
+  instruction); only the "reuse _run_build" detail is deliberately not
+  followed, for the reason above.
+- tests/test_adr06_build_module.py::TestSkipClassesTallyZero — one ABP feed
+  built ENTIRELY from the deliberate-skip subset of
+  tests/test_adr07_parser.py::TestSkip's corpus (comment/control, cosmetic/
+  element-hiding, path/wildcard anchors, IP-valued anchors, plus a
+  `$badfilter` line on an unrelated domain) -> `result.rejects == {}`. The
+  corpus's OWN `test_skip_invalid_domain` cases are deliberately EXCLUDED —
+  those are genuine normalise() shape rejects, not skips, and reusing them
+  here would defeat the test's purpose. This is the direct §7
+  reject-criterion pin at the unit level.
+- tests/test_adr07_reconcile.py::TestRegexReduction
+  ::test_unqueryable_folded_key_is_dropped — extended (not a new test): the
+  existing fold-drop assertions are untouched; added a `tally: P.RejectTally
+  = {}` passed through `_reconcile(..., tally=tally)` (the shared helper
+  gained an optional `tally` param, default None, so every OTHER caller in
+  the file is unaffected) and `assert tally == {("", ""): {"shape": 0,
+  "wire_cap": 2}}` — both crafted regex lines fold to an over-cap key and
+  both tally, attributed to `("", "")` since `_production_rules()` doesn't
+  set feed/group in this file's helper (matches the existing corpus
+  convention there). Before Phase 4: no `tally` param existed at all, so this
+  drop counted NOWHERE (the exact gap #789 names).
+- tests/test_branch_coverage_gaps.py::TestEmitRejectStats — 5 cases:
+  nonzero-bucket rows -> JSON array with only the nonzero feed, exact counts;
+  empty tally -> literal `"[]"`; the atomic-write pattern leaves no stray
+  `.tmp` sibling on success; an unwritable path -> `False`, never raises; and
+  a SOURCE-grep pin (`pfb["pfb_py_reject_stats"] = "..."` in pfb_unbound.py)
+  that the assigned value has no leading `/` — the §3 chroot-relative risk.
+  init_standard() itself needs the live Unbound env and cannot run in this
+  suite (same reason every other init_standard()-touching assertion in this
+  repo is a source/behavioural proxy, never a real call), hence the grep.
+- tests/test_adr10_swap.py::TestEmitCountsToggle — 2 new cases (the existing
+  cases in this class/module are UNCHANGED): `emit_counts=True` + the pfb
+  dict carrying `pfb_py_reject_stats` -> `dnsbl_emit_reject_stats` is called
+  with the exact path + the fresh snapshot's rejects dict (monkeypatched spy);
+  contrast — the SAME toggle but the key ABSENT (asserted via `assert
+  "pfb_py_reject_stats" not in P.pfb` before acting, matching every other
+  pre-existing test in this module) -> the spy is NEVER called, no KeyError —
+  this is the direct proof the `.get()` guard exists and works, and it is why
+  every pre-existing rebuild_and_swap test in this repo (none of which seed
+  the new key) stayed green with zero edits.
+
+PHP (PHPUnit, sink-capture technique from P1/P2):
+- tests/php/PfbEmitEntryRejectStatsTest.php — 5 cases: both buckets nonzero
+  -> two distinct canonical lines in the sink; one bucket zero + one nonzero
+  -> only the nonzero bucket's line appears (proves the per-BUCKET gate, not
+  an all-or-nothing per-row decision); `[]` -> zero lines; absent file -> zero
+  lines, no error; corrupt JSON (`{not valid json`) -> zero lines, no error.
+  Red->green: `pfb_emit_entry_reject_stats` did not exist before this phase.
+
+Smoke (tests/smoke/test_smoke_feeds.py, same conventions as Phase 3 — delta-
+based, self-encapsulated, before-state asserted):
+- test_validate_log_entries_reject_line — a DnsblCase (updatednsbl reload,
+  NOT an IpCase) over an inline ABP body (`h.abp_feed(...)`, no committed
+  fixture needed — plain text, no FreeBSD-libmagic sensitivity) carrying one
+  healthy block + one no-dot host (`shape`) + one 64-char-label host
+  (`wire_cap`). Given: the healthy member resolves before listing + a
+  before-count for BOTH exact markers. When: Force Update. Then: the healthy
+  member is VIP-blocked (proves the feed genuinely loaded/parsed, not merely
+  "didn't crash") AND both
+  `pfb_validate: REJECT feed=adr48ent stage=entries reason=shape detected=1`
+  and `... reason=wire_cap detected=1` appear as NEW lines.
+- test_validate_log_healthy_abp_feed_no_entries_reject — the MUST-ACCOMPANY
+  counterpart: an ABP feed built from deliberate skip lines (comment,
+  cosmetic, path anchor, IP-valued anchor, `$badfilter` on an unrelated
+  domain) plus one healthy block. Given/When as above. Then: the healthy
+  member is VIP-blocked AND the `pfb_validate: REJECT ... stage=entries`
+  marker count for this feed's header is UNCHANGED (delta, not a bare global
+  zero) — the live-box mirror of TestSkipClassesTallyZero.
+  This is also the "extend/confirm the Phase-3 healthy-feed guard covers a
+  healthy ABP feed" requirement: the EXISTING
+  test_validate_log_healthy_feed_no_spurious_reject is an IpCase (plain-IP
+  feed) and was left untouched (it correctly proves the IP-side gates never
+  spam), so a NEW ABP-specific test was added rather than repurposing it —
+  repurposing would have either broken its existing IP-side intent or
+  silently stopped covering IP feeds.
+
+SELF-REVIEW (done before this handoff, walked against the phase prompt's
+checklist item by item)
+
+- normalise() public contract UNTOUCHED: it is a 2-line wrapper over
+  _normalise_verdict(); the entire pre-existing TestNormalise class (7 cases,
+  untouched) stays green with no edits — confirmed via the full 2122-pass run.
+- tally rides an EXPLICIT optional param everywhere (parse_abp(tally=None),
+  reconcile(tally=None)) — NO module global. tally=None reproduces the exact
+  pre-Phase-4 return value at every call site; the pre-existing TestPurity
+  class (test_adr07_parser.py) stays green untouched.
+- ONLY the two buckets exist: 'shape' and 'wire_cap' are the only keys ever
+  written by _tally_reject/_normalise_verdict/dnsbl_emit_reject_stats; grepped
+  the diff to confirm no third bucket name appears anywhere.
+- Every deliberate skip class tallies zero — ran
+  TestSkipClassesTallyZero::test_skip_only_feed_tallies_nothing standalone
+  and read its output (passed, `result.rejects == {}`), plus the live-box
+  mirror (test_validate_log_healthy_abp_feed_no_entries_reject).
+- Artifact atomic (temp+os.replace, mirrors _reload_write_applied) +
+  chroot-relative (pfb["pfb_py_reject_stats"] = "pfb_py_reject_stats.json",
+  no leading '/', pinned by a source-grep test since init_standard() can't
+  run off-appliance) + "[]"-on-empty (tested).
+- PHP emits ONE line per NONZERO bucket (not per row) and stays silent on
+  absent/corrupt/empty — all 5 branches pinned in
+  PfbEmitEntryRejectStatsTest.php, all red->green proven.
+- Smoke deltas have asserted before-states in both new tests (the healthy
+  member's pre-listing resolution AND the marker count(s) captured before
+  each case's own Force Update, inside its own CaseContext-adjacent block —
+  never a cross-test-order-dependent baseline).
+- Gate DECISIONS unchanged: no reject/accept boundary moved — every site
+  still returns exactly what it returned before (None on the same inputs,
+  the same Rule on the same inputs, the same fold-drop `continue`); only a
+  side-channel COUNT was added. ReconcileResult.pruned/reduced/
+  skipped_badfilter semantics are untouched (confirmed by diff — no line
+  inside Step 1's $badfilter-prune block was touched).
+- git diff --stat matches the EXPECTED RESULT exactly: pfb_unbound.py,
+  pfblockerng.inc, and tests only (see SCOPE above) — no fixture files added,
+  no unrelated reformatting, no debug/print/log lines left in.
+
+COMMIT
+  Single commit — "pfb_unbound: tally per-entry rejects, emit stage=entries
+  via PHP (ADR-48 P4)" (code + this handoff together; see `git log -1` on the
+  pushed branch tip for its exact hash — this handoff is part of that same
+  commit's tree, so embedding its own final hash here is self-referential,
+  same caveat Phase 2's handoff noted, restated because amending this file to
+  fix the hash would only shift it again). Parent is Phase 3's commit,
+  rebased onto the fresh origin/devel below — the rebase replayed Phases 1-3
+  too, so their hashes moved: Phase 1 499cd8c0 -> 6bc7a274, Phase 2
+  a2e140a5 -> 8c455771, Phase 3 cb38b521 -> 14233dfb (content unchanged, only
+  the parent commit differs — same pattern Phase 3's own handoff documented
+  for its own rebase).
+
+PUSH
+  Before this phase's commit, `git fetch origin` showed `origin/devel` had
+  advanced two commits past this branch's merge-base (803f951f, 94b1b5bf —
+  unrelated install-time-config-migration smoke coverage). After committing,
+  this branch was rebased onto the fresh origin/devel (clean linear replay,
+  no conflicts — the intervening commits touch unrelated files) and every
+  gate re-run green post-rebase (see GATE SUMMARY). Pushed to
+  adr/48-download-validation-logging.
+
+NOTE FOR THE ORCHESTRATOR — ADR ACCEPTANCE
+
+Phase 4 is the LAST phase (per ADR.md §6). Its own acceptance gate (ADR.md
+§7): `python -m pytest` green including the tally oracle (done, see GATE
+SUMMARY); the live-VM smoke asserting the `stage=entries` line for the
+rejectable fixture feed AND its absence for the healthy one, green on CE +
+Plus (NOT run in this phase — dispatch-only, per the ADR-04 pattern every
+prior phase followed). Suggested dispatch once this branch is pushed:
+
+    gh workflow run smoke.yml -f scope=full -f pytest_filter="validate_log"
+
+(covers both the Phase-3 stage=mime/inner/structural lines and this phase's
+stage=entries lines in one fan-out). Phases 1-3's own acceptance criterion
+(ADR.md §7's first bullet: "a forced MIME / inner rejection emits the
+canonical line... no healthy feed logs a spurious REJECT") was already noted
+by Phase 3 as satisfiable independently of Phase 4 — once BOTH fan-outs are
+green (CE + Plus), the whole ADR (all 4 phases) can flip to Accepted per the
+CLAUDE.md "ADR acceptance — automated tests, not a manual sign-off" rule; a
+PR has not yet been opened (this is Phase 4 of 4 on the same
+worktree/branch, direct push per the established multi-phase convention) —
+opening the PR and running /pr-merge-flow is the orchestrator's next step
+once smoke is green.

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -467,6 +467,7 @@ def _build_swap_snapshot() -> Snapshot | None:
         important_rules=bool(build_result.important_rules),
         counts=len(data_db) + len(zone_db),
         regex_count=len(regex_db) + len(allow_regex_db),
+        rejects=build_result.rejects,
     )
 
 
@@ -1058,6 +1059,11 @@ def init_standard(id: int, env: module_env) -> bool:
     # allowRegexDB AFTER both the user REGEX-ini load and the feed-regex merge, so
     # patterns the static cap dropped are excluded (value changes by design, ADR §2).
     pfb["pfb_py_regex_count"] = "pfb_py_regex_count"
+    # ADR-48 Phase 4 (#789): the per-entry reject tally artifact (BuildResult.rejects,
+    # a JSON array of nonzero-total {feed, group, shape, wire_cap} rows) -- PHP reads
+    # it after a DNSBL run and emits the canonical stage=entries line. Chroot-relative
+    # bare name, exactly like pfb_py_count above (the manifest-boundary discipline).
+    pfb["pfb_py_reject_stats"] = "pfb_py_reject_stats.json"
     pfb["pfb_py_dnsbl"] = "pfb_py_dnsbl.sqlite"
     pfb["pfb_py_cache"] = "pfb_py_cache.sqlite"
     pfb["pfb_py_resolver"] = "pfb_py_resolver.sqlite"
@@ -1401,6 +1407,10 @@ def init_standard(id: int, env: module_env) -> bool:
 
                 # Emit pfb_py_count (the LOADED total) for the UI (inc:3149).
                 dnsbl_emit_count(pfb["pfb_py_count"], build_result.counts)
+                # ADR-48 Phase 4 (#789): emit the per-entry reject tally artifact
+                # alongside the count -- PHP reads it after this run and emits
+                # stage=entries for any feed with a nonzero bucket.
+                dnsbl_emit_reject_stats(pfb["pfb_py_reject_stats"], build_result.rejects)
                 dnsbl_built = True
 
             # While reading 'data|zone' CSV files: Replace 'Feed/Group' pairs with an index value (Memory performance)
@@ -3463,6 +3473,10 @@ class BuildResult:
     regex). ``counts`` is the LOADED total (len(data_db) + len(zone_db)); init emits
     it as pfb_py_count (its value legitimately rises -- lists are un-pruned).
     ``regex_count`` is the ADMITTED feed-regex total for the DNSBL_Regex alias (UI).
+    ``rejects`` is the ADR-48 Phase 4 (#789) per-entry reject tally -- (feed, group)
+    -> {'shape': n, 'wire_cap': m} -- for every domain target a normalise-fail (or
+    the reconcile() wire-cap fold-drop) rejected; a diagnostic count, not consumed
+    by any decision.
     """
 
     data_db: dict[str, dict[str, Any]]
@@ -3474,6 +3488,7 @@ class BuildResult:
     allow_regex_db: dict[str, dict[str, Any]] = field(default_factory=dict)
     important_rules: bool = False
     regex_count: int = 0
+    rejects: RejectTally = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -3511,6 +3526,11 @@ class Snapshot:
     oracles): ``data_db``->dataDB, ``zone_db``->zoneDB, ``white_db``->whiteDB,
     ``regex_db``->regexDB, ``allow_regex_db``->allowRegexDB,
     ``feed_group_index_db``->feedGroupIndexDB, ``hsts_db``->hstsDB.
+
+    ``rejects`` (ADR-48 Phase 4, #789) rides alongside ``counts``/``regex_count`` as
+    a build-diagnostic passthrough -- NOT a per-query stratum (absent from
+    ``containers()``) -- so a no-restart swap can re-emit the reject-stats artifact
+    from the fresh ``BuildResult`` exactly as it re-emits the UI counts.
     """
 
     data_db: dict[str, Any]
@@ -3523,6 +3543,7 @@ class Snapshot:
     important_rules: bool = False
     counts: int = 0
     regex_count: int = 0
+    rejects: RejectTally = field(default_factory=dict)
 
     def containers(self) -> dict[str, Any]:
         """The per-query ``containers`` dict ``evaluate_domain`` reads (legacy keys).
@@ -3687,6 +3708,7 @@ def parse_abp(
     feed: str = "",
     group: str = "",
     log: str = "",
+    tally: RejectTally | None = None,
 ) -> Rule | None:
     """The full DNS-only ABP Stage-A parser: one raw ABP line -> a typed ``Rule``
     (or ``None`` to skip). PURE -- no Unbound symbol, no side effect; NOT wired into
@@ -3710,6 +3732,11 @@ def parse_abp(
     ``feed`` / ``group`` / ``log`` / ``provenance`` are plumbed through unchanged
     (the caller supplies them from the manifest row). Domain targets pass through
     ``normalise()`` (lower-case + shape gate); an invalid domain -> ``None``.
+
+    ``tally`` (ADR-48 Phase 4, issue #789): optional out-param -- when not ``None``,
+    a normalise-fail reject on a domain target (anchor/hosts/bare) is counted into
+    it (bucket 'shape' | 'wire_cap', keyed (feed, group)). Left ``None`` (the
+    default), this function is BYTE-IDENTICAL to before -- purity is test-pinned.
     """
     s = line.strip()
     if not s:
@@ -3762,8 +3789,10 @@ def parse_abp(
             return None
         if _dnsbl_is_ipv4(host):
             return None  # IP-anchored -> PHP firewall path; Python skips (no leak)
-        dom = normalise(host)
+        dom, bucket = _normalise_verdict(host)
         if dom is None:
+            if tally is not None and bucket is not None:
+                _tally_reject(tally, feed, group, bucket)
             return None
         if opts_str:
             classified = _dnsbl_classify_options(opts_str)
@@ -3797,8 +3826,10 @@ def parse_abp(
             return None  # not a hosts line (a real ABP line never has a bare space)
         if _dnsbl_is_ipv4(target):
             return None  # "<ip> <ip>" -> firewall path
-        dom = normalise(target)
+        dom, bucket = _normalise_verdict(target)
         if dom is None:
+            if tally is not None and bucket is not None:
+                _tally_reject(tally, feed, group, bucket)
             return None
         return Rule(
             kind=DNSBL_KIND_BLOCK,
@@ -3817,8 +3848,10 @@ def parse_abp(
     # ---- bare plain domain ---------------------------------------------- #
     if "/" in s or "*" in s:
         return None
-    dom = normalise(s)
+    dom, bucket = _normalise_verdict(s)
     if dom is None:
+        if tally is not None and bucket is not None:
+            _tally_reject(tally, feed, group, bucket)
         return None
     return Rule(
         kind=DNSBL_KIND_BLOCK,
@@ -3908,12 +3941,48 @@ def parse(format_hint: str, line: str) -> ParsedEntry | None:
     return ParsedEntry(kind=DNSBL_KIND_BLOCK, value=token, feed="", group="", log="")
 
 
+# ADR-48 Phase 4 (issue #789): the per-entry reject tally build()/parse_abp()/
+# reconcile() accumulate into, keyed (feed, group) -> {'shape': n, 'wire_cap': m}.
+# A plain dict (no class): the shape never grows past the two RESOLVED buckets
+# (ADR §2 item 4), so a helper that does the defaulting is all this needs.
+RejectTally = dict[tuple[str, str], dict[str, int]]
+
+
+def _tally_reject(tally: RejectTally, feed: str, group: str, bucket: str) -> None:
+    """Increment ``bucket`` ('shape' | 'wire_cap') for (feed, group) in ``tally``,
+    defaulting a fresh {'shape': 0, 'wire_cap': 0} row on first hit."""
+    counts = tally.setdefault((feed, group), {"shape": 0, "wire_cap": 0})
+    counts[bucket] += 1
+
+
 def _dnsbl_within_wire_caps(host: str) -> bool:
     """True iff ``host`` can be encoded in a DNS query (#753): <= 253 chars total
     (the RFC 1035 presentation cap, undotted) and every label <= 63. The domain
     charset is ASCII-only, so chars == octets. Shared by ``normalise()`` and the
     ``reconcile()`` regex fold so the caps live in one place."""
     return len(host) <= 253 and all(len(label) <= 63 for label in host.split("."))
+
+
+def _normalise_verdict(value: str) -> tuple[str | None, str | None]:
+    """The classified body of ``normalise()``: returns ``(domain, None)`` on
+    accept, or ``(None, bucket)`` on reject where ``bucket`` is ``'shape'`` (no
+    dot / edge hyphen / empty label / bad char -- a domain-SHAPE defect) or
+    ``'wire_cap'`` (the #753 length caps -- a well-shaped but unqueryable name).
+    Split out of ``normalise()`` so callers that need the #789 reject tally
+    (``build()`` / ``parse_abp()`` / ``reconcile()``) can bucket it; ``normalise()``
+    itself stays a pure ``str | None`` wrapper (public contract unchanged).
+    """
+    host = value.strip().strip(".").lower()
+    if "." not in host:
+        return None, "shape"
+    if not _dnsbl_within_wire_caps(host):
+        return None, "wire_cap"
+    for label in host.split("."):
+        if not label or label[0] == "-" or label[-1] == "-":
+            return None, "shape"
+        if any(c not in _DNSBL_LABEL_CHARS for c in label):
+            return None, "shape"
+    return host, None
 
 
 def normalise(value: str) -> str | None:
@@ -3933,16 +4002,12 @@ def normalise(value: str) -> str | None:
     encoded in a DNS query could never match a lookup -- rejecting it keeps
     unreachable dead weight out of the block dicts. The ``reconcile()`` regex
     fold applies the same caps to a domain-literal regex key.
+
+    Thin wrapper over ``_normalise_verdict()`` -- see there for the reject-bucket
+    classification (ADR-48 Phase 4, issue #789).
     """
-    host = value.strip().strip(".").lower()
-    if "." not in host or not _dnsbl_within_wire_caps(host):
-        return None
-    for label in host.split("."):
-        if not label or label[0] == "-" or label[-1] == "-":
-            return None
-        if any(c not in _DNSBL_LABEL_CHARS for c in label):
-            return None
-    return host
+    domain, _ = _normalise_verdict(value)
+    return domain
 
 
 def _dnsbl_load_tld_master(
@@ -4150,6 +4215,7 @@ def reconcile(
     rules: Iterable[Rule],
     tlds: dict[str, dict[str, str]],
     exclusion: set[str],
+    tally: RejectTally | None = None,
 ) -> ReconcileResult:
     """Stage-B: reconcile the typed ``Rule`` stream into the pre-emit rule sets.
 
@@ -4173,6 +4239,12 @@ def reconcile(
     kept for signature stability but no longer consulted: classify's registrable-
     parent rule is a plain/hosts-path concept (ADR-06) that must not demote an ABP
     anchor. Matches the Phase-2 oracle ``reconcile`` + ``decide`` precedence.
+
+    ``tally`` (ADR-48 Phase 4, issue #789): optional out-param -- when not ``None``,
+    the #753 wire-cap fold-drop (a reducible regex whose folded key is unqueryable)
+    is counted into it as 'wire_cap', attributed to the ORIGINATING rule's own
+    feed/group (each survivor is reconciled one rule at a time, before any
+    same-key merge, so there is no multi-feed key to disambiguate).
     """
     rule_list = list(rules)
 
@@ -4226,6 +4298,8 @@ def reconcile(
             # outright (keeping it as a compiled regex would pay per-query cost
             # for a pattern that can never match).
             if not _dnsbl_within_wire_caps(domain):
+                if tally is not None:
+                    _tally_reject(tally, r.feed, r.group, "wire_cap")
                 continue
             result.reduced += 1
         elif r.target == RULE_TARGET_DOMAIN:
@@ -4658,6 +4732,11 @@ def build(
     are simply overwritten last-wins by dict assignment (the documented attribution
     change, ADR.md SS2), and redundant subdomains stay because their parent zone still
     matches them.
+
+    ADR-48 Phase 4 (#789): every domain target a normalise-fail rejects (permit path,
+    plain path, both parse_abp() call sites) and the reconcile() wire-cap fold-drop
+    are tallied into ``BuildResult.rejects`` (bucket 'shape' | 'wire_cap', keyed
+    (feed, group)) -- accounting only, no gate DECISION changes.
     """
     suffix_lines = list(config.get("tld_master", []))
     tld_blacklist = list(config.get("tld_blacklist", []))
@@ -4675,6 +4754,8 @@ def build(
     feed_group_index_db: dict[int, dict[str, str]] = {}
     feed_group_db: dict[str, int] = {}
     next_index = 0
+    # ADR-48 Phase 4 (#789): the per-entry reject tally this build accumulates.
+    rejects: RejectTally = {}
 
     def index_for(feed: str, group: str) -> int:
         nonlocal next_index
@@ -4763,8 +4844,10 @@ def build(
                 entry = parse(fmt, stripped)
                 if entry is None:
                     continue
-                domain = normalise(entry.value)
+                domain, bucket = _normalise_verdict(entry.value)
                 if domain is None:
+                    if bucket is not None:
+                        _tally_reject(rejects, feed, group, bucket)
                     continue
                 # Insert as band-2 wildcard allow (@@||host^ shape) into whiteDB.
                 # Monotonic-widen on collision: never downgrade an existing higher band
@@ -4797,7 +4880,7 @@ def build(
         block_band = PRIO_USER_BLOCK if provenance == RULE_PROV_USER else PRIO_FEED_BLOCK
         if fmt == "abp":
             for raw_line in line_reader(feed_row["raw"]):
-                rule = parse_abp(raw_line, provenance=provenance, feed=feed, group=group, log=log_flag)
+                rule = parse_abp(raw_line, provenance=provenance, feed=feed, group=group, log=log_flag, tally=rejects)
                 if rule is not None:
                     abp_rules.append(rule)
             continue
@@ -4811,15 +4894,17 @@ def build(
             # for path/wildcard/IP anchors and non-DNS $options -> silently skipped.
             stripped = raw_line.strip()
             if stripped.startswith("||") or stripped.startswith("@@||"):
-                rule = parse_abp(stripped, provenance=provenance, feed=feed, group=group, log=log_flag)
+                rule = parse_abp(stripped, provenance=provenance, feed=feed, group=group, log=log_flag, tally=rejects)
                 if rule is not None:
                     abp_rules.append(rule)
                 continue
             entry = parse(fmt, raw_line)
             if entry is None:
                 continue
-            domain = normalise(entry.value)
+            domain, bucket = _normalise_verdict(entry.value)
             if domain is None:
+                if bucket is not None:
+                    _tally_reject(rejects, feed, group, bucket)
                 continue
             # Only BLOCK is produced by the lite path (ABP-ready seam; module header).
             if entry.kind != DNSBL_KIND_BLOCK:
@@ -4840,7 +4925,7 @@ def build(
     important_rules = permit_allow_inserted
     regex_count = 0
     if abp_rules:
-        result = reconcile(abp_rules, tlds, exclusion)
+        result = reconcile(abp_rules, tlds, exclusion, tally=rejects)
         important_rules = important_rules or result.important_rules
 
         # Domain blocks -> dataDB/zoneDB (carry band + $important).
@@ -4894,6 +4979,7 @@ def build(
         allow_regex_db=allow_regex_db,
         important_rules=important_rules,
         regex_count=regex_count,
+        rejects=rejects,
     )
 
 
@@ -5047,6 +5133,39 @@ def dnsbl_emit_count(count_path: str, count: int) -> bool:
         return False
 
 
+def dnsbl_emit_reject_stats(stats_path: str, rejects: RejectTally) -> bool:
+    """Write the ADR-48 Phase 4 (#789) per-entry reject tally to ``pfb_py_reject_stats``
+    as a JSON array of ``{"feed", "group", "shape", "wire_cap"}`` rows, one per
+    (feed, group) with a NONZERO bucket -- PHP reads it after a DNSBL run and emits
+    the canonical ``stage=entries`` line per nonzero bucket (Python never logs the
+    line itself; sinks stay PHP-only). An empty ``rejects`` still writes ``"[]"`` so
+    PHP can tell "ran, zero rejects" from "no artifact" (fresh boot / an old python
+    module that predates this file). Atomic temp + ``os.replace`` (mirrors
+    ``_reload_write_applied``): a partial write can never leave PHP reading a
+    truncated/corrupt artifact. Returns True on success.
+    """
+    entries = [
+        {"feed": feed, "group": group, "shape": counts["shape"], "wire_cap": counts["wire_cap"]}
+        for (feed, group), counts in sorted(rejects.items())
+        if counts["shape"] or counts["wire_cap"]
+    ]
+    tmp = "{}.tmp".format(stats_path)
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(entries, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, stats_path)
+        return True
+    except OSError as e:
+        sys.stderr.write("[pfBlockerNG]: Failed to write DNSBL reject stats '{}': {}".format(stats_path, e))
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return False
+
+
 def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_counts: bool = True) -> bool:
     """ADR-10 P3: the single fail-closed build -> atomic-swap + cache-reset step.
 
@@ -5124,6 +5243,13 @@ def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_coun
     if emit_counts:
         dnsbl_emit_count(pfb["pfb_py_count"], new_snapshot.counts)
         dnsbl_emit_count(pfb["pfb_py_regex_count"], new_snapshot.regex_count)
+        # ADR-48 Phase 4 (#789): re-emit the reject-stats artifact from the new
+        # snapshot on a no-restart swap too, exactly like the UI counts above.
+        # ``.get()`` (not a bare index): unit tests build a bare ``pfb`` dict
+        # without this key and must not KeyError on an unrelated code path.
+        reject_stats_path = pfb.get("pfb_py_reject_stats")
+        if reject_stats_path:
+            dnsbl_emit_reject_stats(reject_stats_path, new_snapshot.rejects)
     return True
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -128,6 +128,7 @@ $pfb['unbound_py_ss']	= '/var/unbound/pfb_py_ss.txt';
 $pfb['unbound_py_hsts']	= '/var/unbound/pfb_py_hsts.txt';	// SHIPPED file re-staged by dnsbl_cache_stage() cp -f; fingerprinted so a package update ships a new list and triggers a zero-downtime reload
 $pfb['unbound_py_count']= '/var/unbound/pfb_py_count';
 $pfb['unbound_py_regex_count']= '/var/unbound/pfb_py_regex_count';	// ADR-07 P8: Python-emitted ADMITTED (cap-filtered) feed+user regex total for the DNSBL_Regex alias
+$pfb['unbound_py_reject_stats']= '/var/unbound/pfb_py_reject_stats.json';	// ADR-48 P4: Python-emitted per-entry reject tally (issue #789), read by pfb_emit_entry_reject_stats()
 $pfb['unbound_py_sources']= '/var/unbound/pfb_py_sources.json';	// ADR-06: per-feed manifest consumed by pfb_unbound.py init
 $pfb['unbound_py_rawdir']= '/var/unbound/pfb_py_raw';		// ADR-06: per-feed IP-stripped raw feeds referenced by the manifest
 
@@ -883,6 +884,37 @@ function pfb_validate_log_line(string $feed, string $stage, string $reason, stri
 // (default 2 = pfB log + error log). One call site per rejection.
 function pfb_validate_log(string $feed, string $stage, string $reason, string $detail = '', int $level = 2): void {
 	pfb_logger(pfb_validate_log_line($feed, $stage, $reason, $detail), $level);
+}
+
+// ADR-48 Phase 4 (issue #789): reads the Python-emitted per-entry reject tally
+// artifact (pfb_py_reject_stats.json -- build()'s normalise() domain-shape rejects
+// and #753 wire-cap rejects, bucketed shape/wire_cap, per feed/group) and emits
+// ONE canonical stage=entries line per (feed, nonzero bucket) via pfb_validate_log().
+// Missing, unreadable, corrupt, or non-array JSON is a silent no-op -- a fresh boot
+// or an old python module that predates the artifact, never an error. Python only
+// WRITES the artifact; this is the sole place the line is EMITTED (sinks stay
+// PHP-only, ADR §2 item 2).
+function pfb_emit_entry_reject_stats(string $path): void {
+	$raw = @file_get_contents($path);
+	if ($raw === FALSE || $raw === '') {
+		return;
+	}
+	$stats = json_decode($raw, TRUE);
+	if (!is_array($stats)) {
+		return;
+	}
+	foreach ($stats as $entry) {
+		if (!is_array($entry) || !isset($entry['feed'])) {
+			continue;
+		}
+		$feed = (string) $entry['feed'];
+		foreach (array('shape', 'wire_cap') as $bucket) {
+			$count = isset($entry[$bucket]) ? (int) $entry[$bucket] : 0;
+			if ($count > 0) {
+				pfb_validate_log($feed, 'entries', $bucket, (string) $count);
+			}
+		}
+	}
 }
 
 // Function to filter/sanitize user input
@@ -7910,6 +7942,10 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 	$loaded_cnt = trim((string) @file_get_contents($pfb['unbound_py_count']));
 	$log = "\nDNSBL update [ feed lines: {$dnsbl_cnt} | loaded entries: {$loaded_cnt} ]... completed [ NOW ]";
 	pfb_logger("{$log}", 1);
+
+	// ADR-48 Phase 4 (issue #789): emit stage=entries reject lines for any feed
+	// with a nonzero per-entry tally, BEFORE clearing work files.
+	pfb_emit_entry_reject_stats($pfb['unbound_py_reject_stats']);
 
 	// Clear work files
 	pfb_unbound_clear_work_files();

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -904,12 +904,12 @@ function pfb_emit_entry_reject_stats(string $path): void {
 		return;
 	}
 	foreach ($stats as $entry) {
-		if (!is_array($entry) || !isset($entry['feed'])) {
+		if (!is_array($entry) || !isset($entry['feed']) || !is_scalar($entry['feed'])) {
 			continue;
 		}
 		$feed = (string) $entry['feed'];
 		foreach (array('shape', 'wire_cap') as $bucket) {
-			$count = isset($entry[$bucket]) ? (int) $entry[$bucket] : 0;
+			$count = (isset($entry[$bucket]) && is_scalar($entry[$bucket])) ? (int) $entry[$bucket] : 0;
 			if ($count > 0) {
 				pfb_validate_log($feed, 'entries', $bucket, (string) $count);
 			}
@@ -1294,7 +1294,14 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			unset($retval);
 			unset($output);
 			if (!file_exists($input[1])) {
-				pfb_logger("{$header} Downloaded file not found: [" .  htmlspecialchars($input[0]) . "|" . htmlspecialchars($input[1]) . "]", 2);
+				// ADR-48 P2: honour the out-param contract on EVERY reject path — an
+				// opted-in caller emits the canonical line itself, so fill the detail
+				// and suppress the legacy message (mirrors the mime-reject branch).
+				if (is_array($reject_detail)) {
+					$reject_detail = array('mime_raw' => 'file-not-found', 'mime' => '', 'retval' => -1);
+				} else {
+					pfb_logger("{$header} Downloaded file not found: [" .  htmlspecialchars($input[0]) . "|" . htmlspecialchars($input[1]) . "]", 2);
+				}
 				return FALSE;
 			}
 			exec("/usr/bin/file -b --mime-type " . escapeshellarg($input[1]) . " 2>&1", $output, $retval);
@@ -1356,7 +1363,12 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			unset($retval);
 			unset($output);
 			if (!file_exists($input[1])) {
-				pfb_logger("{$header} Downloaded file not found: [" .  htmlspecialchars($input[0]) . "|" . htmlspecialchars($input[1]) . "]", 2);
+				// ADR-48 P2: same out-param contract as the FILE_MIME branch above.
+				if (is_array($reject_detail)) {
+					$reject_detail = array('mime_raw' => 'file-not-found', 'mime' => '', 'retval' => -1);
+				} else {
+					pfb_logger("{$header} Downloaded file not found: [" .  htmlspecialchars($input[0]) . "|" . htmlspecialchars($input[1]) . "]", 2);
+				}
 				return FALSE;
 			}
 			exec("/usr/bin/file -bZ --mime-type " . escapeshellarg($input[1]) . " 2>&1", $output, $retval);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -886,6 +886,13 @@ function pfb_validate_log(string $feed, string $stage, string $reason, string $d
 	pfb_logger(pfb_validate_log_line($feed, $stage, $reason, $detail), $level);
 }
 
+// ADR-48 P2: the one formatter for the detected= summary built from pfb_filter()'s
+// $reject_detail out-param -- every wired pfb_download() call site uses it, so the
+// shape has a single place to change.
+function pfb_reject_detail_summary(array $reject_detail): string {
+	return "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}";
+}
+
 // ADR-48 Phase 4 (issue #789): reads the Python-emitted per-entry reject tally
 // artifact (pfb_py_reject_stats.json -- build()'s normalise() domain-shape rejects
 // and #753 wire-cap rejects, bucketed shape/wire_cap, per feed/group) and emits
@@ -955,6 +962,13 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 		foreach ($input as $vline) {
 			if (preg_match("/[\p{C}]+/u", $vline) !== 0) {
 				pfb_logger("{$header} Control characters found [ " . htmlspecialchars($vline) . " ]", 6);
+				// ADR-48 P2: this early return precedes the switch, so it also rejects
+				// the FILE_MIME types -- fill the out-param for an opted-in caller
+				// (keep the level-6 diagnostic; it is errlog-only, not the legacy
+				// reject message the contract suppresses).
+				if (is_array($reject_detail)) {
+					$reject_detail = array('mime_raw' => 'control-characters', 'mime' => '', 'retval' => -1);
+				}
 				return $return_type;
 			}
 		}
@@ -962,6 +976,9 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 	else {
 		if (preg_match("/[\p{C}]+/u", $input) !== 0) {
 			pfb_logger("{$header} Control characters found [ " . htmlspecialchars($input) . " ]", 6);
+			if (is_array($reject_detail)) {
+				$reject_detail = array('mime_raw' => 'control-characters', 'mime' => '', 'retval' => -1);
+			}
 			return $return_type;
 		}
 	}
@@ -9288,7 +9305,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		$reject_detail = array();
 		$file_type = pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download', '', FALSE, $reject_detail);
 		if (!$file_type) {
-			pfb_validate_log($header, 'mime', 'mime_not_allowed', "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}");
+			pfb_validate_log($header, 'mime', 'mime_not_allowed', pfb_reject_detail_summary($reject_detail));
 			return FALSE;
 		}
 
@@ -9373,7 +9390,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			else {
 				$reject_detail = array();
 				if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail)) {
-					pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}");
+					pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
 					return FALSE;
 				}
 				pfb_logger('.', 1);
@@ -9388,7 +9405,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			}
 			$reject_detail = array();
 			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail)) {
-				pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}");
+				pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
 				return FALSE;
 			}
 			pfb_logger('.', 1);
@@ -9448,7 +9465,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			// pfb_mime_normalise()).
 			$reject_detail = array();
 			if (!pfb_filter(array("{$file_org_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download', '', FALSE, $reject_detail)) {
-				pfb_validate_log($header, 'inner', 'inner_mime_not_allowed', "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}");
+				pfb_validate_log($header, 'inner', 'inner_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
 				unlink_if_exists("{$file_org_esc}");
 				return FALSE;
 			}
@@ -9470,7 +9487,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			}
 			$reject_detail = array();
 			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail)) {
-				pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}");
+				pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
 				return FALSE;
 			}
 			pfb_logger('.', 1);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -852,6 +852,39 @@ function pfb_archive_missing_tool(string $canonical_type, ?callable $checker = N
 	return $checker($argv[0]) ? NULL : $argv[0];
 }
 
+// ADR-48 Phase 1: pure formatter for the canonical download-validation reject line —
+// a single greppable line naming which feed/stage/reason caused a rejection and the
+// raw detected detail (e.g. file(1) output, a tool's exit code, an offending member
+// name). $stage is one of mime|structural|inner|member|plaintext|entries; this
+// formatter does not validate the token, callers own the vocabulary.
+//
+// Canonical shape (leading "\n" per the pfb_logger() caller convention -- pfb_logger()
+// itself emits no newline):
+//   \npfb_validate: REJECT feed=<feed> stage=<stage> reason=<reason> detected=<detail>
+//
+// Escaping is applied to EACH of the four values independently, in this order:
+//   1. every control byte in [\x00-\x1F\x7F] is replaced with a single space -- these
+//      values may carry attacker-influenced file(1) output, and a raw "\n"/"\r" would
+//      forge or split the greppable line;
+//   2. htmlspecialchars() (matching the escaping the existing reject messages use).
+// Pure: string in, string out, no I/O, no globals.
+function pfb_validate_log_line(string $feed, string $stage, string $reason, string $detail = ''): string {
+	[$feed, $stage, $reason, $detail] = array_map(
+		static function (string $value): string {
+			return htmlspecialchars(preg_replace('/[\x00-\x1F\x7F]/', ' ', $value) ?? '');
+		},
+		[$feed, $stage, $reason, $detail]
+	);
+	return "\npfb_validate: REJECT feed={$feed} stage={$stage} reason={$reason} detected={$detail}";
+}
+
+// ADR-48 Phase 1: thin emit wrapper -- builds the canonical reject line via
+// pfb_validate_log_line() and emits it through pfb_logger() at the reject level
+// (default 2 = pfB log + error log). One call site per rejection.
+function pfb_validate_log(string $feed, string $stage, string $reason, string $detail = '', int $level = 2): void {
+	pfb_logger(pfb_validate_log_line($feed, $stage, $reason, $detail), $level);
+}
+
 // Function to filter/sanitize user input
 function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FALSE) {
 	global $pfb;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -886,7 +886,17 @@ function pfb_validate_log(string $feed, string $stage, string $reason, string $d
 }
 
 // Function to filter/sanitize user input
-function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FALSE) {
+//
+// ADR-48 Phase 2: $reject_detail is an optional by-ref out-param for the
+// PFB_FILTER_FILE_MIME / PFB_FILTER_FILE_MIME_COMPRESSED reject paths only. A
+// caller that pre-sets it to an array() opts in: on rejection this function
+// fills it with the raw detail (['mime_raw', 'mime', 'retval']) and SUPPRESSES
+// its own legacy message so the caller can emit the canonical
+// pfb_validate_log() line instead (it has the feed header + true stage in
+// scope, which pfb_filter() does not). A caller that leaves it NULL (the
+// default) gets the legacy in-filter message unchanged -- no rejection ever
+// loses its log entry.
+function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FALSE, &$reject_detail=NULL) {
 	global $pfb;
 
 	$header = "\n PFB_FILTER - {$type} | {$reference} [ NOW ]";
@@ -1288,7 +1298,17 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 						pfb_logger("MIME recovered: octet-stream positively identified as \"" . htmlspecialchars($recovered) . "\" via structural probe", 5);
 						$output[0] = $recovered;
 					} else {
-						pfb_logger("\n[PFB_FILTER - {$type}] Failed or invalid Mime Type: [" .  htmlspecialchars($output[0]) . "|" . htmlspecialchars($retval) . "]", 2);
+						// ADR-48 P2: opted-in caller (pre-set $reject_detail = array())
+						// gets the raw detail back instead of the legacy message.
+						if (is_array($reject_detail)) {
+							$reject_detail = array(
+								'mime_raw' => $mime_raw ?? $output[0],
+								'mime'     => $output[0],
+								'retval'   => $retval,
+							);
+						} else {
+							pfb_logger("\n[PFB_FILTER - {$type}] Failed or invalid Mime Type: [" .  htmlspecialchars($output[0]) . "|" . htmlspecialchars($retval) . "]", 2);
+						}
 						unlink_if_exists($input[1]);
 						return FALSE;
 					}
@@ -1309,7 +1329,16 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			}
 			exec("/usr/bin/file -bZ --mime-type " . escapeshellarg($input[1]) . " 2>&1", $output, $retval);
 			if ($retval != 0 || empty($output[0]) || !pfb_mime_in_allowlist($output[0], $pfb['mime_types'])) {
-				pfb_logger("{$header} Failed or invalid Mime Type Compressed: [" .  htmlspecialchars($output[0]) . "|" . htmlspecialchars($retval) . "]", 2);
+				// ADR-48 P2: same out-param contract as the FILE_MIME branch above.
+				if (is_array($reject_detail)) {
+					$reject_detail = array(
+						'mime_raw' => $output[0],
+						'mime'     => $output[0],
+						'retval'   => $retval,
+					);
+				} else {
+					pfb_logger("{$header} Failed or invalid Mime Type Compressed: [" .  htmlspecialchars($output[0]) . "|" . htmlspecialchars($retval) . "]", 2);
+				}
 				unlink_if_exists($input[1]);
 				return FALSE;
 			}
@@ -9208,8 +9237,10 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		unset($retval);
 
 		// Validate File Mime-type
-		$file_type = pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download');
+		$reject_detail = array();
+		$file_type = pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download', '', FALSE, $reject_detail);
 		if (!$file_type) {
+			pfb_validate_log($header, 'mime', 'mime_not_allowed', "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}");
 			return FALSE;
 		}
 
@@ -9236,7 +9267,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		// Decompress file if required
 		if ($file_type == 'application/x-gzip' || $file_type == 'application/gzip') {
 			if (!pfb_validate_archive($file_download, $file_type)) {
-				pfb_logger("\n[pfb_download] Corrupt or unreadable {$file_type} archive (structural probe failed): [" . htmlspecialchars($file_download) . "]", 2);
+				pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
 				unlink_if_exists($file_download);
 				return FALSE;
 			}
@@ -9292,7 +9323,9 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				}
 			}
 			else {
-				if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download')) {
+				$reject_detail = array();
+				if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail)) {
+					pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}");
 					return FALSE;
 				}
 				pfb_logger('.', 1);
@@ -9301,11 +9334,13 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		}
 		elseif ($file_type == 'application/x-bzip2') {
 			if (!pfb_validate_archive($file_download, $file_type)) {
-				pfb_logger("\n[pfb_download] Corrupt or unreadable {$file_type} archive (structural probe failed): [" . htmlspecialchars($file_download) . "]", 2);
+				pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
 				unlink_if_exists($file_download);
 				return FALSE;
 			}
-			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download')) {
+			$reject_detail = array();
+			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail)) {
+				pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}");
 				return FALSE;
 			}
 			pfb_logger('.', 1);
@@ -9313,7 +9348,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		}
 		elseif ($file_type == 'application/zip') {
 			if (!pfb_validate_archive($file_download, $file_type)) {
-				pfb_logger("\n[pfb_download] Corrupt or unreadable {$file_type} archive (structural probe failed): [" . htmlspecialchars($file_download) . "]", 2);
+				pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
 				unlink_if_exists($file_download);
 				return FALSE;
 			}
@@ -9363,7 +9398,9 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			// Post-extraction content validation: re-run the MIME gate on the extracted
 			// file (the outer-container variant handling is covered by ADR-44's
 			// pfb_mime_normalise()).
-			if (!pfb_filter(array("{$file_org_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download')) {
+			$reject_detail = array();
+			if (!pfb_filter(array("{$file_org_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download', '', FALSE, $reject_detail)) {
+				pfb_validate_log($header, 'inner', 'inner_mime_not_allowed', "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}");
 				unlink_if_exists("{$file_org_esc}");
 				return FALSE;
 			}
@@ -9379,11 +9416,13 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				return FALSE;
 			}
 			if (!pfb_validate_archive($file_download, $file_type)) {
-				pfb_logger("\n[pfb_download] Corrupt or unreadable {$file_type} archive (structural probe failed): [" . htmlspecialchars($file_download) . "]", 2);
+				pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
 				unlink_if_exists($file_download);
 				return FALSE;
 			}
-			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download')) {
+			$reject_detail = array();
+			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail)) {
+				pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}");
 				return FALSE;
 			}
 			pfb_logger('.', 1);

--- a/tests/php/PfbEmitEntryRejectStatsTest.php
+++ b/tests/php/PfbEmitEntryRejectStatsTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_emit_entry_reject_stats() -- reads the Python-emitted per-entry reject tally
+ * artifact (ADR-48 Phase 4, issue #789) and emits ONE canonical stage=entries
+ * line per (feed, nonzero bucket) via pfb_validate_log(). Python only WRITES the
+ * artifact; this is the sole place the line is EMITTED (sinks stay PHP-only).
+ * Uses the sink-capture technique from PfbValidateLogTest: $GLOBALS['pfb']
+ * 'log'/'errlog' point at temp files so the real on-disk write is asserted.
+ */
+#[CoversFunction('pfb_emit_entry_reject_stats')]
+final class PfbEmitEntryRejectStatsTest extends TestCase
+{
+	/** @var string[] temp files to remove in tearDown */
+	private array $tmpfiles = [];
+
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
+	protected function setUp(): void
+	{
+		foreach (['log', 'errlog', 'pnow', 'runlog', 'runlog_active'] as $k) {
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
+		}
+		// A stray 'runlog_active' from an earlier test must not mirror our writes
+		// into a third file this test never provisions.
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === false) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+		foreach ($this->tmpfiles as $f) {
+			if (is_file($f)) {
+				$this->assertTrue(unlink($f), "failed to remove temp file {$f}");
+			}
+		}
+		$this->tmpfiles = [];
+	}
+
+	private function tempFile(string $prefix): string
+	{
+		$path = tempnam(sys_get_temp_dir(), $prefix);
+		$this->assertNotFalse($path, "could not create temp file for {$prefix}");
+		$this->tmpfiles[] = $path;
+		return $path;
+	}
+
+	private function statsFile(string $contents): string
+	{
+		$path = $this->tempFile('pfb_py_reject_stats_');
+		file_put_contents($path, $contents);
+		return $path;
+	}
+
+	/** Seed BOTH sinks the sink-capture technique reads and return the pfB log path. */
+	private function seedLogSinks(): string
+	{
+		$log = $this->tempFile('pfb_emit_reject_log_');
+		$GLOBALS['pfb']['log'] = $log;
+		$GLOBALS['pfb']['errlog'] = $this->tempFile('pfb_emit_reject_errlog_');
+		return $log;
+	}
+
+	public function testNonzeroBucketsEmitOneCanonicalLineEach(): void
+	{
+		// Given: an artifact row with BOTH buckets nonzero.
+		$log = $this->seedLogSinks();
+		$stats = $this->statsFile(json_encode([
+			['feed' => 'FeedA', 'group' => 'GroupA', 'shape' => 3, 'wire_cap' => 5],
+		]));
+
+		// When: the artifact is read.
+		pfb_emit_entry_reject_stats($stats);
+
+		// Then: one canonical line per bucket, exact shape.
+		$logContents = (string) file_get_contents($log);
+		$expectedShape = pfb_validate_log_line('FeedA', 'entries', 'shape', '3');
+		$expectedWireCap = pfb_validate_log_line('FeedA', 'entries', 'wire_cap', '5');
+		$this->assertStringContainsString(
+			$expectedShape,
+			$logContents,
+			"expected <{$expectedShape}> in <{$logContents}>"
+		);
+		$this->assertStringContainsString(
+			$expectedWireCap,
+			$logContents,
+			"expected <{$expectedWireCap}> in <{$logContents}>"
+		);
+	}
+
+	public function testZeroCountBucketEmitsNoLineButNonzeroSiblingStillDoes(): void
+	{
+		// Given: one bucket is zero, the other nonzero -- proves the per-bucket
+		// gate, not an all-or-nothing row decision.
+		$log = $this->seedLogSinks();
+		$stats = $this->statsFile(json_encode([
+			['feed' => 'FeedB', 'group' => 'GroupB', 'shape' => 0, 'wire_cap' => 2],
+		]));
+
+		pfb_emit_entry_reject_stats($stats);
+
+		$logContents = (string) file_get_contents($log);
+		$shapeLine = pfb_validate_log_line('FeedB', 'entries', 'shape', '0');
+		$this->assertStringNotContainsString(
+			$shapeLine,
+			$logContents,
+			"a zero-count bucket must not log a line, got <{$logContents}>"
+		);
+		$wireCapLine = pfb_validate_log_line('FeedB', 'entries', 'wire_cap', '2');
+		$this->assertStringContainsString($wireCapLine, $logContents);
+	}
+
+	public function testEmptyArrayEmitsNoLines(): void
+	{
+		// Given: the artifact Python writes when a run had zero rejects ("[]").
+		$log = $this->seedLogSinks();
+		$stats = $this->statsFile('[]');
+
+		pfb_emit_entry_reject_stats($stats);
+
+		$this->assertSame('', file_get_contents($log), 'an empty tally artifact must emit nothing');
+	}
+
+	public function testAbsentFileEmitsNoLinesAndDoesNotError(): void
+	{
+		// Given: no artifact at all (fresh boot / an old python module).
+		$log = $this->seedLogSinks();
+
+		pfb_emit_entry_reject_stats(sys_get_temp_dir() . '/pfb_py_reject_stats_does_not_exist.json');
+
+		$this->assertSame('', file_get_contents($log), 'a missing artifact must emit nothing, never error');
+	}
+
+	public function testCorruptJsonEmitsNoLinesAndDoesNotError(): void
+	{
+		// Given: a truncated/corrupt artifact (e.g. a write raced a read).
+		$log = $this->seedLogSinks();
+		$stats = $this->statsFile('{not valid json');
+
+		pfb_emit_entry_reject_stats($stats);
+
+		$this->assertSame('', file_get_contents($log), 'corrupt JSON must emit nothing, never throw');
+	}
+}

--- a/tests/php/PfbEmitEntryRejectStatsTest.php
+++ b/tests/php/PfbEmitEntryRejectStatsTest.php
@@ -153,4 +153,31 @@ final class PfbEmitEntryRejectStatsTest extends TestCase
 
 		$this->assertSame('', file_get_contents($log), 'corrupt JSON must emit nothing, never throw');
 	}
+
+	public function testNonScalarFieldsAreSkippedSilently(): void
+	{
+		// Given: syntactically valid JSON whose values have hostile SHAPES -- an
+		// array where a scalar belongs. (string)/(int) casts on an array raise
+		// PHP warnings and stringify to "Array", so such entries must be skipped
+		// outright, and a non-scalar COUNT must read as 0, not emit
+		// (adversarial-review fix, PR #807). The doc contract is "corrupt
+		// artifact = silent no-op" -- warnings are not silent.
+		$log = $this->seedLogSinks();
+		$stats = $this->statsFile(json_encode([
+			['feed' => [1, 2], 'shape' => 5],                    // array feed -> whole entry skipped
+			['feed' => 'FeedOk', 'shape' => ['nested' => 1]],    // array count -> bucket reads 0
+			['feed' => 'FeedReal', 'wire_cap' => 3],             // sane sibling still emits
+		]));
+
+		pfb_emit_entry_reject_stats($stats);
+
+		$logContents = (string) file_get_contents($log);
+		$this->assertStringNotContainsString('feed=Array', $logContents, 'an array feed must never stringify into a line');
+		$this->assertStringNotContainsString('FeedOk', $logContents, 'a non-scalar count must read as 0 (no line)');
+		$this->assertStringContainsString(
+			pfb_validate_log_line('FeedReal', 'entries', 'wire_cap', '3'),
+			$logContents,
+			'a sane sibling entry must still emit despite hostile neighbours'
+		);
+	}
 }

--- a/tests/php/PfbFilterRejectDetailTest.php
+++ b/tests/php/PfbFilterRejectDetailTest.php
@@ -135,6 +135,51 @@ final class PfbFilterRejectDetailTest extends TestCase
 		unlink($log);
 	}
 
+	/**
+	 * Scenario: the file-not-found reject path honours the SAME out-param contract
+	 * (adversarial-review fix, PR #807). Every reject path inside the FILE_MIME /
+	 * FILE_MIME_COMPRESSED cases must either fill the out-param (opted in) or write
+	 * the legacy message (not opted in) -- an opted-in caller that got FALSE with an
+	 * UNFILLED array would double-log and emit undefined-index warnings at the
+	 * pfb_download() call sites.
+	 *
+	 * Given  a path that does not exist
+	 * When   FILE_MIME (and _COMPRESSED) validate it, opted in and not
+	 * Then   opted-in: detail filled ('file-not-found', retval -1), NO legacy line;
+	 *        non-opted: the legacy "Downloaded file not found" line, unchanged.
+	 */
+	public function testFileNotFoundRejectHonoursOutParamContract(): void
+	{
+		$missing = $this->dir . '/never-created.bin';
+
+		foreach ([PFB_FILTER_FILE_MIME, PFB_FILTER_FILE_MIME_COMPRESSED] as $type) {
+			// Opted in: detail filled, legacy suppressed.
+			$log = $this->tempLog();
+			$GLOBALS['pfb']['log'] = $log;
+			$detail = array();
+			$result = pfb_filter(["'unused'", $missing, 'http://feed.example/'], $type, 'test', '', FALSE, $detail);
+			$this->assertFalse($result);
+			$this->assertSame('file-not-found', $detail['mime_raw'] ?? null, "type {$type}: mime_raw must mark the missing file");
+			$this->assertSame(-1, $detail['retval'] ?? null, "type {$type}: retval must be the no-exec sentinel -1");
+			$logged = (string) file_get_contents($log);
+			$this->assertSame('', $logged, "type {$type}: expected NO legacy message once opted in, got <{$logged}>");
+			unlink($log);
+
+			// Not opted in: byte-identical legacy behaviour.
+			$log = $this->tempLog();
+			$GLOBALS['pfb']['log'] = $log;
+			$result = pfb_filter(["'unused'", $missing, 'http://feed.example/'], $type, 'test');
+			$this->assertFalse($result);
+			$logged = (string) file_get_contents($log);
+			$this->assertStringContainsString(
+				'Downloaded file not found:',
+				$logged,
+				"type {$type}: expected legacy file-not-found message in <{$logged}>"
+			);
+			unlink($log);
+		}
+	}
+
 	// --- PFB_FILTER_FILE_MIME_COMPRESSED ------------------------------------
 
 	private function skipIfHostLacksDashZSemantics(): void

--- a/tests/php/PfbFilterRejectDetailTest.php
+++ b/tests/php/PfbFilterRejectDetailTest.php
@@ -180,6 +180,41 @@ final class PfbFilterRejectDetailTest extends TestCase
 		}
 	}
 
+	/**
+	 * Scenario: the PRE-SWITCH control-character early return honours the out-param
+	 * contract too (CodeRabbit finding, PR #807). That gate runs before the switch
+	 * and rejects the FILE_MIME types with $return_type = FALSE -- an opted-in
+	 * caller must get a filled detail there as well, or its canonical-line
+	 * interpolation emits undefined-index warnings.
+	 *
+	 * Given  an input whose URL element carries a control character
+	 * When   FILE_MIME validates it with the out-param bound
+	 * Then   pfb_filter() rejects and the detail marks 'control-characters'
+	 *        (retval -1, the no-exec sentinel).
+	 */
+	public function testControlCharacterRejectFillsDetailForOptedInCaller(): void
+	{
+		// The control-char gate logs at level 6 (errlog only) -- provision that
+		// sink so the diagnostic write has somewhere real to land.
+		$errlog = $this->tempLog();
+		$GLOBALS['pfb']['errlog'] = $errlog;
+
+		$detail = array();
+		$result = pfb_filter(
+			["'unused'", $this->pdfPath, "http://feed.example/\x01"],
+			PFB_FILTER_FILE_MIME,
+			'test',
+			'',
+			FALSE,
+			$detail
+		);
+
+		$this->assertFalse($result);
+		$this->assertSame('control-characters', $detail['mime_raw'] ?? null, 'mime_raw must mark the control-char reject');
+		$this->assertSame(-1, $detail['retval'] ?? null, 'retval must be the no-exec sentinel -1');
+		unlink($errlog);
+	}
+
 	// --- PFB_FILTER_FILE_MIME_COMPRESSED ------------------------------------
 
 	private function skipIfHostLacksDashZSemantics(): void

--- a/tests/php/PfbFilterRejectDetailTest.php
+++ b/tests/php/PfbFilterRejectDetailTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_filter() FILE_MIME / FILE_MIME_COMPRESSED reject -- the out-param contract
+ * (ADR-48 Phase 2, §2 fork resolution option (a)). An opted-in caller (pre-sets
+ * $reject_detail = array()) gets the raw mime/retval detail back and pfb_filter()
+ * SUPPRESSES its own legacy message -- the caller emits pfb_validate_log() instead,
+ * since it has the feed header + true stage in scope and pfb_filter() does not. A
+ * caller that does NOT opt in (the plain call every un-migrated site still uses)
+ * keeps the exact legacy message unchanged -- no rejection may ever lose its log
+ * entry.
+ *
+ * Fixture: a real on-disk PDF ("%PDF-1.4\n") -- file(1) reliably reports
+ * application/pdf for it (verified empirically: a bare PNG/EXE magic alone reads as
+ * application/octet-stream on this host's libmagic, which would instead exercise the
+ * octet-stream structural-probe recovery branch -- not the plain allow-list reject
+ * this test targets). application/pdf is outside the tests' single-entry allow-list
+ * (text/plain), so the reject path fires deterministically, without hitting the
+ * hostname exceptions (text/x-asm, ipinfo.io octet-stream) either.
+ */
+#[CoversFunction('pfb_filter')]
+final class PfbFilterRejectDetailTest extends TestCase
+{
+	private string $dir;
+	private string $cwd;
+	private string $pdfPath;
+
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_reject_detail_' . uniqid('', TRUE);
+		mkdir($this->dir);
+		$this->cwd     = (string) getcwd();
+		$this->pdfPath = $this->dir . '/reject.pdf';
+		file_put_contents($this->pdfPath, "%PDF-1.4\n");
+
+		foreach (['log', 'errlog', 'mime_types', 'runlog', 'runlog_active'] as $k) {
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
+		}
+		// A stray 'runlog_active' from an earlier test must not mirror our writes
+		// into a third file this test never provisions.
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
+		// Only text/plain is allow-listed -- application/pdf always fails the gate.
+		$GLOBALS['pfb']['mime_types'] = ['text/plain' => 1];
+	}
+
+	protected function tearDown(): void
+	{
+		chdir($this->cwd);
+		@unlink($this->pdfPath);
+		@rmdir($this->dir);
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === false) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+	}
+
+	private function tempLog(): string
+	{
+		$path = tempnam(sys_get_temp_dir(), 'pfb_reject_detail_log_');
+		$this->assertNotFalse($path, 'could not create temp log file');
+		return $path;
+	}
+
+	// --- PFB_FILTER_FILE_MIME ----------------------------------------------
+
+	/**
+	 * Scenario: an un-migrated caller (5-arg call, no out-param)
+	 * Given  a PDF whose mime is outside the allow-list
+	 * When   FILE_MIME validates it via the plain (non-opted-in) call shape
+	 * Then   pfb_filter() rejects it AND still writes its own legacy message
+	 *        -- the back-compat regression pin for every caller that never
+	 *        migrates to the out-param.
+	 */
+	public function testNonOptedCallerKeepsLegacyMessage(): void
+	{
+		$log = $this->tempLog();
+		$GLOBALS['pfb']['log'] = $log;
+		$this->assertSame('', file_get_contents($log), 'sink must start empty');
+
+		$result = pfb_filter(["'unused'", $this->pdfPath, 'http://feed.example/'], PFB_FILTER_FILE_MIME, 'test');
+
+		$this->assertFalse($result);
+		$logged = (string) file_get_contents($log);
+		$this->assertStringContainsString(
+			'Failed or invalid Mime Type: [application/pdf|0]',
+			$logged,
+			"expected legacy reject message in <{$logged}>"
+		);
+		unlink($log);
+	}
+
+	/**
+	 * Scenario: an opted-in caller (pre-sets $reject_detail = array())
+	 * Given  the SAME PDF fixture and allow-list as the non-opted case above
+	 * When   FILE_MIME validates it with the out-param bound
+	 * Then   pfb_filter() still rejects it, fills the out-param with the raw
+	 *        mime/retval detail, and SUPPRESSES its own legacy message -- proving
+	 *        the suppression is a real branch (the sibling test above shows the
+	 *        SAME reject DOES log when not opted in), not an always-silent path.
+	 */
+	public function testOptedInCallerSuppressesLegacyMessageAndFillsDetail(): void
+	{
+		$log = $this->tempLog();
+		$GLOBALS['pfb']['log'] = $log;
+		$this->assertSame('', file_get_contents($log), 'sink must start empty');
+
+		$detail = array();
+		$result = pfb_filter(
+			["'unused'", $this->pdfPath, 'http://feed.example/'],
+			PFB_FILTER_FILE_MIME,
+			'test',
+			'',
+			FALSE,
+			$detail
+		);
+
+		$this->assertFalse($result);
+		$this->assertSame('application/pdf', $detail['mime_raw'] ?? null, 'mime_raw must carry the raw file(1) output');
+		$this->assertSame('application/pdf', $detail['mime'] ?? null, 'mime must carry the (normalised) mime');
+		$this->assertSame(0, $detail['retval'] ?? null, 'retval must carry the file(1) exit code');
+
+		$logged = (string) file_get_contents($log);
+		$this->assertSame('', $logged, "expected NO legacy message once opted in, got <{$logged}>");
+		unlink($log);
+	}
+
+	// --- PFB_FILTER_FILE_MIME_COMPRESSED ------------------------------------
+
+	private function skipIfHostLacksDashZSemantics(): void
+	{
+		$probe = [];
+		exec('/usr/bin/file -bZ --mime-type ' . escapeshellarg($this->pdfPath), $probe, $rc);
+		if ($rc !== 0 || ($probe[0] ?? '') !== 'application/pdf') {
+			$this->markTestSkipped(
+				'host file(1) -bZ returned ' . ($probe[0] ?? '(empty)') . ' for the PDF fixture; '
+				. 'expected application/pdf -- skipping COMPRESSED wiring test on this host'
+			);
+		}
+	}
+
+	/**
+	 * Scenario: an un-migrated caller, FILE_MIME_COMPRESSED
+	 * Same back-compat pin as testNonOptedCallerKeepsLegacyMessage, for the
+	 * `file -bZ` (compressed) branch.
+	 */
+	public function testCompressedNonOptedCallerKeepsLegacyMessage(): void
+	{
+		$this->skipIfHostLacksDashZSemantics();
+
+		$log = $this->tempLog();
+		$GLOBALS['pfb']['log'] = $log;
+		$this->assertSame('', file_get_contents($log), 'sink must start empty');
+
+		$result = pfb_filter(["'unused'", $this->pdfPath, 'http://feed.example/'], PFB_FILTER_FILE_MIME_COMPRESSED, 'test');
+
+		$this->assertFalse($result);
+		$logged = (string) file_get_contents($log);
+		$this->assertStringContainsString(
+			'Failed or invalid Mime Type Compressed: [application/pdf|0]',
+			$logged,
+			"expected legacy compressed reject message in <{$logged}>"
+		);
+		unlink($log);
+	}
+
+	/**
+	 * Scenario: an opted-in caller, FILE_MIME_COMPRESSED
+	 * Same out-param + suppression pin as testOptedInCallerSuppressesLegacyMessageAndFillsDetail,
+	 * for the `file -bZ` (compressed) branch.
+	 */
+	public function testCompressedOptedInCallerSuppressesLegacyMessageAndFillsDetail(): void
+	{
+		$this->skipIfHostLacksDashZSemantics();
+
+		$log = $this->tempLog();
+		$GLOBALS['pfb']['log'] = $log;
+		$this->assertSame('', file_get_contents($log), 'sink must start empty');
+
+		$detail = array();
+		$result = pfb_filter(
+			["'unused'", $this->pdfPath, 'http://feed.example/'],
+			PFB_FILTER_FILE_MIME_COMPRESSED,
+			'test',
+			'',
+			FALSE,
+			$detail
+		);
+
+		$this->assertFalse($result);
+		$this->assertSame('application/pdf', $detail['mime_raw'] ?? null, 'mime_raw must carry the raw file(1) -bZ output');
+		$this->assertSame('application/pdf', $detail['mime'] ?? null, 'mime must carry the same (no normalisation on this branch)');
+		$this->assertSame(0, $detail['retval'] ?? null, 'retval must carry the file(1) exit code');
+
+		$logged = (string) file_get_contents($log);
+		$this->assertSame('', $logged, "expected NO legacy compressed message once opted in, got <{$logged}>");
+		unlink($log);
+	}
+}

--- a/tests/php/PfbValidateLogLineTest.php
+++ b/tests/php/PfbValidateLogLineTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for pfb_validate_log_line() -- ADR-48 Phase 1.
+ *
+ * pfb_validate_log_line() is the pure formatter behind the canonical, greppable
+ * download-validation reject line:
+ *
+ *   \npfb_validate: REJECT feed=<feed> stage=<stage> reason=<reason> detected=<detail>
+ *
+ * Every one of the four values is escaped independently: control bytes in
+ * [\x00-\x1F\x7F] are first neutralised to a single space (these values may carry
+ * attacker-influenced file(1) output, and a raw "\n"/"\r" would forge or split the
+ * greppable line), THEN htmlspecialchars() is applied. Pure function: string in,
+ * string out, no I/O, no globals.
+ */
+#[CoversFunction('pfb_validate_log_line')]
+final class PfbValidateLogLineTest extends TestCase
+{
+	// --- Canonical shape, one exact-string oracle per stage token in the fixed
+	// vocabulary (mime | structural | inner | member | plaintext | entries). None of
+	// these values carry hostile bytes -- they pin the SHAPE; escaping is separately
+	// pinned below.
+
+	public function testCanonicalLineForStageMime(): void
+	{
+		$this->assertSame(
+			"\npfb_validate: REJECT feed=pfB_Feed1 stage=mime reason=invalid-mime detected=application/x-msi",
+			pfb_validate_log_line('pfB_Feed1', 'mime', 'invalid-mime', 'application/x-msi')
+		);
+	}
+
+	public function testCanonicalLineForStageStructural(): void
+	{
+		$this->assertSame(
+			"\npfb_validate: REJECT feed=pfB_Feed2 stage=structural reason=corrupt-archive detected=gzip: unexpected end of file",
+			pfb_validate_log_line('pfB_Feed2', 'structural', 'corrupt-archive', 'gzip: unexpected end of file')
+		);
+	}
+
+	public function testCanonicalLineForStageInner(): void
+	{
+		$this->assertSame(
+			"\npfb_validate: REJECT feed=pfB_Feed3 stage=inner reason=invalid-mime detected=application/x-executable",
+			pfb_validate_log_line('pfB_Feed3', 'inner', 'invalid-mime', 'application/x-executable')
+		);
+	}
+
+	public function testCanonicalLineForStageMember(): void
+	{
+		$this->assertSame(
+			"\npfb_validate: REJECT feed=pfB_Feed4 stage=member reason=path-traversal detected=../../etc/passwd",
+			pfb_validate_log_line('pfB_Feed4', 'member', 'path-traversal', '../../etc/passwd')
+		);
+	}
+
+	public function testCanonicalLineForStagePlaintext(): void
+	{
+		$this->assertSame(
+			"\npfb_validate: REJECT feed=pfB_Feed5 stage=plaintext reason=non-ascii-content detected=0x00 byte at offset 42",
+			pfb_validate_log_line('pfB_Feed5', 'plaintext', 'non-ascii-content', '0x00 byte at offset 42')
+		);
+	}
+
+	public function testCanonicalLineForStageEntries(): void
+	{
+		$this->assertSame(
+			"\npfb_validate: REJECT feed=pfB_Feed6 stage=entries reason=wire_cap detected=17",
+			pfb_validate_log_line('pfB_Feed6', 'entries', 'wire_cap', '17')
+		);
+	}
+
+	// --- Empty detail: `detected=` still present (exact-string), both via an
+	// explicit '' and via the omitted default parameter.
+
+	public function testEmptyDetailStillPrintsDetectedEquals(): void
+	{
+		$this->assertSame(
+			"\npfb_validate: REJECT feed=F stage=mime reason=r detected=",
+			pfb_validate_log_line('F', 'mime', 'r', '')
+		);
+	}
+
+	public function testOmittedDetailDefaultsToEmptyDetectedEquals(): void
+	{
+		$this->assertSame(
+			"\npfb_validate: REJECT feed=F stage=mime reason=r detected=",
+			pfb_validate_log_line('F', 'mime', 'r')
+		);
+	}
+
+	// --- Hostile detail: raw file(1) output is attacker-influenced. A value
+	// carrying a NUL byte, "\n", and HTML metacharacters -- including an embedded
+	// fake "pfb_validate: REJECT" line, an attempt to forge a second greppable
+	// entry -- must collapse to a SINGLE line (no "\n" past the leading one), with
+	// every control byte turned into a space and <, >, & escaped.
+
+	public function testHostileDetailNeutralisedToSingleEscapedLine(): void
+	{
+		$hostileDetail = "app\x00lication/zip\nfake pfb_validate: REJECT x <b>&";
+
+		$result = pfb_validate_log_line('FeedZ', 'mime', 'hostile-detail', $hostileDetail);
+
+		$this->assertSame(
+			"\npfb_validate: REJECT feed=FeedZ stage=mime reason=hostile-detail detected="
+			. 'app lication/zip fake pfb_validate: REJECT x &lt;b&gt;&amp;',
+			$result
+		);
+		// Defensive: only the pinned leading "\n" may appear -- a hostile detail can
+		// never split the canonical line into two greppable entries.
+		$this->assertSame(
+			1,
+			substr_count($result, "\n"),
+			"expected exactly one \\n (the leading one) in <{$result}>"
+		);
+	}
+
+	// --- Hostile feed/reason/stage: same escaping code path as detail: one case
+	// each is enough to prove it applies uniformly to all four values.
+
+	public function testHostileFeedIsNeutralisedAndEscaped(): void
+	{
+		$this->assertSame(
+			"\npfb_validate: REJECT feed=Feed &lt;Name&gt;&amp; stage=mime reason=r detected=d",
+			pfb_validate_log_line("Feed\x01<Name>&", 'mime', 'r', 'd')
+		);
+	}
+
+	public function testHostileReasonIsNeutralisedAndEscaped(): void
+	{
+		$this->assertSame(
+			"\npfb_validate: REJECT feed=f stage=mime reason=bad reason&amp;x detected=d",
+			pfb_validate_log_line('f', 'mime', "bad\x1freason&x", 'd')
+		);
+	}
+
+	public function testHostileStageIsNeutralisedAndEscaped(): void
+	{
+		$this->assertSame(
+			"\npfb_validate: REJECT feed=f stage=mi me&lt;x&gt; reason=r detected=d",
+			pfb_validate_log_line('f', "mi\x7fme<x>", 'r', 'd')
+		);
+	}
+}

--- a/tests/php/PfbValidateLogTest.php
+++ b/tests/php/PfbValidateLogTest.php
@@ -120,4 +120,44 @@ final class PfbValidateLogTest extends TestCase
 			"expected error log to stay EMPTY at level 1, got <{$errlogContents}>"
 		);
 	}
+
+	/**
+	 * ADR-48 Phase 2: the four ADR-45 structural-probe call sites in pfb_download()
+	 * build detail as `"{$file_type} " . basename($file_download)` and pass it
+	 * RAW (no pre-htmlspecialchars) to pfb_validate_log($header, 'structural',
+	 * 'probe_failed', $detail) -- pfb_download() itself is not off-appliance
+	 * unit-testable (curl/exec), so this pins the exact call-site detail SHAPE and
+	 * proves it is escaped exactly ONCE at the sink (never pre-escaped by the
+	 * caller then escaped again by the formatter). Phase 3 smoke covers the true
+	 * end-to-end four lines on the live VM.
+	 */
+	public function testStructuralStageCallSiteShapeIsSinglyEscapedInSink(): void
+	{
+		// Given: an empty sink and the exact detail-construction expression used
+		// at the call sites, fed a raw (unescaped) '&' -- as file(1) output could
+		// carry one.
+		$log = $this->tempFile('pfb_validate_structural_log_');
+		$GLOBALS['pfb']['log'] = $log;
+		$this->assertSame('', file_get_contents($log), 'pfB log must start empty');
+
+		$file_type     = 'application/x-gzip&evil';
+		$file_download = '/tmp/pfB_Feed7.gz';
+		$detail        = "{$file_type} " . basename($file_download);
+
+		// When: the call-site swap emits through pfb_validate_log().
+		pfb_validate_log('pfB_Feed7', 'structural', 'probe_failed', $detail);
+
+		// Then: the sink carries the canonical line, with '&' escaped EXACTLY
+		// once ("&amp;", never "&amp;amp;") -- the call site passes the raw
+		// value straight through; pfb_validate_log_line() is the sole escaper.
+		$expectedLine = pfb_validate_log_line('pfB_Feed7', 'structural', 'probe_failed', $detail);
+		$logged       = (string) file_get_contents($log);
+		$this->assertStringContainsString($expectedLine, $logged);
+		$this->assertStringContainsString('application/x-gzip&amp;evil', $logged);
+		$this->assertStringNotContainsString(
+			'&amp;amp;',
+			$logged,
+			"detail was double-escaped in <{$logged}>"
+		);
+	}
 }

--- a/tests/php/PfbValidateLogTest.php
+++ b/tests/php/PfbValidateLogTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_validate_log() -- the thin emit wrapper for the canonical download-validation
+ * reject line (ADR-48 Phase 1). It must route through pfb_logger() at the caller's
+ * level: the default reject level (2) writes to BOTH the pfB log and the error log;
+ * level 1 writes to the pfB log only -- proving level routing, not just presence.
+ * Uses the sink-capture technique from PfbLoggerIsoTimestampTest: $GLOBALS['pfb']
+ * 'log'/'errlog' point at temp files so the real on-disk write is asserted.
+ */
+#[CoversFunction('pfb_validate_log')]
+final class PfbValidateLogTest extends TestCase
+{
+	/** @var string[] temp files to remove in tearDown */
+	private array $tmpfiles = [];
+
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
+	protected function setUp(): void
+	{
+		foreach (['log', 'errlog', 'pnow', 'runlog', 'runlog_active'] as $k) {
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
+		}
+		// A stray 'runlog_active' from an earlier test must not mirror our writes
+		// into a third file this test never provisions.
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === false) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+		foreach ($this->tmpfiles as $f) {
+			if (is_file($f)) {
+				$this->assertTrue(unlink($f), "failed to remove temp file {$f}");
+			}
+		}
+		$this->tmpfiles = [];
+	}
+
+	private function tempFile(string $prefix): string
+	{
+		$path = tempnam(sys_get_temp_dir(), $prefix);
+		$this->assertNotFalse($path, "could not create temp file for {$prefix}");
+		$this->tmpfiles[] = $path;
+		return $path;
+	}
+
+	public function testDefaultLevelWritesBothPfbLogAndErrorLog(): void
+	{
+		// Given: two empty temp sinks.
+		$log    = $this->tempFile('pfb_validate_log_');
+		$errlog = $this->tempFile('pfb_validate_errlog_');
+		$GLOBALS['pfb']['log']    = $log;
+		$GLOBALS['pfb']['errlog'] = $errlog;
+
+		$this->assertSame('', file_get_contents($log), 'pfB log must start empty');
+		$this->assertSame('', file_get_contents($errlog), 'error log must start empty');
+
+		$expectedLine = pfb_validate_log_line('FeedX', 'mime', 'r', 'd');
+
+		// When: emitted at the default (reject) level.
+		pfb_validate_log('FeedX', 'mime', 'r', 'd');
+
+		// Then: the canonical line lands in BOTH sinks (level 2 semantics).
+		$logContents    = (string) file_get_contents($log);
+		$errlogContents = (string) file_get_contents($errlog);
+		$this->assertStringContainsString(
+			$expectedLine,
+			$logContents,
+			"expected pfB log to contain <{$expectedLine}>, got <{$logContents}>"
+		);
+		$this->assertStringContainsString(
+			$expectedLine,
+			$errlogContents,
+			"expected error log to contain <{$expectedLine}>, got <{$errlogContents}>"
+		);
+	}
+
+	public function testLevelOneWritesPfbLogOnlyNotErrorLog(): void
+	{
+		// Given: two empty temp sinks.
+		$log    = $this->tempFile('pfb_validate_log_');
+		$errlog = $this->tempFile('pfb_validate_errlog_');
+		$GLOBALS['pfb']['log']    = $log;
+		$GLOBALS['pfb']['errlog'] = $errlog;
+
+		$this->assertSame('', file_get_contents($log), 'pfB log must start empty');
+		$this->assertSame('', file_get_contents($errlog), 'error log must start empty');
+
+		$expectedLine = pfb_validate_log_line('FeedY', 'structural', 'r2', 'd2');
+
+		// When: emitted at level 1 (pfB log only -- not the reject default).
+		pfb_validate_log('FeedY', 'structural', 'r2', 'd2', 1);
+
+		// Then: the pfB log carries the line...
+		$logContents = (string) file_get_contents($log);
+		$this->assertStringContainsString(
+			$expectedLine,
+			$logContents,
+			"expected pfB log to contain <{$expectedLine}>, got <{$logContents}>"
+		);
+		// ...but the error log stays untouched -- proves level routing, not just
+		// that SOME write happened.
+		$errlogContents = (string) file_get_contents($errlog);
+		$this->assertSame(
+			'',
+			$errlogContents,
+			"expected error log to stay EMPTY at level 1, got <{$errlogContents}>"
+		);
+	}
+}

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -2177,16 +2177,18 @@ def _fixture_bytes(name: str) -> bytes:
     return (FIXTURES_DIR / name).read_bytes()
 
 
-def _box_mime_type(vm: SmokeVM, data: bytes, remote_tmp: str = "/tmp/adr45_mime_probe.bin") -> str:
+def _box_mime_type(vm: SmokeVM, data: bytes, remote_tmp: str = "/tmp/adr45_mime_probe.bin", flag: str = "-b") -> str:
     """Upload ``data`` to ``remote_tmp`` on the guest via stdin, return ``file(1)`` MIME type.
 
     Used by the ADR-45 octet-stream guard tests to verify that the specific bytes
     actually trigger ``application/octet-stream`` on the box's ``file(1)`` before
-    asserting the recovery / rejection behaviour.  Cleans up the temp file afterwards.
+    asserting the recovery / rejection behaviour.  Pass ``flag="-bZ"`` for the
+    decompress-and-look verdict (the ADR-48 compressed-peek guard).  Cleans up
+    the temp file afterwards.
     """
     # Binary upload: subprocess.run without text=True accepts bytes as input.
     subprocess.run(vm.ssh_argv("tee", remote_tmp), input=data, capture_output=True, timeout=30.0, check=False)
-    result = vm.ssh("file", "-b", "--mime-type", remote_tmp)
+    result = vm.ssh("file", flag, "--mime-type", remote_tmp)
     vm.ssh("rm", "-f", remote_tmp)
     return result.stdout.strip()
 
@@ -2723,8 +2725,12 @@ def test_validate_log_structural_reject_line(deployed_vm: SmokeVM, mock_feeds: _
     rendered ``detected=`` value here is known without a fresh on-box probe.
     ``detected=`` is ``"{file_type} " . basename($file_download)``
     (RESULTS/02_Results.txt), and ``$file_download``'s basename is always
-    ``{header}.raw`` (pfb_download() builds ``$file_dwn = "{pfborig}/{header}"``
-    then appends ``.raw``) -- fully deterministic from the header we choose.
+    ``{header}_v4.raw`` -- the package suffixes the on-box feed header with the
+    address family (``_v4``/``_v6``), and pfb_download() builds
+    ``$file_dwn = "{pfborig}/{header}"`` then appends ``.raw`` -- fully
+    deterministic from the header + family we choose (proven live: the first
+    fan-out logged ``feed=adr48stc_v4 ... adr48stc_v4.raw`` while this marker
+    grepped the unsuffixed header and counted 0).
 
     Before ADR-48 Phase 2, this branch logged an ad-hoc "Corrupt or unreadable
     {type} archive"-style message via pfb_logger() directly, with no
@@ -2747,8 +2753,8 @@ def test_validate_log_structural_reject_line(deployed_vm: SmokeVM, mock_feeds: _
     feed_url = mock_feeds.feed_url("archive_corrupt.gz")
     spec = h.IpCase(aliasname=header, feed_url=feed_url, header=header, family="v4")
     marker = (
-        f"pfb_validate: REJECT feed={header} stage=structural reason=probe_failed "
-        f"detected=application/gzip {header}.raw"
+        f"pfb_validate: REJECT feed={header}_v4 stage=structural reason=probe_failed "
+        f"detected=application/gzip {header}_v4.raw"
     )
 
     # Given -- alias absent + delta baseline for this feed's canonical line.
@@ -2804,8 +2810,11 @@ def test_validate_log_mime_reject_line(deployed_vm: SmokeVM, mock_feeds: _MockFe
     fixture = "archive_junk_octet.bin"
     feed_url = mock_feeds.feed_url(fixture)
     spec = h.IpCase(aliasname=header, feed_url=feed_url, header=header, family="v4")
+    # feed= carries the on-box header, which the package suffixes with the
+    # address family (_v4) -- see the structural test's docstring.
     marker = (
-        f"pfb_validate: REJECT feed={header} stage=mime reason=mime_not_allowed detected=application/octet-stream rc=0"
+        f"pfb_validate: REJECT feed={header}_v4 stage=mime reason=mime_not_allowed "
+        f"detected=application/octet-stream rc=0"
     )
 
     # On-box guard: the mime-gate reject only fires this way when file(1) sees octet-stream
@@ -2840,79 +2849,83 @@ def test_validate_log_mime_reject_line(deployed_vm: SmokeVM, mock_feeds: _MockFe
 
 @pytest.mark.timeout(120)
 def test_validate_log_inner_reject_line(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
-    """ADR-48 P3: the ZIP post-extraction MIME re-run emits the canonical stage=inner line.
+    """ADR-48 P3: the gzip pre-extraction compressed peek emits the canonical stage=inner line.
 
-    Built INLINE (like the healthy test_zip_feed_imports / ADR-44 tests) rather
-    than a committed fixture: a valid zip is trivially cross-platform-portable
-    (any zipfile writer's output is a valid archive bsdtar reads fine), unlike
-    the FreeBSD-libmagic-sensitive CORRUPT/octet-stream corpus this ADR reuses
-    elsewhere. The zip wraps a single inert entry containing the exact
-    "%PDF-1.4\\n" byte string tests/php/PfbFilterRejectDetailTest.php already
-    uses off-appliance: file(1) reliably reports application/pdf for it via the
-    plain "%PDF-" text magic (no chunk/CRC structure needed) -- this repo has
-    already found a BARE PNG/EXE magic alone unreliable (reads as octet-stream
-    on at least one dev host; see that test's docblock), so the on-box guard
-    below re-confirms the verdict for these exact bytes rather than assuming it.
+    Forces the inner stage through the gz ``file -bZ`` COMPRESSED-PEEK sub-path
+    (reason=compressed_mime_not_allowed). The zip POST-EXTRACTION sub-path
+    cannot be forced live: the re-run probes ``$input[1]`` = the ORIGINAL
+    archive (the extracted file rides in the legacy-unused ``$input[0]``), so
+    it always passes for a valid zip -- a pre-existing no-op tracked in issue
+    #808 (probe-target fix = ADR-46 inner-content scope, not ADR-48's
+    message-only scope). The first fan-out proved it live: a valid zip wrapping
+    a PDF payload produced NO inner reject on either edition.
 
-    The entry contains no comma bytes, so pfb_download()'s extraction pipe
-    (``tar -xOf | sed 's/,[[:space:]]/; /g' | tr ',' '\\n'``) passes it through
-    byte-for-byte -- the post-extraction file(1) probe sees the same bytes
-    served. Exercises the POST-EXTRACTION inner sub-path specifically (the
-    pre-extraction compressed-peek sub-path only applies to the gz/bz2/7z
-    branches, not zip -- see RESULTS/02_Results.txt's caller map).
+    Built INLINE: a valid gzip stream is trivially portable (any gzip writer's
+    output passes ``gunzip -t``), unlike the FreeBSD-libmagic-sensitive
+    corrupt/octet-stream corpus this ADR reuses elsewhere. The gzip wraps the
+    exact "%PDF-1.4\\n" byte string tests/php/PfbFilterRejectDetailTest.php
+    already uses off-appliance: file(1) reliably reports application/pdf via
+    the plain "%PDF-" text magic -- and ``file -bZ`` (decompress-and-look) on
+    the gzip must yield the same inner verdict, which the on-box guard below
+    re-confirms for the exact served bytes rather than assuming it.
 
-    Before ADR-48 Phase 2, this branch logged an ad-hoc "[PFB_FILTER - 17]
-    Failed or invalid Mime Type: [...]" message with no "pfb_validate: REJECT"
+    Route on-box: outer MIME gate sees application/gzip (allow-listed), the
+    ADR-45 structural probe (``gunzip -t``) passes -- valid stream -- then the
+    pre-extraction ``file -bZ`` peek sees application/pdf, which is NOT in the
+    allow-list, and rejects with stage=inner.
+
+    Before ADR-48 Phase 2, this branch logged an ad-hoc "Failed or invalid
+    Mime Type Compressed: [...]" message with no "pfb_validate: REJECT"
     substring anywhere -- this test would FAIL on that pre-Phase-2 code.
 
     Given the alias is absent and no canonical inner-reject line for this
       feed's header exists yet (delta baseline).
-    When the case Force-Updates over the zip (the structural probe passes --
-      it is a valid zip -- extraction succeeds, then the post-extraction
-      MIME re-run rejects the PDF-signature payload),
+    When the case Force-Updates over the gzip (structural probe passes, the
+      compressed peek rejects the PDF inner content),
     Then the alias remains absent AND a NEW line matching "pfb_validate: REJECT
-      feed=<hdr> stage=inner reason=inner_mime_not_allowed detected=application/pdf
-      rc=0" appears in the pfB log.
+      feed=<hdr>_v4 stage=inner reason=compressed_mime_not_allowed
+      detected=application/pdf rc=0" appears in the pfB log.
     """
     header = "adr48inr"
     entry_bytes = b"%PDF-1.4\n"
+    gz_bytes = gzip.compress(entry_bytes)
 
-    # On-box guard: the inner post-extraction reject only fires this way when file(1)
-    # reports application/pdf for these exact bytes (mirrors the ADR-45 octet-stream
-    # guards' "probe file(1) on EXACTLY the served bytes" discipline).
-    box_mime = _box_mime_type(deployed_vm, entry_bytes)
-    if box_mime != "application/pdf":
+    # On-box guard: the compressed peek only rejects this way when file -bZ sees
+    # application/pdf inside the EXACT gzip bytes served (same probe-the-served-
+    # bytes discipline as the ADR-45 octet-stream guards).
+    box_inner_mime = _box_mime_type(deployed_vm, gz_bytes, flag="-bZ")
+    if box_inner_mime != "application/pdf":
         pytest.skip(
-            f"PDF-signature payload produced {box_mime!r} on this box (not application/pdf); "
-            f"the inner post-extraction reject branch is not exercised — test inconclusive"
+            f"gzip-wrapped PDF payload produced {box_inner_mime!r} on this box's file -bZ "
+            f"(not application/pdf); the compressed-peek reject branch is not exercised — test inconclusive"
         )
 
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
-        z.writestr("payload.bin", entry_bytes)
-    feed_url = mock_feeds.register("adr48_inner.zip", buf.getvalue())
+    feed_url = mock_feeds.register("adr48_inner.gz", gz_bytes)
     spec = h.IpCase(aliasname=header, feed_url=feed_url, header=header, family="v4")
+    # feed= carries the on-box header, which the package suffixes with the
+    # address family (_v4) -- see the structural test's docstring.
     marker = (
-        f"pfb_validate: REJECT feed={header} stage=inner reason=inner_mime_not_allowed detected=application/pdf rc=0"
+        f"pfb_validate: REJECT feed={header}_v4 stage=inner reason=compressed_mime_not_allowed "
+        f"detected=application/pdf rc=0"
     )
 
     # Given -- alias absent + delta baseline for this feed's canonical line.
-    assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the inner-reject zip feed"
+    assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the inner-reject gzip feed"
     before = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
 
     with h.CaseContext(deployed_vm, spec):
-        # When -- Force Update; the zip extracts fine but the post-extraction re-run rejects.
+        # When -- Force Update; the gzip is structurally valid but the peek rejects its inner type.
         tables_after = h.pfctl_tables(deployed_vm)
         assert spec.alias not in tables_after, (
-            f"expected {spec.alias!r} absent after the inner-reject zip (post-extraction "
-            f"MIME re-run must reject), found it present — tables: {tables_after}"
+            f"expected {spec.alias!r} absent after the inner-reject gzip (compressed peek "
+            f"must reject), found it present — tables: {tables_after}"
         )
         # Then -- a NEW canonical reject line was logged.
         after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
         if not (after > before):
             raise AssertionError(
                 f"expected a NEW line matching {marker!r} in {h.PFB_LOG} after the inner-reject "
-                f"zip Force Update; count before={before} after={after}\n"
+                f"gzip Force Update; count before={before} after={after}\n"
                 f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
             )
 

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -2963,3 +2963,156 @@ def test_validate_log_healthy_feed_no_spurious_reject(deployed_vm: SmokeVM, mock
                 f"validation reject)\n"
                 f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
             )
+
+
+# --------------------------------------------------------------------------- #
+# ADR-48 Phase 4 (issue #789): the Python-side per-entry reject tally surfaces
+# as the SAME canonical marker at stage=entries. Unlike Phases 1-3 (rejects
+# inside pfb_download()'s PHP-side MIME/structural gates), these entries are
+# rejected by Python's ABP parser (parse_abp/normalise, ADR-06/07) once the
+# feed content itself has already passed those PHP-side gates -- so the fixture
+# here is a plain ABP body (built inline, no FreeBSD-sensitive archive/MIME
+# concern), delivered via a DnsblCase reload (updatednsbl), not an IpCase.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(120)
+def test_validate_log_entries_reject_line(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
+    """ADR-48 P4: rejectable ABP entries tally + emit the canonical stage=entries line.
+
+    The feed carries THREE lines: one healthy block (proves the feed genuinely
+    loaded/parsed -- not merely "didn't crash") and one entry per RESOLVED
+    reject bucket -- a no-dot host ('shape') and a 64-char label ('wire_cap',
+    over the #753 63-char cap). Before this phase, pfb_unbound.py counted
+    neither rejection anywhere, so no 'pfb_validate: REJECT ... stage=entries'
+    line could ever appear -- this test FAILS on pre-Phase-4 code (the marker
+    cannot exist) and PASSES once build()'s tally + pfb_emit_entry_reject_stats()
+    wire it end-to-end.
+
+    Given the healthy member resolves before listing (no stale block from a
+      prior case) and no canonical entries-reject line for this feed's header
+      exists yet for either bucket (the delta baseline).
+    When the case Force-Updates (updatednsbl) over the ABP feed,
+    Then the healthy member is VIP-blocked (feed loaded) AND a NEW
+      'pfb_validate: REJECT feed=<hdr> stage=entries reason=shape detected=1'
+      line appears AND a NEW '... reason=wire_cap detected=1' line appears.
+    """
+    header = "adr48ent"
+    blocked_name = h.unique_domain("adr48ent")
+    shape_reject_host = "adr48noshapehost"  # no "." -> normalise() 'shape' reject
+    wire_cap_reject_host = "a" * 64 + ".example.com"  # 64-char label -> #753 'wire_cap' reject
+    body = h.abp_feed(
+        f"||{blocked_name}^",
+        f"||{shape_reject_host}^",
+        f"||{wire_cap_reject_host}^",
+    )
+    feed_url = mock_feeds.register("adr48_entries.txt", body)
+    spec = h.DnsblCase(aliasname=header, feed_url=feed_url, header=header, mode=h.DnsblMode.VIP)
+    shape_marker = f"pfb_validate: REJECT feed={header} stage=entries reason=shape detected=1"
+    wire_cap_marker = f"pfb_validate: REJECT feed={header} stage=entries reason=wire_cap detected=1"
+
+    # Given -- the healthy member resolves before listing + delta baseline for both markers.
+    before_probe = h.dns_probe_client(client_vm, blocked_name, "A")
+    assert h.resolves_to(before_probe, STUB_DNS_A), (
+        f"{blocked_name} should resolve via stub BEFORE listing, got {before_probe}"
+    )
+    assert not h.is_vip(before_probe), f"{blocked_name} unexpectedly VIP-blocked before any feed: {before_probe}"
+    before_shape = h.count_log_marker(deployed_vm, h.PFB_LOG, shape_marker)
+    before_wire_cap = h.count_log_marker(deployed_vm, h.PFB_LOG, wire_cap_marker)
+
+    with h.CaseContext(deployed_vm, spec):
+        # When -- Force Update; egress stays OPEN only to warm/flush the cache entry
+        # (the block itself resolves locally regardless).
+        h.unblock_egress()
+        h.flush_unbound_name(deployed_vm, blocked_name)
+        ans = h.dns_probe_client_until(client_vm, blocked_name, h.is_vip)
+        assert h.is_vip(ans), (
+            f"expected {blocked_name!r} VIP-blocked after the entries-reject feed (feed must have "
+            f"genuinely loaded/parsed), got {ans}"
+        )
+
+        # Then -- each rejectable entry tallied + emitted its OWN canonical line.
+        after_shape = h.count_log_marker(deployed_vm, h.PFB_LOG, shape_marker)
+        if not (after_shape > before_shape):
+            raise AssertionError(
+                f"expected a NEW line matching {shape_marker!r} in {h.PFB_LOG} after the "
+                f"entries-reject Force Update; count before={before_shape} after={after_shape}\n"
+                f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
+            )
+        after_wire_cap = h.count_log_marker(deployed_vm, h.PFB_LOG, wire_cap_marker)
+        if not (after_wire_cap > before_wire_cap):
+            raise AssertionError(
+                f"expected a NEW line matching {wire_cap_marker!r} in {h.PFB_LOG} after the "
+                f"entries-reject Force Update; count before={before_wire_cap} after={after_wire_cap}\n"
+                f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
+            )
+
+
+@pytest.mark.timeout(120)
+def test_validate_log_healthy_abp_feed_no_entries_reject(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
+    """ADR-48 P4 / §7 reject-criterion pin: a healthy ABP feed emits ZERO new
+    'stage=entries' lines, even with deliberate SKIP-class lines present.
+
+    The MUST-ACCOMPANY counterpart to ``test_validate_log_entries_reject_line``
+    above: reuses the deliberate-skip corpus (comment, cosmetic/element-hiding,
+    a tracking-script path anchor, an IP-valued anchor, a ``$badfilter`` rule on
+    an UNRELATED domain) that ``tests/test_adr06_build_module.py::
+    TestSkipClassesTallyZero`` already pins as tallying nothing at the unit
+    level -- this proves the same guarantee end-to-end on the live box: a feed
+    built entirely of skips (plus one healthy block, proving the feed loaded)
+    must never spam the operator with a spurious ``stage=entries`` line.
+
+    Given the healthy member resolves before listing and no 'stage=entries'
+      line for this feed's header exists yet (the delta baseline, module-wide
+      generic-marker style per the Phase-3 healthy-feed guard).
+    When the case Force-Updates over the skip-only + one-healthy-block feed,
+    Then the healthy member is VIP-blocked (feed genuinely loaded) AND the
+      'pfb_validate: REJECT ... feed=<hdr> stage=entries' marker count is
+      UNCHANGED -- no skip class was miscounted as a reject.
+    """
+    header = "adr48ehl"
+    blocked_name = h.unique_domain("adr48ehl")
+    body = h.abp_feed(
+        "! Title: a comment line",
+        "example.com##.ad-banner",
+        "||cdn.example.net/track.js",  # path anchor -> SKIP, not a reject
+        "||203.0.113.7^",  # IP-valued anchor -> firewall path, not a reject
+        "||gone.example.com^$badfilter",  # parses to a Rule, pruned in reconcile() -- unrelated domain
+        f"||{blocked_name}^",
+    )
+    feed_url = mock_feeds.register("adr48_healthy_abp.txt", body)
+    spec = h.DnsblCase(aliasname=header, feed_url=feed_url, header=header, mode=h.DnsblMode.VIP)
+    entries_marker = f"pfb_validate: REJECT feed={header} stage=entries"
+
+    # Given -- the healthy member resolves before listing + delta baseline.
+    before_probe = h.dns_probe_client(client_vm, blocked_name, "A")
+    assert h.resolves_to(before_probe, STUB_DNS_A), (
+        f"{blocked_name} should resolve via stub BEFORE listing, got {before_probe}"
+    )
+    assert not h.is_vip(before_probe), f"{blocked_name} unexpectedly VIP-blocked before any feed: {before_probe}"
+    before = h.count_log_marker(deployed_vm, h.PFB_LOG, entries_marker)
+
+    with h.CaseContext(deployed_vm, spec):
+        # When -- Force Update; the skip lines never reach a block dict, only the
+        # clean anchor does.
+        h.unblock_egress()
+        h.flush_unbound_name(deployed_vm, blocked_name)
+        ans = h.dns_probe_client_until(client_vm, blocked_name, h.is_vip)
+        assert h.is_vip(ans), (
+            f"expected {blocked_name!r} VIP-blocked after the healthy ABP feed (feed must have "
+            f"genuinely loaded/parsed), got {ans}"
+        )
+
+        # Then -- no NEW stage=entries line for this feed (the skip classes tallied nothing).
+        after = h.count_log_marker(deployed_vm, h.PFB_LOG, entries_marker)
+        if not (after == before):
+            raise AssertionError(
+                f"expected NO NEW {entries_marker!r} line in {h.PFB_LOG} after a healthy ABP feed "
+                f"load (a deliberate skip class must never tally as a reject); count "
+                f"before={before} after={after}\n"
+                f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
+            )

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -2682,3 +2682,284 @@ def test_7z_missing_binary_rejected(deployed_vm: SmokeVM, mock_feeds: _MockFeedS
     finally:
         if hidden:
             deployed_vm.ssh(f"mv {stash} {_SEVENZIP_BIN}")
+
+
+# --------------------------------------------------------------------------- #
+# ADR-48: canonical 'pfb_validate: REJECT' log line per wired download-
+# validation stage. Phases 1-2 landed pfb_validate_log_line() /
+# pfb_validate_log() and wired every LIVE reject site through it (see
+# RESULTS/01_Results.txt, RESULTS/02_Results.txt for the exact rendered
+# templates these tests grep). Before Phase 2, pfb_download() logged an
+# ad-hoc, per-site message with no common shape and no "pfb_validate: REJECT"
+# substring anywhere -- so every assertion below FAILS on pre-Phase-2 code
+# (the marker cannot exist) and PASSES post-Phase-2. Delta-based (count
+# BEFORE vs AFTER each case's own Force Update, computed INSIDE its
+# CaseContext block) so a test never rides another test's leftover log lines
+# -- self-encapsulated per the CLAUDE.md ordering-independence mandate.
+# --------------------------------------------------------------------------- #
+
+
+def _recent_validate_lines(vm: SmokeVM, limit: int = 5) -> str:
+    """Return up to the last ``limit`` 'pfb_validate:' lines from the pfB log.
+
+    Diagnostic-only, called ONLY from inside a failing branch below (never
+    unconditionally in an ``assert`` message, which Python would evaluate even
+    on the passing path) -- a bare count tells you a line was missing, not
+    what WAS actually logged instead. Feeds the CLAUDE.md expected-vs-actual
+    mandate: the failure message shows the REAL log excerpt, not just a number.
+    """
+    text = h.read_log_file(vm, h.PFB_LOG)
+    lines = [ln for ln in text.splitlines() if "pfb_validate:" in ln]
+    return "\n".join(lines[-limit:]) if lines else "(no 'pfb_validate:' line found in the log)"
+
+
+@pytest.mark.timeout(120)
+def test_validate_log_structural_reject_line(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """ADR-48 P3: a structural-probe reject emits the canonical stage=structural line.
+
+    Reuses the FreeBSD-verified ADR-45 corpus fixture (fixtures/archive_corrupt.gz;
+    see fixtures/README.md "Archive corpus") -- a truncated gzip whose on-box
+    file(1) verdict is the already-confirmed ``application/gzip``, so the
+    rendered ``detected=`` value here is known without a fresh on-box probe.
+    ``detected=`` is ``"{file_type} " . basename($file_download)``
+    (RESULTS/02_Results.txt), and ``$file_download``'s basename is always
+    ``{header}.raw`` (pfb_download() builds ``$file_dwn = "{pfborig}/{header}"``
+    then appends ``.raw``) -- fully deterministic from the header we choose.
+
+    Before ADR-48 Phase 2, this branch logged an ad-hoc "Corrupt or unreadable
+    {type} archive"-style message via pfb_logger() directly, with no
+    "pfb_validate: REJECT" substring anywhere -- this test would FAIL on that
+    pre-Phase-2 code (no line ever matches the canonical marker) and PASSES
+    once pfb_validate_log() wires the site.
+
+    Given the alias is absent and no canonical structural-reject line for this
+      feed's header exists yet (the delta baseline, captured before the Force
+      Update -- not asserted as a global zero, per the no-false-pass-from-a-
+      sibling-test rule).
+    When the case Force-Updates over the truncated gzip (the structural probe
+      -- gunzip -t -- rejects it, same as ADR-45's test_corrupt_gzip_rejected),
+    Then the alias remains absent (ADR-45's existing pin) AND a NEW line
+      matching "pfb_validate: REJECT feed=<hdr> stage=structural
+      reason=probe_failed detected=application/gzip <hdr>.raw" appears in the
+      pfB log.
+    """
+    header = "adr48stc"
+    feed_url = mock_feeds.feed_url("archive_corrupt.gz")
+    spec = h.IpCase(aliasname=header, feed_url=feed_url, header=header, family="v4")
+    marker = (
+        f"pfb_validate: REJECT feed={header} stage=structural reason=probe_failed "
+        f"detected=application/gzip {header}.raw"
+    )
+
+    # Given -- alias absent + delta baseline for this feed's canonical line.
+    assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the corrupt-gzip feed"
+    before = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+
+    with h.CaseContext(deployed_vm, spec):
+        # When -- Force Update; the structural probe (gunzip -t) rejects the truncated stream.
+        tables_after = h.pfctl_tables(deployed_vm)
+        assert spec.alias not in tables_after, (
+            f"expected {spec.alias!r} absent after corrupt gzip (structural probe must reject), "
+            f"found it present — tables: {tables_after}"
+        )
+        # Then -- a NEW canonical reject line was logged (proves the ADR-48 wiring
+        # fired, not merely that the reject happened -- ADR-45 already pins the latter).
+        after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+        if not (after > before):
+            raise AssertionError(
+                f"expected a NEW line matching {marker!r} in {h.PFB_LOG} after the corrupt-gzip "
+                f"Force Update; count before={before} after={after}\n"
+                f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
+            )
+
+
+@pytest.mark.timeout(120)
+def test_validate_log_mime_reject_line(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """ADR-48 P3: an outer MIME-gate reject emits the canonical stage=mime line.
+
+    Reuses the FreeBSD-verified ADR-45 corpus fixture (fixtures/archive_junk_octet.bin;
+    see fixtures/README.md) -- pure NUL/control bytes that file(1) reports as
+    application/octet-stream, for which pfb_octet_recover_type() finds no
+    archive type that passes -- the reject falls through to the OUTER MIME
+    gate (stage=mime, reason=mime_not_allowed) with
+    mime_raw=application/octet-stream, rc=0 (file(1) itself succeeds; it is
+    the allow-list check that fails -- RESULTS/02_Results.txt's rendered
+    template).
+
+    Before ADR-48 Phase 2, this branch logged an ad-hoc "[PFB_FILTER - 17]
+    Failed or invalid Mime Type: [...]" message with no "pfb_validate: REJECT"
+    substring anywhere -- this test would FAIL on that pre-Phase-2 code.
+
+    Given the alias is absent and no canonical mime-reject line for this feed's
+      header exists yet (delta baseline).
+    When the case Force-Updates over the junk octet-stream blob (same fixture
+      as ADR-45's test_junk_octet_stream_rejected; skipped, not failed, if this
+      box's file(1) does not report octet-stream for it -- the reject branch
+      would then not be exercised, matching that sibling test's own guard),
+    Then the alias remains absent AND a NEW line matching "pfb_validate: REJECT
+      feed=<hdr> stage=mime reason=mime_not_allowed
+      detected=application/octet-stream rc=0" appears in the pfB log.
+    """
+    header = "adr48mim"
+    fixture = "archive_junk_octet.bin"
+    feed_url = mock_feeds.feed_url(fixture)
+    spec = h.IpCase(aliasname=header, feed_url=feed_url, header=header, family="v4")
+    marker = (
+        f"pfb_validate: REJECT feed={header} stage=mime reason=mime_not_allowed detected=application/octet-stream rc=0"
+    )
+
+    # On-box guard: the mime-gate reject only fires this way when file(1) sees octet-stream
+    # for these exact bytes (mirrors test_junk_octet_stream_rejected's guard for the same fixture).
+    box_mime = _box_mime_type(deployed_vm, _fixture_bytes(fixture))
+    if box_mime != "application/octet-stream":
+        pytest.skip(
+            f"junk blob produced {box_mime!r} on this box (not application/octet-stream); "
+            f"the mime-gate reject branch is not exercised — test inconclusive"
+        )
+
+    # Given -- alias absent + delta baseline for this feed's canonical line.
+    assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the junk-blob feed"
+    before = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+
+    with h.CaseContext(deployed_vm, spec):
+        # When -- Force Update; the outer MIME gate rejects (no archive type recovers).
+        tables_after = h.pfctl_tables(deployed_vm)
+        assert spec.alias not in tables_after, (
+            f"expected {spec.alias!r} absent after junk octet-stream (mime gate must reject), "
+            f"found it present — tables: {tables_after}"
+        )
+        # Then -- a NEW canonical reject line was logged.
+        after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+        if not (after > before):
+            raise AssertionError(
+                f"expected a NEW line matching {marker!r} in {h.PFB_LOG} after the junk-blob "
+                f"Force Update; count before={before} after={after}\n"
+                f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
+            )
+
+
+@pytest.mark.timeout(120)
+def test_validate_log_inner_reject_line(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """ADR-48 P3: the ZIP post-extraction MIME re-run emits the canonical stage=inner line.
+
+    Built INLINE (like the healthy test_zip_feed_imports / ADR-44 tests) rather
+    than a committed fixture: a valid zip is trivially cross-platform-portable
+    (any zipfile writer's output is a valid archive bsdtar reads fine), unlike
+    the FreeBSD-libmagic-sensitive CORRUPT/octet-stream corpus this ADR reuses
+    elsewhere. The zip wraps a single inert entry containing the exact
+    "%PDF-1.4\\n" byte string tests/php/PfbFilterRejectDetailTest.php already
+    uses off-appliance: file(1) reliably reports application/pdf for it via the
+    plain "%PDF-" text magic (no chunk/CRC structure needed) -- this repo has
+    already found a BARE PNG/EXE magic alone unreliable (reads as octet-stream
+    on at least one dev host; see that test's docblock), so the on-box guard
+    below re-confirms the verdict for these exact bytes rather than assuming it.
+
+    The entry contains no comma bytes, so pfb_download()'s extraction pipe
+    (``tar -xOf | sed 's/,[[:space:]]/; /g' | tr ',' '\\n'``) passes it through
+    byte-for-byte -- the post-extraction file(1) probe sees the same bytes
+    served. Exercises the POST-EXTRACTION inner sub-path specifically (the
+    pre-extraction compressed-peek sub-path only applies to the gz/bz2/7z
+    branches, not zip -- see RESULTS/02_Results.txt's caller map).
+
+    Before ADR-48 Phase 2, this branch logged an ad-hoc "[PFB_FILTER - 17]
+    Failed or invalid Mime Type: [...]" message with no "pfb_validate: REJECT"
+    substring anywhere -- this test would FAIL on that pre-Phase-2 code.
+
+    Given the alias is absent and no canonical inner-reject line for this
+      feed's header exists yet (delta baseline).
+    When the case Force-Updates over the zip (the structural probe passes --
+      it is a valid zip -- extraction succeeds, then the post-extraction
+      MIME re-run rejects the PDF-signature payload),
+    Then the alias remains absent AND a NEW line matching "pfb_validate: REJECT
+      feed=<hdr> stage=inner reason=inner_mime_not_allowed detected=application/pdf
+      rc=0" appears in the pfB log.
+    """
+    header = "adr48inr"
+    entry_bytes = b"%PDF-1.4\n"
+
+    # On-box guard: the inner post-extraction reject only fires this way when file(1)
+    # reports application/pdf for these exact bytes (mirrors the ADR-45 octet-stream
+    # guards' "probe file(1) on EXACTLY the served bytes" discipline).
+    box_mime = _box_mime_type(deployed_vm, entry_bytes)
+    if box_mime != "application/pdf":
+        pytest.skip(
+            f"PDF-signature payload produced {box_mime!r} on this box (not application/pdf); "
+            f"the inner post-extraction reject branch is not exercised — test inconclusive"
+        )
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("payload.bin", entry_bytes)
+    feed_url = mock_feeds.register("adr48_inner.zip", buf.getvalue())
+    spec = h.IpCase(aliasname=header, feed_url=feed_url, header=header, family="v4")
+    marker = (
+        f"pfb_validate: REJECT feed={header} stage=inner reason=inner_mime_not_allowed detected=application/pdf rc=0"
+    )
+
+    # Given -- alias absent + delta baseline for this feed's canonical line.
+    assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the inner-reject zip feed"
+    before = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+
+    with h.CaseContext(deployed_vm, spec):
+        # When -- Force Update; the zip extracts fine but the post-extraction re-run rejects.
+        tables_after = h.pfctl_tables(deployed_vm)
+        assert spec.alias not in tables_after, (
+            f"expected {spec.alias!r} absent after the inner-reject zip (post-extraction "
+            f"MIME re-run must reject), found it present — tables: {tables_after}"
+        )
+        # Then -- a NEW canonical reject line was logged.
+        after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+        if not (after > before):
+            raise AssertionError(
+                f"expected a NEW line matching {marker!r} in {h.PFB_LOG} after the inner-reject "
+                f"zip Force Update; count before={before} after={after}\n"
+                f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
+            )
+
+
+@pytest.mark.timeout(120)
+def test_validate_log_healthy_feed_no_spurious_reject(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """ADR-48 P3: a healthy feed load emits ZERO new 'pfb_validate: REJECT' lines.
+
+    The MUST-ACCOMPANY counterpart to the three reject-line tests above --
+    together they prove the canonical marker is a REAL reject signal tied to
+    an actual validation failure, not something pfb_download() logs on every
+    run regardless of outcome (the ADR §7 / RESULTS/03 reject criterion: "no
+    healthy feed logs a spurious REJECT"). Reuses the Phase-4 ip_plain_cidr.txt
+    fixture (already the KILL-GATE healthy-load fixture for
+    test_ip_http_feed_loads).
+
+    Given the alias is absent and a delta baseline of every 'pfb_validate:
+      REJECT' line already in the pfB log (module-wide, on purpose: whatever
+      an earlier test in this module already wrote is irrelevant here -- only
+      the delta across THIS case's own Force Update window is asserted, so
+      this test never depends on run order).
+    When the case Force-Updates over the healthy plain-IP+CIDR feed,
+    Then the listed member loads (the feed genuinely succeeded, not merely
+      "didn't crash") AND the REJECT-marker count is UNCHANGED -- no spurious
+      REJECT line was logged for a feed that never failed validation.
+    """
+    header = "adr48hlt"
+    feed_url = mock_feeds.feed_url("ip_plain_cidr.txt")
+    spec = h.IpCase(aliasname=header, feed_url=feed_url, header=header, family="v4")
+    member_host = "203.0.113.5"  # the plain listed host (fixtures/README.md)
+
+    # Given -- alias absent + delta baseline of ANY reject marker.
+    assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the healthy feed was loaded"
+    before = h.count_log_marker(deployed_vm, h.PFB_LOG, "pfb_validate: REJECT")
+
+    with h.CaseContext(deployed_vm, spec):
+        # When -- Force Update loads the healthy feed successfully.
+        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        assert h.member_present(members, member_host), (
+            f"expected {member_host!r} in {spec.alias} after the healthy feed load, got: {members}"
+        )
+        # Then -- no NEW canonical REJECT line was logged for this successful load.
+        after = h.count_log_marker(deployed_vm, h.PFB_LOG, "pfb_validate: REJECT")
+        if not (after == before):
+            raise AssertionError(
+                f"expected NO NEW 'pfb_validate: REJECT' line in {h.PFB_LOG} after a healthy feed "
+                f"load; count before={before} after={after} (a healthy feed must never emit a "
+                f"validation reject)\n"
+                f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
+            )

--- a/tests/test_adr06_build_module.py
+++ b/tests/test_adr06_build_module.py
@@ -254,6 +254,39 @@ class TestNormalise:
         assert pfb_unbound.normalise(name_253 + ".") == name_253
 
 
+class TestNormaliseVerdictBucket:
+    """ADR-48 Phase 4 (#789): ``_normalise_verdict`` is the classified body
+    ``normalise()`` wraps -- every reject class ``TestNormalise`` above pins as
+    ``None`` here additionally pins WHICH of the two RESOLVED buckets ('shape' vs
+    'wire_cap') it tallies as, since build()/parse_abp()/reconcile() rely on that
+    split to avoid spamming a healthy feed's operator with the wrong reason.
+    """
+
+    def test_accept_returns_domain_and_no_bucket(self) -> None:
+        assert pfb_unbound._normalise_verdict(" Tracker.ORG. ") == ("tracker.org", None)
+
+    def test_no_dot_is_shape(self) -> None:
+        assert pfb_unbound._normalise_verdict("localhost") == (None, "shape")
+
+    def test_edge_hyphen_is_shape(self) -> None:
+        assert pfb_unbound._normalise_verdict("-bad.com") == (None, "shape")
+        assert pfb_unbound._normalise_verdict("bad-.com") == (None, "shape")
+
+    def test_empty_label_is_shape(self) -> None:
+        assert pfb_unbound._normalise_verdict("emp..ty") == (None, "shape")
+
+    def test_bad_char_is_shape(self) -> None:
+        assert pfb_unbound._normalise_verdict("sp ace.com") == (None, "shape")
+
+    def test_over_label_cap_is_wire_cap(self) -> None:
+        # #753: 64-char label -- well-shaped (a dot IS present) but unqueryable.
+        assert pfb_unbound._normalise_verdict("a" * 64 + ".com") == (None, "wire_cap")
+
+    def test_over_total_cap_is_wire_cap(self) -> None:
+        name_254 = ".".join(["b" * 61] * 4) + "." + "b" * 6
+        assert pfb_unbound._normalise_verdict(name_254) == (None, "wire_cap")
+
+
 # --------------------------------------------------------------------------- #
 # classify()
 # --------------------------------------------------------------------------- #
@@ -477,3 +510,106 @@ class TestBuildPurity:
         # And the returned structures are NOT the module globals.
         assert result.data_db is not pfb_unbound.dataDB
         assert result.zone_db is not pfb_unbound.zoneDB
+
+
+# --------------------------------------------------------------------------- #
+# ADR-48 Phase 4 (#789) -- build()'s per-entry reject tally.
+#
+# A synthetic in-memory manifest + line_reader (the ``_manifest``/``lambda raw:
+# [...]`` idiom already used by TestBuildBranches in test_branch_coverage_gaps.py)
+# gives EXACT control over how many shape/wire_cap rejects a feed carries -- the
+# golden-fixture-driven ``_run_build()`` helper above is deliberately NOT reused
+# here: its feed contents are tuned for the ADR-06 decision oracle, not for
+# pinning an exact reject count, and coupling this test to that fixture's byte
+# content would make it fragile to unrelated fixture edits.
+# --------------------------------------------------------------------------- #
+
+
+class TestEntryRejectTally:
+    """``build()`` tallies every domain-target entry the normalise() domain-shape
+    gate rejects (bucket 'shape' | 'wire_cap', ADR §2 item 4) so an operator can
+    explain a feed-size vs dict-size discrepancy from one grep instead of
+    guessing (issue #789). RED on pre-Phase-4 code: ``BuildResult`` carried no
+    ``rejects`` field at all (``AttributeError``).
+    """
+
+    def test_abp_feed_tallies_exact_shape_and_wire_cap_counts(self) -> None:
+        # Given: an ABP feed with EXACTLY 2 shape-rejectable entries (no-dot host,
+        # edge-hyphen label) and 2 wire-cap-rejectable entries (a 64-char label, a
+        # >253-char total name) among otherwise-healthy accepted entries.
+        long_label = "a" * 64
+        name_254 = ".".join(["b" * 61] * 4) + "." + "b" * 6
+        feed_row = {"feed": "RejFeed", "group": "RejGroup", "format_hint": "abp", "log_flag": "1", "raw": "r"}
+        lines = [
+            "||good.example.com^",  # accepted -- must not be counted
+            "||no-dot-host^",  # shape: no "." in host
+            "||-bad.example.com^",  # shape: edge-hyphen label
+            f"||{long_label}.com^",  # wire_cap: 64-char label
+            f"||{name_254}^",  # wire_cap: >253-char total
+        ]
+        # When: build() runs the feed through parse_abp() -> reconcile().
+        result = pfb_unbound.build(
+            {"feeds": [feed_row], "config": {}},
+            {},
+            line_reader=lambda raw: lines,
+        )
+        # Then: the tally holds EXACTLY the crafted counts, keyed (feed, group);
+        # the accepted entry landed in the block structures, not in the tally.
+        assert result.rejects == {("RejFeed", "RejGroup"): {"shape": 2, "wire_cap": 2}}
+        assert "good.example.com" in result.data_db or "good.example.com" in result.zone_db
+
+    def test_plain_feed_tallies_normalise_reject(self) -> None:
+        # Given: a plain (non-ABP) feed with exactly 1 shape-rejectable line --
+        # proves the plain build path (not just the ABP path) counts too.
+        feed_row = {"feed": "PlainFeed", "group": "PlainGroup", "format_hint": "plain", "log_flag": "1", "raw": "r"}
+        result = pfb_unbound.build(
+            {"feeds": [feed_row], "config": {}},
+            {},
+            line_reader=lambda raw: ["good.example.com", "no-dot-host"],
+        )
+        assert result.rejects == {("PlainFeed", "PlainGroup"): {"shape": 1, "wire_cap": 0}}
+
+
+class TestSkipClassesTallyZero:
+    """ADR-48 §7 reject-criterion pin: a deliberate ABP SKIP (comment, cosmetic/
+    element-hiding, path/wildcard anchor, IP-valued anchor, non-DNS $options,
+    $badfilter) is NOT a reject -- it must tally NOTHING, or a perfectly healthy
+    feed built entirely of such lines would log spurious REJECT lines. The lines
+    below are the deliberate-skip subset of tests/test_adr07_parser.py::TestSkip's
+    corpus (its test_skip_invalid_domain lines are EXCLUDED on purpose: those ARE
+    genuine normalise() shape rejects, not skips, and must tally -- reusing them
+    here would defeat the point of this test).
+    """
+
+    def test_skip_only_feed_tallies_nothing(self) -> None:
+        feed_row = {"feed": "SkipFeed", "group": "SkipGroup", "format_hint": "abp", "log_flag": "1", "raw": "r"}
+        skip_lines = [
+            "",
+            "   ",
+            "! Title: comment",
+            "[Adblock Plus 2.0]",
+            "# plain comment",
+            "example.com##.ad-banner",
+            "##.global-ad",
+            "example.net#@#.whitelisted-ad",
+            "example.org#?#div:has(> .ad)",
+            "example.com#%#//scriptlet('x')",
+            "example.com#$#body { color: red; }",
+            "||example.com/ads/*",
+            "||cdn.example.net/track.js",
+            "/banners/*.gif",
+            "||shop.example^/affiliate?id=",
+            "||wild.*^",
+            "not a domain at all",
+            "||203.0.113.7^",  # IP-valued anchor -> PHP firewall path
+            "||198.51.100.42^",
+            "0.0.0.0 203.0.113.99",
+            "127.0.0.1 10.0.0.1",
+            "||gone.example^$badfilter",  # parses to a Rule, pruned in reconcile()
+        ]
+        result = pfb_unbound.build(
+            {"feeds": [feed_row], "config": {}},
+            {},
+            line_reader=lambda raw: skip_lines,
+        )
+        assert result.rejects == {}

--- a/tests/test_adr07_reconcile.py
+++ b/tests/test_adr07_reconcile.py
@@ -87,8 +87,12 @@ _TLDS: dict[str, dict[str, str]] = {
 _EXCLUSION: set[str] = set()
 
 
-def _reconcile(lines: list[str], provenance: str = P.RULE_PROV_FEED) -> P.ReconcileResult:
-    return P.reconcile(_production_rules(lines, provenance), _TLDS, _EXCLUSION)
+def _reconcile(
+    lines: list[str],
+    provenance: str = P.RULE_PROV_FEED,
+    tally: P.RejectTally | None = None,
+) -> P.ReconcileResult:
+    return P.reconcile(_production_rules(lines, provenance), _TLDS, _EXCLUSION, tally=tally)
 
 
 def _resolve(result: P.ReconcileResult, query: str) -> str:
@@ -268,15 +272,22 @@ class TestRegexReduction:
         # kept as a compiled regex (that would pay per-query cost for a pattern
         # that can never match).
         long_label = "a" * 64
+        tally: P.RejectTally = {}
         res = _reconcile(
             [
                 f"/^(.+\\.)?{long_label}\\.com$/",
                 f"@@/^{long_label}\\.net$/",
-            ]
+            ],
+            tally=tally,
         )
         assert res.block_domains == [] and res.allow_domains == []
         assert res.block_regex_irreducible == [] and res.allow_regex_irreducible == []
         assert res.reduced == 0
+        # ADR-48 Phase 4 (#789): the dropped fold now tallies 'wire_cap', attributed
+        # to the originating rule's own (feed, group) -- ("", "") here, since
+        # _production_rules() doesn't set feed/group. RED before this phase: there
+        # was no ``tally`` parameter at all, so this drop counted NOWHERE.
+        assert tally == {("", ""): {"shape": 0, "wire_cap": 2}}
 
     def test_reduction_matches_oracle_and_spike(self) -> None:
         spike = _spike()

--- a/tests/test_adr10_swap.py
+++ b/tests/test_adr10_swap.py
@@ -32,7 +32,13 @@ import pfb_unbound as P
 # --------------------------------------------------------------------------- #
 
 
-def _snapshot(*, data: dict[str, Any] | None = None, counts: int = 0, regex_count: int = 0) -> P.Snapshot:
+def _snapshot(
+    *,
+    data: dict[str, Any] | None = None,
+    counts: int = 0,
+    regex_count: int = 0,
+    rejects: P.RejectTally | None = None,
+) -> P.Snapshot:
     """A populated Snapshot with distinct identity + counts so the swap is observable."""
     return P.Snapshot(
         data_db=data if data is not None else {},
@@ -45,6 +51,7 @@ def _snapshot(*, data: dict[str, Any] | None = None, counts: int = 0, regex_coun
         important_rules=False,
         counts=counts,
         regex_count=regex_count,
+        rejects=rejects if rejects is not None else {},
     )
 
 
@@ -358,6 +365,50 @@ class TestEmitCountsToggle:
         assert P.rebuild_and_swap(lambda: new) is True
         assert emitted[P.pfb["pfb_py_count"]] == 99
         assert emitted[P.pfb["pfb_py_regex_count"]] == 5
+
+    def test_emit_counts_true_also_reemits_reject_stats_when_path_set(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # ADR-48 Phase 4 (#789): a no-restart swap re-emits the reject-stats
+        # artifact from the FRESH snapshot too, exactly like the UI counts above.
+        # init_standard() sets the path (needs the live Unbound env, can't run
+        # here), so this test seeds it directly on the bare pfb dict.
+        P._snapshot = _snapshot(counts=1)
+        _seed_cache_row(str(tmp_path / "cache.sqlite"))
+        _set_count_paths(tmp_path)
+        P.pfb["pfb_py_reject_stats"] = str(tmp_path / "pfb_py_reject_stats.json")
+        monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+        emitted_stats: dict[str, P.RejectTally] = {}
+        monkeypatch.setattr(
+            P,
+            "dnsbl_emit_reject_stats",
+            lambda path, rejects: emitted_stats.update({path: rejects}) or True,
+        )
+
+        new = _snapshot(counts=99, rejects={("F", "G"): {"shape": 1, "wire_cap": 2}})
+        assert P.rebuild_and_swap(lambda: new) is True
+
+        assert emitted_stats[P.pfb["pfb_py_reject_stats"]] == {("F", "G"): {"shape": 1, "wire_cap": 2}}
+
+    def test_emit_counts_true_skips_reject_stats_when_path_absent(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # Contrast: a bare pfb dict without the key (every OTHER test in this
+        # module never seeds it) must NOT KeyError -- the caller guards with
+        # ``pfb.get(...)`` precisely because unit tests build a minimal pfb dict.
+        P._snapshot = _snapshot(counts=1)
+        _seed_cache_row(str(tmp_path / "cache.sqlite"))
+        _set_count_paths(tmp_path)
+        assert "pfb_py_reject_stats" not in P.pfb
+        monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+        called: list[Any] = []
+
+        def _spy_emit_reject_stats(*a: Any, **k: Any) -> bool:
+            called.append((a, k))
+            return True
+
+        monkeypatch.setattr(P, "dnsbl_emit_reject_stats", _spy_emit_reject_stats)
+
+        new = _snapshot(counts=99, rejects={("F", "G"): {"shape": 1, "wire_cap": 0}})
+        assert P.rebuild_and_swap(lambda: new) is True
+
+        assert called == []
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_branch_coverage_gaps.py
+++ b/tests/test_branch_coverage_gaps.py
@@ -58,6 +58,7 @@ from pfb_unbound import (
     classify_idn,
     dnsbl_build_from_manifest,
     dnsbl_emit_count,
+    dnsbl_emit_reject_stats,
     evaluate_domain,
     parse,
     parse_abp,
@@ -553,6 +554,55 @@ class TestManifestErrorBranches:
         out = tmp_path / "count.txt"
         assert dnsbl_emit_count(str(out), 7) is True
         assert out.read_text().strip() == "7"
+
+
+# --------------------------------------------------------------------------- #
+# ADR-48 Phase 4 (#789) -- dnsbl_emit_reject_stats() artifact writer.
+# --------------------------------------------------------------------------- #
+class TestEmitRejectStats:
+    def test_writes_only_nonzero_feeds_as_json(self, tmp_path: Path) -> None:
+        # Given: a tally with one all-zero row (never emitted by build() in
+        # practice, but the writer must not depend on that) and one nonzero row.
+        out = tmp_path / "pfb_py_reject_stats.json"
+        tally = {
+            ("ZeroFeed", "ZeroGroup"): {"shape": 0, "wire_cap": 0},
+            ("RejFeed", "RejGroup"): {"shape": 3, "wire_cap": 5},
+        }
+        # When: the artifact is written.
+        assert dnsbl_emit_reject_stats(str(out), tally) is True
+        # Then: valid JSON, only the nonzero feed present, exact counts.
+        written = json.loads(out.read_text())
+        assert written == [{"feed": "RejFeed", "group": "RejGroup", "shape": 3, "wire_cap": 5}]
+
+    def test_empty_tally_writes_empty_json_array(self, tmp_path: Path) -> None:
+        # PHP must distinguish "ran, zero rejects" ("[]") from "no artifact" (absent
+        # file, fresh boot / an old python module) -- an empty tally still writes.
+        out = tmp_path / "pfb_py_reject_stats.json"
+        assert dnsbl_emit_reject_stats(str(out), {}) is True
+        assert out.read_text() == "[]"
+
+    def test_atomic_write_leaves_no_stray_tmp_file(self, tmp_path: Path) -> None:
+        # The atomic temp+os.replace pattern (mirrors _reload_write_applied) must
+        # not leave a ".tmp" sibling behind on success.
+        out = tmp_path / "pfb_py_reject_stats.json"
+        assert dnsbl_emit_reject_stats(str(out), {("F", "G"): {"shape": 1, "wire_cap": 0}}) is True
+        assert out.exists()
+        assert not (tmp_path / "pfb_py_reject_stats.json.tmp").exists()
+
+    def test_returns_false_on_write_error(self) -> None:
+        # An unwritable path -> OSError caught -> False (never raises into the run).
+        assert dnsbl_emit_reject_stats("/no/such/dir/pfb_py_reject_stats.json", {}) is False
+
+    def test_reject_stats_path_key_is_chroot_relative(self) -> None:
+        # ADR §3 risk: init_standard() must set a bare filename (never a
+        # host-absolute path) -- a host-absolute path silently fails to load
+        # inside Unbound's chroot (the exact manifest-boundary bug class this repo
+        # already hit once). init_standard() needs the live Unbound env and can't
+        # run in this suite, so this pins the assignment directly in the source.
+        source = Path(pfb_unbound.__file__).read_text()
+        match = re.search(r'pfb\["pfb_py_reject_stats"\]\s*=\s*"([^"]+)"', source)
+        assert match is not None, "pfb['pfb_py_reject_stats'] assignment not found in pfb_unbound.py"
+        assert not match.group(1).startswith("/"), f"expected a chroot-relative bare name, got {match.group(1)!r}"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Implements **ADR-48 — Standardised download-validation rejection logging** (`.ADRs/ADR_48_Download_Validation_Logging/ADR.md`), the observability layer of the issue #581 feed-validation suite (sibling of ADR-44/45/46/49), plus the Phase 4 Python entry-reject accounting from issue #789.

Part of #581. Part of #789.

## What changed

**Phase 1 — canonical formatter (pure) + emit wrapper**

- `pfb_validate_log_line($feed, $stage, $reason, $detail)` produces the single greppable line:
  `pfb_validate: REJECT feed=<feed> stage=<stage> reason=<reason> detected=<detail>`
  Each value is control-character-neutralised (a hostile `file(1)` output cannot forge or split the line) and `htmlspecialchars()`-escaped. `pfb_validate_log()` emits it through `pfb_logger()` at the reject level (default 2).

**Phase 2 — wire the landed reject sites (§2 fork resolved as option (a))**

- `pfb_filter()` gains an optional by-ref `$reject_detail` out-param: an opted-in caller pre-sets it to an array; the FILE_MIME / FILE_MIME_COMPRESSED reject paths fill `mime_raw`/`mime`/`retval` and suppress the legacy in-filter message; non-opted callers are byte-identical to before.
- All five `pfb_download()` FILE_MIME* sites emit the canonical line: outer MIME gate (`stage=mime`, `detected=` raw `file` output), ZIP post-extraction re-run (`stage=inner`), gz/bz2/7z `-bZ` peeks (`stage=inner`).
- The four ADR-45 structural-probe rejects now emit `stage=structural reason=probe_failed`.
- Untouched by design: the 7z missing-tool message (resolved OUT of the stage vocabulary — a tooling failure, not a content verdict) and the commented-out ZIP inner-content block (ADR-46).

**Phase 3 — live-VM smoke**

- One test per wired stage (structural / mime / inner) asserting the canonical line lands in the pfB log (delta-based, before-state asserted), plus a healthy-feed guard asserting zero spurious REJECT lines. Fixtures reuse the FreeBSD-verified ADR-45 archive corpus.

**Phase 4 — Python-side per-entry reject accounting (issue #789)**

- Count, don't guard: the Python gates stay the sole ABP filter and now tally what they drop, bucketed `shape` (domain-shape rejects in `normalise()`) and `wire_cap` (#753 caps incl. the `reconcile()` fold-drop), per feed/group. Deliberate skip classes (comments, cosmetic rules, non-DNS `$options`, path/wildcard/IP anchors, `$badfilter`) tally zero.
- `build()` returns the tally; a chroot-relative `pfb_py_reject_stats.json` artifact is written atomically next to the built DBs; PHP reads its host-absolute twin after a DNSBL run and emits one `stage=entries` line per nonzero bucket. Python never logs the line itself — sinks stay PHP-only.

## Tests

- PHPUnit: formatter oracle (every stage token, hostile-value escaping, exact shapes), wrapper sink routing, `pfb_filter()` out-param contract red→green + non-opted back-compat pin, `pfb_emit_entry_reject_stats()` reader (nonzero emits, absent/corrupt/empty silent).
- pytest: tally oracle (exact `{shape: N, wire_cap: M}`), skip-classes-tally-zero pin, fold-drop attribution, `normalise()` contract preserved, artifact atomicity + chroot-relative path pin.
- Smoke (`-k validate_log`, 6 tests): canonical line per wired stage, `stage=entries` for a rejectable ABP fixture, healthy-feed zero-REJECT guards.

All red→green evidence is recorded in the per-phase handoffs under `.ADRs/ADR_48_Download_Validation_Logging/RESULTS/`.

## Acceptance

Per ADR §7, Accepted flips on a green CE + Plus live-VM fan-out of the `validate_log` smoke tests (dispatched from this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVWLiFeaGYpg178rFMeo7P


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer validation logging for download and feed processing, including consistent reject messages and detailed rejection categories.
  * Added reject-statistics reporting so rejection counts can be surfaced per feed and group.

* **Bug Fixes**
  * Improved handling of MIME, structural, and content-based rejection paths to reduce inconsistent or duplicate log output.
  * Tightened escaping and sanitization so log lines remain single-line and safe.

* **Tests**
  * Expanded automated coverage for logging, rejection handling, and reject-statistics emission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->