### PR TITLE
pfblockerng: open the dnsbl stats DB on a control-channel enable (#870)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2447,6 +2447,34 @@ def _dnsbl_stats_wanted() -> bool:
     return bool(pfb["python_blacklist"] or pfb.get("forwarding"))
 
 
+def _open_dnsbl_stats_db_if_wanted() -> None:
+    # Issue #862 / #870: open the dnsbl stats SQLite DB when stats are newly wanted but
+    # init left it closed (a forwarding-off, no-feeds boot skips the open). Shared by
+    # every site that flips python_blacklist True AFTER init -- the ADR-10 swap
+    # (rebuild_and_swap) and the PFBL-03 control-channel enable / timed re-enable
+    # (pfb_apply_control_command, python_control_sleep) -- so all post-init enable paths
+    # stay consistent; else _db_flush_dnsbl and _log_upstream_block (both gated on
+    # sqlite3_dnsbl_con) silently drop every counter until the next full restart.
+    #
+    # Idempotent (the not-sqlite3_dnsbl_con guard no-ops when init already opened it) and
+    # off the DNS fast path: pfb_db_validate -> _db_run is _db_lock-serialized with a
+    # check_same_thread=False connection, safe on the watcher / control-sleep threads.
+    # Same mod_sqlite3 gate + two-attempt retry shape as init_standard's "Enable DNSBL
+    # statistics" block.
+    if pfb["mod_sqlite3"] and not pfb["sqlite3_dnsbl_con"] and _dnsbl_stats_wanted():
+        for i in range(2):
+            try:
+                if pfb_db_validate(DB_DNSBL):
+                    pfb["sqlite3_dnsbl_con"] = True
+                    break
+            except Exception as e:
+                sys.stderr.write(
+                    "[pfBlockerNG]: Failed to open pfb_py_dnsbl.sqlite database (Attempt: {}/2): {}".format(i + 1, e)
+                )
+                if os.path.isfile(pfb["pfb_py_dnsbl"]):
+                    os.remove(pfb["pfb_py_dnsbl"])
+
+
 def _db_apply(task: tuple) -> None:
     # Synchronous fallback when no DB worker is running (init, tests).
     kind = task[0]
@@ -3007,6 +3035,9 @@ def python_control_sleep(duration: int, arg: Any) -> bool:
     try:
         time.sleep(duration)
         pfb["python_blacklist"] = True
+        # Issue #870: the timed re-enable newly wants DNSBL stats too -- open the DB
+        # init skipped, same as the control-channel enable and the ADR-10 swap.
+        _open_dnsbl_stats_db_if_wanted()
     except Exception as e:
         sys.stderr.write("[pfBlockerNG] python_control_sleep: {}".format(e))
         pass
@@ -3082,6 +3113,10 @@ def pfb_apply_control_command(control_command: list[str]) -> tuple[bool, str]:
             control_rcd = True
             control_msg = "Python_control: DNSBL enabled"
             pfb["python_blacklist"] = True
+            # Issue #870: enabling via the control channel newly satisfies
+            # _dnsbl_stats_wanted(); open the stats DB init skipped at boot (sibling of
+            # #862's swap-path open) so per-feed/Upstream counters do not silently no-op.
+            _open_dnsbl_stats_db_if_wanted()
 
         elif control_command[1] == "addbypass" or control_command[1] == "removebypass":
             # PFBL-03: reject a malformed bypass command instead of raising
@@ -5269,29 +5304,12 @@ def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_coun
     # a reload that brings lists legitimately re-enables blocking, exactly as init does.)
     if new_snapshot.data_db or new_snapshot.zone_db or new_snapshot.regex_db or new_snapshot.allow_regex_db:
         pfb["python_blacklist"] = True
-    # Issue #862 (sibling of #860): init opens the dnsbl stats DB only when
-    # _dnsbl_stats_wanted() held at boot. A swap that NEWLY satisfies the predicate here
+    # Issue #862 (sibling of #860): a swap that NEWLY satisfies _dnsbl_stats_wanted()
     # -- python_blacklist just flipped True above (feeds added post-boot, no Unbound
-    # restart) -- must open the DB init skipped, or every per-feed and Upstream counter
-    # increment silently no-ops (both _db_flush_dnsbl and _log_upstream_block gate on
-    # sqlite3_dnsbl_con) until the next full restart. Off the DNS fast path: this runs on
-    # the watcher thread, and pfb_db_validate -> _db_run is _db_lock-serialized with a
-    # check_same_thread=False connection, so it is safe beside the query threads. Same
-    # mod_sqlite3 gate + two-attempt retry shape as init_standard's "Enable DNSBL
-    # statistics" block; the not-sqlite3_dnsbl_con guard keeps it idempotent (the
-    # synchronous init swap, where init already opened the DB, is a no-op).
-    if pfb["mod_sqlite3"] and not pfb["sqlite3_dnsbl_con"] and _dnsbl_stats_wanted():
-        for i in range(2):
-            try:
-                if pfb_db_validate(DB_DNSBL):
-                    pfb["sqlite3_dnsbl_con"] = True
-                    break
-            except Exception as e:
-                sys.stderr.write(
-                    "[pfBlockerNG]: Failed to open pfb_py_dnsbl.sqlite database (Attempt: {}/2): {}".format(i + 1, e)
-                )
-                if os.path.isfile(pfb["pfb_py_dnsbl"]):
-                    os.remove(pfb["pfb_py_dnsbl"])
+    # restart) -- must open the stats DB init skipped at boot, or every per-feed and
+    # Upstream counter increment silently no-ops until the next restart. Shared with the
+    # PFBL-03 control-channel enable path (issue #870); see _open_dnsbl_stats_db_if_wanted().
+    _open_dnsbl_stats_db_if_wanted()
     if emit_counts:
         dnsbl_emit_count(pfb["pfb_py_count"], new_snapshot.counts)
         dnsbl_emit_count(pfb["pfb_py_regex_count"], new_snapshot.regex_count)

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2471,8 +2471,14 @@ def _open_dnsbl_stats_db_if_wanted() -> None:
                 sys.stderr.write(
                     "[pfBlockerNG]: Failed to open pfb_py_dnsbl.sqlite database (Attempt: {}/2): {}".format(i + 1, e)
                 )
+                # Now reachable from three threads (swap, control-enable, timed re-enable):
+                # a concurrent caller may have already removed the corrupt DB, so a losing
+                # race on the delete is a harmless no-op, not an uncaught FileNotFoundError.
                 if os.path.isfile(pfb["pfb_py_dnsbl"]):
-                    os.remove(pfb["pfb_py_dnsbl"])
+                    try:
+                        os.remove(pfb["pfb_py_dnsbl"])
+                    except OSError:
+                        pass
 
 
 def _db_apply(task: tuple) -> None:

--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -219,6 +219,40 @@ class TestControlEnableOpensDnsblStatsDb:
         assert P._db_conns[P.DB_DNSBL] is first_con, "an already-open stats DB must not be reconnected by enable"
         assert first_con.execute("SELECT counter FROM dnsbl WHERE groupname = 'Upstream'").fetchone() == (7,)
 
+    def test_open_helper_survives_a_losing_race_on_corrupt_db_delete(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """Concurrency guard: the shared open helper now runs from three threads (the
+        ADR-10 swap, the control-channel enable, the timed re-enable). Two racing to
+        recover the SAME corrupt stats DB can both pass the ``isfile()`` check, so the
+        loser's ``os.remove()`` hits an already-deleted file. That FileNotFoundError must
+        NOT escape the helper -- from the un-wrapped enable call site it would propagate
+        out of ``pfb_apply_control_command``, kill ``pfb_control_watcher``'s thread, and
+        silently disable the control channel until Unbound restarts (issue #870).
+
+        RED without the inner try/except: os.remove's FileNotFoundError propagates and
+        this call raises.
+        """
+        db = tmp_path / "dnsbl.sqlite"
+        db.write_text("corrupt")  # a real file so os.path.isfile() is genuinely True
+        P.pfb["mod_sqlite3"] = True
+        P.pfb["pfb_py_dnsbl"] = str(db)
+        P.pfb["python_blacklist"] = True  # stats wanted -> the open path runs
+        P.pfb["sqlite3_dnsbl_con"] = False
+
+        # Every open attempt fails (corrupt DB) AND the file vanished under us (the other
+        # thread already removed it), so os.remove raises FileNotFoundError.
+        def _fail_open(*_a: Any, **_k: Any) -> bool:
+            raise OSError("simulated corrupt DB open failure")
+
+        def _already_removed(_path: str) -> None:
+            raise FileNotFoundError(_path)
+
+        monkeypatch.setattr(P, "pfb_db_validate", _fail_open)
+        monkeypatch.setattr(P.os, "remove", _already_removed)
+
+        # Must not raise; both attempts fail so the DB stays closed.
+        P._open_dnsbl_stats_db_if_wanted()
+        assert P.pfb["sqlite3_dnsbl_con"] is False
+
 
 class TestSharedHandlerBypass:
     def test_addbypass_adds_ip_to_gplistdb(self) -> None:

--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -100,6 +100,126 @@ class TestSharedHandlerDisableEnable:
         assert P.pfb["python_blacklist"] is False
 
 
+class TestControlEnableOpensDnsblStatsDb:
+    """Scenario: enabling DNSBL via the PFBL-03 control channel (or the timed re-enable)
+    opens the dnsbl stats DB that init left closed at boot, so a subsequent counter flush
+    lands.
+
+    Background:
+        init_standard opens ``sqlite3_dnsbl_con`` only when ``_dnsbl_stats_wanted()``
+        (python_blacklist OR forwarding) holds AT INIT; a forwarding-off / no-feeds boot
+        leaves it False. A later control-channel ``enable`` -- or the ``disable.<dur>``
+        timed re-enable -- raises ``python_blacklist``, newly satisfying the predicate.
+        Pre-fix neither control site re-opened the DB, so ``_db_flush_dnsbl`` (and
+        ``_log_upstream_block``, both gated on ``sqlite3_dnsbl_con``) silently dropped
+        every counter until a full restart -- the same silent-loss class #862 fixed for
+        the ADR-10 swap path, reached via the control channel instead (issue #870).
+
+    Each test asserts the BEFORE-state (DB closed, stats not wanted) first, so a green
+    proves the enable CAUSED the open. Every input of the shared open guard is covered:
+    the enable opens it, the timed re-enable opens it, mod_sqlite3=False keeps it closed,
+    and an already-open DB is not reconnected.
+    """
+
+    def test_control_enable_opens_db_and_flush_lands_counter(self, tmp_path: Any) -> None:
+        """A control-channel ``enable`` on a boot that left the stats DB closed opens it,
+        and a counter flush then lands -- the exact effect the bug silently lost.
+
+        RED pre-fix: the enable branch raised python_blacklist but left sqlite3_dnsbl_con
+        False, so the ``assert ... sqlite3_dnsbl_con`` below fails.
+        """
+        # Given: a forwarding-off, no-feeds boot -> init left the stats DB closed.
+        P.pfb["mod_sqlite3"] = True  # pin every guard input so "closed" is provably the predicate, not sqlite off
+        P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
+        P.pfb["python_blacklist"] = False
+        P.pfb["forwarding"] = False
+        assert not P.pfb["sqlite3_dnsbl_con"]
+        assert not P._dnsbl_stats_wanted()
+
+        # When: DNSBL is enabled over the control channel.
+        applied, _ = P.pfb_apply_control_command(["python_control", "enable"])
+        assert applied is True
+
+        # Then: the gate flipped AND the stats DB is now open.
+        assert P.pfb["python_blacklist"] is True
+        assert P.pfb["sqlite3_dnsbl_con"], (
+            "a control-channel enable that newly wants stats must open the dnsbl DB (issue #870)"
+        )
+
+        # And a counter flush actually lands now (pre-fix: guarded no-op).
+        assert P._db_flush_dnsbl({"Upstream": 1})
+        con = P._db_conns[P.DB_DNSBL]
+        row = con.execute("SELECT counter FROM dnsbl WHERE groupname = 'Upstream'").fetchone()
+        assert row == (1,), f"Upstream counter not incremented after enable opened the DB: {row!r}"
+
+    def test_timed_reenable_opens_db(self, tmp_path: Any) -> None:
+        """The other post-init control site: the ``disable.<dur>`` timed re-enable
+        (python_control_sleep) also newly wants stats and must open the DB. Called with
+        duration 0 so it returns immediately -- no real wait, no spawned thread.
+
+        RED pre-fix: sqlite3_dnsbl_con stays False across the re-enable.
+        """
+        P.pfb["mod_sqlite3"] = True  # pin every guard input so "closed" is provably the predicate, not sqlite off
+        P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
+        P.pfb["python_blacklist"] = False
+        P.pfb["forwarding"] = False
+        assert not P.pfb["sqlite3_dnsbl_con"]
+
+        # When: the timed re-enable fires (duration 0 -> returns immediately).
+        assert P.python_control_sleep(0, None) is True
+
+        # Then: blocking is back on AND the stats DB opened.
+        assert P.pfb["python_blacklist"] is True
+        assert P.pfb["sqlite3_dnsbl_con"], (
+            "the timed re-enable that newly wants stats must open the dnsbl DB (issue #870)"
+        )
+
+    def test_control_enable_does_not_open_db_when_mod_sqlite3_unavailable(self, tmp_path: Any) -> None:
+        """mod_sqlite3 conjunct: with the sqlite3 module unavailable, an enable that WOULD
+        otherwise want stats must still NOT open the DB -- matching init's own gate.
+
+        Failable guard: drop the ``mod_sqlite3 and`` conjunct and this fails -- sqlite3 is
+        importable in the test env, so the open would succeed and sqlite3_dnsbl_con flip True.
+        """
+        P.pfb["mod_sqlite3"] = False  # sqlite3 module unavailable on this install
+        P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
+        P.pfb["python_blacklist"] = False
+        P.pfb["forwarding"] = False
+        assert not P.pfb["sqlite3_dnsbl_con"]
+
+        applied, _ = P.pfb_apply_control_command(["python_control", "enable"])
+        assert applied is True
+
+        # The gate flips and stats ARE wanted, but mod_sqlite3=False keeps the DB closed.
+        assert P.pfb["python_blacklist"] is True
+        assert P._dnsbl_stats_wanted()
+        assert not P.pfb["sqlite3_dnsbl_con"], "mod_sqlite3=False must gate the control-enable DB open"
+        assert P.DB_DNSBL not in P._db_conns, "no connection may open when the sqlite3 module is unavailable"
+
+    def test_control_enable_does_not_reopen_an_already_open_db(self, tmp_path: Any) -> None:
+        """Idempotency: when the stats DB is already open (init opened it), an enable must
+        NOT reconnect -- the not-sqlite3_dnsbl_con guard makes the open a no-op, preserving
+        the existing connection and its accumulated counter."""
+        P.pfb["mod_sqlite3"] = True  # pin every guard input so "closed" is provably the predicate, not sqlite off
+        P.pfb["pfb_py_dnsbl"] = str(tmp_path / "dnsbl.sqlite")
+
+        # Given: the DB is already open with an accumulated Upstream counter.
+        P.pfb["python_blacklist"] = True
+        P.pfb["sqlite3_dnsbl_con"] = True
+        assert P._db_flush_dnsbl({"Upstream": 7})
+        first_con = P._db_conns[P.DB_DNSBL]
+        assert first_con.execute("SELECT counter FROM dnsbl WHERE groupname = 'Upstream'").fetchone() == (7,)
+
+        # When: an enable is applied while the DB is already open.
+        applied, _ = P.pfb_apply_control_command(["python_control", "enable"])
+        assert applied is True
+
+        # Then: same connection object (no reconnect), counter preserved.
+        assert P.pfb["sqlite3_dnsbl_con"]
+        assert P._db_conns[P.DB_DNSBL] is first_con, "an already-open stats DB must not be reconnected by enable"
+        assert first_con.execute("SELECT counter FROM dnsbl WHERE groupname = 'Upstream'").fetchone() == (7,)
+
+
 class TestSharedHandlerBypass:
     def test_addbypass_adds_ip_to_gplistdb(self) -> None:
         # Given: the IP is NOT in the bypass DB (BEFORE).


### PR DESCRIPTION
## Problem

Sibling of #862 / #860. The PFBL-03 control-channel `enable` branch and the `disable.<dur>` timed re-enable (`python_control_sleep`) both flip `python_blacklist` True **outside** `rebuild_and_swap`, newly satisfying `_dnsbl_stats_wanted()`, but neither opened the dnsbl stats SQLite DB.

On a boot that left `sqlite3_dnsbl_con` False (forwarding off, no feeds — init skipped the DB open), a control-channel enable or timed re-enable then silently dropped every per-feed and Upstream counter increment (`_db_flush_dnsbl` and `_log_upstream_block` both gate on `sqlite3_dnsbl_con`) until the next full restart — the same silent-counter-loss class #862 fixed for the swap path, reached via the control channel instead.

## Fix

Factor #862's stats-DB open sequence into a shared `_open_dnsbl_stats_db_if_wanted()` helper and call it from all three post-init enable sites — the swap path (`rebuild_and_swap`), the control-channel `enable`, and the timed re-enable — so they stay consistent. The open is idempotent (the `not sqlite3_dnsbl_con` guard no-ops when init already opened it), `mod_sqlite3`-gated, and off the DNS fast path (`_db_lock`-serialized, `check_same_thread=False`).

## Tests

`tests/test_pfbl03_control_channel.py::TestControlEnableOpensDnsblStatsDb` — red→green pinning:

- control-channel `enable` on a closed-DB boot opens the DB and a counter flush lands (RED pre-fix);
- the timed re-enable opens it too (RED pre-fix);
- `mod_sqlite3=False` keeps it closed (guard branch);
- an already-open DB is not reconnected (idempotency).

Verified failing on pre-fix code for the exact reason, passing after. Full suite: 2154 passed, 4 skipped.

Fixes #870