### PR TITLE
tests/smoke: fail the UI tier on a missing admin password, never skip

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -58,7 +58,7 @@ name: UI tests fan-out (all CI legs, live pfSense VM)
 #   SMOKE_SSH_PRIV_KEY   private SSH key matching the image's baked authorized_keys (secret)
 #   SMOKE_ADMIN_PASSWORD baked webConfigurator admin password (secret) — REQUIRED here:
 #                        the UI tier logs in over the CSRF form; without it the ui
-#                        fixtures SKIP cleanly (never fail).
+#                        fixtures FAIL (never skip — a skipped tier is a false pass).
 # Optional:
 #   SMOKE_ADMIN_USER     webConfigurator user (var; default "admin")
 #   SMOKE_DNSBL_VIP4     baked pfb_dnsvip4 (the functional DNSBL flow injects the VIP); default 10.10.10.1
@@ -492,7 +492,7 @@ jobs:
           SMOKE_REDACT_VALUES: ${{ env.RESOLVED_REDACT }}
           # The Phase-1 gap closed: the UI tier logs into the webConfigurator over
           # the CSRF form, so the baked admin password MUST reach pytest. Without
-          # it the ui fixtures SKIP (never fail).
+          # it the ui fixtures FAIL (never skip).
           SMOKE_ADMIN_PASSWORD: ${{ secrets.SMOKE_ADMIN_PASSWORD }}
           SMOKE_ADMIN_USER: ${{ vars.SMOKE_ADMIN_USER }}
           # Screenshot artifact layout: <root>/<version>/<name>.png (browser tier).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -853,7 +853,7 @@ mechanics, CI wiring (`ui-tests.yml`), gate status — are documented in
   on-box `php_error.log` line — **never HTTP 200 alone**. Tiers B `ui_e2e`/`ui_browser` are
   schedule/dispatch-only (non-PR-blocking). Run a tier: `python -m pytest tests/smoke/ui -m
   ui_render --override-ini="addopts="` (`SMOKE_ADMIN_PASSWORD` must be set, else the UI fixtures
-  SKIP, never fail).
+  FAIL — the UI tests cannot run without it and a skip is not a pass).
 - **Selective dispatch (validate your own change cheaply).** A bare `gh workflow run
   smoke.yml`/`ui-tests.yml` defaults to **`scope=impacted`**: the **min CE leg** + only the test
   modules **changed vs `origin/devel`** (auto-derived). Pass **`-f pytest_filter="a or b"`** to add the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1024,14 +1024,14 @@ python -m playwright install chromium                 # browser tier only
 export SMOKE_IMAGE_REF=ghcr.io/<org>/pfsense-ce@sha256:<digest>
 export SMOKE_SSH_KEY=/path/to/guest_priv_key          # mode 600
 export SMOKE_PKG=/path/to/pfBlockerNG-*.pkg           # from build-pkg
-export SMOKE_ADMIN_PASSWORD=<baked admin password>    # else the UI fixtures SKIP
+export SMOKE_ADMIN_PASSWORD=<baked admin password>    # REQUIRED — else the UI fixtures FAIL
 python -m pytest tests/smoke/ui -m ui_render   --override-ini="addopts="   # Tier A
 python -m pytest tests/smoke/ui -m ui_e2e      --override-ini="addopts="   # Tier B functional
 python -m pytest tests/smoke/ui -m ui_browser  --override-ini="addopts="   # Tier B browser
 ```
 
-Without `SMOKE_ADMIN_PASSWORD` the UI fixtures **skip** cleanly (never fail), so a
-run that lacks the baked credential degrades gracefully. Screenshots land under
+Without `SMOKE_ADMIN_PASSWORD` the UI fixtures **fail** (never skip) — the tests cannot
+run without the baked credential, and a skipped tier would report a false pass. Screenshots land under
 `$SMOKE_UI_SCREENSHOT_DIR/<version>/` (default `test-results/ui-screenshots/`, a
 git-ignored build output).
 

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -214,8 +214,8 @@ to drive the live webConfigurator. It is off the default `pytest` like the rest 
   (`python -m playwright install chromium`); module-level `importorskip` SKIPs cleanly without it.
 
 Run a tier against a smoke VM exactly like the smoke suite — re-enable the package and select
-the marker (`SMOKE_ADMIN_PASSWORD` must be set; if unset the UI fixtures SKIP off-CI but FAIL
-under CI — `CI`/`GITHUB_ACTIONS` — so a missing secret can't pass the tier by skipping it):
+the marker (`SMOKE_ADMIN_PASSWORD` must be set; if unset the UI fixtures FAIL everywhere — CI and
+local alike — so a missing secret can't pass the tier by skipping it):
 
 ```sh
 python -m pytest tests/smoke/ui -m ui_render --override-ini="addopts="

--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -47,8 +47,8 @@ scripts/local-smoke.sh --marker ui_render
 A UI-tier marker auto-scopes the run to `tests/smoke/ui` with the 300s per-test ceiling
 (matching `ui-tests.yml`); `ui_browser` additionally installs the headless Chromium binary on
 the box. **The webConfigurator admin password must be on the box** — the UI fixtures log in over
-the CSRF form, so an unset `SMOKE_ADMIN_PASSWORD` SKIPS the whole tier off-CI (a false-green of
-all-skips). Put it (and an optional `SMOKE_ADMIN_USER`, default `admin`) in the box's
+the CSRF form, so an unset `SMOKE_ADMIN_PASSWORD` FAILS the whole tier (never skips — a skipped
+tier would be a false green). Put it (and an optional `SMOKE_ADMIN_USER`, default `admin`) in the box's
 `~/.ssh/environment` (needs `PermitUserEnvironment yes`) so the on-box pytest inherits it; it
 must match the password baked into the pfSense image the box pulls.
 

--- a/tests/smoke/ui/conftest.py
+++ b/tests/smoke/ui/conftest.py
@@ -9,10 +9,9 @@ Credentials: the pfSense ``admin`` password is the ADR-04 baked
 ``SMOKE_ADMIN_PASSWORD`` (bcrypt in ``config.xml``, plaintext in the secret).
 It is NOT yet exported to pytest by ``smoke-single.yml`` (ADR-04 used SSH-key auth and
 reachability-only WebUI). :func:`admin_credentials` reads it from the environment.
