### PR TITLE
pfblockerng: stream lifecycle-hook output live to the pkg Software page

### DIFF
--- a/docs/misc/external-process-waits.md
+++ b/docs/misc/external-process-waits.md
@@ -88,13 +88,18 @@ so the page streams live progress. The unbound-stop wait logs its keepalive dots
 path, so that closes the silent gap too. Visibility only: the fd-detach, `--foreground`, and
 redirect safety above are untouched.
 
-An **update hook's own** stdout/stderr needs the same treatment, but it can't just be printed live:
-the hook body is redirected to the log file precisely so a daemon it starts can't hold the capture
-pipe (above), so mirroring it with a `tee`/pipe would reintroduce the hang. Instead `pfb_run_hooks()`
-records the log offset before `exec()` and, after the hook returns, `pfb_mirror_hook_output()` reads
-back exactly the bytes the hook appended and prints them (during a lifecycle callback only). A plain
-file read can't hang — the daemon holds a harmless file fd, not the reader — so the page shows the
-`[ pfB Hook ] …` markers *and* the hook's real output between them (issue #693).
+An **update hook's own** stdout/stderr needs the same treatment, but it can't just be printed live
+through a pipe: the hook body is redirected to the log file precisely so a daemon it starts can't
+hold the capture pipe (above), so mirroring it with a `tee`/pipe would reintroduce the hang.
+Instead, during a lifecycle callback `pfb_run_hooks()` runs the hook under `proc_open()` with its
+stdout/stderr pointed at the log **file** via the descriptor spec (never a pipe back to PHP — a
+spawned daemon inherits only a harmless file fd), tracks the child with `proc_get_status()`, and
+**tails the file to stdout with `pfb_log_tail_chunk()` while the hook runs** — so the page shows the
+`[ pfB Hook ] …` markers *and* the hook's real output streaming live between them, not one block
+after it exits (issues #693/#883). The exit code (124 on timeout, else the hook's own) comes off
+the status; a plain file read can't hang, so the daemon-safety is preserved. On the non-lifecycle
+cron/manual/Run-Now path the hook stays a blocking `exec()` (the Update page's AJAX viewer already
+tails the per-run log); `pfb_mirror_hook_output()` remains only as the `proc_open`-failure fallback.
 
 ## Following one specific dispatched process — pidfile, not a `ps` pattern or a log string
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ ignore = [
 "tests/smoke/test_downgrade_prepare.py"         = ["F811"]
 "tests/smoke/test_pkg_op_teardown.py"           = ["F811"]
 "tests/smoke/test_lifecycle_hook_visibility.py" = ["F811"]
+"tests/smoke/test_hook_stream_visibility.py" = ["F811"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["pfb_unbound"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ ignore = [
 "tests/smoke/test_downgrade_prepare.py"         = ["F811"]
 "tests/smoke/test_pkg_op_teardown.py"           = ["F811"]
 "tests/smoke/test_lifecycle_hook_visibility.py" = ["F811"]
-"tests/smoke/test_hook_stream_visibility.py" = ["F811"]
+"tests/smoke/test_hook_stream_visibility.py"    = ["F811"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["pfb_unbound"]

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4237,11 +4237,77 @@ function pfb_run_hooks($when, $ctx = array()) {
 
 		$discard = array();
 		$retval  = 0;
-		exec($cmd, $discard, $retval);
 
-		// #693: during a pkg install/upgrade/uninstall (lifecycle callback), stream the hook's
-		// captured output to the package-manager output so the admin sees what it actually did.
-		pfb_mirror_hook_output($logtarget, $hook_log_offset);
+		if (empty($pfb['hook_lifecycle'])) {
+			// Normal cron/manual/Run-Now pass: unchanged synchronous path. The Update page's own
+			// AJAX tail already streams $logtarget (the per-run log) straight to the browser, so
+			// no extra streaming/mirroring is needed here.
+			exec($cmd, $discard, $retval);
+		} else {
+			// pkg install/upgrade/uninstall (lifecycle callback): STREAM the hook's own output to
+			// the pkg Software page AS it runs, instead of one block after it exits.
+			// pfb_mirror_hook_output() (below) only closed the "arrives at all" gap (#693); this
+			// closes "arrives live". Run the SAME timeout+redirect-to-file command in the
+			// BACKGROUND under daemon(8) -- output still lands on the log FILE, never a live pipe,
+			// so a hook that restarts a daemon still can't hang exec() (#662) -- and tail the file
+			// to stdout while daemon -p's pidfile stays live (isvalidpid), the same dispatch shape
+			// as pfb_runnow() in pfblockerng_update.php. The inner `echo $? > rcfile` captures the
+			// hook's real exit code (124 on timeout, else the hook's own) since a background
+			// launch has no exec() return value to read.
+			$idxsafe = (int) $idx;
+			$pidfile = "/var/run/pfb_hook_{$idxsafe}.pid";
+			$rcfile  = "/var/run/pfb_hook_{$idxsafe}.rc";
+			@unlink($pidfile);
+			@unlink($rcfile);
+			$inner = "/usr/bin/timeout --foreground -s TERM -k " . PFB_HOOK_KILL_GRACE .
+				" {$timeout} " . escapeshellarg($path) . " >> {$logf} 2>&1 < /dev/null; " .
+				'echo $? > ' . escapeshellarg($rcfile);
+			mwexec_bg("{$envprefix} /usr/sbin/daemon -p " . escapeshellarg($pidfile) .
+				' /bin/sh -c ' . escapeshellarg($inner));
+
+			// Bounded launch grace (~5s @ 200ms): daemon(8) needs a moment to fork and write the
+			// pidfile -- or, for a near-instant hook, $rcfile may already exist by the time we
+			// check. Neither showing up means the background launch itself failed.
+			$launched = FALSE;
+			for ($i = 0; $i < 25; $i++) {
+				if (isvalidpid($pidfile) || is_file($rcfile)) {
+					$launched = TRUE;
+					break;
+				}
+				usleep(200000);
+			}
+
+			if (!$launched) {
+				// Launch failed -- never lose the hook run: fall back to the exact synchronous
+				// path used outside a lifecycle callback, then mirror the captured body once.
+				@unlink($pidfile);
+				@unlink($rcfile);
+				exec($cmd, $discard, $retval);
+				pfb_mirror_hook_output($logtarget, $hook_log_offset);
+			} else {
+				// Tail the delta while the hook is alive. Hard-bounded so a wedged isvalidpid()
+				// can never hang the pass -- timeout(1) already kills the hook at $timeout +
+				// PFB_HOOK_KILL_GRACE, so the pidfile clears well inside this cap.
+				$off = $hook_log_offset;
+				$maxiter = (int) ceil(($timeout + PFB_HOOK_KILL_GRACE + 10) / 0.2);
+				for ($i = 0; $i < $maxiter && isvalidpid($pidfile); $i++) {
+					$chunk = pfb_log_tail_chunk($logtarget, $off, FALSE);
+					if ($chunk['data'] !== '') {
+						print $chunk['data'];
+					}
+					$off = $chunk['offset'];
+					usleep(200000);
+				}
+				// Final drain: flush the trailing partial line the whole-lines-only tail held back.
+				$chunk = pfb_log_tail_chunk($logtarget, $off, TRUE);
+				if ($chunk['data'] !== '') {
+					print $chunk['data'];
+				}
+				$retval = is_file($rcfile) ? (int) trim((string) @file_get_contents($rcfile)) : 0;
+				@unlink($pidfile);
+				@unlink($rcfile);
+			}
+		}
 
 		if ($retval === 124) {
 			pfb_logger("[ pfB Hook ] {$when} {$label} TIMED OUT after {$timeout}s (killed); continuing\n", 2);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4270,10 +4270,12 @@ function pfb_run_hooks($when, $ctx = array()) {
 				pfb_mirror_hook_output($logtarget, $hook_log_offset);
 			} else {
 				// Tail the delta while the hook is alive, then drain the trailing partial line.
-				// Hard-bounded so a wedged status can never hang the pass -- timeout(1) already
-				// kills the hook at $timeout + PFB_HOOK_KILL_GRACE.
+				// The loop is bounded so a wedged status can't spin forever -- timeout(1) already
+				// kills the hook at $timeout + PFB_HOOK_KILL_GRACE, so a healthy child always reports
+				// exit well inside the cap; exhausting it means the child never reported dead.
 				$off     = $hook_log_offset;
 				$maxiter = (int) ceil(($timeout + PFB_HOOK_KILL_GRACE + 10) / 0.2);
+				$exited  = FALSE;
 				for ($i = 0; $i < $maxiter; $i++) {
 					$chunk = pfb_log_tail_chunk($logtarget, $off, FALSE);
 					if ($chunk['data'] !== '') {
@@ -4284,6 +4286,7 @@ function pfb_run_hooks($when, $ctx = array()) {
 					if (!$st['running']) {
 						// First not-running read carries the real exit code (later reads/close give -1).
 						$retval = (int) $st['exitcode'];
+						$exited = TRUE;
 						break;
 					}
 					usleep(200000);
@@ -4291,6 +4294,13 @@ function pfb_run_hooks($when, $ctx = array()) {
 				$chunk = pfb_log_tail_chunk($logtarget, $off, TRUE);
 				if ($chunk['data'] !== '') {
 					print $chunk['data'];
+				}
+				if (!$exited) {
+					// Cap exhausted with the child still "running" -- a pathologically wedged process.
+					// Don't let proc_close() block on it, and don't mis-log success: kill it and mark
+					// the status unknown (-1) so the branch below logs a failure, not "completed".
+					@proc_terminate($proc, 9);
+					$retval = -1;
 				}
 				proc_close($proc);
 			}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4247,65 +4247,52 @@ function pfb_run_hooks($when, $ctx = array()) {
 			// pkg install/upgrade/uninstall (lifecycle callback): STREAM the hook's own output to
 			// the pkg Software page AS it runs, instead of one block after it exits.
 			// pfb_mirror_hook_output() (below) only closed the "arrives at all" gap (#693); this
-			// closes "arrives live". Run the SAME timeout+redirect-to-file command in the
-			// BACKGROUND under daemon(8) -- output still lands on the log FILE, never a live pipe,
-			// so a hook that restarts a daemon still can't hang exec() (#662) -- and tail the file
-			// to stdout while daemon -p's pidfile stays live (isvalidpid), the same dispatch shape
-			// as pfb_runnow() in pfblockerng_update.php. The inner `echo $? > rcfile` captures the
-			// hook's real exit code (124 on timeout, else the hook's own) since a background
-			// launch has no exec() return value to read.
-			$idxsafe = (int) $idx;
-			$pidfile = "/var/run/pfb_hook_{$idxsafe}.pid";
-			$rcfile  = "/var/run/pfb_hook_{$idxsafe}.rc";
-			@unlink($pidfile);
-			@unlink($rcfile);
-			$inner = "/usr/bin/timeout --foreground -s TERM -k " . PFB_HOOK_KILL_GRACE .
-				" {$timeout} " . escapeshellarg($path) . " >> {$logf} 2>&1 < /dev/null; " .
-				'echo $? > ' . escapeshellarg($rcfile);
-			mwexec_bg("{$envprefix} /usr/sbin/daemon -p " . escapeshellarg($pidfile) .
-				' /bin/sh -c ' . escapeshellarg($inner));
+			// closes "arrives live". proc_open() runs the hook as a DIRECT child with its
+			// stdout/stderr pointed at the log FILE via the descriptor spec -- never a pipe back to
+			// PHP, so a hook that restarts a daemon inheriting fd 1 still can't hang us (#662), the
+			// daemon just holds a harmless file fd. We track the child with proc_get_status() (no
+			// daemon(8)/pidfile needed) and tail the file to stdout while it runs; the exit code
+			// (124 on timeout, else the hook's own) comes straight off the status.
+			$descriptors = array(
+				0 => array('file', '/dev/null', 'r'),
+				1 => array('file', $logtarget, 'a'),
+				2 => array('file', $logtarget, 'a'),
+			);
+			$proccmd = "{$envprefix} /usr/bin/timeout --foreground -s TERM -k " .
+				PFB_HOOK_KILL_GRACE . " {$timeout} " . escapeshellarg($path);
+			$pipes = array();
+			$proc  = @proc_open($proccmd, $descriptors, $pipes);
 
-			// Bounded launch grace (~5s @ 200ms): daemon(8) needs a moment to fork and write the
-			// pidfile -- or, for a near-instant hook, $rcfile may already exist by the time we
-			// check. Neither showing up means the background launch itself failed.
-			$launched = FALSE;
-			for ($i = 0; $i < 25; $i++) {
-				if (isvalidpid($pidfile) || is_file($rcfile)) {
-					$launched = TRUE;
-					break;
-				}
-				usleep(200000);
-			}
-
-			if (!$launched) {
-				// Launch failed -- never lose the hook run: fall back to the exact synchronous
-				// path used outside a lifecycle callback, then mirror the captured body once.
-				@unlink($pidfile);
-				@unlink($rcfile);
+			if (!is_resource($proc)) {
+				// proc_open unavailable/failed -- never lose the hook run: fall back to the exact
+				// synchronous path, then mirror the captured body once.
 				exec($cmd, $discard, $retval);
 				pfb_mirror_hook_output($logtarget, $hook_log_offset);
 			} else {
-				// Tail the delta while the hook is alive. Hard-bounded so a wedged isvalidpid()
-				// can never hang the pass -- timeout(1) already kills the hook at $timeout +
-				// PFB_HOOK_KILL_GRACE, so the pidfile clears well inside this cap.
-				$off = $hook_log_offset;
+				// Tail the delta while the hook is alive, then drain the trailing partial line.
+				// Hard-bounded so a wedged status can never hang the pass -- timeout(1) already
+				// kills the hook at $timeout + PFB_HOOK_KILL_GRACE.
+				$off     = $hook_log_offset;
 				$maxiter = (int) ceil(($timeout + PFB_HOOK_KILL_GRACE + 10) / 0.2);
-				for ($i = 0; $i < $maxiter && isvalidpid($pidfile); $i++) {
+				for ($i = 0; $i < $maxiter; $i++) {
 					$chunk = pfb_log_tail_chunk($logtarget, $off, FALSE);
 					if ($chunk['data'] !== '') {
 						print $chunk['data'];
 					}
 					$off = $chunk['offset'];
+					$st  = proc_get_status($proc);
+					if (!$st['running']) {
+						// First not-running read carries the real exit code (later reads/close give -1).
+						$retval = (int) $st['exitcode'];
+						break;
+					}
 					usleep(200000);
 				}
-				// Final drain: flush the trailing partial line the whole-lines-only tail held back.
 				$chunk = pfb_log_tail_chunk($logtarget, $off, TRUE);
 				if ($chunk['data'] !== '') {
 					print $chunk['data'];
 				}
-				$retval = is_file($rcfile) ? (int) trim((string) @file_get_contents($rcfile)) : 0;
-				@unlink($pidfile);
-				@unlink($rcfile);
+				proc_close($proc);
 			}
 		}
 

--- a/tests/smoke/test_hook_stream_visibility.py
+++ b/tests/smoke/test_hook_stream_visibility.py
@@ -1,0 +1,172 @@
+"""ADR-12 / #693 — a hook's output must STREAM to the GUI while the hook runs, not
+appear as one block only after it exits.
+
+``test_lifecycle_hook_visibility`` proves a hook's output ENDS UP in the GUI log; this
+proves it gets there PROGRESSIVELY. Today ``pfb_run_hooks()`` runs the hook to completion
+under a blocking ``exec()`` (its output redirected to a file so a spawned daemon can't hang
+the pass, #662) and only then mirrors the whole delta to stdout (``pfb_mirror_hook_output``)
+— so a slow hook (e.g. a 30 s HAProxy reload printing progress) shows BLANK on the pkg
+Software page the whole time, then dumps everything at the end.
+
+This pins the streaming contract without a browser: install a hook that prints LINE1, then
+BLOCKS on a test-controlled "proceed" file (a signal, not a sleep — deterministic), then
+prints LINE2. While the hook is still blocked, LINE1 must already be visible in the GUI-tailed
+log. RED against the block-behavior (LINE1 absent mid-hook); GREEN once the hook output streams.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM
+from .test_repo_install import (  # noqa: F401
+    NETGATE_REPO_NAME,
+    OURS_REPO_DIR,
+    PKG_NAME,
+    pkg_delete,
+    pkg_install_from_repo,
+    pkg_installed_version,
+    pkg_update,
+    repo_priority,
+    repo_vm,
+    write_repo_conf,
+)
+
+pytestmark = pytest.mark.repo
+
+PFSENSE_UPGRADE = "/usr/local/sbin/pfSense-upgrade"
+GUI_LOG = "/tmp/pfb_gui_stream.txt"
+WAITING = "/tmp/pfb_hook_waiting"  # hook touches this after printing LINE1, before blocking
+PROCEED = "/tmp/pfb_hook_proceed"  # test touches this to release the hook to print LINE2
+LINE1 = "PFB_STREAM_LINE1"
+LINE2 = "PFB_STREAM_LINE2"
+
+
+def _streaming_hook(token: str) -> dict[str, str]:
+    """A post hook: print LINE1, signal 'waiting', BLOCK on PROCEED (bounded), print LINE2.
+
+    The block is a busy-wait on a test-created file — a signal, not a fixed sleep — so the
+    test releases the hook deterministically and never races a timer. The 30 s inner bound
+    (150 * 0.2 s) is a self-guard so the hook can never outlive its own timeout budget.
+    """
+    body = (
+        "#!/bin/sh\n"
+        f"echo '{LINE1}'\n"
+        f": > {WAITING}\n"
+        f"i=0\nwhile [ ! -f {PROCEED} ] && [ $i -lt 150 ]; do sleep 0.2; i=$((i + 1)); done\n"
+        f"echo '{LINE2}'\n"
+        f"rm -f {WAITING}\n"
+    )
+    return {
+        "script": f"hook_post_{token}_stream.sh",
+        "_body": body,
+        "when": "post",
+        "enabled": "on",
+        "description": f"smoke {token} stream",
+        "timeout": "120",  # must exceed the block window so the wait is not killed
+    }
+
+
+def _wait_for_guest_file(vm: SmokeVM, path: str, *, deadline_s: float, poll_s: float = 1.0) -> bool:
+    """Poll until ``path`` exists on the guest or the deadline passes. Returns True iff it appeared.
+
+    A bounded poll on a REMOTE file the hook creates — the only side we cannot signal — with a
+    hard deadline (never an open wait). This is the sanctioned last-resort poll, kept loud: the
+    caller asserts the return.
+    """
+    end = time.monotonic() + deadline_s
+    while time.monotonic() < end:
+        if vm.ssh("/bin/test", "-f", path).returncode == 0:
+            return True
+        time.sleep(poll_s)
+    return False
+
+
+@pytest.mark.timeout(1200)
+def test_hook_output_streams_to_gui_while_running(repo_vm: SmokeVM) -> None:
+    """A hook's stdout is visible in the GUI log WHILE the hook is still running.
+
+    Scenario: a slow hook's progress must stream to the pkg Software page, not appear only
+      after it finishes.
+      Background: our NONE-signed file:// repo above the Netgate repo (repo_vm).
+
+    Given pfBlockerNG installed with a post hook that prints LINE1, then blocks on a
+      test-controlled signal file, then prints LINE2,
+    When the GUI "Update now" wrapper (``pfSense-upgrade -i <name> -f``) runs it — launched
+      detached so we can observe mid-flight — and the hook signals it has printed LINE1 and is
+      now blocked,
+    Then LINE1 is ALREADY present in the GUI-tailed log (``-l`` file) while LINE2 is NOT — the
+      hook's output streamed. (RED against today's block-behavior: the whole hook body is
+      mirrored only after the hook exits, so LINE1 is absent here.)
+    When the hook is released and the op completes,
+    Then BOTH LINE1 and LINE2 are in the GUI log — the tail drained to completion.
+    """
+    vm = repo_vm
+    pfsense_prio = repo_priority(vm, NETGATE_REPO_NAME)
+    token = "streamvis"
+
+    try:
+        # ---- GIVEN: install from our repo + the block-on-signal streaming hook ----- #
+        pkg_delete(vm)
+        write_repo_conf(vm, OURS_REPO_DIR, ours_priority=pfsense_prio + 100)
+        pkg_update(vm)
+        assert pkg_installed_version(vm) is None, f"{PKG_NAME} unexpectedly present before install"
+        pkg_install_from_repo(vm)
+        assert pkg_installed_version(vm) is not None, "the from-repo install did not register the package"
+
+        h.set_update_hooks(vm, [_streaming_hook(token)])
+        vm.ssh("/bin/rm", "-f", GUI_LOG, WAITING, PROCEED)
+
+        # ---- WHEN: launch the GUI reinstall DETACHED so we can watch mid-hook ------- #
+        # nohup + & so ssh returns immediately; pfSense-upgrade keeps running on the guest.
+        vm.ssh(
+            "/bin/sh",
+            "-c",
+            f"nohup {PFSENSE_UPGRADE} -y -l {GUI_LOG} -i {PKG_NAME} -f >/dev/null 2>&1 &",
+        )
+
+        # The hook fires late in the resync; wait (bounded) for it to print LINE1 and block.
+        assert _wait_for_guest_file(vm, WAITING, deadline_s=300.0), (
+            "the streaming hook never reached its wait state within 300s — the reinstall resync "
+            "did not fire the post hook (was pfSense-upgrade -i -f run and the hook configured?)"
+        )
+
+        # ---- THEN (streaming): LINE1 visible mid-hook, LINE2 not yet --------------- #
+        # The hook is provably still blocked (WAITING exists, PROCEED not created yet).
+        mid = vm.ssh("cat", GUI_LOG).stdout
+        assert LINE1 in mid, (
+            f"the hook's first line {LINE1!r} is NOT in the GUI log while the hook is still "
+            f"running — its output is buffered until the hook exits instead of streaming to the "
+            f"pkg Software page. GUI log so far:\n{mid[-3000:]}"
+        )
+        assert LINE2 not in mid, (
+            f"{LINE2!r} appeared before the hook was released — the block-on-signal setup is "
+            f"broken (the hook did not actually wait). GUI log:\n{mid[-3000:]}"
+        )
+
+        # ---- WHEN: release the hook, let the op finish ----------------------------- #
+        vm.ssh("/usr/bin/touch", PROCEED)
+        assert _wait_for_guest_file(vm, GUI_LOG, deadline_s=60.0), "GUI log vanished after release"
+
+        # Wait (bounded) for LINE2 to land — the op is done once the final line is mirrored.
+        end = time.monotonic() + 120.0
+        final = ""
+        while time.monotonic() < end:
+            final = vm.ssh("cat", GUI_LOG).stdout
+            if LINE2 in final:
+                break
+            time.sleep(1.0)
+
+        # ---- THEN: both lines present at the end ----------------------------------- #
+        assert LINE1 in final and LINE2 in final, (
+            f"after releasing the hook, the GUI log is missing a line (LINE1={LINE1 in final}, "
+            f"LINE2={LINE2 in final}):\n{final[-3000:]}"
+        )
+    finally:
+        vm.ssh("/usr/bin/touch", PROCEED)  # never leave a blocked hook behind
+        h.clear_update_hooks(vm)
+        vm.ssh("/bin/rm", "-f", GUI_LOG, WAITING, PROCEED)
+        pkg_delete(vm)

--- a/tests/smoke/test_hook_stream_visibility.py
+++ b/tests/smoke/test_hook_stream_visibility.py
@@ -197,8 +197,12 @@ def test_hook_output_streams_to_gui_while_running(repo_vm: SmokeVM) -> None:
 
         # LINE2 means the HOOK finished, but the wrapping detached pfSense-upgrade keeps its pkg
         # lock through the rest of the resync. Drain it before cleanup so pkg_delete() below (in
-        # finally) doesn't race the still-held lock.
-        _wait_upgrade_gone(vm, deadline_s=120.0)
+        # finally) doesn't race the still-held lock. Assert (loud timeout): if it never exits the
+        # test is not deterministic — surface that rather than proceed into a lock race.
+        assert _wait_upgrade_gone(vm, deadline_s=120.0), (
+            "pfSense-upgrade did not exit within 120s after the hook finished — cleanup would race "
+            "its still-held pkg lock"
+        )
     finally:
         vm.ssh("/usr/bin/touch", PROCEED)  # never leave a blocked hook behind
         _wait_upgrade_gone(vm, deadline_s=60.0)  # let a failed-path run release its pkg lock too

--- a/tests/smoke/test_hook_stream_visibility.py
+++ b/tests/smoke/test_hook_stream_visibility.py
@@ -135,12 +135,28 @@ def test_hook_output_streams_to_gui_while_running(repo_vm: SmokeVM) -> None:
         )
 
         # ---- THEN (streaming): LINE1 visible mid-hook, LINE2 not yet --------------- #
-        # The hook is provably still blocked (WAITING exists, PROCEED not created yet).
-        mid = vm.ssh("cat", GUI_LOG).stdout
+        # The hook is provably still blocked: it touched WAITING (removed only after LINE2),
+        # and PROCEED is not created until below — so nothing releases it during this window.
+        # Streaming has inherent lag (the on-box tail polls every 200ms, then pfSense-upgrade
+        # tees), so poll (bounded) for LINE1 rather than a single racy read. A hook whose output
+        # only appears AFTER it exits (block-behaviour) never shows LINE1 here — the hook cannot
+        # exit until PROCEED, which is created only after this loop.
+        mid = ""
+        pid_seen = False
+        end = time.monotonic() + 20.0
+        while time.monotonic() < end:
+            mid = vm.ssh("cat", GUI_LOG).stdout
+            pid_seen = pid_seen or vm.ssh("/bin/sh", "-c", "ls /var/run/pfb_hook_*.pid 2>/dev/null").returncode == 0
+            if LINE1 in mid:
+                break
+            time.sleep(1.0)
+        assert vm.ssh("/bin/test", "-f", WAITING).returncode == 0, (
+            "the hook left its wait state before LINE1 was checked — timing invariant broken"
+        )
         assert LINE1 in mid, (
-            f"the hook's first line {LINE1!r} is NOT in the GUI log while the hook is still "
-            f"running — its output is buffered until the hook exits instead of streaming to the "
-            f"pkg Software page. GUI log so far:\n{mid[-3000:]}"
+            f"the hook's first line {LINE1!r} did NOT reach the GUI log while the hook is still "
+            f"blocked — its output is buffered until the hook exits instead of streaming to the pkg "
+            f"Software page (streaming daemon pidfile seen mid-hook: {pid_seen}). GUI log so far:\n{mid[-3000:]}"
         )
         assert LINE2 not in mid, (
             f"{LINE2!r} appeared before the hook was released — the block-on-signal setup is "

--- a/tests/smoke/test_hook_stream_visibility.py
+++ b/tests/smoke/test_hook_stream_visibility.py
@@ -85,6 +85,21 @@ def _wait_for_guest_file(vm: SmokeVM, path: str, *, deadline_s: float, poll_s: f
     return False
 
 
+def _wait_upgrade_gone(vm: SmokeVM, *, deadline_s: float, poll_s: float = 2.0) -> bool:
+    """Poll (bounded) until no pfSense-upgrade process remains. Returns True iff it drained.
+
+    The test launches pfSense-upgrade DETACHED, so the wrapping pkg transaction (and its pkg
+    lock) outlives the hook itself. Wait for it to exit before touching the package again; a
+    bounded wait, never open-ended (pgrep rc 1 = none left).
+    """
+    end = time.monotonic() + deadline_s
+    while time.monotonic() < end:
+        if vm.ssh("/bin/sh", "-c", "pgrep -f pfSense-upgrade >/dev/null").returncode != 0:
+            return True
+        time.sleep(poll_s)
+    return False
+
+
 @pytest.mark.timeout(1200)
 def test_hook_output_streams_to_gui_while_running(repo_vm: SmokeVM) -> None:
     """A hook's stdout is visible in the GUI log WHILE the hook is still running.
@@ -142,11 +157,9 @@ def test_hook_output_streams_to_gui_while_running(repo_vm: SmokeVM) -> None:
         # only appears AFTER it exits (block-behaviour) never shows LINE1 here — the hook cannot
         # exit until PROCEED, which is created only after this loop.
         mid = ""
-        pid_seen = False
         end = time.monotonic() + 20.0
         while time.monotonic() < end:
             mid = vm.ssh("cat", GUI_LOG).stdout
-            pid_seen = pid_seen or vm.ssh("/bin/sh", "-c", "ls /var/run/pfb_hook_*.pid 2>/dev/null").returncode == 0
             if LINE1 in mid:
                 break
             time.sleep(1.0)
@@ -156,7 +169,7 @@ def test_hook_output_streams_to_gui_while_running(repo_vm: SmokeVM) -> None:
         assert LINE1 in mid, (
             f"the hook's first line {LINE1!r} did NOT reach the GUI log while the hook is still "
             f"blocked — its output is buffered until the hook exits instead of streaming to the pkg "
-            f"Software page (streaming daemon pidfile seen mid-hook: {pid_seen}). GUI log so far:\n{mid[-3000:]}"
+            f"Software page. GUI log so far:\n{mid[-3000:]}"
         )
         assert LINE2 not in mid, (
             f"{LINE2!r} appeared before the hook was released — the block-on-signal setup is "
@@ -181,8 +194,14 @@ def test_hook_output_streams_to_gui_while_running(repo_vm: SmokeVM) -> None:
             f"after releasing the hook, the GUI log is missing a line (LINE1={LINE1 in final}, "
             f"LINE2={LINE2 in final}):\n{final[-3000:]}"
         )
+
+        # LINE2 means the HOOK finished, but the wrapping detached pfSense-upgrade keeps its pkg
+        # lock through the rest of the resync. Drain it before cleanup so pkg_delete() below (in
+        # finally) doesn't race the still-held lock.
+        _wait_upgrade_gone(vm, deadline_s=120.0)
     finally:
         vm.ssh("/usr/bin/touch", PROCEED)  # never leave a blocked hook behind
+        _wait_upgrade_gone(vm, deadline_s=60.0)  # let a failed-path run release its pkg lock too
         h.clear_update_hooks(vm)
         vm.ssh("/bin/rm", "-f", GUI_LOG, WAITING, PROCEED)
         pkg_delete(vm)


### PR DESCRIPTION
## Summary

During a pkg install/upgrade/uninstall, an ADR-12 hook's own stdout now **streams to the pkg Software page as the hook runs**, instead of appearing as one block only after it exits. Previously `pfb_run_hooks()` ran the hook to completion under a blocking `exec()` (output redirected to a file so a daemon it spawns can't hang the pass, #662) and only then mirrored the whole delta (`pfb_mirror_hook_output`, #693) — so a slow hook (e.g. a 30s HAProxy reload printing progress) showed **blank** on the page the whole time, then dumped everything at the end.

The lifecycle path now uses `proc_open()`: the hook runs as a **direct child** with stdout/stderr pointed at the log **file** via the descriptor spec (never a pipe back to PHP — a daemon inheriting fd 1 still can't hang us, same #662 safety, it just holds a harmless file fd), PHP tracks it with `proc_get_status()`, tails the file to stdout while it runs, and reads the exit code (124 on timeout / else the hook's own) straight off the status. No `daemon`/pidfile/rcfile apparatus. The **non-lifecycle** cron/manual/Run-Now path is byte-identical to before (the Update page's own AJAX tail already streams the run-log). The `timeout --foreground` SIGTERM/SIGKILL semantics and the 124/non-zero/0 logging are unchanged.

## Tests

- **New `tests/smoke/test_hook_stream_visibility.py`** (`repo`, red→green): a hook prints LINE1, blocks on a test-controlled signal file, then prints LINE2; it asserts LINE1 is in the GUI-tailed log **while the hook is still blocked**. Proven RED against the old block-behaviour ([28773030534](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28773030534) — the resync progress + the hook *header* streamed live but not the hook *body*), GREEN with this fix ([28774290296](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28774290296)).
- **No regression:** `test_lifecycle_hook_visibility` (POST_INSTALL/PRE_UNINSTALL firing, GUI visibility, teardown) re-run alongside — both files green ([28774455140](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28774455140)).
- `php -l`, PHPStan, PHPCS clean; PHPUnit hook suites 38/38 green.

## Follow-up (not this PR)

A broader ADR is planned to unify the whole output model — everything to stdout/stderr → one run-log → one tail — which would delete the #690/#693 mirrors and the `hook_lifecycle` branching entirely and make every surface (Update page + pkg GUI Upgrade) show the identical stream, keeping detached dispatch only for the async Run-Now that must outlive its web request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ooLjvBBm6oznTBUg9mxVF