### PR TITLE
pfblockerng: force grep filename prefixes at every pfb_parse_query() site (#833)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8431,7 +8431,12 @@ function find_reported_header($ip, $pfbfolder, $geoip=FALSE) {
 
 	// Find exact IP match
 	$q_ip	= escapeshellarg(str_replace('.', '\.', "^{$ip}"));
-	$query	= exec("{$pfb['grep']} -s {$q_ip} {$pfbfolder} 2>&1");
+	// issue #833: /dev/null forces grep to always be given >=2 files, so it
+	// always emits the "path:" prefix -- even when $pfbfolder's glob resolves to
+	// exactly ONE .txt file. Without it, pfb_parse_query() gets an unprefixed
+	// line and returns a 1-element array (no [1]), corrupting every downstream
+	// consumer that reads it.
+	$query	= exec("{$pfb['grep']} -s {$q_ip} {$pfbfolder} /dev/null 2>&1");
 	if (!empty($query)) {
 		$rx = pfb_parse_query($query);
 		return $rx;
@@ -8449,10 +8454,12 @@ function find_reported_header($ip, $pfbfolder, $geoip=FALSE) {
 
 		$result = array();
 		if (!$geoip) {
-			exec("{$pfb['grep']} -s {$query_esc} {$pfbfolder} 2>&1", $result);
+			// issue #833: same /dev/null forced-prefix fix as the exact-match exec
+			// above.
+			exec("{$pfb['grep']} -s {$query_esc} {$pfbfolder} /dev/null 2>&1", $result);
 		} else {
 			$geoip_list = "Africa\|Antarctica\|Asia\|Europe\|North_America\|South_America\|Oceania\|Proxy_and_Satellite\|Top_Spammers";
-			exec("{$pfb['grep']} -s {$query_esc} {$pfb['ccdir']}/*.txt | {$pfb['grep']} -v '{$geoip_list}' 2>&1", $result);
+			exec("{$pfb['grep']} -s {$query_esc} {$pfb['ccdir']}/*.txt /dev/null | {$pfb['grep']} -v '{$geoip_list}' 2>&1", $result);
 		}
 
 		// issue #809 Phase 3b: the CIDR-selection loop (collect CIDR-shaped candidates
@@ -8801,7 +8808,9 @@ function pfb_find_reported_headers(array $hosts, $pfbfolder, $geoip = FALSE, ?ar
 	foreach ($hosts as $host) {
 		$patterns[] = '^' . str_replace('.', '\.', $host);
 	}
-	$lines = pfb_ip_prefetch_grep_lines("{$pfb['grep']} -s -f", "{$pfbfolder} 2>&1", $patterns);
+	// issue #833: /dev/null forces the same file-prefix output as find_reported_
+	// header()'s own exact-match exec, even for a single-file $pfbfolder glob.
+	$lines = pfb_ip_prefetch_grep_lines("{$pfb['grep']} -s -f", "{$pfbfolder} /dev/null 2>&1", $patterns);
 
 	if ($lines === NULL) {
 		$grep_failed = array_fill_keys($hosts, TRUE);
@@ -8860,10 +8869,11 @@ function pfb_find_reported_headers(array $hosts, $pfbfolder, $geoip = FALSE, ?ar
 
 		$result = array();
 		if (!$geoip) {
-			exec("{$pfb['grep']} -s {$query_esc} {$pfbfolder} 2>&1", $result);
+			// issue #833: same /dev/null forced-prefix fix as Round A above.
+			exec("{$pfb['grep']} -s {$query_esc} {$pfbfolder} /dev/null 2>&1", $result);
 		} else {
 			$geoip_list = "Africa\|Antarctica\|Asia\|Europe\|North_America\|South_America\|Oceania\|Proxy_and_Satellite\|Top_Spammers";
-			exec("{$pfb['grep']} -s {$query_esc} {$pfb['ccdir']}/*.txt | {$pfb['grep']} -v '{$geoip_list}' 2>&1", $result);
+			exec("{$pfb['grep']} -s {$query_esc} {$pfb['ccdir']}/*.txt /dev/null | {$pfb['grep']} -v '{$geoip_list}' 2>&1", $result);
 		}
 
 		foreach ($group['hosts'] as $host) {
@@ -8991,26 +9001,25 @@ function pfb_ip_prefetch(array $rows): void {
 		if (!array_key_exists($miss_key, $headers_by_host_folder)) {
 			continue;
 		}
+		// issue #833: find_reported_header()/pfb_find_reported_headers() now force
+		// grep's file-prefix output at every exec() site (a trailing /dev/null), so
+		// pfb_parse_query() always returns the 2-element [feed, value] shape -- the
+		// issue #831 1-element skip-seed guard that used to live here is dead code,
+		// removed.
 		$pfb_query = $headers_by_host_folder[$miss_key];
-		if (!array_key_exists(1, $pfb_query)) {
-			// issue #831: a folder glob matching exactly ONE .txt file makes grep emit
-			// its match UNPREFIXED (no "path:" part), so pfb_parse_query() returns a
-			// one-element array. Seeding from it would hand a NULL to the strict-typed
-			// pfb_ip_prefetch_last_match() below and fatal the whole page render. Leave
-			// the row unseeded instead -- convert_ip_log()'s per-row fallback then
-			// reproduces the legacy (pre-batching) rendering for it byte-for-byte,
-			// including the pre-existing single-file quirk tracked in issue #833.
-			continue;
-		}
 		$eval_new = ($pfb_query[1] == 'Unknown') ? 'Not listed!' : $pfb_query[1];
 		$eval_new_by_key[$miss_key] = $eval_new;
 		$alias_patterns[] = '^' . str_replace('.', '\.', $eval_new);
 	}
 	$alias_patterns = array_values(array_unique($alias_patterns));
 
+	// issue #833: '/dev/null' rides ahead of xargs's own appended file list, so
+	// grep always has >=2 files and always emits the "path:" prefix, matching
+	// convert_ip_log()'s own per-row aliastables exec (pfblockerng_alerts.php)
+	// which needs that same forced-prefix fix for its downstream alias-name parse.
 	$alias_lines = pfb_ip_prefetch_grep_lines(
 		"/usr/bin/find {$pfb['aliasdir']}/*.txt -type f | xargs {$pfb['grep']} -f",
-		'2>&1',
+		'/dev/null 2>&1',
 		$alias_patterns
 	);
 	if ($alias_lines === NULL) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -3092,7 +3092,11 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 			// Determine if IP is in a new Aliastable
 			$q_ip = str_replace('.', '\.', $eval_new);
 			$q_ip_esc = escapeshellarg("^{$q_ip}");
-			$raw_validate = exec("/usr/bin/find {$pfb['aliasdir']}/*.txt -type f | xargs {$pfb['grep']} {$q_ip_esc} 2>&1");
+			// issue #833: '/dev/null' gives xargs a permanent extra file arg, so
+			// grep always emits a "path:" prefix even when aliasdir holds exactly
+			// one .txt file -- the ltrim(strrchr(strstr(strstr(...)))) alias-name
+			// parse below requires that shape.
+			$raw_validate = exec("/usr/bin/find {$pfb['aliasdir']}/*.txt -type f | xargs {$pfb['grep']} {$q_ip_esc} /dev/null 2>&1");
 
 			return array($pfb_query, $raw_validate);
 		});

--- a/tests/php/AlertsIpConvertPrefetchParityTest.php
+++ b/tests/php/AlertsIpConvertPrefetchParityTest.php
@@ -220,8 +220,12 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 	/**
 	 * Given/When/Then core shared by every scenario below: prefetch-seed then render,
 	 * reset-then-render cold, and assert the two renders are byte-identical.
+	 *
+	 * @return string the (identical) rendered HTML -- callers needing to assert its
+	 *                 CONTENT (not just that both renders agree) reuse this instead of
+	 *                 re-driving convert_ip_log() themselves.
 	 */
-	private function assertParity(array $fields, string $rtype, string $scenario): void
+	private function assertParity(array $fields, string $rtype, string $scenario): string
 	{
 		// Given: the batched prefetch pass seeds pfb_ip_render_memos() from the SAME
 		// row-derivation the page's Pass 1.5 uses.
@@ -274,6 +278,8 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 				. "and cold render.\n--- cold (expected) ---\n{$htmlCold}\n"
 				. "--- prefetch-seeded (actual) ---\n{$htmlSeeded}"
 		);
+
+		return $htmlCold;
 	}
 
 	/**
@@ -410,5 +416,47 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 		]);
 
 		$this->assertParity($fields, 'Block', 'ET-header feed');
+	}
+
+	/**
+	 * Case 9 -- aliastable-changed, TRULY single-file aliasdir (issue #833).
+	 *
+	 * Case 7 above keeps aliasdir's setUp()-provided placeholder file precisely so
+	 * grep already has >1 file and emits a "path:" prefix (see the class-level
+	 * comment at setUp() explaining why that placeholder exists at all). This case
+	 * removes it -- aliasdir holds ONLY the new alias's file, the exact shape issue
+	 * #833 reports as broken.
+	 *
+	 * Given: pre-fix, `find aliasdir/*.txt | xargs grep` hands grep a single file,
+	 * so its match comes back UNPREFIXED; convert_ip_log()'s alias-name parse chain
+	 * (pfblockerng_alerts.php ltrim(strrchr(strstr(strstr(...))))) requires the
+	 * "path:content" shape and silently collapses to '' without it -- the rendered
+	 * row would show NO "moved to a new alias" cell at all, even though the IP
+	 * genuinely moved.
+	 * When: convert_ip_log() renders, both prefetch-seeded and cold.
+	 * Then: parity holds (both paths went through the SAME now-fixed grep shape),
+	 * AND the rendered HTML shows the REAL new alias name -- not a blank cell.
+	 */
+	public function test_aliastable_changed_single_file_aliasdir_renders_the_real_alias_name(): void
+	{
+		unlink("{$this->aliasdir}/AliasPlaceholder.txt");	// truly single-file aliasdir
+
+		file_put_contents("{$this->denydir}/DenyFeedNewH.txt", "192.0.2.88\n");
+		file_put_contents("{$this->aliasdir}/pfB_LoneNewAlias_v4.txt", "192.0.2.88\n");
+
+		$fields = $this->rawFields([
+			8 => '192.0.2.88', 15 => '192.0.2.88',
+			14 => 'pfB_OldAlias_v4', 16 => 'DenyFeedOldH',
+		]);
+
+		$html = $this->assertParity($fields, 'Block', 'aliastable-changed, single-file aliasdir');
+
+		// And: the rendered HTML shows the REAL new alias name, not a blank cell --
+		// the actual issue #833 symptom this case targets.
+		$this->assertStringContainsString(
+			'pfB_LoneNewAlias_v4',
+			$html,
+			"expected the rendered row to show the real new alias name 'pfB_LoneNewAlias_v4', got:\n{$html}"
+		);
 	}
 }

--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -72,6 +72,21 @@ use PHPUnit\Framework\TestCase;
  *
  *   R4: after a prefetch pass, no pfb_ip_prefetch_* pattern-file temp file remains --
  *   guards the try/finally cleanup against a future regression.
+ *
+ *   Scenario: issue #833 -- a single-.txt-file folder must resolve EXACT and CIDR
+ *             matches correctly, and the aliastables round must force the same
+ *             file-prefix output
+ *     Pre-fix, grep given exactly one file emits its match UNPREFIXED, so
+ *     pfb_parse_query() returns a 1-element array with no [1] -- every consumer
+ *     reading result[1] (find_reported_header()'s own return, pfb_match_reported_
+ *     cidr()'s CIDR-shape check) silently mishandles it, up to a genuinely
+ *     covering CIDR being dropped to Unknown/Unknown. Every find_reported_
+ *     header()/pfb_find_reported_headers() exec() (and the aliastables find|xargs
+ *     grep pipeline) now appends a trailing /dev/null, forcing grep to always be
+ *     given >=2 files -- it always emits the "path:" prefix. The issue #831
+ *     skip-seed guard (a defensive no-fatal patch, not a real fix) is now dead
+ *     code and removed; its regression test is updated to pin the row being
+ *     correctly SEEDED instead of merely left alone.
  */
 #[CoversFunction('pfb_match_reported_cidr')]
 #[CoversFunction('pfb_ip_render_query')]
@@ -411,6 +426,100 @@ final class IpPrefetchTest extends TestCase
 	}
 
 	// ------------------------------------------------------------------------------
+	// issue #833: a folder glob resolving to exactly ONE .txt file must resolve
+	// EXACT and CIDR matches correctly, not silently drop them
+	// ------------------------------------------------------------------------------
+
+	/**
+	 * Scenario: a single-file folder holding an EXACT match for the reported IP.
+	 *
+	 * Given: pre-fix, grep given exactly one file emits its match UNPREFIXED, so
+	 * pfb_parse_query() returns a 1-element array (no [1]) -- find_reported_
+	 * header()'s exact-match branch returns that 1-element array VERBATIM (it has
+	 * no Unknown/Unknown fallback of its own), corrupting every caller that reads
+	 * result[1] (e.g. convert_ip_log() builds a degenerate '^' aliastables
+	 * pattern from the resulting NULL).
+	 * When: the per-row AND batched lookups both run against the single-file
+	 * folder.
+	 * Then: both resolve the real (feed, ip) pair -- RED before the fix (a
+	 * 1-element array), GREEN after (grep's forced /dev/null file-prefix gives
+	 * pfb_parse_query() the 2-element shape).
+	 */
+	public function test_single_file_folder_exact_match_resolves_correctly_per_row_and_batched(): void
+	{
+		$tmp = sys_get_temp_dir() . '/pfb_833_exact_' . getmypid();
+		mkdir($tmp, 0777, true);
+		file_put_contents("{$tmp}/LoneFeed.txt", "192.0.2.201\n");
+		$folder = "{$tmp}/*.txt";
+
+		try {
+			$perRow = find_reported_header('192.0.2.201', $folder);
+			$this->assertSame(
+				['LoneFeed', '192.0.2.201'],
+				$perRow,
+				'expected the per-row find_reported_header() to resolve the exact match in the single-file folder, got '
+					. var_export($perRow, true)
+			);
+
+			$batched = pfb_find_reported_headers(['192.0.2.201'], $folder);
+			$this->assertSame(
+				['LoneFeed', '192.0.2.201'],
+				$batched['192.0.2.201'],
+				'expected the batched pfb_find_reported_headers() to resolve the exact match in the single-file folder, got '
+					. var_export($batched['192.0.2.201'], true)
+			);
+		} finally {
+			unlink("{$tmp}/LoneFeed.txt");
+			rmdir($tmp);
+		}
+	}
+
+	/**
+	 * Scenario: a single-file folder whose ONLY covering entry is a CIDR (no
+	 * exact-match line at all) -- the WORST pre-fix failure mode.
+	 *
+	 * Given: pre-fix, the exact-match round misses (the file has no line equal
+	 * to the host), so the prefix/CIDR round runs pfb_match_reported_cidr()
+	 * against the single-file $result. Each line goes through pfb_parse_query(),
+	 * which -- unprefixed -- returns a 1-element array with no [1]; `strpos($rx[1]
+	 * ?? NULL, '/')` then NEVER recognises the line as CIDR-shaped, so the
+	 * genuinely-covering CIDR is silently dropped and the host resolves to
+	 * Unknown/Unknown ("Not listed!") even though it IS still covered.
+	 * When: the per-row AND batched lookups both run against the single-file
+	 * folder.
+	 * Then: both resolve the real CIDR header -- RED before the fix (silently
+	 * "Not listed!"), GREEN after.
+	 */
+	public function test_single_file_folder_cidr_only_coverage_resolves_correctly_per_row_and_batched(): void
+	{
+		$tmp = sys_get_temp_dir() . '/pfb_833_cidr_' . getmypid();
+		mkdir($tmp, 0777, true);
+		file_put_contents("{$tmp}/LoneCidrFeed.txt", "192.0.2.0/24\n");
+		$folder = "{$tmp}/*.txt";
+
+		try {
+			$perRow = find_reported_header('192.0.2.5', $folder);
+			$this->assertSame(
+				['LoneCidrFeed', '192.0.2.0/24'],
+				$perRow,
+				'expected the per-row find_reported_header() to resolve the CIDR match in the single-file folder, got '
+					. var_export($perRow, true)
+			);
+
+			$batched = pfb_find_reported_headers(['192.0.2.5'], $folder);
+			$this->assertSame(
+				['LoneCidrFeed', '192.0.2.0/24'],
+				$batched['192.0.2.5'],
+				'expected the batched pfb_find_reported_headers() to resolve the CIDR match in the single-file folder, got '
+					. var_export($batched['192.0.2.5'], true)
+			);
+		} finally {
+			unlink("{$tmp}/LoneCidrFeed.txt");
+			rmdir($tmp);
+		}
+	}
+
+	// ------------------------------------------------------------------------------
 	// pfb_ip_prefetch() end-to-end -- seeding pfb_ip_render_memos() for real rows
 	// ------------------------------------------------------------------------------
 
@@ -476,12 +585,17 @@ final class IpPrefetchTest extends TestCase
 		// Then: the miss round resolved via find_reported_header()'s CIDR match against
 		// the SAME DenyFeed.txt entry, AND the aliastables round found the identical CIDR
 		// string in the alias fixture -- exactly what a per-row exec would have produced.
+		// issue #833: the alias fixture dir (fixtures/ip_prefetch/alias) holds exactly
+		// ONE .txt file, so the aliastables grep is now forced (via /dev/null) to emit
+		// its "path:" prefix -- the shape convert_ip_log()'s own alias-name parse chain
+		// (pfblockerng_alerts.php ltrim/strrchr/strstr) requires.
 		$missKey = "{$rq['host']}|{$rq['folder']}";
 		$this->assertArrayHasKey($missKey, $memos['miss'], "expected the miss round to seed key '{$missKey}'");
+		$expectedRawValidate = "{$GLOBALS['pfb']['aliasdir']}/pfB_SomeAlias_v4.txt:192.0.2.0/24";
 		$this->assertSame(
-			[['DenyFeed', '192.0.2.0/24'], '192.0.2.0/24'],
+			[['DenyFeed', '192.0.2.0/24'], $expectedRawValidate],
 			$memos['miss'][$missKey],
-			'expected [pfb_query, raw_validate] to be ' . var_export([['DenyFeed', '192.0.2.0/24'], '192.0.2.0/24'], true)
+			'expected [pfb_query, raw_validate] to be ' . var_export([['DenyFeed', '192.0.2.0/24'], $expectedRawValidate], true)
 				. ', got ' . var_export($memos['miss'][$missKey], true)
 		);
 	}
@@ -675,7 +789,10 @@ final class IpPrefetchTest extends TestCase
 		pfb_ip_prefetch($rows);
 		$memos   = &pfb_ip_render_memos();
 		$missKey = "{$rq['host']}|{$rq['folder']}";
-		$this->assertSame([['DenyFeed', '192.0.2.0/24'], '192.0.2.0/24'], $memos['miss'][$missKey]);
+		// issue #833: see the sibling assertion above -- the single-file alias
+		// fixture's raw_validate is now the forced-prefix "path:content" shape.
+		$expectedRawValidate = "{$GLOBALS['pfb']['aliasdir']}/pfB_SomeAlias_v4.txt:192.0.2.0/24";
+		$this->assertSame([['DenyFeed', '192.0.2.0/24'], $expectedRawValidate], $memos['miss'][$missKey]);
 
 		// When: the backing deny/native/alias directories are renamed away -- a FRESH
 		// find_reported_header() call (or a fresh aliastables exec) against these paths
@@ -711,7 +828,7 @@ final class IpPrefetchTest extends TestCase
 				'expected the CACHED pfb_query to survive the directories disappearing, got ' . var_export($cachedQuery, true)
 			);
 			$this->assertSame(
-				'192.0.2.0/24',
+				$expectedRawValidate,
 				$cachedValidate,
 				'expected the CACHED aliastables content to survive the directories disappearing, got ' . var_export($cachedValidate, true)
 			);
@@ -723,7 +840,8 @@ final class IpPrefetchTest extends TestCase
 	}
 
 	// ------------------------------------------------------------------------------
-	// issue #831: a single-.txt folder must never fatal the batched prefetch
+	// issue #831 / #833: a single-.txt folder must never fatal, and must resolve
+	// its miss round correctly (not merely avoid a crash)
 	// ------------------------------------------------------------------------------
 
 	/**
@@ -731,18 +849,25 @@ final class IpPrefetchTest extends TestCase
 	 * exactly ONE .txt file (a GeoIP row's ccdir here; an ET row's etdir is the
 	 * other in-tree shape).
 	 *
-	 * Given: with exactly one file argument grep emits its match UNPREFIXED (no
-	 * "path:" part), so pfb_parse_query() returns a one-element array with no
-	 * [1]. (The Block/Permit/Match folders are immune: their two-token
-	 * "<dir>/*.txt <nativedir>/*.txt" list always hands grep a second argument
-	 * -- even an unexpanded literal counts -- forcing filename prefixes.)
+	 * Given: pre-issue-#833, with exactly one file argument grep emitted its
+	 * match UNPREFIXED (no "path:" part), so pfb_parse_query() returned a
+	 * one-element array with no [1] -- issue #831's guard caught this and left
+	 * the row unseeded (no fatal, but no seed either). issue #833 fixes the ROOT
+	 * CAUSE instead: every find_reported_header()/pfb_find_reported_headers()
+	 * exec() now appends a trailing /dev/null, forcing grep to always be given
+	 * >=2 files -- it always emits the "path:" prefix, so pfb_parse_query()
+	 * always returns the 2-element shape and the #831 guard is now dead code
+	 * (removed).
+	 * (The Block/Permit/Match folders were always immune to the ORIGINAL bug:
+	 * their two-token "<dir>/*.txt <nativedir>/*.txt" list already hands grep a
+	 * second argument -- even an unexpanded literal counts -- forcing filename
+	 * prefixes with no #833 fix needed.)
 	 * When: pfb_ip_prefetch() runs its miss + aliastables rounds for that row.
-	 * Then: the prefetch completes WITHOUT the issue #831 TypeError (NULL into
-	 * the strict-typed pfb_ip_prefetch_last_match()), and the row is left
-	 * UNSEEDED -- convert_ip_log()'s per-row fallback then reproduces the
-	 * legacy (pre-batching) rendering for it, single-file quirk (#833) and all.
+	 * Then: the prefetch completes WITHOUT the issue #831 TypeError, AND the row
+	 * is now correctly SEEDED with the real (feed, value) pair -- no longer left
+	 * to convert_ip_log()'s per-row fallback.
 	 */
-	public function test_single_file_folder_miss_row_is_left_unseeded_instead_of_fataling(): void
+	public function test_single_file_folder_miss_row_is_correctly_seeded_after_the_833_fix(): void
 	{
 		// Given: a GeoIP cc dir holding exactly ONE feed file that contains the host.
 		$tmp = sys_get_temp_dir() . '/pfb_831_' . getmypid();
@@ -767,9 +892,9 @@ final class IpPrefetchTest extends TestCase
 				'eval_ip_raw'       => $fields[14],
 			]];
 
-			// When: the batched prefetch runs. Pre-fix this fataled with
-			// "pfb_ip_prefetch_last_match(): Argument #2 ($raw_prefix) must be of
-			// type string, null given" -- reaching the assertions below IS the fix.
+			// When: the batched prefetch runs. Pre-#833-fix this reached the #831
+			// skip-seed guard (no TypeError, but the row stayed unseeded); reaching
+			// the assertions below with a SEEDED, CORRECT entry IS this fix.
 			pfb_ip_prefetch($rows);
 			$memos = &pfb_ip_render_memos();
 
@@ -781,14 +906,16 @@ final class IpPrefetchTest extends TestCase
 					. var_export($memos['validate'][$rq['validate_cmd']] ?? 'MISSING', true)
 			);
 
