### PR TITLE
tests/smoke: anchor the DoT 853 matcher on the descr prefix (CE + Plus renders)

### DIFF
--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -61,23 +61,19 @@ pytestmark = pytest.mark.smoke
 # Package name on the devel channel (matches test_dns_redirect.py).
 _PKG_NAME = "pfSense-pkg-pfBlockerNG-devel"
 
-# Marker prefix for DoT/DoQ-block owned rules (mirrors PFB_DOT_BLOCK_DESCR_PFX).
+# Marker prefix for DoT/DoQ-block owned rules (mirrors PFB_DOT_BLOCK_DESCR_PFX). Doubles as
+# the ``_is_block_853_line`` ownership anchor in ``pfctl -sr`` output (#813, #849): plain
+# ``pfctl -sr`` prints the config row's ``descr`` as rule TEXT, but the label SHAPE differs by
+# edition — CE 2.8 renders one ``label "USER_RULE: <descr>"`` clause (live CE guest, run
+# 28704593724), Plus 26.03 renders split labels with no ``USER_RULE:`` prefix —
+# ``label "id=<N>" label "tags=user_rule" label "descr=<descr>"`` (live Plus leg of run
+# 28733176915, where a CE-only ``USER_RULE: `` anchor missed every loaded rule). The descr
+# text is the one token present in BOTH renders, so the matcher anchors on this bare prefix
+# (shared by the per-interface and floating descrs; no foreign rule carries it).
 _DOT_BLOCK_DESCR_PFX = "pfB_DoT_Block_"
 
 # Marker for the single floating DoT/DoQ-block rule (mirrors PFB_DOT_BLOCK_FLOATING_DESCR).
 _DOT_BLOCK_FLOATING_DESCR = "pfB_DoT_Block_Floating"
-
-# Rendered pf label anchoring for a pfB-owned DoT/DoQ block rule (#813, #849). Plain
-# ``pfctl -sr`` (no ``-v`` needed) prints the config row's ``descr`` as rule TEXT — pf labels
-# are emitted by ``print_rule()`` regardless of verbosity — but the label SHAPE differs by
-# edition: CE 2.8 renders one ``label "USER_RULE: <descr>"`` clause (confirmed on a live CE
-# guest, run 28704593724), while Plus 26.03 renders split labels with no ``USER_RULE:``
-# prefix — ``label "id=<N>" label "tags=user_rule" label "descr=<descr>"`` (confirmed on the
-# live Plus leg of run 28733176915, where the CE-only ``USER_RULE: `` anchor missed every
-# loaded rule). The one token present in BOTH renders is the descr itself, and both the
-# per-interface descr (``pfB_DoT_Block_<iface>``) and the floating descr
-# (``pfB_DoT_Block_Floating``) share the ``_DOT_BLOCK_DESCR_PFX`` prefix — so the matcher
-# anchors on that bare prefix (no foreign rule carries it; see the #813 false-match concern).
 
 # User filter rule descriptor seeded in Cases 3 and 6 to prove survival.
 _USER_FILTER_DESCR = "my-user-filter-dot-block-smoke"

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -67,13 +67,17 @@ _DOT_BLOCK_DESCR_PFX = "pfB_DoT_Block_"
 # Marker for the single floating DoT/DoQ-block rule (mirrors PFB_DOT_BLOCK_FLOATING_DESCR).
 _DOT_BLOCK_FLOATING_DESCR = "pfB_DoT_Block_Floating"
 
