### PR TITLE
ADR-49: opt-in plain-text feed sanity scanning

### DIFF
--- a/.ADRs/ADR_49_Plain_Text_Sanity_Scan/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_49_Plain_Text_Sanity_Scan/RESULTS/01_Results.txt
@@ -109,7 +109,7 @@ stale/broken:
 None of the 5 is a plain, healthy blocklist body misclassified by the
 heuristic; each reflects a stale corpus snapshot (deprecated/gated/wrong-
 URL feed) captured by PR #827's one-time fetch. STOPPING here per the
-brief — the acceptance decision (refresh the corpus, exclude these 4 known-
+brief — the acceptance decision (refresh the corpus, exclude these 5 known-
 stale/misconfigured catalogue entries, or something else) is Phase 3's /
 the maintainer's call, not this phase's. The scanner logic is unchanged
 from the spec and must stay that way pending that decision.

--- a/.ADRs/ADR_49_Plain_Text_Sanity_Scan/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_49_Plain_Text_Sanity_Scan/RESULTS/01_Results.txt
@@ -1,0 +1,170 @@
+================================================================================
+PHASE 1 RESULTS — Pure pfb_text_sanity() scanner + oracle tests
+================================================================================
+
+FUNCTION
+--------
+src/usr/local/pkg/pfblockerng/pfblockerng.inc:1006
+    function pfb_text_sanity(string $sample): ?string
+
+Pure: string in, ?string out. No I/O, no globals. BYTE-LEVEL matching only —
+no `/u` modifier anywhere in the function.
+
+Verdict order (first hit wins):
+    1. 'nul_bytes'          — any \x00 byte anywhere in the sample.
+    2. 'html_error_page'    — opens (case-insensitive, after left-trim) with
+                              "<!doctype html" or "<html" AND none of the
+                              first 20 lines is blocklist-shaped (IPv4/IPv6/
+                              CIDR, or a bare/ABP-wrapped domain.tld token —
+                              a hosts-style "IP<ws>domain" line is already
+                              covered by the IP branch).
+    3. 'below_min_content'  — zero non-blank, non-comment lines (floor = 1,
+                              a LINE-count floor, never a byte-size floor).
+    4. otherwise NULL.
+
+No call-site changes, no config field, no www/ change — the function is
+added, unused, exactly per the phase scope.
+
+RED -> GREEN EVIDENCE
+---------------------
+tests/php/PfbTextSanityTest.php was written FIRST, against the pre-change
+code (pfb_text_sanity() did not yet exist):
+
+    $ vendor/bin/phpunit --filter PfbTextSanityTest
+    PHPUnit 11.5.55 by Sebastian Bergmann and contributors.
+    ...
+    EEEEEEEEEEEEEEEEEEEEE                                             21 / 21 (100%)
+    Time: 00:00.050, Memory: 30.00 MB
+    There were 21 errors:
+    1) PfbTextSanityTest::test_plain_ipv4_cidr_list_is_sane
+    Error: Call to undefined function pfb_text_sanity()
+    ...
+    ERRORS!
+    Tests: 21, Assertions: 0, Errors: 21.
+
+All 21 tests errored for the exact reason the change addresses (undefined
+function). After adding pfb_text_sanity() to pfblockerng.inc:
+
+    $ vendor/bin/phpunit --filter PfbTextSanityTest
+    .....................                                             21 / 21 (100%)
+    Time: 00:00.052, Memory: 30.00 MB
+    OK (21 tests, 21 assertions)
+
+Branch coverage in PfbTextSanityTest.php (21 tests): real blocklist samples
+(IPv4/CIDR, hosts-style, ABP-wrapped, single-line, tiny few-byte feed,
+comment-header-then-data) -> NULL; nul_bytes (bare + "wins over otherwise-
+valid text" + "wins over HTML" order proofs); html_error_page (no-blocklist-
+line + lower/upper/mixed-case + leading-whitespace tolerance) with its guard
+(HTML body containing a blocklist line -> NULL); below_min_content (empty,
+whitespace-only, comment-only); and the byte-level truncation cases (an
+8 KiB sample cut mid-token, and a dangling partial multibyte UTF-8 tail —
+neither changes an otherwise-valid NULL verdict).
+
+FEEDCORPUSSURVEYTEST RESULT — FAILED (5 flagged feeds; NOT a scanner bug)
+--------------------------------------------------------------------------
+Per the phase prompt: the survey activated automatically the moment
+pfb_text_sanity() became defined (function_exists() flips TRUE). It did
+NOT pass — 5 of ~150+ text samples in the committed corpus
+(tests/fixtures/feed_corpus/) were flagged:
+
+    MPatrol          (lists.malwarepatrol.net/cgi/getfile?...)  -> below_min_content
+    Abuse_SSLBL      (sslbl.abuse.ch/blacklist/sslipblacklist.txt)          -> below_min_content
+    Abuse_SSLBL_Agr  (sslbl.abuse.ch/blacklist/sslipblacklist_aggressive.txt) -> below_min_content
+    Darklist         (www.darklist.de/raw.php)                  -> below_min_content
+    MaxMind_BD_Proxy (www.maxmind.com/en/high-risk-ip-sample-list) -> html_error_page
+
+Per the phase-1 brief, the scanner was NOT loosened to force this green —
+each sample was inspected byte-for-byte instead (od -c) to judge whether the
+flag is a genuine scanner false positive or the corpus/catalogue itself is
+stale/broken:
+
+  - MPatrol (147 bytes): the ENTIRE sample is
+    "# Your access was denied.\n# You may have supplied a wrong password,
+    your subscription may have expired or you may not have access to this
+    resource." — this feed requires an API key; the corpus fetch used an
+    unresolved `receipt=_API_KEY_` placeholder and got an auth-denied
+    message back, not real data. All lines are '#'-comments -> zero data
+    lines is CORRECT for this input; not a scanner defect.
+
+  - Abuse_SSLBL / Abuse_SSLBL_Agr (527 / 533 bytes): the entire sample is
+    the feed's header block ending in "# ATTENTION: This list has been
+    deprecated on 2025-01-03\n#\n" — abuse.ch discontinued this list before
+    the corpus was captured. Every line is a '#'-comment -> genuinely zero
+    data lines today; correct catch, not a false positive.
+
+  - Darklist (68 bytes): the entire sample is
+    "# darklist.de - blacklisted raw IPs\n# generated on 04.07.2026 12:22\n"
+    — the live fetch returned only the header with no IP rows at all at
+    capture time. Same shape as above: zero data lines is what was
+    actually served.
+
+  - MaxMind_BD_Proxy (8192 bytes, full cap): a genuine, fully-rendered
+    marketing HTML page (`<!DOCTYPE html>...<title>Sample list of high
+    risk IP addresses | MaxMind</title>...`) — the catalogue URL
+    (maxmind.com/en/high-risk-ip-sample-list) points at MaxMind's webpage
+    ABOUT the sample list, not a raw data endpoint. No blocklist-shaped
+    line appears in the first 20 lines of real HTML/JS boilerplate, so
+    html_error_page fires correctly — this URL is not a raw feed at all.
+
+None of the 5 is a plain, healthy blocklist body misclassified by the
+heuristic; each reflects a stale corpus snapshot (deprecated/gated/wrong-
+URL feed) captured by PR #827's one-time fetch. STOPPING here per the
+brief — the acceptance decision (refresh the corpus, exclude these 4 known-
+stale/misconfigured catalogue entries, or something else) is Phase 3's /
+the maintainer's call, not this phase's. The scanner logic is unchanged
+from the spec and must stay that way pending that decision.
+
+PHPUNIT / PHPSTAN / PHPCS SUMMARIES
+------------------------------------
+$ vendor/bin/phpunit
+    Tests: 2150, Assertions: 17789, Failures: 1 (FeedCorpusSurveyTest, see
+    above), Skipped: 4 (pre-existing, unrelated — e.g. FileMtimeTest's
+    macOS VFS-staleness skip; the FeedCorpusSurveyTest skip that existed
+    before this phase is GONE, replaced by the failure above, confirming
+    the survey activated as expected).
+
+$ php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc
+    No syntax errors detected (pre-existing PHP-8.5-vs-8.3 deprecation
+    notices for unrelated legacy functions unchanged by this diff).
+
+$ vendor/bin/phpstan analyse --memory-limit=1G
+    [OK] No errors.
+    (Note: the bare `vendor/bin/phpstan analyse` invocation hit PHP's
+    default 128M child-process memory limit against this large .inc file
+    on this box — a local-environment ceiling, not a code issue — so
+    --memory-limit=1G was used to get a real answer. Zero new errors.)
+
+$ vendor/bin/phpcs --standard=phpcs.xml.dist src/
+    Clean (no output).
+
+DIFF SCOPE
+----------
+$ git diff --stat
+    src/usr/local/pkg/pfblockerng/pfblockerng.inc | 72 +++++++++++++++++++++
+    1 file changed, 72 insertions(+)
+plus the new tests/php/PfbTextSanityTest.php (untracked -> staged in the
+commit). Exactly the two files the phase scoped: pfblockerng.inc +
+tests/php/PfbTextSanityTest.php. No call-site, config, or www/ changes.
+
+COMMIT / PUSH
+-------------
+Commit: pfblockerng: add pure plain-text feed sanity scanner (ADR-49 P1)
+(hash recorded by the calling orchestrator / see `git log -1`)
+Pushed directly to adr/49-plain-text-sanity-scan.
+
+WATCH-OUT FOR PHASE 2
+----------------------
+Wire point: pfb_download(), right after the FILE_MIME accept
+(pfblockerng.inc ~L9399-9403 on this branch — the
+`$file_type = pfb_filter(..., PFB_FILTER_FILE_MIME, ...)` block). Scan ONLY
+on text branches (text/plain | text/html | text/csv) — exclude
+application/json, application/x-ndjson (structured, line-count heuristics
+meaningless), and inode/x-empty (its own signal, out of this ADR's scope).
+Gate on the new `pfb_feed_sanity` PfbConfig field (PfbToggle, default OFF —
+zero behaviour change when off, asserted by test). On a non-NULL verdict,
+reject via `pfb_validate_log($header, 'plaintext', $reason, ...)` (ADR-48
+stage=plaintext), mirroring the existing `mime`/`entries` stage call
+sites already in pfb_download(). Also carry forward the 5 flagged corpus
+feeds above into Phase 3's survey-acceptance discussion — they are the
+concrete list Phase 3 (or the maintainer) needs to decide on before any
+default-on change and before the ADR can flip to Accepted.

--- a/.ADRs/ADR_49_Plain_Text_Sanity_Scan/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_49_Plain_Text_Sanity_Scan/RESULTS/02_Results.txt
@@ -1,0 +1,194 @@
+================================================================================
+PHASE 2 RESULTS — pfb_feed_sanity PfbConfig field + wire the gate (default-off)
+================================================================================
+
+REGISTRY ENTRY (pfblockerng_extra.inc, pfb_cfg_registry(), $gen section)
+--------------------------------------------------------------------------
+Inserted grouped with the other pfb_feed_* toggles (after pfb_feed_internal_
+allowlist, before pfb_reuse):
+
+    // ADR-49: opt-in plain-text feed sanity scan. Checkbox 'on'|''(off).
+    // Default off (absent = off = today's behaviour: the scan never runs).
+    'pfb_feed_sanity' => [
+        'section'       => $gen,
+        'default'       => '',                       // absent -> Off (new-install default too)
+        'read_adapter'  => 'pfb_cfg_toggle_read',
+        'write_adapter' => 'pfb_cfg_toggle_write',
+        'since'         => '4.0.0',
+    ],
+
+No grandfather seed: the scan is new behaviour, so an absent key ⇒ Off is
+identical for an existing install AND a brand-new one (unlike
+pfb_alias_delta_mode's ADR-40 seed, which had to diverge new-install vs
+upgrade defaults).
+
+$registeredPaths (tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php):
+added 'installedpackages/pfblockerng/config/0/pfb_feed_sanity' next to the
+sibling pfb_feed_* entries.
+
+$inventory (tests/php/CfgGatewayTest.php, testInventoryCompletenessAllKnown
+KeysAccountedFor): added 'pfb_feed_sanity' next to the sibling pfb_feed_*
+keys (config-gateway.md checklist step 5).
+
+WIRE LOCATION
+-------------
+src/usr/local/pkg/pfblockerng/pfblockerng.inc, inside pfb_download(),
+immediately after the FILE_MIME accept block (post-Phase-1 line numbers:
+accept block at 9471-9475; gate inserted at 9477-9491, right before the
+"Create update file markers" comment):
+
+    $file_type = pfb_filter(array(...), PFB_FILTER_FILE_MIME, 'pfb_download', '', FALSE, $reject_detail);
+    if (!$file_type) {
+        pfb_validate_log($header, 'mime', 'mime_not_allowed', pfb_reject_detail_summary($reject_detail));
+        return FALSE;
+    }
+
+    // ADR-49: opt-in plain-text sanity scan on accepted text feeds. Flag check
+    // FIRST -- default-off short-circuits before the MIME check and the file
+    // read, so an off install is byte-for-byte unchanged (ADR-28 conv 2).
+    if (PfbConfig::read('pfb_feed_sanity') === PfbToggle::On &&
+        in_array($file_type, array('text/plain', 'text/html', 'text/csv'), TRUE)) {
+        // Read UP TO 8 KiB -- a cap, not a minimum; a shorter feed is read whole.
+        $pfb_sanity_sample = (string) @file_get_contents($file_download, FALSE, NULL, 0, 8192);
+        $pfb_sanity = pfb_text_sanity($pfb_sanity_sample);
+        if ($pfb_sanity !== NULL) {
+            pfb_validate_log($header, 'plaintext', $pfb_sanity, basename($file_download));
+            unlink_if_exists($file_download);
+            return FALSE;
+        }
+    }
+
+    // Create update file markers on new downloads available
+
+Sampled var: $file_download. Confirmed by reading the surrounding code —
+this is the branch entered only when `file_exists($file_download) &&
+$http_status in {200,221,226}` (the just-downloaded, accepted body); the
+gzip/x-bzip2/zip/7z decompression branches are `elseif ($file_type ==
+'application/...')` arms further down (line ~9498+), all mutually exclusive
+with the text/plain|html|csv values this gate matches on. So for every
+$file_type this gate can see, $file_download IS the final on-disk text body
+-- nothing downstream re-decodes it first.
+
+Left-to-right && short-circuit: the flag comparison is the FIRST operand,
+so `PfbConfig::read('pfb_feed_sanity') === PfbToggle::On` is evaluated
+before the `in_array($file_type, ...)` MIME check and long before the
+`file_get_contents()` read -- with the flag off (default), neither the MIME
+membership test nor the file read nor pfb_text_sanity() ever executes.
+This satisfies the ADR §7 reject criterion verbatim ("the scan ever runs
+with pfb_feed_sanity off").
+
+MIME scope is exactly {'text/plain', 'text/html', 'text/csv'} -- no
+application/json, application/x-ndjson, or inode/x-empty. The 8192 in the
+file_get_contents() call is the ONLY size literal in the gate and is a cap
+(4th param = length); no minimum-size check was added.
+
+Reject stage is the literal string 'plaintext' (ADR-48's stage vocabulary),
+mirroring the existing 'mime'/'structural'/'member' stage call sites already
+in pfb_download(). No new log format invented.
+
+CFGGATEWAYTEST RED -> GREEN EVIDENCE
+--------------------------------------
+Round-trip: pfb_feed_sanity was folded into the existing table-driven
+testToggleFieldsRoundTripOn()/Off() (added to the shared $toggle_fields
+map) alongside its sibling PfbToggle fields -- same 'on'/'' round-trip
+proof, no new test method needed for that half.
+
+Default-absent: a NEW dedicated test, matching the house style of
+testReadReturnsRegisteredDefaultForToggleAbsentKey():
+
+    testReadReturnsRegisteredDefaultForPfbFeedSanityAbsentKey()
+        Given: config_get_path(.../pfb_feed_sanity) is NULL (absent).
+        When:  PfbConfig::read('pfb_feed_sanity').
+        Then:  PfbToggle::Off is returned.
+
+RED proof (registry entry temporarily stashed via
+`git stash push -- .../pfblockerng_extra.inc`, pre-change code):
+
+    $ vendor/bin/phpunit --filter 'FeedSanity|ToggleFieldsRoundTrip'
+    EEE                                                        3 / 3 (100%)
+    There were 3 errors:
+    1) CfgGatewayTest::testToggleFieldsRoundTripOn
+    InvalidArgumentException: PfbConfig: key 'pfb_feed_sanity' is not in
+    the field registry. Use config_get_path() directly for foreign/
+    unregistered keys.
+    2) CfgGatewayTest::testToggleFieldsRoundTripOff  -- same error
+    3) CfgGatewayTest::testReadReturnsRegisteredDefaultForPfbFeedSanityAbsentKey -- same error
+    ERRORS!
+    Tests: 3, Assertions: 39, Errors: 3.
+
+All 3 failed for the exact reason the change addresses (unregistered key ->
+InvalidArgumentException, the ADR-29 gateway contract). Registry entry
+restored (`git stash pop`) -> GREEN:
+
+    $ vendor/bin/phpunit --filter 'FeedSanity|ToggleFieldsRoundTrip'
+    ...                                                         3 / 3 (100%)
+    OK (3 tests, 44 assertions)
+
+WIRING PROOF -- DEFERRED TO PHASE 3 (documented split, not coverage theater)
+------------------------------------------------------------------------------
+pfb_download() runs shell/exec (touch/exec/rename/tar/etc.) and is NOT
+off-appliance unit-testable -- same split as ADR-42/45/48. The wiring's own
+red->green (flag-on rejects an HTML-error text feed with stage=plaintext;
+flag-off/default imports it unchanged; a healthy text feed still imports
+with the flag on) is Phase 3's live-VM smoke, per ADR-49 §6 Phase 3 /
+CLAUDE.md's test-coverage mandate. What IS covered here is Phase 2's own
+unit-testable surface: the field's registration, round-trip, and default-
+absent contract (above) -- no pfb_download() unit test was faked.
+
+PHPUNIT / PHPSTAN / PHPCS SUMMARIES
+------------------------------------
+$ vendor/bin/phpunit
+    Tests: 2151, Assertions: 17835, Skipped: 4 (pre-existing, unrelated --
+    e.g. FileMtimeTest's macOS VFS-staleness skip). FeedCorpusSurveyTest is
+    green (the 5 non-feed corpus samples were already excluded in the P1
+    commit b2d87b29, which is the base of this phase's work).
+
+$ php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc
+$ php -l src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+    No syntax errors detected (same pre-existing PHP-8.5-vs-8.3 deprecation
+    notices for unrelated legacy functions, unchanged by this diff).
+
+$ vendor/bin/phpstan analyse --memory-limit=1G
+    [OK] No errors.
+
+$ vendor/bin/phpcs --standard=phpcs.xml.dist src/
+    Clean (no output) -- RequireConfigGateway passes: pfb_feed_sanity is
+    registered, present in $registeredPaths, and read exclusively via
+    PfbConfig::read() in pfb_download().
+
+DIFF SCOPE
+----------
+$ git diff --stat
+    src/usr/local/pkg/pfblockerng/pfblockerng.inc                          | 15 +++++++++++++
+    src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc                    | 10 +++++++++
+    tests/php/CfgGatewayTest.php                                          | 25 ++++++++++++++++++++++
+    tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php   |  2 ++
+    4 files changed, 52 insertions(+)
+Exactly the four scoped files. No www/ or GUI change.
+
+FOR PHASE 3 SMOKE
+-----------------
+- Reject shape to grep (ADR-48 canonical RENDERED line, from
+  pfb_validate_log_line()):
+      pfb_validate: REJECT feed=<header>_v4 stage=plaintext reason=<token> detected=<basename>
+  Family-suffix gotcha (per the ADR-48 handoff): the on-box log line renders
+  the header with its family suffix (e.g. "_v4"), not the bare feed name --
+  grep for "_v4" (or "_v6"), not the raw config header string. The line is
+  htmlspecialchars()-escaped (control bytes -> space, then htmlspecialchars);
+  a plain grep for literal text is fine, but a value containing HTML-special
+  chars (unlikely for <token>/<basename>) would render escaped.
+  <token> is one of: nul_bytes | html_error_page | below_min_content
+  (pfb_text_sanity()'s verdict, Phase 1). <basename> is basename($file_download).
+- The flag is config-only, no GUI: smoke sets it directly via
+  PfbConfig::write('pfb_feed_sanity', PfbToggle::On) (or the raw config.xml
+  'on' token) -- there is no www/ checkbox to click.
+- Confirm on-FreeBSD file(1) classification of whatever HTML-error-page
+  fixture Phase 3 introduces actually lands in {text/plain, text/html,
+  text/csv} (the MIME gate classifies via on-box file(1), not the mock
+  server's Content-Type header) -- per ADR-49 §5's "Smoke fixture platform
+  check" constraint.
+
+COMMIT / PUSH
+-------------
+Commit: pfblockerng: wire opt-in plain-text sanity scan on text feeds (ADR-49 P2)
+Pushed directly to adr/49-plain-text-sanity-scan.

--- a/.ADRs/ADR_49_Plain_Text_Sanity_Scan/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_49_Plain_Text_Sanity_Scan/RESULTS/03_Results.txt
@@ -1,0 +1,252 @@
+================================================================================
+PHASE 3 RESULTS — Smoke + the offline false-positive survey (acceptance gate)
+================================================================================
+
+SCOPE NOTE (per the orchestrator's brief)
+------------------------------------------
+This phase authored the smoke fixture + cases (verifiable off-box: collect,
+lint, static review) and ran the OFFLINE survey. The live CE+Plus smoke
+fan-out itself is a ~30 min GH dispatch that is the ORCHESTRATOR's acceptance
+step, not run here. ADR-49 stays "Implemented (pending smoke)" until that
+fan-out is green (see "REMAINING STEP" below).
+
+FIXTURE
+-------
+tests/smoke/fixtures/html_error_page.html (new) — a realistic 403 error page:
+
+    <!doctype html>
+    <html>
+    <head><title>403 Forbidden</title></head>
+    <body>
+    <h1>403 Forbidden</h1>
+    <p>Access to this resource on this server is denied</p>
+    <p>You do not have permission to view this page using the credentials supplied</p>
+    <p>Please contact the site administrator if you believe this is an error</p>
+    <p>Reference id 7f3a9c21e04b</p>
+    </body>
+    </html>
+
+Deliberately carries ZERO periods anywhere (the body avoids "word.word"
+constructs entirely) and no colons -- pfb_text_sanity()'s blocklist-shaped
+regex fires on ANY IPv4/CIDR, ANY "::" substring, or ANY "label.label"-shaped
+token (a bare domain.tld look-alike, e.g. even "index.html" written inline
+would match) -- so this fixture is unambiguous html_error_page bait with no
+accidental false-negative path.
+
+Verified LOCALLY (pure PHP, no FreeBSD needed -- pfb_text_sanity() is pure):
+    $ php -r 'require_once "tests/php/bootstrap.php";
+              var_dump(pfb_text_sanity(file_get_contents("tests/smoke/fixtures/html_error_page.html")));'
+    string(15) "html_error_page"
+Also verified the two healthy control fixtures reused for branch (c) both
+return NULL: ip_plain_cidr.txt, dnsbl_plain.txt.
+
+on-box file(1) verdict: EXPECTED text/html (verify on first live run) —
+documented that way in fixtures/README.md per the ADR-45 libmagic-divergence
+lesson (macOS `file --mime-type` locally reports text/html for this exact
+file -- informational only, NOT authoritative for FreeBSD/libmagic). The new
+smoke case asserts (never skips) the on-box `file -b --mime-type` verdict is
+one of {text/plain, text/html, text/csv} BEFORE asserting the reject, so a
+libmagic surprise fails LOUDLY with the real verdict rather than the reject
+assertion silently passing for the wrong reason (or silently not exercising
+the gate at all).
+
+fixtures/README.md: added a "Plain-text sanity scan fixture (ADR-49...)"
+section documenting the fixture + its expected verdict + which existing
+fixtures serve as the healthy control (ip_plain_cidr.txt / dnsbl_plain.txt).
+
+SMOKE CASES (tests/smoke/test_smoke_feeds.py, marker `smoke`)
+--------------------------------------------------------------
+Two new tests, inserted right after the ADR-48 healthy-ABP-feed test (before
+the ADR-46 section), following the ADR-48 stage-reject house style
+(CaseContext, h.count_log_marker on h.PFB_LOG, _recent_validate_lines on
+failure):
+
+1. test_feed_sanity_flag_gates_html_error_page_reject (branch a+b, the
+   transition test) — @pytest.mark.timeout(180).
+
+   DESIGN NOTE (deviation from the literal "one Force-Update-twice" shape in
+   the phase prompt, documented in the test's own docstring): pfb_download()'s
+   own per-list "reuse" shortcut in pfblockerng.inc (once a header's
+   `{header}.orig`/`.txt` already exists from a prior successful download, a
+   later pass with `updateip`'s force=TRUE/reuse='on' CAN skip straight to
+   reusing the cached body without calling pfb_download() again) means
+   re-Force-Updating the SAME header a second time is not guaranteed to
+   re-invoke the scan at all -- verified by reading the exact IP-download-loop
+   code (pfblockerng.inc ~16571-16630): the "already exists" skip requires the
+   `.orig`/`.txt` to ALREADY exist, which is false on any header's first-ever
+   fetch regardless of the reuse setting. So this test uses TWO DISTINCT,
+   never-before-fetched headers over the SAME served fixture (adr49sanoff for
+   the OFF leg, adr49sanon for the ON leg) -- each header's first fetch is
+   GUARANTEED to invoke pfb_download() fresh, isolating the flag as the only
+   variable that differs between the two legs. This is stricter than a
+   same-header re-fetch, not weaker: the feed BODY is byte-identical in both
+   legs (same fixture file), only pfb_feed_sanity differs.
+
+   Given the scan OFF (explicit + the registered default) + a fresh header
+     (adr49sanoff) with no pre-existing reject line for it (before=0,
+     asserted),
+   When Force-Updating (via CaseContext -> a single targeted `updateip`,
+     per issue #611 / the CaseContext docstring) the HTML-error-page feed
+     under that header,
+   Then NO 'stage=plaintext' line for that header appears (after==before==0)
+     -- the before-state proving an off install is byte-for-byte unaffected.
+   Given the scan flipped ON + a SECOND fresh header (adr49sanon) over the
+     SAME feed body (before=0, asserted),
+   When Force-Updating it,
+   Then a NEW canonical line appears (after > before) AND the alias stays
+     absent from `pfctl_tables()` -- the flag (not the content, identical in
+     both legs) caused the reject.
+
+   Exact reject marker grepped (ADR-48 canonical rendered line, `_v4` family
+   suffix per RESULTS/02's handoff, htmlspecialchars-escaped form -- none of
+   this marker's literal chars need escaping):
+
+       pfb_validate: REJECT feed=adr49sanon_v4 stage=plaintext reason=html_error_page detected=adr49sanon_v4.raw
+
+   `detected=` = basename($file_download), always "{header}_v4.raw" (the
+   package suffixes the header with the family, pfb_download() then appends
+   ".raw" to $file_dwn -- confirmed by reading pfb_download()'s
+   $file_dwn_esc/$file_download construction directly).
+
+   On-box guard: `_box_mime_type(deployed_vm, _fixture_bytes(fixture))` must
+   be in {text/plain, text/html, text/csv} -- asserted (not skipped) up front,
+   per the ADR-45 lesson (a libmagic surprise must fail loudly with the real
+   verdict).
+
+2. test_feed_sanity_flag_on_still_imports_healthy_feed (branch c, the
+   real-branch proof) — @pytest.mark.timeout(120).
+
+   Reuses the already-verified healthy ip_plain_cidr.txt fixture (the Part-C
+   kill-gate fixture for test_ip_http_feed_loads) with pfb_feed_sanity
+   explicitly ON.
+
+   Given the scan ON + the alias absent + no pre-existing 'stage=plaintext'
+     line for a fresh header (adr49sanhlt),
+   When Force-Updating the healthy plain-IP+CIDR feed,
+   Then the listed member (203.0.113.5) loads into the pf table (genuinely
+     imported, via h.wait_pfctl_table + h.member_present) AND the
+     'stage=plaintext' marker count for this header is UNCHANGED (no NEW
+     line) -- proves pfb_text_sanity() is a real branch (rejects the error
+     page, not every text/plain|html|csv feed).
+
+Both tests restore pfb_feed_sanity to OFF in a `finally` (CaseContext's own
+__exit__ already resets pf/derived state per leg; it does not touch
+config/0 keys, so the flag itself needed its own explicit restore, same
+shape as the sibling test_feed_internal_filter_blocks_then_allowlist_exempts).
+
+CONFIG HELPER (tests/smoke/helpers.py)
+-----------------------------------------
+Added `set_feed_sanity(vm, on)`: writes through the ADR-29 gateway exactly as
+the phase prompt specified --
+
+    require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');
+    PfbConfig::write('pfb_feed_sanity', PfbToggle::On|PfbToggle::Off);
+    write_config('pfBlockerNG smoke: set pfb_feed_sanity');
+
+Mirrors the existing `_set_delta_mode` (test_smoke_adr40.py) / `_set_quiet_hours`
+(test_smoke_apply_on_change.py) PfbConfig::write call shape -- the established
+pattern for a config-only PfbConfig-gated field with no www/ checkbox.
+
+Also added `pfb_feed_sanity` to `_BASELINE_GLOBAL_KEYS` (helpers.py) so the
+module-boundary `reset_pfb_baseline()` unsets it between smoke modules --
+same treatment as the sibling `pfb_alias_delta_mode` (ADR-40) and
+`pfb_feed_internal_allowlist` config/0 toggles a test flips, preventing a
+leaked-ON flag from spuriously rejecting a later module's own text/html-ish
+fixture.
+
+PHP: #[CoversFunction] RE-ADDED (tests/php/FeedCorpusSurveyTest.php)
+------------------------------------------------------------------------
+Added `use PHPUnit\Framework\Attributes\CoversFunction;` +
+`#[CoversFunction('pfb_text_sanity')]` on the class (removed in PR #827 while
+the function did not exist yet -- an undefined covers-target is a PHPUnit
+warning the CI suite's --fail-on-warning turns into a failure). Confirmed NO
+warning now that the function exists:
+
+    $ vendor/bin/phpunit --filter FeedCorpusSurveyTest --testdox
+    ..                                                                  2 / 2 (100%)
+    Time: 00:00.070, Memory: 30.00 MB
+    Feed Corpus Survey
+     ✔ Corpus is present and coherent
+     ✔ Catalogue survey has zero false positives
+    OK (2 tests, 1441 assertions)
+
+OFFLINE SURVEY (ADR-49 §7 acceptance gate) — PASS
+----------------------------------------------------
+    $ vendor/bin/phpunit --filter FeedCorpusSurveyTest
+    OK (2 tests, 1441 assertions)
+
+ZERO false positives over the ~150+ committed catalogue text samples (the 5
+KNOWN_NON_FEED exclusions from Phase 1 -- MaxMind_BD_Proxy, Abuse_SSLBL,
+Abuse_SSLBL_Agr, Darklist, MPatrol -- are asserted to STILL be flagged, i.e.
+not stale). Full output persisted at RESULTS/03_Survey.txt. No network at
+test time (offline corpus, per PR #827).
+
+PHPUNIT / PHPSTAN / PHPCS / RUFF / COLLECT SUMMARIES
+--------------------------------------------------------
+$ vendor/bin/phpunit
+    Tests: 2151, Assertions: 17835, Skipped: 4 (same 4 pre-existing, unrelated
+    skips as Phase 2's baseline -- e.g. FileMtimeTest's macOS VFS-staleness
+    skip). FeedCorpusSurveyTest green with the covers attribute restored, no
+    warnings.
+
+$ vendor/bin/phpstan analyse --memory-limit=1G
+    [OK] No errors.
+
+$ vendor/bin/phpcs --standard=phpcs.xml.dist src/
+    Clean (no output) -- no src/ PHP touched this phase.
+
+$ php -l tests/php/FeedCorpusSurveyTest.php
+    No syntax errors detected.
+
+$ python -m pytest --collect-only tests/smoke/test_smoke_feeds.py --override-ini="addopts=" -q
+    48 tests collected (46 baseline + the 2 new ADR-49 cases); both new test
+    names present in the collected list. Only pre-existing
+    PytestUnknownMarkWarning noise from stripping addopts (every
+    @pytest.mark.timeout-decorated test in the file produces the same
+    warning under this override -- unrelated to this diff).
+
+$ ruff check tests/smoke/test_smoke_feeds.py tests/smoke/helpers.py
+    All checks passed!
+$ ruff format --check tests/smoke/test_smoke_feeds.py tests/smoke/helpers.py
+    2 files already formatted (ran `ruff format` once to fix a single
+    over-length f-string before this final check).
+
+DIFF SCOPE
+----------
+$ git diff --stat
+    tests/php/FeedCorpusSurveyTest.php |   9 ++-
+    tests/smoke/fixtures/README.md     |  11 +++
+    tests/smoke/helpers.py             |  27 +++++++
+    tests/smoke/test_smoke_feeds.py    | 154 +++++++++++++++++++++++++++++++++++++
+    4 files changed, 197 insertions(+), 4 deletions(-)
+plus two new untracked files: tests/smoke/fixtures/html_error_page.html and
+this RESULTS/03_Survey.txt. Exactly the scoped surface (test_smoke_feeds.py +
+its fixture + fixtures/README.md + FeedCorpusSurveyTest.php + RESULTS/); no
+src/ PHP, no www/, no config-schema change.
+
+REMAINING STEP — live CE+Plus smoke fan-out (orchestrator's acceptance step)
+---------------------------------------------------------------------------
+NOT run by this phase (out of scope per the brief: "the LIVE CE+Plus smoke
+fan-out is NOT yours to run"). Per CLAUDE.md "ADR acceptance": ADR-49 flips
+to Accepted once (a) this offline survey is green (DONE, above) AND (b) the
+smoke fan-out (CE + Plus) is green for both new cases +
+test_validate_log_healthy_feed_no_spurious_reject-style regression coverage.
+Until the fan-out runs and is confirmed green, ADR-49 stays "Implemented
+(pending smoke)" -- do not flip Status to Accepted based on this phase alone.
+
+Dispatch command (selective, per CLAUDE.md "Selective dispatch"):
+    gh workflow run smoke.yml -f scope=impacted \
+      -f pytest_filter="test_feed_sanity_flag_gates_html_error_page_reject or test_feed_sanity_flag_on_still_imports_healthy_feed"
+(or `-f scope=full` for the every-leg run before flipping to Accepted).
+
+OUT OF SCOPE (explicitly, per ADR §7 / the phase brief)
+-----------------------------------------------------------
+The default-on decision for pfb_feed_sanity is a SEPARATE decision (a
+follow-up ADR/PR), not part of this phase or this ADR's acceptance gate.
+pfb_feed_sanity remains registered default OFF; nothing in this phase changes
+that default.
+
+COMMIT / PUSH
+-------------
+Commit: pfblockerng: smoke + zero-FP survey for plain-text sanity scan (ADR-49 P3)
+Pushed directly to adr/49-plain-text-sanity-scan.

--- a/.ADRs/ADR_49_Plain_Text_Sanity_Scan/RESULTS/03_Survey.txt
+++ b/.ADRs/ADR_49_Plain_Text_Sanity_Scan/RESULTS/03_Survey.txt
@@ -1,0 +1,48 @@
+================================================================================
+ADR-49 §7 ACCEPTANCE GATE — offline false-positive survey (Phase 3)
+================================================================================
+Command:
+    $ vendor/bin/phpunit --filter FeedCorpusSurveyTest --testdox
+
+Result: PASS — zero false positives over the committed catalogue corpus.
+
+PHPUnit 11.5.55 by Sebastian Bergmann and contributors.
+
+Runtime:       PHP 8.5.7
+Configuration: /Users/andre/git/pfBlockerNG/.claude/worktrees/adr-49/phpunit.xml
+
+..                                                                  2 / 2 (100%)
+
+Time: 00:00.070, Memory: 30.00 MB
+
+Feed Corpus Survey
+ ✔ Corpus is present and coherent
+ ✔ Catalogue survey has zero false positives
+
+OK (2 tests, 1441 assertions)
+
+--------------------------------------------------------------------------------
+Notes
+--------------------------------------------------------------------------------
+- "Corpus is present and coherent": the manifest.json / samples/ integrity checks
+  (file existence, size, sha256, no case-collisions, >150 fetched / >100 text
+  samples) — unrelated to the scanner, always runs.
+- "Catalogue survey has zero false positives": the ADR-49 gate itself. Runs
+  pfb_text_sanity() over every non-archive text sample in
+  tests/fixtures/feed_corpus/ (from PR #827's one-time offline capture) and
+  asserts NULL for every one EXCEPT the 5 documented KNOWN_NON_FEED entries
+  (MaxMind_BD_Proxy, Abuse_SSLBL, Abuse_SSLBL_Agr, Darklist, MPatrol — see
+  RESULTS/01_Results.txt for the byte-level inspection proving each is a
+  stale/gated/wrong-URL capture, not a scanner false positive), which are
+  asserted to STILL be flagged (so a live comeback would fail loudly as
+  "stale exclusion" rather than silently mask a real regression).
+- #[CoversFunction('pfb_text_sanity')] is back on FeedCorpusSurveyTest (removed
+  in PR #827 while the function did not exist yet, per its own docblock) — no
+  PHPUnit warning: the full suite run (`vendor/bin/phpunit`, RESULTS/03_Results.txt)
+  confirms zero warnings/skips beyond the 4 pre-existing unrelated skips.
+- No network at test time — the corpus is a committed, offline artifact; this
+  gate is fully reproducible / CI-safe with no live catalogue fetch.
+
+CONCLUSION: the §7 acceptance survey gate is GREEN. Combined with green CE+Plus
+live smoke (the remaining orchestrator step, not run by this phase), ADR-49 is
+ready to flip to Accepted.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -974,6 +974,78 @@ function pfb_emit_entry_reject_stats(string $path): void {
 	}
 }
 
+// ADR-49 Phase 1: pure content-sanity scan over the first chunk of a downloaded
+// text feed. The caller reads up to 8 KiB and passes it in as $sample -- this
+// function does no I/O and has no notion of the cap: an 8 KiB read is a ceiling,
+// never a floor, so a feed shorter than that is a COMPLETE sample and is never
+// penalised for its size.
+//
+// Returns NULL when the sample looks like plausible blocklist text, else one of
+// three reason tokens naming why it does not. Evaluated in this order, first
+// hit wins:
+//   1. 'nul_bytes'         -- the sample contains ANY NUL byte. Unambiguous for
+//                             a text feed, so it is checked first.
+//   2. 'html_error_page'   -- the sample, left-trimmed of leading whitespace,
+//                             opens (case-insensitively) with "<!doctype html"
+//                             or "<html", AND none of its first 20 lines is
+//                             "blocklist-shaped" (an IPv4/IPv6 address or CIDR,
+//                             a hosts-style "IP<whitespace>domain" line, or a
+//                             bare/ABP-wrapped domain.tld token). This is the
+//                             false-positive guard: an HTML-ish feed that DOES
+//                             carry blocklist lines is not flagged.
+//   3. 'below_min_content' -- a LINE-count floor of 1, never a byte-size floor:
+//                             fires only when the sample has ZERO non-blank,
+//                             non-comment lines (a comment line begins with
+//                             '#' or '!' after trimming leading whitespace). A
+//                             single legitimate data line satisfies the floor.
+//   4. otherwise NULL.
+//
+// BYTE-LEVEL matching only -- no `/u` modifier anywhere. Every pattern above is
+// pure ASCII, so a chunk-truncated multibyte tail can never flip a verdict.
+// Pure: string in, ?string out, no I/O, no globals.
+function pfb_text_sanity(string $sample): ?string {
+	if (strpos($sample, "\x00") !== FALSE) {
+		return 'nul_bytes';
+	}
+
+	$lines = preg_split('/\r\n|\r|\n/', $sample);
+
+	$leading_trimmed = ltrim($sample);
+	$opens_as_html = stripos($leading_trimmed, '<!doctype html') === 0
+		|| stripos($leading_trimmed, '<html') === 0;
+
+	// Blocklist-shaped = an IPv4/IPv6 address or CIDR, OR a bare/ABP-wrapped
+	// domain.tld token -- a hosts-style "IP<ws>domain" line already satisfies
+	// the IP branch, so it needs no separate pattern.
+	$blocklist_shaped = '/(?:\d{1,3}\.){3}\d{1,3}(?:\/\d{1,2})?'
+		. '|(?:[0-9A-Fa-f]{1,4}:){3,7}[0-9A-Fa-f]{1,4}|[0-9A-Fa-f]*::[0-9A-Fa-f:]*'
+		. '|(?:\|\|)?[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?'
+		. '(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*\.[A-Za-z]{2,}\^?/';
+
+	if ($opens_as_html) {
+		$has_blocklist_line = FALSE;
+		foreach (array_slice($lines, 0, 20) as $line) {
+			if (preg_match($blocklist_shaped, $line) === 1) {
+				$has_blocklist_line = TRUE;
+				break;
+			}
+		}
+		if (!$has_blocklist_line) {
+			return 'html_error_page';
+		}
+	}
+
+	foreach ($lines as $line) {
+		$content = ltrim($line);
+		if ($content === '' || $content[0] === '#' || $content[0] === '!') {
+			continue;
+		}
+		return NULL;    // at least one non-blank, non-comment line -- floor met
+	}
+
+	return 'below_min_content';
+}
+
 // Function to filter/sanitize user input
 //
 // ADR-48 Phase 2: $reject_detail is an optional by-ref out-param for the

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9976,6 +9976,21 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			return FALSE;
 		}
 
+		// ADR-49: opt-in plain-text sanity scan on accepted text feeds. Flag check
+		// FIRST -- default-off short-circuits before the MIME check and the file
+		// read, so an off install is byte-for-byte unchanged (ADR-28 conv 2).
+		if (PfbConfig::read('pfb_feed_sanity') === PfbToggle::On &&
+			in_array($file_type, array('text/plain', 'text/html', 'text/csv'), TRUE)) {
+			// Read UP TO 8 KiB -- a cap, not a minimum; a shorter feed is read whole.
+			$pfb_sanity_sample = (string) @file_get_contents($file_download, FALSE, NULL, 0, 8192);
+			$pfb_sanity = pfb_text_sanity($pfb_sanity_sample);
+			if ($pfb_sanity !== NULL) {
+				pfb_validate_log($header, 'plaintext', $pfb_sanity, basename($file_download));
+				unlink_if_exists($file_download);
+				return FALSE;
+			}
+		}
+
 		// Create update file markers on new downloads available
 		switch($type) {
 			case 'geoip':

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9976,18 +9976,28 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			return FALSE;
 		}
 
-		// ADR-49: opt-in plain-text sanity scan on accepted text feeds. Flag check
-		// FIRST -- default-off short-circuits before the MIME check and the file
-		// read, so an off install is byte-for-byte unchanged (ADR-28 conv 2).
+		// ADR-49: opt-in plain-text sanity scan on accepted text feeds. The flag is
+		// checked FIRST -- when default-off it short-circuits before THIS scan's own
+		// MIME-scope check (the in_array below) and the sample read, so an off install
+		// adds no work here (ADR-28 conv 2). ($file_type was already produced by the
+		// upstream FILE_MIME check above; this gate only narrows to the text types.)
+		// 'application/csv' rides with 'text/csv' -- same CSV body, just a different
+		// libmagic verdict (both are allow-listed synonyms; see pfb_filter FILE_MIME).
 		if (PfbConfig::read('pfb_feed_sanity') === PfbToggle::On &&
-			in_array($file_type, array('text/plain', 'text/html', 'text/csv'), TRUE)) {
+			in_array($file_type, array('text/plain', 'text/html', 'text/csv', 'application/csv'), TRUE)) {
 			// Read UP TO 8 KiB -- a cap, not a minimum; a shorter feed is read whole.
-			$pfb_sanity_sample = (string) @file_get_contents($file_download, FALSE, NULL, 0, 8192);
-			$pfb_sanity = pfb_text_sanity($pfb_sanity_sample);
-			if ($pfb_sanity !== NULL) {
-				pfb_validate_log($header, 'plaintext', $pfb_sanity, basename($file_download));
-				unlink_if_exists($file_download);
-				return FALSE;
+			$pfb_sanity_sample = @file_get_contents($file_download, FALSE, NULL, 0, 8192);
+			// A read error (FALSE) is NOT an empty feed: skip the scan (fail-open) so a
+			// transient I/O glitch is not mislogged as below_min_content and the feed --
+			// already MIME-validated -- proceeds instead of being wrongly dropped. A truly
+			// empty (0-byte) feed reads as '' (not FALSE), so below_min_content still fires.
+			if ($pfb_sanity_sample !== FALSE) {
+				$pfb_sanity = pfb_text_sanity($pfb_sanity_sample);
+				if ($pfb_sanity !== NULL) {
+					pfb_validate_log($header, 'plaintext', $pfb_sanity, basename($file_download));
+					unlink_if_exists($file_download);
+					return FALSE;
+				}
 			}
 		}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -541,6 +541,16 @@ function pfb_cfg_registry(): array
 			'since'         => '3.1.0',
 		],
 
+		// ADR-49: opt-in plain-text feed sanity scan. Checkbox 'on'|''(off).
+		// Default off (absent = off = today's behaviour: the scan never runs).
+		'pfb_feed_sanity' => [
+			'section'       => $gen,
+			'default'       => '',                       // absent -> Off (new-install default too)
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'since'         => '4.0.0',
+		],
+
 		// Reuse blocklists across updates: 'on' | '' (checkbox). Default ''.
 		'pfb_reuse' => [
 			'section'       => $gen,

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -75,6 +75,7 @@ final class CfgGatewayTest extends TestCase
 			'pfb_dnsbl_nonat'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat',
 			'pfb_reuse'        => 'installedpackages/pfblockerng/config/0/pfb_reuse',
 			'pfb_hsts'         => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
+			'pfb_feed_sanity'  => 'installedpackages/pfblockerng/config/0/pfb_feed_sanity',
 		];
 
 		foreach ($toggle_fields as $key => $path) {
@@ -104,6 +105,7 @@ final class CfgGatewayTest extends TestCase
 			'pfb_dnsbl_nonat'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat',
 			'pfb_reuse'        => 'installedpackages/pfblockerng/config/0/pfb_reuse',
 			'pfb_hsts'         => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
+			'pfb_feed_sanity'  => 'installedpackages/pfblockerng/config/0/pfb_feed_sanity',
 		];
 
 		foreach ($toggle_fields as $key => $path) {
@@ -272,6 +274,27 @@ final class CfgGatewayTest extends TestCase
 		// When/Then: returns Off (default '').
 		$result = PfbConfig::read('enable_cb');
 		$this->assertSame(PfbToggle::Off, $result, 'enable_cb absent -> Off (default)');
+	}
+
+	/**
+	 * ADR-49: pfb_feed_sanity absent key returns Off — proves the scan is
+	 * unreachable (never consulted) on an existing install that predates the
+	 * feature, exactly like a brand-new install (no grandfather seed needed).
+	 *
+	 * Scenario:
+	 *   Background: config[.../pfb_feed_sanity] is unset (feature is new).
+	 *     Given no seed.
+	 *     When PfbConfig::read('pfb_feed_sanity').
+	 *     Then PfbToggle::Off is returned (default '').
+	 */
+	public function testReadReturnsRegisteredDefaultForPfbFeedSanityAbsentKey(): void
+	{
+		// Before: key absent.
+		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_feed_sanity'));
+
+		// When/Then: returns Off (default '').
+		$result = PfbConfig::read('pfb_feed_sanity');
+		$this->assertSame(PfbToggle::Off, $result, 'pfb_feed_sanity absent -> Off (default)');
 	}
 
 	public function testReadReturnsRegisteredDefaultForPfbKeepAbsentKey(): void
@@ -848,6 +871,8 @@ final class CfgGatewayTest extends TestCase
 			'pfb_software_check',
 			'pfb_feed_internal_filter',
 			'pfb_feed_internal_allowlist',
+			// ADR-49: opt-in plain-text feed sanity scan toggle
+			'pfb_feed_sanity',
 			'pfb_reuse',
 			// ADR-40: alias-table apply mode + batch size
 			'pfb_alias_delta_mode',

--- a/tests/php/FeedCorpusSurveyTest.php
+++ b/tests/php/FeedCorpusSurveyTest.php
@@ -127,6 +127,23 @@ final class FeedCorpusSurveyTest extends TestCase
 		$this->assertGreaterThan(100, count(self::textSamples()), 'too few TEXT samples for the survey');
 	}
 
+	/**
+	 * Corpus samples that are NOT real feed bodies, so a non-null verdict on them is
+	 * the scanner working correctly, NOT a false positive. Keyed by feed header ->
+	 * the documented reason. The one-time PR #827 capture caught these five: two are
+	 * catalogue-marked `discontinued`, and three are dead/gated feeds whose captured
+	 * body is a header-only stub or an auth wall. Each is asserted below to STILL be
+	 * flagged, so a stale entry (a feed that came back to life) fails loudly rather
+	 * than silently masking a real regression.
+	 */
+	private const KNOWN_NON_FEED = [
+		'MaxMind_BD_Proxy' => 'catalogue status=discontinued — the url is MaxMind\'s HTML sample-list webpage, not a raw feed (html_error_page)',
+		'Abuse_SSLBL'      => 'catalogue status=discontinued — abuse.ch retired the SSLBL IP blacklist; the body is header-only, zero data rows (below_min_content)',
+		'Abuse_SSLBL_Agr'  => 'the retired SSLBL aggressive list — sibling of the discontinued Abuse_SSLBL (catalogue status unset); header-only, zero data rows (below_min_content)',
+		'Darklist'         => 'header-only at capture — darklist.de/raw.php returned its 2-line header with zero IP rows (below_min_content)',
+		'MPatrol'          => 'API-key gated — the catalogue url is an _API_KEY_ template; the capture hit the "access denied" auth wall, not the feed (below_min_content)',
+	];
+
 	public function testCatalogueSurveyHasZeroFalsePositives(): void
 	{
 		if (!function_exists('pfb_text_sanity')) {
@@ -136,9 +153,18 @@ final class FeedCorpusSurveyTest extends TestCase
 			);
 		}
 		$flagged = [];
+		$stale = [];
 		foreach (self::textSamples() as $feed) {
 			$sample = (string) file_get_contents(self::CORPUS_DIR . '/' . $feed['sample_file']);
 			$verdict = pfb_text_sanity($sample);
+			if (isset(self::KNOWN_NON_FEED[$feed['header']])) {
+				// A known non-feed sample MUST stay flagged: if it now passes, the feed
+				// came back or the capture changed, so the exclusion is stale.
+				if ($verdict === NULL) {
+					$stale[] = "{$feed['header']} — now passes pfb_text_sanity(); re-check the feed and drop it from KNOWN_NON_FEED";
+				}
+				continue;
+			}
 			if ($verdict !== NULL) {
 				$flagged[] = "{$feed['header']} ({$feed['url']}) -> {$verdict}";
 			}
@@ -148,6 +174,12 @@ final class FeedCorpusSurveyTest extends TestCase
 			$flagged,
 			"pfb_text_sanity() flagged REAL catalogue feeds (false positives — each would drop a live blocklist):\n"
 			. implode("\n", $flagged)
+		);
+		$this->assertSame(
+			[],
+			$stale,
+			"KNOWN_NON_FEED exclusions that are no longer flagged (stale — re-check the feed and remove the entry):\n"
+			. implode("\n", $stale)
 		);
 	}
 }

--- a/tests/php/FeedCorpusSurveyTest.php
+++ b/tests/php/FeedCorpusSurveyTest.php
@@ -153,12 +153,18 @@ final class FeedCorpusSurveyTest extends TestCase
 				. 'and gates the ADR\'s flip to Accepted (§7)'
 			);
 		}
+		// Self-encapsulated floor: the zero-FP assertion must never pass vacuously on a
+		// degraded/emptied corpus (e.g. this test run alone via --filter). Don't lean on
+		// the sibling coherence test's >100 count to establish there is anything to survey.
+		$this->assertNotEmpty(self::textSamples(), 'no text samples to survey — the corpus is degraded');
 		$flagged = [];
 		$stale = [];
+		$matched = [];
 		foreach (self::textSamples() as $feed) {
 			$sample = (string) file_get_contents(self::CORPUS_DIR . '/' . $feed['sample_file']);
 			$verdict = pfb_text_sanity($sample);
 			if (isset(self::KNOWN_NON_FEED[$feed['header']])) {
+				$matched[$feed['header']] = TRUE;
 				// A known non-feed sample MUST stay flagged: if it now passes, the feed
 				// came back or the capture changed, so the exclusion is stale.
 				if ($verdict === NULL) {
@@ -181,6 +187,18 @@ final class FeedCorpusSurveyTest extends TestCase
 			$stale,
 			"KNOWN_NON_FEED exclusions that are no longer flagged (stale — re-check the feed and remove the entry):\n"
 			. implode("\n", $stale)
+		);
+		// Completeness: every KNOWN_NON_FEED key must have been encountered in the corpus.
+		// A feed dropped/renamed in the catalogue makes its exclusion inert (visited by
+		// neither the flagged nor the stale branch), so a dead entry would rot undetected
+		// while reading as "still validated" — fail loudly instead, mirroring the reverse-
+		// coherence orphan guard in testCorpusIsPresentAndCoherent.
+		$dead = array_values(array_diff(array_keys(self::KNOWN_NON_FEED), array_keys($matched)));
+		$this->assertSame(
+			[],
+			$dead,
+			"KNOWN_NON_FEED entries no longer present in the corpus (dropped/renamed feed — remove them or refresh the corpus):\n"
+			. implode("\n", $dead)
 		);
 	}
 }

--- a/tests/php/FeedCorpusSurveyTest.php
+++ b/tests/php/FeedCorpusSurveyTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,11 +21,11 @@ use PHPUnit\Framework\TestCase;
  *   Archive-typed samples (gzip/zip/bz2/7z magics) are not text feeds and are
  *   excluded; unreachable-at-fetch-time feeds have no sample to judge.
  *
- * No #[CoversFunction] here: pfb_text_sanity() does not exist until ADR-49 Phase 1,
- * and a covers-target for an undefined function is a PHPUnit warning that the CI
- * suite (run with --fail-on-warning) turns into a failure. The survey test guards on
- * function_exists() instead; add the covers attribute when the scanner lands.
+ * #[CoversFunction] re-added in Phase 3: pfb_text_sanity() now exists (ADR-49
+ * Phase 1 landed it), so the covers-target is no longer a PHPUnit warning
+ * (undefined-covers-target was the reason it was removed in PR #827).
  */
+#[CoversFunction('pfb_text_sanity')]
 final class FeedCorpusSurveyTest extends TestCase
 {
 	private const CORPUS_DIR = __DIR__ . '/../fixtures/feed_corpus';

--- a/tests/php/PfbTextSanityTest.php
+++ b/tests/php/PfbTextSanityTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for pfb_text_sanity() — ADR-49 Phase 1.
+ *
+ * pfb_text_sanity(string $sample): ?string is a PURE content-sanity scanner over
+ * the first chunk (up to 8 KiB, a read cap never a floor) of a downloaded text
+ * feed. It returns NULL when the sample looks like plausible blocklist text, or
+ * one of three reason tokens otherwise. Verdict order (first hit wins):
+ *   1. 'nul_bytes'         — any \x00 byte anywhere in the sample.
+ *   2. 'html_error_page'   — opens with <!doctype html>/<html> AND carries no
+ *                            blocklist-shaped line in its first 20 lines.
+ *   3. 'below_min_content' — zero non-blank, non-comment lines (floor = 1).
+ * All matching is BYTE-LEVEL (no `/u` modifier) — every pattern is pure ASCII,
+ * so a chunk-truncated multibyte tail can never flip a verdict.
+ */
+#[CoversFunction('pfb_text_sanity')]
+final class PfbTextSanityTest extends TestCase
+{
+	// -- Real blocklist samples -> NULL ------------------------------------------------
+
+	public function test_plain_ipv4_cidr_list_is_sane(): void
+	{
+		$sample = "1.2.3.4\n5.6.7.0/24\n2001:db8::1\n";
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	public function test_hosts_style_ip_domain_list_is_sane(): void
+	{
+		$sample = "0.0.0.0 ads.example.org\n0.0.0.0 tracker.example.net\n";
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	public function test_abp_wrapped_domain_list_is_sane(): void
+	{
+		$sample = "||ads.example.org^\n||tracker.example.net^\n";
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	public function test_single_legitimate_data_line_satisfies_the_floor(): void
+	{
+		// Floor = 1: one non-blank, non-comment line is a COMPLETE sample, not a
+		// truncated/too-small one.
+		$this->assertNull(pfb_text_sanity("0.0.0.0 x.example\n"));
+	}
+
+	public function test_tiny_few_byte_feed_is_not_size_penalised(): void
+	{
+		// A short body (well under the 8 KiB read cap) is a complete sample, never
+		// penalised for its size — no "too small" heuristic exists.
+		$this->assertNull(pfb_text_sanity("1.2.3.4\n"));
+	}
+
+	public function test_comment_header_then_data_is_sane(): void
+	{
+		// Comment lines never count toward the floor, but the trailing data line
+		// satisfies it on its own.
+		$sample = "# license\n# generated 2026-01-01\n0.0.0.0 x.example\n";
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	// -- 'nul_bytes' --------------------------------------------------------------------
+
+	public function test_embedded_nul_byte_is_flagged(): void
+	{
+		$this->assertSame('nul_bytes', pfb_text_sanity("1.2.3.4\n\x00garbage"));
+	}
+
+	public function test_nul_byte_wins_over_otherwise_valid_blocklist_text(): void
+	{
+		// Proves NUL is checked FIRST: an otherwise-perfect blocklist body still
+		// flags nul_bytes the moment one NUL byte is present.
+		$sample = "0.0.0.0 ads.example.org\n0.0.0.0 tracker.example.net\n\x00\n0.0.0.0 more.example\n";
+		$this->assertSame('nul_bytes', pfb_text_sanity($sample));
+	}
+
+	// -- 'html_error_page' ---------------------------------------------------------------
+
+	public function test_html_error_page_with_no_blocklist_line_is_flagged(): void
+	{
+		$sample = "<!doctype html>\n<html><body><h1>404 Not Found</h1></body></html>\n";
+		$this->assertSame('html_error_page', pfb_text_sanity($sample));
+	}
+
+	public function test_html_tag_lowercase_is_flagged(): void
+	{
+		$sample = "<html><body>Forbidden</body></html>\n";
+		$this->assertSame('html_error_page', pfb_text_sanity($sample));
+	}
+
+	public function test_html_tag_uppercase_is_flagged(): void
+	{
+		$sample = "<HTML><BODY>FORBIDDEN</BODY></HTML>\n";
+		$this->assertSame('html_error_page', pfb_text_sanity($sample));
+	}
+
+	public function test_html_tag_mixed_case_is_flagged(): void
+	{
+		$sample = "<HtMl><body>captcha required</body></html>\n";
+		$this->assertSame('html_error_page', pfb_text_sanity($sample));
+	}
+
+	public function test_html_tag_with_leading_whitespace_and_newlines_is_flagged(): void
+	{
+		// Leading whitespace/newlines before the tag are tolerated (left-trim).
+		$sample = "\n\n   \t<html><body>error</body></html>\n";
+		$this->assertSame('html_error_page', pfb_text_sanity($sample));
+	}
+
+	public function test_html_body_with_a_blocklist_line_is_not_flagged(): void
+	{
+		// The false-positive guard: an HTML-ish feed that DOES carry a
+		// blocklist-shaped line within its first 20 lines must NOT be flagged.
+		$sample = "<html><body>\n0.0.0.0 ads.example.org\n</body></html>\n";
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	// -- 'below_min_content' --------------------------------------------------------------
+
+	public function test_empty_string_is_below_min_content(): void
+	{
+		$this->assertSame('below_min_content', pfb_text_sanity(''));
+	}
+
+	public function test_whitespace_only_is_below_min_content(): void
+	{
+		$this->assertSame('below_min_content', pfb_text_sanity("   \n\t\n  \n"));
+	}
+
+	public function test_comment_only_body_is_below_min_content(): void
+	{
+		// '#' and '!' comment lines never count toward the floor; zero data lines
+		// means the floor of 1 is never met.
+		$this->assertSame('below_min_content', pfb_text_sanity("# a\n! b\n"));
+	}
+
+	// -- Verdict order proof (nul_bytes -> html_error_page -> below_min_content) ---------
+
+	public function test_nul_bearing_html_error_page_flags_nul_first(): void
+	{
+		$sample = "<!doctype html>\n\x00\n<html><body>error</body></html>\n";
+		$this->assertSame('nul_bytes', pfb_text_sanity($sample));
+	}
+
+	public function test_all_comment_html_less_body_flags_below_min(): void
+	{
+		// No NUL, no HTML opening tag -> falls through to the content floor.
+		$this->assertSame('below_min_content', pfb_text_sanity("# nothing here\n! still nothing\n"));
+	}
+
+	// -- Byte-level (no /u) truncation cases ----------------------------------------------
+
+	public function test_truncated_mid_token_line_does_not_change_a_valid_verdict(): void
+	{
+		// An 8 KiB sample whose final line is cut mid-token is still a valid
+		// blocklist body — the earlier complete lines already satisfy the floor,
+		// and a truncated trailing token is not itself NUL/HTML/empty.
+		$body = str_repeat("0.0.0.0 filler.example.org\n", 400); // well over 8 KiB
+		$sample = substr($body . '0.0.0.0 trunc', 0, 8192);
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	public function test_dangling_partial_multibyte_tail_does_not_change_verdict(): void
+	{
+		// Byte-level matching: a split multibyte UTF-8 character at the very end
+		// (here, the lead byte of a 2-byte sequence with no continuation byte)
+		// must not flip an otherwise-valid blocklist body away from NULL.
+		$sample = "0.0.0.0 x.example\n0.0.0.0 y.example\n" . "\xC3"; // dangling lead byte
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+}

--- a/tests/php/PfbTextSanityTest.php
+++ b/tests/php/PfbTextSanityTest.php
@@ -154,23 +154,46 @@ final class PfbTextSanityTest extends TestCase
 	}
 
 	// -- Byte-level (no /u) truncation cases ----------------------------------------------
+	//
+	// Each makes the truncated/multibyte tail the SOLE floor candidate (a comment
+	// header precedes it), so NULL genuinely depends on the scanner reaching and
+	// correctly handling that tail -- not short-circuiting on an earlier data line.
+	// That is what makes them fail on a byte-level regression rather than pass
+	// vacuously on any implementation of the floor loop.
 
-	public function test_truncated_mid_token_line_does_not_change_a_valid_verdict(): void
+	public function test_truncated_mid_token_line_is_the_sole_floor_candidate(): void
 	{
-		// An 8 KiB sample whose final line is cut mid-token is still a valid
-		// blocklist body — the earlier complete lines already satisfy the floor,
-		// and a truncated trailing token is not itself NUL/HTML/empty.
-		$body = str_repeat("0.0.0.0 filler.example.org\n", 400); // well over 8 KiB
-		$sample = substr($body . '0.0.0.0 trunc', 0, 8192);
-		$this->assertNull(pfb_text_sanity($sample));
+		// 8180 bytes of comments, then a data line cut mid-token by the 8 KiB read
+		// cap. The truncated "0.0.0.0 fill" is the ONLY non-comment line, so NULL
+		// proves the floor loop counted the truncated tail as content; a mis-split
+		// of it would flip the verdict to below_min_content.
+		$header = str_repeat("# c\n", 2045);                              // 8180 bytes, all comments
+		$sample = substr($header . "0.0.0.0 filler.example.org\n", 0, 8192);
+		$lines  = explode("\n", $sample);
+		// Guard the construction: the deciding line really is the mid-token cut, not
+		// a line dropped past the cap -- else the test would silently retest comments.
+		$this->assertSame('0.0.0.0 fill', end($lines), 'setup drift: final line must be the mid-token cut');
+		$this->assertNull(pfb_text_sanity($sample), 'a truncated sole data line still meets the content floor');
 	}
 
-	public function test_dangling_partial_multibyte_tail_does_not_change_verdict(): void
+	public function test_dangling_partial_multibyte_tail_stays_byte_level(): void
 	{
-		// Byte-level matching: a split multibyte UTF-8 character at the very end
-		// (here, the lead byte of a 2-byte sequence with no continuation byte)
-		// must not flip an otherwise-valid blocklist body away from NULL.
-		$sample = "0.0.0.0 x.example\n0.0.0.0 y.example\n" . "\xC3"; // dangling lead byte
-		$this->assertNull(pfb_text_sanity($sample));
+		// A split multibyte UTF-8 char (lead byte 0xC3, no continuation) ends the
+		// SOLE data line. A /u regression on the preg_split would make PCRE reject
+		// the invalid-UTF-8 subject -> FALSE -> zero lines -> below_min_content, so
+		// NULL proves the split stayed byte-level AND the tailed line was reached.
+		$sample = str_repeat("# c\n", 2045) . "0.0.0.0 x.example\xC3";
+		$this->assertNull(pfb_text_sanity($sample), 'a dangling multibyte tail must not flip the verdict');
+	}
+
+	public function test_html_opening_with_multibyte_tailed_blocklist_line_stays_byte_level(): void
+	{
+		// The html branch runs preg_match($blocklist_shaped) per line. An html-opening
+		// body whose only blocklist-shaped line ends in a dangling multibyte byte must
+		// still match byte-level and yield NULL -- NOT html_error_page. A /u regression
+		// on $blocklist_shaped would make preg_match reject the invalid-UTF-8 subject,
+		// find no blocklist line, and wrongly return html_error_page (test flips red).
+		$sample = "<html>\n0.0.0.0 real.example\xC3\n";
+		$this->assertNull(pfb_text_sanity($sample), 'byte-level blocklist match must survive a multibyte tail');
 	}
 }

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -101,6 +101,8 @@ class RequireConfigGatewaySniff implements Sniff
 		'installedpackages/pfblockerng/config/0/pfb_software_check',
 		'installedpackages/pfblockerng/config/0/pfb_feed_internal_filter',
 		'installedpackages/pfblockerng/config/0/pfb_feed_internal_allowlist',
+		// ADR-49: opt-in plain-text feed sanity scan toggle
+		'installedpackages/pfblockerng/config/0/pfb_feed_sanity',
 		'installedpackages/pfblockerng/config/0/pfb_reuse',
 		// ADR-40: alias-table apply mode + batch size
 		'installedpackages/pfblockerng/config/0/pfb_alias_delta_mode',

--- a/tests/smoke/fixtures/README.md
+++ b/tests/smoke/fixtures/README.md
@@ -51,6 +51,17 @@ DNSBL assertion: `dns_probe` block-shape on the box (NOERROR + VIP, or NULL per 
 list's `logging`); the non-member (and the ABP allow-exception, where a feed `@@`
 allow band 2 beats the `||` block band 1) must RESOLVE, not block.
 
+## Plain-text sanity scan fixture (ADR-49, `IpCase`, `test_smoke_feeds.py`)
+
+| File | on-box `file(1)` | Purpose |
+| --- | --- | --- |
+| `html_error_page.html` | expected `text/html` (verify on first live run) | A realistic 403/error-page body (`<!doctype html>...403 Forbidden...</html>`) carrying NO blocklist-shaped line (no IP/CIDR, no `domain.tld` token, no `#`/`!` comment) anywhere, so `pfb_text_sanity()` returns `html_error_page` when the ADR-49 `pfb_feed_sanity` scan is ON. Its on-box MIME classification is asserted at test time (`file -b --mime-type`, per the ADR-45 libmagic-divergence lesson) before the reject is asserted, so a libmagic surprise fails loudly with the actual verdict rather than silently not exercising the gate. |
+
+The scan's healthy-feed control reuses the already-verified `ip_plain_cidr.txt` (IP
+feeds) / `dnsbl_plain.txt` (DNSBL feeds) above — both are plain `text/plain` bodies
+that load successfully today, proving `pfb_feed_sanity=on` is a real branch (rejects
+the error page, not every text feed).
+
 ## Archive corpus (ADR-45 — structural integrity)
 
 Binary fixtures for the ADR-45 structural-probe + octet-stream-recovery smoke cases

--- a/tests/smoke/fixtures/html_error_page.html
+++ b/tests/smoke/fixtures/html_error_page.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head><title>403 Forbidden</title></head>
+<body>
+<h1>403 Forbidden</h1>
+<p>Access to this resource on this server is denied</p>
+<p>You do not have permission to view this page using the credentials supplied</p>
+<p>Please contact the site administrator if you believe this is an error</p>
+<p>Reference id 7f3a9c21e04b</p>
+</body>
+</html>

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1250,6 +1250,29 @@ def set_feed_internal_allowlist(vm: SmokeVM, value: str, *, timeout: float = 60.
         )
 
 
+def set_feed_sanity(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
+    """Set the ADR-49 opt-in plain-text feed sanity scan (``pfb_feed_sanity``, default OFF).
+
+    Config-only knob (no www/ checkbox) -- written through the ADR-29 gateway
+    (``PfbConfig::write``), the same call a future UI save path would make. Gates
+    ``pfb_text_sanity()`` inside ``pfb_download()`` on accepted ``text/plain`` /
+    ``text/html`` / ``text/csv`` feeds: ON rejects a feed whose sampled body looks
+    like an HTML error page / NUL-laden / near-empty (``stage=plaintext``); OFF
+    (the default) never calls the scanner. Call BEFORE the reload under test --
+    ``pfb_download()`` reads the flag once per fetch.
+    """
+    value = "PfbToggle::On" if on else "PfbToggle::Off"
+    snippet = (
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
+        f"PfbConfig::write('pfb_feed_sanity', {value});\n"
+        "write_config('pfBlockerNG smoke: set pfb_feed_sanity');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"set_feed_sanity({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
 @timed_step("use_system_dns_upstream")
 def use_system_dns_upstream(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     """Point pfSense at the runner-side mock via its REAL System-DNS path (no custom zone).
@@ -2430,6 +2453,10 @@ _BASELINE_GLOBAL_KEYS = (
     # (test_trigger_api / test_smoke_feeds) must not leak the exemption forward, or a
     # later module runs with the default-ON guard effectively disabled (false-green).
     "pfb_feed_internal_allowlist",
+    # ADR-49 opt-in plain-text sanity scan: test_smoke_feeds flips this ON to prove the
+    # reject branch; unset so a later module's healthy text/html-ish feed is not
+    # spuriously rejected by a leaked-forward flag (default is OFF).
+    "pfb_feed_sanity",
 )
 
 

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -3312,6 +3312,160 @@ def test_validate_log_healthy_abp_feed_no_entries_reject(
 
 
 # --------------------------------------------------------------------------- #
+# ADR-49: opt-in plain-text sanity scan (pfb_feed_sanity, default OFF). Live-VM
+# proof that the config-only gate wired in Phase 2 (pfblockerng.inc's pfb_download,
+# right after the MIME accept) genuinely runs: OFF is a no-op on an HTML-error-page
+# feed that would otherwise sail through the MIME allow-list; ON rejects it
+# (stage=plaintext) via the same ADR-48 canonical line the mime/structural/inner
+# stages already use; and a real blocklist feed still imports with the scan ON
+# (a real branch, not an always-reject path).
+# --------------------------------------------------------------------------- #
+
+_SANITY_SCANNED_MIME_TYPES = ("text/plain", "text/html", "text/csv")
+
+
+@pytest.mark.timeout(180)
+def test_feed_sanity_flag_gates_html_error_page_reject(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """ADR-49: pfb_feed_sanity OFF (default) never rejects; ON rejects an HTML-error-page feed.
+
+    Two DISTINCT, never-before-fetched headers over the SAME served fixture
+    (``html_error_page.html``) -- not one header Force-Updated twice -- because
+    pfb_download()'s own per-list "reuse" shortcut (pfblockerng.inc: once a header's
+    ``{header}.orig``/``.txt`` already exists, a later pass can skip straight to
+    reusing it without calling pfb_download() again) means re-running the SAME
+    header a second time is not guaranteed to re-invoke the gate at all. A header
+    pfBlockerNG has never fetched before has no such shortcut available -- the first
+    fetch of ANY header always calls pfb_download() -- so using two fresh headers
+    isolates the flag as the only variable that differs between the OFF and ON legs.
+
+    Given the scan OFF (explicit + the registered default) and a fresh header with
+      no pre-existing reject line,
+    When Force-Updating the HTML-error-page feed under that header,
+    Then NO 'stage=plaintext' reject line appears for it (the before-state proving
+      an off install is unaffected).
+    Given the scan then flipped ON and a SECOND fresh header over the SAME feed body,
+    When Force-Updating it,
+    Then a NEW 'pfb_validate: REJECT ... stage=plaintext reason=html_error_page ...'
+      line appears for THAT header, and its alias table stays absent -- the flag
+      (not the feed content, which is identical in both legs) caused the reject.
+    """
+    fixture = "html_error_page.html"
+    feed_url = mock_feeds.feed_url(fixture)
+
+    # On-box guard (ADR-49 §5 / the ADR-45 libmagic-divergence lesson): ASSERT, never
+    # skip, so a libmagic surprise fails LOUDLY with the real verdict -- the plaintext
+    # gate only ever sees this fixture at all if FreeBSD file(1) calls it an
+    # allow-listed text type.
+    box_mime = _box_mime_type(deployed_vm, _fixture_bytes(fixture))
+    assert box_mime in _SANITY_SCANNED_MIME_TYPES, (
+        f"expected {fixture} on-box file(1) verdict in {_SANITY_SCANNED_MIME_TYPES}, "
+        f"got {box_mime!r} -- the plaintext gate would never see this fixture at all "
+        f"(adjust the fixture bytes until it lands on a scanned text type)"
+    )
+
+    header_off = "adr49sanoff"
+    header_on = "adr49sanon"
+    # feed= carries the on-box header with its family suffix (see the ADR-48
+    # structural-reject test's docstring); detected= is basename($file_download),
+    # always "<header>_v4.raw".
+    marker_off = f"pfb_validate: REJECT feed={header_off}_v4 stage=plaintext"
+    marker_on = (
+        f"pfb_validate: REJECT feed={header_on}_v4 stage=plaintext reason=html_error_page detected={header_on}_v4.raw"
+    )
+
+    try:
+        # Given -- flag OFF (explicit; also the registered default) + a fresh header.
+        h.set_feed_sanity(deployed_vm, False)
+        before_off = h.count_log_marker(deployed_vm, h.PFB_LOG, marker_off)
+        assert before_off == 0, f"{marker_off!r} must not pre-exist for a brand-new header, got {before_off}"
+
+        spec_off = h.IpCase(aliasname=header_off, feed_url=feed_url, header=header_off, family="v4")
+        with h.CaseContext(deployed_vm, spec_off):
+            # Then -- the scan never ran: no reject line for this header (the before-state).
+            after_off = h.count_log_marker(deployed_vm, h.PFB_LOG, marker_off)
+            if not (after_off == before_off == 0):
+                raise AssertionError(
+                    f"flag OFF must be a no-op: expected NO {marker_off!r} line in {h.PFB_LOG} "
+                    f"(before={before_off}), got after={after_off} -- the scan ran with "
+                    f"pfb_feed_sanity off\n"
+                    f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
+                )
+
+        # When -- flip the SAME feed body's flag ON, fetched under a FRESH header.
+        h.set_feed_sanity(deployed_vm, True)
+        before_on = h.count_log_marker(deployed_vm, h.PFB_LOG, marker_on)
+        assert before_on == 0, f"{marker_on!r} must not pre-exist for a brand-new header, got {before_on}"
+
+        spec_on = h.IpCase(aliasname=header_on, feed_url=feed_url, header=header_on, family="v4")
+        with h.CaseContext(deployed_vm, spec_on):
+            # Then -- a NEW canonical reject line appears; the flag CAUSED the reject
+            # (the flag-off leg above is the before-state proving causation, not merely
+            # "a line exists somewhere").
+            after_on = h.count_log_marker(deployed_vm, h.PFB_LOG, marker_on)
+            if not (after_on > before_on):
+                raise AssertionError(
+                    f"expected a NEW line matching {marker_on!r} in {h.PFB_LOG} after enabling "
+                    f"pfb_feed_sanity and Force-Updating the error-page feed; count "
+                    f"before={before_on} after={after_on}\n"
+                    f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
+                )
+            tables_on = h.pfctl_tables(deployed_vm)
+            assert spec_on.alias not in tables_on, (
+                f"expected {spec_on.alias!r} absent after a rejected download (stage=plaintext "
+                f"must reject before any table build), found it present — tables: {tables_on}"
+            )
+    finally:
+        h.set_feed_sanity(deployed_vm, False)
+
+
+@pytest.mark.timeout(120)
+def test_feed_sanity_flag_on_still_imports_healthy_feed(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """ADR-49: pfb_feed_sanity ON still imports a genuinely healthy text feed.
+
+    The MUST-ACCOMPANY counterpart to the reject-line test above -- proves the scan
+    is a REAL branch (rejects the error page, not every text/plain|html|csv feed) by
+    reusing the already-verified healthy ``ip_plain_cidr.txt`` fixture (the Part-C
+    kill-gate fixture for ``test_ip_http_feed_loads``) with the scan explicitly ON.
+
+    Given the scan ON and the alias absent (a fresh header, no pre-existing reject
+      line),
+    When Force-Updating the healthy plain-IP+CIDR feed,
+    Then the listed member loads into the pf table (genuinely imported, not merely
+      "didn't crash") AND no NEW 'stage=plaintext' reject line was logged for it.
+    """
+    header = "adr49sanhlt"
+    feed_url = mock_feeds.feed_url("ip_plain_cidr.txt")
+    spec = h.IpCase(aliasname=header, feed_url=feed_url, header=header, family="v4")
+    member_host = "203.0.113.5"  # the plain listed host (fixtures/README.md)
+    reject_marker = f"pfb_validate: REJECT feed={header}_v4 stage=plaintext"
+
+    try:
+        # Given -- scan ON, alias absent, no pre-existing reject line for this fresh header.
+        h.set_feed_sanity(deployed_vm, True)
+        assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the healthy feed was loaded"
+        before = h.count_log_marker(deployed_vm, h.PFB_LOG, reject_marker)
+
+        with h.CaseContext(deployed_vm, spec):
+            # When -- Force Update loads the healthy feed with the scan ON.
+            members = h.wait_pfctl_table(deployed_vm, spec.alias)
+            assert h.member_present(members, member_host), (
+                f"expected {member_host!r} in {spec.alias} after the healthy feed load with "
+                f"pfb_feed_sanity ON, got: {members}"
+            )
+            # Then -- no NEW reject line: the scan is a real branch, not an always-reject path.
+            after = h.count_log_marker(deployed_vm, h.PFB_LOG, reject_marker)
+            if not (after == before):
+                raise AssertionError(
+                    f"expected NO NEW {reject_marker!r} line in {h.PFB_LOG} after a healthy feed "
+                    f"load with pfb_feed_sanity ON; count before={before} after={after} (a healthy "
+                    f"feed must never be misclassified as an error page)\n"
+                    f"recent pfb_validate lines actually in the log:\n{_recent_validate_lines(deployed_vm)}"
+                )
+    finally:
+        h.set_feed_sanity(deployed_vm, False)
+
+
+# --------------------------------------------------------------------------- #
 # ADR-46: archive member-name guard before disk-writing extraction. The
 # GeoIP/top-1M/blacklist URLs are hardcoded in pfblockerng.php, so these cases
 # drive pfb_download() DIRECTLY via h.php_eval pointed at the mock server (the

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -3442,7 +3442,10 @@ def test_feed_sanity_flag_on_still_imports_healthy_feed(deployed_vm: SmokeVM, mo
     try:
         # Given -- scan ON, alias absent, no pre-existing reject line for this fresh header.
         h.set_feed_sanity(deployed_vm, True)
-        assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the healthy feed was loaded"
+        tables_before = h.pfctl_tables(deployed_vm)
+        assert spec.alias not in tables_before, (
+            f"{spec.alias} present before the healthy feed was loaded; pfctl tables: {tables_before}"
+        )
         before = h.count_log_marker(deployed_vm, h.PFB_LOG, reject_marker)
 
         with h.CaseContext(deployed_vm, spec):


### PR DESCRIPTION
## ADR-49: opt-in plain-text feed sanity scanning

Implements ADR-49 — a **default-off**, opt-in heuristic that catches feeds which pass the MIME gate but are not real blocklists: an HTML error/captcha page, a truncated/empty body, or NUL-bearing binary served as a text type (issue #581). Such a feed today either fails opaquely during parsing or silently imports a near-empty list.

### What lands (3 phases)

1. **`pfb_text_sanity(string $sample): ?string`** — a pure, byte-level scanner over the first ≤8 KiB of an accepted text feed. Returns `null` (looks like a blocklist) or a reason token, evaluated in order: `nul_bytes` (any `\x00`) → `html_error_page` (`<!doctype`/`<html` open with zero blocklist-shaped lines in the first 20) → `below_min_content` (zero non-blank/non-comment lines) → `null`. The 8 KiB is a read **cap, not a floor** — a short feed is complete, never size-penalised (`below_min_content` is a line-count floor of 1). 21 oracle tests, every verdict + its guard.
2. **`pfb_feed_sanity`** — a registered `PfbConfig` `PfbToggle`, **default off** (absent = off = today's behaviour, no grandfather seed). Wired in `pfb_download()` right after the FILE_MIME accept, **flag-check first** so an off install short-circuits before the MIME test and the file read (byte-for-byte unchanged). Scans `text/plain`/`text/html`/`text/csv` only; a non-null verdict rejects through the ADR-48 canonical `stage=plaintext` line and removes the file.
3. **Smoke + the offline false-positive survey.** Smoke (CE+Plus): flag-off imports an HTML-error feed, flag-on rejects it (`stage=plaintext reason=html_error_page`), flag-on still imports a healthy feed; the on-box `file(1)` verdict is asserted first (ADR-45 libmagic lesson). The survey (`FeedCorpusSurveyTest`, offline against the PR #827 corpus) runs every non-archive text sample through the scanner: **zero false positives** on ~196 real feeds.

### The survey found real, expected true-positives

Activating the scanner flagged **5 corpus samples — all genuinely non-feed content, none a real blocklist wrongly rejected**: `MaxMind_BD_Proxy` + `Abuse_SSLBL` (catalogue `status=discontinued`), `Abuse_SSLBL_Agr` (the retired SSLBL sibling), `Darklist` (header-only at capture), `MPatrol` (API-key-gated `_API_KEY_` template → auth wall). These are the feature working as intended, so they are excluded via a documented `KNOWN_NON_FEED` allowlist (header → reason) with a **self-correcting guard**: each must *stay* flagged, so a feed that comes back to life fails loudly instead of masking a regression.

### Scope / notes

- Config-only knob (no GUI), like ADR-43's `pfb_tick_interval` — no `www/` change, so no UI tier.
- The scanner is **byte-level** (no `/u`) — a chunk-truncated multibyte tail can't flip a verdict.
- ADR-49 stays **Proposed** until the live CE+Plus smoke fan-out is green (the acceptance gate); flipping to Accepted and any default-on change are separate decisions.

Per-phase handoffs + the persisted survey run are under `.ADRs/ADR_49_Plain_Text_Sanity_Scan/RESULTS/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional plain-text feed sanity scan that can flag clearly invalid feed content before import.
  * Introduced a new configuration toggle to turn this scan on or off.

* **Bug Fixes**
  * Improved detection of malformed feeds, including HTML error pages, embedded null bytes, and feeds with too little content.
  * Added end-to-end coverage to ensure valid feeds still import normally when the scan is enabled.

* **Tests**
  * Expanded unit, survey, and smoke test coverage for the new scan and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->