-			// Then: the miss round left the row UNSEEDED (per-row fallback territory),
-			// never a seeded entry fabricated from the one-element pfb_parse_query().
+			// Then: the miss round is now SEEDED with the correct exact match --
+			// find_reported_header()'s forced-prefix grep resolved 'LoneFeed', and
+			// the aliastables round genuinely misses (the class-wide alias fixture
+			// only holds an unrelated CIDR), seeding the empty-string no-hit.
 			$missKey = "{$rq['host']}|{$rq['folder']}";
-			$this->assertArrayNotHasKey(
-				$missKey,
-				$memos['miss'],
-				"expected miss key '{$missKey}' to stay unseeded for the unprefixed single-file match, got "
-					. var_export($memos['miss'][$missKey] ?? null, true)
+			$this->assertSame(
+				[['LoneFeed', '192.0.2.201'], ''],
+				$memos['miss'][$missKey] ?? 'MISSING',
+				"expected miss key '{$missKey}' to be correctly seeded for the single-file match, got "
+					. var_export($memos['miss'][$missKey] ?? 'MISSING', true)
 			);
 		} finally {
 			foreach (["{$tmp}/cc/LoneFeed.txt", "{$tmp}/cc", $tmp] as $path) {


### PR DESCRIPTION
Fixes #833.

## What

`pfb_parse_query()` splits grep output on `.txt:` — but grep only prefixes matches with the filename when given ≥2 files, so a folder glob resolving to exactly ONE `.txt` file yields unprefixed matches, a 1-element array, and NULL `[1]` semantics in every consumer. Three failure modes (the third from the issue's scope-broadening comment):

- `convert_ip_log()`'s miss path: NULL `$eval_new` → degenerate `'^'` aliastables pattern + NULL-ish render cells.
- `pfb_ip_prefetch()`: previously papered over by the issue #831 skip-seed guard.
- `pfb_match_reported_cidr()`: a still-covering CIDR line silently dropped → **"Not listed!" rendered for an IP that is still covered** (silent wrong render, the worst of the three).

## Fix

Append `/dev/null` to the grep file list at every exec whose output feeds the prefix-dependent parsers, so grep always emits `path:content`:

- `find_reported_header()` exact + prefix execs (incl. the GeoIP piped variant),
- `pfb_find_reported_headers()` Round A (batched `-f`) + Round B (incl. GeoIP variant),
- both aliastables rounds — `pfb_ip_prefetch()`'s batched `find | xargs grep -f /dev/null` and `convert_ip_log()`'s per-row exec (their shared downstream parse chain at `pfblockerng_alerts.php:3119` is prefix-dependent),

then remove the now-dead #831 skip-seed guard, restoring batched == per-row output symmetry (the issue's explicit requirement). `pfb_parse_query()` itself is untouched — the filename is genuinely absent from unprefixed lines, so the call sites are the root cause.

## Tests (each red on pre-fix code → green after)

- Single-file folder, exact match: per-row + batched resolve the real (feed, entry) — was `array('')`.
- Single-file folder, CIDR-only coverage: per-row + batched resolve the covering CIDR — was silently `Unknown` with an "Undefined array key 1" warning at the `pfb_match_reported_cidr()` loop.
- The #831 regression test repurposed: the single-file miss row is now correctly SEEDED (was: pinned-unseeded fallback).
- Validate/miss-round seeding now carries the full `path:content` line.
- New parity case 9: single-file aliasdir renders the real `pfB_*` alias name (was: no moved-to-alias cell at all).
- Existing multi-file pins (batched==per-row for every v4/v6 shape, GeoIP variant, parity cases 1–8) stay green — multi-file behavior unchanged.

`www/` note: `pfblockerng_alerts.php`'s change is exercised by the existing Tier A alerts `ui_render` gate; the rendered-cell behavior is pinned off-box by the new parity case (no new page/flow/visual change → no Tier B). Deliberate trade-off: a live Tier B case for the single-file-aliasdir symptom would require deleting every other alias table's backing file on the VM; the parity test drives the identical real `find | xargs grep` exec boundary against real files, just not over live HTTP.

Full suite: 2260 tests green except the 3 pre-existing macOS `open_basedir`/`tempnam()` environment failures (identical on `devel`); PHPStan/PHPCS/php -l clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alias and IP lookup handling so single-file folder matches are parsed consistently.
  * Improved detection of real alias names in cases where only one file is present.
  * Corrected prefetch behavior so exact matches and CIDR-based entries resolve properly in both row-by-row and batched views.
  * Updated miss handling so previously skipped entries are now seeded as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->