### PR TITLE
ci: harden the coverage-pairing gate — red canary, label justification, cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -628,14 +628,13 @@ jobs:
             exit 1
           fi
           # Escape-hatch justification (issue #921's "applied deliberately" constraint,
-          # enforced per #934): the no-test-needed label requires a
-          # `no-test-needed: <why>` line in the PR body; a bare label fails the gate
-          # instead of downgrading it.
-          if [ -n "$WARN_ONLY" ] && ! printf '%s\n' "$PR_BODY" | grep -qiE 'no-test-needed:[[:space:]]*[^[:space:]]'; then
-            echo "::error::the no-test-needed label is set but the PR body has no 'no-test-needed: <why>' justification line (issue #921: the label must be applied deliberately, with its justification recorded in the PR body)"
-            exit 1
-          fi
-          python3 scripts/check_coverage_pairing.py ${WARN_ONLY:+--warn-only} < changed.txt | tee -a "$GITHUB_STEP_SUMMARY"
+          # enforced per #934): with the no-test-needed label set, the PR body is
+          # handed to the script (--pr-body-file), which requires a line starting
+          # `no-test-needed: <why>` — else it FAILS instead of downgrading. The
+          # decision logic lives in the tested script, not in shell (mid-sentence
+          # mentions and blockquotes must not count; pinned by its unit tests).
+          printf '%s\n' "$PR_BODY" > pr_body.txt
+          python3 scripts/check_coverage_pairing.py ${WARN_ONLY:+--warn-only} ${WARN_ONLY:+--pr-body-file pr_body.txt} < changed.txt | tee -a "$GITHUB_STEP_SUMMARY"
 
   # Single stable job name for branch-protection required-status-checks.
   # Must use if: always() so it runs (and fails) even when 'test' fails.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,13 @@ on:
       - '.claude/skills/caveman/LICENSE'
       - '.claude/skills/caveman/UPSTREAM'
   pull_request:
-    # labeled/unlabeled so adding or removing the `ui-tests` label re-evaluates the
-    # (label-gated) UI suite gate; synchronize re-runs it on new pushes while labeled.
+    # labeled/unlabeled so adding or removing a gate label re-evaluates the
+    # label-gated jobs — TWO depend on these types: `ui-tests` (the UI suite gate)
+    # and `no-test-needed` (the coverage-pairing escape hatch, issue #921). Without
+    # them a failed coverage-pairing gate would stay failed after the label is
+    # applied: label changes trigger no run, and a manual re-run reuses the stale
+    # event payload (the label list at original event time). synchronize re-runs
+    # the gates on new pushes while labeled.
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - '**/*.md'
@@ -604,11 +609,32 @@ jobs:
         # `bash -e {0}` (the default template — NOT `-o pipefail`), so without it
         # the tee's exit 0 would mask the script's exit 1 and this gate would
         # silently always pass. Setting it explicitly makes the exit code of the
-        # script (not tee) decide the job result.
+        # script (not tee) decide the job result — and the red canary below pins
+        # that on every run (CLAUDE.md "CI-gate wiring proves its red path in-job").
+        # PR_BODY arrives via env, never inline ${{ }} in run: — script injection.
         env:
           WARN_ONLY: ${{ contains(github.event.pull_request.labels.*.name, 'no-test-needed') && '1' || '' }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
+          # Red canary: prove ON THIS RUNNER, under THIS block's shell options, that
+          # a violating input propagates exit 1 through the `| tee` pipeline before
+          # trusting the real run below. Same run: block as the enforce line, so
+          # dropping the `set` line above trips the canary instead of silencing the
+          # gate (#933's near-miss class).
+          echo "Red canary: the FAILED output below is expected; the canary passes iff it exits nonzero."
+          if echo "src/canary.inc" | python3 scripts/check_coverage_pairing.py | tee /dev/null; then
+            echo "::error::coverage-pairing red canary failed: a violating input did not propagate exit 1 through the pipe — fix this step's shell options before trusting the gate"
+            exit 1
+          fi
+          # Escape-hatch justification (issue #921's "applied deliberately" constraint,
+          # enforced per #934): the no-test-needed label requires a
+          # `no-test-needed: <why>` line in the PR body; a bare label fails the gate
+          # instead of downgrading it.
+          if [ -n "$WARN_ONLY" ] && ! printf '%s\n' "$PR_BODY" | grep -qiE 'no-test-needed:[[:space:]]*[^[:space:]]'; then
+            echo "::error::the no-test-needed label is set but the PR body has no 'no-test-needed: <why>' justification line (issue #921: the label must be applied deliberately, with its justification recorded in the PR body)"
+            exit 1
+          fi
           python3 scripts/check_coverage_pairing.py ${WARN_ONLY:+--warn-only} < changed.txt | tee -a "$GITHUB_STEP_SUMMARY"
 
   # Single stable job name for branch-protection required-status-checks.

--- a/scripts/check_coverage_pairing.py
+++ b/scripts/check_coverage_pairing.py
@@ -35,7 +35,11 @@ ESCAPE HATCH
 The CI job downgrades a violation to a warning (exit 0, printed to
 ``$GITHUB_STEP_SUMMARY``) instead of failing the PR when the PR carries the
 ``no-test-needed`` label — the ``--warn-only`` CLI flag mirrors that from this
-script's side; the label itself is applied by a human, not this script.
+script's side; the label itself is applied by a human, not this script. When the
+label is set, the CI job additionally requires a ``no-test-needed: <why>``
+justification line in the PR body (issue #921's "applied deliberately"
+constraint, enforced per #934); that check lives in the workflow, not here — it
+reads the PR body, and this script reasons over paths only.
 
 This is dev/CI-only tooling under ``scripts/`` (mirrors ``check_url_encoding.py``
 / ``check_appliance_python.py``): it reasons over path STRINGS only, never reads
@@ -51,12 +55,12 @@ _FIX_HINT = "add the paired test, or apply the `no-test-needed` label if none is
 
 def _is_docs(path: str) -> bool:
     """True if ``path`` is documentation and therefore neutral to both rules."""
-    return path.lower().endswith(".md") or path == "docs" or path.startswith("docs/")
+    return path.lower().endswith(".md") or path.startswith("docs/")
 
 
 def _is_src(path: str) -> bool:
     """True if ``path`` is production ``src/**`` code (docs under src excluded)."""
-    return not _is_docs(path) and (path == "src" or path.startswith("src/"))
+    return not _is_docs(path) and path.startswith("src/")
 
 
 def _is_www(path: str) -> bool:
@@ -66,12 +70,12 @@ def _is_www(path: str) -> bool:
 
 def _is_test(path: str) -> bool:
     """True if ``path`` is under ``tests/**`` (a sibling ``othertests/`` is not)."""
-    return path == "tests" or path.startswith("tests/")
+    return path.startswith("tests/")
 
 
 def _is_ui_test(path: str) -> bool:
     """True if ``path`` is under ``tests/smoke/ui/**`` (Tier-A UI coverage)."""
-    return path == "tests/smoke/ui" or path.startswith("tests/smoke/ui/")
+    return path.startswith("tests/smoke/ui/")
 
 
 def evaluate(changed: list[str]) -> list[str]:

--- a/scripts/check_coverage_pairing.py
+++ b/scripts/check_coverage_pairing.py
@@ -36,10 +36,11 @@ The CI job downgrades a violation to a warning (exit 0, printed to
 ``$GITHUB_STEP_SUMMARY``) instead of failing the PR when the PR carries the
 ``no-test-needed`` label — the ``--warn-only`` CLI flag mirrors that from this
 script's side; the label itself is applied by a human, not this script. When the
-label is set, the CI job additionally requires a ``no-test-needed: <why>``
-justification line in the PR body (issue #921's "applied deliberately"
-constraint, enforced per #934); that check lives in the workflow, not here — it
-reads the PR body, and this script reasons over paths only.
+label is set, the CI job additionally passes ``--pr-body-file`` so this script
+requires a ``no-test-needed: <why>`` justification LINE in the PR body (issue
+#921's "applied deliberately" constraint, enforced per #934) — an unjustified
+label FAILS the gate instead of downgrading it. See ``_has_justification`` for
+the exact (line-anchored) matching rules.
 
 This is dev/CI-only tooling under ``scripts/`` (mirrors ``check_url_encoding.py``
 / ``check_appliance_python.py``): it reasons over path STRINGS only, never reads
@@ -105,6 +106,24 @@ def evaluate(changed: list[str]) -> list[str]:
     return violations
 
 
+def _has_justification(body: str) -> bool:
+    """True if a LINE of ``body`` starts with ``no-test-needed:`` plus non-blank text.
+
+    Line-anchored on purpose: a mid-sentence mention of the token (prose
+    describing the feature), a blockquoted ``> no-test-needed: …``, or an
+    indented code block never counts as a justification — only a line the
+    author deliberately started with the token does. Case-insensitive;
+    ``splitlines()`` handles CRLF bodies natively. Documented accepted
+    limitation: a fenced code block whose line STARTS with the token still
+    matches (fence-stripping is not worth the complexity for this gate).
+    """
+    prefix = "no-test-needed:"
+    for line in body.splitlines():
+        if line.lower().startswith(prefix) and line[len(prefix) :].strip():
+            return True
+    return False
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point.
 
@@ -113,14 +132,40 @@ def main(argv: list[str] | None = None) -> int:
     ``git diff --name-only`` output in. Both entry points are normalized the
     same way (surrounding whitespace stripped, blank entries dropped), so a
     padded positional arg and a trailing-newline stdin line classify identically.
+
+    ``--pr-body-file <path>`` (passed by the CI job iff the ``no-test-needed``
+    label is set, alongside ``--warn-only``): the file holds the PR body; when
+    ``--warn-only`` is set and the body has no ``no-test-needed: <why>``
+    justification line, the gate FAILS (exit 1) instead of downgrading —
+    issue #921's "applied deliberately" constraint, enforced per #934. Without
+    the flag, ``--warn-only`` keeps its pure downgrade semantics.
     """
     args = list(sys.argv[1:] if argv is None else argv)
     warn_only = "--warn-only" in args
+    body_file: str | None = None
+    if "--pr-body-file" in args:
+        i = args.index("--pr-body-file")
+        if i + 1 >= len(args):
+            print("error: --pr-body-file requires a file path argument")
+            return 2
+        body_file = args[i + 1]
+        del args[i : i + 2]
     paths = [a for a in args if a != "--warn-only"]
 
     if not paths:
         paths = list(sys.stdin)
     paths = [p.strip() for p in paths if p.strip()]
+
+    if warn_only and body_file is not None:
+        with open(body_file, encoding="utf-8", errors="replace") as fh:
+            body = fh.read()
+        if not _has_justification(body):
+            print(
+                "no-test-needed label is set but the PR body has no 'no-test-needed: <why>' "
+                "justification line (issue #921: the label must be applied deliberately, with "
+                "its justification recorded in the PR body)."
+            )
+            return 1
 
     violations = evaluate(paths)
 

--- a/scripts/check_coverage_pairing.py
+++ b/scripts/check_coverage_pairing.py
@@ -143,8 +143,8 @@ def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
     warn_only = "--warn-only" in args
     body_file: str | None = None
-    if "--pr-body-file" in args:
-        i = args.index("--pr-body-file")
+    while "--pr-body-file" in args:  # strip EVERY occurrence — a leaked repeat must
+        i = args.index("--pr-body-file")  # never enter the path list; last value wins
         if i + 1 >= len(args):
             print("error: --pr-body-file requires a file path argument")
             return 2
@@ -157,8 +157,13 @@ def main(argv: list[str] | None = None) -> int:
     paths = [p.strip() for p in paths if p.strip()]
 
     if warn_only and body_file is not None:
-        with open(body_file, encoding="utf-8", errors="replace") as fh:
-            body = fh.read()
+        try:
+            # utf-8-sig: a BOM at byte 0 must not hide a justification line.
+            with open(body_file, encoding="utf-8-sig", errors="replace") as fh:
+                body = fh.read()
+        except OSError as exc:
+            print(f"error: cannot read --pr-body-file {body_file!r}: {exc}")
+            return 2
         if not _has_justification(body):
             print(
                 "no-test-needed label is set but the PR body has no 'no-test-needed: <why>' "

--- a/tests/test_coverage_pairing_check.py
+++ b/tests/test_coverage_pairing_check.py
@@ -61,7 +61,53 @@ def test_warn_only_flag_downgrades_to_pass() -> None:
     path = "src/usr/local/pkg/pfblockerng/pfblockerng.inc"
     assert ccp.main([path]) == 1, "without the label, a violation must fail the gate"
     # --warn-only (the no-test-needed label's CI-side effect) downgrades to pass.
+    # Without --pr-body-file it keeps its pure downgrade semantics (no
+    # justification requirement) — the CI job always passes both together.
     assert ccp.main(["--warn-only", path]) == 0, "--warn-only must downgrade a violation to pass"
+
+
+# ---- no-test-needed justification (--pr-body-file, issue #921 via #934) ----
+
+_SRC_ONLY = "src/usr/local/pkg/pfblockerng/pfblockerng.inc"
+
+
+def _main_with_body(tmp_path: Any, body: str) -> int:
+    # Scenario shared by the justification tests: a rule-1 violation + the
+    # no-test-needed label (--warn-only) + the PR body handed over as the CI
+    # job does. The body's justification line alone decides warn-vs-fail.
+    f = tmp_path / "pr_body.txt"
+    f.write_text(body, encoding="utf-8")
+    return ccp.main(["--warn-only", "--pr-body-file", str(f), _SRC_ONLY])
+
+
+def test_justified_body_keeps_the_warn_downgrade(tmp_path: Any) -> None:
+    # A deliberate `no-test-needed: <why>` line preserves the label's downgrade;
+    # CRLF bodies (GitHub API) and case variants are equally valid.
+    assert _main_with_body(tmp_path, "Reasons.\nno-test-needed: comment-only change") == 0
+    assert _main_with_body(tmp_path, "Reasons.\r\nNo-Test-Needed: docs move\r\n") == 0
+
+
+def test_unjustified_body_fails_hard_despite_label(tmp_path: Any) -> None:
+    # The label without a justification line FAILS the gate (issue #921's
+    # "applied deliberately" constraint) — stricter than no label at all being
+    # merely violation-driven.
+    assert _main_with_body(tmp_path, "ordinary body that never mentions the token") == 1
+    assert _main_with_body(tmp_path, "") == 1, "an empty PR body is not a justification"
+    assert _main_with_body(tmp_path, "no-test-needed:   \n") == 1, "a blank <why> is not a justification"
+
+
+def test_mentions_of_the_token_are_not_justification(tmp_path: Any) -> None:
+    # The false-positive class found in PR #936's review: the check is
+    # line-anchored, so prose ABOUT the feature, a blockquote, or an indented
+    # line never counts — only a line the author started with the token does.
+    prose = "the PR body must now contain a `no-test-needed: <why>` line"
+    assert _main_with_body(tmp_path, prose) == 1, "a mid-sentence mention must not justify"
+    assert _main_with_body(tmp_path, "> no-test-needed: quoted, not real") == 1, "a blockquote must not justify"
+    assert _main_with_body(tmp_path, "  no-test-needed: indented") == 1, "an indented line must not justify"
+
+
+def test_pr_body_file_flag_requires_a_value() -> None:
+    assert ccp.main(["--warn-only", "--pr-body-file"]) == 2, "a dangling --pr-body-file must error, not crash"
 
 
 def test_docs_only_diff_is_neutral() -> None:

--- a/tests/test_coverage_pairing_check.py
+++ b/tests/test_coverage_pairing_check.py
@@ -110,6 +110,25 @@ def test_pr_body_file_flag_requires_a_value() -> None:
     assert ccp.main(["--warn-only", "--pr-body-file"]) == 2, "a dangling --pr-body-file must error, not crash"
 
 
+def test_pr_body_file_hostile_cli_shapes(tmp_path: Any) -> None:
+    # Hostile CLI rows from PR #936's fix-delta review (all unreachable via the
+    # CI wiring, pinned so a refactor cannot regress them into reachability):
+    justified = tmp_path / "b.txt"
+    justified.write_text("no-test-needed: why", encoding="utf-8")
+    # A missing body file is a clean rc-2 error, never a traceback.
+    assert ccp.main(["--warn-only", "--pr-body-file", str(tmp_path / "absent.txt"), _SRC_ONLY]) == 2
+    # A duplicated flag is stripped ENTIRELY (last value wins) — its value must
+    # be consumed as a (here: missing) file, never leak into the path list where
+    # a `tests/...`-shaped string would silently satisfy rule 1.
+    assert (
+        ccp.main(["--warn-only", "--pr-body-file", str(justified), "--pr-body-file", "tests/leaked.py", _SRC_ONLY]) == 2
+    ), "a repeated --pr-body-file must not leak its value into the changed-path list"
+    # A UTF-8 BOM at byte 0 must not hide a justification line (utf-8-sig read).
+    bom = tmp_path / "bom.txt"
+    bom.write_text("\ufeffno-test-needed: bom-leading body", encoding="utf-8")
+    assert ccp.main(["--warn-only", "--pr-body-file", str(bom), _SRC_ONLY]) == 0
+
+
 def test_docs_only_diff_is_neutral() -> None:
     # A .md under src/ is still neutral (docs-under-src does not count as src code).
     violations = ccp.evaluate(

--- a/tests/test_coverage_pairing_check.py
+++ b/tests/test_coverage_pairing_check.py
@@ -138,12 +138,3 @@ def test_uppercase_md_extension_is_neutral() -> None:
     # is still docs-neutral -- paired with a firing sibling to prove discrimination.
     assert ccp.evaluate(["src/usr/local/pkg/pfblockerng/NOTES.MD"]) == [], "an uppercase .MD is docs, neutral"
     assert ccp.evaluate(["src/usr/local/pkg/pfblockerng/notes.inc"]) != [], "a .inc sibling is src code, fires"
-
-
-def test_bare_directory_names_hit_the_equality_branches() -> None:
-    # The `path == "src"` / `== "tests"` equality clauses exist for completeness
-    # (git never emits a bare directory from --name-only, but the branches are
-    # written and documented): a bare `src` is src code (fires, no test), and a
-    # bare `tests` satisfies rule 1's pairing.
-    assert ccp.evaluate(["src"]) != [], "bare `src` classifies as src code and fires rule 1"
-    assert ccp.evaluate(["src", "tests"]) == [], "bare `tests` satisfies the src<->tests pairing"


### PR DESCRIPTION
Fixes #934. Four hardenings of the `coverage-pairing` gate (PR #933 / issue #921), from the post-merge review.

## 1. In-job red canary

The gate's failure propagation rides shell wiring unit tests cannot cover: `python3 … | tee` only fails the job because `set -euo pipefail` is set (the default `run:` shell is `bash -e {0}` — no `pipefail`). That was verified one-off during #933; nothing pinned it. The enforce step now leads with a red canary **in the same `run:` block** (same shell options): a known-violating input (`src/canary.inc`) is fed through the identical `| tee` pipeline and must exit nonzero before the real check runs. Dropping the `set` line now trips the canary loudly instead of silencing the gate.

Executed proof (shipped block extracted verbatim from the YAML):

- With the `set` line: violating input → canary passes, real run decides (all four scenarios below).
- With the `set` line stripped (the exact #933 regression class, under `bash -e`): canary trips — `::error::coverage-pairing red canary failed …`, rc=1.

## 2. `no-test-needed` requires a justification line

Issue #921 required the label be "applied deliberately (by the maintainer or an orchestrator that records its justification in the PR body)" — that constraint was never encoded. When the label is set, the PR body must now contain a `no-test-needed: <why>` line; a bare label **fails** the gate instead of downgrading it. The body reaches the step via `env:` (never inline `${{ }}` into `run:` — script injection). Label description updated to say so.

Executed scenarios (shipped block, verbatim): label+no-justification → rc=1 with a pointed error; label+justification+src-only violation → WARNING, rc=0; no label+violation → rc=1; this PR's own diff, no label → rc=0. CRLF bodies and case variants probed.

## 3. Escape-hatch coupling documented

The label path only re-triggers the workflow because `pull_request.types` includes `labeled`/`unlabeled` — wired for `ui-tests` long before #933, and the comment named only `ui-tests`. If the types were ever trimmed, the escape hatch would die silently (label edits trigger no run; manual re-runs reuse the stale event payload). The comment now names both dependents.

## 4. Dead bare-directory equality clauses removed

`git diff --name-only` never emits a bare directory, so the four `path == "docs" | "src" | "tests" | "tests/smoke/ui"` clauses were dead code — #933's review-fix pinned only 2 of the 4, and `_is_www` never had one. All four deleted along with their pinning test, rather than completing the asymmetry.

Red proof for the deletion (executed): with the clauses removed and the pin still present, exactly `test_bare_directory_names_hit_the_equality_branches` failed and the other 15 passed — the deletion changed only the dead-branch behaviour; every git-emittable input is pinned unchanged by the surviving suite.

## Gates

`python3 -m pytest` → 2303 passed, 4 skipped · `ruff check .` clean · `ruff format --check .` clean (190 files) · `python3 -m mypy tests/` clean (79 files) · `test.yml` YAML parse OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request gate re-checking so label changes are applied correctly during reruns.
  * Strengthened coverage-pairing validation with clearer failures when required test coverage or justification is missing.
  * Added an extra safeguard to ensure invalid coverage inputs fail reliably in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->