### PR TITLE
git: keep ADR/docs out of language stats + local doc-free history views

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,11 @@
 # stats and collapses their diffs in GitHub review views.
 .claude/skills/ponytail/** linguist-vendored
 .claude/skills/caveman/** linguist-vendored
+
+# ADR text and dev-only docs dominate many commits (95%+ of the changed
+# lines). linguist-documentation keeps them out of the language stats while
+# leaving their diffs reviewable on GitHub (unlike linguist-generated, which
+# suppresses diffs). For local history views without the doc noise, use
+# scripts/git-no-docs.sh — it derives its excludes from these entries.
+.ADRs/** linguist-documentation
+docs/** linguist-documentation

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -179,6 +179,7 @@ in `read-version-matrix.sh`.
 | [`deploy.sh`](deploy.sh) | Fast code update of an **already-installed** pfBlockerNG: rsync `src/` + restart unbound/nginx. |
 | [`pfb-downgrade-prep.sh`](pfb-downgrade-prep.sh) | **Before rolling the package back** to a pre-4.0.x release: run on the box as root to reverse the two non-self-healing 4.0.x changes — restore custom `list_scripts/` pre/post scripts to the package root, and remove the ADR-43 `tick` cron. |
 | [`setup-hooks.sh`](setup-hooks.sh) | Point git at `.githooks` (run once after cloning). |
+| [`git-no-docs.sh`](git-no-docs.sh) | Local doc-free history views: run a read-only git command (default `log -p`) with the `.gitattributes` `linguist-documentation` trees (`.ADRs/`, `docs/`) excluded from its pathspec. |
 | [`update-pfsense-stubs.py`](update-pfsense-stubs.py) | Regenerate `stubs/pfsense/` after a CE bump. |
 | [`claude-stop-guard.py`](claude-stop-guard.py) | Claude Code Stop-hook: blocks a done/fixed/implemented claim made after editing `src/`/`tests/` with no gate command run since (issue #925). Not yet registered in `.claude/settings.json`. |
 

--- a/scripts/git-no-docs.sh
+++ b/scripts/git-no-docs.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# git-no-docs.sh — run a read-only git command with the documentation trees
+# excluded from its pathspec, so doc-heavy commits show only their code lines.
+#
+# Local companion to the linguist-documentation entries in .gitattributes:
+# on GitHub that attribute only removes the trees from language stats (it
+# never suppresses diffs), so this script provides the diff-side half for
+# local history views. The excluded patterns are read from .gitattributes
+# itself — single source of truth; add a tree there and this picks it up.
+#
+# Parsing is deliberately minimal (see tests/shell/git_no_docs_spec.sh):
+# each line is matched independently, so git's "last matching line wins"
+# attribute resolution is NOT honored — a later overriding line for the
+# same path (e.g. `docs/** -linguist-documentation`) will not undo an
+# earlier match. Quoted (space-containing) patterns that carry
+# linguist-documentation are refused loudly; [attr] macro lines are skipped.
+#
+# Usage: scripts/git-no-docs.sh [read-only git command and args]  (default: log -p)
+#   scripts/git-no-docs.sh                     # git log -p without doc lines
+#   scripts/git-no-docs.sh log --stat devel..
+#   scripts/git-no-docs.sh show HEAD
+#
+# git refuses to combine any pathspec with `log -L` or `diff --no-index`,
+# so those two forms fail loudly here — unsupported.
+set -eu
+
+root=$(git rev-parse --show-toplevel)
+
+[ "$#" -gt 0 ] || set -- log -p
+
+# An exclude appended to a state-mutating command would silently change what
+# git RECORDS (`git add -A -- ':(exclude)docs/**'` really does skip the doc
+# trees) — this tool must only ever affect the view.
+case "$1" in
+	log | show | diff | grep | blame | shortlog) ;;
+	*)
+		echo "git-no-docs.sh: read-only git commands only (log, show, diff, grep, blame, shortlog); got '$1'" >&2
+		exit 1
+		;;
+esac
+
+set -- "$@" --
+
+cr=$(printf '\r')
+
+# Append one ':(top,glob,exclude)<pattern>' pathspec per
+# linguist-documentation entry (bare or =true form; a pattern may carry
+# several attributes). 'top' anchors the pattern at the repo root so a
+# subdirectory cwd works; 'glob' pins wildmatch semantics regardless of
+# ambient GIT_NOGLOB_PATHSPECS/--noglob-pathspecs; '|| [ -n ... ]' keeps a
+# final line that lacks a trailing newline.
+found=0
+while read -r pattern attrs || [ -n "${pattern:-}" ]; do
+	pattern=${pattern%"${cr}"}
+	attrs=${attrs%"${cr}"}
+	case "${pattern}" in
+	'' | \#*) continue ;;
+	\[attr\]*) continue ;; # macro definition, not a path pattern
+	\"*)
+		# C-quoted pattern: `read` mis-splits it into a dead exclude. Refuse
+		# loudly when it affects documentation; skip when it cannot.
+		case "${attrs}" in
+		*linguist-documentation*)
+			echo "git-no-docs.sh: quoted pattern unsupported: ${pattern} ${attrs}" >&2
+			exit 1
+			;;
+		*) continue ;;
+		esac
+		;;
+	esac
+	case " ${attrs} " in
+	*' linguist-documentation '* | *' linguist-documentation=true '*) ;;
+	*) continue ;;
+	esac
+	# Strip a leading slash: 'top' already anchors at the repo root, and
+	# ':(top)' composed with '/pattern' silently matches nothing.
+	set -- "$@" ":(top,glob,exclude)${pattern#/}"
+	found=1
+done < "${root}/.gitattributes"
+
+# Fail loudly rather than silently degrade into an unfiltered git command.
+if [ "${found}" -eq 0 ]; then
+	echo "git-no-docs.sh: no linguist-documentation patterns in ${root}/.gitattributes" >&2
+	exit 1
+fi
+
+exec git "$@"

--- a/tests/shell/git_no_docs_spec.sh
+++ b/tests/shell/git_no_docs_spec.sh
@@ -1,0 +1,204 @@
+#shellcheck shell=sh
+# git_no_docs_spec.sh — pins scripts/git-no-docs.sh, the local companion to
+# the linguist-documentation entries in .gitattributes: it runs a read-only
+# git command (default `log -p`) with one ':(top,exclude)<pattern>' pathspec
+# appended per linguist-documentation pattern, so doc-heavy commits show only
+# their code lines locally (GitHub's linguist-documentation only affects
+# language stats, never diff rendering — the script is the diff-side half of
+# the pair).
+#
+# RED->GREEN evidence: the first four examples were authored before the
+# script existed — every one failed ("cannot open .../git-no-docs.sh",
+# nonzero status); all pass once the script landed. The hostile-input
+# examples (subdirectory cwd, state-mutating subcommand, missing trailing
+# newline, quoted pattern, CRLF, macro line) were authored against the
+# first-cut script from PR #956's adversarial review findings and each
+# failed on it before the corresponding fix.
+
+Describe 'git-no-docs.sh'
+  SCRIPT="${PFB_ROOT}/scripts/git-no-docs.sh"
+
+  setup() {
+    scrub_git_env
+    repo=$(mktemp -d)
+    git -C "$repo" init -q
+    git -C "$repo" config user.name t
+    git -C "$repo" config user.email t@t
+    printf '%s\n' 'docsdir/** linguist-documentation' > "$repo/.gitattributes"
+    mkdir -p "$repo/docsdir"
+    printf 'doc line\n' > "$repo/docsdir/notes.md"
+    printf 'code line\n' > "$repo/code.sh"
+    git -C "$repo" add -A
+    git -C "$repo" commit -qm 'mixed commit'
+  }
+  cleanup() {
+    rm -rf "$repo"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  # shellcheck disable=SC2120  # args come from the `When call` DSL lines
+  run_in_repo() {
+    ( cd "$repo" && sh "$SCRIPT" "$@" )
+  }
+
+  It 'defaults to log -p and hides the documentation tree'
+    When call run_in_repo
+    The status should be success
+    The output should include 'code.sh'
+    The output should not include 'notes.md'
+  End
+
+  It 'still shows the doc-hidden commit itself'
+    # Exclusion drops the doc LINES, never the commit from history.
+    When call run_in_repo
+    The output should include 'mixed commit'
+  End
+
+  It 'passes an explicit git command through with the excludes appended'
+    When call run_in_repo show --stat HEAD
+    The status should be success
+    The output should include 'code.sh'
+    The output should not include 'notes.md'
+  End
+
+  # Vacuity guard: without the loud failure the script would silently
+  # degrade into plain `git log -p` and hide nothing.
+  run_without_docattr() {
+    printf '%s\n' 'docsdir/** linguist-generated' > "$repo/.gitattributes"
+    run_in_repo
+  }
+
+  It 'fails loudly when .gitattributes has no linguist-documentation entries'
+    When call run_without_docattr
+    The status should equal 1
+    The stderr should include 'no linguist-documentation patterns'
+  End
+
+  # ── Hostile inputs (PR #956 review findings) ──────────────────────────────
+
+  run_from_subdir() {
+    mkdir -p "$repo/sub"
+    ( cd "$repo/sub" && sh "$SCRIPT" )
+  }
+
+  It 'excludes the doc tree when run from a repo subdirectory'
+    # ':(exclude)' without 'top' anchors at the cwd and silently stops
+    # matching from anywhere but the repo root.
+    When call run_from_subdir
+    The status should be success
+    The output should include 'code.sh'
+    The output should not include 'notes.md'
+  End
+
+  It 'refuses state-mutating git subcommands'
+    # `git add -A -- :(exclude)docsdir/**` really would skip the doc trees
+    # from what git RECORDS — the tool must only ever affect the view.
+    When call run_in_repo add -A
+    The status should equal 1
+    The stderr should include 'read-only git commands only'
+  End
+
+  run_without_trailing_newline() {
+    printf '%s' 'docsdir/** linguist-documentation' > "$repo/.gitattributes"
+    run_in_repo
+  }
+
+  It 'honors a final .gitattributes line without a trailing newline'
+    # Plain `while read` returns nonzero on EOF-without-newline and drops
+    # the last line.
+    When call run_without_trailing_newline
+    The status should be success
+    The output should include 'code.sh'
+    The output should not include 'notes.md'
+  End
+
+  run_with_quoted_doc_pattern() {
+    printf '%s\n' '"spacey dir/**" linguist-documentation' \
+      'docsdir/** linguist-documentation' > "$repo/.gitattributes"
+    run_in_repo
+  }
+
+  It 'fails loudly on a quoted (space-containing) documentation pattern'
+    # `read -r pattern attrs` mis-splits a C-quoted pattern into a dead
+    # exclude; loud refusal beats a silent doc leak.
+    When call run_with_quoted_doc_pattern
+    The status should equal 1
+    The stderr should include 'quoted pattern unsupported'
+  End
+
+  run_with_quoted_other_pattern() {
+    printf '%s\n' '"spacey dir/**" linguist-vendored' \
+      'docsdir/** linguist-documentation' > "$repo/.gitattributes"
+    run_in_repo
+  }
+
+  It 'skips a quoted pattern that does not carry linguist-documentation'
+    When call run_with_quoted_other_pattern
+    The status should be success
+    The output should not include 'notes.md'
+  End
+
+  run_with_crlf() {
+    printf 'docsdir/** linguist-documentation\r\n' > "$repo/.gitattributes"
+    run_in_repo
+  }
+
+  It 'parses CRLF line endings'
+    When call run_with_crlf
+    The status should be success
+    The output should not include 'notes.md'
+  End
+
+  run_with_leading_slash() {
+    printf '%s\n' '/docsdir/** linguist-documentation' > "$repo/.gitattributes"
+    run_in_repo
+  }
+
+  It 'honors a leading-slash (anchored) documentation pattern'
+    # ':(top)' does not compose with a pattern's own leading slash — the
+    # exclude silently matches nothing unless the slash is stripped.
+    When call run_with_leading_slash
+    The status should be success
+    The output should include 'code.sh'
+    The output should not include 'notes.md'
+  End
+
+  run_with_noglob_env() {
+    ( cd "$repo" && GIT_NOGLOB_PATHSPECS=1 sh "$SCRIPT" )
+  }
+
+  It 'excludes the doc tree under GIT_NOGLOB_PATHSPECS (explicit glob magic)'
+    # Without ':(glob)' magic the pattern inherits the ambient pathspec
+    # mode and GIT_NOGLOB_PATHSPECS=1 turns the exclude into a dead
+    # literal match.
+    When call run_with_noglob_env
+    The status should be success
+    The output should include 'code.sh'
+    The output should not include 'notes.md'
+  End
+
+  run_with_macro_only() {
+    printf '%s\n' '[attr]mydoc linguist-documentation' > "$repo/.gitattributes"
+    run_in_repo
+  }
+
+  It 'does not count a macro definition line as a documentation pattern'
+    # A macro line misread as a pattern would set found=1 and mask the
+    # loud no-entries failure.
+    When call run_with_macro_only
+    The status should equal 1
+    The stderr should include 'no linguist-documentation patterns'
+  End
+
+  run_with_false_value() {
+    printf '%s\n' 'docsdir/** linguist-documentation=false' > "$repo/.gitattributes"
+    run_in_repo
+  }
+
+  It 'does not treat linguist-documentation=false as a documentation pattern'
+    When call run_with_false_value
+    The status should equal 1
+    The stderr should include 'no linguist-documentation patterns'
+  End
+End


### PR DESCRIPTION
Doc-heavy commits routinely carry 1000+ changed lines of which 95% are ADR/docs text, drowning the code part of the diff in history views.

## Changes

- **`.gitattributes`**: mark `.ADRs/**` and `docs/**` as `linguist-documentation` — excluded from GitHub language stats while their diffs stay reviewable and searchable on GitHub (`linguist-generated` was considered and rejected: it suppresses diffs and excludes the trees from code search; verified against github-linguist `docs/overrides.md`).
- **`scripts/git-no-docs.sh`** (new): local companion for the diff side. Runs a read-only git command (default `log -p`; `log`/`show`/`diff`/`grep`/`blame`/`shortlog` allowed) with one `:(top,glob,exclude)<pattern>` pathspec appended per `linguist-documentation` entry in `.gitattributes`. Patterns are read from `.gitattributes` at runtime — single source of truth — and the script fails loudly when no entries are found instead of silently degrading into an unfiltered command. Hardened per the adversarial + Copilot reviews on this PR: `top` anchors patterns at the repo root (a plain `:(exclude)` is cwd-relative and silently stops matching from a subdirectory); `glob` pins wildmatch semantics against ambient `GIT_NOGLOB_PATHSPECS`; state-mutating subcommands (`add`, `stash`, …) are refused because an appended exclude would change what git *records*, not just what it shows; a final `.gitattributes` line without a trailing newline is still parsed; quoted (space-containing) documentation patterns fail loudly instead of silently mis-splitting; CRLF is tolerated; `[attr]` macro lines are skipped.
- **`tests/shell/git_no_docs_spec.sh`** (new): 13 shellspec examples — the four base behaviours plus one hostile-input example per hardening above.
- **`scripts/README.md`**: one-line pointer to the new script.

## Verification

- Red→green, executed both directions: the four base examples were authored before the script existed (4/4 fail, `cannot open .../git-no-docs.sh`); each hostile-input example was red against the unhardened script before its fix (subdirectory leak, `add -A` passthrough, dropped final line, silent quoted-pattern mis-split, CRLF, macro false-positive, `GIT_NOGLOB_PATHSPECS` leak) and is green after.
- Full shellspec suite: 449 examples, 0 failures, 9 pre-existing skips. `sh -n` + shellcheck clean.
- Real-history probe (reproducible): `scripts/git-no-docs.sh show --stat 61c7c7a` (a 397-line docs-only commit) shows the commit with an empty stat; `show --stat 96e009a` drops `docs/misc/config-gateway.md` from the stat — including when run from `scripts/` (the subdirectory case the first cut got wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFpGRpVdmENxz6nkszYSLE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local Git helper for viewing history, diffs, and blame output without documentation files.
  * Documentation-heavy paths can now be excluded from common review views while keeping diffs available.

* **Documentation**
  * Updated usage notes with a new entry for the Git helper and how to use it.

* **Bug Fixes**
  * Improved handling of documentation path exclusions so local history views are cleaner and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->