### PR TITLE
dev: defer FreeBSD/PHP/Python version claims to the ci-metadata matrix

### DIFF
--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -22,8 +22,10 @@ name: build-pkg (Linux, portable)
 # docs/misc/version-bump-runbook.md.
 #
 # TARGET facts (ABI, py-flavor, PHP) are INPUTS, never read from this fork's tree:
-# they describe the pfSense the .pkg installs onto (CE 2.8 = FreeBSD 15 / py311 /
-# php 8.3).
+# they describe the pfSense the .pkg installs onto, and every value is derived from
+# the ci-metadata version matrix (supported-versions.json) — no FreeBSD/PHP/Python
+# version is fixed per edition. The bare-dispatch defaults below mirror the current
+# min-CE matrix entry.
 #
 # workflow_dispatch (iterate on the build) + workflow_call (smoke consumes it).
 
@@ -35,15 +37,15 @@ on:
         required: false
         default: "devel"
       abi:
-        description: "Target ABI — match the pfSense base (CE 2.8 = FreeBSD:15:amd64; Plus = FreeBSD:16:amd64)"
+        description: "Target ABI — FreeBSD:<freebsd_major>:<arch> for the target pfSense base, per the ci-metadata version matrix"
         required: false
         default: "FreeBSD:15:amd64"
       py_flavor:
-        description: "Python flavor for dep names (CE 2.8 = py311)"
+        description: "Python flavor for dep names (the matrix entry's py_flavor)"
         required: false
         default: "py311"
       php_version:
-        description: "PHP version for dep names (CE 2.8 = 8.3)"
+        description: "PHP version for dep names (the matrix entry's php_version)"
         required: false
         default: "8.3"
       ports_repo:

--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -17,7 +17,8 @@ name: Repo install (live pfSense VM)
 # but selects the `repo` pytest marker (tests/smoke/test_repo_install.py) instead of
 # `smoke`. The `repo` tests are deselected from `-m smoke`, so the smoke gate never
 # runs them and this never runs the smoke matrix. Each leg builds its own ABI-matched
-# .pkg (CE FreeBSD:15 / Plus FreeBSD:16 — pkg add refuses a cross-major-ABI package).
+# .pkg — pkg add refuses a cross-major-ABI package, and each version's FreeBSD major
+# comes from the ci-metadata version matrix.
 #
 # TRIGGERS: workflow_dispatch (always runs) + a nightly `schedule`. The scheduled run
 # is GATED — it only proceeds when `devel` actually moved since the previous nightly

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -57,15 +57,15 @@ on:
         required: false
         default: "BC:24:11:37:9C:AC"
       abi:
-        description: "Target ABI for the .pkg the smoke leg installs — MUST match the image's pfSense base (CE 2.8 = FreeBSD:15:amd64; Plus 26.03 = FreeBSD:16:amd64). pkg add refuses a cross-major-ABI .pkg. The fan-out passes FreeBSD:<matrix.freebsd_major>:amd64."
+        description: "Target ABI for the .pkg the smoke leg installs — MUST match the image's pfSense base, per the ci-metadata version matrix. pkg add refuses a cross-major-ABI .pkg. The fan-out passes FreeBSD:<matrix.freebsd_major>:amd64."
         required: false
         default: "FreeBSD:15:amd64"
       php_version:
-        description: "PHP version for the .pkg's dep names (CE 2.8 = 8.3; Plus 26.03 = 8.5). The fan-out passes matrix.php_version."
+        description: "PHP version for the .pkg's dep names, per the ci-metadata version matrix. The fan-out passes matrix.php_version."
         required: false
         default: "8.3"
       py_flavor:
-        description: "Python flavor for the .pkg's dep names (CE/Plus = py311). The fan-out passes matrix.py_flavor."
+        description: "Python flavor for the .pkg's dep names, per the ci-metadata version matrix. The fan-out passes matrix.py_flavor."
         required: false
         default: "py311"
       pytest_marker:
@@ -119,17 +119,17 @@ on:
         type: string
         default: "BC:24:11:37:9C:AC"
       abi:
