### PR TITLE
pfblockerng: redact query-string/userinfo when logging download URLs (#890)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9808,14 +9808,29 @@ function pfb_redact_url($url) {
 		return $redacted;
 	}
 
-	// Fallback: strip a leading '[scheme://]user[:pass]@' userinfo prefix,
-	// then truncate at the first '?' -- covers malformed URLs and the bare
-	// rsync '[user@]host::module' shorthand (parse_url reports no host for
-	// either, so both land here).
-	$redacted	= preg_replace('#(^|//)[^\s/@]+@#', '$1', $url, 1) ?? $url;
-	$qpos		= strpos($redacted, '?');
-	if ($qpos !== FALSE) {
-		$redacted = substr($redacted, 0, $qpos) . '?[redacted]';
+	// Fallback (parse_url found no host): a malformed URL, or pfBlockerNG's bare
+	// rsync '[user@]host::module' shorthand. Strip a '[scheme://]user[:pass]@'
+	// userinfo prefix using the RIGHTMOST '@' in the authority -- an rsync
+	// password may itself contain a literal '@' (mirrors pfb_download's own
+	// strrpos('@') host handling), so a first-'@' split would leak part of it --
+	// then drop any query AND fragment, either of which can carry a credential.
+	$prefix		= '';
+	$body		= $url;
+	if (preg_match('#^([a-z][a-z0-9+.-]*://|//)#i', $body, $m)) {
+		$prefix	= $m[0];
+		$body	= substr($body, strlen($prefix));
+	}
+	$auth_end	= strcspn($body, '/?#');		// authority = up to the first /?#
+	$authority	= substr($body, 0, $auth_end);
+	$tail		= substr($body, $auth_end);
+	$at		= strrpos($authority, '@');
+	if ($at !== FALSE) {
+		$authority = substr($authority, $at + 1);
+	}
+	$redacted	= $prefix . $authority . $tail;
+	$cut		= strcspn($redacted, '?#');		// truncate a query OR fragment
+	if ($cut < strlen($redacted)) {
+		$redacted = substr($redacted, 0, $cut) . '?[redacted]';
 	}
 	return $redacted;
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1234,17 +1234,17 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 				} else {
 					$data = parse_url($input);
 					if (!in_array($data['scheme'], array('http', 'https', 'rsync', 'ftp'))) {
-						pfb_logger("{$header} Invalid URL Scheme [ " . htmlspecialchars($input) . " ]", 6);
+						pfb_logger("{$header} Invalid URL Scheme [ " . htmlspecialchars(pfb_redact_url($input)) . " ]", 6);
 						return FALSE;
 					}
 				}
 
 				$validate_list = '';
 				if (!$data || !is_array($data)) {
-					pfb_logger("{$header} Invalid URL (missing data) [ " . htmlspecialchars($input) . " ]", 6);
+					pfb_logger("{$header} Invalid URL (missing data) [ " . htmlspecialchars(pfb_redact_url($input)) . " ]", 6);
 					return FALSE;
 				} elseif (!isset($data['host']) || empty($data['host'])) {
-					pfb_logger("{$header} Invalid URL (missing hostname) [ " . htmlspecialchars($input) . " ]", 6);
+					pfb_logger("{$header} Invalid URL (missing hostname) [ " . htmlspecialchars(pfb_redact_url($input)) . " ]", 6);
 					return FALSE;
 				} elseif (is_ipaddr($data['host'])) {
 					$validate_list = array(array('type' => 'IP', 'data' => $data['host']));
@@ -1295,7 +1295,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 				}
 				else {
 					// Cannot resolve host
-					pfb_logger("{$header} Invalid URL (cannot resolve) [ " . htmlspecialchars($input) . " ]", 6);
+					pfb_logger("{$header} Invalid URL (cannot resolve) [ " . htmlspecialchars(pfb_redact_url($input)) . " ]", 6);
 					return FALSE;
 				}
 
@@ -1318,7 +1318,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 					}
 
 					if ($reference == 'alerts refresh') {
-						pfb_logger("{$header} Invalid URL (alerts tab) [ " . htmlspecialchars($input) . " ]", 6);
+						pfb_logger("{$header} Invalid URL (alerts tab) [ " . htmlspecialchars(pfb_redact_url($input)) . " ]", 6);
 					}
 					return FALSE;
 				}
@@ -1335,7 +1335,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 					if ($path == '/') {
 						return TRUE;
 					}
-					pfb_logger("{$header} Invalid URL (not allowed) [ " . htmlspecialchars($input) . " ]", 6);
+					pfb_logger("{$header} Invalid URL (not allowed) [ " . htmlspecialchars(pfb_redact_url($input)) . " ]", 6);
 					return FALSE;
 				}
 
@@ -1348,7 +1348,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 				$pinned	= '';
 				if (pfb_feed_filter_enabled() &&
 				    !pfb_feed_host_allowed($data['host'], $reason, $pinned)) {
-					pfb_logger("{$header} Invalid URL ({$reason}) [ " . htmlspecialchars($input) . " ]", 6);
+					pfb_logger("{$header} Invalid URL ({$reason}) [ " . htmlspecialchars(pfb_redact_url($input)) . " ]", 6);
 					return FALSE;
 				}
 				return TRUE;
@@ -1377,7 +1377,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 				// exist (or cannot be resolved) — reject it.
 				$real = realpath($input);
 				if ($real === FALSE) {
-					pfb_logger("\n[PFB_FILTER - {$type}] Invalid URL (cannot resolve path) [ " . htmlspecialchars($input) . " ]", 6);
+					pfb_logger("\n[PFB_FILTER - {$type}] Invalid URL (cannot resolve path) [ " . htmlspecialchars(pfb_redact_url($input)) . " ]", 6);
 					return FALSE;
 				}
 
@@ -1386,7 +1386,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 				$base = basename($real);
 				if ($base === '' || $base === '.' || $base === '..' ||
 				    strpbrk($base, '/\\') !== FALSE) {
-					pfb_logger("\n[PFB_FILTER - {$type}] Invalid URL (not allowed2) [ " . htmlspecialchars($input) . " ]", 6);
+					pfb_logger("\n[PFB_FILTER - {$type}] Invalid URL (not allowed2) [ " . htmlspecialchars(pfb_redact_url($input)) . " ]", 6);
 					return FALSE;
 				}
 
@@ -1398,7 +1398,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 					return TRUE;
 				}
 			}
-			pfb_logger("\n[PFB_FILTER - {$type}] Invalid URL (not allowed2) [ " . htmlspecialchars($input) . " ]", 6);
+			pfb_logger("\n[PFB_FILTER - {$type}] Invalid URL (not allowed2) [ " . htmlspecialchars(pfb_redact_url($input)) . " ]", 6);
 			return FALSE;
 			break;
 		case PFB_FILTER_WORD:
@@ -9779,6 +9779,48 @@ function pfb_rsync_pin_url($list_url, $ip) {
 }
 
 
