### PR TITLE
test: match category-edit help assertion to the reworded page string

### DIFF
--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -928,7 +928,7 @@ def test_ipv4_category_edit_renders_alias_type_help_text(
 
     Scenario: a GET of ``pfblockerng_category_edit.php?type=ipv4`` returns a
     200 response with the ``Must be a Port-type alias.`` and
-    ``Must be a Network or Host-type alias.`` help strings that were added by
+    ``Must be an address-type (Host, Network, URL or URL Table) alias.`` help strings that were added by
     issue #356 to guide the user when filling the Advanced In/Out alias fields.
 
     Background:
@@ -944,7 +944,7 @@ def test_ipv4_category_edit_renders_alias_type_help_text(
     Then:
         - HTTP 200.
         - Body contains ``Must be a Port-type alias.``
-        - Body contains ``Must be a Network or Host-type alias.``
+        - Body contains ``Must be an address-type (Host, Network, URL or URL Table) alias.``
         - Body free of ``Fatal error``, ``Parse error``, ``Warning``, ``Notice``,
           ``Uncaught`` (standard ui_render guarantee).
     """
@@ -957,8 +957,9 @@ def test_ipv4_category_edit_renders_alias_type_help_text(
     assert "Must be a Port-type alias." in body, (
         "IPv4 category-edit page is missing help text 'Must be a Port-type alias.'"
     )
-    assert "Must be a Network or Host-type alias." in body, (
-        "IPv4 category-edit page is missing help text 'Must be a Network or Host-type alias.'"
+    assert "Must be an address-type (Host, Network, URL or URL Table) alias." in body, (
+        "IPv4 category-edit page is missing help text "
+        "'Must be an address-type (Host, Network, URL or URL Table) alias.'"
     )
 
 


### PR DESCRIPTION
The Advanced In/Out address help was reworded on devel (327337a6) — "Must be a Network or Host-type alias." → "Must be an address-type (Host, Network, URL or URL Table) alias." (the field also accepts URL / URL-Table aliases). The Tier A render test still asserted the old wording, so `test_ipv4_category_edit_renders_alias_type_help_text` fails on devel; the Port help was unchanged, so only the address assertion broke. This points the assertion + docstring at the current page wording.

Verified: a dispatched `ui_render` run is red on the pre-change assertion; the built .pkg renders the new string. A green-after `ui_render` dispatch on this branch is linked below.

Fixes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfJUsCQkpFZxXufncGUS2f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the category edit help text to use broader, clearer address-type wording.
  * The message now indicates that Host, Network, URL, and URL Table aliases are accepted, instead of only Host or Network aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->