### PR TITLE
dev: vendored mode skills + SubagentStart capsule + updater script

### DIFF
--- a/.claude/hooks/vendored-plugin-hook.sh
+++ b/.claude/hooks/vendored-plugin-hook.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# vendored-plugin-hook.sh -- run a VENDORED plugin hook script when the real
+# marketplace plugin is not installed (managed/cloud sessions never install
+# plugins; the vendored copies live in committed .claude/skills/<plugin>/).
+#
+# Args: $1 = plugin name, $2 = hook script path relative to the vendored root
+# (upstream-relative, matching the plugin's own ${CLAUDE_PLUGIN_ROOT} manifest).
+#
+# Resolution ladder, silent (exit 0) at every rung that does not apply:
+#   1. real plugin installed locally -> IT injects; running the vendored copy
+#      too would double-inject every event
+#   2. no node on PATH -> the static repo hooks (SessionStart mandate,
+#      SubagentStart capsule) are the fallback
+#   3. vendored script missing (not yet vendored / plugin removed) -> nothing
+#   4. otherwise exec node with CLAUDE_PLUGIN_ROOT at the vendored root;
+#      stdin (the hook's JSON payload) passes through to the script
+set -eu
+
+plugin=$1
+js=$2
+
+cfg_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+if [ -d "${cfg_dir}/plugins/marketplaces/${plugin}" ]; then
+	exit 0
+fi
+
+command -v node >/dev/null 2>&1 || exit 0
+
+root="${CLAUDE_PROJECT_DIR:-.}/.claude/skills/${plugin}"
+[ -f "${root}/${js}" ] || exit 0
+
+CLAUDE_PLUGIN_ROOT="${root}" exec node "${root}/${js}"

--- a/.claude/hooks/vendored-plugin-hook.sh
+++ b/.claude/hooks/vendored-plugin-hook.sh
@@ -20,7 +20,12 @@ plugin=$1
 js=$2
 
 cfg_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-if [ -d "${cfg_dir}/plugins/marketplaces/${plugin}" ]; then
+# installed_plugins.json (keyed plugin@marketplace) is the authoritative "is
+# the real plugin present" source -- a marketplace-clone directory check keyed
+# by PLUGIN name only works while plugin and marketplace happen to share a
+# name (#931 delta review).
+installed="${cfg_dir}/plugins/installed_plugins.json"
+if [ -f "${installed}" ] && grep -q "\"${plugin}@" "${installed}"; then
 	exit 0
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,14 @@
         "hooks": [
           {
             "type": "command",
+            "command": "sh \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/vendored-plugin-hook.sh\" ponytail hooks/ponytail-activate.js"
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/vendored-plugin-hook.sh\" caveman src/hooks/caveman-activate.js"
+          },
+          {
+            "type": "command",
             "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"MANDATORY: this repo has a CLAUDE.md — read it and follow it, especially Working principles (investigate, do not assume; confirm genuine forks before building) and Code standards. docs/misc/workflow-reference.md is a POLICY ANNEX of CLAUDE.md — its sections are binding; read the relevant section whenever the task touches one CLAUDE.md points there. Activate BOTH modes when available: if the ponytail plugin is installed, run /ponytail:ponytail full (laziest working solution), AND if the caveman plugin/skill is available, run /caveman (terse, no filler, full technical accuracy); when only one is available, activate that one alone. This step CANNOT be skipped. Exception for external or public-facing text and documentation (GitHub issue and PR/MR comments, PR bodies, commit messages, docs): stay concise and to the point but use normal professional grammar, toning the caveman style down. Org rule: in ANY pfBlockerNG-org repository, the pfBlockerNG/pfBlockerNG CLAUDE.md and its project plus user settings are the default way of working unless that repo overrides a rule in its own CLAUDE.md; the pfBlockerNG-package-specific mechanics and language or runtime specifics do not carry over.\"}}'"
           }
         ]
@@ -51,6 +59,14 @@
     "UserPromptSubmit": [
       {
         "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/vendored-plugin-hook.sh\" ponytail hooks/ponytail-mode-tracker.js"
+          },
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/vendored-plugin-hook.sh\" caveman src/hooks/caveman-mode-tracker.js"
+          },
           {
             "type": "command",
             "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"DISCIPLINE (CLAUDE.md, every turn): (1) Evidence before conclusion — a claim without a run artifact is ASSUMED; probe environmental facts before writing them into code/comments/workflows. (2) Debugging: >=2 hypotheses + a discriminating probe BEFORE any fix edit. (3) Scope: enumerate EVERY sibling axis (v4/v6, ports, CE/Plus versions, callers, parse modes) from grep or the version matrix — never from memory; never hardcode env-derived values. (4) Done = executed verification with pasted output; red->green is run, never reasoned. (5) No self-exemption from MUST rules — deviation requires quoting the authorizing user message. (6) Delegation follows CLAUDE.md The delegation contract (brief/handoff/gate fields). (7) Output stays caveman-terse + ponytail-lazy; terse prose, FULL checks.\"}}'"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,16 @@
         ]
       }
     ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SubagentStart\",\"additionalContext\":\"DELEGATE MODES (repo policy, injected into every subagent): (1) PONYTAIL full — build the laziest working solution: YAGNI, reuse what already exists in this codebase, stdlib/native before dependencies, shortest correct diff; never simplify away input validation, error handling, security, tests, or anything the brief explicitly requires. EXCEPTION: if your task is review/verification only, ponytail does not govern it — you build nothing; hunt with full thoroughness. (2) CAVEMAN full — write your report/handoff terse: drop articles, filler, hedging; fragments OK. VERBATIM EVIDENCE RULE: pasted command outputs, test results, red->green runs, error strings, and code stay byte-exact and complete — caveman compresses connective prose only. Fill EVERY required handoff/output field; a missing field is a gate failure. Public-facing text (PR/issue comments, commit messages, docs) uses normal professional grammar. These modes govern style and scope, never rigor: run every gate, paste real outputs.\"}}'"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/.claude/skills/adr-phase/SKILL.md
+++ b/.claude/skills/adr-phase/SKILL.md
@@ -192,10 +192,10 @@ is only safe because you gate every step). Give it a **self-contained** brief �
 carry-over from this conversation, though it has the full worktree (the whole codebase) to
 read and edit:
 
-- **If `ponytail` is active in THIS session, the brief's FIRST line is
-  `Run /ponytail:ponytail <level>`** (the level active here — full/lite/ultra; CLAUDE.md "Plan
-  with a higher model"), so the implementer matches the parent's ponytail mode. Omit only when
-  ponytail is not active.
+- **Mode propagation is mechanical** — the `SubagentStart` hook injects the ponytail +
+  caveman capsule into the implementer (CLAUDE.md "Plan with a higher model"). Add a FIRST
+  line `Run /ponytail:ponytail <level>` ONLY when a non-default level (`lite`/`ultra`) is
+  active in THIS session; at the default `full`, the hook alone propagates it.
 - The **full text** of the phase prompt `{ADR_DIR}/{MM}_*.txt`.
 - "Work **entirely inside** the worktree at `<path>` — all edits and all git
   commands there (`git -C <path> …`). Do not touch the main checkout."

--- a/.claude/skills/caveman/LICENSE
+++ b/.claude/skills/caveman/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Julius Brussee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/caveman/README.md
+++ b/.claude/skills/caveman/README.md
@@ -1,0 +1,48 @@
+# caveman
+
+Talk like smart caveman. Same brain, fewer tokens.
+
+## What it does
+
+Compress every model response to caveman-style prose. Drops articles, filler, pleasantries, and hedging. Keeps every technical detail, code block, error string, and symbol exact. Cuts 65% of output tokens (measured) with full accuracy preserved. Mode persists for the whole session until changed or stopped.
+
+Six intensity levels:
+
+| Level | What change |
+|-------|-------------|
+| `lite` | Drop filler/hedging. Sentences stay full. Professional but tight. |
+| `full` | Default. Drop articles, fragments OK, short synonyms. |
+| `ultra` | Bare fragments. Abbreviations (DB, auth, fn). Arrows for causality. |
+| `wenyan-lite` | Classical Chinese register, light compression. |
+| `wenyan-full` | Maximum 文言文. 80-90% character reduction. |
+| `wenyan-ultra` | Extreme classical compression. |
+
+Auto-clarity rule: caveman drops to normal prose for security warnings, irreversible-action confirmations, multi-step sequences where fragment ambiguity risks misread, and when user repeats a question. Resumes after the clear part.
+
+## How to invoke
+
+```
+/caveman              # full mode (default)
+/caveman lite         # lighter compression
+/caveman ultra        # extreme compression
+/caveman wenyan       # classical Chinese
+stop caveman          # back to normal prose
+```
+
+## Example output
+
+Question: "Why does my React component re-render?"
+
+Normal prose:
+> Your component re-renders because you create a new object reference each render. Wrapping it in `useMemo` will fix the issue.
+
+Caveman (full):
+> New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`.
+
+Caveman (ultra):
+> Inline obj prop → new ref → re-render. `useMemo`.
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — full LLM-facing instructions
+- [Caveman README](../../README.md) — repo overview, install, benchmarks

--- a/.claude/skills/caveman/SKILL.md
+++ b/.claude/skills/caveman/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode. Cuts output tokens 65% (measured) by speaking like caveman
+  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
+  wenyan-lite, wenyan-full, wenyan-ultra.
+  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
+  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+
+Default: **full**. Switch: `/caveman lite|full|ultra`.
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked — quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) — tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either — own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. User write Spanish → reply Spanish caveman. Compress the style, not the language. No forced English openings or status phrases. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim — unless user explicitly ask for translation.
+
+No self-reference. Never name or announce the style. No "caveman mode on", "me caveman think", no third-person caveman tags. Output caveman-only — never normal answer plus "Caveman:" recap. Exception: user explicitly ask what the mode is.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations |
+| **ultra** | Strip conjunctions when cause-then-effect stay unambiguous. One word when one word enough. State each fact once. NO prose abbreviations (cfg/impl/req/res/fn/auth), NO arrows (X → Y) — measured zero token saving under tokenizer, cost decode clarity. Code symbols, function names, API names, error strings: never touch |
+| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
+| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
+| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+
+Example — "Why React component re-render?"
+- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra: "Inline obj prop, new ref, re-render. `useMemo`."
+- wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
+- wenyan-full: "每繪新生對象參照，故重繪；以 useMemo 包之則免。"
+- wenyan-ultra: "新參照則重繪。useMemo 包之。"
+
+Example — "Explain database connection pooling."
+- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra: "Pool reuse open DB connections. No per-request handshake."
+- wenyan-full: "池蓄已開之連，不逐請而新開，省握手之費。"
+- wenyan-ultra: "池蓄連，免逐請新開，省握手。"
+
+## Auto-Clarity
+
+Drop caveman when:
+- Security warnings
+- Irreversible action confirmations
+- Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` — order unclear without articles/conjunctions)
+- User asks to clarify or repeats question
+
+Resume caveman after clear part done.
+
+Example — destructive op:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.

--- a/.claude/skills/caveman/UPSTREAM
+++ b/.claude/skills/caveman/UPSTREAM
@@ -1,0 +1,1 @@
+JuliusBrussee/caveman @ 0d95a81d35a9f2d123a5e9430d1cfc43d55f1bb0 (2026-07-07)

--- a/.claude/skills/caveman/UPSTREAM
+++ b/.claude/skills/caveman/UPSTREAM
@@ -1,1 +1,1 @@
-JuliusBrussee/caveman @ 0d95a81d35a9f2d123a5e9430d1cfc43d55f1bb0 (2026-07-07)
+JuliusBrussee/caveman @ 0d95a81d35a9f2d123a5e9430d1cfc43d55f1bb0 (ref v1.9.1, 2026-07-07)

--- a/.claude/skills/caveman/skills/caveman/README.md
+++ b/.claude/skills/caveman/skills/caveman/README.md
@@ -1,0 +1,48 @@
+# caveman
+
+Talk like smart caveman. Same brain, fewer tokens.
+
+## What it does
+
+Compress every model response to caveman-style prose. Drops articles, filler, pleasantries, and hedging. Keeps every technical detail, code block, error string, and symbol exact. Cuts 65% of output tokens (measured) with full accuracy preserved. Mode persists for the whole session until changed or stopped.
+
+Six intensity levels:
+
+| Level | What change |
+|-------|-------------|
+| `lite` | Drop filler/hedging. Sentences stay full. Professional but tight. |
+| `full` | Default. Drop articles, fragments OK, short synonyms. |
+| `ultra` | Bare fragments. Abbreviations (DB, auth, fn). Arrows for causality. |
+| `wenyan-lite` | Classical Chinese register, light compression. |
+| `wenyan-full` | Maximum 文言文. 80-90% character reduction. |
+| `wenyan-ultra` | Extreme classical compression. |
+
+Auto-clarity rule: caveman drops to normal prose for security warnings, irreversible-action confirmations, multi-step sequences where fragment ambiguity risks misread, and when user repeats a question. Resumes after the clear part.
+
+## How to invoke
+
+```
+/caveman              # full mode (default)
+/caveman lite         # lighter compression
+/caveman ultra        # extreme compression
+/caveman wenyan       # classical Chinese
+stop caveman          # back to normal prose
+```
+
+## Example output
+
+Question: "Why does my React component re-render?"
+
+Normal prose:
+> Your component re-renders because you create a new object reference each render. Wrapping it in `useMemo` will fix the issue.
+
+Caveman (full):
+> New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`.
+
+Caveman (ultra):
+> Inline obj prop → new ref → re-render. `useMemo`.
+
+## See also
+
+- [`SKILL.md`](./SKILL.md) — full LLM-facing instructions
+- [Caveman README](../../README.md) — repo overview, install, benchmarks

--- a/.claude/skills/caveman/skills/caveman/SKILL.md
+++ b/.claude/skills/caveman/skills/caveman/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: caveman
+description: >
+  Ultra-compressed communication mode. Cuts output tokens 65% (measured) by speaking like caveman
+  while keeping full technical accuracy. Supports intensity levels: lite, full (default), ultra,
+  wenyan-lite, wenyan-full, wenyan-ultra.
+  Use when user says "caveman mode", "talk like caveman", "use caveman", "less tokens",
+  "be brief", or invokes /caveman. Also auto-triggers when token efficiency is requested.
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".
+
+Default: **full**. Switch: `/caveman lite|full|ultra`.
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). No tool-call narration, no decorative tables/emoji, no dumping long raw error logs unless asked — quote shortest decisive line. Standard well-known tech acronyms OK (DB/API/HTTP); never invent new abbreviations (cfg/impl/req/res/fn) — tokenizer split them same as full word: zero token saved, reader still decode. Full word cheaper AND clearer. No causal arrows (→) either — own token, save nothing. Technical terms exact. Code blocks unchanged. Errors quoted exact.
+
+Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. User write Spanish → reply Spanish caveman. Compress the style, not the language. No forced English openings or status phrases. ALWAYS keep technical terms, code, API names, CLI commands, commit-type keywords (feat/fix/...), and exact error strings verbatim — unless user explicitly ask for translation.
+
+No self-reference. Never name or announce the style. No "caveman mode on", "me caveman think", no third-person caveman tags. Output caveman-only — never normal answer plus "Caveman:" recap. Exception: user explicitly ask what the mode is.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | No filler/hedging. Keep articles + full sentences. Professional but tight |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations |
+| **ultra** | Strip conjunctions when cause-then-effect stay unambiguous. One word when one word enough. State each fact once. NO prose abbreviations (cfg/impl/req/res/fn/auth), NO arrows (X → Y) — measured zero token saving under tokenizer, cost decode clarity. Code symbols, function names, API names, error strings: never touch |
+| **wenyan-lite** | Semi-classical. Drop filler/hedging but keep grammar structure, classical register |
+| **wenyan-full** | Maximum classical terseness. Fully 文言文. 80-90% character reduction. Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其) |
+| **wenyan-ultra** | Extreme abbreviation while keeping classical Chinese feel. Maximum compression, ultra terse |
+
+Example — "Why React component re-render?"
+- lite: "Your component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- full: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- ultra: "Inline obj prop, new ref, re-render. `useMemo`."
+- wenyan-lite: "組件頻重繪，以每繪新生對象參照故。以 useMemo 包之。"
+- wenyan-full: "每繪新生對象參照，故重繪；以 useMemo 包之則免。"
+- wenyan-ultra: "新參照則重繪。useMemo 包之。"
+
+Example — "Explain database connection pooling."
+- lite: "Connection pooling reuses open connections instead of creating new ones per request. Avoids repeated handshake overhead."
+- full: "Pool reuse open DB connections. No new connection per request. Skip handshake overhead."
+- ultra: "Pool reuse open DB connections. No per-request handshake."
+- wenyan-full: "池蓄已開之連，不逐請而新開，省握手之費。"
+- wenyan-ultra: "池蓄連，免逐請新開，省握手。"
+
+## Auto-Clarity
+
+Drop caveman when:
+- Security warnings
+- Irreversible action confirmations
+- Multi-step sequences where fragment order or omitted conjunctions risk misread
+- Compression itself creates technical ambiguity (e.g., `"migrate table drop column backup first"` — order unclear without articles/conjunctions)
+- User asks to clarify or repeats question
+
+Resume caveman after clear part done.
+
+Example — destructive op:
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+> ```sql
+> DROP TABLE users;
+> ```
+> Caveman resume. Verify backup exist first.
+
+## Boundaries
+
+Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.

--- a/.claude/skills/caveman/src/hooks/cavecrew-model-overrides.js
+++ b/.claude/skills/caveman/src/hooks/cavecrew-model-overrides.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// cavecrew model overrides — patch installed agent frontmatter from env vars.
+//
+// Called by caveman-activate.js early in SessionStart so users can pin
+// per-agent models without shadow-copying entire agent files.
+//
+// Env vars:
+//   CAVECREW_REVIEWER_MODEL    → agents/cavecrew-reviewer.md
+//   CAVECREW_BUILDER_MODEL     → agents/cavecrew-builder.md
+//   CAVECREW_INVESTIGATOR_MODEL → agents/cavecrew-investigator.md
+//
+// Rules:
+//   - Unset / blank → no-op.
+//   - Values containing newlines or control characters → ignored.
+//   - Existing `model:` line in frontmatter → replaced in-place.
+//   - No `model:` line → inserted after `tools:` (or before closing `---`).
+//   - File missing / outside plugin layout → silent no-op.
+//   - All filesystem errors → silent fail.
+
+const fs = require('fs');
+const path = require('path');
+
+const AGENT_ENV_MAP = [
+  { envVar: 'CAVECREW_REVIEWER_MODEL',     file: path.join('agents', 'cavecrew-reviewer.md') },
+  { envVar: 'CAVECREW_BUILDER_MODEL',      file: path.join('agents', 'cavecrew-builder.md') },
+  { envVar: 'CAVECREW_INVESTIGATOR_MODEL', file: path.join('agents', 'cavecrew-investigator.md') },
+];
+
+// Return the plugin root directory given the hooks directory path.
+// Plugin layout: <plugin_root>/hooks/<this-file>  →  plugin root = parent of hooks dir.
+function resolvePluginRoot(hookDir) {
+  return path.resolve(hookDir, '..');
+}
+
+// Patch the YAML frontmatter of `content` to set `model: <modelValue>`.
+// Returns the patched string, or the original if no frontmatter or already identical.
+// Rejects `modelValue` strings that contain newlines or control characters.
+function patchFrontmatterModel(content, modelValue) {
+  // Reject blank or unsafe model strings
+  if (!modelValue || /[\x00-\x1f\x7f]/.test(modelValue)) return content;
+
+  // Must begin with YAML frontmatter delimiter
+  if (!content.startsWith('---')) return content;
+
+  // Find the closing ---
+  const closeIdx = content.indexOf('\n---', 3);
+  if (closeIdx === -1) return content;
+
+  const fmRaw = content.slice(0, closeIdx);           // opening --- through last fm line
+  const after  = content.slice(closeIdx);             // \n--- onward (body)
+
+  // Preserve original line ending so we don't create mixed CRLF/LF on Windows
+  const nl = fmRaw.includes('\r\n') ? '\r\n' : '\n';
+
+  const modelLine = 'model: ' + modelValue;
+  const modelRe   = /^model:[ \t]*.*$/m;
+
+  if (modelRe.test(fmRaw)) {
+    // Replace existing model: line
+    const patched = fmRaw.replace(modelRe, modelLine);
+    if (patched === fmRaw) return content;            // already identical
+    return patched + after;
+  }
+
+  // Insert after tools: line when present; else before closing ---
+  const toolsMatch = fmRaw.match(/^tools:[ \t]*.*$/m);
+  if (toolsMatch) {
+    const toolsEnd = fmRaw.indexOf(toolsMatch[0]) + toolsMatch[0].length;
+    return fmRaw.slice(0, toolsEnd) + nl + modelLine + fmRaw.slice(toolsEnd) + after;
+  }
+
+  // Append before closing delimiter
+  return fmRaw + nl + modelLine + after;
+}
+
+// Apply all env-var overrides to agent files under `pluginRoot`.
+// `env` defaults to process.env; pass an object in tests.
+function applyOverrides(pluginRoot, env) {
+  const envArg = env || process.env;
+  for (const { envVar, file } of AGENT_ENV_MAP) {
+    const raw = envArg[envVar];
+    if (!raw || !raw.trim()) continue;
+
+    const modelValue = raw.trim();
+    if (/[\x00-\x1f\x7f]/.test(modelValue)) continue;
+
+    const agentPath = path.join(pluginRoot, file);
+    let content;
+    try {
+      content = fs.readFileSync(agentPath, 'utf8');
+    } catch (e) {
+      continue; // missing file or wrong layout → silent no-op
+    }
+
+    const patched = patchFrontmatterModel(content, modelValue);
+    if (patched === content) continue;
+
+    try {
+      fs.writeFileSync(agentPath, patched, 'utf8');
+    } catch (e) {
+      // Silent fail — never block session start
+    }
+  }
+}
+
+module.exports = { resolvePluginRoot, patchFrontmatterModel, applyOverrides, AGENT_ENV_MAP };

--- a/.claude/skills/caveman/src/hooks/caveman-activate.js
+++ b/.claude/skills/caveman/src/hooks/caveman-activate.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// caveman — Claude Code SessionStart activation hook
+//
+// Runs on every session start:
+//   1. Writes flag file at $CLAUDE_CONFIG_DIR/.caveman-active (statusline reads this)
+//   2. Emits caveman ruleset as hidden SessionStart context
+//   3. Detects missing statusline config and emits setup nudge
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { getDefaultMode, safeWriteFlag, recordModeChange } = require('./caveman-config');
+
+const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const flagPath = path.join(claudeDir, '.caveman-active');
+const settingsPath = path.join(claudeDir, 'settings.json');
+
+// Apply per-agent model overrides from env vars before emitting rules.
+// Best-effort: any error is swallowed so SessionStart is never blocked.
+try {
+  const { applyOverrides, resolvePluginRoot } = require('./cavecrew-model-overrides');
+  applyOverrides(resolvePluginRoot(__dirname));
+} catch (e) {}
+
+const mode = getDefaultMode();
+
+// "off" mode — skip activation entirely, don't write flag or emit rules
+if (mode === 'off') {
+  recordModeChange(claudeDir, null); // #601: timestamped transition log
+  try { fs.unlinkSync(flagPath); } catch (e) {}
+  process.stdout.write('OK');
+  process.exit(0);
+}
+
+// 1. Write flag file (symlink-safe)
+recordModeChange(claudeDir, mode); // #601
+safeWriteFlag(flagPath, mode);
+
+// 2. Emit full caveman ruleset, filtered to the active intensity level.
+//    The old 2-sentence summary was too weak — models drifted back to verbose
+//    mid-conversation, especially after context compression pruned it away.
+//    Full rules with examples anchor behavior much more reliably.
+//
+//    Reads SKILL.md at runtime so edits to the source of truth propagate
+//    automatically — no hardcoded duplication to go stale.
+
+// Modes that have their own independent skill files — not caveman intensity levels.
+// For these, emit a short activation line; the skill itself handles behavior.
+const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
+
+if (INDEPENDENT_MODES.has(mode)) {
+  process.stdout.write('CAVEMAN MODE ACTIVE — level: ' + mode + '. Behavior defined by /caveman-' + mode + ' skill.');
+  process.exit(0);
+}
+
+// Resolve the canonical label for wenyan alias
+const modeLabel = mode === 'wenyan' ? 'wenyan-full' : mode;
+
+// Read SKILL.md — the single source of truth for caveman behavior.
+// Candidate locations, tried in order (#587/#589 — the old single '..' path
+// resolved to <plugin_root>/src/skills/, which doesn't exist, so plugin
+// installs silently used the stale fallback ruleset):
+//   1. $CLAUDE_PLUGIN_ROOT/skills/caveman/SKILL.md — Claude Code sets
+//      CLAUDE_PLUGIN_ROOT when invoking plugin hooks; authoritative when present.
+//   2. ../../skills/caveman/SKILL.md — hook at <plugin_root>/src/hooks/
+//      (plugin.json layout) or a repo checkout.
+//   3. ../skills/caveman/SKILL.md — standalone install with hooks at
+//      $CLAUDE_CONFIG_DIR/hooks/ and the skill at $CLAUDE_CONFIG_DIR/skills/caveman/.
+// All misses fall through to the hardcoded fallback ruleset below.
+const skillCandidates = [];
+if (process.env.CLAUDE_PLUGIN_ROOT) {
+  skillCandidates.push(path.join(process.env.CLAUDE_PLUGIN_ROOT, 'skills', 'caveman', 'SKILL.md'));
+}
+skillCandidates.push(
+  path.join(__dirname, '..', '..', 'skills', 'caveman', 'SKILL.md'),
+  path.join(__dirname, '..', 'skills', 'caveman', 'SKILL.md')
+);
+
+let skillContent = '';
+for (const candidate of skillCandidates) {
+  try {
+    skillContent = fs.readFileSync(candidate, 'utf8');
+    break;
+  } catch (e) { /* try next candidate */ }
+}
+
+let output;
+
+if (skillContent) {
+  // Strip YAML frontmatter
+  const body = skillContent.replace(/^---[\s\S]*?---\s*/, '');
+
+  // Filter intensity table: keep header rows + only the active level's row
+  const filtered = body.split('\n').reduce((acc, line) => {
+    // Intensity table rows start with | **level** |
+    const tableRowMatch = line.match(/^\|\s*\*\*(\S+?)\*\*\s*\|/);
+    if (tableRowMatch) {
+      // Keep only the active level's row (and always keep header/separator)
+      if (tableRowMatch[1] === modeLabel) {
+        acc.push(line);
+      }
+      return acc;
+    }
+
+    // Example lines start with "- level:" — keep only lines matching active level
+    const exampleMatch = line.match(/^- (\S+?):\s/);
+    if (exampleMatch) {
+      if (exampleMatch[1] === modeLabel) {
+        acc.push(line);
+      }
+      return acc;
+    }
+
+    acc.push(line);
+    return acc;
+  }, []);
+
+  output = 'CAVEMAN MODE ACTIVE — level: ' + modeLabel + '\n\n' + filtered.join('\n');
+} else {
+  // Fallback when SKILL.md is not found (standalone hook install without skills dir).
+  // This is the minimum viable ruleset — better than nothing.
+  output =
+    'CAVEMAN MODE ACTIVE — level: ' + modeLabel + '\n\n' +
+    'Respond terse like smart caveman. All technical substance stay. Only fluff die.\n\n' +
+    '## Persistence\n\n' +
+    'ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure. Off only: "stop caveman" / "normal mode".\n\n' +
+    'Current level: **' + modeLabel + '**. Switch: `/caveman lite|full|ultra`.\n\n' +
+    '## Rules\n\n' +
+    'Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. ' +
+    'Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Technical terms exact. Code blocks unchanged. Errors quoted exact.\n\n' +
+    "Preserve user's dominant language. User write Portuguese → reply Portuguese caveman. Compress the style, not the language. Technical terms, code, API names, commands, error strings stay verbatim.\n\n" +
+    'No self-reference. Never name or announce the style. No "caveman mode on" tags. Output caveman-only.\n\n' +
+    'Pattern: `[thing] [action] [reason]. [next step].`\n\n' +
+    'Not: "Sure! I\'d be happy to help you with that. The issue you\'re experiencing is likely caused by..."\n' +
+    'Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"\n\n' +
+    '## Auto-Clarity\n\n' +
+    'Drop caveman for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume caveman after clear part done.\n\n' +
+    '## Boundaries\n\n' +
+    'Code/commits/PRs: write normal. "stop caveman" or "normal mode": revert. Level persist until changed or session end.';
+}
+
+// 3. Detect missing statusline config — nudge Claude to help set it up
+try {
+  let hasStatusline = false;
+  if (fs.existsSync(settingsPath)) {
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    if (settings.statusLine) {
+      hasStatusline = true;
+    }
+  }
+
+  if (!hasStatusline) {
+    const isWindows = process.platform === 'win32';
+    const scriptName = isWindows ? 'caveman-statusline.ps1' : 'caveman-statusline.sh';
+    const scriptPath = path.join(__dirname, scriptName);
+    const command = isWindows
+      ? `powershell -ExecutionPolicy Bypass -File "${scriptPath}"`
+      : `bash "${scriptPath}"`;
+    const statusLineSnippet =
+      '"statusLine": { "type": "command", "command": ' + JSON.stringify(command) + ' }';
+    output += "\n\n" +
+      "STATUSLINE SETUP NEEDED: The caveman plugin includes a statusline badge showing active mode " +
+      "(e.g. [CAVEMAN], [CAVEMAN:ULTRA]). It is not configured yet. " +
+      "To enable, add this to " + path.join(claudeDir, 'settings.json') + ": " +
+      statusLineSnippet + " " +
+      "Proactively offer to set this up for the user on first interaction.";
+  }
+} catch (e) {
+  // Silent fail — don't block session start over statusline detection
+}
+
+process.stdout.write(output);

--- a/.claude/skills/caveman/src/hooks/caveman-config.js
+++ b/.claude/skills/caveman/src/hooks/caveman-config.js
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+// caveman — shared configuration resolver
+//
+// Resolution order for default mode:
+//   1. CAVEMAN_DEFAULT_MODE environment variable
+//   2. Repo-local config (checked-in, per-project default):
+//      - <cwd>/.caveman/config.json
+//      - <cwd>/.caveman.json
+//      Walks up from process.cwd() to the nearest ancestor containing one of
+//      these (stops at filesystem root). Lets a team pin a project's default
+//      mode without polluting every contributor's user-level config or env.
+//   3. User config file defaultMode field:
+//      - $XDG_CONFIG_HOME/caveman/config.json (any platform, if set)
+//      - ~/.config/caveman/config.json (macOS / Linux fallback)
+//      - %APPDATA%\caveman\config.json (Windows fallback)
+//   4. 'full'
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const VALID_MODES = [
+  'off', 'lite', 'full', 'ultra',
+  'wenyan-lite', 'wenyan', 'wenyan-full', 'wenyan-ultra',
+  'commit', 'review', 'compress'
+];
+
+function getConfigDir() {
+  if (process.env.XDG_CONFIG_HOME) {
+    return path.join(process.env.XDG_CONFIG_HOME, 'caveman');
+  }
+  if (process.platform === 'win32') {
+    return path.join(
+      process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'),
+      'caveman'
+    );
+  }
+  return path.join(os.homedir(), '.config', 'caveman');
+}
+
+function getConfigPath() {
+  return path.join(getConfigDir(), 'config.json');
+}
+
+// Walk up from `start` looking for a repo-local caveman config. Returns the
+// absolute path of the first match, or null. Stops at the filesystem root.
+// Candidates per dir (first wins): .caveman/config.json, .caveman.json.
+//
+// Bounded to 64 levels to defend against symlink cycles on pathological mounts.
+function findRepoConfigPath(start) {
+  try {
+    let dir = path.resolve(start || process.cwd());
+    const candidates = ['.caveman/config.json', '.caveman.json'];
+    for (let i = 0; i < 64; i++) {
+      for (const rel of candidates) {
+        const p = path.join(dir, rel);
+        try {
+          const st = fs.lstatSync(p);
+          // Refuse symlinks — symmetric with safeWriteFlag/readFlag policy.
+          if (st.isSymbolicLink() || !st.isFile()) continue;
+          return p;
+        } catch (e) {
+          // not present, try next candidate
+        }
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) return null;
+      dir = parent;
+    }
+  } catch (e) {
+    // Defensive: any cwd / fs failure → no repo config
+  }
+  return null;
+}
+
+function readModeFromConfigFile(configPath) {
+  try {
+    const raw = fs.readFileSync(configPath, 'utf8');
+    const config = JSON.parse(raw);
+    if (config && config.defaultMode &&
+        VALID_MODES.includes(String(config.defaultMode).toLowerCase())) {
+      return String(config.defaultMode).toLowerCase();
+    }
+  } catch (e) {
+    // Missing / unreadable / invalid JSON → caller falls through
+  }
+  return null;
+}
+
+function getDefaultMode() {
+  // 1. Environment variable (highest priority)
+  const envMode = process.env.CAVEMAN_DEFAULT_MODE;
+  if (envMode && VALID_MODES.includes(envMode.toLowerCase())) {
+    return envMode.toLowerCase();
+  }
+
+  // 2. Repo-local config (checked-in, per-project default)
+  const repoConfigPath = findRepoConfigPath(process.cwd());
+  if (repoConfigPath) {
+    const repoMode = readModeFromConfigFile(repoConfigPath);
+    if (repoMode) return repoMode;
+  }
+
+  // 3. User config file
+  const userMode = readModeFromConfigFile(getConfigPath());
+  if (userMode) return userMode;
+
+  // 4. Default
+  return 'full';
+}
+
+// Symlink-safe flag file write.
+// Uses O_NOFOLLOW where available, writes atomically via temp + rename with
+// 0600 permissions. Protects against local attackers replacing the predictable
+// flag path (~/.claude/.caveman-active) with a symlink to clobber other files.
+//
+// When the parent directory is itself a symlink (legitimate pattern: ~/.claude
+// symlinked to another drive or shared config dir), resolves through to the
+// real path and verifies ownership on Unix (uid match). This allows e.g.
+//   ln -s /opt/shared-claude-config ~/.claude
+// while still refusing attacker-planted symlinks pointing to dirs owned by
+// another user.
+//
+// On Windows, uid checks are unavailable — falls back to verifying the resolved
+// path lives under the user's home directory.
+//
+// The flag file itself must never be a symlink (that's the actual clobber vector).
+//
+// Set CAVEMAN_DEBUG=1 to emit stderr diagnostics when flag writes are refused.
+//
+// Silent-fails on any filesystem error — the flag is best-effort.
+function safeWriteFlag(flagPath, content) {
+  const debug = process.env.CAVEMAN_DEBUG === '1';
+  try {
+    const flagDir = path.dirname(flagPath);
+    fs.mkdirSync(flagDir, { recursive: true });
+
+    // When the parent directory is a symlink, resolve it and verify ownership.
+    // This allows legitimate symlinked ~/.claude dirs while still refusing
+    // attacker-planted symlinks pointing at dirs owned by another user.
+    let realFlagDir;
+    try {
+      const lstat = fs.lstatSync(flagDir);
+      if (lstat.isSymbolicLink()) {
+        realFlagDir = fs.realpathSync(flagDir);
+        const realStat = fs.statSync(realFlagDir);
+        if (!realStat.isDirectory()) {
+          if (debug) process.stderr.write(`[caveman] safeWriteFlag: symlink target ${realFlagDir} is not a directory\n`);
+          return;
+        }
+        if (typeof process.getuid === 'function') {
+          if (realStat.uid !== process.getuid()) {
+            if (debug) process.stderr.write(`[caveman] safeWriteFlag: symlink target ${realFlagDir} owned by uid ${realStat.uid}, not current user ${process.getuid()}\n`);
+            return;
+          }
+        } else {
+          const home = os.homedir();
+          const normalizedReal = path.resolve(realFlagDir);
+          const normalizedHome = path.resolve(home);
+          if (!normalizedReal.toLowerCase().startsWith(normalizedHome.toLowerCase() + path.sep) &&
+              normalizedReal.toLowerCase() !== normalizedHome.toLowerCase()) {
+            if (debug) process.stderr.write(`[caveman] safeWriteFlag: symlink target ${normalizedReal} is outside home directory ${normalizedHome}\n`);
+            return;
+          }
+        }
+      } else {
+        realFlagDir = flagDir;
+      }
+    } catch (e) {
+      return;
+    }
+
+    // The flag file itself must never be a symlink (that's the actual clobber vector).
+    const realFlagPath = path.join(realFlagDir, path.basename(flagPath));
+    try {
+      if (fs.lstatSync(realFlagPath).isSymbolicLink()) return;
+    } catch (e) {
+      if (e.code !== 'ENOENT') return;
+    }
+
+    const tempPath = path.join(realFlagDir, `.caveman-active.${process.pid}.${Date.now()}`);
+    const O_NOFOLLOW = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0;
+    const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | O_NOFOLLOW;
+    let fd;
+    try {
+      fd = fs.openSync(tempPath, flags, 0o600);
+      fs.writeSync(fd, String(content));
+      try { fs.fchmodSync(fd, 0o600); } catch (e) { /* best-effort on Windows */ }
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
+    }
+    fs.renameSync(tempPath, realFlagPath);
+  } catch (e) {
+    // Silent fail — flag is best-effort
+  }
+}
+
+// Symlink-safe, size-capped, whitelist-validated flag file read.
+// Symmetric with safeWriteFlag: refuses symlinks at the target, caps the read,
+// and rejects anything that isn't a known mode. Returns null on any anomaly.
+//
+// Without this, a local attacker with write access to ~/.claude/ could replace
+// the flag with a symlink to ~/.ssh/id_rsa (or any user-readable secret). Every
+// reader — statusline, per-turn reinforcement — would slurp that content and
+// either echo it to the terminal or inject it into model context.
+//
+// MAX_FLAG_BYTES is a hard cap. The longest legitimate value is "wenyan-ultra"
+// (12 bytes); 64 leaves slack without enabling exfil.
+const MAX_FLAG_BYTES = 64;
+
+function readFlag(flagPath) {
+  try {
+    let st;
+    try {
+      st = fs.lstatSync(flagPath);
+    } catch (e) {
+      return null;
+    }
+    if (st.isSymbolicLink() || !st.isFile()) return null;
+    if (st.size > MAX_FLAG_BYTES) return null;
+
+    const O_NOFOLLOW = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0;
+    const flags = fs.constants.O_RDONLY | O_NOFOLLOW;
+    let fd;
+    let out;
+    try {
+      fd = fs.openSync(flagPath, flags);
+      const buf = Buffer.alloc(MAX_FLAG_BYTES);
+      const n = fs.readSync(fd, buf, 0, MAX_FLAG_BYTES, 0);
+      out = buf.slice(0, n).toString('utf8');
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
+    }
+
+    const raw = out.trim().toLowerCase();
+    if (!VALID_MODES.includes(raw)) return null;
+    return raw;
+  } catch (e) {
+    return null;
+  }
+}
+
+// Symlink-safe append. Same parent-dir + symlink-target rules as safeWriteFlag,
+// but opens with O_APPEND so concurrent writers from different sessions don't
+// clobber each other. Used for the lifetime stats log
+// ($CLAUDE_CONFIG_DIR/.caveman-history.jsonl).
+//
+// Silent-fails on any filesystem error.
+function appendFlag(filePath, line) {
+  const debug = process.env.CAVEMAN_DEBUG === '1';
+  try {
+    const dir = path.dirname(filePath);
+    fs.mkdirSync(dir, { recursive: true });
+
+    let realDir;
+    try {
+      const lstat = fs.lstatSync(dir);
+      if (lstat.isSymbolicLink()) {
+        realDir = fs.realpathSync(dir);
+        const realStat = fs.statSync(realDir);
+        if (!realStat.isDirectory()) return;
+        if (typeof process.getuid === 'function') {
+          if (realStat.uid !== process.getuid()) {
+            if (debug) process.stderr.write(`[caveman] appendFlag: symlink target ${realDir} owned by uid ${realStat.uid}\n`);
+            return;
+          }
+        } else {
+          const home = os.homedir();
+          const normalized = path.resolve(realDir).toLowerCase();
+          const normalizedHome = path.resolve(home).toLowerCase();
+          if (!normalized.startsWith(normalizedHome + path.sep) && normalized !== normalizedHome) return;
+        }
+      } else {
+        realDir = dir;
+      }
+    } catch (e) {
+      return;
+    }
+
+    const realPath = path.join(realDir, path.basename(filePath));
+    try {
+      if (fs.lstatSync(realPath).isSymbolicLink()) return;
+    } catch (e) {
+      if (e.code !== 'ENOENT') return;
+    }
+
+    const O_NOFOLLOW = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0;
+    const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_APPEND | O_NOFOLLOW;
+    let fd;
+    try {
+      fd = fs.openSync(realPath, flags, 0o600);
+      fs.writeSync(fd, String(line).replace(/\n$/, '') + '\n');
+      try { fs.fchmodSync(fd, 0o600); } catch (e) { /* best-effort on Windows */ }
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
+    }
+  } catch (e) {
+    // Silent fail — history is best-effort
+  }
+}
+
+// Mode-transition log (#601). Whenever the active-mode flag actually changes,
+// append {ts, mode, prev} to $CLAUDE_CONFIG_DIR/.caveman-mode-log.jsonl so
+// caveman-stats can attribute output tokens to the mode that was active when
+// each message was generated, instead of whatever mode the flag holds at
+// stats time. mode/prev are a VALID_MODES string or null (null = caveman off).
+// prev lets stats attribute messages that predate the first logged transition
+// of a session. No-op when the mode is unchanged; best-effort like all flag IO.
+const MODE_LOG_BASENAME = '.caveman-mode-log.jsonl';
+
+function recordModeChange(claudeDir, newMode) {
+  try {
+    const current = readFlag(path.join(claudeDir, '.caveman-active'));
+    const next = newMode || null;
+    if ((current || null) === next) return;
+    appendFlag(
+      path.join(claudeDir, MODE_LOG_BASENAME),
+      JSON.stringify({ ts: Date.now(), mode: next, prev: current || null })
+    );
+  } catch (e) {
+    // Silent fail — the log is best-effort
+  }
+}
+
+// Symlink-safe history read. Returns lines (untrimmed) or empty array on any
+// anomaly. Caller is responsible for parsing JSON. Does NOT enforce a size cap
+// the way readFlag does — history is expected to grow with use.
+function readHistory(filePath) {
+  try {
+    const st = fs.lstatSync(filePath);
+    if (st.isSymbolicLink() || !st.isFile()) return [];
+    const O_NOFOLLOW = typeof fs.constants.O_NOFOLLOW === 'number' ? fs.constants.O_NOFOLLOW : 0;
+    const flags = fs.constants.O_RDONLY | O_NOFOLLOW;
+    let fd;
+    let raw;
+    try {
+      fd = fs.openSync(filePath, flags);
+      raw = fs.readFileSync(fd, 'utf8');
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
+    }
+    return raw.split('\n').filter(line => line.trim());
+  } catch (e) {
+    return [];
+  }
+}
+
+module.exports = { getDefaultMode, getConfigDir, getConfigPath, findRepoConfigPath, VALID_MODES, safeWriteFlag, readFlag, appendFlag, readHistory, recordModeChange, MODE_LOG_BASENAME };

--- a/.claude/skills/caveman/src/hooks/caveman-mode-tracker.js
+++ b/.claude/skills/caveman/src/hooks/caveman-mode-tracker.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+// caveman — UserPromptSubmit hook to track which caveman mode is active
+// Inspects user input for /caveman commands and writes mode to flag file
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFileSync } = require('child_process');
+const { getDefaultMode, safeWriteFlag, readFlag, recordModeChange, VALID_MODES } = require('./caveman-config');
+
+// Modes handled by their own slash commands (/caveman-commit, etc.) — not
+// selectable via /caveman <arg>.
+const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
+
+const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const flagPath = path.join(claudeDir, '.caveman-active');
+// Remembers the prose mode active before a one-shot independent mode
+// (/caveman-commit etc.) so the next ordinary prompt can restore it (#599).
+const prevPath = path.join(claudeDir, '.caveman-active.prev');
+
+let input = '';
+process.stdin.on('data', chunk => { input += chunk; });
+// Abnormal stdin close (broken pipe, parent crash) emits 'error'; without a
+// listener Node throws it as an uncaught exception and the hook exits
+// non-zero — a spurious hook failure (#538). Hooks must always exit 0.
+process.stdin.on('error', () => process.exit(0));
+process.stdin.on('end', () => {
+  try {
+    const data = JSON.parse(input);
+    // Collapse whitespace so phrase triggers still match multiline prompts —
+    // every regex below sees a single-line prompt (#598).
+    const prompt = (data.prompt || '').trim().toLowerCase().replace(/\s+/g, ' ');
+
+    // Deactivation intent — computed FIRST so "turn caveman mode off" never
+    // falls through to the activation patterns (#598: the old contiguous
+    // "turn off" phrasing missed the "turn X off" word order entirely, and
+    // the activation regex then re-armed caveman at the default level).
+    const wantsOff =
+      /\b(stop|disable|deactivate|quit|exit|kill)\s+(the\s+)?caveman\b/.test(prompt) ||
+      /\bcaveman(\s+mode)?\s+(off|stop|disabled?)\b/.test(prompt) ||
+      /\bturn\s+off\s+(the\s+)?caveman\b/.test(prompt) ||
+      // "normal mode" only as a command (prompt-initial, optionally led by a
+      // switch-back verb) or with caveman context — never mid-sentence for
+      // e.g. vim's normal mode ("how do I exit vim normal mode").
+      /^(please\s+)?(go\s+|back\s+to\s+|switch\s+(back\s+)?to\s+|return\s+to\s+)?normal\s+mode\b/.test(prompt) ||
+      (/\bnormal\s+mode\b/.test(prompt) && /\bcaveman\b/.test(prompt));
+
+    // Questions about caveman are not activation commands
+    // ("what is caveman mode?", "does caveman lite drop articles?").
+    const isQuestion =
+      /^(what|whats|what's|how|why|when|where|who|does|do|did|is|are|can|could|would|should|tell me|explain)\b/.test(prompt);
+
+    // Natural language activation (e.g. "activate caveman", "turn on caveman
+    // mode", "talk like caveman"). README tells users they can say these.
+    // Also brevity requests ("less tokens", "be brief/terse", "fewer tokens",
+    // "shorter answers") — but not when scoped to a single section
+    // ("be brief in the summary"), which is a one-off instruction, not a
+    // session-wide mode switch.
+    if (!wantsOff && !isQuestion) {
+      if (/\b(activate|enable|start|turn on|use|switch to|want|give me)\b[^.]{0,40}\bcaveman\b/.test(prompt) ||
+          /\btalk like\b[^.]{0,40}\bcaveman\b/.test(prompt) ||
+          /\bcaveman\s+mode\s+(on|please|now)\b/.test(prompt) ||
+          /^caveman(\s+mode)?\s*[.!]*$/.test(prompt) ||
+          /\b(less tokens|fewer tokens|be brief|be terse|shorter answers)\b(?!\s+(in|for|on|about|when|during|with)\b)/.test(prompt)) {
+        const mode = getDefaultMode();
+        if (mode !== 'off') {
+          recordModeChange(claudeDir, mode); // #601: timestamped transition log
+          safeWriteFlag(flagPath, mode);
+        }
+      }
+    }
+
+    // /caveman-stats [--share] — block the prompt and inject stats output as
+    // the hook's reason. The script reads the active session log, so we pass
+    // transcript_path through when Claude Code provides it.
+    const statsMatch = /^\/caveman(?::caveman)?-stats(?:\s+(.*))?$/.exec(prompt);
+    if (statsMatch) {
+      const tailArgs = (statsMatch[1] || '').trim().split(/\s+/).filter(Boolean);
+      try {
+        const statsPath = path.join(__dirname, 'caveman-stats.js');
+        const argv = [statsPath];
+        if (data.transcript_path) argv.push('--session-file', data.transcript_path);
+        if (tailArgs.includes('--share')) argv.push('--share');
+        if (tailArgs.includes('--all')) argv.push('--all');
+        const sinceIdx = tailArgs.indexOf('--since');
+        if (sinceIdx !== -1 && tailArgs[sinceIdx + 1]) {
+          argv.push('--since', tailArgs[sinceIdx + 1]);
+        }
+        const out = execFileSync(process.execPath, argv, { encoding: 'utf8', timeout: 5000 });
+        process.stdout.write(JSON.stringify({ decision: 'block', reason: out.trim() }));
+      } catch (e) {
+        process.stdout.write(JSON.stringify({
+          decision: 'block',
+          reason: 'caveman-stats: could not run stats script.\nTry manually: node hooks/caveman-stats.js'
+        }));
+      }
+      return;
+    }
+
+    // Match /caveman commands. Independent one-shot modes remember the prose
+    // mode active before them so the next ordinary prompt restores it (#599)
+    // — SKILL.md promises "Level persist until changed or session end", and a
+    // one-shot skill invocation should not count as "changed" forever.
+    let setIndependentThisTurn = false;
+    if (prompt.startsWith('/caveman')) {
+      const parts = prompt.split(/\s+/);
+      const cmd = parts[0]; // /caveman, /caveman-commit, /caveman-review, etc.
+      const arg = parts[1] || '';
+
+      let mode = null;
+
+      // Marketplace plugin installs surface commands namespaced as
+      // /caveman:caveman-<name> — accept both forms for every skill (#599:
+      // only compress and stats had the namespaced variant).
+      if (cmd === '/caveman-commit' || cmd === '/caveman:caveman-commit') {
+        mode = 'commit';
+      } else if (cmd === '/caveman-review' || cmd === '/caveman:caveman-review') {
+        mode = 'review';
+      } else if (cmd === '/caveman-compress' || cmd === '/caveman:caveman-compress') {
+        mode = 'compress';
+      } else if (cmd === '/caveman' || cmd === '/caveman:caveman') {
+        // Bare /caveman → activate at configured default
+        if (!arg) {
+          mode = getDefaultMode();
+        } else if (arg === 'off' || arg === 'stop' || arg === 'disable') {
+          mode = 'off';
+        } else if (arg === 'wenyan-full') {
+          // Canonical alias — config stores as 'wenyan'
+          mode = 'wenyan';
+        } else if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) {
+          mode = arg;
+        }
+        // Unknown arg → mode stays null, flag untouched (no silent overwrite)
+      }
+
+      if (mode && mode !== 'off') {
+        if (INDEPENDENT_MODES.has(mode)) {
+          // Save the prose mode being displaced — but never overwrite an
+          // already-saved one with another independent mode (/caveman-commit
+          // followed by /caveman-review must still restore the original).
+          const current = readFlag(flagPath);
+          if (current && !INDEPENDENT_MODES.has(current)) {
+            safeWriteFlag(prevPath, current);
+          }
+          setIndependentThisTurn = true;
+        }
+        recordModeChange(claudeDir, mode); // #601
+        safeWriteFlag(flagPath, mode);
+      } else if (mode === 'off') {
+        recordModeChange(claudeDir, null); // #601
+        try { fs.unlinkSync(flagPath); } catch (e) {}
+        try { fs.unlinkSync(prevPath); } catch (e) {}
+      }
+    }
+
+    // Apply deactivation detected above
+    if (wantsOff) {
+      recordModeChange(claudeDir, null); // #601
+      try { fs.unlinkSync(flagPath); } catch (e) {}
+      try { fs.unlinkSync(prevPath); } catch (e) {}
+    }
+
+    // Per-turn reinforcement: emit a structured reminder when caveman is active.
+    // The SessionStart hook injects the full ruleset once, but models lose it
+    // when other plugins inject competing style instructions every turn.
+    // This keeps caveman visible in the model's attention on every user message.
+    //
+    // Skip independent modes (commit, review, compress) — they have their own
+    // skill behavior and the base caveman rules would conflict.
+    // readFlag enforces symlink-safe read + size cap + VALID_MODES whitelist.
+    // If the flag is missing, corrupted, oversized, or a symlink pointing at
+    // something like ~/.ssh/id_rsa, readFlag returns null and we emit nothing
+    // — never inject untrusted bytes into model context.
+    let activeMode = readFlag(flagPath);
+
+    // One-shot restore (#599): an independent mode set on a PREVIOUS prompt
+    // has served its turn — bring back the prose mode that was active before
+    // it, or deactivate if caveman wasn't active then.
+    if (activeMode && INDEPENDENT_MODES.has(activeMode) && !setIndependentThisTurn) {
+      const prev = readFlag(prevPath);
+      try { fs.unlinkSync(prevPath); } catch (e) {}
+      if (prev && !INDEPENDENT_MODES.has(prev)) {
+        recordModeChange(claudeDir, prev); // #601
+        safeWriteFlag(flagPath, prev);
+        activeMode = prev;
+      } else {
+        recordModeChange(claudeDir, null); // #601
+        try { fs.unlinkSync(flagPath); } catch (e) {}
+        activeMode = null;
+      }
+    }
+
+    if (activeMode && !INDEPENDENT_MODES.has(activeMode)) {
+      process.stdout.write(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "UserPromptSubmit",
+          additionalContext: "CAVEMAN MODE ACTIVE (" + activeMode + "). " +
+            "Drop articles/filler/pleasantries/hedging. Fragments OK. " +
+            "Code/commits/security: write normal."
+        }
+      }));
+    }
+  } catch (e) {
+    // Silent fail
+  }
+});

--- a/.claude/skills/caveman/src/hooks/caveman-stats.js
+++ b/.claude/skills/caveman/src/hooks/caveman-stats.js
@@ -1,0 +1,533 @@
+#!/usr/bin/env node
+// caveman-stats — read the active Claude Code session log, print real token
+// usage plus an estimated savings figure from the benchmark in benchmarks/.
+//
+// Run directly:    node hooks/caveman-stats.js
+// Inside Claude:   /caveman-stats triggers this via the UserPromptSubmit hook.
+// Hook integration passes --session-file <transcript_path> so we always read
+// the active session, not whichever JSONL was modified most recently.
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { readFlag, appendFlag, readHistory, safeWriteFlag, VALID_MODES, MODE_LOG_BASENAME } = require('./caveman-config');
+
+// Mean per-task savings from benchmarks/results/*.json (avg_savings: 65 across
+// 10 tasks, sonnet-4-20250514). Only 'full' has measured data; lite / ultra /
+// wenyan modes show no estimate until benchmarked. Add an entry here when a new
+// run is committed.
+const COMPRESSION = { 'full': 0.65 };
+
+// Approximate Anthropic public output-token pricing, USD per million.
+// Match by model id prefix so this stays correct across point releases
+// (e.g. claude-sonnet-4-20250514, claude-sonnet-4-7). Update from
+// https://www.anthropic.com/pricing if a release changes the tier.
+// Most-specific prefixes MUST come first — priceForModel returns the first match.
+const MODEL_OUTPUT_PRICE_PER_M = [
+  // Legacy Opus 4.0 / 4.1 (pre-4.5) billed at the old $75/M output tier,
+  // including the dated ids (e.g. claude-opus-4-20250514).
+  ['claude-opus-4-0',    75.00],
+  ['claude-opus-4-1',    75.00],
+  ['claude-opus-4-2025', 75.00],
+  // Opus 4.5–4.8 dropped to $25/M output (rate card held since 4.5).
+  ['claude-opus-4',      25.00],
+  ['claude-sonnet-4',    15.00],
+  ['claude-haiku-4',      5.00],   // Haiku 4.5 = $5/M output
+  ['claude-3-5-sonnet',  15.00],
+  ['claude-3-5-haiku',    4.00],
+  ['claude-3-opus',      75.00],
+];
+
+function priceForModel(model) {
+  if (!model) return null;
+  for (const [prefix, price] of MODEL_OUTPUT_PRICE_PER_M) {
+    if (model.startsWith(prefix)) return price;
+  }
+  return null;
+}
+
+function formatUsd(amount) {
+  if (amount >= 1) return `$${amount.toFixed(2)}`;
+  if (amount >= 0.01) return `$${amount.toFixed(3)}`;
+  return `$${amount.toFixed(4)}`;
+}
+
+function findRecentSession(claudeDir) {
+  const projectsDir = path.join(claudeDir, 'projects');
+  let entries;
+  try { entries = fs.readdirSync(projectsDir, { withFileTypes: true }); }
+  catch { return null; }
+
+  let best = null;
+  const stack = entries.map(e => path.join(projectsDir, e.name));
+  while (stack.length) {
+    const p = stack.pop();
+    let st;
+    try { st = fs.statSync(p); } catch { continue; }
+    if (st.isDirectory()) {
+      try {
+        for (const child of fs.readdirSync(p)) stack.push(path.join(p, child));
+      } catch {}
+    } else if (p.endsWith('.jsonl') && (!best || st.mtimeMs > best.mtime)) {
+      best = { file: p, mtime: st.mtimeMs };
+    }
+  }
+  return best ? best.file : null;
+}
+
+function parseSession(filePath) {
+  let raw;
+  try { raw = fs.readFileSync(filePath, 'utf8'); }
+  catch { return { outputTokens: 0, cacheReadTokens: 0, turns: 0, model: null, messages: [] }; }
+
+  let outputTokens = 0;
+  let cacheReadTokens = 0;
+  let turns = 0;
+  let model = null;
+  const messages = []; // per-message {ts, outputTokens} for mode attribution (#601)
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    let entry;
+    try { entry = JSON.parse(line); } catch { continue; }
+    if (entry.type !== 'assistant' || !entry.message) continue;
+    const usage = entry.message.usage;
+    if (!usage) continue;
+    outputTokens    += usage.output_tokens           || 0;
+    cacheReadTokens += usage.cache_read_input_tokens || 0;
+    turns++;
+    if (!model && entry.message.model) model = entry.message.model;
+    const ts = entry.timestamp ? Date.parse(entry.timestamp) : NaN;
+    messages.push({
+      ts: Number.isFinite(ts) ? ts : null,
+      outputTokens: usage.output_tokens || 0,
+    });
+  }
+  return { outputTokens, cacheReadTokens, turns, model, messages };
+}
+
+// Detect *.original.md / *.md pairs left behind by caveman-compress. The
+// presence of a *.original.md backup means the *.md sibling is a compressed
+// memory file — every session start reads the compressed version, so the
+// delta is per-session input-token savings (passive). Returns a summary or
+// null if nothing was found in the given dirs.
+function findCompressedPairs(dirs) {
+  const pairs = [];
+  for (const dir of dirs) {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+    catch { continue; }
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.original.md')) continue;
+      const base = entry.name.slice(0, -'.original.md'.length);
+      const originalPath = path.join(dir, entry.name);
+      const compressedPath = path.join(dir, `${base}.md`);
+      let oSize, cSize;
+      try {
+        oSize = fs.statSync(originalPath).size;
+        cSize = fs.statSync(compressedPath).size;
+      } catch { continue; }
+      if (oSize <= cSize) continue;
+      pairs.push({ name: base, dir, originalSize: oSize, compressedSize: cSize });
+    }
+  }
+  return pairs;
+}
+
+function summarizeCompressed(pairs) {
+  if (!pairs || pairs.length === 0) return null;
+  const totalOriginal = pairs.reduce((s, p) => s + p.originalSize, 0);
+  const totalCompressed = pairs.reduce((s, p) => s + p.compressedSize, 0);
+  const bytesSaved = totalOriginal - totalCompressed;
+  // English prose runs ~4 chars per token. Label result as approximate so we
+  // don't make claims tighter than the method warrants.
+  const tokensSaved = Math.round(bytesSaved / 4);
+  return { count: pairs.length, bytesSaved, tokensSaved };
+}
+
+// ── Per-mode attribution (#601) ─────────────────────────────────────────────
+// The whole session's tokens must never be credited to whatever mode the flag
+// happens to hold at stats time — a mid-session mode change would inflate the
+// estimate (verbose tokens counted as compressed) or zero it (caveman tokens
+// counted as uncompressed). The mode tracker + SessionStart hook append
+// {ts, mode, prev} rows to .caveman-mode-log.jsonl on every actual transition;
+// stats joins those timestamps against the session JSONL message timestamps.
+
+// Read + validate the transition log. Returns rows sorted by ts.
+function readModeLog(logPath) {
+  const rows = [];
+  for (const line of readHistory(logPath)) {
+    let e;
+    try { e = JSON.parse(line); } catch { continue; }
+    if (!e || typeof e !== 'object' || !Number.isFinite(e.ts)) continue;
+    const norm = (v) => (v == null ? null : (VALID_MODES.includes(String(v)) ? String(v) : undefined));
+    const mode = norm(e.mode);
+    const prev = norm(e.prev);
+    if (mode === undefined || prev === undefined) continue; // reject non-whitelisted values
+    rows.push({ ts: e.ts, mode, prev });
+  }
+  rows.sort((a, b) => a.ts - b.ts);
+  return rows;
+}
+
+// Attribute each message's output tokens to the mode active when it was
+// generated. Sources, most to least exact:
+//   'log'           — the transition log covers the message (rows at/before its
+//                     ts, or the first row's `prev` for the pre-inception span).
+//   'flag-mtime'    — no log rows, but the flag was written mid-session: tokens
+//                     from the write onward belong to the current mode; earlier
+//                     tokens have UNKNOWN mode and are excluded, never guessed
+//                     (no-fake-savings). Messages without timestamps are also
+//                     unknown in this case.
+//   'whole-session' — no log and no evidence of a mid-session change: the
+//                     current mode covers the whole session (correct when the
+//                     mode never changed; pre-#601 behavior).
+// Returns { byMode: {modeKey: tokens}, unknownTokens, basis } where modeKey is
+// a mode string or 'none' (caveman inactive).
+function attributeByMode({ messages, modeLog, mode, flagMtimeMs, outputTokens }) {
+  const currentKey = mode || 'none';
+  const msgs = messages || [];
+  let firstTs = null;
+  for (const m of msgs) {
+    if (m.ts != null && (firstTs === null || m.ts < firstTs)) firstTs = m.ts;
+  }
+
+  let events = modeLog || [];
+  let basis = 'log';
+  let prefixMode; // mode for messages before the first event (undefined = unknown)
+  if (events.length === 0) {
+    if (flagMtimeMs != null && firstTs != null && flagMtimeMs > firstTs) {
+      // Flag written mid-session with no transition log: only the span from
+      // the write onward is attributable. The write may have been a
+      // reaffirmation of the same mode, but assuming so would guess savings
+      // into existence — exclude the prefix instead.
+      events = [{ ts: flagMtimeMs, mode: mode || null }];
+      basis = 'flag-mtime';
+      prefixMode = undefined;
+    } else {
+      return { byMode: { [currentKey]: outputTokens || 0 }, unknownTokens: 0, basis: 'whole-session' };
+    }
+  } else {
+    // Every transition since log inception is recorded, so the span before
+    // the first row ran under that row's `prev` mode.
+    prefixMode = events[0].prev;
+  }
+
+  const byMode = {};
+  let unknownTokens = 0;
+  const add = (key, tokens) => { byMode[key] = (byMode[key] || 0) + tokens; };
+  for (const m of msgs) {
+    if (m.ts == null) { unknownTokens += m.outputTokens; continue; }
+    let active;
+    for (const ev of events) {
+      if (ev.ts <= m.ts) active = ev;
+      else break;
+    }
+    if (active !== undefined) add(active.mode || 'none', m.outputTokens);
+    else if (prefixMode !== undefined) add(prefixMode || 'none', m.outputTokens);
+    else unknownTokens += m.outputTokens;
+  }
+  return { byMode, unknownTokens, basis };
+}
+
+// Attribution shape for callers without a session log to join against
+// (kept for formatStats/formatShare backward compatibility in tests).
+function wholeSessionAttribution(mode, outputTokens) {
+  return { byMode: { [mode || 'none']: outputTokens || 0 }, unknownTokens: 0, basis: 'whole-session' };
+}
+
+// Compute the savings figures we want to log/share for one session snapshot.
+// Sums per-mode: only spans whose mode has benchmark data earn an estimate;
+// unknown spans earn nothing.
+function deriveSavings({ byMode, model }) {
+  let estSavedTokens = 0;
+  for (const [key, tokens] of Object.entries(byMode || {})) {
+    const ratio = COMPRESSION[key];
+    if (ratio == null || tokens <= 0) continue;
+    estSavedTokens += Math.round(tokens / (1 - ratio)) - tokens;
+  }
+  const price = priceForModel(model);
+  const estSavedUsd = price !== null ? (estSavedTokens / 1_000_000) * price : 0;
+  return { estSavedTokens, estSavedUsd };
+}
+
+// Parse "7d", "12h" etc. to milliseconds. Returns null on invalid input.
+function parseDuration(spec) {
+  if (!spec) return null;
+  const m = /^(\d+)([dh])$/.exec(spec.trim());
+  if (!m) return null;
+  const n = parseInt(m[1], 10);
+  return m[2] === 'd' ? n * 86_400_000 : n * 3_600_000;
+}
+
+// Aggregate history into latest-per-session totals, optionally filtered to a
+// time window. Returns { sessions, outputTokens, estSavedTokens, estSavedUsd }.
+function aggregateHistory(historyPath, sinceMs) {
+  const lines = readHistory(historyPath);
+  const cutoff = sinceMs ? Date.now() - sinceMs : null;
+  const latestPerSession = new Map();
+  for (const line of lines) {
+    let entry;
+    try { entry = JSON.parse(line); } catch { continue; }
+    if (!entry || typeof entry !== 'object') continue;
+    if (cutoff !== null && (entry.ts || 0) < cutoff) continue;
+    const id = entry.session_id || '_';
+    const prev = latestPerSession.get(id);
+    if (!prev || (entry.ts || 0) >= (prev.ts || 0)) latestPerSession.set(id, entry);
+  }
+  let outputTokens = 0, estSavedTokens = 0, estSavedUsd = 0;
+  for (const e of latestPerSession.values()) {
+    outputTokens   += e.output_tokens     || 0;
+    estSavedTokens += e.est_saved_tokens  || 0;
+    estSavedUsd    += e.est_saved_usd     || 0;
+  }
+  return { sessions: latestPerSession.size, outputTokens, estSavedTokens, estSavedUsd };
+}
+
+// Output-reduction share: saved / (saved + used) = the fraction of the
+// would-be OUTPUT tokens that caveman avoided. That is the only ratio we can
+// honestly compute from output counts alone. It is NOT a share of session or
+// limit usage — input + cache tokens dominate agentic sessions, count against
+// Pro/Max limits, and are not reduced by caveman, so real limit relief is far
+// smaller (docs/HONEST-NUMBERS.md: session-level totals land ~14–21%, below
+// zero on terse workloads). Never label this "usage" or "budget". Returns a
+// rounded percent, or null when there is nothing measured to divide.
+function outputReductionPct(savedTokens, usedTokens) {
+  if (!Number.isFinite(savedTokens) || !Number.isFinite(usedTokens)) return null;
+  if (savedTokens <= 0 || usedTokens < 0) return null;
+  const total = savedTokens + usedTokens;
+  if (total <= 0) return null;
+  return Math.round((savedTokens / total) * 100);
+}
+
+function humanizeTokens(n) {
+  if (!Number.isFinite(n) || n <= 0) return '0';
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + 'k';
+  return String(Math.round(n));
+}
+
+function formatHistory({ sessions, outputTokens, estSavedTokens, estSavedUsd, since }) {
+  const sep = '──────────────────────────────────';
+  const window = since ? ` (last ${since})` : '';
+  if (sessions === 0) {
+    return `\nCaveman Stats — Lifetime${window}\n${sep}\nNo sessions logged yet — run /caveman-stats inside any session to start tracking.\n${sep}\n`;
+  }
+  const usdLine = estSavedUsd > 0 ? `Est. saved (USD):      ~${formatUsd(estSavedUsd)}\n` : '';
+  const pct = outputReductionPct(estSavedTokens, outputTokens);
+  const budgetLine = pct !== null
+    ? `Est. output reduction: ~${pct}% (output tokens only, est.)\n`
+    : '';
+  return `\nCaveman Stats — Lifetime${window}\n${sep}\n` +
+    `Sessions:   ${sessions.toLocaleString()}\n${sep}\n` +
+    `Output tokens:         ${outputTokens.toLocaleString()}\n` +
+    `Est. tokens saved:     ${estSavedTokens.toLocaleString()}\n` +
+    budgetLine + usdLine + sep + '\n';
+}
+
+// Single-line tweetable summary. Stays human-friendly when no ratio is known.
+// Savings come from per-mode attribution (#601) so a mid-session mode change
+// never inflates the shared number.
+function formatShare({ outputTokens, turns, mode, model, attribution }) {
+  if (turns === 0) {
+    return '🪨 caveman armed but no turns yet — caveman.sh';
+  }
+  const attr = attribution || wholeSessionAttribution(mode, outputTokens);
+  const { estSavedTokens, estSavedUsd } = deriveSavings({ byMode: attr.byMode, model });
+
+  if (estSavedTokens > 0) {
+    const usd = estSavedUsd > 0 ? ` (~${formatUsd(estSavedUsd)})` : '';
+    return `🪨 Saved ${estSavedTokens.toLocaleString()} output tokens${usd} across ${turns} turns this session — caveman.sh`;
+  }
+  return `🪨 ${turns} turns, ${outputTokens.toLocaleString()} output tokens this session — caveman.sh`;
+}
+
+// Pure formatter — separated from main() so tests can pass synthetic inputs.
+// `attribution` (from attributeByMode, #601) splits output tokens per mode;
+// when omitted, the current mode is assumed for the whole session.
+function formatStats({ outputTokens, cacheReadTokens, turns, mode, model, sessionPath, compressed, attribution }) {
+  const sep = '──────────────────────────────────';
+  const shortPath = sessionPath && sessionPath.length > 45
+    ? '...' + sessionPath.slice(-45)
+    : (sessionPath || '');
+
+  if (turns === 0) {
+    return `\nCaveman Stats\n${sep}\nNo conversation yet — stats available after first response.\n${sep}\n`;
+  }
+
+  const attr = attribution || wholeSessionAttribution(mode, outputTokens);
+  const activeKeys = Object.keys(attr.byMode).filter(k => attr.byMode[k] > 0);
+  // Uniform = every token ran under the CURRENT mode. Anything else — a
+  // second mode, tokens under a mode the flag no longer shows, or spans we
+  // could not attribute — gets the per-mode breakdown below.
+  const uniform = attr.unknownTokens === 0 &&
+    (activeKeys.length === 0 || (activeKeys.length === 1 && activeKeys[0] === (mode || 'none')));
+
+  const ratio = COMPRESSION[mode] != null ? COMPRESSION[mode] : null;
+  const price = priceForModel(model);
+
+  let savings;
+  let footer = '';
+  if (!uniform) {
+    const { estSavedTokens, estSavedUsd } = deriveSavings({ byMode: attr.byMode, model });
+    const lines = [attr.basis === 'flag-mtime'
+      ? 'Mode was set mid-session — only output after the change is attributed:'
+      : 'Mode changed mid-session — output attributed per mode:'];
+    for (const key of activeKeys) {
+      const tokens = attr.byMode[key];
+      const r = COMPRESSION[key];
+      const label = key === 'none' ? 'caveman off' : key;
+      const note = r != null
+        ? `est. ${(Math.round(tokens / (1 - r)) - tokens).toLocaleString()} saved`
+        : 'no benchmark estimate';
+      lines.push(`  ${label}: ${tokens.toLocaleString()} tokens (${note})`);
+    }
+    if (attr.unknownTokens > 0) {
+      lines.push(`  unattributed: ${attr.unknownTokens.toLocaleString()} tokens (mode unknown — excluded from estimate)`);
+    }
+    lines.push(`Est. tokens saved:     ${estSavedTokens.toLocaleString()}`);
+    if (estSavedUsd > 0) lines.push(`Est. saved (USD):      ~${formatUsd(estSavedUsd)}`);
+    savings = lines.join('\n');
+
+    footer = 'Savings est. from benchmarks/ (mean per-task), applied only to spans whose mode is known.';
+    if (estSavedUsd > 0) footer += ` Pricing for ${model}.`;
+    if (attr.basis === 'flag-mtime') {
+      footer += ' Tokens before the mode change could not be attributed and are excluded rather than guessed.';
+    } else if (attr.unknownTokens > 0) {
+      footer += ' Unattributed tokens are excluded rather than guessed.';
+    }
+    footer += ' Reduction is of output tokens only; input/cache usage is unchanged.';
+  } else if (ratio !== null) {
+    const estNormal = Math.round(outputTokens / (1 - ratio));
+    const estSaved = estNormal - outputTokens;
+    let usdLine = '';
+    if (price !== null) {
+      const usd = (estSaved / 1_000_000) * price;
+      usdLine = `Est. saved (USD):      ~${formatUsd(usd)}\n`;
+      footer = `Savings est. from benchmarks/ (mean per-task). Pricing for ${model}. Actual varies by task.`;
+    } else {
+      footer = 'Savings est. from benchmarks/ (mean per-task). Actual varies by task.';
+    }
+    // No "% of your usage/budget" line here on purpose: from output tokens
+    // alone the only computable ratio is the output reduction already shown
+    // on the line above, and input + cache tokens (which dominate agentic
+    // sessions and count against Pro/Max limits) are untouched by caveman —
+    // any session-usage % would overstate real limit relief. See
+    // docs/HONEST-NUMBERS.md.
+    footer += ' Reduction is of output tokens only; input/cache usage is unchanged.';
+    savings = (`Est. without caveman:  ${estNormal.toLocaleString()}\n` +
+              `Est. tokens saved:     ${estSaved.toLocaleString()} (~${Math.round(ratio * 100)}% of output)\n` +
+              usdLine).replace(/\n$/, '');
+  } else if (mode && mode !== 'off') {
+    savings = `No savings estimate for '${mode}' mode — only 'full' has benchmark data.`;
+  } else {
+    savings = 'Caveman not active this session.';
+  }
+
+  let memoryLine = '';
+  if (compressed && compressed.count > 0) {
+    const tokensApprox = compressed.tokensSaved.toLocaleString();
+    memoryLine = `${sep}\nMemory compressed:     ${compressed.count} file${compressed.count === 1 ? '' : 's'}, ` +
+      `~${tokensApprox} tokens saved per session start (approx)\n`;
+  }
+
+  return `\nCaveman Stats\n${sep}\n` +
+    (shortPath ? `Session:  ${shortPath}\n` : '') +
+    `Turns:    ${turns}\n${sep}\n` +
+    `Output tokens:         ${outputTokens.toLocaleString()}\n` +
+    `Cache-read tokens:     ${cacheReadTokens.toLocaleString()}\n${sep}\n` +
+    `${savings}\n` +
+    memoryLine +
+    (footer ? footer + '\n' : '');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const i = args.indexOf('--session-file');
+  const sessionFileArg = i !== -1 ? args[i + 1] : null;
+  const share = args.includes('--share');
+  const all = args.includes('--all');
+  const sinceIdx = args.indexOf('--since');
+  const sinceArg = sinceIdx !== -1 ? args[sinceIdx + 1] : null;
+
+  const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+  const historyPath = path.join(claudeDir, '.caveman-history.jsonl');
+
+  // Lifetime aggregation paths short-circuit before we need a live session.
+  if (all || sinceArg) {
+    const sinceMs = parseDuration(sinceArg);
+    if (sinceArg && sinceMs === null) {
+      process.stderr.write(`caveman-stats: --since takes Nh or Nd (e.g. 7d, 24h), got: ${sinceArg}\n`);
+      process.exit(2);
+    }
+    const agg = aggregateHistory(historyPath, sinceMs);
+    process.stdout.write(formatHistory({ ...agg, since: sinceArg || null }));
+    return;
+  }
+
+  const sessionFile = sessionFileArg || findRecentSession(claudeDir);
+
+  if (!sessionFile) {
+    process.stderr.write('caveman-stats: no Claude Code session found.\n');
+    process.exit(1);
+  }
+
+  const parsed = parseSession(sessionFile);
+  const flagPath = path.join(claudeDir, '.caveman-active');
+  const mode = readFlag(flagPath);
+
+  // #601: attribute tokens to the mode active when each message happened,
+  // via the transition log the hooks maintain (fallbacks documented on
+  // attributeByMode). Never credit the whole session to the current flag.
+  let flagMtimeMs = null;
+  try { flagMtimeMs = fs.statSync(flagPath).mtimeMs; } catch (e) {}
+  const modeLog = readModeLog(path.join(claudeDir, MODE_LOG_BASENAME));
+  const attribution = attributeByMode({
+    messages: parsed.messages,
+    modeLog,
+    mode,
+    flagMtimeMs,
+    outputTokens: parsed.outputTokens,
+  });
+
+  // Append a snapshot of this session's totals to the lifetime log. Multiple
+  // /caveman-stats calls in one session emit multiple lines for the same
+  // session_id; aggregateHistory keeps only the latest per session_id.
+  if (parsed.turns > 0) {
+    const { estSavedTokens, estSavedUsd } = deriveSavings({ byMode: attribution.byMode, model: parsed.model });
+    const sessionId = path.basename(sessionFile, '.jsonl');
+    appendFlag(historyPath, JSON.stringify({
+      ts: Date.now(),
+      session_id: sessionId,
+      mode: mode || null,
+      model: parsed.model || null,
+      output_tokens: parsed.outputTokens,
+      est_saved_tokens: estSavedTokens,
+      est_saved_usd: estSavedUsd,
+    }));
+
+    // Statusline suffix: tiny pre-rendered string the shell statusline can
+    // cat without parsing JSONL. Updated on every /caveman-stats run.
+    // Routed through safeWriteFlag — the suffix path is predictable and
+    // user-owned, same symlink-clobber surface as the .caveman-active flag.
+    const agg = aggregateHistory(historyPath, null);
+    const suffix = agg.estSavedTokens > 0 ? `⛏  ${humanizeTokens(agg.estSavedTokens)}` : '';
+    safeWriteFlag(path.join(claudeDir, '.caveman-statusline-suffix'), suffix);
+  }
+
+  if (share) {
+    process.stdout.write(formatShare({ ...parsed, mode, attribution }) + '\n');
+  } else {
+    const scanDirs = [claudeDir, process.cwd()].filter((d, i, a) => a.indexOf(d) === i);
+    const compressed = summarizeCompressed(findCompressedPairs(scanDirs));
+    process.stdout.write(formatStats({ ...parsed, mode, sessionPath: sessionFile, compressed, attribution }));
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  formatStats, formatShare, formatHistory, aggregateHistory, parseDuration, deriveSavings,
+  parseSession, priceForModel, formatUsd, COMPRESSION, MODEL_OUTPUT_PRICE_PER_M,
+  findCompressedPairs, summarizeCompressed, humanizeTokens, outputReductionPct,
+  readModeLog, attributeByMode,
+};

--- a/.claude/skills/caveman/src/hooks/caveman-statusline.ps1
+++ b/.claude/skills/caveman/src/hooks/caveman-statusline.ps1
@@ -1,0 +1,62 @@
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
+$Flag = Join-Path $ClaudeDir ".caveman-active"
+if (-not (Test-Path $Flag)) { exit 0 }
+
+# Refuse reparse points (symlinks / junctions) and oversized files. Without
+# this, a local attacker could point the flag at a secret file and have the
+# statusline render its bytes (including ANSI escape sequences) to the terminal
+# every keystroke.
+try {
+    $Item = Get-Item -LiteralPath $Flag -Force -ErrorAction Stop
+    if ($Item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) { exit 0 }
+    if ($Item.Length -gt 64) { exit 0 }
+} catch {
+    exit 0
+}
+
+$Mode = ""
+try {
+    $Raw = Get-Content -LiteralPath $Flag -TotalCount 1 -ErrorAction Stop
+    if ($null -ne $Raw) { $Mode = ([string]$Raw).Trim() }
+} catch {
+    exit 0
+}
+
+# Strip anything outside [a-z0-9-] — blocks terminal-escape and OSC hyperlink
+# injection via the flag contents. Then whitelist-validate.
+$Mode = $Mode.ToLowerInvariant()
+$Mode = ($Mode -replace '[^a-z0-9-]', '')
+
+$Valid = @('off','lite','full','ultra','wenyan-lite','wenyan','wenyan-full','wenyan-ultra','commit','review','compress')
+if (-not ($Valid -contains $Mode)) { exit 0 }
+
+$Esc = [char]27
+if ([string]::IsNullOrEmpty($Mode) -or $Mode -eq "full") {
+    [Console]::Write("${Esc}[38;5;172m[CAVEMAN]${Esc}[0m")
+} else {
+    $Suffix = $Mode.ToUpperInvariant()
+    [Console]::Write("${Esc}[38;5;172m[CAVEMAN:$Suffix]${Esc}[0m")
+}
+
+# Savings suffix: on by default. Opt out via CAVEMAN_STATUSLINE_SAVINGS=0.
+# Reads a pre-rendered string written by caveman-stats.js. Refuses reparse
+# points and strips control bytes (matches statusline.sh hardening). Until
+# /caveman-stats has run at least once, the suffix file is absent and nothing
+# is rendered — safe default for fresh installs.
+if ($env:CAVEMAN_STATUSLINE_SAVINGS -ne "0") {
+    $SavingsFile = Join-Path $ClaudeDir ".caveman-statusline-suffix"
+    if (Test-Path $SavingsFile) {
+        try {
+            $SavingsItem = Get-Item -LiteralPath $SavingsFile -Force -ErrorAction Stop
+            if (-not ($SavingsItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -and
+                $SavingsItem.Length -le 64) {
+                $Savings = (Get-Content -LiteralPath $SavingsFile -Encoding UTF8 -Raw -ErrorAction Stop).TrimEnd()
+                $Savings = ($Savings -replace '[\x00-\x1F]', '')
+                if ($Savings.Length -gt 0) {
+                    [Console]::Write(" ${Esc}[38;5;172m$Savings${Esc}[0m")
+                }
+            }
+        } catch {}
+    }
+}

--- a/.claude/skills/caveman/src/hooks/caveman-statusline.sh
+++ b/.claude/skills/caveman/src/hooks/caveman-statusline.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# caveman — statusline badge script for Claude Code
+# Reads the caveman mode flag file and outputs a colored badge.
+#
+# Usage in ~/.claude/settings.json:
+#   "statusLine": { "type": "command", "command": "bash /path/to/caveman-statusline.sh" }
+#
+# Plugin users: Claude will offer to set this up on first session.
+# Standalone users: install.sh wires this automatically.
+
+FLAG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.caveman-active"
+
+# Refuse symlinks — a local attacker could point the flag at ~/.ssh/id_rsa and
+# have the statusline render its bytes (including ANSI escape sequences) to
+# the terminal every keystroke.
+[ -L "$FLAG" ] && exit 0
+[ ! -f "$FLAG" ] && exit 0
+
+# Hard-cap the read at 64 bytes and strip anything outside [a-z0-9-] — blocks
+# terminal-escape injection and OSC hyperlink spoofing via the flag contents.
+MODE=$(head -c 64 "$FLAG" 2>/dev/null | tr -d '\n\r' | tr '[:upper:]' '[:lower:]')
+MODE=$(printf '%s' "$MODE" | tr -cd 'a-z0-9-')
+
+# Whitelist. Anything else → render nothing rather than echo attacker bytes.
+case "$MODE" in
+  off|lite|full|ultra|wenyan-lite|wenyan|wenyan-full|wenyan-ultra|commit|review|compress) ;;
+  *) exit 0 ;;
+esac
+
+if [ -z "$MODE" ] || [ "$MODE" = "full" ]; then
+  printf '\033[38;5;172m[CAVEMAN]\033[0m'
+else
+  SUFFIX=$(printf '%s' "$MODE" | tr '[:lower:]' '[:upper:]')
+  printf '\033[38;5;172m[CAVEMAN:%s]\033[0m' "$SUFFIX"
+fi
+
+# Savings suffix: on by default. Opt out via CAVEMAN_STATUSLINE_SAVINGS=0.
+# Reads a pre-rendered string written by caveman-stats.js so we don't shell out
+# to node on every keystroke. Refuses symlinks and strips control bytes —
+# same hardening as the flag file (a local attacker could plant a file with
+# ANSI escape codes otherwise). Until /caveman-stats has run at least once,
+# the suffix file is absent and nothing is rendered — so the default is safe
+# for fresh installs (no fake number, no crash).
+if [ "${CAVEMAN_STATUSLINE_SAVINGS:-1}" != "0" ]; then
+  SAVINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.caveman-statusline-suffix"
+  if [ -f "$SAVINGS_FILE" ] && [ ! -L "$SAVINGS_FILE" ]; then
+    SAVINGS=$(head -c 64 "$SAVINGS_FILE" 2>/dev/null | tr -d '\000-\037')
+    [ -n "$SAVINGS" ] && printf ' \033[38;5;172m%s\033[0m' "$SAVINGS"
+  fi
+fi

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -39,8 +39,9 @@ Verification — the canonical gates + per-item acceptance checks ("WHEN `<comma
 `<observable>`"). 7. The ESCALATE contract.
 
 Also in the brief: worktree-only work, the fixed HANDOFF fields (CLAUDE.md "THE HANDOFF"),
-commit style, and — if ponytail is active in this session — the first line
-`Run /ponytail:ponytail <level>`.
+and commit style. Mode propagation is mechanical (the `SubagentStart` hook injects the
+ponytail + caveman capsule); add a first line `Run /ponytail:ponytail <level>` ONLY when a
+non-default level (`lite`/`ultra`) is active in this session.
 
 A weak brief is YOUR bug. If a load-bearing fact is unverified, probe it now or mark it
 ASSUMED with a verification step in the brief.

--- a/.claude/skills/gh-issue/SKILL.md
+++ b/.claude/skills/gh-issue/SKILL.md
@@ -283,9 +283,10 @@ run the verification gates and not proceed red, to **self-review the diff agains
 step objective and the issue** before finishing, then to make a focused commit
 (`<scope>: <imperative summary>`, CLAUDE.md commit style; reference the issue), and
 to **return the handoff document** in the Step-5 format. Tell it its returned message
-IS the handoff. If `ponytail` is active in this session, the brief's **first** instruction is
-`Run /ponytail:ponytail <level>` (the level active here — full/lite/ultra; CLAUDE.md "Plan with
-a higher model"), so the implementer matches the parent's ponytail mode.
+IS the handoff. Mode propagation is mechanical — the `SubagentStart` hook injects the
+ponytail + caveman capsule (CLAUDE.md "Plan with a higher model"); make the brief's **first**
+instruction `Run /ponytail:ponytail <level>` ONLY when a non-default level (`lite`/`ultra`)
+is active in this session.
 
 **7b. Orchestrator gate (independent, mechanical — CLAUDE.md "THE GATE"; you verify the
 transaction and content, you don't re-implement).** Terse prose, full checks; a skipped item is

--- a/.claude/skills/ponytail/LICENSE
+++ b/.claude/skills/ponytail/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DietrichGebert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/ponytail/SKILL.md
+++ b/.claude/skills/ponytail/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: ponytail
+description: >
+  Forces the laziest solution that actually works, simplest, shortest, most
+  minimal. Channels a senior dev who has seen everything: question whether the
+  task needs to exist at all (YAGNI), reach for the standard library before
+  custom code, native platform features before dependencies, one line before
+  fifty. Supports intensity levels: lite, full (default), ultra. Use on ANY
+  coding task: writing, adding, refactoring, fixing, reviewing, or designing
+  code, and choosing libraries or dependencies. Also use whenever the user
+  says "ponytail", "be lazy", "lazy mode", "simplest solution", "minimal
+  solution", "yagni", "do less", or "shortest path", or complains about
+  over-engineering, bloat, boilerplate, or unnecessary dependencies. Do NOT
+  use for non-coding requests (general knowledge, prose, translation,
+  summaries, recipes).
+argument-hint: "[lite|full|ultra]"
+license: MIT
+---
+
+# Ponytail
+
+You are a lazy senior developer. Lazy means efficient, not careless. You have
+seen every over-engineered codebase and been paged at 3am for one. The best
+code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
+unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
+Switch: `/ponytail lite|full|ultra`.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
+2. **Already in this codebase?** A helper, util, type, or pattern that already lives here → reuse it. Look before you write; re-implementing what's a few files over is the most common slop.
+3. **Stdlib does it?** Use it.
+4. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
+5. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
+6. **Can it be one line?** One line.
+7. **Only then:** the minimum code that works.
+
+The ladder is a reflex, not a research project — but it runs *after* you
+understand the problem, not instead of it. Read the task and the code it
+touches first, trace the real flow end to end, then climb. Two rungs work →
+take the higher one and move on. The first lazy solution that works is the
+right one — once you actually know what the change has to touch.
+
+**Bug fix = root cause, not symptom.** A report names a symptom. Before you
+edit, grep every caller of the function you're about to touch. The lazy fix IS
+the root-cause fix: one guard in the shared function is a smaller diff than a
+guard in every caller — and patching only the path the ticket names leaves
+every sibling caller still broken. Fix it once, where all callers route through.
+
+## Rules
+
+- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No boilerplate, no scaffolding "for later", later can scaffold for itself.
+- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
+- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
+- Mark deliberate simplifications with a `ponytail:` comment (`// ponytail: this exists`), simple reads as intent, not ignorance. Shortcut with a known ceiling (global lock, O(n²) scan, naive heuristic)? The comment names the ceiling and the upgrade path: `# ponytail: global lock, per-account locks if throughput matters`.
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it.
+No essays, no feature tours, no design notes. If the explanation is longer
+than the code, delete the explanation, every paragraph defending a
+simplification is complexity smuggled back in as prose. Explanation the user
+explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
+give it in full, the rule is only against unrequested prose.
+
+Pattern: `[code] → skipped: [X], add when [Y].`
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
+| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
+
+Example: "Add a cache for these API responses."
+- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
+- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
+- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
+
+## When NOT to be lazy
+
+Never simplify away: input validation at trust boundaries, error handling
+that prevents data loss, security measures, accessibility basics, anything
+explicitly requested. User insists on the full version → build it, no
+re-arguing.
+
+Never lazy about understanding the problem. The ladder shortens the
+solution, never the reading. Trace the whole thing first — every file the
+change touches, the actual flow — before picking a rung. Laziness that skips
+comprehension to ship a small diff is the dangerous kind: it dresses up as
+efficiency and ships a confident wrong fix. Read fully, then be lazy.
+
+Hardware is never the ideal on paper: a real clock drifts, a real sensor
+reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
+just less code, the physical world needs tuning a minimal model can't see.
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a
+loop, a parser, a money/security path) leaves ONE runnable check behind, the
+smallest thing that fails if the logic breaks: an `assert`-based
+`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
+fixtures, no per-function suites unless asked. Trivial one-liners need no
+test, YAGNI applies to tests too.
+
+## Boundaries
+
+Ponytail governs what you build, not how you talk (pair with Caveman for
+terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+changed or session end.
+
+The shortest path to done is the right path.

--- a/.claude/skills/ponytail/UPSTREAM
+++ b/.claude/skills/ponytail/UPSTREAM
@@ -1,0 +1,1 @@
+DietrichGebert/ponytail @ 1b2760d384c44e573a9d8c7a729fac616e5c3a76 (2026-07-07)

--- a/.claude/skills/ponytail/UPSTREAM
+++ b/.claude/skills/ponytail/UPSTREAM
@@ -1,1 +1,1 @@
-DietrichGebert/ponytail @ 1b2760d384c44e573a9d8c7a729fac616e5c3a76 (2026-07-07)
+DietrichGebert/ponytail @ bc9ee949d5f439e8b9f3bb92c6d6d3d1e6ebd324 (ref v4.8.4, 2026-07-07)

--- a/.claude/skills/ponytail/hooks/ponytail-activate.js
+++ b/.claude/skills/ponytail/hooks/ponytail-activate.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// ponytail — Claude Code SessionStart activation hook
+//
+// Runs on every session start:
+//   1. Writes flag file at $CLAUDE_CONFIG_DIR/.ponytail-active (defaults to ~/.claude; statusline reads this)
+//   2. Emits ponytail ruleset as hidden SessionStart context
+//   3. Detects missing statusline config and emits setup nudge
+
+const fs = require('fs');
+const path = require('path');
+const { getDefaultMode, getClaudeDir, isShellSafe } = require('./ponytail-config');
+const { getPonytailInstructions } = require('./ponytail-instructions');
+const {
+  clearMode,
+  isCodex,
+  isCopilot,
+  setMode,
+  writeHookOutput,
+} = require('./ponytail-runtime');
+
+const claudeDir = getClaudeDir();
+const settingsPath = path.join(claudeDir, 'settings.json');
+
+const mode = getDefaultMode();
+
+// "off" mode — skip activation entirely, don't write flag or emit rules
+if (mode === 'off') {
+  clearMode();
+  const hookOutput = (isCodex || isCopilot) ? '' : 'OK';
+  writeHookOutput('SessionStart', 'off', hookOutput);
+  process.exit(0);
+}
+
+// 1. Write flag file
+try {
+  setMode(mode);
+} catch (e) {
+  // Silent fail -- flag is best-effort, don't block the hook
+}
+
+// 2. Emit the ponytail ruleset, filtered to the active intensity level.
+let output = getPonytailInstructions(mode);
+
+// 3. Detect missing statusline config — nudge Claude to help set it up
+if (!isCodex && !isCopilot) try {
+  let hasStatusline = false;
+  if (fs.existsSync(settingsPath)) {
+    // Strip UTF-8 BOM some editors prepend on Windows (breaks JSON.parse)
+    const raw = fs.readFileSync(settingsPath, 'utf8').replace(/^\uFEFF/, '');
+    const settings = JSON.parse(raw);
+    if (settings.statusLine) {
+      hasStatusline = true;
+    }
+  }
+
+  if (!hasStatusline) {
+    const isWindows = process.platform === 'win32';
+    const scriptName = isWindows ? 'ponytail-statusline.ps1' : 'ponytail-statusline.sh';
+    const scriptPath = path.join(__dirname, scriptName);
+    if (isShellSafe(scriptPath)) {
+      const command = isWindows
+        ? `powershell -ExecutionPolicy Bypass -File "${scriptPath}"`
+        : `bash "${scriptPath}"`;
+      const statusLineSnippet =
+        '"statusLine": { "type": "command", "command": ' + JSON.stringify(command) + ' }';
+      output += "\n\n" +
+        "STATUSLINE SETUP NEEDED: The ponytail plugin includes a statusline badge showing active mode " +
+        "(e.g. [PONYTAIL], [PONYTAIL:ULTRA]). It is not configured yet. " +
+        "To enable, add this to ~/.claude/settings.json: " +
+        statusLineSnippet + " " +
+        "Proactively offer to set this up for the user on first interaction.";
+    } else {
+      // ponytail: install path has shell metacharacters — don't embed it in a
+      // command snippet; have the agent wire it up by hand instead.
+      output += "\n\n" +
+        "STATUSLINE SETUP NEEDED: The ponytail plugin includes a statusline badge showing active mode. " +
+        "Its install path contains characters unsafe to embed in a shell command, so configure it manually: " +
+        "add a statusLine command of type \"command\" that runs " + scriptName +
+        " from the plugin's hooks directory to ~/.claude/settings.json, quoting/escaping the path for your shell. " +
+        "Proactively offer to set this up for the user on first interaction.";
+    }
+  }
+} catch (e) {
+  // Silent fail — don't block session start over statusline detection
+}
+
+try {
+  writeHookOutput('SessionStart', mode, output);
+} catch (e) {
+  // Silent fail — stdout closed/EPIPE at hook exit must not surface as a hook failure
+}

--- a/.claude/skills/ponytail/hooks/ponytail-config.js
+++ b/.claude/skills/ponytail/hooks/ponytail-config.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// ponytail — shared configuration resolver
+//
+// Resolution order for default mode:
+//   1. PONYTAIL_DEFAULT_MODE environment variable
+//   2. Config file defaultMode field:
+//      - $XDG_CONFIG_HOME/ponytail/config.json (any platform, if set)
+//      - ~/.config/ponytail/config.json (macOS / Linux fallback)
+//      - %APPDATA%\ponytail\config.json (Windows fallback)
+//   3. 'full'
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const DEFAULT_MODE = 'full';
+const VALID_MODES = ['off', 'lite', 'full', 'ultra', 'review'];
+const RUNTIME_MODES = ['off', 'lite', 'full', 'ultra'];
+
+function normalizeMode(mode) {
+  if (typeof mode !== 'string') return null;
+  const normalized = mode.trim().toLowerCase();
+  return RUNTIME_MODES.includes(normalized) ? normalized : null;
+}
+
+function normalizeConfigMode(mode) {
+  if (typeof mode !== 'string') return null;
+  const normalized = mode.trim().toLowerCase();
+  return VALID_MODES.includes(normalized) ? normalized : null;
+}
+
+function normalizePersistedMode(mode) {
+  return normalizeMode(mode) || normalizeConfigMode(mode);
+}
+
+// "stop ponytail" / "normal mode" turn ponytail off, but only as a standalone
+// command. Matching the phrase anywhere in the message turned it off mid-task
+// for ordinary requests like "add a normal mode toggle" — so require the whole
+// message to be the command, ignoring case and trailing punctuation.
+function isDeactivationCommand(text) {
+  const t = String(text || '').trim().toLowerCase().replace(/[.!?\s]+$/, '');
+  return t === 'stop ponytail' || t === 'normal mode';
+}
+
+// ponytail: only embed the plugin install path in a statusline shell command when
+// it's made of ordinary path characters. An allowlist beats escaping every shell's
+// metacharacters; a hostile clone path (quotes, &, $, backtick, ;, etc.) falls back
+// to manual setup instead. Allows : \ / for normal Windows and POSIX paths. Full
+// per-shell escaper only if a real need appears.
+function isShellSafe(p) {
+  return typeof p === 'string' && /^[A-Za-z0-9 _.\-:/\\~]+$/.test(p);
+}
+
+function getConfigDir() {
+  if (process.env.XDG_CONFIG_HOME) {
+    return path.join(process.env.XDG_CONFIG_HOME, 'ponytail');
+  }
+  if (process.platform === 'win32') {
+    return path.join(
+      process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'),
+      'ponytail'
+    );
+  }
+  return path.join(os.homedir(), '.config', 'ponytail');
+}
+
+function getConfigPath() {
+  return path.join(getConfigDir(), 'config.json');
+}
+
+function getClaudeDir() {
+  // ponytail: CLAUDE_CONFIG_DIR overrides ~/.claude, matching Claude Code.
+  return process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+}
+
+function getDefaultMode() {
+  // 1. Environment variable (highest priority)
+  const envMode = process.env.PONYTAIL_DEFAULT_MODE;
+  if (envMode && VALID_MODES.includes(envMode.toLowerCase())) {
+    return envMode.toLowerCase();
+  }
+
+  // 2. Config file
+  try {
+    const configPath = getConfigPath();
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    if (config.defaultMode && VALID_MODES.includes(config.defaultMode.toLowerCase())) {
+      return config.defaultMode.toLowerCase();
+    }
+  } catch (e) {
+    // Config file doesn't exist or is invalid — fall through
+  }
+
+  // 3. Default
+  return DEFAULT_MODE;
+}
+
+function writeDefaultMode(mode) {
+  const normalized = normalizeConfigMode(mode);
+  if (!normalized) return null;
+
+  const configPath = getConfigPath();
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify({ defaultMode: normalized }, null, 2), 'utf8');
+  return normalized;
+}
+
+module.exports = {
+  DEFAULT_MODE,
+  VALID_MODES,
+  RUNTIME_MODES,
+  getDefaultMode,
+  getConfigDir,
+  getConfigPath,
+  getClaudeDir,
+  isShellSafe,
+  normalizeMode,
+  normalizeConfigMode,
+  normalizePersistedMode,
+  isDeactivationCommand,
+  writeDefaultMode,
+};

--- a/.claude/skills/ponytail/hooks/ponytail-instructions.js
+++ b/.claude/skills/ponytail/hooks/ponytail-instructions.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Shared Ponytail instruction builder for Claude hooks and Pi extension.
+
+const fs = require('fs');
+const path = require('path');
+const { DEFAULT_MODE, normalizeMode, normalizePersistedMode } = require('./ponytail-config');
+
+const INDEPENDENT_MODES = new Set(['review']);
+const SKILL_PATH = path.join(__dirname, '..', 'skills', 'ponytail', 'SKILL.md');
+
+function filterSkillBodyForMode(body, mode) {
+  const effectiveMode = normalizeMode(mode) || DEFAULT_MODE;
+  const withoutFrontmatter = String(body || '').replace(/^---[\s\S]*?---\s*/, '');
+
+  // Only the intensity table rows and worked examples are mode-specific, and
+  // both are keyed by a mode name (lite/full/ultra). A bullet whose label is
+  // not a mode — e.g. "No unrequested abstractions: ..." — is a normal rule
+  // and must be kept verbatim.
+  return withoutFrontmatter
+    .split(/\r?\n/)
+    .filter((line) => {
+      const tableLabel = line.match(/^\|\s*\*\*(.+?)\*\*\s*\|/);
+      if (tableLabel) {
+        const labelMode = normalizeMode(tableLabel[1].trim());
+        if (labelMode) return labelMode === effectiveMode;
+      }
+
+      const exampleLabel = line.match(/^-\s*([^:]+):\s*/);
+      if (exampleLabel) {
+        const labelMode = normalizeMode(exampleLabel[1].trim());
+        if (labelMode) return labelMode === effectiveMode;
+      }
+
+      return true;
+    })
+    .join('\n');
+}
+
+function getFallbackInstructions(mode) {
+  return 'PONYTAIL MODE ACTIVE — level: ' + mode + '\n\n' +
+    'You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.\n\n' +
+    '## Persistence\n\n' +
+    'ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if unsure. Off only: "stop ponytail" / "normal mode".\n\n' +
+    'Current level: **' + mode + '**. Switch: `/ponytail lite|full|ultra`.\n\n' +
+    '## The ladder\n\n' +
+    'Before any code, stop at the first rung that holds (the ladder runs after you understand the problem, not instead of it — read the code it touches and trace the real flow first):\n' +
+    '1. Does this need to be built at all? (YAGNI)\n' +
+    '2. Does it already exist in this codebase? Reuse what is already here, do not re-write it.\n' +
+    '3. Does the standard library do this? Use it.\n' +
+    '4. Does a native platform feature cover it? Use it.\n' +
+    '5. Does an already-installed dependency solve it? Use it.\n' +
+    '6. Can this be one line? Make it one line.\n' +
+    '7. Only then: write the minimum code that works.\n\n' +
+    'Bug fix = root cause, not symptom: grep every caller of the function you touch and fix the shared function once (a smaller diff than one guard per caller); patching only the path the ticket names leaves a sibling caller broken.\n\n' +
+    '## Rules\n\n' +
+    'No abstractions that were not requested. No avoidable dependencies. No boilerplate nobody asked for. ' +
+    'Deletion over addition. Boring over clever. Fewest files possible. ' +
+    'Ship the lazy version and question the complex request in the same response — never stall. ' +
+    'Between two same-size stdlib options, pick the one correct on edge cases. ' +
+    'Mark intentional simplifications with a `ponytail:` comment — a shortcut with a known ceiling names the ceiling and the upgrade path in the comment.\n\n' +
+    '## Output\n\n' +
+    'Code first. Then at most three short lines: what was skipped, when to add it. ' +
+    'If the explanation is longer than the code, delete the explanation. ' +
+    'Explanation the user explicitly asked for is not debt, give it in full.\n\n' +
+    '## When NOT to be lazy\n\n' +
+    'Never simplify away: understanding the problem (read it fully and trace the real flow before picking a rung — a small diff you do not understand is just laziness dressed up as efficiency), input validation at trust boundaries, error handling that prevents data loss, ' +
+    'security measures, accessibility basics, the calibration real hardware needs (the platform is never the spec ideal), anything the user explicitly asked to keep. ' +
+    'Lazy code without its check is unfinished: non-trivial logic leaves ONE runnable check behind (assert-based demo/self-check or one small test file; no frameworks). Trivial one-liners need no test.\n\n' +
+    '## Boundaries\n\n' +
+    'Ponytail governs what you build, not how you talk. "stop ponytail" or "normal mode": revert. Level persists until changed or session end.';
+}
+
+function getPonytailInstructions(mode) {
+  const configuredMode = normalizePersistedMode(mode) || DEFAULT_MODE;
+
+  if (INDEPENDENT_MODES.has(configuredMode)) {
+    return 'PONYTAIL MODE ACTIVE — level: ' + configuredMode + '. Behavior defined by /ponytail-' + configuredMode + ' skill.';
+  }
+
+  const effectiveMode = normalizeMode(configuredMode) || DEFAULT_MODE;
+
+  try {
+    return 'PONYTAIL MODE ACTIVE — level: ' + effectiveMode + '\n\n' +
+      filterSkillBodyForMode(fs.readFileSync(SKILL_PATH, 'utf8'), effectiveMode);
+  } catch (e) {
+    return getFallbackInstructions(effectiveMode);
+  }
+}
+
+module.exports = {
+  filterSkillBodyForMode,
+  getFallbackInstructions,
+  getPonytailInstructions,
+};

--- a/.claude/skills/ponytail/hooks/ponytail-mode-tracker.js
+++ b/.claude/skills/ponytail/hooks/ponytail-mode-tracker.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// ponytail — UserPromptSubmit hook to track which ponytail mode is active
+// Inspects user input for /ponytail commands and writes mode to flag file
+
+const { getDefaultMode, isDeactivationCommand } = require('./ponytail-config');
+const { clearMode, setMode, writeHookOutput } = require('./ponytail-runtime');
+
+let input = '';
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', () => {
+  try {
+    // Strip UTF-8 BOM some shells prepend when piping (breaks JSON.parse)
+    const data = JSON.parse(input.replace(/^\uFEFF/, ''));
+    const prompt = (data.prompt || '').trim().toLowerCase();
+
+    // Match /ponytail commands
+    if (/^[/@$]ponytail/.test(prompt)) {
+      const parts = prompt.split(/\s+/);
+      const cmd = parts[0].replace(/^[@$]/, '/');
+      const arg = parts[1] || '';
+
+      let mode = null;
+
+      if (cmd === '/ponytail-review' || cmd === '/ponytail:ponytail-review') {
+        mode = 'review';
+      } else if (cmd === '/ponytail' || cmd === '/ponytail:ponytail') {
+        if (arg === 'lite') mode = 'lite';
+        else if (arg === 'full') mode = 'full';
+        else if (arg === 'ultra') mode = 'ultra';
+        else if (arg === 'off') mode = 'off';
+        else mode = getDefaultMode();
+      }
+
+      if (mode && mode !== 'off') {
+        setMode(mode);
+        writeHookOutput(
+          'UserPromptSubmit',
+          mode,
+          'PONYTAIL MODE CHANGED — level: ' + mode,
+        );
+      } else if (mode === 'off') {
+        clearMode();
+        writeHookOutput('UserPromptSubmit', 'off', 'PONYTAIL MODE OFF');
+      }
+    }
+
+    // Detect deactivation
+    if (isDeactivationCommand(prompt)) {
+      clearMode();
+      writeHookOutput('UserPromptSubmit', 'off', 'PONYTAIL MODE OFF');
+    }
+  } catch (e) {
+    // Silent fail
+  }
+});

--- a/.claude/skills/ponytail/hooks/ponytail-runtime.js
+++ b/.claude/skills/ponytail/hooks/ponytail-runtime.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+const { getClaudeDir } = require('./ponytail-config');
+
+const STATE_FILE = '.ponytail-active';
+const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
+const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
+
+let stateDir = getClaudeDir();
+if (isCodex) stateDir = process.env.PLUGIN_DATA;
+if (isCopilot) stateDir = process.env.COPILOT_PLUGIN_DATA;
+
+const statePath = path.join(stateDir, STATE_FILE);
+
+function setMode(mode) {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, mode);
+}
+
+function clearMode() {
+  try { fs.unlinkSync(statePath); } catch (e) {}
+}
+
+// Live mode written by activate/mode-tracker. Absent flag = ponytail off.
+function readMode() {
+  try {
+    return fs.readFileSync(statePath, 'utf8').trim() || null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function writeHookOutput(event, mode, context = '') {
+  if (isCopilot) {
+    // Copilot reads additionalContext on SessionStart; ignores output elsewhere.
+    process.stdout.write(JSON.stringify(
+      event === 'SessionStart' && context ? { additionalContext: context } : {}));
+    return;
+  }
+  if (isCodex) {
+    const output = { systemMessage: `PONYTAIL:${mode.toUpperCase()}` };
+    if (context) {
+      output.hookSpecificOutput = {
+        hookEventName: event,
+        additionalContext: context,
+      };
+    }
+    process.stdout.write(JSON.stringify(output));
+    return;
+  }
+  // Native Claude: SessionStart accepts raw stdout, but SubagentStart needs the
+  // hookSpecificOutput JSON form or the context is dropped.
+  if (event === 'SubagentStart') {
+    process.stdout.write(JSON.stringify(
+      { hookSpecificOutput: { hookEventName: event, additionalContext: context } }));
+    return;
+  }
+  process.stdout.write(context);
+}
+
+module.exports = {
+  clearMode,
+  isCodex,
+  isCopilot,
+  readMode,
+  setMode,
+  writeHookOutput,
+};

--- a/.claude/skills/ponytail/hooks/ponytail-statusline.ps1
+++ b/.claude/skills/ponytail/hooks/ponytail-statusline.ps1
@@ -1,0 +1,21 @@
+# CLAUDE_CONFIG_DIR overrides ~/.claude, matching where the hooks write the flag (issue #34)
+$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
+$Flag = Join-Path $ClaudeDir ".ponytail-active"
+if (-not (Test-Path $Flag)) {
+    exit 0
+}
+
+$Mode = ""
+try {
+    $Mode = (Get-Content $Flag -ErrorAction Stop | Select-Object -First 1).Trim()
+} catch {
+    exit 0
+}
+
+$Esc = [char]27
+if ([string]::IsNullOrEmpty($Mode) -or $Mode -eq "full") {
+    [Console]::Write("${Esc}[38;5;108m[PONYTAIL]${Esc}[0m")
+} else {
+    $Suffix = $Mode.ToUpperInvariant()
+    [Console]::Write("${Esc}[38;5;108m[PONYTAIL:$Suffix]${Esc}[0m")
+}

--- a/.claude/skills/ponytail/hooks/ponytail-statusline.sh
+++ b/.claude/skills/ponytail/hooks/ponytail-statusline.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# CLAUDE_CONFIG_DIR overrides ~/.claude, matching where the hooks write the flag (issue #34)
+flag="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.ponytail-active"
+[ -f "$flag" ] || exit 0
+
+mode=$(head -n1 "$flag" | tr -d '[:space:]')
+
+if [ -z "$mode" ] || [ "$mode" = "full" ]; then
+    printf '\033[38;5;108m[PONYTAIL]\033[0m'
+else
+    printf '\033[38;5;108m[PONYTAIL:%s]\033[0m' "$(printf '%s' "$mode" | tr '[:lower:]' '[:upper:]')"
+fi

--- a/.claude/skills/ponytail/hooks/ponytail-subagent.js
+++ b/.claude/skills/ponytail/hooks/ponytail-subagent.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// ponytail — Claude Code SubagentStart hook
+//
+// SessionStart context is parent-thread only and never reaches subagents, so
+// without this every Task-spawned agent runs ponytail-unaware (issue #252).
+// When ponytail mode is active, inject the same ruleset into each subagent.
+
+const { getPonytailInstructions } = require('./ponytail-instructions');
+const { readMode, writeHookOutput } = require('./ponytail-runtime');
+
+const mode = readMode();
+
+// Absent flag or off → ponytail isn't active; inject nothing.
+if (!mode || mode === 'off') {
+  process.exit(0);
+}
+
+try {
+  writeHookOutput('SubagentStart', mode, getPonytailInstructions(mode));
+} catch (e) {
+  // Silent fail — a stdout error at hook exit must not surface as a hook failure.
+}

--- a/.claude/skills/ponytail/skills/ponytail/SKILL.md
+++ b/.claude/skills/ponytail/skills/ponytail/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: ponytail
+description: >
+  Forces the laziest solution that actually works, simplest, shortest, most
+  minimal. Channels a senior dev who has seen everything: question whether the
+  task needs to exist at all (YAGNI), reach for the standard library before
+  custom code, native platform features before dependencies, one line before
+  fifty. Supports intensity levels: lite, full (default), ultra. Use on ANY
+  coding task: writing, adding, refactoring, fixing, reviewing, or designing
+  code, and choosing libraries or dependencies. Also use whenever the user
+  says "ponytail", "be lazy", "lazy mode", "simplest solution", "minimal
+  solution", "yagni", "do less", or "shortest path", or complains about
+  over-engineering, bloat, boilerplate, or unnecessary dependencies. Do NOT
+  use for non-coding requests (general knowledge, prose, translation,
+  summaries, recipes).
+argument-hint: "[lite|full|ultra]"
+license: MIT
+---
+
+# Ponytail
+
+You are a lazy senior developer. Lazy means efficient, not careless. You have
+seen every over-engineered codebase and been paged at 3am for one. The best
+code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
+unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
+Switch: `/ponytail lite|full|ultra`.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
+2. **Already in this codebase?** A helper, util, type, or pattern that already lives here → reuse it. Look before you write; re-implementing what's a few files over is the most common slop.
+3. **Stdlib does it?** Use it.
+4. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
+5. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
+6. **Can it be one line?** One line.
+7. **Only then:** the minimum code that works.
+
+The ladder is a reflex, not a research project — but it runs *after* you
+understand the problem, not instead of it. Read the task and the code it
+touches first, trace the real flow end to end, then climb. Two rungs work →
+take the higher one and move on. The first lazy solution that works is the
+right one — once you actually know what the change has to touch.
+
+**Bug fix = root cause, not symptom.** A report names a symptom. Before you
+edit, grep every caller of the function you're about to touch. The lazy fix IS
+the root-cause fix: one guard in the shared function is a smaller diff than a
+guard in every caller — and patching only the path the ticket names leaves
+every sibling caller still broken. Fix it once, where all callers route through.
+
+## Rules
+
+- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No boilerplate, no scaffolding "for later", later can scaffold for itself.
+- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
+- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
+- Mark deliberate simplifications with a `ponytail:` comment (`// ponytail: this exists`), simple reads as intent, not ignorance. Shortcut with a known ceiling (global lock, O(n²) scan, naive heuristic)? The comment names the ceiling and the upgrade path: `# ponytail: global lock, per-account locks if throughput matters`.
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it.
+No essays, no feature tours, no design notes. If the explanation is longer
+than the code, delete the explanation, every paragraph defending a
+simplification is complexity smuggled back in as prose. Explanation the user
+explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
+give it in full, the rule is only against unrequested prose.
+
+Pattern: `[code] → skipped: [X], add when [Y].`
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
+| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
+
+Example: "Add a cache for these API responses."
+- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
+- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
+- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
+
+## When NOT to be lazy
+
+Never simplify away: input validation at trust boundaries, error handling
+that prevents data loss, security measures, accessibility basics, anything
+explicitly requested. User insists on the full version → build it, no
+re-arguing.
+
+Never lazy about understanding the problem. The ladder shortens the
+solution, never the reading. Trace the whole thing first — every file the
+change touches, the actual flow — before picking a rung. Laziness that skips
+comprehension to ship a small diff is the dangerous kind: it dresses up as
+efficiency and ships a confident wrong fix. Read fully, then be lazy.
+
+Hardware is never the ideal on paper: a real clock drifts, a real sensor
+reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
+just less code, the physical world needs tuning a minimal model can't see.
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a
+loop, a parser, a money/security path) leaves ONE runnable check behind, the
+smallest thing that fails if the logic breaks: an `assert`-based
+`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
+fixtures, no per-function suites unless asked. Trivial one-liners need no
+test, YAGNI applies to tests too.
+
+## Boundaries
+
+Ponytail governs what you build, not how you talk (pair with Caveman for
+terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+changed or session end.
+
+The shortest path to done is the right path.

--- a/.claude/skills/pr-merge-flow/SKILL.md
+++ b/.claude/skills/pr-merge-flow/SKILL.md
@@ -194,7 +194,10 @@ it, and it does not replace CodeRabbit; when CodeRabbit never reviews it stands 
    env-derived literals (versions, ABIs, paths, column indexes) that the spec or matrix
    says must be enumerated or resolved at runtime; **`www/` touched → Tier-A UI test
    present, else a `blocking` finding** (test mandate #4); **stale comments/docs** about
-   touched symbols. The reviewer **executes, not just reads**: it MAY run the gates and
+   touched symbols. The VENDORED plugin trees (`.claude/skills/ponytail/`,
+   `.claude/skills/caveman/` — byte-identical upstream copies, see their UPSTREAM files) are
+   OUT of review scope: only byte-identity with the pinned ref and the provenance itself are
+   reviewable; never their content/style. The reviewer **executes, not just reads**: it MAY run the gates and
    MUST ground each `blocking` correctness claim in an executed probe (command + output —
    the "Empirically verified:" standard) wherever the claim is executable off-appliance.
    Each finding: severity (`blocking` / `nitpick` / `outside-diff`), `file:line`, the

--- a/.claude/skills/pr-merge-flow/SKILL.md
+++ b/.claude/skills/pr-merge-flow/SKILL.md
@@ -195,9 +195,9 @@ it, and it does not replace CodeRabbit; when CodeRabbit never reviews it stands 
    says must be enumerated or resolved at runtime; **`www/` touched → Tier-A UI test
    present, else a `blocking` finding** (test mandate #4); **stale comments/docs** about
    touched symbols. The VENDORED plugin trees (`.claude/skills/ponytail/`,
-   `.claude/skills/caveman/` — byte-identical upstream copies, see their UPSTREAM files) are
-   OUT of review scope: only byte-identity with the pinned ref and the provenance itself are
-   reviewable; never their content/style. The reviewer **executes, not just reads**: it MAY run the gates and
+   `.claude/skills/caveman/`) are OUT of review scope — byte-identical upstream copies (see
+   their UPSTREAM files); only byte-identity with the pinned ref and the provenance itself
+   are reviewable, never their content or style. The reviewer **executes, not just reads**: it MAY run the gates and
    MUST ground each `blocking` correctness claim in an executed probe (command + output —
    the "Empirically verified:" standard) wherever the claim is executable off-appliance.
    Each finding: severity (`blocking` / `nitpick` / `outside-diff`), `file:line`, the

--- a/.claude/workflows/review-fanout.js
+++ b/.claude/workflows/review-fanout.js
@@ -55,7 +55,7 @@ const VERDICT = {
   },
 }
 
-const COMMON = `You are an independent ADVERSARIAL reviewer of PR #${pr} (base ${base}) in a READ-ONLY checkout at ${worktree}. Diff: git -C ${worktree} diff origin/${base}...HEAD. Read surrounding code, not just hunks; you may run commands/gates but never edit, commit, or push. Ground every blocking correctness claim in an EXECUTED probe (command + output) where executable off-appliance — create scratch fixtures under /tmp, never inside the checkout. Return structured findings; your output is the review. THE SPEC (review the diff AGAINST this; silently narrowed scope is a blocking finding): ${spec}`
+const COMMON = `You are an independent ADVERSARIAL reviewer of PR #${pr} (base ${base}) in a READ-ONLY checkout at ${worktree}. Diff: git -C ${worktree} diff origin/${base}...HEAD. Read surrounding code, not just hunks; you may run commands/gates but never edit, commit, or push. Ground every blocking correctness claim in an EXECUTED probe (command + output) where executable off-appliance — create scratch fixtures under /tmp, never inside the checkout. Files under .claude/skills/ponytail/ and .claude/skills/caveman/ are VENDORED byte-identical third-party trees (see their UPSTREAM provenance files) — do NOT review their content or style; only byte-identity with the pinned upstream ref and the UPSTREAM provenance are reviewable. Return structured findings; your output is the review. THE SPEC (review the diff AGAINST this; silently narrowed scope is a blocking finding): ${spec}`
 
 phase('Find')
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+# CodeRabbit configuration.
+#
+# The vendored third-party plugin trees are excluded from review entirely:
+# they are byte-identical upstream copies (each dir carries an UPSTREAM
+# provenance file naming the exact upstream commit), refreshed wholesale by
+# scripts/update-vendored-skills.py — style/content findings on them are not
+# actionable here (fixes belong upstream) and local edits would drift.
+reviews:
+  path_filters:
+    - "!.claude/skills/ponytail/**"
+    - "!.claude/skills/caveman/**"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Vendored third-party plugin trees (byte-identical upstream copies; see each
+# dir's UPSTREAM provenance file). linguist-vendored keeps them out of language
+# stats and collapses their diffs in GitHub review views.
+.claude/skills/ponytail/** linguist-vendored
+.claude/skills/caveman/** linguist-vendored

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -116,7 +116,9 @@ if [ "$staged_sh" = 1 ]; then
 	# has no /bin/bash, and macOS /bin/bash is the ancient 3.2). Scans ALL tracked
 	# files, so it also covers tests/ (not lint-globbed below).
 	step 'shebang policy (no #!bash)'
-	git ls-files | while IFS= read -r f; do
+	# Vendored third-party plugin trees are exempt (upstream content, refreshed
+	# wholesale by scripts/update-vendored-skills.py; never runs on the box).
+	git ls-files | grep -v -e '^\.claude/skills/ponytail/' -e '^\.claude/skills/caveman/' | while IFS= read -r f; do
 		case $(head -n1 "$f" 2>/dev/null) in
 		'#!'*bash*)
 			printf '[pre-commit] bash shebang not allowed (use #!/bin/sh): %s\n' "$f" >&2
@@ -125,9 +127,9 @@ if [ "$staged_sh" = 1 ]; then
 		esac
 	done || failed 'shebang policy'
 
-	# sh -n parse gate (src + scripts + tests; cheap, tool-free).
+	# sh -n parse gate (src + scripts + tests + .claude/hooks; cheap, tool-free).
 	step 'shell (sh -n)'
-	find src scripts tests -name '*.sh' | sort | while IFS= read -r f; do
+	find src scripts tests .claude/hooks -name '*.sh' | sort | while IFS= read -r f; do
 		sh -n "$f" || exit 1
 	done || failed 'sh -n'
 
@@ -135,7 +137,7 @@ if [ "$staged_sh" = 1 ]; then
 	# false-positives — tracked as a separate cleanup).
 	if have shellcheck; then
 		step 'shellcheck'
-		find src scripts -name '*.sh' | sort \
+		find src scripts .claude/hooks -name '*.sh' | sort \
 			| xargs shellcheck --severity=info || failed 'shellcheck'
 	else
 		skip shellcheck

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+# Copilot review instructions — pfBlockerNG
+
+- Do **not** review anything under `.claude/skills/ponytail/` or
+  `.claude/skills/caveman/`. These are vendored third-party plugin trees,
+  copied **byte-identical** from their MIT upstreams (each directory carries
+  an `UPSTREAM` provenance file naming the exact upstream commit) and
+  refreshed wholesale by `scripts/update-vendored-skills.py`. Style, wording,
+  or lint findings on them are not actionable in this repository — fixes
+  belong upstream, and local edits would silently drift until the next
+  refresh reverts them. The only reviewable properties are byte-identity with
+  the pinned upstream ref and the `UPSTREAM` provenance itself.
+- Everything else follows `CLAUDE.md` (code standards, test-coverage
+  mandate, commit style).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ on:
       - '**/*.md'
       - '*.md'
       - 'docs/**'
+      # Vendored third-party plugin trees (refreshed wholesale by
+      # scripts/update-vendored-skills.py; nothing in CI consumes them).
+      - '.claude/skills/ponytail/**'
+      - '.claude/skills/caveman/**'
   pull_request:
     # labeled/unlabeled so adding or removing the `ui-tests` label re-evaluates the
     # (label-gated) UI suite gate; synchronize re-runs it on new pushes while labeled.
@@ -33,6 +37,10 @@ on:
       - '**/*.md'
       - '*.md'
       - 'docs/**'
+      # Vendored third-party plugin trees (refreshed wholesale by
+      # scripts/update-vendored-skills.py; nothing in CI consumes them).
+      - '.claude/skills/ponytail/**'
+      - '.claude/skills/caveman/**'
   # Manual trigger to opt INTO the benchmark kill-gates (issue #76). They are OFF in
   # the automated push/PR flow: a synthetic corpus on a generic runner is not the
   # number that matters — the production-faithful build-time/RAM measurement belongs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,8 +205,10 @@ jobs:
       - name: Forbid bash shebangs
         # Repo is #!/bin/sh POSIX (no /bin/bash on FreeBSD/pfSense; macOS /bin/bash is
         # the ancient 3.2). Scans ALL tracked files, so it also covers tests/.
+        # Vendored third-party plugin trees are exempt (upstream content, never
+        # runs on the box; same fence as .githooks/pre-commit).
         run: |
-          bad=$(git ls-files | while IFS= read -r f; do
+          bad=$(git ls-files | grep -v -e '^\.claude/skills/ponytail/' -e '^\.claude/skills/caveman/' | while IFS= read -r f; do
             case $(head -n1 "$f" 2>/dev/null) in '#!'*bash*) echo "$f" ;; esac
           done)
           if [ -n "$bad" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,15 @@ on:
       - '**/*.md'
       - '*.md'
       - 'docs/**'
-      # Vendored third-party plugin trees (refreshed wholesale by
-      # scripts/update-vendored-skills.py; nothing in CI consumes them).
-      - '.claude/skills/ponytail/**'
-      - '.claude/skills/caveman/**'
+      # Vendored plugin trees: only the INERT files skip CI. The vendored
+      # hook scripts (hooks/*.js, src/hooks/*.js) are EXECUTED at runtime by
+      # .claude/hooks/vendored-plugin-hook.sh and integration-tested by
+      # pytest, so a refresh touching them must run the suite (the top
+      # '**/*.md' pattern already covers the vendored markdown).
+      - '.claude/skills/ponytail/LICENSE'
+      - '.claude/skills/ponytail/UPSTREAM'
+      - '.claude/skills/caveman/LICENSE'
+      - '.claude/skills/caveman/UPSTREAM'
   pull_request:
     # labeled/unlabeled so adding or removing the `ui-tests` label re-evaluates the
     # (label-gated) UI suite gate; synchronize re-runs it on new pushes while labeled.
@@ -37,10 +42,15 @@ on:
       - '**/*.md'
       - '*.md'
       - 'docs/**'
-      # Vendored third-party plugin trees (refreshed wholesale by
-      # scripts/update-vendored-skills.py; nothing in CI consumes them).
-      - '.claude/skills/ponytail/**'
-      - '.claude/skills/caveman/**'
+      # Vendored plugin trees: only the INERT files skip CI. The vendored
+      # hook scripts (hooks/*.js, src/hooks/*.js) are EXECUTED at runtime by
+      # .claude/hooks/vendored-plugin-hook.sh and integration-tested by
+      # pytest, so a refresh touching them must run the suite (the top
+      # '**/*.md' pattern already covers the vendored markdown).
+      - '.claude/skills/ponytail/LICENSE'
+      - '.claude/skills/ponytail/UPSTREAM'
+      - '.claude/skills/caveman/LICENSE'
+      - '.claude/skills/caveman/UPSTREAM'
   # Manual trigger to opt INTO the benchmark kill-gates (issue #76). They are OFF in
   # the automated push/PR flow: a synthetic corpus on a generic runner is not the
   # number that matters — the production-faithful build-time/RAM measurement belongs
@@ -214,7 +224,7 @@ jobs:
         # tests/ shellspec specs trip SC2034 false-positives (separate cleanup).
         # --severity=info also gates the unquoted-variable class (SC2086) so the
         # quoting / word-splitting bugs the shell audit found cannot silently regress.
-        run: find src scripts -name '*.sh' | sort | xargs shellcheck --severity=info
+        run: find src scripts .claude/hooks -name '*.sh' | sort | xargs shellcheck --severity=info
 
       - name: Forbid naked $var in curl/wget/fetch URLs
         # Preventative: a query value jammed straight into a URL (`?ip=$VAR`) breaks

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -14,6 +14,12 @@
     // Verbatim conversation transcript (a historical record, not maintained
     // documentation): its repeated "User"/"Assistant" headings and multiple
     // H1s are inherent to the format, so it is not linted.
-    "**/TRANSCRIPT.md"
+    "**/TRANSCRIPT.md",
+    // Vendored third-party plugin skills (upstream MIT content, copied
+    // byte-identical so managed/cloud sessions can load the modes without
+    // plugin machinery): not ours to lint — fixing them here would drift
+    // from upstream.
+    ".claude/skills/ponytail/**",
+    ".claude/skills/caveman/**"
   ]
 }

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -2,7 +2,8 @@
   // markdownlint-cli2 runner config (globs + ignores). Rule set lives in
   // `.markdownlint.jsonc`. Run from the repo root: `npx markdownlint-cli2`
   // (add `--fix` to auto-fix). Lints every tracked Markdown file, including
-  // .ADRs/ and .claude/skills/; skips dependency/virtualenv trees.
+  // .ADRs/ and the repo's own .claude/skills/; skips dependency/virtualenv
+  // trees and the VENDORED plugin skill trees listed below.
   "globs": ["**/*.md"],
   "ignores": [
     "node_modules",

--- a/.snyk
+++ b/.snyk
@@ -8,3 +8,7 @@ exclude:
     - build/**
     - ci/**
     - .github/**
+    # Vendored third-party plugin trees (byte-identical upstream copies,
+    # refreshed by scripts/update-vendored-skills.py; see UPSTREAM files).
+    - .claude/skills/ponytail/**
+    - .claude/skills/caveman/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,11 +101,10 @@ non-trivial, multi-step `src/`/`tests/`/CI work.
 - **The planner's brief to Sonnet 5 follows the delegation contract below** — a vague or wrong
   brief is a planner bug, and a handful of real shipped defects trace directly to brief bugs
   (a half-enumerated axis, a vacuous test spec, an unverified "fact" stated as truth).
-- **Propagate an active ponytail level to every delegate.** If `ponytail` is active in the
-  orchestrator's session, every spawned sub-agent MUST run at the **same level** — make the
-  **first** line of its brief `Run /ponytail:ponytail <level>`. **Sole exception —
-  reviewer/verifier agents:** ponytail governs what you *build*; a reviewer builds nothing, so
-  do not propagate it to review/verify delegates.
+- **Mode propagation to delegates is mechanical** — the `SubagentStart` hook
+  (`.claude/settings.json`) injects the ponytail + caveman capsule into every spawned
+  sub-agent; the capsule itself carries the rules (reviewer carve-out; "terse prose,
+  verbatim evidence"). Briefs add a mode line only for a non-default level (e.g. `ultra`).
 - **Sonnet 5 follows every directive in this file.** The implementer is cheaper, not exempt.
 - **Run at effort xhigh or better** — the session default in `.claude/settings.json`
   (`effortLevel: xhigh`), and stated explicitly in every spawn (never rely on inheritance).

--- a/scripts/update-vendored-skills.py
+++ b/scripts/update-vendored-skills.py
@@ -7,15 +7,23 @@ skills this repo relies on (ponytail, caveman) are vendored byte-identical
 into committed .claude/skills/, which cloud sessions do load. This script
 automates the refresh so the vendored copies can track their upstreams:
 
-  python3 scripts/update-vendored-skills.py          # refresh all
-  git diff                                           # inspect, then commit
+  python3 scripts/update-vendored-skills.py                 # latest RELEASES
+  python3 scripts/update-vendored-skills.py --ref ponytail=v4.8.3
+  git diff                                                  # inspect, then commit
 
 For each plugin that is BOTH enabled in .claude/settings.json's
 `enabledPlugins` AND declared in its `extraKnownMarketplaces` with a GitHub
-source, it shallow-clones the upstream repo, copies `skills/<plugin>/`
-(the plugin's core mode skill) plus the repo-root LICENSE into
-`.claude/skills/<plugin>/`, and writes an UPSTREAM provenance line
-(repo @ commit sha, clone date) so drift stays visible.
+source, it fetches the upstream repo at one ref -- `--ref PLUGIN=REF` (a tag,
+branch, or commit sha), defaulting to the tag of the upstream's LATEST GitHub
+RELEASE -- and copies:
+
+  - `skills/<plugin>/` (the plugin's core mode skill) -> `.claude/skills/<plugin>/`
+  - the repo-root LICENSE
+  - the plugin's hook scripts (EXTRA_VENDOR_GLOBS below, upstream-relative
+    paths preserved) so `.claude/hooks/vendored-plugin-hook.sh` can run them
+    with CLAUDE_PLUGIN_ROOT pointed at the vendored root
+  - an UPSTREAM provenance line (repo @ commit sha, ref, date) so drift stays
+    visible
 
 Deliberately NOT run in managed environments -- it needs network + git and
 its output is committed; cloud sessions just consume the committed copies.
@@ -28,10 +36,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import re
 import shutil
 import subprocess
 import sys
 import tempfile
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -39,9 +51,31 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SETTINGS_FILE = REPO_ROOT / ".claude/settings.json"
 SKILLS_DIR = REPO_ROOT / ".claude/skills"
 
-# ponytail: default clone base swapped only by tests (file:// fixtures) or a
-# GitHub Enterprise mirror; not a user-facing knob.
-DEFAULT_CLONE_BASE = "https://github.com/"
+GITHUB_RELEASE_API = "https://api.github.com/repos/{repo}/releases/latest"
+
+# The plugin name becomes a path segment under --skills-dir (and the rmtree
+# target of a refresh), so it must be a plain single-segment name -- an empty
+# segment ('@bogus' typo) would resolve to the skills dir itself and a '../'
+# name would escape it (#931 review).
+_PLUGIN_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+
+# Per-plugin upstream paths vendored IN ADDITION to skills/<plugin>/ + LICENSE,
+# copied with their upstream-relative paths preserved under the vendored root
+# (matching each plugin's own ${CLAUDE_PLUGIN_ROOT}-relative hook manifest).
+EXTRA_VENDOR_GLOBS: dict[str, tuple[str, ...]] = {
+    "ponytail": ("hooks/*.js",),
+    "caveman": ("src/hooks/*.js",),
+}
+
+
+def _git_env() -> dict[str, str]:
+    """os.environ minus every GIT_* var.
+
+    Under a git hook, exported GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE would point
+    this script's `git fetch`/`git rev-parse` at the WRONG repository (#931
+    review); scrub them so the temp clone is the sole git context.
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
 
 
 def enabled_github_plugins(settings: dict) -> dict[str, str]:
@@ -49,14 +83,21 @@ def enabled_github_plugins(settings: dict) -> dict[str, str]:
 
     `enabledPlugins` keys are `plugin@marketplace`; only marketplaces with a
     GitHub source are vendorable (a `directory` source has no canonical
-    upstream to refresh from -- skipped with a notice, not an error).
+    upstream to refresh from). Every skipped key is reported -- a silent skip
+    reads as "vendored" when it wasn't (#931 review).
     """
     marketplaces = settings.get("extraKnownMarketplaces", {})
     plugins: dict[str, str] = {}
     for key, enabled in settings.get("enabledPlugins", {}).items():
-        if not enabled or "@" not in key:
+        if "@" not in key:
+            print(f"SKIP {key!r}: not a plugin@marketplace key")
             continue
         plugin, marketplace = key.split("@", 1)
+        if not enabled:
+            print(f"SKIP {plugin}: disabled")
+            continue
+        if not _PLUGIN_NAME_RE.match(plugin):
+            raise ValueError(f"unsafe plugin name {plugin!r} in enabledPlugins -- must match {_PLUGIN_NAME_RE.pattern}")
         source = marketplaces.get(marketplace, {}).get("source", {})
         if source.get("source") == "github" and source.get("repo"):
             plugins[plugin] = source["repo"]
@@ -65,39 +106,91 @@ def enabled_github_plugins(settings: dict) -> dict[str, str]:
     return plugins
 
 
-def vendor_one(plugin: str, repo: str, clone_base: str, skills_dir: Path) -> None:
-    """Clone `repo` shallow and copy its `skills/<plugin>/` + LICENSE into skills_dir."""
+def latest_release_tag(repo: str) -> str:
+    """Tag name of `repo`'s latest GitHub release; loud failure if there is none."""
+    request = urllib.request.Request(
+        GITHUB_RELEASE_API.format(repo=repo),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "pfBlockerNG-update-vendored-skills",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as resp:
+            tag = json.load(resp).get("tag_name", "")
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(
+            f"no latest GitHub release for {repo} (HTTP {exc.code}) -- pass --ref <plugin>=<ref> explicitly"
+        ) from exc
+    if not tag:
+        raise RuntimeError(f"latest release of {repo} carries no tag_name -- pass --ref <plugin>=<ref> explicitly")
+    return tag
+
+
+def _refuse_symlinks(paths: list[Path], clone: Path, repo: str) -> None:
+    """Refuse to vendor symlinks -- copying would dereference them (#931 review).
+
+    A hostile/compromised upstream could point a symlink outside the clone
+    (same escape class scripts/build-pkg-portable.py's _safe_extract guards);
+    vendored trees must be regular files only.
+    """
+    for path in paths:
+        if path.is_symlink():
+            raise ValueError(f"{repo}: refusing to vendor symlink {path.relative_to(clone)}")
+
+
+def vendor_one(plugin: str, repo: str, skills_dir: Path, ref: str | None, extra_globs: tuple[str, ...] = ()) -> None:
+    """Fetch `repo` at `ref` (tag/branch/sha; None = remote HEAD) and vendor `plugin`."""
     with tempfile.TemporaryDirectory(prefix=f"vendor-{plugin}-") as tmp:
         clone = Path(tmp) / "clone"
-        url = f"{clone_base}{repo}.git" if not repo.startswith("file://") else repo
-        subprocess.run(
-            ["git", "clone", "--quiet", "--depth", "1", url, str(clone)],
-            check=True,
-        )
-        sha = subprocess.run(
-            ["git", "-C", str(clone), "rev-parse", "HEAD"],
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
+        clone.mkdir()
+        url = repo if repo.startswith("file://") else f"https://github.com/{repo}.git"
+
+        def _git(*args: str) -> str:
+            return subprocess.run(
+                ["git", "-C", str(clone), *args],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=_git_env(),
+            ).stdout.strip()
+
+        # init + fetch-by-ref + detach handles tags, branches, AND commit shas
+        # with one code path (clone --branch cannot take a sha).
+        _git("init", "-q")
+        _git("remote", "add", "origin", url)
+        _git("fetch", "-q", "--depth", "1", "origin", ref or "HEAD")
+        _git("checkout", "-q", "--detach", "FETCH_HEAD")
+        sha = _git("rev-parse", "HEAD")
 
         upstream_skill = clone / "skills" / plugin
         if not upstream_skill.is_dir():
             raise FileNotFoundError(f"{repo} has no skills/{plugin}/ directory -- upstream layout changed?")
 
+        licence = clone / "LICENSE"
+        extra_files: list[Path] = []
+        for pattern in extra_globs:
+            matched = sorted(clone.glob(pattern))
+            if not matched:
+                raise FileNotFoundError(f"{repo} has no files matching {pattern!r} -- upstream layout changed?")
+            extra_files.extend(matched)
+        _refuse_symlinks([*upstream_skill.rglob("*"), licence, *extra_files], clone, repo)
+
         target = skills_dir / plugin
         if target.exists():
             shutil.rmtree(target)
         shutil.copytree(upstream_skill, target)
-
-        licence = clone / "LICENSE"
         if licence.is_file():
             shutil.copy2(licence, target / "LICENSE")
+        for src in extra_files:
+            dest = target / src.relative_to(clone)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
 
         date = datetime.now(timezone.utc).date().isoformat()
-        (target / "UPSTREAM").write_text(f"{repo} @ {sha} ({date})\n", encoding="utf-8")
+        (target / "UPSTREAM").write_text(f"{repo} @ {sha} (ref {ref or 'HEAD'}, {date})\n", encoding="utf-8")
         shown = target.relative_to(REPO_ROOT) if target.is_relative_to(REPO_ROOT) else target
-        print(f"OK  {plugin}: {repo} @ {sha[:12]} -> {shown}")
+        print(f"OK  {plugin}: {repo} @ {sha[:12]} (ref {ref or 'HEAD'}) -> {shown}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -115,21 +208,40 @@ def main(argv: list[str] | None = None) -> int:
         help="destination .claude/skills directory",
     )
     parser.add_argument(
-        "--clone-base",
-        default=DEFAULT_CLONE_BASE,
-        help="prefix for `owner/repo` clone URLs (default: GitHub)",
+        "--ref",
+        action="append",
+        default=[],
+        metavar="PLUGIN=REF",
+        help="vendor PLUGIN at REF (tag, branch, or commit sha); repeatable. "
+        "Default: the tag of the plugin's latest GitHub release",
     )
     args = parser.parse_args(argv)
+
+    refs: dict[str, str] = {}
+    for spec in args.ref:
+        plugin, sep, ref = spec.partition("=")
+        if not sep or not plugin or not ref:
+            print(f"bad --ref {spec!r}: expected PLUGIN=REF", file=sys.stderr)
+            return 1
+        refs[plugin] = ref
 
     settings = json.loads(args.settings.read_text(encoding="utf-8"))
     plugins = enabled_github_plugins(settings)
     if not plugins:
         print(f"expected at least one enabled GitHub-sourced plugin in {args.settings}, found none", file=sys.stderr)
         return 1
+    unknown = sorted(set(refs) - set(plugins))
+    if unknown:
+        print(f"--ref names unknown plugin(s) {unknown} -- enabled: {sorted(plugins)}", file=sys.stderr)
+        return 1
 
     args.skills_dir.mkdir(parents=True, exist_ok=True)
     for plugin, repo in sorted(plugins.items()):
-        vendor_one(plugin, repo, args.clone_base, args.skills_dir)
+        ref = refs.get(plugin)
+        if ref is None and not repo.startswith("file://"):
+            ref = latest_release_tag(repo)
+            print(f"    {plugin}: latest release of {repo} is {ref}")
+        vendor_one(plugin, repo, args.skills_dir, ref, EXTRA_VENDOR_GLOBS.get(plugin, ()))
     return 0
 
 

--- a/scripts/update-vendored-skills.py
+++ b/scripts/update-vendored-skills.py
@@ -63,8 +63,8 @@ _PLUGIN_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
 # copied with their upstream-relative paths preserved under the vendored root
 # (matching each plugin's own ${CLAUDE_PLUGIN_ROOT}-relative hook manifest).
 EXTRA_VENDOR_GLOBS: dict[str, tuple[str, ...]] = {
-    "ponytail": ("hooks/*.js",),
-    "caveman": ("src/hooks/*.js",),
+    "ponytail": ("hooks/*.js", "hooks/ponytail-statusline.*"),
+    "caveman": ("src/hooks/*.js", "src/hooks/caveman-statusline.*"),
 }
 
 
@@ -122,6 +122,10 @@ def latest_release_tag(repo: str) -> str:
         raise RuntimeError(
             f"no latest GitHub release for {repo} (HTTP {exc.code}) -- pass --ref <plugin>=<ref> explicitly"
         ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"failed to query the latest release of {repo} ({exc.reason}) -- pass --ref <plugin>=<ref> explicitly"
+        ) from exc
     if not tag:
         raise RuntimeError(f"latest release of {repo} carries no tag_name -- pass --ref <plugin>=<ref> explicitly")
     return tag
@@ -132,11 +136,19 @@ def _refuse_symlinks(paths: list[Path], clone: Path, repo: str) -> None:
 
     A hostile/compromised upstream could point a symlink outside the clone
     (same escape class scripts/build-pkg-portable.py's _safe_extract guards);
-    vendored trees must be regular files only.
+    vendored trees must be regular files only. Every COMPONENT between each
+    path and the clone root is checked too: a symlinked skills/<plugin>/ (or
+    hooks/) directory would otherwise smuggle its target's files through as
+    regular-looking descendants (#931 delta review).
     """
     for path in paths:
-        if path.is_symlink():
-            raise ValueError(f"{repo}: refusing to vendor symlink {path.relative_to(clone)}")
+        p = path
+        while p != clone:
+            if p.is_symlink():
+                raise ValueError(f"{repo}: refusing to vendor symlink {p.relative_to(clone)}")
+            if p == p.parent:  # filesystem root -- path was never under the clone
+                raise ValueError(f"{repo}: {path} escapes the clone")
+            p = p.parent
 
 
 def vendor_one(plugin: str, repo: str, skills_dir: Path, ref: str | None, extra_globs: tuple[str, ...] = ()) -> None:
@@ -174,7 +186,7 @@ def vendor_one(plugin: str, repo: str, skills_dir: Path, ref: str | None, extra_
             if not matched:
                 raise FileNotFoundError(f"{repo} has no files matching {pattern!r} -- upstream layout changed?")
             extra_files.extend(matched)
-        _refuse_symlinks([*upstream_skill.rglob("*"), licence, *extra_files], clone, repo)
+        _refuse_symlinks([upstream_skill, *upstream_skill.rglob("*"), licence, *extra_files], clone, repo)
 
         target = skills_dir / plugin
         if target.exists():
@@ -186,6 +198,15 @@ def vendor_one(plugin: str, repo: str, skills_dir: Path, ref: str | None, extra_
             dest = target / src.relative_to(clone)
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dest)
+
+        # Compatibility shim (#931 delta review): the vendored hook scripts were
+        # written for the upstream PLUGIN-ROOT layout and resolve the skill text
+        # via __dirname math at <plugin-root>/skills/<plugin>/SKILL.md. Our
+        # vendored root IS upstream's skills/<plugin>/, so re-copy the skill dir
+        # at its upstream-relative path too -- without it every managed-session
+        # activation silently emits the js's frozen built-in fallback ruleset
+        # instead of the real, current SKILL.md.
+        shutil.copytree(upstream_skill, target / "skills" / plugin)
 
         date = datetime.now(timezone.utc).date().isoformat()
         (target / "UPSTREAM").write_text(f"{repo} @ {sha} (ref {ref or 'HEAD'}, {date})\n", encoding="utf-8")
@@ -222,6 +243,9 @@ def main(argv: list[str] | None = None) -> int:
         plugin, sep, ref = spec.partition("=")
         if not sep or not plugin or not ref:
             print(f"bad --ref {spec!r}: expected PLUGIN=REF", file=sys.stderr)
+            return 1
+        if plugin in refs:
+            print(f"duplicate --ref for {plugin!r} ({refs[plugin]!r} then {ref!r}) -- pass it once", file=sys.stderr)
             return 1
         refs[plugin] = ref
 

--- a/scripts/update-vendored-skills.py
+++ b/scripts/update-vendored-skills.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""update-vendored-skills.py -- refresh the vendored plugin skills in .claude/skills/.
+
+Managed/cloud Claude sessions never load marketplace plugins (their slash
+commands and the /plugin diagnostics are both unavailable there), so the mode
+skills this repo relies on (ponytail, caveman) are vendored byte-identical
+into committed .claude/skills/, which cloud sessions do load. This script
+automates the refresh so the vendored copies can track their upstreams:
+
+  python3 scripts/update-vendored-skills.py          # refresh all
+  git diff                                           # inspect, then commit
+
+For each plugin that is BOTH enabled in .claude/settings.json's
+`enabledPlugins` AND declared in its `extraKnownMarketplaces` with a GitHub
+source, it shallow-clones the upstream repo, copies `skills/<plugin>/`
+(the plugin's core mode skill) plus the repo-root LICENSE into
+`.claude/skills/<plugin>/`, and writes an UPSTREAM provenance line
+(repo @ commit sha, clone date) so drift stays visible.
+
+Deliberately NOT run in managed environments -- it needs network + git and
+its output is committed; cloud sessions just consume the committed copies.
+
+Dev-host tooling (scripts/): bare `python3` is fine here, this never runs on
+the pfSense appliance (CLAUDE.md's appliance-python carve-out).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SETTINGS_FILE = REPO_ROOT / ".claude/settings.json"
+SKILLS_DIR = REPO_ROOT / ".claude/skills"
+
+# ponytail: default clone base swapped only by tests (file:// fixtures) or a
+# GitHub Enterprise mirror; not a user-facing knob.
+DEFAULT_CLONE_BASE = "https://github.com/"
+
+
+def enabled_github_plugins(settings: dict) -> dict[str, str]:
+    """Map plugin name -> GitHub `owner/repo` for every enabled marketplace plugin.
+
+    `enabledPlugins` keys are `plugin@marketplace`; only marketplaces with a
+    GitHub source are vendorable (a `directory` source has no canonical
+    upstream to refresh from -- skipped with a notice, not an error).
+    """
+    marketplaces = settings.get("extraKnownMarketplaces", {})
+    plugins: dict[str, str] = {}
+    for key, enabled in settings.get("enabledPlugins", {}).items():
+        if not enabled or "@" not in key:
+            continue
+        plugin, marketplace = key.split("@", 1)
+        source = marketplaces.get(marketplace, {}).get("source", {})
+        if source.get("source") == "github" and source.get("repo"):
+            plugins[plugin] = source["repo"]
+        else:
+            print(f"SKIP {plugin}: marketplace {marketplace!r} has no GitHub source")
+    return plugins
+
+
+def vendor_one(plugin: str, repo: str, clone_base: str, skills_dir: Path) -> None:
+    """Clone `repo` shallow and copy its `skills/<plugin>/` + LICENSE into skills_dir."""
+    with tempfile.TemporaryDirectory(prefix=f"vendor-{plugin}-") as tmp:
+        clone = Path(tmp) / "clone"
+        url = f"{clone_base}{repo}.git" if not repo.startswith("file://") else repo
+        subprocess.run(
+            ["git", "clone", "--quiet", "--depth", "1", url, str(clone)],
+            check=True,
+        )
+        sha = subprocess.run(
+            ["git", "-C", str(clone), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        upstream_skill = clone / "skills" / plugin
+        if not upstream_skill.is_dir():
+            raise FileNotFoundError(f"{repo} has no skills/{plugin}/ directory -- upstream layout changed?")
+
+        target = skills_dir / plugin
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(upstream_skill, target)
+
+        licence = clone / "LICENSE"
+        if licence.is_file():
+            shutil.copy2(licence, target / "LICENSE")
+
+        date = datetime.now(timezone.utc).date().isoformat()
+        (target / "UPSTREAM").write_text(f"{repo} @ {sha} ({date})\n", encoding="utf-8")
+        shown = target.relative_to(REPO_ROOT) if target.is_relative_to(REPO_ROOT) else target
+        print(f"OK  {plugin}: {repo} @ {sha[:12]} -> {shown}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--settings",
+        type=Path,
+        default=SETTINGS_FILE,
+        help="settings.json declaring enabledPlugins + extraKnownMarketplaces",
+    )
+    parser.add_argument(
+        "--skills-dir",
+        type=Path,
+        default=SKILLS_DIR,
+        help="destination .claude/skills directory",
+    )
+    parser.add_argument(
+        "--clone-base",
+        default=DEFAULT_CLONE_BASE,
+        help="prefix for `owner/repo` clone URLs (default: GitHub)",
+    )
+    args = parser.parse_args(argv)
+
+    settings = json.loads(args.settings.read_text(encoding="utf-8"))
+    plugins = enabled_github_plugins(settings)
+    if not plugins:
+        print(f"expected at least one enabled GitHub-sourced plugin in {args.settings}, found none", file=sys.stderr)
+        return 1
+
+    args.skills_dir.mkdir(parents=True, exist_ok=True)
+    for plugin, repo in sorted(plugins.items()):
+        vendor_one(plugin, repo, args.clone_base, args.skills_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_update_vendored_skills.py
+++ b/tests/test_update_vendored_skills.py
@@ -1,29 +1,35 @@
 """scripts/update-vendored-skills.py -- vendoring refresh for the mode skills.
 
 Managed/cloud sessions load only committed .claude/skills/, never marketplace
-plugins, so the ponytail/caveman skills are vendored and refreshed by this
-script. These tests pin the refresh contract against LOCAL fixture upstreams
-(file:// clones -- no network):
+plugins, so the ponytail/caveman skills (and their hook scripts) are vendored
+and refreshed by this script. These tests pin the refresh contract against
+LOCAL fixture upstreams (file:// fetches -- no network):
 
-  - an enabled GitHub-sourced plugin's skills/<plugin>/ dir + LICENSE are
+  - an enabled GitHub-sourced plugin's skills/<plugin>/ dir + LICENSE (+ any
+    EXTRA_VENDOR_GLOBS hook scripts, upstream-relative paths preserved) are
     copied byte-identical, with an UPSTREAM provenance line naming the exact
-    upstream commit;
-  - a refresh REPLACES the target dir (stale files from an older upstream
-    layout do not survive);
-  - re-running against an unchanged upstream is idempotent;
-  - a disabled plugin and a non-GitHub (directory-source) marketplace are
-    skipped, an upstream without skills/<plugin>/ fails loudly, and an empty
-    plugin set is a non-zero exit (never a silent no-op).
+    upstream commit and ref;
+  - --ref targets ANY ref -- a tag or a commit sha (one fetch code path);
+    the default for GitHub-slug repos is the latest release's tag (file://
+    fixtures never touch the release API);
+  - a refresh REPLACES the target dir; re-running is idempotent;
+  - every skipped plugin is skipped VISIBLY (disabled, malformed key,
+    non-GitHub source), hostile plugin names ('@bogus' empty segment,
+    '../'-traversal) fail loudly BEFORE any path is built, symlinked upstream
+    content is refused, and GIT_* env poisoning cannot redirect the fetch.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
 import subprocess
 import sys
+import urllib.error
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -40,15 +46,41 @@ def _scrub_git_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Strip GIT_* vars so the fixture repos are the sole git context.
 
     Same rationale as test_read_version_matrix._clean_git_env(): under a git
-    hook, exported GIT_DIR/GIT_WORK_TREE would point the script's `git clone`
-    and the fixtures' `git init` at the real repository.
+    hook, exported GIT_DIR/GIT_WORK_TREE would point the fixtures' `git init`
+    at the real repository. The script scrubs its own subprocesses (pinned by
+    test_git_env_poisoning_cannot_redirect_the_fetch below).
     """
     for key in list(os.environ):
         if key.startswith("GIT_"):
             monkeypatch.delenv(key, raising=False)
 
 
-def _make_upstream(root: Path, plugin: str, *, skill_files: dict[str, str] | None = None) -> tuple[str, str]:
+@pytest.fixture(autouse=True)
+def _no_release_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """file:// fixtures must never consult the GitHub release API.
+
+    Any test that needs latest_release_tag() re-monkeypatches it explicitly;
+    for everything else an unexpected call is a hard failure, pinning the
+    'default resolves the release tag only for GitHub-slug repos' rule.
+    """
+
+    def _boom(repo: str) -> str:
+        raise AssertionError(f"latest_release_tag unexpectedly called for {repo}")
+
+    monkeypatch.setattr(uvs, "latest_release_tag", _boom)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True).stdout.strip()
+
+
+def _make_upstream(
+    root: Path,
+    plugin: str,
+    *,
+    skill_files: dict[str, str] | None = None,
+    extra_files: dict[str, str] | None = None,
+) -> tuple[str, str]:
     """Create a one-commit fixture upstream repo; return (file:// url, HEAD sha)."""
     repo = root / f"{plugin}-upstream"
     skill_dir = repo / "skills" / plugin
@@ -56,18 +88,22 @@ def _make_upstream(root: Path, plugin: str, *, skill_files: dict[str, str] | Non
     files = skill_files if skill_files is not None else {"SKILL.md": f"---\nname: {plugin}\n---\n\n# {plugin}\n"}
     for name, content in files.items():
         (skill_dir / name).write_text(content, encoding="utf-8")
+    for rel, content in (extra_files or {}).items():
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
     (repo / "LICENSE").write_text(f"MIT License\n\nCopyright (c) 2026 {plugin} upstream\n", encoding="utf-8")
 
-    def _git(*args: str) -> str:
-        return subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True).stdout.strip()
-
-    _git("init", "-q", "-b", "main")
-    _git("config", "user.email", "test@example.com")
-    _git("config", "user.name", "test")
-    _git("config", "commit.gpgsign", "false")
-    _git("add", "-A")
-    _git("commit", "-q", "-m", "fixture upstream")
-    return f"file://{repo}", _git("rev-parse", "HEAD")
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "test")
+    _git(repo, "config", "commit.gpgsign", "false")
+    # Lets the script's fetch-by-sha path work against a file:// remote, as it
+    # does against GitHub (which enables allow-any-sha server-side).
+    _git(repo, "config", "uploadpack.allowAnySHA1InWant", "true")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "fixture upstream")
+    return f"file://{repo}", _git(repo, "rev-parse", "HEAD")
 
 
 def _settings_file(root: Path, plugins: dict[str, dict], enabled: dict[str, bool]) -> Path:
@@ -76,104 +112,280 @@ def _settings_file(root: Path, plugins: dict[str, dict], enabled: dict[str, bool
     return settings
 
 
+def _run(settings: Path, skills: Path, *extra: str) -> int:
+    return uvs.main(["--settings", str(settings), "--skills-dir", str(skills), *extra])
+
+
 def test_vendors_enabled_plugin_byte_identical_with_provenance(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    url, sha = _make_upstream(tmp_path, "ponytail")
+    url, sha = _make_upstream(tmp_path, "myplugin")
     settings = _settings_file(
         tmp_path,
-        {"ponytail": {"source": {"source": "github", "repo": url}}},
-        {"ponytail@ponytail": True},
+        {"myplugin": {"source": {"source": "github", "repo": url}}},
+        {"myplugin@myplugin": True},
     )
     skills = tmp_path / "skills"
 
-    rc = uvs.main(["--settings", str(settings), "--skills-dir", str(skills)])
+    rc = _run(settings, skills)
 
     assert rc == 0, f"expected exit 0, got {rc}; output: {capsys.readouterr().out}"
-    copied = (skills / "ponytail" / "SKILL.md").read_text(encoding="utf-8")
-    assert copied == "---\nname: ponytail\n---\n\n# ponytail\n", f"SKILL.md not byte-identical: {copied!r}"
-    licence = (skills / "ponytail" / "LICENSE").read_text(encoding="utf-8")
+    copied = (skills / "myplugin" / "SKILL.md").read_text(encoding="utf-8")
+    assert copied == "---\nname: myplugin\n---\n\n# myplugin\n", f"SKILL.md not byte-identical: {copied!r}"
+    licence = (skills / "myplugin" / "LICENSE").read_text(encoding="utf-8")
     assert "MIT License" in licence, f"LICENSE not copied: {licence!r}"
-    upstream = (skills / "ponytail" / "UPSTREAM").read_text(encoding="utf-8")
+    upstream = (skills / "myplugin" / "UPSTREAM").read_text(encoding="utf-8")
     assert sha in upstream and url in upstream, f"expected {url} and {sha} in provenance, got {upstream!r}"
+    assert "(ref HEAD" in upstream, f"expected the fetched ref in provenance, got {upstream!r}"
+
+
+def test_ref_targets_a_tag(tmp_path: Path) -> None:
+    url, _ = _make_upstream(tmp_path, "myplugin", skill_files={"SKILL.md": "tagged content\n"})
+    repo = tmp_path / "myplugin-upstream"
+    _git(repo, "tag", "v1.0.0")
+    (repo / "skills" / "myplugin" / "SKILL.md").write_text("newer content\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "post-release drift")
+    tagged_sha = _git(repo, "rev-parse", "v1.0.0^{commit}")
+    settings = _settings_file(
+        tmp_path,
+        {"myplugin": {"source": {"source": "github", "repo": url}}},
+        {"myplugin@myplugin": True},
+    )
+    skills = tmp_path / "skills"
+
+    assert _run(settings, skills, "--ref", "myplugin=v1.0.0") == 0
+
+    copied = (skills / "myplugin" / "SKILL.md").read_text(encoding="utf-8")
+    assert copied == "tagged content\n", f"--ref must vendor the TAGGED commit, got: {copied!r}"
+    upstream = (skills / "myplugin" / "UPSTREAM").read_text(encoding="utf-8")
+    assert tagged_sha in upstream and "(ref v1.0.0" in upstream, f"provenance must pin tag + sha, got {upstream!r}"
+
+
+def test_ref_targets_a_commit_sha(tmp_path: Path) -> None:
+    url, first_sha = _make_upstream(tmp_path, "myplugin", skill_files={"SKILL.md": "first\n"})
+    repo = tmp_path / "myplugin-upstream"
+    (repo / "skills" / "myplugin" / "SKILL.md").write_text("second\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "second")
+    settings = _settings_file(
+        tmp_path,
+        {"myplugin": {"source": {"source": "github", "repo": url}}},
+        {"myplugin@myplugin": True},
+    )
+    skills = tmp_path / "skills"
+
+    assert _run(settings, skills, "--ref", f"myplugin={first_sha}") == 0
+
+    copied = (skills / "myplugin" / "SKILL.md").read_text(encoding="utf-8")
+    assert copied == "first\n", f"--ref must vendor the exact sha, got: {copied!r}"
+    assert first_sha in (skills / "myplugin" / "UPSTREAM").read_text(encoding="utf-8")
+
+
+def test_extra_vendor_globs_copy_hook_scripts_with_relative_paths(tmp_path: Path) -> None:
+    url, _ = _make_upstream(
+        tmp_path,
+        "myplugin",
+        extra_files={"hooks/a.js": "// hook a\n", "hooks/b.js": "// hook b\n", "hooks/skipme.sh": "#!/bin/sh\n"},
+    )
+    skills = tmp_path / "skills"
+
+    uvs.vendor_one("myplugin", url, skills, None, ("hooks/*.js",))
+
+    assert (skills / "myplugin" / "hooks" / "a.js").read_text(encoding="utf-8") == "// hook a\n"
+    assert (skills / "myplugin" / "hooks" / "b.js").is_file()
+    assert not (skills / "myplugin" / "hooks" / "skipme.sh").exists(), "only the glob's matches may be vendored"
+
+
+def test_missing_extra_glob_fails_loudly(tmp_path: Path) -> None:
+    url, _ = _make_upstream(tmp_path, "myplugin")
+
+    with pytest.raises(FileNotFoundError, match="src/hooks"):
+        uvs.vendor_one("myplugin", url, tmp_path / "skills", None, ("src/hooks/*.js",))
+
+
+def test_latest_release_tag_parses_the_github_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Direct unit test of the resolver on a FRESH module instance (the autouse
+    # fixture stubs the shared module's attribute).
+    captured: dict[str, Any] = {}
+
+    class _FakeResponse(io.BytesIO):
+        def __enter__(self) -> _FakeResponse:
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            self.close()
+
+    def fake_urlopen(request: Any, timeout: float = 0) -> _FakeResponse:
+        captured["url"] = request.full_url
+        return _FakeResponse(b'{"tag_name": "v9.9.9"}')
+
+    fresh = _real_latest_release_tag()
+    monkeypatch.setattr(sys.modules[fresh.__module__].urllib.request, "urlopen", fake_urlopen)
+
+    result = fresh("owner/name")
+
+    assert result == "v9.9.9", f"expected the release tag_name, got {result!r}"
+    assert captured["url"] == "https://api.github.com/repos/owner/name/releases/latest"
+
+
+def _real_latest_release_tag() -> Any:
+    """The un-stubbed latest_release_tag (the autouse fixture replaces the module attr)."""
+    fresh_spec = importlib.util.spec_from_file_location("uvs_fresh", _SCRIPT)
+    assert fresh_spec is not None and fresh_spec.loader is not None
+    fresh = importlib.util.module_from_spec(fresh_spec)
+    sys.modules[fresh_spec.name] = fresh
+    fresh_spec.loader.exec_module(fresh)
+    return fresh.latest_release_tag
+
+
+def test_latest_release_tag_missing_release_is_loud(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(request: Any, timeout: float = 0) -> Any:
+        raise urllib.error.HTTPError(request.full_url, 404, "Not Found", None, None)  # type: ignore[arg-type]
+
+    fresh = _real_latest_release_tag()
+    monkeypatch.setattr(sys.modules[fresh.__module__].urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match=r"--ref"):
+        fresh("owner/name")
 
 
 def test_refresh_replaces_target_removing_stale_files(tmp_path: Path) -> None:
-    url, _ = _make_upstream(tmp_path, "caveman")
+    url, _ = _make_upstream(tmp_path, "myplugin")
     settings = _settings_file(
         tmp_path,
-        {"caveman": {"source": {"source": "github", "repo": url}}},
-        {"caveman@caveman": True},
+        {"myplugin": {"source": {"source": "github", "repo": url}}},
+        {"myplugin@myplugin": True},
     )
     skills = tmp_path / "skills"
-    stale = skills / "caveman" / "OBSOLETE.md"
+    stale = skills / "myplugin" / "OBSOLETE.md"
     stale.parent.mkdir(parents=True)
     stale.write_text("left over from an older upstream layout\n", encoding="utf-8")
 
-    rc = uvs.main(["--settings", str(settings), "--skills-dir", str(skills)])
-
-    assert rc == 0
+    assert _run(settings, skills) == 0
     assert not stale.exists(), "refresh must REPLACE the target dir -- stale files may not survive"
-    assert (skills / "caveman" / "SKILL.md").is_file()
+    assert (skills / "myplugin" / "SKILL.md").is_file()
 
 
 def test_rerun_against_unchanged_upstream_is_idempotent(tmp_path: Path) -> None:
-    url, _ = _make_upstream(tmp_path, "ponytail")
+    url, _ = _make_upstream(tmp_path, "myplugin")
     settings = _settings_file(
         tmp_path,
-        {"ponytail": {"source": {"source": "github", "repo": url}}},
-        {"ponytail@ponytail": True},
+        {"myplugin": {"source": {"source": "github", "repo": url}}},
+        {"myplugin@myplugin": True},
     )
     skills = tmp_path / "skills"
 
-    assert uvs.main(["--settings", str(settings), "--skills-dir", str(skills)]) == 0
+    assert _run(settings, skills) == 0
     first = {p.relative_to(skills): p.read_bytes() for p in sorted(skills.rglob("*")) if p.is_file()}
-    assert uvs.main(["--settings", str(settings), "--skills-dir", str(skills)]) == 0
+    assert _run(settings, skills) == 0
     second = {p.relative_to(skills): p.read_bytes() for p in sorted(skills.rglob("*")) if p.is_file()}
 
     assert first == second, f"re-run must be a byte-identical no-op; diff keys: {set(first) ^ set(second)}"
 
 
-def test_disabled_plugin_and_directory_source_are_skipped(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    url, _ = _make_upstream(tmp_path, "ponytail")
+def test_every_skipped_plugin_is_skipped_visibly(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    url, _ = _make_upstream(tmp_path, "myplugin")
     settings = _settings_file(
         tmp_path,
         {
-            "ponytail": {"source": {"source": "github", "repo": url}},
+            "myplugin": {"source": {"source": "github", "repo": url}},
             "disabledone": {"source": {"source": "github", "repo": url}},
             "dirsourced": {"source": {"source": "directory", "path": "/somewhere"}},
         },
-        {"ponytail@ponytail": True, "disabledone@disabledone": False, "dirsourced@dirsourced": True},
+        {
+            "myplugin@myplugin": True,
+            "disabledone@disabledone": False,
+            "dirsourced@dirsourced": True,
+            "notakey": True,
+        },
     )
     skills = tmp_path / "skills"
 
-    rc = uvs.main(["--settings", str(settings), "--skills-dir", str(skills)])
+    rc = _run(settings, skills)
 
     assert rc == 0
-    assert (skills / "ponytail").is_dir()
+    assert (skills / "myplugin").is_dir()
     assert not (skills / "disabledone").exists(), "a disabled plugin must not be vendored"
     assert not (skills / "dirsourced").exists(), "a directory-source marketplace has no upstream to vendor"
     out = capsys.readouterr().out
+    assert "SKIP disabledone: disabled" in out, f"a disabled plugin must be skipped VISIBLY, got: {out!r}"
     assert "SKIP dirsourced" in out, f"directory-source skip must be visible, got: {out!r}"
+    assert "SKIP 'notakey'" in out, f"a malformed enabledPlugins key must be skipped visibly, got: {out!r}"
 
 
-def test_upstream_without_the_skill_dir_fails_loudly(tmp_path: Path) -> None:
-    url, _ = _make_upstream(tmp_path, "renamedplugin", skill_files={"SKILL.md": "x\n"})
+@pytest.mark.parametrize("hostile_key", ["@bogus", "../escape@mp", "a/b@mp"])
+def test_hostile_plugin_names_fail_loudly_before_any_path_is_built(tmp_path: Path, hostile_key: str) -> None:
+    # '@bogus' yields an EMPTY plugin segment -- skills_dir / '' resolves to the
+    # skills dir itself, which a refresh would rmtree; '../'-shaped names escape
+    # it. Both must die in validation, never reach the filesystem (#931 review).
     settings = _settings_file(
         tmp_path,
-        {"ponytail": {"source": {"source": "github", "repo": url}}},
-        {"ponytail@ponytail": True},
+        {"mp": {"source": {"source": "github", "repo": "owner/repo"}}},
+        {hostile_key: True},
     )
 
-    with pytest.raises(FileNotFoundError, match="skills/ponytail"):
-        uvs.main(["--settings", str(settings), "--skills-dir", str(tmp_path / "skills")])
+    with pytest.raises(ValueError, match="unsafe plugin name"):
+        _run(settings, tmp_path / "skills")
+
+
+def test_symlinked_upstream_content_is_refused(tmp_path: Path) -> None:
+    outside = tmp_path / "outside-secret"
+    outside.write_text("must never be vendored\n", encoding="utf-8")
+    url, _ = _make_upstream(tmp_path, "myplugin")
+    repo = tmp_path / "myplugin-upstream"
+    (repo / "skills" / "myplugin" / "evil.md").symlink_to(outside)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "add symlink")
+
+    with pytest.raises(ValueError, match="symlink"):
+        uvs.vendor_one("myplugin", url, tmp_path / "skills", None)
+
+    assert not (tmp_path / "skills" / "myplugin").exists(), "refusal must happen before any copy"
+
+
+def test_git_env_poisoning_cannot_redirect_the_fetch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    url, sha = _make_upstream(tmp_path, "myplugin")
+    decoy = tmp_path / "decoy"
+    decoy.mkdir()
+    _git(decoy, "init", "-q", "-b", "main")
+    monkeypatch.setenv("GIT_DIR", str(decoy / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(decoy))
+    skills = tmp_path / "skills"
+
+    uvs.vendor_one("myplugin", url, skills, None)
+
+    upstream = (skills / "myplugin" / "UPSTREAM").read_text(encoding="utf-8")
+    assert sha in upstream, f"GIT_DIR poisoning must not redirect the fetch; provenance: {upstream!r}"
+
+
+def test_unknown_ref_plugin_is_a_nonzero_exit(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    url, _ = _make_upstream(tmp_path, "myplugin")
+    settings = _settings_file(
+        tmp_path,
+        {"myplugin": {"source": {"source": "github", "repo": url}}},
+        {"myplugin@myplugin": True},
+    )
+
+    rc = _run(settings, tmp_path / "skills", "--ref", "nosuch=v1.0.0")
+
+    assert rc == 1, "--ref for an unknown plugin must fail loudly"
+    assert "nosuch" in capsys.readouterr().err
+
+
+def test_bad_ref_spec_is_a_nonzero_exit(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    settings = _settings_file(tmp_path, {}, {})
+
+    rc = _run(settings, tmp_path / "skills", "--ref", "justaword")
+
+    assert rc == 1
+    assert "PLUGIN=REF" in capsys.readouterr().err
 
 
 def test_no_enabled_github_plugins_is_a_nonzero_exit(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     settings = _settings_file(tmp_path, {}, {})
 
-    rc = uvs.main(["--settings", str(settings), "--skills-dir", str(tmp_path / "skills")])
+    rc = _run(settings, tmp_path / "skills")
 
     assert rc == 1, "an empty plugin set must fail loudly, never silently vendor nothing"
-    err = capsys.readouterr().err
-    assert "found none" in err, f"expected the reason on stderr, got: {err!r}"
+    assert "found none" in capsys.readouterr().err

--- a/tests/test_update_vendored_skills.py
+++ b/tests/test_update_vendored_skills.py
@@ -382,6 +382,79 @@ def test_bad_ref_spec_is_a_nonzero_exit(tmp_path: Path, capsys: pytest.CaptureFi
     assert "PLUGIN=REF" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize("target_kind", ["relative-inside-repo", "absolute-outside-clone"])
+def test_symlinked_skill_root_is_refused(tmp_path: Path, target_kind: str) -> None:
+    # The ROOT escape (#931 delta review): if skills/<plugin> is ITSELF a
+    # symlink, every descendant globs as a regular file from the TARGET --
+    # the component walk must reject the root before any copy.
+    if target_kind == "relative-inside-repo":
+        url, _ = _make_upstream(tmp_path, "myplugin")
+        repo = tmp_path / "myplugin-upstream"
+        decoy = repo / "decoy"
+        decoy.mkdir()
+        (decoy / "SKILL.md").write_text("smuggled\n", encoding="utf-8")
+        import shutil as _shutil
+
+        _shutil.rmtree(repo / "skills" / "myplugin")
+        (repo / "skills" / "myplugin").symlink_to(Path("..") / "decoy", target_is_directory=True)
+    else:
+        outside = tmp_path / "outside-clone"
+        outside.mkdir()
+        (outside / "SKILL.md").write_text("exfiltrated\n", encoding="utf-8")
+        url, _ = _make_upstream(tmp_path, "myplugin")
+        repo = tmp_path / "myplugin-upstream"
+        import shutil as _shutil
+
+        _shutil.rmtree(repo / "skills" / "myplugin")
+        (repo / "skills" / "myplugin").symlink_to(outside, target_is_directory=True)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "root symlink")
+
+    with pytest.raises(ValueError, match="symlink|escapes"):
+        uvs.vendor_one("myplugin", url, tmp_path / "skills", None)
+
+    assert not (tmp_path / "skills" / "myplugin").exists(), "root-symlink refusal must happen before any copy"
+
+
+def test_shim_copy_exists_at_the_upstream_relative_path(tmp_path: Path) -> None:
+    # The vendored hook scripts resolve SKILL.md at
+    # <plugin-root>/skills/<plugin>/SKILL.md via __dirname math; the shim copy
+    # keeps that path real inside the flattened vendored root (#931 delta review).
+    url, _ = _make_upstream(tmp_path, "myplugin")
+    skills = tmp_path / "skills"
+
+    uvs.vendor_one("myplugin", url, skills, None)
+
+    root_copy = (skills / "myplugin" / "SKILL.md").read_bytes()
+    shim_copy = (skills / "myplugin" / "skills" / "myplugin" / "SKILL.md").read_bytes()
+    assert shim_copy == root_copy, "the shim copy must be byte-identical to the root copy"
+
+
+def test_duplicate_ref_flag_is_a_nonzero_exit(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    url, _ = _make_upstream(tmp_path, "myplugin")
+    settings = _settings_file(
+        tmp_path,
+        {"myplugin": {"source": {"source": "github", "repo": url}}},
+        {"myplugin@myplugin": True},
+    )
+
+    rc = _run(settings, tmp_path / "skills", "--ref", "myplugin=v1", "--ref", "myplugin=v2")
+
+    assert rc == 1, "a duplicate --ref must fail loudly, not silently last-win"
+    assert "duplicate --ref" in capsys.readouterr().err
+
+
+def test_latest_release_tag_network_failure_is_loud(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(request: Any, timeout: float = 0) -> Any:
+        raise urllib.error.URLError("dns lookup failed")
+
+    fresh = _real_latest_release_tag()
+    monkeypatch.setattr(sys.modules[fresh.__module__].urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match=r"--ref"):
+        fresh("owner/name")
+
+
 def test_no_enabled_github_plugins_is_a_nonzero_exit(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     settings = _settings_file(tmp_path, {}, {})
 

--- a/tests/test_update_vendored_skills.py
+++ b/tests/test_update_vendored_skills.py
@@ -1,0 +1,179 @@
+"""scripts/update-vendored-skills.py -- vendoring refresh for the mode skills.
+
+Managed/cloud sessions load only committed .claude/skills/, never marketplace
+plugins, so the ponytail/caveman skills are vendored and refreshed by this
+script. These tests pin the refresh contract against LOCAL fixture upstreams
+(file:// clones -- no network):
+
+  - an enabled GitHub-sourced plugin's skills/<plugin>/ dir + LICENSE are
+    copied byte-identical, with an UPSTREAM provenance line naming the exact
+    upstream commit;
+  - a refresh REPLACES the target dir (stale files from an older upstream
+    layout do not survive);
+  - re-running against an unchanged upstream is idempotent;
+  - a disabled plugin and a non-GitHub (directory-source) marketplace are
+    skipped, an upstream without skills/<plugin>/ fails loudly, and an empty
+    plugin set is a non-zero exit (never a silent no-op).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "update-vendored-skills.py"
+_spec = importlib.util.spec_from_file_location("update_vendored_skills", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+uvs = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = uvs
+_spec.loader.exec_module(uvs)
+
+
+@pytest.fixture(autouse=True)
+def _scrub_git_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip GIT_* vars so the fixture repos are the sole git context.
+
+    Same rationale as test_read_version_matrix._clean_git_env(): under a git
+    hook, exported GIT_DIR/GIT_WORK_TREE would point the script's `git clone`
+    and the fixtures' `git init` at the real repository.
+    """
+    for key in list(os.environ):
+        if key.startswith("GIT_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def _make_upstream(root: Path, plugin: str, *, skill_files: dict[str, str] | None = None) -> tuple[str, str]:
+    """Create a one-commit fixture upstream repo; return (file:// url, HEAD sha)."""
+    repo = root / f"{plugin}-upstream"
+    skill_dir = repo / "skills" / plugin
+    skill_dir.mkdir(parents=True)
+    files = skill_files if skill_files is not None else {"SKILL.md": f"---\nname: {plugin}\n---\n\n# {plugin}\n"}
+    for name, content in files.items():
+        (skill_dir / name).write_text(content, encoding="utf-8")
+    (repo / "LICENSE").write_text(f"MIT License\n\nCopyright (c) 2026 {plugin} upstream\n", encoding="utf-8")
+
+    def _git(*args: str) -> str:
+        return subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True).stdout.strip()
+
+    _git("init", "-q", "-b", "main")
+    _git("config", "user.email", "test@example.com")
+    _git("config", "user.name", "test")
+    _git("config", "commit.gpgsign", "false")
+    _git("add", "-A")
+    _git("commit", "-q", "-m", "fixture upstream")
+    return f"file://{repo}", _git("rev-parse", "HEAD")
+
+
+def _settings_file(root: Path, plugins: dict[str, dict], enabled: dict[str, bool]) -> Path:
+    settings = root / "settings.json"
+    settings.write_text(json.dumps({"enabledPlugins": enabled, "extraKnownMarketplaces": plugins}), encoding="utf-8")
+    return settings
+
+
+def test_vendors_enabled_plugin_byte_identical_with_provenance(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    url, sha = _make_upstream(tmp_path, "ponytail")
+    settings = _settings_file(
+        tmp_path,
+        {"ponytail": {"source": {"source": "github", "repo": url}}},
+        {"ponytail@ponytail": True},
+    )
+    skills = tmp_path / "skills"
+
+    rc = uvs.main(["--settings", str(settings), "--skills-dir", str(skills)])
+
+    assert rc == 0, f"expected exit 0, got {rc}; output: {capsys.readouterr().out}"
+    copied = (skills / "ponytail" / "SKILL.md").read_text(encoding="utf-8")
+    assert copied == "---\nname: ponytail\n---\n\n# ponytail\n", f"SKILL.md not byte-identical: {copied!r}"
+    licence = (skills / "ponytail" / "LICENSE").read_text(encoding="utf-8")
+    assert "MIT License" in licence, f"LICENSE not copied: {licence!r}"
+    upstream = (skills / "ponytail" / "UPSTREAM").read_text(encoding="utf-8")
+    assert sha in upstream and url in upstream, f"expected {url} and {sha} in provenance, got {upstream!r}"
+
+
+def test_refresh_replaces_target_removing_stale_files(tmp_path: Path) -> None:
+    url, _ = _make_upstream(tmp_path, "caveman")
+    settings = _settings_file(
+        tmp_path,
+        {"caveman": {"source": {"source": "github", "repo": url}}},
+        {"caveman@caveman": True},
+    )
+    skills = tmp_path / "skills"
+    stale = skills / "caveman" / "OBSOLETE.md"
+    stale.parent.mkdir(parents=True)
+    stale.write_text("left over from an older upstream layout\n", encoding="utf-8")
+
+    rc = uvs.main(["--settings", str(settings), "--skills-dir", str(skills)])
+
+    assert rc == 0
+    assert not stale.exists(), "refresh must REPLACE the target dir -- stale files may not survive"
+    assert (skills / "caveman" / "SKILL.md").is_file()
+
+
+def test_rerun_against_unchanged_upstream_is_idempotent(tmp_path: Path) -> None:
+    url, _ = _make_upstream(tmp_path, "ponytail")
+    settings = _settings_file(
+        tmp_path,
+        {"ponytail": {"source": {"source": "github", "repo": url}}},
+        {"ponytail@ponytail": True},
+    )
+    skills = tmp_path / "skills"
+
+    assert uvs.main(["--settings", str(settings), "--skills-dir", str(skills)]) == 0
+    first = {p.relative_to(skills): p.read_bytes() for p in sorted(skills.rglob("*")) if p.is_file()}
+    assert uvs.main(["--settings", str(settings), "--skills-dir", str(skills)]) == 0
+    second = {p.relative_to(skills): p.read_bytes() for p in sorted(skills.rglob("*")) if p.is_file()}
+
+    assert first == second, f"re-run must be a byte-identical no-op; diff keys: {set(first) ^ set(second)}"
+
+
+def test_disabled_plugin_and_directory_source_are_skipped(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    url, _ = _make_upstream(tmp_path, "ponytail")
+    settings = _settings_file(
+        tmp_path,
+        {
+            "ponytail": {"source": {"source": "github", "repo": url}},
+            "disabledone": {"source": {"source": "github", "repo": url}},
+            "dirsourced": {"source": {"source": "directory", "path": "/somewhere"}},
+        },
+        {"ponytail@ponytail": True, "disabledone@disabledone": False, "dirsourced@dirsourced": True},
+    )
+    skills = tmp_path / "skills"
+
+    rc = uvs.main(["--settings", str(settings), "--skills-dir", str(skills)])
+
+    assert rc == 0
+    assert (skills / "ponytail").is_dir()
+    assert not (skills / "disabledone").exists(), "a disabled plugin must not be vendored"
+    assert not (skills / "dirsourced").exists(), "a directory-source marketplace has no upstream to vendor"
+    out = capsys.readouterr().out
+    assert "SKIP dirsourced" in out, f"directory-source skip must be visible, got: {out!r}"
+
+
+def test_upstream_without_the_skill_dir_fails_loudly(tmp_path: Path) -> None:
+    url, _ = _make_upstream(tmp_path, "renamedplugin", skill_files={"SKILL.md": "x\n"})
+    settings = _settings_file(
+        tmp_path,
+        {"ponytail": {"source": {"source": "github", "repo": url}}},
+        {"ponytail@ponytail": True},
+    )
+
+    with pytest.raises(FileNotFoundError, match="skills/ponytail"):
+        uvs.main(["--settings", str(settings), "--skills-dir", str(tmp_path / "skills")])
+
+
+def test_no_enabled_github_plugins_is_a_nonzero_exit(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    settings = _settings_file(tmp_path, {}, {})
+
+    rc = uvs.main(["--settings", str(settings), "--skills-dir", str(tmp_path / "skills")])
+
+    assert rc == 1, "an empty plugin set must fail loudly, never silently vendor nothing"
+    err = capsys.readouterr().err
+    assert "found none" in err, f"expected the reason on stderr, got: {err!r}"

--- a/tests/test_vendored_plugin_hook.py
+++ b/tests/test_vendored_plugin_hook.py
@@ -21,6 +21,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 _HOOK = Path(__file__).resolve().parent.parent / ".claude" / "hooks" / "vendored-plugin-hook.sh"
 
 
@@ -35,7 +37,12 @@ def _run(
     cfg = tmp_path / "cfg"
     project = tmp_path / "project"
     if plugin_installed:
-        (cfg / "plugins" / "marketplaces" / "myplugin").mkdir(parents=True)
+        # installed_plugins.json (keyed plugin@marketplace) is the authoritative
+        # marker the hook greps -- NOT a marketplace-clone dir (#931 delta review:
+        # plugin and marketplace names need not match).
+        marker = cfg / "plugins" / "installed_plugins.json"
+        marker.parent.mkdir(parents=True)
+        marker.write_text('{"myplugin@some-marketplace": {"version": "1.0.0"}}', encoding="utf-8")
     if vendored_js:
         js = project / ".claude" / "skills" / "myplugin" / "hooks" / "activate.js"
         js.parent.mkdir(parents=True)
@@ -48,7 +55,7 @@ def _run(
         )
     path_dir = tmp_path / "bin"
     path_dir.mkdir()
-    for tool in ("sh", "dirname", "env"):  # minimal POSIX the script itself needs
+    for tool in ("sh", "dirname", "env", "grep"):  # minimal POSIX the script itself needs
         real = subprocess.run(["/usr/bin/which", tool], capture_output=True, text=True).stdout.strip()
         if real:
             (path_dir / tool).symlink_to(real)
@@ -104,3 +111,79 @@ def test_vendored_script_runs_with_plugin_root_and_stdin_passthrough(tmp_path: P
     expected_root = os.path.join(str(tmp_path / "project"), ".claude", "skills", "myplugin")
     assert out["root"] == expected_root, f"CLAUDE_PLUGIN_ROOT must point at the vendored root, got: {out['root']!r}"
     assert out["stdin"] == payload, f"the hook's stdin JSON must reach the vendored script, got: {out['stdin']!r}"
+
+
+# --------------------------------------------------------------------------- #
+# Integration: the REAL committed vendored hooks (not stubs) must emit the
+# REAL, current SKILL.md -- not the js's frozen built-in fallback (#931 delta
+# review: the flattened layout silently broke SKILL resolution; the vendor-time
+# shim copy at skills/<plugin>/ keeps the upstream-relative path real).
+# --------------------------------------------------------------------------- #
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_ACTIVATES = {
+    "ponytail": ("hooks/ponytail-activate.js", "/ponytail full"),
+    "caveman": ("src/hooks/caveman-activate.js", "/caveman full"),
+}
+_TRACKERS = {
+    "ponytail": "hooks/ponytail-mode-tracker.js",
+    "caveman": "src/hooks/caveman-mode-tracker.js",
+}
+
+
+def _skill_marker_lines(plugin: str) -> list[str]:
+    """Distinctive SKILL.md lines absent from the vendored js (fallback text lives there)."""
+    skill = (_REPO_ROOT / ".claude" / "skills" / plugin / "SKILL.md").read_text(encoding="utf-8")
+    js_blobs = "".join(
+        f.read_text(encoding="utf-8") for f in (_REPO_ROOT / ".claude" / "skills" / plugin).rglob("*.js")
+    )
+    lines = [ln.strip() for ln in skill.splitlines() if len(ln.strip()) >= 40 and ln.strip() not in js_blobs]
+    assert lines, f"no discriminating SKILL.md line for {plugin} -- marker heuristic needs rework"
+    return lines
+
+
+@pytest.mark.parametrize("plugin", sorted(_ACTIVATES))
+def test_real_vendored_activate_emits_the_real_skill_text(tmp_path: Path, plugin: str) -> None:
+    if not subprocess.run(["/usr/bin/which", "node"], capture_output=True, text=True).stdout.strip():
+        pytest.skip("node not available on this host (CI installs it for the widget JS tests)")
+    js, activate_cmd = _ACTIVATES[plugin]
+    cfg = tmp_path / "cfg"
+    cfg.mkdir()
+    env = {
+        "PATH": os.environ["PATH"],
+        "HOME": str(tmp_path),
+        "CLAUDE_CONFIG_DIR": str(cfg),
+        "CLAUDE_PROJECT_DIR": str(_REPO_ROOT),
+    }
+
+    # Given: the mode was activated (the tracker writes the flag file) -- the
+    # production path a real session takes before SessionStart re-injection.
+    subprocess.run(
+        ["/bin/sh", str(_HOOK), plugin, _TRACKERS[plugin]],
+        capture_output=True,
+        text=True,
+        env=env,
+        input=json.dumps({"prompt": activate_cmd}),
+        timeout=30,
+        check=True,
+    )
+
+    # When: the real vendored activate hook runs through the real sh shim.
+    result = subprocess.run(
+        ["/bin/sh", str(_HOOK), plugin, js],
+        capture_output=True,
+        text=True,
+        env=env,
+        input=json.dumps({"hook_event_name": "SessionStart"}),
+        timeout=30,
+    )
+
+    # Then: the output contains the REAL SKILL.md's text, not just the js's
+    # frozen fallback ruleset.
+    assert result.returncode == 0, f"{plugin} activate failed: {result.stderr!r}"
+    markers = _skill_marker_lines(plugin)
+    hits = [m for m in markers if m in result.stdout]
+    assert hits, (
+        f"{plugin}: activation output matches only the js fallback, not the current SKILL.md "
+        f"(0/{len(markers)} marker lines found). Output head: {result.stdout[:400]!r}"
+    )

--- a/tests/test_vendored_plugin_hook.py
+++ b/tests/test_vendored_plugin_hook.py
@@ -1,0 +1,106 @@
+"""`.claude/hooks/vendored-plugin-hook.sh` -- vendored plugin hooks for managed sessions.
+
+The script runs a vendored plugin hook (node) ONLY when the real marketplace
+plugin is absent, falling silent otherwise -- so locally the plugin injects
+(no double-injection) and in managed/cloud sessions the vendored copy takes
+over. Pinned here through the real production surface (the sh script run as
+a subprocess with a controlled env), one test per resolution rung:
+
+  - real plugin installed  -> silent no-op (rung 1)
+  - node missing from PATH -> silent no-op (rung 2)
+  - vendored script absent -> silent no-op (rung 3)
+  - otherwise              -> node runs the vendored script with
+                              CLAUDE_PLUGIN_ROOT at the vendored root and the
+                              hook's stdin JSON passed through (rung 4)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+_HOOK = Path(__file__).resolve().parent.parent / ".claude" / "hooks" / "vendored-plugin-hook.sh"
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    plugin_installed: bool,
+    with_node: bool,
+    vendored_js: bool,
+    stdin: str = "",
+) -> subprocess.CompletedProcess[str]:
+    cfg = tmp_path / "cfg"
+    project = tmp_path / "project"
+    if plugin_installed:
+        (cfg / "plugins" / "marketplaces" / "myplugin").mkdir(parents=True)
+    if vendored_js:
+        js = project / ".claude" / "skills" / "myplugin" / "hooks" / "activate.js"
+        js.parent.mkdir(parents=True)
+        # The stub proves three things at once: it ran, it saw
+        # CLAUDE_PLUGIN_ROOT, and stdin reached it.
+        js.write_text(
+            "const data = require('fs').readFileSync(0, 'utf8');\n"
+            "console.log(JSON.stringify({root: process.env.CLAUDE_PLUGIN_ROOT, stdin: data.trim()}));\n",
+            encoding="utf-8",
+        )
+    path_dir = tmp_path / "bin"
+    path_dir.mkdir()
+    for tool in ("sh", "dirname", "env"):  # minimal POSIX the script itself needs
+        real = subprocess.run(["/usr/bin/which", tool], capture_output=True, text=True).stdout.strip()
+        if real:
+            (path_dir / tool).symlink_to(real)
+    if with_node:
+        real_node = subprocess.run(["/usr/bin/which", "node"], capture_output=True, text=True).stdout.strip()
+        assert real_node, "these tests need node on the dev host (CI installs it for the widget JS tests)"
+        (path_dir / "node").symlink_to(real_node)
+
+    env = {
+        "PATH": str(path_dir),
+        "HOME": str(tmp_path),
+        "CLAUDE_CONFIG_DIR": str(cfg),
+        "CLAUDE_PROJECT_DIR": str(project),
+    }
+    return subprocess.run(
+        ["/bin/sh", str(_HOOK), "myplugin", "hooks/activate.js"],
+        capture_output=True,
+        text=True,
+        env=env,
+        input=stdin,
+        timeout=30,
+    )
+
+
+def test_installed_plugin_wins_and_the_hook_stays_silent(tmp_path: Path) -> None:
+    result = _run(tmp_path, plugin_installed=True, with_node=True, vendored_js=True)
+
+    assert result.returncode == 0, f"expected silent success, got rc={result.returncode}: {result.stderr!r}"
+    assert result.stdout == "", f"installed plugin must mean NO vendored injection, got: {result.stdout!r}"
+
+
+def test_missing_node_is_a_silent_noop(tmp_path: Path) -> None:
+    result = _run(tmp_path, plugin_installed=False, with_node=False, vendored_js=True)
+
+    assert result.returncode == 0, f"expected silent success, got rc={result.returncode}: {result.stderr!r}"
+    assert result.stdout == "", f"no node must mean no output (static hooks are the fallback), got: {result.stdout!r}"
+
+
+def test_missing_vendored_script_is_a_silent_noop(tmp_path: Path) -> None:
+    result = _run(tmp_path, plugin_installed=False, with_node=True, vendored_js=False)
+
+    assert result.returncode == 0, f"expected silent success, got rc={result.returncode}: {result.stderr!r}"
+    assert result.stdout == "", f"missing vendored script must be a no-op, got: {result.stdout!r}"
+
+
+def test_vendored_script_runs_with_plugin_root_and_stdin_passthrough(tmp_path: Path) -> None:
+    payload = '{"hook_event_name": "SessionStart"}'
+
+    result = _run(tmp_path, plugin_installed=False, with_node=True, vendored_js=True, stdin=payload)
+
+    assert result.returncode == 0, f"expected the vendored hook to run, got rc={result.returncode}: {result.stderr!r}"
+    out = json.loads(result.stdout)
+    expected_root = os.path.join(str(tmp_path / "project"), ".claude", "skills", "myplugin")
+    assert out["root"] == expected_root, f"CLAUDE_PLUGIN_ROOT must point at the vendored root, got: {out['root']!r}"
+    assert out["stdin"] == payload, f"the hook's stdin JSON must reach the vendored script, got: {out['stdin']!r}"


### PR DESCRIPTION
Managed/cloud Claude sessions never load marketplace plugins — their slash commands and the
`/plugin` diagnostics are both unavailable there — so the two mode skills this repo's workflow
depends on (ponytail, caveman) get vendored into committed `.claude/skills/`, which cloud
sessions do load. Two commits:

## 1. Vendor the skills + make mode propagation mechanical

- `.claude/skills/{ponytail,caveman}/` — SKILL.md + MIT LICENSE, byte-identical from upstream
  (`DietrichGebert/ponytail`, `JuliusBrussee/caveman`).
- `SubagentStart` hook in `.claude/settings.json` (project-settings event, v2.1.193+, runs
  local and cloud): injects the delegate-mode capsule into every spawned sub-agent — ponytail
  full for builders (review/verify-only delegates exempt), caveman full for every report with
  the verbatim-evidence rule. Replaces the CLAUDE.md brief-line propagation requirement;
  the CLAUDE.md bullet shrinks to naming the hook as the mechanism.
- `.markdownlint-cli2.jsonc` ignores the vendored trees (upstream content, not maintained docs).

## 2. `scripts/update-vendored-skills.py` — periodic refresh

Reads `enabledPlugins` + `extraKnownMarketplaces` from `.claude/settings.json`, shallow-clones
each GitHub-sourced upstream, copies the plugin's core skill dir + LICENSE, and writes an
`UPSTREAM` provenance line (repo @ commit, date). Refresh = run script, commit diff. This PR's
vendored files are the script's own output against live upstreams
(caveman @ 0d95a81d, ponytail @ 1b2760d3).

Pinned by `tests/test_update_vendored_skills.py` against `file://` fixture upstreams:
byte-identical copy + provenance, stale-file replacement, idempotent re-run,
disabled-plugin/directory-source skips, loud failure on a missing skill dir or empty plugin
set. Red→green executed (script absent at HEAD~1 → collection error; restored → 6 passed).

Gates: pytest 2265 passed, ruff + format clean, mypy clean, markdownlint clean, settings.json
JSON-valid, SubagentStart hook envelope verified (`sh -c <command> | json parse`, capsule
1001 chars < 10k limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Ponytail” and ultra-compressed “Caveman” response modes with intensity levels and persistent session behavior.
  * Added mode commands (activate/deactivate) and a visual status badge; Caveman also includes session/lifetime stats.
  * Automatically propagates active modes to spawned sub-agents.
* **Bug Fixes**
  * Improved delegated-response handling so selected modes are applied more consistently.
* **Documentation**
  * Added usage guides, skill specs, and bundled license/upstream reference notes for the response modes.
* **Tests**
  * Added coverage for skill refresh behavior and for the vendored hook activation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->