### PR TITLE
pfblockerng: fix ET/Proofpoint rows breaking the alerts IP validate find (#832)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8609,9 +8609,10 @@ function pfb_ip_render_query(array $fields): array {
 
 		// issue #832: the ET/Proofpoint branch above blanks $query/$query_host/
 		// $query_prefix (no filename filter -- every file under etdir is a
-		// candidate), so only append the filter tail when there IS one -- three
-		// escaped empty-string operands made `find` error out ("unknown primary or
-		// operator"), which silently killed the validate round for every ET row.
+		// candidate), so only append the filter tail when there IS one -- two
+		// escaped empty-string operands (plus the blank, contentless $query_prefix)
+		// made `find` error out ("unknown primary or operator"), which silently
+		// killed the validate round for every ET row.
 		$filter = '';
 		if ($query !== '') {
 			$query_esc	= escapeshellarg($query);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8605,11 +8605,21 @@ function pfb_ip_render_query(array $fields): array {
 	if ($fields[14] != 'Unknown' && $fields[15] != 'Unknown') {
 		$q_ip = str_replace('.', '\.', $fields[14]);
 
-		$query_esc	= escapeshellarg($query);
-		$query_host_esc	= escapeshellarg($query_host);
-		$q_ip_esc	= escapeshellarg("^{$q_ip}");
+		$q_ip_esc = escapeshellarg("^{$q_ip}");
 
-		$validate_file_cmd = "/usr/bin/find {$folder} -type f {$query_prefix} {$query_esc} {$query_host_esc}";
+		// issue #832: the ET/Proofpoint branch above blanks $query/$query_host/
+		// $query_prefix (no filename filter -- every file under etdir is a
+		// candidate), so only append the filter tail when there IS one -- three
+		// escaped empty-string operands made `find` error out ("unknown primary or
+		// operator"), which silently killed the validate round for every ET row.
+		$filter = '';
+		if ($query !== '') {
+			$query_esc	= escapeshellarg($query);
+			$query_host_esc	= escapeshellarg($query_host);
+			$filter = " {$query_prefix} {$query_esc} {$query_host_esc}";
+		}
+
+		$validate_file_cmd = "/usr/bin/find {$folder} -type f{$filter}";
 		$validate_cmd	   = "{$validate_file_cmd} | xargs {$pfb['grep']} {$q_ip_esc} 2>&1";
 	}
 

--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -800,4 +800,107 @@ final class IpPrefetchTest extends TestCase
 			}
 		}
 	}
