### PR TITLE
Fix the #582 follow-up batch: feed-log scoping, ADR-41 P4 live wiring, anchored DoT matcher, syslog dst match

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8790,6 +8790,30 @@ function pfb_feed_host_allowed($host, &$reason, &$pinned) {
 }
 
 
+// Issue #811: shared entry-reject logger. When a feed URL fails PFB_FILTER_URL vetting,
+// pfb_filter() logs its reject to error.log only — so when the CAUSE is the feed-host
+// guard (an internal-resolving host), the reason never reaches the main log. Every
+// entry-reject site calls this to re-run the guard and, iff the guard is why vetting
+// failed, land the same header-scoped "[ header ] <reason> — skipped" line the
+// fetch-time gates in pfb_download() emit. Any other rejection reason logs nothing here.
+function pfb_log_feed_host_reject($list_url, $header, $logtype) {
+
+	if (!pfb_feed_filter_enabled()) {
+		return;
+	}
+	$entry_host = parse_url($list_url, PHP_URL_HOST) ?: '';
+	if ($entry_host === '') {
+		return;
+	}
+	$entry_reason = '';
+	$entry_pinned = '';
+	if (!pfb_feed_host_allowed($entry_host, $entry_reason, $entry_pinned)) {
+		$log = "\n[ {$header} ] {$entry_reason} \xe2\x80\x94 skipped\n";
+		pfb_logger("{$log}", "{$logtype}");
+	}
+}
+
+
 // Resolve a (possibly relative) HTTP redirect Location against the URL it was
 // returned from, then re-run the feed-host guard on the redirect target so a
 // redirect cannot send the fetch to a non-permitted address. Returns FALSE when
@@ -8969,6 +8993,10 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		}
 	}
 	elseif (!pfb_filter($list_url, PFB_FILTER_URL, 'pfb_download_failure')) {
+		// Issue #811: land the header-scoped, reason-bearing skip line in the main log
+		// when the feed-host guard is why entry vetting failed (pfb_filter's own reject
+		// line goes to error.log only). See pfb_log_feed_host_reject().
+		pfb_log_feed_host_reject($list_url, $header, $logtype);
 		pfb_logger("\n Failed", 2);
 		return FALSE;
 	}
@@ -9092,6 +9120,12 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			$feed_scheme	= strtolower($url_parts['scheme'] ?? '');
 			$feed_reason	= '';
 			$feed_pinned	= '';
+			// Fetch-time rebind (DNS-rebind/TOCTOU) re-check: entry vetting already ran
+			// this same guard (pfb_filter -> pfb_feed_host_allowed) before the download
+			// was scheduled. Re-resolving here and pinning to THIS verdict's IP is what
+			// catches a host whose resolution changed since -- statically unreachable
+			// otherwise, since a host still resolving the same way was already rejected
+			// at entry and never gets here.
 			if ($feed_filter &&
 			    !pfb_feed_host_allowed($feed_host, $feed_reason, $feed_pinned)) {
 				$log = "\n[ {$header} ] {$feed_reason} \xe2\x80\x94 skipped\n";

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8801,6 +8801,15 @@ function pfb_log_feed_host_reject($list_url, $header, $logtype) {
 	if (!pfb_feed_filter_enabled()) {
 		return;
 	}
+	// Only speak for the guard when the URL would have REACHED the guard: pfb_filter()
+	// rejects a disallowed scheme before ever consulting pfb_feed_host_allowed(), so a
+	// bad-scheme URL whose host happens to resolve internally must NOT be attributed to
+	// the SSRF guard. Mirror pfb_filter()'s scheme allow-list (the host::module rsync
+	// form has no scheme and is covered by pfb_download()'s own rsync gate instead).
+	$entry_scheme = strtolower((string) (parse_url($list_url, PHP_URL_SCHEME) ?: ''));
+	if (!in_array($entry_scheme, array('http', 'https', 'rsync', 'ftp'), TRUE)) {
+		return;
+	}
 	$entry_host = parse_url($list_url, PHP_URL_HOST) ?: '';
 	if ($entry_host === '') {
 		return;

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -464,6 +464,11 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 		}
 	}
 	elseif (!pfb_filter($list_url, PFB_FILTER_URL, 'php')) {
+		// Issue #811: in the update flow this reject fires BEFORE any download is
+		// scheduled, so pfb_download()'s entry/fetch gates never run — land the
+		// header-scoped feed-host skip line here too (no-op unless the guard is
+		// why vetting failed). The line below stays for non-guard rejects.
+		pfb_log_feed_host_reject($list_url, $header, 1);
 		pfb_logger("\n Invalid URL. Terminating Download! [ {$list_url} ]\n", 1);
 		return;
 	}
@@ -526,7 +531,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 			// to xxh128 there without touching this call site).
 			$pfb['cron_update'] = pfb_local_feed_changed($list_download, $local_file);
 			if (!$pfb['cron_update']) {
-				$log = "  ( local feed unchanged )\tUpdate not required\n";
+				$log = "[ {$header} ] ( local feed unchanged )\tUpdate not required\n";
 				pfb_logger("{$log}", 1);
 			}
 		}
@@ -567,7 +572,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 
 			if ($probe_status === '304') {
 				// Server confirmed not-modified via conditional GET → no re-ingest needed.
-				$log = "\n\t\t\t\t( 304 not modified )\tUpdate not required\n";
+				$log = "\n[ {$header} ] ( 304 not modified )\tUpdate not required\n";
 				pfb_logger("{$log}", 1);
 				unlink_if_exists("{$pfborig}/{$header}.md5.raw");
 				// Persist any refreshed validators from the 304 response.
@@ -588,7 +593,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 				$changed = pfb_conditional_get_decision($probe_status, $body_hash, $persisted_hash);
 
 				if ($changed) {
-					$log = "\n\t\t\t\t( content changed )\tUpdate found\n";
+					$log = "\n[ {$header} ] ( content changed )\tUpdate found\n";
 					pfb_logger("{$log}", 1);
 					// Persist the validators from this 200 response so the next run
 					// can send a conditional GET.
@@ -598,7 +603,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 					return;
 				}
 				else {
-					$log = "\n\t\t\t\t( content unchanged )\tUpdate not required\n";
+					$log = "\n[ {$header} ] ( content unchanged )\tUpdate not required\n";
 					pfb_logger("{$log}", 1);
 					unlink_if_exists("{$pfborig}/{$header}.md5.raw");
 					// Refresh validators even on a spurious 200 so the next run can

--- a/tests/php/PfbDownloadEntryVettingSkipLogTest.php
+++ b/tests/php/PfbDownloadEntryVettingSkipLogTest.php
@@ -191,6 +191,62 @@ final class PfbDownloadEntryVettingSkipLogTest extends TestCase
 	}
 
 	/**
+	 * Entry vetting rejects the URL for an UNRELATED reason (a disallowed URL
+	 * scheme) while the host resolves INTERNALLY -- the combination that could
+	 * misattribute the rejection to the SSRF guard: pfb_filter() failed on the
+	 * scheme check (it never consulted the guard), yet a bare guard re-check
+	 * would also reject this host. The skip line must NOT appear -- the helper
+	 * only speaks for the guard when the URL would have reached it (the scheme
+	 * gate mirrors pfb_filter()'s allow-list).
+	 */
+	public function testEntryRejectionOnSchemeWithInternalHostLogsNoSkipLine(): void
+	{
+		// Given a host that resolves to a non-public, non-allowlisted address.
+		$GLOBALS['pfb_test_resolve_map']['internal.scheme.vet.'] = [
+			['type' => 'A', 'data' => '10.20.30.43'],
+		];
+		$log = $this->tempFile('pfb_download_entry_log_');
+		$GLOBALS['pfb']['log'] = $log;
+		$GLOBALS['pfb']['errlog'] = $this->tempFile('pfb_download_entry_errlog_');
+
+		// When pfb_download() is called with a disallowed scheme on that host --
+		// pfb_filter() rejects on the scheme check, never reaching the guard.
+		$response_meta = null;
+		$result = pfb_download(
+			'gopher://internal.scheme.vet/list.txt',
+			'/tmp/pfb_entry_vet_test3',
+			FALSE,
+			'entryvettest3',
+			'',
+			2,
+			'',
+			300,
+			'',
+			'',
+			'',
+			FALSE,
+			$response_meta
+		);
+
+		// Then the download is refused ...
+		$this->assertFalse($result, 'pfb_download must refuse an invalid-scheme URL');
+
+		// ... and the main log carries NO guard skip line even though the host
+		// is internal -- the guard was not why vetting failed.
+		$logged = (string) file_get_contents($log);
+		$this->assertStringNotContainsString(
+			'skipped',
+			$logged,
+			"expected NO guard skip line when the scheme check, not the guard, rejected; got <{$logged}>"
+		);
+		$this->assertStringContainsString(
+			'Failed',
+			$logged,
+			'the pre-existing bare failure line must still fire'
+		);
+	}
+
+	/**
 	 * Helper-direct (the #811 live fixup): pfb_log_feed_host_reject() is what
 	 * every entry-reject site calls -- including pfb_update_check() in the www
 	 * script the harness cannot load. An internal-resolving URL logs the exact

--- a/tests/php/PfbDownloadEntryVettingSkipLogTest.php
+++ b/tests/php/PfbDownloadEntryVettingSkipLogTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Entry URL-vetting rejection visibility (issue #811). When pfb_filter()
+ * rejects a feed URL at an entry gate, the reason-bearing line lands in
+ * error.log ONLY (pfb_filter's own logtype-6 call) and the fetch-time gate
+ * that WOULD log a header-scoped "[ header ] <reason> -- skipped" line to the
+ * main log is statically unreachable (the caller returns before any download).
+ * #811's shared helper pfb_log_feed_host_reject() re-runs the SAME guard
+ * (pfb_feed_host_allowed) at every entry-reject site -- pfb_download()'s entry
+ * branch AND pfb_update_check()'s upstream reject (pfblockerng.php, the site
+ * the update flow actually hits; the live #811 fixup) -- landing the line in
+ * the MAIN log iff the guard is why vetting failed.
+ *
+ * pfb_download() as a whole is not off-appliance unit-testable (curl/exec),
+ * but its entry early-return path needs neither, so it is exercised directly.
+ * pfb_update_check() lives in a www script the harness cannot load -- its call
+ * site is covered by the helper-direct tests plus the live smoke test
+ * (test_feed_internal_filter_blocks_then_allowlist_exempts).
+ *
+ * Scenario: an internal-resolving feed host rejected at entry vetting becomes
+ * ALSO visible in the main log, header-scoped and reason-bearing -- but only
+ * when the guard itself is why entry vetting failed.
+ *   Background:
+ *     Given the feed-host filter is enabled (default ON) and the allowlist is empty
+ *     And the resolver is driven by $GLOBALS['pfb_test_resolve_map']
+ */
+#[CoversFunction('pfb_log_feed_host_reject')]
+#[CoversFunction('pfb_download')]
+#[CoversFunction('pfb_feed_host_allowed')]
+#[CoversFunction('pfb_feed_filter_enabled')]
+final class PfbDownloadEntryVettingSkipLogTest extends TestCase
+{
+	/** @var string[] temp files to remove in tearDown */
+	private array $tmpfiles = [];
+
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_resolve_map'] = [];
+		$GLOBALS['pfb_test_configured_ips'] = [];
+		foreach (['log', 'errlog', 'pnow', 'runlog', 'runlog_active'] as $k) {
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
+		}
+		// A stray 'runlog_active' from an earlier test must not mirror our writes
+		// into a third file this test never provisions.
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['config'], $GLOBALS['pfb_test_resolve_map'], $GLOBALS['pfb_test_configured_ips']);
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === false) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+		foreach ($this->tmpfiles as $f) {
+			if (is_file($f)) {
+				$this->assertTrue(unlink($f), "failed to remove temp file {$f}");
+			}
+		}
+		$this->tmpfiles = [];
+	}
+
+	private function tempFile(string $prefix): string
+	{
+		$path = tempnam(sys_get_temp_dir(), $prefix);
+		$this->assertNotFalse($path, "could not create temp file for {$prefix}");
+		$this->tmpfiles[] = $path;
+		return $path;
+	}
+
+	/**
+	 * Entry vetting rejects an internal-resolving feed host -- the guard's OWN
+	 * verdict is the reason pfb_filter() failed. The MAIN log now carries
+	 * "[ header ] <reason> -- skipped" in addition to the pre-existing bare
+	 * "\n Failed" -- proving the new line, not merely that something failed
+	 * (pre-#811 code never wrote this line to the main log).
+	 */
+	public function testInternalHostRejectionLogsHeaderScopedSkipLineToMainLog(): void
+	{
+		// Given a host that resolves to a non-public, non-allowlisted address.
+		$GLOBALS['pfb_test_resolve_map']['internal.entry.vet.'] = [
+			['type' => 'A', 'data' => '10.20.30.40'],
+		];
+		$log = $this->tempFile('pfb_download_entry_log_');
+		$GLOBALS['pfb']['log'] = $log;
+		$GLOBALS['pfb']['errlog'] = $this->tempFile('pfb_download_entry_errlog_');
+
+		// When pfb_download() is called on that URL (a plain remote format, so
+		// entry vetting takes the PFB_FILTER_URL elseif branch).
+		$response_meta = null;
+		$result = pfb_download(
+			'https://internal.entry.vet/list.txt',
+			'/tmp/pfb_entry_vet_test',
+			FALSE,
+			'entryvettest',
+			'',
+			2,
+			'',
+			300,
+			'',
+			'',
+			'',
+			FALSE,
+			$response_meta
+		);
+
+		// Then the download is refused ...
+		$this->assertFalse($result, 'pfb_download must refuse a URL rejected at entry vetting');
+
+		// ... and the MAIN log carries the header-scoped, reason-bearing skip
+		// line (issue #811), alongside the pre-existing bare failure line.
+		$logged = (string) file_get_contents($log);
+		$this->assertStringContainsString(
+			"[ entryvettest ] feed host resolves to a non-permitted address \xe2\x80\x94 skipped",
+			$logged,
+			"expected the header-scoped skip line in the main log, got <{$logged}>"
+		);
+		$this->assertStringContainsString(
+			'Failed',
+			$logged,
+			'the pre-existing bare failure line must stay untouched'
+		);
+	}
+
+	/**
+	 * Entry vetting rejects the URL for an UNRELATED reason (a disallowed URL
+	 * scheme) while the host itself resolves to a PUBLIC address the guard
+	 * would allow: the guard-specific skip line must NOT appear -- proving the
+	 * new logging is scoped to the guard's OWN verdict, not "pfb_filter
+	 * rejected for any reason".
+	 */
+	public function testEntryRejectionForOtherReasonWithPublicHostLogsNoSkipLine(): void
+	{
+		// Given a host that resolves to a public address.
+		$GLOBALS['pfb_test_resolve_map']['public.entry.vet.'] = [
+			['type' => 'A', 'data' => '203.0.113.20'],
+		];
+		$log = $this->tempFile('pfb_download_entry_log_');
+		$GLOBALS['pfb']['log'] = $log;
+		$GLOBALS['pfb']['errlog'] = $this->tempFile('pfb_download_entry_errlog_');
+
+		// When pfb_download() is called with a disallowed scheme (gopher) --
+		// pfb_filter() rejects on the scheme check, before ever consulting the
+		// feed-host guard for its own verdict.
+		$response_meta = null;
+		$result = pfb_download(
+			'gopher://public.entry.vet/list.txt',
+			'/tmp/pfb_entry_vet_test2',
+			FALSE,
+			'entryvettest2',
+			'',
+			2,
+			'',
+			300,
+			'',
+			'',
+			'',
+			FALSE,
+			$response_meta
+		);
+
+		// Then the download is refused ...
+		$this->assertFalse($result, 'pfb_download must refuse an invalid-scheme URL');
+
+		// ... but the main log carries NO guard skip line -- the guard itself
+		// would have allowed this host, so #811's re-check must not fire.
+		$logged = (string) file_get_contents($log);
+		$this->assertStringNotContainsString(
+			'skipped',
+			$logged,
+			"expected NO guard skip line for a public host rejected on an unrelated ground, got <{$logged}>"
+		);
+		$this->assertStringContainsString(
+			'Failed',
+			$logged,
+			'the pre-existing bare failure line must still fire'
+		);
+	}
+
+	/**
+	 * Helper-direct (the #811 live fixup): pfb_log_feed_host_reject() is what
+	 * every entry-reject site calls -- including pfb_update_check() in the www
+	 * script the harness cannot load. An internal-resolving URL logs the exact
+	 * header-scoped, reason-bearing line at the caller's logtype.
+	 */
+	public function testHelperLogsHeaderScopedSkipLineForInternalHost(): void
+	{
+		// Given a host that resolves to a non-public, non-allowlisted address.
+		$GLOBALS['pfb_test_resolve_map']['internal.helper.vet.'] = [
+			['type' => 'A', 'data' => '10.20.30.41'],
+		];
+		$log = $this->tempFile('pfb_helper_log_');
+		$GLOBALS['pfb']['log'] = $log;
+		$GLOBALS['pfb']['errlog'] = $this->tempFile('pfb_helper_errlog_');
+
+		// When the helper runs at logtype 1 (pfb_update_check's logtype).
+		pfb_log_feed_host_reject('http://internal.helper.vet/list.txt', 'helpervettest', 1);
+
+		// Then the main log carries the exact header-scoped skip line.
+		$logged = (string) file_get_contents($log);
+		$this->assertStringContainsString(
+			"[ helpervettest ] feed host resolves to a non-permitted address \xe2\x80\x94 skipped",
+			$logged,
+			"expected the header-scoped skip line in the main log, got <{$logged}>"
+		);
+	}
+
+	/**
+	 * Helper-direct negative: a URL whose host the guard ALLOWS (public) logs
+	 * nothing -- the helper reports the guard's own verdict, never a blanket
+	 * "vetting failed" message.
+	 */
+	public function testHelperLogsNothingForPublicHost(): void
+	{
+		// Given a host that resolves to a public address.
+		$GLOBALS['pfb_test_resolve_map']['public.helper.vet.'] = [
+			['type' => 'A', 'data' => '203.0.113.21'],
+		];
+		$log = $this->tempFile('pfb_helper_log_');
+		$GLOBALS['pfb']['log'] = $log;
+
+		// When the helper runs.
+		pfb_log_feed_host_reject('http://public.helper.vet/list.txt', 'helpervettest2', 1);
+
+		// Then nothing is logged.
+		$this->assertSame(
+			'',
+			(string) file_get_contents($log),
+			'a guard-allowed host must log no skip line'
+		);
+	}
+
+	/**
+	 * Helper-direct negative: with the feed-host filter toggled OFF the helper
+	 * is a no-op even for an internal-resolving host -- the guard is opt-out,
+	 * and the skip line must follow the same toggle as the gates it mirrors.
+	 */
+	public function testHelperLogsNothingWhenFilterDisabled(): void
+	{
+		// Given an internal-resolving host but the filter toggled OFF.
+		$GLOBALS['pfb_test_resolve_map']['internal.helper.off.'] = [
+			['type' => 'A', 'data' => '10.20.30.42'],
+		];
+		config_set_path('installedpackages/pfblockerng/config/0/pfb_feed_internal_filter', 'off');
+		$log = $this->tempFile('pfb_helper_log_');
+		$GLOBALS['pfb']['log'] = $log;
+
+		// When the helper runs.
+		pfb_log_feed_host_reject('http://internal.helper.off/list.txt', 'helpervettest3', 1);
+
+		// Then nothing is logged (filter off => no guard, no line).
+		$this->assertSame(
+			'',
+			(string) file_get_contents($log),
+			'the skip line must not fire with the feed-host filter disabled'
+		);
+	}
+}

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -67,6 +67,14 @@ _DOT_BLOCK_DESCR_PFX = "pfB_DoT_Block_"
 # Marker for the single floating DoT/DoQ-block rule (mirrors PFB_DOT_BLOCK_FLOATING_DESCR).
 _DOT_BLOCK_FLOATING_DESCR = "pfB_DoT_Block_Floating"
 
+# Rendered pf label anchor for a pfB-owned DoT/DoQ block rule (#813). Plain ``pfctl -sr``
+# (no ``-v`` needed) prints ``label "USER_RULE: <descr>"`` for every config filter/rule row
+# that carries a ``descr`` — pf labels are rule TEXT, emitted by ``print_rule()`` regardless
+# of verbosity (confirmed on a real CE 2.8 smoke-diagnostics guest, run 28704593724). Both
+# the per-interface descr (``pfB_DoT_Block_<iface>``) and the floating descr
+# (``pfB_DoT_Block_Floating``) share this prefix, so anchoring on the PREFIX covers both.
+_DOT_BLOCK_LABEL_ANCHOR = "USER_RULE: " + _DOT_BLOCK_DESCR_PFX
+
 # User filter rule descriptor seeded in Cases 3 and 6 to prove survival.
 _USER_FILTER_DESCR = "my-user-filter-dot-block-smoke"
 
@@ -206,10 +214,29 @@ def _filter_rule_present(vm: SmokeVM, descr: str, *, timeout: float = 60.0) -> b
 
 
 def _is_block_853_line(line: str) -> bool:
-    """True iff a ``pfctl -sr`` line is a block rule for port 853.
+    """True iff a ``pfctl -sr`` line is a pfBlockerNG-owned block rule for port 853.
 
     pfctl renders port 853 as the ``/etc/services`` name ``domain-s`` (DoT/DoQ), not the
     literal ``853`` — so a ``"853" in line`` test alone misses a correctly-loaded rule.
