### PR TITLE
ci: shard Plus legs like CE by default — one shards value for every leg

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -19,9 +19,9 @@ name: Smoke fan-out (all CI legs, live pfSense VM)
 # un-filtered run splits into `shards` parallel slices (default 3), each
 # booting its own VM; a slice is module-level or, for an oversized module,
 # test-level (issue #855's hybrid split via scripts/shard-modules.sh). A
-# -k-narrowed run or a non-'smoke' marker collapses back to 1 shard, and a
-# Plus leg is capped at 1 unless the plus_shards opt-in is set (issue #856:
-# same-identity parallel Plus boots). The AND-gate below is unaffected:
+# -k-narrowed run or a non-'smoke' marker collapses back to 1 shard. Plus
+# legs shard exactly like CE — same `shards` count and defaults (issue #856
+# validated same-identity parallel Plus boots). The AND-gate below is unaffected:
 # needs.smoke.result already aggregates the WHOLE expanded matrix, shard
 # entries included.
 #
@@ -70,14 +70,9 @@ on:
         required: false
         default: ""
       shards:
-        description: "Number of parallel module shards per CE leg for full-marker, un-filtered runs (issue #797). Collapses to 1 when pytest_filter is set or pytest_marker != smoke. Plus legs are capped at 1 shard unless plus_shards is set. Clamped to the leg's test-module count."
+        description: "Number of parallel module shards per leg — CE and Plus alike (issues #797/#856) — for full-marker, un-filtered runs. Collapses to 1 when pytest_filter is set or pytest_marker != smoke. Clamped to the leg's test-module count."
         required: false
         default: "3"
-      plus_shards:
-        description: "Opt-in (issue #856): shard the Plus leg too, at the same `shards` count — N concurrent Plus boots under the single SMOKE_PLUS_* identity. Default off: Plus stays at 1 shard."
-        required: false
-        type: boolean
-        default: false
   # Called by other workflows. Defaults to the FULL suite so existing callers
   # that pass nothing are unchanged (workflow_call -> scope=full by default).
   workflow_call:
@@ -103,7 +98,7 @@ on:
         type: string
         default: ""
       shards:
-        description: "Number of parallel module shards per CE leg for full-marker, un-filtered runs (issue #797). Collapses to 1 when pytest_filter is set or pytest_marker != smoke. Plus legs are always capped at 1 shard on a call (the plus_shards opt-in is dispatch-only). Clamped to the leg's test-module count."
+        description: "Number of parallel module shards per leg — CE and Plus alike (issues #797/#856) — for full-marker, un-filtered runs. Collapses to 1 when pytest_filter is set or pytest_marker != smoke. Clamped to the leg's test-module count."
         required: false
         type: string
         default: "3"
@@ -157,9 +152,6 @@ jobs:
           # 3 since #855: the hybrid splitter breaks the test_smoke_feeds ceiling,
           # so a third CE shard now buys real wall-clock (~11 min legs).
           SHARDS_INPUT: ${{ inputs.shards || '3' }}