+
+	// ------------------------------------------------------------------------------
+	// issue #832: an ET/Proofpoint row's validate command must not break `find`
+	// with escaped-empty operands
+	// ------------------------------------------------------------------------------
+
+	/**
+	 * Scenario: an ET/Proofpoint-style row (':' in the logged Feed Name) blanks
+	 * $query/$query_host/$query_prefix in pfb_ip_render_query() -- there is no
+	 * per-feed filename filter, every file under etdir is a candidate.
+	 *
+	 * Given: such a row.
+	 * When: pfb_ip_render_query() builds its validate_file_cmd.
+	 * Then: the command is a plain `find <etdir>/*.txt -type f` with NO escaped
+	 * empty-string operands -- pre-fix it appended `{$query_prefix} '' ''`
+	 * (all three blanked), which made `find` itself error out ("unknown primary
+	 * or operator") and silently emit nothing, so the validate round always
+	 * missed for every ET row.
+	 */
+	public function test_et_header_validate_file_cmd_has_no_empty_find_operands(): void
+	{
+		$fields     = $this->buildBlockFields('192.0.2.201');
+		$fields[15] = 'IQRisk:Category1';	// ':' in the Feed Name -- the ET/Proofpoint branch
+
+		$rq = pfb_ip_render_query($fields);
+
+		$expected = "/usr/bin/find {$GLOBALS['pfb']['etdir']}/*.txt -type f";
+		$this->assertSame(
+			$expected,
+			$rq['validate_file_cmd'],
+			"expected an ET row's validate_file_cmd to carry no filename filter, got "
+				. var_export($rq['validate_file_cmd'], true)
+		);
+	}
+
+	/**
+	 * Scenario: an ET row whose reported IP is STILL present, verbatim, in its ET
+	 * feed file -- the exact real-world case issue #832 reports as broken.
+	 *
+	 * Given: a real etdir fixture file containing the reported IP.
+	 * When: the row's validate_cmd (built by pfb_ip_render_query()) is actually
+	 * exec()'d, exactly as convert_ip_log() does.
+	 * Then: the still-listed line comes back. Pre-fix, `find`'s primary-operator
+	 * error left the pipe with nothing for `xargs grep` to search, so this always
+	 * came back empty (a false "no longer listed") regardless of the real feed
+	 * state.
+	 */
+	public function test_et_header_still_listed_ip_is_found_by_the_real_validate_exec(): void
+	{
+		$tmp = sys_get_temp_dir() . '/pfb_832_et_' . getmypid();
+		mkdir($tmp, 0777, true);
+		file_put_contents("{$tmp}/IQRiskFeed.txt", "192.0.2.201\n");
+		$savedEtdir = $GLOBALS['pfb']['etdir'];
+		$GLOBALS['pfb']['etdir'] = $tmp;
+
+		try {
+			$fields     = $this->buildBlockFields('192.0.2.201');
+			$fields[15] = 'IQRisk:Category1';
+
+			$rq = pfb_ip_render_query($fields);
+			$this->assertNotNull($rq['validate_cmd'], 'expected a validate command to be built for a known IP/feed');
+
+			exec($rq['validate_cmd'], $output, $exitCode);
+
+			$this->assertNotEmpty(
+				$output,
+				"expected the real validate exec to find the still-listed IP via '{$rq['validate_cmd']}', "
+					. 'got empty output (exit ' . $exitCode . ') -- this is the issue #832 symptom: '
+					. "find errors out on the escaped-empty operands and the row silently reads as delisted"
+			);
+			$this->assertStringContainsString(
+				'192.0.2.201',
+				implode("\n", $output),
+				'expected the matched line to contain the reported IP, got ' . var_export($output, true)
+			);
+		} finally {
+			$GLOBALS['pfb']['etdir'] = $savedEtdir;
+			unlink("{$tmp}/IQRiskFeed.txt");
+			rmdir($tmp);
+		}
+	}
+
+	/**
+	 * Regression guard: the issue #832 fix only special-cases the ET branch's
+	 * blanked $query/$query_host/$query_prefix -- a normal (non-ET) Block row's
+	 * validate_file_cmd must stay byte-for-byte the command it was before.
+	 */
+	public function test_non_et_validate_file_cmd_shape_is_unchanged(): void
+	{
+		$fields = $this->buildBlockFields('192.0.2.77');
+		$rq     = pfb_ip_render_query($fields);
+
+		$queryEsc     = escapeshellarg($GLOBALS['pfb']['grep']);
+		$queryHostEsc = escapeshellarg('OldFeed.txt');	// buildBlockFields()'s fields[15]
+		$expected     = "/usr/bin/find {$rq['folder']} -type f | {$queryEsc} {$queryHostEsc}";
+
+		$this->assertSame(
+			$expected,
+			$rq['validate_file_cmd'],
+			"expected a non-ET row's validate_file_cmd shape to stay unchanged, got "
+				. var_export($rq['validate_file_cmd'], true)
+		);
+	}
 }


### PR DESCRIPTION
Fixes #832.

## What

`pfb_ip_render_query()` blanks `$query`/`$query_host`/`$query_prefix` for an ET/Proofpoint row (`:` in the feed name), then unconditionally `escapeshellarg()`'d and interpolated all three into the validate `find` command, rendering `/usr/bin/find <etdir>/*.txt -type f  '' ''`. `find` treats the two empty-string operands as unknown primaries and errors out, so the validate exec always returned empty and every ET row fell into the expensive miss path (`find_reported_header()` + the aliastables sweep) even when the IP was still listed in its ET feed file.

The fix appends the find/grep filter tail only when `$query` is non-empty. The non-ET command shape is byte-for-byte unchanged (pinned by a new shape-parity test). Both `convert_ip_log()` (per-row) and `pfb_ip_prefetch()` (batched) share this one builder, so one fix covers both paths.

## Tests (red → green on the pre-fix code)

- `test_et_header_validate_file_cmd_has_no_empty_find_operands` — exact command-string assertion (red pre-fix: the `'' ''` operands present).
- `test_et_header_still_listed_ip_is_found_by_the_real_validate_exec` — the issue's required functional proof: a real temp `etdir` fixture + `exec()` of the actual `validate_cmd` finds the still-listed IP (red pre-fix: find errors → empty output).
- `test_non_et_validate_file_cmd_shape_is_unchanged` — regression pin for the non-ET shape (green on both sides by design).

Full suite: 2257 tests green except the 3 pre-existing macOS `open_basedir`/`tempnam()` environment failures (identical on `devel`); PHPStan/PHPCS/php -l clean.

Note for the queued #833 fix: it touches the same builder (`/dev/null` in the xargs-grep stage) and will be rebased on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation for certain threat-feed entries so empty query values no longer produce invalid file-search expressions.
  * Improved handling of matching rules in ET/Proofpoint-related checks, preventing validation failures while preserving expected results.

* **Tests**
  * Added regression coverage for the ET/Proofpoint validation flow.
  * Verified that existing behavior remains unchanged for non-ET entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->