### PR TITLE
ci: reopen closed dedup trackers + pipefail in top1m-healthcheck/version-tracker

### DIFF
--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -169,18 +169,31 @@ jobs:
 
       - name: Open or update the tracking issue
         run: |
-          set -eu
+          # pipefail: without it a failed `gh issue list` is masked by the
+          # jq/sort pipeline below and the dedup opens duplicates (issue #960,
+          # the PR #933 default-shell class).
+          set -euo pipefail
           TITLE="[top1m-healthcheck] provider URL unhealthy"
 
           # Scope to the tracking label and lift the default 30-item cap (see
-          # version-tracker.yml's dedup note) so an older open issue past the
-          # first page is still found and updated in place, not re-created.
-          EXISTING_NUM=$(gh issue list --repo "$REPO" --state open \
-            --label "top1m-provider" --limit 500 --json number,title \
-            | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
-            | sort -n | head -1)
+          # version-tracker.yml's dedup note) so an older issue past the
+          # first page is still found and updated in place, not re-created --
+          # but across ALL states: a recurrence after a closed tracker
+          # REOPENS it instead of filing a duplicate (issue #960). Prefer an
+          # open match, then the lowest issue number.
+          MATCH=$(gh issue list --repo "$REPO" --state all \
+            --label "top1m-provider" --limit 500 --json number,title,state \
+            | jq -r --arg t "$TITLE" \
+                '[.[] | select(.title == $t)] | sort_by(.state != "OPEN", .number)
+                 | .[0] | if . then "\(.number) \(.state)" else empty end')
 
-          if [ -n "$EXISTING_NUM" ]; then
+          if [ -n "$MATCH" ]; then
+            EXISTING_NUM=${MATCH% *}
+            EXISTING_STATE=${MATCH#* }
+            if [ "$EXISTING_STATE" = "CLOSED" ]; then
+              echo "[reopen] Reopening tracking issue #${EXISTING_NUM}"
+              gh issue reopen "$EXISTING_NUM" --repo "$REPO"
+            fi
             echo "[update] Updating tracking issue #${EXISTING_NUM}"
             gh issue edit "$EXISTING_NUM" --repo "$REPO" --body-file "${{ steps.report.outputs.body_file }}"
           else

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -372,10 +372,11 @@ jobs:
               continue
             fi
 
-            if [ -n "$MATCH" ]; then
+            if [ -n "$MATCH" ] && [ "${MATCH#* }" = "CLOSED" ]; then
               EXISTING_NUM=${MATCH% *}
               echo "  [reopen] Reopening tracking issue #${EXISTING_NUM} for ${CHANNEL} ${VERSION}"
-              gh issue reopen "$EXISTING_NUM" --repo "$REPO"
+              gh issue reopen "$EXISTING_NUM" --repo "$REPO" \
+                || echo "  ::warning::Could not reopen tracking issue #${EXISTING_NUM}"
               continue
             fi
 

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -327,7 +327,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          set -eu
+          # pipefail: without it a failed `gh issue list` is masked by the
+          # jq pipeline below and the dedup opens duplicates (issue #960, the
+          # PR #933 default-shell class).
+          set -euo pipefail
           COUNT=$(jq '.supported_missing | length' probe_result.json)
           echo "supported_missing count: ${COUNT}"
           [ "$COUNT" -eq 0 ] && echo "No supported-but-missing versions detected." && exit 0
@@ -341,26 +344,38 @@ jobs:
 
             TITLE="[version-tracker] pfSense ${CHANNEL} ${VERSION} still-supported — evaluate for matrix"
 
-            # Skip if an open issue with this exact title already exists.
             # Scope to the version-tracker label and lift the default 30-item cap:
             # without an explicit --limit, gh issue list returns only the 30 newest
             # open issues, so an older tracker issue beyond that window is invisible
-            # to the dedup and a duplicate is opened every run.
-            EXISTING=$(gh issue list --repo "$REPO" --state open \
-              --label "version-tracker" --limit 500 --json title 2>/dev/null \
-              | jq --arg t "$TITLE" '[.[] | select(.title == $t)] | length')
-            if [ "${EXISTING:-0}" -gt 0 ]; then
+            # to the dedup and a duplicate is opened every run. Match across ALL
+            # states (issue #960): a recurrence after a closed tracker REOPENS it
+            # instead of filing a duplicate. Prefer an open match, then the lowest
+            # issue number.
+            MATCH=$(gh issue list --repo "$REPO" --state all \
+              --label "version-tracker" --limit 500 --json number,title,state \
+              | jq -r --arg t "$TITLE" \
+                  '[.[] | select(.title == $t)] | sort_by(.state != "OPEN", .number)
+                   | .[0] | if . then "\(.number) \(.state)" else empty end')
+            if [ -n "$MATCH" ] && [ "${MATCH#* }" = "OPEN" ]; then
               echo "  [skip] open issue already exists for ${CHANNEL} ${VERSION}"
               continue
             fi
 
             # Skip if a closed issue with tracker-wontfix mentions this version.
-            # --limit 500 lifts the default 30-item cap (see the dedup note above).
+            # Checked BEFORE reopening: a wontfix'd version must never be
+            # reopened. --limit 500 lifts the default 30-item cap (see above).
             WONTFIX=$(gh issue list --repo "$REPO" --state closed --label "tracker-wontfix" \
-              --limit 500 --json title 2>/dev/null \
+              --limit 500 --json title \
               | jq --arg v "$VERSION" '[.[] | select(.title | contains($v))] | length')
             if [ "${WONTFIX:-0}" -gt 0 ]; then
               echo "  [wontfix] suppressed for ${CHANNEL} ${VERSION}"
+              continue
+            fi
+
+            if [ -n "$MATCH" ]; then
+              EXISTING_NUM=${MATCH% *}
+              echo "  [reopen] Reopening tracking issue #${EXISTING_NUM} for ${CHANNEL} ${VERSION}"
+              gh issue reopen "$EXISTING_NUM" --repo "$REPO"
               continue
             fi
 
@@ -398,7 +413,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          set -eu
+          # pipefail: without it a failed `gh issue list` is masked by the
+          # jq/sort pipeline below and the dedup opens duplicates (issue #960,
+          # the PR #933 default-shell class).
+          set -euo pipefail
           COUNT=$(jq '.future | length' probe_result.json)
           echo "future count: ${COUNT}"
           [ "$COUNT" -eq 0 ] && echo "No future/TBD versions detected." && exit 0
@@ -431,16 +449,27 @@ jobs:
               printf '_the page signal changes (TBD → released date → GA)._\n'
             } > "$BODY_FILE"
 
-            # Update an existing open tracking issue; create one if none exists.
+            # Update an existing tracking issue; create one if none exists.
             # Scope to the version-tracker label and lift the default 30-item cap so
             # an older tracking issue past the first page is still found and updated
-            # in place rather than re-created (the duplicate-issue bug).
-            EXISTING_NUM=$(gh issue list --repo "$REPO" --state open \
-              --label "version-tracker" --limit 500 --json number,title 2>/dev/null \
-              | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
-              | sort -n | head -1)
+            # in place rather than re-created (the duplicate-issue bug). Match across
+            # ALL states (issue #960): a recurrence after a closed tracker REOPENS it
+            # instead of filing a duplicate. Prefer an open match, then the lowest
+            # issue number.
+            MATCH=$(gh issue list --repo "$REPO" --state all \
+              --label "version-tracker" --limit 500 --json number,title,state \
+              | jq -r --arg t "$TITLE" \
+                  '[.[] | select(.title == $t)] | sort_by(.state != "OPEN", .number)
+                   | .[0] | if . then "\(.number) \(.state)" else empty end')
 
-            if [ -n "$EXISTING_NUM" ]; then
+            if [ -n "$MATCH" ]; then
+              EXISTING_NUM=${MATCH% *}
+              EXISTING_STATE=${MATCH#* }
+              if [ "$EXISTING_STATE" = "CLOSED" ]; then
+                echo "  [reopen] Reopening tracking issue #${EXISTING_NUM} for ${CHANNEL} ${VERSION}"
+                gh issue reopen "$EXISTING_NUM" --repo "$REPO" \
+                  || echo "  ::warning::Could not reopen tracking issue #${EXISTING_NUM}"
+              fi
               echo "  [update] Updating tracking issue #${EXISTING_NUM} for ${CHANNEL} ${VERSION}"
               gh issue edit "$EXISTING_NUM" --repo "$REPO" --body-file "$BODY_FILE" \
                 || echo "  ::warning::Could not update tracking issue #${EXISTING_NUM}"


### PR DESCRIPTION
Fixes #960

Ports the issue-dedup fix shape landed in `nightly-failure-alert.yml` (PR #958) to its three pre-existing sibling sites, enumerated from source in the issue:

1. **`top1m-healthcheck.yml` "Open or update the tracking issue"** — dedup now matches across **all** states (label + exact title, `--limit 500` page-cap lift kept), prefers the open match then the lowest number, and **reopens** a closed tracker before editing instead of filing a duplicate.
2. **`version-tracker.yml` "Open nudge issues for supported-but-missing versions"** — same all-states match; order is open-match → skip, `tracker-wontfix` suppression (checked **before** reopening, so a wontfix'd version is never reopened), closed match → reopen, none → create. Dropped `2>/dev/null` from the `gh issue list` calls so failures stay diagnosable.
3. **`version-tracker.yml` "Open or update tracking issues for upcoming/TBD versions"** — all-states match + reopen-when-closed (with the same `::warning` fallback style as its sibling edit), then edit; none → create.

All three blocks move from `set -eu` to `set -euo pipefail`: without it a failed `gh issue list` (auth/rate-limit/transient) exits 0 through the `| jq | sort | head` pipeline, the dedup sees "no issue", and a duplicate is created (the PR #933 default-shell class).

## Verification (executed)

- Dry-run harness (mock `gh` honouring `--state`/`--label`, per-call log, extracted step scripts by step **name** via YAML parse): 15-row coverage matrix × 50 assertions — open→edit/skip, closed→reopen, none→create, open-preferred-over-closed, lookalike-title non-match, wontfix-precedence-over-reopen, and gh-failure→loud-nonzero per site.
- **Red→green executed both directions**: on the pre-change blocks the harness fails 14 assertions (closed match → duplicate create; failed `gh` → exit 0 + create); post-change 50/50 pass. Re-executed independently by the gate (checkout `HEAD~1` of the two workflows, rerun, restore).
- `yaml.safe_load` OK on both files; `bash -n` OK on all three extracted step scripts; `scripts/check_version_literals.py` and `scripts/check_url_encoding.py` clean (fixtures use inert `9.9.9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Db1iA1CwDotFwAX4v44ti2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Db1iA1CwDotFwAX4v44ti2)_