### PR TITLE
ci: string-aware paren matching + full-set discover floor in the Top1M health-check

### DIFF
--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -44,9 +44,14 @@ jobs:
           echo "Discovered providers:"
           printf '%s\n' "$MATRIX" | python3 -m json.tool
 
-          # Floor guard: a broken extractor returning an empty/near-empty
-          # matrix would run 0 (or too few) legs and still exit green --
-          # the exact silent death this watchdog exists to catch (#884 review).
+          # The real floor guard lives in check_top1m_providers.py --extract
+          # itself (--min-providers, default: the committed provider count,
+          # #908) -- a too-small matrix already made `set -eu` abort this
+          # step at the `MATRIX=$(...)` line above with a non-zero exit, so a
+          # partial extractor breakage never reaches this point. This is a
+          # secondary belt-and-suspenders check for a literal zero/empty
+          # matrix (the exact silent death this watchdog exists to catch,
+          # #884 review).
           COUNT=$(jq 'length' <<<"$MATRIX")
           [ "$COUNT" -ge 1 ] || { echo "::error::no top1m providers discovered -- extractor may be broken"; exit 1; }
 

--- a/scripts/misc/check_top1m_providers.py
+++ b/scripts/misc/check_top1m_providers.py
@@ -23,7 +23,10 @@ Two modes:
                        to stdout (name/url/container/auth/secret_env/
                        auth_header/auth_scheme). Feeds the workflow's
                        matrix -- add/remove a descriptor row and this picks
-                       it up with no edit here.
+                       it up with no edit here. Fails (non-zero, no stdout)
+                       if fewer than --min-providers (default: the committed
+                       count) are discovered -- catches a partial extractor
+                       breakage silently dropping providers (#908).
   --check-url <url>   Fetch + validate one URL. Prints an expected-vs-actual
                        report. Exit 0 = healthy (or visibly skipped for a
                        token provider with no configured secret), non-zero
@@ -65,6 +68,13 @@ MAX_AGE_DAYS = 180
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_DESCRIPTOR_FILE = REPO_ROOT / "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 
+# --extract's floor (#908): the committed provider count in
+# pfb_top1m_providers() (Tranco/Cisco/DomCop/Majestic/Cloudflare). A partial
+# extractor breakage that silently drops a provider must fail loud here
+# rather than pass a too-small matrix on to the workflow. Bump this whenever
+# a row is added to or removed from that descriptor table.
+MIN_PROVIDERS = 5
+
 # Matches "Top1mSource::<Case>->value => array(" -- the start of one provider's
 # descriptor block in pfb_top1m_providers()'s return array. Unique to that
 # table (grepped): every other `->value` use in the file is `$this->value`
@@ -95,15 +105,33 @@ def _strip_php_line_comments(php_text: str) -> str:
 
 
 def _matching_paren(text: str, open_idx: int) -> int:
-    """Index of the ')' that balances the '(' at text[open_idx]."""
+    """Index of the ')' that balances the '(' at text[open_idx].
+
+    String-literal-aware (#908): skips over single- and double-quoted spans
+    (backslash-escaping the quote char) while counting, so a `(`/`)` inside a
+    provider's 'label'/'licence'/'url' string doesn't unbalance the count and
+    truncate or over-extend the parsed block.
+    """
     depth = 0
-    for i in range(open_idx, len(text)):
-        if text[i] == "(":
+    quote: str | None = None
+    i = open_idx
+    while i < len(text):
+        ch = text[i]
+        if quote is not None:
+            if ch == "\\":
+                i += 2  # skip the escaped char -- it can't end the string
+                continue
+            if ch == quote:
+                quote = None
+        elif ch in ("'", '"'):
+            quote = ch
+        elif ch == "(":
             depth += 1
-        elif text[i] == ")":
+        elif ch == ")":
             depth -= 1
             if depth == 0:
                 return i
+        i += 1
     raise ValueError("unbalanced parentheses scanning a provider descriptor block")
 
 
@@ -351,6 +379,13 @@ def main(argv: list[str] | None = None) -> int:
     group.add_argument("--extract", action="store_true", help="print every top1m provider as JSON")
     group.add_argument("--check-url", metavar="URL", help="fetch + validate one provider URL")
     parser.add_argument(
+        "--min-providers",
+        type=int,
+        default=MIN_PROVIDERS,
+        metavar="N",
+        help=f"--extract: fail if fewer than N providers are discovered (default: {MIN_PROVIDERS})",
+    )
+    parser.add_argument(
         "--container", choices=("zip", "plain"), default="zip", help="--check-url's body shape (default: zip)"
     )
     parser.add_argument(
@@ -365,6 +400,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.extract:
         providers = extract_providers(DEFAULT_DESCRIPTOR_FILE.read_text(encoding="utf-8"))
+        if len(providers) < args.min_providers:
+            print(
+                f"expected >= {args.min_providers} providers from {DEFAULT_DESCRIPTOR_FILE}, "
+                f"found {len(providers)} -- extractor may be broken",
+                file=sys.stderr,
+            )
+            return 1
         print(json.dumps(providers))
         return 0
 

--- a/tests/test_check_top1m_providers.py
+++ b/tests/test_check_top1m_providers.py
@@ -26,6 +26,7 @@ import csv
 import http.client
 import importlib.util
 import io
+import json
 import sys
 import urllib.error
 import zipfile
@@ -239,8 +240,77 @@ def test_extract_providers_reads_the_real_descriptor_file_and_finds_all_five() -
 
 
 # --------------------------------------------------------------------------- #
-# validate_top1m / _scan_csv -- in-memory zips + plain bodies, no network
+# _matching_paren -- string-literal-aware paren counting (issue #908)
 # --------------------------------------------------------------------------- #
+
+# A 'label' with an unbalanced ')' inside the string (one '(', two ')') --
+# the current table is paren-free, but a future provider naming its mirror
+# "Tranco Mirror (EU))" (or any label/licence containing a stray paren) must
+# not confuse the block-boundary scanner.
+#
+# FAIL-BEFORE/PASS-AFTER (#908): pre-fix, the naive char-counting
+# `_matching_paren` treats every '(' / ')' in the raw text as real -- the
+# extra ')' inside this label makes its depth hit 0 one field early, cutting
+# the provider's block off mid-string (before the closing quote). The
+# resulting truncated block has no closing `'` for 'label' to match, so
+# `_LABEL_FIELD_RE` fails to match at all and the provider silently falls
+# back to its URL's netloc ("tranco-list.eu") instead of the real label --
+# confirmed against pre-fix code (`git stash`): the assertion below FAILS,
+# `providers["Tranco Mirror (EU))"]` is absent (KeyError) because the name
+# came out as "tranco-list.eu" instead. Post-fix, the scanner never leaves
+# the quoted span for those parens, so the real closing paren is found and
+# every field (url/container/auth/label) survives intact.
+_PHP_DESCRIPTOR_TABLE_WITH_AN_UNBALANCED_PAREN_IN_A_LABEL = """
+function pfb_top1m_providers(): array
+{
+	return array(
+		Top1mSource::Tranco->value	=> array(
+			'url'		=> 'https://tranco-list.eu/top-1m.csv.zip',
+			'container'	=> 'zip',
+			'auth'		=> 'none',
+			'label'		=> 'Tranco Mirror (EU))',
+			'licence'	=> 'CC0',
+		),
+		Top1mSource::Cisco->value	=> array(
+			'url'		=> 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip',
+			'container'	=> 'zip',
+			'auth'		=> 'none',
+			'label'		=> 'Cisco Umbrella',
+			'licence'	=> 'proprietary',
+		),
+	);
+}
+"""
+
+
+def test_extract_providers_handles_an_unbalanced_paren_inside_a_label_string() -> None:
+    providers = {p["name"]: p for p in ctp.extract_providers(_PHP_DESCRIPTOR_TABLE_WITH_AN_UNBALANCED_PAREN_IN_A_LABEL)}
+    assert set(providers) == {"Tranco Mirror (EU))", "Cisco Umbrella"}
+
+    tranco = providers["Tranco Mirror (EU))"]
+    assert tranco["url"] == "https://tranco-list.eu/top-1m.csv.zip"
+    assert tranco["container"] == "zip"
+    assert tranco["auth"] == "none"
+
+    # The block boundary must not have leaked into Cisco's row either.
+    cisco = providers["Cisco Umbrella"]
+    assert cisco["url"] == "https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip"
+
+
+def test_matching_paren_treats_a_backslash_escaped_quote_as_not_ending_the_string() -> None:
+    # FAIL-BEFORE/PASS-AFTER (#908): the literal PHP string is  Rob's)  -- an
+    # escaped quote (\\') followed by a stray, unmatched ')' still inside the
+    # quotes. Pre-fix (no quote-awareness at all), the scanner reads every
+    # character literally: it hits the escaped "'" and treats it as a normal
+    # char (no effect), but then the following genuine ')' balances the
+    # opening '(' and returns index 13 -- the ')' INSIDE the string, not the
+    # array's real closing paren at index 23 (confirmed against pre-fix code
+    # via `git stash`). Post-fix, the scanner recognizes `\'` as an escaped
+    # quote that keeps the string open, so the stray ')' is skipped and the
+    # true closing paren (index 23) is returned.
+    text = r"""array('Rob\'s)', 'more')"""
+    open_idx = text.index("(")
+    assert ctp._matching_paren(text, open_idx) == len(text) - 1 == 23
 
 
 def _zip_of(rows: list[tuple[str, ...]], member: str = "top-1m.csv") -> bytes:
@@ -663,3 +733,41 @@ def test_main_never_prints_the_token_on_an_unhealthy_token_provider_result(monke
     assert code != 0
     out = capsys.readouterr().out
     assert "mock-token-value" not in out
+
+
+# --------------------------------------------------------------------------- #
+# main --extract -- the --min-providers floor (issue #908 defect 2): a
+# partial extractor breakage silently dropping providers must FAIL, not pass
+# a too-small matrix on to the workflow.
+# --------------------------------------------------------------------------- #
+
+
+def test_main_extract_fails_when_discovered_providers_are_below_the_floor(monkeypatch: Any, capsys: Any) -> None:
+    # Before-state below pairs with the at-floor pass test right after it --
+    # together they prove the count, not something else, drives the verdict.
+    monkeypatch.setattr(ctp, "extract_providers", lambda _text: [{"name": "Only One"}])
+    code = ctp.main(["--extract", "--min-providers", "2"])
+    assert code != 0
+    err = capsys.readouterr().err
+    assert "expected >= 2" in err
+    assert "found 1" in err
+
+
+def test_main_extract_passes_when_discovered_providers_meet_the_floor(monkeypatch: Any, capsys: Any) -> None:
+    fake_providers = [{"name": "One"}, {"name": "Two"}]
+    monkeypatch.setattr(ctp, "extract_providers", lambda _text: fake_providers)
+    code = ctp.main(["--extract", "--min-providers", "2"])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert json.loads(out) == fake_providers
+
+
+def test_main_extract_default_min_providers_matches_the_real_descriptor_file() -> None:
+    # Regression guard: the default floor (MIN_PROVIDERS) must equal the
+    # ACTUAL committed provider count, else either a legitimate table would
+    # spuriously fail this gate, or the floor would silently tolerate a
+    # dropped provider. Pairs with
+    # test_extract_providers_reads_the_real_descriptor_file_and_finds_all_five
+    # -- both must move together whenever a provider is added/removed.
+    real_count = len(ctp.extract_providers(ctp.DEFAULT_DESCRIPTOR_FILE.read_text(encoding="utf-8")))
+    assert ctp.MIN_PROVIDERS == real_count


### PR DESCRIPTION
## Summary

`scripts/misc/check_top1m_providers.py` (PRs #885/#892) extracts the Top1M provider descriptor table from `pfblockerng_extra.inc` for the weekly `top1m-healthcheck.yml` workflow. Two latent defects (the current descriptor table is paren-free, so neither had triggered yet):

1. **`_matching_paren` counted parens inside PHP string literals.** A provider whose `label`/`licence`/`url` contains `(` or `)` could truncate or over-extend its parsed block — e.g. a label with a stray `)` cut the block off before its own closing quote, so the field regex silently fell back to the URL's netloc instead of the real label. Fixed by making the scanner string-literal-aware: it now tracks single-/double-quoted spans (with backslash-escape handling for the quote char) and ignores parens inside them.
2. **The workflow's discover floor was `>= 1`.** A partial extractor breakage dropping 4 of 5 providers still passed the guard whose comment claims to catch "too few providers discovered." Fixed by giving `--extract` a `--min-providers N` option (default: the committed provider count, currently 5, with a bump-on-new-provider comment at the constant) that fails loud — before printing anything to stdout — when the discovered count drops below it. The workflow's own `MATRIX=$(...)` assignment already aborts the step under `set -eu` when the checker exits non-zero, so the pre-existing `jq`-based `>= 1` check is now a secondary belt-and-suspenders guard for a literal empty matrix; its comment was updated to say so.

## Red-before-green evidence

Ran the new/changed tests against the pre-fix code (`git stash` the script + workflow, keep the tests) to confirm each fails for the exact reason the fix addresses, then restored:

```text
FAILED test_extract_providers_handles_an_unbalanced_paren_inside_a_label_string
  - AssertionError: assert {'tranco-list.eu', 'Cisco Umbrella'} == {'Tranco Mirror (EU))', 'Cisco Umbrella'}
FAILED test_matching_paren_treats_a_backslash_escaped_quote_as_not_ending_the_string
  - assert 13 == (24 - 1)   # stray ')' inside the string mistaken for the array's real close
FAILED test_main_extract_fails_when_discovered_providers_are_below_the_floor
  - SystemExit: 2   # --min-providers doesn't exist yet
FAILED test_main_extract_passes_when_discovered_providers_meet_the_floor
  - SystemExit: 2
FAILED test_main_extract_default_min_providers_matches_the_real_descriptor_file
  - AttributeError: module 'check_top1m_providers' has no attribute 'MIN_PROVIDERS'
5 failed, 35 passed
```

All 40 tests in `tests/test_check_top1m_providers.py` pass post-fix; the full suite (2218 tests) is green.

## Test plan

- [x] `python -m pytest` — 2218 passed, 4 skipped
- [x] Red-before-green: 5 new/changed tests fail pre-fix (see above), pass post-fix
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `python -m mypy tests/` clean
- [x] YAML parses (`.github/workflows/top1m-healthcheck.yml`)

Fixes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)