### PR TITLE
www: mask MaxMind license key field, write-only with blank-keeps (#924)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2358,7 +2358,7 @@ function pfb_global() {
 	$pfb['rdns']		= pfb_resolve_enabled($pfb['ipconfig']);			// Reverse-DNS lookup for block-log entries (issue #336)
 
 	$pfb['maxmind_account']	= pfb_filter($pfb['ipconfig']['maxmind_account'], PFB_FILTER_WORD, 'pfb_global')	?: '';		// Maxmind Account ID
-	$pfb['maxmind_key']	= pfb_filter($pfb['ipconfig']['maxmind_key'], PFB_FILTER_WORD, 'pfb_global')		?: '';		// Maxmind License Key
+	$pfb['maxmind_key']	= pfb_filter($pfb['ipconfig']['maxmind_key'], PFB_FILTER_WORD, 'maxmind_key')		?: '';		// Maxmind License Key (issue #924: log-safe reference -- a rejected key is never logged on this consumer path either)
 
 	$pfb['dnsbl']		= PfbConfig::read('pfb_dnsbl')->value;							// Enabled state of DNSBL
 	$pfb['dnsbl_vip_auto']	= PfbConfig::read('pfb_dnsvip_auto')->value;						// [ ADR-13 ] Auto-create/remove the DNSBL sinkhole VIP(s) (default off)

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1653,8 +1653,9 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 
 		// Exceptions -- callers whose rejected input must never be logged, even at
 		// debug level: 'DNSBL_Download' (parsed feed lines -- volume); 'top1m_token'
-		// (ADR-59 P5 -- the secret itself, not merely its download URL).
-		if (in_array($reference, array('DNSBL_Download', 'top1m_token'))) {
+		// (ADR-59 P5 -- the secret itself, not merely its download URL); 'maxmind_key'
+		// (issue #924 -- same masked/write-only treatment for the MaxMind license key).
+		if (in_array($reference, array('DNSBL_Download', 'top1m_token', 'maxmind_key'))) {
 			//
 		} else {
 			pfb_logger("{$header} Failed validation [ " . htmlspecialchars($input) . " ]", 6);

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -57,7 +57,10 @@ $pconfig['asn_reporting']	= $pfb['iconfig']['asn_reporting']			?: 'disabled';
 $pconfig['asn_token']		= $pfb['iconfig']['asn_token']				?: '';
 $pconfig['database_cc']		= $pfb['iconfig']['database_cc']			?: '';
 $pconfig['maxmind_account']	= $pfb['iconfig']['maxmind_account']			?: '';
-$pconfig['maxmind_key']		= $pfb['iconfig']['maxmind_key']			?: '';
+// issue #924: maxmind_key is masked/write-only -- never populate it from the stored value.
+// A GET renders blank; a validation-error redisplay preserves the just-typed $_POST value
+// (like every other field), never PfbConfig/iconfig.
+$pconfig['maxmind_key']		= $_POST['maxmind_key'] ?? '';
 $pconfig['inbound_interface']	= explode(',', $pfb['iconfig']['inbound_interface'])	?: array();
 $pconfig['inbound_deny_action']	= $pfb['iconfig']['inbound_deny_action']		?: 'block';
 $pconfig['outbound_interface']	= explode(',', $pfb['iconfig']['outbound_interface'])	?: array();
@@ -138,7 +141,11 @@ if ($_POST) {
 			$input_errors[] = 'MaxMind Account Invalid';
 		}
 
-		if (!empty($_POST['maxmind_key']) && empty(pfb_filter($_POST['maxmind_key'], PFB_FILTER_WORD, 'ip'))) {
+		// issue #924: maxmind_key is masked/write-only -- a blank POST keeps the stored key, so
+		// validate only a non-empty submission. Reference 'maxmind_key' suppresses pfb_filter()'s
+		// failed-validation log line so the secret never reaches a log, even when rejected.
+		$pfb_maxmind_key_post = trim((string) ($_POST['maxmind_key'] ?? ''));
+		if ($pfb_maxmind_key_post !== '' && empty(pfb_filter($pfb_maxmind_key_post, PFB_FILTER_WORD, 'maxmind_key'))) {
 			$input_errors[] = 'MaxMind License key Invalid';
 		}
 
@@ -207,7 +214,12 @@ if ($_POST) {
 			$pfb['iconfig']['maxmind_locale']	= $_POST['maxmind_locale']					?: 'en';
 			$pfb['iconfig']['database_cc']		= pfb_filter($_POST['database_cc'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['maxmind_account']	= pfb_filter($_POST['maxmind_account'], PFB_FILTER_WORD, 'ip')	?: '';
-			$pfb['iconfig']['maxmind_key']		= pfb_filter($_POST['maxmind_key'], PFB_FILTER_WORD, 'ip')	?: '';
+			// issue #924: blank keeps the existing stored key -- only overwrite on a non-empty
+			// submission, never clear it via a blank re-post ($pfb['iconfig']['maxmind_key']
+			// already holds the current stored value from the readSection() above).
+			if ($pfb_maxmind_key_post !== '') {
+				$pfb['iconfig']['maxmind_key'] = pfb_filter($pfb_maxmind_key_post, PFB_FILTER_WORD, 'maxmind_key') ?: '';
+			}
 			$pfb['iconfig']['asn_reporting']	= $_POST['asn_reporting']					?: 'disabled';
 			$pfb['iconfig']['asn_token']		= $_POST['asn_token']					?: '';
 			$pfb['iconfig']['inbound_interface']	= implode(',', (array)$_POST['inbound_interface'])		?: '';
@@ -465,12 +477,13 @@ $section->addInput(new Form_Input(
 $section->addInput(new Form_Input(
 	'maxmind_key',
 	gettext('MaxMind License Key'),
-	'text',
-	$pconfig['maxmind_key'],
-	['placeholder' => 'Enter your MaxMind GeoLite2 License Key']
+	'password',
+	$pconfig['maxmind_key'] ?? '',
+	['placeholder' => 'Enter your MaxMind GeoLite2 License Key -- leave blank to keep the current key']
 ))->setHelp('To utilize the free MaxMind GeoLite2 GeoIP functionality, you must first register for a free MaxMind user account. Visit the following '
 	. '<a href="https://www.maxmind.com/en/geolite2/signup" target="_blank">Link to Register</a> for a free MaxMind user account. '
-	. '<strong>Utilize the GeoIP Update version 3.1.1 or newer registration option.</strong>')
+	. '<strong>Utilize the GeoIP Update version 3.1.1 or newer registration option.</strong>'
+	. ' The stored key is never displayed here; leaving this field blank on Save keeps the existing key unchanged.')
   ->setAttribute('autocomplete', 'off');
 
 $section->addInput(new Form_Select(

--- a/tests/php/PfbFilterTest.php
+++ b/tests/php/PfbFilterTest.php
@@ -211,6 +211,54 @@ final class PfbFilterTest extends TestCase
 		}
 	}
 
+	/**
+	 * issue #924 (security): a MaxMind license key rejected by PFB_FILTER_WORD must NEVER be
+	 * logged -- the same reference-scoped suppression proven above for top1m_token, extended
+	 * to the 'maxmind_key' reference (added to the pfb_filter() exceptions list at
+	 * pfblockerng.inc ~1658). Every maxmind_key call site passes this reference -- the UI
+	 * validate/store (pfblockerng_ip.php) AND the pfb_global() consumer read
+	 * (pfblockerng.inc ~2361) -- so a rejected stored key never reaches the log on any path.
+	 * A DIFFERENT reference still logs the reject, proving the suppression is reference-scoped
+	 * and not a side effect of PFB_FILTER_WORD itself.
+	 */
+	public function testWordFilterRejectionNeverLogsForMaxmindKeyReferenceButOtherReferencesStillDo(): void
+	{
+		$errlog = tempnam(sys_get_temp_dir(), 'pfb_filter_maxmind_errlog_');
+		$this->assertNotFalse($errlog, 'could not create temp errlog');
+		$saved = array_key_exists('errlog', $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb']['errlog'] : false;
+		$GLOBALS['pfb']['errlog'] = $errlog;
+
+		try {
+			// A key with non-word chars ('-'/'!') that PFB_FILTER_WORD rejects.
+			$secret = 'REJECTED-MAXMIND-KEY-should-never-be-logged!!!';
+
+			// Given/When: reference 'maxmind_key' -- the issue #924 exception.
+			$this->assertSame('', pfb_filter($secret, PFB_FILTER_WORD, 'maxmind_key'));
+			// Then: the rejected key never reaches the error log.
+			$this->assertStringNotContainsString(
+				$secret,
+				(string) file_get_contents($errlog),
+				'a key rejected via the maxmind_key reference must never be logged'
+			);
+
+			// Given/When: a DIFFERENT (ordinary) reference for the same rejected input.
+			$this->assertSame('', pfb_filter($secret, PFB_FILTER_WORD, 'some_other_caller'));
+			// Then: the suppression is reference-scoped -- an ordinary caller still logs.
+			$this->assertStringContainsString(
+				$secret,
+				(string) file_get_contents($errlog),
+				'a non-maxmind_key reference must still log its rejected input as before'
+			);
+		} finally {
+			if ($saved === false) {
+				unset($GLOBALS['pfb']['errlog']);
+			} else {
+				$GLOBALS['pfb']['errlog'] = $saved;
+			}
+			unlink($errlog);
+		}
+	}
+
 	public function testControlCharactersRejected(): void
 	{
 		// A control char anywhere makes the whole input fail, returning default.

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -479,6 +479,98 @@ def test_dnsbl_top1m_token_masked_field_persists_and_is_never_echoed(
         assert "OK" in restore.stdout, f"failed to restore top1m_token: {restore.stdout!r}"
 
 
+def test_ip_maxmind_key_masked_field_persists_and_is_never_echoed(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """The masked ``maxmind_key`` field (issue #924) persists via config.xml -- the
+    HTTP body is never proof of a save (ADR §1 fact 3) -- and is a WRITE-ONLY field
+    with the same "blank preserves" contract as ``top1m_token`` (ADR-59 P5) above,
+    mirrored here for the MaxMind GeoIP license key on the IP-settings page.
+
+    Scenario: masked/write-only maxmind_key on the IP-settings page (issue #924).
+      Background: pfBlockerNG deployed; webConfigurator authenticated.
+
+    Given an inert MaxMind license key is already stored (seeded directly via the
+      config API -- the BEFORE state, independent of the save path under test),
+    When the IP page is fetched, Then the raw HTML never echoes the stored key
+      (write-only, masked field);
+    When a BLANK maxmind_key rides a save (the form always renders this field
+      blank, so this is what EVERY unrelated IP-settings save actually posts),
+      Then the stored key is PRESERVED -- this is the red->green core of #924:
+      pre-change, the save unconditionally wrote
+      ``pfb_filter($_POST['maxmind_key'], PFB_FILTER_WORD, 'ip') ?: ''``, so a
+      blank POST cleared the key (this assertion FAILS on that code); post-change,
+      the blank-keeps guard skips the assignment entirely (this assertion PASSES);
+    When a NEW inert key is posted, Then it REPLACES the stored key (branch
+      coverage: a non-empty submission still writes through);
+    When a non-word BOGUS key is posted, Then the WHOLE save aborts and the stored
+      key is UNCHANGED (the shared ``PFB_FILTER_WORD`` reject branch also covered
+      for maxmind_account/asn_token in test_ip_word_filter_field_valid_and_reject_
+      unchanged -- maxmind_key keeps that reject behaviour, only its BLANK handling
+      differs, so it is asserted here instead of in that shared parametrization).
+
+    The web form cannot blank/clear this field by design (proven above), so the
+    original value is restored directly via the config API in `finally` (mirrors
+    the `pfSsh.php` restore idiom already used for top1m_token), leaving the box
+    clean for the other flows on this session-scoped VM.
+    """
+    page = IP_PAGE
+    cfg = "installedpackages/pfblockerngipsettings/config/0/maxmind_key"
+    seed_token = "PFBTESTKEY000001"
+    new_token = "PFBTESTKEY000002"
+    original = helpers.config_get(smoke_vm, cfg)
+    try:
+        # GIVEN: an inert key is already stored -- seeded directly (not via the form
+        # under test), so the BEFORE state is established independently.
+        seed = helpers.php_eval(
+            smoke_vm,
+            f"config_set_path({helpers._php_str(cfg)}, {helpers._php_str(seed_token)});\n"
+            "write_config('#924 smoke: seed maxmind_key');\necho 'OK';",
+        )
+        assert "OK" in seed.stdout, f"failed to seed maxmind_key: {seed.stdout!r}"
+        assert helpers.config_get(smoke_vm, cfg) == seed_token, "seed did not take before the GET/POST assertions"
+
+        # THEN: a GET never echoes the stored key in the raw HTML (write-only, masked).
+        resp = webui.get(page)
+        assert seed_token not in resp.text, (
+            f"maxmind_key must never be echoed back on GET (write-only masked field) -- "
+            f"searched for {seed_token!r} in the {page} response body"
+        )
+
+        # WHEN: a blank maxmind_key rides a save. THEN: unchanged (the red->green core).
+        got_after_blank = _post_and_get(webui, smoke_vm, page, {"maxmind_key": ""}, cfg)
+        assert got_after_blank == seed_token, (
+            f"a blank maxmind_key POST must preserve the existing stored key: "
+            f"expected {seed_token!r}, got {got_after_blank!r}"
+        )
+
+        # WHEN: a NEW key is posted. THEN: it replaces the stored key.
+        got_after_new = _post_and_get(webui, smoke_vm, page, {"maxmind_key": new_token}, cfg)
+        assert got_after_new == new_token, (
+            f"maxmind_key should persist a new posted value: expected {new_token!r}, got {got_after_new!r}"
+        )
+
+        # WHEN: a non-word BOGUS key is posted. THEN: the whole save aborts -- config
+        # UNCHANGED at new_token (not the bogus value, not blanked). Same
+        # PFB_FILTER_WORD reject branch as maxmind_account/asn_token, unaffected by
+        # this fix (only the blank-handling above changed).
+        got_after_bogus = _post_and_get(webui, smoke_vm, page, {"maxmind_key": "bad/key"}, cfg)
+        assert got_after_bogus == new_token, (
+            f"a non-word maxmind_key must abort the save, leaving config unchanged: "
+            f"expected {new_token!r}, got {got_after_bogus!r}"
+        )
+    finally:
+        # Restore directly via the config API -- the web form cannot blank this field
+        # by design (proven above), so a normal POST can't be used for cleanup.
+        restore = helpers.php_eval(
+            smoke_vm,
+            f"config_set_path({helpers._php_str(cfg)}, {helpers._php_str(original)});\n"
+            "write_config('#924 smoke: restore maxmind_key');\necho 'OK';",
+        )
+        assert "OK" in restore.stdout, f"failed to restore maxmind_key: {restore.stdout!r}"
+
+
 # --------------------------------------------------------------------------- #
 # General settings (installedpackages/pfblockerng/config/0)
 # --------------------------------------------------------------------------- #
@@ -597,6 +689,14 @@ def _post_and_confirm_general(
 # the SOFT-COERCE select (asn_reporting) coerces to its default. The interface
 # multiselects are unvalidated (implode comma-join). No test overrides
 # maxmind_locale, so the ugc conversion never fires -- every flow is hermetic.
+#
+# maxmind_key (issue #924) is a HARD-ABORT validator too (a non-word bogus value
+# still aborts the whole save), but it is NOT in the parametrized WORD-filter flow
+# below alongside maxmind_account/asn_token: it is now masked/write-only, so an
+# EMPTY POST means "keep the stored key" rather than "overwrite with empty" --
+# incompatible with that flow's shared "restore via a blank/original POST" idiom.
+# Its own valid/blank-keeps/reject coverage lives in
+# test_ip_maxmind_key_masked_field_persists_and_is_never_echoed above.
 # --------------------------------------------------------------------------- #
 
 IP_PLACEHOLDER_CFG = "installedpackages/pfblockerngipsettings/config/0/ip_placeholder"
@@ -641,10 +741,9 @@ def test_ip_placeholder_valid_isolated_ipv4_and_reject_unchanged(
     ("field", "valid", "bogus"),
     [
         ("maxmind_account", "Test_123", "bad-chars!"),
-        ("maxmind_key", "Key_456", "bad/key"),
         ("asn_token", "Tok_789", "tok@en"),
     ],
-    ids=["maxmind_account", "maxmind_key", "asn_token"],
+    ids=["maxmind_account", "asn_token"],
 )
 def test_ip_word_filter_field_valid_and_reject_unchanged(
     field: str,
@@ -658,12 +757,14 @@ def test_ip_word_filter_field_valid_and_reject_unchanged(
     ``PFB_FILTER_WORD`` = no non-word char (``/\\W/``): only ``[A-Za-z0-9_]`` passes.
     Save guard: ``!empty($_POST[field]) && empty(pfb_filter($_POST[field],
     PFB_FILTER_WORD, 'ip'))`` -> a field-specific input error -> the WHOLE save
-    aborts -> config UNCHANGED. A valid word ('Test_123' / 'Key_456' / 'Tok_789')
-    passes and is stored verbatim; a value with a non-word char ('bad-chars!',
-    'bad/key', 'tok@en') is REJECTED -> config unchanged (NOT the bogus value, NOT
-    empty). Empty input is allowed (the ``!empty`` guard) and stores ''. Pure regex
-    validation, NO egress (these tokens only drive update/reload lookups, not this
-    save). Same mechanism for all three fields -> parametrized.
+    aborts -> config UNCHANGED. A valid word ('Test_123' / 'Tok_789') passes and is
+    stored verbatim; a value with a non-word char ('bad-chars!', 'tok@en') is
+    REJECTED -> config unchanged (NOT the bogus value, NOT empty). Empty input is
+    allowed (the ``!empty`` guard) and stores ''. Pure regex validation, NO egress
+    (these tokens only drive update/reload lookups, not this save). Same mechanism
+    for both fields -> parametrized. (``maxmind_key`` shares the same
+    ``PFB_FILTER_WORD`` reject branch but NOT this "blank stores empty" contract --
+    see the masked-field test above.)
     """
     vm = smoke_vm
     cfg = f"installedpackages/pfblockerngipsettings/config/0/{field}"

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -479,6 +479,9 @@ def test_dnsbl_top1m_token_masked_field_persists_and_is_never_echoed(
         assert "OK" in restore.stdout, f"failed to restore top1m_token: {restore.stdout!r}"
 
 
+MAXMIND_KEY_CFG = "installedpackages/pfblockerngipsettings/config/0/maxmind_key"
+
+
 def test_ip_maxmind_key_masked_field_persists_and_is_never_echoed(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
@@ -516,7 +519,7 @@ def test_ip_maxmind_key_masked_field_persists_and_is_never_echoed(
     clean for the other flows on this session-scoped VM.
     """
     page = IP_PAGE
-    cfg = "installedpackages/pfblockerngipsettings/config/0/maxmind_key"
+    cfg = MAXMIND_KEY_CFG
     seed_token = "PFBTESTKEY000001"
     new_token = "PFBTESTKEY000002"
     original = helpers.config_get(smoke_vm, cfg)
@@ -532,7 +535,15 @@ def test_ip_maxmind_key_masked_field_persists_and_is_never_echoed(
         assert helpers.config_get(smoke_vm, cfg) == seed_token, "seed did not take before the GET/POST assertions"
 
         # THEN: a GET never echoes the stored key in the raw HTML (write-only, masked).
+        # Guard against a false pass first: a redirect/login/error page also lacks the
+        # token, so prove this is the real IP page (200 + the maxmind_key field present)
+        # before trusting the absence check below.
         resp = webui.get(page)
+        assert resp.status_code == 200, f"GET {page} -> HTTP {resp.status_code} (expected 200)"
+        assert 'name="maxmind_key"' in resp.text, (
+            f"{page} did not render the maxmind_key field -- not the expected IP page "
+            f"(redirect/login/error?), which would make the never-leak check vacuous"
+        )
         assert seed_token not in resp.text, (
             f"maxmind_key must never be echoed back on GET (write-only masked field) -- "
             f"searched for {seed_token!r} in the {page} response body"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -344,7 +344,9 @@ def test_ip_page_renders_v6_suppression_section(webui: WebUI) -> None:
 _CFG_MAXMIND_KEY = "installedpackages/pfblockerngipsettings/config/0/maxmind_key"
 
 
-def test_ip_page_never_leaks_maxmind_key(smoke_vm: SmokeVM, webui: WebUI) -> None:
+def test_ip_page_never_leaks_maxmind_key(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:  # noqa: ARG001
     """The masked ``maxmind_key`` field (issue #924) never echoes the stored MaxMind
     license key back into the rendered HTML, and is masked (``type="password"``).
 
@@ -366,6 +368,11 @@ def test_ip_page_never_leaks_maxmind_key(smoke_vm: SmokeVM, webui: WebUI) -> Non
         "echo 'OK';",
     )
     assert "OK" in seed.stdout, f"failed to seed maxmind_key: {seed.stdout!r}"
+    # Confirm the seed actually persisted BEFORE the never-leak GET -- else "OK" (which
+    # prints even if config_set_path silently no-opped) would let the `not in body`
+    # assertion pass vacuously, with the leakable fixture it must fail on absent.
+    seeded = helpers.config_get(smoke_vm, _CFG_MAXMIND_KEY)
+    assert seeded == seed_token, f"seed did not take: expected {seed_token!r}, got {seeded!r}"
     try:
         resp = webui.get(_IP_PAGE)
         assert resp.status_code == 200, f"GET {_IP_PAGE} -> HTTP {resp.status_code} (expected 200)"
@@ -374,11 +381,14 @@ def test_ip_page_never_leaks_maxmind_key(smoke_vm: SmokeVM, webui: WebUI) -> Non
             f"maxmind_key leaked into the IP page body: expected {seed_token!r} to be ABSENT, "
             f"but it was found in the response (write-only masked field must never echo the stored key)"
         )
-        assert 'name="maxmind_key"' in body, "maxmind_key input not present on the IP page"
-        # maxmind_key is the IP page's only password-type input (asn_token stays plain
-        # text -- out of #924's scope), so this substring is unambiguous, matching the
-        # sibling top1m_token Tier-A assertion (test_dnsbl_top1m_source_options_exclude_alexa).
-        assert 'type="password"' in body, 'maxmind_key input must be masked (type="password"), not a plain text field'
+        # Bind type="password" to the maxmind_key input tag ITSELF -- a bare page-level
+        # 'type="password"' substring could be satisfied by any other element, so match the
+        # maxmind_key <input> tag and assert the mask attribute lives inside it.
+        tag = re.search(r'<input[^>]*\bname="maxmind_key"[^>]*>', body)
+        assert tag, "maxmind_key input not present on the IP page"
+        assert 'type="password"' in tag.group(0), (
+            f'maxmind_key input must be masked (type="password"), not a plain text field: got {tag.group(0)!r}'
+        )
     finally:
         restore = helpers.php_eval(
             smoke_vm,

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -341,6 +341,54 @@ def test_ip_page_renders_v6_suppression_section(webui: WebUI) -> None:
     )
 
 
+_CFG_MAXMIND_KEY = "installedpackages/pfblockerngipsettings/config/0/maxmind_key"
+
+
+def test_ip_page_never_leaks_maxmind_key(smoke_vm: SmokeVM, webui: WebUI) -> None:
+    """The masked ``maxmind_key`` field (issue #924) never echoes the stored MaxMind
+    license key back into the rendered HTML, and is masked (``type="password"``).
+
+    Before this fix the field was a plain ``text`` input pre-filled with the stored
+    key verbatim (``$pconfig['maxmind_key'] = $pfb['iconfig']['maxmind_key']``), so a
+    GET leaked the secret straight into the page source and into any screen-share /
+    browser autofill. Seed an inert key directly (independent of the save path Tier
+    B covers), GET the page, and assert (1) the exact stored key string is ABSENT
+    from the body -- this is the never-leak assertion PRE-change would FAIL on, since
+    the old code echoed it verbatim into the ``value`` attribute -- and (2) the
+    ``maxmind_key`` input renders ``type="password"`` (masked), not ``type="text"``.
+    """
+    seed_token = "PFBTESTKEY000001"
+    original = helpers.config_get(smoke_vm, _CFG_MAXMIND_KEY)
+    seed = helpers.php_eval(
+        smoke_vm,
+        f"config_set_path({helpers._php_str(_CFG_MAXMIND_KEY)}, {helpers._php_str(seed_token)});\n"
+        "write_config('#924 smoke: seed maxmind_key for the never-leak render check');\n"
+        "echo 'OK';",
+    )
+    assert "OK" in seed.stdout, f"failed to seed maxmind_key: {seed.stdout!r}"
+    try:
+        resp = webui.get(_IP_PAGE)
+        assert resp.status_code == 200, f"GET {_IP_PAGE} -> HTTP {resp.status_code} (expected 200)"
+        body = resp.text
+        assert seed_token not in body, (
+            f"maxmind_key leaked into the IP page body: expected {seed_token!r} to be ABSENT, "
+            f"but it was found in the response (write-only masked field must never echo the stored key)"
+        )
+        assert 'name="maxmind_key"' in body, "maxmind_key input not present on the IP page"
+        # maxmind_key is the IP page's only password-type input (asn_token stays plain
+        # text -- out of #924's scope), so this substring is unambiguous, matching the
+        # sibling top1m_token Tier-A assertion (test_dnsbl_top1m_source_options_exclude_alexa).
+        assert 'type="password"' in body, 'maxmind_key input must be masked (type="password"), not a plain text field'
+    finally:
+        restore = helpers.php_eval(
+            smoke_vm,
+            f"config_set_path({helpers._php_str(_CFG_MAXMIND_KEY)}, {helpers._php_str(original)});\n"
+            "write_config('#924 smoke: restore maxmind_key');\n"
+            "echo 'OK';",
+        )
+        assert "OK" in restore.stdout, f"failed to restore maxmind_key: {restore.stdout!r}"
+
+
 _UPDATE_PAGE = "/pfblockerng/pfblockerng_update.php"
 _HOOKS_PAGE = "/pfblockerng/pfblockerng_hooks.php"
 


### PR DESCRIPTION
Fixes #924.

Hardens the MaxMind **License Key** on the IP settings page to the masked/write-only pattern ADR-59 P5 already uses for the DNSBL `top1m_token`. Scope is the **license key only** — `maxmind_account` stays plaintext (it is a username, not a credential; masking it hurts usability).

### Before

The key is the HTTP password for the GeoIP download (`pfblockerng.php:666`), yet was a plain `text` input **pre-filled from the stored value**, so:

- the stored key was emitted into the page HTML on every GET (cleartext exposure);
- a blank submit **cleared** the stored key (the store wrote `pfb_filter($_POST['maxmind_key'], …)` unconditionally), so any unrelated save that re-posted an emptied field wiped it;
- a rejected key was logged (validation reference `'ip'` does not suppress `pfb_filter()`'s failed-validation line).

### After (mirrors `top1m_token`)

- `password` field, **never pre-filled** — blank on GET; a validation-error redisplay preserves the just-typed value, never the stored one.
- **Blank submit keeps** the existing stored key (`iconfig` already holds it from `readSection`, so the store skips the assignment when blank).
- Validation runs only on a non-empty submission, with reference `'maxmind_key'` added to the `pfb_filter()` log-suppression list so the secret never reaches a log, even when rejected.

### Tests (ADR-14 smoke UI — the page logic is inline, so no PHPUnit path)

- **Tier A** (`test_ip_page_never_leaks_maxmind_key`): with a key stored, the value is absent from the IP-page HTML and the input is `type="password"`. Fails pre-change (old code echoed it verbatim).
- **Tier B** (`test_ip_maxmind_key_masked_field_persists_and_is_never_echoed`): seed → GET never echoes → **blank save preserves** (red→green core: pre-change a blank save cleared the key) → new key replaces → bogus key aborts the save, config unchanged.
- Reconciled `test_ip_word_filter_field_valid_and_reject_unchanged`: dropped `maxmind_key` from the shared WORD-filter parametrization (its blank contract changed to "keep", incompatible with that flow's blank-restore idiom); its reject branch is now covered in the dedicated test above.

Tier A/B run on the live ADR-04 VM (dispatch-only). Local gates green: `php -l`, PHPStan, PHPCS, `ruff`, `mypy`, full `pytest` unit suite, and smoke-UI collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The MaxMind license key is now treated as hidden and write-only on the IP settings page.
  * The stored key is no longer shown in the form, and leaving the field blank keeps the existing value unchanged.
  * Saving a new valid key updates it correctly without clearing it on blank resubmission.
  * The page now renders the key field as a password input and avoids exposing the saved value in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->