### PR TITLE
pfblockerng: fix Custom Source/Destination alias autocomplete + DNSBL save-reset

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -531,16 +531,24 @@ function pfb_exclude_alias_types(): array {
 	return ['host', 'network', 'url', 'urltable'];
 }
 
+// Port-bearing firewall alias types, valid for the Adv. In/Outbound Custom Port field --
+// the port-side counterpart to pfb_exclude_alias_types(): a 'port' alias plus the two
+// port-list types.
+function pfb_port_alias_types(): array {
+	return ['port', 'url_ports', 'urltable_ports'];
+}
+
 // Build the alias-name maps that feed the Adv. In/Outbound rule autocomplete + the
 // save-time option validation on the IP, DNSBL, and Feed (category-edit) pages
 // (Custom Port + Custom Source/Destination fields). Returned name=>name maps are
 // NAME-KEYED so a save-time array_key_exists($posted, $options) works.
 //
-// Ports: 'port' aliases. Addresses: every address-bearing alias type
-// (pfb_exclude_alias_types() -- host/network/url/urltable), NOT just 'network', so a
-// Host alias (a single IP) autocompletes and saves too. pfB_-managed (pfB_*) aliases
-// are skipped from the address list: the field help forbids them and they are not
-// valid rule sources.
+// Ports: every port-bearing type (pfb_port_alias_types() -- port/url_ports/urltable_ports).
+// Addresses: every address-bearing type (pfb_exclude_alias_types() -- host/network/url/
+// urltable), NOT just 'network', so a Host alias (a single IP) autocompletes and saves too.
+// pfB_-managed (pfB_*) aliases are skipped from BOTH lists: the field help forbids them
+// (e.g. the package's own pfB_DNSBL_Ports port alias) and they are not valid user rule
+// sources.
 //
 // @param array $aliases The config_get_path('aliases/alias', []) list.
 // @return array{ports: array<string,string>, networks: array<string,string>}
