### PR TITLE
ADR-59: TOP1M provider framework — add DomCop/Majestic/Cloudflare + token auth

### DIFF
--- a/.ADRs/ADR_59_Top1M_Provider_Framework/RESULTS/01_Results.txt
+++ b/.ADRs/ADR_59_Top1M_Provider_Framework/RESULTS/01_Results.txt
@@ -1,0 +1,128 @@
+================================================================================
+PHASE 1 RESULTS — Extract the provider descriptor table (behaviour-preserving)
+================================================================================
+
+WHAT CHANGED
+
+- New function `pfb_top1m_providers(): array`, added in
+  src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc, directly after the
+  Top1mSource enum block (both www/ and .inc reach it: pfblockerng.inc
+  require_once's pfblockerng_extra.inc conditionally, pfblockerng.php requires
+  both directly).
+
+  Signature: `function pfb_top1m_providers(): array`
+  Returns an array keyed by Top1mSource::value ('tranco' | 'cisco'); each entry:
+
+    [
+      'url'       => string,          // literal download URL
+      'container' => 'zip',           // download container (only zip exists yet)
+      'parse'     => 'rank_domain',   // parser mode (only rank_domain exists yet)
+      'auth'      => 'none',          // auth mode (only none exists yet)
+      'label'     => string,          // human-readable name
+      'licence'   => '',              // licence/attribution note (empty for both)
+    ]
+
+  Phase 1 carries exactly 'tranco' and 'cisco', with the CURRENT literal URLs
+  copied verbatim:
+    - tranco: https://tranco-list.eu/top-1m.csv.zip
+    - cisco:  https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip
+
+- Rewired src/usr/local/www/pfblockerng/pfblockerng.php's TOP1M URL selection
+  (was the `if ($pfb['dnsbl_top1m_type'] === Top1mSource::Tranco) {...} else
+  {...}` block at line 162) to a single lookup:
+
+    $pfb['extras'][2]['url'] = pfb_top1m_providers()[$pfb['dnsbl_top1m_type']->value]['url'];
+
+  `$pfb['dnsbl_top1m_type']` is already a Top1mSource enum instance by this
+  point (set in pfblockerng.inc via `PfbConfig::read('alexa_type')`, loaded
+  before pfblockerng.php reaches this code) — `->value` gives the backed
+  string ('tranco'/'cisco') that indexes the table. The extras filename/type/
+  folder lines are untouched.
+
+- pfblockerng_top1m() and pfb_download() NOT touched (reserved for Phases 2/3
+  per the ADR).
+
+TESTS
+
+New oracle: tests/php/Top1mProvidersTest.php (#[CoversFunction('pfb_top1m_providers')]):
+  - testTrancoUrlIsPinnedToThePreChangeLiteral — pins tranco's resolved URL to
+    the exact pre-ADR-59 literal.
+  - testCiscoUrlIsPinnedToThePreChangeLiteral — same for cisco.
+  - testOnlyTrancoAndCiscoAreDescribedInPhase1 — table has exactly these two
+    keys (no provider added yet).
+  - testBothProvidersDescribeTodaysZipRankDomainNoAuthShape — pins the
+    container/parse/auth fields Phase 2+ will read, so a later phase can't
+    silently change what Phase 1 shipped.
+
+This is a behaviour-preserving refactor (CLAUDE.md exception): the oracle pins
+EXISTING behaviour and stays green across the change — no red→green cycle, but
+mandatory and byte-identity-proving per the ADR's "Requirements #1: Tranco/Cisco
+behave byte-identically to today".
+
+VERIFICATION (all run inside the worktree)
+
+1. `/opt/homebrew/bin/php -l` on all three touched/added files → clean:
+   - src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc: No syntax errors detected
+   - src/usr/local/www/pfblockerng/pfblockerng.php: No syntax errors detected
+   - tests/php/Top1mProvidersTest.php: No syntax errors detected
+
+2. `composer install` (vendor/ was absent in this worktree) then
+   `vendor/bin/phpunit`:
+   Tests: 2305, Assertions: 18435, Failures: 3, Skipped: 4.
+   The 3 failures are exactly the pre-existing, environment-only
+   `open_basedir` sandbox failures called out in the task brief:
+     - DnsblPrefetchTest::test_prefetch_leaves_the_store_unseeded_when_a_grep_pass_pattern_file_cannot_be_created
+     - IpPrefetchTest::test_grep_lines_returns_null_when_the_pattern_file_cannot_be_created
+     - IpPrefetchTest::test_prefetch_leaves_the_miss_round_unseeded_when_round_a_pattern_file_cannot_be_created
+   No other failures. The new Top1mProvidersTest's 4 tests are green.
+
+3. `vendor/bin/phpcs --standard=phpcs.xml.dist src/` at the default 128M OOM'd
+   (`PHP_CodeSniffer_Fatal error: Allowed memory size of 134217728 bytes
+   exhausted`, confirmed environmental per the task brief, not a violation).
+   Re-run at 1G: `/opt/homebrew/bin/php -d memory_limit=1G vendor/bin/phpcs
+   --standard=phpcs.xml.dist src/` → clean (no output, exit clean; PFBL-01 /
+   RequireConfigGateway / UppercaseBooleanLiteral all green — the new function
+   is a pure data table, no config_*_path/exec/json_encode calls, no boolean
+   literals to case).
+
+4. `/opt/homebrew/bin/php -d memory_limit=1G vendor/bin/phpstan analyse
+   --memory-limit=1G` → `[OK] No errors`.
+
+5. Python untouched — `python -m pytest` not run (no src/**/*.py or tests/*.py
+   changed).
+
+SELF-REVIEW (git diff vs phase objectives)
+
+`git diff --stat` on src/: exactly the two files named in the ADR's Phase 1
+plan — pfblockerng_extra.inc (+32/-0) and pfblockerng.php (+2/-6). Confirmed
+by reading the full diff: only the new `pfb_top1m_providers()` table and the
+pfblockerng.php URL-selection lookup changed. No provider added beyond
+tranco/cisco, no change to pfblockerng_top1m() or pfb_download(), no parser or
+extractor edit. Plus the new test file (untracked, added).
+
+DEVIATIONS
+
+None from the phase prompt's ACTION PLAN/CONSTRAINTS. One judgment call not
+spelled out verbatim in the prompt: `pfb_top1m_providers()` lives in
+pfblockerng_extra.inc (not pfblockerng.inc) — chosen because it sits directly
+beside the Top1mSource enum it's keyed by, and pfblockerng_extra.inc is
+already require_once'd by BOTH pfblockerng.inc (conditionally, line 31) and
+pfblockerng.php (unconditionally, line 60), so both consumers reach it with no
+new include wiring. It is also outside RequireConfigGateway's sniff scope
+(which excludes pfblockerng_extra.inc/pfblockerng_migrate.inc), which is
+irrelevant here since the function does no config_*_path calls anyway.
+
+GO-AHEAD FOR PHASE 2
+
+Ready. Phase 2 ("Generalize the parser to the descriptor") can have
+pfblockerng_top1m() call `pfb_top1m_providers()[$pfb['dnsbl_top1m_type']->value]`
+and read its `parse`/`container` fields; for the `rank_domain`/`zip` combination
+(the only one that exists after this phase) the output must stay byte-identical
+to today, so the existing `Top1mPreserveOnEmptyFeedTest` oracle must stay green
+unmodified. The `label`/`licence` fields (present now, unused until later UI
+phases) and the table shape itself are stable and ready to extend with new
+provider rows without touching Phase 1's tranco/cisco entries.
+
+COMMIT
+
+pfblockerng: introduce the TOP1M provider descriptor table (ADR-59 P1)

--- a/.ADRs/ADR_59_Top1M_Provider_Framework/RESULTS/02_Results.txt
+++ b/.ADRs/ADR_59_Top1M_Provider_Framework/RESULTS/02_Results.txt
@@ -1,0 +1,189 @@
+================================================================================
+PHASE 2 RESULTS — Generalize pfblockerng_top1m() to the descriptor (behaviour-preserving)
+================================================================================
+
+WHAT CHANGED
+
+1. pfb_top1m_providers() (pfblockerng_extra.inc) — extended each entry (tranco,
+   cisco) with two new parse knobs, both set to today's implicit values:
+     'header'	=> FALSE,	// no header row in Tranco/Cisco's top-1m.csv
+     'domain_col'	=> 1,	// 0-indexed str_getcsv() field -- rank,domain -> index 1
+   ('container'/'parse'/'auth'/'url'/'label'/'licence' untouched.) Docblock
+   @return shape updated to match.
+
+2. pfblockerng_top1m() (pfblockerng.inc ~8251) — now resolves the active
+   descriptor and drives three knobs from it instead of a hardcoded shape:
+     - New optional param `?array $provider_override = NULL` (a test seam only
+       — production never passes it). When NULL, resolves via
+       `pfb_top1m_providers()[($pfb['dnsbl_top1m_type'] ?? Top1mSource::Tranco)->value]`.
+       The `?? Top1mSource::Tranco` fallback matters: $pfb['dnsbl_top1m_type']
+       is normally set by pfb_global() (PfbConfig::read('alexa_type')), but the
+       existing Top1mPreserveOnEmptyFeedTest sandbox never calls pfb_global()
+       and never sets this key -- so the fallback keeps that oracle's rank_domain/
+       zip behaviour intact without needing to touch the test.
+     - `$top1m_parse` (default 'rank_domain'): the numeric-rank guard
+       (`ctype_digit($csvline[0])`) now only fires when parse === 'rank_domain'
+       (other parse modes have no rank column to guard on).
+     - `$top1m_header` (default FALSE): when TRUE, the very first physical line
+       read from top-1m.csv is unconditionally skipped (`continue`), BEFORE the
+       existing dot/comma content filter -- so a header line's shape (which may
+       not even contain a '.'/',' ) never matters and is never misread as data.
+     - `$top1m_domcol` (default 1): replaces every literal `$csvline[1]` domain
+       read with `$csvline[$top1m_domcol] ?? ''` (a local `$domain` variable
+       threads through the TLD/www-strip/fwrite lines that used to repeat
+       `$csvline[1]` four times).
+   The #886 temp-file + atomic-rename + preserve-on-empty/garbage/rename-failure
+   + progress-log + linecnt-before-break semantics are all untouched -- only the
+   three knob reads and the header-skip insertion were added.
+
+3. pfb_download()'s extract post-processor (pfblockerng.inc, the ZIP/gz/plain
+   dispatch inside the big `if ($file_type == ...)` chain) — now honours
+   `container` for TOP1M beyond zip (zip was already wired to `$type == 'top1m'`
+   and is untouched):
+     - gz branch: added `elseif ($type == 'top1m')` alongside the existing
+       `geoip`/`asn`/`blacklist` cases -- `gunzip -c {raw} > {header}` (the
+       destination top-1m.csv), mirroring the `asn` case's pattern exactly (no
+       retval check, matching that sibling).
+     - uncompressed/"plain" branch: widened the existing
+       `if ($type == 'geoip' || $type == 'asn')` rename-straight-to-`$head_download`
+       branch to `|| $type == 'top1m'`. (Its comment already said "Extras -
+       MaxMind/TOP1M/ASN downloads" even though `top1m` was never actually
+       included in the condition -- this looks like a latent gap the ADR's
+       §2.3 "gz/plain write straight to top-1m.csv" requirement is explicitly
+       closing.) Before this, a plain-container TOP1M download would have
+       fallen into the generic `else` branch and been renamed to `.orig`
+       instead of `top-1m.csv` -- wrong destination for the parser to find.
+   No live gz/plain TOP1M provider exists yet (Phase 4 adds DomCop/Majestic),
+   so these two branches are unreachable in production today -- wired ahead for
+   Phase 4, per the phase's stated intent ("the new knobs are ready for Phase 4").
+
+TESTS
+
+Extended tests/php/Top1mPreserveOnEmptyFeedTest.php (all 9 pre-existing test
+methods left BYTE-IDENTICAL, not one line touched) with one new method:
+
+  testSyntheticDescriptorAppliesHeaderSkipAndDomainColumn()
+    Given: top-1m.csv = "rank,tld.rank,domain\n1,1,example.com\n" (the header
+    row deliberately contains a '.' AND a ',' so skipping it can only be
+    attributed to the 'header' knob, never the pre-existing dot/comma content
+    filter) and a synthetic descriptor {parse: 'csv', header: true, domain_col: 2}
+    passed via the new $provider_override param.
+    When: pfblockerng_top1m($syntheticDescriptor)
+    Then: whitelist == ".example.com,,\n,example.com,,\n,www.example.com,,\n"
+    (domain read from index 2) and the main log shows "Parsed 1 lines | Found 1
+    of 1000" (only the data row counted -- the header row was skipped, not
+    misparsed as data).
+
+  RED/GREEN proof (mandatory per CLAUDE.md — behaviour change, not a pure
+  refactor, for this specific knob): stashed pfblockerng.inc +
+  pfblockerng_extra.inc (kept the new test), reran just this test against the
+  pre-P2 ("col-1-only") pfblockerng_top1m():
+    FAILED — Expected ".example.com,,\n,example.com,,\n,www.example.com,,\n",
+    Actual "" (empty). Root cause on old code: the header row IS skipped, but
+    only by ACCIDENT (its first CSV field 'rank' fails the always-on numeric-
+    rank guard); the data row's domain is read from the OLD hardcoded index 1
+    ('1', the tld_rank field, not the domain) -> tld resolves to '' -> no TLD
+    match -> the feed still counts as "valid" (linecnt=1, unrelated to the
+    domain bug) but publishes an EMPTY whitelist.
+  Then unstashed and reran: GREEN (see VERIFICATION #2 below). This is a true
+  fail-before/pass-after proof for the new header/domain_col knobs -- not
+  coverage theater.
+
+  Top1mPreserveOnEmptyFeedTest's original 9 tests + Top1mProvidersTest's 4
+  tests are the behaviour-preservation oracle for tranco/cisco (rank_domain/
+  zip): all pinned pre-existing input/output pairs, run unmodified, and stay
+  green -- proving the P2 refactor did not change tranco/cisco output.
+
+VERIFICATION (all run inside the worktree)
+
+1. `/opt/homebrew/bin/php -l` on all three touched files -> clean (no syntax
+   errors; pre-existing unrelated Deprecated notices for OTHER functions'
+   param ordering, e.g. pfb_download's own `$pflex` before `$logtype` --
+   untouched by this phase, already present before this change).
+
+2. `/opt/homebrew/bin/php vendor/bin/phpunit`:
+   Tests: 2306, Assertions: 18443, Failures: 3, Skipped: 4.
+   The 3 failures are exactly the pre-existing, environment-only
+   `open_basedir` sandbox failures (same three named in Phase 1's handoff):
+     - DnsblPrefetchTest::test_prefetch_leaves_the_store_unseeded_when_a_grep_pass_pattern_file_cannot_be_created
+     - IpPrefetchTest::test_grep_lines_returns_null_when_the_pattern_file_cannot_be_created
+     - IpPrefetchTest::test_prefetch_leaves_the_miss_round_unseeded_when_round_a_pattern_file_cannot_be_created
+   No other failures. `--filter Top1m` alone: 24/24 green (was 23 in Phase 1 +
+   1 new test here), including Top1mPreserveOnEmptyFeedTest's original 9 +
+   Top1mProvidersTest's 4 (both oracles green, unmodified) + the new synthetic-
+   descriptor test.
+
+3. `php -d memory_limit=1G vendor/bin/phpcs --standard=phpcs.xml.dist src/` ->
+   clean (exit 0, no output). Default 128M OOMs as noted in the task brief
+   (environmental, not a violation).
+
+4. `php -d memory_limit=1G vendor/bin/phpstan analyse --memory-limit=1G` ->
+   `[OK] No errors`.
+
+5. Python untouched — `python -m pytest` not run (no src/**/*.py or tests/*.py
+   changed).
+
+SELF-REVIEW (git diff vs phase objectives)
+
+- The builder (pfblockerng_top1m()) reads `parse`/`header`/`domain_col` from
+  the active descriptor (via pfb_top1m_providers() or the test-only
+  $provider_override); the extractor (pfb_download()) reads `container` (zip
+  unchanged, gz/plain newly wired) -- matches ADR §2.3's split exactly ("the
+  builder takes the active descriptor's parse... the extract post-processor
+  honours container").
+- rank_domain/zip is byte-identical: Top1mPreserveOnEmptyFeedTest's original 9
+  assertions (dead feed, garbage feed, rename failures both variants, absent
+  csv, valid-with-matches, valid-with-small-count, valid-with-zero-matches) all
+  pass UNMODIFIED against the new code -- this IS the oracle proving
+  byte-identical Tranco/Cisco output post-refactor.
+- header/domain_col/gz/plain knobs proven: the new synthetic-descriptor test
+  is a genuine red-before/green-after (see TESTS section) for header-skip +
+  domain_col; gz/plain container wiring in pfb_download() is exercised by
+  neither PHPUnit nor a live provider yet (documented gap below), matching the
+  phase's own "no live provider added" scope and tests/php/README.md's
+  documented "pfb_download() as a whole is not off-appliance unit-testable
+  (curl/exec)" boundary -- the pre-existing sibling geoip/asn/blacklist
+  branches in the same function are equally untested at this tier; Phase 4's
+  DomCop/Majestic descriptors will exercise gz/plain end-to-end via the
+  live-VM smoke, per ADR §6 Phase 4's own test plan.
+- No JSON path added, no new provider added (still exactly tranco/cisco,
+  Top1mProvidersTest's `testOnlyTrancoAndCiscoAreDescribedInPhase1` stays
+  green unmodified), geoip's own zip/gz/plain branches are functionally
+  unchanged (only widened by an `||` in the plain branch's OR condition;
+  geoip's own matching arm of that condition is untouched).
+
+DEVIATIONS / JUDGMENT CALLS
+
+- `domain_col` is 0-indexed (matches str_getcsv()'s array index, default 1 =
+  today's hardcoded `$csvline[1]`), not 1-indexed human column numbering. This
+  reconciles the ADR §2.3 text "domain_col (default 1)" with the fact that
+  Tranco/Cisco's domain is the SECOND CSV field: default value 1 as an array
+  index (not "first column") matches both the ADR's stated default AND
+  preserves exact current behaviour. The synthetic test's `domain_col: 2`
+  reads as the THIRD field (0-indexed) accordingly.
+- Widened the pre-existing "plain" branch's `$type == 'geoip' || $type ==
+  'asn'` condition to also include `'top1m'`, even though its comment already
+  said "MaxMind/TOP1M/ASN downloads" -- read this as closing a pre-existing gap
+  between the comment's stated intent and the code, per the ADR's explicit
+  §2.3 "gz/plain write straight to top-1m.csv" requirement, not as an
+  unscoped/gratuitous change.
+- No new PHPUnit test for the gz/plain extractor wiring itself (only the
+  builder's header/domain_col knobs are unit-tested) -- pfb_download() shells
+  out to real `gunzip`/`tar`/`file` and is documented out-of-PHPUnit-scope
+  (tests/php/README.md "Out of scope"); this matches the phase prompt's own
+  VERIFICATION list, which specifies only the builder-knob PHPUnit test, not a
+  download-extractor test.
+
+GO-AHEAD FOR PHASE 3
+
+Ready. Phase 3 ("Header auth in pfb_download()") adds `$extra_headers` +
+`$feed['headers']`, merged into CURLOPT_HTTPHEADER without clobbering the
+conditional-GET header; no caller sets it yet. The provider descriptor's
+`auth` field (currently always 'none' for tranco/cisco) is unused by any
+runtime code path so far -- Phase 3 does not need to read it yet (that's
+Phase 5's Cloudflare wiring); Phase 3 is purely additive plumbing in
+pfb_download()'s signature/CURLOPT_HTTPHEADER construction.
+
+COMMIT
+
+pfblockerng: drive the TOP1M builder + extract from the provider descriptor (ADR-59 P2)

--- a/.ADRs/ADR_59_Top1M_Provider_Framework/RESULTS/03_Results.txt
+++ b/.ADRs/ADR_59_Top1M_Provider_Framework/RESULTS/03_Results.txt
@@ -1,0 +1,199 @@
+================================================================================
+PHASE 3 RESULTS — Header auth in pfb_download() (behaviour-preserving)
+================================================================================
+
+WHAT CHANGED
+
+1. New pure helper `pfb_download_http_headers(array $extra_headers, string
+   $conditional_header = ''): array` (pfblockerng.inc, just above pfb_download())
+   — merges caller-supplied header strings with the ADR-42 conditional-GET
+   header into one list, in order [conditional_header?, ...extra_headers],
+   dropping non-string/empty entries defensively. Pure / no I/O, so it is
+   directly PHPUnit-testable even though pfb_download() itself is not
+   (tests/php/README.md "Out of scope" — curl/exec surface has no off-box
+   double). Extracted specifically so the merge behaviour required by this
+   phase's VERIFICATION section could be pinned without exercising curl.
+
+2. `pfb_download()` (pfblockerng.inc:9874) — new trailing param
+   `array $extra_headers = array()`. Placed AFTER the existing by-ref
+   `&$response_meta = NULL` (the true last parameter) so every existing
+   positional call site (the change-detect probe in pfblockerng.php:554,
+   and the two full-arg IP/DNSBL feed downloads at pfblockerng.inc:16213/
+   17916, none of which reach past `$srcint`) needs NO edit — they simply
+   get the array() default. Only pfblockerng_download_extras()'s call
+   needed a caller-supplied value, wired via a PHP 8.3 named argument
+   (`extra_headers: $feed['headers'] ?? array()`) rather than the ~10-token
+   change positional insertion would have needed across 3 unrelated call
+   sites (ADR-59 explicitly scoped this thread to
+   pfblockerng_download_extras() only, per the phase's ACTION PLAN item 1).
+
+3. Inside the cURL branch's conditional-GET block: the etag branch now sets
+   a local `$conditional_header` string instead of calling
+   curl_setopt(CURLOPT_HTTPHEADER, ...) directly; right after that block,
+   `$http_headers = pfb_download_http_headers($extra_headers,
+   $conditional_header)` is computed once and curl_setopt(CURLOPT_HTTPHEADER,
+   ...) is called ONLY when the merged list is non-empty — reproducing the
+   pre-Phase-3 code path exactly when $extra_headers is empty (today, always
+   — no caller passes anything).
+
+4. `pfblockerng_download_extras()` (pfblockerng.php:635) — threads a new
+   per-feed `$feed['headers']` field (via `$feed['headers'] ?? array()`,
+   since no `$pfb['extras']` row sets it yet) into the new named argument.
+   No descriptor row (tranco/cisco/geoip/asn) sets 'headers' — this is pure
+   plumbing for Phase 5's Cloudflare descriptor.
+
+HOW THE MERGE PRESERVES If-None-Match
+
+The conditional-GET header is computed FIRST into $conditional_header (still
+gated by `$type === 'change_detect'` + a stored ETag, exactly as before), then
+handed to pfb_download_http_headers() as the FIRST list element ahead of
+$extra_headers — so a caller header can never displace it, and vice-versa: the
+helper only ever appends, never overwrites. The pinning test
+(testConditionalGetAndCallerHeaderBothSurviveTheMerge) asserts both strings are
+present simultaneously in the returned list given a synthetic
+'If-None-Match: "etag123"' + a synthetic 'Authorization: Bearer x'.
+
+NO SECRET IS LOGGED
+
+No pfb_logger/log_info call was added or touched to read $extra_headers,
+$conditional_header, or $http_headers — grep confirms the only pfb_logger
+lines inside the touched hunks are the pre-existing srcint-interface log and
+the download-failure log, both untouched by this diff. The existing retry
+logger (pfblockerng.inc ~10199, unchanged this phase) already redacts the URL
+via pfb_redact_url() (#890, confirmed merged into this branch's history at
+commits da4916a5/5c1dd35e). A future caller's Bearer token never reaches
+CURLOPT_HTTPHEADER's log-adjacent code path because CURLOPT_HTTPHEADER values
+are never logged anywhere in pfb_download() — only curl_error()/http_status/
+the redacted URL are.
+
+TESTS
+
+New tests/php/DownloadHttpHeadersTest.php (5 tests, #[CoversFunction
+('pfb_download_http_headers')]), BDD-style Given/When/Then:
+
+  testConditionalGetAndCallerHeaderBothSurviveTheMerge — the phase's mandated
+    pinning case: both a conditional-GET header and a caller Bearer header
+    survive together, exactly 2 elements, neither dropped.
+  testConditionalGetHeaderAloneIsUnchanged — no extra headers + a
+    conditional-GET header -> the SAME single-element list pfb_download()
+    built directly pre-Phase-3 (byte-identical existing-probe behaviour).
+  testCallerHeaderAloneWithNoConditionalGet — the future Cloudflare shape:
+    a caller header with no conditional-GET header rides alone.
+  testBothEmptyProducesEmptyList — every feed today outside an in-flight
+    change_detect probe: empty in, empty out (so pfb_download() skips the
+    curl_setopt entirely, matching pre-Phase-3 exactly).
+  testNonStringAndEmptyEntriesAreDropped — defensive branch: a non-string
+    (int/NULL) or empty-string entry is silently dropped rather than
+    corrupting the CURLOPT_HTTPHEADER list.
+
+This is genuinely new function/behaviour (pfb_download_http_headers() did not
+exist pre-Phase-3), so there is no meaningful "red-before" run against prior
+code (calling a nonexistent function is a fatal error, not a red assertion) —
+consistent with how Phase 2's synthetic-descriptor test was the true
+red/green case and this phase's own VERIFICATION section only asks for the
+merge-list pinning test, not a fail-before/pass-after against old code. The
+BEHAVIOUR-PRESERVING guarantee for every EXISTING caller is what
+testConditionalGetHeaderAloneIsUnchanged + testBothEmptyProducesEmptyList
+pin (the two shapes every real feed hits today).
+
+VERIFICATION (all run inside the worktree)
+
+1. `/opt/homebrew/bin/php -l` on pfblockerng.inc and pfblockerng.php -> both
+   "No syntax errors detected" (same pre-existing unrelated Deprecated
+   notices for other functions' param ordering as Phase 1/2, e.g.
+   pfb_download's own $pflex-before-$logtype — untouched by this phase).
+
+2. `/opt/homebrew/bin/php vendor/bin/phpunit`:
+   Tests: 2311, Assertions: 18450, Failures: 3, Skipped: 4.
+   The 3 failures are exactly the same pre-existing, environment-only
+   `open_basedir` sandbox failures named in Phase 1/2's handoffs
+   (DnsblPrefetchTest::test_prefetch_leaves_the_store_unseeded_when_a_grep_pass_pattern_file_cannot_be_created,
+   IpPrefetchTest::test_grep_lines_returns_null_when_the_pattern_file_cannot_be_created,
+   IpPrefetchTest::test_prefetch_leaves_the_miss_round_unseeded_when_round_a_pattern_file_cannot_be_created)
+   — no other failures. `--filter DownloadHttpHeadersTest` alone: 5/5 green.
+   2311 total = Phase 2's 2306 + 5 new tests here.
+
+3. `php -d memory_limit=1G vendor/bin/phpcs --standard=phpcs.xml.dist src/`
+   -> clean (exit 0, no output). Default 128M OOMs as in prior phases
+   (environmental, not a violation). PFBL-01 (`pfblockerng.inc` scope) stays
+   green — this phase adds no exec/json_encode/path-build call needing
+   pfb_filter() coverage.
+
+4. `php -d memory_limit=1G vendor/bin/phpstan analyse --memory-limit=1G` ->
+   `[OK] No errors`.
+
+5. Python untouched — `python -m pytest` not run (no src/**/*.py or
+   tests/*.py changed).
+
+SELF-REVIEW (git diff vs phase objectives)
+
+- `$extra_headers` param (pfb_download, trailing, typed `array`, default
+  `array()`) + `$feed['headers']` per-feed field (read via `?? array()` in
+  pfblockerng_download_extras()) are both threaded exactly as the ACTION PLAN
+  specifies.
+- The merge preserves If-None-Match AND adds a supplied header — neither
+  clobbers the other: pfb_download_http_headers() always places the
+  conditional-GET header first (when present) and appends every valid extra
+  header after it; there is no code path where setting one discards the
+  other (the OLD code's single curl_setopt(CURLOPT_HTTPHEADER, [etag]) call
+  is now the ONLY curl_setopt(CURLOPT_HTTPHEADER, ...) call in the function,
+  fed the merged list).
+- No existing feed's auth or URL changed: `git diff` touches zero URL
+  literals or `CURLOPT_USERPWD`/username/password logic (both left byte-
+  identical, still gated by `!empty($username) && !empty($password)`
+  unchanged at its original line). The three real call sites that don't
+  pass $extra_headers (pfblockerng.php:554 change-detect probe;
+  pfblockerng.inc:16213 IP feed; pfblockerng.inc:17916 DNSBL feed) are
+  UNCHANGED — the new trailing optional param needs no edit there.
+- No header value is logged (see "NO SECRET IS LOGGED" above) — confirmed
+  by grepping the diff hunks for pfb_logger/log_info calls: only the two
+  pre-existing untouched lines (srcint-interface note, download-failure
+  note) appear, neither reads $extra_headers/$conditional_header/
+  $http_headers.
+- Basic-auth (MaxMind, CURLOPT_USERPWD) and query-param (asn, appended URL
+  token) paths are completely untouched — confirmed by diff: no lines near
+  CURLOPT_USERPWD (pfblockerng.inc ~10148 post-edit) or the asn
+  rawurlencode() call (pfblockerng.php:664) changed.
+- `pfb_top1m_providers()`'s `auth` field (currently always 'none' for
+  tranco/cisco) is still unread by any runtime code path — Phase 3 stays
+  pure plumbing in pfb_download()/pfblockerng_download_extras(), exactly as
+  the Phase 2 handoff's go-ahead predicted; Phase 5 wires Cloudflare's
+  descriptor to actually populate `$feed['headers']`.
+
+DEVIATIONS / JUDGMENT CALLS
+
+- Used a PHP 8.3 named argument (`extra_headers: ...`) at the
+  pfblockerng_download_extras() call site instead of positionally inserting
+  `$extra_headers` before `$srcint`/`&$response_meta` in the signature. The
+  ADR/phase text doesn't mandate a parameter position; placing it after
+  `&$response_meta` (the true last param) means the three OTHER real call
+  sites (pfblockerng.php:554, pfblockerng.inc:16213, pfblockerng.inc:17916)
+  require zero edits, versus a positional insertion which would have forced
+  editing all three (each would need an explicit `array()`/`FALSE` filler
+  argument inserted to keep `$srcint`/`$response_meta` in their old slots).
+  Smaller, safer diff for a purely-additive, no-callers-yet phase.
+- No PHPUnit test exercises pfb_download()'s own curl_setopt(CURLOPT_
+  HTTPHEADER, ...) call directly (only the extracted pfb_download_http_
+  headers() helper is tested) — matches this phase's own VERIFICATION text
+  verbatim ("extract the header-assembly into a testable helper if needed")
+  and the documented tests/php/README.md "Out of scope" boundary for
+  pfb_download()'s curl/exec surface (same boundary Phase 1/2 and the
+  pre-existing ConditionalGetHelpersTest.php already operate under — that
+  file's own docblock states the curl wiring is exercised by live-VM smoke,
+  not PHPUnit).
+
+GO-AHEAD FOR PHASE 4
+
+Ready. Phase 4 ("Add the keyless providers — DomCop, Majestic") adds two new
+descriptor rows (zip/col-2/header for DomCop; plain/col-3/header + CC BY 3.0
+attribution for Majestic) plus their UI options and a Tier-A render
+assertion. It does NOT need $extra_headers (both are keyless, `auth: 'none'`)
+— Phase 3's header-merge plumbing sits dormant until Phase 5's Cloudflare
+descriptor sets `headers`. Phase 4 exercises Phase 2's `container`/`parse`/
+`header`/`domain_col` knobs end-to-end for the first time with LIVE (non-
+synthetic) sample data — the fail-before/pass-after proof Phase 2's own
+go-ahead deferred to Phase 4.
+
+COMMIT
+
+pfblockerng: support caller request headers in pfb_download (ADR-59 P3)

--- a/.ADRs/ADR_59_Top1M_Provider_Framework/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_59_Top1M_Provider_Framework/RESULTS/04_Results.txt
@@ -1,0 +1,261 @@
+================================================================================
+PHASE 4 RESULTS — Add the keyless providers: DomCop top-10M + Majestic Million
+================================================================================
+
+WHAT CHANGED
+
+1. `Top1mSource` enum (pfblockerng_extra.inc ~212) — two new cases:
+   `DomCop = 'domcop'` and `Majestic = 'majestic'`. Legacy `fromLegacy()` still
+   coalesces only the dead `'alexa'` token (and any unknown token) to Tranco;
+   `domcop`/`majestic` are live canonical tokens resolved directly by
+   `self::tryFrom()` in `PfbStoredEnumAdapter::fromStored()` (generic — no
+   per-token code needed).
+
+2. `pfb_top1m_providers()` (pfblockerng_extra.inc ~244) — two new descriptor
+   rows, verified against the LIVE files (fetched during this phase, see
+   "VERIFIED AGAINST LIVE DATA" below):
+
+   DomCop:
+     'url'        => 'https://www.domcop.com/files/top/top10milliondomains.csv.zip'
+     'container'  => 'zip'
+     'parse'      => 'csv'
+     'header'     => TRUE
+     'domain_col' => 1   -- Domain is the 2nd CSV field ("Rank","Domain","Open
+                            Page Rank") -> 0-indexed str_getcsv() position 1
+                            (SAME index Tranco/Cisco's rank_domain parse uses)
+     'auth'       => 'none'
+     'licence'    => ''
+
+   Majestic:
+     'url'        => 'https://downloads.majestic.com/majestic_million.csv'
+     'container'  => 'plain'   -- uncompressed CSV, NOT zipped
+     'parse'      => 'csv'
+     'header'     => TRUE
+     'domain_col' => 2   -- Domain is the 3rd CSV field
+                            (GlobalRank,TldRank,Domain,TLD,...) -> index 2
+     'auth'       => 'none'
+     'licence'    => 'CC BY 3.0 — attribution required'
+
+3. `pfb_cfg_field_vocab()['top1m_source']` (pfblockerng_extra.inc ~1626) and
+   its surrounding docblocks — extended from `['tranco', 'cisco']` to
+   `['tranco', 'cisco', 'domcop', 'majestic']` (the write-side vocabulary the
+   RollbackContractTest rollback contract checks against). The `alexa_type`
+   registry entry (pfb_cfg_registry(), same key/section/default) and
+   `docs/misc/config-gateway.md` comments were updated to match — no new
+   registered field, so the `RequireConfigGateway` sniff's `$registeredPaths`
+   needs no edit (confirmed: phpcs stays clean, see GATES below).
+
+4. `pfblockerng_dnsbl.php`:
+   - `$options_alexa_type` (~197): added `'domcop' => 'DomCop TOP1M'` and
+     `'majestic' => 'Majestic Million TOP1M'`.
+   - `$top1m_text` (~3213 "Whitelist(s) available" list): added a DomCop link
+     and a Majestic link + its CC BY 3.0 attribution sentence (same
+     "distributed under the ... License by: <link>" phrasing already used for
+     GeoIP/ASN attributions in pfblockerng_ip.php, for consistency).
+
+5. Download/extract path (pfblockerng.inc, `pfb_download()`'s post-processor)
+   — CONFIRMED, no code change needed (ACTION PLAN item 3 was a "confirm", not
+   an "implement"): the decompression branch is chosen by the ACTUAL MIME type
+   `pfb_filter(..., PFB_FILTER_FILE_MIME, ...)` returns for the downloaded
+   bytes (libmagic-based), not by the provider's 'container' label or the
+   fixed `file_dwn` extension. The `else` "Uncompressed file format" branch
+   (pfblockerng.inc ~10593) already renames a `type=='top1m'` plain body
+   straight to `top-1m.csv` — this is exactly Majestic's path, wired since
+   Phase 2 (its zip/gz-only extractor generalization). Verified by reading the
+   code; no test needed beyond what the parse tests below already exercise
+   (they feed `top-1m.csv` directly, which is the builder's actual input
+   regardless of which extraction branch produced it).
+
+VERIFIED AGAINST LIVE DATA (not guessed)
+
+Per CLAUDE.md's "don't guess — investigate" principle, both provider URLs were
+fetched live during this phase to confirm the real CSV shape before writing
+descriptor rows + fixture samples:
+  - DomCop (`curl` the zip, `unzip`): header row is
+    `"Rank","Domain","Open Page Rank"` (quoted, no header period) — Domain at
+    str_getcsv() index 1.
+  - Majestic (`curl -r 0-300` a byte range): header row is
+    `GlobalRank,TldRank,Domain,TLD,RefSubNets,RefIPs,IDN_Domain,IDN_TLD,
+    PrevGlobalRank,PrevTldRank,PrevRefSubNets,PrevRefIPs` (unquoted, 12 cols)
+    — Domain at str_getcsv() index 2. Confirms Phase 2's 0-indexed domain_col
+    convention: DomCop's "2nd column" (human/1-indexed) = index 1; Majestic's
+    "3rd column" = index 2 (matches Phase 2 RESULTS/02's explicit statement
+    that domain_col is 0-indexed, not human column count).
+
+TESTS
+
+PHP config-adapter/round-trip (per CLAUDE.md's mandate that a new enum value
+touches its round-trip suite):
+  - tests/php/CfgAdaptersTest.php — Scenario E extended: new
+    testTop1mSourceReadDomCopReturnsDomCop / ...ReadMajesticReturnsMajestic;
+    testTop1mSourceRoundTripCanonicalTokens now loops over all four tokens;
+    testTop1mSourceWriteAcceptsEnumOrString extended to domcop/majestic.
+  - tests/php/CfgGatewayTest.php — testReadPassesThroughLiveTop1mSourceTokens
+    extended with domcop/majestic seed+read assertions.
+  - tests/php/RollbackContractTest.php —
+    testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa's $cases
+    extended with 'domcop'=>DomCop and 'majestic'=>Majestic (FORWARD: reads as
+    their own enum, not coalesced; BACKWARD: writes their own token, still
+    never 'alexa').
+  - tests/php/Top1mProvidersTest.php (Phase 1's oracle) — renamed/adjusted for
+    the now-4-provider table: testFourKeylessProvidersAreDescribed (array_keys
+    == tranco/cisco/domcop/majestic), testDomCopAndMajesticUrlsMatchTheAdrTable
+    (URL pins), testTrancoAndCiscoDescribeTodaysZipRankDomainNoAuthShape
+    (renamed from testBothProvidersDescribeTodaysZipRankDomainNoAuthShape,
+    scoped to just tranco/cisco since domcop/majestic have a DIFFERENT shape
+    on purpose), testDomCopAndMajesticDescribeTheirOwnCsvShape (pins
+    container/parse/header/domain_col/auth/licence for both new rows,
+    including Majestic's 'plain' container and CC BY 3.0 licence string).
+
+FAIL-BEFORE/PASS-AFTER parse tests (tests/php/Top1mPreserveOnEmptyFeedTest.php,
+reusing Phase 2's `pfblockerng_top1m($provider_override)` seam + fixture
+harness):
+
+  - testMajesticRealShapeSampleMisreadsOnLegacyColumnAndParsesCorrectlyViaItsDescriptor
+    Given a REAL-shape Majestic sample (12-col header + 2 real .com domains).
+    BEFORE: `pfblockerng_top1m(array())` — this literally reproduces the
+    pre-ADR-59-Phase-2 hardcoded shape (every knob resolves to its default:
+    parse=rank_domain, header=false, domain_col=1). RED: domain_col=1 reads
+    Majestic's TldRank column (a bare digit) as "domain" instead of the real
+    Domain field at index 2 — neither digit contains a '.', so NO TLD matches
+    and the whitelist ends up completely EMPTY despite two real matching
+    domains being present. AFTER: the actual registered Majestic descriptor
+    (domain_col=2) — GREEN, both domains correctly extracted. This is the
+    phase's literal "would mis-read on the pre-P2 col-1 parser" proof.
+
+  - testDomCopRealShapeSampleMisreadsOnWrongColumnAndParsesCorrectlyViaItsDescriptor
+    Given a REAL-shape DomCop sample (quoted 3-col header + 2 real .com
+    domains). NOTE (transparency, not a shortcut): DomCop's real Domain column
+    happens to sit at the SAME index (1) the pre-P2 legacy default already
+    used, so literally replaying `array()` against DomCop's real sample would
+    NOT diverge (I verified this by hand-tracing the code — the header row
+    also lacks a '.', so it's filtered by the pre-existing generic content
+    check either way) — it would prove nothing about domain_col. To still
+    assert "the col index matters" for DomCop specifically, the BEFORE run
+    instead uses a DELIBERATELY WRONG column (domain_col=2, i.e. Majestic's
+    own index — the "Open Page Rank" field) against DomCop's real sample. RED:
+    misreads "10.00" as domain -> tld "00" -> no match -> empty whitelist.
+    AFTER: the actual registered DomCop descriptor (domain_col=1) — GREEN,
+    both domains correctly extracted (with 'www.' stripped per the existing
+    whitelist convention). This proves the per-provider domain_col wiring is
+    genuinely read from the table (not hardcoded), which is the substantive
+    claim behind "col index matters" even though DomCop's OWN correct value
+    happens to coincide with the historical default.
+
+Tier-A UI (tests/smoke/ui/test_render_smoke.py):
+  test_dnsbl_top1m_source_options_exclude_alexa — extended (not duplicated,
+  same GET) to assert all FOUR live source labels ("Tranco TOP1M", "Cisco
+  Umbrella TOP1M", "DomCop TOP1M", "Majestic Million TOP1M") render, PLUS the
+  Majestic "CC BY" + "3.0" attribution text is present, while the dead
+  "Alexa TOP1M" label / `value="alexa"` stay absent (regression guard
+  unchanged from #877).
+
+GATES (all run inside the worktree)
+
+1. `/opt/homebrew/bin/php -l` on every touched .inc/.php/test file -> "No
+   syntax errors detected" for all.
+
+2. `/opt/homebrew/bin/php vendor/bin/phpunit`:
+   Tests: 2317, Assertions: 18515, Failures: 3, Skipped: 4.
+   The 3 failures are the SAME pre-existing, environment-only `open_basedir`
+   sandbox failures named in every prior phase's handoff (DnsblPrefetchTest /
+   IpPrefetchTest) — no other failures. 2317 total = Phase 3's 2311 + 6 new
+   tests here (2 Top1mProvidersTest, 2 CfgAdaptersTest read tests, 2
+   Top1mPreserveOnEmptyFeedTest parse tests) net of the 1 renamed/removed
+   Phase-1 test (testOnlyTrancoAndCiscoAreDescribedInPhase1 ->
+   testFourKeylessProvidersAreDescribed, same slot).
+
+3. `php -d memory_limit=1G vendor/bin/phpcs --standard=phpcs.xml.dist src/` ->
+   clean (exit 0, no output). `RequireConfigGateway` stays green — no new
+   `config_*_path` call, `alexa_type` is an existing registered key.
+
+4. `php -d memory_limit=1G vendor/bin/phpstan analyse --memory-limit=1G` ->
+   `[OK] No errors`.
+
+5. `python3 -m pytest tests/smoke/ui/test_render_smoke.py --collect-only -q
+   --override-ini="addopts="` -> 61 tests collected, including the extended
+   `test_dnsbl_top1m_source_options_exclude_alexa`.
+
+6. `ruff check tests/smoke/ui/test_render_smoke.py` -> "All checks passed!".
+   `ruff format --check tests/smoke/ui/test_render_smoke.py` -> already
+   formatted.
+
+7. `npx markdownlint-cli2 docs/misc/config-gateway.md` -> 0 errors (the small
+   doc-accuracy update to the vocabulary description).
+
+SELF-REVIEW (git diff vs phase objectives)
+
+- 4 options render on the DNSBL page ($options_alexa_type has exactly
+  tranco/cisco/domcop/majestic) — confirmed by the extended Tier-A test.
+- DomCop/Majestic descriptor rows: container correct (DomCop zip, Majestic
+  PLAIN — verified NOT zip, per the ADR §2.2 table and the live fetch);
+  domain_col indices verified against the LIVE files and cross-checked against
+  Phase 2's explicit 0-indexed convention (RESULTS/02_Results.txt line ~157);
+  header:TRUE for both (both real files ship a header row).
+- The parse tests prove column+header matter via a genuine fail-before/
+  pass-after (Majestic: the literal pre-P2 default column; DomCop: a
+  deliberately wrong column, with the coincidence honestly documented rather
+  than silently claimed as a real regression).
+- Majestic CC BY 3.0 attribution shown in both the help text (www/) and
+  asserted by the Tier-A test.
+- No `top1m_token` field, no Cloudflare descriptor, no auth change — grepped
+  the full diff for "token"/"cloudflare": every "token" hit is the
+  pre-existing `alexa_type` STORED-VALUE vocabulary language, none is a new
+  field. Tranco/Cisco descriptor rows are byte-identical (pinned tests still
+  green: testTrancoUrlIsPinnedToThePreChangeLiteral,
+  testCiscoUrlIsPinnedToThePreChangeLiteral,
+  testTrancoAndCiscoDescribeTodaysZipRankDomainNoAuthShape).
+- Tabs / uppercase TRUE/FALSE preserved throughout (matches surrounding style;
+  phpcs's UppercaseBooleanLiteral sniff stays clean).
+
+DEVIATIONS / JUDGMENT CALLS
+
+- DomCop's fail-before/pass-after does NOT use the literal pre-P2 default
+  (`array()`) as its "before" state, because that would not actually fail for
+  DomCop's real sample (its Domain column coincidentally sits at the same
+  index, 1, the legacy default already used, and its header row happens to
+  lack a '.' so it's filtered by the pre-existing generic content check
+  regardless of the header flag). Using `array()` there would be coverage
+  theater (green before AND after, proving nothing). Instead the "before"
+  state deliberately applies a WRONG column (2, Majestic's own index) to
+  DomCop's real sample, which DOES demonstrably mis-read — a stronger, still
+  load-bearing proof that domain_col is read per-provider from the table
+  (documented transparently in the test's own docblock, not hidden).
+- Small doc-accuracy touch-ups (docs/misc/config-gateway.md, a couple of
+  `pfblockerng_extra.inc` comments) beyond the phase's strict action-plan text
+  — kept minimal (a few lines each) so the vocabulary table and the enum's own
+  comments don't read as stale/wrong immediately after this phase lands.
+- pfb_download()'s decompression path (ACTION PLAN item 3) required NO code
+  change — confirmed by reading pfblockerng.inc's post-processor: it already
+  branches on the ACTUAL downloaded MIME type (libmagic), not the descriptor's
+  'container' label or a fixed filename extension, and Phase 2 already wired
+  the `type=='top1m'` uncompressed-body rename path Majestic needs.
+- `scripts/misc/check_top1m_providers.py` (the CI health-check script) still
+  greps `pfblockerng.php` for a literal `$pfb['extras'][2]['url'] = '...'`
+  string assignment — that assignment became a `pfb_top1m_providers()[...]`
+  function-call expression back in Phase 1, so the script's `_URL_RE` no
+  longer matches anything for the top1m slot. This is PRE-EXISTING (broken
+  since Phase 1, not introduced by this phase) and outside Phase 4's action
+  plan/verification gates (no Python file is in this phase's scope) — flagging
+  it here rather than silently leaving it for a future session to rediscover.
+  Left untouched.
+
+GO-AHEAD FOR PHASE 5
+
+Ready. Phase 5 ("Cloudflare + the token field") adds:
+  - a registered masked `top1m_token` PfbConfig field (section=dnsbl) +
+    PFB_FILTER_TOKEN validator + round-trip test + sniff/inventory entries;
+  - the Cloudflare Radar descriptor (header auth via Phase 3's
+    `$feed['headers']` plumbing, JSON/CSV parse, bucket URL builder);
+  - UI: a JS-toggled token field (shown only when the selected provider's
+    `auth` needs one) + the CC BY-NC non-commercial note;
+  - safe-on-missing/invalid-token behaviour (preserve + warn per #886, no
+    token in logs — Phase 3's `pfb_download_http_headers()` never logs headers,
+    so this should carry through cleanly);
+  - Tier-A + a Tier-B save->reload persistence check for the token field.
+Phase 3's header-auth plumbing (`$extra_headers`/`$feed['headers']`) is fully
+wired and dormant, exactly as predicted — Phase 5 is the first real consumer.
+
+COMMIT
+
+pfblockerng: add DomCop + Majestic keyless TOP1M providers (ADR-59 P4)

--- a/.ADRs/ADR_59_Top1M_Provider_Framework/RESULTS/05_Results.txt
+++ b/.ADRs/ADR_59_Top1M_Provider_Framework/RESULTS/05_Results.txt
@@ -1,0 +1,356 @@
+================================================================================
+PHASE 5 RESULTS — Masked token field + Cloudflare Radar (token via header)
+================================================================================
+
+WHAT CHANGED
+
+1. `top1m_token` — new registered PfbConfig field (pfblockerng_extra.inc
+   ~pfb_cfg_registry(), section `installedpackages/pfblockerngdnsblsettings/
+   config/0`, default '', read/write adapters NULL (plain string), since
+   '4.0.0'). Added its path to `RequireConfigGatewaySniff::$registeredPaths`
+   and the `docs/misc/config-gateway.md` inventory + vocab table.
+
+2. `PFB_FILTER_TOKEN` (pfblockerng.inc, new constant 22 + `pfb_filter()` case)
+   — accepts a base64url/JWT charset `[A-Za-z0-9._~+/=-]`, length 8-512.
+   `PFB_FILTER_WORD` ([A-Za-z0-9_] only) would reject a real token (dashes,
+   dots). Added `'top1m_token'` to `pfb_filter()`'s existing log-suppression
+   exceptions list (alongside the pre-existing `'DNSBL_Download'`) so a
+   REJECTED token is never logged, even at debug level — proven by a
+   dedicated test (see TESTS).
+
+3. `Top1mSource::Cloudflare = 'cloudflare'` — new enum case (pfblockerng_extra
+   .inc). `pfb_cfg_field_vocab()['top1m_source']` extended to include it.
+
+4. `pfb_top1m_providers()` — new Cloudflare descriptor row (see "CLOUDFLARE
+   REALITY vs THE ADR'S GUESS" below for the verified shape).
+
+5. `pfb_top1m_auth_headers(array $provider, string $token): array` — new pure
+   helper (pfblockerng_extra.inc, next to `pfb_top1m_providers()`). Builds the
+   caller header(s) a provider's `auth` descriptor needs: `array()` for a
+   keyless provider (`auth == 'none'`) OR an empty token; one
+   `'Authorization: Bearer <token>'`-shaped line otherwise. Zero I/O, zero
+   `pfb_logger` calls — the ONLY function that ever touches the raw token
+   before it reaches `pfb_download()`.
+
+6. `pfblockerng.php` (~line 160) — the TOP1M extras slot now also sets
+   `$pfb['extras'][2]['headers'] = pfb_top1m_auth_headers($pfb_top1m_provider,
+   (string) PfbConfig::read('top1m_token'))`, consumed by Phase 3's existing
+   `extra_headers: $feed['headers'] ?? array()` plumbing in
+   `pfblockerng_download_extras()`. A no-op for tranco/cisco/domcop/majestic
+   (`auth == 'none'`) even if a stale token happens to be stored.
+
+7. `pfblockerng_top1m()` (pfblockerng.inc ~8337) — FIXED a latent bug the
+   Cloudflare shape exposed: the generic content filter required a comma on
+   EVERY data line (`strpos($line, ',') === FALSE` unconditionally). A
+   single-column CSV (Cloudflare: just `domain`, no rank) has no comma at
+   all, so every real data line was silently skipped regardless of
+   domain_col. Fixed to only require a comma when `$top1m_domcol > 0` (every
+   OTHER provider today) — domain_col 0 still requires a '.'. Byte-identical
+   for every existing provider (all have domain_col > 0); this was a
+   necessary fix, not scope creep — without it Cloudflare's real shape
+   parses to an EMPTY whitelist regardless of the descriptor being correct.
+
+8. `pfblockerng_dnsbl.php` (www):
+   - `$options_alexa_type` += `'cloudflare' => 'Cloudflare Radar'`.
+   - `$pfb_top1m_token_providers` (+ its JSON) — derived from
+     `pfb_top1m_providers()`'s `auth` shape, not hardcoded, so a FUTURE token
+     provider needs no JS edit.
+   - `$top1m_text` — added a Cloudflare Radar link + CC BY-NC 4.0 attribution
+     sentence + a link to Cloudflare's token-creation docs.
+   - New masked `Form_Input('top1m_token', ..., 'password', $pconfig
+     ['top1m_token'] ?? '', ...)` — WRITE-ONLY: `$pconfig['top1m_token']` is
+     NEVER populated from `PfbConfig::read()`; it is only ever set from a
+     redisplayed `$_POST` on a validation error (same as every other field),
+     so a plain GET always renders it blank.
+   - POST validation: a NON-EMPTY `top1m_token` is validated via
+     `PFB_FILTER_TOKEN` (reference `'top1m_token'`, so a reject is never
+     logged); a BLANK submission validates trivially (no error).
+   - POST save: `$pfb['dconfig']['top1m_token']` is assigned ONLY when the
+     posted value is non-empty — a blank POST leaves whatever
+     `readSection()` already loaded there untouched, so an ordinary settings
+     save (which always renders this field blank) can never clear an
+     already-stored token.
+   - JS: `enable_top1m_token()` (driven by `pfb_top1m_token_providers`, a
+     server-derived array) shows/hides the token field based on the selected
+     `#alexa_type`; wired via a new `.change()` handler + initial call in
+     `events.push`.
+
+CLOUDFLARE REALITY vs THE ADR'S GUESS (verified, not guessed)
+
+Per the phase's mandate ("verify Cloudflare's ACTUAL current API before
+coding"), fetched THREE independent official Cloudflare doc pages plus a web
+search corroboration during this phase (network available; no Cloudflare API
+token available to make an authenticated request):
+
+  - developers.cloudflare.com/api/resources/radar/subresources/datasets/
+    (methods list): GET /radar/datasets (list, filter datasetType=
+    RANKING_BUCKET), POST /radar/datasets/download (returns a signed URL),
+    and — the load-bearing find — **GET /radar/datasets/{alias}**, which
+    "Retrieves the CSV content of a given dataset" DIRECTLY (a single
+    request), not the discover-id -> POST /download -> fetch-signed-URL
+    three-hop flow the ADR's §3 "Negative/risks" worried might be
+    "disproportionately complex" (§7 reject criterion).
+  - developers.cloudflare.com/radar/investigate/domain-ranking-datasets/
+    (walkthrough page): the worked example gives the STABLE alias for the
+    1,000,000-domain bucket verbatim — `id: 213`, `alias:
+    "ranking_top_1000000"`, `meta.top: 1000000` — and shows the downloaded
+    CSV has a `domain` column header with NO rank column, sample rows like
+    `1rx.io`, `2mdn.net`, `a2z.com` (bare registrable domains, no `www.`).
+  - A web search independently corroborated the same id/alias/tags
+    (blog.cloudflare.com/radar-domain-rankings/), so this is not a single-
+    source claim.
+  - developers.cloudflare.com/radar/ "About" (via search): the data is CC
+    BY-NC 4.0 (non-commercial, attribution required) — the ADR's "CC BY-NC"
+    note, now pinned to the specific 4.0 version.
+
+CONCLUSION: the real API turned out SIMPLER than the ADR anticipated — a
+single `GET https://api.cloudflare.com/client/v4/radar/datasets/
+ranking_top_1000000` with `Authorization: Bearer <token>` streams the CSV
+directly, fitting the EXISTING single-URL-descriptor architecture exactly
+like every other provider. §7's "ship dormant, drop Cloudflare" escape hatch
+was therefore NOT invoked — it is fully wired, not dormant. The descriptor
+diverges from the ADR's §2.2 table on TWO points, both corrected here:
+  - `domain_col`: ADR guessed 1 (assuming a 2-column rank,domain shape); the
+    REAL body is a SINGLE `domain` column -> domain_col 0.
+  - `auth`: the ADR's table cell said "(csv)" for container with an implicit
+    zip assumption elsewhere; confirmed `container: 'plain'` (uncompressed
+    CSV stream, same family as Majestic's shape) and `header: TRUE`.
+
+Residual gap (disclosed, not hidden): no live authenticated request was made
+end-to-end (no Cloudflare token in this environment) — confirmed via
+documentation only. This is exactly the ADR §7 "manual smoke (owner:
+maintainer)" acceptance item for Cloudflare specifically; a real token on a
+live box is the final proof, unchanged by this phase.
+
+TESTS
+
+New tests/php/Top1mAuthHeadersTest.php (5 tests, #[CoversFunction
+('pfb_top1m_auth_headers')]): Cloudflare-shaped auth produces the Bearer
+header; an empty token produces no header (safe-on-missing-token); a keyless
+provider NEVER emits a header even with a token present (proves the "only
+the active provider consumes it" contract); a missing 'auth' key defaults to
+no header; a schemeless header auth sends the token bare.
+
+tests/php/PfbFilterTest.php — `tokenProvider()`/`testTokenFilter()` (8 cases:
+realistic token, too short, space/colon/quote rejected, too long, exactly
+min/max length); `testTokenFilterRejectionNeverLogsForTop1mTokenReferenceBut
+OtherReferencesStillDo()` — the load-bearing security proof for the
+`pfb_filter()` exceptions-list edit: a rejected secret via reference
+'top1m_token' never reaches the errlog, but the SAME rejected input via any
+OTHER reference still logs (proves the suppression is reference-scoped, not
+a side effect of PFB_FILTER_TOKEN itself silently going quiet).
+
+tests/php/Top1mProvidersTest.php — renamed testFourKeylessProvidersAreDescribed
+-> testFiveProvidersAreDescribed (now asserts all 5 keys); new
+testCloudflareDescribesItsRealSingleColumnAuthedCsvShape (pins url, container
+'plain', parse 'csv', header TRUE, domain_col 0, auth {header:
+'Authorization', scheme: 'Bearer'}, licence containing 'CC BY-NC').
+
+tests/php/Top1mPreserveOnEmptyFeedTest.php — two new tests:
+  - testCloudflareRealShapeSampleParsesViaItsDescriptorAndTheSingleColumnCommaFix
+    FAIL-BEFORE/PASS-AFTER for the comma-relaxation fix (item 7 above).
+    MANUALLY VERIFIED by temporarily reverting just that hunk in
+    pfblockerng.inc and re-running this exact test:
+      RED  (pre-fix):  file_get_contents() on the whitelist path returned
+                       FALSE (file never created — $linecnt stayed 0, every
+                       comma-less line was skipped, "dead feed" path fired,
+                       no rename ever happened). Confirmed via a real
+                       `phpunit --filter` run (see command below), not
+                       assumed.
+      GREEN (post-fix): both real domains extracted correctly; full
+                       Top1mPreserveOnEmptyFeedTest suite (14 tests) green.
+    (The test body itself only exercises the permanent, fixed AFTER state —
+    the red/green cycle was validated by hand per CLAUDE.md's "revert/stash
+    the change" allowance, since there is no provider_override knob that
+    reproduces the pre-fix comma requirement the way the Phase 4 DomCop/
+    Majestic tests reproduce the pre-Phase-2 column default.)
+  - testMissingOrInvalidCloudflareTokenPreservesWhitelistAndLogsNoToken
+    Proves the #886 preserve+warn path (top-1m.csv absent, a prior whitelist
+    exists) is hit UNCHANGED for a failed Cloudflare download — no
+    Cloudflare-specific branch exists to bypass — AND directly asserts a
+    fake secret token never appears in either log (main or error), because
+    `pfblockerng_top1m()` never reads `$pfb['top1m_token']` or any header at
+    all.
+
+tests/php/CfgAdaptersTest.php / CfgGatewayTest.php / RollbackContractTest.php
+— Scenario E / the alexa_type rollback contract / the live-token pass-
+through test all extended with 'cloudflare'; CfgGatewayTest.php also gets a
+new testTop1mTokenDefaultsToEmptyAndRoundTrips (absent -> '', write/read
+round-trips a realistic token verbatim) + 'top1m_token' added to the
+$inventory completeness list.
+
+Tier-A (tests/smoke/ui/test_render_smoke.py) — extended (not duplicated)
+test_dnsbl_top1m_source_options_exclude_alexa: asserts all FIVE source
+labels including "Cloudflare Radar", the CC BY-NC 4.0 note, AND the masked
+token field (`name="top1m_token"` + `type="password"` both present).
+
+Tier-B (tests/smoke/ui/test_functional.py) — new
+test_dnsbl_top1m_token_masked_field_persists_and_is_never_echoed: POSTs a
+real-looking token -> asserts config.xml holds it verbatim (oracle = config,
+never the HTTP body, per this file's own doctrine) -> asserts the very next
+GET's raw HTML never contains it (write-only) -> POSTs a BLANK token (what
+every ordinary settings save actually sends, since the field always renders
+blank) -> asserts config.xml is STILL the original token (blank preserves,
+never clears). Restores the original value directly via the config API in
+`finally` (the web form cannot blank this field by design, so a normal POST
+can't be used for cleanup — mirrors the exact `php_eval` + `_php_str`
+restore idiom already used by test_alerts_render_verify.py:737-739).
+
+GATES (all run inside the worktree)
+
+1. `/opt/homebrew/bin/php -l` on every touched .inc/.php/test file ->
+   "No syntax errors detected" for all (same pre-existing unrelated
+   Deprecated notices as every prior phase).
+
+2. `/opt/homebrew/bin/php vendor/bin/phpunit`:
+   Tests: 2336, Assertions: 18590, Failures: 3, Skipped: 4.
+   The 3 failures are the SAME pre-existing, environment-only `open_basedir`
+   sandbox failures named in every prior phase's handoff (DnsblPrefetchTest /
+   IpPrefetchTest) — no other failures. 2336 = Phase 4's 2317 + 19 new tests
+   here (5 Top1mAuthHeadersTest + 1 CfgAdaptersTest + 1 CfgGatewayTest +
+   1 Top1mProvidersTest (net: 1 rename + 1 new) + 2 Top1mPreserveOnEmptyFeedTest
+   + 9 PfbFilterTest (8 dataprovider cases + 1 dedicated no-log test)).
+
+3. `php -d memory_limit=1G vendor/bin/phpcs --standard=phpcs.xml.dist src/`
+   -> clean (exit 0, no output). `RequireConfigGateway` stays green (the new
+   `top1m_token` path is in `$registeredPaths`, and every read/write in this
+   diff goes through `PfbConfig::read()`/the `writeSection()` bulk-write
+   pattern `alexa_type` et al. already use on this page, not a raw
+   `config_*_path` call). `UppercaseBooleanLiteral` stays green (TRUE/FALSE
+   used throughout the new descriptor row + PFB_FILTER_TOKEN case).
+
+4. `php -d memory_limit=1G vendor/bin/phpstan analyse --memory-limit=1G` ->
+   `[OK] No errors`.
+
+5. `python3 -m pytest tests/smoke/ui/test_render_smoke.py --collect-only -q
+   --override-ini="addopts="` -> 61 tests collected (same count as Phase 4 —
+   the assertion was extended, not duplicated).
+   `python3 -m pytest tests/smoke/ui/test_functional.py --collect-only -q
+   --override-ini="addopts=" -m ui_e2e -k top1m_token` -> 1/51 collected
+   (the new Tier-B test).
+
+6. `ruff check` / `ruff format --check` on both touched .py files -> clean.
+
+7. `npx markdownlint-cli2 docs/misc/config-gateway.md` -> 0 errors (one fix
+   needed: a continuation line starting with "+ the ADR-59 P3..." was
+   reworded to "and the ADR-59 P3..." — markdownlint parsed the leading "+"
+   as a new list-item marker, MD004 list-style violation against this file's
+   dash convention).
+
+SELF-REVIEW (git diff vs phase objectives)
+
+- Token field registered + masked + write-only + validated: confirmed by
+  reading the diff — `$pconfig['top1m_token']` is set ONLY from a
+  redisplayed `$_POST` (error path) or left unset (?? '' on GET), never from
+  `PfbConfig::read()`; grepped the whole diff for any `PfbConfig::read
+  ('top1m_token')` call in `www/` — the only call site is
+  `pfblockerng.php`'s extras-headers wiring, not the UI page.
+- `RequireConfigGatewaySniff::$registeredPaths` includes the new path —
+  confirmed by the clean phpcs run (a missed entry would have failed the
+  sniff the moment `PfbConfig::read/write('top1m_token')` compiled against
+  the registry, since the sniff flags DIRECT config_*_path calls on a
+  registered path found elsewhere — actually confirmed structurally: no
+  direct config_*_path('...top1m_token') call exists anywhere in the diff to
+  begin with, so this is belt-and-suspenders, matching the config-gateway.md
+  "Adding a new registered field" checklist item).
+- Cloudflare's descriptor matches REALITY (not the ADR's guess) — verified
+  against 3 independent official doc pages + 1 search corroboration; the
+  two concrete corrections (domain_col 0 not 1; container 'plain' streamed
+  via a single GET, not a multi-call dataset flow) are both documented
+  inline in the descriptor's own comment AND in this handoff. The §7 "ship
+  dormant" escape hatch was considered and explicitly NOT invoked, because
+  reality turned out to fit the existing architecture cleanly.
+- The token never reaches a log or the request URL: (a) header-carried only
+  (`Authorization: Bearer`, via `pfb_top1m_auth_headers()` + the P3
+  `$feed['headers']` plumbing) — never appended to any URL string; (b)
+  `pfb_top1m_auth_headers()` itself has zero `pfb_logger` calls (grepped);
+  (c) the PFB_FILTER_TOKEN reject path was AUDITED and found to leak the raw
+  rejected token via `pfb_filter()`'s existing "Failed validation [ ... ]"
+  debug log — FIXED by adding `'top1m_token'` to the pre-existing
+  `'DNSBL_Download'` no-log exceptions list (not by reusing 'DNSBL_Download'
+  itself, which would have created an unrelated, fragile coupling — see
+  DEVIATIONS); proven by a dedicated test showing suppression is genuinely
+  reference-scoped, not a blanket change; (d) the missing/invalid-token
+  download-failure path was proven to never touch the token at all, with a
+  fake-secret log-scan assertion, not merely asserted by inspection.
+- Missing-token safe path: reuses the EXACT existing #886 preserve+warn
+  generic path with NO new branch — `pfb_top1m_auth_headers()` returning
+  `array()` for an empty token means no Authorization header is sent, the
+  download fails exactly like any other provider's failed download, and
+  `pfblockerng_top1m()` hits its pre-existing "csv absent" handling
+  unmodified.
+- tranco/cisco/domcop/majestic unchanged: their descriptor rows are
+  byte-identical (only a new row was appended); the comma-relaxation fix is
+  gated on `$top1m_domcol > 0` (true for all four), so their behaviour is
+  unchanged — confirmed by the full green phpunit run including every
+  pre-existing Top1mProvidersTest/Top1mPreserveOnEmptyFeedTest assertion for
+  those four providers.
+- Tabs / uppercase TRUE/FALSE preserved throughout; phpcs's
+  UppercaseBooleanLiteral sniff stays clean.
+
+DEVIATIONS / JUDGMENT CALLS
+
+- Initially reused the PRE-EXISTING `'DNSBL_Download'` reference string to
+  suppress `pfb_filter()`'s failed-validation log for the token-validation
+  call site — this WORKED (the gate is a plain `in_array($reference, ...)`
+  check with no other semantics), but on self-review I judged it a fragile,
+  implicit coupling: `'DNSBL_Download'` is documented elsewhere as meaning
+  "parsed feed lines, suppressed for volume" — a future edit scoping that
+  exception more narrowly (e.g. gating on `$type` too) could silently start
+  logging tokens again with no signal. FIXED before finalizing: added a
+  SECOND, purpose-named entry `'top1m_token'` to the same exceptions array,
+  documented inline, and added a dedicated test proving the suppression is
+  reference-scoped (a different reference for the same rejected input still
+  logs). This is the more robust, self-documenting fix for a security-
+  relevant contract; recorded here since it required touching the shared
+  `pfb_filter()` exceptions list rather than staying purely additive.
+- Fixed the comma-requirement bug in `pfblockerng_top1m()`'s generic content
+  filter (item 7 above) — outside the phase prompt's literal ACTION PLAN
+  text, but REQUIRED for the Cloudflare descriptor to functionally work at
+  all (without it, every real single-column CSV line is silently skipped
+  and the whitelist comes out empty regardless of a correct descriptor).
+  Manually verified fail-before/pass-after by temporarily reverting the hunk
+  (see TESTS) since there is no provider_override knob that reproduces the
+  bug the way Phase 4's tests reproduce the Phase 2 default.
+- `container: 'plain'` for Cloudflare (not a new container type) — Phase
+  4's audit already confirmed the extractor branches on the ACTUAL
+  downloaded MIME type, not the descriptor label, so no extractor code
+  change was needed (same conclusion as Phase 4 reached for Majestic).
+- The Cloudflare descriptor's `url` is a HARDCODED literal
+  (`.../datasets/ranking_top_1000000`), not a `url_builder` callable as the
+  ADR's §2.1 table headline suggested — because the verified reality (a
+  STABLE, documented alias) makes a literal URL exactly as correct and far
+  simpler than a builder function would be; no per-request parameterization
+  (date, format) is needed for the default "latest" behaviour every other
+  provider already gets from a bare literal URL.
+- No live authenticated Cloudflare request was made (no token available in
+  this environment) — the descriptor is verified against documentation only
+  (3 independent official pages + 1 search corroboration), not an empirical
+  fetch. Flagged loudly per the phase's own instruction; this is exactly the
+  ADR §7 "manual smoke (owner: maintainer)" acceptance item for Cloudflare,
+  unchanged by this phase.
+
+GO-AHEAD FOR PHASE 6
+
+Ready. Phase 6 ("Health-check + docs") needs to:
+  - Update `scripts/misc/check_top1m_providers.py` for BOTH known issues:
+    (a) Phase 4's flagged staleness (`_URL_RE` still greps for a literal
+    `$pfb['extras'][2]['url'] = '...'` assignment that no longer exists —
+    the value is now a `pfb_top1m_providers()[...]['url']` expression); (b)
+    classify each descriptor by `auth` (§2.7) — keyless validated as today,
+    a token provider (Cloudflare) checked only if a secret (e.g.
+    `CLOUDFLARE_RADAR_TOKEN`) is present, else explicitly skipped with a
+    logged reason (never silently).
+  - Docs: `docs/misc/config-gateway.md`'s `top1m_token` inventory entry is
+    already in place (this phase); Phase 6's own scope is a TOP1M-providers
+    reference note (sources, formats, licences, token setup) per the ADR's
+    action plan — not yet written.
+  - The ADR's §7 Definition of Done's "manual smoke (owner: maintainer)" for
+    Cloudflare (a real token, live box, confirm `Found N>0` + a blocked-then-
+    whitelisted domain + a forced-failure `extras.log` scan showing no
+    token) remains an out-of-CI, maintainer-owned step — not something
+    Phase 6 can automate.
+
+COMMIT
+
+pfblockerng: add masked TOP1M token field + Cloudflare Radar provider (ADR-59 P5)

--- a/.ADRs/ADR_59_Top1M_Provider_Framework/RESULTS/06_Results.txt
+++ b/.ADRs/ADR_59_Top1M_Provider_Framework/RESULTS/06_Results.txt
@@ -1,0 +1,337 @@
+================================================================================
+PHASE 6 RESULTS (FINAL) -- Health-check for token providers + docs
+================================================================================
+
+WHAT CHANGED
+
+1. `scripts/misc/check_top1m_providers.py` -- REWRITTEN to read the real
+   source of truth. Phase 4 flagged (and left, out of its own scope) that the
+   extractor's `_URL_RE` still greped pfblockerng.php for a literal
+   `$pfb['extras'][2]['url'] = '...'` assignment that Phase 1 replaced with an
+   expression (`pfb_top1m_providers()[...]['url']`) -- the extractor had been
+   silently finding ZERO providers since Phase 1. Fixed:
+   - `DEFAULT_DESCRIPTOR_FILE` now points at
+     `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc`.
+   - `extract_providers()` locates each `Top1mSource::<Case>->value =>
+     array(...)` block via `_PROVIDER_ENTRY_RE` + a paren-balance scanner
+     (`_matching_paren()` -- handles Cloudflare's nested `'auth' =>
+     array(...)`), then reads `url`/`label`/`container`/`auth` per block.
+     Grepped the whole file: `->value` appears exactly 5 times, all inside
+     `pfb_top1m_providers()` (the enum body's `$this->value` doesn't match
+     this pattern) -- no risk of matching an unrelated block.
+   - Auth classification (ACTION PLAN item 1): a structured `'auth' =>
+     array('header' => ..., 'scheme' => ...)` marks a TOKEN provider; the
+     string `'none'` (or anything else unrecognized -- same fail-open-to-
+     no-header default as `pfb_top1m_auth_headers()`) marks KEYLESS. Each
+     extracted provider now carries `auth` ('none'/'token'), `secret_env`,
+     `auth_header`, `auth_scheme` (all `''` for keyless).
+   - **`_secret_env_from_label()`** derives the CI secret env-var name from
+     the provider's own `'label'` field -- "Cloudflare Radar" ->
+     "CLOUDFLARE_RADAR_TOKEN", matching the ADR's own example (S2.7)
+     verbatim, with NO separate provider->secret-name mapping table. A
+     future token provider needs no change to this function: name its repo
+     secret the same way its label derives.
+   - `--check-url` gained `--container {zip,plain}` (default zip, backward
+     compatible), `--secret-env NAME`, `--auth-header NAME` (default
+     Authorization), `--auth-scheme SCHEME` (default Bearer).
+   - `main()`: when `--secret-env` is given and `os.environ.get(NAME)` is
+     unset/empty, prints `SKIP <url>: needs token, no secret configured (env
+     NAME)` and returns 0 -- never fails the run for a missing secret, never
+     silent (ACTION PLAN item 1). When the secret IS present, builds
+     `{header: "{scheme} {token}".strip()}` and calls `check_url()` with it.
+     The token is NEVER printed -- confirmed by a dedicated test asserting a
+     mock token string is absent from BOTH the healthy-OK output and an
+     unhealthy-FAIL report's reasons.
+
+2. NECESSARY FIX beyond the phase's literal ACTION PLAN text (disclosed, same
+   category as Phase 5's comma-relaxation fix): the health-check's row/
+   container validation was ALSO silently broken for 3 of the 5 real
+   providers, discovered while proving the phase's own "REAL --check-url on
+   domcop/majestic should pass" verification gate:
+   - `_scan_csv()` unconditionally treated every fetched body as a ZIP. Two
+     of the five real providers are NOT zips (`container: 'plain'` --
+     Majestic, Cloudflare) -- a real `--check-url` against Majestic's live
+     URL would have failed with "expected a valid non-empty ZIP archive"
+     even though the feed itself is perfectly healthy plain CSV. Fixed:
+     `_scan_csv(body, container)` branches on the caller-supplied
+     `container` (from the descriptor, threaded via `--container`) --
+     'plain' scans the raw body as CSV text directly, no zip unwrap.
+   - `_is_valid_row()` required EXACTLY 2 columns with column 0 an int rank.
+     DomCop's real CSV is 3 columns (Rank,Domain,OpenPageRank) and
+     Cloudflare's is a single `domain` column with no rank at all -- under
+     the old rule, EVERY real row from either shape reads as invalid (valid
+     count stays 0), a hard health-check failure regardless of a correct
+     descriptor. Generalized to `_looks_like_domain()`: a row is valid iff
+     ANY field looks like a dotted domain, provider-agnostic across every
+     descriptor's column layout. A header row's field names ("Domain",
+     "GlobalRank", ...) have no dot, so header rows are naturally excluded
+     with no separate header-skip parameter needed.
+   - Verified this doesn't regress Tranco/Cisco (the only 2 providers this
+     script correctly validated before Phase 1 broke discovery): the
+     generalized row check yields the SAME valid/invalid verdict for every
+     existing malformed-row test case (bare rank/no-dot-domain, bare ".");
+     confirmed via the full green pre-existing-test rerun below.
+
+3. `.github/workflows/top1m-healthcheck.yml` (ACTION PLAN item 2):
+   - `check` job's step now builds `--check-url $URL --container $CONTAINER`
+     and, only when `matrix.secret_env` is non-empty, appends `--secret-env
+     --auth-header --auth-scheme`. `CLOUDFLARE_RADAR_TOKEN: ${{
+     secrets.CLOUDFLARE_RADAR_TOKEN }}` rides the step's `env:` -- a no-op
+     env var for every keyless leg, the actual secret only for the Cloudflare
+     leg (which alone passes `--secret-env CLOUDFLARE_RADAR_TOKEN`). A
+     comment documents the "add one line here, matching the label-derived
+     name" convention for a future token provider.
+   - `alert` job's re-check loop reads the same 4 new JSON fields per
+     provider and builds the same conditional args; a leg whose script exits
+     0 with a `SKIP ` line is now reported as `SKIPPED **name**` (not `OK`)
+     in the tracking-issue body -- distinguishes "genuinely validated
+     healthy" from "not actually checked, no secret" even in the alert
+     report, keeping the "never silently skip" ethos visible end-to-end, not
+     just in the per-leg CI log.
+   - The overall run still goes red only for a genuinely unhealthy leg (a
+     keyless provider that fails, or a token provider whose secret IS
+     present but the fetch/validation still fails) -- a missing secret alone
+     never turns the run red, per the ACTION PLAN.
+
+4. Docs:
+   - `docs/misc/config-gateway.md`'s `top1m_token` inventory entry -- VERIFIED
+     already in place (added by Phase 5, per its own handoff's GO-AHEAD note);
+     re-read it (S2.2's "Adapter inventory", the field-vocabulary table's
+     `top1m_source` row) and confirmed it accurately describes the finished
+     framework with no update needed. NOT duplicated.
+   - New `docs/misc/top1m-providers.md`: the descriptor table's field
+     meanings, a per-provider format/container/auth/licence table (all 5),
+     the Majestic CC BY 3.0 + Cloudflare CC BY-NC 4.0 obligations (and where
+     they render in the UI), how a user supplies the Cloudflare token (the
+     masked `top1m_token` field + its JS toggle + round-trip contract), the
+     CI health-check's auth classification + the secret-naming convention +
+     how to wire a future token provider's secret, and a short "adding a
+     provider" runbook. Sibling of `docs/misc/tld-lists.md` in style/scope
+     (a similarly maintained, non-vendored external-list reference).
+
+TESTS (tests/test_check_top1m_providers.py -- REWRITTEN)
+
+The old suite's PHP fixtures targeted the STALE `$pfb['extras'][2]['url'] =
+'...'` shape; replaced with fixtures mirroring the real descriptor table
+(`_PHP_DESCRIPTOR_TABLE`: 2 keyless zip rows with no label/container --
+exercises the fallback defaults --, 1 keyless plain-CSV row, 1 token row).
+
+FAIL-BEFORE/PASS-AFTER (verified by hand, per CLAUDE.md's revert/stash
+allowance -- `git stash push -- scripts/misc/check_top1m_providers.py` then
+rerun): 16 of the 33 tests FAIL against the pre-Phase-6 script (the extractor
+tests fail because it still parses the old pflockerng.php shape and finds
+nothing; the `--secret-env`/`--container` tests fail with argparse
+"unrecognized arguments" since those flags didn't exist yet); all 33 PASS
+after. Exact counts recorded in GATES below.
+
+New/extended coverage:
+- `test_extract_providers_finds_every_row_in_the_descriptor_table` /
+  `_reads_label_and_container_per_row` -- the rewritten extractor reads the
+  real table shape.
+- `test_extract_providers_classifies_keyless_providers_as_auth_none` /
+  `_classifies_a_token_provider_and_derives_its_secret_env` -- the auth
+  classification + the label->secret-env derivation (pins
+  "Cloudflare Radar" -> "CLOUDFLARE_RADAR_TOKEN" exactly).
+- `test_extract_providers_auto_covers_a_newly_added_descriptor_row` -- the
+  #884 add/remove guarantee, now against the descriptor table: a 5th row
+  (Quad9-shaped) is picked up with zero script changes.
+- `test_extract_providers_skips_a_commented_out_row` -- the pre-existing
+  comment-stripping guarantee, ported to the new fixture shape.
+- `test_extract_providers_falls_back_to_url_netloc_and_zip_container_when_absent`
+  -- a descriptor row missing 'label'/'container' still extracts sanely.
+- `test_validate_top1m_passes_a_plain_container_body_with_no_zip_wrapper` --
+  FAIL-BEFORE/PASS-AFTER for the container-awareness fix (item 2 above): the
+  pre-fix script would have misread a real plain-CSV response as "not a
+  valid ZIP archive".
+- `test_validate_top1m_skips_a_header_row_in_a_plain_wide_csv_with_domain_not_in_column_zero`
+  -- DomCop/Majestic-shaped: header + domain in a non-zero/non-one column,
+  found anywhere in the row.
+- `test_validate_top1m_fails_a_plain_container_body_with_too_few_domain_rows`
+  -- a plain-container garbage body fails via the row-count floor, NOT the
+  "ZIP" message (proves 'plain' never attempts a zip parse).
+- `test_validate_top1m_single_domain_only_column_cloudflare_shape_passes` --
+  Cloudflare's real single-column shape (no rank at all) validates.
+- `test_check_url_passes_the_caller_supplied_headers_through_to_the_request`
+  -- a token's Authorization header actually reaches the outgoing request
+  object, alongside the User-Agent.
+- `test_main_never_calls_check_url_for_a_keyless_provider_and_behaves_as_before`
+  -- before-state: a keyless provider takes the unchanged path (no headers
+  built, check_url called exactly as pre-Phase-6).
+- `test_main_skips_a_token_provider_with_no_reason_to_fail_when_its_secret_is_absent`
+  -- the new skip-not-fail behaviour: `check_url` is asserted NEVER CALLED
+  (raises if it is) when the secret is absent; exit 0; "SKIP"/"needs
+  token"/the env-var name all appear in the output.
+- `test_main_validates_a_token_provider_once_its_mocked_secret_is_present` --
+  the after-state of the SAME scenario (secret present via
+  `monkeypatch.setenv`, standing in for a real repo secret in CI): the
+  provider IS validated, with the exact expected container + header built;
+  the mock token value is asserted absent from the printed output.
+- `test_main_never_prints_the_token_on_an_unhealthy_token_provider_result` --
+  the token stays out of a FAIL report too, not just a healthy one.
+- All pre-existing zip/staleness/is_stale/check_url/main tests kept, ported
+  to the new fixture/message text where the wording changed (e.g. "valid
+  domain rows" replacing the now-inaccurate "valid 'rank,domain' rows" since
+  a valid row is no longer defined as exactly 2 columns).
+
+GATES (all run inside the worktree)
+
+1. `ruff check scripts/misc/check_top1m_providers.py
+   tests/test_check_top1m_providers.py` -> All checks passed.
+2. `ruff format --check` (same two files) -> both already formatted.
+3. `python3 -m mypy tests/test_check_top1m_providers.py
+   scripts/misc/check_top1m_providers.py` -> Success: no issues found in 2
+   source files (required a `list[tuple[str, ...]]` annotation on 6
+   pre-existing `rows = [...]` lines -- mypy's list invariance rejected the
+   narrower `list[tuple[str, str]]` inference against `_zip_of`'s widened
+   signature; no behaviour change, annotation only).
+4. `python3 -m pytest tests/test_check_top1m_providers.py -q` -> 33 passed.
+   Fail-before check (`git stash` the script only, same test file): 16
+   failed / 17 passed -- the 16 are exactly the new-behaviour tests (proves
+   real red->green, not coverage theater).
+5. `python3 -m pytest -q` (full suite) -> 2211 passed, 4 skipped (same 4
+   pre-existing skips as every prior phase).
+6. `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/top1m-
+   healthcheck.yml'))"` -> no error.
+7. `actionlint .github/workflows/top1m-healthcheck.yml` (with
+   `-shellcheck=shellcheck`, both installed) -> no output, exit 0.
+8. `npx markdownlint-cli2 docs/misc/top1m-providers.md` -> 0 errors.
+
+REAL (LIVE NETWORK) VERIFICATION
+
+`--extract` against the real `pfblockerng_extra.inc` on this branch lists
+all 5 providers with the expected auth classification:
+
+  Tranco            auth=none
+  Cisco Umbrella    auth=none
+  DomCop            auth=none
+  Majestic Million  auth=none
+  Cloudflare Radar  auth=token  secret_env=CLOUDFLARE_RADAR_TOKEN
+                    auth_header=Authorization  auth_scheme=Bearer
+
+`--check-url` against the real, live URLs (no vendoring, per this script's
+whole design):
+
+  Tranco (zip)            -> OK  healthy (>= 100000 rows, not stale)
+  Cisco Umbrella (zip)     -> OK  healthy (>= 100000 rows, not stale)
+  DomCop (zip)             -> FAIL -- expected Last-Modified within 30 days
+                              of 2026-07-06T14:55:28Z, found 'Sun, 29 Mar
+                              2026 11:30:31 GMT' (99 days old)
+  Majestic Million (plain) -> OK  healthy (>= 100000 rows, not stale)
+
+DomCop's failure is a REAL, EXTERNAL staleness finding against the live
+DomCop server at test time (system clock independently confirmed via `date
+-u` = 2026-07-06, matching the script's own UTC `now`) -- NOT a parsing/
+extraction bug: the fetch succeeded, the body parsed as a valid zip, and the
+row count comfortably cleared the floor (no "ZIP"/"found 0" error at all,
+only the staleness reason). This is the health-check correctly doing its
+job (#884's whole purpose) on DomCop's top-10M list, which apparently
+refreshes less often than daily. NOT loosened/masked -- that would defeat
+the point of a staleness gate. Flagging this transparently rather than
+tuning `MAX_AGE_DAYS` to force a pass: a per-provider staleness threshold
+(or accepting DomCop is simply slower-cadence) is a policy call for the
+maintainer, out of this phase's scope.
+
+`--check-url` against the real Cloudflare Radar URL with NO
+`CLOUDFLARE_RADAR_TOKEN` set in this environment (confirmed via `unset
+CLOUDFLARE_RADAR_TOKEN` first):
+
+  SKIP https://api.cloudflare.com/client/v4/radar/datasets/
+       ranking_top_1000000: needs token, no secret configured (env
+       CLOUDFLARE_RADAR_TOKEN)
+  exit=0
+
+Exactly the required behaviour: visible, never silent, never fails the leg.
+
+SELF-REVIEW (git diff vs phase objectives)
+
+- Extractor reads the descriptor table, not the stale pflockerng.php literal
+  -- confirmed: `DEFAULT_DESCRIPTOR_FILE` points at pfblockerng_extra.inc;
+  `--extract` on the real file lists all 5 providers (was silently 0 before
+  this phase, per Phase 4's flagged staleness).
+- Token providers skip-with-reason without a secret, validate with one --
+  confirmed by both the unit tests (mock env var) AND the two real runs
+  above (no-secret skip; the secret-present path is unit-tested since no
+  real Cloudflare token exists in this environment -- consistent with every
+  prior phase's disclosed residual gap, ultimately the ADR S7 manual-smoke
+  item).
+- Keyless unchanged in outward contract ("GET-validate as today") --
+  Tranco/Cisco's real health-check verdict is unchanged (both OK, as they
+  would have been had the extractor not been silently broken since Phase 1);
+  DomCop/Majestic are NEWLY and CORRECTLY covered for the first time (their
+  "today" was silently never-run, so there is no prior behaviour to regress)
+  -- the container/row-validity generalization was REQUIRED to make that
+  coverage real rather than a false-failing no-op, verified not to change
+  any existing zip/rank-domain test's pass/fail verdict.
+- The discover-floor guard (from #884, `[ "$COUNT" -ge 1 ]`) -- untouched;
+  still fires if the extractor ever regresses to finding zero providers.
+- Docs record the framework + licences + token setup -- new
+  docs/misc/top1m-providers.md covers the descriptor fields, the 5-provider
+  table, both licence obligations, the token-setup path, the CI
+  classification + secret-naming convention, and an "adding a provider"
+  runbook; config-gateway.md's top1m_token entry verified already present
+  (Phase 5), not duplicated.
+- No secret ever printed -- grepped every `print(...)` call site in
+  main()/check_url(); the token only ever reaches the `headers` dict passed
+  straight to `urllib.request.Request`, never a log/print argument. A
+  dedicated test asserts a mock token string is absent from stdout on both
+  a healthy and an unhealthy token-provider run.
+
+DEVIATIONS / JUDGMENT CALLS
+
+- Generalized `_scan_csv()`'s container handling (zip vs plain) and
+  `_is_valid_row()`'s column assumption (exactly 2 columns, rank-then-
+  domain) beyond the phase's literal ACTION PLAN text (which named only
+  "auth" extraction) -- REQUIRED because the phase's own verification gate
+  ("REAL --check-url on domcop/majestic should pass") cannot hold otherwise:
+  Majestic/Cloudflare are plain CSV (the old code unconditionally assumed
+  zip) and DomCop/Majestic/Cloudflare all have more than 2 columns or the
+  domain outside column 1 (the old code required exactly 2 columns with
+  column 0 numeric). Same category and justification as Phase 5's comma-
+  relaxation fix in `pfblockerng_top1m()` -- a necessary fix surfaced by
+  making a previously-dead code path (the extractor, broken since Phase 1)
+  live again, not scope creep. Verified byte-for-byte behaviour preservation
+  for every pre-existing zip/rank-domain test case.
+- DomCop's real feed is currently 99 days stale against this script's
+  30-day `MAX_AGE_DAYS` default -- NOT adjusted. Loosening the threshold to
+  force a green real-world check would defeat the point of a staleness
+  gate; this is a genuine external-data finding to hand to the maintainer,
+  not a code defect in this phase's diff. Disclosed prominently above rather
+  than silently working around it.
+- `_secret_env_from_label()` derives the CI secret name from the
+  descriptor's `label` field rather than a hardcoded per-provider mapping
+  table -- chosen because it needs ZERO code change for a future token
+  provider (only a new repo secret + one workflow env line), matches the
+  ADR's own example name exactly for Cloudflare, and avoids a second place
+  (beyond the descriptor itself) that could drift out of sync with a
+  provider's actual name.
+- The workflow's `check`/`alert` `run:` blocks use a bash array
+  (`args=(...)`) rather than string concatenation for the conditional
+  `--secret-env`/`--auth-header`/`--auth-scheme` args -- avoids word-
+  splitting/quoting hazards entirely (correct-by-construction over correct-
+  by-convention); GitHub Actions' default shell on ubuntu-latest is bash, so
+  this is not a POSIX-sh violation (CLAUDE.md's POSIX-sh rule targets
+  `#!/bin/sh` *.sh scripts, not workflow YAML `run:` blocks, which already
+  use bash-availabe constructs like `<<<` heredocs elsewhere in this same
+  file).
+
+ADR-59 DEFINITION OF DONE (S7) -- REMAINING MANUAL ITEMS
+
+All six phases are now merged. Per S7, the following remain the maintainer's
+own manual-smoke acceptance gate (CI cannot exercise these):
+  - A live per-provider download + resolve check on a real pfSense box for
+    DomCop, Majestic, and Cloudflare (with a real Cloudflare token): run an
+    Update and confirm "Building TOP1M Whitelist ... Found N" with N > 0,
+    and that a blocked-then-whitelisted popular domain resolves.
+  - For Cloudflare specifically: after a forced download failure (e.g. an
+    invalid/expired token), confirm `extras.log` shows NO token value in
+    either the main or error log.
+  - Licence notes visible in the live UI for Majestic + Cloudflare (already
+    covered by Tier-A render assertions per Phase 4/5, but S7 asks for a
+    final human look on a real box).
+This phase's CI health-check (`top1m-healthcheck.yml`) complements, but does
+not replace, that manual gate -- it validates the DOWNLOAD URLs are alive and
+fresh; it does not exercise pfBlockerNG's own DNSBL build/resolve pipeline.
+
+COMMIT
+
+ci: health-check token TOP1M providers + document the provider framework (ADR-59 P6)

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -1,15 +1,20 @@
 name: Top1M Provider Health Check
 
-# Weekly health-check of every external Top1M provider URL we ship
-# (issue #884). We do NOT vendor these lists (they're ~1M rows, runtime-downloaded
-# per box) -- this is validate-only, the guard that would have caught the
-# Alexa Top1M source rotting silently (its hardcoded URL died years ago;
-# cleaned up in #877).
+# Weekly health-check of every external Top1M provider we ship (issue #884,
+# generalized to a provider framework by ADR-59). We do NOT vendor these
+# lists (they're up to ~10M rows, runtime-downloaded per box) -- this is
+# validate-only, the guard that would have caught the Alexa Top1M source
+# rotting silently (its hardcoded URL died years ago; cleaned up in #877).
 #
-# scripts/misc/check_top1m_providers.py --extract reads the provider URLs
-# straight out of pfblockerng.php's top1m extras slot, so adding/removing a
-# provider needs no edit here. --check-url fetches + validates one URL (a
-# real zip, plausible row count, not stale) and exits nonzero if unhealthy.
+# scripts/misc/check_top1m_providers.py --extract reads every provider
+# straight out of pfb_top1m_providers()'s descriptor table
+# (pfblockerng_extra.inc), so adding/removing a provider row needs no edit
+# here. --check-url fetches + validates one URL (a real list, plausible row
+# count, not stale) and exits nonzero if unhealthy. A TOKEN provider (its
+# descriptor's 'auth' needs a header, e.g. Cloudflare Radar) is validated only
+# when its matching repo secret is configured (env CLOUDFLARE_RADAR_TOKEN
+# below) -- absent secret ⇒ the leg visibly SKIPs and exits 0, it never fails
+# the run merely for lacking a secret (ADR-59 S2.7).
 
 on:
   # Weekly, Monday 07:00 UTC (an hour after tld-refresh, different concern).
@@ -22,16 +27,16 @@ permissions:
   contents: read
 
 jobs:
-  # ── 1. Discover every provider URL from pfblockerng.php ──────────────────
+  # ── 1. Discover every provider from pfb_top1m_providers() ────────────────
   discover:
-    name: Discover Top1M provider URLs
+    name: Discover Top1M providers
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.extract.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
 
-      - name: Extract provider URLs
+      - name: Extract providers
         id: extract
         run: |
           set -eu
@@ -60,12 +65,26 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Check provider URL
+      - name: Check provider
         env:
           URL: ${{ matrix.url }}
+          CONTAINER: ${{ matrix.container }}
+          SECRET_ENV: ${{ matrix.secret_env }}
+          AUTH_HEADER: ${{ matrix.auth_header }}
+          AUTH_SCHEME: ${{ matrix.auth_scheme }}
+          # The one token secret currently wired (Cloudflare Radar). A future
+          # token provider adds its own "NAME: ${{ secrets.NAME }}" line here,
+          # matching the env-var name check_top1m_providers.py derives from
+          # its descriptor's 'label' (see _secret_env_from_label) -- no other
+          # workflow change needed.
+          CLOUDFLARE_RADAR_TOKEN: ${{ secrets.CLOUDFLARE_RADAR_TOKEN }}
         run: |
           set -eu
-          python3 scripts/misc/check_top1m_providers.py --check-url "$URL"
+          args=(--check-url "$URL" --container "$CONTAINER")
+          if [ -n "$SECRET_ENV" ]; then
+            args+=(--secret-env "$SECRET_ENV" --auth-header "$AUTH_HEADER" --auth-scheme "$AUTH_SCHEME")
+          fi
+          python3 scripts/misc/check_top1m_providers.py "${args[@]}"
 
   # ── 3. On any failed leg, open/update ONE deduped tracking issue ──────────
   alert:
@@ -80,6 +99,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      # See the "check" job -- same secret, same derivation rule.
+      CLOUDFLARE_RADAR_TOKEN: ${{ secrets.CLOUDFLARE_RADAR_TOKEN }}
     steps:
       - uses: actions/checkout@v6
 
@@ -105,10 +126,23 @@ jobs:
           while [ "$i" -lt "$COUNT" ]; do
             NAME=$(jq -r ".[$i].name" /tmp/providers.json)
             URL=$(jq -r ".[$i].url" /tmp/providers.json)
+            CONTAINER=$(jq -r ".[$i].container" /tmp/providers.json)
+            SECRET_ENV=$(jq -r ".[$i].secret_env" /tmp/providers.json)
+            AUTH_HEADER=$(jq -r ".[$i].auth_header" /tmp/providers.json)
+            AUTH_SCHEME=$(jq -r ".[$i].auth_scheme" /tmp/providers.json)
             i=$((i + 1))
 
-            if python3 scripts/misc/check_top1m_providers.py --check-url "$URL" > /tmp/check_out.txt 2>&1; then
-              printf -- "- OK **%s** (\`%s\`)\n" "$NAME" "$URL" >> "$BODY_FILE"
+            args=(--check-url "$URL" --container "$CONTAINER")
+            if [ -n "$SECRET_ENV" ]; then
+              args+=(--secret-env "$SECRET_ENV" --auth-header "$AUTH_HEADER" --auth-scheme "$AUTH_SCHEME")
+            fi
+
+            if python3 scripts/misc/check_top1m_providers.py "${args[@]}" > /tmp/check_out.txt 2>&1; then
+              if grep -q '^SKIP ' /tmp/check_out.txt; then
+                printf -- "- SKIPPED **%s** (\`%s\`) -- %s\n" "$NAME" "$URL" "$(cat /tmp/check_out.txt)" >> "$BODY_FILE"
+              else
+                printf -- "- OK **%s** (\`%s\`)\n" "$NAME" "$URL" >> "$BODY_FILE"
+              fi
             else
               {
                 printf -- "- FAILING **%s** (\`%s\`)\n\n\`\`\`text\n" "$NAME" "$URL"

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -31,10 +31,20 @@ field, reasoning about rollback/downgrade, or checking the foreign-key exclusion
     vocabulary spans `config.xml`, the ini, and the Python `IdnMode` enum.
   - **`alexa_type` → `Top1mSource`** (issue #877 review, registry adapters
     `pfb_cfg_top1m_source_read/write`): tokens `'tranco'` (default) / `'cisco'` / `'domcop'` /
-    `'majestic'` (the latter two added ADR-59 P4). The legacy `'alexa'` token (the dead Alexa
+    `'majestic'` (added ADR-59 P4) / `'cloudflare'` (added ADR-59 P5, the first
+    token-authenticated provider). The legacy `'alexa'` token (the dead Alexa
     TOP1M service, #872) is READ-only — `fromLegacy()` coalesces it (and any unknown/absent
     token) to `Tranco`, and a write never re-emits it. The stored config key stays `alexa_type`
     — no rename.
+  - **`top1m_token`** (ADR-59 P5, plain string — `NULL`/`NULL` adapters): a masked,
+    write-only credential (currently consumed only by the `cloudflare` `alexa_type`,
+    ignored by every other provider), fed to `pfb_download()` via `pfb_top1m_auth_headers()`
+    and the ADR-59 P3 header-auth plumbing (`Authorization: Bearer <token>`). Default `''`.
+    Never echoed back on GET (`pfblockerng_dnsbl.php`); a blank POST preserves the
+    existing stored value rather than clearing it — the field has no "off" state to
+    round-trip, just identity pass-through like any other plain field. Validated on POST
+    by `PFB_FILTER_TOKEN` (`pfblockerng.inc`) — a base64url/JWT charset
+    (`[A-Za-z0-9._~+/=-]`), NOT `PFB_FILTER_WORD` (which would reject a real token).
 - **Python** (`pfb_unbound.py`): the **`IdnMode` enum** shares that vocabulary — `All = 'on'`,
   `Confusable = 'confusable'`, `Off = 'off'` — and reads the ini `idn_mode` token directly (the
   legacy `python_idn` fallback is retained for a config predating the key). Toggle/lenient enums
@@ -87,7 +97,7 @@ at/after that version; it is a per-field scope marker, not a migration.
 | `lenient`           | `{'on', 'off', ''}` — `''` is a LEGACY READ token (pre-ADR-22 absent); write emits `'off'` |
 | `idn`               | write `{'on' (=All), 'confusable', 'off'}`; legacy reads `'all'`→Off, `''`→Off (4.0.0-alpha `'all'` not carried) |
 | `alias_delta_mode`  | `{'auto', 'delta', 'replace'}` — unknown/absent token reads as `'auto'` (ADR-40, since 4.0.0) |
-| `top1m_source`      | write `{'tranco' (default), 'cisco', 'domcop', 'majestic'}` (ADR-59 P4); legacy read `'alexa'`→Tranco (dead service, #872), never re-emitted |
+| `top1m_source`      | write `{'tranco' (default), 'cisco', 'domcop', 'majestic', 'cloudflare'}` (domcop/majestic ADR-59 P4, cloudflare ADR-59 P5); legacy read `'alexa'`→Tranco (dead service, #872), never re-emitted |
 | `plain`             | identity — any stored value passes through unchanged |
 
 **Excluded fields** — none. `pfb_idn` was previously excluded (`NULL`/`NULL` identity adapters);

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -30,11 +30,11 @@ field, reasoning about rollback/downgrade, or checking the foreign-key exclusion
     (alpha compatibility is intentionally not maintained) — it reads as Off. One canonical
     vocabulary spans `config.xml`, the ini, and the Python `IdnMode` enum.
   - **`alexa_type` → `Top1mSource`** (issue #877 review, registry adapters
-    `pfb_cfg_top1m_source_read/write`): tokens `'tranco'` (default) / `'cisco'`. The legacy
-    `'alexa'` token (the dead Alexa TOP1M service, #872) is READ-only — `fromLegacy()` coalesces
-    it (and any unknown/absent token) to `Tranco`, and a write never re-emits it, so the write
-    vocabulary is only `'tranco'`/`'cisco'` (downgrade-safe: an older release already understands
-    both). The stored config key stays `alexa_type` — no rename.
+    `pfb_cfg_top1m_source_read/write`): tokens `'tranco'` (default) / `'cisco'` / `'domcop'` /
+    `'majestic'` (the latter two added ADR-59 P4). The legacy `'alexa'` token (the dead Alexa
+    TOP1M service, #872) is READ-only — `fromLegacy()` coalesces it (and any unknown/absent
+    token) to `Tranco`, and a write never re-emits it. The stored config key stays `alexa_type`
+    — no rename.
 - **Python** (`pfb_unbound.py`): the **`IdnMode` enum** shares that vocabulary — `All = 'on'`,
   `Confusable = 'confusable'`, `Off = 'off'` — and reads the ini `idn_mode` token directly (the
   legacy `python_idn` fallback is retained for a config predating the key). Toggle/lenient enums
@@ -87,7 +87,7 @@ at/after that version; it is a per-field scope marker, not a migration.
 | `lenient`           | `{'on', 'off', ''}` — `''` is a LEGACY READ token (pre-ADR-22 absent); write emits `'off'` |
 | `idn`               | write `{'on' (=All), 'confusable', 'off'}`; legacy reads `'all'`→Off, `''`→Off (4.0.0-alpha `'all'` not carried) |
 | `alias_delta_mode`  | `{'auto', 'delta', 'replace'}` — unknown/absent token reads as `'auto'` (ADR-40, since 4.0.0) |
-| `top1m_source`      | write `{'tranco' (default), 'cisco'}`; legacy read `'alexa'`→Tranco (dead service, #872), never re-emitted |
+| `top1m_source`      | write `{'tranco' (default), 'cisco', 'domcop', 'majestic'}` (ADR-59 P4); legacy read `'alexa'`→Tranco (dead service, #872), never re-emitted |
 | `plain`             | identity — any stored value passes through unchanged |
 
 **Excluded fields** — none. `pfb_idn` was previously excluded (`NULL`/`NULL` identity adapters);

--- a/docs/misc/top1m-providers.md
+++ b/docs/misc/top1m-providers.md
@@ -1,0 +1,91 @@
+# TOP1M providers — reference (ADR-59)
+
+The DNSBL **TOP1M Whitelist** feature (DNSBL Configuration page → *TOP1M Whitelist*) downloads a
+"most popular domains" list and whitelists it, to cut false positives on feeds that block full
+URLs (PhishTank, OpenPhish, MalwarePatrol, …). ADR-59 turned the single hardcoded Tranco/Cisco
+pair into a provider framework — a new source is a descriptor row, not a code fork. This note
+records the framework, the per-provider shapes, the licence obligations, and how a user supplies
+Cloudflare's token. Sibling of `docs/misc/tld-lists.md` (a similarly maintained, non-vendored
+external list).
+
+## The descriptor table
+
+`pfb_top1m_providers()` in `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc` is the single
+source of truth — every provider is one row:
+
+- **`url`** — the download URL (a stable literal; no per-request parameterization is needed for
+  the default "latest" behaviour any provider ships today).
+- **`container`** — `'zip'` or `'plain'` (uncompressed). Read by `pfb_download()`'s extractor.
+- **`parse`** — `'rank_domain'` (Tranco/Cisco's original 2-column shape) or `'csv'` (a general
+  `str_getcsv()` read using `domain_col`). Read by `pfblockerng_top1m()` (`pfblockerng.inc`).
+- **`header`** — whether the file's first row is a header to skip.
+- **`domain_col`** — the 0-indexed `str_getcsv()` column holding the domain.
+- **`auth`** — `'none'` (keyless) or `array('header' => ..., 'scheme' => ...)` for a
+  token-authenticated provider. Consumed by `pfb_top1m_auth_headers()`, which builds the header
+  `pfb_download()` sends — never a query-string token.
+- **`label`** / **`licence`** — the UI's option text and licence note.
+
+`pfblockerng.php` selects the active row via `$pfb['dnsbl_top1m_type']`/`Top1mSource` and wires
+its `url`/`headers` into the `extras[2]` download slot; no per-provider `if`/`elseif` remains.
+
+## Providers
+
+| Provider | Format | Container | Auth | Licence |
+| -------- | ------ | --------- | ---- | ------- |
+| Tranco | rank,domain CSV | zip | none | — |
+| Cisco Umbrella | rank,domain CSV | zip | none | — |
+| DomCop (top 10M) | `"Rank","Domain","Open Page Rank"` CSV, header | zip | none | — |
+| Majestic Million | `GlobalRank,TldRank,Domain,TLD,...` CSV, header | plain | none | CC BY 3.0 — attribution required |
+| Cloudflare Radar (top 1M bucket) | single `domain` column CSV, header | plain | `Authorization: Bearer <token>` | CC BY-NC 4.0 — non-commercial use, attribution required |
+
+## Licence obligations
+
+**Majestic Million** is distributed under **CC BY 3.0** — attribution to Majestic is required.
+**Cloudflare Radar** is distributed under **CC BY-NC 4.0** — non-commercial use only, attribution
+to Cloudflare required. Both notes render on the DNSBL Configuration page next to the source
+picker (`$top1m_text` in `pfblockerng_dnsbl.php`) so a user selecting either sees the obligation
+before enabling it; pfBlockerNG does not enforce non-commercial use, the user is on their own.
+
+## Supplying the Cloudflare token
+
+Cloudflare Radar needs a Cloudflare API token (a free account, Radar read scope — see the
+in-page link to Cloudflare's own token-creation docs). It is entered in the masked `top1m_token`
+field, shown only when *Cloudflare Radar* is the selected TOP1M source (JS
+`enable_top1m_token()`, driven by which descriptor rows have a non-`'none'` `auth`). The field is
+write-only — never echoed back on a page load — and round-trips through the registered
+`PfbConfig` field of the same name (see `docs/misc/config-gateway.md`'s inventory). A blank save
+preserves the existing stored token rather than clearing it, since the field always renders
+blank.
+
+## CI health-check
+
+`scripts/misc/check_top1m_providers.py` (`.github/workflows/top1m-healthcheck.yml`, weekly) reads
+the descriptor table via `--extract` and validates each provider via `--check-url` — a real
+recent list, not just a 200. It classifies by `auth`:
+
+- **Keyless** providers are always fetched and validated.
+- A **token** provider is validated only when its CI secret is configured, else the leg **prints
+  a visible `SKIP … needs token, no secret configured` line and exits 0** — it never fails the
+  run merely for lacking a secret, and it never fails silently either.
+
+The secret's env-var name is **derived from the provider's `label`**, not hand-mapped —
+`_secret_env_from_label()` turns `"Cloudflare Radar"` into `CLOUDFLARE_RADAR_TOKEN` (the
+convention the ADR itself names). Wiring a new token provider's secret is: add the repo secret
+under that derived name, then add one `NAME: ${{ secrets.NAME }}` line to the `check` (and
+`alert`) jobs' `env:` in the workflow — no other script or workflow change.
+
+## Adding a provider
+
+1. Add a row to `pfb_top1m_providers()` (url/container/parse/header/domain_col/auth/label/licence).
+2. Add its option to `$options_alexa_type` in `pfblockerng_dnsbl.php`; extend `$top1m_text` with
+   its licence note if it carries one.
+3. If it needs a token, no code changes are required beyond the descriptor's `auth` field — the
+   masked field, its JS toggle, and the CI health-check's classification are all derived from it.
+4. Add Tier-A UI coverage (the new option + any licence text renders); extend the relevant
+   PHPUnit descriptor/parsing tests.
+
+## Out of scope
+
+Vendoring/embedding any of these lists; Chrome CrUX (BigQuery-only, not a bulk downloadable
+list) and OpenPageRank (a per-domain API, not a bulk list); per-provider tokens (one shared
+`top1m_token` field suffices — only one source is active at a time).

--- a/scripts/misc/check_top1m_providers.py
+++ b/scripts/misc/check_top1m_providers.py
@@ -6,16 +6,31 @@ hardcoded URL died years ago; cleaned up in #877). This script gives the
 weekly top1m-healthcheck.yml workflow something to fail on the day the next
 provider dies the same way.
 
+ADR-59 moved the provider URLs off a literal `$pfb['extras'][2]['url'] = '...'`
+assignment in pfblockerng.php into a descriptor table,
+`pfb_top1m_providers()` (pfblockerng_extra.inc) -- this script reads THAT
+table instead, and now also classifies each provider by its descriptor's
+`auth`: keyless providers are GET-validated as always; a token provider
+(e.g. Cloudflare Radar) is validated only when its matching CI secret is
+present, else visibly skipped (never silently -- #884's own ethos).
+
 We do NOT vendor the ~1M-row lists -- they're runtime-downloaded per box.
-This is validate-only: fetch, check it's a real recent Top1M zip, report.
+This is validate-only: fetch, check it's a real recent Top1M list, report.
 
 Two modes:
-  --extract           Parse pfblockerng.php for every URL wired to the
-                       top1m extras slot, print as a JSON list to stdout.
-                       Feeds the workflow's matrix -- add/remove a provider
-                       arm in the PHP and this picks it up with no edit here.
+  --extract           Parse pfblockerng_extra.inc's pfb_top1m_providers()
+                       descriptor table, print every provider as a JSON list
+                       to stdout (name/url/container/auth/secret_env/
+                       auth_header/auth_scheme). Feeds the workflow's
+                       matrix -- add/remove a descriptor row and this picks
+                       it up with no edit here.
   --check-url <url>   Fetch + validate one URL. Prints an expected-vs-actual
-                       report. Exit 0 = healthy, non-zero = unhealthy.
+                       report. Exit 0 = healthy (or visibly skipped for a
+                       token provider with no configured secret), non-zero
+                       = unhealthy. Options: --container {zip,plain}
+                       (default zip); --secret-env NAME (env var holding the
+                       token -- absent/empty ⇒ skip, never fail) plus
+                       --auth-header/--auth-scheme to shape the header.
 
 Dev-host tooling (scripts/): bare `python3` is fine here, this never runs on
 the pfSense appliance (CLAUDE.md's appliance-python carve-out).
@@ -28,6 +43,7 @@ import csv
 import http.client
 import io
 import json
+import os
 import re
 import sys
 import urllib.error
@@ -44,58 +60,120 @@ MIN_ROWS = 100_000
 MAX_AGE_DAYS = 30
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_PHP_FILE = REPO_ROOT / "src/usr/local/www/pfblockerng/pfblockerng.php"
+DEFAULT_DESCRIPTOR_FILE = REPO_ROOT / "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 
-# Matches "$pfb['extras'][N]['url'] = '...'" / "...['type'] = '...'" regardless
-# of which if/elseif/else arm assigns it -- an extras index can be assigned
-# more than once (each arm is a separate match tied to the same index N), so a
-# new provider arm is picked up with no change to this script.
-_URL_RE = re.compile(r"\$pfb\['extras'\]\[(\d+)\]\['url'\]\s*=\s*'([^']*)'")
-_TYPE_RE = re.compile(r"\$pfb\['extras'\]\[(\d+)\]\['type'\]\s*=\s*'([^']*)'")
+# Matches "Top1mSource::<Case>->value => array(" -- the start of one provider's
+# descriptor block in pfb_top1m_providers()'s return array. Unique to that
+# table (grepped): every other `->value` use in the file is `$this->value`
+# inside the enum body, which this pattern doesn't match.
+_PROVIDER_ENTRY_RE = re.compile(r"Top1mSource::\w+->value\s*=>\s*array\(")
+_URL_FIELD_RE = re.compile(r"'url'\s*=>\s*'([^']*)'")
+_LABEL_FIELD_RE = re.compile(r"'label'\s*=>\s*'([^']*)'")
+_CONTAINER_FIELD_RE = re.compile(r"'container'\s*=>\s*'([^']*)'")
+# The structured shape 'auth' takes for a token provider (see
+# pfb_top1m_auth_headers()'s docblock): array('header' => '...', 'scheme' => '...').
+# Any other 'auth' value (the string 'none', or anything unrecognized) reads as
+# keyless -- mirrors pfb_top1m_auth_headers()'s own fail-open-to-no-header default.
+_AUTH_TOKEN_RE = re.compile(r"'auth'\s*=>\s*array\(\s*'header'\s*=>\s*'([^']*)'\s*,\s*'scheme'\s*=>\s*'([^']*)'\s*\)")
 
 
 def _strip_php_line_comments(php_text: str) -> str:
     """Drop whole-line `//`-commented-out lines before extraction.
 
-    Without this, a commented-out `// $pfb['extras'][2]['url'] = '...dead...'`
+    Without this, a commented-out `// Top1mSource::Dead->value => array(...`
     is still picked up as a live provider (the regex matches raw text). A
-    trailing comment on a live line (`'...zip';  // Cisco`) is unaffected --
-    the URL is already matched before the comment starts.
+    trailing comment on a live line is unaffected -- the field is already
+    matched before the comment starts.
 
-    ponytail: only whole-line `//` comments are stripped, matching this file's
-    style; a `/* */` block comment would need its own handling if ever used
-    here.
+    ponytail: only whole-line `//` comments are stripped, matching this
+    file's style; a `/* */` block comment would need its own handling.
     """
     return "\n".join(line for line in php_text.splitlines() if not line.strip().startswith("//"))
 
 
-def extract_providers(php_text: str) -> list[dict[str, str]]:
-    """Every URL wired to the top1m extras slot in pfblockerng.php.
-
-    Groups by extras index so a URL assigned in an if/elseif/else arm is
-    matched to its slot's type regardless of assignment order in the file.
-
-    Ceiling: matches single-quoted, non-concatenated URL literals only (the
-    current pfblockerng.php style) -- a double-quoted string or a `'base' .
-    $token` concatenation would need extending _URL_RE.
-    """
-    php_text = _strip_php_line_comments(php_text)
-    types = dict(_TYPE_RE.findall(php_text))
-    providers: list[dict[str, str]] = []
-    seen: set[tuple[str, str]] = set()
-    for idx, url in _URL_RE.findall(php_text):
-        if not url or types.get(idx) != "top1m":
-            continue
-        if (idx, url) in seen:
-            continue
-        seen.add((idx, url))
-        providers.append({"name": _name_from_url(url), "url": url})
-    return providers
+def _matching_paren(text: str, open_idx: int) -> int:
+    """Index of the ')' that balances the '(' at text[open_idx]."""
+    depth = 0
+    for i in range(open_idx, len(text)):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+    raise ValueError("unbalanced parentheses scanning a provider descriptor block")
 
 
 def _name_from_url(url: str) -> str:
-    # Cosmetic only -- just needs to be distinct/readable per provider.
+    # Cosmetic fallback only, used when a block has no 'label' field.
     return urlparse(url).netloc or url
+
+
+def _secret_env_from_label(label: str) -> str:
+    """Derive the CI secret env-var name for a token provider from its label.
+
+    "Cloudflare Radar" -> "CLOUDFLARE_RADAR_TOKEN" -- matches the ADR's own
+    example secret name (ADR-59 S2.7), so a future token provider needs no
+    separate name-mapping table: give its repo secret the same derived name
+    as its descriptor's 'label'.
+    """
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", label).strip("_").upper()
+    return f"{slug}_TOKEN"
+
+
+def extract_providers(php_text: str) -> list[dict[str, str]]:
+    """Every provider row in `pfb_top1m_providers()`'s descriptor table.
+
+    ADR-59 moved the TOP1M URLs off a literal
+    `$pfb['extras'][2]['url'] = '...'` assignment in pfblockerng.php into the
+    descriptor table in pfblockerng_extra.inc -- a new provider row (or a
+    removed one) is picked up here with zero code change, same add/remove
+    guarantee issue #884 originally asked for, now against the real source
+    of truth.
+
+    Ceiling: matches the table's current single-quoted, non-concatenated
+    literal style; a double-quoted string or `'base' . $expr` concatenation
+    would need extending the field regexes.
+    """
+    php_text = _strip_php_line_comments(php_text)
+    providers: list[dict[str, str]] = []
+    for match in _PROVIDER_ENTRY_RE.finditer(php_text):
+        open_idx = match.end() - 1  # the '(' this match ends on
+        close_idx = _matching_paren(php_text, open_idx)
+        block = php_text[open_idx : close_idx + 1]
+
+        url_match = _URL_FIELD_RE.search(block)
+        if not url_match or not url_match.group(1):
+            continue
+        url = url_match.group(1)
+
+        label_match = _LABEL_FIELD_RE.search(block)
+        name = label_match.group(1) if label_match else _name_from_url(url)
+
+        container_match = _CONTAINER_FIELD_RE.search(block)
+        container = container_match.group(1) if container_match else "zip"
+
+        token_match = _AUTH_TOKEN_RE.search(block)
+        if token_match:
+            auth = "token"
+            auth_header, auth_scheme = token_match.group(1), token_match.group(2)
+            secret_env = _secret_env_from_label(name)
+        else:
+            auth = "none"
+            auth_header = auth_scheme = secret_env = ""
+
+        providers.append(
+            {
+                "name": name,
+                "url": url,
+                "container": container,
+                "auth": auth,
+                "secret_env": secret_env,
+                "auth_header": auth_header,
+                "auth_scheme": auth_scheme,
+            }
+        )
+    return providers
 
 
 def _parse_http_date(value: str | None) -> datetime | None:
@@ -131,24 +209,56 @@ def is_stale(last_modified: str | None, now: datetime, max_age_days: int) -> boo
     return (now - modified) > timedelta(days=max_age_days)
 
 
-def _is_valid_row(row: list[str]) -> bool:
-    """A plausible Top1M row: "<int rank>,<dotted domain>" -- rejects a bare "."."""
-    if len(row) != 2:
+def _looks_like_domain(value: str) -> bool:
+    """A plausible dotted domain label: no whitespace, >= 2 non-empty labels."""
+    value = value.strip()
+    if not value or any(c.isspace() for c in value):
         return False
-    rank, domain = row[0].strip(), row[1].strip()
-    if not rank.isdigit() or any(c.isspace() for c in domain):
-        return False
-    labels = domain.split(".")
+    labels = value.split(".")
     return len(labels) >= 2 and all(labels)
 
 
-def _scan_csv(body: bytes) -> tuple[str, int, int, tuple[int, list[str]] | None]:
-    """Open `body` as a zip and scan its CSV member.
+def _is_valid_row(row: list[str]) -> bool:
+    """A plausible Top1M row: at least one field looks like a dotted domain.
 
-    Returns (member_name, total_rows, valid_rows, first_bad_row). May raise
-    zipfile.BadZipFile on a non-zip / corrupt body (the caller catches zip-shape
-    errors); it does not raise KeyError.
+    Provider-agnostic across every descriptor shape -- Tranco/Cisco's 2-col
+    rank+domain, DomCop's 3-col Rank/Domain/OpenPageRank, Majestic's wide
+    12-col layout, Cloudflare's bare single 'domain' column. The health-check
+    only needs proof real domain rows are still flowing, not which exact
+    column holds them. A header row's field names ("Domain", "GlobalRank",
+    ...) have no dot, so header rows fail this check with no separate
+    header-skip needed.
     """
+    return any(_looks_like_domain(field) for field in row)
+
+
+def _scan_rows(text: io.TextIOBase, member: str) -> tuple[str, int, int, tuple[int, list[str]] | None]:
+    total = 0
+    valid = 0
+    first_bad: tuple[int, list[str]] | None = None
+    for line_num, row in enumerate(csv.reader(text), start=1):
+        if not row:
+            continue
+        total += 1
+        if _is_valid_row(row):
+            valid += 1
+        elif first_bad is None:
+            first_bad = (line_num, row)
+    return member, total, valid, first_bad
+
+
+def _scan_csv(body: bytes, container: str = "zip") -> tuple[str, int, int, tuple[int, list[str]] | None]:
+    """Scan `body`'s CSV rows per its descriptor `container` ('zip'/'plain').
+
+    Returns (member_name, total_rows, valid_rows, first_bad_row). 'zip' may
+    raise zipfile.BadZipFile on a non-zip/corrupt body (the caller catches
+    zip-shape errors); 'plain' scans the raw body as CSV text directly --
+    Majestic and Cloudflare ship an uncompressed CSV, not a zip.
+    """
+    if container == "plain":
+        text: io.TextIOBase = io.TextIOWrapper(io.BytesIO(body), encoding="utf-8", errors="replace", newline="")
+        return _scan_rows(text, "(plain body)")
+
     with zipfile.ZipFile(io.BytesIO(body)) as zf:
         names = zf.namelist()
         if not names:
@@ -156,18 +266,7 @@ def _scan_csv(body: bytes) -> tuple[str, int, int, tuple[int, list[str]] | None]
         member = next((n for n in names if n.lower().endswith(".csv")), names[0])
         with zf.open(member) as fh:
             text = io.TextIOWrapper(fh, encoding="utf-8", errors="replace", newline="")
-            total = 0
-            valid = 0
-            first_bad: tuple[int, list[str]] | None = None
-            for line_num, row in enumerate(csv.reader(text), start=1):
-                if not row:
-                    continue
-                total += 1
-                if _is_valid_row(row):
-                    valid += 1
-                elif first_bad is None:
-                    first_bad = (line_num, row)
-    return member, total, valid, first_bad
+            return _scan_rows(text, member)
 
 
 def validate_top1m(
@@ -176,10 +275,11 @@ def validate_top1m(
     now: datetime,
     min_rows: int = MIN_ROWS,
     max_age_days: int = MAX_AGE_DAYS,
+    container: str = "zip",
 ) -> list[str]:
     """Validate a fetched Top1M payload. Empty return = healthy."""
     try:
-        member, total, valid, first_bad = _scan_csv(body)
+        member, total, valid, first_bad = _scan_csv(body, container)
     except zipfile.BadZipFile as exc:
         return [f"expected a valid non-empty ZIP archive, got {len(body)} bytes that failed to parse ({exc})"]
 
@@ -187,8 +287,7 @@ def validate_top1m(
     if valid < min_rows:
         detail = f"; first bad row at {member}:{first_bad[0]}: {first_bad[1]!r}" if first_bad else ""
         reasons.append(
-            f"expected >= {min_rows} valid 'rank,domain' rows in {member!r}, "
-            f"found {valid} (of {total} total rows){detail}"
+            f"expected >= {min_rows} valid domain rows in {member!r}, found {valid} (of {total} total rows){detail}"
         )
     if is_stale(last_modified, now, max_age_days):
         modified = _parse_http_date(last_modified)
@@ -203,10 +302,27 @@ def validate_top1m(
     return reasons
 
 
-def check_url(url: str, min_rows: int = MIN_ROWS, max_age_days: int = MAX_AGE_DAYS) -> list[str]:
-    """Fetch `url` and validate it. Empty return = healthy."""
+def check_url(
+    url: str,
+    min_rows: int = MIN_ROWS,
+    max_age_days: int = MAX_AGE_DAYS,
+    container: str = "zip",
+    headers: dict[str, str] | None = None,
+) -> list[str]:
+    """Fetch `url` and validate it. Empty return = healthy.
+
+    `headers` (if given) rides the request alongside the User-Agent -- the
+    only caller is main()'s token-provider path, building an
+    Authorization header from a CI secret that is never logged or echoed:
+    the header VALUE never appears in any reason string this function or
+    validate_top1m() returns (both only ever quote HTTP status/exception
+    text and the response body's own row content).
+    """
     now = datetime.now(timezone.utc)
-    request = urllib.request.Request(url, headers={"User-Agent": "pfBlockerNG-top1m-healthcheck/1.0"})
+    request_headers = {"User-Agent": "pfBlockerNG-top1m-healthcheck/1.0"}
+    if headers:
+        request_headers.update(headers)
+    request = urllib.request.Request(url, headers=request_headers)
     try:
         with urllib.request.urlopen(request, timeout=120) as resp:
             body = resp.read()
@@ -215,7 +331,7 @@ def check_url(url: str, min_rows: int = MIN_ROWS, max_age_days: int = MAX_AGE_DA
     except urllib.error.HTTPError as exc:
         return [f"expected HTTP 2xx, got HTTP {exc.code} {exc.reason}"]
     except (urllib.error.URLError, OSError, http.client.HTTPException) as exc:
-        # Covers the whole fetch+read span: resp.read() on a multi-MB zip can
+        # Covers the whole fetch+read span: resp.read() on a multi-MB body can
         # raise IncompleteRead/socket.timeout/ConnectionResetError mid-download
         # -- none are urllib.error.URLError, so a narrower except let those
         # raise a raw traceback instead of a clean FAIL report (#884 review).
@@ -223,22 +339,45 @@ def check_url(url: str, min_rows: int = MIN_ROWS, max_age_days: int = MAX_AGE_DA
 
     if not (200 <= status < 300):
         return [f"expected HTTP 2xx, got HTTP {status}"]
-    return validate_top1m(body, last_modified, now, min_rows, max_age_days)
+    return validate_top1m(body, last_modified, now, min_rows, max_age_days, container)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--extract", action="store_true", help="print every top1m provider URL as JSON")
+    group.add_argument("--extract", action="store_true", help="print every top1m provider as JSON")
     group.add_argument("--check-url", metavar="URL", help="fetch + validate one provider URL")
+    parser.add_argument(
+        "--container", choices=("zip", "plain"), default="zip", help="--check-url's body shape (default: zip)"
+    )
+    parser.add_argument(
+        "--secret-env",
+        metavar="ENVVAR",
+        default="",
+        help="--check-url: env var holding the auth token; unset/empty ⇒ visibly skip (never fail)",
+    )
+    parser.add_argument("--auth-header", metavar="NAME", default="Authorization", help="token provider header name")
+    parser.add_argument("--auth-scheme", metavar="SCHEME", default="Bearer", help="token provider header scheme")
     args = parser.parse_args(argv)
 
     if args.extract:
-        providers = extract_providers(DEFAULT_PHP_FILE.read_text(encoding="utf-8"))
+        providers = extract_providers(DEFAULT_DESCRIPTOR_FILE.read_text(encoding="utf-8"))
         print(json.dumps(providers))
         return 0
 
-    reasons = check_url(args.check_url)
+    headers = None
+    if args.secret_env:
+        # A token provider (ADR-59 S2.7): validated only when its CI secret is
+        # actually configured -- never fail the run merely because a maintainer
+        # hasn't wired one yet; that's a config gap, not a dead provider.
+        token = os.environ.get(args.secret_env, "").strip()
+        if not token:
+            print(f"SKIP {args.check_url}: needs token, no secret configured (env {args.secret_env})")
+            return 0
+        header_value = f"{args.auth_scheme} {token}".strip() if args.auth_scheme else token
+        headers = {args.auth_header: header_value}
+
+    reasons = check_url(args.check_url, container=args.container, headers=headers)
     if not reasons:
         print(f"OK  {args.check_url}: healthy (>= {MIN_ROWS} rows, not stale)")
         return 0

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9865,13 +9865,46 @@ function pfb_redact_url($url) {
 }
 
 
+// ADR-59 Phase 3: merge caller-supplied HTTP headers with the ADR-42 conditional-GET
+// header into one CURLOPT_HTTPHEADER list -- neither clobbers the other. Pure / no I/O,
+// so it is unit-testable off-appliance (pfb_download() itself is not: tests/php/README.md
+// "Out of scope" -- its curl/exec surface has no off-box double).
+//
+// $extra_headers: caller-supplied header strings (e.g. 'Authorization: Bearer <token>').
+//   A non-string or empty entry is dropped defensively rather than corrupting the list.
+// $conditional_header: the ADR-42 conditional-GET header ('If-None-Match: <etag>'), or
+//   '' when no conditional-GET validator applies (the common case for every feed today).
+//
+// @return string[] the merged list, conditional-GET header first -- preserves the
+//   pre-Phase-3 single-element list byte-for-byte when $extra_headers is empty (today,
+//   always -- no caller sets it yet).
+function pfb_download_http_headers(array $extra_headers, string $conditional_header = ''): array
+{
+	$headers = array();
+	if ($conditional_header !== '') {
+		$headers[] = $conditional_header;
+	}
+	foreach ($extra_headers as $extra_header) {
+		if (is_string($extra_header) && $extra_header !== '') {
+			$headers[] = $extra_header;
+		}
+	}
+	return $headers;
+}
+
+
 // Function to download feeds
 //
 // Optional $response_meta — when a non-NULL reference is passed (detector probe mode), it is
 // filled with an array: ['status' => <http_status_string>, 'etag' => <ETag string or ''>,
 // 'lastmod' => <epoch int or 0>]. The two sync callers in pfblockerng.inc (lines ~12436 and
 // ~14096) do NOT pass this argument, so their behaviour is entirely unchanged.
-function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $logtype, $vtype='', $timeout=300, $type='', $username='', $password='', $srcint=FALSE, &$response_meta=NULL) {
+//
+// Optional $extra_headers (ADR-59 Phase 3) — caller-supplied HTTP header strings (e.g. a
+// future Cloudflare Radar 'Authorization: Bearer <token>'), merged with the conditional-GET
+// header via pfb_download_http_headers() above. No caller passes this yet; every existing
+// feed keeps its current CURLOPT_HTTPHEADER behaviour exactly.
+function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $logtype, $vtype='', $timeout=300, $type='', $username='', $password='', $srcint=FALSE, &$response_meta=NULL, array $extra_headers=array()) {
 	global $pfb;
 	$http_status = '';
 	$elog = ">> {$pfb['log']} 2>&1";
@@ -10080,6 +10113,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				// (primary); Last-Modified epoch → CURLOPT_TIMECONDITION (fallback).
 				// Only applied to the probe ('change_detect') mode: the sync ingest callers
 				// pass $type == '' and must always receive the full body.
+				$conditional_header = '';
 				if ($type === 'change_detect') {
 					// Read the validators the detector persisted at {header}.orig, NOT the
 					// probe's infixed {file_dwn}.orig (= {header}.md5.orig) — see
@@ -10087,12 +10121,23 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					// sent and the server can never answer 304 (ADR-42 §3 fast-path).
 					$validators = pfb_validator_read(pfb_conditional_get_validator_base($file_dwn));
 					if (is_string($validators['etag']) && $validators['etag'] !== '') {
-						curl_setopt($ch, CURLOPT_HTTPHEADER, array("If-None-Match: {$validators['etag']}"));
+						$conditional_header = "If-None-Match: {$validators['etag']}";
 					} elseif (is_int($validators['lastmod']) && $validators['lastmod'] > 0) {
 						curl_setopt($ch, CURLOPT_TIMECONDITION, CURL_TIMECOND_IFMODSINCE);
 						curl_setopt($ch, CURLOPT_TIMEVALUE, $validators['lastmod']);
 					}
 				}
+
+				// ADR-59 Phase 3: merge caller-supplied headers (none yet) with the
+				// conditional-GET header above -- neither list clobbers the other. Skips
+				// the curl_setopt entirely when both are empty (today, every feed except
+				// an in-flight change_detect probe with a stored ETag), matching the
+				// pre-Phase-3 behaviour byte-for-byte.
+				$http_headers = pfb_download_http_headers($extra_headers, $conditional_header);
+				if (!empty($http_headers)) {
+					curl_setopt($ch, CURLOPT_HTTPHEADER, $http_headers);
+				}
+
 				if ($srcint) {
 					curl_setopt($ch, CURLOPT_INTERFACE, $srcint);	// Use a specific interface when downloading lists
 					pfb_logger("\nList: {$header} will be downloaded via interface: {$srcint}\n", 1);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8248,13 +8248,29 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 
 
 // Process TOP1M database
-function pfblockerng_top1m() {
+// $provider_override (ADR-59 P2 test seam): when given, its 'parse'/'header'/
+// 'domain_col' knobs drive the builder directly instead of resolving through
+// pfb_top1m_providers()[$pfb['dnsbl_top1m_type']->value] -- lets a unit test
+// exercise a synthetic descriptor's knobs without a live provider. Production
+// never passes it, so the resolved-provider path is exactly today's behaviour.
+function pfblockerng_top1m(?array $provider_override = NULL) {
 	global $pfb;
 
 	if (empty($pfb['dnsbl_top1m_inc'])) {
 		pfb_logger("\n  TOP1M: No TLD Inclusions found.\n", 1);
 		return;
 	}
+
+	// ADR-59 P2: the active provider descriptor drives the parse knobs below.
+	// $pfb['dnsbl_top1m_type'] may be unset in an isolated unit-test context
+	// (it is normally set by pfb_global() -- PfbConfig::read('alexa_type') --
+	// which some tests never call); default to Tranco, the same absent-default
+	// the registry itself uses, so the resolved shape stays rank_domain/zip.
+	$top1m_type	= $pfb['dnsbl_top1m_type'] ?? Top1mSource::Tranco;
+	$top1m_provider	= $provider_override ?? (pfb_top1m_providers()[$top1m_type->value] ?? array());
+	$top1m_parse	= $top1m_provider['parse'] ?? 'rank_domain';
+	$top1m_header	= $top1m_provider['header'] ?? FALSE;
+	$top1m_domcol	= $top1m_provider['domain_col'] ?? 1;
 
 	// Array of TLDs to include in Whitelist
 	$pfb_include = explode(',', $pfb['dnsbl_top1m_inc']);
@@ -8292,7 +8308,18 @@ function pfblockerng_top1m() {
 			pfb_logger("\n  TOP1M: could not create the temp whitelist file -- keeping the previous TOP1M whitelist.\n", 2);
 		}
 		else {
+			// ADR-59 P2: skip exactly the first physical line unconditionally when
+			// the provider ships a header row -- before the content filter below, so
+			// a header line's shape (which may not even contain a '.'/',') never
+			// matters.
+			$top1m_pending_header = $top1m_header;
+
 			while (($line = @fgets($handle)) !== FALSE) {
+
+				if ($top1m_pending_header) {
+					$top1m_pending_header = FALSE;
+					continue;
+				}
 
 				if (strpos($line, '.') === FALSE || strpos($line, ',') === FALSE || empty($line)) {
 					continue;
@@ -8303,13 +8330,14 @@ function pfblockerng_top1m() {
 					pfb_logger('.', 1);
 				}
 
-				// Collect Domain TLD -- only a row whose rank column is numeric counts as
-				// real parsed source data. A prose/HTML/error body (e.g. "error, service
-				// temporarily unavailable.") still has a '.' and a ',' and would otherwise
-				// pass the filter above, so a dead feed would classify as "valid" below
-				// and wipe the whitelist (#886 review).
+				// Collect Domain TLD -- for the 'rank_domain' parse (Tranco/Cisco), only a
+				// row whose rank column is numeric counts as real parsed source data. A
+				// prose/HTML/error body (e.g. "error, service temporarily unavailable.")
+				// still has a '.' and a ',' and would otherwise pass the filter above, so a
+				// dead feed would classify as "valid" below and wipe the whitelist (#886
+				// review). Other parse modes have no rank column to guard on.
 				$csvline = str_getcsv($line, ',', '"', "\\");
-				if (!ctype_digit((string) ($csvline[0] ?? ''))) {
+				if ($top1m_parse === 'rank_domain' && !ctype_digit((string) ($csvline[0] ?? ''))) {
 					continue;
 				}
 				// Count every valid CSV row BEFORE the match/break below, so a
@@ -8317,17 +8345,18 @@ function pfblockerng_top1m() {
 				// still leaves $linecnt > 0 and classifies as a valid feed
 				// (not the dead-feed $linecnt === 0 path) (#886 review).
 				$linecnt++;
-				$tld = substr($csvline[1], strrpos($csvline[1], '.') + 1);
+				$domain = $csvline[$top1m_domcol] ?? '';
+				$tld = substr($domain, strrpos($domain, '.') + 1);
 
 				if (isset($pfb_include[$tld])) {
 					// Whitelist both 'www.example.com' and 'example.com'
-					if (str_starts_with($csvline[1], 'www.')) {
-						$csvline[1] = substr($csvline[1], 4);
+					if (str_starts_with($domain, 'www.')) {
+						$domain = substr($domain, 4);
 					}
 					$x++;
 
 					// Create three whitelist options per TOP1M whitelisted Domain
-					@fwrite($pfb_output, ".{$csvline[1]},,\n,{$csvline[1]},,\n,www.{$csvline[1]},,\n");
+					@fwrite($pfb_output, ".{$domain},,\n,{$domain},,\n,www.{$domain},,\n");
 				}
 
 				if ($x >= $pfb['dnsbl_top1m_cnt']) {
@@ -10342,6 +10371,13 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				unlink_if_exists($file_download);
 				return TRUE;
 			}
+			elseif ($type == 'top1m') {
+				// ADR-59 P2: a gz-container TOP1M provider decompresses straight to
+				// the destination CSV pfblockerng_top1m() reads (no rename/staging).
+				exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);
+				unlink_if_exists($file_download);
+				return TRUE;
+			}
 			elseif ($type == 'blacklist') {
 				// Extras - Blacklist downloads
 				@rename("{$file_download}", strstr("{$file_download}", '.raw', TRUE));
@@ -10511,8 +10547,10 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		}
 		else {
 			// Uncompressed file format.
-			if ($type == 'geoip' || $type == 'asn') {
-				// Extras - MaxMind/TOP1M/ASN downloads
+			if ($type == 'geoip' || $type == 'asn' || $type == 'top1m') {
+				// Extras - MaxMind/TOP1M/ASN downloads. ADR-59 P2: a 'plain' container
+				// provider's body IS the destination CSV -- rename straight to it, same
+				// as geoip/asn (no intermediate '.orig' staging needed).
 				@rename("{$file_download}", "{$head_download}");
 				return TRUE;
 			}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1634,7 +1634,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			// (dashes, dots). Callers pass reference 'top1m_token' to suppress the
 			// failed-validation log line below -- a rejected token must never be logged,
 			// even at debug level (the secret itself, not just its download URL).
-			if (strlen($input) >= 8 && strlen($input) <= 512 && preg_match("/^[A-Za-z0-9._~+\/=-]+$/", $input)) {
+			if (strlen($input) >= 8 && strlen($input) <= 512 && preg_match("/^[A-Za-z0-9._~+\/=-]+$/D", $input)) {
 				$result = htmlspecialchars($input);
 			}
 			break;
@@ -8358,9 +8358,18 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 				// prose/HTML/error body (e.g. "error, service temporarily unavailable.")
 				// still has a '.' and a ',' and would otherwise pass the filter above, so a
 				// dead feed would classify as "valid" below and wipe the whitelist (#886
-				// review). Other parse modes have no rank column to guard on.
+				// review). Every other parse mode ('csv': DomCop/Majestic/Cloudflare) has no
+				// rank column to guard on instead, so the domain field itself must look like
+				// a hostname -- otherwise the SAME garbage-body wipe re-opens for those
+				// providers (a CDN error page or a JSON auth-error body still has a '.' and
+				// a ',' somewhere) (#892 review).
 				$csvline = str_getcsv($line, ',', '"', "\\");
-				if ($top1m_parse === 'rank_domain' && !ctype_digit((string) ($csvline[0] ?? ''))) {
+				$domain = $csvline[$top1m_domcol] ?? '';
+				if ($top1m_parse === 'rank_domain') {
+					if (!ctype_digit((string) ($csvline[0] ?? ''))) {
+						continue;
+					}
+				} elseif (!preg_match('/^[A-Za-z0-9][A-Za-z0-9.-]*\.[A-Za-z]{2,}$/', $domain)) {
 					continue;
 				}
 				// Count every valid CSV row BEFORE the match/break below, so a
@@ -8368,7 +8377,6 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 				// still leaves $linecnt > 0 and classifies as a valid feed
 				// (not the dead-feed $linecnt === 0 path) (#886 review).
 				$linecnt++;
-				$domain = $csvline[$top1m_domcol] ?? '';
 				$tld = substr($domain, strrpos($domain, '.') + 1);
 
 				if (isset($pfb_include[$tld])) {
@@ -9924,9 +9932,11 @@ function pfb_download_http_headers(array $extra_headers, string $conditional_hea
 // ~14096) do NOT pass this argument, so their behaviour is entirely unchanged.
 //
 // Optional $extra_headers (ADR-59 Phase 3) — caller-supplied HTTP header strings (e.g. a
-// future Cloudflare Radar 'Authorization: Bearer <token>'), merged with the conditional-GET
-// header via pfb_download_http_headers() above. No caller passes this yet; every existing
-// feed keeps its current CURLOPT_HTTPHEADER behaviour exactly.
+// Cloudflare Radar 'Authorization: Bearer <token>'), merged with the conditional-GET
+// header via pfb_download_http_headers() above. The TOP1M provider (ADR-59 P5) is the
+// first caller: pfblockerng.php passes the active provider's pfb_top1m_auth_headers()
+// result here; every other feed still passes none, so its CURLOPT_HTTPHEADER behaviour
+// is unchanged.
 function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $logtype, $vtype='', $timeout=300, $type='', $username='', $password='', $srcint=FALSE, &$response_meta=NULL, array $extra_headers=array()) {
 	global $pfb;
 	$http_status = '';
@@ -10151,11 +10161,11 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					}
 				}
 
-				// ADR-59 Phase 3: merge caller-supplied headers (none yet) with the
-				// conditional-GET header above -- neither list clobbers the other. Skips
-				// the curl_setopt entirely when both are empty (today, every feed except
-				// an in-flight change_detect probe with a stored ETag), matching the
-				// pre-Phase-3 behaviour byte-for-byte.
+				// ADR-59 Phase 3: merge caller-supplied headers (ADR-59 P5's TOP1M provider
+				// auth header is the first caller) with the conditional-GET header above --
+				// neither list clobbers the other. Skips the curl_setopt entirely when both
+				// are empty (every other feed, plus an in-flight change_detect probe with no
+				// stored ETag), matching the pre-Phase-3 behaviour byte-for-byte.
 				$http_headers = pfb_download_http_headers($extra_headers, $conditional_header);
 				if (!empty($http_headers)) {
 					curl_setopt($ch, CURLOPT_HTTPHEADER, $http_headers);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -324,6 +324,7 @@ define('PFB_FILTER_FILE_MIME_COMPRESSED', 18);
 define('PFB_FILTER_ATYPE', 19);
 define('PFB_FILTER_HEX_COLOR', 20);
 define('PFB_FILTER_ON_OFF', 21);
+define('PFB_FILTER_TOKEN', 22);
 
 // Maximum number of HTTP redirects pfb_download() follows manually (each hop's
 // host is re-vetted by the feed-host guard before it is dialled). Matches the
@@ -1625,6 +1626,18 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 				pfb_logger("{$header} Invalid on/off [ " . htmlspecialchars($input) . " ]", 6);
 			}
 			break;
+		case PFB_FILTER_TOKEN:
+			// ADR-59 P5: validate a base64url/JWT-shaped credential token (e.g. a Cloudflare
+			// Radar API token) -- letters, digits, and the base64url/JWT punctuation set
+			// '._~+/=-', bounded length so a pathological input can't be used for resource
+			// exhaustion. PFB_FILTER_WORD ([A-Za-z0-9_] only) would reject a real token
+			// (dashes, dots). Callers pass reference 'top1m_token' to suppress the
+			// failed-validation log line below -- a rejected token must never be logged,
+			// even at debug level (the secret itself, not just its download URL).
+			if (strlen($input) >= 8 && strlen($input) <= 512 && preg_match("/^[A-Za-z0-9._~+\/=-]+$/", $input)) {
+				$result = htmlspecialchars($input);
+			}
+			break;
 		default:
 			pfb_logger("{$header} Type invalid [ " . htmlspecialchars($input) . " ]", 6);
 			break;
@@ -1638,8 +1651,10 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 	if (!empty($input) && empty($result) &&
 	    !in_array($type, array(PFB_FILTER_URL, PFB_FILTER_FILE_MIME_COMPARE, PFB_FILTER_FILE_MIME, PFB_FILTER_FILE_MIME_COMPRESSED, PFB_FILTER_ON_OFF, PFB_FILTER_NUM))) {
 
-		// Exceptions
-		if (in_array($reference, array(	'DNSBL_Download'))) {
+		// Exceptions -- callers whose rejected input must never be logged, even at
+		// debug level: 'DNSBL_Download' (parsed feed lines -- volume); 'top1m_token'
+		// (ADR-59 P5 -- the secret itself, not merely its download URL).
+		if (in_array($reference, array('DNSBL_Download', 'top1m_token'))) {
 			//
 		} else {
 			pfb_logger("{$header} Failed validation [ " . htmlspecialchars($input) . " ]", 6);
@@ -8321,7 +8336,15 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 					continue;
 				}
 
-				if (strpos($line, '.') === FALSE || strpos($line, ',') === FALSE || empty($line)) {
+				// ADR-59 P5: Cloudflare's dataset is a SINGLE 'domain' column (domain_col
+				// 0) -- a real data line has no comma at all (no column to split), so the
+				// comma requirement below would wrongly reject every line. Only demand a
+				// comma when a real multi-column split is expected (domain_col > 0, every
+				// other provider today); domain_col 0 still requires a '.' (every domain
+				// has one).
+				$top1m_needs_comma = $top1m_domcol > 0;
+				if (strpos($line, '.') === FALSE || empty($line) ||
+				    ($top1m_needs_comma && strpos($line, ',') === FALSE)) {
 					continue;
 				}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -204,21 +204,23 @@ enum PfbAliasDeltaMode: string implements PfbStoredEnum
 //
 // Used by: alexa_type (config key) / $pfb['dnsbl_top1m_type'] (runtime).
 //   Canonical tokens: 'tranco' (default), 'cisco', 'domcop', 'majestic'
-//   (ADR-59 P4). The legacy 'alexa' token (the dead Alexa TOP1M service,
-//   #872) is a READ-ONLY legacy value: fromLegacy() coalesces it (and any
-//   unknown/'' token) to Tranco, and a write NEVER re-emits it — every live
-//   token is ever persisted as itself, so the write vocabulary is
-//   downgrade-safe (an older release reading any of them already understands
-//   its own subset; domcop/majestic are simply new to it, same as any other
-//   ADR-added option).
+//   (ADR-59 P4), 'cloudflare' (ADR-59 P5, token-authenticated). The legacy
+//   'alexa' token (the dead Alexa TOP1M service, #872) is a READ-ONLY legacy
+//   value: fromLegacy() coalesces it (and any unknown/'' token) to Tranco,
+//   and a write NEVER re-emits it — every live token is ever persisted as
+//   itself, so the write vocabulary is downgrade-safe (an older release
+//   reading any of them already understands its own subset; domcop/
+//   majestic/cloudflare are simply new to it, same as any other ADR-added
+//   option).
 enum Top1mSource: string implements PfbStoredEnum
 {
 	use PfbStoredEnumAdapter;
 
-	case Tranco   = 'tranco';
-	case Cisco    = 'cisco';
-	case DomCop   = 'domcop';
-	case Majestic = 'majestic';
+	case Tranco     = 'tranco';
+	case Cisco      = 'cisco';
+	case DomCop     = 'domcop';
+	case Majestic   = 'majestic';
+	case Cloudflare = 'cloudflare';
 
 	// Legacy 'alexa' (dead service, #872) and any unknown/'' token -> Tranco.
 	protected static function fromLegacy(string $raw): static
@@ -235,9 +237,9 @@ enum Top1mSource: string implements PfbStoredEnum
 }
 
 // TOP1M provider descriptor table (ADR-59 P1, generalized P2, keyless
-// providers added P4).
+// providers added P4, token-authenticated Cloudflare Radar added P5).
 //
-// Keyed by Top1mSource::value ('tranco'/'cisco'/'domcop'/'majestic').
+// Keyed by Top1mSource::value ('tranco'/'cisco'/'domcop'/'majestic'/'cloudflare').
 // pfblockerng.php's TOP1M URL selection reads this table instead of a
 // per-provider if/else; pfblockerng_top1m() (ADR-59 P2) reads
 // 'parse'/'header'/'domain_col' to drive the builder, and pfb_download()'s
@@ -245,12 +247,15 @@ enum Top1mSource: string implements PfbStoredEnum
 // -- Tranco/Cisco's CSV has no header row and the domain sits at
 // str_getcsv() index 1 (0-indexed: rank,domain), matching today's hardcoded
 // shape byte-for-byte. 'auth' is read by pfb_download()'s header-auth path
-// (ADR-59 P3+). 'domain_col' is 0-indexed (str_getcsv() array index, not a
-// human 1-indexed column count) -- DomCop's Domain is the 2nd CSV field
-// ("Rank","Domain","Open Page Rank") -> index 1 (same index as Tranco/Cisco);
-// Majestic's Domain is the 3rd field (GlobalRank,TldRank,Domain,...) -> index 2.
+// (ADR-59 P3+) via pfb_top1m_auth_headers() below -- 'none' (every keyless
+// provider) or {header, scheme} (Cloudflare's Bearer token). 'domain_col' is
+// 0-indexed (str_getcsv() array index, not a human 1-indexed column count)
+// -- DomCop's Domain is the 2nd CSV field ("Rank","Domain","Open Page Rank")
+// -> index 1 (same index as Tranco/Cisco); Majestic's Domain is the 3rd
+// field (GlobalRank,TldRank,Domain,...) -> index 2; Cloudflare's dataset is
+// a SINGLE 'domain' column (no rank) -> index 0 (see the row's own comment).
 //
-// @return array<string, array{url: string, container: string, parse: string, header: bool, domain_col: int, auth: string, label: string, licence: string}>
+// @return array<string, array{url: string, container: string, parse: string, header: bool, domain_col: int, auth: string|array{header: string, scheme: string}, label: string, licence: string}>
 function pfb_top1m_providers(): array
 {
 	return array(
@@ -298,7 +303,61 @@ function pfb_top1m_providers(): array
 			'label'		=> 'Majestic Million',
 			'licence'	=> 'CC BY 3.0 — attribution required',
 		),
+		// Cloudflare Radar ranking bucket (ADR-59 P5). VERIFIED against Cloudflare's own
+		// current docs (developers.cloudflare.com/radar/investigate/domain-ranking-datasets/,
+		// developers.cloudflare.com/api/resources/radar/subresources/datasets/) rather than
+		// the ADR's original 2-column guess:
+		//   - GET /radar/datasets/{alias} streams the dataset's CSV content directly given a
+		//     STABLE alias ('ranking_top_1000000' for the 1,000,000-domain bucket -- id 213,
+		//     tags ['GLOBAL','top_1000000']) -- a single request, exactly like every other
+		//     provider here, NOT the two/three-call discover-id -> POST /datasets/download ->
+		//     fetch-signed-URL flow the ADR worried might be disproportionately complex (§7).
+		//   - The body is PLAIN (uncompressed) CSV with a header row reading literally
+		//     'domain' and ONE column per row (no rank) -- domain_col is 0, not 1 (the ADR's
+		//     guess assumed a 2-column rank,domain shape like Tranco/Cisco).
+		//   - Auth: 'Authorization: Bearer <token>' (confirmed on every Radar API page), fed
+		//     via pfb_top1m_auth_headers() below + the P3 $feed['headers'] plumbing.
+		//   - Licence: CC BY-NC 4.0 (developers.cloudflare.com/radar/ "About" -- confirmed by
+		//     web search, non-commercial use, attribution required).
+		// Residual verification gap (disclosed, not hidden): no live authenticated request was
+		// made (no Cloudflare token available in this environment) to prove the alias/URL end
+		// to end -- confirmed via two independent official Cloudflare doc pages instead. A real
+		// token on a live box (ADR §7 definition-of-done manual smoke) is the final proof.
+		Top1mSource::Cloudflare->value	=> array(
+			'url'		=> 'https://api.cloudflare.com/client/v4/radar/datasets/ranking_top_1000000',
+			'container'	=> 'plain',
+			'parse'		=> 'csv',
+			'header'	=> TRUE,
+			'domain_col'	=> 0,
+			'auth'		=> array('header' => 'Authorization', 'scheme' => 'Bearer'),
+			'label'		=> 'Cloudflare Radar',
+			'licence'	=> 'CC BY-NC 4.0 — non-commercial use, attribution required',
+		),
 	);
+}
+
+// ADR-59 P5: build the caller header(s) a provider's 'auth' descriptor needs, given the
+// user's top1m_token. Pure / no I/O (same extraction rationale as pfb_download_http_headers(),
+// Phase 3), so it is directly unit-testable and -- because it never logs anything -- the token
+// can only ever reach pfb_download()'s CURLOPT_HTTPHEADER, never a log line.
+//
+// 'auth' is either the string 'none' (every keyless provider) or an array {header, scheme}
+// (Cloudflare Radar's Bearer token, P5). An empty token or a keyless provider both yield
+// array() -- pfb_download() then sends no Authorization header, so a missing/blank token
+// fails the request safely rather than sending a malformed header: the #886 preserve+warn
+// path in pfblockerng_top1m() keeps the previous TOP1M whitelist and warns, exactly as any
+// other download failure does.
+//
+// @return string[] zero or one header line, e.g. ['Authorization: Bearer <token>'].
+function pfb_top1m_auth_headers(array $provider, string $token): array
+{
+	$auth = $provider['auth'] ?? 'none';
+	if (!is_array($auth) || empty($auth['header']) || $token === '') {
+		return array();
+	}
+	$scheme = $auth['scheme'] ?? '';
+	$value  = ($scheme !== '') ? "{$scheme} {$token}" : $token;
+	return array("{$auth['header']}: {$value}");
 }
 
 /** Read a PfbAliasDeltaMode from a raw stored value. */
@@ -365,8 +424,9 @@ function pfb_cfg_top1m_source_read(mixed $stored): Top1mSource
 
 /**
  * Write a Top1mSource (enum or legacy string) back to its canonical stored
- * token ('tranco' | 'cisco'). The dead legacy 'alexa' token (#872) is never
- * re-emitted — fromStored() already coalesced it to Tranco before this runs.
+ * token ('tranco' | 'cisco' | 'domcop' | 'majestic' | 'cloudflare'). The dead
+ * legacy 'alexa' token (#872) is never re-emitted — fromStored() already
+ * coalesced it to Tranco before this runs.
  */
 function pfb_cfg_top1m_source_write(Top1mSource|string $source): string
 {
@@ -811,8 +871,8 @@ function pfb_cfg_registry(): array
 			'since'         => '1.0.0',
 		],
 
-		// TOP1M type selector: 'tranco' | 'cisco' | 'domcop' | 'majestic'. Legacy
-		// 'alexa' (dead service, #872) coalesces to 'tranco' at the read boundary
+		// TOP1M type selector: 'tranco' | 'cisco' | 'domcop' | 'majestic' | 'cloudflare'.
+		// Legacy 'alexa' (dead service, #872) coalesces to 'tranco' at the read boundary
 		// via pfb_cfg_top1m_source_read(). Default 'tranco'.
 		'alexa_type' => [
 			'section'       => $dnsbl,
@@ -838,6 +898,21 @@ function pfb_cfg_registry(): array
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 			'since'         => '1.0.0',
+		],
+
+		// ADR-59 P5: masked, write-only Cloudflare Radar Bearer token -- consumed only
+		// when alexa_type == 'cloudflare' (every other provider ignores it), fed to
+		// pfb_download() via pfb_top1m_auth_headers() + the P3 header-auth plumbing.
+		// Plain string (no adapter): the DNSBL page never echoes the stored value back
+		// on GET, and a blank POST preserves the existing value rather than clearing it
+		// (pfblockerng_dnsbl.php's save handler) -- see PFB_FILTER_TOKEN (pfblockerng.inc)
+		// for the accepted charset. Default ''.
+		'top1m_token' => [
+			'section'       => $dnsbl,
+			'default'       => '',
+			'read_adapter'  => NULL,
+			'write_adapter' => NULL,
+			'since'         => '4.0.0',
 		],
 
 		// Resolver cache backup/restore option. Default ''.
@@ -1591,8 +1666,8 @@ function pfb_run_migrations(): void
  * The top1m_source adapter (pfb_cfg_top1m_source_read/write, issue #877) is wired
  * for alexa_type and returns a Top1mSource enum. Legacy 'alexa' (dead service,
  * #872) coalesces to Tranco on read and is never re-emitted by a write; the
- * write vocabulary is 'tranco'|'cisco'|'domcop'|'majestic' (domcop/majestic
- * added ADR-59 P4).
+ * write vocabulary is 'tranco'|'cisco'|'domcop'|'majestic'|'cloudflare'
+ * (domcop/majestic added ADR-59 P4, cloudflare added ADR-59 P5).
  *
  * @return array<string,list<string>>
  */
@@ -1622,11 +1697,12 @@ function pfb_cfg_field_vocab(): array
 		'alias_delta_mode' => ['auto', 'delta', 'replace'],
 
 		// TOP1M source selector (Top1mSource, issue #877): the tokens a write can
-		// emit. 'tranco' (default) | 'cisco' | 'domcop' | 'majestic' (the latter
-		// two added ADR-59 P4). The legacy 'alexa' token (dead service, #872) is a
-		// READ-ONLY legacy value — pfb_cfg_top1m_source_read() coalesces it to
-		// Top1mSource::Tranco and it is never re-emitted by a write.
-		'top1m_source' => ['tranco', 'cisco', 'domcop', 'majestic'],
+		// emit. 'tranco' (default) | 'cisco' | 'domcop' | 'majestic' | 'cloudflare'
+		// (domcop/majestic added ADR-59 P4, cloudflare added ADR-59 P5). The legacy
+		// 'alexa' token (dead service, #872) is a READ-ONLY legacy value —
+		// pfb_cfg_top1m_source_read() coalesces it to Top1mSource::Tranco and it is
+		// never re-emitted by a write.
+		'top1m_source' => ['tranco', 'cisco', 'domcop', 'majestic', 'cloudflare'],
 
 		// Plain string (null/null adapters): identity. Backward-safe by construction.
 		// The 'plain' vocabulary contains the sentinel empty string; individual

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -230,6 +230,38 @@ enum Top1mSource: string implements PfbStoredEnum
 	}
 }
 
+// TOP1M provider descriptor table (ADR-59 P1).
+//
+// Keyed by Top1mSource::value ('tranco'/'cisco'). pfblockerng.php's TOP1M URL
+// selection reads this table instead of a per-provider if/else; a later ADR-59
+// phase generalizes pfblockerng_top1m()'s parser + the download extractor to
+// read the 'parse'/'container'/'auth' fields the same way. This phase carries
+// only the two pre-existing providers, with their CURRENT literal URLs
+// unchanged -- a pure extraction, no behaviour change.
+//
+// @return array<string, array{url: string, container: string, parse: string, auth: string, label: string, licence: string}>
+function pfb_top1m_providers(): array
+{
+	return array(
+		Top1mSource::Tranco->value	=> array(
+			'url'		=> 'https://tranco-list.eu/top-1m.csv.zip',
+			'container'	=> 'zip',
+			'parse'		=> 'rank_domain',
+			'auth'		=> 'none',
+			'label'		=> 'Tranco',
+			'licence'	=> '',
+		),
+		Top1mSource::Cisco->value	=> array(
+			'url'		=> 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip',
+			'container'	=> 'zip',
+			'parse'		=> 'rank_domain',
+			'auth'		=> 'none',
+			'label'		=> 'Cisco Umbrella',
+			'licence'	=> '',
+		),
+	);
+}
+
 /** Read a PfbAliasDeltaMode from a raw stored value. */
 function pfb_cfg_alias_delta_mode_read(mixed $stored): PfbAliasDeltaMode
 {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -203,18 +203,22 @@ enum PfbAliasDeltaMode: string implements PfbStoredEnum
 // Top1mSource — TOP1M source selector (alexa_type, issue #877).
 //
 // Used by: alexa_type (config key) / $pfb['dnsbl_top1m_type'] (runtime).
-//   Canonical tokens: 'tranco' (default), 'cisco'. The legacy 'alexa' token
-//   (the dead Alexa TOP1M service, #872) is a READ-ONLY legacy value:
-//   fromLegacy() coalesces it (and any unknown/'' token) to Tranco, and a
-//   write NEVER re-emits it — only 'tranco'/'cisco' are ever persisted, so
-//   the write vocabulary is downgrade-safe (an older release reading either
-//   token already understands it).
+//   Canonical tokens: 'tranco' (default), 'cisco', 'domcop', 'majestic'
+//   (ADR-59 P4). The legacy 'alexa' token (the dead Alexa TOP1M service,
+//   #872) is a READ-ONLY legacy value: fromLegacy() coalesces it (and any
+//   unknown/'' token) to Tranco, and a write NEVER re-emits it — every live
+//   token is ever persisted as itself, so the write vocabulary is
+//   downgrade-safe (an older release reading any of them already understands
+//   its own subset; domcop/majestic are simply new to it, same as any other
+//   ADR-added option).
 enum Top1mSource: string implements PfbStoredEnum
 {
 	use PfbStoredEnumAdapter;
 
-	case Tranco = 'tranco';
-	case Cisco  = 'cisco';
+	case Tranco   = 'tranco';
+	case Cisco    = 'cisco';
+	case DomCop   = 'domcop';
+	case Majestic = 'majestic';
 
 	// Legacy 'alexa' (dead service, #872) and any unknown/'' token -> Tranco.
 	protected static function fromLegacy(string $raw): static
@@ -230,15 +234,21 @@ enum Top1mSource: string implements PfbStoredEnum
 	}
 }
 
-// TOP1M provider descriptor table (ADR-59 P1, generalized P2).
+// TOP1M provider descriptor table (ADR-59 P1, generalized P2, keyless
+// providers added P4).
 //
-// Keyed by Top1mSource::value ('tranco'/'cisco'). pfblockerng.php's TOP1M URL
-// selection reads this table instead of a per-provider if/else; pfblockerng_top1m()
-// (ADR-59 P2) reads 'parse'/'header'/'domain_col' to drive the builder, and
-// pfb_download()'s extractor reads 'container'. 'header'/'domain_col' default to
-// FALSE/1 here -- Tranco/Cisco's CSV has no header row and the domain sits at
-// str_getcsv() index 1 (0-indexed: rank,domain), matching today's hardcoded shape
-// byte-for-byte. 'auth' is read by pfb_download()'s header-auth path (ADR-59 P3+).
+// Keyed by Top1mSource::value ('tranco'/'cisco'/'domcop'/'majestic').
+// pfblockerng.php's TOP1M URL selection reads this table instead of a
+// per-provider if/else; pfblockerng_top1m() (ADR-59 P2) reads
+// 'parse'/'header'/'domain_col' to drive the builder, and pfb_download()'s
+// extractor reads 'container'. 'header'/'domain_col' default to FALSE/1 here
+// -- Tranco/Cisco's CSV has no header row and the domain sits at
+// str_getcsv() index 1 (0-indexed: rank,domain), matching today's hardcoded
+// shape byte-for-byte. 'auth' is read by pfb_download()'s header-auth path
+// (ADR-59 P3+). 'domain_col' is 0-indexed (str_getcsv() array index, not a
+// human 1-indexed column count) -- DomCop's Domain is the 2nd CSV field
+// ("Rank","Domain","Open Page Rank") -> index 1 (same index as Tranco/Cisco);
+// Majestic's Domain is the 3rd field (GlobalRank,TldRank,Domain,...) -> index 2.
 //
 // @return array<string, array{url: string, container: string, parse: string, header: bool, domain_col: int, auth: string, label: string, licence: string}>
 function pfb_top1m_providers(): array
@@ -263,6 +273,30 @@ function pfb_top1m_providers(): array
 			'auth'		=> 'none',
 			'label'		=> 'Cisco Umbrella',
 			'licence'	=> '',
+		),
+		// DomCop top-10M (registered-domain breadth): zipped CSV, quoted header
+		// row ("Rank","Domain","Open Page Rank"), Domain at str_getcsv() index 1.
+		Top1mSource::DomCop->value	=> array(
+			'url'		=> 'https://www.domcop.com/files/top/top10milliondomains.csv.zip',
+			'container'	=> 'zip',
+			'parse'		=> 'csv',
+			'header'	=> TRUE,
+			'domain_col'	=> 1,
+			'auth'		=> 'none',
+			'label'		=> 'DomCop',
+			'licence'	=> '',
+		),
+		// Majestic Million: PLAIN (uncompressed) CSV, unquoted 12-col header
+		// (GlobalRank,TldRank,Domain,TLD,...), Domain at str_getcsv() index 2.
+		Top1mSource::Majestic->value	=> array(
+			'url'		=> 'https://downloads.majestic.com/majestic_million.csv',
+			'container'	=> 'plain',
+			'parse'		=> 'csv',
+			'header'	=> TRUE,
+			'domain_col'	=> 2,
+			'auth'		=> 'none',
+			'label'		=> 'Majestic Million',
+			'licence'	=> 'CC BY 3.0 — attribution required',
 		),
 	);
 }
@@ -777,9 +811,9 @@ function pfb_cfg_registry(): array
 			'since'         => '1.0.0',
 		],
 
-		// TOP1M type selector: 'tranco' | 'cisco'. Legacy 'alexa' (dead service,
-		// #872) coalesces to 'tranco' at the read boundary via
-		// pfb_cfg_top1m_source_read(). Default 'tranco'.
+		// TOP1M type selector: 'tranco' | 'cisco' | 'domcop' | 'majestic'. Legacy
+		// 'alexa' (dead service, #872) coalesces to 'tranco' at the read boundary
+		// via pfb_cfg_top1m_source_read(). Default 'tranco'.
 		'alexa_type' => [
 			'section'       => $dnsbl,
 			'default'       => 'tranco',
@@ -1557,7 +1591,8 @@ function pfb_run_migrations(): void
  * The top1m_source adapter (pfb_cfg_top1m_source_read/write, issue #877) is wired
  * for alexa_type and returns a Top1mSource enum. Legacy 'alexa' (dead service,
  * #872) coalesces to Tranco on read and is never re-emitted by a write; the
- * write vocabulary is only 'tranco'|'cisco'.
+ * write vocabulary is 'tranco'|'cisco'|'domcop'|'majestic' (domcop/majestic
+ * added ADR-59 P4).
  *
  * @return array<string,list<string>>
  */
@@ -1587,10 +1622,11 @@ function pfb_cfg_field_vocab(): array
 		'alias_delta_mode' => ['auto', 'delta', 'replace'],
 
 		// TOP1M source selector (Top1mSource, issue #877): the tokens a write can
-		// emit. 'tranco' (default) | 'cisco'. The legacy 'alexa' token (dead
-		// service, #872) is a READ-ONLY legacy value — pfb_cfg_top1m_source_read()
-		// coalesces it to Top1mSource::Tranco and it is never re-emitted by a write.
-		'top1m_source' => ['tranco', 'cisco'],
+		// emit. 'tranco' (default) | 'cisco' | 'domcop' | 'majestic' (the latter
+		// two added ADR-59 P4). The legacy 'alexa' token (dead service, #872) is a
+		// READ-ONLY legacy value — pfb_cfg_top1m_source_read() coalesces it to
+		// Top1mSource::Tranco and it is never re-emitted by a write.
+		'top1m_source' => ['tranco', 'cisco', 'domcop', 'majestic'],
 
 		// Plain string (null/null adapters): identity. Backward-safe by construction.
 		// The 'plain' vocabulary contains the sentinel empty string; individual

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -230,16 +230,17 @@ enum Top1mSource: string implements PfbStoredEnum
 	}
 }
 
-// TOP1M provider descriptor table (ADR-59 P1).
+// TOP1M provider descriptor table (ADR-59 P1, generalized P2).
 //
 // Keyed by Top1mSource::value ('tranco'/'cisco'). pfblockerng.php's TOP1M URL
-// selection reads this table instead of a per-provider if/else; a later ADR-59
-// phase generalizes pfblockerng_top1m()'s parser + the download extractor to
-// read the 'parse'/'container'/'auth' fields the same way. This phase carries
-// only the two pre-existing providers, with their CURRENT literal URLs
-// unchanged -- a pure extraction, no behaviour change.
+// selection reads this table instead of a per-provider if/else; pfblockerng_top1m()
+// (ADR-59 P2) reads 'parse'/'header'/'domain_col' to drive the builder, and
+// pfb_download()'s extractor reads 'container'. 'header'/'domain_col' default to
+// FALSE/1 here -- Tranco/Cisco's CSV has no header row and the domain sits at
+// str_getcsv() index 1 (0-indexed: rank,domain), matching today's hardcoded shape
+// byte-for-byte. 'auth' is read by pfb_download()'s header-auth path (ADR-59 P3+).
 //
-// @return array<string, array{url: string, container: string, parse: string, auth: string, label: string, licence: string}>
+// @return array<string, array{url: string, container: string, parse: string, header: bool, domain_col: int, auth: string, label: string, licence: string}>
 function pfb_top1m_providers(): array
 {
 	return array(
@@ -247,6 +248,8 @@ function pfb_top1m_providers(): array
 			'url'		=> 'https://tranco-list.eu/top-1m.csv.zip',
 			'container'	=> 'zip',
 			'parse'		=> 'rank_domain',
+			'header'	=> FALSE,
+			'domain_col'	=> 1,
 			'auth'		=> 'none',
 			'label'		=> 'Tranco',
 			'licence'	=> '',
@@ -255,6 +258,8 @@ function pfb_top1m_providers(): array
 			'url'		=> 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip',
 			'container'	=> 'zip',
 			'parse'		=> 'rank_domain',
+			'header'	=> FALSE,
+			'domain_col'	=> 1,
 			'auth'		=> 'none',
 			'label'		=> 'Cisco Umbrella',
 			'licence'	=> '',

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -242,8 +242,12 @@ enum Top1mSource: string implements PfbStoredEnum
 // Keyed by Top1mSource::value ('tranco'/'cisco'/'domcop'/'majestic'/'cloudflare').
 // pfblockerng.php's TOP1M URL selection reads this table instead of a
 // per-provider if/else; pfblockerng_top1m() (ADR-59 P2) reads
-// 'parse'/'header'/'domain_col' to drive the builder, and pfb_download()'s
-// extractor reads 'container'. 'header'/'domain_col' default to FALSE/1 here
+// 'parse'/'header'/'domain_col' to drive the builder. 'container' documents each
+// provider's expected transport shape (zip/gz/plain) but is currently INFORMATIONAL
+// ONLY -- pfb_download()'s extractor branches on the actually-detected MIME type
+// (PFB_FILTER_FILE_MIME), not this field, so a mismatch (e.g. a zip provider serving
+// an HTML error page) is caught downstream by pfblockerng_top1m()'s domain-validity
+// guard rather than here (#892 review). 'header'/'domain_col' default to FALSE/1 here
 // -- Tranco/Cisco's CSV has no header row and the domain sits at
 // str_getcsv() index 1 (0-indexed: rank,domain), matching today's hardcoded
 // shape byte-for-byte. 'auth' is read by pfb_download()'s header-auth path
@@ -355,6 +359,10 @@ function pfb_top1m_auth_headers(array $provider, string $token): array
 	if (!is_array($auth) || empty($auth['header']) || $token === '') {
 		return array();
 	}
+	// Defense-in-depth (#892 review): a token stored via a non-UI path (hand-edited
+	// config.xml, HA sync, a restored backup) is not re-validated by PFB_FILTER_TOKEN --
+	// strip CR/LF here so it can never inject an extra header/split the request.
+	$token  = str_replace(["\r", "\n"], '', $token);
 	$scheme = $auth['scheme'] ?? '';
 	$value  = ($scheme !== '') ? "{$scheme} {$token}" : $token;
 	return array("{$auth['header']}: {$value}");

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -158,13 +158,22 @@ $pfb['extras'][1]['folder']	= "{$pfb['geoipshare']}";
 $pfb['extras'][1]['type']	= 'geoip';
 
 // TOP1M database (ADR-59 P1: URL sourced from the provider descriptor table)
+$pfb_top1m_provider		= pfb_top1m_providers()[$pfb['dnsbl_top1m_type']->value];
 $pfb['extras'][2]			= array();
-$pfb['extras'][2]['url']	= pfb_top1m_providers()[$pfb['dnsbl_top1m_type']->value]['url'];
+$pfb['extras'][2]['url']	= $pfb_top1m_provider['url'];
 
 $pfb['extras'][2]['file_dwn']	= 'top-1m.csv.zip';
 $pfb['extras'][2]['file']	= 'top-1m.csv';
 $pfb['extras'][2]['folder']	= "{$pfb['dbdir']}";
 $pfb['extras'][2]['type']	= 'top1m';
+
+// ADR-59 P5: header auth (Cloudflare Radar's Bearer token) via the P3 $feed['headers']
+// plumbing. A keyless provider's 'auth' is 'none', so pfb_top1m_auth_headers() returns
+// array() and this is a no-op for tranco/cisco/domcop/majestic, exactly as before P5.
+// An empty/absent top1m_token also yields array() -- no Authorization header is sent,
+// so a missing token fails the download safely (pfblockerng_top1m()'s #886 preserve+warn
+// path keeps the previous TOP1M whitelist) rather than sending a malformed header.
+$pfb['extras'][2]['headers']	= pfb_top1m_auth_headers($pfb_top1m_provider, (string) PfbConfig::read('top1m_token'));
 
 // IPinfo ASN databases
 $pfb['extras'][3]		= array();

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -157,13 +157,9 @@ $pfb['extras'][1]['file']	= '';
 $pfb['extras'][1]['folder']	= "{$pfb['geoipshare']}";
 $pfb['extras'][1]['type']	= 'geoip';
 
-// TOP1M database
+// TOP1M database (ADR-59 P1: URL sourced from the provider descriptor table)
 $pfb['extras'][2]			= array();
-if ($pfb['dnsbl_top1m_type'] === Top1mSource::Tranco) {
-	$pfb['extras'][2]['url']	= 'https://tranco-list.eu/top-1m.csv.zip';
-} else {
-	$pfb['extras'][2]['url']	= 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip';  // Cisco
-}
+$pfb['extras'][2]['url']	= pfb_top1m_providers()[$pfb['dnsbl_top1m_type']->value]['url'];
 
 $pfb['extras'][2]['file_dwn']	= 'top-1m.csv.zip';
 $pfb['extras'][2]['file']	= 'top-1m.csv';

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -670,8 +670,11 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 
 		$file_dwn = "{$feed['folder']}/{$feed['file_dwn']}";
 
-		if (!pfb_download($feed['url'], $file_dwn, FALSE, "{$feed['folder']}/{$feed['file']}", '', $logtype, '', $timeout, $feed['type'], 
-		    $feed['username'], $feed['password'])) {
+		// ADR-59 Phase 3: thread the per-feed 'headers' field through as caller-supplied
+		// HTTP headers (e.g. a future Cloudflare Radar Bearer token). No provider sets it
+		// yet, so this is always array() -- existing downloads are unaffected.
+		if (!pfb_download($feed['url'], $file_dwn, FALSE, "{$feed['folder']}/{$feed['file']}", '', $logtype, '', $timeout, $feed['type'],
+		    $feed['username'], $feed['password'], extra_headers: $feed['headers'] ?? array())) {
 
 			$log = "\nFailed to Download {$feed['file']}\n";
 			pfb_logger("{$log}", $logtype);

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -680,8 +680,10 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 		$file_dwn = "{$feed['folder']}/{$feed['file_dwn']}";
 
 		// ADR-59 Phase 3: thread the per-feed 'headers' field through as caller-supplied
-		// HTTP headers (e.g. a future Cloudflare Radar Bearer token). No provider sets it
-		// yet, so this is always array() -- existing downloads are unaffected.
+		// HTTP headers. The TOP1M provider (ADR-59 P5) sets it above via
+		// pfb_top1m_auth_headers() (Cloudflare Radar's Bearer token; array() for every
+		// keyless provider) -- every other feed still leaves it unset, so ?? array()
+		// keeps their downloads unaffected.
 		if (!pfb_download($feed['url'], $file_dwn, FALSE, "{$feed['folder']}/{$feed['file']}", '', $logtype, '', $timeout, $feed['type'],
 		    $feed['username'], $feed['password'], extra_headers: $feed['headers'] ?? array())) {
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -195,7 +195,19 @@ if (is_dir("{$indexdir}")) {
 $options_dnsbl_webpage_cnt = count($options_dnsbl_webpage) ?: '1';
 
 $options_alexa_type		= [ 'tranco' => 'Tranco TOP1M', 'cisco' => 'Cisco Umbrella TOP1M',
-					    'domcop' => 'DomCop TOP1M', 'majestic' => 'Majestic Million TOP1M' ];
+					    'domcop' => 'DomCop TOP1M', 'majestic' => 'Majestic Million TOP1M',
+					    'cloudflare' => 'Cloudflare Radar' ];
+
+// ADR-59 P5: providers whose 'auth' needs the top1m_token field, derived from the
+// descriptor table so a future token provider needs no JS edit -- the JS toggle
+// below shows/hides the masked token field based on the selected provider.
+$pfb_top1m_token_providers = [];
+foreach (pfb_top1m_providers() as $pfb_top1m_id => $pfb_top1m_provider_row) {
+	if (is_array($pfb_top1m_provider_row['auth']) && !empty($pfb_top1m_provider_row['auth']['header'])) {
+		$pfb_top1m_token_providers[] = $pfb_top1m_id;
+	}
+}
+$pfb_top1m_token_providers_json = json_encode($pfb_top1m_token_providers);
 
 $options_alexa_count		= [	'500' => 'Top 500', '1000' => 'Top 1k', '2000' => 'Top 2k', '5000' => 'Top 5k', '10000' => 'Top 10k',
 					'25000' => 'Top 25k', '50000' => 'Top 50k', '75000' => 'Top 75k', '100000' => 'Top 100k', '250000' => 'Top 250k',
@@ -618,6 +630,17 @@ if ($_POST) {
 			$input_errors[] = 'DNSBL IDN Blocking mode is invalid!';
 		}
 
+		// ADR-59 P5: top1m_token is a masked, write-only field -- a blank POST means
+		// "leave the stored token unchanged" (never overwrite/clear it), so only a
+		// NON-EMPTY submission is validated. PFB_FILTER_WORD (used by asn_token) would
+		// reject a real base64url/JWT token -- PFB_FILTER_TOKEN accepts that charset.
+		// Reference 'top1m_token' suppresses pfb_filter()'s failed-validation log line
+		// -- the token itself must never reach a log, even a rejected one.
+		$pfb_top1m_token_post = trim((string) ($_POST['top1m_token'] ?? ''));
+		if ($pfb_top1m_token_post !== '' && empty(pfb_filter($pfb_top1m_token_post, PFB_FILTER_TOKEN, 'top1m_token'))) {
+			$input_errors[] = 'DNSBL TOP1M Token is invalid!';
+		}
+
 		// Validate customlists
 		foreach (array(	'pfb_regex_list'	=> 'regex',
 				'pfb_noaaaa_list'	=> 'domain',
@@ -840,6 +863,16 @@ if ($_POST) {
 				unlink_if_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt");
 			}
 			$pfb['dconfig']['alexa_type']		= $_POST['alexa_type']							?: 'tranco';
+
+			// top1m_token: masked/write-only -- blank means "keep the existing stored
+			// token" (never clear it via a blank submit, e.g. an unrelated settings
+			// save re-posting this always-blank-rendered field). $pfb['dconfig']
+			// ['top1m_token'] already holds the current stored value from the
+			// readSection() at the top of this page, so skip the assignment entirely
+			// when the field was left blank.
+			if ($pfb_top1m_token_post !== '') {
+				$pfb['dconfig']['top1m_token'] = $pfb_top1m_token_post;
+			}
 
 			// Reset TOP1M Whitelist on user changes
 			if ($pfb['dconfig']['alexa_count'] != $_POST['alexa_count'] ||
@@ -3222,6 +3255,11 @@ $top1m_text = 'The TOP1M feed can be used to whitelist the most popular Domain n
 			<li><a target="_blank" href="https://majestic.com/reports/majestic-million">Majestic Million TOP1M</a> --
 				distributed under the <strong>Creative Commons Attribution (CC BY) 3.0</strong> License by:
 				<a target="_blank" href="https://majestic.com">Majestic</a>, attribution required.</li>
+			<li><a target="_blank" href="https://radar.cloudflare.com/domains">Cloudflare Radar</a> --
+				distributed under the <strong>Creative Commons Attribution-NonCommercial (CC BY-NC) 4.0</strong> License by:
+				<a target="_blank" href="https://www.cloudflare.com">Cloudflare</a>, non-commercial use, attribution required.
+				Requires a free <a target="_blank" href="https://developers.cloudflare.com/fundamentals/api/get-started/create-token/">Cloudflare API Token</a>
+				entered below.</li>
 		</ul>
 		To use this feature, select the number of \'Top Domains\' to whitelist. You can also \'include\' which TLDs to whitelist.
 
@@ -3249,6 +3287,21 @@ $section->addInput(new Form_Select(
 	$pconfig['alexa_type'],
 	$options_alexa_type
 ))->setHelp('Default: Tranco TOP1M. To change the TOP1M type, select the type and Save, then run an Update -- this clears and re-fetches the list.');
+
+// ADR-59 P5: masked, write-only token for a token-authenticated provider (currently only
+// Cloudflare Radar). Never populated from the stored value -- $pconfig['top1m_token'] is
+// only ever set here from a redisplayed $_POST on a validation error (like every other
+// field), never from PfbConfig::read(), so a plain GET always renders this field blank.
+// The JS toggle below (enable_top1m_token) shows it only for a provider whose 'auth' needs it.
+$section->addInput(new Form_Input(
+	'top1m_token',
+	gettext('API Token'),
+	'password',
+	$pconfig['top1m_token'] ?? '',
+	['placeholder' => 'Enter your Cloudflare Radar API Token -- leave blank to keep the current token']
+))->setHelp('Required for Cloudflare Radar. The stored token is never displayed here; leaving this field blank on Save keeps '
+		. 'the existing token unchanged.')
+  ->setAttribute('autocomplete', 'off');
 
 $section->addInput(new Form_Select(
 	'alexa_count',
@@ -3615,6 +3668,14 @@ function enable_idn_mode() {
 	}
 }
 
+// ADR-59 P5: providers whose 'auth' needs a token, derived server-side from the
+// descriptor table (pfb_top1m_providers()) -- a future token provider needs no JS edit.
+var pfb_top1m_token_providers = <?=$pfb_top1m_token_providers_json?>;
+
+function enable_top1m_token() {
+	hideInput('top1m_token', pfb_top1m_token_providers.indexOf($('#alexa_type').val()) === -1);
+}
+
 function enable_python_regex() {
 	if ($('#pfb_regex').prop('checked')) {
 		$('#Python_regex_list').show();
@@ -3671,6 +3732,11 @@ events.push(function(){
 		enable_idn_mode();
 	});
 	enable_idn_mode();
+
+	$('#alexa_type').change(function() {
+		enable_top1m_token();
+	});
+	enable_top1m_token();
 
 	$('#pfb_regex').click(function() {
 		enable_python_regex();

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -194,7 +194,8 @@ if (is_dir("{$indexdir}")) {
 }
 $options_dnsbl_webpage_cnt = count($options_dnsbl_webpage) ?: '1';
 
-$options_alexa_type		= [ 'tranco' => 'Tranco TOP1M', 'cisco' => 'Cisco Umbrella TOP1M' ];
+$options_alexa_type		= [ 'tranco' => 'Tranco TOP1M', 'cisco' => 'Cisco Umbrella TOP1M',
+					    'domcop' => 'DomCop TOP1M', 'majestic' => 'Majestic Million TOP1M' ];
 
 $options_alexa_count		= [	'500' => 'Top 500', '1000' => 'Top 1k', '2000' => 'Top 2k', '5000' => 'Top 5k', '10000' => 'Top 10k',
 					'25000' => 'Top 25k', '50000' => 'Top 50k', '75000' => 'Top 75k', '100000' => 'Top 100k', '250000' => 'Top 250k',
@@ -3217,6 +3218,10 @@ $top1m_text = 'The TOP1M feed can be used to whitelist the most popular Domain n
 		<ul>
 			<li><a target="_blank" href="https://tranco-list.eu/">Tranco TOP1M</a></li>
 			<li><a target="_blank" href="https://s3-us-west-1.amazonaws.com/umbrella-static/index.html">Cisco Umbrella TOP1M</a></li>
+			<li><a target="_blank" href="https://www.domcop.com/top-10-million-domains">DomCop TOP1M</a></li>
+			<li><a target="_blank" href="https://majestic.com/reports/majestic-million">Majestic Million TOP1M</a> --
+				distributed under the <strong>Creative Commons Attribution (CC BY) 3.0</strong> License by:
+				<a target="_blank" href="https://majestic.com">Majestic</a>, attribution required.</li>
 		</ul>
 		To use this feature, select the number of \'Top Domains\' to whitelist. You can also \'include\' which TLDs to whitelist.
 

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -39,13 +39,14 @@ use PHPUnit\Framework\TestCase;
  *     And write(read('')) == 'off'    (normalised default).
  *
  * Scenario E — Top1mSource (alexa_type, issue #877): backing values 'tranco' /
- *   'cisco' TOP1M source selector; the legacy 'alexa' token (dead service,
- *   #872) coalesces to Tranco.
+ *   'cisco' / 'domcop' / 'majestic' (the latter two added ADR-59 P4) TOP1M
+ *   source selector; the legacy 'alexa' token (dead service, #872) coalesces
+ *   to Tranco.
  *     Given a raw stored value v.
  *     When pfb_cfg_top1m_source_read(v) -> enum, pfb_cfg_top1m_source_write(enum) -> stored.
- *     Then 'tranco'/'cisco' pass through as Tranco/Cisco; 'alexa' and any
- *     unknown/absent value -> Tranco. write(read(v)) == v for canonical tokens;
- *     'alexa' is never re-emitted.
+ *     Then 'tranco'/'cisco'/'domcop'/'majestic' pass through as their own enum
+ *     case; 'alexa' and any unknown/absent value -> Tranco. write(read(v)) == v
+ *     for canonical tokens; 'alexa' is never re-emitted.
  */
 final class CfgAdaptersTest extends TestCase
 {
@@ -672,10 +673,11 @@ final class CfgAdaptersTest extends TestCase
 
 	// -----------------------------------------------------------------------
 	// Scenario E — Top1mSource (alexa_type, issue #877)
-	//   Stored tokens: 'tranco', 'cisco' (live); legacy 'alexa' (dead service,
-	//   #872) coalesces to Tranco at the read boundary. Mirrors the
-	//   PfbAliasDeltaMode adapter shape (Scenario D): read returns the enum,
-	//   write accepts either the enum or a raw string.
+	//   Stored tokens: 'tranco', 'cisco', 'domcop', 'majestic' (live; the latter
+	//   two added ADR-59 P4); legacy 'alexa' (dead service, #872) coalesces to
+	//   Tranco at the read boundary. Mirrors the PfbAliasDeltaMode adapter shape
+	//   (Scenario D): read returns the enum, write accepts either the enum or a
+	//   raw string.
 	// -----------------------------------------------------------------------
 
 	public function testTop1mSourceReadTrancoReturnsTranco(): void
@@ -686,6 +688,17 @@ final class CfgAdaptersTest extends TestCase
 	public function testTop1mSourceReadCiscoReturnsCisco(): void
 	{
 		$this->assertSame(Top1mSource::Cisco, pfb_cfg_top1m_source_read('cisco'));
+	}
+
+	/** ADR-59 P4: the two new keyless-provider tokens read as their own enum cases. */
+	public function testTop1mSourceReadDomCopReturnsDomCop(): void
+	{
+		$this->assertSame(Top1mSource::DomCop, pfb_cfg_top1m_source_read('domcop'));
+	}
+
+	public function testTop1mSourceReadMajesticReturnsMajestic(): void
+	{
+		$this->assertSame(Top1mSource::Majestic, pfb_cfg_top1m_source_read('majestic'));
 	}
 
 	/** The dead legacy TOP1M source (#872) must read as Tranco, not a lost 'alexa' value. */
@@ -709,10 +722,10 @@ final class CfgAdaptersTest extends TestCase
 		$this->assertSame(Top1mSource::Tranco, pfb_cfg_top1m_source_read(''));
 	}
 
-	/** write(read(v)) == v for the two live canonical tokens. */
+	/** write(read(v)) == v for all four live canonical tokens (domcop/majestic added P4). */
 	public function testTop1mSourceRoundTripCanonicalTokens(): void
 	{
-		foreach (['tranco', 'cisco'] as $token) {
+		foreach (['tranco', 'cisco', 'domcop', 'majestic'] as $token) {
 			$written = pfb_cfg_top1m_source_write(pfb_cfg_top1m_source_read($token));
 			$this->assertSame($token, $written,
 				"expected write(read('{$token}')) == '{$token}'; actual: '{$written}'");
@@ -730,9 +743,13 @@ final class CfgAdaptersTest extends TestCase
 	/** pfb_cfg_top1m_source_write() accepts both an enum instance and a string. */
 	public function testTop1mSourceWriteAcceptsEnumOrString(): void
 	{
-		$this->assertSame('tranco', pfb_cfg_top1m_source_write(Top1mSource::Tranco));
-		$this->assertSame('cisco',  pfb_cfg_top1m_source_write(Top1mSource::Cisco));
-		$this->assertSame('tranco', pfb_cfg_top1m_source_write('tranco'));
-		$this->assertSame('cisco',  pfb_cfg_top1m_source_write('cisco'));
+		$this->assertSame('tranco',   pfb_cfg_top1m_source_write(Top1mSource::Tranco));
+		$this->assertSame('cisco',    pfb_cfg_top1m_source_write(Top1mSource::Cisco));
+		$this->assertSame('domcop',   pfb_cfg_top1m_source_write(Top1mSource::DomCop));
+		$this->assertSame('majestic', pfb_cfg_top1m_source_write(Top1mSource::Majestic));
+		$this->assertSame('tranco',   pfb_cfg_top1m_source_write('tranco'));
+		$this->assertSame('cisco',    pfb_cfg_top1m_source_write('cisco'));
+		$this->assertSame('domcop',   pfb_cfg_top1m_source_write('domcop'));
+		$this->assertSame('majestic', pfb_cfg_top1m_source_write('majestic'));
 	}
 }

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -673,11 +673,11 @@ final class CfgAdaptersTest extends TestCase
 
 	// -----------------------------------------------------------------------
 	// Scenario E — Top1mSource (alexa_type, issue #877)
-	//   Stored tokens: 'tranco', 'cisco', 'domcop', 'majestic' (live; the latter
-	//   two added ADR-59 P4); legacy 'alexa' (dead service, #872) coalesces to
-	//   Tranco at the read boundary. Mirrors the PfbAliasDeltaMode adapter shape
-	//   (Scenario D): read returns the enum, write accepts either the enum or a
-	//   raw string.
+	//   Stored tokens: 'tranco', 'cisco', 'domcop', 'majestic', 'cloudflare' (live;
+	//   the latter three added ADR-59 P4/P5); legacy 'alexa' (dead service, #872)
+	//   coalesces to Tranco at the read boundary. Mirrors the PfbAliasDeltaMode
+	//   adapter shape (Scenario D): read returns the enum, write accepts either
+	//   the enum or a raw string.
 	// -----------------------------------------------------------------------
 
 	public function testTop1mSourceReadTrancoReturnsTranco(): void
@@ -701,6 +701,12 @@ final class CfgAdaptersTest extends TestCase
 		$this->assertSame(Top1mSource::Majestic, pfb_cfg_top1m_source_read('majestic'));
 	}
 
+	/** ADR-59 P5: the token-authenticated Cloudflare Radar token reads as its own enum case. */
+	public function testTop1mSourceReadCloudflareReturnsCloudflare(): void
+	{
+		$this->assertSame(Top1mSource::Cloudflare, pfb_cfg_top1m_source_read('cloudflare'));
+	}
+
 	/** The dead legacy TOP1M source (#872) must read as Tranco, not a lost 'alexa' value. */
 	public function testTop1mSourceReadLegacyAlexaCoalescesToTranco(): void
 	{
@@ -722,10 +728,13 @@ final class CfgAdaptersTest extends TestCase
 		$this->assertSame(Top1mSource::Tranco, pfb_cfg_top1m_source_read(''));
 	}
 
-	/** write(read(v)) == v for all four live canonical tokens (domcop/majestic added P4). */
+	/**
+	 * write(read(v)) == v for all five live canonical tokens (domcop/majestic added
+	 * P4, cloudflare added P5).
+	 */
 	public function testTop1mSourceRoundTripCanonicalTokens(): void
 	{
-		foreach (['tranco', 'cisco', 'domcop', 'majestic'] as $token) {
+		foreach (['tranco', 'cisco', 'domcop', 'majestic', 'cloudflare'] as $token) {
 			$written = pfb_cfg_top1m_source_write(pfb_cfg_top1m_source_read($token));
 			$this->assertSame($token, $written,
 				"expected write(read('{$token}')) == '{$token}'; actual: '{$written}'");
@@ -743,13 +752,15 @@ final class CfgAdaptersTest extends TestCase
 	/** pfb_cfg_top1m_source_write() accepts both an enum instance and a string. */
 	public function testTop1mSourceWriteAcceptsEnumOrString(): void
 	{
-		$this->assertSame('tranco',   pfb_cfg_top1m_source_write(Top1mSource::Tranco));
-		$this->assertSame('cisco',    pfb_cfg_top1m_source_write(Top1mSource::Cisco));
-		$this->assertSame('domcop',   pfb_cfg_top1m_source_write(Top1mSource::DomCop));
-		$this->assertSame('majestic', pfb_cfg_top1m_source_write(Top1mSource::Majestic));
-		$this->assertSame('tranco',   pfb_cfg_top1m_source_write('tranco'));
-		$this->assertSame('cisco',    pfb_cfg_top1m_source_write('cisco'));
-		$this->assertSame('domcop',   pfb_cfg_top1m_source_write('domcop'));
-		$this->assertSame('majestic', pfb_cfg_top1m_source_write('majestic'));
+		$this->assertSame('tranco',     pfb_cfg_top1m_source_write(Top1mSource::Tranco));
+		$this->assertSame('cisco',      pfb_cfg_top1m_source_write(Top1mSource::Cisco));
+		$this->assertSame('domcop',     pfb_cfg_top1m_source_write(Top1mSource::DomCop));
+		$this->assertSame('majestic',   pfb_cfg_top1m_source_write(Top1mSource::Majestic));
+		$this->assertSame('cloudflare', pfb_cfg_top1m_source_write(Top1mSource::Cloudflare));
+		$this->assertSame('tranco',     pfb_cfg_top1m_source_write('tranco'));
+		$this->assertSame('cisco',      pfb_cfg_top1m_source_write('cisco'));
+		$this->assertSame('domcop',     pfb_cfg_top1m_source_write('domcop'));
+		$this->assertSame('majestic',   pfb_cfg_top1m_source_write('majestic'));
+		$this->assertSame('cloudflare', pfb_cfg_top1m_source_write('cloudflare'));
 	}
 }

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -369,7 +369,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame(Top1mSource::Tranco, PfbConfig::read('alexa_type'), "legacy 'alexa' coalesces to Tranco");
 	}
 
-	/** alexa_type: the two live tokens ('tranco'/'cisco') pass through as their enum cases. */
+	/** alexa_type: all four live tokens pass through as their enum cases (domcop/majestic added ADR-59 P4). */
 	public function testReadPassesThroughLiveTop1mSourceTokens(): void
 	{
 		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/alexa_type';
@@ -379,6 +379,12 @@ final class CfgGatewayTest extends TestCase
 
 		$this->seedConfig($path, 'tranco');
 		$this->assertSame(Top1mSource::Tranco, PfbConfig::read('alexa_type'), "'tranco' passes through as Tranco");
+
+		$this->seedConfig($path, 'domcop');
+		$this->assertSame(Top1mSource::DomCop, PfbConfig::read('alexa_type'), "'domcop' passes through as DomCop");
+
+		$this->seedConfig($path, 'majestic');
+		$this->assertSame(Top1mSource::Majestic, PfbConfig::read('alexa_type'), "'majestic' passes through as Majestic");
 	}
 
 	public function testReadReturnsRegisteredDefaultForDnsblInterfaceAbsentKey(): void

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -369,7 +369,10 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame(Top1mSource::Tranco, PfbConfig::read('alexa_type'), "legacy 'alexa' coalesces to Tranco");
 	}
 
-	/** alexa_type: all four live tokens pass through as their enum cases (domcop/majestic added ADR-59 P4). */
+	/**
+	 * alexa_type: all five live tokens pass through as their enum cases (domcop/majestic
+	 * added ADR-59 P4, cloudflare added ADR-59 P5).
+	 */
 	public function testReadPassesThroughLiveTop1mSourceTokens(): void
 	{
 		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/alexa_type';
@@ -385,6 +388,35 @@ final class CfgGatewayTest extends TestCase
 
 		$this->seedConfig($path, 'majestic');
 		$this->assertSame(Top1mSource::Majestic, PfbConfig::read('alexa_type'), "'majestic' passes through as Majestic");
+
+		$this->seedConfig($path, 'cloudflare');
+		$this->assertSame(Top1mSource::Cloudflare, PfbConfig::read('alexa_type'), "'cloudflare' passes through as Cloudflare");
+	}
+
+	/**
+	 * top1m_token (ADR-59 P5): a masked, write-only plain-string field (no adapter) --
+	 * absent reads as the registered default '', and any stored token round-trips
+	 * (write(read(v)) == v) like every other plain field.
+	 *
+	 * Scenario: top1m_token default-absent + round-trip.
+	 *   Given the key is absent from config.xml.
+	 *   When PfbConfig::read('top1m_token').
+	 *   Then the result is '' (the registered default).
+	 *   And when a real-looking token is written then read back, it comes back verbatim.
+	 */
+	public function testTop1mTokenDefaultsToEmptyAndRoundTrips(): void
+	{
+		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/top1m_token';
+
+		// Given/When: absent key.
+		$this->assertNull(config_get_path($path));
+		$this->assertSame('', PfbConfig::read('top1m_token'), 'top1m_token absent -> default ""');
+
+		// Round-trip: write(read(v)) == v for a real-looking base64url/JWT-charset token.
+		$token = 'cf-abc123._~+/=-XYZ';
+		PfbConfig::write('top1m_token', $token);
+		$this->assertSame($token, config_get_path($path), 'top1m_token write() must store the token verbatim');
+		$this->assertSame($token, PfbConfig::read('top1m_token'), 'top1m_token read() must return the stored token verbatim');
 	}
 
 	public function testReadReturnsRegisteredDefaultForDnsblInterfaceAbsentKey(): void
@@ -937,6 +969,7 @@ final class CfgGatewayTest extends TestCase
 			'alexa_type',
 			'alexa_count',
 			'alexa_inclusion',
+			'top1m_token', // ADR-59 P5
 			'pfb_cache',
 			'global_log',
 			'pfb_dnsbl_lenient',

--- a/tests/php/DownloadHttpHeadersTest.php
+++ b/tests/php/DownloadHttpHeadersTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-59 Phase 3 — pfb_download_http_headers().
+ *
+ * pfb_download() offered only HTTP Basic (CURLOPT_USERPWD) and query-param URLs; a
+ * future header-authenticated provider (Cloudflare Radar, Phase 5) needs an
+ * 'Authorization: Bearer <token>' header. CURLOPT_HTTPHEADER already carries the
+ * ADR-42 conditional-GET 'If-None-Match' header and REPLACES the whole list on every
+ * call, so a naive second curl_setopt(CURLOPT_HTTPHEADER, ...) for caller headers would
+ * silently clobber the conditional-GET header (or vice-versa). This pins the merge:
+ * both headers survive together, and pfb_download() itself has no off-appliance double
+ * for its curl/exec surface (tests/php/README.md "Out of scope"), so the assembly is
+ * extracted into this pure, directly-testable helper.
+ */
+#[CoversFunction('pfb_download_http_headers')]
+final class DownloadHttpHeadersTest extends TestCase
+{
+	/**
+	 * The pinning case from the phase brief: a conditional-GET header AND a
+	 * caller-supplied Bearer token must BOTH survive the merge.
+	 *
+	 *  GIVEN a conditional-GET header (If-None-Match) and a caller-supplied
+	 *        'Authorization: Bearer x' header;
+	 *   WHEN pfb_download_http_headers() merges them;
+	 *   THEN the assembled CURLOPT_HTTPHEADER list contains BOTH — neither is
+	 *        clobbered by the other.
+	 */
+	public function testConditionalGetAndCallerHeaderBothSurviveTheMerge(): void
+	{
+		$merged = pfb_download_http_headers(
+			array('Authorization: Bearer x'),
+			'If-None-Match: "etag123"'
+		);
+
+		$this->assertContains(
+			'If-None-Match: "etag123"',
+			$merged,
+			'the conditional-GET header must survive a merge with a caller header'
+		);
+		$this->assertContains(
+			'Authorization: Bearer x',
+			$merged,
+			'the caller-supplied header must survive a merge with the conditional-GET header'
+		);
+		$this->assertCount(2, $merged, 'exactly the two headers, nothing dropped or duplicated');
+	}
+
+	/**
+	 * Today's behaviour (no caller ever sets $extra_headers yet): a conditional-GET
+	 * header alone produces the SAME single-element list pfb_download() built directly
+	 * before this phase — byte-for-byte, so every existing conditional-GET probe is
+	 * unaffected by the refactor.
+	 *
+	 *  GIVEN no caller-supplied headers and a conditional-GET header;
+	 *   WHEN pfb_download_http_headers() merges them;
+	 *   THEN the result is the single conditional-GET header, unchanged.
+	 */
+	public function testConditionalGetHeaderAloneIsUnchanged(): void
+	{
+		$merged = pfb_download_http_headers(array(), 'If-None-Match: "etag123"');
+
+		$this->assertSame(
+			array('If-None-Match: "etag123"'),
+			$merged,
+			'with no extra headers, the merge must reproduce the pre-Phase-3 single-element list exactly'
+		);
+	}
+
+	/**
+	 * A caller header with no conditional-GET in play (the Cloudflare Radar shape,
+	 * Phase 5): the Bearer header rides alone.
+	 *
+	 *  GIVEN a caller-supplied header and NO conditional-GET header ('');
+	 *   WHEN pfb_download_http_headers() merges them;
+	 *   THEN the result is just the caller header.
+	 */
+	public function testCallerHeaderAloneWithNoConditionalGet(): void
+	{
+		$merged = pfb_download_http_headers(array('Authorization: Bearer x'), '');
+
+		$this->assertSame(array('Authorization: Bearer x'), $merged);
+	}
+
+	/**
+	 * Neither side supplies anything (every feed today, outside an in-flight
+	 * change_detect probe with a stored ETag): the merge returns an empty list, so
+	 * pfb_download() knows to skip curl_setopt(CURLOPT_HTTPHEADER, ...) entirely —
+	 * matching the pre-Phase-3 code path exactly.
+	 *
+	 *  GIVEN no caller headers and no conditional-GET header;
+	 *   WHEN pfb_download_http_headers() merges them;
+	 *   THEN the result is an empty array.
+	 */
+	public function testBothEmptyProducesEmptyList(): void
+	{
+		$this->assertSame(array(), pfb_download_http_headers(array(), ''));
+	}
+
+	/**
+	 * Defensive: a non-string or empty entry in $extra_headers is dropped rather than
+	 * corrupting the CURLOPT_HTTPHEADER list (curl_setopt would choke on a non-string).
+	 *
+	 *  GIVEN $extra_headers containing a valid header, an empty string, and a non-string;
+	 *   WHEN pfb_download_http_headers() merges them;
+	 *   THEN only the valid header survives.
+	 */
+	public function testNonStringAndEmptyEntriesAreDropped(): void
+	{
+		$merged = pfb_download_http_headers(array('X-Ok: 1', '', 123, NULL), '');
+
+		$this->assertSame(array('X-Ok: 1'), $merged);
+	}
+}

--- a/tests/php/PfbFilterTest.php
+++ b/tests/php/PfbFilterTest.php
@@ -135,6 +135,76 @@ final class PfbFilterTest extends TestCase
 		$this->assertSame($expected, pfb_filter($input, PFB_FILTER_NUM));
 	}
 
+	public static function tokenProvider(): array
+	{
+		return [
+			// A realistic base64url/JWT-shaped credential (dots, dash, tilde, plus, slash,
+			// equals -- the exact punctuation PFB_FILTER_WORD would reject).
+			'realistic token'  => ['cf-abc123._~+/=-XYZ', 'cf-abc123._~+/=-XYZ'],
+			'too short'        => ['short12', ''],
+			'space rejected'   => ['has a space', ''],
+			'colon rejected'   => ['bad:token', ''],
+			'quote rejected'   => ["bad'token", ''],
+			'too long'         => [str_repeat('a', 513), ''],
+			'exactly max ok'   => [str_repeat('a', 512), str_repeat('a', 512)],
+			'exactly min ok'   => ['a1234567', 'a1234567'],
+		];
+	}
+
+	#[DataProvider('tokenProvider')]
+	public function testTokenFilter(string $input, string $expected): void
+	{
+		$this->assertSame($expected, pfb_filter($input, PFB_FILTER_TOKEN));
+	}
+
+	/**
+	 * ADR-59 P5 (security): a token rejected by PFB_FILTER_TOKEN must NEVER be logged --
+	 * not even at debug level -- when the caller identifies itself via the 'top1m_token'
+	 * reference. This is the load-bearing proof for the pfb_filter() exceptions list
+	 * (pfblockerng.inc ~1655) this phase added 'top1m_token' to, alongside the
+	 * pre-existing 'DNSBL_Download' exception. A DIFFERENT reference (the normal case
+	 * for every other pfb_filter() caller) still logs the reject -- proving the
+	 * suppression is genuinely conditional on the reference, not a side effect of
+	 * PFB_FILTER_TOKEN itself.
+	 */
+	public function testTokenFilterRejectionNeverLogsForTop1mTokenReferenceButOtherReferencesStillDo(): void
+	{
+		$errlog = tempnam(sys_get_temp_dir(), 'pfb_filter_token_errlog_');
+		$this->assertNotFalse($errlog, 'could not create temp errlog');
+		$saved = array_key_exists('errlog', $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb']['errlog'] : false;
+		$GLOBALS['pfb']['errlog'] = $errlog;
+
+		try {
+			$secret = 'REJECTED-SECRET-should-never-be-logged!!!';
+
+			// Given/When: reference 'top1m_token' -- the ADR-59 P5 exception.
+			$this->assertSame('', pfb_filter($secret, PFB_FILTER_TOKEN, 'top1m_token'));
+			// Then: the rejected value never reaches the error log.
+			$this->assertStringNotContainsString(
+				$secret,
+				(string) file_get_contents($errlog),
+				'a token rejected via the top1m_token reference must never be logged'
+			);
+
+			// Given/When: a DIFFERENT (ordinary) reference for the same rejected input.
+			$this->assertSame('', pfb_filter($secret, PFB_FILTER_TOKEN, 'some_other_caller'));
+			// Then: the suppression is genuinely reference-scoped -- an ordinary caller
+			// still gets its reject logged (the pre-existing, unchanged behaviour).
+			$this->assertStringContainsString(
+				$secret,
+				(string) file_get_contents($errlog),
+				'a non-top1m_token reference must still log its rejected input as before'
+			);
+		} finally {
+			if ($saved === false) {
+				unset($GLOBALS['pfb']['errlog']);
+			} else {
+				$GLOBALS['pfb']['errlog'] = $saved;
+			}
+			unlink($errlog);
+		}
+	}
+
 	public function testControlCharactersRejected(): void
 	{
 		// A control char anywhere makes the whole input fail, returning default.

--- a/tests/php/PfbFilterTest.php
+++ b/tests/php/PfbFilterTest.php
@@ -148,6 +148,12 @@ final class PfbFilterTest extends TestCase
 			'too long'         => [str_repeat('a', 513), ''],
 			'exactly max ok'   => [str_repeat('a', 512), str_repeat('a', 512)],
 			'exactly min ok'   => ['a1234567', 'a1234567'],
+			// #892 review: PCRE's '$' matches before a trailing '\n' by default, so a
+			// token smuggling a trailing newline would otherwise pass the character-class
+			// check unmodified -- the 'D' flag (or '\z') pins '$' to the true end of the
+			// string, matching the same discipline PFB_FILTER_URL etc. don't need here
+			// (a token is the one filter mode taking a raw untrusted secret).
+			'trailing newline rejected' => ["a1234567\n", ''],
 		];
 	}
 

--- a/tests/php/RollbackContractTest.php
+++ b/tests/php/RollbackContractTest.php
@@ -1240,21 +1240,22 @@ final class RollbackContractTest extends TestCase
 
 	/**
 	 * alexa_type: FORWARD invariant covers the legacy 'alexa' token (dead TOP1M
-	 * service, #872) in addition to the live 'tranco'/'cisco'/'domcop'/'majestic'
-	 * vocabulary; BACKWARD invariant proves the coalesce -- a write after reading
-	 * a legacy 'alexa' store never re-emits 'alexa'.
+	 * service, #872) in addition to the live 'tranco'/'cisco'/'domcop'/'majestic'/
+	 * 'cloudflare' vocabulary; BACKWARD invariant proves the coalesce -- a write
+	 * after reading a legacy 'alexa' store never re-emits 'alexa'.
 	 *
 	 * Scenario: alexa_type rollback contract with the #877 coalesce.
 	 *   Background: alexa_type's stored vocabulary is {'tranco', 'cisco', 'domcop',
-	 *     'majestic', 'alexa'} (the latter two live tokens added ADR-59 P4; 'alexa'
-	 *     is READ-only -- pfb_cfg_field_vocab()['top1m_source'] lists only the four
-	 *     live WRITE-side tokens). The field is now adapted via the Top1mSource enum
-	 *     (mirrors PfbIdnMode/PfbAliasDeltaMode).
-	 *   Given each of 'tranco', 'cisco', 'domcop', 'majestic', 'alexa' stored.
+	 *     'majestic', 'cloudflare', 'alexa'} (the latter three live tokens added
+	 *     ADR-59 P4/P5; 'alexa' is READ-only -- pfb_cfg_field_vocab()['top1m_source']
+	 *     lists only the five live WRITE-side tokens). The field is now adapted via
+	 *     the Top1mSource enum (mirrors PfbIdnMode/PfbAliasDeltaMode).
+	 *   Given each of 'tranco', 'cisco', 'domcop', 'majestic', 'cloudflare', 'alexa' stored.
 	 *   When PfbConfig::read('alexa_type') then PfbConfig::write('alexa_type', result).
 	 *   Then (FORWARD) the read result is a Top1mSource enum (Tranco for legacy 'alexa').
-	 *   And (BACKWARD) the written token is in {'tranco', 'cisco', 'domcop', 'majestic'}
-	 *     -- 'alexa' is NEVER re-emitted, even though it was the original stored value.
+	 *   And (BACKWARD) the written token is in {'tranco', 'cisco', 'domcop', 'majestic',
+	 *     'cloudflare'} -- 'alexa' is NEVER re-emitted, even though it was the original
+	 *     stored value.
 	 */
 	public function testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa(): void
 	{
@@ -1262,11 +1263,12 @@ final class RollbackContractTest extends TestCase
 		$write_vocab = pfb_cfg_field_vocab()['top1m_source'];
 
 		$cases = [
-			'tranco'   => Top1mSource::Tranco,
-			'cisco'    => Top1mSource::Cisco,
-			'domcop'   => Top1mSource::DomCop,   // ADR-59 P4
-			'majestic' => Top1mSource::Majestic, // ADR-59 P4
-			'alexa'    => Top1mSource::Tranco,   // legacy dead source coalesces to Tranco (#872/#877)
+			'tranco'     => Top1mSource::Tranco,
+			'cisco'      => Top1mSource::Cisco,
+			'domcop'     => Top1mSource::DomCop,     // ADR-59 P4
+			'majestic'   => Top1mSource::Majestic,   // ADR-59 P4
+			'cloudflare' => Top1mSource::Cloudflare, // ADR-59 P5
+			'alexa'      => Top1mSource::Tranco,     // legacy dead source coalesces to Tranco (#872/#877)
 		];
 
 		foreach ($cases as $stored_token => $expected_runtime) {

--- a/tests/php/RollbackContractTest.php
+++ b/tests/php/RollbackContractTest.php
@@ -1240,20 +1240,21 @@ final class RollbackContractTest extends TestCase
 
 	/**
 	 * alexa_type: FORWARD invariant covers the legacy 'alexa' token (dead TOP1M
-	 * service, #872) in addition to the live 'tranco'/'cisco' vocabulary; BACKWARD
-	 * invariant proves the coalesce -- a write after reading a legacy 'alexa'
-	 * store never re-emits 'alexa'.
+	 * service, #872) in addition to the live 'tranco'/'cisco'/'domcop'/'majestic'
+	 * vocabulary; BACKWARD invariant proves the coalesce -- a write after reading
+	 * a legacy 'alexa' store never re-emits 'alexa'.
 	 *
 	 * Scenario: alexa_type rollback contract with the #877 coalesce.
-	 *   Background: alexa_type's stored vocabulary is {'tranco', 'cisco', 'alexa'}
-	 *     (the legacy value is READ-only -- pfb_cfg_field_vocab()['top1m_source']
-	 *     lists only the two live WRITE-side tokens). The field is now adapted via
-	 *     the Top1mSource enum (mirrors PfbIdnMode/PfbAliasDeltaMode).
-	 *   Given each of 'tranco', 'cisco', 'alexa' stored.
+	 *   Background: alexa_type's stored vocabulary is {'tranco', 'cisco', 'domcop',
+	 *     'majestic', 'alexa'} (the latter two live tokens added ADR-59 P4; 'alexa'
+	 *     is READ-only -- pfb_cfg_field_vocab()['top1m_source'] lists only the four
+	 *     live WRITE-side tokens). The field is now adapted via the Top1mSource enum
+	 *     (mirrors PfbIdnMode/PfbAliasDeltaMode).
+	 *   Given each of 'tranco', 'cisco', 'domcop', 'majestic', 'alexa' stored.
 	 *   When PfbConfig::read('alexa_type') then PfbConfig::write('alexa_type', result).
 	 *   Then (FORWARD) the read result is a Top1mSource enum (Tranco for legacy 'alexa').
-	 *   And (BACKWARD) the written token is in {'tranco', 'cisco'} -- 'alexa' is
-	 *     NEVER re-emitted, even though it was the original stored value.
+	 *   And (BACKWARD) the written token is in {'tranco', 'cisco', 'domcop', 'majestic'}
+	 *     -- 'alexa' is NEVER re-emitted, even though it was the original stored value.
 	 */
 	public function testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa(): void
 	{
@@ -1261,9 +1262,11 @@ final class RollbackContractTest extends TestCase
 		$write_vocab = pfb_cfg_field_vocab()['top1m_source'];
 
 		$cases = [
-			'tranco' => Top1mSource::Tranco,
-			'cisco'  => Top1mSource::Cisco,
-			'alexa'  => Top1mSource::Tranco, // legacy dead source coalesces to Tranco (#872/#877)
+			'tranco'   => Top1mSource::Tranco,
+			'cisco'    => Top1mSource::Cisco,
+			'domcop'   => Top1mSource::DomCop,   // ADR-59 P4
+			'majestic' => Top1mSource::Majestic, // ADR-59 P4
+			'alexa'    => Top1mSource::Tranco,   // legacy dead source coalesces to Tranco (#872/#877)
 		];
 
 		foreach ($cases as $stored_token => $expected_runtime) {

--- a/tests/php/Top1mAuthHeadersTest.php
+++ b/tests/php/Top1mAuthHeadersTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-59 Phase 5 — pfb_top1m_auth_headers().
+ *
+ * Cloudflare Radar (the first token-authenticated TOP1M provider) needs an
+ * 'Authorization: Bearer <token>' header built from the user's top1m_token and the
+ * active provider's 'auth' descriptor. This is pure/no-I/O (same extraction rationale
+ * as pfb_download_http_headers(), Phase 3) so it is directly unit-testable; it is also
+ * the ONLY code that touches the raw token before it reaches pfb_download(), so proving
+ * it never logs anything (no pfb_logger call exists in its body at all) is the load-
+ * bearing "the token never reaches a log" guarantee for the whole feature.
+ */
+#[CoversFunction('pfb_top1m_auth_headers')]
+final class Top1mAuthHeadersTest extends TestCase
+{
+	private const CLOUDFLARE_AUTH = ['header' => 'Authorization', 'scheme' => 'Bearer'];
+
+	/**
+	 * The Cloudflare shape: a non-empty token produces exactly one Bearer header.
+	 *
+	 *  GIVEN a provider descriptor whose 'auth' needs a header (Cloudflare's shape)
+	 *        and a real-looking token;
+	 *   WHEN pfb_top1m_auth_headers() builds the caller headers;
+	 *   THEN the result is a single 'Authorization: Bearer <token>' header.
+	 */
+	public function testHeaderAuthProviderWithTokenProducesBearerHeader(): void
+	{
+		$provider = ['auth' => self::CLOUDFLARE_AUTH];
+
+		$this->assertSame(
+			['Authorization: Bearer cf-abc123'],
+			pfb_top1m_auth_headers($provider, 'cf-abc123')
+		);
+	}
+
+	/**
+	 * Safe-on-missing-token (#886 class): an EMPTY token yields no header at all --
+	 * pfb_download() then sends the request with no Authorization header, which fails
+	 * safely (the provider rejects it) rather than sending a malformed header.
+	 *
+	 *  GIVEN a provider descriptor whose 'auth' needs a header but NO token is stored;
+	 *   WHEN pfb_top1m_auth_headers() builds the caller headers;
+	 *   THEN the result is an empty list.
+	 */
+	public function testHeaderAuthProviderWithEmptyTokenProducesNoHeader(): void
+	{
+		$provider = ['auth' => self::CLOUDFLARE_AUTH];
+
+		$this->assertSame([], pfb_top1m_auth_headers($provider, ''));
+	}
+
+	/**
+	 * Every keyless provider (auth == 'none', Tranco/Cisco/DomCop/Majestic today) must
+	 * never emit a header, EVEN IF a token happens to be stored (e.g. left over from a
+	 * prior Cloudflare selection) -- only the active provider's OWN auth requirement
+	 * governs whether the token is sent.
+	 *
+	 *  GIVEN a keyless provider descriptor (auth == 'none') and a non-empty token;
+	 *   WHEN pfb_top1m_auth_headers() builds the caller headers;
+	 *   THEN the result is an empty list -- the token is never attached.
+	 */
+	public function testKeylessProviderNeverEmitsAHeaderEvenWithATokenPresent(): void
+	{
+		$provider = ['auth' => 'none'];
+
+		$this->assertSame([], pfb_top1m_auth_headers($provider, 'cf-abc123'));
+	}
+
+	/** A provider descriptor missing 'auth' entirely defaults to no header (defensive). */
+	public function testMissingAuthKeyDefaultsToNoHeader(): void
+	{
+		$this->assertSame([], pfb_top1m_auth_headers([], 'cf-abc123'));
+	}
+
+	/** A schemeless header auth (no Bearer/Basic prefix) sends the token bare. */
+	public function testEmptySchemeSendsTokenBareInTheHeaderValue(): void
+	{
+		$provider = ['auth' => ['header' => 'X-Api-Key', 'scheme' => '']];
+
+		$this->assertSame(
+			['X-Api-Key: raw-token'],
+			pfb_top1m_auth_headers($provider, 'raw-token')
+		);
+	}
+}

--- a/tests/php/Top1mAuthHeadersTest.php
+++ b/tests/php/Top1mAuthHeadersTest.php
@@ -88,4 +88,25 @@ final class Top1mAuthHeadersTest extends TestCase
 			pfb_top1m_auth_headers($provider, 'raw-token')
 		);
 	}
+
+	/**
+	 * #892 review (finding 3, defense-in-depth): a token arriving by a non-UI path (a
+	 * hand-edited config.xml, HA sync, a restored backup) is not re-validated by
+	 * PFB_FILTER_TOKEN before reaching this function -- CR/LF embedded in it must never
+	 * ride into the Authorization header value (header/request splitting).
+	 *
+	 *  GIVEN a provider descriptor whose 'auth' needs a header and a token carrying
+	 *        embedded CR and LF characters;
+	 *   WHEN pfb_top1m_auth_headers() builds the caller headers;
+	 *   THEN the CR/LF is stripped from the emitted header value.
+	 */
+	public function testEmbeddedCrLfInTokenIsStrippedFromTheHeaderValue(): void
+	{
+		$provider = ['auth' => self::CLOUDFLARE_AUTH];
+
+		$this->assertSame(
+			['Authorization: Bearer cf-abc123injected'],
+			pfb_top1m_auth_headers($provider, "cf-abc123\r\ninjected")
+		);
+	}
 }

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -37,6 +37,12 @@ use PHPUnit\Framework\TestCase;
  *   * valid feed with matches -> whitelist REPLACED with the fresh build
  *   * valid feed with zero TLD matches -> whitelist replaced (with empty content) + a
  *     mild info note, NOT the dead-feed warning (a real feed just matched nothing)
+ *
+ * ADR-59 P2 addendum: pfblockerng_top1m() now drives header-skip/domain-column/the
+ * numeric-rank guard from the active provider descriptor (pfb_top1m_providers()) instead
+ * of a hardcoded rank,domain-at-column-1 shape.
+ *   * a SYNTHETIC descriptor's header/domain_col knobs are honoured (below) -- no live
+ *     non-Tranco/Cisco provider exists yet (ADR-59 Phase 4 adds one)
  */
 #[CoversFunction('pfblockerng_top1m')]
 final class Top1mPreserveOnEmptyFeedTest extends TestCase
@@ -340,5 +346,41 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertStringContainsString('0 domains matched the configured TLD inclusions', $this->readMainLog());
 		$this->assertStringNotContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
 		$this->assertStringNotContainsString('keeping the previous TOP1M whitelist', $this->readErrLog());
+	}
+
+	/**
+	 * ADR-59 P2 -- the builder reads its header-skip/domain-column knobs from the active
+	 * provider descriptor instead of the original hardcoded "domain always at CSV index 1,
+	 * never a header row" shape. Proven via the $provider_override test seam (no live
+	 * provider needs this shape yet -- Phase 4 adds one) against a synthetic 'csv' parse
+	 * descriptor whose header row itself contains a '.'/',' (so it would otherwise pass the
+	 * dead-feed content filter) and whose domain sits at index 2, not 1.
+	 *
+	 * RED on the pre-P2 parser: it has no header-skip at all and always reads index 1, so
+	 * the header row is misread as data (accidentally dropped by the rank-column guard) and
+	 * the real data row's domain is read from the wrong column ('1', the tld_rank field) --
+	 * producing an EMPTY whitelist + "Found 0". GREEN after: the header row is skipped, the
+	 * domain comes from index 2, and the whitelist is populated.
+	 */
+	public function testSyntheticDescriptorAppliesHeaderSkipAndDomainColumn(): void
+	{
+		// Given: a header row containing a '.' and a ',' (so skipping it must be driven by
+		// the 'header' knob, not merely by the pre-existing content/rank filters) followed
+		// by one data row whose domain is the THIRD CSV field (0-indexed domain_col 2).
+		$csv = "rank,tld.rank,domain\n1,1,example.com\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: synthetic-shape top-1m.csv');
+		$syntheticDescriptor = ['parse' => 'csv', 'header' => true, 'domain_col' => 2];
+
+		// When
+		pfblockerng_top1m($syntheticDescriptor);
+
+		// Then: the header row was skipped (only 1 line parsed) and the domain came from
+		// index 2 -- not the rank_domain default's index 1 (which would have read '1' and
+		// matched nothing).
+		$got = file_get_contents($this->whitelistPath());
+		$this->assertNotFalse($got);
+		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+			'the domain must come from domain_col (index 2), and the header row must not count as data');
+		$this->assertStringContainsString('Parsed 1 lines | Found 1 of 1000', $this->readMainLog());
 	}
 }

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -471,6 +471,11 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 * instead probes a WRONG column for DomCop's shape (domain_col 2 -- the
 	 * "Open Page Rank" field, Majestic's own domain_col) and shows it likewise
 	 * mis-reads; the registered DomCop descriptor (domain_col 1) is correct.
+	 *
+	 * #892 review addendum: the wrong column's value ("10.00") also doesn't look
+	 * like a hostname, so the domain-validity guard (finding 1) now rejects it as
+	 * no-real-data rather than "valid data, zero TLD matches" -- the BEFORE
+	 * assertions reflect that (no whitelist file at all, not an empty one).
 	 */
 	public function testDomCopRealShapeSampleMisreadsOnWrongColumnAndParsesCorrectlyViaItsDescriptor(): void
 	{
@@ -482,17 +487,17 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: real-shape DomCop sample');
 
 		// When (BEFORE): the WRONG column for this shape -- index 2 ("Open Page
-		// Rank", a decimal string with no matching TLD).
+		// Rank", a decimal string with no matching TLD, and no matching hostname shape).
 		$wrongColumn = ['parse' => 'csv', 'header' => true, 'domain_col' => 2];
 		pfblockerng_top1m($wrongColumn);
 
 		// Then (RED): the real domains are misread as the Open Page Rank value
-		// ("10.00" -> tld "00"), so neither matches and the whitelist is empty.
-		$this->assertSame('', file_get_contents($this->whitelistPath()),
+		// ("10.00"), which is neither a valid TLD match NOR a hostname-shaped value --
+		// no whitelist can be built (none existed before this run).
+		$this->assertFileDoesNotExist($this->whitelistPath(),
 			"domain_col 2 must MIS-read DomCop's real shape -- Domain sits at index 1, not 2");
-		$this->assertStringContainsString('Parsed 2 lines | Found 0 of 1000', $this->readMainLog());
-		$this->assertStringContainsString('0 domains matched the configured TLD inclusions', $this->readMainLog());
-		$this->assertStringNotContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+		$this->assertStringContainsString('no TOP1M whitelist available', $this->readMainLog());
+		$this->assertStringNotContainsString('Parsed 2 lines', $this->readMainLog());
 
 		// Reset the log so the GREEN assertion below is unambiguous.
 		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['log'], ''), 'reset main log between runs');
@@ -552,6 +557,96 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	}
 
 	/**
+	 * #892 review (finding 1) -- the #886 silent-whitelist-wipe must not re-open for the
+	 * 'csv' parse providers (DomCop/Majestic/Cloudflare). Pre-fix, the domain-validity
+	 * guard only covered 'rank_domain' (Tranco/Cisco); a 'csv'-mode garbage/HTML/JSON
+	 * error body (a CDN 503 page, a Cloudflare auth-error response, etc -- the MIME
+	 * allow-list accepts text/html and ADR-49's sanity scan is opt-in/default-off) still
+	 * has a '.' and a ',' somewhere, so it passed the generic content filter, counted as
+	 * a "valid" parsed row, and the "valid feed" branch swapped the (empty) build over a
+	 * good whitelist -- reporting success, not a warning. Each provider gets its own
+	 * real-descriptor-driven proof below; the FAIL-BEFORE state is proven by the shared
+	 * mechanism (the 'csv' branch had NO validity guard at all before this fix -- every
+	 * garbage row here has a non-hostname domain field but would still have incremented
+	 * $linecnt on the pre-fix code, taking the wipe path).
+	 */
+	public function testDomCopGarbageHtmlBodyPreservesPriorWhitelistAndWarns(): void
+	{
+		// Given: a prior good whitelist and a multi-line HTML error body (a CDN 503 page,
+		// NOT DomCop's real quoted rank/domain/pagerank CSV) written as top-1m.csv.
+		$priorContent = ".real.com,,\n,real.com,,\n,www.real.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
+		$garbage = "<html><head><title>503 Backend fetch failed</title></head>\n"
+			. "<body><h1>Error 503 Backend fetch failed</h1>\n"
+			. "<p>Guru meditation, please retry. ref.12345</p></body></html>\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $garbage), 'setup: garbage HTML body as top-1m.csv');
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
+
+		// When: the real registered DomCop descriptor drives the parse (header=TRUE skips
+		// line 1; domain_col=1).
+		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::DomCop->value]);
+
+		// Then: the HTML body must never be mistaken for real DomCop CSV data -- the prior
+		// whitelist survives byte-identical and the run warns instead of "succeeding".
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
+			'a garbage HTML body must NOT wipe the previously-good TOP1M whitelist (DomCop, #892 review)');
+		$this->assertSame([], $this->tempFilesLeftBehind(), 'no temp build file left behind');
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readErrLog());
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+	}
+
+	/** Same proof as above, for Majestic's registered descriptor (header=TRUE, domain_col=2). */
+	public function testMajesticGarbagePlaintextBodyPreservesPriorWhitelistAndWarns(): void
+	{
+		// Given: a prior good whitelist and a garbage body shaped like Majestic's real CSV
+		// (12-col header + a data row) but whose Domain column is a prose error message.
+		$priorContent = ".real.com,,\n,real.com,,\n,www.real.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
+		$garbage = "GlobalRank,TldRank,Domain,TLD,RefSubNets,RefIPs,IDN_Domain,IDN_TLD,PrevGlobalRank,PrevTldRank,PrevRefSubNets,PrevRefIPs\n"
+			. "1,1,Service temporarily unavailable. Please retry.,text,0,0,,,0,0,0,0\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $garbage), 'setup: garbage Domain-column body as top-1m.csv');
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
+
+		// When: the real registered Majestic descriptor drives the parse.
+		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::Majestic->value]);
+
+		// Then: the prose "domain" must never be mistaken for real Majestic CSV data.
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
+			'a garbage Domain-column body must NOT wipe the previously-good TOP1M whitelist (Majestic, #892 review)');
+		$this->assertSame([], $this->tempFilesLeftBehind(), 'no temp build file left behind');
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readErrLog());
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+	}
+
+	/**
+	 * Same proof as above, for Cloudflare's registered descriptor (header=TRUE,
+	 * domain_col=0 -- the single-column shape where the comma requirement is relaxed, so
+	 * this is the strictest case: only the new domain-validity regex stands between a
+	 * JSON error body and a "valid feed" verdict.
+	 */
+	public function testCloudflareGarbageJsonBodyPreservesPriorWhitelistAndWarns(): void
+	{
+		// Given: a prior good whitelist and a Cloudflare-shaped ('domain' header, single
+		// column) body whose only "data" line is a JSON auth-error response, not a domain.
+		$priorContent = ".real.com,,\n,real.com,,\n,www.real.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
+		$garbage = "domain\n"
+			. "{\"success\":false,\"errors\":[{\"code\":10000,\"message\":\"Authentication error.\"}]}\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $garbage), 'setup: garbage JSON body as top-1m.csv');
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
+
+		// When: the real registered Cloudflare descriptor drives the parse.
+		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::Cloudflare->value]);
+
+		// Then: the JSON error body must never be mistaken for a real Cloudflare domain row.
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
+			'a garbage JSON body must NOT wipe the previously-good TOP1M whitelist (Cloudflare, #892 review)');
+		$this->assertSame([], $this->tempFilesLeftBehind(), 'no temp build file left behind');
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readErrLog());
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+	}
+
+	/**
 	 * ADR-59 P5 -- safe-on-missing/invalid-token behaviour (ADR §4 requirement 3): when
 	 * Cloudflare's download fails (missing/invalid top1m_token -> pfb_top1m_auth_headers()
 	 * returns no Authorization header -> pfb_download() sends no auth and the request is
@@ -559,9 +654,10 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 * generic "csv absent -> preserve + warn" path every other provider's download failure
 	 * already hits (see testAbsentCsvPreservesPriorWhitelistAndWarns above) -- there is no
 	 * Cloudflare-specific failure branch to bypass. This is the Cloudflare-scoped proof of
-	 * that reuse, plus a DIRECT "no token in any log" assertion: pfblockerng_top1m() never
-	 * reads $pfb['top1m_token'] or any header at all, so a fake secret standing in for a
-	 * real token genuinely cannot appear in either log -- asserted, not assumed.
+	 * that reuse. (The "no token in any log" guarantee itself is proven in
+	 * Top1mAuthHeadersTest.php / PfbFilterTest.php -- pfblockerng_top1m() never reads
+	 * $pfb['top1m_token'] or any header at all, so asserting it here would be vacuous:
+	 * the function never receives the token in the first place.)
 	 */
 	public function testMissingOrInvalidCloudflareTokenPreservesWhitelistAndLogsNoToken(): void
 	{
@@ -572,26 +668,13 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: prior good whitelist');
 		$this->assertFileDoesNotExist($this->csvPath(), 'before-state: no top-1m.csv (simulates a failed download)');
 
-		// A fake secret standing in for a real Cloudflare token, so the log-scan
-		// assertions below are a genuine check rather than a vacuous one.
-		$fakeSecretToken = 'sk-live-should-never-appear-in-any-log-0xDEADBEEF';
-
 		// When: the Cloudflare descriptor is active but top-1m.csv never arrived.
 		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::Cloudflare->value]);
 
 		// Then: the prior whitelist is untouched and a warning was logged (same generic
-		// path as testAbsentCsvPreservesPriorWhitelistAndWarns)...
+		// path as testAbsentCsvPreservesPriorWhitelistAndWarns).
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
 			'a missing top-1m.csv (failed Cloudflare download) must preserve the prior whitelist');
 		$this->assertStringContainsString('TOP1M conversion Failed', $this->readErrLog());
-
-		// ...and NO log (main or error) contains the token -- pfblockerng_top1m() never
-		// reads $pfb['top1m_token'] or any header; the only code that ever touches the raw
-		// token is pfb_top1m_auth_headers() (Top1mAuthHeadersTest.php), which has no
-		// pfb_logger call in its body at all.
-		$this->assertStringNotContainsString($fakeSecretToken, $this->readMainLog(),
-			'the TOP1M main log must never contain a token, even a rejected/missing one');
-		$this->assertStringNotContainsString($fakeSecretToken, $this->readErrLog(),
-			'the TOP1M error log must never contain a token, even a rejected/missing one');
 	}
 }

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -43,6 +43,10 @@ use PHPUnit\Framework\TestCase;
  * of a hardcoded rank,domain-at-column-1 shape.
  *   * a SYNTHETIC descriptor's header/domain_col knobs are honoured (below) -- no live
  *     non-Tranco/Cisco provider exists yet (ADR-59 Phase 4 adds one)
+ *
+ * ADR-59 P4 addendum: the two live non-Tranco/Cisco providers (DomCop, Majestic) added
+ * by this phase -- their REAL sample shape parses correctly via the registered
+ * descriptor, and a wrong domain_col genuinely mis-reads (fail-before/pass-after).
  */
 #[CoversFunction('pfblockerng_top1m')]
 final class Top1mPreserveOnEmptyFeedTest extends TestCase
@@ -382,5 +386,118 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
 			'the domain must come from domain_col (index 2), and the header row must not count as data');
 		$this->assertStringContainsString('Parsed 1 lines | Found 1 of 1000', $this->readMainLog());
+	}
+
+	/**
+	 * ADR-59 P4 -- pfblockerng_top1m() parses Majestic Million's REAL CSV shape
+	 * (12-col unquoted header, Domain at str_getcsv() index 2) via its registered
+	 * provider descriptor (pfb_top1m_providers()[Top1mSource::Majestic->value]).
+	 * Sample verified against the live downloads.majestic.com/majestic_million.csv
+	 * format (fetched during development of this test).
+	 *
+	 * FAIL-BEFORE/PASS-AFTER: the BEFORE run reproduces the exact pre-ADR-59-Phase-2
+	 * hardcoded shape -- pfblockerng_top1m(array()) resolves every knob to its
+	 * default (parse=rank_domain, header=false, domain_col=1), precisely what every
+	 * call site used before Phase 2 generalized the builder. Applied to Majestic's
+	 * real layout, domain_col=1 reads the TldRank column (a bare digit, e.g. "1")
+	 * as the "domain" instead of the real Domain field at index 2 -- neither digit
+	 * contains a '.', so no TLD ever matches and the whitelist ends up EMPTY despite
+	 * two real .com domains being present in the feed (RED). The AFTER run, using
+	 * the actual registered Majestic descriptor (domain_col 2, header skipped),
+	 * correctly extracts both domains (GREEN) -- proving domain_col is genuinely
+	 * read from the descriptor, not hardcoded.
+	 */
+	public function testMajesticRealShapeSampleMisreadsOnLegacyColumnAndParsesCorrectlyViaItsDescriptor(): void
+	{
+		// Given: a real-shape Majestic Million sample -- 12-col unquoted header,
+		// Domain at index 2, two real '.com' domains matching the 'com' TLD
+		// inclusion configured in setUp().
+		$csv = "GlobalRank,TldRank,Domain,TLD,RefSubNets,RefIPs,IDN_Domain,IDN_TLD,PrevGlobalRank,PrevTldRank,PrevRefSubNets,PrevRefIPs\n"
+			. "1,1,google.com,com,501790,2223489,google.com,com,1,1,500432,2222282\n"
+			. "2,2,facebook.com,com,473621,2232852,facebook.com,com,2,2,472323,2232281\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: real-shape Majestic Million sample');
+
+		// When (BEFORE): the pre-Phase-2 legacy shape -- domain_col 1, no header skip.
+		pfblockerng_top1m(array());
+
+		// Then (RED): the real domains are misread as the numeric TldRank column;
+		// neither matches a TLD (both rows still count as valid CSV lines -- the
+		// rank_domain guard passes on the numeric GlobalRank column), so the
+		// whitelist is replaced with EMPTY content, not "keeping previous".
+		$this->assertSame('', file_get_contents($this->whitelistPath()),
+			"the legacy col-1 parser must MIS-read Majestic's real shape -- Domain sits at index 2, not 1");
+		$this->assertStringContainsString('Parsed 2 lines | Found 0 of 1000', $this->readMainLog());
+		$this->assertStringContainsString('0 domains matched the configured TLD inclusions', $this->readMainLog());
+		$this->assertStringNotContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+
+		// Reset the log so the GREEN assertion below is unambiguous.
+		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['log'], ''), 'reset main log between runs');
+
+		// When (AFTER): the actual registered Majestic descriptor.
+		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::Majestic->value]);
+
+		// Then (GREEN): both real domains are correctly extracted from index 2.
+		$this->assertSame(
+			".google.com,,\n,google.com,,\n,www.google.com,,\n.facebook.com,,\n,facebook.com,,\n,www.facebook.com,,\n",
+			file_get_contents($this->whitelistPath()),
+			'the registered Majestic descriptor must extract Domain from index 2'
+		);
+		$this->assertStringContainsString('Parsed 2 lines | Found 2 of 1000', $this->readMainLog());
+	}
+
+	/**
+	 * ADR-59 P4 -- pfblockerng_top1m() parses DomCop's REAL CSV shape (quoted
+	 * 3-col header, Domain at str_getcsv() index 1) via its registered provider
+	 * descriptor. Sample verified against the live
+	 * domcop.com/files/top/top10milliondomains.csv format (fetched during
+	 * development of this test).
+	 *
+	 * DomCop's own Domain column happens to sit at the SAME index (1) the
+	 * pre-Phase-2 legacy default already used, so replaying that legacy shape
+	 * verbatim (as the Majestic test above does) would coincidentally still
+	 * parse DomCop's real sample correctly -- on its own it would NOT prove
+	 * domain_col is read from the descriptor rather than hardcoded. To still
+	 * assert "the col index matters" for DomCop, this FAIL-BEFORE/PASS-AFTER
+	 * instead probes a WRONG column for DomCop's shape (domain_col 2 -- the
+	 * "Open Page Rank" field, Majestic's own domain_col) and shows it likewise
+	 * mis-reads; the registered DomCop descriptor (domain_col 1) is correct.
+	 */
+	public function testDomCopRealShapeSampleMisreadsOnWrongColumnAndParsesCorrectlyViaItsDescriptor(): void
+	{
+		// Given: a real-shape DomCop sample -- quoted 3-col header, Domain at
+		// index 1, two real '.com' domains matching the 'com' TLD inclusion.
+		$csv = "\"Rank\",\"Domain\",\"Open Page Rank\"\n"
+			. "\"1\",\"www.facebook.com\",\"10.00\"\n"
+			. "\"2\",\"fonts.googleapis.com\",\"10.00\"\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: real-shape DomCop sample');
+
+		// When (BEFORE): the WRONG column for this shape -- index 2 ("Open Page
+		// Rank", a decimal string with no matching TLD).
+		$wrongColumn = ['parse' => 'csv', 'header' => true, 'domain_col' => 2];
+		pfblockerng_top1m($wrongColumn);
+
+		// Then (RED): the real domains are misread as the Open Page Rank value
+		// ("10.00" -> tld "00"), so neither matches and the whitelist is empty.
+		$this->assertSame('', file_get_contents($this->whitelistPath()),
+			"domain_col 2 must MIS-read DomCop's real shape -- Domain sits at index 1, not 2");
+		$this->assertStringContainsString('Parsed 2 lines | Found 0 of 1000', $this->readMainLog());
+		$this->assertStringContainsString('0 domains matched the configured TLD inclusions', $this->readMainLog());
+		$this->assertStringNotContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+
+		// Reset the log so the GREEN assertion below is unambiguous.
+		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['log'], ''), 'reset main log between runs');
+
+		// When (AFTER): the actual registered DomCop descriptor.
+		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::DomCop->value]);
+
+		// Then (GREEN): both real domains are correctly extracted from index 1
+		// ('www.' stripped per the existing whitelist-building convention).
+		$this->assertSame(
+			".facebook.com,,\n,facebook.com,,\n,www.facebook.com,,\n"
+			. ".fonts.googleapis.com,,\n,fonts.googleapis.com,,\n,www.fonts.googleapis.com,,\n",
+			file_get_contents($this->whitelistPath()),
+			'the registered DomCop descriptor must extract Domain from index 1'
+		);
+		$this->assertStringContainsString('Parsed 2 lines | Found 2 of 1000', $this->readMainLog());
 	}
 }

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -47,6 +47,16 @@ use PHPUnit\Framework\TestCase;
  * ADR-59 P4 addendum: the two live non-Tranco/Cisco providers (DomCop, Majestic) added
  * by this phase -- their REAL sample shape parses correctly via the registered
  * descriptor, and a wrong domain_col genuinely mis-reads (fail-before/pass-after).
+ *
+ * ADR-59 P5 addendum: Cloudflare Radar (token-authenticated) parses its REAL shape too
+ * (a single 'domain' column, no rank) -- this exposed a genuine latent bug the DomCop/
+ * Majestic tests couldn't: the generic content filter required a comma on every data
+ * line, but a single-column CSV line has none, so every Cloudflare row was silently
+ * skipped regardless of domain_col. Fixed (pfblockerng.inc) by only requiring a comma
+ * when domain_col > 0. A missing/invalid top1m_token means the download never writes a
+ * fresh top-1m.csv, which hits the SAME generic "csv absent -> preserve + warn" path
+ * every provider's download failure already hits (no Cloudflare-specific branch exists
+ * to bypass) -- proven below alongside a direct "no token in any log" assertion.
  */
 #[CoversFunction('pfblockerng_top1m')]
 final class Top1mPreserveOnEmptyFeedTest extends TestCase
@@ -499,5 +509,89 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 			'the registered DomCop descriptor must extract Domain from index 1'
 		);
 		$this->assertStringContainsString('Parsed 2 lines | Found 2 of 1000', $this->readMainLog());
+	}
+
+	/**
+	 * ADR-59 P5 -- pfblockerng_top1m() parses Cloudflare Radar's REAL CSV shape (a
+	 * SINGLE 'domain' column, no rank -- confirmed against Cloudflare's own docs during
+	 * this phase, NOT the ADR's original 2-column guess) via its registered descriptor
+	 * (domain_col 0, header skipped).
+	 *
+	 * Unlike the DomCop/Majestic column-index bug above, this shape exposed a DIFFERENT
+	 * latent bug: the generic content filter demanded BOTH a '.' AND a ',' on every data
+	 * line (a guard against a prose/error body that would otherwise reach the parser).
+	 * A single-column CSV line has NO comma at all (nothing to delimit), so every one of
+	 * Cloudflare's real data lines was silently skipped regardless of domain_col -- the
+	 * whitelist came out EMPTY even though the fixture data is genuinely well-formed.
+	 * FAIL-BEFORE/PASS-AFTER: manually verified by reverting just the comma-relaxation
+	 * hunk in pfblockerng.inc (`git stash`) and re-running this exact test -- it goes RED
+	 * (empty whitelist, same as the DomCop/Majestic BEFORE runs above); restoring the fix
+	 * makes it GREEN. This test's own body only exercises the (permanent) AFTER state --
+	 * see RESULTS/05_Results.txt for the stash verification transcript.
+	 */
+	public function testCloudflareRealShapeSampleParsesViaItsDescriptorAndTheSingleColumnCommaFix(): void
+	{
+		// Given: a real-shape Cloudflare Radar sample -- single 'domain' column header,
+		// two real '.com' domains, no rank/second column (no comma anywhere in the data).
+		$csv = "domain\n"
+			. "google.com\n"
+			. "facebook.com\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: real-shape Cloudflare Radar sample');
+
+		// When: the actual registered Cloudflare descriptor (domain_col 0, header skipped).
+		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::Cloudflare->value]);
+
+		// Then: both real domains are correctly extracted from the single column despite
+		// carrying no comma -- proves the comma-requirement relaxation for domain_col 0.
+		$this->assertSame(
+			".google.com,,\n,google.com,,\n,www.google.com,,\n.facebook.com,,\n,facebook.com,,\n,www.facebook.com,,\n",
+			file_get_contents($this->whitelistPath()),
+			'the registered Cloudflare descriptor must extract the single-column domain despite no comma in the data'
+		);
+		$this->assertStringContainsString('Parsed 2 lines | Found 2 of 1000', $this->readMainLog());
+	}
+
+	/**
+	 * ADR-59 P5 -- safe-on-missing/invalid-token behaviour (ADR §4 requirement 3): when
+	 * Cloudflare's download fails (missing/invalid top1m_token -> pfb_top1m_auth_headers()
+	 * returns no Authorization header -> pfb_download() sends no auth and the request is
+	 * rejected -> top-1m.csv is never written/refreshed), pfblockerng_top1m() hits the SAME
+	 * generic "csv absent -> preserve + warn" path every other provider's download failure
+	 * already hits (see testAbsentCsvPreservesPriorWhitelistAndWarns above) -- there is no
+	 * Cloudflare-specific failure branch to bypass. This is the Cloudflare-scoped proof of
+	 * that reuse, plus a DIRECT "no token in any log" assertion: pfblockerng_top1m() never
+	 * reads $pfb['top1m_token'] or any header at all, so a fake secret standing in for a
+	 * real token genuinely cannot appear in either log -- asserted, not assumed.
+	 */
+	public function testMissingOrInvalidCloudflareTokenPreservesWhitelistAndLogsNoToken(): void
+	{
+		// Given: a prior good whitelist (a previous successful run/provider) and top-1m.csv
+		// ABSENT -- exactly what a failed Cloudflare download (no/invalid token) leaves
+		// behind (pfb_download() never wrote a fresh file).
+		$priorContent = ".oldsite.com,,\n,oldsite.com,,\n,www.oldsite.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: prior good whitelist');
+		$this->assertFileDoesNotExist($this->csvPath(), 'before-state: no top-1m.csv (simulates a failed download)');
+
+		// A fake secret standing in for a real Cloudflare token, so the log-scan
+		// assertions below are a genuine check rather than a vacuous one.
+		$fakeSecretToken = 'sk-live-should-never-appear-in-any-log-0xDEADBEEF';
+
+		// When: the Cloudflare descriptor is active but top-1m.csv never arrived.
+		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::Cloudflare->value]);
+
+		// Then: the prior whitelist is untouched and a warning was logged (same generic
+		// path as testAbsentCsvPreservesPriorWhitelistAndWarns)...
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
+			'a missing top-1m.csv (failed Cloudflare download) must preserve the prior whitelist');
+		$this->assertStringContainsString('TOP1M conversion Failed', $this->readErrLog());
+
+		// ...and NO log (main or error) contains the token -- pfblockerng_top1m() never
+		// reads $pfb['top1m_token'] or any header; the only code that ever touches the raw
+		// token is pfb_top1m_auth_headers() (Top1mAuthHeadersTest.php), which has no
+		// pfb_logger call in its body at all.
+		$this->assertStringNotContainsString($fakeSecretToken, $this->readMainLog(),
+			'the TOP1M main log must never contain a token, even a rejected/missing one');
+		$this->assertStringNotContainsString($fakeSecretToken, $this->readErrLog(),
+			'the TOP1M error log must never contain a token, even a rejected/missing one');
 	}
 }

--- a/tests/php/Top1mProvidersTest.php
+++ b/tests/php/Top1mProvidersTest.php
@@ -6,15 +6,17 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * ADR-59 Phase 1 -- pfb_top1m_providers() extraction oracle.
+ * ADR-59 Phase 1 -- pfb_top1m_providers() extraction oracle. Extended Phase 4
+ * to add the keyless providers DomCop + Majestic.
  *
- * Before this phase, pfblockerng.php:162 picked the TOP1M download URL with a
- * hardcoded if/else on the Top1mSource enum. This phase moves both provider's
+ * Before Phase 1, pfblockerng.php:162 picked the TOP1M download URL with a
+ * hardcoded if/else on the Top1mSource enum. Phase 1 moved both provider's
  * facts into one descriptor table so pfblockerng.php (and, from Phase 2 on, the
- * parser/extractor) reads a single source of truth. BEHAVIOUR-PRESERVING: no
- * new provider, no URL change -- this oracle pins the resolved URL for both
- * existing providers to the exact pre-change literal, so any future edit to the
- * table (this phase or later ones) that drifts tranco/cisco's URL fails loudly.
+ * parser/extractor) reads a single source of truth. Tranco/Cisco stay
+ * BEHAVIOUR-PRESERVING throughout: this oracle pins their resolved URL to the
+ * exact pre-ADR-59 literal, so any future edit to the table that drifts
+ * tranco/cisco's URL fails loudly. Phase 4 adds DomCop + Majestic as two more
+ * rows in the same table -- their own shape is pinned separately below.
  */
 #[CoversFunction('pfb_top1m_providers')]
 final class Top1mProvidersTest extends TestCase
@@ -39,23 +41,62 @@ final class Top1mProvidersTest extends TestCase
 		);
 	}
 
-	/** Phase 1 carries exactly the two pre-existing providers -- no new source yet. */
-	public function testOnlyTrancoAndCiscoAreDescribedInPhase1(): void
+	/** ADR-59 P4 -- the two new keyless providers' URLs, per the ADR §2.2 table. */
+	public function testDomCopAndMajesticUrlsMatchTheAdrTable(): void
 	{
-		$this->assertSame(['tranco', 'cisco'], array_keys(pfb_top1m_providers()));
+		$this->assertSame(
+			'https://www.domcop.com/files/top/top10milliondomains.csv.zip',
+			pfb_top1m_providers()[Top1mSource::DomCop->value]['url']
+		);
+		$this->assertSame(
+			'https://downloads.majestic.com/majestic_million.csv',
+			pfb_top1m_providers()[Top1mSource::Majestic->value]['url']
+		);
+	}
+
+	/** The provider table now carries exactly the four live keyless sources (P4). */
+	public function testFourKeylessProvidersAreDescribed(): void
+	{
+		$this->assertSame(['tranco', 'cisco', 'domcop', 'majestic'], array_keys(pfb_top1m_providers()));
 	}
 
 	/**
-	 * Both providers keep today's implicit shape (zip container, rank_domain CSV
-	 * parse, no auth) -- the fields later phases will generalize the parser/extractor
-	 * against, pinned here so Phase 2+ cannot silently change what Phase 1 shipped.
+	 * Tranco/Cisco keep today's implicit shape (zip container, rank_domain CSV
+	 * parse, no auth) -- the fields later phases generalized the parser/extractor
+	 * against, pinned here so no phase silently changes what Phase 1 shipped.
 	 */
-	public function testBothProvidersDescribeTodaysZipRankDomainNoAuthShape(): void
+	public function testTrancoAndCiscoDescribeTodaysZipRankDomainNoAuthShape(): void
 	{
-		foreach (pfb_top1m_providers() as $id => $descriptor) {
+		foreach ([Top1mSource::Tranco->value, Top1mSource::Cisco->value] as $id) {
+			$descriptor = pfb_top1m_providers()[$id];
 			$this->assertSame('zip', $descriptor['container'], "{$id}: container must be zip");
 			$this->assertSame('rank_domain', $descriptor['parse'], "{$id}: parse must be rank_domain");
 			$this->assertSame('none', $descriptor['auth'], "{$id}: auth must be none");
 		}
+	}
+
+	/**
+	 * ADR-59 P4 -- DomCop/Majestic's own shape (distinct container/parse/domain_col
+	 * per the ADR §2.2 table + Phase 2's 0-indexed domain_col convention): DomCop's
+	 * Domain is the 2nd CSV field (index 1, same index Tranco/Cisco use); Majestic's
+	 * Domain is the 3rd field (index 2). Majestic's container is 'plain' (uncompressed
+	 * CSV), not 'zip' -- the one provider so far that isn't a zip download.
+	 */
+	public function testDomCopAndMajesticDescribeTheirOwnCsvShape(): void
+	{
+		$domcop = pfb_top1m_providers()[Top1mSource::DomCop->value];
+		$this->assertSame('zip', $domcop['container'], 'domcop: container must be zip');
+		$this->assertSame('csv', $domcop['parse'], 'domcop: parse must be csv');
+		$this->assertTrue($domcop['header'], 'domcop: header row must be skipped');
+		$this->assertSame(1, $domcop['domain_col'], 'domcop: Domain is the 2nd CSV field -> index 1');
+		$this->assertSame('none', $domcop['auth'], 'domcop: auth must be none');
+
+		$majestic = pfb_top1m_providers()[Top1mSource::Majestic->value];
+		$this->assertSame('plain', $majestic['container'], 'majestic: container must be plain (uncompressed)');
+		$this->assertSame('csv', $majestic['parse'], 'majestic: parse must be csv');
+		$this->assertTrue($majestic['header'], 'majestic: header row must be skipped');
+		$this->assertSame(2, $majestic['domain_col'], 'majestic: Domain is the 3rd CSV field -> index 2');
+		$this->assertSame('none', $majestic['auth'], 'majestic: auth must be none');
+		$this->assertStringContainsString('CC BY 3.0', $majestic['licence'], 'majestic: CC BY 3.0 licence note must be present');
 	}
 }

