### PR TITLE
tests: harden smoke helpers — grep faults raise, exact licence assertion, stale comment (#909)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -120,7 +120,7 @@ on:
         required: false
         type: string
         default: "3"
-  # Daily nightly run — runs the full CE suite every night.
+  # Daily nightly run — scope=full: the whole marker on every ci:true leg (CE + Plus).
   schedule:
     - cron: "0 7 * * *"
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -811,14 +811,22 @@ def php_ini_int(vm: SmokeVM, key: str, *, timeout: float = 30.0) -> int:
 def guest_file_contains(vm: SmokeVM, path: str, needle: str, *, timeout: float = 30.0) -> bool:
     """True iff the guest file at ``path`` contains the fixed string ``needle`` (``grep -F -q``).
 
-    grep exits 0 (match) / 1 (no match, including a not-yet-created log) / >1 (other). Only an
-    ssh transport failure (rc 255) is a real read fault worth raising — mirror PhpErrorLogGuard:
-    a missing file legitimately means "does not contain needle", so 1 and 2 both read as absent.
+    A missing file (e.g. a not-yet-created log) legitimately reads as "does not contain":
+    the existence pre-check maps it to rc 1 before grep runs. Any OTHER failure — an
+    unreadable file (grep rc 2) or an ssh transport fault (rc 255) — raises instead of
+    reading as absent, so a negative assertion (``assert not guest_file_contains(...)``)
+    can never pass vacuously on a file that was never actually read (issue #909).
     """
-    res = vm.ssh("/usr/bin/grep", "-F", "-q", "--", needle, path, timeout=timeout)
-    if res.returncode == 255:
-        raise RuntimeError(f"ssh failed grepping guest {path!r}: {(res.stderr or res.stdout).strip()!r}")
-    return res.returncode == 0
+    probe = f"[ -e {shlex.quote(path)} ] || exit 1; /usr/bin/grep -F -q -- {shlex.quote(needle)} {shlex.quote(path)}"
+    res = vm.ssh(probe, timeout=timeout)
+    if res.returncode == 0:
+        return True
+    if res.returncode == 1:
+        return False
+    raise RuntimeError(
+        f"grep on guest {path!r} failed rc={res.returncode} (0=match/1=absent expected): "
+        f"{(res.stderr or res.stdout).strip()!r}"
+    )
 
 
 _FPM_PROBE_FILE = "/usr/local/www/pfb_smoke_er_probe.php"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -683,7 +683,9 @@ def test_dnsbl_top1m_source_options_exclude_alexa(webui: WebUI, php_error_log_gu
     # and "3.0" are also individually satisfied by Cloudflare's "(CC BY-NC) 4.0" note, so
     # this would pass even if Majestic's own note vanished.
     assert "(CC BY) 3.0" in body, "DNSBL page is missing the Majestic (CC BY) 3.0 attribution note"
-    assert "CC BY-NC" in body and "4.0" in body, "DNSBL page is missing the Cloudflare CC BY-NC 4.0 attribution note"
+    # Exact form, like Majestic's above (#909): the split "CC BY-NC" + "4.0" pair was
+    # satisfiable by any unrelated "4.0" elsewhere in the page body.
+    assert "(CC BY-NC) 4.0" in body, "DNSBL page is missing the Cloudflare (CC BY-NC) 4.0 attribution note"
     assert 'name="top1m_token"' in body, "DNSBL page is missing the top1m_token field"
     assert 'type="password"' in body, "DNSBL page's top1m_token field must be masked (type=password)"
     for absent in ("Alexa TOP1M", 'value="alexa"'):

--- a/tests/test_guest_file_contains.py
+++ b/tests/test_guest_file_contains.py
@@ -1,0 +1,77 @@
+"""``guest_file_contains`` must never read a failed grep as "absent".
+
+Issue #909: grep rc 2 (e.g. an unreadable file) was folded into ``False``, so a
+negative assertion (``assert not guest_file_contains(...)``) could pass vacuously
+on a file that was never actually read. A missing file stays a legitimate
+``False`` — the helper's on-guest existence pre-check maps it to rc 1 before
+grep runs. Pinned off-VM with the ``_FakeVM`` pattern (precedent:
+``test_smoke_unbound_ready.py``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from tests.smoke import helpers
+
+
+@dataclass
+class _FakeResult:
+    """Stand-in for ``subprocess.CompletedProcess[str]`` (the shape ``SmokeVM.ssh`` returns)."""
+
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class _FakeVM:
+    """Fake ``vm.ssh(*remote, timeout=...)`` — records calls, replays one scripted result."""
+
+    result: _FakeResult
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+
+    def ssh(self, *remote: str, timeout: float = 60.0) -> _FakeResult:
+        self.calls.append(remote)
+        return self.result
+
+
+def test_match_returns_true() -> None:
+    """rc 0 (grep matched) is True."""
+    vm = _FakeVM(result=_FakeResult(returncode=0))
+    assert helpers.guest_file_contains(vm, "/var/log/x.log", "needle") is True  # type: ignore[arg-type]
+
+
+def test_absent_returns_false() -> None:
+    """rc 1 is False — no match, or the file does not exist (the on-guest
+    existence pre-check maps a missing file to rc 1 before grep runs)."""
+    vm = _FakeVM(result=_FakeResult(returncode=1))
+    assert helpers.guest_file_contains(vm, "/var/log/x.log", "needle") is False  # type: ignore[arg-type]
+
+
+def test_grep_read_error_raises_not_absent() -> None:
+    """rc 2 (grep read fault, e.g. an unreadable file) raises — it must NOT read
+    as "does not contain": pre-#909 this returned False, letting a negative
+    assertion pass without the log ever being read."""
+    vm = _FakeVM(result=_FakeResult(returncode=2, stderr="grep: /var/log/x.log: Permission denied"))
+    with pytest.raises(RuntimeError, match=r"rc=2.*Permission denied"):
+        helpers.guest_file_contains(vm, "/var/log/x.log", "needle")  # type: ignore[arg-type]
+
+
+def test_ssh_transport_failure_still_raises() -> None:
+    """rc 255 (ssh transport fault) raises, as it always did."""
+    vm = _FakeVM(result=_FakeResult(returncode=255, stderr="ssh: connect refused"))
+    with pytest.raises(RuntimeError, match=r"rc=255"):
+        helpers.guest_file_contains(vm, "/var/log/x.log", "needle")  # type: ignore[arg-type]
+
+
+def test_probe_prechecks_existence_before_grep() -> None:
+    """The single guest command must gate grep behind an existence check, so a
+    missing file surfaces as rc 1 (absent) rather than grep's own rc 2."""
+    vm = _FakeVM(result=_FakeResult(returncode=1))
+    helpers.guest_file_contains(vm, "/var/log/x.log", "needle")  # type: ignore[arg-type]
+    (probe,) = vm.calls[0]
+    assert "[ -e /var/log/x.log ] || exit 1" in probe
+    assert "grep -F -q" in probe


### PR DESCRIPTION
## What

Three low-priority hardening items from the test-suite review (#909):

1. **`tests/smoke/helpers.py` `guest_file_contains`** — grep rc 2 (a real read fault, e.g. an unreadable file) was folded into "does not contain", so `assert not guest_file_contains(...)` could pass vacuously on a file that was never read. It now raises on any rc other than 0/1. A missing file (not-yet-created log) still legitimately reads as absent: the single guest command gates grep behind an `[ -e path ]` existence pre-check that maps it to rc 1, preserving every caller's semantics.
2. **`tests/smoke/ui/test_render_smoke.py`** — Cloudflare's licence assertion was the split pair `"CC BY-NC" and "4.0"`, satisfiable by any unrelated "4.0" in the page body; now the exact `"(CC BY-NC) 4.0"` form (mirroring the Majestic fix from the #892 review; source renders exactly that).
3. **`.github/workflows/smoke.yml`** — stale comment said the nightly runs "the full CE suite"; schedule resolves scope=full which runs every ci:true leg (CE + Plus).

## Red-before-green evidence

New off-VM unit suite `tests/test_guest_file_contains.py` (the `_FakeVM` pattern from `test_smoke_unbound_ready.py`), run against pre-fix helpers:

```text
FAILED test_grep_read_error_raises_not_absent - Failed: DID NOT RAISE RuntimeError
FAILED test_ssh_transport_failure_still_raises - AssertionError: Regex pattern did not match.
FAILED test_probe_prechecks_existence_before_grep - ValueError: too many values to unpack
3 failed, 2 passed
```

All 5 pass post-fix. The render assertion is Tier-A-observable only; its exactness is pinned against the live source string (`pfblockerng_dnsbl.php:3259`).

## Gates

`python3 -m pytest`: 2218+5 passed, 4 pre-existing skips. `ruff check` + `ruff format --check` clean. `mypy tests/` clean. `smoke.yml` YAML parses.

Fixes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)