### PR TITLE
pfblockerng: open the dnsbl stats DB on a swap that newly enables it (#862)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5269,6 +5269,29 @@ def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_coun
     # a reload that brings lists legitimately re-enables blocking, exactly as init does.)
     if new_snapshot.data_db or new_snapshot.zone_db or new_snapshot.regex_db or new_snapshot.allow_regex_db:
         pfb["python_blacklist"] = True
+    # Issue #862 (sibling of #860): init opens the dnsbl stats DB only when
+    # _dnsbl_stats_wanted() held at boot. A swap that NEWLY satisfies the predicate here
+    # -- python_blacklist just flipped True above (feeds added post-boot, no Unbound
+    # restart) -- must open the DB init skipped, or every per-feed and Upstream counter
+    # increment silently no-ops (both _db_flush_dnsbl and _log_upstream_block gate on
+    # sqlite3_dnsbl_con) until the next full restart. Off the DNS fast path: this runs on
+    # the watcher thread, and pfb_db_validate -> _db_run is _db_lock-serialized with a
+    # check_same_thread=False connection, so it is safe beside the query threads. Same
+    # mod_sqlite3 gate + two-attempt retry shape as init_standard's "Enable DNSBL
+    # statistics" block; the not-sqlite3_dnsbl_con guard keeps it idempotent (the
+    # synchronous init swap, where init already opened the DB, is a no-op).
+    if pfb["mod_sqlite3"] and not pfb["sqlite3_dnsbl_con"] and _dnsbl_stats_wanted():
+        for i in range(2):
+            try:
+                if pfb_db_validate(DB_DNSBL):
+                    pfb["sqlite3_dnsbl_con"] = True
+                    break
+            except Exception as e:
+                sys.stderr.write(
+                    "[pfBlockerNG]: Failed to open pfb_py_dnsbl.sqlite database (Attempt: {}/2): {}".format(i + 1, e)
+                )
+                if os.path.isfile(pfb["pfb_py_dnsbl"]):
+                    os.remove(pfb["pfb_py_dnsbl"])
     if emit_counts:
         dnsbl_emit_count(pfb["pfb_py_count"], new_snapshot.counts)
         dnsbl_emit_count(pfb["pfb_py_regex_count"], new_snapshot.regex_count)

--- a/tests/test_adr10_swap.py
+++ b/tests/test_adr10_swap.py
@@ -581,6 +581,34 @@ class TestSwapOpensDnsblStatsDb:
         assert not P.pfb["sqlite3_dnsbl_con"]
         assert P.DB_DNSBL not in P._db_conns, "an empty swap that does not want stats must not open the dnsbl DB"
 
+    def test_swap_does_not_open_db_when_mod_sqlite3_unavailable(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """Third input of the AND guard (mod_sqlite3): with the sqlite3 module unavailable,
+        a swap that WOULD otherwise want stats (python_blacklist flips True) must still NOT
+        open the DB -- the mod_sqlite3 conjunct gates it, matching init's own mod_sqlite3
+        gate. Completes branch coverage of the guard's three inputs.
+
+        Failable guard: drop the `mod_sqlite3 and` conjunct and this fails -- sqlite3 is
+        importable in the test env, so the open would succeed and sqlite3_dnsbl_con flip True.
+        """
+        _set_count_paths(tmp_path)
+        monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+        P.pfb["mod_sqlite3"] = False  # sqlite3 module unavailable on this install
+        P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
+        P.pfb["python_blacklist"] = False
+        P.pfb["forwarding"] = False
+        P._snapshot = _snapshot(counts=0)
+        assert not P.pfb["sqlite3_dnsbl_con"]
+
+        # ---- act: a swap loads a feed -> flips python_blacklist True (stats WOULD be wanted).
+        new = _snapshot(data={"blocked.example.com": {"log": "1", "index": 0, "important": False}}, counts=5)
+        assert P.rebuild_and_swap(lambda: new) is True
+
+        # ---- the master gate flips and stats ARE wanted, but mod_sqlite3=False keeps the DB closed.
+        assert P.pfb["python_blacklist"] is True
+        assert _dnsbl_stats_wanted()
+        assert not P.pfb["sqlite3_dnsbl_con"], "mod_sqlite3=False must gate the swap-side DB open"
+        assert P.DB_DNSBL not in P._db_conns, "no connection may open when the sqlite3 module is unavailable"
+
     def test_swap_does_not_reopen_an_already_open_db(self, tmp_path: Any, monkeypatch: Any) -> None:
         """Idempotency: when the stats DB is already open (init opened it), a later swap
         must NOT reconnect -- the not-sqlite3_dnsbl_con guard makes the open a no-op, so

--- a/tests/test_adr10_swap.py
+++ b/tests/test_adr10_swap.py
@@ -26,6 +26,7 @@ import threading
 from typing import Any
 
 import pfb_unbound as P
+from pfb_unbound import _db_flush_dnsbl, _dnsbl_stats_wanted
 
 # --------------------------------------------------------------------------- #
 # Helpers
@@ -476,6 +477,130 @@ class TestSwapGatesFromSnapshot:
             'pfb["hstsDB"]',
         ):
             assert stale not in code, f"operate() must not read the stale {stale} gate (swap-invisible)"
+
+
+# --------------------------------------------------------------------------- #
+# Issue #862 (sibling of #860): a swap that NEWLY wants DNSBL stats opens the
+# stats DB init skipped at boot -- else per-feed/Upstream counters no-op forever.
+# --------------------------------------------------------------------------- #
+
+
+class TestSwapOpensDnsblStatsDb:
+    """Scenario: an ADR-10 swap that newly satisfies ``_dnsbl_stats_wanted()`` opens the
+    dnsbl stats DB that init left closed at boot, so a subsequent counter flush lands.
+
+    Background:
+        init_standard opens ``sqlite3_dnsbl_con`` only when ``_dnsbl_stats_wanted()``
+        (python_blacklist OR forwarding -- issue #860) holds AT INIT. A forwarding-off /
+        no-feeds boot leaves it False. A later zero-downtime swap raises
+        ``python_blacklist`` (feeds added post-boot, no Unbound restart), but pre-fix
+        rebuild_and_swap never re-opened the DB -- so ``_db_flush_dnsbl``'s
+        ``sqlite3_dnsbl_con`` guard (and ``_log_upstream_block``'s enqueue) silently
+        dropped every increment until a full restart. Same silent-loss class #860 fixed
+        for the forwarding-only init; this pins the swap path.
+
+    Every test asserts the BEFORE-state (DB closed) first, then swaps, so a green proves
+    the swap CAUSED the open. All three branches of the ``_dnsbl_stats_wanted()`` guard
+    inside the new open are covered: blacklist-flip opens it, forwarding-only opens it,
+    neither leaves it closed.
+    """
+
+    def test_swap_enabling_blacklist_opens_db_and_flush_lands_counter(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """A swap that loads feeds (flips python_blacklist True) opens the stats DB and a
+        counter flush then lands -- the exact effect the bug silently lost.
+
+        RED pre-fix: rebuild_and_swap raised python_blacklist but left sqlite3_dnsbl_con
+        False, so the ``assert ... sqlite3_dnsbl_con`` below fails.
+        """
+        _set_count_paths(tmp_path)
+        monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+        P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
+
+        # ---- BEFORE: boot state where stats were NOT wanted -> init left the DB closed.
+        P.pfb["python_blacklist"] = False
+        P.pfb["forwarding"] = False
+        P._snapshot = _snapshot(counts=0)
+        assert not P.pfb["sqlite3_dnsbl_con"]
+        assert not _dnsbl_stats_wanted()
+
+        # ---- act: a swap loads a data-stratum feed -> flips the master gate True.
+        new = _snapshot(data={"blocked.example.com": {"log": "1", "index": 0, "important": False}}, counts=5)
+        assert P.rebuild_and_swap(lambda: new) is True
+
+        # ---- AFTER: the gate flipped AND the stats DB is now open.
+        assert P.pfb["python_blacklist"] is True
+        assert P.pfb["sqlite3_dnsbl_con"], "a swap that newly wants stats must open the dnsbl DB (issue #862)"
+
+        # ---- and a counter flush actually lands now (pre-fix: guarded no-op).
+        assert _db_flush_dnsbl({"Upstream": 1})
+        con = P._db_conns[P.DB_DNSBL]
+        row = con.execute("SELECT counter FROM dnsbl WHERE groupname = 'Upstream'").fetchone()
+        assert row == (1,), f"Upstream counter not incremented after the swap opened the DB: {row!r}"
+
+    def test_forwarding_only_swap_opens_db_even_with_empty_snapshot(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """Other truthy branch of the guard: forwarding alone (no blacklist) wants stats
+        too (#860 predicate), so a swap opens the DB even when the snapshot has no lists --
+        the Upstream-counter path -- WITHOUT spuriously flipping python_blacklist.
+
+        RED pre-fix: sqlite3_dnsbl_con stays False across the swap.
+        """
+        _set_count_paths(tmp_path)
+        monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+        P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
+
+        # ---- BEFORE: forwarding on, but the DB somehow closed (DB never opened).
+        P.pfb["python_blacklist"] = False
+        P.pfb["forwarding"] = True
+        P._snapshot = _snapshot(counts=0)
+        assert not P.pfb["sqlite3_dnsbl_con"]
+
+        assert P.rebuild_and_swap(lambda: _snapshot(counts=0)) is True
+
+        # ---- AFTER: an empty snapshot leaves python_blacklist False, but forwarding still
+        # wants stats -> the DB opens.
+        assert P.pfb["python_blacklist"] is False
+        assert P.pfb["sqlite3_dnsbl_con"], "forwarding-only swap must open the dnsbl stats DB (issue #862/#860)"
+
+    def test_empty_swap_no_forwarding_leaves_db_closed(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """Guard-intact branch: a swap that does NOT newly want stats (empty snapshot, no
+        forwarding, gate stays False) must NOT open the DB -- proving the open is scoped to
+        a swap that actually enables stats, not a blanket open-on-every-swap."""
+        _set_count_paths(tmp_path)
+        monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+        P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
+        P.pfb["python_blacklist"] = False
+        P.pfb["forwarding"] = False
+        P._snapshot = _snapshot(counts=0)
+
+        assert P.rebuild_and_swap(lambda: _snapshot(counts=0)) is True
+
+        assert P.pfb["python_blacklist"] is False
+        assert not P.pfb["sqlite3_dnsbl_con"]
+        assert P.DB_DNSBL not in P._db_conns, "an empty swap that does not want stats must not open the dnsbl DB"
+
+    def test_swap_does_not_reopen_an_already_open_db(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """Idempotency: when the stats DB is already open (init opened it), a later swap
+        must NOT reconnect -- the not-sqlite3_dnsbl_con guard makes the open a no-op, so
+        the existing connection (and its accumulated counter) is preserved."""
+        _set_count_paths(tmp_path)
+        monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+        P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
+
+        # ---- BEFORE: the DB is already open with an accumulated Upstream counter.
+        P.pfb["python_blacklist"] = True
+        P.pfb["sqlite3_dnsbl_con"] = True
+        assert _db_flush_dnsbl({"Upstream": 7})
+        first_con = P._db_conns[P.DB_DNSBL]
+        assert first_con.execute("SELECT counter FROM dnsbl WHERE groupname = 'Upstream'").fetchone() == (7,)
+
+        P._snapshot = _snapshot(counts=0)
+        new = _snapshot(data={"blocked.example.com": {"log": "1", "index": 0, "important": False}}, counts=5)
+        assert P.rebuild_and_swap(lambda: new) is True
+
+        # ---- AFTER: same connection object (no reconnect), counter preserved.
+        assert P.pfb["sqlite3_dnsbl_con"]
+        assert P._db_conns[P.DB_DNSBL] is first_con, "an already-open stats DB must not be reconnected by the swap"
+        assert first_con.execute("SELECT counter FROM dnsbl WHERE groupname = 'Upstream'").fetchone() == (7,)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_adr10_swap.py
+++ b/tests/test_adr10_swap.py
@@ -514,6 +514,7 @@ class TestSwapOpensDnsblStatsDb:
         """
         _set_count_paths(tmp_path)
         monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+        P.pfb["mod_sqlite3"] = True  # pin every guard input so "closed" is provably the predicate, not sqlite off
         P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
 
         # ---- BEFORE: boot state where stats were NOT wanted -> init left the DB closed.
@@ -546,6 +547,7 @@ class TestSwapOpensDnsblStatsDb:
         """
         _set_count_paths(tmp_path)
         monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+        P.pfb["mod_sqlite3"] = True  # pin every guard input so "closed" is provably the predicate, not sqlite off
         P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
 
         # ---- BEFORE: forwarding on, but the DB somehow closed (DB never opened).
@@ -567,6 +569,7 @@ class TestSwapOpensDnsblStatsDb:
         a swap that actually enables stats, not a blanket open-on-every-swap."""
         _set_count_paths(tmp_path)
         monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+        P.pfb["mod_sqlite3"] = True  # pin every guard input so "closed" is provably the predicate, not sqlite off
         P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
         P.pfb["python_blacklist"] = False
         P.pfb["forwarding"] = False
@@ -584,6 +587,7 @@ class TestSwapOpensDnsblStatsDb:
         the existing connection (and its accumulated counter) is preserved."""
         _set_count_paths(tmp_path)
         monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+        P.pfb["mod_sqlite3"] = True  # pin every guard input so "closed" is provably the predicate, not sqlite off
         P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
 
         # ---- BEFORE: the DB is already open with an accumulated Upstream counter.


### PR DESCRIPTION
Fixes #862.

## Problem

`_dnsbl_stats_wanted()` (the `python_blacklist OR forwarding` gate from #860) is evaluated **only at Unbound Python init**, inside init's `mod_sqlite3` block. An ADR-10 zero-downtime swap that turns `python_blacklist` on **after** an init where the predicate was False — forwarding off, no feeds at boot; feeds added later without an Unbound restart — flips the master gate (`rebuild_and_swap`, `pfb_unbound.py:5271`) but never opened the dnsbl stats DB. `sqlite3_dnsbl_con` stayed permanently False, so every per-feed and Upstream counter increment silently no-opped — both `_db_flush_dnsbl` and `_log_upstream_block`'s enqueue gate on that flag — until the next full Unbound restart. Same silent-loss class #860 fixed for the forwarding-only init.

## Fix

`rebuild_and_swap()` now opens the dnsbl stats DB when a swap newly satisfies `_dnsbl_stats_wanted()` with `sqlite3_dnsbl_con` still False, using the same `mod_sqlite3` gate and two-attempt `pfb_db_validate(DB_DNSBL)` retry shape as init's "Enable DNSBL statistics" block. It runs on the watcher thread (off the DNS fast path); `pfb_db_validate` → `_db_run` is `_db_lock`-serialized on a `check_same_thread=False` connection, so it is safe beside the query threads. The `not sqlite3_dnsbl_con` guard keeps it idempotent, so the synchronous init swap (where init already opened the DB) is a no-op.

## Tests

New `TestSwapOpensDnsblStatsDb` in `tests/test_adr10_swap.py`, covering every branch of the guard:

- **`test_swap_enabling_blacklist_opens_db_and_flush_lands_counter`** — a swap that loads a feed flips `python_blacklist` True, opens the DB, and a subsequent Upstream flush lands the counter (the effect the bug silently lost).
- **`test_forwarding_only_swap_opens_db_even_with_empty_snapshot`** — the forwarding branch of the predicate opens the DB without spuriously flipping `python_blacklist`.
- **`test_empty_swap_no_forwarding_leaves_db_closed`** — guard intact: a swap that does not want stats never opens the DB.
- **`test_swap_does_not_reopen_an_already_open_db`** — idempotency: an already-open connection (and its counter) is preserved, no reconnect.

Red→green verified: with the source fix reverted, the two behaviour-change tests fail for the exact reason (`sqlite3_dnsbl_con` stays False after the swap); both pass with the fix. `ruff`, `ruff format`, `mypy tests/`, and the swap/upstream/watcher suites (97) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKWbuT6mTbQaYKTcyS1vXD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNSBL statistics are now initialized automatically after a successful swap when blocking becomes active and stats are needed.
  * If database setup fails twice, the app now logs the error and clears the existing DNSBL file so the next attempt can start cleanly.
  * Swaps that do not require DNSBL stats no longer open the database unnecessarily, and existing connections are not reopened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->