### PR TITLE
dev: add PreToolUse Bash guard blocking agent git bypasses

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,6 +28,17 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PROJECT_DIR:-.}/scripts/claude-bash-guard.sh\""
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -16,7 +16,8 @@
 #   Rule C -- `git worktree remove` with a force flag : CLAUDE.md forbids
 #             force-removing a worktree an agent does not own.
 #
-# First matching rule wins (A, then B, then C).
+# First matching (segment, rule) pair wins: segments are scanned left to
+# right (see MATCHING below); within one segment, A, then B, then C.
 #
 # FAIL-OPEN CONTRACT: this hook must NEVER block a legitimate Bash call
 # because of a parsing failure. Empty stdin, garbled/non-JSON stdin, or no
@@ -29,22 +30,34 @@
 #
 # MATCHING: deliberately a raw-text scan, not a JSON parser (no jq / no
 # non-base dependency -- see issue #923). It reads the whole PreToolUse stdin
-# payload once, builds ONE normalized view of it ($norm, see below), and
-# every rule matches against $norm as text -- never a real shell/argv parse.
-# This is robust to garbled JSON (it just fails to match, i.e. fail-open) but
-# has TWO documented, ACCEPTED false-positive surfaces:
+# payload once, builds ONE normalized view of it ($norm, see below), splits
+# $norm into newline-separated SEGMENTS on shell command-separator
+# metacharacters (`; & | ( )`, see $segs below), and every rule matches
+# against ONE segment at a time ($seg) -- never a real shell/argv parse, and
+# never across a segment boundary. Per-segment scoping is what fixes a
+# cross-segment false positive (issue #923 review, Copilot): scanning the
+# WHOLE payload let a force flag belonging to one part of a compound command
+# "leak" into a rule for an unrelated, unforced git subcommand elsewhere in
+# the same command, e.g. `git worktree remove ../wt && git push
+# --force-with-lease` used to wrongly deny on the (unforced) worktree remove
+# because `--force` appeared ANYWHERE in the payload.
 #
-#   1. The scan runs over the WHOLE payload (JSON structure and all), not
-#      just tool_input.command, so a trigger phrase occurring ANYWHERE in the
-#      payload denies -- e.g. a commit MESSAGE that merely CONTAINS the
-#      literal text "--no-verify" (`git commit -m 'handle the --no-verify
-#      flag'`) also denies, because the guard cannot distinguish "the flag"
-#      from "prose about the flag" without a real parse.
+# This is robust to garbled JSON (it just fails to match, i.e. fail-open) but
+# has TWO documented, ACCEPTED false-positive surfaces, each now scoped to a
+# single segment rather than the whole payload:
+#
+#   1. The scan runs over a segment's full text (JSON structure and all, for
+#      whichever segment the JSON's tool_input.command value falls into), so
+#      a trigger phrase occurring ANYWHERE in that SAME segment denies --
+#      e.g. a commit MESSAGE that merely CONTAINS the literal text
+#      "--no-verify" (`git commit -m 'handle the --no-verify flag'`) also
+#      denies, because the guard cannot distinguish "the flag" from "prose
+#      about the flag" without a real parse.
 #   2. Normalization (below) strips quotes/backslashes and collapses
-#      whitespace before matching, specifically so whitespace/quoting
-#      variance in the invoking command can't evade a rule -- but it applies
-#      to the WHOLE payload, so the same phrase-anywhere caveat holds after
-#      normalization too.
+#      whitespace BEFORE splitting into segments, specifically so
+#      whitespace/quoting variance in the invoking command can't evade a
+#      rule -- but matching still runs over a segment's full text, so the
+#      same phrase-anywhere-in-segment caveat holds after normalization too.
 #
 # Erring toward blocking is the intended tradeoff in both cases.
 #
@@ -66,7 +79,9 @@
 #   2. Collapsing every run of whitespace (space/tab/newline) to one space --
 #      defeats `git  commit` (double space) or a literal tab between tokens.
 # Fail-open holds through normalization: empty/garbled input still normalizes
-# to a string with no rule match, i.e. exit 0.
+# to a string with no rule match, i.e. exit 0. $norm is then split into
+# per-segment matching units ($segs/$seg, see below) -- normalization always
+# runs on the WHOLE payload first, splitting happens second.
 #
 # Standalone `-f` (short form of --force) and a clustered short flag
 # containing `f` (`-uf`, `-fu`, ...) are matched with an explicit boundary so
@@ -81,24 +96,39 @@ payload="$(cat)"
 # space.
 norm="$(printf '%s' "$payload" | tr -d '\\"' | tr -s '[:space:]' ' ')"
 
-# _contains <needle> -- true (rc 0) iff $norm contains <needle> as a literal
-# substring, independent of where else in the payload it occurs.
+# segs -- $norm split into newline-separated SEGMENTS on shell
+# command-separator metacharacters (`; & | ( )`). Each rule below matches
+# against ONE segment at a time ($seg, set by the per-segment loop further
+# down) instead of the whole payload -- this is what keeps a force flag in
+# one part of a compound command from "leaking" into a rule for an
+# unrelated, unforced git subcommand elsewhere in the same command (issue
+# #923 review, Copilot). $norm has already collapsed real newlines to spaces
+# (see NORMALIZATION above), so using a bare newline as the segment
+# delimiter here is unambiguous.
+segs="$(printf '%s' "$norm" | tr ';&|()' '\n')"
+
+# _contains <needle> -- true (rc 0) iff the CURRENT SEGMENT ($seg, set by
+# the per-segment loop below) contains <needle> as a literal substring.
 _contains() {
-	case "$norm" in
+	case "$seg" in
 	*"$1"*) return 0 ;;
 	*) return 1 ;;
 	esac
 }
 
 # Boundary class for a short force-flag token: the separator on either side
-# is start/end-of-string, whitespace, a shell word-terminator a metacharacter
-# can place directly after a flag with no space in between (`; | & ( ) < >
-# ,`), or a JSON structural brace (`{` `}`) -- normalization (above) strips
-# the payload's quotes, so a flag at the end of the JSON command value sits
-# directly against the closing `}}` with no other separator left to match.
+# is start/end-of-segment, whitespace, a shell word-terminator a
+# metacharacter can place directly after a flag with no space in between
+# (`; | & ( ) < > ,` -- none of `; | & ( )` can actually occur WITHIN a
+# segment any more, since those are exactly the characters $segs split on;
+# they stay in this class as harmless dead alternatives), or a JSON
+# structural brace (`{` `}`) -- normalization (above) strips the payload's
+# quotes, so a flag at the end of the last segment sits directly against
+# the closing `}}` with no other separator left to match.
 _SEP='[[:space:];|&(){}<>,]'
 
-# _has_force_flag -- true iff $norm carries a force flag:
+# _has_force_flag -- true iff the CURRENT SEGMENT ($seg) carries a force
+# flag:
 #   * the literal substring --force (covers --force and --force-with-lease
 #     alike; callers that must distinguish the two check --force-with-lease
 #     separately), OR
@@ -113,7 +143,7 @@ _SEP='[[:space:];|&(){}<>,]'
 #     f-cluster as force on those two subcommands is safe.
 _has_force_flag() {
 	_contains '--force' && return 0
-	printf '%s' "$norm" | grep -Eq "(^|${_SEP})-[a-z]*f[a-z]*(\$|${_SEP})"
+	printf '%s' "$seg" | grep -Eq "(^|${_SEP})-[a-z]*f[a-z]*(\$|${_SEP})"
 }
 
 # _deny <reason> -- print the PreToolUse deny JSON and exit 0 (exit 0 is
@@ -125,18 +155,27 @@ _deny() {
 	exit 0
 }
 
-if _contains 'git commit' && _contains '--no-verify'; then
-	_deny "the pre-commit lint gate's --no-verify bypass is for humans, not agents (CLAUDE.md)"
-fi
-
-if _contains 'git push' && _has_force_flag; then
-	if ! _contains '--force-with-lease'; then
-		_deny "the rebase-only landing flow uses --force-with-lease exclusively; a bare force-push can clobber another session's PR (CLAUDE.md)"
+# Walk $segs one segment at a time, applying all three rules to each ($seg
+# is read by _contains / _has_force_flag above). Fed via a heredoc (not a
+# `| while`) so this loop runs in the CURRENT shell, not a subshell: dash (the
+# box's /bin/sh) forks a subshell for the reader end of a pipe, which would
+# swallow _deny's `exit 0` instead of ending the whole script.
+while IFS= read -r seg; do
+	if _contains 'git commit' && _contains '--no-verify'; then
+		_deny "the pre-commit lint gate's --no-verify bypass is for humans, not agents (CLAUDE.md)"
 	fi
-fi
 
-if _contains 'git worktree remove' && _has_force_flag; then
-	_deny "CLAUDE.md forbids force-removing a worktree you do not own"
-fi
+	if _contains 'git push' && _has_force_flag; then
+		if ! _contains '--force-with-lease'; then
+			_deny "the rebase-only landing flow uses --force-with-lease exclusively; a bare force-push can clobber another session's PR (CLAUDE.md)"
+		fi
+	fi
+
+	if _contains 'git worktree remove' && _has_force_flag; then
+		_deny "CLAUDE.md forbids force-removing a worktree you do not own"
+	fi
+done <<_PFB_SEGS_
+$segs
+_PFB_SEGS_
 
 exit 0

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -8,7 +8,8 @@
 #   Rule A -- `git commit` with `--no-verify`   : the pre-commit lint gate's
 #             --no-verify bypass is for humans, not agents (CLAUDE.md "Git
 #             hooks").
-#   Rule B -- `git push` with a force flag (--force or standalone -f) and
+#   Rule B -- `git push` with a force flag (--force, --force-with-lease,
+#             standalone -f, or a clustered short flag like -uf/-fu) and
 #             WITHOUT --force-with-lease        : the rebase-only landing
 #             flow uses --force-with-lease exclusively; a bare force-push can
 #             clobber another session's in-flight PR (CLAUDE.md "Worktrees").
@@ -28,40 +29,80 @@
 #
 # MATCHING: deliberately a raw-text scan, not a JSON parser (no jq / no
 # non-base dependency -- see issue #923). It reads the whole PreToolUse stdin
-# payload once and greps it AS TEXT for the git tokens/flags, which appear
-# verbatim (unescaped) inside tool_input.command for every shape the three
-# rules care about. This is robust to garbled JSON (it just fails to match,
-# i.e. fail-open) but has ONE documented, ACCEPTED false-positive: a commit
-# message that merely CONTAINS the literal text "--no-verify" (e.g.
-# `git commit -m 'handle the --no-verify flag'`) also denies, because the
-# guard cannot distinguish "the flag" from "prose about the flag" without a
-# real shell/argv parse. Erring toward blocking is the intended tradeoff.
+# payload once, builds ONE normalized view of it ($norm, see below), and
+# every rule matches against $norm as text -- never a real shell/argv parse.
+# This is robust to garbled JSON (it just fails to match, i.e. fail-open) but
+# has TWO documented, ACCEPTED false-positive surfaces:
 #
-# Standalone `-f` (short form of --force) is matched with an explicit
-# boundary so it does NOT fire inside --force, --force-with-lease, -force,
-# or a filename ending in "-f" (e.g. my-f-dir) -- see _has_force_flag below.
+#   1. The scan runs over the WHOLE payload (JSON structure and all), not
+#      just tool_input.command, so a trigger phrase occurring ANYWHERE in the
+#      payload denies -- e.g. a commit MESSAGE that merely CONTAINS the
+#      literal text "--no-verify" (`git commit -m 'handle the --no-verify
+#      flag'`) also denies, because the guard cannot distinguish "the flag"
+#      from "prose about the flag" without a real parse.
+#   2. Normalization (below) strips quotes/backslashes and collapses
+#      whitespace before matching, specifically so whitespace/quoting
+#      variance in the invoking command can't evade a rule -- but it applies
+#      to the WHOLE payload, so the same phrase-anywhere caveat holds after
+#      normalization too.
+#
+# Erring toward blocking is the intended tradeoff in both cases.
+#
+# NORMALIZATION (issue #923 review F1): rather than matching rules against
+# the raw payload, everything matches against $norm, built by:
+#   1. Deleting every `"` and `\` character -- collapses JSON-escaped quotes
+#      and a quoted subcommand token alike (`git \"commit\"` -> `git commit`).
+#   2. Collapsing every run of whitespace (space/tab/newline) to one space --
+#      defeats `git  commit` (double space) or a literal tab between tokens.
+# Fail-open holds through normalization: empty/garbled input still normalizes
+# to a string with no rule match, i.e. exit 0.
+#
+# Standalone `-f` (short form of --force) and a clustered short flag
+# containing `f` (`-uf`, `-fu`, ...) are matched with an explicit boundary so
+# they do NOT fire inside --force, --force-with-lease, -force, or a filename
+# ending in "-f" (e.g. my-f-dir) -- see _has_force_flag below.
 set -u
 
 payload="$(cat)"
 
