### PR TITLE
scripts: reject nodeids with tabs/consecutive spaces at shard-table ingest

### DIFF
--- a/scripts/shard-modules.sh
+++ b/scripts/shard-modules.sh
@@ -183,6 +183,11 @@ if [ -f "$durfile" ]; then
 	# reader fix); only a TAB or a run of 2+ spaces is hostile. One guard
 	# here, at first read of the table, so every stage after it inherits it
 	# -- checked on the RAW line, before any split collapses the evidence.
+	# PERMANENT format limitation, not a style rule: the '<key> <weight>'
+	# single-space-joined table format cannot round-trip a nodeid with a real
+	# run of 2+ spaces (pytest permits one via parametrize string values), so
+	# rejecting loudly here is the only correct behaviour. If a real test ever
+	# hits this, give it a single-token ids= override in its parametrize.
 	LC_ALL=C awk '
 		/^[ \t]*#/ || /^[ \t]*$/ { next }
 		index($0, "\t") {

--- a/scripts/shard-modules.sh
+++ b/scripts/shard-modules.sh
@@ -170,6 +170,31 @@ module_count="$#"
 durfile="${SHARD_DURATIONS_FILE:-${dir}/module-durations.txt}"
 
 if [ -f "$durfile" ]; then
+	# Reject a hostile row before it's ever parsed (issue #907, latent found
+	# reviewing #861): the table reader below (stage 1's awk BEGIN block)
+	# rebuilds a row's key via awk's DEFAULT field split, which COLLAPSES any
+	# run of whitespace -- a nodeid containing a TAB or two-plus consecutive
+	# spaces silently reconstructs to the WRONG key. That produces either a
+	# never-matching `--deselect` (the test then double-runs across shards)
+	# or a nonexistent bare node ID (pytest exit 4 on that shard) -- a
+	# confusing downstream failure instead of a pointed one. A single space
+	# is fine and expected (a parametrized nodeid's own bracket text, e.g.
+	# `test_foo[hello world]`, round-trips correctly -- see the #861 table
+	# reader fix); only a TAB or a run of 2+ spaces is hostile. One guard
+	# here, at first read of the table, so every stage after it inherits it
+	# -- checked on the RAW line, before any split collapses the evidence.
+	LC_ALL=C awk '
+		/^[ \t]*#/ || /^[ \t]*$/ { next }
+		index($0, "\t") {
+			printf "shard-modules: duration-table row has an embedded TAB, would corrupt the nodeid key: %s\n", $0 > "/dev/stderr"
+			exit 1
+		}
+		index($0, "  ") {
+			printf "shard-modules: duration-table row has consecutive spaces, would corrupt the nodeid key: %s\n", $0 > "/dev/stderr"
+			exit 1
+		}
+	' "$durfile"
+
 	# Hybrid duration-balanced greedy LPT (issue #855, extending #816) — see
 	# the header for the full rule. Three stages:
 	#

--- a/tests/shell/shard_modules_spec.sh
+++ b/tests/shell/shard_modules_spec.sh
@@ -675,4 +675,56 @@ ${fixture_dir}/test_e.py"
       The output should equal "$baseline"
     End
   End
+
+  Describe 'hostile duration-table row rejected loudly (issue #907, latent found reviewing #861)'
+    # Stage 1's awk BEGIN block reconstructs a row's key via awk's DEFAULT
+    # field split, which collapses any whitespace run -- a nodeid with an
+    # embedded TAB or consecutive spaces silently reconstructs to the WRONG
+    # key (never matches the real pytest nodeid), producing either a
+    # never-matching --deselect (double-run) or a nonexistent bare node ID
+    # (pytest exit 4) downstream. Pinned here at the point the row is first
+    # read, per CLAUDE.md's root-cause-not-symptom rule.
+    #
+    # RED->GREEN evidence (#907): the two rejection examples below were run
+    # against the PRE-fix script (the guard block removed, `git stash` on
+    # scripts/shard-modules.sh only) and FAILED both ("The status should be
+    # failure" -- the pre-fix script silently exits 0 with a corrupted
+    # split instead of erroring). After adding the guard, both pass with no
+    # other change to this file. The control example stayed green
+    # throughout (single-space nodeids were never broken), proving the
+    # guard doesn't regress the legitimate #861 case.
+    write_table() {
+      : > "${fixture_dir}/module-durations.txt"
+      for line in "$@"; do
+        printf '%s\n' "$line" >> "${fixture_dir}/module-durations.txt"
+      done
+    }
+
+    It 'rejects a row whose nodeid has an embedded TAB, naming the offending row'
+      tab="$(printf '\t')"
+      write_table 'test_a.py 100.00' "test_a.py::test_foo[hello${tab}world] 40.00" \
+        'test_b.py 5.00'
+      When run shard 0 2
+      The status should be failure
+      The stderr should include 'TAB'
+      The stderr should include 'test_a.py::test_foo[hello'
+    End
+
+    It 'rejects a row whose nodeid has consecutive spaces, naming the offending row'
+      write_table 'test_a.py 100.00' 'test_a.py::test_foo[hello  world] 40.00' \
+        'test_b.py 5.00'
+      When run shard 0 2
+      The status should be failure
+      The stderr should include 'consecutive spaces'
+      The stderr should include 'test_a.py::test_foo[hello'
+    End
+
+    It 'does not reject a normal single-space parametrized nodeid (control case)'
+      write_table 'test_a.py 100.00' 'test_a.py::test_foo[hello world] 40.00' \
+        'test_b.py 5.00'
+      When call shard 0 2
+      The status should be success
+      The output should equal "${fixture_dir}/test_a.py"
+    End
+  End
 End

--- a/tests/test_shard_union.py
+++ b/tests/test_shard_union.py
@@ -295,3 +295,29 @@ def test_committed_table_has_no_prefix_blind_spot(oracle_ids: set[str]) -> None:
     in-tree test_cron_detects_changed_local_feed / ..._same_second pair is exactly
     this shape)."""
     _assert_committed_table_has_no_prefix_blind_spot(_COMMITTED_DURATIONS_FILE, oracle_ids)
+
+
+def _assert_committed_table_has_no_hostile_whitespace(table_path: Path) -> None:
+    """No row may carry an embedded TAB or consecutive spaces -- checked on the RAW
+    line (never via _parse_duration_table, whose own rsplit(None, 1) collapses that
+    same whitespace and would hide the very corruption being checked for)."""
+    hostile = [
+        (lineno, raw_line)
+        for lineno, raw_line in enumerate(table_path.read_text().splitlines(), start=1)
+        if raw_line.strip() and not raw_line.strip().startswith("#") and ("\t" in raw_line or "  " in raw_line)
+    ]
+    assert not hostile, (
+        f"duration-table row(s) with an embedded TAB or consecutive spaces in {table_path} -- "
+        f"scripts/shard-modules.sh's whitespace-collapsing table reader would reconstruct the "
+        f"WRONG key from these (issue #907).\n"
+        f"  row(s): {hostile}"
+    )
+
+
+def test_committed_table_has_no_hostile_whitespace_keys() -> None:
+    """The COMMITTED tests/smoke/module-durations.txt must never carry a nodeid with
+    an embedded TAB or consecutive spaces -- shard-modules.sh's table reader collapses
+    that whitespace when rebuilding the row's key, producing a never-matching
+    --deselect (double-run) or a nonexistent bare node ID (pytest exit 4) on some
+    shard (issue #907, latent -- defensive pin on the committed data)."""
+    _assert_committed_table_has_no_hostile_whitespace(_COMMITTED_DURATIONS_FILE)


### PR DESCRIPTION
## Summary

`scripts/shard-modules.sh`'s duration-balanced LPT table reader rebuilds a row's key by splitting the raw line on whitespace and rejoining every field but the last (the weight) with single spaces. awk's default field split **collapses** any run of whitespace, so a parametrized pytest nodeid carrying an embedded TAB or two-plus consecutive spaces silently reconstructs to the **wrong** key — a string that matches no real pytest nodeid.

Two ways that manifests downstream, both confusing rather than pointed:

- The corrupted key is used to build a `--deselect <nodeid>` pair on the carrier shard for an oversized module's test → the deselect never matches the real nodeid, so the test **double-runs** across shards.
- The corrupted key is emitted as a bare positional nodeid on its assigned shard → pytest can't collect it, and the shard fails with **exit 4**.

This is currently latent — no committed nodeid contains a TAB or consecutive spaces — but nothing stopped a future one from silently tripping it.

## Fix

Root-cause placement: one guard where duration-table rows are first read (`scripts/shard-modules.sh`, top of the `durfile`-present branch), before the row-key reconstruction happens — not a patch per downstream stage. It runs as its own awk pass over the raw table (not nested inside the existing multi-stage pipe, so its exit status reaches `set -eu` directly) and:

- Skips comment/blank lines exactly like the existing table reader.
- Rejects any row containing a TAB or two-plus consecutive spaces, printing the offending row to stderr and exiting non-zero.
- Leaves a single space legal — a parametrized nodeid's own bracket text (e.g. `test_foo[hello world]`) still round-trips correctly per the existing #861 table-parser fix.

Also added a defensive pin on the Python side (`tests/test_shard_union.py`): the **committed** `tests/smoke/module-durations.txt` must never carry such a row, checked on the raw line (not via the existing `_parse_duration_table` helper, whose own `rsplit(None, 1)` collapses the same whitespace and would hide the corruption).

## Test plan

- [x] `tests/shell/shard_modules_spec.sh`: new `Describe` block adds an embedded-TAB case, a consecutive-spaces case, and a control case (a normal single-space parametrized nodeid still works, unchanged).
- [x] Red-before-green verified by hand: with the guard temporarily removed (`git stash` on `scripts/shard-modules.sh` only), both rejection examples failed — the pre-fix script silently exits 0 with a corrupted split instead of erroring, exactly the latent defect described in #907. Restoring the fix turns both green with no other change to the spec file.
- [x] Full `shellspec` suite green (379 examples, 0 failures, 8 environment-gated skips unrelated to this change).
- [x] `shellcheck scripts/shard-modules.sh` clean; `sh -n scripts/shard-modules.sh` clean.
- [x] `python -m pytest` green (2214 passed, 4 skipped), including the new `test_committed_table_has_no_hostile_whitespace_keys`.
- [x] `ruff check` / `ruff format --check` / `mypy tests/` clean.

Fixes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)