### PR TITLE
scripts: add pfb-downgrade-prep.sh devops downgrade tool + tests

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -103,6 +103,46 @@ downgrade to LOWER build via `pkg delete` + reinstall → assert the stored conf
 preserved (sane reads, behaviour intact) AND the DNSBL probe still returns VIP. Skips cleanly
 when `SMOKE_PKG`/`repo_vm` is absent.
 
+## Downgrade-preparation tool — structural reversals the config layer can't cover
+
+The adapter/rollback contract above covers **config.xml scalar values**. A 4.0.x → pre-4.0.x
+downgrade also has two **structural** (filesystem / cron) changes that a config adapter cannot
+reverse and that do **not** self-heal on an older release:
+
+1. **Relocated custom list scripts.** On upgrade, `pfblockerng_install.inc` moves a user's
+   `{ip,dnsbl}_{pre,post}_*.{sh,py}` scripts from the package root into `list_scripts/`. A
+   pre-4.0.x release resolves list scripts against the package **root only**, so a moved script
+   silently stops running after a downgrade.
+2. **The ADR-43 `tick` cron.** The `pfblockerng.php tick` entry replaced the older
+   `cron`/`dcc`/`ss_refresh`/`bl` fleet; an older release has no `tick` verb, so the entry becomes
+   an orphan and the update fleet is absent until the older release re-syncs.
+
+Everything else the upgrade changed is already downgrade-safe: new-in-4.0.x config keys are
+**ignored** by an older release (inert, preserved for roll-forward), and the `.md5` →
+`.xxhash128` feed sidecars and the `.tar.bz2` → `.tar.zst` MFS archive **self-heal** on the next
+feed update / rebuild.
+
+**`scripts/pfb-downgrade-prep.sh`** reverses exactly those two non-self-healing changes. It is a
+**dev/ops-only** POSIX-sh tool — **not shipped** in the package (release archives are `src/` only) —
+that an operator copies to the appliance and runs as **root, before** the `pkg` downgrade (never
+fired automatically — a normal upgrade or uninstall must not trigger it):
+
+- Moves custom list scripts back to the package root, **skipping shipped scripts by name**
+  (`ip_pre_AWS_*.sh`, `aws_region_prefixes.sh` — the only files pfBlockerNG ships in `list_scripts/`),
+  so a shipped AWS wrapper is never moved. No pkg query is involved. Caveat: a user script named
+  exactly like a shipped wrapper is treated as shipped and left in place — the shipped namespace is
+  reserved.
+- Removes the `tick` cron via `pfSsh.php` (the shipped `install_cron_job()`), so config.xml and the
+  live crontab are rewritten cleanly.
+
+It is **idempotent** (a second run restores nothing and reports the tick cron already gone) and
+prints a short report of what it did.
+
+Coverage: `tests/shell/pfb_downgrade_prep_spec.sh` (shellspec — the file-move logic, the shipped-name
+gate, before/after, idempotency, skip-shipped, skip-existing, and the tick-cron output parsing via a
+fake `pfSsh.php`) and `tests/smoke/test_downgrade_prepare.py` (the tool end-to-end on a live VM,
+`repo` marker — real file moves + real `install_cron_job` tick removal).
+
 ## Foreign-key exclusion list (use `config_*_path` directly — NOT via `PfbConfig`)
 
 The following `installedpackages/pfblockerng*` paths are **not** registered in `pfb_cfg_registry()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ ignore = [
 # re-export idiom, not real shadowing. F811 is suppressed only for these files.
 "tests/smoke/test_software_update.py"              = ["F811"]
 "tests/smoke/test_upgrade_config_stability.py"  = ["F811"]
+"tests/smoke/test_downgrade_prepare.py"         = ["F811"]
 "tests/smoke/test_pkg_op_teardown.py"           = ["F811"]
 
 [tool.ruff.lint.isort]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -177,6 +177,7 @@ in `read-version-matrix.sh`.
 | --- | --- |
 | [`install-from-repo.sh`](install-from-repo.sh) | **First-time install** onto a clean pfSense from `src/` — no Netgate pkg. |
 | [`deploy.sh`](deploy.sh) | Fast code update of an **already-installed** pfBlockerNG: rsync `src/` + restart unbound/nginx. |
+| [`pfb-downgrade-prep.sh`](pfb-downgrade-prep.sh) | **Before rolling the package back** to a pre-4.0.x release: run on the box as root to reverse the two non-self-healing 4.0.x changes — restore custom `list_scripts/` pre/post scripts to the package root, and remove the ADR-43 `tick` cron. |
 | [`setup-hooks.sh`](setup-hooks.sh) | Point git at `.githooks` (run once after cloning). |
 | [`update-pfsense-stubs.py`](update-pfsense-stubs.py) | Regenerate `stubs/pfsense/` after a CE bump. |
 

--- a/scripts/pfb-downgrade-prep.sh
+++ b/scripts/pfb-downgrade-prep.sh
@@ -1,0 +1,148 @@
+#!/bin/sh
+# pfb-downgrade-prep.sh — prepare a pfBlockerNG 4.0.x install for a downgrade to a
+# pre-4.0.x release, so rolling the package back is clean.
+#
+# Dev/ops-only tool: NOT shipped in the package (release archives are src/ only).
+# Copy it to the appliance and run it there as root, BEFORE the `pkg` downgrade.
+#
+#   scp scripts/pfb-downgrade-prep.sh root@<box>:/tmp/
+#   ssh root@<box> 'sh /tmp/pfb-downgrade-prep.sh'
+#   ssh root@<box> 'pkg delete pfSense-pkg-pfBlockerNG-devel && pkg install <older>'
+#
+# It reverses the two 4.0.x changes a pre-4.0.x release cannot cope with and that do
+# NOT self-heal:
+#
+#   1. Custom list pre/post scripts relocated into list_scripts/ on upgrade — a
+#      pre-4.0.x release resolves list scripts against the package ROOT only, so a
+#      moved script silently stops running. They are moved back to the root.
+#   2. The ADR-43 `pfblockerng.php tick` cron entry (which replaced the older
+#      cron/dcc/ss_refresh/bl fleet) is removed, so the downgraded release
+#      re-establishes its own schedule on its next sync instead of leaving an
+#      orphan tick cron behind that it has no verb to run.
+#
+# Everything else the upgrade changed is already downgrade-safe: new-in-4.0.x config
+# keys are ignored by an older release (inert, preserved for roll-forward), and the
+# .md5 -> .xxhash128 feed sidecars and the .tar.bz2 -> .tar.zst MFS archive self-heal
+# on the next feed update / rebuild.
+#
+# Idempotent: a second run restores nothing (scripts already at the root) and reports
+# the tick cron already gone.
+#
+# Tests: tests/shell/pfb_downgrade_prep_spec.sh (shellspec — the file-move logic and
+# the shipped-name gate) and tests/smoke/test_downgrade_prepare.py (the live tool
+# end-to-end on a real VM).
+
+# Paths are env-overridable so the pure functions are unit-testable off-appliance.
+PFB_PKGDIR="${PFB_PKGDIR:-/usr/local/pkg/pfblockerng}"
+PFB_LISTDIR="${PFB_LISTDIR:-${PFB_PKGDIR}/list_scripts}"
+PFB_PFSSH="${PFB_PFSSH:-/usr/local/sbin/pfSsh.php}"
+
+# The {ip,dnsbl}_{pre,post}_*.{sh,py} name space, enumerated (POSIX sh has no brace
+# glob). Single source of truth for what a "list script" is.
+PFB_LIST_SCRIPT_GLOBS='ip_pre_*.sh ip_pre_*.py ip_post_*.sh ip_post_*.py dnsbl_pre_*.sh dnsbl_pre_*.py dnsbl_post_*.sh dnsbl_post_*.py'
+
+# pfb_is_shipped_list_script <path>
+# Exit 0 iff the basename is a SHIPPED list script that must NOT be moved to the
+# package root (moving a shipped file would leave a stray duplicate the downgrade's
+# `pkg delete` cannot account for). pfBlockerNG ships only the AWS region wrappers
+# and aws_region_prefixes.sh in list_scripts/, so a name gate is sufficient and needs
+# no pkg query. Caveat: a user script named exactly like a shipped wrapper
+# (ip_pre_AWS_*.sh) is treated as shipped and left in place — the shipped namespace is
+# reserved, so this is an accepted, documented edge.
+pfb_is_shipped_list_script() {
+	case "$(basename "$1")" in
+		ip_pre_AWS_*.sh|aws_region_prefixes.sh) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+# pfb_restore_list_scripts
+# Move a user's custom list scripts from list_scripts/ back to the package root,
+# skipping shipped scripts and never clobbering a same-named file already at the root.
+# Prints the number restored to stdout; diagnostics go to stderr.
+pfb_restore_list_scripts() {
+	_restored=0
+	[ -d "$PFB_LISTDIR" ] || { echo "$_restored"; return 0; }
+	# shellcheck disable=SC2086  # deliberate word-split: PFB_LIST_SCRIPT_GLOBS is a list of patterns.
+	for _glob in $PFB_LIST_SCRIPT_GLOBS; do
+		# $_glob is unquoted on purpose so the shell expands the wildcard; a
+		# non-matching pattern stays literal and is skipped by the -f test.
+		# shellcheck disable=SC2086  # deliberate glob expansion of the pattern.
+		for _src in "$PFB_LISTDIR"/$_glob; do
+			[ -f "$_src" ] || continue
+			if pfb_is_shipped_list_script "$_src"; then
+				continue
+			fi
+			_dest="${PFB_PKGDIR}/$(basename "$_src")"
+			if [ -e "$_dest" ]; then
+				echo "pfb-downgrade-prep: not overwriting existing ${_dest}; left $(basename "$_src") in list_scripts/" >&2
+				continue
+			fi
+			if mv "$_src" "$_dest"; then
+				chmod 0755 "$_dest" 2>/dev/null
+				_restored=$((_restored + 1))
+			else
+				echo "pfb-downgrade-prep: failed to move ${_src} -> ${_dest}" >&2
+			fi
+		done
+	done
+	echo "$_restored"
+}
+
+# pfb_remove_tick_cron
+# Remove the ADR-43 `pfblockerng.php tick` cron entry via pfSsh.php, which calls the
+# shipped install_cron_job() so config.xml + the live crontab are rewritten cleanly.
+# Prints "removed" / "absent" to stdout; returns non-zero (and prints to stderr) if
+# pfSsh.php is unavailable.
+pfb_remove_tick_cron() {
+	if [ ! -f "$PFB_PFSSH" ]; then
+		echo "pfb-downgrade-prep: pfSsh.php not found at ${PFB_PFSSH}; cannot remove the tick cron" >&2
+		return 2
+	fi
+	# Heredoc is quoted ('PHP') so the shell passes the PHP through verbatim. The
+	# trailing `exec`/`exit` are pfSsh.php's run-buffer / quit protocol, not PHP.
+	_out=$("$PFB_PFSSH" <<'PHP'
+$present = FALSE;
+foreach (config_get_path('cron/item', array()) as $i) {
+	if (strpos($i['command'] ?? '', 'pfblockerng.php tick') !== FALSE) { $present = TRUE; break; }
+}
+if ($present) { install_cron_job('pfblockerng.php tick', FALSE); echo "PFB_TICK_REMOVED\n"; }
+else { echo "PFB_TICK_ABSENT\n"; }
+exec
+exit
+PHP
+	)
+	case "$_out" in
+		*PFB_TICK_REMOVED*) echo removed ; return 0 ;;
+		*PFB_TICK_ABSENT*)  echo absent  ; return 0 ;;
+		*)
+			echo "pfb-downgrade-prep: unexpected pfSsh.php output while removing the tick cron: ${_out}" >&2
+			return 1
+			;;
+	esac
+}
+
+# pfb_downgrade_prep_main — orchestrate both reversals and report.
+pfb_downgrade_prep_main() {
+	if [ "$(id -u 2>/dev/null)" != '0' ]; then
+		echo "pfb-downgrade-prep: must run as root (it moves package files and edits config.xml)" >&2
+		return 1
+	fi
+
+	_restored=$(pfb_restore_list_scripts)
+	if _tick=$(pfb_remove_tick_cron); then
+		:
+	else
+		_tick='ERROR (see stderr)'
+	fi
+
+	echo "pfBlockerNG downgrade preparation:"
+	echo "  Custom list scripts restored to package root: ${_restored}"
+	echo "  ADR-43 tick cron entry: ${_tick}"
+}
+
+# Run main only when executed directly; a shellspec source sets PFB_DOWNGRADE_PREP_SOURCED
+# to load the functions in isolation without running anything.
+if [ -z "${PFB_DOWNGRADE_PREP_SOURCED:-}" ]; then
+	pfb_downgrade_prep_main "$@"
+fi

--- a/scripts/pfb-downgrade-prep.sh
+++ b/scripts/pfb-downgrade-prep.sh
@@ -46,9 +46,16 @@ PFB_LIST_SCRIPT_GLOBS='ip_pre_*.sh ip_pre_*.py ip_post_*.sh ip_post_*.py dnsbl_p
 # package root (moving a shipped file would leave a stray duplicate the downgrade's
 # `pkg delete` cannot account for). pfBlockerNG ships only the AWS region wrappers
 # and aws_region_prefixes.sh in list_scripts/, so a name gate is sufficient and needs
-# no pkg query. Caveat: a user script named exactly like a shipped wrapper
-# (ip_pre_AWS_*.sh) is treated as shipped and left in place — the shipped namespace is
-# reserved, so this is an accepted, documented edge.
+# no pkg query.
+#
+# This gate is a NAME SNAPSHOT of the shipped list_scripts/ contents. Two consequences,
+# both accepted for a dev/ops tool:
+#   - A user script named exactly like a shipped wrapper (ip_pre_AWS_*.sh) is treated
+#     as shipped and left in place — the shipped namespace is reserved.
+#   - If a FUTURE release ships a new list script under a different name, this gate
+#     would move it to the root. MAINTENANCE: keep the patterns below in sync with the
+#     shipped src/usr/local/pkg/pfblockerng/list_scripts/ contents, and run the tool
+#     version that matches the pfBlockerNG version installed on the box.
 pfb_is_shipped_list_script() {
 	case "$(basename "$1")" in
 		ip_pre_AWS_*.sh|aws_region_prefixes.sh) return 0 ;;
@@ -59,9 +66,12 @@ pfb_is_shipped_list_script() {
 # pfb_restore_list_scripts
 # Move a user's custom list scripts from list_scripts/ back to the package root,
 # skipping shipped scripts and never clobbering a same-named file already at the root.
-# Prints the number restored to stdout; diagnostics go to stderr.
+# Prints the number restored to stdout; diagnostics go to stderr. Returns non-zero if
+# any `mv` failed (so the caller can surface a partial failure), zero otherwise. A
+# deliberate no-clobber skip is NOT a failure.
 pfb_restore_list_scripts() {
 	_restored=0
+	_rc=0
 	[ -d "$PFB_LISTDIR" ] || { echo "$_restored"; return 0; }
 	# shellcheck disable=SC2086  # deliberate word-split: PFB_LIST_SCRIPT_GLOBS is a list of patterns.
 	for _glob in $PFB_LIST_SCRIPT_GLOBS; do
@@ -83,10 +93,12 @@ pfb_restore_list_scripts() {
 				_restored=$((_restored + 1))
 			else
 				echo "pfb-downgrade-prep: failed to move ${_src} -> ${_dest}" >&2
+				_rc=1
 			fi
 		done
 	done
 	echo "$_restored"
+	return "$_rc"
 }
 
 # pfb_remove_tick_cron
@@ -101,7 +113,9 @@ pfb_remove_tick_cron() {
 	fi
 	# Heredoc is quoted ('PHP') so the shell passes the PHP through verbatim. The
 	# trailing `exec`/`exit` are pfSsh.php's run-buffer / quit protocol, not PHP.
-	_out=$("$PFB_PFSSH" <<'PHP'
+	# Bounded with timeout(1): pfSsh.php loads AND LOCKS the config, so a concurrent
+	# holder (a sync in progress, a GUI save) could otherwise block us indefinitely.
+	_out=$(timeout 120 "$PFB_PFSSH" <<'PHP'
 $present = FALSE;
 foreach (config_get_path('cron/item', array()) as $i) {
 	if (strpos($i['command'] ?? '', 'pfblockerng.php tick') !== FALSE) { $present = TRUE; break; }
@@ -112,6 +126,11 @@ exec
 exit
 PHP
 	)
+	_tick_rc=$?
+	if [ "$_tick_rc" -eq 124 ]; then
+		echo "pfb-downgrade-prep: pfSsh.php timed out removing the tick cron (config locked by another process?)" >&2
+		return 1
+	fi
 	case "$_out" in
 		*PFB_TICK_REMOVED*) echo removed ; return 0 ;;
 		*PFB_TICK_ABSENT*)  echo absent  ; return 0 ;;
@@ -123,22 +142,28 @@ PHP
 }
 
 # pfb_downgrade_prep_main — orchestrate both reversals and report.
+# Returns non-zero if EITHER reversal failed, so an operator chaining this with the
+# downgrade (`sh pfb-downgrade-prep.sh && pkg delete ... && pkg install <older>`) does
+# NOT proceed on a silent failure (e.g. a tick cron that was never removed).
 pfb_downgrade_prep_main() {
 	if [ "$(id -u 2>/dev/null)" != '0' ]; then
 		echo "pfb-downgrade-prep: must run as root (it moves package files and edits config.xml)" >&2
 		return 1
 	fi
 
-	_restored=$(pfb_restore_list_scripts)
+	_rc=0
+	_restored=$(pfb_restore_list_scripts) || _rc=1
 	if _tick=$(pfb_remove_tick_cron); then
 		:
 	else
 		_tick='ERROR (see stderr)'
+		_rc=1
 	fi
 
 	echo "pfBlockerNG downgrade preparation:"
 	echo "  Custom list scripts restored to package root: ${_restored}"
 	echo "  ADR-43 tick cron entry: ${_tick}"
+	return "$_rc"
 }
 
 # Run main only when executed directly; a shellspec source sets PFB_DOWNGRADE_PREP_SOURCED

--- a/tests/shell/pfb_downgrade_prep_spec.sh
+++ b/tests/shell/pfb_downgrade_prep_spec.sh
@@ -1,0 +1,144 @@
+#shellcheck shell=sh
+# pfb-downgrade-prep.sh spec — the devops downgrade-preparation tool.
+#
+# Covers the file-move logic (restore user list scripts to the package root) and the
+# shipped-name gate, plus the tick-cron removal's OUTPUT PARSING via a fake pfSsh.php.
+# The real install_cron_job() effect of the tick removal is exercised on a live VM by
+# tests/smoke/test_downgrade_prepare.py (this suite runs off-appliance, no pfSsh.php).
+#
+# The tool is sourced as a library: PFB_DOWNGRADE_PREP_SOURCED=1 makes its source guard
+# define the functions and skip main(). PFB_PKGDIR / PFB_LISTDIR / PFB_PFSSH are
+# env-overridable, so every example points them at a private temp sandbox.
+
+Describe 'pfb-downgrade-prep.sh'
+  # shellcheck disable=SC2034  # PFB_DOWNGRADE_PREP_SOURCED is read by the tool's source guard
+  BeforeAll 'PFB_DOWNGRADE_PREP_SOURCED=1; . "${PFB_ROOT}/scripts/pfb-downgrade-prep.sh"'
+
+  setup() {
+    PFBDG_WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbdg.XXXXXX")"
+    PFB_PKGDIR="${PFBDG_WORK}/pkg"
+    PFB_LISTDIR="${PFB_PKGDIR}/list_scripts"
+    mkdir -p "${PFB_LISTDIR}"
+  }
+  cleanup() { rm -rf "${PFBDG_WORK}"; }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  Describe 'pfb_is_shipped_list_script (shipped-name gate)'
+    It 'treats an AWS region wrapper as shipped'
+      When call pfb_is_shipped_list_script "${PFB_LISTDIR}/ip_pre_AWS_US.sh"
+      The status should be success
+    End
+
+    It 'treats aws_region_prefixes.sh as shipped'
+      When call pfb_is_shipped_list_script "${PFB_LISTDIR}/aws_region_prefixes.sh"
+      The status should be success
+    End
+
+    It 'treats a user-authored script as not shipped'
+      When call pfb_is_shipped_list_script "${PFB_LISTDIR}/ip_pre_custom.sh"
+      The status should be failure
+    End
+  End
+
+  Describe 'pfb_restore_list_scripts'
+    It 'moves a user script from list_scripts/ back to the package root'
+      touch "${PFB_LISTDIR}/ip_pre_custom.sh"
+      When call pfb_restore_list_scripts
+      The output should equal 1
+      The path "${PFB_PKGDIR}/ip_pre_custom.sh" should be file
+      The path "${PFB_LISTDIR}/ip_pre_custom.sh" should not be exist
+    End
+
+    It 'restores .sh and .py user scripts across every stage'
+      touch "${PFB_LISTDIR}/ip_pre_a.sh" "${PFB_LISTDIR}/dnsbl_post_b.py"
+      When call pfb_restore_list_scripts
+      The output should equal 2
+      The path "${PFB_PKGDIR}/ip_pre_a.sh" should be file
+      The path "${PFB_PKGDIR}/dnsbl_post_b.py" should be file
+    End
+
+    It 'leaves shipped AWS wrappers in list_scripts/ (never orphaned to the root)'
+      touch "${PFB_LISTDIR}/ip_pre_AWS_US.sh" "${PFB_LISTDIR}/aws_region_prefixes.sh"
+      When call pfb_restore_list_scripts
+      The output should equal 0
+      The path "${PFB_LISTDIR}/ip_pre_AWS_US.sh" should be file
+      The path "${PFB_PKGDIR}/ip_pre_AWS_US.sh" should not be exist
+      The path "${PFB_LISTDIR}/aws_region_prefixes.sh" should be file
+    End
+
+    It 'ignores files that are not list scripts'
+      touch "${PFB_LISTDIR}/readme.txt"
+      When call pfb_restore_list_scripts
+      The output should equal 0
+      The path "${PFB_LISTDIR}/readme.txt" should be file
+    End
+
+    It 'never clobbers a same-named file already at the root'
+      printf ROOT > "${PFB_PKGDIR}/ip_post_dup.sh"
+      printf LIST > "${PFB_LISTDIR}/ip_post_dup.sh"
+      When call pfb_restore_list_scripts
+      The output should equal 0
+      The contents of file "${PFB_PKGDIR}/ip_post_dup.sh" should equal ROOT
+      The path "${PFB_LISTDIR}/ip_post_dup.sh" should be file
+      The stderr should include 'not overwriting'
+    End
+
+    It 'is idempotent — a second run restores nothing'
+      touch "${PFB_LISTDIR}/ip_pre_custom.sh"
+      pfb_restore_list_scripts >/dev/null   # first run relocates it
+      When call pfb_restore_list_scripts    # second run
+      The output should equal 0
+      The path "${PFB_PKGDIR}/ip_pre_custom.sh" should be file
+    End
+
+    It 'is a no-op when list_scripts/ is absent'
+      rm -rf "${PFB_LISTDIR}"
+      When call pfb_restore_list_scripts
+      The output should equal 0
+    End
+  End
+
+  Describe 'pfb_remove_tick_cron (output parsing)'
+    # A fake pfSsh.php: consumes stdin (the PHP snippet) and prints a fixed marker.
+    # Exercises the parse branches without a live box.
+    fake_pfssh() {
+      _fp="${PFBDG_WORK}/pfssh_$1"
+      cat > "${_fp}" <<EOF
+#!/bin/sh
+cat >/dev/null
+echo "$2"
+EOF
+      chmod +x "${_fp}"
+      echo "${_fp}"
+    }
+
+    It 'reports "removed" when pfSsh.php signals removal'
+      PFB_PFSSH="$(fake_pfssh removed PFB_TICK_REMOVED)"
+      When call pfb_remove_tick_cron
+      The output should equal removed
+      The status should be success
+    End
+
+    It 'reports "absent" when there is no tick cron'
+      PFB_PFSSH="$(fake_pfssh absent PFB_TICK_ABSENT)"
+      When call pfb_remove_tick_cron
+      The output should equal absent
+      The status should be success
+    End
+
+    It 'fails when the pfSsh.php output is unrecognised'
+      PFB_PFSSH="$(fake_pfssh junk SOMETHING_ELSE)"
+      When call pfb_remove_tick_cron
+      The status should be failure
+      The stderr should include 'unexpected pfSsh.php output'
+    End
+
+    It 'fails cleanly when pfSsh.php is missing'
+      PFB_PFSSH="${PFBDG_WORK}/nonexistent-pfSsh.php"
+      When call pfb_remove_tick_cron
+      The status should be failure
+      The stderr should include 'pfSsh.php not found'
+    End
+  End
+End

--- a/tests/shell/pfb_downgrade_prep_spec.sh
+++ b/tests/shell/pfb_downgrade_prep_spec.sh
@@ -24,6 +24,29 @@ Describe 'pfb-downgrade-prep.sh'
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
+  # A fake pfSsh.php: consumes stdin (the PHP snippet) and prints a fixed marker.
+  # Exercises the tick-cron parse/aggregation branches without a live box.
+  fake_pfssh() {
+    _fp="${PFBDG_WORK}/pfssh_$1"
+    cat > "${_fp}" <<EOF
+#!/bin/sh
+cat >/dev/null
+echo "$2"
+EOF
+    chmod +x "${_fp}"
+    echo "${_fp}"
+  }
+
+  # Prepend a fake \`id\` on PATH that prints $1 as the uid, so the tool's root guard
+  # can be driven deterministically on a non-root CI host.
+  shim_id() {
+    _bin="${PFBDG_WORK}/bin"
+    mkdir -p "${_bin}"
+    printf '#!/bin/sh\necho %s\n' "$1" > "${_bin}/id"
+    chmod +x "${_bin}/id"
+    PATH="${_bin}:${PATH}"
+  }
+
   Describe 'pfb_is_shipped_list_script (shipped-name gate)'
     It 'treats an AWS region wrapper as shipped'
       When call pfb_is_shipped_list_script "${PFB_LISTDIR}/ip_pre_AWS_US.sh"
@@ -100,19 +123,6 @@ Describe 'pfb-downgrade-prep.sh'
   End
 
   Describe 'pfb_remove_tick_cron (output parsing)'
-    # A fake pfSsh.php: consumes stdin (the PHP snippet) and prints a fixed marker.
-    # Exercises the parse branches without a live box.
-    fake_pfssh() {
-      _fp="${PFBDG_WORK}/pfssh_$1"
-      cat > "${_fp}" <<EOF
-#!/bin/sh
-cat >/dev/null
-echo "$2"
-EOF
-      chmod +x "${_fp}"
-      echo "${_fp}"
-    }
-
     It 'reports "removed" when pfSsh.php signals removal'
       PFB_PFSSH="$(fake_pfssh removed PFB_TICK_REMOVED)"
       When call pfb_remove_tick_cron
@@ -139,6 +149,38 @@ EOF
       When call pfb_remove_tick_cron
       The status should be failure
       The stderr should include 'pfSsh.php not found'
+    End
+  End
+
+  Describe 'pfb_downgrade_prep_main (orchestration + exit status)'
+    It 'refuses to run as non-root'
+      shim_id 1000
+      When call pfb_downgrade_prep_main
+      The status should be failure
+      The stderr should include 'must run as root'
+    End
+
+    It 'succeeds (exit 0) when both reversals succeed and reports them'
+      shim_id 0
+      touch "${PFB_LISTDIR}/ip_pre_custom.sh"
+      PFB_PFSSH="$(fake_pfssh ok PFB_TICK_REMOVED)"
+      When call pfb_downgrade_prep_main
+      The status should be success
+      The output should include 'restored to package root: 1'
+      The output should include 'tick cron entry: removed'
+      The path "${PFB_PKGDIR}/ip_pre_custom.sh" should be file
+    End
+
+    It 'fails (non-zero exit) when the tick-cron removal fails — so a chained downgrade stops'
+      shim_id 0
+      touch "${PFB_LISTDIR}/ip_pre_custom.sh"
+      PFB_PFSSH="${PFBDG_WORK}/nonexistent-pfSsh.php"   # pfSsh.php missing -> tick removal fails
+      When call pfb_downgrade_prep_main
+      The status should be failure
+      The output should include 'tick cron entry: ERROR'
+      The stderr should include 'pfSsh.php not found'
+      # The script restore still happened; only the exit status signals the partial failure.
+      The path "${PFB_PKGDIR}/ip_pre_custom.sh" should be file
     End
   End
 End

--- a/tests/smoke/test_downgrade_prepare.py
+++ b/tests/smoke/test_downgrade_prepare.py
@@ -1,0 +1,251 @@
+"""Live downgrade-preparation contract — the ``scripts/pfb-downgrade-prep.sh`` devops tool.
+
+NOT A SMOKE TEST. Like ``test_upgrade_config_stability.py`` this validates a
+*distribution* mechanic — here the ADMIN-DRIVEN downgrade-preparation step that makes
+rolling the package back to a pre-4.0.x release clean — and carries the ``repo`` marker
+(NOT ``smoke``), so ``pytest -m smoke`` never selects it. It reuses
+``test_repo_install.py``'s hermetic ``file://`` catalog and ``repo_vm`` fixture.
+
+THE TOOL (``scripts/pfb-downgrade-prep.sh``) is a dev/ops-only script — NOT shipped in
+the package — that an operator copies to the appliance and runs as root before the
+``pkg`` downgrade. It reverses the two 4.0.x changes a pre-4.0.x release cannot cope
+with:
+
+  1. Custom list pre/post transform scripts relocated into ``list_scripts/`` on upgrade —
+     an older release resolves list scripts against the package ROOT only, so a moved
+     script silently stops running. They are moved back to the root (shipped AWS wrappers
+     are left in place, recognised by name — no pkg query).
+  2. The ADR-43 ``pfblockerng.php tick`` cron entry is removed via ``pfSsh.php`` (the
+     shipped ``install_cron_job()``), so the downgraded release re-establishes its own
+     schedule instead of leaving an orphan tick cron behind.
+
+WHAT THIS PROVES on a REAL box that the off-box shellspec suite
+(``tests/shell/pfb_downgrade_prep_spec.sh``) cannot: the tool runs end-to-end on the
+appliance — it moves a real file inside the real package dir, LEAVES the shipped AWS
+wrapper in place, and removes the real tick cron from config.xml via ``install_cron_job``.
+
+DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke`` in
+pyproject.toml). Run only via its own dispatch::
+
+    python -m pytest tests/smoke -m repo --override-ini="addopts="
+
+Needs the booted ``repo_vm`` fixture and the branch ``.pkg`` (``SMOKE_PKG``); without
+them it skips cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import tests.smoke.helpers as h
+
+from .conftest import SmokeVM
+from .test_repo_install import (  # noqa: F401
+    NETGATE_REPO_NAME,
+    UPGRADE_REPO_DIR,
+    build_guest_repo,
+    pkg_delete,
+    pkg_install_from_repo,
+    pkg_installed_version,
+    pkg_update,
+    read_compact_version,
+    repo_priority,
+    repo_vm,
+    write_repo_conf,
+)
+
+pytestmark = pytest.mark.repo
+
+_PKGDIR = "/usr/local/pkg/pfblockerng"
+_LISTDIR = f"{_PKGDIR}/list_scripts"
+
+# The dev tool under test and where it is staged on the guest.
+_TOOL_SRC = Path(__file__).resolve().parents[2] / "scripts" / "pfb-downgrade-prep.sh"
+_TOOL_DEST = "/tmp/pfb-downgrade-prep.sh"
+
+# A user's custom list pre/post script (matches {ip,dnsbl}_{pre,post}_*.{sh,py}) — the
+# file the tool must move back to the package root.
+_USER_SCRIPT = "ip_pre_pfbdgsmoke.sh"
+# A shipped AWS region wrapper — the tool must leave it in list_scripts/ (name gate).
+_SHIPPED_SCRIPT = "ip_pre_AWS_US.sh"
+
+_TICK_CMD = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php tick >> /var/log/pfblockerng.log 2>&1"
+
+_TICK_OPEN = "<<<TICK>>>"
+_TICK_CLOSE = "<<<TICKEND>>>"
+
+
+def _file_exists(vm: SmokeVM, path: str) -> bool:
+    """TRUE iff ``path`` is a regular file on the guest (driven via /bin/sh -c by ssh)."""
+    return vm.ssh("test", "-f", path, timeout=30.0).returncode == 0
+
+
+def _scp_to_guest(vm: SmokeVM, local: Path, remote: str) -> None:
+    """Copy a host file to the guest via scp (the tool is dev-only, not in the pkg)."""
+    argv = [
+        "scp",
+        "-i",
+        vm.ssh_key_path,
+        "-P",
+        str(vm.ssh_port),
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "LogLevel=ERROR",
+        str(local),
+        f"{vm.ssh_target}:{remote}",
+    ]
+    result = subprocess.run(argv, capture_output=True, text=True, timeout=60.0, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"scp {local} -> {remote} failed: rc={result.returncode} {result.stderr!r}")
+
+
+def _seed_tick_cron(vm: SmokeVM) -> None:
+    """Plant the ADR-43 tick cron item directly into config.xml (the precondition the
+    tool must remove). Direct config_set_path append — no dependency on install_cron_job
+    being reachable from the pfSsh.php context."""
+    snippet = (
+        "$items = config_get_path('cron/item', array());\n"
+        "$items[] = array('minute' => '*/15', 'hour' => '*', 'mday' => '*', "
+        "'month' => '*', 'wday' => '*', 'who' => 'root', "
+        f"'command' => {h._php_str(_TICK_CMD)});\n"
+        "config_set_path('cron/item', $items);\n"
+        "write_config('pfBlockerNG downgrade smoke: seed ADR-43 tick cron');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=60.0)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_seed_tick_cron failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def _tick_cron_present(vm: SmokeVM) -> bool:
+    """Scan config.xml cron items for the tick command."""
+    snippet = (
+        "$present = '0';\n"
+        "foreach (config_get_path('cron/item', array()) as $i) {\n"
+        "    if (strpos($i['command'] ?? '', 'pfblockerng.php tick') !== false) { $present = '1'; break; }\n"
+        "}\n"
+        f"echo {h._php_str(_TICK_OPEN)} . $present . {h._php_str(_TICK_CLOSE)};"
+    )
+    result = h.php_eval(vm, snippet, timeout=60.0)
+    if result.returncode != 0:
+        raise RuntimeError(f"_tick_cron_present failed: rc={result.returncode} {result.stderr!r}")
+    out = result.stdout
+    start = out.find(_TICK_OPEN)
+    end = out.find(_TICK_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(f"_tick_cron_present: no delimited value in output: {out!r}")
+    return out[start + len(_TICK_OPEN) : end] == "1"
+
+
+@pytest.mark.timeout(600)  # one pkg install cycle + a few ssh probes > the 30s default cap
+def test_downgrade_tool_restores_scripts_and_removes_tick_cron(repo_vm: SmokeVM) -> None:
+    """DOWNGRADE-PREPARATION CONTRACT: ``pfb-downgrade-prep.sh`` restores a relocated
+    custom list script to the package root and removes the ADR-43 tick cron, WITHOUT
+    moving a shipped AWS wrapper.
+
+    Scenario: an admin prepares a 4.0.x box for a downgrade to a pre-4.0.x release.
+      Background: our NONE-signed file:// repo above the Netgate ``pfSense`` repo.
+
+    Given the branch build installed, the dev tool staged on the box, a custom user
+      script ``ip_pre_pfbdgsmoke.sh`` sitting in list_scripts/ (as a prior upgrade would
+      have relocated it), the shipped ``ip_pre_AWS_US.sh`` also in list_scripts/, and an
+      ADR-43 tick cron in config.xml,
+
+    When ``pfb-downgrade-prep.sh`` is run on the box as root,
+
+    Then the custom script is back at the package ROOT and gone from list_scripts/, the
+      shipped AWS wrapper is left untouched in list_scripts/, and the tick cron entry is
+      removed from config.xml.
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file — repo_vm already gated this"
+    assert _TOOL_SRC.is_file(), f"dev tool not found at {_TOOL_SRC}"
+
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+
+    root_user = f"{_PKGDIR}/{_USER_SCRIPT}"
+    list_user = f"{_LISTDIR}/{_USER_SCRIPT}"
+    list_shipped = f"{_LISTDIR}/{_SHIPPED_SCRIPT}"
+    root_shipped = f"{_PKGDIR}/{_SHIPPED_SCRIPT}"
+
+    try:
+        # ------------------------------------------------------------------ #
+        # GIVEN: branch build installed; tool staged; preconditions planted   #
+        # ------------------------------------------------------------------ #
+        pkg_delete(repo_vm)
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [Path(pkg)])
+        write_repo_conf(repo_vm, UPGRADE_REPO_DIR, ours_priority=pfsense_prio + 100)
+        pkg_update(repo_vm)
+        pkg_install_from_repo(repo_vm)
+        installed = pkg_installed_version(repo_vm)
+        expected = read_compact_version(Path(pkg))
+        assert installed == expected, f"expected branch build {expected!r} installed, got {installed!r}"
+
+        # The shipped AWS wrapper must be present after install.
+        assert _file_exists(repo_vm, list_shipped), (
+            f"shipped {_SHIPPED_SCRIPT} not found in list_scripts/ after install — "
+            "the fixture assumption (a shipped AWS wrapper exists) is broken"
+        )
+
+        # Stage the dev tool on the guest.
+        _scp_to_guest(repo_vm, _TOOL_SRC, _TOOL_DEST)
+
+        # Plant the user's custom script in list_scripts/ (as a prior upgrade would have).
+        repo_vm.ssh("/usr/bin/touch", list_user, timeout=30.0)
+        repo_vm.ssh("/bin/chmod", "0755", list_user, timeout=30.0)
+
+        # Seed the ADR-43 tick cron.
+        _seed_tick_cron(repo_vm)
+
+        # BEFORE: user script only in list_scripts/, not at the root; tick cron present.
+        assert _file_exists(repo_vm, list_user), f"precondition: {_USER_SCRIPT} must be in list_scripts/"
+        assert not _file_exists(repo_vm, root_user), f"precondition: {_USER_SCRIPT} must NOT be at the package root yet"
+        assert _tick_cron_present(repo_vm), "precondition: the tick cron must be present before the tool runs"
+
+        # ------------------------------------------------------------------ #
+        # WHEN: the admin runs the downgrade-preparation tool as root         #
+        # ------------------------------------------------------------------ #
+        proc = repo_vm.ssh("/bin/sh", _TOOL_DEST, timeout=120.0)
+        assert proc.returncode == 0, (
+            f"pfb-downgrade-prep.sh failed: rc={proc.returncode} stdout={proc.stdout[-2000:]!r} stderr={proc.stderr!r}"
+        )
+        # The tool reports what it did.
+        assert "restored to package root: 1" in proc.stdout, (
+            f"tool did not report restoring the custom script: {proc.stdout!r}"
+        )
+        assert "tick cron entry: removed" in proc.stdout, f"tool did not report removing the tick cron: {proc.stdout!r}"
+
+        # ------------------------------------------------------------------ #
+        # THEN: script back at the root; shipped untouched; tick cron gone    #
+        # ------------------------------------------------------------------ #
+        assert _file_exists(repo_vm, root_user), (
+            f"AFTER: {_USER_SCRIPT} must be restored to the package root ({root_user})"
+        )
+        assert not _file_exists(repo_vm, list_user), (
+            f"AFTER: {_USER_SCRIPT} must be gone from list_scripts/ ({list_user})"
+        )
+        # Shipped AWS wrapper: never moved to the root, still in list_scripts/.
+        assert _file_exists(repo_vm, list_shipped), (
+            f"AFTER: shipped {_SHIPPED_SCRIPT} must remain in list_scripts/ (name gate, never moved)"
+        )
+        assert not _file_exists(repo_vm, root_shipped), (
+            f"AFTER: shipped {_SHIPPED_SCRIPT} must NOT be moved to the package root"
+        )
+        # Tick cron removed.
+        assert not _tick_cron_present(repo_vm), "AFTER: the ADR-43 tick cron must be removed from config.xml"
+
+    finally:
+        # Remove the user script from both possible locations and the staged tool, then
+        # delete the package + guest repo dir (self-encapsulation: leave no state).
+        repo_vm.ssh("/bin/rm", "-f", root_user, list_user, _TOOL_DEST, timeout=30.0)
+        pkg_delete(repo_vm)
+        repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)

--- a/tests/smoke/test_downgrade_prepare.py
+++ b/tests/smoke/test_downgrade_prepare.py
@@ -146,6 +146,25 @@ def _tick_cron_present(vm: SmokeVM) -> bool:
     return out[start + len(_TICK_OPEN) : end] == "1"
 
 
+def _remove_tick_cron(vm: SmokeVM) -> None:
+    """Strip any pfBlockerNG tick cron item from config.xml (teardown safety net).
+
+    The tool removes it on the happy path, but a body assertion that fires AFTER
+    ``_seed_tick_cron`` would otherwise leave the seeded item on the module-scoped
+    ``repo_vm`` — dirtying config.xml for a sibling test. Self-encapsulation.
+    """
+    snippet = (
+        "$kept = array();\n"
+        "foreach (config_get_path('cron/item', array()) as $i) {\n"
+        "    if (strpos($i['command'] ?? '', 'pfblockerng.php tick') === false) { $kept[] = $i; }\n"
+        "}\n"
+        "config_set_path('cron/item', $kept);\n"
+        "write_config('pfBlockerNG downgrade smoke: cleanup seeded tick cron');\n"
+        "echo 'OK';"
+    )
+    h.php_eval(vm, snippet, timeout=60.0)
+
+
 @pytest.mark.timeout(600)  # one pkg install cycle + a few ssh probes > the 30s default cap
 def test_downgrade_tool_restores_scripts_and_removes_tick_cron(repo_vm: SmokeVM) -> None:
     """DOWNGRADE-PREPARATION CONTRACT: ``pfb-downgrade-prep.sh`` restores a relocated
@@ -244,8 +263,14 @@ def test_downgrade_tool_restores_scripts_and_removes_tick_cron(repo_vm: SmokeVM)
         assert not _tick_cron_present(repo_vm), "AFTER: the ADR-43 tick cron must be removed from config.xml"
 
     finally:
-        # Remove the user script from both possible locations and the staged tool, then
-        # delete the package + guest repo dir (self-encapsulation: leave no state).
+        # Remove the user script from both possible locations and the staged tool, strip
+        # any leftover seeded tick cron (best-effort — a body assert may have fired before
+        # the tool removed it), then delete the package + guest repo dir. Self-encapsulation:
+        # leave no state for a sibling. The tick-cron cleanup must not mask a real failure.
         repo_vm.ssh("/bin/rm", "-f", root_user, list_user, _TOOL_DEST, timeout=30.0)
+        try:
+            _remove_tick_cron(repo_vm)
+        except Exception as exc:  # noqa: BLE001 -- cleanup must not mask the real test outcome
+            print(f"[smoke] _remove_tick_cron failed (non-fatal): {exc}")
         pkg_delete(repo_vm)
         repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)


### PR DESCRIPTION
## Summary

Makes a 4.0.x → pre-4.0.x package downgrade go cleanly, via a **dev/ops-only** tool (not shipped in the package).

The config-value layer is already downgrade-safe by construction (the ADR-28/29 adapters only ever write legacy-vocabulary tokens, and new-in-4.0.x keys are simply ignored by an older release). The gap is on the **structural** side: two 4.0.x changes actively break a downgraded older release and do **not** self-heal:

1. **Relocated custom list scripts** — on upgrade, user `{ip,dnsbl}_{pre,post}_*.{sh,py}` scripts are moved from the package root into `list_scripts/`. A pre-4.0.x release resolves list scripts against the package **root only**, so a moved script silently stops running.
2. **The ADR-43 `tick` cron** — `pfblockerng.php tick` replaced the older `cron`/`dcc`/`ss_refresh`/`bl` fleet; an older release has no `tick` verb, so the entry becomes an orphan and scheduled updates stop until it re-syncs.

Everything else self-heals: new-in-4.0.x config keys are inert on an older release (preserved for roll-forward), and the `.md5` → `.xxhash128` feed sidecars and `.tar.bz2` → `.tar.zst` MFS archive rebuild on the next update.

## Changes

**`scripts/pfb-downgrade-prep.sh`** — a dev/ops-only POSIX-sh tool, **not shipped** in the package (release archives are `src/` only). An operator copies it to the appliance and runs it as **root, before** the `pkg` downgrade — never fired automatically. It reverses exactly the two non-self-healing changes and is idempotent:

- Moves custom list scripts back to the package root, **skipping shipped scripts by name** (`ip_pre_AWS_*.sh`, `aws_region_prefixes.sh` — the only files pfBlockerNG ships in `list_scripts/`), so a shipped AWS wrapper is never moved. No pkg query is involved. (Caveat: a user script named exactly like a shipped wrapper is treated as shipped and left in place — the shipped namespace is reserved.)
- Removes the `tick` cron via `pfSsh.php` (the shipped `install_cron_job()`), so config.xml and the live crontab are rewritten cleanly.

The package itself (`src/`) is untouched.

## Tests

- `tests/shell/pfb_downgrade_prep_spec.sh` — shellspec: the file-move logic, the shipped-name gate, before/after, idempotency, skip-shipped, skip-existing, and the tick-cron output parsing via a fake `pfSsh.php`.
- `tests/smoke/test_downgrade_prepare.py` — the tool end-to-end on a live VM (`repo` marker): real file moves in the real package dir, the shipped AWS wrapper left in place, and the real `install_cron_job` tick removal.

Docs in `docs/misc/config-gateway.md` and `scripts/README.md`.

## Notes

Validated locally: `sh -n` + a direct run of the script's functions against temp dirs (restore/skip/clobber/idempotency and all `pfb_remove_tick_cron` output branches); `ruff`/`mypy tests/`/`markdownlint`/`url-encoding` clean via pre-commit. `shellcheck` + `shellspec` run in CI (not installed on the authoring host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4sMLigFLTMD3nu7NCVn1u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual downgrade-preparation tool for operators rolling back to an earlier release.
  * It restores custom scripts to the expected location and removes an outdated scheduled task before downgrade.

* **Documentation**
  * Expanded install/deploy guidance with downgrade instructions and when to use the new tool.

* **Tests**
  * Added end-to-end and shell coverage to verify script restoration, scheduled task cleanup, and safe handling of built-in files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->