### PR TITLE
dev: run phpcs under memory_limit=1G in the pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -195,7 +195,11 @@ if [ "$staged_php" = 1 ]; then
 	# from phpcs.xml.dist.
 	if [ -x vendor/bin/phpcs ]; then
 		step 'phpcs'
-		vendor/bin/phpcs || failed 'phpcs'
+		# issue #895: cap memory like the phpstan step above — phpcs tokenising a
+		# large file (pfblockerng.inc ~19.5k lines) exhausts PHP's default 128M and
+		# aborts, which forces --no-verify and skips ALL gates. CI runs at
+		# memory_limit=-1 so it never OOMs there; this closes the local-only gap.
+		vendor/bin/phpcs -d memory_limit=1G || failed 'phpcs'
 	else
 		skip phpcs
 	fi

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,6 @@
     "scripts": {
         "test": "phpunit",
         "phpstan": "phpstan analyse --no-progress --memory-limit=1G",
-        "phpcs": "phpcs"
+        "phpcs": "phpcs -d memory_limit=1G"
     }
 }


### PR DESCRIPTION
`.githooks/pre-commit` ran `vendor/bin/phpcs` with no memory limit, so phpcs tokenising a large file (`pfblockerng.inc`, ~19.5k lines) exhausts PHP's default 128M and aborts — forcing `git commit --no-verify`, which silently skips every pre-commit gate. CI runs phpcs at `memory_limit=-1`, so the gap is local-only. Caps phpcs at `memory_limit=1G` (matching the phpstan step) and mirrors it in the composer `phpcs` script.

Reproduced locally: the bare hook invocation OOMs at 128M; `-d memory_limit=1G` clears it.

Fixes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfJUsCQkpFZxXufncGUS2f