### PR TITLE
pfblockerng: preserve TOP1M whitelist + warn on failed/empty feed; fix stale help (#886)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8262,11 +8262,19 @@ function pfblockerng_top1m() {
 		$pfb_include = array_flip($pfb_include);
 	}
 
+	$whitelist_file	= "{$pfb['dbdir']}/pfbalexawhitelist.txt";
+	$had_previous	= file_exists($whitelist_file);
+
 	$linecnt = $x = 0;
 	pfb_logger(" Building TOP1M Whitelist [", 1);
 
 	if (($handle = @fopen("{$pfb['dbdir']}/top-1m.csv", 'r')) !== FALSE) {
-		$pfb_output = @fopen("{$pfb['dbdir']}/pfbalexawhitelist.txt", 'w');
+		// Build into a TEMP file first -- an empty/invalid top-1m.csv must never
+		// truncate a previously-good whitelist (issue #886); only a build that
+		// actually parsed source lines is swapped into place below.
+		$tmp_file	= "{$whitelist_file}.tmp";
+		unlink_if_exists($tmp_file);
+		$pfb_output	= @fopen($tmp_file, 'w');
 		while (($line = @fgets($handle)) !== FALSE) {
 
 			if (strpos($line, '.') === FALSE || strpos($line, ',') === FALSE || empty($line)) {
@@ -8298,18 +8306,35 @@ function pfblockerng_top1m() {
 			}
 			$linecnt++;
 		}
-		pfb_logger("] [ Parsed {$linecnt} lines | Found {$x} of {$pfb['dnsbl_top1m_cnt']} ]...", 1);
+		if ($pfb_output) {
+			@fclose($pfb_output);
+		}
+		@fclose($handle);
+
+		if ($linecnt === 0) {
+			// Dead feed (empty/invalid top-1m.csv) -- discard the temp build and
+			// keep whatever whitelist was already on disk instead of wiping it.
+			unlink_if_exists($tmp_file);
+			if ($had_previous) {
+				pfb_logger("\n  TOP1M: feed returned no valid data (empty/invalid) -- keeping the previous TOP1M whitelist.\n", 2);
+			}
+			else {
+				pfb_logger("\n  TOP1M: feed returned no valid data (empty/invalid) -- no TOP1M whitelist available.\n", 2);
+			}
+		}
+		else {
+			// Valid feed -- atomically swap the validated build into place.
+			@rename($tmp_file, $whitelist_file);
+			unlink_if_exists($tmp_file);	// no-op on success; cleans up if rename failed
+			pfb_logger("] [ Parsed {$linecnt} lines | Found {$x} of {$pfb['dnsbl_top1m_cnt']} ]...", 1);
+			if ($x === 0) {
+				pfb_logger("\n  TOP1M: 0 domains matched the configured TLD inclusions.\n", 1);
+			}
+		}
 	}
 	else {
 		$log = "\nTOP1M conversion Failed. File: top-1m.csv, not found...";
 		pfb_logger("{$log}", 2);
-	}
-
-	if ($handle) {
-		@fclose($handle);
-	}
-	if ($pfb_output) {
-		@fclose($pfb_output);
 	}
 
 	// Remove Top1M update file marker
@@ -15723,6 +15748,15 @@ function sync_package_pfblockerng($cron='') {
 						$log = "\n TOP1M Database downloading ( approx 21MB ) ... Please wait ...\n";
 						pfb_logger("{$log}", 1);
 						exec('/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php al');
+
+						// Download attempted above (blocking exec) -- top-1m.csv still
+						// missing means the fetch failed (404/timeout/invalid). Warn
+						// rather than silently keeping (or wiping) any prior whitelist
+						// (issue #886); pfblockerng_top1m() below is not invoked when a
+						// previous whitelist exists and no top-1m.update marker was set.
+						if (!file_exists("{$pfb['dbdir']}/top-1m.csv")) {
+							pfb_logger("\n  TOP1M: feed download failed -- keeping the previous TOP1M whitelist (if any).\n", 2);
+						}
 					}
 					else {
 						$log = "\n TOP1M download already in process...\n";

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8271,64 +8271,92 @@ function pfblockerng_top1m() {
 	if (($handle = @fopen("{$pfb['dbdir']}/top-1m.csv", 'r')) !== FALSE) {
 		// Build into a TEMP file first -- an empty/invalid top-1m.csv must never
 		// truncate a previously-good whitelist (issue #886); only a build that
-		// actually parsed source lines is swapped into place below.
-		$tmp_file	= "{$whitelist_file}.tmp";
-		unlink_if_exists($tmp_file);
-		$pfb_output	= @fopen($tmp_file, 'w');
-		while (($line = @fgets($handle)) !== FALSE) {
+		// actually parsed source lines is swapped into place below. tempnam()
+		// (not a fixed '.tmp' name) so a manual "Run Now" racing a cron tick can't
+		// collide on the same staging file (#886 review).
+		$tmp_file	= @tempnam(dirname($whitelist_file), '.pfbtop1m_');
+		$pfb_output	= ($tmp_file !== FALSE) ? @fopen($tmp_file, 'w') : FALSE;
 
-			if (strpos($line, '.') === FALSE || strpos($line, ',') === FALSE || empty($line)) {
-				continue;
+		if ($pfb_output === FALSE) {
+			// Could not stage the build at all (perms/full disk) -- never touch
+			// the existing whitelist; warn and move on (#886 review). Not
+			// deterministically unit-triggerable without an open_basedir-restricted
+			// child process (tempnam() falls back to the system temp dir for a
+			// merely-unwritable-but-existing dir) -- see the covered rename-failure
+			// branches (+ this gap's rationale) in
+			// tests/php/Top1mPreserveOnEmptyFeedTest.php.
+			if ($tmp_file !== FALSE) {
+				unlink_if_exists($tmp_file);
 			}
-
-			// Display progress indicator
-			if ($linecnt % 100000 == 0) {
-				pfb_logger('.', 1);
-			}
-
-			// Collect Domain TLD
-			$csvline	= str_getcsv($line, ',', '"', "\\");
-			$tld		= substr($csvline[1], strrpos($csvline[1], '.') + 1);
-
-			if (isset($pfb_include[$tld])) {
-				// Whitelist both 'www.example.com' and 'example.com'
-				if (str_starts_with($csvline[1], 'www.')) {
-					$csvline[1] = substr($csvline[1], 4);
-				}
-				$x++;
-
-				// Create three whitelist options per TOP1M whitelisted Domain
-				@fwrite($pfb_output, ".{$csvline[1]},,\n,{$csvline[1]},,\n,www.{$csvline[1]},,\n");
-			}
-
-			if ($x >= $pfb['dnsbl_top1m_cnt']) {
-				break;
-			}
-			$linecnt++;
-		}
-		if ($pfb_output) {
-			@fclose($pfb_output);
-		}
-		@fclose($handle);
-
-		if ($linecnt === 0) {
-			// Dead feed (empty/invalid top-1m.csv) -- discard the temp build and
-			// keep whatever whitelist was already on disk instead of wiping it.
-			unlink_if_exists($tmp_file);
-			if ($had_previous) {
-				pfb_logger("\n  TOP1M: feed returned no valid data (empty/invalid) -- keeping the previous TOP1M whitelist.\n", 2);
-			}
-			else {
-				pfb_logger("\n  TOP1M: feed returned no valid data (empty/invalid) -- no TOP1M whitelist available.\n", 2);
-			}
+			@fclose($handle);
+			pfb_logger("\n  TOP1M: could not create the temp whitelist file -- keeping the previous TOP1M whitelist.\n", 2);
 		}
 		else {
-			// Valid feed -- atomically swap the validated build into place.
-			@rename($tmp_file, $whitelist_file);
-			unlink_if_exists($tmp_file);	// no-op on success; cleans up if rename failed
-			pfb_logger("] [ Parsed {$linecnt} lines | Found {$x} of {$pfb['dnsbl_top1m_cnt']} ]...", 1);
-			if ($x === 0) {
-				pfb_logger("\n  TOP1M: 0 domains matched the configured TLD inclusions.\n", 1);
+			while (($line = @fgets($handle)) !== FALSE) {
+
+				if (strpos($line, '.') === FALSE || strpos($line, ',') === FALSE || empty($line)) {
+					continue;
+				}
+
+				// Display progress indicator
+				if ($linecnt % 100000 == 0) {
+					pfb_logger('.', 1);
+				}
+
+				// Collect Domain TLD -- only a row whose rank column is numeric counts as
+				// real parsed source data. A prose/HTML/error body (e.g. "error, service
+				// temporarily unavailable.") still has a '.' and a ',' and would otherwise
+				// pass the filter above, so a dead feed would classify as "valid" below
+				// and wipe the whitelist (#886 review).
+				$csvline = str_getcsv($line, ',', '"', "\\");
+				if (!ctype_digit((string) ($csvline[0] ?? ''))) {
+					continue;
+				}
+				$tld = substr($csvline[1], strrpos($csvline[1], '.') + 1);
+
+				if (isset($pfb_include[$tld])) {
+					// Whitelist both 'www.example.com' and 'example.com'
+					if (str_starts_with($csvline[1], 'www.')) {
+						$csvline[1] = substr($csvline[1], 4);
+					}
+					$x++;
+
+					// Create three whitelist options per TOP1M whitelisted Domain
+					@fwrite($pfb_output, ".{$csvline[1]},,\n,{$csvline[1]},,\n,www.{$csvline[1]},,\n");
+				}
+
+				if ($x >= $pfb['dnsbl_top1m_cnt']) {
+					break;
+				}
+				$linecnt++;
+			}
+			@fclose($pfb_output);
+			@fclose($handle);
+
+			if ($linecnt === 0) {
+				// Dead feed (empty/invalid top-1m.csv) -- discard the temp build and
+				// keep whatever whitelist was already on disk instead of wiping it.
+				unlink_if_exists($tmp_file);
+				if ($had_previous) {
+					pfb_logger("\n  TOP1M: feed returned no valid data (empty/invalid) -- keeping the previous TOP1M whitelist.\n", 2);
+				}
+				else {
+					pfb_logger("\n  TOP1M: feed returned no valid data (empty/invalid) -- no TOP1M whitelist available.\n", 2);
+				}
+			}
+			else if (@rename($tmp_file, $whitelist_file)) {
+				// Valid feed -- atomically swap the validated build into place.
+				pfb_logger("] [ Parsed {$linecnt} lines | Found {$x} of {$pfb['dnsbl_top1m_cnt']} ]...", 1);
+				if ($x === 0) {
+					pfb_logger("\n  TOP1M: 0 domains matched the configured TLD inclusions.\n", 1);
+				}
+			}
+			else {
+				// The parse looked valid but publishing it did not (perms/cross-device/
+				// disk) -- never report success while silently keeping a stale whitelist
+				// (#886 review).
+				unlink_if_exists($tmp_file);
+				pfb_logger("\n  TOP1M: failed to publish the new whitelist build -- keeping the previous TOP1M whitelist.\n", 2);
 			}
 		}
 	}
@@ -15754,6 +15782,9 @@ function sync_package_pfblockerng($cron='') {
 						// rather than silently keeping (or wiping) any prior whitelist
 						// (issue #886); pfblockerng_top1m() below is not invoked when a
 						// previous whitelist exists and no top-1m.update marker was set.
+						// Not unit-tested: this exec()'s a real download attempt --
+						// deep pfSense-runtime integration is the live-VM smoke's job
+						// (tests/php/README.md "Out of scope"; ADR-04).
 						if (!file_exists("{$pfb['dbdir']}/top-1m.csv")) {
 							pfb_logger("\n  TOP1M: feed download failed -- keeping the previous TOP1M whitelist (if any).\n", 2);
 						}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8312,6 +8312,11 @@ function pfblockerng_top1m() {
 				if (!ctype_digit((string) ($csvline[0] ?? ''))) {
 					continue;
 				}
+				// Count every valid CSV row BEFORE the match/break below, so a
+				// small dnsbl_top1m_cnt (e.g. 1) that breaks on the first match
+				// still leaves $linecnt > 0 and classifies as a valid feed
+				// (not the dead-feed $linecnt === 0 path) (#886 review).
+				$linecnt++;
 				$tld = substr($csvline[1], strrpos($csvline[1], '.') + 1);
 
 				if (isset($pfb_include[$tld])) {
@@ -8328,7 +8333,6 @@ function pfblockerng_top1m() {
 				if ($x >= $pfb['dnsbl_top1m_cnt']) {
 					break;
 				}
-				$linecnt++;
 			}
 			@fclose($pfb_output);
 			@fclose($handle);

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3243,7 +3243,7 @@ $section->addInput(new Form_Select(
 	gettext('Type'),
 	$pconfig['alexa_type'],
 	$options_alexa_type
-))->setHelp('Default: Tranco TOP1M. To change the TOP1M type, select type and Save, followed by a \'Force Reload - DNSBL\'');
+))->setHelp('Default: Tranco TOP1M. To change the TOP1M type, select the type and Save, then run an Update -- the previous list is cleared on save and re-fetched on the next Update.');
 
 $section->addInput(new Form_Select(
 	'alexa_count',

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3243,7 +3243,7 @@ $section->addInput(new Form_Select(
 	gettext('Type'),
 	$pconfig['alexa_type'],
 	$options_alexa_type
-))->setHelp('Default: Tranco TOP1M. To change the TOP1M type, select the type and Save, then run an Update -- the previous list is cleared on save and re-fetched on the next Update.');
+))->setHelp('Default: Tranco TOP1M. To change the TOP1M type, select the type and Save, then run an Update -- this clears and re-fetches the list.');
 
 $section->addInput(new Form_Select(
 	'alexa_count',

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -298,6 +298,33 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertStringContainsString('Parsed 3 lines | Found 1 of 1000', $this->readMainLog());
 	}
 
+	/**
+	 * A valid feed with a SMALL dnsbl_top1m_cnt must still classify as valid.
+	 * Regression for the #886-review off-by-one: $linecnt was incremented AFTER
+	 * the "$x >= dnsbl_top1m_cnt" break, so cnt=1 matching the first line broke
+	 * with $linecnt still 0 -- wrongly tripping the dead-feed path and keeping the
+	 * stale whitelist instead of publishing the (valid) 1-entry build.
+	 */
+	public function testValidFeedWithSmallCountReplacesNotPreserved(): void
+	{
+		$staleContent = ".stale.com,,\n,stale.com,,\n,www.stale.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $staleContent), 'setup: seed stale whitelist');
+		$GLOBALS['pfb']['dnsbl_top1m_cnt'] = '1';	// break on the very first match
+		// First line matches '.com' -> $x reaches 1 and the loop breaks immediately.
+		$csv = "1,example.com\n2,other.com\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: valid top-1m.csv');
+
+		pfblockerng_top1m();
+
+		$got = file_get_contents($this->whitelistPath());
+		$this->assertNotFalse($got);
+		$this->assertStringNotContainsString('stale.com', $got, 'a valid small-count feed must replace the stale whitelist');
+		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got);
+		$this->assertStringNotContainsString('keeping the previous TOP1M whitelist', $this->readErrLog(),
+			'a valid feed must NOT emit the dead-feed warning');
+		$this->assertStringContainsString('Parsed 1 lines | Found 1 of 1', $this->readMainLog());
+	}
+
 	/** Valid feed, zero TLD matches -- replaced (with empty content) + a mild note, NOT the dead-feed warning. */
 	public function testValidFeedWithZeroMatchesReplacesAndNotesNoMatches(): void
 	{

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #886 -- pfblockerng_top1m() must never wipe a previously-good TOP1M whitelist
+ * when the top-1m.csv feed is empty/invalid; it must warn instead of silently "completing".
+ *
+ * Root cause (pre-change): the function opened pfbalexawhitelist.txt with fopen(...,'w')
+ * UP FRONT -- before knowing the parse would find anything -- so a 0-byte/garbage
+ * top-1m.csv truncated a good whitelist to empty while logging only an info-level
+ * "Parsed 0 lines" line. Fix: build into a temp file, and only swap it into place when
+ * the parse actually found usable source lines; otherwise discard the temp and warn
+ * (level 2) that the previous whitelist was kept.
+ *
+ * Feature: TOP1M whitelist rebuild survives an empty/invalid feed
+ *   Background:
+ *     Given $pfb['dbdir'] holds the feed at top-1m.csv and the whitelist at
+ *           pfbalexawhitelist.txt
+ *     And   $pfb['dnsbl_top1m_inc'] names at least one TLD to include
+ *
+ * Branch coverage (every condition, both sides):
+ *   * dead feed (0 usable source lines) WITH a prior whitelist -> preserved + WARN
+ *   * dead feed WITH NO prior whitelist -> stays absent + WARN ("no list available")
+ *   * valid feed with matches -> whitelist REPLACED with the fresh build
+ *   * valid feed with zero TLD matches -> whitelist replaced (with empty content) + a
+ *     mild info note, NOT the dead-feed warning (a real feed just matched nothing)
+ */
+#[CoversFunction('pfblockerng_top1m')]
+final class Top1mPreserveOnEmptyFeedTest extends TestCase
+{
+	private string $dbdir;
+
+	/** Saved $GLOBALS['pfb'] keys this test touches, restored in tearDown for isolation. */
+	private array $savedPfb = [];
+
+	protected function setUp(): void
+	{
+		$this->dbdir = sys_get_temp_dir() . '/pfb_top1m_' . getmypid() . '_' . uniqid();
+		$this->assertTrue(@mkdir($this->dbdir, 0777, true), "could not create sandbox {$this->dbdir}");
+
+		foreach (['dbdir', 'log', 'errlog', 'dnsbl_top1m_inc', 'dnsbl_top1m_cnt', 'runlog',
+			  'runlog_active', 'hook_lifecycle', 'pnow'] as $key) {
+			$this->savedPfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$key] : false;
+		}
+
+		$GLOBALS['pfb']['dbdir']		= $this->dbdir;
+		$GLOBALS['pfb']['log']			= "{$this->dbdir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog']		= "{$this->dbdir}/pfblockerng_error.log";
+		$GLOBALS['pfb']['dnsbl_top1m_inc']	= 'com';
+		$GLOBALS['pfb']['dnsbl_top1m_cnt']	= '1000';
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active'],
+		      $GLOBALS['pfb']['hook_lifecycle'], $GLOBALS['pfb']['pnow']);
+
+		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['log'], ''), 'could not create main log');
+		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['errlog'], ''), 'could not create error log');
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->savedPfb as $key => $val) {
+			if ($val === false) {
+				unset($GLOBALS['pfb'][$key]);
+			} else {
+				$GLOBALS['pfb'][$key] = $val;
+			}
+		}
+		foreach ((array) (@glob("{$this->dbdir}/*") ?: []) as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->dbdir);
+	}
+
+	private function whitelistPath(): string
+	{
+		return "{$this->dbdir}/pfbalexawhitelist.txt";
+	}
+
+	private function csvPath(): string
+	{
+		return "{$this->dbdir}/top-1m.csv";
+	}
+
+	private function readErrLog(): string
+	{
+		$raw = file_get_contents($GLOBALS['pfb']['errlog']);
+		$this->assertNotFalse($raw, 'could not read error log');
+		return (string) $raw;
+	}
+
+	private function readMainLog(): string
+	{
+		$raw = file_get_contents($GLOBALS['pfb']['log']);
+		$this->assertNotFalse($raw, 'could not read main log');
+		return (string) $raw;
+	}
+
+	/**
+	 * THE core proof: a prior good whitelist survives a 0-byte top-1m.csv (empty feed),
+	 * and the run warns instead of silently completing. On pre-change code this FAILS --
+	 * the fopen(...,'w') truncates pfbalexawhitelist.txt to empty before the parse even
+	 * runs (verified by stashing the fix and re-running).
+	 */
+	public function testEmptyFeedPreservesPriorWhitelistAndWarns(): void
+	{
+		// Given: a prior good whitelist and an empty (0-byte) top-1m.csv.
+		$priorContent = ".example.com,,\n,example.com,,\n,www.example.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
+		$this->assertNotFalse(file_put_contents($this->csvPath(), ''), 'setup: empty top-1m.csv');
+		// Assert the before-state explicitly so the post-call assertion proves preservation,
+		// not merely "some content happens to be there".
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
+
+		// When
+		pfblockerng_top1m();
+
+		// Then: unchanged, no leftover temp file, and a level-2 (main log + error log) warning.
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
+			'a dead feed must NOT wipe the previously-good TOP1M whitelist');
+		$this->assertFileDoesNotExist("{$this->whitelistPath()}.tmp", 'no temp build file left behind');
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readErrLog());
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+	}
+
+	/** Same dead-feed path, but with NO prior whitelist -- says so, and still no wipe/creation. */
+	public function testEmptyFeedWithNoPriorWhitelistWarnsNoListAvailable(): void
+	{
+		// Given: an empty (0-byte) top-1m.csv and no prior whitelist.
+		$this->assertNotFalse(file_put_contents($this->csvPath(), ''), 'setup: empty top-1m.csv');
+		$this->assertFileDoesNotExist($this->whitelistPath(), 'before-state: no prior whitelist');
+
+		// When
+		pfblockerng_top1m();
+
+		// Then: still absent, and the warning names the "no list available" case.
+		$this->assertFileDoesNotExist($this->whitelistPath(), 'a dead feed must not fabricate an empty whitelist');
+		$this->assertStringContainsString('no TOP1M whitelist available', $this->readErrLog());
+	}
+
+	/** Regression guard: an absent top-1m.csv (download never landed) already preserved + warned. */
+	public function testAbsentCsvPreservesPriorWhitelistAndWarns(): void
+	{
+		$priorContent = ".kept.com,,\n,kept.com,,\n,www.kept.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
+		$this->assertFileDoesNotExist($this->csvPath(), 'before-state: no top-1m.csv');
+
+		pfblockerng_top1m();
+
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
+			'a missing feed file must not wipe the previously-good TOP1M whitelist');
+		$this->assertStringContainsString('TOP1M conversion Failed', $this->readErrLog());
+	}
+
+	/** Valid feed with matches -- the whitelist IS replaced with the fresh build. */
+	public function testValidFeedReplacesWhitelist(): void
+	{
+		$staleContent = ".stale.com,,\n,stale.com,,\n,www.stale.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $staleContent), 'setup: seed stale whitelist');
+		// 3 usable source lines, 1 '.com' TLD match ('other.net'/'sample.org' don't match).
+		$csv = "1,example.com\n2,other.net\n3,sample.org\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: valid top-1m.csv');
+
+		pfblockerng_top1m();
+
+		$got = file_get_contents($this->whitelistPath());
+		$this->assertNotFalse($got);
+		$this->assertStringNotContainsString('stale.com', $got, 'the stale build must be replaced, not appended to');
+		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got);
+		$this->assertFileDoesNotExist("{$this->whitelistPath()}.tmp", 'no temp build file left behind');
+		$this->assertStringContainsString('Parsed 3 lines | Found 1 of 1000', $this->readMainLog());
+	}
+
+	/** Valid feed, zero TLD matches -- replaced (with empty content) + a mild note, NOT the dead-feed warning. */
+	public function testValidFeedWithZeroMatchesReplacesAndNotesNoMatches(): void
+	{
+		$staleContent = ".stale.com,,\n,stale.com,,\n,www.stale.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $staleContent), 'setup: seed stale whitelist');
+		$csv = "1,example.net\n2,other.net\n";	// valid source lines, but no '.com' TLD present
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: valid feed, no TLD match');
+
+		pfblockerng_top1m();
+
+		$this->assertSame('', file_get_contents($this->whitelistPath()),
+			'a valid feed that matched nothing still replaces the stale build (it is not a dead feed)');
+		$this->assertStringContainsString('0 domains matched the configured TLD inclusions', $this->readMainLog());
+		$this->assertStringNotContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+		$this->assertStringNotContainsString('keeping the previous TOP1M whitelist', $this->readErrLog());
+	}
+}

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -12,9 +12,11 @@ use PHPUnit\Framework\TestCase;
  * Root cause (pre-change): the function opened pfbalexawhitelist.txt with fopen(...,'w')
  * UP FRONT -- before knowing the parse would find anything -- so a 0-byte/garbage
  * top-1m.csv truncated a good whitelist to empty while logging only an info-level
- * "Parsed 0 lines" line. Fix: build into a temp file, and only swap it into place when
- * the parse actually found usable source lines; otherwise discard the temp and warn
- * (level 2) that the previous whitelist was kept.
+ * "Parsed 0 lines" line. Fix: build into a temp file (tempnam(), collision-safe), and
+ * only swap it into place -- via a CHECKED @rename() -- when the parse actually found
+ * rows with a numeric rank column; otherwise discard the temp and warn (level 2) that
+ * the previous whitelist was kept. A prose/HTML/error body that merely happens to
+ * contain a '.' and a ',' no longer counts as "valid data found" (2nd review round).
  *
  * Feature: TOP1M whitelist rebuild survives an empty/invalid feed
  *   Background:
@@ -25,6 +27,13 @@ use PHPUnit\Framework\TestCase;
  * Branch coverage (every condition, both sides):
  *   * dead feed (0 usable source lines) WITH a prior whitelist -> preserved + WARN
  *   * dead feed WITH NO prior whitelist -> stays absent + WARN ("no list available")
+ *   * garbage-but-nonempty feed (numeric-rank guard) -> preserved + WARN, same as dead
+ *   * @rename() FAILURE (publish denied, two distinct real-world triggers: an occupied
+ *     destination path and a read-only dbdir) -> preserved + WARN, not reported as
+ *     success. The tempnam()/fopen()-returns-FALSE branch itself needs an
+ *     `open_basedir`-restricted child process to force deterministically (see
+ *     DnsblPrefetchTest/IpPrefetchTest's sandbox helper) -- left as a documented
+ *     out-of-CI/covered-by-guard gap rather than a further locally-flaky sandboxed test.
  *   * valid feed with matches -> whitelist REPLACED with the fresh build
  *   * valid feed with zero TLD matches -> whitelist replaced (with empty content) + a
  *     mild info note, NOT the dead-feed warning (a real feed just matched nothing)
@@ -68,8 +77,15 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 				$GLOBALS['pfb'][$key] = $val;
 			}
 		}
