### PR TITLE
docs: fix release-notes casing per Copilot review (PR #971)

### DIFF
--- a/docs/release-notes/v4.0.0.alpha.20.md
+++ b/docs/release-notes/v4.0.0.alpha.20.md
@@ -1,4 +1,4 @@
-<!-- SUMMARY: TOP1M providers refresh -->
+<!-- SUMMARY: Top1M providers refresh -->
 
 ## Features
 
@@ -9,7 +9,7 @@
 
 - Replace the discontinued **DomCop** Top1M provider with **OpenPageRank**
   ([#928](https://github.com/pfBlockerNG/pfBlockerNG/issues/928)).
-- Rename **Alexa to Top1M** throughout the UI, drop Alexa as a source (the
+- Rename **Alexa** to **Top1M** throughout the UI, drop Alexa as a source (the
   service has long been discontinued), and coalesce existing configurations
   to Tranco ([#877](https://github.com/pfBlockerNG/pfBlockerNG/issues/877)).
 - Refresh **TLD Allow lists** directly from IANA with a dynamic count instead


### PR DESCRIPTION
Follow-up to #971 (merged before Copilot's review landed): applies its two nitpicks to `docs/release-notes/v4.0.0.alpha.20.md`.

- `SUMMARY` marker now matches the "Top1M" casing used throughout the rest of the file (was "TOP1M").
- Narrow the bold span in the Alexa→Top1M bullet to just the product names, not "Alexa to Top1M" as one span.

Docs-only change (CI is skipped via `paths-ignore`).

## Test plan

- [x] `npx markdownlint-cli2 docs/release-notes/v4.0.0.alpha.20.md` → 0 errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01TNM71rSfK3zUy4srGJfFxP)_