### PR TITLE
ci: read the no-test-needed label and PR body live in the coverage-pairing gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -630,10 +630,9 @@ jobs:
         # silently always pass. Setting it explicitly makes the exit code of the
         # script (not tee) decide the job result — and the red canary below pins
         # that on every run (CLAUDE.md "CI-gate wiring proves its red path in-job").
-        # PR_BODY arrives via env, never inline ${{ }} in run: — script injection.
         env:
-          WARN_ONLY: ${{ contains(github.event.pull_request.labels.*.name, 'no-test-needed') && '1' || '' }}
-          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           # Red canary: prove ON THIS RUNNER, under THIS block's shell options, that
@@ -646,13 +645,23 @@ jobs:
             echo "::error::coverage-pairing red canary failed: a violating input did not propagate exit 1 through the pipe — fix this step's shell options before trusting the gate"
             exit 1
           fi
+          # LIVE label + body read — never the trigger-time event payload. The
+          # no-test-needed escape is applied AFTER this gate goes red, and a re-run
+          # keeps the original payload, so a payload read makes the failure
+          # message's own remedy impossible without a synthetic push/reopen
+          # (issue #969). A failed fetch leaves WARN_ONLY/body empty = strict
+          # mode: an API hiccup tightens the gate, never skips it.
+          WARN_ONLY=''
+          if gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUM}/labels" --jq '.[].name' 2>/dev/null | grep -qx 'no-test-needed'; then
+            WARN_ONLY=1
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUM}" --jq '.body // ""' > pr_body.txt 2>/dev/null || : > pr_body.txt
           # Escape-hatch justification (issue #921's "applied deliberately" constraint,
           # enforced per #934): with the no-test-needed label set, the PR body is
           # handed to the script (--pr-body-file), which requires a line starting
           # `no-test-needed: <why>` — else it FAILS instead of downgrading. The
           # decision logic lives in the tested script, not in shell (mid-sentence
           # mentions and blockquotes must not count; pinned by its unit tests).
-          printf '%s\n' "$PR_BODY" > pr_body.txt
           python3 scripts/check_coverage_pairing.py ${WARN_ONLY:+--warn-only} ${WARN_ONLY:+--pr-body-file pr_body.txt} < changed.txt | tee -a "$GITHUB_STEP_SUMMARY"
 
   # ── Comment-narration gate (CLAUDE.md "Comments — constraint, not narration") ──

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -606,6 +606,13 @@ jobs:
     name: Coverage pairing (src/tests + www/ui)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    # Job-level override (replaces the workflow-level set entirely): the live
+    # label/body reads need issues+pull-requests read, which the workflow-level
+    # contents+packages grant forces to none (issue #969).
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -645,17 +652,26 @@ jobs:
             echo "::error::coverage-pairing red canary failed: a violating input did not propagate exit 1 through the pipe — fix this step's shell options before trusting the gate"
             exit 1
           fi
-          # LIVE label + body read — never the trigger-time event payload. The
-          # no-test-needed escape is applied AFTER this gate goes red, and a re-run
-          # keeps the original payload, so a payload read makes the failure
-          # message's own remedy impossible without a synthetic push/reopen
-          # (issue #969). A failed fetch leaves WARN_ONLY/body empty = strict
-          # mode: an API hiccup tightens the gate, never skips it.
+          # LIVE label + body read — never the trigger-time event payload. A
+          # payload read breaks the escape hatch twice over (issue #969): a
+          # manual re-run reuses the stale payload, and the `labeled`-event run
+          # snapshots the body BEFORE the justification edit when the label is
+          # applied first. A failed fetch is reported loudly and leaves
+          # WARN_ONLY/body empty = strict mode: an API failure tightens the
+          # gate, never skips it. Label/body content is attacker-influenced but
+          # only ever flows into grep/a file redirect — never eval'd.
           WARN_ONLY=''
-          if gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUM}/labels" --jq '.[].name' 2>/dev/null | grep -qx 'no-test-needed'; then
-            WARN_ONLY=1
+          if labels=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUM}/labels" --jq '.[].name'); then
+            if printf '%s\n' "$labels" | grep -qx 'no-test-needed'; then
+              WARN_ONLY=1
+            fi
+          else
+            echo "::warning::coverage-pairing: label fetch failed — strict mode, the no-test-needed escape is unavailable this run"
           fi
-          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUM}" --jq '.body // ""' > pr_body.txt 2>/dev/null || : > pr_body.txt
+          if ! gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUM}" --jq '.body // ""' > pr_body.txt; then
+            echo "::warning::coverage-pairing: PR body fetch failed — strict mode"
+            : > pr_body.txt
+          fi
           # Escape-hatch justification (issue #921's "applied deliberately" constraint,
           # enforced per #934): with the no-test-needed label set, the PR body is
           # handed to the script (--pr-body-file), which requires a line starting

