### PR TITLE
ci: dispatch real CI onto GITHUB_TOKEN-created refresh PRs/commits

### DIFF
--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -35,7 +35,7 @@ on:
 
 permissions:
   contents: write   # commit the refreshed table to devel
-  actions: read     # download the smoke run's artifacts (cross-run)
+  actions: write    # download the smoke run's artifacts (cross-run) + dispatch CI onto devel (#902)
 
 # One refresh at a time; a newer run supersedes an in-flight one.
 concurrency:
@@ -104,6 +104,8 @@ jobs:
           cat tests/smoke/module-durations.txt
 
       - name: Commit the refreshed table (only if it changed)
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -eu
           if git diff --quiet -- tests/smoke/module-durations.txt; then
@@ -124,3 +126,11 @@ jobs:
             git pull --rebase origin devel
           done
           echo "Committed refreshed module-durations.txt to devel."
+
+          # GITHUB_TOKEN-created pushes trigger no workflow runs, so this commit
+          # would otherwise land on devel with no push-CI, and a stale table row
+          # (e.g. a test renamed between nightly start and this commit) silently
+          # reds the drift gate (tests/test_shard_union.py) on every later PR
+          # until someone notices (issue #902). Dispatch the unit suite onto
+          # devel's new tip ourselves; loud on failure (`set -eu`, no `|| true`).
+          gh workflow run test.yml --ref devel

--- a/.github/workflows/tld-refresh.yml
+++ b/.github/workflows/tld-refresh.yml
@@ -5,9 +5,16 @@ name: TLD List Refresh
 # scripts/misc/update_tld_lists.py rewrites the gTLD/ccTLD/iTLD arrays in
 # src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php from the authoritative
 # IANA root-zone list (bgTLD is hand-curated and never touched). When the root
-# zone changes, this workflow opens/updates a PR against devel so the normal CI
-# (Tier-A ui_render) gates the data change — it NEVER pushes to devel directly.
-# See issue #872 (maintenance umbrella) and docs/misc/tld-lists.md.
+# zone changes, this workflow opens/updates a PR against devel — it NEVER
+# pushes to devel directly.
+#
+# GitHub suppresses push/pull_request-triggered workflow runs for events
+# created by GITHUB_TOKEN, so test.yml's own pull_request gate never fires on
+# this PR. workflow_dispatch is the documented exception, so this workflow
+# dispatches the real gates (test.yml's unit suite + ui-tests.yml's Tier-A
+# ui_render) onto the branch head itself, right after every push, so checks
+# attach to the PR's commit. See issue #872 (maintenance umbrella), issue #902
+# (the CI-dispatch fix), and docs/misc/tld-lists.md.
 
 on:
   # Weekly, Monday 06:00 UTC. The root zone changes slowly; weekly is ample.
@@ -40,6 +47,7 @@ jobs:
     permissions:
       contents: write        # push the automation branch (NOT devel)
       pull-requests: write    # open/label the PR
+      actions: write          # dispatch the CI gates onto the branch head (#902)
     env:
       GH_TOKEN: ${{ github.token }}
       BRANCH: tld-refresh/auto
@@ -81,6 +89,16 @@ jobs:
           git commit -m "pfblockerng: refresh TLD Allow lists from IANA (automated)"
           git push --force origin "$BRANCH"
 
+          # GITHUB_TOKEN-created pushes trigger no workflow runs (GitHub
+          # suppresses push/pull_request events from GITHUB_TOKEN actors), so
+          # the branch head above gets no automatic CI. workflow_dispatch is
+          # the documented exception — dispatch the real gates onto it
+          # ourselves so real checks attach to this commit / the PR's SHA
+          # (issue #902). Loud on failure: no `|| true`, `set -eu` is active.
+          echo "Dispatching CI onto $BRANCH (GITHUB_TOKEN pushes trigger no workflow runs)."
+          gh workflow run test.yml --ref "$BRANCH"
+          gh workflow run ui-tests.yml --ref "$BRANCH" -f tier=render -f scope=impacted
+
           # One open PR at a time: push above already updated any existing one.
           if [ "$(gh pr list --head "$BRANCH" --base devel --state open --json number --jq 'length')" -gt 0 ]; then
             echo "An open PR from $BRANCH already exists — the force-push updated it."
