### PR TITLE
pfblockerng: probe the extracted payload in the ZIP inner-content MIME gate

### DIFF
--- a/.ADRs/ADR_46_Zip_Inner_Content_Hardening/ADR.md
+++ b/.ADRs/ADR_46_Zip_Inner_Content_Hardening/ADR.md
@@ -1,6 +1,6 @@
 # ADR-46: ZIP inner-content validation consistency and extraction-path hardening
 
-- **Status:** **Proposed** (2026-06-28; facts refreshed 2026-07-03 against `devel` — the §1 extraction inventory was corrected to THREE disk-writing sites, and the guard-scope question in §2.3 is an open fork; phase prompts not yet authored) — defense-in-depth; lower priority than ADR-45 (most of the original "re-enable the inner check" ask is already satisfied — see §1)
+- **Status:** **Proposed** (2026-06-28; facts refreshed 2026-07-03 against `devel` — the §1 extraction inventory was corrected to THREE disk-writing sites, and the guard-scope question in §2.3 is an open fork; phase prompts not yet authored) — defense-in-depth; lower priority than ADR-45 (most of the original "re-enable the inner check" ask is already satisfied — see §1) — **(facts refreshed 2026-07-04: the §1 "inner validation already active" premise was wrong — issue #808; the probe-target fix landed independently, narrowing this ADR to the member-name guard)**
 - **Date:** 2026-06-28
 - **Branch:** `adr/46-zip-inner-content-hardening` (off `devel`) / **Component(s):** `src/usr/local/pkg/pfblockerng/pfblockerng.inc`
 - **Target runtime:** PHP 8.3, FreeBSD / pfSense; `bsdtar` (libarchive)
@@ -16,11 +16,13 @@ The source review proposed three things for the ZIP path: **re-enable the inner-
 defences.** Reading the *current* `pfb_download()` rather than the pre-implementation
 spec, two of the three are already handled or infeasible:
 
-- **ZIP inner-content validation is already active** — after `tar -xOf` extraction the
-  ZIP branch **re-runs `PFB_FILTER_FILE_MIME` on the extracted payload**
-  (`pfb_download()` in `pfblockerng.inc`, ~:9209). So a ZIP whose *contents* are not an
-  allow-listed type is already rejected. The source review itself noted this
-  post-extraction check "is actually quite good."
+- **ZIP inner-content validation is now real — it was a no-op until issue #808's fix.** After
+  `tar -xOf` extraction the ZIP branch **re-runs `PFB_FILTER_FILE_MIME`**
+  (`pfb_download()` in `pfblockerng.inc`, ~:9469), but until issue #808 the re-check probed
+  `$input[1]` = `$file_download`, the ORIGINAL archive (already outer-MIME-allow-listed as
+  `application/zip`), never the extracted payload — a pure no-op, live-confirmed by the
+  ADR-48 fan-out. Issue #808's fix (landed on `devel`) repoints the probe at the extracted
+  file, so a ZIP whose *contents* are not an allow-listed type is now genuinely rejected.
 - **The `file -bZ` `_COMPRESSED` check cannot be re-enabled for ZIP.** libmagic's `-Z`
   decompresses a *single compressed stream* (gzip/bzip2/xz) and classifies the inner
   bytes; a **ZIP is a multi-member container**, not a single stream, so `-Z` does not
@@ -91,18 +93,18 @@ path is unchanged; the GeoIP/top-1M extraction still works for legitimate archiv
    left unchanged (no disk write, no traversal surface) but gains a one-line comment
    recording why no guard is needed there.
 
-4. **Formalise the inner-content comment.** Replace the disabled `_COMPRESSED` block's prose
-   with a precise statement: ZIP inner-content validation **is** the post-extraction
-   `PFB_FILTER_FILE_MIME` re-check; `file -bZ` is not used for ZIP because `-Z` does not
-   classify multi-member containers. Remove the "deferred to a future ADR" wording (this ADR
-   *is* that resolution).
+4. **Formalise the inner-content comment — SATISFIED by issue #808's fix, outside this ADR.**
+   The in-code comment above the post-extraction re-check now documents it as the ZIP
+   inner-content gate and explains why `-bZ` stays off (multi-member containers); no
+   "deferred to a future ADR" wording remains. This ADR's residual scope is items 1–3 (the
+   member-name guard) only.
 
 ### Per-area decision table
 
 | Area | Decision |
 |---|---|
-| ZIP inner-content gate | Keep the post-extraction `PFB_FILTER_FILE_MIME` re-check; document it as the gate |
-| `file -bZ` for ZIP | Stays off — `-Z` cannot classify a multi-member container (documented, not deferred) |
+| ZIP inner-content gate | **Satisfied (issue #808)** — post-extraction `PFB_FILTER_FILE_MIME` re-check now probes the extracted payload and is documented as the gate |
+| `file -bZ` for ZIP | **Satisfied (issue #808)** — stays off, now documented in-code: `-Z` cannot classify a multi-member container |
 | `tar -xOf` main path | Unchanged (stdout — no traversal surface); comment why |
 | `tar … -C` disk-writing paths (gzip GeoIP, UT1/blacklist, ZIP GeoIP/top-1M) | Add `pfb_archive_members_safe()` guard before extraction (scope per the §1.2 open fork) |
 | `pfb_archive_members_safe()` | New pure predicate: reject absolute / `..` / over-long member names |
@@ -157,12 +159,13 @@ path is unchanged; the GeoIP/top-1M extraction still works for legitimate archiv
 Add the pure predicate and pin its decision matrix (absolute / `..` / over-long → reject;
 benign → accept). No call-site change.
 
-### Phase 2 — Wire the guard before disk extraction + formalise the inner-content comment
+### Phase 2 — Wire the guard before disk extraction
 
 **Prompt:** `02_Wire_Guard_And_Document.txt`
 
-Call the guard before the GeoIP/top-1M `tar -xf -C`; reject on failure. Replace the disabled
-`_COMPRESSED` prose with the precise inner-validation statement. Smoke: a malicious-member
+Call the guard before the GeoIP/top-1M `tar -xf -C`; reject on failure. (The inner-content
+comment formalisation originally scoped here was satisfied by issue #808 — see §2 item 4;
+Phase 2 is now the guard-wiring only.) Smoke: a malicious-member
 archive is rejected; a legitimate multi-file archive still imports.
 
 ### Phase 3 — Smoke + accept

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9439,8 +9439,10 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			   the allow-list gate. On a stock pfSense box, /usr/bin/file already returns
 			   application/zip for real ZIP bytes (no false rejections occur without it);
 			   normalisation is defensive — it handles custom magic databases and live
-			   epub+zip-style archive types. The post-extraction inner-content MIME check
-			   below stays disabled — ZIP inner-content validation is deferred to a future ADR.
+			   epub+zip-style archive types. This branch stays disabled because file -bZ
+			   cannot classify a multi-member container (-Z decompresses a single stream);
+			   the post-extraction PFB_FILTER_FILE_MIME re-check below is the ZIP
+			   inner-content gate (issue #808).
 			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download')) {
 				return FALSE;
 			}
@@ -9460,13 +9462,13 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				exec("/usr/bin/tar -xOf {$file_dwn_esc} | /usr/bin/sed 's/,[[:space:]]/; /g' | /usr/bin/tr ',' '\n' > {$file_org_esc}", $output, $retval);
 			}
 
-			// Post-extraction content validation: re-run the MIME gate on the extracted
-			// file (the outer-container variant handling is covered by ADR-44's
-			// pfb_mime_normalise()).
+			// ZIP inner-content gate (issue #808): probe the EXTRACTED payload
+			// (orig_download), not the outer archive -- the outer container is
+			// already covered by ADR-44's pfb_mime_normalise().
 			$reject_detail = array();
-			if (!pfb_filter(array("{$file_org_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download', '', FALSE, $reject_detail)) {
+			if (!pfb_filter(array("{$file_org_esc}", "{$orig_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download', '', FALSE, $reject_detail)) {
 				pfb_validate_log($header, 'inner', 'inner_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
-				unlink_if_exists("{$file_org_esc}");
+				unlink_if_exists($file_download);
 				return FALSE;
 			}
 		}

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -2959,7 +2959,7 @@ def test_validate_log_zip_inner_reject_line(deployed_vm: SmokeVM, mock_feeds: _M
       feed=<hdr>_v4 stage=inner reason=inner_mime_not_allowed detected=application/pdf
       rc=0" appears in the pfB log.
     """
-    header = "iss808zin"
+    header = "issue808zin"
     entry_bytes = b"%PDF-1.4\n"
 
     buf = io.BytesIO()
@@ -2982,7 +2982,7 @@ def test_validate_log_zip_inner_reject_line(deployed_vm: SmokeVM, mock_feeds: _M
             f"the extracted-content probe would not reject — test inconclusive"
         )
 
-    feed_url = mock_feeds.register("iss808_zip_inner.zip", zip_bytes)
+    feed_url = mock_feeds.register("issue808_zip_inner.zip", zip_bytes)
     spec = h.IpCase(aliasname=header, feed_url=feed_url, header=header, family="v4")
     # feed= carries the on-box header, which the package suffixes with the
     # address family (_v4) -- see the structural test's docstring.

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -2852,13 +2852,13 @@ def test_validate_log_inner_reject_line(deployed_vm: SmokeVM, mock_feeds: _MockF
     """ADR-48 P3: the gzip pre-extraction compressed peek emits the canonical stage=inner line.
 
     Forces the inner stage through the gz ``file -bZ`` COMPRESSED-PEEK sub-path
-    (reason=compressed_mime_not_allowed). The zip POST-EXTRACTION sub-path
-    cannot be forced live: the re-run probes ``$input[1]`` = the ORIGINAL
-    archive (the extracted file rides in the legacy-unused ``$input[0]``), so
-    it always passes for a valid zip -- a pre-existing no-op tracked in issue
-    #808 (probe-target fix = ADR-46 inner-content scope, not ADR-48's
-    message-only scope). The first fan-out proved it live: a valid zip wrapping
-    a PDF payload produced NO inner reject on either edition.
+    (reason=compressed_mime_not_allowed). The zip POST-EXTRACTION sub-path is
+    covered separately by ``test_validate_log_zip_inner_reject_line`` below --
+    before issue #808's fix the re-run probed ``$input[1]`` = the ORIGINAL
+    archive (the extracted file rode in the legacy-unused ``$input[0]``), so it
+    always passed for a valid zip; the first fan-out proved that no-op live (a
+    valid zip wrapping a PDF payload produced NO inner reject on either
+    edition). The fix repoints the probe at the extracted payload.
 
     Built INLINE: a valid gzip stream is trivially portable (any gzip writer's
     output passes ``gunzip -t``), unlike the FreeBSD-libmagic-sensitive
@@ -2926,6 +2926,88 @@ def test_validate_log_inner_reject_line(deployed_vm: SmokeVM, mock_feeds: _MockF
             raise AssertionError(
                 f"expected a NEW line matching {marker!r} in {h.PFB_LOG} after the inner-reject "
                 f"gzip Force Update; count before={before} after={after}\n"
+                f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
+            )
+
+
+@pytest.mark.timeout(120)
+def test_validate_log_zip_inner_reject_line(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """Issue #808: the ZIP post-extraction re-check now probes the EXTRACTED payload, not the archive.
+
+    Before the fix, the ZIP inner-content re-check called ``pfb_filter(array($file_org_esc,
+    $file_download, ...), PFB_FILTER_FILE_MIME, ...)`` -- ``$input[1]`` was
+    ``$file_download``, the ORIGINAL zip archive (already outer-MIME-allow-listed as
+    application/zip), never the extracted file. So a zip wrapping a disallowed inner
+    payload sailed through with NO inner reject -- a pure no-op observed LIVE by the
+    ADR-48 fan-out (run 28700531268) on both CE 2.8 and Plus 26.03. The fix repoints the
+    probe at ``$orig_download`` (the extracted file), so this canonical stage=inner line
+    now fires for real.
+
+    Built INLINE: a single-member zip wrapping the same "%PDF-1.4\\n" byte string the
+    sibling gzip inner-reject test uses (also tests/php/PfbFilterRejectDetailTest.php's
+    fixture) -- file(1) reliably reports application/pdf for it via the plain "%PDF-"
+    text magic. The member name avoids ".xlsx" (would route to the xlsx-extraction
+    branch instead) and the payload has no commas (the tar|sed|tr extraction pipeline
+    must pass it through byte-intact for the re-probe to see the same PDF bytes).
+
+    Given the alias is absent and no canonical inner-reject line for this feed's header
+      exists yet (delta baseline).
+    When the case Force-Updates over the zip (outer MIME gate + structural probe both
+      pass -- valid application/zip -- extraction succeeds, then the post-extraction
+      re-check probes the extracted PDF payload and rejects it),
+    Then the alias remains absent AND a NEW line matching "pfb_validate: REJECT
+      feed=<hdr>_v4 stage=inner reason=inner_mime_not_allowed detected=application/pdf
+      rc=0" appears in the pfB log.
+    """
+    header = "iss808zin"
+    entry_bytes = b"%PDF-1.4\n"
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("payload.pdf", entry_bytes)
+    zip_bytes = buf.getvalue()
+
+    # On-box guards (skip-if-inconclusive): the outer gate must route to the ZIP
+    # branch at all, and the extracted-content probe must actually see application/pdf.
+    box_outer_mime = _box_mime_type(deployed_vm, zip_bytes)
+    if box_outer_mime != "application/zip":
+        pytest.skip(
+            f"zip bytes produced {box_outer_mime!r} on this box's file -b (not application/zip); "
+            f"the outer gate would not route to the ZIP branch — test inconclusive"
+        )
+    box_inner_mime = _box_mime_type(deployed_vm, entry_bytes)
+    if box_inner_mime != "application/pdf":
+        pytest.skip(
+            f"PDF payload produced {box_inner_mime!r} on this box's file -b (not application/pdf); "
+            f"the extracted-content probe would not reject — test inconclusive"
+        )
+
+    feed_url = mock_feeds.register("iss808_zip_inner.zip", zip_bytes)
+    spec = h.IpCase(aliasname=header, feed_url=feed_url, header=header, family="v4")
+    # feed= carries the on-box header, which the package suffixes with the
+    # address family (_v4) -- see the structural test's docstring.
+    marker = (
+        f"pfb_validate: REJECT feed={header}_v4 stage=inner reason=inner_mime_not_allowed detected=application/pdf rc=0"
+    )
+
+    # Given -- alias absent + delta baseline for this feed's canonical line.
+    assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the inner-reject zip feed"
+    before = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+
+    with h.CaseContext(deployed_vm, spec):
+        # When -- Force Update; the zip is structurally valid but the extracted-payload
+        # re-check rejects its inner PDF content.
+        tables_after = h.pfctl_tables(deployed_vm)
+        assert spec.alias not in tables_after, (
+            f"expected {spec.alias!r} absent after the inner-reject zip (post-extraction "
+            f"re-check must reject), found it present — tables: {tables_after}"
+        )
+        # Then -- a NEW canonical reject line was logged.
+        after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+        if not (after > before):
+            raise AssertionError(
+                f"expected a NEW line matching {marker!r} in {h.PFB_LOG} after the inner-reject "
+                f"zip Force Update; count before={before} after={after}\n"
                 f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
             )
 


### PR DESCRIPTION
## Summary

Fixes the no-op ZIP inner-content gate reported in #808: the post-extraction MIME re-check in `pfb_download()` probed `$input[1]` = `$file_download` — the **original ZIP archive** (by definition already allow-listed as `application/zip`) — while the extracted file rode in the legacy-unused `$input[0]`. Extracted content of a disallowed type was never rejected at this gate.

## Changes

- **`pfblockerng.inc`** — the re-check now probes `$orig_download` (the raw extracted-file path). The reject-path cleanup now unlinks `$file_download` (raw archive path): the extracted file is already unlinked inside the `PFB_FILTER_FILE_MIME` reject path, and the previous `unlink_if_exists("{$file_org_esc}")` passed a shell-quoted path that never matched a real file (a second no-op). Comments above the gate and in the disabled `_COMPRESSED` block updated to document the post-extraction re-check as *the* ZIP inner-content gate and why `file -bZ` stays off for ZIP.
- **`tests/smoke/test_smoke_feeds.py`** — new `test_validate_log_zip_inner_reject_line`: a valid single-member ZIP wrapping a PDF payload must be rejected with the canonical `stage=inner reason=inner_mime_not_allowed detected=application/pdf` line (ADR-48 format), alias absent. On-box MIME guards mirror the sibling gzip inner-reject test. The sibling test's "cannot be forced live" docstring claim is corrected.
- **`ADR_46_Zip_Inner_Content_Hardening/ADR.md`** — the §1 premise "ZIP inner-content validation is already active" was wrong (this issue proved the no-op); corrected, and the §2 comment-formalisation item + two decision-table rows marked satisfied by this fix. ADR-46's residual scope is the member-name guard.

## Red→green evidence

- **Red (pre-fix):** observed live by the ADR-48 fan-out (run 28700531268) on both CE 2.8 and Plus 26.03 — a valid ZIP wrapping a PDF produced no inner reject; documented in the new test's docstring.
- **Green (post-fix):** smoke dispatch on this branch (link in comments).

Regression risk is low: the allow-list includes `inode/x-empty` and the usual text types, so normal ZIP feeds (which extract to text) keep importing; the easylist/ipinfo host exceptions and octet-stream recovery are unchanged.

Fixes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfJUsCQkpFZxXufncGUS2f
