### PR TITLE
ci: refresh smoke module-durations table on a schedule

### DIFF
--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -1,0 +1,104 @@
+name: Module-durations table refresh
+
+# Rebuild the smoke-suite module-duration table (tests/smoke/module-durations.txt,
+# issue #816) from CI and commit it when it drifts, so scripts/shard-modules.sh
+# keeps balancing the live-VM smoke shards by measured LOAD instead of going stale.
+#
+# WHY a separate workflow (not a step in smoke.yml): smoke.yml's standing
+# invariant is that it NEVER writes any branch. So the aggregate-and-commit runs
+# here, downstream, gated on that run finishing GREEN.
+#
+# Triggered by `workflow_run` after the smoke fan-out completes, but only for the
+# nightly `schedule` run — that is the one guaranteed to be a FULL fan-out (every
+# ci:true leg, whole marker, all module shards). A selective/impacted dispatch
+# runs a subset and would drop rows from the table, so those are ignored. A
+# maintainer can still refresh off-cycle via workflow_dispatch with a run id.
+#
+# SCOPE: this table balances the direct-child tests/smoke/test_*.py modules only.
+# The UI tiers (tests/smoke/ui) are sharded as a unit and are intentionally NOT
+# part of this table (see scripts/shard-modules.sh), so ui-tests.yml is unrelated.
+
+on:
+  workflow_run:
+    workflows: ["Smoke fan-out (all CI legs, live pfSense VM)"]
+    types: [completed]
+  # Manual refresh from a specific, already-finished FULL smoke fan-out.
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Run ID of a completed FULL smoke fan-out whose logs to aggregate."
+        required: true
+
+permissions:
+  contents: write   # commit the refreshed table to devel
+  actions: read     # download the smoke run's artifacts (cross-run)
+
+# One refresh at a time; a newer run supersedes an in-flight one.
+concurrency:
+  group: module-durations-refresh
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    name: Rebuild + commit module-durations.txt
+    runs-on: ubuntu-latest
+    # workflow_run: only the nightly (schedule) full run, and only if it passed.
+    # workflow_dispatch: the operator vouches the given run was a full fan-out.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'schedule')
+    steps:
+      - name: Checkout devel
+        uses: actions/checkout@v6
+        with:
+          ref: devel
+          fetch-depth: 0   # full history so the pre-push rebase can replay cleanly
+
+      - name: Download the smoke run's diagnostics artifacts
+        uses: actions/download-artifact@v8
+        with:
+          run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
+          github-token: ${{ github.token }}
+          pattern: smoke-diagnostics-*
+          path: smoke-artifacts
+
+      - name: Rebuild the module-durations table
+        run: |
+          set -eu
+          # Feed every leg/shard's captured pytest --durations log. module-durations.sh
+          # sums per module BASENAME across all inputs, so input order is irrelevant and
+          # the union of the shards covers the whole suite (issue #816).
+          LOGS=$(find smoke-artifacts -name pytest-durations.log | LC_ALL=C sort)
+          if [ -z "$LOGS" ]; then
+            echo "::error::no pytest-durations.log found in the smoke artifacts — nothing to aggregate."
+            exit 1
+          fi
+          echo "Aggregating these shard logs:"
+          printf '  %s\n' $LOGS
+          # shellcheck disable=SC2086  # deliberate word-split: one arg per log path (all ASCII)
+          sh scripts/module-durations.sh $LOGS > tests/smoke/module-durations.txt
+          echo "=== refreshed table ==="
+          cat tests/smoke/module-durations.txt
+
+      - name: Commit the refreshed table (only if it changed)
+        run: |
+          set -eu
+          if git diff --quiet -- tests/smoke/module-durations.txt; then
+            echo "module-durations.txt unchanged — nothing to commit."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add tests/smoke/module-durations.txt
+          git commit -m "tests/smoke: refresh module-durations table from nightly smoke run"
+          # devel can advance between the nightly smoke start and now — rebase onto the
+          # live tip and retry the push a few times to absorb a concurrent landing.
+          n=0
+          until git push origin HEAD:devel; do
+            n=$((n + 1))
+            [ "$n" -le 5 ] || { echo "::error::push failed after $n rebase attempts."; exit 1; }
+            echo "push rejected — rebasing onto origin/devel (attempt $n) and retrying."
+            git pull --rebase origin devel
+          done
+          echo "Committed refreshed module-durations.txt to devel."

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -9,10 +9,14 @@ name: Module-durations table refresh
 # here, downstream, gated on that run finishing GREEN.
 #
 # Triggered by `workflow_run` after the smoke fan-out completes, but only for the
-# nightly `schedule` run — that is the one guaranteed to be a FULL fan-out (every
-# ci:true leg, whole marker, all module shards). A selective/impacted dispatch
-# runs a subset and would drop rows from the table, so those are ignored. A
-# maintainer can still refresh off-cycle via workflow_dispatch with a run id.
+# nightly `schedule` run — that is the one whose EVENT is unambiguously a FULL
+# fan-out (every ci:true leg, whole marker, all module shards). Other full runs
+# exist (e.g. version-tracker.yml dispatches `scope=full` after a version bump),
+# but at the workflow_run level a `scope=full` dispatch is indistinguishable from
+# a bare/`impacted` dispatch (both are `event == 'workflow_dispatch'`), and an
+# impacted run covers only a subset and would drop rows. So the AUTO refresh is
+# restricted to the nightly; refresh any other full run on demand via
+# workflow_dispatch with its run id (or just let the next nightly reconcile it).
 #
 # SCOPE: this table balances the direct-child tests/smoke/test_*.py modules only.
 # The UI tiers (tests/smoke/ui) are sharded as a unit and are intentionally NOT
@@ -54,6 +58,24 @@ jobs:
         with:
           ref: devel
           fetch-depth: 0   # full history so the pre-push rebase can replay cleanly
+
+      - name: Verify the source smoke run finished green
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
+        run: |
+          set -eu
+          # The workflow_run auto-trigger is already gated on conclusion=='success'
+          # in the job `if:`, but a manual workflow_dispatch names an ARBITRARY
+          # run_id (completed, not necessarily green). Refuse a partial/failed run
+          # here rather than aggregate its incomplete logs into a row-dropped table
+          # and commit it to devel.
+          conc=$(gh run view "$RUN_ID" --json conclusion -q .conclusion)
+          echo "source smoke run $RUN_ID conclusion: $conc"
+          [ "$conc" = success ] || {
+            echo "::error::source run $RUN_ID concluded '$conc', not success — refusing to aggregate."
+            exit 1
+          }
 
       - name: Download the smoke run's diagnostics artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -558,7 +558,10 @@ jobs:
           SMOKE_STUB_DNS_ADDR: "127.0.0.1"
           SMOKE_STUB_DNS_PORT: "53"
         run: |
-          set -eu
+          # pipefail is REQUIRED: run-smoke.sh's output is teed to a log below, so
+          # its exit status must survive the pipe or a genuine smoke failure would
+          # read green. GitHub's default shell already sets it; make it explicit.
+          set -euo pipefail
           # pfSense's System DNS is 10.0.2.2 (libslirp's host alias); libslirp NATs
           # guest->10.0.2.2:53 to the runner's 127.0.0.1:53 (the mock), the SAME host-alias
           # path the mock-feed HTTP server already rides. So the ONLY runner-side prep is
@@ -576,7 +579,13 @@ jobs:
           set -- --paths tests/smoke -m "${PYTEST_MARKER}" --timeout 30
           [ -n "${PYTEST_FILTER:-}" ] && set -- "$@" --filter "${PYTEST_FILTER}"
           set -- "$@" --shard "${SHARD}" --shard-total "${SHARD_TOTAL}"
-          sh scripts/run-smoke.sh "$@"
+          # Tee the run into the diagnostics dir so its pytest --durations=0 lines
+          # ride the smoke-diagnostics artifact. module-durations.yml aggregates
+          # every leg/shard's log after a green nightly to refresh the sharding
+          # duration table (issue #816). Stderr is folded in — the parser ignores
+          # non-duration lines. pipefail (above) keeps run-smoke.sh's exit status.
+          mkdir -p smoke-diag
+          sh scripts/run-smoke.sh "$@" 2>&1 | tee smoke-diag/pytest-durations.log
 
       # ADR-24 / ADR-47 P5: runner-side scrub delegated to the shared script.
       # resolve-legs.sh scrub --root smoke-diag handles: non-CE screenshot deletion,

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -560,7 +560,9 @@ jobs:
         run: |
           # pipefail is REQUIRED: run-smoke.sh's output is teed to a log below, so
           # its exit status must survive the pipe or a genuine smoke failure would
-          # read green. GitHub's default shell already sets it; make it explicit.
+          # read green. This step leaves `shell:` unset, so the runner uses `bash -e`
+          # WITHOUT pipefail (only an explicit `shell: bash` implies `-o pipefail`) —
+          # this `set -o pipefail` is what actually turns it on.
           set -euo pipefail
           # pfSense's System DNS is 10.0.2.2 (libslirp's host alias); libslirp NATs
           # guest->10.0.2.2:53 to the runner's 127.0.0.1:53 (the mock), the SAME host-alias


### PR DESCRIPTION
## What

Automates regeneration of `tests/smoke/module-durations.txt` (issue #816) instead of the current manual `scripts/module-durations.sh <log>... > tests/smoke/module-durations.txt` step. Keeps `scripts/shard-modules.sh` balancing the live-VM smoke shards by measured load rather than letting the table drift.

## How

- **`smoke-single.yml`** — tee each leg/shard's `pytest --durations=0` output to `smoke-diag/pytest-durations.log` so it rides the existing `smoke-diagnostics-*` artifact. `set -o pipefail` is made explicit so a real smoke failure still fails the step through the tee.
- **`module-durations.yml`** (new) — `workflow_run` after the smoke fan-out **succeeds**, gated to the **nightly `schedule`** run only (the guaranteed full fan-out; a selective/impacted dispatch runs a subset and would drop rows). Downloads the run's diagnostics artifacts, feeds every shard log through the already-tested `scripts/module-durations.sh`, and commits the refreshed table to `devel` **only when it changed**. A `workflow_dispatch` with a `run_id` allows an off-cycle refresh.

## Why a separate workflow

`smoke.yml`'s standing invariant is that it **never writes any branch**, so the aggregate-and-commit runs downstream, gated on that run finishing green. The push uses `GITHUB_TOKEN`, so it does not recursively re-trigger CI.

## Scope note

This table balances only the direct-child `tests/smoke/test_*.py` modules. The UI tiers (`tests/smoke/ui`) are sharded as a unit and are intentionally excluded by `shard-modules.sh`, so `ui-tests.yml` is unrelated.

## Verification

- Aggregation exercised locally with synthetic CE-shard0 + CE-shard1 + Plus shard logs: `find … | module-durations.sh` produces the correct per-module sums.
- `pipefail`-through-tee confirmed to propagate a non-zero smoke exit.
- `tests/shell/module_durations_spec.sh` green (script unchanged); both workflow YAMLs parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG