### PR TITLE
pfblockerng: make corrupt stats-DB recovery reachable — validate-False is the corrupt case (#900)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2430,9 +2430,12 @@ def _validate_db_with_recovery(db: int) -> bool:
     # Issue #900: pfb_db_validate -> _db_run swallows every connect/PRAGMA fault
     # (a corrupt file included) and returns False -- it never raises, so the
     # try/except recovery this replaces was dead code and a corrupt DB was never
-    # healed. Treat a False validate as the corrupt/broken-DB case: delete the
-    # file (tolerating a removal fault -- e.g. a read-only dir) and revalidate
-    # once -- no infinite retry.
+    # healed. Treat a False validate as the broken-DB case (usually corruption;
+    # disk-full/read-only faults also land here -- acceptable for a stats-only
+    # DB): delete the file plus its WAL/SHM sidecars (the DBs run journal_mode=
+    # WAL, so a stale -wal/-shm surviving next to a recreated main file must not
+    # linger; each remove tolerates a fault, e.g. a read-only dir) and
+    # revalidate once -- no infinite retry.
     #
     # The whole validate -> remove -> revalidate sequence holds _db_recovery_lock:
     # without it, two threads recovering the same corrupt DB can both validate
@@ -2446,10 +2449,12 @@ def _validate_db_with_recovery(db: int) -> bool:
     with _db_recovery_lock:
         if pfb_db_validate(db):
             return True
-        try:
-            os.remove(_db_file(db))
-        except OSError:
-            pass  # already gone, or unremovable; the revalidate below reports if still broken
+        base = _db_file(db)
+        for stale in (base, base + "-wal", base + "-shm"):
+            try:
+                os.remove(stale)
+            except OSError:
+                pass  # already gone, or unremovable; the revalidate below reports if still broken
         return pfb_db_validate(db)
 
 

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1532,41 +1532,24 @@ def init_standard(id: int, env: module_env) -> bool:
             # accurate even with feed regex but no user regex.
             dnsbl_emit_count(pfb["pfb_py_regex_count"], len(regexDB) + len(allowRegexDB))
 
-            # Validate SQLite3 database connections
+            # Validate SQLite3 database connections. A False validate (issue #900)
+            # is the corrupt/broken-DB case -- _validate_db_with_recovery deletes
+            # the file and retries once; still False just leaves the flag off (no
+            # crash, no infinite retry) and is logged loudly.
             if pfb["mod_sqlite3"]:
                 # Enable Resolver query statistics
-                for i in range(2):
-                    try:
-                        if pfb_db_validate(1):
-                            pfb["sqlite3_resolver_con"] = True
-                            break
-                    except Exception as e:
-                        sys.stderr.write(
-                            "[pfBlockerNG]: Failed to open pfb_py_resolver.sqlite database (Attempt: {}/2): {}".format(
-                                i + 1, e
-                            )
-                        )
-                        pass
-                        if os.path.isfile(pfb["pfb_py_resolver"]):
-                            os.remove(pfb["pfb_py_resolver"])
+                if _validate_db_with_recovery(DB_RESOLVER):
+                    pfb["sqlite3_resolver_con"] = True
+                else:
+                    sys.stderr.write("[pfBlockerNG]: Failed to open pfb_py_resolver.sqlite database\n")
 
                 # Enable DNSBL statistics -- forwarding-gated too, not just
                 # blacklist-gated (issue #860; see _dnsbl_stats_wanted).
                 if _dnsbl_stats_wanted():
-                    for i in range(2):
-                        try:
-                            if pfb_db_validate(2):
-                                pfb["sqlite3_dnsbl_con"] = True
-                                break
-                        except Exception as e:
-                            sys.stderr.write(
-                                "[pfBlockerNG]: Failed to open pfb_py_dnsbl.sqlite database (Attempt: {}/2): {}".format(
-                                    i + 1, e
-                                )
-                            )
-                            pass
-                            if os.path.isfile(pfb["pfb_py_dnsbl"]):
-                                os.remove(pfb["pfb_py_dnsbl"])
+                    if _validate_db_with_recovery(DB_DNSBL):
+                        pfb["sqlite3_dnsbl_con"] = True
+                    else:
+                        sys.stderr.write("[pfBlockerNG]: Failed to open pfb_py_dnsbl.sqlite database\n")
 
             # Open MaxMind db reader for DNS Reply GeoIP logging
             if pfb["mod_maxminddb"] and pfb["python_reply"] and os.path.isfile(pfb["maxminddb"]):
@@ -2253,6 +2236,14 @@ def is_unknown(x: Any) -> Any:
 # check_same_thread=False so the DB worker and the synchronous fallback (init,
 # tests) can share them safely under the lock.
 _db_lock: Any = threading.Lock() if pfb.get("mod_threading") else nullcontext()
+# Issue #900: serializes corrupt-DB recovery -- _validate_db_with_recovery's whole
+# validate -> remove -> revalidate sequence must be atomic across its caller threads
+# (init, the ADR-10 swap watcher, the control-channel enable / timed re-enable), or a
+# losing racer can delete the winner's freshly rebuilt LIVE DB file. Lock ordering:
+# _db_recovery_lock -> _db_lock only (_db_lock is a plain lock acquired solely inside
+# _db_run, which pfb_db_validate calls under this lock); no path acquires
+# _db_recovery_lock while holding _db_lock, so the ordering never inverts -- no deadlock.
+_db_recovery_lock: Any = threading.Lock() if pfb.get("mod_threading") else nullcontext()
 _db_conns: dict[int, Any] = {}
 
 PFB_DB_QUEUE_MAXSIZE = 5000
@@ -2435,6 +2426,33 @@ def pfb_db_validate(db: int) -> bool:
     return _db_run(db, lambda con: None)
 
 
+def _validate_db_with_recovery(db: int) -> bool:
+    # Issue #900: pfb_db_validate -> _db_run swallows every connect/PRAGMA fault
+    # (a corrupt file included) and returns False -- it never raises, so the
+    # try/except recovery this replaces was dead code and a corrupt DB was never
+    # healed. Treat a False validate as the corrupt/broken-DB case: delete the
+    # file (tolerating a removal fault -- e.g. a read-only dir) and revalidate
+    # once -- no infinite retry.
+    #
+    # The whole validate -> remove -> revalidate sequence holds _db_recovery_lock:
+    # without it, two threads recovering the same corrupt DB can both validate
+    # False, and the loser's remove then deletes the winner's freshly rebuilt LIVE
+    # file while the cached connection in _db_conns keeps writing to the unlinked
+    # inode -- counters silently lost again. The first validate inside the lock
+    # doubles as the loser's recheck: it succeeds via the winner's cached
+    # connection and returns without a second delete. Lock ordering stays
+    # _db_recovery_lock -> _db_lock (via pfb_db_validate -> _db_run); see the
+    # _db_recovery_lock definition.
+    with _db_recovery_lock:
+        if pfb_db_validate(db):
+            return True
+        try:
+            os.remove(_db_file(db))
+        except OSError:
+            pass  # already gone, or unremovable; the revalidate below reports if still broken
+        return pfb_db_validate(db)
+
+
 def _dnsbl_stats_wanted() -> bool:
     # Issue #860: the Upstream counter (issue #267 forwarding-mode detection) shares
     # the dnsbl stats DB with per-feed blocks. Detection itself is forwarding-gated
@@ -2456,29 +2474,17 @@ def _open_dnsbl_stats_db_if_wanted() -> None:
     # stay consistent; else _db_flush_dnsbl and _log_upstream_block (both gated on
     # sqlite3_dnsbl_con) silently drop every counter until the next full restart.
     #
-    # Idempotent (the not-sqlite3_dnsbl_con guard no-ops when init already opened it) and
-    # off the DNS fast path: pfb_db_validate -> _db_run is _db_lock-serialized with a
-    # check_same_thread=False connection, safe on the watcher / control-sleep threads.
-    # Same mod_sqlite3 gate + two-attempt retry shape as init_standard's "Enable DNSBL
-    # statistics" block.
+    # Idempotent (the not-sqlite3_dnsbl_con guard no-ops when init already opened it).
+    # NOT off the DNS fast path under the legacy control transport: pfb_apply_control_command
+    # is reachable from operate() (the python_control_legacy branch), so this can run on an
+    # Unbound query worker, not just the watcher / control-sleep threads. Issue #900: a
+    # corrupt DB is recovered (delete + one revalidate) by _validate_db_with_recovery, shared
+    # with init_standard's identical "Enable DNSBL statistics" gate.
     if pfb["mod_sqlite3"] and not pfb["sqlite3_dnsbl_con"] and _dnsbl_stats_wanted():
-        for i in range(2):
-            try:
-                if pfb_db_validate(DB_DNSBL):
-                    pfb["sqlite3_dnsbl_con"] = True
-                    break
-            except Exception as e:
-                sys.stderr.write(
-                    "[pfBlockerNG]: Failed to open pfb_py_dnsbl.sqlite database (Attempt: {}/2): {}".format(i + 1, e)
-                )
-                # Now reachable from three threads (swap, control-enable, timed re-enable):
-                # a concurrent caller may have already removed the corrupt DB, so a losing
-                # race on the delete is a harmless no-op, not an uncaught FileNotFoundError.
-                if os.path.isfile(pfb["pfb_py_dnsbl"]):
-                    try:
-                        os.remove(pfb["pfb_py_dnsbl"])
-                    except OSError:
-                        pass
+        if _validate_db_with_recovery(DB_DNSBL):
+            pfb["sqlite3_dnsbl_con"] = True
+        else:
+            sys.stderr.write("[pfBlockerNG]: Failed to open pfb_py_dnsbl.sqlite database after recovery attempt\n")
 
 
 def _db_apply(task: tuple) -> None:

--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -290,6 +290,13 @@ class TestCorruptDnsblStatsDbRecovery:
         monkeypatch.setattr(P.time, "sleep", lambda *_a, **_k: None)
         db = tmp_path / "dnsbl.sqlite"
         db.write_bytes(b"not a sqlite database")  # garbage bytes -> genuinely corrupt
+        # Stale WAL/SHM sidecars beside the corrupt main file (the DBs run
+        # journal_mode=WAL): recovery must sweep these too, or they linger next
+        # to the freshly recreated main file (#900 review).
+        wal = tmp_path / "dnsbl.sqlite-wal"
+        shm = tmp_path / "dnsbl.sqlite-shm"
+        wal.write_bytes(b"stale wal")
+        shm.write_bytes(b"stale shm")
         P.pfb["mod_sqlite3"] = True
         P.pfb["pfb_py_dnsbl"] = str(db)
         P.pfb["python_blacklist"] = True  # stats wanted -> the open path runs
@@ -307,6 +314,18 @@ class TestCorruptDnsblStatsDbRecovery:
         # ---- AFTER: the corrupt file was deleted+rebuilt, the retry connected, flag True.
         assert P.pfb["sqlite3_dnsbl_con"] is True, "recovery must delete + revalidate a corrupt DB (issue #900)"
         assert P.DB_DNSBL in P._db_conns
+        # Pinned invariant (behaviour-preserving, not red->green): the planted
+        # stale sidecar bytes never survive recovery. sqlite itself resets a
+        # salt-mismatched WAL pair on the fresh connect, and recovery now also
+        # sweeps them explicitly (#900 review) so the guarantee does not hinge
+        # on sqlite version behaviour. A fresh WAL pair for the recreated DB
+        # may exist -- only the planted bytes must be gone.
+        assert not wal.exists() or wal.read_bytes() != b"stale wal", (
+            f"stale -wal sidecar survived recovery: {wal.read_bytes()[:20]!r}"
+        )
+        assert not shm.exists() or shm.read_bytes() != b"stale shm", (
+            f"stale -shm sidecar survived recovery: {shm.read_bytes()[:20]!r}"
+        )
 
         # ---- and a counter flush actually lands on the recovered DB.
         assert P._db_flush_dnsbl({"Upstream": 1})
@@ -417,11 +436,11 @@ class TestCorruptDnsblStatsDbRecovery:
             finally:
                 t2_progressed.set()  # pre-fix path: T2 ran straight through and returned
 
-        t1 = threading.Thread(target=t1_run)
+        t1 = threading.Thread(target=t1_run, daemon=True)
         t1.start()
         assert t1_parked.wait(5), "loud timeout: T1 never reached its recovery delete"
 
-        t2 = threading.Thread(target=t2_run)
+        t2 = threading.Thread(target=t2_run, daemon=True)
         t2.start()
         assert t2_progressed.wait(5), "loud timeout: T2 neither blocked on the recovery lock nor completed"
 
@@ -431,10 +450,12 @@ class TestCorruptDnsblStatsDbRecovery:
         assert not t1.is_alive() and not t2.is_alive(), "loud timeout: recovery threads did not finish"
         assert not errors, f"a recovery thread raised: {errors!r}"
 
-        # Then: exactly ONE delete happened -- the loser revalidated instead of deleting
-        # the winner's rebuilt DB.
-        assert len(remove_calls) == 1, (
-            f"racing recovery must delete the corrupt DB exactly once, got {len(remove_calls)}: {remove_calls!r}"
+        # Then: exactly ONE recovery ran -- the loser revalidated instead of deleting
+        # the winner's rebuilt DB. Recovery sweeps the WAL/SHM sidecars alongside the
+        # main file (#900 review), so count MAIN-file removes: one recovery = one.
+        main_removes = [c for c in remove_calls if c == str(db)]
+        assert len(main_removes) == 1, (
+            f"racing recovery must delete the corrupt DB exactly once, got {len(main_removes)}: {remove_calls!r}"
         )
         assert P.pfb["sqlite3_dnsbl_con"] is True
 

--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -22,6 +22,7 @@ is gated on ``pfb["mod_threading"]`` and only a test that explicitly starts it r
 
 from __future__ import annotations
 
+import sqlite3
 import threading
 import time
 from typing import Any
@@ -222,36 +223,231 @@ class TestControlEnableOpensDnsblStatsDb:
     def test_open_helper_survives_a_losing_race_on_corrupt_db_delete(self, tmp_path: Any, monkeypatch: Any) -> None:
         """Concurrency guard: the shared open helper now runs from three threads (the
         ADR-10 swap, the control-channel enable, the timed re-enable). Two racing to
-        recover the SAME corrupt stats DB can both pass the ``isfile()`` check, so the
-        loser's ``os.remove()`` hits an already-deleted file. That FileNotFoundError must
-        NOT escape the helper -- from the un-wrapped enable call site it would propagate
-        out of ``pfb_apply_control_command``, kill ``pfb_control_watcher``'s thread, and
-        silently disable the control channel until Unbound restarts (issue #870).
+        recover the SAME corrupt stats DB can both fail ``_validate_db_with_recovery``'s
+        first validate, so the loser's ``os.remove()`` hits an already-deleted file. That
+        FileNotFoundError must NOT escape the helper -- from the un-wrapped enable call
+        site it would propagate out of ``pfb_apply_control_command``, kill
+        ``pfb_control_watcher``'s thread, and silently disable the control channel until
+        Unbound restarts (issue #870).
 
-        RED without the inner try/except: os.remove's FileNotFoundError propagates and
-        this call raises.
+        Issue #900: ``pfb_db_validate`` -> ``_db_run`` swallows every fault internally and
+        never raises in production, so (unlike the test this replaces) it is NOT
+        monkeypatched here -- a genuinely corrupt file on disk drives its first, real
+        False. Only ``os.remove`` -- the boundary the guard actually protects -- is
+        monkeypatched, to simulate the losing race (another thread got there first).
         """
+        monkeypatch.setattr(P.time, "sleep", lambda *_a, **_k: None)  # skip _db_run's real retry backoff
         db = tmp_path / "dnsbl.sqlite"
-        db.write_text("corrupt")  # a real file so os.path.isfile() is genuinely True
+        db.write_text("corrupt")  # genuinely invalid sqlite file -> validate() really fails
         P.pfb["mod_sqlite3"] = True
         P.pfb["pfb_py_dnsbl"] = str(db)
         P.pfb["python_blacklist"] = True  # stats wanted -> the open path runs
         P.pfb["sqlite3_dnsbl_con"] = False
 
-        # Every open attempt fails (corrupt DB) AND the file vanished under us (the other
-        # thread already removed it), so os.remove raises FileNotFoundError.
-        def _fail_open(*_a: Any, **_k: Any) -> bool:
-            raise OSError("simulated corrupt DB open failure")
-
         def _already_removed(_path: str) -> None:
             raise FileNotFoundError(_path)
 
-        monkeypatch.setattr(P, "pfb_db_validate", _fail_open)
         monkeypatch.setattr(P.os, "remove", _already_removed)
 
-        # Must not raise; both attempts fail so the DB stays closed.
+        # Must not raise, even though the delete step lost the race.
         P._open_dnsbl_stats_db_if_wanted()
+
+        # os.remove was faked (not a real delete), so the corrupt bytes are still on disk --
+        # the revalidate genuinely fails too, so the DB stays closed. The point of this test
+        # is the FIRST assertion (no exception escaped), not this one.
         assert P.pfb["sqlite3_dnsbl_con"] is False
+
+
+class TestCorruptDnsblStatsDbRecovery:
+    """Issue #900: a genuinely corrupt ``pfb_py_dnsbl.sqlite`` on disk (e.g. after a power
+    loss) is recovered by the shared open helper -- deleted and rebuilt -- instead of
+    silently leaving the stats DB closed forever.
+
+    Background: ``pfb_db_validate`` -> ``_db_run`` swallows every connect/PRAGMA fault
+    internally and returns ``False``; it never raises. The old ``except Exception``
+    recovery around ``pfb_db_validate`` in both the helper and ``init_standard`` was
+    therefore dead code -- a corrupt file was never deleted, every DNSBL counter was
+    silently dropped forever, and each swap/enable re-paid a ~1.5s stall inside
+    ``_db_lock`` for nothing. ``_validate_db_with_recovery`` (shared by both call sites)
+    fixes this: a ``False`` validate is treated as the corrupt case (delete + one
+    revalidate).
+
+    Each test monkeypatches ``time.sleep`` to a no-op -- ``_db_run``'s internal retry
+    backoff is real production behaviour being exercised here, not test/production
+    concurrency to coordinate, so there is nothing to actually wait for.
+    """
+
+    def test_corrupt_db_is_deleted_rebuilt_and_flush_lands(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """Positive branch: recovery deletes the corrupt file, the retry connects, the
+        flag goes True, and a counter flush lands.
+
+        RED pre-fix (confirmed by stashing this fix and re-running): the corrupt file
+        was NOT deleted (still on disk after the call) and
+        ``assert P.pfb["sqlite3_dnsbl_con"] is True`` failed -- actual: ``False`` --
+        because the recovery lived in a dead ``except`` branch ``pfb_db_validate``
+        never raises into.
+        """
+        monkeypatch.setattr(P.time, "sleep", lambda *_a, **_k: None)
+        db = tmp_path / "dnsbl.sqlite"
+        db.write_bytes(b"not a sqlite database")  # garbage bytes -> genuinely corrupt
+        P.pfb["mod_sqlite3"] = True
+        P.pfb["pfb_py_dnsbl"] = str(db)
+        P.pfb["python_blacklist"] = True  # stats wanted -> the open path runs
+        P.pfb["sqlite3_dnsbl_con"] = False
+
+        # ---- BEFORE: the corrupt file genuinely fails validation and the flag is off.
+        assert P.pfb_db_validate(P.DB_DNSBL) is False
+        assert db.exists(), "a failed validate alone must not touch the file"
+        assert P.pfb["sqlite3_dnsbl_con"] is False
+
+        # ---- act: drive the shared helper (the swap / control-enable / timed-re-enable
+        # entry point -- see _open_dnsbl_stats_db_if_wanted's docstring for its callers).
+        P._open_dnsbl_stats_db_if_wanted()
+
+        # ---- AFTER: the corrupt file was deleted+rebuilt, the retry connected, flag True.
+        assert P.pfb["sqlite3_dnsbl_con"] is True, "recovery must delete + revalidate a corrupt DB (issue #900)"
+        assert P.DB_DNSBL in P._db_conns
+
+        # ---- and a counter flush actually lands on the recovered DB.
+        assert P._db_flush_dnsbl({"Upstream": 1})
+        con = P._db_conns[P.DB_DNSBL]
+        row = con.execute("SELECT counter FROM dnsbl WHERE groupname = 'Upstream'").fetchone()
+        assert row == (1,), f"Upstream counter not incremented after corrupt-DB recovery: {row!r}"
+
+    def test_recovery_delete_failure_leaves_flag_false_with_no_crash(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """Negative branch: when the recovery's own delete step itself fails (an
+        unremovable path), the helper must not crash -- it just leaves the stats DB
+        closed, no infinite retry, no uncaught exception.
+
+        Simulated by pointing ``pfb_py_dnsbl`` at a directory: sqlite3 can never open a
+        directory as a database (so validate() genuinely, always fails) and
+        ``os.remove()`` on a directory always fails too (``IsADirectoryError`` on Linux,
+        ``PermissionError`` on macOS) -- exercising the guard's ``except OSError``
+        without depending on a real file-permission model.
+        """
+        monkeypatch.setattr(P.time, "sleep", lambda *_a, **_k: None)
+        P.pfb["mod_sqlite3"] = True
+        P.pfb["pfb_py_dnsbl"] = str(tmp_path)  # a directory, never a valid sqlite file
+        P.pfb["python_blacklist"] = True
+        P.pfb["sqlite3_dnsbl_con"] = False
+
+        # Must not raise.
+        P._open_dnsbl_stats_db_if_wanted()
+
+        assert P.pfb["sqlite3_dnsbl_con"] is False
+        assert tmp_path.exists(), "the unremovable path (a directory) must survive the failed delete"
+
+    def test_racing_second_recovery_cannot_delete_the_winners_rebuilt_db(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """Concurrency: two threads recovering the SAME corrupt stats DB must not
+        interleave -- without serialization, both validate False, the winner deletes +
+        rebuilds the file, and the LOSER's delete then unlinks the winner's freshly
+        rebuilt LIVE file while the cached connection in ``_db_conns`` keeps writing to
+        the unlinked inode: every counter silently lost, the exact class #900 fixes.
+        ``_db_recovery_lock`` makes validate -> remove -> revalidate atomic; the loser's
+        first validate inside the lock doubles as its recheck (succeeds via the winner's
+        cached connection, no second delete).
+
+        Deterministic choreography (no sleeps; every wait carries a loud-timeout assert):
+        T1's ``os.remove`` parks on an Event between its validate-False and its delete --
+        the exact window the lock must close. T2 then enters the helper: WITH the lock it
+        blocks at the (instrumented) recovery lock, signalling ``t2_progressed`` on the
+        contended acquire; WITHOUT the lock it runs straight through the parked T1's
+        window (validate False -> second delete -> rebuild) and signals ``t2_progressed``
+        on return. Either way main can then release T1 and join both -- no branch waits
+        on wall-clock time. The instrumented lock is a behaviourally identical stand-in
+        installed with ``raising=False`` so the same test runs against pre-fix code
+        (where the attribute does not exist and is simply never consulted).
+
+        RED pre-fix (confirmed by stashing the lock and re-running): both threads
+        performed a delete -- ``assert len(remove_calls) == 1`` failed with 2 calls,
+        T2's second delete having unlinked the winner's rebuilt live DB.
+        """
+        monkeypatch.setattr(P.time, "sleep", lambda *_a, **_k: None)
+        db = tmp_path / "dnsbl.sqlite"
+        db.write_bytes(b"not a sqlite database")  # garbage bytes -> genuinely corrupt
+        P.pfb["mod_sqlite3"] = True
+        P.pfb["pfb_py_dnsbl"] = str(db)
+        P.pfb["python_blacklist"] = True  # stats wanted -> the open path runs
+        P.pfb["sqlite3_dnsbl_con"] = False
+
+        t1_parked = threading.Event()  # T1 is inside its recovery delete
+        release_t1 = threading.Event()  # main lets T1's delete proceed
+        t2_progressed = threading.Event()  # T2 blocked on the lock OR completed
+        errors: list[BaseException] = []
+
+        real_remove = P.os.remove
+        remove_calls: list[str] = []
+
+        def choreographed_remove(path: str) -> None:
+            remove_calls.append(path)
+            if len(remove_calls) == 1:  # T1: park in the validate->delete window
+                t1_parked.set()
+                assert release_t1.wait(5), "loud timeout: T1 was never released from its parked delete"
+            real_remove(path)
+
+        class _SignallingLock:
+            """Same mutual exclusion as the real recovery lock, plus a signal on a
+            contended acquire so main knows (deterministically) that T2 is waiting."""
+
+            def __init__(self) -> None:
+                self._lock = threading.Lock()
+
+            def __enter__(self) -> None:
+                if not self._lock.acquire(blocking=False):
+                    t2_progressed.set()  # contended: the loser is waiting on the winner
+                    self._lock.acquire()
+
+            def __exit__(self, *_exc: object) -> None:
+                self._lock.release()
+
+        monkeypatch.setattr(P.os, "remove", choreographed_remove)
+        monkeypatch.setattr(P, "_db_recovery_lock", _SignallingLock(), raising=False)
+
+        def t1_run() -> None:
+            try:
+                P._open_dnsbl_stats_db_if_wanted()
+            except BaseException as e:  # noqa: BLE001 -- surface thread faults in main
+                errors.append(e)
+
+        def t2_run() -> None:
+            try:
+                P._open_dnsbl_stats_db_if_wanted()
+            except BaseException as e:  # noqa: BLE001 -- surface thread faults in main
+                errors.append(e)
+            finally:
+                t2_progressed.set()  # pre-fix path: T2 ran straight through and returned
+
+        t1 = threading.Thread(target=t1_run)
+        t1.start()
+        assert t1_parked.wait(5), "loud timeout: T1 never reached its recovery delete"
+
+        t2 = threading.Thread(target=t2_run)
+        t2.start()
+        assert t2_progressed.wait(5), "loud timeout: T2 neither blocked on the recovery lock nor completed"
+
+        release_t1.set()
+        t1.join(5)
+        t2.join(5)
+        assert not t1.is_alive() and not t2.is_alive(), "loud timeout: recovery threads did not finish"
+        assert not errors, f"a recovery thread raised: {errors!r}"
+
+        # Then: exactly ONE delete happened -- the loser revalidated instead of deleting
+        # the winner's rebuilt DB.
+        assert len(remove_calls) == 1, (
+            f"racing recovery must delete the corrupt DB exactly once, got {len(remove_calls)}: {remove_calls!r}"
+        )
+        assert P.pfb["sqlite3_dnsbl_con"] is True
+
+        # And: a flush lands AND is visible through a FRESH connection to the on-disk
+        # path -- proving the cached connection's file IS the live on-disk file, not an
+        # unlinked-inode ghost.
+        assert P._db_flush_dnsbl({"Upstream": 1})
+        fresh = sqlite3.connect(str(db))
+        try:
+            row = fresh.execute("SELECT counter FROM dnsbl WHERE groupname = 'Upstream'").fetchone()
+        finally:
+            fresh.close()
+        assert row == (1,), f"flush not visible via a fresh connection to the on-disk DB (ghost inode?): {row!r}"
 
 
 class TestSharedHandlerBypass:


### PR DESCRIPTION
## What / why

`_open_dnsbl_stats_db_if_wanted()` and `init_standard()`'s "Validate SQLite3 database
connections" block both wrapped `pfb_db_validate()` in `try/except` and put corrupt-DB
recovery (delete the file + retry) in the `except` branch. That branch is unreachable:
`pfb_db_validate()` → `_db_run()` catches every connect/PRAGMA fault internally (a
corrupt file included) and returns `False` — it never raises. Net effect: a corrupt
`pfb_py_dnsbl.sqlite` (or `pfb_py_resolver.sqlite`) was never deleted, every DNSBL/
resolver counter was silently dropped forever, and each swap/control-channel enable
re-paid a ~1.5s stall inside `_db_lock` (two full validate() calls, 8 connect attempts +
6×0.25s sleeps) for nothing.

Fix: extract `_validate_db_with_recovery(db)`, shared by every call site (the two init
blocks and the post-init helper). It treats a `False` validate as the corrupt case:
guarded delete (tolerating a losing race or an unremovable path) + one revalidate. Still
`False` → the flag simply stays off, logged loudly — no crash, no infinite retry.

The whole validate → remove → revalidate sequence holds a new `_db_recovery_lock`:
without it, two threads recovering the same corrupt DB (the helper is reachable from the
ADR-10 swap watcher, the control-channel enable, and the timed re-enable) can both
validate `False`, and the loser's delete then unlinks the winner's freshly rebuilt LIVE
file while the cached connection in `_db_conns` keeps writing to the unlinked inode —
counters silently lost again. The loser's first validate inside the lock doubles as its
recheck (succeeds via the winner's cached connection, no second delete). Lock ordering
is `_db_recovery_lock` → `_db_lock` only (`_db_lock` is acquired solely inside
`_db_run`), so the ordering never inverts — no deadlock.

Also fixes the `_open_dnsbl_stats_db_if_wanted` comment's false claim of being "off the
DNS fast path": `pfb_apply_control_command` is reachable from `operate()` under the
legacy `python_control_legacy` transport, so this can run on an Unbound query worker.

## Red-before-green evidence

Stashed the `src/` fix, kept the new tests, and re-ran them:

```text
FAILED tests/test_pfbl03_control_channel.py::TestCorruptDnsblStatsDbRecovery::test_corrupt_db_is_deleted_rebuilt_and_flush_lands
AssertionError: recovery must delete + revalidate a corrupt DB (issue #900)
assert False is True
```

Race test, stashed to the recovery-without-lock intermediate (5/5 runs red, 5/5 green
with the lock):

```text
FAILED tests/test_pfbl03_control_channel.py::TestCorruptDnsblStatsDbRecovery::test_racing_second_recovery_cannot_delete_the_winners_rebuilt_db
AssertionError: racing recovery must delete the corrupt DB exactly once, got 2: [...]
assert 2 == 1
```

Un-stashed the fix and re-ran: green.

## Test coverage

- `TestCorruptDnsblStatsDbRecovery` (new class, `tests/test_pfbl03_control_channel.py`):
  - `test_corrupt_db_is_deleted_rebuilt_and_flush_lands` — a genuinely corrupt file on
    disk fails the first validate (asserted BEFORE), the shared helper deletes it,
    revalidates, the flag flips `True`, and a subsequent counter flush lands. RED
    pre-fix as shown above.
  - `test_recovery_delete_failure_leaves_flag_false_with_no_crash` — the recovery's own
    delete step failing (simulated by pointing the DB path at a directory, so
    `os.remove()` genuinely raises) leaves the flag `False` with no exception escaping.
  - `test_racing_second_recovery_cannot_delete_the_winners_rebuilt_db` — deterministic
    two-thread choreography (no sleeps; every wait carries a loud-timeout assert): T1
    parks inside its recovery delete, T2 enters the helper; with the lock T2 blocks and
    revalidates via the winner's connection (exactly ONE delete, flush visible through a
    FRESH connection to the on-disk path — no unlinked-inode ghost); without the lock
    both threads delete. RED pre-fix as shown above.
- `test_open_helper_survives_a_losing_race_on_corrupt_db_delete` reworked: it previously
  monkeypatched `pfb_db_validate` to raise `OSError`, a fault production cannot produce
  (pinning the dead branch). Now a real corrupt file drives the genuine `False` validate,
  and only `os.remove` (the actual guarded boundary) is monkeypatched to simulate the
  losing race.
- Full suite green: `python -m pytest` → 2216 passed, 4 skipped (pre-existing).
  `ruff check` / `ruff format --check` clean. `mypy tests/` clean.

Fixes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)