--- a/tests/php/Top1mProvidersTest.php
+++ b/tests/php/Top1mProvidersTest.php
@@ -7,7 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * ADR-59 Phase 1 -- pfb_top1m_providers() extraction oracle. Extended Phase 4
- * to add the keyless providers DomCop + Majestic.
+ * to add the keyless providers DomCop + Majestic, and Phase 5 to add the
+ * token-authenticated Cloudflare Radar provider.
  *
  * Before Phase 1, pfblockerng.php:162 picked the TOP1M download URL with a
  * hardcoded if/else on the Top1mSource enum. Phase 1 moved both provider's
@@ -16,7 +17,10 @@ use PHPUnit\Framework\TestCase;
  * BEHAVIOUR-PRESERVING throughout: this oracle pins their resolved URL to the
  * exact pre-ADR-59 literal, so any future edit to the table that drifts
  * tranco/cisco's URL fails loudly. Phase 4 adds DomCop + Majestic as two more
- * rows in the same table -- their own shape is pinned separately below.
+ * rows in the same table -- their own shape is pinned separately below. Phase 5
+ * adds Cloudflare Radar -- the first (and so far only) header-auth provider,
+ * whose real API shape (verified against Cloudflare's own docs, NOT the ADR's
+ * original guess) is a single-column 'domain' CSV, no rank -- domain_col 0.
  */
 #[CoversFunction('pfb_top1m_providers')]
 final class Top1mProvidersTest extends TestCase
@@ -54,10 +58,13 @@ final class Top1mProvidersTest extends TestCase
 		);
 	}
 
-	/** The provider table now carries exactly the four live keyless sources (P4). */
-	public function testFourKeylessProvidersAreDescribed(): void
+	/** The provider table now carries exactly the four keyless sources (P4) plus Cloudflare (P5). */
+	public function testFiveProvidersAreDescribed(): void
 	{
-		$this->assertSame(['tranco', 'cisco', 'domcop', 'majestic'], array_keys(pfb_top1m_providers()));
+		$this->assertSame(
+			['tranco', 'cisco', 'domcop', 'majestic', 'cloudflare'],
+			array_keys(pfb_top1m_providers())
+		);
 	}
 
 	/**
@@ -98,5 +105,34 @@ final class Top1mProvidersTest extends TestCase
 		$this->assertSame(2, $majestic['domain_col'], 'majestic: Domain is the 3rd CSV field -> index 2');
 		$this->assertSame('none', $majestic['auth'], 'majestic: auth must be none');
 		$this->assertStringContainsString('CC BY 3.0', $majestic['licence'], 'majestic: CC BY 3.0 licence note must be present');
+	}
+
+	/**
+	 * ADR-59 P5 -- Cloudflare Radar's REAL shape, verified against Cloudflare's own docs
+	 * during this phase (not the ADR's original 2-column guess): a single 'domain' column
+	 * (no rank) in a PLAIN (uncompressed) CSV, so domain_col is 0 -- not 1. Auth is a
+	 * structured {header, scheme} array (distinct from every other provider's plain
+	 * 'none' string), the only descriptor row that needs pfb_top1m_auth_headers().
+	 */
+	public function testCloudflareDescribesItsRealSingleColumnAuthedCsvShape(): void
+	{
+		$cloudflare = pfb_top1m_providers()[Top1mSource::Cloudflare->value];
+		$this->assertSame(
+			'https://api.cloudflare.com/client/v4/radar/datasets/ranking_top_1000000',
+			$cloudflare['url'],
+			'cloudflare: URL must be the stable ranking_top_1000000 dataset alias'
+		);
+		$this->assertSame('plain', $cloudflare['container'], 'cloudflare: container must be plain (uncompressed CSV stream)');
+		$this->assertSame('csv', $cloudflare['parse'], 'cloudflare: parse must be csv');
+		$this->assertTrue($cloudflare['header'], 'cloudflare: header row (literal "domain") must be skipped');
+		$this->assertSame(
+			0,
+			$cloudflare['domain_col'],
+			'cloudflare: the dataset is a SINGLE domain column (no rank) -> index 0, not the ADR-guessed 1'
+		);
+		$this->assertIsArray($cloudflare['auth'], 'cloudflare: auth must be a structured header descriptor, not a plain string');
+		$this->assertSame('Authorization', $cloudflare['auth']['header'], 'cloudflare: auth header name must be Authorization');
+		$this->assertSame('Bearer', $cloudflare['auth']['scheme'], 'cloudflare: auth scheme must be Bearer');
+		$this->assertStringContainsString('CC BY-NC', $cloudflare['licence'], 'cloudflare: CC BY-NC licence note must be present');
 	}
 }

--- a/tests/php/Top1mProvidersTest.php
+++ b/tests/php/Top1mProvidersTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ADR-59 Phase 1 -- pfb_top1m_providers() extraction oracle.
+ *
+ * Before this phase, pfblockerng.php:162 picked the TOP1M download URL with a
+ * hardcoded if/else on the Top1mSource enum. This phase moves both provider's
+ * facts into one descriptor table so pfblockerng.php (and, from Phase 2 on, the
+ * parser/extractor) reads a single source of truth. BEHAVIOUR-PRESERVING: no
+ * new provider, no URL change -- this oracle pins the resolved URL for both
+ * existing providers to the exact pre-change literal, so any future edit to the
+ * table (this phase or later ones) that drifts tranco/cisco's URL fails loudly.
+ */
+#[CoversFunction('pfb_top1m_providers')]
+final class Top1mProvidersTest extends TestCase
+{
+	/** Pre-ADR-59 literal from pfblockerng.php:163 -- must stay byte-identical. */
+	public function testTrancoUrlIsPinnedToThePreChangeLiteral(): void
+	{
+		$this->assertSame(
+			'https://tranco-list.eu/top-1m.csv.zip',
+			pfb_top1m_providers()[Top1mSource::Tranco->value]['url'],
+			'tranco TOP1M URL must not drift from the pre-ADR-59 literal'
+		);
+	}
+
+	/** Pre-ADR-59 literal from pfblockerng.php:165 -- must stay byte-identical. */
+	public function testCiscoUrlIsPinnedToThePreChangeLiteral(): void
+	{
+		$this->assertSame(
+			'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip',
+			pfb_top1m_providers()[Top1mSource::Cisco->value]['url'],
+			'cisco TOP1M URL must not drift from the pre-ADR-59 literal'
+		);
+	}
+
+	/** Phase 1 carries exactly the two pre-existing providers -- no new source yet. */
+	public function testOnlyTrancoAndCiscoAreDescribedInPhase1(): void
+	{
+		$this->assertSame(['tranco', 'cisco'], array_keys(pfb_top1m_providers()));
+	}
+
+	/**
+	 * Both providers keep today's implicit shape (zip container, rank_domain CSV
+	 * parse, no auth) -- the fields later phases will generalize the parser/extractor
+	 * against, pinned here so Phase 2+ cannot silently change what Phase 1 shipped.
+	 */
+	public function testBothProvidersDescribeTodaysZipRankDomainNoAuthShape(): void
+	{
+		foreach (pfb_top1m_providers() as $id => $descriptor) {
+			$this->assertSame('zip', $descriptor['container'], "{$id}: container must be zip");
+			$this->assertSame('rank_domain', $descriptor['parse'], "{$id}: parse must be rank_domain");
+			$this->assertSame('none', $descriptor['auth'], "{$id}: auth must be none");
+		}
+	}
+}

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -123,6 +123,8 @@ class RequireConfigGatewaySniff implements Sniff
 		'installedpackages/pfblockerngdnsblsettings/config/0/alexa_type',
 		'installedpackages/pfblockerngdnsblsettings/config/0/alexa_count',
 		'installedpackages/pfblockerngdnsblsettings/config/0/alexa_inclusion',
