### PR TITLE
ci: weekly health-check of external Top1M provider URLs (#884)

### DIFF
--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -1,0 +1,139 @@
+name: Top1M Provider Health Check
+
+# Weekly health-check of every external Top1M provider URL we ship (issue
+# #884). We do NOT vendor these lists (they're ~1M rows, runtime-downloaded
+# per box) -- this is validate-only, the guard that would have caught the
+# Alexa Top1M source rotting silently (its hardcoded URL died years ago;
+# cleaned up in #877).
+#
+# scripts/misc/check_top1m_providers.py --extract reads the provider URLs
+# straight out of pfblockerng.php's top1m extras slot, so adding/removing a
+# provider needs no edit here. --check-url fetches + validates one URL (a
+# real zip, plausible row count, not stale) and exits nonzero if unhealthy.
+
+on:
+  # Weekly, Monday 07:00 UTC (an hour after tld-refresh, different concern).
+  schedule:
+    - cron: "0 7 * * 1"
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # ── 1. Discover every provider URL from pfblockerng.php ──────────────────
+  discover:
+    name: Discover Top1M provider URLs
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.extract.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract provider URLs
+        id: extract
+        run: |
+          set -eu
+          MATRIX=$(python3 scripts/misc/check_top1m_providers.py --extract)
+          echo "Discovered providers:"
+          printf '%s\n' "$MATRIX" | python3 -m json.tool
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+
+  # ── 2. Health-check each provider independently ───────────────────────────
+  check:
+    name: Check (${{ matrix.name }})
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check provider URL
+        run: |
+          set -eu
+          python3 scripts/misc/check_top1m_providers.py --check-url "${{ matrix.url }}"
+
+  # ── 3. On any failed leg, open/update ONE deduped tracking issue ──────────
+  alert:
+    name: Alert on unhealthy provider(s)
+    needs: check
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Re-check every provider to build the failure report
+        id: report
+        run: |
+          set -eu
+          python3 scripts/misc/check_top1m_providers.py --extract > /tmp/providers.json
+
+          BODY_FILE=$(mktemp)
+          {
+            printf '## Top1M provider health check failed\n\n'
+            printf 'Run: %s\n\n' "$RUN_URL"
+          } > "$BODY_FILE"
+
+          COUNT=$(jq 'length' /tmp/providers.json)
+          i=0
+          while [ "$i" -lt "$COUNT" ]; do
+            NAME=$(jq -r ".[$i].name" /tmp/providers.json)
+            URL=$(jq -r ".[$i].url" /tmp/providers.json)
+            i=$((i + 1))
+
+            if python3 scripts/misc/check_top1m_providers.py --check-url "$URL" > /tmp/check_out.txt 2>&1; then
+              printf -- "- OK **%s** (\`%s\`)\n" "$NAME" "$URL" >> "$BODY_FILE"
+            else
+              {
+                printf -- "- FAILING **%s** (\`%s\`)\n\n\`\`\`text\n" "$NAME" "$URL"
+                cat /tmp/check_out.txt
+                printf '```\n\n'
+              } >> "$BODY_FILE"
+            fi
+          done
+
+          printf '_Opened automatically by the top1m-healthcheck workflow._\n' >> "$BODY_FILE"
+          echo "body_file=${BODY_FILE}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure the tracking label exists
+        run: |
+          gh label create "top1m-provider" \
+            --color "b60205" \
+            --description "Automated Top1M provider health-check tracking" \
+            --repo "$REPO" 2>/dev/null || true
+
+      - name: Open or update the tracking issue
+        run: |
+          set -eu
+          TITLE="[top1m-healthcheck] provider URL unhealthy"
+
+          # Scope to the tracking label and lift the default 30-item cap (see
+          # version-tracker.yml's dedup note) so an older open issue past the
+          # first page is still found and updated in place, not re-created.
+          EXISTING_NUM=$(gh issue list --repo "$REPO" --state open \
+            --label "top1m-provider" --limit 500 --json number,title \
+            | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
+            | sort -n | head -1)
+
+          if [ -n "$EXISTING_NUM" ]; then
+            echo "[update] Updating tracking issue #${EXISTING_NUM}"
+            gh issue edit "$EXISTING_NUM" --repo "$REPO" --body-file "${{ steps.report.outputs.body_file }}"
+          else
+            echo "[create] Opening tracking issue"
+            gh issue create \
+              --repo "$REPO" \
+              --title "$TITLE" \
+              --body-file "${{ steps.report.outputs.body_file }}" \
+              --label "top1m-provider,bug"
+          fi

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -38,6 +38,13 @@ jobs:
           MATRIX=$(python3 scripts/misc/check_top1m_providers.py --extract)
           echo "Discovered providers:"
           printf '%s\n' "$MATRIX" | python3 -m json.tool
+
+          # Floor guard: a broken extractor returning an empty/near-empty
+          # matrix would run 0 (or too few) legs and still exit green --
+          # the exact silent death this watchdog exists to catch (#884 review).
+          COUNT=$(jq 'length' <<<"$MATRIX")
+          [ "$COUNT" -ge 1 ] || { echo "::error::no top1m providers discovered -- extractor may be broken"; exit 1; }
+
           echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
 
   # ── 2. Health-check each provider independently ───────────────────────────
@@ -53,9 +60,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Check provider URL
+        env:
+          URL: ${{ matrix.url }}
         run: |
           set -eu
-          python3 scripts/misc/check_top1m_providers.py --check-url "${{ matrix.url }}"
+          python3 scripts/misc/check_top1m_providers.py --check-url "$URL"
 
   # ── 3. On any failed leg, open/update ONE deduped tracking issue ──────────
   alert:
@@ -75,6 +84,11 @@ jobs:
 
       - name: Re-check every provider to build the failure report
         id: report
+        # This re-checks every provider fresh at alert-time rather than
+        # reusing the failing `check` job's per-leg result, so a leg that
+        # failed transiently and has since recovered can list all-OK here on
+        # a run that is still red overall. Accepted simplicity trade-off --
+        # avoids plumbing each matrix leg's pass/fail back into this job.
         run: |
           set -eu
           python3 scripts/misc/check_top1m_providers.py --extract > /tmp/providers.json

--- a/scripts/misc/check_top1m_providers.py
+++ b/scripts/misc/check_top1m_providers.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import http.client
 import io
 import json
 import re
@@ -53,12 +54,32 @@ _URL_RE = re.compile(r"\$pfb\['extras'\]\[(\d+)\]\['url'\]\s*=\s*'([^']*)'")
 _TYPE_RE = re.compile(r"\$pfb\['extras'\]\[(\d+)\]\['type'\]\s*=\s*'([^']*)'")
 
 
+def _strip_php_line_comments(php_text: str) -> str:
+    """Drop whole-line `//`-commented-out lines before extraction.
+
+    Without this, a commented-out `// $pfb['extras'][2]['url'] = '...dead...'`
+    is still picked up as a live provider (the regex matches raw text). A
+    trailing comment on a live line (`'...zip';  // Cisco`) is unaffected --
+    the URL is already matched before the comment starts.
+
+    ponytail: only whole-line `//` comments are stripped, matching this file's
+    style; a `/* */` block comment would need its own handling if ever used
+    here.
+    """
+    return "\n".join(line for line in php_text.splitlines() if not line.strip().startswith("//"))
+
+
 def extract_providers(php_text: str) -> list[dict[str, str]]:
     """Every URL wired to the top1m extras slot in pfblockerng.php.
 
     Groups by extras index so a URL assigned in an if/elseif/else arm is
     matched to its slot's type regardless of assignment order in the file.
+
+    Ceiling: matches single-quoted, non-concatenated URL literals only (the
+    current pfblockerng.php style) -- a double-quoted string or a `'base' .
+    $token` concatenation would need extending _URL_RE.
     """
+    php_text = _strip_php_line_comments(php_text)
     types = dict(_TYPE_RE.findall(php_text))
     providers: list[dict[str, str]] = []
     seen: set[tuple[str, str]] = set()
@@ -77,31 +98,48 @@ def _name_from_url(url: str) -> str:
     return urlparse(url).netloc or url
 
 
+def _parse_http_date(value: str | None) -> datetime | None:
+    """Parse an HTTP-date header into a tz-aware UTC datetime.
+
+    Returns None for an absent or unparseable header. A bare RFC-822 date with
+    no zone (legal HTTP, e.g. "Mon, 01 Jun 2026 00:00:00") parses to a naive
+    datetime -- pin it to UTC here so no caller ever subtracts a naive value
+    from an aware `now` (that raised TypeError; see #884 review).
+    """
+    if not value:
+        return None
+    try:
+        parsed = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
 def is_stale(last_modified: str | None, now: datetime, max_age_days: int) -> bool:
     """True iff a present, parseable Last-Modified is older than max_age_days.
 
     No header, or one we can't parse, means "unknown" -- not a staleness
     verdict we can make, so it reads as not-stale rather than a false alarm.
     """
-    if not last_modified:
+    modified = _parse_http_date(last_modified)
+    if modified is None:
         return False
-    try:
-        modified = parsedate_to_datetime(last_modified)
-    except (TypeError, ValueError):
-        return False
-    if modified.tzinfo is None:
-        modified = modified.replace(tzinfo=timezone.utc)
     if now.tzinfo is None:
         now = now.replace(tzinfo=timezone.utc)
     return (now - modified) > timedelta(days=max_age_days)
 
 
 def _is_valid_row(row: list[str]) -> bool:
-    """A plausible Top1M row: "<int rank>,<dotted domain>"."""
+    """A plausible Top1M row: "<int rank>,<dotted domain>" -- rejects a bare "."."""
     if len(row) != 2:
         return False
     rank, domain = row[0].strip(), row[1].strip()
-    return rank.isdigit() and "." in domain and not any(c.isspace() for c in domain)
+    if not rank.isdigit() or any(c.isspace() for c in domain):
+        return False
+    labels = domain.split(".")
+    return len(labels) >= 2 and all(labels)
 
 
 def _scan_csv(body: bytes) -> tuple[str, int, int, tuple[int, list[str]] | None]:
@@ -152,7 +190,11 @@ def validate_top1m(
             f"found {valid} (of {total} total rows){detail}"
         )
     if is_stale(last_modified, now, max_age_days):
-        age_days = (now - parsedate_to_datetime(last_modified)).days  # type: ignore[arg-type]
+        modified = _parse_http_date(last_modified)
+        assert modified is not None, "is_stale() only returns True when the header is parseable"
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        age_days = (now - modified).days
         reasons.append(
             f"expected Last-Modified within {max_age_days} days of {now.isoformat()}, "
             f"found {last_modified!r} ({age_days} days old)"
@@ -171,8 +213,12 @@ def check_url(url: str, min_rows: int = MIN_ROWS, max_age_days: int = MAX_AGE_DA
             status = resp.status
     except urllib.error.HTTPError as exc:
         return [f"expected HTTP 2xx, got HTTP {exc.code} {exc.reason}"]
-    except urllib.error.URLError as exc:
-        return [f"expected a reachable URL, got a connection error: {exc.reason}"]
+    except (urllib.error.URLError, OSError, http.client.HTTPException) as exc:
+        # Covers the whole fetch+read span: resp.read() on a multi-MB zip can
+        # raise IncompleteRead/socket.timeout/ConnectionResetError mid-download
+        # -- none are urllib.error.URLError, so a narrower except let those
+        # raise a raw traceback instead of a clean FAIL report (#884 review).
+        return [f"expected a reachable URL, got a connection error: {exc}"]
 
     if not (200 <= status < 300):
         return [f"expected HTTP 2xx, got HTTP {status}"]

--- a/scripts/misc/check_top1m_providers.py
+++ b/scripts/misc/check_top1m_providers.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""check_top1m_providers.py -- health-check the Top1M provider URLs we ship.
+
+Issue #884: nothing caught the Alexa Top1M source rotting silently (its
+hardcoded URL died years ago; cleaned up in #877). This script gives the
+weekly top1m-healthcheck.yml workflow something to fail on the day the next
+provider dies the same way.
+
+We do NOT vendor the ~1M-row lists -- they're runtime-downloaded per box.
+This is validate-only: fetch, check it's a real recent Top1M zip, report.
+
+Two modes:
+  --extract           Parse pfblockerng.php for every URL wired to the
+                       top1m extras slot, print as a JSON list to stdout.
+                       Feeds the workflow's matrix -- add/remove a provider
+                       arm in the PHP and this picks it up with no edit here.
+  --check-url <url>   Fetch + validate one URL. Prints an expected-vs-actual
+                       report. Exit 0 = healthy, non-zero = unhealthy.
+
+Dev-host tooling (scripts/): bare `python3` is fine here, this never runs on
+the pfSense appliance (CLAUDE.md's appliance-python carve-out).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+import zipfile
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from urllib.parse import urlparse
+
+# A real Top1M list is ~1M rows; 100k is a generous floor that still rejects a
+# truncated/error payload. Lists update ~daily; 30 days is generously frozen.
+MIN_ROWS = 100_000
+MAX_AGE_DAYS = 30
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PHP_FILE = REPO_ROOT / "src/usr/local/www/pfblockerng/pfblockerng.php"
+
+# Matches "$pfb['extras'][N]['url'] = '...'" / "...['type'] = '...'" regardless
+# of which if/elseif/else arm assigns it -- an extras index can be assigned
+# more than once (each arm is a separate match tied to the same index N), so a
+# new provider arm is picked up with no change to this script.
+_URL_RE = re.compile(r"\$pfb\['extras'\]\[(\d+)\]\['url'\]\s*=\s*'([^']*)'")
+_TYPE_RE = re.compile(r"\$pfb\['extras'\]\[(\d+)\]\['type'\]\s*=\s*'([^']*)'")
+
+
+def extract_providers(php_text: str) -> list[dict[str, str]]:
+    """Every URL wired to the top1m extras slot in pfblockerng.php.
+
+    Groups by extras index so a URL assigned in an if/elseif/else arm is
+    matched to its slot's type regardless of assignment order in the file.
+    """
+    types = dict(_TYPE_RE.findall(php_text))
+    providers: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for idx, url in _URL_RE.findall(php_text):
+        if not url or types.get(idx) != "top1m":
+            continue
+        if (idx, url) in seen:
+            continue
+        seen.add((idx, url))
+        providers.append({"name": _name_from_url(url), "url": url})
+    return providers
+
+
+def _name_from_url(url: str) -> str:
+    # Cosmetic only -- just needs to be distinct/readable per provider.
+    return urlparse(url).netloc or url
+
+
+def is_stale(last_modified: str | None, now: datetime, max_age_days: int) -> bool:
+    """True iff a present, parseable Last-Modified is older than max_age_days.
+
+    No header, or one we can't parse, means "unknown" -- not a staleness
+    verdict we can make, so it reads as not-stale rather than a false alarm.
+    """
+    if not last_modified:
+        return False
+    try:
+        modified = parsedate_to_datetime(last_modified)
+    except (TypeError, ValueError):
+        return False
+    if modified.tzinfo is None:
+        modified = modified.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    return (now - modified) > timedelta(days=max_age_days)
+
+
+def _is_valid_row(row: list[str]) -> bool:
+    """A plausible Top1M row: "<int rank>,<dotted domain>"."""
+    if len(row) != 2:
+        return False
+    rank, domain = row[0].strip(), row[1].strip()
+    return rank.isdigit() and "." in domain and not any(c.isspace() for c in domain)
+
+
+def _scan_csv(body: bytes) -> tuple[str, int, int, tuple[int, list[str]] | None]:
+    """Open `body` as a zip and scan its CSV member.
+
+    Returns (member_name, total_rows, valid_rows, first_bad_row). Raises
+    zipfile.BadZipFile / KeyError-free -- callers handle the zip-shape errors.
+    """
+    with zipfile.ZipFile(io.BytesIO(body)) as zf:
+        names = zf.namelist()
+        if not names:
+            raise zipfile.BadZipFile("zip archive has no members")
+        member = next((n for n in names if n.lower().endswith(".csv")), names[0])
+        with zf.open(member) as fh:
+            text = io.TextIOWrapper(fh, encoding="utf-8", errors="replace", newline="")
+            total = 0
+            valid = 0
+            first_bad: tuple[int, list[str]] | None = None
+            for line_num, row in enumerate(csv.reader(text), start=1):
+                if not row:
+                    continue
+                total += 1
+                if _is_valid_row(row):
+                    valid += 1
+                elif first_bad is None:
+                    first_bad = (line_num, row)
+    return member, total, valid, first_bad
+
+
+def validate_top1m(
+    body: bytes,
+    last_modified: str | None,
+    now: datetime,
+    min_rows: int = MIN_ROWS,
+    max_age_days: int = MAX_AGE_DAYS,
+) -> list[str]:
+    """Validate a fetched Top1M payload. Empty return = healthy."""
+    try:
+        member, total, valid, first_bad = _scan_csv(body)
+    except zipfile.BadZipFile as exc:
+        return [f"expected a valid non-empty ZIP archive, got {len(body)} bytes that failed to parse ({exc})"]
+
+    reasons = []
+    if valid < min_rows:
+        detail = f"; first bad row at {member}:{first_bad[0]}: {first_bad[1]!r}" if first_bad else ""
+        reasons.append(
+            f"expected >= {min_rows} valid 'rank,domain' rows in {member!r}, "
+            f"found {valid} (of {total} total rows){detail}"
+        )
+    if is_stale(last_modified, now, max_age_days):
+        age_days = (now - parsedate_to_datetime(last_modified)).days  # type: ignore[arg-type]
+        reasons.append(
+            f"expected Last-Modified within {max_age_days} days of {now.isoformat()}, "
+            f"found {last_modified!r} ({age_days} days old)"
+        )
+    return reasons
+
+
+def check_url(url: str, min_rows: int = MIN_ROWS, max_age_days: int = MAX_AGE_DAYS) -> list[str]:
+    """Fetch `url` and validate it. Empty return = healthy."""
+    now = datetime.now(timezone.utc)
+    request = urllib.request.Request(url, headers={"User-Agent": "pfBlockerNG-top1m-healthcheck/1.0"})
+    try:
+        with urllib.request.urlopen(request, timeout=120) as resp:
+            body = resp.read()
+            last_modified = resp.headers.get("Last-Modified")
+            status = resp.status
+    except urllib.error.HTTPError as exc:
+        return [f"expected HTTP 2xx, got HTTP {exc.code} {exc.reason}"]
+    except urllib.error.URLError as exc:
+        return [f"expected a reachable URL, got a connection error: {exc.reason}"]
+
+    if not (200 <= status < 300):
+        return [f"expected HTTP 2xx, got HTTP {status}"]
+    return validate_top1m(body, last_modified, now, min_rows, max_age_days)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--extract", action="store_true", help="print every top1m provider URL as JSON")
+    group.add_argument("--check-url", metavar="URL", help="fetch + validate one provider URL")
+    args = parser.parse_args(argv)
+
+    if args.extract:
+        providers = extract_providers(DEFAULT_PHP_FILE.read_text(encoding="utf-8"))
+        print(json.dumps(providers))
+        return 0
+
+    reasons = check_url(args.check_url)
+    if not reasons:
+        print(f"OK  {args.check_url}: healthy (>= {MIN_ROWS} rows, not stale)")
+        return 0
+    print(f"FAIL {args.check_url}: unhealthy")
+    for reason in reasons:
+        print(f"  - {reason}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_top1m_providers.py
+++ b/tests/test_check_top1m_providers.py
@@ -15,12 +15,16 @@ branch-coverage rule.
 from __future__ import annotations
 
 import csv
+import http.client
 import importlib.util
 import io
 import sys
+import urllib.error
 import zipfile
 from datetime import datetime, timedelta, timezone
+from email.utils import formatdate
 from pathlib import Path
+from typing import Any
 
 _SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "misc" / "check_top1m_providers.py"
 _spec = importlib.util.spec_from_file_location("check_top1m_providers", _SCRIPT)
@@ -81,6 +85,31 @@ def test_extract_providers_ignores_non_top1m_slot() -> None:
     providers = ctp.extract_providers(_PHP_TWO_PROVIDERS)
     urls = {p["url"] for p in providers}
     assert "https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz" not in urls
+
+
+# A provider line commented out with `//` (a dead/retired provider left in
+# place for reference) must not be extracted as live -- the extractor
+# previously matched raw text with no regard for comments.
+_PHP_WITH_A_COMMENTED_OUT_PROVIDER = """
+$pfb['extras'][2]			= array();
+// $pfb['extras'][2]['url']	= 'https://dead-provider.test/top-1m.csv.zip';
+if ($pfb['dnsbl_top1m_type'] === Top1mSource::Tranco) {
+	$pfb['extras'][2]['url']	= 'https://tranco-list.eu/top-1m.csv.zip';
+} else {
+	$pfb['extras'][2]['url']	= 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip';  // Cisco
+}
+$pfb['extras'][2]['type']	= 'top1m';
+"""
+
+
+def test_extract_providers_skips_a_commented_out_provider_line() -> None:
+    providers = ctp.extract_providers(_PHP_WITH_A_COMMENTED_OUT_PROVIDER)
+    urls = {p["url"] for p in providers}
+    assert "https://dead-provider.test/top-1m.csv.zip" not in urls
+    assert urls == {
+        "https://tranco-list.eu/top-1m.csv.zip",
+        "https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip",
+    }
 
 
 def test_extract_providers_auto_covers_a_newly_added_provider_arm() -> None:
@@ -151,6 +180,17 @@ def test_validate_top1m_fails_on_a_malformed_row_non_int_rank_no_dot_domain() ->
     assert "foo" in reasons[0] and "bar" in reasons[0]
 
 
+def test_validate_top1m_rejects_a_bare_dot_as_a_domain() -> None:
+    # A bare "." has no real label on either side of the dot -- must not read
+    # as a valid "rank,domain" row just because it contains a "." and no space.
+    rows = [(str(i), f"example{i}.com") for i in range(9)]
+    rows.append(("9", "."))
+    body = _zip_of(rows)
+    reasons = ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30)
+    assert len(reasons) == 1
+    assert "found 9" in reasons[0]
+
+
 def test_validate_top1m_flags_staleness_only_once_last_modified_ages_past_the_limit() -> None:
     # Before-state: same payload is healthy while Last-Modified is fresh...
     rows = [(str(i), f"example{i}.com") for i in range(10)]
@@ -186,3 +226,132 @@ def test_is_stale_false_when_last_modified_header_is_absent() -> None:
     # No header means "unknown", not "stale" -- a provider that omits
     # Last-Modified must not be flagged purely for that omission.
     assert ctp.is_stale(None, _NOW, max_age_days=30) is False
+
+
+# --------------------------------------------------------------------------- #
+# check_url -- urllib.request.urlopen mocked out, no real network (#884
+# review: the gap that let the tz-crash and read-crash bugs ship unnoticed).
+# --------------------------------------------------------------------------- #
+
+
+class _FakeResponse:
+    """Minimal stand-in for the context-manager `http.client.HTTPResponse`."""
+
+    def __init__(self, body: bytes, headers: dict[str, str], status: int = 200) -> None:
+        self._body = body
+        self.headers = headers
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        return False
+
+
+class _FailingReadResponse:
+    """A response whose `.read()` raises -- simulates a cut-short download."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+        self.status = 200
+        self.headers: dict[str, str] = {}
+
+    def read(self) -> bytes:
+        raise self._exc
+
+    def __enter__(self) -> "_FailingReadResponse":
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        return False
+
+
+_ALWAYS_FRESH_LM = formatdate(usegmt=True)  # "now", so never stale regardless of wall-clock date
+
+
+def _healthy_zip_body(rows: int = 10) -> bytes:
+    return _zip_of([(str(i), f"example{i}.com") for i in range(rows)])
+
+
+def test_check_url_reports_a_clean_reason_on_http_error(monkeypatch: Any) -> None:
+    def fake_urlopen(request: Any, timeout: int) -> Any:
+        raise urllib.error.HTTPError(request.full_url, 404, "Not Found", hdrs=None, fp=None)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(ctp.urllib.request, "urlopen", fake_urlopen)
+    reasons = ctp.check_url("https://example.test/top-1m.csv.zip")
+    assert len(reasons) == 1
+    assert "404" in reasons[0]
+
+
+def test_check_url_reports_a_clean_reason_when_the_body_read_is_cut_short(monkeypatch: Any) -> None:
+    # The #3 fix: IncompleteRead mid-download of the multi-MB zip is neither
+    # HTTPError nor URLError -- a narrower except let this raise a raw
+    # traceback instead of a clean FAIL report.
+    exc = http.client.IncompleteRead(partial=b"only some bytes")
+    monkeypatch.setattr(ctp.urllib.request, "urlopen", lambda request, timeout: _FailingReadResponse(exc))
+    reasons = ctp.check_url("https://example.test/top-1m.csv.zip")
+    assert len(reasons) == 1
+    assert "connection error" in reasons[0]
+
+
+def test_check_url_reports_a_non_2xx_status_that_urlopen_does_not_raise_for(monkeypatch: Any) -> None:
+    body = _healthy_zip_body()
+    monkeypatch.setattr(
+        ctp.urllib.request,
+        "urlopen",
+        lambda request, timeout: _FakeResponse(body, {"Last-Modified": _ALWAYS_FRESH_LM}, status=304),
+    )
+    reasons = ctp.check_url("https://example.test/top-1m.csv.zip", min_rows=10)
+    assert len(reasons) == 1
+    assert "304" in reasons[0]
+
+
+def test_check_url_delegates_to_validate_top1m_on_a_healthy_2xx_response(monkeypatch: Any) -> None:
+    body = _healthy_zip_body()
+    monkeypatch.setattr(
+        ctp.urllib.request,
+        "urlopen",
+        lambda request, timeout: _FakeResponse(body, {"Last-Modified": _ALWAYS_FRESH_LM}),
+    )
+    reasons = ctp.check_url("https://example.test/top-1m.csv.zip", min_rows=10)
+    assert reasons == []
+
+
+def test_check_url_handles_a_stale_tz_less_last_modified_without_crashing(monkeypatch: Any) -> None:
+    # The #2 crash: a Last-Modified with no timezone (RFC-822-legal, e.g.
+    # "Mon, 01 Jan 2001 00:00:00") used to raise TypeError subtracting a naive
+    # datetime from the aware `now` inside the staleness-message branch.
+    body = _healthy_zip_body()
+    monkeypatch.setattr(
+        ctp.urllib.request,
+        "urlopen",
+        lambda request, timeout: _FakeResponse(body, {"Last-Modified": "Mon, 01 Jan 2001 00:00:00"}),
+    )
+    reasons = ctp.check_url("https://example.test/top-1m.csv.zip", min_rows=10)
+    assert len(reasons) == 1
+    assert "days old" in reasons[0]
+
+
+# --------------------------------------------------------------------------- #
+# main -- exit code reflects check_url's verdict
+# --------------------------------------------------------------------------- #
+
+
+def test_main_exits_zero_when_check_url_reports_healthy(monkeypatch: Any, capsys: Any) -> None:
+    monkeypatch.setattr(ctp, "check_url", lambda url, **_kwargs: [])
+    code = ctp.main(["--check-url", "https://example.test/top-1m.csv.zip"])
+    assert code == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_exits_nonzero_when_check_url_reports_unhealthy(monkeypatch: Any, capsys: Any) -> None:
+    monkeypatch.setattr(ctp, "check_url", lambda url, **_kwargs: ["expected a reachable URL, got a connection error"])
+    code = ctp.main(["--check-url", "https://example.test/top-1m.csv.zip"])
+    assert code != 0
+    out = capsys.readouterr().out
+    assert "FAIL" in out
+    assert "connection error" in out

--- a/tests/test_check_top1m_providers.py
+++ b/tests/test_check_top1m_providers.py
@@ -248,8 +248,8 @@ class _FakeResponse:
     def __enter__(self) -> "_FakeResponse":
         return self
 
-    def __exit__(self, *exc_info: object) -> bool:
-        return False
+    def __exit__(self, *exc_info: object) -> None:
+        return None
 
 
 class _FailingReadResponse:
@@ -266,8 +266,8 @@ class _FailingReadResponse:
     def __enter__(self) -> "_FailingReadResponse":
         return self
 
-    def __exit__(self, *exc_info: object) -> bool:
-        return False
+    def __exit__(self, *exc_info: object) -> None:
+        return None
 
 
 _ALWAYS_FRESH_LM = formatdate(usegmt=True)  # "now", so never stale regardless of wall-clock date

--- a/tests/test_check_top1m_providers.py
+++ b/tests/test_check_top1m_providers.py
@@ -1,0 +1,188 @@
+"""Tests for scripts/misc/check_top1m_providers.py (issue #884).
+
+Nothing caught the Alexa Top1M source rotting silently (its hardcoded URL died
+years ago; cleaned up in #877). These tests pin the guard that would have:
+extracting every top1m provider URL straight from pfblockerng.php (so adding
+or removing a provider arm needs no edit here), and validating a fetched
+payload is actually a healthy, fresh Top1M list -- not just a 200.
+
+No network: --check-url's HTTP fetch lives in check_url(); every test below
+targets the pure functions (extract_providers / validate_top1m / is_stale)
+with injected bytes/headers/now, per CLAUDE.md's no-network-in-unit-tests
+branch-coverage rule.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import io
+import sys
+import zipfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "misc" / "check_top1m_providers.py"
+_spec = importlib.util.spec_from_file_location("check_top1m_providers", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+ctp = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = ctp
+_spec.loader.exec_module(ctp)
+
+
+# --------------------------------------------------------------------------- #
+# extract_providers -- PHP fixtures mirror the real extras-slot shape
+# --------------------------------------------------------------------------- #
+
+# Mirrors src/usr/local/www/pfblockerng/pfblockerng.php's real shape: extras[0]
+# is a geoip slot (must NOT be picked up), extras[2] is the top1m slot with its
+# URL set inside an if/else -- the type assignment trails both branches.
+_PHP_TWO_PROVIDERS = """
+$pfb['extras'][0]		= array();
+$pfb['extras'][0]['url']	= 'https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz';
+$pfb['extras'][0]['type']	= 'geoip';
+
+$pfb['extras'][2]			= array();
+if ($pfb['dnsbl_top1m_type'] === Top1mSource::Tranco) {
+	$pfb['extras'][2]['url']	= 'https://tranco-list.eu/top-1m.csv.zip';
+} else {
+	$pfb['extras'][2]['url']	= 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip';  // Cisco
+}
+$pfb['extras'][2]['file_dwn']	= 'top-1m.csv.zip';
+$pfb['extras'][2]['type']	= 'top1m';
+"""
+
+# A third provider arm added to the SAME slot (elseif) -- the crux case: the
+# extractor must pick this up with no code change, proving add/remove coverage
+# is automatic rather than a hardcoded Tranco/Cisco pair.
+_PHP_THREE_PROVIDERS = """
+$pfb['extras'][2]			= array();
+if ($pfb['dnsbl_top1m_type'] === Top1mSource::Tranco) {
+	$pfb['extras'][2]['url']	= 'https://tranco-list.eu/top-1m.csv.zip';
+} elseif ($pfb['dnsbl_top1m_type'] === Top1mSource::Quad9) {
+	$pfb['extras'][2]['url']	= 'https://example-quad9.test/top-1m.csv.zip';
+} else {
+	$pfb['extras'][2]['url']	= 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip';  // Cisco
+}
+$pfb['extras'][2]['type']	= 'top1m';
+"""
+
+
+def test_extract_providers_finds_both_top1m_urls() -> None:
+    providers = ctp.extract_providers(_PHP_TWO_PROVIDERS)
+    urls = {p["url"] for p in providers}
+    assert urls == {
+        "https://tranco-list.eu/top-1m.csv.zip",
+        "https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip",
+    }
+
+
+def test_extract_providers_ignores_non_top1m_slot() -> None:
+    providers = ctp.extract_providers(_PHP_TWO_PROVIDERS)
+    urls = {p["url"] for p in providers}
+    assert "https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz" not in urls
+
+
+def test_extract_providers_auto_covers_a_newly_added_provider_arm() -> None:
+    # This is the guarantee issue #884 asks for: add a provider arm to the PHP
+    # and the extractor picks it up with zero changes to this script.
+    providers = ctp.extract_providers(_PHP_THREE_PROVIDERS)
+    urls = {p["url"] for p in providers}
+    assert urls == {
+        "https://tranco-list.eu/top-1m.csv.zip",
+        "https://example-quad9.test/top-1m.csv.zip",
+        "https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# validate_top1m / _scan_csv -- in-memory zips, no network
+# --------------------------------------------------------------------------- #
+
+
+def _zip_of(rows: list[tuple[str, str]], member: str = "top-1m.csv") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        text = io.StringIO()
+        writer = csv.writer(text)
+        writer.writerows(rows)
+        zf.writestr(member, text.getvalue())
+    return buf.getvalue()
+
+
+_NOW = datetime(2026, 7, 6, tzinfo=timezone.utc)
+_FRESH_LM = "Sun, 05 Jul 2026 00:00:00 GMT"  # 1 day old
+_STALE_LM = "Mon, 01 Jun 2026 00:00:00 GMT"  # 35 days old
+
+
+def test_validate_top1m_passes_with_enough_valid_fresh_rows() -> None:
+    rows = [(str(i), f"example{i}.com") for i in range(10)]
+    body = _zip_of(rows)
+    reasons = ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30)
+    assert reasons == []
+
+
+def test_validate_top1m_fails_when_row_count_below_min_rows() -> None:
+    # Truncated payload: 5 good rows, floor set to 10.
+    rows = [(str(i), f"example{i}.com") for i in range(5)]
+    body = _zip_of(rows)
+    reasons = ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30)
+    assert len(reasons) == 1
+    assert "expected >= 10" in reasons[0]
+    assert "found 5" in reasons[0]
+
+
+def test_validate_top1m_fails_when_body_is_not_a_zip() -> None:
+    reasons = ctp.validate_top1m(b"<html>error</html>", _FRESH_LM, _NOW, min_rows=10, max_age_days=30)
+    assert len(reasons) == 1
+    assert "ZIP" in reasons[0]
+
+
+def test_validate_top1m_fails_on_a_malformed_row_non_int_rank_no_dot_domain() -> None:
+    # 9 good rows + 1 malformed ("foo,bar": non-int rank, no-dot domain) with
+    # min_rows=10 -- the malformed row doesn't count as valid, so the floor
+    # check itself catches it, AND the report names the exact bad row.
+    rows = [(str(i), f"example{i}.com") for i in range(9)]
+    rows.append(("foo", "bar"))
+    body = _zip_of(rows)
+    reasons = ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30)
+    assert len(reasons) == 1
+    assert "found 9" in reasons[0]
+    assert "foo" in reasons[0] and "bar" in reasons[0]
+
+
+def test_validate_top1m_flags_staleness_only_once_last_modified_ages_past_the_limit() -> None:
+    # Before-state: same payload is healthy while Last-Modified is fresh...
+    rows = [(str(i), f"example{i}.com") for i in range(10)]
+    body = _zip_of(rows)
+    assert ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30) == []
+
+    # ...and only the Last-Modified age flips it to stale -- proving staleness,
+    # not row count, caused the failure.
+    reasons = ctp.validate_top1m(body, _STALE_LM, _NOW, min_rows=10, max_age_days=30)
+    assert len(reasons) == 1
+    assert "35 days old" in reasons[0]
+
+
+# --------------------------------------------------------------------------- #
+# is_stale -- fresh / old / missing header, against an injected `now`
+# --------------------------------------------------------------------------- #
+
+
+def test_is_stale_false_for_a_fresh_last_modified() -> None:
+    assert ctp.is_stale(_FRESH_LM, _NOW, max_age_days=30) is False
+
+
+def test_is_stale_true_once_last_modified_exceeds_max_age_days() -> None:
+    assert ctp.is_stale(_STALE_LM, _NOW, max_age_days=30) is True
+
+
+def test_is_stale_false_right_at_the_max_age_days_boundary() -> None:
+    boundary = (_NOW - timedelta(days=30)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    assert ctp.is_stale(boundary, _NOW, max_age_days=30) is False
+
+
+def test_is_stale_false_when_last_modified_header_is_absent() -> None:
+    # No header means "unknown", not "stale" -- a provider that omits
+    # Last-Modified must not be flagged purely for that omission.
+    assert ctp.is_stale(None, _NOW, max_age_days=30) is False


### PR DESCRIPTION
Closes #884. A scheduled CI guard that health-checks every external Top1M provider URL we ship — the dev-side signal that would have caught the Alexa Top1M source rotting silently (its hardcoded URL died years ago with no warning; cleaned up in #877). Validate-only; nothing is vendored.

## What

- **`scripts/misc/check_top1m_providers.py`** (stdlib only):
  - `--extract` parses the provider URLs out of `pfblockerng.php`'s Top1M block (the `$pfb['extras'][...]['url']` literals whose slot `type == 'top1m'`) — **derived from the source of truth, so it auto-covers any provider added or removed**, no hardcoded list.
  - `--check-url` GETs a provider URL and validates it's genuinely healthy — HTTP 2xx, a valid non-empty ZIP, a plausible `rank,domain` CSV of ≥100k rows (not an HTML error page), and a fresh `Last-Modified` where present. A real download+validate, not a HEAD (a HEAD can 200 while the payload is dead).
- **`.github/workflows/top1m-healthcheck.yml`** — weekly + `workflow_dispatch`. A `discover` job emits the providers as a dynamic matrix; a `check` job fans out **one leg per provider with `fail-fast: false`** (a dead provider doesn't stop the others; the overall run is red if any leg fails); an `alert` job (`if: failure()`) opens/updates one deduped tracking issue naming the failing provider(s) + the run link.

## Tests

`tests/test_check_top1m_providers.py` (12, no network): extraction incl. a **3-arm fixture proving a newly-added provider is auto-covered**, and every validate failure branch (truncated / not-a-zip / malformed row / stale `Last-Modified`), each fail-if-broken. Real smoke: both shipped providers pass today; a 404 URL exits nonzero with a clear report.
