### PR TITLE
ci: plus_shards opt-in lifts the Plus 1-shard smoke cap

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -20,8 +20,8 @@ name: Smoke fan-out (all CI legs, live pfSense VM)
 # booting its own VM; a slice is module-level or, for an oversized module,
 # test-level (issue #855's hybrid split via scripts/shard-modules.sh). A
 # -k-narrowed run or a non-'smoke' marker collapses back to 1 shard, and a
-# Plus leg is always hard-capped at 1 (concurrent Netgate-side check-ins from
-# parallel Plus boots are untested). The AND-gate below is unaffected:
+# Plus leg is capped at 1 unless the plus_shards opt-in is set (issue #856:
+# same-identity parallel Plus boots). The AND-gate below is unaffected:
 # needs.smoke.result already aggregates the WHOLE expanded matrix, shard
 # entries included.
 #
@@ -70,9 +70,14 @@ on:
         required: false
         default: ""
       shards:
-        description: "Number of parallel module shards per CE leg for full-marker, un-filtered runs (issue #797). Collapses to 1 when pytest_filter is set or pytest_marker != smoke. Plus legs are always capped at 1 shard (parallel Plus boots are unvalidated). Clamped to the leg's test-module count."
+        description: "Number of parallel module shards per CE leg for full-marker, un-filtered runs (issue #797). Collapses to 1 when pytest_filter is set or pytest_marker != smoke. Plus legs are capped at 1 shard unless plus_shards is set. Clamped to the leg's test-module count."
         required: false
         default: "3"
+      plus_shards:
+        description: "Opt-in (issue #856): shard the Plus leg too, at the same `shards` count — N concurrent Plus boots under the single SMOKE_PLUS_* identity. Default off: Plus stays at 1 shard."
+        required: false
+        type: boolean
+        default: false
   # Called by other workflows. Defaults to the FULL suite so existing callers
   # that pass nothing are unchanged (workflow_call -> scope=full by default).
   workflow_call:
@@ -98,7 +103,7 @@ on:
         type: string
         default: ""
       shards:
-        description: "Number of parallel module shards per CE leg for full-marker, un-filtered runs (issue #797). Collapses to 1 when pytest_filter is set or pytest_marker != smoke. Plus legs are always capped at 1 shard (parallel Plus boots are unvalidated). Clamped to the leg's test-module count."
+        description: "Number of parallel module shards per CE leg for full-marker, un-filtered runs (issue #797). Collapses to 1 when pytest_filter is set or pytest_marker != smoke. Plus legs are always capped at 1 shard on a call (the plus_shards opt-in is dispatch-only). Clamped to the leg's test-module count."
         required: false
         type: string
         default: "3"
@@ -152,6 +157,9 @@ jobs:
           # 3 since #855: the hybrid splitter breaks the test_smoke_feeds ceiling,
           # so a third CE shard now buys real wall-clock (~11 min legs).
           SHARDS_INPUT: ${{ inputs.shards || '3' }}
