### PR TITLE
scripts: gate process-narration comments in newly added code

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -192,6 +192,17 @@ if [ "$staged_py" = 1 ] || [ "$staged_php" = 1 ] || [ "$staged_sh" = 1 ] || [ "$
 	fi
 fi
 
+# --- Forbid delegation-process narration (Phase N, RESULTS/ refs, review
+#     archaeology) in ADDED comment lines under src/ + scripts/. Diff-scoped:
+#     judges only the staged diff, so pre-existing narration is grandfathered
+#     until its cleanup lands. Escape inline with `# narration-ok: <reason>`. ---
+if [ -n "$py_bin" ]; then
+	step 'comment-narration (no process narration in new comments)'
+	"$py_bin" scripts/check_comment_narration.py --staged || failed 'comment-narration'
+else
+	skip comment-narration
+fi
+
 # --- ADR phase prompts: post-contract prompts (ADR >= 60) must carry the
 #     delegation-contract blocks (VERIFICATION, HANDOFF->RESULTS, test mode,
 #     reality-override). Older ADRs are grandfathered by the script itself. ---

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -655,6 +655,33 @@ jobs:
           printf '%s\n' "$PR_BODY" > pr_body.txt
           python3 scripts/check_coverage_pairing.py ${WARN_ONLY:+--warn-only} ${WARN_ONLY:+--pr-body-file pr_body.txt} < changed.txt | tee -a "$GITHUB_STEP_SUMMARY"
 
+  # ── Comment-narration gate (CLAUDE.md "Comments — constraint, not narration") ──
+  # PR-only, diff-scoped: judges only the lines this PR ADDS under src/ + scripts/,
+  # so the pre-existing narration is grandfathered until its cleanup lands. Forbids
+  # ADR phase numbers, RESULTS/ handoff refs, and review archaeology in new
+  # comments — that evidence belongs in the ADR / handoff / PR body. On push
+  # (post-merge, no PR base) it is skipped and folds into all-tests-passed as a
+  # pass, same shape as coverage-pairing above.
+  comment-narration:
+    name: Comment narration (no process narration in new comments)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need the merge-base with the PR base ref for the three-dot diff
+
+      - name: Forbid process narration in added comments
+        # ubuntu-latest ships python3. Escape a genuine need inline with
+        # `# narration-ok: <reason>`.
+        env:
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -eu
+          git fetch --no-tags origin "$BASE:refs/remotes/origin/$BASE"
+          python3 scripts/check_comment_narration.py --diff "origin/$BASE"
+
   # Single stable job name for branch-protection required-status-checks.
   # Must use if: always() so it runs (and fails) even when 'test' fails.
   all-tests-passed:
@@ -666,7 +693,7 @@ jobs:
     # The ADR-14 UI suite (`ui-suite`) IS folded in: it is skipped (== pass) on an
     # unlabeled PR / push, and only a `ui-tests`-labeled PR whose UI suite FAILS
     # blocks here — that is how the opt-in label gates a merge.
-    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, ui-suite, coverage-pairing]
+    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, ui-suite, coverage-pairing, comment-narration]
     runs-on: ubuntu-latest
     steps:
       - name: Check matrix results
@@ -733,4 +760,11 @@ jobs:
           case "${{ needs.coverage-pairing.result }}" in
             success|skipped) ;;
             *) echo "Coverage-pairing gate (src/tests, www/ui) failed or was cancelled."; exit 1 ;;
+          esac
+          # Comment-narration gate: 'skipped' (push, no PR base) is a PASS; a PR
+          # that ADDS process-narration comments (Phase N, RESULTS/, review
+          # archaeology) blocks here.
+          case "${{ needs.comment-narration.result }}" in
+            success|skipped) ;;
+            *) echo "Comment-narration gate (no process narration in new comments) failed or was cancelled."; exit 1 ;;
           esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,9 @@ and review.
    these).
 5. **Constraints** — the do-NOT-touch list, plus the **never-weaken rule**: a brief may never
    weaken a CLAUDE.md mandate. In particular, red→green is an **executed run with output
-   pasted**, never "reasoned through" or "verified by reading".
+   pasted**, never "reasoned through" or "verified by reading". Comments follow "Comments —
+   constraint, not narration" (Code standards): gate-facing justification goes in the
+   handoff, never the code.
 6. **Verification** — the canonical gates (table below) plus per-item acceptance checks, each
    a runnable command with its expected observable (the shape "WHEN `<command/input>` THEN
    `<observable>`"), mapping 1:1 to the tests the step ships.
@@ -199,7 +201,8 @@ the gate report's wording, never to which checks run.
    matches the house pattern (#905); comments/docs mentioning touched symbols reconciled with
    the new reality (stale-comment defects recur); any comment/doc claim naming a **sibling
    file or house convention** verified by grep — in-repo claims are the cheapest probes there
-   are (PR #937 shipped a fabricated "mirrors the URL-encoding checker" lineage, #941).
+   are (PR #937 shipped a fabricated "mirrors the URL-encoding checker" lineage, #941);
+   added comments respect the comment budget ("Comments — constraint, not narration").
 6. **Write the gate record** — a fixed-field block (or per-phase file where the skill says
    so): commands + results, red/green evidence, per-item diff verdicts, matrix confirmation,
    the SKIPPED list. This artifact is what makes a skipped check auditable.
@@ -331,6 +334,21 @@ that file (or similar files)** — match the surrounding pattern (prefix, casing
 word order); with sibling `pfB_*` identifiers, a wizard flag is `pfB_wizard_disable`, not
 `donotshowthisagain`. An off-pattern name is a smell even when it works. Spans the whole
 stack.
+
+### Comments — constraint, not narration
+
+A comment states a constraint the code cannot show; default budget **≤3 lines**. Design
+rationale lives in the ADR / architecture-notes and the comment carries a one-line pointer
+(`// ADR-49: content-sanity gate; contract pinned by PfbTextSanityTest`) — never a
+restatement: a contract stored in ADR + comment + test is three copies, two of which drift.
+One-line regression breadcrumbs stay (`// issue #946: decode UTF-16 BOM first — else
+nul_bytes false-positives`). **Never in committed comments:** ADR **phase numbers**
+("wired in Phase 4"), **`RESULTS/` handoff refs**, **review archaeology** (reviewer names,
+`PR #N` finding IDs, `review-fanout CN`), or correctness argument aimed at the gate/reviewer
+— that evidence belongs in the handoff / gate record / PR body, not the tree. Enforced on
+**added** lines under `src/` + `scripts/` by `scripts/check_comment_narration.py`
+(pre-commit + CI, diff-scoped — pre-existing narration is grandfathered until its cleanup
+lands); escape a genuine need inline with `# narration-ok: <reason>`.
 
 ### PHP
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,6 +465,10 @@ Run linters while working; the `.githooks/pre-commit` hook blocks failing commit
   Read it from the ci-metadata matrix (`read-version-matrix.sh`) at runtime instead of
   restating it (a literal silently drifts when the matrix moves). Prose, comments, and Python
   docstrings stay clean; escape a genuine one-off with an inline `# version-literal-ok: <reason>`.
+- **Comment-narration check** (`scripts/check_comment_narration.py`, pre-commit + CI,
+  diff-scoped): forbids ADR phase numbers, `RESULTS/` handoff refs, and review archaeology on
+  **added** lines under `src/` + `scripts/` ("Comments — constraint, not narration"); escape a
+  genuine need inline with `# narration-ok: <reason>`.
 - **Markdown:** `npx markdownlint-cli2` (`--fix` to autofix). Blank line around every
   heading/list/fence; a language on every fence (`text` for plain output); single trailing
   newline. Rules + rationale in `.markdownlint.jsonc`; clean lint enforced pre-commit + CI.

--- a/scripts/check_comment_narration.py
+++ b/scripts/check_comment_narration.py
@@ -13,6 +13,11 @@ grandfathered until its cleanup lands and this gate never blocks an unrelated
 change. Scope: `src/` and `scripts/`, minus `*.md` and the files whose subject
 IS phases/narration (this checker, its test, `check_phase_prompts.py`).
 
+Every added line is judged, not only comment-shaped ones: the banned
+vocabulary has no legitimate code/string use in the scan roots, and
+per-language comment parsing is the known false-positive trap; a genuine
+future hit rides the escape hatch.
+
 Escape a genuine need inline with `# narration-ok: <reason>`.
 
 Exit status: 0 = clean, 1 = violations (printed file:line), 2 = usage/git error.
@@ -30,9 +35,9 @@ _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"RESULTS/"), "delegation handoff artifact (RESULTS/...)"),
     # Capitalised only: ADR narration always writes "Phase N"; ordinary prose
     # about a protocol's "phase 2" stays legal.
-    (re.compile(r"\bPhase [0-9]"), "ADR phase narration (Phase N)"),
+    (re.compile(r"\bPhase [0-9]+\b"), "ADR phase narration (Phase N)"),
     (re.compile(r"review-fanout", re.IGNORECASE), "review archaeology (review-fanout)"),
-    (re.compile(r"\bPR ?#[0-9]"), "review archaeology (PR #N)"),
+    (re.compile(r"\bPR ?#[0-9]+\b"), "review archaeology (PR #N)"),
 )
 
 # Matched case-insensitively so a differently-cased escape still exempts.

--- a/scripts/check_comment_narration.py
+++ b/scripts/check_comment_narration.py
@@ -31,19 +31,21 @@ _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     # Capitalised only: ADR narration always writes "Phase N"; ordinary prose
     # about a protocol's "phase 2" stays legal.
     (re.compile(r"\bPhase [0-9]"), "ADR phase narration (Phase N)"),
-    (re.compile(r"review-fanout"), "review archaeology (review-fanout)"),
-    (re.compile(r"\bPR #[0-9]"), "review archaeology (PR #N)"),
+    (re.compile(r"review-fanout", re.IGNORECASE), "review archaeology (review-fanout)"),
+    (re.compile(r"\bPR ?#[0-9]"), "review archaeology (PR #N)"),
 )
 
+# Matched case-insensitively so a differently-cased escape still exempts.
 _ESCAPE = "narration-ok"
 
 _SCAN_ROOTS = ("src", "scripts")
 
-# Self-reference: these define/validate the banned vocabulary.
-_EXCLUDED_NAMES = (
-    "check_comment_narration.py",
-    "test_comment_narration_check.py",
-    "check_phase_prompts.py",
+# Self-reference: these define/validate the banned vocabulary. Full repo-relative
+# paths, so an unrelated same-named file elsewhere is still scanned.
+_EXCLUDED_PATHS = (
+    "scripts/check_comment_narration.py",
+    "tests/test_comment_narration_check.py",
+    "scripts/check_phase_prompts.py",
 )
 
 
@@ -56,7 +58,7 @@ class Violation(NamedTuple):
 
 def _in_scope(path: str) -> bool:
     p = PurePosixPath(path)
-    if p.suffix == ".md" or p.name in _EXCLUDED_NAMES:
+    if p.suffix == ".md" or path in _EXCLUDED_PATHS:
         return False
     return any(p.parts and p.parts[0] == root for root in _SCAN_ROOTS)
 
@@ -68,8 +70,11 @@ def find_violations(diff_text: str) -> list[Violation]:
     lineno = 0
     for raw in diff_text.splitlines():
         if raw.startswith("+++ "):
+            # _git_diff pins the b/ prefix; a space-bearing path still gets git's
+            # disambiguation tab appended — strip it. A control-char path stays
+            # quoted even under core.quotePath=false and is skipped (absurd corner).
             name = raw[4:]
-            path = name[2:] if name.startswith("b/") else None  # +++ /dev/null
+            path = name[2:].split("\t", 1)[0] if name.startswith("b/") else None
             continue
         if raw.startswith("@@"):
             m = re.match(r"@@ -\S+ \+(\d+)", raw)
@@ -77,7 +82,7 @@ def find_violations(diff_text: str) -> list[Violation]:
             continue
         if raw.startswith("+") and not raw.startswith("+++"):
             line = raw[1:]
-            if path is not None and _in_scope(path) and _ESCAPE not in line:
+            if path is not None and _in_scope(path) and _ESCAPE not in line.lower():
                 for pattern, reason in _PATTERNS:
                     if pattern.search(line):
                         violations.append(Violation(path, lineno, line.strip(), reason))
@@ -89,8 +94,21 @@ def find_violations(diff_text: str) -> list[Violation]:
 
 
 def _git_diff(args: list[str]) -> str:
+    # core.quotePath defaults to true (octal-quotes non-ASCII paths) and
+    # diff.mnemonicPrefix/noprefix rewrite the +++ prefix — any of them silently
+    # defeats the b/ parse. Pin all three so user git config cannot bypass the gate.
     out = subprocess.run(
-        ["git", "diff", "--unified=0", "--no-color", *args],
+        [
+            "git",
+            "-c",
+            "core.quotePath=false",
+            "diff",
+            "--unified=0",
+            "--no-color",
+            "--src-prefix=a/",
+            "--dst-prefix=b/",
+            *args,
+        ],
         capture_output=True,
         text=True,
         check=True,

--- a/scripts/check_comment_narration.py
+++ b/scripts/check_comment_narration.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Forbid delegation-process narration in newly added code comments.
+
+ADR phase numbers ("wired in Phase 4"), `RESULTS/` handoff refs, and review
+archaeology ("review-fanout C9", "Copilot, PR #947") narrate how a change was
+produced, not what the code must uphold — that evidence belongs in the ADR,
+the handoff, or the PR body (CLAUDE.md "Comments — constraint, not
+narration"). One-line `issue #NNN` regression breadcrumbs stay legal.
+
+DIFF-SCOPED: only ADDED lines are judged (`--staged` for the pre-commit hook,
+`--diff <base>` for CI's PR gate), so the pre-existing narration is
+grandfathered until its cleanup lands and this gate never blocks an unrelated
+change. Scope: `src/` and `scripts/`, minus `*.md` and the files whose subject
+IS phases/narration (this checker, its test, `check_phase_prompts.py`).
+
+Escape a genuine need inline with `# narration-ok: <reason>`.
+
+Exit status: 0 = clean, 1 = violations (printed file:line), 2 = usage/git error.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import PurePosixPath
+from typing import NamedTuple
+
+_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"RESULTS/"), "delegation handoff artifact (RESULTS/...)"),
+    # Capitalised only: ADR narration always writes "Phase N"; ordinary prose
+    # about a protocol's "phase 2" stays legal.
+    (re.compile(r"\bPhase [0-9]"), "ADR phase narration (Phase N)"),
+    (re.compile(r"review-fanout"), "review archaeology (review-fanout)"),
+    (re.compile(r"\bPR #[0-9]"), "review archaeology (PR #N)"),
+)
+
+_ESCAPE = "narration-ok"
+
+_SCAN_ROOTS = ("src", "scripts")
+
+# Self-reference: these define/validate the banned vocabulary.
+_EXCLUDED_NAMES = (
+    "check_comment_narration.py",
+    "test_comment_narration_check.py",
+    "check_phase_prompts.py",
+)
+
+
+class Violation(NamedTuple):
+    path: str
+    line: int
+    text: str
+    reason: str
+
+
+def _in_scope(path: str) -> bool:
+    p = PurePosixPath(path)
+    if p.suffix == ".md" or p.name in _EXCLUDED_NAMES:
+        return False
+    return any(p.parts and p.parts[0] == root for root in _SCAN_ROOTS)
+
+
+def find_violations(diff_text: str) -> list[Violation]:
+    """Scan a unified diff (``git diff`` output) and judge its ADDED lines."""
+    violations: list[Violation] = []
+    path: str | None = None
+    lineno = 0
+    for raw in diff_text.splitlines():
+        if raw.startswith("+++ "):
+            name = raw[4:]
+            path = name[2:] if name.startswith("b/") else None  # +++ /dev/null
+            continue
+        if raw.startswith("@@"):
+            m = re.match(r"@@ -\S+ \+(\d+)", raw)
+            lineno = int(m.group(1)) if m else 0
+            continue
+        if raw.startswith("+") and not raw.startswith("+++"):
+            line = raw[1:]
+            if path is not None and _in_scope(path) and _ESCAPE not in line:
+                for pattern, reason in _PATTERNS:
+                    if pattern.search(line):
+                        violations.append(Violation(path, lineno, line.strip(), reason))
+                        break
+            lineno += 1
+        elif not raw.startswith("-"):
+            lineno += 1  # context line (absent under --unified=0, tolerated)
+    return violations
+
+
+def _git_diff(args: list[str]) -> str:
+    out = subprocess.run(
+        ["git", "diff", "--unified=0", "--no-color", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout
+
+
+def main(argv: list[str]) -> int:
+    try:
+        if argv == ["--staged"]:
+            diff = _git_diff(["--cached"])
+        elif len(argv) == 2 and argv[0] == "--diff":
+            diff = _git_diff([f"{argv[1]}...HEAD"])
+        else:
+            print("usage: check_comment_narration.py --staged | --diff <base>", file=sys.stderr)
+            return 2
+    except subprocess.CalledProcessError as exc:
+        print(f"git diff failed: {exc.stderr.strip()}", file=sys.stderr)
+        return 2
+    violations = find_violations(diff)
+    if not violations:
+        return 0
+    print("Process-narration comment(s) in added lines:\n", file=sys.stderr)
+    for v in violations:
+        print(f"  {v.path}:{v.line}: [{v.reason}] {v.text}", file=sys.stderr)
+    print(
+        "\nPhase numbers, RESULTS/ refs, and review archaeology narrate how a change\n"
+        "was produced — put that in the ADR / handoff / PR body and keep the comment\n"
+        'to the constraint itself (CLAUDE.md "Comments — constraint, not narration").\n'
+        "Escape a genuine need inline with `# narration-ok: <reason>`.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_comment_narration.py
+++ b/scripts/check_comment_narration.py
@@ -99,9 +99,11 @@ def find_violations(diff_text: str) -> list[Violation]:
 
 
 def _git_diff(args: list[str]) -> str:
-    # core.quotePath defaults to true (octal-quotes non-ASCII paths) and
-    # diff.mnemonicPrefix/noprefix rewrite the +++ prefix — any of them silently
-    # defeats the b/ parse. Pin all three so user git config cannot bypass the gate.
+    # core.quotePath defaults to true (octal-quotes non-ASCII paths),
+    # diff.mnemonicPrefix/noprefix rewrite the +++ prefix, and an external diff
+    # driver (diff.external / GIT_EXTERNAL_DIFF) replaces the unified output
+    # entirely — any of them silently defeats the b/ parse. Pin them all so
+    # user git config/environment cannot bypass the gate.
     out = subprocess.run(
         [
             "git",
@@ -110,6 +112,7 @@ def _git_diff(args: list[str]) -> str:
             "diff",
             "--unified=0",
             "--no-color",
+            "--no-ext-diff",
             "--src-prefix=a/",
             "--dst-prefix=b/",
             *args,

--- a/tests/test_comment_narration_check.py
+++ b/tests/test_comment_narration_check.py
@@ -63,6 +63,14 @@ def test_lowercase_phase_number_is_clean() -> None:
     assert _find("src/a.py", ["# TLS handshake phase 2 resumes here"]) == []
 
 
+def test_number_needs_trailing_boundary() -> None:
+    # "Phase 9x"/"PR #9foo" are not phase/PR references; multi-digit ones are.
+    assert _find("src/a.py", ["# gets a Phase 9x speedup"]) == []
+    assert _find("src/a.inc", ["// tracked as PR #9foo"]) == []
+    assert len(_find("src/a.py", ["# wired in Phase 10"])) == 1
+    assert len(_find("src/a.inc", ["// per PR #1024"])) == 1
+
+
 def test_review_fanout_is_flagged() -> None:
     v = _find("scripts/build-leg.sh", ["# review-fanout C9 pinned this"])
     assert len(v) == 1

--- a/tests/test_comment_narration_check.py
+++ b/tests/test_comment_narration_check.py
@@ -1,0 +1,180 @@
+"""Tests for scripts/check_comment_narration.py.
+
+Covers both branches per dimension (CLAUDE.md test-coverage rules): every
+pattern that flags a violation is paired with the nearest correct form that
+must stay clean, so a green proves the checker discriminates rather than
+always firing (or never firing).
+
+The checker is diff-scoped: only ADDED lines are judged, so the tests build
+unified-diff text (the exact format `git diff --unified=0` emits) rather than
+whole files.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_comment_narration.py"
+_spec = importlib.util.spec_from_file_location("check_comment_narration", _TOOL)
+assert _spec is not None and _spec.loader is not None
+ccn = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = ccn
+_spec.loader.exec_module(ccn)
+
+
+def _diff(path: str, added: list[str], start: int = 1) -> str:
+    """Unified diff adding ``added`` lines to ``path`` at ``start``."""
+    hunk = "\n".join("+" + line for line in added)
+    return f"diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n@@ -0,0 +{start},{len(added)} @@\n{hunk}\n"
+
+
+def _find(path: str, added: list[str], start: int = 1) -> list:
+    return ccn.find_violations(_diff(path, added, start))
+
+
+# --------------------------------------------------------------------------- #
+# Patterns — flagged vs the nearest clean sibling
+# --------------------------------------------------------------------------- #
+
+
+def test_results_ref_is_flagged() -> None:
+    v = _find("src/usr/local/pkg/pfblockerng/pfblockerng.inc", ["// see RESULTS/01 SS2"])
+    assert len(v) == 1
+    assert v[0].line == 1
+    assert "RESULTS/" in v[0].reason
+
+
+def test_results_word_without_slash_is_clean() -> None:
+    assert _find("src/a.inc", ["// the RESULTS are cached"]) == []
+
+
+def test_capital_phase_number_is_flagged() -> None:
+    v = _find("src/a.py", ["# wired into init() in Phase 4"])
+    assert len(v) == 1
+    assert "phase" in v[0].reason.lower()
+
+
+def test_lowercase_phase_number_is_clean() -> None:
+    # Only the ADR-narration capitalised form is banned; ordinary prose about a
+    # protocol's "phase 2" stays legal.
+    assert _find("src/a.py", ["# TLS handshake phase 2 resumes here"]) == []
+
+
+def test_review_fanout_is_flagged() -> None:
+    v = _find("scripts/build-leg.sh", ["# review-fanout C9 pinned this"])
+    assert len(v) == 1
+
+
+def test_pr_number_is_flagged_but_issue_breadcrumb_is_clean() -> None:
+    assert len(_find("src/a.inc", ["// escape-aware (Copilot, PR #947)"])) == 1
+    assert _find("src/a.inc", ["// issue #946: decode UTF-16 BOM first"]) == []
+    assert _find("src/a.inc", ["// case-fold TOP1M match (#920)"]) == []
+
+
+# --------------------------------------------------------------------------- #
+# Scope — roots, extensions, self-exclusions, escape hatch
+# --------------------------------------------------------------------------- #
+
+
+def test_markdown_and_out_of_root_paths_are_clean() -> None:
+    bad = ["see RESULTS/01 and Phase 3"]
+    assert _find("docs/misc/architecture-notes.md", bad) == []
+    assert _find("src/notes.md", bad) == []
+    assert _find("tests/test_x.py", bad) == []
+    assert _find(".ADRs/ADR_60_X/prompt.txt", bad) == []
+
+
+def test_self_and_phase_prompt_checker_are_excluded() -> None:
+    bad = ["# RESULTS/ Phase 1"]
+    assert _find("scripts/check_comment_narration.py", bad) == []
+    assert _find("tests/test_comment_narration_check.py", bad) == []
+    assert _find("scripts/check_phase_prompts.py", bad) == []
+
+
+def test_narration_ok_escape_exempts_the_line() -> None:
+    assert _find("src/a.inc", ["// Phase 2 of BGP convergence  // narration-ok: protocol term"]) == []
+
+
+# --------------------------------------------------------------------------- #
+# Diff mechanics — only added lines judged, line numbers from hunk headers
+# --------------------------------------------------------------------------- #
+
+
+def test_removed_and_context_lines_are_ignored() -> None:
+    diff = (
+        "diff --git a/src/a.inc b/src/a.inc\n"
+        "--- a/src/a.inc\n"
+        "+++ b/src/a.inc\n"
+        "@@ -5,2 +5,1 @@\n"
+        "-// old RESULTS/01 note\n"
+        " // context Phase 9 line\n"
+        "+// clean replacement\n"
+    )
+    assert ccn.find_violations(diff) == []
+
+
+def test_line_numbers_track_hunk_headers_across_files() -> None:
+    diff = _diff("src/a.inc", ["// ok", "// see RESULTS/02"], start=40) + _diff(
+        "src/b.py", ["# ADR-48 Phase 4 tally"], start=7
+    )
+    v = ccn.find_violations(diff)
+    assert [(x.path, x.line) for x in v] == [("src/a.inc", 41), ("src/b.py", 7)]
+
+
+def test_clean_diff_yields_nothing() -> None:
+    assert _find("src/a.inc", ["// pfb_foo(): guard empty input"]) == []
+
+
+# --------------------------------------------------------------------------- #
+# CLI — the two production modes, end-to-end in a scratch repo
+# --------------------------------------------------------------------------- #
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(_TOOL), *args], cwd=repo, capture_output=True, text=True)
+
+
+def test_cli_staged_and_diff_modes(tmp_path: Path) -> None:
+    _git(tmp_path, "init", "-q", "-b", "devel")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/a.inc").write_text("// clean\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+
+    # --staged: violating staged line fails with file:line on stderr...
+    (tmp_path / "src/a.inc").write_text("// clean\n// per RESULTS/03 SS1\n")
+    _git(tmp_path, "add", ".")
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 1, res.stderr
+    assert "src/a.inc:2" in res.stderr
+
+    # --diff BASE: committed violation vs the base branch fails the same way,
+    # and a clean staged tree passes --staged.
+    _git(tmp_path, "commit", "-qm", "bad")
+    assert _run(tmp_path, "--staged").returncode == 0
+    res = _run(tmp_path, "--diff", "devel~1")
+    assert res.returncode == 1, res.stderr
+    assert "src/a.inc:2" in res.stderr
+
+    # Reverting to clean content passes --diff again.
+    (tmp_path / "src/a.inc").write_text("// clean\n")
+    _git(tmp_path, "commit", "-qam", "clean")
+    assert _run(tmp_path, "--diff", "devel~2").returncode == 0
+
+
+def test_cli_usage_error(tmp_path: Path) -> None:
+    _git(tmp_path, "init", "-q")
+    assert _run(tmp_path).returncode == 2
+    assert _run(tmp_path, "--bogus").returncode == 2

--- a/tests/test_comment_narration_check.py
+++ b/tests/test_comment_narration_check.py
@@ -70,8 +70,13 @@ def test_review_fanout_is_flagged() -> None:
 
 def test_pr_number_is_flagged_but_issue_breadcrumb_is_clean() -> None:
     assert len(_find("src/a.inc", ["// escape-aware (Copilot, PR #947)"])) == 1
+    assert len(_find("src/a.inc", ["// see PR#947 for context"])) == 1
     assert _find("src/a.inc", ["// issue #946: decode UTF-16 BOM first"]) == []
     assert _find("src/a.inc", ["// case-fold TOP1M match (#920)"]) == []
+
+
+def test_review_fanout_is_case_insensitive() -> None:
+    assert len(_find("src/a.inc", ["// Review-Fanout C9 pinned this"])) == 1
 
 
 # --------------------------------------------------------------------------- #
@@ -94,13 +99,31 @@ def test_self_and_phase_prompt_checker_are_excluded() -> None:
     assert _find("scripts/check_phase_prompts.py", bad) == []
 
 
+def test_self_exclusion_is_full_path_not_basename() -> None:
+    assert len(_find("src/nested/check_comment_narration.py", ["# RESULTS/ Phase 1"])) == 1
+
+
 def test_narration_ok_escape_exempts_the_line() -> None:
     assert _find("src/a.inc", ["// Phase 2 of BGP convergence  // narration-ok: protocol term"]) == []
+    assert _find("src/a.inc", ["// Phase 2 of BGP convergence  // Narration-OK: protocol term"]) == []
 
 
 # --------------------------------------------------------------------------- #
 # Diff mechanics — only added lines judged, line numbers from hunk headers
 # --------------------------------------------------------------------------- #
+
+
+def test_space_bearing_path_tab_is_stripped() -> None:
+    # git appends a disambiguation tab to +++ headers of space-bearing paths;
+    # unstripped it defeats the .md suffix exclusion.
+    tabbed = (
+        "diff --git a/src/my notes.md b/src/my notes.md\n"
+        "--- a/src/my notes.md\t\n"
+        "+++ b/src/my notes.md\t\n"
+        "@@ -0,0 +1,1 @@\n"
+        "+see RESULTS/01 and Phase 4\n"
+    )
+    assert ccn.find_violations(tabbed) == []
 
 
 def test_removed_and_context_lines_are_ignored() -> None:
@@ -174,7 +197,48 @@ def test_cli_staged_and_diff_modes(tmp_path: Path) -> None:
     assert _run(tmp_path, "--diff", "devel~2").returncode == 0
 
 
+def test_cli_hostile_git_configs_cannot_bypass_the_gate(tmp_path: Path) -> None:
+    # core.quotePath defaults true (octal-quotes non-ASCII paths) and
+    # diff.mnemonicPrefix rewrites the +++ prefix — either must not blind the scan.
+    _git(tmp_path, "init", "-q", "-b", "devel")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/café.inc").write_text("// clean\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+    (tmp_path / "src/café.inc").write_text("// clean\n// see RESULTS/01\n")
+    _git(tmp_path, "add", ".")
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 1, res.stderr
+    assert "src/café.inc:2" in res.stderr
+
+    _git(tmp_path, "config", "diff.mnemonicPrefix", "true")
+    _git(tmp_path, "config", "diff.noprefix", "true")
+    assert _run(tmp_path, "--staged").returncode == 1
+
+
+def test_cli_space_bearing_md_path_stays_clean(tmp_path: Path) -> None:
+    _git(tmp_path, "init", "-q", "-b", "devel")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/my notes.md").write_text("// clean\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+    (tmp_path / "src/my notes.md").write_text("// clean\n// RESULTS/01 and Phase 4\n")
+    _git(tmp_path, "add", ".")
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 0, res.stderr
+
+
 def test_cli_usage_error(tmp_path: Path) -> None:
     _git(tmp_path, "init", "-q")
     assert _run(tmp_path).returncode == 2
     assert _run(tmp_path, "--bogus").returncode == 2
+
+
+def test_cli_bad_ref_is_a_usage_error_not_a_traceback(tmp_path: Path) -> None:
+    _git(tmp_path, "init", "-qb", "devel")
+    (tmp_path / "f").write_text("x\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+    res = _run(tmp_path, "--diff", "no-such-ref")
+    assert res.returncode == 2, res.stderr
+    assert "git diff failed" in res.stderr

--- a/tests/test_comment_narration_check.py
+++ b/tests/test_comment_narration_check.py
@@ -13,6 +13,7 @@ whole files.
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -222,6 +223,16 @@ def test_cli_hostile_git_configs_cannot_bypass_the_gate(tmp_path: Path) -> None:
     _git(tmp_path, "config", "diff.mnemonicPrefix", "true")
     _git(tmp_path, "config", "diff.noprefix", "true")
     assert _run(tmp_path, "--staged").returncode == 1
+
+    # An external diff driver replaces the unified output entirely — the gate
+    # must still see the real diff (config form and env form).
+    _git(tmp_path, "config", "diff.external", "/bin/echo")
+    assert _run(tmp_path, "--staged").returncode == 1
+    env = {**os.environ, "GIT_EXTERNAL_DIFF": "/bin/echo"}
+    res = subprocess.run(
+        [sys.executable, str(_TOOL), "--staged"], cwd=tmp_path, capture_output=True, text=True, env=env
+    )
+    assert res.returncode == 1, res.stderr
 
 
 def test_cli_space_bearing_md_path_stays_clean(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Preventive measures against AI-era comment bloat (session finding: `pfblockerng_extra.inc` at 44.7% comment density, blocks up to 39 consecutive comment lines, 65 phase-numbered comments and 19 `RESULTS/` handoff refs shipped under `src/`).

- **CLAUDE.md — new "Comments — constraint, not narration" rule** (Code standards): ≤3-line default budget; design rationale lives in the ADR/architecture-notes behind a one-line pointer, never restated; one-line `issue #NNN` regression breadcrumbs stay; ADR phase numbers, `RESULTS/` handoff refs, and review archaeology are banned from committed comments. Referenced from the delegation brief's Constraints (§5) and the gate's Conventions check (§5).
- **`scripts/check_comment_narration.py`** — diff-scoped checker enforcing the ban on **added** lines under `src/` + `scripts/` (`*.md` and the files whose subject is phases/narration excluded). Patterns: `RESULTS/`, `Phase N` (capitalised only — prose "phase 2" stays legal), `review-fanout`, `PR #N`. Pre-existing narration is grandfathered until its cleanup lands. Inline escape: `# narration-ok: <reason>`.
- **Wiring**: unconditional pre-commit step (`--staged`; self-scoping, near-zero cost) and a PR-only `comment-narration` CI job in `test.yml` (`--diff origin/$BASE`, same shape as `coverage-pairing`), folded into `all-tests-passed` with skipped==pass on push.
- **`tests/test_comment_narration_check.py`** — 14 tests: every flagging pattern paired with its nearest clean sibling (discrimination, not just firing), diff mechanics (hunk line numbers, removed/context lines ignored), scope/exclusions/escape hatch, and both CLI modes end-to-end in a scratch repo.

## Evidence

- Red→green executed: test suite fails `FileNotFoundError` without the checker, `14 passed` with it.
- Wired-gate red paths demonstrated in-session: staged violating file → pre-commit `FAILED: comment-narration` (rc=1); violating commit → `--diff` exits 1 with `file:line`; this branch's real diff → rc=0.
- Gates: full pytest `2399 passed, 5 skipped`; `ruff check` / `ruff format --check` clean; `mypy tests/` clean; `sh -n` on the hook OK; markdownlint rc=0.

Cleanup of the existing narration is a follow-up work item, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013UZDT8tKD1VwxBTjU9Uxnd)_