--- a/scripts/check_comment_narration.py
+++ b/scripts/check_comment_narration.py
@@ -32,7 +32,7 @@ from pathlib import PurePosixPath
 from typing import NamedTuple
 
 _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"RESULTS/"), "delegation handoff artifact (RESULTS/...)"),
+    (re.compile(r"RESULTS[-/]"), "delegation handoff artifact (RESULTS/ or RESULTS-Pn)"),
     # Capitalised only: ADR narration always writes "Phase N"; ordinary prose
     # about a protocol's "phase 2" stays legal.
     (re.compile(r"\bPhase[ -][0-9]+\b"), "ADR phase narration (Phase N)"),

--- a/scripts/check_coverage_pairing.py
+++ b/scripts/check_coverage_pairing.py
@@ -51,7 +51,11 @@ from __future__ import annotations
 
 import sys
 
-_FIX_HINT = "add the paired test, or apply the `no-test-needed` label if none is warranted"
+_FIX_HINT = (
+    "add the paired test, or — if none is warranted — apply the `no-test-needed` label, "
+    "add a `no-test-needed: <why>` line to the PR body, and re-run this check "
+    "(labels/body are re-read live on every run; issue #969)"
+)
 
 
 def _is_docs(path: str) -> bool:

--- a/scripts/parity-guard.sh
+++ b/scripts/parity-guard.sh
@@ -4,14 +4,14 @@
 # After ADR-47 (build path and test path), workflow YAML must route
 # through the shared scripts. Violations are caught by five rules.
 #
-# BUILD RULES (P3):
+# BUILD RULES:
 #   1. build-pkg-portable.py called directly (bypasses build-leg.sh).
 #   2. sparse-clone-ports.sh called directly (bypasses build-leg.sh).
 #   3. An inline-derived arg to build-leg.sh — $(...) or backtick AFTER the
 #      build-leg.sh token on the same line.
 #      Legit: PKG="$(sh scripts/build-leg.sh ...)" has $( BEFORE → not flagged.
 #
-# TEST RULES (P5):
+# TEST RULES:
 #   4. A direct  python[3] -m pytest tests/smoke  call (bypasses run-smoke.sh).
 #      False-positive guard: bare `python -m pytest` with NO tests/smoke path
 #      on the same line (e.g. the unit runner in test.yml) is NOT flagged.

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4131,7 +4131,7 @@ def _dnsbl_reduce_regex(inner: str) -> tuple[bool, str] | None:
 
 
 def _dnsbl_rule_band(rule: Rule) -> int:
-    """The numeric priority band (1-6) for a surviving rule (ADR.md SS2 / the P3
+    """The numeric priority band (1-6) for a surviving rule (ADR.md SS2 / the
     PRIO_* constants). USER -> band 5/6 (sovereign); FEED -> 1/2, +$important ->
     3/4. ``important`` is meaningless for USER rules (they are always sovereign)."""
     user = rule.provenance == RULE_PROV_USER
@@ -4350,7 +4350,7 @@ def reconcile(
             )
         # NOTE: a user rule alone does NOT force ``important_rules`` -- today's fast
         # path already handles a pure user whitelist (important whiteDB) + user
-        # blocks (P3 SS3). The flag is about the feed $important/@@/regex the fast
+        # blocks. The flag is about the feed $important/@@/regex the fast
         # path cannot resolve; once that is set, the numeric branch sees the user
         # bands (5/6) too.
 
@@ -5327,7 +5327,7 @@ def whitelist_lookup_domain(name: str, white_db: dict[str, Any], tld_seg: int) -
     ``www.``-strip, then a parent-suffix walk gated by ``tld_seg`` that only honours
     WILDCARD entries), but also returns the matched entry's ``important`` flag so the
     numeric 6-band resolution can place a user allow in band 6. Behaviour for the
-    boolean ``matched`` result is byte-identical to the pre-P3 function.
+    boolean ``matched`` result is byte-identical to the pre-ABP function.
     """
     entry = white_db.get(name)
     if entry is not None:
@@ -5484,7 +5484,7 @@ class _LruCache:
             self._d.clear()
 
 
-# ADR-07: the 6-band precedence scale (ADR.md SS2 / RESULTS-P2 SS2). Highest wins;
+# ADR-07: the 6-band precedence scale (ADR.md SS2). Highest wins;
 # a block wins iff block_prio > allow_prio (no ties: block in {1,3,5}, allow in {2,4,6}).
 #   6 user allow   5 user block   4 feed allow+important
 #   3 feed block+important   2 feed allow (@@)   1 feed block (||)
@@ -5919,7 +5919,7 @@ def evaluate_domain(
 
     # Resolution stratum. FAST PATH (important_rules False): the historical "a block is
     # found, then an allow overrides it" -- whiteDB checked as a plain override,
-    # byte-for-byte the pre-P3 matcher; this is the path when no ABP @@/regex/$important
+    # byte-for-byte the pre-ABP matcher; this is the path when no ABP @@/regex/$important
     # is loaded. The numeric 6-band resolution is the important_rules==True branch -- it
     # IS reached in production once an ABP feed (or user regex / Custom_List) loads a
     # feed @@ / $important / feed-regex (ADR-07 wired it; not just synthetic tests).

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -18676,7 +18676,7 @@ function sync_package_pfblockerng($cron='') {
 
 			// ADR-40: $pfb_alias_lists is the content-diff set — aliases whose
 			// canonical membership set changed this pass (or ip_unlock forced a re-block).
-			// P4: apply each changed alias via forward delta (or replace per mode/churn).
+			// Apply each changed alias via forward delta (or replace per mode/churn).
 			$final_alias = array_unique($pfb_alias_lists);
 
 			if (!empty($final_alias)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -272,7 +272,7 @@ function pfb_top1m_providers(): array
 		//     'domain' and ONE column per row (no rank) -- domain_col is 0, not 1 (the ADR's
 		//     guess assumed a 2-column rank,domain shape like Tranco/Cisco).
 		//   - Auth: 'Authorization: Bearer <token>' (confirmed on every Radar API page), fed
-		//     via pfb_top1m_auth_headers() below + the P3 $feed['headers'] plumbing.
+		//     via pfb_top1m_auth_headers() below + the $feed['headers'] plumbing.
 		//   - Licence: CC BY-NC 4.0 (developers.cloudflare.com/radar/ "About" -- confirmed by
 		//     web search, non-commercial use, attribution required).
 		// Residual verification gap (disclosed, not hidden): no live authenticated request was
@@ -839,7 +839,7 @@ function pfb_cfg_registry(): array
 
 		// ADR-59: masked, write-only Cloudflare Radar Bearer token -- consumed only
 		// when alexa_type == 'cloudflare' (every other provider ignores it), fed to
-		// pfb_download() via pfb_top1m_auth_headers() + the P3 header-auth plumbing.
+		// pfb_download() via pfb_top1m_auth_headers() + the header-auth plumbing.
 		// Plain string (no adapter): the DNSBL page never echoes the stored value back
 		// on GET, and a blank POST preserves the existing value rather than clearing it
 		// (pfblockerng_dnsbl.php's save handler) -- see PFB_FILTER_TOKEN (pfblockerng.inc)
@@ -3254,8 +3254,8 @@ function pfb_ip_suppressed_match(string $ip, array $entries): ?string
 // (and the dashboard widget, sharing its stats read) used to punch a hole in a live pf table
 // by deleting an exact '/24' and re-adding 254 sibling hosts, refusing anything "blocked by a
 // CIDR other than /24" (ADR-53 §1.2). This replaces that with the same covering-CIDR
-// set-subtraction already proven for the persisted engines (P3's v4 `iprange --except` pass,
-// P5's v6 PHP pass): locate the table entr(y/ies) that actually contain the host, delete them,
+// set-subtraction already proven for the persisted engines (the v4 `iprange --except` pass,
+// the v6 PHP pass): locate the table entr(y/ies) that actually contain the host, delete them,
 // and re-add only the covering-CIDR remainder -- any mask, both families.
 // ---------------------------------------------------------------------------
 
@@ -3265,7 +3265,7 @@ function pfb_ip_suppressed_match(string $ip, array $entries): ?string
  * sibling of pfb_cidr_subtract_v6(), scoped to the one-entry/one-hole shape
  * the live punch actually needs -- pfb_cidr_subtract_v6() stays the only
  * general multi-hole engine (the v4 persisted engine already has its own for
- * that, P3's `iprange --except`). A v4 range fits a plain PHP int (32 bits,
+ * that, `iprange --except`). A v4 range fits a plain PHP int (32 bits,
  * ip2long32() already returns it unsigned on 64-bit PHP), so no
  * binary-string arithmetic is needed here.
  *

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -160,9 +160,9 @@ $pfb['extras'][2]['file']	= 'top-1m.csv';
 $pfb['extras'][2]['folder']	= "{$pfb['dbdir']}";
 $pfb['extras'][2]['type']	= 'top1m';
 
-// ADR-59: header auth (Cloudflare Radar's Bearer token) via the P3 $feed['headers']
+// ADR-59: header auth (Cloudflare Radar's Bearer token) via the $feed['headers']
 // plumbing. A keyless provider's 'auth' is 'none', so pfb_top1m_auth_headers() returns
-// array() and this is a no-op for tranco/cisco/openpagerank/majestic, exactly as before P5.
+// array() and this is a no-op for tranco/cisco/openpagerank/majestic — their behaviour is unchanged.
 // An empty/absent top1m_token also yields array() -- no Authorization header is sent,
 // so a missing token fails the download safely (pfblockerng_top1m()'s #886 preserve+warn
 // path keeps the previous TOP1M whitelist) rather than sending a malformed header.

--- a/tests/test_comment_narration_check.py
+++ b/tests/test_comment_narration_check.py
@@ -52,6 +52,10 @@ def test_results_word_without_slash_is_clean() -> None:
     assert _find("src/a.inc", ["// the RESULTS are cached"]) == []
 
 
+def test_slashless_results_handoff_ref_is_flagged() -> None:
+    assert len(_find("src/a.py", ["# the 6-band scale (RESULTS-P2 SS2)"])) == 1
+
+
 def test_capital_phase_number_is_flagged() -> None:
     v = _find("src/a.py", ["# wired into init() in Phase 4"])
     assert len(v) == 1

--- a/tests/test_coverage_pairing_check.py
+++ b/tests/test_coverage_pairing_check.py
@@ -28,6 +28,13 @@ def test_src_only_no_tests_fires_rule1() -> None:
     assert "tests/**" in violations[0], f"rule-1 message must name tests/**; got {violations[0]!r}"
 
 
+def test_violation_message_says_rerun_after_labeling() -> None:
+    # issue #969: the remedy must work as written — labels/body are re-read live,
+    # so the hint tells the author a plain re-run suffices after labeling.
+    violations = ccp.evaluate(["src/usr/local/pkg/pfblockerng/pfblockerng.inc"])
+    assert "re-run this check" in violations[0], f"hint must say re-run works; got {violations[0]!r}"
+
+
 def test_src_with_paired_test_passes() -> None:
     # Discriminating sibling of the above: adding the paired test clears rule 1.
     violations = ccp.evaluate(["src/usr/local/pkg/pfblockerng/pfblockerng.inc", "tests/test_x.py"])


### PR DESCRIPTION
Fixes #969.

## Root cause (hit on PR #967)

The `coverage-pairing` job computed `WARN_ONLY` and `PR_BODY` from `${{ github.event.pull_request.labels }}` / `...body` — the event payload **frozen at trigger time**. Two holes: a manual re-run reuses the stale payload, and the `labeled`-event run snapshots the body *before* the justification edit when the label is applied first (the ordering race actually observed on #967). Only a close/reopen made the escape hatch take.

## Fix

- The job now fetches the label set and PR body **live** via `gh api` inside the run step, with a job-level `issues: read` + `pull-requests: read` grant (the workflow-level `contents+packages` block forces unlisted scopes to `none` — the first cut of this fix would have 403'd silently; caught by the adversarial review).
- **Fail-closed and loud:** a failed fetch emits a `::warning` and runs strict — an API failure tightens the gate, never skips it.
- The script's fix hint now says a plain re-run suffices after labeling (pinned by `test_violation_message_says_rerun_after_labeling`, executed red→green).
- Rides along: the #967 post-merge tail-audit cleanup — 14 residual bare `Pn`/`RESULTS-Pn` narration tokens reworded (constraints kept), checker's RESULTS pattern widened to the slashless form (red→green tested).

## Evidence

- Wiring exercised locally against a stubbed `gh` across all four paths (strict / downgrade / unjustified-label fail / 403 loud+strict).
- **Live proof on this very PR**: run 28928585030's coverage-pairing job shows the fetches succeeding (no `::warning`) and the correct strict rule-2 verdict before the label below was applied; the labeled-triggered run demonstrates the escape hatch end-to-end.
- Gates: full pytest `2428 passed, 5 skipped`; PHPUnit `2431/19020, 5 skipped`; PHPStan `[OK]`; PHPCS clean; ruff/mypy clean; workflow YAML parses.

no-test-needed: the `www/` file in this diff (`pfblockerng.php`) changes comment text only — narration-token rewords from the #967 tail audit; no rendered element or behaviour can change, and the existing Tier-A `ui_render` suite already pins the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)