### PR TITLE
ci: raise TOP1M health-check staleness cutoff to 6 months

### DIFF
--- a/scripts/misc/check_top1m_providers.py
+++ b/scripts/misc/check_top1m_providers.py
@@ -55,9 +55,12 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 # A real Top1M list is ~1M rows; 100k is a generous floor that still rejects a
-# truncated/error payload. Lists update ~daily; 30 days is generously frozen.
+# truncated/error payload. Refresh cadence varies by provider -- some publish
+# ~daily, others only monthly/quarterly (e.g. DomCop) -- so the staleness cutoff
+# is a deliberately generous 6 months: below that is too soon to declare a feed
+# dead, past it the source has almost certainly stopped updating.
 MIN_ROWS = 100_000
-MAX_AGE_DAYS = 30
+MAX_AGE_DAYS = 180
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_DESCRIPTOR_FILE = REPO_ROOT / "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"

--- a/tests/test_check_top1m_providers.py
+++ b/tests/test_check_top1m_providers.py
@@ -324,6 +324,22 @@ def test_validate_top1m_flags_staleness_only_once_last_modified_ages_past_the_li
     assert "35 days old" in reasons[0]
 
 
+# A ~5-month-old Last-Modified: past the old 30-day default, well within the new
+# 6-month one. A provider that refreshes only monthly/quarterly (e.g. DomCop) is
+# not dead at this age.
+_WITHIN_SIX_MONTHS_LM = "Fri, 06 Feb 2026 00:00:00 GMT"  # 150 days before _NOW
+
+
+def test_validate_top1m_default_staleness_window_is_six_months_not_thirty_days() -> None:
+    # FAIL-BEFORE/PASS-AFTER for the 30 -> 180 day default bump: this calls
+    # validate_top1m WITHOUT max_age_days, so it exercises the MAX_AGE_DAYS
+    # default. A 150-day-old feed is stale under the old 30-day default (test
+    # fails) and fresh under the new 6-month one (test passes).
+    rows: list[tuple[str, ...]] = [(str(i), f"example{i}.com") for i in range(10)]
+    body = _zip_of(rows)
+    assert ctp.validate_top1m(body, _WITHIN_SIX_MONTHS_LM, _NOW, min_rows=10) == []
+
+
 # --- 'plain' container (Majestic/Cloudflare's real shape): no zip wrapper --- #
 
 


### PR DESCRIPTION
The TOP1M provider health-check (`scripts/misc/check_top1m_providers.py`) flagged a feed as stale once its `Last-Modified` passed **30 days**. That's too aggressive: refresh cadence varies by provider — some publish ~daily, others only monthly/quarterly. DomCop's live top-10M list read ~99 days old, so the check reported a healthy source as dead.

Raise `MAX_AGE_DAYS` 30 → **180 (6 months)**: below that is too soon to declare any of the bundled feeds dead; past it the source has almost certainly stopped updating.

The per-call `max_age_days` param is unchanged (the existing tests that pass it explicitly still pin the logic). A new test exercises the **default** window — fail-before/pass-after on the 30→180 bump: a 150-day-old feed is stale under the old default, fresh under the new one.