### PR TITLE
pfblockerng: init $cname_cnt before the total-miss drill path (#834)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -13177,6 +13177,9 @@ function pfb_dnsbl_parse_compute($mode, $domain, $src_ip, $req_agent) {
 	// If domain is not in DNSBL cache, query for blocked domain details
 	if (!$dnsbl_cache) {
 		$o_domain = $domain; // Store original domain for CNAME query
+		$cname_cnt = 0; // issue #834: only ever set inside the CNAME-found branch below,
+		// but read unconditionally at "if ($cname_cnt == 0)" -- init so a total miss (no
+		// data/zone/CNAME match) doesn't read an undefined variable there.
 
 		// issue #809 Phase 3a: NULL unless the Alerts page's DNSBL table render pass
 		// seeded it via pfb_dnsbl_prefetch() -- read once here and reused at both grep

--- a/tests/php/DnsblParseComputeMetacharTest.php
+++ b/tests/php/DnsblParseComputeMetacharTest.php
@@ -85,13 +85,11 @@ final class DnsblParseComputeMetacharTest extends TestCase
 
 	/**
 	 * mode='test' -- neither 'alerts' nor 'daemon', so pfb_dnsbl_parse_compute() opens and
-	 * closes a fresh SQLite3 handle per call and returns the assoc-array shape. @ suppresses
-	 * the pre-existing (out-of-scope) "Undefined variable $cname_cnt" notice a total miss
-	 * raises when drill finds no CNAME -- unrelated legacy noise, not the value under test.
+	 * closes a fresh SQLite3 handle per call and returns the assoc-array shape.
 	 */
 	private function parse(string $domain): array
 	{
-		return @pfb_dnsbl_parse_compute('test', $domain, '', '');
+		return pfb_dnsbl_parse_compute('test', $domain, '', '');
 	}
 
 	/**
@@ -194,6 +192,51 @@ final class DnsblParseComputeMetacharTest extends TestCase
 			['pfb_mode' => 'TLD', 'pfb_group' => 'PlainZoneGroup', 'pfb_final' => $suffix, 'pfb_feed' => 'PlainZoneFeed'],
 			$result,
 			"expected the plain suffix '{$suffix}' to be found via the zone label-walk for '{$queryDomain}', got " . var_export($result, true)
+		);
+	}
+
+	/**
+	 * Given a domain that misses the data file, misses the zone label-walk, AND drill
+	 * returns no CNAME records -- a "total miss" (issue #834: $cname_cnt is assigned ONLY
+	 * inside the CNAME-found branch, so this path reads "if ($cname_cnt == 0)" before any
+	 * assignment ever ran).
+	 * When the total-miss compute runs, with every raised PHP error captured explicitly.
+	 * Then it raises NO PHP warning -- RED pre-fix ("Undefined variable $cname_cnt"), GREEN
+	 * post-fix ($cname_cnt initialised to 0 alongside $o_domain, same 0 == 0 outcome).
+	 */
+	public function test_total_miss_raises_no_undefined_cname_cnt_warning(): void
+	{
+		$domain = 'totalmiss834.com';
+		$this->seedSandbox('', ''); // empty data + zone files: guaranteed miss at both grep sites
+
+		$caught = [];
+		set_error_handler(function (int $errno, string $errstr) use (&$caught): bool {
+			$caught[] = $errstr;
+			return true; // swallow -- assert on the captured list below, not PHP's own output
+		});
+
+		try {
+			$result = pfb_dnsbl_parse_compute('test', $domain, '', '');
+		} finally {
+			restore_error_handler();
+		}
+
+		// pfb_open_sqlite()'s @chown/@chgrp to the 'unbound' user (absent on a dev box) is
+		// unrelated dev-box harness noise -- filter it out so this test targets only the bug.
+		$unexpected = array_values(array_filter($caught, static function (string $msg): bool {
+			return !str_contains($msg, 'Unable to find uid for unbound')
+				&& !str_contains($msg, 'Unable to find gid for unbound');
+		}));
+
+		$this->assertSame(
+			[],
+			$unexpected,
+			'expected no PHP warning/notice on the total-miss compute path, got: ' . var_export($unexpected, true)
+		);
+		$this->assertSame(
+			['pfb_mode' => 'Unknown', 'pfb_group' => 'Unknown', 'pfb_final' => 'Unknown', 'pfb_feed' => 'Unknown'],
+			$result,
+			'expected the total-miss domain to resolve to Unknown, got ' . var_export($result, true)
 		);
 	}
 }

--- a/tests/php/DnsblPrefetchTest.php
+++ b/tests/php/DnsblPrefetchTest.php
@@ -139,16 +139,13 @@ final class DnsblPrefetchTest extends TestCase
 	}
 
 	/**
-	 * Call pfb_dnsbl_parse_compute('alerts', ...) for $domain. A genuine total-miss
-	 * domain falls through to the CNAME/drill chase, which has a pre-existing (Phase
-	 * 3a out-of-scope) "Undefined variable $cname_cnt" notice when drill is absent
-	 * (true of this environment) and no CNAME is found -- @ keeps that unrelated
-	 * legacy noise out of this phase's test output without masking the return value
-	 * under test.
+	 * Call pfb_dnsbl_parse_compute('alerts', ...) for $domain. No error suppression:
+	 * the total-miss "Undefined variable $cname_cnt" notice this used to @-silence
+	 * is fixed (issue #834), so a regression now fails loudly here too.
 	 */
 	private function parse(string $domain): array
 	{
-		return @pfb_dnsbl_parse_compute('alerts', $domain, '', '');
+		return pfb_dnsbl_parse_compute('alerts', $domain, '', '');
 	}
 
 	/**


### PR DESCRIPTION
Fixes #834.

## What

`pfb_dnsbl_parse_compute()` assigns `$cname_cnt` only inside the CNAME-found branch after the `drill` exec, but reads it unconditionally at `if ($cname_cnt == 0)`. When a domain misses the data file, the zone walk, AND `drill` returns no (valid) CNAME records — the total-miss path, one warning per de-listed domain per render — PHP 8 emits `Undefined variable $cname_cnt`. Behaviour was already correct (`NULL == 0` is TRUE), so this is a warning-pollution fix: the noise grows `php_error.log`, which the Tier A render gate watches.

Fix: initialise `$cname_cnt = 0;` alongside `$o_domain` before the `while (TRUE)` loop — behaviour-identical.

## Tests (red → green on the pre-fix code)

- `test_total_miss_raises_no_undefined_cname_cnt_warning` (DnsblParseComputeMetacharTest): replays the total-miss compute path off-appliance (empty data+zone files, unreachable extdns → no CNAMEs) with a capturing error handler; red pre-fix: `Undefined variable $cname_cnt` captured; green post-fix.
- The now-dead `@` suppression in the test harness's shared `parse()` helper (which had been silencing exactly this warning for the file's other tests) is removed, so a regression fails loudly suite-wide.

Full suite: 2255 tests green except the 3 pre-existing macOS `open_basedir`/`tempnam()` environment failures (identical on `devel`); PHPStan/PHPCS/php -l clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG