### PR TITLE
ci: aggregate module durations from CE shards only (#901)

### DIFF
--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -97,14 +97,20 @@ jobs:
           # the union of the shards covers the whole suite (issue #816). Only ONE CE
           # version's shards may be aggregated — a second CE leg would double-count the
           # suite exactly like the Plus legs excluded by the download pattern above.
-          LOGS=$(find smoke-artifacts -path '*/smoke-diagnostics-pfsense-ce-*' -name pytest-durations.log | LC_ALL=C sort)
+          # PREFIX must stay in sync with the download `pattern:` above — the with:
+          # block cannot share a shell variable.
+          PREFIX='smoke-diagnostics-pfsense-ce-'
+          LOGS=$(find smoke-artifacts -path "*/${PREFIX}*" -name pytest-durations.log | LC_ALL=C sort)
           if [ -z "$LOGS" ]; then
             echo "::error::no pytest-durations.log found in the smoke artifacts — nothing to aggregate."
             exit 1
           fi
-          VERSIONS=$(printf '%s\n' $LOGS | sed -n 's|.*/smoke-diagnostics-pfsense-ce-\(.*\)-s[0-9][0-9]*/.*|\1|p' | LC_ALL=C sort -u)
-          if [ "$(printf '%s\n' "$VERSIONS" | wc -l)" -ne 1 ]; then
-            echo "::error::CE diagnostics span more than one pfSense version ($(printf '%s' "$VERSIONS" | tr '\n' ' ')) — aggregating them would double-count the suite. Narrow to one CE leg."
+          VERSIONS=$(printf '%s\n' $LOGS | sed -n "s|.*/${PREFIX}\(.*\)-s[0-9][0-9]*/.*|\1|p" | LC_ALL=C sort -u)
+          # Fail closed on an EMPTY extraction too: zero matched versions means the
+          # artifact naming drifted from PREFIX — the guard must not read a blank
+          # line as "one version" (wc -l would report 1).
+          if [ -z "$VERSIONS" ] || [ "$(printf '%s\n' "$VERSIONS" | wc -l)" -ne 1 ]; then
+            echo "::error::CE diagnostics must resolve to exactly one pfSense version, got: '$(printf '%s' "$VERSIONS" | tr '\n' ' ')' — empty means artifact-name drift; multiple would double-count the suite."
             exit 1
           fi
           echo "Aggregating these shard logs:"

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -92,27 +92,17 @@ jobs:
       - name: Rebuild the module-durations table
         run: |
           set -eu
-          # Feed every CE shard's captured pytest --durations log. module-durations.sh
-          # sums per module BASENAME across all inputs, so input order is irrelevant and
-          # the union of the shards covers the whole suite (issue #816). Only ONE CE
-          # version's shards may be aggregated — a second CE leg would double-count the
-          # suite exactly like the Plus legs excluded by the download pattern above.
-          # PREFIX must stay in sync with the download `pattern:` above — the with:
-          # block cannot share a shell variable.
-          PREFIX='smoke-diagnostics-pfsense-ce-'
-          LOGS=$(find smoke-artifacts -path "*/${PREFIX}*" -name pytest-durations.log | LC_ALL=C sort)
-          if [ -z "$LOGS" ]; then
-            echo "::error::no pytest-durations.log found in the smoke artifacts — nothing to aggregate."
-            exit 1
-          fi
-          VERSIONS=$(printf '%s\n' $LOGS | sed -n "s|.*/${PREFIX}\(.*\)-s[0-9][0-9]*/.*|\1|p" | LC_ALL=C sort -u)
-          # Fail closed on an EMPTY extraction too: zero matched versions means the
-          # artifact naming drifted from PREFIX — the guard must not read a blank
-          # line as "one version" (wc -l would report 1).
-          if [ -z "$VERSIONS" ] || [ "$(printf '%s\n' "$VERSIONS" | wc -l)" -ne 1 ]; then
-            echo "::error::CE diagnostics must resolve to exactly one pfSense version, got: '$(printf '%s' "$VERSIONS" | tr '\n' ' ')' — empty means artifact-name drift; multiple would double-count the suite."
-            exit 1
-          fi
+          # Feed ONE CE version's shard logs. module-durations.sh sums per module
+          # BASENAME across all inputs, so input order is irrelevant and the union
+          # of the shards covers the whole suite (issue #816) — but exactly one
+          # full-suite leg may be aggregated (a second leg double-counts). The
+          # selection lives in scripts/module-durations-logs.sh (shellspec-pinned,
+          # issue #901 / #910 review): it excludes Plus, picks the numeric-minimum
+          # CE version when the supported window holds two GA CE versions (the
+          # drop_ce steady state — never a nightly hard-fail), and fails loudly on
+          # zero logs or artifact-name drift. Its PREFIX must stay in sync with
+          # the download `pattern:` above.
+          LOGS=$(sh scripts/module-durations-logs.sh smoke-artifacts)
           echo "Aggregating these shard logs:"
           printf '  %s\n' $LOGS
           # shellcheck disable=SC2086  # deliberate word-split: one arg per log path (all ASCII)

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -82,18 +82,29 @@ jobs:
         with:
           run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
           github-token: ${{ github.token }}
-          pattern: smoke-diagnostics-*
+          # CE shards ONLY (issue #901). The nightly full fan-out also runs the
+          # Plus legs, but module-durations.sh's contract forbids feeding a
+          # second leg that re-runs the whole suite: it sums per module, so a
+          # Plus leg double-counts every test with non-uniform CE-vs-Plus skew.
+          pattern: smoke-diagnostics-pfsense-ce-*
           path: smoke-artifacts
 
       - name: Rebuild the module-durations table
         run: |
           set -eu
-          # Feed every leg/shard's captured pytest --durations log. module-durations.sh
+          # Feed every CE shard's captured pytest --durations log. module-durations.sh
           # sums per module BASENAME across all inputs, so input order is irrelevant and
-          # the union of the shards covers the whole suite (issue #816).
-          LOGS=$(find smoke-artifacts -name pytest-durations.log | LC_ALL=C sort)
+          # the union of the shards covers the whole suite (issue #816). Only ONE CE
+          # version's shards may be aggregated — a second CE leg would double-count the
+          # suite exactly like the Plus legs excluded by the download pattern above.
+          LOGS=$(find smoke-artifacts -path '*/smoke-diagnostics-pfsense-ce-*' -name pytest-durations.log | LC_ALL=C sort)
           if [ -z "$LOGS" ]; then
             echo "::error::no pytest-durations.log found in the smoke artifacts — nothing to aggregate."
+            exit 1
+          fi
+          VERSIONS=$(printf '%s\n' $LOGS | sed -n 's|.*/smoke-diagnostics-pfsense-ce-\(.*\)-s[0-9][0-9]*/.*|\1|p' | LC_ALL=C sort -u)
+          if [ "$(printf '%s\n' "$VERSIONS" | wc -l)" -ne 1 ]; then
+            echo "::error::CE diagnostics span more than one pfSense version ($(printf '%s' "$VERSIONS" | tr '\n' ' ')) — aggregating them would double-count the suite. Narrow to one CE leg."
             exit 1
           fi
           echo "Aggregating these shard logs:"

--- a/scripts/module-durations-logs.sh
+++ b/scripts/module-durations-logs.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# module-durations-logs.sh — select ONE CE version's pytest-durations logs from
+# an extracted smoke-artifacts tree, for scripts/module-durations.sh (issue
+# #901; #910 review). The duration table's contract allows exactly ONE
+# full-suite leg: Plus legs are excluded by the artifact prefix, and when the
+# supported window holds two GA CE versions (ci-metadata `drop_ce` policy — the
+# NORMAL steady state, not an edge case) the MINIMUM version is selected, the
+# same min-CE convention resolve-legs.sh uses for impacted scope. Failing on a
+# multi-CE window would permanently red the nightly refresh instead.
+#
+# Usage: module-durations-logs.sh <artifacts-dir>
+#   stdout — the selected pytest-durations.log paths, one per line
+#   stderr — the multi-version selection notice + loud errors
+#   rc 1   — no CE logs found, or artifact naming drifted from the PREFIX shape
+#
+# PREFIX must stay in sync with smoke-single.yml's smoke-diagnostics artifact
+# name and module-durations.yml's download `pattern:` (a with: block cannot
+# share a shell variable).
+set -eu
+
+PREFIX='smoke-diagnostics-pfsense-ce-'
+dir="${1:?usage: module-durations-logs.sh <artifacts-dir>}"
+
+LOGS=$(find "$dir" -path "*/${PREFIX}*" -name pytest-durations.log | LC_ALL=C sort)
+if [ -z "$LOGS" ]; then
+	echo "module-durations-logs: no pytest-durations.log under ${dir} matching ${PREFIX}* — nothing to aggregate." >&2
+	exit 1
+fi
+
+# Version token sits between the prefix and the shard suffix: <PREFIX><ver>-s<N>/.
+# Numeric two-field sort (2.8 < 2.10, not lexical).
+VERSIONS=$(printf '%s\n' "$LOGS" \
+	| sed -n "s|.*/${PREFIX}\(.*\)-s[0-9][0-9]*/.*|\1|p" \
+	| LC_ALL=C sort -t. -k1,1n -k2,2n -u)
+if [ -z "$VERSIONS" ]; then
+	echo "module-durations-logs: CE logs found but no version extracted — artifact naming drifted from ${PREFIX}<ver>-s<N>/." >&2
+	exit 1
+fi
+
+MIN_VER=$(printf '%s\n' "$VERSIONS" | head -n 1)
+if [ "$(printf '%s\n' "$VERSIONS" | wc -l)" -gt 1 ]; then
+	echo "module-durations-logs: multiple CE versions present ($(printf '%s' "$VERSIONS" | tr '\n' ' ')) — selecting min ${MIN_VER}; the table aggregates exactly one full-suite leg." >&2
+fi
+
+printf '%s\n' "$LOGS" | grep -F "/${PREFIX}${MIN_VER}-s"

--- a/tests/shell/module_durations_logs_spec.sh
+++ b/tests/shell/module_durations_logs_spec.sh
@@ -1,0 +1,80 @@
+#shellcheck shell=sh
+# module_durations_logs_spec.sh — pins scripts/module-durations-logs.sh (issue
+# #901; #910 review), the selector that picks ONE CE version's
+# pytest-durations.log files out of an extracted smoke-artifacts tree for
+# module-durations.sh. The table's contract allows exactly one full-suite leg,
+# and the supported window normally holds TWO GA CE versions (ci-metadata
+# drop_ce policy), so the selector must pick the numeric-minimum CE version —
+# never fail on the steady state, never mix legs, and fail LOUDLY on zero
+# logs or artifact-name drift.
+#
+# RED->GREEN evidence: this suite was authored against the #910 first-cut
+# behaviour (inline workflow guard that hard-failed on ANY multi-CE-version
+# artifact set and did not exist as a script). Run before the script existed,
+# every example failed with "No such file or directory"; the multi-version
+# example additionally pins the behaviour CHANGE (select min, rc 0) that the
+# first-cut guard (exit 1) would fail.
+#
+# No git operations here (pure filesystem), so no scrub_git_env is needed.
+
+Describe 'module-durations-logs.sh'
+  SCRIPT="${PFB_ROOT}/scripts/module-durations-logs.sh"
+
+  setup() {
+    fixture_dir=$(mktemp -d)
+  }
+  cleanup() {
+    rm -rf "$fixture_dir"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  # Lay out an extracted-artifact directory: <root>/smoke-diagnostics-<image>-<ver>-s<shard>/pytest-durations.log
+  add_shard_log() {
+    # $1=image ("pfsense-ce"/"pfsense-plus") $2=version $3=shard
+    mkdir -p "${fixture_dir}/smoke-diagnostics-$1-$2-s$3"
+    printf 'log\n' > "${fixture_dir}/smoke-diagnostics-$1-$2-s$3/pytest-durations.log"
+  }
+
+  It 'selects all shards of the single CE version and ignores Plus legs'
+    add_shard_log pfsense-ce 2.8 0
+    add_shard_log pfsense-ce 2.8 1
+    add_shard_log pfsense-plus 26.03 0
+    When run sh "$SCRIPT" "$fixture_dir"
+    The status should be success
+    The output should include 'smoke-diagnostics-pfsense-ce-2.8-s0/pytest-durations.log'
+    The output should include 'smoke-diagnostics-pfsense-ce-2.8-s1/pytest-durations.log'
+    The output should not include 'pfsense-plus'
+    The stderr should equal ''
+  End
+
+  It 'picks the NUMERIC minimum CE version in a two-GA-CE window (2.8 < 2.10, not lexical) with a loud notice'
+    # The drop_ce steady state: two GA CE versions ci:true at once. The
+    # selector must not fail (the #910 first-cut guard did) and must sort
+    # numerically -- a lexical sort would pick 2.10.
+    add_shard_log pfsense-ce 2.8 0
+    add_shard_log pfsense-ce 2.10 0
+    add_shard_log pfsense-ce 2.10 1
+    When run sh "$SCRIPT" "$fixture_dir"
+    The status should be success
+    The output should include 'smoke-diagnostics-pfsense-ce-2.8-s0/pytest-durations.log'
+    The output should not include 'pfsense-ce-2.10'
+    The stderr should include 'multiple CE versions present'
+    The stderr should include 'selecting min 2.8'
+  End
+
+  It 'fails loudly when no CE logs exist at all (Plus-only artifacts)'
+    add_shard_log pfsense-plus 26.03 0
+    When run sh "$SCRIPT" "$fixture_dir"
+    The status should be failure
+    The stderr should include 'no pytest-durations.log'
+  End
+
+  It 'fails loudly on artifact-name drift (CE log present but no <ver>-s<N> shape to extract)'
+    mkdir -p "${fixture_dir}/smoke-diagnostics-pfsense-ce-weird"
+    printf 'log\n' > "${fixture_dir}/smoke-diagnostics-pfsense-ce-weird/pytest-durations.log"
+    When run sh "$SCRIPT" "$fixture_dir"
+    The status should be failure
+    The stderr should include 'artifact naming drifted'
+  End
+End


### PR DESCRIPTION
## What

The nightly module-durations refresh downloaded `smoke-diagnostics-*` — every leg of the full fan-out, CE **and** Plus — and aggregated all `pytest-durations.log` files it found. `scripts/module-durations.sh`'s own contract (and the generated table's header) forbids feeding a second leg that re-runs the whole suite: sums are per module, so the Plus legs double-count every test with non-uniform CE-vs-Plus skew, degrading the LPT shard balance the table exists to feed.

## Fix

- Narrow the artifact download pattern to `smoke-diagnostics-pfsense-ce-*`.
- Guard the aggregation: if the CE logs span more than one pfSense version (a second CE leg would double-count exactly like Plus), fail loudly instead of committing a skewed table.

The committed table was produced under the old behaviour (CE+Plus sums); it self-corrects on the next nightly refresh — the CE-only sums will differ, so the commit-if-changed step fires.

## Validation

Workflow YAML has no unit harness in this repo: validated by YAML parse and the artifact-name scheme in `smoke-single.yml` (`smoke-diagnostics-${image_name}-${pfsense_version}-s${shard}`, `image_name` ∈ `pfsense-ce`/`pfsense-plus`). The version-guard `sed`/`sort`/`wc` pipeline was exercised locally against synthetic paths for the one-version and two-version cases.

Fixes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of module duration updates by using only matching CE diagnostics data.
  * Added a safeguard to prevent mixing results from different pfSense versions, reducing the chance of double-counted timing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->