+// Issue #890: redact the query string and userinfo ('user:pass@') from a feed/
+// download URL before it is written to any log -- either can carry a credential,
+// and log files (including extras.log) ship inside pfSense support bundles.
+// scheme/host/port/path are kept so the log line stays useful for diagnosing a
+// failed download. A well-formed http(s)/ftp/rsync:// URL is rebuilt from
+// parse_url() (userinfo is simply dropped by not carrying it over; the query,
+// when present, is replaced with a '[redacted]' marker). Anything parse_url()
+// can't make sense of as a URL (a malformed input, or pfBlockerNG's own
+// '[user@]host::module' rsync shorthand) falls back to a regex strip -- when in
+// doubt this over-redacts rather than risk leaking a secret.
+function pfb_redact_url($url) {
+	if (!is_string($url) || $url === '') {
+		return (string) $url;
+	}
+
+	$parts = parse_url($url);
+	if (is_array($parts) && !empty($parts['host'])) {
+		$scheme		= $parts['scheme'] ?? '';
+		$redacted	= ($scheme !== '' ? "{$scheme}://" : '//') . $parts['host'];
+		if (isset($parts['port'])) {
+			$redacted .= ":{$parts['port']}";
+		}
+		$redacted .= $parts['path'] ?? '';
+		if (isset($parts['query'])) {
+			$redacted .= '?[redacted]';
+		}
+		return $redacted;
+	}
+
+	// Fallback: strip a leading '[scheme://]user[:pass]@' userinfo prefix,
+	// then truncate at the first '?' -- covers malformed URLs and the bare
+	// rsync '[user@]host::module' shorthand (parse_url reports no host for
+	// either, so both land here).
+	$redacted	= preg_replace('#(^|//)[^\s/@]+@#', '$1', $url, 1) ?? $url;
+	$qpos		= strpos($redacted, '?');
+	if ($qpos !== FALSE) {
+		$redacted = substr($redacted, 0, $qpos) . '?[redacted]';
+	}
+	return $redacted;
+}
+
+
 // Function to download feeds
 //
 // Optional $response_meta — when a non-NULL reference is passed (detector probe mode), it is
@@ -10078,7 +10120,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 						}
 						else {
 							if ($retries == 3) {
-								$log = curl_error($ch) . " |{$head_download}|{$list_download}| Retry [{$retries}] in 5 seconds...\n";
+								$log = curl_error($ch) . " |{$head_download}|" . pfb_redact_url($list_download) . "| Retry [{$retries}] in 5 seconds...\n";
 							} else {
 								$log = curl_error($ch) . " Retry [{$retries}] in 5 seconds...\n";
 							}
@@ -10435,7 +10477,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			// "corrupt archive" the structural probe would otherwise report (ADR-45).
 			$missing_7z = pfb_archive_missing_tool($file_type);
 			if ($missing_7z !== NULL) {
-				pfb_logger("\n[pfb_download] Cannot process {$file_type} feed: '{$missing_7z}' is not installed. Install the 7-Zip package (pkg install 7-zip) to use 7z-compressed feeds. Skipping [" . htmlspecialchars($list_url) . "]", 2);
+				pfb_logger("\n[pfb_download] Cannot process {$file_type} feed: '{$missing_7z}' is not installed. Install the 7-Zip package (pkg install 7-zip) to use 7z-compressed feeds. Skipping [" . htmlspecialchars(pfb_redact_url($list_url)) . "]", 2);
 				unlink_if_exists($file_download);
 				return FALSE;
 			}
@@ -10519,16 +10561,16 @@ function pfb_download_failure($alias, $header, $pfbfolder, $list_url, $format, $
 	// Re-evaluate URL
 	if ($format == 'whois') {
 		if (empty(pfb_filter($list_url, PFB_FILTER_DOMAIN, 'pfb_download_failure'))) {
-			pfb_logger("\n Invalid WHOIS. Terminating Download! [ {$list_url} ]\n", 1);
+			pfb_logger("\n Invalid WHOIS. Terminating Download! [ " . pfb_redact_url($list_url) . " ]\n", 1);
 		}
 	}
 	elseif ($format == 'asn') {
 		if (empty(pfb_filter($list_url, PFB_FILTER_ALNUM, 'pfb_download_failure'))) {
-			pfb_logger("\n Invalid ASN. Terminating Download! [ {$list_url} ]\n", 1);
+			pfb_logger("\n Invalid ASN. Terminating Download! [ " . pfb_redact_url($list_url) . " ]\n", 1);
 		}
 	}
 	elseif (!pfb_filter($list_url, PFB_FILTER_URL, 'pfb_download_failure')) {
-		pfb_logger("\n Invalid URL. Terminating Download! [ {$list_url} ]\n", 1);
+		pfb_logger("\n Invalid URL. Terminating Download! [ " . pfb_redact_url($list_url) . " ]\n", 1);
 	}
 	else {
 		// Determine if URL is a localfile

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -440,7 +440,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 		}
 
 		if (empty(pfb_filter($list_url, $pfb_filter_type, 'php'))) {
-                        pfb_logger("\n Invalid {$pfb_filter_text}. Terminating Download! [ {$list_url} ]\n", 1);
+                        pfb_logger("\n Invalid {$pfb_filter_text}. Terminating Download! [ " . pfb_redact_url($list_url) . " ]\n", 1);
 			return;
 		}
 
@@ -457,7 +457,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 		if (!empty(pfb_filter($list_url, PFB_FILTER_WORD, 'php'))) {
 			$list_url = "/usr/local/share/GeoIP/cc/{$list_url}{$vtype}.txt";
 		} else {
-			pfb_logger("\n Invalid GEOIP. Terminating Download! [ {$list_url} ]\n", 1);
+			pfb_logger("\n Invalid GEOIP. Terminating Download! [ " . pfb_redact_url($list_url) . " ]\n", 1);
 			return;
 		}
 	}
@@ -467,7 +467,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 		// header-scoped feed-host skip line here too (no-op unless the guard is
 		// why vetting failed). The line below stays for non-guard rejects.
 		pfb_log_feed_host_reject($list_url, $header, 1);
-		pfb_logger("\n Invalid URL. Terminating Download! [ {$list_url} ]\n", 1);
+		pfb_logger("\n Invalid URL. Terminating Download! [ " . pfb_redact_url($list_url) . " ]\n", 1);
 		return;
 	}
 