-        description: "Target ABI for the .pkg the smoke leg installs — MUST match the image's pfSense base (CE 2.8 = FreeBSD:15:amd64; Plus 26.03 = FreeBSD:16:amd64). pkg add refuses a cross-major-ABI .pkg. The fan-out passes FreeBSD:<matrix.freebsd_major>:amd64."
+        description: "Target ABI for the .pkg the smoke leg installs — MUST match the image's pfSense base, per the ci-metadata version matrix. pkg add refuses a cross-major-ABI .pkg. The fan-out passes FreeBSD:<matrix.freebsd_major>:amd64."
         required: false
         type: string
         default: "FreeBSD:15:amd64"
       php_version:
-        description: "PHP version for the .pkg's dep names (CE 2.8 = 8.3; Plus 26.03 = 8.5). The fan-out passes matrix.php_version."
+        description: "PHP version for the .pkg's dep names, per the ci-metadata version matrix. The fan-out passes matrix.php_version."
         required: false
         type: string
         default: "8.3"
       py_flavor:
-        description: "Python flavor for the .pkg's dep names (CE/Plus = py311). The fan-out passes matrix.py_flavor."
+        description: "Python flavor for the .pkg's dep names, per the ci-metadata version matrix. The fan-out passes matrix.py_flavor."
         required: false
         type: string
         default: "py311"
@@ -190,9 +190,9 @@ jobs:
     with:
       channel: devel
       # Build a .pkg whose ABI + dep names match THIS leg's image. A bare dispatch