@@ -549,13 +557,14 @@ function pfb_alias_autocomplete_lists(array $aliases): array {
 	$networks = [];
 	foreach ($aliases as $alias) {
 		$name = (string) ($alias['name'] ?? '');
-		if ($name === '') {
+		// Skip empty names and pfB_-managed aliases (forbidden in both fields).
+		if ($name === '' || str_starts_with($name, PFB_MANAGED_FILTER_PFX)) {
 			continue;
 		}
 		$type = (string) ($alias['type'] ?? '');
-		if ($type === 'port') {
+		if (in_array($type, pfb_port_alias_types(), TRUE)) {
 			$ports[$name] = $name;
-		} elseif (in_array($type, pfb_exclude_alias_types(), TRUE) && !str_starts_with($name, PFB_MANAGED_FILTER_PFX)) {
+		} elseif (in_array($type, pfb_exclude_alias_types(), TRUE)) {
 			$networks[$name] = $name;
 		}
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -531,6 +531,37 @@ function pfb_exclude_alias_types(): array {
 	return ['host', 'network', 'url', 'urltable'];
 }
 
+// Build the alias-name maps that feed the Adv. In/Outbound rule autocomplete + the
+// save-time option validation on the IP, DNSBL, and Feed (category-edit) pages
+// (Custom Port + Custom Source/Destination fields). Returned name=>name maps are
+// NAME-KEYED so a save-time array_key_exists($posted, $options) works.
+//
+// Ports: 'port' aliases. Addresses: every address-bearing alias type
+// (pfb_exclude_alias_types() -- host/network/url/urltable), NOT just 'network', so a
+// Host alias (a single IP) autocompletes and saves too. pfB_-managed (pfB_*) aliases
+// are skipped from the address list: the field help forbids them and they are not
+// valid rule sources.
+//
+// @param array $aliases The config_get_path('aliases/alias', []) list.
+// @return array{ports: array<string,string>, networks: array<string,string>}
+function pfb_alias_autocomplete_lists(array $aliases): array {
+	$ports    = [];
+	$networks = [];
+	foreach ($aliases as $alias) {
+		$name = (string) ($alias['name'] ?? '');
+		if ($name === '') {
+			continue;
+		}
+		$type = (string) ($alias['type'] ?? '');
+		if ($type === 'port') {
+			$ports[$name] = $name;
+		} elseif (in_array($type, pfb_exclude_alias_types(), TRUE) && !str_starts_with($name, PFB_MANAGED_FILTER_PFX)) {
+			$networks[$name] = $name;
+		}
+	}
+	return ['ports' => $ports, 'networks' => $networks];
+}
+
 // Return the configured type of the firewall alias named $alias ('host'|'network'|'urltable'|
 // 'port'|…), or NULL when no alias by that name exists. Reads the configuration directly,
 // which is correct in EVERY context — unlike is_alias(), which consults the in-memory

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1644,9 +1644,9 @@ function pfb_alias_rename_followup(string $old_name, string $new_name): bool
 //
 // The four Advanced Inbound/Outbound alias fields accept different alias
 // types: port fields (aliasports_*) require a pfSense 'port' alias; address
-// fields (aliasaddr_*) require a 'network' or 'host' alias.  This helper
-// encodes that rule in one testable place so the category-edit validation
-// loop and any future caller stay in sync.
+// fields (aliasaddr_*) require an address-bearing alias (host/network/url/urltable).
+// This helper encodes that rule in one testable place so the category-edit
+// validation loop and any future caller stay in sync.
 // ---------------------------------------------------------------------------
 
 /**
@@ -1654,7 +1654,7 @@ function pfb_alias_rename_followup(string $old_name, string $new_name): bool
  * given Advanced Inbound/Outbound field.
  *
  * Port fields (aliasports_*) require a 'port' alias; address fields
- * (aliasaddr_*) require a 'network' or 'host' alias.
+ * (aliasaddr_*) require an address-bearing alias (host/network/url/urltable).
  * Unknown field names return FALSE (fail closed).
  *
  * @param  string $field       One of aliasports_in, aliasports_out,
@@ -1668,7 +1668,9 @@ function pfb_alias_field_type_ok(string $field, string $alias_type): bool
 		return $alias_type === 'port';
 	}
 	if ($field === 'aliasaddr_in' || $field === 'aliasaddr_out') {
-		return $alias_type === 'network' || $alias_type === 'host';
+		// Any address-bearing alias type (host/network/url/urltable), matching the
+		// broadened autocomplete + the DNS-redirect exception source (pfb_exclude_alias_types()).
+		return in_array($alias_type, pfb_exclude_alias_types(), TRUE);
 	}
 	return FALSE;
 }
@@ -1678,7 +1680,7 @@ function pfb_alias_field_type_ok(string $field, string $alias_type): bool
  * fields of a category-edit POST (issue #356, #636).
  *
  * Each non-empty field must name an EXISTING firewall alias whose type the field
- * accepts (port fields -> a port alias; address fields -> a network or host alias).
+ * accepts (port fields -> a port alias; address fields -> an address-bearing alias).
  *
  * Existence AND type are resolved from alias_get_type(), which reads the
  * 'aliases/alias' configuration directly (returning '' for an unknown name) —
@@ -1696,8 +1698,8 @@ function pfb_adv_alias_field_errors(array $post): array
 	$adv_alias_fields = [
 		'aliasports_in'  => ['dir' => 'Port In',         'type_label' => 'Port-type'],
 		'aliasports_out' => ['dir' => 'Port Out',        'type_label' => 'Port-type'],
-		'aliasaddr_in'   => ['dir' => 'Destination In',  'type_label' => 'Network or Host-type'],
-		'aliasaddr_out'  => ['dir' => 'Source Out',      'type_label' => 'Network or Host-type'],
+		'aliasaddr_in'   => ['dir' => 'Destination In',  'type_label' => 'Network, Host or URL-type'],
+		'aliasaddr_out'  => ['dir' => 'Source Out',      'type_label' => 'Network, Host or URL-type'],
 	];
 
 	$errors = [];

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1643,18 +1643,18 @@ function pfb_alias_rename_followup(string $old_name, string $new_name): bool
 // Issue #356 — per-field alias-type validation helper.
 //
 // The four Advanced Inbound/Outbound alias fields accept different alias
-// types: port fields (aliasports_*) require a pfSense 'port' alias; address
-// fields (aliasaddr_*) require an address-bearing alias (host/network/url/urltable).
-// This helper encodes that rule in one testable place so the category-edit
-// validation loop and any future caller stay in sync.
+// types: port fields (aliasports_*) require a port-bearing alias
+// (port/url_ports/urltable_ports); address fields (aliasaddr_*) require an
+// address-bearing alias (host/network/url/urltable). This helper encodes that rule in
+// one testable place so the category-edit validation loop and any future caller stay in sync.
 // ---------------------------------------------------------------------------
 
 /**
  * pfb_alias_field_type_ok — check whether an alias type is valid for a
  * given Advanced Inbound/Outbound field.
  *
- * Port fields (aliasports_*) require a 'port' alias; address fields
- * (aliasaddr_*) require an address-bearing alias (host/network/url/urltable).
+ * Port fields (aliasports_*) require a port-bearing alias (port/url_ports/urltable_ports);
+ * address fields (aliasaddr_*) require an address-bearing alias (host/network/url/urltable).
  * Unknown field names return FALSE (fail closed).
  *
  * @param  string $field       One of aliasports_in, aliasports_out,
@@ -1665,7 +1665,9 @@ function pfb_alias_rename_followup(string $old_name, string $new_name): bool
 function pfb_alias_field_type_ok(string $field, string $alias_type): bool
 {
 	if ($field === 'aliasports_in' || $field === 'aliasports_out') {
-		return $alias_type === 'port';
+		// Any port-bearing alias type (port/url_ports/urltable_ports), matching the
+		// broadened Custom Port autocomplete (pfb_port_alias_types()).
+		return in_array($alias_type, pfb_port_alias_types(), TRUE);
 	}
 	if ($field === 'aliasaddr_in' || $field === 'aliasaddr_out') {
 		// Any address-bearing alias type (host/network/url/urltable), matching the
@@ -1698,8 +1700,8 @@ function pfb_adv_alias_field_errors(array $post): array
 	$adv_alias_fields = [
 		'aliasports_in'  => ['dir' => 'Port In',         'type_label' => 'Port-type'],
 		'aliasports_out' => ['dir' => 'Port Out',        'type_label' => 'Port-type'],
-		'aliasaddr_in'   => ['dir' => 'Destination In',  'type_label' => 'Network, Host or URL-type'],
-		'aliasaddr_out'  => ['dir' => 'Source Out',      'type_label' => 'Network, Host or URL-type'],
+		'aliasaddr_in'   => ['dir' => 'Destination In',  'type_label' => 'Host, Network, URL or URL-Table-type'],
+		'aliasaddr_out'  => ['dir' => 'Source Out',      'type_label' => 'Host, Network, URL or URL-Table-type'],
 	];
 
 	$errors = [];

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -2111,7 +2111,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 		'text',
 		$pconfig['aliasaddr_' . $advmode]
 	))->sethelp('<a target="_blank" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
-		. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the address-type (Host/Network) Alias name.<br />'
+		. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the address-type (Host/Network/URL/URL Table) Alias name.<br />'
 		. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)"
 	)->setWidth(8);
 	$section->add($group);

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1675,27 +1675,12 @@ $options_action			= [	'Disabled' => 'Disabled', 'Deny_Inbound' => 'Deny Inbound'
 
 $options_aliaslog		= [	'enabled' => 'Enabled', 'disabled' => 'Disabled' ];
 
-// Collect all pfSense 'Port' Aliases
-$portslist = $networkslist = '';
-// Init all four to arrays: with no network aliases the address options are never
-// populated below, so a later array_key_exists($v, $options_aliasaddr_*) would fatal
-// on PHP 8 (TypeError on a null array arg) when a settings page is saved.
-$options_aliasports_in = $options_aliasports_out = $options_aliasaddr_in = $options_aliasaddr_out = array();
-
-foreach (config_get_path('aliases/alias', []) as $alias) {
-	if ($alias['type'] == 'port') {
-		$portslist .= "{$alias['name']},";
-		$options_aliasports_in[$alias['name']] = $alias['name'];
-		$options_aliasports_out[$alias['name']] = $alias['name'];
-	}
-	elseif ($alias['type'] == 'network') {
-		$networkslist .= "{$alias['name']},";
-		$options_aliasaddr_in[$alias['name']] = $alias['name'];
-		$options_aliasaddr_out[$alias['name']] = $alias['name'];
-	}
-}
-$ports_list			= trim($portslist, ',');
-$networks_list			= trim($networkslist, ',');
+// Collect all pfSense 'Port' Aliases (+ address-bearing types for Custom Source/Destination)
+$pfb_ac_lists			= pfb_alias_autocomplete_lists(config_get_path('aliases/alias', []));
+$options_aliasports_in		= $options_aliasports_out	= $pfb_ac_lists['ports'];
+$options_aliasaddr_in		= $options_aliasaddr_out	= $pfb_ac_lists['networks'];
+$ports_list			= implode(',', array_keys($pfb_ac_lists['ports']));
+$networks_list			= implode(',', array_keys($pfb_ac_lists['networks']));
 
 $options_autoproto_in		= $options_autoproto_out	= get_ipprotocols();
 $options_agateway_in		= $options_agateway_out		= pfb_get_gateways();
@@ -2126,7 +2111,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 		'text',
 		$pconfig['aliasaddr_' . $advmode]
 	))->sethelp('<a target="_blank" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
-		. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the \'IP Network Type\' Alias name.<br />'
+		. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the address-type (Host/Network) Alias name.<br />'
 		. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)"
 	)->setWidth(8);
 	$section->add($group);

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -414,25 +414,13 @@ $options_sort			= [	'sort' => 'Enable auto-sort', 'no-sort' => 'Disable auto-sor
 $options_aliaslog		= [	'enabled' => 'Enabled', 'disabled' => 'Disabled' ];
 $options_stateremoval		= [	'enabled' => 'Enabled', 'disabled' => 'Disabled' ];
 
-// Collect all pfSense 'Port' Aliases
-$portslist = $networkslist = '';
-$options_aliasports_in = $options_aliasports_out = array();
-
+// Collect all pfSense 'Port' + address-bearing Aliases
 // foreign section: aliases/alias is a pfSense core section, not in registry
-foreach (config_get_path('aliases/alias', []) as $alias) {
-	if ($alias['type'] == 'port') {
-		$portslist .= "{$alias['name']},";
-		$options_aliasports_in[$alias['name']] = $alias['name'];
-		$options_aliasports_out[$alias['name']] = $alias['name'];
-	}
-	elseif ($alias['type'] == 'network') {
-		$networkslist .= "{$alias['name']},";
-		$options_aliasaddr_in[$alias['name']] = $alias['name'];
-		$options_aliasaddr_out[$alias['name']] = $alias['name'];
-	}
-}
-$ports_list			= trim($portslist, ',');
-$networks_list			= trim($networkslist, ',');
+$pfb_ac_lists			= pfb_alias_autocomplete_lists(config_get_path('aliases/alias', []));
+$options_aliasports_in		= $options_aliasports_out	= $pfb_ac_lists['ports'];
+$options_aliasaddr_in		= $options_aliasaddr_out	= $pfb_ac_lists['networks'];
+$ports_list			= implode(',', array_keys($pfb_ac_lists['ports']));
+$networks_list			= implode(',', array_keys($pfb_ac_lists['networks']));
 
 $options_autoproto_in		= $options_autoproto_out	= get_ipprotocols();
 $options_agateway_in		= $options_agateway_out		= pfb_get_gateways();
@@ -1531,8 +1519,8 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 			'text',
 			$pconfig['aliasaddr_' . $advmode]
 		))->sethelp('<a target="_blank" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
-			. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the \'IP Network Type\' Alias name.<br />'
-			. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)<br />Must be a Network or Host-type alias.")
+			. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the address-type (Host/Network) Alias name.<br />'
+			. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)<br />Must be an address-type (Host, Network or URL) alias.")
 		  ->setWidth(8);
 		$section->add($group);
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -1519,8 +1519,8 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 			'text',
 			$pconfig['aliasaddr_' . $advmode]
 		))->sethelp('<a target="_blank" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
-			. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the address-type (Host/Network) Alias name.<br />'
-			. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)<br />Must be an address-type (Host, Network or URL) alias.")
+			. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the address-type (Host/Network/URL/URL Table) Alias name.<br />'
+			. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)<br />Must be an address-type (Host, Network, URL or URL Table) alias.")
 		  ->setWidth(8);
 		$section->add($group);
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3450,7 +3450,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 		'text',
 		$pconfig['aliasaddr_' . $advmode]
 	))->sethelp('<a target="_blank" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
-		. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the address-type (Host/Network) Alias name.<br />'
+		. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the address-type (Host/Network/URL/URL Table) Alias name.<br />'
 		. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)"
 	)->setWidth(8)
 	 ->addClass('dnsbl_ip');

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -497,20 +497,13 @@ $options_safesearch_doh_list	= [
 					'zero.dns0.eu' => 'European public DNS DoH/DoT/DoQ [zero.dns0.eu]'
 					];
 
-// Collect all pfSense 'Port' Aliases
+// Collect all pfSense 'Port' + address-bearing Aliases
 // foreign key — out of ADR-29 gateway scope (aliases/alias is not a pfblockerng* path)
-$ports_list = $networks_list = '';
-foreach (config_get_path('aliases/alias', []) as $alias) {
-	if ($alias['type'] == 'port') {
-		$ports_list .= "{$alias['name']},";
-	} elseif ($alias['type'] == 'network') {
-		$networks_list .= "{$alias['name']},";
-	}
-}
-$ports_list			= trim($ports_list, ',');
-$networks_list			= trim($networks_list, ',');
-$options_aliasports_in		= $options_aliasports_out	= explode(',', $ports_list);
-$options_aliasaddr_in		= $options_aliasaddr_out	= explode(',', $networks_list);
+$pfb_ac_lists			= pfb_alias_autocomplete_lists(config_get_path('aliases/alias', []));
+$options_aliasports_in		= $options_aliasports_out	= $pfb_ac_lists['ports'];
+$options_aliasaddr_in		= $options_aliasaddr_out	= $pfb_ac_lists['networks'];
+$ports_list			= implode(',', array_keys($pfb_ac_lists['ports']));
+$networks_list			= implode(',', array_keys($pfb_ac_lists['networks']));
 
 $options_autoproto_in		= $options_autoproto_out	= get_ipprotocols();
 $options_agateway_in		= $options_agateway_out		= pfb_get_gateways();
@@ -3457,7 +3450,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 		'text',
 		$pconfig['aliasaddr_' . $advmode]
 	))->sethelp('<a target="_blank" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
-		. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the \'IP Network Type\' Alias name.<br />'
+		. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the address-type (Host/Network) Alias name.<br />'
 		. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)"
 	)->setWidth(8)
 	 ->addClass('dnsbl_ip');

--- a/tests/php/AdvAliasFieldErrorsTest.php
+++ b/tests/php/AdvAliasFieldErrorsTest.php
@@ -97,6 +97,28 @@ final class AdvAliasFieldErrorsTest extends TestCase
 		$this->assertSame([], $errors);
 	}
 
+	public function testExistingUrlAliasInAddressFieldIsAccepted(): void
+	{
+		// A URL alias is address-bearing, so an address field accepts it — the
+		// autocomplete offers it, so the validator must not reject it (dropdown/
+		// validator parity). Pre-broadening this was rejected as wrong-type.
+		$this->seedAliases(['MyUrl' => 'url']);
+
+		$errors = pfb_adv_alias_field_errors(['aliasaddr_out' => 'MyUrl']);
+
+		$this->assertSame([], $errors);
+	}
+
+	public function testExistingUrltableAliasInAddressFieldIsAccepted(): void
+	{
+		// A URL-Table alias is likewise a valid rule address source.
+		$this->seedAliases(['MyUrlTable' => 'urltable']);
+
+		$errors = pfb_adv_alias_field_errors(['aliasaddr_in' => 'MyUrlTable']);
+
+		$this->assertSame([], $errors);
+	}
+
 	// -----------------------------------------------------------------------
 	// Non-existent alias — rejected with "Must use an existing Alias".
 	// -----------------------------------------------------------------------
@@ -146,7 +168,7 @@ final class AdvAliasFieldErrorsTest extends TestCase
 
 		// Then rejected as the wrong type
 		$this->assertCount(1, $errors);
-		$this->assertStringContainsString('Must use a Network or Host-type alias', $errors[0]);
+		$this->assertStringContainsString('Must use a Network, Host or URL-type alias', $errors[0]);
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/AdvAliasFieldErrorsTest.php
+++ b/tests/php/AdvAliasFieldErrorsTest.php
@@ -75,6 +75,28 @@ final class AdvAliasFieldErrorsTest extends TestCase
 		$this->assertSame([], $errors);
 	}
 
+	public function testExistingUrlPortsAliasInPortFieldIsAccepted(): void
+	{
+		// A URL-Ports alias is port-bearing, so a port field accepts it — the broadened
+		// autocomplete offers it, so the validator must not reject it. Pre-broadening the
+		// port branch only accepted the literal 'port' type and rejected this.
+		$this->seedAliases(['MyUrlPorts' => 'url_ports']);
+
+		$errors = pfb_adv_alias_field_errors(['aliasports_out' => 'MyUrlPorts']);
+
+		$this->assertSame([], $errors);
+	}
+
+	public function testExistingUrltablePortsAliasInPortFieldIsAccepted(): void
+	{
+		// A URL-Table (Ports) alias is likewise a valid port restriction.
+		$this->seedAliases(['MyUrlTablePorts' => 'urltable_ports']);
+
+		$errors = pfb_adv_alias_field_errors(['aliasports_in' => 'MyUrlTablePorts']);
+
+		$this->assertSame([], $errors);
+	}
+
 	public function testExistingNetworkAliasInAddressFieldIsAccepted(): void
 	{
 		// Given a network alias that exists
@@ -168,7 +190,7 @@ final class AdvAliasFieldErrorsTest extends TestCase
 
 		// Then rejected as the wrong type
 		$this->assertCount(1, $errors);
-		$this->assertStringContainsString('Must use a Network, Host or URL-type alias', $errors[0]);
+		$this->assertStringContainsString('Must use a Host, Network, URL or URL-Table-type alias', $errors[0]);
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/AliasAutocompleteListsTest.php
+++ b/tests/php/AliasAutocompleteListsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for pfb_alias_autocomplete_lists() — the Custom Source/Destination/Port
+ * autocomplete + save-time option-validation map builder shared by the IP,
+ * DNSBL, and Feed (category-edit) settings pages.
+ *
+ * Two bugs this pins:
+ *
+ *   Bug A — the old per-page loops collected ONLY 'network'-type aliases for
+ *   the address list, excluding 'host' (single-IP), 'url', and 'urltable'
+ *   aliases. A Host alias — the common case — never appeared in the "Custom
+ *   Source"/"Custom Destination" autocomplete dropdown on any of the three
+ *   pages.
+ *
+ *   Bug B — the DNSBL page built its address/port option arrays as
+ *   explode(',', $csv) — a VALUE list with numeric keys — while the save
+ *   validator checks array_key_exists($_POST[$field], $options_...). Against
+ *   a numeric-keyed array that is always FALSE, so every submitted Custom
+ *   field was silently reset to '' on save. The fix returns NAME-KEYED
+ *   (name => name) maps so array_key_exists() works.
+ */
+#[CoversFunction('pfb_alias_autocomplete_lists')]
+final class AliasAutocompleteListsTest extends TestCase
+{
+	public function testAddressListIncludesEveryAddressBearingTypeNameKeyedExcludingManagedAndPorts(): void
+	{
+		// Given a mix of alias types, including a pfB_-managed one and an empty name
+		$aliases = [
+			['name' => 'H',           'type' => 'host'],
+			['name' => 'N',           'type' => 'network'],
+			['name' => 'U',           'type' => 'url'],
+			['name' => 'UT',          'type' => 'urltable'],
+			['name' => 'P1',          'type' => 'port'],
+			['name' => 'P2',          'type' => 'port'],
+			['name' => 'pfB_Managed', 'type' => 'urltable'],
+			['name' => '',            'type' => 'network'],
+		];
+
+		// When the autocomplete maps are built
+		$r = pfb_alias_autocomplete_lists($aliases);
+
+		// Then every address-bearing type is present and NAME-KEYED — this is the
+		// Bug A + Bug B fix: a Host alias ('H') is now offered AND
+		// array_key_exists('H', $r['networks']) works (the old explode()-built,
+		// network-only list failed BOTH: it excluded 'H' entirely, and even a
+		// present name was reachable only by value, never by key).
+		$this->assertTrue(array_key_exists('H', $r['networks']),
+			'a Host alias must be a key in the address map (old network-only + explode() logic failed this)');
+		$this->assertSame('H', $r['networks']['H']);
+		$this->assertArrayHasKey('N', $r['networks']);
+		$this->assertSame('N', $r['networks']['N']);
+		$this->assertArrayHasKey('U', $r['networks']);
+		$this->assertArrayHasKey('UT', $r['networks']);
+
+		// Managed (pfB_*), port, and empty-name entries are excluded from the address map
+		$this->assertArrayNotHasKey('pfB_Managed', $r['networks']);
+		$this->assertArrayNotHasKey('P1', $r['networks']);
+		$this->assertArrayNotHasKey('P2', $r['networks']);
+		$this->assertArrayNotHasKey('', $r['networks']);
+	}
+
+	public function testPortListIsNameKeyedAndExcludesAddressesAndManagedAliases(): void
+	{
+		// Given the same mixed input
+		$aliases = [
+			['name' => 'H',           'type' => 'host'],
+			['name' => 'N',           'type' => 'network'],
+			['name' => 'U',           'type' => 'url'],
+			['name' => 'UT',          'type' => 'urltable'],
+			['name' => 'P1',          'type' => 'port'],
+			['name' => 'P2',          'type' => 'port'],
+			['name' => 'pfB_Managed', 'type' => 'urltable'],
+			['name' => '',            'type' => 'network'],
+		];
+
+		// When built
+		$r = pfb_alias_autocomplete_lists($aliases);
+
+		// Then the port map is exactly the name-keyed port aliases
+		$this->assertSame(['P1' => 'P1', 'P2' => 'P2'], $r['ports']);
+		$this->assertArrayNotHasKey('H', $r['ports']);
+		$this->assertArrayNotHasKey('pfB_Managed', $r['ports']);
+	}
+}

--- a/tests/php/AliasAutocompleteListsTest.php
+++ b/tests/php/AliasAutocompleteListsTest.php
@@ -38,7 +38,10 @@ final class AliasAutocompleteListsTest extends TestCase
 			['name' => 'UT',          'type' => 'urltable'],
 			['name' => 'P1',          'type' => 'port'],
 			['name' => 'P2',          'type' => 'port'],
+			['name' => 'UP',          'type' => 'url_ports'],
+			['name' => 'UTP',         'type' => 'urltable_ports'],
 			['name' => 'pfB_Managed', 'type' => 'urltable'],
+			['name' => 'pfB_Ports',   'type' => 'port'],
 			['name' => '',            'type' => 'network'],
 		];
 
@@ -58,14 +61,16 @@ final class AliasAutocompleteListsTest extends TestCase
 		$this->assertArrayHasKey('U', $r['networks']);
 		$this->assertArrayHasKey('UT', $r['networks']);
 
-		// Managed (pfB_*), port, and empty-name entries are excluded from the address map
+		// Managed (pfB_*), port-bearing, and empty-name entries are excluded from the address map
 		$this->assertArrayNotHasKey('pfB_Managed', $r['networks']);
 		$this->assertArrayNotHasKey('P1', $r['networks']);
 		$this->assertArrayNotHasKey('P2', $r['networks']);
+		$this->assertArrayNotHasKey('UP', $r['networks']);   // url_ports is a port type, not an address
+		$this->assertArrayNotHasKey('UTP', $r['networks']);  // urltable_ports is a port type, not an address
 		$this->assertArrayNotHasKey('', $r['networks']);
 	}
 
-	public function testPortListIsNameKeyedAndExcludesAddressesAndManagedAliases(): void
+	public function testPortListIncludesEveryPortBearingTypeNameKeyedExcludingManagedAndAddresses(): void
 	{
 		// Given the same mixed input
 		$aliases = [
@@ -75,16 +80,24 @@ final class AliasAutocompleteListsTest extends TestCase
 			['name' => 'UT',          'type' => 'urltable'],
 			['name' => 'P1',          'type' => 'port'],
 			['name' => 'P2',          'type' => 'port'],
+			['name' => 'UP',          'type' => 'url_ports'],
+			['name' => 'UTP',         'type' => 'urltable_ports'],
 			['name' => 'pfB_Managed', 'type' => 'urltable'],
+			['name' => 'pfB_Ports',   'type' => 'port'],
 			['name' => '',            'type' => 'network'],
 		];
 
 		// When built
 		$r = pfb_alias_autocomplete_lists($aliases);
 
-		// Then the port map is exactly the name-keyed port aliases
-		$this->assertSame(['P1' => 'P1', 'P2' => 'P2'], $r['ports']);
-		$this->assertArrayNotHasKey('H', $r['ports']);
+		// Then the port map is exactly the name-keyed port-bearing aliases (port +
+		// url_ports + urltable_ports), NAME-KEYED so array_key_exists() save-validation works.
+		$this->assertSame(['P1' => 'P1', 'P2' => 'P2', 'UP' => 'UP', 'UTP' => 'UTP'], $r['ports']);
+		// A pfB_-managed PORT alias (e.g. the package's own pfB_DNSBL_Ports) must be excluded --
+		// the field help forbids it. This is the real pfB_-skip assertion: 'pfB_Ports' is a
+		// port-type alias, so it is dropped by the pfB_ prefix check, not merely by its type.
+		$this->assertArrayNotHasKey('pfB_Ports', $r['ports']);
 		$this->assertArrayNotHasKey('pfB_Managed', $r['ports']);
+		$this->assertArrayNotHasKey('H', $r['ports']);
 	}
 }


### PR DESCRIPTION
## Problem

Reported: the DNSBL IPs → Advanced In/Outbound **Custom Source / Custom Destination** autocomplete shows no suggestions.

Investigation found two long-standing bugs (both present since the initial `src/` import) behind the "Advanced In/Outbound rule" Custom alias fields:

- **Bug A — empty address autocomplete (all three pages: IP, DNSBL, Feeds).** The autocomplete + option lists collected only `type == 'network'` aliases, excluding `host` (single-IP), `url`, and `urltable` aliases. A Host alias — the common case — never appeared in the dropdown. (Custom Port autocomplete worked, which is why the address fields stood out.)
- **Bug B — silent save-reset (DNSBL page only).** The DNSBL page built `$options_aliasaddr_*` / `$options_aliasports_*` as `explode(',', $csv)` — a value list with numeric keys — while the save-validation uses `array_key_exists($_POST[$field], $options_...)`. Against a numeric-keyed array that is always false, so **every submitted Custom Port/Source/Destination value was silently reset to empty on save**. (The IP and Feeds pages build these name-keyed, so they saved correctly.)

Net effect on the DNSBL page: the Custom Source/Destination/Port feature was effectively non-functional (empty dropdown *and* unsaveable).

## Fix

- Add a shared `pfb_alias_autocomplete_lists()` helper returning **name-keyed** maps for ports and for every address-bearing alias type (`host`/`network`/`url`/`urltable` via `pfb_exclude_alias_types()`), excluding `pfB_`-managed aliases.
- Wire all three pages (IP settings, DNSBL, Feeds/category-edit) to it — fixing the empty autocomplete everywhere and the DNSBL numeric-key save-reset in one place. This also removes three duplicated collection loops and fixes a latent undefined-`$options_aliasaddr_*` path on the Feeds page.
- Broaden the issue-#636 field-type validator (`pfb_alias_field_type_ok`) to the same address set, so a `url`/`urltable` alias picked from the now-broadened dropdown validates on save instead of being rejected as wrong-type (dropdown/validator parity).
- Refresh the field help text ("IP Network Type" → address-type).

## Tests

- `tests/php/AliasAutocompleteListsTest.php` — the helper offers every address-bearing type, name-keyed (proves Bug A + Bug B fixes), and excludes port / `pfB_`-managed / empty-name entries; ports are name-keyed and exclude addresses. Red on the old network-only + `explode()` logic.
- `tests/php/AdvAliasFieldErrorsTest.php` — added `url` / `urltable` accepted-in-address-field cases (red on the old `network`/`host`-only validator) and updated the wrong-type message.

Gates: PHPUnit (new tests pass; the 3 `open_basedir tempnam` failures are pre-existing local-env only, identical on `HEAD`), PHPStan (No errors), PHPCS (clean), `php -l` (clean).

Live browser confirmation of the dropdown + save round-trip is the dispatch-only Web-UI Tier B leg.