+		// A rename-failure test occupies the whitelist path with a directory; restore
+		// write access from any temp-open-failure test before removing entries.
+		@chmod($this->dbdir, 0777);
 		foreach ((array) (@glob("{$this->dbdir}/*") ?: []) as $f) {
-			@unlink($f);
+			if (is_dir($f)) {
+				@rmdir($f);
+			} else {
+				@unlink($f);
+			}
 		}
 		@rmdir($this->dbdir);
 	}
@@ -82,6 +98,12 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	private function csvPath(): string
 	{
 		return "{$this->dbdir}/top-1m.csv";
+	}
+
+	/** Stray '.pfbtop1m_*' staging files left in dbdir after a run (should always be empty). */
+	private function tempFilesLeftBehind(): array
+	{
+		return (array) (@glob("{$this->dbdir}/.pfbtop1m_*") ?: []);
 	}
 
 	private function readErrLog(): string
@@ -120,9 +142,112 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		// Then: unchanged, no leftover temp file, and a level-2 (main log + error log) warning.
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
 			'a dead feed must NOT wipe the previously-good TOP1M whitelist');
-		$this->assertFileDoesNotExist("{$this->whitelistPath()}.tmp", 'no temp build file left behind');
+		$this->assertSame([], $this->tempFilesLeftBehind(), 'no temp build file left behind');
 		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readErrLog());
 		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+	}
