### PR TITLE
Baseline-failure hardening: nightly-red alerting, cloud-session env fixes, gotcha docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,10 @@
           },
           {
             "type": "command",
+            "command": "command -v zstd >/dev/null 2>&1 || python3 -c 'import zstandard' 2>/dev/null || pip3 install -q zstandard >/dev/null 2>&1 || true"
+          },
+          {
+            "type": "command",
             "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"MANDATORY: this repo has a CLAUDE.md — read it and follow it, especially Working principles (investigate, do not assume; confirm genuine forks before building) and Code standards. docs/misc/workflow-reference.md is a POLICY ANNEX of CLAUDE.md — its sections are binding; read the relevant section whenever the task touches one CLAUDE.md points there. Activate BOTH modes: ponytail at full (/ponytail:ponytail plugin form or /ponytail vendored form, whichever exists — laziest working solution) and /caveman (terse, no filler, full technical accuracy); when only one mode exists, activate it alone. This step CANNOT be skipped. Exception for external or public-facing text and documentation (GitHub issue and PR/MR comments, PR bodies, commit messages, docs): stay concise and to the point but use normal professional grammar, toning the caveman style down. Org rule: in ANY pfBlockerNG-org repository, the pfBlockerNG/pfBlockerNG CLAUDE.md and its project plus user settings are the default way of working unless that repo overrides a rule in its own CLAUDE.md; the pfBlockerNG-package-specific mechanics and language or runtime specifics do not carry over.\"}}'"
           }
         ]

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -37,6 +37,11 @@ permissions:
 jobs:
   alert:
     name: Open/update the nightly-red tracking issue
+    # Serialize per workflow name: the list-then-create dedup is check-then-act,
+    # so two concurrent alerts for the same title (drill overlapping a real
+    # failure) could both see "no match" and file duplicates (PR #958 review).
+    concurrency:
+      group: nightly-red-${{ github.event_name == 'workflow_dispatch' && inputs.workflow_name || github.event.workflow_run.name }}
     # Real path: a schedule-triggered run that concluded failure. Dispatch
     # path: always (that IS the drill).
     if: >-

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -53,6 +53,9 @@ jobs:
       WF_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.workflow_name || github.event.workflow_run.name }}
       RUN_URL: ${{ github.event_name == 'workflow_dispatch' && format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) || github.event.workflow_run.html_url }}
       HEAD_SHA: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
+      # Nightlies run on the default branch; read it from the payload rather than
+      # hardcoding it (PR #958 review) — the title doubles as the dedup key.
+      BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.workflow_run.head_branch }}
       DRILL: ${{ github.event_name == 'workflow_dispatch' && '1' || '' }}
     steps:
       - name: Ensure the tracking label exists
@@ -64,8 +67,11 @@ jobs:
 
       - name: Open or update the tracking issue
         run: |
-          set -eu
-          TITLE="[nightly-red] ${WF_NAME} failing on devel"
+          # pipefail: without it a failed `gh issue list` is masked by the jq/sort
+          # pipeline below and the dedup opens duplicates (PR #958 review, the
+          # PR #933 default-shell class).
+          set -euo pipefail
+          TITLE="[nightly-red] ${WF_NAME} failing on ${BRANCH}"
 
           BODY_FILE=$(mktemp)
           {
@@ -82,13 +88,22 @@ jobs:
           } > "$BODY_FILE"
 
           # Dedup by label + exact title (top1m-healthcheck pattern, incl. the
-          # >30-item page-cap lift).
-          EXISTING_NUM=$(gh issue list --repo "$REPO" --state open \
-            --label "nightly-red" --limit 500 --json number,title \
-            | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
-            | sort -n | head -1)
+          # >30-item page-cap lift) — but across ALL states: a recurrence after a
+          # fix REOPENS the closed tracker instead of filing a duplicate (PR #958
+          # review). Prefer an open match, then the lowest issue number.
+          MATCH=$(gh issue list --repo "$REPO" --state all \
+            --label "nightly-red" --limit 500 --json number,title,state \
+            | jq -r --arg t "$TITLE" \
+                '[.[] | select(.title == $t)] | sort_by(.state != "OPEN", .number)
+                 | .[0] | if . then "\(.number) \(.state)" else empty end')
 
-          if [ -n "$EXISTING_NUM" ]; then
+          if [ -n "$MATCH" ]; then
+            EXISTING_NUM=${MATCH% *}
+            EXISTING_STATE=${MATCH#* }
+            if [ "$EXISTING_STATE" = "CLOSED" ]; then
+              echo "[reopen] Reopening tracking issue #${EXISTING_NUM}"
+              gh issue reopen "$EXISTING_NUM" --repo "$REPO"
+            fi
             echo "[update] Updating tracking issue #${EXISTING_NUM}"
             gh issue edit "$EXISTING_NUM" --repo "$REPO" --body-file "$BODY_FILE"
           else

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -1,0 +1,101 @@
+name: Nightly failure alert
+
+# File ONE deduped tracking issue when a NIGHTLY (schedule-triggered) run of a
+# live-VM suite fails, so a red nightly becomes a work item instead of waiting
+# for someone to notice. Issue #820 sat red DAILY for 8 days (2026-06-26 ->
+# 07-04, a real config-loss bug shipping in alphas) precisely because nothing
+# watches these: smoke/ui/repo-install are schedule+dispatch only (no PR gate),
+# and dispatch failures are already watched by whoever dispatched them — so
+# this alerts on the `schedule` event only.
+#
+# Pattern follows top1m-healthcheck.yml's alert job (dedup by label + exact
+# title, update-in-place). WHY workflow_run and not an `if: failure()` job in
+# each suite: one file, no edits to the three fan-out matrices, and it runs
+# with its own token even when the failing run's jobs are all red (see
+# module-durations.yml for the same trigger shape).
+
+on:
+  workflow_run:
+    workflows:
+      - "Smoke fan-out (all CI legs, live pfSense VM)"
+      - "UI tests fan-out (all CI legs, live pfSense VM)"
+      - "Repo install (live pfSense VM)"
+    types: [completed]
+  # Red-path test handle (CLAUDE.md: a newly wired gate demonstrates its red
+  # path once): simulate a failed nightly of the named workflow. The issue it
+  # files is real — close it after the drill.
+  workflow_dispatch:
+    inputs:
+      workflow_name:
+        description: "Workflow name to simulate a failed nightly for."
+        required: true
+        default: "Smoke fan-out (all CI legs, live pfSense VM)"
+
+permissions:
+  contents: read
+
+jobs:
+  alert:
+    name: Open/update the nightly-red tracking issue
+    # Real path: a schedule-triggered run that concluded failure. Dispatch
+    # path: always (that IS the drill).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'schedule' &&
+       github.event.workflow_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      # Dispatch drill: the run link points at THIS run, clearly labeled below.
+      WF_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.workflow_name || github.event.workflow_run.name }}
+      RUN_URL: ${{ github.event_name == 'workflow_dispatch' && format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) || github.event.workflow_run.html_url }}
+      HEAD_SHA: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
+      DRILL: ${{ github.event_name == 'workflow_dispatch' && '1' || '' }}
+    steps:
+      - name: Ensure the tracking label exists
+        run: |
+          gh label create "nightly-red" \
+            --color "b60205" \
+            --description "Automated nightly-suite failure tracking" \
+            --repo "$REPO" 2>/dev/null || true
+
+      - name: Open or update the tracking issue
+        run: |
+          set -eu
+          TITLE="[nightly-red] ${WF_NAME} failing on devel"
+
+          BODY_FILE=$(mktemp)
+          {
+            printf '## Nightly run failed: %s\n\n' "$WF_NAME"
+            if [ -n "$DRILL" ]; then
+              printf '**DRILL** — manual red-path test of the alert wiring, not a real failure. Close me.\n\n'
+            fi
+            printf -- '- Run: %s\n' "$RUN_URL"
+            printf -- '- Head: `%s`\n\n' "$HEAD_SHA"
+            printf 'Triage: read the run'"'"'s failing job logs + its diagnostics artifact first '
+            printf '(CLAUDE.md "Smoke tests"). If the failure is a devel regression, fix it on a '
+            printf 'branch and close this; if flaky, say so here with the evidence.\n\n'
+            printf '_Opened automatically by the nightly-failure-alert workflow. Updated in place on every red nightly; closes manually with the fix._\n'
+          } > "$BODY_FILE"
+
+          # Dedup by label + exact title (top1m-healthcheck pattern, incl. the
+          # >30-item page-cap lift).
+          EXISTING_NUM=$(gh issue list --repo "$REPO" --state open \
+            --label "nightly-red" --limit 500 --json number,title \
+            | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
+            | sort -n | head -1)
+
+          if [ -n "$EXISTING_NUM" ]; then
+            echo "[update] Updating tracking issue #${EXISTING_NUM}"
+            gh issue edit "$EXISTING_NUM" --repo "$REPO" --body-file "$BODY_FILE"
+          else
+            echo "[create] Opening tracking issue"
+            gh issue create \
+              --repo "$REPO" \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE" \
+              --label "nightly-red,bug"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,6 +514,16 @@ composer install        # once; if it 403s in a managed cloud session, run
 vendor/bin/phpunit      # PHP suite: loads the REAL pfblockerng.inc off-appliance
 ```
 
+Environment gotchas that read as fake "baseline failures" — fix the env, never dismiss the
+red: the pytest suite needs a **zstd encoder** (the `zstd` binary or the `zstandard` module);
+a bare managed-cloud container lacks one and ~70 pkg/repo tests fail — the `SessionStart`
+hook auto-installs it (manual: `pip3 install zstandard`). PHPUnit permission-denial tests
+(`chmod 0555` fixtures) **skip under root** via a `posix_getuid() === 0` guard — root
+bypasses file permissions, so a root run cannot simulate the denial (a red there means the
+guard is missing, not that the code broke). Any other local-only failure: diagnose before
+dismissing — if it is genuinely pre-existing on the base branch, **file a tracking issue**
+(exemplars #791, #894); never leave it as folklore.
+
 The PHPUnit bootstrap satisfies `require_once` with empty shims (`tests/php/shims/`) +
 behavioural doubles (`tests/php/pfsense_doubles.php`); when a tested path reaches a new
 pfSense function, add a `function_exists()`-guarded double there (stubs can't serve —

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -227,6 +227,10 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 */
 	public function testReadOnlyDbdirCausesRenameFailurePreservesPriorWhitelistAndWarns(): void
 	{
+		if (function_exists('posix_getuid') && posix_getuid() === 0) {
+			$this->markTestSkipped('running as root -- permission-based failure injection cannot be simulated');
+		}
+
 		// Given: a prior good whitelist, a valid+matching top-1m.csv, but a dbdir made
 		// read-only AFTER seeding both files.
 		$priorContent = ".kept2.com,,\n,kept2.com,,\n,www.kept2.com,,\n";


### PR DESCRIPTION
Closes the gaps found by the baseline-test-failures investigation: no standing red exists on devel today, but the "pre-existing failure" pattern bit three times in ten days (#791, #894, and #820 — the latter red daily for 8 days behind a real config-loss bug), and managed cloud sessions manufacture fake local baseline failures that train agents to dismiss red.

## Changes

1. **`ci:` nightly failure alerting** (`.github/workflows/nightly-failure-alert.yml`): a `workflow_run` listener on the three live-VM suites (smoke fan-out, UI fan-out, repo-install). A failed **schedule** run opens/updates one deduped `nightly-red`-labeled tracking issue per workflow (top1m-healthcheck alert pattern: label + exact-title dedup, update-in-place, page-cap lift). Dispatch failures are excluded — whoever dispatched is already watching. A `workflow_dispatch` input simulates a failure for the one-time red-path drill; dispatch registration requires the file on the default branch, so the drill runs post-merge (both `run:` blocks `bash -n`-validated and the body/title generation dry-run in-session).

2. **`dev:` zstd encoder at session start** (`.claude/settings.json`, CLAUDE.md): bare managed-cloud containers lack both the `zstd` binary and the `zstandard` module — 70 pkg/repo pytest tests fail and read as "baseline". The SessionStart hook now installs `zstandard` iff neither encoder is present (no-op elsewhere). Red→green executed: without the module 6/7 `test_pfb_pkg.py` tests fail; after the hook command, 7/7 pass.

3. **`tests:` root-skip guard** (`tests/php/Top1mPreserveOnEmptyFeedTest.php`): `testReadOnlyDbdirCausesRenameFailurePreservesPriorWhitelistAndWarns` relies on a `chmod 0555` read-only dbdir, which root bypasses — deterministic false failure in root-run containers. Added the existing house guard (verbatim from `V6CidrSubtractTest::testFilePutContentsFailureUnlinksStrayTmpFile`). Coverage axis enumerated by grep: these are the only two permission-denial tests; all other `chmod` calls grant bits and are root-immune. Verified both directions: skips as root, executes and passes (9 assertions) as non-root.

4. **CLAUDE.md "Running tests"**: documents both env gotchas and mandates filing a tracking issue for any genuine pre-existing base failure (exemplars #791, #894) instead of leaving it as folklore.

Related: #957 (watcher flake under CPU contention, filed from the same investigation).

## Gates (executed)

- `php -l` OK; PHPUnit 2424 tests, 0 failures (root run: the new skip fires; non-root run: the guarded test executes and passes)
- pytest: 2385 passed, 5 skipped
- PHPStan `[OK]`; PHPCS rc=0; markdownlint rc=0; version-literal + URL-encoding checkers rc=0; workflow YAML parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoTnAB4JsbvYmQaPrNaEWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoTnAB4JsbvYmQaPrNaEWa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated tracking for nightly CI failures by creating or updating a dedicated issue when scheduled runs fail.

* **Bug Fixes**
  * Improved reliability around environment setup so missing compression tooling won’t block startup.
  * Made permission-based test behavior safer by skipping an unsupported case when running as root.

* **Documentation**
  * Added notes about common local test pitfalls and expected skip/failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->