--- a/tests/php/RedactUrlTest.php
+++ b/tests/php/RedactUrlTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_redact_url() — issue #890: a download URL logged verbatim can carry a
+ * credential (query-string token, or 'user:pass@' userinfo), and pfBlockerNG's
+ * logs ship inside pfSense support bundles. This pins that neither ever survives
+ * into the string handed to a logger, while the scheme/host/port/path a
+ * maintainer needs to diagnose a failed download are kept intact.
+ */
+#[CoversFunction('pfb_redact_url')]
+final class RedactUrlTest extends TestCase
+{
+	public function testQueryStringIsRedacted(): void
+	{
+		$redacted = pfb_redact_url('https://h/p?token=SECRET');
+		$this->assertStringNotContainsString('SECRET', $redacted);
+		$this->assertSame('https://h/p?[redacted]', $redacted);
+	}
+
+	public function testUserinfoIsRedacted(): void
+	{
+		$redacted = pfb_redact_url('https://user:pass@h/p');
+		$this->assertStringNotContainsString('pass', $redacted);
+		$this->assertSame('https://h/p', $redacted);
+	}
+
+	public function testUserinfoAndQueryStringAreBothRedacted(): void
+	{
+		$redacted = pfb_redact_url('https://user:pass@h/p?token=SECRET');
+		$this->assertStringNotContainsString('pass', $redacted);
+		$this->assertStringNotContainsString('SECRET', $redacted);
+		$this->assertSame('https://h/p?[redacted]', $redacted);
+	}
+
+	public function testMalformedUrlNeverLeaksTheSecret(): void
+	{
+		// parse_url() can't make sense of this as a URL (no host) -- the regex
+		// fallback engages. Over-redacting is acceptable; leaking is not.
+		$redacted = pfb_redact_url('not a url ?token=SECRET');
+		$this->assertStringNotContainsString('SECRET', $redacted);
+	}
+
+	public function testPlainUrlWithNoQueryOrUserinfoRoundTripsUnchanged(): void
+	{
+		$this->assertSame('https://h/p', pfb_redact_url('https://h/p'));
+	}
+
+	#[DataProvider('rsyncShorthandProvider')]
+	public function testBareRsyncShorthandUserinfoIsRedacted(string $url, string $expected): void
+	{
+		// pfBlockerNG's own '[user@]host::module' rsync source form has no scheme
+		// and no '//', so parse_url() reports no host for it either -- same
+		// fallback path, same guarantee: no userinfo survives.
+		$this->assertSame($expected, pfb_redact_url($url));
+	}
+
+	public static function rsyncShorthandProvider(): array
+	{
+		return [
+			'user@ only'       => ['user@host::module', 'host::module'],
+			'user:pass@ form'  => ['user:pass@host::module/path?x=1', 'host::module/path?[redacted]'],
+			'no userinfo'      => ['host::module', 'host::module'],
+		];
+	}
+}

--- a/tests/php/RedactUrlTest.php
+++ b/tests/php/RedactUrlTest.php
@@ -46,6 +46,33 @@ final class RedactUrlTest extends TestCase
 		$this->assertStringNotContainsString('SECRET', $redacted);
 	}
 
+	/**
+	 * The fallback path's two escape hatches -- a fragment ('#...') and a
+	 * userinfo password that itself contains '@' -- must not leak. Both landed
+	 * here because the input has no parse_url-detectable host (the bare rsync
+	 * '[user@]host::module' shorthand). A first-'@' split or a '?'-only truncate
+	 * used to leak part of the secret.
+	 *
+	 * @return array<string,array{string,string}>
+	 */
+	public static function fallbackLeakProvider(): array
+	{
+		return [
+			'password contains @'  => ['user:p@ss@host::module', 'host::module'],
+			'fragment secret'      => ['user@host::module#token=SECRET', 'host::module?[redacted]'],
+			'fragment no userinfo' => ['some garbage#token=SECRET', 'some garbage?[redacted]'],
+		];
+	}
+
+	#[DataProvider('fallbackLeakProvider')]
+	public function testFallbackDoesNotLeakFragmentOrAtInPassword(string $url, string $expected): void
+	{
+		$redacted = pfb_redact_url($url);
+		$this->assertStringNotContainsString('SECRET', $redacted, 'a fragment secret must not survive');
+		$this->assertStringNotContainsString('ss@', $redacted, 'an @-in-password must be fully stripped');
+		$this->assertSame($expected, $redacted);
+	}
+
 	public function testPlainUrlWithNoQueryOrUserinfoRoundTripsUnchanged(): void
 	{
 		$this->assertSame('https://h/p', pfb_redact_url('https://h/p'));


### PR DESCRIPTION
Fixes #890. Hardening: the feed/extras downloader logged the **full request URL** on a failed download. A source that carries credentials in the URL — a `?…` query parameter or `user:pass@` userinfo — thus wrote those secrets into `extras.log`, which is included in pfSense diagnostic/support bundles.

## What

- Add `pfb_redact_url()` — rebuilds a URL as `scheme://host[:port][path]`, dropping userinfo and replacing any query string with `?[redacted]`; a robust regex fallback covers malformed input and pfBlockerNG's `user@host::module` rsync shorthand, so a secret is never returned raw.
- Apply it at **every** site that logs a request/download URL — the root-cause site is the `pfb_filter(PFB_FILTER_URL)` validation gate (every feed URL routes through it), plus the `pfb_download` retry logger, `pfb_download_failure`, and `pfb_update_check`. Sources that carry credentials in an HTTP header or Basic-auth were already safe (never in the logged URL).

Only the **logged** form changes; the actual request URL is untouched.

## Tests

`tests/php/RedactUrlTest.php` (8, fail-before/pass-after via stash): query string redacted, userinfo redacted, both together, malformed input never leaks, plain URL round-trips, rsync shorthand redacted — each asserting the secret is absent AND the exact redacted string.