### PR TITLE
tests/smoke: widen wait_unbound_ready budget + add timeout diagnostics

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2957,12 +2957,18 @@ def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 60, delay: float = 2.0) -
         time.sleep(delay)
     # issue #845: never raise a bare message — print expected vs. actual (the last
     # poll) plus the process list, so "never started" reads differently from "slow".
-    procs = vm.ssh('ps auxww | grep -i "[u]nbound"', timeout=15.0)
+    # The probe is best-effort: on an unresponsive box it can itself time out, and
+    # that must not swallow the detailed RuntimeError below (PR #846 review).
+    try:
+        procs = vm.ssh('ps auxww | grep -i "[u]nbound"', timeout=15.0)
+        procs_diag = f"rc={procs.returncode} stdout={procs.stdout!r} stderr={procs.stderr!r}"
+    except Exception as exc:
+        procs_diag = f"<process-list probe failed: {exc!r}>"
     raise RuntimeError(
         f"Unbound did not become ready after reload: expected rc=0 from "
         f"`unbound-control status` within {attempts} attempts x {delay}s; "
         f"last poll rc={rc} stdout={out!r} stderr={err!r}; "
-        f"unbound processes: rc={procs.returncode} stdout={procs.stdout!r} stderr={procs.stderr!r}"
+        f"unbound processes: {procs_diag}"
     )
 
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2940,15 +2940,30 @@ def assert_unbound_adds_only_python_config(vm: SmokeVM, *, timeout: float = 30.0
 
 
 @timed_step("wait_unbound_ready")
-def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 30, delay: float = 2.0) -> None:
-    """Poll ``unbound-control status`` until ready (mirrors install-pkg.sh)."""
+def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 60, delay: float = 2.0) -> None:
+    """Poll ``unbound-control status`` until ready (mirrors install-pkg.sh).
+
+    Budget is wider than the shell twin's (120s vs. install-pkg.sh's 60s, issue
+    #845): a restart-class reload (unbound restart + DNSBL structure rebuild
+    before the control socket answers) can legitimately exceed 60s under CI load.
+    """
     cmd = "/usr/local/sbin/unbound-control -c /var/unbound/unbound.conf status"
+    rc, out, err = None, None, None
     for _ in range(attempts):
         result = vm.ssh(cmd, timeout=15.0)
         if result.returncode == 0:
             return
+        rc, out, err = result.returncode, result.stdout, result.stderr
         time.sleep(delay)
-    raise RuntimeError("Unbound did not become ready after reload")
+    # issue #845: never raise a bare message — print expected vs. actual (the last
+    # poll) plus the process list, so "never started" reads differently from "slow".
+    procs = vm.ssh('ps auxww | grep -i "[u]nbound"', timeout=15.0)
+    raise RuntimeError(
+        f"Unbound did not become ready after reload: expected rc=0 from "
+        f"`unbound-control status` within {attempts} attempts x {delay}s; "
+        f"last poll rc={rc} stdout={out!r} stderr={err!r}; "
+        f"unbound processes: rc={procs.returncode} stdout={procs.stdout!r} stderr={procs.stderr!r}"
+    )
 
 
 def wait_boot_complete(vm: SmokeVM, *, timeout: float = 180.0, delay: float = 3.0) -> None:

--- a/tests/test_smoke_unbound_ready.py
+++ b/tests/test_smoke_unbound_ready.py
@@ -1,0 +1,115 @@
+"""``wait_unbound_ready`` must survive slow restart-class reloads AND fail loudly.
+
+Issue #845: a restart-class reload (unbound restart + DNSBL structure rebuild before
+the control socket answers) legitimately exceeds the old 60s budget (30 attempts x 2s)
+under CI load — the identical rerun passed. Additionally, on exhaustion the old code
+raised a bare ``RuntimeError`` with zero diagnostics, making "unbound never started"
+indistinguishable from "started but slow". This module pins BOTH the widened budget
+and the timeout-diagnostics contract off-VM (no VM I/O; ``tests.smoke.helpers`` is
+import-safe — precedent: ``test_smoke_unblock_egress.py``).
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+
+import pytest
+
+from tests.smoke import helpers
+
+
+@dataclass
+class _FakeResult:
+    """Stand-in for ``subprocess.CompletedProcess[str]`` (the shape ``SmokeVM.ssh`` returns)."""
+
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class _FakeVM:
+    """Fake ``vm.ssh(*remote, timeout=...)`` — records calls, replays scripted results."""
+
+    results: list[_FakeResult]
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+
+    def ssh(self, *remote: str, timeout: float = 60.0) -> _FakeResult:
+        self.calls.append(remote)
+        index = min(len(self.calls) - 1, len(self.results) - 1)
+        return self.results[index]
+
+
+def test_default_budget_polls_at_least_120_seconds_worth_of_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given a fake vm whose status check never returns rc=0
+    When wait_unbound_ready runs with the DEFAULT attempts/delay
+    Then (a) attempts x delay is >= 120s — the widened CI budget (issue #845), not
+    the old 60s (30 x 2) that flaked under a slow restart-class reload — and (b) the
+    loop actually polls that many times (excluding the post-loop diagnostics call)
+    before giving up, proving the widened budget is real, not just a signature claim.
+    """
+    monkeypatch.setattr(helpers.time, "sleep", lambda _seconds: None)
+    sig = inspect.signature(helpers.wait_unbound_ready)
+    default_attempts = sig.parameters["attempts"].default
+    default_delay = sig.parameters["delay"].default
+    assert default_attempts * default_delay >= 120.0
+
+    vm = _FakeVM(results=[_FakeResult(returncode=1, stdout="down", stderr="")])
+
+    with pytest.raises(RuntimeError):
+        helpers.wait_unbound_ready(vm)  # type: ignore[arg-type]
+
+    status_polls = [c for c in vm.calls if "unbound-control" in c[0]]
+    assert len(status_polls) == default_attempts
+
+
+def test_timeout_error_reports_last_poll_and_process_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given unbound-control status always fails with distinctive output
+    When wait_unbound_ready exhausts its attempts
+    Then the raised RuntimeError names the LAST poll's rc/stdout/stderr AND the
+    unbound process-list diagnostics — never a bare message (CLAUDE.md: print
+    expected vs. actual on every failing poll) — so a reader can tell "never
+    started" from "started but slow".
+    """
+    monkeypatch.setattr(helpers.time, "sleep", lambda _seconds: None)
+
+    status_result = _FakeResult(returncode=1, stdout="STATUS-SENTINEL-OUT", stderr="STATUS-SENTINEL-ERR")
+    procs_result = _FakeResult(returncode=0, stdout="PROC-LIST-SENTINEL unbound", stderr="")
+    vm = _FakeVM(results=[status_result])
+
+    def ssh(*remote: str, timeout: float = 60.0) -> _FakeResult:
+        vm.calls.append(remote)
+        if "unbound-control" in remote[0]:
+            return status_result
+        return procs_result
+
+    monkeypatch.setattr(vm, "ssh", ssh)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        helpers.wait_unbound_ready(vm, attempts=2, delay=0)  # type: ignore[arg-type]
+
+    message = str(excinfo.value)
+    assert "STATUS-SENTINEL-OUT" in message
+    assert "STATUS-SENTINEL-ERR" in message
+    assert "rc=1" in message
+    assert "PROC-LIST-SENTINEL" in message
+
+
+def test_returns_without_raising_once_status_reports_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given unbound-control status returns rc=0 on the FIRST poll
+    When wait_unbound_ready runs
+    Then it returns immediately (no raise, no diagnostics probe, exactly one ssh call).
+    """
+    monkeypatch.setattr(helpers.time, "sleep", lambda _seconds: None)
+    vm = _FakeVM(results=[_FakeResult(returncode=0, stdout="ok", stderr="")])
+
+    helpers.wait_unbound_ready(vm, delay=0)  # type: ignore[arg-type]
+
+    assert len(vm.calls) == 1

--- a/tests/test_smoke_unbound_ready.py
+++ b/tests/test_smoke_unbound_ready.py
@@ -100,6 +100,38 @@ def test_timeout_error_reports_last_poll_and_process_list(
     assert "PROC-LIST-SENTINEL" in message
 
 
+def test_timeout_diagnostics_survive_a_failing_process_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given unbound-control status always fails AND the process-list probe itself
+    raises (an unresponsive box times out the diagnostics ssh call too)
+    When wait_unbound_ready exhausts its attempts
+    Then the detailed RuntimeError still fires with the last poll's rc/stdout/stderr
+    and names the probe failure — the best-effort probe never replaces the
+    expected-vs-actual diagnostics with an opaque unrelated exception (PR #846 review).
+    """
+    monkeypatch.setattr(helpers.time, "sleep", lambda _seconds: None)
+
+    status_result = _FakeResult(returncode=1, stdout="STATUS-SENTINEL-OUT", stderr="STATUS-SENTINEL-ERR")
+    vm = _FakeVM(results=[status_result])
+
+    def ssh(*remote: str, timeout: float = 60.0) -> _FakeResult:
+        vm.calls.append(remote)
+        if "unbound-control" in remote[0]:
+            return status_result
+        raise TimeoutError("PROBE-TIMEOUT-SENTINEL")
+
+    monkeypatch.setattr(vm, "ssh", ssh)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        helpers.wait_unbound_ready(vm, attempts=2, delay=0)  # type: ignore[arg-type]
+
+    message = str(excinfo.value)
+    assert "STATUS-SENTINEL-OUT" in message
+    assert "rc=1" in message
+    assert "PROBE-TIMEOUT-SENTINEL" in message
+
+
 def test_returns_without_raising_once_status_reports_ready(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #845

## What

- `wait_unbound_ready` (tests/smoke/helpers.py): default budget widened from 30 attempts × 2 s (60 s) to 60 attempts × 2 s (120 s). A restart-class reload (unbound restart + DNSBL structure rebuild before the control socket answers) can legitimately exceed 60 s under CI load — the flake in #845 reran green on identical code.
- On exhaustion the `RuntimeError` now reports expected vs. actual: the last poll's rc/stdout/stderr plus an on-box `ps` unbound process list, so "never started" is distinguishable from "started but slow to ready" (previously a bare message, violating the print-expected-vs-actual test mandate).
- New off-VM unit tests (`tests/test_smoke_unbound_ready.py`, fake-vm precedent from `test_smoke_unblock_egress.py`) pin the ≥120 s default budget, the real poll count, the diagnostics content, and the untouched success path. Red→green verified: budget and diagnostics tests fail on the pre-fix helper, pass post-fix.

## Scope

Shared-function fix — every `wait_unbound_ready` caller gets the wider budget and diagnostics. No `src/` change; test harness only. `install-pkg.sh`'s shell twin keeps its own loop (has its own rich diagnostics dump already).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfJUsCQkpFZxXufncGUS2f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checks for Unbound so the system waits longer before timing out, reducing false failures during slow starts.
  * Timeout messages now include more helpful diagnostic details, making it easier to tell whether the service never started or was still coming up.
  
* **Tests**
  * Added coverage for slow-start, immediate-ready, and timeout scenarios to verify the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->