+
+	/**
+	 * THE #886-review proof: a garbage-but-nonempty top-1m.csv (a prose/error body, not
+	 * real CSV data) must classify the SAME as a dead feed -- not as "valid data found".
+	 * Pre-fix code's only filter was a '.' AND a ',' present on the line, so a body like
+	 * "error, service temporarily unavailable." passed it, $linecnt went > 0, and the
+	 * "valid feed" branch replaced (wiped) a good whitelist with the empty temp build --
+	 * reporting success ("Parsed N lines"), not a warning.
+	 */
+	public function testGarbageNonemptyFeedPreservesPriorWhitelistAndWarns(): void
+	{
+		// Given: a prior good whitelist and a top-1m.csv whose only line has a '.' AND a
+		// ',' (passes the old filter) but no numeric rank column (not real CSV data).
+		$priorContent = ".real.com,,\n,real.com,,\n,www.real.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
+		$this->assertNotFalse(
+			file_put_contents($this->csvPath(), "error, service temporarily unavailable.\n"),
+			'setup: garbage (non-CSV) top-1m.csv'
+		);
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
+
+		// When
+		pfblockerng_top1m();
+
+		// Then: unchanged, no leftover temp file, and a level-2 warning -- a garbage body
+		// must never be mistaken for a valid feed.
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
+			'a garbage-but-nonempty feed must NOT wipe the previously-good TOP1M whitelist');
+		$this->assertSame([], $this->tempFilesLeftBehind(), 'no temp build file left behind');
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readErrLog());
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+	}
+
+	/**
+	 * #886-review guard (finding 2 -- guard the temp-file open): a read-only dbdir must
+	 * warn and keep the previous whitelist, never fatal. RED on pre-fix code (verified
+	 * directly): the old code opened a FIXED "{$whitelist_file}.tmp" path with a plain
+	 * @fopen(..., 'w') -- which the read-only dbdir genuinely fails outright -- and then
+	 * @fwrite()'d to the FALSE handle, throwing an uncaught `TypeError: fwrite(): Argument
+	 * #1 ($stream) must be of type resource, false given` (a real PHP 8 fatal, exactly
+	 * finding 2). GREEN after: the guarded fopen() is checked up front.
+	 *
+	 * NOTE on the fixed code path actually exercised here: PHP's tempnam() (used by the
+	 * fix, unlike the old fixed name) silently FALLS BACK to the system temp dir when the
+	 * given directory exists but isn't writable (verified empirically -- it does not
+	 * return FALSE merely for "not writable"), so post-fix staging still succeeds; it is
+	 * the final @rename() into the read-only dbdir that then fails, landing in the
+	 * "failed to publish" branch (a second, realistic real-world trigger for the same
+	 * guard as testRenameFailurePreservesPriorWhitelistAndWarns below). The genuine
+	 * tempnam()/fopen()-returns-FALSE branch (both the given dir AND the system temp dir
+	 * refuse the create) is only deterministically forceable via an
+	 * `open_basedir`-restricted child process -- the same mechanism already used by
+	 * DnsblPrefetchTest/IpPrefetchTest's `runInRestrictedTempDirSandbox()`, which is
+	 * known-flaky in this local dev environment (see this suite's pre-existing 3
+	 * failures) -- so THAT exact branch is left as a documented out-of-CI/covered-by-
+	 * guard gap rather than a fourth locally-flaky sandboxed test; this test still pins
+	 * the finding-2 crash fix via the read-only-dbdir trigger.
+	 */
+	public function testReadOnlyDbdirCausesRenameFailurePreservesPriorWhitelistAndWarns(): void
+	{
+		// Given: a prior good whitelist, a valid+matching top-1m.csv, but a dbdir made
+		// read-only AFTER seeding both files.
+		$priorContent = ".kept2.com,,\n,kept2.com,,\n,www.kept2.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "1,example.com\n"), 'setup: valid top-1m.csv');
+		$this->assertTrue(@chmod($this->dbdir, 0555), 'setup: make dbdir read-only (deny new-file create)');
+
+		try {
+			// When
+			pfblockerng_top1m();
+		} finally {
+			// Restore write access up front so tearDown() can clean the sandbox.
+			@chmod($this->dbdir, 0777);
+		}
+
+		// Then: unchanged, no fatal, and a level-2 warning naming the publish failure.
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
+			'a read-only dbdir must NOT wipe the previously-good TOP1M whitelist');
+		$this->assertStringContainsString('failed to publish the new whitelist build', $this->readErrLog());
+	}
+
+	/**
+	 * #886-review guard: an @rename() FAILURE (the parse looked valid, but publishing it
+	 * did not happen -- perms/cross-device/disk) must warn, not report "Parsed N lines"
+	 * success while silently keeping a stale whitelist.
+	 */
+	public function testRenameFailurePreservesPriorWhitelistAndWarns(): void
+	{
+		// Given: a valid feed that WILL find a match, but the whitelist path is occupied
+		// by a DIRECTORY -- rename(file, existing_directory) fails (EISDIR) without
+		// needing a platform-specific cross-device/perm trick.
+		$this->assertTrue(@mkdir($this->whitelistPath(), 0777), 'setup: occupy whitelist path with a directory');
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "1,example.com\n"), 'setup: valid top-1m.csv');
+
+		// When
+		pfblockerng_top1m();
+
+		// Then: the occupying directory survives (a failed rename must not destroy it),
+		// no leftover temp file, and a level-2 warning naming the publish failure.
+		$this->assertDirectoryExists($this->whitelistPath(), 'a failed rename must not destroy the existing path');
+		$this->assertSame([], $this->tempFilesLeftBehind(), 'no leftover temp file after a failed rename');
+		$this->assertStringContainsString('failed to publish the new whitelist build', $this->readErrLog());
 	}
 
 	/** Same dead-feed path, but with NO prior whitelist -- says so, and still no wipe/creation. */