-      # keeps the CE 2.8 defaults (FreeBSD:15:amd64 / 8.3 / py311) — byte-identical
-      # to before; the fan-out passes per-leg values so the Plus leg gets a
-      # FreeBSD:16 / php85 .pkg (a FreeBSD:15 .pkg is refused on the Plus base).
+      # keeps the workflow's min-CE defaults; the fan-out passes per-leg values from
+      # the ci-metadata version matrix so each leg gets an ABI/flavor-matched .pkg
+      # (pkg add refuses a cross-major-ABI .pkg).
       abi: ${{ inputs.abi }}
       php_version: ${{ inputs.php_version }}
       py_flavor: ${{ inputs.py_flavor }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -207,8 +207,9 @@ jobs:
   # input + the pfsense_version tag (each input overriding its repo-variable default),
   # exports mac as SMOKE_VM_MAC for the boot, AND builds the leg's .pkg for the
   # matching ABI (FreeBSD:<major>:amd64) + dep flavors. The ABI step is essential:
-  # pkg add refuses a cross-major .pkg, so a CE FreeBSD:15 .pkg cannot install on the
-  # Plus FreeBSD:16 base — each leg must build its own ABI-matched package.
+  # pkg add refuses a cross-major .pkg, so a .pkg built for one leg's FreeBSD major
+  # cannot install on another's — each leg must build its own ABI-matched package,
+  # with every major/flavor coming from the ci-metadata version matrix.
   smoke:
     name: Smoke (${{ matrix.channel }} ${{ matrix.pfsense_version }} shard ${{ matrix.shard_label }}/${{ matrix.shard_total }})
     needs: prepare

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -155,9 +155,10 @@ permissions:
 jobs:
   # Build the branch's .pkg on a plain Linux runner (same builder the smoke gate
   # consumes). ONE build PER ci:true leg (version/ABI), not one global build:
-  # pkg add refuses a cross-major-ABI .pkg, so a CE FreeBSD:15 package cannot
-  # install on the Plus FreeBSD:16 base — each leg needs its own ABI-matched
-  # package. The build matrix is the distinct legs (prepare.build_matrix); each
+  # pkg add refuses a cross-major-ABI .pkg, so a package built for one leg's
+  # FreeBSD major cannot install on another's — each leg needs its own ABI-matched
+  # package (majors/flavors per the ci-metadata version matrix). The build matrix
+  # is the distinct legs (prepare.build_matrix); each
   # leg's artifact is named pfBlockerNG-pkg-<version> and the ui leg downloads the
   # one matching its own version.
   #
@@ -174,8 +175,8 @@ jobs:
     uses: ./.github/workflows/build-pkg-linux.yml
     with:
       channel: devel
-      # Build the leg's .pkg for its own pfSense base (CE=FreeBSD:15/php83,
-      # Plus=FreeBSD:16/php85). A CE-only run keeps the prior defaults.
+      # Build the leg's .pkg for its own pfSense base, with the ABI/php/python
+      # values coming from the leg's version-matrix entry.
       abi: FreeBSD:${{ matrix.freebsd_major }}:amd64
       php_version: ${{ matrix.php_version }}
       py_flavor: ${{ matrix.py_flavor }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -764,9 +764,9 @@ catalog (`meta.conf`/`packagesite.pkg`/`data.pkg`) per ABI, and deploys the whol
 `${ABI}/` tree. The site is replaced each run (no history), so every published version/ABI
 is retained for free and a rollback is a re-deploy.
 
-- **Per-`${ABI}` tree.** One catalog under `…/<ABI>/` (today only `FreeBSD:15:amd64` — CE
-  2.8 and Plus 25.03 share it). The client conf's literal `${ABI}` lets one conf follow the
-  box across a pfSense OS upgrade.
+- **Per-`${ABI}` tree.** One catalog under `…/<ABI>/` per ABI present in the ci-metadata
+  version matrix (`supported-versions.json`). The client conf's literal `${ABI}` lets one
+  conf follow the box across a pfSense OS upgrade.
 - **NONE-signed, TLS-anchored.** No signing key in CI; trust is HTTPS to the Pages host. The
   catalog is served at the project's GitHub Pages URL
   **`https://pfblockerng.github.io/pkg/${ABI}`**.

--- a/docs/build-pkg-portable.md
+++ b/docs/build-pkg-portable.md
@@ -119,7 +119,7 @@ interactive, the tool prompts; otherwise it exits with an error naming the flag.
 
 | Option | Example | Description |
 | --- | --- | --- |
-| `--abi ABI` | `FreeBSD:15:amd64` | The package ABI. CE 2.8 = `FreeBSD:15:amd64`; Plus = `FreeBSD:16:amd64`. Sets the manifest `abi`. |
+| `--abi ABI` | `FreeBSD:15:amd64` | The package ABI (`FreeBSD:<major>:<arch>`), from the target version's entry in the ci-metadata version matrix (`supported-versions.json`). Sets the manifest `abi`. |
 | `--arch TRIPLET` | `freebsd:15:x86:64` | The manifest `arch` triplet. Default: derived from `--abi` (`amd64` → `x86:64`, etc.). |
 | `--py-flavor FLAVOR` | `py311` | The Python flavor used in dependency names (`py311-sqlite3`, …) and the `python<XY>` dep. |
 | `--php VERSION` | `8.3` | The PHP version for the `USES=php` dependency (`php83`, `php83-intl`). Asked **only** when the port uses PHP. |
@@ -303,6 +303,10 @@ the PORTVERSION changes, `PORTREVISION` is removed (reset to 0, no `_N` suffix).
 
 ## Examples
 
+The `--abi` / `--py-flavor` / `--php` values below are the current matrix values for
+the version each example targets — always take them from the ci-metadata version
+matrix (`supported-versions.json`), never treat them as fixed per edition.
+
 ```sh
 # 1) Build the local working tree for CE 2.8 (devel channel), into /tmp.
 python3 scripts/build-pkg-portable.py --ports ../FreeBSD-ports --local-src . \
@@ -319,9 +323,9 @@ python3 scripts/build-pkg-portable.py --ports ../FreeBSD-ports \
     --gh-tagname 3b4b27eb18c12a371d0b80366b8d3f20d201d1d1 \
     --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3 --repo-catalogue auto
 
-# 4) Target pfSense Plus (FreeBSD 16), xz compression, keep the work dir.
+# 4) Target pfSense Plus 26.03, xz compression, keep the work dir.
 python3 scripts/build-pkg-portable.py --ports ../FreeBSD-ports --local-src . \
-    --abi FreeBSD:16:amd64 --py-flavor py311 --php 8.3 \
+    --abi FreeBSD:16:amd64 --py-flavor py311 --php 8.5 \
     --compression xz --keep-work
 
 # 5) Just inspect the plan.

--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -145,7 +145,7 @@ separate from `SMOKE_IMAGE_DIR`.
 ## Building the `.pkg` off-FreeBSD (CI reference)
 
 The portable Linux builder reproduces `make package` for this `NO_BUILD` port. For CE 2.8
-(FreeBSD 15):
+(flag values from the target version's ci-metadata matrix entry):
 
 ```sh
 python3 scripts/build-pkg-portable.py \

--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -145,7 +145,7 @@ separate from `SMOKE_IMAGE_DIR`.
 ## Building the `.pkg` off-FreeBSD (CI reference)
 
 The portable Linux builder reproduces `make package` for this `NO_BUILD` port. For CE 2.8
-(flag values from the target version's ci-metadata matrix entry):
+(values from the CE 2.8 entry in the ci-metadata matrix):
 
 ```sh
 python3 scripts/build-pkg-portable.py \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -233,8 +233,9 @@ python3 scripts/build-pkg-portable.py --ports ../FreeBSD-ports \
     --local-src . --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3 --out /tmp
 
 # or build exactly what the port fetches (a commit/tag with a src/ tree), targeting Plus
+# (flag values from the target version's ci-metadata matrix entry)
 python3 scripts/build-pkg-portable.py --ports ../FreeBSD-ports \
-    --gh-tagname <commit> --abi FreeBSD:16:amd64 --py-flavor py311 --php 8.3
+    --gh-tagname <commit> --abi FreeBSD:16:amd64 --py-flavor py311 --php 8.5
 ```
 
 Needs only python3 (stdlib) + a zstd encoder (`zstd` / `brew install zstd` /

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1381,9 +1381,9 @@ def run_build(args: argparse.Namespace) -> Build:
     # Version-dependent TARGET facts. These are properties of the target pfSense
     # edition+version, NOT of the --ports checkout: that fork tree is a single
     # snapshot whose default versions (e.g. PHP 8.4) need not match what a given
-    # pfSense release ships (CE 2.8 = PHP 8.3, Python 3.11). So never derive them
-    # from the tree — take them explicitly and ask if missing. The repo's
-    # docs/misc/pfSense_versions.md is the authoritative per-version mirror.
+    # pfSense release ships. So never derive them from the tree — take them
+    # explicitly (from the ci-metadata version matrix, supported-versions.json)
+    # and ask if missing. docs/misc/pfSense_versions.md mirrors the same facts.
     #
     # Three such facts affect this tool's output: the ABI (manifest abi/arch), the
     # Python flavor, and the PHP version. `make package` records 12 deps for

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -41,10 +41,10 @@
 # FLAVOR-COLLISION GUARD: identical to build-repo.sh — two .pkg sharing
 # name+version+ABI but differing in php/py flavor (their php*/python*/py*-
 # dependency names) CANNOT coexist in one catalog (the second would silently
-# shadow the first). We FAIL LOUD (exit 1) rather than drop a build. No colliding
-# combo exists today (CE 2.8 + Plus 25.03 are both FreeBSD:15:amd64 / php83 /
-# py311); the fix when one arises is a flavored layout <out>/<ABI>-<php><py>/,
-# intentionally NOT implemented here.
+# shadow the first). We FAIL LOUD (exit 1) rather than drop a build. Whether a
+# colliding combo exists depends on the ci-metadata version matrix (two entries
+# sharing a FreeBSD major with different php/py flavors); the fix when one arises
+# is a flavored layout <out>/<ABI>-<php><py>/, intentionally NOT implemented here.
 #
 # VERSION-KEYED CATALOG DIRS (ADR-20 Phase 3)
 #   Pass --catalog-name <name> (e.g. "ce-2.8", "plus-26.03") to write the catalog

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -43,8 +43,9 @@
 # dependency names) CANNOT coexist in one catalog (the second would silently
 # shadow the first). We FAIL LOUD (exit 1) rather than drop a build. Whether a
 # colliding combo exists depends on the ci-metadata version matrix (two entries
-# sharing a FreeBSD major with different php/py flavors); the fix when one arises
-# is a flavored layout <out>/<ABI>-<php><py>/, intentionally NOT implemented here.
+# sharing a full ABI — FreeBSD major AND arch — with different php/py flavors);
+# the fix when one arises is a flavored layout <out>/<ABI>-<php><py>/,
+# intentionally NOT implemented here.
 #
 # VERSION-KEYED CATALOG DIRS (ADR-20 Phase 3)
 #   Pass --catalog-name <name> (e.g. "ce-2.8", "plus-26.03") to write the catalog

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -26,8 +26,8 @@
 # differing in php/py flavor (their `php*`/`py*-*` dependency names) CANNOT
 # coexist in one catalog — the second would silently shadow the first. We FAIL
 # LOUD rather than drop a build. Whether a colliding combo exists depends on the
-# ci-metadata version matrix (two entries sharing a FreeBSD major with different
-# php/py flavors); when one ever arises, the fix is a flavored layout
+# ci-metadata version matrix (two entries sharing a full ABI — FreeBSD major AND
+# arch — with different php/py flavors); when one ever arises, the fix is a flavored layout
 # `<out>/<ABI>-<php><py>/` (add-repo.sh would then detect + pin the box's flavor).
 # That split is intentionally NOT implemented here — see the guard below.
 #

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -25,11 +25,11 @@
 # FLAVOR-COLLISION GUARD: two .pkg sharing package-name + version + ABI but
 # differing in php/py flavor (their `php*`/`py*-*` dependency names) CANNOT
 # coexist in one catalog — the second would silently shadow the first. We FAIL
-# LOUD rather than drop a build. No colliding combo exists today (CE 2.8 + Plus
-# 25.03 are both FreeBSD:15:amd64 / php83 / py311); when one ever does, the fix
-# is a flavored layout `<out>/<ABI>-<php><py>/` (add-repo.sh would then detect +
-# pin the box's flavor). That split is intentionally NOT implemented here — see
-# the guard below.
+# LOUD rather than drop a build. Whether a colliding combo exists depends on the
+# ci-metadata version matrix (two entries sharing a FreeBSD major with different
+# php/py flavors); when one ever arises, the fix is a flavored layout
+# `<out>/<ABI>-<php><py>/` (add-repo.sh would then detect + pin the box's flavor).
+# That split is intentionally NOT implemented here — see the guard below.
 #
 # LIBPKG PROVENANCE: `pkg repo` is a libpkg op needing the `pkg` binary. On
 # FreeBSD (or the pfSense VM) `pkg` is present. On a Linux CI runner it is NOT in


### PR DESCRIPTION
Comments, workflow input descriptions, and doc examples asserted fixed per-edition versions ("CE = FreeBSD:15/php83", "Plus = FreeBSD:16/php85", "CE/Plus = py311") as if they were constants. Every FreeBSD ABI, PHP, and Python version is purely derived from the ci-metadata version matrix (`supported-versions.json`) — and some of these claims had already drifted stale:

- `scripts/build-repo.sh` + `scripts/build-repo-portable.py`: the flavor-collision note still described "CE 2.8 + Plus 25.03 both FreeBSD:15:amd64 / php83 / py311" — the current matrix has Plus 26.03 on FreeBSD 16 / php 8.5.
- `docs/build-pkg-portable.md`: the "target pfSense Plus" example used `--php 8.3` where the current Plus matrix entry is `8.5`.

## Change

Wording-only sweep (no functional change): reword the stale claims to name the matrix as the source of truth — `build-pkg-linux.yml`, `repo-install.yml`, `smoke-single.yml`, `smoke.yml`, `ui-tests.yml` (header comments + input descriptions), the two repo builders' collision notes, `build-pkg-portable.py`'s target-facts comment, and the two docs. Bare-dispatch workflow defaults are functional fallbacks and stay unchanged.

Deliberately untouched: ADR text + phase RESULTS (point-in-time records), test fixtures, format-transform examples (`FreeBSD:15:amd64 → freebsd-15-amd64`), `test-version-matrix.yml`'s seed assertion (a deliberate canary), and version-anchored facts ("CE 2.8 ships PHP 8.3" — immutable for a released version; `docs/misc/pfSense_versions.md` already names the matrix as SSOT).

## Tests

None — comment/description/doc wording only; no behaviour changes. Gates: `sh -n` + shellcheck clean on `build-repo.sh`, ruff check + format clean on the touched Python, markdownlint `0 error(s)`, all five workflow YAMLs parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG