### PR TITLE
pfblockerng: case-fold the TOP1M TLD inclusion match; anchor the csv hostname guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -509,7 +509,8 @@ Activate once after cloning: `sh scripts/setup-hooks.sh` (sets `core.hooksPath`)
 
 ```sh
 python3 -m pytest        # from repo root; run after ANY change to pfb_unbound.py or tests/
-composer install        # once
+composer install        # once; if it 403s in a managed cloud session, run
+                        # scripts/composer-cloud-install.sh instead (issue #950)
 vendor/bin/phpunit      # PHP suite: loads the REAL pfblockerng.inc off-appliance
 ```
 

--- a/scripts/composer-cloud-install.sh
+++ b/scripts/composer-cloud-install.sh
@@ -20,7 +20,10 @@
 #
 # ponytail: phpstan/phpstan is the only dist-only package in today's lock;
 # generalize the strip/fetch to a package list if another one ever appears.
-set -eu
+#
+# No top-level `set -eu`: the shellspec suite sources this file for its helper
+# functions, and mutating the sourcing shell's options there is a side effect;
+# main() sets strict mode for direct execution.
 
 REPO_ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 
@@ -53,7 +56,18 @@ strip_phpstan() {
 	' "$1" "$2"
 }
 
+# The fallback mutates composer.json/lock in a repo ($1) and restores them via
+# git checkout; refuse to run over uncommitted user edits — staged OR unstaged,
+# hence the diff against HEAD, not just the index (PR #953 review).
+refuse_if_composer_files_dirty() {
+	if ! git -C "$1" diff --quiet HEAD -- composer.json composer.lock; then
+		echo "composer-cloud-install: composer.json/composer.lock have uncommitted changes; commit or stash them first" >&2
+		return 1
+	fi
+}
+
 main() {
+	set -eu
 	cd "$REPO_ROOT"
 	# Composer refuses plugins as root without this; harmless as non-root.
 	export COMPOSER_ALLOW_SUPERUSER=1
@@ -64,12 +78,7 @@ main() {
 
 	echo "composer-cloud-install: plain install failed -- applying the cloud egress fallback (issue #950)" >&2
 
-	# The fallback mutates composer.json/lock and restores them via git checkout;
-	# refuse to run over uncommitted user edits it would clobber.
-	if ! git diff --quiet -- composer.json composer.lock; then
-		echo "composer-cloud-install: composer.json/composer.lock have uncommitted changes; commit or stash them first" >&2
-		exit 1
-	fi
+	refuse_if_composer_files_dirty "$REPO_ROOT"
 
 	ref="$(phpstan_ref_from_lock composer.lock)"
 	if [ -z "$ref" ]; then
@@ -83,7 +92,7 @@ main() {
 	git checkout -- composer.json composer.lock
 	trap - EXIT
 
-	staging="$(mktemp -d)"
+	staging="$(mktemp -d "${TMPDIR:-/tmp}/composercloud.XXXXXX")"
 	git init -q "$staging"
 	git -C "$staging" fetch -q --depth 1 https://github.com/phpstan/phpstan.git "$ref"
 	git -C "$staging" checkout -q FETCH_HEAD

--- a/scripts/composer-cloud-install.sh
+++ b/scripts/composer-cloud-install.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# composer-cloud-install.sh — composer install with fallbacks for egress-restricted
+# managed cloud sessions (issue #950).
+#
+# In Anthropic managed cloud sessions, GitHub REST endpoints (api.github.com,
+# codeload.github.com) are repo-scoped: any third-party repo returns 403, so every
+# composer dist (zipball) download fails with "Could not authenticate against
+# github.com". Plain git clone/fetch of public GitHub repos still works. The one
+# package that cannot ride `--prefer-source` is phpstan/phpstan: it is dist-only in
+# composer.lock (the phar distribution repo carries no source entry), and a full
+# mirror clone of it times out (phar blobs across the whole history).
+#
+# Recipe (validated in issue #950):
+#   1. Plain `composer install`; on success, done — no fallback needed.
+#   2. Strip phpstan/phpstan from composer.json + composer.lock (composer
+#      hard-errors on a json/lock mismatch, so both), then
+#      `composer install --prefer-source` (git transport), then restore both files.
+#   3. Shallow-fetch phpstan at the lock's pinned dist reference (single commit,
+#      fast), place it under vendor/phpstan/phpstan, symlink vendor/bin/phpstan.
+#
+# ponytail: phpstan/phpstan is the only dist-only package in today's lock;
+# generalize the strip/fetch to a package list if another one ever appears.
+set -eu
+
+REPO_ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+
+# Echo phpstan/phpstan's pinned dist reference from a composer.lock ($1).
+phpstan_ref_from_lock() {
+	# shellcheck disable=SC2016  # the $-signs are PHP variables, not shell expansions
+	php -r '
+		$l = json_decode(file_get_contents($argv[1]), true);
+		foreach (array_merge($l["packages"] ?? [], $l["packages-dev"] ?? []) as $p) {
+			if ($p["name"] === "phpstan/phpstan") {
+				echo $p["dist"]["reference"] ?? "";
+				exit;
+			}
+		}
+	' "$1"
+}
+
+# Remove phpstan/phpstan from a composer.json ($1) and composer.lock ($2), in place.
+strip_phpstan() {
+	# shellcheck disable=SC2016  # the $-signs are PHP variables, not shell expansions
+	php -r '
+		$j = json_decode(file_get_contents($argv[1]), true);
+		unset($j["require-dev"]["phpstan/phpstan"]);
+		file_put_contents($argv[1], json_encode($j, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+		$l = json_decode(file_get_contents($argv[2]), true);
+		foreach (["packages", "packages-dev"] as $k) {
+			$l[$k] = array_values(array_filter($l[$k] ?? [], fn ($p) => $p["name"] !== "phpstan/phpstan"));
+		}
+		file_put_contents($argv[2], json_encode($l, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+	' "$1" "$2"
+}
+
+main() {
+	cd "$REPO_ROOT"
+	# Composer refuses plugins as root without this; harmless as non-root.
+	export COMPOSER_ALLOW_SUPERUSER=1
+
+	if composer install --no-interaction; then
+		exit 0
+	fi
+
+	echo "composer-cloud-install: plain install failed -- applying the cloud egress fallback (issue #950)" >&2
+
+	# The fallback mutates composer.json/lock and restores them via git checkout;
+	# refuse to run over uncommitted user edits it would clobber.
+	if ! git diff --quiet -- composer.json composer.lock; then
+		echo "composer-cloud-install: composer.json/composer.lock have uncommitted changes; commit or stash them first" >&2
+		exit 1
+	fi
+
+	ref="$(phpstan_ref_from_lock composer.lock)"
+	if [ -z "$ref" ]; then
+		echo "composer-cloud-install: no phpstan/phpstan dist reference in composer.lock" >&2
+		exit 1
+	fi
+
+	trap 'git -C "$REPO_ROOT" checkout -- composer.json composer.lock' EXIT
+	strip_phpstan composer.json composer.lock
+	composer install --no-interaction --prefer-source
+	git checkout -- composer.json composer.lock
+	trap - EXIT
+
+	staging="$(mktemp -d)"
+	git init -q "$staging"
+	git -C "$staging" fetch -q --depth 1 https://github.com/phpstan/phpstan.git "$ref"
+	git -C "$staging" checkout -q FETCH_HEAD
+	rm -rf "$staging/.git" vendor/phpstan/phpstan
+	mkdir -p vendor/phpstan
+	mv "$staging" vendor/phpstan/phpstan
+	ln -sf ../phpstan/phpstan/phpstan vendor/bin/phpstan
+
+	echo "composer-cloud-install: fallback complete" >&2
+	vendor/bin/phpstan --version
+}
+
+# Run only when executed, not when sourced by the shellspec suite.
+case "${0##*/}" in
+	composer-cloud-install.sh) main "$@" ;;
+esac

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8534,12 +8534,21 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 				// providers (a CDN error page or a JSON auth-error body still has a '.' and
 				// a ',' somewhere) (#892 review).
 				$csvline = str_getcsv($line, ',', '"', "\\");
-				$domain = $csvline[$top1m_domcol] ?? '';
+				// #920: fold once here -- the GUI's inclusion keys are always lowercase
+				// (pfblockerng_dnsbl.php's $options_alexa_inclusion), so an uppercase/
+				// mixed-case feed domain otherwise passes every guard below but silently
+				// fails the isset($pfb_include[$tld]) compare; folding here also feeds
+				// the 'www.' strip and the write, so every downstream use is canonical.
+				$domain = strtolower($csvline[$top1m_domcol] ?? '');
 				if ($top1m_parse === 'rank_domain') {
 					if (!ctype_digit((string) ($csvline[0] ?? ''))) {
 						continue;
 					}
-				} elseif (!preg_match('/^[A-Za-z0-9][A-Za-z0-9.-]*\.(?:[A-Za-z]{2,}|[Xx][Nn]--[A-Za-z0-9][A-Za-z0-9-]+)$/', $domain)) {
+				// #920: the `D` modifier anchors '$' to the true string end -- without it, a
+				// quoted-unterminated CSV field (str_getcsv() retains its trailing "\n", unlike
+				// every other field shape) wrongly passes and can flip a garbage-only feed from
+				// dead (preserve) to valid (wipe), the same class of bug the #886/#892 guards fix.
+				} elseif (!preg_match('/^[A-Za-z0-9][A-Za-z0-9.-]*\.(?:[A-Za-z]{2,}|[Xx][Nn]--[A-Za-z0-9][A-Za-z0-9-]+)$/D', $domain)) {
 					continue;
 				}
 				// Count every valid CSV row BEFORE the match/break below, so a

--- a/tests/php/Top1mTldCaseFoldTest.php
+++ b/tests/php/Top1mTldCaseFoldTest.php
@@ -40,13 +40,12 @@ use PHPUnit\Framework\TestCase;
  *     'WWW.' is stripped AFTER folding; a folded TLD that still doesn't match
  *     still counts toward $linecnt (not a dead feed) but writes no entry;
  *     an already-lowercase row is unaffected (no regression).
- *   * csv (OpenPageRank/Majestic/Cloudflare shapes): an uppercase
- *     single-column domain (Cloudflare shape) folds and matches; a
- *     quoted-unterminated field (domain_col 0 AND domain_col 1, header
- *     modes) is REJECTED by the anchored regex, taking the dead-feed
- *     preserve-prior-whitelist path instead of the pre-fix wipe; a
- *     mixed-case domain at a non-default column (Majestic shape, domain_col
- *     2) still folds and matches, proving the fix is not column-dependent.
+ *   * csv (OpenPageRank/Majestic/Cloudflare -- each via its REAL registered
+ *     descriptor from pfb_top1m_providers()): an uppercase/mixed-case domain
+ *     folds and matches at every registered domain_col (0 Cloudflare,
+ *     1 OpenPageRank, 2 Majestic); a quoted-unterminated field (domain_col 0
+ *     AND domain_col 1) is REJECTED by the anchored regex, taking the
+ *     dead-feed preserve-prior-whitelist path instead of the pre-fix wipe.
  */
 #[CoversFunction('pfblockerng_top1m')]
 final class Top1mTldCaseFoldTest extends TestCase
@@ -207,22 +206,25 @@ final class Top1mTldCaseFoldTest extends TestCase
 	}
 
 	/**
-	 * Row 6 -- 'csv' parse, domain_col 0 (Cloudflare's single-column shape,
-	 * no header): an uppercase domain still passes the hostname guard
-	 * (its character classes already cover both cases) and must fold before
-	 * the TLD compare, same as the rank_domain rows above.
+	 * Row 6 -- 'csv' parse, domain_col 0 via the REAL registered Cloudflare
+	 * descriptor (header=TRUE, single 'domain' column): an uppercase domain
+	 * still passes the hostname guard (its character classes already cover
+	 * both cases) and must fold before the TLD compare, same as the
+	 * rank_domain rows above (PR #953 review: the real descriptor, not a
+	 * synthetic no-header stand-in no registered provider matches).
 	 */
 	public function testCsvDomainCol0UppercaseDomainMatchesAndFoldsToLowercaseEntries(): void
 	{
-		$provider = ['parse' => 'csv', 'header' => FALSE, 'domain_col' => 0];
-		$this->assertNotFalse(file_put_contents($this->csvPath(), "EXAMPLE.COM\n"), 'setup: single-column uppercase domain, no header');
+		$csv = "domain\n"
+			. "EXAMPLE.COM\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: Cloudflare-shaped header + uppercase single-column domain');
 
-		pfblockerng_top1m($provider);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::Cloudflare->value]);
 
 		$got = file_get_contents($this->whitelistPath());
 		$this->assertNotFalse($got);
 		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
-			'domain_col 0 must fold an uppercase single-column domain the same as every other column shape');
+			'domain_col 0 (real Cloudflare descriptor) must fold an uppercase single-column domain the same as every other column shape');
 	}
 
 	/**
@@ -240,15 +242,16 @@ final class Top1mTldCaseFoldTest extends TestCase
 	 */
 	public function testCsvDomainCol0QuotedUnterminatedNewlineRejectedPreservesPriorWhitelist(): void
 	{
-		$provider = ['parse' => 'csv', 'header' => FALSE, 'domain_col' => 0];
 		$priorContent = ".real.com,,\n,real.com,,\n,www.real.com,,\n";
 		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
 		// Written directly (not via an escaped literal) so the unterminated quote + trailing
 		// newline survive exactly as str_getcsv() would receive them from a real corrupted line.
-		$this->assertNotFalse(file_put_contents($this->csvPath(), "\"example.com\n"), 'setup: quoted-unterminated single-column row');
+		// Real Cloudflare descriptor (header=TRUE): the header row is skipped, the
+		// quoted-unterminated row is the only data line.
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "domain\n\"example.com\n"), 'setup: header + quoted-unterminated single-column row');
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
 