-# Rendered pf label anchor for a pfB-owned DoT/DoQ block rule (#813). Plain ``pfctl -sr``
-# (no ``-v`` needed) prints ``label "USER_RULE: <descr>"`` for every config filter/rule row
-# that carries a ``descr`` — pf labels are rule TEXT, emitted by ``print_rule()`` regardless
-# of verbosity (confirmed on a real CE 2.8 smoke-diagnostics guest, run 28704593724). Both
-# the per-interface descr (``pfB_DoT_Block_<iface>``) and the floating descr
-# (``pfB_DoT_Block_Floating``) share this prefix, so anchoring on the PREFIX covers both.
-_DOT_BLOCK_LABEL_ANCHOR = "USER_RULE: " + _DOT_BLOCK_DESCR_PFX
+# Rendered pf label anchoring for a pfB-owned DoT/DoQ block rule (#813, #849). Plain
+# ``pfctl -sr`` (no ``-v`` needed) prints the config row's ``descr`` as rule TEXT — pf labels
+# are emitted by ``print_rule()`` regardless of verbosity — but the label SHAPE differs by
+# edition: CE 2.8 renders one ``label "USER_RULE: <descr>"`` clause (confirmed on a live CE
+# guest, run 28704593724), while Plus 26.03 renders split labels with no ``USER_RULE:``
+# prefix — ``label "id=<N>" label "tags=user_rule" label "descr=<descr>"`` (confirmed on the
+# live Plus leg of run 28733176915, where the CE-only ``USER_RULE: `` anchor missed every
+# loaded rule). The one token present in BOTH renders is the descr itself, and both the
+# per-interface descr (``pfB_DoT_Block_<iface>``) and the floating descr
+# (``pfB_DoT_Block_Floating``) share the ``_DOT_BLOCK_DESCR_PFX`` prefix — so the matcher
+# anchors on that bare prefix (no foreign rule carries it; see the #813 false-match concern).
 
 # User filter rule descriptor seeded in Cases 3 and 6 to prove survival.
 _USER_FILTER_DESCR = "my-user-filter-dot-block-smoke"
@@ -219,13 +223,15 @@ def _is_block_853_line(line: str) -> bool:
     pfctl renders port 853 as the ``/etc/services`` name ``domain-s`` (DoT/DoQ), not the
     literal ``853`` — so a ``"853" in line`` test alone misses a correctly-loaded rule.
 