@@ -93,7 +111,7 @@ jobs:
             --title "pfblockerng: refresh TLD Allow lists from IANA (automated)" \
             --label "enhancement" \
             --label "ui-tests" \
-            --body "Automated weekly refresh of the DNSBL **TLD Allow** picker arrays (\`gTLD\`/\`ccTLD\`/\`iTLD\`) from the [IANA root zone](https://data.iana.org/TLD/tlds-alpha-by-domain.txt), via \`scripts/misc/update_tld_lists.py\`. \`bgTLD\` is hand-curated and untouched. Part of the recurring maintenance in #872 — review the data diff, then merge once CI (Tier-A \`ui_render\`) is green."
+            --body "Automated weekly refresh of the DNSBL **TLD Allow** picker arrays (\`gTLD\`/\`ccTLD\`/\`iTLD\`) from the [IANA root zone](https://data.iana.org/TLD/tlds-alpha-by-domain.txt), via \`scripts/misc/update_tld_lists.py\`. \`bgTLD\` is hand-curated and untouched. Part of the recurring maintenance in #872 — review the data diff. GitHub does not run CI automatically on a GITHUB_TOKEN-created PR, so this workflow dispatched the unit suite (\`test.yml\`) and the Tier-A \`ui_render\` UI gate (\`ui-tests.yml\`) onto this branch's head itself — see the Checks tab for their status. Merge once both are green."
 
       - name: Dry-run summary
         if: steps.refresh.outputs.changed == 'true' && env.DRY_RUN == 'true'

--- a/.github/workflows/tld-refresh.yml
+++ b/.github/workflows/tld-refresh.yml
@@ -10,11 +10,16 @@ name: TLD List Refresh
 #
 # GitHub suppresses push/pull_request-triggered workflow runs for events
 # created by GITHUB_TOKEN, so test.yml's own pull_request gate never fires on
-# this PR. workflow_dispatch is the documented exception, so this workflow
-# dispatches the real gates (test.yml's unit suite + ui-tests.yml's Tier-A
-# ui_render) onto the branch head itself, right after every push, so checks
-# attach to the PR's commit. See issue #872 (maintenance umbrella), issue #902
-# (the CI-dispatch fix), and docs/misc/tld-lists.md.
+# this PR — and a workflow_dispatch run's checks do NOT attach to a PR's
+# Checks tab either (only pull_request-triggered runs do; verified on #911).
+# So this workflow dispatches the real gates (test.yml's unit suite +
+# ui-tests.yml's Tier-A ui_render) onto the branch head after opening/updating
+# the PR, then posts a PR comment linking both runs: the PR's Checks tab stays
+# empty by GitHub's design — the linked runs (Actions tab) ARE the gate.
+# NOTE: the dry_run self-test validates the IANA diff only; the push / PR /
+# dispatch / comment path is exercised only by a real (non-dry) run. See issue
+# #872 (maintenance umbrella), issue #902 (the CI-dispatch fix), and
+# docs/misc/tld-lists.md.
 
 on:
   # Weekly, Monday 06:00 UTC. The root zone changes slowly; weekly is ample.
@@ -26,7 +31,8 @@ on:
       dry_run:
         description: >
           If 'true', log the drift that WOULD be proposed but open no PR and
-          push nothing. Use this to self-test the workflow.
+          push nothing. Self-tests the IANA diff only — the push/PR/CI-dispatch
+          path runs only on a real (non-dry) run.
         required: false
         default: "false"
 
@@ -88,30 +94,68 @@ jobs:
           git add src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
           git commit -m "pfblockerng: refresh TLD Allow lists from IANA (automated)"
           git push --force origin "$BRANCH"
+          HEAD_SHA=$(git rev-parse HEAD)
 
-          # GITHUB_TOKEN-created pushes trigger no workflow runs (GitHub
-          # suppresses push/pull_request events from GITHUB_TOKEN actors), so
-          # the branch head above gets no automatic CI. workflow_dispatch is
-          # the documented exception — dispatch the real gates onto it
-          # ourselves so real checks attach to this commit / the PR's SHA
-          # (issue #902). Loud on failure: no `|| true`, `set -eu` is active.
-          echo "Dispatching CI onto $BRANCH (GITHUB_TOKEN pushes trigger no workflow runs)."
+          # PR first, CI dispatch after: the PR is the primary side effect — a
+          # transient dispatch failure must not leave a pushed branch with no
+          # PR until next Monday. One open PR at a time: the force-push above
+          # already updated any existing one.
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --base devel --state open --json number --jq '.[0].number // empty')
+          if [ -n "$PR_NUMBER" ]; then
+            echo "An open PR from $BRANCH already exists (#$PR_NUMBER) — the force-push updated it."
+          else
+            gh pr create \
+              --base devel \
+              --head "$BRANCH" \
+              --title "pfblockerng: refresh TLD Allow lists from IANA (automated)" \
+              --label "enhancement" \
+              --label "ui-tests" \
+              --body "Automated weekly refresh of the DNSBL **TLD Allow** picker arrays (\`gTLD\`/\`ccTLD\`/\`iTLD\`) from the [IANA root zone](https://data.iana.org/TLD/tlds-alpha-by-domain.txt), via \`scripts/misc/update_tld_lists.py\`. \`bgTLD\` is hand-curated and untouched. Part of the recurring maintenance in #872 — review the data diff. GitHub runs no automatic CI on a GITHUB_TOKEN-created PR, and dispatched runs do not appear in this PR's Checks tab — the workflow dispatches the unit suite (\`test.yml\`) and the Tier-A \`ui_render\` gate (\`ui-tests.yml\`) onto this branch's head and links both runs in a comment below (they are also visible in the repo's Actions tab). Merge once both linked runs are green."
+            PR_NUMBER=$(gh pr list --head "$BRANCH" --base devel --state open --json number --jq '.[0].number')
+          fi
+
+          # GITHUB_TOKEN-created pushes/PRs trigger no workflow runs, so the
+          # branch head gets no automatic CI. workflow_dispatch is the
+          # documented exception — dispatch the real gates onto the branch.
+          # --ref only accepts a branch/tag (a bare SHA is rejected with HTTP
+          # 422 "No ref found"), so dispatch by branch and pin the runs to
+          # HEAD_SHA when resolving them below. scope=impacted derives its -k
+          # from changed TEST files only; this PR changes src only, so the
+          # derivation is empty and resolve-legs.sh falls back to the WHOLE
+          # ui_render tier on the min-CE leg — the intended gate. Loud on
+          # failure: no `|| true`, `set -eu` is active (issue #902).
           gh workflow run test.yml --ref "$BRANCH"
           gh workflow run ui-tests.yml --ref "$BRANCH" -f tier=render -f scope=impacted
 
-          # One open PR at a time: push above already updated any existing one.
-          if [ "$(gh pr list --head "$BRANCH" --base devel --state open --json number --jq 'length')" -gt 0 ]; then
-            echo "An open PR from $BRANCH already exists — the force-push updated it."
-            exit 0
-          fi
-
-          gh pr create \
-            --base devel \
-            --head "$BRANCH" \
-            --title "pfblockerng: refresh TLD Allow lists from IANA (automated)" \
-            --label "enhancement" \
-            --label "ui-tests" \
-            --body "Automated weekly refresh of the DNSBL **TLD Allow** picker arrays (\`gTLD\`/\`ccTLD\`/\`iTLD\`) from the [IANA root zone](https://data.iana.org/TLD/tlds-alpha-by-domain.txt), via \`scripts/misc/update_tld_lists.py\`. \`bgTLD\` is hand-curated and untouched. Part of the recurring maintenance in #872 — review the data diff. GitHub does not run CI automatically on a GITHUB_TOKEN-created PR, so this workflow dispatched the unit suite (\`test.yml\`) and the Tier-A \`ui_render\` UI gate (\`ui-tests.yml\`) onto this branch's head itself — see the Checks tab for their status. Merge once both are green."
+          # A workflow_dispatch run's checks never attach to the PR's Checks
+          # tab (only pull_request-triggered runs do), so without this comment
+          # the PR looks unchecked. Resolve each dispatched run's URL — runs
+          # take a few seconds to appear — and link them on the PR.
+          find_run_url() {
+            # $1 = workflow file; poll for the dispatched run at OUR head SHA.
+            _i=0
+            while [ "$_i" -lt 6 ]; do
+              _url=$(gh run list --workflow "$1" --branch "$BRANCH" \
+                       --event workflow_dispatch --limit 5 --json url,headSha \
+                       --jq ".[] | select(.headSha == \"$HEAD_SHA\") | .url" | head -n 1)
+              if [ -n "$_url" ]; then
+                printf '%s\n' "$_url"
+                return 0
+              fi
+              _i=$((_i + 1))
+              sleep 5
+            done
+            return 1
+          }
+          UNIT_URL=$(find_run_url test.yml) || {
+            echo "::warning::could not resolve the dispatched test.yml run for $HEAD_SHA — find it in the Actions tab."
+            UNIT_URL="not resolved — see the repo's Actions tab (workflow: Tests, branch: $BRANCH)"
+          }
+          UI_URL=$(find_run_url ui-tests.yml) || {
+            echo "::warning::could not resolve the dispatched ui-tests.yml run for $HEAD_SHA — find it in the Actions tab."
+            UI_URL="not resolved — see the repo's Actions tab (workflow: UI tests fan-out, branch: $BRANCH)"
+          }
+          gh pr comment "$PR_NUMBER" --body "CI for head \`$HEAD_SHA\` was dispatched by the refresh workflow (GitHub runs no automatic checks on a GITHUB_TOKEN-created PR, and dispatched runs do not appear in this PR's Checks tab): unit CI: $UNIT_URL — Tier-A UI render: $UI_URL. Merge once both runs are green."
 
       - name: Dry-run summary
         if: steps.refresh.outputs.changed == 'true' && env.DRY_RUN == 'true'

--- a/docs/misc/tld-lists.md
+++ b/docs/misc/tld-lists.md
@@ -42,8 +42,11 @@ so it never goes stale.
 
 - **Automated (weekly):** `.github/workflows/tld-refresh.yml` runs the script every Monday and,
   when the root zone has drifted, opens/updates a PR against `devel` from a bot-owned branch.
-  It never pushes to `devel`/`main`; the normal CI (Tier-A `ui_render`) gates the data change.
-  The auto-PR carries the `ui-tests` label so that guard runs and blocks.
+  It never pushes to `devel`/`main`. GitHub runs no automatic CI on a GITHUB_TOKEN-created PR
+  (and a dispatched run's checks never attach to its Checks tab), so the workflow dispatches
+  the real gates — the unit suite (`test.yml`) and Tier-A `ui_render` (`ui-tests.yml`) — onto
+  the branch head and posts a PR comment linking both runs (issue #902); merge once the linked
+  runs are green. The auto-PR carries the `ui-tests` label to mark it as UI-affecting.
 - **Manual:** from the repo root, `python3 scripts/misc/update_tld_lists.py` (rewrites the file)
   or `python3 scripts/misc/update_tld_lists.py --check` (exit 1 + a diff if out of date, no
   write). A manual refresh is otherwise a 6–12 month task, or whenever a major new gTLD batch


### PR DESCRIPTION
## Summary

Fixes #902. GitHub silently excludes `GITHUB_TOKEN`-created push/pull_request
events from triggering workflow runs. Two automation workflows in this repo
rely on those triggers and were both affected:

- `tld-refresh.yml` pushes its weekly refresh branch and opens the auto-PR
  with `github.token` (`gh pr create`). Its header comment and generated PR
  body both promised "the normal CI (Tier-A `ui_render`) gates the data
  change... merge once CI is green" — but `test.yml`'s `pull_request` trigger
  (and the label-gated `ui-suite` job) never fires on that PR, so it shows
  zero checks.
- `module-durations.yml` pushes its refreshed table straight to `devel` with
  `github.token`. That commit gets no push-CI either, so a stale row (e.g. a
  test renamed between nightly start and commit) can silently red the drift
  gate (`tests/test_shard_union.py`) on every later PR until someone notices.

`workflow_dispatch` is the documented exception to that suppression, so both
workflows now dispatch the real gates onto their own commit right after
pushing it, using the existing `github.token`. One important caveat
(established during adversarial review, empirically — a dispatched `test.yml`
run against this branch attached zero check runs to this PR's
`statusCheckRollup`): **a `workflow_dispatch` run's checks never appear in a
PR's Checks tab** — only `pull_request`-triggered runs do. So the dispatch
alone would leave the auto-PR still *looking* unchecked. The tld-refresh flow
therefore also resolves each dispatched run's URL and posts a PR comment
linking both runs; that comment is how a maintainer finds and gates on the CI.

Mechanism per workflow:

- `tld-refresh.yml`, after the force-push, in this order:
  1. Create the PR (or detect the existing one) **first** — the PR is the
     primary side effect, so a transient dispatch failure cannot leave a
     pushed branch with no PR until the next weekly run.
  2. `gh workflow run test.yml --ref "$BRANCH"` and
     `gh workflow run ui-tests.yml --ref "$BRANCH" -f tier=render -f scope=impacted`.
     `--ref` requires a branch/tag (a bare SHA is rejected with HTTP 422 "No
     ref found" — verified), so the runs are pinned to the pushed head SHA at
     resolution time instead. On `scope=impacted`: the `-k` derivation
     considers changed **test** files only; a src-only data change yields an
     empty derivation and `resolve-legs.sh` falls back to the whole
     `ui_render` tier on the min-CE leg — the intended gate.
  3. Resolve both dispatched runs' URLs (bounded poll: 6 tries x 5 s,
     matching on the pushed head SHA; a loud `::warning` + Actions-tab
     pointer if resolution fails) and post one PR comment linking them.
- `module-durations.yml`, right after the push to `devel` succeeds:
  `gh workflow run test.yml --ref devel` (no PR exists there; the run is
  visible in the Actions tab and a failure notifies normally).

Both call sites needed `actions: write` in their job/workflow `permissions:`
(workflow-dispatch requires it; `write` implies the `read` that
`module-durations.yml`'s `download-artifact` already needed). All dispatch
calls sit inside `set -eu` scripts with no `|| true`, so a failed dispatch
fails the job loudly instead of silently no-opping.

Contract text updated to describe the actual mechanism: `tld-refresh.yml`'s
header comment, its `dry_run` input description (dry-run validates the IANA
diff only — the push/PR/dispatch/comment path runs only on a real run), its
generated PR body, and `docs/misc/tld-lists.md`.

## Validation

Workflow YAML has no unit harness in this repo, so validation is the usual
lint/parse path:

- `actionlint` on both changed workflows — clean except one pre-existing
  SC2086 finding in `module-durations.yml` (present identically on
  `origin/devel`, in a line this PR does not touch).
- `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))"` on both
  changed files — parses clean; additionally every `run:` block of both
  workflows was extracted and passed `sh -n` (POSIX syntax check).
- `gh workflow run --help` checked against the flags used (`--ref`, `-f`) —
  match; `--ref <sha>` empirically rejected (HTTP 422), confirming the
  branch-ref + SHA-pinned-resolution design.
- `npx markdownlint-cli2` on the touched doc — 0 errors.
- `python -m pytest` — 2213 passed, 4 skipped (unrelated; confirms nothing in
  the Python suite regressed).

Both workflows get their first end-to-end exercise on the next scheduled run
(tld-refresh weekly, module-durations after the next nightly smoke fan-out),
per repo practice for workflow-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)