@@ -169,7 +294,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertNotFalse($got);
 		$this->assertStringNotContainsString('stale.com', $got, 'the stale build must be replaced, not appended to');
 		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got);
-		$this->assertFileDoesNotExist("{$this->whitelistPath()}.tmp", 'no temp build file left behind');
+		$this->assertSame([], $this->tempFilesLeftBehind(), 'no temp build file left behind');
 		$this->assertStringContainsString('Parsed 3 lines | Found 1 of 1000', $this->readMainLog());
 	}
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -673,6 +673,33 @@ def test_dnsbl_top1m_source_options_exclude_alexa(webui: WebUI, php_error_log_gu
         assert absent not in body, f"DNSBL page still renders the dropped Alexa TOP1M option ({absent!r})"
 
 
+def test_dnsbl_top1m_type_help_says_update_not_force_reload(
+    webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:
+    """The TOP1M 'Type' select's help text says an Update suffices after a type change,
+    not the stale 'Force Reload - DNSBL' instruction (#886) — the Save handler already
+    clears the cached CSV/whitelist on a type change, so a plain Update re-fetches and
+    rebuilds them; a Force Reload was never actually required.
+
+    Asserts the page passes the clean-render oracle AND that the field's help text
+    mentions 'Update' while no longer telling the user to run a Force Reload.
+    """
+    path = "/pfblockerng/pfblockerng_dnsbl.php"
+    resp = webui.get(path)
+    result = evaluate_render(path, resp.status_code, resp.text, ("DNSBL Configuration",))
+    assert result.ok, f"DNSBL render oracle failed: {result.detail}"
+    body = resp.text
+    assert "select the type and Save, then run an Update" in body, (
+        "DNSBL page's TOP1M Type help no longer tells the user an Update suffices"
+    )
+    # The old TOP1M Type help's exact wording (distinct from the OTHER, still-accurate
+    # Force-Reload help texts elsewhere on this page -- TLD Exclusion / Global-log) --
+    # its absence pins that the stale instruction was actually replaced, not just added to.
+    assert "select type and Save, followed by a" not in body, (
+        "DNSBL page's TOP1M Type help still carries the stale Force-Reload wording"
+    )
+
+
 def test_dnsbl_lenient_parsing_field_renders(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """The ADR-22 'Lenient Feed Parsing' toggle renders cleanly on the DNSBL page — so a
     regression that drops or breaks the field is caught at the render tier (not only by the


### PR DESCRIPTION
Closes #886. When a TOP1M whitelist feed fails or returns empty/invalid, the DNSBL Update **silently wiped the existing whitelist and reported success**. This preserves the good list and warns clearly, without failing the update.

## The bug

`pfblockerng_top1m()` opened `pfbalexawhitelist.txt` with `fopen(..., 'w')` **up-front** — truncating the previous good list before knowing the parse produced anything — so an empty/invalid `top-1m.csv` wiped it, `Found 0` logged at info level, and the update "completed":

```
 Building TOP1M Whitelist [] [ Parsed 0 lines | Found 0 of 1000 ]...
 DNSBL - TOP1M changes found - Rebuilding!
 completed
```

## Fix (`pfblockerng.inc`)

- **Build into a temp file, then atomically `rename()` over `pfbalexawhitelist.txt` only when the feed was usable.** If `top-1m.csv` is absent or yields **0 parsed source lines** (the dead-feed signal), the existing whitelist is left untouched and a **level-2 warning** is logged (`"feed returned no valid data (empty/invalid) — keeping the previous TOP1M whitelist"`, or `"— no TOP1M whitelist available"` when there is no prior list). A valid feed that matches 0 domains after the TLD filter is a separate, mild info note — not a wipe.
- **The rebuild block warns** (level 2) when the download attempt itself fails (`"feed download failed — keeping the previous TOP1M whitelist (if any)"`), only on the branch that actually dispatched the download.
- The update still reaches ` completed` — it does not fail over a dead TOP1M feed.

## Help text (`pfblockerng_dnsbl.php:3246`)

The TOP1M-type help said a *"Force Reload - DNSBL"* was required to change the source. Stale — the Save handler already clears `top-1m.csv` + `pfbalexawhitelist.txt` on a type change, so a normal **Update** re-fetches. Reworded to say so.

## Tests

- **PHPUnit** `Top1mPreserveOnEmptyFeedTest` (5, fail-before/pass-after): an empty/absent `top-1m.csv` with a prior whitelist → the prior file is **preserved** and a warning logged (fails on the truncate-first code, passes after); a valid feed → replaced; a valid feed matching nothing → replaced + noted.
- **Tier-A UI** `test_dnsbl_top1m_type_help_says_update_not_force_reload`.

The live-VM smoke case (a genuinely dead TOP1M download → warn + preserve) is deferred as an out-of-CI limitation: the TOP1M URL is hardcoded per `Top1mSource`, so `_MockFeedServer` can't redirect it without adding a test-only override to production code; the PHPUnit suite exercises `pfblockerng_top1m()`'s branch logic (the actual fix) directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TOP1M list updates so incomplete or missing downloads no longer overwrite the existing whitelist.
  * Added safer handling for empty feeds and failed downloads, preserving the last valid list when needed.
* **Documentation**
  * Updated the TOP1M help text to better explain that changes take effect after saving and running an update.
* **Tests**
  * Added coverage for empty, missing, and valid TOP1M feed scenarios.
  * Added a UI smoke test to verify the updated help text appears correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->