### PR TITLE
pfblockerng: remove Alexa as a Top1M source + rename Alexa→Top1M (#877)

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -29,6 +29,12 @@ field, reasoning about rollback/downgrade, or checking the foreign-key exclusion
     `=== PfbIdnMode::All` / `::Confusable`. The 4.0.0-alpha-only `'all'` token is **not** carried
     (alpha compatibility is intentionally not maintained) — it reads as Off. One canonical
     vocabulary spans `config.xml`, the ini, and the Python `IdnMode` enum.
+  - **`alexa_type` → `Top1mSource`** (issue #877 review, registry adapters
+    `pfb_cfg_top1m_source_read/write`): tokens `'tranco'` (default) / `'cisco'`. The legacy
+    `'alexa'` token (the dead Alexa TOP1M service, #872) is READ-only — `fromLegacy()` coalesces
+    it (and any unknown/absent token) to `Tranco`, and a write never re-emits it, so the write
+    vocabulary is only `'tranco'`/`'cisco'` (downgrade-safe: an older release already understands
+    both). The stored config key stays `alexa_type` — no rename.
 - **Python** (`pfb_unbound.py`): the **`IdnMode` enum** shares that vocabulary — `All = 'on'`,
   `Confusable = 'confusable'`, `Off = 'off'` — and reads the ini `idn_mode` token directly (the
   legacy `python_idn` fallback is retained for a config predating the key). Toggle/lenient enums
@@ -81,11 +87,13 @@ at/after that version; it is a per-field scope marker, not a migration.
 | `lenient`           | `{'on', 'off', ''}` — `''` is a LEGACY READ token (pre-ADR-22 absent); write emits `'off'` |
 | `idn`               | write `{'on' (=All), 'confusable', 'off'}`; legacy reads `'all'`→Off, `''`→Off (4.0.0-alpha `'all'` not carried) |
 | `alias_delta_mode`  | `{'auto', 'delta', 'replace'}` — unknown/absent token reads as `'auto'` (ADR-40, since 4.0.0) |
+| `top1m_source`      | write `{'tranco' (default), 'cisco'}`; legacy read `'alexa'`→Tranco (dead service, #872), never re-emitted |
 | `plain`             | identity — any stored value passes through unchanged |
 
 **Excluded fields** — none. `pfb_idn` was previously excluded (`NULL`/`NULL` identity adapters);
 it is now adopted as `PfbIdnMode` (see ADR-28 §2.2). `All` reuses the legacy `'on'` token, so the
-adoption is migration-free and downgrade-safe.
+adoption is migration-free and downgrade-safe. `alexa_type` similarly moved off a plain-string
+read-boundary coalesce onto the `Top1mSource` enum (issue #877 review) — same shape, no migration.
 
 ## Since-version convention
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2381,7 +2381,7 @@ function pfb_global() {
 	$pfb['dnsbl_port']	= $pfb['dnsblconfig']['pfb_dnsport'];									// Lighttpd web server http port setting
 	$pfb['dnsbl_port_ssl']	= $pfb['dnsblconfig']['pfb_dnsport_ssl'];								// Lighttpd web server https port setting
 	$pfb['dnsbl_top1m']	= $pfb['dnsblconfig']['alexa_enable'];							// TOP1M whitelist
-	$pfb['dnsbl_top1m_type']	= PfbConfig::read('alexa_type');						// TOP1M type (Tranco or Cisco; legacy 'alexa' coalesces to 'tranco', #877) (default 'tranco')
+	$pfb['dnsbl_top1m_type']	= PfbConfig::read('alexa_type');						// TOP1M type (Top1mSource enum; legacy 'alexa' coalesces to Tranco, #877) (default Tranco)
 	$pfb['dnsbl_res_cache']	= $pfb['dnsblconfig']['pfb_cache'];							// DNSBL Option to backup/restore Resolver cache
 	$pfb['dnsbl_global_log']= PfbConfig::read('global_log');							// Global Logging/Blocking mode (default '')
 	// ADR-22: lenient feed parsing. 'on' = permissive scheme strip (today); anything else =

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2381,7 +2381,7 @@ function pfb_global() {
 	$pfb['dnsbl_port']	= $pfb['dnsblconfig']['pfb_dnsport'];									// Lighttpd web server http port setting
 	$pfb['dnsbl_port_ssl']	= $pfb['dnsblconfig']['pfb_dnsport_ssl'];								// Lighttpd web server https port setting
 	$pfb['dnsbl_alexa']	= $pfb['dnsblconfig']['alexa_enable'];							// TOP1M whitelist
-	$pfb['dnsbl_alexatype']	= PfbConfig::read('alexa_type');							// TOP1M type (Tranco, Alexa or Cisco) (default 'tranco')
+	$pfb['dnsbl_alexatype']	= PfbConfig::read('alexa_type');							// TOP1M type (Tranco or Cisco; legacy 'alexa' coalesces to 'tranco', #877) (default 'tranco')
 	$pfb['dnsbl_res_cache']	= $pfb['dnsblconfig']['pfb_cache'];							// DNSBL Option to backup/restore Resolver cache
 	$pfb['dnsbl_global_log']= PfbConfig::read('global_log');							// Global Logging/Blocking mode (default '')
 	// ADR-22: lenient feed parsing. 'on' = permissive scheme strip (today); anything else =

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2380,8 +2380,8 @@ function pfb_global() {
 
 	$pfb['dnsbl_port']	= $pfb['dnsblconfig']['pfb_dnsport'];									// Lighttpd web server http port setting
 	$pfb['dnsbl_port_ssl']	= $pfb['dnsblconfig']['pfb_dnsport_ssl'];								// Lighttpd web server https port setting
-	$pfb['dnsbl_alexa']	= $pfb['dnsblconfig']['alexa_enable'];							// TOP1M whitelist
-	$pfb['dnsbl_alexatype']	= PfbConfig::read('alexa_type');							// TOP1M type (Tranco or Cisco; legacy 'alexa' coalesces to 'tranco', #877) (default 'tranco')
+	$pfb['dnsbl_top1m']	= $pfb['dnsblconfig']['alexa_enable'];							// TOP1M whitelist
+	$pfb['dnsbl_top1m_type']	= PfbConfig::read('alexa_type');						// TOP1M type (Tranco or Cisco; legacy 'alexa' coalesces to 'tranco', #877) (default 'tranco')
 	$pfb['dnsbl_res_cache']	= $pfb['dnsblconfig']['pfb_cache'];							// DNSBL Option to backup/restore Resolver cache
 	$pfb['dnsbl_global_log']= PfbConfig::read('global_log');							// Global Logging/Blocking mode (default '')
 	// ADR-22: lenient feed parsing. 'on' = permissive scheme strip (today); anything else =
@@ -6965,14 +6965,16 @@ function pfb_unbound_python_sources($feeds) {
 	// Synthetic whole-TLD blacklist feed (DNSBL_TLD): the Python build emits these
 	// as whole-TLD ZONE entries from config.tld_blacklist, so no raw file is needed.
 
-	// TOP1M (Alexa/Tranco) popularity whitelist -> query-time whiteDB only when on.
-	$top1m_enabled	= ($pfb['dnsbl_alexa'] == 'on' &&
+	// TOP1M (Tranco/Cisco) popularity whitelist -> query-time whiteDB only when on.
+	// ponytail: pfbalexawhitelist.txt keeps its on-disk name -- renaming a generated
+	// artifact needs old-file cleanup for zero user benefit (#877 triage decision).
+	$top1m_enabled	= ($pfb['dnsbl_top1m'] == 'on' &&
 			   file_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt"));
 	$top1m_list	= array();
 	if ($top1m_enabled) {
-		$alexa = @file("{$pfb['dbdir']}/pfbalexawhitelist.txt", FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-		if (is_array($alexa)) {
-			$top1m_list = $alexa;
+		$top1m_lines = @file("{$pfb['dbdir']}/pfbalexawhitelist.txt", FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		if (is_array($top1m_lines)) {
+			$top1m_list = $top1m_lines;
 		}
 	}
 
@@ -8186,13 +8188,13 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 function pfblockerng_top1m() {
 	global $pfb;
 
-	if (empty($pfb['dnsbl_alexa_inc'])) {
+	if (empty($pfb['dnsbl_top1m_inc'])) {
 		pfb_logger("\n  TOP1M: No TLD Inclusions found.\n", 1);
 		return;
 	}
 
 	// Array of TLDs to include in Whitelist
-	$pfb_include = explode(',', $pfb['dnsbl_alexa_inc']);
+	$pfb_include = explode(',', $pfb['dnsbl_top1m_inc']);
 	if (!empty($pfb_include)) {
 		$pfb_include = array_flip($pfb_include);
 	}
@@ -8228,12 +8230,12 @@ function pfblockerng_top1m() {
 				@fwrite($pfb_output, ".{$csvline[1]},,\n,{$csvline[1]},,\n,www.{$csvline[1]},,\n");
 			}
 
-			if ($x >= $pfb['dnsbl_alexa_cnt']) {
+			if ($x >= $pfb['dnsbl_top1m_cnt']) {
 				break;
 			}
 			$linecnt++;
 		}
-		pfb_logger("] [ Parsed {$linecnt} lines | Found {$x} of {$pfb['dnsbl_alexa_cnt']} ]...", 1);
+		pfb_logger("] [ Parsed {$linecnt} lines | Found {$x} of {$pfb['dnsbl_top1m_cnt']} ]...", 1);
 	}
 	else {
 		$log = "\nTOP1M conversion Failed. File: top-1m.csv, not found...";
@@ -14815,19 +14817,19 @@ function sync_package_pfblockerng($cron='') {
 	// DNSBL settings
 	$pfb['dnsbl_ip']	= $pfb['dnsblconfig']['action']		?:  'Disabled';		// Enable/Disable IP blocking from DNSBL lists
 	$pfb['dnsbl_rule']	= $pfb['dnsblconfig']['pfb_dnsbl_rule'] ?: 'Disabled';		// Auto create a Floating Pass Rule for other Lan subnets
-	$pfb['dnsbl_alexa_cnt']	= $pfb['dnsblconfig']['alexa_count']	?: '1000';		// TOP1M whitelist domain setting
+	$pfb['dnsbl_top1m_cnt']	= $pfb['dnsblconfig']['alexa_count']	?: '1000';		// TOP1M whitelist domain setting
 	// DNSBL Python decision-cache cap (LRU); 0 = unlimited. 0 is meaningful so avoid the
 	// ?: idiom (0 is falsy), and reject non-numeric input -- else the intval() at the ini
 	// emit would coerce a malformed value to 0 = silently unlimited. Clamp to the WebUI range.
 	$pfb_dcm_raw = (string) ($pfb['dnsblconfig']['pfb_py_cache_max'] ?? '');
 	$pfb['dnsbl_decisiondb_max'] = ctype_digit($pfb_dcm_raw) ? (string) min(5000000, (int) $pfb_dcm_raw) : '10000';
-	$pfb['dnsbl_alexa_inc']	= $pfb['dnsblconfig']['alexa_inclusion']?: '';			// TOP1M TLDs inclusions for whitelisting
+	$pfb['dnsbl_top1m_inc']	= $pfb['dnsblconfig']['alexa_inclusion']?: '';			// TOP1M TLDs inclusions for whitelisting
 	$pfb['dnsbl_tld']	= $pfb['dnsblconfig']['pfb_tld'];				// Enable TLD Function
 	$pfb['dnsbl_control']	= $pfb['dnsblconfig']['pfb_control']	?: '';			// Python Control integration
 	$pfb['dnsbl_control_legacy']	= $pfb['dnsblconfig']['pfb_control_legacy']	?? '';	// PFBL-03: deprecated legacy DNS-TXT control transport
 
 	// Validate pfB Script variable
-	$pfb['dnsbl_alexa_inc'] = pfb_filter($pfb['dnsbl_alexa_inc'], PFB_FILTER_CSV, 'Validate pfB Script variable');
+	$pfb['dnsbl_top1m_inc'] = pfb_filter($pfb['dnsbl_top1m_inc'], PFB_FILTER_CSV, 'Validate pfB Script variable');
 
 	// Reputation config variables
 	$pfb['config_rep'] = config_get_path('installedpackages/pfblockerngreputation/config/0', []);
@@ -15647,7 +15649,7 @@ function sync_package_pfblockerng($cron='') {
 
 
 			// Call TOP1M whitelist process
-			if ($pfb['dnsbl_alexa'] == 'on') {
+			if ($pfb['dnsbl_top1m'] == 'on') {
 				pfb_logger("\n Loading TOP1M Whitelist...", 1);
 
 				// Check if TOP1M database exists

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -73,8 +73,9 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 	pathasncsv="/usr/local/share/GeoIP/asn.csv"
 	pathasntable="/usr/local/www/pfblockerng/pfblockerng_asn.txt"
 	pfbsuppression=/var/db/pfblockerng/pfbsuppression.txt
-	# ADR-06: pfbdnsblsuppression / pfbalexa removed (only used by the dropped
-	# dnsbl_scrub build-time whitelist/TOP1M removal; now applied at query time).
+	# ADR-06: pfbdnsblsuppression / pfbalexa (legacy TOP1M whitelist) removed
+	# (only used by the dropped dnsbl_scrub build-time whitelist/TOP1M removal;
+	# now applied at query time).
 	masterfile=/var/db/pfblockerng/masterfile
 	mastercat=/var/db/pfblockerng/mastercat
 	geoiplog=/var/log/pfblockerng/geoip.log

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -256,6 +256,35 @@ function pfb_cfg_idn_mode_write(PfbIdnMode|string $mode): string
 	return ($mode instanceof PfbIdnMode ? $mode : PfbIdnMode::fromStored($mode))->toStored();
 }
 
+/**
+ * Read the TOP1M source selector, coalescing the legacy 'alexa' token (dead
+ * service, #872) to 'tranco'. 'tranco'/'cisco' pass through unchanged.
+ *
+ * Read-boundary only — the stored value is untouched until the user re-saves
+ * (the DNSBL page now only POSTs 'tranco'/'cisco', already canonical), so a
+ * downgrade to an older release still reads the original stored 'alexa'.
+ *
+ * ponytail: a plain-string coalesce, not a PfbStoredEnum — the field has 2
+ * live values and every consumer (pfblockerng.inc, pfblockerng.php) compares
+ * it as a string; an enum would ripple with zero behavioural benefit.
+ */
+function pfb_cfg_top1m_source_read(mixed $stored): string
+{
+	$raw = is_string($stored) ? $stored : '';
+	return in_array($raw, ['tranco', 'cisco'], TRUE) ? $raw : 'tranco';
+}
+
+/**
+ * Write the TOP1M source selector back to its stored string. Identity — the
+ * runtime value is already the canonical stored token ('tranco' | 'cisco');
+ * this exists only to satisfy the registry's paired-adapter contract (every
+ * read_adapter needs a matching write_adapter).
+ */
+function pfb_cfg_top1m_source_write(string $value): string
+{
+	return $value;
+}
+
 // ---------------------------------------------------------------------------
 // ADR-29 Phase 1 — PfbConfig gateway + declarative field registry.
 //
@@ -694,12 +723,14 @@ function pfb_cfg_registry(): array
 			'since'         => '1.0.0',
 		],
 
-		// TOP1M type selector ('tranco'|'alexa'|'cisco'). Default 'tranco'.
+		// TOP1M type selector: 'tranco' | 'cisco'. Legacy 'alexa' (dead service,
+		// #872) coalesces to 'tranco' at the read boundary via
+		// pfb_cfg_top1m_source_read(). Default 'tranco'.
 		'alexa_type' => [
 			'section'       => $dnsbl,
 			'default'       => 'tranco',
-			'read_adapter'  => NULL,
-			'write_adapter' => NULL,
+			'read_adapter'  => 'pfb_cfg_top1m_source_read',
+			'write_adapter' => 'pfb_cfg_top1m_source_write',
 			'since'         => '2.0.0',
 		],
 
@@ -1469,6 +1500,10 @@ function pfb_run_migrations(): void
  * idn vocabulary ('on'|'confusable'|'off'); the dropped 4.0.0-alpha 'all' token is
  * read as Off and never written.
  *
+ * The top1m_source adapter (pfb_cfg_top1m_source_read, issue #877) is wired for
+ * alexa_type. Legacy 'alexa' (dead service, #872) coalesces to 'tranco' on read
+ * and is never re-emitted by a write; the write vocabulary is only 'tranco'|'cisco'.
+ *
  * @return array<string,list<string>>
  */
 function pfb_cfg_field_vocab(): array
@@ -1495,6 +1530,12 @@ function pfb_cfg_field_vocab(): array
 		// An older release (pre-4.0.0) has no knowledge of these fields; they simply
 		// do not exist in config.xml, and the feature falls back to full replace.
 		'alias_delta_mode' => ['auto', 'delta', 'replace'],
+
+		// TOP1M source selector (alexa_type, issue #877): the tokens a write can
+		// emit. 'tranco' (default) | 'cisco'. The legacy 'alexa' token (dead
+		// service, #872) is a READ-ONLY legacy value — pfb_cfg_top1m_source_read()
+		// coalesces it to 'tranco' and it is never re-emitted by a write.
+		'top1m_source' => ['tranco', 'cisco'],
 
 		// Plain string (null/null adapters): identity. Backward-safe by construction.
 		// The 'plain' vocabulary contains the sentinel empty string; individual
@@ -1527,6 +1568,9 @@ function pfb_cfg_field_adapter_type(array $entry): string
 	}
 	if ($read === 'pfb_cfg_alias_delta_mode_read') {
 		return 'alias_delta_mode';
+	}
+	if ($read === 'pfb_cfg_top1m_source_read') {
+		return 'top1m_source';
 	}
 	// All other adapters are toggle (pfb_cfg_toggle_read).
 	return 'toggle';

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -714,7 +714,7 @@ function pfb_cfg_registry(): array
 			'since'         => '1.0.0',
 		],
 
-		// TOP1M (Alexa/Tranco) whitelist enable. Default ''.
+		// TOP1M whitelist enable. Default ''.
 		'alexa_enable' => [
 			'section'       => $dnsbl,
 			'default'       => '',

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -200,6 +200,36 @@ enum PfbAliasDeltaMode: string implements PfbStoredEnum
 	}
 }
 
+// Top1mSource — TOP1M source selector (alexa_type, issue #877).
+//
+// Used by: alexa_type (config key) / $pfb['dnsbl_top1m_type'] (runtime).
+//   Canonical tokens: 'tranco' (default), 'cisco'. The legacy 'alexa' token
+//   (the dead Alexa TOP1M service, #872) is a READ-ONLY legacy value:
+//   fromLegacy() coalesces it (and any unknown/'' token) to Tranco, and a
+//   write NEVER re-emits it — only 'tranco'/'cisco' are ever persisted, so
+//   the write vocabulary is downgrade-safe (an older release reading either
+//   token already understands it).
+enum Top1mSource: string implements PfbStoredEnum
+{
+	use PfbStoredEnumAdapter;
+
+	case Tranco = 'tranco';
+	case Cisco  = 'cisco';
+
+	// Legacy 'alexa' (dead service, #872) and any unknown/'' token -> Tranco.
+	protected static function fromLegacy(string $raw): static
+	{
+		return self::Tranco;
+	}
+
+	// Parse-fallback ONLY (unknown/non-scalar -> Tranco). NOT the absent default
+	// (that is the registry's $entry['default'], also 'tranco').
+	public static function default(): static
+	{
+		return self::Tranco;
+	}
+}
+
 /** Read a PfbAliasDeltaMode from a raw stored value. */
 function pfb_cfg_alias_delta_mode_read(mixed $stored): PfbAliasDeltaMode
 {
@@ -256,33 +286,20 @@ function pfb_cfg_idn_mode_write(PfbIdnMode|string $mode): string
 	return ($mode instanceof PfbIdnMode ? $mode : PfbIdnMode::fromStored($mode))->toStored();
 }
 
-/**
- * Read the TOP1M source selector, coalescing the legacy 'alexa' token (dead
- * service, #872) to 'tranco'. 'tranco'/'cisco' pass through unchanged.
- *
- * Read-boundary only — the stored value is untouched until the user re-saves
- * (the DNSBL page now only POSTs 'tranco'/'cisco', already canonical), so a
- * downgrade to an older release still reads the original stored 'alexa'.
- *
- * ponytail: a plain-string coalesce, not a PfbStoredEnum — the field has 2
- * live values and every consumer (pfblockerng.inc, pfblockerng.php) compares
- * it as a string; an enum would ripple with zero behavioural benefit.
- */
-function pfb_cfg_top1m_source_read(mixed $stored): string
+/** Read a Top1mSource from a raw stored value (legacy 'alexa' -> Tranco). */
+function pfb_cfg_top1m_source_read(mixed $stored): Top1mSource
 {
-	$raw = is_string($stored) ? $stored : '';
-	return in_array($raw, ['tranco', 'cisco'], TRUE) ? $raw : 'tranco';
+	return Top1mSource::fromStored($stored);
 }
 
 /**
- * Write the TOP1M source selector back to its stored string. Identity — the
- * runtime value is already the canonical stored token ('tranco' | 'cisco');
- * this exists only to satisfy the registry's paired-adapter contract (every
- * read_adapter needs a matching write_adapter).
+ * Write a Top1mSource (enum or legacy string) back to its canonical stored
+ * token ('tranco' | 'cisco'). The dead legacy 'alexa' token (#872) is never
+ * re-emitted — fromStored() already coalesced it to Tranco before this runs.
  */
-function pfb_cfg_top1m_source_write(string $value): string
+function pfb_cfg_top1m_source_write(Top1mSource|string $source): string
 {
-	return $value;
+	return ($source instanceof Top1mSource ? $source : Top1mSource::fromStored($source))->toStored();
 }
 
 // ---------------------------------------------------------------------------
@@ -1500,9 +1517,10 @@ function pfb_run_migrations(): void
  * idn vocabulary ('on'|'confusable'|'off'); the dropped 4.0.0-alpha 'all' token is
  * read as Off and never written.
  *
- * The top1m_source adapter (pfb_cfg_top1m_source_read, issue #877) is wired for
- * alexa_type. Legacy 'alexa' (dead service, #872) coalesces to 'tranco' on read
- * and is never re-emitted by a write; the write vocabulary is only 'tranco'|'cisco'.
+ * The top1m_source adapter (pfb_cfg_top1m_source_read/write, issue #877) is wired
+ * for alexa_type and returns a Top1mSource enum. Legacy 'alexa' (dead service,
+ * #872) coalesces to Tranco on read and is never re-emitted by a write; the
+ * write vocabulary is only 'tranco'|'cisco'.
  *
  * @return array<string,list<string>>
  */
@@ -1531,10 +1549,10 @@ function pfb_cfg_field_vocab(): array
 		// do not exist in config.xml, and the feature falls back to full replace.
 		'alias_delta_mode' => ['auto', 'delta', 'replace'],
 
-		// TOP1M source selector (alexa_type, issue #877): the tokens a write can
+		// TOP1M source selector (Top1mSource, issue #877): the tokens a write can
 		// emit. 'tranco' (default) | 'cisco'. The legacy 'alexa' token (dead
 		// service, #872) is a READ-ONLY legacy value — pfb_cfg_top1m_source_read()
-		// coalesces it to 'tranco' and it is never re-emitted by a write.
+		// coalesces it to Top1mSource::Tranco and it is never re-emitted by a write.
 		'top1m_source' => ['tranco', 'cisco'],
 
 		// Plain string (null/null adapters): identity. Backward-safe by construction.

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -159,7 +159,7 @@ $pfb['extras'][1]['type']	= 'geoip';
 
 // TOP1M database
 $pfb['extras'][2]			= array();
-if ($pfb['dnsbl_top1m_type'] == 'tranco') {
+if ($pfb['dnsbl_top1m_type'] === Top1mSource::Tranco) {
 	$pfb['extras'][2]['url']	= 'https://tranco-list.eu/top-1m.csv.zip';
 } else {
 	$pfb['extras'][2]['url']	= 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip';  // Cisco

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -159,7 +159,7 @@ $pfb['extras'][1]['type']	= 'geoip';
 
 // TOP1M database
 $pfb['extras'][2]			= array();
-if ($pfb['dnsbl_alexatype'] == 'tranco') {
+if ($pfb['dnsbl_top1m_type'] == 'tranco') {
 	$pfb['extras'][2]['url']	= 'https://tranco-list.eu/top-1m.csv.zip';
 } else {
 	$pfb['extras'][2]['url']	= 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip';  // Cisco
@@ -308,7 +308,7 @@ if (in_array($argv[1], array('update', 'updateip', 'updatednsbl', 'dc', 'dcc', '
 				}
 
 				// Skip TOP1M update, if disabled
-				if (pfb_cfg_toggle_read($pfb['dnsbl_alexa']) !== PfbToggle::On) {
+				if (pfb_cfg_toggle_read($pfb['dnsbl_top1m']) !== PfbToggle::On) {
 					unset($pfb['extras'][2]); // Remove TOP1M
 				}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -159,9 +159,7 @@ $pfb['extras'][1]['type']	= 'geoip';
 
 // TOP1M database
 $pfb['extras'][2]			= array();
-if ($pfb['dnsbl_alexatype'] == 'alexa') {
-	$pfb['extras'][2]['url']	= 'https://s3.amazonaws.com/alexa-static/top-1m.csv.zip';
-} elseif ($pfb['dnsbl_alexatype'] == 'tranco') {
+if ($pfb['dnsbl_alexatype'] == 'tranco') {
 	$pfb['extras'][2]['url']	= 'https://tranco-list.eu/top-1m.csv.zip';
 } else {
 	$pfb['extras'][2]['url']	= 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip';  // Cisco

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -110,7 +110,9 @@ $pconfig['agateway_out']	= $pfb['dconfig']['agateway_out']			?: 'default';
 $pconfig['suppression']		= base64_decode($pfb['dconfig']['suppression'])		?: '';
 
 $pconfig['alexa_enable']	= $pfb['dconfig']['alexa_enable']			?: '';
-$pconfig['alexa_type']		= $pfb['dconfig']['alexa_type']				?: 'tranco';
+// Routed via the gateway (not the section array) so a stored legacy 'alexa'
+// (dead TOP1M source, #872/#877) coalesces to 'tranco' for the form select.
+$pconfig['alexa_type']		= PfbConfig::read('alexa_type');
 $pconfig['alexa_count']		= $pfb['dconfig']['alexa_count']			?: '1000';
 // 0 (unlimited) is meaningful, so don't use the ?: idiom (0 is falsy -> would reset to default).
 $pconfig['pfb_py_cache_max']	= (isset($pfb['dconfig']['pfb_py_cache_max']) && $pfb['dconfig']['pfb_py_cache_max'] !== '') ? $pfb['dconfig']['pfb_py_cache_max'] : '10000';
@@ -190,7 +192,7 @@ if (is_dir("{$indexdir}")) {
 }
 $options_dnsbl_webpage_cnt = count($options_dnsbl_webpage) ?: '1';
 
-$options_alexa_type		= [ 'tranco' => 'Tranco TOP1M', 'cisco' => 'Cisco Umbrella TOP1M', 'alexa' => 'Alexa TOP1M' ];
+$options_alexa_type		= [ 'tranco' => 'Tranco TOP1M', 'cisco' => 'Cisco Umbrella TOP1M' ];
 
 $options_alexa_count		= [	'500' => 'Top 500', '1000' => 'Top 1k', '2000' => 'Top 2k', '5000' => 'Top 5k', '10000' => 'Top 10k',
 					'25000' => 'Top 25k', '50000' => 'Top 50k', '75000' => 'Top 75k', '100000' => 'Top 100k', '250000' => 'Top 250k',
@@ -3213,7 +3215,6 @@ $top1m_text = 'The TOP1M feed can be used to whitelist the most popular Domain n
 		<ul>
 			<li><a target="_blank" href="https://tranco-list.eu/">Tranco TOP1M</a></li>
 			<li><a target="_blank" href="https://s3-us-west-1.amazonaws.com/umbrella-static/index.html">Cisco Umbrella TOP1M</a></li>
-			<li><a target="_blank" href="https://aws.amazon.com/alexa-top-sites/">Alexa TOP1M (out-of-date)</a></li>
 		</ul>
 		To use this feature, select the number of \'Top Domains\' to whitelist. You can also \'include\' which TLDs to whitelist.
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -112,7 +112,9 @@ $pconfig['suppression']		= base64_decode($pfb['dconfig']['suppression'])		?: '';
 $pconfig['alexa_enable']	= $pfb['dconfig']['alexa_enable']			?: '';
 // Routed via the gateway (not the section array) so a stored legacy 'alexa'
 // (dead TOP1M source, #872/#877) coalesces to 'tranco' for the form select.
-$pconfig['alexa_type']		= PfbConfig::read('alexa_type');
+// ->toStored() unwraps the Top1mSource enum to its scalar option key (a
+// Form_Select selected-value must be the scalar, not the enum instance).
+$pconfig['alexa_type']		= PfbConfig::read('alexa_type')->toStored();
 $pconfig['alexa_count']		= $pfb['dconfig']['alexa_count']			?: '1000';
 // 0 (unlimited) is meaningful, so don't use the ?: idiom (0 is falsy -> would reset to default).
 $pconfig['pfb_py_cache_max']	= (isset($pfb['dconfig']['pfb_py_cache_max']) && $pfb['dconfig']['pfb_py_cache_max'] !== '') ? $pfb['dconfig']['pfb_py_cache_max'] : '10000';

--- a/src/usr/local/www/pfblockerng/pfblockerng_threats.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_threats.php
@@ -298,11 +298,6 @@ $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblo
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.alexa.com/siteinfo/<?=$domain;?>">
-						<?=gettext("Alexa");?></a></td>
-				</tr>
-				<tr>
-					<td><i class="fa-solid fa-globe pull-right"></i></td>
 					<td><a target="_blank" href="https://safeweb.norton.com/report/show?url=<?=$domain;?>">
 						<?=gettext("Norton Safe Web");?></a></td>
 				</tr>

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -38,13 +38,14 @@ use PHPUnit\Framework\TestCase;
  *     And write(read('all')) == 'off'  (dropped alpha token -> Off).
  *     And write(read('')) == 'off'    (normalised default).
  *
- * Scenario E — top1m_source (alexa_type, issue #877): 'tranco' / 'cisco' TOP1M
- *   source selector; the legacy 'alexa' token (dead service, #872) coalesces
- *   to 'tranco'. Read-boundary only, plain-string result (no enum, no write
- *   adapter — the field is written back unchanged since it is already canonical).
+ * Scenario E — Top1mSource (alexa_type, issue #877): backing values 'tranco' /
+ *   'cisco' TOP1M source selector; the legacy 'alexa' token (dead service,
+ *   #872) coalesces to Tranco.
  *     Given a raw stored value v.
- *     When pfb_cfg_top1m_source_read(v).
- *     Then 'tranco'/'cisco' pass through; 'alexa' and any unknown/absent value -> 'tranco'.
+ *     When pfb_cfg_top1m_source_read(v) -> enum, pfb_cfg_top1m_source_write(enum) -> stored.
+ *     Then 'tranco'/'cisco' pass through as Tranco/Cisco; 'alexa' and any
+ *     unknown/absent value -> Tranco. write(read(v)) == v for canonical tokens;
+ *     'alexa' is never re-emitted.
  */
 final class CfgAdaptersTest extends TestCase
 {
@@ -112,6 +113,7 @@ final class CfgAdaptersTest extends TestCase
 		$this->assertSame(PfbLenient::On, PfbLenient::fromStored(PfbLenient::On));
 		$this->assertSame(PfbIdnMode::Confusable, PfbIdnMode::fromStored(PfbIdnMode::Confusable));
 		$this->assertSame(PfbAliasDeltaMode::Delta, PfbAliasDeltaMode::fromStored(PfbAliasDeltaMode::Delta));
+		$this->assertSame(Top1mSource::Cisco, Top1mSource::fromStored(Top1mSource::Cisco));
 	}
 
 	public function testToggleRoundTripOn(): void
@@ -669,42 +671,42 @@ final class CfgAdaptersTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// Scenario E — top1m_source (alexa_type, issue #877)
+	// Scenario E — Top1mSource (alexa_type, issue #877)
 	//   Stored tokens: 'tranco', 'cisco' (live); legacy 'alexa' (dead service,
-	//   #872) coalesces to 'tranco' at the read boundary. write_adapter is a
-	//   pure identity (the runtime value is already the canonical stored
-	//   token) -- present only to satisfy the registry's paired-adapter rule.
+	//   #872) coalesces to Tranco at the read boundary. Mirrors the
+	//   PfbAliasDeltaMode adapter shape (Scenario D): read returns the enum,
+	//   write accepts either the enum or a raw string.
 	// -----------------------------------------------------------------------
 
 	public function testTop1mSourceReadTrancoReturnsTranco(): void
 	{
-		$this->assertSame('tranco', pfb_cfg_top1m_source_read('tranco'));
+		$this->assertSame(Top1mSource::Tranco, pfb_cfg_top1m_source_read('tranco'));
 	}
 
 	public function testTop1mSourceReadCiscoReturnsCisco(): void
 	{
-		$this->assertSame('cisco', pfb_cfg_top1m_source_read('cisco'));
+		$this->assertSame(Top1mSource::Cisco, pfb_cfg_top1m_source_read('cisco'));
 	}
 
-	/** The dead legacy TOP1M source (#872) must read as 'tranco', not 'alexa'. */
+	/** The dead legacy TOP1M source (#872) must read as Tranco, not a lost 'alexa' value. */
 	public function testTop1mSourceReadLegacyAlexaCoalescesToTranco(): void
 	{
-		$this->assertSame('tranco', pfb_cfg_top1m_source_read('alexa'));
+		$this->assertSame(Top1mSource::Tranco, pfb_cfg_top1m_source_read('alexa'));
 	}
 
 	public function testTop1mSourceReadUnknownTokenDefaultsToTranco(): void
 	{
-		$this->assertSame('tranco', pfb_cfg_top1m_source_read('junk'));
+		$this->assertSame(Top1mSource::Tranco, pfb_cfg_top1m_source_read('junk'));
 	}
 
 	public function testTop1mSourceReadNullDefaultsToTranco(): void
 	{
-		$this->assertSame('tranco', pfb_cfg_top1m_source_read(null));
+		$this->assertSame(Top1mSource::Tranco, pfb_cfg_top1m_source_read(null));
 	}
 
 	public function testTop1mSourceReadEmptyDefaultsToTranco(): void
 	{
-		$this->assertSame('tranco', pfb_cfg_top1m_source_read(''));
+		$this->assertSame(Top1mSource::Tranco, pfb_cfg_top1m_source_read(''));
 	}
 
 	/** write(read(v)) == v for the two live canonical tokens. */
@@ -723,5 +725,14 @@ final class CfgAdaptersTest extends TestCase
 		$written = pfb_cfg_top1m_source_write(pfb_cfg_top1m_source_read('alexa'));
 		$this->assertSame('tranco', $written,
 			"expected write(read('alexa')) == 'tranco'; actual: '{$written}'");
+	}
+
+	/** pfb_cfg_top1m_source_write() accepts both an enum instance and a string. */
+	public function testTop1mSourceWriteAcceptsEnumOrString(): void
+	{
+		$this->assertSame('tranco', pfb_cfg_top1m_source_write(Top1mSource::Tranco));
+		$this->assertSame('cisco',  pfb_cfg_top1m_source_write(Top1mSource::Cisco));
+		$this->assertSame('tranco', pfb_cfg_top1m_source_write('tranco'));
+		$this->assertSame('cisco',  pfb_cfg_top1m_source_write('cisco'));
 	}
 }

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -37,6 +37,14 @@ use PHPUnit\Framework\TestCase;
  *     And write(read('off')) == 'off'  (identity).
  *     And write(read('all')) == 'off'  (dropped alpha token -> Off).
  *     And write(read('')) == 'off'    (normalised default).
+ *
+ * Scenario E — top1m_source (alexa_type, issue #877): 'tranco' / 'cisco' TOP1M
+ *   source selector; the legacy 'alexa' token (dead service, #872) coalesces
+ *   to 'tranco'. Read-boundary only, plain-string result (no enum, no write
+ *   adapter — the field is written back unchanged since it is already canonical).
+ *     Given a raw stored value v.
+ *     When pfb_cfg_top1m_source_read(v).
+ *     Then 'tranco'/'cisco' pass through; 'alexa' and any unknown/absent value -> 'tranco'.
  */
 final class CfgAdaptersTest extends TestCase
 {
@@ -658,5 +666,62 @@ final class CfgAdaptersTest extends TestCase
 		$this->assertSame('auto',    pfb_cfg_alias_delta_mode_write('auto'));
 		$this->assertSame('delta',   pfb_cfg_alias_delta_mode_write('delta'));
 		$this->assertSame('replace', pfb_cfg_alias_delta_mode_write('replace'));
+	}
+
+	// -----------------------------------------------------------------------
+	// Scenario E — top1m_source (alexa_type, issue #877)
+	//   Stored tokens: 'tranco', 'cisco' (live); legacy 'alexa' (dead service,
+	//   #872) coalesces to 'tranco' at the read boundary. write_adapter is a
+	//   pure identity (the runtime value is already the canonical stored
+	//   token) -- present only to satisfy the registry's paired-adapter rule.
+	// -----------------------------------------------------------------------
+
+	public function testTop1mSourceReadTrancoReturnsTranco(): void
+	{
+		$this->assertSame('tranco', pfb_cfg_top1m_source_read('tranco'));
+	}
+
+	public function testTop1mSourceReadCiscoReturnsCisco(): void
+	{
+		$this->assertSame('cisco', pfb_cfg_top1m_source_read('cisco'));
+	}
+
+	/** The dead legacy TOP1M source (#872) must read as 'tranco', not 'alexa'. */
+	public function testTop1mSourceReadLegacyAlexaCoalescesToTranco(): void
+	{
+		$this->assertSame('tranco', pfb_cfg_top1m_source_read('alexa'));
+	}
+
+	public function testTop1mSourceReadUnknownTokenDefaultsToTranco(): void
+	{
+		$this->assertSame('tranco', pfb_cfg_top1m_source_read('junk'));
+	}
+
+	public function testTop1mSourceReadNullDefaultsToTranco(): void
+	{
+		$this->assertSame('tranco', pfb_cfg_top1m_source_read(null));
+	}
+
+	public function testTop1mSourceReadEmptyDefaultsToTranco(): void
+	{
+		$this->assertSame('tranco', pfb_cfg_top1m_source_read(''));
+	}
+
+	/** write(read(v)) == v for the two live canonical tokens. */
+	public function testTop1mSourceRoundTripCanonicalTokens(): void
+	{
+		foreach (['tranco', 'cisco'] as $token) {
+			$written = pfb_cfg_top1m_source_write(pfb_cfg_top1m_source_read($token));
+			$this->assertSame($token, $written,
+				"expected write(read('{$token}')) == '{$token}'; actual: '{$written}'");
+		}
+	}
+
+	/** The legacy 'alexa' token never round-trips back to itself -- it is coalesced. */
+	public function testTop1mSourceRoundTripLegacyAlexaNeverReemitted(): void
+	{
+		$written = pfb_cfg_top1m_source_write(pfb_cfg_top1m_source_read('alexa'));
+		$this->assertSame('tranco', $written,
+			"expected write(read('alexa')) == 'tranco'; actual: '{$written}'");
 	}
 }

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -346,6 +346,40 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('tranco', $result);
 	}
 
+	/**
+	 * alexa_type (issue #877): a stored legacy 'alexa' (dead TOP1M source, #872)
+	 * coalesces to 'tranco' through the gateway's read adapter.
+	 *
+	 * Scenario: the dropped Alexa TOP1M option still reads safely on an existing
+	 * install that had it selected.
+	 *   Given alexa_type stored as the legacy 'alexa' token.
+	 *   When PfbConfig::read('alexa_type').
+	 *   Then the result is 'tranco', not the dead 'alexa' token.
+	 */
+	public function testReadCoalescesLegacyAlexaTypeToTranco(): void
+	{
+		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/alexa_type';
+
+		// Given: legacy 'alexa' stored.
+		$this->seedConfig($path, 'alexa');
+		$this->assertSame('alexa', config_get_path($path), 'before: alexa_type seed is legacy alexa');
+
+		// When/Then: coalesced to 'tranco'.
+		$this->assertSame('tranco', PfbConfig::read('alexa_type'), "legacy 'alexa' coalesces to 'tranco'");
+	}
+
+	/** alexa_type: the two live tokens ('tranco'/'cisco') pass through unchanged. */
+	public function testReadPassesThroughLiveTop1mSourceTokens(): void
+	{
+		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/alexa_type';
+
+		$this->seedConfig($path, 'cisco');
+		$this->assertSame('cisco', PfbConfig::read('alexa_type'), "'cisco' passes through unchanged");
+
+		$this->seedConfig($path, 'tranco');
+		$this->assertSame('tranco', PfbConfig::read('alexa_type'), "'tranco' passes through unchanged");
+	}
+
 	public function testReadReturnsRegisteredDefaultForDnsblInterfaceAbsentKey(): void
 	{
 		// dnsbl_interface default is 'lo0'.

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -337,24 +337,25 @@ final class CfgGatewayTest extends TestCase
 
 	public function testReadReturnsRegisteredDefaultForAlexaTypeAbsentKey(): void
 	{
-		// alexa_type default is 'tranco'.
+		// alexa_type default is 'tranco' -> Top1mSource::Tranco.
 		$this->assertNull(
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/alexa_type')
 		);
 
 		$result = PfbConfig::read('alexa_type');
-		$this->assertSame('tranco', $result);
+		$this->assertInstanceOf(Top1mSource::class, $result, 'alexa_type must return a Top1mSource enum');
+		$this->assertSame(Top1mSource::Tranco, $result);
 	}
 
 	/**
 	 * alexa_type (issue #877): a stored legacy 'alexa' (dead TOP1M source, #872)
-	 * coalesces to 'tranco' through the gateway's read adapter.
+	 * coalesces to Top1mSource::Tranco through the gateway's read adapter.
 	 *
 	 * Scenario: the dropped Alexa TOP1M option still reads safely on an existing
 	 * install that had it selected.
 	 *   Given alexa_type stored as the legacy 'alexa' token.
 	 *   When PfbConfig::read('alexa_type').
-	 *   Then the result is 'tranco', not the dead 'alexa' token.
+	 *   Then the result is Top1mSource::Tranco, not the dead 'alexa' token.
 	 */
 	public function testReadCoalescesLegacyAlexaTypeToTranco(): void
 	{
@@ -364,20 +365,20 @@ final class CfgGatewayTest extends TestCase
 		$this->seedConfig($path, 'alexa');
 		$this->assertSame('alexa', config_get_path($path), 'before: alexa_type seed is legacy alexa');
 
-		// When/Then: coalesced to 'tranco'.
-		$this->assertSame('tranco', PfbConfig::read('alexa_type'), "legacy 'alexa' coalesces to 'tranco'");
+		// When/Then: coalesced to Top1mSource::Tranco.
+		$this->assertSame(Top1mSource::Tranco, PfbConfig::read('alexa_type'), "legacy 'alexa' coalesces to Tranco");
 	}
 
-	/** alexa_type: the two live tokens ('tranco'/'cisco') pass through unchanged. */
+	/** alexa_type: the two live tokens ('tranco'/'cisco') pass through as their enum cases. */
 	public function testReadPassesThroughLiveTop1mSourceTokens(): void
 	{
 		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/alexa_type';
 
 		$this->seedConfig($path, 'cisco');
-		$this->assertSame('cisco', PfbConfig::read('alexa_type'), "'cisco' passes through unchanged");
+		$this->assertSame(Top1mSource::Cisco, PfbConfig::read('alexa_type'), "'cisco' passes through as Cisco");
 
 		$this->seedConfig($path, 'tranco');
-		$this->assertSame('tranco', PfbConfig::read('alexa_type'), "'tranco' passes through unchanged");
+		$this->assertSame(Top1mSource::Tranco, PfbConfig::read('alexa_type'), "'tranco' passes through as Tranco");
 	}
 
 	public function testReadReturnsRegisteredDefaultForDnsblInterfaceAbsentKey(): void

--- a/tests/php/PfbGlobalParityTest.php
+++ b/tests/php/PfbGlobalParityTest.php
@@ -246,8 +246,9 @@ final class PfbGlobalParityTest extends TestCase
 	 * alexa_type: OLD = isset($pfb['dnsblconfig']['alexa_type'])
 	 *                   ? $pfb['dnsblconfig']['alexa_type'] : 'tranco'.
 	 * When absent: 'tranco'.
-	 * Via gateway: PfbConfig::read('alexa_type') = 'tranco' (registered default).
-	 * PARITY: identical.
+	 * Via gateway: PfbConfig::read('alexa_type') = Top1mSource::Tranco (registered
+	 * default 'tranco', adapted through the Top1mSource enum, issue #877 review).
+	 * PARITY: same runtime meaning ('tranco'), now enum-typed instead of a raw string.
 	 */
 	public function testParityAlexaTypeAbsentYieldsTranco(): void
 	{
@@ -257,7 +258,7 @@ final class PfbGlobalParityTest extends TestCase
 
 		$result = PfbConfig::read('alexa_type');
 
-		$this->assertSame('tranco', $result, 'alexa_type absent -> "tranco"');
+		$this->assertSame(Top1mSource::Tranco, $result, 'alexa_type absent -> Top1mSource::Tranco');
 	}
 
 	/**

--- a/tests/php/RollbackContractTest.php
+++ b/tests/php/RollbackContractTest.php
@@ -764,7 +764,7 @@ final class RollbackContractTest extends TestCase
 	public function testAdapterTypeHelperReturnsValidTypeForEveryRegisteredField(): void
 	{
 		$registry    = pfb_cfg_registry();
-		$valid_types = ['toggle', 'lenient', 'idn', 'plain', 'alias_delta_mode'];
+		$valid_types = ['toggle', 'lenient', 'idn', 'plain', 'alias_delta_mode', 'top1m_source'];
 
 		foreach ($registry as $key => $entry) {
 			$type = pfb_cfg_field_adapter_type($entry);
@@ -1224,6 +1224,65 @@ final class RollbackContractTest extends TestCase
 			$stored = (string) config_get_path($path);
 			$this->assertContains($stored, $vocab,
 				"BACKWARD: log_syslog token='{$token}' write(read) stored='{$stored}' not in vocab"
+			);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// I -- issue #877: alexa_type TOP1M-source coalesce (dead 'alexa' -> 'tranco')
+	// -----------------------------------------------------------------------
+
+	/**
+	 * alexa_type: FORWARD invariant covers the legacy 'alexa' token (dead TOP1M
+	 * service, #872) in addition to the live 'tranco'/'cisco' vocabulary; BACKWARD
+	 * invariant proves the coalesce -- a write after reading a legacy 'alexa'
+	 * store never re-emits 'alexa'.
+	 *
+	 * Scenario: alexa_type rollback contract with the #877 coalesce.
+	 *   Background: alexa_type's stored vocabulary is {'tranco', 'cisco', 'alexa'}
+	 *     (the legacy value is READ-only -- pfb_cfg_field_vocab()['top1m_source']
+	 *     lists only the two live WRITE-side tokens).
+	 *   Given each of 'tranco', 'cisco', 'alexa' stored.
+	 *   When PfbConfig::read('alexa_type') then PfbConfig::write('alexa_type', result).
+	 *   Then (FORWARD) the read result is a string ('tranco' for legacy 'alexa').
+	 *   And (BACKWARD) the written token is in {'tranco', 'cisco'} -- 'alexa' is
+	 *     NEVER re-emitted, even though it was the original stored value.
+	 */
+	public function testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa(): void
+	{
+		$path        = 'installedpackages/pfblockerngdnsblsettings/config/0/alexa_type';
+		$write_vocab = pfb_cfg_field_vocab()['top1m_source'];
+
+		$cases = [
+			'tranco' => 'tranco',
+			'cisco'  => 'cisco',
+			'alexa'  => 'tranco', // legacy dead source coalesces to tranco (#872/#877)
+		];
+
+		foreach ($cases as $stored_token => $expected_runtime) {
+			// Reset.
+			$GLOBALS['config'] = [];
+			config_set_path($path, $stored_token);
+
+			// BEFORE: raw value confirmed.
+			$this->assertSame($stored_token, config_get_path($path),
+				"before forward+backward: alexa_type token='{$stored_token}'"
+			);
+
+			// FORWARD: read coalesces the legacy token; live tokens pass through.
+			$runtime = PfbConfig::read('alexa_type');
+			$this->assertSame($expected_runtime, $runtime,
+				"FORWARD: alexa_type token='{$stored_token}' must read as '{$expected_runtime}'"
+			);
+
+			// BACKWARD: write(runtime) stores only a live vocabulary token -- never 'alexa'.
+			PfbConfig::write('alexa_type', $runtime);
+			$stored = (string) config_get_path($path);
+			$this->assertContains($stored, $write_vocab,
+				"BACKWARD: alexa_type token='{$stored_token}' write(read) stored='{$stored}' not in vocab"
+			);
+			$this->assertNotSame('alexa', $stored,
+				"BACKWARD: alexa_type write must never re-emit dead legacy token 'alexa'"
 			);
 		}
 	}

--- a/tests/php/RollbackContractTest.php
+++ b/tests/php/RollbackContractTest.php
@@ -370,20 +370,23 @@ final class RollbackContractTest extends TestCase
 	 *     Then the result is the same string (identity; no crash, no type change).
 	 *
 	 * Note: pfb_idn is now adapted via PfbIdnMode (NOT plain-string). See
-	 * testPfbIdnModeAdapterForwardAndBackward() for pfb_idn coverage.
+	 * testPfbIdnModeAdapterForwardAndBackward() for pfb_idn coverage. alexa_type is
+	 * likewise adapted via Top1mSource (issue #877 review) -- see
+	 * testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa() for its coverage.
 	 */
 	public function testForwardPlainStringFieldsPassLegacyTokensUnchanged(): void
 	{
 		// Representative plain-string fields with canonical legacy stored values.
 		// pfb_idn is intentionally excluded: it uses the PfbIdnMode adapter (not
-		// null/null) so it returns a PfbIdnMode enum, not a plain string.
+		// null/null) so it returns a PfbIdnMode enum, not a plain string. alexa_type
+		// is likewise excluded: it uses the Top1mSource adapter (not null/null) so
+		// it returns a Top1mSource enum, not a plain string.
 		$cases = [
 			// General section
 			'pfb_interval'          => ['installedpackages/pfblockerng/config/0/pfb_interval', '1'],
 			'pfb_agg_types'         => ['installedpackages/pfblockerng/config/0/pfb_agg_types', 'Deny'],
 			// DNSBL settings section
 			'dnsbl_interface'       => ['installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_interface', 'lo0'],
-			'alexa_type'            => ['installedpackages/pfblockerngdnsblsettings/config/0/alexa_type', 'tranco'],
 			'alexa_count'           => ['installedpackages/pfblockerngdnsblsettings/config/0/alexa_count', '1000'],
 			'action'                => ['installedpackages/pfblockerngdnsblsettings/config/0/action', 'Disabled'],
 			'pfb_dnsbl_rule'        => ['installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_rule', 'Disabled'],
@@ -648,18 +651,21 @@ final class RollbackContractTest extends TestCase
 	 *     Then stored == $str (the adapter cannot introduce any novel token).
 	 *
 	 * Note: pfb_idn is now adapted via PfbIdnMode (NOT plain-string). See
-	 * testPfbIdnModeAdapterForwardAndBackward() for pfb_idn backward coverage.
+	 * testPfbIdnModeAdapterForwardAndBackward() for pfb_idn backward coverage. alexa_type
+	 * is likewise adapted via Top1mSource (issue #877 review) -- see
+	 * testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa() for its coverage.
 	 */
 	public function testBackwardPlainStringFieldsIdentityAdapterCannotIntroduceNovelTokens(): void
 	{
 		// pfb_idn is intentionally excluded: it now uses the PfbIdnMode write adapter,
 		// which normalises to the canonical vocabulary ('on'|'confusable'|'off') rather
 		// than emitting identity for every input (e.g. the dropped alpha 'all' -> 'off').
-		// See testPfbIdnModeAdapterForwardAndBackward().
+		// See testPfbIdnModeAdapterForwardAndBackward(). alexa_type is likewise excluded:
+		// it uses the Top1mSource write adapter (enum-typed), covered by
+		// testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa() instead.
 		$cases = [
 			'pfb_interval'      => ['installedpackages/pfblockerng/config/0/pfb_interval', '6'],
 			'dnsbl_interface'   => ['installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_interface', 'lo0'],
-			'alexa_type'        => ['installedpackages/pfblockerngdnsblsettings/config/0/alexa_type', 'tranco'],
 			'safesearch_enable' => ['installedpackages/pfblockerngsafesearch/safesearch_enable', 'Disable'],
 		];
 
@@ -1241,10 +1247,11 @@ final class RollbackContractTest extends TestCase
 	 * Scenario: alexa_type rollback contract with the #877 coalesce.
 	 *   Background: alexa_type's stored vocabulary is {'tranco', 'cisco', 'alexa'}
 	 *     (the legacy value is READ-only -- pfb_cfg_field_vocab()['top1m_source']
-	 *     lists only the two live WRITE-side tokens).
+	 *     lists only the two live WRITE-side tokens). The field is now adapted via
+	 *     the Top1mSource enum (mirrors PfbIdnMode/PfbAliasDeltaMode).
 	 *   Given each of 'tranco', 'cisco', 'alexa' stored.
 	 *   When PfbConfig::read('alexa_type') then PfbConfig::write('alexa_type', result).
-	 *   Then (FORWARD) the read result is a string ('tranco' for legacy 'alexa').
+	 *   Then (FORWARD) the read result is a Top1mSource enum (Tranco for legacy 'alexa').
 	 *   And (BACKWARD) the written token is in {'tranco', 'cisco'} -- 'alexa' is
 	 *     NEVER re-emitted, even though it was the original stored value.
 	 */
@@ -1254,9 +1261,9 @@ final class RollbackContractTest extends TestCase
 		$write_vocab = pfb_cfg_field_vocab()['top1m_source'];
 
 		$cases = [
-			'tranco' => 'tranco',
-			'cisco'  => 'cisco',
-			'alexa'  => 'tranco', // legacy dead source coalesces to tranco (#872/#877)
+			'tranco' => Top1mSource::Tranco,
+			'cisco'  => Top1mSource::Cisco,
+			'alexa'  => Top1mSource::Tranco, // legacy dead source coalesces to Tranco (#872/#877)
 		];
 
 		foreach ($cases as $stored_token => $expected_runtime) {
@@ -1271,8 +1278,11 @@ final class RollbackContractTest extends TestCase
 
 			// FORWARD: read coalesces the legacy token; live tokens pass through.
 			$runtime = PfbConfig::read('alexa_type');
+			$this->assertInstanceOf(Top1mSource::class, $runtime,
+				"FORWARD: alexa_type token='{$stored_token}' must yield a Top1mSource enum"
+			);
 			$this->assertSame($expected_runtime, $runtime,
-				"FORWARD: alexa_type token='{$stored_token}' must read as '{$expected_runtime}'"
+				"FORWARD: alexa_type token='{$stored_token}' must read as {$expected_runtime->name}"
 			);
 
 			// BACKWARD: write(runtime) stores only a live vocabulary token -- never 'alexa'.

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -53,7 +53,7 @@ final class UnboundPythonSourcesTest extends TestCase
 			'dnsdir'             => "{$this->tmp}/dnsbl",
 			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
 			'dbdir'              => "{$this->tmp}/db",
-			'dnsbl_alexa'        => 'off',
+			'dnsbl_top1m'        => 'off',
 			'dnsbl_tld_data'     => "{$this->tmp}/does_not_exist",
 			'dnsbl_unlock'       => "{$this->tmp}/dnsbl_unlock",
 			'dnsblconfig'        => [

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1059,6 +1059,24 @@ def test_threats_rejects_malformed_lookup(name: str, query: str, message: str, w
     assert not present, f"{name}: reject path unexpectedly rendered lookup chrome {present}"
 
 
+def test_threats_domain_dead_alexa_siteinfo_link_removed(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """The domain threat-lookup page no longer links out to alexa.com/siteinfo (#877).
+
+    Alexa.com's siteinfo service shut down in 2022, so the link 404s. Asserts the
+    page still passes the clean-render oracle (Threat Domain Lookup chrome intact)
+    AND that the dead Alexa link is gone from the body while the sibling domain-intel
+    links (Talos, Norton Safe Web) remain -- proving only the one dead link was cut.
+    """
+    path = f"{THREATS_PAGE}?domain={helpers.unique_domain()}"
+    resp = webui.get(path)
+    result = evaluate_render(path, resp.status_code, resp.text, ("Threat Domain", "Source IP"))
+    assert result.ok, f"threats domain render oracle failed: {result.detail}"
+    body = resp.text
+    assert "alexa.com/siteinfo" not in body, "threats domain page still links to the dead alexa.com/siteinfo service"
+    for needle in ("Talos Threat Intelligence", "Norton Safe Web"):
+        assert needle in body, f"threats domain page lost an unrelated domain-intel link {needle!r}"
+
+
 # ADR-19: the "Software" page + tab are PROVENANCE-GATED — present ONLY on a build installed
 # from one of OUR repos (pkg %R == pfblockerng / pfblockerng-nightly). The ADR-04 UI harness
 # sideloads the branch .pkg with `pkg add -f` (offline), so its %R is empty -> the auto-detect

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -652,6 +652,27 @@ def test_dnsbl_control_fields_render(webui: WebUI, php_error_log_guard: PhpError
         assert needle in body, f"DNSBL page is missing the control marker {needle!r}"
 
 
+def test_dnsbl_top1m_source_options_exclude_alexa(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """The TOP1M 'Type' select renders only the two live sources (Tranco, Cisco
+    Umbrella) — the dead Alexa TOP1M option (#872) is dropped from the page
+    (#877), so a regression that resurrects the option is caught at the render
+    tier.
+
+    Asserts the page passes the clean-render oracle AND that both live option
+    labels are present while the removed 'Alexa TOP1M' label and its
+    ``value="alexa"`` option are absent from the body.
+    """
+    path = "/pfblockerng/pfblockerng_dnsbl.php"
+    resp = webui.get(path)
+    result = evaluate_render(path, resp.status_code, resp.text, ("DNSBL Configuration",))
+    assert result.ok, f"DNSBL render oracle failed: {result.detail}"
+    body = resp.text
+    for needle in ("Tranco TOP1M", "Cisco Umbrella TOP1M"):
+        assert needle in body, f"DNSBL page is missing the TOP1M source option {needle!r}"
+    for absent in ("Alexa TOP1M", 'value="alexa"'):
+        assert absent not in body, f"DNSBL page still renders the dropped Alexa TOP1M option ({absent!r})"
+
+
 def test_dnsbl_lenient_parsing_field_renders(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """The ADR-22 'Lenient Feed Parsing' toggle renders cleanly on the DNSBL page — so a
     regression that drops or breaks the field is caught at the render tier (not only by the


### PR DESCRIPTION
Part B of #872 (TLD Allow + Alexa cleanup). Removes **Alexa** as a Top1M whitelist source and renames the Alexa-flavoured naming to generic **Top1M** — **everywhere except the stored config keys**, so upgrade and downgrade stay fully compatible with no migration.

## What

- **Drop `'alexa'` as a Top1M source.** The source selector now offers only Tranco + Cisco Umbrella; the dead `s3.amazonaws.com/alexa-static` URL branch is gone.
- **Legacy compatibility via the config gateway.** A stored `alexa_type='alexa'` is coalesced to `tranco` at the read boundary (`pfb_cfg_top1m_source_read`, wired on the `alexa_type` registry entry); writes stay canonical (`tranco`/`cisco`). A plain-string coalesce, not an enum — the field has two live values and every consumer compares it as a string, so an enum would ripple for no benefit.
- **Stored config keys are unchanged on disk** — `alexa_enable`, `alexa_type`, `alexa_count`, `alexa_inclusion`, `filter_alexa` keep their names, so there is no migration and downgrade is safe.
- **Rename the visible surface to Top1M** — the four `$pfb['dnsbl_alexa*']` runtime keys → `dnsbl_top1m*`, the local var, comments, and UI labels. The Python side was already `top1m_*` (the manifest boundary renames at the edge), so no Python change.
- **Remove the dead `alexa.com/siteinfo` domain-intel link** from the alerts/threats page (Alexa siteinfo shut down in 2022; the link 404s). The sibling Talos/Norton links are untouched.

Left intentionally: the `pfbalexawhitelist.txt` generated artifact filename (renaming it needs on-disk cleanup for zero user benefit — marked with a `ponytail:` note) and the `feeds.json` "Alexa Rank" prose (it factually describes an external feed's historical methodology).

## Tests

- Round-trip / coalesce (fail-before/pass-after): `CfgAdaptersTest`, `CfgGatewayTest::testReadCoalescesLegacyAlexaTypeToTranco`, `RollbackContractTest::testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa` — a stored `'alexa'` reads back as `'tranco'` (failed before) and a write never re-emits `'alexa'`.
- Tier-A UI: `test_dnsbl_top1m_source_options_exclude_alexa` (selector has Tranco+Cisco, no Alexa) and `test_threats_domain_dead_alexa_siteinfo_link_removed` (dead link gone, sibling links kept).
- The visible rename is behaviour-preserving — the full PHPUnit/PHPCS/PHPStan suite stays green across it.

Fixes #877.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the TOP1M source setting to support the current live options and preserve legacy values transparently.
  * Added clearer handling for TOP1M source selection in the web interface and update flow.

* **Bug Fixes**
  * Legacy TOP1M values now load safely as the default option instead of appearing as invalid entries.
  * Removed outdated Alexa TOP1M links/options from the UI and threat lookup page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->