+          # Dispatch-only #856 opt-in; empty on schedule/workflow_call, so the
+          # Plus leg stays capped at 1 shard on every non-dispatch path.
+          PLUS_SHARDS_INPUT: ${{ inputs.plus_shards }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           set -eu
@@ -242,8 +250,9 @@ jobs:
       pytest_marker: ${{ needs.prepare.outputs.pytest_marker || 'smoke' }}
       pytest_filter: ${{ needs.prepare.outputs.pytest_filter }}
       # Module-shard identity (issue #797): resolve-legs.sh stamped these onto
-      # every expanded matrix entry (CE: 0..shards-1 of `shards`; Plus always
-      # "0" of "1"). N=1 is a byte-identical no-op in run-smoke.sh.
+      # every expanded matrix entry (CE: 0..shards-1 of `shards`; Plus "0" of
+      # "1" unless the plus_shards opt-in lifted the cap, issue #856). N=1 is
+      # a byte-identical no-op in run-smoke.sh.
       shard: ${{ matrix.shard }}
       shard_total: ${{ matrix.shard_total }}
     secrets: inherit

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -250,7 +250,8 @@ sharding splits an already-selected, full-marker run across N parallel workers. 
 takes a `shards` input (default 3): a CE leg with the default `smoke` marker and no `-k` filter
 expands into `shards` matrix entries (`resolve-legs.sh legs`), each running one shard's slice —
 module-level, or test-level for an oversized module (issue #855's hybrid split, below); a Plus leg
-is always hard-capped at 1 shard (concurrent Netgate-licensed boots are unvalidated); the count is
+is capped at 1 shard unless the `plus_shards` dispatch opt-in is set (issue #856 validated
+same-identity parallel Plus boots — run 28749104142: both shards green, no license errors); the count is
 clamped to the leg's `test_*.py` module count; and a filtered (`pytest_filter` set) or
 non-`smoke`-marker leg collapses to 1 shard — the same empty-slice hazard `local-smoke.sh --shards`
 guards against (an N-way split can leave a shard with zero matching tests). The residual case — a

--- a/scripts/resolve-legs.sh
+++ b/scripts/resolve-legs.sh
@@ -14,8 +14,9 @@
 #                 "smoke", and is clamped to the --test-dir's direct-child
 #                 test_*.py module count. Every FILTERED entry gets `shard` /
 #                 `shard_label` / `shard_total` STRING fields (CE: 0..S-1 / S,
-#                 label = shard+1 for display; Plus is
-#                 hard-capped at 1 — parallel Plus boots are untested).
+#                 label = shard+1 for display; Plus is capped at 1 unless
+#                 PLUS_SHARDS_INPUT=true — the issue #856 opt-in for
+#                 same-identity parallel Plus boots).
 #                 Prints the filtered legs JSON to stdout.
 #                 Writes scope= / ci_matrix= / pytest_filter= to $GITHUB_OUTPUT.
 #
@@ -159,15 +160,17 @@ _rl_legs() {
     # Expand ALWAYS (even at S=1) so every matrix entry uniformly carries
     # shard/shard_total as STRINGS (workflow_call inputs are typed string;
     # avoid number/string coercion surprises). CE gets S copies; Plus is
-    # HARD-CAPPED at 1 shard — #797's constraint: concurrent Netgate-side
-    # check-ins from parallel Plus boots are untested.
+    # capped at 1 shard unless PLUS_SHARDS_INPUT is exactly "true" — the
+    # issue #856 opt-in (same-identity parallel Plus boots; anything else
+    # fails closed to 1, #797's conservative default).
     # shard_label is the 1-based DISPLAY counterpart of the 0-based shard index —
     # job names read "shard 1/2".."2/2" instead of the off-by-one-looking "0/2"
     # (and "shard 1/1" for an unsharded leg instead of "0/1"). Scripts keep the
     # 0-based `shard` field; the label exists for naming only.
     FILTERED="$(printf '%s\n' "$FILTERED" | jq -c --argjson s "$S" \
+        --arg plus "${PLUS_SHARDS_INPUT:-}" \
         '[ .[] | . as $e
-           | (if $e.channel == "CE" then $s else 1 end) as $n
+           | (if ($e.channel == "CE" or $plus == "true") then $s else 1 end) as $n
            | range(0; $n) as $i
            | $e + {shard: ($i | tostring), shard_label: (($i + 1) | tostring), shard_total: ($n | tostring)} ]')"
 

--- a/tests/shell/resolve_legs_spec.sh
+++ b/tests/shell/resolve_legs_spec.sh
@@ -238,7 +238,7 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
 
     setup() {
         scrub_git_env
-        unset SCOPE_INPUT VERSION_INPUT PYTEST_FILTER_INPUT MARKER_INPUT SHARDS_INPUT GITHUB_OUTPUT GITHUB_ENV PFB_BASE_REF
+        unset SCOPE_INPUT VERSION_INPUT PYTEST_FILTER_INPUT MARKER_INPUT SHARDS_INPUT PLUS_SHARDS_INPUT GITHUB_OUTPUT GITHUB_ENV PFB_BASE_REF
     }
     BeforeEach 'setup'
 
@@ -326,6 +326,68 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
         The output should include '"shard":"0","shard_label":"1","shard_total":"1"'
         The output should not include 'shard_total":"2"'
         The error should include 'legs=2'
+    End
+
+    It 'PLUS_SHARDS_INPUT=true + SHARDS_INPUT=2 -> Plus expands to 2 shards too (issue #856 opt-in)'
+        # Given: the #856 opt-in — same-identity parallel Plus boots validated,
+        #        so the Plus 1-shard cap may be lifted on explicit request.
+        # When: legs runs with SHARDS_INPUT=2 and PLUS_SHARDS_INPUT=true.
+        # Then: BOTH legs expand to 2 shards (4 legs total); no entry keeps
+        #       the capped shard_total "1".
+        When run env \
+            CI_MATRIX="$ONE_CE_ONE_PLUS" \
+            EVENT_NAME="workflow_dispatch" \
+            SCOPE_INPUT="full" \
+            SHARDS_INPUT="2" \
+            PLUS_SHARDS_INPUT="true" \
+            sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
+        The status should be success
+        The output should include '"channel":"Plus"'
+        The output should include '"shard":"1","shard_label":"2","shard_total":"2"'
+        The output should not include '"shard_total":"1"'
+        The error should include 'legs=4'
+    End
+
+    It 'PLUS_SHARDS_INPUT=true + PYTEST_FILTER_INPUT set -> still collapses ALL legs to 1'
+        # Given: the Plus opt-in AND an explicit -k.
+        # When: legs runs.
+        # Then: the -k collapse wins — the opt-in never resurrects sharding
+        #       for a filtered run (a shard slice may not contain the tests).
+        When run env \
+            CI_MATRIX="$ONE_CE_ONE_PLUS" \
+            EVENT_NAME="workflow_dispatch" \
+            SCOPE_INPUT="full" \
+            SHARDS_INPUT="2" \
+            PLUS_SHARDS_INPUT="true" \
+            PYTEST_FILTER_INPUT="test_foo" \
+            sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
+        The status should be success
+        The output should include '"shard":"0","shard_label":"1","shard_total":"1"'
+        The output should not include 'shard_total":"2"'
+        The error should include 'legs=2'
+    End
+
+    Context 'PLUS_SHARDS_INPUT non-true values keep the Plus cap'
+        # Only the literal "true" lifts the cap — anything else (the workflow's
+        # rendered boolean "false" included) fails closed to 1 Plus shard.
+        Parameters
+            "false"
+            "1"
+            "yes"
+        End
+        It "PLUS_SHARDS_INPUT='$1' -> CE expands, Plus stays 1 shard"
+            When run env \
+                CI_MATRIX="$ONE_CE_ONE_PLUS" \
+                EVENT_NAME="workflow_dispatch" \
+                SCOPE_INPUT="full" \
+                SHARDS_INPUT="2" \
+                PLUS_SHARDS_INPUT="$1" \
+                sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
+            The status should be success
+            The output should include '"channel":"Plus"'
+            The output should include '"shard":"0","shard_label":"1","shard_total":"1"'
+            The error should include 'legs=3'
+        End
     End
 
     Context 'shard-count parsing errors'


### PR DESCRIPTION
## Summary

Adds the dispatch-only `plus_shards` boolean input to `smoke.yml` (default `false`): when set, `resolve-legs.sh` shards the Plus leg at the same `shards` count instead of hard-capping it at 1. Only the literal `"true"` in `PLUS_SHARDS_INPUT` lifts the cap — schedule, `workflow_call`, and any other value fail closed to 1 Plus shard, and the existing `-k`/marker collapse still wins over the opt-in.

The cap existed because concurrent Netgate-side check-ins under the single `SMOKE_PLUS_*` identity were untested (#797). Issue #856's experiment validated them: run [28749104142](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28749104142) booted two Plus 26.03 VMs fully concurrently under the one identity (~21 min overlap), both shards green, no license/registration errors in either guest's logs.

## Tests

- `tests/shell/resolve_legs_spec.sh`: opt-in expands Plus to 2 shards (fails pre-change, passes post-change); `-k` collapse still wins over the opt-in; non-`true` values (`false`, `1`, `yes`) keep the cap; existing cap-off default pinned by the pre-existing shard tests.
- Full shellspec suite green (362 examples); `shellcheck`, `sh -n`, `actionlint` clean.
- Live proof: the experiment run above exercised the changed path end-to-end (`scope=full version=26.03 shards=2 plus_shards=true` → 2 concurrent Plus legs, AND-gate green).

Fixes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ooLjvBBm6oznTBUg9mxVF