### PR TITLE
Strip process narration and shrink oversized comments across src/ + scripts/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,10 @@ rationale lives in the ADR / architecture-notes and the comment carries a one-li
 (`// ADR-49: content-sanity gate; contract pinned by PfbTextSanityTest`) — never a
 restatement: a contract stored in ADR + comment + test is three copies, two of which drift.
 One-line regression breadcrumbs stay (`// issue #946: decode UTF-16 BOM first — else
-nul_bytes false-positives`). **Never in committed comments:** ADR **phase numbers**
+nul_bytes false-positives`). **Operational headers of executable scripts are interface
+documentation, not narration** — usage, options/params with defaults, env vars, examples
+stay in the header at full length unless the script itself prints an equivalent
+`--help`/usage. **Never in committed comments:** ADR **phase numbers**
 ("wired in Phase 4"), **`RESULTS/` handoff refs**, **review archaeology** (reviewer names,
 `PR #N` finding IDs, `review-fanout CN`), or correctness argument aimed at the gate/reviewer
 — that evidence belongs in the handoff / gate record / PR body, not the tree. Enforced on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,10 +342,14 @@ rationale lives in the ADR / architecture-notes and the comment carries a one-li
 (`// ADR-49: content-sanity gate; contract pinned by PfbTextSanityTest`) — never a
 restatement: a contract stored in ADR + comment + test is three copies, two of which drift.
 One-line regression breadcrumbs stay (`// issue #946: decode UTF-16 BOM first — else
-nul_bytes false-positives`). **Operational headers of executable scripts are interface
-documentation, not narration** — usage, options/params with defaults, env vars, examples
-stay in the header at full length unless the script itself prints an equivalent
-`--help`/usage. **Never in committed comments:** ADR **phase numbers**
+nul_bytes false-positives`). **Compression must never lose information: usage
+instructions and function-contract facts (params, returns, invariants, defaults) that
+are expressed nowhere else may be reworded tighter, never removed.** The budget bites
+hardest mid-code; a file header carrying interface documentation may run long.
+**Operational headers of executable scripts are interface documentation, not
+narration** — usage, options/params with defaults, env vars, examples stay in the
+header unless the script itself prints an equivalent `--help`/usage. **Never in
+committed comments:** ADR **phase numbers**
 ("wired in Phase 4"), **`RESULTS/` handoff refs**, **review archaeology** (reviewer names,
 `PR #N` finding IDs, `review-fanout CN`), or correctness argument aimed at the gate/reviewer
 — that evidence belongs in the handoff / gate record / PR body, not the tree. Enforced on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,7 @@ rationale lives in the ADR / architecture-notes and the comment carries a one-li
 (`// ADR-49: content-sanity gate; contract pinned by PfbTextSanityTest`) — never a
 restatement: a contract stored in ADR + comment + test is three copies, two of which drift.
 One-line regression breadcrumbs stay (`// issue #946: decode UTF-16 BOM first — else
-nul_bytes false-positives`). **Compression must never lose information: usage
+nul_bytes false-positives`). **Compression sheds redundancy, never essential information: usage
 instructions and function-contract facts (params, returns, invariants, defaults) that
 are expressed nowhere else may be reworded tighter, never removed.** The budget bites
 hardest mid-code; a file header carrying interface documentation may run long.

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -4,7 +4,7 @@
 # boot-time repo-conf generator rc.d hook (ADR-39), which does ALL edition/
 # version/arch detection itself (an OS upgrade self-corrects, no work here),
 # runs the hook once now, then `pkg update` + verifies the package is visible
-# from OUR repo. Default sets up the shared `pfblockerng` release repo (stable
+# from the pfBlockerNG repo. Default sets up the shared `pfblockerng` release repo (stable
 # + devel; pick the package at install time); --nightly sets up the separate
 # bleeding-edge `pfblockerng-nightly` repo instead. Idempotent; see --help.
 
@@ -125,7 +125,7 @@ print_conf() {
 # fully resolved for this box's edition/version/arch (ADR-39); the boot
 # rc.d hook updates it on a pfSense OS upgrade.
 # priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo
-# resolution (pkg install/upgrade, GUI Install) selects our build.
+# resolution (pkg install/upgrade, GUI Install) selects the pfBlockerNG build.
 ${REPO_NAME}: {
   url: "${_pc_url}",
   mirror_type: none,
@@ -197,13 +197,13 @@ fi
 printf '==> Conf resolved:\n'
 sed -n 's/^[[:space:]]*url:[[:space:]]*/    url: /p' "${CONF_PATH}" >&2
 
-# 5. pkg update (refresh catalogs, including our repo).
-printf '==> pkg update (refreshing catalogs, including our repo)\n'
+# 5. pkg update (refresh catalogs, including the pfBlockerNG repo).
+printf '==> pkg update (refreshing catalogs, including the pfBlockerNG repo)\n'
 env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" update -f >/dev/null
 
-# 6. VERIFY a pfBlockerNG package is visible FROM OUR repo (not merely that pkg
+# 6. VERIFY a pfBlockerNG package is visible FROM the pfBlockerNG repo (not merely that pkg
 #    update ran). `pkg rquery -r <repo>` queries that ONE repo's catalog; a hit
-#    means our catalog loaded and carries the package. The release repo carries
+#    means the pfBlockerNG catalog loaded and carries the package. The release repo carries
 #    two (stable may not be published yet) — finding EITHER proves the repo
 #    loaded; nightly carries one. Exit non-zero (fail loud) only if NONE present.
 printf '==> Verifying pfBlockerNG package(s) are visible from repo '\''%s'\''\n' "${REPO_NAME}"

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -1,64 +1,12 @@
 #!/bin/sh
 # add-repo.sh — bootstrap pfBlockerNG's self-hosted pkg repository on a pfSense
-# box (ADR-17 Phase 4, the client side). Run it ON the pfSense box. It installs
-# the boot-time repo-conf generator rc.d hook (ADR-39), stubs the repo conf so
-# the hook regenerates it for THIS box's edition/version/arch, runs the hook
-# once to resolve the conf now, then runs `pkg update` and VERIFIES our package
-# is visible from OUR repo — after which
-#   pkg install pfSense-pkg-pfBlockerNG-devel   (or -y, no -f, no -r)
-# resolves deps and installs our build, and the stock webConfigurator Install
-# pulls it too via cross-repo resolution (ADR §2; install is not repo-locked).
-#
-# WHY A HOOK DOES THE DETECTION: a pfSense OS upgrade can change the box's
-# edition/version/arch (which moves the catalog subtree). The rc.d hook
-# regenerates the conf every boot, so the URL self-corrects after an upgrade
-# with no work here. add-repo.sh therefore does NO detection itself — it installs
-# the hook and runs it; the hook is the single source of the resolved conf.
-#
-# CHANNELS
-#   Default (NO argument) sets up the RELEASE repo `pfblockerng` — one shared catalog
-#   carrying BOTH the stable and devel packages, exactly like Netgate ships
-#   `pfSense-pkg-pfBlockerNG` and `-devel` from its single `pfSense` repo (the two
-#   packages CONFLICT — install one). After the bootstrap, pick the package:
-#       pkg install pfSense-pkg-pfBlockerNG          # stable
-#       pkg install pfSense-pkg-pfBlockerNG-devel    # development tree
-#
-#   --nightly sets up the SEPARATE `pfblockerng-nightly` repo instead (its own
-#   `nightly/` catalog path). Bleeding edge — NOT for daily use: the only guarantee is
-#   that CI passed (devel still carries a stability target; nightly does not):
-#       pkg install pfSense-pkg-pfBlockerNG-nightly
-#
-#   default     -> conf /usr/local/etc/pkg/repos/pfblockerng.conf,         repo `pfblockerng`
-#   --nightly   -> conf /usr/local/etc/pkg/repos/pfblockerng-nightly.conf, repo `pfblockerng-nightly`
-#
-# THE CONF (single source of truth — byte-identical to `build-repo.sh --print-conf`,
-# `build-repo-portable.py --print-conf`, and what the rc.d hook writes):
-#   url:            Direct GitHub Pages URL, fully resolved by the hook for this box:
-#                   https://pfblockerng.github.io/pkg/<channel>/<varver>/<arch>
-#   mirror_type:    none.
-#   signature_type: none — NONE-signed; trust anchor is HTTPS to the host (no CI
-#                   signing key). pfSense honors per-repo `none` (ADR §1 Context 4).
-#   priority:       ABOVE the base Netgate `pfSense` repo (ships 0). Phase 1 PROVED
-#                   repo priority decides cross-repo selection (a higher-priority
-#                   repo wins even at a lower version), so this is what makes our
-#                   build win. 100 clears pfSense's 0 with margin.
-#   enabled:        yes.
-#
-# IDEMPOTENT: re-running reinstalls the hook and re-runs it (safe at any time).
-#
-# Usage:
-#   add-repo.sh                       # set up the release repo (stable + devel), pkg update, verify
-#   add-repo.sh --nightly             # set up the nightly repo instead (bleeding edge)
-#   add-repo.sh --print-conf [--nightly] [--catalog-path <varver>/<arch>]
-#                                     # print the conf to stdout and exit (no writes)
-#   add-repo.sh --base-url <url> [--nightly]   # override the catalog base (forks/staging)
-#
-# POSIX sh; quoted expansions; absolute path for the privileged `pkg` binary.
-# Env:
-#   PFBLOCKERNG_ROOT  filesystem root prefix (default: /); override in tests to
-#                     redirect conf/hook writes to a temp dir.
-#   PKG_BIN           pkg binary path (default: /usr/local/sbin/pkg); override
-#                     in tests to stub out pkg.
+# box (ADR-17, the client side). Run it ON the pfSense box: installs the
+# boot-time repo-conf generator rc.d hook (ADR-39), which does ALL edition/
+# version/arch detection itself (an OS upgrade self-corrects, no work here),
+# runs the hook once now, then `pkg update` + verifies the package is visible
+# from OUR repo. Default sets up the shared `pfblockerng` release repo (stable
+# + devel; pick the package at install time); --nightly sets up the separate
+# bleeding-edge `pfblockerng-nightly` repo instead. Idempotent; see --help.
 
 set -eu
 

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -1,12 +1,56 @@
 #!/bin/sh
 # add-repo.sh — bootstrap pfBlockerNG's self-hosted pkg repository on a pfSense
-# box (ADR-17, the client side). Run it ON the pfSense box: installs the
-# boot-time repo-conf generator rc.d hook (ADR-39), which does ALL edition/
-# version/arch detection itself (an OS upgrade self-corrects, no work here),
-# runs the hook once now, then `pkg update` + verifies the package is visible
-# from the pfBlockerNG repo. Default sets up the shared `pfblockerng` release repo (stable
-# + devel; pick the package at install time); --nightly sets up the separate
-# bleeding-edge `pfblockerng-nightly` repo instead. Idempotent; see --help.
+# box (ADR-17, the client side). Run it ON the pfSense box. It installs the
+# boot-time repo-conf generator rc.d hook (ADR-39), stubs the repo conf so the
+# hook regenerates it for THIS box's edition/version/arch, runs the hook once
+# to resolve the conf now, then runs `pkg update` and VERIFIES the package is
+# visible from the pfBlockerNG repo — after which
+#   pkg install pfSense-pkg-pfBlockerNG-devel   (or -y, no -f, no -r)
+# resolves deps and installs the pfBlockerNG build, and the stock
+# webConfigurator Install pulls it too via cross-repo resolution (ADR §2;
+# install is not repo-locked). Invocation forms: see --help.
+#
+# WHY A HOOK DOES THE DETECTION: a pfSense OS upgrade can change the box's
+# edition/version/arch (which moves the catalog subtree). The rc.d hook
+# regenerates the conf every boot, so the URL self-corrects after an upgrade
+# with no work here. add-repo.sh therefore does NO detection itself — it installs
+# the hook and runs it; the hook is the single source of the resolved conf.
+#
+# CHANNELS
+#   Default (NO argument) sets up the RELEASE repo `pfblockerng` — one shared catalog
+#   carrying BOTH the stable and devel packages, exactly like Netgate ships
+#   `pfSense-pkg-pfBlockerNG` and `-devel` from its single `pfSense` repo (the two
+#   packages CONFLICT — install one, see --help).
+#
+#   --nightly sets up the SEPARATE `pfblockerng-nightly` repo instead (its own
+#   `nightly/` catalog path). Bleeding edge — NOT for daily use: the only guarantee is
+#   that CI passed (devel still carries a stability target; nightly does not):
+#       pkg install pfSense-pkg-pfBlockerNG-nightly
+#
+#   default     -> conf /usr/local/etc/pkg/repos/pfblockerng.conf,         repo `pfblockerng`
+#   --nightly   -> conf /usr/local/etc/pkg/repos/pfblockerng-nightly.conf, repo `pfblockerng-nightly`
+#
+# THE CONF (single source of truth — byte-identical to `build-repo.sh --print-conf`,
+# `build-repo-portable.py --print-conf`, and what the rc.d hook writes):
+#   url:            Direct GitHub Pages URL, fully resolved by the hook for this box:
+#                   https://pfblockerng.github.io/pkg/<channel>/<varver>/<arch>
+#   mirror_type:    none.
+#   signature_type: none — NONE-signed; trust anchor is HTTPS to the host (no CI
+#                   signing key). pfSense honors per-repo `none` (ADR §1 Context 4).
+#   priority:       ABOVE the base Netgate `pfSense` repo (ships 0). Repo priority
+#                   decides cross-repo selection (a higher-priority repo wins even
+#                   at a lower version — proven in ADR-17), so this is what makes
+#                   the pfBlockerNG build win. 100 clears pfSense's 0 with margin.
+#   enabled:        yes.
+#
+# IDEMPOTENT: re-running reinstalls the hook and re-runs it (safe at any time).
+#
+# POSIX sh; quoted expansions; absolute path for the privileged `pkg` binary.
+# Env:
+#   PFBLOCKERNG_ROOT  filesystem root prefix (default: /); override in tests to
+#                     redirect conf/hook writes to a temp dir.
+#   PKG_BIN           pkg binary path (default: /usr/local/sbin/pkg); override
+#                     in tests to stub out pkg.
 
 set -eu
 

--- a/scripts/bench_pfctl_tables.sh
+++ b/scripts/bench_pfctl_tables.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# bench_pfctl_tables.sh — ADR-40 Phase 2: pfctl table benchmark harness (guest side).
+# bench_pfctl_tables.sh — ADR-40 pfctl table benchmark harness (guest side).
 #
 # Runs ON the pfSense guest (as root, via SSH from the pytest harness).
 # Outputs: key=val lines to stdout; progress/diagnostics to stderr.

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -753,7 +753,7 @@ def print_conf(resolved_url: str) -> None:
         "# fully resolved for this box's edition/version/arch (ADR-39); the boot\n"
         "# rc.d hook updates it on a pfSense OS upgrade.\n"
         f"# priority {CONF_PRIORITY} sits above the base Netgate `pfSense` repo so cross-repo\n"
-        "# resolution (pkg install/upgrade, GUI Install) selects our build.\n"
+        "# resolution (pkg install/upgrade, GUI Install) selects the pfBlockerNG build.\n"
         "pfblockerng: {\n"
         f'  url: "{url}",\n'
         "  mirror_type: none,\n"

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -4,9 +4,11 @@
 # for a plain Linux CI runner with no real `pkg` binary, hand-rolling the same
 # catalog `pkg repo` produces (meta.conf/packagesite.pkg/data.pkg, incl. the
 # libpkg `sum` checksum — see pkg_checksum()) from each .pkg's manifest,
-# deterministically and without network. FLAVOR-COLLISION GUARD, version-keyed
-# catalogs (ADR-20), the matrix-driven build, and release retention are each
-# documented at their own function; see --help for full CLI usage.
+# deterministically and without network. (scripts/build-repo.sh drives a real
+# `pkg repo` and stays the FreeBSD/pfSense-side fallback; this is the CI/release
+# builder.) FLAVOR-COLLISION GUARD, version-keyed catalogs (ADR-20), the
+# matrix-driven build, and release retention are each documented at their own
+# function; see --help for full CLI usage.
 
 from __future__ import annotations
 

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -1,94 +1,12 @@
 #!/usr/bin/env python3
 # build-repo-portable.py — turn a directory of pfBlockerNG .pkg files into a
-# per-ABI FreeBSD `pkg` repository tree WITHOUT libpkg or the `pkg` binary, in
-# pure Python (stdlib + the `zstd` binary, exactly like scripts/build-pkg-portable.py).
-# ADR-17 Phase 3a. This is the catalog generator the Phase-3b publish job runs on
-# a plain Linux runner that has NO libpkg.
-#
-# WHY A PURE-PYTHON GENERATOR
-#   `pkg repo` is a libpkg op. On FreeBSD (or the pfSense VM) `pkg` is present —
-#   scripts/build-repo.sh (Phase 2) drives it and STAYS the FreeBSD-VM fallback.
-#   On a plain Linux runner there is no apt `pkg` and no official prebuilt; the
-#   Phase-2 path needs `pkg` built from source + an ABI forced in the env. So,
-#   mirroring how build-pkg-portable.py hand-rolls the .pkg archive in pure Python,
-#   this tool hand-rolls the REPOSITORY CATALOG: it reads each .pkg's manifest
-#   directly (no libpkg, no ABI guessing) and emits a `pkg`-format catalog a real
-#   pfSense `pkg update`/`pkg install` accepts.
-#
-# WHAT IT EMITS (verified byte-structurally against real `pkg repo` output — see
-# ADR-17 RESULTS/03a): for each distinct ABI, under <out>/<ABI>/:
-#   * the input .pkg file(s),
-#   * meta.conf  (+ an identical copy named `meta`) — the catalog descriptor:
-#       version = 2; packing_format = "tzst"; manifests = "packagesite.yaml";
-#       data = "data"; filesite = "files"; manifests_archive = "packagesite";
-#       filesite_archive = "files";
-#   * packagesite.pkg — a zstd-compressed tar holding `packagesite.yaml`:
-#       newline-delimited JSON, ONE object per package = that pkg's
-#       +COMPACT_MANIFEST plus the repo fields `sum`/`flatsize`/`path`/`repopath`/
-#       `pkgsize` libpkg injects, in libpkg's field order.
-#   * data.pkg — a zstd-compressed tar holding `data`:
-#       {"groups":[], "expired_packages":[], "packages":[<the same objects>]}.
-#
-# THE `sum` FIELD (load-bearing — `pkg install` validates the downloaded .pkg
-# against it): libpkg checksum type 2 = `2$` + z-base-32(blake2b(file)). blake2b
-# is the 64-byte default digest; the base32 is z-base-32 (alphabet
-# "ybndrfg8ejkmcpqxot1uwisza345h769") packed LSB-first. Reproduced exactly here
-# (cracked against a real `pkg repo` oracle), so a real box accepts the .pkg.
-#
-# Deterministic + re-runnable + NO network: same inputs -> byte-identical tree;
-# a re-run wipes and rebuilds each ABI bucket so a removed .pkg never lingers.
-#
-# FLAVOR-COLLISION GUARD: identical to build-repo.sh — two .pkg sharing
-# name+version+ABI but differing in php/py flavor (their php*/python*/py*-
-# dependency names) CANNOT coexist in one catalog (the second would silently
-# shadow the first). We FAIL LOUD (exit 1) rather than drop a build. Whether a
-# colliding combo exists depends on the ci-metadata version matrix (two entries
-# sharing a full ABI — FreeBSD major AND arch — with different php/py flavors);
-# the fix when one arises is a flavored layout <out>/<ABI>-<php><py>/,
-# intentionally NOT implemented here.
-#
-# VERSION-KEYED CATALOG DIRS (ADR-20 Phase 3)
-#   Pass --catalog-name <name> (e.g. "ce-2.8", "plus-26.03") to write the catalog
-#   under <out>/<catalog-name>/<ABI>/ instead of <out>/<ABI>/.
-#   When absent, behaviour is UNCHANGED (writes to <ABI>/ — the legacy path).
-#
-#   Catalog name derivation rule (use catalog_name_from_version()):
-#     Both CE and Plus strip any trailing patch component, taking only major.minor:
-#       "2.8.1"  + "CE"   -> "ce-2.8"
-#       "2.8.x"  + "CE"   -> "ce-2.8"
-#       "26.03"  + "Plus" -> "plus-26.03"
-#       "26.03.1"+ "Plus" -> "plus-26.03"
-#
-#   The publish pipeline loops over all active ci-metadata entries and calls this
-#   tool once per entry with the appropriate --catalog-name. Each versioned subdir
-#   is self-contained; multiple coexist under the same <out> root.
-#
-# MATRIX-DRIVEN BUILD — the BRAIN
-#   Pass --build-matrix --matrix-json <file|-> --out <dir> to drive the DUMB
-#   build-pkg-portable.py per (matrix entry × channel) and project the version matrix
-#   1:1 onto the tree:
-#       release/<variant>-<major.minor>/<arch>/<catalog files>   (devel + stable)
-#       nightly/<variant>-<major.minor>/<arch>/<catalog files>   (retained to N)
-#   The LEAF is the bare arch (amd64/aarch64) — the version segment already implies
-#   the FreeBSD major, and each .pkg's manifest carries its real ABI.
-#   Also callable from Python as build_repo_matrix(...).
-#
-# Requires: python3 (stdlib only) + a zstd encoder (the `zstd` binary, or the
-# python `zstandard` module) — the same compressor contract as build-pkg-portable.py.
-#
-# Usage:
-#   build-repo-portable.py --in <dir-of-.pkg> --out <dir>   # build the per-ABI tree
-#   build-repo-portable.py --in <dir> --out <dir> --catalog-name ce-2.8  # versioned
-#   build-repo-portable.py --print-conf [--base-url <url>]  # print the client repo-conf
-#
-# RELEASE RETENTION (ADR-27 Phase 2)
-#   --release-keep-devel N   retain the N newest devel releases per ABI (default 1 = latest-only)
-#   --release-keep-stable M  retain the M newest stable releases per ABI (default 1 = latest-only)
-#   --release-extra-pkgs <path>  (repeatable) pre-built older-release .pkg to fold in alongside
-#     the fresh build; publish.yml downloads these from GitHub Releases and passes them here.
-#   Defaults (N=M=1) reproduce today's behaviour; set higher values to enable rollback.
-#
-# This is a developer tool (not shipped in release archives). See --help.
+# per-ABI FreeBSD `pkg` repository tree WITHOUT libpkg, in pure Python (ADR-17):
+# for a plain Linux CI runner with no real `pkg` binary, hand-rolling the same
+# catalog `pkg repo` produces (meta.conf/packagesite.pkg/data.pkg, incl. the
+# libpkg `sum` checksum — see pkg_checksum()) from each .pkg's manifest,
+# deterministically and without network. FLAVOR-COLLISION GUARD, version-keyed
+# catalogs (ADR-20), the matrix-driven build, and release retention are each
+# documented at their own function; see --help for full CLI usage.
 
 from __future__ import annotations
 
@@ -122,17 +40,14 @@ META_CONF = (
     'filesite_archive = "files";\n'
 )
 
-# The shared client repo-conf template (the SINGLE source Phase 4's add-repo.sh +
-# the README reuse). Kept byte-identical to scripts/build-repo.sh --print-conf so
-# the two generators are interchangeable. ${ABI} is the literal pkg(8) variable
-# (expanded by pkg, not the shell), so one conf follows the box across an OS
-# upgrade; priority 100 sits above the base Netgate `pfSense` repo (priority 0) —
-# Phase 1 proved priority dominates version, so this is the precedence lever.
-# The published GitHub Pages base — the repo's standard project Pages URL, and the
-# canonical client conf base (ADR-39; the Cloudflare Worker has been retired). The
-# per-box conf URL resolves to <base>/<channel>/<varver>/<arch>, regenerated by the
-# rc.d hook on an OS upgrade. Kept identical to scripts/build-repo.sh / add-repo.sh
-# DEFAULT_BASE_URL so all three generators emit a byte-equal --print-conf.
+# The shared client repo-conf template — kept byte-identical to
+# scripts/build-repo.sh / add-repo.sh --print-conf (pinned by
+# tests/test_add_repo_conf.py) so all three generators are interchangeable.
+# ${ABI} is the literal pkg(8) variable (expanded by pkg, never the shell), so
+# one conf follows the box across an OS upgrade; priority 100 sits above the
+# base Netgate `pfSense` repo (priority 0) because priority — not version —
+# decides cross-repo resolution. Base URL is this repo's GitHub Pages root
+# (ADR-39; the Cloudflare Worker has been retired).
 DEFAULT_BASE_URL = "https://pfblockerng.github.io/pkg"
 CONF_PRIORITY = 100
 
@@ -153,7 +68,7 @@ class BuildRepoError(Exception):
 # blake2b default digest = 64 bytes; z-base-32 (RFC-less human base32, alphabet
 # "ybndrfg8ejkmcpqxot1uwisza345h769") packs the bit stream LSB-FIRST within each
 # byte — matching libpkg's pkg_checksum_encode_base32(). Cracked against a real
-# `pkg repo` oracle (RESULTS/03a). 64 bytes -> 103 base32 chars (ceil(64*8/5)).
+# `pkg repo` oracle. 64 bytes -> 103 base32 chars (ceil(64*8/5)).
 # --------------------------------------------------------------------------- #
 
 _ZBASE32 = "ybndrfg8ejkmcpqxot1uwisza345h769"
@@ -325,7 +240,7 @@ def _check_collisions(entries: list[tuple[Path, dict]]) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# ADR-20 Phase 3: catalog name derivation + routing manifest
+# ADR-20: catalog name derivation + routing manifest
 # --------------------------------------------------------------------------- #
 
 
@@ -446,25 +361,13 @@ def _write_catalog_dir(dest: Path, items: dict[tuple[str, str], tuple[Path, dict
 
 
 # --------------------------------------------------------------------------- #
-# ADR-20 routing rework: the matrix-driven BRAIN
-#
-# build_repo_matrix() is the single orchestrator. It reads the ci-metadata version
-# matrix and, per (entry × channel), drives the DUMB build-pkg-portable.py builder,
-# places each .pkg into a literal 1:1 projection of the matrix —
-#     release/<variant>-<major.minor>/<arch>/<catalog files>
-#     nightly/<variant>-<major.minor>/<arch>/<catalog files>
-# — generates each subtree's catalog.
-#
-# Layout decisions (maintainer-confirmed):
-#   * channel-group "release" = the production (stable-tag) + devel packages in ONE
-#     catalog (Netgate-style; both coexist). "nightly" = nightly only, retained to N.
-#   * the version segment = catalog_name_from_version() ("ce-2.8" / "plus-26.03").
-#   * the LEAF is the bare ARCH (amd64 / aarch64), NOT the full ABI: the version
-#     segment already implies the FreeBSD major, and each .pkg's real ABI lives in
-#     its own manifest (pkg validates the ABI from the package), so the directory is
-#     purely the routing path.
-#   * FULL MATRIX, NO DEDUP — each entry populates its own (version, arch) subtree
-#     independently, even if two pfSense versions share ABI+PHP+PY.
+# ADR-20: the matrix-driven BRAIN. build_repo_matrix() drives the DUMB
+# build-pkg-portable.py builder per (ci-metadata entry x channel) and projects
+# the matrix 1:1 onto release/<variant>-<major.minor>/<arch>/... (stable+devel,
+# one catalog) and nightly/<variant>-<major.minor>/<arch>/... (retained to N).
+# The leaf is the bare ARCH, not the full ABI (the version segment already
+# implies the FreeBSD major; each .pkg's real ABI lives in its own manifest).
+# FULL MATRIX, NO DEDUP: every entry gets its own subtree.
 # --------------------------------------------------------------------------- #
 
 
@@ -865,14 +768,14 @@ def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(
         prog="build-repo-portable.py",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="Generate a per-ABI FreeBSD pkg repository catalog in pure Python (no libpkg). ADR-17 Phase 3a.",
+        description="Generate a per-ABI FreeBSD pkg repository catalog in pure Python (no libpkg). ADR-17.",
         epilog=(
             "examples:\n"
             "  # build a catalog tree from a dir of release .pkg\n"
             "  build-repo-portable.py --in ./pkgs --out ./site\n\n"
             "  # build under a version-keyed subdir (ADR-20)\n"
             "  build-repo-portable.py --in ./pkgs --out ./site --catalog-name ce-2.8\n\n"
-            "  # print the client repo-conf (Phase 4 add-repo.sh + README reuse it)\n"
+            "  # print the client repo-conf (add-repo.sh + README reuse it)\n"
             "  build-repo-portable.py --print-conf --base-url https://example.github.io/pkg\n\n"
             "  # matrix-driven: build the full variant/arch tree (ADR-20)\n"
             "  read-version-matrix.sh --print-build | build-repo-portable.py --build-matrix \\\n"

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -33,7 +33,7 @@ set -eu
 # (expanded by pkg itself, never shell-interpolated), so one conf auto-follows
 # an OS upgrade. priority sits above the base Netgate `pfSense` repo (ships 0)
 # because priority — not version — decides cross-repo resolution; that is the
-# lever that makes our build win. Override the base with --base-url for a fork.
+# lever that makes the pfBlockerNG build win. Override the base with --base-url for a fork.
 DEFAULT_BASE_URL="https://pfblockerng.github.io/pkg"
 CONF_PRIORITY=100
 
@@ -50,7 +50,7 @@ print_conf() {
 # fully resolved for this box's edition/version/arch (ADR-39); the boot
 # rc.d hook updates it on a pfSense OS upgrade.
 # priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo
-# resolution (pkg install/upgrade, GUI Install) selects our build.
+# resolution (pkg install/upgrade, GUI Install) selects the pfBlockerNG build.
 pfblockerng: {
   url: "${base}",
   mirror_type: none,

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -1,41 +1,12 @@
 #!/bin/sh
 # build-repo.sh — turn a directory of pfBlockerNG .pkg files into a per-ABI
-# FreeBSD `pkg` repository tree (ADR-17 Phase 2). This is the reusable, proven
-# catalog generator the Phase-3 publish job calls over the .pkg assets ADR-09
-# attaches to each GitHub Release.
-#
-# WHAT IT DOES
-#   1. Reads each input .pkg's ABI FROM THE PACKAGE (`pkg query -F <f> '%q'`) —
-#      never guessed from the filename.
-#   2. Buckets each .pkg under  <out>/release/<ABI>/  (the release channel subtree,
-#      one catalog per ABI, e.g. <out>/release/FreeBSD:15:amd64/) and copies the
-#      .pkg there — symmetric with the nightly/ subtree
-#      (ADR-20), so a conf url with the explicit `release/${ABI}` prefix resolves.
-#   3. Runs `pkg repo <out>/release/<ABI>` per bucket with NO signing key, emitting the
-#      catalog triple (meta.conf / packagesite.pkg / data.pkg) a client
-#      `pkg update` consumes. NONE-signed by construction (the ADR trust model:
-#      TLS to the host, no CI key — ADR §2 "Trust model").
-#   4. Optionally prints the shared client repo-conf TEMPLATE (`--print-conf`):
-#      the single `${ABI}` / NONE-signed / above-pfSense-priority stanza Phase 4's
-#      add-repo.sh and the README reuse.
-#
-# Deterministic + re-runnable + NO network: the same inputs yield the same tree;
-# a re-run wipes and rebuilds each ABI bucket so a removed .pkg never lingers.
-#
-# FLAVOR-COLLISION GUARD: two .pkg sharing package-name + version + ABI but
-# differing in php/py flavor (their `php*`/`py*-*` dependency names) CANNOT
-# coexist in one catalog — the second would silently shadow the first. We FAIL
-# LOUD rather than drop a build. Whether a colliding combo exists depends on the
-# ci-metadata version matrix (two entries sharing a full ABI — FreeBSD major AND
-# arch — with different php/py flavors); when one ever arises, the fix is a flavored layout
-# `<out>/<ABI>-<php><py>/` (add-repo.sh would then detect + pin the box's flavor).
-# That split is intentionally NOT implemented here — see the guard below.
-#
-# LIBPKG PROVENANCE: `pkg repo` is a libpkg op needing the `pkg` binary. On
-# FreeBSD (or the pfSense VM) `pkg` is present. On a Linux CI runner it is NOT in
-# apt and has no official prebuilt — see RESULTS/02 for the libpkg-on-Linux vs
-# FreeBSD-VM-fallback verdict that decides where Phase 3 runs this. The script is
-# transport-agnostic: it only needs SOME `pkg` on PATH (override with PKG_BIN).
+# FreeBSD `pkg` repository tree (ADR-17): reads each .pkg's ABI FROM THE
+# PACKAGE (never the filename), buckets it under <out>/release/<ABI>/
+# (symmetric with the nightly/ subtree, ADR-20), and runs unsigned `pkg repo`
+# per bucket (NONE-signed trust model, ADR §2). Deterministic + re-runnable +
+# no network: each ABI bucket is wiped and rebuilt every run. A flavor
+# collision (same name+version+ABI, different php/py flavor) fails loud — see
+# the guard below. `pkg` must be a real libpkg build on PATH (override PKG_BIN).
 #
 # Usage:
 #   build-repo.sh --in <dir-of-.pkg> --out <dir>      # build the per-ABI tree
@@ -55,37 +26,14 @@
 
 set -eu
 
-# ── The shared client repo-conf template ───────────────────────────────────────
-#
-# The SINGLE source of the client stanza (Phase 4's add-repo.sh + the README
-# reuse this exact shape). Fields, per ADR §2 "Client bootstrap":
-#   * url:            STATIC base + the literal ${ABI} pkg variable (NO shell/query
-#                     interpolation) so one conf auto-follows the box's ABI across
-#                     an OS upgrade. ${ABI} is expanded by pkg(8), not the shell.
-#   * mirror_type: none / signature_type: none — NONE-signed; trust = HTTPS to the host.
-#   * priority:       ABOVE the base Netgate `pfSense` repo so cross-repo resolution
-#                     picks our build. Phase 1 PROVED priority dominates version (a
-#                     higher-priority repo wins even at a lower version), so this is
-#                     the real precedence lever. The pfSense repo ships priority 0 by
-#                     default; 100 clears it with margin while staying an ordinary
-#                     positive value (add-repo.sh may recompute it live, +100 over the
-#                     effective pfSense priority, the way the Phase-1 smoke does).
-#   * enabled: yes.
-# `pfblockerng` matches the shared release conf Phase 4 writes
-# (/usr/local/etc/pkg/repos/pfblockerng.conf) — the one repo that carries BOTH the
-# stable and devel packages (Netgate-style); only nightly gets its own conf.
-# The published GitHub Pages base — the repo's standard project Pages URL
-# (gh api repos/.../pages -> html_url https://pfblockerng.github.io/pkg/);
-# we serve over HTTPS, so the base is https://pfblockerng.github.io/pkg and the conf
-# appends the literal ${ABI} pkg(8) variable. Override with --base-url for a fork.
-# NOTE: the Pages tree also publishes VERSION-KEYED subdirs:
-#   https://pfblockerng.github.io/pkg/ce-2.8/${ABI}/   (CE 2.8.x)
-#   https://pfblockerng.github.io/pkg/plus-26.03/${ABI}/  (Plus 26.03)
-# The variant conf is written by add-repo.sh (install/self-heal) and points directly
-# to the versioned GitHub Pages URL for the box's variant — no intermediary layer.
-# This --print-conf template is kept in sync with add-repo.sh (byte-identical release
-# stanza — what `add-repo.sh stable` and `add-repo.sh devel` both write). Override with
-# --base-url for forks/staging.
+# ── The shared client repo-conf template ─────────────────────────────────────
+# Single source of the client stanza — add-repo.sh, build-repo-portable.py, and
+# the README reuse this exact shape (byte-identical; pinned by
+# tests/test_add_repo_conf.py). url carries the LITERAL ${ABI} pkg(8) variable
+# (expanded by pkg itself, never shell-interpolated), so one conf auto-follows
+# an OS upgrade. priority sits above the base Netgate `pfSense` repo (ships 0)
+# because priority — not version — decides cross-repo resolution; that is the
+# lever that makes our build win. Override the base with --base-url for a fork.
 DEFAULT_BASE_URL="https://pfblockerng.github.io/pkg"
 CONF_PRIORITY=100
 
@@ -129,7 +77,7 @@ while [ $# -gt 0 ]; do
         --base-url)      BASE_URL="$2"; shift 2 ;;
         --catalog-path)  CATALOG_PATH="$2"; shift 2 ;;
         -h|--help)
-            sed -n '37,57p' "$0"   # the Usage/Options/Env block from the header
+            sed -n '11,25p' "$0"   # the Usage/Options/Env block from the header
             exit 0 ;;
         *) echo "build-repo: unknown arg: $1" >&2; exit 2 ;;
     esac

--- a/scripts/check_comment_narration.py
+++ b/scripts/check_comment_narration.py
@@ -35,7 +35,8 @@ _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"RESULTS/"), "delegation handoff artifact (RESULTS/...)"),
     # Capitalised only: ADR narration always writes "Phase N"; ordinary prose
     # about a protocol's "phase 2" stays legal.
-    (re.compile(r"\bPhase [0-9]+\b"), "ADR phase narration (Phase N)"),
+    (re.compile(r"\bPhase[ -][0-9]+\b"), "ADR phase narration (Phase N)"),
+    (re.compile(r"\bADR-[0-9]+ P[0-9]+\b"), "ADR phase narration (ADR-NN PN)"),
     (re.compile(r"review-fanout", re.IGNORECASE), "review archaeology (review-fanout)"),
     (re.compile(r"\bPR ?#[0-9]+\b"), "review archaeology (PR #N)"),
 )

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -69,18 +69,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Each alternative is a full-value token shape (no anchors here -- anchors are
-# added once, around the whole alternation, at the two call sites below).
-#
-# Unambiguous shapes (FreeBSD ABI, php/py flavors, varvers) are version-AGNOSTIC:
-# a stale or future version restated as a literal is just as much a drift hazard
-# as a current one (issue #940). Only the bare CE/Plus numerics stay WINDOWED --
-# a generic decimal shape would false-positive on unrelated version numbers --
-# and that window is tripwired against the live matrix by --verify-matrix (a
-# blocking CI step): the moment supported-versions.json carries a version these
-# patterns no longer cover, CI fails loudly instead of the gate narrowing
-# silently. This file restating the window is otherwise the exact disease it
-# polices, in a file self-excluded from its own scan.
+# Each alternative is a full-value token shape (anchored once, at the
+# alternation, by the two call sites below). Unambiguous shapes (ABI/php/py/
+# varver) are version-AGNOSTIC -- any restated literal is a drift hazard
+# (issue #940). Only the bare CE/Plus numerics stay WINDOWED (an unbounded
+# decimal shape would false-positive on unrelated numbers); --verify-matrix
+# tripwires that window against the live matrix so it widens instead of
+# silently narrowing.
 _TOKEN_ALTERNATIVES = (
     r"2\.[89]",  # CE version window: 2.8 / 2.9 (tripwired)
     r"2[56]\.[0-9]{2}",  # Plus version window: 25.NN / 26.NN (tripwired)
@@ -88,59 +83,38 @@ _TOKEN_ALTERNATIVES = (
     r"php[0-9]{2}",  # php flavor: php74..php99
     r"py3[0-9]{2}",  # py flavor: py310..py399
     r"ce-[0-9]+\.[0-9]+",  # varver: ce-X.Y
-    r"plus-[0-9]+\.[0-9]+",  # varver: plus-X.Y (generalized like ce- — review-fanout C8, PR #947)
+    r"plus-[0-9]+\.[0-9]+",  # varver: plus-X.Y (generalized like ce-)
 )
 
-# ponytail: a flavor token embedded in a hardcoded package name (e.g.
-# "py311-sqlite3" outside the install_deps_* allowlist) is not caught -- this
-# checker only matches a token that is the WHOLE value. Upgrade to substring
-# matching if hardcoded dependency names spread beyond the allowlisted file.
+# ponytail: a flavor token embedded in a hardcoded name (e.g. "py311-sqlite3")
+# is not caught -- only whole-value tokens are; extend if that ever spreads.
 #
-# ponytail: the unquoted-RHS check (_ASSIGNMENT_RE) matches a single whole-line
-# `key: value` / `key=value` (optionally prefixed by a shell assignment builtin)
-# only. It does NOT catch a token in a compound statement (`A=x; B=y`) or an
-# unquoted YAML sequence item (`- FreeBSD:15:amd64` / `[a, b]`); none occur in
-# the tree and the spec scopes to key/value. A QUOTED token in any of these is
-# still caught by the quoted-literal path.
+# ponytail: _ASSIGNMENT_RE matches only a single whole-line key:value/key=value
+# -- misses compound statements/unquoted YAML sequences (a quoted token there still hits the quoted-literal path).
 #
-# ponytail: a quoted illustrative example inside a multi-line YAML folded/
-# literal scalar (`description: >` ... "e.g. \"2.8\"" on a continuation line)
-# is not recognised as prose -- only comments and Python triple-quoted
-# docstrings are tracked. The single such site today (version-tracker.yml) was
-# fixed by DE-QUOTING the example, because a `version-literal-ok` comment cannot
-# sit inside a folded-scalar body without corrupting the visible description.
-# Upgrade to a YAML block-scalar tracker (indentation-based, mirroring
-# _code_lines's docstring state machine) if more than one line ever needs it.
+# ponytail: a quoted example inside a multi-line YAML folded/literal scalar is
+# not recognised as prose (the one site was fixed by de-quoting instead).
 #
-# ponytail: XML comments (`<!-- -->`) are not tracked -- the scan roots hold 3
-# XML files with no version-token history; add a tracker if one ever bites.
-# Same for JS private fields (`this.#x`): `#` is treated as a comment opener
-# only in PHP-family files, so JS is safe from that, but a token inside a JS
-# regex literal containing `//` could be mis-stripped (2 JS files, none such).
+# ponytail: XML comments and JS private-field `#x` syntax are not tracked --
+# no version-token history in either today; add a tracker if one ever bites.
 _FULL_VALUE_RE = re.compile("^(?:" + "|".join(_TOKEN_ALTERNATIVES) + ")$")
-# Optional assignment-builtin prefix. The class is enumerated, not example-driven
-# (PR #937 pinned only the two keywords Copilot named -- issue #941): POSIX
-# `export`/`readonly`, the near-universal `local`, and bash/ksh
-# `declare`/`typeset` (with option words), which shellcheck bans here but a
-# hardcode guard should still see.
+# Optional assignment-builtin prefix. The class is enumerated, not example-
+# driven (issue #941): POSIX `export`/`readonly`, the near-universal `local`,
+# and bash/ksh `declare`/`typeset` (with option words), which shellcheck bans
+# here but a hardcode guard should still see.
 _ASSIGNMENT_RE = re.compile(
     r"^\s*(?:(?:export|readonly|local|declare|typeset)(?:\s+-\w+)*\s+)?"
     r"[\w.-]+\s*[:=]\s*(?:" + "|".join(_TOKEN_ALTERNATIVES) + r")\s*$"
 )
 
-# The double-quote side is escape-aware (\" is content in sh/php/js/py alike),
-# so an escaped quote does not mispair the spans and swallow a later literal
-# (Copilot, PR #947). The single-quote side is language-scoped: PHP/JS support
-# \' inside single quotes, so the C-style variant is escape-aware there too
-# (review-fanout C9, PR #947 — a \' earlier on the line mispaired the spans
-# and swallowed a later single-quoted token); POSIX sh has NO single-quote
-# escapes, so the shell/YAML variant keeps the naive single-quote side, which
-# is shell-correct. Both variants CONSUME backtick spans so quote pairing
-# cannot cross a backtick boundary (re-review F1, PR #947 — two backtick
-# segments each holding an odd quote count swallowed the value between them):
-# in the C-style variant the span is also CAPTURED (a JS template literal is a
-# value); in the shell variant it is consume-only (shell backticks are command
-# substitution, not a value literal).
+# The double-quote side is escape-aware (\" is content in sh/php/js/py alike)
+# so an escaped quote cannot mispair spans and swallow a later literal. The
+# single-quote side is language-scoped: PHP/JS support \', so that side is
+# escape-aware too there; POSIX sh has none, so the shell/YAML variant stays
+# naive (shell-correct). Both variants CONSUME backtick spans so quote pairing
+# never crosses one; the C-style variant also CAPTURES that span (a JS
+# template literal is a value), the shell variant does not (backticks are
+# command substitution, not a value).
 _QUOTED_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|\'([^\']*)\'|`(?:[^`\\]|\\.)*`')
 _QUOTED_C_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|\'((?:[^\'\\]|\\.)*)\'|`((?:[^`\\]|\\.)*)`')
 
@@ -189,8 +163,8 @@ def _strip_inline_comment(line: str) -> str:
     a full comment line, just not confined to the start of the line. A ``#``
     INSIDE a quoted string is left alone (rare, but real content). Inside a
     DOUBLE-quoted string a backslash escapes the next char, so an escaped
-    quote does not mis-close the string (Copilot, PR #947); single quotes stay
-    escape-free -- POSIX sh has no escapes there.
+    quote does not mis-close the string; single quotes stay escape-free --
+    POSIX sh has no escapes there.
     """
     quote: str | None = None
     i = 0
@@ -220,19 +194,17 @@ def _split_c_comment(line: str, hash_comments: bool) -> tuple[str, bool]:
 
     Quote-aware: ``//``, ``/*`` and ``#`` inside a quoted string are content,
     not comments, and a backslash inside a quoted string escapes the next char
-    (PHP/JS support ``\\'``/``\\"`` in both quote types -- Copilot, PR #947),
-    so an escaped quote does not mis-close the string. Backticks are tracked
-    as a third quote type (review-fanout C5, PR #947): a JS template literal
-    (or PHP shell-exec string) containing ``//`` must not truncate the scan of
-    real code after it. A ``/*...*/`` pair closed on the same line is dropped
-    and the code after it is kept. ``hash_comments`` enables ``#`` (PHP family
-    only -- in JS, ``#`` is a private-field sigil).
+    (PHP/JS support ``\\'``/``\\"`` in both quote types), so an escaped quote
+    does not mis-close the string. Backticks are tracked as a third quote
+    type: a JS template literal (or PHP shell-exec string) containing ``//``
+    must not truncate the scan of real code after it. A ``/*...*/`` pair
+    closed on the same line is dropped and the code after it is kept.
+    ``hash_comments`` enables ``#`` (PHP family only -- in JS, ``#`` is a
+    private-field sigil).
 
-    ponytail: quote state is per-line -- a PHP/JS string spanning physical
-    lines without heredoc can hide a value on its continuation line
-    (review-fanout C6; none in the tree, house style uses single-line strings
-    or heredoc). Carry the open quote across lines like ``in_block`` if that
-    ever bites.
+    ponytail: quote state is per-line, so a multi-line PHP/JS string (no
+    heredoc) could hide a value on a continuation line (none today) -- carry
+    the open quote across lines like ``in_block`` if that ever bites.
     """
     out: list[str] = []
     quote: str | None = None
@@ -305,16 +277,14 @@ def _code_lines(lines: list[str], suffix: str) -> list[str | None]:
     * everything else: ``#`` line/trailing comments.
     * ``.py`` additionally tracks triple-quoted docstrings: an ODD number of
       triple-quote tokens toggles the docstring state (a close-and-reopen on
-      one line therefore stays open -- the PR #937 parity bug, issue #941),
-      while an EVEN count on a non-docstring line falls through to the value
-      scan, so a one-line triple-quoted assignment (X = triple-quoted token)
-      is caught by the quoted-literal path instead of being swept as prose
-      (the ``.py`` mirror of PR #937's blocking F1). ponytail: a one-line
-      module docstring whose ENTIRE text is a bare token would now
-      false-positive -- absurd corner, escape-comment it if it ever occurs.
-      This is deliberately NOT applied to shell/YAML: a shell value wrapped in
-      triple quotes is adjacent-quote concatenation evaluating to the exact
-      inner literal (PR #937 F1).
+      one line therefore stays open), while an EVEN count on a non-docstring
+      line falls through to the value scan, so a one-line triple-quoted
+      assignment (X = triple-quoted token) is caught by the quoted-literal
+      path instead of being swept as prose. ponytail: a one-line module
+      docstring whose ENTIRE text is a bare token would false-positive --
+      absurd corner; escape-comment it if it occurs. This is deliberately
+      NOT applied to shell/YAML: a shell value wrapped in triple quotes is
+      adjacent-quote concatenation evaluating to the exact inner literal.
     """
     out: list[str | None] = []
     if suffix in _C_COMMENT_EXTS:
@@ -381,9 +351,9 @@ def _matrix_tokens(matrix: dict) -> list[str]:
 
     ``role=route-only`` entries (ADR-27: EOL'd but still served, frozen
     catalog, no longer built/tested) are excluded, mirroring
-    ``read-version-matrix.sh``'s BUILD/CI derivations (review-fanout C1,
-    PR #947): a frozen version's identity is no longer an active-development
-    value, so the window need not keep covering it forever.
+    ``read-version-matrix.sh``'s BUILD/CI derivations: a frozen version's
+    identity is no longer an active-development value, so the window need
+    not keep covering it forever.
     """
     tokens: list[str] = []
     for entry in matrix.get("versions", []):
@@ -431,8 +401,8 @@ def _verify_matrix(argv: list[str]) -> int:
             print(f"unknown --verify-matrix option: {arg}", file=sys.stderr)
             return 2
     # A misconfigured invocation (bad ref, missing file, malformed JSON) gets the
-    # file's one-line stderr convention + exit 2, not a traceback (review-fanout
-    # C7, PR #947) -- distinct from exit 1 (uncovered tokens) so CI logs read right.
+    # file's one-line stderr convention + exit 2, not a traceback -- distinct
+    # from exit 1 (uncovered tokens) so CI logs read right.
     try:
         if matrix_file is not None:
             text = Path(matrix_file).read_text(encoding="utf-8")

--- a/scripts/composer-cloud-install.sh
+++ b/scripts/composer-cloud-install.sh
@@ -58,7 +58,7 @@ strip_phpstan() {
 
 # The fallback mutates composer.json/lock in a repo ($1) and restores them via
 # git checkout; refuse to run over uncommitted user edits — staged OR unstaged,
-# hence the diff against HEAD, not just the index (PR #953 review).
+# hence the diff against HEAD, not just the index.
 refuse_if_composer_files_dirty() {
 	if ! git -C "$1" diff --quiet HEAD -- composer.json composer.lock; then
 		echo "composer-cloud-install: composer.json/composer.lock have uncommitted changes; commit or stash them first" >&2

--- a/scripts/image-publish.sh
+++ b/scripts/image-publish.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # image-publish.sh — export a Proxmox VM's disk to a compressed qcow2 and
-# publish it to GHCR as a pfBlockerNG smoke-test base image (ADR-04, Phase 2).
+# publish it to GHCR as a pfBlockerNG smoke-test base image (ADR-04).
 #
 # Drive it FROM YOUR MACHINE: pass the Proxmox SSH coordinates and the script
 # runs the native steps (qm/pvesm/qemu-img — all shipped with Proxmox VE) over

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -162,7 +162,7 @@ FORCE=0
 image_px_defaults
 
 # The non-interactive pfSense upgrade command. NOTE: confirm the exact flags for
-# the running CE release during the Phase-1 spike (ADR-04 §6 flags this) — `yes |`
+# the running CE release during the spike (ADR-04 §6 flags this) — `yes |`
 # is a hedge against any interactive prompt; the version-poll below detects the
 # real completion regardless of how it reboots.
 UPGRADE_CMD='yes | /usr/local/sbin/pfSense-upgrade -d'

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # image-upgrade.sh — upgrade a published pfSense (CE or Plus) smoke base to a
-# newer release and publish the result as a new tag (ADR-04, Phase 2 "upgrade in
-# place").
+# newer release and publish the result as a new tag (ADR-04's "upgrade in
+# place" flow).
 #
 # Drive it FROM YOUR MACHINE: the KVM boot + in-VM upgrade must run on a KVM host
 # (your Proxmox host), so pass its SSH coordinates and the script runs qemu there

--- a/scripts/install-from-repo.sh
+++ b/scripts/install-from-repo.sh
@@ -6,7 +6,7 @@
 # (overlay discarded), so every run is a clean install of the branch under test.
 #
 # It does NOT add feeds / addresses / whitelists / response modes — that is
-# per-case config injection (ADR-04 Phase 4), done later by the test harness.
+# per-case config injection (ADR-04), done later by the test harness.
 #
 # The pfSense setup wizard is a GUI-only first-run prompt; the baked image is
 # already a configured box (config.xml present), so there is nothing to skip

--- a/scripts/lib/git-env-scrub.sh
+++ b/scripts/lib/git-env-scrub.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# scripts/lib/git-env-scrub.sh — shared GIT_* context scrubber (ADR-47 P5).
+# scripts/lib/git-env-scrub.sh — shared GIT_* context scrubber (ADR-47).
 #
 # Safe to source: no top-level side effects, no set -e, no traps.
 #

--- a/scripts/misc/bench_aggregate_union.sh
+++ b/scripts/misc/bench_aggregate_union.sh
@@ -1,43 +1,13 @@
 #!/bin/sh
-# bench_aggregate_union.sh — ADR-11 Phase 1 cost benchmark (DE-RISKING, dev-only).
+# bench_aggregate_union.sh — dev-only benchmark: cost of unioning pfBlockerNG's
+# Deny set into the aggregate ("Uber") alias (cat -> sort -u -> cidr_aggregate()
+# /iprange): wall-time, peak RSS, dedup ratio. Uses the real `iprange` when
+# present; else a Python ipaddress.collapse_addresses stand-in — ratio-faithful
+# but its wall-clock is a dev-box proxy only (live iprange timing needs a
+# maintainer run on real hardware). Synthetic data; not part of the release
+# archive (only src/ ships).
 #
-# Characterise the cost of unioning pfBlockerNG's effective Deny set into the
-# aggregate ("Uber") alias, so ADR-11 can choose full-rebuild-each-pass vs an
-# incremental (rebuild-on-member-change) build, and document the RAM caveat.
-#
-# What it measures, for the union step `cat members -> sort -u -> aggregate`:
-#   * wall-time (real seconds)
-#   * peak RAM (maximum resident set size)
-#   * input entry count vs output entry count (the dedup/aggregation ratio)
-#
-# The aggregation primitive pfBlockerNG uses is `cidr_aggregate()` in
-# pfblockerng.sh, which shells out to `/usr/local/bin/iprange` (a single file
-# arg -> stdout: sort + collapse of overlapping/adjacent CIDRs). This script
-# benchmarks the SAME primitive:
-#   * If `iprange` is present (a real pfSense box / a box with it installed),
-#     it is used directly -> a faithful, live-equivalent number.
-#   * Otherwise (e.g. a macOS/Linux dev box without it) a portable Python
-#     stand-in built on `ipaddress.collapse_addresses` is used. That performs
-#     the identical job (sort + merge overlapping/adjacent CIDRs into the
-#     minimal covering set); it is NOT the production binary, so its TIME is a
-#     dev-box proxy only — the authoritative live `iprange` timing is a
-#     maintainer-run slot (see RESULTS/01_Results.txt). The dedup/aggregation
-#     RATIO and the output entry count it reports ARE representative (same
-#     collapse semantics), only the wall-clock is implementation-specific.
-#
-# This is a measurement harness on SYNTHETIC data. It changes no shipped
-# behaviour and is not part of the release archive (only src/ ships).
-#
-# POSIX sh. Usage:
-#   scripts/misc/bench_aggregate_union.sh [v4_cidrs] [v6_cidrs] [members]
-#
-#   v4_cidrs  total IPv4 CIDR lines to synthesize  (default 2000000)
-#   v6_cidrs  total IPv6 CIDR lines to synthesize  (default  500000)
-#   members   number of member files to split them across (default 30)
-#
-# The synthetic generator deliberately injects exact-duplicate lines and
-# adjacent/contained subnets across members so `sort -u` + aggregate have real
-# work to collapse (mirrors overlapping real-world deny feeds).
+# Usage: scripts/misc/bench_aggregate_union.sh [v4_cidrs=2000000] [v6_cidrs=500000] [members=30]
 
 set -eu
 
@@ -101,7 +71,7 @@ for u in ('B','KiB','MiB','GiB','TiB'):
 }
 
 # --- 1. synthesize representative member files -------------------------------
-echo "ADR-11 Phase 1 — aggregate-union cost benchmark"
+echo "ADR-11 aggregate-union cost benchmark"
 echo "================================================"
 echo "host          : $(uname -s -m -r)"
 echo "agg primitive : ${agg_mode}"
@@ -113,7 +83,7 @@ python3 - "${memberdir}" "${v4_total}" "${v6_total}" "${members}" <<'PY'
 import ipaddress, random, sys, os
 
 memberdir, v4_total, v6_total, members = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
-random.seed(1108)  # deterministic: ADR-11, Phase 1
+random.seed(1108)  # deterministic: ADR-11
 
 fhs = [open(os.path.join(memberdir, f"deny_{i:03d}.txt"), "w") for i in range(members)]
 

--- a/scripts/parity-guard.sh
+++ b/scripts/parity-guard.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # scripts/parity-guard.sh — lint GitHub Actions workflows for build/test-parity violations.
 #
-# After ADR-47 P3 (build path) and P5 (test path), workflow YAML must route
+# After ADR-47 (build path and test path), workflow YAML must route
 # through the shared scripts. Violations are caught by five rules.
 #
 # BUILD RULES (P3):

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -2,7 +2,7 @@
 # /usr/local/etc/rc.d/pfblockerng_repo_generate.sh — boot-time repo-conf
 # regenerator (ADR-39). Installed by add-repo.sh.
 #
-# WHAT IT DOES (and nothing more): for each of our pkg-repo conf files that
+# WHAT IT DOES (and nothing more): for each pfBlockerNG pkg-repo conf file that
 # EXISTS, it detects this box's pfSense edition/version/arch and UNCONDITIONALLY
 # overwrites the conf with the canonical body — a fully-resolved GitHub Pages
 # catalog URL for the box's variant (ADR-17 / ADR-20) plus a marker comment.
@@ -89,7 +89,7 @@ _emit_conf() {
 # fully resolved for this box's edition/version/arch (ADR-39); the boot
 # rc.d hook updates it on a pfSense OS upgrade.
 # priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo
-# resolution (pkg install/upgrade, GUI Install) selects our build.
+# resolution (pkg install/upgrade, GUI Install) selects the pfBlockerNG build.
 ${_ec_repo}: {
   url: "${_ec_url}",
   mirror_type: none,

--- a/scripts/resolve-legs.sh
+++ b/scripts/resolve-legs.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# scripts/resolve-legs.sh — shared leg-resolution + per-leg helpers (ADR-47 P5).
+# scripts/resolve-legs.sh — shared leg-resolution + per-leg helpers (ADR-47).
 #
 # Six subcommands covering the inline blocks previously repeated across
 # smoke.yml / smoke-single.yml / ui-tests.yml:
@@ -57,7 +57,7 @@ set -eu
 # ── Self-dir (for lib + sibling scripts) ─────────────────────────────────── #
 _RL_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# ── GIT_* scrub (ADR-47 P5 chokepoint) ───────────────────────────────────── #
+# ── GIT_* scrub (ADR-47 chokepoint) ───────────────────────────────────── #
 # shellcheck source=scripts/lib/git-env-scrub.sh
 . "${_RL_DIR}/lib/git-env-scrub.sh"
 pfb_scrub_git_env

--- a/scripts/run-smoke.sh
+++ b/scripts/run-smoke.sh
@@ -1,12 +1,57 @@
 #!/bin/sh
-# scripts/run-smoke.sh — the ONE canonical pytest invocation for all three call
-# sites (smoke-single.yml, ui-tests.yml, scripts/smoke-on-box.sh). Builds argv
-# via right-to-left `set --` prepends only (no eval; passthrough args are never
-# word-split or interpreted): [PATH?] [-m MARKER?] [fixed flags] [-k FILTER?]
-# [passthrough...]. A leading positional path in the passthrough REPLACES the
-# default --paths (never appended); --shard-total N>1 replaces it with a shard
-# slice via scripts/shard-modules.sh instead, and conflicts loudly with an
-# explicit passthrough path. POSIX sh; shellcheck clean.
+# scripts/run-smoke.sh — the ONE canonical pytest invocation for all three call sites:
+#   smoke-single.yml, ui-tests.yml, scripts/smoke-on-box.sh (local runs via lease).
+#
+# Emits and executes:
+#   $PYTHON -m pytest $PATHS -m $MARKER
+#     --override-ini="addopts=" --override-ini="timeout_func_only=true"
+#     --timeout=$TIMEOUT --timeout-method=signal --durations=0 --capture=tee-sys -v
+#     [-k $K] [passthrough...]
+#
+# --durations=0 reports every test's setup/call/teardown phase timing (issue #605
+#   Layer A); --capture=tee-sys streams stdout live so the per-step PFB_TIMING lines
+#   (Layer B, tests/timing.py) show on a PASSING run, not only on failure.
+#
+# Params + defaults (structured flags must precede passthrough):
+#   --paths P        default tests/smoke   (UI: tests/smoke/ui)
+#   -m/--marker M    default smoke         (CI smoke: smoke|repo; UI: ui_render|...)
+#   --timeout N      default 30            (UI: 300)
+#   --filter EXPR    optional; ONE arg, no word-split (passed to pytest as -k "expr")
+#   --shard I        default 0             (0-based shard index; issue #797)
+#   --shard-total N  default 1             (N=1: no-op, byte-identical to pre-#797
+#                                            behaviour; N>1: --paths is replaced by
+#                                            its shard slice -- a pytest argv
+#                                            fragment, module-level or, for an
+#                                            oversized module, test-level, issue #855)
+#   trailing passthrough → forwarded to pytest verbatim
+#
+# AMENDMENTS:
+#   bare-path parity: a positional path in the passthrough REPLACES --paths (not
+#     appended) — so `local-smoke.sh -m ui_render tests/smoke/ui` runs only that
+#     subtree. Only the FIRST non-option token in the passthrough is treated as a
+#     path; a subsequent non-'-' token (e.g. the '1' in --maxfail 1) is an option
+#     value and must not suppress the default --paths.
+#   PYTHON/CI parity: when GITHUB_ACTIONS is set the runner has no .venv; python3
+#     is always used.  Locally (GITHUB_ACTIONS unset), prefers the .venv when
+#     executable.  PYTHON env overrides both.
+#   argv injection: passthrough args are assembled via successive set -- prepends —
+#     no eval, no numbered vars; shell metacharacters in passthrough args are
+#     never interpreted.
+#   shard slicing (issue #797, hybrid test-level split issue #855): --shard-total
+#     N>1 hands the single --paths dir to scripts/shard-modules.sh and splices its
+#     newline-separated stdout -- a pytest ARGV FRAGMENT (module paths, bare node
+#     IDs, and adjacent `--deselect`/node-ID pairs, one argv word per line) -- in
+#     as MULTIPLE leftmost pytest args, in the exact spot the one path occupies
+#     today. An explicit passthrough path together with N>1 is a conflict (loud
+#     error, never a silent pick); the splitter's own errors (e.g. an empty slice)
+#     propagate as-is under `set -eu`. When N>1, pytest exit 5 ("no tests ran") is
+#     mapped to 0 — a shard whose slice carries no test matching the marker is a
+#     partition artifact, not a failure; unsharded runs keep exit 5 fatal.
+#
+# Env passthrough: RUN_ID / PFB_DIAG_DIR / SMOKE_LANE reach pytest by inheritance (no
+#   explicit forwarding needed — subprocess env-inherit covers it).
+#
+# POSIX sh; shellcheck clean.
 
 set -eu
 
@@ -64,10 +109,10 @@ while [ "$#" -gt 0 ]; do
 done
 # "$@" is now the passthrough.
 
-# ── Phase 1b: validate --shard / --shard-total (cheap guard) ───────────────── #
-# Out-of-range index (I >= N) is the SPLITTER's job (Phase 4d propagates its
-# error); this only rejects non-numeric input and a total < 1 before anything
-# else runs.
+# ── Validate --shard / --shard-total (cheap guard) ─────────────────────────── #
+# Out-of-range index (I >= N) is the SPLITTER's job (the shard-slice step below
+# propagates its error); this only rejects non-numeric input and a total < 1
+# before anything else runs.
 case "$_SHARD" in
     '' | *[!0-9]*)
         printf 'run-smoke: --shard must be a non-negative integer: %s\n' "$_SHARD" >&2

--- a/scripts/run-smoke.sh
+++ b/scripts/run-smoke.sh
@@ -1,57 +1,12 @@
 #!/bin/sh
-# scripts/run-smoke.sh — the ONE canonical pytest invocation for all three call sites:
-#   smoke-single.yml, ui-tests.yml, scripts/smoke-on-box.sh (local runs via lease).
-#
-# Emits and executes:
-#   $PYTHON -m pytest $PATHS -m $MARKER
-#     --override-ini="addopts=" --override-ini="timeout_func_only=true"
-#     --timeout=$TIMEOUT --timeout-method=signal --durations=0 --capture=tee-sys -v
-#     [-k $K] [passthrough...]
-#
-# --durations=0 reports every test's setup/call/teardown phase timing (issue #605
-#   Layer A); --capture=tee-sys streams stdout live so the per-step PFB_TIMING lines
-#   (Layer B, tests/timing.py) show on a PASSING run, not only on failure.
-#
-# Params + defaults (structured flags must precede passthrough):
-#   --paths P        default tests/smoke   (UI: tests/smoke/ui)
-#   -m/--marker M    default smoke         (CI smoke: smoke|repo; UI: ui_render|...)
-#   --timeout N      default 30            (UI: 300)
-#   --filter EXPR    optional; ONE arg, no word-split (passed to pytest as -k "expr")
-#   --shard I        default 0             (0-based shard index; issue #797)
-#   --shard-total N  default 1             (N=1: no-op, byte-identical to pre-#797
-#                                            behaviour; N>1: --paths is replaced by
-#                                            its shard slice -- a pytest argv
-#                                            fragment, module-level or, for an
-#                                            oversized module, test-level, issue #855)
-#   trailing passthrough → forwarded to pytest verbatim
-#
-# AMENDMENTS:
-#   bare-path parity: a positional path in the passthrough REPLACES --paths (not
-#     appended) — so `local-smoke.sh -m ui_render tests/smoke/ui` runs only that
-#     subtree. Only the FIRST non-option token in the passthrough is treated as a
-#     path; a subsequent non-'-' token (e.g. the '1' in --maxfail 1) is an option
-#     value and must not suppress the default --paths.
-#   PYTHON/CI parity: when GITHUB_ACTIONS is set the runner has no .venv; python3
-#     is always used.  Locally (GITHUB_ACTIONS unset), prefers the .venv when
-#     executable.  PYTHON env overrides both.
-#   argv injection: passthrough args are assembled via successive set -- prepends —
-#     no eval, no numbered vars; shell metacharacters in passthrough args are
-#     never interpreted.
-#   shard slicing (issue #797, hybrid test-level split issue #855): --shard-total
-#     N>1 hands the single --paths dir to scripts/shard-modules.sh and splices its
-#     newline-separated stdout -- a pytest ARGV FRAGMENT (module paths, bare node
-#     IDs, and adjacent `--deselect`/node-ID pairs, one argv word per line) -- in
-#     as MULTIPLE leftmost pytest args, in the exact spot the one path occupies
-#     today. An explicit passthrough path together with N>1 is a conflict (loud
-#     error, never a silent pick); the splitter's own errors (e.g. an empty slice)
-#     propagate as-is under `set -eu`. When N>1, pytest exit 5 ("no tests ran") is
-#     mapped to 0 — a shard whose slice carries no test matching the marker is a
-#     partition artifact, not a failure; unsharded runs keep exit 5 fatal.
-#
-# Env passthrough: RUN_ID / PFB_DIAG_DIR / SMOKE_LANE reach pytest by inheritance (no
-#   explicit forwarding needed — subprocess env-inherit covers it).
-#
-# POSIX sh; shellcheck clean.
+# scripts/run-smoke.sh — the ONE canonical pytest invocation for all three call
+# sites (smoke-single.yml, ui-tests.yml, scripts/smoke-on-box.sh). Builds argv
+# via right-to-left `set --` prepends only (no eval; passthrough args are never
+# word-split or interpreted): [PATH?] [-m MARKER?] [fixed flags] [-k FILTER?]
+# [passthrough...]. A leading positional path in the passthrough REPLACES the
+# default --paths (never appended); --shard-total N>1 replaces it with a shard
+# slice via scripts/shard-modules.sh instead, and conflicts loudly with an
+# explicit passthrough path. POSIX sh; shellcheck clean.
 
 set -eu
 
@@ -66,7 +21,7 @@ _MARKER_EXPLICIT=0  # set to 1 when -m/--marker was given as a structured flag
 _SHARD=0       # 0-based shard index (issue #797)
 _SHARD_TOTAL=1 # N=1 = no sharding (default; byte-identical to pre-#797)
 
-# ── Phase 1: parse structured flags; remaining "$@" = passthrough ─────────── #
+# ── Parse structured flags; remaining "$@" = passthrough ───────────────────── #
 # Structured flags must come before any passthrough args.
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -130,7 +85,7 @@ if [ "$_SHARD_TOTAL" -lt 1 ]; then
     exit 1
 fi
 
-# ── Phase 2: scan passthrough for the -m guard and bare-path guard ─────────── #
+# ── Scan passthrough for the -m guard and bare-path guard ──────────────────── #
 # -m guard: if the passthrough already has -m, do NOT inject our default marker.
 # bare-path: a caller-supplied pytest TARGET (path/file/node-id) replaces the
 #   default tests/smoke. Detect it by SHAPE, not position: a real target contains
@@ -158,7 +113,7 @@ if [ "$_SHARD_TOTAL" -gt 1 ] && [ "$_CALLER_GAVE_PATH" -eq 1 ]; then
     exit 1
 fi
 
-# ── Phase 3: PYTHON resolution ─────────────────────────────────────────────── #
+# ── PYTHON resolution ───────────────────────────────────────────────────────── #
 # CI parity: when GITHUB_ACTIONS is set the runner has no .venv; use python3
 # unconditionally to prevent a stray future .venv from silently drifting CI vs
 # local behaviour.  PYTHON env overrides both paths.
@@ -170,10 +125,10 @@ if [ -z "${PYTHON:-}" ]; then
     fi
 fi
 
-# ── Phase 4: build the canonical argv — no eval ───────────────────────────── #
-# "$@" = passthrough (intact since Phase 1). Build the final pytest argv via
-# successive right-to-left prepends — each set -- replaces "$@" entirely, so the
-# LAST prepend ends up LEFTMOST in the final exec. No eval; no numbered vars;
+# ── Build the canonical argv — no eval ──────────────────────────────────────── #
+# "$@" = passthrough (intact from arg parsing above). Build the final pytest argv
+# via successive right-to-left prepends — each set -- replaces "$@" entirely, so
+# the LAST prepend ends up LEFTMOST in the final exec. No eval; no numbered vars;
 # shell metacharacters in passthrough args are never interpreted.
 #
 # Final order: [PATH?] [-m MARKER?] [fixed...] [-k K?] [passthrough...]

--- a/scripts/select-box.sh
+++ b/scripts/select-box.sh
@@ -43,7 +43,7 @@
 # ── Locate sibling lib/ (same directory as this script) ──────────────────────
 _SB_SELF="$(cd "$(dirname "$0")" && pwd)"
 
-# ── Scrub inherited GIT_* context (via shared lib — ADR-47 P5 chokepoint) ────
+# ── Scrub inherited GIT_* context (via shared lib — ADR-47 chokepoint) ────
 # The pre-commit hook exports GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE / ...
 # pointing at the real repo. Any child process that runs git would operate on
 # the real repo instead of its own fixture. Scrub them once here for the whole

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -51,7 +51,7 @@ _SHARD_TOTAL=1 # N=1 = no sharding (default)
 
 REPO_ROOT="/root/pfBlockerNG"
 
-# ── Scrub inherited GIT_* context (via shared lib — ADR-47 P5 chokepoint) ─── #
+# ── Scrub inherited GIT_* context (via shared lib — ADR-47 chokepoint) ─── #
 # Inherited from the pre-commit hook or the orchestrator's env; scrub once
 # before any git operations in this script.
 # shellcheck source=scripts/lib/git-env-scrub.sh

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -243,37 +243,14 @@ def pfb_async(func: Callable[..., Any], *args: Any) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# ADR-10 P4 -- the zero-downtime reload-watcher (daemon thread + background swap).
-#
-# A daemon thread (started next to pfb_db_worker/pfb_async_worker, gated on
-# pfb["mod_threading"]) waits on the reload SENTINEL. PHP/shell (Phase 5) atomically
-# publishes the new manifest + per-feed raw and then writes a monotonically-advancing
-# GENERATION ID into the sentinel; the watcher wakes, reads the generation, and on an
-# ADVANCE runs rebuild_and_swap() OFF the query threads -- queries keep serving the OLD
-# snapshot through the (seconds-long) ABP build, then a single GIL-atomic ref rebind
-# swaps the new one in (zero downtime, briefly stale by design).
-#
-# Correctness rides on the atomic publish + the generation COMPARE, NOT on notify
-# latency: a missed/coalesced event only DELAYS, never corrupts (the watcher always
-# reads the current generation before building). Single-flight: at most one build runs
-# at a time; a trigger arriving mid-build is coalesced and re-checked after the build.
-#
-# Watch mechanism: select.kqueue EVFILT_VNODE on the sentinel's DIRECTORY where
-# available (FreeBSD) -- watching the dir survives an atomic rename/replace of the
-# sentinel file (a file fd would go stale). A low-frequency mtime-POLL fallback is used
-# where kqueue is unavailable (inotify is Linux-only and NOT on pfSense -- never used).
-#
-# RAM gate (mandatory -- RESULTS/01 SS2): the in-process build holds the OLD + NEW
-# matcher sets simultaneously (~2x, ~786 MiB at ABP scale), which busts a ~358 MiB
-# transient budget on a 1 GB box. Before building, the watcher PROJECTS the transient
-# (~RELOAD_BYTES_PER_ENTRY x current entry count) and checks TOTAL RAM (a coarse
-# impossibility backstop, consistent with PHP's hw.usermem gate -- NOT free pages, which
-# spuriously declined on cache-heavy boxes); if it would
-# not fit, it DECLINES the swap fail-closed -- the OLD snapshot stays live and a clear
-# log line says the box is RAM-constrained and the update needs the restart fallback.
-# The PRIMARY gate is PHP (Phase 5, before flipping the sentinel); this is the Python
-# safety net so a constrained box never OOMs even if PHP flips the sentinel anyway.
-# stdlib-only + injectable so it is unit-testable without a live box.
+# ADR-10: zero-downtime reload-watcher daemon (gated on pfb["mod_threading"]).
+# Watches a generation-id sentinel PHP/shell advance after an atomic publish;
+# on advance, rebuild_and_swap() builds off the query threads and swaps in
+# the new snapshot via one GIL-atomic ref rebind (old snapshot serves until
+# then; single-flight). Watch is kqueue EVFILT_VNODE on the sentinel's
+# directory where available, else a low-frequency mtime poll. RAM-gated:
+# declines the swap fail-closed if the OLD+NEW-resident build would not fit.
+# Pinned by tests/test_adr10_watcher.py, tests/test_adr10_swap.py.
 # --------------------------------------------------------------------------- #
 
 # Steady-state retained bytes per matcher entry (ADR-05 SS3a / ADR-10 P1 spike:
@@ -392,7 +369,7 @@ def _build_swap_snapshot() -> Snapshot | None:
         ``None`` (absent/unparseable manifest, build error) -> the whole swap is a no-op.
       * USER REGEX-ini patterns merged on top (band PRIO_USER_BLOCK, sovereign over feed
         allows), honouring the opt-in static cap -- so a swap NEVER drops user regex
-        (RESULTS/02 / ADR-07).
+        (ADR-07).
       * hstsDB reloaded from pfb_py_hsts.txt (watch-out (b): hstsDB is NOT in the
         manifest; omitting it would ship an empty hsts_db and silently flip HSTS NULL-vs-
         VIP behaviour)."""
@@ -628,20 +605,12 @@ class _ReloadKqueueWaiter:
 
 
 # --------------------------------------------------------------------------- #
-# PFBL-03 -- the local privileged DNSBL-control command channel (reader daemon).
-#
-# A daemon thread mirrors the ADR-10 reload watcher: it waits on the control file's
-# DIRECTORY (kqueue EVFILT_VNODE where available, mtime-poll fallback) and, on a change,
-# reads the JSON record. The record carries a monotonically-advancing SEQUENCE; the
-# watcher tracks the last-applied seq and IGNORES any record with seq <= last_applied
-# (exactly-once + replay safety, exactly as the reload watcher compares generations).
-# A FRESH record is re-validated and routed through the SHARED pfb_apply_control_command()
-# handler -- the same implementation the legacy DNS-TXT branch uses -- then the applied
-# seq is published so the writer can confirm execution. Correctness rides on the atomic
-# publish + the seq COMPARE, NOT on notify latency: a missed event only delays.
-#
-# The reader runs OFF the query threads (its own daemon, blocking only on the kqueue/poll
-# wait), so it never blocks DNS response processing.
+# PFBL-03: the local privileged DNSBL-control command channel (reader daemon).
+# Mirrors the ADR-10 reload watcher: waits on the control file's directory
+# (kqueue EVFILT_VNODE, mtime-poll fallback); on change, reads a JSON record
+# carrying a monotonic SEQUENCE and ignores any seq <= last-applied (exactly-
+# once + replay safety). A fresh record routes through the shared
+# pfb_apply_control_command() handler; runs off the query threads.
 # --------------------------------------------------------------------------- #
 
 
@@ -967,7 +936,7 @@ def init_standard(id: int, env: module_env) -> bool:
     # ADR-08: the IDN-feature mode, derived from python_idn (see idn_mode_from_legacy).
     # Default OFF; the ini load below recomputes it from the loaded python_idn.
     pfb["idn_mode"] = IdnMode.Off
-    # ADR-08 Phase 5: the two Confusable-mode sub-toggles. block_malicious is DEFAULT-ON
+    # ADR-08: the two Confusable-mode sub-toggles. block_malicious is DEFAULT-ON
     # (a cross-script confusable homograph blocks unless the operator disables it);
     # escalate_suspicious is OPT-IN (a suspicious/flagged anomaly only alerts unless the
     # operator escalates it to a block). Both only act in IDN_MODE_CONFUSABLE.
@@ -1019,9 +988,9 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["pfb_py_ss"] = "pfb_py_ss.txt"
     # ADR-06: per-feed manifest (the new shell->Python boundary) and the
     # Python-emitted entry count. When the manifest is present, init builds the
-    # DNSBL structures from the raw feeds via the pure build() layer (ADR-06 P4);
-    # otherwise it falls back to the legacy data/zone CSV load (shell/PHP still
-    # produce those files until Phase 5 removes the duplication).
+    # DNSBL structures from the raw feeds via the pure build() layer; otherwise
+    # it falls back to the legacy data/zone CSV load (shell/PHP still produce
+    # those files for that fallback).
     pfb["pfb_py_sources"] = "pfb_py_sources.json"
     # ADR-10 P4: the zero-downtime RELOAD SENTINEL. Path is chroot-relative (Unbound
     # is chrooted at /var/unbound, the module's CWD) -- so the in-chroot absolute path
@@ -1059,7 +1028,7 @@ def init_standard(id: int, env: module_env) -> bool:
     # allowRegexDB AFTER both the user REGEX-ini load and the feed-regex merge, so
     # patterns the static cap dropped are excluded (value changes by design, ADR §2).
     pfb["pfb_py_regex_count"] = "pfb_py_regex_count"
-    # ADR-48 Phase 4 (#789): the per-entry reject tally artifact (BuildResult.rejects,
+    # ADR-48 (issue #789): the per-entry reject tally artifact (BuildResult.rejects,
     # a JSON array of nonzero-total {feed, group, shape, wire_cap} rows) -- PHP reads
     # it after a DNSBL run and emits the canonical stage=entries line. Chroot-relative
     # bare name, exactly like pfb_py_count above (the manifest-boundary discipline).
@@ -1159,10 +1128,10 @@ def init_standard(id: int, env: module_env) -> bool:
                 pfb["python_hsts"] = config.getboolean("MAIN", "python_hsts")
             if config.has_option("MAIN", "python_idn"):
                 pfb["python_idn"] = config.getboolean("MAIN", "python_idn")
-            # ADR-08: the IDN mode. The PHP ini writer (Phase 6+) emits an explicit
-            # idn_mode = off|all|confusable key; honour it when present. For a config that
-            # predates the key (only python_idn=on|off written), fall back to the legacy
-            # derivation -- 'on'->All-IDN, off->Off -- byte-identical to today.
+            # ADR-08: the IDN mode. The PHP ini writer emits an explicit
+            # idn_mode = off|all|confusable key; honour it when present, else fall
+            # back to the legacy derivation ('on'->All-IDN, off->Off) for a config
+            # written before the key existed.
             if config.has_option("MAIN", "idn_mode"):
                 _raw_idn = config.get("MAIN", "idn_mode").strip().lower()
                 if _raw_idn in (IDN_MODE_OFF, IDN_MODE_ALL, IDN_MODE_CONFUSABLE):
@@ -1171,9 +1140,9 @@ def init_standard(id: int, env: module_env) -> bool:
                     pfb["idn_mode"] = idn_mode_from_legacy(pfb["python_idn"])
             else:
                 pfb["idn_mode"] = idn_mode_from_legacy(pfb["python_idn"])
-            # ADR-08 Phase 5: the two Confusable sub-toggles. The PHP ini writer emits these
-            # MAIN keys from Phase 6 on; read them when present so the matcher honours the
-            # operator's choice, else keep the defaults (block_malicious ON, escalate OFF).
+            # ADR-08: the two Confusable sub-toggles. Read the MAIN keys when the
+            # PHP ini writer emits them, else keep the defaults (block_malicious
+            # ON, escalate OFF).
             if config.has_option("MAIN", "python_idn_block_malicious"):
                 pfb["python_idn_block_malicious"] = config.getboolean("MAIN", "python_idn_block_malicious")
             if config.has_option("MAIN", "python_idn_escalate_suspicious"):
@@ -1371,8 +1340,8 @@ def init_standard(id: int, env: module_env) -> bool:
             # (data/zone) -> builds dataDB/zoneDB/feedGroupIndexDB/whiteDB and emits
             # the entry count -- it is now the source of truth for the built
             # structures. The legacy data/zone/whitelist CSV load below is the
-            # FALLBACK (shell/PHP still produce those files until Phase 5 removes the
-            # duplication), used only when no manifest is present. Python ignores
+            # FALLBACK (shell/PHP still produce those files for this fallback),
+            # used only when no manifest is present. Python ignores
             # stray IP lines and never touches the firewall/IP path (DNSBL-IP stays
             # in PHP). The build call site is the future zero-downtime swap point;
             # no background-thread/restart-free behaviour is added here.
@@ -1407,7 +1376,7 @@ def init_standard(id: int, env: module_env) -> bool:
 
                 # Emit pfb_py_count (the LOADED total) for the UI (inc:3149).
                 dnsbl_emit_count(pfb["pfb_py_count"], build_result.counts)
-                # ADR-48 Phase 4 (#789): emit the per-entry reject tally artifact
+                # ADR-48 (issue #789): emit the per-entry reject tally artifact
                 # alongside the count -- PHP reads it after this run and emits
                 # stage=entries for any feed with a nonzero bucket.
                 dnsbl_emit_reject_stats(pfb["pfb_py_reject_stats"], build_result.rejects)
@@ -1570,7 +1539,7 @@ def init_standard(id: int, env: module_env) -> bool:
     # ``important_rules`` fast-path gate sits in pfb["important_rules"]. The builder
     # closure wraps those SAME dict objects into a fresh Snapshot (no copy, no shape
     # change), and rebuild_and_swap is the SINGLE place the ``_snapshot`` ref is bound
-    # (one GIL-atomic store; the future zero-downtime swap point Phase 4 reuses). It
+    # (one GIL-atomic store; the zero-downtime reload-watcher reuses this same point). It
     # runs on BOTH the python_enable and the else (empty defaultdicts) paths, so a
     # snapshot is always present for operate(). Decision-identical to the old per-global
     # read -- the same dict objects, just bundled (pinned by the retained ADR-06/07
@@ -1581,7 +1550,7 @@ def init_standard(id: int, env: module_env) -> bool:
     # ``emit_counts=False`` keeps init's existing path-specific inline count emits (the
     # manifest-path pfb_py_count + the always-on pfb_py_regex_count above) -- the swap
     # must NOT re-emit here or the CSV-fallback/else paths would gain count writes they
-    # do not make today. Phase 4's background caller uses the default emit_counts=True.
+    # do not make today. The background reload-watcher caller uses the default emit_counts=True.
     def _init_build_snapshot() -> Snapshot:
         return Snapshot(
             data_db=dataDB,
@@ -1657,17 +1626,12 @@ def init_standard(id: int, env: module_env) -> bool:
     return True
 
 
-# ADR-08: IDN-feature mode selector. The legacy on/off ``python_idn`` toggle becomes
-# a three-valued mode so a later phase can add a surgical cross-script-homoglyph tier
-# without disturbing the two behaviour-preserving modes:
-#   IDN_MODE_OFF        -- the IDN feed never fires (every xn-- query resolves normally).
-#   IDN_MODE_ALL        -- block EVERY xn-- query as feed="IDN" (pure prefix match, no
-#                          punycode decode). Token "on" (reused from the pre-ADR-08 binary
-#                          IDN toggle): the PHP gateway, py_unbound.ini, and this enum all
-#                          share the one vocabulary 'on'|'confusable'|'off' (ADR-28).
-#   IDN_MODE_CONFUSABLE  -- the TR39 mixed-script analyzer tier.
-# Legacy: a config predating the idn_mode key (only python_idn=on|off) still maps via
-# idn_mode_from_legacy() -- on->All, off/absent->Off.
+# ADR-08: IDN-feature mode selector (ADR-28 shared vocabulary 'on'/'confusable'/'off'
+# across config.xml, py_unbound.ini, and this enum). IDN_MODE_OFF: the IDN feed never
+# fires. IDN_MODE_ALL: block every xn-- query as feed="IDN" (prefix match only, no
+# punycode decode); token "on" is the legacy value. IDN_MODE_CONFUSABLE: the TR39
+# mixed-script analyzer tier. A config predating idn_mode (only python_idn=on|off)
+# maps via idn_mode_from_legacy(): on->All, off/absent->Off.
 IDN_MODE_OFF = "off"
 IDN_MODE_ALL = "on"
 IDN_MODE_CONFUSABLE = "confusable"
@@ -1702,11 +1666,11 @@ class IdnMode(Enum):
 
 
 def idn_mode_from_legacy(python_idn: bool) -> IdnMode:
-    """Map the legacy on/off ``python_idn`` flag to an IDN mode (RESULTS/01 SS1).
+    """Map the legacy on/off ``python_idn`` flag to an IDN mode.
 
     True ('on') -> IdnMode.All (today's block-all-IDN behaviour); False -> IdnMode.Off.
-    The Confusable value cannot arise from the legacy flag -- it reaches Python only once
-    the PHP UI emits it (Phase 6); until then this is the sole derivation of the mode.
+    The Confusable value cannot arise from the legacy flag -- it reaches Python only
+    once the PHP UI emits it.
     """
     return IdnMode.All if python_idn else IdnMode.Off
 
@@ -1718,13 +1682,10 @@ def is_idn_domain(q_name: str) -> bool:
 def idn_mode_decision(q_name: str, idn_mode: IdnMode) -> bool:
     """Pure IDN feed decision: should this query be blocked by the All-IDN feed?
 
-    Extracted verbatim from the evaluate_domain IDN branch so the contract can be
-    pinned (ADR-08 Phase 3). Returns True only in IdnMode.All on an xn-- query --
-    the exact condition the inline ``cfg["python_idn"] and is_idn_domain(q_name)``
-    encoded. IdnMode.Off and IdnMode.Confusable return False here -- Off never
-    blocks, and the Confusable tier is decided by ``idn_confusable_action`` (Phase 5),
-    NOT this gate. No punycode decode, no script work. The Off/All arms it governs
-    stay byte-identical to today (the Phase-3 golden gate).
+    Returns True only in IdnMode.All on an xn-- query. IdnMode.Off and
+    IdnMode.Confusable return False here -- the Confusable tier is decided by
+    ``idn_confusable_action`` instead, not this gate. No punycode decode, no
+    script work. Pinned by tests/test_adr08_mode_baseline.py.
     """
     return idn_mode is IdnMode.All and is_idn_domain(q_name)
 
@@ -1872,7 +1833,7 @@ def classify_idn(q_name: str) -> NameVerdict:
     return NameVerdict(q_name, verdicts, worst.severity, worst.offending)
 
 
-# ADR-08 Phase 5: the Confusable tier. Distinct feed/group labels so a homoglyph block
+# ADR-08: the Confusable tier. Distinct feed/group labels so a homoglyph block
 # is attributed apart from the blunt All-IDN feed ("IDN"/"DNSBL_IDN") and the alerts
 # page / Reports can break it out. Malicious -> the Homoglyph feed; the suspicious/
 # flagged (non-malicious anomaly) tier -> the Suspect feed.
@@ -2416,8 +2377,8 @@ def _db_reset_cache() -> bool:
     # the schema + WAL connection live so the very next enqueued block row inserts
     # cleanly post-swap; _db_run re-creates the table on a faulted reconnect. The
     # current PHP Reports reader reads ALL rows (no generation column), so a destructive
-    # clear is the correct no-restart equivalent of today's wipe-on-restart; see the
-    # Phase-3 handoff for the generation-key alternative deferred to Phase 5/PHP.
+    # clear is the correct no-restart equivalent of today's wipe-on-restart; a
+    # generation-key alternative is deferred to PHP.
     return _db_run(DB_CACHE, lambda con: con.execute("DELETE FROM dnsblcache"))
 
 
@@ -3076,22 +3037,14 @@ def python_control_addbypass(duration: int, b_ip: str) -> bool:
     return False
 
 
-# PFBL-03: the SINGLE DNSBL-control command handler. Both transports route here -- the
-# legacy DNS-TXT branch (operate(), retired in a later phase) and the local privileged
-# command channel consumed by pfb_control_watcher() -- so the command grammar and its
-# side effects have exactly one implementation.
-#
-# ``control_command`` is the dot-split token list exactly as the DNS-TXT path builds it
-# (q_name "python_control.disable.60" -> ["python_control", "disable", "60"]); the file
-# reader builds the identical list from its JSON record. Validation contract (re-checked
-# here, never trusting the transport): a bypass IP must parse via ipaddress.ip_address()
-# and a duration must pass python_control_duration() (1-3600) before any side effect.
-#
-# Returns ``(applied, message)`` -- ``applied`` is the DNS-TXT branch's control_rcd
-# (True only when the command took effect), ``message`` its human-readable status. The
-# behaviour is BYTE-FOR-BYTE the prior DNS-TXT branch (disable/enable toggle
-# python_blacklist; addbypass/removebypass mutate gpListDB; durations spawn the same
-# timed re-enable/remove threads).
+# PFBL-03: the SINGLE DNSBL-control command handler. Both transports route
+# here -- the legacy DNS-TXT branch (operate()) and the local privileged
+# command channel (pfb_control_watcher()) -- so the grammar and its side
+# effects have exactly one implementation. ``control_command`` is the
+# dot-split token list both build identically; validated here (never
+# trusting the transport): a bypass IP via ipaddress.ip_address(), a
+# duration via python_control_duration() (1-3600). Returns
+# ``(applied, message)``; behaviour is byte-for-byte the prior DNS-TXT branch.
 def pfb_apply_control_command(control_command: list[str]) -> tuple[bool, str]:
     global pfb, gpListDB
 
@@ -3385,40 +3338,24 @@ def inform_super(id: int, qstate: module_qstate, superqstate: module_qstate, qda
 
 
 # --------------------------------------------------------------------------- #
-# DNSBL build layer (ADR-06) -- pure, stdlib-only, Unbound-symbol-free.
+# DNSBL build layer (ADR-06) -- pure, stdlib-only, Unbound-symbol-free. Moves
+# list preprocessing (parse -> normalise -> classify data/zone -> build dicts)
+# out of shell/PHP: the boundary is "shell/PHP fetch + tag; Python parse ->
+# normalise -> classify -> build dicts -> emit counts" (ADR.md SS2), wired
+# into init() via dnsbl_build_from_manifest().
 #
-# Moves the DNSBL list preprocessing (parse -> normalise -> classify data/zone ->
-# build dicts) out of shell/PHP into this plugin. The boundary is "shell/PHP fetch
-# + tag; Python parse -> normalise -> classify -> build dicts -> emit counts"
-# (ADR.md SS2). The layer is wired into init() via dnsbl_build_from_manifest()
-# (Phase 4), and the duplicated shell/PHP preprocessing has since been removed
-# (Phase 5); decision-equivalence is pinned against the Phase-2 oracle.
+#   * Build-time OPTIMISATIONS are dropped, not reimplemented -- no dedup/
+#     collapse/build-time whitelist removal (the dict load dedups keys for
+#     free; whitelisting is QUERY-TIME via whiteDB).
+#   * Classification mirrors tld_analysis/tld_search: a registrable parent ->
+#     wildcard ZONE; a deeper sub-domain under an unknown public suffix, or a
+#     TLD-excluded name -> exact DATA; a blacklisted TLD -> a whole-TLD ZONE.
+#   * IP extraction is NOT Python's job -- it stays in PHP; the parser SKIPS
+#     non-domain lines and never produces firewall input.
+#   * build() is REENTRANT (returns a new structure-set, mutates no module
+#     global) so a zero-downtime reload can run it off-thread and swap in.
 #
-# Design notes the contract pins (RESULTS/01_Results.txt, RESULTS/02_Results.txt):
-#   * Build-time OPTIMISATIONS are dropped, not reimplemented: no within/cross-feed
-#     dedup, no subdomain collapse, no build-time user-whitelist or TOP1M removal.
-#     The dict load dedups keys for free (last-wins) and redundant subdomains stay
-#     because the parent zone still matches them.
-#   * Data/zone CLASSIFICATION is kept (it is not an optimisation) and mirrors
-#     tld_analysis/tld_search exactly: a registrable parent -> wildcard ZONE; a
-#     deeper sub-domain whose parent is not a known public suffix -> exact DATA;
-#     TLD exclusion forces exact DATA; a blacklisted TLD -> a whole-TLD ZONE entry.
-#   * Whitelisting is QUERY-TIME: build() loads the user whitelist into whiteDB
-#     (input normalisation moves here) and loads the TOP1M list into whiteDB ONLY
-#     when enabled. No list pruning at build time.
-#   * IP extraction is NOT Python's job -- it stays in PHP (Phase 5). The parser
-#     SKIPS non-domain lines (bare IPs fail domain validation); it never produces
-#     firewall input.
-#   * ENTRY MODEL: every entry carries a ``kind`` tag (block | allow | regex) so the
-#     model is ABP-ready, BUT this phase produces ONLY ``block`` and still IGNORES
-#     ``@@`` exceptions, regex rules, element-hiding (``##`` / ``#@#``), path/URL
-#     rules and non-domain ``$options`` -- exactly as today. The allow/regex kinds
-#     and their query-time matching are the future ABP ADR, not here.
-#   * build() is REENTRANT: it returns a NEW structure-set and mutates no module
-#     global, so a future zero-downtime reload can run it on a background thread and
-#     atomically swap the result in (the swap itself is not built here).
-#
-# No Unbound symbol is referenced below; only the stdlib (csv) is used.
+# Pinned by tests/test_adr06_build_module.py.
 # --------------------------------------------------------------------------- #
 
 # Entry kinds (ABP-ready seam). The ADR-06 plain/hosts/csv path emits ONLY BLOCK;
@@ -3434,25 +3371,17 @@ DNSBL_CLASS_DATA = "data"  # exact match  (loaded into dataDB)
 DNSBL_CLASS_ZONE = "zone"  # wildcard-incl-self match (loaded into zoneDB)
 
 # --------------------------------------------------------------------------- #
-# ADR-07 -- the intermediate ABP Rule model (Stage A).
+# ADR-07: the intermediate ABP Rule model. ``parse_abp(line, ...) -> Rule |
+# None`` turns one raw ABP line into a typed Rule (or None to skip), agreeing
+# on every corpus line with the reference oracle
+# (tests/test_adr07_decision_spec.py::parse_abp_line).
 #
-# ``parse_abp(line, ...) -> Rule | None`` turns one raw ABP line into a typed
-# Rule (or None to skip). This is PURE + ADDITIVE: it is NOT wired into build()
-# / init in this phase (the reconcile/reduce/emit + the live matcher are later
-# phases). The reference TARGET for this parser is the Phase-2 oracle
-# (tests/test_adr07_decision_spec.py::parse_abp_line); this production parser
-# agrees with it on every corpus line.
-#
-# A Rule's ``target`` says what it matches:
-#   RULE_TARGET_DOMAIN -- an exact-or-wildcard domain literal (``wildcard`` says
-#                         whether subdomains are covered); ``key`` is the domain.
-#   RULE_TARGET_REGEX  -- an irreducible regex pattern (NOT compiled here -- the
-#                         raw inner pattern is stored in ``key``; compile/load is
-#                         a later phase, runtime safety is a later phase).
-# A Rule's ``kind`` is DNSBL_KIND_BLOCK (``||`` / hosts / plain / ``/re/``) or
-# DNSBL_KIND_ALLOW (``@@||`` / ``@@/re/``).
-# A Rule's ``provenance`` is RULE_PROV_FEED (a downloaded feed line) or
-# RULE_PROV_USER (a user-supplied rule -- sovereign, $badfilter-immune, fact 7).
+# A Rule's ``target``: RULE_TARGET_DOMAIN (an exact-or-wildcard domain
+# literal, ``wildcard`` says whether subdomains are covered) or
+# RULE_TARGET_REGEX (an irreducible pattern stored raw in ``key``, NOT
+# compiled here). ``kind`` is DNSBL_KIND_BLOCK (``||``/hosts/plain/``/re/``)
+# or DNSBL_KIND_ALLOW (``@@||``/``@@/re/``). ``provenance`` is RULE_PROV_FEED
+# (a downloaded feed line) or RULE_PROV_USER (sovereign, $badfilter-immune).
 # --------------------------------------------------------------------------- #
 RULE_TARGET_DOMAIN = "domain"
 RULE_TARGET_REGEX = "regex"
@@ -3472,11 +3401,10 @@ _DNSBL_LABEL_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789-_")
 class Rule:
     """One typed, DNS-only ABP rule (Stage A) -- the output of ``parse_abp``.
 
-    This is the intermediate model the reconcile / precedence stages (Phase 5+)
-    stand on; it carries everything ``$badfilter`` / ``$important`` / provenance
+    This is the intermediate model the reconcile / precedence stages stand on;
+    it carries everything ``$badfilter`` / ``$important`` / provenance
     resolution need, none of which can survive being folded into a domain-keyed
-    dict. Mirrors the Phase-2 oracle Rule (tests/test_adr07_decision_spec.py) and
-    RESULTS/01_Results.txt SS1c.
+    dict. Mirrors the reference oracle Rule (tests/test_adr07_decision_spec.py).
 
     Fields:
         kind            DNSBL_KIND_BLOCK (``||`` / hosts / plain / ``/re/``) or
@@ -3493,7 +3421,7 @@ class Rule:
                         3/4). Always meaningless for, but recorded on, USER rules
                         (they are sovereign regardless).
         badfilter       the rule carried ``$badfilter`` (feed-only prune key; the
-                        rule itself emits no decision -- Phase 5 consumes it).
+                        rule itself emits no decision -- reconcile() consumes it).
         provenance      RULE_PROV_USER (sovereign, $badfilter-immune, fact 7) or
                         RULE_PROV_FEED.
         feed/group/log  the per-feed manifest row metadata (attached by the caller;
@@ -3502,7 +3430,7 @@ class Rule:
                         ``(key_or_pattern, tuple(sorted DNS-options)) MINUS $badfilter``.
                         Two rules with the same signature are the same target+options
                         (a feed ``$badfilter`` prunes a feed rule with a matching
-                        signature in Phase 5).
+                        signature during reconcile()).
     """
 
     kind: str
@@ -3537,12 +3465,12 @@ class ParsedEntry:
 @dataclass
 class BuildResult:
     """The structure-set build() returns -- decision-equivalent to the loader
-    contract (RESULTS/01_Results.txt SS1f). All dicts are FRESH (no module global
-    is mutated), so the result is safe to atomically swap in later.
+    contract. All dicts are FRESH (no module global is mutated), so the
+    result is safe to atomically swap in later.
 
     Shapes (ADR-07 widened payloads). For a non-ABP (plain/hosts/csv) build every
     ``important`` is ``False`` and ``band`` is the feed-block band (1); the ABP path
-    (Phase 6, format_hint='abp') sets ``important``/``band`` from the reconciled rule:
+    (format_hint='abp') sets ``important``/``band`` from the reconciled rule:
         data_db[domain]          = {"log": <"0"|"1"|"2">, "index": <int>, "important": bool, "band": int}
         zone_db[registrable]     = {"log": <flag>,        "index": <int>, "important": bool, "band": int}
         feed_group_index_db[idx] = {"feed": <str>, "group": <str>}
@@ -3554,7 +3482,7 @@ class BuildResult:
     regex). ``counts`` is the LOADED total (len(data_db) + len(zone_db)); init emits
     it as pfb_py_count (its value legitimately rises -- lists are un-pruned).
     ``regex_count`` is the ADMITTED feed-regex total for the DNSBL_Regex alias (UI).
-    ``rejects`` is the ADR-48 Phase 4 (#789) per-entry reject tally -- (feed, group)
+    ``rejects`` is the ADR-48 (issue #789) per-entry reject tally -- (feed, group)
     -> {'shape': n, 'wire_cap': m} -- for every domain target a normalise-fail (or
     the reconcile() wire-cap fold-drop) rejected; a diagnostic count, not consumed
     by any decision.
@@ -3596,7 +3524,7 @@ class Snapshot:
     so it is not an immutable swap target. ``rcodeDB``/``maxmindReader`` shape the reply,
     not the block decision, and are likewise out.
 
-    Immutability note (Phase 3/4 watch-out): the tuple of fields is frozen, but the
+    Immutability note (watch-out): the tuple of fields is frozen, but the
     contained dicts are ordinary dicts. ADR-07's runtime regex eviction still mutates
     ``regex_db`` in place (``_regex_evict_names`` in ``evaluate_domain``); a swap replaces
     the whole snapshot with a freshly-compiled set, so any evicted-pattern state is
@@ -3608,7 +3536,7 @@ class Snapshot:
     ``regex_db``->regexDB, ``allow_regex_db``->allowRegexDB,
     ``feed_group_index_db``->feedGroupIndexDB, ``hsts_db``->hstsDB.
 
-    ``rejects`` (ADR-48 Phase 4, #789) rides alongside ``counts``/``regex_count`` as
+    ``rejects`` (ADR-48, issue #789) rides alongside ``counts``/``regex_count`` as
     a build-diagnostic passthrough -- NOT a per-query stratum (absent from
     ``containers()``) -- so a no-restart swap can re-emit the reject-stats artifact
     from the fresh ``BuildResult`` exactly as it re-emits the UI counts.
@@ -3674,14 +3602,12 @@ def _dnsbl_parse_abp_line(line: str) -> str | None:
 
 
 # --------------------------------------------------------------------------- #
-# ADR-07 Stage-A -- DNS-only ABP option / scope classification.
-#
-# A ``$options`` tail is KEPT only if EVERY option is DNS-relevant ($important /
-# $badfilter). Any page-context option ($third-party / $domain= / $script /
-# $image / $csp / ...), any non-DNS AdGuard modifier whose only effect is a
-# rewrite ($dnsrewrite / $dnstype / $client / $ctag), OR any UNRECOGNISED option
-# makes the whole rule out of DNS scope -> the rule is skipped (parse_abp returns
-# None). Mirrors the Phase-2 oracle _classify_options + ADR.md SS2 "Scope".
+# ADR-07 Stage-A: DNS-only ABP option / scope classification. A ``$options``
+# tail is KEPT only if EVERY option is DNS-relevant ($important / $badfilter).
+# Any page-context option ($third-party / $domain= / $script / $image / $csp
+# / ...), any non-DNS AdGuard modifier that only rewrites ($dnsrewrite /
+# $dnstype / $client / $ctag), or any UNRECOGNISED option puts the whole rule
+# out of DNS scope -> skipped (parse_abp returns None).
 # --------------------------------------------------------------------------- #
 # Options that DO modify a DNS block/allow decision (kept):
 _DNSBL_DNS_RELEVANT_OPTS = frozenset({"important", "badfilter"})
@@ -3726,7 +3652,7 @@ def _dnsbl_classify_options(opts_str: str) -> tuple[tuple[str, ...], bool, bool]
 
     ``sorted_dns_opts`` is the sorted tuple of DNS-relevant option NAMES that are
     NOT ``$badfilter`` (i.e. ``("important",)`` or ``()``) -- it feeds the rule's
-    $badfilter signature (Phase 5). A page-context option, a non-DNS modifier, or
+    $badfilter signature. A page-context option, a non-DNS modifier, or
     an unrecognised option returns None (conservative: never invent a DNS decision
     for a modifier we do not model).
     """
@@ -3756,9 +3682,10 @@ def _dnsbl_parse_abp_regex(stripped: str) -> tuple[str, str, str] | None:
     """Recognise a regex rule. Return ``(kind, inner, opts_str)`` for ``/re/`` (block)
     or ``@@/re/`` (allow), with an OPTIONAL ``$options`` suffix after the closing
     slash (``/re/$important``, ``@@/re/$badfilter``); else ``None``. ``inner`` is the
-    raw pattern between the slashes (NOT compiled here -- reduction is Phase 5,
-    compile/load is Phase 6); ``opts_str`` is the ``$``-suffix (without the ``$``) or
-    "" when absent. The closing slash is the last ``/`` of the rule (no options) or
+    raw pattern between the slashes (NOT compiled here -- reduction happens in
+    reconcile(), compile/load in _dnsbl_compile_regex_rules()); ``opts_str`` is
+    the ``$``-suffix (without the ``$``) or "" when absent. The closing slash
+    is the last ``/`` of the rule (no options) or
     the ``/`` immediately preceding ``$`` (options) -- so a ``/`` inside the pattern
     body does not end it."""
     if stripped.startswith("@@/"):
@@ -3792,9 +3719,8 @@ def parse_abp(
     tally: RejectTally | None = None,
 ) -> Rule | None:
     """The full DNS-only ABP Stage-A parser: one raw ABP line -> a typed ``Rule``
-    (or ``None`` to skip). PURE -- no Unbound symbol, no side effect; NOT wired into
-    build()/init this phase. The reference TARGET is the Phase-2 oracle
-    (tests/test_adr07_decision_spec.py::parse_abp_line); this agrees with it on
+    (or ``None`` to skip). PURE -- no Unbound symbol, no side effect. Agrees with
+    the reference oracle (tests/test_adr07_decision_spec.py::parse_abp_line) on
     every corpus line.
 
     KEEP (-> Rule):
@@ -3814,7 +3740,7 @@ def parse_abp(
     (the caller supplies them from the manifest row). Domain targets pass through
     ``normalise()`` (lower-case + shape gate); an invalid domain -> ``None``.
 
-    ``tally`` (ADR-48 Phase 4, issue #789): optional out-param -- when not ``None``,
+    ``tally`` (ADR-48, issue #789): optional out-param -- when not ``None``,
     a normalise-fail reject on a domain target (anchor/hosts/bare) is counted into
     it (bucket 'shape' | 'wire_cap', keyed (feed, group)). Left ``None`` (the
     default), this function is BYTE-IDENTICAL to before -- purity is test-pinned.
@@ -3972,7 +3898,7 @@ def parse(format_hint: str, line: str) -> ParsedEntry | None:
     reproduces today's per-format behaviour, including which lines are IGNORED.
 
     Bare-IP lines and the csv:pon col-0 IP are NOT returned here -- IP extraction is
-    a PHP/firewall concern (Phase 5); a stray bare IP simply yields ``None`` (and
+    a PHP/firewall concern; a stray bare IP simply yields ``None`` (and
     would fail domain validation anyway). ``feed`` / ``group`` / ``log`` are attached
     by build() from the manifest row, so parse() only resolves the domain token.
 
@@ -3995,7 +3921,7 @@ def parse(format_hint: str, line: str) -> ParsedEntry | None:
 
     if format_hint == "csv:pon":
         # 9-col CSV: domain = col2 (always kept). col0 is handled by the PHP DNSBL-IP
-        # pass (Phase 5); Python ignores it here.
+        # pass; Python ignores it here.
         if stripped.startswith("!") or stripped.lower().startswith("timestamp"):
             return None
         try:
@@ -4022,7 +3948,7 @@ def parse(format_hint: str, line: str) -> ParsedEntry | None:
     return ParsedEntry(kind=DNSBL_KIND_BLOCK, value=token, feed="", group="", log="")
 
 
-# ADR-48 Phase 4 (issue #789): the per-entry reject tally build()/parse_abp()/
+# ADR-48 (issue #789): the per-entry reject tally build()/parse_abp()/
 # reconcile() accumulate into, keyed (feed, group) -> {'shape': n, 'wire_cap': m}.
 # A plain dict (no class): the shape never grows past the two RESOLVED buckets
 # (ADR §2 item 4), so a helper that does the defaulting is all this needs.
@@ -4076,16 +4002,16 @@ def normalise(value: str) -> str | None:
     Length caps mirror the PHP gate at the queryable bound (#753): every label
     <= 63 chars, whole name <= 253 chars (``_dnsbl_within_wire_caps``; the RFC
     1035 presentation cap, applied after the trailing dot is stripped -- the
-    same names PHP's ``strlen < 255`` accepts in dotted form, PR #752). PHP also
+    same names PHP's ``strlen < 255`` accepts in dotted form, #752). PHP also
     tolerates a bare 254-char undotted name (an inert sanity-cap artefact,
-    pinned by PR #752); this gate rejects it as unqueryable. Every entry gated
+    pinned by #752); this gate rejects it as unqueryable. Every entry gated
     here becomes an exact or wildcard match key, and a name that cannot be
     encoded in a DNS query could never match a lookup -- rejecting it keeps
     unreachable dead weight out of the block dicts. The ``reconcile()`` regex
     fold applies the same caps to a domain-literal regex key.
 
     Thin wrapper over ``_normalise_verdict()`` -- see there for the reject-bucket
-    classification (ADR-48 Phase 4, issue #789).
+    classification (ADR-48, issue #789).
     """
     domain, _ = _normalise_verdict(value)
     return domain
@@ -4156,12 +4082,10 @@ def classify(domain: str, tlds: dict[str, dict[str, str]], exclusion: set[str]) 
 # --------------------------------------------------------------------------- #
 # ADR-07 Stage-B reconcile: $badfilter prune + regex reduction + classify +
 # priority bands. PURE / reentrant -- consumes the typed ``Rule`` stream from
-# Stage-A (parse_abp) and produces the pre-emit rule sets. NOT wired into
-# build()/init (Phase 6) and NEVER compiles/executes a regex.
-#
-# The reference TARGETs are tests/test_adr07_decision_spec.py (reduce_regex /
-# reconcile / priority / decide) and benchmarks/spike_adr07_regex.reduce_pattern;
-# this agrees with both. ADR.md SS2 ($badfilter / Regex-reduction / Precedence).
+# Stage-A (parse_abp) into the pre-emit rule sets build() folds in; NEVER
+# compiles/executes a regex itself. Reference oracle:
+# tests/test_adr07_decision_spec.py (reduce_regex/reconcile/priority/decide),
+# benchmarks/spike_adr07_regex.reduce_pattern; ADR.md SS2.
 # --------------------------------------------------------------------------- #
 
 # Regex-reduction grammar (mirrors the Phase-2 oracle reduce_regex + the spike
@@ -4218,7 +4142,7 @@ def _dnsbl_rule_band(rule: Rule) -> int:
 
 @dataclass(frozen=True)
 class BlockDomainRule:
-    """A reconciled domain BLOCK ready to emit into dataDB/zoneDB (Phase 6).
+    """A reconciled domain BLOCK ready to emit into dataDB/zoneDB.
 
     ``cls`` is DNSBL_CLASS_DATA (exact) or DNSBL_CLASS_ZONE (wildcard); ``key`` is
     the anchor domain itself for a ZONE (ABP ``||host^`` covers subdomains at any
@@ -4238,7 +4162,7 @@ class BlockDomainRule:
 
 @dataclass(frozen=True)
 class AllowDomainRule:
-    """A reconciled domain ALLOW ready to emit into whiteDB (Phase 6).
+    """A reconciled domain ALLOW ready to emit into whiteDB.
 
     ``wildcard`` True -> domain + subdomains; False -> exact. ``important`` raises a
     feed allow's band to 4 (and is always effectively sovereign for USER rules)."""
@@ -4252,8 +4176,9 @@ class AllowDomainRule:
 
 @dataclass(frozen=True)
 class RegexRule:
-    """A reconciled IRREDUCIBLE regex (block or allow) handed to Phase 6 to
-    COMPILE (raw ``pattern`` -- NOT compiled here; Stage B never executes a regex).
+    """A reconciled IRREDUCIBLE regex (block or allow), raw ``pattern`` NOT
+    compiled here -- Stage B never executes a regex; ``_dnsbl_compile_regex_rules()``
+    compiles it.
 
     ``kind`` is DNSBL_KIND_BLOCK or DNSBL_KIND_ALLOW. ``band`` is the priority band;
     ``important`` is carried for the 6-band resolution."""
@@ -4272,11 +4197,11 @@ class RegexRule:
 class ReconcileResult:
     """The Stage-B pre-emit rule sets (pure return value -- no global is touched).
 
-    Phase 6 folds these into the matcher dicts + compiles the irreducible regex:
+    build() folds these into the matcher dicts + compiles the irreducible regex:
         block_domains            -> dataDB/zoneDB (+band/important/feed/group/log)
         allow_domains            -> whiteDB ({wildcard, important} + band)
-        block_regex_irreducible  -> regexDB     (compiled in Phase 6)
-        allow_regex_irreducible  -> allowRegexDB (compiled in Phase 6)
+        block_regex_irreducible  -> regexDB     (compiled by _dnsbl_compile_regex_rules())
+        allow_regex_irreducible  -> allowRegexDB (compiled by _dnsbl_compile_regex_rules())
     ``important_rules`` is the build-emitted fast-path flag (ADR.md SS2 "Query-time
     matcher"): True iff ANY surviving rule would engage the numeric 6-band branch
     (any $important, any feed allow/@@ or feed regex). False keeps today's matcher.
@@ -4302,7 +4227,7 @@ def reconcile(
 
     PURE + REENTRANT: builds and returns a FRESH ``ReconcileResult``, mutates no
     argument and no module global, never compiles/executes a regex -- two calls on
-    equal inputs yield equal results. Steps (ADR.md SS2 / RESULTS/04 SS7):
+    equal inputs yield equal results. Steps (ADR.md SS2):
 
       1. $BADFILTER PRUNE (feed-only): collect the signatures of FEED rules carrying
          ``$badfilter``; drop every FEED rule with a matching signature; the
@@ -4310,7 +4235,7 @@ def reconcile(
          collected, never pruned -- sovereignty, fact 7).
       2. REGEX REDUCTION: a reducible regex Rule folds to a domain rule (block ->
          data/zone by its wildcard bit, allow -> whiteDB wildcard); irreducible
-         regex passes through into the irreducible set (compiled in Phase 6).
+         regex passes through into the irreducible set (compiled by build()).
       3. DATA vs ZONE: a wildcard block (``||host^`` / wildcard fold) emits a ZONE
          keyed at the anchor itself -- ABP subdomain coverage at ANY depth (#718);
          a TLD-exclusion domain still forces exact DATA; an exact fold stays DATA.
@@ -4321,7 +4246,7 @@ def reconcile(
     parent rule is a plain/hosts-path concept (ADR-06) that must not demote an ABP
     anchor. Matches the Phase-2 oracle ``reconcile`` + ``decide`` precedence.
 
-    ``tally`` (ADR-48 Phase 4, issue #789): optional out-param -- when not ``None``,
+    ``tally`` (ADR-48, issue #789): optional out-param -- when not ``None``,
     the #753 wire-cap fold-drop (a reducible regex whose folded key is unqueryable)
     is counted into it as 'wire_cap', attributed to the ORIGINATING rule's own
     feed/group (each survivor is reconciled one rule at a time, before any
@@ -4353,7 +4278,7 @@ def reconcile(
         if r.target == RULE_TARGET_REGEX:
             reduced = _dnsbl_reduce_regex(r.key_or_pattern)
             if reduced is None:
-                # Irreducible -> hand the RAW pattern to Phase 6 (compile candidate).
+                # Irreducible -> hand the RAW pattern through as a compile candidate.
                 if r.provenance == RULE_PROV_FEED:
                     result.important_rules = True  # any feed regex engages numeric path
                 regex_rule = RegexRule(
@@ -4472,24 +4397,20 @@ def _dnsbl_normalise_whitelist(
 
 
 # ============================================================================ #
-# ADR-07 P7 -- regex safety (opt-in static cap + always-on runtime warn/evict)  #
+# ADR-07: regex safety (opt-in static cap + always-on runtime warn/evict)      #
 # ============================================================================ #
 # `re` does not release the GIL during a match and a Python thread cannot be
-# killed (ADR.md fact 2), so a query-time timeout CANNOT interrupt a catastrophic
-# match. The accepted design is a bounded residual: a pathological pattern's FIRST
-# match may block one query, but it is then EVICTED so it cannot hang again. Two
-# layers, both stdlib + in-process, applied to FEED *and* user regex:
-#   (1) opt-in static cap -- drop over-long / nested-quantifier patterns at LOAD
-#       (no execution) when the "Limit long/complex regex" setting is enabled;
-#   (2) always-on runtime timing -- time each match (per-thread CPU); over a WARN
-#       ceiling log (rate-limited), over a higher EVICT ceiling log + remove the
-#       pattern from the live regexDB/allowRegexDB (snapshot-iterate, evict-after-
-#       loop -- never mutate mid-iteration; dict.pop is atomic under the GIL).
+# killed, so a query-time timeout CANNOT interrupt a catastrophic match. Bounded
+# residual instead: a pathological pattern's FIRST match may block one query,
+# then it is EVICTED so it cannot hang again. (1) opt-in static cap drops
+# over-long/nested-quantifier patterns at LOAD; (2) always-on runtime timing
+# evicts a pattern from the live regexDB/allowRegexDB over an EVICT ceiling
+# (snapshot-iterate, evict-after-loop; dict.pop is atomic under the GIL).
 
-# Length ceiling (Phase-1 RESULTS/01 SS3c heuristic): a pattern over this many
-# characters is dropped at load ONLY when the opt-in "Limit long/complex regex"
-# setting is enabled. Length alone is a tunable convenience cap, NOT a safety gate --
-# a long pattern is not inherently pathological -- so it stays behind the flag.
+# Length ceiling (heuristic): a pattern over this many characters is dropped
+# at load ONLY when the opt-in "Limit long/complex regex" setting is enabled.
+# Length alone is a tunable convenience cap, NOT a safety gate -- a long
+# pattern is not inherently pathological -- so it stays behind the flag.
 REGEX_STATIC_LEN_CAP = 200
 
 # A quantified group that itself sits inside a quantifier: (a+)+, (a*)*, (\w+\.)+,
@@ -4569,8 +4490,7 @@ def _required_literal(pattern: str) -> str | None:
     Backs the per-query regex-rule prefilter: rules are bucketed by this literal's
     first char and only run when it is present in the query; a rule with no literal
     is always-run.  Necessary-condition only -- it never drops a match.  Rationale,
-    benchmarks, and the bucket-vs-Aho-Corasick decision live in
-    .ADRs/ADR_28_Code_Quality_Conventions/RESULTS/12_Results.txt.
+    benchmarks, and the bucket-vs-Aho-Corasick decision live in ADR-28.
 
     Walks Python's regex AST to find the longest contiguous run of mandatory literal
     characters.  A run is broken by anything that is not a guaranteed-present literal:
@@ -4798,14 +4718,14 @@ def build(
 ) -> BuildResult:
     """Pure, reentrant DNSBL build: raw feeds + config -> matcher structure-set.
 
-    ``manifest`` is the per-feed boundary (RESULTS/01_Results.txt SS1i): one row per
+    ``manifest`` is the per-feed boundary: one row per
     raw feed file mapping it to ``{raw, feed, group, format_hint, log_flag}``.
     ``config`` carries the classification + whitelist inputs (``tld_master`` suffix
     lines, ``tld_blacklist``, ``tld_exclusion``, ``user_whitelist``, ``user_unlock``,
     ``top1m_list``).
     ``line_reader`` yields the raw lines for a feed's ``raw`` reference -- injected so
     this stays pure and side-effect-free (no filesystem coupling, unit-testable; the
-    init wiring in Phase 4 supplies a file-backed reader).
+    init wiring supplies a file-backed reader).
 
     Returns a FRESH ``BuildResult`` and mutates no module global -- calling it twice
     yields equal structures (reentrant / zero-downtime-ready). It performs NO dedup,
@@ -4814,7 +4734,7 @@ def build(
     change, ADR.md SS2), and redundant subdomains stay because their parent zone still
     matches them.
 
-    ADR-48 Phase 4 (#789): every domain target a normalise-fail rejects (permit path,
+    ADR-48 (issue #789): every domain target a normalise-fail rejects (permit path,
     plain path, both parse_abp() call sites) and the reconcile() wire-cap fold-drop
     are tallied into ``BuildResult.rejects`` (bucket 'shape' | 'wire_cap', keyed
     (feed, group)) -- accounting only, no gate DECISION changes.
@@ -4835,7 +4755,7 @@ def build(
     feed_group_index_db: dict[int, dict[str, str]] = {}
     feed_group_db: dict[str, int] = {}
     next_index = 0
-    # ADR-48 Phase 4 (#789): the per-entry reject tally this build accumulates.
+    # ADR-48 (issue #789): the per-entry reject tally this build accumulates.
     rejects: RejectTally = {}
 
     def index_for(feed: str, group: str) -> int:
@@ -5040,9 +4960,10 @@ def build(
                     "band": a.band,
                 }
 
-        # Irreducible regex -> regexDB (block) / allowRegexDB (allow). Compile here
-        # (Phase 6); a broken pattern is logged + skipped, mirroring the init regex
-        # load (pfb_unbound.py REGEX section). NO runtime cap/evict guard yet (P7).
+        # Irreducible regex -> regexDB (block) / allowRegexDB (allow). Compile here;
+        # a broken pattern is logged + skipped, mirroring the init regex load
+        # (pfb_unbound.py REGEX section). The runtime warn/evict guard (ADR-07)
+        # applies later, at query time in evaluate_domain, not during this compile.
         # Iterate over a stable list so the emit order is deterministic.
         regex_db, block_admitted = _dnsbl_compile_regex_rules(result.block_regex_irreducible, static_cap=static_cap)
         allow_regex_db, allow_admitted = _dnsbl_compile_regex_rules(
@@ -5083,7 +5004,7 @@ def _dnsbl_path_within_base(path: str, base_dir: str) -> bool:
 
 def _dnsbl_file_line_reader(base_dir: str) -> Callable[[str], Iterable[str]]:
     """A file-backed ``line_reader`` for build(): map a feed_row["raw"] reference to
-    its raw lines, streamed lazily so peak RAM stays at the dict floor (RESULTS/01).
+    its raw lines, streamed lazily so peak RAM stays at the dict floor.
 
     ``raw`` may be an absolute path or a name relative to ``base_dir`` (the directory
     holding the manifest). Yields stripped-of-newline lines; a missing/unreadable feed
@@ -5164,10 +5085,10 @@ def dnsbl_build_from_manifest(manifest_path: str) -> BuildResult | None:
     at init and assigns the result into the module globals -- no background/restart-
     free behaviour is added here.
 
-    The manifest carries ``feeds`` (one row per raw feed file) and a ``config`` block
-    (RESULTS/01 SS2). ``top1m_enabled`` is taken from ``config["top1m_enabled"]``.
-    Returns ``None`` when the manifest is absent or cannot be parsed (init then falls
-    back to the legacy CSV load -- shell/PHP still produce those files until Phase 5).
+    The manifest carries ``feeds`` (one row per raw feed file) and a ``config`` block.
+    ``top1m_enabled`` is taken from ``config["top1m_enabled"]``. Returns ``None`` when
+    the manifest is absent or cannot be parsed (init then falls back to the legacy
+    CSV load -- shell/PHP still produce those files for that fallback).
     """
     if not os.path.isfile(manifest_path):
         return None
@@ -5201,9 +5122,9 @@ def dnsbl_emit_count(count_path: str, count: int) -> bool:
 
     ADR-06 redefines ``pfb_py_count`` to the LOADED entry total (len(dataDB)+len(
     zoneDB)); its value legitimately RISES vs today because the lists are no longer
-    dedup/collapse/whitelist/TOP1M-pruned (RESULTS/01 SS1e). The sync-check at
-    inc:3149-3156 still subtracts this value -- it must be reconciled when shell/PHP
-    is slimmed (Phase 5); flagged in the handoff. Returns True on success.
+    dedup/collapse/whitelist/TOP1M-pruned. The sync-check at inc:3149-3156 still
+    subtracts this value -- it must be reconciled once shell/PHP is slimmed to
+    match. Returns True on success.
     """
     try:
         with open(count_path, "w", encoding="utf-8") as fh:
@@ -5215,7 +5136,7 @@ def dnsbl_emit_count(count_path: str, count: int) -> bool:
 
 
 def dnsbl_emit_reject_stats(stats_path: str, rejects: RejectTally) -> bool:
-    """Write the ADR-48 Phase 4 (#789) per-entry reject tally to ``pfb_py_reject_stats``
+    """Write the ADR-48 (issue #789) per-entry reject tally to ``pfb_py_reject_stats``
     as a JSON array of ``{"feed", "group", "shape", "wire_cap"}`` rows, one per
     (feed, group) with a NONZERO bucket -- PHP reads it after a DNSBL run and emits
     the canonical ``stage=entries`` line per nonzero bucket (Python never logs the
@@ -5258,8 +5179,8 @@ def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_coun
 
     On SUCCESS (a non-None Snapshot):
       1. atomically rebind the single module ``_snapshot`` ref (one GIL-atomic STORE --
-         RESULTS/01 SS1: shared __main__ dict + GIL, so the new snapshot is visible to
-         every query worker without a lock on the hot path);
+         shared __main__ dict + GIL, so the new snapshot is visible to every query
+         worker without a lock on the hot path);
       2. ``decisionDB.clear()`` -- the unified per-name LRU query memo (#67/#70/#72).
          It is otherwise reset only by ``init`` re-creating it, so a no-restart swap
          MUST clear it or ``operate()`` re-serves a STALE block/allow verdict on a cache
@@ -5275,14 +5196,14 @@ def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_coun
     NEITHER cache (decisionDB AND the Reports sqlite stay intact), log, and return
     ``False`` -- fail-closed, mirroring init's ``build_result is not None`` guard. The
     swap NEVER installs an empty/partial set on a build error; the resolver keeps
-    serving the last good snapshot (Phase 4's background watcher relies on exactly this
-    so a failed reload is a no-op, not an outage).
+    serving the last good snapshot (the background reload-watcher relies on exactly
+    this so a failed reload is a no-op, not an outage).
 
-    This phase calls it SYNCHRONOUSLY from ``init_standard`` (net init behaviour
-    unchanged: the same snapshot, a no-op decisionDB clear on the fresh empty cache, a
-    Reports reset in parity with the init os.remove, and -- with ``emit_counts=False``
-    -- init's own unchanged inline count emits). Phase 4 adds only the background
-    thread + trigger that calls this same function with the default ``emit_counts=True``.
+    ``init_standard`` calls it SYNCHRONOUSLY (net init behaviour unchanged: the same
+    snapshot, a no-op decisionDB clear on the fresh empty cache, a Reports reset in
+    parity with the init os.remove, and -- with ``emit_counts=False`` -- init's own
+    unchanged inline count emits). The background reload-watcher thread calls this
+    same function with the default ``emit_counts=True``.
     """
     global _snapshot
 
@@ -5330,7 +5251,7 @@ def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_coun
     if emit_counts:
         dnsbl_emit_count(pfb["pfb_py_count"], new_snapshot.counts)
         dnsbl_emit_count(pfb["pfb_py_regex_count"], new_snapshot.regex_count)
-        # ADR-48 Phase 4 (#789): re-emit the reject-stats artifact from the new
+        # ADR-48 (issue #789): re-emit the reject-stats artifact from the new
         # snapshot on a no-restart swap too, exactly like the UI counts above.
         # ``.get()`` (not a bare index): unit tests build a bare ``pfb`` dict
         # without this key and must not KeyError on an unrelated code path.
@@ -5473,7 +5394,7 @@ class DnsblDecision:
     feed: Any
     group: Any
     b_eval: str
-    # ADR-08 Phase 5: a Confusable-mode ALERT (suspicious/flagged, or malicious with
+    # ADR-08: a Confusable-mode ALERT (suspicious/flagged, or malicious with
     # block disabled) does NOT block -- the name resolves (is_found stays False) -- but
     # the anomaly must be surfaced. When an alert fired this carries its
     # (feed, group, b_eval) so operate() emits a dnsbl.log line in the same shape as a
@@ -5836,7 +5757,7 @@ def evaluate_domain(
     feed: Any = "Unknown"
     group: Any = "Unknown"
     b_eval = ""
-    # ADR-08 Phase 5: a Confusable-mode ALERT (non-blocking) records its attribution here
+    # ADR-08: a Confusable-mode ALERT (non-blocking) records its attribution here
     # so operate() can log it while the name still resolves; None on the common path.
     idn_alert: Any = None
     # The dual-form description of a Confusable BLOCK (xn-- [decoded] script), captured in
@@ -5925,7 +5846,7 @@ def evaluate_domain(
                 # overridden (allow_band >= 0 is always true) and resolve it anyway.
                 block_band = PRIO_FEED_BLOCK
             elif idn_mode is IdnMode.Confusable:
-                # Confusable arm (Phase 5): decode + TR39 mixed-script analysis, PER-LABEL,
+                # Confusable arm: decode + TR39 mixed-script analysis, PER-LABEL,
                 # gated by is_idn_domain (a non-xn-- query pays nothing). classify_idn is
                 # decode-safe -- a malformed label is FLAGGED, never raised into the resolver.
                 action, verdict = idn_confusable_action(
@@ -6595,9 +6516,10 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
         # SafeSearch CNAME redirect (duckduckgo.com / pixabay.com). Handled here,
         # post-resolution, because Unbound will not chase a CNAME the module hands
         # it (issue #149 / unbound #976): we plant the synthetic CNAME in the cache
-        # and restart the iterator so it chases the target itself. Phase 1 (plant +
-        # restart) and phase 2 (fix DNSSEC + finish, or #2 baked fallback) are
-        # distinguished inside safesearch_cname_redirect by the resolved answer.
+        # and restart the iterator so it chases the target itself. The first pass
+        # (plant + restart) and the second pass (fix DNSSEC + finish, or the baked
+        # fallback) are distinguished inside safesearch_cname_redirect by the
+        # resolved answer.
         if qstate_valid and pfb["safeSearchDB"]:
             isSafeSearch = safesearch_entry(q_name_original)
             if isSafeSearch is not None and isSafeSearch["A"] == "cname":

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -121,7 +121,7 @@ safeSearchDB: defaultdict[str, Any]
 feedGroupIndexDB: defaultdict[int, Any]
 maxmindReader: Any
 
-# ADR-10 P2: the single module-level reference to the current immutable matcher
+# ADR-10: the single module-level reference to the current immutable matcher
 # snapshot. init_standard builds it from the loaded strata and assigns it ONCE
 # (replacing the per-global query-time read); operate() captures this ONE ref per
 # query and reads every matcher field off it. A future zero-downtime reload rebinds
@@ -139,7 +139,7 @@ pfb_log_queue: queue.Queue
 pfb_log_listener: Any
 pfb_loggers: dict[str, Any] = {}
 
-# ADR-10 P4: the reload-watcher daemon thread + its stop handle (a threading.Event).
+# ADR-10: the reload-watcher daemon thread + its stop handle (a threading.Event).
 # The watcher waits on the reload sentinel's DIRECTORY and runs rebuild_and_swap() off
 # the query threads on a generation-id advance. Declared here; created in init_standard
 # (gated on pfb["mod_threading"]) and joined in deinit.
@@ -253,7 +253,7 @@ def pfb_async(func: Callable[..., Any], *args: Any) -> None:
 # Pinned by tests/test_adr10_watcher.py, tests/test_adr10_swap.py.
 # --------------------------------------------------------------------------- #
 
-# Steady-state retained bytes per matcher entry (ADR-05 SS3a / ADR-10 P1 spike:
+# Steady-state retained bytes per matcher entry (ADR-05 SS3a / ADR-10 spike:
 # 274-276 B/entry). Used to PROJECT the both-resident transient of an in-process build.
 RELOAD_BYTES_PER_ENTRY = 276
 # Headroom kept free above the projected transient so the build does not drive the box
@@ -454,7 +454,7 @@ def _reload_run_swap(builder: Callable[[], Snapshot | None]) -> bool:
     Projects the build's transient from the LIVE snapshot's entry count and consults the
     RAM gate FIRST; if the box cannot fit the ~2x transient, DECLINE fail-closed -- the
     old snapshot stays live, log that the update needs the restart fallback. Otherwise
-    delegate to the Phase-3 fail-closed rebuild_and_swap (default emit_counts=True so the
+    delegate to the fail-closed rebuild_and_swap (default emit_counts=True so the
     UI counts refresh without a restart).
 
     Returns ``True`` iff the snapshot was actually swapped in (the caller then advances
@@ -919,14 +919,14 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["hstsDB"] = False
     pfb["whiteDB"] = False
     pfb["regexDB"] = False
-    # ADR-07 P3: allow-regex container (@@/re/) and the $important/$badfilter fast-path
+    # ADR-07: allow-regex container (@@/re/) and the $important/$badfilter fast-path
     # flag. Both are inert today (no ABP rule is parsed yet) -- the matcher keeps its
     # existing early-exit path while important_rules is False (behaviour-preserving).
     pfb["allowRegexDB"] = False
     pfb["important_rules"] = False
-    # ADR-07 P7 regex-safety defaults: cap OFF (nothing dropped at load unless the
+    # ADR-07 regex-safety defaults: cap OFF (nothing dropped at load unless the
     # user enables "Limit long/complex regex"); runtime warn/evict ALWAYS on at the
-    # Phase-1 ceilings. The ini MAIN section overrides these.
+    # measured ceilings. The ini MAIN section overrides these.
     pfb["regex_cap"] = False
     pfb["regex_warn_ms"] = REGEX_WARN_MS_DEFAULT
     pfb["regex_evict_ms"] = REGEX_EVICT_MS_DEFAULT
@@ -992,7 +992,7 @@ def init_standard(id: int, env: module_env) -> bool:
     # it falls back to the legacy data/zone CSV load (shell/PHP still produce
     # those files for that fallback).
     pfb["pfb_py_sources"] = "pfb_py_sources.json"
-    # ADR-10 P4: the zero-downtime RELOAD SENTINEL. Path is chroot-relative (Unbound
+    # ADR-10: the zero-downtime RELOAD SENTINEL. Path is chroot-relative (Unbound
     # is chrooted at /var/unbound, the module's CWD) -- so the in-chroot absolute path
     # PHP/shell must write is /var/unbound/pfb_py_reload. PHP atomically publishes the
     # new manifest + per-feed raw, then writes a monotonically-advancing GENERATION ID
@@ -1023,7 +1023,7 @@ def init_standard(id: int, env: module_env) -> bool:
     # so the writer can confirm execution. Host path /var/unbound/pfb_py_control.applied.
     pfb["pfb_py_control_applied"] = "pfb_py_control.applied"
     pfb["pfb_py_count"] = "pfb_py_count"
-    # ADR-07 P8: the ADMITTED (cap-filtered) feed+user regex total -- the count the
+    # ADR-07: the ADMITTED (cap-filtered) feed+user regex total -- the count the
     # DNSBL_Regex UI alias reads (inc:8329). It is the live size of regexDB +
     # allowRegexDB AFTER both the user REGEX-ini load and the feed-regex merge, so
     # patterns the static cap dropped are excluded (value changes by design, ADR §2).
@@ -1092,7 +1092,7 @@ def init_standard(id: int, env: module_env) -> bool:
 
     regexDB = defaultdict(str)
     allowRegexDB = defaultdict(str)
-    # ADR-07 P7: clear the runtime warn rate-limit + perf-fallback strike state on a
+    # ADR-07: clear the runtime warn rate-limit + perf-fallback strike state on a
     # (re)load so a fresh regex set starts with clean warn/evict bookkeeping.
     _regex_warned.clear()
     _regex_perf_strikes.clear()
@@ -1184,11 +1184,11 @@ def init_standard(id: int, env: module_env) -> bool:
             if config.has_option("MAIN", "forwarding"):
                 pfb["forwarding"] = config.getboolean("MAIN", "forwarding")
 
-            # ADR-07 P7: regex-safety knobs. ``regex_cap`` is the opt-in "Limit
+            # ADR-07: regex-safety knobs. ``regex_cap`` is the opt-in "Limit
             # long/complex regex" static pre-filter (drops over-long/nested-quantifier
             # patterns at load -- feed AND user). ``regex_warn_ms`` / ``regex_evict_ms``
             # are the always-on runtime warn/evict ceilings (per-match thread CPU). All
-            # default to OFF / the Phase-1 defaults when absent.
+            # default to OFF / the measured defaults when absent.
             if config.has_option("MAIN", "regex_cap"):
                 pfb["regex_cap"] = config.getboolean("MAIN", "regex_cap")
             if config.has_option("MAIN", "regex_warn_ms"):
@@ -1250,7 +1250,7 @@ def init_standard(id: int, env: module_env) -> bool:
                 if regex_config:
                     r_count = 1
                     for name, pattern in regex_config:
-                        # ADR-07 P7: a catastrophic SHAPE in the un-vetted USER regex
+                        # ADR-07: a catastrophic SHAPE in the un-vetted USER regex
                         # list is dropped at load UNCONDITIONALLY (logged, not compiled)
                         # -- the always-on safety gate. The opt-in length ceiling (the
                         # "Limit long/complex regex" setting) is the separate tunable
@@ -1334,7 +1334,7 @@ def init_standard(id: int, env: module_env) -> bool:
             # Collect SafeSearch Redirection list
             _load_safesearch_db()
 
-            # ADR-06 P4: prefer BUILDING the DNSBL structures from the raw feeds via
+            # ADR-06: prefer BUILDING the DNSBL structures from the raw feeds via
             # the pure build() layer (the new shell->Python boundary). When the
             # per-feed manifest is present, Python parses -> normalises -> classifies
             # (data/zone) -> builds dataDB/zoneDB/feedGroupIndexDB/whiteDB and emits
@@ -1355,7 +1355,7 @@ def init_standard(id: int, env: module_env) -> bool:
                 feedGroupIndexDB = build_result.feed_group_index_db
                 whiteDB = build_result.white_db
 
-                # ADR-07 P6: MERGE the ABP feed block-regex into regexDB (preserving the
+                # ADR-07: MERGE the ABP feed block-regex into regexDB (preserving the
                 # user-regex patterns compiled from the REGEX ini section above) and load
                 # the @@/re/ allow-regex into allowRegexDB. Feed regex carry an explicit
                 # band + $important; user regex are the {re, band: PRIO_USER_BLOCK (5)}
@@ -1467,7 +1467,7 @@ def init_standard(id: int, env: module_env) -> bool:
                                         wildcard = True
                                     else:
                                         wildcard = False
-                                    # ADR-07 P3: whiteDB value widens to
+                                    # ADR-07: whiteDB value widens to
                                     # {"wildcard", "important"}; the legacy CSV is the
                                     # USER whitelist -> important=True (sovereignty).
                                     whiteDB[row[0]] = {"wildcard": wildcard, "important": True}
@@ -1492,7 +1492,7 @@ def init_standard(id: int, env: module_env) -> bool:
                         sys.stderr.write("[pfBlockerNG]: Failed to load: {}: {}".format(pfb["pfb_py_hsts"], e))
                         pass
 
-            # ADR-07 P8: emit the ADMITTED regex total for the DNSBL_Regex UI alias
+            # ADR-07: emit the ADMITTED regex total for the DNSBL_Regex UI alias
             # (inc:8329). regexDB now holds USER regex (REGEX-ini) + FEED block regex
             # (merged from build()); allowRegexDB holds FEED @@/re/ allow regex. Both
             # have already had over-cap patterns dropped at load when the static cap is
@@ -1531,7 +1531,7 @@ def init_standard(id: int, env: module_env) -> bool:
     else:
         log_info("[pfBlockerNG]: Failed to load ini configuration. Ini file missing.")
 
-    # ADR-10 P3: BUNDLE the loaded matcher strata into ONE immutable Snapshot and
+    # ADR-10: BUNDLE the loaded matcher strata into ONE immutable Snapshot and
     # install it through the shared fail-closed rebuild_and_swap(). Up to here init
     # populated the scratch globals (dataDB/zoneDB/whiteDB/regexDB/allowRegexDB/
     # feedGroupIndexDB/hstsDB) exactly as before -- from the manifest build() OR the
@@ -1589,7 +1589,7 @@ def init_standard(id: int, env: module_env) -> bool:
             pfb["async_worker"] = False
             sys.stderr.write("[pfBlockerNG]: Failed to start async I/O worker: {}".format(e))
 
-    # ADR-10 P4: start the zero-downtime reload-watcher (daemon). It waits on the reload
+    # ADR-10: start the zero-downtime reload-watcher (daemon). It waits on the reload
     # sentinel and runs a single-flight, RAM-gated rebuild_and_swap() off the query
     # threads on a generation advance -- no Unbound restart for a DNSBL-data update.
     if pfb["mod_threading"] and not pfb.get("reload_watcher"):
@@ -1695,7 +1695,7 @@ def idn_mode_decision(q_name: str, idn_mode: IdnMode) -> bool:
 # is punycode-decoded, each code point's script read from unicodedata.name(), and
 # a severity assigned PER LABEL (never unioned across the dot). Decode-safe: a
 # malformed label is FLAGGED, never raised into operate(). Graded against the
-# Phase-2 oracle + corpus in tests/test_adr08_*.
+# reference oracle + corpus in tests/test_adr08_*.
 # --------------------------------------------------------------------------- #
 
 SEV_LEGIT = "legit"
@@ -1842,7 +1842,7 @@ IDN_GROUP_MALICIOUS = "DNSBL_Homoglyph"
 IDN_FEED_SUSPECT = "Homoglyph_Suspect"
 IDN_GROUP_SUSPECT = "DNSBL_Homoglyph_Suspect"
 
-# The three matcher actions the analyzer's severity maps to (mirrors the Phase-2
+# The three matcher actions the analyzer's severity maps to (mirrors the reference
 # oracle's ACT_NONE/ACT_ALERT/ACT_BLOCK under the two sub-toggles).
 IDN_ACT_NONE = "none"
 IDN_ACT_ALERT = "alert"
@@ -1965,7 +1965,7 @@ def idn_confusable_action(
     work, returns ``(IDN_ACT_NONE, None)``). On an xn-- query it classifies the name
     PER-LABEL via the pure analyzer (``classify_idn`` never raises -- a malformed label
     is FLAGGED, the resolver never crashes) and maps severity -> action exactly like the
-    Phase-2 oracle's ``action(...)`` under the two sub-toggles:
+    reference oracle's ``action(...)`` under the two sub-toggles:
 
       * MALICIOUS  -> block  when ``block_malicious`` (default-ON); alert when disabled.
       * SUSPICIOUS / FLAGGED -> alert by default; block when ``escalate_suspicious`` (opt-in).
@@ -2368,7 +2368,7 @@ def _db_flush_cache(rows: list[Any]) -> bool:
 
 
 def _db_reset_cache() -> bool:
-    # ADR-10 P3: reset the DNSBL Reports cache (the dnsblcache table the Reports tab
+    # ADR-10: reset the DNSBL Reports cache (the dnsblcache table the Reports tab
     # reads) on a zero-downtime DNSBL swap, in parity with the init-time os.remove of
     # pfb_py_cache.sqlite. Goes through _db_run -> _db_lock, so it serializes with the
     # off-thread pfb_db_worker (and the synchronous fallback) on the SAME persistent
@@ -3276,7 +3276,7 @@ def deinit(id: int) -> bool:
     if pfb["python_maxmind"]:
         maxmindReader.close()
 
-    # ADR-10 P4: stop the reload-watcher cleanly -- set the stop Event (which also wakes
+    # ADR-10: stop the reload-watcher cleanly -- set the stop Event (which also wakes
     # the kqueue/poll wait via its timeout), then join with a timeout so deinit never
     # hangs on a stuck watcher. The thread is a daemon, so a missed join cannot block
     # interpreter shutdown either.
@@ -3502,7 +3502,7 @@ class BuildResult:
 
 @dataclass(frozen=True)
 class Snapshot:
-    """ADR-10 P2: the immutable bundle of every matcher stratum a DNS query reads.
+    """ADR-10: the immutable bundle of every matcher stratum a DNS query reads.
 
     Today the matcher reads several independent module globals per query
     (``dataDB``/``zoneDB``/``whiteDB``/``regexDB`` + ADR-07's ``allowRegexDB`` and the
@@ -3849,7 +3849,7 @@ def parse_abp(
             group=group,
             log=log,
             signature=(dom, ()),
-            wildcard=True,  # plain/hosts cover the domain + subdomains (Phase-2 spec)
+            wildcard=True,  # plain/hosts cover the domain + subdomains (reference oracle)
         )
 
     # ---- bare plain domain ---------------------------------------------- #
@@ -4088,7 +4088,7 @@ def classify(domain: str, tlds: dict[str, dict[str, str]], exclusion: set[str]) 
 # benchmarks/spike_adr07_regex.reduce_pattern; ADR.md SS2.
 # --------------------------------------------------------------------------- #
 
-# Regex-reduction grammar (mirrors the Phase-2 oracle reduce_regex + the spike
+# Regex-reduction grammar (mirrors the reference oracle reduce_regex + the spike
 # reduce_pattern). A reducible ``/re/`` decides IDENTICALLY to a domain/wildcard
 # rule, so it folds to a domain Rule at zero per-query cost. ``D`` is a domain
 # literal: labels of [a-z0-9-] joined by ESCAPED dots (``\.``), no other metachar.
@@ -4106,7 +4106,7 @@ def _dnsbl_reduce_regex(inner: str) -> tuple[bool, str] | None:
     domain/wildcard rule, else ``None`` (irreducible -- stays a compiled pattern).
 
     ``wildcard`` True -> domain + subdomains (zone); False -> exact (data). Mirrors
-    the Phase-2 oracle ``reduce_regex`` + ``spike.reduce_pattern`` exactly (so a
+    the reference oracle ``reduce_regex`` + ``spike.reduce_pattern`` exactly (so a
     reducible feed regex == its dict form). Pure; does NOT compile the pattern.
     Per ADR.md SS2 we do NOT expand finite classes (``ad[0-9]\\.x`` stays a regex).
     """
@@ -4244,7 +4244,7 @@ def reconcile(
     ``exclusion`` is the TLD-exclusion set (same shape build() uses). ``tlds`` is
     kept for signature stability but no longer consulted: classify's registrable-
     parent rule is a plain/hosts-path concept (ADR-06) that must not demote an ABP
-    anchor. Matches the Phase-2 oracle ``reconcile`` + ``decide`` precedence.
+    anchor. Matches the reference oracle ``reconcile`` + ``decide`` precedence.
 
     ``tally`` (ADR-48, issue #789): optional out-param -- when not ``None``,
     the #753 wire-cap fold-drop (a reducible regex whose folded key is unqueryable)
@@ -4367,7 +4367,7 @@ def _dnsbl_normalise_whitelist(
     TOP1M entries are loaded ONLY when enabled (bare domains -> exact). No build-time
     list pruning -- this only populates whiteDB.
 
-    ADR-07 P3: the whiteDB value widens from a bare ``bool`` (wildcard?) to
+    ADR-07: the whiteDB value widens from a bare ``bool`` (wildcard?) to
     ``{"wildcard": bool, "important": bool}``. User whitelist + TOP1M load as
     ``important=True`` (user-intent sovereignty, ADR.md SS2 / fact 7). Because an
     allow already beats every block today, this changes NO decision now -- the
@@ -4414,7 +4414,7 @@ def _dnsbl_normalise_whitelist(
 REGEX_STATIC_LEN_CAP = 200
 
 # A quantified group that itself sits inside a quantifier: (a+)+, (a*)*, (\w+\.)+,
-# ([a-z]+)*, (.*a){20}. Phase-1 measured this catching 1/1 catastrophic patterns in
+# ([a-z]+)*, (.*a){20}. Measured to catch 1/1 catastrophic patterns in
 # the corpus with no false-negatives and no false-positives on the cap-passing set.
 _REGEX_NESTED_QUANTIFIER = re.compile(r"\([^()]*[+*][^()]*\)\s*[+*{]")
 
@@ -4446,12 +4446,12 @@ _REGEX_STACKED_BOUNDED_REPEAT = re.compile(r"(?:\)|\]|\w)\{\d+(?:,\d*)?\}\{\d+(?
 # pair matches a structural template. The threshold (12) is generous: realistic ABP/DNS
 # feed regex carries a handful of anchors + one or two trailing quantifiers (a domain
 # pattern like `^(.+\.)?ads?[0-9]*\.example\.(com|net|org)$` counts ~5), so 12 clears
-# every benign pattern in the Phase-1 corpus while still bounding adversarial stacking.
+# every benign pattern in the corpus while still bounding adversarial stacking.
 _REGEX_BUDGET_MAX = 12
 _REGEX_UNBOUNDED_QUANTIFIER = re.compile(r"(?<!\\)[+*]")
 _REGEX_ALTERNATION = re.compile(r"(?<!\\)\|")
 
-# Runtime warn/evict ceilings (milliseconds of per-match thread CPU; Phase-1
+# Runtime warn/evict ceilings (milliseconds of per-match thread CPU; measured
 # defaults, ADR.md SS2). Overridable via the pfb_unbound.ini MAIN section
 # (regex_warn_ms / regex_evict_ms) -> cfg, so they are not hardcoded magic.
 REGEX_WARN_MS_DEFAULT = 10.0
@@ -4664,7 +4664,7 @@ def _dnsbl_compile_regex_rules(
     load) -- it never aborts the build. Names are unique per pattern occurrence so two
     feeds carrying the same pattern both load.
 
-    ADR-07 P7: a pattern carrying a catastrophic SHAPE (nested / adjacent / overlapping
+    ADR-07: a pattern carrying a catastrophic SHAPE (nested / adjacent / overlapping
     unbounded quantifier, stacked bounded repeat, or over the complexity budget) is
     DROPPED at load UNCONDITIONALLY -- independent of ``static_cap`` -- because such a
     shape drives catastrophic backtracking in the `re` engine. The opt-in length ceiling
@@ -4744,7 +4744,7 @@ def build(
     tld_exclusion = list(config.get("tld_exclusion", []))
     exclusion = {e.strip(".") for e in tld_exclusion}
 
-    # ADR-07 P7: the opt-in static cap (drop over-long / nested-quantifier feed regex
+    # ADR-07: the opt-in static cap (drop over-long / nested-quantifier feed regex
     # at load). Read from the manifest config; OFF by default so nothing is dropped.
     static_cap = bool(config.get("regex_cap", False))
 
@@ -4806,7 +4806,7 @@ def build(
             "band": max(_white_entry_band(existing), _white_entry_band(unlock_entry)),
         }
 
-    # ADR-07 P6: ABP feeds (format_hint='abp') are parsed into the typed Rule stream
+    # ADR-07: ABP feeds (format_hint='abp') are parsed into the typed Rule stream
     # (Stage A, parse_abp) and reconciled (Stage B) into the banded pre-emit rule
     # sets; non-ABP feeds keep the ADR-06 lite parse() -> block-only path unchanged.
     # The reconciled ABP structures (incl. @@/regex/important/badfilter) are emitted
@@ -5058,7 +5058,7 @@ def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict
             except OSError as e:
                 sys.stderr.write("[pfBlockerNG]: Failed to read tld_master '{}': {}".format(path, e))
 
-    # ADR-07 P7: the static-cap flag reaches build() via the ini-derived pfb setting
+    # ADR-07: the static-cap flag reaches build() via the ini-derived pfb setting
     # (the cap setting lives in pfb_unbound.ini MAIN, not the manifest); a manifest
     # ``config.regex_cap`` (if present) takes precedence so the build stays a pure
     # function of (manifest+config) in tests that inject it directly.
@@ -5079,7 +5079,7 @@ def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict
 def dnsbl_build_from_manifest(manifest_path: str) -> BuildResult | None:
     """Read the per-feed manifest JSON and BUILD the DNSBL structure-set from raw.
 
-    This is the ADR-06 P4 init swap point: a pure ``(manifest+raw) -> BuildResult``
+    This is the ADR-06 init swap point: a pure ``(manifest+raw) -> BuildResult``
     step (build() mutates no global) that a future zero-downtime reload can run on a
     background thread and atomically swap in. This phase only calls it synchronously
     at init and assigns the result into the module globals -- no background/restart-
@@ -5169,7 +5169,7 @@ def dnsbl_emit_reject_stats(stats_path: str, rejects: RejectTally) -> bool:
 
 
 def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_counts: bool = True) -> bool:
-    """ADR-10 P3: the single fail-closed build -> atomic-swap + cache-reset step.
+    """ADR-10: the single fail-closed build -> atomic-swap + cache-reset step.
 
     ``build_snapshot`` is a zero-arg builder that produces a BRAND-NEW ``Snapshot`` off
     the live one (the pure ``build()``/``dnsbl_build_from_manifest()`` layer plus the
@@ -5228,7 +5228,7 @@ def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_coun
     # warn-suppression + perf-fallback strike bookkeeping keyed on pattern NAME must not
     # survive it -- a name reused across reloads (a re-added or edited rule) would
     # otherwise inherit stale strikes/suppression from the OLD pattern object. Mirrors
-    # the init_standard clear (ADR-07 P7) so a no-restart swap resets the same state a
+    # the init_standard clear (ADR-07) so a no-restart swap resets the same state a
     # restart would.
     _regex_warned.clear()
     _regex_perf_strikes.clear()
@@ -5288,7 +5288,7 @@ def find_noaaaa_wildcard_parent(q_name: str, noaaaa_db: dict[str, Any]) -> str |
 def _white_entry_wildcard(entry: Any) -> bool:
     """Wildcard flag of a whiteDB value, tolerant of both shapes.
 
-    ADR-07 P3 widens whiteDB values from a bare ``bool`` (wildcard?) to
+    ADR-07 widens whiteDB values from a bare ``bool`` (wildcard?) to
     ``{"wildcard": bool, "important": bool}``. Existing callers/tests still seed bare
     bools (e.g. ``add_white`` and the retained ADR-06 oracle), so the matcher accepts
     either: a dict reads ``["wildcard"]``; a bare bool IS the wildcard flag.
@@ -5299,7 +5299,7 @@ def _white_entry_wildcard(entry: Any) -> bool:
 
 
 def _white_entry_important(entry: Any) -> bool:
-    """Sovereignty flag of a whiteDB value (ADR-07 P3). Bare-bool legacy entries are
+    """Sovereignty flag of a whiteDB value (ADR-07). Bare-bool legacy entries are
     treated as not-important (False); only the new dict shape can carry it. Consulted
     solely by the numeric 6-band branch (unreachable while important_rules is False)."""
     if isinstance(entry, dict):
@@ -5308,7 +5308,7 @@ def _white_entry_important(entry: Any) -> bool:
 
 
 def _white_entry_band(entry: Any) -> int:
-    """Numeric band of a whiteDB value (ADR-07 P6). A dict entry carries an explicit
+    """Numeric band of a whiteDB value (ADR-07). A dict entry carries an explicit
     ``band`` (feed allow 2/4, user allow 6); else it is derived from ``important``
     (an important entry is a user allow -> band 6, a bare-bool/legacy feed allow ->
     band 2). Consulted only by the numeric 6-band branch."""
@@ -5484,7 +5484,7 @@ class _LruCache:
             self._d.clear()
 
 
-# ADR-07 P3: the 6-band precedence scale (ADR.md SS2 / RESULTS-P2 SS2). Highest wins;
+# ADR-07: the 6-band precedence scale (ADR.md SS2 / RESULTS-P2 SS2). Highest wins;
 # a block wins iff block_prio > allow_prio (no ties: block in {1,3,5}, allow in {2,4,6}).
 #   6 user allow   5 user block   4 feed allow+important
 #   3 feed block+important   2 feed allow (@@)   1 feed block (||)
@@ -5557,7 +5557,7 @@ def _scan_block_band(
 
     ``None`` when nothing matched. The numeric 6-band resolution takes the max block
     band (decide() semantics) -- the fast-path discovery short-circuits on the first
-    hit, which is wrong for the max. Snapshot-iterates the regex DB (Phase-7 eviction
+    hit, which is wrong for the max. Snapshot-iterates the regex DB (eviction
     safety). On a tie the first scanned kind (data -> zone -> regex) holds best_meta,
     but the caller only re-attributes when this band strictly exceeds the discovered
     one, so a tie never disturbs the discovered attribution."""
@@ -5599,7 +5599,7 @@ def _scan_block_band(
                 for _name, _lit in _b:
                     if _lit in q_lower:
                         cand.add(_name)
-        # Snapshot-iterate + time each match (ADR-07 P7), same warn/evict policy as the
+        # Snapshot-iterate + time each match (ADR-07), same warn/evict policy as the
         # fast-path discovery scan; collect evicted names and pop AFTER the loop.
         warn_ms = cfg.get("regex_warn_ms", REGEX_WARN_MS_DEFAULT)
         evict_ms = cfg.get("regex_evict_ms", REGEX_EVICT_MS_DEFAULT)
@@ -5631,7 +5631,7 @@ def _scan_allow_regex_band(
     """Highest allow band over the allow-regex (@@/re/) entries that match ``q_name``;
     0 if none match. Values mirror regexDB's tolerant shape: a bare compiled pattern,
     or a {"re", "important", "band"} payload. Iterates a SNAPSHOT (list(...)) and TIMES
-    each match (ADR-07 P7): over the warn ceiling logs once, over the evict ceiling is
+    each match (ADR-07): over the warn ceiling logs once, over the evict ceiling is
     removed from the live allow-regex DB AFTER the loop (snapshot-iterate, evict-after-
     loop -- the same warn/evict policy as the block-regex scans; fact 3)."""
     if not q_name:
@@ -5715,7 +5715,7 @@ def _resolve_numeric_allow(
     its highest matching band (computed by the caller over data/zone/block-regex).
     Blocked iff ``block_band > allow_band``; with no allow match ``allow_band`` is 0
     so the block stands. Engaged only when ``important_rules`` is True (an ABP
-    $important / feed @@ / feed regex was loaded); proven against the Phase-2 band
+    $important / feed @@ / feed regex was loaded); proven against the 6-band precedence
     table by synthetic-payload unit tests and the production ABP equivalence tests.
     """
     allow_band = 0
@@ -5824,7 +5824,7 @@ def evaluate_domain(
         # internally); derive it from the legacy cfg["python_idn"] when a cfg predates the
         # key (legacy callers/tests still pass only python_idn -- True->All-IDN).  The
         # explicit None check is REQUIRED: IdnMode.Off is truthy so an ``or`` idiom would
-        # bypass the stored value whenever Off is present (ADR-28 P8 landmine fix).
+        # bypass the stored value whenever Off is present (ADR-28 landmine fix).
         if not is_found:
             _raw = cfg.get("idn_mode")
             if isinstance(_raw, IdnMode):
@@ -5835,7 +5835,7 @@ def evaluate_domain(
                 # None (key absent) or unrecognised string -> legacy fallback preserving
                 # the pre-ADR-08 behaviour (python_idn=True -> All-IDN, False -> Off).
                 idn_mode = idn_mode_from_legacy(cfg.get("python_idn", False))
-            # All-IDN / Off arm -- BYTE-IDENTICAL to today (the Phase-3 golden gate):
+            # All-IDN / Off arm -- BYTE-IDENTICAL to today (the golden gate):
             # idn_mode_decision blocks IFF All-IDN on an xn-- query, as the old inline test.
             if idn_mode_decision(q_name, idn_mode):
                 is_found = True
@@ -5910,7 +5910,7 @@ def evaluate_domain(
         if is_found:
             b_eval = q_name
             log_type = "1"
-            # ADR-08 P5: a Confusable BLOCK reports the dual-form (xn-- [decoded] script)
+            # ADR-08: a Confusable BLOCK reports the dual-form (xn-- [decoded] script)
             # instead of the bare A-label, so the dnsbl.log line / alerts page are
             # actionable. Only set on the homoglyph block path; the All-IDN feed and every
             # other stratum keep b_eval = q_name untouched.
@@ -5922,7 +5922,7 @@ def evaluate_domain(
     # byte-for-byte the pre-P3 matcher; this is the path when no ABP @@/regex/$important
     # is loaded. The numeric 6-band resolution is the important_rules==True branch -- it
     # IS reached in production once an ABP feed (or user regex / Custom_List) loads a
-    # feed @@ / $important / feed-regex (ADR-07 P6 wired it; not just synthetic tests).
+    # feed @@ / $important / feed-regex (ADR-07 wired it; not just synthetic tests).
     if is_found:
         if not cfg.get("important_rules", False):
             if cfg["whiteDB"]:
@@ -6335,7 +6335,7 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                 if isgpBypass is not None:
                     bypass_dnsbl = True
 
-        # ADR-10 P2: capture the ONE live matcher snapshot ref for this query. Every
+        # ADR-10: capture the ONE live matcher snapshot ref for this query. Every
         # name in this query (the original + any CNAME-chain targets) is evaluated
         # against this single immutable snapshot, so a swap that rebinds ``_snapshot``
         # mid-query never tears a decision across names (ADR.md SS2 atomic-swap shape).
@@ -6410,7 +6410,7 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                     # hand-edited ini, or a test seeding only python_idn) still resolves
                     # to today's mode rather than KeyError-ing.
                     "idn_mode": pfb.get("idn_mode") or idn_mode_from_legacy(pfb.get("python_idn", False)),
-                    # ADR-08 P5: the Confusable sub-toggles (only read in IDN_MODE_CONFUSABLE).
+                    # ADR-08: the Confusable sub-toggles (only read in IDN_MODE_CONFUSABLE).
                     # Default-ON malicious block, opt-in suspicious escalation.
                     "python_idn_block_malicious": pfb.get("python_idn_block_malicious", True),
                     "python_idn_escalate_suspicious": pfb.get("python_idn_escalate_suspicious", False),
@@ -6424,7 +6424,7 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                     "hstsDB": bool(snap.hsts_db),
                     "hsts_tlds": pfb["hsts_tlds"],
                 }
-                # ADR-10 P2: read every matcher stratum off the ONE captured snapshot
+                # ADR-10: read every matcher stratum off the ONE captured snapshot
                 # ref (``snap``, taken once at the top of this per-name loop) instead of
                 # re-assembling ``containers`` from separate module globals. ``snap`` is
                 # immutable for this query, so a swap that rebinds ``_snapshot`` mid-query
@@ -6445,7 +6445,7 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                 if dnsbl.is_found and not dnsbl.in_whitelist:
                     pfb_db_enqueue(("cache", (dnsbl.b_type, q_name, dnsbl.group, dnsbl.b_eval, dnsbl.feed)))
 
-                # ADR-08 P5: a Confusable-mode ALERT (suspicious/flagged, or malicious with
+                # ADR-08: a Confusable-mode ALERT (suspicious/flagged, or malicious with
                 # block disabled) does NOT block -- the name resolves -- but the anomaly is
                 # surfaced once, here on the fresh evaluation, in the same dnsbl.log shape as
                 # a block (dual-form b_eval so it is actionable). A repeat query reuses the

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -92,7 +92,7 @@ $pfb['dnsbl_parse_err']	= "{$pfb['logdir']}/dnsbl_parsed_error.log";
 
 $pfb['master']		= "{$pfb['dbdir']}/masterfile";
 $pfb['supptxt']		= "{$pfb['dbdir']}/pfbsuppression.txt";
-$pfb['supptxt_v6']	= "{$pfb['dbdir']}/pfbsuppression_v6.txt";	// ADR-53 P6: IPv6 suppression customlist
+$pfb['supptxt_v6']	= "{$pfb['dbdir']}/pfbsuppression_v6.txt";	// ADR-53: IPv6 suppression customlist
 $pfb['dnsbl_supptxt']	= "{$pfb['dbdir']}/pfbdnsblsuppression.txt";
 $pfb['geoip_isos']	= "{$pfb['dbdir']}/geoip.txt";
 $pfb['dnsbl_info']	= '/var/unbound/pfb_py_dnsbl.sqlite';
@@ -127,8 +127,8 @@ $pfb['unbound_py_zone'] = '/var/unbound/pfb_py_zone.txt';
 $pfb['unbound_py_ss']	= '/var/unbound/pfb_py_ss.txt';
 $pfb['unbound_py_hsts']	= '/var/unbound/pfb_py_hsts.txt';	// SHIPPED file re-staged by dnsbl_cache_stage() cp -f; fingerprinted so a package update ships a new list and triggers a zero-downtime reload
 $pfb['unbound_py_count']= '/var/unbound/pfb_py_count';
-$pfb['unbound_py_regex_count']= '/var/unbound/pfb_py_regex_count';	// ADR-07 P8: Python-emitted ADMITTED (cap-filtered) feed+user regex total for the DNSBL_Regex alias
-$pfb['unbound_py_reject_stats']= '/var/unbound/pfb_py_reject_stats.json';	// ADR-48 P4: Python-emitted per-entry reject tally (issue #789), read by pfb_emit_entry_reject_stats()
+$pfb['unbound_py_regex_count']= '/var/unbound/pfb_py_regex_count';	// ADR-07: Python-emitted ADMITTED (cap-filtered) feed+user regex total for the DNSBL_Regex alias
+$pfb['unbound_py_reject_stats']= '/var/unbound/pfb_py_reject_stats.json';	// ADR-48: Python-emitted per-entry reject tally (issue #789), read by pfb_emit_entry_reject_stats()
 $pfb['unbound_py_sources']= '/var/unbound/pfb_py_sources.json';	// ADR-06: per-feed manifest consumed by pfb_unbound.py init
 $pfb['unbound_py_rawdir']= '/var/unbound/pfb_py_raw';		// ADR-06: per-feed IP-stripped raw feeds referenced by the manifest
 
@@ -897,7 +897,7 @@ function pfb_validate_log(string $feed, string $stage, string $reason, string $d
 	pfb_logger(pfb_validate_log_line($feed, $stage, $reason, $detail), $level);
 }
 
-// ADR-48 P2: the one formatter for the detected= summary built from pfb_filter()'s
+// ADR-48: the one formatter for the detected= summary built from pfb_filter()'s
 // $reject_detail out-param -- every wired pfb_download() call site uses it, so the
 // shape has a single place to change.
 function pfb_reject_detail_summary(array $reject_detail): string {
@@ -1202,7 +1202,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 		foreach ($input as $vline) {
 			if (preg_match("/[\p{C}]+/u", $vline) !== 0) {
 				pfb_logger("{$header} Control characters found [ " . htmlspecialchars($vline) . " ]", 6);
-				// ADR-48 P2: this early return precedes the switch, so it also rejects
+				// ADR-48: this early return precedes the switch, so it also rejects
 				// the FILE_MIME types -- fill the out-param for an opted-in caller
 				// (keep the level-6 diagnostic; it is errlog-only, not the legacy
 				// reject message the contract suppresses).
@@ -1551,7 +1551,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			unset($retval);
 			unset($output);
 			if (!file_exists($input[1])) {
-				// ADR-48 P2: honour the out-param contract on EVERY reject path — an
+				// ADR-48: honour the out-param contract on EVERY reject path — an
 				// opted-in caller emits the canonical line itself, so fill the detail
 				// and suppress the legacy message (mirrors the mime-reject branch).
 				if (is_array($reject_detail)) {
@@ -1594,7 +1594,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 						pfb_logger("MIME recovered: octet-stream positively identified as \"" . htmlspecialchars($recovered) . "\" via structural probe", 5);
 						$output[0] = $recovered;
 					} else {
-						// ADR-48 P2: opted-in caller (pre-set $reject_detail = array())
+						// ADR-48: opted-in caller (pre-set $reject_detail = array())
 						// gets the raw detail back instead of the legacy message.
 						if (is_array($reject_detail)) {
 							$reject_detail = array(
@@ -1620,7 +1620,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			unset($retval);
 			unset($output);
 			if (!file_exists($input[1])) {
-				// ADR-48 P2: same out-param contract as the FILE_MIME branch above.
+				// ADR-48: same out-param contract as the FILE_MIME branch above.
 				if (is_array($reject_detail)) {
 					$reject_detail = array('mime_raw' => 'file-not-found', 'mime' => '', 'retval' => -1);
 				} else {
@@ -1630,7 +1630,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			}
 			exec("/usr/bin/file -bZ --mime-type " . escapeshellarg($input[1]) . " 2>&1", $output, $retval);
 			if ($retval != 0 || empty($output[0]) || !pfb_mime_in_allowlist($output[0], $pfb['mime_types'])) {
-				// ADR-48 P2: same out-param contract as the FILE_MIME branch above.
+				// ADR-48: same out-param contract as the FILE_MIME branch above.
 				if (is_array($reject_detail)) {
 					$reject_detail = array(
 						'mime_raw' => $output[0],
@@ -1666,7 +1666,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			}
 			break;
 		case PFB_FILTER_TOKEN:
-			// ADR-59 P5: validate a base64url/JWT-shaped credential token (e.g. a Cloudflare
+			// ADR-59: validate a base64url/JWT-shaped credential token (e.g. a Cloudflare
 			// Radar API token) -- letters, digits, and the base64url/JWT punctuation set
 			// '._~+/=-', bounded length so a pathological input can't be used for resource
 			// exhaustion. PFB_FILTER_WORD ([A-Za-z0-9_] only) would reject a real token
@@ -1692,7 +1692,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 
 		// Exceptions -- callers whose rejected input must never be logged, even at
 		// debug level: 'DNSBL_Download' (parsed feed lines -- volume); 'top1m_token'
-		// (ADR-59 P5 -- the secret itself, not merely its download URL); 'maxmind_key'
+		// (ADR-59 -- the secret itself, not merely its download URL); 'maxmind_key'
 		// (issue #924 -- same masked/write-only treatment for the MaxMind license key).
 		if (in_array($reference, array('DNSBL_Download', 'top1m_token', 'maxmind_key'))) {
 			//
@@ -1895,7 +1895,7 @@ function pfb_dnsblip_mark_reprocess($action, string $vtype): void {
 // v6 stays OPTIONAL (ADR-13 §7 pivot): a missing v6 VIP never fails validation, even when
 // the resolver listens on IPv6 — pfb_global surfaces that as a non-blocking warning, not a
 // force-disable. The validator only checks the VIPs that ARE configured (existence,
-// interface, overlap). Behaviour is identical to before the (reverted) Phase-3 hard rule.
+// interface, overlap). Behaviour is identical to before the (reverted) hard rule.
 function pfb_validate_vips(string $interface, string|null $vip4 = '', string|null $vip6 = ''): array {
 	$enabled4 = !empty($vip4);
 	$enabled6 = !empty($vip6);
@@ -2291,7 +2291,7 @@ function pfb_global() {
 	// Reload config.xml to get any recent changes
 	config_read_file(FALSE, TRUE);
 
-	// General variables — registered sections read through the gateway (ADR-29 P4).
+	// General variables — registered sections read through the gateway (ADR-29).
 	$pfb['config']		= PfbConfig::readSection('installedpackages/pfblockerng/config/0');
 	$pfb['ipconfig']	= config_get_path('installedpackages/pfblockerngipsettings/config/0', []);
 	$pfb['dnsblconfig']	= PfbConfig::readSection('installedpackages/pfblockerngdnsblsettings/config/0');
@@ -2402,7 +2402,7 @@ function pfb_global() {
 	$pfb['dnsbl_gp']		= $pfb['dnsblconfig']['pfb_gp'];		// DNSBL Resolver python - DNSBL Bypass
 	$pfb['dnsbl_gp_bypass_list']	= $pfb['dnsblconfig']['pfb_gp_bypass_list'];	// DNSBL Resolver python - List of Local IPs to bypass DNSBL
 
-	// SafeSearch — read via gateway (ADR-29 P4).
+	// SafeSearch — read via gateway (ADR-29).
 	$pfb['safesearch_enable']	= PfbConfig::read('safesearch_enable');
 	$pfb['safesearch_youtube']	= PfbConfig::read('safesearch_youtube');
 	$pfb['safesearch_doh']		= PfbConfig::read('safesearch_doh');
@@ -4921,7 +4921,7 @@ function pfb_concat_member_files(array $member_paths): string {
  *
  * Applies LC_ALL=C sort -u (ADR-26) to the concatenated member content, returning
  * an array of unique, C-sorted IP/CIDR strings with blank lines and comments stripped.
- * Used as the content-addressed gate input (ADR-40 P3) and the delta last_set source (P4).
+ * Used as the content-addressed gate input and the delta last_set source (ADR-40).
  *
  * @param string $member_content Raw concatenated member content (output of pfb_concat_member_files).
  * @return string[] Sorted, unique, non-empty lines. Empty array for empty/blank input.
@@ -4963,7 +4963,7 @@ function pfb_write_canonical_alias(string $path, array $canonical_set): void {
  * does not exist yet, as on boot/initial-load for non-empty sets).
  *
  * Set comparison is ORDER- and DUPLICATE-immune: the mirror is also passed
- * through pfb_canonical_alias_set() before comparing, so a pre-Phase-3
+ * through pfb_canonical_alias_set() before comparing, so a legacy
  * non-canonical mirror (raw concat with dups) round-trips correctly on
  * the first upgrade pass.
  *
@@ -5085,7 +5085,7 @@ function pfb_alias_delta_batch_resolve(string $raw): int {
  *
  * ADR-40 contract items satisfied:
  *   (1) End-state == replace: after delta apply, table membership equals $desired_set.
- *   (5) Empty-table: full replace handles initial population (mirrors Phase-3 gate).
+ *   (5) Empty-table: full replace handles initial population (mirrors the content-addressed gate).
  *   (8) Idempotence: identical $desired_set and $last_set → empty delta → zero pfctl calls.
  *
  * Failures: a pfctl error is logged; the caller can still verify the table state.
@@ -5336,7 +5336,7 @@ function pfb_create_suppression_file() {
 		unlink_if_exists("{$pfb['supptxt']}");
 	}
 
-	// ADR-53 P6: v6 sibling -- same decode/write/unlink-when-empty shape as v4 above.
+	// ADR-53: v6 sibling -- same decode/write/unlink-when-empty shape as v4 above.
 	$v6suppression = pfbng_text_area_decode($pfb['ipconfig']['v6suppression'] ?? '', FALSE, TRUE);
 	if (!empty($v6suppression)) {
 		@file_put_contents("{$pfb['supptxt_v6']}", $v6suppression, LOCK_EX);
@@ -6254,7 +6254,7 @@ function pfb_dnsbl_unlock_lines() {
 	return $out;
 }
 
-// ADR-07 P8: extract an IP from an ABP-anchored / hosts line for the DNSBL-IP
+// ADR-07: extract an IP from an ABP-anchored / hosts line for the DNSBL-IP
 // firewall pass (coexistence). The raw ABP line itself still flows to Python, which
 // SKIPS IP-valued anchors (parse_abp returns None) -- so IP -> firewall only,
 // domain/regex -> Python only (no double-handling, no leak; ADR-06 fact 7).
@@ -6436,7 +6436,7 @@ function pfb_dnsbl_is_abp_header($line) {
 }
 
 
-// ADR-10 P5: atomically publish a file to the chroot (/var/unbound). Stage into a
+// ADR-10: atomically publish a file to the chroot (/var/unbound). Stage into a
 // temp file ON THE SAME FILESYSTEM (same directory) -> flush + fsync the data ->
 // fix ownership -> atomic rename() over the final path. The plugin only ever reads
 // a fully-written, immutable file: a half-written manifest is never visible because
@@ -6488,7 +6488,7 @@ function pfb_unbound_py_atomic_write($path, $content) {
 }
 
 
-// ADR-10 P5: flip the zero-downtime RELOAD SENTINEL (the all-or-nothing commit that
+// ADR-10: flip the zero-downtime RELOAD SENTINEL (the all-or-nothing commit that
 // wakes the Python reload-watcher). The sentinel host path is /var/unbound/pfb_py_reload
 // (Unbound is chrooted at /var/unbound; the module opens it as the chroot-relative
 // "pfb_py_reload"). Its content is a monotonically NON-DECREASING
@@ -6744,7 +6744,7 @@ function pfb_unbound_py_write_control($cmd, $ip = '', $duration = '', $wait_time
 }
 
 
-// ADR-10 P5: PRIMARY RAM gate for the zero-downtime swap (the Python watcher re-checks it as a
+// ADR-10: PRIMARY RAM gate for the zero-downtime swap (the Python watcher re-checks it as a
 // safety net). The background rebuild holds OLD + NEW matcher structures resident at once
 // (~2x transient); on a constrained box that bust would OOM mid-swap. Mirrors the Python
 // projection: 2 * loaded_entries * 276 B + 64 MiB headroom, measured against hw.usermem.
@@ -6849,7 +6849,7 @@ function pfb_unbound_python_sources($feeds) {
 		$header	= isset($feed['header']) ? $feed['header'] : '';
 		$group	= isset($feed['group'])  ? $feed['group']  : '';
 		$logf	= isset($feed['log'])    ? (string) $feed['log'] : '1';
-		// ADR-07 P8: 'abp' feeds carry RAW ABP lines verbatim to the Python parser;
+		// ADR-07: 'abp' feeds carry RAW ABP lines verbatim to the Python parser;
 		// every other feed stays 'plain' (PHP-extracted bare domains, ADR-06).
 		$format	= (isset($feed['format']) && $feed['format'] === 'abp') ? 'abp' : 'plain';
 
@@ -6877,7 +6877,7 @@ function pfb_unbound_python_sources($feeds) {
 		if (($in_h = @fopen($src, 'r')) !== FALSE) {
 			while (($line = @fgets($in_h)) !== FALSE) {
 				if ($format === 'abp') {
-					// ADR-07 P8: pass the RAW ABP line through unmodified -- the
+					// ADR-07: pass the RAW ABP line through unmodified -- the
 					// '.txt' of an 'abp' feed already holds raw ABP lines (the
 					// lite parser is gone). Python's parse_abp does all parsing.
 					$line = rtrim($line, "\r\n");
@@ -6988,7 +6988,7 @@ function pfb_unbound_python_sources($feeds) {
 
 	$json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 	if ($json !== FALSE) {
-		// ADR-10 P5: atomic publish (stage -> fsync -> rename). The per-feed raw
+		// ADR-10: atomic publish (stage -> fsync -> rename). The per-feed raw
 		// files were already (re)written into unbound_py_rawdir above; the manifest
 		// rename is the point at which the new immutable set becomes readable. The
 		// sentinel flip that ACTS on it is driven by pfb_reload_unbound's data
@@ -7028,7 +7028,7 @@ function pfb_unbound_python_sources_patch($key, $values) {
 
 	$json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 	if ($json !== FALSE) {
-		// ADR-10 P5: atomic publish (the sentinel flip is driven by the reload).
+		// ADR-10: atomic publish (the sentinel flip is driven by the reload).
 		return pfb_unbound_py_atomic_write($pfb['unbound_py_sources'], $json);
 	}
 
@@ -7572,7 +7572,7 @@ function tld_analysis() {
 
 	pfb_logger("TLD analysis", 1);
 
-	// ADR-07 P8: ABP/EasyList feeds carry RAW ABP lines (||x^, @@||x^, /re/,
+	// ADR-07: ABP/EasyList feeds carry RAW ABP lines (||x^, @@||x^, /re/,
 	// '0.0.0.0 host') -- NOT the legacy ',domain,,log,feed,group' CSV shape that
 	// this loop parses. Parsing them as CSV yields garbage/empty domains. ABP feeds
 	// are tagged with a persisted '{$header}.abp' marker and are built ENTIRELY by
@@ -7596,7 +7596,7 @@ function tld_analysis() {
 				continue;
 			}
 
-			// ADR-07 P8: skip ABP-feed lines (see note above). A plain CSV row is
+			// ADR-07: skip ABP-feed lines (see note above). A plain CSV row is
 			// ',domain,,log,feed,group'; the feed name is column index 4. ABP raw
 			// lines lack this shape, so an unset/empty feed column also means skip.
 			if (!empty($abp_feeds)) {
@@ -7768,7 +7768,7 @@ function pfb_stop_start_unbound($type) {
 }
 
 
-// ADR-10 P5: is the DNSBL Unbound python integration the LIVE resolver mode? The
+// ADR-10: is the DNSBL Unbound python integration the LIVE resolver mode? The
 // zero-downtime swap only applies when the in-memory matcher (pfb_unbound.py) is the
 // active blocklist source -- i.e. the resolver config has the python module wired in.
 // Read from config.xml (the source of truth), not a generated file.
@@ -7778,7 +7778,7 @@ function pfb_unbound_py_mode_active() {
 }
 
 
-// ADR-10 P5: C-cache flip for a zero-downtime swap. Staleness is ONE-DIRECTIONAL: since #43
+// ADR-10: C-cache flip for a zero-downtime swap. Staleness is ONE-DIRECTIONAL: since #43
 // DNSBL blocks set qstate.no_cache_store=1, a block reply is NEVER cached. block->allow needs
 // NO flush (decisionDB.clear() suffices); allow->block leaves the previously-resolved answer
 // cached until TTL, so ONLY that direction needs a flush, ONLY for newly-blocked names. $names:
@@ -7830,7 +7830,7 @@ function pfb_unbound_py_ccache_flush($names) {
 }
 
 
-// Reload Resolver. ADR-10 P5: $datapath signals a pure DNSBL-DATA update (feed/cron or a #51
+// Reload Resolver. ADR-10: $datapath signals a pure DNSBL-DATA update (feed/cron or a #51
 // custom-list edit) already published atomically to the manifest. When python is live, unbound
 // is running, no config change is pending, and the RAM gate fits, this takes the ZERO-DOWNTIME
 // fast path (flip the reload sentinel, no restart). $newly_blocked carries the allow->block
@@ -8083,7 +8083,7 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 	// Load new DNSBL updates
 	if (is_service_running('unbound')) {
 
-		// ADR-10 P5: a feed/cron DNSBL-DATA update takes the zero-downtime swap when the
+		// ADR-10: a feed/cron DNSBL-DATA update takes the zero-downtime swap when the
 		// reload introduces NO config change ($pfbpython FALSE -> unbound.conf/ini/mounts
 		// unchanged). The manifest + per-feed raw were already published atomically by
 		// pfb_unbound_python_sources() above; flip the sentinel, no restart. A config
@@ -8131,7 +8131,7 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 
 
 // Process TOP1M database
-// $provider_override (ADR-59 P2 test seam): when given, its 'parse'/'header'/
+// $provider_override (ADR-59 test seam): when given, its 'parse'/'header'/
 // 'domain_col' knobs drive the builder directly instead of resolving through
 // pfb_top1m_providers()[$pfb['dnsbl_top1m_type']->value] -- lets a unit test
 // exercise a synthetic descriptor's knobs without a live provider. Production
@@ -8144,7 +8144,7 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 		return;
 	}
 
-	// ADR-59 P2: the active provider descriptor drives the parse knobs below.
+	// ADR-59: the active provider descriptor drives the parse knobs below.
 	// $pfb['dnsbl_top1m_type'] may be unset in an isolated unit-test context
 	// (it is normally set by pfb_global() -- PfbConfig::read('alexa_type') --
 	// which some tests never call); default to Tranco, the same absent-default
@@ -8191,7 +8191,7 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 			pfb_logger("\n  TOP1M: could not create the temp whitelist file -- keeping the previous TOP1M whitelist.\n", 2);
 		}
 		else {
-			// ADR-59 P2: skip exactly the first physical line unconditionally when
+			// ADR-59: skip exactly the first physical line unconditionally when
 			// the provider ships a header row -- before the content filter below, so
 			// a header line's shape (which may not even contain a '.'/',') never
 			// matters.
@@ -8204,7 +8204,7 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 					continue;
 				}
 
-				// ADR-59 P5: Cloudflare's dataset is a SINGLE 'domain' column (domain_col
+				// ADR-59: Cloudflare's dataset is a SINGLE 'domain' column (domain_col
 				// 0) -- a real data line has no comma at all (no column to split), so the
 				// comma requirement below would wrongly reject every line. Only demand a
 				// comma when a real multi-column split is expected (domain_col > 0, every
@@ -10249,7 +10249,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				return TRUE;
 			}
 			elseif ($type == 'top1m') {
-				// ADR-59 P2: a gz-container TOP1M provider decompresses straight to
+				// ADR-59: a gz-container TOP1M provider decompresses straight to
 				// the destination CSV pfblockerng_top1m() reads (no rename/staging).
 				exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);
 				unlink_if_exists($file_download);
@@ -10425,7 +10425,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		else {
 			// Uncompressed file format.
 			if ($type == 'geoip' || $type == 'asn' || $type == 'top1m') {
-				// Extras - MaxMind/TOP1M/ASN downloads. ADR-59 P2: a 'plain' container
+				// Extras - MaxMind/TOP1M/ASN downloads. ADR-59: a 'plain' container
 				// provider's body IS the destination CSV -- rename straight to it, same
 				// as geoip/asn (no intermediate '.orig' staging needed).
 				@rename("{$file_download}", "{$head_download}");
@@ -11027,7 +11027,7 @@ function pfb_aliastables($mode) {
 			// pfb_dnsbl_cache() (different lifecycle); ADR-08 had wrongly piggybacked
 			// the /var/unbound/pfb_unbound* + pfb_py_* files onto this IP archive.
 			$files = glob("{{$pfb['aliasdir']}/pfB_*.txt,{$pfb['dnsbl_file']}.conf}", GLOB_BRACE) ?: [];
-			// ADR-43 P4: include the due-ledger so cron schedules survive a RAM-disk reboot.
+			// ADR-43: include the due-ledger so cron schedules survive a RAM-disk reboot.
 			$pfb_ledger = "{$pfb['dbdir']}/pfb_due_ledger.json";
 			if (is_file($pfb_ledger)) {
 				$files[] = $pfb_ledger;
@@ -11321,7 +11321,7 @@ function pfb_remove_states() {
 	// List of IPs to suppress
 	$pfb_local = $pfb_localsub = array();
 
-	// Collect v4/v6 Suppression list entries (ADR-53 P7): checked prefix-aware via
+	// Collect v4/v6 Suppression list entries (ADR-53): checked prefix-aware via
 	// pfb_ip_suppressed() below, replacing the old exact-IP hashmap + subnetv4_expand()
 	// '/24' materialisation -- which could only express a bare host or an exact '/24';
 	// any other containing mask (v4 '/8'-'/23', any v6 mask) silently stayed
@@ -12197,7 +12197,7 @@ function pfb_local_feed_changed($source_path, $orig_path) {
 		return ($src_hash !== $sidecar['digest']);
 	}
 
-	// 'xxh128' — canonical post-Phase-2 path.
+	// 'xxh128' — canonical path.
 	$src_hash = pfb_content_hash($source_path, TRUE);
 	if ($src_hash === FALSE) {
 		return TRUE;
@@ -14687,7 +14687,7 @@ function sync_package_pfblockerng($cron='') {
 		$pfb_is_noups  = ($pfb_cron_str === 'noupdates');
 		// 'update' is the deprecated CLI verb that historically called sync_package_pfblockerng('cron'),
 		// so it got $pfb_cron_tick=TRUE and the reuse_dnsbl propagation below fired.
-		// Post-Phase-3 it reaches here as 'update' → trigger='manual' → cron_tick FALSE.
+		// Now it reaches here as 'update' → trigger='manual' → cron_tick FALSE.
 		// Restore back-compat for this DEPRECATED STRING path only: treat 'update' like 'cron'
 		// for the reuse_dnsbl elseif guard. The new ARRAY path stays unaffected (trigger='manual'
 		// from pfb_trigger_request('update') keeps cron_tick FALSE there, as intended).
@@ -15877,7 +15877,7 @@ function sync_package_pfblockerng($cron='') {
 								$custom = FALSE;
 							}
 
-							// ADR-31 P4: per-row action → manifest mode.
+							// ADR-31: per-row action → manifest mode.
 							// 'action' is a dynamic per-row key (like 'custom') — read
 							// directly; default/absent ⇒ 'Deny' (deny path, byte-identical).
 							// Config storage freeze (ADR-28): only 'Permit'/'Deny' are stored;
@@ -15933,10 +15933,10 @@ function sync_package_pfblockerng($cron='') {
 								// Collect existing list stats
 								$lists_dnsbl_all[]	= "{$row['header']}.txt";
 								$lists_dnsbl_current[]	= "{$row['header']}";
-								// ADR-07 P8: a reused feed isn't re-parsed, so read the
+								// ADR-07: a reused feed isn't re-parsed, so read the
 								// persisted '.abp' marker to carry its format_hint forward.
-								// ADR-31 P3: delegate to pfb_feed_manifest_row() (deny default).
-								// ADR-31 P4: pass $mode derived from per-row 'action' (above).
+								// ADR-31: delegate to pfb_feed_manifest_row() (deny default).
+								// ADR-31: pass $mode derived from per-row 'action' (above).
 								$pfb_py_feeds[]		= pfb_feed_manifest_row(
 									$header, $alias, $logging_type,
 									file_exists("{$pfbfolder}/{$header}.abp") ? 'abp' : 'plain',
@@ -15998,7 +15998,7 @@ function sync_package_pfblockerng($cron='') {
 									$liteparser = TRUE;
 								}
 
-								// ADR-07 P8: ABP/EasyList feeds are header-sniffed (below) and
+								// ADR-07: ABP/EasyList feeds are header-sniffed (below) and
 								// tagged format_hint='abp'; their RAW lines pass through to the
 								// Python parser. The old PHP lite parser ($e_replace token-strip)
 								// is deleted -- $easylist now only flags the feed as ABP.
@@ -16072,7 +16072,7 @@ function sync_package_pfblockerng($cron='') {
 											}
 
 											if ($easylist) {
-												// ADR-07 P8: the PHP $easylist lite parser is
+												// ADR-07: the PHP $easylist lite parser is
 												// DELETED. ABP feeds are tagged format_hint='abp'
 												// and their RAW lines are passed through verbatim
 												// to the Python parser (parse_abp), which is now
@@ -16545,18 +16545,18 @@ function sync_package_pfblockerng($cron='') {
 								$pfb['domain_update']	= $pfb['aliasupdate'] = $pfb['summary'] = TRUE;
 								$lists_dnsbl_all[]	= "{$row['header']}.txt";
 								$lists_dnsbl_current[]	= "{$row['header']}";
-								// ADR-07 P8: tag ABP feeds 'abp' so the manifest writer passes
+								// ADR-07: tag ABP feeds 'abp' so the manifest writer passes
 								// their RAW lines through to the Python parser (parse_abp); all
 								// other feeds stay 'plain' (PHP-extracted bare domains).
-								// ADR-31 P3: delegate to pfb_feed_manifest_row() (deny default).
-								// ADR-31 P4: pass $mode derived from per-row 'action' (above).
+								// ADR-31: delegate to pfb_feed_manifest_row() (deny default).
+								// ADR-31: pass $mode derived from per-row 'action' (above).
 								$pfb_py_feeds[]		= pfb_feed_manifest_row(
 									$header, $alias, $logging_type,
 									$easylist ? 'abp' : 'plain',
 									$custom ? 'user' : 'feed',
 									$mode);
 
-								// ADR-07 P8: persist the ABP marker so a future reuse build (which
+								// ADR-07: persist the ABP marker so a future reuse build (which
 								// does not re-parse the feed) carries the format_hint forward.
 								if ($easylist) {
 									@touch("{$pfbfolder}/{$header}.abp");
@@ -16659,7 +16659,7 @@ function sync_package_pfblockerng($cron='') {
 			$pfb['alias_dnsbl_all'][] = 'DNSBL_TLD_Allow';
 			dnsbl_alias_update('update', 'DNSBL_TLD_Allow', '', '', $pytld_cnt);
 		}
-		// ADR-07 P8: the DNSBL_Regex alias count now reflects the ADMITTED
+		// ADR-07: the DNSBL_Regex alias count now reflects the ADMITTED
 		// (cap-filtered) feed + user regex total emitted by Python (regexDB +
 		// allowRegexDB after the static cap drops over-cap patterns at load) --
 		// value changes by design (ADR §2 "Emit + counts"). The Python count file
@@ -16862,7 +16862,7 @@ function sync_package_pfblockerng($cron='') {
 				@file_put_contents($pfb['unbound_py_data'], '', LOCK_EX);	// present-but-empty CSV
 				unlink_if_exists($pfb['unbound_py_zone']);			// python mode: zone must be absent
 				unlink_if_exists($pfb['unbound_py_count']);
-				unlink_if_exists($pfb['unbound_py_regex_count']);		// ADR-07 P8
+				unlink_if_exists($pfb['unbound_py_regex_count']);		// ADR-07
 			}
 		}
 		else {
@@ -18121,7 +18121,7 @@ function sync_package_pfblockerng($cron='') {
 	#	CONFIGURE ALIASES AND FIREWALL RULES	#
 	#################################################
 
-	// ADR-40 P3: Snapshot the feed-changed set (populated by the download loop above)
+	// ADR-40: Snapshot the feed-changed set (populated by the download loop above)
 	// before the file-write loop.  The file-write loop will rebuild $pfb_alias_lists
 	// as the content-diff set (aliases whose canonical membership set actually changed),
 	// which is what the pfctl regions and ADR-12 emit consume.
@@ -18129,12 +18129,12 @@ function sync_package_pfblockerng($cron='') {
 	// and "read member files" decision anchored to feed-changed aliases.
 	$pfb_feed_changed    = $pfb_alias_lists;
 	$pfb_alias_lists     = array();   // reset: refilled below with content-validated aliases
-	// ADR-40 P4: per-alias map from alias name -> previous canonical set (what was in the
+	// ADR-40: per-alias map from alias name -> previous canonical set (what was in the
 	// mirror BEFORE this pass wrote the new one).  Captured in the write loop (below) so the
 	// no-rule-change reload site can compute add/del deltas without a second file read.
 	$pfb_alias_prev_sets = array();
 
-	// ADR-40 P3: hoist cross-list scope and feed-changed alias selection here — both
+	// ADR-40: hoist cross-list scope and feed-changed alias selection here — both
 	// inputs ($pfb['dup'], $pfb['drep'], $pfb['prep'], $pfb_feed_changed,
 	// $pfb_alias_lists_all) are invariant across the $ip_types / $lists loops below.
 	// Avoids redundant recomputation on every list iteration.
@@ -18207,7 +18207,7 @@ function sync_package_pfblockerng($cron='') {
 				$pfbdescr	= $pfbarr['descr'];
 				$pfbfolder	= $pfbarr['folder'];
 
-				// ADR-40 P3: Content-addressed reload gate (hybrid scope).
+				// ADR-40: Content-addressed reload gate (hybrid scope).
 				// $pfb_cross_list and $final_alias_old are computed once before the
 				// $ip_types / $lists loops (their inputs are loop-invariant) — see
 				// the hoist above.
@@ -18231,7 +18231,7 @@ function sync_package_pfblockerng($cron='') {
 
 								$pfctlck = pfb_pfctl_table_count($alias);
 
-								// ADR-40 P3: read member files when:
+								// ADR-40: read member files when:
 								//   (a) cross-list scope → always (dedup/rep can shift any alias), OR
 								//   (b) this alias had a feed change this pass, OR
 								//   (c) kernel table is empty (boot/repopulation).
@@ -18254,7 +18254,7 @@ function sync_package_pfblockerng($cron='') {
 										}
 									}
 
-									// ADR-53 P6: v6 sibling of the v4 suppression block above -- a direct
+									// ADR-53: v6 sibling of the v4 suppression block above -- a direct
 									// PHP call (pfb_suppress_file_v6()), no shell round-trip (ADR-53 §2.1 v6
 									// wiring). No masterfile/dedup resync here: that bookkeeping is v4-only
 									// (§1.2). $pfbrunonce is reset TRUE at the top of EVERY vtype pass (see
@@ -18295,7 +18295,7 @@ function sync_package_pfblockerng($cron='') {
 					$pfctlck = pfb_pfctl_table_count($alias);
 					if (!empty($list['custom'])) {
 						$urlvalue .= "{$aliasname},";
-						// ADR-40 P3: same scope logic for custom lists.
+						// ADR-40: same scope logic for custom lists.
 						$custom_eligible = file_exists("{$pfbfolder}/{$aliasname}.txt")
 							&& ($pfb_cross_list || in_array($alias, $final_alias_old) || empty($pfctlck));
 						if ($custom_eligible) {
@@ -18309,7 +18309,7 @@ function sync_package_pfblockerng($cron='') {
 						unlink_if_exists("{$pfb['aliasdir']}/{$alias}.txt");
 					}
 					else {
-						// ADR-40 P3: Compute the canonical set from the raw concat, compare
+						// ADR-40: Compute the canonical set from the raw concat, compare
 						// against the last-applied mirror (the existing aliasdir file), and write
 						// only when the set changed.  This replaces the old pfbupdate flag write
 						// (which wrote on every feed-fetch) with a content-addressed gate.
@@ -18317,7 +18317,7 @@ function sync_package_pfblockerng($cron='') {
 							$alias_mirror  = "{$pfb['aliasdir']}/{$alias}.txt";
 							$canonical_set = pfb_canonical_alias_set($alias_ips);
 							if (pfb_alias_set_different($canonical_set, $alias_mirror) || empty($pfctlck)) {
-								// ADR-40 P4: capture the previous canonical set before overwriting
+								// ADR-40: capture the previous canonical set before overwriting
 								// the mirror, so the reload site has last_set for delta computation.
 								// When the kernel table is empty (empty($pfctlck)), stash an empty
 								// array so the reload site's force_rpl = empty([]) = TRUE fires a
@@ -18618,7 +18618,7 @@ function sync_package_pfblockerng($cron='') {
 
 		exec("{$pfb['pfctl']} -s Tables | {$pfb['grep']} '^pfB_'", $pfb_tables);
 		if (isset($pfb_tables)) {
-			// ADR-40 P3: $pfb_alias_lists is the content-diff set (aliases whose
+			// ADR-40: $pfb_alias_lists is the content-diff set (aliases whose
 			// canonical membership set changed this pass).
 			// Rule-change path: filter_configure() rebuilds all pf tables from the
 			// aliasdir files after this block, so we always do a full -T replace here
@@ -18666,7 +18666,7 @@ function sync_package_pfblockerng($cron='') {
 				$pfb_ip_unlock_forced = TRUE;
 				unlink_if_exists("{$pfb['ip_unlock']}");
 				$pfb['repcheck'] = TRUE;
-				// ADR-40 P3: ip_unlock forces a re-block of all active aliases (the previously
+				// ADR-40: ip_unlock forces a re-block of all active aliases (the previously
 				// unlocked IP must be re-added to every alias it belongs to).  With content
 				// gating, $pfb_alias_lists may be empty (if no feed changed this pass), so
 				// explicitly add all active aliases to the reload set here — same as the old
@@ -18674,7 +18674,7 @@ function sync_package_pfblockerng($cron='') {
 				$pfb_alias_lists = array_unique(array_merge($pfb_alias_lists, $pfb_alias_lists_all));
 			}
 
-			// ADR-40 P3/P4: $pfb_alias_lists is the content-diff set — aliases whose
+			// ADR-40: $pfb_alias_lists is the content-diff set — aliases whose
 			// canonical membership set changed this pass (or ip_unlock forced a re-block).
 			// P4: apply each changed alias via forward delta (or replace per mode/churn).
 			$final_alias = array_unique($pfb_alias_lists);
@@ -18682,7 +18682,7 @@ function sync_package_pfblockerng($cron='') {
 			if (!empty($final_alias)) {
 				pfb_logger(localize_text("Alias table changes detected, updating:") . "\n", 1);
 
-				// ADR-40 P4: read mode/batch once for the loop (PfbConfig gateway).
+				// ADR-40: read mode/batch once for the loop (PfbConfig gateway).
 				$pfb_delta_mode  = (string) PfbConfig::read('pfb_alias_delta_mode')->toStored();
 				$pfb_delta_batch = pfb_alias_delta_batch_clamp((string) PfbConfig::read('pfb_alias_delta_batch'));
 
@@ -18690,7 +18690,7 @@ function sync_package_pfblockerng($cron='') {
 					$log = " Updating: {$final}\n";	// trailing \n only — a leading \n put a blank line before each entry
 					pfb_logger("{$log}", 1);
 					if (file_exists("{$pfb['aliasdir']}/{$final}.txt")) {
-						// ADR-40 P4: compute delta from the stashed previous canonical set.
+						// ADR-40: compute delta from the stashed previous canonical set.
 						// Two cases always get force_rpl = TRUE here:
 						//   • ip_unlock-widened aliases: not in $pfb_alias_prev_sets (added
 						//     after the write loop), so ?? NULL → empty(NULL) = TRUE.
@@ -18852,7 +18852,7 @@ function sync_package_pfblockerng($cron='') {
 	#	Define/Apply CRON Jobs		#
 	#########################################
 
-	// ADR-43 P4: one trigger-tick replaces the cron/dcc/ss_refresh/bl fleet.
+	// ADR-43: one trigger-tick replaces the cron/dcc/ss_refresh/bl fleet.
 	// A single */pfb_tick_interval cron entry fires; the tick reads the due-ledger
 	// and dispatches each job only when its entry says "due". clearip/cleardnsbl
 	// are out of scope (ADR-30 territory) and remain as separate jobs below.
@@ -18947,7 +18947,7 @@ function sync_package_pfblockerng($cron='') {
 	//   PFB_CHANGED_IP_ALIASES = the space-separated list of IP firewall aliases UPDATED
 	//       this pass (ADR-12) = $pfb_alias_lists (the content-diff set --
 	//       pfB_*_v4/_v6 whose canonical membership set actually changed this pass,
-	//       as determined by pfb_alias_set_different(); ADR-40 P3).  Reputation/dedup
+	//       as determined by pfb_alias_set_different(); ADR-40).  Reputation/dedup
 	//       no longer inflate this to all active aliases -- only moved tables appear here.
 	//       The IP locals are in scope only at this tail, so they are merged into
 	//       $pfb['changed_ip_aliases'] here, then de-duped at emit.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3466,8 +3466,8 @@ function pfb_pkg_installed_repo(string $pkgname): string {
 }
 
 /*
- * OUR repo's latest version of $pkgname: `pkg update -r <repo>` (best-effort refresh of
- * just our catalog DB) then `pkg rquery -r <repo> '%v' <pkgname>`. Reads ONLY our repo
+ * The pfBlockerNG repo's latest version of $pkgname: `pkg update -r <repo>` (best-effort refresh of
+ * just that repo's catalog DB) then `pkg rquery -r <repo> '%v' <pkgname>`. Reads ONLY that repo
  * ($reponame) — never -r pfSense / get_pkg_info (ADR-19 §2 "Read latest"). Returns ''
  * (the caller then serves cache) when:
  *   - $pkgname/$reponame is empty;
@@ -3490,7 +3490,7 @@ function pfb_pkg_latest(string $pkgname, string $reponame): string {
 	// Bound both networked pkg calls with timeout(1) (same idiom as the hook runner) so a
 	// hung mirror can never stall the cron pass or the page's forced "Check now".
 	$tmo = '/usr/bin/timeout -s TERM -k 5 60 ';
-	// Best-effort catalog refresh of our repo only; ignore failures (stale DB still reads).
+	// Best-effort catalog refresh of the pfBlockerNG repo only; ignore failures (stale DB still reads).
 	exec("{$tmo}{$bin} update -r {$repo} 2>/dev/null");
 	$out = array();
 	$ret = -1;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -539,17 +539,11 @@ function pfb_port_alias_types(): array {
 	return ['port', 'url_ports', 'urltable_ports'];
 }
 
-// Build the alias-name maps that feed the Adv. In/Outbound rule autocomplete + the
-// save-time option validation on the IP, DNSBL, and Feed (category-edit) pages
-// (Custom Port + Custom Source/Destination fields). Returned name=>name maps are
-// NAME-KEYED so a save-time array_key_exists($posted, $options) works.
-//
-// Ports: every port-bearing type (pfb_port_alias_types() -- port/url_ports/urltable_ports).
-// Addresses: every address-bearing type (pfb_exclude_alias_types() -- host/network/url/
-// urltable), NOT just 'network', so a Host alias (a single IP) autocompletes and saves too.
-// pfB_-managed (pfB_*) aliases are skipped from BOTH lists: the field help forbids them
-// (e.g. the package's own pfB_DNSBL_Ports port alias) and they are not valid user rule
-// sources.
+// Alias-name maps for the Adv. In/Outbound autocomplete + save-time option validation on the
+// IP/DNSBL/Feed pages. NAME-KEYED so a save-time array_key_exists($posted, $options) works.
+// Ports: pfb_port_alias_types(). Addresses: pfb_exclude_alias_types() (host/network/url/
+// urltable, so a single-IP Host alias autocompletes/saves too). pfB_-managed aliases are
+// skipped from both — forbidden by field help and not valid user rule sources.
 //
 // @param array $aliases The config_get_path('aliases/alias', []) list.
 // @return array{ports: array<string,string>, networks: array<string,string>}
@@ -605,16 +599,12 @@ function pfb_exclude_alias_exists(string $alias): bool {
 	return $type !== NULL && in_array($type, pfb_exclude_alias_types(), TRUE);
 }
 
-// Build the NAT/filter SOURCE array for a DNS-redirect / DoT-block exception alias.
-// An empty alias yields source 'any' (no exception). A non-empty alias becomes a negated
-// source (listed hosts bypass) ONLY when it is a usable firewall-rule source (an existing
-// address-bearing, non-pfB_ alias); a missing / port / managed / stale name falls back to
-// 'any' and is logged. This guard is the single point that prevents a non-resolving alias
-// from emitting a sourceless "from ! ..." rule — pf rejects that as a syntax error, which
-// fails the WHOLE ruleset load, not just this one rule. Shared by pfb_dot_block_rule(),
-// pfb_dot_block_floating_rule() and the DNS-redirect NAT builder in sync_package_pfblockerng().
-// $context names the specific rule (interface [+ IP version]) so the log identifies WHICH rule
-// dropped its exception, rather than repeating an identical line per rule (#664).
+// Build the NAT/filter SOURCE array for a DNS-redirect/DoT-block exception alias. Empty alias
+// -> source 'any'. Non-empty alias -> negated source ONLY when it resolves to a usable,
+// non-pfB_ address alias; otherwise falls back to 'any' (logged) — a non-resolving alias must
+// never reach a sourceless "from ! ..." rule, which pf rejects and fails the WHOLE ruleset load.
+// Shared by pfb_dot_block_rule(), pfb_dot_block_floating_rule(), and the DNS-redirect NAT
+// builder. $context names the rule so the log identifies WHICH rule dropped its exception (#664).
 function pfb_redirect_exclude_source(string $alias, string $context = ''): array {
 	if ($alias === '') {
 		return ['any' => ''];
@@ -731,15 +721,10 @@ function pfb_rule_alias_needs_v4_suffix($address, $ipprotocol) {
 	       $ipprotocol === 'inet';
 }
 
-// Collect the auto-rule suffix already in use by an existing pfB_ firewall
-// rule (sync_package_pfblockerng() auto-rule-suffix configuration, issue
-// #713). Scans $rules for the FIRST rule whose descr matches the
-// pfBlockerNG auto-rule naming pattern ('pfB_<Type><suffix>') and, when
-// found, both confirms a pfB_ rule already exists ('found') and extracts its
-// suffix ('suffix') so the caller can preserve it instead of re-applying the
-// currently configured suffix setting over already-deployed rules.
-//
-// PURE — no I/O, no globals, no side effects.
+// Collect the auto-rule suffix already in use by an existing pfB_ firewall rule (issue #713).
+// Scans $rules for the FIRST rule whose descr matches 'pfB_<Type><suffix>'; when found, reports
+// existence ('found') and extracts 'suffix' so the caller preserves it instead of re-applying
+// the configured suffix over already-deployed rules. PURE — no I/O, no globals, no side effects.
 //
 // @param array<int, array<string, mixed>> $rules  config 'filter/rule' entries.
 // @return array{found: bool, suffix: string}
@@ -757,17 +742,12 @@ function pfb_collect_autorule_suffix(array $rules): array {
 	return ['found' => $found, 'suffix' => $suffix];
 }
 
-// Validate and normalise the Reports-tab whitelist composite 'atype' parameter,
-// which arrives as 'Whitelist|<ip>|<description>'. The IP is validated via
-// PFB_FILTER_IP (is_ipaddr); an invalid IP yields an empty IP slot
-// ('Whitelist||<descr>') that the downstream invalid-IP branch in the addgroup
-// block catches and surfaces as a user-visible error. The description is kept as
-// normalised raw text — control characters and newlines are collapsed to a single
-// space so it cannot inject extra lines into the (base64-stored) custom list — and
-// is NOT HTML-encoded here: storage is base64 and each display sink escapes on
-// output (json_encode for the JS variable, Form_Input/Form_Textarea for HTML).
-// Splitting with a limit of 3 preserves any '|' characters inside the description.
-// A non-'Whitelist' first token is rejected (returns '').
+// Validate/normalise the Reports-tab whitelist composite 'atype' param ('Whitelist|<ip>|
+// <description>'). IP validated via PFB_FILTER_IP; an invalid IP yields an empty slot that the
+// addgroup block surfaces as a user error. Description: control chars/newlines collapsed to a
+// space (blocks line injection into the base64-stored custom list); NOT HTML-encoded here —
+// each display sink escapes on output. Split limit 3 preserves '|' inside the description; a
+// non-'Whitelist' first token is rejected (returns '').
 function pfb_filter_whitelist_atype(string $raw): string {
 	$parts = explode('|', $raw, 3);
 	if (($parts[0] ?? '') !== 'Whitelist') {
@@ -789,10 +769,9 @@ function pfb_sync_filter_password(string $value): string {
 	return $value;
 }
 
-// Pure allow-list membership test for a MIME-type string.
-// Encapsulates the isset($pfb['mime_types'][...]) lookup used by the
-// PFB_FILTER_FILE_MIME (17) and PFB_FILTER_FILE_MIME_COMPRESSED (18) branches
-// so that Phase 2 normalisation has a clean, single insertion point.
+// Pure allow-list membership test for a MIME-type string. Encapsulates the
+// isset($pfb['mime_types'][...]) lookup used by the PFB_FILTER_FILE_MIME (17) and
+// PFB_FILTER_FILE_MIME_COMPRESSED (18) branches as a single insertion point.
 function pfb_mime_in_allowlist(string $mime, array $allowlist): bool {
 	return isset($allowlist[$mime]);
 }
@@ -821,7 +800,7 @@ function pfb_mime_normalise(string $raw): string {
 	return $raw;
 }
 
-// ADR-45 Phase 1: pure mapping — canonical archive MIME → base integrity-test argv.
+// ADR-45: pure mapping — canonical archive MIME → base integrity-test argv.
 // Returns the binary + flags array (file NOT included; pfb_validate_archive() appends
 // it at call time so this helper stays pure and trivially oracle-testable).
 // Returns NULL for non-archive types — nothing to probe.
@@ -841,7 +820,7 @@ function pfb_archive_probe(string $canonical_type): ?array {
 	}
 }
 
-// ADR-45 Phase 1: run the structural integrity probe for $file.
+// ADR-45: run the structural integrity probe for $file.
 // Returns TRUE for non-archive types (nothing to test), TRUE if the probe exits 0
 // (archive is intact), FALSE if the probe exits non-zero (corrupt/truncated archive).
 // The $runner callable(array $argv): int is injectable for unit tests — default runner
@@ -863,7 +842,7 @@ function pfb_validate_archive(string $file, string $canonical_type, ?callable $r
 	return $runner($argv) === 0;
 }
 
-// ADR-45 Phase 3: seamed recovery helper for application/octet-stream (or empty) MIME.
+// ADR-45: seamed recovery helper for application/octet-stream (or empty) MIME.
 // Loops $supported_types in order; returns the first $type for which $validator($file, $type)
 // is TRUE (positive structural identification), or NULL when no probe matches.
 // $validator shape: callable(string $file, string $type): bool — production value is
@@ -894,22 +873,13 @@ function pfb_archive_missing_tool(string $canonical_type, ?callable $checker = N
 	return $checker($argv[0]) ? NULL : $argv[0];
 }
 
-// ADR-48 Phase 1: pure formatter for the canonical download-validation reject line —
-// a single greppable line naming which feed/stage/reason caused a rejection and the
-// raw detected detail (e.g. file(1) output, a tool's exit code, an offending member
-// name). $stage is one of mime|structural|inner|member|plaintext|entries; this
-// formatter does not validate the token, callers own the vocabulary.
-//
-// Canonical shape (leading "\n" per the pfb_logger() caller convention -- pfb_logger()
-// itself emits no newline):
-//   \npfb_validate: REJECT feed=<feed> stage=<stage> reason=<reason> detected=<detail>
-//
-// Escaping is applied to EACH of the four values independently, in this order:
-//   1. every control byte in [\x00-\x1F\x7F] is replaced with a single space -- these
-//      values may carry attacker-influenced file(1) output, and a raw "\n"/"\r" would
-//      forge or split the greppable line;
-//   2. htmlspecialchars() (matching the escaping the existing reject messages use).
-// Pure: string in, string out, no I/O, no globals.
+// ADR-48: pure formatter for the canonical download-validation reject line — a single
+// greppable line naming feed/stage/reason + raw detected detail. $stage is one of
+// mime|structural|inner|member|plaintext|entries (caller-owned vocabulary, unvalidated here).
+// Shape: "\npfb_validate: REJECT feed=<feed> stage=<stage> reason=<reason> detected=<detail>"
+// (leading "\n" per pfb_logger() convention). Each value is escaped independently: control
+// bytes -> space (blocks forging/splitting the line via attacker-influenced detail), then
+// htmlspecialchars(). Pure: string in, string out, no I/O, no globals.
 function pfb_validate_log_line(string $feed, string $stage, string $reason, string $detail = ''): string {
 	[$feed, $stage, $reason, $detail] = array_map(
 		static function (string $value): string {
@@ -920,7 +890,7 @@ function pfb_validate_log_line(string $feed, string $stage, string $reason, stri
 	return "\npfb_validate: REJECT feed={$feed} stage={$stage} reason={$reason} detected={$detail}";
 }
 
-// ADR-48 Phase 1: thin emit wrapper -- builds the canonical reject line via
+// ADR-48: thin emit wrapper -- builds the canonical reject line via
 // pfb_validate_log_line() and emits it through pfb_logger() at the reject level
 // (default 2 = pfB log + error log). One call site per rejection.
 function pfb_validate_log(string $feed, string $stage, string $reason, string $detail = '', int $level = 2): void {
@@ -984,7 +954,7 @@ function pfb_archive_unsafe_member(?array $names): ?string {
 	return NULL;
 }
 
-// ADR-48 Phase 4 (issue #789): reads the Python-emitted per-entry reject tally
+// ADR-48 (issue #789): reads the Python-emitted per-entry reject tally
 // artifact (pfb_py_reject_stats.json -- build()'s normalise() domain-shape rejects
 // and #753 wire-cap rejects, bucketed shape/wire_cap, per feed/group) and emits
 // ONE canonical stage=entries line per (feed, nonzero bucket) via pfb_validate_log().
@@ -1055,22 +1025,15 @@ function pfb_utf16_sample_to_utf8(string $sample): string {
 	return ($converted === FALSE) ? $sample : $converted;
 }
 
-// issue #946: transcode a UTF-16/UTF-32-BOM-prefixed FILE to UTF-8 in place, atomically.
-// Only the first 4 bytes are read to sniff the BOM (this runs on every text-feed ingest
-// that reaches the .orig finalize step, and
-// feeds can be tens of MB -- slurping them all just to look at a prefix would risk the PHP
-// memory limit, which file_get_contents() hits as a fatal error, not a catchable failure);
-// the full read happens only for an actual BOM match. Returns FALSE (file left untouched)
-// when: the path is unreadable, no BOM matches, or mb_convert_encoding() fails (logged as a
-// warning; believed unreachable on stock mbstring, which substitutes '?' instead of failing)
-// -- fail-open in every case, so downstream behaves exactly as it did before this function
-// existed. Returns TRUE after a successful same-filesystem rename() with the original mtime
-// (when its stat succeeded) and permission bits (same) restored -- the caller runs this AFTER
-// the remote_stamp touch(), so that stamp must survive, and tempnam() creates 0600 files, so
-// the mode must be carried over explicitly (same discipline as the atomic-publish helpers).
-// ponytail: whole-file read/rewrite for the BOM-matched case only -- BOM-marked feeds are
-// rare and small in practice; switch to a streaming decode if that assumption ever stops
-// holding.
+// issue #946: transcode a UTF-16/UTF-32-BOM-prefixed FILE to UTF-8 in place, atomically. Reads
+// only the first 4 bytes to sniff the BOM (feeds can be tens of MB; a full read risks the PHP
+// memory limit) — the full read happens only on an actual BOM match. Returns FALSE (untouched)
+// on an unreadable path, no BOM match, or a failed mb_convert_encoding() (fail-open in every
+// case). Returns TRUE after a same-filesystem rename() with the original mtime/permission bits
+// restored (tempnam() creates 0600 files, so the mode must be carried over explicitly).
+//
+// ponytail: whole-file read/rewrite for the BOM-matched case only; switch to streaming if
+// BOM-marked feeds stop being rare/small.
 function pfb_utf16_transcode_file(string $path): bool {
 	if (!@is_readable($path)) {
 		return FALSE;
@@ -1119,45 +1082,15 @@ function pfb_utf16_transcode_file(string $path): bool {
 	return TRUE;
 }
 
-// ADR-49 Phase 1: pure content-sanity scan over the first chunk of a downloaded
-// text feed. The caller reads a capped head sample (64 KiB at the pfb_download()
-// gate) and passes it in as $sample -- this function does no I/O and has no
-// notion of the cap: the read is a ceiling, never a floor, so a feed shorter
-// than the cap is a COMPLETE sample and is never penalised for its size.
+// ADR-49: content-sanity gate for a downloaded text feed's first 64-KiB chunk; pinned by
+// PfbTextSanityTest. Reason order (first hit wins): 'nul_bytes' (any NUL byte) >
+// 'html_error_page' (opens as HTML AND no line is blocklist-shaped: an IPv4/IPv6/CIDR
+// anywhere, or a whole-line domain.tld token) > 'below_min_content' (zero non-blank,
+// non-comment lines) > NULL. BYTE-LEVEL matching only (no `/u`) so a chunk-truncated
+// multibyte tail can never flip a verdict. Pure: string in, ?string out, no I/O.
 //
-// Returns NULL when the sample looks like plausible blocklist text, else one of
-// three reason tokens naming why it does not. Evaluated in this order, first
-// hit wins:
-//   1. 'nul_bytes'         -- the sample contains ANY NUL byte. Unambiguous for
-//                             a text feed, so it is checked first.
-//   2. 'html_error_page'   -- the sample, left-trimmed of leading whitespace,
-//                             opens (case-insensitively) with "<!doctype html"
-//                             or "<html", AND no line of the sample is
-//                             "blocklist-shaped": an IPv4/IPv6 address or CIDR
-//                             anywhere in the line (real feeds -- ProjectHoneypot,
-//                             cybercrime-tracker -- embed IPs inside HTML markup),
-//                             or a WHOLE line that is one bare/ABP-wrapped
-//                             domain.tld token. The domain token must BE the
-//                             line, never a substring: real error pages embed
-//                             domain-shaped tokens in markup (a DOCTYPE's w3.org
-//                             DTD URL, favicon.ico / *.css hrefs, CDN links),
-//                             and those must not suppress the verdict. This is
-//                             the false-positive guard: an HTML-ish feed that
-//                             DOES carry blocklist lines is not flagged.
-//   3. 'below_min_content' -- a LINE-count floor of 1, never a byte-size floor:
-//                             fires only when the sample has ZERO non-blank,
-//                             non-comment lines (a comment line begins with
-//                             '#' or '!' after trimming leading whitespace). A
-//                             single legitimate data line satisfies the floor.
-//   4. otherwise NULL.
-//
-// BYTE-LEVEL matching only -- no `/u` modifier anywhere. Every pattern above is
-// pure ASCII, so a chunk-truncated multibyte tail can never flip a verdict.
-// Pure: string in, ?string out, no I/O, no globals.
-//
-// issue #946: a UTF-16/UTF-32-BOM-prefixed sample is decoded to UTF-8 FIRST (before
-// the UTF-8 BOM strip below) -- otherwise every line of a legitimate UTF-16/32 feed
-// carries interleaved NUL bytes and trips 'nul_bytes' on text that is actually fine.
+// issue #946: a UTF-16/32-BOM-prefixed sample is decoded to UTF-8 FIRST (before the UTF-8
+// BOM strip below) -- else a legitimate wide-char feed trips 'nul_bytes' on its own bytes.
 function pfb_text_sanity(string $sample): ?string {
 	$sample = pfb_utf16_sample_to_utf8($sample);
 
@@ -1235,17 +1168,13 @@ function pfb_text_sanity(string $sample): ?string {
 	return 'below_min_content';
 }
 
-// Function to filter/sanitize user input
+// Function to filter/sanitize user input.
 //
-// ADR-48 Phase 2: $reject_detail is an optional by-ref out-param for the
-// PFB_FILTER_FILE_MIME / PFB_FILTER_FILE_MIME_COMPRESSED reject paths only. A
-// caller that pre-sets it to an array() opts in: on rejection this function
-// fills it with the raw detail (['mime_raw', 'mime', 'retval']) and SUPPRESSES
-// its own legacy message so the caller can emit the canonical
-// pfb_validate_log() line instead (it has the feed header + true stage in
-// scope, which pfb_filter() does not). A caller that leaves it NULL (the
-// default) gets the legacy in-filter message unchanged -- no rejection ever
-// loses its log entry.
+// ADR-48: $reject_detail is an optional by-ref out-param for the PFB_FILTER_FILE_MIME /
+// PFB_FILTER_FILE_MIME_COMPRESSED reject paths only. A caller that pre-sets it to an array()
+// opts in: on rejection this fills it with the raw detail and SUPPRESSES the legacy message so
+// the caller can emit the canonical pfb_validate_log() line instead. A caller that leaves it
+// NULL (default) gets the legacy in-filter message unchanged -- no rejection loses its log.
 function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FALSE, &$reject_detail=NULL) {
 	global $pfb;
 
@@ -1833,16 +1762,11 @@ function pfb_get_vip_options(int $family, bool $pkg_xml_format = FALSE) {
 	return $options;
 }
 
-// [ ADR-13 ] Pure decision: is a v6 sinkhole VIP WANTED for this DNSBL config?
-// True iff the DNS Resolver listens on IPv6 AND the package is NOT auto-provisioning
-// the VIP (manual mode). When auto-create is on, pfb_manage_dnsbl_vip() provisions the
-// v6 VIP with no user friction. When auto is off, a v6-listening resolver SHOULD have a
-// v6 sinkhole VIP so AAAA blocks are sinkholed too — but this is a NON-BLOCKING
-// recommendation (ADR-13 §7 pivot): pfb_global logs a warning and DNSBL keeps running
-// on IPv4. It is NOT a hard requirement — an earlier revision force-disabled DNSBL here,
-// which broke every existing manual setup whose resolver listens on IPv6 without a v6
-// VIP (the common case). Pure: takes the two booleans, decides; no global/config access,
-// so the recommendation has a single, directly-testable source of truth.
+// [ADR-13] Pure decision: is a v6 sinkhole VIP WANTED for this DNSBL config? True iff the DNS
+// Resolver listens on IPv6 AND auto-provisioning is off (manual mode) — a NON-BLOCKING
+// recommendation (ADR-13 §7): pfb_global logs a warning, DNSBL keeps running on IPv4. NOT a hard
+// requirement — a v6-listening resolver without a v6 VIP is a common, valid manual setup. Pure:
+// no global/config access, single directly-testable source of truth.
 function pfb_dnsbl_v6_vip_required(bool $listens_v6, bool $auto): bool {
 	return $listens_v6 && !$auto;
 }
@@ -2006,22 +1930,10 @@ function pfb_validate_vips(string $interface, string|null $vip4 = '', string|nul
 	return [TRUE, null];
 }
 
-// [ ADR-13 / issue #473 / issue #487 ] Small fixed ordered list of DNS-themed
-// candidate sinkhole VIP addresses for a family. Pure (no side effects).
-//
-// IPv4 — three candidates, Class B first (least-used RFC1918 on end-user LANs),
-// then Class C, then Class A (most-used, so last). Each is a /32 .53 host
-// (DNS-port homage):
-//   172.16.53.53  (172.16/12)
-//   192.168.53.53 (192.168/16)
-//   10.53.53.53   (10/8)
-//
-// IPv6 — single ULA candidate: fd00:53:53:53:53:53:53:53 (/128). On conflict
-// the picker returns null and the user resolves it manually (an IPv6 user on
-// that exact ULA can address it themselves without a larger pool).
-//
-// The conflict-aware picker (pfb_pick_free_dnsbl_vip) returns the first free one.
-// Returns [] for any other family.
+// [ADR-13] (issue #473 / #487) Fixed ordered candidate sinkhole VIP list per family, each a
+// DNS-port-homage .53 host; IPv4 ordered least-used RFC1918 first (Class B, C, then A). IPv6:
+// single ULA fd00:53:53:53:53:53:53:53/128 — on conflict the picker returns null and the user
+// resolves it manually. pfb_pick_free_dnsbl_vip() returns the first free candidate. Pure.
 function pfb_dnsbl_vip_candidates(int $family): array {
 
 	if ($family === AF_INET) {
@@ -2076,33 +1988,14 @@ function pfb_pick_free_dnsbl_vip(int $family, string $interface): ?string {
 	return null;
 }
 
-// [ ADR-13 ] True iff the DNS Resolver (Unbound) is configured to listen on at least
-// one IPv6 address. Mirrors how pfSense builds Unbound's listen set in
-// unbound_generate_config_text() (src/etc/inc/unbound.inc) — verified verbatim
-// against upstream at RELENG_2_7_2 (frozen public-mirror ref, signatures stable
-// 2.7->2.8) and master; the active_interface key, the empty/'all' => automatic
-// branch, and the per-interface get_interface_ip()/get_interface_ipv6() resolution
-// are identical across both refs:
-//
-//   $active = array_filter(explode(',', $unboundcfg['active_interface']));
-//   if (empty($active) || in_array('all', $active, true)) { interface-automatic: yes }
-//   else foreach ($active as $ubif) { ... get_interface_ipv6($ubif) -> bind v6 ... }
-//
-// Predicate (conservative/correct over clever):
-//   * Resolver disabled (config_path_enabled('unbound') false) -> listens on nothing
-//     -> false.
-//   * active_interface empty or contains 'all' -> Unbound emits 'interface-automatic:
-//     yes' and binds EVERY address on its enabled interfaces, v6 included -> true iff
-//     ANY configured interface currently resolves to an IPv6 address (get_interface_ipv6).
-//   * otherwise -> the explicit per-interface list: true iff ANY listed token is a v6
-//     literal (is_ipaddrv6) or an interface that resolves to a v6 address
-//     (get_interface_ipv6), mirroring upstream's bind loop (incl. the up/enabled
-//     status guard from redmine #11087).
-//
-// MUST still be confirmed on-box (no PHP/Unbound runtime in CI): that
-// get_interface_ipv6() returns a routable v6 (not just link-local) for an automatic
-// bind, and that 'interface-automatic: yes' does in fact accept v6 queries on the
-// box's configuration. Used by Phase 3 (v6-mandatory rule) — UNWIRED in Phase 1.
+// [ADR-13] True iff Unbound is configured to listen on IPv6. Mirrors unbound_generate_config_text()
+// (src/etc/inc/unbound.inc) — verified verbatim against upstream at RELENG_2_7_2 and master.
+// Predicate: resolver disabled -> false; active_interface empty/'all' -> 'interface-automatic:
+// yes', true iff ANY enabled interface currently has a v6 address; else true iff ANY listed
+// token is a v6 literal or an interface resolving to v6 (mirrors upstream's bind loop, incl.
+// the up/enabled guard from redmine #11087). MUST be confirmed on-box (no PHP/Unbound runtime
+// in CI): that an automatic bind's v6 is routable (not link-local only), and that
+// 'interface-automatic: yes' does accept v6 queries. Not yet wired into the v6-mandatory rule.
 function pfb_unbound_listens_v6(): bool {
 
 	// A disabled resolver listens on nothing.
@@ -2144,18 +2037,12 @@ function pfb_unbound_listens_v6(): bool {
 	return FALSE;
 }
 
-// [ ADR-13 ] Locate the index of the auto-managed DNSBL VIP this package owns inside a
-// virtualip/vip array. Pure (no side effects). Ownership is decided by TWO predicates,
-// both required, mirroring the lifecycle contract:
-//   (1) MARKER  : pfb_is_managed_obj($vip['descr']) AND marker match via the same
-//                 prefix/contains logic as pfb_find_managed_obj. VIP markers
-//                 (PFB_AUTO_VIP_DESCR_V4/V6) start with 'pfB_' → str_starts_with.
-//   (2) IP MATCH: when $match_ip is a non-empty string, $vip['subnet'] must equal it.
-//                 Used on delete to bind removal to the address currently resolved from
-//                 the stored pfb_dnsvip4/6 config, so we never delete a marked VIP whose
-//                 address no longer corresponds to our config. Pass null to match on the
-//                 marker alone (idempotent reuse on create, before any id is stored).
-// Returns the integer key of the first matching entry, or null if none matches.
+// [ADR-13] Locate the index of the auto-managed DNSBL VIP this package owns inside a
+// virtualip/vip array. Pure. Ownership requires BOTH: (1) MARKER — pfb_is_managed_obj($descr)
+// AND a prefix/contains match against PFB_AUTO_VIP_DESCR_V4/V6 (same logic as
+// pfb_find_managed_obj); (2) IP MATCH — when $match_ip is non-empty, $vip['subnet'] must equal
+// it (binds delete to the address currently resolved from stored config, so a marked VIP whose
+// address no longer matches is never deleted). Pass null to match on the marker alone (create).
 function pfb_find_marked_vip(array $vips_config, string $marker, ?string $match_ip): ?int {
 	$use_prefix = str_starts_with($marker, PFB_MANAGED_FILTER_PFX);
 	foreach ($vips_config as $idx => $vip) {
@@ -2179,35 +2066,14 @@ function pfb_find_marked_vip(array $vips_config, string $marker, ?string $match_
 	return null;
 }
 
-// [ ADR-13 ] VIP lifecycle manager. Creates the marked DNSBL sinkhole VIP(s) on enable
-// (when 'Create VIPs automatically' is on) and removes ONLY the marked + IP-matched
-// VIP(s) on disable / when no longer managed. Wired into pfb_create_dnsbl($mode).
-//
-// ADDITIVE: with pfb_dnsvip_auto off (and never previously on) there is no marked VIP,
-// so neither the enabled nor the disabled path finds a marker+IP-matched VIP to remove
-// -> $changed stays FALSE -> no write_config -> the runtime is byte-identical to today.
-//
-// Marker/IP delete guard: a VIP is removed iff BOTH (a) its descr equals
-// PFB_AUTO_VIP_DESCR_V4/_V6 AND (b) its subnet equals the IP currently resolved from the
-// stored pfb_dnsvip4/6 config (pfb_find_marked_vip(..., $match_ip)). A manually-created
-// VIP (no marker) is NEVER touched; a marked VIP whose address no longer matches stored
-// config is NEVER deleted on the basis of the marker alone.
-//
-// Create apply sequence matches upstream firewall_virtual_ip.inc (config first, then
-// apply): the vip entry is written into virtualip/vip and the dnsvip id into the DNSBL
-// settings, write_config fires ONCE iff anything changed, then interface_ipalias_configure()
-// brings the alias up live.
-//
-// Validation contract (PFBL-01): $interface (the stored dnsbl_interface setting; a
-// pfSense friendly interface name -- 'lo0', 'lan', 'optN', 'enc0', 'openvpn', 'l2tp',
-// per pfb_build_if_list()) must validate via pfb_filter(PFB_FILTER_WORD) before it is
-// written into a VIP entry or handed to interface_vip_bring_down() /
-// interface_ipalias_configure(). Every legal friendly name is \w-only, so the WORD
-// filter passes all of them unchanged and rejects anything carrying separators,
-// spaces, quotes or other non-word characters. As a singular required parameter, a
-// value failing the filter ABORTS VIP management for the run (log + return, no
-// config read or write, no VIP operation). The constant's accept/reject behaviour
-// is pinned by tests/php/PfbFilterContractTest.php.
+// [ADR-13] VIP lifecycle manager: creates the marked DNSBL sinkhole VIP(s) on enable (auto
+// on), removes ONLY the marked + IP-matched VIP(s) on disable/unmanaged. ADDITIVE: with
+// pfb_dnsvip_auto never turned on, no marked VIP is found -> no write_config -> byte-identical
+// runtime. Delete guard: removed iff descr == PFB_AUTO_VIP_DESCR_V4/_V6 AND subnet == the
+// address resolved from stored pfb_dnsvip4/6 (pfb_find_marked_vip) — a manual or
+// address-drifted VIP is NEVER deleted. Apply order matches upstream firewall_virtual_ip.inc.
+// PFBL-01: $interface must pass pfb_filter(PFB_FILTER_WORD) before use, else the run aborts;
+// pinned by tests/php/PfbFilterContractTest.php.
 function pfb_manage_dnsbl_vip(string $mode): void {
 	global $pfb;
 
@@ -2238,7 +2104,7 @@ function pfb_manage_dnsbl_vip(string $mode): void {
 
 	// Families to provision when creating. v4 is always managed. v6 is managed when a
 	// v6 VIP is already requested (an id stored) or the resolver listens on IPv6
-	// (Phase 3 makes v6 mandatory in that case; here we simply provision it).
+	// (provisioned here; not yet made mandatory in that case).
 	$want_v6 = !empty($pfb['dnsblconfig']['pfb_dnsvip6']) || pfb_unbound_listens_v6();
 
 	// Per-family descriptor table: marker, AF, subnet_bits, the stored-id config key.
@@ -2891,19 +2757,13 @@ function pfbng_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
 }
 
 
-// Resolve a stored 'log_max_<type>' config value to the truncation limit
-// pfb_log_mgmt() should apply. The web UI stores the literal string 'nolimit'
-// for the "No Limit - Not recommended" option (pfblockerng_general.php);
-// PFB_FILTER_NUM only accepts digit strings, so running the raw value
-// through it directly silently collapses 'nolimit' to the numeric default
-// and the opt-out never takes effect (issue #713) — this helper must run on
-// the RAW config value, before any numeric filtering.
-//
-// PURE — no I/O, no globals, no side effects.
+// Resolve a stored 'log_max_<type>' config value to the truncation limit pfb_log_mgmt() should
+// apply. UI stores literal 'nolimit' for "No Limit"; PFB_FILTER_NUM accepts digits only, so
+// filtering the raw value directly silently collapses 'nolimit' to the numeric default and the
+// opt-out never takes effect (issue #713) — must run on the RAW value first. PURE.
 //
 // @param mixed $raw  Raw 'log_max_<type>' config value.
-// @return int|string  'nolimit' (skip truncation), or a positive int line
-//                      count (a numeric raw value, else the 20000 default).
+// @return int|string  'nolimit', or a positive int line count (numeric raw, else 20000 default).
 function pfb_log_max_lines($raw) {
 	if ($raw === 'nolimit') {
 		return 'nolimit';
@@ -3541,7 +3401,7 @@ function pfb_should_notify(?string $installed, ?string $latest, ?string $last_no
 }
 
 /*
- * ADR-19 Phase 3 — pkg IO wrapper + cron-driven update check (consumes the pure core).
+ * ADR-19 — pkg IO wrapper + cron-driven update check (consumes the pure core).
  *
  * The pfb_pkg_*() functions below are the ONLY new code that shells to `pkg`; isolating
  * the shellout in thin wrappers keeps pfb_software_update_check() unit-testable (the
@@ -3782,7 +3642,7 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 }
 
 /*
- * ADR-19 Phase 4 — provenance gate for the shipped GUI surfaces.
+ * ADR-19 — provenance gate for the shipped GUI surfaces.
  *
  * Live wrapper over the pure pfb_software_is_our_build() (ADR-19 2026-06-15
  * amendment): reads the installed package's provenance from `pkg query '%R'`
@@ -4510,7 +4370,7 @@ function pfb_hook_trigger($cron) {
  *                  'force'   => bool,
  *                  'trigger' => 'cron'|'manual'|'force' }
  *
- * ADR-43 Phase 3: 'update' gets its own 'manual' trigger identity (was 'cron' in Phase 1).
+ * ADR-43: 'update' now gets its own 'manual' trigger identity (previously 'cron').
  * PFB_TRIGGER is now derived by pfb_req_to_hook_trigger() from the struct's 'trigger' field:
  *   'cron'   → 'cron'          (scheduled cron and noupdates)
  *   'manual' → 'update'        (pfblockerng.php 'update' verb, HA-sync, settings save)
@@ -4519,8 +4379,7 @@ function pfb_hook_trigger($cron) {
  * 'noupdates' and '' (settings save / de-install) carry the same struct as 'cron'; their
  * side-channel behaviour ($pfb['save']=TRUE; no-scope-change) is handled by sync_package.
  *
- * ADR-43 Phase 1 — oracle: TriggerRequestTest.php pins this table; Phase 3 breaks
- * testUpdateVerbMapsIdenticallyToCronToday (trigger 'cron'→'manual') red→green.
+ * ADR-43 — oracle: TriggerRequestTest.php pins this table (trigger 'cron'→'manual' for 'update').
  */
 function pfb_trigger_request($verb) {
 	switch ((string) $verb) {
@@ -4529,7 +4388,7 @@ function pfb_trigger_request($verb) {
 		case 'updatednsbl':
 			return ['scope' => 'dnsbl', 'force' => TRUE,  'trigger' => 'force'];
 		case 'update':
-			// ADR-43 Phase 3: 'update' gets its own 'manual' trigger identity.
+			// ADR-43: 'update' gets its own 'manual' trigger identity.
 			// pfblockerng.php now passes 'update' (not 'cron') so the verb is distinguishable
 			// inside the pass. PFB_TRIGGER = pfb_req_to_hook_trigger('manual') = 'update'.
 			return ['scope' => 'both', 'force' => FALSE, 'trigger' => 'manual'];
@@ -4543,7 +4402,7 @@ function pfb_trigger_request($verb) {
 /*
  * Map the 'trigger' field of a pfb_trigger_request() struct to the ADR-12 PFB_TRIGGER value.
  *
- * ADR-43 Phase 3: replaces the direct pfb_hook_trigger($cron) calls in sync_package_pfblockerng()
+ * ADR-43: replaces the direct pfb_hook_trigger($cron) calls in sync_package_pfblockerng()
  * for the array (new API) path. The string path still uses pfb_hook_trigger() directly so the
  * back-compat mapping is preserved without duplication.
  *
@@ -4563,7 +4422,7 @@ function pfb_req_to_hook_trigger($trigger) {
 /*
  * Return the deprecation warning string for a legacy verb string, or '' if not deprecated.
  *
- * ADR-43 Phase 3: 'update', 'updateip', 'updatednsbl' are DEPRECATED as sync_package_pfblockerng()
+ * ADR-43: 'update', 'updateip', 'updatednsbl' are DEPRECATED as sync_package_pfblockerng()
  * string arguments. Callers should pass the explicit {scope, force, trigger} request array instead
  * (or use pfb_trigger_request($verb) to build it). Removal is scheduled for a future major release.
  *
@@ -4728,40 +4587,14 @@ function pfb_determine_list_detail($list='', $header='', $confconfig='', $key=''
 }
 
 
-// ADR-11: Return the EFFECTIVE member-file list for one aggregate action type and
-// family -- the input the Phase-3 caller hands to `pfblockerng.sh aggregate` to union
-// into pfB_<Type>_Aggregated_<fam>. Pure: it reads the per-type dir off disk and
-// returns the matching family member files; it has NO side effects and is NOT yet
-// called from the update pass (Phase 2 is behaviour-preserving).
-//
-// Type -> dir map (mirrors pfb_determine_list_detail's action -> folder routing):
-//   'Deny'   -> denydir    'Permit' -> permitdir
-//   'Match'  -> matchdir   'Native' -> nativedir
-//
-// EFFECTIVE / post-suppression -- the key Phase-4 fact:
-//   The denydir '<header>_<fam>.txt' member files are ALREADY the effective
-//   (post-suppression / post-whitelist) block set on disk. During the update pass
-//   the shell 'suppress' action (pfblockerng.sh suppress, grepcidr -vf
-//   pfbsuppression.txt) rewrites each Deny member file IN PLACE (pfblockerng.inc
-//   ~:10829-10834) BEFORE it is read into the alias (~:10836) -- and
-//   pfb_create_suppression_file() folds the user whitelist, local/DNS IPs and
-//   Permit-customlist IPs into pfbsuppression.txt. So reading denydir/*_<fam>.txt
-//   yields the effective set directly; the helper applies NO further suppression.
-//   (Phase 3 must therefore run the aggregate AFTER the per-member suppress step.)
-//
-// DNSBLIP + GeoIP fold in for FREE -- no special-casing here:
-//   DNSBLIP_<fam>.txt is deposited into the dir of its configured action
-//   ($pfb['dnsbl_ip'], e.g. Deny -> denydir) during the build loop, and each
-//   Deny-action GeoIP continent likewise lands in denydir by its action
-//   (pfblockerng.inc ~:9926, the §1.5 "GeoIP folds by action" fact). Both are plain
-//   '<header>_<fam>.txt' members in the type's dir, so this glob already includes
-//   them; a continent set to Permit/Match lands in that type's dir instead, never
-//   double-listed.
-//
-// $type   : 'Deny' | 'Permit' | 'Match' | 'Native'   (the GUI action-group labels)
-// $family : 'v4' | 'v6'
-// Returns : array of absolute member-file paths (possibly empty); [] for an unknown
-//           type/family so the caller can treat it as "nothing to aggregate".
+// ADR-11: Return the EFFECTIVE member-file list for one aggregate action type + family — the
+// input `pfblockerng.sh aggregate` unions into pfB_<Type>_Aggregated_<fam>. Pure: reads the
+// per-type dir off disk (Deny->denydir, Permit->permitdir, Match->matchdir, Native->nativedir);
+// no side effects; not yet called from the update pass. denydir's '<header>_<fam>.txt' members
+// are ALREADY the effective (post-suppression/whitelist) set — the shell 'suppress' action
+// rewrites each Deny member file in place before the alias read, so this helper must run AFTER
+// that step and applies NO further suppression. DNSBLIP + Deny-action GeoIP continents fold in
+// for free (land in denydir like any other member). $type/$family per GUI; [] if unknown.
 function pfb_aggregate_member_list($type, $family) {
 	global $pfb;
 
@@ -4914,30 +4747,14 @@ function pfb_pfctl_test_match_count(string $output): int {
 }
 
 
-// ADR-11 Phase 3: build + register the opt-in per-type aggregate ("Uber") Native aliases.
-//
-// ONE generic loop over the type->dir map {Deny,Permit,Match,Native} x family {v4,v6}.
-// For each SELECTED type ($pfb['agg_types'], CSV scalar, default none):
-//   pfb_aggregate_member_list($type,$family) -> write a memberlist file -> run
-//   `pfblockerng.sh aggregate <family> <memberlist> <aggout> <consumerout>` (cat|sort -u|
-//   iprange, mtime-gated inside the action) -> register pfB_<Type>_Aggregated_<fam> as a
-//   standard pfB `urltable` alias (mirrors the member-alias registration shape) -> load the
-//   table via `pfctl -T replace -f`. NEVER pfb_firewall_rule -- "Native" is the registration
-//   mode (no rule), regardless of which action class is being aggregated. When an aggregate
-//   is actually (re)built this pass (aggout mtime advanced), its name is merged into
-//   $pfb['changed_ip_aliases'] (emitted to the ADR-12 post-hook as PFB_CHANGED_IP_ALIASES)
-//   and into $pfb_alias_lists, so a recipe can gate its reload on the aggregate changing.
-//
-// A NON-selected type (or pfBlockerNG disabled) is torn down: its aggregate file, consumer
-// file and pf table are removed cleanly, and -- by NOT appending its name to
-// $new_aliases_list -- the caller's existing pfB orphan-prune also unlinks its alias .txt.
-//
-// Additive guarantee: nothing selected => the loop registers/builds nothing and tears down
-// nothing that exists (the aliases were never created), so the pass is byte-identical.
-//
-// $new_aliases, $new_aliases_list, $pfb_alias_lists are taken by reference (the caller's
-// alias-registration arrays); the aggregate alias entries are appended like any other pfB
-// alias so the normal config write + reconcile path carries them.
+// ADR-11: build + register the opt-in per-type aggregate ("Uber") Native aliases. ONE generic
+// loop over type->dir {Deny,Permit,Match,Native} x family {v4,v6}: each SELECTED type
+// ($pfb['agg_types']) gets a memberlist, an mtime-gated `pfblockerng.sh aggregate` run, and a
+// standard pfB urltable alias pfB_<Type>_Aggregated_<fam> (NEVER a firewall rule). A rebuilt
+// aggregate's name merges into $pfb['changed_ip_aliases']/$pfb_alias_lists (reload gating); a
+// non-selected type is torn down (files + pf table removed, omitted from $new_aliases_list so
+// the caller's orphan-prune unlinks it). Additive: nothing selected => byte-identical pass.
+// Array args are by-reference (caller's alias-registration arrays).
 function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_list, array &$pfb_alias_lists) {
 	global $pfb;
 
@@ -5029,7 +4846,7 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 
 
 // ---------------------------------------------------------------------------
-// ADR-40 Phase 1 — alias reload-scope helpers (extracted from sync_package_pfblockerng)
+// ADR-40 — alias reload-scope helpers (extracted from sync_package_pfblockerng)
 // ---------------------------------------------------------------------------
 
 /**
@@ -5080,8 +4897,8 @@ function pfb_select_reload_aliases(
  * (pfblockerng.inc:14460 / :14481) — order-dependent, not deduplicated. This helper
  * captures that exact semantic: read each existing path in order and concatenate.
  *
- * Phase 3 will replace callers with pfb_canonical_alias_set() once content-addressed
- * gating is wired in. Until then this is the oracle for the current behaviour.
+ * This is the oracle for the current (pre-content-addressed) behaviour; callers move to
+ * pfb_canonical_alias_set() once content-addressed gating lands.
  *
  * @param string[] $member_paths Absolute paths to the per-feed .txt files, in the order
  *                               they should be concatenated (matches the row iteration order
@@ -5225,7 +5042,7 @@ function pfb_supp_update_active(bool $pfbadv, bool $supp_enabled): bool {
 }
 
 // ---------------------------------------------------------------------------
-// ADR-40 Phase 4 — forward-delta alias-table apply
+// ADR-40 — forward-delta alias-table apply
 // ---------------------------------------------------------------------------
 
 /** Churn-ratio threshold above which 'auto' mode falls back to -T replace (5%). */
@@ -6026,24 +5843,14 @@ function pfb_create_dnsbl($mode) {
 }
 
 
-// Resolve a SafeSearch CNAME target (e.g. safe.duckduckgo.com) to its current
-// A/AAAA via the configured external DNS server. These are the #2 baked-fallback
-// IPs written into the SafeSearch CSV (issue #149): pfb_unbound.py uses them only
-// when the live CNAME chase yields no address, and the SafeSearch freshness cron
-// re-runs this every 15 minutes to keep them current. Returns array($v4, $v6),
-// each '' when unresolved.
-//
-// Validation contract (PFBL-01): $target is built into an exec() command line
-// (escapeshellarg() supplies the quoting; $pfb['extdns'] is already
-// PFB_FILTER_IPV4-validated in pfb_global). The contract for this boundary is
-// that $target must ALSO validate as a domain via pfb_filter(PFB_FILTER_DOMAIN)
-// before any command is composed -- semantic validation and shell quoting are
-// two distinct layers (the pattern pfb_unbound_py_ccache_flush_cmds() already
-// follows). A value failing the filter is rejected: logged and returned as
-// array('', '') with no command run -- the same shape as the empty-target
-// guard, so pfb_ss_refresh_lines() keeps the prior baked IPs for a rejected
-// target exactly as it does for a failed resolution. The constant's
-// accept/reject behaviour is pinned by tests/php/PfbFilterContractTest.php.
+// Resolve a SafeSearch CNAME target (e.g. safe.duckduckgo.com) to its current A/AAAA via the
+// configured external DNS server — the baked-fallback IPs in the SafeSearch CSV (issue #149);
+// pfb_unbound.py uses them only when the live CNAME chase fails. Returns array($v4, $v6), each
+// '' when unresolved. PFBL-01: $target is built into an exec() command line (escapeshellarg()
+// handles quoting) and must ALSO validate as a domain via pfb_filter(PFB_FILTER_DOMAIN) first —
+// semantic validation and shell quoting are distinct layers. A rejected value returns array('',
+// '') with no command run (same shape as a failed resolution); pinned by
+// tests/php/PfbFilterContractTest.php.
 function pfb_ss_resolve_target($target) {
 	global $pfb;
 
@@ -6133,18 +5940,12 @@ function pfb_ss_refresh_lines(array $lines, callable $resolver) {
 	return array($out, $changed);
 }
 
-// #740 install/upgrade migration: pfBlockerNG shipped a malformed DoH-block conf entry
-// (local-zone: "yandex.dns" -- not a real hostname, so it never matched real Yandex
-// encrypted-DNS traffic) alongside its paired UI option key 'yandex.dns'. Both are now
-// replaced with the real endpoints under the 'dns.yandex' substring key. An existing
-// install with the dead 'yandex.dns' token still selected in its 'safesearch_doh_list'
-// CSV would silently lose that selection (the token now matches nothing in the
-// corrected conf), so this migrates it in place: replaces the CSV element 'yandex.dns'
-// with 'dns.yandex', preserving element order and de-duplicating against an
-// already-present 'dns.yandex'. $stored is the raw PfbConfig::read('safesearch_doh_list')
-// CSV string. Returns the rewritten CSV to persist, or NULL when there is nothing to
-// migrate (absent/empty/non-string input, or the legacy token is not present as a CSV
-// element).
+// #740 install/upgrade migration: the shipped DoH-block conf's dead 'yandex.dns' local-zone
+// token (never a real hostname) is now 'dns.yandex'; an install with 'yandex.dns' still
+// selected in its 'safesearch_doh_list' CSV would silently lose that selection. Migrates the
+// CSV in place: replaces 'yandex.dns' with 'dns.yandex' (preserving order, de-duplicating
+// against an existing 'dns.yandex'). $stored is the raw CSV string; returns the rewritten CSV,
+// or NULL when nothing to migrate (absent/empty/non-string input, or token not present).
 function pfb_ss_doh_list_yandex_migrate($stored) {
 
 	if (!is_string($stored) || $stored === '') {
@@ -6391,18 +6192,12 @@ function pfb_unbound_python_whitelist($mode='') {
 }
 
 
-// ADR-06: Collect the user DNSBL whitelist as a normalised list of source lines
-// for the Python build manifest (config.user_whitelist). The Python build performs
-// the www-strip / leading-dot->wildcard normalisation itself (pfb_unbound.py
-// _dnsbl_normalise_whitelist), so this hands the RAW suppression lines through.
-//
-// Validation contract (PFBL-01): the suppression textarea is free-form user input
-// and pfbng_text_area_decode() only normalises encoding (no domain validation), yet
-// each line lands in the manifest (config.user_whitelist) and from there in the
-// query-time whiteDB. Each line must validate via pfb_filter(PFB_FILTER_DOMAIN)
-// before it is returned -- the filter accepts the leading-dot wildcard form
-// ('.example.com') as well as plain domains. A line failing the filter is
-// SKIPPED + logged (list iteration), never silently dropped.
+// ADR-06: Collect the user DNSBL whitelist as normalised source lines for the Python build
+// manifest (config.user_whitelist); Python does the www-strip/leading-dot->wildcard
+// normalisation itself, so this hands the RAW suppression lines through. PFBL-01: each line
+// (free-form textarea input) must validate via pfb_filter(PFB_FILTER_DOMAIN) — accepting the
+// leading-dot wildcard form — before it reaches the manifest and query-time whiteDB; a failing
+// line is SKIPPED + logged, never silently dropped.
 function pfb_dnsbl_whitelist_lines() {
 	global $pfb;
 
@@ -6427,25 +6222,14 @@ function pfb_dnsbl_whitelist_lines() {
 	return $out;
 }
 
-// ADR-06 (#51): collect the TEMPORARY per-alert DNSBL unlock store
-// ($pfb['dnsbl_unlock'], a CSV of "domain,type" rows toggled by the alerts
-// Lock/Unlock icon) as a normalised list of domains for the Python build manifest
-// (config.user_unlock). The Python build merges these into whiteDB as band-6 user
-// allows (same shape as config.user_whitelist) so an unlocked domain resolves. This
-// store is deliberately temporary: it lives in /tmp and a full update / Force / Cron
-// deletes it (pfb_update_unbound), so a FULL build emits an EMPTY user_unlock and the
-// rebuilt manifest re-locks every unlock (the "re-locked on Cron/Force" behaviour
-// documented in the alerts icon tooltip). Only pfb_unbound_python_sources_unlock()
-// (the incremental alerts path) feeds the live store into the manifest.
-//
-// Validation contract (PFBL-01): the alerts handler filters the POSTed domain with
-// pfb_filter(PFB_FILTER_DOMAIN) before it enters the store, but the store itself is
-// a plain file under /tmp re-read here later -- so this reader is a boundary of its
-// own and must not trust the file contents (same posture as
-// pfb_unbound_py_ccache_flush_cmds() towards its callers). Each domain read from
-// the store re-validates via pfb_filter(PFB_FILTER_DOMAIN) before it is placed
-// into the manifest (config.user_unlock); a row failing the filter is SKIPPED
-// + logged.
+// ADR-06 (#51): collect the TEMPORARY per-alert DNSBL unlock store ($pfb['dnsbl_unlock'], CSV
+// "domain,type" rows toggled by the alerts Lock/Unlock icon) as domains for the Python build
+// manifest (config.user_unlock), merged into whiteDB as band-6 user allows. Deliberately
+// temporary: lives in /tmp, deleted by a full update/Force/Cron, so a FULL build emits an EMPTY
+// user_unlock and re-locks every unlock (documented in the alerts icon tooltip); only the
+// incremental alerts path feeds the live store into the manifest. PFBL-01: the store is a plain
+// file re-read here, so this reader is its own trust boundary — each domain re-validates via
+// pfb_filter(PFB_FILTER_DOMAIN) before entering the manifest; a failing row is SKIPPED + logged.
 function pfb_dnsbl_unlock_lines() {
 	global $pfb;
 
@@ -6538,21 +6322,12 @@ function pfb_strip_trailing_port($line) {
 }
 
 
-// ADR-22: the non-lite scheme strip, gated on the 'pfb_dnsbl_lenient' toggle.
-//
-// No '://' present  -> return the line unchanged (no scheme to strip).
-//
-// $strict === FALSE (lenient -- today's behaviour, byte-identical): strip everything up to
-// and including the FIRST '://' and return the remainder (paths/query/port handled
-// downstream). strpos() finds the first '://' anywhere, so the permissive cases
-// ('123://evil.com', '://evil.com', mid-token schemes) are accepted exactly as before. The
-// $strict parameter DEFAULTS to FALSE so callers (and the Phase-1 oracle tests) that pass no
-// second argument observe this unchanged behaviour.
-//
-// $strict === TRUE (lenient OFF): validate the text before '://' against the RFC 3986 scheme
-// grammar (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )); an invalid scheme returns FALSE.
-// A single trailing '/' (root path) is normalised away; any remaining '/' is an actual path
-// and returns FALSE. A FALSE return tells the caller to skip + log the line (ADR §2.3/§2.4).
+// ADR-22: the non-lite scheme strip, gated on the 'pfb_dnsbl_lenient' toggle. No '://' ->
+// line unchanged. $strict === FALSE (lenient, today's default/byte-identical): strip through
+// the FIRST '://' (permissive: '123://evil.com', '://evil.com', mid-token schemes all accepted,
+// matching legacy behaviour). $strict === TRUE (lenient OFF): the text before '://' must match
+// the RFC 3986 scheme grammar; a single trailing '/' is normalised away, any other '/' is a
+// real path -> FALSE. FALSE tells the caller to skip + log the line (ADR §2.3/§2.4).
 function pfb_dnsbl_strip_scheme(string $line, bool $strict = FALSE): string|false {
 	$pos = strpos($line, '://');
 	if ($pos === FALSE) {
@@ -6716,7 +6491,7 @@ function pfb_unbound_py_atomic_write($path, $content) {
 // ADR-10 P5: flip the zero-downtime RELOAD SENTINEL (the all-or-nothing commit that
 // wakes the Python reload-watcher). The sentinel host path is /var/unbound/pfb_py_reload
 // (Unbound is chrooted at /var/unbound; the module opens it as the chroot-relative
-// "pfb_py_reload" -- RESULTS/04 SS1). Its content is a monotonically NON-DECREASING
+// "pfb_py_reload"). Its content is a monotonically NON-DECREASING
 // base-10 integer GENERATION on the FIRST LINE. The watcher swaps IFF the freshly-read
 // generation is a STRICT ADVANCE over its last-seen value, so we write current+1 (or 1
 // when the sentinel is absent/empty/non-integer). The write is atomic (stage -> fsync ->
@@ -6782,16 +6557,12 @@ function pfb_unbound_py_wait_marker($path, $target, $timeout_s) {
 }
 
 
-// ADR-10: wait (bounded) for the reload-watcher to APPLY a published generation.
-// After flipping the sentinel to $gen, PHP blocks here until the watcher writes a value
-// >= $gen to the applied marker (/var/unbound/pfb_py_reload.applied), so the data fast
-// path returns only once the new lists are LIVE -- restoring the "lists live on return"
-// invariant the restart had (the ADR-12 post hook + the #51 alert page then observe the
-// new state, not a pending swap). Queries NEVER stop: the old snapshot keeps serving
-// during the wait, so this stays zero-downtime/zero-dropped. Returns TRUE once applied;
-// FALSE on timeout -- the caller then falls back to the restart so the lists still load
-// (fail-safe). The watcher's poll cadence (RELOAD_POLL_INTERVAL ~2s) + the rebuild time
-// bound the latency; the default budget covers a large ABP rebuild.
+// ADR-10: wait (bounded) for the reload-watcher to APPLY a published generation. After
+// flipping the sentinel to $gen, blocks until the watcher writes a value >= $gen to the applied
+// marker (/var/unbound/pfb_py_reload.applied) — restoring the "lists live on return" invariant
+// the restart had. Queries NEVER stop during the wait (zero-downtime/zero-dropped). Returns
+// TRUE once applied; FALSE on timeout, where the caller falls back to the restart (fail-safe).
+// Poll cadence (~2s) + rebuild time bound the latency; the default budget covers a large ABP rebuild.
 function pfb_unbound_py_wait_applied($gen, $timeout_s = 30) {
 	global $pfb;
 
@@ -6872,23 +6643,14 @@ function pfb_unbound_py_atomic_write_root($path, $content) {
 }
 
 
-// PFBL-03: root-only DNSBL-control writer. Validates the command + its argument (the
-// SEMANTIC layer -- a bypass IP through pfb_filter(PFB_FILTER_IP), a duration through
-// pfb_filter(PFB_FILTER_NUM) clamped to 1-3600), assembles a small JSON record carrying a
-// monotonically-advancing SEQUENCE, and atomically publishes it to the local privileged
-// command channel with the root:unbound 0640 permission model (pfb_unbound_py_atomic_write_root).
-// The control-watcher in pfb_unbound.py consumes a record only when its seq advances
-// (exactly-once + replay safety) and re-validates every argument again before any side
-// effect, so this writer and the reader form a dual-validation boundary.
-//
-//   $cmd      one of disable|enable|addbypass|removebypass
-//   $ip       required for addbypass/removebypass (a v4/v6 literal); ignored otherwise
-//   $duration optional seconds (1-3600) for disable/addbypass; ignored otherwise
-//
-// Returns the published sequence (>= 1) on success, or FALSE on an invalid command /
-// invalid argument / lock failure / write failure. No die()/exit().
-// $wait_timeout: seconds to wait for the watcher to apply the command (default 5).
-//   <= 0 = fire-and-forget (skip the wait entirely, return the seq immediately).
+// PFBL-03: root-only DNSBL-control writer. Validates command + argument (bypass IP via
+// PFB_FILTER_IP, duration via PFB_FILTER_NUM clamped 1-3600), assembles a JSON record with a
+// monotonically-advancing SEQUENCE, and atomically publishes to the privileged command channel
+// (root:unbound 0640, pfb_unbound_py_atomic_write_root). pfb_unbound.py's control-watcher
+// consumes a record only when its seq advances and re-validates every argument itself — writer
+// + reader form a dual-validation boundary. $cmd: disable|enable|addbypass|removebypass; $ip
+// required for add/removebypass; $duration optional 1-3600s. Returns the published sequence
+// (>= 1) or FALSE on failure; $wait_timeout <= 0 = fire-and-forget.
 function pfb_unbound_py_write_control($cmd, $ip = '', $duration = '', $wait_timeout = 5) {
 	global $pfb;
 
@@ -6982,16 +6744,13 @@ function pfb_unbound_py_write_control($cmd, $ip = '', $duration = '', $wait_time
 }
 
 
-// ADR-10 P5: PRIMARY RAM gate for the zero-downtime swap (the Python watcher re-checks
-// it as a safety net -- RESULTS/04 SS3). The background rebuild holds the OLD and NEW
-// matcher structures resident at once (~2x transient); on a constrained box that bust
-// would OOM mid-swap (RESULTS/01 SS2: 785.9 MiB both-resident at ABP scale busts a 1 GB
-// box). Mirror the Python projection: 2 * loaded_entries * 276 B + a 64 MiB headroom,
-// measured against hw.usermem (physical RAM the OS can hand out). Returns TRUE when the
-// projected build FITS (zero-downtime allowed); FALSE -> the caller must take the restart
-// fallback so the new lists actually load. Unknown RAM / unknown count -> FALSE
-// (fail-closed: when in doubt, restart -- which never doubles, it frees the old set by
-// dying before rebuilding).
+// ADR-10 P5: PRIMARY RAM gate for the zero-downtime swap (the Python watcher re-checks it as a
+// safety net). The background rebuild holds OLD + NEW matcher structures resident at once
+// (~2x transient); on a constrained box that bust would OOM mid-swap. Mirrors the Python
+// projection: 2 * loaded_entries * 276 B + 64 MiB headroom, measured against hw.usermem.
+// Returns TRUE when the projected build FITS (zero-downtime allowed); FALSE -> the caller
+// takes the restart fallback. Unknown RAM/count -> FALSE (fail-closed: restart never doubles,
+// frees the old set by dying before rebuilding).
 function pfb_unbound_py_swap_fits_ram() {
 	global $pfb;
 
@@ -7043,17 +6802,11 @@ function pfb_sanitise_feed_header(string $header, string $reference = 'pfb_sanit
 }
 
 
-// ADR-31 P3: Build a single per-feed manifest row for $pfb_py_feeds[]. Extracted
-// from the DNSBL download loop so the DNSWL section (Phase 4) can reuse the same
-// structure parameterised by $mode.
-//
-// $mode = 'deny'   → omit the 'mode' key (byte-identical with pre-ADR-31 deny entries;
-//                    Python treats absent as deny — Phase 2 contract).
-// $mode = 'permit' → add 'mode' => 'permit' to the row (Phase 4 DNSWL feeds).
-//
-// No file I/O, no exec, no validation side-effects — pure array construction; the
-// producing loops have already validated $header (PFB_FILTER_WORD) and resolved
-// $format/$provenance before calling here.
+// ADR-31: Build a single per-feed manifest row for $pfb_py_feeds[], parameterised by $mode so
+// DNSWL feeds can reuse the same structure as DNSBL. $mode = 'deny' omits the 'mode' key
+// (byte-identical with pre-ADR-31 entries; Python treats absent as deny); $mode = 'permit' adds
+// 'mode' => 'permit'. No file I/O, no exec, no validation side-effects — pure array
+// construction; callers have already validated $header and resolved $format/$provenance.
 function pfb_feed_manifest_row(string $header, string $group, string $log_flag,
 	string $format, string $provenance, string $mode = 'deny'): array
 {
@@ -7072,43 +6825,14 @@ function pfb_feed_manifest_row(string $header, string $group, string $log_flag,
 }
 
 
-// ADR-06: Build the shell->Python contract. Writes the per-feed manifest
-// ($pfb['unbound_py_sources']) plus a per-feed IP-stripped raw file (one bare,
-// lower-cased domain per line) referenced by the manifest. The Python plugin's
-// init (pfb_unbound.py dnsbl_build_from_manifest) consumes this to build the
-// DNSBL structures from raw -- replacing the previous data/zone CSV load.
-//
-// For 'plain' feeds the per-feed raw is the bare-domain extraction of the already-
-// parsed per-feed '.txt' (col1 of the 6-col CSV produced by the download loop). The
-// download loop already routes embedded IPs to the firewall '*_v4.ip' path and
-// excludes them from '.txt', so the raw handed to Python carries NO bare-IP lines
-// (ADR-06 §3b; Python would ignore stray IPs anyway). PHP has already done all
-// per-format extraction (hosts/CSV/IDN), so Python only revalidates + lower-cases
-// the bare domains -- decision-equivalent.
-//
-// ADR-07 P8: ABP/EasyList feeds are tagged format_hint='abp' (via the row 'format'
-// key, set from $easylist in the download loop). Their '.txt' holds RAW ABP lines
-// (the PHP lite parser is deleted) which are copied to the per-feed raw VERBATIM, so
-// the full DNS-only ABP parser in Python (parse_abp: @@/regex/$important/$badfilter)
-// sees them intact. Non-ABP feeds stay 'plain' exactly as ADR-06 left them.
-//
-// $feeds: array of rows [ 'header' => <feed>, 'group' => <alias>, 'log' => <flag>,
-//         'format' => 'abp'|'plain', 'provenance' => 'user'|'feed' ]. ADR-07: a
-//         Custom_List ({alias}_custom) row is 'user' -> the Python build bands it as a
-//         sovereign user block (5); a downloaded feed is 'feed' -> band 1.
-//
-// Validation contract (PFBL-01): each row's 'header' names the per-feed source
-// '.txt' and staged '.raw' files and becomes the manifest 'feed'/'raw' keys. The
-// producing loops already validate headers with pfb_filter(PFB_FILTER_WORD) (e.g.
-// 'DNSBL - Processes'), but this writer is the choke point for every path derived
-// from a header and RE-validates each one via pfb_sanitise_feed_header() before
-// use -- it must not trust its callers (the posture
-// pfb_unbound_py_ccache_flush_cmds() documents). Note PFB_FILTER_WORD is the
-// correct constant here, NOT PFB_FILTER_DOMAIN: headers are \w-only list labels
-// (no dots), so the DOMAIN filter would reject every legal header. A row whose
-// header fails the filter is SKIPPED + logged, before any file is touched. The
-// constant's accept/reject behaviour is pinned by
-// tests/php/PfbFilterContractTest.php.
+// ADR-06: Build the shell->Python contract: the per-feed manifest ($pfb['unbound_py_sources'])
+// plus a per-feed IP-stripped raw domain file that pfb_unbound.py's dnsbl_build_from_manifest
+// consumes. 'plain' feeds: raw is the bare-domain extraction of the parsed '.txt' (IPs already
+// routed elsewhere). ADR-07: 'abp' feeds copy their RAW '.txt' lines verbatim so Python's
+// parse_abp sees them intact. $feeds rows: header/group/log/format/provenance ('user'
+// Custom_List -> band 5, 'feed' download -> band 1). PFBL-01: RE-validates each header via
+// pfb_sanitise_feed_header() (PFB_FILTER_WORD, not DOMAIN); a failing row is SKIPPED + logged
+// before any file touch; pinned by tests/php/PfbFilterContractTest.php.
 function pfb_unbound_python_sources($feeds) {
 	global $pfb;
 
@@ -7332,16 +7056,12 @@ function pfb_unbound_python_sources_unlock() {
 }
 
 
-// ADR-06 (#51): map a per-alert DNSBL Lock/Unlock action (the dnsbl_remove POST
-// value) to its temporary-unlock STORE operation + status message. Extracted from
-// the pfblockerng_alerts.php handler so the four-way dispatch is unit-testable (every
-// branch covered, not just the unlock/lock paths the smoke matrix observes). The four
-// icon actions collapse onto two pfb_unlock modes: unlock/relock ADD the domain to
-// the store ('unlock'), lock/reunlock REMOVE it ('lock'). An UNKNOWN action returns an
-// empty mode so the handler does NOTHING -- a crafted POST cannot mutate the store
-// (the old inline `else` treated any non-unlock/relock value as a REMOVE). 'msg'
-// carries a single %s for the domain (sprintf in the handler); empty for an unknown
-// action so the redirect shows no status.
+// ADR-06 (#51): map a per-alert DNSBL Lock/Unlock action (dnsbl_remove POST value) to its
+// temporary-unlock STORE operation + status message. The four icon actions collapse onto two
+// pfb_unlock modes: unlock/relock ADD the domain ('unlock'), lock/reunlock REMOVE it ('lock').
+// An UNKNOWN action returns an empty mode so the handler does NOTHING — a crafted POST cannot
+// mutate the store. 'msg' carries a single %s for the domain (sprintf in the handler); empty
+// for an unknown action so the redirect shows no status.
 function pfb_dnsbl_unlock_action($action) {
 	switch ($action) {
 		case 'unlock':
@@ -8058,30 +7778,14 @@ function pfb_unbound_py_mode_active() {
 }
 
 
-// ADR-10 P5: C-cache flip for a zero-downtime swap. Staleness is ONE-DIRECTIONAL
-// (RESULTS/01 SS4b, Context 7): since #43 DNSBL blocks set qstate.no_cache_store=1 so a
-// block reply is NEVER in Unbound's message cache. So:
-//   block->allow (unlock / name removed): IMMEDIATE -- nothing to flush (the swap's
-//     decisionDB.clear() inside the module is all it needs).
-//   allow->block (lock / name added): the previously-RESOLVED real answer is still cached
-//     and serves until its TTL. ONLY this direction needs a flush, and ONLY for names
-//     whose new verdict is "blocked".
-// $names: the newly-blocked names (allow->block delta). For an alerts Lock this is the
-// single known domain (exact, cheap); a feed/cron update's delta is not cheaply
-// computable here, so the caller passes none and we accept TTL-bounded staleness -- NOT a
-// regression (today's restart preserves the resolved cache, so today is stale too).
-// Coalesced into ONE chroot unbound-control session and gated behind the DNSBL-queries
-// daemon's '.sync' suppression marker (touched by pfb_update_unbound / the fast path) so
-// the flush does not collide with the daemon on the control socket.
-// Build the coalesced unbound-control C-cache flush command list for the newly-blocked
-// names. Each name is VALIDATED as a domain via pfb_filter() (issue #153) before it can be
-// interpolated into a command: a non-domain / shell-metachar entry is DROPPED, never
-// reaching the exec() in pfb_unbound_py_ccache_flush() -- defence in depth atop the
-// escapeshellarg() below (the names already arrive PFB_FILTER_DOMAIN-filtered from the
-// alerts page, but this choke point must not trust its input). Returns the full command
-// strings (chroot_cmd-prefixed, each variant escapeshellarg'd), de-duplicated across each
-// name + its 'www.' sibling. Pure (no globals / side effects) so every branch is
-// unit-testable off-appliance (the exec lives in the wrapper below).
+// ADR-10 P5: C-cache flip for a zero-downtime swap. Staleness is ONE-DIRECTIONAL: since #43
+// DNSBL blocks set qstate.no_cache_store=1, a block reply is NEVER cached. block->allow needs
+// NO flush (decisionDB.clear() suffices); allow->block leaves the previously-resolved answer
+// cached until TTL, so ONLY that direction needs a flush, ONLY for newly-blocked names. $names:
+// the allow->block delta (alerts Lock passes one domain; feed/cron pass none, accepting
+// TTL-bounded staleness — no regression, a restart is equally stale). Each name is VALIDATED as
+// a domain (issue #153) before interpolation, dropped otherwise — defence in depth atop
+// escapeshellarg(). Pure; coalesced into ONE chroot session, de-duped per name + 'www.' sibling.
 function pfb_unbound_py_ccache_flush_cmds($names, $chroot_cmd) {
 	$cmds = array();
 	if (!is_array($names) || empty($names)) {
@@ -8126,18 +7830,12 @@ function pfb_unbound_py_ccache_flush($names) {
 }
 
 
-// Reload Resolver
-//
-// ADR-10 P5: $datapath signals a pure DNSBL-DATA update (feed/cron, or a #51 user
-// custom-list Lock/Unlock/whitelist edit) that has already been published atomically to
-// the manifest. When the python integration is the live mode, unbound is running, no
-// config change is pending, and the projected ~2x build fits RAM, such an update takes
-// the ZERO-DOWNTIME fast path: flip the reload sentinel (the module rebuilds + swaps off
-// the query threads) with NO unbound restart. $newly_blocked carries the allow->block
-// delta to flush from the C-cache after the swap (a #51 Lock passes the one locked name;
-// feed/cron pass none -> accepted TTL-bounded staleness). Any other case -- a config
-// change, the feature unavailable, or the RAM gate declining -- falls back to the restart
-// (the fail-safe; PHP is the PRIMARY gate so we never "flip and hope").
+// Reload Resolver. ADR-10 P5: $datapath signals a pure DNSBL-DATA update (feed/cron or a #51
+// custom-list edit) already published atomically to the manifest. When python is live, unbound
+// is running, no config change is pending, and the RAM gate fits, this takes the ZERO-DOWNTIME
+// fast path (flip the reload sentinel, no restart). $newly_blocked carries the allow->block
+// delta to flush from the C-cache after the swap. Any other case falls back to the restart
+// (fail-safe; PHP is the PRIMARY gate — never "flip and hope").
 function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FALSE, $newly_blocked=array()) {
 	global $g, $pfb;
 
@@ -8392,7 +8090,7 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 		// change ($pfbpython TRUE) -> $datapath FALSE -> the restart path. The feed delta
 		// (allow->block names) is not cheaply computable here, so no targeted C-cache
 		// flush is passed -> accepted TTL-bounded staleness (no worse than the restart,
-		// which preserves the resolved cache too -- RESULTS/01 SS4b).
+		// which preserves the resolved cache too).
 		$datapath = !$pfbpython;
 		pfb_reload_unbound($mode, TRUE, $pfbpython, $datapath);
 	}
@@ -8422,7 +8120,7 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 	$log = "\nDNSBL update [ feed lines: {$dnsbl_cnt} | loaded entries: {$loaded_cnt} ]... completed [ NOW ]";
 	pfb_logger("{$log}", 1);
 
-	// ADR-48 Phase 4 (issue #789): emit stage=entries reject lines for any feed
+	// ADR-48 (issue #789): emit stage=entries reject lines for any feed
 	// with a nonzero per-entry tally, BEFORE clearing work files.
 	pfb_emit_entry_reject_stats($pfb['unbound_py_reject_stats']);
 
@@ -8718,17 +8416,12 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 }
 
 
-// IPv6 sibling of sanitize_ipaddr(): exclude private/reserved/loopback IPv6
-// addresses from loaded block lists when Suppression is enabled. A downloaded
-// feed's explicit /0 is clamped to a single host (issue #744); otherwise the
-// entry is returned unchanged when kept, nothing (dropped) when excluded.
-// Also drops documentation (RFC 3849), multicast and the NAT64 well-known
-// prefix (RFC 6052), which the PHP filter flags leave routable (issue #760).
-// These are explicit prefix checks rather than another filter flag, so the
-// behaviour is independent of PHP's patch level (the RFC 6890 refactor in
-// PHP 8.3.16/8.4.3 moved 2001:db8::/32 between filter sets). $pfbcidr is the
-// per-category Advanced "Suppression CIDR Limit" floor (issue #760 §3), the
-// v6 sibling of sanitize_ipaddr()'s $pfbcidr.
+// IPv6 sibling of sanitize_ipaddr(): excludes private/reserved/loopback IPv6 from loaded block
+// lists when Suppression is enabled; a feed's explicit /0 clamps to a single host (issue #744).
+// Also drops documentation (RFC 3849), multicast, and the NAT64 prefix (RFC 6052), which PHP's
+// filter flags leave routable (issue #760) — explicit prefix checks so behaviour is independent
+// of PHP's patch level (RFC 6890 moved 2001:db8::/32 between filter sets in 8.3.16/8.4.3).
+// $pfbcidr: per-category Advanced "Suppression CIDR Limit" floor (issue #760 §3).
 function sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr = 'Disabled') {
 	global $pfb;
 
@@ -8866,7 +8559,7 @@ function find_reported_header($ip, $pfbfolder, $geoip=FALSE) {
 			exec("{$pfb['grep']} -s {$query_esc} {$pfb['ccdir']}/*.txt /dev/null | {$pfb['grep']} -v '{$geoip_list}' 2>&1", $result);
 		}
 
-		// issue #809 Phase 3b: the CIDR-selection loop (collect CIDR-shaped candidates
+		// issue #809: the CIDR-selection loop (collect CIDR-shaped candidates
 		// from $result, then walk them doing the v4 mask math / v6 gen_subnetv6 +
 		// Net_IPv6::isInNetmask() match) is extracted to pfb_match_reported_cidr() so the
 		// batched pfb_find_reported_headers() sibling below can reuse the EXACT same logic
@@ -8885,8 +8578,8 @@ function find_reported_header($ip, $pfbfolder, $geoip=FALSE) {
 }
 
 
-// Shared CIDR-selection core of find_reported_header()'s prefix-match branch (issue #809
-// Phase 3b): given the RAW grep output lines already collected for a first-octet (v4) or
+// Shared CIDR-selection core of find_reported_header()'s prefix-match branch (issue #809):
+// given the RAW grep output lines already collected for a first-octet (v4) or
 // prefix (v6) query, parse out every CIDR-shaped candidate and return the first one
 // containing $ip, or NULL if none does. find_reported_header() calls this on its own
 // single-host $result array (behaviour unchanged); the batched pfb_find_reported_headers()
@@ -8937,28 +8630,16 @@ function pfb_match_reported_cidr(array $result, string $ip, bool $v4_type): ?arr
 }
 
 
-// issue #809 Phase 3b: the exact per-row query derivation convert_ip_log()
-// (pfblockerng_alerts.php) needs before it can validate/re-locate a reported IP --
-// extracted VERBATIM (same order, same values) so the batched prefetch pass below
-// (pfb_ip_prefetch()) can derive the IDENTICAL lookup groups from a copy of the same
-// $fields, with no separate re-derivation to drift from convert_ip_log()'s own logic.
-// $fields must already be in convert_ip_log()'s POST-REORDER shape (called AFTER that
-// function's own `$fields[99] = array_shift($fields);` line) -- the reorder itself is not
-// part of what this derivation consumes, so it stays in the caller, unchanged.
+// issue #809: the exact per-row query derivation convert_ip_log() (pfblockerng_alerts.php)
+// needs before validating/re-locating a reported IP — extracted VERBATIM so the batched
+// prefetch pass (pfb_ip_prefetch()) derives IDENTICAL lookup groups from the same $fields.
+// $fields must already be in convert_ip_log()'s POST-REORDER shape (called AFTER
+// `$fields[99] = array_shift($fields);`).
 //
-// Returns:
-//   host              - the reported IP/CIDR host (SRC on inbound, DST on outbound)
-//   hostname          - array('src'=>.., 'dst'=>..), RAW (not yet htmlencoded)
-//   pfb_geoip         - TRUE iff the row's alias name is a GeoIP continent alias
-//   field15           - $fields[15], with any Proofpoint IQRisk 'Category:Feed' prefix
-//                        stripped (render-visible -- the caller must write this back)
-//   folder            - the feed-dir glob this row's IP is checked against
-//   validate_file_cmd - the "find <folder> -type f <prefix> <query> <query_host>" pipe
-//                        (no ip pattern yet) that GROUPS rows for the batched validate
-//                        round below, or NULL when this row never runs a validate exec at
-//                        all (mirrors the guard on validate_cmd)
-//   validate_cmd      - the exact validate command convert_ip_log() execs (and memoizes,
-//                        keyed by this string), or NULL under the same guard
+// Returns: host (reported IP/CIDR); hostname (array('src','dst'), RAW); pfb_geoip (TRUE iff a
+// GeoIP continent alias); field15 (Proofpoint IQRisk prefix stripped, render-visible — caller
+// writes back); folder (feed-dir glob); validate_file_cmd/validate_cmd (row-grouping find pipe
+// / exact memoized validate command, each NULL when this row never validates).
 function pfb_ip_render_query(array $fields): array {
 	global $pfb, $continents;
 
@@ -9048,14 +8729,13 @@ function pfb_ip_render_query(array $fields): array {
 }
 
 
-// issue #809 Phase 3b: promotes convert_ip_log()'s two Phase-1 function-static memo stores
-// ($validate_memo / $ip_miss_memo, pfblockerng_alerts.php) to a reference-returning
-// accessor so the batched prefetch pass below (pfb_ip_prefetch()) can seed them from
-// OUTSIDE convert_ip_log(). Same one-page-load lifetime as before (a static local, just
-// declared here instead of inside convert_ip_log()). No reset is needed between the three
-// per-type IP tables rendered on one page load: every key is content-derived (the exact
-// validate command string, or "$host|$folder") and therefore stable regardless of which
-// table populated it first -- the same reasoning as the original Phase 1 memos.
+// issue #809: promotes convert_ip_log()'s two function-static memo stores ($validate_memo /
+// $ip_miss_memo, pfblockerng_alerts.php) to a reference-returning accessor so the batched
+// prefetch pass below (pfb_ip_prefetch()) can seed them from OUTSIDE convert_ip_log(). Same
+// one-page-load lifetime as before (a static local, just declared here). No reset is needed
+// between the three per-type IP tables rendered on one page load: every key is content-derived
+// (the exact validate command string, or "$host|$folder") and therefore stable regardless of
+// which table populated it first.
 function &pfb_ip_render_memos(): array {
 	static $memos = array('validate' => array(), 'miss' => array());
 	return $memos;
@@ -9089,17 +8769,13 @@ function pfb_prefetch_pattern_file_write_ok($written, string $data): bool {
 }
 
 
-// Run ONE batched `grep -f <patternfile>` pass (issue #809 Phase 3b), sharing the pattern-
-// file plumbing across every IP-table batched round (validate / miss-header / aliastables)
-// below. Returns every matched line (not a first-match map, unlike pfb_dnsbl_prefetch_grep())
-// since callers here attribute possibly-many lines per candidate themselves (see
-// pfb_ip_prefetch_last_match()). The pattern-file path is inserted between $cmd_prefix and
-// $cmd_suffix verbatim (no sprintf/format-string parsing of caller-supplied paths).
-//
-// B3/R1 (issue #809 review): returns NULL -- distinct from a genuine empty-array no-match
-// result -- when the pattern file itself could not be created or fully written (a full or
-// read-only temp dir). Every caller must treat NULL as "this batched pass did not run" and
-// leave the rows it would have covered UNSEEDED, never seed a false negative from it.
+// Run ONE batched `grep -f <patternfile>` pass, sharing the pattern-file plumbing across every
+// IP-table batched round (validate / miss-header / aliastables) below. Returns every matched
+// line (not a first-match map, unlike pfb_dnsbl_prefetch_grep()) since callers attribute
+// possibly-many lines per candidate themselves. The pattern-file path is inserted between
+// $cmd_prefix and $cmd_suffix verbatim (no sprintf/format-string parsing). Returns NULL —
+// distinct from a genuine empty-array no-match — when the pattern file could not be created or
+// fully written; every caller must treat NULL as "did not run" and leave rows UNSEEDED.
 function pfb_ip_prefetch_grep_lines(string $cmd_prefix, string $cmd_suffix, array $patterns): ?array {
 
 	$lines = array();
@@ -9129,30 +8805,14 @@ function pfb_ip_prefetch_grep_lines(string $cmd_prefix, string $cmd_suffix, arra
 }
 
 
-// Attribute the LAST line in $lines (grep's original file/line order is preserved
-// regardless of pattern order) that "belongs" to $raw_prefix -- reproducing the "last line
-// of output" semantics a per-row single-pattern exec() call gives (PHP's exec() without an
-// $output array returns only the last stdout line), from a batched multi-pattern grep pass
-// whose output interleaves every candidate's matches together (issue #809 Phase 3b).
-//
-// A line belongs to $raw_prefix under either shape grep can emit:
-//   - unprefixed (the `find` pipeline matched exactly one file): the line IS the file
-//     content, so a direct prefix match applies;
-//   - file-prefixed (more than one file matched): grep emits "path:content", where the
-//     path is one of THIS module's own absolute glob results -- always containing '/' --
-//     so the substring after the FIRST ':' is unambiguously the content, and that is what
-//     must carry the prefix.
-// This deliberately preserves grep's own prefix-match quirk (an anchored `^1\.2\.3\.4`
-// pattern also matches content beginning `1.2.3.45`) -- the per-row exec has the identical
-// quirk, so reproducing it (rather than an exact-match) is what keeps this behaviour-
-// identical to the code it replaces.
-//
-// N1 (issue #809 review): the colon-fallback used to apply on ANY ':' in the line, which
-// misattributed an UNPREFIXED IPv6 content line (its OWN ':' is part of the address, not a
-// path separator) whenever the tail after that first ':' happened to equal $raw_prefix.
-// Guarded now by requiring the segment BEFORE that ':' to look like a path (contain '/') --
-// true of every real "path:content" line this module ever greps, and never true of a bare
-// IPv6 literal.
+// Attribute the LAST line in $lines (grep's original order is preserved regardless of pattern
+// order) that "belongs" to $raw_prefix — reproducing per-row exec()'s "last stdout line"
+// semantics from a batched multi-pattern grep pass whose output interleaves every candidate's
+// matches. A line belongs under either grep shape: unprefixed (single file matched, line IS
+// the content) or file-prefixed ("path:content", path always contains '/', so the substring
+// after the FIRST ':' is the content) — preserving grep's own prefix-match quirk (`^1.2.3.4`
+// also matches `1.2.3.45`) for behaviour-identity with the exec it replaces. The colon-fallback
+// requires the segment BEFORE ':' to contain '/', else an unprefixed IPv6 line could misattribute.
 function pfb_ip_prefetch_last_match(array $lines, string $raw_prefix): ?string {
 
 	$match = NULL;
@@ -9172,26 +8832,15 @@ function pfb_ip_prefetch_last_match(array $lines, string $raw_prefix): ?string {
 }
 
 
-// Batched sibling of find_reported_header() (issue #809 Phase 3b): resolves every host in
-// $hosts against the SAME $pfbfolder/$geoip via one exact-match Round-A pass over ALL
-// hosts, followed -- for any host Round A missed -- by Round B: one grep per DISTINCT
-// first-octet (v4) / prefix (v6) group among the still-missing hosts (issue #809 review,
-// R3: best case one shared pass when every miss shares a prefix, worst case one PER HOST
-// under fully-diverse prefixes -- corrects an earlier "at most two batched grep passes"
-// docblock, which did not account for Round B's per-group multiplicity). At most two
-// batched exec()s touch any ONE host (its Round-A pass, and -- if missed -- its own
-// Round-B group's pass), replacing one-to-two exec() calls run independently per host.
-// Returns a map host => $pfb_query (['Unknown','Unknown'] on a total miss, matching
-// find_reported_header()'s own return shape).
-//
-// B3 (issue #809 review): Round A's batched pattern-file grep
-// (pfb_ip_prefetch_grep_lines()) can fail (its pattern file could not be created/written)
-// -- a NULL sentinel distinct from a genuine zero-hit round. On that failure this function
-// does NOT run Round B for any host in $hosts (a failed batching layer means "could not
-// resolve", never "resolved to nothing") and reports every host via the $grep_failed
-// out-parameter (keyed by host, value TRUE) so the caller (pfb_ip_prefetch()) can leave
-// them entirely UNSEEDED rather than caching this function's placeholder Unknown/Unknown
-// as a false negative.
+// Batched sibling of find_reported_header(): resolves every host in $hosts against the SAME
+// $pfbfolder/$geoip via one exact-match Round-A pass over ALL hosts, then Round B for any
+// Round-A miss: one grep per DISTINCT first-octet (v4) / prefix (v6) group among the
+// still-missing hosts (worst case one PER HOST under fully-diverse prefixes). At most two
+// batched exec()s touch any ONE host, replacing one-to-two exec() calls run independently per
+// host. Returns host => $pfb_query (['Unknown','Unknown'] on a total miss). Round A's batched
+// grep can fail with a NULL sentinel (pattern file unwritable, distinct from a genuine
+// zero-hit round); on that failure Round B does NOT run, and every host is reported via
+// $grep_failed so the caller leaves them UNSEEDED rather than caching a false Unknown/Unknown.
 function pfb_find_reported_headers(array $hosts, $pfbfolder, $geoip = FALSE, ?array &$grep_failed = NULL): array {
 	global $pfb;
 
@@ -9293,20 +8942,14 @@ function pfb_find_reported_headers(array $hosts, $pfbfolder, $geoip = FALSE, ?ar
 }
 
 
-// Batch every buffered, filter-ACCEPTED row's render-time IP lookups ahead of the per-type
-// IP table's replay pass (issue #809 Phase 3b): the validate round (is the logged IP/CIDR
-// still in its logged feed file), the miss round (find_reported_header()'s exact + prefix/
-// CIDR search), and the aliastables round (which alias table now holds the resolved IP),
-// each collapsed from one exec() per row to at most one grep pass per distinct group.
-// Seeds pfb_ip_render_memos() -- convert_ip_log() (pfblockerng_alerts.php) transparently
-// consults the same memo stores via pfb_render_memo(), falling back to its own per-row exec
-// for anything this pass did not cover (an unseeded key, or when this function was never
-// called at all -- e.g. the Unified table, out of scope for this phase).
-//
-// $rows is one entry per buffered, filter-accepted row (pfblockerng_alerts.php's Pass 1.5)
-// -- keys: 'host', 'folder', 'eval_ip_raw' (the raw $fields[14] evaluated-IP literal), and
-// 'validate_file_cmd'/'validate_cmd' from pfb_ip_render_query() (both NULL when that row
-// never runs a validate exec at all).
+// Batch every buffered, filter-ACCEPTED row's render-time IP lookups ahead of the per-type IP
+// table's replay pass: the validate round (is the logged IP/CIDR still in its feed file), the
+// miss round (find_reported_header()'s exact + prefix/CIDR search), and the aliastables round
+// (which alias table now holds the resolved IP), each collapsed from one exec() per row to at
+// most one grep pass per distinct group. Seeds pfb_ip_render_memos() — convert_ip_log()
+// consults the same memo stores, falling back to its own per-row exec for anything unseeded.
+// $rows: one entry per buffered, filter-accepted row — 'host', 'folder', 'eval_ip_raw',
+// 'validate_file_cmd'/'validate_cmd' from pfb_ip_render_query() (both NULL when unused).
 function pfb_ip_prefetch(array $rows): void {
 	global $pfb;
 
@@ -9656,15 +9299,12 @@ function pfb_dnsbl_python_migrate($dconfig) {
 
 
 // PFBL-03: one-time upgrade seed for the deprecated legacy DNS-TXT control sub-toggle.
-// $dconfig is the existing DNSBL-settings 'config/0' node. DNSBL control is CLI-driven and
-// the DNS-TXT transport is OFF by default; to avoid breaking an operator already driving
-// control over DNS TXT, the legacy sub-toggle is seeded ON IFF the pre-existing config
-// already had DNSBL Control enabled ('pfb_control' == 'on') at this upgrade. A one-shot
-// marker ('pfb_control_legacy_seeded') makes this run EXACTLY ONCE: once set, the function
-// returns NULL (no change), so a later save never re-seeds and never re-enables a toggle
-// the operator deliberately turned back off. Returns the updated config array to persist,
-// or NULL when nothing should change (empty config, or the seed already ran). Slated for
-// removal next release with the rest of the legacy DNS-TXT path.
+// $dconfig is the DNSBL-settings 'config/0' node; DNS-TXT transport is OFF by default, so to
+// avoid breaking an operator already driving control over DNS TXT, the legacy sub-toggle is
+// seeded ON IFF the pre-existing config already had 'pfb_control' == 'on'. A one-shot marker
+// ('pfb_control_legacy_seeded') makes this run EXACTLY ONCE, so a later save never re-enables
+// a toggle the operator turned back off. Returns the updated config, or NULL when nothing
+// changes (empty config, or already seeded). Slated for removal with the legacy DNS-TXT path.
 function pfb_control_legacy_seed($dconfig) {
 
 	if (!is_array($dconfig) || empty($dconfig)) {
@@ -9681,16 +9321,12 @@ function pfb_control_legacy_seed($dconfig) {
 }
 
 
-// ADR-22: one-time upgrade migration for the 'pfb_dnsbl_lenient' DNSBL scheme-parsing
-// toggle. $dconfig is the existing DNSBL-settings 'config/0' node. New installs default to
-// OFF (strict RFC 3986 parsing); an EXISTING install (a non-empty config section) that
-// predates this key is migrated to 'on' (lenient) to preserve the permissive behaviour it
-// already relies on -- malformed-scheme lines were silently accepted/blocked before. Keying
-// on a non-empty $dconfig distinguishes an upgrade from a first-ever install (which has no
-// prior config section, so the new-install strict default stands). Migration ONLY sets a
-// missing key -- an existing 'on'/'off' value is never overwritten. Returns the updated
-// config array to persist, or NULL when nothing should change (fresh install, or the key
-// already present).
+// ADR-22: one-time upgrade migration for the 'pfb_dnsbl_lenient' DNSBL scheme-parsing toggle.
+// New installs default to OFF (strict RFC 3986 parsing); an EXISTING install (non-empty
+// $dconfig, distinguishing upgrade from first-ever install) that predates this key is migrated
+// to 'on' (lenient) to preserve the permissive behaviour it already relies on. Migration ONLY
+// sets a missing key — an existing 'on'/'off' value is never overwritten. Returns the updated
+// config, or NULL when nothing should change (fresh install, or the key already present).
 function pfb_dnsbl_lenient_migrate($dconfig) {
 
 	if (!is_array($dconfig) || empty($dconfig)) {
@@ -9751,18 +9387,14 @@ function pfb_ip_is_self($ip) {
 }
 
 
-// Verify a feed host does not resolve to a non-public/reserved address before any
-// connection is made. Fail-closed: an unresolvable host, or any resolved address
-// that is non-public AND not covered by the operator's internal-address allowlist,
-// is rejected. On success $pinned receives the vetted IP the caller pins the
-// connection to (so the fetch cannot rebind to another address); $reason carries a
-// neutral skip reason on rejection.
-//
-// A resolved address is permitted when it is public, when it is the firewall itself
-// (its own configured address / loopback — a self-hosted feed), or when it is covered
-// by an allowlist entry (exact IP, or containment in an allowlisted CIDR — General
-// settings: 'internal-address exemptions'). An empty allowlist (the default) blocks
-// every other feed that resolves to an internal/private address.
+// Verify a feed host does not resolve to a non-public/reserved address before any connection
+// is made. Fail-closed: an unresolvable host, or any resolved address that is non-public AND
+// not covered by the operator's internal-address allowlist, is rejected. On success $pinned
+// receives the vetted IP the caller pins the connection to (so the fetch cannot rebind to
+// another address); $reason carries a neutral skip reason on rejection. A resolved address is
+// permitted when public, self-hosted (firewall's own address/loopback), or allowlisted (exact
+// IP or CIDR containment, General settings 'internal-address exemptions'); an empty allowlist
+// (default) blocks every other internal/private-resolving feed.
 function pfb_feed_host_allowed($host, &$reason, &$pinned) {
 
 	$reason = '';
@@ -10021,16 +9653,12 @@ function pfb_rsync_pin_url($list_url, $ip) {
 }
 
 
-// Issue #890: redact the query string and userinfo ('user:pass@') from a feed/
-// download URL before it is written to any log -- either can carry a credential,
-// and log files (including extras.log) ship inside pfSense support bundles.
-// scheme/host/port/path are kept so the log line stays useful for diagnosing a
-// failed download. A well-formed http(s)/ftp/rsync:// URL is rebuilt from
-// parse_url() (userinfo is simply dropped by not carrying it over; the query,
-// when present, is replaced with a '[redacted]' marker). Anything parse_url()
-// can't make sense of as a URL (a malformed input, or pfBlockerNG's own
-// '[user@]host::module' rsync shorthand) falls back to a regex strip -- when in
-// doubt this over-redacts rather than risk leaking a secret.
+// Issue #890: redact the query string and userinfo ('user:pass@') from a feed/download URL
+// before it is written to any log — either can carry a credential, and log files ship inside
+// pfSense support bundles. scheme/host/port/path are kept for diagnosability. A well-formed
+// http(s)/ftp/rsync:// URL is rebuilt from parse_url() (userinfo dropped, query replaced with
+// '[redacted]'); anything parse_url() can't parse (malformed input, or the '[user@]host::module'
+// rsync shorthand) falls back to a regex strip — when in doubt this over-redacts.
 function pfb_redact_url($url) {
 	if (!is_string($url) || $url === '') {
 		return (string) $url;
@@ -10078,19 +9706,14 @@ function pfb_redact_url($url) {
 }
 
 
-// ADR-59 Phase 3: merge caller-supplied HTTP headers with the ADR-42 conditional-GET
-// header into one CURLOPT_HTTPHEADER list -- neither clobbers the other. Pure / no I/O,
-// so it is unit-testable off-appliance (pfb_download() itself is not: tests/php/README.md
-// "Out of scope" -- its curl/exec surface has no off-box double).
+// ADR-59: merge caller-supplied HTTP headers with the ADR-42 conditional-GET header into one
+// CURLOPT_HTTPHEADER list — neither clobbers the other. Pure/no I/O (pfb_download() itself
+// isn't: tests/php/README.md "Out of scope").
 //
-// $extra_headers: caller-supplied header strings (e.g. 'Authorization: Bearer <token>').
-//   A non-string or empty entry is dropped defensively rather than corrupting the list.
-// $conditional_header: the ADR-42 conditional-GET header ('If-None-Match: <etag>'), or
-//   '' when no conditional-GET validator applies (the common case for every feed today).
-//
-// @return string[] the merged list, conditional-GET header first -- preserves the
-//   pre-Phase-3 single-element list byte-for-byte when $extra_headers is empty (today,
-//   always -- no caller sets it yet).
+// $extra_headers: caller-supplied header strings; a non-string/empty entry is dropped.
+// $conditional_header: the ADR-42 conditional-GET header, or '' when none applies.
+// @return string[] merged list, conditional-GET header first; byte-identical to the prior
+//   single-element list when $extra_headers is empty (today, always).
 function pfb_download_http_headers(array $extra_headers, string $conditional_header = ''): array
 {
 	$headers = array();
@@ -10106,19 +9729,13 @@ function pfb_download_http_headers(array $extra_headers, string $conditional_hea
 }
 
 
-// Function to download feeds
-//
-// Optional $response_meta — when a non-NULL reference is passed (detector probe mode), it is
-// filled with an array: ['status' => <http_status_string>, 'etag' => <ETag string or ''>,
-// 'lastmod' => <epoch int or 0>]. The two sync callers in pfblockerng.inc (lines ~12436 and
-// ~14096) do NOT pass this argument, so their behaviour is entirely unchanged.
-//
-// Optional $extra_headers (ADR-59 Phase 3) — caller-supplied HTTP header strings (e.g. a
-// Cloudflare Radar 'Authorization: Bearer <token>'), merged with the conditional-GET
-// header via pfb_download_http_headers() above. The TOP1M provider (ADR-59 P5) is the
-// first caller: pfblockerng.php passes the active provider's pfb_top1m_auth_headers()
-// result here; every other feed still passes none, so its CURLOPT_HTTPHEADER behaviour
-// is unchanged.
+// Function to download feeds. Optional $response_meta — when a non-NULL reference is passed
+// (detector probe mode), filled with ['status' => <http_status_string>, 'etag' => <ETag or
+// ''>, 'lastmod' => <epoch or 0>]; the two sync callers in this file do NOT pass it, so their
+// behaviour is unchanged. Optional $extra_headers (ADR-59) — caller-supplied HTTP header
+// strings (e.g. a Cloudflare Radar 'Authorization: Bearer <token>'), merged with the
+// conditional-GET header via pfb_download_http_headers(). The TOP1M provider is the first
+// caller; every other feed still passes none, so its CURLOPT_HTTPHEADER behaviour is unchanged.
 function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $logtype, $vtype='', $timeout=300, $type='', $username='', $password='', $srcint=FALSE, &$response_meta=NULL, array $extra_headers=array()) {
 	global $pfb;
 	$http_status = '';
@@ -10305,7 +9922,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				curl_setopt($ch, CURLOPT_MAXREDIRS, $feed_filter ? 0 : PFB_DOWNLOAD_MAXREDIRS);
 
 				// Capture the response 'Location' header for the manual redirect
-				// follow and the 'ETag' header for ADR-42 Phase 3 conditional-GET.
+				// follow and the 'ETag' header for ADR-42 conditional-GET.
 				// Reset per hop ($redirect_location is cleared before each curl_exec).
 				// Bodies are written to $fhandle; a redirect hop's body is truncated
 				// away before the next hop so only the final 2xx body survives.
@@ -10323,7 +9940,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					}
 				);
 
-				// ADR-42 Phase 3: send a conditional GET when stored validators are
+				// ADR-42: send a conditional GET when stored validators are
 				// available for this feed's .orig baseline.  ETag → If-None-Match
 				// (primary); Last-Modified epoch → CURLOPT_TIMECONDITION (fallback).
 				// Only applied to the probe ('change_detect') mode: the sync ingest callers
@@ -10343,11 +9960,11 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					}
 				}
 
-				// ADR-59 Phase 3: merge caller-supplied headers (ADR-59 P5's TOP1M provider
-				// auth header is the first caller) with the conditional-GET header above --
-				// neither list clobbers the other. Skips the curl_setopt entirely when both
-				// are empty (every other feed, plus an in-flight change_detect probe with no
-				// stored ETag), matching the pre-Phase-3 behaviour byte-for-byte.
+				// ADR-59: merge caller-supplied headers (the TOP1M provider auth header is
+				// the first caller) with the conditional-GET header above -- neither list
+				// clobbers the other. Skips the curl_setopt entirely when both are empty
+				// (every other feed, plus an in-flight change_detect probe with no stored
+				// ETag), matching prior behaviour byte-for-byte.
 				$http_headers = pfb_download_http_headers($extra_headers, $conditional_header);
 				if (!empty($http_headers)) {
 					curl_setopt($ch, CURLOPT_HTTPHEADER, $http_headers);
@@ -10510,7 +10127,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 	}
 
 	// Probe mode for the cron detector (type='change_detect'): fill $response_meta when
-	// the caller requested it (ADR-42 Phase 3 conditional-GET path), then return.
+	// the caller requested it (ADR-42 conditional-GET path), then return.
 	// A 304 means "not modified" — the server confirmed the feed unchanged; the
 	// caller (pfb_update_check detector) handles the 304 via pfb_conditional_get_decision.
 	// Any 200 means the body was downloaded to {file_dwn}.raw; the caller hashes it.
@@ -10830,7 +10447,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				@touch("{$orig_download}", $remote_stamp);
 			}
 
-			// ADR-42 Phase 2 / issue #713 bug 5: refresh the content-hash sidecar at every
+			// ADR-42 / issue #713 bug 5: refresh the content-hash sidecar at every
 			// successful ingest so pfb_local_feed_changed() / the probe's conditional-GET
 			// compare always land on the SAME domain of bytes the probe hashed.  The probe
 			// (pfb_update_check -> pfb_download($type='change_detect')) hashes the RAW
@@ -11094,21 +10711,14 @@ function pfb_tracker($alias, $int, $text) {
 }
 
 
-// Deterministic, IP-independent firewall-rule tracker for pfBlockerNG MANAGED
-// STATIC rules (ADR-37 DoT/DoQ block). Modelled on pfb_tracker() (feed rules) but
-// keyed on the rule's stable 'descr' ALONE -- no interface IP/subnet -- so the id
-// is identical across re-syncs and survives a DHCP renewal. That stability is the
-// point: a fresh-each-sync tracker (e.g. the GUI's (int)microtime()) would make the
-// rule's change-detection always fire, churning write_config()/filter_configure()
-// every sync. (ADR-36 NAT redirect rules need NO tracker -- pfSense NAT rules don't
-// carry one, and 'associated-rule-id=pass' has no companion filter rule to link.)
-//
-// Namespaced '176' to mark it as a pfBlockerNG MANAGED-rule tracker, distinct from
-// feed trackers ('177'). 176xxxxxxx is a PAST Unix epoch (~Oct 2025), so it can
-// never collide with a future GUI rule's (int)microtime() tracker, and it stays
-// well under 2^32 so pf's uint32 'ridentifier' never overflows. Duplicates (same
-// char-sum) step to a sequential id in the same namespace, registered like
-// pfb_tracker() so a managed tracker never clashes with a feed tracker in one sync.
+// Deterministic, IP-independent firewall-rule tracker for pfBlockerNG MANAGED STATIC rules
+// (ADR-37 DoT/DoQ block). Modelled on pfb_tracker() (feed rules) but keyed on the rule's
+// stable 'descr' ALONE — no interface IP/subnet — so the id is identical across re-syncs and
+// survives a DHCP renewal; a fresh-each-sync tracker would churn write_config()/
+// filter_configure() every sync. (ADR-36 NAT redirect rules need no tracker.) Namespaced '176'
+// (distinct from feed trackers '177'); 176xxxxxxx is a PAST Unix epoch (~Oct 2025) so it can
+// never collide with a future GUI rule's microtime() tracker, staying under pf's uint32
+// ridentifier ceiling. Duplicates step to a sequential id in the same namespace.
 function pfb_managed_rule_tracker(string $descr): int {
 	global $pfb;
 
@@ -11508,16 +11118,13 @@ function pfb_aliastables($mode) {
 }
 
 
-// #468: DNSBL python-integration cache for RAM-disk /var (use_mfs_tmpvar) installs.
-// SEPARATE from pfb_aliastables() on purpose -- the IP-alias archive and the DNSBL
-// archive have different lifecycles (DNSBL changes vs IP-rule changes). All file ops
-// live in 'pfblockerng.sh dnsbl_cache' (the shipped-file list has one home, in shell).
-//
-//   'conf' -- register the boot 'dnsbl_cache restore' earlyshellcmd when DNSBL is
-//             enabled AND /var is a RAM disk; otherwise remove it and delete the
-//             archive (DNSBL off or MFS off -> nothing to restore).
-//   'save' -- archive the current generated DNSBL state (called post-reload on a real
-//             DNSBL change; the caller gates on use_mfs_tmpvar + DNSBL enabled).
+// #468: DNSBL python-integration cache for RAM-disk /var (use_mfs_tmpvar) installs. SEPARATE
+// from pfb_aliastables() on purpose — the IP-alias archive and the DNSBL archive have different
+// lifecycles. All file ops live in 'pfblockerng.sh dnsbl_cache' (one home, in shell). 'conf':
+// register the boot 'dnsbl_cache restore' earlyshellcmd when DNSBL is enabled AND /var is a RAM
+// disk; otherwise remove it and delete the archive. 'save': archive the current generated DNSBL
+// state (called post-reload on a real DNSBL change; the caller gates on use_mfs_tmpvar + DNSBL
+// enabled).
 function pfb_dnsbl_cache($mode) {
 	global $pfb;
 
@@ -12235,19 +11842,16 @@ function pfb_collect_localhosts() {
 }
 
 
-// Resolve a filter.log Tracker ID to a pfBlockerNG rule.
+// Resolve a filter.log Tracker ID to a pfBlockerNG rule. Returns TRUE when $tracker is a pfB
+// rule whose type matches $type (caller processes the line); FALSE for a known non-pfB
+// ('other') or an unresolvable tracker (caller skips).
 //
-// Returns TRUE when $tracker is a pfB rule whose type matches $type (caller processes
-// the line); FALSE for a known non-pfB ('other') or an unresolvable tracker (caller skips).
-//
-// $rule_list  : positive cache from pfb_filterrules(); rebuilt in place on a reparse.
-// $miss_cache : PERSISTENT negative cache keyed by "tracker\0type"; survives reparses (a
-//               reparse rebuilds $rule_list but not this), so each unresolvable tracker/type
-//               triggers at most ONE reparse for the daemon's life. Keying by type (and
-//               checking the positive pfB cache first) ensures a transient type mismatch
-//               never suppresses a later log event whose type DOES match the pfB rule.
-// $reparse    : callable() => array — fresh rule list (production: 'pfb_filterrules').
-// $on_reparse : callable() => void  — refresh daemon-local IP/host collections after a reparse.
+// $rule_list: positive cache from pfb_filterrules(); rebuilt in place on a reparse.
+// $miss_cache: PERSISTENT negative cache keyed by "tracker\0type"; survives reparses, so each
+//   unresolvable tracker/type triggers at most ONE reparse for the daemon's life (keyed by
+//   type + checking the positive cache first, so a transient type mismatch never suppresses a
+//   later match). $reparse: callable() => array, fresh rule list. $on_reparse: callable() =>
+//   void, refresh daemon-local IP/host collections after a reparse.
 function pfb_resolve_tracker(
 	array &$rule_list,
 	array &$miss_cache,
@@ -12396,23 +12000,14 @@ function pfb_hash_read($base) {
 	return $sentinel;
 }
 
-// ADR-42 / issue #713 bug 5: resolve which on-disk file holds the RAW fetched body, so
-// the source-hash sidecar pfb_download() persists at ingest time hashes the SAME bytes
-// as the probe (pfb_update_check -> pfb_download($type='change_detect') hashes the raw
-// fetched body -- it returns before any decompression).
-//
-// $file_download is the '.raw' download (pre-decompression); $orig_download is the
-// finalised '.orig' the caller will ingest (decompressed for a compressed feed, or the
-// renamed raw file itself for an uncompressed one).
-//
-//   - Compressed feed (gz/bz2/zip/7z): the decompress tool (gunzip/bzip2/tar/7z) does
-//     not delete its source archive, so $file_download still exists on disk here and IS
-//     the raw fetched bytes -> hash that, not the decompressed $orig_download.
-//   - Uncompressed feed: $file_download was already @rename()'d onto $orig_download
-//     before this is called, so it no longer exists on disk -- but $orig_download now
-//     holds byte-identical content to what was fetched, so falling back to it is exact.
-//
-// Pure / no I/O beyond file_exists(); unit-testable in isolation from pfb_download().
+// ADR-42 / issue #713 bug 5: resolve which on-disk file holds the RAW fetched body, so the
+// source-hash sidecar pfb_download() persists at ingest hashes the SAME bytes as the probe
+// (which hashes the raw body before any decompression). $file_download is the '.raw' download
+// (pre-decompression); $orig_download is the finalised '.orig'. Compressed feed: the decompress
+// tool doesn't delete its source, so $file_download still exists and IS the raw bytes — hash
+// that. Uncompressed feed: $file_download was already renamed onto $orig_download, so it's gone
+// but $orig_download holds byte-identical content — falling back to it is exact. Pure / no I/O
+// beyond file_exists().
 function pfb_source_hash_target($file_download, $orig_download) {
 	return file_exists($file_download) ? $file_download : $orig_download;
 }
@@ -12434,7 +12029,7 @@ function pfb_hash_write($base, $path) {
 	return $ok;
 }
 
-// ADR-42 Phase 3: map a probe ('change_detect' mode) download path to the feed's persisted
+// ADR-42: map a probe ('change_detect' mode) download path to the feed's persisted
 // conditional-GET validator baseline.  The detector (pfb_update_check) persists the
 // ETag/Last-Modified sidecars at {header}.orig (pfb_validator_write on its $local_file),
 // but the probe is handed file_dwn = {header}.md5 so the probe body ({file_dwn}.raw =
@@ -12450,7 +12045,7 @@ function pfb_conditional_get_validator_base($file_dwn) {
 	return "{$file_dwn}.orig";
 }
 
-// ADR-42 Phase 3: read the per-feed HTTP validators (ETag + Last-Modified epoch)
+// ADR-42: read the per-feed HTTP validators (ETag + Last-Modified epoch)
 // stored as sidecars next to the .orig baseline.
 //
 // Returns an array with keys:
@@ -12488,7 +12083,7 @@ function pfb_validator_read($base) {
 	return array('etag' => $etag, 'lastmod' => $lastmod);
 }
 
-// ADR-42 Phase 3: persist the HTTP validators for a feed's .orig base path.
+// ADR-42: persist the HTTP validators for a feed's .orig base path.
 // $etag is the ETag response header value (string) or FALSE/'' to skip.
 // $lastmod is the Last-Modified epoch (int > 0) or FALSE to skip.
 // Does nothing when neither value is meaningful — never writes an empty sidecar.
@@ -12545,21 +12140,12 @@ function pfb_force_scope_dirs(string $scope, string $ip_origdir, string $dnsbl_o
 	return array($ip_origdir, $dnsbl_origdir);
 }
 
-// ADR-42 Phase 3: pure decision helper for the remote conditional-GET result.
-// Called by the detector after pfb_download returns the probe response.
-//
-// Contract (ADR-42 §2 #5 and #6):
-//   304 → unchanged (server confirmed — body was not re-sent).
-//   200 with body_hash == persisted_hash → unchanged (spurious 200; same bytes as baseline).
-//   200 with body_hash != persisted_hash → changed (real update; re-ingest needed).
-//   200 with no persisted hash ('') or body_hash FALSE → changed (no baseline to compare;
-//     fail-safe: cannot confirm unchanged, so treat as changed).
-//   Any other status or body_hash FALSE → changed (ambiguous/error; fail-safe, never false skip).
-//
-// $http_status  — the HTTP status code string from pfb_download's $response_meta['status'].
-// $body_hash    — the xxh128 digest of the probe body (string) or FALSE if unreadable.
-// $persisted_hash — the stored xxh128 digest of the last-ingested .orig (string) or '' if absent.
-// Returns TRUE when re-ingest is needed, FALSE when the feed is confirmed unchanged.
+// ADR-42: pure decision helper for the remote conditional-GET result, called by the detector
+// after pfb_download returns the probe response (contract: ADR-42 §2 #5/#6). 304 -> unchanged.
+// 200 with body_hash == persisted_hash -> unchanged (spurious 200). 200 with body_hash !=
+// persisted_hash -> changed. 200 with no persisted hash or body_hash FALSE -> changed
+// (fail-safe: no baseline to compare). Any other status -> changed (fail-safe, never a false
+// skip). Returns TRUE when re-ingest is needed, FALSE when confirmed unchanged.
 function pfb_conditional_get_decision($http_status, $body_hash, $persisted_hash) {
 	if ($http_status === '304') {
 		return FALSE;	// Server confirmed: not modified.
@@ -12574,25 +12160,15 @@ function pfb_conditional_get_decision($http_status, $body_hash, $persisted_hash)
 	return ($body_hash !== $persisted_hash);	// TRUE = changed, FALSE = spurious 200 (same bytes).
 }
 
-// Extract the local-feed change decision from pfb_update_check() as a named,
-// off-appliance-testable helper. Callers pass the source path and the .orig baseline;
-// this function returns TRUE when the feed has changed (re-ingest needed), FALSE when it
-// has not. It never concludes "unchanged" on a read failure — fail-safe.
-//
-// Algorithm (ADR-42 Phase 2 — content-hash gate, mtime removed):
-//  1. If either file is absent → changed (no baseline = first run).
-//  2. Read the tagged sidecar for the .orig via pfb_hash_read():
-//     - sentinel (no/corrupt sidecar) → live-hash the .orig as the baseline (the
-//       first-pass-after-upgrade case; also handles new installs before any sidecar exists).
-//     - 'md5' → baseline = sidecar digest; compare source with md5_file().
-//     - 'xxh128' → baseline = sidecar digest; compare source with pfb_content_hash().
-//  3. Hash the source in the SAME algo as the baseline.
-//  4. changed = (source_hash !== baseline). Any read failure → TRUE (fail-safe).
-//
-// NOTE: The sidecar is written (refreshed) at ingest time inside pfb_download(), so the
-// baseline is always the hash of the last-ingested .orig.  This prevents the staleness
-// trap: if the sidecar were only written here (before ingest) it would hold the OLD hash
-// after re-ingest, causing every subsequent cron to falsely report "changed".
+// Extract the local-feed change decision from pfb_update_check() as a named, off-appliance-
+// testable helper. Returns TRUE when the feed changed (re-ingest needed), FALSE when not;
+// never concludes "unchanged" on a read failure — fail-safe. Algorithm (ADR-42 content-hash
+// gate, mtime removed): either file absent -> changed (no baseline); else read the tagged
+// .orig sidecar (sentinel -> live-hash the .orig as baseline; 'md5'/'xxh128' -> sidecar digest
+// compared with the matching hash function); hash the source in the SAME algo; changed =
+// source_hash !== baseline. The sidecar is refreshed at ingest inside pfb_download(), so the
+// baseline is always the last-ingested .orig's hash — else it would go stale and falsely
+// report "changed" every cron after a real re-ingest.
 function pfb_local_feed_changed($source_path, $orig_path) {
 	if (!file_exists($source_path) || !file_exists($orig_path)) {
 		return TRUE;
@@ -12655,14 +12231,11 @@ function pfb_filterlog_refresh_config() {
 	}
 }
 
-// Select the correct filterlog port field for an exploded filter.log CSV row ($d) by
-// IP version ($d[8]) and flow direction. The v4 row carries its ports at $d[20]
-// (src) / $d[21] (dst); the v6 row -- which has fewer leading fields -- carries them
-// at $d[17] (src) / $d[18] (dst). Issue #713: the port-selection at the 'in'/'out'
-// branch used the v4 indices unconditionally, so a v6 flow read the wrong CSV field
-// as its port, mis-attributing the local_hosts reverse-lookup key.
-//
-// PURE -- no I/O, no globals, no side effects.
+// Select the correct filterlog port field for an exploded filter.log CSV row ($d) by IP
+// version ($d[8]) and flow direction. v4 carries ports at $d[20]/$d[21] (src/dst); v6 — fewer
+// leading fields — carries them at $d[17]/$d[18]. Issue #713: the port-selection used to use
+// v4 indices unconditionally, mis-attributing the local_hosts reverse-lookup key for v6 flows.
+// PURE — no I/O, no globals, no side effects.
 //
 // @param array<int, string> $d           Exploded filter.log CSV row.
 // @param bool                $is_inbound  TRUE for the 'in' branch (dst is local).
@@ -13327,27 +12900,14 @@ function pfb_render_memo(array &$store, string $key, callable $resolver) {
 }
 
 
-// Predicate for the Unified-log render loop (pfblockerng_alerts.php): TRUE once no
-// converter (convert_dnsbl_log() / convert_dns_reply_log() / convert_ip_log()) can
-// possibly render another row, so the caller can break out of its fgetcsv() loop
-// instead of parsing the rest of the log for nothing (issue #809 Phase 2).
-//
-// Non-filter mode ($filterlogentries FALSE): all three converters share one counter
-// ($counter['Unified']) and one limit ($pfbentries) -- each converter's own
-// top-of-function gate is `$counter['Unified'] >= $pfbentries`, so once that holds,
-// every converter call from here on is a guaranteed no-op (its OWN early-return guard,
-// e.g. `if ($dnsblfilterlimit) return TRUE;`, trips before any side effect). Done is
-// therefore exactly `$unified_count >= $pfbentries`.
-//
-// Filter mode ($filterlogentries TRUE): each converter instead gates on its OWN
-// per-type counter/limit ($dnsblfilterlimitentries/$dnsfilterlimitentries/
-// $ipfilterlimitentries) and sets its OWN flag ($dnsblfilterlimit/$dnsfilterlimit/
-// $ipfilterlimit) once reached -- exactly mirroring the <tfoot> Unified summary's own
-// "Filter Limit setting reached" check (`$ipfilterlimit && $dnsblfilterlimit &&
-// $dnsfilterlimit`). Only once ALL THREE are TRUE can no type render anything more, so
-// done is `$ipfilterlimit && $dnsblfilterlimit && $dnsfilterlimit`. If any one knob is
-// 0 (unlimited), its flag never sets and this never returns TRUE -- the loop then
-// correctly runs to EOF exactly as before this change.
+// Predicate for the Unified-log render loop (pfblockerng_alerts.php): TRUE once no converter
+// (convert_dnsbl_log/convert_dns_reply_log/convert_ip_log) can render another row, so the
+// caller can break out of fgetcsv() instead of parsing the rest of the log for nothing (issue
+// #809). Non-filter mode: all three share one counter/limit, so done = `$unified_count >=
+// $pfbentries`. Filter mode: each converter gates on its OWN counter/limit and sets its OWN
+// flag; done = `$ipfilterlimit && $dnsblfilterlimit && $dnsfilterlimit` (mirrors the <tfoot>
+// summary check) — an unlimited (0) knob never sets its flag, so the loop runs to EOF as
+// before.
 function pfb_alerts_unified_scan_done($filterlogentries, $unified_count, $pfbentries, $ipfilterlimit, $dnsblfilterlimit, $dnsfilterlimit): bool {
 	if ($filterlogentries) {
 		return $ipfilterlimit && $dnsblfilterlimit && $dnsfilterlimit;
@@ -13356,15 +12916,12 @@ function pfb_alerts_unified_scan_done($filterlogentries, $unified_count, $pfbent
 }
 
 
-// Pass-1 buffer-append rule for the DNSBL non-filter two-pass render
-// (pfblockerng_alerts.php, issue #809 Phase 3a). Extracted verbatim (issue #809 T2
-// review) so the compression arithmetic is unit-pinned by AlertsBufferReplayTest
-// instead of living only as inline page code with no committed coverage.
-//
-// A duplicate-marker line ('-') either extends the buffer's trailing int run (a
-// run-length counter) or opens a fresh one; a non-dup line is appended verbatim as
-// $row. The page passes $row = NULL when $is_dup is TRUE ($row is unused on that
-// branch). See pfb_alerts_dnsbl_replay_step() for the Pass-2 counterpart.
+// Pass-1 buffer-append rule for the DNSBL non-filter two-pass render (pfblockerng_alerts.php).
+// Extracted verbatim so the compression arithmetic is unit-pinned by AlertsBufferReplayTest
+// instead of living only as inline page code with no committed coverage. A duplicate-marker
+// line ('-') either extends the buffer's trailing int run (a run-length counter) or opens a
+// fresh one; a non-dup line is appended verbatim as $row ($row is unused when $is_dup is
+// TRUE). See pfb_alerts_dnsbl_replay_step() for the Pass-2 counterpart.
 function pfb_alerts_dnsbl_buffer_push(array &$buf, bool $is_dup, $row): void {
 	if ($is_dup) {
 		$last = count($buf) - 1;
@@ -13399,26 +12956,15 @@ function pfb_alerts_dnsbl_replay_step($entry): array {
 }
 
 
-// Pass-1 buffer-append rule for the IP two-pass render's two COMPRESSIBLE line
-// kinds (pfblockerng_alerts.php, issue #809 Phase 3b). Extracted verbatim (issue
-// #809 T2 review) so the compression arithmetic is unit-pinned by
-// AlertsBufferReplayTest instead of living only as inline page code with no
-// committed coverage. The third buffer shape -- an ACCEPTED row, array($fields,
-// TRUE) -- is not compressible and stays appended inline by the page.
-//
-// $kind is 'dup' (a duplicate-marker '-' line) or 'reject' (a filter-rejected
-// line):
-//   'dup'    -- extend a trailing int run, extend a trailing gap marker's 'dup'
-//               counter, or open a fresh int run.
-//   'reject' -- zero a trailing gap marker's 'dup' counter (mirrors the streamed
-//               loop's `$dup[$rtype] = 0` on every reject), REPLACE a trailing
-//               pure int run with a fresh zero-dup gap (those dups precede the
-//               reject, so the reset makes them irrelevant), or open a fresh
-//               zero-dup gap. A reject's fields are deliberately never kept --
-//               convert_ip_log()'s filter-reject path has a CONSTANT,
-//               field-independent effect (`$dup[$rtype] = 0; return
-//               array(FALSE, '');`), so only the post-last-reject dup count
-//               needs to survive.
+// Pass-1 buffer-append rule for the IP two-pass render's two COMPRESSIBLE line kinds
+// (pfblockerng_alerts.php). Extracted verbatim so the compression arithmetic is unit-pinned by
+// AlertsBufferReplayTest instead of living only as inline page code. The third buffer shape —
+// an ACCEPTED row, array($fields, TRUE) — is not compressible and stays appended inline.
+// $kind is 'dup' (a duplicate-marker '-' line) or 'reject': 'dup' extends a trailing int run or
+// a trailing gap marker's 'dup' counter, or opens a fresh int run. 'reject' zeroes a trailing
+// gap marker's 'dup' counter, REPLACES a trailing pure int run with a fresh zero-dup gap, or
+// opens a fresh zero-dup gap — a reject's fields are never kept since convert_ip_log()'s
+// filter-reject path has a CONSTANT effect, so only the post-last-reject dup count survives.
 // See pfb_alerts_ip_replay_step() for the Pass-2 counterpart.
 function pfb_alerts_ip_buffer_push(array &$buf, string $kind): void {
 	$last = count($buf) - 1;
@@ -13447,23 +12993,15 @@ function pfb_alerts_ip_buffer_push(array &$buf, string $kind): void {
 }
 
 
-// Pass-2 replay-decode counterpart to pfb_alerts_ip_buffer_push(): tells the IP
-// render loop what a buffered entry MEANS, so it never has to inspect the
-// buffer's storage shape itself.
-//
-//   int N                -> array('dup_add' => N) -- a pure dup run: one
-//                            accumulation into $dup[$rtype], output-identical to
-//                            N individual $dup[$rtype]++ increments.
-//   array('rej'=>...,
-//         'dup'=>N)      -> array('gap' => N) -- a mixed dup/reject run. The
-//                            caller must SET $dup[$rtype] = N (never +=) and
-//                            clear $p_query_port, exactly as a reject's
-//                            convert_ip_log() return does; N is the dup count
-//                            AFTER the last reject in the run (earlier dups
-//                            never reach the next rendered row's badge).
-//   array($fields, TRUE) -> array('render' => $fields) -- an accepted row,
-//                            replayed through the unchanged convert_ip_log()
-//                            call.
+// Pass-2 replay-decode counterpart to pfb_alerts_ip_buffer_push(): tells the IP render loop
+// what a buffered entry MEANS, so it never has to inspect the buffer's storage shape itself.
+//   int N -> array('dup_add' => N): a pure dup run, one accumulation into $dup[$rtype],
+//     output-identical to N individual increments.
+//   array('rej'=>...,'dup'=>N) -> array('gap' => N): a mixed dup/reject run — the caller must
+//     SET $dup[$rtype] = N (never +=) and clear $p_query_port, exactly as a reject's
+//     convert_ip_log() return does; N is the dup count AFTER the last reject in the run.
+//   array($fields, TRUE) -> array('render' => $fields): an accepted row, replayed through the
+//     unchanged convert_ip_log() call.
 function pfb_alerts_ip_replay_step($entry): array {
 	if (is_int($entry)) {
 		return array('dup_add' => $entry);
@@ -13477,20 +13015,13 @@ function pfb_alerts_ip_replay_step($entry): array {
 }
 
 
-// Page-scope prefetch store for pfb_dnsbl_parse_compute()'s data/zone grep sites (issue
-// #809 Phase 3a). NULL means "no prefetch ran" -- every consult site then falls straight
-// through to its normal per-row exec, so daemon mode (which never seeds this) and any
-// alerts-mode call outside a batched render pass are completely unaffected.
-//
-// Read current value:   pfb_dnsbl_prefetch_store()
-// Seed / reset value:   pfb_dnsbl_prefetch_store($arrayOrNull)  -- an explicit NULL
-//                        argument (func_num_args() > 0) resets to "no prefetch", which
-//                        is how the DNSBL table render pass (pfblockerng_alerts.php)
-//                        clears the store once it finishes. Defensive hygiene, not a
-//                        live fix: that page renders at most one prefetch-consuming
-//                        table per request, so no later same-process consumer can
-//                        actually see a stale seed today -- the reset just guarantees
-//                        that stays true if a future change adds a second consumer.
+// Page-scope prefetch store for pfb_dnsbl_parse_compute()'s data/zone grep sites (issue #809).
+// NULL means "no prefetch ran" — every consult site falls straight through to its normal
+// per-row exec, so daemon mode (which never seeds this) is unaffected. Read:
+// pfb_dnsbl_prefetch_store(); seed/reset: pfb_dnsbl_prefetch_store($arrayOrNull) — an explicit
+// NULL argument (func_num_args() > 0) resets to "no prefetch", which the DNSBL table render
+// pass clears once it finishes (defensive hygiene: today's page renders at most one
+// prefetch-consuming table per request, so no live bug depends on the reset yet).
 function pfb_dnsbl_prefetch_store(?array $seed = NULL): ?array {
 	static $store = NULL;
 
@@ -13502,37 +13033,15 @@ function pfb_dnsbl_prefetch_store(?array $seed = NULL): ?array {
 }
 
 
-// Batch the DNSBL/TLD render-time grep lookups for a set of domains ahead of a page
-// render pass (issue #809 Phase 3a). Reproduces, in at most one grep pass per file, the
-// per-row match pfb_dnsbl_parse_compute() would otherwise run separately for each of
-// $qdomains:
-//
-//   - data file ($pfb['unbound_py_data']): the per-row site matches the fixed-string
-//     literal ",{domain},," with `grep -shm1 -F` (issue #837 -- previously an escaped-BRE
-//     match that hand-escaped only the dot, so any OTHER BRE metacharacter in the domain
-//     rode into the regex live). Batched here as a single `grep -shF -f <patternfile>`
-//     pass with the same RAW literal patterns.
-//   - zone file ($pfb['unbound_py_zone']): the per-row site walks the domain's labels
-//     longest-first (full domain, then each suffix with the leftmost label stripped,
-//     down to the bare TLD), matching each step the same way. Batched by collecting
-//     every suffix of every domain and running ONE fixed-string pass over the zone file.
-//
-// Negative results are recorded too ('covered'/'zone_covered' with no matching
-// 'data'/'zone' entry): a domain/suffix this prefetch pass covered but did not find is a
-// genuine miss, and the consult sites must serve that cached '' rather than falling back
-// to a per-row exec (which would just re-run the identical grep for the same answer).
-//
-// B2 (issue #809 review; revised for issue #837): a domain is only added to 'covered'
-// (and only contributes data/zone patterns) when it VALIDATES as PFB_FILTER_DOMAIN --
-// guards against an embedded control character (a fgetcsv()'d quoted field can carry a
-// literal \r/\n) reaching the pattern file. Since the per-row sites are now ALSO `-F`
-// fixed-string (issue #837), batched == per-row by construction for every domain, not
-// only ones passing this filter; a domain that fails it is simply left UNCOVERED and
-// falls straight through to the unchanged (and, post-#837, equally fixed-string) per-row
-// exec at pfb_dnsbl_parse_compute()'s consult sites.
-//
-// Seeds pfb_dnsbl_prefetch_store(); the caller (pfblockerng_alerts.php's DNSBL table
-// branch) is responsible for resetting the store once its render pass is done.
+// Batch the DNSBL/TLD render-time grep lookups for $qdomains ahead of a page render pass
+// (issue #809): one grep pass per file instead of a per-row exec each. Data file: fixed-string
+// ",{domain},," match via `grep -shF` (issue #837 fixed a prior escaped-BRE match that let
+// non-dot metacharacters ride into the regex live). Zone file: batches every longest-first
+// label-suffix of every domain into one fixed-string pass. Negative results are cached too
+// ('covered'/'zone_covered' with no match) so the consult sites serve a genuine miss from
+// cache, never re-exec. A domain enters 'covered' only when it VALIDATES as PFB_FILTER_DOMAIN
+// — guards an embedded control char reaching the pattern file. Seeds
+// pfb_dnsbl_prefetch_store(); the caller resets it once rendering finishes.
 function pfb_dnsbl_prefetch(array $qdomains) {
 	global $pfb;
 
@@ -13591,25 +13100,15 @@ function pfb_dnsbl_prefetch(array $qdomains) {
 
 
 // One `grep -shF -f <patternfile>` pass over $file, returning a map of the matched
-// domain/suffix (each line's field [1] -- the same position pfb_dnsbl_parse_compute()
-// destructures on a per-row hit) to the FIRST line seen for it. grep preserves the
-// file's original line order regardless of pattern order, so "first seen in this batched
-// pass" is exactly the per-row `-m1` result for that same domain/suffix. $patterns are
-// raw literal ",{domain-or-suffix},," strings (no regex escaping) -- the per-row sites
-// are `-F` fixed-string too (issue #837; see pfb_dnsbl_prefetch()'s docblock), so both
-// sides match identically by construction.
-//
-// Keying the map by field [1] relies on where a ",X,," pattern can match: in the
-// ",domain,,log_type,feed,group" line shape, the empty placeholder after the domain slot
-// is the only double comma a well-formed line contains, so a ",X,," fixed string can
-// only ever match with X in the domain slot -- field [1]. That is exactly what makes
-// "key by field [1]" select the same line the per-row `grep -shm1 -F ',X,,'` would.
-//
-// B3/R1 (issue #809 review): returns NULL -- distinct from a genuine empty-array
-// no-match result -- when the pattern file itself could not be created or fully written
-// (a full or read-only temp dir). pfb_dnsbl_prefetch() must treat NULL as "this batched
-// pass did not run" and leave its store unseeded entirely, never seed a false negative
-// from it.
+// domain/suffix (field [1], same position pfb_dnsbl_parse_compute() destructures per-row) to
+// the FIRST line seen for it — grep preserves file order, so "first seen in this batched pass"
+// matches the per-row `-m1` result. $patterns are raw literal ",{domain-or-suffix},," strings
+// (no regex escaping); the per-row sites are also `-F` fixed-string (issue #837), so both sides
+// match identically by construction. Keying by field [1] works because in the
+// ",domain,,log_type,feed,group" line shape the only double comma is right after the domain
+// slot, so a ",X,," pattern can only match with X there. Returns NULL — distinct from a genuine
+// empty-array no-match — when the pattern file could not be created/written; the caller must
+// leave its store unseeded, never seed a false negative.
 function pfb_dnsbl_prefetch_grep(array $patterns, string $file): ?array {
 	global $pfb;
 
@@ -13650,15 +13149,14 @@ function pfb_dnsbl_prefetch_grep(array $patterns, string $file): ?array {
 }
 
 
-// Functon to find which DNSBL Feed/Groupname blocked this event
+// Function to find which DNSBL Feed/Groupname blocked this event.
 //
-// issue #809 (Alerts page render-time performance): in 'alerts' mode ONLY, memoize the
-// whole return value per $domain -- a render request is one PHP process, so a repeated
-// domain across rows on one page load costs zero further SQLite/grep/drill work (the
-// real work lives in pfb_dnsbl_parse_compute() below). 'daemon' mode (the long-running
-// filterlog/dnsbl daemons) is completely unchanged: it is never memoized (an unbounded
-// static store has no place in a process that runs for the life of the service) and
-// always calls straight through.
+// issue #809 (Alerts page render-time performance): in 'alerts' mode ONLY, memoize the whole
+// return value per $domain — a render request is one PHP process, so a repeated domain across
+// rows on one page load costs zero further SQLite/grep/drill work (the real work lives in
+// pfb_dnsbl_parse_compute() below). 'daemon' mode (the long-running filterlog/dnsbl daemons) is
+// unchanged: never memoized (an unbounded static store has no place in a service-lifetime
+// process) and always calls straight through.
 function pfb_dnsbl_parse($mode='daemon', $domain, $src_ip, $req_agent) {
 	static $alerts_memo = array();
 
@@ -13720,7 +13218,7 @@ function pfb_dnsbl_parse_compute($mode, $domain, $src_ip, $req_agent) {
 		// but read unconditionally at "if ($cname_cnt == 0)" -- init so a total miss (no
 		// data/zone/CNAME match) doesn't read an undefined variable there.
 
-		// issue #809 Phase 3a: NULL unless the Alerts page's DNSBL table render pass
+		// issue #809: NULL unless the Alerts page's DNSBL table render pass
 		// seeded it via pfb_dnsbl_prefetch() -- read once here and reused at both grep
 		// sites below (data + zone) for every iteration of the CNAME while(TRUE) loop.
 		$prefetch_store = pfb_dnsbl_prefetch_store();
@@ -14380,17 +13878,12 @@ function pfb_js_string(string $text): string {
 
 
 // Read the next slice of a live log file for the AJAX tail endpoint, starting at byte $offset.
-// Returns ['data' => <new text>, 'offset' => <next byte offset to request>].
-//
-// - Whole lines only (default): a trailing partial line is held back -- $offset advances only
-//   past the last newline -- so a multibyte UTF-8 char is never split across two polls (the JSON
-//   encoder would otherwise substitute the split byte and corrupt it irreparably). Pass
-//   $flush = TRUE on the FINAL read (the run is done, no more lines are coming) to emit the
-//   trailing partial line too.
-// - $offset is always a RAW byte position in the file; the returned data has CR stripped for
-//   display only, so the count is computed on raw bytes BEFORE stripping (the two would diverge).
-// - $offset past EOF (the file was truncated/rotated -- e.g. a fresh run truncated the run log)
-//   resets to 0, so the tail re-reads from the new start instead of desyncing.
+// Returns ['data' => <new text>, 'offset' => <next byte offset to request>]. Whole lines only
+// by default — a trailing partial line is held back ($offset advances only past the last
+// newline) so a multibyte UTF-8 char is never split across two polls; pass $flush = TRUE on the
+// FINAL read to emit the trailing partial line too. $offset is a RAW byte position (the
+// returned data has CR stripped for display only, so the count is computed BEFORE stripping).
+// $offset past EOF (file truncated/rotated) resets to 0 so the tail re-reads from the new start.
 function pfb_log_tail_chunk(string $file, int $offset, bool $flush = FALSE): array {
 	clearstatcache(FALSE, $file);
 	$len = @filesize($file);
@@ -15106,7 +14599,7 @@ function sync_package_pfblockerng($cron='') {
 
 	$pfb['filter_configure']	= FALSE;	// Flag to call filter_configure once
 
-	// ADR-12 Phase 6: TWO pass-scoped accumulators of the names UPDATED this pass,
+	// ADR-12: TWO pass-scoped accumulators of the names UPDATED this pass,
 	// split by side because DNSBL groups are NOT firewall aliases. They feed the
 	// 'post' hook's PFB_CHANGED_IP_ALIASES and PFB_CHANGED_DNSBL_GROUPS. Both are
 	// initialised empty here so they are always defined at the hook (even on a pass
@@ -15175,7 +14668,7 @@ function sync_package_pfblockerng($cron='') {
 		return;
 	}
 
-	// ADR-43 Phase 3: normalize the trigger input.
+	// ADR-43: normalize the trigger input.
 	// Array = new API (explicit request, no deprecation log).
 	// String = back-compat (routes through pfb_trigger_request(); deprecated verbs log once).
 	if (is_array($cron)) {
@@ -17090,7 +16583,7 @@ function sync_package_pfblockerng($cron='') {
 						}
 					}
 
-					// ADR-12 Phase 6: record GENUINELY-changed DNSBL groups for
+					// ADR-12: record GENUINELY-changed DNSBL groups for
 					// PFB_CHANGED_DNSBL_GROUPS. $pfb['aliasupdate'] is final for the
 					// group here (reset at :8859, set TRUE at :9500 ONLY when a feed in
 					// this group was actually (re)downloaded+parsed -- stays FALSE on
@@ -19452,14 +18945,14 @@ function sync_package_pfblockerng($cron='') {
 	//       whose block did not run — no undefined-variable warning.
 	//   PFB_TRIGGER       = $pfb_hook_val (from pfb_req_to_hook_trigger / pfb_hook_trigger).
 	//   PFB_CHANGED_IP_ALIASES = the space-separated list of IP firewall aliases UPDATED
-	//       this pass (ADR-12 Phase 6) = $pfb_alias_lists (the content-diff set --
+	//       this pass (ADR-12) = $pfb_alias_lists (the content-diff set --
 	//       pfB_*_v4/_v6 whose canonical membership set actually changed this pass,
 	//       as determined by pfb_alias_set_different(); ADR-40 P3).  Reputation/dedup
 	//       no longer inflate this to all active aliases -- only moved tables appear here.
 	//       The IP locals are in scope only at this tail, so they are merged into
 	//       $pfb['changed_ip_aliases'] here, then de-duped at emit.
 	//   PFB_CHANGED_DNSBL_GROUPS = the space-separated list of DNSBL groups UPDATED this
-	//       pass (ADR-12 Phase 6) = the DNSBL_<group> names appended in the per-group
+	//       pass (ADR-12) = the DNSBL_<group> names appended in the per-group
 	//       feed loop under $pfb['aliasupdate'] (genuine feed (re)parse only -- file-reuse
 	//       and the always-rebuilt DNSBL_IDN/DNSBL_TLD_Allow/DNSBL_Regex specials are
 	//       excluded), de-duped at emit. DNSBL groups are NOT firewall aliases, so they

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -137,21 +137,13 @@ exitnow() {
 }
 
 
-# Token-shape guards for feed-derived list data. The list-processing functions
-# iterate values that ultimately originate from downloaded feeds and splice them
-# into `grep` patterns (anchored octet-prefix matches such as `^10\.0\.0\.`).
-# Previously only the literal dot was escaped, so any other regex metacharacter
-# in a token stayed live and `grep` interpreted it as a pattern -- yielding an
-# over-broad / incorrect match set, or an expensive pattern.
-#
-# Each guard returns success only when the token is built solely from the
-# characters that shape allows (digits, dots, and -- for CIDR -- a slash). A
-# token that fails is dropped by its caller (`continue`), never matched. Because
-# the surviving tokens contain only digits/dots/slashes, the existing dot-escape
-# + `^` anchor that follows is then exact and safe.
-#
-# Reject the empty string explicitly: `case ''` would match the `*[!set]*`
-# negation as "no disallowed char present" and pass.
+# Token-shape guards for feed-derived list data spliced into `grep` patterns (anchored
+# octet-prefix matches like `^10\.0\.0\.`). Previously only the literal dot was escaped, so
+# any other regex metacharacter stayed live -- yielding an over-broad/incorrect match or an
+# expensive pattern. Each guard passes only when the token is built solely from its allowed
+# characters (digits, dots, and -- for CIDR -- a slash); a failing token is dropped by its
+# caller (`continue`), never matched. Reject '' explicitly: `case ''` would match
+# `*[!set]*`'s negation as "no disallowed char present" and pass.
 
 # An octet prefix: one or more dot-separated decimal octets, digits and dots
 # only (e.g. '10' or '10.0.0'). No anchors, no slash.
@@ -315,26 +307,14 @@ aliastables() {
 }
 
 
-# DNSBL python-integration cache (#468). On a RAM-disk /var (use_mfs_tmpvar) the
-# chroot is wiped on reboot, so DNSBL comes up dead. This keeps DNSBL alive across a
-# reboot with PURE FILE OPS (no reload/restart -- Unbound's normal start loads the
-# restored files). Kept SEPARATE from the IP aliastables flow above on purpose: the
-# two have different lifecycles (DNSBL state vs IP-rule state).
-#
-#   stage   -- single source of truth for the SHIPPED file set (PFB_PY_SHIPPED): copy
-#              each from /usr/local into the chroot, after making the chroot + the
-#              nullfs/devfs mount-point dirs (fresh MFS lacks them, which is what made
-#              pfb_python_mount fail). Re-run on every save/restore so the shipped code
-#              is always current from /usr/local (never restored stale from an archive).
-#   save    -- stage, then archive ONLY the GENERATED set (pfb_unbound*/pfb_py_* +
-#              pfb_unbound.ini: the manifest, raw feeds, caches, ini). Shipped files
-#              are NOT archived -- they come from /usr/local on restore.
-#   restore -- the boot earlyshellcmd: untar the generated set (if present) THEN stage.
-#
-# Naming contract: the generated archive set is matched by the pfb_unbound* / pfb_py_*
-# globs below; a new generated DNSBL file MUST keep that prefix to be carried across a
-# reboot. The shipped set is the explicit PFB_PY_SHIPPED list -- add a new shipped file
-# there (and to the pkg-plist / chroot-copy wiring) so it stays the one definition.
+# DNSBL python-integration cache (#468). On a RAM-disk /var (use_mfs_tmpvar) the chroot is
+# wiped on reboot, so DNSBL comes up dead; this keeps it alive across reboot with PURE FILE
+# OPS (no reload/restart), kept SEPARATE from the IP aliastables flow above (different
+# lifecycles). stage = copy the SHIPPED set (PFB_PY_SHIPPED) from /usr/local into the chroot
+# (re-run on every save/restore, never restored stale); save = stage then archive ONLY the
+# GENERATED set (pfb_unbound*/pfb_py_*/pfb_unbound.ini); restore = boot earlyshellcmd, untar
+# the generated set THEN stage. Naming contract: a new generated file MUST keep the
+# pfb_unbound*/pfb_py_* prefix; a new shipped file goes in PFB_PY_SHIPPED + pkg-plist wiring.
 dnsbl_cache() {
 	# Overridable for unit tests; default to the live locations.
 	pfbchroot="${pfbchroot:-/var/unbound}"
@@ -630,27 +610,15 @@ cidr_aggregate() {
 }
 
 
-# ADR-11: Union a set of already-effective member files into ONE deduped + CIDR-
-# aggregated alias file, plus a never-empty '-f' consumer file. Type-AGNOSTIC: it is
-# handed a plain list of member-file paths (one per line) and does not care which
-# action class (Deny/Permit/Match/Native) they belong to -- the per-type membership
-# is decided in PHP (pfb_aggregate_member_list) by the Phase-3 caller.
-#
-# Reuses the existing aggregation primitive (${pathaggregate} = iprange, the same
-# binary cidr_aggregate() shells out to) -- NO new aggregation algorithm. iprange is
-# set-exact (minimal CIDR cover equal to the union; never adds an address), so the
-# union cannot widen the set.
-#
-# Positional args (read directly, not via the global $alias/$max slots):
-#   $2 family       : 'v4' | 'v6'   (informational; iprange handles either family)
-#   $3 memberlist   : path to a file listing member files, one path per line
-#   $4 aggout       : path to write the aggregate alias file (the urltable content)
-#   $5 consumerout  : path to write the never-empty '-f' consumer file
-#
-# mtime-gate (Phase 1 strategy): rebuild only when a listed member file is newer than
-# the existing aggregate output -- otherwise the prior aggregate is current, so skip
-# the cat|sort -u|iprange entirely. The consumer file must also already exist and be
-# non-empty, else we always (re)build to honour the never-empty contract.
+# ADR-11: Union a set of already-effective member files into ONE deduped + CIDR-aggregated
+# alias file, plus a never-empty '-f' consumer file. Type-AGNOSTIC (handed a plain list of
+# member-file paths; per-type membership is decided in PHP by pfb_aggregate_member_list).
+# Reuses the existing aggregation primitive (${pathaggregate} = iprange, set-exact: minimal
+# CIDR cover equal to the union, never adds an address) -- NO new aggregation algorithm.
+# Args: $2 family ('v4'|'v6', informational), $3 memberlist (member-file-list path), $4
+# aggout (aggregate alias output), $5 consumerout (never-empty '-f' consumer output).
+# mtime-gate: rebuild only when a listed member file is newer than the existing aggregate
+# output; the consumer file must also already exist and be non-empty, else always rebuild.
 pfb_aggregate() {
 	agg_family="${2}"
 	agg_memberlist="${3}"

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -23,25 +23,11 @@
 // This file is used to 'include functions' not yet merged into pfSense
 
 // ---------------------------------------------------------------------------
-// ADR-28 — config field enums + the PfbStoredEnum adapter contract.
-//
-// Backed string enums for recurring config flags. Each enum OWNS its stored-value
-// semantics (the PfbStoredEnum interface + PfbStoredEnumAdapter trait) so the
-// PfbConfig gateway and the pfb_cfg_* helpers stay trivial:
-//   - read : EnumClass::fromStored($raw)   — the NULL/absent default is the registry's
-//             $entry['default'] (applied by PfbConfig::read() BEFORE the adapter);
-//             '', legacy aliases, and junk are resolved by the enum itself.
-//   - write: $enum->toStored()             — the canonical persisted token.
-//
-// Policy (ADR-28 §2.2, reframed): the goal is PRESERVE BEHAVIOUR ON UPGRADE, not
-// byte-identical storage. A write may persist a normalised canonical token when it
-// is behaviour-equivalent to the legacy one (e.g. pfb_idn All persists the legacy
-// 'on' token, reproducing the prior block-all-IDN behaviour). Downgrade is tolerated:
-// older releases string-compared these values, so an unknown token falls through to
-// the safe default there.
-//
+// ADR-28 — config field enums (PfbStoredEnum contract): read = EnumClass::fromStored($raw)
+// (registry default applied first; '' / legacy / junk resolved by the enum), write =
+// $enum->toStored(). Goal: preserve upgrade behaviour, not byte-identical storage — a
+// downgrade-unknown token falls through to the safe default.
 // Tests: tests/php/CfgAdaptersTest.php, tests/php/RollbackContractTest.php.
-// Naming follows pfb_* conventions (CLAUDE.md "Naming").
 // ---------------------------------------------------------------------------
 
 // PfbStoredEnum — the contract every config-backed enum implements. Keeps the
@@ -112,16 +98,10 @@ enum PfbToggle: string implements PfbStoredEnum
 	}
 }
 
-// PfbLenient — a tri-state {on, off, legacy ''} flag (the explicit 'off' token
-// survives the live config round-trip where a toggle's '' off-value would not).
-//
-// Used by: pfb_dnsbl_lenient (pfb_dnsblconfig['pfb_dnsbl_lenient'], ADR-22 scheme-parsing
-//   leniency) and pfb_keep (#484 — so a default-on keep flag can store 'off' explicitly).
-//   Stored vocabulary: 'on' | 'off' | '' (legacy: a missing pre-ADR-22 / pre-#484 install).
-//   pfb_global() reads pfb_dnsbl_lenient as a PfbLenient enum via PfbConfig::read()
-//   (the registry wires pfb_cfg_lenient_read/write); consumers compare === PfbLenient::On.
-//   Note: '' (missing key) maps to Off ('off'), NOT to the PfbToggle '' value.
-//   This field's "off" stored value is 'off', distinct from PfbToggle::Off = ''.
+// PfbLenient — tri-state {on, off, legacy ''} flag; explicit 'off' survives the config
+// round-trip where a toggle's '' off-value would not. Used by pfb_dnsbl_lenient (ADR-22
+// scheme-parsing leniency) and pfb_keep (#484, default-on keep storing 'off' explicitly).
+// Stored vocabulary: 'on' | 'off' | '' (legacy missing key -> Off, NOT PfbToggle's '').
 enum PfbLenient: string implements PfbStoredEnum
 {
 	use PfbStoredEnumAdapter;
@@ -136,16 +116,11 @@ enum PfbLenient: string implements PfbStoredEnum
 	}
 }
 
-// PfbIdnMode — ADR-08 IDN-feature mode selector. Adopted into the PfbConfig gateway.
-//
-// Used by: pfb_idn (config key) / $pfb['dnsbl_idn'] (runtime).
-//   Canonical tokens (config.xml AND py_unbound.ini AND the Python IdnMode enum, all the
-//   same vocabulary): 'on' (= All), 'confusable', 'off'. '' / unknown -> Off.
-//   Reusing the original 'on' token for All is the key move — pre-4.0.0 installs round-trip
-//   with no migration and an older release reading 'on' still blocks all IDN (behaviour
-//   preserved on downgrade). 'confusable' is the only genuinely new token; an old release
-//   treats it as off (acceptable). PfbConfig::read('pfb_idn') returns the enum;
-//   PfbConfig::write() persists toStored(); the ini build emits the same toStored() token.
+// PfbIdnMode — ADR-08 IDN-feature mode selector, adopted into the PfbConfig gateway.
+// Used by pfb_idn / $pfb['dnsbl_idn']. Canonical tokens (config.xml, py_unbound.ini, and
+// the Python IdnMode enum share one vocabulary): 'on' (=All), 'confusable', 'off'; '' /
+// unknown -> Off. Reusing 'on' for All keeps pre-4.0.0 installs migration-free and
+// downgrade-safe (an older release reading 'on' still blocks all IDN).
 enum PfbIdnMode: string implements PfbStoredEnum
 {
 	use PfbStoredEnumAdapter;
@@ -169,23 +144,12 @@ enum PfbIdnMode: string implements PfbStoredEnum
 }
 
 // PfbAliasDeltaMode — ADR-40 alias-table apply mechanism selector.
-//
-// Three modes control how pfBlockerNG applies alias-table changes to the pf kernel:
-//   Auto    ('auto')    — default; delta (-T add/-T delete) for small churn (< ~5%),
-//                         full -T replace for initial load / boot / large churn. Safe
-//                         default for all deployments.
-//   Delta   ('delta')   — ALWAYS apply via forward delta (-T add/-T delete); NO
-//                         large-churn replace fallback. Power-user/controlled-incremental
-//                         override — can be slow on a full-table rebuild. Use 'auto' for
-//                         the safe default.
+//   Auto    ('auto')    — default; delta for small churn (< ~5%), full replace for
+//                         initial load / boot / large churn.
+//   Delta   ('delta')   — ALWAYS forward delta, no large-churn replace fallback.
 //   Replace ('replace') — always full -T replace (pre-ADR-40 behaviour).
-//
-// Absent-default = 'auto' for a NEW install. An already-configured install is grandfathered to
-// 'replace' (pre-ADR-40 full -T replace) by a one-time install/upgrade seed
-// (pfb_alias_delta_mode_install_default() + pfblockerng_install.inc), so an upgrade preserves the
-// operator's prior apply path instead of silently switching to delta — the absent-default 'auto'
-// reaches only brand-new installs. Downgrade-safe: an older release lacking this key ignores it
-// and performs its existing full replace.
+// Absent-default 'auto' reaches only brand-new installs; an existing install is
+// grandfathered to 'replace' at install/upgrade (pfb_alias_delta_mode_install_default()).
 enum PfbAliasDeltaMode: string implements PfbStoredEnum
 {
 	use PfbStoredEnumAdapter;
@@ -201,18 +165,11 @@ enum PfbAliasDeltaMode: string implements PfbStoredEnum
 }
 
 // PfbTop1mSource — TOP1M source selector (alexa_type, issue #877).
-//
-// Used by: alexa_type (config key) / $pfb['dnsbl_top1m_type'] (runtime).
-//   Canonical tokens: 'tranco' (default), 'cisco', 'openpagerank' (#928,
-//   replacing ADR-59 P4's 'domcop'), 'majestic' (ADR-59 P4), 'cloudflare'
-//   (ADR-59 P5, token-authenticated). TWO tokens
-//   are READ-ONLY legacy values, never re-emitted by a write: 'alexa' (the
-//   dead Alexa TOP1M service, #872) and 'domcop' (the DomCop top-10M list's
-//   hosting moved to OpenPageRank, #928) both coalesce to their replacement
-//   at the read boundary — every live token is ever persisted as itself, so
-//   the write vocabulary is downgrade-safe (an older release reading any of
-//   them already understands its own subset; openpagerank/majestic/
-//   cloudflare are simply new to it, same as any other ADR-added option).
+// Used by alexa_type (config key) / $pfb['dnsbl_top1m_type'] (runtime). Canonical tokens:
+// 'tranco' (default), 'cisco', 'openpagerank' (#928, replacing ADR-59 P4's 'domcop'),
+// 'majestic' (ADR-59 P4), 'cloudflare' (ADR-59 P5, token-authenticated). 'alexa' (#872) and
+// 'domcop' (#928) are READ-ONLY legacy tokens, coalesced to their replacement on read — the
+// write vocabulary only ever emits live tokens, so it is downgrade-safe.
 enum PfbTop1mSource: string implements PfbStoredEnum
 {
 	use PfbStoredEnumAdapter;
@@ -241,29 +198,15 @@ enum PfbTop1mSource: string implements PfbStoredEnum
 	}
 }
 
-// TOP1M provider descriptor table (ADR-59 P1, generalized P2, keyless
-// providers added P4, token-authenticated Cloudflare Radar added P5).
-//
-// Keyed by PfbTop1mSource::value ('tranco'/'cisco'/'openpagerank'/'majestic'/'cloudflare').
-// pfblockerng.php's TOP1M URL selection reads this table instead of a
-// per-provider if/else; pfblockerng_top1m() (ADR-59 P2) reads
-// 'parse'/'header'/'domain_col' to drive the builder. 'container' documents each
-// provider's expected transport shape (zip/gz/plain) but is currently INFORMATIONAL
-// ONLY -- pfb_download()'s extractor branches on the actually-detected MIME type
-// (PFB_FILTER_FILE_MIME), not this field, so a mismatch (e.g. a zip provider serving
-// an HTML error page) is caught downstream by pfblockerng_top1m()'s domain-validity
-// guard rather than here (#892 review). 'header'/'domain_col' default to FALSE/1 here
-// -- Tranco/Cisco's CSV has no header row and the domain sits at
-// str_getcsv() index 1 (0-indexed: rank,domain), matching today's hardcoded
-// shape byte-for-byte. 'auth' is read by pfb_download()'s header-auth path
-// (ADR-59 P3+) via pfb_top1m_auth_headers() below -- 'none' (every keyless
-// provider) or {header, scheme} (Cloudflare's Bearer token). 'domain_col' is
-// 0-indexed (str_getcsv() array index, not a human 1-indexed column count)
-// -- OpenPageRank's Domain is the 2nd CSV field
-// (Rank,Domain,Extension,Open Page Rank,Referring Domains) -> index 1 (same
-// index as Tranco/Cisco); Majestic's Domain is the 3rd field
-// (GlobalRank,TldRank,Domain,...) -> index 2; Cloudflare's dataset is a
-// SINGLE 'domain' column (no rank) -> index 0 (see the row's own comment).
+// TOP1M provider descriptor table (ADR-59). Keyed by PfbTop1mSource::value.
+// pfblockerng.php's TOP1M URL selection and pfblockerng_top1m() read
+// 'parse'/'header'/'domain_col' to drive the builder; 'container' is INFORMATIONAL ONLY —
+// pfb_download() branches on the actually-detected MIME type, not this field, so a mismatch
+// (e.g. a zip provider serving an HTML error page) is caught by pfblockerng_top1m()'s
+// domain-validity guard instead (#892). 'domain_col' is 0-indexed (str_getcsv() array
+// index): Tranco/Cisco/OpenPageRank -> 1, Majestic -> 2, Cloudflare's single 'domain'
+// column (no rank) -> 0. 'auth' is read by pfb_download()'s header-auth path via
+// pfb_top1m_auth_headers() below: 'none' or {header, scheme} (Cloudflare's Bearer token).
 //
 // @return array<string, array{url: string, container: string, parse: string, header: bool, domain_col: int, auth: string|array{header: string, scheme: string}, label: string, licence: string}>
 function pfb_top1m_providers(): array
@@ -349,17 +292,12 @@ function pfb_top1m_providers(): array
 	);
 }
 
-// ADR-59 P5: build the caller header(s) a provider's 'auth' descriptor needs, given the
-// user's top1m_token. Pure / no I/O (same extraction rationale as pfb_download_http_headers(),
-// Phase 3), so it is directly unit-testable and -- because it never logs anything -- the token
-// can only ever reach pfb_download()'s CURLOPT_HTTPHEADER, never a log line.
-//
-// 'auth' is either the string 'none' (every keyless provider) or an array {header, scheme}
-// (Cloudflare Radar's Bearer token, P5). An empty token or a keyless provider both yield
-// array() -- pfb_download() then sends no Authorization header, so a missing/blank token
-// fails the request safely rather than sending a malformed header: the #886 preserve+warn
-// path in pfblockerng_top1m() keeps the previous TOP1M whitelist and warns, exactly as any
-// other download failure does.
+// ADR-59 P5: build the caller header(s) a provider's 'auth' descriptor needs. Pure / no I/O,
+// so it is unit-testable and -- because it never logs -- the token only ever reaches
+// pfb_download()'s CURLOPT_HTTPHEADER, never a log line. 'auth' is 'none' (keyless) or
+// {header, scheme} (Cloudflare's Bearer token); an empty token/keyless provider yields
+// array() so pfb_download() sends no Authorization header -- the #886 preserve+warn path
+// keeps the previous TOP1M whitelist and warns on a resulting failure.
 //
 // @return string[] zero or one header line, e.g. ['Authorization: Bearer <token>'].
 function pfb_top1m_auth_headers(array $provider, string $token): array
@@ -452,32 +390,12 @@ function pfb_cfg_top1m_source_write(PfbTop1mSource|string $source): string
 }
 
 // ---------------------------------------------------------------------------
-// ADR-29 Phase 1 — PfbConfig gateway + declarative field registry.
-//
-// PfbConfig is the single sanctioned gateway for all config.xml reads/writes
-// of registered installedpackages/pfblockerng* keys. It wraps
-// config_get_path / config_set_path / config_del_path, applying the
-// registered default and the field-aware adapter (from ADR-28) at the
-// boundary.
-//
-// Field registry shape (pfb_cfg_registry()):
-//   key => [
-//     'section'       => 'installedpackages/pfblockerng*/config/0',  // config.xml path prefix
-//     'default'       => <stored-string default for absent/null>,
-//     'read_adapter'  => callable|null,   // null = plain string (identity)
-//     'write_adapter' => callable|null,   // null = plain string (identity)
-//     'since'         => 'x.y.z',        // version that introduced the key
-//   ]
-//
-// Section-level helpers (read/write/delete a whole section) allow www/ pages and
-// pfb_remove_config_settings() to flow through one gateway call in later phases.
-//
-// CONSTRAINTS (ADR-29 §5, ADR-28 §2.2):
-//   - Registry keys are the EXACT existing config.xml keys — no renames.
-//   - Stored values NEVER change; adapters map to the legacy stored string on write.
-//   - Round-trip identity: write(read(v)) == v for every canonical stored value.
-//   - This phase adds the class + registry only; no call site changed yet.
-//
+// ADR-29 — PfbConfig gateway: the single sanctioned gateway for config.xml reads/writes of
+// registered installedpackages/pfblockerng* keys, wrapping config_get/set/del_path with the
+// registered default + field adapter (ADR-28) at the boundary.
+// CONSTRAINTS (ADR-29 §5, ADR-28 §2.2): registry keys are the EXACT existing config.xml keys
+// (no renames); stored values NEVER change (adapters map to the legacy stored string on
+// write); round-trip identity write(read(v)) == v for every canonical stored value.
 // Tests: tests/php/CfgGatewayTest.php (round-trip, default, inventory).
 // ---------------------------------------------------------------------------
 
@@ -1371,18 +1289,13 @@ function pfb_cfg_registry(): array
 	return $registry;
 }
 
-// Read the configured DNSBL block-page template filename. issue #713: this is a
-// FOREIGN key (ADR-29 §2.5 out-of-scope) written directly by pfblockerng_dnsbl.php
-// as 'dnsbl_webpage' — NOT a gateway-registered key — so it is read here with a
-// direct config_get_path(), mirroring how the DNSBL settings page stores and reads
-// it ($pfb['dconfig']['dnsbl_webpage'] ?: 'dnsbl_default.php'). config_get_path()'s
-// default arg only substitutes when the key is ABSENT, not when it is present but
-// empty (''), so the `?:` coercion below is required to actually match that page —
-// a saved-then-cleared 'dnsbl_webpage' must still report 'dnsbl_default.php', the
-// same as an install that never saved DNSBL settings (and the install/upgrade
-// refresh of dnsbl_active.php then fires). Fixes the dead read of the mis-spelled
-// 'dnsblwebpage' registry key, which always returned '' because nothing ever
-// writes that path.
+// Read the configured DNSBL block-page template filename. issue #713: this is a FOREIGN key
+// (ADR-29 §2.5 out-of-scope), written directly by pfblockerng_dnsbl.php as 'dnsbl_webpage' —
+// so it is read here via a direct config_get_path(), mirroring how the DNSBL settings page
+// stores/reads it. config_get_path()'s default arg only substitutes when the key is ABSENT,
+// not when present-but-empty (''), so the `?:` coercion below is required — a
+// saved-then-cleared 'dnsbl_webpage' must still report 'dnsbl_default.php'. Fixes the dead
+// read of the mis-spelled 'dnsblwebpage' key, which always returned ''.
 function pfb_dnsbl_webpage(): string
 {
 	return config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_webpage', 'dnsbl_default.php') ?: 'dnsbl_default.php';
@@ -1467,9 +1380,7 @@ final class PfbConfig
 	 *
 	 * This is the equivalent of config_get_path($section, []) for callers
 	 * (www/ pages, pfb_global) that load an entire section blob at once
-	 * and access keys individually. Phase 1 exposes this seam without
-	 * changing existing call sites; later phases route per-key reads through
-	 * it.
+	 * and access keys individually.
 	 *
 	 * @param  string $section  The full config.xml section path (e.g.
 	 *                          'installedpackages/pfblockerng/config/0').
@@ -1566,26 +1477,13 @@ final class PfbConfig
 }
 
 // ---------------------------------------------------------------------------
-// ADR-29 Phase 2 — Migration registry + driver.
-//
-// pfb_migration_registry() is the ordered, idempotent, since-version-gated
-// inventory of every upgrade migration. Each entry delegates to an existing
-// *_migrate / *_seed helper (from pfblockerng.inc) and carries the exact
-// write_config() message that appeared in the original install.inc block.
-//
-// Registry shape:
-//   'id'       => string — unique, stable identifier for the migration
-//   'section'  => string — full config.xml section path to read/write
-//   'apply'    => callable($cfg: array): ?array
-//                   returns the updated section array to persist,
-//                   or NULL for a no-op (already migrated / fresh install)
-//   'message'  => string — write_config() description when the migration writes
-//   'since'    => string — version that introduced the migration
-//
-// The driver in pfblockerng_install.inc calls pfb_run_migrations() to execute
-// all entries in registry order. The helper bodies are UNCHANGED; this registry
-// only wraps/calls them so the install.inc is one loop instead of four blocks.
-//
+// ADR-29 — Migration registry + driver: pfb_migration_registry() is the ordered,
+// idempotent, since-version-gated inventory of every upgrade migration (shape below);
+// each entry delegates to an existing *_migrate/*_seed helper and carries its original
+// write_config() message. 'apply' returns the updated section array to persist, or NULL
+// for a no-op (already migrated / fresh install). The pfblockerng_install.inc driver calls
+// pfb_run_migrations() to execute all entries in registry order; helper bodies are
+// UNCHANGED, this registry only wraps them.
 // Tests: tests/php/MigrationRegistryTest.php
 // ---------------------------------------------------------------------------
 
@@ -1659,38 +1557,13 @@ function pfb_run_migrations(): void
 }
 
 // ---------------------------------------------------------------------------
-// ADR-29 Phase 3 — Rollback / backward-compat contract helpers.
-//
-// pfb_cfg_field_vocab() documents the FULL STORED VOCABULARY for every
-// registered field adapter type. The tests (RollbackContractTest.php) use
-// this to assert the FORWARD invariant (every legacy stored token yields a
-// sane runtime value) and the BACKWARD invariant (every write emits ONLY a
-// token in the legacy vocabulary — never a novel on-disk token an older
-// release would not recognise).
-//
-// ROLLBACK CONTRACT (ADR-29 §2.3):
-//   - A field PASSES the backward invariant iff, for every possible runtime
-//     value R, write_adapter(R) returns a string that is a member of the
-//     field's legacy stored vocabulary.  The gateway always writes legacy
-//     tokens, so downgrades leave older code reading values it already
-//     understands.
-//   - At the PfbConfig level no field is excluded: every write adapter emits a
-//     token from the field's known vocabulary. A write may NORMALISE a legacy
-//     token to a behaviour-equivalent canonical one (e.g. pfb_idn: All persists
-//     the legacy 'on' token, and the dropped 4.0.0-alpha 'all' normalises to
-//     'off') — the emitted token is always one an older release understands.
-//
-// SINCE-VERSION CONVENTION:
-//   The 'since' field in pfb_cfg_registry() records the package release that
-//   INTRODUCED the key to config.xml. For keys that pre-date the registry
-//   (i.e. existed before ADR-29 Phase 1), 'since' is set to the earliest
-//   release that still ships the pfBlockerNG line that uses the key — using
-//   the legacy release series as a conservative baseline (e.g. '1.0.0' for
-//   original-era keys, '2.0.0' for the Python-mode era, '3.x.y' for ADR-xx
-//   additions).  The current shipped devel version is always an acceptable
-//   baseline for any key whose introduction predates the registry (there is
-//   no config-version migration routine, so any installed config.xml may
-//   contain any subset of these keys).
+// ADR-29 §2.3 — Rollback / backward-compat contract. pfb_cfg_field_vocab() documents the
+// FULL STORED VOCABULARY per field adapter; RollbackContractTest.php asserts the FORWARD
+// invariant (every legacy token yields a sane runtime value) and the BACKWARD invariant
+// (every write emits ONLY a legacy-vocabulary token, never a novel on-disk one — a write may
+// normalise to a behaviour-equivalent canonical token, e.g. pfb_idn All persisting 'on').
+// SINCE-VERSION: 'since' records the release that introduced the key; pre-registry keys use
+// the earliest release still shipping that key's line (no config-version migration exists).
 // ---------------------------------------------------------------------------
 
 /**
@@ -1802,16 +1675,11 @@ function pfb_cfg_field_adapter_type(array $entry): string
 }
 
 // ---------------------------------------------------------------------------
-// Issue #357 — alias-rename follow-up helper.
-//
-// pfSense's alias-rename path (saveAlias() in alias-utils.inc) calls
-// update_alias_name() to rewrite core config sections (aliases, filter,
-// nat, …) but does NOT touch installedpackages/*.  The four per-row
-// Advanced Inbound/Outbound alias keys (aliasports_in / aliasports_out /
-// aliasaddr_in / aliasaddr_out) stored in our list sections go stale after
-// a rename.  pfb_alias_rename_followup() rewrites them in-memory via the
-// PfbConfig section gateway; the caller (the pre_write_config shim or any
-// other save path) is responsible for persisting via write_config().
+// Issue #357 — pfSense's alias-rename path (update_alias_name()) rewrites core config
+// sections but not installedpackages/*, so the four per-row Advanced Inbound/Outbound
+// alias keys (aliasports_in/out, aliasaddr_in/out) go stale after a rename.
+// pfb_alias_rename_followup() rewrites them in-memory via PfbConfig; the caller persists
+// via write_config().
 // ---------------------------------------------------------------------------
 
 /**
@@ -1997,23 +1865,12 @@ function pfb_adv_alias_field_errors(array $post): array
 }
 
 // ---------------------------------------------------------------------------
-// ADR-30 Phase 1 — Pure schedule-period deciders for log rotation.
-//
-// Two pure helper functions — no I/O, no globals, no config access.
-// The caller passes all inputs explicitly; this is the testable seam.
-//
-// Period-key format (what gets stored in the state file per log type):
-//   'off' or ''           -> '' (schedule disabled; no key)
-//   'daily'               -> 'YYYY-MM-DD'    (date('Y-m-d', $ts))
-//   'weekly'              -> 'YYYY-Www'       (date('o-\WW', $ts) — ISO week-year)
-//   'monthly'             -> 'YYYY-MM'        (date('Y-m', $ts))
-//   any unrecognised      -> '' (off-default; defensive)
-//
-// ISO week-year note: date('o') returns the ISO 8601 week-YEAR (not the
-// calendar year), so 2027-01-01 (calendar year 2027) yields '2026-W53'
-// (ISO year 2026, week 53) rather than the wrong '2027-W01'. This is the
-// correct behaviour — use date('o'), never date('Y'), for the week key.
-//
+// ADR-30 — Pure schedule-period deciders for log rotation (no I/O, no globals, no config
+// access; caller passes all inputs explicitly). Period-key format (state file per log type):
+//   'off'/''  -> ''            'daily'   -> 'YYYY-MM-DD'
+//   'weekly'  -> 'YYYY-Www' (ISO week-year)   'monthly' -> 'YYYY-MM'   unrecognised -> ''
+// ISO week-year: date('o') returns the ISO week-YEAR, not calendar year — 2027-01-01 yields
+// '2026-W53', not '2027-W01'. Use date('o'), never date('Y'), for the week key.
 // Tests: tests/php/LogRotateScheduleTest.php
 // ---------------------------------------------------------------------------
 
@@ -2071,41 +1928,9 @@ function pfb_log_should_reset(string $schedule, string $last_key, int $now_ts): 
 }
 
 // ---------------------------------------------------------------------------
-// ADR-38 Phase 1 — Pure key=value syslog event formatters.
-//
-// pfb_syslog_format_ip(array $fields): string
-//   Maps the already-computed IP Block/Permit/Match event fields to a single
-//   space-separated "key=value ..." string suitable for emission as a syslog
-//   message body.  The key order is fixed and documented below; this is the
-//   stable contract that later phases wire to syslog(3) and that tests pin.
-//
-// Key vocabulary (fixed order):
-//   act   — action:   'block'|'pass'|'match'
-//   dir   — direction: 'in'|'out'
-//   if    — friendly interface name (e.g. 'em0', 'LAN')
-//   proto — protocol string (e.g. 'TCP', 'UDP', 'TCP-SA')
-//   src   — source IP address
-//   dst   — destination IP address
-//   sport — source port (omitted when empty)
-//   dport — destination port (omitted when empty)
-//   ipver — IP version: '4' or '6'
-//   geoip — GeoIP ISO country code (omitted when empty or 'Unk'/'Unknown')
-//   alias — pfBlockerNG alias name (omitted when empty or 'Unknown')
-//   feed  — feed name (omitted when empty or 'Unknown')
-//   host  — resolved hostname of the external IP (omitted when empty/'Unknown')
-//   asn   — ASN string (omitted when empty or 'Unknown'/'null')
-//
-// Empty-value convention:
-//   Required fields (act/dir/if/proto/src/dst/ipver) are always present.
-//   Optional fields (sport/dport/geoip/alias/feed/host/asn) are OMITTED
-//   entirely when the value is empty, 'Unknown', 'Unk', or 'null'.
-//
-// Escaping rule:
-//   A value containing a space, '=', or '"' is double-quoted; internal '"'
-//   characters are backslash-escaped (\").  Newlines (\n, \r) are replaced
-//   with a space before quoting to keep the message single-line.
-//   Other punctuation (e.g. '|', ':', '/') is not quoted.
-//
+// ADR-38: pure key=value syslog event formatters (pfb_syslog_format_ip() etc.) — the fixed
+// key order, empty-value omission rules, and quoting/escaping are specified in
+// .ADRs/ADR_38_System_Log_Integration/ and pinned by tests/php/SyslogFormatTest.php.
 // PURE — no globals, no I/O, no config reads.
 // ---------------------------------------------------------------------------
 
@@ -2185,27 +2010,11 @@ function pfb_syslog_format_ip(array $fields): string
 }
 
 // ---------------------------------------------------------------------------
-// ADR-38 Amendment 1 — DNSBL syslog + unified.log formatters.
-//
-// pfb_syslog_format_dnsbl(array $fields): string
-//   PHP port of the (retired) Python syslog_format_dnsbl().  Formats a DNSBL
-//   block event as a space-separated key=value string for syslog emission.
-//   Fixed key order: act qname qip qtype [group] [feed] btype eval.
-//   group and feed are OPTIONAL — omitted entirely when the value is ''.
-//   Escaping rule is identical to pfb_syslog_format_ip (see above).
-//
-// pfb_unified_format_ip(array $fields): string
-//   Renders a unified.log IP row as a comma-joined string from 4 named fields:
-//   l_type, log, details, dup.  No escaping — raw passthrough join.
-//
-// pfb_unified_format_dnsbl(array $fields): string
-//   Renders a dnsbl.log CSV line as a comma-joined string from 11 named fields
-//   in the FIXED column order that dnsbl.log defines.  No escaping.
-//
-// pfb_unified_format_dnsreply(array $fields): string
-//   Renders a DNS-reply row for unified.log as a comma-joined string from 10
-//   named fields in fixed column order.  No escaping.
-//
+// ADR-38 Amendment 1 — DNSBL syslog + unified.log formatters. pfb_syslog_format_dnsbl()
+// (PHP port of the retired Python syslog_format_dnsbl()) formats a DNSBL block event as
+// key=value; fixed order act qname qip qtype [group] [feed] btype eval (group/feed omitted
+// when ''); escaping matches pfb_syslog_format_ip. pfb_unified_format_ip/_dnsbl/_dnsreply
+// render comma-joined unified.log/dnsbl.log rows in FIXED column order — no escaping.
 // All four are PURE — no globals, no I/O, no config reads.
 // ---------------------------------------------------------------------------
 
@@ -2332,31 +2141,12 @@ function pfb_unified_format_dnsreply(array $fields): string
 }
 
 // ---------------------------------------------------------------------------
-// ADR-38 — PHP syslog event emitter.
-//
-// pfb_syslog_event(string $body): void
-//   Emits ONE syslog record with the syslog ident (program name) 'pfblockerng'
-//   at a FIXED facility (LOG_LOCAL6) and severity (LOG_INFO).
-//
-//   Facility/severity are NOT user-configurable (ADR-38 Amendment 1): the events
-//   are routed to the dedicated pfblockerng_syslog.log by the package <logging>
-//   block's PROGRAM-name filter (!pfblockerng), so the facility never affects
-//   where they land; and every exported event is the same class of record, so a
-//   severity picker would only ever set one fixed level. They are all
-//   informational security events -> LOG_INFO. The only user control is the
-//   log_syslog master toggle.
-//
-//   Behaviour:
-//     - Reads log_syslog FRESH on every call (no per-process cache). The
-//       long-running pfb_filter daemon is the sole caller and the user can
-//       toggle log_syslog live; a cached value would keep emitting (or stay
-//       silent) until a daemon restart. This fires only on block events (the
-//       caller gates on the event class), not per packet, so the PfbConfig
-//       array read is cheap. The daemon keeps $config current via
-//       pfb_filterlog_refresh_config() so PfbConfig sees the live value.
-//     - No-op when log_syslog is off (PfbToggle::Off / '').
-//     - openlog() sets ident + facility; syslog() emits at LOG_INFO; closelog()
-//       releases the connection.
+// ADR-38 — PHP syslog event emitter. pfb_syslog_event(string $body) emits ONE record with
+// ident 'pfblockerng' at a FIXED facility (LOG_LOCAL6) and severity (LOG_INFO) — not
+// user-configurable: the package <logging> PROGRAM-name filter routes events regardless of
+// facility, and every event is the same informational-security class. Reads log_syslog FRESH
+// on every call (no per-process cache) since the long-running pfb_filter daemon is the sole
+// caller and the user can toggle it live; no-op when off (PfbToggle::Off / '').
 // ---------------------------------------------------------------------------
 
 /**
@@ -2402,42 +2192,12 @@ function pfb_syslog_event(string $body): void
 }
 
 // ---------------------------------------------------------------------------
-// ADR-43 Phase 2 — Due-ledger library (pure core + I/O helpers).
-//
-// A persisted per-job next-due ledger stored as a single JSON file
-// (pfb_due_ledger.json) under $pfb['dbdir']. This evolves the existing
-// .update/.last sentinel pattern: instead of flag files that only record
-// "needs update", each entry records {last_run, next_due, jitter} so a
-// single tick can decide what is due without reading the clock per-job.
-//
-// Design invariants (ADR-43 §2.C):
-//   - Absent entry (new install or wiped RAM-disk) ⇒ is_due returns TRUE.
-//     The stable seeded jitter is applied on mark_ran, spreading next_due.
-//   - next_due in the past                         ⇒ is_due returns TRUE (catch-up).
-//   - next_due in the future                       ⇒ is_due returns FALSE.
-//   - mark_ran sets next_due = now + interval + seeded_jitter(job, seed, max).
-//   - Corrupt or absent ledger file                ⇒ treated as absent (fail-safe).
-//
-// #468 persist/restore integration:
-//   pfb_due_ledger.json lives in $pfb['dbdir'] (= /var/db/pfblockerng on MFS).
-//   Phase 4 adds it to the earlyshellcmd archive set (alongside IP aliastables)
-//   so a clean reboot restores the schedule and avoids the boot stampede that the
-//   absent-entry rule guards against. Until Phase 4 wires this, the absent-⇒-due
-//   rule is the sole boot-stampede defence (jobs spread by their seeded jitter
-//   after the first post-boot mark_ran).
-//
-// On-disk layout (pfb_due_ledger.json under ledger_dir):
-//   {
-//     "dcc":  {"last_run": 1234567890, "next_due": 1234567890, "jitter": 35079},
-//     "bl":   {"last_run": 1234567890, "next_due": 1234567890, "jitter": 79870}
-//   }
-//   Writes are atomic: content assembled, written to .tmp with LOCK_EX, then
-//   renamed to the target (atomic on POSIX / FreeBSD same-filesystem rename).
-//
-// Clock and seed are INJECTABLE (passed as arguments to every function that needs
-// them) so PHPUnit can pin the date math without wall-clock or rand() flakiness.
-// Only a thin outer wrapper (Phase 4's tick) reads time() and the install seed.
-//
+// ADR-43 — Due-ledger library: persisted per-job next-due ledger (pfb_due_ledger.json under
+// $pfb['dbdir']) recording {last_run, next_due, jitter} so a tick decides what's due without
+// per-job clock reads. Invariants (§2.C): absent/corrupt -> is_due TRUE (fail-safe, sole
+// boot-stampede defence pending earlyshellcmd archival); next_due past -> TRUE, future ->
+// FALSE; mark_ran sets next_due = now + interval + seeded_jitter(job, seed, max). Atomic
+// writes (.tmp + LOCK_EX + rename); clock/seed INJECTABLE for PHPUnit determinism.
 // Tests: tests/php/DueLedgerTest.php
 // ---------------------------------------------------------------------------
 
@@ -3029,11 +2789,8 @@ function pfblockerng_tick(): void
  * Mirrors the tolerant textarea shape the page already accepts: a line starting
  * with '#', or blank, is a no-op (skip, no error); an inline comment introduced
  * by '#' (e.g. "10.0.0.1/32 # example.com") is stripped before validating the
- * address/mask. IPv4 accepts masks /8-/32 (ADR-53 §2.3 fork 1 — the /8 floor is
- * a fail-open-typo guard; the carve engine itself is mask-agnostic since Phase
- * 3's iprange --except swap). IPv6 accepts masks /32-/128 (ADR-53 Phase 6 — the
- * /32 floor is the same fail-open-typo guard; the Phase 5 pure-PHP set-diff
- * engine is likewise mask-agnostic).
+ * address/mask. IPv4 accepts masks /8-/32, IPv6 accepts masks /32-/128 (ADR-53 §2.3
+ * fork 1 — pure fail-open-typo guards; both carve engines are themselves mask-agnostic).
  *
  * PURE — no config access, no I/O; only the pfSense is_subnetv4()/is_subnetv6()
  * predicates.
@@ -3090,23 +2847,15 @@ function pfb_validate_suppression_line(string $line, string $family): ?string
 }
 
 // ---------------------------------------------------------------------------
-// ADR-53 P5 — pure IPv6 CIDR set-subtraction engine
+// ADR-53 P5 — pure IPv6 CIDR set-subtraction engine. IPv6 suppression can't carve by host
+// enumeration (a /64 minus a /128 hole is 2^64 hosts -- ADR-53 §1.2) and `iprange` mangles v6
+// input outright (parses a v6 literal as a hostname); unlike the v4 engine's `iprange --except`,
+// this is pure-PHP set subtraction over fixed-width 128-bit binary-string ranges, emitting the
+// minimal covering-CIDR remainder via pfSense's REAL ip_range_to_subnet_array() (never
+// redefined here; a faithful double stands in under PHPUnit, tests/php/pfsense_doubles.php).
+// Every binary-string comparison uses strcmp(), NEVER bare </>/<=/>=/min()/max(): a 128-char
+// '0'/'1' string is a PHP "numeric string" and normal comparison risks silent float coercion.
 // ---------------------------------------------------------------------------
-//
-// IPv6 suppression can't carve by host enumeration (a /64 minus a /128 hole is
-// 2^64 hosts -- ADR-53 §1.2) and `iprange` mangles v6 input outright (it parses
-// a v6 literal as a hostname). Unlike the v4 engine (Phase 3's `iprange
-// --except`), this is a pure-PHP set subtraction over fixed-width 128-bit
-// binary-string ranges, emitting the minimal covering-CIDR remainder via
-// pfSense's own ip_range_to_subnet_array() -- the REAL on-appliance function
-// (never redefined here; a faithful double stands in for it under PHPUnit,
-// see tests/php/pfsense_doubles.php).
-//
-// Every binary-string comparison below goes through strcmp(), NEVER the bare
-// <, >, <=, >=, min(), max() operators: a 128-char string of '0'/'1' digits is
-// a PHP "numeric string", and comparing two of those the normal way risks a
-// silent (lossy, float-precision) numeric coercion for a string this long.
-// strcmp() is the only byte-exact comparison for a fixed-width digit string.
 
 /**
  * pfb_v6_cidr_to_range — parse one IPv6 CIDR token ('addr/bits') into its
@@ -3501,17 +3250,14 @@ function pfb_ip_suppressed_match(string $ip, array $entries): ?string
 }
 
 // ---------------------------------------------------------------------------
-// ADR-53 P8 -- Alerts "+" / widget live-punch plan (any mask + v6)
-// ---------------------------------------------------------------------------
-//
-// The Alerts "+" button (and the dashboard widget, which shares its stats
-// read of the same suppression config) used to punch a hole in a live pf
-// table by deleting an exact '/24' and re-adding 254 sibling hosts, refusing
-// anything "blocked by a CIDR other than /24" (ADR-53 §1.2). This replaces
-// that with the same covering-CIDR set-subtraction already proven for the
-// persisted engines (P3's v4 `iprange --except` pass, P5's v6 PHP pass):
-// locate the table entr(y/ies) that actually contain the host, delete them,
+// ADR-53 P8 -- Alerts "+" / widget live-punch plan (any mask + v6). The Alerts "+" button
+// (and the dashboard widget, sharing its stats read) used to punch a hole in a live pf table
+// by deleting an exact '/24' and re-adding 254 sibling hosts, refusing anything "blocked by a
+// CIDR other than /24" (ADR-53 §1.2). This replaces that with the same covering-CIDR
+// set-subtraction already proven for the persisted engines (P3's v4 `iprange --except` pass,
+// P5's v6 PHP pass): locate the table entr(y/ies) that actually contain the host, delete them,
 // and re-add only the covering-CIDR remainder -- any mask, both families.
+// ---------------------------------------------------------------------------
 
 /**
  * pfb_v4_carve_single -- the covering-CIDR remainder of one IPv4 CIDR (or

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -166,8 +166,8 @@ enum PfbAliasDeltaMode: string implements PfbStoredEnum
 
 // PfbTop1mSource — TOP1M source selector (alexa_type, issue #877).
 // Used by alexa_type (config key) / $pfb['dnsbl_top1m_type'] (runtime). Canonical tokens:
-// 'tranco' (default), 'cisco', 'openpagerank' (#928, replacing ADR-59 P4's 'domcop'),
-// 'majestic' (ADR-59 P4), 'cloudflare' (ADR-59 P5, token-authenticated). 'alexa' (#872) and
+// 'tranco' (default), 'cisco', 'openpagerank' (#928, replacing ADR-59's 'domcop'),
+// 'majestic' (ADR-59), 'cloudflare' (ADR-59, token-authenticated). 'alexa' (#872) and
 // 'domcop' (#928) are READ-ONLY legacy tokens, coalesced to their replacement on read — the
 // write vocabulary only ever emits live tokens, so it is downgrade-safe.
 enum PfbTop1mSource: string implements PfbStoredEnum
@@ -259,7 +259,7 @@ function pfb_top1m_providers(): array
 			'label'		=> 'Majestic Million',
 			'licence'	=> 'CC BY 3.0 — attribution required',
 		),
-		// Cloudflare Radar ranking bucket (ADR-59 P5). VERIFIED against Cloudflare's own
+		// Cloudflare Radar ranking bucket (ADR-59). VERIFIED against Cloudflare's own
 		// current docs (developers.cloudflare.com/radar/investigate/domain-ranking-datasets/,
 		// developers.cloudflare.com/api/resources/radar/subresources/datasets/) rather than
 		// the ADR's original 2-column guess:
@@ -292,7 +292,7 @@ function pfb_top1m_providers(): array
 	);
 }
 
-// ADR-59 P5: build the caller header(s) a provider's 'auth' descriptor needs. Pure / no I/O,
+// ADR-59: build the caller header(s) a provider's 'auth' descriptor needs. Pure / no I/O,
 // so it is unit-testable and -- because it never logs -- the token only ever reaches
 // pfb_download()'s CURLOPT_HTTPHEADER, never a log line. 'auth' is 'none' (keyless) or
 // {header, scheme} (Cloudflare's Bearer token); an empty token/keyless provider yields
@@ -709,7 +709,7 @@ function pfb_cfg_registry(): array
 			'since'         => '4.0.0',
 		],
 
-		// ADR-43 P5: optional apply-on-change maintenance window ("HH:MM-HH:MM", local time).
+		// ADR-43: optional apply-on-change maintenance window ("HH:MM-HH:MM", local time).
 		// When set: detected changes outside the window are deferred (pending); the first tick
 		// inside the window applies them. Empty string (default) = apply immediately (no deferral).
 		// Wrapping windows (e.g. "23:00-03:00") span midnight. Malformed = fail-safe (apply now).
@@ -837,7 +837,7 @@ function pfb_cfg_registry(): array
 			'since'         => '1.0.0',
 		],
 
-		// ADR-59 P5: masked, write-only Cloudflare Radar Bearer token -- consumed only
+		// ADR-59: masked, write-only Cloudflare Radar Bearer token -- consumed only
 		// when alexa_type == 'cloudflare' (every other provider ignores it), fed to
 		// pfb_download() via pfb_top1m_auth_headers() + the P3 header-auth plumbing.
 		// Plain string (no adapter): the DNSBL page never echoes the stored value back
@@ -1273,7 +1273,7 @@ function pfb_cfg_registry(): array
 			'since'         => '1.0.0',
 		],
 
-		// ADR-53 P6: IPv6 suppression customlist -- the v4 blob's v6 sibling
+		// ADR-53: IPv6 suppression customlist -- the v4 blob's v6 sibling
 		// (same base64/newline-separated shape). Genuinely new (no pre-registry
 		// era to inherit from v4suppression's), so 'since' is the current
 		// development version rather than a legacy '1.0.0'. Default ''.
@@ -1595,8 +1595,8 @@ function pfb_run_migrations(): void
  * #872) coalesces to Tranco on read, and legacy 'domcop' (list moved hosting,
  * #928) coalesces to OpenPageRank on read; neither is ever re-emitted by a write.
  * The write vocabulary is 'tranco'|'cisco'|'openpagerank'|'majestic'|'cloudflare'
- * (majestic added ADR-59 P4, cloudflare added ADR-59 P5; openpagerank replaced
- * P4's domcop in #928).
+ * (majestic added ADR-59, cloudflare added ADR-59; openpagerank replaced
+ * ADR-59's domcop in #928).
  *
  * @return array<string,list<string>>
  */
@@ -1627,8 +1627,8 @@ function pfb_cfg_field_vocab(): array
 
 		// TOP1M source selector (PfbTop1mSource, issue #877): the tokens a write can
 		// emit. 'tranco' (default) | 'cisco' | 'openpagerank' | 'majestic' | 'cloudflare'
-		// (majestic added ADR-59 P4, cloudflare added ADR-59 P5; openpagerank
-		// replaced P4's domcop in #928). Two
+		// (majestic added ADR-59, cloudflare added ADR-59; openpagerank
+		// replaced ADR-59's domcop in #928). Two
 		// tokens are READ-ONLY legacy values — 'alexa' (dead service, #872) and
 		// 'domcop' (list moved hosting, #928) — pfb_cfg_top1m_source_read() coalesces
 		// them to PfbTop1mSource::Tranco / ::OpenPageRank respectively and neither is
@@ -2519,7 +2519,7 @@ function pfb_tick_seed(): string
 /**
  * pfb_tick_due_jobs — which scheduled jobs are due this tick?
  *
- * Delegates to the Phase-2 due-ledger API for each job. The $now, $seed, and
+ * Delegates to the due-ledger API for each job. The $now, $seed, and
  * $dbdir are injectable so PHPUnit can verify cadence without filesystem or
  * wall-clock dependencies. ss_refresh is not returned — it runs every tick
  * unconditionally (called directly by pfblockerng_tick()).
@@ -2548,7 +2548,7 @@ function pfb_tick_due_jobs(
 }
 
 // ---------------------------------------------------------------------------
-// ADR-43 P5 — apply-on-change maintenance window + pending helpers
+// ADR-43 — apply-on-change maintenance window + pending helpers
 // ---------------------------------------------------------------------------
 
 /**
@@ -2632,7 +2632,7 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir): bool
 }
 
 /**
- * pfblockerng_tick — ADR-43 P5: apply-on-change due-ledger tick dispatcher.
+ * pfblockerng_tick — ADR-43: apply-on-change due-ledger tick dispatcher.
  *
  * Reads the ledger, dispatches each job that is due (feeds, dcc, bl) via exec() as a
  * separate process, then marks each as ran. ss_refresh runs every tick; the scheduled
@@ -2691,7 +2691,7 @@ function pfblockerng_tick(): void
 	// --- Due check ---
 	$due = pfb_tick_due_jobs($now, $seed, $dbdir, $cron_secs, $bl_secs);
 
-	// --- Apply-on-change window (ADR-43 P5) ---
+	// --- Apply-on-change window (ADR-43) ---
 	// Empty window = apply immediately (default). Non-empty = defer outside window.
 	$window = (string) PfbConfig::read('pfb_quiet_hours');
 	$in_win = pfb_quiet_hours_in_window($now, $window);
@@ -2780,7 +2780,7 @@ function pfblockerng_tick(): void
 }
 
 // ---------------------------------------------------------------------------
-// ADR-53 P4 — pure suppression-line validator (v4 mask lift /8-/32)
+// ADR-53 — pure suppression-line validator (v4 mask lift /8-/32)
 // ---------------------------------------------------------------------------
 
 /**
@@ -2847,13 +2847,13 @@ function pfb_validate_suppression_line(string $line, string $family): ?string
 }
 
 // ---------------------------------------------------------------------------
-// ADR-53 P5 — pure IPv6 CIDR set-subtraction engine. IPv6 suppression can't carve by host
+// ADR-53 — pure IPv6 CIDR set-subtraction engine. IPv6 suppression can't carve by host
 // enumeration (a /64 minus a /128 hole is 2^64 hosts -- ADR-53 §1.2) and `iprange` mangles v6
 // input outright (parses a v6 literal as a hostname); unlike the v4 engine's `iprange --except`,
 // this is pure-PHP set subtraction over fixed-width 128-bit binary-string ranges, emitting the
 // minimal covering-CIDR remainder via pfSense's REAL ip_range_to_subnet_array() (never
 // redefined here; a faithful double stands in under PHPUnit, tests/php/pfsense_doubles.php).
-// Every binary-string comparison uses strcmp(), NEVER bare </>/<=/>=/min()/max(): a 128-char
+// Every binary-string comparison uses strcmp(), NEVER bare <, >, <=, >=, min(), max(): a 128-char
 // '0'/'1' string is a PHP "numeric string" and normal comparison risks silent float coercion.
 // ---------------------------------------------------------------------------
 
@@ -3148,7 +3148,7 @@ function pfb_suppress_file_v6(string $file, string $suppfile): bool
 }
 
 // ---------------------------------------------------------------------------
-// ADR-53 P7 — prefix-aware killstates suppression exclusion
+// ADR-53 — prefix-aware killstates suppression exclusion
 // ---------------------------------------------------------------------------
 
 /**
@@ -3188,7 +3188,7 @@ function pfb_ip_suppressed(string $ip, array $entries): bool
 /**
  * pfb_ip_suppressed_match — same coverage test as pfb_ip_suppressed(), but
  * returns the MOST SPECIFIC (longest-prefix) covering entry instead of a
- * bool (issue #422, follow-up to ADR-53 P7/P8). Feeds two Alerts surfaces
+ * bool (issue #422, follow-up to ADR-53). Feeds two Alerts surfaces
  * that need to act on the actual customlist line, not just a yes/no: the
  * un-suppress ('delete_ip') handler (which entry to remove + re-add) and the
  * suppressed-row icon detection in the Alerts render loop.
@@ -3250,7 +3250,7 @@ function pfb_ip_suppressed_match(string $ip, array $entries): ?string
 }
 
 // ---------------------------------------------------------------------------
-// ADR-53 P8 -- Alerts "+" / widget live-punch plan (any mask + v6). The Alerts "+" button
+// ADR-53 -- Alerts "+" / widget live-punch plan (any mask + v6). The Alerts "+" button
 // (and the dashboard widget, sharing its stats read) used to punch a hole in a live pf table
 // by deleting an exact '/24' and re-adding 254 sibling hosts, refusing anything "blocked by a
 // CIDR other than /24" (ADR-53 §1.2). This replaces that with the same covering-CIDR

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -113,7 +113,7 @@ if (
 	pfb_global();
 }
 
-// ADR-29 P2: run all registered upgrade migrations in order. Each migration's apply()
+// ADR-29: run all registered upgrade migrations in order. Each migration's apply()
 // callable reads the section, returns the updated array or NULL (no-op), and the driver
 // writes back and calls write_config() only when a change is needed. Replaces the four
 // hand-wired blocks (ADR-02, PFBL-03, ADR-22, issue #281) with a single ordered registry.

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -100,7 +100,7 @@ if (isset($argv[1])) {
 		pfblockerng_ss_refresh();
 		exit;
 	}
-	// ADR-43 P4: due-ledger trigger-tick. Reads the ledger, dispatches each job
+	// ADR-43: due-ledger trigger-tick. Reads the ledger, dispatches each job
 	// that is due (feeds, dcc, bl), then calls ss_refresh unconditionally (cheap).
 	elseif ($argv[1] == 'tick') {
 		pfblockerng_tick();
@@ -150,7 +150,7 @@ $pfb['extras'][1]['file']	= '';
 $pfb['extras'][1]['folder']	= "{$pfb['geoipshare']}";
 $pfb['extras'][1]['type']	= 'geoip';
 
-// TOP1M database (ADR-59 P1: URL sourced from the provider descriptor table)
+// TOP1M database (ADR-59: URL sourced from the provider descriptor table)
 $pfb_top1m_provider		= pfb_top1m_providers()[$pfb['dnsbl_top1m_type']->value];
 $pfb['extras'][2]			= array();
 $pfb['extras'][2]['url']	= $pfb_top1m_provider['url'];
@@ -160,7 +160,7 @@ $pfb['extras'][2]['file']	= 'top-1m.csv';
 $pfb['extras'][2]['folder']	= "{$pfb['dbdir']}";
 $pfb['extras'][2]['type']	= 'top1m';
 
-// ADR-59 P5: header auth (Cloudflare Radar's Bearer token) via the P3 $feed['headers']
+// ADR-59: header auth (Cloudflare Radar's Bearer token) via the P3 $feed['headers']
 // plumbing. A keyless provider's 'auth' is 'none', so pfb_top1m_auth_headers() returns
 // array() and this is a no-op for tranco/cisco/openpagerank/majestic, exactly as before P5.
 // An empty/absent top1m_token also yields array() -- no Authorization header is sent,

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -73,19 +73,12 @@ if (isset($argv[1])) {
 		pfBlockerNG_clearsqlite('cleardnsbl');
 		exit;
 	}
-	// ADR-12 Phase 1: manual hook-runner test path (unwired from the update
-	// pass). Usage: pfblockerng.php runhooks <pre|post> [trigger]
-	// Runs the configured 'pre'/'post' hooks with a synthetic context so the
-	// runner can be exercised live without performing an update.
-	//
-	// This path does NOT run sync_package_pfblockerng, so NOTHING is updated --
-	// the LIVE post context (incl. the real PFB_CHANGED_IP_ALIASES /
-	// PFB_CHANGED_DNSBL_GROUPS populated from $pfb['changed_ip_aliases'] /
-	// $pfb['changed_dnsbl_groups'], ADR-12 Phase 6) is built only in
-	// pfblockerng.inc's closing tail. Here every post key is a fixed synthetic
-	// value, and both changed lists are '' BECAUSE no pass ran (no alias/group was
-	// updated) -- not a reserved placeholder. PFB_STATUS stays the reserved 'ok'
-	// placeholder there too.
+	// ADR-12: manual hook-runner test path (unwired from the update pass). Usage:
+	// pfblockerng.php runhooks <pre|post> [trigger]. Runs the configured pre/post
+	// hooks with a synthetic context WITHOUT sync_package_pfblockerng (nothing is
+	// updated) -- the real CHANGED_* context is built only in pfblockerng.inc's
+	// closing tail. Both lists are '' here because no pass ran, not a reserved
+	// placeholder; PFB_STATUS stays the reserved 'ok'.
 	elseif ($argv[1] == 'runhooks') {
 		$when = ($argv[2] ?? '') === 'post' ? 'post' : 'pre';
 		$ctx  = array('TRIGGER' => ($argv[3] ?? 'manual-test'));
@@ -255,7 +248,7 @@ if (in_array($argv[1], array('update', 'updateip', 'updatednsbl', 'dc', 'dcc', '
 		case 'update':		// Sync 'Force update' [DEPRECATED — use pfb_trigger scope=both force=false trigger=manual]
 			sync_package_pfblockerng('update');	// deprecation warning logged inside sync_package_pfblockerng
 			break;
-		case 'pfb_trigger':	// ADR-43 Phase 3: explicit {scope, force, trigger} API
+		case 'pfb_trigger':	// ADR-43: explicit {scope, force, trigger} API
 			// Usage: pfblockerng.php pfb_trigger scope=<both|ip|dnsbl> force=<true|false> trigger=<cron|manual|force>
 			$pfb_tscope   = 'both';
 			$pfb_tforce   = FALSE;
@@ -528,10 +521,9 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 		}
 
 		if ($localfile) {
-			// ADR-42 Phase 1: local-file change detection delegated to the extracted helper
-			// pfb_local_feed_changed() (pfblockerng.inc). Behaviour-preserving refactor:
-			// the helper encodes today's mtime + md5-confirm decision (Phase 2 will swap
-			// to xxh128 there without touching this call site).
+			// ADR-42: local-file change detection delegated to pfb_local_feed_changed()
+			// (pfblockerng.inc) -- content-hash (xxh128) gate, mtime removed; pinned by
+			// FeedChangeHashHelpersTest.
 			$pfb['cron_update'] = pfb_local_feed_changed($list_download, $local_file);
 			if (!$pfb['cron_update']) {
 				$log = "[ {$header} ] ( local feed unchanged )\tUpdate not required\n";
@@ -539,26 +531,11 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 			}
 		}
 		else {
-			// ADR-42 Phase 3: replace the HEAD+Last-Modified client-compare and the
-			// whole-feed md5 fallback with a single conditional GET.
-			//
-			// pfb_download() (probe mode, type='change_detect') downloads the body to
-			// {pfborig}/{header}.md5.raw and fills $probe_meta with the response HTTP
-			// status, the response ETag, and the response Last-Modified epoch.  Before
-			// the request it sends If-None-Match (from the stored .etag sidecar) or
-			// CURLOPT_TIMECONDITION/CURLOPT_TIMEVALUE (from the stored .lastmod sidecar),
-			// so a server that supports conditional requests can answer 304 (no body).
-			//
-			// Decision matrix (pfb_conditional_get_decision):
-			//   304 → unchanged (server confirmed; no body was sent; reuse cached .orig).
-			//   200, body_hash == persisted_hash → unchanged (spurious 200; same bytes).
-			//   200, body_hash != persisted_hash → changed (real update; re-ingest).
-			//   200, no persisted_hash → download+hash decides (first run or upgrade).
-			//   error / unknown status → fail-safe (re-ingest; never a false skip).
-			//
-			// The SSRF guard (pfb_feed_host_allowed + CURLOPT_RESOLVE IP-pin) and the
-			// manual redirect revalidation loop stay fully intact because the probe goes
-			// through pfb_download(), not a separate bare curl_init().
+			// ADR-42: replaces the HEAD+Last-Modified compare and whole-feed md5 fallback
+			// with a conditional GET via pfb_download() (probe mode, type='change_detect'),
+			// decided by pfb_conditional_get_decision() (decision matrix documented
+			// there). The SSRF guard + redirect revalidation loop stay intact because the
+			// probe goes through pfb_download(), not a bare curl_init().
 			$probe_meta = array();
 			$probe_ok = pfb_download("{$list_download}", "{$pfborig}/{$header}.md5", $pflex, $header, '', 1, '', 300, 'change_detect', '', '', $srcint, $probe_meta);
 
@@ -679,11 +656,11 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 
 		$file_dwn = "{$feed['folder']}/{$feed['file_dwn']}";
 
-		// ADR-59 Phase 3: thread the per-feed 'headers' field through as caller-supplied
-		// HTTP headers. The TOP1M provider (ADR-59 P5) sets it above via
-		// pfb_top1m_auth_headers() (Cloudflare Radar's Bearer token; array() for every
-		// keyless provider) -- every other feed still leaves it unset, so ?? array()
-		// keeps their downloads unaffected.
+		// ADR-59: thread the per-feed 'headers' field through as caller-supplied HTTP
+		// headers. The TOP1M provider sets it above via pfb_top1m_auth_headers()
+		// (Cloudflare Radar's Bearer token; array() for every keyless provider) --
+		// every other feed leaves it unset, so ?? array() keeps their downloads
+		// unaffected.
 		if (!pfb_download($feed['url'], $file_dwn, FALSE, "{$feed['folder']}/{$feed['file']}", '', $logtype, '', $timeout, $feed['type'],
 		    $feed['username'], $feed['password'], extra_headers: $feed['headers'] ?? array())) {
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1450,22 +1450,12 @@ if (isset($_POST) && !empty($_POST)) {
 			exit;
 		}
 
-		// ADR-06 (#51): DNSBL is built by the Unbound python plugin from the per-feed
-		// manifest (pfb_py_sources.json); the legacy pfb_py_whitelist.txt / pfb_py_data
-		// / pfb_py_zone files this handler once wrote are no longer read by the build,
-		// so writing them was a no-op. The TEMPORARY per-alert Lock/Unlock now toggles
-		// ONLY the pfb_unlock state store ($pfb['dnsbl_unlock']); the resolver effect
-		// comes from regenerating the manifest's config.user_unlock (band-6 user allows,
-		// merged into whiteDB) from that store and reloading Unbound.
-		//
-		// Store toggle: unlock/relock ADD the domain, lock/reunlock REMOVE it --
-		// preserving the four icon states rendered from $dnsbl_unlock (red lock /
-		// primary unlock / warning relock / warning reunlock). user_unlock is recomputed
-		// as the store's domains, so an unlocked (in-store, non-whitelisted) domain
-		// resolves and a re-locked one returns to its feed-blocked state on reload. The
-		// four-way action -> (store-mode, message) dispatch lives in
-		// pfb_dnsbl_unlock_action() (unit-tested); an unknown action has an empty mode
-		// and is a no-op here.
+		// ADR-06 (#51): DNSBL is built by Unbound's python plugin from the per-feed
+		// manifest; the legacy pfb_py_whitelist.txt/pfb_py_data/pfb_py_zone files this
+		// handler once wrote are no longer read, so writing them was a no-op. Lock/Unlock
+		// now only toggles $pfb['dnsbl_unlock']; the resolver effect comes from
+		// regenerating the manifest's config.user_unlock from that store and reloading
+		// Unbound. Dispatch: pfb_dnsbl_unlock_action() (unit-tested); unknown action = no-op.
 		$ua = pfb_dnsbl_unlock_action($action);
 		if ($ua['mode'] !== '') {
 			pfb_unlock($ua['mode'], 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
@@ -1812,10 +1802,10 @@ if ($alert_summary) {
 
 	// Total entry count for this view is constant across every $stat_info
 	// iteration (the log doesn't change mid-loop), so compute it once here
-	// instead of once per iteration (issue #809 Phase 2). The per-iteration
-	// assignment below stays IN the loop body -- if every stat type is hidden
-	// the loop body never runs, so $alert_stats['count'] must stay unset for
-	// this view exactly as it does today.
+	// instead of once per iteration (issue #809). The per-iteration assignment
+	// below stays IN the loop body -- if every stat type is hidden the loop body
+	// never runs, so $alert_stats['count'] must stay unset for this view exactly
+	// as it does today.
 	$alert_log_total_count = file_exists($alert_log) ? (exec("{$pfb['grep']} -c ^ {$alert_log} 2>&1") ?: 0) : 0;
 
 	foreach ($stat_info as $stat_type => $column) {
@@ -1920,9 +1910,9 @@ if ($alert_summary) {
 					$alert_stats[$alert_view]['dnsblgpblock'] = array();
 				}
 			}
-			// The exec is hoisted above the loop (issue #809 Phase 2); this
-			// assignment stays here so an all-hidden $stat_info leaves
-			// $alert_stats['count'] unset for this view, exactly as before.
+			// The exec is hoisted above the loop (issue #809); this assignment
+			// stays here so an all-hidden $stat_info leaves $alert_stats['count']
+			// unset for this view, exactly as before.
 			$alert_stats['count'][$alert_view] = $alert_log_total_count;
 		}
 		else {
@@ -2232,16 +2222,13 @@ function convert_dnsbl_log($mode, $fields) {
 		return TRUE;
 	}
 
-	// Counter/limit gate (issue #809): only the NON-FILTER limit check is
-	// order-independent of the expensive render-time re-check below
-	// (pfb_dnsbl_parse() + the dnsbl_whitelist_type() calls) -- it only reads
-	// $counter/$pfbentries, neither of which the parse produces -- so it is hoisted
-	// here, output-identical to evaluating it after the parse. The filter-mode limit
-	// gate is NOT hoisted and stays after the filter-MATCH gate (restored ahead of the
-	// $counter[...]++ below): on origin/devel it only ever tripped on a row that
-	// PASSED the filter match, so hoisting it here changed the tfoot "Filter Limit"
-	// flag for a post-limit tail of rows that never match the filter (B1, PR #825
-	// review) -- see the "Ordering constraint" note ahead of that gate below.
+	// Counter/limit gate (issue #809): only the non-filter limit check is
+	// order-independent of the render-time re-check below (pfb_dnsbl_parse() +
+	// dnsbl_whitelist_type()), so it is hoisted here, output-identical to
+	// evaluating it after the parse. The filter-mode limit gate stays after the
+	// filter-MATCH gate below -- it only trips on rows that pass the match, so
+	// hoisting it would mis-flag a post-limit tail of non-matching rows (see the
+	// "Ordering constraint" note below in this function).
 	if (!$pfb['filterlogentries'] &&
 		$counter[$mode == 'Unified' && !$pfb['filterlogentries'] ? 'Unified' : 'DNSBL'] >= $pfbentries) {
 		$dnsblfilterlimit = TRUE;
@@ -2291,22 +2278,10 @@ function convert_dnsbl_log($mode, $fields) {
 	$p_group = $p_domain = $p_feed = $p_mode = '';
 	$p_feed_disp = $p_group_disp = '';
 
-	// Collect current details about domain
-	// Skip for upstream blocks: the domain is not in a local feed, so pfb_dnsbl_parse()
-	// would rewrite group/feed/mode to 'Unknown', corrupting the row.
-	// Cost: on a dnsblcache miss this greps the whole DNSBL data file (a de-listed
-	// domain scans all of it), greps the zone file per label, and falls back to a live
-	// drill against the external DNS server — and the cache is wiped on every DNSBL
-	// swap, so post-update loads miss for most rows (alerts-reports-pipeline.md).
-	// issue #809: pfb_dnsbl_parse('alerts', ...) memoizes its full result per domain
-	// and reuses one open dnsblcache SQLite3 handle for the rest of this page load, so
-	// a repeated domain (or a warm cache) no longer pays per-row open/close -- only a
-	// genuinely new domain still runs the grep/zone/drill path above. issue #809 Phase
-	// 3a additionally batches the grep/zone lookups themselves: in non-filter mode the
-	// DNSBL table branch prefetches every displayed row's domain in ONE grep pass per
-	// file (pfb_dnsbl_prefetch()) before this loop runs, so a dnsblcache miss here
-	// consults that seeded result instead of re-executing grep -- the drill fallback
-	// is untouched (still per-domain, only reached on a genuine miss).
+	// Collect current details about domain. Skip for upstream blocks: the domain is
+	// not in a local feed, so pfb_dnsbl_parse() would rewrite group/feed/mode to
+	// 'Unknown', corrupting the row. Cost + memoization + batched-prefetch behaviour:
+	// docs/misc/alerts-reports-pipeline.md.
 	if (!$isPython && !$isUpstream && !$isWhitelist_found) {
 		$domain_details = pfb_dnsbl_parse('alerts', $qdomain, '', '');
 		$pfb_mode	= $domain_details['pfb_mode']	?: 'Unknown';
@@ -2514,14 +2489,12 @@ function convert_dnsbl_log($mode, $fields) {
 	$pfbalertdnsbl[99]	= pfb_hsc($fields[1]);	// Timestamp
 
 	// If alerts filtering is selected, process filters as required.
-	// Ordering constraint: this filter matches the CORRECTED fields ($pfbalertdnsbl is
-	// built from post-pfb_dnsbl_parse values), so the filter-MATCH gate cannot be
-	// hoisted above the parse without changing filter semantics — a feed-name filter
-	// matches the domain's current feed, not the stale logged one. The filter-mode
-	// limit gate below shares that constraint: it only trips AFTER a row passes the
-	// match, so it stays here too (issue #809 only hoists the non-filter limit gate to
-	// the top of this function, since that one is parse-independent — see the comment
-	// there; B1, PR #825 review).
+	// Ordering constraint: this filter matches CORRECTED fields ($pfbalertdnsbl is
+	// built from post-pfb_dnsbl_parse values), so the filter-MATCH gate cannot move
+	// above the parse -- a feed-name filter must match the domain's current feed, not
+	// the stale logged one. The filter-mode limit gate shares that constraint (only
+	// trips after a match); issue #809 hoists only the non-filter limit gate above,
+	// since that one is parse-independent (see the comment there).
 	if ($pfb['filterlogentries']) {
 		if (empty($filterfieldsarray[1])) {
 			return TRUE;
@@ -2926,16 +2899,12 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		return array(TRUE, '');
 	}
 
-	// issue #809 page-scope memos (pfb_render_memo(), pfblockerng.inc): one page load
-	// = one process, so these persist for exactly one render.
-	// - $memos['validate']: the "is the logged IP/CIDR still in its logged feed file"
-	//   validate exec below, keyed by the exact command about to run.
-	// - $memos['miss']: the "where does this host live NOW" miss path (find_reported_header()
-	//   plus the raw aliastables grep), keyed by host+folder -- see the comment at its
-	//   call site for what stays outside the memo.
-	// issue #809 Phase 3b: promoted from two function-statics to the shared accessor
-	// pfb_ip_render_memos() so the batched prefetch pass (pfb_ip_prefetch(), called from
-	// this page's two-pass IP table render) can seed them from OUTSIDE this function.
+	// issue #809: page-scope memos (pfb_render_memo(), pfblockerng.inc) live for one
+	// render. $memos['validate'] caches the "still in its logged feed file" validate
+	// exec, keyed by the exact command; $memos['miss'] caches the "where does this
+	// host live NOW" path (find_reported_header() + raw aliastables grep), keyed by
+	// host+folder. pfb_ip_render_memos() is a shared accessor so pfb_ip_prefetch()
+	// can seed both from outside this function.
 	$memos = &pfb_ip_render_memos();
 
 	$alert_ip = $pfb_query = $pfb_matchtitle = '';
@@ -3009,8 +2978,8 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		$vtype = 4;
 	}
 
-	// IPv4 IP address mask -- relocated up from its original position (issue #809 Phase
-	// 3b): it depends only on $pfb_ipv4/$fields[14], neither of which the derivation below
+	// IPv4 IP address mask -- relocated up from its original position (issue #809):
+	// it depends only on $pfb_ipv4/$fields[14], neither of which the derivation below
 	// touches, and nothing between here and its original site reads $mask, so this is
 	// behaviour-identical.
 	$mask = '';
@@ -3018,11 +2987,11 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		$mask = strstr($fields[14], '/', FALSE) ?: '/32';
 	}
 
-	// issue #809 Phase 3b: the GeoIP/host-selection/ET-header/folder/validate-command
-	// derivation is extracted to pfb_ip_render_query() (pfblockerng.inc) -- a verbatim-
-	// motion refactor so the batched prefetch pass (pfb_ip_prefetch(), called from this
-	// page's two-pass IP table render below) derives the IDENTICAL lookup groups from a
-	// copy of the same $fields, with no separate re-derivation to drift from this one.
+	// issue #809: the GeoIP/host-selection/ET-header/folder/validate-command derivation
+	// is extracted to pfb_ip_render_query() (pfblockerng.inc) -- a verbatim-motion
+	// refactor so the batched prefetch pass (pfb_ip_prefetch(), called from this page's
+	// two-pass IP table render below) derives the IDENTICAL lookup groups from a copy
+	// of the same $fields, with no separate re-derivation to drift from this one.
 	$rq = pfb_ip_render_query($fields);
 
 	$host		= $rq['host'];
@@ -3035,18 +3004,12 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	$hostname['src'] = pfb_hsc($hostname['src']);
 	$hostname['dst'] = pfb_hsc($hostname['dst']);
 
-	// Determine if event IP still exists in Feed Aliastable
-	// Per-row pipeline with no render-time cache (the daemon's ipcache is event-time
-	// only); a miss falls into find_reported_header() — full grep sweeps of the feed
-	// dirs — plus a whole-aliastables grep below, so after a feed update de-lists or
-	// moves entries, most rows take that path (alerts-reports-pipeline.md, issue #809).
-	// Memoized by the exact command about to run: two rows that would exec the
-	// byte-identical find|xargs-grep pipeline share one result for the rest of this
-	// page load. issue #809 Phase 3b: in non-filter mode (or bounded-filter mode) this
-	// key is usually pre-seeded by pfb_ip_prefetch()'s batched validate round, so the
-	// closure below never actually runs for a covered row -- it remains the per-row
-	// fallback for anything the prefetch pass did not cover (the Unified table; any row
-	// it missed).
+	// Determine if event IP still exists in Feed Aliastable. Per-row pipeline with no
+	// render-time cache (the daemon's ipcache is event-time only); a miss falls into
+	// find_reported_header() -- full grep sweeps of the feed dirs -- plus a whole-
+	// aliastables grep below (alerts-reports-pipeline.md, issue #809). Memoized by the
+	// exact command about to run; in non-filter/bounded-filter mode this key is usually
+	// pre-seeded by pfb_ip_prefetch(), so the closure below is the per-row fallback.
 	$validate = '';
 	if ($rq['validate_cmd'] !== NULL) {
 		$validate_cmd = $rq['validate_cmd'];
@@ -4250,13 +4213,12 @@ if (!$alert_summary):
 				'Match'		=> "{$pfb['ip_matchlog']}",
 				'Unified'	=> "{$pfb['unilog']}") as $logtype => $pfb_log ):
 
-		// $pfbentries gets a definite default here (issue #809 Phase 2, same
-		// approach as $folder above): every reachable path below overwrites it
-		// before the post-switch reads (the "Skip table output" gate, the Unified
-		// early-exit call, the <tfoot> message); the only paths that skip those
-		// reads are the `continue 2`s, which never reach them either. The default
-		// makes that provable to PHPStan instead of relying on it to trace the
-		// switch/if/continue control flow.
+		// $pfbentries gets a definite default here (issue #809, same approach as
+		// $folder above): every reachable path below overwrites it before the
+		// post-switch reads (the "Skip table output" gate, the Unified early-exit
+		// call, the <tfoot> message) -- the `continue 2` paths skip those reads too.
+		// The default makes that provable to PHPStan instead of relying on it to
+		// trace the switch/if/continue control flow.
 		$pfbentries = 0;
 
 		// Validate Alert view and Log type
@@ -4363,12 +4325,11 @@ if (!$alert_summary):
 			<tbody>
 	<?php
 			// This loop reads the reversed log via a popen() stream (no on-disk .rev
-			// copy, issue #809 Phase 2) and breaks as soon as
-			// pfb_alerts_unified_scan_done() determines no converter
-			// (convert_dnsbl_log() / convert_dns_reply_log() / convert_ip_log()) can
-			// render another row -- see that helper for the exact non-filter/filter
-			// mode conditions. If any per-type filter-limit knob is 0 (unlimited) its
-			// flag never sets and this still scans to EOF, exactly as before.
+			// copy, issue #809) and breaks as soon as pfb_alerts_unified_scan_done()
+			// determines no converter (convert_dnsbl_log() / convert_dns_reply_log() /
+			// convert_ip_log()) can render another row -- see that helper for the exact
+			// non-filter/filter mode conditions. If any per-type filter-limit knob is 0
+			// (unlimited) its flag never sets and this still scans to EOF, exactly as before.
 			if (($handle = @popen('/usr/bin/tail -r ' . escapeshellarg($pfb_log), 'r')) !== FALSE) {
 				while (($fields = @fgetcsv($handle)) !== FALSE) {
 
@@ -4436,9 +4397,9 @@ if (!$alert_summary):
 			</thead>
 			<tbody>
 	<?php
-			// issue #809 Phase 3a scope guard: batching (below) only ever applies in
-			// non-filter mode. Filtered mode keeps today's single-pass streaming loop --
-			// the Alert-filter match runs against the CORRECTED fields (post
+			// issue #809 scope guard: batching (below) only ever applies in non-filter
+			// mode. Filtered mode keeps today's single-pass streaming loop -- the
+			// Alert-filter match runs against the CORRECTED fields (post
 			// pfb_dnsbl_parse()), so a row can't be pre-collected without parsing it
 			// first; see the "Ordering constraint" note in convert_dnsbl_log() and
 			// docs/misc/alerts-reports-pipeline.md.
@@ -4461,26 +4422,12 @@ if (!$alert_summary):
 					@pclose($handle);
 				}
 			} else {
-				// Non-filter mode: two passes over the reversed log instead of one, so the
-				// DNSBL data/zone-file lookups for every row this render will walk are
-				// batched into at most one grep pass each (pfb_dnsbl_prefetch()) instead of
-				// one exec per row.
-				//
-				// Pass 1 (collect): buffer until $pfbentries + 1 NON-dup lines are seen or
-				// EOF. That "+1" line is exactly the one whose convert_dnsbl_log() call
-				// trips the counter/limit gate and breaks today's loop, so buffering stops
-				// there; lines beyond it are unreachable today too. The '-' duplicate lines
-				// are run-length compressed: their field content is never read anywhere in
-				// the render loop -- only their COUNT feeds the $dup['DNSBL'] badge
-				// accumulator -- so a buffer entry is either a $fields array (non-dup line)
-				// or an integer (length of a consecutive dup run). Real dnsbl.logs are
-				// dup-heavy, so this is what bounds the buffer at <= ($pfbentries + 1)
-				// field arrays plus <= ($pfbentries + 2) integers regardless of log size,
-				// keeping this pass as O(rows-rendered) in memory as the streamed loop it
-				// replaces (which held one line at a time). The append rule itself is
-				// pfb_alerts_dnsbl_buffer_push() (pfblockerng.inc) -- the single source of
-				// this compression arithmetic, unit-pinned by AlertsBufferReplayTest
-				// (issue #809 T2).
+				// Non-filter mode: two passes over the reversed log instead of one, so DNSBL
+				// data/zone-file lookups for every row this render will walk are batched into
+				// at most one grep pass each (pfb_dnsbl_prefetch()) instead of one exec per row.
+				// Pass 1 buffers up to ($pfbentries + 1) non-dup rows, run-length compressing
+				// '-' duplicate lines to an int count -- append rule + bound proof:
+				// pfb_alerts_dnsbl_buffer_push() (pfblockerng.inc), pinned by AlertsBufferReplayTest.
 				$dnsbl_buffered	 = array();
 				$dnsbl_qdomains	 = array();
 				$dnsbl_nondup_seen = 0;
@@ -4516,16 +4463,11 @@ if (!$alert_summary):
 				// pfb_dnsbl_parse_compute() call in pass 2 below transparently consults.
 				pfb_dnsbl_prefetch($dnsbl_qdomains);
 
-				// Pass 2 (render): replay the buffer in the same (reversed) order, decoding
-				// each entry via pfb_alerts_dnsbl_replay_step() (pfblockerng.inc) -- the
-				// same single source the compression above appended through, unit-pinned
-				// by AlertsBufferReplayTest (issue #809 T2). A 'dup' step is a compressed
-				// dup run and replays as one accumulation -- output-identical to the N
-				// individual $dup['DNSBL']++ increments the streamed loop performed for
-				// those N consecutive lines. A 'render' step runs today's exact loop body,
-				// verbatim (its dup-marker check can never fire for a buffered row -- dup
-				// lines were compressed away in pass 1 -- but keeping it keeps the body
-				// identical to the streamed loop's).
+				// Pass 2 (render): replay the buffer in the same (reversed) order via
+				// pfb_alerts_dnsbl_replay_step() (pfblockerng.inc; decode contract documented
+				// there), unit-pinned by AlertsBufferReplayTest -- 'render' steps run today's
+				// exact loop body verbatim (its dup-marker check can never fire for a buffered
+				// row, but keeping it keeps the body identical to the streamed loop's).
 				foreach ($dnsbl_buffered as $dnsbl_entry) {
 
 					$dnsbl_step = pfb_alerts_dnsbl_replay_step($dnsbl_entry);
@@ -4622,20 +4564,14 @@ if (!$alert_summary):
 
 			$p_query_port = '';
 
-			// issue #809 Phase 3b scope guard: batching (below) only runs when a finite row
-			// bound exists -- non-filter mode (bound $pfbentries), or filter mode with a real
-			// per-row limit ($ipfilterlimitentries != 0) AND real filter fields set. Filter
-			// mode with $ipfilterlimitentries == 0 never trips convert_ip_log()'s own limit
-			// check (see its `if ($pfb['filterlogentries'])` branch), so the log is genuinely
-			// scanned to EOF -- an unbounded buffer is not safe to build -- and the degenerate
-			// empty($filterfieldsarray[0]) case (every row short-circuits immediately) both
-			// keep today's single-pass streaming loop verbatim. See
-			// docs/misc/alerts-reports-pipeline.md.
-			// $ipfilterlimitentries is always genuinely set by this point (the
-			// $aglobal_array dynamic ${"$type"} assignment near the top of this file) --
-			// PHPStan just cannot trace that dynamic assignment, so this coalesce is a
-			// runtime no-op that keeps every read below provably defined (same approach
-			// as the $pfbentries/$folder defaults elsewhere in this file, issue #809).
+			// issue #809 scope guard: batching below only runs when a finite row bound
+			// exists -- non-filter mode (bound $pfbentries), or filter mode with a real
+			// per-row limit ($ipfilterlimitentries != 0) AND real filter fields set.
+			// Otherwise the log genuinely scans to EOF (unbounded buffer unsafe), so both
+			// cases keep the single-pass streaming loop. See docs/misc/alerts-reports-pipeline.md.
+			// $ipfilterlimitentries is always genuinely set by this point (the dynamic
+			// ${"$type"} assignment near the top of this file, which PHPStan can't trace);
+			// this coalesce is a runtime no-op that keeps every read below provably defined.
 			$ipfilterlimitentries = $ipfilterlimitentries ?? 0;
 			$ip_two_pass = !$pfb['filterlogentries'] || ($ipfilterlimitentries != 0 && !empty($filterfieldsarray[0]));
 
@@ -4662,43 +4598,13 @@ if (!$alert_summary):
 					@pclose($handle);
 				}
 			} else {
-				// Two passes over the reversed log instead of one, so every buffered row's
-				// render-time IP lookups (validate / miss-header / aliastables) are batched
-				// into a bounded number of grep passes (pfb_ip_prefetch()) instead of one-to-
-				// three exec()s per row.
-				//
-				// Pass 1 (collect): buffer up to and including the row that trips today's
-				// counter/limit gate ($pfbentries + 1 ACCEPTED rows -- in filter mode
-				// "accepted" means it passes pfb_match_filter_field(); in non-filter mode
-				// every non-dup row counts). A buffer entry is one of exactly three shapes:
-				//
-				//   array($fields, TRUE)              -- an accepted row (replayed verbatim);
-				//   int N                             -- a pure run of N consecutive '-'
-				//                                        duplicate-marker lines (Phase 3a
-				//                                        style: content never read, only the
-				//                                        count feeds $dup[$rtype]);
-				//   array('rej' => TRUE, 'dup' => N)  -- a "gap": a mixed run of dup-marker
-				//                                        and REJECTED lines containing >= 1
-				//                                        reject, of which N dup lines came
-				//                                        AFTER the last reject.
-				//
-				// The gap compression is sound because a rejected row's entire effect in
-				// today's streamed loop is CONSTANT and field-independent: convert_ip_log()'s
-				// filter-reject path does exactly `$dup[$rtype] = 0; return array(FALSE, '');`
-				// (nothing else -- no counter, no output), and the caller then assigns
-				// $p_query_port = ''. So within any run between two accepted rows, each reject
-				// wipes whatever dup count preceded it, and only the dups AFTER the LAST
-				// reject survive into the next rendered row's "[N]" badge -- two numbers
-				// (had-a-reject; dups-since-last-reject) reproduce the run's entire effect.
-				// This is what bounds the buffer in FILTER mode too: at most one int-or-gap
-				// entry can sit between consecutive accepted entries (a reject REPLACES a
-				// trailing int run with a gap; later dups/rejects mutate that same gap), so
-				// the buffer holds <= ($pfbentries + 1) field arrays plus <= ($pfbentries + 2)
-				// int/gap entries REGARDLESS of log size or filter selectivity -- O(rows
-				// rendered), never O(rows scanned). The 'dup'/'reject' append rules
-				// themselves are pfb_alerts_ip_buffer_push() (pfblockerng.inc) -- the single
-				// source of this compression arithmetic, unit-pinned by
-				// AlertsBufferReplayTest (issue #809 T2).
+				// Two passes over the reversed log instead of one: render-time IP lookups for
+				// every buffered row are batched via pfb_ip_prefetch() instead of one-to-three
+				// exec()s per row. Buffer entries: array($fields, TRUE) (accepted row), int N
+				// (N dup-marker lines), or array('rej'=>TRUE,'dup'=>N) (a mixed dup/reject run
+				// collapsed to one gap marker). Bound + correctness proof:
+				// docs/misc/alerts-reports-pipeline.md; compression logic is
+				// pfb_alerts_ip_buffer_push() (pfblockerng.inc), pinned by AlertsBufferReplayTest.
 				$ip_buffered	  = array();
 				$ip_accepted_seen = 0;
 				if (($handle = @popen('/usr/bin/tail -r ' . escapeshellarg($pfb_log), 'r')) !== FALSE) {
@@ -4768,28 +4674,12 @@ if (!$alert_summary):
 				}
 				pfb_ip_prefetch($ip_prefetch_rows);
 
-				// Pass 2 (render): replay the buffer in the same (reversed) order, decoding
-				// each entry via pfb_alerts_ip_replay_step() (pfblockerng.inc) -- the same
-				// single source the compression above appended through, unit-pinned by
-				// AlertsBufferReplayTest (issue #809 T2).
-				// - 'dup_add' N: a pure dup run -- one accumulation, output-identical to the N
-				//   individual $dup[$rtype]++ increments the streamed loop performed.
-				// - 'gap' N: a mixed dup/reject run. The streamed loop's net effect for
-				//   [d1 dups][reject]...[last reject][d2 dups] is $dup[$rtype] === d2 (each
-				//   reject RESET the count, then d2 post-reject dups re-accumulated) and
-				//   $p_query_port === '' (every reject returns array(FALSE, '') and the
-				//   caller assigns it) -- so the replay SETS $dup[$rtype] (never +=) to the
-				//   marker's post-last-reject count and clears $p_query_port. Ordering
-				//   matters and is preserved: the pre-reject d1 dups never reach the next
-				//   rendered row's badge, exactly as in the streamed loop.
-				// - 'render' $fields: today's exact loop body, unchanged, over the SAME
-				//   post-dup-pop $fields the streaming loop would have handed
-				//   convert_ip_log() (which transparently consults the batched prefetch
-				//   above via pfb_ip_render_memos(), falling back to its own per-row exec
-				//   for anything Pass 1.5 did not cover).
-				// $rtype is always genuinely set by the case 'alert': switch above (the
-				// only path that reaches this block) -- see the $ipfilterlimitentries
-				// coalesce comment above for why PHPStan needs this spelled out anyway.
+				// Pass 2 (render): replay the buffer in the same (reversed) order via
+				// pfb_alerts_ip_replay_step() (pfblockerng.inc; decode contract documented
+				// there), unit-pinned by AlertsBufferReplayTest -- 'render' rows replay through
+				// the unchanged convert_ip_log() loop body, consulting the batched prefetch via
+				// pfb_ip_render_memos() first. $rtype is always set here (see the
+				// $ipfilterlimitentries coalesce note above; PHPStan can't trace it).
 				$rtype = $rtype ?? '';
 				foreach ($ip_buffered as $ip_entry) {
 					$ip_step = pfb_alerts_ip_replay_step($ip_entry);

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -261,14 +261,14 @@ if (!$alert_summary) {
 
 	PfbConfig::write('v4suppression', PfbConfig::read('v4suppression') ?: '');
 
-	// ADR-53 P8: v6 sibling -- same absent-key normalisation as v4suppression above.
+	// ADR-53: v6 sibling -- same absent-key normalisation as v4suppression above.
 	PfbConfig::write('v6suppression', PfbConfig::read('v6suppression') ?: '');
 
 	PfbConfig::write('suppression', PfbConfig::read('suppression') ?: '');
 
 	PfbConfig::write('tldexclusion', PfbConfig::read('tldexclusion') ?: '');
 
-	// ADR-53 P8: 'ipsuppression_v6' is the new v6suppression sibling of
+	// ADR-53: 'ipsuppression_v6' is the new v6suppression sibling of
 	// 'ipsuppression' (v4) -- same collection shape, keyed separately so the
 	// addsuppress handler below can dedup/rewrite each family's customlist
 	// independently.
@@ -865,7 +865,7 @@ if (isset($_POST) && !empty($_POST)) {
 			// already covered by a BROADER manual suppression entry (e.g. a
 			// /24 already covers this /32) -- appending the exact host on top
 			// would be a redundant customlist entry. Reuses the same
-			// prefix-aware predicate killstates uses (ADR-53 P7) rather than
+			// prefix-aware predicate killstates uses (ADR-53) rather than
 			// re-deriving containment here. The live punch above already ran
 			// (unaffected by this dedup); the suppression file is still
 			// refreshed below so it reflects the covering entry.
@@ -996,7 +996,7 @@ if (isset($_POST) && !empty($_POST)) {
 		}
 
 		// Reload if the Custom_List grew or the domain was stripped from the whitelist.
-		// ADR-10 P5: this is a #51 user custom-list DATA edit -- take the zero-downtime
+		// ADR-10: this is a #51 user custom-list DATA edit -- take the zero-downtime
 		// fast path (no restart). It is an allow->block transition (the domain becomes
 		// blocked), so pass it as the newly-blocked delta for the targeted C-cache flush.
 		if ($cl_added || $wl_removed) {
@@ -1170,7 +1170,7 @@ if (isset($_POST) && !empty($_POST)) {
 			// config.user_whitelist so the next build's whiteDB un-blocks this domain.
 			pfb_unbound_python_whitelist('alerts');
 			pfb_unbound_python_sources_whitelist();
-			// ADR-10 P5: #51 whitelist add is a block->allow DATA edit -> zero-downtime
+			// ADR-10: #51 whitelist add is a block->allow DATA edit -> zero-downtime
 			// fast path (no restart). block->allow is immediate (blocks were never
 			// C-cached since #43), so no newly-blocked delta is passed.
 			pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);
@@ -1424,7 +1424,7 @@ if (isset($_POST) && !empty($_POST)) {
 			if ($dnsbl_py_changes) {
 				pfb_unbound_python_whitelist('alerts');
 				pfb_unbound_python_sources_whitelist();
-				// ADR-10 P5: #51 customlist delete is a DATA edit -> zero-downtime fast
+				// ADR-10: #51 customlist delete is a DATA edit -> zero-downtime fast
 				// path (no restart). Removing a block is block->allow (immediate, no
 				// C-cache flush needed since blocks are not cached, #43).
 				pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);
@@ -1452,7 +1452,8 @@ if (isset($_POST) && !empty($_POST)) {
 
 		// ADR-06 (#51): DNSBL is built by Unbound's python plugin from the per-feed
 		// manifest; the legacy pfb_py_whitelist.txt/pfb_py_data/pfb_py_zone files this
-		// handler once wrote are no longer read, so writing them was a no-op. Lock/Unlock
+		// handler once wrote are not read on the manifest path (only pfb_unbound.py's
+		// legacy CSV fallback still loads them), so writing them was a no-op. Lock/Unlock
 		// now only toggles $pfb['dnsbl_unlock']; the resolver effect comes from
 		// regenerating the manifest's config.user_unlock from that store and reloading
 		// Unbound. Dispatch: pfb_dnsbl_unlock_action() (unit-tested); unknown action = no-op.
@@ -1464,7 +1465,7 @@ if (isset($_POST) && !empty($_POST)) {
 			// reload Unbound so the query-time whiteDB picks up the change.
 			pfb_unbound_python_sources_unlock();
 
-			// ADR-10 P5: #51 Lock/Unlock is a user custom-list DATA edit -> zero-downtime
+			// ADR-10: #51 Lock/Unlock is a user custom-list DATA edit -> zero-downtime
 			// fast path (no restart). pfb_dnsbl_unlock_action() collapses the four icons
 			// onto two store modes: 'lock' (lock/reunlock) REMOVES the domain from the
 			// unlock store -> it returns to feed-blocked = allow->block -> targeted C-cache
@@ -2023,7 +2024,7 @@ function pfb_match_filter_field($flent, $fields) {
    query they make is the freshness re-check: is the logged attribution still true against
    the CURRENT feed/DNSBL state (drift strikethrough + icon decisions). That re-check is
    per-row (shell pipelines, SQLite cycles, a drill fallback) and dominates page load
-   time; the dnsblcache in front of it is wiped on every DNSBL swap (ADR-10 P3), and the
+   time; the dnsblcache in front of it is wiped on every DNSBL swap (ADR-10), and the
    IP path has no render-time cache at all. See the doc before changing lookup ordering
    or caching here. */
 
@@ -5496,7 +5497,7 @@ function ip_suppression() {
 	}
 }
 
-// ADR-53 P8: the "+" now carves the reported host out of WHICHEVER table
+// ADR-53: the "+" now carves the reported host out of WHICHEVER table
 // entry currently contains it, at any mask -- the /32-vs-/24 mask-choice
 // dialog this function used to show is no longer meaningful (the backend
 // never reads a chosen mask, see pfblockerng_alerts.php's addsuppress

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -1172,7 +1172,7 @@ foreach ($rowdata[$rowid] as $tags) {
 		  ->setAttribute('style', $failed_bg)
 		  ->setWidth(3);
 
-		// ADR-31 P5: per-row Deny/Permit action for DNSBL feeds.
+		// ADR-31: per-row Deny/Permit action for DNSBL feeds.
 		// Absent or unrecognised value defaults to 'Deny' (block) — matches the engine default.
 		// Dynamic per-row key (like 'logging') — saved by the rowhelper loop below; not via PfbConfig.
 		if ($gtype == 'dnsbl') {

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -198,7 +198,7 @@ $options_alexa_type		= [ 'tranco' => 'Tranco TOP1M', 'cisco' => 'Cisco Umbrella 
 					    'openpagerank' => 'OpenPageRank TOP1M', 'majestic' => 'Majestic Million TOP1M',
 					    'cloudflare' => 'Cloudflare Radar' ];
 
-// ADR-59 P5: providers whose 'auth' needs the top1m_token field, derived from the
+// ADR-59: providers whose 'auth' needs the top1m_token field, derived from the
 // descriptor table so a future token provider needs no JS edit -- the JS toggle
 // below shows/hides the masked token field based on the selected provider.
 $pfb_top1m_token_providers = [];
@@ -630,7 +630,7 @@ if ($_POST) {
 			$input_errors[] = 'DNSBL IDN Blocking mode is invalid!';
 		}
 
-		// ADR-59 P5: top1m_token is a masked, write-only field -- a blank POST means
+		// ADR-59: top1m_token is a masked, write-only field -- a blank POST means
 		// "leave the stored token unchanged" (never overwrite/clear it), so only a
 		// NON-EMPTY submission is validated. PFB_FILTER_WORD (used by asn_token) would
 		// reject a real base64url/JWT token -- PFB_FILTER_TOKEN accepts that charset.
@@ -3288,7 +3288,7 @@ $section->addInput(new Form_Select(
 	$options_alexa_type
 ))->setHelp('Default: Tranco TOP1M. To change the TOP1M type, select the type and Save, then run an Update -- this clears and re-fetches the list.');
 
-// ADR-59 P5: masked, write-only token for a token-authenticated provider (currently only
+// ADR-59: masked, write-only token for a token-authenticated provider (currently only
 // Cloudflare Radar). Never populated from the stored value -- $pconfig['top1m_token'] is
 // only ever set here from a redisplayed $_POST on a validation error (like every other
 // field), never from PfbConfig::read(), so a plain GET always renders this field blank.
@@ -3668,7 +3668,7 @@ function enable_idn_mode() {
 	}
 }
 
-// ADR-59 P5: providers whose 'auth' needs a token, derived server-side from the
+// ADR-59: providers whose 'auth' needs a token, derived server-side from the
 // descriptor table (pfb_top1m_providers()) -- a future token provider needs no JS edit.
 var pfb_top1m_token_providers = <?=$pfb_top1m_token_providers_json?>;
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
@@ -143,7 +143,7 @@ if ($_POST) {
 		if (!$input_errors) {
 
 			// Rebuild the hooks list from POST, preserving row order. Map each
-			// rowhelper field to the Phase-1 config key the runner consumes.
+			// rowhelper field to the config key the runner consumes.
 			$hooks = array();
 			foreach (array_keys($rowhelper_exist) as $rowid) {
 				$hook = array(

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -163,7 +163,7 @@ if ($_POST) {
 			}
 		}
 
-		// ADR-53 P6: v6 sibling of the v4 validation above. explode() always returns a
+		// ADR-53: v6 sibling of the v4 validation above. explode() always returns a
 		// non-empty array, so (unlike the v4 block above) this skips the vestigial
 		// !empty() wrapper -- avoids replicating the pre-existing PHPStan
 		// empty.variable finding baselined for v4suppression at the same call shape.
@@ -542,7 +542,7 @@ $section->addInput(new Form_Textarea(
 
 $form->add($section);
 
-// Print Custom List TextArea section (ADR-53 P6: v6 sibling of the v4 section above)
+// Print Custom List TextArea section (ADR-53: v6 sibling of the v4 section above)
 $section = new Form_Section('IPv6 Suppression', 'IPv6_Suppression_customlist', COLLAPSIBLE|SEC_CLOSED);
 $suppression_text_v6 = '<strong><u>This suppression list is for [ /32 through /128 ] IPv6 addresses only!</u></strong><br /><br />
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -86,7 +86,7 @@ if ($_POST && isset($_POST['save'])) {
 	exit;
 }
 
-// "Check now" — a manual, explicit cache refresh from our repo, then redisplay. $force=true
+// "Check now" — a manual, explicit cache refresh from the pfBlockerNG repo, then redisplay. $force=true
 // bypasses the "Check for new versions" enable-gate so a one-off check always works.
 if ($pfb_sw_action === 'check') {
 	pfb_software_update_check(TRUE);
@@ -175,7 +175,7 @@ $form->add($section);
 
 $section = new Form_Section('Actions');
 
-// Check now — a local cache refresh from our repo (no network mutation), POSTed below.
+// Check now — a local cache refresh from the pfBlockerNG repo (no network mutation), POSTed below.
 $btn_check = new Form_Button(
 	'pfb_sw_check',
 	'Check now',

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -75,7 +75,7 @@ function pfb_active_task_running(): bool {
 	return pfb_feed_task_running();
 }
 
-// Dispatch pfb_trigger via the Phase-3 explicit API, then update the due ledger so the Schedule
+// Dispatch pfb_trigger via the explicit API, then update the due ledger so the Schedule
 // view reflects the manual run. The page returns immediately; the client polls ?ajax=tail.
 function pfb_runnow(string $scope, bool $force): void {
 	global $pfb;
@@ -180,7 +180,7 @@ if ($_POST) {
 	$pconfig = $_POST;
 }
 
-// Wizard handler (updated to Phase-3 API: scope=both, force=parse).
+// Wizard handler (updated to the explicit API: scope=both, force=parse).
 $pfb_wizard = FALSE;
 if (isset($_GET) && isset($_GET['wizard']) && $_GET['wizard'] == 'reload') {
 	$pconfig['run']            = '';

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -684,7 +684,7 @@ function pfBlockerNG_get_header($mode='') {
 					}
 				}
 
-				// ADR-53 P8: the Suppression count was v4-only ($config_path above
+				// ADR-53: the Suppression count was v4-only ($config_path above
 				// is v4suppression) -- fold in v6suppression too, now that the
 				// Alerts "+" writes v6 entries as well, so the widget stat reflects
 				// the TOTAL suppressed-host count across both families.

--- a/tests/shell/build_repo_help_spec.sh
+++ b/tests/shell/build_repo_help_spec.sh
@@ -1,0 +1,22 @@
+#shellcheck shell=sh
+# build_repo_help_spec.sh — pin build-repo.sh --help to the header it extracts.
+#
+# --help prints the header's Usage/Options/Env block via a self-referential
+# `sed -n '<start>,<end>p' "$0"` line-range literal. That range silently goes
+# stale whenever the header above it grows or shrinks (a comment edit breaks
+# runtime output), so pin the extracted block's load-bearing markers.
+
+Describe 'build-repo.sh --help'
+  SCRIPT="${PFB_ROOT}/scripts/build-repo.sh"
+
+  It 'prints the Usage/Options/Env header block, not code or unrelated prose'
+    When run sh "$SCRIPT" --help
+    The status should equal 0
+    The output should include 'Usage:'
+    The output should include '--print-conf'
+    The output should include 'PKG_BIN'
+    # A stale range drags in non-comment code — a `set -eu` or assignment line.
+    The output should not match pattern '*
+set -eu*'
+  End
+End

--- a/tests/test_comment_narration_check.py
+++ b/tests/test_comment_narration_check.py
@@ -64,6 +64,14 @@ def test_lowercase_phase_number_is_clean() -> None:
     assert _find("src/a.py", ["# TLS handshake phase 2 resumes here"]) == []
 
 
+def test_hyphenated_and_abbreviated_phase_idioms_are_flagged() -> None:
+    # The repo's other narration spellings: "Phase-3" and "ADR-NN PN".
+    assert len(_find("src/a.inc", ["// falls back to the Phase-3 hard rule"])) == 1
+    assert len(_find("src/a.py", ["# ADR-53 P6: token-shape guard"])) == 1
+    assert _find("src/a.py", ["# two-phase-commit protocol, phase-2 resumes"]) == []
+    assert _find("src/a.py", ["# the P6 bus register"]) == []
+
+
 def test_number_needs_trailing_boundary() -> None:
     # "Phase 9x"/"PR #9foo" are not phase/PR references; multi-digit ones are.
     assert _find("src/a.py", ["# gets a Phase 9x speedup"]) == []


### PR DESCRIPTION
## What

The cleanup half of the comment-hygiene work (#959 shipped the preventive gate; this PR un-grandfathers the tree). Comment/docstring-only sweep of every narration site and oversized comment block under `src/` + `scripts/`, per CLAUDE.md "Comments — constraint, not narration":

- All narration sites removed across two passes: ~200 `Phase N` / `RESULTS/` / review-archaeology sites, then the 175 sites in the abbreviated idioms the first pass missed (`ADR-NN PN`, hyphenated `Phase-N`), plus the retired "our repo / our build" framing (16 sites; the Software-tab installed-from-OUR-repos guard keeps its wording deliberately). Constraint wording kept where the sentence carried one; plain `(ADR-NN)` pointers and `issue #NNN` breadcrumbs kept.
- 72 oversized (≥10-line) comment blocks compressed to constraint-plus-pointer form; five factually stale comments fixed against the current call sites; review-precision fixes (legacy CSV-fallback qualifier, operator-list spelling).
- Essential-information restores after owner review: `run-smoke.sh` and `add-repo.sh` operational headers (interface docs with no `--help` equivalent), the build-repo sibling-tool relationship.
- Guardrails hardened en route: `check_comment_narration.py` now catches the hyphenated/abbreviated idioms (red→green tested); a new shellspec pins `build-repo.sh --help` to its header extraction range; CLAUDE.md codifies "compression sheds redundancy, never essential information" + the script-header carve-out.

**Disclosed non-comment line changes (all narration-in-strings or forced by the sweep):** the `build-repo.sh --help` sed line-range literal (pinned by `tests/shell/build_repo_help_spec.sh`), the `build-repo-portable.py` argparse description/epilog phase labels, the `bench_aggregate_union.sh` stdout banner, one `//` comment line inside the JS emitted by `pfblockerng_alerts.php` (token-stream diff shows exactly that one line), and the shared client repo-conf stanza comment across all four byte-identical generators (cross-generator byte-identity test run red with one stale copy, green with all four).

## Evidence (behaviour-preserving — existing suites are the oracle)

- **Code equivalence proven mechanically**: `php -w` token-stream md5 identical to `origin/devel` for `pfblockerng.inc`, `pfblockerng_extra.inc`, `pfblockerng.php` (and `pfblockerng_alerts.php` modulo the one disclosed JS-comment line); docstring-stripped `ast.dump` identical for `pfb_unbound.py`.
- Full gates green after every pass: pytest `2426 passed, 5 skipped`; PHPUnit `2431 tests, 19020 assertions, 5 skipped`; PHPStan `[OK]`; PHPCS clean; ruff/mypy clean; `sh -n` + shellspec on touched scripts.
- Repo-wide scan for `RESULTS/` / `Phase N` / `Phase-N` / `ADR-NN PN` / `review-fanout` / `PR #N` under `src/` + `scripts/`: zero (outside the checker's own exclusions).

no-test-needed: the `www/` changes are comment-text-only — `php -w` token streams are byte-identical to `origin/devel` (sole exception: one JS comment line in the emitted alerts page, disclosed above), so no rendered element, layout, or behaviour can change and the existing Tier-A `ui_render` suite already pins the pages; a new UI test would assert nothing this diff can affect.

Executed by eight Sonnet implementer agents on disjoint file groups under the CLAUDE.md delegation contract (planner-enumerated row matrices, fixed-field handoffs, gates re-derived independently), with a two-lens adversarial review (information-loss + completeness) between the passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)