### PR TITLE
pfblockerng.sh: force grep file prefix in the Empty-Lists report (#844)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1548,7 +1548,12 @@ closingprocess() {
 		wc -l "${pfbnative}"*.txt 2>/dev/null | sort -n -r
 	fi
 	if [ -d "${pfbdeny}" ] && [ "$(ls -A "${pfbdeny}")" ]; then
-		emptylists="$(grep "^${ip_placeholder2}$" "${pfbdeny}"*.txt | cut -d ':' -f1 | sed -e 's/^.*[a-zA-Z]\///')"
+		# grep only prefixes matches with "path:" when given >=2 file args; a deny glob that
+		# resolves to exactly one file then returns the bare match (the placeholder IP) and
+		# `cut -d ':' -f1` picks that up instead of the filename. The appended /dev/null forces
+		# a second (never-matching) file arg so the prefix -- and the filename -- always shows,
+		# same idiom as issue #833's PHP-side fix (#842). See issue #844.
+		emptylists="$(grep "^${ip_placeholder2}$" "${pfbdeny}"*.txt /dev/null | cut -d ':' -f1 | sed -e 's/^.*[a-zA-Z]\///')"
 		if [ -n "${emptylists}" ]; then
 			echo; echo "====================[ Empty Lists w/${ip_placeholder} ]=================="; echo
 			for list in ${emptylists}; do

--- a/tests/shell/pfblockerng_empty_lists_spec.sh
+++ b/tests/shell/pfblockerng_empty_lists_spec.sh
@@ -1,0 +1,52 @@
+#shellcheck shell=sh
+# closingprocess()'s "Empty Lists" report names the DENY-LIST FILE whose sole
+# content is the placeholder IP -- not the placeholder IP itself. grep only
+# emits a "path:" prefix when given >=2 file args, so a deny glob that
+# resolves to exactly ONE file used to return the bare match line (the
+# placeholder), and `cut -d ':' -f1` picked that up instead of the filename
+# (issue #844).
+
+Describe 'closingprocess() Empty Lists report names the file, not the matched IP (#844)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/emptylists.XXXXXX")"
+    pfborig="${work}/orig/"; pfbdeny="${work}/deny/"
+    pfbpermit="${work}/permit/"; pfbmatch="${work}/match/"; pfbnative="${work}/native/"
+    mkdir -p "$pfborig" "$pfbdeny" "$pfbpermit" "$pfbmatch" "$pfbnative"
+    masterfile="${work}/masterfile"; mastercat="${work}/mastercat"
+    tempfile="${work}/t1"; errorlog="${work}/err.log"; now="now"
+    ip_placeholder2="127.0.0.1"
+    alias="off"
+    pathpfctl="${work}/pfctl"; printf '#!/bin/sh\n' > "$pathpfctl"; chmod +x "$pathpfctl"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'names the sole file when the deny glob resolves to exactly ONE list'
+    # Given a single deny-list file whose only content is the placeholder IP.
+    printf '%s\n' "$ip_placeholder2" > "${pfbdeny}LONEFEED.txt"
+
+    # When the final report runs.
+    When call closingprocess
+
+    # Then the Empty Lists section names the file, not the bare placeholder IP.
+    The status should be success
+    The stdout should include 'LONEFEED.txt'
+    The stdout should not include "$ip_placeholder2"
+  End
+
+  It 'names each file when the deny glob resolves to MULTIPLE lists'
+    # Given two deny-list files, both emptied down to the placeholder IP.
+    printf '%s\n' "$ip_placeholder2" > "${pfbdeny}FeedA.txt"
+    printf '%s\n' "$ip_placeholder2" > "${pfbdeny}FeedB.txt"
+
+    # When the final report runs.
+    When call closingprocess
+
+    # Then both files are named in the Empty Lists section.
+    The status should be success
+    The stdout should include 'FeedA.txt'
+    The stdout should include 'FeedB.txt'
+  End
+End


### PR DESCRIPTION
Fixes #844.

The "Empty Lists" diagnostics report in `closingprocess()` greps the deny glob and parses the filename out of grep's `path:` prefix. grep only emits that prefix when given >=2 file args, so a glob resolving to exactly ONE file returned the bare match line and `cut -d ':' -f1` printed the placeholder IP where the list name belongs. Shell-side sibling of issue #833 (PHP sites fixed in #842).

## Change

- Append `/dev/null` to the grep file list so grep always has >=2 file args and always emits the filename prefix — the same idiom #842 applied to the PHP sites. One-token functional change; swept the script, this is the only `cut -d ':' -f1`-after-glob-grep site.

## Tests

- New `tests/shell/pfblockerng_empty_lists_spec.sh` pins both glob-cardinality branches: one deny file (the regression — report must name `LONEFEED.txt`, not the placeholder IP) and two files (already correct pre-fix).
- Red before / green after verified both by the implementer and independently by the orchestrator (reverting the script hunk fails the single-file case exactly as the issue describes).

Gates: `sh -n` clean, `shellcheck` clean, full shellspec suite `336 examples, 0 failures, 8 skips` (skips are pre-existing, environment-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG