### PR TITLE
pfblockerng: parse bracketed IPv6 literals and strip UTF-8 BOM in DNSBL feeds

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6470,7 +6470,7 @@ function pfb_dnsbl_strip_scheme(string $line, bool $strict = FALSE): string|fals
 
 
 // Issue #938: strip a leading UTF-8 BOM (EF BB BF) -- encoding metadata, not content,
-// the same class of noise pfb_text_sanity() strips up front (line ~1054) and
+// the same class of noise pfb_text_sanity() strips up front and
 // pfb_dnsbl_is_abp_header() peels per-line (below). Left in place on a feed's first line
 // it defeats the str_starts_with($line, '#') comment check, so a BOM-led '# Title: ...'
 // header is treated as data and error-logged instead of skipped as a comment. Strips

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6469,6 +6469,38 @@ function pfb_dnsbl_strip_scheme(string $line, bool $strict = FALSE): string|fals
 }
 
 
+// Issue #938: strip a leading UTF-8 BOM (EF BB BF) -- encoding metadata, not content,
+// the same class of noise pfb_text_sanity() strips up front (line ~1054) and
+// pfb_dnsbl_is_abp_header() peels per-line (below). Left in place on a feed's first line
+// it defeats the str_starts_with($line, '#') comment check, so a BOM-led '# Title: ...'
+// header is treated as data and error-logged instead of skipped as a comment. Strips
+// exactly ONE BOM (a malformed doubled BOM keeps its second copy rather than looping).
+function pfb_dnsbl_strip_bom(string $line): string {
+	if (str_starts_with($line, "\xEF\xBB\xBF")) {
+		return substr($line, 3);
+	}
+	return $line;
+}
+
+
+// Issue #938: unwrap a bracketed IPv6 literal ('[2604:2dc0:100:4ed8::]' -> '2604:2dc0:100:4ed8::')
+// so the existing is_ipaddrv6($line) collection branch (feeding $domain_data_ip6) recognises it.
+// is_ipaddrv6() rejects the brackets outright and pfb_filter() rejects it as a domain, so today
+// every such line hits the DNSBL parse-error log on every feed update. Only a '[' ... ']' wrapper
+// around a VALID IPv6 literal is unwrapped; anything else ('[not-an-ip]', '[]', a bracketed IPv4
+// literal -- IPv4 is never bracket-legal here) is returned UNCHANGED and keeps flowing to domain
+// validation (and the parse-error log) exactly as before.
+function pfb_dnsbl_unbracket_ip6(string $line): string {
+	if (str_starts_with($line, '[') && str_ends_with($line, ']')) {
+		$inner = substr($line, 1, -1);
+		if (is_ipaddrv6($inner)) {
+			return $inner;
+		}
+	}
+	return $line;
+}
+
+
 // ADR-22: per-line scheme parse for the non-lite download path. Returns the parsed host
 // string to keep, or FALSE when strict parsing rejected the line (invalid scheme or a URL
 // path). On rejection it records the line in the DNSBL parse-error log (the established
@@ -16468,6 +16500,12 @@ function sync_package_pfblockerng($cron='') {
 													$line = str_replace('%20', '', $line);
 												}
 
+												// Issue #938: strip a UTF-8 BOM before ANY first-char
+												// classification below -- left in place it defeats the
+												// '#' comment check just below, so a BOM-led header
+												// line is treated as data and error-logged.
+												$line = pfb_dnsbl_strip_bom($line);
+
 												// Remove comment lines and special format considerations
 												if (str_starts_with($line, '#')) {
 													// Exit (hpHosts) when end of domain names found.
@@ -16718,6 +16756,11 @@ function sync_package_pfblockerng($cron='') {
 												// Remove any Port numbers at end of line (IPv6-safe:
 												// never mangle a bare IPv6 literal's trailing hextet).
 												$line = pfb_strip_trailing_port($line);
+
+												// Issue #938: unwrap a bracketed IPv6 literal (e.g. a
+												// URI-style '[2604:2dc0::]') so the is_ipaddrv6($line)
+												// collection branch below recognises it.
+												$line = pfb_dnsbl_unbracket_ip6($line);
 											}
 											$line = trim($line);
 

--- a/tests/php/PfbDnsblStripBomTest.php
+++ b/tests/php/PfbDnsblStripBomTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_strip_bom() -- issue #938.
+ *
+ * A UTF-8 BOM (EF BB BF) on a feed's first line defeats the generic DNSBL parser's
+ * str_starts_with($line, '#') comment check, so a BOM-led '# Title: ...' header line is
+ * treated as data and error-logged instead of skipped as a comment. This helper strips
+ * exactly ONE leading BOM (encoding metadata, not content) and leaves everything else --
+ * including a non-leading BOM -- untouched.
+ */
+#[CoversFunction('pfb_dnsbl_strip_bom')]
+final class PfbDnsblStripBomTest extends TestCase
+{
+	public function testBomLedCommentLineBecomesRecognisable(): void
+	{
+		// Given a BOM-prefixed '# Title: ...' header line, stripping the BOM restores
+		// the '#'-prefix the comment check needs.
+		$this->assertSame('# Title: x', pfb_dnsbl_strip_bom("\xEF\xBB\xBF# Title: x"));
+	}
+
+	public function testBomLedDataLineIsStripped(): void
+	{
+		$this->assertSame('example.com', pfb_dnsbl_strip_bom("\xEF\xBB\xBFexample.com"));
+	}
+
+	public function testBareBomBecomesEmptyString(): void
+	{
+		$this->assertSame('', pfb_dnsbl_strip_bom("\xEF\xBB\xBF"));
+	}
+
+	public function testNoBomLeavesLineUnchanged(): void
+	{
+		$this->assertSame('example.com', pfb_dnsbl_strip_bom('example.com'));
+	}
+
+	public function testDoubleBomStripsExactlyOne(): void
+	{
+		// Pins the exactly-once contract: a malformed doubled BOM keeps its second
+		// copy rather than the helper looping to strip every leading BOM.
+		$this->assertSame("\xEF\xBB\xBFexample.com", pfb_dnsbl_strip_bom("\xEF\xBB\xBF\xEF\xBB\xBFexample.com"));
+	}
+
+	public function testMidLineBomIsNeverStripped(): void
+	{
+		// A BOM that is not at position 0 is content, not encoding metadata -- leave
+		// the line unchanged.
+		$line = "exam\xEF\xBB\xBFple.com";
+		$this->assertSame($line, pfb_dnsbl_strip_bom($line));
+	}
+}

--- a/tests/php/PfbDnsblUnbracketIp6Test.php
+++ b/tests/php/PfbDnsblUnbracketIp6Test.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_unbracket_ip6() -- issue #938.
+ *
+ * After scheme/port stripping, a bracketed IPv6 literal ('[2604:2dc0:100:4ed8::]') is never
+ * recognised: is_ipaddrv6() rejects the brackets, pfb_filter() rejects it as a domain, and
+ * every such line hits the DNSBL parse-error log on every feed update. This helper unwraps a
+ * '[' ... ']' pair around a VALID IPv6 literal to the bare literal so the existing
+ * is_ipaddrv6($line) collection branch picks it up; anything else stays unchanged and keeps
+ * flowing to domain validation exactly as before.
+ */
+#[CoversFunction('pfb_dnsbl_unbracket_ip6')]
+final class PfbDnsblUnbracketIp6Test extends TestCase
+{
+	public function testBracketedIp6Unwrapped(): void
+	{
+		$this->assertSame('2604:2dc0:100:4ed8::', pfb_dnsbl_unbracket_ip6('[2604:2dc0:100:4ed8::]'));
+	}
+
+	public function testBracketedFullIp6Unwrapped(): void
+	{
+		$this->assertSame(
+			'2600:3c06::f03c:95ff:fed9:ce5e',
+			pfb_dnsbl_unbracket_ip6('[2600:3c06::f03c:95ff:fed9:ce5e]')
+		);
+	}
+
+	public function testBracketedLoopbackUnwrapped(): void
+	{
+		$this->assertSame('::1', pfb_dnsbl_unbracket_ip6('[::1]'));
+	}
+
+	public function testBracketedUnspecifiedUnwrapped(): void
+	{
+		$this->assertSame('::', pfb_dnsbl_unbracket_ip6('[::]'));
+	}
+
+	public function testBracketedNonIpUnchanged(): void
+	{
+		$this->assertSame('[not:an:ip]', pfb_dnsbl_unbracket_ip6('[not:an:ip]'));
+	}
+
+	public function testEmptyBracketsUnchanged(): void
+	{
+		$this->assertSame('[]', pfb_dnsbl_unbracket_ip6('[]'));
+	}
+
+	public function testBracketedIp4Unchanged(): void
+	{
+		// IPv4 is never bracket-legal in this feed grammar -- leave it for domain
+		// validation (and the parse-error log) to reject exactly as before.
+		$this->assertSame('[1.2.3.4]', pfb_dnsbl_unbracket_ip6('[1.2.3.4]'));
+	}
+
+	public function testUnclosedBracketUnchanged(): void
+	{
+		$this->assertSame('[2604::', pfb_dnsbl_unbracket_ip6('[2604::'));
+	}
+
+	public function testBareLiteralWithoutBracketsUnchanged(): void
+	{
+		// Already-bare literals aren't this helper's job -- the is_ipaddrv6($line)
+		// collection branch downstream handles them directly.
+		$this->assertSame('2604::', pfb_dnsbl_unbracket_ip6('2604::'));
+	}
+
+	public function testDoubleBracketedUnchanged(): void
+	{
+		// Outer brackets peel to the inner '[::]', which is NOT a valid IPv6 literal
+		// (brackets aren't part of the address grammar) -- unchanged.
+		$this->assertSame('[[::]]', pfb_dnsbl_unbracket_ip6('[[::]]'));
+	}
+
+	public function testPortSuffixedLineUnchangedByThisHelperAlone(): void
+	{
+		// The trailing ':443' means the line does not END with ']', so this helper
+		// alone leaves it untouched -- port stripping happens upstream at the call site.
+		$this->assertSame('[2604:2dc0::]:443', pfb_dnsbl_unbracket_ip6('[2604:2dc0::]:443'));
+	}
+
+	public function testComposedWithPortStripPinsCallSiteOrdering(): void
+	{
+		// Pins the production call-site order (pfb_strip_trailing_port() THEN
+		// pfb_dnsbl_unbracket_ip6()): the port is stripped first, exposing the closing
+		// ']' so the bracket unwrap can then fire.
+		$this->assertSame(
+			'2604:2dc0::',
+			pfb_dnsbl_unbracket_ip6(pfb_strip_trailing_port('[2604:2dc0::]:443'))
+		);
+	}
+
+	public function testZoneIdLiteralFollowsIsIpaddrv6Verbatim(): void
+	{
+		// Observed truth (run, not guessed): the pfSense is_ipaddrv6() double treats
+		// 'fe80::1%em0' as a valid link-local literal (zone-id retained in the address
+		// grammar for link-local addresses), so the bracket wrapper unwraps it verbatim
+		// -- the helper never itself strips the zone id, it only defers to is_ipaddrv6().
+		$this->assertTrue(is_ipaddrv6('fe80::1%em0'));
+		$this->assertSame('fe80::1%em0', pfb_dnsbl_unbracket_ip6('[fe80::1%em0]'));
+	}
+}

--- a/tests/php/PfbDnsblUnbracketIp6Test.php
+++ b/tests/php/PfbDnsblUnbracketIp6Test.php
@@ -97,10 +97,11 @@ final class PfbDnsblUnbracketIp6Test extends TestCase
 
 	public function testZoneIdLiteralFollowsIsIpaddrv6Verbatim(): void
 	{
-		// Observed truth (run, not guessed): the pfSense is_ipaddrv6() double treats
-		// 'fe80::1%em0' as a valid link-local literal (zone-id retained in the address
-		// grammar for link-local addresses), so the bracket wrapper unwraps it verbatim
-		// -- the helper never itself strips the zone id, it only defers to is_ipaddrv6().
+		// Observed truth (run, not guessed): the pfSense is_ipaddrv6() double accepts
+		// 'fe80::1%em0' -- for a link-local literal it strips the '%zone' suffix during
+		// validation (see pfsense_doubles.php) -- and the bracket wrapper unwraps the
+		// ORIGINAL literal verbatim, zone id included: the helper never itself strips
+		// the zone id, it only defers to is_ipaddrv6() for validity.
 		$this->assertTrue(is_ipaddrv6('fe80::1%em0'));
 		$this->assertSame('fe80::1%em0', pfb_dnsbl_unbracket_ip6('[fe80::1%em0]'));
 	}


### PR DESCRIPTION
Fixes #938.

Two generic-parser (non-ABP) DNSBL gaps that spam `dnsbl_parsed_error.log` on every update of common feeds (StevenBlack, Dandelion Sprout's Anti-Malware list):

1. **Bracketed IPv6 literals** (`://[2604:2dc0:100:4ed8::]`) survive scheme/port stripping unrecognised — `is_ipaddrv6()` rejects the brackets, the domain filter rejects the remainder, and the line is error-logged instead of feeding the existing DNSBL-IP v6 extraction. New `pfb_dnsbl_unbracket_ip6()` unwraps a `[`…`]` pair **only when the inner text is a valid IPv6 literal**; everything else (`[not:an:ip]`, `[]`, bracketed IPv4) flows to domain validation and the parse-error log exactly as before.
2. **A UTF-8 BOM** on a feed's first line defeats the `#` comment check, so a BOM-led `# Title: …` header is error-logged on every update. New `pfb_dnsbl_strip_bom()` strips exactly one leading BOM before first-char classification (same class of handling as `pfb_text_sanity()` and `pfb_dnsbl_is_abp_header()`).

Both helpers sit beside `pfb_dnsbl_strip_scheme()` and follow its style. Deliberately untouched: the ABP branch (own IP handling), hosts-format extraction, ADR-22 strict-mode scheme semantics (strict still rejects the empty-scheme `://[v6]` form; lenient — the migrated default — extracts), CSV cases, `$dnsbl_skip`, and `!`-directive handling (out of scope per the issue).

Tests: `PfbDnsblStripBomTest` (6 rows) + `PfbDnsblUnbracketIp6Test` (13 rows incl. the port-strip composition pinning call-site order and the zone-id literal's probed behaviour) — 19 tests red on pre-change code (undefined function), green after; full suite 2376 passing; phpstan + phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfJUsCQkpFZxXufncGUS2f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved DNS feed line handling by automatically cleaning up leading BOM characters and recognizing bracketed IPv6 literals more reliably.
* **Bug Fixes**
  * Prevented BOM-prefixed comments and data from being misread during parsing.
  * Avoided valid bracketed IPv6 entries being treated as invalid domain data or logged as parse errors.
* **Tests**
  * Added coverage for BOM stripping and IPv6 unbracketing edge cases, including malformed inputs and special IPv6 formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->