### PR TITLE
pfblockerng: drain output buffer so upgrade progress/hook output streams fully

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3121,6 +3121,12 @@ function pfb_logger($log, $logtype) {
 	// detached rc.d daemons are untouched -- this is visibility only, not the process-safety.
 	if (($logtype == 1 || $logtype == 2) && !empty($pfb['hook_lifecycle'])) {
 		print "{$log}";
+		// The pkg Software page (pkg_mgr_install.php) runs the resync under an
+		// active PHP output buffer, which holds each print until the buffer is
+		// flushed -- so its trailing content is delivered late or lost and the
+		// page shows progress cut off "mid way". Drain the ob buffer (if any)
+		// and the SAPI so every line reaches the tailed log immediately.
+		pfb_flush_output();
 	}
 }
 
@@ -4041,6 +4047,27 @@ function pfb_pkg_op_tears_down(string $op): bool {
 
 
 /*
+ * Push already-printed mirror bytes all the way to the client NOW (shared by the two
+ * lifecycle mirrors: pfb_logger()'s #690 progress mirror and pfb_mirror_hook_output()'s
+ * #693 hook-body mirror).
+ *
+ * The pkg Software page (pkg_mgr_install.php) runs the pfBlockerNG resync under an active
+ * PHP output buffer. A plain print() then only reaches the ob buffer, which is flushed in
+ * chunks / at request end -- so on a long upgrade the page shows the progress + hook output
+ * cut off "mid way" until the very end (or drops the tail if the poll stops first). Draining
+ * the ob buffer (when one is active) and then the SAPI makes each mirrored line stream
+ * immediately. No-op when no buffer is active (e.g. a CLI run, stdout already unbuffered),
+ * so it is safe on every path.
+ */
+function pfb_flush_output(): void {
+	if (ob_get_level() > 0) {
+		@ob_flush();
+	}
+	@flush();
+}
+
+
+/*
  * #693 (follow-up to #690): mirror a completed hook's captured stdout/stderr to the
  * package-manager output during a pkg install/upgrade/uninstall.
  *
@@ -4071,6 +4098,10 @@ function pfb_mirror_hook_output(string $logfile, int $offset): void {
 	$body = @file_get_contents($logfile, FALSE, NULL, $offset, $end - $offset);
 	if (is_string($body) && $body !== '') {
 		print $body;
+		// Same reason as the #690 mirror in pfb_logger(): the pkg Software page
+		// runs this under an active PHP output buffer, so without draining it
+		// the hook body is held back and the page shows it truncated "mid way".
+		pfb_flush_output();
 	}
 }
 

--- a/tests/php/LiveLogPkgMirrorTest.php
+++ b/tests/php/LiveLogPkgMirrorTest.php
@@ -42,9 +42,16 @@ final class LiveLogPkgMirrorTest extends TestCase
 
 	private function capture(string $msg, int $logtype): string
 	{
+		// pfb_logger()'s mirror now drains the output buffer (pfb_flush_output -> ob_flush) so an
+		// upgrade page streams live instead of truncating. Capture with TWO nested buffers: the
+		// mirror's ob_flush pushes the inner into the outer, which we then read -- otherwise the
+		// drained bytes would escape to the real STDOUT and ob_get_clean() would see nothing.
+		ob_start();
 		ob_start();
 		pfb_logger($msg, $logtype);
-		return (string) ob_get_clean();
+		$inner = (string) ob_get_clean();
+		$outer = (string) ob_get_clean();
+		return $outer . $inner;
 	}
 
 	public function testMainLogMirrorsToStdoutDuringAPackageLifecycleCallback(): void

--- a/tests/php/PfbHookOutputMirrorTest.php
+++ b/tests/php/PfbHookOutputMirrorTest.php
@@ -50,9 +50,16 @@ final class PfbHookOutputMirrorTest extends TestCase
 
 	private function capture(int $offset): string
 	{
+		// pfb_mirror_hook_output() now drains the output buffer (pfb_flush_output -> ob_flush) so
+		// the upgrade page streams the hook body instead of truncating it. Capture with TWO nested
+		// buffers: the mirror's ob_flush pushes the inner into the outer, which we then read --
+		// otherwise the drained bytes would escape to the real STDOUT and ob_get_clean() see nothing.
+		ob_start();
 		ob_start();
 		pfb_mirror_hook_output($this->logfile, $offset);
-		return (string) ob_get_clean();
+		$inner = (string) ob_get_clean();
+		$outer = (string) ob_get_clean();
+		return $outer . $inner;
 	}
 
 	public function testMirrorsOnlyTheHookBodyDeltaDuringALifecycleCallback(): void
@@ -93,8 +100,12 @@ final class PfbHookOutputMirrorTest extends TestCase
 	{
 		global $pfb;
 		$pfb['hook_lifecycle'] = 'install';
+		// Empty path -> the guard returns before any print/drain; nested capture stays ''.
+		ob_start();
 		ob_start();
 		pfb_mirror_hook_output('', 0);
-		$this->assertSame('', (string) ob_get_clean());
+		$inner = (string) ob_get_clean();
+		$outer = (string) ob_get_clean();
+		$this->assertSame('', $outer . $inner);
 	}
 }

--- a/tests/php/PfbMirrorFlushTest.php
+++ b/tests/php/PfbMirrorFlushTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/*
+ * During a pkg install/upgrade pfSense's Software page (pkg_mgr_install.php) runs
+ * the pfBlockerNG resync under an ACTIVE PHP output buffer. The two lifecycle
+ * mirrors -- pfb_logger()'s #690 progress mirror and pfb_mirror_hook_output()'s
+ * #693 hook-body mirror -- print() into that buffer, which is flushed only in
+ * chunks / at request end, so a long upgrade shows the progress + hook output cut
+ * off "mid way" (and drops the tail if the poll stops first). pfb_flush_output()
+ * drains the ob buffer + SAPI after each mirror print so every line streams now.
+ *
+ * The existing PfbHookOutputMirrorTest captures via ob_start()+ob_get_clean(),
+ * which reads the buffer directly and so sees the print whether or not it was
+ * drained -- it cannot prove this fix. This pins the DRAIN directly: run the mirror
+ * under ob_start() in a child whose real stdout is a redirected FILE, then SIGKILL
+ * the child before the shutdown that would flush the buffer. The bytes are on disk
+ * only if the code drained the buffer itself -- red without pfb_flush_output()
+ * (output dies in the ob buffer with the process), green with it.
+ */
+#[CoversFunction('pfb_mirror_hook_output')]
+#[CoversFunction('pfb_logger')]
+#[CoversFunction('pfb_flush_output')]
+final class PfbMirrorFlushTest extends TestCase
+{
+	private const BODY   = "Firing up HAProxy ACL update hook\nReloading HAProxy\n";
+	private const MARKER = 'pfb-upgrade-progress-marker';
+
+	private array $tmp = [];
+
+	protected function setUp(): void
+	{
+		// SIGKILL-before-shutdown is how we deny the process its exit-time fflush;
+		// without ext-posix there is no portable way to observe the pre-exit flush.
+		if (!function_exists('posix_kill') || !defined('SIGKILL')) {
+			$this->markTestSkipped('ext-posix (posix_kill/SIGKILL) required to observe the pre-exit flush');
+		}
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->tmp as $f) {
+			@unlink($f);
+		}
+		$this->tmp = [];
+	}
+
+	private function tempfile(string $prefix): string
+	{
+		$f = (string) tempnam(sys_get_temp_dir(), $prefix);
+		$this->tmp[] = $f;
+		return $f;
+	}
+
+	/*
+	 * Run the fixture child with its stdout redirected to a file, wait for it to die
+	 * (SIGKILL), and return exactly what landed on disk.
+	 */
+	private function runChild(string $mode, string $logfile, int $offset, string $marker): string
+	{
+		$child   = __DIR__ . '/fixtures/mirror_flush_child.php';
+		$outfile = $this->tempfile('pfb_mirror_out_');
+		$cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($child) . ' '
+			. escapeshellarg($mode) . ' ' . escapeshellarg($logfile) . ' '
+			. escapeshellarg((string) $offset) . ' ' . escapeshellarg($marker)
+			. ' > ' . escapeshellarg($outfile) . ' 2>/dev/null';
+		exec($cmd);
+		return (string) @file_get_contents($outfile);
+	}
+
+	public function testHookBodyReachesRedirectedStdoutBeforeProcessExit(): void
+	{
+		// Given a hook that appended BODY after the framing-marker offset,
+		$logfile = $this->tempfile('pfb_mirror_log_');
+		file_put_contents($logfile, "[ pfB Hook ] post haproxy\n");
+		clearstatcache(TRUE, $logfile);
+		$offset = (int) filesize($logfile);
+		file_put_contents($logfile, self::BODY, FILE_APPEND);
+
+		// When the mirror runs under an active output buffer and the child is SIGKILLed before
+		// the shutdown that would flush it,
+		$out = $this->runChild('hook', $logfile, $offset, '');
+
+		// Then the whole body is already on disk -- pfb_mirror_hook_output() drained the buffer
+		// itself. Pre-fix it would die in the ob buffer with the process and $out would be empty.
+		$this->assertSame(self::BODY, $out);
+	}
+
+	public function testLoggerLifecycleMirrorReachesRedirectedStdoutBeforeProcessExit(): void
+	{
+		// Given a lifecycle callback, a case-1 pfb_logger() line is mirrored to stdout (#690).
+		// When it runs under an active output buffer and the child is SIGKILLed before exit,
+		$out = $this->runChild('logger', '', 0, self::MARKER);
+
+		// Then the mirrored line is already on disk -- pfb_logger() drained the buffer itself.
+		// Pre-fix it would sit in the ob buffer and be lost, leaving $out without the marker.
+		$this->assertStringContainsString(self::MARKER, $out);
+	}
+}

--- a/tests/php/fixtures/mirror_flush_child.php
+++ b/tests/php/fixtures/mirror_flush_child.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Child process for PfbMirrorFlushTest.
+ *
+ * Models the pkg Software page condition: the resync runs under an ACTIVE PHP
+ * output buffer (ob_start). Each mirror print() lands in that buffer; only an
+ * explicit ob_flush()+flush() (pfb_flush_output(), the code under test) pushes it
+ * to the real stdout, which the parent redirects to a FILE. The child then
+ * HARD-KILLS itself with SIGKILL, so PHP's shutdown -- which would otherwise flush
+ * the ob buffer -- never runs. The printed bytes are on disk afterwards ONLY if
+ * the production code drained the buffer itself; without that they die in the ob
+ * buffer with the process and the file stays empty.
+ *
+ * argv: <mode: hook|logger> <logfile> <offset> <marker>
+ *   hook   -> pfb_mirror_hook_output($logfile, $offset) prints the log delta
+ *   logger -> pfb_logger("<marker>\n", 1) prints via the #690 lifecycle mirror
+ */
+
+// Capture argv BEFORE bootstrap.php clears $argv (it blanks it to keep the
+// pfblockerng.inc daemon dispatch dormant).
+$args = $argv;
+require __DIR__ . '/../bootstrap.php';
+
+global $pfb;
+$mode    = $args[1] ?? '';
+$logfile = $args[2] ?? '';
+$offset  = (int) ($args[3] ?? 0);
+$marker  = $args[4] ?? '';
+
+// A pkg lifecycle callback is what turns on both mirrors.
+$pfb['hook_lifecycle'] = 'install';
+
+// The pkg Software page runs the resync under output buffering -- reproduce that,
+// so a print() reaches the fd only if the code under test drains the ob buffer.
+ob_start();
+
+if ($mode === 'logger') {
+	pfb_logger("{$marker}\n", 1);
+} else {
+	pfb_mirror_hook_output($logfile, $offset);
+}
+
+// Terminate WITHOUT PHP's shutdown sequence (which flushes the ob buffer). SIGKILL
+// leaves any still-buffered output unwritten — the whole point of the probe.
+posix_kill(posix_getpid(), SIGKILL);


### PR DESCRIPTION
## Problem

During a pkg install/upgrade/uninstall, pfSense's Software page (`pkg_mgr_install.php`) runs the pfBlockerNG resync under an **active PHP output buffer**. The two lifecycle mirrors — `pfb_logger()`'s #690 progress mirror and `pfb_mirror_hook_output()`'s #693 hook-body mirror — `print()` into that buffer, which is only flushed in chunks / at request end. On a long upgrade the page therefore shows the progress and hook output cut off **"mid way"** (and drops the tail entirely if the page stops polling once the pkg pid is gone).

## Why a plain flush() is not enough

PHP CLI stdout is unbuffered (direct `write()` syscall), so `flush()` there is a no-op — the trapped bytes are sitting in the **ob** buffer, and only `ob_flush()` drains that. (The first cut of this fix used `flush()` only; the new test caught that it changed nothing and drove the correct fix.)

## Fix

Add `pfb_flush_output()` — `ob_flush()` when a buffer is active, then `flush()` — and call it after each mirror `print`. Every mirrored line then reaches the tailed log immediately. It is a **no-op on every non-upgrade path**: the mirrors only run inside a pkg lifecycle callback (`$pfb['hook_lifecycle']`), and `ob_flush` is skipped when no buffer is active (e.g. a CLI/Run-Now pass, where the Update page's own AJAX tail reads the run-log file directly and is untouched).

## Tests

- **New `PfbMirrorFlushTest`** (fail-before/pass-after): runs each mirror under `ob_start()` in a child process whose real stdout is a redirected file, then `SIGKILL`s the child *before* the shutdown flush. The bytes survive only if the code drained the buffer itself — **red with `flush()` alone, green with `ob_flush()`**. Covers both mirror sites (`pfb_mirror_hook_output` and the `pfb_logger` #690 path).
- The existing ob-capture mirror tests (`PfbHookOutputMirrorTest`, `LiveLogPkgMirrorTest`) now nest an inner buffer so production's `ob_flush` pushes into the outer capture — same assertions, adapted capture.
- Full PHPUnit suite green (the 3 `*Prefetch*` "pattern file cannot be created" failures are pre-existing and environment-specific — they fail identically without this change, on a root/macOS filesystem; green on CI). PHPStan + PHPCS clean on the touched file.

**Out-of-CI limitation:** the true end-to-end proof is watching a real pkg upgrade stream on the Software page (a live-VM upgrade), which isn't a PR-blocking CI leg; the subprocess test above pins the buffer-drain behaviour at the unit level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ooLjvBBm6oznTBUg9mxVF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live progress and mirrored hook output so it appears immediately on the package page, even during long-running operations.
  * Prevented buffered output from being delayed or lost when a process ends unexpectedly.

* **Tests**
  * Added coverage for output flushing behavior in live logging and hook mirroring.
  * Updated existing tests to handle nested buffering correctly and verify empty-output cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->