### PR TITLE
tests/smoke: give test_abp_regex_admitted_count fail-safe headroom (#875)

### DIFF
--- a/tests/smoke/test_smoke_abp.py
+++ b/tests/smoke/test_smoke_abp.py
@@ -315,9 +315,11 @@ def test_abp_regex_block_and_allow(deployed_vm: SmokeVM, client_vm: SmokeVM, moc
         assert h.resolves_to(ans_allow, STUB_DNS_A), f"@@ regex should un-block {unblocked} via stub, got {ans_allow}"
 
 
-@pytest.mark.timeout(90)  # two CaseContext reload cycles; each zero-downtime swap may burn its full
-# 30s watcher handshake before the designed restart fallback (pfb_unbound_py_wait_applied), so the
-# 30s default cap kills the test mid-fail-safe on a rare watcher stall (#875).
+@pytest.mark.timeout(90)  # two CaseContext reload cycles, and BOTH change module ini settings
+# (pfb_regex_list, then pfb_regex_cap) -> $pfbpython=TRUE -> $datapath=FALSE, so each cycle takes
+# the full RESTART path (pfb_stop_start_unbound), never the zero-downtime swap. Its bounded
+# stop-wait (up to 30s for unbound to terminate) can stall either cycle past the default 30s cap
+# on a rare transient -- observed once, reload 29.22s vs 2.5s sibling norm (#875).
 def test_abp_regex_admitted_count(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """The DNSBL_Regex count reflects ADMITTED regex; the length cap (opt-in) shrinks it.
 
@@ -509,6 +511,9 @@ def test_custom_list_block_beats_feed_important_allow(
 # --------------------------------------------------------------------------- #
 
 
+@pytest.mark.timeout(90)  # same class as test_abp_regex_admitted_count above: two CaseContext
+# reload cycles, both flipping a module ini setting (pfb_cname) -> the RESTART path each time,
+# whose bounded 30s stop-wait can stall one cycle past the default 30s cap (#875).
 def test_cname_validation_on_off(
     deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer, stub_dns: _StubDnsServer
 ) -> None:

--- a/tests/smoke/test_smoke_abp.py
+++ b/tests/smoke/test_smoke_abp.py
@@ -315,6 +315,9 @@ def test_abp_regex_block_and_allow(deployed_vm: SmokeVM, client_vm: SmokeVM, moc
         assert h.resolves_to(ans_allow, STUB_DNS_A), f"@@ regex should un-block {unblocked} via stub, got {ans_allow}"
 
 
+@pytest.mark.timeout(90)  # two CaseContext reload cycles; each zero-downtime swap may burn its full
+# 30s watcher handshake before the designed restart fallback (pfb_unbound_py_wait_applied), so the
+# 30s default cap kills the test mid-fail-safe on a rare watcher stall (#875).
 def test_abp_regex_admitted_count(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """The DNSBL_Regex count reflects ADMITTED regex; the length cap (opt-in) shrinks it.
 


### PR DESCRIPTION
## What

Adds `@pytest.mark.timeout(90)` to two `tests/smoke/test_smoke_abp.py` tests whose bodies run **two** on-box reload cycles under the smoke suite's default 30 s per-test cap:

- `test_abp_regex_admitted_count` (the test #875 observed timing out)
- `test_cname_validation_on_off` (same risk class — found by AST enumeration of all ≥2-`CaseContext` smoke tests during the adversarial review; the only other unmarked member)

This matches the sibling two-reload tests in `test_smoke_autorule_immutable.py` (`timeout(90)  # two Force-Update reloads…`).

## Why — diagnostics from the failing run

Triage of #875 pulled the `smoke-diagnostics` artifact from failing run [28755782317](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28755782317):

- The stall is a single on-box reload: `PFB_TIMING ssh:pfblockerng.php pfb_trigger scope=dnsbl 29.22s` (sibling reloads in the same module: 2.5 s), killed by the 30 s pytest-timeout while still inside `reload()` → `SmokeVM.ssh`. Everything else in the failing run ran at its committed norm, confirming the issue's read: isolated transient, not systematic load.
- **Mechanism (corrected during review):** both of the test's reload cycles change module ini settings (`pfb_regex_list`, then `pfb_regex_cap`), so `pfb_unbound_python()` reports a config change, `$datapath = !$pfbpython` is FALSE, and `pfb_reload_unbound()` takes the **restart path** (`pfb_stop_start_unbound`) on every cycle — never the ADR-10 zero-downtime swap. That restart path's own bounded stop-wait ("wait up to 30 seconds for [unbound] to terminate", `pfblockerng.inc`) is the internal 30 s budget a rare transient can burn.
- A single stalled cycle therefore lands right at the test's whole 30 s budget, and pytest kills the test **mid-fail-safe** — before the product's own bounded recovery completes.

So this is not an unbounded product hang: each cycle's worst case is bounded (~30-35 s); the test just gave it zero headroom. A 90 s cap keeps the hang-detection property (a real hang still fails fast) while letting the designed recovery finish — the remediation #875 itself proposed for the transient case. If either test ever trips 90 s, that is a genuine product hang and worth a fresh issue with its diagnostics.

## Review

Claude Sonnet 5 adversarial review (xhigh) found the original comment blamed the wrong mechanism (`pfb_unbound_py_wait_applied` — structurally unreachable for these tests) and surfaced the unmarked sibling; both fixed in the second commit. CodeRabbit was rate-limited (no review); Copilot reviewed with no findings; Snyk hit its scan quota (skipped). Full audit trail in the PR comments.

## Verification

- `pytest` (unit suite): 2361 passed, 5 skipped
- `ruff check .` / `ruff format --check .` / `mypy tests/`: clean
- Smoke collection of the module: 15 tests collected with `-W error::PytestUnknownMarkWarning` (the `timeout` marker is registered in `pyproject.toml`)
- Marker semantics verified against the smoke flags (`--timeout-method=signal`, `timeout_func_only=true`): the mark overrides only the timeout value; method/func_only fall back to the env settings
- Red→green on the live VM is infeasible: the trigger is a rare, non-reproducible transient (observed once in two consecutive bare `smoke-single` runs)

Fixes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wa8L3NyV43YGKKLgwK31K1