### PR TITLE
ci: pass scope=full to the labeled ui-suite gate; drop the dead workflow_call rung (#906)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,6 +376,10 @@ jobs:
     uses: ./.github/workflows/ui-tests.yml
     with:
       tier: all
+      # Explicit (issue #906): a workflow_call callee sees the CALLER's event,
+      # so without this the scope ladder resolves `impacted` — min-CE leg only —
+      # not the full pre-release fan-out this job exists for.
+      scope: full
     secrets: inherit
 
   # ── 1c. Read version matrix ──────────────────────────────────────────────

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -90,12 +90,13 @@ on:
         description: "Number of parallel module shards per leg — CE and Plus alike (issues #797/#856) — for full-marker, un-filtered runs. Collapses to 1 when pytest_filter is set or pytest_marker != smoke. Clamped to the leg's test-module count."
         required: false
         default: "3"
-  # Called by other workflows. Defaults to the FULL suite so existing callers
-  # that pass nothing are unchanged (workflow_call -> scope=full by default).
+  # Called by other workflows. A callee sees the CALLER's event_name, so scope
+  # never auto-resolves to full here (issue #906): blank = impacted; a caller
+  # that wants the full suite passes scope=full explicitly.
   workflow_call:
     inputs:
       scope:
-        description: "impacted | full. Blank on a call = full (preserve existing callers)."
+        description: "impacted | full. Blank on a call = impacted (issue #906); pass full explicitly for the whole fan-out."
         required: false
         type: string
         default: ""
@@ -153,9 +154,11 @@ jobs:
 
       # Resolve the run scope, the leg set, and the effective -k. Default for a
       # bare DISPATCH is `impacted` (min CE leg + only the tests changed vs
-      # origin/devel); schedule and workflow_call default to `full` (every ci:true
-      # leg, whole marker) so the nightly run, the post-version-bump dispatch
-      # (version-tracker passes scope=full), and any caller stay unchanged.
+      # origin/devel); schedule resolves `full` (every ci:true leg, whole
+      # marker). A workflow_call caller gets NO special default (issue #906 —
+      # the callee sees the caller's event): the nightly schedule and the
+      # post-version-bump dispatch (version-tracker passes scope=full) stay
+      # full; any other caller passes scope explicitly.
       - name: Resolve scope, legs, and -k
         id: filter
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -546,6 +546,11 @@ jobs:
     uses: ./.github/workflows/ui-tests.yml
     with:
       tier: all
+      # Explicit on purpose (issue #906): a reusable-workflow callee sees the
+      # CALLER's event (pull_request here), so without this the scope ladder
+      # resolved `impacted` — min-CE leg + changed-UI-modules only — silently
+      # shrinking the labeled gate. The label opts into the FULL fan-out.
+      scope: full
     secrets: inherit
 
   # Single stable job name for branch-protection required-status-checks.

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -82,7 +82,7 @@ on:
         type: string
         default: "all"
       scope:
-        description: "impacted | full. Blank on a call = full (preserve existing callers like test.yml/release.yml)."
+        description: "impacted | full. Blank on a call = impacted (issue #906 — the callee sees the caller's event); test.yml/release.yml pass full explicitly."
         required: false
         type: string
         default: ""

--- a/scripts/resolve-legs.sh
+++ b/scripts/resolve-legs.sh
@@ -75,14 +75,16 @@ _rl_legs() {
     done
 
     # ── SCOPE ladder ───────────────────────────────────────────────────────── #
-    # schedule → full; explicit SCOPE_INPUT wins; workflow_call → full;
-    # bare dispatch → impacted (the new lean default).
+    # schedule → full; explicit SCOPE_INPUT wins; anything else → impacted (the
+    # lean default). Deliberately NO workflow_call rung: inside a reusable-
+    # workflow callee `github.event_name` is always the CALLER's event (never
+    # "workflow_call"), so such a rung is unreachable — a workflow_call gate
+    # that wants the full fan-out must pass `scope: full` explicitly
+    # (issue #906; test.yml's ui-suite does).
     if [ "${EVENT_NAME:-}" = "schedule" ]; then
         SCOPE="full"
     elif [ -n "${SCOPE_INPUT:-}" ]; then
         SCOPE="$SCOPE_INPUT"
-    elif [ "${EVENT_NAME:-}" = "workflow_call" ]; then
-        SCOPE="full"
     else
         SCOPE="impacted"
     fi

--- a/tests/shell/resolve_legs_spec.sh
+++ b/tests/shell/resolve_legs_spec.sh
@@ -58,14 +58,19 @@ Describe 'resolve-legs.sh legs — scope + leg selection'
         The error should include 'scope='
     End
 
-    It 'workflow_call → full scope → all 3 legs'
+    It 'EVENT_NAME=workflow_call without SCOPE_INPUT → impacted (no special rung)'
+        # A reusable-workflow callee sees the CALLER's event_name, never
+        # "workflow_call", so a dedicated rung could never fire in CI. Pin the
+        # fallthrough: without an explicit SCOPE_INPUT this resolves like any
+        # other event — impacted, min-CE leg only. A workflow_call gate that
+        # wants the full fan-out passes scope=full explicitly (issue #906).
         When run env \
             CI_MATRIX="$FIXTURE_MATRIX" \
             EVENT_NAME="workflow_call" \
             sh "$SCRIPT" legs --test-dir tests/smoke --label marker
         The status should be success
         The output should include '"pfsense_version":"2.8"'
-        The output should include '"pfsense_version":"26.03"'
+        The output should not include '"pfsense_version":"26.03"'
         The error should include 'scope='
     End
 

--- a/tests/shell/resolve_legs_spec.sh
+++ b/tests/shell/resolve_legs_spec.sh
@@ -70,6 +70,7 @@ Describe 'resolve-legs.sh legs — scope + leg selection'
             sh "$SCRIPT" legs --test-dir tests/smoke --label marker
         The status should be success
         The output should include '"pfsense_version":"2.8"'
+        The output should not include '"pfsense_version":"2.10"'
         The output should not include '"pfsense_version":"26.03"'
         The error should include 'scope='
     End


### PR DESCRIPTION
## What

`scripts/resolve-legs.sh`'s scope ladder had a `workflow_call → full` rung that can never fire: inside a reusable-workflow callee, `github.event_name` is always the **caller's** event, never `workflow_call`. Consequence: the `ui-tests`-labeled per-PR gate (`test.yml`'s `ui-suite`, which passes only `tier: all`) resolved `EVENT_NAME=pull_request` → scope=**impacted** — min-CE leg + changed-UI-modules `-k` only — silently shrinking the gate the label promises. A UI regression in an unchanged module, or on the Plus leg, passed the labeled gate.

## Fix

- `test.yml` `ui-suite` now passes `scope: full` explicitly (with a comment explaining why it must be explicit).
- The unreachable `workflow_call` rung in `resolve-legs.sh` is deleted; the ladder comment documents the contract (workflow_call gates pass scope explicitly).
- The shellspec case that pinned the dead rung now pins the real fallthrough: `EVENT_NAME=workflow_call` with no `SCOPE_INPUT` resolves impacted (min-CE leg only).

## Red-before-green evidence

The rewritten spec case run against the pre-fix script: `resolve_legs_spec.sh:61 … FAILED` (old code resolved full → the Plus leg appeared). With the fix: `31 examples, 0 failures` for the file; full shellspec suite `376 examples, 0 failures, 8 skips` (pre-existing environment skips). `shellcheck` + `sh -n` clean; `test.yml` YAML parses clean.

`version-tracker` is unaffected (already passes `scope=full` explicitly); `release.yml`'s ui-suite is `if: false`.

Fixes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)