### PR TITLE
tests/smoke: conditional per-test config isolation for the UI tier

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1589,14 +1589,16 @@ def _pfb_module_baseline(request: pytest.FixtureRequest) -> Generator[None, None
     config; module 1 is already clean from the fresh boot.
 
     Scoped to the SMOKE tier only — the UI tier (``tests/smoke/ui/``) shares a session-scoped
-    login + box and is reset separately, so it is excluded here. A strict no-op unless
-    ``SMOKE_PKG`` is set (a package was actually deployed) AND the VM was actually booted, so
-    off-box modules that never touch the VM are untouched (and never boot one just to reset).
-    A genuine reset failure is allowed to SURFACE — silently swallowing it would leak dirty
-    state into the next module, defeating the isolation this fixture exists to provide.
+    login + box and is reset by its own per-test mechanism instead
+    (``tests/smoke/ui/conftest.py::_ui_pfb_isolation``, issue #810), so it is excluded here.
+    A strict no-op unless ``SMOKE_PKG`` is set (a package was actually deployed) AND the VM
+    was actually booted, so off-box modules that never touch the VM are untouched (and never
+    boot one just to reset). A genuine reset failure is allowed to SURFACE — silently
+    swallowing it would leak dirty state into the next module, defeating the isolation this
+    fixture exists to provide.
     """
     yield
-    # UI tier shares session state (deferred to its own per-test reset) — leave it alone.
+    # UI tier has its own per-test reset (_ui_pfb_isolation, issue #810) — leave it alone here.
     if Path(str(request.path)).parent.name == "ui":
         return
     # No-op outside a real deployed smoke run, so off-box modules (no VM) are unaffected.

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -40,6 +40,7 @@ so importing this module does not require the smoke deps.
 from __future__ import annotations
 
 import base64
+import hashlib
 import ipaddress
 import os
 import re
@@ -2737,6 +2738,114 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
                     f"reset_pfb_baseline {verb} failed: rc={cleared.returncode} stderr={cleared.stderr!r}"
                 )
     apply_filter_sync(vm)
+
+
+def restore_pfb_config_baseline(vm: SmokeVM, *, snapshot_path: str, timeout: float = 300.0) -> None:
+    """Restore ``/conf/config.xml`` from a guest-side snapshot (UI-tier session isolation).
+
+    :func:`reset_pfb_baseline` WIPES pfBlockerNG config to empty — correct for the
+    module-scoped SMOKE tier, where the next module's ``deployed_vm`` re-establishes
+    whatever infrastructure (VIP, ports, ...) it needs. The UI tier is ONE session: a
+    wipe deletes ``pfb_dnsvip4``/``pfb_dnsport``/``pfb_dnsport_ssl`` (the
+    :data:`_DNSBL_INFRA_KEYS`) with nothing left in the session to re-provision them,
+    so every LATER ``pfblockerng_dnsbl.php``/SafeSearch save runs ``pfb_validate_vips``
+    against a VIP-less config and gets rejected — 23 functional tests + 1 browser test
+    failed this way in ui-tests.yml run 28900064099, all reading back ``''`` after the
+    FIRST dirty-path reset. So the UI tier's per-test isolation is RESTORE-to-session-
+    baseline, not wipe-to-empty: copy back a config.xml snapshot taken once at session
+    start (after the DNSBL VIP was established — see ``deployed_vm``), rather than
+    reconstructing it from nothing.
+
+    Sequence, each step raising ``RuntimeError`` on failure so a broken restore
+    surfaces loudly (never silently leaves a dirty box for the next test):
+
+    1. Copy the snapshot over ``/conf/config.xml`` and drop the serialized config
+       cache. pfSense re-parses ``config.xml`` only when the cache is absent/stale —
+       upstream ``config.lib.inc`` itself does
+       ``unlink_if_exists(g_get('tmp_path') . '/config.cache')`` (``/tmp/config.cache``)
+       right after replacing the file on disk, commented "Configuration file has been
+       replaced, remove the config cache." (config.lib.inc:198-199 and :720-721,
+       confirmed against pfsense/pfSense ``master`` this session) — mirrored here
+       exactly.
+    2. ``services_unbound_configure()`` regenerates the resolver config/host entries
+       from the restored config (the fresh ``pfSsh.php`` process reads ``config.xml``
+       anew now that the cache is gone).
+    3. ``clearip``/``cleardnsbl`` (skipped when the package is uninstalled — same
+       guard and rationale as :func:`reset_pfb_baseline`: an uninstall test already
+       dropped the derived state, and ``PFB_CLI`` no longer exists to shell out to).
+    4. A blocking :func:`apply_filter_sync` so the pf ruleset matches the restored
+       config.
+
+    Issue #810.
+    """
+    cp_result = vm.ssh(
+        "/bin/sh",
+        "-c",
+        f"cp {snapshot_path} /conf/config.xml && rm -f /tmp/config.cache",
+        timeout=timeout,
+    )
+    if cp_result.returncode != 0:
+        raise RuntimeError(
+            f"restore_pfb_config_baseline: restoring {snapshot_path} failed: "
+            f"rc={cp_result.returncode} stderr={cp_result.stderr!r}"
+        )
+    eval_result = php_eval(vm, "services_unbound_configure();\necho 'OK';", timeout=timeout)
+    if eval_result.returncode != 0 or "OK" not in eval_result.stdout:
+        raise RuntimeError(
+            f"restore_pfb_config_baseline: services_unbound_configure failed: "
+            f"rc={eval_result.returncode} {eval_result.stderr!r} {eval_result.stdout!r}"
+        )
+    if pkg_installed(vm):
+        for verb in ("clearip", "cleardnsbl"):
+            cleared = vm.ssh(PHP_BIN, PFB_CLI, verb, timeout=120.0)
+            if cleared.returncode != 0:
+                raise RuntimeError(
+                    f"restore_pfb_config_baseline {verb} failed: rc={cleared.returncode} stderr={cleared.stderr!r}"
+                )
+    apply_filter_sync(vm)
+
+
+# --------------------------------------------------------------------------- #
+# Per-test UI config-change detection (issue #810) — cheap probe so the UI
+# tier's per-test reset only pays reset_pfb_baseline's cost when a test
+# actually left config dirty.
+# --------------------------------------------------------------------------- #
+
+
+def strip_config_revision(text: str) -> str:
+    """Remove the FIRST ``<revision>...</revision>`` block from a config.xml body.
+
+    ``<revision>`` (time/description/username) is REWRITTEN by every
+    ``write_config()`` call, so it is pure noise for detecting a REAL config
+    change (issue #810). It is the volatile block near the top, a direct child
+    of ``<pfsense>`` — ``count=1`` strips ONLY that first occurrence. Any LATER
+    ``<revision>``-shaped content (hostile: a package key literally named
+    "revision") is deliberately PRESERVED, so a change buried in it still reads
+    as dirty — false-dirty (an extra reset) is safe, false-clean is not.
+    """
+    return re.sub(r"<revision>.*?</revision>", "", text, count=1, flags=re.DOTALL)
+
+
+def pfb_config_digest(vm: SmokeVM, *, timeout: float = 30.0) -> str:
+    """A cheap content digest of the guest's ``/conf/config.xml`` (issue #810).
+
+    One ``ssh`` round-trip (a bare ``cat``, no ``pfSsh.php`` spin-up) — that
+    spin-up cost is exactly what the UI tier's per-test isolation probe must
+    avoid on the common (test self-restored) path. MD5 of the config text with
+    its volatile ``<revision>`` block stripped (:func:`strip_config_revision`) —
+    a Python-side SELF-comparison digest only (ADR-42 policy), never a
+    cross-language digest. Raises on a non-zero read or EMPTY stdout: a
+    failed/truncated read must NEVER fold into a digest value — the same #909
+    lesson as :func:`guest_file_contains` (a bad read must surface, never
+    silently compare-equal to some other bad read).
+    """
+    result = vm.ssh("cat", "/conf/config.xml", timeout=timeout)
+    if result.returncode != 0 or not result.stdout:
+        raise RuntimeError(
+            f"pfb_config_digest: reading /conf/config.xml failed: rc={result.returncode} "
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+    return hashlib.md5(strip_config_revision(result.stdout).encode("utf-8")).hexdigest()
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2780,10 +2780,10 @@ def restore_pfb_config_baseline(vm: SmokeVM, *, snapshot_path: str, timeout: flo
 
     Issue #810.
     """
+    # Single-string ssh convention (runs verbatim under the guest /bin/sh -- required for
+    # the `&&`); shlex.quote hardens the caller-supplied path (PR #965 Copilot review).
     cp_result = vm.ssh(
-        "/bin/sh",
-        "-c",
-        f"cp {snapshot_path} /conf/config.xml && rm -f /tmp/config.cache",
+        f"cp {shlex.quote(snapshot_path)} /conf/config.xml && rm -f /tmp/config.cache",
         timeout=timeout,
     )
     if cp_result.returncode != 0:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2847,7 +2847,7 @@ def pfb_config_digest(vm: SmokeVM, *, timeout: float = 30.0) -> str:
             f"pfb_config_digest: reading /conf/config.xml failed: rc={result.returncode} "
             f"stderr={result.stderr!r} stdout={result.stdout!r}"
         )
-    return hashlib.md5(strip_config_revision(result.stdout).encode("utf-8")).hexdigest()
+    return hashlib.md5(strip_config_revision(result.stdout).encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2749,9 +2749,11 @@ def restore_pfb_config_baseline(vm: SmokeVM, *, snapshot_path: str, timeout: flo
     wipe deletes ``pfb_dnsvip4``/``pfb_dnsport``/``pfb_dnsport_ssl`` (the
     :data:`_DNSBL_INFRA_KEYS`) with nothing left in the session to re-provision them,
     so every LATER ``pfblockerng_dnsbl.php``/SafeSearch save runs ``pfb_validate_vips``
-    against a VIP-less config and gets rejected — 23 functional tests + 1 browser test
-    failed this way in ui-tests.yml run 28900064099, all reading back ``''`` after the
-    FIRST dirty-path reset. So the UI tier's per-test isolation is RESTORE-to-session-
+    against a VIP-less config and gets rejected — 23 functional-leg tests failed this
+    way in ui-tests.yml run 28900064099, all reading back ``''`` after the FIRST
+    dirty-path reset (that run's one browser-leg failure was the unrelated,
+    pre-existing issue #964 vocabulary bug, fixed separately). So the UI tier's
+    per-test isolation is RESTORE-to-session-
     baseline, not wipe-to-empty: copy back a config.xml snapshot taken once at session
     start (after the DNSBL VIP was established — see ``deployed_vm``), rather than
     reconstructing it from nothing.

--- a/tests/smoke/ui/conftest.py
+++ b/tests/smoke/ui/conftest.py
@@ -337,7 +337,9 @@ def _ui_config_baseline(webui: WebUI, smoke_vm: SmokeVM) -> dict[str, str]:
     """
     from .. import helpers
 
-    result = smoke_vm.ssh("/bin/sh", "-c", f"cp /conf/config.xml {UI_CONFIG_SNAPSHOT}")
+    # Single-string ssh convention (verbatim under the guest /bin/sh); both paths are
+    # fixed internal constants (PR #965 Copilot review: no extra /bin/sh -c layer).
+    result = smoke_vm.ssh(f"cp /conf/config.xml {UI_CONFIG_SNAPSHOT}")
     if result.returncode != 0:
         raise RuntimeError(
             f"_ui_config_baseline: snapshotting /conf/config.xml to {UI_CONFIG_SNAPSHOT} failed: "

--- a/tests/smoke/ui/conftest.py
+++ b/tests/smoke/ui/conftest.py
@@ -18,6 +18,7 @@ phase does NOT edit any workflow.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import time
 from collections.abc import Iterator
@@ -188,10 +189,20 @@ def deployed_vm(smoke_vm: SmokeVM) -> SmokeVM:
     which reads as a UI failure but is really "the package was never installed".
     ``pkg add`` resolves RUN_DEPENDS from the baked image offline (ADR-04), so no
     egress is required.
+
+    Also establishes the DNSBL sinkhole VIP (:func:`~tests.smoke.helpers.ensure_dnsbl_vip`)
+    here, once: unlike the module-scoped SMOKE tier (each module's ``deployed_vm``
+    re-establishes its own infra), the UI tier is ONE session, so the VIP/ports are
+    part of THIS tier's baseline -- every ``pfblockerng_dnsbl.php``/SafeSearch save
+    runs ``pfb_validate_vips``, and once per-test isolation RESTORES config
+    (:func:`_ui_pfb_isolation`) there is no later re-provisioning step to add it back
+    (issue #810). ``ensure_dnsbl_vip`` is idempotent on its fixed uniqid, so the
+    tests that also call it directly (e.g. ``dnsbl_vip_ready``) stay digest-clean.
     """
     from .. import helpers
 
     helpers.deploy(smoke_vm)
+    helpers.ensure_dnsbl_vip(smoke_vm)
     return smoke_vm
 
 
@@ -286,6 +297,110 @@ def webui(deployed_vm: SmokeVM, admin_credentials: tuple[str, str], webgui_proto
 
 
 # --------------------------------------------------------------------------- #
+# Per-test config isolation (issue #810) — the UI tier shares ONE session-scoped
+# login + box across ~170 mutating tests; `_pfb_module_baseline` (tests/smoke/
+# conftest.py) explicitly excludes this ``ui/`` subpackage and defers to this
+# mechanism. Unconditional reset_pfb_baseline() after every ui_e2e/ui_browser
+# test would cost ~15-30s each (write_config + services_unbound_configure +
+# clearip/cleardnsbl + apply_filter_sync) -- unacceptable at this volume. So:
+# a cheap one-ssh-round-trip digest probe per test, full reset ONLY when dirty.
+# Most UI e2e tests already self-restore (drive-form-back / finally-restore),
+# so the common path costs exactly one extra `cat /conf/config.xml`.
+#
+# The dirty path RESTORES to the session baseline (a guest-side config.xml
+# snapshot), not `reset_pfb_baseline`'s wipe-to-empty: a wipe deletes the DNSBL
+# VIP `deployed_vm` established, and the UI tier -- ONE session -- has no later
+# re-provisioning step to add it back, so every subsequent DNSBL/SafeSearch save
+# was rejected by `pfb_validate_vips` (ui-tests.yml run 28900064099, issue #810).
+# --------------------------------------------------------------------------- #
+
+# Guest-side path for the session-baseline config.xml snapshot (issue #810) --
+# the restore artifact `_ui_pfb_isolation`'s dirty path copies back over
+# `/conf/config.xml`. Under `/root` (writable, survives for the VM's lifetime,
+# outside `/conf` so it is never itself clobbered by a config restore).
+UI_CONFIG_SNAPSHOT = "/root/pfb_ui_config_baseline.xml"
+
+
+@pytest.fixture(scope="session")
+def _ui_config_baseline(webui: WebUI, smoke_vm: SmokeVM) -> dict[str, str]:
+    """Snapshot + digest the post-login config (issue #810) -- the per-test isolation oracle.
+
+    Depending on ``webui`` (not ``deployed_vm``) is REQUIRED and deliberate: it
+    guarantees the snapshot is taken AFTER login + ``_dismiss_pfblockerng_wizard``
+    (itself a config write -- ``pfb_wizard_skip``) AND after ``deployed_vm``
+    established the DNSBL VIP, so the baseline already includes both. The guest-side
+    copy to :data:`UI_CONFIG_SNAPSHOT` IS the restore artifact
+    :func:`~tests.smoke.helpers.restore_pfb_config_baseline` copies back on the dirty
+    path -- taken back-to-back with the digest, no writer running in between, so the
+    two describe the exact same config state. Mutable (a dict, not a bare str) so
+    :func:`_ui_pfb_isolation` can re-snapshot the digest in place after a restore.
+    """
+    from .. import helpers
+
+    result = smoke_vm.ssh("/bin/sh", "-c", f"cp /conf/config.xml {UI_CONFIG_SNAPSHOT}")
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"_ui_config_baseline: snapshotting /conf/config.xml to {UI_CONFIG_SNAPSHOT} failed: "
+            f"rc={result.returncode} stderr={result.stderr!r}"
+        )
+    return {"digest": helpers.pfb_config_digest(smoke_vm)}
+
+
+@pytest.fixture(autouse=True)
+def _ui_pfb_isolation(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Restore pfBlockerNG config to baseline after a mutating UI test LEFT it dirty (issue #810).
+
+    ``ui_render`` and unmarked tests get a plain no-op ``yield`` -- no VM/webui
+    setup, no probe cost, matching Tier A's read-only contract. For ``ui_e2e``/
+    ``ui_browser`` tests: at TEARDOWN, compare the current config digest
+    (:func:`~tests.smoke.helpers.pfb_config_digest`) against the session
+    baseline; only a MISMATCH pays
+    :func:`~tests.smoke.helpers.restore_pfb_config_baseline`'s real cost, then the
+    baseline is re-snapshotted to the post-restore digest -- without this
+    re-snapshot every LATER probe would compare against the pre-restore baseline
+    and read as dirty forever, resetting on every single test regardless of
+    whether it actually mutated anything.
+
+    RESTORE, not `reset_pfb_baseline`'s wipe-to-empty: the SMOKE tier's module-scoped
+    ``deployed_vm`` re-establishes any infra a wipe drops, but this tier is ONE
+    session -- a wipe deletes ``pfb_dnsvip4``/ports with nothing left to re-add them,
+    so every LATER DNSBL/SafeSearch save fails ``pfb_validate_vips`` (the failure
+    class ui-tests.yml run 28900064099 hit: 23 functional + 1 browser test failed
+    reading back ``''`` after the first dirty-path wipe). Restoring the
+    :data:`UI_CONFIG_SNAPSHOT` guest-side snapshot -- taken once, post-VIP, at session
+    start -- puts the box back exactly where the session began instead.
+
+    A false POSITIVE (reads dirty when the test actually self-restored) is
+    safe -- one wasted restore. A false NEGATIVE (reads clean when config truly
+    changed) is not, so ``strip_config_revision`` errs toward over-detecting
+    (see its docstring) and a genuine probe/restore failure is left to SURFACE
+    here rather than suppressed -- mirroring ``_pfb_module_baseline``'s
+    rationale: a teardown error is reported separately from the test's own
+    result and must never mask a leaked dirty state.
+
+    PHPSESSID is untouched by any of this: ``restore_pfb_config_baseline`` only
+    touches ``/conf/config.xml`` + derived pf/Unbound state, never the
+    webConfigurator session store, and the browser tier's session cookie lives
+    on the session-scoped ``browser_context`` (not per-test), so it survives
+    regardless of whether a restore ran.
+    """
+    is_mutating = request.node.get_closest_marker("ui_e2e") or request.node.get_closest_marker("ui_browser")
+    if not is_mutating:
+        yield
+        return
+
+    baseline = request.getfixturevalue("_ui_config_baseline")
+    vm = request.getfixturevalue("smoke_vm")
+    yield
+    from .. import helpers
+
+    current = helpers.pfb_config_digest(vm)
+    if current != baseline["digest"]:
+        helpers.restore_pfb_config_baseline(vm, snapshot_path=UI_CONFIG_SNAPSHOT)
+        baseline["digest"] = helpers.pfb_config_digest(vm)
+
+
+# --------------------------------------------------------------------------- #
 # Tier B — browser (ADR-14 Phase 4). Headless Chromium reusing the Phase-1
 # authenticated session: the `webui` PHPSESSID cookie is injected into the
 # browser context so the browser never logs in a second time (a second login is
@@ -361,4 +476,10 @@ def browser_page(browser_context: BrowserContext) -> Iterator[Page]:
     try:
         yield page
     finally:
+        # issue #810: clear per-origin storage a browser test wrote so it doesn't leak into
+        # the next browser test. Cookies (PHPSESSID) are untouched -- they live on the
+        # session-scoped browser_context, not here. Best-effort: the page may already be
+        # crashed/closed, or parked on an origin where storage access throws.
+        with contextlib.suppress(Exception):
+            page.evaluate("() => { localStorage.clear(); sessionStorage.clear(); }")
         page.close()

--- a/tests/smoke/ui/conftest.py
+++ b/tests/smoke/ui/conftest.py
@@ -350,9 +350,13 @@ def _ui_config_baseline(webui: WebUI, smoke_vm: SmokeVM) -> dict[str, str]:
 def _ui_pfb_isolation(request: pytest.FixtureRequest) -> Iterator[None]:
     """Restore pfBlockerNG config to baseline after a mutating UI test LEFT it dirty (issue #810).
 
-    ``ui_render`` and unmarked tests get a plain no-op ``yield`` -- no VM/webui
-    setup, no probe cost, matching Tier A's read-only contract. For ``ui_e2e``/
-    ``ui_browser`` tests: at TEARDOWN, compare the current config digest
+    Gating rule: a test carrying the ``ui_e2e`` or ``ui_browser`` marker anywhere in
+    its chain is probed -- INCLUDING a test dual-marked ``ui_render`` (a mutating
+    render test rides the net, and a read-only test in a ``ui_e2e`` module pays one
+    ~0.1s probe -- the safe direction). Tests with NEITHER marker (the pure
+    ``ui_render`` modules and unmarked tests) get a plain no-op ``yield`` -- no
+    VM/webui setup, no probe cost, matching Tier A's read-only contract. For probed
+    tests: at TEARDOWN, compare the current config digest
     (:func:`~tests.smoke.helpers.pfb_config_digest`) against the session
     baseline; only a MISMATCH pays
     :func:`~tests.smoke.helpers.restore_pfb_config_baseline`'s real cost, then the
@@ -365,8 +369,9 @@ def _ui_pfb_isolation(request: pytest.FixtureRequest) -> Iterator[None]:
     ``deployed_vm`` re-establishes any infra a wipe drops, but this tier is ONE
     session -- a wipe deletes ``pfb_dnsvip4``/ports with nothing left to re-add them,
     so every LATER DNSBL/SafeSearch save fails ``pfb_validate_vips`` (the failure
-    class ui-tests.yml run 28900064099 hit: 23 functional + 1 browser test failed
-    reading back ``''`` after the first dirty-path wipe). Restoring the
+    class ui-tests.yml run 28900064099 hit: 23 functional-leg tests failed reading
+    back ``''`` after the first dirty-path wipe; its one browser-leg failure was
+    the unrelated pre-existing issue #964 bug, fixed separately). Restoring the
     :data:`UI_CONFIG_SNAPSHOT` guest-side snapshot -- taken once, post-VIP, at session
     start -- puts the box back exactly where the session began instead.
 

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -389,12 +389,14 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
     checkbox token for ``pfb_dnsbl_lenient`` and that the page re-renders the checkbox
     in the matching state when reloaded.
 
-    NOTE on the stored vocabulary: although ``pfb_dnsbl_lenient`` has a 3-state
-    PfbLenient *read* adapter at the ``pfb_global()`` seam ('on'/'off'/''), the DNSBL
-    *page* treats it as a plain on/'' checkbox — it saves via ``pfb_filter(...,
-    PFB_FILTER_ON_OFF)`` (which rejects 'off') and renders via
-    ``pfb_cfg_toggle_read() === PfbToggle::On``. So the only page-reachable stored
-    tokens are 'on' (checked) and '' (unchecked); this test round-trips those.
+    NOTE on the stored vocabulary (issue #964): the page form sends 'on' (checked) or
+    '' (unchecked) — ``pfb_filter(..., PFB_FILTER_ON_OFF)`` rejects 'off' — but the
+    save persists the section via ``PfbConfig::writeSection`` (pfblockerng_dnsbl.php:903),
+    which since a2c5c26a round-trips every adapter-carrying key through its read+write
+    adapters, and ``PfbLenient``'s canonical off token is 'off', never '' — so an
+    unchecked save STORES 'off'. Page-reachable stored tokens: 'on' (checked) and
+    'off' (unchecked); the render side maps both correctly
+    (``pfb_cfg_toggle_read('off') !== PfbToggle::On`` → unchecked).
 
     Scenario: ADR-29 gateway save→reload round-trip for pfb_dnsbl_lenient on the DNSBL page.
       Background: pfBlockerNG deployed; DNSBL VIP seeded; webConfigurator authenticated.
@@ -402,29 +404,33 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
     Given the current checkbox state of pfb_dnsbl_lenient (read via config_get oracle —
       'on' = checked, anything else = unchecked),
     When the DNSBL page is POST-saved with the checkbox flipped,
-    Then config.xml holds the matching token ('on' or ''); AND the DNSBL page, navigated
-      fresh in the browser, renders the checkbox in the matching state; AND a second POST
-      restores the original state with the same two assertions (both directions).
+    Then config.xml holds the CANONICAL token ('on' or 'off'); AND the DNSBL page,
+      navigated fresh in the browser, renders the checkbox in the matching state; AND a
+      second POST restores the original state with the same two assertions (both
+      directions).
     """
     page = browser_page
 
-    # GIVEN: the page stores this field as a plain on/'' checkbox ('off' is not a
-    # page-reachable token — pfb_filter ON_OFF rejects it). Map the stored value to its
-    # checkbox token: 'on' = checked, anything else (''/'off'/absent) = unchecked.
+    # GIVEN: the form sends a plain on/'' checkbox, but the save's writeSection adapter
+    # ride coalesces the unchecked '' to PfbLenient's canonical 'off' (issue #964).
+    # Map the stored value to its checkbox token ('on' = checked, anything else =
+    # unchecked) and each POSTed token to the value the save will STORE.
     original_raw = helpers.config_get(smoke_vm, _CFG_LENIENT)
     original_box = "on" if original_raw == "on" else ""
     flipped = "" if original_box == "on" else "on"
+    stored_token = {"on": "on", "": "off"}  # POSTed checkbox token -> canonical stored token
 
     try:
         # ---- FLIP: POST the checkbox to the opposite state ---- #
         resp = webui.post(DNSBL_PAGE, {"pfb_dnsbl_lenient": flipped}, timeout=_DNSBL_POST_TIMEOUT)
         assert "Sign In" not in resp.text, "pfb_dnsbl_lenient flip POST lost the session"
 
-        # Config oracle: stored token must equal the flipped checkbox value.
+        # Config oracle: stored token must be the CANONICAL form of the flipped value.
         stored_flip = helpers.config_get(smoke_vm, _CFG_LENIENT)
-        assert stored_flip == flipped, (
+        assert stored_flip == stored_token[flipped], (
             f"pfb_dnsbl_lenient gateway FAIL after flip: stored {stored_flip!r}, "
-            f"expected {flipped!r} (the DNSBL-page checkbox stores 'on'/'' through the gateway)"
+            f"expected {stored_token[flipped]!r} (the writeSection adapter ride stores "
+            f"canonical 'on'/'off', issue #964)"
         )
 
         # DOM oracle: reload the DNSBL page and assert the checkbox state matches.
@@ -441,10 +447,11 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
         resp = webui.post(DNSBL_PAGE, {"pfb_dnsbl_lenient": original_box}, timeout=_DNSBL_POST_TIMEOUT)
         assert "Sign In" not in resp.text, "pfb_dnsbl_lenient restore POST lost the session"
 
-        # Config oracle: stored token must equal the original checkbox value.
+        # Config oracle: stored token must be the CANONICAL form of the original value.
         stored_restore = helpers.config_get(smoke_vm, _CFG_LENIENT)
-        assert stored_restore == original_box, (
-            f"pfb_dnsbl_lenient gateway FAIL after restore: stored {stored_restore!r}, expected {original_box!r}"
+        assert stored_restore == stored_token[original_box], (
+            f"pfb_dnsbl_lenient gateway FAIL after restore: stored {stored_restore!r}, "
+            f"expected {stored_token[original_box]!r} (canonical 'on'/'off', issue #964)"
         )
 
         # DOM oracle: reload and assert the checkbox matches the restored value.
@@ -458,8 +465,9 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
         _shot(page, screenshot_dir, "gateway_dnsbl_lenient_after_restore")
 
     finally:
-        # Belt-and-suspenders: restore to the original checkbox value on any mid-flip abort.
-        if helpers.config_get(smoke_vm, _CFG_LENIENT) != original_box:
+        # Belt-and-suspenders: restore to the original checkbox value on any mid-flip
+        # abort (compare against the canonical stored token an unchecked save leaves).
+        if helpers.config_get(smoke_vm, _CFG_LENIENT) != stored_token[original_box]:
             webui.post(DNSBL_PAGE, {"pfb_dnsbl_lenient": original_box}, timeout=_DNSBL_POST_TIMEOUT)
 
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -344,6 +344,10 @@ def test_ip_page_renders_v6_suppression_section(webui: WebUI) -> None:
 _CFG_MAXMIND_KEY = "installedpackages/pfblockerngipsettings/config/0/maxmind_key"
 
 
+# Dual-marked ui_e2e (issue #810): this test MUTATES config.xml (seeds maxmind_key) as
+# setup, so it must ride the per-test isolation probe (_ui_pfb_isolation gates on the
+# ui_e2e/ui_browser markers); the module-level ui_render marker keeps it in the Tier-A gate.
+@pytest.mark.ui_e2e
 def test_ip_page_never_leaks_maxmind_key(
     smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
 ) -> None:  # noqa: ARG001
@@ -986,6 +990,10 @@ def test_dnsbl_page_renders_tld_pickers(webui: WebUI, php_error_log_guard: PhpEr
 CFG_PFB_DNSBL = "installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl"
 
 
+# Dual-marked ui_e2e (issue #810): this test MUTATES config.xml (flips pfb_dnsbl on) as
+# setup, so it must ride the per-test isolation probe (_ui_pfb_isolation gates on the
+# ui_e2e/ui_browser markers); the module-level ui_render marker keeps it in the Tier-A gate.
+@pytest.mark.ui_e2e
 def test_alerts_unified_log_colour_fields_render(
     smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
 ) -> None:

--- a/tests/test_smoke_ui_config_digest.py
+++ b/tests/test_smoke_ui_config_digest.py
@@ -1,0 +1,343 @@
+"""Off-box pins for the UI tier's per-test config-change probe + restore (issue #810).
+
+``tests/smoke/ui/conftest.py``'s ``_ui_pfb_isolation`` autouse fixture pays
+``helpers.restore_pfb_config_baseline``'s real cost (a config.xml byte restore +
+services_unbound_configure + clearip/cleardnsbl + apply_filter_sync, ~15-30s) ONLY when a
+mutating UI test actually left config dirty -- detected via a cheap ``pfb_config_digest``
+probe (one ``cat /conf/config.xml`` over ssh, no ``pfSsh.php`` spin-up). This module pins
+the digest logic off-VM: ``strip_config_revision``'s "strip only the FIRST <revision> block"
+contract (the volatile write_config-rewritten block must never make a real change read as
+clean; any LATER <revision>-shaped content -- e.g. a hostile package key literally named
+"revision" -- must stay live so a change inside it still reads as dirty) and
+``pfb_config_digest``'s never-fold-a-failed-read-into-a-digest contract (the same #909
+lesson as ``guest_file_contains``); it also pins ``restore_pfb_config_baseline``'s sequence
+(cp the snapshot + drop the config cache, THEN services_unbound_configure, THEN
+clearip/cleardnsbl gated on package presence, THEN apply_filter_sync) -- the RESTORE-to-
+session-baseline mechanism that replaced ``reset_pfb_baseline``'s wipe-to-empty after the
+latter deleted the DNSBL VIP and broke every later DNSBL/SafeSearch save in ui-tests.yml
+run 28900064099. ``tests.smoke.helpers`` is import-safe off-VM (precedent:
+``test_smoke_unblock_egress.py``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+
+import pytest
+
+from tests.smoke import helpers
+
+
+@dataclass
+class _FakeResult:
+    """Stand-in for ``subprocess.CompletedProcess[str]`` (the shape ``SmokeVM.ssh`` returns)."""
+
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class _FakeVM:
+    """Fake ``vm.ssh(*remote, timeout=...)`` -- records calls, replays scripted result(s).
+
+    ``results`` (a list) supports the restore sequence's MULTIPLE distinct ``vm.ssh``
+    calls (the cp step, then clearip/cleardnsbl) -- each call pops the next entry.
+    When empty (the (a)-(j) tests' shape), every call replays the single ``result``
+    instead, unchanged from before this extension.
+    """
+
+    result: _FakeResult
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+    results: list[_FakeResult] = field(default_factory=list)
+
+    def ssh(self, *remote: str, timeout: float = 60.0) -> _FakeResult:
+        self.calls.append(remote)
+        if self.results:
+            return self.results.pop(0)
+        return self.result
+
+
+# --------------------------------------------------------------------------- #
+# strip_config_revision
+# --------------------------------------------------------------------------- #
+
+
+def test_revision_only_diff_reads_equal() -> None:
+    """(a) Two configs differing ONLY inside the first <revision> block strip to identical
+    text -- the self-restoring-test clean path (a write_config with no real change)."""
+    saved_at_t1 = (
+        "<pfsense>\n<revision><time>1700000000</time><description>saved</description></revision>\n"
+        "<system><hostname>pfsense</hostname></system>\n</pfsense>\n"
+    )
+    saved_at_t2 = (
+        "<pfsense>\n<revision><time>1700000123</time><description>saved again</description></revision>\n"
+        "<system><hostname>pfsense</hostname></system>\n</pfsense>\n"
+    )
+    stripped_t1 = helpers.strip_config_revision(saved_at_t1)
+    stripped_t2 = helpers.strip_config_revision(saved_at_t2)
+    assert stripped_t1 == stripped_t2, f"expected equal after strip, got {stripped_t1!r} != {stripped_t2!r}"
+
+
+def test_real_value_diff_reads_different() -> None:
+    """(b) A change OUTSIDE <revision> (a real config edit) must still differ after stripping --
+    the dirty path a mutating UI test is supposed to trip."""
+    before = (
+        "<pfsense>\n<revision><time>1</time></revision>\n"
+        "<installedpackages><pfblockerng><enable_cb>on</enable_cb></pfblockerng></installedpackages>\n"
+        "</pfsense>\n"
+    )
+    after = before.replace("<enable_cb>on</enable_cb>", "<enable_cb></enable_cb>")
+    stripped_before = helpers.strip_config_revision(before)
+    stripped_after = helpers.strip_config_revision(after)
+    assert stripped_before != stripped_after, "a real config edit must not collapse to the same stripped text"
+
+
+def test_no_revision_block_is_a_no_op() -> None:
+    """(c) A body with no <revision> element at all strips to itself, unraised."""
+    text = "<pfsense>\n<system><hostname>pfsense</hostname></system>\n</pfsense>\n"
+    result = helpers.strip_config_revision(text)
+    assert result == text, f"expected no-op, got {result!r}"
+
+
+def test_second_revision_shaped_block_is_preserved() -> None:
+    """(d) Only the FIRST <revision> block is stripped -- a SECOND <revision>-shaped block
+    (hostile: e.g. a package key literally named "revision") survives, so a change buried
+    in IT still reads as dirty (fail-safe-to-dirty, never fail-safe-to-clean)."""
+    template = "<pfsense><revision><time>1</time></revision><installedpackages>{inner}</installedpackages></pfsense>"
+    before = template.format(inner="<revision><time>1</time></revision>")
+    after = template.format(inner="<revision><time>2</time></revision>")
+    stripped_before = helpers.strip_config_revision(before)
+    stripped_after = helpers.strip_config_revision(after)
+    assert stripped_before != stripped_after, "a change inside the SECOND <revision>-shaped block must survive"
+    # Only the first (real, volatile) <revision> block was removed -- the second remains once.
+    assert stripped_before.count("<revision>") == 1, f"expected exactly one <revision> left, got {stripped_before!r}"
+    assert stripped_after.count("<revision>") == 1, f"expected exactly one <revision> left, got {stripped_after!r}"
+
+
+def test_empty_string_is_a_no_op() -> None:
+    """(e) Empty input strips to empty -- no crash on the degenerate case."""
+    result = helpers.strip_config_revision("")
+    assert result == "", f"expected empty, got {result!r}"
+
+
+def test_multiline_nested_revision_fully_stripped() -> None:
+    """(f) A realistic multi-line <revision> with nested <time>/<description> children is
+    stripped in FULL -- pins the DOTALL flag (a naive non-DOTALL regex would stop at the
+    first newline and leave the tail of the block behind)."""
+    text = (
+        "before"
+        "<revision>\n"
+        "\t<time>1700000000</time>\n"
+        "\t<description>Made unknown change - not sure why this happened.</description>\n"
+        "\t<username>admin@10.0.0.1</username>\n"
+        "</revision>"
+        "after"
+    )
+    result = helpers.strip_config_revision(text)
+    assert result == "beforeafter", f"expected the whole nested block gone, got {result!r}"
+
+
+def test_crlf_line_endings_still_stripped_deterministically() -> None:
+    """(g) CRLF-terminated config text (a real pfSense-generated file can carry ``\\r\\n``)
+    still strips the <revision> block, and the resulting digest is deterministic."""
+    crlf_before = (
+        "<pfsense>\r\n<revision><time>1</time>\r\n<description>x</description></revision>\r\n"
+        "<system><hostname>pfsense</hostname></system>\r\n</pfsense>\r\n"
+    )
+    crlf_after = (
+        "<pfsense>\r\n<revision><time>2</time>\r\n<description>y</description></revision>\r\n"
+        "<system><hostname>pfsense</hostname></system>\r\n</pfsense>\r\n"
+    )
+    stripped_before = helpers.strip_config_revision(crlf_before)
+    stripped_after = helpers.strip_config_revision(crlf_after)
+    assert stripped_before == stripped_after, (
+        f"CRLF revision-only diff must still collapse to equal, got {stripped_before!r} != {stripped_after!r}"
+    )
+    digest_before = hashlib.md5(stripped_before.encode("utf-8")).hexdigest()
+    digest_after = hashlib.md5(stripped_after.encode("utf-8")).hexdigest()
+    assert digest_before == digest_after, "deterministic digest expected once <revision> content is stripped"
+
+
+# --------------------------------------------------------------------------- #
+# pfb_config_digest
+# --------------------------------------------------------------------------- #
+
+
+def test_digest_raises_on_nonzero_returncode() -> None:
+    """(h) A failed guest read (ssh transport fault, permission error, ...) raises -- it must
+    NEVER fold into a digest value that could spuriously compare equal to another failure."""
+    vm = _FakeVM(result=_FakeResult(returncode=1, stderr="cat: /conf/config.xml: Permission denied"))
+    with pytest.raises(RuntimeError, match=r"rc=1.*Permission denied"):
+        helpers.pfb_config_digest(vm)  # type: ignore[arg-type]
+
+
+def test_digest_raises_on_empty_stdout() -> None:
+    """(i) rc 0 with EMPTY stdout is a truncated/absent read, not a valid (empty) config --
+    must raise, never quietly digest the empty string."""
+    vm = _FakeVM(result=_FakeResult(returncode=0, stdout=""))
+    with pytest.raises(RuntimeError, match=r"pfb_config_digest"):
+        helpers.pfb_config_digest(vm)  # type: ignore[arg-type]
+
+
+def test_digest_happy_path_matches_independent_md5() -> None:
+    """(j) The happy path returns exactly the md5 hexdigest of the stripped config text,
+    computed independently here (not by re-calling the function under test)."""
+    text = (
+        "<pfsense>\n<revision><time>1700000000</time></revision>\n"
+        "<system><hostname>pfsense</hostname></system>\n</pfsense>\n"
+    )
+    vm = _FakeVM(result=_FakeResult(returncode=0, stdout=text))
+    expected = hashlib.md5(helpers.strip_config_revision(text).encode("utf-8")).hexdigest()
+    actual = helpers.pfb_config_digest(vm)  # type: ignore[arg-type]
+    assert actual == expected, f"expected {expected}, got {actual}"
+
+
+# --------------------------------------------------------------------------- #
+# restore_pfb_config_baseline (issue #810 follow-up: RESTORE-to-session-baseline,
+# not reset_pfb_baseline's wipe-to-empty -- see helpers.restore_pfb_config_baseline's
+# docstring for why the wipe broke the UI tier, ui-tests.yml run 28900064099).
+# --------------------------------------------------------------------------- #
+
+_SNAPSHOT_PATH = "/root/pfb_ui_config_baseline.xml"
+
+
+def test_restore_cp_failure_raises_before_php_eval(monkeypatch: pytest.MonkeyPatch) -> None:
+    """(k) A failed guest-side ``cp`` (bad snapshot path, disk full, ...) raises RuntimeError
+    BEFORE ``php_eval`` runs -- a broken restore must surface immediately, never limp forward
+    into a resolver reconfigure against a config.xml that was never actually replaced."""
+    php_eval_calls: list[str] = []
+
+    def fake_php_eval(vm: object, snippet: str, *, timeout: float = 60.0) -> _FakeResult:
+        php_eval_calls.append(snippet)
+        return _FakeResult(returncode=0, stdout="OK")
+
+    monkeypatch.setattr(helpers, "php_eval", fake_php_eval)
+
+    vm = _FakeVM(result=_FakeResult(returncode=1, stderr="cp: cannot stat 'snapshot': No such file"))
+    with pytest.raises(RuntimeError, match=r"rc=1.*No such file"):
+        helpers.restore_pfb_config_baseline(vm, snapshot_path=_SNAPSHOT_PATH)  # type: ignore[arg-type]
+    assert php_eval_calls == [], f"php_eval must not run when the cp step failed, got calls={php_eval_calls!r}"
+
+
+def test_restore_happy_path_with_pkg_installed_runs_steps_in_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    """(l) Happy path, package installed: cp, THEN services_unbound_configure (php_eval), THEN
+    clearip/cleardnsbl, THEN a blocking apply_filter_sync -- the exact sequence
+    reset_pfb_baseline uses for its own derived-state teardown, adapted to a byte restore."""
+    trace: list[str] = []
+    vm = _FakeVM(
+        result=_FakeResult(returncode=0),
+        results=[_FakeResult(returncode=0), _FakeResult(returncode=0), _FakeResult(returncode=0)],
+    )
+    real_ssh = vm.ssh
+
+    def traced_ssh(*remote: str, timeout: float = 60.0) -> _FakeResult:
+        trace.append(f"ssh:{remote}")
+        return real_ssh(*remote, timeout=timeout)
+
+    vm.ssh = traced_ssh  # type: ignore[method-assign]
+
+    def fake_php_eval(v: object, snippet: str, *, timeout: float = 60.0) -> _FakeResult:
+        assert v is vm, "php_eval must be called with the same vm"
+        trace.append(f"php_eval:{snippet}")
+        return _FakeResult(returncode=0, stdout="OK")
+
+    def fake_pkg_installed(v: object, *, timeout: float = 30.0) -> bool:
+        assert v is vm, "pkg_installed must be called with the same vm"
+        trace.append("pkg_installed")
+        return True
+
+    def fake_apply_filter_sync(v: object, *, timeout: float = 60.0) -> None:
+        assert v is vm, "apply_filter_sync must be called with the same vm"
+        trace.append("apply_filter_sync")
+
+    monkeypatch.setattr(helpers, "php_eval", fake_php_eval)
+    monkeypatch.setattr(helpers, "pkg_installed", fake_pkg_installed)
+    monkeypatch.setattr(helpers, "apply_filter_sync", fake_apply_filter_sync)
+
+    helpers.restore_pfb_config_baseline(vm, snapshot_path=_SNAPSHOT_PATH)  # type: ignore[arg-type]
+
+    assert len(trace) == 6, f"expected exactly 6 recorded steps, got trace={trace!r}"
+    cp_call = trace[0]
+    assert cp_call.startswith("ssh:"), f"first step must be the cp ssh call, got {cp_call!r}"
+    assert _SNAPSHOT_PATH in cp_call, f"cp step must reference the snapshot path, got {cp_call!r}"
+    assert "/conf/config.xml" in cp_call, f"cp step must target /conf/config.xml, got {cp_call!r}"
+    assert "rm -f /tmp/config.cache" in cp_call, f"cp step must drop the config cache, got {cp_call!r}"
+
+    php_eval_idx = next(i for i, e in enumerate(trace) if e.startswith("php_eval:"))
+    assert "services_unbound_configure" in trace[php_eval_idx], (
+        f"expected services_unbound_configure in the php_eval snippet, got {trace[php_eval_idx]!r}"
+    )
+
+    pkg_installed_idx = trace.index("pkg_installed")
+    clearip_idx = next(i for i, e in enumerate(trace) if e.startswith("ssh:") and "clearip" in e)
+    cleardnsbl_idx = next(i for i, e in enumerate(trace) if e.startswith("ssh:") and "cleardnsbl" in e)
+    apply_filter_sync_idx = trace.index("apply_filter_sync")
+
+    assert 0 < php_eval_idx < pkg_installed_idx < clearip_idx < cleardnsbl_idx < apply_filter_sync_idx, (
+        f"expected cp < php_eval < pkg_installed < clearip < cleardnsbl < apply_filter_sync, got trace={trace!r}"
+    )
+
+
+def test_restore_skips_clearip_cleardnsbl_when_pkg_not_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """(m) Package NOT installed (a prior test uninstalled it): NO clearip/cleardnsbl ssh calls
+    are made (PFB_CLI no longer exists to shell out to), but apply_filter_sync still runs -- the
+    same guard/rationale reset_pfb_baseline uses for its own derived-state clear."""
+    apply_filter_sync_calls: list[object] = []
+
+    def fake_php_eval(vm: object, snippet: str, *, timeout: float = 60.0) -> _FakeResult:
+        return _FakeResult(returncode=0, stdout="OK")
+
+    def fake_pkg_installed(vm: object, *, timeout: float = 30.0) -> bool:
+        return False
+
+    def fake_apply_filter_sync(vm: object, *, timeout: float = 60.0) -> None:
+        apply_filter_sync_calls.append(vm)
+
+    monkeypatch.setattr(helpers, "php_eval", fake_php_eval)
+    monkeypatch.setattr(helpers, "pkg_installed", fake_pkg_installed)
+    monkeypatch.setattr(helpers, "apply_filter_sync", fake_apply_filter_sync)
+
+    vm = _FakeVM(result=_FakeResult(returncode=0))
+    helpers.restore_pfb_config_baseline(vm, snapshot_path=_SNAPSHOT_PATH)  # type: ignore[arg-type]
+
+    clear_calls = [c for c in vm.calls if "clearip" in c or "cleardnsbl" in c]
+    assert clear_calls == [], f"expected no clearip/cleardnsbl ssh calls when pkg not installed, got {clear_calls!r}"
+    assert len(apply_filter_sync_calls) == 1, (
+        f"expected apply_filter_sync to still run once, got {len(apply_filter_sync_calls)} calls"
+    )
+
+
+@pytest.mark.parametrize(
+    "eval_result",
+    [
+        _FakeResult(returncode=1, stdout="OK", stderr="pfSsh.php: syntax error"),
+        _FakeResult(returncode=0, stdout="no sentinel here"),
+    ],
+    ids=["nonzero-rc", "rc-zero-missing-OK-sentinel"],
+)
+def test_restore_php_eval_failure_raises_and_skips_apply_filter_sync(
+    monkeypatch: pytest.MonkeyPatch, eval_result: _FakeResult
+) -> None:
+    """(n) A failed services_unbound_configure eval -- either a non-zero pfSsh.php exit OR an
+    'OK' sentinel missing from stdout -- raises RuntimeError and never reaches
+    apply_filter_sync (a resolver reconfigure that did not actually succeed must not be
+    followed by a filter sync as if it had)."""
+    apply_filter_sync_calls: list[object] = []
+
+    def fake_php_eval(vm: object, snippet: str, *, timeout: float = 60.0) -> _FakeResult:
+        return eval_result
+
+    def fake_apply_filter_sync(vm: object, *, timeout: float = 60.0) -> None:
+        apply_filter_sync_calls.append(vm)
+
+    monkeypatch.setattr(helpers, "php_eval", fake_php_eval)
+    monkeypatch.setattr(helpers, "apply_filter_sync", fake_apply_filter_sync)
+
+    vm = _FakeVM(result=_FakeResult(returncode=0))
+    with pytest.raises(RuntimeError, match=r"restore_pfb_config_baseline"):
+        helpers.restore_pfb_config_baseline(vm, snapshot_path=_SNAPSHOT_PATH)  # type: ignore[arg-type]
+    assert apply_filter_sync_calls == [], (
+        f"apply_filter_sync must not run after a failed php_eval, got calls={apply_filter_sync_calls!r}"
+    )


### PR DESCRIPTION
Implements the deferred #576 keystone STEP 5 (#582 section C): per-test config isolation for the ADR-14 UI tier, which shares one session-scoped login+box across ~170 mutating `ui_e2e`/`ui_browser` tests with no reset mechanism — `_pfb_module_baseline` excludes `tests/smoke/ui/` and pointed at a per-test mechanism that was never built.

## Design (sized for the performance concern on the issue)

An unconditional reset after every mutating test is unaffordable, so the autouse fixture `_ui_pfb_isolation` probes a **one-ssh config digest** at teardown (`helpers.pfb_config_digest`: md5 of `config.xml` with the volatile `<revision>` block stripped — false-dirty is safe, false-clean is not) and acts **only when a test actually left config dirty**:

- **Clean path** (most tests — the drive-form-back/finally-restore idiom): one `cat /conf/config.xml` over ssh, **~0.1s measured**.
- **Dirty path**: `helpers.restore_pfb_config_baseline` — copy back a guest-side `config.xml` snapshot taken at session baseline + drop `/tmp/config.cache` (the exact idiom upstream `config.lib.inc` uses on a config replace), then `services_unbound_configure` + `clearip`/`cleardnsbl` (package-presence gated) + a blocking `apply_filter_sync`. **~2.5s measured**, paid only by tests that genuinely leak (~40 in the functional leg).

Restore-to-session-baseline, **not** `reset_pfb_baseline`'s wipe-to-empty: the wipe fits the module-scoped smoke tier (each module re-establishes its infra) but under the UI tier's single session it deleted `pfb_dnsvip4`/ports with nothing left to re-add them, so every later `pfblockerng_dnsbl.php`/SafeSearch save failed `pfb_validate_vips` (run 28900064099, 23 functional + 1 browser failures — all reading back `''`). `deployed_vm` now establishes the DNSBL VIP once (idempotent), so it is part of the tier baseline; `browser_page` clears `localStorage`/`sessionStorage` per test (PHPSESSID untouched — it lives on the session-scoped `browser_context`).

Second commit fixes #964, found by this work: a2c5c26a routed section saves through the PfbConfig write adapters, so an unchecked `pfb_dnsbl_lenient` save stores the canonical `'off'` (verified: `pfb_cfg_lenient_write(pfb_cfg_lenient_read(''))` → `'off'`); the gateway roundtrip test still asserted the pre-adapter `''` vocabulary and failed on every browser dispatch since.

## Verification (live-VM dispatches, scope=full, CE + Plus)

Runs: 28907688229 (all tiers, isolation commit) + 28913116113 (browser tier, after the #964 test fix) — **all legs green**. Off-box: 14 new unit tests (digest semantics incl. hostile rows: no/second `<revision>` block, CRLF, empty, ssh-failure raise paths; restore sequence/guards), red→green executed both directions.

Wall clock, pytest step vs the last full-scope devel nightly (28851771590):

| leg | render | functional (`ui_e2e`) | browser |
|---|---|---|---|
| ce-2.8 | 69s → 70s | 318s → 620s | 132s → 148s |
| plus-26.03 | 66s → 68s | 389s → 706s | 128s → 157s |

The functional legs pay ~+5 min each — ~40 non-self-restoring tests × restore + 128 probes, plus the resolver reconfigures those restores trigger. These suites are dispatch-only (not PR-gating); a follow-up can shrink this by making the leaky tests self-restore.

Fixes #810.
Fixes #964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fh8xjHdECzVmC9Ed5TmD9p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fh8xjHdECzVmC9Ed5TmD9p)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI smoke isolation by detecting config drift and automatically restoring the UI baseline when tests mutate `/conf/config.xml`.
  * Hardened browser test cleanup by clearing per-origin storage to prevent cross-test leakage.

* **Tests**
  * Added dedicated unit coverage for UI config digesting and revision stripping, including multiple edge cases.
  * Extended restore/baseline sequencing tests and updated DNSBL UI behavior assertions to match canonical saved tokens.
  * Re-tagged affected UI rendering tests to run under the stricter isolation probe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->