### PR TITLE
scripts: harden version-literal checker — per-language comments, py triple-quote fixes, matrix tripwire

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,7 +261,7 @@ jobs:
         # file self-excluded from its own scan (issue #940). Fail loudly the moment
         # supported-versions.json carries a version those patterns no longer cover,
         # instead of the gate narrowing silently. Checkout doesn't bring orphan refs,
-        # so fetch ci-metadata first (same as test-version-matrix).
+        # so fetch ci-metadata first (same fetch as the read-matrix job above).
         run: |
           git fetch --no-tags --depth=1 origin ci-metadata:refs/remotes/origin/ci-metadata
           python3 scripts/check_version_literals.py --verify-matrix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,6 +256,16 @@ jobs:
         # `# version-literal-ok: <reason>`.
         run: python3 scripts/check_version_literals.py
 
+      - name: Version-literal patterns cover the live matrix (tripwire)
+        # The checker's windowed CE/Plus numeric shapes restate the matrix window, in a
+        # file self-excluded from its own scan (issue #940). Fail loudly the moment
+        # supported-versions.json carries a version those patterns no longer cover,
+        # instead of the gate narrowing silently. Checkout doesn't bring orphan refs,
+        # so fetch ci-metadata first (same as test-version-matrix).
+        run: |
+          git fetch --no-tags --depth=1 origin ci-metadata:refs/remotes/origin/ci-metadata
+          python3 scripts/check_version_literals.py --verify-matrix
+
   shell-tests:
     name: shellspec (POSIX sh)
     runs-on: ubuntu-latest

--- a/docs/misc/pfSense_versions.md
+++ b/docs/misc/pfSense_versions.md
@@ -33,6 +33,12 @@ Observed on a CE **2.8.1** box; 2.8.0 shares the same base toolchain.
 > any unmapped version — the reject-unknown contract from issue #22 is preserved).
 > When adding a new supported CE version, add an entry to `supported-versions.json`
 > on `ci-metadata` **and** update the table here. No workflow edit needed.
+>
+> **These values must never be restated as literals** in `src/`, `scripts/`, or
+> `.github/workflows/` — read them from the matrix at runtime/generation time
+> (`scripts/read-version-matrix.sh`). `scripts/check_version_literals.py`
+> (pre-commit + CI) enforces this; escape a genuine one-off with an inline
+> `# version-literal-ok: <reason>` comment.
 
 ### pfBlockerNG runtime dependencies (port `RUN_DEPENDS`)
 

--- a/docs/misc/version-bump-runbook.md
+++ b/docs/misc/version-bump-runbook.md
@@ -88,3 +88,11 @@ entry — no new shipped file, no extra deploy wiring.
    `2$blake2b`), tar flavor/uid, mtime, and best-effort dep versions — are enumerated in
    `docs/build-pkg-portable.md` ("Fidelity vs `make package`"); anything else is a builder bug to
    fix before the bump lands.
+5. **Sweep the version-literal checker + seeded escapes** (issue #940) — as soon as the matrix
+   moves, `test.yml`'s tripwire step (`scripts/check_version_literals.py --verify-matrix`) fails
+   if the new version falls outside the checker's **windowed CE/Plus numeric shapes**
+   (`_TOKEN_ALTERNATIVES`); widen the window and update the checker's tests. Then sweep every
+   `version-literal-ok` escape (`git grep -n version-literal-ok -- src scripts .github`): the
+   escaped `workflow_dispatch` fallback defaults and dev-tooling defaults still name the OLD
+   version and need bumping by hand — the escape comment exempts them from the gate, so nothing
+   else will remind you.

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -52,10 +52,17 @@ SCOPE (deliberately low false-positive: VALUES only, never prose)
   token is not the ENTIRE value there.
 
 Exit status: 0 = clean, 1 = one or more violations (printed with file:line).
+
+A second mode, ``--verify-matrix [--ref <git-ref> | --matrix-file <path>]``,
+tripwires the WINDOWED token shapes against ``supported-versions.json``
+(issue #940; a blocking CI step in ``test.yml``): exit 1 lists every
+matrix-implied token the patterns no longer cover, so the window is widened
+the moment the matrix moves instead of the gate narrowing silently.
 """
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import sys
@@ -63,13 +70,23 @@ from pathlib import Path
 
 # Each alternative is a full-value token shape (no anchors here -- anchors are
 # added once, around the whole alternation, at the two call sites below).
+#
+# Unambiguous shapes (FreeBSD ABI, php/py flavors, varvers) are version-AGNOSTIC:
+# a stale or future version restated as a literal is just as much a drift hazard
+# as a current one (issue #940). Only the bare CE/Plus numerics stay WINDOWED --
+# a generic decimal shape would false-positive on unrelated version numbers --
+# and that window is tripwired against the live matrix by --verify-matrix (a
+# blocking CI step): the moment supported-versions.json carries a version these
+# patterns no longer cover, CI fails loudly instead of the gate narrowing
+# silently. This file restating the window is otherwise the exact disease it
+# polices, in a file self-excluded from its own scan.
 _TOKEN_ALTERNATIVES = (
-    r"2\.[89]",  # CE version: 2.8 / 2.9
-    r"2[56]\.[0-9]{2}",  # Plus version: 25.NN / 26.NN
-    r"FreeBSD:1[56](?::[a-z0-9_]+)?",  # FreeBSD ABI: FreeBSD:15/:16, optional :arch
-    r"php8[0-9]",  # php flavor: php80..php89
-    r"py31[0-9]",  # py flavor: py310..py319
-    r"ce-[0-9]\.[0-9]",  # varver: ce-X.Y
+    r"2\.[89]",  # CE version window: 2.8 / 2.9 (tripwired)
+    r"2[56]\.[0-9]{2}",  # Plus version window: 25.NN / 26.NN (tripwired)
+    r"FreeBSD:[0-9]+(?::[a-z0-9_]+)?",  # FreeBSD ABI, any major, optional :arch
+    r"php[0-9]{2}",  # php flavor: php74..php99
+    r"py3[0-9]{2}",  # py flavor: py310..py399
+    r"ce-[0-9]+\.[0-9]+",  # varver: ce-X.Y
     r"plus-[0-9]{2}\.[0-9]{2}",  # varver: plus-NN.NN
 )
 
@@ -306,7 +323,82 @@ def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
     return violations
 
 
+def _matrix_tokens(matrix: dict) -> list[str]:
+    """Derive every version-shaped token a ``supported-versions.json`` entry implies.
+
+    Per entry: the bare pfSense version (a trailing ``.x`` stripped), its
+    ``ce-``/``plus-`` varver, the ``FreeBSD:<major>`` ABI prefix, the php
+    flavor (``php_version`` with the dot dropped), and the py flavor verbatim.
+    """
+    tokens: list[str] = []
+    for entry in matrix.get("versions", []):
+        version = str(entry.get("pfsense_version", "")).removesuffix(".x")
+        channel = str(entry.get("channel", "")).lower()
+        major = str(entry.get("freebsd_major", ""))
+        php = str(entry.get("php_version", ""))
+        py = str(entry.get("py_flavor", ""))
+        if version:
+            tokens.append(version)
+            tokens.append(("ce-" if channel == "ce" else "plus-") + version)
+        if major:
+            tokens.append(f"FreeBSD:{major}")
+        if php:
+            tokens.append("php" + php.replace(".", ""))
+        if py:
+            tokens.append(py)
+    return tokens
+
+
+def uncovered_matrix_tokens(matrix: dict) -> list[str]:
+    """Matrix-implied tokens that ``_FULL_VALUE_RE`` no longer covers (sorted, unique)."""
+    return sorted({t for t in _matrix_tokens(matrix) if not _FULL_VALUE_RE.fullmatch(t)})
+
+
+def _verify_matrix(argv: list[str]) -> int:
+    """The ``--verify-matrix`` mode: tripwire the windowed token shapes (issue #940).
+
+    Reads ``supported-versions.json`` from the ci-metadata ref (``--ref``,
+    default ``origin/ci-metadata``) or from ``--matrix-file <path>``; exits 1
+    listing any matrix-implied token the patterns no longer cover.
+    """
+    ref = "origin/ci-metadata"
+    matrix_file: str | None = None
+    it = iter(argv)
+    for arg in it:
+        if arg == "--ref":
+            ref = next(it, ref)
+        elif arg == "--matrix-file":
+            matrix_file = next(it, None)
+        else:
+            print(f"unknown --verify-matrix option: {arg}", file=sys.stderr)
+            return 2
+    if matrix_file is not None:
+        text = Path(matrix_file).read_text(encoding="utf-8")
+    else:
+        out = subprocess.run(
+            ["git", "show", f"{ref}:supported-versions.json"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        text = out.stdout
+    uncovered = uncovered_matrix_tokens(json.loads(text))
+    if not uncovered:
+        return 0
+    print(
+        "supported-versions.json carries version token(s) the version-literal patterns\n"
+        "no longer cover -- widen the windowed shapes in _TOKEN_ALTERNATIVES\n"
+        "(scripts/check_version_literals.py) or the gate silently stops seeing them:\n",
+        file=sys.stderr,
+    )
+    for token in uncovered:
+        print(f"  {token}", file=sys.stderr)
+    return 1
+
+
 def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--verify-matrix":
+        return _verify_matrix(argv[1:])
     if argv:
         paths = [p for p in (Path(a) for a in argv) if not _is_excluded(p)]
     else:

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -57,7 +57,8 @@ A second mode, ``--verify-matrix [--ref <git-ref> | --matrix-file <path>]``,
 tripwires the WINDOWED token shapes against ``supported-versions.json``
 (issue #940; a blocking CI step in ``test.yml``): exit 1 lists every
 matrix-implied token the patterns no longer cover, so the window is widened
-the moment the matrix moves instead of the gate narrowing silently.
+the moment the matrix moves instead of the gate narrowing silently; a
+misconfigured invocation (bad ref, missing file, malformed JSON) exits 2.
 """
 
 from __future__ import annotations
@@ -134,9 +135,14 @@ _ASSIGNMENT_RE = re.compile(
 # (review-fanout C9, PR #947 — a \' earlier on the line mispaired the spans
 # and swallowed a later single-quoted token); POSIX sh has NO single-quote
 # escapes, so the shell/YAML variant keeps the naive single-quote side, which
-# is shell-correct.
-_QUOTED_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|\'([^\']*)\'')
-_QUOTED_C_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|\'((?:[^\'\\]|\\.)*)\'')
+# is shell-correct. Both variants CONSUME backtick spans so quote pairing
+# cannot cross a backtick boundary (re-review F1, PR #947 — two backtick
+# segments each holding an odd quote count swallowed the value between them):
+# in the C-style variant the span is also CAPTURED (a JS template literal is a
+# value); in the shell variant it is consume-only (shell backticks are command
+# substitution, not a value literal).
+_QUOTED_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|\'([^\']*)\'|`(?:[^`\\]|\\.)*`')
+_QUOTED_C_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|\'((?:[^\'\\]|\\.)*)\'|`((?:[^`\\]|\\.)*)`')
 
 # Inline per-line escape (`# version-literal-ok: <reason>`), spec'd in issue #922.
 _ESCAPE = "version-literal-ok"
