### PR TITLE
pfblockerng: transcode UTF-16/UTF-32 feeds at ingest; hoist the UTF-8 BOM strip above all per-line classifications

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1015,6 +1015,91 @@ function pfb_emit_entry_reject_stats(string $path): void {
 	}
 }
 
+// issue #946: detect a UTF-16/UTF-32 BOM at the start of $head, returning the
+// mb_convert_encoding() encoding name to decode it with, or NULL if none matches.
+// Order is load-bearing: UTF-32LE's BOM ("\xFF\xFE\x00\x00") is a strict superset
+// of UTF-16LE's ("\xFF\xFE") -- checking UTF-16LE first would misdetect every
+// UTF-32LE feed. Pure: string in, ?string out, no I/O.
+function pfb_utf16_bom_encoding(string $head): ?string {
+	if (strncmp($head, "\xFF\xFE\x00\x00", 4) === 0) {
+		return 'UTF-32LE';
+	}
+	if (strncmp($head, "\x00\x00\xFE\xFF", 4) === 0) {
+		return 'UTF-32BE';
+	}
+	if (strncmp($head, "\xFF\xFE", 2) === 0) {
+		return 'UTF-16LE';
+	}
+	if (strncmp($head, "\xFE\xFF", 2) === 0) {
+		return 'UTF-16BE';
+	}
+	return NULL;
+}
+
+// issue #946: decode a UTF-16/UTF-32-BOM-prefixed sample to UTF-8 for pfb_text_sanity()'s
+// benefit. No BOM match -> returned unchanged. Fail-open: a conversion failure returns the
+// ORIGINAL sample unchanged, never throws -- the sanity scan then sees the same bytes it did
+// before this helper existed. Pure: string in, string out, no I/O.
+function pfb_utf16_sample_to_utf8(string $sample): string {
+	$enc = pfb_utf16_bom_encoding($sample);
+	if ($enc === NULL) {
+		return $sample;
+	}
+
+	$bom_len = ($enc === 'UTF-32LE' || $enc === 'UTF-32BE') ? 4 : 2;
+	$converted = @mb_convert_encoding(substr($sample, $bom_len), 'UTF-8', $enc);
+
+	return ($converted === FALSE) ? $sample : $converted;
+}
+
+// issue #946: transcode a UTF-16/UTF-32-BOM-prefixed FILE to UTF-8 in place, atomically.
+// Returns FALSE (file left untouched) when: the path is unreadable, no BOM matches, or
+// mb_convert_encoding() fails (logged as a warning) -- fail-open in every case, so downstream
+// behaves exactly as it did before this function existed. Returns TRUE after a successful
+// same-filesystem rename() with the original mtime restored (the caller runs this AFTER the
+// remote_stamp touch(), so that stamp must survive).
+// ponytail: whole-file read/rewrite -- BOM-marked feeds are rare and small in practice (a text
+// blocklist, not a multi-GB dataset); switch to a streaming decode if that assumption ever
+// stops holding.
+function pfb_utf16_transcode_file(string $path): bool {
+	if (!@is_readable($path)) {
+		return FALSE;
+	}
+	$content = @file_get_contents($path);
+	if ($content === FALSE) {
+		return FALSE;
+	}
+
+	$enc = pfb_utf16_bom_encoding($content);
+	if ($enc === NULL) {
+		return FALSE;
+	}
+
+	$bom_len = ($enc === 'UTF-32LE' || $enc === 'UTF-32BE') ? 4 : 2;
+	$converted = @mb_convert_encoding(substr($content, $bom_len), 'UTF-8', $enc);
+	if ($converted === FALSE) {
+		pfb_logger("\npfb_utf16_transcode_file: mb_convert_encoding failed for [{$path}] ({$enc}) -- leaving file untouched", 2);
+		return FALSE;
+	}
+
+	$mtime = @filemtime($path);
+	$tmp = @tempnam(dirname($path), 'pfb_u16_');
+	if ($tmp === FALSE || @file_put_contents($tmp, $converted) === FALSE) {
+		if ($tmp !== FALSE) {
+			@unlink($tmp);
+		}
+		return FALSE;
+	}
+	if (!@rename($tmp, $path)) {
+		@unlink($tmp);
+		return FALSE;
+	}
+	if ($mtime !== FALSE) {
+		@touch($path, $mtime);
+	}
+	return TRUE;
+}
+
 // ADR-49 Phase 1: pure content-sanity scan over the first chunk of a downloaded
 // text feed. The caller reads a capped head sample (64 KiB at the pfb_download()
 // gate) and passes it in as $sample -- this function does no I/O and has no