-		pfblockerng_top1m($provider);
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::Cloudflare->value]);
 
 		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
 			'a quoted-unterminated field (trailing newline retained) must NOT be accepted as a valid hostname');
@@ -277,6 +280,27 @@ final class Top1mTldCaseFoldTest extends TestCase
 			'a quoted-unterminated Domain field must NOT be accepted, even at a non-zero column with a header row');
 		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readErrLog());
 		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+	}
+
+	/**
+	 * Row 8b -- 'csv' parse, domain_col 1 via the REAL registered OpenPageRank
+	 * descriptor (header=TRUE): an uppercase Domain field must fold and match,
+	 * completing the case-fold proof for every csv domain_col the provider
+	 * registry names (0/1/2) against its real descriptor (PR #953 review: row 8
+	 * only proved the /D anchor at this column, never the fold).
+	 */
+	public function testCsvDomainCol1OpenPageRankShapeUppercaseDomainMatchesAndFolds(): void
+	{
+		$csv = "Rank,Domain,Extension,Open Page Rank,Referring Domains\n"
+			. "1,EXAMPLE.COM,com,7.5,1000\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: OpenPageRank-shaped header + uppercase Domain row');
+
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::OpenPageRank->value]);
+
+		$got = file_get_contents($this->whitelistPath());
+		$this->assertNotFalse($got);
+		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+			'an uppercase Domain field at domain_col 1 (real OpenPageRank descriptor) must still fold and match');
 	}
 
 	/**

--- a/tests/php/Top1mTldCaseFoldTest.php
+++ b/tests/php/Top1mTldCaseFoldTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #920 -- pfblockerng_top1m()'s TLD inclusion match is case-sensitive
+ * while the include keys are always lowercase (the GUI's fixed
+ * $options_alexa_inclusion list, pfblockerng_dnsbl.php, keys like 'ae'/'com').
+ * A feed row with an uppercase/mixed-case domain (EXAMPLE.COM,
+ * example.XN--P1AI) passed every guard, counted toward $linecnt, but silently
+ * failed isset($pfb_include[$tld]) -- never whitelisted, no warning, no log.
+ *
+ * Fix: fold $domain to lowercase ONCE at extraction (before the TLD split,
+ * the 'www.' strip, and the write), so the TLD compare, the www-strip, and
+ * the written whitelist entries are all case-insensitive/canonical in one
+ * spot -- downstream (pfb_unbound.py) already lowercases on ingest.
+ *
+ * Same issue also anchors the 'csv' parse mode's hostname guard regex with
+ * the `D` modifier: without it, `$` matches before a trailing "\n" PHP's
+ * multiline mode. str_getcsv() strips a bare trailing newline in every
+ * mode, but a QUOTED UNTERMINATED field (e.g. a truncated/corrupted feed
+ * line starting '"') retains it verbatim -- so pre-fix, that garbage row
+ * passed the hostname guard, incremented $linecnt, and could flip a feed of
+ * only such rows from "dead" (preserve prior whitelist) to "valid" (swap in
+ * an empty build), silently wiping a good whitelist (same failure class as
+ * the #886/#892 dead-feed guards this function already carries).
+ *
+ * Feature: TOP1M TLD inclusion match is case-insensitive; the csv-mode
+ * hostname guard is anchored against a trailing-newline bypass
+ *   Background:
+ *     Given $pfb['dnsbl_top1m_inc'] names lowercase TLD(s) (the GUI's only
+ *           possible shape)
+ *
+ * Branch coverage (every parse mode x case shape):
+ *   * rank_domain (Tranco/Cisco, default resolved provider): uppercase
+ *     domain matches a lowercase inclusion; mixed-case punycode TLD matches;
+ *     'WWW.' is stripped AFTER folding; a folded TLD that still doesn't match
+ *     still counts toward $linecnt (not a dead feed) but writes no entry;
+ *     an already-lowercase row is unaffected (no regression).
+ *   * csv (OpenPageRank/Majestic/Cloudflare shapes): an uppercase
+ *     single-column domain (Cloudflare shape) folds and matches; a
+ *     quoted-unterminated field (domain_col 0 AND domain_col 1, header
+ *     modes) is REJECTED by the anchored regex, taking the dead-feed
+ *     preserve-prior-whitelist path instead of the pre-fix wipe; a
+ *     mixed-case domain at a non-default column (Majestic shape, domain_col
+ *     2) still folds and matches, proving the fix is not column-dependent.
+ */
+#[CoversFunction('pfblockerng_top1m')]
+final class Top1mTldCaseFoldTest extends TestCase
+{
+	private string $dbdir;
+
+	/** Saved $GLOBALS['pfb'] keys this test touches, restored in tearDown for isolation. */
+	private array $savedPfb = [];
+
+	protected function setUp(): void
+	{
+		$this->dbdir = sys_get_temp_dir() . '/pfb_top1m_casefold_' . getmypid() . '_' . uniqid();
+		$this->assertTrue(@mkdir($this->dbdir, 0777, true), "could not create sandbox {$this->dbdir}");
+
+		foreach (['dbdir', 'log', 'errlog', 'dnsbl_top1m_inc', 'dnsbl_top1m_cnt', 'runlog',
+			  'runlog_active', 'hook_lifecycle', 'pnow'] as $key) {
+			$this->savedPfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$key] : false;
+		}
+
+		$GLOBALS['pfb']['dbdir']		= $this->dbdir;
+		$GLOBALS['pfb']['log']			= "{$this->dbdir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog']		= "{$this->dbdir}/pfblockerng_error.log";
+		$GLOBALS['pfb']['dnsbl_top1m_inc']	= 'com';
+		$GLOBALS['pfb']['dnsbl_top1m_cnt']	= '1000';
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active'],
+		      $GLOBALS['pfb']['hook_lifecycle'], $GLOBALS['pfb']['pnow']);
+
+		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['log'], ''), 'could not create main log');
+		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['errlog'], ''), 'could not create error log');
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->savedPfb as $key => $val) {
+			if ($val === false) {
+				unset($GLOBALS['pfb'][$key]);
+			} else {
+				$GLOBALS['pfb'][$key] = $val;
+			}
+		}
+		foreach ((array) (@glob("{$this->dbdir}/*") ?: []) as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->dbdir);
+	}
+
+	private function whitelistPath(): string
+	{
+		return "{$this->dbdir}/pfbalexawhitelist.txt";
+	}
+
+	private function csvPath(): string
+	{
+		return "{$this->dbdir}/top-1m.csv";
+	}
+
+	private function readErrLog(): string
+	{
+		$raw = file_get_contents($GLOBALS['pfb']['errlog']);
+		$this->assertNotFalse($raw, 'could not read error log');
+		return (string) $raw;
+	}
+
+	private function readMainLog(): string
+	{
+		$raw = file_get_contents($GLOBALS['pfb']['log']);
+		$this->assertNotFalse($raw, 'could not read main log');
+		return (string) $raw;
+	}
+
+	/**
+	 * Row 1 -- default resolved provider (NO override -> rank_domain,
+	 * domain_col 1, the Tranco/Cisco shape): an all-uppercase domain must
+	 * still match the GUI's lowercase 'com' inclusion, and the entries
+	 * written are canonical lowercase.
+	 */
+	public function testRankDomainUppercaseDomainMatchesLowercaseInclusionAndWritesLowercaseEntries(): void
+	{
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "5,EXAMPLE.COM\n"), 'setup: uppercase-domain rank_domain row');
+
+		pfblockerng_top1m();
+
+		$got = file_get_contents($this->whitelistPath());
+		$this->assertNotFalse($got);
+		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+			'an uppercase domain must fold to lowercase before the TLD compare and the write');
+	}
+
+	/**
+	 * Row 2 -- rank_domain: a mixed-case punycode TLD ('example.XN--P1AI')
+	 * must fold and match a lowercase 'xn--p1ai' inclusion, exactly as
+	 * issue #904's all-lowercase punycode case already does.
+	 */
+	public function testRankDomainMixedCasePunycodeTldMatchesLowercaseInclusion(): void
+	{
+		$GLOBALS['pfb']['dnsbl_top1m_inc'] = 'xn--p1ai';
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "6,example.XN--P1AI\n"), 'setup: mixed-case punycode-TLD row');
+
+		pfblockerng_top1m();
+
+		$got = file_get_contents($this->whitelistPath());
+		$this->assertNotFalse($got);
+		$this->assertSame(".example.xn--p1ai,,\n,example.xn--p1ai,,\n,www.example.xn--p1ai,,\n", $got,
+			'a mixed-case punycode TLD must fold to lowercase before the TLD compare');
+	}
+
+	/**
+	 * Row 3 -- rank_domain: 'WWW.' must be stripped AFTER the fold, so an
+	 * uppercase 'WWW.EXAMPLE.COM' still whitelists as example.com (never a
+	 * literal 'www.example.com'-prefixed leftover from an un-folded strip).
+	 */
+	public function testRankDomainUppercaseWwwPrefixStrippedAfterFold(): void
+	{
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "7,WWW.EXAMPLE.COM\n"), 'setup: uppercase www-prefixed row');
+
+		pfblockerng_top1m();
+
+		$got = file_get_contents($this->whitelistPath());
+		$this->assertNotFalse($got);
+		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+			"the 'www.' strip must run against the FOLDED domain, not the raw uppercase value");
+	}
+
+	/**
+	 * Row 4 -- negative guard: the fold must not OVER-match. An uppercase
+	 * domain whose TLD genuinely is not in the inclusion set is still
+	 * counted toward $linecnt (a valid parsed row -- not a dead feed) but
+	 * writes no whitelist entry.
+	 */
+	public function testRankDomainUppercaseDomainNotMatchingInclusionCountsButWritesNoEntry(): void
+	{
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "8,EXAMPLE.ORG\n"), 'setup: uppercase row, TLD not in the inclusion set');
+
+		pfblockerng_top1m();
+
+		$this->assertSame('', file_get_contents($this->whitelistPath()),
+			'a valid row whose (folded) TLD does not match must write no entry, but still replace the build (not dead-feed)');
+		$this->assertStringContainsString('Parsed 1 lines | Found 0 of 1000', $this->readMainLog(),
+			'the row must still count toward $linecnt -- the feed is valid, just non-matching');
+		$this->assertStringNotContainsString('keeping the previous TOP1M whitelist', $this->readMainLog(),
+			'a non-matching row must never be classified as a dead feed');
+	}
+
+	/**
+	 * Row 5 -- regression guard: an already-lowercase domain is unaffected
+	 * by the fold (byte-identical to pre-fix behaviour).
+	 */
+	public function testRankDomainLowercaseControlStillMatchesUnaffectedByFold(): void
+	{
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "9,example.com\n"), 'setup: already-lowercase row');
+
+		pfblockerng_top1m();
+
+		$got = file_get_contents($this->whitelistPath());
+		$this->assertNotFalse($got);
+		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+			'an already-lowercase domain must match exactly as before -- no regression from the fold');
+	}
+
+	/**
+	 * Row 6 -- 'csv' parse, domain_col 0 (Cloudflare's single-column shape,
+	 * no header): an uppercase domain still passes the hostname guard
+	 * (its character classes already cover both cases) and must fold before
+	 * the TLD compare, same as the rank_domain rows above.
+	 */
+	public function testCsvDomainCol0UppercaseDomainMatchesAndFoldsToLowercaseEntries(): void
+	{
+		$provider = ['parse' => 'csv', 'header' => FALSE, 'domain_col' => 0];
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "EXAMPLE.COM\n"), 'setup: single-column uppercase domain, no header');
+
+		pfblockerng_top1m($provider);
+
+		$got = file_get_contents($this->whitelistPath());
+		$this->assertNotFalse($got);
+		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+			'domain_col 0 must fold an uppercase single-column domain the same as every other column shape');
+	}
+
+	/**
+	 * Row 7 -- the `D` modifier anchor: a quoted-UNTERMINATED field (e.g.
+	 * "\"example.com\n" with no closing quote) retains its trailing "\n"
+	 * through str_getcsv() -- verified this session: str_getcsv() strips a
+	 * bare trailing newline in every parse mode, but a quoted/unterminated
+	 * field does not. Pre-fix (no `D`), `$` matches before that "\n" in PHP's
+	 * default multiline `$`, so the regex WRONGLY accepts it, $linecnt goes
+	 * to 1, and the "valid feed" branch REPLACES a good prior whitelist with
+	 * an empty build. Post-fix (`D` anchors `$` to the true string end), the
+	 * row is rejected, $linecnt stays 0, and the dead-feed path PRESERVES
+	 * the prior whitelist + warns -- exactly the #886/#892 guard this
+	 * function already relies on for other garbage-row shapes.
+	 */
+	public function testCsvDomainCol0QuotedUnterminatedNewlineRejectedPreservesPriorWhitelist(): void
+	{
+		$provider = ['parse' => 'csv', 'header' => FALSE, 'domain_col' => 0];
+		$priorContent = ".real.com,,\n,real.com,,\n,www.real.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
+		// Written directly (not via an escaped literal) so the unterminated quote + trailing
+		// newline survive exactly as str_getcsv() would receive them from a real corrupted line.
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "\"example.com\n"), 'setup: quoted-unterminated single-column row');
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
+
+		pfblockerng_top1m($provider);
+
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
+			'a quoted-unterminated field (trailing newline retained) must NOT be accepted as a valid hostname');
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readErrLog());
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+	}
+
+	/**
+	 * Row 8 -- same `D`-modifier anchor as row 7, but via the REAL registered
+	 * OpenPageRank descriptor (header=TRUE, domain_col 1) -- a multi-column
+	 * row whose Domain field is quoted-unterminated (e.g. a feed truncated
+	 * mid-line) must be rejected the same way, after the header is skipped.
+	 */
+	public function testCsvDomainCol1HeaderModeQuotedUnterminatedNewlineRejectedPreservesPriorWhitelist(): void
+	{
+		$priorContent = ".real.com,,\n,real.com,,\n,www.real.com,,\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
+		$csv = "Rank,Domain,Extension,Open Page Rank,Referring Domains\n"
+			. "1,\"example.com\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: header + quoted-unterminated Domain field');
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
+
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::OpenPageRank->value]);
+
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
+			'a quoted-unterminated Domain field must NOT be accepted, even at a non-zero column with a header row');
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readErrLog());
+		$this->assertStringContainsString('keeping the previous TOP1M whitelist', $this->readMainLog());
+	}
+
+	/**
+	 * Row 9 -- 'csv' parse, domain_col 2 (Majestic's real shape, header=TRUE):
+	 * a mixed-case Domain field ('Example.CoM') must fold and match, proving
+	 * the fix is not specific to domain_col 0/1.
+	 */
+	public function testCsvDomainCol2MajesticShapeMixedCaseDomainMatchesAndFolds(): void
+	{
+		$csv = "GlobalRank,TldRank,Domain,TLD,RefSubNets,RefIPs,IDN_Domain,IDN_TLD,PrevGlobalRank,PrevTldRank,PrevRefSubNets,PrevRefIPs\n"
+			. "1,1,Example.CoM,extra\n";
+		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: Majestic-shaped mixed-case Domain row');
+
+		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::Majestic->value]);
+
+		$got = file_get_contents($this->whitelistPath());
+		$this->assertNotFalse($got);
+		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+			'a mixed-case Domain field at a non-default column (Majestic, index 2) must still fold and match');
+	}
+}

--- a/tests/shell/composer_cloud_install_spec.sh
+++ b/tests/shell/composer_cloud_install_spec.sh
@@ -1,13 +1,16 @@
 #shellcheck shell=sh
 # composer-cloud-install.sh — the cloud egress fallback's offline-testable pieces
-# (issue #950): the lock-ref extraction and the json/lock phpstan strip. The
-# network stages (composer --prefer-source, the shallow phpstan fetch) need live
-# egress and are exercised by actually using the script in a cloud session.
+# (issue #950): the lock-ref extraction, the json/lock phpstan strip, and the
+# uncommitted-edits guard. The network stages (composer --prefer-source, the
+# shallow phpstan fetch) need live egress and are exercised by actually using
+# the script in a cloud session.
 
 Describe 'composer-cloud-install.sh helpers (issue #950)'
   SCRIPT="${PFB_ROOT}/scripts/composer-cloud-install.sh"
 
   setup() {
+    # Scrub inherited git context (GIT_DIR etc. would corrupt the fixture repo).
+    scrub_git_env
     WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/composercloud.XXXXXX")"
     cat > "${WORK}/composer.json" << 'EOF'
 {
@@ -94,6 +97,43 @@ EOF
       strip_phpstan "${WORK}/composer.json" "${WORK}/composer.lock"
       When call json_still_parses "${WORK}/composer.json" "${WORK}/composer.lock"
       The output should equal 'ok'
+    End
+  End
+
+  Describe 'refuse_if_composer_files_dirty'
+    # Turn the WORK fixture dir into a git repo with both files committed, so
+    # the guard's HEAD comparison has a baseline to diff against.
+    commit_baseline() {
+      git -C "$WORK" init -q
+      git -C "$WORK" -c user.name=spec -c user.email=spec@example.invalid \
+        add composer.json composer.lock
+      git -C "$WORK" -c user.name=spec -c user.email=spec@example.invalid \
+        commit -qm baseline
+    }
+
+    It 'passes on a clean composer.json/composer.lock'
+      commit_baseline
+      When call refuse_if_composer_files_dirty "$WORK"
+      The status should be success
+    End
+
+    It 'refuses UNSTAGED composer.json edits'
+      commit_baseline
+      echo '{"changed": true}' > "${WORK}/composer.json"
+      When call refuse_if_composer_files_dirty "$WORK"
+      The status should be failure
+      The stderr should include 'uncommitted changes'
+    End
+
+    # PR #953 review: `git diff --quiet` alone compares worktree vs index and
+    # silently passes STAGED edits; the guard must diff against HEAD instead.
+    It 'refuses STAGED composer.lock edits'
+      commit_baseline
+      echo '{"packages": []}' > "${WORK}/composer.lock"
+      git -C "$WORK" add composer.lock
+      When call refuse_if_composer_files_dirty "$WORK"
+      The status should be failure
+      The stderr should include 'uncommitted changes'
     End
   End
 End

--- a/tests/shell/composer_cloud_install_spec.sh
+++ b/tests/shell/composer_cloud_install_spec.sh
@@ -1,0 +1,99 @@
+#shellcheck shell=sh
+# composer-cloud-install.sh — the cloud egress fallback's offline-testable pieces
+# (issue #950): the lock-ref extraction and the json/lock phpstan strip. The
+# network stages (composer --prefer-source, the shallow phpstan fetch) need live
+# egress and are exercised by actually using the script in a cloud session.
+
+Describe 'composer-cloud-install.sh helpers (issue #950)'
+  SCRIPT="${PFB_ROOT}/scripts/composer-cloud-install.sh"
+
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/composercloud.XXXXXX")"
+    cat > "${WORK}/composer.json" << 'EOF'
+{
+    "require-dev": {
+        "phpstan/phpstan": "^2.1",
+        "phpunit/phpunit": "^11.0"
+    }
+}
+EOF
+    cat > "${WORK}/composer.lock" << 'EOF'
+{
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.1",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/abc123def456",
+                "reference": "abc123def456"
+            }
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.55",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fff",
+                "reference": "fff"
+            }
+        }
+    ]
+}
+EOF
+  }
+
+  cleanup() {
+    rm -rf "$WORK"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  # shellcheck disable=SC1090  # sourced for its function definitions only
+  source_script() { . "$SCRIPT"; }
+  BeforeAll 'source_script'
+
+  Describe 'phpstan_ref_from_lock'
+    It "echoes phpstan/phpstan's pinned dist reference"
+      When call phpstan_ref_from_lock "${WORK}/composer.lock"
+      The output should equal 'abc123def456'
+    End
+
+    It 'echoes nothing when the lock has no phpstan/phpstan'
+      # Reuse the strip to produce a phpstan-less lock, then extract from it.
+      strip_phpstan "${WORK}/composer.json" "${WORK}/composer.lock"
+      When call phpstan_ref_from_lock "${WORK}/composer.lock"
+      The output should equal ''
+    End
+  End
+
+  Describe 'strip_phpstan'
+    It 'removes phpstan/phpstan from both files and keeps every other package'
+      When call strip_phpstan "${WORK}/composer.json" "${WORK}/composer.lock"
+      The status should be success
+      The contents of file "${WORK}/composer.json" should not include 'phpstan/phpstan'
+      The contents of file "${WORK}/composer.json" should include 'phpunit/phpunit'
+      The contents of file "${WORK}/composer.lock" should not include 'phpstan/phpstan'
+      The contents of file "${WORK}/composer.lock" should include 'phpunit/phpunit'
+    End
+
+    # A helper function, not an inline multi-line `When call php -r` -- shellspec's
+    # DSL rewrites multi-line call arguments and corrupts the PHP snippet.
+    # shellcheck disable=SC2016  # the $-signs are PHP variables, not shell expansions
+    json_still_parses() {
+      php -r '
+        $j = json_decode(file_get_contents($argv[1]), true);
+        $l = json_decode(file_get_contents($argv[2]), true);
+        echo ($j !== null && $l !== null && is_array($l["packages"]) && is_array($l["packages-dev"])) ? "ok" : "broken";
+      ' "$1" "$2"
+    }
+
+    It 'leaves both files as parseable JSON with the lock package arrays intact'
+      strip_phpstan "${WORK}/composer.json" "${WORK}/composer.lock"
+      When call json_still_parses "${WORK}/composer.json" "${WORK}/composer.lock"
+      The output should equal 'ok'
+    End
+  End
+End


### PR DESCRIPTION
Fixes #920. Fixes #950.

## TOP1M csv guard (#920) — both items confirmed by in-session probes

1. **Case-fold the TLD inclusion match.** `pfblockerng_top1m()` compared `isset($pfb_include[$tld])` case-sensitively while the include keys are always lowercase (the GUI's fixed `$options_alexa_inclusion` list). An uppercase/mixed-case feed domain (`EXAMPLE.COM`, `example.XN--P1AI`) passed every guard and counted toward `$linecnt` but silently failed the whitelist match. Fix: `strtolower()` the extracted domain once, so the TLD compare, the `www.` strip, and the written whitelist entries are all canonical in one spot (downstream `pfb_unbound.py` already lowercases on ingest; real-world feeds are lowercase, so current inputs are byte-identical).
2. **`D` modifier on the csv-mode hostname guard.** Probed: `str_getcsv()` strips a *bare* trailing newline in every mode, but a **quoted unterminated** field (a truncated/corrupt feed line) retains it — and without `/D`, `$` matches before that newline, so the garbage row passed the guard, incremented `$linecnt`, and could flip a garbage-only feed from dead (preserve prior whitelist) to valid (swap in an empty build) — the same failure class as the #886/#892 guards. This narrows the issue's original "only plausibly reachable for a single-column mode" guess: the reachable path is a quoted unterminated field in **any** `csv`-parse provider.

New `tests/php/Top1mTldCaseFoldTest.php` (9 tests) pins both fixes across every parse mode × domain column from the provider registry (`rank_domain` col 1; `csv` cols 0/1/2 — Cloudflare/OpenPageRank/Majestic shapes), including the negative guard (fold must not over-match), the lowercase control (no regression), and both quoted-unterminated dead-feed-preserve transitions with before-state assertions. Red→green executed: on the pre-change source the 7 fix-dependent tests fail, the 2 fix-independent guards pass; all 9 green post-fix. Full PHP gates green (`php -l`, PHPUnit 2385 tests, PHPStan, PHPCS).

## Composer bootstrap for managed cloud sessions (#950)

`scripts/composer-cloud-install.sh` automates the validated fallback for egress-restricted cloud sessions where `api.github.com`/`codeload.github.com` are repo-scoped (403 for third-party dists): plain `composer install` first; on failure, strip dist-only `phpstan/phpstan` from `composer.json`+`composer.lock`, install the rest `--prefer-source` over git, restore both files, then shallow-fetch phpstan at the lock's pinned reference into `vendor/`. Offline-testable helpers covered by `tests/shell/composer_cloud_install_spec.sh` (shellspec, 4 examples; full shell suite 387/0); `sh -n` + shellcheck clean. One-line pointer added to CLAUDE.md "Running tests".

Bundled on one branch because this managed session's push policy pins all work to a single minted branch; the two changes are otherwise independent commits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWzcfy2513ohNTkSVHm8WF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fallback installation path for Composer in managed-cloud environments when the standard install hits a 403 error.

* **Bug Fixes**
  * Improved domain validation so mixed-case entries are handled consistently and malformed CSV rows are rejected more reliably.
  * Preserves the existing TOP1M whitelist when new feed data contains invalid or unterminated fields.

* **Documentation**
  * Updated test/setup instructions to include the new Composer fallback command.

* **Tests**
  * Added coverage for case-folding, CSV parsing edge cases, and the Composer fallback workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->