### PR TITLE
dev: lint ADR phase prompts for the delegation-contract blocks

### DIFF
--- a/.claude/skills/adr-create/SKILL.md
+++ b/.claude/skills/adr-create/SKILL.md
@@ -265,6 +265,11 @@ Rules:
 - §7 Definition of Done always carries the **CE+Plus live-VM fan-out** line (the
   org-default validation matrix); an ADR wanting to skip it states the exemption
   explicitly.
+- **After writing all prompts, lint them:**
+  `python3 scripts/check_phase_prompts.py .ADRs/ADR_{NN}_{Name}/[0-9]*.txt`
+  (the `/spec-lint` checker — also a pre-commit gate). Fix any missing block
+  before reporting the ADR done; never weaken the checker to make a prompt
+  pass.
 
 ## Step 5 — Do NOT pre-write handoffs
 

--- a/.claude/skills/spec-lint/SKILL.md
+++ b/.claude/skills/spec-lint/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: spec-lint
+description: >
+  Lint ADR phase prompts for the delegation-contract blocks (VERIFICATION,
+  HANDOFF naming its RESULTS file, declared test mode, reality-override line)
+  via scripts/check_phase_prompts.py — the mechanical floor beneath /adr-create.
+  Args: [ADR number or prompt file paths] (default: every tracked post-contract
+  prompt). Use when the user says "lint the ADR prompts", "spec-lint ADR N",
+  "check the phase prompts", or invokes /spec-lint. /adr-create runs this
+  before reporting a new ADR done.
+---
+
+Run the phase-prompt checker and report. The checker enforces **presence** of the
+CLAUDE.md delegation-contract blocks; judging their **depth** stays your job.
+
+Args: `{{ args }}`
+
+## Step 1 — Resolve targets and run
+
+- No args → `python3 scripts/check_phase_prompts.py` (scans every tracked prompt; ADRs
+  below the grandfather cutoff in the script are skipped by design).
+- An ADR number `N` → pass that ADR's prompt files:
+  `python3 scripts/check_phase_prompts.py .ADRs/ADR_{NN}_*/[0-9]*.txt`.
+- Explicit paths → pass them through verbatim.
+
+## Step 2 — Report
+
+- Clean → say so, one line, and note anything the checker cannot see that you noticed
+  anyway (a vague ACTION PLAN, a missing coverage matrix where the ADR says "all X" — the
+  checker's known blind spots).
+- Violations → list them file-by-file with the missing block, and fix the prompts (prompt
+  text is the ADR-text dev-only class — direct-to-`devel` landing per CLAUDE.md
+  "Worktrees") or hand the list back to the author, per what the user asked.
+
+Do not weaken the checker to make a prompt pass (CLAUDE.md never-weaken rule); a prompt that
+genuinely cannot satisfy a block states why in the prompt itself and the ADR documents the
+exemption.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -55,6 +55,7 @@ staged_py=0;  staged_has '\.py$'        && staged_py=1
 staged_md=0;  staged_has '\.md$'        && staged_md=1
 staged_php=0; staged_has '\.(php|inc)$' && staged_php=1
 staged_sh=0;  staged_has '\.sh$'        && staged_sh=1
+staged_adrtxt=0; staged_has '^\.ADRs/.*\.txt$' && staged_adrtxt=1
 
 # =============================== Python (*.py) =============================== #
 if [ "$staged_py" = 1 ]; then
@@ -130,7 +131,7 @@ if [ "$staged_sh" = 1 ]; then
 		sh -n "$f" || exit 1
 	done || failed 'sh -n'
 
-	# shellcheck (src + scripts only; tests/ shellspec specs trip SC2034
+	# ShellCheck (src + scripts only; tests/ shellspec specs trip SC2034
 	# false-positives — tracked as a separate cleanup).
 	if have shellcheck; then
 		step 'shellcheck'
@@ -170,6 +171,18 @@ if [ "$staged_py" = 1 ] || [ "$staged_php" = 1 ] || [ "$staged_sh" = 1 ]; then
 		"$py_bin" scripts/check_appliance_python.py || failed 'no-appliance-python'
 	else
 		skip no-appliance-python
+	fi
+fi
+
+# --- ADR phase prompts: post-contract prompts (ADR >= 60) must carry the
+#     delegation-contract blocks (VERIFICATION, HANDOFF->RESULTS, test mode,
+#     reality-override). Older ADRs are grandfathered by the script itself. ---
+if [ "$staged_adrtxt" = 1 ]; then
+	if [ -n "$py_bin" ]; then
+		step 'phase-prompts (delegation-contract blocks)'
+		"$py_bin" scripts/check_phase_prompts.py || failed 'phase-prompts'
+	else
+		skip phase-prompts
 	fi
 fi
 

--- a/scripts/check_phase_prompts.py
+++ b/scripts/check_phase_prompts.py
@@ -56,8 +56,9 @@ _RETROFITTED_ADRS = frozenset({25, 32, 33, 34, 54, 55})
 # .ADRs/ADR_{NN}_{Name}/{MM}_{Name}.txt — capture the ADR number for the cutoff.
 _PROMPT_RE = re.compile(r"(?:^|/)\.ADRs/ADR_(\d+)_[^/]+/\d+_[^/]+\.txt$")
 
-# Mode tokens (lowercase; matched case-insensitively). One must appear.
-_MODE_TOKENS = ("red-run", "red->green", "red→green", "behaviour-preserving", "oracle")
+# Mode tokens (matched case-insensitively, word-bounded so e.g. "coracle" never
+# satisfies "oracle"). One must appear.
+_MODE_RE = re.compile(r"(?<!\w)(red-run|red->green|red→green|behaviour-preserving|oracle)(?!\w)")
 
 
 def _prompt_adr_number(path: Path) -> int | None:
@@ -68,16 +69,41 @@ def _prompt_adr_number(path: Path) -> int | None:
     return int(m.group(1))
 
 
+# Resolve the repo root from this file's location so the tracked scan is
+# cwd-independent — `git ls-files .ADRs` from a subdirectory silently matches
+# nothing and would defeat the CI gate (PR #927 review finding).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
 def tracked_phase_prompts() -> list[Path]:
     """Every git-tracked phase prompt under ``.ADRs/`` (all ADR numbers)."""
     out = subprocess.run(
-        ["git", "ls-files", "-z", ".ADRs"],
+        ["git", "-C", str(_REPO_ROOT), "ls-files", "-z", ".ADRs"],
         capture_output=True,
         text=True,
         check=True,
     )
-    paths = [Path(p) for p in out.stdout.split("\0") if p]
+    paths = [_REPO_ROOT / p for p in out.stdout.split("\0") if p]
     return [p for p in paths if _prompt_adr_number(p) is not None]
+
+
+def _handoff_names_results(text: str) -> bool:
+    """True iff a HANDOFF block names a ``RESULTS/`` file within its own span
+    (the ``HANDOFF`` line and its continuation, up to the next all-caps section
+    header). A ``RESULTS/`` mention elsewhere — e.g. REQUIRED READING citing the
+    PRIOR phase's handoff — must not satisfy the check."""
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if not line.startswith("HANDOFF"):
+            continue
+        if "RESULTS/" in line:
+            return True
+        for nxt in lines[i + 1 :]:
+            if "RESULTS/" in nxt:
+                return True
+            if re.match(r"^[A-Z][A-Z0-9 -]{3,}", nxt):
+                break
+    return False
 
 
 def _check_prompt(text: str) -> list[tuple[str, str]]:
@@ -86,9 +112,9 @@ def _check_prompt(text: str) -> list[tuple[str, str]]:
     missing: list[tuple[str, str]] = []
     if not re.search(r"^VERIFICATION", text, flags=re.MULTILINE):
         missing.append(("verification-section", "no VERIFICATION section"))
-    if not (re.search(r"^HANDOFF", text, flags=re.MULTILINE) and "RESULTS/" in text):
+    if not _handoff_names_results(text):
         missing.append(("handoff-results", "no HANDOFF block naming its RESULTS/ file"))
-    if not any(token in lower for token in _MODE_TOKENS):
+    if not _MODE_RE.search(lower):
         missing.append(("mode-declared", "no test mode declared (red-run/red->green vs behaviour-preserving/oracle)"))
     if "override this prompt" not in lower:
         missing.append(("reality-override", 'no "prior RESULTS + live tree override this prompt" line'))
@@ -106,7 +132,8 @@ def find_violations(paths: list[Path]) -> list[tuple[Path, str, str]]:
             continue
         try:
             text = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
+        except OSError as exc:
+            violations.append((path, "unreadable", f"cannot read prompt: {exc}"))
             continue
         violations.extend((path, check, msg) for check, msg in _check_prompt(text))
     return violations

--- a/scripts/check_phase_prompts.py
+++ b/scripts/check_phase_prompts.py
@@ -27,9 +27,11 @@ SCOPE
 * Phase prompts only: tracked ``.ADRs/ADR_{NN}_*/{MM}_*.txt``. ``RESULTS/``
   handoffs and non-numeric ``.txt`` notes are not prompts and are skipped.
 * **Grandfather cutoff:** ADRs numbered below :data:`_CONTRACT_MIN_ADR` predate
-  the delegation contract and are never flagged (retrofitting 59 finished ADRs
-  would be noise, not safety). The cutoff applies in file-argument mode too, so
-  a typo fix in a legacy prompt is never blocked.
+  the delegation contract and are never flagged (retrofitting finished ADRs
+  would be noise, not safety) — EXCEPT the :data:`_RETROFITTED_ADRS` set: those
+  are still unimplemented, their prompts drive future implementer runs, and they
+  were brought up to the contract, so they are gated. The cutoff applies in
+  file-argument mode too, so a typo fix in a legacy prompt is never blocked.
 
 Exit status: 0 = clean, 1 = one or more violations (printed with file + check).
 """
@@ -42,8 +44,14 @@ import sys
 from pathlib import Path
 
 # First ADR authored under the delegation contract (CLAUDE.md, landed 2026-07).
-# Everything older is grandfathered.
+# Everything older is grandfathered — except the retrofitted set below.
 _CONTRACT_MIN_ADR = 60
+
+# Pre-contract ADRs whose prompts still drive FUTURE implementer runs (Proposed /
+# unimplemented at retrofit time) — brought up to the contract in 2821b9df and
+# gated despite their number. An ADR implemented before the contract stays
+# grandfathered; one added here must comply.
+_RETROFITTED_ADRS = frozenset({25, 32, 33, 34, 54, 55})
 
 # .ADRs/ADR_{NN}_{Name}/{MM}_{Name}.txt — capture the ADR number for the cutoff.
 _PROMPT_RE = re.compile(r"(?:^|/)\.ADRs/ADR_(\d+)_[^/]+/\d+_[^/]+\.txt$")
@@ -94,7 +102,7 @@ def find_violations(paths: list[Path]) -> list[tuple[Path, str, str]]:
     violations: list[tuple[Path, str, str]] = []
     for path in paths:
         adr = _prompt_adr_number(path)
-        if adr is None or adr < _CONTRACT_MIN_ADR:
+        if adr is None or (adr < _CONTRACT_MIN_ADR and adr not in _RETROFITTED_ADRS):
             continue
         try:
             text = path.read_text(encoding="utf-8", errors="replace")

--- a/scripts/check_phase_prompts.py
+++ b/scripts/check_phase_prompts.py
@@ -47,11 +47,13 @@ from pathlib import Path
 # Everything older is grandfathered — except the retrofitted set below.
 _CONTRACT_MIN_ADR = 60
 
-# Pre-contract ADRs whose prompts still drive FUTURE implementer runs (Proposed /
-# unimplemented at retrofit time) — brought up to the contract in 2821b9df and
-# gated despite their number. An ADR implemented before the contract stays
-# grandfathered; one added here must comply.
-_RETROFITTED_ADRS = frozenset({25, 32, 33, 34, 54, 55})
+# Pre-contract ADRs whose prompts still drive FUTURE implementer runs (every ADR
+# still Proposed/unimplemented at retrofit time — existing prompts brought up to
+# the contract in 2821b9df/9b21b75e; 51/56/57 have no prompts yet, but any they
+# gain are gated). An ADR implemented before the contract stays grandfathered;
+# an ADR added here must comply. Keep in sync with the Proposed set (positive
+# Status grep — a negative grep ate ADR-52's "Not yet implemented" once).
+_RETROFITTED_ADRS = frozenset({25, 32, 33, 34, 51, 52, 54, 55, 56, 57})
 
 # .ADRs/ADR_{NN}_{Name}/{MM}_{Name}.txt — capture the ADR number for the cutoff.
 _PROMPT_RE = re.compile(r"(?:^|/)\.ADRs/ADR_(\d+)_[^/]+/\d+_[^/]+\.txt$")
@@ -146,7 +148,11 @@ def main(argv: list[str]) -> int:
         return 0
     print("Phase prompt missing delegation-contract blocks:\n", file=sys.stderr)
     for path, check, msg in violations:
-        print(f"  {path}: {check}: {msg}", file=sys.stderr)
+        try:
+            shown = path.relative_to(_REPO_ROOT)
+        except ValueError:
+            shown = path
+        print(f"  {shown}: {check}: {msg}", file=sys.stderr)
     print(
         "\nEvery post-contract phase prompt (ADR >= "
         f"{_CONTRACT_MIN_ADR}) must carry the CLAUDE.md delegation-contract blocks: "

--- a/scripts/check_phase_prompts.py
+++ b/scripts/check_phase_prompts.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Lint ADR phase prompts for the delegation-contract blocks.
+
+PROBLEM
+-------
+An `/adr-phase` implementer executes a phase prompt verbatim, so a weak prompt
+ships weak work: the 2026-07 audit (issues #900-#909) traced several shipped
+defects to specs missing an executable verification plan, a declared test mode,
+or the instruction to distrust the prompt's own stale claims. CLAUDE.md's
+delegation contract now mandates those blocks; this check is the mechanical
+floor that keeps a new ADR's prompts from silently omitting them (the depth of
+each block stays the orchestrator gate's job — this only proves presence).
+
+CHECKS (per post-contract phase prompt)
+---------------------------------------
+* ``verification-section`` — a line starting with ``VERIFICATION`` exists.
+* ``handoff-results``      — a line starting with ``HANDOFF`` exists and the
+  prompt names its ``RESULTS/`` handoff file.
+* ``mode-declared``        — the prompt declares its test mode: a red-first
+  token (``red-run`` / ``red->green`` / ``red→green``) or a behaviour-preserving
+  one (``behaviour-preserving`` / ``oracle``), case-insensitive.
+* ``reality-override``     — the standing line telling the implementer the live
+  tree and prior RESULTS "override this prompt" on any conflict is present.
+
+SCOPE
+-----
+* Phase prompts only: tracked ``.ADRs/ADR_{NN}_*/{MM}_*.txt``. ``RESULTS/``
+  handoffs and non-numeric ``.txt`` notes are not prompts and are skipped.
+* **Grandfather cutoff:** ADRs numbered below :data:`_CONTRACT_MIN_ADR` predate
+  the delegation contract and are never flagged (retrofitting 59 finished ADRs
+  would be noise, not safety). The cutoff applies in file-argument mode too, so
+  a typo fix in a legacy prompt is never blocked.
+
+Exit status: 0 = clean, 1 = one or more violations (printed with file + check).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# First ADR authored under the delegation contract (CLAUDE.md, landed 2026-07).
+# Everything older is grandfathered.
+_CONTRACT_MIN_ADR = 60
+
+# .ADRs/ADR_{NN}_{Name}/{MM}_{Name}.txt — capture the ADR number for the cutoff.
+_PROMPT_RE = re.compile(r"(?:^|/)\.ADRs/ADR_(\d+)_[^/]+/\d+_[^/]+\.txt$")
+
+# Mode tokens (lowercase; matched case-insensitively). One must appear.
+_MODE_TOKENS = ("red-run", "red->green", "red→green", "behaviour-preserving", "oracle")
+
+
+def _prompt_adr_number(path: Path) -> int | None:
+    """The ADR number when ``path`` is a phase prompt, else ``None``."""
+    m = _PROMPT_RE.search(path.as_posix())
+    if m is None or "/RESULTS/" in path.as_posix():
+        return None
+    return int(m.group(1))
+
+
+def tracked_phase_prompts() -> list[Path]:
+    """Every git-tracked phase prompt under ``.ADRs/`` (all ADR numbers)."""
+    out = subprocess.run(
+        ["git", "ls-files", "-z", ".ADRs"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    paths = [Path(p) for p in out.stdout.split("\0") if p]
+    return [p for p in paths if _prompt_adr_number(p) is not None]
+
+
+def _check_prompt(text: str) -> list[tuple[str, str]]:
+    """Return ``(check_id, message)`` for each contract block missing in ``text``."""
+    lower = text.lower()
+    missing: list[tuple[str, str]] = []
+    if not re.search(r"^VERIFICATION", text, flags=re.MULTILINE):
+        missing.append(("verification-section", "no VERIFICATION section"))
+    if not (re.search(r"^HANDOFF", text, flags=re.MULTILINE) and "RESULTS/" in text):
+        missing.append(("handoff-results", "no HANDOFF block naming its RESULTS/ file"))
+    if not any(token in lower for token in _MODE_TOKENS):
+        missing.append(("mode-declared", "no test mode declared (red-run/red->green vs behaviour-preserving/oracle)"))
+    if "override this prompt" not in lower:
+        missing.append(("reality-override", 'no "prior RESULTS + live tree override this prompt" line'))
+    return missing
+
+
+def find_violations(paths: list[Path]) -> list[tuple[Path, str, str]]:
+    """``(path, check_id, message)`` for every contract block missing from a
+    post-contract phase prompt in ``paths``. Non-prompt and grandfathered files
+    are skipped."""
+    violations: list[tuple[Path, str, str]] = []
+    for path in paths:
+        adr = _prompt_adr_number(path)
+        if adr is None or adr < _CONTRACT_MIN_ADR:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        violations.extend((path, check, msg) for check, msg in _check_prompt(text))
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    paths = [Path(a) for a in argv] if argv else tracked_phase_prompts()
+    violations = find_violations(paths)
+    if not violations:
+        return 0
+    print("Phase prompt missing delegation-contract blocks:\n", file=sys.stderr)
+    for path, check, msg in violations:
+        print(f"  {path}: {check}: {msg}", file=sys.stderr)
+    print(
+        "\nEvery post-contract phase prompt (ADR >= "
+        f"{_CONTRACT_MIN_ADR}) must carry the CLAUDE.md delegation-contract blocks: "
+        "a VERIFICATION section, a HANDOFF block naming its RESULTS/ file, a declared "
+        "test mode (red-run vs behaviour-preserving/oracle), and the reality-override "
+        'line. Template: /adr-create Step 4; law: CLAUDE.md "The delegation contract".',
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_phase_prompt_check.py
+++ b/tests/test_phase_prompt_check.py
@@ -143,3 +143,16 @@ def test_repo_tree_is_clean() -> None:
     # CI enforcement: every tracked post-contract phase prompt in THIS repo
     # complies. (Trivially green until ADR_60 exists; from then on it gates.)
     assert cpp.find_violations(cpp.tracked_phase_prompts()) == []
+
+
+def test_retrofitted_unimplemented_adrs_are_gated(tmp_path: Path) -> None:
+    # ADR-25/32/33/34/54/55 are Proposed (unimplemented) — their prompts drive
+    # FUTURE implementer runs, were retrofitted to comply (2821b9df), and are
+    # gated despite predating the contract cutoff.
+    rel = ".ADRs/ADR_55_Client_Groups_Group_Policy/05_New_Phase.txt"
+    assert sorted(_violations(tmp_path, rel, "just do the thing\n")) == [
+        "handoff-results",
+        "mode-declared",
+        "reality-override",
+        "verification-section",
+    ]

--- a/tests/test_phase_prompt_check.py
+++ b/tests/test_phase_prompt_check.py
@@ -1,0 +1,145 @@
+"""Tests for scripts/check_phase_prompts.py.
+
+Intent: a phase prompt authored after the delegation contract (ADR >= 60) must
+carry the contract's mandatory blocks — a VERIFICATION section, a HANDOFF block
+naming its RESULTS file, a declared test mode (red-run vs behaviour-preserving
+oracle), and the reality-override line — so a weak spec is caught before a
+Sonnet implementer executes it. Pre-contract ADRs (<= 59) are grandfathered and
+must never be flagged.
+
+Per the test mandate, every flagged case is paired with the compliant form that
+must stay clean, so green proves the check DISCRIMINATES rather than always or
+never firing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_phase_prompts.py"
+_spec = importlib.util.spec_from_file_location("check_phase_prompts", _TOOL)
+assert _spec is not None and _spec.loader is not None
+cpp = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = cpp
+_spec.loader.exec_module(cpp)
+
+
+_COMPLIANT = """\
+================================================================================
+PHASE 1 PROMPT — Example (behaviour-preserving)
+Target model: Claude Sonnet 5
+================================================================================
+
+ROLE
+Phase 1 of 2. BEHAVIOUR-PRESERVING refactor.
+
+REQUIRED READING
+- src/example.inc — the helper (~line 10).
+Line numbers and code-state claims in this prompt were written before earlier
+phases ran; the prior RESULTS files and the live tree override this prompt on
+any conflict — verify each claim before acting on it.
+
+ACTION PLAN
+1. Do the thing.
+
+VERIFICATION (must all pass)
+- python -m pytest → green
+- oracle test pins the resolved URL byte-identically
+
+HANDOFF — write .ADRs/ADR_60_Example/RESULTS/01_Results.txt with the fixed
+fields (CLAUDE.md "THE HANDOFF").
+"""
+
+
+def _write(tmp_path: Path, rel: str, text: str) -> Path:
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def _violations(tmp_path: Path, rel: str, text: str) -> list[str]:
+    """Check ids flagged for one prompt file written at ``rel``."""
+    path = _write(tmp_path, rel, text)
+    return [check for (_, check, _) in cpp.find_violations([path])]
+
+
+PROMPT_60 = ".ADRs/ADR_60_Example/01_Example.txt"
+
+
+def test_compliant_prompt_is_clean(tmp_path: Path) -> None:
+    assert _violations(tmp_path, PROMPT_60, _COMPLIANT) == []
+
+
+def test_missing_verification_section_is_flagged(tmp_path: Path) -> None:
+    text = _COMPLIANT.replace("VERIFICATION (must all pass)", "CHECKS (informal)")
+    assert _violations(tmp_path, PROMPT_60, text) == ["verification-section"]
+
+
+def test_handoff_without_results_file_is_flagged(tmp_path: Path) -> None:
+    text = _COMPLIANT.replace(
+        "HANDOFF — write .ADRs/ADR_60_Example/RESULTS/01_Results.txt with the fixed",
+        "HANDOFF — summarize what you did in the chat, with the fixed",
+    )
+    assert _violations(tmp_path, PROMPT_60, text) == ["handoff-results"]
+
+
+def test_missing_mode_declaration_is_flagged(tmp_path: Path) -> None:
+    text = _COMPLIANT.replace("(behaviour-preserving)", "").replace("BEHAVIOUR-PRESERVING refactor.", "A refactor.")
+    text = text.replace("- oracle test pins the resolved URL byte-identically\n", "")
+    assert _violations(tmp_path, PROMPT_60, text) == ["mode-declared"]
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["red-run", "red->green", "red→green", "behaviour-preserving", "oracle"],
+)
+def test_each_mode_token_satisfies_the_mode_check(tmp_path: Path, token: str) -> None:
+    # Strip every mode token from the compliant prompt, then re-add exactly one.
+    text = _COMPLIANT.replace("(behaviour-preserving)", "").replace("BEHAVIOUR-PRESERVING refactor.", "A refactor.")
+    text = text.replace("- oracle test pins the resolved URL byte-identically\n", "")
+    text += f"\nMODE NOTE: this phase is {token}.\n"
+    assert _violations(tmp_path, PROMPT_60, text) == []
+
+
+def test_missing_reality_override_line_is_flagged(tmp_path: Path) -> None:
+    text = _COMPLIANT.replace(
+        "phases ran; the prior RESULTS files and the live tree override this prompt on\n"
+        "any conflict — verify each claim before acting on it.\n",
+        "",
+    )
+    assert _violations(tmp_path, PROMPT_60, text) == ["reality-override"]
+
+
+def test_noncompliant_prompt_reports_every_missing_block(tmp_path: Path) -> None:
+    assert sorted(_violations(tmp_path, PROMPT_60, "just do the thing\n")) == [
+        "handoff-results",
+        "mode-declared",
+        "reality-override",
+        "verification-section",
+    ]
+
+
+def test_pre_contract_adr_is_grandfathered(tmp_path: Path) -> None:
+    # Same fully non-compliant text, but under ADR_59 — must not be flagged.
+    rel = ".ADRs/ADR_59_Legacy/01_Legacy.txt"
+    assert _violations(tmp_path, rel, "just do the thing\n") == []
+
+
+def test_results_handoffs_and_non_phase_files_are_skipped(tmp_path: Path) -> None:
+    # RESULTS handoffs match the NN_*.txt shape but are outputs, not prompts;
+    # non-numeric .txt notes are not phase prompts either.
+    results = ".ADRs/ADR_60_Example/RESULTS/01_Results.txt"
+    notes = ".ADRs/ADR_60_Example/notes.txt"
+    assert _violations(tmp_path, results, "no blocks here\n") == []
+    assert _violations(tmp_path, notes, "no blocks here\n") == []
+
+
+def test_repo_tree_is_clean() -> None:
+    # CI enforcement: every tracked post-contract phase prompt in THIS repo
+    # complies. (Trivially green until ADR_60 exists; from then on it gates.)
+    assert cpp.find_violations(cpp.tracked_phase_prompts()) == []

--- a/tests/test_phase_prompts_check.py
+++ b/tests/test_phase_prompts_check.py
@@ -1,4 +1,4 @@
-"""Tests for scripts/check_phase_prompts.py.
+"""Tests for scripts/check_phase_prompts.py (sibling-named: test_phase_prompts_check).
 
 Intent: a phase prompt authored after the delegation contract (ADR >= 60) must
 carry the contract's mandatory blocks — a VERIFICATION section, a HANDOFF block
@@ -156,3 +156,45 @@ def test_retrofitted_unimplemented_adrs_are_gated(tmp_path: Path) -> None:
         "reality-override",
         "verification-section",
     ]
+
+
+def test_handoff_results_must_be_in_the_handoff_span(tmp_path: Path) -> None:
+    # Review finding (PR #927): a phase-2 prompt legitimately cites the PRIOR
+    # phase's RESULTS file in REQUIRED READING; that mention must not satisfy
+    # the check when the HANDOFF block itself names no RESULTS/ file.
+    text = _COMPLIANT.replace(
+        "- src/example.inc — the helper (~line 10).",
+        "- src/example.inc — the helper (~line 10).\n"
+        "- .ADRs/ADR_60_Example/RESULTS/01_Results.txt — the prior handoff.",
+    ).replace(
+        'HANDOFF — write .ADRs/ADR_60_Example/RESULTS/01_Results.txt with the fixed\nfields (CLAUDE.md "THE HANDOFF").',
+        "HANDOFF — summarize what you did in the chat when finished.",
+    )
+    assert _violations(tmp_path, PROMPT_60, text) == ["handoff-results"]
+
+
+def test_mode_tokens_are_word_bounded(tmp_path: Path) -> None:
+    # Review finding (PR #927): "oracle" inside an unrelated word must not
+    # count as a mode declaration.
+    text = _COMPLIANT.replace("(behaviour-preserving)", "").replace("BEHAVIOUR-PRESERVING refactor.", "A refactor.")
+    text = text.replace("- oracle test pins the resolved URL byte-identically\n", "")
+    text += "\nWe sail in a coracle down the river.\n"
+    assert _violations(tmp_path, PROMPT_60, text) == ["mode-declared"]
+
+
+def test_tracked_scan_is_cwd_independent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Review finding (PR #927): `git ls-files .ADRs` resolved against the
+    # process cwd silently scans nothing when pytest runs from elsewhere,
+    # defeating test_repo_tree_is_clean.
+    from_root = {p.name for p in cpp.tracked_phase_prompts()}
+    assert from_root, "repo has tracked phase prompts; empty means the scan is broken"
+    monkeypatch.chdir(tmp_path)
+    assert {p.name for p in cpp.tracked_phase_prompts()} == from_root
+
+
+def test_unreadable_prompt_is_a_loud_violation(tmp_path: Path) -> None:
+    # Review finding (PR #927): an unreadable gated prompt must surface, not
+    # silently count as compliant.
+    missing = tmp_path / ".ADRs/ADR_60_Example/01_Ghost.txt"
+    checks = [c for (_, c, _) in cpp.find_violations([missing])]
+    assert checks == ["unreadable"]

--- a/tests/test_phase_prompts_check.py
+++ b/tests/test_phase_prompts_check.py
@@ -145,11 +145,15 @@ def test_repo_tree_is_clean() -> None:
     assert cpp.find_violations(cpp.tracked_phase_prompts()) == []
 
 
-def test_retrofitted_unimplemented_adrs_are_gated(tmp_path: Path) -> None:
-    # ADR-25/32/33/34/54/55 are Proposed (unimplemented) — their prompts drive
-    # FUTURE implementer runs, were retrofitted to comply (2821b9df), and are
-    # gated despite predating the contract cutoff.
-    rel = ".ADRs/ADR_55_Client_Groups_Group_Policy/05_New_Phase.txt"
+@pytest.mark.parametrize("adr", sorted({25, 32, 33, 34, 51, 52, 54, 55, 56, 57}))
+def test_retrofitted_unimplemented_adrs_are_gated(tmp_path: Path, adr: int) -> None:
+    # Every Proposed (unimplemented) ADR is gated — its prompts (existing,
+    # retrofitted in 2821b9df/9b21b75e, or authored in the future like
+    # ADR-51/56/57's) drive FUTURE implementer runs despite predating the
+    # contract cutoff. ADR-52 was missed by the first retrofit sweep (a
+    # negative status grep ate "Not yet implemented") — hence pinning the
+    # whole set, not one representative.
+    rel = f".ADRs/ADR_{adr}_Example/05_New_Phase.txt"
     assert sorted(_violations(tmp_path, rel, "just do the thing\n")) == [
         "handoff-results",
         "mode-declared",


### PR DESCRIPTION
Follow-up to the delegation contract (7ce4573b) and companion to #921/#922: the mechanical floor for spec quality. An `/adr-phase` implementer executes a phase prompt verbatim, so a prompt missing the contract blocks ships weak work before any gate can catch it.

## What

- **`scripts/check_phase_prompts.py`** — flags a post-contract phase prompt (ADR ≥ 60; older ADRs grandfathered, in file-argument mode too) missing any of: a `VERIFICATION` section, a `HANDOFF` block naming its `RESULTS/` file, a declared test mode (`red-run`/`red->green` vs `behaviour-preserving`/`oracle`), or the reality-override line. Presence only — depth stays the orchestrator gate's job.
- **Pre-commit**: runs when `.ADRs/**.txt` is staged. **CI**: `test_repo_tree_is_clean` in the pytest suite gates every tracked post-contract prompt.
- **`/spec-lint`** skill wraps it; **`/adr-create`** now runs it before reporting a new ADR done.
- Drive-by: capitalised a `# shellcheck (…)` comment in `.githooks/pre-commit` that ShellCheck parsed as a malformed directive (SC1073), unblocking `shellcheck` on the hook itself.

## Evidence

- Red→green: tests written first, run against the absent module → collection error; after implementation → `14 passed`.
- Live hook runs: staged non-compliant `ADR_60` prompt → pre-commit `rc=1` naming all four missing blocks; compliant prompt → `rc=0`.
- Gates: `python -m pytest` → 2245 passed, 4 skipped; `ruff check`/`ruff format --check` clean; `mypy tests/` clean; `sh -n` + `shellcheck --severity=info` on the hook clean bar the pre-existing SC2016 info (deliberate literal `$var` in a step label, untouched).

## Coverage matrix

Every check red+green paired; each mode token parametrised; grandfather cutoff (ADR_59 non-compliant → clean); RESULTS handoffs and non-numeric `.txt` skipped; fully non-compliant prompt reports all four; repo-tree scan green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfJUsCQkpFZxXufncGUS2f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic validation for ADR phase prompts to catch missing required sections and formatting issues before completion.
  * Introduced a new prompt-checking workflow that reports clear pass/fail results and flags unreadable files.

* **Bug Fixes**
  * Strengthened pre-commit checks so ADR-related prompt files are validated consistently, helping prevent incomplete or noncompliant prompts from being submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->