-    Anchored on the rendered pfB label, not just the 853/domain-s token (#813): without it,
-    a foreign port-853 block rule baked onto the smoke image (unrelated to pfBlockerNG)
-    could false-match the positive gate, and the ABSENT gate could false-fail on it instead
-    of asserting pfB-owned rules specifically are gone. See ``_DOT_BLOCK_LABEL_ANCHOR`` for
-    the evidence that plain ``pfctl -sr`` already renders this label with no ``-v`` needed.
+    Anchored on the rendered pfB descr prefix, not just the 853/domain-s token (#813):
+    without it, a foreign port-853 block rule baked onto the smoke image (unrelated to
+    pfBlockerNG) could false-match the positive gate, and the ABSENT gate could false-fail
+    on it instead of asserting pfB-owned rules specifically are gone. The BARE descr prefix
+    (not a composed ``USER_RULE: <descr>`` label) is deliberate: CE and Plus render the
+    label differently and only the descr text appears in both (#849) — see the
+    ``_DOT_BLOCK_DESCR_PFX`` anchoring comment for the per-edition render evidence.
     """
-    return "block" in line and ("853" in line or "domain-s" in line) and _DOT_BLOCK_LABEL_ANCHOR in line
+    return "block" in line and ("853" in line or "domain-s" in line) and _DOT_BLOCK_DESCR_PFX in line
 
 
 def _is_block_853_line_loose(line: str) -> bool:

--- a/tests/test_dot_doq_block_853_line.py
+++ b/tests/test_dot_doq_block_853_line.py
@@ -1,20 +1,26 @@
-"""Issue #813 — anchor ``_is_block_853_line`` on the rendered pfB DoT-block label.
+"""Issues #813 + #849 — anchor ``_is_block_853_line`` on the pfB DoT-block descr prefix.
 
 Pins the pure, off-VM predicate ``_is_block_853_line`` from
-``tests/smoke/test_dot_doq_block.py``: before the fix it was
-``"block" in line and ("853" in line or "domain-s" in line)`` — unanchored, so ANY
-block/reject rule mentioning port 853 (a foreign rule baked onto the smoke image,
-unrelated firewall policy, etc.) false-matched the positive gate
-(``_pfctl_sr_has_block_853``), and the ABSENT gate (``_pfctl_sr_block_853_absent``)
-could false-fail on a rule pfBlockerNG never created.
+``tests/smoke/test_dot_doq_block.py`` across BOTH pf label renders:
 
-Real pfSense renders every config ``filter/rule`` row that carries a ``descr`` as
-``label "USER_RULE: <descr>"`` in PLAIN ``pfctl -sr`` output — no ``-v`` needed, pf
-labels are rule TEXT emitted by ``print_rule()`` regardless of verbosity (confirmed on
-a live CE 2.8 smoke-diagnostics guest, run 28704593724). pfBlockerNG's DoT/DoQ block
-rows carry descr ``pfB_DoT_Block_<iface>`` (or the floating variant
-``pfB_DoT_Block_Floating``) — anchoring on that rendered label PREFIX lets the matcher
-tell a pfB-owned 853 block from any other.
+- **#813 (ownership anchor).** Before #813 the matcher was
+  ``"block" in line and ("853" in line or "domain-s" in line)`` — unanchored, so ANY
+  block/reject rule mentioning port 853 (a foreign rule baked onto the smoke image,
+  unrelated firewall policy, etc.) false-matched the positive gate
+  (``_pfctl_sr_has_block_853``), and the ABSENT gate (``_pfctl_sr_block_853_absent``)
+  could false-fail on a rule pfBlockerNG never created.
+- **#849 (edition-portable anchor).** The #813 fix anchored on the composed CE label
+  ``USER_RULE: pfB_DoT_Block_`` — but that is the **CE 2.8** render only. Plus 26.03
+  renders split labels with no ``USER_RULE:`` prefix —
+  ``label "id=<N>" label "tags=user_rule" label "descr=<descr>"`` (live Plus leg of run
+  28733176915: all four loaded rules missed, every dot_doq live-pf gate failed). The one
+  token present in both renders is the descr itself, so the matcher anchors on the bare
+  ``pfB_DoT_Block_`` prefix.
+
+Render evidence: CE 2.8 prints ``label "USER_RULE: <descr>"`` in PLAIN ``pfctl -sr``
+output — no ``-v`` needed, pf labels are rule TEXT emitted by ``print_rule()`` regardless
+of verbosity (live CE smoke-diagnostics guest, run 28704593724). Plus 26.03 prints the
+split-label form above (live Plus leg, run 28733176915).
 
 Importing ``tests.smoke.test_dot_doq_block`` here is import-safe off-VM — established
 pattern: ``tests/test_bench_pfctl_parse.py`` pulls pure functions out of
@@ -26,8 +32,8 @@ from __future__ import annotations
 from tests.smoke.test_dot_doq_block import _is_block_853_line
 
 
-def _rendered_line(*, action: str, port_token: str, label: str | None) -> str:
-    """Build a realistic ``pfctl -sr`` line in the shape pfSense actually renders.
+def _rendered_line_ce(*, action: str, port_token: str, label: str | None) -> str:
+    """Build a realistic **CE 2.8** ``pfctl -sr`` line.
 
     Mirrors the evidence from a live CE 2.8 guest (run 28704593724): plain ``pfctl -sr``
     prints ``label "USER_RULE: <descr>"`` (plus an internal ``id:N`` label) for every
@@ -41,43 +47,87 @@ def _rendered_line(*, action: str, port_token: str, label: str | None) -> str:
     )
 
 
-def test_pfb_owned_reject_default_rendering_matches() -> None:
-    """(a) The genuine pfB DoT-block rendered line (Reject default, domain-s) matches.
+def _rendered_line_plus(*, action: str, port_token: str, descr: str | None) -> str:
+    """Build a realistic **Plus 26.03** ``pfctl -sr`` line.
+
+    Mirrors the evidence from the live Plus leg of run 28733176915: Plus renders split
+    labels — ``label "id=<N>" label "tags=user_rule" label "descr=<descr>"`` — with no
+    ``USER_RULE:`` prefix anywhere on the line.
+    """
+    descr_clause = f' label "descr={descr}"' if descr is not None else ""
+    return (
+        f"{action} in quick on vtnet2 inet proto tcp from any to ! (self) "
+        f'port = {port_token} label "id=1760001634" label "tags=user_rule"{descr_clause} '
+        "ridentifier 1760001634"
+    )
+
+
+def test_pfb_owned_reject_default_ce_rendering_matches() -> None:
+    """(a) The genuine pfB DoT-block CE-rendered line (Reject default, domain-s) matches.
 
     Given the reject-default rule's pfctl -sr line (pfSense renders 'reject' as
-      'block return' — PR #562) carrying the pfB_DoT_Block_wan label,
+      'block return' — PR #562) carrying the CE label "USER_RULE: pfB_DoT_Block_wan",
     Then _is_block_853_line returns True.
     """
-    line = _rendered_line(action="block return", port_token="domain-s", label="pfB_DoT_Block_wan")
-    assert _is_block_853_line(line), f"expected a match for the genuine pfB rendered line, got False:\n  {line!r}"
+    line = _rendered_line_ce(action="block return", port_token="domain-s", label="pfB_DoT_Block_wan")
+    assert _is_block_853_line(line), f"expected a match for the genuine pfB CE-rendered line, got False:\n  {line!r}"
 
 
-def test_foreign_853_block_line_without_pfb_label_does_not_match() -> None:
-    """(b) A foreign block rule on port 853 with NO pfB label must NOT match (#813).
+def test_pfb_owned_plus_split_label_rendering_matches() -> None:
+    """(a') The genuine pfB DoT-block PLUS-rendered line (split labels) matches (#849).
+
+    Given the same rule as rendered by Plus 26.03 — split labels, the descr carried as
+      label "descr=pfB_DoT_Block_lan", no USER_RULE: prefix anywhere,
+    Then _is_block_853_line returns True.
+
+    RED on the #813 matcher (anchored on the composed CE label "USER_RULE: pfB_DoT_Block_"):
+    that anchor never appears in the Plus render, so every loaded rule read as absent —
+    the exact live failure of run 28733176915 (all five dot_doq live-pf gates, Plus leg).
+    """
+    line = _rendered_line_plus(action="block return", port_token="domain-s", descr="pfB_DoT_Block_lan")
+    assert _is_block_853_line(line), f"expected a match for the genuine pfB Plus-rendered line, got False:\n  {line!r}"
+
+
+def test_foreign_853_block_ce_line_without_pfb_descr_does_not_match() -> None:
+    """(b) A foreign CE-rendered block rule on port 853 with NO pfB descr must NOT match (#813).
 
     Given a baked harness-style block rule that also targets port 853 (some other
       firewall policy on the smoke image, unrelated to pfBlockerNG),
-    Then _is_block_853_line returns False — the label anchor rejects it.
+    Then _is_block_853_line returns False — the descr-prefix anchor rejects it.
 
     RED on the pre-#813 matcher (``"block" in line and ("853" in line or "domain-s" in
-    line)``, no label check): that older matcher returns True here, false-matching the
+    line)``, no ownership check): that older matcher returns True here, false-matching the
     positive gate and making the ABSENT gate false-fail on a rule pfBlockerNG never
     created.
     """
-    line = _rendered_line(action="block drop", port_token="853", label="Deny inbound DoT probe")
+    line = _rendered_line_ce(action="block drop", port_token="853", label="Deny inbound DoT probe")
     assert not _is_block_853_line(line), (
-        f"expected NO match for a foreign (non-pfB) port-853 block line, got True:\n  {line!r}"
+        f"expected NO match for a foreign (non-pfB) port-853 CE block line, got True:\n  {line!r}"
+    )
+
+
+def test_foreign_853_block_plus_line_without_pfb_descr_does_not_match() -> None:
+    """(b') A foreign PLUS-rendered block rule on port 853 with NO pfB descr must NOT match.
+
+    Given a Plus split-label block rule targeting port 853 whose descr is not
+      pfBlockerNG's (label "descr=Deny inbound DoT probe"),
+    Then _is_block_853_line returns False — ownership still filters on the Plus render;
+      the bare "tags=user_rule" label alone never qualifies a line.
+    """
+    line = _rendered_line_plus(action="block drop", port_token="853", descr="Deny inbound DoT probe")
+    assert not _is_block_853_line(line), (
+        f"expected NO match for a foreign (non-pfB) port-853 Plus block line, got True:\n  {line!r}"
     )
 
 
 def test_pfb_labeled_non_853_line_does_not_match() -> None:
     """(c) A pfB-labeled block rule that is NOT about port 853 must not match.
 
-    Given a pfctl -sr line carrying the pfB_DoT_Block_ label but a different port,
-    Then _is_block_853_line returns False — the label alone is not sufficient without
+    Given a pfctl -sr line carrying the pfB_DoT_Block_ descr but a different port,
+    Then _is_block_853_line returns False — the descr alone is not sufficient without
       the 853/domain-s port token.
     """
-    line = _rendered_line(action="block return", port_token="http", label="pfB_DoT_Block_wan")
+    line = _rendered_line_ce(action="block return", port_token="http", label="pfB_DoT_Block_wan")
     assert not _is_block_853_line(line), f"expected NO match (wrong port), got True:\n  {line!r}"
 
 
@@ -89,16 +139,16 @@ def test_block_action_rendering_also_matches() -> None:
       still returns True — the matcher checks for the substring 'block', covering both
       dispositions.
     """
-    line = _rendered_line(action="block drop", port_token="domain-s", label="pfB_DoT_Block_wan")
+    line = _rendered_line_ce(action="block drop", port_token="domain-s", label="pfB_DoT_Block_wan")
     assert _is_block_853_line(line), f"expected a match for the Block-action rendering, got False:\n  {line!r}"
 
 
-def test_floating_variant_label_still_matches() -> None:
+def test_floating_variant_descr_still_matches() -> None:
     """The floating opt-in variant (descr pfB_DoT_Block_Floating) still matches.
 
-    Given the floating rule's rendered line — same label PREFIX, different suffix,
-    Then _is_block_853_line returns True: the anchor matches the label PREFIX, not the
+    Given the floating rule's rendered line — same descr PREFIX, different suffix,
+    Then _is_block_853_line returns True: the anchor matches the descr PREFIX, not the
       full per-interface descr, so the floating variant is covered too.
     """
-    line = _rendered_line(action="block return", port_token="domain-s", label="pfB_DoT_Block_Floating")
+    line = _rendered_line_ce(action="block return", port_token="domain-s", label="pfB_DoT_Block_Floating")
     assert _is_block_853_line(line), f"expected a match for the floating pfB rendered line, got False:\n  {line!r}"


### PR DESCRIPTION
Fixes #849.

## What

`_is_block_853_line` (the dot_doq live-pf gate matcher) now anchors on the bare descr prefix `pfB_DoT_Block_` instead of the composed CE label `USER_RULE: pfB_DoT_Block_` introduced by #813.

## Why

Plus 26.03 renders user rules with split labels and no `USER_RULE:` prefix — `label "id=<N>" label "tags=user_rule" label "descr=pfB_DoT_Block_lan"` — so the #813 anchor matched nothing on Plus: all four loaded rules read as absent and every dot_doq live-pf gate failed on the Plus leg of the full-scope run 28733176915 (CE legs green). The descr text is the one token present in both renders, and it still excludes foreign port-853 rules (the #813 false-match concern): no non-pfB rule carries the `pfB_DoT_Block_` prefix.

## Tests

- `tests/test_dot_doq_block_853_line.py` extended with a Plus-render line builder and two new cases: the pfB Plus-rendered line must match (**red** on the CE-only anchor — the exact run-28733176915 failure — **green** after), and a foreign Plus-rendered port-853 rule must not (ownership still filters; `tags=user_rule` alone never qualifies).
- All pre-existing CE cases unchanged and green (ownership anchor, wrong-port, block-action, floating variant).
- Off-appliance gates: pytest 2133 passed, ruff check/format clean, mypy clean.

## Live validation

- CE (impacted, dot_doq module): run 28734352974
- Plus 26.03 (`version=26.03`, `pytest_filter=test_dot_doq_block`): run 28734353634

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ooLjvBBm6oznTBUg9mxVF
