### PR TITLE
scripts: stabilise TLD refinement — xn-- stays iTLD, gate implausible tlds.json

### DIFF
--- a/scripts/misc/update_tld_lists.py
+++ b/scripts/misc/update_tld_lists.py
@@ -66,6 +66,13 @@ TLDS_JSON_URL = "https://data.iana.org/TLD/tlds.json"
 # discards every curated label). Refuse below this floor instead.
 MIN_PLAUSIBLE_TLDS = 1000
 
+# Plausibility floor for tlds.json's OPTIONAL type map (ccTLD refinement only, see
+# fetch_tlds_json). Set well under the real population (~1,450 TLDs) but far above
+# a garbage response that still happens to be valid JSON (a captive-portal/proxy
+# page, a truncated body with a handful of records) -- below this floor the
+# refinement is skipped exactly like a fetch failure, never partially applied.
+MIN_PLAUSIBLE_TLD_TYPES = 500
+
 DEFAULT_PHP_FILE = Path(__file__).resolve().parent.parent.parent / "src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php"
 
 _TLD_KEYS = ("gTLD", "ccTLD", "iTLD")
@@ -96,17 +103,35 @@ def require_plausible(iana_tlds: set[str]) -> None:
         )
 
 
+def plausible_tld_types(iana_types: dict[str, str]) -> bool:
+    """True iff tlds.json's OPTIONAL tld->type map is large enough to trust.
+
+    Mirrors require_plausible's floor, but for the best-effort refinement source:
+    unlike the required tlds-alpha fetch (which must hard-refuse below its floor),
+    a too-small tlds.json is simply discarded by the caller -- proceeding exactly
+    as on a fetch failure -- since classification never depends on it.
+    """
+    return len(iana_types) >= MIN_PLAUSIBLE_TLD_TYPES
+
+
 def classify(tld: str, iana_types: dict[str, str] | None = None) -> str:
     """Classify a lowercase TLD into 'iTLD' / 'ccTLD' / 'gTLD'.
 
     The heuristic (punycode -> iTLD, two ASCII letters -> ccTLD, else gTLD) is
     correct standalone. When tlds.json's type map is available, a 'country-code'
     entry is honored as ccTLD too -- pure refinement, never required.
+
+    xn-- is checked BEFORE the type map, unconditionally: the committed arrays
+    keep every xn-- TLD (including IDN ccTLDs) in iTLD, curated with a '(cc)'
+    marker in the label rather than a bucket move. Checking type first would make
+    an IDN ccTLD's bucket flip with whatever tlds.json happens to report on a
+    given run -- and since label retention is keyed by tld, not bucket, a flip
+    also silently replaces the curated '(cc) ...' label with a bare uppercase one.
     """
-    if iana_types and iana_types.get(tld) == "country-code":
-        return "ccTLD"
     if tld.startswith("xn--"):
         return "iTLD"
+    if iana_types and iana_types.get(tld) == "country-code":
+        return "ccTLD"
     if len(tld) == 2 and tld.isalpha():
         return "ccTLD"
     return "gTLD"
@@ -150,11 +175,18 @@ def build_fresh_arrays(
         buckets[classify(tld, iana_types)].add(tld)
     buckets["gTLD"] -= bgtld_keys
 
+    # Label lookup spans ALL regenerated buckets, not just the target one: a TLD
+    # that legitimately moves bucket (e.g. IANA re-typing a plain gTLD as a ccTLD)
+    # must still keep its curated label rather than falling back to a bare
+    # uppercase one just because the label lived in its old bucket.
+    existing_by_tld: dict[str, str] = {}
+    for key in _TLD_KEYS:
+        existing_by_tld.update(existing.get(key, {}))
+
     fresh: dict[str, dict[str, str]] = {}
     for key, tlds in buckets.items():
-        existing_labels = existing.get(key, {})
         fresh[key] = {
-            tld: strip_count(existing_labels[tld]) if tld in existing_labels else tld.upper() for tld in sorted(tlds)
+            tld: strip_count(existing_by_tld[tld]) if tld in existing_by_tld else tld.upper() for tld in sorted(tlds)
         }
     return fresh
 
@@ -191,8 +223,10 @@ def fetch_tlds_json(timeout: float = 15) -> dict[str, str] | None:
     """Best-effort fetch of tlds.json's tld->type map (ccTLD refinement only).
 
     Returns None on ANY problem -- unreachable, empty body (observed in some
-    sandboxed environments), or an unexpected schema. Classification never
-    depends on this succeeding.
+    sandboxed environments), an unexpected schema, or a body that parses fine but
+    is implausibly small (below MIN_PLAUSIBLE_TLD_TYPES; logged as a warning and
+    treated exactly like a fetch failure). Classification never depends on this
+    succeeding.
     """
     try:
         with urllib.request.urlopen(TLDS_JSON_URL, timeout=timeout) as resp:  # noqa: S310
@@ -201,9 +235,17 @@ def fetch_tlds_json(timeout: float = 15) -> dict[str, str] | None:
             return None
         data = json.loads(raw)
         records = data["tlds"] if isinstance(data, dict) else data
-        return {rec["tld"].lower(): rec.get("type", "") for rec in records}
+        result = {rec["tld"].lower(): rec.get("type", "") for rec in records}
     except Exception:
         return None
+    if not plausible_tld_types(result):
+        print(
+            f"warning: tlds.json refinement skipped -- only {len(result)} entries "
+            f"(< {MIN_PLAUSIBLE_TLD_TYPES}); proceeding as if the fetch had failed.",
+            file=sys.stderr,
+        )
+        return None
+    return result
 
 
 # ── CLI ─────────────────────────────────────────────────────────────────────

--- a/scripts/misc/update_tld_lists.py
+++ b/scripts/misc/update_tld_lists.py
@@ -119,7 +119,11 @@ def classify(tld: str, iana_types: dict[str, str] | None = None) -> str:
 
     The heuristic (punycode -> iTLD, two ASCII letters -> ccTLD, else gTLD) is
     correct standalone. When tlds.json's type map is available, a 'country-code'
-    entry is honored as ccTLD too -- pure refinement, never required.
+    entry is honored as ccTLD too -- pure refinement, never required. For real
+    IANA data the refinement is effectively a no-op: every real ccTLD is either
+    exactly two ASCII letters or an xn-- A-label, and both forms are already
+    classified without the type map. Kept as a defensive fallback for a
+    hypothetical future TLD form, not because any current input needs it.
 
     xn-- is checked BEFORE the type map, unconditionally: the committed arrays
     keep every xn-- TLD (including IDN ccTLDs) in iTLD, curated with a '(cc)'

--- a/tests/test_update_tld_lists.py
+++ b/tests/test_update_tld_lists.py
@@ -280,8 +280,10 @@ def test_fresh_xn_dash_dash_stays_itld_with_curated_label_despite_country_code_t
 
 def test_fresh_non_xn_bucket_move_preserves_curated_label_across_buckets() -> None:
     # Given: 'com' is curated in the existing gTLD array with a feed-star label
-    # ('COM*'), but tlds.json types it as a ccTLD ('country-code') -- a genuine,
-    # non-xn-- bucket move (unlike xn--, classify() honors the type map here).
+    # ('COM*'), but tlds.json types it as a ccTLD ('country-code') -- a
+    # hypothetical bucket move (no real gTLD is typed country-code by IANA;
+    # this exercises existing_by_tld's cross-bucket generality, defence in
+    # depth for the unreachable-in-production branch classify() keeps).
     existing = utl.parse_existing_arrays(_FAKE_EXISTING_PHP)
     # When: the fresh arrays are built with that type map.
     fresh = utl.build_fresh_arrays(_FAKE_IANA_TLDS, existing, iana_types={"com": "country-code"})

--- a/tests/test_update_tld_lists.py
+++ b/tests/test_update_tld_lists.py
@@ -249,3 +249,57 @@ def test_require_plausible_rejects_an_implausibly_small_fetch() -> None:
 def test_require_plausible_accepts_a_full_root_zone() -> None:
     # A realistic root-zone-sized set passes the floor unchanged (no exception).
     utl.require_plausible({f"tld{i}" for i in range(utl.MIN_PLAUSIBLE_TLDS)})
+
+
+# --------------------------------------------------------------------------- #
+# Regression coverage for issue #903: tlds.json's optional country-code typing
+# must never destabilize the xn-- bucket or destroy a curated label, and an
+# implausibly small tlds.json body must be treated exactly like a fetch failure.
+# --------------------------------------------------------------------------- #
+
+
+def test_fresh_xn_dash_dash_stays_itld_with_curated_label_despite_country_code_type() -> None:
+    # Given: tlds.json types 'xn--abc' as a ccTLD ('country-code'), matching what
+    # the real endpoint does for IDN ccTLDs (e.g. 'xn--1qqw23a'), but the existing
+    # array curates it in iTLD with a native-script label -- that '(cc)'-style
+    # curation is how we record country-code-ness for xn-- entries, not a bucket.
+    existing = utl.parse_existing_arrays(_FAKE_EXISTING_PHP)
+    # When: the fresh arrays are built with that type map.
+    fresh = utl.build_fresh_arrays(_FAKE_IANA_TLDS, existing, iana_types={"xn--abc": "country-code"})
+    # Then: it STAYS in iTLD with its curated label intact, never migrating to
+    # ccTLD. FAILS on pre-#903 code: classify() honored 'country-code' before the
+    # xn-- check, moving 'xn--abc' to ccTLD -- and because label retention was
+    # per-bucket, the curated label was lost too (ccTLD's existing map has no
+    # 'xn--abc' entry, so it fell back to a bare 'XN--ABC'). Verified by stashing
+    # the #903 source fix and re-running: this assertion failed with
+    # `assert {} == {'xn--abc': 'XN--ABC - foo'}` (fresh["iTLD"] was empty --
+    # 'xn--abc' had migrated to ccTLD with the label reduced to 'XN--ABC').
+    assert fresh["iTLD"] == {"xn--abc": "XN--ABC - foo"}
+    assert "xn--abc" not in fresh["ccTLD"]
+
+
+def test_fresh_non_xn_bucket_move_preserves_curated_label_across_buckets() -> None:
+    # Given: 'com' is curated in the existing gTLD array with a feed-star label
+    # ('COM*'), but tlds.json types it as a ccTLD ('country-code') -- a genuine,
+    # non-xn-- bucket move (unlike xn--, classify() honors the type map here).
+    existing = utl.parse_existing_arrays(_FAKE_EXISTING_PHP)
+    # When: the fresh arrays are built with that type map.
+    fresh = utl.build_fresh_arrays(_FAKE_IANA_TLDS, existing, iana_types={"com": "country-code"})
+    # Then: 'com' moves to ccTLD AND keeps its curated star marker -- label
+    # lookup spans every regenerated bucket, not just the TLD's old (gTLD) one.
+    assert "com" not in fresh["gTLD"]
+    assert fresh["ccTLD"]["com"] == "COM*"
+
+
+def test_plausible_tld_types_rejects_an_implausibly_small_type_map() -> None:
+    # A tiny-but-valid tlds.json body (an empty object, or a captive-portal/proxy
+    # page that happens to parse as JSON with a handful of entries) must not be
+    # honored -- the caller (fetch_tlds_json) treats this exactly like a fetch
+    # failure, discarding the map rather than partially applying it.
+    assert utl.plausible_tld_types({}) is False
+    assert utl.plausible_tld_types({f"tld{i}": "generic" for i in range(utl.MIN_PLAUSIBLE_TLD_TYPES - 1)}) is False
+
+
+def test_plausible_tld_types_accepts_a_realistic_type_map() -> None:
+    # The other side of the same boundary: a root-zone-sized type map is trusted.
+    assert utl.plausible_tld_types({f"tld{i}": "generic" for i in range(utl.MIN_PLAUSIBLE_TLD_TYPES)}) is True


### PR DESCRIPTION
## Summary

`scripts/misc/update_tld_lists.py`'s optional `tlds.json` refinement (added in #880) had two coupled defects. Both are latent today because `https://data.iana.org/TLD/tlds.json` currently returns HTTP 200 with a 1-byte body, so `json.loads` fails and the refinement path never runs. The day the endpoint returns real data, these would activate together:

1. **`classify()` honored `tlds.json`'s `type == "country-code"` before the `xn--` check.** All 151 `xn--` TLDs in the committed arrays live in the `iTLD` bucket today, including IDN ccTLDs curated with a `(cc)` marker in the label (e.g. `'xn--1qqw23a' => '(cc) XN--1QQW23A - 佛山'`) — `ccTLD` has zero `xn--` entries. Once `tlds.json` starts reporting real types, every IDN ccTLD would migrate `iTLD → ccTLD`.
2. **Label retention in `build_fresh_arrays` was per-bucket.** A TLD moving buckets lost its curated label and got a bare uppercase one regenerated in its place (`XN--1QQW23A`).

Combined, this produces a flip-flop: IDN ccTLDs migrate and lose their curated labels the day the endpoint recovers, then flip back (regaining the label, since the endpoint fails again) on the next run — a recurring diff that would auto-PR weekly.

## Fix

- **`classify()`**: check `xn--` first, unconditionally. An `xn--` TLD never leaves `iTLD` regardless of what `tlds.json` reports — the `(cc)` marker inside the curated label is how country-code-ness is recorded for these entries, not a bucket move.
- **`build_fresh_arrays()`**: label lookup now spans every regenerated bucket (`gTLD`/`ccTLD`/`iTLD`), not just the TLD's target bucket, so a *genuine* (non-`xn--`) bucket move still keeps the curated label instead of falling back to a bare uppercase one.
- **`fetch_tlds_json()`**: added a plausibility floor (`MIN_PLAUSIBLE_TLD_TYPES = 500`, well under the real ~1,450-TLD population but far above a garbage response) on the *parsed* type map — separate from the existing floor on the required `tlds-alpha` fetch. A body that parses fine but is implausibly small (e.g. a captive-portal/proxy page that happens to be valid JSON) is logged as a warning and discarded exactly like a fetch failure, never partially applied.

## Tests

Extended `tests/test_update_tld_lists.py` (no network — same fixture style as the rest of the suite):

- `test_fresh_xn_dash_dash_stays_itld_with_curated_label_despite_country_code_type` — feeds a `tlds.json` type map that types an `xn--` TLD as `country-code`, asserts it stays in `iTLD` with its curated label intact. **Confirmed red against pre-fix code**: stashing the source fix and re-running produced `assert {} == {'xn--abc': 'XN--ABC - foo'}` (the entry had migrated to `ccTLD` with its label reduced to `XN--ABC`).
- `test_fresh_non_xn_bucket_move_preserves_curated_label_across_buckets` — a genuine (non-`xn--`) bucket move via the type map still keeps the curated label (`'COM*'`, not a regenerated `'COM'`). **Confirmed red against pre-fix code**: `assert 'COM' == 'COM*'`.
- `test_plausible_tld_types_rejects_an_implausibly_small_type_map` / `test_plausible_tld_types_accepts_a_realistic_type_map` — both sides of the `MIN_PLAUSIBLE_TLD_TYPES` boundary.

## Test plan

- [x] `python -m pytest` — 2217 passed, 4 skipped
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy tests/` — clean

Fixes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLD updates so small or suspicious type maps are ignored instead of partially applied.
  * Ensured punycode entries are classified correctly before refinement checks.
  * Preserved curated labels when TLDs move between categories, so existing naming is not lost during updates.

* **Tests**
  * Added regression coverage for TLD reclassification, label retention, and validation of trusted type-map sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->