-# _contains <needle> -- true (rc 0) iff $payload contains <needle> as a
-# literal substring, independent of where else in the payload it occurs.
+# norm -- the single normalized view every rule matches against (see
+# NORMALIZATION above): strip " and \, then collapse whitespace runs to one
+# space.
+norm="$(printf '%s' "$payload" | tr -d '\\"' | tr -s '[:space:]' ' ')"
+
+# _contains <needle> -- true (rc 0) iff $norm contains <needle> as a literal
+# substring, independent of where else in the payload it occurs.
 _contains() {
-	case "$payload" in
+	case "$norm" in
 	*"$1"*) return 0 ;;
 	*) return 1 ;;
 	esac
 }
 
-# _has_force_flag -- true iff $payload carries a force flag: the literal
-# substring --force (covers --force and --force-with-lease alike; callers
-# that must distinguish the two check --force-with-lease separately), OR a
-# standalone -f token bounded LEFT by start/whitespace/" and RIGHT by
-# end/whitespace/"/backslash. The boundary keeps -f from matching inside
-# --force*, -force, or a token like foo-f.
+# Boundary class for a short force-flag token: the separator on either side
+# is start/end-of-string, whitespace, a shell word-terminator a metacharacter
+# can place directly after a flag with no space in between (`; | & ( ) < >
+# ,`), or a JSON structural brace (`{` `}`) -- normalization (above) strips
+# the payload's quotes, so a flag at the end of the JSON command value sits
+# directly against the closing `}}` with no other separator left to match.
+_SEP='[[:space:];|&(){}<>,]'
+
+# _has_force_flag -- true iff $norm carries a force flag:
+#   * the literal substring --force (covers --force and --force-with-lease
+#     alike; callers that must distinguish the two check --force-with-lease
+#     separately), OR
+#   * a single-dash short-flag CLUSTER containing f (-f, -uf, -fu, ...) --
+#     getopt clusters short flags, so `git push -uf origin main` force-pushes
+#     exactly like `-f`. The mandatory single leading dash (never --) is why
+#     this never matches --force/--force-with-lease: the character right
+#     after the boundary dash in "--force" is another dash, not [a-z], so the
+#     match can't start there, and the first dash itself has no valid
+#     boundary before it either. The only f-bearing short flag on `git push`
+#     / `git worktree remove` is force, so treating any single-dash
+#     f-cluster as force on those two subcommands is safe.
 _has_force_flag() {
 	_contains '--force' && return 0
-	printf '%s' "$payload" | grep -Eq '(^|[[:space:]"])-f($|[[:space:]"\\])'
+	printf '%s' "$norm" | grep -Eq "(^|${_SEP})-[a-z]*f[a-z]*(\$|${_SEP})"
 }
 
 # _deny <reason> -- print the PreToolUse deny JSON and exit 0 (exit 0 is

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# scripts/claude-bash-guard.sh -- PreToolUse Bash guard: deny 3 agent git bypasses.
+#
+# Wired in .claude/settings.json as a PreToolUse hook matching the Bash tool.
+# Denies, at the TOOL layer (before the command ever runs), three git
+# operations CLAUDE.md forbids an AGENT from running even though a human may:
+#
+#   Rule A -- `git commit` with `--no-verify`   : the pre-commit lint gate's
+#             --no-verify bypass is for humans, not agents (CLAUDE.md "Git
+#             hooks").
+#   Rule B -- `git push` with a force flag (--force or standalone -f) and
+#             WITHOUT --force-with-lease        : the rebase-only landing
+#             flow uses --force-with-lease exclusively; a bare force-push can
+#             clobber another session's in-flight PR (CLAUDE.md "Worktrees").
+#   Rule C -- `git worktree remove` with a force flag : CLAUDE.md forbids
+#             force-removing a worktree an agent does not own.
+#
+# First matching rule wins (A, then B, then C).
+#
+# FAIL-OPEN CONTRACT: this hook must NEVER block a legitimate Bash call
+# because of a parsing failure. Empty stdin, garbled/non-JSON stdin, or no
+# rule match all fall through to `exit 0` with NO stdout, which Claude Code
+# reads as "no decision" (normal permission flow continues unaffected).
+# Only an actual rule match prints the PreToolUse deny JSON. `set -u`, not
+# `set -e`: an unset var is a script bug that must surface immediately, not a
+# reason to abort -- an abort here would look identical to normal
+# pass-through and hide the bug instead of failing loudly.
+#
+# MATCHING: deliberately a raw-text scan, not a JSON parser (no jq / no
+# non-base dependency -- see issue #923). It reads the whole PreToolUse stdin
+# payload once and greps it AS TEXT for the git tokens/flags, which appear
+# verbatim (unescaped) inside tool_input.command for every shape the three
+# rules care about. This is robust to garbled JSON (it just fails to match,
+# i.e. fail-open) but has ONE documented, ACCEPTED false-positive: a commit
+# message that merely CONTAINS the literal text "--no-verify" (e.g.
+# `git commit -m 'handle the --no-verify flag'`) also denies, because the
+# guard cannot distinguish "the flag" from "prose about the flag" without a
+# real shell/argv parse. Erring toward blocking is the intended tradeoff.
+#
+# Standalone `-f` (short form of --force) is matched with an explicit
+# boundary so it does NOT fire inside --force, --force-with-lease, -force,
+# or a filename ending in "-f" (e.g. my-f-dir) -- see _has_force_flag below.
+set -u
+
+payload="$(cat)"
+
+# _contains <needle> -- true (rc 0) iff $payload contains <needle> as a
+# literal substring, independent of where else in the payload it occurs.
+_contains() {
+	case "$payload" in
+	*"$1"*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+# _has_force_flag -- true iff $payload carries a force flag: the literal
+# substring --force (covers --force and --force-with-lease alike; callers
+# that must distinguish the two check --force-with-lease separately), OR a
+# standalone -f token bounded LEFT by start/whitespace/" and RIGHT by
+# end/whitespace/"/backslash. The boundary keeps -f from matching inside
+# --force*, -force, or a token like foo-f.
+_has_force_flag() {
+	_contains '--force' && return 0
+	printf '%s' "$payload" | grep -Eq '(^|[[:space:]"])-f($|[[:space:]"\\])'
+}
+
+# _deny <reason> -- print the PreToolUse deny JSON and exit 0 (exit 0 is
+# required even for a deny: Claude Code reads the decision from stdout, not
+# from the process exit status). <reason> must contain no " or \ so it can
+# be inlined into the JSON string literally, with no escaping.
+_deny() {
+	printf '%s\n' "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"$1\"}}"
+	exit 0
+}
+
+if _contains 'git commit' && _contains '--no-verify'; then
+	_deny "the pre-commit lint gate's --no-verify bypass is for humans, not agents (CLAUDE.md)"
+fi
+
+if _contains 'git push' && _has_force_flag; then
+	if ! _contains '--force-with-lease'; then
+		_deny "the rebase-only landing flow uses --force-with-lease exclusively; a bare force-push can clobber another session's PR (CLAUDE.md)"
+	fi
+fi
+
+if _contains 'git worktree remove' && _has_force_flag; then
+	_deny "CLAUDE.md forbids force-removing a worktree you do not own"
+fi
+
+exit 0

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -48,6 +48,17 @@
 #
 # Erring toward blocking is the intended tradeoff in both cases.
 #
+# ACCEPTED LIMITATION (issue #923 review F4): being a static text scan, this
+# guard cannot defend against ACTIVE circumvention -- e.g. an agent that
+# pre-defines a git alias (`git config alias.p 'push --force'; git p`) so the
+# blocked subcommand phrase never appears in the command text at all.
+# Detecting that would require running `git config` with repo knowledge the
+# hook does not have. Out of scope BY DESIGN: issue #923's threat model is an
+# agent "talking itself past prose", not one deliberately constructing
+# payloads to defeat a technical control (if an agent does the latter, the
+# prose rules have already failed and this guard is not the intended
+# backstop). Accepted and documented per maintainer sign-off.
+#
 # NORMALIZATION (issue #923 review F1): rather than matching rules against
 # the raw payload, everything matches against $norm, built by:
 #   1. Deleting every `"` and `\` character -- collapses JSON-escaped quotes

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -10,19 +10,30 @@
 #
 # Contracts pinned here:
 #   Rule A  -- git commit + --no-verify                       -> DENY
-#   Rule B  -- git push + force flag (--force / standalone -f)
+#   Rule B  -- git push + force flag (--force / standalone -f /
+#              a clustered short flag like -uf, -fu)
 #              WITHOUT --force-with-lease                     -> DENY
 #              (lease present -> PASS, lease wins even alongside a bare -f)
 #   Rule C  -- git worktree remove + force flag                -> DENY
 #   fail-open -- empty / garbled stdin, no rule match           -> PASS
-#   -f boundary -- standalone -f only; never matches inside
-#                  --force/-force/a token like foo-f            -> PASS
+#   -f boundary -- standalone -f / an f-bearing short-flag cluster,
+#                  never matching inside --force/-force/a token
+#                  like foo-f                                   -> PASS
+#   normalization (#923 review F1) -- every rule matches against a
+#              normalized view (quotes/backslashes stripped, whitespace
+#              runs collapsed to one space), so double/tab whitespace and a
+#              quoted subcommand token can't evade a rule               -> DENY
+#   force-flag boundary (#923 review F2/F3) -- a shell metacharacter
+#              (`; | & ( ) < > ,`) directly after -f, or a clustered short
+#              flag (-uf/-fu), still counts as force                    -> DENY
 #
 # One documented, ACCEPTED false-positive (B10): a commit message that merely
 # CONTAINS the literal text "--no-verify" also denies -- the guard is a raw
 # text scan (no jq / real argv parse in scope, see the guard's own header),
 # so it cannot distinguish "the flag" from "prose about the flag". Erring
-# toward blocking is the intended tradeoff, not a bug.
+# toward blocking is the intended tradeoff, not a bug. More generally
+# (#923 review F6): the scan runs over the WHOLE stdin payload, so a trigger
+# phrase occurring ANYWHERE in the payload denies, not just in the command.
 
 Describe 'claude-bash-guard.sh'
   GUARD="${PFB_ROOT}/scripts/claude-bash-guard.sh"
@@ -63,6 +74,42 @@ Describe 'claude-bash-guard.sh'
       When run script "$GUARD"
       The status should be success
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H1 (F1 whitespace evasion): double space between git and commit (git  commit --no-verify -m x) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git  commit --no-verify -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H2 (F1 whitespace evasion): a literal TAB between git and commit -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git	commit --no-verify"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H3 (F1 quoting evasion): quoted subcommand token (git \"commit\" --no-verify) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git \"commit\" --no-verify"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H12a (F5 full JSON validity): exact deny JSON for Rule A'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit --no-verify -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"the pre-commit lint gate'"'"'s --no-verify bypass is for humans, not agents (CLAUDE.md)"}}'
     End
 
     It 'B10 (documented accepted false-positive): --no-verify inside the commit MESSAGE text -> DENY'
@@ -136,6 +183,69 @@ Describe 'claude-bash-guard.sh'
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
 
+    It 'H4 (F2 metachar boundary): git push -f;true -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push -f;true"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H5 (F2 metachar boundary): git push -f|cat -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push -f|cat"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H6 (F2 metachar boundary): git push -f&&echo done -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push -f&&echo done"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H7 (F3 clustered short flag): git push -uf origin main -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push -uf origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H8 (F3 clustered short flag, other order): git push -fu origin main -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push -fu origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H10: --force-with-lease with a trailing metachar (;true) -> PASS (lease still wins)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease;true"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'H12b (F5 full JSON validity): exact deny JSON for Rule B'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"the rebase-only landing flow uses --force-with-lease exclusively; a bare force-push can clobber another session'"'"'s PR (CLAUDE.md)"}}'
+    End
+
     It 'P1: --force-with-lease alone -> PASS (contains substring --force but lease wins)'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease"}}
@@ -194,6 +304,24 @@ Describe 'claude-bash-guard.sh'
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
 
+    It 'H9 (F1 whitespace evasion): double space (git worktree  remove --force ../wt) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree  remove --force ../wt"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H12c (F5 full JSON validity): exact deny JSON for Rule C'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove --force ../wt"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"CLAUDE.md forbids force-removing a worktree you do not own"}}'
+    End
+
     It 'P5: remove without force -> PASS'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove ../wt"}}
@@ -237,6 +365,15 @@ Describe 'claude-bash-guard.sh'
     It 'P14: -f embedded in a path token (git worktree add ../my-f-dir) -> PASS (not a standalone -f, and not remove)'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git worktree add ../my-f-dir"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'H11 (F3 over-match guard): bare -f on a non-push/remove git command (echo -f && git status) -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"echo -f && git status"}}
       End
       When run script "$GUARD"
       The status should be success

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -1,0 +1,279 @@
+#shellcheck shell=sh
+# claude-bash-guard.sh -- shellspec pinning the PreToolUse Bash guard (#923).
+#
+# TOPOLOGY UNDER TEST: the guard reads one PreToolUse-shaped JSON payload from
+# stdin and either denies (prints the PreToolUse deny JSON, exit 0) or passes
+# through silently (exit 0, empty stdout). Each example feeds one payload via
+# a `Data` block (raw stdin -- shellspec's `shellspec_evaluation_execute`
+# redirects stdin from the Data block for both `When call` and `When run`) and
+# asserts the exit status + stdout shape.
+#
+# Contracts pinned here:
+#   Rule A  -- git commit + --no-verify                       -> DENY
+#   Rule B  -- git push + force flag (--force / standalone -f)
+#              WITHOUT --force-with-lease                     -> DENY
+#              (lease present -> PASS, lease wins even alongside a bare -f)
+#   Rule C  -- git worktree remove + force flag                -> DENY
+#   fail-open -- empty / garbled stdin, no rule match           -> PASS
+#   -f boundary -- standalone -f only; never matches inside
+#                  --force/-force/a token like foo-f            -> PASS
+#
+# One documented, ACCEPTED false-positive (B10): a commit message that merely
+# CONTAINS the literal text "--no-verify" also denies -- the guard is a raw
+# text scan (no jq / real argv parse in scope, see the guard's own header),
+# so it cannot distinguish "the flag" from "prose about the flag". Erring
+# toward blocking is the intended tradeoff, not a bug.
+
+Describe 'claude-bash-guard.sh'
+  GUARD="${PFB_ROOT}/scripts/claude-bash-guard.sh"
+
+  setup() {
+    # Every example's Data payload embeds the literal text "git " (e.g.
+    # `git commit --no-verify`) which trips git-env-scrub-guard.sh's clause 2
+    # unless scrub_git_env is called -- defensive, cheap, mandatory per spec_helper.
+    scrub_git_env
+  }
+  BeforeEach 'setup'
+
+  # ── Rule A: git commit + --no-verify ────────────────────────────────────────
+
+  Describe 'Rule A: git commit --no-verify'
+    It 'B1: --no-verify first (git commit --no-verify -m x) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit --no-verify -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B2: --no-verify last (git commit -m x --no-verify) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -m x --no-verify"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B3: --no-verify amid other flags (git commit -m "wip" --no-verify --amend) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -m \"wip\" --no-verify --amend"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B10 (documented accepted false-positive): --no-verify inside the commit MESSAGE text -> DENY'
+      # `git commit -m 'handle the --no-verify flag'` is a normal commit whose
+      # message merely mentions --no-verify in prose. The guard is a raw text
+      # scan (no argv parse), so it denies this too. ACCEPTED: erring toward
+      # blocking is the intended tradeoff (see guard header + spec header).
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -m 'handle the --no-verify flag'"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'P3: normal commit, no --no-verify (git commit -m x) -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'P10: git commit --amend, no --no-verify -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit --amend"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+  End
+
+  # ── Rule B: git push + force flag, without --force-with-lease ──────────────
+
+  Describe 'Rule B: git push force (non-lease)'
+    It 'B4: long flag (git push --force) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B5: short flag (git push -f) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push -f"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B6: flag after args (git push origin main --force) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push origin main --force"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B7: flag before args (git push --force origin main) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'P1: --force-with-lease alone -> PASS (contains substring --force but lease wins)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'P2: --force-with-lease with args -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'P4: normal push, no force flag (git push origin main) -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'P13 (edge case): --force-with-lease alongside a bare -f -> PASS (lease wins)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease -f"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+  End
+
+  # ── Rule C: git worktree remove + force flag ────────────────────────────────
+
+  Describe 'Rule C: git worktree remove --force'
+    It 'B8: long flag (git worktree remove --force ../wt) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove --force ../wt"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B9: short flag (git worktree remove -f ../wt) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove -f ../wt"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'P5: remove without force -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove ../wt"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'P6: worktree add (not remove) -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree add ../wt -b br origin/devel"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+  End
+
+  # ── standalone -f boundary: must not over-match ─────────────────────────────
+
+  Describe 'standalone -f boundary (no false match inside another token, or out of scope)'
+    It 'P7: bare -f on a non-git command (ls -f) -> PASS (force rule out of scope, no git push/worktree remove)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"ls -f"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'P8: bare -f on grep (grep -f pattern.txt file) -> PASS (not git)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"grep -f pattern.txt file"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'P14: -f embedded in a path token (git worktree add ../my-f-dir) -> PASS (not a standalone -f, and not remove)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree add ../my-f-dir"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+  End
+
+  # ── plain git, no rule in scope ─────────────────────────────────────────────
+
+  It 'P9: plain git status -> PASS'
+    Data
+      #|{"tool_name":"Bash","tool_input":{"command":"git status"}}
+    End
+    When run script "$GUARD"
+    The status should be success
+    The output should equal ""
+  End
+
+  # ── fail-open: empty / garbled stdin never blocks ───────────────────────────
+
+  Describe 'fail-open: unparseable input never denies'
+    It 'P11: empty stdin -> PASS'
+      Data
+        #|
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'P12: garbled non-JSON stdin -> PASS'
+      Data
+        #|not json at all {{{
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+  End
+End

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -381,6 +381,84 @@ Describe 'claude-bash-guard.sh'
     End
   End
 
+  # ── per-segment scoping: a force flag in one compound-command segment must
+  #    not leak into a rule for an unrelated, unforced segment (#923 review,
+  #    Copilot false-positive) ───────────────────────────────────────────────
+
+  Describe 'per-segment scoping (compound commands): a rule only fires when its trigger and its force flag share ONE segment'
+    It 'C1 (Rule C FP, Copilot case): unforced worktree remove && leased push -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove ../wt && git push --force-with-lease"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'C2 (Rule C FP, reversed order): leased push && unforced worktree remove -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease && git worktree remove ../wt"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'C3 (Rule B FP): git clean --force && normal git push -> PASS (force belongs to git clean, not the push)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git clean --force && git push origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'C4 (Rule B FP, subshell boundary): (git clean --force); git push origin main -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"(git clean --force); git push origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'C5 (still caught): git status && a genuinely forced push in its own segment -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git status && git push --force"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'C6 (still caught): git fetch && a genuinely forced worktree remove -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git fetch && git worktree remove -f ../wt"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'C7 (still caught): git status && git commit --no-verify -m x -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git status && git commit --no-verify -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'C8 (unforced remove next to a genuinely forced push): the push segment is still denied on its own merits'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove ../wt && git push --force origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+  End
+
   # ── plain git, no rule in scope ─────────────────────────────────────────────
 
   It 'P9: plain git status -> PASS'


### PR DESCRIPTION
Fixes #923.

## What

A POSIX-sh `PreToolUse` Bash guard hook that denies, at the tool layer (before the command runs), three git operations CLAUDE.md forbids an agent from taking even though a human may:

- **Rule A** — `git commit` with `--no-verify` (the pre-commit lint gate's bypass is for humans, not agents)
- **Rule B** — `git push` with a force flag (`--force` or standalone `-f`) and *without* `--force-with-lease` (the rebase-only landing flow uses `--force-with-lease` exclusively; a bare force-push can clobber another session's in-flight PR)
- **Rule C** — `git worktree remove` with a force flag (forbidden to force-remove a worktree you do not own)

## Files

- `scripts/claude-bash-guard.sh` — the guard. `set -u` (never `set -e`), raw-text scan of the PreToolUse stdin payload, no `jq`/no non-base dependency. **Fail-open**: empty stdin, garbled/non-JSON stdin, or no rule match all fall through to `exit 0` with no stdout (Claude Code reads that as "no decision"; normal permission flow continues). Only a real match prints the deny JSON. Standalone `-f` is boundary-matched so it never fires inside `--force`, `--force-with-lease`, `-force`, or a path token like `my-f-dir`.
- `.claude/settings.json` — wires the guard as a `PreToolUse` hook on the `Bash` matcher. Existing hooks and `permissions.deny` (which already denies `git stash`) are untouched.
- `tests/shell/claude_bash_guard_spec.sh` — 24 shellspec examples: all three rules, the `--force-with-lease` exception, the standalone-`-f` boundary, empty/garbled fail-open, and two documented, accepted false-positives.

The deny JSON schema (`hookSpecificOutput.{hookEventName,permissionDecision:"deny",permissionDecisionReason}`, exit 0) was verified against the current Claude Code hooks documentation, not from memory.

## Accepted tradeoffs (documented in the guard header + spec)

The guard is a raw text scan, not a shell/argv parser, so it errs toward blocking:

- A commit message merely mentioning the literal text `--no-verify` in prose is also denied.
- A force flag anywhere in a compound command (e.g. `rm -f x && git push`) triggers Rule B.

This is the intended tradeoff for a guardrail — the observed failure mode is an agent talking itself past a prose rule, and a tool-layer deny cannot be argued with.

## Verification

- `sh -n`, `shellcheck` (clean, no suppressions), `shellspec` (24 examples, 0 failures)
- `scripts/git-env-scrub-guard.sh` clean; `.claude/settings.json` validates as JSON
- Red→green: with the deny logic stubbed out, exactly the 10 DENY examples fail while the 14 PASS examples stay green; restoring the logic returns 24/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016eEYi6qMrYRV5ErhcEgzEb)_