### PR TITLE
scripts: version-literal checker — forbid hardcoded pfSense/FreeBSD version tokens outside the matrix

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -55,6 +55,7 @@ staged_py=0;  staged_has '\.py$'        && staged_py=1
 staged_md=0;  staged_has '\.md$'        && staged_md=1
 staged_php=0; staged_has '\.(php|inc)$' && staged_php=1
 staged_sh=0;  staged_has '\.sh$'        && staged_sh=1
+staged_yaml=0; staged_has '\.ya?ml$'    && staged_yaml=1
 staged_adrtxt=0; staged_has '^\.ADRs/.*\.txt$' && staged_adrtxt=1
 
 # =============================== Python (*.py) =============================== #
@@ -173,6 +174,21 @@ if [ "$staged_py" = 1 ] || [ "$staged_php" = 1 ] || [ "$staged_sh" = 1 ]; then
 		"$py_bin" scripts/check_appliance_python.py || failed 'no-appliance-python'
 	else
 		skip no-appliance-python
+	fi
+fi
+
+# --- Forbid hardcoded pfSense/FreeBSD version tokens in value positions (CE 2.8,
+#     FreeBSD:15, py311, ...): they must be read from the ci-metadata matrix at
+#     runtime, not restated as literals that silently drift when the matrix moves.
+#     Relevant to any scan-root language (src/scripts/.github/workflows carry
+#     py/php/sh/yaml). Scans the whole tracked set; escape a real one-off inline
+#     with `# version-literal-ok: <reason>`. ---
+if [ "$staged_py" = 1 ] || [ "$staged_php" = 1 ] || [ "$staged_sh" = 1 ] || [ "$staged_yaml" = 1 ]; then
+	if [ -n "$py_bin" ]; then
+		step 'version-literals (no hardcoded version tokens)'
+		"$py_bin" scripts/check_version_literals.py || failed 'version-literals'
+	else
+		skip version-literals
 	fi
 fi
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -43,7 +43,7 @@ on:
       pfsense_ce_version:
         description: "Target pfSense CE floating tag to publish (e.g. 2.8)"
         required: true
-        default: "2.8"
+        default: "2.8"  # version-literal-ok: dispatch fallback default; the CE floating tag to publish
       base_source:
         description: "Base source: 'upgrade' (boot a prior tag + pfSense-upgrade in place) or 'seed' (re-verify an existing maintainer seed; seeds are created off-runner via image-publish.sh)"
         required: true

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -39,11 +39,11 @@ on:
       abi:
         description: "Target ABI — FreeBSD:<freebsd_major>:<arch> for the target pfSense base, per the ci-metadata version matrix"
         required: false
-        default: "FreeBSD:15:amd64"
+        default: "FreeBSD:15:amd64"  # version-literal-ok: dispatch/caller fallback default; the fan-out passes the matrix value
       py_flavor:
         description: "Python flavor for dep names (the matrix entry's py_flavor)"
         required: false
-        default: "py311"
+        default: "py311"  # version-literal-ok: dispatch/caller fallback default; the fan-out passes the matrix value
       php_version:
         description: "PHP version for dep names (the matrix entry's php_version)"
         required: false
@@ -69,11 +69,11 @@ on:
       abi:
         required: false
         type: string
-        default: "FreeBSD:15:amd64"
+        default: "FreeBSD:15:amd64"  # version-literal-ok: dispatch/caller fallback default; the fan-out passes the matrix value
       py_flavor:
         required: false
         type: string
-        default: "py311"
+        default: "py311"  # version-literal-ok: dispatch/caller fallback default; the fan-out passes the matrix value
       php_version:
         required: false
         type: string

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -59,7 +59,7 @@ on:
       abi:
         description: "Target ABI for the .pkg the smoke leg installs — MUST match the image's pfSense base, per the ci-metadata version matrix. pkg add refuses a cross-major-ABI .pkg. The fan-out passes FreeBSD:<matrix.freebsd_major>:amd64."
         required: false
-        default: "FreeBSD:15:amd64"
+        default: "FreeBSD:15:amd64"  # version-literal-ok: dispatch/caller fallback default; the fan-out passes the matrix value
       php_version:
         description: "PHP version for the .pkg's dep names, per the ci-metadata version matrix. The fan-out passes matrix.php_version."
         required: false
@@ -67,7 +67,7 @@ on:
       py_flavor:
         description: "Python flavor for the .pkg's dep names, per the ci-metadata version matrix. The fan-out passes matrix.py_flavor."
         required: false
-        default: "py311"
+        default: "py311"  # version-literal-ok: dispatch/caller fallback default; the fan-out passes the matrix value
       pytest_marker:
         description: "pytest marker to select (default 'smoke'; 'repo' = the ADR-17 repository-install flow)."
         required: false
@@ -126,7 +126,7 @@ on:
         description: "Target ABI for the .pkg the smoke leg installs — MUST match the image's pfSense base, per the ci-metadata version matrix. pkg add refuses a cross-major-ABI .pkg. The fan-out passes FreeBSD:<matrix.freebsd_major>:amd64."
         required: false
         type: string
-        default: "FreeBSD:15:amd64"
+        default: "FreeBSD:15:amd64"  # version-literal-ok: dispatch/caller fallback default; the fan-out passes the matrix value
       php_version:
         description: "PHP version for the .pkg's dep names, per the ci-metadata version matrix. The fan-out passes matrix.php_version."
         required: false
@@ -136,7 +136,7 @@ on:
         description: "Python flavor for the .pkg's dep names, per the ci-metadata version matrix. The fan-out passes matrix.py_flavor."
         required: false
         type: string
-        default: "py311"
+        default: "py311"  # version-literal-ok: dispatch/caller fallback default; the fan-out passes the matrix value
       pytest_marker:
         description: "pytest marker to select (default 'smoke'; 'repo' = the ADR-17 repository-install flow)."
         required: false

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -51,7 +51,7 @@ jobs:
           set -eu
           # Sanity: the seed must have the 2.8 CE entry with FreeBSD 15 + PHP 8.3.
           ENTRY="$(printf '%s' "$BUILD_MATRIX" | jq -e '
-            .[] | select(.channel == "CE" and .pfsense_version == "2.8")
+            .[] | select(.channel == "CE" and .pfsense_version == "2.8")  # version-literal-ok: sanity pin - asserts the seed carries the expected CE entry
           ')" || {
             printf '::error::BUILD matrix is missing the expected CE 2.8 entry\n'
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,6 +247,15 @@ jobs:
         # (Unbound's embedded loader). Scans tracked src/ + tests/ (the checker's defaults).
         run: python3 scripts/check_appliance_python.py
 
+      - name: Forbid hardcoded pfSense/FreeBSD version literals
+        # supported-versions.json (origin/ci-metadata) is the single source of truth for
+        # every supported version pairing. A version token restated as a literal (CE 2.8,
+        # FreeBSD:15, py311, ...) silently drifts when the matrix moves — read it at
+        # runtime via read-version-matrix.sh instead. Scans tracked src/ + scripts/ +
+        # .github/workflows/ (the checker's defaults); escape a real one-off inline with
+        # `# version-literal-ok: <reason>`.
+        run: python3 scripts/check_version_literals.py
+
   shell-tests:
     name: shellspec (POSIX sh)
     runs-on: ubuntu-latest

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -38,7 +38,7 @@ on:
         default: "false"
       target_version:
         description: >
-          Restrict reactions to a specific pfsense_version (e.g. "2.8").
+          Restrict reactions to a specific pfsense_version (e.g. 2.8).
           Leave empty to react to all matrix entries.
         required: false
         default: ""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,6 +425,13 @@ Run linters while working; the `.githooks/pre-commit` hook blocks failing commit
 - **URL-encoding check** (`scripts/check_url_encoding.py`, pre-commit + CI): forbids naked
   shell-var interpolation into an HTTP-client URL query — let the value ride
   `curl --data-urlencode` instead.
+- **Version-literal check** (`scripts/check_version_literals.py`, pre-commit + CI): forbids
+  hardcoding a supported pfSense/FreeBSD version token (CE/Plus version, `FreeBSD:NN` ABI,
+  `php8x`/`py31x` flavor, `ce-`/`plus-` varver) as a **value** — an exact quoted literal or a
+  bare `key=value`/`key: value` RHS — anywhere under `src/`/`scripts/`/`.github/workflows/`.
+  Read it from the ci-metadata matrix (`read-version-matrix.sh`) at runtime instead of
+  restating it (a literal silently drifts when the matrix moves). Prose, comments, and Python
+  docstrings stay clean; escape a genuine one-off with an inline `# version-literal-ok: <reason>`.
 - **Markdown:** `npx markdownlint-cli2` (`--fix` to autofix). Blank line around every
   heading/list/fence; a language on every fence (`text` for plain output); single trailing
   newline. Rules + rationale in `.markdownlint.jsonc`; clean lint enforced pre-commit + CI.

--- a/scripts/build-leg.sh
+++ b/scripts/build-leg.sh
@@ -61,8 +61,8 @@ pfb_scrub_git_env
 PORTS_REPO='pfBlockerNG/FreeBSD-ports'
 PORTS_REF='pfblockerng/use-github'
 CHANNEL='devel'
-ABI='FreeBSD:15:amd64'
-PYFLAVOR='py311'
+ABI='FreeBSD:15:amd64'  # version-literal-ok: default; overridden by --abi (CI passes the matrix ABI)
+PYFLAVOR='py311'  # version-literal-ok: default; overridden by --py-flavor (CI passes the matrix flavor)
 PHP='8.3'
 LOCAL_SRC='.'
 PKGVERSION=''

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Forbid hardcoded pfSense/FreeBSD version tokens in VALUE positions.
+
+PROBLEM
+-------
+``supported-versions.json`` on the ``origin/ci-metadata`` orphan ref is the
+single machine-readable source of truth for every supported pfSense/FreeBSD
+version pairing (CE ``2.8``/FreeBSD ``15``/``php8.3``, Plus ``26.03``/FreeBSD
+``16``/``php8.5``, both ``py311``). A script or workflow that restates one of
+those values as a literal —
+
+    _ABI="FreeBSD:15:amd64"
+    default: "py311"
+
+— silently drifts from the matrix the moment a version is added or dropped
+there (a new CE goes GA, an old one is EOL'd): the literal still "works" but
+now lies about what is actually supported. The fix is always to read the
+value from the matrix at runtime/generation time (``scripts/read-version-matrix.sh``),
+never to spell it out again.
+
+This check is PREVENTATIVE — it guards against re-introducing the footgun,
+not against a bug already shipped.
+
+SCOPE (deliberately low false-positive: VALUES only, never prose)
+-------------------------------------------------------------------
+* Scans tracked files under ``src/``, ``scripts/``, and ``.github/workflows/``
+  (production code, dev/CI tooling, and workflow YAML — everywhere a version
+  literal could plausibly be pasted).
+* Excludes: any ``*.md`` path (docs describe value *formats*, not enforce
+  them — the user chose values-only enforcement); ``scripts/misc/install_deps_*``
+  (real FreeBSD package names such as ``py311-sqlite3`` legitimately hardcode
+  a flavor there — an intentional allowlist); this file and its own test
+  (they define/contain the patterns being matched, so scanning them is
+  meaningless self-reference). ``docs/misc/pfSense_versions.md`` is outside
+  the scan roots anyway; it is named here only to document that intent.
+* A line containing the substring ``version-literal-ok`` is exempt (inline
+  escape: ``# version-literal-ok: <reason>``).
+* A ``#``-comment line, an unquoted trailing ``# ...`` comment on an
+  otherwise-real code line, and any line inside a triple-quoted
+  docstring/prose block are all exempt outright — a doc example illustrating
+  a transformation (e.g. an arrow mapping shown inside a docstring, or a
+  trailing ``# e.g. "ce-2.8"``) is prose, not a value assignment, even though
+  the quoted span alone would otherwise fullmatch a token.
+* Flags a token ONLY when it stands ALONE as a value: the entire inner text
+  of a quoted string literal (``"2.8"``, ``'py311'``), or the entire unquoted
+  right-hand side of a ``key: value`` / ``key=value`` assignment. A token
+  embedded in a longer string (prose, ``--help`` text, a comment) is NOT
+  flagged — e.g. ``help="target ABI, e.g. FreeBSD:15:amd64 (CE 2.8)"`` and
+  ``# FreeBSD:15:amd64 -> freebsd-15-amd64`` both stay clean, because the
+  token is not the ENTIRE value there.
+
+Exit status: 0 = clean, 1 = one or more violations (printed with file:line).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Each alternative is a full-value token shape (no anchors here -- anchors are
+# added once, around the whole alternation, at the two call sites below).
+_TOKEN_ALTERNATIVES = (
+    r"2\.[89]",  # CE version: 2.8 / 2.9
+    r"2[56]\.[0-9]{2}",  # Plus version: 25.NN / 26.NN
+    r"FreeBSD:1[56](?::[a-z0-9_]+)?",  # FreeBSD ABI: FreeBSD:15/:16, optional :arch
+    r"php8[0-9]",  # php flavor: php80..php89
+    r"py31[0-9]",  # py flavor: py310..py319
+    r"ce-[0-9]\.[0-9]",  # varver: ce-X.Y
+    r"plus-[0-9]{2}\.[0-9]{2}",  # varver: plus-NN.NN
+)
+
+# ponytail: a flavor token embedded in a hardcoded package name (e.g.
+# "py311-sqlite3" outside the install_deps_* allowlist) is not caught -- this
+# checker only matches a token that is the WHOLE value. Upgrade to substring
+# matching if hardcoded dependency names spread beyond the allowlisted file.
+#
+# ponytail: a quoted illustrative example inside a multi-line YAML folded/
+# literal scalar (`description: >` ... "e.g. \"2.8\"" on a continuation line)
+# is not recognised as prose -- only `#` comments and Python triple-quoted
+# docstrings are tracked. Upgrade to a YAML block-scalar tracker (indentation-
+# based, mirroring _prose_line_flags's docstring state machine) if more than
+# this one line ever needs it; today `version-literal-ok` covers it.
+_FULL_VALUE_RE = re.compile("^(?:" + "|".join(_TOKEN_ALTERNATIVES) + ")$")
+_ASSIGNMENT_RE = re.compile(r"^\s*[\w.-]+\s*[:=]\s*(?:" + "|".join(_TOKEN_ALTERNATIVES) + r")\s*$")
+
+_QUOTED_RE = re.compile(r'"([^"]*)"|\'([^\']*)\'')
+
+# Inline per-line escape, mirroring the URL-encoding checker's convention.
+_ESCAPE = "version-literal-ok"
+
+# Tracked-tree roots where a version literal could plausibly be pasted.
+_SCAN_ROOTS = ("src", "scripts", ".github/workflows")
+
+# Self-reference: this checker and its own test define/contain the patterns.
+_EXCLUDED_SELF_NAMES = ("check_version_literals.py", "test_version_literal_check.py")
+
+# Documented for intent only -- already outside _SCAN_ROOTS, so never scanned.
+_ALSO_EXCLUDED_DOC = "docs/misc/pfSense_versions.md"
+
+
+def _is_excluded(path: Path) -> bool:
+    """True if ``path`` is out of scope for the value-literal scan."""
+    if path.suffix == ".md":
+        return True
+    if path.name in _EXCLUDED_SELF_NAMES:
+        return True
+    # scripts/misc/install_deps_*.sh: real FreeBSD package names (py311-sqlite3)
+    # legitimately hardcode a flavor -- the spec's one intentional allowlist.
+    return path.name.startswith("install_deps_")
+
+
+def _quoted_literals(line: str) -> list[str]:
+    """Return the inner text of every single- or double-quoted span on ``line``."""
+    return [m.group(1) if m.group(1) is not None else m.group(2) for m in _QUOTED_RE.finditer(line)]
+
+
+def _strip_inline_comment(line: str) -> str:
+    """Return ``line`` with any unquoted trailing ``#...`` comment removed.
+
+    A trailing ``# e.g. "ce-2.8"`` on an otherwise-real code line is a comment
+    illustrating the value, not the value itself -- same "prose" exemption as
+    a full comment line, just not confined to the start of the line. A ``#``
+    INSIDE a quoted string is left alone (rare, but real content).
+    """
+    quote: str | None = None
+    for i, ch in enumerate(line):
+        if quote is not None:
+            if ch == quote:
+                quote = None
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            continue
+        if ch == "#":
+            return line[:i]
+    return line
+
+
+def _line_has_value_literal(line: str) -> bool:
+    """True if ``line`` holds a version token standing ALONE as a value."""
+    code = _strip_inline_comment(line)
+    for literal in _quoted_literals(code):
+        if _FULL_VALUE_RE.fullmatch(literal):
+            return True
+    return bool(_ASSIGNMENT_RE.match(code))
+
+
+def _tracked_files(roots: tuple[str, ...]) -> list[Path]:
+    """Return every git-tracked, non-excluded file under the given roots."""
+    out = subprocess.run(
+        ["git", "ls-files", "-z", *roots],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [Path(p) for p in out.stdout.split("\0") if p and not _is_excluded(Path(p))]
+
+
+_TRIPLE_QUOTE_TOKENS = ('"""', "'''")
+
+
+def _prose_line_flags(lines: list[str]) -> list[bool]:
+    """Return, per line, whether it is a ``#`` comment or triple-quote-delimited prose.
+
+    Tracks triple-quote (docstring) state across the whole file: once a line
+    opens an odd number of triple-double- or triple-single-quote tokens,
+    every following line is prose until the matching token closes it. A doc
+    example line showing an arrow-mapping transformation is prose, not a real
+    assignment, even though the quoted span alone would otherwise fullmatch a
+    token -- this is a line-level heuristic (no real tokenizer), sufficient to
+    keep documentation/example content out of the value-position scan.
+    """
+    flags: list[bool] = []
+    open_token = ""
+    for line in lines:
+        if open_token:
+            flags.append(True)
+            if open_token in line:
+                open_token = ""
+            continue
+        if line.lstrip().startswith("#"):
+            flags.append(True)
+            continue
+        prose = False
+        for token in _TRIPLE_QUOTE_TOKENS:
+            count = line.count(token)
+            if count:
+                prose = True
+                if count % 2 == 1:
+                    open_token = token
+                break
+        flags.append(prose)
+    return flags
+
+
+def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
+    """Return ``(path, lineno, line)`` for every value-position version literal."""
+    violations: list[tuple[Path, int, str]] = []
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except (OSError, UnicodeError):
+            continue
+        lines = text.splitlines()
+        for lineno, (line, is_prose) in enumerate(zip(lines, _prose_line_flags(lines), strict=True), start=1):
+            if is_prose or _ESCAPE in line:
+                continue
+            if _line_has_value_literal(line):
+                violations.append((path, lineno, line.strip()))
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    if argv:
+        paths = [p for p in (Path(a) for a in argv) if not _is_excluded(p)]
+    else:
+        paths = _tracked_files(_SCAN_ROOTS)
+    violations = find_violations(paths)
+    if not violations:
+        return 0
+    print("Hardcoded pfSense/FreeBSD version literal(s) in value position:\n", file=sys.stderr)
+    for path, lineno, line in violations:
+        print(f"  {path}:{lineno}: {line}", file=sys.stderr)
+    print(
+        "\nsupported-versions.json (origin/ci-metadata) is the single source of truth for "
+        "every supported version pairing -- read it at runtime/generation time via "
+        "scripts/read-version-matrix.sh instead of restating a value here.\n"
+        "Escape a genuine one-off with an inline `# version-literal-ok: <reason>` comment. "
+        "See CLAUDE.md and docs/misc/pfSense_versions.md.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -96,9 +96,6 @@ _SCAN_ROOTS = ("src", "scripts", ".github/workflows")
 # Self-reference: this checker and its own test define/contain the patterns.
 _EXCLUDED_SELF_NAMES = ("check_version_literals.py", "test_version_literal_check.py")
 
-# Documented for intent only -- already outside _SCAN_ROOTS, so never scanned.
-_ALSO_EXCLUDED_DOC = "docs/misc/pfSense_versions.md"
-
 
 def _is_excluded(path: Path) -> bool:
     """True if ``path`` is out of scope for the value-literal scan."""

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -27,9 +27,9 @@ SCOPE (deliberately low false-positive: VALUES only, never prose)
   (production code, dev/CI tooling, and workflow YAML — everywhere a version
   literal could plausibly be pasted).
 * Excludes: any ``*.md`` path (docs describe value *formats*, not enforce
-  them — the user chose values-only enforcement); ``scripts/misc/install_deps_*``
+  them — the user chose values-only enforcement); any ``install_deps_*`` file
   (real FreeBSD package names such as ``py311-sqlite3`` legitimately hardcode
-  a flavor there — an intentional allowlist); this file and its own test
+  a flavor there — an intentional allowlist, matched by filename); this file and its own test
   (they define/contain the patterns being matched, so scanning them is
   meaningless self-reference). ``docs/misc/pfSense_versions.md`` is outside
   the scan roots anyway; it is named here only to document that intent.
@@ -76,14 +76,27 @@ _TOKEN_ALTERNATIVES = (
 # checker only matches a token that is the WHOLE value. Upgrade to substring
 # matching if hardcoded dependency names spread beyond the allowlisted file.
 #
+# ponytail: the unquoted-RHS check (_ASSIGNMENT_RE) matches a single whole-line
+# `key: value` / `key=value` (optionally `export`/`readonly`-prefixed) only. It
+# does NOT catch a token in a compound statement (`A=x; B=y`) or an unquoted
+# YAML sequence item (`- FreeBSD:15:amd64` / `[a, b]`); none occur in the tree
+# and the spec scopes to key/value. A QUOTED token in any of these is still
+# caught by the quoted-literal path.
+#
 # ponytail: a quoted illustrative example inside a multi-line YAML folded/
 # literal scalar (`description: >` ... "e.g. \"2.8\"" on a continuation line)
 # is not recognised as prose -- only `#` comments and Python triple-quoted
-# docstrings are tracked. Upgrade to a YAML block-scalar tracker (indentation-
-# based, mirroring _prose_line_flags's docstring state machine) if more than
-# this one line ever needs it; today `version-literal-ok` covers it.
+# docstrings are tracked. The single such site today (version-tracker.yml) was
+# fixed by DE-QUOTING the example, because a `version-literal-ok` comment cannot
+# sit inside a folded-scalar body without corrupting the visible description.
+# Upgrade to a YAML block-scalar tracker (indentation-based, mirroring
+# _prose_line_flags's docstring state machine) if more than one line ever needs it.
 _FULL_VALUE_RE = re.compile("^(?:" + "|".join(_TOKEN_ALTERNATIVES) + ")$")
-_ASSIGNMENT_RE = re.compile(r"^\s*[\w.-]+\s*[:=]\s*(?:" + "|".join(_TOKEN_ALTERNATIVES) + r")\s*$")
+# Optional `export`/`readonly` prefix: an unquoted `export ABI=FreeBSD:15:amd64`
+# is a real hardcode the quoted-literal path can't see (Copilot, PR #937).
+_ASSIGNMENT_RE = re.compile(
+    r"^\s*(?:export\s+|readonly\s+)?[\w.-]+\s*[:=]\s*(?:" + "|".join(_TOKEN_ALTERNATIVES) + r")\s*$"
+)
 
 _QUOTED_RE = re.compile(r'"([^"]*)"|\'([^\']*)\'')
 
@@ -103,8 +116,9 @@ def _is_excluded(path: Path) -> bool:
         return True
     if path.name in _EXCLUDED_SELF_NAMES:
         return True
-    # scripts/misc/install_deps_*.sh: real FreeBSD package names (py311-sqlite3)
-    # legitimately hardcode a flavor -- the spec's one intentional allowlist.
+    # install_deps_* (e.g. scripts/misc/install_deps_CE_2.8.sh): real FreeBSD
+    # package names (py311-sqlite3) legitimately hardcode a flavor -- the spec's
+    # one intentional allowlist, matched by filename.
     return path.name.startswith("install_deps_")
 
 
@@ -158,16 +172,21 @@ def _tracked_files(roots: tuple[str, ...]) -> list[Path]:
 _TRIPLE_QUOTE_TOKENS = ('"""', "'''")
 
 
-def _prose_line_flags(lines: list[str]) -> list[bool]:
-    """Return, per line, whether it is a ``#`` comment or triple-quote-delimited prose.
+def _prose_line_flags(lines: list[str], is_python: bool) -> list[bool]:
+    """Return, per line, whether it is a ``#`` comment or (in a .py file) prose.
 
-    Tracks triple-quote (docstring) state across the whole file: once a line
-    opens an odd number of triple-double- or triple-single-quote tokens,
-    every following line is prose until the matching token closes it. A doc
-    example line showing an arrow-mapping transformation is prose, not a real
-    assignment, even though the quoted span alone would otherwise fullmatch a
-    token -- this is a line-level heuristic (no real tokenizer), sufficient to
-    keep documentation/example content out of the value-position scan.
+    ``#`` comment lines are prose in every scanned language (sh/yaml/py), so
+    that exemption is unconditional.
+
+    The triple-quote (docstring) state machine runs ONLY for Python sources
+    (``is_python``): once a line opens an odd number of triple-double- or
+    triple-single-quote tokens, every following line is prose until the matching
+    token closes it, so a docstring example (an arrow-mapping transformation)
+    stays out of the value scan. It is deliberately NOT applied to shell/YAML:
+    a shell value wrapped in triple quotes is valid POSIX adjacent-quote
+    concatenation that evaluates to the exact inner literal, so treating such a
+    line as prose outside .py would let a hardcoded token bypass the gate
+    entirely (PR #937).
     """
     flags: list[bool] = []
     open_token = ""
@@ -181,13 +200,14 @@ def _prose_line_flags(lines: list[str]) -> list[bool]:
             flags.append(True)
             continue
         prose = False
-        for token in _TRIPLE_QUOTE_TOKENS:
-            count = line.count(token)
-            if count:
-                prose = True
-                if count % 2 == 1:
-                    open_token = token
-                break
+        if is_python:
+            for token in _TRIPLE_QUOTE_TOKENS:
+                count = line.count(token)
+                if count:
+                    prose = True
+                    if count % 2 == 1:
+                        open_token = token
+                    break
         flags.append(prose)
     return flags
 
@@ -201,7 +221,8 @@ def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
         except (OSError, UnicodeError):
             continue
         lines = text.splitlines()
-        for lineno, (line, is_prose) in enumerate(zip(lines, _prose_line_flags(lines), strict=True), start=1):
+        prose_flags = _prose_line_flags(lines, path.suffix == ".py")
+        for lineno, (line, is_prose) in enumerate(zip(lines, prose_flags, strict=True), start=1):
             if is_prose or _ESCAPE in line:
                 continue
             if _line_has_value_literal(line):

--- a/scripts/install-from-repo.sh
+++ b/scripts/install-from-repo.sh
@@ -94,7 +94,7 @@ if [ -z "$PY_FLAVOR" ]; then
     # The box knows its own python: the py3xx that owns its py-sqlite3, if already present.
     PY_FLAVOR="$(ssh_t "pkg query %n 2>/dev/null | grep -E '^py3[0-9]+-sqlite3\$' | sed 's/-sqlite3//' | head -1" | tr -d '\r' || true)"
 fi
-[ -n "$PY_FLAVOR" ] || PY_FLAVOR="py311"
+[ -n "$PY_FLAVOR" ] || PY_FLAVOR="py311"  # version-literal-ok: last-resort fallback after probing the box + matrix
 echo "==> Python dep flavor for ${BOX_ABI:-unknown ABI}: ${PY_FLAVOR}"
 
 # 0b) Install the package's other RUN_DEPENDS — what `pkg install

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -71,7 +71,7 @@ export PFB_BOXES
 
 # ── Parse flags ───────────────────────────────────────────────────────────── #
 _REF="${PFB_REF:-}"
-_ABI="FreeBSD:15:amd64"
+_ABI="FreeBSD:15:amd64"  # version-literal-ok: local-dev default; overridden by --abi
 _MARKER="smoke"
 _FILTER=""
 _NO_TWO_VM=0

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -42,7 +42,7 @@ set -eu
 
 # ── Defaults ──────────────────────────────────────────────────────────────── #
 _REF=""        # resolved below (HEAD) if not given
-_ABI="FreeBSD:15:amd64"
+_ABI="FreeBSD:15:amd64"  # version-literal-ok: local-dev default; overridden by --abi
 _MARKER="smoke"
 _FILTER=""
 _NO_TWO_VM=0
@@ -131,7 +131,7 @@ case "$_freebsd_major" in
         ;;
 esac
 # ponytail: all current legs use py311; extend the case above when this changes.
-_py_flavor="py311"
+_py_flavor="py311"  # version-literal-ok: all current legs are py311 (see comment above)
 
 # ── Step 2: ports tree — bring to pfblockerng/use-github ───────────────────── #
 printf 'smoke-on-box: updating FreeBSD-ports at %s (php=%s %s)\n' \

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -238,3 +238,39 @@ def test_lookalike_tokens_not_flagged(tmp_path: Path) -> None:
     # Longer lookalikes that merely start with a real token must not fullmatch.
     assert _find(tmp_path, f'flavor: "{_PY3110_LOOKALIKE}"\n') == [], "py3110 is not py31[0-9]"
     assert _find(tmp_path, f'target: "{_FREEBSD14}"\n') == [], "FreeBSD:14 is outside 15/16"
+
+
+# --- PR #937 review follow-ups ---------------------------------------------
+
+
+def test_shell_triple_quoted_value_flagged(tmp_path: Path) -> None:
+    # F1 (blocking, PR #937): the triple-quote docstring heuristic is Python-only.
+    # In shell, `X="""tok"""` is adjacent-quote concatenation that evaluates to
+    # `tok`; treating a `"""` line as prose in a .sh/.yml file let a hardcoded
+    # token bypass the whole gate. These MUST flag (they scan as .sh via _find).
+    assert len(_find(tmp_path, f'ABI="""{_FREEBSD15}"""\n')) == 1, "shell triple-double-quoted value must flag"
+    assert len(_find(tmp_path, f"PYF='''{_PY311}'''\n")) == 1, "shell triple-single-quoted value must flag"
+
+
+def test_python_docstring_body_still_exempt(tmp_path: Path) -> None:
+    # The boundary complement of the above: inside a real .py docstring the same
+    # triple-quoted token stays prose-exempt, so F1's fix did not over-correct.
+    content = '"""\n' + f'    "{_PY311}"\n' + '"""\n'
+    f = tmp_path / "d.py"
+    f.write_text(content, encoding="utf-8")
+    assert cvl.find_violations([f]) == [], "a .py docstring body must remain prose-exempt"
+
+
+def test_export_readonly_prefixed_unquoted_assignment_flagged(tmp_path: Path) -> None:
+    # Copilot (PR #937): `export`/`readonly` prefixes slipped UNQUOTED assignments
+    # past _ASSIGNMENT_RE (the quoted form was always caught by the literal path).
+    assert len(_find(tmp_path, f"export ABI={_FREEBSD15}\n")) == 1, "export-prefixed unquoted assignment must flag"
+    assert len(_find(tmp_path, f"readonly PYF={_PY311}\n")) == 1, "readonly-prefixed unquoted assignment must flag"
+
+
+def test_flags_php_flavor_quoted_value(tmp_path: Path) -> None:
+    # F4 (PR #937): the php8[0-9] token shape had no explicit coverage-matrix row.
+    php83 = "php8" + "3"
+    php85 = "php8" + "5"
+    assert len(_find(tmp_path, f'PHPFLAVOR="{php83}"\n')) == 1, "quoted php83 flavor must flag"
+    assert len(_find(tmp_path, f'flavor: "{php85}"\n')) == 1, "quoted php85 flavor must flag"

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -1,0 +1,240 @@
+"""Tests for scripts/check_version_literals.py.
+
+Per CLAUDE.md's test-coverage rule, every flagged case is paired with the
+correct/embedded/prose form that must stay clean, so a green run proves the
+check discriminates on VALUE POSITION (a version token that stands alone as a
+whole value) rather than firing on any occurrence of a version-shaped
+substring.
+
+The bad tokens are assembled at runtime (string concatenation) so this
+tracked test file does not match its own checker's patterns, mirroring
+tests/test_appliance_python_check.py's convention -- defensive even though
+``tests/`` is not one of the checker's scan roots today.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_version_literals.py"
+_spec = importlib.util.spec_from_file_location("check_version_literals", _TOOL)
+assert _spec is not None and _spec.loader is not None
+cvl = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = cvl
+_spec.loader.exec_module(cvl)
+
+# Version tokens, assembled so no literal token appears as source text here.
+_FREEBSD15 = "FreeBSD" + ":15:amd64"
+_FREEBSD14 = "FreeBSD" + ":14"
+_FREEBSD17 = "FreeBSD" + ":17"
+_PY311 = "py3" + "11"
+_PY311_PKG = _PY311 + "-sqlite3"
+_PY3110_LOOKALIKE = _PY311 + "0"
+_CE28 = "2" + ".8"
+_PLUS2603 = "26" + ".03"
+_CE_VARVER = "ce-" + _CE28
+_PLUS_VARVER = "plus-" + _PLUS2603
+
+
+def _find(tmp_path: Path, content: str) -> list[Any]:
+    f = tmp_path / "sample.sh"
+    f.write_text(content, encoding="utf-8")
+    return cvl.find_violations([f])
+
+
+# --- Row 1: FreeBSD ABI as exact quoted value -> FLAGGED ------------------
+
+
+def test_flags_freebsd_abi_exact_quoted_value(tmp_path: Path) -> None:
+    line = f'_ABI="{_FREEBSD15}"\n'
+    violations = _find(tmp_path, line)
+    assert len(violations) == 1, f"exact quoted FreeBSD ABI must be flagged; got {violations}"
+    assert violations[0][1] == 1
+
+
+# --- Row 2: FreeBSD ABI embedded in a help/sentence string -> NOT flagged -
+
+
+def test_freebsd_abi_embedded_in_sentence_not_flagged(tmp_path: Path) -> None:
+    line = f'help="target ABI, e.g. {_FREEBSD15} (CE {_CE28}) -- see docs"\n'
+    assert _find(tmp_path, line) == [], "a token embedded in a prose sentence must stay clean"
+
+
+# --- Row 3: ABI in a `#` comment / doc arrow -> NOT flagged ----------------
+
+
+def test_freebsd_abi_in_comment_not_flagged(tmp_path: Path) -> None:
+    line = f"# {_FREEBSD15} -> freebsd-15-amd64\n"
+    assert _find(tmp_path, line) == [], "a comment restating the value must stay clean"
+
+
+# --- Row 4: py flavor exact quoted value -> FLAGGED (two syntaxes) --------
+
+
+def test_flags_py_flavor_exact_quoted_value(tmp_path: Path) -> None:
+    yaml_line = f'default: "{_PY311}"\n'
+    shell_line = f"PYFLAVOR='{_PY311}'\n"
+    assert len(_find(tmp_path, yaml_line)) == 1, "YAML quoted py flavor must be flagged"
+    assert len(_find(tmp_path, shell_line)) == 1, "shell single-quoted py flavor must be flagged"
+
+
+# --- Row 5: py flavor embedded in a package name -> NOT flagged (ceiling) -
+
+
+def test_py_flavor_embedded_in_package_name_not_flagged(tmp_path: Path) -> None:
+    # Documents the checker's known ceiling: a flavor token glued to a longer
+    # package name is not a value on its own, so it is not caught here.
+    line = f'pkg install -y "{_PY311_PKG}"\n'
+    assert _find(tmp_path, line) == [], "a flavor embedded in a package name must stay clean"
+
+
+# --- Row 6: CE "2.8" and Plus "26.03" quoted -> both FLAGGED ---------------
+
+
+def test_flags_ce_and_plus_quoted_values(tmp_path: Path) -> None:
+    assert len(_find(tmp_path, f'version: "{_CE28}"\n')) == 1, "quoted CE version must be flagged"
+    assert len(_find(tmp_path, f'version: "{_PLUS2603}"\n')) == 1, "quoted Plus version must be flagged"
+
+
+# --- Row 7: varver "ce-2.8" / "plus-26.03" quoted -> both FLAGGED ----------
+
+
+def test_flags_varver_quoted_values(tmp_path: Path) -> None:
+    assert len(_find(tmp_path, f'varver: "{_CE_VARVER}"\n')) == 1, "quoted ce-X.Y varver must be flagged"
+    assert len(_find(tmp_path, f'varver: "{_PLUS_VARVER}"\n')) == 1, "quoted plus-NN.NN varver must be flagged"
+
+
+# --- Row 8: unquoted standalone RHS -> FLAGGED (shell and YAML) -----------
+
+
+def test_flags_unquoted_standalone_rhs(tmp_path: Path) -> None:
+    shell_line = f"ABI={_FREEBSD15}\n"
+    yaml_line = f"default: {_PY311}\n"
+    assert len(_find(tmp_path, shell_line)) == 1, "unquoted shell assignment must be flagged"
+    assert len(_find(tmp_path, yaml_line)) == 1, "unquoted YAML assignment must be flagged"
+
+
+# --- Row 9: `version-literal-ok` escape suppresses an otherwise-exact hit -
+
+
+def test_escape_comment_suppresses_flag(tmp_path: Path) -> None:
+    line = f'_ABI="{_FREEBSD15}"  # version-literal-ok: pinned intentionally\n'
+    assert _find(tmp_path, line) == [], "the version-literal-ok escape must suppress the flag"
+
+
+# --- Row 10: path exclusion, Markdown -> NOT flagged (via main()) ---------
+
+
+def test_path_exclusion_markdown_not_flagged(tmp_path: Path) -> None:
+    md = tmp_path / "notes.md"
+    md.write_text(f'version: "{_CE28}"\n', encoding="utf-8")
+    assert cvl.main([str(md)]) == 0, "a .md path must be excluded even with an exact quoted token"
+
+
+# --- Row 11: path exclusion, install_deps_* -> NOT flagged (via main()) --
+
+
+def test_path_exclusion_install_deps_not_flagged(tmp_path: Path) -> None:
+    dep_file = tmp_path / "install_deps_CE_2.8.sh"
+    dep_file.write_text(f'PYFLAVOR="{_PY311}"\n', encoding="utf-8")
+    assert cvl.main([str(dep_file)]) == 0, "install_deps_* must be excluded even with an exact token"
+
+
+# --- Row 12: main() exit codes ---------------------------------------------
+
+
+def test_main_exit_codes(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.sh"
+    bad.write_text(f'_ABI="{_FREEBSD15}"\n', encoding="utf-8")
+    good = tmp_path / "good.sh"
+    good.write_text('_ABI="$ABI_FROM_MATRIX"\n', encoding="utf-8")
+    assert cvl.main([str(good)]) == 0
+    assert cvl.main([str(bad)]) == 1
+
+
+# --- Row 13: VACUITY GUARD -- version-shaped non-tokens stay clean --------
+
+
+def test_vacuity_guard_non_token_decimals_stay_clean(tmp_path: Path) -> None:
+    # python/php DOTTED forms ("3.11", "8.3") are not in the token list -- only
+    # php8x/py31x/2.8/2.9 are. FreeBSD:14/:17 are outside the supported 15/16
+    # window. If the checker discriminated on nothing but decimal shape, every
+    # one of these would (wrongly) flag.
+    assert _find(tmp_path, 'python_version: "3.11"\n') == [], '"3.11" is not a token'
+    assert _find(tmp_path, 'php_version: "8.3"\n') == [], '"8.3" is not a token'
+    assert _find(tmp_path, f'target: "{_FREEBSD14}"\n') == [], "FreeBSD:14 is outside the supported window"
+    assert _find(tmp_path, f'target: "{_FREEBSD17}"\n') == [], "FreeBSD:17 is outside the supported window"
+
+
+# --- Hostile inputs ---------------------------------------------------------
+
+
+def test_empty_file_stays_clean(tmp_path: Path) -> None:
+    assert _find(tmp_path, "") == []
+
+
+def test_blank_lines_stay_clean(tmp_path: Path) -> None:
+    assert _find(tmp_path, "\n\n\n") == []
+
+
+def test_undecodable_file_skipped_gracefully(tmp_path: Path) -> None:
+    f = tmp_path / "binary.sh"
+    f.write_bytes(b"\xff\xfe\x00\x01garbage")
+    # Must not raise; the mold's read_text(errors="replace") degrades gracefully.
+    violations = cvl.find_violations([f])
+    assert violations == []
+
+
+def test_extra_whitespace_around_quoted_value_still_flagged(tmp_path: Path) -> None:
+    line = f'default:   "{_PY311}"   \n'
+    assert len(_find(tmp_path, line)) == 1, "surrounding whitespace must not hide an exact quoted value"
+
+
+def test_two_quoted_literals_only_exact_one_flags(tmp_path: Path) -> None:
+    # The line carries one EXACT value and one token embedded in prose -- it
+    # must still flag (because of the exact one), proving the exact match is
+    # what triggers detection, not mere token presence anywhere on the line.
+    line = f'_ABI="{_FREEBSD15}"  # see also: "{_FREEBSD15} is the CE {_CE28} ABI"\n'
+    violations = _find(tmp_path, line)
+    assert len(violations) == 1, f"expected exactly one flag from the exact-value literal; got {violations}"
+
+
+def test_docstring_example_line_not_flagged(tmp_path: Path) -> None:
+    # A doc example illustrating a transformation inside a Python docstring is
+    # prose, not a value assignment, even though the quoted span alone would
+    # otherwise fullmatch a token exactly (real case from build-repo-portable.py).
+    content = (
+        "def f(v: str) -> str:\n"
+        '    """Derive the catalog name.\n'
+        "\n"
+        f'      "2.8.1"  + "CE"   -> "{_CE_VARVER}"\n'
+        f'      "{_PLUS2603}"  + "Plus" -> "{_PLUS_VARVER}"\n'
+        '    """\n'
+    )
+    f = tmp_path / "sample.py"
+    f.write_text(content, encoding="utf-8")
+    assert cvl.find_violations([f]) == [], "docstring example lines must stay clean"
+
+
+def test_comment_prefixed_quoted_example_not_flagged(tmp_path: Path) -> None:
+    # A `#`-comment line with an EXACT quoted token (not just an embedded/prose
+    # token like row 3) must also stay clean -- it's documentation, not a value.
+    line = f'# pfsense_version is now the floating tag (e.g. "{_CE28}"), so...\n'
+    assert _find(tmp_path, line) == [], "a quoted example inside a comment must stay clean"
+
+
+def test_inline_trailing_comment_example_not_flagged(tmp_path: Path) -> None:
+    # A trailing `# e.g. "ce-2.8"` on an otherwise-real code line is a comment
+    # illustrating the value, not the value itself (real case from
+    # build-repo-portable.py / check-pfsense-versions.py).
+    line = f'varver = catalog_name_from_version(version, variant)  # e.g. "{_CE_VARVER}"\n'
+    assert _find(tmp_path, line) == [], "a trailing inline comment example must stay clean"
+
+
+def test_lookalike_tokens_not_flagged(tmp_path: Path) -> None:
+    # Longer lookalikes that merely start with a real token must not fullmatch.
+    assert _find(tmp_path, f'flavor: "{_PY3110_LOOKALIKE}"\n') == [], "py3110 is not py31[0-9]"
+    assert _find(tmp_path, f'target: "{_FREEBSD14}"\n') == [], "FreeBSD:14 is outside 15/16"


### PR DESCRIPTION
## What

Adds `scripts/check_version_literals.py`, a preventative pre-commit + CI policy checker (in the mold of `check_appliance_python.py`) that forbids restating supported pfSense/FreeBSD version tokens as **hardcoded literals** — they must be read from the ci-metadata matrix (`supported-versions.json` via `read-version-matrix.sh`) at runtime, so a script/workflow can't silently drift when a version is added or dropped.

Fixes #922.

## Scope — values only, deliberately low false-positive

The user chose **values-only** enforcement. The checker flags a version token (CE `2.8`/`2.9`, Plus `25.NN`/`26.NN`, `FreeBSD:15`/`16` ABI, `php8x`/`py31x` flavors, `ce-X.Y`/`plus-NN.NN` varvers) **only when it stands alone as a value** — the entire content of a quoted literal (`"py311"`, `'FreeBSD:15:amd64'`) or the whole RHS of a `key=value`/`key: value` assignment. A token embedded in prose, `--help` text, a `#` comment, or a docstring stays clean, as does a flavor inside a package name (`py311-sqlite3`).

Excluded paths: `*.md`, `scripts/misc/install_deps_*` (real FreeBSD package names), and the checker + its own test (self-reference). Inline escape: `# version-literal-ok: <reason>`.

## Wiring + seed (lands blocking)

- **`.githooks/pre-commit`**: a new `staged_yaml` class + a version-literals gate that runs when any scan-root language (py/php/sh/yaml) is staged.
- **`.github/workflows/test.yml`**: a blocking policy-check step beside the appliance-python check.
- **Seeded the 17 pre-existing value-position hits** so the tree passes clean: 15 dev-tooling / `workflow_dispatch` fallback defaults get an inline escape (the real value is passed from the matrix at runtime — verified each default is overridable); the `test-version-matrix` sanity `jq` pin is escaped (jq accepts the `#` comment — verified); the `version-tracker` help-text example is de-quoted so it reads as prose.

## Tests

`tests/test_version_literal_check.py` — 22 discriminating tests: every token shape flagged as a value; every embedded/prose/comment/docstring/package-name form kept clean; path exclusions; escape suppression; a vacuity guard (`"3.11"`, `"8.3"`, `FreeBSD:14`/`17` stay clean). Non-vacuity proven by weakening the value-position rule → 7 discriminators go red → restore → green.

## Notes

- Documented ceiling (`ponytail:` comment): a version token inside a multi-line YAML folded/literal block scalar isn't recognized as prose — only `#` comments and Python docstrings are tracked; `version-literal-ok` covers the single such site today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to catch hardcoded version values in tracked files and CI workflows.
  * Expanded workflow and script guidance for intentionally allowed version values.

* **Bug Fixes**
  * Reduced the risk of version drift by encouraging version values to be sourced dynamically.
  * Improved handling of version defaults and examples across build and smoke workflows.

* **Tests**
  * Added coverage for the new version-literal validation behavior and related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->