### PR TITLE
tests/smoke+ui: fix three false-red live-VM tests (#802, #804, #805)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2422,6 +2422,10 @@ _BASELINE_GLOBAL_KEYS = (
     # dispatch; leaked forward it silently disables dispatch for every later module
     # (bit test_smoke_apply_on_change — issue #805).
     "pfb_interval",
+    # ADR-40 apply-path mode: test_smoke_adr40 writes 'delta'/'auto'/'replace' via
+    # PfbConfig (General section, issue #804); unset so later modules read the
+    # box's own default (end-state is mode-invariant, but the apply path is not).
+    "pfb_alias_delta_mode",
     # Feed-host SSRF-guard allowlist: a module that allowlists the SLIRP mock net
     # (test_trigger_api / test_smoke_feeds) must not leak the exemption forward, or a
     # later module runs with the default-ON guard effectively disabled (false-green).

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2405,7 +2405,7 @@ _BASELINE_DEL_SECTIONS = (
 )
 # Behaviour toggles a case writes into CFG_GLOBAL (config/0). Derived from every config/0
 # write-site in this module + the apply/tick tests: the IP master switch (enable_cb), the
-# ADR-38 syslog toggle (log_syslog), the cron knobs (pfb_dailystart/pfb_reuse), the
+# ADR-38 syslog toggle (log_syslog), the cron knobs (pfb_dailystart/pfb_reuse/pfb_interval), the
 # managed-objects keep flag (pfb_keep), the ADR-11 aggregate selector (pfb_agg_types) and
 # the ADR-43 PfbConfig knobs (pfb_quiet_hours/pfb_tick_interval). Unset (not section-
 # deleted) so the section's install defaults survive.
@@ -2418,6 +2418,10 @@ _BASELINE_GLOBAL_KEYS = (
     "pfb_agg_types",
     "pfb_quiet_hours",
     "pfb_tick_interval",
+    # Update Frequency: test_log_rotate writes 'Disabled' to gate the tick's feed-cron
+    # dispatch; leaked forward it silently disables dispatch for every later module
+    # (bit test_smoke_apply_on_change — issue #805).
+    "pfb_interval",
     # Feed-host SSRF-guard allowlist: a module that allowlists the SLIRP mock net
     # (test_trigger_api / test_smoke_feeds) must not leak the exemption forward, or a
     # later module runs with the default-ON guard effectively disabled (false-green).

--- a/tests/smoke/test_smoke_adr40.py
+++ b/tests/smoke/test_smoke_adr40.py
@@ -327,14 +327,19 @@ def test_adr40_content_gate_fires_on_change(adr40_vm: SmokeVM) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# ADR-12 helper — set pfb_alias_delta_mode via CFG_IP_SETTINGS
+# ADR-40 helper — set pfb_alias_delta_mode via the config gateway
 # --------------------------------------------------------------------------- #
 
 
 def _set_delta_mode(vm: h.SmokeVM, mode: str, *, timeout: float = 60.0) -> None:
-    """Persist ``pfb_alias_delta_mode`` in the IP-settings config section.
+    """Persist ``pfb_alias_delta_mode`` through ``PfbConfig::write``.
 
     Mirrors the UI save path (pfblockerng_ip.php POST → PfbConfig::write).
+    The key is REGISTERED UNDER THE GENERAL SECTION (config/0), so the gateway
+    is the section-proof way to land it where ``PfbConfig::read`` looks: a
+    hand-rolled ``config_set_path`` into CFG_IP_SETTINGS wrote a value
+    production never read, so the apply path silently kept the box's own mode
+    — 'replace' on the grandfather-seeded smoke install (issue #804).
     Valid stored values: ``'auto'`` / ``'delta'`` / ``'replace'``.  An empty
     string is the absent-default for existing installs (reads to ``'auto'``
     via the PfbAliasDeltaMode adapter); the tests write the explicit token so
@@ -344,9 +349,8 @@ def _set_delta_mode(vm: h.SmokeVM, mode: str, *, timeout: float = 60.0) -> None:
     once per pass via ``PfbConfig::read('pfb_alias_delta_mode')``.
     """
     snippet = (
-        f"$ip = config_get_path({h._php_str(h.CFG_IP_SETTINGS)}, array());\n"
-        f"$ip['pfb_alias_delta_mode'] = {h._php_str(mode)};\n"
-        f"config_set_path({h._php_str(h.CFG_IP_SETTINGS)}, $ip);\n"
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
+        f"PfbConfig::write('pfb_alias_delta_mode', {h._php_str(mode)});\n"
         "write_config('pfBlockerNG smoke: set pfb_alias_delta_mode');\n"
         "echo 'OK';"
     )

--- a/tests/smoke/ui/test_browser_category_edit.py
+++ b/tests/smoke/ui/test_browser_category_edit.py
@@ -625,6 +625,9 @@ def test_alias_type_port_field_normalizes_network_alias_away(
         )
 
         # The wrong-type value was dropped -- normalized to '', not saved verbatim.
+        # config_get() reads absent and ''-valued keys identically, so this check alone
+        # cannot tell "normalized" from "rejected, row never written" -- the aliasname
+        # assert above is what rules the rejected case out. Keep it first.
         got_ports_in = helpers.config_get(vm, f"{base}/aliasports_in")
         assert got_ports_in == "", (
             f"expected the wrong-type alias to be normalized away\n"

--- a/tests/smoke/ui/test_browser_category_edit.py
+++ b/tests/smoke/ui/test_browser_category_edit.py
@@ -53,6 +53,7 @@ lazily via ``importorskip`` so collecting this module without it does not error.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote
@@ -382,24 +383,46 @@ def test_addrow_clones_a_source_row_and_renumbers(
 
 
 # --------------------------------------------------------------------------- #
-# Alias-type validation (#356): wrong alias type in a port/address field is
-# rejected by the server with the expected error string.
+# Alias-type normalization (#802, sibling of #676/#636): a wrong-type alias
+# submitted to a port/address field is silently normalized away, not rejected.
 #
-# Implementation note: the alias-type check (``pfb_alias_field_type_ok``) fires
-# on the SAVE round-trip (a PHP server validation), not purely in JS.  Driving
-# it through a Playwright browser would require navigating away from the page on
-# submit (the error page replaces the form page) and then back — a brittle,
-# slow flow that is harder to reason about than a direct HTTP POST.  The HTTP
-# approach (webui.session.post) is the same mechanism ``test_category_edit.py``
-# uses for every save flow and is the accepted pattern in this suite.  We use
-# ``webui`` here (its session is already authenticated, shared, and correct) with
-# a fresh CSRF token harvested from a real GET — the same pattern as
-# ``_post_form`` in ``test_category_edit.py``.
+# The save round-trip's "Validate Select field options" whitelist sanitiser
+# (pfblockerng_category_edit.php ~479-513) resets any field whose submitted
+# value is not a key in its type-specific options dropdown to '' BEFORE
+# ``pfb_adv_alias_field_errors()`` (~620) ever runs -- so a wrong-type alias
+# name never reaches validation as an error, it is dropped. This is the same
+# normalize-before-validate contract already pinned for the sibling IP-settings
+# page by ``tests/php/IpSettingsAdvAliasValidationTest.php``.
+#
+# Implementation note: driving the save through a Playwright browser would
+# require navigating away from the page on submit (the response page replaces
+# the form page) and then back — a brittle, slow flow that is harder to reason
+# about than a direct HTTP POST. The HTTP approach (webui.session.post) is the
+# same mechanism ``test_category_edit.py`` uses for every save flow and is the
+# accepted pattern in this suite. We use ``webui`` here (its session is already
+# authenticated, shared, and correct) with a fresh CSRF token harvested from a
+# real GET — the same pattern as ``_post_form`` in ``test_category_edit.py``.
 # --------------------------------------------------------------------------- #
 
 _CATEGORY_PAGE = "/pfblockerng/pfblockerng_category_edit.php"
 _SAVE_TIMEOUT = 120.0
 _CFG_IPV4 = "installedpackages/pfblockernglistsv4/config"
+
+# pfSense's print_input_errors() (guiconfig.inc) renders one non-nested
+# <div class="alert alert-danger input-errors">...</div> per response.
+_INPUT_ERRORS_RE = re.compile(r"<div[^>]*\binput-errors\b[^>]*>.*?</div>", re.DOTALL)
+
+
+def _input_errors_block(body: str) -> str:
+    """Extract pfSense's ``print_input_errors()`` alert block from a save-response body.
+
+    Pulling just that block out of the full page keeps failure diagnostics readable
+    (CLAUDE.md "On failure, print expected vs actual"). Absent the div -- the save carried
+    no validation error -- returns an explicit marker so a diagnostic never reads as "the
+    response was empty".
+    """
+    match = _INPUT_ERRORS_RE.search(body)
+    return match.group(0) if match else "<no input-errors block in response>"
 
 
 def _post_ipv4_form(webui: WebUI, payload: dict[str, str]) -> str:
@@ -511,49 +534,53 @@ def _ipv4_payload(rowid: int, aliasname: str, **overrides: str) -> dict[str, str
     return payload
 
 
-def test_alias_type_port_field_rejects_network_alias(
+def test_alias_type_port_field_normalizes_network_alias_away(
     webui: "WebUI",
     smoke_vm: helpers.SmokeVM,
     browser_page: "Page",  # noqa: ARG001
     screenshot_dir: Path,  # noqa: ARG001
 ) -> None:
-    """Saving a network alias in ``aliasports_in`` (a port field) is rejected.
+    """Saving a network alias into ``aliasports_in`` is silently normalized away, not rejected.
 
-    Scenario: ``pfb_alias_field_type_ok()`` validates that port alias fields
-    only accept port-type aliases. Supplying a network alias produces the error
-    ``Must use a Port-type alias`` in the response; a valid port alias in the
-    same field is accepted.
+    Scenario: the category_edit save round-trip runs TWO steps in order -- first a "Validate
+    Select field options" whitelist sanitiser (pfblockerng_category_edit.php ~479-513), then
+    ``pfb_adv_alias_field_errors($_POST)`` (~620). ``$options_aliasports_in`` is built from
+    PORT-type aliases only (~419-426), so a NETWORK-type alias name is never a key in it: the
+    whitelist step resets ``$_POST['aliasports_in']`` to ``''`` BEFORE the validator ever runs,
+    so ``pfb_adv_alias_field_errors()`` sees an empty field and emits nothing -- the save
+    proceeds and the wrong-type value is dropped, not rejected.
 
     Background:
-        Issue #356 added ``pfb_alias_field_type_ok()`` which returns FALSE when
-        an address-type alias (``alias_get_type() === 'network'``) is passed to
-        a port field (``aliasports_*``). The save handler converts that to an
-        ``$input_errors`` entry whose text matches ``'Must use a Port-type alias'``.
-        A browser form-submit round-trip would navigate away from the page, making
-        it fragile to drive with Playwright; the server-side validation is
-        equivalently exercised through the authenticated HTTP session (the same
-        mechanism ``test_category_edit.py`` uses for all save flows).
+        This is the same two-step, normalize-before-validate contract already pinned for the
+        sibling IP-settings page by ``tests/php/IpSettingsAdvAliasValidationTest.php`` (#676,
+        sibling of #636): "a non-existent or wrong-type value never reaches validation as an
+        error -- it is reset to '' and saved empty". Issue #802 is this same behaviour on
+        category_edit's own save round-trip: the old oracle here expected a loud
+        ``'Must use a Port-type alias'`` rejection that the page, by this design, never emits
+        on this path -- it never passed against a live VM.
 
     Given:
         - A network alias ``smkbwtypenet`` exists in the firewall config.
         - A port alias ``smkbwtypeport`` exists in the firewall config.
-        - The target IPv4 rowid is free.
-    When (reject):
-        POST the IPv4 save with ``aliasports_in=smkbwtypenet`` (network alias
-        in a port field) and ``autoports_in=on``, ``autoproto_in=tcp``.
-    Then (reject):
-        - The response body contains ``Must use a Port-type alias``
-          (server validation error — the config is NOT written).
+        - The target IPv4 rowid is free (no ``aliasports_in`` set yet).
+    When (normalize):
+        POST the IPv4 save with ``aliasports_in=smkbwtypenet`` (a network alias in a port
+        field), ``autoports_in=on``, ``autoproto_in=tcp``.
+    Then (normalize):
+        - The response contains NEITHER ``Must use a Port-type alias`` NOR
+          ``Must use an existing Alias`` -- the value never reaches validation as an error.
+        - The save WENT THROUGH: ``aliasname`` is written (a rejected save writes nothing).
+        - The wrong-type value was dropped: ``aliasports_in`` reads back as ``''``.
     When (accept):
-        POST the same payload with ``aliasports_in=smkbwtypeport`` (correct
-        port alias in the port field).
+        POST the same payload with ``aliasports_in=smkbwtypeport`` (a correct port alias).
     Then (accept):
-        - The response body does NOT contain ``Must use a Port-type alias``.
-        - config.xml stores ``aliasports_in='smkbwtypeport'``.
+        - The response contains no alias-type error.
+        - ``aliasports_in`` reads back as ``smkbwtypeport``.
     """
     vm = smoke_vm
     net_alias = "smkbwtypenet"
     port_alias = "smkbwtypeport"
+    aliasname = "smkbwtype"
     rowid = _free_rowid_ipv4(vm)
     base = f"{_CFG_IPV4}/{rowid}"
 
@@ -569,42 +596,62 @@ def test_alias_type_port_field_rejects_network_alias(
             f"precondition: rowid {rowid} not free (aliasports_in already set)"
         )
 
-        # REJECT: network alias supplied to a port field -> server validation error.
-        reject_body = _post_ipv4_form(
+        # NORMALIZE: a network alias in a port field is silently dropped, not rejected.
+        norm_body = _post_ipv4_form(
             webui,
             _ipv4_payload(
                 rowid,
-                "smkbwtype",
+                aliasname,
                 autoports_in="on",
                 autoproto_in="tcp",
                 aliasports_in=net_alias,
             ),
         )
-        assert "Must use a Port-type alias" in reject_body, (
-            f"expected 'Must use a Port-type alias' error in response when a network alias "
-            f"is used in a port field, but it was absent (first 500 chars: {reject_body[:500]!r})"
-        )
-        # Config must NOT have been written (the error aborted the save).
-        assert helpers.config_get(vm, f"{base}/aliasports_in") == "", (
-            "aliasports_in must not be written when the save is rejected by alias-type validation"
+        for error in ("Must use a Port-type alias", "Must use an existing Alias"):
+            assert error not in norm_body, (
+                f"expected NO {error!r} error -- the whitelist sanitiser resets a wrong-type "
+                f"alias to '' before pfb_adv_alias_field_errors() ever runs, so this value "
+                f"never reaches validation as an error.\n"
+                f"  response input-errors block: {_input_errors_block(norm_body)}"
+            )
+
+        # The save WENT THROUGH -- a rejected save would write nothing at all.
+        got_aliasname = helpers.config_get(vm, f"{base}/aliasname")
+        assert got_aliasname == aliasname, (
+            f"expected the save to go through (a rejected save writes nothing)\n"
+            f"  expected aliasname: {aliasname!r}\n"
+            f"  actual aliasname  : {got_aliasname!r}\n"
+            f"  response input-errors block: {_input_errors_block(norm_body)}"
         )
 
-        # ACCEPT: correct port alias in the port field -> no error, config written.
+        # The wrong-type value was dropped -- normalized to '', not saved verbatim.
+        got_ports_in = helpers.config_get(vm, f"{base}/aliasports_in")
+        assert got_ports_in == "", (
+            f"expected the wrong-type alias to be normalized away\n"
+            f"  expected aliasports_in: ''\n"
+            f"  actual aliasports_in  : {got_ports_in!r}"
+        )
+
+        # ACCEPT: a correct port alias in the port field is saved as-is (unchanged semantics).
         accept_body = _post_ipv4_form(
             webui,
             _ipv4_payload(
                 rowid,
-                "smkbwtype",
+                aliasname,
                 autoports_in="on",
                 autoproto_in="tcp",
                 aliasports_in=port_alias,
             ),
         )
         assert "Must use a Port-type alias" not in accept_body, (
-            "expected no alias-type error when a port alias is used in a port field"
+            f"expected no alias-type error when a port alias is used in a port field\n"
+            f"  response input-errors block: {_input_errors_block(accept_body)}"
         )
-        assert helpers.config_get(vm, f"{base}/aliasports_in") == port_alias, (
-            f"aliasports_in was not written after a valid save with port alias {port_alias!r}"
+        got_accept_ports_in = helpers.config_get(vm, f"{base}/aliasports_in")
+        assert got_accept_ports_in == port_alias, (
+            f"expected aliasports_in to be written after a valid save\n"
+            f"  expected aliasports_in: {port_alias!r}\n"
+            f"  actual aliasports_in  : {got_accept_ports_in!r}"
         )
     finally:
         _del_rowid_ipv4(vm, rowid)


### PR DESCRIPTION
Batch fix for three live-VM suite failures found during #799/#582 validation. All three are test-side; no `src/` changes. Triage of the fourth batch member (#815) concluded invalid — closed with rationale, no change.

## One commit per issue

- **#805 — `tests/smoke: reset pfb_interval in the cross-module baseline`**: `test_log_rotate`'s module fixture (8e5b5761) writes `pfb_interval='Disabled'` and the cross-module baseline never unset it, so every later module ticked with the feed cron gated off — all four `test_smoke_apply_on_change` tests failed with the ledger stuck at `{last_run: 0, next_due: 0}`. The #573 anchoring change suspected in the issue is innocent (`mark_ran_anchored` with `next_due=0` is observably identical to the old `mark_ran`). Fix: add `pfb_interval` to `_BASELINE_GLOBAL_KEYS`.
- **#804 — `tests/smoke: write pfb_alias_delta_mode through PfbConfig`**: `_set_delta_mode` hand-rolled a `config_set_path` into the IP-settings section, but the key is registered under General — production never saw the test's `'delta'` and applied the box's grandfathered `'replace'`. Not a window regression: the delta/replace path assertions were born in 609b84a2 (after the last green nightly), so their first execution exposed a latent arrange bug. Fix: persist via `PfbConfig::write` (the UI save path), and unset the key in the baseline so the General-section write cannot leak into later modules.
- **#802 — `tests/ui: pin silent alias-type normalization on category_edit save`**: the save handler's select-options whitelist sanitiser resets a not-in-options `aliasports_in` value to `''` **before** `pfb_adv_alias_field_errors()` runs, so a wrong-type alias is silently dropped and the save succeeds — the page never emits `'Must use a Port-type alias'` on this path. That normalize-before-validate contract is already pinned for the sibling IP-settings page (`IpSettingsAdvAliasValidationTest`, #676). The browser test's loud-rejection oracle never passed on a live run; rewritten to pin the real semantics (save succeeds, value dropped, no error), renamed accordingly, with failure diagnostics that extract the pfSense input-errors block.

## Live-VM evidence (this branch)

- smoke.yml run 28702168980 — `test_log_rotate or test_smoke_adr40 or test_smoke_apply_on_change`: **16 passed** (log_rotate deliberately included and collected *before* apply_on_change, so the #805 leak path was genuinely exercised, not dodged).
- ui-tests.yml run 28702174268 — browser tier, the rewritten #802 test: **1 passed** on the live CE leg.
- Off-box: `python -m pytest` 2122 passed; ruff clean.

The red baseline is the cited nightly runs (28646758406, 28653687575, 28699362798) — all three failures reproduce on `devel` there and are green here.

Fixes #802
Fixes #804
Fixes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ooLjvBBm6oznTBUg9mxVF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of alias settings so browser saves now clear invalid alias types instead of blocking the save.
  * Preserved the selected alias value correctly across reloads when using the matching type.
  * Prevented certain configuration settings from carrying over between smoke-test flows, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->