### PR TITLE
pfblockerng: replace DomCop TOP1M provider with OpenPageRank (#928)

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -30,12 +30,13 @@ field, reasoning about rollback/downgrade, or checking the foreign-key exclusion
     (alpha compatibility is intentionally not maintained) — it reads as Off. One canonical
     vocabulary spans `config.xml`, the ini, and the Python `IdnMode` enum.
   - **`alexa_type` → `PfbTop1mSource`** (issue #877 review, registry adapters
-    `pfb_cfg_top1m_source_read/write`): tokens `'tranco'` (default) / `'cisco'` / `'domcop'` /
+    `pfb_cfg_top1m_source_read/write`): tokens `'tranco'` (default) / `'cisco'` / `'openpagerank'` /
     `'majestic'` (added ADR-59 P4) / `'cloudflare'` (added ADR-59 P5, the first
-    token-authenticated provider). The legacy `'alexa'` token (the dead Alexa
-    TOP1M service, #872) is READ-only — `fromLegacy()` coalesces it (and any unknown/absent
-    token) to `Tranco`, and a write never re-emits it. The stored config key stays `alexa_type`
-    — no rename.
+    token-authenticated provider). TWO tokens are READ-only, never re-emitted by a write —
+    `'alexa'` (the dead Alexa TOP1M service, #872) coalesces to `Tranco`, and `'domcop'`
+    (the DomCop TOP1M list's hosting moved to OpenPageRank, #928) coalesces to
+    `OpenPageRank`; `fromLegacy()` coalesces any other unknown/absent token to `Tranco`.
+    The stored config key stays `alexa_type` — no rename.
   - **`top1m_token`** (ADR-59 P5, plain string — `NULL`/`NULL` adapters): a masked,
     write-only credential (currently consumed only by the `cloudflare` `alexa_type`,
     ignored by every other provider), fed to `pfb_download()` via `pfb_top1m_auth_headers()`
@@ -97,7 +98,7 @@ at/after that version; it is a per-field scope marker, not a migration.
 | `lenient`           | `{'on', 'off', ''}` — `''` is a LEGACY READ token (pre-ADR-22 absent); write emits `'off'` |
 | `idn`               | write `{'on' (=All), 'confusable', 'off'}`; legacy reads `'all'`→Off, `''`→Off (4.0.0-alpha `'all'` not carried) |
 | `alias_delta_mode`  | `{'auto', 'delta', 'replace'}` — unknown/absent token reads as `'auto'` (ADR-40, since 4.0.0) |
-| `top1m_source`      | write `{'tranco' (default), 'cisco', 'domcop', 'majestic', 'cloudflare'}` (domcop/majestic ADR-59 P4, cloudflare ADR-59 P5); legacy read `'alexa'`→Tranco (dead service, #872), never re-emitted |
+| `top1m_source`      | write `{'tranco' (default), 'cisco', 'openpagerank', 'majestic', 'cloudflare'}` (openpagerank/majestic ADR-59 P4, cloudflare ADR-59 P5); legacy read `'alexa'`→Tranco (dead service, #872) and `'domcop'`→OpenPageRank (list moved hosting, #928), neither re-emitted |
 | `plain`             | identity — any stored value passes through unchanged |
 
 **Excluded fields** — none. `pfb_idn` was previously excluded (`NULL`/`NULL` identity adapters);

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -30,7 +30,8 @@ field, reasoning about rollback/downgrade, or checking the foreign-key exclusion
     (alpha compatibility is intentionally not maintained) — it reads as Off. One canonical
     vocabulary spans `config.xml`, the ini, and the Python `IdnMode` enum.
   - **`alexa_type` → `PfbTop1mSource`** (issue #877 review, registry adapters
-    `pfb_cfg_top1m_source_read/write`): tokens `'tranco'` (default) / `'cisco'` / `'openpagerank'` /
+    `pfb_cfg_top1m_source_read/write`): tokens `'tranco'` (default) / `'cisco'` /
+    `'openpagerank'` (#928, replacing ADR-59 P4's `'domcop'`) /
     `'majestic'` (added ADR-59 P4) / `'cloudflare'` (added ADR-59 P5, the first
     token-authenticated provider). TWO tokens are READ-only, never re-emitted by a write —
     `'alexa'` (the dead Alexa TOP1M service, #872) coalesces to `Tranco`, and `'domcop'`
@@ -98,7 +99,7 @@ at/after that version; it is a per-field scope marker, not a migration.
 | `lenient`           | `{'on', 'off', ''}` — `''` is a LEGACY READ token (pre-ADR-22 absent); write emits `'off'` |
 | `idn`               | write `{'on' (=All), 'confusable', 'off'}`; legacy reads `'all'`→Off, `''`→Off (4.0.0-alpha `'all'` not carried) |
 | `alias_delta_mode`  | `{'auto', 'delta', 'replace'}` — unknown/absent token reads as `'auto'` (ADR-40, since 4.0.0) |
-| `top1m_source`      | write `{'tranco' (default), 'cisco', 'openpagerank', 'majestic', 'cloudflare'}` (openpagerank/majestic ADR-59 P4, cloudflare ADR-59 P5); legacy read `'alexa'`→Tranco (dead service, #872) and `'domcop'`→OpenPageRank (list moved hosting, #928), neither re-emitted |
+| `top1m_source`      | write `{'tranco' (default), 'cisco', 'openpagerank', 'majestic', 'cloudflare'}` (majestic ADR-59 P4, cloudflare ADR-59 P5, openpagerank replaced P4's domcop in #928); legacy read `'alexa'`→Tranco (dead service, #872) and `'domcop'`→OpenPageRank (list moved hosting, #928), neither re-emitted |
 | `plain`             | identity — any stored value passes through unchanged |
 
 **Excluded fields** — none. `pfb_idn` was previously excluded (`NULL`/`NULL` identity adapters);

--- a/docs/misc/top1m-providers.md
+++ b/docs/misc/top1m-providers.md
@@ -34,7 +34,7 @@ its `url`/`headers` into the `extras[2]` download slot; no per-provider `if`/`el
 | -------- | ------ | --------- | ---- | ------- |
 | Tranco | rank,domain CSV | zip | none | — |
 | Cisco Umbrella | rank,domain CSV | zip | none | — |
-| DomCop (top 10M) | `"Rank","Domain","Open Page Rank"` CSV, header | zip | none | — |
+| OpenPageRank (top 10M) | `Rank,Domain,Extension,Open Page Rank,Referring Domains` CSV, header | zip | none | — |
 | Majestic Million | `GlobalRank,TldRank,Domain,TLD,...` CSV, header | plain | none | CC BY 3.0 — attribution required |
 | Cloudflare Radar (top 1M bucket) | single `domain` column CSV, header | plain | `Authorization: Bearer <token>` | CC BY-NC 4.0 — non-commercial use, attribution required |
 
@@ -87,5 +87,10 @@ under that derived name, then add one `NAME: ${{ secrets.NAME }}` line to the `c
 ## Out of scope
 
 Vendoring/embedding any of these lists; Chrome CrUX (BigQuery-only, not a bulk downloadable
-list) and OpenPageRank (a per-domain API, not a bulk list); per-provider tokens (one shared
-`top1m_token` field suffices — only one source is active at a time).
+list); per-provider tokens (one shared `top1m_token` field suffices — only one source is
+active at a time).
+
+Note (#928): the bulk top-10M list itself moved hosting from DomCop to OpenPageRank in 2026 (the
+DomCop URL froze 2026-03-29) — the descriptor above tracks that bulk CSV download, not
+OpenPageRank's separate **per-domain API** (a rank lookup for one domain at a time), which
+remains out of scope for the same reason as Chrome CrUX: this feature only downloads bulk lists.

--- a/scripts/misc/check_top1m_providers.py
+++ b/scripts/misc/check_top1m_providers.py
@@ -59,9 +59,10 @@ from urllib.parse import urlparse
 
 # A real Top1M list is ~1M rows; 100k is a generous floor that still rejects a
 # truncated/error payload. Refresh cadence varies by provider -- some publish
-# ~daily, others only monthly/quarterly (e.g. DomCop) -- so the staleness cutoff
-# is a deliberately generous 6 months: below that is too soon to declare a feed
-# dead, past it the source has almost certainly stopped updating.
+# ~daily, others only monthly/quarterly (e.g. OpenPageRank, which inherited
+# DomCop's cadence when the list moved hosting, #928) -- so the staleness
+# cutoff is a deliberately generous 6 months: below that is too soon to
+# declare a feed dead, past it the source has almost certainly stopped updating.
 MIN_ROWS = 100_000
 MAX_AGE_DAYS = 180
 
@@ -69,7 +70,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_DESCRIPTOR_FILE = REPO_ROOT / "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 
 # --extract's floor (#908): the committed provider count in
-# pfb_top1m_providers() (Tranco/Cisco/DomCop/Majestic/Cloudflare). A partial
+# pfb_top1m_providers() (Tranco/Cisco/OpenPageRank/Majestic/Cloudflare). A partial
 # extractor breakage that silently drops a provider must fail loud here
 # rather than pass a too-small matrix on to the workflow. Bump this whenever
 # a row is added to or removed from that descriptor table.
@@ -253,8 +254,8 @@ def _is_valid_row(row: list[str]) -> bool:
     """A plausible Top1M row: at least one field looks like a dotted domain.
 
     Provider-agnostic across every descriptor shape -- Tranco/Cisco's 2-col
-    rank+domain, DomCop's 3-col Rank/Domain/OpenPageRank, Majestic's wide
-    12-col layout, Cloudflare's bare single 'domain' column. The health-check
+    rank+domain, OpenPageRank's 5-col Rank/Domain/Extension/PageRank/RefDomains,
+    Majestic's wide 12-col layout, Cloudflare's bare single 'domain' column. The health-check
     only needs proof real domain rows are still flowing, not which exact
     column holds them. A header row's field names ("Domain", "GlobalRank",
     ...) have no dot, so header rows fail this check with no separate

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8386,7 +8386,7 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 				// prose/HTML/error body (e.g. "error, service temporarily unavailable.")
 				// still has a '.' and a ',' and would otherwise pass the filter above, so a
 				// dead feed would classify as "valid" below and wipe the whitelist (#886
-				// review). Every other parse mode ('csv': DomCop/Majestic/Cloudflare) has no
+				// review). Every other parse mode ('csv': OpenPageRank/Majestic/Cloudflare) has no
 				// rank column to guard on instead, so the domain field itself must look like
 				// a hostname -- otherwise the SAME garbage-body wipe re-opens for those
 				// providers (a CDN error page or a JSON auth-error body still has a '.' and

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -203,29 +203,33 @@ enum PfbAliasDeltaMode: string implements PfbStoredEnum
 // PfbTop1mSource — TOP1M source selector (alexa_type, issue #877).
 //
 // Used by: alexa_type (config key) / $pfb['dnsbl_top1m_type'] (runtime).
-//   Canonical tokens: 'tranco' (default), 'cisco', 'domcop', 'majestic'
-//   (ADR-59 P4), 'cloudflare' (ADR-59 P5, token-authenticated). The legacy
-//   'alexa' token (the dead Alexa TOP1M service, #872) is a READ-ONLY legacy
-//   value: fromLegacy() coalesces it (and any unknown/'' token) to Tranco,
-//   and a write NEVER re-emits it — every live token is ever persisted as
-//   itself, so the write vocabulary is downgrade-safe (an older release
-//   reading any of them already understands its own subset; domcop/
-//   majestic/cloudflare are simply new to it, same as any other ADR-added
-//   option).
+//   Canonical tokens: 'tranco' (default), 'cisco', 'openpagerank', 'majestic'
+//   (ADR-59 P4), 'cloudflare' (ADR-59 P5, token-authenticated). TWO tokens
+//   are READ-ONLY legacy values, never re-emitted by a write: 'alexa' (the
+//   dead Alexa TOP1M service, #872) and 'domcop' (the DomCop top-10M list's
+//   hosting moved to OpenPageRank, #928) both coalesce to their replacement
+//   at the read boundary — every live token is ever persisted as itself, so
+//   the write vocabulary is downgrade-safe (an older release reading any of
+//   them already understands its own subset; openpagerank/majestic/
+//   cloudflare are simply new to it, same as any other ADR-added option).
 enum PfbTop1mSource: string implements PfbStoredEnum
 {
 	use PfbStoredEnumAdapter;
 
-	case Tranco     = 'tranco';
-	case Cisco      = 'cisco';
-	case DomCop     = 'domcop';
-	case Majestic   = 'majestic';
-	case Cloudflare = 'cloudflare';
+	case Tranco       = 'tranco';
+	case Cisco        = 'cisco';
+	case OpenPageRank = 'openpagerank';
+	case Majestic     = 'majestic';
+	case Cloudflare   = 'cloudflare';
 
-	// Legacy 'alexa' (dead service, #872) and any unknown/'' token -> Tranco.
+	// Legacy 'alexa' (dead service, #872) -> Tranco; legacy 'domcop' (list moved
+	// hosting to OpenPageRank, #928) -> OpenPageRank; any other unknown/'' token -> Tranco.
 	protected static function fromLegacy(string $raw): static
 	{
-		return self::Tranco;
+		return match ($raw) {
+			'domcop' => self::OpenPageRank,
+			default  => self::Tranco,
+		};
 	}
 
 	// Parse-fallback ONLY (unknown/non-scalar -> Tranco). NOT the absent default
@@ -239,7 +243,7 @@ enum PfbTop1mSource: string implements PfbStoredEnum
 // TOP1M provider descriptor table (ADR-59 P1, generalized P2, keyless
 // providers added P4, token-authenticated Cloudflare Radar added P5).
 //
-// Keyed by PfbTop1mSource::value ('tranco'/'cisco'/'domcop'/'majestic'/'cloudflare').
+// Keyed by PfbTop1mSource::value ('tranco'/'cisco'/'openpagerank'/'majestic'/'cloudflare').
 // pfblockerng.php's TOP1M URL selection reads this table instead of a
 // per-provider if/else; pfblockerng_top1m() (ADR-59 P2) reads
 // 'parse'/'header'/'domain_col' to drive the builder. 'container' documents each
@@ -254,10 +258,11 @@ enum PfbTop1mSource: string implements PfbStoredEnum
 // (ADR-59 P3+) via pfb_top1m_auth_headers() below -- 'none' (every keyless
 // provider) or {header, scheme} (Cloudflare's Bearer token). 'domain_col' is
 // 0-indexed (str_getcsv() array index, not a human 1-indexed column count)
-// -- DomCop's Domain is the 2nd CSV field ("Rank","Domain","Open Page Rank")
-// -> index 1 (same index as Tranco/Cisco); Majestic's Domain is the 3rd
-// field (GlobalRank,TldRank,Domain,...) -> index 2; Cloudflare's dataset is
-// a SINGLE 'domain' column (no rank) -> index 0 (see the row's own comment).
+// -- OpenPageRank's Domain is the 2nd CSV field
+// (Rank,Domain,Extension,Open Page Rank,Referring Domains) -> index 1 (same
+// index as Tranco/Cisco); Majestic's Domain is the 3rd field
+// (GlobalRank,TldRank,Domain,...) -> index 2; Cloudflare's dataset is a
+// SINGLE 'domain' column (no rank) -> index 0 (see the row's own comment).
 //
 // @return array<string, array{url: string, container: string, parse: string, header: bool, domain_col: int, auth: string|array{header: string, scheme: string}, label: string, licence: string}>
 function pfb_top1m_providers(): array
@@ -283,16 +288,19 @@ function pfb_top1m_providers(): array
 			'label'		=> 'Cisco Umbrella',
 			'licence'	=> '',
 		),
-		// DomCop top-10M (registered-domain breadth): zipped CSV, quoted header
-		// row ("Rank","Domain","Open Page Rank"), Domain at str_getcsv() index 1.
-		PfbTop1mSource::DomCop->value	=> array(
-			'url'		=> 'https://www.domcop.com/files/top/top10milliondomains.csv.zip',
+		// OpenPageRank top-10M (registered-domain breadth; formerly hosted by
+		// DomCop, #928 -- the DomCop URL froze 2026-03-29 when the list's hosting
+		// moved): zipped CSV, unquoted 5-col header
+		// (Rank,Domain,Extension,Open Page Rank,Referring Domains), Domain at
+		// str_getcsv() index 1.
+		PfbTop1mSource::OpenPageRank->value	=> array(
+			'url'		=> 'https://openpagerank.keywordseverywhere.com/downloads/top10milliondomains.csv.zip',
 			'container'	=> 'zip',
 			'parse'		=> 'csv',
 			'header'	=> TRUE,
 			'domain_col'	=> 1,
 			'auth'		=> 'none',
-			'label'		=> 'DomCop',
+			'label'		=> 'OpenPageRank',
 			'licence'	=> '',
 		),
 		// Majestic Million: PLAIN (uncompressed) CSV, unquoted 12-col header
@@ -424,7 +432,7 @@ function pfb_cfg_idn_mode_write(PfbIdnMode|string $mode): string
 	return ($mode instanceof PfbIdnMode ? $mode : PfbIdnMode::fromStored($mode))->toStored();
 }
 
-/** Read a PfbTop1mSource from a raw stored value (legacy 'alexa' -> Tranco). */
+/** Read a PfbTop1mSource from a raw stored value (legacy 'alexa' -> Tranco, 'domcop' -> OpenPageRank). */
 function pfb_cfg_top1m_source_read(mixed $stored): PfbTop1mSource
 {
 	return PfbTop1mSource::fromStored($stored);
@@ -432,9 +440,10 @@ function pfb_cfg_top1m_source_read(mixed $stored): PfbTop1mSource
 
 /**
  * Write a PfbTop1mSource (enum or legacy string) back to its canonical stored
- * token ('tranco' | 'cisco' | 'domcop' | 'majestic' | 'cloudflare'). The dead
- * legacy 'alexa' token (#872) is never re-emitted — fromStored() already
- * coalesced it to Tranco before this runs.
+ * token ('tranco' | 'cisco' | 'openpagerank' | 'majestic' | 'cloudflare'). The
+ * dead legacy 'alexa' token (#872) and the moved legacy 'domcop' token (#928)
+ * are never re-emitted — fromStored() already coalesced them to Tranco /
+ * OpenPageRank respectively before this runs.
  */
 function pfb_cfg_top1m_source_write(PfbTop1mSource|string $source): string
 {
@@ -879,8 +888,9 @@ function pfb_cfg_registry(): array
 			'since'         => '1.0.0',
 		],
 
-		// TOP1M type selector: 'tranco' | 'cisco' | 'domcop' | 'majestic' | 'cloudflare'.
-		// Legacy 'alexa' (dead service, #872) coalesces to 'tranco' at the read boundary
+		// TOP1M type selector: 'tranco' | 'cisco' | 'openpagerank' | 'majestic' | 'cloudflare'.
+		// Legacy 'alexa' (dead service, #872) coalesces to 'tranco', and legacy 'domcop'
+		// (list moved hosting, #928) coalesces to 'openpagerank', at the read boundary
 		// via pfb_cfg_top1m_source_read(). Default 'tranco'.
 		'alexa_type' => [
 			'section'       => $dnsbl,
@@ -1673,9 +1683,10 @@ function pfb_run_migrations(): void
  *
  * The top1m_source adapter (pfb_cfg_top1m_source_read/write, issue #877) is wired
  * for alexa_type and returns a PfbTop1mSource enum. Legacy 'alexa' (dead service,
- * #872) coalesces to Tranco on read and is never re-emitted by a write; the
- * write vocabulary is 'tranco'|'cisco'|'domcop'|'majestic'|'cloudflare'
- * (domcop/majestic added ADR-59 P4, cloudflare added ADR-59 P5).
+ * #872) coalesces to Tranco on read, and legacy 'domcop' (list moved hosting,
+ * #928) coalesces to OpenPageRank on read; neither is ever re-emitted by a write.
+ * The write vocabulary is 'tranco'|'cisco'|'openpagerank'|'majestic'|'cloudflare'
+ * (openpagerank/majestic added ADR-59 P4, cloudflare added ADR-59 P5).
  *
  * @return array<string,list<string>>
  */
@@ -1705,12 +1716,13 @@ function pfb_cfg_field_vocab(): array
 		'alias_delta_mode' => ['auto', 'delta', 'replace'],
 
 		// TOP1M source selector (PfbTop1mSource, issue #877): the tokens a write can
-		// emit. 'tranco' (default) | 'cisco' | 'domcop' | 'majestic' | 'cloudflare'
-		// (domcop/majestic added ADR-59 P4, cloudflare added ADR-59 P5). The legacy
-		// 'alexa' token (dead service, #872) is a READ-ONLY legacy value —
-		// pfb_cfg_top1m_source_read() coalesces it to PfbTop1mSource::Tranco and it is
-		// never re-emitted by a write.
-		'top1m_source' => ['tranco', 'cisco', 'domcop', 'majestic', 'cloudflare'],
+		// emit. 'tranco' (default) | 'cisco' | 'openpagerank' | 'majestic' | 'cloudflare'
+		// (openpagerank/majestic added ADR-59 P4, cloudflare added ADR-59 P5). Two
+		// tokens are READ-ONLY legacy values — 'alexa' (dead service, #872) and
+		// 'domcop' (list moved hosting, #928) — pfb_cfg_top1m_source_read() coalesces
+		// them to PfbTop1mSource::Tranco / ::OpenPageRank respectively and neither is
+		// ever re-emitted by a write.
+		'top1m_source' => ['tranco', 'cisco', 'openpagerank', 'majestic', 'cloudflare'],
 
 		// Plain string (null/null adapters): identity. Backward-safe by construction.
 		// The 'plain' vocabulary contains the sentinel empty string; individual

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -203,8 +203,9 @@ enum PfbAliasDeltaMode: string implements PfbStoredEnum
 // PfbTop1mSource — TOP1M source selector (alexa_type, issue #877).
 //
 // Used by: alexa_type (config key) / $pfb['dnsbl_top1m_type'] (runtime).
-//   Canonical tokens: 'tranco' (default), 'cisco', 'openpagerank', 'majestic'
-//   (ADR-59 P4), 'cloudflare' (ADR-59 P5, token-authenticated). TWO tokens
+//   Canonical tokens: 'tranco' (default), 'cisco', 'openpagerank' (#928,
+//   replacing ADR-59 P4's 'domcop'), 'majestic' (ADR-59 P4), 'cloudflare'
+//   (ADR-59 P5, token-authenticated). TWO tokens
 //   are READ-ONLY legacy values, never re-emitted by a write: 'alexa' (the
 //   dead Alexa TOP1M service, #872) and 'domcop' (the DomCop top-10M list's
 //   hosting moved to OpenPageRank, #928) both coalesce to their replacement
@@ -1686,7 +1687,8 @@ function pfb_run_migrations(): void
  * #872) coalesces to Tranco on read, and legacy 'domcop' (list moved hosting,
  * #928) coalesces to OpenPageRank on read; neither is ever re-emitted by a write.
  * The write vocabulary is 'tranco'|'cisco'|'openpagerank'|'majestic'|'cloudflare'
- * (openpagerank/majestic added ADR-59 P4, cloudflare added ADR-59 P5).
+ * (majestic added ADR-59 P4, cloudflare added ADR-59 P5; openpagerank replaced
+ * P4's domcop in #928).
  *
  * @return array<string,list<string>>
  */
@@ -1717,7 +1719,8 @@ function pfb_cfg_field_vocab(): array
 
 		// TOP1M source selector (PfbTop1mSource, issue #877): the tokens a write can
 		// emit. 'tranco' (default) | 'cisco' | 'openpagerank' | 'majestic' | 'cloudflare'
-		// (openpagerank/majestic added ADR-59 P4, cloudflare added ADR-59 P5). Two
+		// (majestic added ADR-59 P4, cloudflare added ADR-59 P5; openpagerank
+		// replaced P4's domcop in #928). Two
 		// tokens are READ-ONLY legacy values — 'alexa' (dead service, #872) and
 		// 'domcop' (list moved hosting, #928) — pfb_cfg_top1m_source_read() coalesces
 		// them to PfbTop1mSource::Tranco / ::OpenPageRank respectively and neither is

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -169,7 +169,7 @@ $pfb['extras'][2]['type']	= 'top1m';
 
 // ADR-59 P5: header auth (Cloudflare Radar's Bearer token) via the P3 $feed['headers']
 // plumbing. A keyless provider's 'auth' is 'none', so pfb_top1m_auth_headers() returns
-// array() and this is a no-op for tranco/cisco/domcop/majestic, exactly as before P5.
+// array() and this is a no-op for tranco/cisco/openpagerank/majestic, exactly as before P5.
 // An empty/absent top1m_token also yields array() -- no Authorization header is sent,
 // so a missing token fails the download safely (pfblockerng_top1m()'s #886 preserve+warn
 // path keeps the previous TOP1M whitelist) rather than sending a malformed header.

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -195,7 +195,7 @@ if (is_dir("{$indexdir}")) {
 $options_dnsbl_webpage_cnt = count($options_dnsbl_webpage) ?: '1';
 
 $options_alexa_type		= [ 'tranco' => 'Tranco TOP1M', 'cisco' => 'Cisco Umbrella TOP1M',
-					    'domcop' => 'DomCop TOP1M', 'majestic' => 'Majestic Million TOP1M',
+					    'openpagerank' => 'OpenPageRank TOP1M', 'majestic' => 'Majestic Million TOP1M',
 					    'cloudflare' => 'Cloudflare Radar' ];
 
 // ADR-59 P5: providers whose 'auth' needs the top1m_token field, derived from the
@@ -3251,7 +3251,7 @@ $top1m_text = 'The TOP1M feed can be used to whitelist the most popular Domain n
 		<ul>
 			<li><a target="_blank" href="https://tranco-list.eu/">Tranco TOP1M</a></li>
 			<li><a target="_blank" href="https://s3-us-west-1.amazonaws.com/umbrella-static/index.html">Cisco Umbrella TOP1M</a></li>
-			<li><a target="_blank" href="https://www.domcop.com/top-10-million-domains">DomCop TOP1M</a></li>
+			<li><a target="_blank" href="https://openpagerank.keywordseverywhere.com/top-10-million-domains">OpenPageRank TOP1M</a></li>
 			<li><a target="_blank" href="https://majestic.com/reports/majestic-million">Majestic Million TOP1M</a> --
 				distributed under the <strong>Creative Commons Attribution (CC BY) 3.0</strong> License by:
 				<a target="_blank" href="https://majestic.com">Majestic</a>, attribution required.</li>

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -39,7 +39,8 @@ use PHPUnit\Framework\TestCase;
  *     And write(read('')) == 'off'    (normalised default).
  *
  * Scenario E — PfbTop1mSource (alexa_type, issue #877): backing values 'tranco' /
- *   'cisco' / 'openpagerank' / 'majestic' (the latter two added ADR-59 P4) TOP1M
+ *   'cisco' / 'openpagerank' (#928, replacing ADR-59 P4's 'domcop') / 'majestic'
+ *   (added ADR-59 P4) TOP1M
  *   source selector; the legacy 'alexa' token (dead service, #872) coalesces
  *   to Tranco, and the legacy 'domcop' token (list moved hosting, #928)
  *   coalesces to OpenPageRank.
@@ -676,7 +677,8 @@ final class CfgAdaptersTest extends TestCase
 	// -----------------------------------------------------------------------
 	// Scenario E — PfbTop1mSource (alexa_type, issue #877)
 	//   Stored tokens: 'tranco', 'cisco', 'openpagerank', 'majestic', 'cloudflare'
-	//   (live; the latter three added ADR-59 P4/P5); legacy 'alexa' (dead service,
+	//   (live; majestic/cloudflare added ADR-59 P4/P5, openpagerank replaced P4's
+	//   domcop in #928); legacy 'alexa' (dead service,
 	//   #872) coalesces to Tranco, legacy 'domcop' (list moved hosting, #928)
 	//   coalesces to OpenPageRank, both at the read boundary. Mirrors the
 	//   PfbAliasDeltaMode adapter shape (Scenario D): read returns the enum,
@@ -738,8 +740,8 @@ final class CfgAdaptersTest extends TestCase
 	}
 
 	/**
-	 * write(read(v)) == v for all five live canonical tokens (openpagerank/majestic added
-	 * P4, cloudflare added P5).
+	 * write(read(v)) == v for all five live canonical tokens (majestic added P4,
+	 * cloudflare added P5, openpagerank replaced P4's domcop in #928).
 	 */
 	public function testPfbTop1mSourceRoundTripCanonicalTokens(): void
 	{

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -39,14 +39,16 @@ use PHPUnit\Framework\TestCase;
  *     And write(read('')) == 'off'    (normalised default).
  *
  * Scenario E — PfbTop1mSource (alexa_type, issue #877): backing values 'tranco' /
- *   'cisco' / 'domcop' / 'majestic' (the latter two added ADR-59 P4) TOP1M
+ *   'cisco' / 'openpagerank' / 'majestic' (the latter two added ADR-59 P4) TOP1M
  *   source selector; the legacy 'alexa' token (dead service, #872) coalesces
- *   to Tranco.
+ *   to Tranco, and the legacy 'domcop' token (list moved hosting, #928)
+ *   coalesces to OpenPageRank.
  *     Given a raw stored value v.
  *     When pfb_cfg_top1m_source_read(v) -> enum, pfb_cfg_top1m_source_write(enum) -> stored.
- *     Then 'tranco'/'cisco'/'domcop'/'majestic' pass through as their own enum
- *     case; 'alexa' and any unknown/absent value -> Tranco. write(read(v)) == v
- *     for canonical tokens; 'alexa' is never re-emitted.
+ *     Then 'tranco'/'cisco'/'openpagerank'/'majestic' pass through as their own
+ *     enum case; 'alexa' -> Tranco, 'domcop' -> OpenPageRank, any other
+ *     unknown/absent value -> Tranco. write(read(v)) == v for canonical
+ *     tokens; neither legacy token is ever re-emitted.
  */
 final class CfgAdaptersTest extends TestCase
 {
@@ -673,11 +675,12 @@ final class CfgAdaptersTest extends TestCase
 
 	// -----------------------------------------------------------------------
 	// Scenario E — PfbTop1mSource (alexa_type, issue #877)
-	//   Stored tokens: 'tranco', 'cisco', 'domcop', 'majestic', 'cloudflare' (live;
-	//   the latter three added ADR-59 P4/P5); legacy 'alexa' (dead service, #872)
-	//   coalesces to Tranco at the read boundary. Mirrors the PfbAliasDeltaMode
-	//   adapter shape (Scenario D): read returns the enum, write accepts either
-	//   the enum or a raw string.
+	//   Stored tokens: 'tranco', 'cisco', 'openpagerank', 'majestic', 'cloudflare'
+	//   (live; the latter three added ADR-59 P4/P5); legacy 'alexa' (dead service,
+	//   #872) coalesces to Tranco, legacy 'domcop' (list moved hosting, #928)
+	//   coalesces to OpenPageRank, both at the read boundary. Mirrors the
+	//   PfbAliasDeltaMode adapter shape (Scenario D): read returns the enum,
+	//   write accepts either the enum or a raw string.
 	// -----------------------------------------------------------------------
 
 	public function testPfbTop1mSourceReadTrancoReturnsTranco(): void
@@ -691,9 +694,9 @@ final class CfgAdaptersTest extends TestCase
 	}
 
 	/** ADR-59 P4: the two new keyless-provider tokens read as their own enum cases. */
-	public function testPfbTop1mSourceReadDomCopReturnsDomCop(): void
+	public function testPfbTop1mSourceReadOpenPageRankReturnsOpenPageRank(): void
 	{
-		$this->assertSame(PfbTop1mSource::DomCop, pfb_cfg_top1m_source_read('domcop'));
+		$this->assertSame(PfbTop1mSource::OpenPageRank, pfb_cfg_top1m_source_read('openpagerank'));
 	}
 
 	public function testPfbTop1mSourceReadMajesticReturnsMajestic(): void
@@ -713,6 +716,12 @@ final class CfgAdaptersTest extends TestCase
 		$this->assertSame(PfbTop1mSource::Tranco, pfb_cfg_top1m_source_read('alexa'));
 	}
 
+	/** #928: DomCop's list moved hosting to OpenPageRank -- the legacy token must not vanish. */
+	public function testPfbTop1mSourceReadLegacyDomCopCoalescesToOpenPageRank(): void
+	{
+		$this->assertSame(PfbTop1mSource::OpenPageRank, pfb_cfg_top1m_source_read('domcop'));
+	}
+
 	public function testPfbTop1mSourceReadUnknownTokenDefaultsToTranco(): void
 	{
 		$this->assertSame(PfbTop1mSource::Tranco, pfb_cfg_top1m_source_read('junk'));
@@ -729,12 +738,12 @@ final class CfgAdaptersTest extends TestCase
 	}
 
 	/**
-	 * write(read(v)) == v for all five live canonical tokens (domcop/majestic added
+	 * write(read(v)) == v for all five live canonical tokens (openpagerank/majestic added
 	 * P4, cloudflare added P5).
 	 */
 	public function testPfbTop1mSourceRoundTripCanonicalTokens(): void
 	{
-		foreach (['tranco', 'cisco', 'domcop', 'majestic', 'cloudflare'] as $token) {
+		foreach (['tranco', 'cisco', 'openpagerank', 'majestic', 'cloudflare'] as $token) {
 			$written = pfb_cfg_top1m_source_write(pfb_cfg_top1m_source_read($token));
 			$this->assertSame($token, $written,
 				"expected write(read('{$token}')) == '{$token}'; actual: '{$written}'");
@@ -749,18 +758,26 @@ final class CfgAdaptersTest extends TestCase
 			"expected write(read('alexa')) == 'tranco'; actual: '{$written}'");
 	}
 
+	/** The legacy 'domcop' token never round-trips back to itself -- it is coalesced (#928). */
+	public function testPfbTop1mSourceRoundTripLegacyDomCopNeverReemitted(): void
+	{
+		$written = pfb_cfg_top1m_source_write(pfb_cfg_top1m_source_read('domcop'));
+		$this->assertSame('openpagerank', $written,
+			"expected write(read('domcop')) == 'openpagerank'; actual: '{$written}'");
+	}
+
 	/** pfb_cfg_top1m_source_write() accepts both an enum instance and a string. */
 	public function testPfbTop1mSourceWriteAcceptsEnumOrString(): void
 	{
-		$this->assertSame('tranco',     pfb_cfg_top1m_source_write(PfbTop1mSource::Tranco));
-		$this->assertSame('cisco',      pfb_cfg_top1m_source_write(PfbTop1mSource::Cisco));
-		$this->assertSame('domcop',     pfb_cfg_top1m_source_write(PfbTop1mSource::DomCop));
-		$this->assertSame('majestic',   pfb_cfg_top1m_source_write(PfbTop1mSource::Majestic));
-		$this->assertSame('cloudflare', pfb_cfg_top1m_source_write(PfbTop1mSource::Cloudflare));
-		$this->assertSame('tranco',     pfb_cfg_top1m_source_write('tranco'));
-		$this->assertSame('cisco',      pfb_cfg_top1m_source_write('cisco'));
-		$this->assertSame('domcop',     pfb_cfg_top1m_source_write('domcop'));
-		$this->assertSame('majestic',   pfb_cfg_top1m_source_write('majestic'));
-		$this->assertSame('cloudflare', pfb_cfg_top1m_source_write('cloudflare'));
+		$this->assertSame('tranco',       pfb_cfg_top1m_source_write(PfbTop1mSource::Tranco));
+		$this->assertSame('cisco',        pfb_cfg_top1m_source_write(PfbTop1mSource::Cisco));
+		$this->assertSame('openpagerank', pfb_cfg_top1m_source_write(PfbTop1mSource::OpenPageRank));
+		$this->assertSame('majestic',     pfb_cfg_top1m_source_write(PfbTop1mSource::Majestic));
+		$this->assertSame('cloudflare',   pfb_cfg_top1m_source_write(PfbTop1mSource::Cloudflare));
+		$this->assertSame('tranco',       pfb_cfg_top1m_source_write('tranco'));
+		$this->assertSame('cisco',        pfb_cfg_top1m_source_write('cisco'));
+		$this->assertSame('openpagerank', pfb_cfg_top1m_source_write('openpagerank'));
+		$this->assertSame('majestic',     pfb_cfg_top1m_source_write('majestic'));
+		$this->assertSame('cloudflare',   pfb_cfg_top1m_source_write('cloudflare'));
 	}
 }

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -370,7 +370,33 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	/**
-	 * alexa_type: all five live tokens pass through as their enum cases (domcop/majestic
+	 * alexa_type (issue #928): a stored legacy 'domcop' token (the DomCop TOP1M list's
+	 * hosting moved to OpenPageRank) coalesces to PfbTop1mSource::OpenPageRank through
+	 * the gateway's read adapter -- same shape as the 'alexa' legacy coalesce above.
+	 *
+	 * Scenario: an existing install with DomCop selected still reads safely.
+	 *   Given alexa_type stored as the legacy 'domcop' token.
+	 *   When PfbConfig::read('alexa_type').
+	 *   Then the result is PfbTop1mSource::OpenPageRank, not the dead 'domcop' token.
+	 */
+	public function testReadCoalescesLegacyDomCopTypeToOpenPageRank(): void
+	{
+		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/alexa_type';
+
+		// Given: legacy 'domcop' stored.
+		$this->seedConfig($path, 'domcop');
+		$this->assertSame('domcop', config_get_path($path), 'before: alexa_type seed is legacy domcop');
+
+		// When/Then: coalesced to PfbTop1mSource::OpenPageRank.
+		$this->assertSame(
+			PfbTop1mSource::OpenPageRank,
+			PfbConfig::read('alexa_type'),
+			"legacy 'domcop' coalesces to OpenPageRank"
+		);
+	}
+
+	/**
+	 * alexa_type: all five live tokens pass through as their enum cases (openpagerank/majestic
 	 * added ADR-59 P4, cloudflare added ADR-59 P5).
 	 */
 	public function testReadPassesThroughLivePfbTop1mSourceTokens(): void
@@ -383,8 +409,8 @@ final class CfgGatewayTest extends TestCase
 		$this->seedConfig($path, 'tranco');
 		$this->assertSame(PfbTop1mSource::Tranco, PfbConfig::read('alexa_type'), "'tranco' passes through as Tranco");
 
-		$this->seedConfig($path, 'domcop');
-		$this->assertSame(PfbTop1mSource::DomCop, PfbConfig::read('alexa_type'), "'domcop' passes through as DomCop");
+		$this->seedConfig($path, 'openpagerank');
+		$this->assertSame(PfbTop1mSource::OpenPageRank, PfbConfig::read('alexa_type'), "'openpagerank' passes through as OpenPageRank");
 
 		$this->seedConfig($path, 'majestic');
 		$this->assertSame(PfbTop1mSource::Majestic, PfbConfig::read('alexa_type'), "'majestic' passes through as Majestic");

--- a/tests/php/RollbackContractTest.php
+++ b/tests/php/RollbackContractTest.php
@@ -372,7 +372,7 @@ final class RollbackContractTest extends TestCase
 	 * Note: pfb_idn is now adapted via PfbIdnMode (NOT plain-string). See
 	 * testPfbIdnModeAdapterForwardAndBackward() for pfb_idn coverage. alexa_type is
 	 * likewise adapted via PfbTop1mSource (issue #877 review) -- see
-	 * testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa() for its coverage.
+	 * testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsLegacyTokens() for its coverage.
 	 */
 	public function testForwardPlainStringFieldsPassLegacyTokensUnchanged(): void
 	{
@@ -653,7 +653,7 @@ final class RollbackContractTest extends TestCase
 	 * Note: pfb_idn is now adapted via PfbIdnMode (NOT plain-string). See
 	 * testPfbIdnModeAdapterForwardAndBackward() for pfb_idn backward coverage. alexa_type
 	 * is likewise adapted via PfbTop1mSource (issue #877 review) -- see
-	 * testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa() for its coverage.
+	 * testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsLegacyTokens() for its coverage.
 	 */
 	public function testBackwardPlainStringFieldsIdentityAdapterCannotIntroduceNovelTokens(): void
 	{
@@ -662,7 +662,7 @@ final class RollbackContractTest extends TestCase
 		// than emitting identity for every input (e.g. the dropped alpha 'all' -> 'off').
 		// See testPfbIdnModeAdapterForwardAndBackward(). alexa_type is likewise excluded:
 		// it uses the PfbTop1mSource write adapter (enum-typed), covered by
-		// testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa() instead.
+		// testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsLegacyTokens() instead.
 		$cases = [
 			'pfb_interval'      => ['installedpackages/pfblockerng/config/0/pfb_interval', '6'],
 			'dnsbl_interface'   => ['installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_interface', 'lo0'],
@@ -1239,36 +1239,41 @@ final class RollbackContractTest extends TestCase
 	// -----------------------------------------------------------------------
 
 	/**
-	 * alexa_type: FORWARD invariant covers the legacy 'alexa' token (dead TOP1M
-	 * service, #872) in addition to the live 'tranco'/'cisco'/'domcop'/'majestic'/
-	 * 'cloudflare' vocabulary; BACKWARD invariant proves the coalesce -- a write
-	 * after reading a legacy 'alexa' store never re-emits 'alexa'.
+	 * alexa_type: FORWARD invariant covers the legacy 'alexa' AND 'domcop' tokens
+	 * (dead TOP1M service #872; DomCop's list moved hosting to OpenPageRank #928)
+	 * in addition to the live 'tranco'/'cisco'/'openpagerank'/'majestic'/'cloudflare'
+	 * vocabulary; BACKWARD invariant proves the coalesce -- a write after reading a
+	 * legacy 'alexa' or 'domcop' store never re-emits either legacy token.
 	 *
-	 * Scenario: alexa_type rollback contract with the #877 coalesce.
-	 *   Background: alexa_type's stored vocabulary is {'tranco', 'cisco', 'domcop',
-	 *     'majestic', 'cloudflare', 'alexa'} (the latter three live tokens added
-	 *     ADR-59 P4/P5; 'alexa' is READ-only -- pfb_cfg_field_vocab()['top1m_source']
-	 *     lists only the five live WRITE-side tokens). The field is now adapted via
-	 *     the PfbTop1mSource enum (mirrors PfbIdnMode/PfbAliasDeltaMode).
-	 *   Given each of 'tranco', 'cisco', 'domcop', 'majestic', 'cloudflare', 'alexa' stored.
+	 * Scenario: alexa_type rollback contract with the #877/#928 coalesces.
+	 *   Background: alexa_type's stored vocabulary is {'tranco', 'cisco', 'openpagerank',
+	 *     'majestic', 'cloudflare', 'alexa', 'domcop'} (the latter three live tokens added
+	 *     ADR-59 P4/P5; 'alexa'/'domcop' are READ-only --
+	 *     pfb_cfg_field_vocab()['top1m_source'] lists only the five live WRITE-side
+	 *     tokens). The field is now adapted via the PfbTop1mSource enum (mirrors
+	 *     PfbIdnMode/PfbAliasDeltaMode).
+	 *   Given each of 'tranco', 'cisco', 'openpagerank', 'majestic', 'cloudflare',
+	 *     'alexa', 'domcop' stored.
 	 *   When PfbConfig::read('alexa_type') then PfbConfig::write('alexa_type', result).
-	 *   Then (FORWARD) the read result is a PfbTop1mSource enum (Tranco for legacy 'alexa').
-	 *   And (BACKWARD) the written token is in {'tranco', 'cisco', 'domcop', 'majestic',
-	 *     'cloudflare'} -- 'alexa' is NEVER re-emitted, even though it was the original
-	 *     stored value.
+	 *   Then (FORWARD) the read result is a PfbTop1mSource enum (Tranco for legacy
+	 *     'alexa'; OpenPageRank for legacy 'domcop').
+	 *   And (BACKWARD) the written token is in {'tranco', 'cisco', 'openpagerank',
+	 *     'majestic', 'cloudflare'} -- neither 'alexa' nor 'domcop' is ever re-emitted,
+	 *     even though it was the original stored value.
 	 */
-	public function testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsAlexa(): void
+	public function testAlexaTypeForwardCoalescesLegacyAndBackwardNeverReemitsLegacyTokens(): void
 	{
 		$path        = 'installedpackages/pfblockerngdnsblsettings/config/0/alexa_type';
 		$write_vocab = pfb_cfg_field_vocab()['top1m_source'];
 
 		$cases = [
-			'tranco'     => PfbTop1mSource::Tranco,
-			'cisco'      => PfbTop1mSource::Cisco,
-			'domcop'     => PfbTop1mSource::DomCop,     // ADR-59 P4
-			'majestic'   => PfbTop1mSource::Majestic,   // ADR-59 P4
-			'cloudflare' => PfbTop1mSource::Cloudflare, // ADR-59 P5
-			'alexa'      => PfbTop1mSource::Tranco,     // legacy dead source coalesces to Tranco (#872/#877)
+			'tranco'       => PfbTop1mSource::Tranco,
+			'cisco'        => PfbTop1mSource::Cisco,
+			'openpagerank' => PfbTop1mSource::OpenPageRank, // ADR-59 P4
+			'majestic'     => PfbTop1mSource::Majestic,     // ADR-59 P4
+			'cloudflare'   => PfbTop1mSource::Cloudflare,   // ADR-59 P5
+			'alexa'        => PfbTop1mSource::Tranco,       // legacy dead source coalesces to Tranco (#872/#877)
+			'domcop'       => PfbTop1mSource::OpenPageRank, // legacy: list moved hosting (#928)
 		];
 
 		foreach ($cases as $stored_token => $expected_runtime) {
@@ -1290,7 +1295,7 @@ final class RollbackContractTest extends TestCase
 				"FORWARD: alexa_type token='{$stored_token}' must read as {$expected_runtime->name}"
 			);
 
-			// BACKWARD: write(runtime) stores only a live vocabulary token -- never 'alexa'.
+			// BACKWARD: write(runtime) stores only a live vocabulary token -- never a legacy token.
 			PfbConfig::write('alexa_type', $runtime);
 			$stored = (string) config_get_path($path);
 			$this->assertContains($stored, $write_vocab,
@@ -1298,6 +1303,9 @@ final class RollbackContractTest extends TestCase
 			);
 			$this->assertNotSame('alexa', $stored,
 				"BACKWARD: alexa_type write must never re-emit dead legacy token 'alexa'"
+			);
+			$this->assertNotSame('domcop', $stored,
+				"BACKWARD: alexa_type write must never re-emit moved legacy token 'domcop'"
 			);
 		}
 	}

--- a/tests/php/Top1mAuthHeadersTest.php
+++ b/tests/php/Top1mAuthHeadersTest.php
@@ -56,7 +56,7 @@ final class Top1mAuthHeadersTest extends TestCase
 	}
 
 	/**
-	 * Every keyless provider (auth == 'none', Tranco/Cisco/DomCop/Majestic today) must
+	 * Every keyless provider (auth == 'none', Tranco/Cisco/OpenPageRank/Majestic today) must
 	 * never emit a header, EVEN IF a token happens to be stored (e.g. left over from a
 	 * prior Cloudflare selection) -- only the active provider's OWN auth requirement
 	 * governs whether the token is sent.

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -44,12 +44,14 @@ use PHPUnit\Framework\TestCase;
  *   * a SYNTHETIC descriptor's header/domain_col knobs are honoured (below) -- no live
  *     non-Tranco/Cisco provider exists yet (ADR-59 Phase 4 adds one)
  *
- * ADR-59 P4 addendum: the two live non-Tranco/Cisco providers (DomCop, Majestic) added
- * by this phase -- their REAL sample shape parses correctly via the registered
+ * ADR-59 P4 addendum: the two live non-Tranco/Cisco providers (OpenPageRank, Majestic)
+ * added by this phase -- their REAL sample shape parses correctly via the registered
  * descriptor, and a wrong domain_col genuinely mis-reads (fail-before/pass-after).
+ * (OpenPageRank was originally DomCop; the list's hosting moved, #928 -- same
+ * descriptor shape/index, only the URL/label/token changed.)
  *
  * ADR-59 P5 addendum: Cloudflare Radar (token-authenticated) parses its REAL shape too
- * (a single 'domain' column, no rank) -- this exposed a genuine latent bug the DomCop/
+ * (a single 'domain' column, no rank) -- this exposed a genuine latent bug the OpenPageRank/
  * Majestic tests couldn't: the generic content filter required a comma on every data
  * line, but a single-column CSV line has none, so every Cloudflare row was silently
  * skipped regardless of domain_col. Fixed (pfblockerng.inc) by only requiring a comma
@@ -455,54 +457,57 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	}
 
 	/**
-	 * ADR-59 P4 -- pfblockerng_top1m() parses DomCop's REAL CSV shape (quoted
-	 * 3-col header, Domain at str_getcsv() index 1) via its registered provider
+	 * ADR-59 P4 -- pfblockerng_top1m() parses OpenPageRank's REAL CSV shape (unquoted
+	 * 5-col header, Domain at str_getcsv() index 1) via its registered provider
 	 * descriptor. Sample verified against the live
-	 * domcop.com/files/top/top10milliondomains.csv format (fetched during
-	 * development of this test).
+	 * openpagerank.keywordseverywhere.com/downloads/top10milliondomains.csv format
+	 * (fetched 2026-07-07; #928 -- this list was formerly hosted by DomCop, whose
+	 * URL froze 2026-03-29).
 	 *
-	 * DomCop's own Domain column happens to sit at the SAME index (1) the
+	 * OpenPageRank's own Domain column happens to sit at the SAME index (1) the
 	 * pre-Phase-2 legacy default already used, so replaying that legacy shape
 	 * verbatim (as the Majestic test above does) would coincidentally still
-	 * parse DomCop's real sample correctly -- on its own it would NOT prove
+	 * parse OpenPageRank's real sample correctly -- on its own it would NOT prove
 	 * domain_col is read from the descriptor rather than hardcoded. To still
-	 * assert "the col index matters" for DomCop, this FAIL-BEFORE/PASS-AFTER
-	 * instead probes a WRONG column for DomCop's shape (domain_col 2 -- the
-	 * "Open Page Rank" field, Majestic's own domain_col) and shows it likewise
-	 * mis-reads; the registered DomCop descriptor (domain_col 1) is correct.
+	 * assert "the col index matters" for OpenPageRank, this FAIL-BEFORE/PASS-AFTER
+	 * instead probes a WRONG column for OpenPageRank's shape (domain_col 2 -- the
+	 * "Extension" field, e.g. "com": dotless, so it cannot be mistaken for a
+	 * hostname) and shows it likewise mis-reads; the registered OpenPageRank
+	 * descriptor (domain_col 1) is correct.
 	 *
-	 * #892 review addendum: the wrong column's value ("10.00") also doesn't look
+	 * #892 review addendum: the wrong column's value ("com") also doesn't look
 	 * like a hostname, so the domain-validity guard (finding 1) now rejects it as
 	 * no-real-data rather than "valid data, zero TLD matches" -- the BEFORE
 	 * assertions reflect that (no whitelist file at all, not an empty one).
 	 */
-	public function testDomCopRealShapeSampleMisreadsOnWrongColumnAndParsesCorrectlyViaItsDescriptor(): void
+	public function testOpenPageRankRealShapeSampleMisreadsOnWrongColumnAndParsesCorrectlyViaItsDescriptor(): void
 	{
-		// Given: a real-shape DomCop sample -- quoted 3-col header, Domain at
+		// Given: a real-shape OpenPageRank sample -- unquoted 5-col header
+		// (Rank,Domain,Extension,Open Page Rank,Referring Domains), Domain at
 		// index 1, two real '.com' domains matching the 'com' TLD inclusion.
-		$csv = "\"Rank\",\"Domain\",\"Open Page Rank\"\n"
-			. "\"1\",\"www.facebook.com\",\"10.00\"\n"
-			. "\"2\",\"fonts.googleapis.com\",\"10.00\"\n";
-		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: real-shape DomCop sample');
+		$csv = "Rank,Domain,Extension,Open Page Rank,Referring Domains\n"
+			. "1,www.facebook.com,com,10,2059716\n"
+			. "2,fonts.googleapis.com,com,10,2059716\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: real-shape OpenPageRank sample');
 
-		// When (BEFORE): the WRONG column for this shape -- index 2 ("Open Page
-		// Rank", a decimal string with no matching TLD, and no matching hostname shape).
+		// When (BEFORE): the WRONG column for this shape -- index 2 ("Extension",
+		// a bare dotless TLD string with no matching TLD, and no matching hostname shape).
 		$wrongColumn = ['parse' => 'csv', 'header' => true, 'domain_col' => 2];
 		pfblockerng_top1m($wrongColumn);
 
-		// Then (RED): the real domains are misread as the Open Page Rank value
-		// ("10.00"), which is neither a valid TLD match NOR a hostname-shaped value --
+		// Then (RED): the real domains are misread as the Extension value ("com"),
+		// which is neither a valid TLD match NOR a hostname-shaped value (no dot) --
 		// no whitelist can be built (none existed before this run).
 		$this->assertFileDoesNotExist($this->whitelistPath(),
-			"domain_col 2 must MIS-read DomCop's real shape -- Domain sits at index 1, not 2");
+			"domain_col 2 must MIS-read OpenPageRank's real shape -- Domain sits at index 1, not 2");
 		$this->assertStringContainsString('no TOP1M whitelist available', $this->readMainLog());
 		$this->assertStringNotContainsString('Parsed 2 lines', $this->readMainLog());
 
 		// Reset the log so the GREEN assertion below is unambiguous.
 		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['log'], ''), 'reset main log between runs');
 
-		// When (AFTER): the actual registered DomCop descriptor.
-		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::DomCop->value]);
+		// When (AFTER): the actual registered OpenPageRank descriptor.
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::OpenPageRank->value]);
 
 		// Then (GREEN): both real domains are correctly extracted from index 1
 		// ('www.' stripped per the existing whitelist-building convention).
@@ -510,7 +515,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 			".facebook.com,,\n,facebook.com,,\n,www.facebook.com,,\n"
 			. ".fonts.googleapis.com,,\n,fonts.googleapis.com,,\n,www.fonts.googleapis.com,,\n",
 			file_get_contents($this->whitelistPath()),
-			'the registered DomCop descriptor must extract Domain from index 1'
+			'the registered OpenPageRank descriptor must extract Domain from index 1'
 		);
 		$this->assertStringContainsString('Parsed 2 lines | Found 2 of 1000', $this->readMainLog());
 	}
@@ -521,7 +526,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 * this phase, NOT the ADR's original 2-column guess) via its registered descriptor
 	 * (domain_col 0, header skipped).
 	 *
-	 * Unlike the DomCop/Majestic column-index bug above, this shape exposed a DIFFERENT
+	 * Unlike the OpenPageRank/Majestic column-index bug above, this shape exposed a DIFFERENT
 	 * latent bug: the generic content filter demanded BOTH a '.' AND a ',' on every data
 	 * line (a guard against a prose/error body that would otherwise reach the parser).
 	 * A single-column CSV line has NO comma at all (nothing to delimit), so every one of
@@ -529,7 +534,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 * whitelist came out EMPTY even though the fixture data is genuinely well-formed.
 	 * FAIL-BEFORE/PASS-AFTER: manually verified by reverting just the comma-relaxation
 	 * hunk in pfblockerng.inc (`git stash`) and re-running this exact test -- it goes RED
-	 * (empty whitelist, same as the DomCop/Majestic BEFORE runs above); restoring the fix
+	 * (empty whitelist, same as the OpenPageRank/Majestic BEFORE runs above); restoring the fix
 	 * makes it GREEN. This test's own body only exercises the (permanent) AFTER state --
 	 * see RESULTS/05_Results.txt for the stash verification transcript.
 	 */
@@ -557,7 +562,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 
 	/**
 	 * #892 review (finding 1) -- the #886 silent-whitelist-wipe must not re-open for the
-	 * 'csv' parse providers (DomCop/Majestic/Cloudflare). Pre-fix, the domain-validity
+	 * 'csv' parse providers (OpenPageRank/Majestic/Cloudflare). Pre-fix, the domain-validity
 	 * guard only covered 'rank_domain' (Tranco/Cisco); a 'csv'-mode garbage/HTML/JSON
 	 * error body (a CDN 503 page, a Cloudflare auth-error response, etc -- the MIME
 	 * allow-list accepts text/html and ADR-49's sanity scan is opt-in/default-off) still
@@ -569,10 +574,11 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 * garbage row here has a non-hostname domain field but would still have incremented
 	 * $linecnt on the pre-fix code, taking the wipe path).
 	 */
-	public function testDomCopGarbageHtmlBodyPreservesPriorWhitelistAndWarns(): void
+	public function testOpenPageRankGarbageHtmlBodyPreservesPriorWhitelistAndWarns(): void
 	{
 		// Given: a prior good whitelist and a multi-line HTML error body (a CDN 503 page,
-		// NOT DomCop's real quoted rank/domain/pagerank CSV) written as top-1m.csv.
+		// NOT OpenPageRank's real unquoted rank/domain/extension/pagerank/refdomains CSV)
+		// written as top-1m.csv.
 		$priorContent = ".real.com,,\n,real.com,,\n,www.real.com,,\n";
 		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
 		$garbage = "<html><head><title>503 Backend fetch failed</title></head>\n"
@@ -581,14 +587,14 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertNotFalse(file_put_contents($this->csvPath(), $garbage), 'setup: garbage HTML body as top-1m.csv');
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
 
-		// When: the real registered DomCop descriptor drives the parse (header=TRUE skips
+		// When: the real registered OpenPageRank descriptor drives the parse (header=TRUE skips
 		// line 1; domain_col=1).
-		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::DomCop->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::OpenPageRank->value]);
 
-		// Then: the HTML body must never be mistaken for real DomCop CSV data -- the prior
+		// Then: the HTML body must never be mistaken for real OpenPageRank CSV data -- the prior
 		// whitelist survives byte-identical and the run warns instead of "succeeding".
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
-			'a garbage HTML body must NOT wipe the previously-good TOP1M whitelist (DomCop, #892 review)');
+			'a garbage HTML body must NOT wipe the previously-good TOP1M whitelist (OpenPageRank, #892 review)');
 		$this->assertSame([], $this->tempFilesLeftBehind(), 'no temp build file left behind');
 		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readErrLog());
 		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
@@ -681,7 +687,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 * Issue #904 -- the 'csv' parse guard's final-label class (`[A-Za-z]{2,}`)
 	 * rejected every punycode TLD (they contain digits/hyphens, e.g.
 	 * 'xn--p1ai' == .рф), so a user selecting a punycode TLD inclusion with a
-	 * csv-parse provider (DomCop/Majestic/Cloudflare) got ZERO matching
+	 * csv-parse provider (OpenPageRank/Majestic/Cloudflare) got ZERO matching
 	 * whitelist entries -- silently -- while the identical config on
 	 * Tranco/Cisco ('rank_domain' parse, no such guard) whitelisted them.
 	 * Fixed by widening the final-label alternative to also accept an
@@ -697,15 +703,15 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 */
 	public function testCsvModeAcceptsPunycodeTldDomainIntoWhitelist(): void
 	{
-		// Given: a DomCop-shaped csv row whose domain ends in a punycode TLD
+		// Given: an OpenPageRank-shaped csv row whose domain ends in a punycode TLD
 		// (xn--p1ai == .рф), and the TOP1M inclusion set names that exact TLD.
 		$GLOBALS['pfb']['dnsbl_top1m_inc'] = 'xn--p1ai';
-		$csv = "\"Rank\",\"Domain\",\"Open Page Rank\"\n"
-			. "\"1\",\"example.xn--p1ai\",\"10.00\"\n";
-		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: DomCop-shaped punycode-TLD row');
+		$csv = "Rank,Domain,Extension,Open Page Rank,Referring Domains\n"
+			. "1,example.xn--p1ai,xn--p1ai,10,2059716\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: OpenPageRank-shaped punycode-TLD row');
 
 		// When
-		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::DomCop->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::OpenPageRank->value]);
 
 		// Then: the punycode-TLD row is counted as valid data and whitelisted
 		// -- not silently dropped by the final-label guard.
@@ -725,17 +731,17 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 */
 	public function testCsvModeStillRejectsNumericTldJunkRow(): void
 	{
-		// Given: a prior good whitelist and a DomCop-shaped row whose "Domain"
+		// Given: a prior good whitelist and an OpenPageRank-shaped row whose "Domain"
 		// field is an IP-shaped string -- garbage, not a TLD in any form.
 		$priorContent = ".real.com,,\n,real.com,,\n,www.real.com,,\n";
 		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
-		$csv = "\"Rank\",\"Domain\",\"Open Page Rank\"\n"
-			. "\"1\",\"192.168.1.1\",\"10.00\"\n";
+		$csv = "Rank,Domain,Extension,Open Page Rank,Referring Domains\n"
+			. "1,192.168.1.1,com,10,2059716\n";
 		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: numeric-TLD junk row');
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
 
 		// When
-		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::DomCop->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::OpenPageRank->value]);
 
 		// Then: the numeric-final-label row is still rejected.
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
@@ -751,12 +757,12 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 */
 	public function testCsvModeStillRejectsDomainFieldWithNoDot(): void
 	{
-		// Given: a prior good whitelist and a DomCop-shaped row whose Domain
+		// Given: a prior good whitelist and an OpenPageRank-shaped row whose Domain
 		// field has no dot at all.
 		$priorContent = ".real.com,,\n,real.com,,\n,www.real.com,,\n";
 		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
-		$csv = "\"Rank\",\"Domain\",\"Open Page Rank\"\n"
-			. "\"1\",\"nodomainhere\",\"v1.0\"\n";
+		$csv = "Rank,Domain,Extension,Open Page Rank,Referring Domains\n"
+			. "1,nodomainhere,v1.0,10,2059716\n";
 		$this->assertNotFalse(
 			file_put_contents($this->csvPath(), $csv),
 			'setup: dotless Domain field, dot elsewhere on the line'
@@ -764,7 +770,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
 
 		// When
-		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::DomCop->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::OpenPageRank->value]);
 
 		// Then: a dotless Domain field is still rejected even though the line
 		// itself contains a '.' (in another column).
@@ -788,17 +794,17 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 */
 	public function testCsvModeStillRejectsMalformedPunycodeTldRow(string $domain): void
 	{
-		// Given: a prior good whitelist and a DomCop-shaped row whose Domain
+		// Given: a prior good whitelist and an OpenPageRank-shaped row whose Domain
 		// field ends in a malformed punycode-shaped TLD.
 		$priorContent = ".real.com,,\n,real.com,,\n,www.real.com,,\n";
 		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
-		$csv = "\"Rank\",\"Domain\",\"Open Page Rank\"\n"
-			. "\"1\",\"{$domain}\",\"10.00\"\n";
+		$csv = "Rank,Domain,Extension,Open Page Rank,Referring Domains\n"
+			. "1,{$domain},com,10,2059716\n";
 		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), "setup: malformed punycode row {$domain}");
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
 
 		// When
-		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::DomCop->value]);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::OpenPageRank->value]);
 
 		// Then: the malformed punycode-shaped TLD is rejected -- the widening
 		// admits real ACE labels only, not hyphen-runs or truncated prefixes.

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -491,13 +491,15 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: real-shape OpenPageRank sample');
 
 		// When (BEFORE): the WRONG column for this shape -- index 2 ("Extension",
-		// a bare dotless TLD string with no matching TLD, and no matching hostname shape).
+		// a bare dotless string like "com" -- the hostname-shape guard rejects it
+		// before TLD matching is ever reached).
 		$wrongColumn = ['parse' => 'csv', 'header' => true, 'domain_col' => 2];
 		pfblockerng_top1m($wrongColumn);
 
 		// Then (RED): the real domains are misread as the Extension value ("com"),
-		// which is neither a valid TLD match NOR a hostname-shaped value (no dot) --
-		// no whitelist can be built (none existed before this run).
+		// which the domain-validity guard rejects as not hostname-shaped (no dot),
+		// so TLD matching is never reached -- no whitelist can be built (none
+		// existed before this run).
 		$this->assertFileDoesNotExist($this->whitelistPath(),
 			"domain_col 2 must MIS-read OpenPageRank's real shape -- Domain sits at index 1, not 2");
 		$this->assertStringContainsString('no TOP1M whitelist available', $this->readMainLog());

--- a/tests/php/Top1mProvidersTest.php
+++ b/tests/php/Top1mProvidersTest.php
@@ -17,8 +17,9 @@ use PHPUnit\Framework\TestCase;
  * parser/extractor) reads a single source of truth. Tranco/Cisco stay
  * BEHAVIOUR-PRESERVING throughout: this oracle pins their resolved URL to the
  * exact pre-ADR-59 literal, so any future edit to the table that drifts
- * tranco/cisco's URL fails loudly. Phase 4 adds OpenPageRank + Majestic as two
- * more rows in the same table -- their own shape is pinned separately below.
+ * tranco/cisco's URL fails loudly. Phase 4 added DomCop + Majestic as two more
+ * rows in the same table (DomCop's row became OpenPageRank in #928) -- their
+ * own shape is pinned separately below.
  * Phase 5 adds Cloudflare Radar -- the first (and so far only) header-auth
  * provider, whose real API shape (verified against Cloudflare's own docs, NOT
  * the ADR's original guess) is a single-column 'domain' CSV, no rank -- domain_col 0.
@@ -84,7 +85,8 @@ final class Top1mProvidersTest extends TestCase
 	}
 
 	/**
-	 * ADR-59 P4 -- OpenPageRank/Majestic's own shape (distinct container/parse/domain_col
+	 * ADR-59 P4 -- OpenPageRank/Majestic's own shape (OpenPageRank was P4's DomCop,
+	 * #928; distinct container/parse/domain_col
 	 * per the ADR §2.2 table + Phase 2's 0-indexed domain_col convention): OpenPageRank's
 	 * Domain is the 2nd CSV field (index 1, same index Tranco/Cisco use); Majestic's
 	 * Domain is the 3rd field (index 2). Majestic's container is 'plain' (uncompressed

--- a/tests/php/Top1mProvidersTest.php
+++ b/tests/php/Top1mProvidersTest.php
@@ -7,7 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * ADR-59 Phase 1 -- pfb_top1m_providers() extraction oracle. Extended Phase 4
- * to add the keyless providers DomCop + Majestic, and Phase 5 to add the
+ * to add the keyless providers DomCop (now OpenPageRank, #928 -- the DomCop
+ * URL froze when the list's hosting moved) + Majestic, and Phase 5 to add the
  * token-authenticated Cloudflare Radar provider.
  *
  * Before Phase 1, pfblockerng.php:162 picked the TOP1M download URL with a
@@ -16,11 +17,11 @@ use PHPUnit\Framework\TestCase;
  * parser/extractor) reads a single source of truth. Tranco/Cisco stay
  * BEHAVIOUR-PRESERVING throughout: this oracle pins their resolved URL to the
  * exact pre-ADR-59 literal, so any future edit to the table that drifts
- * tranco/cisco's URL fails loudly. Phase 4 adds DomCop + Majestic as two more
- * rows in the same table -- their own shape is pinned separately below. Phase 5
- * adds Cloudflare Radar -- the first (and so far only) header-auth provider,
- * whose real API shape (verified against Cloudflare's own docs, NOT the ADR's
- * original guess) is a single-column 'domain' CSV, no rank -- domain_col 0.
+ * tranco/cisco's URL fails loudly. Phase 4 adds OpenPageRank + Majestic as two
+ * more rows in the same table -- their own shape is pinned separately below.
+ * Phase 5 adds Cloudflare Radar -- the first (and so far only) header-auth
+ * provider, whose real API shape (verified against Cloudflare's own docs, NOT
+ * the ADR's original guess) is a single-column 'domain' CSV, no rank -- domain_col 0.
  */
 #[CoversFunction('pfb_top1m_providers')]
 final class Top1mProvidersTest extends TestCase
@@ -45,12 +46,12 @@ final class Top1mProvidersTest extends TestCase
 		);
 	}
 
-	/** ADR-59 P4 -- the two new keyless providers' URLs, per the ADR §2.2 table. */
-	public function testDomCopAndMajesticUrlsMatchTheAdrTable(): void
+	/** ADR-59 P4 -- the two new keyless providers' URLs; OpenPageRank's per #928 (was DomCop). */
+	public function testOpenPageRankAndMajesticUrlsMatchTheAdrTable(): void
 	{
 		$this->assertSame(
-			'https://www.domcop.com/files/top/top10milliondomains.csv.zip',
-			pfb_top1m_providers()[PfbTop1mSource::DomCop->value]['url']
+			'https://openpagerank.keywordseverywhere.com/downloads/top10milliondomains.csv.zip',
+			pfb_top1m_providers()[PfbTop1mSource::OpenPageRank->value]['url']
 		);
 		$this->assertSame(
 			'https://downloads.majestic.com/majestic_million.csv',
@@ -62,7 +63,7 @@ final class Top1mProvidersTest extends TestCase
 	public function testFiveProvidersAreDescribed(): void
 	{
 		$this->assertSame(
-			['tranco', 'cisco', 'domcop', 'majestic', 'cloudflare'],
+			['tranco', 'cisco', 'openpagerank', 'majestic', 'cloudflare'],
 			array_keys(pfb_top1m_providers())
 		);
 	}
@@ -83,20 +84,20 @@ final class Top1mProvidersTest extends TestCase
 	}
 
 	/**
-	 * ADR-59 P4 -- DomCop/Majestic's own shape (distinct container/parse/domain_col
-	 * per the ADR §2.2 table + Phase 2's 0-indexed domain_col convention): DomCop's
+	 * ADR-59 P4 -- OpenPageRank/Majestic's own shape (distinct container/parse/domain_col
+	 * per the ADR §2.2 table + Phase 2's 0-indexed domain_col convention): OpenPageRank's
 	 * Domain is the 2nd CSV field (index 1, same index Tranco/Cisco use); Majestic's
 	 * Domain is the 3rd field (index 2). Majestic's container is 'plain' (uncompressed
 	 * CSV), not 'zip' -- the one provider so far that isn't a zip download.
 	 */
-	public function testDomCopAndMajesticDescribeTheirOwnCsvShape(): void
+	public function testOpenPageRankAndMajesticDescribeTheirOwnCsvShape(): void
 	{
-		$domcop = pfb_top1m_providers()[PfbTop1mSource::DomCop->value];
-		$this->assertSame('zip', $domcop['container'], 'domcop: container must be zip');
-		$this->assertSame('csv', $domcop['parse'], 'domcop: parse must be csv');
-		$this->assertTrue($domcop['header'], 'domcop: header row must be skipped');
-		$this->assertSame(1, $domcop['domain_col'], 'domcop: Domain is the 2nd CSV field -> index 1');
-		$this->assertSame('none', $domcop['auth'], 'domcop: auth must be none');
+		$openpagerank = pfb_top1m_providers()[PfbTop1mSource::OpenPageRank->value];
+		$this->assertSame('zip', $openpagerank['container'], 'openpagerank: container must be zip');
+		$this->assertSame('csv', $openpagerank['parse'], 'openpagerank: parse must be csv');
+		$this->assertTrue($openpagerank['header'], 'openpagerank: header row must be skipped');
+		$this->assertSame(1, $openpagerank['domain_col'], 'openpagerank: Domain is the 2nd CSV field -> index 1');
+		$this->assertSame('none', $openpagerank['auth'], 'openpagerank: auth must be none');
 
 		$majestic = pfb_top1m_providers()[PfbTop1mSource::Majestic->value];
 		$this->assertSame('plain', $majestic['container'], 'majestic: container must be plain (uncompressed)');

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -712,7 +712,7 @@ def test_dnsbl_control_fields_render(webui: WebUI, php_error_log_guard: PhpError
 
 def test_dnsbl_top1m_source_options_exclude_alexa(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """The TOP1M 'Type' select renders the five live sources (Tranco, Cisco
-    Umbrella, DomCop, Majestic Million — added ADR-59 Phase 4 — and Cloudflare
+    Umbrella, OpenPageRank, Majestic Million — added ADR-59 Phase 4 — and Cloudflare
     Radar — added ADR-59 Phase 5) — the dead Alexa TOP1M option (#872) is dropped
     from the page (#877), so a regression that resurrects the option, or drops a
     live one, is caught at the render tier. Majestic's CC BY 3.0 and Cloudflare's
@@ -732,7 +732,7 @@ def test_dnsbl_top1m_source_options_exclude_alexa(webui: WebUI, php_error_log_gu
     for needle in (
         "Tranco TOP1M",
         "Cisco Umbrella TOP1M",
-        "DomCop TOP1M",
+        "OpenPageRank TOP1M",
         "Majestic Million TOP1M",
         "Cloudflare Radar",
     ):

--- a/tests/test_check_top1m_providers.py
+++ b/tests/test_check_top1m_providers.py
@@ -226,9 +226,9 @@ def test_extract_providers_reads_the_real_descriptor_file_and_finds_all_five() -
     # go undetected here while still breaking check_top1m_providers.py in CI. Read the
     # real file straight off disk instead of a fixture.
     providers = {p["name"]: p for p in ctp.extract_providers(ctp.DEFAULT_DESCRIPTOR_FILE.read_text(encoding="utf-8"))}
-    assert set(providers) == {"Tranco", "Cisco Umbrella", "DomCop", "Majestic Million", "Cloudflare Radar"}
+    assert set(providers) == {"Tranco", "Cisco Umbrella", "OpenPageRank", "Majestic Million", "Cloudflare Radar"}
 
-    for name in ("Tranco", "Cisco Umbrella", "DomCop", "Majestic Million"):
+    for name in ("Tranco", "Cisco Umbrella", "OpenPageRank", "Majestic Million"):
         assert providers[name]["auth"] == "none", name
         assert providers[name]["secret_env"] == "", name
 
@@ -395,7 +395,7 @@ def test_validate_top1m_flags_staleness_only_once_last_modified_ages_past_the_li
 
 
 # A ~5-month-old Last-Modified: past the old 30-day default, well within the new
-# 6-month one. A provider that refreshes only monthly/quarterly (e.g. DomCop) is
+# 6-month one. A provider that refreshes only monthly/quarterly (e.g. OpenPageRank) is
 # not dead at this age.
 _WITHIN_SIX_MONTHS_LM = "Fri, 06 Feb 2026 00:00:00 GMT"  # 150 days before _NOW
 
@@ -426,7 +426,7 @@ def test_validate_top1m_passes_a_plain_container_body_with_no_zip_wrapper() -> N
 
 
 def test_validate_top1m_skips_a_header_row_in_a_plain_wide_csv_with_domain_not_in_column_zero() -> None:
-    # Majestic/DomCop-shaped: a header row, then real rows with the domain in
+    # Majestic/OpenPageRank-shaped: a header row, then real rows with the domain in
     # a column other than 0/1 -- _is_valid_row must find it anywhere in the
     # row (provider-agnostic), and the header row (no dotted field) must not
     # count as valid or as the "first bad row".


### PR DESCRIPTION
Fixes #928.

## What

The DomCop top-10M list's hosting moved to OpenPageRank; the shipped DomCop URL has served
a file frozen at `Last-Modified: 2026-03-29` for ~100 days (the weekly healthcheck's 180-day
staleness gate would start failing in ~80 more). This PR replaces the `domcop` provider with
`openpagerank`:

- **Enum/token**: `PfbTop1mSource::DomCop ('domcop')` → `::OpenPageRank ('openpagerank')`.
  The stored legacy `'domcop'` token coalesces to OpenPageRank on read and is never
  re-emitted by a write — the exact pattern of the dead `'alexa'` → Tranco token (#872), so
  existing installs migrate transparently on their next settings save.
- **Descriptor**: new URL `https://openpagerank.keywordseverywhere.com/downloads/top10milliondomains.csv.zip`
  (302 → `download.openpagerank.net`, followed by `pfb_download()` and the healthcheck alike).
  Container/parse mechanics unchanged: zip, csv, header row, Domain at `str_getcsv()` index 1 —
  verified against the real payload (fetched 2026-07-07: 10,000,000 rows, header
  `Rank,Domain,Extension,Open Page Rank,Referring Domains`, `Last-Modified: 2026-06-28`).
- **UI**: option label + provider link on the DNSBL page (no licence note — none is stated,
  same as DomCop).
- **Tests**: vocabulary/rollback-contract/gateway coverage extended with the legacy coalesce
  (`'domcop'` read → OpenPageRank; write never re-emits `'domcop'`); all
  `Top1mPreserveOnEmptyFeedTest` fixtures reshaped to OpenPageRank's real 5-column CSV
  (every hostile axis retained — wrong-column probe, garbage-HTML preserve+warn, punycode
  TLD, numeric/dotless junk); Tier-A `ui_render` label assertion updated.
- **Docs/healthcheck**: `top1m-providers.md` (incl. the now-outdated "OpenPageRank is
  API-only" out-of-scope note), `config-gateway.md`, comment-only updates in
  `check_top1m_providers.py`. The healthcheck workflow needs no edit — its matrix
  self-derives from the descriptor table (`MIN_PROVIDERS` stays 5).

## Verification

- Full gate run green: PHPUnit 2352 tests / 18705 assertions, PHPStan, PHPCS, `php -l`,
  pytest 2231 passed, ruff + format, mypy, markdownlint.
- Red→green executed both directions (enum case absent pre-change → 2 errors; green after:
  2 tests / 3 assertions).
- End-to-end: `check_top1m_providers.py --check-url <new URL>` → `OK ... healthy
  (>= 100000 rows, not stale)` (real ~123 MB download).
- `--extract` lists exactly 5 providers with OpenPageRank's name/URL; the only surviving
  `domcop` reference in `src/` is the `fromLegacy()` coalesce arm itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG