### PR TITLE
pfblockerng: reject reserved table names in the Advanced In/Outbound alias validator

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -998,3 +998,55 @@ in), `tests/php/V6CidrSubtractTest.php` (the pure-PHP engine, incl. the `/64 −
 before-state asserted first, plus the whole-token/mask-agnostic upgrade-parity scenarios) and the
 Alerts "+" Tier B e2e above. Per CLAUDE.md "ADR acceptance", ADR-53 moves to Accepted on the green
 CE+Plus live-VM fan-out of those cases.
+
+## Firewall-alias resolution — config reads, not pfSense alias helpers
+
+Everywhere pfBlockerNG needs a firewall alias's existence, type, members, or config index, it
+reads `config_get_path('aliases/alias', [])` (or the package resolver `pfb_alias_type()` in
+`pfblockerng.inc`) instead of pfSense's alias helpers. This is a **deliberate, audited
+decision** — do not "clean it up" back to the helpers. Evidence base: the 2026-07-07 contract
+audit, which extracted every helper body at 7 dated refs of the public mirror (CE 2.8.0
+`ed6c2eb8` 2025-05-28, Plus 25.07/25.07.1, CE 2.8.1, Plus 25.11/25.11.1, and
+master≙26.03/26.03.1 `9363ac5b` 2026-03-31) and found them **byte-identical at every ref** —
+the blockers below are structural, not version drift.
+
+**Why `get_alias_list()` cannot serve (all refs, `util.inc`):**
+
+- Returns **names only** (a `string[]`) — most of our sites need the full entry (`type`,
+  `address`, `detail`), the config array **index** (the widget's `alias_info_popup($id)`), or
+  **write access** (the alias-reconcile region) — none of which a name list provides.
+- `$type` must be a **comma-separated string**; an array argument silently returns `[]`
+  (the dead-feature bug found in pfSense-pkg-haproxy — already true at CE 2.8.0, so no
+  "old ref" is safe either).
+- Merges in the **reserved system table names** and returns `null` (undefined `$result`)
+  instead of `[]` when nothing matches — `foreach` warnings on an alias-less config.
+
+**Why `alias_get_type()` / `is_alias()` cannot serve as existence checks:**
+
+- `is_alias()` consults the in-memory `$aliastable` cache that only `alias_make_table()`
+  (filter generation) populates — empty on settings pages and in cron syncs, reporting every
+  real alias missing (#636, #664).
+- `alias_get_type()` gives **reserved system table names precedence** over the configuration
+  (`get_reserved_table_names()`, matched case-insensitively). The 8 static reserved entries —
+  `bogons`/`bogonsv6` (`urltable`), `sshguard`/`snort2c`/`virusprot` (`host`),
+  `vpn_networks`/`negate_networks`/`tonatsubnets` (`network`), identical CE 2.8.0..master,
+  extensible at runtime via `add_reserved_table()` — are ALL address-bearing types, so they
+  pass any address-field validation while having **no `aliases/alias` entry**: the Advanced
+  In/Outbound rule builder (`pfblockerng.inc`, non-empty `address` required) silently drops
+  them, and `pfb_redirect_exclude_source()` would risk emitting a negated source for a pf
+  table that may not exist (`bogons` without block-bogons ⇒ whole-ruleset load failure, the
+  #664 class). Save-time validators therefore resolve via `pfb_alias_type()` (returns `NULL`
+  for anything not in the configuration — reserved names included) so a reserved name is
+  rejected at save, consistent with the autocomplete (`pfb_alias_autocomplete_lists()`, which
+  never offers reserved or `pfB_*` names).
+
+**Test-double fidelity.** The off-appliance `alias_get_type()` double
+(`tests/php/pfsense_doubles.php`) mirrors the reserved-table precedence — keep it faithful to
+upstream `util.inc`, not to what would be convenient: the config-only version it replaced is
+exactly what hid the reserved-name defect from the suite. Behaviour pinned by the reserved-name
+cases in `tests/php/AdvAliasFieldErrorsTest.php`.
+
+**Audit scope note.** The same audit hash-compared all 104 pfSense functions called from
+`src/` across those 7 refs: no call-site contract break anywhere (the 20 upstream body changes
+are internal — logging refactors, debug gates, `config_read_file`'s Plus-25.11 cache rework,
+which is inert for us because every call passes explicit `(FALSE, TRUE)`).

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1948,7 +1948,10 @@ function pfb_adv_alias_field_errors(array $post): array
 		if (empty($post[$field])) {
 			continue;
 		}
-		$alias_type = pfb_alias_type($post[$field]) ?? '';
+		// A crafted request can submit the field as an array (aliasaddr_in[]=...);
+		// pfb_alias_type() is string-typed, so a non-string would TypeError. Treat
+		// it as non-existent — same verdict the untyped resolver reached.
+		$alias_type = is_string($post[$field]) ? (pfb_alias_type($post[$field]) ?? '') : '';
 		if ($alias_type === '') {
 			$errors[] = "Settings: Advanced {$meta['dir']}bound Alias error - Must use an existing Alias";
 		} elseif (!pfb_alias_field_type_ok($field, $alias_type)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1893,7 +1893,7 @@ function pfb_alias_rename_followup(string $old_name, string $new_name): bool
  *
  * @param  string $field       One of aliasports_in, aliasports_out,
  *                             aliasaddr_in, aliasaddr_out.
- * @param  string $alias_type  The type string returned by alias_get_type().
+ * @param  string $alias_type  The alias type string (pfb_alias_type() value).
  * @return bool                TRUE when the alias type is allowed for this field.
  */
 function pfb_alias_field_type_ok(string $field, string $alias_type): bool
@@ -1918,13 +1918,18 @@ function pfb_alias_field_type_ok(string $field, string $alias_type): bool
  * Each non-empty field must name an EXISTING firewall alias whose type the field
  * accepts (port fields -> a port alias; address fields -> an address-bearing alias).
  *
- * Existence AND type are resolved from alias_get_type(), which reads the
- * 'aliases/alias' configuration directly (returning '' for an unknown name) —
- * the same source the page builds its alias dropdowns/autocomplete from. This
- * deliberately replaces is_alias(): is_alias() consults the in-memory $aliastable
- * cache, populated only by alias_make_table() during filter generation, so on the
- * category-edit page that cache is empty and is_alias() reports every existing
- * alias as missing — rejecting valid aliases with "Must use an existing Alias" (#636).
+ * Existence AND type are resolved from pfb_alias_type(), which reads the
+ * 'aliases/alias' configuration directly — the same source the page builds its
+ * alias dropdowns/autocomplete from and the same resolver the DNS-redirect
+ * exception path uses. This deliberately replaces BOTH pfSense helpers:
+ *   - is_alias() consults the in-memory $aliastable cache, populated only by
+ *     alias_make_table() during filter generation, so on the category-edit page
+ *     that cache is empty and every existing alias is reported missing (#636);
+ *   - alias_get_type() gives reserved system table names (bogons, virusprot, ...)
+ *     precedence over the configuration, so a reserved name passes save-time
+ *     validation here while the rule builder (which requires an aliases/alias
+ *     entry with a non-empty address) silently ignores it — an accepted setting
+ *     that is dead at rule build. Reserved names must be rejected at save.
  *
  * @param  array $post           The submitted form ($_POST).
  * @return array<int, string>    Human-readable input-error strings (empty when valid).
@@ -1943,7 +1948,7 @@ function pfb_adv_alias_field_errors(array $post): array
 		if (empty($post[$field])) {
 			continue;
 		}
-		$alias_type = alias_get_type($post[$field]);
+		$alias_type = pfb_alias_type($post[$field]) ?? '';
 		if ($alias_type === '') {
 			$errors[] = "Settings: Advanced {$meta['dir']}bound Alias error - Must use an existing Alias";
 		} elseif (!pfb_alias_field_type_ok($field, $alias_type)) {

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1786,8 +1786,9 @@ if ($_POST) {
 		}
 
 		// Validate Adv. In/Outbound firewall rules settings (issue #676, sibling of #636).
-		// Existence + type are resolved from the configuration (alias_get_type), NOT is_alias()
-		// whose $aliastable cache is empty on this page — see pfb_adv_alias_field_errors().
+		// Existence + type are resolved from the configuration (pfb_alias_type), NOT is_alias()
+		// (empty $aliastable cache here) nor alias_get_type() (reserved system tables would
+		// wrongly pass) — see pfb_adv_alias_field_errors().
 		// Append (not array_merge): $input_errors is left unset until the first error so the
 		// later isset($input_errors) checks hold — appending auto-vivifies only on a real error.
 		foreach (pfb_adv_alias_field_errors($_POST) as $pfb_alias_error) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -601,8 +601,9 @@ if ($_POST && isset($_POST['save'])) {
 
 
 	// Validate Adv. firewall rule settings (issue #356/#636: per-field alias-type check).
-	// Existence + type are resolved from the configuration (alias_get_type), NOT is_alias()
-	// whose $aliastable cache is empty on this page — see pfb_adv_alias_field_errors().
+	// Existence + type are resolved from the configuration (pfb_alias_type), NOT is_alias()
+	// (empty $aliastable cache here) nor alias_get_type() (reserved system tables would
+	// wrongly pass) — see pfb_adv_alias_field_errors().
 	// Append (not array_merge): $input_errors is left unset until the first error so the
 	// later isset($input_errors) checks hold — appending auto-vivifies only on a real error.
 	foreach (pfb_adv_alias_field_errors($_POST) as $pfb_alias_error) {

--- a/tests/php/AdvAliasFieldErrorsTest.php
+++ b/tests/php/AdvAliasFieldErrorsTest.php
@@ -263,6 +263,18 @@ final class AdvAliasFieldErrorsTest extends TestCase
 		$this->assertStringNotContainsString('Port-type', $errors[0]);
 	}
 
+	public function testReservedNetworkTableNameInPortOutFieldIsRejectedAsMissing(): void
+	{
+		// Closes the field x reserved-type matrix: the fourth field
+		// (aliasports_out) and the third upstream reserved type ('network' —
+		// vpn_networks/negate_networks/tonatsubnets) in one row.
+		$errors = pfb_adv_alias_field_errors(['aliasports_out' => 'vpn_networks']);
+
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('Must use an existing Alias', $errors[0]);
+		$this->assertStringContainsString('Port Outbound', $errors[0]);
+	}
+
 	// -----------------------------------------------------------------------
 	// Hostile input — a crafted POST can submit a field as an ARRAY
 	// (aliasaddr_in[]=x). pfb_alias_type() is string-typed, so without a guard

--- a/tests/php/AdvAliasFieldErrorsTest.php
+++ b/tests/php/AdvAliasFieldErrorsTest.php
@@ -264,6 +264,28 @@ final class AdvAliasFieldErrorsTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
+	// Hostile input — a crafted POST can submit a field as an ARRAY
+	// (aliasaddr_in[]=x). pfb_alias_type() is string-typed, so without a guard
+	// that would throw an uncaught TypeError (fatal on save) instead of a
+	// validation message; the untyped alias_get_type() it replaced returned ''
+	// (array == string is FALSE), so the guard preserves the old verdict.
+	// -----------------------------------------------------------------------
+
+	public function testArrayFieldValueIsRejectedAsMissingNotTypeError(): void
+	{
+		// Given a crafted POST where each field arrives as an array
+		$errors = pfb_adv_alias_field_errors([
+			'aliasports_in' => ['x'],
+			'aliasaddr_in'  => ['MyHosts', 'other'],
+		]);
+
+		// Then each is rejected with the existence message — no TypeError thrown
+		$this->assertCount(2, $errors);
+		$this->assertStringContainsString('Must use an existing Alias', $errors[0]);
+		$this->assertStringContainsString('Must use an existing Alias', $errors[1]);
+	}
+
+	// -----------------------------------------------------------------------
 	// Every field is validated independently — each direction reports its own
 	// error (branch coverage across all four fields).
 	// -----------------------------------------------------------------------

--- a/tests/php/AdvAliasFieldErrorsTest.php
+++ b/tests/php/AdvAliasFieldErrorsTest.php
@@ -12,15 +12,16 @@ use PHPUnit\Framework\TestCase;
  * fields (aliasports_in / aliasports_out / aliasaddr_in / aliasaddr_out) by
  * looking each non-empty value up as a firewall alias and checking its type.
  *
- * Existence + type MUST come from alias_get_type() (config-based), NOT
- * is_alias(): is_alias() reads the in-memory $aliastable cache, which is empty
- * on the category-edit page (it is only populated during filter generation), so
- * is_alias() reports every existing alias as missing — rejecting a valid alias
- * with "Must use an existing Alias" (#636). These tests seed firewall aliases
- * into the configuration — the source the fixed check reads — and are the
- * red->green for the fix: against an is_alias()-backed implementation the
- * "existing alias is accepted" cases fail (the seeded aliases are never written
- * into $aliastable / $GLOBALS['pfb_test_aliases']).
+ * Existence + type MUST come from the config-read pfb_alias_type(), NOT from
+ * either pfSense helper: is_alias() reads the in-memory $aliastable cache, which
+ * is empty on the category-edit page (only populated during filter generation),
+ * so it reports every existing alias as missing (#636); alias_get_type() gives
+ * reserved system table names (bogons, virusprot, ...) precedence over the
+ * configuration, so it accepts names the rule builder then silently ignores.
+ * These tests seed firewall aliases into the configuration — the source the
+ * fixed check reads. Red->green: against an is_alias()-backed implementation
+ * the "existing alias is accepted" cases fail; against an alias_get_type()-
+ * backed one the "reserved table name is rejected" cases fail.
  */
 #[CoversFunction('pfb_adv_alias_field_errors')]
 final class AdvAliasFieldErrorsTest extends TestCase
@@ -209,6 +210,57 @@ final class AdvAliasFieldErrorsTest extends TestCase
 
 		// Then nothing is validated — empty means "no Advanced alias", not an error
 		$this->assertSame([], $errors);
+	}
+
+	// -----------------------------------------------------------------------
+	// pfSense reserved system table names (bogons, virusprot, ...) — rejected
+	// as non-existent. They are dynamic pf tables with NO aliases/alias config
+	// entry, so the Advanced-alias rule builder (pfblockerng.inc, non-empty
+	// 'address' required) silently ignores them: accepting one at save time
+	// yields a setting that is dead at rule build. pfSense's alias_get_type()
+	// resolves them WITH precedence (get_reserved_table_names(), identical
+	// CE 2.8.0..master), which is exactly why the validator must resolve via
+	// the config-read pfb_alias_type() instead — matching the autocomplete
+	// (which never offers reserved names) and the DNS-redirect exception path.
+	// -----------------------------------------------------------------------
+
+	public function testReservedHostTableNameInAddressFieldIsRejectedAsMissing(): void
+	{
+		// Given: a genuinely configured alias is accepted (proves the validator is
+		// live and the rejection below is specific to the reserved name).
+		$this->seedAliases(['RealHosts' => 'host']);
+		$this->assertSame([], pfb_adv_alias_field_errors(['aliasaddr_in' => 'RealHosts']),
+			'pre-condition: a configured host alias is accepted');
+
+		// When a reserved system table name (type 'host' upstream) is supplied
+		$errors = pfb_adv_alias_field_errors(['aliasaddr_in' => 'virusprot']);
+
+		// Then it is rejected as non-existent — not silently accepted and dropped
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('Must use an existing Alias', $errors[0]);
+	}
+
+	public function testReservedUrltableNameInAddressFieldIsRejectedAsMissing(): void
+	{
+		// 'bogons' is type 'urltable' upstream — address-bearing, so under
+		// alias_get_type() it passes BOTH the existence and the type check; and its
+		// pf table only exists when an interface enables block-bogons.
+		$errors = pfb_adv_alias_field_errors(['aliasaddr_out' => 'bogons']);
+
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('Must use an existing Alias', $errors[0]);
+		$this->assertStringContainsString('Source Outbound', $errors[0]);
+	}
+
+	public function testReservedTableNameInPortFieldIsRejectedAsMissing(): void
+	{
+		// In a port field a reserved name must fail the EXISTENCE check (no config
+		// entry), not the type check — pins the resolver, not just the message.
+		$errors = pfb_adv_alias_field_errors(['aliasports_in' => 'virusprot']);
+
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('Must use an existing Alias', $errors[0]);
+		$this->assertStringNotContainsString('Port-type', $errors[0]);
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/IpSettingsAdvAliasValidationTest.php
+++ b/tests/php/IpSettingsAdvAliasValidationTest.php
@@ -21,14 +21,16 @@ use PHPUnit\Framework\TestCase;
  *      for the address fields — so this step silently drops any non-existent or
  *      wrong-type value BEFORE validation.
  *   2. Advanced alias validation: pfb_adv_alias_field_errors() (#636) checks each
- *      surviving value against the configuration via alias_get_type().
+ *      surviving value against the configuration via pfb_alias_type().
  *
  * The #676 bug is in step 2: it used is_alias(), which reads the in-memory
  * $aliastable cache — never populated on this page — so every alias that SURVIVED
  * normalization (i.e. every valid, existing, correct-type alias the user picked
  * from the dropdown) was then rejected with "Must use an existing Alias". The fix
- * resolves existence from alias_get_type() (config-based) instead, so surviving
- * aliases are accepted.
+ * resolves existence from the configuration instead — today via pfb_alias_type(),
+ * which (unlike pfSense's alias_get_type()) also refuses reserved system table
+ * names — so surviving aliases are accepted. Reserved names never even reach
+ * validation here: step 1's dropdown normalization drops them first.
  *
  * Because normalization runs first, a non-existent or wrong-type value never
  * reaches validation as an error — it is reset to '' and saved empty. These tests
@@ -90,7 +92,7 @@ final class IpSettingsAdvAliasValidationTest extends TestCase
 	}
 
 	/**
-	 * Seed firewall aliases into config — the source alias_get_type() and the
+	 * Seed firewall aliases into config — the source pfb_alias_type() and the
 	 * dropdown-option builder both read.
 	 *
 	 * @param array<string, string> $typesByName  name => type ('port'/'network'/'host'/...)

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -821,11 +821,28 @@ if (!function_exists('is_alias')) {
 }
 
 if (!function_exists('alias_get_type')) {
-	// pfSense util.inc: return the 'type' of the named firewall alias from the
-	// configuration ('host'/'network'/'port'/'urltable'/...), or '' when no alias
-	// of that name exists. Config-based (reads aliases/alias via config_get_path),
-	// matching the real function — NOT the $aliastable cache that is_alias() uses.
+	// pfSense util.inc: return the 'type' of the named firewall alias, or '' when no
+	// alias of that name exists. RESERVED SYSTEM TABLE NAMES TAKE PRECEDENCE over the
+	// configuration (get_reserved_table_names(), matched case-insensitively) — the 8
+	// static entries below are byte-identical across CE 2.8.0..master (globals.inc
+	// $reserved_table_names, verified 2026-07-07; upstream can register more at runtime
+	// via add_reserved_table()). Then config-based (reads aliases/alias via
+	// config_get_path) — NOT the $aliastable cache that is_alias() uses.
 	function alias_get_type($name) {
+		$reserved = [
+			'bogons'          => 'urltable',
+			'bogonsv6'        => 'urltable',
+			'sshguard'        => 'host',
+			'snort2c'         => 'host',
+			'virusprot'       => 'host',
+			'vpn_networks'    => 'network',
+			'negate_networks' => 'network',
+			'tonatsubnets'    => 'network',
+		];
+		$lower = strtolower((string) $name);
+		if (isset($reserved[$lower])) {
+			return $reserved[$lower];
+		}
 		foreach (config_get_path('aliases/alias', []) as $a) {
 			if (($a['name'] ?? '') === (string) $name) {
 				return (string) ($a['type'] ?? '');

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -506,7 +506,7 @@ def _mk_alias(vm: helpers.SmokeVM, name: str, alias_type: str, address: str) -> 
 
     Writes a single entry to ``aliases/alias`` and calls ``write_config``.
     ``alias_type`` must be ``'port'`` or ``'network'`` (the values
-    ``alias_get_type()`` returns and the category-edit validation checks).
+    ``pfb_alias_type()`` returns and the category-edit validation checks).
     """
     row = {
         "name": name,
@@ -563,9 +563,9 @@ def test_ipv4_advanced_inout_full_save_persists_and_reloads(
         The save handler (lines 741-764) writes each advanced field via
         ``config_set_path`` only when ``$gtype == 'ipv4'``. ``autoproto_*`` /
         ``aliasports_*`` / ``aliasaddr_*`` are validated: a non-'any' protocol is
-        required when ``autoports_*`` or ``autoaddr_*`` is set (lines 604-614);
-        the alias names must pass ``is_alias()`` + ``alias_get_type() in
-        {network,port}`` (lines 593-601). We therefore create a real port alias
+        required when ``autoports_*`` or ``autoaddr_*`` is set;
+        the alias names must resolve via ``pfb_alias_type()`` to a type the
+        field accepts (``pfb_adv_alias_field_errors``). We therefore create a real port alias
         and a real network alias first, use action=Deny_Both (no Permit guard),
         and supply non-any protocols (tcp / udp).
 


### PR DESCRIPTION
## What

`pfb_adv_alias_field_errors()` (the save-time validator for the category-edit Advanced Inbound/Outbound alias fields) resolved existence + type via pfSense's `alias_get_type()`. Upstream gives **reserved system table names** precedence over the configuration (`get_reserved_table_names()`): `bogons`, `bogonsv6` (`urltable`), `sshguard`, `snort2c`, `virusprot` (`host`), `vpn_networks`, `negate_networks`, `tonatsubnets` (`network`) — verified byte-identical at CE 2.8.0, 2.8.1, Plus 25.07–26.03.1, and master. All 8 are address-bearing types, so a reserved name passed both the existence and the type check — while the Advanced-alias rule builder (`pfblockerng.inc`, requires an `aliases/alias` entry with non-empty `address`) silently ignores it. Net effect: a save-accepted setting that is dead at rule build, with no error or log.

This PR switches the validator to the config-read `pfb_alias_type()`, so reserved names are rejected at save time ("Must use an existing Alias") — consistent with the Advanced-field autocomplete (which never offers reserved names) and the DNS-redirect/DoT exception-alias path (already on `pfb_alias_type()`).

Loosening the rule builder instead was rejected: an emitted rule referencing `bogons` with block-bogons disabled everywhere would name a nonexistent pf table and fail the **whole ruleset load** (the #664 failure class `pfb_redirect_exclude_source()` exists to prevent).

## Test-double fidelity

The off-appliance `alias_get_type()` double (`tests/php/pfsense_doubles.php`) was config-only — missing the reserved-table precedence — which is exactly why the PHPUnit suite could not see this defect. The double now mirrors upstream `util.inc` (reserved precedence, case-insensitive, list cited to the audited refs).

## Red → green (executed)

New tests on the pre-change validator (with the faithful double):

```text
FFF                                                                 3 / 3 (100%)
1) testReservedHostTableNameInAddressFieldIsRejectedAsMissing
   Failed asserting that actual size 0 matches expected size 1.
2) testReservedUrltableNameInAddressFieldIsRejectedAsMissing
   Failed asserting that actual size 0 matches expected size 1.
3) testReservedTableNameInPortFieldIsRejectedAsMissing
   Failed asserting that '... Must use a Port-type alias' contains "Must use an existing Alias".
```

(1–2 prove the silent accept; 3 proves `alias_get_type()` resolved `virusprot` as an existing `host` alias.) After the swap: `OK (15 tests, 31 assertions)`; re-proved mechanically post-commit via `git checkout HEAD~1 -- <src>` → 3 failures → restore → green.

## Gates

- `php -l` on all 5 touched PHP files: clean
- `vendor/bin/phpunit`: 2355 tests OK (4 pre-existing skips)
- `vendor/bin/phpstan --memory-limit=1G`: no errors
- `vendor/bin/phpcs -d memory_limit=1G`: exit 0
- `npx markdownlint-cli2`: 0 errors

`www/` diff is comment-only (stale-comment reconciliation; both pages have existing Tier-A render + Tier-B browser coverage — no observable UI change).

## Docs

New `docs/misc/architecture-notes.md` section "Firewall-alias resolution — config reads, not pfSense alias helpers": the audited rationale for why `get_alias_list()` / `alias_get_type()` / `is_alias()` cannot replace our config reads (names-only return, silent `[]` on array `$type`, reserved-table injection, `null`-instead-of-`[]` wart, `$aliastable` cache emptiness), plus the double-fidelity rule.

Found by the 2026-07-07 pfSense API contract-drift audit (both directions, CE 2.8.0 floor → master; zero call-site contract breaks found — this validator/rule-build inconsistency was the audit's one bug-shaped finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ooLjvBBm6oznTBUg9mxVF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of advanced firewall alias fields so reserved system names are no longer accepted as valid aliases.
  * Fixed cases where alias checks could fail or pass incorrectly when cached data was unavailable.
  * Normalized missing alias-type results to avoid inconsistent validation behavior.

* **Documentation**
  * Updated architecture notes and inline guidance to reflect the current alias-validation approach.

* **Tests**
  * Added coverage for reserved-name and missing-alias scenarios across address and port fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->