### PR TITLE
tests/smoke: run the pfSense VM at Netgate's beta PHP error level

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -601,6 +601,12 @@ def smoke_vm(
         log_path=work / "vm.log",
         boot_timeout=DEFAULT_BOOT_TIMEOUT,
     )
+    # BBcan177: run the VM at the strict PHP error level Netgate uses on its betas,
+    # so smoke + UI tests surface every latent notice / warning / deprecated. One-time,
+    # session-wide (every VM test inherits it); raises loudly if the level doesn't take.
+    from . import helpers
+
+    helpers.enable_strict_php_error_reporting(handle.vm)
     request.session.stash[SMOKE_VM_KEY] = handle.vm
     try:
         yield handle.vm

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -52,7 +52,7 @@ from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 from ..timing import step_min_seconds, timed, timed_step  # issue #605 — per-step timing (PFB_TIMING)
 from .conftest import (
@@ -746,6 +746,173 @@ def _php_kv_array(data: dict[str, str]) -> str:
     """Render a flat dict as a PHP associative-array literal."""
     items = ", ".join(f"{_php_str(k)} => {_php_str(v)}" for k, v in data.items())
     return f"array({items})"
+
+
+# --------------------------------------------------------------------------- #
+# Strict PHP error reporting (BBcan177) — run the VM the way Netgate runs betas
+# --------------------------------------------------------------------------- #
+
+# pfSense's rc.php_ini_setup selects error_reporting by build channel: the low
+# ``E_ERROR | E_PARSE`` on ``-RELEASE`` images (our smoke base) vs the wider
+# ``E_ALL ^ (E_WARNING | E_NOTICE | E_DEPRECATED)`` on beta/dev builds. Netgate raises it
+# on their betas to surface latent PHP issues; we run the smoke + UI VM at that SAME beta
+# level (BBcan177) so a page or reload emitting a structural diagnostic (E_STRICT /
+# E_RECOVERABLE / E_CORE_* / E_COMPILE_* / E_USER_*) trips the guard, plus arg-rich traces
+# (zend.exception_ignore_args=0). It deliberately KEEPS Netgate's mask of the runtime
+# E_WARNING / E_NOTICE / E_DEPRECATED: a plain E_ALL would also flag the pre-existing
+# undefined-array-key / deprecated lines in pfBlockerNG (``?:`` on absent keys) and pfSense
+# core, reddening the gate on issues out of scope for this change.
+_GUEST_PHP_INI = "/usr/local/etc/php.ini"
+# The exact error_reporting Netgate's beta php.ini uses (a PHP ini expression).
+STRICT_PHP_ERROR_REPORTING = "E_ALL ^ (E_WARNING | E_NOTICE | E_DEPRECATED)"
+
+
+def php_effective_error_reporting(vm: SmokeVM, *, timeout: float = 30.0) -> int:
+    """The guest's EFFECTIVE ``error_reporting`` bitmask, read with a bare ``php -r``.
+
+    Bare ``php -r`` — NOT ``pfSsh.php`` — so no pfSense bootstrap can override the
+    level; the returned value reflects ``/usr/local/etc/php.ini`` verbatim, and the
+    output is a plain int with no banner to strip.
+    """
+    res = vm.ssh(PHP_BIN, "-r", "echo error_reporting();", timeout=timeout)
+    if res.returncode != 0:
+        raise RuntimeError(f"reading guest error_reporting failed: {(res.stderr or res.stdout).strip()!r}")
+    return int(res.stdout.strip())
+
+
+def php_constant(vm: SmokeVM, name: str, *, timeout: float = 30.0) -> int:
+    """The guest PHP's value for an integer constant (e.g. ``E_ALL``).
+
+    ``E_ALL`` differs across PHP versions (CE vs Plus), so resolve it ON the box
+    rather than hardcoding a magic int the two editions would disagree on.
+    """
+    res = vm.ssh(PHP_BIN, "-r", f"echo (int)({name});", timeout=timeout)
+    if res.returncode != 0:
+        raise RuntimeError(f"reading guest PHP constant {name} failed: {(res.stderr or res.stdout).strip()!r}")
+    return int(res.stdout.strip())
+
+
+def php_error_log_path(vm: SmokeVM, *, timeout: float = 30.0) -> str:
+    """The guest php.ini ``error_log`` target — where ``log_errors`` writes."""
+    res = vm.ssh(PHP_BIN, "-r", "echo ini_get('error_log');", timeout=timeout)
+    if res.returncode != 0:
+        raise RuntimeError(f"reading guest php error_log path failed: {(res.stderr or res.stdout).strip()!r}")
+    return res.stdout.strip()
+
+
+def guest_file_contains(vm: SmokeVM, path: str, needle: str, *, timeout: float = 30.0) -> bool:
+    """True iff the guest file at ``path`` contains the fixed string ``needle`` (``grep -F -q``)."""
+    res = vm.ssh("/usr/bin/grep", "-F", "-q", "--", needle, path, timeout=timeout)
+    return res.returncode == 0
+
+
+_FPM_PROBE_FILE = "/usr/local/www/pfb_smoke_er_probe.php"
+_FPM_PROBE_URL = "/pfb_smoke_er_probe.php"
+
+
+def php_fpm_effective_error_reporting(vm: SmokeVM, get: Callable[[str], Any], *, timeout: float = 30.0) -> int:
+    """The php-fpm (GUI SAPI) EFFECTIVE ``error_reporting``, via a throwaway webroot probe.
+
+    A bare ``php -r`` proves only the CLI SAPI; the render tier depends on php-fpm
+    WORKERS running at the raised level, which the reload could miss. Drop a one-line PHP
+    probe into the webroot, GET it (nginx → php-fpm executes it in a WORKER), read the
+    level, then remove the probe. ``get`` is an authenticated ``WebUI.get`` bound method
+    (its request rides the fpm path). The probe is inert (echoes an int) and lives only
+    for the GET on the throwaway smoke VM.
+    """
+    write = vm.ssh(f"printf '%s' '<?php echo error_reporting();' > {_FPM_PROBE_FILE}", timeout=timeout)
+    if write.returncode != 0:
+        raise RuntimeError(f"writing fpm probe {_FPM_PROBE_FILE} failed: {(write.stderr or write.stdout).strip()!r}")
+    try:
+        resp = get(_FPM_PROBE_URL)
+        if resp.status_code != 200:
+            raise RuntimeError(f"fpm probe GET {_FPM_PROBE_URL} -> HTTP {resp.status_code}")
+        body = resp.text.strip()
+        try:
+            return int(body)
+        except ValueError as exc:
+            raise RuntimeError(f"fpm probe returned a non-int error_reporting: {body!r}") from exc
+    finally:
+        vm.ssh("/bin/rm", "-f", _FPM_PROBE_FILE, timeout=timeout)
+
+
+def php_trigger_user_warning(vm: SmokeVM, *, level: str, tag: str, timeout: float = 30.0) -> None:
+    """Fire one ``E_USER_WARNING`` under a chosen ``error_reporting`` level (bare ``php``).
+
+    Proves the level GATES logging: the same trigger is suppressed under the minimal
+    ``E_ERROR | E_PARSE`` and logged under ``E_ALL`` (``log_errors=on`` → ``error_log``).
+    ``level`` is a PHP ini value (``"E_ALL"`` / ``"E_ERROR | E_PARSE"``) applied via
+    ``php -d error_reporting=<level>`` at INI-LOAD — NOT a runtime ``error_reporting()``
+    call — so the process has no E_ALL startup window that could log unrelated startup
+    noise before a runtime downgrade takes effect (the box php.ini is now E_ALL). ``tag``
+    is the logged message, so a caller can grep the log for exactly this trigger.
+    """
+    code = f"trigger_error({_php_str(tag)}, E_USER_WARNING);"
+    res = vm.ssh(PHP_BIN, "-d", f"error_reporting={level}", "-r", code, timeout=timeout)
+    # php exits 0 even after emitting a warning; a nonzero code is a real invocation
+    # failure (bad binary / syntax), not the warning itself — surface it.
+    if res.returncode != 0:
+        raise RuntimeError(f"php user-warning trigger failed: {(res.stderr or res.stdout).strip()!r}")
+
+
+def enable_strict_php_error_reporting(vm: SmokeVM, *, timeout: float = 30.0) -> None:
+    """Set ``error_reporting`` to Netgate's beta mask in the guest php.ini and reload php-fpm.
+
+    Called ONCE per session from the ``smoke_vm`` fixture, before any test, so both
+    the CLI / ``pfSsh.php`` paths AND the webConfigurator (php-fpm) run at the strict
+    level — the way Netgate runs their betas. Fails LOUDLY (expected vs actual) if the
+    level does not take, so the suite never runs believing it is strict when it is not.
+
+    ponytail: ``rc.php_ini_setup`` regenerates php.ini only at BOOT, so this single
+    edit survives the session (deploy / reload never re-run it). If some future path
+    re-runs it mid-session, ``test_smoke_vm_php_error_reporting_is_strict`` fails loud
+    (it re-reads the level post-deploy) — move this to a post-deploy re-apply then.
+    """
+    # Rewrite the two channel-conditional lines rc.php_ini_setup emits (the only ones that
+    # differ RELEASE vs beta): error_reporting -> the beta mask, and zend.exception_ignore_args
+    # -> 0 (arg-rich traces). BSD sed (FreeBSD) needs the empty ``-i ''`` backup arg. Passed as
+    # one sh command line (SmokeVM.ssh routes it through /bin/sh -c), so tcsh never sees the
+    # metachars; the mask's ^ ( ) | are literal in a sed REPLACEMENT and the value carries no '/'.
+    sed = (
+        f"/usr/bin/sed -i '' -E "
+        f"-e 's/^error_reporting[[:space:]]*=.*/error_reporting = {STRICT_PHP_ERROR_REPORTING}/' "
+        f"-e 's/^zend.exception_ignore_args[[:space:]]*=.*/zend.exception_ignore_args=0/' "
+        f"{_GUEST_PHP_INI}"
+    )
+    edit = vm.ssh(sed, timeout=timeout)
+    if edit.returncode != 0:
+        raise RuntimeError(
+            f"setting php error_reporting in {_GUEST_PHP_INI} failed: {(edit.stderr or edit.stdout).strip()!r}"
+        )
+
+    # php-fpm workers cache php.ini at start — SIGUSR2 makes the master gracefully
+    # re-exec (``execvp`` with its original ``-c /usr/local/etc/php.ini`` argv) and
+    # respawn workers at the new level, so the GUI (webConfigurator) picks it up too.
+    # Signal the MASTER only — via its pidfile, else by its ``php-fpm: master`` argv —
+    # NOT ``killall php-fpm`` (that also SIGUSR2s workers, whose default USR2 action is
+    # terminate). FATAL if neither lands: a silently-unreloaded fpm would leave the GUI
+    # at the stale RELEASE level with the render sweep catching nothing (false green).
+    # Never use rc.php-fpm_restart — it re-runs rc.php_ini_setup, which regenerates
+    # php.ini and REVERTS this raise on a RELEASE image.
+    reload_fpm = vm.ssh("/usr/bin/pkill", "-USR2", "-F", "/var/run/php-fpm.pid", timeout=timeout)
+    if reload_fpm.returncode != 0:
+        reload_fpm = vm.ssh("/usr/bin/pkill", "-USR2", "-f", "php-fpm: master", timeout=timeout)
+    if reload_fpm.returncode != 0:
+        raise RuntimeError(
+            f"php-fpm SIGUSR2 reload failed (rc={reload_fpm.returncode}): "
+            f"{(reload_fpm.stderr or reload_fpm.stdout).strip()!r} — the GUI would run at the stale level"
+        )
+
+    # Assert the CLI effective level actually took — source of truth is the box.
+    expected = php_constant(vm, STRICT_PHP_ERROR_REPORTING, timeout=timeout)
+    actual = php_effective_error_reporting(vm, timeout=timeout)
+    if actual != expected:
+        raise AssertionError(
+            "guest php error_reporting did not take:\n"
+            f"  expected: {expected} ({STRICT_PHP_ERROR_REPORTING})\n"
+            f"  actual:   {actual}\n"
+            f"  php.ini:  {_GUEST_PHP_INI}"
+        )
 
 
 def _b64_textarea(lines: list[str]) -> str:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -800,9 +800,24 @@ def php_error_log_path(vm: SmokeVM, *, timeout: float = 30.0) -> str:
     return res.stdout.strip()
 
 
+def php_ini_int(vm: SmokeVM, key: str, *, timeout: float = 30.0) -> int:
+    """The guest's EFFECTIVE integer value for a php.ini directive (bare ``php -r`` ``ini_get``)."""
+    res = vm.ssh(PHP_BIN, "-r", f"echo (int)ini_get({_php_str(key)});", timeout=timeout)
+    if res.returncode != 0:
+        raise RuntimeError(f"reading guest php.ini {key} failed: {(res.stderr or res.stdout).strip()!r}")
+    return int(res.stdout.strip())
+
+
 def guest_file_contains(vm: SmokeVM, path: str, needle: str, *, timeout: float = 30.0) -> bool:
-    """True iff the guest file at ``path`` contains the fixed string ``needle`` (``grep -F -q``)."""
+    """True iff the guest file at ``path`` contains the fixed string ``needle`` (``grep -F -q``).
+
+    grep exits 0 (match) / 1 (no match, including a not-yet-created log) / >1 (other). Only an
+    ssh transport failure (rc 255) is a real read fault worth raising — mirror PhpErrorLogGuard:
+    a missing file legitimately means "does not contain needle", so 1 and 2 both read as absent.
+    """
     res = vm.ssh("/usr/bin/grep", "-F", "-q", "--", needle, path, timeout=timeout)
+    if res.returncode == 255:
+        raise RuntimeError(f"ssh failed grepping guest {path!r}: {(res.stderr or res.stdout).strip()!r}")
     return res.returncode == 0
 
 
@@ -810,17 +825,20 @@ _FPM_PROBE_FILE = "/usr/local/www/pfb_smoke_er_probe.php"
 _FPM_PROBE_URL = "/pfb_smoke_er_probe.php"
 
 
-def php_fpm_effective_error_reporting(vm: SmokeVM, get: Callable[[str], Any], *, timeout: float = 30.0) -> int:
-    """The php-fpm (GUI SAPI) EFFECTIVE ``error_reporting``, via a throwaway webroot probe.
+def php_fpm_probe(vm: SmokeVM, get: Callable[[str], Any], *, warn_tag: str, timeout: float = 30.0) -> int:
+    """Execute a probe through php-fpm: echo the effective ``error_reporting`` AND fire a tagged
+    ``E_USER_WARNING``, so a diagnostic is logged via the REAL GUI SAPI at the box's configured
+    level. Returns the FPM ``error_reporting`` bitmask; the caller asserts the level AND that
+    ``warn_tag`` landed in a watched log candidate — the two facts the render sweep depends on but
+    a bare ``php -r`` cannot show (workers strict; FPM logs where the guard looks).
 
-    A bare ``php -r`` proves only the CLI SAPI; the render tier depends on php-fpm
-    WORKERS running at the raised level, which the reload could miss. Drop a one-line PHP
-    probe into the webroot, GET it (nginx → php-fpm executes it in a WORKER), read the
-    level, then remove the probe. ``get`` is an authenticated ``WebUI.get`` bound method
-    (its request rides the fpm path). The probe is inert (echoes an int) and lives only
-    for the GET on the throwaway smoke VM.
+    ``get`` is an authenticated ``WebUI.get`` bound method (its request rides the fpm path). With
+    ``display_errors=off`` the warning goes to the log, not the body, so the body is just the int.
+    The probe is inert (an int + a tagged warning) and removed after; a failed removal is surfaced
+    loudly rather than leaving a stray webroot file silently.
     """
-    write = vm.ssh(f"printf '%s' '<?php echo error_reporting();' > {_FPM_PROBE_FILE}", timeout=timeout)
+    probe = f"<?php echo error_reporting(); trigger_error({_php_str(warn_tag)}, E_USER_WARNING);"
+    write = vm.ssh(f"printf '%s' {shlex.quote(probe)} > {_FPM_PROBE_FILE}", timeout=timeout)
     if write.returncode != 0:
         raise RuntimeError(f"writing fpm probe {_FPM_PROBE_FILE} failed: {(write.stderr or write.stdout).strip()!r}")
     try:
@@ -833,7 +851,12 @@ def php_fpm_effective_error_reporting(vm: SmokeVM, get: Callable[[str], Any], *,
         except ValueError as exc:
             raise RuntimeError(f"fpm probe returned a non-int error_reporting: {body!r}") from exc
     finally:
-        vm.ssh("/bin/rm", "-f", _FPM_PROBE_FILE, timeout=timeout)
+        rm = vm.ssh("/bin/rm", "-f", _FPM_PROBE_FILE, timeout=timeout)
+        if rm.returncode != 0:
+            print(
+                f"[smoke] WARNING: failed to remove fpm probe {_FPM_PROBE_FILE} "
+                f"(rc={rm.returncode}): {(rm.stderr or rm.stdout).strip()!r} — stray file left in webroot"
+            )
 
 
 def php_trigger_user_warning(vm: SmokeVM, *, level: str, tag: str, timeout: float = 30.0) -> None:
@@ -912,6 +935,13 @@ def enable_strict_php_error_reporting(vm: SmokeVM, *, timeout: float = 30.0) -> 
             f"  expected: {expected} ({STRICT_PHP_ERROR_REPORTING})\n"
             f"  actual:   {actual}\n"
             f"  php.ini:  {_GUEST_PHP_INI}"
+        )
+    # Assert the arg-rich-traces directive took too (the second sed edit) — verify the
+    # EFFECTIVE value, so a silently no-op'd substitution (e.g. an unmatched line) is caught.
+    ignore_args = php_ini_int(vm, "zend.exception_ignore_args", timeout=timeout)
+    if ignore_args != 0:
+        raise AssertionError(
+            f"guest zend.exception_ignore_args did not take: expected 0, got {ignore_args} ({_GUEST_PHP_INI})"
         )
 
 

--- a/tests/smoke/ui/render_oracle.py
+++ b/tests/smoke/ui/render_oracle.py
@@ -43,8 +43,10 @@ if TYPE_CHECKING:
 # real diagnostic SHAPE (see _PHP_DIAGNOSTIC_RE) -- never as a bare word: pages
 # carry the level words in legitimate copy ("a pfSense Notice message", the
 # "Warning: ..." input-error strings on pfblockerng_ip.php), so a bare-substring
-# match false-positives. pfSense renders display_errors into the HTML, so a real
-# Warning/Notice/Fatal still bleeds into the body in one of the shapes below --
+# match false-positives. NOTE: pfSense sets display_errors=off (errors are LOGGED,
+# not echoed -- rc.php_ini_setup), so a diagnostic reaches the body only when app
+# code or pfSense's own handler prints it; the sweep-level log guard (condition (d),
+# PhpErrorLogGuard) is the source-of-truth catch for a logged-but-not-echoed error --
 # exactly the regression class Tier A exists to catch.
 PHP_ERROR_LEVELS: tuple[str, ...] = (
     "Fatal error",
@@ -141,12 +143,15 @@ def evaluate_render(path: str, status_code: int, body: str, markers: tuple[str, 
     return RenderResult(path=path, status_code=status_code, ok=not reasons, reasons=tuple(reasons))
 
 
-# php_error.log candidates, in pfSense preference order. pfSense's webConfigurator
-# FPM pool sets error_log to /var/log/php_error.log; php-fpm.log is the daemon's
-# own log on some builds. We snapshot whichever exist so the guard is robust to
-# the image's exact wiring (confirmed on-box at run time via stat -- CLAUDE.md:
-# don't assume a path, read the effective state).
+# php_error.log candidates, in pfSense preference order. rc.php_ini_setup points
+# php.ini's error_log at /tmp/PHP_errors.log (CLI + php-fpm APPLICATION errors); the
+# webConfigurator FPM pool and some builds also write /var/log/php_error.log /
+# /var/log/php-fpm.log. We snapshot whichever EXIST so the guard is robust to the
+# image's exact wiring -- and the strict-error smoke test pins that the guest's
+# effective ini_get('error_log') is one of these (CLAUDE.md: don't assume a path,
+# read the effective state).
 PHP_ERROR_LOG_CANDIDATES: tuple[str, ...] = (
+    "/tmp/PHP_errors.log",
     "/var/log/php_error.log",
     "/var/log/php-fpm.log",
 )

--- a/tests/smoke/ui/test_strict_php_errors.py
+++ b/tests/smoke/ui/test_strict_php_errors.py
@@ -1,0 +1,119 @@
+"""Strict PHP error reporting on the smoke VM (BBcan177) — evidence tests.
+
+Marker ``ui_render`` — collected by the smoke/ui workflow
+(``pytest tests/smoke -m ui_render --override-ini="addopts="``), the same PR gate
+as the render sweep. These pin the two halves of the change that makes the render
+tier's ``php_error.log`` guard meaningful:
+
+* The session VM is set to Netgate's beta ``error_reporting`` mask
+  (``E_ALL ^ (E_WARNING | E_NOTICE | E_DEPRECATED)``, ``enable_strict_php_error_reporting``
+  in the ``smoke_vm`` fixture) — the level Netgate runs on their betas, so a structural
+  diagnostic is generated and logged instead of silently masked. On the stock ``-RELEASE``
+  image the level is ``E_ERROR | E_PARSE`` (= 5), so
+  :func:`test_smoke_vm_php_error_reporting_is_strict` is red without the raise.
+* :class:`~tests.smoke.ui.render_oracle.PhpErrorLogGuard` watches the file PHP
+  actually logs to. :func:`test_render_log_guard_catches_a_logged_diagnostic` proves
+  a warning logged at a raised level grows a watched file (and one suppressed at the
+  minimal level does not) — so the guard is not a no-op reading an unwritten path.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PHP_ERROR_LOG_CANDIDATES, PhpErrorLogGuard
+
+if TYPE_CHECKING:
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+
+def test_smoke_vm_php_error_reporting_is_strict(deployed_vm: SmokeVM) -> None:
+    """The session VM runs at Netgate's beta error-reporting level, and it survives deploy.
+
+    Netgate raises ``error_reporting`` on their betas to catch latent PHP issues; the
+    ``smoke_vm`` fixture sets every smoke VM to that same mask
+    (``E_ALL ^ (E_WARNING | E_NOTICE | E_DEPRECATED)``) for the same reason. This pins
+    that the raise TOOK and still holds after the package deploy — on the stock
+    ``-RELEASE`` image the level is ``E_ERROR | E_PARSE`` (= 5), so this fails without
+    :func:`~tests.smoke.helpers.enable_strict_php_error_reporting` (the before/after
+    evidence) and would also fail if a deploy/reload path clobbered php.ini.
+    """
+    expected = helpers.php_constant(deployed_vm, helpers.STRICT_PHP_ERROR_REPORTING)
+    actual = helpers.php_effective_error_reporting(deployed_vm)
+    assert actual == expected, (
+        f"expected strict error_reporting {helpers.STRICT_PHP_ERROR_REPORTING} ({expected}) "
+        f"but the guest reports {actual} — the enable_strict_php_error_reporting raise "
+        f"did not take or did not survive deploy"
+    )
+
+
+def test_webconfigurator_php_fpm_runs_strict(webui: WebUI, deployed_vm: SmokeVM) -> None:
+    """The php-fpm (GUI) workers run at the strict level too — not just the CLI SAPI.
+
+    The render tier's whole value is that GUI pages log at the raised level; a reload
+    that delivered its SIGUSR2 but left workers on the stale php.ini would leave the GUI
+    weak with the sweep catching nothing (a false green the coverage mandate forbids). T1
+    proves only the CLI SAPI (bare ``php -r`` reads php.ini directly, independent of fpm).
+    Here we read the FPM SAPI's effective ``error_reporting`` by GETting a probe served
+    through nginx → php-fpm, and pin it to the same masked level.
+    """
+    expected = helpers.php_constant(deployed_vm, helpers.STRICT_PHP_ERROR_REPORTING)
+    actual = helpers.php_fpm_effective_error_reporting(deployed_vm, webui.get)
+    assert actual == expected, (
+        f"php-fpm (GUI) error_reporting is {actual}, expected the beta mask ({expected}) — "
+        f"the SIGUSR2 reload did not move fpm workers to the strict level"
+    )
+
+
+def test_render_log_guard_catches_a_logged_diagnostic(deployed_vm: SmokeVM) -> None:
+    """The log guard watches where PHP logs, and the strict level gates what is logged.
+
+    Scenario: a PHP diagnostic is caught by :class:`PhpErrorLogGuard` only when the
+    strict level is active.
+
+      Given the guest's effective ``ini_get('error_log')`` is a file the guard watches
+      When an ``E_USER_WARNING`` fires under the minimal ``E_ERROR | E_PARSE`` level
+      Then the watched log does NOT grow — the diagnostic is suppressed (off branch)
+      When the same ``E_USER_WARNING`` fires under ``E_ALL``
+      Then the watched log grows and the guard fails — the catch (on branch)
+
+    The path assertion is the anti-no-op guard: if PHP logged somewhere unwatched the
+    growth check could never fire, so this pins ``error_log`` INTO the candidate set.
+    """
+    off_tag = "pfb-strict-smoke-off"
+    on_tag = "pfb-strict-smoke-on"
+
+    # Given: the guard must watch wherever the guest's PHP actually writes errors.
+    log_path = helpers.php_error_log_path(deployed_vm)
+    assert log_path in PHP_ERROR_LOG_CANDIDATES, (
+        f"guest php error_log target {log_path!r} is not watched by PhpErrorLogGuard "
+        f"(candidates: {list(PHP_ERROR_LOG_CANDIDATES)}) — a logged diagnostic would be missed"
+    )
+
+    guard = PhpErrorLogGuard(deployed_vm)
+
+    # When/Then (off branch): under the minimal RELEASE level the E_USER_WARNING is
+    # suppressed, so OUR tagged line never reaches the log. Tag-scoped (not whole-file
+    # size) so incidental churn from another process cannot mask a real regression.
+    helpers.php_trigger_user_warning(deployed_vm, level="E_ERROR | E_PARSE", tag=off_tag)
+    assert not helpers.guest_file_contains(deployed_vm, log_path, off_tag), (
+        f"E_USER_WARNING {off_tag!r} was logged at the minimal level E_ERROR|E_PARSE "
+        f"(expected suppressed) in {log_path}"
+    )
+
+    # When/Then (on branch): at E_ALL the same warning IS logged — the size-based guard
+    # the render sweep uses catches the growth, AND our tagged line is in the verified
+    # error_log (so the growth is proven to be our warning, not candidate churn).
+    guard.snapshot()
+    helpers.php_trigger_user_warning(deployed_vm, level="E_ALL", tag=on_tag)
+    with pytest.raises(AssertionError, match="php_error.log gained new lines"):
+        guard.assert_no_growth()
+    assert helpers.guest_file_contains(deployed_vm, log_path, on_tag), (
+        f"E_USER_WARNING {on_tag!r} was not logged at E_ALL (expected logged) in {log_path}"
+    )

--- a/tests/smoke/ui/test_strict_php_errors.py
+++ b/tests/smoke/ui/test_strict_php_errors.py
@@ -53,21 +53,28 @@ def test_smoke_vm_php_error_reporting_is_strict(deployed_vm: SmokeVM) -> None:
     )
 
 
-def test_webconfigurator_php_fpm_runs_strict(webui: WebUI, deployed_vm: SmokeVM) -> None:
-    """The php-fpm (GUI) workers run at the strict level too — not just the CLI SAPI.
+def test_webconfigurator_php_fpm_logs_diagnostic_to_watched_path(webui: WebUI, deployed_vm: SmokeVM) -> None:
+    """php-fpm runs strict AND its diagnostics reach a watched log candidate.
 
-    The render tier's whole value is that GUI pages log at the raised level; a reload
-    that delivered its SIGUSR2 but left workers on the stale php.ini would leave the GUI
-    weak with the sweep catching nothing (a false green the coverage mandate forbids). T1
-    proves only the CLI SAPI (bare ``php -r`` reads php.ini directly, independent of fpm).
-    Here we read the FPM SAPI's effective ``error_reporting`` by GETting a probe served
-    through nginx → php-fpm, and pin it to the same masked level.
+    The render sweep's value is that a GUI page emitting a PHP diagnostic under the raised
+    level trips ``PhpErrorLogGuard``. That needs two facts a bare ``php -r`` cannot show: the
+    php-fpm WORKERS run strict, and php-fpm logs to a path the guard WATCHES. Fire a tagged
+    ``E_USER_WARNING`` from an fpm-served probe (the real GUI SAPI at the box's configured
+    level), then assert the fpm ``error_reporting`` is the mask AND the tagged line landed in a
+    watched candidate. If php-fpm's pool ever redirected ``error_log`` off the candidate list
+    this fails loudly — otherwise the sweep would silently miss every real page error (T1 and
+    the CLI log-catch below cannot see that: they read the CLI SAPI, not fpm's worker path).
     """
     expected = helpers.php_constant(deployed_vm, helpers.STRICT_PHP_ERROR_REPORTING)
-    actual = helpers.php_fpm_effective_error_reporting(deployed_vm, webui.get)
-    assert actual == expected, (
-        f"php-fpm (GUI) error_reporting is {actual}, expected the beta mask ({expected}) — "
+    tag = "pfb-fpm-smoke-diag"
+    level = helpers.php_fpm_probe(deployed_vm, webui.get, warn_tag=tag)
+    assert level == expected, (
+        f"php-fpm (GUI) error_reporting is {level}, expected the beta mask ({expected}) — "
         f"the SIGUSR2 reload did not move fpm workers to the strict level"
+    )
+    assert any(helpers.guest_file_contains(deployed_vm, c, tag) for c in PHP_ERROR_LOG_CANDIDATES), (
+        f"an fpm-logged diagnostic {tag!r} reached none of the watched candidates "
+        f"{list(PHP_ERROR_LOG_CANDIDATES)} — the render sweep's PhpErrorLogGuard would miss real page errors"
     )
 
 


### PR DESCRIPTION
## What

Netgate raises `error_reporting` on their betas to surface latent PHP issues (suggested by BBcan177). This runs the smoke/UI VM at that same beta level so a page or reload emitting a structural diagnostic trips the render tier's `php_error.log` guard instead of being silently masked at the RELEASE default (`E_ERROR | E_PARSE`).

- The `smoke_vm` fixture sets `error_reporting = E_ALL ^ (E_WARNING | E_NOTICE | E_DEPRECATED)` + `zend.exception_ignore_args=0` in the guest php.ini once per session, then SIGUSR2-reloads php-fpm (fatal on failure) so the webConfigurator inherits it. The CLI / `pfSsh.php` paths re-read php.ini per call.
- `PhpErrorLogGuard` now also watches `/tmp/PHP_errors.log` — php.ini's actual `error_log` target per `rc.php_ini_setup`.
- Three `ui_render` evidence tests: the CLI level took and survived deploy; the php-fpm worker level is strict (read via a throwaway webroot probe executed by an fpm worker); and the guard catches a warning logged at a raised level but not one suppressed at the minimal level (tag-bound, both branches).

## Why the Netgate mask, not plain E_ALL

Netgate's own beta level *masks* the runtime `E_WARNING | E_NOTICE | E_DEPRECATED`. Plain `E_ALL` is stricter than what Netgate actually runs and would redden the render gate on pre-existing undefined-array-key (`?:` on absent keys) and deprecated lines in pfBlockerNG and pfSense core — out of scope here. The mask surfaces the structural diagnostics (E_STRICT / E_RECOVERABLE / E_CORE_* / E_USER_*) plus arg-rich traces without that flood.

## Validation

Live-VM `ui_render` smoke on CE 2.8: **86 passed, 0 skipped, 0 failed**. The full render sweep stays green at the mask level (no blast-radius regression — every page including `threats_port` and the `category_edit_*` pages passes), and the three new evidence tests pass on the real VM.

Run: https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28746455876

🤖 Generated with [Claude Code](https://claude.com/claude-code)
