### PR TITLE
pfblockerng: pass the raw path to unlink_if_exists() in the gzip GeoIP/ASN branches

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9440,7 +9440,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					return FALSE;
 				}
 				exec("/usr/bin/tar -xzf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1");
-				unlink_if_exists($file_dwn_esc);
+				unlink_if_exists($file_download);
 				return TRUE;
 			}
 			elseif ($type == 'asn') {
@@ -9449,7 +9449,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				// Update ASN Lookup table definitions
 				exec("{$pfb['script']} asn_table {$elog}");
 
-				unlink_if_exists($file_dwn_esc);
+				unlink_if_exists($file_download);
 				return TRUE;
 			}
 			elseif ($type == 'blacklist') {

--- a/tests/php/EscapedPathFilesystemCallTest.php
+++ b/tests/php/EscapedPathFilesystemCallTest.php
@@ -24,12 +24,40 @@ final class EscapedPathFilesystemCallTest extends TestCase
 {
 	/**
 	 * Filesystem calls that take a path argument. Shell-exec functions are
-	 * deliberately absent — _esc is correct there.
+	 * deliberately absent — _esc is correct there. rename()/copy() get a
+	 * second alternative for their destination-path (second) argument.
 	 */
 	private const FS_CALL_PATTERN =
 		'/\b(?:unlink_if_exists|unlink|file_exists|is_file|is_dir|is_link|touch|rename|copy'
 		. '|filesize|filemtime|file_get_contents|file_put_contents|readfile|fopen|mkdir|rmdir'
-		. '|rmdir_recursive|safe_mkdir)\s*\(\s*\$[A-Za-z0-9_]*_esc\b/';
+		. '|rmdir_recursive|safe_mkdir)\s*\(\s*\$[A-Za-z0-9_]*_esc\b'
+		. '|\b(?:rename|copy)\s*\([^,)]*,\s*\$[A-Za-z0-9_]*_esc\b/';
+
+	/**
+	 * Scenario: the pattern catches an _esc path in either path argument
+	 *
+	 * Given  representative call shapes — an _esc first argument, an _esc
+	 *        destination (second) argument of rename()/copy(), and a
+	 *        legitimate shell-exec interpolation
+	 * When   each is matched against FS_CALL_PATTERN
+	 * Then   the filesystem calls match and the shell-exec line does not —
+	 *        so the src/ scan below cannot silently under-detect.
+	 */
+	public function test_pattern_catches_escaped_path_in_either_argument(): void
+	{
+		$mustMatch = [
+			'unlink_if_exists($file_dwn_esc);',
+			"unlink_if_exists(\n\t\$file_dwn_esc\n);",
+			'rename($src, $dst_esc);',
+			'copy("/tmp/a", $dst_esc);',
+		];
+		foreach ($mustMatch as $snippet) {
+			$this->assertSame(1, preg_match(self::FS_CALL_PATTERN, $snippet),
+				"FS_CALL_PATTERN must match: {$snippet}");
+		}
+		$this->assertSame(0, preg_match(self::FS_CALL_PATTERN, 'exec("/usr/bin/tar -xzf {$file_dwn_esc}");'),
+			'Shell-exec interpolation is the legitimate use of _esc and must not match');
+	}
 
 	/**
 	 * Scenario: no shipped PHP passes an escapeshellarg()-quoted variable to a
@@ -55,7 +83,10 @@ final class EscapedPathFilesystemCallTest extends TestCase
 			}
 			$source = file_get_contents($file->getPathname());
 			$this->assertNotFalse($source, "Failed to read {$file->getPathname()}");
-			if (preg_match_all(self::FS_CALL_PATTERN, $source, $m, PREG_OFFSET_CAPTURE)) {
+			$count = preg_match_all(self::FS_CALL_PATTERN, $source, $m, PREG_OFFSET_CAPTURE);
+			// FALSE = regex-engine error, which must fail loud — not read as "no match".
+			$this->assertNotFalse($count, "preg_match_all failed on {$file->getPathname()}");
+			if ($count) {
 				foreach ($m[0] as [$match, $offset]) {
 					$line = substr_count($source, "\n", 0, $offset) + 1;
 					$rel  = substr($file->getPathname(), strlen($root) + 1);

--- a/tests/php/EscapedPathFilesystemCallTest.php
+++ b/tests/php/EscapedPathFilesystemCallTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source pin for issue #823: a PHP filesystem builtin (or unlink_if_exists())
+ * must never receive an `*_esc` variable — by repo convention those hold
+ * escapeshellarg()-quoted strings, so the literal path probed on disk carries
+ * the surrounding single quotes and never exists. The call silently no-ops
+ * (pfb_download()'s gzip GeoIP/ASN branches left the downloaded .raw behind).
+ *
+ * The escaped form belongs in shell command lines (exec/shell_exec) only;
+ * filesystem calls take the raw path (the `trim($x_esc, "'")` companions,
+ * e.g. $file_download in pfb_download()).
+ *
+ * pfb_download() itself is not off-appliance unit-testable (curl/exec — see
+ * ArchiveValidateWiringTest), so this pins the defect statically across all
+ * shipped PHP: red on the pre-fix source (two hits), red again if the
+ * pattern is reintroduced anywhere.
+ */
+final class EscapedPathFilesystemCallTest extends TestCase
+{
+	/**
+	 * Filesystem calls that take a path argument. Shell-exec functions are
+	 * deliberately absent — _esc is correct there.
+	 */
+	private const FS_CALL_PATTERN =
+		'/\b(?:unlink_if_exists|unlink|file_exists|is_file|is_dir|is_link|touch|rename|copy'
+		. '|filesize|filemtime|file_get_contents|file_put_contents|readfile|fopen|mkdir|rmdir'
+		. '|rmdir_recursive|safe_mkdir)\s*\(\s*\$[A-Za-z0-9_]*_esc\b/';
+
+	/**
+	 * Scenario: no shipped PHP passes an escapeshellarg()-quoted variable to a
+	 * filesystem call
+	 *
+	 * Given  every tracked .php/.inc file under src/
+	 * When   each is scanned for a filesystem call whose first argument is an
+	 *        `$…_esc` variable
+	 * Then   no file matches — a match means the quoted string is being used
+	 *        as an on-disk path, which can never exist.
+	 */
+	public function test_no_filesystem_call_receives_escaped_path(): void
+	{
+		$root = dirname(__DIR__, 2);
+		$violations = [];
+
+		$iter = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator("{$root}/src", FilesystemIterator::SKIP_DOTS)
+		);
+		foreach ($iter as $file) {
+			if (!in_array($file->getExtension(), ['php', 'inc'], TRUE)) {
+				continue;
+			}
+			$source = file_get_contents($file->getPathname());
+			$this->assertNotFalse($source, "Failed to read {$file->getPathname()}");
+			if (preg_match_all(self::FS_CALL_PATTERN, $source, $m, PREG_OFFSET_CAPTURE)) {
+				foreach ($m[0] as [$match, $offset]) {
+					$line = substr_count($source, "\n", 0, $offset) + 1;
+					$rel  = substr($file->getPathname(), strlen($root) + 1);
+					$violations[] = "{$rel}:{$line}: {$match}";
+				}
+			}
+		}
+
+		$this->assertSame([], $violations,
+			"Filesystem call(s) passed an escapeshellarg()-quoted (_esc) variable — the quoted\n"
+			. "literal is never a real path, so the call silently no-ops. Pass the raw path\n"
+			. "(its trim(…, \"'\") companion) instead:\n  " . implode("\n  ", $violations)
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Two `unlink_if_exists()` calls in `pfb_download()`'s gzip GeoIP/ASN branches passed `$file_dwn_esc` — the `escapeshellarg()`-quoted string — so the literal path probed on disk carried the surrounding single quotes and never existed. The downloaded `.raw` file was silently left behind after GeoIP/ASN extras downloads (disk noise; subsequent runs overwrite the same path). Both calls now take `$file_download` (the trimmed raw path), matching the sibling call sites in the same branches.

## Test

`pfb_download()` is not off-appliance unit-testable (curl/exec — see `ArchiveValidateWiringTest`), so `EscapedPathFilesystemCallTest` pins the defect statically across all shipped PHP: any filesystem builtin (or `unlink_if_exists()`) receiving an `$…_esc` variable fails the test. Red on the pre-fix source (exactly the two sites), green after; a repo-wide sweep confirmed no other occurrences.

## Gates

- `php -l` clean
- PHPUnit: 2130 tests, 17795 assertions, green (5 pre-existing host-tool skips)
- PHPStan (`--memory-limit=1G`): no errors
- PHPCS: clean

Fixes #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfJUsCQkpFZxXufncGUS2f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cleanup behavior so temporary files are removed using the intended file reference in key processing paths.
* **Tests**
  * Added a new automated check to catch filesystem operations that use escaped path variables.
  * Expanded coverage to scan shipped PHP files and flag any matching violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->