### PR TITLE
ci: address Copilot nits on the Top1M health-check (#884 review)

### DIFF
--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -1,7 +1,7 @@
 name: Top1M Provider Health Check
 
-# Weekly health-check of every external Top1M provider URL we ship (issue
-# #884). We do NOT vendor these lists (they're ~1M rows, runtime-downloaded
+# Weekly health-check of every external Top1M provider URL we ship
+# (issue #884). We do NOT vendor these lists (they're ~1M rows, runtime-downloaded
 # per box) -- this is validate-only, the guard that would have caught the
 # Alexa Top1M source rotting silently (its hardcoded URL died years ago;
 # cleaned up in #877).
@@ -45,7 +45,8 @@ jobs:
           COUNT=$(jq 'length' <<<"$MATRIX")
           [ "$COUNT" -ge 1 ] || { echo "::error::no top1m providers discovered -- extractor may be broken"; exit 1; }
 
-          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+          # printf (not echo) avoids echo-escaping quirks on structured JSON.
+          printf 'matrix=%s\n' "$MATRIX" >> "$GITHUB_OUTPUT"
 
   # ── 2. Health-check each provider independently ───────────────────────────
   check:

--- a/scripts/misc/check_top1m_providers.py
+++ b/scripts/misc/check_top1m_providers.py
@@ -145,8 +145,9 @@ def _is_valid_row(row: list[str]) -> bool:
 def _scan_csv(body: bytes) -> tuple[str, int, int, tuple[int, list[str]] | None]:
     """Open `body` as a zip and scan its CSV member.
 
-    Returns (member_name, total_rows, valid_rows, first_bad_row). Raises
-    zipfile.BadZipFile / KeyError-free -- callers handle the zip-shape errors.
+    Returns (member_name, total_rows, valid_rows, first_bad_row). May raise
+    zipfile.BadZipFile on a non-zip / corrupt body (the caller catches zip-shape
+    errors); it does not raise KeyError.
     """
     with zipfile.ZipFile(io.BytesIO(body)) as zf:
         names = zf.namelist()


### PR DESCRIPTION
Follow-up to #885 addressing GitHub Copilot's review comments:

- Keep `(issue #884)` on one line so the header comment doesn't render as `issue # #884`.
- Use `printf` instead of `echo` to write the JSON matrix into `$GITHUB_OUTPUT` (safer for structured data).
- Clarify the `_scan_csv` docstring's raises / does-not-raise contract.

Copilot also flagged the `ponytail:` comment marker as unclear; it's a documented repo convention (CLAUDE.md) used throughout the codebase, so it's kept for consistency.