-          # Dispatch-only #856 opt-in; empty on schedule/workflow_call, so the
-          # Plus leg stays capped at 1 shard on every non-dispatch path.
-          PLUS_SHARDS_INPUT: ${{ inputs.plus_shards }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           set -eu
@@ -250,9 +242,8 @@ jobs:
       pytest_marker: ${{ needs.prepare.outputs.pytest_marker || 'smoke' }}
       pytest_filter: ${{ needs.prepare.outputs.pytest_filter }}
       # Module-shard identity (issue #797): resolve-legs.sh stamped these onto
-      # every expanded matrix entry (CE: 0..shards-1 of `shards`; Plus "0" of
-      # "1" unless the plus_shards opt-in lifted the cap, issue #856). N=1 is
-      # a byte-identical no-op in run-smoke.sh.
+      # every expanded matrix entry (0..shards-1 of `shards`, CE and Plus
+      # alike — issue #856). N=1 is a byte-identical no-op in run-smoke.sh.
       shard: ${{ matrix.shard }}
       shard_total: ${{ matrix.shard_total }}
     secrets: inherit

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -249,9 +249,10 @@ through (`scripts/local-smoke.sh` forwards them — `--filter` becomes pytest `-
 sharding splits an already-selected, full-marker run across N parallel workers. CI's `smoke.yml`
 takes a `shards` input (default 3): a CE leg with the default `smoke` marker and no `-k` filter
 expands into `shards` matrix entries (`resolve-legs.sh legs`), each running one shard's slice —
-module-level, or test-level for an oversized module (issue #855's hybrid split, below); a Plus leg
-is capped at 1 shard unless the `plus_shards` dispatch opt-in is set (issue #856 validated
-same-identity parallel Plus boots — run 28749104142: both shards green, no license errors); the count is
+module-level, or test-level for an oversized module (issue #855's hybrid split, below); Plus legs
+shard exactly like CE — same `shards` count and defaults (issue #856 validated same-identity
+parallel Plus boots under the single `SMOKE_PLUS_*` identity — run 28749104142: both shards green,
+no license errors); the count is
 clamped to the leg's `test_*.py` module count; and a filtered (`pytest_filter` set) or
 non-`smoke`-marker leg collapses to 1 shard — the same empty-slice hazard `local-smoke.sh --shards`
 guards against (an N-way split can leave a shard with zero matching tests). The residual case — a

--- a/scripts/resolve-legs.sh
+++ b/scripts/resolve-legs.sh
@@ -13,9 +13,9 @@
 #                 unless the derived -k is EMPTY and the marker is exactly
 #                 "smoke", and is clamped to the --test-dir's direct-child
 #                 test_*.py module count. Every FILTERED entry gets `shard` /
-#                 `shard_label` / `shard_total` STRING fields (CE: 0..S-1 / S,
-#                 label = shard+1 for display; Plus is capped at 1 unless
-#                 PLUS_SHARDS_INPUT=true — the issue #856 opt-in for
+#                 `shard_label` / `shard_total` STRING fields (0..S-1 / S,
+#                 label = shard+1 for display). One S drives every channel —
+#                 Plus shards exactly like CE (issue #856 validated
 #                 same-identity parallel Plus boots).
 #                 Prints the filtered legs JSON to stdout.
 #                 Writes scope= / ci_matrix= / pytest_filter= to $GITHUB_OUTPUT.
@@ -159,20 +159,17 @@ _rl_legs() {
 
     # Expand ALWAYS (even at S=1) so every matrix entry uniformly carries
     # shard/shard_total as STRINGS (workflow_call inputs are typed string;
-    # avoid number/string coercion surprises). CE gets S copies; Plus is
-    # capped at 1 shard unless PLUS_SHARDS_INPUT is exactly "true" — the
-    # issue #856 opt-in (same-identity parallel Plus boots; anything else
-    # fails closed to 1, #797's conservative default).
+    # avoid number/string coercion surprises). Every leg gets S copies —
+    # Plus shards exactly like CE, same count and defaults (issue #856
+    # validated same-identity parallel Plus boots; the #797 1-shard cap and
+    # its #856 opt-in are gone).
     # shard_label is the 1-based DISPLAY counterpart of the 0-based shard index —
     # job names read "shard 1/2".."2/2" instead of the off-by-one-looking "0/2"
     # (and "shard 1/1" for an unsharded leg instead of "0/1"). Scripts keep the
     # 0-based `shard` field; the label exists for naming only.
     FILTERED="$(printf '%s\n' "$FILTERED" | jq -c --argjson s "$S" \
-        --arg plus "${PLUS_SHARDS_INPUT:-}" \
-        '[ .[] | . as $e
-           | (if ($e.channel == "CE" or $plus == "true") then $s else 1 end) as $n
-           | range(0; $n) as $i
-           | $e + {shard: ($i | tostring), shard_label: (($i + 1) | tostring), shard_total: ($n | tostring)} ]')"
+        '[ .[] | range(0; $s) as $i
+           | . + {shard: ($i | tostring), shard_label: (($i + 1) | tostring), shard_total: ($s | tostring)} ]')"
 
     printf 'scope=%s  legs=%s  -k=[%s]\n' "$SCOPE" \
         "$(printf '%s' "$FILTERED" | jq 'length')" "$K" >&2

--- a/tests/shell/resolve_legs_spec.sh
+++ b/tests/shell/resolve_legs_spec.sh
@@ -238,16 +238,18 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
 
     setup() {
         scrub_git_env
-        unset SCOPE_INPUT VERSION_INPUT PYTEST_FILTER_INPUT MARKER_INPUT SHARDS_INPUT PLUS_SHARDS_INPUT GITHUB_OUTPUT GITHUB_ENV PFB_BASE_REF
+        unset SCOPE_INPUT VERSION_INPUT PYTEST_FILTER_INPUT MARKER_INPUT SHARDS_INPUT GITHUB_OUTPUT GITHUB_ENV PFB_BASE_REF
     }
     BeforeEach 'setup'
 
-    It 'SHARDS_INPUT=2, no -k, marker smoke -> CE expands to 2 shards, Plus stays 1, total 3 legs'
+    It 'SHARDS_INPUT=2, no -k, marker smoke -> EVERY leg expands to 2 shards (CE and Plus alike), total 4 legs'
         # Given: full scope (no -k), default marker, a 3-module test-dir (>= 2 shards).
         # When: legs runs with SHARDS_INPUT=2.
-        # Then: the CE leg becomes 2 entries (0-based shard 0/1 of 2, 1-based
-        #       display labels 1/2 and 2/2); Plus stays exactly 1 entry (label 1/1);
-        #       the array carries 3 legs total.
+        # Then: one `shards` value drives every channel — CE and Plus each
+        #       become 2 entries (0-based shard 0/1 of 2, display labels 1/2 and
+        #       2/2); no entry keeps a capped shard_total "1" (issue #856
+        #       validated same-identity parallel Plus boots, so Plus is no
+        #       longer special-cased); the array carries 4 legs total.
         When run env \
             CI_MATRIX="$ONE_CE_ONE_PLUS" \
             EVENT_NAME="workflow_dispatch" \
@@ -259,8 +261,8 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
         The output should include '"shard":"0","shard_label":"1","shard_total":"2"'
         The output should include '"shard":"1","shard_label":"2","shard_total":"2"'
         The output should include '"channel":"Plus"'
-        The output should include '"shard":"0","shard_label":"1","shard_total":"1"'
-        The error should include 'legs=3'
+        The output should not include '"shard_total":"1"'
+        The error should include 'legs=4'
     End
 
     It 'SHARDS_INPUT=2 + PYTEST_FILTER_INPUT set -> collapses to 1 (no expansion)'
@@ -298,10 +300,11 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
         The error should include 'legs=2'
     End
 
-    It 'SHARDS_INPUT=5 over a 3-module test-dir -> clamped to 3 CE entries'
+    It 'SHARDS_INPUT=5 over a 3-module test-dir -> BOTH legs clamped to 3 shards'
         # Given: a fixture dir with exactly 3 test_*.py modules.
         # When: SHARDS_INPUT requests more shards than modules exist.
-        # Then: the CE leg is clamped to 3 shards (0/1/2 of 3), never 5.
+        # Then: every leg (CE and Plus) is clamped to 3 shards (0/1/2 of 3),
+        #       never 5 — 6 legs total.
         When run env \
             CI_MATRIX="$ONE_CE_ONE_PLUS" \
             EVENT_NAME="workflow_dispatch" \
@@ -313,7 +316,8 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
         The output should include '"shard":"1","shard_label":"2","shard_total":"3"'
         The output should include '"shard":"2","shard_label":"3","shard_total":"3"'
         The output should not include 'shard_total":"5"'
-        The error should include 'legs=4'
+        The output should not include '"shard_total":"1"'
+        The error should include 'legs=6'
     End
 
     It 'SHARDS_INPUT unset/empty -> 1 (uniform fields still present)'
@@ -326,68 +330,6 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
         The output should include '"shard":"0","shard_label":"1","shard_total":"1"'
         The output should not include 'shard_total":"2"'
         The error should include 'legs=2'
-    End
-
-    It 'PLUS_SHARDS_INPUT=true + SHARDS_INPUT=2 -> Plus expands to 2 shards too (issue #856 opt-in)'
-        # Given: the #856 opt-in — same-identity parallel Plus boots validated,
-        #        so the Plus 1-shard cap may be lifted on explicit request.
-        # When: legs runs with SHARDS_INPUT=2 and PLUS_SHARDS_INPUT=true.
-        # Then: BOTH legs expand to 2 shards (4 legs total); no entry keeps
-        #       the capped shard_total "1".
-        When run env \
-            CI_MATRIX="$ONE_CE_ONE_PLUS" \
-            EVENT_NAME="workflow_dispatch" \
-            SCOPE_INPUT="full" \
-            SHARDS_INPUT="2" \
-            PLUS_SHARDS_INPUT="true" \
-            sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
-        The status should be success
-        The output should include '"channel":"Plus"'
-        The output should include '"shard":"1","shard_label":"2","shard_total":"2"'
-        The output should not include '"shard_total":"1"'
-        The error should include 'legs=4'
-    End
-
-    It 'PLUS_SHARDS_INPUT=true + PYTEST_FILTER_INPUT set -> still collapses ALL legs to 1'
-        # Given: the Plus opt-in AND an explicit -k.
-        # When: legs runs.
-        # Then: the -k collapse wins — the opt-in never resurrects sharding
-        #       for a filtered run (a shard slice may not contain the tests).
-        When run env \
-            CI_MATRIX="$ONE_CE_ONE_PLUS" \
-            EVENT_NAME="workflow_dispatch" \
-            SCOPE_INPUT="full" \
-            SHARDS_INPUT="2" \
-            PLUS_SHARDS_INPUT="true" \
-            PYTEST_FILTER_INPUT="test_foo" \
-            sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
-        The status should be success
-        The output should include '"shard":"0","shard_label":"1","shard_total":"1"'
-        The output should not include 'shard_total":"2"'
-        The error should include 'legs=2'
-    End
-
-    Context 'PLUS_SHARDS_INPUT non-true values keep the Plus cap'
-        # Only the literal "true" lifts the cap — anything else (the workflow's
-        # rendered boolean "false" included) fails closed to 1 Plus shard.
-        Parameters
-            "false"
-            "1"
-            "yes"
-        End
-        It "PLUS_SHARDS_INPUT='$1' -> CE expands, Plus stays 1 shard"
-            When run env \
-                CI_MATRIX="$ONE_CE_ONE_PLUS" \
-                EVENT_NAME="workflow_dispatch" \
-                SCOPE_INPUT="full" \
-                SHARDS_INPUT="2" \
-                PLUS_SHARDS_INPUT="$1" \
-                sh "$SCRIPT" legs --test-dir "$SHARD_DIR" --label marker
-            The status should be success
-            The output should include '"channel":"Plus"'
-            The output should include '"shard":"0","shard_label":"1","shard_total":"1"'
-            The error should include 'legs=3'
-        End
     End
 
     Context 'shard-count parsing errors'
@@ -431,7 +373,7 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
         The output should not include '"shard_label":1,'
         The output should not include '"shard_total":2,'
         The output should not include '"shard_total":2}'
-        The error should include 'legs=3'
+        The error should include 'legs=4'
     End
 
 End


### PR DESCRIPTION
## Summary

Follow-up to #866 / issue #856, per maintainer request: Plus sharding is now **on by default with exactly the same parameters as CE**. The `plus_shards` opt-in (and the underlying #797 Plus 1-shard cap) is removed entirely — `resolve-legs.sh` expands **every** leg to the same shard count, so the single `shards` input (default 3) drives CE and Plus alike on dispatch, the nightly schedule, and every `workflow_call` gate. The `-k`/marker collapse and the module-count clamp apply unchanged to both channels; every script consuming a shard value uses the one shared `SHARDS_INPUT`.

Safety basis: issue #856's experiment (run [28749104142](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28749104142)) — two fully concurrent Plus 26.03 boots under the single `SMOKE_PLUS_*` identity, both shards green, no license/registration errors in either guest.

Effect on the full fan-out: the Plus leg (~38 min single-shard, the wall-clock floor) now splits like CE — every full run, not just opt-in dispatches, gets the parallel Plus legs.

## Tests

- `tests/shell/resolve_legs_spec.sh`: expansion tests flipped to pin the new contract — `SHARDS_INPUT=2` expands BOTH legs (4 legs, no capped `shard_total:"1"` entry), clamp applies to both channels (6 legs), string-typing test updated; all three fail on pre-change code and pass after. The `plus_shards` opt-in tests are removed with the input. Collapse (`-k`/marker), unset, and garbage-input cases stay green as behaviour-preserving oracles.
- Full shellspec suite green (357 examples); `shellcheck`, `sh -n`, `actionlint`, `markdownlint` clean.
- Repo-wide sweep: zero residual `plus_shards`/`PLUS_SHARDS`/"capped at 1" references.

Net −69 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ooLjvBBm6oznTBUg9mxVF