### PR TITLE
ci: build the smoke .pkg once per leg + surface the filter in run/job names (#857, #853)

### DIFF
--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -96,6 +96,10 @@ on:
         description: "FreeBSD-ports branch (blank = build-pkg-linux default pfblockerng/use-github)."
         required: false
         default: ""
+      pkg_artifact:
+        description: "Name of a pre-built .pkg artifact to download instead of building one here. The smoke.yml fan-out builds one .pkg per version leg and passes its artifact name in; blank = build the .pkg in this workflow (bare dispatch + repo-install path)."
+        required: false
+        default: ""
   workflow_call:
     inputs:
       image_ref:
@@ -168,6 +172,11 @@ on:
         required: false
         type: string
         default: ""
+      pkg_artifact:
+        description: "Name of a pre-built .pkg artifact to download instead of building one here. The smoke.yml fan-out builds one .pkg per version leg and passes its artifact name in; blank = build the .pkg in this workflow (bare dispatch + repo-install path)."
+        required: false
+        type: string
+        default: ""
   # Nightly gated run — enable once the wall-time is confirmed within budget.
   # schedule:
   #   - cron: "0 5 * * *"
@@ -185,7 +194,15 @@ jobs:
   # version), so the portable .pkg installs identically to a `make package` one.
   # The portable builder is the SOLE .pkg builder (the FreeBSD make-package path
   # was retired — pfBlockerNG is NO_BUILD, so there is nothing to compile).
+  #
+  # This build-if-absent path only runs when no pkg_artifact was supplied (issue
+  # #857): the smoke.yml fan-out now builds one shared .pkg per version leg in
+  # its own build-pkg job and passes its artifact name via pkg_artifact, so
+  # every shard of that leg downloads it below instead of rebuilding here. A
+  # bare workflow_dispatch and repo-install.yml's direct call pass no
+  # pkg_artifact, so they keep building their own .pkg exactly as before.
   build-pkg:
+    if: ${{ inputs.pkg_artifact == '' }}
     uses: ./.github/workflows/build-pkg-linux.yml
     with:
       channel: devel
@@ -200,9 +217,8 @@ jobs:
       # so a shared name would collide / cross-feed. Keying on image_name keeps each
       # leg's artifact distinct (and the download below follows build-pkg.outputs.artifact).
       # The `-s<shard>` suffix (issue #797) keys it further: two shards of the SAME
-      # leg each build their own .pkg (a shared cross-shard build is a deferred
-      # optimization, not implemented here) — without it the name-based artifact
-      # download would collide across shards of one leg.
+      # leg each build their own .pkg on THIS path — only reached when pkg_artifact
+      # is blank, so it never collides with the shared per-leg artifact smoke.yml builds.
       artifact_name: pfBlockerNG-pkg-${{ inputs.image_name }}-s${{ inputs.shard }}
       # Optional Option-A validation: point the .pkg build at a FreeBSD-ports branch
       # carrying a new plist entry. Blank -> build-pkg-linux's own defaults
@@ -213,6 +229,10 @@ jobs:
   smoke:
     name: pytest -m smoke (live pfSense VM)
     needs: build-pkg
+    # Run whether build-pkg built (pkg_artifact blank) or was skipped
+    # (pkg_artifact set — build-pkg's `if` above never even started it); skip
+    # only if build-pkg actually ran and failed/was cancelled.
+    if: ${{ always() && (needs.build-pkg.result == 'success' || needs.build-pkg.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -395,9 +415,12 @@ jobs:
           chmod 600 smoke_key
 
       - name: Download the built pfBlockerNG package
+        # pkg_artifact set (issue #857): download the shared per-leg .pkg
+        # smoke.yml's build-pkg job already built. Blank: fall back to the
+        # artifact this workflow's OWN build-pkg job just built above.
         uses: actions/download-artifact@v8
         with:
-          name: ${{ needs.build-pkg.outputs.artifact }}
+          name: ${{ inputs.pkg_artifact != '' && inputs.pkg_artifact || needs.build-pkg.outputs.artifact }}
           path: pkg
 
       - name: Locate the .pkg + the pulled .qcow2

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
           set -eu
           # ADR-47 P5: scope + legs + -k resolved by the shared script.
-          # Writes scope=, ci_matrix=, pytest_filter= to $GITHUB_OUTPUT.
+          # Writes scope=, ci_matrix=, leg_matrix=, pytest_filter= to $GITHUB_OUTPUT.
           sh scripts/resolve-legs.sh legs --test-dir tests/smoke --label marker
           printf 'pytest_marker=%s\n' "${MARKER_INPUT:-smoke}" >> "$GITHUB_OUTPUT"
 
@@ -268,10 +268,17 @@ jobs:
     # just an explicit input. Empty filter + 'smoke' marker → no suffix, byte-identical.
     name: "Smoke (${{ matrix.channel }} ${{ matrix.pfsense_version }} shard ${{ matrix.shard_label }}/${{ matrix.shard_total }})${{ needs.prepare.outputs.pytest_filter && format(' [-k {0}]', needs.prepare.outputs.pytest_filter) || '' }}${{ (needs.prepare.outputs.pytest_marker && needs.prepare.outputs.pytest_marker != 'smoke') && format(' [marker: {0}]', needs.prepare.outputs.pytest_marker) || '' }}"
     needs: [prepare, build-pkg]
-    # Run even if prepare had warnings; skip only if prepare hard-failed. No
-    # status function here, so Actions implicitly ANDs in success() — a
-    # build-pkg failure skips smoke too (the AND gate below still catches it).
-    if: needs.prepare.outputs.leg_count != '0'
+    # Run once prepare produced legs, REGARDLESS of build-pkg's result: the
+    # !cancelled() status function drops the implicit success() gate that
+    # `needs: build-pkg` would otherwise impose, so ONE leg's build failure no
+    # longer skips EVERY leg's smoke (issue #857 review) — yet the run is still
+    # skipped on a genuine cancellation. build-pkg stays a dependency purely for
+    # ordering (builds finish before smoke starts); a leg whose build failed
+    # then fails its own shards at the artifact-download step (before any VM
+    # boots), and the AND gate below still goes red. prepare must have succeeded
+    # — a prepare failure yields no matrix, so we skip rather than fromJson an
+    # empty string.
+    if: ${{ !cancelled() && needs.prepare.result == 'success' && needs.prepare.outputs.leg_count != '0' }}
     strategy:
       fail-fast: false   # REQUIRED: all legs run to completion; no cancellation on failure
       matrix:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,5 +1,15 @@
 name: Smoke fan-out (all CI legs, live pfSense VM)
 
+# run-name surfaces a narrowed dispatch in the Actions run list (issue #853): a
+# scope=full run WITH a pytest_filter (or a non-'smoke' pytest_marker) selects
+# only a subset yet every leg still runs, so it otherwise looks identical to a
+# genuine unfiltered full fan-out. Mirror `name:` verbatim (run-name has no
+# context for the workflow's own name), then append the filter/marker ONLY when
+# set — an unfiltered, default-marker run renders byte-identically to before.
+# Only dispatch/call inputs are visible here; the per-leg job name below also
+# surfaces the impacted scope's auto-derived -k (that needs the prepare output).
+run-name: "Smoke fan-out (all CI legs, live pfSense VM)${{ inputs.pytest_filter && format(' [-k {0}]', inputs.pytest_filter) || '' }}${{ (inputs.pytest_marker && inputs.pytest_marker != 'smoke') && format(' [marker: {0}]', inputs.pytest_marker) || '' }}"
+
 # Fan the ADR-04 smoke suite across every ci:true image in parallel — CE and
 # Plus alike (ADR-24). Each leg carries its own image_name + mac from the matrix;
 # the Plus image is private (Netgate-licensed) — CI pulls it, never publishes it.
@@ -252,7 +262,11 @@ jobs:
   # passed for smoke-single.yml's build-if-absent fallback (a bare dispatch or
   # repo-install.yml's direct call, neither of which sets pkg_artifact).
   smoke:
-    name: Smoke (${{ matrix.channel }} ${{ matrix.pfsense_version }} shard ${{ matrix.shard_label }}/${{ matrix.shard_total }})
+    # Append the effective -k (and a non-'smoke' marker) so a filtered leg is
+    # visually distinct from a full unfiltered one (issue #853). Uses the RESOLVED
+    # prepare output, so it also surfaces the impacted scope's auto-derived -k, not
+    # just an explicit input. Empty filter + 'smoke' marker → no suffix, byte-identical.
+    name: "Smoke (${{ matrix.channel }} ${{ matrix.pfsense_version }} shard ${{ matrix.shard_label }}/${{ matrix.shard_total }})${{ needs.prepare.outputs.pytest_filter && format(' [-k {0}]', needs.prepare.outputs.pytest_filter) || '' }}${{ (needs.prepare.outputs.pytest_marker && needs.prepare.outputs.pytest_marker != 'smoke') && format(' [marker: {0}]', needs.prepare.outputs.pytest_marker) || '' }}"
     needs: [prepare, build-pkg]
     # Run even if prepare had warnings; skip only if prepare hard-failed. No
     # status function here, so Actions implicitly ANDs in success() — a

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -25,6 +25,13 @@ name: Smoke fan-out (all CI legs, live pfSense VM)
 # needs.smoke.result already aggregates the WHOLE expanded matrix, shard
 # entries included.
 #
+# ONE .pkg BUILD PER VERSION LEG, NOT PER SHARD (issue #857): resolve-legs.sh
+# also emits `leg_matrix` — the UNSHARDED per-leg set (one entry per version
+# leg). The `build-pkg` job below matrixes over THAT, so a leg sharded N ways
+# still builds its .pkg exactly once; every shard of that leg (the `smoke`
+# job's shard-expanded matrix) downloads the shared artifact instead of
+# rebuilding a byte-identical .pkg.
+#
 # AND-gate semantics (GitHub Actions needs.*.result):
 #   - All legs pass  → smoke job result = 'success' → gate = green
 #   - Any leg fails  → smoke job result = 'failure' → gate = red
@@ -121,6 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ci_matrix: ${{ steps.filter.outputs.ci_matrix }}
+      leg_matrix: ${{ steps.filter.outputs.leg_matrix }}
       leg_count: ${{ steps.count.outputs.leg_count }}
       pytest_marker: ${{ steps.filter.outputs.pytest_marker }}
       pytest_filter: ${{ steps.filter.outputs.pytest_filter }}
@@ -196,11 +204,42 @@ jobs:
             echo "::warning::CI matrix is empty — no images to smoke-test."
           fi
 
-  # ── 2. Per-CE smoke run (parallel, fail-fast: false) ─────────────────────────
+  # ── 2. Build the .pkg ONCE PER VERSION LEG (issue #857) ──────────────────────
   #
-  # One leg per ci:true CE entry.  Each leg calls the ADR-04 smoke workflow
-  # (smoke-single.yml) as a reusable callee, passing the per-version image ref.
-  # `fail-fast: false` ensures EVERY leg runs to completion regardless of
+  # Matrixes over `leg_matrix` — the UNSHARDED per-leg set — so a leg sharded
+  # N ways (see the SHARD dimension note above) still builds its .pkg exactly
+  # once, not once per shard. build-pkg-linux.yml declares no `secrets:` input,
+  # so this call passes none (no `secrets: inherit`).
+  build-pkg:
+    name: build-pkg (${{ matrix.channel }} ${{ matrix.pfsense_version }})
+    needs: prepare
+    if: needs.prepare.outputs.leg_count != '0'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.leg_matrix) }}
+    uses: ./.github/workflows/build-pkg-linux.yml
+    with:
+      channel: devel
+      # ABI/dep target matching this leg's image (CE=FreeBSD:15, Plus=FreeBSD:16
+      # in the current matrix) — pkg add refuses a cross-major-ABI .pkg.
+      abi: FreeBSD:${{ matrix.freebsd_major }}:amd64
+      php_version: ${{ matrix.php_version }}
+      py_flavor: ${{ matrix.py_flavor }}
+      # Keyed on image_name + pfsense_version (unique per version leg, stable
+      # across its shards) — the smoke job below passes the SAME name as
+      # pkg_artifact so every shard of this leg downloads this one build.
+      artifact_name: pfBlockerNG-pkg-${{ matrix.image_name }}-${{ matrix.pfsense_version }}
+      ports_repo: pfBlockerNG/FreeBSD-ports
+      ports_ref: pfblockerng/use-github
+
+  # ── 3. Per-leg smoke run (parallel, fail-fast: false) ────────────────────────
+  #
+  # One leg per shard-expanded ci:true entry.  Each leg calls the ADR-04 smoke
+  # workflow (smoke-single.yml) as a reusable callee, passing the per-version
+  # image ref AND the shared .pkg artifact build-pkg produced for its version
+  # leg (pkg_artifact) — smoke-single.yml downloads it instead of building its
+  # own. `fail-fast: false` ensures EVERY leg runs to completion regardless of
   # whether another leg has already failed.
   #
   # IMAGE REF RESOLUTION + PER-LEG .pkg ABI:
@@ -209,15 +248,15 @@ jobs:
   # target (freebsd_major, php_version, py_flavor). We pass them all to smoke-single.yml: it
   # composes the GHCR ref from the SMOKE_IMAGE_REPO repo variable + the image_name
   # input + the pfsense_version tag (each input overriding its repo-variable default),
-  # exports mac as SMOKE_VM_MAC for the boot, AND builds the leg's .pkg for the
-  # matching ABI (FreeBSD:<major>:amd64) + dep flavors. The ABI step is essential:
-  # pkg add refuses a cross-major .pkg, so a .pkg built for one leg's FreeBSD major
-  # cannot install on another's — each leg must build its own ABI-matched package,
-  # with every major/flavor coming from the ci-metadata version matrix.
+  # exports mac as SMOKE_VM_MAC for the boot. abi/php_version/py_flavor are still
+  # passed for smoke-single.yml's build-if-absent fallback (a bare dispatch or
+  # repo-install.yml's direct call, neither of which sets pkg_artifact).
   smoke:
     name: Smoke (${{ matrix.channel }} ${{ matrix.pfsense_version }} shard ${{ matrix.shard_label }}/${{ matrix.shard_total }})
-    needs: prepare
-    # Run even if prepare had warnings; skip only if prepare hard-failed.
+    needs: [prepare, build-pkg]
+    # Run even if prepare had warnings; skip only if prepare hard-failed. No
+    # status function here, so Actions implicitly ANDs in success() — a
+    # build-pkg failure skips smoke too (the AND gate below still catches it).
     if: needs.prepare.outputs.leg_count != '0'
     strategy:
       fail-fast: false   # REQUIRED: all legs run to completion; no cancellation on failure
@@ -231,12 +270,16 @@ jobs:
       pfsense_version: ${{ matrix.pfsense_version }}
       image_name: ${{ matrix.image_name }}
       mac: ${{ matrix.mac }}
-      # Per-leg .pkg target so the built package matches the image's pfSense base:
-      # the ABI tag is keyed on the matrix freebsd_major (CE=15, Plus=16) — pkg add
-      # refuses a cross-major-ABI .pkg — and the dep names track php_version/py_flavor.
+      # Per-leg .pkg target — still needed for smoke-single.yml's build-if-absent
+      # fallback path — keyed on the matrix freebsd_major (CE=15, Plus=16); pkg add
+      # refuses a cross-major-ABI .pkg.
       abi: FreeBSD:${{ matrix.freebsd_major }}:amd64
       php_version: ${{ matrix.php_version }}
       py_flavor: ${{ matrix.py_flavor }}
+      # The .pkg build-pkg already produced for this version leg (issue #857):
+      # identical to that job's artifact_name, so every shard of this leg finds
+      # the SAME shared artifact and downloads it instead of rebuilding.
+      pkg_artifact: pfBlockerNG-pkg-${{ matrix.image_name }}-${{ matrix.pfsense_version }}
       # Resolved by the prepare step: the marker, and the effective -k (an explicit
       # input, else the impacted auto-derivation, else blank = whole marker).
       pytest_marker: ${{ needs.prepare.outputs.pytest_marker || 'smoke' }}
@@ -248,7 +291,7 @@ jobs:
       shard_total: ${{ matrix.shard_total }}
     secrets: inherit
 
-  # ── 3. AND-gate: green only if ALL legs passed ───────────────────────────────
+  # ── 4. AND-gate: green only if ALL legs passed ───────────────────────────────
   #
   # This is the REQUIRED STATUS check.  It runs regardless of the smoke matrix
   # outcome (if: always()) and hard-fails unless every leg passed.

--- a/scripts/resolve-legs.sh
+++ b/scripts/resolve-legs.sh
@@ -18,7 +18,11 @@
 #                 Plus shards exactly like CE (issue #856 validated
 #                 same-identity parallel Plus boots).
 #                 Prints the filtered legs JSON to stdout.
-#                 Writes scope= / ci_matrix= / pytest_filter= to $GITHUB_OUTPUT.
+#                 Writes scope= / ci_matrix= / leg_matrix= / pytest_filter= to
+#                 $GITHUB_OUTPUT. leg_matrix is the UNSHARDED per-leg set (one
+#                 entry per version leg, no shard fields) — smoke.yml's
+#                 build-pkg job matrixes over it so each version leg builds
+#                 its .pkg once, shared by every shard (issue #857).
 #
 #   image-ref   Compose the pfSense/civm image ref from env vars.
 #               Reads: INPUT_REF, INPUT_VERSION, INPUT_IMAGE_NAME,
@@ -157,6 +161,12 @@ _rl_legs() {
         S="$_l_mod_count"
     fi
 
+    # Snapshot the UNSHARDED per-leg set (one entry per version leg, no shard
+    # fields) before the expansion below fans it out to legs x shards. This
+    # feeds smoke.yml's build-pkg job (issue #857): one .pkg build per version
+    # leg, shared by every shard of that leg — not one build per shard.
+    _l_leg_matrix="$FILTERED"
+
     # Expand ALWAYS (even at S=1) so every matrix entry uniformly carries
     # shard/shard_total as STRINGS (workflow_call inputs are typed string;
     # avoid number/string coercion surprises). Every leg gets S copies —
@@ -179,6 +189,7 @@ _rl_legs() {
         {
             printf 'scope=%s\n' "$SCOPE"
             printf 'ci_matrix<<__EOF__\n%s\n__EOF__\n' "$FILTERED"
+            printf 'leg_matrix<<__EOF__\n%s\n__EOF__\n' "$_l_leg_matrix"
             printf 'pytest_filter<<__EOF__\n%s\n__EOF__\n' "$K"
         } >> "$GITHUB_OUTPUT"
     fi

--- a/tests/shell/resolve_legs_spec.sh
+++ b/tests/shell/resolve_legs_spec.sh
@@ -378,6 +378,67 @@ Describe 'resolve-legs.sh legs — shard expansion (issue #797)'
 
 End
 
+Describe 'resolve-legs.sh legs — leg_matrix output (issue #857)'
+    # Background: smoke.yml's build-pkg job (issue #857) builds the branch
+    # .pkg ONCE PER VERSION LEG by matrixing over the new leg_matrix output,
+    # while the smoke job keeps matrixing over the shard-expanded ci_matrix
+    # (every shard of a leg downloads that one shared artifact). This spec
+    # proves leg_matrix is the UNSHARDED per-leg set (no shard/shard_total
+    # fields) while ci_matrix keeps its existing shard expansion — the two
+    # outputs must diverge exactly this way, or a shard-count leg would
+    # rebuild its .pkg once per shard again.
+
+    setup() {
+        scrub_git_env
+        unset SCOPE_INPUT VERSION_INPUT PYTEST_FILTER_INPUT MARKER_INPUT SHARDS_INPUT GITHUB_OUTPUT GITHUB_ENV PFB_BASE_REF
+    }
+    BeforeEach 'setup'
+
+    # Run `legs` with $GITHUB_OUTPUT pointed at a temp file, extract the
+    # leg_matrix/ci_matrix heredoc blocks, and print jq summaries as plain
+    # `key=value` lines — shellspec has no built-in file-content matcher, so
+    # the It examples assert on this printed summary instead.
+    resolve_outputs() {
+        _gho="$(mktemp "${SHELLSPEC_TMPBASE:-/tmp}/resolve-legs-gho.XXXXXX")"
+        env GITHUB_OUTPUT="$_gho" \
+            CI_MATRIX="$FIXTURE_MATRIX" \
+            EVENT_NAME="workflow_dispatch" \
+            SCOPE_INPUT="full" \
+            SHARDS_INPUT="2" \
+            sh "$SCRIPT" legs --test-dir tests/smoke --label marker >/dev/null 2>&1
+        _leg_json="$(sed -n '/^leg_matrix<<__EOF__$/,/^__EOF__$/p' "$_gho" | sed '1d;$d')"
+        _ci_json="$(sed -n '/^ci_matrix<<__EOF__$/,/^__EOF__$/p' "$_gho" | sed '1d;$d')"
+        rm -f "$_gho"
+        printf 'leg_count=%s\n' "$(printf '%s' "$_leg_json" | jq 'length')"
+        printf 'leg_has_shard=%s\n' "$(printf '%s' "$_leg_json" | jq '[.[] | has("shard")] | any')"
+        printf 'ci_count=%s\n' "$(printf '%s' "$_ci_json" | jq 'length')"
+        printf 'ci_shard_total_2_count=%s\n' "$(printf '%s' "$_ci_json" | jq '[.[] | select(.shard_total == "2")] | length')"
+    }
+
+    It 'full scope + SHARDS_INPUT=2 -> leg_matrix has one unsharded entry per version leg (no shard fields)'
+        # Given: FIXTURE_MATRIX (3 version legs: CE 2.8, CE 2.10, Plus 26.03),
+        #        full scope, SHARDS_INPUT=2 over tests/smoke (43 modules, no clamp).
+        # When: legs runs and $GITHUB_OUTPUT's leg_matrix block is inspected.
+        # Then: leg_matrix carries exactly 3 entries (one per version leg) and
+        #       none of them carry a `shard` field.
+        When call resolve_outputs
+        The status should be success
+        The output should include 'leg_count=3'
+        The output should include 'leg_has_shard=false'
+    End
+
+    It 'full scope + SHARDS_INPUT=2 -> ci_matrix stays shard-expanded (3 legs x 2 shards = 6)'
+        # Given: the same run as above.
+        # When: $GITHUB_OUTPUT's ci_matrix block is inspected.
+        # Then: ci_matrix still carries 6 entries, all shard_total="2" — the
+        #       shard expansion this fix must NOT touch.
+        When call resolve_outputs
+        The status should be success
+        The output should include 'ci_count=6'
+        The output should include 'ci_shard_total_2_count=6'
+    End
+End
+
 Describe 'resolve-legs.sh image-ref'
 
     setup() {


### PR DESCRIPTION
Two coupled cleanups to the live-VM smoke fan-out, both from the 2026-07-05 shard audit. Bundled in one PR (per request) since they overlap in `smoke.yml`.

## #857 — build the `.pkg` once per version leg, not once per shard

`Fixes #857`

Since #856 every leg (CE and Plus) shards `shards`-ways (default 3), and each shard's `smoke-single.yml` call nested its own `build-pkg` job — so a version leg rebuilt a byte-identical `.pkg` up to 3×, and the seconds-long build children rendered as confusing empty "shard" jobs.

- `resolve-legs.sh` now also emits `leg_matrix` — the unsharded per-leg set (one entry per version leg, no shard fields), alongside the existing shard-expanded `ci_matrix`.
- `smoke.yml` gains a `build-pkg` job matrixed over `leg_matrix` (one build per version leg, named without a shard prefix) and passes the shared artifact name to each shard via a new `pkg_artifact` input.
- `smoke-single.yml` gains the optional `pkg_artifact` input: when set it downloads that artifact and its own `build-pkg` is skipped (`if: inputs.pkg_artifact == ''`); when blank it builds its own — so a bare `smoke-single.yml` dispatch and `repo-install.yml`'s direct call are unchanged.
- `build-pkg-linux.yml` untouched.

**Tests:** `tests/shell/resolve_legs_spec.sh` pins `leg_matrix` (one unsharded entry per leg) against `ci_matrix` (shard-expanded) — it fails before the change and passes after. The behaviour-preservation oracle is the live CE+Plus fan-out (below).

## #853 — surface the `-k`/marker filter in the run + job names

`Fixes #853`

A `scope=full` dispatch with a `pytest_filter` runs every leg but selects only the filter's tests, so in the Actions run list it was indistinguishable from a genuine full fan-out.

- A new top-level `run-name` appends `[-k <filter>]` / `[marker: <m>]` from the dispatch inputs.
- The per-leg job `name` appends the same from the *resolved* `prepare` output, so it also surfaces the impacted scope's auto-derived `-k`.
- An unfiltered, default-marker run renders byte-identically to before (both suffixes collapse to empty).

**Tests:** this is GitHub-Actions display behaviour with no local render oracle — a documented out-of-CI limitation. `actionlint` gates the expression syntax and context validity; the visual proof is the live dispatches below.

## #854 — closed separately as already-fixed (not in this PR)

On investigation, #854's core coverage-completeness invariant is already implemented by `tests/test_shard_union.py` (landed via #855/#861, gated in CI via `test.yml`'s `dnspython` install): it asserts the union of every shard's collected node IDs equals the unsharded oracle with each test collected exactly once, plus the committed-table drift gate. That is a strictly stronger, node-id-granularity check than the module-set shellspec #854 proposed — which the #855 test-level hybrid split would now under-cover. Closed on the issue with that rationale.

## Live validation (run on this branch as part of landing)

- `smoke.yml scope=full` (unfiltered) — full CE+Plus fan-out green, one `build-pkg` job per version leg, shards consume the shared artifact.
- `smoke.yml scope=full -f pytest_filter=…` — run-name + job names show `[-k …]`.
- bare `smoke-single.yml` dispatch — the build-if-absent path still builds and installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
