### PR TITLE
ci: show 1-based shard labels in smoke job names

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -210,7 +210,7 @@ jobs:
   # pkg add refuses a cross-major .pkg, so a CE FreeBSD:15 .pkg cannot install on the
   # Plus FreeBSD:16 base — each leg must build its own ABI-matched package.
   smoke:
-    name: Smoke (${{ matrix.channel }} ${{ matrix.pfsense_version }} shard ${{ matrix.shard }}/${{ matrix.shard_total }})
+    name: Smoke (${{ matrix.channel }} ${{ matrix.pfsense_version }} shard ${{ matrix.shard_label }}/${{ matrix.shard_total }})
     needs: prepare
     # Run even if prepare had warnings; skip only if prepare hard-failed.
     if: needs.prepare.outputs.leg_count != '0'

--- a/scripts/resolve-legs.sh
+++ b/scripts/resolve-legs.sh
@@ -13,7 +13,8 @@
 #                 unless the derived -k is EMPTY and the marker is exactly
 #                 "smoke", and is clamped to the --test-dir's direct-child
 #                 test_*.py module count. Every FILTERED entry gets `shard` /
-#                 `shard_total` STRING fields (CE: 0..S-1 / S; Plus is
+#                 `shard_label` / `shard_total` STRING fields (CE: 0..S-1 / S,
+#                 label = shard+1 for display; Plus is
 #                 hard-capped at 1 — parallel Plus boots are untested).
 #                 Prints the filtered legs JSON to stdout.
 #                 Writes scope= / ci_matrix= / pytest_filter= to $GITHUB_OUTPUT.

--- a/scripts/resolve-legs.sh
+++ b/scripts/resolve-legs.sh
@@ -160,11 +160,15 @@ _rl_legs() {
     # avoid number/string coercion surprises). CE gets S copies; Plus is
     # HARD-CAPPED at 1 shard — #797's constraint: concurrent Netgate-side
     # check-ins from parallel Plus boots are untested.
+    # shard_label is the 1-based DISPLAY counterpart of the 0-based shard index —
+    # job names read "shard 1/2".."2/2" instead of the off-by-one-looking "0/2"
+    # (and "shard 1/1" for an unsharded leg instead of "0/1"). Scripts keep the
+    # 0-based `shard` field; the label exists for naming only.
     FILTERED="$(printf '%s\n' "$FILTERED" | jq -c --argjson s "$S" \
         '[ .[] | . as $e
            | (if $e.channel == "CE" then $s else 1 end) as $n
            | range(0; $n) as $i
-           | $e + {shard: ($i | tostring), shard_total: ($n | tostring)} ]')"
+           | $e + {shard: ($i | tostring), shard_label: (($i + 1) | tostring), shard_total: ($n | tostring)} ]')"
 
     printf 'scope=%s  legs=%s  -k=[%s]\n' "$SCOPE" \
         "$(printf '%s' "$FILTERED" | jq 'length')" "$K" >&2

--- a/tests/shell/module_durations_spec.sh
+++ b/tests/shell/module_durations_spec.sh
@@ -27,7 +27,7 @@ Describe 'module-durations.sh'
   # (multi-file summation), and interleaved noise lines that must be ignored.
   ci_line() {
     # $1=duration (e.g. "1.00s") $2=phase $3=nodeid
-    printf 'Smoke (CE 2.8 shard 0/2) / pytest -m smoke (live pfSense VM)\tUNKNOWN STEP\t2026-07-04T08:16:37.0000000Z %s %s     %s\n' \
+    printf 'Smoke (CE 2.8 shard 1/2) / pytest -m smoke (live pfSense VM)\tUNKNOWN STEP\t2026-07-04T08:16:37.0000000Z %s %s     %s\n' \
       "$1" "$2" "$3"
   }
 

--- a/tests/shell/resolve_legs_spec.sh
+++ b/tests/shell/resolve_legs_spec.sh
@@ -245,8 +245,9 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
     It 'SHARDS_INPUT=2, no -k, marker smoke -> CE expands to 2 shards, Plus stays 1, total 3 legs'
         # Given: full scope (no -k), default marker, a 3-module test-dir (>= 2 shards).
         # When: legs runs with SHARDS_INPUT=2.
-        # Then: the CE leg becomes 2 entries (shard 0/1 of 2); Plus stays exactly 1
-        #       entry (shard 0 of 1); the array carries 3 legs total.
+        # Then: the CE leg becomes 2 entries (0-based shard 0/1 of 2, 1-based
+        #       display labels 1/2 and 2/2); Plus stays exactly 1 entry (label 1/1);
+        #       the array carries 3 legs total.
         When run env \
             CI_MATRIX="$ONE_CE_ONE_PLUS" \
             EVENT_NAME="workflow_dispatch" \
@@ -255,10 +256,10 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
             sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
         The status should be success
         The output should include '"channel":"CE"'
-        The output should include '"shard":"0","shard_total":"2"'
-        The output should include '"shard":"1","shard_total":"2"'
+        The output should include '"shard":"0","shard_label":"1","shard_total":"2"'
+        The output should include '"shard":"1","shard_label":"2","shard_total":"2"'
         The output should include '"channel":"Plus"'
-        The output should include '"shard":"0","shard_total":"1"'
+        The output should include '"shard":"0","shard_label":"1","shard_total":"1"'
         The error should include 'legs=3'
     End
 
@@ -275,7 +276,7 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
             PYTEST_FILTER_INPUT="test_foo" \
             sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
         The status should be success
-        The output should include '"shard":"0","shard_total":"1"'
+        The output should include '"shard":"0","shard_label":"1","shard_total":"1"'
         The output should not include 'shard_total":"2"'
         The error should include 'legs=2'
     End
@@ -292,7 +293,7 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
             MARKER_INPUT="repo" \
             sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
         The status should be success
-        The output should include '"shard":"0","shard_total":"1"'
+        The output should include '"shard":"0","shard_label":"1","shard_total":"1"'
         The output should not include 'shard_total":"2"'
         The error should include 'legs=2'
     End
@@ -308,9 +309,9 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
             SHARDS_INPUT="5" \
             sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
         The status should be success
-        The output should include '"shard":"0","shard_total":"3"'
-        The output should include '"shard":"1","shard_total":"3"'
-        The output should include '"shard":"2","shard_total":"3"'
+        The output should include '"shard":"0","shard_label":"1","shard_total":"3"'
+        The output should include '"shard":"1","shard_label":"2","shard_total":"3"'
+        The output should include '"shard":"2","shard_label":"3","shard_total":"3"'
         The output should not include 'shard_total":"5"'
         The error should include 'legs=4'
     End
@@ -322,7 +323,7 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
             SCOPE_INPUT="full" \
             sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
         The status should be success
-        The output should include '"shard":"0","shard_total":"1"'
+        The output should include '"shard":"0","shard_label":"1","shard_total":"1"'
         The output should not include 'shard_total":"2"'
         The error should include 'legs=2'
     End
@@ -343,7 +344,7 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
                 SHARDS_INPUT="$1" \
                 sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
             The status should be success
-            The output should include '"shard":"0","shard_total":"1"'
+            The output should include '"shard":"0","shard_label":"1","shard_total":"1"'
             The output should not include 'shard_total":"2"'
             The error should include 'legs=2'
         End
@@ -362,8 +363,10 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
             sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
         The status should be success
         The output should include '"shard":"0"'
+        The output should include '"shard_label":"1"'
         The output should include '"shard_total":"2"'
         The output should not include '"shard":0,'
+        The output should not include '"shard_label":1,'
         The output should not include '"shard_total":2,'
         The output should not include '"shard_total":2}'
         The error should include 'legs=3'


### PR DESCRIPTION
## What

Smoke fan-out job names now show a 1-based shard label: `shard 1/2`..`2/2` (and `shard 1/1` for an unsharded leg) instead of the 0-based `shard 0/2` / `shard 0/1`.

## Why

`shard 0/1` on an unsharded leg reads as a missing sibling shard and `shard 0/2` looks off-by-one — it made healthy runs look like some shards were missing or empty (raised while auditing shard selection; the audit itself found no zero-test shard: every sharded run partitions the full suite, e.g. run 28735263674 CE 96+156 = Plus 252).

## How

`resolve-legs.sh` emits an additional `shard_label` matrix field (`shard + 1`, string-typed like its siblings); `smoke.yml` uses it in the job `name:` only. The 0-based `shard` index stays untouched for `smoke-single.yml` inputs, `shard-modules.sh`, and artifact names.

## Tests

`tests/shell/resolve_legs_spec.sh` pins `shard_label` on every expansion path (2-shard expansion, filter/marker collapse, clamp, unset/garbage `SHARDS_INPUT`, string-typing). Red→green: with the spec kept and the script reverted, 9 examples fail; with the change, 29/29 green (full shell suite 336 examples, 0 failures). `shellcheck`, `sh -n`, `actionlint` clean.

## Live validation

Job names on a sharded dispatch of this branch — link in comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ooLjvBBm6oznTBUg9mxVF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shard labeling in CI output so job names now use a clearer, human-friendly shard label.
  * Test leg output now includes a readable shard label alongside the shard index and total count, making shard-related results easier to interpret.

* **Tests**
  * Updated shell coverage to verify the new shard label appears consistently across shard fan-out, single-shard, and clamped-shard scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->