### PR TITLE
docs: add release notes for v4.0.0.alpha.20

### DIFF
--- a/docs/release-notes/v4.0.0.alpha.20.md
+++ b/docs/release-notes/v4.0.0.alpha.20.md
@@ -1,0 +1,53 @@
+<!-- SUMMARY: TOP1M providers refresh -->
+
+## Features
+
+- Add **Majestic** and **Cloudflare Radar** as new keyless/token-based Top1M
+  providers ([#928](https://github.com/pfBlockerNG/pfBlockerNG/issues/928)).
+
+## Improvements
+
+- Replace the discontinued **DomCop** Top1M provider with **OpenPageRank**
+  ([#928](https://github.com/pfBlockerNG/pfBlockerNG/issues/928)).
+- Rename **Alexa to Top1M** throughout the UI, drop Alexa as a source (the
+  service has long been discontinued), and coalesce existing configurations
+  to Tranco ([#877](https://github.com/pfBlockerNG/pfBlockerNG/issues/877)).
+- Refresh **TLD Allow lists** directly from IANA with a dynamic count instead
+  of a static bundled list
+  ([#876](https://github.com/pfBlockerNG/pfBlockerNG/issues/876)).
+- Stream install/upgrade hook output live to the pkg Software page, and
+  stream command-line run progress to STDOUT.
+- **Mask the MaxMind license key field** in the web UI — write-only, blank
+  keeps the existing value
+  ([#924](https://github.com/pfBlockerNG/pfBlockerNG/issues/924)).
+- Support **UTF-16/UTF-32 BOM-encoded feeds**, auto-transcoded to UTF-8, and
+  strip stray UTF-8 BOMs before DNSBL classification.
+- Parse bracketed IPv6 literals in DNSBL feeds.
+- Accept punycode TLDs and case-fold TLD matching in the Top1M CSV-mode
+  hostname guard ([#904](https://github.com/pfBlockerNG/pfBlockerNG/issues/904),
+  [#920](https://github.com/pfBlockerNG/pfBlockerNG/issues/920)).
+
+## Bug Fixes
+
+- Fix the Custom Source/Destination alias autocomplete on the IP, DNSBL, and
+  Feed pages (Host aliases never appeared in the dropdown), and stop the
+  DNSBL page from silently resetting those fields on save
+  ([#881](https://github.com/pfBlockerNG/pfBlockerNG/issues/881)).
+- Open the DNSBL stats database on a control-channel enable, so DNSBL stats
+  are recorded correctly
+  ([#870](https://github.com/pfBlockerNG/pfBlockerNG/issues/870)).
+- Recover cleanly from a corrupted Top1M stats database, including stale
+  WAL/SHM sidecar files
+  ([#900](https://github.com/pfBlockerNG/pfBlockerNG/issues/900)).
+- Redact query-string and userinfo credentials when logging feed download
+  URLs ([#890](https://github.com/pfBlockerNG/pfBlockerNG/issues/890)).
+- Preserve the Top1M whitelist and warn instead of silently emptying it on a
+  failed/empty feed; fix the stale Force-Reload help text
+  ([#886](https://github.com/pfBlockerNG/pfBlockerNG/issues/886)).
+- Guard the Advanced alias validator against array POST values and reject
+  reserved table names.
+- Clarify which Top1M hostname guard applies to which parse mode, and harden
+  the rank/domain field regex
+  ([#954](https://github.com/pfBlockerNG/pfBlockerNG/issues/954)).
+
+**Full changelog:** [`v4.0.0.alpha.19` → `v4.0.0.alpha.20`](https://github.com/pfBlockerNG/pfBlockerNG/compare/v4.0.0.alpha.19...v4.0.0.alpha.20)


### PR DESCRIPTION
Adds hand-authored release notes for `v4.0.0.alpha.20`, following `scripts/release-notes-prompt.txt`'s prompt so the release workflow's GitHub Models step is skipped in favor of this committed file.

Docs-only change (CI is skipped via `paths-ignore`).

## Test plan

- [x] `npx markdownlint-cli2 docs/release-notes/v4.0.0.alpha.20.md` → 0 errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01TNM71rSfK3zUy4srGJfFxP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for `v4.0.0.alpha.20` with a summary of updates and a link to the full changelog.
  * Highlighted new features, improvements, and bug fixes, including provider updates, UI/source changes, feed parsing and encoding support, and fixes for DNSBL and stats database issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->