### PR TITLE
pfblockerng: apply per-field write adapters in PfbConfig::writeSection

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -91,9 +91,9 @@ on rollback the old code **ignores** the key (inert, not misread or corrupting) 
 version (inherent, out of scope). `since-version` bounds each field's rollback claim to releases
 at/after that version; it is a per-field scope marker, not a migration.
 
-### Section writes are normalized too (issue #930)
+### Section writes are normalised too (issue #930)
 
-`PfbConfig::writeSection($section, $data)` applies the **same** BACKWARD-invariant normalization
+`PfbConfig::writeSection($section, $data)` applies the **same** BACKWARD-invariant normalisation
 as a single-key `PfbConfig::write()` — for every key in `$data` that is registered to the EXACT
 target `$section` (a same-named key registered to a *different* section is foreign data and is
 left untouched) and carries **both** a read and a write adapter, the value is round-tripped

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -91,6 +91,32 @@ on rollback the old code **ignores** the key (inert, not misread or corrupting) 
 version (inherent, out of scope). `since-version` bounds each field's rollback claim to releases
 at/after that version; it is a per-field scope marker, not a migration.
 
+### Section writes are normalized too (issue #930)
+
+`PfbConfig::writeSection($section, $data)` applies the **same** BACKWARD-invariant normalization
+as a single-key `PfbConfig::write()` — for every key in `$data` that is registered to the EXACT
+target `$section` (a same-named key registered to a *different* section is foreign data and is
+left untouched) and carries **both** a read and a write adapter, the value is round-tripped
+`read_adapter()` then `write_adapter()` before the section is persisted. A key with no adapter
+pair (plain string) or not present in `$data` passes through byte-identical; `writeSection()`
+never calls `write_config()`.
+
+Before this fix, `writeSection()` called `config_set_path($section, $data)` directly, bypassing
+every adapter — a legacy read-only token (`alexa_type` `'domcop'`/`'alexa'`, `pfb_idn` alpha-only
+`'all'`) or a hostile/junk value riding **any** section-blob write (a `www/` save handler, an
+install seed, a migration) persisted raw into `config.xml` instead of being coalesced to its
+canonical form. The consequence: the RollbackContract's "never re-emitted" guarantee above now
+holds on section writes too, and a legacy token riding a `readSection()` → `writeSection()`
+round-trip (a restored backup, an HA sync, a hand-edited `config.xml`) is coalesced to canonical
+on the next save — it does not perpetually re-emit itself just because the write went through the
+section-level helper instead of the per-key one.
+
+Coverage: `tests/php/CfgGatewayTest.php` — a property test iterating `pfb_cfg_registry()` itself
+(every adapter-bearing field × a canonical/legacy/junk sample set, compared against the
+`PfbConfig::write()` oracle) plus targeted scenario and hostile-input tests (legacy `alexa_type`
+tokens, alpha-only `pfb_idn`, a non-scalar/`NULL`/enum-instance/int value, an unadapted key,
+a same-named key in a foreign section, a mixed realistic section blob).
+
 ## Field vocabularies (`pfb_cfg_field_vocab()`)
 
 | Adapter type | Stored vocabulary |

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1400,7 +1400,7 @@ function pfb_dnsbl_webpage(): string
  *   PfbConfig::write($key, $value)                 — write one field
  *   PfbConfig::delete($key)                        — delete one field
  *   PfbConfig::readSection($section)               — read a whole section array
- *   PfbConfig::writeSection($section, $data)       — write a section array, normalizing
+ *   PfbConfig::writeSection($section, $data)       — write a section array, normalising
  *                                                     its registered fields through their
  *                                                     adapters (issue #930)
  *   PfbConfig::deleteSection($section)             — delete a whole section
@@ -1482,7 +1482,7 @@ final class PfbConfig
 	}
 
 	/**
-	 * Write a whole section array, normalizing every registered field of
+	 * Write a whole section array, normalising every registered field of
 	 * $section through its adapter pair before persisting (issue #930).
 	 *
 	 * For each key in $data that is registered to this EXACT section (a

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1400,7 +1400,9 @@ function pfb_dnsbl_webpage(): string
  *   PfbConfig::write($key, $value)                 — write one field
  *   PfbConfig::delete($key)                        — delete one field
  *   PfbConfig::readSection($section)               — read a whole section array
- *   PfbConfig::writeSection($section, $data)       — write a whole section array
+ *   PfbConfig::writeSection($section, $data)       — write a section array, normalizing
+ *                                                     its registered fields through their
+ *                                                     adapters (issue #930)
  *   PfbConfig::deleteSection($section)             — delete a whole section
  *
  * @see pfb_cfg_registry()
@@ -1480,17 +1482,50 @@ final class PfbConfig
 	}
 
 	/**
-	 * Write a whole section array (no per-key adapters applied).
+	 * Write a whole section array, normalizing every registered field of
+	 * $section through its adapter pair before persisting (issue #930).
 	 *
-	 * Equivalent to config_set_path($section, $data) for callers that
-	 * manipulate the section blob directly (www/ save handlers). Does NOT
-	 * call write_config() — callers persist.
+	 * For each key in $data that is registered to this EXACT section (a
+	 * registered key name living under a DIFFERENT section path is foreign
+	 * data and is left untouched) and carries BOTH a read and a write
+	 * adapter, the value is round-tripped read_adapter() then
+	 * write_adapter() — coalescing a legacy/read-only token (e.g. alexa_type
+	 * 'domcop'/'alexa', pfb_idn 'all'), a NULL, a non-scalar (a crafted POST
+	 * array), or junk input to the field's canonical stored form, exactly as
+	 * a single-key PfbConfig::write() would. Unregistered keys and
+	 * adapter-less (plain-string) registered keys pass through byte-identical.
+	 * Consequence: the RollbackContract "never re-emitted" legacy-token
+	 * guarantee (see class docblock / ADR-29 §2.3) now holds on section
+	 * writes too — a legacy token riding a readSection()->writeSection()
+	 * round-trip (a restored backup, an HA sync, a hand-edited config.xml)
+	 * is coalesced to canonical on the next save. Does NOT call
+	 * write_config() — callers persist.
+	 *
+	 * Read adapter runs FIRST (mixed -> runtime value; the non-scalar guard
+	 * handles arrays/NULL/junk and is idempotent on an already-adapted enum
+	 * instance), write adapter SECOND (runtime value -> canonical stored
+	 * string) — calling the write adapter directly on a raw array or NULL
+	 * would TypeError (write adapters are typed EnumClass|string).
 	 *
 	 * @param string $section  The full config.xml section path.
 	 * @param array  $data     Section data to persist.
 	 */
 	public static function writeSection(string $section, array $data): void
 	{
+		foreach (pfb_cfg_registry() as $key => $entry) {
+			if ($entry['section'] !== $section) {
+				continue;
+			}
+			$read_adapter  = $entry['read_adapter'];
+			$write_adapter = $entry['write_adapter'];
+			if ($read_adapter === NULL || $write_adapter === NULL) {
+				continue;
+			}
+			if (!array_key_exists($key, $data)) {
+				continue;
+			}
+			$data[$key] = $write_adapter($read_adapter($data[$key]));
+		}
 		config_set_path($section, $data);
 	}
 

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -2189,7 +2189,7 @@ final class CfgGatewayTest extends TestCase
 	// directly, bypassing every registered adapter -- a legacy read-only token
 	// ('domcop', 'alexa', alpha-only 'all') or hostile/junk value written through
 	// ANY section blob (www/ save handlers, install seeds, migrations) persisted
-	// raw into config.xml instead of being normalized like a single-key write().
+	// raw into config.xml instead of being normalised like a single-key write().
 	// -----------------------------------------------------------------------
 
 	/**
@@ -2302,7 +2302,7 @@ final class CfgGatewayTest extends TestCase
 
 	/**
 	 * A live canonical alexa_type token ('cisco') riding a section blob write
-	 * passes through byte-identical -- normalization never mangles a live token.
+	 * passes through byte-identical -- normalisation never mangles a live token.
 	 *
 	 * Scenario:
 	 *   Given a DNSBL settings blob with the canonical 'cisco' alexa_type token.
@@ -2323,7 +2323,7 @@ final class CfgGatewayTest extends TestCase
 
 	/**
 	 * pfb_idn: the dropped 4.0.0-alpha-only 'all' token riding a section blob
-	 * write normalizes to 'off' (never re-emitted); the canonical 'on' token
+	 * write normalises to 'off' (never re-emitted); the canonical 'on' token
 	 * (= PfbIdnMode::All) stays 'on' unchanged.
 	 *
 	 * Scenario:
@@ -2337,10 +2337,10 @@ final class CfgGatewayTest extends TestCase
 		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
 		$path    = $section . '/pfb_idn';
 
-		// Alpha-only 'all' -> normalized to 'off'.
+		// Alpha-only 'all' -> normalised to 'off'.
 		PfbConfig::writeSection($section, ['pfb_idn' => 'all']);
 		$this->assertSame('off', config_get_path($path),
-			"dropped alpha-only 'all' riding a section write normalizes to 'off'"
+			"dropped alpha-only 'all' riding a section write normalises to 'off'"
 		);
 
 		// Canonical 'on' -> stays 'on'.
@@ -2352,7 +2352,7 @@ final class CfgGatewayTest extends TestCase
 
 	/**
 	 * pfb_keep: the legacy empty-string token (pre-#484 absent-key install)
-	 * riding a section blob write normalizes to the explicit 'off' token, same
+	 * riding a section blob write normalises to the explicit 'off' token, same
 	 * as the single-key PfbConfig::write() lenient-adapter contract.
 	 *
 	 * Scenario:
@@ -2368,7 +2368,7 @@ final class CfgGatewayTest extends TestCase
 		PfbConfig::writeSection($section, ['pfb_keep' => '']);
 
 		$this->assertSame('off', config_get_path($path),
-			"legacy empty pfb_keep riding a section write normalizes to 'off'"
+			"legacy empty pfb_keep riding a section write normalises to 'off'"
 		);
 	}
 
@@ -2396,7 +2396,7 @@ final class CfgGatewayTest extends TestCase
 	/**
 	 * Hostile input: a crafted array value (e.g. a POST array
 	 * alexa_type[]=x) riding a section blob write hits the adapter's
-	 * non-scalar guard and normalizes to the parse-fallback default, never
+	 * non-scalar guard and normalises to the parse-fallback default, never
 	 * crashes and never persists the raw array.
 	 *
 	 * Scenario:
@@ -2465,7 +2465,7 @@ final class CfgGatewayTest extends TestCase
 	/**
 	 * Hostile input: an integer value on an adapted key riding a section blob
 	 * write hits the non-scalar-adjacent junk path (no matching token) and
-	 * normalizes to the field's parse-fallback default.
+	 * normalises to the field's parse-fallback default.
 	 *
 	 * Scenario:
 	 *   Given a DNSBL settings blob with alexa_type = 1 (int, not a string token).
@@ -2480,14 +2480,14 @@ final class CfgGatewayTest extends TestCase
 		PfbConfig::writeSection($section, ['alexa_type' => 1]);
 
 		$this->assertSame('tranco', config_get_path($path),
-			'int-valued alexa_type riding a section write normalizes to the parse-fallback tranco'
+			'int-valued alexa_type riding a section write normalises to the parse-fallback tranco'
 		);
 	}
 
 	/**
 	 * A registered key with NO adapter pair (plain string, e.g. top1m_token and
 	 * dnsbl_interface) riding a section blob write is left byte-identical --
-	 * normalization only ever touches adapter-bearing keys.
+	 * normalisation only ever touches adapter-bearing keys.
 	 *
 	 * Scenario:
 	 *   Given a DNSBL settings blob with two unadapted registered keys.
@@ -2522,7 +2522,7 @@ final class CfgGatewayTest extends TestCase
 	 *     'alexa_type' (foreign to this section -- the registry maps alexa_type
 	 *     to the DNSBL section only) with the legacy 'domcop' value.
 	 *   When PfbConfig::writeSection() persists it against the SYNC section.
-	 *   Then the stored value is the raw 'domcop' -- no normalization applied,
+	 *   Then the stored value is the raw 'domcop' -- no normalisation applied,
 	 *     because no registry entry has 'section' === the sync section for
 	 *     this key.
 	 */
@@ -2541,7 +2541,7 @@ final class CfgGatewayTest extends TestCase
 	/**
 	 * A realistic dconfig-shaped blob (mirrors pfblockerng_dnsbl.php's save
 	 * handler): a mix of adapted legacy/hostile tokens and unadapted
-	 * base64/plain fields. Adapted fields normalize; every other field is
+	 * base64/plain fields. Adapted fields normalise; every other field is
 	 * byte-identical.
 	 *
 	 * Scenario:
@@ -2557,8 +2557,8 @@ final class CfgGatewayTest extends TestCase
 
 		$data = [
 			'pfb_dnsbl'       => 'on',           // adapted (toggle), canonical.
-			'alexa_type'      => 'domcop',        // adapted (top1m_source), LEGACY -> normalizes.
-			'pfb_idn'         => 'all',           // adapted (idn_mode), ALPHA-ONLY -> normalizes.
+			'alexa_type'      => 'domcop',        // adapted (top1m_source), LEGACY -> normalises.
+			'pfb_idn'         => 'all',           // adapted (idn_mode), ALPHA-ONLY -> normalises.
 			'pfb_hsts'        => 'on',            // adapted (toggle), canonical.
 			'dnsbl_interface' => 'lo0',           // unadapted, plain.
 			'pfb_dnsvip4'     => '',              // unadapted, plain.
@@ -2570,11 +2570,42 @@ final class CfgGatewayTest extends TestCase
 		$result = PfbConfig::readSection($section);
 
 		$this->assertSame('on', $result['pfb_dnsbl'], 'pfb_dnsbl canonical stays on');
-		$this->assertSame('openpagerank', $result['alexa_type'], "legacy 'domcop' normalizes to 'openpagerank'");
-		$this->assertSame('off', $result['pfb_idn'], "alpha-only 'all' normalizes to 'off'");
+		$this->assertSame('openpagerank', $result['alexa_type'], "legacy 'domcop' normalises to 'openpagerank'");
+		$this->assertSame('off', $result['pfb_idn'], "alpha-only 'all' normalises to 'off'");
 		$this->assertSame('on', $result['pfb_hsts'], 'pfb_hsts canonical stays on');
 		$this->assertSame('lo0', $result['dnsbl_interface'], 'unadapted dnsbl_interface is byte-identical');
 		$this->assertSame('', $result['pfb_dnsvip4'], 'unadapted pfb_dnsvip4 is byte-identical');
 		$this->assertSame('QWJjMTIz', $result['top1m_token'], 'unadapted top1m_token is byte-identical');
+	}
+
+	/**
+	 * The gateway NEVER calls write_config() -- the caller decides when to
+	 * flush (CLAUDE.md "Config gateway -- PfbConfig"). Pins that invariant for
+	 * every public PfbConfig method: the pfsense_doubles write_config() records
+	 * each call in $GLOBALS['pfb_test_write_config_calls'], so an accidental
+	 * write_config() slipped into any gateway path fails this test (PR #949
+	 * review: a mutation adding one to writeSection() survived the whole suite).
+	 *
+	 * Scenario:
+	 *   Given a clean write_config() call recorder.
+	 *   When every public PfbConfig method runs (read/write/delete +
+	 *     readSection/writeSection/deleteSection).
+	 *   Then zero write_config() calls were recorded.
+	 */
+	public function testGatewayNeverCallsWriteConfig(): void
+	{
+		$GLOBALS['pfb_test_write_config_calls'] = [];
+
+		PfbConfig::write('pfb_keep', 'on');
+		PfbConfig::read('pfb_keep');
+		PfbConfig::delete('pfb_keep');
+		PfbConfig::readSection('installedpackages/pfblockerng/config/0');
+		PfbConfig::writeSection('installedpackages/pfblockerng/config/0', ['pfb_keep' => '', 'pfb_interval' => '1']);
+		PfbConfig::deleteSection('installedpackages/pfblockerng/config/0');
+
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'],
+			'PfbConfig must never call write_config() -- the caller flushes');
+
+		unset($GLOBALS['pfb_test_write_config_calls']);
 	}
 }

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -2181,4 +2181,400 @@ final class CfgGatewayTest extends TestCase
 			"dnsbl_dot_block_exclude absent -> '' (registered default)"
 		);
 	}
+
+	// -----------------------------------------------------------------------
+	// E — writeSection() applies per-field write adapters (issue #930)
+	//
+	// Before this fix, writeSection() called config_set_path($section, $data)
+	// directly, bypassing every registered adapter -- a legacy read-only token
+	// ('domcop', 'alexa', alpha-only 'all') or hostile/junk value written through
+	// ANY section blob (www/ save handlers, install seeds, migrations) persisted
+	// raw into config.xml instead of being normalized like a single-key write().
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Property test: for EVERY registered key carrying both a read and a write
+	 * adapter (enumerated from pfb_cfg_registry() itself, never a hand-picked
+	 * subset -- so this can't under-enumerate), writeSection($section, [$key =>
+	 * $raw]) must persist the exact same stored byte PfbConfig::write($key, $raw)
+	 * would for a representative sample set per adapter type: a canonical token,
+	 * a legacy/empty token, and a junk string.
+	 *
+	 * Scenario:
+	 *   Given a registered key with an adapter pair, and a raw sample value.
+	 *   When writeSection($section, [$key => $raw]) and write($key, $raw) are each
+	 *     applied to a fresh config slate.
+	 *   Then both persist the identical stored byte at the key's config.xml path.
+	 */
+	public function testWriteSectionAppliesAdapterForEveryRegisteredFieldAndSample(): void
+	{
+		$samples_by_read_adapter = [
+			'pfb_cfg_toggle_read'           => ['on', '', 'junk'],
+			'pfb_cfg_lenient_read'          => ['on', 'off', '', 'junk'],
+			'pfb_cfg_idn_mode_read'         => ['on', 'confusable', 'off', 'all', 'junk'],
+			'pfb_cfg_top1m_source_read'     => ['tranco', 'cisco', 'openpagerank', 'majestic', 'cloudflare', 'alexa', 'domcop', 'junk'],
+			'pfb_cfg_alias_delta_mode_read' => ['auto', 'delta', 'replace', '', 'junk'],
+		];
+
+		$tested = 0;
+		foreach (pfb_cfg_registry() as $key => $entry) {
+			$read_adapter  = $entry['read_adapter'];
+			$write_adapter = $entry['write_adapter'];
+			if ($read_adapter === NULL || $write_adapter === NULL) {
+				continue;
+			}
+			$this->assertArrayHasKey($read_adapter, $samples_by_read_adapter,
+				"no sample set registered for adapter type '{$read_adapter}' (field '{$key}') -- extend the sample map"
+			);
+
+			$section = $entry['section'];
+			$path    = $section . '/' . $key;
+
+			foreach ($samples_by_read_adapter[$read_adapter] as $raw) {
+				// Oracle: PfbConfig::write() on a fresh slate.
+				$GLOBALS['config'] = [];
+				PfbConfig::write($key, $raw);
+				$expected = config_get_path($path);
+
+				// Under test: PfbConfig::writeSection() on a fresh slate.
+				$GLOBALS['config'] = [];
+				PfbConfig::writeSection($section, [$key => $raw]);
+				$actual = config_get_path($path);
+
+				$this->assertSame($expected, $actual,
+					"writeSection() vs write() mismatch for key '{$key}' raw " . var_export($raw, TRUE)
+				);
+				$tested++;
+			}
+		}
+
+		// Sanity: the loop actually exercised all 16 adapted fields x >= 3 samples
+		// each (issue #930 coverage matrix) -- guards against a future registry
+		// refactor silently emptying the loop.
+		$this->assertGreaterThanOrEqual(16 * 3, $tested,
+			'expected at least 16 adapted fields x >= 3 samples each to have been exercised'
+		);
+	}
+
+	/**
+	 * THE pinning red test (mirrors the issue #930 repro): a legacy 'domcop'
+	 * alexa_type token riding a section blob write is no longer re-emitted raw --
+	 * it is coalesced to the canonical 'openpagerank' token, same as a single-key
+	 * PfbConfig::write('alexa_type', 'domcop') would.
+	 *
+	 * Scenario:
+	 *   Given a DNSBL settings blob with the legacy 'domcop' alexa_type token.
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then the stored alexa_type is 'openpagerank', never the dead 'domcop' token.
+	 */
+	public function testWriteSectionAlexaTypeLegacyDomcopNormalisesToOpenPageRank(): void
+	{
+		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
+		$path    = $section . '/alexa_type';
+
+		PfbConfig::writeSection($section, ['alexa_type' => 'domcop']);
+
+		$this->assertSame('openpagerank', config_get_path($path),
+			"legacy 'domcop' riding a section write coalesces to 'openpagerank'"
+		);
+	}
+
+	/**
+	 * Legacy 'alexa' (dead TOP1M service, #872) riding a section blob write
+	 * coalesces to the canonical 'tranco' token.
+	 *
+	 * Scenario:
+	 *   Given a DNSBL settings blob with the legacy 'alexa' alexa_type token.
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then the stored alexa_type is 'tranco', never the dead 'alexa' token.
+	 */
+	public function testWriteSectionAlexaTypeLegacyAlexaNormalisesToTranco(): void
+	{
+		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
+		$path    = $section . '/alexa_type';
+
+		PfbConfig::writeSection($section, ['alexa_type' => 'alexa']);
+
+		$this->assertSame('tranco', config_get_path($path),
+			"legacy 'alexa' riding a section write coalesces to 'tranco'"
+		);
+	}
+
+	/**
+	 * A live canonical alexa_type token ('cisco') riding a section blob write
+	 * passes through byte-identical -- normalization never mangles a live token.
+	 *
+	 * Scenario:
+	 *   Given a DNSBL settings blob with the canonical 'cisco' alexa_type token.
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then the stored alexa_type is still 'cisco'.
+	 */
+	public function testWriteSectionAlexaTypeCanonicalCiscoPassesThroughUnchanged(): void
+	{
+		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
+		$path    = $section . '/alexa_type';
+
+		PfbConfig::writeSection($section, ['alexa_type' => 'cisco']);
+
+		$this->assertSame('cisco', config_get_path($path),
+			"canonical 'cisco' riding a section write is byte-identical"
+		);
+	}
+
+	/**
+	 * pfb_idn: the dropped 4.0.0-alpha-only 'all' token riding a section blob
+	 * write normalizes to 'off' (never re-emitted); the canonical 'on' token
+	 * (= PfbIdnMode::All) stays 'on' unchanged.
+	 *
+	 * Scenario:
+	 *   Given a DNSBL settings blob with pfb_idn = the alpha-only 'all' token.
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then the stored pfb_idn is 'off', never the dropped 'all' token.
+	 *   And a canonical 'on' token riding the same path stays 'on'.
+	 */
+	public function testWriteSectionPfbIdnAlphaOnlyAllNormalisesToOff(): void
+	{
+		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
+		$path    = $section . '/pfb_idn';
+
+		// Alpha-only 'all' -> normalized to 'off'.
+		PfbConfig::writeSection($section, ['pfb_idn' => 'all']);
+		$this->assertSame('off', config_get_path($path),
+			"dropped alpha-only 'all' riding a section write normalizes to 'off'"
+		);
+
+		// Canonical 'on' -> stays 'on'.
+		PfbConfig::writeSection($section, ['pfb_idn' => 'on']);
+		$this->assertSame('on', config_get_path($path),
+			"canonical 'on' riding a section write is byte-identical"
+		);
+	}
+
+	/**
+	 * pfb_keep: the legacy empty-string token (pre-#484 absent-key install)
+	 * riding a section blob write normalizes to the explicit 'off' token, same
+	 * as the single-key PfbConfig::write() lenient-adapter contract.
+	 *
+	 * Scenario:
+	 *   Given a General settings blob with pfb_keep = '' (legacy empty).
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then the stored pfb_keep is 'off', never the legacy '' token.
+	 */
+	public function testWriteSectionPfbKeepEmptyNormalisesToOff(): void
+	{
+		$section = 'installedpackages/pfblockerng/config/0';
+		$path    = $section . '/pfb_keep';
+
+		PfbConfig::writeSection($section, ['pfb_keep' => '']);
+
+		$this->assertSame('off', config_get_path($path),
+			"legacy empty pfb_keep riding a section write normalizes to 'off'"
+		);
+	}
+
+	/**
+	 * A junk value on a toggle-adapted field ('yes' is not a recognized toggle
+	 * token) riding a section blob write parse-falls-back to Off ('').
+	 *
+	 * Scenario:
+	 *   Given a DNSBL settings blob with pfb_dnsbl = 'yes' (hostile/junk).
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then the stored pfb_dnsbl is '' (parse-fallback Off), never 'yes'.
+	 */
+	public function testWriteSectionToggleJunkNormalisesToOff(): void
+	{
+		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
+		$path    = $section . '/pfb_dnsbl';
+
+		PfbConfig::writeSection($section, ['pfb_dnsbl' => 'yes']);
+
+		$this->assertSame('', config_get_path($path),
+			"junk toggle value 'yes' riding a section write parse-falls-back to ''"
+		);
+	}
+
+	/**
+	 * Hostile input: a crafted array value (e.g. a POST array
+	 * alexa_type[]=x) riding a section blob write hits the adapter's
+	 * non-scalar guard and normalizes to the parse-fallback default, never
+	 * crashes and never persists the raw array.
+	 *
+	 * Scenario:
+	 *   Given a DNSBL settings blob with alexa_type = ['x'] (non-scalar).
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then the stored alexa_type is 'tranco' (the non-scalar-guard default).
+	 */
+	public function testWriteSectionAlexaTypeArrayValueNormalisesToDefaultTranco(): void
+	{
+		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
+		$path    = $section . '/alexa_type';
+
+		PfbConfig::writeSection($section, ['alexa_type' => ['x']]);
+
+		$this->assertSame('tranco', config_get_path($path),
+			'array-valued alexa_type riding a section write hits the non-scalar guard -> tranco'
+		);
+	}
+
+	/**
+	 * Hostile input: a NULL value on an adapted key riding a section blob write
+	 * is not a TypeError -- the read adapter's NULL->'' collapse feeds the write
+	 * adapter a well-formed enum, landing on the field's Off/legacy-empty token.
+	 *
+	 * Scenario:
+	 *   Given a General settings blob with pfb_keep = NULL.
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then the stored pfb_keep is 'off' (lenient NULL-collapse path), no crash.
+	 */
+	public function testWriteSectionNullValueNormalisesViaDefaultCollapse(): void
+	{
+		$section = 'installedpackages/pfblockerng/config/0';
+		$path    = $section . '/pfb_keep';
+
+		PfbConfig::writeSection($section, ['pfb_keep' => NULL]);
+
+		$this->assertSame('off', config_get_path($path),
+			'NULL-valued pfb_keep riding a section write collapses to the lenient Off token'
+		);
+	}
+
+	/**
+	 * Hostile input / idempotency: an already-adapted enum instance (e.g. fed
+	 * back through from a prior PfbConfig::read()) riding a section blob write
+	 * is not double-mangled -- the read adapter's `instanceof static` passthrough
+	 * returns it as-is, and the write adapter emits its canonical token.
+	 *
+	 * Scenario:
+	 *   Given a DNSBL settings blob with alexa_type = PfbTop1mSource::Cisco (an
+	 *     enum instance, not a raw string).
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then the stored alexa_type is 'cisco', not mangled by a double-apply.
+	 */
+	public function testWriteSectionAlexaTypeEnumInstanceIsIdempotent(): void
+	{
+		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
+		$path    = $section . '/alexa_type';
+
+		PfbConfig::writeSection($section, ['alexa_type' => PfbTop1mSource::Cisco]);
+
+		$this->assertSame('cisco', config_get_path($path),
+			'an already-adapted PfbTop1mSource enum instance riding a section write is idempotent'
+		);
+	}
+
+	/**
+	 * Hostile input: an integer value on an adapted key riding a section blob
+	 * write hits the non-scalar-adjacent junk path (no matching token) and
+	 * normalizes to the field's parse-fallback default.
+	 *
+	 * Scenario:
+	 *   Given a DNSBL settings blob with alexa_type = 1 (int, not a string token).
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then the stored alexa_type is 'tranco' (the parse-fallback default).
+	 */
+	public function testWriteSectionAlexaTypeIntValueNormalisesToDefaultTranco(): void
+	{
+		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
+		$path    = $section . '/alexa_type';
+
+		PfbConfig::writeSection($section, ['alexa_type' => 1]);
+
+		$this->assertSame('tranco', config_get_path($path),
+			'int-valued alexa_type riding a section write normalizes to the parse-fallback tranco'
+		);
+	}
+
+	/**
+	 * A registered key with NO adapter pair (plain string, e.g. top1m_token and
+	 * dnsbl_interface) riding a section blob write is left byte-identical --
+	 * normalization only ever touches adapter-bearing keys.
+	 *
+	 * Scenario:
+	 *   Given a DNSBL settings blob with two unadapted registered keys.
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then both stored values are byte-identical to the input.
+	 */
+	public function testWriteSectionUnadaptedRegisteredKeysPassThroughRaw(): void
+	{
+		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
+
+		PfbConfig::writeSection($section, [
+			'top1m_token'     => 'AbC123',
+			'dnsbl_interface' => 'lo0',
+		]);
+
+		$this->assertSame('AbC123', config_get_path($section . '/top1m_token'),
+			'unadapted top1m_token riding a section write is byte-identical'
+		);
+		$this->assertSame('lo0', config_get_path($section . '/dnsbl_interface'),
+			'unadapted dnsbl_interface riding a section write is byte-identical'
+		);
+	}
+
+	/**
+	 * An adapted KEY NAME landing in a FOREIGN section (not the section the
+	 * registry maps that key to) stays raw -- writeSection() matches on the
+	 * EXACT registered section string, so a same-named key belonging to a
+	 * different registry entry is untouched foreign data.
+	 *
+	 * Scenario:
+	 *   Given a pfblockerngsync section blob that happens to reuse the key name
+	 *     'alexa_type' (foreign to this section -- the registry maps alexa_type
+	 *     to the DNSBL section only) with the legacy 'domcop' value.
+	 *   When PfbConfig::writeSection() persists it against the SYNC section.
+	 *   Then the stored value is the raw 'domcop' -- no normalization applied,
+	 *     because no registry entry has 'section' === the sync section for
+	 *     this key.
+	 */
+	public function testWriteSectionAdaptedKeyNameInForeignSectionStaysRaw(): void
+	{
+		$section = 'installedpackages/pfblockerngsync/config/0';
+		$path    = $section . '/alexa_type';
+
+		PfbConfig::writeSection($section, ['alexa_type' => 'domcop']);
+
+		$this->assertSame('domcop', config_get_path($path),
+			"a same-named key in a foreign (non-registered-for-it) section stays raw"
+		);
+	}
+
+	/**
+	 * A realistic dconfig-shaped blob (mirrors pfblockerng_dnsbl.php's save
+	 * handler): a mix of adapted legacy/hostile tokens and unadapted
+	 * base64/plain fields. Adapted fields normalize; every other field is
+	 * byte-identical.
+	 *
+	 * Scenario:
+	 *   Given a DNSBL settings blob mixing legacy alexa_type/pfb_idn tokens with
+	 *     unadapted plain fields (dnsbl_interface, pfb_dnsvip4, top1m_token).
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then the adapted fields are stored at their canonical tokens and every
+	 *     unadapted field is byte-identical to the input.
+	 */
+	public function testWriteSectionDconfigShapedBlobNormalisesAdaptedFieldsOnly(): void
+	{
+		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
+
+		$data = [
+			'pfb_dnsbl'       => 'on',           // adapted (toggle), canonical.
+			'alexa_type'      => 'domcop',        // adapted (top1m_source), LEGACY -> normalizes.
+			'pfb_idn'         => 'all',           // adapted (idn_mode), ALPHA-ONLY -> normalizes.
+			'pfb_hsts'        => 'on',            // adapted (toggle), canonical.
+			'dnsbl_interface' => 'lo0',           // unadapted, plain.
+			'pfb_dnsvip4'     => '',              // unadapted, plain.
+			'top1m_token'     => 'QWJjMTIz',      // unadapted, plain (base64-shaped).
+		];
+
+		PfbConfig::writeSection($section, $data);
+
+		$result = PfbConfig::readSection($section);
+
+		$this->assertSame('on', $result['pfb_dnsbl'], 'pfb_dnsbl canonical stays on');
+		$this->assertSame('openpagerank', $result['alexa_type'], "legacy 'domcop' normalizes to 'openpagerank'");
+		$this->assertSame('off', $result['pfb_idn'], "alpha-only 'all' normalizes to 'off'");
+		$this->assertSame('on', $result['pfb_hsts'], 'pfb_hsts canonical stays on');
+		$this->assertSame('lo0', $result['dnsbl_interface'], 'unadapted dnsbl_interface is byte-identical');
+		$this->assertSame('', $result['pfb_dnsvip4'], 'unadapted pfb_dnsvip4 is byte-identical');
+		$this->assertSame('QWJjMTIz', $result['top1m_token'], 'unadapted top1m_token is byte-identical');
+	}
 }

--- a/tests/php/WwwGroupAGatewayTest.php
+++ b/tests/php/WwwGroupAGatewayTest.php
@@ -194,9 +194,14 @@ final class WwwGroupAGatewayTest extends TestCase
 	}
 
 	/**
-	 * General section: pfb_keep = '' (disabled) round-trips identically.
-	 * Asserts the before-state ('on') and the after-state ('') are distinct —
+	 * General section: pfb_keep = '' (disabled) is normalized, not round-tripped raw.
+	 * Asserts the before-state ('on') and the after-state ('off') are distinct —
 	 * proving the write changed the value rather than being an always-equal no-op.
+	 *
+	 * Issue #930: writeSection() now applies the lenient adapter to every
+	 * registered field of the target section (same as a single-key
+	 * PfbConfig::write()) -- the legacy '' token is coalesced to the explicit
+	 * 'off' token instead of persisting raw.
 	 */
 	public function testGeneralSectionPfbKeepOffRoundTrips(): void
 	{
@@ -206,11 +211,11 @@ final class WwwGroupAGatewayTest extends TestCase
 		PfbConfig::writeSection($section, ['pfb_keep' => 'on']);
 		$this->assertSame('on', PfbConfig::readSection($section)['pfb_keep'], 'pfb_keep starts as "on"');
 
-		// When: write '' (disabled).
+		// When: write '' (disabled, legacy empty token).
 		PfbConfig::writeSection($section, ['pfb_keep' => '']);
 
-		// Then: reads back as ''.
-		$this->assertSame('', PfbConfig::readSection($section)['pfb_keep'], 'pfb_keep "" round-trips identically');
+		// Then: reads back as 'off' (lenient-adapter normalization, issue #930).
+		$this->assertSame('off', PfbConfig::readSection($section)['pfb_keep'], 'pfb_keep "" normalizes to "off"');
 	}
 
 	// -----------------------------------------------------------------------
@@ -293,6 +298,12 @@ final class WwwGroupAGatewayTest extends TestCase
 	 *   Given a representative DNSBL settings array (mirrors what the save handler builds).
 	 *   When PfbConfig::writeSection() persists it.
 	 *   Then PfbConfig::readSection() returns an identical array.
+	 *
+	 * Issue #930: pfb_idn is adapter-bearing (PfbIdnMode); its fixture value uses
+	 * the canonical 'off' token (not the legacy '' — writeSection() now normalizes
+	 * every registered field of the target section, and the real save handler's
+	 * 3-way select never emits '' either) so this stays a true byte-identical
+	 * round-trip assertion.
 	 */
 	public function testDnsblSectionWriteReadRoundTrip(): void
 	{
@@ -316,7 +327,7 @@ final class WwwGroupAGatewayTest extends TestCase
 			'pfb_cache'                  => 'on',
 			'pfb_py_reply'               => 'on',
 			'pfb_hsts'                   => 'on',
-			'pfb_idn'                    => '',
+			'pfb_idn'                    => 'off',
 			'pfb_idn_block_malicious'    => 'on',
 			'pfb_idn_escalate_suspicious' => '',
 			'pfb_regex'                  => '',

--- a/tests/php/WwwGroupAGatewayTest.php
+++ b/tests/php/WwwGroupAGatewayTest.php
@@ -194,7 +194,7 @@ final class WwwGroupAGatewayTest extends TestCase
 	}
 
 	/**
-	 * General section: pfb_keep = '' (disabled) is normalized, not round-tripped raw.
+	 * General section: pfb_keep = '' (disabled) is normalised, not round-tripped raw.
 	 * Asserts the before-state ('on') and the after-state ('off') are distinct —
 	 * proving the write changed the value rather than being an always-equal no-op.
 	 *
@@ -214,8 +214,8 @@ final class WwwGroupAGatewayTest extends TestCase
 		// When: write '' (disabled, legacy empty token).
 		PfbConfig::writeSection($section, ['pfb_keep' => '']);
 
-		// Then: reads back as 'off' (lenient-adapter normalization, issue #930).
-		$this->assertSame('off', PfbConfig::readSection($section)['pfb_keep'], 'pfb_keep "" normalizes to "off"');
+		// Then: reads back as 'off' (lenient-adapter normalisation, issue #930).
+		$this->assertSame('off', PfbConfig::readSection($section)['pfb_keep'], 'pfb_keep "" normalises to "off"');
 	}
 
 	// -----------------------------------------------------------------------
@@ -300,7 +300,7 @@ final class WwwGroupAGatewayTest extends TestCase
 	 *   Then PfbConfig::readSection() returns an identical array.
 	 *
 	 * Issue #930: pfb_idn is adapter-bearing (PfbIdnMode); its fixture value uses
-	 * the canonical 'off' token (not the legacy '' — writeSection() now normalizes
+	 * the canonical 'off' token (not the legacy '' — writeSection() now normalises
 	 * every registered field of the target section, and the real save handler's
 	 * 3-way select never emits '' either) so this stays a true byte-identical
 	 * round-trip assertion.


### PR DESCRIPTION
## Summary

`PfbConfig::writeSection()` was a raw `config_set_path()` passthrough — unlike `PfbConfig::write()`, it applied no per-field write adapter. A legacy read-only token (`alexa_type` `'domcop'`/`'alexa'`, `pfb_idn` alpha-only `'all'`) or hostile/junk input riding any section-blob write (a `www/` save handler's raw `$_POST`, an install seed, a migration, a `readSection()`→`writeSection()` round-trip of a restored backup / HA sync / hand-edited config.xml) persisted raw into `config.xml`, sidestepping the RollbackContract "never re-emitted" guarantee.

`writeSection()` now normalizes every key registered to the **exact** target section that carries both adapters, via `write_adapter(read_adapter($value))` — read adapter first (handles arrays/NULL/junk through the non-scalar guard, idempotent on enum instances), write adapter second (emits the canonical stored token). Unregistered keys, adapter-less registered keys, and same-named keys registered to a *different* section pass through byte-identical. Behaviour is now the same as a single-key `PfbConfig::write()` on every path; canonical tokens are unchanged byte-for-byte.

## Coverage

- Property test iterating `pfb_cfg_registry()` itself: every adapter-bearing field (16) × canonical/legacy/junk sample sets, compared against the `PfbConfig::write()` oracle (self-enumerating — cannot under-generate).
- Scenario tests: `'domcop'`→`'openpagerank'`, `'alexa'`→`'tranco'`, canonical passthrough, `pfb_idn` `'all'`→`'off'`, lenient `''`→`'off'`, toggle junk→`''`.
- Hostile inputs: array (crafted `alexa_type[]=x` POST), NULL, enum instance (idempotence), int, unadapted-key raw passthrough, same-named key in a foreign section, realistic mixed dconfig-shaped blob.
- Red→green executed: 11/15 new tests FAIL on pre-change code, 15/15 PASS after.
- Two pre-existing `WwwGroupAGatewayTest` cases pinned the buggy raw round-trip (`pfb_keep` `''`, `pfb_idn` `''`) and were updated to the normalized expectations, with comments citing this issue.
- `docs/misc/config-gateway.md`: new "Section writes are normalized too" subsection under the rollback contract.

Gates: phpunit 2390 tests / 18838 assertions green · phpstan clean · phpcs clean · markdownlint clean.

Fixes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cw58wHpNsax2awNEtkKNZG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Section-based configuration saves now normalize supported values before storing them, preventing legacy or invalid entries from being written back as-is.
  * Round-trip behavior is now consistent across configuration paths, so saved settings match the app’s canonical format.
  * Existing configuration handling was updated to reflect the new normalization behavior for affected options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->