### PR TITLE
pfblockerng: rename Top1mSource to PfbTop1mSource (#905)

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -29,7 +29,7 @@ field, reasoning about rollback/downgrade, or checking the foreign-key exclusion
     `=== PfbIdnMode::All` / `::Confusable`. The 4.0.0-alpha-only `'all'` token is **not** carried
     (alpha compatibility is intentionally not maintained) — it reads as Off. One canonical
     vocabulary spans `config.xml`, the ini, and the Python `IdnMode` enum.
-  - **`alexa_type` → `Top1mSource`** (issue #877 review, registry adapters
+  - **`alexa_type` → `PfbTop1mSource`** (issue #877 review, registry adapters
     `pfb_cfg_top1m_source_read/write`): tokens `'tranco'` (default) / `'cisco'` / `'domcop'` /
     `'majestic'` (added ADR-59 P4) / `'cloudflare'` (added ADR-59 P5, the first
     token-authenticated provider). The legacy `'alexa'` token (the dead Alexa
@@ -103,7 +103,7 @@ at/after that version; it is a per-field scope marker, not a migration.
 **Excluded fields** — none. `pfb_idn` was previously excluded (`NULL`/`NULL` identity adapters);
 it is now adopted as `PfbIdnMode` (see ADR-28 §2.2). `All` reuses the legacy `'on'` token, so the
 adoption is migration-free and downgrade-safe. `alexa_type` similarly moved off a plain-string
-read-boundary coalesce onto the `Top1mSource` enum (issue #877 review) — same shape, no migration.
+read-boundary coalesce onto the `PfbTop1mSource` enum (issue #877 review) — same shape, no migration.
 
 ## Since-version convention
 

--- a/docs/misc/top1m-providers.md
+++ b/docs/misc/top1m-providers.md
@@ -25,7 +25,7 @@ source of truth — every provider is one row:
   `pfb_download()` sends — never a query-string token.
 - **`label`** / **`licence`** — the UI's option text and licence note.
 
-`pfblockerng.php` selects the active row via `$pfb['dnsbl_top1m_type']`/`Top1mSource` and wires
+`pfblockerng.php` selects the active row via `$pfb['dnsbl_top1m_type']`/`PfbTop1mSource` and wires
 its `url`/`headers` into the `extras[2]` download slot; no per-provider `if`/`elseif` remains.
 
 ## Providers

--- a/scripts/misc/check_top1m_providers.py
+++ b/scripts/misc/check_top1m_providers.py
@@ -75,11 +75,11 @@ DEFAULT_DESCRIPTOR_FILE = REPO_ROOT / "src/usr/local/pkg/pfblockerng/pfblockerng
 # a row is added to or removed from that descriptor table.
 MIN_PROVIDERS = 5
 
-# Matches "Top1mSource::<Case>->value => array(" -- the start of one provider's
+# Matches "PfbTop1mSource::<Case>->value => array(" -- the start of one provider's
 # descriptor block in pfb_top1m_providers()'s return array. Unique to that
 # table (grepped): every other `->value` use in the file is `$this->value`
 # inside the enum body, which this pattern doesn't match.
-_PROVIDER_ENTRY_RE = re.compile(r"Top1mSource::\w+->value\s*=>\s*array\(")
+_PROVIDER_ENTRY_RE = re.compile(r"PfbTop1mSource::\w+->value\s*=>\s*array\(")
 _URL_FIELD_RE = re.compile(r"'url'\s*=>\s*'([^']*)'")
 _LABEL_FIELD_RE = re.compile(r"'label'\s*=>\s*'([^']*)'")
 _CONTAINER_FIELD_RE = re.compile(r"'container'\s*=>\s*'([^']*)'")
@@ -93,7 +93,7 @@ _AUTH_TOKEN_RE = re.compile(r"'auth'\s*=>\s*array\(\s*'header'\s*=>\s*'([^']*)'\
 def _strip_php_line_comments(php_text: str) -> str:
     """Drop whole-line `//`-commented-out lines before extraction.
 
-    Without this, a commented-out `// Top1mSource::Dead->value => array(...`
+    Without this, a commented-out `// PfbTop1mSource::Dead->value => array(...`
     is still picked up as a live provider (the regex matches raw text). A
     trailing comment on a live line is unaffected -- the field is already
     matched before the comment starts.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2396,7 +2396,7 @@ function pfb_global() {
 	$pfb['dnsbl_port']	= $pfb['dnsblconfig']['pfb_dnsport'];									// Lighttpd web server http port setting
 	$pfb['dnsbl_port_ssl']	= $pfb['dnsblconfig']['pfb_dnsport_ssl'];								// Lighttpd web server https port setting
 	$pfb['dnsbl_top1m']	= $pfb['dnsblconfig']['alexa_enable'];							// TOP1M whitelist
-	$pfb['dnsbl_top1m_type']	= PfbConfig::read('alexa_type');						// TOP1M type (Top1mSource enum; legacy 'alexa' coalesces to Tranco, #877) (default Tranco)
+	$pfb['dnsbl_top1m_type']	= PfbConfig::read('alexa_type');						// TOP1M type (PfbTop1mSource enum; legacy 'alexa' coalesces to Tranco, #877) (default Tranco)
 	$pfb['dnsbl_res_cache']	= $pfb['dnsblconfig']['pfb_cache'];							// DNSBL Option to backup/restore Resolver cache
 	$pfb['dnsbl_global_log']= PfbConfig::read('global_log');							// Global Logging/Blocking mode (default '')
 	// ADR-22: lenient feed parsing. 'on' = permissive scheme strip (today); anything else =
@@ -8308,7 +8308,7 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 	// (it is normally set by pfb_global() -- PfbConfig::read('alexa_type') --
 	// which some tests never call); default to Tranco, the same absent-default
 	// the registry itself uses, so the resolved shape stays rank_domain/zip.
-	$top1m_type	= $pfb['dnsbl_top1m_type'] ?? Top1mSource::Tranco;
+	$top1m_type	= $pfb['dnsbl_top1m_type'] ?? PfbTop1mSource::Tranco;
 	$top1m_provider	= $provider_override ?? (pfb_top1m_providers()[$top1m_type->value] ?? array());
 	$top1m_parse	= $top1m_provider['parse'] ?? 'rank_domain';
 	$top1m_header	= $top1m_provider['header'] ?? FALSE;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -200,7 +200,7 @@ enum PfbAliasDeltaMode: string implements PfbStoredEnum
 	}
 }
 
-// Top1mSource — TOP1M source selector (alexa_type, issue #877).
+// PfbTop1mSource — TOP1M source selector (alexa_type, issue #877).
 //
 // Used by: alexa_type (config key) / $pfb['dnsbl_top1m_type'] (runtime).
 //   Canonical tokens: 'tranco' (default), 'cisco', 'domcop', 'majestic'
@@ -212,7 +212,7 @@ enum PfbAliasDeltaMode: string implements PfbStoredEnum
 //   reading any of them already understands its own subset; domcop/
 //   majestic/cloudflare are simply new to it, same as any other ADR-added
 //   option).
-enum Top1mSource: string implements PfbStoredEnum
+enum PfbTop1mSource: string implements PfbStoredEnum
 {
 	use PfbStoredEnumAdapter;
 
@@ -239,7 +239,7 @@ enum Top1mSource: string implements PfbStoredEnum
 // TOP1M provider descriptor table (ADR-59 P1, generalized P2, keyless
 // providers added P4, token-authenticated Cloudflare Radar added P5).
 //
-// Keyed by Top1mSource::value ('tranco'/'cisco'/'domcop'/'majestic'/'cloudflare').
+// Keyed by PfbTop1mSource::value ('tranco'/'cisco'/'domcop'/'majestic'/'cloudflare').
 // pfblockerng.php's TOP1M URL selection reads this table instead of a
 // per-provider if/else; pfblockerng_top1m() (ADR-59 P2) reads
 // 'parse'/'header'/'domain_col' to drive the builder. 'container' documents each
@@ -263,7 +263,7 @@ enum Top1mSource: string implements PfbStoredEnum
 function pfb_top1m_providers(): array
 {
 	return array(
-		Top1mSource::Tranco->value	=> array(
+		PfbTop1mSource::Tranco->value	=> array(
 			'url'		=> 'https://tranco-list.eu/top-1m.csv.zip',
 			'container'	=> 'zip',
 			'parse'		=> 'rank_domain',
@@ -273,7 +273,7 @@ function pfb_top1m_providers(): array
 			'label'		=> 'Tranco',
 			'licence'	=> '',
 		),
-		Top1mSource::Cisco->value	=> array(
+		PfbTop1mSource::Cisco->value	=> array(
 			'url'		=> 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip',
 			'container'	=> 'zip',
 			'parse'		=> 'rank_domain',
@@ -285,7 +285,7 @@ function pfb_top1m_providers(): array
 		),
 		// DomCop top-10M (registered-domain breadth): zipped CSV, quoted header
 		// row ("Rank","Domain","Open Page Rank"), Domain at str_getcsv() index 1.
-		Top1mSource::DomCop->value	=> array(
+		PfbTop1mSource::DomCop->value	=> array(
 			'url'		=> 'https://www.domcop.com/files/top/top10milliondomains.csv.zip',
 			'container'	=> 'zip',
 			'parse'		=> 'csv',
@@ -297,7 +297,7 @@ function pfb_top1m_providers(): array
 		),
 		// Majestic Million: PLAIN (uncompressed) CSV, unquoted 12-col header
 		// (GlobalRank,TldRank,Domain,TLD,...), Domain at str_getcsv() index 2.
-		Top1mSource::Majestic->value	=> array(
+		PfbTop1mSource::Majestic->value	=> array(
 			'url'		=> 'https://downloads.majestic.com/majestic_million.csv',
 			'container'	=> 'plain',
 			'parse'		=> 'csv',
@@ -327,7 +327,7 @@ function pfb_top1m_providers(): array
 		// made (no Cloudflare token available in this environment) to prove the alias/URL end
 		// to end -- confirmed via two independent official Cloudflare doc pages instead. A real
 		// token on a live box (ADR §7 definition-of-done manual smoke) is the final proof.
-		Top1mSource::Cloudflare->value	=> array(
+		PfbTop1mSource::Cloudflare->value	=> array(
 			'url'		=> 'https://api.cloudflare.com/client/v4/radar/datasets/ranking_top_1000000',
 			'container'	=> 'plain',
 			'parse'		=> 'csv',
@@ -424,21 +424,21 @@ function pfb_cfg_idn_mode_write(PfbIdnMode|string $mode): string
 	return ($mode instanceof PfbIdnMode ? $mode : PfbIdnMode::fromStored($mode))->toStored();
 }
 
-/** Read a Top1mSource from a raw stored value (legacy 'alexa' -> Tranco). */
-function pfb_cfg_top1m_source_read(mixed $stored): Top1mSource
+/** Read a PfbTop1mSource from a raw stored value (legacy 'alexa' -> Tranco). */
+function pfb_cfg_top1m_source_read(mixed $stored): PfbTop1mSource
 {
-	return Top1mSource::fromStored($stored);
+	return PfbTop1mSource::fromStored($stored);
 }
 
 /**
- * Write a Top1mSource (enum or legacy string) back to its canonical stored
+ * Write a PfbTop1mSource (enum or legacy string) back to its canonical stored
  * token ('tranco' | 'cisco' | 'domcop' | 'majestic' | 'cloudflare'). The dead
  * legacy 'alexa' token (#872) is never re-emitted — fromStored() already
  * coalesced it to Tranco before this runs.
  */
-function pfb_cfg_top1m_source_write(Top1mSource|string $source): string
+function pfb_cfg_top1m_source_write(PfbTop1mSource|string $source): string
 {
-	return ($source instanceof Top1mSource ? $source : Top1mSource::fromStored($source))->toStored();
+	return ($source instanceof PfbTop1mSource ? $source : PfbTop1mSource::fromStored($source))->toStored();
 }
 
 // ---------------------------------------------------------------------------
@@ -1672,7 +1672,7 @@ function pfb_run_migrations(): void
  * read as Off and never written.
  *
  * The top1m_source adapter (pfb_cfg_top1m_source_read/write, issue #877) is wired
- * for alexa_type and returns a Top1mSource enum. Legacy 'alexa' (dead service,
+ * for alexa_type and returns a PfbTop1mSource enum. Legacy 'alexa' (dead service,
  * #872) coalesces to Tranco on read and is never re-emitted by a write; the
  * write vocabulary is 'tranco'|'cisco'|'domcop'|'majestic'|'cloudflare'
  * (domcop/majestic added ADR-59 P4, cloudflare added ADR-59 P5).
@@ -1704,11 +1704,11 @@ function pfb_cfg_field_vocab(): array
 		// do not exist in config.xml, and the feature falls back to full replace.
 		'alias_delta_mode' => ['auto', 'delta', 'replace'],
 
-		// TOP1M source selector (Top1mSource, issue #877): the tokens a write can
+		// TOP1M source selector (PfbTop1mSource, issue #877): the tokens a write can
 		// emit. 'tranco' (default) | 'cisco' | 'domcop' | 'majestic' | 'cloudflare'
 		// (domcop/majestic added ADR-59 P4, cloudflare added ADR-59 P5). The legacy
 		// 'alexa' token (dead service, #872) is a READ-ONLY legacy value —
-		// pfb_cfg_top1m_source_read() coalesces it to Top1mSource::Tranco and it is
+		// pfb_cfg_top1m_source_read() coalesces it to PfbTop1mSource::Tranco and it is
 		// never re-emitted by a write.
 		'top1m_source' => ['tranco', 'cisco', 'domcop', 'majestic', 'cloudflare'],
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -112,7 +112,7 @@ $pconfig['suppression']		= base64_decode($pfb['dconfig']['suppression'])		?: '';
 $pconfig['alexa_enable']	= $pfb['dconfig']['alexa_enable']			?: '';
 // Routed via the gateway (not the section array) so a stored legacy 'alexa'
 // (dead TOP1M source, #872/#877) coalesces to 'tranco' for the form select.
-// ->toStored() unwraps the Top1mSource enum to its scalar option key (a
+// ->toStored() unwraps the PfbTop1mSource enum to its scalar option key (a
 // Form_Select selected-value must be the scalar, not the enum instance).
 $pconfig['alexa_type']		= PfbConfig::read('alexa_type')->toStored();
 $pconfig['alexa_count']		= $pfb['dconfig']['alexa_count']			?: '1000';

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -38,7 +38,7 @@ use PHPUnit\Framework\TestCase;
  *     And write(read('all')) == 'off'  (dropped alpha token -> Off).
  *     And write(read('')) == 'off'    (normalised default).
  *
- * Scenario E — Top1mSource (alexa_type, issue #877): backing values 'tranco' /
+ * Scenario E — PfbTop1mSource (alexa_type, issue #877): backing values 'tranco' /
  *   'cisco' / 'domcop' / 'majestic' (the latter two added ADR-59 P4) TOP1M
  *   source selector; the legacy 'alexa' token (dead service, #872) coalesces
  *   to Tranco.
@@ -114,7 +114,7 @@ final class CfgAdaptersTest extends TestCase
 		$this->assertSame(PfbLenient::On, PfbLenient::fromStored(PfbLenient::On));
 		$this->assertSame(PfbIdnMode::Confusable, PfbIdnMode::fromStored(PfbIdnMode::Confusable));
 		$this->assertSame(PfbAliasDeltaMode::Delta, PfbAliasDeltaMode::fromStored(PfbAliasDeltaMode::Delta));
-		$this->assertSame(Top1mSource::Cisco, Top1mSource::fromStored(Top1mSource::Cisco));
+		$this->assertSame(PfbTop1mSource::Cisco, PfbTop1mSource::fromStored(PfbTop1mSource::Cisco));
 	}
 
 	public function testToggleRoundTripOn(): void
@@ -672,7 +672,7 @@ final class CfgAdaptersTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// Scenario E — Top1mSource (alexa_type, issue #877)
+	// Scenario E — PfbTop1mSource (alexa_type, issue #877)
 	//   Stored tokens: 'tranco', 'cisco', 'domcop', 'majestic', 'cloudflare' (live;
 	//   the latter three added ADR-59 P4/P5); legacy 'alexa' (dead service, #872)
 	//   coalesces to Tranco at the read boundary. Mirrors the PfbAliasDeltaMode
@@ -680,59 +680,59 @@ final class CfgAdaptersTest extends TestCase
 	//   the enum or a raw string.
 	// -----------------------------------------------------------------------
 
-	public function testTop1mSourceReadTrancoReturnsTranco(): void
+	public function testPfbTop1mSourceReadTrancoReturnsTranco(): void
 	{
-		$this->assertSame(Top1mSource::Tranco, pfb_cfg_top1m_source_read('tranco'));
+		$this->assertSame(PfbTop1mSource::Tranco, pfb_cfg_top1m_source_read('tranco'));
 	}
 
-	public function testTop1mSourceReadCiscoReturnsCisco(): void
+	public function testPfbTop1mSourceReadCiscoReturnsCisco(): void
 	{
-		$this->assertSame(Top1mSource::Cisco, pfb_cfg_top1m_source_read('cisco'));
+		$this->assertSame(PfbTop1mSource::Cisco, pfb_cfg_top1m_source_read('cisco'));
 	}
 
 	/** ADR-59 P4: the two new keyless-provider tokens read as their own enum cases. */
-	public function testTop1mSourceReadDomCopReturnsDomCop(): void
+	public function testPfbTop1mSourceReadDomCopReturnsDomCop(): void
 	{
-		$this->assertSame(Top1mSource::DomCop, pfb_cfg_top1m_source_read('domcop'));
+		$this->assertSame(PfbTop1mSource::DomCop, pfb_cfg_top1m_source_read('domcop'));
 	}
 
-	public function testTop1mSourceReadMajesticReturnsMajestic(): void
+	public function testPfbTop1mSourceReadMajesticReturnsMajestic(): void
 	{
-		$this->assertSame(Top1mSource::Majestic, pfb_cfg_top1m_source_read('majestic'));
+		$this->assertSame(PfbTop1mSource::Majestic, pfb_cfg_top1m_source_read('majestic'));
 	}
 
 	/** ADR-59 P5: the token-authenticated Cloudflare Radar token reads as its own enum case. */
-	public function testTop1mSourceReadCloudflareReturnsCloudflare(): void
+	public function testPfbTop1mSourceReadCloudflareReturnsCloudflare(): void
 	{
-		$this->assertSame(Top1mSource::Cloudflare, pfb_cfg_top1m_source_read('cloudflare'));
+		$this->assertSame(PfbTop1mSource::Cloudflare, pfb_cfg_top1m_source_read('cloudflare'));
 	}
 
 	/** The dead legacy TOP1M source (#872) must read as Tranco, not a lost 'alexa' value. */
-	public function testTop1mSourceReadLegacyAlexaCoalescesToTranco(): void
+	public function testPfbTop1mSourceReadLegacyAlexaCoalescesToTranco(): void
 	{
-		$this->assertSame(Top1mSource::Tranco, pfb_cfg_top1m_source_read('alexa'));
+		$this->assertSame(PfbTop1mSource::Tranco, pfb_cfg_top1m_source_read('alexa'));
 	}
 
-	public function testTop1mSourceReadUnknownTokenDefaultsToTranco(): void
+	public function testPfbTop1mSourceReadUnknownTokenDefaultsToTranco(): void
 	{
-		$this->assertSame(Top1mSource::Tranco, pfb_cfg_top1m_source_read('junk'));
+		$this->assertSame(PfbTop1mSource::Tranco, pfb_cfg_top1m_source_read('junk'));
 	}
 
-	public function testTop1mSourceReadNullDefaultsToTranco(): void
+	public function testPfbTop1mSourceReadNullDefaultsToTranco(): void
 	{
-		$this->assertSame(Top1mSource::Tranco, pfb_cfg_top1m_source_read(null));
+		$this->assertSame(PfbTop1mSource::Tranco, pfb_cfg_top1m_source_read(null));
 	}
 
-	public function testTop1mSourceReadEmptyDefaultsToTranco(): void
+	public function testPfbTop1mSourceReadEmptyDefaultsToTranco(): void
 	{
-		$this->assertSame(Top1mSource::Tranco, pfb_cfg_top1m_source_read(''));
+		$this->assertSame(PfbTop1mSource::Tranco, pfb_cfg_top1m_source_read(''));
 	}
 
 	/**
 	 * write(read(v)) == v for all five live canonical tokens (domcop/majestic added
 	 * P4, cloudflare added P5).
 	 */
-	public function testTop1mSourceRoundTripCanonicalTokens(): void
+	public function testPfbTop1mSourceRoundTripCanonicalTokens(): void
 	{
 		foreach (['tranco', 'cisco', 'domcop', 'majestic', 'cloudflare'] as $token) {
 			$written = pfb_cfg_top1m_source_write(pfb_cfg_top1m_source_read($token));
@@ -742,7 +742,7 @@ final class CfgAdaptersTest extends TestCase
 	}
 
 	/** The legacy 'alexa' token never round-trips back to itself -- it is coalesced. */
-	public function testTop1mSourceRoundTripLegacyAlexaNeverReemitted(): void
+	public function testPfbTop1mSourceRoundTripLegacyAlexaNeverReemitted(): void
 	{
 		$written = pfb_cfg_top1m_source_write(pfb_cfg_top1m_source_read('alexa'));
 		$this->assertSame('tranco', $written,
@@ -750,13 +750,13 @@ final class CfgAdaptersTest extends TestCase
 	}
 
 	/** pfb_cfg_top1m_source_write() accepts both an enum instance and a string. */
-	public function testTop1mSourceWriteAcceptsEnumOrString(): void
+	public function testPfbTop1mSourceWriteAcceptsEnumOrString(): void
 	{
-		$this->assertSame('tranco',     pfb_cfg_top1m_source_write(Top1mSource::Tranco));
-		$this->assertSame('cisco',      pfb_cfg_top1m_source_write(Top1mSource::Cisco));
-		$this->assertSame('domcop',     pfb_cfg_top1m_source_write(Top1mSource::DomCop));
-		$this->assertSame('majestic',   pfb_cfg_top1m_source_write(Top1mSource::Majestic));
-		$this->assertSame('cloudflare', pfb_cfg_top1m_source_write(Top1mSource::Cloudflare));
+		$this->assertSame('tranco',     pfb_cfg_top1m_source_write(PfbTop1mSource::Tranco));
+		$this->assertSame('cisco',      pfb_cfg_top1m_source_write(PfbTop1mSource::Cisco));
+		$this->assertSame('domcop',     pfb_cfg_top1m_source_write(PfbTop1mSource::DomCop));
+		$this->assertSame('majestic',   pfb_cfg_top1m_source_write(PfbTop1mSource::Majestic));
+		$this->assertSame('cloudflare', pfb_cfg_top1m_source_write(PfbTop1mSource::Cloudflare));
 		$this->assertSame('tranco',     pfb_cfg_top1m_source_write('tranco'));
 		$this->assertSame('cisco',      pfb_cfg_top1m_source_write('cisco'));
 		$this->assertSame('domcop',     pfb_cfg_top1m_source_write('domcop'));

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -337,25 +337,25 @@ final class CfgGatewayTest extends TestCase
 
 	public function testReadReturnsRegisteredDefaultForAlexaTypeAbsentKey(): void
 	{
-		// alexa_type default is 'tranco' -> Top1mSource::Tranco.
+		// alexa_type default is 'tranco' -> PfbTop1mSource::Tranco.
 		$this->assertNull(
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/alexa_type')
 		);
 
 		$result = PfbConfig::read('alexa_type');
-		$this->assertInstanceOf(Top1mSource::class, $result, 'alexa_type must return a Top1mSource enum');
-		$this->assertSame(Top1mSource::Tranco, $result);
+		$this->assertInstanceOf(PfbTop1mSource::class, $result, 'alexa_type must return a PfbTop1mSource enum');
+		$this->assertSame(PfbTop1mSource::Tranco, $result);
 	}
 
 	/**
 	 * alexa_type (issue #877): a stored legacy 'alexa' (dead TOP1M source, #872)
-	 * coalesces to Top1mSource::Tranco through the gateway's read adapter.
+	 * coalesces to PfbTop1mSource::Tranco through the gateway's read adapter.
 	 *
 	 * Scenario: the dropped Alexa TOP1M option still reads safely on an existing
 	 * install that had it selected.
 	 *   Given alexa_type stored as the legacy 'alexa' token.
 	 *   When PfbConfig::read('alexa_type').
-	 *   Then the result is Top1mSource::Tranco, not the dead 'alexa' token.
+	 *   Then the result is PfbTop1mSource::Tranco, not the dead 'alexa' token.
 	 */
 	public function testReadCoalescesLegacyAlexaTypeToTranco(): void
 	{
@@ -365,32 +365,32 @@ final class CfgGatewayTest extends TestCase
 		$this->seedConfig($path, 'alexa');
 		$this->assertSame('alexa', config_get_path($path), 'before: alexa_type seed is legacy alexa');
 
-		// When/Then: coalesced to Top1mSource::Tranco.
-		$this->assertSame(Top1mSource::Tranco, PfbConfig::read('alexa_type'), "legacy 'alexa' coalesces to Tranco");
+		// When/Then: coalesced to PfbTop1mSource::Tranco.
+		$this->assertSame(PfbTop1mSource::Tranco, PfbConfig::read('alexa_type'), "legacy 'alexa' coalesces to Tranco");
 	}
 
 	/**
 	 * alexa_type: all five live tokens pass through as their enum cases (domcop/majestic
 	 * added ADR-59 P4, cloudflare added ADR-59 P5).
 	 */
-	public function testReadPassesThroughLiveTop1mSourceTokens(): void
+	public function testReadPassesThroughLivePfbTop1mSourceTokens(): void
 	{
 		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/alexa_type';
 
 		$this->seedConfig($path, 'cisco');
-		$this->assertSame(Top1mSource::Cisco, PfbConfig::read('alexa_type'), "'cisco' passes through as Cisco");
+		$this->assertSame(PfbTop1mSource::Cisco, PfbConfig::read('alexa_type'), "'cisco' passes through as Cisco");
 
 		$this->seedConfig($path, 'tranco');
-		$this->assertSame(Top1mSource::Tranco, PfbConfig::read('alexa_type'), "'tranco' passes through as Tranco");
+		$this->assertSame(PfbTop1mSource::Tranco, PfbConfig::read('alexa_type'), "'tranco' passes through as Tranco");
 
 		$this->seedConfig($path, 'domcop');
-		$this->assertSame(Top1mSource::DomCop, PfbConfig::read('alexa_type'), "'domcop' passes through as DomCop");
+		$this->assertSame(PfbTop1mSource::DomCop, PfbConfig::read('alexa_type'), "'domcop' passes through as DomCop");
 
 		$this->seedConfig($path, 'majestic');
-		$this->assertSame(Top1mSource::Majestic, PfbConfig::read('alexa_type'), "'majestic' passes through as Majestic");
+		$this->assertSame(PfbTop1mSource::Majestic, PfbConfig::read('alexa_type'), "'majestic' passes through as Majestic");
 
 		$this->seedConfig($path, 'cloudflare');
-		$this->assertSame(Top1mSource::Cloudflare, PfbConfig::read('alexa_type'), "'cloudflare' passes through as Cloudflare");
+		$this->assertSame(PfbTop1mSource::Cloudflare, PfbConfig::read('alexa_type'), "'cloudflare' passes through as Cloudflare");
 	}
 
 	/**

--- a/tests/php/PfbGlobalParityTest.php
+++ b/tests/php/PfbGlobalParityTest.php
@@ -246,8 +246,8 @@ final class PfbGlobalParityTest extends TestCase
 	 * alexa_type: OLD = isset($pfb['dnsblconfig']['alexa_type'])
 	 *                   ? $pfb['dnsblconfig']['alexa_type'] : 'tranco'.
 	 * When absent: 'tranco'.
-	 * Via gateway: PfbConfig::read('alexa_type') = Top1mSource::Tranco (registered
-	 * default 'tranco', adapted through the Top1mSource enum, issue #877 review).
+	 * Via gateway: PfbConfig::read('alexa_type') = PfbTop1mSource::Tranco (registered
+	 * default 'tranco', adapted through the PfbTop1mSource enum, issue #877 review).
 	 * PARITY: same runtime meaning ('tranco'), now enum-typed instead of a raw string.
 	 */
 	public function testParityAlexaTypeAbsentYieldsTranco(): void
@@ -258,7 +258,7 @@ final class PfbGlobalParityTest extends TestCase
 
 		$result = PfbConfig::read('alexa_type');
 
-		$this->assertSame(Top1mSource::Tranco, $result, 'alexa_type absent -> Top1mSource::Tranco');
+		$this->assertSame(PfbTop1mSource::Tranco, $result, 'alexa_type absent -> PfbTop1mSource::Tranco');
 	}
 
 	/**

--- a/tests/php/RollbackContractTest.php
+++ b/tests/php/RollbackContractTest.php
@@ -371,7 +371,7 @@ final class RollbackContractTest extends TestCase
 	 *
 	 * Note: pfb_idn is now adapted via PfbIdnMode (NOT plain-string). See
 	 * testPfbIdnModeAdapterForwardAndBackward() for pfb_idn coverage. alexa_type is
-	 * likewise adapted via Top1mSource (issue #877 review) -- see
+	 * likewise adapted via PfbTop1mSource (issue #877 review) -- see
 	 * testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa() for its coverage.
 	 */
 	public function testForwardPlainStringFieldsPassLegacyTokensUnchanged(): void
@@ -379,8 +379,8 @@ final class RollbackContractTest extends TestCase
 		// Representative plain-string fields with canonical legacy stored values.
 		// pfb_idn is intentionally excluded: it uses the PfbIdnMode adapter (not
 		// null/null) so it returns a PfbIdnMode enum, not a plain string. alexa_type
-		// is likewise excluded: it uses the Top1mSource adapter (not null/null) so
-		// it returns a Top1mSource enum, not a plain string.
+		// is likewise excluded: it uses the PfbTop1mSource adapter (not null/null) so
+		// it returns a PfbTop1mSource enum, not a plain string.
 		$cases = [
 			// General section
 			'pfb_interval'          => ['installedpackages/pfblockerng/config/0/pfb_interval', '1'],
@@ -652,7 +652,7 @@ final class RollbackContractTest extends TestCase
 	 *
 	 * Note: pfb_idn is now adapted via PfbIdnMode (NOT plain-string). See
 	 * testPfbIdnModeAdapterForwardAndBackward() for pfb_idn backward coverage. alexa_type
-	 * is likewise adapted via Top1mSource (issue #877 review) -- see
+	 * is likewise adapted via PfbTop1mSource (issue #877 review) -- see
 	 * testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa() for its coverage.
 	 */
 	public function testBackwardPlainStringFieldsIdentityAdapterCannotIntroduceNovelTokens(): void
@@ -661,7 +661,7 @@ final class RollbackContractTest extends TestCase
 		// which normalises to the canonical vocabulary ('on'|'confusable'|'off') rather
 		// than emitting identity for every input (e.g. the dropped alpha 'all' -> 'off').
 		// See testPfbIdnModeAdapterForwardAndBackward(). alexa_type is likewise excluded:
-		// it uses the Top1mSource write adapter (enum-typed), covered by
+		// it uses the PfbTop1mSource write adapter (enum-typed), covered by
 		// testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa() instead.
 		$cases = [
 			'pfb_interval'      => ['installedpackages/pfblockerng/config/0/pfb_interval', '6'],
@@ -1249,10 +1249,10 @@ final class RollbackContractTest extends TestCase
 	 *     'majestic', 'cloudflare', 'alexa'} (the latter three live tokens added
 	 *     ADR-59 P4/P5; 'alexa' is READ-only -- pfb_cfg_field_vocab()['top1m_source']
 	 *     lists only the five live WRITE-side tokens). The field is now adapted via
-	 *     the Top1mSource enum (mirrors PfbIdnMode/PfbAliasDeltaMode).
+	 *     the PfbTop1mSource enum (mirrors PfbIdnMode/PfbAliasDeltaMode).
 	 *   Given each of 'tranco', 'cisco', 'domcop', 'majestic', 'cloudflare', 'alexa' stored.
 	 *   When PfbConfig::read('alexa_type') then PfbConfig::write('alexa_type', result).
-	 *   Then (FORWARD) the read result is a Top1mSource enum (Tranco for legacy 'alexa').
+	 *   Then (FORWARD) the read result is a PfbTop1mSource enum (Tranco for legacy 'alexa').
 	 *   And (BACKWARD) the written token is in {'tranco', 'cisco', 'domcop', 'majestic',
 	 *     'cloudflare'} -- 'alexa' is NEVER re-emitted, even though it was the original
 	 *     stored value.
@@ -1263,12 +1263,12 @@ final class RollbackContractTest extends TestCase
 		$write_vocab = pfb_cfg_field_vocab()['top1m_source'];
 
 		$cases = [
-			'tranco'     => Top1mSource::Tranco,
-			'cisco'      => Top1mSource::Cisco,
-			'domcop'     => Top1mSource::DomCop,     // ADR-59 P4
-			'majestic'   => Top1mSource::Majestic,   // ADR-59 P4
-			'cloudflare' => Top1mSource::Cloudflare, // ADR-59 P5
-			'alexa'      => Top1mSource::Tranco,     // legacy dead source coalesces to Tranco (#872/#877)
+			'tranco'     => PfbTop1mSource::Tranco,
+			'cisco'      => PfbTop1mSource::Cisco,
+			'domcop'     => PfbTop1mSource::DomCop,     // ADR-59 P4
+			'majestic'   => PfbTop1mSource::Majestic,   // ADR-59 P4
+			'cloudflare' => PfbTop1mSource::Cloudflare, // ADR-59 P5
+			'alexa'      => PfbTop1mSource::Tranco,     // legacy dead source coalesces to Tranco (#872/#877)
 		];
 
 		foreach ($cases as $stored_token => $expected_runtime) {
@@ -1283,8 +1283,8 @@ final class RollbackContractTest extends TestCase
 
 			// FORWARD: read coalesces the legacy token; live tokens pass through.
 			$runtime = PfbConfig::read('alexa_type');
-			$this->assertInstanceOf(Top1mSource::class, $runtime,
-				"FORWARD: alexa_type token='{$stored_token}' must yield a Top1mSource enum"
+			$this->assertInstanceOf(PfbTop1mSource::class, $runtime,
+				"FORWARD: alexa_type token='{$stored_token}' must yield a PfbTop1mSource enum"
 			);
 			$this->assertSame($expected_runtime, $runtime,
 				"FORWARD: alexa_type token='{$stored_token}' must read as {$expected_runtime->name}"

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -400,7 +400,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	/**
 	 * ADR-59 P4 -- pfblockerng_top1m() parses Majestic Million's REAL CSV shape
 	 * (12-col unquoted header, Domain at str_getcsv() index 2) via its registered
-	 * provider descriptor (pfb_top1m_providers()[Top1mSource::Majestic->value]).
+	 * provider descriptor (pfb_top1m_providers()[PfbTop1mSource::Majestic->value]).
 	 * Sample verified against the live downloads.majestic.com/majestic_million.csv
 	 * format (fetched during development of this test).
 	 *
@@ -443,7 +443,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['log'], ''), 'reset main log between runs');
 
 		// When (AFTER): the actual registered Majestic descriptor.
-		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::Majestic->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::Majestic->value]);
 
 		// Then (GREEN): both real domains are correctly extracted from index 2.
 		$this->assertSame(
@@ -502,7 +502,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['log'], ''), 'reset main log between runs');
 
 		// When (AFTER): the actual registered DomCop descriptor.
-		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::DomCop->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::DomCop->value]);
 
 		// Then (GREEN): both real domains are correctly extracted from index 1
 		// ('www.' stripped per the existing whitelist-building convention).
@@ -543,7 +543,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: real-shape Cloudflare Radar sample');
 
 		// When: the actual registered Cloudflare descriptor (domain_col 0, header skipped).
-		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::Cloudflare->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::Cloudflare->value]);
 
 		// Then: both real domains are correctly extracted from the single column despite
 		// carrying no comma -- proves the comma-requirement relaxation for domain_col 0.
@@ -583,7 +583,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 
 		// When: the real registered DomCop descriptor drives the parse (header=TRUE skips
 		// line 1; domain_col=1).
-		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::DomCop->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::DomCop->value]);
 
 		// Then: the HTML body must never be mistaken for real DomCop CSV data -- the prior
 		// whitelist survives byte-identical and the run warns instead of "succeeding".
@@ -607,7 +607,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
 
 		// When: the real registered Majestic descriptor drives the parse.
-		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::Majestic->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::Majestic->value]);
 
 		// Then: the prose "domain" must never be mistaken for real Majestic CSV data.
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
@@ -635,7 +635,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
 
 		// When: the real registered Cloudflare descriptor drives the parse.
-		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::Cloudflare->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::Cloudflare->value]);
 
 		// Then: the JSON error body must never be mistaken for a real Cloudflare domain row.
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
@@ -668,7 +668,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertFileDoesNotExist($this->csvPath(), 'before-state: no top-1m.csv (simulates a failed download)');
 
 		// When: the Cloudflare descriptor is active but top-1m.csv never arrived.
-		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::Cloudflare->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::Cloudflare->value]);
 
 		// Then: the prior whitelist is untouched and a warning was logged (same generic
 		// path as testAbsentCsvPreservesPriorWhitelistAndWarns).
@@ -705,7 +705,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: DomCop-shaped punycode-TLD row');
 
 		// When
-		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::DomCop->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::DomCop->value]);
 
 		// Then: the punycode-TLD row is counted as valid data and whitelisted
 		// -- not silently dropped by the final-label guard.
@@ -735,7 +735,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
 
 		// When
-		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::DomCop->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::DomCop->value]);
 
 		// Then: the numeric-final-label row is still rejected.
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
@@ -764,7 +764,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
 
 		// When
-		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::DomCop->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::DomCop->value]);
 
 		// Then: a dotless Domain field is still rejected even though the line
 		// itself contains a '.' (in another column).
@@ -798,7 +798,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
 
 		// When
-		pfblockerng_top1m(pfb_top1m_providers()[Top1mSource::DomCop->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::DomCop->value]);
 
 		// Then: the malformed punycode-shaped TLD is rejected -- the widening
 		// admits real ACE labels only, not hyphen-runs or truncated prefixes.

--- a/tests/php/Top1mProvidersTest.php
+++ b/tests/php/Top1mProvidersTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
  * token-authenticated Cloudflare Radar provider.
  *
  * Before Phase 1, pfblockerng.php:162 picked the TOP1M download URL with a
- * hardcoded if/else on the Top1mSource enum. Phase 1 moved both provider's
+ * hardcoded if/else on the PfbTop1mSource enum. Phase 1 moved both provider's
  * facts into one descriptor table so pfblockerng.php (and, from Phase 2 on, the
  * parser/extractor) reads a single source of truth. Tranco/Cisco stay
  * BEHAVIOUR-PRESERVING throughout: this oracle pins their resolved URL to the
@@ -30,7 +30,7 @@ final class Top1mProvidersTest extends TestCase
 	{
 		$this->assertSame(
 			'https://tranco-list.eu/top-1m.csv.zip',
-			pfb_top1m_providers()[Top1mSource::Tranco->value]['url'],
+			pfb_top1m_providers()[PfbTop1mSource::Tranco->value]['url'],
 			'tranco TOP1M URL must not drift from the pre-ADR-59 literal'
 		);
 	}
@@ -40,7 +40,7 @@ final class Top1mProvidersTest extends TestCase
 	{
 		$this->assertSame(
 			'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip',
-			pfb_top1m_providers()[Top1mSource::Cisco->value]['url'],
+			pfb_top1m_providers()[PfbTop1mSource::Cisco->value]['url'],
 			'cisco TOP1M URL must not drift from the pre-ADR-59 literal'
 		);
 	}
@@ -50,11 +50,11 @@ final class Top1mProvidersTest extends TestCase
 	{
 		$this->assertSame(
 			'https://www.domcop.com/files/top/top10milliondomains.csv.zip',
-			pfb_top1m_providers()[Top1mSource::DomCop->value]['url']
+			pfb_top1m_providers()[PfbTop1mSource::DomCop->value]['url']
 		);
 		$this->assertSame(
 			'https://downloads.majestic.com/majestic_million.csv',
-			pfb_top1m_providers()[Top1mSource::Majestic->value]['url']
+			pfb_top1m_providers()[PfbTop1mSource::Majestic->value]['url']
 		);
 	}
 
@@ -74,7 +74,7 @@ final class Top1mProvidersTest extends TestCase
 	 */
 	public function testTrancoAndCiscoDescribeTodaysZipRankDomainNoAuthShape(): void
 	{
-		foreach ([Top1mSource::Tranco->value, Top1mSource::Cisco->value] as $id) {
+		foreach ([PfbTop1mSource::Tranco->value, PfbTop1mSource::Cisco->value] as $id) {
 			$descriptor = pfb_top1m_providers()[$id];
 			$this->assertSame('zip', $descriptor['container'], "{$id}: container must be zip");
 			$this->assertSame('rank_domain', $descriptor['parse'], "{$id}: parse must be rank_domain");
@@ -91,14 +91,14 @@ final class Top1mProvidersTest extends TestCase
 	 */
 	public function testDomCopAndMajesticDescribeTheirOwnCsvShape(): void
 	{
-		$domcop = pfb_top1m_providers()[Top1mSource::DomCop->value];
+		$domcop = pfb_top1m_providers()[PfbTop1mSource::DomCop->value];
 		$this->assertSame('zip', $domcop['container'], 'domcop: container must be zip');
 		$this->assertSame('csv', $domcop['parse'], 'domcop: parse must be csv');
 		$this->assertTrue($domcop['header'], 'domcop: header row must be skipped');
 		$this->assertSame(1, $domcop['domain_col'], 'domcop: Domain is the 2nd CSV field -> index 1');
 		$this->assertSame('none', $domcop['auth'], 'domcop: auth must be none');
 
-		$majestic = pfb_top1m_providers()[Top1mSource::Majestic->value];
+		$majestic = pfb_top1m_providers()[PfbTop1mSource::Majestic->value];
 		$this->assertSame('plain', $majestic['container'], 'majestic: container must be plain (uncompressed)');
 		$this->assertSame('csv', $majestic['parse'], 'majestic: parse must be csv');
 		$this->assertTrue($majestic['header'], 'majestic: header row must be skipped');
@@ -116,7 +116,7 @@ final class Top1mProvidersTest extends TestCase
 	 */
 	public function testCloudflareDescribesItsRealSingleColumnAuthedCsvShape(): void
 	{
-		$cloudflare = pfb_top1m_providers()[Top1mSource::Cloudflare->value];
+		$cloudflare = pfb_top1m_providers()[PfbTop1mSource::Cloudflare->value];
 		$this->assertSame(
 			'https://api.cloudflare.com/client/v4/radar/datasets/ranking_top_1000000',
 			$cloudflare['url'],

--- a/tests/test_check_top1m_providers.py
+++ b/tests/test_check_top1m_providers.py
@@ -55,26 +55,26 @@ _PHP_DESCRIPTOR_TABLE = """
 function pfb_top1m_providers(): array
 {
 	return array(
-		Top1mSource::Tranco->value	=> array(
+		PfbTop1mSource::Tranco->value	=> array(
 			'url'		=> 'https://tranco-list.eu/top-1m.csv.zip',
 			'container'	=> 'zip',
 			'auth'		=> 'none',
 			'label'		=> 'Tranco',
 		),
-		Top1mSource::Cisco->value	=> array(
+		PfbTop1mSource::Cisco->value	=> array(
 			'url'		=> 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip',
 			'container'	=> 'zip',
 			'auth'		=> 'none',
 			'label'		=> 'Cisco Umbrella',
 		),
-		Top1mSource::Majestic->value	=> array(
+		PfbTop1mSource::Majestic->value	=> array(
 			'url'		=> 'https://downloads.majestic.com/majestic_million.csv',
 			'container'	=> 'plain',
 			'auth'		=> 'none',
 			'label'		=> 'Majestic Million',
 			'licence'	=> 'CC BY 3.0 -- attribution required',
 		),
-		Top1mSource::Cloudflare->value	=> array(
+		PfbTop1mSource::Cloudflare->value	=> array(
 			'url'		=> 'https://api.cloudflare.com/client/v4/radar/datasets/ranking_top_1000000',
 			'container'	=> 'plain',
 			'auth'		=> array('header' => 'Authorization', 'scheme' => 'Bearer'),
@@ -132,31 +132,31 @@ _PHP_DESCRIPTOR_TABLE_WITH_A_FIFTH_ROW = """
 function pfb_top1m_providers(): array
 {
 	return array(
-		Top1mSource::Tranco->value	=> array(
+		PfbTop1mSource::Tranco->value	=> array(
 			'url'		=> 'https://tranco-list.eu/top-1m.csv.zip',
 			'container'	=> 'zip',
 			'auth'		=> 'none',
 			'label'		=> 'Tranco',
 		),
-		Top1mSource::Cisco->value	=> array(
+		PfbTop1mSource::Cisco->value	=> array(
 			'url'		=> 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip',
 			'container'	=> 'zip',
 			'auth'		=> 'none',
 			'label'		=> 'Cisco Umbrella',
 		),
-		Top1mSource::Majestic->value	=> array(
+		PfbTop1mSource::Majestic->value	=> array(
 			'url'		=> 'https://downloads.majestic.com/majestic_million.csv',
 			'container'	=> 'plain',
 			'auth'		=> 'none',
 			'label'		=> 'Majestic Million',
 		),
-		Top1mSource::Cloudflare->value	=> array(
+		PfbTop1mSource::Cloudflare->value	=> array(
 			'url'		=> 'https://api.cloudflare.com/client/v4/radar/datasets/ranking_top_1000000',
 			'container'	=> 'plain',
 			'auth'		=> array('header' => 'Authorization', 'scheme' => 'Bearer'),
 			'label'		=> 'Cloudflare Radar',
 		),
-		Top1mSource::Quad9->value	=> array(
+		PfbTop1mSource::Quad9->value	=> array(
 			'url'		=> 'https://example-quad9.test/top-1m.csv.zip',
 			'container'	=> 'zip',
 			'auth'		=> 'none',
@@ -182,8 +182,8 @@ _PHP_WITH_A_COMMENTED_OUT_ROW = """
 function pfb_top1m_providers(): array
 {
 	return array(
-		// Top1mSource::Dead->value	=> array('url' => 'https://dead.test/x.zip', 'auth' => 'none', 'label' => 'Dead'),
-		Top1mSource::Tranco->value	=> array(
+		// PfbTop1mSource::Dead->value	=> array('url' => 'https://dead.test/x', 'auth' => 'none', 'label' => 'Dead'),
+		PfbTop1mSource::Tranco->value	=> array(
 			'url'		=> 'https://tranco-list.eu/top-1m.csv.zip',
 			'container'	=> 'zip',
 			'auth'		=> 'none',
@@ -204,7 +204,7 @@ _PHP_ONE_PROVIDER_NO_LABEL_NO_CONTAINER = """
 function pfb_top1m_providers(): array
 {
 	return array(
-		Top1mSource::Tranco->value	=> array(
+		PfbTop1mSource::Tranco->value	=> array(
 			'url'	=> 'https://tranco-list.eu/top-1m.csv.zip',
 			'auth'	=> 'none',
 		),
@@ -264,14 +264,14 @@ _PHP_DESCRIPTOR_TABLE_WITH_AN_UNBALANCED_PAREN_IN_A_LABEL = """
 function pfb_top1m_providers(): array
 {
 	return array(
-		Top1mSource::Tranco->value	=> array(
+		PfbTop1mSource::Tranco->value	=> array(
 			'url'		=> 'https://tranco-list.eu/top-1m.csv.zip',
 			'container'	=> 'zip',
 			'auth'		=> 'none',
 			'label'		=> 'Tranco Mirror (EU))',
 			'licence'	=> 'CC0',
 		),
-		Top1mSource::Cisco->value	=> array(
+		PfbTop1mSource::Cisco->value	=> array(
 			'url'		=> 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip',
 			'container'	=> 'zip',
 			'auth'		=> 'none',


### PR DESCRIPTION
## What

Mechanical rename `Top1mSource` → `PfbTop1mSource` across all 13 referencing files (src PHP, PHP test suites, the Top1M health-check extractor + its tests, and the two docs pages). Every sibling stored enum in `pfblockerng_extra.inc` carries the `Pfb` prefix (`PfbToggle`, `PfbLenient`, `PfbIdnMode`, `PfbAliasDeltaMode`); this one was the outlier (introduced by #882).

Behaviour-preserving refactor — per the test mandate's refactor exception, the existing suites are the oracle (no red→green): the config round-trip/rollback/parity suites and the extractor's real-file test all pin the behaviour across the rename. One fixture URL in `tests/test_check_top1m_providers.py` shortened (`x.zip` → `x`) to keep the renamed comment line under the 120-column limit.

## Gates

- `vendor/bin/phpunit`: 2342 tests, 18632 assertions, green (4 pre-existing platform skips)
- `vendor/bin/phpstan analyse --memory-limit=1G`: no errors
- `vendor/bin/phpcs --standard=phpcs.xml.dist src/`: clean
- `php -l` on all three changed src files: clean
- `python3 -m pytest`: 2213 passed, 4 skipped (pre-existing)
- `ruff check` + `ruff format --check`: clean
- `markdownlint-cli2` on the two docs: 0 errors

Fixes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)