@@ -1050,7 +1135,13 @@ function pfb_emit_entry_reject_stats(string $path): void {
 // BYTE-LEVEL matching only -- no `/u` modifier anywhere. Every pattern above is
 // pure ASCII, so a chunk-truncated multibyte tail can never flip a verdict.
 // Pure: string in, ?string out, no I/O, no globals.
+//
+// issue #946: a UTF-16/UTF-32-BOM-prefixed sample is decoded to UTF-8 FIRST (before
+// the UTF-8 BOM strip below) -- otherwise every line of a legitimate UTF-16/32 feed
+// carries interleaved NUL bytes and trips 'nul_bytes' on text that is actually fine.
 function pfb_text_sanity(string $sample): ?string {
+	$sample = pfb_utf16_sample_to_utf8($sample);
+
 	// Strip a UTF-8 BOM up front -- encoding metadata, not content. Left in place
 	// it defeats the '<!doctype html'/'<html' opening-tag check (ltrim strips no
 	// BOM) AND lets a BOM-prefixed comment line count as data in the content floor.
@@ -10723,6 +10814,13 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			// (any path that finalises a plain .orig here).  The geoip/asn early-returns
 			// above do not reach this block, so they correctly never get a sidecar.
 			pfb_hash_write("{$orig_download}", pfb_source_hash_target($file_download, $orig_download));
+
+			// issue #946: transcode a UTF-16/UTF-32-BOM-marked feed to UTF-8 AFTER the
+			// hash sidecar above -- the sidecar hashes the RAW wire bytes (ADR-42), so
+			// transcoding first would make the persisted digest diverge from the
+			// change-probe's wire hash and re-ingest the feed every cron. No-op (FALSE,
+			// file untouched) for every feed that isn't UTF-16/32-BOM-marked.
+			pfb_utf16_transcode_file("{$orig_download}");
 
 			// Process Emerging Threats IQRisk if required
 			if (strpos($list_url, 'iprepdata.txt') !== FALSE) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1056,7 +1056,8 @@ function pfb_utf16_sample_to_utf8(string $sample): string {
 }
 
 // issue #946: transcode a UTF-16/UTF-32-BOM-prefixed FILE to UTF-8 in place, atomically.
-// Only the first 4 bytes are read to sniff the BOM (an ingest runs this on EVERY feed, and
+// Only the first 4 bytes are read to sniff the BOM (this runs on every text-feed ingest
+// that reaches the .orig finalize step, and
 // feeds can be tens of MB -- slurping them all just to look at a prefix would risk the PHP
 // memory limit, which file_get_contents() hits as a fatal error, not a catchable failure);
 // the full read happens only for an actual BOM match. Returns FALSE (file left untouched)
@@ -1064,7 +1065,7 @@ function pfb_utf16_sample_to_utf8(string $sample): string {
 // warning; believed unreachable on stock mbstring, which substitutes '?' instead of failing)
 // -- fail-open in every case, so downstream behaves exactly as it did before this function
 // existed. Returns TRUE after a successful same-filesystem rename() with the original mtime
-// (when readable) and permission bits (when readable) restored -- the caller runs this AFTER
+// (when its stat succeeded) and permission bits (same) restored -- the caller runs this AFTER
 // the remote_stamp touch(), so that stamp must survive, and tempnam() creates 0600 files, so
 // the mode must be carried over explicitly (same discipline as the atomic-publish helpers).
 // ponytail: whole-file read/rewrite for the BOM-matched case only -- BOM-marked feeds are

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1047,31 +1047,45 @@ function pfb_utf16_sample_to_utf8(string $sample): string {
 	}
 
 	$bom_len = ($enc === 'UTF-32LE' || $enc === 'UTF-32BE') ? 4 : 2;
+	// Stock mbstring substitutes invalid sequences with '?' rather than returning FALSE,
+	// so this fail-open branch is believed unreachable in practice -- kept as cheap
+	// insurance against a build where the conversion does fail.
 	$converted = @mb_convert_encoding(substr($sample, $bom_len), 'UTF-8', $enc);
 
 	return ($converted === FALSE) ? $sample : $converted;
 }
 
 // issue #946: transcode a UTF-16/UTF-32-BOM-prefixed FILE to UTF-8 in place, atomically.
-// Returns FALSE (file left untouched) when: the path is unreadable, no BOM matches, or
-// mb_convert_encoding() fails (logged as a warning) -- fail-open in every case, so downstream
-// behaves exactly as it did before this function existed. Returns TRUE after a successful
-// same-filesystem rename() with the original mtime restored (the caller runs this AFTER the
-// remote_stamp touch(), so that stamp must survive).
-// ponytail: whole-file read/rewrite -- BOM-marked feeds are rare and small in practice (a text
-// blocklist, not a multi-GB dataset); switch to a streaming decode if that assumption ever
-// stops holding.
+// Only the first 4 bytes are read to sniff the BOM (an ingest runs this on EVERY feed, and
+// feeds can be tens of MB -- slurping them all just to look at a prefix would risk the PHP
+// memory limit, which file_get_contents() hits as a fatal error, not a catchable failure);
+// the full read happens only for an actual BOM match. Returns FALSE (file left untouched)
+// when: the path is unreadable, no BOM matches, or mb_convert_encoding() fails (logged as a
+// warning; believed unreachable on stock mbstring, which substitutes '?' instead of failing)
+// -- fail-open in every case, so downstream behaves exactly as it did before this function
+// existed. Returns TRUE after a successful same-filesystem rename() with the original mtime
+// (when readable) and permission bits (when readable) restored -- the caller runs this AFTER
+// the remote_stamp touch(), so that stamp must survive, and tempnam() creates 0600 files, so
+// the mode must be carried over explicitly (same discipline as the atomic-publish helpers).
+// ponytail: whole-file read/rewrite for the BOM-matched case only -- BOM-marked feeds are
+// rare and small in practice; switch to a streaming decode if that assumption ever stops
+// holding.
 function pfb_utf16_transcode_file(string $path): bool {
 	if (!@is_readable($path)) {
 		return FALSE;
 	}
-	$content = @file_get_contents($path);
-	if ($content === FALSE) {
+	$head = @file_get_contents($path, FALSE, NULL, 0, 4);
+	if ($head === FALSE) {
 		return FALSE;
 	}
 
-	$enc = pfb_utf16_bom_encoding($content);
+	$enc = pfb_utf16_bom_encoding($head);
 	if ($enc === NULL) {
+		return FALSE;
+	}
+
+	$content = @file_get_contents($path);
+	if ($content === FALSE) {
 		return FALSE;
 	}
 
@@ -1083,12 +1097,16 @@ function pfb_utf16_transcode_file(string $path): bool {
 	}
 
 	$mtime = @filemtime($path);
+	$perms = @fileperms($path);
 	$tmp = @tempnam(dirname($path), 'pfb_u16_');
 	if ($tmp === FALSE || @file_put_contents($tmp, $converted) === FALSE) {
 		if ($tmp !== FALSE) {
 			@unlink($tmp);
 		}
 		return FALSE;
+	}
+	if ($perms !== FALSE) {
+		@chmod($tmp, $perms & 0777);
 	}
 	if (!@rename($tmp, $path)) {
 		@unlink($tmp);
@@ -16497,7 +16515,9 @@ function sync_package_pfblockerng($cron='') {
 											// header sniff handles its own BOM, but the '!' comment skip, the ADR-21
 											// '||' anchor short-circuit and the CSV autodetection below do not; a BOM-led
 											// first line would be misclassified by all three. $oline keeps the original
-											// bytes for the parse-error log.
+											// bytes for the parse-error log. This also strips a BOM from raw ABP body
+											// lines before their verbatim passthrough to Python -- intentional and
+											// harmless (Python's parser is byte-oriented too).
 											$line = pfb_dnsbl_strip_bom($line);
 
 											// Validate EasyList/AdBlock/uBlock/ADGuard Feeds.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -16493,6 +16493,13 @@ function sync_package_pfblockerng($cron='') {
 											// Collect original line
 											$oline = $line;
 
+											// Issue #946: strip a UTF-8 BOM before ANY per-line classification -- the ABP
+											// header sniff handles its own BOM, but the '!' comment skip, the ADR-21
+											// '||' anchor short-circuit and the CSV autodetection below do not; a BOM-led
+											// first line would be misclassified by all three. $oline keeps the original
+											// bytes for the parse-error log.
+											$line = pfb_dnsbl_strip_bom($line);
+
 											// Validate EasyList/AdBlock/uBlock/ADGuard Feeds.
 											// ADR-21: broadened to the generic ABP header
 											// convention ('[Adblock'/'[uBlock'/'! Title:'),
@@ -16597,12 +16604,6 @@ function sync_package_pfblockerng($cron='') {
 												if (strpos($line, '%20') !== FALSE) {
 													$line = str_replace('%20', '', $line);
 												}
-
-												// Issue #938: strip a UTF-8 BOM before ANY first-char
-												// classification below -- left in place it defeats the
-												// '#' comment check just below, so a BOM-led header
-												// line is treated as data and error-logged.
-												$line = pfb_dnsbl_strip_bom($line);
 
 												// Remove comment lines and special format considerations
 												if (str_starts_with($line, '#')) {

--- a/tests/php/PfbDnsblStripBomTest.php
+++ b/tests/php/PfbDnsblStripBomTest.php
@@ -53,4 +53,26 @@ final class PfbDnsblStripBomTest extends TestCase
 		$line = "exam\xEF\xBB\xBFple.com";
 		$this->assertSame($line, pfb_dnsbl_strip_bom($line));
 	}
+
+	public function testBomLedAnchorLineBecomesAnchorDetectable(): void
+	{
+		// Issue #946: pins the property the parse-loop hoist depends on -- once the
+		// BOM is stripped, the line starts with '||' again, so the ADR-21 anchor
+		// short-circuit (str_starts_with($line, '||')) can recognise it. Before the
+		// hoist, this check ran AFTER the anchor short-circuit, so a BOM-led anchor
+		// line took the generic parse path instead.
+		$result = pfb_dnsbl_strip_bom("\xEF\xBB\xBF||example.com^");
+		$this->assertSame('||example.com^', $result);
+		$this->assertTrue(str_starts_with($result, '||'));
+	}
+
+	public function testBomLedCommentLineBecomesCommentDetectable(): void
+	{
+		// Issue #946: same property for the '!' comment skip in the !$validate_header
+		// block -- before the hoist, a BOM-led '! comment' first line fell through as
+		// data and was error-logged instead of skipped.
+		$result = pfb_dnsbl_strip_bom("\xEF\xBB\xBF! Some comment");
+		$this->assertSame('! Some comment', $result);
+		$this->assertTrue(str_starts_with($result, '!'));
+	}
 }

--- a/tests/php/PfbTextSanityUtf16Test.php
+++ b/tests/php/PfbTextSanityUtf16Test.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_text_sanity() UTF-16 handling — issue #946.
+ *
+ * Before this change, a UTF-16/UTF-32-BOM-prefixed sample is scanned byte-for-byte:
+ * every ASCII character of a real feed is interleaved with a NUL byte, so the very
+ * first check ('nul_bytes') fires on perfectly legitimate text. pfb_text_sanity()
+ * now decodes a BOM-marked sample to UTF-8 (via pfb_utf16_sample_to_utf8()) as its
+ * FIRST statement, before the existing UTF-8-BOM strip and the 'nul_bytes' check --
+ * so a genuine UTF-16 feed is scanned as text, while BOM-less binary still trips
+ * 'nul_bytes' exactly as before (see PfbTextSanityTest.php, left untouched).
+ */
+#[CoversFunction('pfb_text_sanity')]
+final class PfbTextSanityUtf16Test extends TestCase
+{
+	/**
+	 * THE FIX. A UTF-16LE-encoded valid hosts-style feed must be judged sane (NULL),
+	 * not 'nul_bytes'.
+	 *
+	 * RED on today's code: pfb_text_sanity() has no UTF-16 awareness, so the sample's
+	 * interleaved \x00 bytes trip the 'nul_bytes' check first -- this assertion fails
+	 * (actual 'nul_bytes') until pfb_utf16_sample_to_utf8() is wired in as the first
+	 * statement.
+	 */
+	public function test_utf16le_encoded_valid_feed_is_sane(): void
+	{
+		$text = "0.0.0.0 ads.example.org\n0.0.0.0 tracker.example.net\n";
+		$sample = "\xFF\xFE" . mb_convert_encoding($text, 'UTF-16LE', 'UTF-8');
+
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	/** Same fix, opposite byte order. */
+	public function test_utf16be_encoded_valid_feed_is_sane(): void
+	{
+		$text = "0.0.0.0 ads.example.org\n0.0.0.0 tracker.example.net\n";
+		$sample = "\xFE\xFF" . mb_convert_encoding($text, 'UTF-16BE', 'UTF-8');
+
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+
+	/**
+	 * Proves the scan genuinely runs on DECODED text, not merely skips a BOM-marked
+	 * sample: a UTF-16LE-encoded HTML error page (no blocklist-shaped line anywhere)
+	 * must still be flagged 'html_error_page' -- if the decode were a no-op/bypass,
+	 * this sample would instead trip 'nul_bytes' (its interleaved NULs), not the HTML
+	 * check downstream of the decode.
+	 */
+	public function test_utf16le_encoded_html_error_page_is_flagged(): void
+	{
+		$text = "<!doctype html>\n<html><body><h1>404 Not Found</h1></body></html>\n";
+		$sample = "\xFF\xFE" . mb_convert_encoding($text, 'UTF-16LE', 'UTF-8');
+
+		$this->assertSame('html_error_page', pfb_text_sanity($sample));
+	}
+
+	/**
+	 * Unchanged behaviour: BOM-less binary with interleaved NULs (not a UTF-16/32 BOM)
+	 * is still 'nul_bytes' -- pfb_utf16_sample_to_utf8() is a no-op for it.
+	 */
+	public function test_bom_less_binary_with_nuls_is_still_nul_bytes(): void
+	{
+		$sample = "garbage\x00\x01\x02binary";
+
+		$this->assertSame('nul_bytes', pfb_text_sanity($sample));
+	}
+
+	/**
+	 * Unchanged behaviour: a plain UTF-8 sample (no BOM at all) is judged exactly as
+	 * before -- pfb_utf16_sample_to_utf8() must be a true no-op on non-BOM-marked text.
+	 */
+	public function test_plain_utf8_sample_is_unaffected(): void
+	{
+		$sample = "0.0.0.0 ads.example.org\n0.0.0.0 tracker.example.net\n";
+
+		$this->assertNull(pfb_text_sanity($sample));
+	}
+}

--- a/tests/php/PfbUtf16TranscodeFileTest.php
+++ b/tests/php/PfbUtf16TranscodeFileTest.php
@@ -180,4 +180,58 @@ final class PfbUtf16TranscodeFileTest extends TestCase
 		$this->assertTrue($result);
 		$this->assertSame('AB?', file_get_contents($path), 'pinned observed mb_convert_encoding behaviour for a dangling odd byte');
 	}
+
+	public function test_bom_only_utf16be_and_utf32be_files(): void
+	{
+		// BE siblings of the LE BOM-only pins above -- the conversion path is shared,
+		// and these rows pin that the BE byte orders behave identically (PR #951 review).
+		$path16 = $this->path('bom_only_16be.bin');
+		file_put_contents($path16, "\xFE\xFF");
+		$this->assertTrue(pfb_utf16_transcode_file($path16));
+		$this->assertSame('', file_get_contents($path16));
+
+		$path32 = $this->path('bom_only_32be.bin');
+		file_put_contents($path32, "\x00\x00\xFE\xFF");
+		$this->assertTrue(pfb_utf16_transcode_file($path32));
+		$this->assertSame('', file_get_contents($path32));
+	}
+
+	public function test_odd_length_utf16be_and_utf32_payloads_do_not_crash(): void
+	{
+		// BE / UTF-32 siblings of the odd-length pin: a dangling partial code unit is
+		// substituted with '?' identically across byte orders (PR #951 review).
+		$path16 = $this->path('odd_16be.bin');
+		file_put_contents($path16, "\xFE\xFF" . mb_convert_encoding('AB', 'UTF-16BE', 'UTF-8') . "\x41");
+		$this->assertTrue(pfb_utf16_transcode_file($path16));
+		$this->assertSame('AB?', file_get_contents($path16));
+
+		$path32le = $this->path('odd_32le.bin');
+		file_put_contents($path32le, "\xFF\xFE\x00\x00" . mb_convert_encoding('AB', 'UTF-32LE', 'UTF-8') . "\x41");
+		$this->assertTrue(pfb_utf16_transcode_file($path32le));
+		$this->assertSame('AB?', file_get_contents($path32le));
+
+		$path32be = $this->path('odd_32be.bin');
+		file_put_contents($path32be, "\x00\x00\xFE\xFF" . mb_convert_encoding('AB', 'UTF-32BE', 'UTF-8') . "\x41");
+		$this->assertTrue(pfb_utf16_transcode_file($path32be));
+		$this->assertSame('AB?', file_get_contents($path32be));
+	}
+
+	public function test_transcode_preserves_permission_bits(): void
+	{
+		// tempnam() creates 0600 files; without an explicit chmod the rename would
+		// silently narrow the .orig's mode (PR #951 review, Copilot). Pin that a
+		// distinctive pre-existing mode survives the atomic rewrite.
+		$path = $this->path('perms.bin');
+		file_put_contents($path, "\xFF\xFE" . mb_convert_encoding("0.0.0.0 example.com\n", 'UTF-16LE', 'UTF-8'));
+		chmod($path, 0644);
+
+		$this->assertTrue(pfb_utf16_transcode_file($path));
+
+		clearstatcache();
+		$this->assertSame(
+			'644',
+			decoct(fileperms($path) & 0777),
+			'permission bits must survive the tempnam()+rename() rewrite'
+		);
+	}
 }

--- a/tests/php/PfbUtf16TranscodeFileTest.php
+++ b/tests/php/PfbUtf16TranscodeFileTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_utf16_transcode_file() — issue #946.
+ *
+ * A UTF-16/UTF-32-BOM-marked text feed reaches the byte-oriented DNSBL parser
+ * undecoded: every line fails (default installs) or the ADR-49 opt-in sanity
+ * scan rejects the whole feed as 'nul_bytes'. This function transcodes such a
+ * file to UTF-8 IN PLACE, atomically (temp file in the same directory +
+ * rename()), preserving the original mtime -- fail-open (returns FALSE, file
+ * untouched) for every path that is not BOM-marked UTF-16/UTF-32, unreadable,
+ * or fails conversion.
+ */
+#[CoversFunction('pfb_utf16_transcode_file')]
+#[CoversFunction('pfb_utf16_bom_encoding')]
+#[CoversFunction('pfb_utf16_sample_to_utf8')]
+final class PfbUtf16TranscodeFileTest extends TestCase
+{
+	/** @var string */
+	private string $dir;
+
+	protected function setUp(): void
+	{
+		$dir = sys_get_temp_dir() . '/pfb_u16_test_' . bin2hex(random_bytes(8));
+		if (!mkdir($dir) && !is_dir($dir)) {
+			$this->fail('Could not create temp dir');
+		}
+		$this->dir = $dir;
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob($this->dir . '/*') ?: [] as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->dir);
+	}
+
+	private function path(string $name): string
+	{
+		return $this->dir . '/' . $name;
+	}
+
+	// -- BOM-marked encodings decode correctly, mtime preserved --------------------------
+
+	/** @return array<string, array{0: string}> */
+	public static function bomEncodings(): array
+	{
+		return [
+			'UTF-16LE' => ['UTF-16LE'],
+			'UTF-16BE' => ['UTF-16BE'],
+			'UTF-32LE' => ['UTF-32LE'],
+			'UTF-32BE' => ['UTF-32BE'],
+		];
+	}
+
+	#[DataProvider('bomEncodings')]
+	public function test_bom_marked_file_is_transcoded_to_utf8_and_mtime_preserved(string $enc): void
+	{
+		$text = "0.0.0.0 example.com\n# comment\n";
+		$boms = [
+			'UTF-16LE' => "\xFF\xFE",
+			'UTF-16BE' => "\xFE\xFF",
+			'UTF-32LE' => "\xFF\xFE\x00\x00",
+			'UTF-32BE' => "\x00\x00\xFE\xFF",
+		];
+		$path = $this->path('feed_' . $enc . '.txt');
+		file_put_contents($path, $boms[$enc] . mb_convert_encoding($text, $enc, 'UTF-8'));
+
+		// GIVEN a known, non-current mtime -- so "preserved" is provably the ORIGINAL
+		// stamp, not merely "unchanged because nothing touched it".
+		$knownMtime = time() - 100000;
+		touch($path, $knownMtime);
+		clearstatcache(TRUE, $path);
+		$this->assertSame($knownMtime, filemtime($path), 'setup drift: mtime priming failed');
+
+		$result = pfb_utf16_transcode_file($path);
+
+		$this->assertTrue($result, "{$enc}: expected TRUE (file transcoded)");
+		$this->assertSame($text, file_get_contents($path), "{$enc}: content must be the exact UTF-8 string");
+		clearstatcache(TRUE, $path);
+		$this->assertSame($knownMtime, filemtime($path), "{$enc}: mtime must survive the transcode");
+	}
+
+	// -- Non-BOM / benign inputs: FALSE, byte-identical ----------------------------------
+
+	public function test_plain_ascii_file_is_untouched(): void
+	{
+		$path = $this->path('ascii.txt');
+		$original = "0.0.0.0 example.com\n";
+		file_put_contents($path, $original);
+
+		$this->assertFalse(pfb_utf16_transcode_file($path));
+		$this->assertSame($original, file_get_contents($path));
+	}
+
+	public function test_utf8_bom_file_is_untouched(): void
+	{
+		// The UTF-8 BOM is handled line-level inside pfb_text_sanity()/the parser, not
+		// file-level here -- this function only reacts to UTF-16/UTF-32 BOMs.
+		$path = $this->path('utf8bom.txt');
+		$original = "\xEF\xBB\xBF0.0.0.0 example.com\n";
+		file_put_contents($path, $original);
+
+		$this->assertFalse(pfb_utf16_transcode_file($path));
+		$this->assertSame($original, file_get_contents($path));
+	}
+
+	public function test_empty_file_is_untouched(): void
+	{
+		$path = $this->path('empty.txt');
+		file_put_contents($path, '');
+
+		$this->assertFalse(pfb_utf16_transcode_file($path));
+		$this->assertSame('', file_get_contents($path));
+	}
+
+	public function test_bom_less_nul_interleaved_binary_is_untouched(): void
+	{
+		$path = $this->path('binary.bin');
+		$original = "\x01\x00\x02\x00garbage\x00\xFF";
+		file_put_contents($path, $original);
+
+		$this->assertFalse(pfb_utf16_transcode_file($path));
+		$this->assertSame($original, file_get_contents($path));
+	}
+
+	public function test_nonexistent_path_returns_false_without_warning(): void
+	{
+		// is_readable()/@ guard: no warning-spam for a path that simply doesn't exist.
+		$this->assertFalse(pfb_utf16_transcode_file($this->path('does-not-exist.txt')));
+	}
+
+	// -- Pinned edge cases: deterministic, non-crashing observed behaviour ---------------
+
+	public function test_bom_only_utf16le_file(): void
+	{
+		// Exactly the 2-byte UTF-16LE BOM, no payload: BOM strips to an empty remainder,
+		// mb_convert_encoding('', 'UTF-8', 'UTF-16LE') === '' (not FALSE), so the observed
+		// outcome is TRUE + an empty UTF-8 file.
+		$path = $this->path('bom_only_16le.bin');
+		file_put_contents($path, "\xFF\xFE");
+
+		$result = pfb_utf16_transcode_file($path);
+
+		$this->assertTrue($result, 'BOM-only UTF-16LE: observed outcome is TRUE (empty remainder converts cleanly)');
+		$this->assertSame('', file_get_contents($path));
+	}
+
+	public function test_bom_only_utf32le_file(): void
+	{
+		// Exactly the 4-byte UTF-32LE BOM ("\xFF\xFE\x00\x00") -- this is the load-bearing
+		// detection-order case: it must be read as UTF-32LE (checked FIRST), not UTF-16LE
+		// plus two stray NUL bytes.
+		$path = $this->path('bom_only_32le.bin');
+		file_put_contents($path, "\xFF\xFE\x00\x00");
+
+		$result = pfb_utf16_transcode_file($path);
+
+		$this->assertTrue($result, 'BOM-only UTF-32LE: observed outcome is TRUE (empty remainder converts cleanly)');
+		$this->assertSame('', file_get_contents($path));
+	}
+
+	public function test_odd_length_utf16le_payload_does_not_crash(): void
+	{
+		// BOM + an odd number of trailing bytes (a truncated UTF-16LE code unit). The
+		// only hard requirement is no crash and a deterministic outcome -- pin PHP's
+		// actual mb_convert_encoding() behaviour (a '?' replacement for the dangling byte).
+		$path = $this->path('odd_16le.bin');
+		file_put_contents($path, "\xFF\xFE" . mb_convert_encoding('AB', 'UTF-16LE', 'UTF-8') . "\x41");
+
+		$result = pfb_utf16_transcode_file($path);
+
+		$this->assertTrue($result);
+		$this->assertSame('AB?', file_get_contents($path), 'pinned observed mb_convert_encoding behaviour for a dangling odd byte');
+	}
+}

--- a/tests/php/PfbUtf16TranscodeFileTest.php
+++ b/tests/php/PfbUtf16TranscodeFileTest.php
@@ -181,6 +181,24 @@ final class PfbUtf16TranscodeFileTest extends TestCase
 		$this->assertSame('AB?', file_get_contents($path), 'pinned observed mb_convert_encoding behaviour for a dangling odd byte');
 	}
 
+	public function test_short_heads_no_bom_untouched_truncated_utf32_bom_still_utf16(): void
+	{
+		// Shorter-than-any-BOM heads (1 byte; 3 bytes = a truncated UTF-32 BOM prefix)
+		// must never match and must leave the file untouched (PR #951 fix-delta review).
+		$path1 = $this->path('one_byte.bin');
+		file_put_contents($path1, "\xFF");
+		$this->assertFalse(pfb_utf16_transcode_file($path1));
+		$this->assertSame("\xFF", file_get_contents($path1));
+
+		$path3 = $this->path('three_byte.bin');
+		file_put_contents($path3, "\xFF\xFE\x00");
+		// A 3-byte "\xFF\xFE\x00" head cannot match UTF-32LE (needs 4 bytes) but DOES
+		// carry the 2-byte UTF-16LE BOM -- pin the observed outcome: the single stray
+		// NUL after the BOM converts to a replacement, file transcodes.
+		$this->assertTrue(pfb_utf16_transcode_file($path3));
+		$this->assertSame('?', file_get_contents($path3));
+	}
+
 	public function test_bom_only_utf16be_and_utf32be_files(): void
 	{
 		// BE siblings of the LE BOM-only pins above -- the conversion path is shared,

--- a/tests/smoke/fixtures/README.md
+++ b/tests/smoke/fixtures/README.md
@@ -51,6 +51,20 @@ DNSBL assertion: `dns_probe` block-shape on the box (NOERROR + VIP, or NULL per 
 list's `logging`); the non-member (and the ABP allow-exception, where a feed `@@`
 allow band 2 beats the `||` block band 1) must RESOLVE, not block.
 
+## BOM-led '!' first line fixture (issue #946, `DnsblCase`, `test_smoke_feeds.py`)
+
+| File | First line | Anchor member (blocks) | Hosts member (blocks) |
+| --- | --- | --- | --- |
+| `dnsbl_bom_header.txt` | UTF-8-BOM-led `! ...` comment | `uuid-6c91761cef48.com` (`\|\|domain^`) | `uuid-2329767ef078.com` (`0.0.0.0 domain`) |
+
+Header-less, non-ABP feed whose FIRST bytes are a UTF-8 BOM (`EF BB BF`) directly
+ahead of a `!` comment line -- `pfb_dnsbl_strip_bom()` is hoisted to the top of the
+per-line parse loop so this line is skipped as a comment before the ADR-21 `||`
+anchor short-circuit and CSV autodetection ever see it. Neither the anchor line nor
+the hosts line carries a BOM. Assertion: both members block (VIP), AND the DNSBL
+parse-error log gains no new line for the BOM-led comment (the RED->GREEN carrier --
+pre-fix the still-BOM'd line missed the `!` skip and was logged as invalid data).
+
 ## Plain-text sanity scan fixture (ADR-49, `IpCase`, `test_smoke_feeds.py`)
 
 | File | on-box `file(1)` | Purpose |

--- a/tests/smoke/fixtures/dnsbl_bom_header.txt
+++ b/tests/smoke/fixtures/dnsbl_bom_header.txt
@@ -1,0 +1,3 @@
+﻿! Issue #946: BOM-led '!' comment first line (hosts-format DNSBL feed, non-ABP).
+||uuid-6c91761cef48.com^
+0.0.0.0 uuid-2329767ef078.com

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -610,6 +610,86 @@ def test_abp_perline_path_anchor_not_overblocked(
 
 
 # --------------------------------------------------------------------------- #
+# Issue #946 — the UTF-8 BOM strip is hoisted to the TOP of the per-line parse loop,
+# ahead of the '!' comment skip, the ADR-21 '||' anchor short-circuit, and CSV
+# autodetection (all three previously ran against a still-BOM'd first line). The
+# committed fixture below opens with a BOM directly ahead of a '!' comment line,
+# followed by an anchor line and a hosts line -- neither of the latter two carries a
+# BOM, so they are unaffected by the fix either way (see the test docstring).
+# --------------------------------------------------------------------------- #
+
+
+def test_dnsbl_bom_header_feed_parses_without_error(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
+    """Issue #946: a BOM-led '!' first line no longer misclassifies the rest of the feed.
+
+    ``dnsbl_bom_header.txt`` (header-less, non-ABP) opens with a UTF-8 BOM
+    (``EF BB BF``) directly ahead of a '!' comment line, followed by an ADR-21 ``||``
+    anchor line and a plain hosts (``0.0.0.0 <domain>``) line. ``pfb_dnsbl_strip_bom()``
+    is now hoisted to the TOP of the per-line loop, so line 1's BOM is stripped BEFORE
+    the '!' comment check runs. Pre-fix, that check ran against the still-BOM'd line,
+    missed the '!' prefix, and the line fell through as data -- ultimately failing
+    domain validation and getting logged via ``pfb_parsed_fail()``, whose ``$oline``
+    field is the untouched, BOM-bearing original line.
+
+    The anchor line and the hosts line carry NO BOM, so both block identically
+    whether or not this fix is present -- they prove the feed as a whole still loads,
+    but the parse-error-log assertion below is the actual RED->GREEN carrier.
+
+    Given (before the feed loads) both domains RESOLVE via the controlled stub
+      upstream, and a baseline count of this fixture's exact BOM-led original line in
+      the DNSBL parse-error log (a fresh, never-updated header).
+    When the feed loads over HTTP (Force Update),
+    Then both the anchor-line domain and the hosts-line domain return the VIP block
+      shape, AND the parse-error-log count for the BOM-led line stays AT the baseline
+      -- pre-fix it would strictly increase (the line would be logged as bad data
+      instead of skipped as a comment).
+    """
+    anchor_member = "uuid-6c91761cef48.com"  # ADR-21 '||' anchor line -> must BLOCK
+    hosts_member = "uuid-2329767ef078.com"  # hosts '0.0.0.0 domain' line -> must BLOCK
+    feed_url = mock_feeds.feed_url("dnsbl_bom_header.txt")
+    spec = h.DnsblCase(aliasname="smokefeedbom", feed_url=feed_url, header="smokefeedbom", mode=h.DnsblMode.VIP)
+    # An ASCII substring of the fixture's BOM-led '!' line (skips the BOM bytes
+    # themselves -- grep -F matches it anywhere in the CSV's $oline field, so the
+    # leading BOM need not round-trip through the SSH/grep pipeline byte-for-byte).
+    bom_line_marker = "Issue #946: BOM-led '!' comment first line"
+
+    # BEFORE: neither domain is on any feed yet -> both resolve via the stub sentinel.
+    for name in (anchor_member, hosts_member):
+        before = h.dns_probe_client(client_vm, name, "A")
+        assert h.resolves_to(before, STUB_DNS_A), f"{name} should resolve via stub BEFORE listing, got {before}"
+        assert not h.is_vip(before), f"{name} unexpectedly VIP-blocked before any feed: {before}"
+
+    parse_err_before = h.count_log_marker(deployed_vm, h.DNSBL_PARSE_ERR_LOG, bom_line_marker)
+
+    with h.CaseContext(deployed_vm, spec):
+        h.unblock_egress()
+        for name in (anchor_member, hosts_member):
+            h.flush_unbound_name(deployed_vm, name)
+
+        ans_anchor = h.dns_probe_client_until(client_vm, anchor_member, h.is_vip)
+        assert not h.resolves_to(ans_anchor, STUB_DNS_A), (
+            f"{anchor_member} still resolving after the ADR-21 anchor line block: {ans_anchor}"
+        )
+        ans_hosts = h.dns_probe_client_until(client_vm, hosts_member, h.is_vip)
+        assert not h.resolves_to(ans_hosts, STUB_DNS_A), (
+            f"{hosts_member} still resolving after the hosts-line block: {ans_hosts}"
+        )
+
+        # THEN (RED->GREEN carrier): no NEW parse-error log line for the BOM-led '!'
+        # first line -- pre-fix this count would be strictly greater (the still-BOM'd
+        # line missed the '!' comment skip and was logged as an invalid domain).
+        parse_err_after = h.count_log_marker(deployed_vm, h.DNSBL_PARSE_ERR_LOG, bom_line_marker)
+        assert parse_err_after == parse_err_before, (
+            f"expected NO new DNSBL parse-error log line for the BOM-led '!' first line "
+            f"(before={parse_err_before}, after={parse_err_after}) -- a BOM-led comment "
+            f"must be skipped, never logged as invalid data:\n"
+            f"{h.read_log_file(deployed_vm, h.DNSBL_PARSE_ERR_LOG)[-2000:]}"
+        )
+
+
+# --------------------------------------------------------------------------- #
 # ADR-22 — the "Lenient feed parsing" toggle (pfb_dnsbl_lenient) over the live box.
 #
 # The non-lite DNSBL download path strips a ``<scheme>://`` prefix from each feed


### PR DESCRIPTION
Fixes #946.

The two residual encoding edges deferred from the PR #939 review, resolved per the issue's direction (feed-level transcoding rather than more line-level BOM branches):

## 1. UTF-16/UTF-32 BOM feeds transcode to UTF-8 at ingest

A UTF-16/32-BOM-marked text feed previously reached the byte-oriented parser undecoded: every line failed and was error-logged on default installs, or the opt-in ADR-49 sanity scan rejected the whole feed as `nul_bytes`. Now:

- `pfb_utf16_bom_encoding()` sniffs the BOM (UTF-32 variants checked before UTF-16 — the UTF-32LE BOM is a strict superset of UTF-16LE's).
- `pfb_utf16_transcode_file()` rewrites the finalized `.orig` atomically (same-dir temp + rename, mtime preserved, fail-open with a logged warning on conversion failure). The call site sits **after** `pfb_hash_write()` in `pfb_download()`'s convergence block, so the ADR-42 sidecar keeps hashing raw wire bytes — transcoding first would desync the change-probe's digest and re-ingest the feed every cron. All decompression paths (gz/bz2/zip/7z) converge on the same `.orig` call site.
- `pfb_text_sanity()` decodes its sample first, so a legitimate UTF-16 feed passes the scan while BOM-less binary still trips `nul_bytes`.

## 2. UTF-8 BOM strip hoisted above all per-line classifications

The `pfb_dnsbl_strip_bom()` call (from #938) sat inside the generic branch, *after* three classifications a BOM-led first line defeats: the `!` comment skip, the ADR-21 `||`/`@@||` anchor short-circuit, and CSV autodetection. It now runs once at the top of the per-line loop (right after `$oline` capture, which keeps the original bytes for the parse-error log); the old call site is removed.

## Tests

- `PfbUtf16TranscodeFileTest` (encoding matrix ×4, ASCII/UTF-8-BOM/empty/BOM-only/odd-length/NUL-binary/nonexistent rows, mtime preservation) and `PfbTextSanityUtf16Test` — the sanity rows are a true behavioural red on pre-change code (`nul_bytes` → `NULL`/`html_error_page`), re-executed independently by the step verifier.
- `PfbDnsblStripBomTest` gains two intent-pinning composition rows (BOM-stripped lines are anchor-/comment-detectable).
- New smoke case `test_dnsbl_bom_header_feed_parses_without_error` + fixture (BOM-led `!` header line, ABP anchor line, hosts line): asserts both domains block and the parse-error log stays clean — the executed red→green carrier for the loop-order change, which has no off-appliance unit seam (runs on the live-VM smoke dispatch).
- Full gates green: PHPUnit 2395, PHPStan, PHPCS, pytest 2334, ruff, mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfJUsCQkpFZxXufncGUS2f
