### PR TITLE
ADR-49: harden the plain-text sanity scanner (PR #829 adversarial-review follow-up)

### DIFF
--- a/.ADRs/ADR_49_Plain_Text_Sanity_Scan/ADR.md
+++ b/.ADRs/ADR_49_Plain_Text_Sanity_Scan/ADR.md
@@ -73,6 +73,25 @@ logs *through* it); changing the existing control-char check (kept; this complem
      fail-open/fail-closed question entirely (a truncated UTF-8 tail is simply bytes that match
      or don't).
 
+   **Post-merge review revisions (2026-07-04 — PR #829 adversarial-review follow-up):**
+
+   - **UTF-8 BOM:** stripped up front (encoding metadata, not content) — a BOM-prefixed
+     `<!doctype html`/`<html` page is still detected, and a BOM-prefixed comment line no longer
+     counts as data toward the floor.
+   - **Blocklist-shaped, per branch:** IPv4/CIDR stays a **substring** match (ProjectHoneypot /
+     cybercrime-tracker serve real IPs embedded in HTML markup); IPv6 is substring but
+     **bounded** (a CSS `::before` or a `403 :: Forbidden` separator is not an address); the
+     `domain.tld` (bare/ABP) token must be the **whole line** — real error pages embed
+     domain-shaped tokens in markup (DOCTYPE DTD URLs, favicon/CSS hrefs, CDN links) and those
+     must not suppress the verdict.
+   - **Guard window:** the `html_error_page` guard scans **every sampled line**, not the first
+     20 — HTML-wrapped real feeds carry their first IP only after ~90+ lines of boilerplate.
+   - **Sample cap:** **64 KiB** (was 8 KiB) — cybercrime-tracker's first IP sits ~12 KiB into a
+     650+ KiB page; the cap stays a ceiling, never a floor. The offline survey keeps its 8 KiB
+     corpus captures; `CCT_IP` is documented there as `KNOWN_TRUNCATED_FEED`.
+   - **MIME scope:** `application/csv` rides with `text/csv` (same body, different libmagic
+     verdict; added by the in-PR review fixes, commit 6ddfa1ee).
+
 2. **One registered PfbConfig field (ADR-28/29): `pfb_feed_sanity`** — a `PfbToggle`,
    **default off**. When off, `pfb_text_sanity()` is never consulted (zero behaviour change —
    the existing matrix is byte-for-byte unchanged). When on, a non-`null` reason →

--- a/.ADRs/ADR_49_Plain_Text_Sanity_Scan/ADR.md
+++ b/.ADRs/ADR_49_Plain_Text_Sanity_Scan/ADR.md
@@ -73,7 +73,9 @@ logs *through* it); changing the existing control-char check (kept; this complem
      fail-open/fail-closed question entirely (a truncated UTF-8 tail is simply bytes that match
      or don't).
 
-   **Post-merge review revisions (2026-07-04 — PR #829 adversarial-review follow-up):**
+   **Post-merge review revisions (2026-07-04 — PR #829 adversarial-review follow-up). Where a
+   bullet below conflicts with the resolved-fork bullets above (8 KiB cap, first-20-lines guard
+   window, 3-type MIME scope), the revision below SUPERSEDES the earlier text:**
 
    - **UTF-8 BOM:** stripped up front (encoding metadata, not content) — a BOM-prefixed
      `<!doctype html`/`<html` page is still detected, and a BOM-prefixed comment line no longer

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -975,10 +975,10 @@ function pfb_emit_entry_reject_stats(string $path): void {
 }
 
 // ADR-49 Phase 1: pure content-sanity scan over the first chunk of a downloaded
-// text feed. The caller reads up to 8 KiB and passes it in as $sample -- this
-// function does no I/O and has no notion of the cap: an 8 KiB read is a ceiling,
-// never a floor, so a feed shorter than that is a COMPLETE sample and is never
-// penalised for its size.
+// text feed. The caller reads a capped head sample (64 KiB at the pfb_download()
+// gate) and passes it in as $sample -- this function does no I/O and has no
+// notion of the cap: the read is a ceiling, never a floor, so a feed shorter
+// than the cap is a COMPLETE sample and is never penalised for its size.
 //
 // Returns NULL when the sample looks like plausible blocklist text, else one of
 // three reason tokens naming why it does not. Evaluated in this order, first
@@ -987,12 +987,18 @@ function pfb_emit_entry_reject_stats(string $path): void {
 //                             a text feed, so it is checked first.
 //   2. 'html_error_page'   -- the sample, left-trimmed of leading whitespace,
 //                             opens (case-insensitively) with "<!doctype html"
-//                             or "<html", AND none of its first 20 lines is
-//                             "blocklist-shaped" (an IPv4/IPv6 address or CIDR,
-//                             a hosts-style "IP<whitespace>domain" line, or a
-//                             bare/ABP-wrapped domain.tld token). This is the
-//                             false-positive guard: an HTML-ish feed that DOES
-//                             carry blocklist lines is not flagged.
+//                             or "<html", AND no line of the sample is
+//                             "blocklist-shaped": an IPv4/IPv6 address or CIDR
+//                             anywhere in the line (real feeds -- ProjectHoneypot,
+//                             cybercrime-tracker -- embed IPs inside HTML markup),
+//                             or a WHOLE line that is one bare/ABP-wrapped
+//                             domain.tld token. The domain token must BE the
+//                             line, never a substring: real error pages embed
+//                             domain-shaped tokens in markup (a DOCTYPE's w3.org
+//                             DTD URL, favicon.ico / *.css hrefs, CDN links),
+//                             and those must not suppress the verdict. This is
+//                             the false-positive guard: an HTML-ish feed that
+//                             DOES carry blocklist lines is not flagged.
 //   3. 'below_min_content' -- a LINE-count floor of 1, never a byte-size floor:
 //                             fires only when the sample has ZERO non-blank,
 //                             non-comment lines (a comment line begins with
@@ -1004,6 +1010,13 @@ function pfb_emit_entry_reject_stats(string $path): void {
 // pure ASCII, so a chunk-truncated multibyte tail can never flip a verdict.
 // Pure: string in, ?string out, no I/O, no globals.
 function pfb_text_sanity(string $sample): ?string {
+	// Strip a UTF-8 BOM up front -- encoding metadata, not content. Left in place
+	// it defeats the '<!doctype html'/'<html' opening-tag check (ltrim strips no
+	// BOM) AND lets a BOM-prefixed comment line count as data in the content floor.
+	if (strncmp($sample, "\xEF\xBB\xBF", 3) === 0) {
+		$sample = substr($sample, 3);
+	}
+
 	if (strpos($sample, "\x00") !== FALSE) {
 		return 'nul_bytes';
 	}
@@ -1014,18 +1027,39 @@ function pfb_text_sanity(string $sample): ?string {
 	$opens_as_html = stripos($leading_trimmed, '<!doctype html') === 0
 		|| stripos($leading_trimmed, '<html') === 0;
 
-	// Blocklist-shaped = an IPv4/IPv6 address or CIDR, OR a bare/ABP-wrapped
-	// domain.tld token -- a hosts-style "IP<ws>domain" line already satisfies
-	// the IP branch, so it needs no separate pattern.
-	$blocklist_shaped = '/(?:\d{1,3}\.){3}\d{1,3}(?:\/\d{1,2})?'
-		. '|(?:[0-9A-Fa-f]{1,4}:){3,7}[0-9A-Fa-f]{1,4}|[0-9A-Fa-f]*::[0-9A-Fa-f:]*'
-		. '|(?:\|\|)?[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?'
-		. '(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*\.[A-Za-z]{2,}\^?/';
+	// Blocklist-shaped, per branch:
+	//   - IPv4/CIDR: SUBSTRING match, deliberately -- real catalogue feeds
+	//     (ProjectHoneypot, cybercrime-tracker) serve their IPs embedded in HTML
+	//     markup, and those pages must keep suppressing the verdict.
+	//   - IPv6: substring too, but bounded (lookarounds + at least one hex group)
+	//     so a CSS pseudo-element ("h1::before" in an error page's inline styles)
+	//     or a "403 :: Forbidden" separator cannot suppress it.
+	//   - domain.tld (bare/ABP): the token must BE the whole line. A substring
+	//     match here lets the domain-shaped tokens of real error-page markup
+	//     (a DOCTYPE's w3.org DTD URL, favicon.ico / *.css hrefs, CDN links)
+	//     suppress the verdict -- and genuine domain feeds are one-token-per-line
+	//     formats anyway.
+	$ipv4_shaped = '/(?:\d{1,3}\.){3}\d{1,3}(?:\/\d{1,2})?/';
+	$ipv6_shaped = '/(?<![A-Za-z0-9:])(?:(?:[0-9A-Fa-f]{1,4}:){3,7}[0-9A-Fa-f]{1,4}'
+		. '|[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*::(?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?'
+		. '|::[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)(?![A-Za-z0-9:])/';
+	$domain_only_line = '/^(?:\|\|)?[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?'
+		. '(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*\.[A-Za-z]{2,}\^?$/';
 
+	// The guard scans EVERY line of the sample (already capped at 64 KiB by the
+	// caller), not a fixed head window: HTML-wrapped real feeds (ProjectHoneypot)
+	// carry their first IP only after ~90 lines of boilerplate, while a genuine
+	// error page has no blocklist-shaped line anywhere.
 	if ($opens_as_html) {
 		$has_blocklist_line = FALSE;
-		foreach (array_slice($lines, 0, 20) as $line) {
-			if (preg_match($blocklist_shaped, $line) === 1) {
+		foreach ($lines as $line) {
+			$line = trim($line);
+			if ($line === '') {
+				continue;
+			}
+			if (preg_match($ipv4_shaped, $line) === 1
+				|| preg_match($ipv6_shaped, $line) === 1
+				|| preg_match($domain_only_line, $line) === 1) {
 				$has_blocklist_line = TRUE;
 				break;
 			}
@@ -9995,8 +10029,11 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		// libmagic verdict (both are allow-listed synonyms; see pfb_filter FILE_MIME).
 		if (PfbConfig::read('pfb_feed_sanity') === PfbToggle::On &&
 			in_array($file_type, array('text/plain', 'text/html', 'text/csv', 'application/csv'), TRUE)) {
-			// Read UP TO 8 KiB -- a cap, not a minimum; a shorter feed is read whole.
-			$pfb_sanity_sample = @file_get_contents($file_download, FALSE, NULL, 0, 8192);
+			// Read UP TO 64 KiB -- a cap, not a minimum; a shorter feed is read whole.
+			// 64 KiB (raised from 8 KiB) because HTML-wrapped real feeds bury their
+			// first data token behind boilerplate (cybercrime-tracker's first IP sits
+			// ~12 KiB in) and the html_error_page guard must be able to see it.
+			$pfb_sanity_sample = @file_get_contents($file_download, FALSE, NULL, 0, 65536);
 			// A read error (FALSE) is NOT an empty feed: skip the scan (fail-open) so a
 			// transient I/O glitch is not mislogged as below_min_content and the feed --
 			// already MIME-validated -- proceeds instead of being wrongly dropped. A truly

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1034,17 +1034,21 @@ function pfb_text_sanity(string $sample): ?string {
 	//   - IPv6: substring too, but bounded (lookarounds + at least one hex group)
 	//     so a CSS pseudo-element ("h1::before" in an error page's inline styles)
 	//     or a "403 :: Forbidden" separator cannot suppress it.
-	//   - domain.tld (bare/ABP): the token must BE the whole line. A substring
-	//     match here lets the domain-shaped tokens of real error-page markup
-	//     (a DOCTYPE's w3.org DTD URL, favicon.ico / *.css hrefs, CDN links)
-	//     suppress the verdict -- and genuine domain feeds are one-token-per-line
-	//     formats anyway.
+	//   - domain.tld (bare/ABP/wildcard/FQDN): the token must BE the whole line.
+	//     A substring match here lets the domain-shaped tokens of real error-page
+	//     markup (a DOCTYPE's w3.org DTD URL, favicon.ico / *.css hrefs, CDN
+	//     links) suppress the verdict -- and genuine domain feeds are
+	//     one-token-per-line formats anyway.
+	// ponytail: the {3,7}-group IPv6 branch also matches MAC-like / timestamp
+	// hex-colon runs -- acceptable ceiling: a spurious suppression only defers to
+	// downstream parsing (today's behaviour); tighten to real address shapes if
+	// it ever misfires in practice.
 	$ipv4_shaped = '/(?:\d{1,3}\.){3}\d{1,3}(?:\/\d{1,2})?/';
 	$ipv6_shaped = '/(?<![A-Za-z0-9:])(?:(?:[0-9A-Fa-f]{1,4}:){3,7}[0-9A-Fa-f]{1,4}'
 		. '|[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*::(?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?'
 		. '|::[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)(?![A-Za-z0-9:])/';
-	$domain_only_line = '/^(?:\|\|)?[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?'
-		. '(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*\.[A-Za-z]{2,}\^?$/';
+	$domain_only_line = '/^(?:\|\|)?(?:\*\.)?[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?'
+		. '(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*\.[A-Za-z]{2,}\.?\^?$/';
 
 	// The guard scans EVERY line of the sample (already capped at 64 KiB by the
 	// caller), not a fixed head window: HTML-wrapped real feeds (ProjectHoneypot)

--- a/tests/php/FeedCorpusSurveyTest.php
+++ b/tests/php/FeedCorpusSurveyTest.php
@@ -145,6 +145,18 @@ final class FeedCorpusSurveyTest extends TestCase
 		'MPatrol'          => 'API-key gated — the catalogue url is an _API_KEY_ template; the capture hit the "access denied" auth wall, not the feed (below_min_content)',
 	];
 
+	/**
+	 * Corpus samples whose feed is REAL but whose 8 KiB capture is all leading HTML
+	 * boilerplate — the data starts past the capture cap, so a non-null verdict on
+	 * the TRUNCATED sample is expected and NOT representative of production, where
+	 * pfb_download() samples up to 64 KiB and sees the data. Same stay-flagged +
+	 * completeness guards as KNOWN_NON_FEED: an entry that starts passing means the
+	 * capture (or the scanner) changed and the entry must be re-checked/removed.
+	 */
+	private const KNOWN_TRUNCATED_FEED = [
+		'CCT_IP' => 'HTML-wrapped IP feed; first IP ~12 KiB into a 650+ KiB page (verified live 2026-07-04), past the 8 KiB corpus capture',
+	];
+
 	public function testCatalogueSurveyHasZeroFalsePositives(): void
 	{
 		if (!function_exists('pfb_text_sanity')) {
@@ -160,15 +172,16 @@ final class FeedCorpusSurveyTest extends TestCase
 		$flagged = [];
 		$stale = [];
 		$matched = [];
+		$exclusions = self::KNOWN_NON_FEED + self::KNOWN_TRUNCATED_FEED;
 		foreach (self::textSamples() as $feed) {
 			$sample = (string) file_get_contents(self::CORPUS_DIR . '/' . $feed['sample_file']);
 			$verdict = pfb_text_sanity($sample);
-			if (isset(self::KNOWN_NON_FEED[$feed['header']])) {
+			if (isset($exclusions[$feed['header']])) {
 				$matched[$feed['header']] = TRUE;
-				// A known non-feed sample MUST stay flagged: if it now passes, the feed
-				// came back or the capture changed, so the exclusion is stale.
+				// An excluded sample MUST stay flagged: if it now passes, the feed came
+				// back (or the capture/scanner changed), so the exclusion is stale.
 				if ($verdict === NULL) {
-					$stale[] = "{$feed['header']} — now passes pfb_text_sanity(); re-check the feed and drop it from KNOWN_NON_FEED";
+					$stale[] = "{$feed['header']} — now passes pfb_text_sanity(); re-check the feed and drop its exclusion entry";
 				}
 				continue;
 			}
@@ -185,19 +198,19 @@ final class FeedCorpusSurveyTest extends TestCase
 		$this->assertSame(
 			[],
 			$stale,
-			"KNOWN_NON_FEED exclusions that are no longer flagged (stale — re-check the feed and remove the entry):\n"
+			"exclusions (KNOWN_NON_FEED / KNOWN_TRUNCATED_FEED) that are no longer flagged (stale — re-check the feed and remove the entry):\n"
 			. implode("\n", $stale)
 		);
-		// Completeness: every KNOWN_NON_FEED key must have been encountered in the corpus.
+		// Completeness: every exclusion key must have been encountered in the corpus.
 		// A feed dropped/renamed in the catalogue makes its exclusion inert (visited by
 		// neither the flagged nor the stale branch), so a dead entry would rot undetected
 		// while reading as "still validated" — fail loudly instead, mirroring the reverse-
 		// coherence orphan guard in testCorpusIsPresentAndCoherent.
-		$dead = array_values(array_diff(array_keys(self::KNOWN_NON_FEED), array_keys($matched)));
+		$dead = array_values(array_diff(array_keys($exclusions), array_keys($matched)));
 		$this->assertSame(
 			[],
 			$dead,
-			"KNOWN_NON_FEED entries no longer present in the corpus (dropped/renamed feed — remove them or refresh the corpus):\n"
+			"exclusion entries no longer present in the corpus (dropped/renamed feed — remove them or refresh the corpus):\n"
 			. implode("\n", $dead)
 		);
 	}

--- a/tests/php/FeedCorpusSurveyTest.php
+++ b/tests/php/FeedCorpusSurveyTest.php
@@ -172,6 +172,13 @@ final class FeedCorpusSurveyTest extends TestCase
 		$flagged = [];
 		$stale = [];
 		$matched = [];
+		// '+' keeps the LEFT value on a key collision with no error -- assert the
+		// classes stay disjoint so a duplicated header fails loudly instead.
+		$this->assertSame(
+			[],
+			array_intersect_key(self::KNOWN_NON_FEED, self::KNOWN_TRUNCATED_FEED),
+			'a feed header must appear in only ONE exclusion class'
+		);
 		$exclusions = self::KNOWN_NON_FEED + self::KNOWN_TRUNCATED_FEED;
 		foreach (self::textSamples() as $feed) {
 			$sample = (string) file_get_contents(self::CORPUS_DIR . '/' . $feed['sample_file']);

--- a/tests/php/PfbTextSanityTest.php
+++ b/tests/php/PfbTextSanityTest.php
@@ -138,6 +138,14 @@ final class PfbTextSanityTest extends TestCase
 		$this->assertNull(pfb_text_sanity($sample));
 	}
 
+	public function test_html_body_with_wildcard_and_fqdn_domain_lines_is_not_flagged(): void
+	{
+		// Guard variants: a wildcard label and a trailing-dot FQDN are still
+		// one-token-per-line domain entries.
+		$this->assertNull(pfb_text_sanity("<html>\n*.tracker.example\n</html>\n"));
+		$this->assertNull(pfb_text_sanity("<html>\nads.example.org.\n</html>\n"));
+	}
+
 	public function test_html_wrapped_ipv4_feed_is_not_flagged(): void
 	{
 		// Behaviour pin: real catalogue feeds (ProjectHoneypot, cybercrime-tracker)

--- a/tests/php/PfbTextSanityTest.php
+++ b/tests/php/PfbTextSanityTest.php
@@ -9,12 +9,14 @@ use PHPUnit\Framework\TestCase;
  * Unit tests for pfb_text_sanity() — ADR-49 Phase 1.
  *
  * pfb_text_sanity(string $sample): ?string is a PURE content-sanity scanner over
- * the first chunk (up to 8 KiB, a read cap never a floor) of a downloaded text
- * feed. It returns NULL when the sample looks like plausible blocklist text, or
- * one of three reason tokens otherwise. Verdict order (first hit wins):
+ * the first chunk (up to 64 KiB at the pfb_download() gate, a read cap never a
+ * floor) of a downloaded text feed. It returns NULL when the sample looks like
+ * plausible blocklist text, or one of three reason tokens otherwise. Verdict
+ * order (first hit wins):
  *   1. 'nul_bytes'         — any \x00 byte anywhere in the sample.
  *   2. 'html_error_page'   — opens with <!doctype html>/<html> AND carries no
- *                            blocklist-shaped line in its first 20 lines.
+ *                            blocklist-shaped line anywhere in the sample
+ *                            (IP/CIDR substring; domain.tld only as a whole line).
  *   3. 'below_min_content' — zero non-blank, non-comment lines (floor = 1).
  * All matching is BYTE-LEVEL (no `/u` modifier) — every pattern is pure ASCII,
  * so a chunk-truncated multibyte tail can never flip a verdict.
@@ -51,7 +53,7 @@ final class PfbTextSanityTest extends TestCase
 
 	public function test_tiny_few_byte_feed_is_not_size_penalised(): void
 	{
-		// A short body (well under the 8 KiB read cap) is a complete sample, never
+		// A short body (well under the read cap) is a complete sample, never
 		// penalised for its size — no "too small" heuristic exists.
 		$this->assertNull(pfb_text_sanity("1.2.3.4\n"));
 	}
@@ -115,9 +117,123 @@ final class PfbTextSanityTest extends TestCase
 	public function test_html_body_with_a_blocklist_line_is_not_flagged(): void
 	{
 		// The false-positive guard: an HTML-ish feed that DOES carry a
-		// blocklist-shaped line within its first 20 lines must NOT be flagged.
+		// blocklist-shaped line must NOT be flagged.
 		$sample = "<html><body>\n0.0.0.0 ads.example.org\n</body></html>\n";
 		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	public function test_html_body_with_a_bare_domain_line_is_not_flagged(): void
+	{
+		// Guard variant: a whole line that IS one bare domain token still counts
+		// as blocklist-shaped inside an HTML-opening body.
+		$sample = "<html>\nads.example.org\n</html>\n";
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	public function test_html_body_with_an_abp_line_is_not_flagged(): void
+	{
+		// Guard variant: a whole line that IS one ABP-wrapped domain token still
+		// counts as blocklist-shaped inside an HTML-opening body.
+		$sample = "<html>\n||ads.example.org^\n</html>\n";
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	public function test_html_wrapped_ipv4_feed_is_not_flagged(): void
+	{
+		// Behaviour pin: real catalogue feeds (ProjectHoneypot, cybercrime-tracker)
+		// serve IPs EMBEDDED in HTML markup -- an IPv4 substring inside a markup
+		// line must keep suppressing the verdict (never whole-line-anchor the IPs).
+		$sample = "<html>\n<body>\n<td>192.0.2.1</td>\n</body>\n</html>\n";
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	public function test_html_wrapped_ipv6_feed_is_not_flagged(): void
+	{
+		// Same pin for a compressed IPv6 address inside markup.
+		$sample = "<html>\n<body>\n<td>2001:db8::1</td>\n</body>\n</html>\n";
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	public function test_html_wrapped_feed_with_late_first_ip_is_not_flagged(): void
+	{
+		// The guard scans EVERY sampled line, not a fixed head window: an
+		// HTML-wrapped feed whose first IP appears only after hundreds of
+		// boilerplate lines (ProjectHoneypot ~line 92, cybercrime-tracker ~12 KiB
+		// in) must still suppress the verdict.
+		$sample = "<html>\n<body>\n"
+			. str_repeat("<p>filler markup text</p>\n", 300)
+			. "<td>198.51.100.7</td>\n</body>\n</html>\n";
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	// -- 'html_error_page' guard precision: embedded domain tokens are NOT blocklist lines --
+
+	public function test_xhtml_error_page_with_dtd_url_is_flagged(): void
+	{
+		// A legacy XHTML error page's DOCTYPE/xmlns lines embed w3.org URLs. Those
+		// are markup, not blocklist entries -- the guard must not read them as
+		// blocklist-shaped lines, so the page is still flagged html_error_page.
+		$sample = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\""
+			. " \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n"
+			. "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+			. "<head><title>403 Forbidden</title></head>\n"
+			. "<body><h1>Forbidden</h1><p>You don't have permission to access this resource</p></body>\n"
+			. "</html>\n";
+		$this->assertSame('html_error_page', pfb_text_sanity($sample));
+	}
+
+	public function test_html_error_page_with_asset_hrefs_is_flagged(): void
+	{
+		// favicon.ico / *.css hrefs and CDN links are domain/filename-shaped
+		// substrings inside markup -- typical of virtually every real error page.
+		// They must not suppress the html_error_page verdict.
+		$sample = "<!doctype html>\n"
+			. "<html>\n"
+			. "<head>\n"
+			. "<meta charset=\"utf-8\">\n"
+			. "<title>Access denied</title>\n"
+			. "<link rel=\"icon\" href=\"/favicon.ico\">\n"
+			. "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css\">\n"
+			. "</head>\n"
+			. "<body><h1>Access denied</h1><p>The owner of this website has banned your IP address</p></body>\n"
+			. "</html>\n";
+		$this->assertSame('html_error_page', pfb_text_sanity($sample));
+	}
+
+	public function test_html_error_page_with_css_pseudo_elements_is_flagged(): void
+	{
+		// A '::' CSS pseudo-element (or a "403 :: Forbidden" separator) is not an
+		// IPv6 address -- an error page's inline styles must not suppress the
+		// verdict.
+		$sample = "<!doctype html>\n"
+			. "<html>\n"
+			. "<head>\n"
+			. "<style>\n"
+			. "h1::before { content: \"\" }\n"
+			. "a::hover { color: red }\n"
+			. "</style>\n"
+			. "</head>\n"
+			. "<body><h1>Service Unavailable</h1><p>Try again later</p></body>\n"
+			. "</html>\n";
+		$this->assertSame('html_error_page', pfb_text_sanity($sample));
+	}
+
+	// -- UTF-8 BOM handling ----------------------------------------------------------------
+
+	public function test_bom_prefixed_html_error_page_is_flagged(): void
+	{
+		// A UTF-8 BOM is encoding metadata, not content: it must not defeat the
+		// '<!doctype html'/'<html' opening-tag detection (ltrim strips no BOM).
+		$sample = "\xEF\xBB\xBF<!doctype html>\n<html><body><h1>404 Not Found</h1></body></html>\n";
+		$this->assertSame('html_error_page', pfb_text_sanity($sample));
+	}
+
+	public function test_bom_prefixed_comment_only_body_is_below_min_content(): void
+	{
+		// The BOM must not make the first comment line read as a data line in the
+		// content floor either.
+		$sample = "\xEF\xBB\xBF# generated header\n! nothing else\n";
+		$this->assertSame('below_min_content', pfb_text_sanity($sample));
 	}
 
 	// -- 'below_min_content' --------------------------------------------------------------
@@ -163,8 +279,8 @@ final class PfbTextSanityTest extends TestCase
 
 	public function test_truncated_mid_token_line_is_the_sole_floor_candidate(): void
 	{
-		// 8180 bytes of comments, then a data line cut mid-token by the 8 KiB read
-		// cap. The truncated "0.0.0.0 fill" is the ONLY non-comment line, so NULL
+		// 8180 bytes of comments, then a data line cut mid-token by a read cap.
+		// The truncated "0.0.0.0 fill" is the ONLY non-comment line, so NULL
 		// proves the floor loop counted the truncated tail as content; a mis-split
 		// of it would flip the verdict to below_min_content.
 		$header = str_repeat("# c\n", 2045);                              // 8180 bytes, all comments

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -3321,7 +3321,8 @@ def test_validate_log_healthy_abp_feed_no_entries_reject(
 # (a real branch, not an always-reject path).
 # --------------------------------------------------------------------------- #
 
-_SANITY_SCANNED_MIME_TYPES = ("text/plain", "text/html", "text/csv")
+# Mirrors the gate's in_array() list in pfblockerng.inc pfb_download() -- keep in sync.
+_SANITY_SCANNED_MIME_TYPES = ("text/plain", "text/html", "text/csv", "application/csv")
 
 
 @pytest.mark.timeout(180)


### PR DESCRIPTION
## What

Fixes the two [PR #829](https://github.com/pfBlockerNG/pfBlockerNG/pull/829) adversarial-review findings that were still present in the merged code, plus the collateral they surfaced. Scope: `pfb_text_sanity()` + its `pfb_download()` gate, the oracle/survey tests, one smoke-side constant sync, and a dated ADR-49 amendment.

### 1. UTF-8 BOM bypass (review finding 2 — CONFIRMED)

`ltrim()` strips no BOM, so a BOM-prefixed `<!doctype html>`/`<html>` error page skipped the `html_error_page` check entirely, and the BOM-prefixed first line satisfied the content floor → verdict `NULL` (accepted). BOM-emitting IIS/Windows error pages are a real occurrence. The scanner now strips a leading BOM before any check.

### 2. `html_error_page` guard over-match (review finding 1 — CONFIRMED)

The old guard suppressed the verdict on **any substring** of any of the first 20 lines matching an IP/domain shape. Virtually every real error page carries a domain-shaped token in markup — a legacy DOCTYPE's `w3.org` DTD URL, `favicon.ico`/`*.css` hrefs, CDN links — so 2 of 3 realistic error pages sailed through, and the corpus's only HTML catch (MaxMind) survived by a line-wrapping coincidence. Now per branch:

- **IPv4/CIDR: substring, deliberately** — ProjectHoneypot / cybercrime-tracker are real catalogue feeds serving IPs embedded in HTML markup, and must keep suppressing the verdict.
- **IPv6: bounded substring** — a CSS `::before` or a `403 :: Forbidden` separator no longer reads as an address.
- **`domain.tld` (bare/ABP): whole line only** — genuine domain feeds are one-token-per-line; markup-embedded tokens no longer suppress.

### 3. What the fix surfaced (the interesting part)

With the over-match gone, the offline survey exposed that **10 real HTML-wrapped feeds (HoneyPot ×9, CCT_IP) had only been passing the scanner through the over-match bug**:

- HoneyPot's first IP sits at ~line 92 — past the 20-line guard window. The guard now scans **every sampled line** (the sample is already capped, so this is bounded).
- cybercrime-tracker's first IP sits **~12 KiB into a 650+ KiB page** (verified against the live feed) — past the 8 KiB sample cap. The gate's read cap is raised to **64 KiB** (still a ceiling, never a floor; single local read, negligible cost).
- The committed corpus captures stay at 8 KiB, so `CCT_IP` is documented in the survey as a new `KNOWN_TRUNCATED_FEED` exclusion class (real feed, truncated capture) with the same stay-flagged + completeness guards as `KNOWN_NON_FEED`.

### Tests (red → green on the merged scanner)

XHTML-DTD error page, asset-href error page, CSS-pseudo-element error page, both BOM cases, and the late-first-IP pin all **fail on `devel`'s scanner and pass here**; behaviour pins added for HTML-wrapped IPv4/IPv6 feeds and bare-domain/ABP lines inside HTML. Full suite: PHPUnit green (3 pre-existing macOS `open_basedir`/TMPDIR sandbox failures on `devel` too, unrelated), survey zero-FP with all exclusions matched, PHPStan/PHPCS/ruff/markdownlint clean.

### Not changed

- Findings 3 (read-failure fail-open) and 5 (survey completeness) were already fixed in-PR by commit 6ddfa1ee; finding 4's `application/csv` widening likewise — this PR only syncs the smoke-side `_SANITY_SCANNED_MIME_TYPES` mirror and documents everything in the ADR amendment.
- `pfb_feed_sanity` stays opt-in, default OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed text checks to better handle HTML-wrapped content, including BOM-prefixed responses, late-appearing blocklist data, and common false positives from markup, links, and CSS-like text.
  * Expanded HTML error-page detection so more malformed or boilerplate-heavy feeds are rejected consistently.
  * Increased the amount of feed content inspected before making a decision, helping catch useful data hidden deeper in the response.
  * Added support for another CSV MIME type in feed handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->