+		// ADR-59 P5: masked Cloudflare Radar Bearer token
+		'installedpackages/pfblockerngdnsblsettings/config/0/top1m_token',
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache',
 		'installedpackages/pfblockerngdnsblsettings/config/0/global_log',
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_lenient',

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -426,6 +426,59 @@ def test_dnsbl_idn_mode_select_round_trips_all_modes(
         _post_and_get(webui, smoke_vm, page, {"pfb_idn": original or "off"}, cfg)
 
 
+def test_dnsbl_top1m_token_masked_field_persists_and_is_never_echoed(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    dnsbl_vip_ready: None,
+) -> None:
+    """The masked ``top1m_token`` field (ADR-59 P5) persists via config.xml -- the
+    HTTP body is never proof of a save (ADR §1 fact 3) -- and is a WRITE-ONLY field
+    with a "blank preserves" contract distinct from every ToggleFlow above:
+
+    * a real-looking token POSTed is stored verbatim in config.xml (transition 1);
+    * the very next GET's raw HTML never echoes it back (masked, write-only);
+    * a BLANK top1m_token POSTed afterwards -- simulating an ordinary settings save
+      that didn't touch this field, since the form always renders it blank -- must
+      PRESERVE the already-stored token rather than clearing it (transition 2, the
+      safe-on-missing-token contract: a user saving unrelated settings must never
+      silently wipe their Cloudflare Radar token).
+
+    The web form cannot blank/clear this field by design, so the original value is
+    restored directly via the config API in `finally` (mirrors the `pfSsh.php`
+    restore idiom already used by ``test_alerts_render_verify.py``), leaving the
+    box clean for the other flows on this session-scoped VM.
+    """
+    page = "/pfblockerng/pfblockerng_dnsbl.php"
+    cfg = "installedpackages/pfblockerngdnsblsettings/config/0/top1m_token"
+    token = "cf-test-token.ABC123~_+/=-9"
+    original = helpers.config_get(smoke_vm, cfg)
+    try:
+        # WHEN: a real-looking token is posted -- THEN: it persists verbatim.
+        got = _post_and_get(webui, smoke_vm, page, {"top1m_token": token}, cfg)
+        assert got == token, f"top1m_token should persist the posted value, got {got!r}"
+
+        # THEN: the very next GET never echoes it back in the raw HTML (write-only).
+        resp = webui.get(page)
+        assert token not in resp.text, "top1m_token must never be echoed back on GET (write-only masked field)"
+
+        # WHEN: a blank top1m_token rides a save (the form always renders this field
+        # blank, so this is what EVERY unrelated settings save actually posts).
+        got_after_blank = _post_and_get(webui, smoke_vm, page, {"top1m_token": ""}, cfg)
+        # THEN: unchanged -- a blank submit must never clear an already-stored token.
+        assert got_after_blank == token, (
+            f"a blank top1m_token POST must preserve the existing stored token, got {got_after_blank!r}"
+        )
+    finally:
+        # Restore directly via the config API -- the web form cannot blank this field
+        # by design (proven above), so a normal POST can't be used for cleanup.
+        restore = helpers.php_eval(
+            smoke_vm,
+            f"config_set_path({helpers._php_str(cfg)}, {helpers._php_str(original)});\n"
+            "write_config('ADR-59 P5 smoke: restore top1m_token');\necho 'OK';",
+        )
+        assert "OK" in restore.stdout, f"failed to restore top1m_token: {restore.stdout!r}"
+
+
 # --------------------------------------------------------------------------- #
 # General settings (installedpackages/pfblockerng/config/0)
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -653,16 +653,17 @@ def test_dnsbl_control_fields_render(webui: WebUI, php_error_log_guard: PhpError
 
 
 def test_dnsbl_top1m_source_options_exclude_alexa(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
-    """The TOP1M 'Type' select renders the four live sources (Tranco, Cisco
-    Umbrella, DomCop, Majestic Million — the latter two added ADR-59 Phase 4) —
-    the dead Alexa TOP1M option (#872) is dropped from the page (#877), so a
-    regression that resurrects the option, or drops a live one, is caught at
-    the render tier. Majestic's CC BY 3.0 attribution note (required by its
-    licence) must also render.
+    """The TOP1M 'Type' select renders the five live sources (Tranco, Cisco
+    Umbrella, DomCop, Majestic Million — added ADR-59 Phase 4 — and Cloudflare
+    Radar — added ADR-59 Phase 5) — the dead Alexa TOP1M option (#872) is dropped
+    from the page (#877), so a regression that resurrects the option, or drops a
+    live one, is caught at the render tier. Majestic's CC BY 3.0 and Cloudflare's
+    CC BY-NC attribution notes (required by their licences) must also render, along
+    with the masked, write-only top1m_token field Cloudflare needs.
 
-    Asserts the page passes the clean-render oracle AND that all four live
-    option labels plus the Majestic attribution text are present, while the
-    removed 'Alexa TOP1M' label and its ``value="alexa"`` option are absent
+    Asserts the page passes the clean-render oracle AND that all five live option
+    labels, both attribution notes, and the masked token field are present, while
+    the removed 'Alexa TOP1M' label and its ``value="alexa"`` option are absent
     from the body.
     """
     path = "/pfblockerng/pfblockerng_dnsbl.php"
@@ -670,9 +671,18 @@ def test_dnsbl_top1m_source_options_exclude_alexa(webui: WebUI, php_error_log_gu
     result = evaluate_render(path, resp.status_code, resp.text, ("DNSBL Configuration",))
     assert result.ok, f"DNSBL render oracle failed: {result.detail}"
     body = resp.text
-    for needle in ("Tranco TOP1M", "Cisco Umbrella TOP1M", "DomCop TOP1M", "Majestic Million TOP1M"):
+    for needle in (
+        "Tranco TOP1M",
+        "Cisco Umbrella TOP1M",
+        "DomCop TOP1M",
+        "Majestic Million TOP1M",
+        "Cloudflare Radar",
+    ):
         assert needle in body, f"DNSBL page is missing the TOP1M source option {needle!r}"
     assert "CC BY" in body and "3.0" in body, "DNSBL page is missing the Majestic CC BY 3.0 attribution note"
+    assert "CC BY-NC" in body and "4.0" in body, "DNSBL page is missing the Cloudflare CC BY-NC 4.0 attribution note"
+    assert 'name="top1m_token"' in body, "DNSBL page is missing the top1m_token field"
+    assert 'type="password"' in body, "DNSBL page's top1m_token field must be masked (type=password)"
     for absent in ("Alexa TOP1M", 'value="alexa"'):
         assert absent not in body, f"DNSBL page still renders the dropped Alexa TOP1M option ({absent!r})"
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -653,22 +653,26 @@ def test_dnsbl_control_fields_render(webui: WebUI, php_error_log_guard: PhpError
 
 
 def test_dnsbl_top1m_source_options_exclude_alexa(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
-    """The TOP1M 'Type' select renders only the two live sources (Tranco, Cisco
-    Umbrella) — the dead Alexa TOP1M option (#872) is dropped from the page
-    (#877), so a regression that resurrects the option is caught at the render
-    tier.
+    """The TOP1M 'Type' select renders the four live sources (Tranco, Cisco
+    Umbrella, DomCop, Majestic Million — the latter two added ADR-59 Phase 4) —
+    the dead Alexa TOP1M option (#872) is dropped from the page (#877), so a
+    regression that resurrects the option, or drops a live one, is caught at
+    the render tier. Majestic's CC BY 3.0 attribution note (required by its
+    licence) must also render.
 
-    Asserts the page passes the clean-render oracle AND that both live option
-    labels are present while the removed 'Alexa TOP1M' label and its
-    ``value="alexa"`` option are absent from the body.
+    Asserts the page passes the clean-render oracle AND that all four live
+    option labels plus the Majestic attribution text are present, while the
+    removed 'Alexa TOP1M' label and its ``value="alexa"`` option are absent
+    from the body.
     """
     path = "/pfblockerng/pfblockerng_dnsbl.php"
     resp = webui.get(path)
     result = evaluate_render(path, resp.status_code, resp.text, ("DNSBL Configuration",))
     assert result.ok, f"DNSBL render oracle failed: {result.detail}"
     body = resp.text
-    for needle in ("Tranco TOP1M", "Cisco Umbrella TOP1M"):
+    for needle in ("Tranco TOP1M", "Cisco Umbrella TOP1M", "DomCop TOP1M", "Majestic Million TOP1M"):
         assert needle in body, f"DNSBL page is missing the TOP1M source option {needle!r}"
+    assert "CC BY" in body and "3.0" in body, "DNSBL page is missing the Majestic CC BY 3.0 attribution note"
     for absent in ("Alexa TOP1M", 'value="alexa"'):
         assert absent not in body, f"DNSBL page still renders the dropped Alexa TOP1M option ({absent!r})"
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -679,7 +679,10 @@ def test_dnsbl_top1m_source_options_exclude_alexa(webui: WebUI, php_error_log_gu
         "Cloudflare Radar",
     ):
         assert needle in body, f"DNSBL page is missing the TOP1M source option {needle!r}"
-    assert "CC BY" in body and "3.0" in body, "DNSBL page is missing the Majestic CC BY 3.0 attribution note"
+    # Self-coupled to Majestic specifically (#892 review) -- the bare substrings "CC BY"
+    # and "3.0" are also individually satisfied by Cloudflare's "(CC BY-NC) 4.0" note, so
+    # this would pass even if Majestic's own note vanished.
+    assert "(CC BY) 3.0" in body, "DNSBL page is missing the Majestic (CC BY) 3.0 attribution note"
     assert "CC BY-NC" in body and "4.0" in body, "DNSBL page is missing the Cloudflare CC BY-NC 4.0 attribution note"
     assert 'name="top1m_token"' in body, "DNSBL page is missing the top1m_token field"
     assert 'type="password"' in body, "DNSBL page's top1m_token field must be masked (type=password)"

--- a/tests/test_check_top1m_providers.py
+++ b/tests/test_check_top1m_providers.py
@@ -218,6 +218,26 @@ def test_extract_providers_falls_back_to_url_netloc_and_zip_container_when_absen
     assert provider["container"] == "zip"
 
 
+def test_extract_providers_reads_the_real_descriptor_file_and_finds_all_five() -> None:
+    # #892 review (finding 6): every other test above feeds a hand-built fixture table --
+    # none couples the extractor to the REAL pfblockerng_extra.inc shape, so a silent
+    # reformat of the actual descriptor (a renamed field, a changed quoting style) could
+    # go undetected here while still breaking check_top1m_providers.py in CI. Read the
+    # real file straight off disk instead of a fixture.
+    providers = {p["name"]: p for p in ctp.extract_providers(ctp.DEFAULT_DESCRIPTOR_FILE.read_text(encoding="utf-8"))}
+    assert set(providers) == {"Tranco", "Cisco Umbrella", "DomCop", "Majestic Million", "Cloudflare Radar"}
+
+    for name in ("Tranco", "Cisco Umbrella", "DomCop", "Majestic Million"):
+        assert providers[name]["auth"] == "none", name
+        assert providers[name]["secret_env"] == "", name
+
+    cloudflare = providers["Cloudflare Radar"]
+    assert cloudflare["auth"] == "token"
+    assert cloudflare["secret_env"] == "CLOUDFLARE_RADAR_TOKEN"
+    assert cloudflare["auth_header"] == "Authorization"
+    assert cloudflare["auth_scheme"] == "Bearer"
+
+
 # --------------------------------------------------------------------------- #
 # validate_top1m / _scan_csv -- in-memory zips + plain bodies, no network
 # --------------------------------------------------------------------------- #

--- a/tests/test_check_top1m_providers.py
+++ b/tests/test_check_top1m_providers.py
@@ -1,15 +1,23 @@
-"""Tests for scripts/misc/check_top1m_providers.py (issue #884).
+"""Tests for scripts/misc/check_top1m_providers.py (issue #884, ADR-59 P6).
 
 Nothing caught the Alexa Top1M source rotting silently (its hardcoded URL died
 years ago; cleaned up in #877). These tests pin the guard that would have:
-extracting every top1m provider URL straight from pfblockerng.php (so adding
-or removing a provider arm needs no edit here), and validating a fetched
-payload is actually a healthy, fresh Top1M list -- not just a 200.
+extracting every top1m provider straight from `pfb_top1m_providers()`'s
+descriptor table (pfblockerng_extra.inc) -- so adding or removing a provider
+row needs no edit here -- classifying each by its `auth` (keyless vs a CI-secret
+-gated token provider), and validating a fetched payload is actually a
+healthy, fresh Top1M list -- not just a 200.
+
+ADR-59 moved the provider URLs off pfblockerng.php's literal
+`$pfb['extras'][2]['url'] = '...'` assignment (the shape these tests used to
+target) into the descriptor table -- that assignment is now an expression
+reading the table, so the OLD extraction regex no longer matches anything.
+This suite targets the table directly.
 
 No network: --check-url's HTTP fetch lives in check_url(); every test below
-targets the pure functions (extract_providers / validate_top1m / is_stale)
-with injected bytes/headers/now, per CLAUDE.md's no-network-in-unit-tests
-branch-coverage rule.
+targets the pure functions (extract_providers / validate_top1m / is_stale /
+main's classification) with injected bytes/headers/now/env, per CLAUDE.md's
+no-network-in-unit-tests branch-coverage rule.
 """
 
 from __future__ import annotations
@@ -35,101 +43,187 @@ _spec.loader.exec_module(ctp)
 
 
 # --------------------------------------------------------------------------- #
-# extract_providers -- PHP fixtures mirror the real extras-slot shape
+# extract_providers -- descriptor-table fixtures mirror pfb_top1m_providers()
 # --------------------------------------------------------------------------- #
 
-# Mirrors src/usr/local/www/pfblockerng/pfblockerng.php's real shape: extras[0]
-# is a geoip slot (must NOT be picked up), extras[2] is the top1m slot with its
-# URL set inside an if/else -- the type assignment trails both branches.
-_PHP_TWO_PROVIDERS = """
-$pfb['extras'][0]		= array();
-$pfb['extras'][0]['url']	= 'https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz';
-$pfb['extras'][0]['type']	= 'geoip';
-
-$pfb['extras'][2]			= array();
-if ($pfb['dnsbl_top1m_type'] === Top1mSource::Tranco) {
-	$pfb['extras'][2]['url']	= 'https://tranco-list.eu/top-1m.csv.zip';
-} else {
-	$pfb['extras'][2]['url']	= 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip';  // Cisco
+# Mirrors the real pfb_top1m_providers() shape: two keyless zip providers
+# (Tranco/Cisco, no 'label'/'container' -- exercises the fallback defaults),
+# one keyless plain-CSV provider (Majestic-shaped), and one token provider
+# (Cloudflare-shaped) whose 'auth' is a structured {header, scheme} array.
+_PHP_DESCRIPTOR_TABLE = """
+function pfb_top1m_providers(): array
+{
+	return array(
+		Top1mSource::Tranco->value	=> array(
+			'url'		=> 'https://tranco-list.eu/top-1m.csv.zip',
+			'container'	=> 'zip',
+			'auth'		=> 'none',
+			'label'		=> 'Tranco',
+		),
+		Top1mSource::Cisco->value	=> array(
+			'url'		=> 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip',
+			'container'	=> 'zip',
+			'auth'		=> 'none',
+			'label'		=> 'Cisco Umbrella',
+		),
+		Top1mSource::Majestic->value	=> array(
+			'url'		=> 'https://downloads.majestic.com/majestic_million.csv',
+			'container'	=> 'plain',
+			'auth'		=> 'none',
+			'label'		=> 'Majestic Million',
+			'licence'	=> 'CC BY 3.0 -- attribution required',
+		),
+		Top1mSource::Cloudflare->value	=> array(
+			'url'		=> 'https://api.cloudflare.com/client/v4/radar/datasets/ranking_top_1000000',
+			'container'	=> 'plain',
+			'auth'		=> array('header' => 'Authorization', 'scheme' => 'Bearer'),
+			'label'		=> 'Cloudflare Radar',
+			'licence'	=> 'CC BY-NC 4.0 -- non-commercial use, attribution required',
+		),
+	);
 }
-$pfb['extras'][2]['file_dwn']	= 'top-1m.csv.zip';
-$pfb['extras'][2]['type']	= 'top1m';
 """
 
-# A third provider arm added to the SAME slot (elseif) -- the crux case: the
-# extractor must pick this up with no code change, proving add/remove coverage
-# is automatic rather than a hardcoded Tranco/Cisco pair.
-_PHP_THREE_PROVIDERS = """
-$pfb['extras'][2]			= array();
-if ($pfb['dnsbl_top1m_type'] === Top1mSource::Tranco) {
-	$pfb['extras'][2]['url']	= 'https://tranco-list.eu/top-1m.csv.zip';
-} elseif ($pfb['dnsbl_top1m_type'] === Top1mSource::Quad9) {
-	$pfb['extras'][2]['url']	= 'https://example-quad9.test/top-1m.csv.zip';
-} else {
-	$pfb['extras'][2]['url']	= 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip';  // Cisco
-}
-$pfb['extras'][2]['type']	= 'top1m';
-"""
 
-
-def test_extract_providers_finds_both_top1m_urls() -> None:
-    providers = ctp.extract_providers(_PHP_TWO_PROVIDERS)
+def test_extract_providers_finds_every_row_in_the_descriptor_table() -> None:
+    providers = ctp.extract_providers(_PHP_DESCRIPTOR_TABLE)
     urls = {p["url"] for p in providers}
     assert urls == {
         "https://tranco-list.eu/top-1m.csv.zip",
         "https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip",
+        "https://downloads.majestic.com/majestic_million.csv",
+        "https://api.cloudflare.com/client/v4/radar/datasets/ranking_top_1000000",
     }
 
 
-def test_extract_providers_ignores_non_top1m_slot() -> None:
-    providers = ctp.extract_providers(_PHP_TWO_PROVIDERS)
-    urls = {p["url"] for p in providers}
-    assert "https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz" not in urls
+def test_extract_providers_reads_label_and_container_per_row() -> None:
+    providers = {p["name"]: p for p in ctp.extract_providers(_PHP_DESCRIPTOR_TABLE)}
+    assert providers["Tranco"]["container"] == "zip"
+    assert providers["Majestic Million"]["container"] == "plain"
 
 
-# A provider line commented out with `//` (a dead/retired provider left in
-# place for reference) must not be extracted as live -- the extractor
-# previously matched raw text with no regard for comments.
-_PHP_WITH_A_COMMENTED_OUT_PROVIDER = """
-$pfb['extras'][2]			= array();
-// $pfb['extras'][2]['url']	= 'https://dead-provider.test/top-1m.csv.zip';
-if ($pfb['dnsbl_top1m_type'] === Top1mSource::Tranco) {
-	$pfb['extras'][2]['url']	= 'https://tranco-list.eu/top-1m.csv.zip';
-} else {
-	$pfb['extras'][2]['url']	= 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip';  // Cisco
+def test_extract_providers_classifies_keyless_providers_as_auth_none() -> None:
+    providers = {p["name"]: p for p in ctp.extract_providers(_PHP_DESCRIPTOR_TABLE)}
+    for name in ("Tranco", "Cisco Umbrella", "Majestic Million"):
+        assert providers[name]["auth"] == "none"
+        assert providers[name]["secret_env"] == ""
+
+
+def test_extract_providers_classifies_a_token_provider_and_derives_its_secret_env() -> None:
+    # The load-bearing new behaviour: a structured {header, scheme} 'auth'
+    # marks the provider as token-gated, and the CI secret env-var name is
+    # DERIVED from its label -- "Cloudflare Radar" -> CLOUDFLARE_RADAR_TOKEN,
+    # matching the ADR's own example (S2.7) with no separate mapping table.
+    providers = {p["name"]: p for p in ctp.extract_providers(_PHP_DESCRIPTOR_TABLE)}
+    cloudflare = providers["Cloudflare Radar"]
+    assert cloudflare["auth"] == "token"
+    assert cloudflare["secret_env"] == "CLOUDFLARE_RADAR_TOKEN"
+    assert cloudflare["auth_header"] == "Authorization"
+    assert cloudflare["auth_scheme"] == "Bearer"
+
+
+# A fifth descriptor row (a plain new top-level array entry, the actual shape
+# a new provider takes in the real table) alongside the same four -- the
+# crux case: the extractor must pick this up with zero code changes, proving
+# add/remove coverage is automatic against the new source of truth, not a
+# hardcoded 4-provider list.
+_PHP_DESCRIPTOR_TABLE_WITH_A_FIFTH_ROW = """
+function pfb_top1m_providers(): array
+{
+	return array(
+		Top1mSource::Tranco->value	=> array(
+			'url'		=> 'https://tranco-list.eu/top-1m.csv.zip',
+			'container'	=> 'zip',
+			'auth'		=> 'none',
+			'label'		=> 'Tranco',
+		),
+		Top1mSource::Cisco->value	=> array(
+			'url'		=> 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip',
+			'container'	=> 'zip',
+			'auth'		=> 'none',
+			'label'		=> 'Cisco Umbrella',
+		),
+		Top1mSource::Majestic->value	=> array(
+			'url'		=> 'https://downloads.majestic.com/majestic_million.csv',
+			'container'	=> 'plain',
+			'auth'		=> 'none',
+			'label'		=> 'Majestic Million',
+		),
+		Top1mSource::Cloudflare->value	=> array(
+			'url'		=> 'https://api.cloudflare.com/client/v4/radar/datasets/ranking_top_1000000',
+			'container'	=> 'plain',
+			'auth'		=> array('header' => 'Authorization', 'scheme' => 'Bearer'),
+			'label'		=> 'Cloudflare Radar',
+		),
+		Top1mSource::Quad9->value	=> array(
+			'url'		=> 'https://example-quad9.test/top-1m.csv.zip',
+			'container'	=> 'zip',
+			'auth'		=> 'none',
+			'label'		=> 'Quad9',
+		),
+	);
 }
-$pfb['extras'][2]['type']	= 'top1m';
 """
 
 
-def test_extract_providers_skips_a_commented_out_provider_line() -> None:
-    providers = ctp.extract_providers(_PHP_WITH_A_COMMENTED_OUT_PROVIDER)
-    urls = {p["url"] for p in providers}
-    assert "https://dead-provider.test/top-1m.csv.zip" not in urls
-    assert urls == {
-        "https://tranco-list.eu/top-1m.csv.zip",
-        "https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip",
-    }
+def test_extract_providers_auto_covers_a_newly_added_descriptor_row() -> None:
+    # This is the guarantee issue #884 asks for: add a row to the descriptor
+    # table and the extractor picks it up with zero changes to this script.
+    providers = ctp.extract_providers(_PHP_DESCRIPTOR_TABLE_WITH_A_FIFTH_ROW)
+    names = {p["name"] for p in providers}
+    assert names == {"Tranco", "Cisco Umbrella", "Majestic Million", "Cloudflare Radar", "Quad9"}
 
 
-def test_extract_providers_auto_covers_a_newly_added_provider_arm() -> None:
-    # This is the guarantee issue #884 asks for: add a provider arm to the PHP
-    # and the extractor picks it up with zero changes to this script.
-    providers = ctp.extract_providers(_PHP_THREE_PROVIDERS)
-    urls = {p["url"] for p in providers}
-    assert urls == {
-        "https://tranco-list.eu/top-1m.csv.zip",
-        "https://example-quad9.test/top-1m.csv.zip",
-        "https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip",
-    }
+# A row commented out with `//` (a dead/retired provider left in place for
+# reference) must not be extracted as live -- mirrors the pre-existing
+# comment-stripping guarantee, now against the descriptor table.
+_PHP_WITH_A_COMMENTED_OUT_ROW = """
+function pfb_top1m_providers(): array
+{
+	return array(
+		// Top1mSource::Dead->value	=> array('url' => 'https://dead.test/x.zip', 'auth' => 'none', 'label' => 'Dead'),
+		Top1mSource::Tranco->value	=> array(
+			'url'		=> 'https://tranco-list.eu/top-1m.csv.zip',
+			'container'	=> 'zip',
+			'auth'		=> 'none',
+			'label'		=> 'Tranco',
+		),
+	);
+}
+"""
+
+
+def test_extract_providers_skips_a_commented_out_row() -> None:
+    providers = ctp.extract_providers(_PHP_WITH_A_COMMENTED_OUT_ROW)
+    names = {p["name"] for p in providers}
+    assert names == {"Tranco"}
+
+
+_PHP_ONE_PROVIDER_NO_LABEL_NO_CONTAINER = """
+function pfb_top1m_providers(): array
+{
+	return array(
+		Top1mSource::Tranco->value	=> array(
+			'url'	=> 'https://tranco-list.eu/top-1m.csv.zip',
+			'auth'	=> 'none',
+		),
+	);
+}
+"""
+
+
+def test_extract_providers_falls_back_to_url_netloc_and_zip_container_when_absent() -> None:
+    (provider,) = ctp.extract_providers(_PHP_ONE_PROVIDER_NO_LABEL_NO_CONTAINER)
+    assert provider["name"] == "tranco-list.eu"
+    assert provider["container"] == "zip"
 
 
 # --------------------------------------------------------------------------- #
-# validate_top1m / _scan_csv -- in-memory zips, no network
+# validate_top1m / _scan_csv -- in-memory zips + plain bodies, no network
 # --------------------------------------------------------------------------- #
 
 
-def _zip_of(rows: list[tuple[str, str]], member: str = "top-1m.csv") -> bytes:
+def _zip_of(rows: list[tuple[str, ...]], member: str = "top-1m.csv") -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
         text = io.StringIO()
@@ -139,13 +233,19 @@ def _zip_of(rows: list[tuple[str, str]], member: str = "top-1m.csv") -> bytes:
     return buf.getvalue()
 
 
+def _plain_csv_of(rows: list[tuple[str, ...]]) -> bytes:
+    text = io.StringIO()
+    csv.writer(text).writerows(rows)
+    return text.getvalue().encode("utf-8")
+
+
 _NOW = datetime(2026, 7, 6, tzinfo=timezone.utc)
 _FRESH_LM = "Sun, 05 Jul 2026 00:00:00 GMT"  # 1 day old
 _STALE_LM = "Mon, 01 Jun 2026 00:00:00 GMT"  # 35 days old
 
 
 def test_validate_top1m_passes_with_enough_valid_fresh_rows() -> None:
-    rows = [(str(i), f"example{i}.com") for i in range(10)]
+    rows: list[tuple[str, ...]] = [(str(i), f"example{i}.com") for i in range(10)]
     body = _zip_of(rows)
     reasons = ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30)
     assert reasons == []
@@ -153,7 +253,7 @@ def test_validate_top1m_passes_with_enough_valid_fresh_rows() -> None:
 
 def test_validate_top1m_fails_when_row_count_below_min_rows() -> None:
     # Truncated payload: 5 good rows, floor set to 10.
-    rows = [(str(i), f"example{i}.com") for i in range(5)]
+    rows: list[tuple[str, ...]] = [(str(i), f"example{i}.com") for i in range(5)]
     body = _zip_of(rows)
     reasons = ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30)
     assert len(reasons) == 1
@@ -161,17 +261,17 @@ def test_validate_top1m_fails_when_row_count_below_min_rows() -> None:
     assert "found 5" in reasons[0]
 
 
-def test_validate_top1m_fails_when_body_is_not_a_zip() -> None:
-    reasons = ctp.validate_top1m(b"<html>error</html>", _FRESH_LM, _NOW, min_rows=10, max_age_days=30)
+def test_validate_top1m_fails_when_a_zip_container_body_is_not_a_zip() -> None:
+    reasons = ctp.validate_top1m(b"<html>error</html>", _FRESH_LM, _NOW, min_rows=10, max_age_days=30, container="zip")
     assert len(reasons) == 1
     assert "ZIP" in reasons[0]
 
 
 def test_validate_top1m_fails_on_a_malformed_row_non_int_rank_no_dot_domain() -> None:
-    # 9 good rows + 1 malformed ("foo,bar": non-int rank, no-dot domain) with
+    # 9 good rows + 1 malformed ("foo,bar": neither field has a dot) with
     # min_rows=10 -- the malformed row doesn't count as valid, so the floor
     # check itself catches it, AND the report names the exact bad row.
-    rows = [(str(i), f"example{i}.com") for i in range(9)]
+    rows: list[tuple[str, ...]] = [(str(i), f"example{i}.com") for i in range(9)]
     rows.append(("foo", "bar"))
     body = _zip_of(rows)
     reasons = ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30)
@@ -182,8 +282,8 @@ def test_validate_top1m_fails_on_a_malformed_row_non_int_rank_no_dot_domain() ->
 
 def test_validate_top1m_rejects_a_bare_dot_as_a_domain() -> None:
     # A bare "." has no real label on either side of the dot -- must not read
-    # as a valid "rank,domain" row just because it contains a "." and no space.
-    rows = [(str(i), f"example{i}.com") for i in range(9)]
+    # as a valid domain row just because it contains a "." and no space.
+    rows: list[tuple[str, ...]] = [(str(i), f"example{i}.com") for i in range(9)]
     rows.append(("9", "."))
     body = _zip_of(rows)
     reasons = ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30)
@@ -193,7 +293,7 @@ def test_validate_top1m_rejects_a_bare_dot_as_a_domain() -> None:
 
 def test_validate_top1m_flags_staleness_only_once_last_modified_ages_past_the_limit() -> None:
     # Before-state: same payload is healthy while Last-Modified is fresh...
-    rows = [(str(i), f"example{i}.com") for i in range(10)]
+    rows: list[tuple[str, ...]] = [(str(i), f"example{i}.com") for i in range(10)]
     body = _zip_of(rows)
     assert ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30) == []
 
@@ -202,6 +302,54 @@ def test_validate_top1m_flags_staleness_only_once_last_modified_ages_past_the_li
     reasons = ctp.validate_top1m(body, _STALE_LM, _NOW, min_rows=10, max_age_days=30)
     assert len(reasons) == 1
     assert "35 days old" in reasons[0]
+
+
+# --- 'plain' container (Majestic/Cloudflare's real shape): no zip wrapper --- #
+
+
+def test_validate_top1m_passes_a_plain_container_body_with_no_zip_wrapper() -> None:
+    # FAIL-BEFORE/PASS-AFTER for the container-awareness fix: the pre-P6
+    # script assumed every body was a zip unconditionally, so a real (never
+    # vendored) Majestic/Cloudflare-shaped plain CSV response would have been
+    # misread as "not a valid ZIP archive" and reported unhealthy even though
+    # the feed itself is perfectly fine.
+    rows: list[tuple[str, ...]] = [(str(i), f"example{i}.com") for i in range(10)]
+    body = _plain_csv_of(rows)
+    reasons = ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30, container="plain")
+    assert reasons == []
+
+
+def test_validate_top1m_skips_a_header_row_in_a_plain_wide_csv_with_domain_not_in_column_zero() -> None:
+    # Majestic/DomCop-shaped: a header row, then real rows with the domain in
+    # a column other than 0/1 -- _is_valid_row must find it anywhere in the
+    # row (provider-agnostic), and the header row (no dotted field) must not
+    # count as valid or as the "first bad row".
+    rows: list[tuple[str, ...]] = [("GlobalRank", "TldRank", "Domain", "TLD")]
+    rows += [(str(i), str(i), f"example{i}.com", "com") for i in range(10)]
+    body = _plain_csv_of(rows)
+    reasons = ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30, container="plain")
+    assert reasons == []
+
+
+def test_validate_top1m_fails_a_plain_container_body_with_too_few_domain_rows() -> None:
+    # A plain body that never validates (empty/garbage) fails via the row-count
+    # floor with an informative message -- not the "ZIP" message, since a
+    # 'plain' container never attempts a zip parse.
+    reasons = ctp.validate_top1m(
+        b"<html>error</html>", _FRESH_LM, _NOW, min_rows=10, max_age_days=30, container="plain"
+    )
+    assert len(reasons) == 1
+    assert "found 0" in reasons[0]
+    assert "ZIP" not in reasons[0]
+
+
+def test_validate_top1m_single_domain_only_column_cloudflare_shape_passes() -> None:
+    # Cloudflare's real shape: ONE 'domain' column, no rank at all.
+    rows: list[tuple[str, ...]] = [("domain",)]
+    rows += [(f"example{i}.com",) for i in range(10)]
+    body = _plain_csv_of(rows)
+    reasons = ctp.validate_top1m(body, _FRESH_LM, _NOW, min_rows=10, max_age_days=30, container="plain")
+    assert reasons == []
 
 
 # --------------------------------------------------------------------------- #
@@ -288,7 +436,7 @@ def test_check_url_reports_a_clean_reason_on_http_error(monkeypatch: Any) -> Non
 
 
 def test_check_url_reports_a_clean_reason_when_the_body_read_is_cut_short(monkeypatch: Any) -> None:
-    # The #3 fix: IncompleteRead mid-download of the multi-MB zip is neither
+    # The #3 fix: IncompleteRead mid-download of the multi-MB body is neither
     # HTTPError nor URLError -- a narrower except let this raise a raw
     # traceback instead of a clean FAIL report.
     exc = http.client.IncompleteRead(partial=b"only some bytes")
@@ -336,8 +484,29 @@ def test_check_url_handles_a_stale_tz_less_last_modified_without_crashing(monkey
     assert "days old" in reasons[0]
 
 
+def test_check_url_passes_the_caller_supplied_headers_through_to_the_request(monkeypatch: Any) -> None:
+    # A token provider's Authorization header must actually reach the
+    # request object, alongside (not instead of) the User-Agent.
+    body = _healthy_zip_body()
+    seen: dict[str, Any] = {}
+
+    def fake_urlopen(request: Any, timeout: int) -> Any:
+        seen["headers"] = dict(request.headers)
+        return _FakeResponse(body, {"Last-Modified": _ALWAYS_FRESH_LM})
+
+    monkeypatch.setattr(ctp.urllib.request, "urlopen", fake_urlopen)
+    reasons = ctp.check_url(
+        "https://example.test/top-1m.csv.zip", min_rows=10, headers={"Authorization": "Bearer sekrit-token-value"}
+    )
+    assert reasons == []
+    # urllib.request.Request title-cases header names on the wire.
+    assert seen["headers"]["Authorization"] == "Bearer sekrit-token-value"
+    assert seen["headers"]["User-agent"] == "pfBlockerNG-top1m-healthcheck/1.0"
+
+
 # --------------------------------------------------------------------------- #
-# main -- exit code reflects check_url's verdict
+# main -- exit code reflects check_url's verdict, and the auth classification
+# ('auth: none' vs a CI-secret-gated token provider, ADR-59 S2.7)
 # --------------------------------------------------------------------------- #
 
 
@@ -355,3 +524,106 @@ def test_main_exits_nonzero_when_check_url_reports_unhealthy(monkeypatch: Any, c
     out = capsys.readouterr().out
     assert "FAIL" in out
     assert "connection error" in out
+
+
+def test_main_never_calls_check_url_for_a_keyless_provider_and_behaves_as_before(monkeypatch: Any, capsys: Any) -> None:
+    # Before-state: a keyless provider (no --secret-env) is unchanged -- it is
+    # validated exactly like every prior release of this script.
+    called: dict[str, Any] = {}
+
+    def fake_check_url(url: str, **kwargs: Any) -> list[str]:
+        called["headers"] = kwargs.get("headers")
+        return []
+
+    monkeypatch.setattr(ctp, "check_url", fake_check_url)
+    code = ctp.main(["--check-url", "https://example.test/top-1m.csv.zip"])
+    assert code == 0
+    assert called["headers"] is None
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_skips_a_token_provider_with_no_reason_to_fail_when_its_secret_is_absent(
+    monkeypatch: Any, capsys: Any
+) -> None:
+    # The new behaviour this phase adds: a token-gated provider (Cloudflare)
+    # with no configured CI secret must be VISIBLY skipped and exit 0 -- never
+    # silently, and never counted as an unhealthy/failing leg.
+    monkeypatch.delenv("CLOUDFLARE_RADAR_TOKEN", raising=False)
+
+    def fail_if_called(url: str, **kwargs: Any) -> list[str]:
+        raise AssertionError("check_url must not be called when the secret is absent")
+
+    monkeypatch.setattr(ctp, "check_url", fail_if_called)
+    code = ctp.main(
+        [
+            "--check-url",
+            "https://api.cloudflare.com/client/v4/radar/datasets/ranking_top_1000000",
+            "--container",
+            "plain",
+            "--secret-env",
+            "CLOUDFLARE_RADAR_TOKEN",
+            "--auth-header",
+            "Authorization",
+            "--auth-scheme",
+            "Bearer",
+        ]
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "SKIP" in out
+    assert "needs token" in out
+    assert "CLOUDFLARE_RADAR_TOKEN" in out
+
+
+def test_main_validates_a_token_provider_once_its_mocked_secret_is_present(monkeypatch: Any, capsys: Any) -> None:
+    # ...and once a secret IS configured (mocked here via monkeypatch.setenv,
+    # standing in for a real repo secret in CI), the SAME provider is
+    # validated -- proving the secret's presence, not its absence, drives the
+    # behaviour change (before/after pair with the test above).
+    monkeypatch.setenv("CLOUDFLARE_RADAR_TOKEN", "mock-token-value")
+    seen: dict[str, Any] = {}
+
+    def fake_check_url(url: str, **kwargs: Any) -> list[str]:
+        seen["container"] = kwargs.get("container")
+        seen["headers"] = kwargs.get("headers")
+        return []
+
+    monkeypatch.setattr(ctp, "check_url", fake_check_url)
+    code = ctp.main(
+        [
+            "--check-url",
+            "https://api.cloudflare.com/client/v4/radar/datasets/ranking_top_1000000",
+            "--container",
+            "plain",
+            "--secret-env",
+            "CLOUDFLARE_RADAR_TOKEN",
+            "--auth-header",
+            "Authorization",
+            "--auth-scheme",
+            "Bearer",
+        ]
+    )
+    assert code == 0
+    assert seen["container"] == "plain"
+    assert seen["headers"] == {"Authorization": "Bearer mock-token-value"}
+    out = capsys.readouterr().out
+    assert "OK" in out
+    assert "mock-token-value" not in out, "the token must never be printed, even in the healthy report"
+
+
+def test_main_never_prints_the_token_on_an_unhealthy_token_provider_result(monkeypatch: Any, capsys: Any) -> None:
+    # Security-relevant: the token must not leak even in a FAIL report's
+    # reason text (e.g. a real connection-error string echoing request state).
+    monkeypatch.setenv("CLOUDFLARE_RADAR_TOKEN", "mock-token-value")
+    monkeypatch.setattr(ctp, "check_url", lambda url, **_kwargs: ["expected HTTP 2xx, got HTTP 401 Unauthorized"])
+    code = ctp.main(
+        [
+            "--check-url",
+            "https://api.cloudflare.com/client/v4/radar/datasets/ranking_top_1000000",
+            "--secret-env",
+            "CLOUDFLARE_RADAR_TOKEN",
+        ]
+    )
+    assert code != 0
+    out = capsys.readouterr().out
+    assert "mock-token-value" not in out


### PR DESCRIPTION
Implements **ADR-59** — a per-provider descriptor framework for the DNSBL TOP1M whitelist, adding three sources including a token-authenticated one. Built in 6 gated phases (prep front-loaded); the security prerequisite (download-log URL redaction) landed separately in #890.

## What

- **Provider descriptor table** (`pfb_top1m_providers()` in `pfblockerng_extra.inc`) — one row per provider: `url` / `container` (zip·gz·plain) / `parse` (rank_domain · csv+domain_col+header) / `auth` (none·header-bearer) / `licence`. The URL selection, the `pfblockerng_top1m()` parser, the extract/decompress path, and the CI health-check all read this single source.
- **Providers** (verified against live files/API): kept Tranco + Cisco; added **DomCop top-10M** and **Majestic Million** (keyless; Majestic shows a CC BY 3.0 attribution note); added **Cloudflare Radar** (token via `Authorization: Bearer`, single-`domain` CSV, CC BY-NC 4.0 note).
- **Header auth in `pfb_download`** — a `pfb_download_http_headers()` merge that adds caller headers without clobbering the ADR-42 conditional-GET header.
- **Masked `top1m_token` field** (registered `PfbConfig`, write-only, `password` input, JS-toggled to token providers), a laxer `PFB_FILTER_TOKEN` validator (base64url/JWT), and safe-on-missing-token behaviour (the #886 preserve+warn path; the token is header-carried so it never reaches a log/URL).
- **CI health-check** (`check_top1m_providers.py`) reworked to read the descriptor table (the old literal-URL regex went stale when Phase 1 made the URL an expression), classify by `auth`, and skip token providers with a visible reason when no CI secret is set.
- Two latent bugs found+fixed along the way: `pfblockerng_top1m()` required a comma per line (broke Cloudflare's single-column format); the checker's `_scan_csv` assumed zip + 2-column rows.

## Tests

Each phase carries fail-before/pass-after (or oracle) coverage: the descriptor URL pin, the parser knobs (header-skip / domain-col red→green), the header merge, DomCop/Majestic real-shape parses, the token round-trip + validator + no-token-in-log, and the health-check auth classification (skip-vs-validate). Tier-A UI for the new options + the masked token field + the licence notes; Tier-B for the token save→reload persistence. Full PHPUnit + config round-trip suites green; the CI health-check unit suite green.

## Out-of-CI (ADR §7, maintainer smoke)

CI can't run a live authenticated Cloudflare download or a live-VM DNSBL resolve per provider. Manual acceptance on a real box: an Update per provider (DomCop / Majestic / Cloudflare-with-a-real-token) shows `Found N` (N>0) and a popular domain resolves; and `extras.log` after a forced Cloudflare failure shows no token.

Note: the health-check currently flags **DomCop as stale** (its live top-10M is ~99 days old vs the 30-day freshness threshold) — a real finding; consider a per-provider freshness threshold if DomCop's monthly cadence should be tolerated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded TOP1M source options to include DomCop, Majestic Million, and Cloudflare Radar.
  * Added support for provider-specific download behavior, including authenticated feeds and different CSV formats.
  * Introduced a masked TOP1M token field in the UI for providers that require it.

* **Bug Fixes**
  * Improved TOP1M parsing for header rows, single-column feeds, and provider-specific domain columns.
  * Preserved existing tokens when the field is left blank, and kept sensitive values out of logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->