### PR TITLE
test: route sandbox-child engine diagnostics to stderr (PHP 8.5)

### DIFF
--- a/tests/php/DnsblPrefetchTest.php
+++ b/tests/php/DnsblPrefetchTest.php
@@ -427,7 +427,12 @@ final class DnsblPrefetchTest extends TestCase
 			$code = "<?php\nrequire " . var_export("{$repo}/tests/php/bootstrap.php", true) . ";\n" . $phpBody;
 			file_put_contents($probe, $code);
 
-			$cmd = 'php -d open_basedir=' . escapeshellarg($repo) . ' ' . escapeshellarg($probe) . ' 2>/dev/null';
+			// issue #896: route PHP engine diagnostics to stderr (dropped by the 2>/dev/null
+			// below) so the child's stdout stays pure JSON. Under open_basedir the child's
+			// tempnam() emits a Warning; on PHP 8.5 it lands on STDOUT (not stderr), prepending
+			// non-JSON text that breaks json_decode() — green on 8.3, red on 8.5 without this.
+			$cmd = 'php -d open_basedir=' . escapeshellarg($repo)
+				. ' -d display_errors=stderr ' . escapeshellarg($probe) . ' 2>/dev/null';
 			$output = shell_exec($cmd);
 		} finally {
 			@unlink($probe);

--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -722,7 +722,12 @@ final class IpPrefetchTest extends TestCase
 			$code = "<?php\nrequire " . var_export("{$repo}/tests/php/bootstrap.php", true) . ";\n" . $phpBody;
 			file_put_contents($probe, $code);
 
-			$cmd = 'php -d open_basedir=' . escapeshellarg($repo) . ' ' . escapeshellarg($probe) . ' 2>/dev/null';
+			// issue #896: route PHP engine diagnostics to stderr (dropped by the 2>/dev/null
+			// below) so the child's stdout stays pure JSON. Under open_basedir the child's
+			// tempnam() emits a Warning; on PHP 8.5 it lands on STDOUT (not stderr), prepending
+			// non-JSON text that breaks json_decode() — green on 8.3, red on 8.5 without this.
+			$cmd = 'php -d open_basedir=' . escapeshellarg($repo)
+				. ' -d display_errors=stderr ' . escapeshellarg($probe) . ' 2>/dev/null';
 			$output = shell_exec($cmd);
 		} finally {
 			@unlink($probe);

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -217,12 +217,11 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 * guard as testRenameFailurePreservesPriorWhitelistAndWarns below). The genuine
 	 * tempnam()/fopen()-returns-FALSE branch (both the given dir AND the system temp dir
 	 * refuse the create) is only deterministically forceable via an
-	 * `open_basedir`-restricted child process -- the same mechanism already used by
-	 * DnsblPrefetchTest/IpPrefetchTest's `runInRestrictedTempDirSandbox()`, which is
-	 * known-flaky in this local dev environment (see this suite's pre-existing 3
-	 * failures) -- so THAT exact branch is left as a documented out-of-CI/covered-by-
-	 * guard gap rather than a fourth locally-flaky sandboxed test; this test still pins
-	 * the finding-2 crash fix via the read-only-dbdir trigger.
+	 * `open_basedir`-restricted child process -- the same mechanism used by
+	 * DnsblPrefetchTest/IpPrefetchTest's `runInRestrictedTempDirSandbox()` -- so THAT
+	 * exact branch is left as a documented out-of-CI/covered-by-guard gap rather than
+	 * adding a fourth sandboxed test here; this test still pins the finding-2 crash fix
+	 * via the read-only-dbdir trigger.
 	 */
 	public function testReadOnlyDbdirCausesRenameFailurePreservesPriorWhitelistAndWarns(): void
 	{


### PR DESCRIPTION
`runInRestrictedTempDirSandbox()` (identical helper in DnsblPrefetchTest / IpPrefetchTest) spawns a child PHP process under `-d open_basedir=<repo>` to force a `tempnam()` failure, then `json_decode`s the child's stdout. On a local PHP 8.5 build where `display_errors` defaults to on (e.g. Homebrew), the child's open_basedir Warning is written to STDOUT, so the existing `2>/dev/null` doesn't catch it and the non-JSON text prepended to the child's `echo json_encode(...)` breaks `json_decode` — 3 tests fail. CI's PHP 8.5 leg is unaffected because `shivammathur/setup-php` defaults `display_errors=stderr`; this fix makes the harness hermetic against the host's php.ini instead of relying on that incidental default.

Fix: add `-d display_errors=stderr` to the child `php` invocation so engine diagnostics go to stderr (already dropped by `2>/dev/null`), leaving stdout pure JSON. Also drops a now-stale "known-flaky" comment in Top1mPreserveOnEmptyFeedTest that referenced these 3 tests.

Verified on PHP 8.5.7: red before, green after (3 tests; full suite 2342 passing, 0 failures).

Fixes #896

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfJUsCQkpFZxXufncGUS2f