### PR TITLE
ci: enforce src/tests and www/ui-tests coverage pairing as a PR gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -573,6 +573,44 @@ jobs:
       scope: full
     secrets: inherit
 
+  # ── Coverage-pairing gate (issue #921) ───────────────────────────────────
+  # PR-only: diffs the PR head against its base and enforces src<->tests and
+  # www<->ui-tests pairing (scripts/check_coverage_pairing.py). On push (post-
+  # merge, no PR base) it is skipped and folds into all-tests-passed as a pass,
+  # same shape as the ui-suite label fold below.
+  coverage-pairing:
+    name: Coverage pairing (src/tests + www/ui)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need the merge-base with the PR base ref for the three-dot diff
+
+      - name: Compute changed files vs base
+        env:
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -eu
+          git fetch --no-tags origin "$BASE:refs/remotes/origin/$BASE"
+          git diff --name-only "origin/$BASE...HEAD" > changed.txt
+          echo "Changed files vs origin/$BASE:"; cat changed.txt
+
+      - name: Enforce src<->tests and www<->ui coverage pairing
+        # ubuntu-latest ships python3. --warn-only downgrades a violation to a
+        # visible warning when the PR carries the no-test-needed label.
+        # `pipefail` is REQUIRED here: a step with no `shell:` keyword runs under
+        # `bash -e {0}` (the default template — NOT `-o pipefail`), so without it
+        # the tee's exit 0 would mask the script's exit 1 and this gate would
+        # silently always pass. Setting it explicitly makes the exit code of the
+        # script (not tee) decide the job result.
+        env:
+          WARN_ONLY: ${{ contains(github.event.pull_request.labels.*.name, 'no-test-needed') && '1' || '' }}
+        run: |
+          set -euo pipefail
+          python3 scripts/check_coverage_pairing.py ${WARN_ONLY:+--warn-only} < changed.txt | tee -a "$GITHUB_STEP_SUMMARY"
+
   # Single stable job name for branch-protection required-status-checks.
   # Must use if: always() so it runs (and fails) even when 'test' fails.
   all-tests-passed:
@@ -584,7 +622,7 @@ jobs:
     # The ADR-14 UI suite (`ui-suite`) IS folded in: it is skipped (== pass) on an
     # unlabeled PR / push, and only a `ui-tests`-labeled PR whose UI suite FAILS
     # blocks here — that is how the opt-in label gates a merge.
-    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, ui-suite]
+    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, ui-suite, coverage-pairing]
     runs-on: ubuntu-latest
     steps:
       - name: Check matrix results
@@ -643,4 +681,12 @@ jobs:
           case "${{ needs.ui-suite.result }}" in
             success|skipped) ;;
             *) echo "Labeled UI suite (ui-tests) failed or was cancelled."; exit 1 ;;
+          esac
+          # Coverage-pairing gate (issue #921): 'skipped' (push, no PR base) is a
+          # PASS; a PR whose src<->tests / www<->ui-tests pairing actually FAILED
+          # (or was cancelled) blocks the merge, unless the no-test-needed label
+          # already downgraded it to a warning (job still reports success).
+          case "${{ needs.coverage-pairing.result }}" in
+            success|skipped) ;;
+            *) echo "Coverage-pairing gate (src/tests, www/ui) failed or was cancelled."; exit 1 ;;
           esac

--- a/scripts/check_coverage_pairing.py
+++ b/scripts/check_coverage_pairing.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Gate a PR's diff for src<->tests and www<->UI-test coverage pairing.
+
+PROBLEM
+-------
+CLAUDE.md's test-coverage mandate (#2: "every change ships WITH its tests"; #4:
+"front-end changes REQUIRE front-end tests") is currently enforced only by human/
+review discipline. This script is the mechanical backstop, wired as a PR-only CI
+job in ``.github/workflows/test.yml`` (see the ``coverage-pairing`` job) — never
+in ``.githooks/pre-commit``, because pre-commit only ever sees ONE commit's
+staged files, not the whole PR's diff against its base; the pairing question
+("did this PR's *src* change ship *any* test?") is only answerable with the full
+PR diff, which is what the CI job computes via ``git diff --name-only
+origin/<base>...HEAD`` and pipes into this script over stdin.
+
+THE TWO RULES
+-------------
+1. Any changed ``src/**`` path (rule: "src<->tests") requires at least one
+   changed ``tests/**`` path somewhere in the diff.
+2. Any changed ``src/usr/local/www/**`` path (rule: "www<->ui") additionally
+   requires at least one changed ``tests/smoke/ui/**`` path (Tier-A UI
+   coverage, CLAUDE.md test mandate #4) — a non-UI test under ``tests/`` alone
+   does NOT satisfy this second, stricter rule.
+
+DOCS ARE NEUTRAL
+----------------
+A changed path whose basename ends in ``.md`` (any case) OR that starts with
+``docs/`` never counts toward EITHER side of either rule — it neither trips a
+requirement (a docs-only diff must not fire) nor satisfies one (a `.md` explaining
+a change is not a test). This is checked first, so a `.md` file physically living
+under ``src/`` is still neutral, not "src code with no test".
+
+ESCAPE HATCH
+------------
+The CI job downgrades a violation to a warning (exit 0, printed to
+``$GITHUB_STEP_SUMMARY``) instead of failing the PR when the PR carries the
+``no-test-needed`` label — the ``--warn-only`` CLI flag mirrors that from this
+script's side; the label itself is applied by a human, not this script.
+
+This is dev/CI-only tooling under ``scripts/`` (mirrors ``check_url_encoding.py``
+/ ``check_appliance_python.py``): it reasons over path STRINGS only, never reads
+file contents, and is intentionally NOT part of ``.githooks/pre-commit``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+_FIX_HINT = "add the paired test, or apply the `no-test-needed` label if none is warranted"
+
+
+def _is_docs(path: str) -> bool:
+    """True if ``path`` is documentation and therefore neutral to both rules."""
+    return path.lower().endswith(".md") or path == "docs" or path.startswith("docs/")
+
+
+def _is_src(path: str) -> bool:
+    """True if ``path`` is production ``src/**`` code (docs under src excluded)."""
+    return not _is_docs(path) and (path == "src" or path.startswith("src/"))
+
+
+def _is_www(path: str) -> bool:
+    """True if ``path`` is ``src/usr/local/www/**`` (not e.g. ``www-legacy/``)."""
+    return not _is_docs(path) and path.startswith("src/usr/local/www/")
+
+
+def _is_test(path: str) -> bool:
+    """True if ``path`` is under ``tests/**`` (a sibling ``othertests/`` is not)."""
+    return path == "tests" or path.startswith("tests/")
+
+
+def _is_ui_test(path: str) -> bool:
+    """True if ``path`` is under ``tests/smoke/ui/**`` (Tier-A UI coverage)."""
+    return path == "tests/smoke/ui" or path.startswith("tests/smoke/ui/")
+
+
+def evaluate(changed: list[str]) -> list[str]:
+    """Classify ``changed`` paths and return human-readable violation messages.
+
+    An empty return means the diff passes both pairing rules. Both rules are
+    independent and can both fire (up to 2 messages).
+    """
+    has_src = any(_is_src(p) for p in changed)
+    has_www = any(_is_www(p) for p in changed)
+    has_test = any(_is_test(p) for p in changed)
+    has_ui_test = any(_is_ui_test(p) for p in changed)
+
+    violations: list[str] = []
+    if has_src and not has_test:
+        violations.append(
+            "src<->tests coverage pairing violated: this PR changes `src/**` but ships no "
+            "`tests/**` change (CLAUDE.md test mandate #2: 'every change ships WITH its "
+            f"tests'). {_FIX_HINT}."
+        )
+    if has_www and not has_ui_test:
+        violations.append(
+            "www<->ui-tests coverage pairing violated: this PR changes `src/usr/local/www/**` "
+            "but ships no `tests/smoke/ui/**` change (Tier-A `ui_render` coverage, CLAUDE.md "
+            f"test mandate #4: front-end changes require front-end tests). {_FIX_HINT}."
+        )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Positional args are changed paths (used by tests); with none, changed paths
+    are read newline-separated from stdin (blank lines skipped) — how the CI
+    job pipes ``git diff --name-only`` output in.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    warn_only = "--warn-only" in args
+    paths = [a for a in args if a != "--warn-only"]
+
+    if not paths:
+        paths = [line.strip() for line in sys.stdin if line.strip()]
+
+    violations = evaluate(paths)
+
+    if not violations:
+        print("Coverage pairing OK: no src<->tests or www<->ui-tests violation.")
+        return 0
+
+    if warn_only:
+        print("WARNING (no-test-needed label): coverage pairing would otherwise FAIL this PR:")
+    else:
+        print("Coverage pairing FAILED:")
+    for msg in violations:
+        print(f"  - {msg}")
+
+    if warn_only:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_coverage_pairing.py
+++ b/scripts/check_coverage_pairing.py
@@ -105,15 +105,18 @@ def main(argv: list[str] | None = None) -> int:
     """CLI entry point.
 
     Positional args are changed paths (used by tests); with none, changed paths
-    are read newline-separated from stdin (blank lines skipped) — how the CI
-    job pipes ``git diff --name-only`` output in.
+    are read newline-separated from stdin — how the CI job pipes
+    ``git diff --name-only`` output in. Both entry points are normalized the
+    same way (surrounding whitespace stripped, blank entries dropped), so a
+    padded positional arg and a trailing-newline stdin line classify identically.
     """
     args = list(sys.argv[1:] if argv is None else argv)
     warn_only = "--warn-only" in args
     paths = [a for a in args if a != "--warn-only"]
 
     if not paths:
-        paths = [line.strip() for line in sys.stdin if line.strip()]
+        paths = list(sys.stdin)
+    paths = [p.strip() for p in paths if p.strip()]
 
     violations = evaluate(paths)
 

--- a/tests/test_coverage_pairing_check.py
+++ b/tests/test_coverage_pairing_check.py
@@ -122,3 +122,28 @@ def test_main_reads_stdin_when_no_positional_paths(monkeypatch: Any) -> None:
     # args). Blank lines must be tolerated/skipped.
     monkeypatch.setattr("sys.stdin", io.StringIO("src/x.inc\n\n"))
     assert ccp.main([]) == 1, "stdin-fed src-only path (blank line skipped) must fail the gate"
+
+
+def test_positional_args_are_whitespace_normalized() -> None:
+    # A positional path is stripped the same as a stdin line, so a padded arg is
+    # classified (not silently dropped into no category). Before-state: without
+    # the strip, the padded path matched no classifier and the gate passed.
+    assert ccp.main(["  src/x.inc  "]) == 1, "a padded src path must still fire the gate"
+    # Discriminating sibling: a padded docs path is still neutral (stays a pass).
+    assert ccp.main([" README.md "]) == 0, "a padded docs path must stay neutral"
+
+
+def test_uppercase_md_extension_is_neutral() -> None:
+    # _is_docs matches `.md` case-insensitively, so an uppercase `.MD` under src/
+    # is still docs-neutral -- paired with a firing sibling to prove discrimination.
+    assert ccp.evaluate(["src/usr/local/pkg/pfblockerng/NOTES.MD"]) == [], "an uppercase .MD is docs, neutral"
+    assert ccp.evaluate(["src/usr/local/pkg/pfblockerng/notes.inc"]) != [], "a .inc sibling is src code, fires"
+
+
+def test_bare_directory_names_hit_the_equality_branches() -> None:
+    # The `path == "src"` / `== "tests"` equality clauses exist for completeness
+    # (git never emits a bare directory from --name-only, but the branches are
+    # written and documented): a bare `src` is src code (fires, no test), and a
+    # bare `tests` satisfies rule 1's pairing.
+    assert ccp.evaluate(["src"]) != [], "bare `src` classifies as src code and fires rule 1"
+    assert ccp.evaluate(["src", "tests"]) == [], "bare `tests` satisfies the src<->tests pairing"

--- a/tests/test_coverage_pairing_check.py
+++ b/tests/test_coverage_pairing_check.py
@@ -1,0 +1,124 @@
+"""Tests for scripts/check_coverage_pairing.py.
+
+Per CLAUDE.md's test-coverage rule, every "does NOT fire" / `== []` assertion is
+paired with a sibling case that DOES fire, so a green run proves the classifier
+DISCRIMINATES (src<->tests, www<->ui-tests) rather than always/never firing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+from typing import Any
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_coverage_pairing.py"
+_spec = importlib.util.spec_from_file_location("check_coverage_pairing", _TOOL)
+assert _spec is not None and _spec.loader is not None
+ccp: Any = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = ccp
+_spec.loader.exec_module(ccp)
+
+
+def test_src_only_no_tests_fires_rule1() -> None:
+    # Scenario: a PR touches src/ but ships no tests/ change at all -> rule 1 fires.
+    violations = ccp.evaluate(["src/usr/local/pkg/pfblockerng/pfblockerng.inc"])
+    assert len(violations) == 1, f"expected exactly 1 violation (rule 1); got {violations}"
+    assert "tests/**" in violations[0], f"rule-1 message must name tests/**; got {violations[0]!r}"
+
+
+def test_src_with_paired_test_passes() -> None:
+    # Discriminating sibling of the above: adding the paired test clears rule 1.
+    violations = ccp.evaluate(["src/usr/local/pkg/pfblockerng/pfblockerng.inc", "tests/test_x.py"])
+    assert violations == [], f"src+tests pair must pass; got {violations}"
+
+
+def test_www_only_fires_both_rules() -> None:
+    # Scenario: a PR touches www/ but ships no tests/ at all -> BOTH rule 1 (no
+    # tests/**) and rule 2 (no tests/smoke/ui/**) fire.
+    violations = ccp.evaluate(["src/usr/local/www/pfblockerng_dnsbl.php"])
+    assert len(violations) == 2, f"expected both rule 1 and rule 2 to fire; got {violations}"
+
+
+def test_www_with_non_ui_test_still_fires_rule2() -> None:
+    # A non-UI test satisfies rule 1 (generic src<->tests) but NOT rule 2's
+    # stricter Tier-A UI requirement -- this is the precise Tier-A distinction.
+    violations = ccp.evaluate(["src/usr/local/www/pfblockerng_dnsbl.php", "tests/php/FooTest.php"])
+    assert len(violations) == 1, f"expected only rule 2 to still fire; got {violations}"
+    assert "tests/smoke/ui/**" in violations[0], f"must name tests/smoke/ui/**; got {violations[0]!r}"
+
+
+def test_www_with_ui_test_passes() -> None:
+    # Discriminating sibling: a paired Tier-A UI test clears rule 2 (and rule 1,
+    # since tests/smoke/ui/** is also under tests/**).
+    violations = ccp.evaluate(["src/usr/local/www/pfblockerng_dnsbl.php", "tests/smoke/ui/test_render_x.py"])
+    assert violations == [], f"www+ui-test pair must pass; got {violations}"
+
+
+def test_warn_only_flag_downgrades_to_pass() -> None:
+    # Before-state: the same src-only set FAILS (exit 1) without --warn-only.
+    path = "src/usr/local/pkg/pfblockerng/pfblockerng.inc"
+    assert ccp.main([path]) == 1, "without the label, a violation must fail the gate"
+    # --warn-only (the no-test-needed label's CI-side effect) downgrades to pass.
+    assert ccp.main(["--warn-only", path]) == 0, "--warn-only must downgrade a violation to pass"
+
+
+def test_docs_only_diff_is_neutral() -> None:
+    # A .md under src/ is still neutral (docs-under-src does not count as src code).
+    violations = ccp.evaluate(
+        [
+            "README.md",
+            "docs/misc/architecture-notes.md",
+            "src/usr/local/pkg/pfblockerng/CHANGELOG.md",
+        ]
+    )
+    assert violations == [], f"docs-only diff must never fire either rule; got {violations}"
+
+
+# ---- Hostile-input rows ---------------------------------------------------
+
+
+def test_empty_diff_passes() -> None:
+    assert ccp.evaluate([]) == []
+
+
+def test_delete_or_rename_only_src_path_still_counts_as_change() -> None:
+    # No special-casing of delete/rename-only paths: a bare path string still
+    # counts (the diff carries no change-type info to this classifier anyway).
+    violations = ccp.evaluate(["src/usr/local/pkg/pfblockerng/removed.inc"])
+    assert violations != [], "a lone changed src path (even delete/rename-only) must still fire"
+
+
+def test_www_legacy_is_not_treated_as_www() -> None:
+    # Boundary guard: "www-legacy" must not match the "src/usr/local/www/"
+    # trailing-slash boundary -- it is generic src, not the www/Tier-A surface.
+    # Paired with a plain (non-UI) test it must fully pass (rule 2 never fires).
+    violations = ccp.evaluate(["src/usr/local/www-legacy/x.php", "tests/test_x.py"])
+    assert violations == [], f"www-legacy + a plain test must pass (not treated as www); got {violations}"
+    # Discriminating sibling: alone (no test at all) it still fires rule 1 as
+    # generic src -- proving it IS classified as src, just not as www.
+    alone = ccp.evaluate(["src/usr/local/www-legacy/x.php"])
+    assert len(alone) == 1, f"www-legacy alone must fire generic rule 1 only; got {alone}"
+    assert "tests/smoke/ui/**" not in alone[0], "www-legacy must not trigger the www/Tier-A rule"
+
+
+def test_tests_helper_under_src_is_src_not_test() -> None:
+    # "tests_helper.inc" living under src/ is src code, not a test -- it must
+    # still require a paired tests/** change.
+    violations = ccp.evaluate(["src/usr/local/pkg/pfblockerng/tests_helper.inc"])
+    assert violations != [], "src/.../tests_helper.inc must still require a paired test"
+
+
+def test_sibling_othertests_dir_does_not_satisfy_test_requirement() -> None:
+    # A path under a sibling "othertests/" directory (not "tests/") must NOT
+    # satisfy the test requirement.
+    violations = ccp.evaluate(["src/x.inc", "othertests/x.py"])
+    assert violations != [], "othertests/ is not tests/ and must not satisfy rule 1"
+
+
+def test_main_reads_stdin_when_no_positional_paths(monkeypatch: Any) -> None:
+    # The workflow pipes `git diff --name-only` output via stdin (no positional
+    # args). Blank lines must be tolerated/skipped.
+    monkeypatch.setattr("sys.stdin", io.StringIO("src/x.inc\n\n"))
+    assert ccp.main([]) == 1, "stdin-fed src-only path (blank line skipped) must fail the gate"


### PR DESCRIPTION
Fixes #921.

Adds a mechanical PR gate for the two CLAUDE.md test-coverage mandates that were prose-only at the CI layer (#2 "every change ships WITH its tests"; #4 `www/` changes require Tier-A UI coverage). PR #881 shipped a `www/` behaviour change with zero UI tests and every gate passed silently — this closes that floor.

## What it does

A new PR-only `coverage-pairing` job in `.github/workflows/test.yml` diffs the PR head against its base (`git diff --name-only origin/$BASE...HEAD`) and pipes the changed-file list into a tested decision script:

- Any `src/**` change with **no** `tests/**` change → **fail** (rule 1).
- Any `src/usr/local/www/**` change with **no** `tests/smoke/ui/**` change → **fail** (rule 2, the stricter Tier-A requirement; a non-UI test satisfies rule 1 but not rule 2).
- Docs (`*.md`, `docs/**`) are **neutral** — they neither trip nor satisfy a rule, so a docs-only diff never fires even when mixed with code (a `.md` under `src/` is neutral too).
- Escape hatch: the `no-test-needed` PR label sets `--warn-only`, downgrading a violation to a visible warning in the job summary (exit 0) instead of failing the PR.

The job is folded into `all-tests-passed` with the same `skipped == pass` shape as the existing `ui-suite` label gate, so it is skipped (== pass) on push and only blocks a PR whose pairing actually failed.

## Design

- Decision logic lives in `scripts/check_coverage_pairing.py` as a pure, importable `evaluate(changed) -> list[str]` core plus a thin `main(argv)` CLI (positional args **or** stdin, `--warn-only` flag) — the house pattern of `check_url_encoding.py` / `check_appliance_python.py`. The workflow is a thin caller.
- CI-only by design (not `.githooks/pre-commit`): pre-commit only ever sees one commit's staged files, never the whole-PR diff the pairing question needs.
- Rename-only / delete-only paths are still changes — the classifier reasons over path strings and does not special-case them.

## Tests

`tests/test_coverage_pairing_check.py` — 13 tests, one per branch, each "must not fire" case paired with a firing sibling so green proves the classifier discriminates (not always/never firing): src-only (fail), src+tests (pass), www-only (both rules), www+non-ui test (rule 2 only), www+ui (pass), label-warn vs fail, docs-only neutral, plus hostile rows (empty diff, delete/rename-only, `www-legacy` boundary, `tests_helper.inc` under src, sibling `othertests/`, stdin blank-line parsing).

## Note

One correctness fix was made during review: a `run:` step with no `shell:` keyword runs under `bash -e {0}` — **without** `pipefail` (per GitHub's default-shell template). Without it, `tee`'s exit 0 would mask the script's exit 1 and the gate would silently always pass. The enforce step sets `set -euo pipefail` explicitly so the script's exit code decides the job result.