@@ -168,10 +174,11 @@ def _quoted_literals(line: str, c_style: bool = False) -> list[str]:
     """Return the inner text of every single- or double-quoted span on ``line``.
 
     ``c_style`` selects the PHP/JS variant whose single-quote side is
-    escape-aware (``\\'`` is content there, unlike POSIX sh).
+    escape-aware (``\\'`` is content there, unlike POSIX sh) and whose
+    backtick spans count as values (template literals).
     """
     regex = _QUOTED_C_RE if c_style else _QUOTED_RE
-    return [m.group(1) if m.group(1) is not None else m.group(2) for m in regex.finditer(line)]
+    return [g for m in regex.finditer(line) for g in m.groups() if g is not None]
 
 
 def _strip_inline_comment(line: str) -> str:
@@ -409,7 +416,8 @@ def _verify_matrix(argv: list[str]) -> int:
 
     Reads ``supported-versions.json`` from the ci-metadata ref (``--ref``,
     default ``origin/ci-metadata``) or from ``--matrix-file <path>``; exits 1
-    listing any matrix-implied token the patterns no longer cover.
+    listing any matrix-implied token the patterns no longer cover, and 2 on a
+    misconfigured invocation (unknown option, bad ref, missing file, bad JSON).
     """
     ref = "origin/ci-metadata"
     matrix_file: str | None = None

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -87,7 +87,7 @@ _TOKEN_ALTERNATIVES = (
     r"php[0-9]{2}",  # php flavor: php74..php99
     r"py3[0-9]{2}",  # py flavor: py310..py399
     r"ce-[0-9]+\.[0-9]+",  # varver: ce-X.Y
-    r"plus-[0-9]{2}\.[0-9]{2}",  # varver: plus-NN.NN
+    r"plus-[0-9]+\.[0-9]+",  # varver: plus-X.Y (generalized like ce- — review-fanout C8, PR #947)
 )
 
 # ponytail: a flavor token embedded in a hardcoded package name (e.g.
@@ -129,12 +129,14 @@ _ASSIGNMENT_RE = re.compile(
 
 # The double-quote side is escape-aware (\" is content in sh/php/js/py alike),
 # so an escaped quote does not mispair the spans and swallow a later literal
-# (Copilot, PR #947). ponytail: the single-quote side stays naive -- POSIX sh
-# has NO single-quote escapes, so naive is shell-correct; a PHP/JS \' inside
-# single quotes may mispair spans, but no version token contains a quote and
-# the quoted-literal path still sees every properly paired span. Split the
-# regex per language if that ever bites.
+# (Copilot, PR #947). The single-quote side is language-scoped: PHP/JS support
+# \' inside single quotes, so the C-style variant is escape-aware there too
+# (review-fanout C9, PR #947 — a \' earlier on the line mispaired the spans
+# and swallowed a later single-quoted token); POSIX sh has NO single-quote
+# escapes, so the shell/YAML variant keeps the naive single-quote side, which
+# is shell-correct.
 _QUOTED_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|\'([^\']*)\'')
+_QUOTED_C_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|\'((?:[^\'\\]|\\.)*)\'')
 
 # Inline per-line escape (`# version-literal-ok: <reason>`), spec'd in issue #922.
 _ESCAPE = "version-literal-ok"
@@ -162,9 +164,14 @@ def _is_excluded(path: Path) -> bool:
     return path.name.startswith("install_deps_")
 
 
-def _quoted_literals(line: str) -> list[str]:
-    """Return the inner text of every single- or double-quoted span on ``line``."""
-    return [m.group(1) if m.group(1) is not None else m.group(2) for m in _QUOTED_RE.finditer(line)]
+def _quoted_literals(line: str, c_style: bool = False) -> list[str]:
+    """Return the inner text of every single- or double-quoted span on ``line``.
+
+    ``c_style`` selects the PHP/JS variant whose single-quote side is
+    escape-aware (``\\'`` is content there, unlike POSIX sh).
+    """
+    regex = _QUOTED_C_RE if c_style else _QUOTED_RE
+    return [m.group(1) if m.group(1) is not None else m.group(2) for m in regex.finditer(line)]
 
 
 def _strip_inline_comment(line: str) -> str:
@@ -207,10 +214,18 @@ def _split_c_comment(line: str, hash_comments: bool) -> tuple[str, bool]:
     Quote-aware: ``//``, ``/*`` and ``#`` inside a quoted string are content,
     not comments, and a backslash inside a quoted string escapes the next char
     (PHP/JS support ``\\'``/``\\"`` in both quote types -- Copilot, PR #947),
-    so an escaped quote does not mis-close the string. A ``/*...*/`` pair
-    closed on the same line is dropped and the code after it is kept.
-    ``hash_comments`` enables ``#`` (PHP family only -- in JS, ``#`` is a
-    private-field sigil).
+    so an escaped quote does not mis-close the string. Backticks are tracked
+    as a third quote type (review-fanout C5, PR #947): a JS template literal
+    (or PHP shell-exec string) containing ``//`` must not truncate the scan of
+    real code after it. A ``/*...*/`` pair closed on the same line is dropped
+    and the code after it is kept. ``hash_comments`` enables ``#`` (PHP family
+    only -- in JS, ``#`` is a private-field sigil).
+
+    ponytail: quote state is per-line -- a PHP/JS string spanning physical
+    lines without heredoc can hide a value on its continuation line
+    (review-fanout C6; none in the tree, house style uses single-line strings
+    or heredoc). Carry the open quote across lines like ``in_block`` if that
+    ever bites.
     """
     out: list[str] = []
     quote: str | None = None
@@ -228,7 +243,7 @@ def _split_c_comment(line: str, hash_comments: bool) -> tuple[str, bool]:
             out.append(ch)
             i += 1
             continue
-        if ch in ("'", '"'):
+        if ch in ("'", '"', "`"):
             quote = ch
             out.append(ch)
             i += 1
@@ -248,9 +263,9 @@ def _split_c_comment(line: str, hash_comments: bool) -> tuple[str, bool]:
     return "".join(out), False
 
 
-def _line_has_value_literal(code: str) -> bool:
+def _line_has_value_literal(code: str, c_style: bool = False) -> bool:
     """True if ``code`` (comments already stripped) holds a token standing ALONE as a value."""
-    for literal in _quoted_literals(code):
+    for literal in _quoted_literals(code, c_style):
         if _FULL_VALUE_RE.fullmatch(literal):
             return True
     return bool(_ASSIGNMENT_RE.match(code))
@@ -340,11 +355,12 @@ def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
         except (OSError, UnicodeError):
             continue
         lines = text.splitlines()
+        c_style = path.suffix in _C_COMMENT_EXTS
         code_lines = _code_lines(lines, path.suffix)
         for lineno, (line, code) in enumerate(zip(lines, code_lines, strict=True), start=1):
             if code is None or _ESCAPE in line:
                 continue
-            if _line_has_value_literal(code):
+            if _line_has_value_literal(code, c_style):
                 violations.append((path, lineno, line.strip()))
     return violations
 
@@ -355,9 +371,17 @@ def _matrix_tokens(matrix: dict) -> list[str]:
     Per entry: the bare pfSense version (a trailing ``.x`` stripped), its
     ``ce-``/``plus-`` varver, the ``FreeBSD:<major>`` ABI prefix, the php
     flavor (``php_version`` with the dot dropped), and the py flavor verbatim.
+
+    ``role=route-only`` entries (ADR-27: EOL'd but still served, frozen
+    catalog, no longer built/tested) are excluded, mirroring
+    ``read-version-matrix.sh``'s BUILD/CI derivations (review-fanout C1,
+    PR #947): a frozen version's identity is no longer an active-development
+    value, so the window need not keep covering it forever.
     """
     tokens: list[str] = []
     for entry in matrix.get("versions", []):
+        if str(entry.get("role", "build")) == "route-only":
+            continue
         version = str(entry.get("pfsense_version", "")).removesuffix(".x")
         channel = str(entry.get("channel", "")).lower()
         major = str(entry.get("freebsd_major", ""))
@@ -398,17 +422,25 @@ def _verify_matrix(argv: list[str]) -> int:
         else:
             print(f"unknown --verify-matrix option: {arg}", file=sys.stderr)
             return 2
-    if matrix_file is not None:
-        text = Path(matrix_file).read_text(encoding="utf-8")
-    else:
-        out = subprocess.run(
-            ["git", "show", f"{ref}:supported-versions.json"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        text = out.stdout
-    uncovered = uncovered_matrix_tokens(json.loads(text))
+    # A misconfigured invocation (bad ref, missing file, malformed JSON) gets the
+    # file's one-line stderr convention + exit 2, not a traceback (review-fanout
+    # C7, PR #947) -- distinct from exit 1 (uncovered tokens) so CI logs read right.
+    try:
+        if matrix_file is not None:
+            text = Path(matrix_file).read_text(encoding="utf-8")
+        else:
+            out = subprocess.run(
+                ["git", "show", f"{ref}:supported-versions.json"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            text = out.stdout
+        uncovered = uncovered_matrix_tokens(json.loads(text))
+    except (OSError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        detail = exc.stderr.strip() if isinstance(exc, subprocess.CalledProcessError) else str(exc)
+        print(f"--verify-matrix: cannot read the matrix: {detail}", file=sys.stderr)
+        return 2
     if not uncovered:
         return 0
     print(

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -127,7 +127,14 @@ _ASSIGNMENT_RE = re.compile(
     r"[\w.-]+\s*[:=]\s*(?:" + "|".join(_TOKEN_ALTERNATIVES) + r")\s*$"
 )
 
-_QUOTED_RE = re.compile(r'"([^"]*)"|\'([^\']*)\'')
+# The double-quote side is escape-aware (\" is content in sh/php/js/py alike),
+# so an escaped quote does not mispair the spans and swallow a later literal
+# (Copilot, PR #947). ponytail: the single-quote side stays naive -- POSIX sh
+# has NO single-quote escapes, so naive is shell-correct; a PHP/JS \' inside
+# single quotes may mispair spans, but no version token contains a quote and
+# the quoted-literal path still sees every properly paired span. Split the
+# regex per language if that ever bites.
+_QUOTED_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|\'([^\']*)\'')
 
 # Inline per-line escape (`# version-literal-ok: <reason>`), spec'd in issue #922.
 _ESCAPE = "version-literal-ok"
@@ -166,19 +173,31 @@ def _strip_inline_comment(line: str) -> str:
     A trailing ``# e.g. "ce-2.8"`` on an otherwise-real code line is a comment
     illustrating the value, not the value itself -- same "prose" exemption as
     a full comment line, just not confined to the start of the line. A ``#``
-    INSIDE a quoted string is left alone (rare, but real content).
+    INSIDE a quoted string is left alone (rare, but real content). Inside a
+    DOUBLE-quoted string a backslash escapes the next char, so an escaped
+    quote does not mis-close the string (Copilot, PR #947); single quotes stay
+    escape-free -- POSIX sh has no escapes there.
     """
     quote: str | None = None
-    for i, ch in enumerate(line):
+    i = 0
+    n = len(line)
+    while i < n:
+        ch = line[i]
         if quote is not None:
+            if quote == '"' and ch == "\\":
+                i += 2
+                continue
             if ch == quote:
                 quote = None
+            i += 1
             continue
         if ch in ("'", '"'):
             quote = ch
+            i += 1
             continue
         if ch == "#":
             return line[:i]
+        i += 1
     return line
 
 
@@ -186,9 +205,12 @@ def _split_c_comment(line: str, hash_comments: bool) -> tuple[str, bool]:
     """Return (code part of ``line``, True if an unclosed ``/*`` block opens here).
 
     Quote-aware: ``//``, ``/*`` and ``#`` inside a quoted string are content,
-    not comments. A ``/*...*/`` pair closed on the same line is dropped and the
-    code after it is kept. ``hash_comments`` enables ``#`` (PHP family only --
-    in JS, ``#`` is a private-field sigil).
+    not comments, and a backslash inside a quoted string escapes the next char
+    (PHP/JS support ``\\'``/``\\"`` in both quote types -- Copilot, PR #947),
+    so an escaped quote does not mis-close the string. A ``/*...*/`` pair
+    closed on the same line is dropped and the code after it is kept.
+    ``hash_comments`` enables ``#`` (PHP family only -- in JS, ``#`` is a
+    private-field sigil).
     """
     out: list[str] = []
     quote: str | None = None
@@ -197,6 +219,10 @@ def _split_c_comment(line: str, hash_comments: bool) -> tuple[str, bool]:
     while i < n:
         ch = line[i]
         if quote is not None:
+            if ch == "\\" and i + 1 < n:
+                out.append(line[i : i + 2])
+                i += 2
+                continue
             if ch == quote:
                 quote = None
             out.append(ch)

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -35,12 +35,14 @@ SCOPE (deliberately low false-positive: VALUES only, never prose)
   the scan roots anyway; it is named here only to document that intent.
 * A line containing the substring ``version-literal-ok`` is exempt (inline
   escape: ``# version-literal-ok: <reason>``).
-* A ``#``-comment line, an unquoted trailing ``# ...`` comment on an
-  otherwise-real code line, and any line inside a triple-quoted
-  docstring/prose block are all exempt outright — a doc example illustrating
-  a transformation (e.g. an arrow mapping shown inside a docstring, or a
-  trailing ``# e.g. "ce-2.8"``) is prose, not a value assignment, even though
-  the quoted span alone would otherwise fullmatch a token.
+* Comments are prose in every scanned language, per that language's syntax
+  (enumerated from the scan roots' actual file types — issue #941): ``#``
+  line/trailing comments everywhere; ``//`` and ``/* ... */`` in PHP/JS
+  (``.php``/``.inc``/``.js``, where ``#`` is PHP-only); Python triple-quoted
+  docstring bodies in ``.py``. A doc example illustrating a transformation
+  (an arrow mapping in a docstring, a trailing ``# e.g. "ce-2.8"``, a
+  ``@example "2.8"`` docblock line) is prose, not a value assignment, even
+  though the quoted span alone would otherwise fullmatch a token.
 * Flags a token ONLY when it stands ALONE as a value: the entire inner text
   of a quoted string literal (``"2.8"``, ``'py311'``), or the entire unquoted
   right-hand side of a ``key: value`` / ``key=value`` assignment. A token
@@ -77,30 +79,40 @@ _TOKEN_ALTERNATIVES = (
 # matching if hardcoded dependency names spread beyond the allowlisted file.
 #
 # ponytail: the unquoted-RHS check (_ASSIGNMENT_RE) matches a single whole-line
-# `key: value` / `key=value` (optionally `export`/`readonly`-prefixed) only. It
-# does NOT catch a token in a compound statement (`A=x; B=y`) or an unquoted
-# YAML sequence item (`- FreeBSD:15:amd64` / `[a, b]`); none occur in the tree
-# and the spec scopes to key/value. A QUOTED token in any of these is still
-# caught by the quoted-literal path.
+# `key: value` / `key=value` (optionally prefixed by a shell assignment builtin)
+# only. It does NOT catch a token in a compound statement (`A=x; B=y`) or an
+# unquoted YAML sequence item (`- FreeBSD:15:amd64` / `[a, b]`); none occur in
+# the tree and the spec scopes to key/value. A QUOTED token in any of these is
+# still caught by the quoted-literal path.
 #
 # ponytail: a quoted illustrative example inside a multi-line YAML folded/
 # literal scalar (`description: >` ... "e.g. \"2.8\"" on a continuation line)
-# is not recognised as prose -- only `#` comments and Python triple-quoted
+# is not recognised as prose -- only comments and Python triple-quoted
 # docstrings are tracked. The single such site today (version-tracker.yml) was
 # fixed by DE-QUOTING the example, because a `version-literal-ok` comment cannot
 # sit inside a folded-scalar body without corrupting the visible description.
 # Upgrade to a YAML block-scalar tracker (indentation-based, mirroring
-# _prose_line_flags's docstring state machine) if more than one line ever needs it.
+# _code_lines's docstring state machine) if more than one line ever needs it.
+#
+# ponytail: XML comments (`<!-- -->`) are not tracked -- the scan roots hold 3
+# XML files with no version-token history; add a tracker if one ever bites.
+# Same for JS private fields (`this.#x`): `#` is treated as a comment opener
+# only in PHP-family files, so JS is safe from that, but a token inside a JS
+# regex literal containing `//` could be mis-stripped (2 JS files, none such).
 _FULL_VALUE_RE = re.compile("^(?:" + "|".join(_TOKEN_ALTERNATIVES) + ")$")
-# Optional `export`/`readonly` prefix: an unquoted `export ABI=FreeBSD:15:amd64`
-# is a real hardcode the quoted-literal path can't see (Copilot, PR #937).
+# Optional assignment-builtin prefix. The class is enumerated, not example-driven
+# (PR #937 pinned only the two keywords Copilot named -- issue #941): POSIX
+# `export`/`readonly`, the near-universal `local`, and bash/ksh
+# `declare`/`typeset` (with option words), which shellcheck bans here but a
+# hardcode guard should still see.
 _ASSIGNMENT_RE = re.compile(
-    r"^\s*(?:export\s+|readonly\s+)?[\w.-]+\s*[:=]\s*(?:" + "|".join(_TOKEN_ALTERNATIVES) + r")\s*$"
+    r"^\s*(?:(?:export|readonly|local|declare|typeset)(?:\s+-\w+)*\s+)?"
+    r"[\w.-]+\s*[:=]\s*(?:" + "|".join(_TOKEN_ALTERNATIVES) + r")\s*$"
 )
 
 _QUOTED_RE = re.compile(r'"([^"]*)"|\'([^\']*)\'')
 
-# Inline per-line escape, mirroring the URL-encoding checker's convention.
+# Inline per-line escape (`# version-literal-ok: <reason>`), spec'd in issue #922.
 _ESCAPE = "version-literal-ok"
 
 # Tracked-tree roots where a version literal could plausibly be pasted.
@@ -108,6 +120,10 @@ _SCAN_ROOTS = ("src", "scripts", ".github/workflows")
 
 # Self-reference: this checker and its own test define/contain the patterns.
 _EXCLUDED_SELF_NAMES = ("check_version_literals.py", "test_version_literal_check.py")
+
+# File types using C-style comments (`//`, `/* ... */`); `#` is a comment in
+# the PHP family but NOT in JS (private fields).
+_C_COMMENT_EXTS = (".php", ".inc", ".js")
 
 
 def _is_excluded(path: Path) -> bool:
@@ -149,9 +165,48 @@ def _strip_inline_comment(line: str) -> str:
     return line
 
 
-def _line_has_value_literal(line: str) -> bool:
-    """True if ``line`` holds a version token standing ALONE as a value."""
-    code = _strip_inline_comment(line)
+def _split_c_comment(line: str, hash_comments: bool) -> tuple[str, bool]:
+    """Return (code part of ``line``, True if an unclosed ``/*`` block opens here).
+
+    Quote-aware: ``//``, ``/*`` and ``#`` inside a quoted string are content,
+    not comments. A ``/*...*/`` pair closed on the same line is dropped and the
+    code after it is kept. ``hash_comments`` enables ``#`` (PHP family only --
+    in JS, ``#`` is a private-field sigil).
+    """
+    out: list[str] = []
+    quote: str | None = None
+    i = 0
+    n = len(line)
+    while i < n:
+        ch = line[i]
+        if quote is not None:
+            if ch == quote:
+                quote = None
+            out.append(ch)
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "#" and hash_comments:
+            return "".join(out), False
+        if ch == "/" and i + 1 < n and line[i + 1] == "/":
+            return "".join(out), False
+        if ch == "/" and i + 1 < n and line[i + 1] == "*":
+            end = line.find("*/", i + 2)
+            if end == -1:
+                return "".join(out), True
+            i = end + 2
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out), False
+
+
+def _line_has_value_literal(code: str) -> bool:
+    """True if ``code`` (comments already stripped) holds a token standing ALONE as a value."""
     for literal in _quoted_literals(code):
         if _FULL_VALUE_RE.fullmatch(literal):
             return True
@@ -172,44 +227,65 @@ def _tracked_files(roots: tuple[str, ...]) -> list[Path]:
 _TRIPLE_QUOTE_TOKENS = ('"""', "'''")
 
 
-def _prose_line_flags(lines: list[str], is_python: bool) -> list[bool]:
-    """Return, per line, whether it is a ``#`` comment or (in a .py file) prose.
+def _code_lines(lines: list[str], suffix: str) -> list[str | None]:
+    """Return, per line, the code portion to scan -- or ``None`` for prose.
 
-    ``#`` comment lines are prose in every scanned language (sh/yaml/py), so
-    that exemption is unconditional.
+    Comment syntax follows the file type (the axis is enumerated from the scan
+    roots' actual extensions, issue #941):
 
-    The triple-quote (docstring) state machine runs ONLY for Python sources
-    (``is_python``): once a line opens an odd number of triple-double- or
-    triple-single-quote tokens, every following line is prose until the matching
-    token closes it, so a docstring example (an arrow-mapping transformation)
-    stays out of the value scan. It is deliberately NOT applied to shell/YAML:
-    a shell value wrapped in triple quotes is valid POSIX adjacent-quote
-    concatenation that evaluates to the exact inner literal, so treating such a
-    line as prose outside .py would let a hardcoded token bypass the gate
-    entirely (PR #937).
+    * ``.php``/``.inc``/``.js``: ``//`` and ``/* ... */`` (state-tracked across
+      lines); ``#`` in the PHP family only. ponytail: code after a ``*/`` that
+      closes a MULTI-line block is not scanned until the next line (none in
+      the tree; a same-line `/*...*/` pair keeps its trailing code).
+    * everything else: ``#`` line/trailing comments.
+    * ``.py`` additionally tracks triple-quoted docstrings: an ODD number of
+      triple-quote tokens toggles the docstring state (a close-and-reopen on
+      one line therefore stays open -- the PR #937 parity bug, issue #941),
+      while an EVEN count on a non-docstring line falls through to the value
+      scan, so a one-line triple-quoted assignment (X = triple-quoted token)
+      is caught by the quoted-literal path instead of being swept as prose
+      (the ``.py`` mirror of PR #937's blocking F1). ponytail: a one-line
+      module docstring whose ENTIRE text is a bare token would now
+      false-positive -- absurd corner, escape-comment it if it ever occurs.
+      This is deliberately NOT applied to shell/YAML: a shell value wrapped in
+      triple quotes is adjacent-quote concatenation evaluating to the exact
+      inner literal (PR #937 F1).
     """
-    flags: list[bool] = []
+    out: list[str | None] = []
+    if suffix in _C_COMMENT_EXTS:
+        in_block = False
+        for line in lines:
+            if in_block:
+                if "*/" in line:
+                    in_block = False
+                out.append(None)
+                continue
+            code, in_block = _split_c_comment(line, hash_comments=suffix != ".js")
+            out.append(code)
+        return out
+    is_python = suffix == ".py"
     open_token = ""
     for line in lines:
         if open_token:
-            flags.append(True)
-            if open_token in line:
+            out.append(None)
+            if line.count(open_token) % 2 == 1:
                 open_token = ""
             continue
         if line.lstrip().startswith("#"):
-            flags.append(True)
+            out.append(None)
             continue
-        prose = False
         if is_python:
+            opened = False
             for token in _TRIPLE_QUOTE_TOKENS:
-                count = line.count(token)
-                if count:
-                    prose = True
-                    if count % 2 == 1:
-                        open_token = token
+                if line.count(token) % 2 == 1:
+                    open_token = token
+                    opened = True
                     break
-        flags.append(prose)
-    return flags
+            if opened:
+                out.append(None)
+                continue
+        out.append(_strip_inline_comment(line))
+    return out
 
 
 def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
@@ -221,11 +297,11 @@ def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
         except (OSError, UnicodeError):
             continue
         lines = text.splitlines()
-        prose_flags = _prose_line_flags(lines, path.suffix == ".py")
-        for lineno, (line, is_prose) in enumerate(zip(lines, prose_flags, strict=True), start=1):
-            if is_prose or _ESCAPE in line:
+        code_lines = _code_lines(lines, path.suffix)
+        for lineno, (line, code) in enumerate(zip(lines, code_lines, strict=True), start=1):
+            if code is None or _ESCAPE in line:
                 continue
-            if _line_has_value_literal(line):
+            if _line_has_value_literal(code):
                 violations.append((path, lineno, line.strip()))
     return violations
 

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -353,6 +353,23 @@ def test_js_hash_is_not_a_comment(tmp_path: Path) -> None:
     assert len(violations) == 1, f"# must not comment-strip JS; got {violations}"
 
 
+def test_js_template_literal_slashes_not_a_comment(tmp_path: Path) -> None:
+    # review-fanout C5 (PR #947): a // inside a backtick template literal is
+    # content, not a comment opener -- the real value after it must still flag.
+    content = 'const u = `https://example/x`; const f = "' + _PY311 + '";\n'
+    violations = _find_named(tmp_path, "s.js", content)
+    assert len(violations) == 1, f"// inside a template literal must not truncate the scan; got {violations}"
+
+
+def test_php_escaped_squote_before_squoted_token_flagged(tmp_path: Path) -> None:
+    # review-fanout C9 (PR #947): PHP/JS support \' inside single quotes; the
+    # naive single-quote span pairing swallowed a later single-quoted token on
+    # the same line. The C-style extractor is escape-aware on both quote types.
+    content = "$s = 'it\\'s fine'; $f = '" + _PY311 + "';\n"
+    violations = _find_named(tmp_path, "s.php", content)
+    assert len(violations) == 1, f"\\' must not swallow a later single-quoted token; got {violations}"
+
+
 # --- Issue #941: Python triple-quote fixes (parity + one-line value) --------
 
 
@@ -399,6 +416,15 @@ def test_stale_and_future_version_shapes_flagged(tmp_path: Path) -> None:
     for value in (_FREEBSD14, _FREEBSD17, "php7" + "4", "py3" + "12"):
         violations = _find(tmp_path, f'target: "{value}"\n')
         assert len(violations) == 1, f"version-agnostic shape must flag: {value}; got {violations}"
+
+
+def test_widened_varvers_flagged(tmp_path: Path) -> None:
+    # Discriminating rows for the varver widening (review-fanout C4/C8, PR
+    # #947): multi-digit components the old single-digit ce- pattern and the
+    # old exactly-2-digit plus- pattern could not match.
+    for value in ("ce-" + "2.10", "ce-" + "10.0", "plus-" + "27.1", "plus-" + "100.03"):
+        violations = _find(tmp_path, f'varver: "{value}"\n')
+        assert len(violations) == 1, f"generalized varver must flag: {value}; got {violations}"
 
 
 # --- Issue #940: the matrix tripwire (--verify-matrix) -----------------------
@@ -493,3 +519,34 @@ def test_verify_matrix_cli_exit_codes(tmp_path: Path) -> None:
     bad.write_text(json.dumps(_matrix([bad_entry])), encoding="utf-8")
     assert cvl.main(["--verify-matrix", "--matrix-file", str(good)]) == 0
     assert cvl.main(["--verify-matrix", "--matrix-file", str(bad)]) == 1
+
+
+def test_verify_matrix_config_errors_exit_2(tmp_path: Path) -> None:
+    # review-fanout C7 (PR #947): a misconfigured invocation (missing file,
+    # malformed JSON, bad ref) gets a one-line stderr message + exit 2 -- never
+    # a traceback, and never conflated with exit 1 (uncovered tokens).
+    missing = tmp_path / "nope.json"
+    garbled = tmp_path / "garbled.json"
+    garbled.write_text("{not json", encoding="utf-8")
+    assert cvl.main(["--verify-matrix", "--matrix-file", str(missing)]) == 2
+    assert cvl.main(["--verify-matrix", "--matrix-file", str(garbled)]) == 2
+    assert cvl.main(["--verify-matrix", "--ref", "origin/does-not-exist-" + "xyz"]) == 2
+
+
+def test_matrix_tokens_route_only_entries_excluded() -> None:
+    # review-fanout C1 (PR #947): a role=route-only entry (ADR-27 -- EOL'd but
+    # still served, frozen catalog) is excluded from the tripwire derivation,
+    # mirroring read-version-matrix.sh. Its wildly-out-of-window version must
+    # NOT be reported uncovered; the same entry without the role must be.
+    entry = {
+        "pfsense_version": "99" + ".99",
+        "channel": "Plus",
+        "freebsd_major": "15",
+        "php_version": "8.3",
+        "py_flavor": _PY311,
+        "role": "route-only",
+    }
+    assert cvl.uncovered_matrix_tokens(_matrix([entry])) == [], "route-only entries must be excluded"
+    active = {k: v for k, v in entry.items() if k != "role"}
+    uncovered = cvl.uncovered_matrix_tokens(_matrix([active]))
+    assert uncovered == ["99" + ".99"], f"the same entry without role must be reported; got {uncovered}"

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -274,3 +274,102 @@ def test_flags_php_flavor_quoted_value(tmp_path: Path) -> None:
     php85 = "php8" + "5"
     assert len(_find(tmp_path, f'PHPFLAVOR="{php83}"\n')) == 1, "quoted php83 flavor must flag"
     assert len(_find(tmp_path, f'flavor: "{php85}"\n')) == 1, "quoted php85 flavor must flag"
+
+
+# --- Issue #941: comment syntax follows the file type (PHP/JS) --------------
+# The axis is enumerated from the scan roots' actual extensions (git ls-files):
+# sh/yml/conf use `#` (already covered above); php/inc/js use `//` and
+# `/* ... */`, with `#` valid in the PHP family only.
+
+
+def _find_named(tmp_path: Path, name: str, content: str) -> list[Any]:
+    f = tmp_path / name
+    f.write_text(content, encoding="utf-8")
+    return cvl.find_violations([f])
+
+
+def test_php_line_comment_not_flagged(tmp_path: Path) -> None:
+    content = f'// example: "{_CE28}" is the CE version\n$x = 1;\n'
+    assert _find_named(tmp_path, "s.php", content) == [], "a // comment line must stay clean in PHP"
+
+
+def test_php_docblock_not_flagged(tmp_path: Path) -> None:
+    content = f'/**\n * @example "{_CE28}"\n */\n$x = 1;\n'
+    assert _find_named(tmp_path, "s.inc", content) == [], "a docblock body must stay clean in PHP"
+
+
+def test_php_trailing_line_comment_not_flagged(tmp_path: Path) -> None:
+    content = f'$v = pfb_build_varver($ver);  // e.g. "{_CE_VARVER}"\n'
+    assert _find_named(tmp_path, "s.php", content) == [], "a trailing // example must stay clean in PHP"
+
+
+def test_php_real_value_still_flagged(tmp_path: Path) -> None:
+    # Vacuity complement of the three exemptions above: a REAL PHP value must
+    # still flag, proving the comment stripping does not swallow code.
+    violations = _find_named(tmp_path, "s.php", f'$v = "{_CE28}";\n')
+    assert len(violations) == 1, f"a real PHP value assignment must flag; got {violations}"
+
+
+def test_php_same_line_block_comment_keeps_code(tmp_path: Path) -> None:
+    # A /*...*/ pair closed on the same line drops only the comment span; the
+    # code after it is still scanned.
+    violations = _find_named(tmp_path, "s.php", f'/* note */ $v = "{_CE28}";\n')
+    assert len(violations) == 1, f"code after a same-line block comment must be scanned; got {violations}"
+
+
+def test_php_comment_marker_inside_string_not_comment(tmp_path: Path) -> None:
+    # Quote-awareness: // inside a quoted string is content, so the real value
+    # after it must still flag.
+    violations = _find_named(tmp_path, "s.php", f'$s = "a // b"; $v = "{_CE28}";\n')
+    assert len(violations) == 1, f"// inside a string must not truncate the scan; got {violations}"
+
+
+def test_js_line_and_block_comments_not_flagged(tmp_path: Path) -> None:
+    line = f'// default "{_PY311}"\n'
+    block = f'/*\n * fallback "{_PY311}"\n */\nvar x = 1;\n'
+    assert _find_named(tmp_path, "s.js", line) == [], "a // comment must stay clean in JS"
+    assert _find_named(tmp_path, "s.js", block) == [], "a block-comment body must stay clean in JS"
+
+
+def test_js_hash_is_not_a_comment(tmp_path: Path) -> None:
+    # `#` is a private-field sigil in JS, not a comment -- a real value after a
+    # `#` must still flag (in PHP the same line would be comment-stripped).
+    content = f'this.#flavor = "{_PY311}";\n'
+    violations = _find_named(tmp_path, "s.js", content)
+    assert len(violations) == 1, f"# must not comment-strip JS; got {violations}"
+
+
+# --- Issue #941: Python triple-quote fixes (parity + one-line value) --------
+
+
+def test_py_one_line_triple_quoted_value_flagged(tmp_path: Path) -> None:
+    # The .py mirror of PR #937's blocking F1: X = """tok""" is a real string
+    # assignment, not a docstring -- sweeping any triple-quote line as prose
+    # let it bypass the gate.
+    content = 'FLAVOR = """' + _PY311 + '"""\n'
+    violations = _find_named(tmp_path, "s.py", content)
+    assert len(violations) == 1, f"a one-line triple-quoted value must flag; got {violations}"
+
+
+def test_py_docstring_close_reopen_stays_prose(tmp_path: Path) -> None:
+    # Parity bug (PR #937 audit): a line that closes AND reopens a docstring
+    # (even token count) must leave the docstring state OPEN, so the next line
+    # is still prose. The old `if open_token in line` check cleared the state
+    # and spuriously scanned line 3.
+    content = '"""doc\nx """ + """ y\n"' + _PY311 + '"\n"""\n'
+    assert _find_named(tmp_path, "s.py", content) == [], "a close-and-reopen line must keep the docstring open"
+
+
+# --- Issue #941: shell assignment-prefix builtins (the full class) ----------
+
+
+def test_prefixed_unquoted_assignments_flagged(tmp_path: Path) -> None:
+    # The class enumerated, not example-driven: POSIX export/readonly (covered
+    # above), plus local and bash/ksh declare/typeset (with option words).
+    for line in (
+        f"local ABI={_FREEBSD15}\n",
+        f"declare -r PYF={_PY311}\n",
+        f"typeset ABI={_FREEBSD15}\n",
+    ):
+        violations = _find(tmp_path, line)
+        assert len(violations) == 1, f"prefixed unquoted assignment must flag: {line!r}; got {violations}"

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -365,9 +365,36 @@ def test_php_escaped_squote_before_squoted_token_flagged(tmp_path: Path) -> None
     # review-fanout C9 (PR #947): PHP/JS support \' inside single quotes; the
     # naive single-quote span pairing swallowed a later single-quoted token on
     # the same line. The C-style extractor is escape-aware on both quote types.
+    # The .inc row pins that the whole PHP family shares the branch (re-review
+    # F3, PR #947).
     content = "$s = 'it\\'s fine'; $f = '" + _PY311 + "';\n"
-    violations = _find_named(tmp_path, "s.php", content)
-    assert len(violations) == 1, f"\\' must not swallow a later single-quoted token; got {violations}"
+    for name in ("s.php", "s.inc"):
+        violations = _find_named(tmp_path, name, content)
+        assert len(violations) == 1, f"\\' must not swallow a later single-quoted token ({name}); got {violations}"
+
+
+def test_backtick_spans_do_not_mispair_quotes(tmp_path: Path) -> None:
+    # re-review F1 (PR #947): two backtick segments each holding an odd count
+    # of the same quote char let the extractor pair a quote from inside the
+    # first with one from inside the second, swallowing the real value between
+    # them. Backtick spans are consumed as boundaries in BOTH extractor
+    # variants, so the bracketed value must flag in JS, PHP, and shell alike.
+    js = "const a = `it's`; const b = \"" + _CE28 + "\"; const c = `he's fine`;\n"
+    php = "$a = `it's`; $b = \"" + _CE28 + "\"; $c = `he's fine`;\n"
+    sh = "A=`echo it's`; B=\"" + _CE28 + "\"; C=`echo he's`\n"
+    assert len(_find_named(tmp_path, "s.js", js)) == 1, "JS backtick spans must not swallow the value between them"
+    assert len(_find_named(tmp_path, "s.php", php)) == 1, "PHP backtick spans must not swallow the value between them"
+    assert len(_find(tmp_path, sh)) == 1, "shell backtick spans must not swallow the value between them"
+
+
+def test_backtick_template_literal_is_a_value_in_js_only(tmp_path: Path) -> None:
+    # A backtick-delimited exact token is a template-literal VALUE in JS/PHP
+    # (C-style extractor captures the span); in shell a backtick span is
+    # command substitution, so the same shape stays clean there.
+    js = "const f = `" + _PY311 + "`;\n"
+    sh = "F=`" + _PY311 + "`\n"
+    assert len(_find_named(tmp_path, "s.js", js)) == 1, "a backtick-exact token is a value in JS"
+    assert _find(tmp_path, sh) == [], "a backtick span in shell is command substitution, not a value"
 
 
 # --- Issue #941: Python triple-quote fixes (parity + one-line value) --------

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -15,6 +15,7 @@ tests/test_appliance_python_check.py's convention -- defensive even though
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -159,14 +160,12 @@ def test_main_exit_codes(tmp_path: Path) -> None:
 
 
 def test_vacuity_guard_non_token_decimals_stay_clean(tmp_path: Path) -> None:
-    # python/php DOTTED forms ("3.11", "8.3") are not in the token list -- only
-    # php8x/py31x/2.8/2.9 are. FreeBSD:14/:17 are outside the supported 15/16
-    # window. If the checker discriminated on nothing but decimal shape, every
-    # one of these would (wrongly) flag.
+    # python/php DOTTED forms ("3.11", "8.3") are not in the token list. If the
+    # checker discriminated on nothing but decimal shape, both would (wrongly)
+    # flag. (FreeBSD:14/:17 moved to the FLAGGED rows in issue #940 -- the ABI
+    # shape is version-agnostic now.)
     assert _find(tmp_path, 'python_version: "3.11"\n') == [], '"3.11" is not a token'
     assert _find(tmp_path, 'php_version: "8.3"\n') == [], '"8.3" is not a token'
-    assert _find(tmp_path, f'target: "{_FREEBSD14}"\n') == [], "FreeBSD:14 is outside the supported window"
-    assert _find(tmp_path, f'target: "{_FREEBSD17}"\n') == [], "FreeBSD:17 is outside the supported window"
 
 
 # --- Hostile inputs ---------------------------------------------------------
@@ -235,9 +234,10 @@ def test_inline_trailing_comment_example_not_flagged(tmp_path: Path) -> None:
 
 
 def test_lookalike_tokens_not_flagged(tmp_path: Path) -> None:
-    # Longer lookalikes that merely start with a real token must not fullmatch.
-    assert _find(tmp_path, f'flavor: "{_PY3110_LOOKALIKE}"\n') == [], "py3110 is not py31[0-9]"
-    assert _find(tmp_path, f'target: "{_FREEBSD14}"\n') == [], "FreeBSD:14 is outside 15/16"
+    # Lookalikes that merely start with a real token shape must not fullmatch.
+    freebsd_1x = "FreeBSD" + ":1x"
+    assert _find(tmp_path, f'flavor: "{_PY3110_LOOKALIKE}"\n') == [], "py3110 is one digit too long"
+    assert _find(tmp_path, f'target: "{freebsd_1x}"\n') == [], "FreeBSD:1x is not a numeric ABI"
 
 
 # --- PR #937 review follow-ups ---------------------------------------------
@@ -373,3 +373,109 @@ def test_prefixed_unquoted_assignments_flagged(tmp_path: Path) -> None:
     ):
         violations = _find(tmp_path, line)
         assert len(violations) == 1, f"prefixed unquoted assignment must flag: {line!r}; got {violations}"
+
+
+# --- Issue #940: unambiguous shapes are version-agnostic ---------------------
+
+
+def test_stale_and_future_version_shapes_flagged(tmp_path: Path) -> None:
+    # A stale (FreeBSD:14) or future (FreeBSD:17) ABI, or an out-of-window
+    # php/py flavor, is a hardcode with the same drift hazard as a current one
+    # (issue #940) -- the unambiguous shapes no longer carry a version window.
+    for value in (_FREEBSD14, _FREEBSD17, "php7" + "4", "py3" + "12"):
+        violations = _find(tmp_path, f'target: "{value}"\n')
+        assert len(violations) == 1, f"version-agnostic shape must flag: {value}; got {violations}"
+
+
+# --- Issue #940: the matrix tripwire (--verify-matrix) -----------------------
+# The windowed CE/Plus numerics restate the matrix window; the tripwire fails
+# CI the moment supported-versions.json carries a version they no longer cover.
+
+
+def _matrix(entries: list[dict[str, str]]) -> dict[str, Any]:
+    return {"versions": entries}
+
+
+def _current_shape_matrix() -> dict[str, Any]:
+    return _matrix(
+        [
+            {
+                "pfsense_version": _CE28,
+                "channel": "CE",
+                "freebsd_major": "15",
+                "php_version": "8.3",
+                "py_flavor": _PY311,
+            },
+            {
+                "pfsense_version": _PLUS2603,
+                "channel": "Plus",
+                "freebsd_major": "16",
+                "php_version": "8.5",
+                "py_flavor": _PY311,
+            },
+        ]
+    )
+
+
+def test_matrix_tokens_current_shape_covered() -> None:
+    uncovered = cvl.uncovered_matrix_tokens(_current_shape_matrix())
+    assert uncovered == [], f"the live-shape matrix must be fully covered; got {uncovered}"
+
+
+def test_matrix_tokens_dot_x_suffix_stripped() -> None:
+    m = _matrix(
+        [
+            {
+                "pfsense_version": _CE28 + ".x",
+                "channel": "CE",
+                "freebsd_major": "15",
+                "php_version": "8.3",
+                "py_flavor": _PY311,
+            }
+        ]
+    )
+    uncovered = cvl.uncovered_matrix_tokens(m)
+    assert uncovered == [], f"a trailing .x on pfsense_version must be stripped; got {uncovered}"
+
+
+def test_matrix_tokens_future_versions_uncovered() -> None:
+    # The tripwire's red case: CE 3.0 and Plus 27.01 fall outside the windowed
+    # numerics (their varvers, ABI, and flavors are already version-agnostic).
+    ce30 = "3" + ".0"
+    plus2701 = "27" + ".01"
+    m = _matrix(
+        [
+            {
+                "pfsense_version": ce30,
+                "channel": "CE",
+                "freebsd_major": "17",
+                "php_version": "9.1",
+                "py_flavor": "py3" + "13",
+            },
+            {
+                "pfsense_version": plus2701,
+                "channel": "Plus",
+                "freebsd_major": "17",
+                "php_version": "9.1",
+                "py_flavor": "py3" + "13",
+            },
+        ]
+    )
+    uncovered = cvl.uncovered_matrix_tokens(m)
+    assert uncovered == [plus2701, ce30], f"future windowed numerics must be reported uncovered; got {uncovered}"
+
+
+def test_verify_matrix_cli_exit_codes(tmp_path: Path) -> None:
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps(_current_shape_matrix()), encoding="utf-8")
+    bad = tmp_path / "bad.json"
+    bad_entry = {
+        "pfsense_version": "27" + ".01",
+        "channel": "Plus",
+        "freebsd_major": "17",
+        "php_version": "9.1",
+        "py_flavor": "py3" + "13",
+    }
+    bad.write_text(json.dumps(_matrix([bad_entry])), encoding="utf-8")
+    assert cvl.main(["--verify-matrix", "--matrix-file", str(good)]) == 0
+    assert cvl.main(["--verify-matrix", "--matrix-file", str(bad)]) == 1

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -331,6 +331,20 @@ def test_js_line_and_block_comments_not_flagged(tmp_path: Path) -> None:
     assert _find_named(tmp_path, "s.js", block) == [], "a block-comment body must stay clean in JS"
 
 
+def test_escaped_quote_does_not_misclose_string(tmp_path: Path) -> None:
+    # Copilot (PR #947): a backslash-escaped quote inside a string mis-closed
+    # the quote tracker, so a // (PHP/JS) or # (shell) INSIDE the string read
+    # as a comment opener and truncated the scan -- hiding a real value after
+    # it. Same class in both trackers (_split_c_comment and
+    # _strip_inline_comment), so all three rows must flag.
+    php_dquote = '$s = "a \\" // not a comment"; $v = "' + _CE28 + '";\n'
+    php_squote = "$s = 'it\\'s // x'; $v = \"" + _CE28 + '";\n'
+    sh_dquote = 'MSG="a \\" # note"; V="' + _CE28 + '"\n'
+    assert len(_find_named(tmp_path, "s.php", php_dquote)) == 1, "escaped dquote must not hide a PHP value"
+    assert len(_find_named(tmp_path, "s2.php", php_squote)) == 1, "escaped squote must not hide a PHP value"
+    assert len(_find(tmp_path, sh_dquote)) == 1, "escaped dquote must not hide a shell value"
+
+
 def test_js_hash_is_not_a_comment(tmp_path: Path) -> None:
     # `#` is a private-field sigil in JS, not a comment -- a real value after a
     # `#` must still flag (in PHP the same line would be comment-stripped).


### PR DESCRIPTION
Hardens `scripts/check_version_literals.py` (PR #937 / issue #922) against the residual gaps the post-merge audit found. Two commits, one per issue.

## Commit 1 — detection gaps (#941)

Every gap was reproduced by an executed probe before fixing:

- **Comment syntax now follows the file type**, with the axis enumerated from the scan roots' actual extensions (`git ls-files`): PHP/`.inc`/JS get quote-aware `//` and `/* ... */` handling (block state tracked across lines); `#` stays a comment in the PHP family only (in JS it is a private-field sigil). Previously a `// example: "2.8"` PHP comment flagged as a value — a latent false-positive class in `src/`'s dominant language, which had zero test rows.
- **Python triple-quote machine fixed on token parity**: a close-and-reopen line keeps the docstring open (was: spurious scan of docstring content), and an even-count code line falls through to the value scan, so a one-line `X = """py311"""` assignment no longer bypasses the gate — the `.py` mirror of PR #937's blocking F1.
- **Assignment-prefix builtins enumerated as a class** (`local`/`declare`/`typeset` join `export`/`readonly`) instead of pinning only the keywords the original review finding named.
- **Documentation pointers fixed**: the invented "mirrors the URL-encoding checker's convention" lineage is gone (no sibling checker has an escape mechanism), and `docs/misc/pfSense_versions.md` now actually documents the policy the failure message points at.

## Commit 2 — matrix-window drift tripwire (#940)

The checker's own patterns restated today's matrix window in a file self-excluded from its own scan — the exact silent-narrowing drift it polices:

- **Unambiguous shapes are version-agnostic now**: `FreeBSD:<any major>`, `php[0-9]{2}`, `py3[0-9]{2}`, generalized varvers. A stale (`FreeBSD:14`) or future (`FreeBSD:17`) ABI is as much a hardcode as a current one. Probed before widening: zero new hits over the tree.
- **The windowed CE/Plus numerics get a tripwire**: new `--verify-matrix` mode derives every version-shaped token implied by `supported-versions.json` (bare version, varver, ABI, php/py flavors) and exits 1 listing any the patterns no longer cover; wired as a blocking `test.yml` step (fetching `ci-metadata` the same way `test-version-matrix` does). The moment the matrix moves past the window, CI fails loudly instead of the gate narrowing silently.
- **`version-bump-runbook.md` gains step 5**: widen the window when the tripwire fires; hand-sweep the `version-literal-ok` escaped defaults, which the escape exempts from every other gate.

## Evidence

- Red→green executed both commits: commit 1's 8 behaviour-changing tests fail on the pre-fix checker (`8 failed, 29 passed`) and pass after; commit 2's 5 tests fail on the commit-1 checker (`5 failed, 37 passed`) and pass after (`42 passed`).
- Executed red demos for the new wiring: `--verify-matrix` against a Plus 27.01 fixture exits 1 naming `27.01`; staging a violating file trips the pre-commit hook (`[pre-commit] FAILED: version-literals`).
- Gates: full pytest `2352 passed, 2 skipped`; `ruff check` / `ruff format --check` / `mypy tests/` clean; `markdownlint` clean; `test.yml` YAML-parses; tree scan and live `--verify-matrix` both exit 0.

Fixes #940. Fixes #941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ooLjvBBm6oznTBUg9mxVF
