### PR TITLE
pfblockerng: fixed-string per-row DNSBL grep (fixes #837) + #835 review follow-ups

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -20,7 +20,8 @@ name: UI tests fan-out (all CI legs, live pfSense VM)
 #   * Tier A (render) is the cheap/hermetic PR gate — test.yml runs it per-PR on
 #     PHP/JS changes and folds it into the "All tests passed" aggregate.
 #   * Tier B (functional + browser) is daily/on-demand and NEVER gates a PR:
-#     the `schedule` (daily) + `workflow_dispatch` triggers here, plus the
+#     the `schedule` (daily; it also rides a Tier A render leg — see
+#     DEFAULT_SCHEDULE_TIERS below) + `workflow_dispatch` triggers here, plus the
 #     marker being off the default collection, keep it non-blocking by
 #     construction (RESULTS/04 §6). The browser leg's §7 demote/drop is a
 #     ONE-LINE switch: drop `browser` from DEFAULT_SCHEDULE_TIERS below to stop
@@ -140,7 +141,8 @@ on:
         description: "FreeBSD-ports branch (blank = build-pkg-linux default pfblockerng/use-github)."
         required: false
         default: ""
-  # Daily Tier-B run (functional + browser). Non-PR-blocking by construction.
+  # Daily run: Tier A render + Tier B (functional + browser). Non-PR-blocking
+  # by construction.
   # The `prepare` job guards it to SKIP when there were no commits in the last
   # day (mirrors a smoke-style nightly guard) so an idle repo does not boot a VM.
   schedule:
@@ -214,7 +216,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           # For a dispatch/call the tier input narrows the matrix; the schedule
-          # ignores it and always runs the daily Tier-B set.
+          # ignores it and always runs the full DEFAULT_SCHEDULE_TIERS set.
           TIER_INPUT: ${{ inputs.tier }}
           # Optional narrow-to-one filter: a pfsense_version (e.g. "2.8"). Blank =
           # scope decides (min CE for impacted, all legs for full).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -804,7 +804,9 @@ Non-obvious truths, each costly to relearn:
 - **Test domains MUST be `helpers.unique_domain()`** (`uuid-*.com`): never RFC 6761 TLDs
   (`.test`/`.example`/`.invalid`/…) — Unbound's built-in `local-zone`s shadow them
   (NXDOMAIN/NODATA) before DNSBL — and never HSTS-preload names (`pfb_hsts`, default ON, forces
-  a would-be VIP block to NULL).
+  a would-be VIP block to NULL). **Sole carve-out:** a byte-identity harness (captures must be
+  byte-comparable across two separate CI runs, e.g. `tests/smoke/ui/test_alerts_render_verify.py`)
+  uses fixed inert literals instead — the RFC 6761 and HSTS-preload prohibitions still apply.
 - **Block shapes (python mode):** NOERROR + VIP (`dnsbl_ipv4`) or NULL (`0.0.0.0`/`::`); NEVER
   NXDOMAIN for a feed match (NXDOMAIN is SafeSearch-only). Per-list `logging` selects VIP vs
   NULL and is a **LIST-level** field (`$list['logging']`), not per-row. Compare IPs **by value**

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -13045,15 +13045,15 @@ function pfb_dnsbl_prefetch(array $qdomains) {
 // destructures on a per-row hit) to the FIRST line seen for it. grep preserves the
 // file's original line order regardless of pattern order, so "first seen in this batched
 // pass" is exactly the per-row `-m1` result for that same domain/suffix. $patterns are
-// raw literal ",{domain-or-suffix},," strings (no regex escaping) -- see
-// pfb_dnsbl_prefetch()'s docblock for why -F fixed-string matching is equivalent to the
-// per-row escaped-BRE match here.
+// raw literal ",{domain-or-suffix},," strings (no regex escaping) -- the per-row sites
+// are `-F` fixed-string too (issue #837; see pfb_dnsbl_prefetch()'s docblock), so both
+// sides match identically by construction.
 //
 // Keying the map by field [1] relies on where a ",X,," pattern can match: in the
 // ",domain,,log_type,feed,group" line shape, the empty placeholder after the domain slot
 // is the only double comma a well-formed line contains, so a ",X,," fixed string can
 // only ever match with X in the domain slot -- field [1]. That is exactly what makes
-// "key by field [1]" select the same line the per-row `grep -shm1 ',X,,'` would.
+// "key by field [1]" select the same line the per-row `grep -shm1 -F ',X,,'` would.
 //
 // B3/R1 (issue #809 review): returns NULL -- distinct from a genuine empty-array
 // no-match result -- when the pattern file itself could not be created or fully written

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12957,13 +12957,11 @@ function pfb_dnsbl_prefetch_store(?array $seed = NULL): ?array {
 // per-row match pfb_dnsbl_parse_compute() would otherwise run separately for each of
 // $qdomains:
 //
-//   - data file ($pfb['unbound_py_data']): the per-row site matches the escaped-regex
-//     literal ",{$domainparse},," (dots backslash-escaped) with `grep -shm1`. Escaping
-//     the dots exists only to neutralise BRE's any-character '.' metacharacter --
-//     domains carry no other BRE-special character -- so the escaped-regex match and a
-//     plain fixed-string match of ",{domain},," select exactly the same lines. Batched
-//     here as a single `grep -shF -f <patternfile>` pass with the RAW (unescaped)
-//     literal patterns.
+//   - data file ($pfb['unbound_py_data']): the per-row site matches the fixed-string
+//     literal ",{domain},," with `grep -shm1 -F` (issue #837 -- previously an escaped-BRE
+//     match that hand-escaped only the dot, so any OTHER BRE metacharacter in the domain
+//     rode into the regex live). Batched here as a single `grep -shF -f <patternfile>`
+//     pass with the same RAW literal patterns.
 //   - zone file ($pfb['unbound_py_zone']): the per-row site walks the domain's labels
 //     longest-first (full domain, then each suffix with the leftmost label stripped,
 //     down to the bare TLD), matching each step the same way. Batched by collecting
@@ -12974,17 +12972,14 @@ function pfb_dnsbl_prefetch_store(?array $seed = NULL): ?array {
 // genuine miss, and the consult sites must serve that cached '' rather than falling back
 // to a per-row exec (which would just re-run the identical grep for the same answer).
 //
-// B2 (issue #809 review): a domain is only added to 'covered' (and only contributes data/
-// zone patterns) when it VALIDATES as PFB_FILTER_DOMAIN. That filter's charset
-// ([a-zA-Z0-9_.-]) carries no live BRE metacharacter besides '.' -- the ONLY character the
-// per-row site escapes (str_replace('.', '\.', $domain)) -- and no embedded control
-// character (a fgetcsv()'d quoted field can carry a literal \r/\n). Under those
-// constraints an exact `-F` fixed-string match and the per-row escaped-BRE match select
-// the IDENTICAL lines, so batched == per-row for every covered domain. A domain that
-// fails this filter is left UNCOVERED entirely, so it falls straight through to the
-// unchanged per-row exec at pfb_dnsbl_parse_compute()'s consult sites -- exactly where a
-// domain carrying a live BRE metacharacter (which could false-match a DIFFERENT literal
-// domain under the per-row BRE, something a batched `-F` match never would) belongs.
+// B2 (issue #809 review; revised for issue #837): a domain is only added to 'covered'
+// (and only contributes data/zone patterns) when it VALIDATES as PFB_FILTER_DOMAIN --
+// guards against an embedded control character (a fgetcsv()'d quoted field can carry a
+// literal \r/\n) reaching the pattern file. Since the per-row sites are now ALSO `-F`
+// fixed-string (issue #837), batched == per-row by construction for every domain, not
+// only ones passing this filter; a domain that fails it is simply left UNCOVERED and
+// falls straight through to the unchanged (and, post-#837, equally fixed-string) per-row
+// exec at pfb_dnsbl_parse_compute()'s consult sites.
 //
 // Seeds pfb_dnsbl_prefetch_store(); the caller (pfblockerng_alerts.php's DNSBL table
 // branch) is responsible for resetting the store once its render pass is done.
@@ -13179,8 +13174,6 @@ function pfb_dnsbl_parse_compute($mode, $domain, $src_ip, $req_agent) {
 
 		while (TRUE) {
 
-			$domainparse = str_replace('.', '\.', $domain);
-
 			// A covered domain reuses the batched grep's answer (a covered miss is a
 			// cached '', never re-exec'd here); an uncovered one -- no store seeded, or
 			// a CNAME-chain domain the prefetch pass never saw -- falls straight through
@@ -13188,8 +13181,12 @@ function pfb_dnsbl_parse_compute($mode, $domain, $src_ip, $req_agent) {
 			if ($prefetch_store !== NULL && isset($prefetch_store['covered'][$domain])) {
 				$pfb_feed = $prefetch_store['data'][$domain] ?? '';
 			} else {
-				$dquery_esc	= escapeshellarg(",{$domainparse},,");
-				$pfb_feed	= exec("{$pfb['grep']} -shm1 {$dquery_esc} {$pfb['unbound_py_data']} 2>&1");
+				// issue #837: fixed-string match on the raw domain -- no regex escaping,
+				// so no BRE metacharacter (besides the dot this used to hand-escape) can
+				// false-match a different literal line, nor make the domain's own entry
+				// unfindable. Same shape as the batched prefetch grep.
+				$dquery_esc	= escapeshellarg(",{$domain},,");
+				$pfb_feed	= exec("{$pfb['grep']} -shm1 -F {$dquery_esc} {$pfb['unbound_py_data']} 2>&1");
 			}
 			$pfb_group = $pfb_mode = $pfb_final = 'Unknown';
 
@@ -13207,7 +13204,6 @@ function pfb_dnsbl_parse_compute($mode, $domain, $src_ip, $req_agent) {
 
 				for ($i=0; $i < $dcnt; $i++) {
 
-					$domainparse	= str_replace('.', '\.', implode('.', $dparts));
 					$suffix		= implode('.', $dparts);
 
 					// Same prefetch consult as the data-grep site above, keyed by this
@@ -13215,15 +13211,16 @@ function pfb_dnsbl_parse_compute($mode, $domain, $src_ip, $req_agent) {
 					if ($prefetch_store !== NULL && isset($prefetch_store['zone_covered'][$suffix])) {
 						$pfb_feed = $prefetch_store['zone'][$suffix] ?? '';
 					} else {
-						$dquery_esc	= escapeshellarg(",{$domainparse},,");
-						$pfb_feed	= exec("{$pfb['grep']} -shm1 {$dquery_esc} {$pfb['unbound_py_zone']} 2>&1");
+						// issue #837: fixed-string match -- see the data-grep site above.
+						$dquery_esc	= escapeshellarg(",{$suffix},,");
+						$pfb_feed	= exec("{$pfb['grep']} -shm1 -F {$dquery_esc} {$pfb['unbound_py_zone']} 2>&1");
 					}
 
 					// Collect Alias Group name
 					if (!empty($pfb_feed)) {
 						list($dummy, $d_found, $empty_placeholder, $log_type, $pfb_feed, $pfb_group) = explode(',', $pfb_feed);
 
-						$pfb_final = str_replace('\.', '.', $domainparse);
+						$pfb_final = $suffix;
 						$pfb_mode = 'TLD';
 						if ($pfb_feed == 'DNSBL_TLD') {
 							$pfb_mode = 'DNSBL_TLD';

--- a/tests/php/AlertsIpConvertPrefetchParityTest.php
+++ b/tests/php/AlertsIpConvertPrefetchParityTest.php
@@ -49,26 +49,10 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		// Load convert_ip_log() (+ its same-file helpers) off-appliance, exactly like
-		// WhitelistTrashIconTest / AlertsRowOutputEncodingTest: read the page source,
-		// strip its require_once() lines, and eval only the function-definition block
-		// (from the first `function` to the top-level `$pgtitle = ` render wiring).
-		if (function_exists('convert_ip_log')) {
-			return;
-		}
-		$src = file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
-		);
-		if ($src === FALSE) {
-			throw new RuntimeException('failed to read pfblockerng_alerts.php');
-		}
-		$src = preg_replace('/^\s*require_once\(.*\);\s*$/m', '', $src);
-		$start = strpos($src, "\nfunction ");
-		$end   = strpos($src, "\n\$pgtitle = ");
-		if ($start === FALSE || $end === FALSE || $end <= $start) {
-			throw new RuntimeException('could not locate the function block in pfblockerng_alerts.php');
-		}
-		eval("\n" . substr($src, $start + 1, $end - $start - 1));
+		// See AlertsPageLoader.php for the off-appliance load mechanics (shared with
+		// WhitelistTrashIconTest / AlertsRowOutputEncodingTest).
+		require_once __DIR__ . '/AlertsPageLoader.php';
+		pfb_test_load_alerts_page_functions();
 	}
 
 	protected function setUp(): void
@@ -150,22 +134,9 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 			}
 		}
 
-		$this->rrmdir($this->tmpDir);
-	}
-
-	private function rrmdir(string $dir): void
-	{
-		if (!is_dir($dir)) {
-			return;
-		}
-		foreach (scandir($dir) as $entry) {
-			if ($entry === '.' || $entry === '..') {
-				continue;
-			}
-			$path = "{$dir}/{$entry}";
-			is_dir($path) ? $this->rrmdir($path) : @unlink($path);
-		}
-		@rmdir($dir);
+		// rmdir_recursive() is the bootstrap-loaded pfsense_doubles.php double for
+		// pfSense's util.inc function of the same name (tests/php/pfsense_doubles.php:195).
+		rmdir_recursive($this->tmpDir);
 	}
 
 	/**

--- a/tests/php/AlertsPageLoader.php
+++ b/tests/php/AlertsPageLoader.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Shared off-appliance loader for the pfblockerng_alerts.php function block.
+ *
+ * Three sibling test classes (WhitelistTrashIconTest, AlertsRowOutputEncodingTest,
+ * AlertsIpConvertPrefetchParityTest) each need convert_ip_log() / convert_dnsbl_log() /
+ * pfb_whitelist_trash_icon() and friends defined off-appliance, without running the
+ * page's top-level render wiring (which needs a live pfSense runtime). All of them
+ * live in ONE contiguous function block in the page source, so one load covers every
+ * caller: read the source, strip its top-of-file require_once() lines (the bootstrap
+ * has already loaded the real pfblockerng.inc + shims), and eval only from the first
+ * `function` keyword up to the first top-level statement that follows the block --
+ * `$pgtitle = array(...)`, which precedes include_once('head.inc') and
+ * display_top_tabs(). No production file is modified to make it testable.
+ */
+function pfb_test_load_alerts_page_functions(): void
+{
+	if (function_exists('convert_ip_log')) {
+		return;
+	}
+	$src = file_get_contents(
+		dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
+	);
+	if ($src === false) {
+		throw new RuntimeException('failed to read pfblockerng_alerts.php');
+	}
+	$src = preg_replace('/^\s*require_once\(.*\);\s*$/m', '', $src);
+	$start = strpos($src, "\nfunction ");
+	$end   = strpos($src, "\n\$pgtitle = ");
+	if ($start === false || $end === false || $end <= $start) {
+		throw new RuntimeException('could not locate the function block in pfblockerng_alerts.php');
+	}
+	eval("\n" . substr($src, $start + 1, $end - $start - 1));
+}

--- a/tests/php/AlertsRowOutputEncodingTest.php
+++ b/tests/php/AlertsRowOutputEncodingTest.php
@@ -44,32 +44,10 @@ final class AlertsRowOutputEncodingTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        // Load the alerts-page row-builder functions off-appliance: read the
-        // source, drop the top-of-file require_once() lines (the bootstrap has
-        // already loaded the real pfblockerng.inc + shims), and eval only the
-        // function definitions, skipping the page-render wiring. Mirrors the
-        // wizard-function load in bootstrap.php.
-        if (function_exists('convert_dnsbl_log')) {
-            return;
-        }
-        $src = file_get_contents(
-            dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
-        );
-        if ($src === false) {
-            throw new RuntimeException('failed to read pfblockerng_alerts.php');
-        }
-        $src = preg_replace('/^\s*require_once\(.*\);\s*$/m', '', $src);
-        // The row-builder functions form one contiguous block; after them the
-        // page resumes top-level render wiring (the first such statement is the
-        // `$pgtitle = array(...)` line, which precedes include_once('head.inc')
-        // and display_top_tabs()). Eval only [first `function ` .. that line) so
-        // we define the builders without executing any page-render code.
-        $start = strpos($src, "\nfunction ");
-        $end = strpos($src, "\n\$pgtitle = ");
-        if ($start === false || $end === false || $end <= $start) {
-            throw new RuntimeException('could not locate the row-builder function block in pfblockerng_alerts.php');
-        }
-        eval("\n" . substr($src, $start + 1, $end - $start - 1));
+        // See AlertsPageLoader.php for the off-appliance load mechanics (shared with
+        // WhitelistTrashIconTest / AlertsIpConvertPrefetchParityTest).
+        require_once __DIR__ . '/AlertsPageLoader.php';
+        pfb_test_load_alerts_page_functions();
     }
 
     protected function setUp(): void

--- a/tests/php/DnsblParseComputeMetacharTest.php
+++ b/tests/php/DnsblParseComputeMetacharTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_parse_compute() -- issue #837: the per-row DNSBL data/zone grep sites build a
+ * BRE pattern that escapes ONLY the dot metacharacter (str_replace('.', '\.', $domain)).
+ * Any OTHER BRE metachar in the query domain rides into the regex live:
+ *   - a query domain carrying a metachar can FALSE-MATCH a different, unrelated literal
+ *     domain already in the data/zone file (e.g. 'a*b837.com' as BRE means zero-or-more
+ *     'a' then literal 'b837.com' -- matches the line for plain 'b837.com');
+ *   - conversely, a domain that itself carries a metachar and IS present verbatim in the
+ *     data/zone file can fail to be found by its own mis-escaped pattern.
+ *
+ * Fix: both per-row grep sites match with `-F` (fixed string) against the raw, unescaped
+ * domain/suffix -- the same shape the batched prefetch pass (pfb_dnsbl_prefetch_grep())
+ * already uses.
+ *
+ * Feature: the per-row DNSBL data/zone lookup treats the query domain as a literal string
+ *   Background:
+ *     Given the real DNSBL data/zone file line shape ",{domain-or-suffix},,{log},{feed},{group}"
+ *     And pfb_dnsbl_parse_compute() run in a mode that is neither 'alerts' (which caches
+ *       ONE SQLite3 handle for the life of the PHP process) nor 'daemon' (which returns a
+ *       packed CSV string instead of the assoc array asserted below) -- a fresh SQLite3
+ *       cache handle opens and closes on every call, so a distinct cache-db path per test
+ *       is real isolation.
+ */
+#[CoversFunction('pfb_dnsbl_parse_compute')]
+final class DnsblParseComputeMetacharTest extends TestCase
+{
+	/** @var array<string, mixed>|null */
+	private ?array $savedPfb = null;
+
+	private ?string $tmpDir = null;
+
+	protected function setUp(): void
+	{
+		$this->savedPfb = $GLOBALS['pfb'] ?? null;
+		pfb_dnsbl_prefetch_store(NULL);
+	}
+
+	protected function tearDown(): void
+	{
+		pfb_dnsbl_prefetch_store(NULL);
+		if ($this->savedPfb === null) {
+			unset($GLOBALS['pfb']);
+		} else {
+			$GLOBALS['pfb'] = $this->savedPfb;
+		}
+		if ($this->tmpDir !== null) {
+			rmdir_recursive($this->tmpDir);	// the util.inc double from pfsense_doubles.php
+			$this->tmpDir = null;
+		}
+	}
+
+	/**
+	 * Fresh per-test sandbox: its own tmp dir, data/zone fixture files, and SQLite cache
+	 * path. Because parse() below never runs in 'alerts' mode, every call opens/closes its
+	 * own SQLite3 handle against THIS test's cache path -- no state leaks between tests.
+	 */
+	private function seedSandbox(string $dataContent, string $zoneContent): void
+	{
+		$tmpDir = sys_get_temp_dir() . '/pfb_dnsbl_metachar_test_' . bin2hex(random_bytes(8));
+		mkdir($tmpDir, 0777, true);
+		$this->tmpDir = $tmpDir;
+
+		$dataFile = "{$tmpDir}/data.txt";
+		$zoneFile = "{$tmpDir}/zone.txt";
+		file_put_contents($dataFile, $dataContent);
+		file_put_contents($zoneFile, $zoneContent);
+
+		$GLOBALS['pfb'] = [
+			'grep'            => '/usr/bin/grep',
+			'extdns'          => '127.0.0.1', // deterministic: no drill CNAME answers on any machine
+			'unbound_py_data' => $dataFile,
+			'unbound_py_zone' => $zoneFile,
+			'dnsbl_cache'     => "{$tmpDir}/dnsblcache.sqlite",
+			'errlog'          => "{$tmpDir}/error.log",
+			'sqlite_timeout'  => 2000,
+		];
+	}
+
+	/**
+	 * mode='test' -- neither 'alerts' nor 'daemon', so pfb_dnsbl_parse_compute() opens and
+	 * closes a fresh SQLite3 handle per call and returns the assoc-array shape. @ suppresses
+	 * the pre-existing (out-of-scope) "Undefined variable $cname_cnt" notice a total miss
+	 * raises when drill finds no CNAME -- unrelated legacy noise, not the value under test.
+	 */
+	private function parse(string $domain): array
+	{
+		return @pfb_dnsbl_parse_compute('test', $domain, '', '');
+	}
+
+	/**
+	 * Given a data-file line for a domain that itself carries a live BRE metachar ('*').
+	 * When looked up by its own literal value.
+	 * Then it is found -- RED pre-fix (the query's own metachar breaks its own escaped-BRE
+	 * pattern, so it comes back 'Unknown' instead of its real feed/group), GREEN post-fix.
+	 */
+	public function test_metachar_domain_present_in_data_file_is_found(): void
+	{
+		$domain = 'rv837*m1.com';
+		$this->seedSandbox(",{$domain},,A,FeedX,GroupX\n", '');
+
+		$result = $this->parse($domain);
+
+		$this->assertSame(
+			['pfb_mode' => 'DNSBL', 'pfb_group' => 'GroupX', 'pfb_final' => $domain, 'pfb_feed' => 'FeedX'],
+			$result,
+			"expected the metachar domain '{$domain}' to be found by its own literal data-file entry, got " . var_export($result, true)
+		);
+	}
+
+	/**
+	 * Given a data-file line for a DIFFERENT, unrelated literal domain ('b837.com').
+	 * When a domain carrying a live BRE metachar ('a*b837.com', BRE = zero-or-more 'a' then
+	 * 'b837.com') is looked up.
+	 * Then it does NOT match that unrelated entry -- RED pre-fix (the per-row BRE
+	 * false-matches, mis-attributing FeedB/GroupB to a domain that was never listed),
+	 * GREEN post-fix ('-F' treats '*' as a literal character, so no match -> 'Unknown').
+	 */
+	public function test_metachar_domain_cannot_false_match_a_different_literal_domain(): void
+	{
+		$queryDomain = 'a*b837.com';
+		$this->seedSandbox(",b837.com,,A,FeedB,GroupB\n", '');
+
+		$result = $this->parse($queryDomain);
+
+		$this->assertSame(
+			['pfb_mode' => 'Unknown', 'pfb_group' => 'Unknown', 'pfb_final' => 'Unknown', 'pfb_feed' => 'Unknown'],
+			$result,
+			"expected the metachar query '{$queryDomain}' NOT to false-match the unrelated data-file entry for 'b837.com', got " . var_export($result, true)
+		);
+	}
+
+	/**
+	 * Regression pin: an ordinary (metachar-free) domain is found in the data file both
+	 * before and after the fix -- the common path is undisturbed.
+	 */
+	public function test_plain_domain_still_found_in_data_file(): void
+	{
+		$domain = 'plain837.com';
+		$this->seedSandbox(",{$domain},,A,PlainFeed,PlainGroup\n", '');
+
+		$result = $this->parse($domain);
+
+		$this->assertSame(
+			['pfb_mode' => 'DNSBL', 'pfb_group' => 'PlainGroup', 'pfb_final' => $domain, 'pfb_feed' => 'PlainFeed'],
+			$result,
+			"expected the plain domain '{$domain}' to be found in the data file, got " . var_export($result, true)
+		);
+	}
+
+	/**
+	 * Given a zone-file line for a metachar TLD/suffix ('rv837*z1.com') present verbatim.
+	 * When a subdomain of it is looked up via the label-walk.
+	 * Then the label-walk finds the suffix and reports it as the evaluated TLD -- RED
+	 * pre-fix (the zone site has the identical escaped-BRE bug, so its own suffix is never
+	 * found at any label-walk depth), GREEN post-fix. $pfb_final is asserted to equal the
+	 * exact literal suffix, proving the fix's `$pfb_final = $suffix` replacement (no
+	 * escape/unescape round-trip needed once the pattern is a plain literal).
+	 */
+	public function test_metachar_suffix_present_in_zone_file_is_found_as_tld(): void
+	{
+		$suffix = 'rv837*z1.com';
+		$queryDomain = "sub.{$suffix}";
+		$this->seedSandbox('', ",{$suffix},,A,FeedZ,GroupZ\n");
+
+		$result = $this->parse($queryDomain);
+
+		$this->assertSame(
+			['pfb_mode' => 'TLD', 'pfb_group' => 'GroupZ', 'pfb_final' => $suffix, 'pfb_feed' => 'FeedZ'],
+			$result,
+			"expected the metachar suffix '{$suffix}' to be found via the zone label-walk for '{$queryDomain}', got " . var_export($result, true)
+		);
+	}
+
+	/**
+	 * Regression pin: an ordinary (metachar-free) suffix is still found via the zone
+	 * label-walk both before and after the fix.
+	 */
+	public function test_plain_suffix_zone_walk_still_found(): void
+	{
+		$suffix = 'plainzone837.com';
+		$queryDomain = "sub.{$suffix}";
+		$this->seedSandbox('', ",{$suffix},,A,PlainZoneFeed,PlainZoneGroup\n");
+
+		$result = $this->parse($queryDomain);
+
+		$this->assertSame(
+			['pfb_mode' => 'TLD', 'pfb_group' => 'PlainZoneGroup', 'pfb_final' => $suffix, 'pfb_feed' => 'PlainZoneFeed'],
+			$result,
+			"expected the plain suffix '{$suffix}' to be found via the zone label-walk for '{$queryDomain}', got " . var_export($result, true)
+		);
+	}
+}

--- a/tests/php/DnsblPrefetchTest.php
+++ b/tests/php/DnsblPrefetchTest.php
@@ -37,12 +37,13 @@ use PHPUnit\Framework\TestCase;
  *   covered domain must never fall through to a per-row exec, which against a missing
  *   file can only return empty/'Unknown', never the correct non-'Unknown' answer.
  *
- *   B2 (issue #809 review): a domain carrying a live BRE metacharacter (anything besides
- *   '.') is excluded from prefetch coverage entirely -- the per-row site's BRE only ever
- *   escapes '.', so such a domain can false-match a DIFFERENT literal line under the
- *   per-row exec that a batched `-F` fixed-string match never would. Proven by a
- *   differential: the unseeded AND "seeded" (never actually covered) lookups must agree,
- *   both landing on the per-row BRE path.
+ *   B2 (issue #809 review; revised for issue #837): a domain outside PFB_FILTER_DOMAIN's
+ *   charset is excluded from prefetch coverage on validation grounds (an embedded control
+ *   character reaching the pattern file), not to dodge a per-row BRE false-match -- issue
+ *   #837 made the per-row sites `-F` fixed-string too, so batched == per-row by
+ *   construction for every domain. Proven by a differential: the unseeded AND "seeded"
+ *   (never actually covered) lookups must agree, both landing on the per-row fixed-string
+ *   path, on the CORRECT answer.
  *
  *   B3/R1 (issue #809 review): a batched grep pass whose pattern file cannot be created
  *   or fully written returns a NULL sentinel -- distinct from a genuine empty-array
@@ -375,25 +376,25 @@ final class DnsblPrefetchTest extends TestCase
 	}
 
 	/**
-	 * B2 (issue #809 review): a domain outside PFB_FILTER_DOMAIN's charset carries a live
-	 * BRE metacharacter into the per-row site's regex (which escapes ONLY '.'), so it can
-	 * false-match a DIFFERENT literal data-file line under the per-row BRE that a batched
-	 * `-F` fixed-string match never would. Excluding such a domain from prefetch coverage
-	 * entirely means BOTH the unseeded and "seeded" lookups fall through to the identical
-	 * per-row BRE path and therefore agree -- RED before the fix (the seeded consult
-	 * diverged to Unknown while the per-row BRE false-matched RealFeed/RealGroup), GREEN
-	 * after.
+	 * B2 (issue #809 review; revised for issue #837): a domain outside PFB_FILTER_DOMAIN's
+	 * charset is excluded from prefetch coverage on validation grounds alone (an embedded
+	 * control character reaching the pattern file) -- not, any more, to dodge a per-row BRE
+	 * false-match. Since issue #837 made the per-row sites `-F` fixed-string too, the
+	 * unseeded and "seeded" (never actually covered) lookups fall through to the identical
+	 * per-row fixed-string path and agree on the CORRECT answer: no match, despite a
+	 * same-length literal domain ('evil.5.example.com') sitting in the data file. RED
+	 * before #837 (the per-row BRE false-matched RealFeed/RealGroup), GREEN after.
 	 */
 	public function test_a_domain_with_a_live_bre_metacharacter_is_excluded_from_prefetch_coverage(): void
 	{
 		$domain = 'evil.[0-9].example.com';
 
 		$this->assertPrefetchMatchesPerRow($domain, [
-			'pfb_mode'  => 'DNSBL',
-			'pfb_group' => 'RealGroup',
-			'pfb_final' => 'evil.5.example.com',
-			'pfb_feed'  => 'RealFeed',
-		], 'BRE metacharacter domain false-matches a different literal domain via the per-row BRE path');
+			'pfb_mode'  => 'Unknown',
+			'pfb_group' => 'Unknown',
+			'pfb_final' => 'Unknown',
+			'pfb_feed'  => 'Unknown',
+		], 'BRE metacharacter domain no longer false-matches a different literal domain -- both per-row sites are fixed-string (issue #837)');
 	}
 
 	/**

--- a/tests/php/WhitelistTrashIconTest.php
+++ b/tests/php/WhitelistTrashIconTest.php
@@ -23,22 +23,10 @@ final class WhitelistTrashIconTest extends TestCase
 {
 	public static function setUpBeforeClass(): void
 	{
-		if (function_exists('pfb_whitelist_trash_icon')) {
-			return;
-		}
-		$src = file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
-		);
-		if ($src === false) {
-			throw new RuntimeException('failed to read pfblockerng_alerts.php');
-		}
-		$src = preg_replace('/^\s*require_once\(.*\);\s*$/m', '', $src);
-		$start = strpos($src, "\nfunction ");
-		$end   = strpos($src, "\n\$pgtitle = ");
-		if ($start === false || $end === false || $end <= $start) {
-			throw new RuntimeException('could not locate the function block in pfblockerng_alerts.php');
-		}
-		eval("\n" . substr($src, $start + 1, $end - $start - 1));
+		// See AlertsPageLoader.php for the off-appliance load mechanics (shared with
+		// AlertsRowOutputEncodingTest / AlertsIpConvertPrefetchParityTest).
+		require_once __DIR__ . '/AlertsPageLoader.php';
+		pfb_test_load_alerts_page_functions();
 	}
 
 	/**

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -453,16 +453,16 @@ def _tail(path: Path, lines: int = 40) -> str:
     return "\n".join(text.splitlines()[-lines:])
 
 
-# Diagnostics for a wedged boot are written here, RELATIVE to the workspace cwd
-# (where pytest runs). The smoke workflow's "Upload diagnostics" step globs
-# ``smoke-diag/**`` + ``**/screen-*.png`` — so anything dropped here is uploaded.
-# This is the ONLY window into a setup-time boot failure: the session VM fixture
-# errors before any test runs, so the on-failure ``_dump_vm_on_failure`` hook
-# (which needs SSH) never fires, and the boot log otherwise lives under pytest's
-# tmp dir (outside the artifact globs).
-# ponytail: `or "smoke-diag"` guards an exported-empty PFB_DIAG_DIR (Path("") == cwd,
-# which escapes the CI upload globs); the `or` treats both None and "" as absent.
-DIAG_DIR = Path(os.environ.get("PFB_DIAG_DIR") or "smoke-diag")
+# Diagnostics for a wedged boot are written under helpers.DIAG_DIR, RELATIVE to
+# the workspace cwd (where pytest runs). The smoke workflow's "Upload
+# diagnostics" step globs ``smoke-diag/**`` + ``**/screen-*.png`` — so anything
+# dropped there is uploaded. This is the ONLY window into a setup-time boot
+# failure: the session VM fixture errors before any test runs, so the
+# on-failure ``_dump_vm_on_failure`` hook (which needs SSH) never fires, and
+# the boot log otherwise lives under pytest's tmp dir (outside the artifact
+# globs). DIAG_DIR itself lives in helpers.py (shared with the render-diff UI
+# harness); ``_capture_boot_failure`` below local-imports ``helpers`` for it
+# (the usual conftest<->helpers cycle guard).
 
 
 def _qmp_sock_path(tag: str) -> str:
@@ -490,14 +490,16 @@ def _capture_boot_failure(tag: str, qmp_sock: str | None, log_path: Path, proces
 
     MUST run BEFORE the qemu process is killed — QMP needs the process alive.
     """
+    from . import helpers  # local import: helpers imports from conftest (avoid cycle)
+
     with contextlib.suppress(Exception):
-        DIAG_DIR.mkdir(parents=True, exist_ok=True)
+        helpers.DIAG_DIR.mkdir(parents=True, exist_ok=True)
     with contextlib.suppress(Exception):
-        shutil.copyfile(log_path, DIAG_DIR / f"boot-{tag}.log")
+        shutil.copyfile(log_path, helpers.DIAG_DIR / f"boot-{tag}.log")
     if qmp_sock and process.poll() is None and Path(qmp_sock).exists():
         with contextlib.suppress(Exception):
             subprocess.run(
-                ["python3", str(SMOKE_DIR / "screendump.py"), qmp_sock, str(DIAG_DIR / f"screen-{tag}.png")],
+                ["python3", str(SMOKE_DIR / "screendump.py"), qmp_sock, str(helpers.DIAG_DIR / f"screen-{tag}.png")],
                 capture_output=True,
                 text=True,
                 timeout=60,

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -69,6 +69,13 @@ from .conftest import (
 # Paths / constants
 # --------------------------------------------------------------------------- #
 
+# Diagnostics dir, RELATIVE to the workspace cwd (where pytest runs) unless
+# PFB_DIAG_DIR is absolute. The smoke workflow's "Upload diagnostics" step globs
+# ``smoke-diag/**`` -- so anything dropped here is uploaded.
+# ponytail: `or "smoke-diag"` guards an exported-empty PFB_DIAG_DIR (Path("") == cwd,
+# which escapes the CI upload globs); the `or` treats both None and "" as absent.
+DIAG_DIR = Path(os.environ.get("PFB_DIAG_DIR") or "smoke-diag")
+
 INSTALL_PKG_SH = SMOKE_DIR.parent.parent / "scripts" / "install-pkg.sh"
 PHP_BIN = "/usr/local/bin/php"
 # pfSense developer shell — runs PHP in the fully-bootstrapped env (config

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -37,7 +37,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from .. import helpers
-from .webui import extract_csrf_token, looks_like_login_page
+from .webui import extract_csrf_token, looks_like_login_page, row_containing
 
 if TYPE_CHECKING:
     import requests
@@ -1295,24 +1295,6 @@ def test_alerts_rows_render_whitelist_icons_oracle(
 # --------------------------------------------------------------------------- #
 
 
-def _row_containing(html_body: str, needle: str) -> str:
-    """Return the single ``<tr ...>...</tr>`` block containing ``needle``.
-
-    ``convert_dnsbl_log()`` prints one ``<tr>`` per event row (alerts.php:2571 /
-    2593) with the domain, group, and icons all inside it. A fixed byte-distance
-    window around a match can straddle the PREVIOUS or NEXT table row when rows
-    are dense, false-matching (or false-missing) a marker that belongs to a
-    neighbour -- row-isolating avoids that entirely.
-    """
-    idx = html_body.find(needle)
-    assert idx != -1, f"{needle!r} not found in rendered HTML"
-    tr_start = html_body.rfind("<tr", 0, idx)
-    assert tr_start != -1, f"no opening <tr found before {needle!r}"
-    tr_end = html_body.find("</tr>", idx)
-    assert tr_end != -1, f"no closing </tr> found after {needle!r}"
-    return html_body[tr_start : tr_end + len("</tr>")]
-
-
 def test_upstream_block_renders_cloud_icon_and_correct_group(
     webui: "WebUI",
     smoke_vm: helpers.SmokeVM,
@@ -1402,7 +1384,7 @@ def test_upstream_block_renders_cloud_icon_and_correct_group(
 
         # Row-isolate: the domain's OWN <tr>, not a byte-distance window that can
         # straddle a neighbouring row.
-        row = _row_containing(html_body, domain)
+        row = row_containing(html_body, domain)
 
         # THEN (a): the cloud icon class is present in the domain's OWN row (Edit D step 9).
         assert "fa-cloud" in row, (

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -533,24 +533,76 @@ def _seed_feed_files(vm: helpers.SmokeVM) -> None:
         assert result.returncode == 0, f"failed to write {path!r}: rc={result.returncode} stderr={result.stderr!r}"
 
 
+def _sqlite_open_guarded() -> str:
+    """PHP prologue: open the dnsblcache DB via the package's own opener, loudly.
+
+    Uses ``pfb_open_sqlite(4, ...)`` — the exact opener the Alerts page itself runs —
+    NOT a raw ``new SQLite3``: the package opener carries the ADR-03 WAL pragma, the
+    integrity-check + corrupt-DB self-heal, and the unbound chown, all of which a
+    home-rolled open skips. That skip bit runs 28721363021/28721822624: the first
+    sessions running this module AFTER test_alerts.py found the cache DB in a state
+    where every raw statement returned ``disk I/O error``, and the bare ``bindValue()
+    on false`` fatal carried zero diagnostic value. The opener alone is not enough
+    either (run 28722003668): in PHP's SQLite3 warnings mode its internal recovery
+    fails silently and it returns a handle whose writes still all fail — so the
+    handle is probed with ``BEGIN IMMEDIATE`` before use. An unusable handle triggers
+    a WAL-family quarantine (db + -wal + -shm — it is a query CACHE; the package
+    rebuilds it, and production's own recovery similarly recreates a corrupt DB) and
+    one retry; still failing → echo every attempt's lastErrorMsg() plus df/ls/fstat
+    context (CLAUDE.md "print expected vs actual") and exit non-zero.
+    """
+    db = helpers._php_str(DNSBL_CACHE_DB)
+    return (
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+        "pfb_global();\n"
+        "global $pfb_smoke_err;\n"
+        "$pfb_smoke_err = [];\n"
+        # PHP's SQLite3 runs in warnings (not exceptions) mode here, so pfb_open_sqlite's
+        # internal integrity/recovery failures return FALSE silently and it can hand back
+        # a handle whose every WRITE still fails (run 28722003668). BEGIN IMMEDIATE is the
+        # usability probe: it must acquire the write lock and touch the WAL, so a broken
+        # handle fails HERE, not at the caller's first real statement.
+        "function pfb_smoke_cache_open($tag) {\n"
+        "\tglobal $pfb_smoke_err;\n"
+        "\t$db = pfb_open_sqlite(4, 'smoke render-verify ' . $tag);\n"
+        "\tif (empty($db)) { $pfb_smoke_err[] = $tag . ': open returned NULL'; return NULL; }\n"
+        "\tif ($db->exec('BEGIN IMMEDIATE;') === FALSE) {\n"
+        "\t\t$pfb_smoke_err[] = $tag . ': ' . $db->lastErrorMsg();\n"
+        "\t\t@$db->exec('ROLLBACK;');\n"
+        "\t\t$db->close();\n"
+        "\t\treturn NULL;\n"
+        "\t}\n"
+        "\t$db->exec('COMMIT;');\n"
+        "\treturn $db;\n"
+        "}\n"
+        "$db = pfb_smoke_cache_open('first');\n"
+        "if (empty($db)) {\n"
+        f"\tforeach ([{db}, {db} . '-wal', {db} . '-shm'] as $f) {{ @unlink($f); }}\n"
+        "\t$db = pfb_smoke_cache_open('after-reset');\n"
+        "}\n"
+        "if (empty($db)) {\n"
+        "\techo 'ERR open: ' . implode(' | ', $pfb_smoke_err) . ' || '\n"
+        f"\t\t. shell_exec('df -k /var/unbound; ls -l ' . {db} . '* 2>&1; fstat ' . {db} . ' 2>&1');\n"
+        "\texit(1);\n"
+        "}\n"
+    )
+
+
 def _seed_dnsbl_cache(vm: helpers.SmokeVM) -> None:
     """D1 cache-hit: pre-populate ``dnsblcache`` with a group/feed DIFFERENT from
     the logged line, so the render deterministically drifts (strikes the logged
     values, shows the cached ones)."""
     snippet = (
-        f"$db = new SQLite3({helpers._php_str(DNSBL_CACHE_DB)});\n"
-        "$db->busyTimeout(5000);\n"
-        '$db->exec("CREATE TABLE IF NOT EXISTS dnsblcache '
-        '( type TEXT, domain TEXT, groupname TEXT, final TEXT, feed TEXT );");\n'
-        "$stmt = $db->prepare("
+        _sqlite_open_guarded() + "$stmt = $db->prepare("
         "'INSERT INTO dnsblcache (type, domain, groupname, final, feed) "
         "VALUES (:type, :domain, :groupname, :final, :feed)');\n"
+        "if ($stmt === FALSE) { echo 'ERR prepare: ' . $db->lastErrorMsg(); exit(1); }\n"
         f"$stmt->bindValue(':type', {helpers._php_str('DNSBL')}, SQLITE3_TEXT);\n"
         f"$stmt->bindValue(':domain', {helpers._php_str(D1_DOMAIN)}, SQLITE3_TEXT);\n"
         f"$stmt->bindValue(':groupname', {helpers._php_str(D1_CACHE_GROUP)}, SQLITE3_TEXT);\n"
         f"$stmt->bindValue(':final', {helpers._php_str(D1_DOMAIN)}, SQLITE3_TEXT);\n"
         f"$stmt->bindValue(':feed', {helpers._php_str(D1_CACHE_FEED)}, SQLITE3_TEXT);\n"
-        "$stmt->execute();\n"
+        "if ($stmt->execute() === FALSE) { echo 'ERR execute: ' . $db->lastErrorMsg(); exit(1); }\n"
         "echo 'OK';"
     )
     result = helpers.php_eval(vm, snippet)
@@ -560,14 +612,17 @@ def _seed_dnsbl_cache(vm: helpers.SmokeVM) -> None:
 
 
 def _clear_dnsbl_cache(vm: helpers.SmokeVM) -> None:
+    # pfb_open_sqlite() guarantees the table exists (its db_create runs on open), so
+    # the DELETE can no longer silently no-op on a fresh VM the way the old raw
+    # new-SQLite3 + bare-DELETE snippet did.
     snippet = (
-        f"$db = new SQLite3({helpers._php_str(DNSBL_CACHE_DB)});\n"
-        "$db->exec(\"DELETE FROM dnsblcache WHERE domain LIKE 'rv809%'\");\n"
+        _sqlite_open_guarded() + "$del = $db->exec(\"DELETE FROM dnsblcache WHERE domain LIKE 'rv809%'\");\n"
+        "if ($del === FALSE) { echo 'ERR delete: ' . $db->lastErrorMsg(); exit(1); }\n"
         "echo 'OK';"
     )
     result = helpers.php_eval(vm, snippet)
     assert result.returncode == 0 and "OK" in result.stdout, (
-        f"FAILED to clear dnsblcache during teardown: rc={result.returncode} "
+        f"FAILED to clear dnsblcache: rc={result.returncode} "
         f"stdout={result.stdout!r} stderr={result.stderr!r} -- dnsblcache may be left polluted for sibling tests"
     )
 

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -51,13 +51,11 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import re
 import subprocess
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
@@ -65,7 +63,7 @@ import pytest
 
 from .. import helpers
 from .render_oracle import evaluate_render
-from .webui import looks_like_login_page
+from .webui import looks_like_login_page, row_containing
 
 if TYPE_CHECKING:
     from .webui import WebUI
@@ -169,7 +167,7 @@ M1_ALIAS, M2_ALIAS = "RVAliasM1", "RVAliasM2"
 FEED_PERMIT_NAME = "RVPermitFeed"
 FEED_MATCH_NAME = "RVMatchFeed"
 
-# --- dnsbl.log / unified.log scenarios (D1-D7) ---
+# --- dnsbl.log / unified.log scenarios (D1-D8) ---
 D1_DOMAIN = "rv809-c1.com"
 D2_DOMAIN = "rv809-d1.com"
 D3_DOMAIN = "sub.rv809-z1.com"
@@ -181,7 +179,12 @@ D5_DOMAIN = "rv809-up1.com"
 # pfb_dnsbl_parse_compute()'s per-row fallback instead of the batched grep. NB the
 # brief's own suggestion of an underscore does NOT trigger this: PFB_FILTER_DOMAIN's
 # charset explicitly includes '_', so an underscore domain WOULD be covered/batched.
+# D7 is nowhere on disk (total miss -> Unknown); D8 below is its positive counterpart
+# (present verbatim in pfb_py_data.txt -- proves issue #837's per-row fixed-string
+# fallback actually FINDS a covered metachar domain, not just that an uncovered one
+# renders the same 'Unknown' shape as a covered total miss).
 D7_DOMAIN = "rv809*m1.com"
+D8_DOMAIN = "rv809*p1.com"
 
 D1_CACHE_GROUP, D1_CACHE_FEED = "RVCacheGroup", "RVCacheFeed"
 D1_LOGGED_GROUP, D1_LOGGED_FEED = "RVLoggedGroup1", "RVLoggedFeed1"
@@ -190,6 +193,8 @@ D2_LOGGED_GROUP, D2_LOGGED_FEED = "RVLoggedGroupD2", "RVLoggedFeedD2"
 D3_GROUP, D3_FEED = "RVGroupZ3", "RVFeedZ3"  # SAME logged + zone value -- isolates mode+domain drift
 D4_LOGGED_GROUP, D4_LOGGED_FEED = "RVLoggedGroupD4", "RVLoggedFeedD4"
 D7_LOGGED_GROUP, D7_LOGGED_FEED = "RVLoggedGroupD7", "RVLoggedFeedD7"
+D8_DATA_GROUP, D8_DATA_FEED = "RVGroupMeta", "RVFeedMeta"
+D8_LOGGED_GROUP, D8_LOGGED_FEED = "RVLoggedGroupMeta", "RVLoggedFeedMeta"
 FILLER_DNSBL_GROUP, FILLER_DNSBL_FEED = "RVFillerGroup", "RVFillerFeed"
 
 FILLER_DNSBL_DOMAINS = [f"rv809-f{i}.com" for i in range(30)]
@@ -341,7 +346,7 @@ def _match_lines() -> list[str]:
 
 
 def _dnsbl_scenarios() -> list[str]:
-    """D1-D7 (+ D6, the dup marker for D1) -- see the module docstring's scenario table."""
+    """D1-D8 (+ D6, the dup marker for D1) -- see the module docstring's scenario table."""
     return [
         _dnsbl_line(domain=D1_DOMAIN, group=D1_LOGGED_GROUP, feed=D1_LOGGED_FEED),
         # D6: dup of D1, appended immediately after (same reverse-read reasoning as S7).
@@ -351,6 +356,7 @@ def _dnsbl_scenarios() -> list[str]:
         _dnsbl_line(domain=D4_DOMAIN, group=D4_LOGGED_GROUP, feed=D4_LOGGED_FEED),
         f"DNSBL-python,{FIXED_TS},{D5_DOMAIN},127.0.0.1,Python,Upstream_Block,Upstream,NXRA,Quad9,+,A\n",
         _dnsbl_line(domain=D7_DOMAIN, group=D7_LOGGED_GROUP, feed=D7_LOGGED_FEED),
+        _dnsbl_line(domain=D8_DOMAIN, group=D8_LOGGED_GROUP, feed=D8_LOGGED_FEED),
     ]
 
 
@@ -388,7 +394,7 @@ def _unified_lines() -> list[str]:
 
 
 def _py_data_appendix() -> str:
-    lines = [f"x,{D2_DOMAIN},,A,{D2_DATA_FEED},{D2_DATA_GROUP}"]
+    lines = [f"x,{D2_DOMAIN},,A,{D2_DATA_FEED},{D2_DATA_GROUP}", f"x,{D8_DOMAIN},,A,{D8_DATA_FEED},{D8_DATA_GROUP}"]
     lines += [f"x,{d},,A,{FILLER_DNSBL_FEED},{FILLER_DNSBL_GROUP}" for d in FILLER_DNSBL_DOMAINS]
     return "\n".join(lines) + "\n"
 
@@ -406,7 +412,6 @@ def _py_zone_appendix() -> str:
 class Capture:
     """One GET's captured response + wall-clock timing."""
 
-    key: str
     status: int
     body: str
     elapsed: float
@@ -440,28 +445,6 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _row_containing(body: str, needle: str) -> str:
-    """Return the single ``<tr ...>...</tr>`` block containing ``needle`` (row-isolated).
-
-    Mirrors ``test_alerts.py``'s ``_row_containing``: a byte-distance window can
-    straddle a neighbouring row when rows are dense; isolating by the enclosing
-    ``<tr>`` avoids false-matching (or false-missing) a marker that belongs to a
-    sibling row.
-    """
-    idx = body.find(needle)
-    assert idx != -1, f"{needle!r} not found anywhere in the rendered body"
-    tr_start = body.rfind("<tr", 0, idx)
-    assert tr_start != -1, f"no opening <tr found before {needle!r}"
-    tr_end = body.find("</tr>", idx)
-    assert tr_end != -1, f"no closing </tr> found after {needle!r}"
-    return body[tr_start : tr_end + len("</tr>")]
-
-
-def _diag_dir() -> Path:
-    """Mirrors tests/smoke/conftest.py's DIAG_DIR resolution exactly (PFB_DIAG_DIR, default 'smoke-diag')."""
-    return Path(os.environ.get("PFB_DIAG_DIR") or "smoke-diag") / "renderdiff"
-
-
 def _write_diagnostics(baseline: dict[str, Capture], captures: dict[str, Capture]) -> None:
     """Persist every capture's full body, its ``<tbody>`` regions (+ SHA-256), and per-GET timings.
 
@@ -472,7 +455,7 @@ def _write_diagnostics(baseline: dict[str, Capture], captures: dict[str, Capture
         manifest.json                              -- [{get_key, region_index, sha256, byte_len}, ...]
         timings.json                                -- {"<baseline|main>_<key>": seconds, ...}
     """
-    diag_dir = _diag_dir()
+    diag_dir = helpers.DIAG_DIR / "renderdiff"
     bodies_dir = diag_dir / "bodies"
     regions_dir = diag_dir / "regions"
     bodies_dir.mkdir(parents=True, exist_ok=True)
@@ -645,7 +628,7 @@ def render_diff_state(smoke_vm: helpers.SmokeVM, webui: WebUI) -> Iterator[dict[
             resp = webui.get(path)
             elapsed = time.perf_counter() - t0
             assert not looks_like_login_page(resp.text), f"baseline GET {path!r} returned the login form"
-            baseline[key] = Capture(key=key, status=resp.status_code, body=resp.text, elapsed=elapsed)
+            baseline[key] = Capture(status=resp.status_code, body=resp.text, elapsed=elapsed)
 
         # (2) SEED every log/file/cache row this module's scenarios need.
         _seed_feed_files(vm)
@@ -667,7 +650,7 @@ def render_diff_state(smoke_vm: helpers.SmokeVM, webui: WebUI) -> Iterator[dict[
             resp = webui.get(path)
             elapsed = time.perf_counter() - t0
             assert not looks_like_login_page(resp.text), f"GET {path!r} returned the login form"
-            captures[key] = Capture(key=key, status=resp.status_code, body=resp.text, elapsed=elapsed)
+            captures[key] = Capture(status=resp.status_code, body=resp.text, elapsed=elapsed)
 
         _write_diagnostics(baseline, captures)
 
@@ -753,7 +736,7 @@ def test_s1_still_listed_renders_without_strike(render_diff_state: dict[str, dic
     the row shows its logged feed/eval verbatim, with no <s> strike anywhere.
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, f"host={S1_IP}")
+    row = row_containing(body, f"host={S1_IP}")
     assert "<s>" not in row, f"S1 ({S1_IP}) row unexpectedly struck (still-listed row should render clean): {row!r}"
     assert "Not listed!" not in row, f"S1 ({S1_IP}) row wrongly rendered 'Not listed!': {row!r}"
 
@@ -766,7 +749,7 @@ def test_s2_delisted_renders_not_listed(render_diff_state: dict[str, dict[str, C
     and evaluated-IP cells substitute 'Not listed!' (struck old value first).
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, f"host={S2_IP}")
+    row = row_containing(body, f"host={S2_IP}")
     assert "Not listed!" in row, f"S2 ({S2_IP}) expected 'Not listed!' -- row: {row!r}"
     assert "<s>" in row, f"S2 ({S2_IP}) expected a struck old feed/IP -- row: {row!r}"
 
@@ -779,7 +762,7 @@ def test_s3_moved_feed_renders_strike(render_diff_state: dict[str, dict[str, Cap
     the old feed name and displays the new one.
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, f"host={S3_IP}")
+    row = row_containing(body, f"host={S3_IP}")
     assert f"<s>{FEED_A_NAME}</s>" in row, f"S3 ({S3_IP}) expected the old feed {FEED_A_NAME!r} struck: {row!r}"
     assert FEED_B_NAME in row, f"S3 ({S3_IP}) expected the new feed {FEED_B_NAME!r} present: {row!r}"
 
@@ -793,7 +776,7 @@ def test_s4_cidr_renders_evaluated_cell(render_diff_state: dict[str, dict[str, C
     appears as the row's (re-)evaluated match.
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, f"host={S4_IP}")
+    row = row_containing(body, f"host={S4_IP}")
     assert "203.0.113.0/24" in row, f"S4 ({S4_IP}) expected the covering CIDR 203.0.113.0/24 in its cell: {row!r}"
 
 
@@ -805,7 +788,7 @@ def test_s5_geoip_row_renders(render_diff_state: dict[str, dict[str, Capture]]) 
     Then: the row renders with no strike/miss (the GeoIP folder validate succeeds).
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, f"host={S5_IP}")
+    row = row_containing(body, f"host={S5_IP}")
     assert "Not listed!" not in row, f"S5 ({S5_IP}) GeoIP row wrongly rendered 'Not listed!': {row!r}"
 
 
@@ -817,7 +800,7 @@ def test_s6_ipv6_row_renders(render_diff_state: dict[str, dict[str, Capture]]) -
     unlike the SRC/DST table cells which wrap it in [...] with zero-width spaces).
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, f"host={S6_IP}")
+    row = row_containing(body, f"host={S6_IP}")
     assert "<s>" not in row, f"S6 ({S6_IP}) IPv6 row unexpectedly struck: {row!r}"
 
 
@@ -830,7 +813,7 @@ def test_s7_dup_badge_renders_on_s1_row(render_diff_state: dict[str, dict[str, C
     Then: S1's row carries the ' [1]' duplicate-count badge.
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, f"host={S1_IP}")
+    row = row_containing(body, f"host={S1_IP}")
     assert "[1]" in row, f"S1 row missing the dup-count badge '[1]' expected from S7's dup marker: {row!r}"
 
 
@@ -844,7 +827,7 @@ def test_s8_alias_changed_cell_renders(render_diff_state: dict[str, dict[str, Ca
     Rule column struck-shows the old alias name, then the new one.
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, f"host={S8_IP}")
+    row = row_containing(body, f"host={S8_IP}")
     assert f"<s>{S8_ALIAS_LOGGED}</s>" in row, f"S8 ({S8_IP}) expected the stale alias struck: {row!r}"
     assert "pfB_RVOther_v4" in row, f"S8 ({S8_IP}) expected the new alias table name pfB_RVOther_v4: {row!r}"
 
@@ -858,7 +841,7 @@ def test_s9_outbound_direction_still_listed(render_diff_state: dict[str, dict[st
     branch is exercised (S1 already covers the inbound branch).
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, f"host={S9_IP}")
+    row = row_containing(body, f"host={S9_IP}")
     assert "Not listed!" not in row, f"S9 ({S9_IP}) outbound row wrongly rendered 'Not listed!': {row!r}"
     assert "<s>" not in row, f"S9 ({S9_IP}) outbound row unexpectedly struck: {row!r}"
 
@@ -872,7 +855,7 @@ def test_s10_et_feed_row_renders(render_diff_state: dict[str, dict[str, Capture]
     folder-selection branch.
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, f"host={S10_IP}")
+    row = row_containing(body, f"host={S10_IP}")
     assert "Not listed!" not in row, f"S10 ({S10_IP}) ET-feed row wrongly rendered 'Not listed!': {row!r}"
 
 
@@ -884,9 +867,9 @@ def test_permit_still_listed_and_delisted(render_diff_state: dict[str, dict[str,
     unique to its own log).
     """
     body = render_diff_state["captures"]["alert"].body
-    listed = _row_containing(body, P1_IP)
+    listed = row_containing(body, P1_IP)
     assert "Not listed!" not in listed, f"Permit {P1_IP} (still-listed) wrongly rendered 'Not listed!': {listed!r}"
-    delisted = _row_containing(body, P2_IP)
+    delisted = row_containing(body, P2_IP)
     assert "Not listed!" in delisted, f"Permit {P2_IP} (de-listed) expected 'Not listed!': {delisted!r}"
 
 
@@ -896,9 +879,9 @@ def test_match_still_listed_and_delisted(render_diff_state: dict[str, dict[str, 
     Same bare-IP row location as the permit test (no ``host=`` marker on Match rows).
     """
     body = render_diff_state["captures"]["alert"].body
-    listed = _row_containing(body, M1_IP)
+    listed = row_containing(body, M1_IP)
     assert "Not listed!" not in listed, f"Match {M1_IP} (still-listed) wrongly rendered 'Not listed!': {listed!r}"
-    delisted = _row_containing(body, M2_IP)
+    delisted = row_containing(body, M2_IP)
     assert "Not listed!" in delisted, f"Match {M2_IP} (de-listed) expected 'Not listed!': {delisted!r}"
 
 
@@ -912,7 +895,7 @@ def test_d1_cache_hit_drift_renders_cache_groupname(render_diff_state: dict[str,
     the logged group/feed and displays the cached ones.
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, D1_DOMAIN)
+    row = row_containing(body, D1_DOMAIN)
     assert f"<s>{D1_LOGGED_GROUP}</s>" in row, f"D1 expected the logged group struck: {row!r}"
     assert D1_CACHE_GROUP in row, f"D1 expected the cached group {D1_CACHE_GROUP!r} present: {row!r}"
     assert f"<s>{D1_LOGGED_FEED}</s>" in row, f"D1 expected the logged feed struck: {row!r}"
@@ -928,7 +911,7 @@ def test_d2_data_hit_drift_renders_data_feed(render_diff_state: dict[str, dict[s
     struck-shows the logged values, displaying the data-file ones.
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, D2_DOMAIN)
+    row = row_containing(body, D2_DOMAIN)
     assert f"<s>{D2_LOGGED_GROUP}</s>" in row, f"D2 expected the logged group struck: {row!r}"
     assert D2_DATA_GROUP in row, f"D2 expected the data-file group {D2_DATA_GROUP!r} present: {row!r}"
     assert f"<s>{D2_LOGGED_FEED}</s>" in row, f"D2 expected the logged feed struck: {row!r}"
@@ -945,7 +928,7 @@ def test_d3_zone_hit_renders_tld_mode(render_diff_state: dict[str, dict[str, Cap
     stripped parent -- both struck against the originally-logged values.
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, D3_DOMAIN)
+    row = row_containing(body, D3_DOMAIN)
     assert '<s title="Previous Blocking Mode">DNSBL</s>' in row, f"D3 expected the logged mode struck: {row!r}"
     assert "TLD" in row, f"D3 expected the corrected mode 'TLD' present: {row!r}"
     # NB: D3_PARENT ("rv809-z1.com") is a trailing substring of D3_DOMAIN
@@ -973,7 +956,7 @@ def test_d4_delisted_renders_unknown(render_diff_state: dict[str, dict[str, Capt
     struck against the logged (fabricated) values.
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, D4_DOMAIN)
+    row = row_containing(body, D4_DOMAIN)
     assert f"<s>{D4_LOGGED_GROUP}</s>" in row, f"D4 expected the logged group struck: {row!r}"
     assert "Unknown" in row, f"D4 expected 'Unknown' (total miss) present: {row!r}"
 
@@ -985,7 +968,7 @@ def test_d5_upstream_renders_cloud_icon_and_group(render_diff_state: dict[str, d
     test_upstream_block_renders_cloud_icon_and_correct_group precedent.
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, D5_DOMAIN)
+    row = row_containing(body, D5_DOMAIN)
     assert "fa-cloud" in row, f"D5 upstream row missing the cloud-icon override: {row!r}"
     assert "Upstream" in row, f"D5 upstream row missing the preserved 'Upstream' group: {row!r}"
     assert "Unknown" not in row, f"D5 upstream row wrongly ran the stale-entry correction ('Unknown' present): {row!r}"
@@ -999,13 +982,42 @@ def test_d7_uncovered_metachar_domain_renders_unknown(render_diff_state: dict[st
     its 'covered' set, so pfb_dnsbl_parse_compute() takes its UNBATCHED per-row
     exec fallback for every consult site (identical to how #825's predecessor
     behaved for every domain).
-    Then: it renders 'Unknown' (nowhere found) exactly like D4 -- proving the
-    uncovered/fallback path produces the SAME output as the covered/batched one.
+    Then: it renders 'Unknown' (nowhere found) exactly like D4 -- SAME shape as
+    the covered/batched total-miss path. This is a NEGATIVE-only proof (a
+    domain absent everywhere renders 'Unknown' whether or not the per-row
+    fallback works at all); D8 below is the positive counterpart that actually
+    discriminates a working per-row fallback from a broken one (issue #837).
     """
     body = render_diff_state["captures"]["alert"].body
-    row = _row_containing(body, D7_DOMAIN)
+    row = row_containing(body, D7_DOMAIN)
     assert f"<s>{D7_LOGGED_GROUP}</s>" in row, f"D7 expected the logged group struck: {row!r}"
     assert "Unknown" in row, f"D7 expected 'Unknown' (uncovered total miss) present: {row!r}"
+
+
+def test_d8_covered_metachar_domain_found_via_per_row_fallback(
+    render_diff_state: dict[str, dict[str, Capture]],
+) -> None:
+    """D8: a metachar domain the per-row fallback CAN find, unlike D7's total miss.
+
+    Given: 'rv809*p1.com' contains '*' so it also fails PFB_FILTER_DOMAIN and is
+    excluded from the batched prefetch, exactly like D7 -- but unlike D7 it IS
+    present verbatim in pfb_py_data.txt.
+    When: the alert view renders.
+    Then: pfb_dnsbl_parse_compute()'s per-row fixed-string fallback (issue #837:
+    `grep -F` on the raw domain, not a hand-escaped BRE) actually FINDS its own
+    entry -- the row struck-shows the logged group/feed and displays the
+    data-file ones, never 'Unknown'. Red on a pre-#837 package (the per-row BRE
+    mis-escapes the '*' and misses the domain's own data-file line -> Unknown),
+    green post-fix; the offline red->green proof is
+    tests/php/DnsblParseComputeMetacharTest.php.
+    """
+    body = render_diff_state["captures"]["alert"].body
+    row = row_containing(body, D8_DOMAIN)
+    assert f"<s>{D8_LOGGED_GROUP}</s>" in row, f"D8 expected the logged group struck: {row!r}"
+    assert D8_DATA_GROUP in row, f"D8 expected the data-file group {D8_DATA_GROUP!r} present: {row!r}"
+    assert f"<s>{D8_LOGGED_FEED}</s>" in row, f"D8 expected the logged feed struck: {row!r}"
+    assert D8_DATA_FEED in row, f"D8 expected the data-file feed {D8_DATA_FEED!r} present: {row!r}"
+    assert "Unknown" not in row, f"D8 covered metachar domain wrongly rendered 'Unknown': {row!r}"
 
 
 def test_ip_block_nonfilter_cap_enforced(render_diff_state: dict[str, dict[str, Capture]]) -> None:
@@ -1040,7 +1052,7 @@ def test_ip_block_nonfilter_cap_enforced(render_diff_state: dict[str, dict[str, 
 def test_dnsbl_nonfilter_cap_enforced(render_diff_state: dict[str, dict[str, Capture]]) -> None:
     """The default alert view never renders more than pfbdnscnt=25 DNSBL Python rows.
 
-    Given: 36 non-dup DNSBL rows were fed (30 filler + 6 scenarios -- D6 is a
+    Given: 37 non-dup DNSBL rows were fed (30 filler + 7 scenarios -- D6 is a
     dup marker, not its own row).
     Then: the DNSBL Python panel's <tbody> (region 1, see the ordering note on
     the Block-cap test above) renders AT MOST 25 rows.
@@ -1057,7 +1069,7 @@ def test_dnsbl_nonfilter_cap_enforced(render_diff_state: dict[str, dict[str, Cap
     dnsbl_rows = len(_TR_RE.findall(regions[1]))
     assert dnsbl_rows <= 25, (
         f"DNSBL Python panel rendered {dnsbl_rows} rows -- expected <= 25 (pfbdnscnt default); "
-        f"36 non-dup rows were fed, so the cap must have truncated"
+        f"37 non-dup rows were fed, so the cap must have truncated"
     )
 
 
@@ -1151,7 +1163,7 @@ def test_alert_view_stable_across_cache_populate_rerender(render_diff_state: dic
     """GET #12 (post-cache-populate re-render) reproduces GET #1's tbody hashes byte-for-byte.
 
     Scenario: dnsblcache round-trip stability.
-    Given: GET #1 (alert view) computed D1-D7's DNSBL attribution fresh (a
+    Given: GET #1 (alert view) computed D1-D8's DNSBL attribution fresh (a
         cache hit for D1, data/zone/drill fallbacks for the rest) and INSERTed
         each newly-computed result into dnsblcache.
     When: the SAME view is GET-ted again (GET #12) with no log/file mutation in

--- a/tests/smoke/ui/webui.py
+++ b/tests/smoke/ui/webui.py
@@ -233,6 +233,29 @@ def scrape_form_fields(page_html: str) -> dict[str, str]:
     return fields
 
 
+# --------------------------------------------------------------------------- #
+# Row isolation -- locate the single <tr>...</tr> block around a marker
+# --------------------------------------------------------------------------- #
+
+
+def row_containing(html_body: str, needle: str) -> str:
+    """Return the single ``<tr ...>...</tr>`` block containing ``needle`` (row-isolated).
+
+    Alert-page renderers (e.g. ``convert_dnsbl_log()``, alerts.php:2571/2593) print one
+    ``<tr>`` per event row with every cell/icon inside it. A fixed byte-distance window
+    around a match can straddle a neighbouring row when rows are dense, false-matching
+    (or false-missing) a marker that belongs to a different row -- isolating by the
+    enclosing ``<tr>`` avoids that entirely.
+    """
+    idx = html_body.find(needle)
+    assert idx != -1, f"{needle!r} not found in rendered HTML"
+    tr_start = html_body.rfind("<tr", 0, idx)
+    assert tr_start != -1, f"no opening <tr found before {needle!r}"
+    tr_end = html_body.find("</tr>", idx)
+    assert tr_end != -1, f"no closing </tr> found after {needle!r}"
+    return html_body[tr_start : tr_end + len("</tr>")]
+
+
 class WebUI:
     """An authenticated webConfigurator HTTP session for the smoke VM.
 

--- a/tests/test_adr47_conftest_lane.py
+++ b/tests/test_adr47_conftest_lane.py
@@ -3,7 +3,8 @@
 Pins the TOCTOU-fix changes made to tests/smoke/conftest.py:
   1. _validate_lane ceiling: 12340 (LAN socket, new highest base) → max lane 5319.
   2. DEFAULT_LAN_SOCKET_PORT: deterministic, lane-strided from 12340.
-  3. DIAG_DIR: empty PFB_DIAG_DIR falls back to "smoke-diag" (not Path("")).
+  3. DIAG_DIR (tests.smoke.helpers -- PR #835 review moved it off conftest, issue #837):
+     empty PFB_DIAG_DIR falls back to "smoke-diag" (not Path("")).
   4. _validate_lane reads SMOKE_LAN_SOCKET_PORT: ceiling shifts with the base.
   5. Cross-port disjointness: the five port series share no host port across 33 lanes.
 
@@ -32,8 +33,9 @@ import types
 import pytest
 
 # ---------------------------------------------------------------------------
-# Helpers — load conftest in an isolated environment with a controlled SMOKE_LANE
-# and PFB_DIAG_DIR so we can vary them per test without cross-contamination.
+# Helpers — load conftest (or helpers) in an isolated environment with a
+# controlled SMOKE_LANE / PFB_DIAG_DIR so we can vary them per test without
+# cross-contamination.
 # ---------------------------------------------------------------------------
 
 # All env vars that conftest reads or writes at import time.
@@ -44,16 +46,15 @@ _CONFTEST_ENV_KEYS: tuple[str, ...] = (
     "SMOKE_WEB_HOSTPORT",
     "SMOKE_CLIENT_SSH_HOSTPORT",
     "SMOKE_LAN_SOCKET_PORT",
-    "PFB_DIAG_DIR",
 )
 
 
-def _load_conftest(lane: int = 0, diag_dir: str | None = None) -> types.ModuleType:
+def _load_conftest(lane: int = 0) -> types.ModuleType:
     """Import tests.smoke.conftest with SMOKE_LANE=lane.
 
     Uses importlib.import_module after patching os.environ so the module's
-    top-level assignments (DEFAULT_* ports, DIAG_DIR) pick up the right values.
-    The module is freshly loaded each call via sys.modules manipulation.
+    top-level assignments (DEFAULT_* ports) pick up the right values. The
+    module is freshly loaded each call via sys.modules manipulation.
 
     Saves and restores all conftest-side-effected env vars (_CONFTEST_ENV_KEYS) in
     the finally block so tests are isolated from one another.  The env state written
@@ -63,10 +64,6 @@ def _load_conftest(lane: int = 0, diag_dir: str | None = None) -> types.ModuleTy
     saved = {k: os.environ.get(k) for k in _CONFTEST_ENV_KEYS}
 
     os.environ["SMOKE_LANE"] = str(lane)
-    if diag_dir is None:
-        os.environ.pop("PFB_DIAG_DIR", None)
-    else:
-        os.environ["PFB_DIAG_DIR"] = diag_dir
 
     # Force a fresh import by removing any cached module and all conftest deps that
     # cache the lane at import time.
@@ -87,6 +84,33 @@ def _load_conftest(lane: int = 0, diag_dir: str | None = None) -> types.ModuleTy
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = v
+
+
+def _load_helpers(diag_dir: str | None = None) -> types.ModuleType:
+    """Import tests.smoke.helpers with PFB_DIAG_DIR set, forcing a fresh DIAG_DIR read.
+
+    DIAG_DIR moved off tests.smoke.conftest onto tests.smoke.helpers (PR #835
+    review, issue #837) -- shared with the render-diff UI harness
+    (test_alerts_render_verify.py). Mirrors _load_conftest's env-patch-then-
+    reimport shape for that one name.
+    """
+    saved = os.environ.get("PFB_DIAG_DIR")
+    if diag_dir is None:
+        os.environ.pop("PFB_DIAG_DIR", None)
+    else:
+        os.environ["PFB_DIAG_DIR"] = diag_dir
+
+    for key in list(sys.modules):
+        if "smoke.helpers" in key or key == "tests.smoke.helpers":
+            del sys.modules[key]
+
+    try:
+        return importlib.import_module("tests.smoke.helpers")
+    finally:
+        if saved is None:
+            os.environ.pop("PFB_DIAG_DIR", None)
+        else:
+            os.environ["PFB_DIAG_DIR"] = saved
 
 
 # ---------------------------------------------------------------------------
@@ -217,11 +241,11 @@ class TestDefaultLanSocketPort:
 
 
 class TestDiagDir:
-    """DIAG_DIR falls back to 'smoke-diag' when PFB_DIAG_DIR is absent or empty."""
+    """helpers.DIAG_DIR falls back to 'smoke-diag' when PFB_DIAG_DIR is absent or empty."""
 
     def test_absent_env_uses_default(self) -> None:
         """PFB_DIAG_DIR not set → Path('smoke-diag')."""
-        mod = _load_conftest(diag_dir=None)
+        mod = _load_helpers(diag_dir=None)
         assert mod.DIAG_DIR.name == "smoke-diag", f"expected 'smoke-diag'; got {mod.DIAG_DIR}"
 
     def test_empty_env_uses_default(self) -> None:
@@ -233,7 +257,7 @@ class TestDiagDir:
           Path('smoke-diag') — correct relative path.
         This is the red→green assertion: old code → Path('') → assertion FAILS.
         """
-        mod = _load_conftest(diag_dir="")
+        mod = _load_helpers(diag_dir="")
         assert mod.DIAG_DIR.name == "smoke-diag", (
             f"PFB_DIAG_DIR='' must fall back to 'smoke-diag'; got {mod.DIAG_DIR!r}"
         )
@@ -241,7 +265,7 @@ class TestDiagDir:
 
     def test_explicit_env_is_honoured(self) -> None:
         """PFB_DIAG_DIR=/some/path → Path('/some/path')."""
-        mod = _load_conftest(diag_dir="/some/diags")
+        mod = _load_helpers(diag_dir="/some/diags")
         assert str(mod.DIAG_DIR) == "/some/diags", f"expected '/some/diags'; got {mod.DIAG_DIR!r}"
 
 


### PR DESCRIPTION
# Summary

Fixes #837 and lands the remaining follow-ups from the PR #835 post-merge adversarial review (the CIDR-round finding went to #833 as a scope-broadening comment instead — it belongs to that issue's shared fix).

## The #837 fix

`pfb_dnsbl_parse_compute()`'s per-row data/zone grep sites built a BRE escaping only dots, so any other metacharacter in a logged domain rode into the pattern live — a hostile/garbage DNS query name could mis-attribute a different literal domain's feed/group on the Alerts page (`a*b.com` false-matches `b.com`), or fail to find its own verbatim entry. Both sites now `grep -F` the raw literal — the same shape the batched prefetch pass (PR #825) already uses — and the evaluated TLD derives from the raw suffix. The prefetch header + B2 design comments are updated, and `DnsblPrefetchTest`'s B2 oracle is re-pinned (it had pinned the old false-match as expected behaviour).

**Red→green:** `DnsblParseComputeMetacharTest` (new, 5 cases) fails all three metachar directions pre-fix — own-entry false-miss (data), cross-domain false-match (data), own-suffix false-miss (zone/TLD) — and passes post-fix; the two plain-domain pins are green on both sides. Live counterpart: the render harness gains **D8**, a metachar domain present verbatim in `pfb_py_data.txt`, asserting the per-row fallback renders its data-file group/feed (D7 stays as the negative/uncovered case; its docstring now points at D8 as the discriminating positive).

## Review follow-ups (#835)

- **tests/php:** the alerts-page eval-extraction block was triple-copied across `WhitelistTrashIconTest` / `AlertsRowOutputEncodingTest` / `AlertsIpConvertPrefetchParityTest` — extracted to a shared `AlertsPageLoader.php`; the parity test's private `rrmdir()` now calls the bootstrap-loaded `rmdir_recursive()` double. Behaviour-preserving; suite is the oracle.
- **tests/smoke:** `_row_containing` (byte-identical in `test_alerts.py` and the render harness) is now shared `webui.row_containing()`; `DIAG_DIR` resolution moved to `helpers.py` so the harness and conftest share one derivation; dropped the never-read `Capture.key` field; `test_adr47_conftest_lane.py` repointed at the moved constant.
- **ci:** three `ui-tests.yml` comments still described the nightly as Tier-B-only after #835 added the render tier to `DEFAULT_SCHEDULE_TIERS` — synced.
- **docs:** `CLAUDE.md` gains the byte-identity carve-out for the `unique_domain()` rule (the render harness's documented deviation; RFC 6761/HSTS prohibitions unchanged).

## Gates

- PHPUnit full suite green (the only failures are the three pre-existing macOS-local `tempnam`/`open_basedir` sandbox quirks, proven pre-existing by a stash/re-run of pristine code; CI Linux unaffected).
- PHPStan `[OK]`, PHPCS clean, `php -l` clean.
- `ruff check` + `ruff format --check` clean, `mypy tests/` clean, offline pytest 2127 passed.
- Live validation: selective `ui-tests.yml` dispatch on this branch (functional tier, impacted modules) — link in comments once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ooLjvBBm6oznTBUg9mxVF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared helpers for smoke and PHP tests to load alert-page logic consistently.
  * Added broader smoke/UI coverage for DNSBL render behavior, including a new positive metacharacter case.

* **Bug Fixes**
  * Fixed DNSBL matching to treat lookup patterns as literal strings, improving behavior for domains and suffixes with special characters.
  * Updated diagnostics handling so boot-failure logs and screenshots are stored in a consistent location.

* **Tests**
  * Added and updated regression tests for DNSBL prefetch, parsing, and alert rendering.

* **Documentation**
  * Clarified CI workflow comments and smoke-test guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->