+
+    Anchored on the rendered pfB label, not just the 853/domain-s token (#813): without it,
+    a foreign port-853 block rule baked onto the smoke image (unrelated to pfBlockerNG)
+    could false-match the positive gate, and the ABSENT gate could false-fail on it instead
+    of asserting pfB-owned rules specifically are gone. See ``_DOT_BLOCK_LABEL_ANCHOR`` for
+    the evidence that plain ``pfctl -sr`` already renders this label with no ``-v`` needed.
+    """
+    return "block" in line and ("853" in line or "domain-s" in line) and _DOT_BLOCK_LABEL_ANCHOR in line
+
+
+def _is_block_853_line_loose(line: str) -> bool:
+    """True iff a ``pfctl -sr`` line is ANY block rule mentioning port 853 — pfB or not.
+
+    Diagnostic-only counterpart to :func:`_is_block_853_line`: drops the pfB label anchor
+    so :func:`_dot_block_match_report` can still show near-miss lines (e.g. a foreign
+    baked port-853 block rule) on a live failure, instead of under-reporting by filtering
+    on the same anchored token the gate itself asserts (CLAUDE.md "print expected vs
+    actual" — a diagnostic that filters by the anchor can hide exactly what a reader needs
+    to see when the anchor is the thing in question).
     """
     return "block" in line and ("853" in line or "domain-s" in line)
 
@@ -280,13 +307,20 @@ def _dot_block_match_report(vm: SmokeVM, *, expected_present: bool, timeout: flo
 
     The harness has no assertion framework, so a failing live-pf check must put the
     comparison on the terminal — what was EXPECTED next to what ``pfctl -sr`` ACTUALLY held.
-    Lists the live block rules that mention port 853 / ``domain-s`` verbatim.
+    Lists every LOOSE 853/domain-s block line (pfB-owned or not), each tagged ``[pfB]`` or
+    ``[other]`` by the anchored matcher — a near-miss (e.g. a foreign baked port-853 block
+    rule) must still show up here even though the gates themselves only count ``[pfB]``
+    lines (#813; filtering this listing by the same anchored token would under-report).
     """
     result = vm.ssh(h.PFCTL, "-sr", timeout=timeout)
     if result.returncode != 0:
         actual = [f"<pfctl -sr failed: rc={result.returncode} {result.stderr.strip()}>"]
     else:
-        actual = [ln.strip() for ln in result.stdout.splitlines() if _is_block_853_line(ln)]
+        actual = [
+            f"{'[pfB]  ' if _is_block_853_line(ln) else '[other]'} {ln.strip()}"
+            for ln in result.stdout.splitlines()
+            if _is_block_853_line_loose(ln)
+        ]
     want = "PRESENT (both protocols)" if expected_present else "ABSENT (no protocol)"
     # This report renders INSIDE a failing assert's message — a transient pfctl error on
     # this second read must fold into the report, not replace it with a bare RuntimeError.

--- a/tests/smoke/test_smoke_autorule_immutable.py
+++ b/tests/smoke/test_smoke_autorule_immutable.py
@@ -797,6 +797,13 @@ def test_pfb_permit_precedes_user_block_every_order(
             f"{_probe_diag(vm, DENY_VICTIM)}"
         )
         pkts_after = _rule_block_packets(vm, DENY_ALIAS_TABLE)
+        # A -1 read is "counter unreadable", not a packet count — surface it as a distinct
+        # read failure instead of letting it masquerade as a precedence failure below.
+        assert pkts_before >= 0 and pkts_after >= 0, (
+            f"{pass_order}: could not READ the Deny rule's pf packet counter (before="
+            f"{pkts_before}, after={pkts_after}; -1 = unreadable) — cannot judge the block "
+            f"delta; check the pfctl -sr -vv output format.\n{_probe_diag(vm, DENY_VICTIM)}"
+        )
         assert pkts_after > pkts_before, (
             f"{pass_order}: the Deny rule's pf packet counter did not increase (before="
             f"{pkts_before}, after={pkts_after}) — absence of a state is not proof of an "

--- a/tests/smoke/test_smoke_autorule_immutable.py
+++ b/tests/smoke/test_smoke_autorule_immutable.py
@@ -12,20 +12,40 @@ THE PRECEDENCE TRAP (why this file exists)
 The binary-anchor design (PR #561) put the whole block of user rules — including
 user Block rules — ahead of the pfB block for order_1/order_2, so a pfB Permit
 list could not override a user Block. The Deny-only kill-gate never saw it
-(the pfB-pass bucket was empty). The acceptance sweep here MUST use a config
-with BOTH a pfB Permit and a pfB Deny list AND a user pass AND a user block on
-the same interface, and assert the data-plane verdict per pass_order — this is
-the falsifying case the Phase-2 gate omitted (RESULTS/05).
+(the pfB-pass bucket was empty). The sweep below uses a config with BOTH a pfB
+Permit and a pfB Deny list AND a user pass AND a user block on the same
+interface, and asserts the data-plane verdict per pass_order — this is the
+falsifying case the Phase-2 gate omitted (RESULTS/05).
 
-LIVE RUN DEFERRED TO PHASE 4
------------------------------
-The live-VM harness (ADR-04) proves the on-box pf state after pfBlockerNG reloads;
-Phase 4 wires the fixtures + the per-pass_order data-plane sweep. This file is
-written so Phase 4 can extend and execute it without rebuilding the structure.
-The off-appliance contract (incl. the Permit-vs-Block trap, all five orders) is
-already pinned in tests/php/AutoruleListOracleTest.php.
+ADR-41 Phase 4 (#812): live wiring. Every fixture below is materialized on-box
+(LAN-interface lists via ``_inject_lan_lists`` / a scoped user Block rule via
+``_inject_user_block_rule``), ``pass_order`` is set explicitly per test via
+``config_set_path`` (never left to the fixture's implicit state — the isolation
+guarantee is that EVERY test/fixture that cares sets its own value, since
+``h.reset()``/``h.reset_pfb_baseline()`` do not touch the IP-settings
+``pass_order`` key), and the parametrized trap sweep adds the ADR-41 §7
+data-plane probe on top of the pre-existing config-order assertions. All index
+assertions are computed WITHIN the LAN-interface projection (``_lan_rules``):
+the ORDER table applies per pf group, and the flat filter/rule array
+interleaves other interfaces' baked rules (MGT blocks, an empty-descr row on
+the smoke image). T1-T4 are single-VM (``pfb_enabled_deny_only``); the trap
+sweep + the order_4 reorder test additionally need the two-VM ``client_vm``
+(civm) fixture to drive real traffic through pf — requesting it auto-applies
+the ``two_vm`` marker (conftest's ``_needs_two_vm``; never hand-applied).
 
-To run manually once Phase 4 is underway (box at 10.0.0.23, NO_TWO_VM=1):
+CIVM-BRICKING TRAP (heeded, not just avoided): a LAN-interface pfB rule was
+once found to drop the baked "Default allow LAN to any" rule on a second
+reload, cutting civm off entirely (see test_syslog_export.py's Test-2 comment
+block). ADR-41's immutable-user reconciliation is precisely the fix for that
+drop — T1 pins it — but the injected user Block rule below is still scoped to
+a SINGLE RFC 5737 destination (never 'any'), so regardless of where pass_order
+places it, civm's own DNS/ICMP/control traffic is never a match.
+
+Off-appliance contract (incl. the Permit-vs-Block trap, all five orders) is
+pinned in tests/php/AutoruleListOracleTest.php.
+
+Run manually once deployed (box at 10.0.0.23, NO_TWO_VM=1 for the single-VM
+tests only — T5/T6 need civm):
 
     python -m pytest tests/smoke/test_smoke_autorule_immutable.py \
         --override-ini="addopts=" -v
@@ -34,22 +54,25 @@ To run manually once Phase 4 is underway (box at 10.0.0.23, NO_TWO_VM=1):
 from __future__ import annotations
 
 import json
+import os
+import time
+from collections.abc import Iterator
 
 import pytest
 
 from . import helpers as h
+from .conftest import PFSENSE_LAN_IP, SmokeVM
 
-# ---------------------------------------------------------------------------
-# Pytest marks
-# ---------------------------------------------------------------------------
+pytestmark = pytest.mark.smoke
 
-# Marked `smoke` so it joins the ADR-04 fan-out, but skipped at module level until ADR-41 Phase 4
-# wires the live fixtures + per-pass_order data-plane sweep (the harness was VM-flaky this session).
-# Phase 4 removes the skip. The off-appliance contract is already pinned in AutoruleListOracleTest.
-pytestmark = [
-    pytest.mark.smoke,
-    pytest.mark.skip(reason="ADR-41 Phase 4: live autorule-immutability wiring pending (see RESULTS/03)"),
-]
+# LAN interface friendly name — the interface that exercises the #532/ADR-41 reconciliation
+# (helpers.SMOKE_IP_IFACE defaults to 'wan', so every list injection here uses a dedicated
+# LAN-scoped helper instead of helpers.inject()/inject_ip_lists()).
+LAN_IFACE = "lan"
+
+# The user LAN pass rule description pfSense bakes into fresh images (mirrors
+# test_smoke_lan_rule_preserve.py — same baked-in fixture, same needle).
+DEFAULT_ALLOW_LAN_DESCR = "Default allow LAN to any"
 
 
 # ---------------------------------------------------------------------------
@@ -57,7 +80,7 @@ pytestmark = [
 # ---------------------------------------------------------------------------
 
 
-def _get_filter_rules(vm: h.SmokeVM) -> list[dict]:
+def _get_filter_rules(vm: SmokeVM) -> list[dict]:
     """Return config.xml /filter/rule as a Python list of dicts.
 
     Uses the proven harness pattern: h.php_eval() runs the snippet via pfSsh.php (config already
@@ -87,23 +110,318 @@ def _user_rules(rules: list[dict]) -> list[dict]:
     return out
 
 
+def _lan_rules(rules: list[dict]) -> list[dict]:
+    """Project to the LAN interface pf group (non-floating rules with interface == LAN_IFACE).
+
+    The ORDER table applies PER pf GROUP — pfb_build_autorule_list() reorders each interface's
+    rules and the floating group INDEPENDENTLY (the off-appliance oracle asserts per-interface
+    projections for the same reason). The flat filter/rule array interleaves OTHER interfaces'
+    rules — the smoke image bakes MGT-interface block rules ('Deny all from MGT', 'Deny MG1 to
+    LAN/WAN' — descr mentions LAN but the interface is MGT) and one rule with an EMPTY descr —
+    so an index comparison is only meaningful within one interface's projection. This bit the
+    first live run: "first non-pfB block anywhere" matched a baked MGT block at flat index 0
+    while the LAN ordering was actually correct.
+    """
+    return [r for r in rules if r.get("interface") == LAN_IFACE and r.get("floating", "") != "yes"]
+
+
+def _default_allow_lan_idx(lan_rules: list[dict]) -> int | None:
+    """Index of the baked 'Default allow LAN to any' pass rule within the LAN projection.
+
+    Needle-matched case-insensitively (the live descr is 'Default Allow LAN to any rule' —
+    capital A + ' rule' suffix); the needle excludes the IPv6 sibling. Matching THE specific
+    baked rule — never "first pass with a truthy descr" — because the image also bakes rules
+    with an empty descr and anti-lockout pass rows.
+    """
+    needle = DEFAULT_ALLOW_LAN_DESCR.lower()
+    return next(
+        (i for i, r in enumerate(lan_rules) if needle in r.get("descr", "").lower() and r.get("type") == "pass"),
+        None,
+    )
+
+
+def _has_default_allow_lan(rules: list[dict]) -> bool:
+    """True iff the baked-in LAN 'Default allow LAN to any' pass rule is present."""
+    needle = DEFAULT_ALLOW_LAN_DESCR.lower()
+    return any(needle in r.get("descr", "").lower() and r.get("type") == "pass" for r in rules)
+
+
+def _assert_default_allow_lan_present(rules: list[dict], *, when: str) -> None:
+    """Verify the baked-in user pass rule survives — never assumed (issue #532/ADR-41)."""
+    assert _has_default_allow_lan(rules), (
+        f"{when}: {DEFAULT_ALLOW_LAN_DESCR!r} must be present in config.xml filter/rule (the "
+        f"ADR-41 immutable-user guarantee) — actual descrs:\n  {_descr_list(rules)}"
+    )
+
+
 # ---------------------------------------------------------------------------
+# Helpers — LAN-scoped config injection (pass_order, IP lists, a user rule)
+# ---------------------------------------------------------------------------
+
+
+def _set_pass_order(vm: SmokeVM, pass_order: str | None, *, timeout: float = 60.0) -> None:
+    """Set (or clear) the IP-settings pass_order field — the reconciler's ``$pfb['order']`` input.
+
+    ``None`` removes the key (defaults to order_0 per #532); an explicit ``'order_N'`` value
+    exercises the configured-order branch. Mirrors ``_inject_lan_ip_rule``'s pass_order handling
+    in test_smoke_lan_rule_preserve.py. Neither ``h.reset()`` nor ``h.reset_pfb_baseline()``
+    restores this key by itself (reset() never touches IP settings at all;
+    reset_pfb_baseline() deletes the whole IP-settings SECTION between MODULES, not between
+    tests within this one) — every test in this file that cares about pass_order sets it
+    explicitly, which is the isolation guarantee, not an assumption about run order.
+    """
+    line = (
+        f"$ip['pass_order'] = {h._php_str(pass_order)};\n" if pass_order is not None else "unset($ip['pass_order']);\n"
+    )
+    snippet = (
+        f"$ip = config_get_path({h._php_str(h.CFG_IP_SETTINGS)}, array());\n"
+        f"{line}"
+        f"config_set_path({h._php_str(h.CFG_IP_SETTINGS)}, $ip);\n"
+        "write_config('pfBlockerNG smoke: autorule-immutable pass_order');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_set_pass_order({pass_order!r}) failed: rc={result.returncode} {result.stderr!r}")
+
+
+def _inject_lan_lists(vm: SmokeVM, specs: list[h.IpCase], *, timeout: float = 90.0) -> None:
+    """Write one or more IPv4 list groups to CFG_IP_V4_LISTS with inbound/outbound = LAN.
+
+    Reuses helpers.IpCase + the private helpers._ip_list_php literal builder (same pattern
+    helpers.inject_ip_lists uses to group MULTIPLE list rows in one write, so a second
+    single-list write cannot replace the first) but forces LAN — the interface that exercises
+    the #532/ADR-41 reconciliation — rather than helpers.SMOKE_IP_IFACE's 'wan' default.
+    """
+    groups = ", ".join(h._ip_list_php(spec) for spec in specs)
+    ipset = {"inbound_interface": LAN_IFACE, "outbound_interface": LAN_IFACE}
+    snippet = (
+        f"$g = config_get_path({h._php_str(h.CFG_GLOBAL)}, array());\n"
+        "$g['enable_cb'] = 'on';\n"
+        f"config_set_path({h._php_str(h.CFG_GLOBAL)}, $g);\n"
+        f"$ip = config_get_path({h._php_str(h.CFG_IP_SETTINGS)}, array());\n"
+        f"$ip = array_merge($ip, {h._php_kv_array(ipset)});\n"
+        f"config_set_path({h._php_str(h.CFG_IP_SETTINGS)}, $ip);\n"
+        f"config_set_path({h._php_str(h.CFG_IP_V4_LISTS)}, array({groups}));\n"
+        "write_config('pfBlockerNG smoke: autorule-immutable LAN lists');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_inject_lan_lists failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def _inject_user_block_rule(vm: SmokeVM, *, descr: str, dest_ip: str, timeout: float = 60.0) -> None:
+    """Prepend (idempotently replace) a narrowly-scoped user Block rule on LAN.
+
+    PREPENDED — ahead of the baked-in "Default allow LAN to any" — the standard admin layout
+    (block above allow), and what makes the order_0 data-plane probe DECISIVE: order_0 keeps
+    the user bucket UNSPLIT in original config order, so an APPENDED Block would sit behind
+    the broad default allow and PERMIT_VICTIM would be reachable via that allow regardless of
+    whether pfB's Permit actually beats the Block. With the Block first, only pfB's Permit
+    (emitted ahead of the whole user bucket) can pass the SYN — and the probe would also have
+    caught the historical binary-anchor bug shape (the whole user bucket, Block first, placed
+    ahead of pfB's rules).
+
+    Deliberately scoped to a SINGLE RFC 5737 destination (never 'any'): a LAN-interface pfB
+    rule was once found to drop the permissive "Default allow LAN to any" rule on reload and
+    brick every subsequent civm probe (see test_syslog_export.py's civm-bricking trap comment).
+    ADR-41's immutable-user reconciliation fixes that drop (T1 pins it), but a BROAD user Block
+    here would still legitimately intercept civm's own DNS/ICMP traffic depending on pass_order
+    — scoping the destination to one victim keeps every other civm probe unaffected regardless
+    of where this rule lands in the reconciled sequence.
+    """
+    snippet = (
+        "$rules = config_get_path('filter/rule', array());\n"
+        f"$rules = array_values(array_filter($rules, fn($r) => ($r['descr'] ?? '') !== {h._php_str(descr)}));\n"
+        "array_unshift($rules, array(\n"
+        f"  'descr' => {h._php_str(descr)},\n"
+        "  'type' => 'block',\n"
+        f"  'interface' => {h._php_str(LAN_IFACE)},\n"
+        "  'ipprotocol' => 'inet',\n"
+        "  'source' => array('any' => ''),\n"
+        f"  'destination' => array('address' => {h._php_str(dest_ip)}),\n"
+        "));\n"
+        "config_set_path('filter/rule', $rules);\n"
+        "write_config('pfBlockerNG smoke: autorule-immutable user block rule');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_inject_user_block_rule({descr!r}) failed: rc={result.returncode} {result.stderr!r}")
+
+
+def _remove_filter_rule(vm: SmokeVM, descr: str, *, timeout: float = 60.0) -> None:
+    """Remove any filter/rule row with this descr — idempotent (no-op if already gone).
+
+    A manually-injected user rule (no pfB marker) is NEVER auto-removed by the immutable-user
+    reconciler, so the injector must clean it up itself in a finally, or it leaks into every
+    later smoke module (issue #582 — see test_dot_doq_block.py's _remove_user_filter).
+    """
+    snippet = (
+        "$rules = config_get_path('filter/rule', array());\n"
+        "$kept = array_values(array_filter($rules, function ($r) {\n"
+        f"  return ($r['descr'] ?? '') !== {h._php_str(descr)};\n"
+        "}));\n"
+        "config_set_path('filter/rule', $kept);\n"
+        "write_config('pfBlockerNG smoke: remove autorule-immutable user block rule');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_remove_filter_rule({descr!r}) failed: rc={result.returncode} {result.stderr!r}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers — the ADR-41 §7 data-plane probe (civm-driven, killstates instrument style)
+# ---------------------------------------------------------------------------
+
+
+def _civm_connect(cl: SmokeVM, ip: str, *, timeout: float = 20.0) -> int:
+    """civm attempts a TCP connection to ``ip`` through pfSense; return curl's rc.
+
+    Pins a host route for ``ip`` via pfSense (civm has two equal-metric default routes;
+    without the pin the SYN may egress the mgmt NIC instead of the LAN data NIC) — identical
+    technique to test_smoke_killstates.py's ``_civm_connect``.
+    """
+    r = cl.ssh(
+        "/bin/sh",
+        "-c",
+        f"dev=$(ip -4 -o addr show | awk '/192\\.168\\.1\\./{{print $2; exit}}'); "
+        f'ip route replace {ip}/32 via {PFSENSE_LAN_IP} dev "$dev" 2>/dev/null || true; '
+        f"curl -s -o /dev/null --connect-timeout 3 --max-time 4 http://{ip}/ >/dev/null 2>&1; echo rc=$?",
+        timeout=timeout,
+    )
+    marker = "rc="
+    line = next((ln for ln in r.stdout.splitlines() if ln.startswith(marker)), "rc=-1")
+    return int(line[len(marker) :] or -1)
+
+
+def _victim_states(vm: SmokeVM, ip: str, *, timeout: float = 30.0) -> str:
+    """The pf state-table lines referencing exactly ``ip`` (boundary-anchored, empty if none).
+
+    Boundary-anchored for the same reason as test_smoke_killstates.py's ``_victim_states``: a
+    bare substring grep for e.g. 203.0.113.5 would ALSO match 203.0.113.50/.60.
+    """
+    pat = ip.replace(".", "\\.")
+    cmd = f"pfctl -ss 2>/dev/null | grep -E '(^|[^0-9]){pat}([^0-9]|$)' || true"
+    return vm.ssh("/bin/sh", "-c", cmd, timeout=timeout).stdout.strip()
+
+
+def _rule_block_packets(vm: SmokeVM, alias_table: str, *, timeout: float = 30.0) -> int:
+    """Packets the rule referencing ``alias_table`` has matched (its pf counter); -1 if unreadable.
+
+    Mirrors test_smoke_killstates.py's ``_rule_block_packets`` — proves a rule actively DROPPED
+    traffic (the counter incremented), not merely that no state happened to form.
+    """
+    out = vm.ssh(
+        "/bin/sh",
+        "-c",
+        f"pfctl -sr -vv 2>/dev/null | grep -A1 '{alias_table}' "
+        "| grep -oE 'Packets: [0-9]+' | head -1 | grep -oE '[0-9]+'",
+        timeout=timeout,
+    ).stdout.strip()
+    return int(out or -1)
+
+
+def _probe_reachable(vm: SmokeVM, cl: SmokeVM, ip: str, *, attempts: int = 6) -> bool:
+    """civm attempts a connection to ``ip`` through pfSense; True iff a pf state formed (SYN passed).
+
+    Kills any stale state for ``ip`` FIRST — in BOTH directions: this fixture is shared across
+    a 5-order parametrized sweep, and pf matches an EXISTING state before rules (the classic
+    gotcha test_smoke_killstates.py exercises) — a leftover PASS-shaped state from an earlier
+    pass_order case would falsely read as "reachable" for THIS case too. ``pfctl -k <host>``
+    with a SINGLE -k kills by SOURCE host only; the two-arg form ``-k 0.0.0.0/0 -k <host>``
+    kills src-any -> dst <host>. The victim is always our probes' DESTINATION, so the
+    source-only kill misses the stale states entirely — the take-2 live run failed exactly
+    there: order_1/order_2 legitimately created PASS states to DENY_VICTIM (SYN_SENT,
+    tcp.first ~120s), which survived into order_3/order_4 and false-read as "reachable".
+    Bounded retry with a fixed inter-attempt settle: the SYN's round-trip is real network I/O
+    we cannot signal on (issue #456's documented poll-is-last-resort carve-out), never an
+    unbounded wait.
+    """
+    kill = f"pfctl -k {ip} >/dev/null 2>&1; pfctl -k 0.0.0.0/0 -k {ip} >/dev/null 2>&1 || true"
+    vm.ssh("/bin/sh", "-c", kill, timeout=15)
+    for _ in range(attempts):
+        _civm_connect(cl, ip)
+        time.sleep(1.0)
+        if ip in _victim_states(vm, ip):
+            return True
+        time.sleep(1.0)
+    return False
+
+
+def _probe_diag(vm: SmokeVM, ip: str) -> str:
+    """Expected-vs-actual diagnostics for a data-plane reachability probe failure.
+
+    Layers the same way test_smoke_killstates.py's ``_state_diag`` does: alias membership,
+    the matched rule lines, and the live pf state — so a failure localises instead of printing
+    a bare boolean.
+    """
+
+    def _try(cmd: str) -> str:
+        try:
+            return vm.ssh("/bin/sh", "-c", cmd, timeout=20).stdout.strip()
+        except Exception:
+            return "(error)"
+
+    state = _victim_states(vm, ip)
+    permit_tbl = _try(f"pfctl -t {PERMIT_ALIAS_TABLE} -T show 2>/dev/null | tr -d ' ' || true")
+    deny_tbl = _try(f"pfctl -t {DENY_ALIAS_TABLE} -T show 2>/dev/null | tr -d ' ' || true")
+    rules = _try(
+        f"pfctl -sr 2>/dev/null | grep -iE '{PERMIT_HEADER}|{DENY_HEADER}|Default Allow LAN|{USER_BLOCK_DESCR}' "
+        "|| echo '(no matching rule lines)'"
+    )
+    return (
+        f"\n  pf states for {ip}: {state or '(none)'}\n"
+        f"  permit alias {PERMIT_ALIAS_TABLE}: {permit_tbl!r}\n"
+        f"  deny alias {DENY_ALIAS_TABLE}: {deny_tbl!r}\n"
+        f"  matching pf rules (pfctl -sr):\n{rules}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """Deploy the branch .pkg once for the ADR-41 autorule-immutability module."""
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    yield smoke_vm
+
+
 # Fixture: ensure pfBlockerNG is enabled with a minimal Deny_* IP list
-# ---------------------------------------------------------------------------
+DENY_ONLY_HEADER = "pfbautoruledenyonly"
+DENY_ONLY_FEED_FILE = "pfb_autorule_denyonly_ip.txt"
+DENY_ONLY_DUMMY_IP = "203.0.113.40"  # RFC 5737 TEST-NET-3, inert — only rule PRESENCE matters here
 
 
 @pytest.fixture()
-def pfb_enabled_deny_only(smoke_vm: h.SmokeVM) -> h.SmokeVM:  # type: ignore[return]
+def pfb_enabled_deny_only(deployed_vm: SmokeVM) -> SmokeVM:
     """
     Given:
         pfBlockerNG enabled, one Deny_* v4 IP list active (RFC-5737 addresses),
         LAN default-pass rule present (pfSense default).
+
+    Function-scoped (fresh per test): each test sets its OWN pass_order and runs its OWN
+    reload, so re-materializing the list config here (a plain overwrite) costs nothing and
+    guarantees no test depends on a sibling's leftover pass_order or reload cycle.
     """
-    # Phase 4: wire up h.ensure_pfblockerng_enabled() + a deny-list fixture.
-    # The harness already provides smoke_vm; extend it here.
-    raise NotImplementedError(
-        "Phase 4: wire pfb_enabled_deny_only fixture using h.deploy() + h.write_local_feed() + h.reload()."
+    vm = deployed_vm
+    feed = h.write_local_feed(vm, DENY_ONLY_FEED_FILE, f"{DENY_ONLY_DUMMY_IP}/32\n")
+    _inject_lan_lists(
+        vm,
+        [
+            h.IpCase(
+                aliasname=DENY_ONLY_HEADER, feed_url=feed, action="Deny_Outbound", family="v4", header=DENY_ONLY_HEADER
+            )
+        ],
     )
+    return vm
 
 
 # ---------------------------------------------------------------------------
@@ -111,19 +429,20 @@ def pfb_enabled_deny_only(smoke_vm: h.SmokeVM) -> h.SmokeVM:  # type: ignore[ret
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.usefixtures("pfb_enabled_deny_only")
-def test_user_rules_preserved_after_force_update(smoke_vm: h.SmokeVM) -> None:
+@pytest.mark.timeout(90)  # two Force-Update reloads in the test body > the 30s smoke cap.
+def test_user_rules_preserved_after_force_update(pfb_enabled_deny_only: SmokeVM) -> None:
     """
     Scenario: pfBlockerNG Force-Update on an install with a default-pass LAN rule.
 
     Given:
-        pfBlockerNG active; config.xml has a user 'Default allow LAN to any' pass rule.
+        pfBlockerNG active; config.xml has a user 'Default allow LAN to any' pass rule;
+        pass_order pinned to 'order_0' (this test's own baseline — self-encapsulated).
 
     When:
-        pfblockerng.php update  (Force-Update = full reconcile)
+        pfblockerng.php update  (Force-Update = full reconcile), twice.
 
     Then:
-        - Every non-pfB-owned rule that existed BEFORE the update still exists AFTER.
+        - Every non-pfB-owned rule that existed BEFORE the second update still exists AFTER.
         - No user rule is duplicated (multiset check).
         - User rules appear in the same relative order (order check).
 
@@ -131,18 +450,27 @@ def test_user_rules_preserved_after_force_update(smoke_vm: h.SmokeVM) -> None:
         Assert BEFORE state first, then trigger update, then assert AFTER —
         never just the final state.
     """
-    # --- Given ---
-    before = _user_rules(_get_filter_rules(smoke_vm))
+    vm = pfb_enabled_deny_only
+    _set_pass_order(vm, "order_0")
+
+    # --- Given: establish the baseline via one reload, THEN capture "before". ---
+    h.force_ip_refetch(vm, f"{DENY_ONLY_HEADER}_v4")
+    h.reload(vm, "update")
+    h.apply_filter_sync(vm)
+
+    before = _user_rules(_get_filter_rules(vm))
     assert len(before) >= 1, (
         f"Pre-condition: at least one user rule expected before update.\n"
-        f"Actual rules: {_descr_list(_get_filter_rules(smoke_vm))}"
+        f"Actual rules: {_descr_list(_get_filter_rules(vm))}"
     )
 
     # --- When ---
-    h.reload(smoke_vm)  # Phase 4: replace with h.force_update() once wired.
+    h.force_ip_refetch(vm, f"{DENY_ONLY_HEADER}_v4")
+    h.reload(vm, "update")
+    h.apply_filter_sync(vm)
 
     # --- Then ---
-    after = _user_rules(_get_filter_rules(smoke_vm))
+    after = _user_rules(_get_filter_rules(vm))
 
     assert [r.get("descr") for r in before] == [r.get("descr") for r in after], (
         "User-rule fidelity failure: non-pfB rules changed across the update.\n"
@@ -156,13 +484,13 @@ def test_user_rules_preserved_after_force_update(smoke_vm: h.SmokeVM) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.usefixtures("pfb_enabled_deny_only")
-def test_force_update_is_idempotent(smoke_vm: h.SmokeVM) -> None:
+@pytest.mark.timeout(90)  # two Force-Update reloads in the test body > the 30s smoke cap.
+def test_force_update_is_idempotent(pfb_enabled_deny_only: SmokeVM) -> None:
     """
     Scenario: two successive Force-Updates produce the same filter-rule list.
 
     Given:
-        pfBlockerNG active after an initial update.
+        pfBlockerNG active after an initial update; pass_order pinned to 'order_0'.
 
     When:
         pfblockerng.php update  (first pass)
@@ -175,13 +503,20 @@ def test_force_update_is_idempotent(smoke_vm: h.SmokeVM) -> None:
     output is a no-op), proven off-appliance in Phase 3 PHPUnit and validated
     live here.
     """
+    vm = pfb_enabled_deny_only
+    _set_pass_order(vm, "order_0")
+
     # --- first update ---
-    h.reload(smoke_vm)  # Phase 4: replace with h.force_update().
-    after_first = _get_filter_rules(smoke_vm)
+    h.force_ip_refetch(vm, f"{DENY_ONLY_HEADER}_v4")
+    h.reload(vm, "update")
+    h.apply_filter_sync(vm)
+    after_first = _get_filter_rules(vm)
 
     # --- second update ---
-    h.reload(smoke_vm)
-    after_second = _get_filter_rules(smoke_vm)
+    h.force_ip_refetch(vm, f"{DENY_ONLY_HEADER}_v4")
+    h.reload(vm, "update")
+    h.apply_filter_sync(vm)
+    after_second = _get_filter_rules(vm)
 
     assert _descr_list(after_first) == _descr_list(after_second), (
         "Idempotence failure: second update mutated the rule list.\n"
@@ -195,14 +530,15 @@ def test_force_update_is_idempotent(smoke_vm: h.SmokeVM) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.usefixtures("pfb_enabled_deny_only")
-def test_order0_pfb_block_before_user_pass(smoke_vm: h.SmokeVM) -> None:
+@pytest.mark.timeout(60)  # a pass_order change forces a filter/rule rewrite, not just content > 30s cap.
+def test_order0_pfb_block_before_user_pass(pfb_enabled_deny_only: SmokeVM) -> None:
     """
     Scenario: pass_order=order_0 (default); pfB block must precede the user pass rule
     in config.xml (which maps to pf first-match order on the LAN interface).
 
     Given:
-        pass_order='order_0', one pfB Deny_* block rule, one user pass rule on LAN.
+        pass_order='order_0' (set explicitly — this test's own precondition), one pfB
+        Deny_* block rule, one user pass rule on LAN.
 
     When:
         Force-Update applied.
@@ -210,33 +546,33 @@ def test_order0_pfb_block_before_user_pass(smoke_vm: h.SmokeVM) -> None:
     Then:
         In the post-update filter/rule list, at least one pfB block rule appears
         at a lower index than the user pass rule on the same interface.
-
-    Phase 4 note: complement this with a live DNS-block probe to confirm that
-    pfB's block actually wins at the data plane (see ADR-41 §7).
     """
-    h.reload(smoke_vm)  # Phase 4: set pass_order=order_0 explicitly via h.php_eval().
-    rules = _get_filter_rules(smoke_vm)
-    descrs = _descr_list(rules)
+    vm = pfb_enabled_deny_only
+    _set_pass_order(vm, "order_0")
+    h.force_ip_refetch(vm, f"{DENY_ONLY_HEADER}_v4")
+    h.reload(vm, "update")
+    h.apply_filter_sync(vm)
+    rules = _get_filter_rules(vm)
+    # Indices are computed WITHIN the LAN projection — the ORDER table is per pf group, and the
+    # flat array interleaves other interfaces' baked rules (see _lan_rules).
+    lan = _lan_rules(rules)
+    both = f"LAN-projection descrs:\n  {_descr_list(lan)}\nFull filter/rule descrs:\n  {_descr_list(rules)}"
 
     pfb_block_idx = next(
         (
             i
-            for i, r in enumerate(rules)
+            for i, r in enumerate(lan)
             if r.get("descr", "").startswith("pfB_") and r.get("type") in ("block", "reject")
         ),
         None,
     )
-    user_pass_idx = next(
-        (i for i, r in enumerate(rules) if not r.get("descr", "").startswith("pfB_") and r.get("type") == "pass"),
-        None,
-    )
+    user_pass_idx = _default_allow_lan_idx(lan)
 
-    assert pfb_block_idx is not None, f"No pfB block rule found in filter/rule.\nActual rule descrs:\n  {descrs}"
-    assert user_pass_idx is not None, f"No user pass rule found in filter/rule.\nActual rule descrs:\n  {descrs}"
+    assert pfb_block_idx is not None, f"No pfB block rule found in the LAN projection.\n{both}"
+    assert user_pass_idx is not None, f"No LAN default-allow pass rule found in the LAN projection.\n{both}"
     assert pfb_block_idx < user_pass_idx, (
-        f"order_0: pfB block must appear BEFORE user pass (pfB wins).\n"
-        f"pfB block at index {pfb_block_idx}, user pass at index {user_pass_idx}.\n"
-        f"Actual rule descrs:\n  {descrs}"
+        f"order_0: pfB block must appear BEFORE the user pass (pfB wins) within the LAN group.\n"
+        f"pfB block at LAN index {pfb_block_idx}, user pass at LAN index {user_pass_idx}.\n{both}"
     )
 
 
@@ -245,13 +581,13 @@ def test_order0_pfb_block_before_user_pass(smoke_vm: h.SmokeVM) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.usefixtures("pfb_enabled_deny_only")
-def test_order1_user_pass_before_pfb_block(smoke_vm: h.SmokeVM) -> None:
+@pytest.mark.timeout(60)  # a pass_order change forces a filter/rule rewrite, not just content > 30s cap.
+def test_order1_user_pass_before_pfb_block(pfb_enabled_deny_only: SmokeVM) -> None:
     """
     Scenario: pass_order=order_1; the user's pass rule must precede the pfB block.
 
     Given:
-        pass_order='order_1' (set via h.php_eval()), same fixture as T3.
+        pass_order='order_1' (set explicitly — this test's own precondition), same fixture as T3.
 
     When:
         Force-Update applied.
@@ -259,34 +595,32 @@ def test_order1_user_pass_before_pfb_block(smoke_vm: h.SmokeVM) -> None:
     Then:
         The user pass rule appears at a lower index than the first pfB block rule
         on the same interface.
-
-    Phase 4 note: complement with a live DNS probe to confirm user's pass wins
-    (i.e., a blocked domain resolves when a user allow-pass is first).
     """
-    # Phase 4: set pass_order=order_1 before reload.
-    h.reload(smoke_vm)
-    rules = _get_filter_rules(smoke_vm)
-    descrs = _descr_list(rules)
+    vm = pfb_enabled_deny_only
+    _set_pass_order(vm, "order_1")
+    h.force_ip_refetch(vm, f"{DENY_ONLY_HEADER}_v4")
+    h.reload(vm, "update")
+    h.apply_filter_sync(vm)
+    rules = _get_filter_rules(vm)
+    # Indices within the LAN projection — per pf group, see _lan_rules.
+    lan = _lan_rules(rules)
+    both = f"LAN-projection descrs:\n  {_descr_list(lan)}\nFull filter/rule descrs:\n  {_descr_list(rules)}"
 
-    user_pass_idx = next(
-        (i for i, r in enumerate(rules) if not r.get("descr", "").startswith("pfB_") and r.get("type") == "pass"),
-        None,
-    )
+    user_pass_idx = _default_allow_lan_idx(lan)
     pfb_block_idx = next(
         (
             i
-            for i, r in enumerate(rules)
+            for i, r in enumerate(lan)
             if r.get("descr", "").startswith("pfB_") and r.get("type") in ("block", "reject")
         ),
         None,
     )
 
-    assert user_pass_idx is not None, f"No user pass rule found.\nActual rule descrs:\n  {descrs}"
-    assert pfb_block_idx is not None, f"No pfB block rule found.\nActual rule descrs:\n  {descrs}"
+    assert user_pass_idx is not None, f"No LAN default-allow pass rule found in the LAN projection.\n{both}"
+    assert pfb_block_idx is not None, f"No pfB block rule found in the LAN projection.\n{both}"
     assert user_pass_idx < pfb_block_idx, (
-        f"order_1: user pass must appear BEFORE pfB block (user wins).\n"
-        f"User pass at index {user_pass_idx}, pfB block at index {pfb_block_idx}.\n"
-        f"Actual rule descrs:\n  {descrs}"
+        f"order_1: user pass must appear BEFORE pfB block (user wins) within the LAN group.\n"
+        f"User pass at LAN index {user_pass_idx}, pfB block at LAN index {pfb_block_idx}.\n{both}"
     )
 
 
@@ -294,34 +628,84 @@ def test_order1_user_pass_before_pfb_block(smoke_vm: h.SmokeVM) -> None:
 # Fixture + sweep: THE PRECEDENCE TRAP — pfB Permit + pfB Deny + user pass + block
 # ---------------------------------------------------------------------------
 
-
-@pytest.fixture()
-def pfb_enabled_permit_and_deny(smoke_vm: h.SmokeVM) -> h.SmokeVM:  # type: ignore[return]
-    """
-    Given:
-        pfBlockerNG enabled with BOTH a Permit_* and a Deny_* v4 IP list active on LAN
-        (RFC-5737 addresses), plus a user PASS rule and a user BLOCK rule on LAN.
-
-    This is the config the binary-anchor design got wrong and the Deny-only gate missed:
-    the pfB Permit (pass) must precede the user Block for order_1..order_4.
-    """
-    # Phase 4: wire h.ensure_pfblockerng_enabled() + a Permit_* list + a Deny_* list +
-    # inject a user pass and a user block rule on LAN via h.php_eval(config_set_path).
-    raise NotImplementedError(
-        "Phase 4: wire pfb_enabled_permit_and_deny (Permit_* + Deny_* lists + user pass + user "
-        "block on LAN) using h.deploy() + h.write_local_feed() + h.reload()."
-    )
-
+PERMIT_HEADER = "pfbautorulepermit"
+DENY_HEADER = "pfbautoruledeny"
+PERMIT_FEED_FILE = "pfb_autorule_permit_ip.txt"
+DENY_FEED_FILE = "pfb_autorule_deny_ip.txt"
+# PERMIT_VICTIM sits on the Permit_* alias AND is the user Block rule's dst — the genuine
+# conflict the trap is about (an admin allowlist vs a user's own block on the SAME host).
+# DENY_VICTIM sits only on the Deny_* alias, untouched by the user Block.
+PERMIT_VICTIM = "203.0.113.50"
+DENY_VICTIM = "203.0.113.60"
+PERMIT_ALIAS_TABLE = f"pfB_{PERMIT_HEADER}_v4"
+DENY_ALIAS_TABLE = f"pfB_{DENY_HEADER}_v4"
+USER_BLOCK_DESCR = "pfbsmoke-autorule-user-block"
 
 # order -> (does pfB Permit precede the user Block?  does the user Pass precede the pfB Deny?)
 # Per the ORDER table, the pfB Permit (pass) precedes the user Block in EVERY order_1..order_4
 # (and order_0); order_1/order_2 additionally place the user Pass ahead of the pfB Deny.
 _TRAP_ORDERS = ["order_0", "order_1", "order_2", "order_3", "order_4"]
 
+# Orders where pfB's whole pass/block bucket precedes ALL user rules on the LAN interface
+# group (order_0/order_3: pfB p/m, pfB b/r, user p/m, user b/r; order_4: pfB p/m, pfB b/r,
+# user b/r, user p/m) -> pfB's narrower Deny rule is the first match for DENY_VICTIM, so it is
+# genuinely BLOCKED. For order_0 this holds regardless of the user Block's PREPENDED position
+# (see _inject_user_block_rule): the unsplit user bucket — Block first or last — sits entirely
+# BEHIND pfB's buckets, and DENY_VICTIM is not the user Block's dst anyway. order_1 (user p/m,
+# pfB p/m, pfB b/r, user b/r) and order_2 (pfB p/m, user p/m, pfB b/r, user b/r) both place the
+# broad "Default allow LAN to any" user-pass rule (destination=any — a pf first-match SUPERSET
+# of pfB's alias-scoped Deny) ahead of pfB's block bucket, so that broad allow wins for EVERY
+# destination including DENY_VICTIM (REACHABLE) — the documented "user rules take precedence"
+# semantics of order_1/order_2, not a probe limitation. See the ORDER table in
+# RESULTS/05_Results.txt and pfb_build_autorule_list()'s $apply() sequencing (pfblockerng.inc).
+_DENY_BLOCKED_ORDERS = frozenset({"order_0", "order_3", "order_4"})
 
+
+@pytest.fixture()
+def pfb_enabled_permit_and_deny(deployed_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """
+    Given:
+        pfBlockerNG enabled with BOTH a Permit_* and a Deny_* v4 IP list active on LAN
+        (RFC-5737 addresses), plus the baked-in user PASS rule and an injected user BLOCK
+        rule (scoped to PERMIT_VICTIM only) on LAN.
+
+    This is the config the binary-anchor design got wrong and the Deny-only gate missed:
+    the pfB Permit (pass) must precede the user Block for order_1..order_4.
+
+    Function-scoped: fresh per (parametrized) test, so no case's pass_order or reload state
+    can leak into a sibling's. The injected user Block rule is removed in the finally (issue
+    #582 — a non-pfB rule is never auto-swept, so the injector must clean up its own mess).
+    """
+    vm = deployed_vm
+    permit_feed = h.write_local_feed(vm, PERMIT_FEED_FILE, f"{PERMIT_VICTIM}/32\n")
+    deny_feed = h.write_local_feed(vm, DENY_FEED_FILE, f"{DENY_VICTIM}/32\n")
+    _inject_lan_lists(
+        vm,
+        [
+            h.IpCase(
+                aliasname=PERMIT_HEADER,
+                feed_url=permit_feed,
+                action="Permit_Outbound",
+                family="v4",
+                header=PERMIT_HEADER,
+            ),
+            h.IpCase(
+                aliasname=DENY_HEADER, feed_url=deny_feed, action="Deny_Outbound", family="v4", header=DENY_HEADER
+            ),
+        ],
+    )
+    _inject_user_block_rule(vm, descr=USER_BLOCK_DESCR, dest_ip=PERMIT_VICTIM)
+    try:
+        yield vm
+    finally:
+        _remove_filter_rule(vm, USER_BLOCK_DESCR)
+
+
+@pytest.mark.timeout(180)  # a reload + two civm-driven data-plane probes (up to ~12s each) > 30s cap.
 @pytest.mark.parametrize("pass_order", _TRAP_ORDERS)
-@pytest.mark.usefixtures("pfb_enabled_permit_and_deny")
-def test_pfb_permit_precedes_user_block_every_order(smoke_vm: h.SmokeVM, pass_order: str) -> None:
+def test_pfb_permit_precedes_user_block_every_order(
+    pfb_enabled_permit_and_deny: SmokeVM, client_vm: SmokeVM, pass_order: str
+) -> None:
     """
     Scenario: with a pfB Permit list AND a user Block on LAN, the pfB Permit (pass) must precede
     the user Block for every pass_order — so the admin's allowlist overrides the user's block.
@@ -330,68 +714,164 @@ def test_pfb_permit_precedes_user_block_every_order(smoke_vm: h.SmokeVM, pass_or
     user block of rules, including the user Block, ahead of the pfB Permit).
 
     Given:
-        pass_order=<param>; pfB Permit_* + Deny_* lists; user pass + user block on LAN.
+        pass_order=<param>; pfB Permit_* + Deny_* lists; the baked-in user pass rule; a user
+        Block scoped to PERMIT_VICTIM (the trap: pfB's allowlist and the user's block target
+        the SAME host).
 
     When:
         Force-Update applied with pass_order set to <param>.
 
-    Then:
-        config.xml index(pfB Permit pass) < index(user Block) on LAN, AND a data-plane probe
-        confirms a host on the Permit list is REACHABLE despite the user Block (pf first-match).
-
-    Evidence requirement: assert the data-plane verdict (a permit-listed host reachable, a
-    block-listed host unreachable), not just config.xml index order — see ADR-41 §7.
+    Then (config-order-proven):
+        config.xml index(pfB Permit pass) < index(user Block) on LAN.
+    And (data-plane-proven, ADR-41 §7):
+        a connection to PERMIT_VICTIM from civm creates a pf state (REACHABLE) despite the
+        user Block targeting the same address.
+    And (data-plane-proven where feasible, config-order-proven implicitly otherwise):
+        DENY_VICTIM is BLOCKED for order_0/order_3/order_4 (pfB's Deny bucket precedes every
+        user rule) and REACHABLE for order_1/order_2 (the broad user-pass-any rule precedes
+        pfB's Deny there — real pf first-match semantics, not an infeasible probe).
     """
-    # Phase 4: set pass_order=<param> via h.php_eval(config_set_path) before the reload, then
-    # probe the data plane (e.g. a TCP connect / ICMP to a permit-listed vs block-listed host).
-    h.reload(smoke_vm)
-    rules = _get_filter_rules(smoke_vm)
-    descrs = _descr_list(rules)
+    vm = pfb_enabled_permit_and_deny
+    cl = client_vm
 
+    # --- When: pin this case's pass_order and force a full reconcile. ---
+    _set_pass_order(vm, pass_order)
+    h.force_ip_refetch(vm, f"{PERMIT_HEADER}_v4")
+    h.force_ip_refetch(vm, f"{DENY_HEADER}_v4")
+    h.reload(vm, "update")
+    h.apply_filter_sync(vm)
+
+    rules = _get_filter_rules(vm)
+    _assert_default_allow_lan_present(rules, when=f"{pass_order}: after reload")
+    # Indices are computed WITHIN the LAN projection — the ORDER table is per pf group, and the
+    # flat array interleaves other interfaces' baked rules (MGT blocks, an empty-descr row); the
+    # first live run failed exactly on that (see _lan_rules).
+    lan = _lan_rules(rules)
+    both = f"LAN-projection descrs:\n  {_descr_list(lan)}\nFull filter/rule descrs:\n  {_descr_list(rules)}"
+
+    # --- Then (config-order-proven): pfB Permit precedes the user Block on LAN. ---
     pfb_permit_idx = next(
-        (i for i, r in enumerate(rules) if r.get("descr", "").startswith("pfB_") and r.get("type") == "pass"),
+        (i for i, r in enumerate(lan) if r.get("descr", "").startswith("pfB_") and r.get("type") == "pass"),
         None,
     )
-    user_block_idx = next(
-        (
-            i
-            for i, r in enumerate(rules)
-            if not r.get("descr", "").startswith("pfB_") and r.get("type") in ("block", "reject")
-        ),
-        None,
-    )
+    # OUR injected Block by exact descr — never "first non-pfB block": foreign baked blocks exist.
+    user_block_idx = next((i for i, r in enumerate(lan) if r.get("descr") == USER_BLOCK_DESCR), None)
 
-    assert pfb_permit_idx is not None, f"No pfB Permit (pass) rule found.\nActual rule descrs:\n  {descrs}"
-    assert user_block_idx is not None, f"No user block rule found.\nActual rule descrs:\n  {descrs}"
+    assert pfb_permit_idx is not None, f"No pfB Permit (pass) rule found in the LAN projection.\n{both}"
+    assert user_block_idx is not None, (
+        f"The injected user Block ({USER_BLOCK_DESCR!r}) not found in the LAN projection.\n{both}"
+    )
     assert pfb_permit_idx < user_block_idx, (
-        f"{pass_order}: pfB Permit (pass) must precede the user Block — a pfB allowlist must "
-        f"override a user block.\npfB Permit at index {pfb_permit_idx}, user block at index "
-        f"{user_block_idx}.\nActual rule descrs:\n  {descrs}"
+        f"{pass_order}: pfB Permit (pass) must precede the user Block within the LAN group — a "
+        f"pfB allowlist must override a user block.\npfB Permit at LAN index {pfb_permit_idx}, "
+        f"user block at LAN index {user_block_idx}.\n{both}"
     )
 
+    # --- Then (data-plane-proven, ADR-41 §7): the permit-listed victim is reachable despite
+    # the user Block on the SAME address — some pass rule always precedes the user Block in
+    # the intended layout (config-order-proven above / by construction of the ORDER table), so
+    # a live SYN must get through. The user Block is PREPENDED ahead of the default allow (see
+    # _inject_user_block_rule), so for order_0 (unsplit user bucket, Block first) and order_4
+    # (user b/r before user p/m) pfB's Permit is the ONLY pass rule before the Block — fully
+    # decisive. In order_1/2/3 the default allow (user p/m) also precedes the user b/r bucket,
+    # so reachability alone cannot attribute the pass to pfB's Permit there — but the probe
+    # still catches the historical binary-anchor failure shape (the whole user bucket, Block
+    # first, placed ahead of ALL pfB rules for order_1/order_2: the SYN would hit the Block
+    # and fail), and the config-order assertion above pins the Permit-before-Block invariant
+    # in every order. ---
+    assert _probe_reachable(vm, cl, PERMIT_VICTIM), (
+        f"{pass_order}: expected the Permit-listed {PERMIT_VICTIM} REACHABLE despite the user "
+        f"Block on the same address (the ADR-41 trap) — the connection never created a pf "
+        f"state.\n{_probe_diag(vm, PERMIT_VICTIM)}"
+    )
 
-@pytest.mark.usefixtures("pfb_enabled_permit_and_deny")
-def test_order4_reorders_user_block_before_user_pass(smoke_vm: h.SmokeVM) -> None:
+    # --- Then (data-plane-proven both branches): the deny-listed victim's reachability
+    # follows pf's real first-match semantics on the sequence above, per _DENY_BLOCKED_ORDERS. ---
+    expect_deny_blocked = pass_order in _DENY_BLOCKED_ORDERS
+    pkts_before = _rule_block_packets(vm, DENY_ALIAS_TABLE)
+    deny_reachable = _probe_reachable(vm, cl, DENY_VICTIM)
+    if expect_deny_blocked:
+        assert not deny_reachable, (
+            f"{pass_order}: expected the Deny-listed {DENY_VICTIM} BLOCKED (pfB's Deny bucket "
+            f"precedes every user rule in this order) but a pf state formed.\n"
+            f"{_probe_diag(vm, DENY_VICTIM)}"
+        )
+        pkts_after = _rule_block_packets(vm, DENY_ALIAS_TABLE)
+        assert pkts_after > pkts_before, (
+            f"{pass_order}: the Deny rule's pf packet counter did not increase (before="
+            f"{pkts_before}, after={pkts_after}) — absence of a state is not proof of an "
+            f"active block.\n{_probe_diag(vm, DENY_VICTIM)}"
+        )
+    else:
+        assert deny_reachable, (
+            f"{pass_order}: expected the Deny-listed {DENY_VICTIM} REACHABLE (the broad "
+            f"'Default allow LAN to any' user pass rule precedes pfB's Deny bucket in this "
+            f"order — documented user-first semantics) but no pf state formed.\n"
+            f"{_probe_diag(vm, DENY_VICTIM)}"
+        )
+
+
+@pytest.mark.timeout(90)  # two Force-Update reloads (order_3 baseline + order_4) > the 30s smoke cap.
+def test_order4_reorders_user_block_before_user_pass(pfb_enabled_permit_and_deny: SmokeVM) -> None:
     """
     Scenario: order_4 places the user's own Block before its Pass (intended pass_order semantics:
     order_4 = pfB p/m | pfB b/r | pfSense Block/Reject | pfSense Pass/Match).
 
-    The binary-anchor design wrongly dropped this (it froze user-rule order). Confirm the user
-    Block precedes the user Pass under order_4.
+    The binary-anchor design wrongly dropped this (it froze user-rule order). Confirm — with a
+    genuine before/after — that order_3 emits user pass-before-block and order_4 flips it, so
+    the flip is attributable to the pass_order change, not incidental.
+
+    Given: pass_order='order_3' (baseline) — user p/m precedes user b/r BY BUCKET ORDER
+           (order_3 = pfB p/m | pfB b/r | user p/m | user b/r), deliberately insertion-
+           independent: the fixture PREPENDS the user Block ahead of the default allow (see
+           _inject_user_block_rule), so an order_0 baseline (unsplit user bucket in original
+           config order) would already read block-before-pass and destroy the contrast.
+    When:  pass_order switches to 'order_4'.
+    Then:  the user Block now precedes the user Pass.
     """
-    # Phase 4: set pass_order=order_4 via h.php_eval() before the reload.
-    h.reload(smoke_vm)
-    rules = _get_filter_rules(smoke_vm)
-    descrs = _descr_list(rules)
-    user_rules = _user_rules(rules)
+    vm = pfb_enabled_permit_and_deny
 
-    user_block_idx = next((i for i, r in enumerate(user_rules) if r.get("type") in ("block", "reject")), None)
-    user_pass_idx = next((i for i, r in enumerate(user_rules) if r.get("type") == "pass"), None)
+    # --- Given: order_3 baseline (user pass-before-block by bucket order). ---
+    _set_pass_order(vm, "order_3")
+    h.force_ip_refetch(vm, f"{PERMIT_HEADER}_v4")
+    h.force_ip_refetch(vm, f"{DENY_HEADER}_v4")
+    h.reload(vm, "update")
+    h.apply_filter_sync(vm)
 
-    assert user_block_idx is not None, f"No user block rule found.\nActual rule descrs:\n  {descrs}"
-    assert user_pass_idx is not None, f"No user pass rule found.\nActual rule descrs:\n  {descrs}"
+    rules = _get_filter_rules(vm)
+    _assert_default_allow_lan_present(rules, when="Given (order_3 baseline)")
+    # User rules within the LAN projection only — the ORDER table is per pf group, and the flat
+    # array interleaves other interfaces' baked user rules (MGT blocks — see _lan_rules).
+    user_rules = _user_rules(_lan_rules(rules))
+    both = f"LAN user-rule descrs:\n  {_descr_list(user_rules)}\nFull filter/rule descrs:\n  {_descr_list(rules)}"
+    base_pass_idx = _default_allow_lan_idx(user_rules)
+    base_block_idx = next((i for i, r in enumerate(user_rules) if r.get("descr") == USER_BLOCK_DESCR), None)
+    assert base_pass_idx is not None, f"No LAN default-allow pass rule found.\n{both}"
+    assert base_block_idx is not None, f"The injected user Block ({USER_BLOCK_DESCR!r}) not found on LAN.\n{both}"
+    assert base_pass_idx < base_block_idx, (
+        f"Before-state (order_3): user pass must precede user block (the user p/m bucket leads "
+        f"the user b/r bucket in order_3), so the order_4 reorder below is attributable to the "
+        f"pass_order change, not incidental.\n{both}"
+    )
+
+    # --- When: switch to order_4. ---
+    _set_pass_order(vm, "order_4")
+    h.force_ip_refetch(vm, f"{PERMIT_HEADER}_v4")
+    h.force_ip_refetch(vm, f"{DENY_HEADER}_v4")
+    h.reload(vm, "update")
+    h.apply_filter_sync(vm)
+
+    # --- Then: the user's own Block now precedes its Pass (within the LAN projection). ---
+    rules = _get_filter_rules(vm)
+    user_rules = _user_rules(_lan_rules(rules))
+    both = f"LAN user-rule descrs:\n  {_descr_list(user_rules)}\nFull filter/rule descrs:\n  {_descr_list(rules)}"
+
+    user_block_idx = next((i for i, r in enumerate(user_rules) if r.get("descr") == USER_BLOCK_DESCR), None)
+    user_pass_idx = _default_allow_lan_idx(user_rules)
+
+    assert user_block_idx is not None, f"The injected user Block ({USER_BLOCK_DESCR!r}) not found on LAN.\n{both}"
+    assert user_pass_idx is not None, f"No LAN default-allow pass rule found.\n{both}"
     assert user_block_idx < user_pass_idx, (
         f"order_4: the user's own Block must precede its Pass (intended pass_order layout).\n"
-        f"user block at index {user_block_idx}, user pass at index {user_pass_idx}.\n"
-        f"Actual rule descrs:\n  {descrs}"
+        f"user block at LAN index {user_block_idx}, user pass at LAN index {user_pass_idx}.\n{both}"
     )

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -219,15 +219,20 @@ def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM
     """
     feed_url = mock_feeds.feed_url("ip_plain_cidr.txt")
     spec = h.IpCase(aliasname="smokefiltergate", feed_url=feed_url, header="smokefiltergate", family="v4")
-    # The refusal fires at pfb_download()'s ENTRY URL vetting (pfb_filter PFB_FILTER_URL
-    # routes through pfb_feed_host_allowed, pfblockerng.inc:1067), NOT the later
-    # download-time gate at :8974 — that '[ header ] … — skipped' line is unreachable
-    # for an internal-host URL. The reason-bearing line lands in error.log (logtype 6):
-    #   "… Invalid URL (feed host resolves to a non-permitted address) [ <url> ]"
-    # Scope it by the reason AND this run's unique mock URL (host:port/fixture), so a
-    # sibling feed's failure can never satisfy it.
-    refused_marker = f"Invalid URL (feed host resolves to a non-permitted address) [ {feed_url} ]"
-    error_log = f"{h.PFB_LOGDIR}/error.log"
+    # The refusal fires at pfb_download()'s entry vetting during the IP download pass
+    # (pfb_filter PFB_FILTER_URL routes through pfb_feed_host_allowed; observed live in
+    # run 28706678122 — the error.log reject carries the 'pfb_download_failure' reference).
+    # pfb_filter's reason-free "… Invalid URL (…) [ <url> ]" error.log line (logtype 6)
+    # is untouched by #811 — but every entry-reject site now also calls
+    # pfb_log_feed_host_reject() (#811), so a header-scoped, reason-bearing
+    # "[ header ] <reason> — skipped" line lands in the MAIN log, making the cause
+    # visible without digging through error.log. Assert THAT line: scope it by header
+    # AND the exact guard reason, so a sibling feed's failure can never satisfy it.
+    # NOTE: the download pipeline's on-box header carries the family suffix
+    # ("smokefiltergate_v4"), so the marker anchors on that rendered form, not the bare
+    # alias name (run 28706678122: the line logged as "[ smokefiltergate_v4 ] … — skipped").
+    refused_marker = f"[ {spec.header}_v4 ] feed host resolves to a non-permitted address — skipped"
+    main_log = h.PFB_LOG
     # The mock fetch must be reachable across both updates (the SSRF filter, not egress,
     # is what we are exercising).
     h.unblock_egress()
@@ -239,7 +244,7 @@ def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM
         # the "table not built" assertion reflects a fully settled reload, not a race.
         h.set_feed_internal_allowlist(deployed_vm, "")
         assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before any load"
-        refused_before = h.count_log_marker(deployed_vm, error_log, refused_marker)
+        refused_before = h.count_log_marker(deployed_vm, main_log, refused_marker)
         h.reload(deployed_vm, "update")
         h.reload(deployed_vm, "updateip")
         assert spec.alias not in h.pfctl_tables(deployed_vm), (
@@ -248,9 +253,9 @@ def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM
         # A missing pf table alone is non-specific — a dead mock server would look identical.
         # Assert the actual refusal reason was logged, so this proves the SSRF guard fired,
         # not merely that nothing happened to load.
-        refused_after = h.count_log_marker(deployed_vm, error_log, refused_marker)
+        refused_after = h.count_log_marker(deployed_vm, main_log, refused_marker)
         assert refused_after > refused_before, (
-            f"Expected {refused_marker!r} in {error_log} after the filtered update "
+            f"Expected {refused_marker!r} in {main_log} after the filtered update "
             f"(before={refused_before}, after={refused_after}) — the pf table being empty does "
             "not by itself prove the SSRF guard refused the download"
         )
@@ -1703,38 +1708,31 @@ def test_cron_304_skips_unchanged_remote_feed(
         ans_before = h.dns_probe_client_until(client_vm, dom, h.is_vip)
         assert h.is_vip(ans_before), f"BEFORE: {dom} must be VIP-blocked after initial ingest, got {ans_before}"
 
-        # Feed unchanged; ETag still matches. The "( 304 not modified )" verdict line is
-        # logged WITHOUT the "[ header ]" prefix (pfblockerng.php:553, pfb_logger writes it
-        # verbatim), so it is not header-scopable — count it globally over the cron window.
-        # This test is the only feed set up with a matching ETag, so the before/after delta
-        # isolates its conditional GET.
+        # Feed unchanged; ETag still matches. #811 header-scopes the "( 304 not modified )"
+        # verdict line itself (pfblockerng.php's pfb_update_check now prefixes it "[ header ] ",
+        # matching the fetch-time gates' format), so the marker below is scoped by header AND
+        # verdict — no separate global count + "fast guard" needed.
         _pin_cron_due(deployed_vm)
-        not_mod_before = h.count_log_marker(deployed_vm, h.PFB_LOG, "304 not modified")
+        not_mod_marker = f"[ {header} ] ( 304 not modified )"
+        not_mod_before = h.count_log_marker(deployed_vm, h.PFB_LOG, not_mod_marker)
         dl_before = _feed_log_count(deployed_vm, header, "Downloading update")
-        hdr_before = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
 
         # WHEN — the conditional-GET 304 needs the validator PERSISTED first, then READ on a
         # later probe. The validator is written by the cron detector (pfb_update_check) on a
         # 200, NOT by the updatednsbl Force ingest above, and only once a {header}.orig baseline
         # exists — so the store-then-read can span a couple of cron passes. Run cron until
-        # "304 not modified" appears (the #572 fix aligned the read base to {header}.orig),
-        # capped so a genuine failure still surfaces.
+        # the marker appears (the #572 fix aligned the read base to {header}.orig), capped so
+        # a genuine failure still surfaces.
         for _pass in range(4):
             h.reload(deployed_vm, "cron")
-            if h.count_log_marker(deployed_vm, h.PFB_LOG, "304 not modified") > not_mod_before:
+            if h.count_log_marker(deployed_vm, h.PFB_LOG, not_mod_marker) > not_mod_before:
                 break
 
-        # Fast guard — the feed was evaluated at least once.
-        hdr_after = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
-        assert hdr_after > hdr_before, (
-            f"cron did not evaluate [ {header} ] (before={hdr_before}, after={hdr_after}) — "
-            f"EveryDay feed not due (hour rollover?); re-run"
-        )
-
-        # THEN — "304 not modified" appeared within the cap (Phase-3 code-path proof).
-        not_mod_after = h.count_log_marker(deployed_vm, h.PFB_LOG, "304 not modified")
+        # THEN — "[ header ] ( 304 not modified )" appeared within the cap (Phase-3 code-path
+        # proof, now also proving the SAME cron pass evaluated THIS feed's header).
+        not_mod_after = h.count_log_marker(deployed_vm, h.PFB_LOG, not_mod_marker)
         assert not_mod_after > not_mod_before, (
-            f"Expected '( 304 not modified )' (Phase-3 conditional GET proof) within 4 cron "
+            f"Expected {not_mod_marker!r} (Phase-3 conditional GET proof) within 4 cron "
             f"passes (before={not_mod_before}, after={not_mod_after}) — 304 path not taken"
         )
 
@@ -1809,17 +1807,16 @@ def test_cron_200_reingest_changed_remote_feed(
         mock_feeds.set_content(feed_name, dom_old + "\n" + dom_new + "\n", etag=etag_v2)
 
         _pin_cron_due(deployed_vm)
-        hdr_before = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
         dl_before = _feed_log_count(deployed_vm, header, "Downloading update")
-        # "( content changed )" is the Phase-3 hash-compare verdict itself (not merely its
-        # re-ingest side effect) — the docstring's RED premise (a status-only impl that skips
-        # the hash compare) would still log "Downloading update" without ever logging this.
-        chg_before = h.count_log_marker(deployed_vm, h.PFB_LOG, "content changed")
+        # "[ header ] ( content changed )" is the Phase-3 hash-compare verdict itself (not
+        # merely its re-ingest side effect), header-scoped by #811 — the docstring's RED
+        # premise (a status-only impl that skips the hash compare) would still log
+        # "Downloading update" without ever logging this, and a header-scoped count also
+        # proves THIS feed (not a sibling) was the one evaluated.
+        chg_marker = f"[ {header} ] ( content changed )"
+        chg_before = h.count_log_marker(deployed_vm, h.PFB_LOG, chg_marker)
 
         h.reload(deployed_vm, "cron")
-
-        hdr_after = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
-        assert hdr_after > hdr_before, f"cron did not evaluate [ {header} ] — EveryDay feed not due; re-run"
 
         # THEN — "Downloading update" appeared (feed was re-ingested).
         dl_after = _feed_log_count(deployed_vm, header, "Downloading update")
@@ -1828,10 +1825,10 @@ def test_cron_200_reingest_changed_remote_feed(
             f"(before={dl_before}, after={dl_after}) — detector did not detect the change"
         )
 
-        # THEN — the hash-compare verdict itself fired: "( content changed )".
-        chg_after = h.count_log_marker(deployed_vm, h.PFB_LOG, "content changed")
+        # THEN — the hash-compare verdict itself fired: "[ header ] ( content changed )".
+        chg_after = h.count_log_marker(deployed_vm, h.PFB_LOG, chg_marker)
         assert chg_after > chg_before, (
-            f"Expected '( content changed )' verdict after the ETag bump + body change "
+            f"Expected {chg_marker!r} verdict after the ETag bump + body change "
             f"(before={chg_before}, after={chg_after}) — hash-compare path not taken"
         )
 
@@ -1902,21 +1899,21 @@ def test_cron_no_validator_download_hash_decides(
         ans_before = h.dns_probe_client_until(client_vm, dom, h.is_vip)
         assert h.is_vip(ans_before), f"BEFORE: {dom} must be VIP-blocked after initial ingest, got {ans_before}"
 
-        # Feed unchanged; no If-None-Match will be sent (no stored ETag).
+        # Feed unchanged; no If-None-Match will be sent (no stored ETag). #811 header-scopes
+        # the "( content unchanged )" verdict line, so the marker below proves BOTH the
+        # verdict and that THIS feed's header was evaluated.
         _pin_cron_due(deployed_vm)
-        not_unch_before = h.count_log_marker(deployed_vm, h.PFB_LOG, "content unchanged")
+        not_unch_marker = f"[ {header} ] ( content unchanged )"
+        not_unch_before = h.count_log_marker(deployed_vm, h.PFB_LOG, not_unch_marker)
         dl_before = _feed_log_count(deployed_vm, header, "Downloading update")
-        hdr_before = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
 
         h.reload(deployed_vm, "cron")
 
-        hdr_after = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
-        assert hdr_after > hdr_before, f"cron did not evaluate [ {header} ] — EveryDay feed not due; re-run"
-
-        # THEN — "content unchanged" appeared (full download + hash comparison taken).
-        not_unch_after = h.count_log_marker(deployed_vm, h.PFB_LOG, "content unchanged")
+        # THEN — "[ header ] ( content unchanged )" appeared (full download + hash comparison
+        # taken for THIS feed).
+        not_unch_after = h.count_log_marker(deployed_vm, h.PFB_LOG, not_unch_marker)
         assert not_unch_after > not_unch_before, (
-            f"Expected 'content unchanged' log line after no-validator cron "
+            f"Expected {not_unch_marker!r} log line after no-validator cron "
             f"(before={not_unch_before}, after={not_unch_after}) — download+hash path not taken"
         )
 
@@ -1986,22 +1983,22 @@ def test_cron_spurious_200_same_bytes_no_reingest(
                 f"BEFORE: {member_ip} must be in {spec.alias}: {members_before}"
             )
 
-            # Pin cron due (inside CaseContext so config is active).
+            # Pin cron due (inside CaseContext so config is active). #811 header-scopes the
+            # "( content unchanged )" verdict, so the marker below proves both the verdict
+            # and that THIS feed's marker (aliasname_family) was the one evaluated.
             _pin_cron_due(deployed_vm)
-            not_unch_before = h.count_log_marker(deployed_vm, h.PFB_LOG, "content unchanged")
+            not_unch_marker = f"[ {feed_marker} ] ( content unchanged )"
+            not_unch_before = h.count_log_marker(deployed_vm, h.PFB_LOG, not_unch_marker)
             dl_before = _feed_log_count(deployed_vm, feed_marker, "Downloading update")
-            hdr_before = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {feed_marker} ]")
 
             # WHEN — cron; server returns 200 (no ETag → no If-None-Match → plain 200).
             h.reload(deployed_vm, "cron")
 
-            hdr_after = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {feed_marker} ]")
-            assert hdr_after > hdr_before, f"cron did not evaluate [ {feed_marker} ] — EveryDay feed not due; re-run"
-
-            # THEN — "content unchanged" appeared (spurious 200 detected by hash).
-            not_unch_after = h.count_log_marker(deployed_vm, h.PFB_LOG, "content unchanged")
+            # THEN — "[ feed_marker ] ( content unchanged )" appeared (spurious 200 detected
+            # by hash, for THIS feed).
+            not_unch_after = h.count_log_marker(deployed_vm, h.PFB_LOG, not_unch_marker)
             assert not_unch_after > not_unch_before, (
-                f"Expected 'content unchanged' after spurious-200 cron "
+                f"Expected {not_unch_marker!r} after spurious-200 cron "
                 f"(before={not_unch_before}, after={not_unch_after}) — hash compare not applied"
             )
 
@@ -2082,36 +2079,28 @@ def test_cron_lastmod_304_skips_unchanged_feed(
         ans_before = h.dns_probe_client_until(client_vm, dom, h.is_vip)
         assert h.is_vip(ans_before), f"BEFORE: {dom} must be VIP-blocked after initial ingest, got {ans_before}"
 
-        # Feed unchanged; the stored Last-Modified validator still matches. Same global-count
-        # rationale as case (a): "( 304 not modified )" is logged without a "[ header ]" prefix,
-        # so count it globally over the cron window. No other feed in this run stores a
-        # Last-Modified-only validator that the server actually honours, so the delta isolates
-        # this feed's conditional GET.
+        # Feed unchanged; the stored Last-Modified validator still matches. #811 header-scopes
+        # the "( 304 not modified )" verdict line itself, so the marker below is scoped by
+        # header AND verdict — no separate global count + "fast guard" needed.
         _pin_cron_due(deployed_vm)
-        not_mod_before = h.count_log_marker(deployed_vm, h.PFB_LOG, "304 not modified")
+        not_mod_marker = f"[ {header} ] ( 304 not modified )"
+        not_mod_before = h.count_log_marker(deployed_vm, h.PFB_LOG, not_mod_marker)
         dl_before = _feed_log_count(deployed_vm, header, "Downloading update")
-        hdr_before = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
 
         # WHEN — same store-then-read span as case (a): the .lastmod validator is written by
         # the cron detector (pfb_update_check) on its first 200, not by the updatednsbl Force
-        # ingest above. Run cron until "304 not modified" appears, capped so a genuine failure
-        # still surfaces.
+        # ingest above. Run cron until the marker appears, capped so a genuine failure still
+        # surfaces.
         for _pass in range(4):
             h.reload(deployed_vm, "cron")
-            if h.count_log_marker(deployed_vm, h.PFB_LOG, "304 not modified") > not_mod_before:
+            if h.count_log_marker(deployed_vm, h.PFB_LOG, not_mod_marker) > not_mod_before:
                 break
 
-        # Fast guard — the feed was evaluated at least once.
-        hdr_after = h.count_log_marker(deployed_vm, h.PFB_LOG, f"[ {header} ]")
-        assert hdr_after > hdr_before, (
-            f"cron did not evaluate [ {header} ] (before={hdr_before}, after={hdr_after}) — "
-            f"EveryDay feed not due (hour rollover?); re-run"
-        )
-
-        # THEN — "304 not modified" appeared within the cap (CURLOPT_TIMECONDITION proof).
-        not_mod_after = h.count_log_marker(deployed_vm, h.PFB_LOG, "304 not modified")
+        # THEN — "[ header ] ( 304 not modified )" appeared within the cap
+        # (CURLOPT_TIMECONDITION proof, now also proving THIS feed's header was evaluated).
+        not_mod_after = h.count_log_marker(deployed_vm, h.PFB_LOG, not_mod_marker)
         assert not_mod_after > not_mod_before, (
-            f"Expected '( 304 not modified )' (Last-Modified/CURLOPT_TIMECONDITION 304 proof) "
+            f"Expected {not_mod_marker!r} (Last-Modified/CURLOPT_TIMECONDITION 304 proof) "
             f"within 4 cron passes (before={not_mod_before}, after={not_mod_after}) — "
             f"the no-ETag conditional-GET fallback did not reach a 304"
         )

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -494,8 +494,10 @@ def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: Smok
            behind the firewall.
     When:  the civm client curls the blocked WAN IP (pass-through traffic pf blocks
            + logs on WAN-out — NOT pfSense's own traffic, which the rule misses).
-    Then:  a new pfblockerng record appears in the dedicated file with an IP action
-           token (act=block/pass/match).
+    Then:  a new pfblockerng record appears in the dedicated file that references the
+           victim dst IP (TEST_IP_BLOCK_DST) LITERALLY and carries an IP action token
+           (act=block/pass/match) — not merely any new pfB event (#814: a resolved
+           hostname in place of the literal dst would previously slip past this assert).
     And:   the CSV ip_block.log is also written (additive).
     """
     vm = deployed_vm
@@ -508,12 +510,23 @@ def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: Smok
 
     _trigger_ip_block(client_vm)
 
-    line = _wait_for_event(vm, baseline_len=len(before), want=(), any_of=IP_ACT_TOKENS)
+    line = _wait_for_event(vm, baseline_len=len(before), want=(TEST_IP_BLOCK_DST,), any_of=IP_ACT_TOKENS)
     if not line:
         ps = vm.ssh("/bin/ps", "-wax", timeout=30)
         daemon_running = "pfblockerng.inc filterlog" in ps.stdout
         pfctl = vm.ssh("/sbin/pfctl", "-t", "pfB_pfb_syslog_iptest_v4", "-T", "show", timeout=30)
         alias_populated = TEST_IP_BLOCK_DST in pfctl.stdout
+        # #814 near-miss diagnostic: the OLD (loose) match was "any new pfB act= event" —
+        # any_of=IP_ACT_TOKENS with no want. If that loose condition WOULD have matched but the
+        # tightened want=(TEST_IP_BLOCK_DST,) did not, the daemon IS exporting IP-block events,
+        # just not ones that reference the victim dst literally (e.g. a resolved hostname in
+        # its place) — the exact evidence needed to tell "nothing exported" apart from "exported,
+        # but not the literal IP".
+        new_lines = _pfb_event_lines(vm)[len(before) :]
+        near_misses = [
+            ln for ln in new_lines if any(tok in ln for tok in IP_ACT_TOKENS) and TEST_IP_BLOCK_DST not in ln
+        ]
+        near_miss_report = "\n    ".join(near_misses[-5:]) if near_misses else "(none)"
         # An unpopulated alias or a dead filterlog daemon are NOT benign preconditions to skip
         # past -- this un-xfailed leg (ADR-38 A2.4) exists specifically to catch those two
         # regression classes (a failed IP feed reload / a crashed export daemon), so both fold
@@ -525,12 +538,19 @@ def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: Smok
             )
         elif not daemon_running:
             precondition = "filterlog daemon not running — the pfBlockerNG export daemon died"
+        elif near_misses:
+            precondition = (
+                f"a new pfB IP event fired but did not reference {TEST_IP_BLOCK_DST} literally — "
+                "see the near-miss lines below (possibly a resolved hostname instead of the dst IP)"
+            )
         else:
             precondition = "none — daemon running and alias populated"
         raise AssertionError(
-            f"No new IP-block export record after connection to {TEST_IP_BLOCK_DST}.\n"
-            f"  expected a new line in {PFB_SYSLOG_LOG} with one of {list(IP_ACT_TOKENS)!r}\n"
+            f"No new IP-block export record referencing {TEST_IP_BLOCK_DST} after connection to it.\n"
+            f"  expected a new line in {PFB_SYSLOG_LOG} with {TEST_IP_BLOCK_DST!r} and one of {list(IP_ACT_TOKENS)!r}\n"
             f"  actual:   no matching line found\n"
+            f"  new pfB events that did NOT reference the victim dst (last {min(len(near_misses), 5)}):\n"
+            f"    {near_miss_report}\n"
             f"  daemon_running={daemon_running} alias_populated={alias_populated}\n"
             f"  precondition broken: {precondition}\n"
             f"  ps: {ps.stdout[:400]!r}\n"

--- a/tests/test_dot_doq_block_853_line.py
+++ b/tests/test_dot_doq_block_853_line.py
@@ -1,0 +1,104 @@
+"""Issue #813 — anchor ``_is_block_853_line`` on the rendered pfB DoT-block label.
+
+Pins the pure, off-VM predicate ``_is_block_853_line`` from
+``tests/smoke/test_dot_doq_block.py``: before the fix it was
+``"block" in line and ("853" in line or "domain-s" in line)`` — unanchored, so ANY
+block/reject rule mentioning port 853 (a foreign rule baked onto the smoke image,
+unrelated firewall policy, etc.) false-matched the positive gate
+(``_pfctl_sr_has_block_853``), and the ABSENT gate (``_pfctl_sr_block_853_absent``)
+could false-fail on a rule pfBlockerNG never created.
+
+Real pfSense renders every config ``filter/rule`` row that carries a ``descr`` as
+``label "USER_RULE: <descr>"`` in PLAIN ``pfctl -sr`` output — no ``-v`` needed, pf
+labels are rule TEXT emitted by ``print_rule()`` regardless of verbosity (confirmed on
+a live CE 2.8 smoke-diagnostics guest, run 28704593724). pfBlockerNG's DoT/DoQ block
+rows carry descr ``pfB_DoT_Block_<iface>`` (or the floating variant
+``pfB_DoT_Block_Floating``) — anchoring on that rendered label PREFIX lets the matcher
+tell a pfB-owned 853 block from any other.
+
+Importing ``tests.smoke.test_dot_doq_block`` here is import-safe off-VM — established
+pattern: ``tests/test_bench_pfctl_parse.py`` pulls pure functions out of
+``tests/smoke/`` the same way.
+"""
+
+from __future__ import annotations
+
+from tests.smoke.test_dot_doq_block import _is_block_853_line
+
+
+def _rendered_line(*, action: str, port_token: str, label: str | None) -> str:
+    """Build a realistic ``pfctl -sr`` line in the shape pfSense actually renders.
+
+    Mirrors the evidence from a live CE 2.8 guest (run 28704593724): plain ``pfctl -sr``
+    prints ``label "USER_RULE: <descr>"`` (plus an internal ``id:N`` label) for every
+    config filter/rule row that carries a ``descr``.
+    """
+    label_clause = f' label "USER_RULE: {label}"' if label is not None else ""
+    return (
+        f"{action} out on em0 inet46 proto tcp from any to ! (self) "
+        f"port = {port_token} flags S/SA keep state{label_clause} "
+        'label "id:1782416890" ridentifier 1782416890'
+    )
+
+
+def test_pfb_owned_reject_default_rendering_matches() -> None:
+    """(a) The genuine pfB DoT-block rendered line (Reject default, domain-s) matches.
+
+    Given the reject-default rule's pfctl -sr line (pfSense renders 'reject' as
+      'block return' — PR #562) carrying the pfB_DoT_Block_wan label,
+    Then _is_block_853_line returns True.
+    """
+    line = _rendered_line(action="block return", port_token="domain-s", label="pfB_DoT_Block_wan")
+    assert _is_block_853_line(line), f"expected a match for the genuine pfB rendered line, got False:\n  {line!r}"
+
+
+def test_foreign_853_block_line_without_pfb_label_does_not_match() -> None:
+    """(b) A foreign block rule on port 853 with NO pfB label must NOT match (#813).
+
+    Given a baked harness-style block rule that also targets port 853 (some other
+      firewall policy on the smoke image, unrelated to pfBlockerNG),
+    Then _is_block_853_line returns False — the label anchor rejects it.
+
+    RED on the pre-#813 matcher (``"block" in line and ("853" in line or "domain-s" in
+    line)``, no label check): that older matcher returns True here, false-matching the
+    positive gate and making the ABSENT gate false-fail on a rule pfBlockerNG never
+    created.
+    """
+    line = _rendered_line(action="block drop", port_token="853", label="Deny inbound DoT probe")
+    assert not _is_block_853_line(line), (
+        f"expected NO match for a foreign (non-pfB) port-853 block line, got True:\n  {line!r}"
+    )
+
+
+def test_pfb_labeled_non_853_line_does_not_match() -> None:
+    """(c) A pfB-labeled block rule that is NOT about port 853 must not match.
+
+    Given a pfctl -sr line carrying the pfB_DoT_Block_ label but a different port,
+    Then _is_block_853_line returns False — the label alone is not sufficient without
+      the 853/domain-s port token.
+    """
+    line = _rendered_line(action="block return", port_token="http", label="pfB_DoT_Block_wan")
+    assert not _is_block_853_line(line), f"expected NO match (wrong port), got True:\n  {line!r}"
+
+
+def test_block_action_rendering_also_matches() -> None:
+    """(d) The explicit Block-action rendering ('block drop') matches too.
+
+    Given the rule Action selector set to 'block' instead of the Reject default,
+    Then pfSense renders 'block drop' (not 'block return') and _is_block_853_line
+      still returns True — the matcher checks for the substring 'block', covering both
+      dispositions.
+    """
+    line = _rendered_line(action="block drop", port_token="domain-s", label="pfB_DoT_Block_wan")
+    assert _is_block_853_line(line), f"expected a match for the Block-action rendering, got False:\n  {line!r}"
+
+
+def test_floating_variant_label_still_matches() -> None:
+    """The floating opt-in variant (descr pfB_DoT_Block_Floating) still matches.
+
+    Given the floating rule's rendered line — same label PREFIX, different suffix,
+    Then _is_block_853_line returns True: the anchor matches the label PREFIX, not the
+      full per-interface descr, so the floating variant is covered too.
+    """
+    line = _rendered_line(action="block return", port_token="domain-s", label="pfB_DoT_Block_Floating")
+    assert _is_block_853_line(line), f"expected a match for the floating pfB rendered line, got False:\n  {line!r}"


### PR DESCRIPTION
Batch of the four remaining #582 follow-ups — one commit per issue.

## #811 — header-scoped feed verdict + entry-vetting skip log lines
- The four ADR-42 verdict lines (`( local feed unchanged )`, `( 304 not modified )`, `( content changed )`, `( content unchanged )`) now carry a `[ {header} ]` prefix, so log consumers (and the smoke suite) can scope them per feed instead of counting globally.
- `pfb_download()`'s entry URL vetting now also lands a reason-bearing, header-scoped `[ {header} ] {reason} — skipped` line in the main log when the feed-host guard is why validation failed (previously error.log only). The fetch-time gate is kept — it is the DNS-rebind/TOCTOU re-check, now documented as such — resolving the issue's remove-vs-restructure fork in favour of restructure.
- Smoke markers switched to the header-scoped forms; new off-appliance PHPUnit test pins the entry-vetting skip line (fails pre-change, passes post-change).

## #812 — ADR-41 Phase 4: autorule-immutability live wiring (un-skipped)
- `tests/smoke/test_smoke_autorule_immutable.py` module skip removed; both fixtures wired (Deny-only, and the Permit+Deny+user-pass+user-block trap config).
- `pass_order` is now set explicitly per test via the IP-settings config path; the 5-order trap sweep gained the ADR-41 §7 blocked-vs-allowed data-plane probe (civm-driven, killstates-style state/packet-counter instrument), with the user Block prepended ahead of the default LAN allow so the order_0/order_4 probes are decisive.
- Config-order-proven vs data-plane-proven assertions are labelled per test.

## #813 — anchored `_is_block_853_line`
- The matcher now requires the rendered `USER_RULE: pfB_DoT_Block_` label in addition to the block+853/`domain-s` tokens, so a foreign port-853 block rule baked onto the smoke image can never false-match the positive gate or false-fail the ABSENT gate. Plain `pfctl -sr` renders the label (confirmed on a live CE 2.8 guest snapshot, run 28704593724) — no `-srvv` needed.
- The diagnostic lister keeps showing near-miss lines (tagged `[pfB]`/`[other]`). New off-VM unit test pins the anchor (the foreign-rule case fails on the old matcher).

## #814 — syslog-export IP-block wait matches the victim dst
- `test_syslog_on_ip_block_event_exported` now waits for a line carrying the literal `TEST_IP_BLOCK_DST` AND an `act=` token (was: any new pfB `act=` event). On timeout the diagnostics print near-miss lines (new pfB events that did not reference the victim dst) so a hostname-vs-literal-IP mismatch is visible evidence, not a bare timeout.

## Validation
- Off-appliance: pytest 2127 passed, PHPUnit 2123 passed, PHPStan/PHPCS/ruff/mypy clean.
- Live: impacted CE dispatch (changed smoke modules) + a Plus-leg dispatch of the autorule module (ADR-41 wants the CE+Plus fan-out) — links in the PR checks/comments.

Fixes #811
Fixes #812
Fixes #813
Fixes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed-update and download logging so skipped, unchanged, and modified states are shown with clearer feed-specific context.
  * Added more precise handling for rejected downloads, helping distinguish why a feed was skipped.
  * Tightened syslog export checks so IP-block events are recorded with the expected destination IP.

* **Tests**
  * Expanded smoke and regression coverage for feed updates, rule ordering, DoT/DoQ blocking, and log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->