-Off-CI (a credential-less local run) an unset password is a clean skip; under CI
-(``CI`` / ``GITHUB_ACTIONS`` set) it is a HARD FAILURE -- the secret is required
-there, and skipping the whole tier while the job reports green is a false pass (see
-:mod:`tests.smoke.ui.credgate`). Phase 5 wires ``SMOKE_ADMIN_PASSWORD`` (and an
+An unset password is a HARD FAILURE (never a skip): the UI tests cannot run without the
+webConfigurator admin password, and skipping the tier while the job reports green is a
+false pass (see :mod:`tests.smoke.ui.credgate`). Phase 5 wires ``SMOKE_ADMIN_PASSWORD`` (and an
 optional ``SMOKE_ADMIN_USER``) into the workflow's pytest ``env:`` block -- this
 phase does NOT edit any workflow.
 """
@@ -46,7 +45,7 @@ PFB_READY_PATH = "/pfblockerng/pfblockerng_general.php"
 PFB_READY_ATTEMPTS = 60
 PFB_READY_DELAY = 2.0
 
-# The admin password env var ("SMOKE_ADMIN_PASSWORD") + its skip/fail decision live in .credgate.
+# The admin password env var ("SMOKE_ADMIN_PASSWORD") + its ok/fail decision live in .credgate.
 # Optional override of the admin username; pfSense's default is "admin".
 ADMIN_USER_ENV = "SMOKE_ADMIN_USER"
 DEFAULT_ADMIN_USER = "admin"
@@ -150,15 +149,13 @@ __all__ = ["REDACTED", "mask_page_identity"]
 def admin_credentials() -> tuple[str, str]:
     """``(username, password)`` for the webConfigurator, from the environment.
 
-    Off-CI (a credential-less local run) an unset ``SMOKE_ADMIN_PASSWORD`` is a clean
-    skip. Under CI it is a HARD FAILURE: the secret is required there, and skipping the
-    whole UI tier while the job still reports green is a false pass (see :mod:`.credgate`).
+    An unset ``SMOKE_ADMIN_PASSWORD`` is a HARD FAILURE, never a skip: the UI tests cannot
+    run without the webConfigurator admin password, and skipping the tier while the job
+    reports green is a false pass (see :mod:`.credgate`).
     """
     action, value = admin_password_decision(os.environ)
     if action == "fail":
         pytest.fail(value)
-    if action == "skip":
-        pytest.skip(value)
     # action == "ok": value is the password.
     username = os.environ.get(ADMIN_USER_ENV) or DEFAULT_ADMIN_USER
     return username, value

--- a/tests/smoke/ui/credgate.py
+++ b/tests/smoke/ui/credgate.py
@@ -4,9 +4,10 @@ Kept in its own module (no ``requests``/VM imports) so the default unit suite ca
 import and test it; ``tests/smoke`` itself is ``--ignore``d by the default
 ``python -m pytest``, so a meta-test must live under ``tests/`` and import THIS.
 
-The point: a missing ``SMOKE_ADMIN_PASSWORD`` must NOT let the whole UI tier skip and
-still report the job green (a false pass). Off-CI (a credential-less local run) a skip is
-correct; under CI the secret is required, so an unset password is a hard failure.
+The point: a missing ``SMOKE_ADMIN_PASSWORD`` must NOT let the UI tier skip and still
+report green (a false pass). The UI tests literally cannot run without the webConfigurator
+admin password, so an unset password is a hard FAILURE everywhere — CI and local alike;
+skipping the tier is never a pass.
 """
 
 from __future__ import annotations
@@ -18,25 +19,22 @@ from typing import Literal
 ADMIN_PASSWORD_ENV = "SMOKE_ADMIN_PASSWORD"
 
 
-def admin_password_decision(env: Mapping[str, str]) -> tuple[Literal["ok", "fail", "skip"], str]:
+def admin_password_decision(env: Mapping[str, str]) -> tuple[Literal["ok", "fail"], str]:
     """Decide how the ``admin_credentials`` fixture resolves the admin password.
 
     Returns ``(action, value)``:
 
     * ``("ok", password)``  — the password is set; use it.
-    * ``("fail", message)`` — the password is unset AND we are running under CI
-      (``CI`` or ``GITHUB_ACTIONS`` set): a required secret is misconfigured, so the
-      UI tier must FAIL loudly rather than skip the whole tier and report green.
-    * ``("skip", message)`` — the password is unset off-CI (a credential-less local
-      run): a clean skip, as before.
+    * ``("fail", message)`` — the password is unset (or empty): the UI tests cannot run
+      without the webConfigurator admin password, and skipping the tier would report a
+      false pass, so it FAILS loudly. This holds EVERYWHERE — CI and local alike; a
+      credential-less run is a setup error to fix, not a tier to silently skip.
     """
     password = env.get(ADMIN_PASSWORD_ENV)
     if password:
         return ("ok", password)
-    if env.get("CI") or env.get("GITHUB_ACTIONS"):
-        return (
-            "fail",
-            f"{ADMIN_PASSWORD_ENV} not set in CI — the UI tier requires the webConfigurator "
-            "admin password; refusing to skip the tier and report a false pass.",
-        )
-    return ("skip", f"{ADMIN_PASSWORD_ENV} not set -- no webConfigurator admin password")
+    return (
+        "fail",
+        f"{ADMIN_PASSWORD_ENV} not set — the UI tier requires the webConfigurator admin "
+        "password; UI tests cannot run without it and skipping is not passing.",
+    )

--- a/tests/test_ui_admin_password_gate.py
+++ b/tests/test_ui_admin_password_gate.py
@@ -1,14 +1,14 @@
-"""The UI tier must not skip-as-pass when its required secret is missing in CI.
+"""The UI tier must not skip-as-pass when its required secret is missing.
 
 Pins :func:`tests.smoke.ui.credgate.admin_password_decision`: the pure decision the
 ``admin_credentials`` fixture acts on. ``tests/smoke`` is ``--ignore``d by the default
 ``python -m pytest`` (it needs a live VM), so this meta-test lives under ``tests/`` to run
 in the PR unit gate — exactly where the false-green would otherwise hide.
 
-Red->green: before the fix the fixture unconditionally ``pytest.skip``ed on an unset
-password, so a CI run with the secret missing skipped the whole UI tier and the job still
-reported success. Now an unset password under CI maps to ``"fail"`` (a hard failure);
-off-CI it still maps to ``"skip"``.
+Red->green: the fix makes an unset password map to ``"fail"`` (a hard failure) EVERYWHERE
+— CI and local alike. Previously a credential-less off-CI run mapped to ``"skip"``, silently
+skipping the whole UI tier while the job still reported success; the UI tests cannot run
+without the secret, so a skip is not a pass.
 """
 
 from __future__ import annotations
@@ -41,16 +41,21 @@ def test_unset_password_in_ci_fails() -> None:
         assert ADMIN_PASSWORD_ENV in msg, f"failure message should name the env var, got {msg!r}"
 
 
-def test_unset_password_off_ci_skips() -> None:
-    """Unset password with no CI marker => clean skip (credential-less local run)."""
+def test_unset_password_off_ci_also_fails() -> None:
+    """Unset password with NO CI marker => hard FAIL too (a skip is not a pass).
+
+    The regression guard for this change: the UI tests cannot run without the secret, so
+    even a credential-less LOCAL run must fail rather than silently skip. Pre-change this
+    returned a skip (the false green this closes).
+    """
     action, msg = admin_password_decision({})
-    assert action == "skip", f"unset password off-CI must skip, got {action!r}"
-    assert ADMIN_PASSWORD_ENV in msg, f"skip message should name the env var, got {msg!r}"
+    assert action == "fail", f"unset password off-CI must FAIL (never skip), got {action!r}"
+    assert ADMIN_PASSWORD_ENV in msg, f"failure message should name the env var, got {msg!r}"
 
 
 def test_empty_password_treated_as_unset() -> None:
-    """An empty-string password is not a real credential — treated as unset."""
+    """An empty-string password is not a real credential — treated as unset (=> fail everywhere)."""
     action, _ = admin_password_decision({ADMIN_PASSWORD_ENV: ""})
-    assert action == "skip", f"empty password off-CI must skip (treated as unset), got {action!r}"
+    assert action == "fail", f"empty password must fail (treated as unset), got {action!r}"
     action, _ = admin_password_decision({ADMIN_PASSWORD_ENV: "", "CI": "true"})
     assert action == "fail", f"empty password under CI must fail (treated as unset), got {action!r}"


### PR DESCRIPTION
## What

The UI tier's tests cannot run without the webConfigurator admin password (`SMOKE_ADMIN_PASSWORD`), and a *skipped* tier still reports the job green — a false pass. `credgate` previously skipped off-CI (a credential-less local run) and only failed under CI. This makes it **fail everywhere** an unset (or empty) password is seen — CI and local alike; a credential-less run is a setup error to fix, not a tier to silently skip.

- `admin_password_decision` drops the off-CI `skip` branch: unset/empty → `("fail", …)` (return type is now `Literal["ok", "fail"]`).
- The `admin_credentials` fixture drops its `pytest.skip` path.
- The credgate meta-test flips the off-CI + empty cases from skip to fail — the red→green guard — and drops the CI-specific framing.
- CLAUDE.md's stale "UI fixtures SKIP, never fail" line is corrected.

## Validation

Unit meta-test (`tests/test_ui_admin_password_gate.py`, runs in the default PR gate): red→green proven — 2 fail against pre-change credgate (the flipped off-CI + empty cases), 5 pass against post-change. In CI `SMOKE_ADMIN_PASSWORD` is set, so live smoke is unaffected; the fail path is unit-covered.

Follow-up to #864 (per maintainer request: UI tests must fail, not skip, on a missing secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
