### PR TITLE
pfblockerng: fix Logs tab textarea escaping and editability

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -257,7 +257,10 @@ if (isset($_REQUEST) && isset($_REQUEST['ajax'])) {
 					continue;
 				}
 
-				$data .= htmlspecialchars($line, ENT_NOQUOTES);
+				// Raw: this only ever feeds the #fileContent <textarea> via JS .val()
+				// (never HTML-parsed). A future .html()/innerHTML consumer must escape
+				// at that point instead.
+				$data .= $line;
 				$linecnt++;
 			}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -442,7 +442,7 @@ $section->addInput(new Form_Textarea(
 	NULL,
 	''
 ))->removeClass('form-control')->addClass('row-fluid col-sm-12')->setAttribute('rows', '30')->setAttribute('wrap', 'off')
-  ->setAttribute('style', 'background:#fafafa; width: 100%');
+  ->setAttribute('style', 'background:#fafafa; width: 100%')->setAttribute('readonly', 'readonly');
 
 // Scroll to end of page when loading logs
 $section->addInput(new Form_StaticText(

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -442,7 +442,7 @@ $section->addInput(new Form_Textarea(
 	NULL,
 	''
 ))->removeClass('form-control')->addClass('row-fluid col-sm-12')->setAttribute('rows', '30')->setAttribute('wrap', 'off')
-  ->setAttribute('style', 'background:#fafafa; width: 100%')->setAttribute('readonly', 'readonly');
+  ->setAttribute('readonly', 'readonly')->setAttribute('style', 'background:#fafafa; width: 100%');
 
 // Scroll to end of page when loading logs
 $section->addInput(new Form_StaticText(

--- a/tests/smoke/ui/test_log.py
+++ b/tests/smoke/ui/test_log.py
@@ -204,8 +204,9 @@ def _decode_load_body(body: str) -> tuple[str, str]:
     """Parse the ``|code|info|base64|`` AJAX envelope -> ``(code, decoded_text)``.
 
     The handler prints ``|<code>|<info>|<base64-of-content>|``; on the load path
-    code '0' is success and the third field is base64 of the file's (html-escaped)
-    bytes. Mirrors the page's JS (``responseText.split('|')`` then ``atob``).
+    code '0' is success and the third field is base64 of the file's raw bytes
+    (verbatim, no HTML-escaping). Mirrors the page's JS (``responseText.split('|')``
+    then ``atob``).
     """
     parts = body.split("|")
     # parts[0] is the leading '' before the first '|'; [1]=code, [2]=info, [3]=b64.
@@ -251,6 +252,77 @@ def test_load_returns_real_file_content(webui: WebUI, smoke_vm: helpers.SmokeVM)
             f"load body content {decoded!r} != on-box file {_cat(vm, target)!r} (handler must return the real file)"
         )
         assert marker in decoded, f"seeded marker missing from the loaded content: {decoded!r}"
+    finally:
+        _rm(vm, target)
+
+
+def test_load_does_not_html_escape_content(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """``act=load`` returns bytes verbatim -- no HTML-entity substitution.
+
+    Regression pin: the handler used to htmlspecialchars() each line before
+    base64-encoding it, even though the only consumer is the #fileContent
+    <textarea>'s JS ``.val()`` -- a plain-text sink that never decodes entities, so
+    the escape only ever produced literal "&lt;"/"&gt;" text on screen. Seeds a
+    line carrying every char htmlspecialchars would touch and asserts the decoded
+    body is byte-identical to the on-box file, not an escaped variant.
+    """
+    vm = smoke_vm
+    target = _throwaway_log("pfblockerng.log")
+    marker = helpers.unique_domain("esc")
+    expected = f"<{marker}> & \"quoted\" 'single'\n"
+    _seed_file(vm, target, expected)
+    try:
+        assert _cat(vm, target) == expected, "seed line not present on the box before load"
+
+        token = _csrf(webui)
+        resp = _post_load(webui, token, target)
+        assert not looks_like_login_page(resp.text), "load POST returned the login form (session lost)"
+        code, decoded = _decode_load_body(resp.text)
+        assert code == "0", f"load did not report success: envelope={resp.text!r}"
+        assert decoded == expected, (
+            f"load body {decoded!r} != raw seeded content {expected!r} "
+            "(handler must not HTML-escape -- the textarea sink never decodes entities)"
+        )
+        assert "&lt;" not in decoded and "&gt;" not in decoded and "&amp;" not in decoded, (
+            f"load body still HTML-escaped: {decoded!r}"
+        )
+    finally:
+        _rm(vm, target)
+
+
+def test_load_does_not_double_escape_write_time_escaped_lines(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """``act=load`` must not add a SECOND escape layer atop write-time-escaped lines.
+
+    ``pfb_validate_log_line()`` (ADR-48, pfblockerng.inc) already htmlspecialchars()s
+    reject-line fields at WRITE time for pfblockerng.log/error.log -- that write-time
+    escape is untouched by this fix and stays correct. Before this fix, load()'s OWN
+    htmlspecialchars() ran a SECOND time over that already-escaped text, turning
+    "&lt;" into "&amp;lt;" -- a genuine double-escape distinct from the never-escaped
+    case above. Seeds a line shaped like pfb_validate_log_line's output (pre-escaped
+    '&lt;'/'&amp;') and asserts it survives load() with no additional escaping.
+    """
+    vm = smoke_vm
+    target = _throwaway_log("error.log")
+    marker = helpers.unique_domain("dblesc")
+    # Mirrors pfb_validate_log_line()'s write-time-escaped shape for a REJECT line
+    # whose detail field originally contained '<' '>' '&'.
+    expected = f"pfb_validate: REJECT feed=x stage=y reason=z detected=&lt;{marker}&gt; &amp; done\n"
+    _seed_file(vm, target, expected)
+    try:
+        assert _cat(vm, target) == expected, "seed line not present on the box before load"
+
+        token = _csrf(webui)
+        resp = _post_load(webui, token, target)
+        assert not looks_like_login_page(resp.text), "load POST returned the login form (session lost)"
+        code, decoded = _decode_load_body(resp.text)
+        assert code == "0", f"load did not report success: envelope={resp.text!r}"
+        assert decoded == expected, (
+            f"load body {decoded!r} != raw seeded content {expected!r} "
+            "(handler re-escaped an already-escaped line -- double escape regression)"
+        )
+        assert "&amp;lt;" not in decoded and "&amp;amp;" not in decoded, (
+            f"load body double-escaped the write-time-escaped line: {decoded!r}"
+        )
     finally:
         _rm(vm, target)
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -405,6 +405,7 @@ def test_ip_page_never_leaks_maxmind_key(
 
 _UPDATE_PAGE = "/pfblockerng/pfblockerng_update.php"
 _HOOKS_PAGE = "/pfblockerng/pfblockerng_hooks.php"
+_LOG_PAGE = "/pfblockerng/pfblockerng_log.php"
 
 
 def test_update_hooks_subtab_relocation(webui: WebUI) -> None:
@@ -512,6 +513,27 @@ def test_update_log_textareas_are_readonly(webui: WebUI) -> None:
         assert m is not None, f"update page is missing the '{name}' textarea"
         tag = m.group(0)
         assert re.search(r"\breadonly\b", tag), f"'{name}' textarea is editable (no readonly): {tag}"
+
+
+def test_log_page_textarea_is_readonly(webui: WebUI) -> None:
+    """The Logs page's file-content viewer is display-only — it renders readonly.
+
+    Same footgun as the Update page's log windows (see
+    ``test_update_log_textareas_are_readonly``): 'fileContent' is populated by the
+    load AJAX action, not typed into, so an editable textarea let a user
+    accidentally cut/type into it with no effect on the underlying file. It must
+    carry the readonly attribute.
+
+    Given the rendered Log page,
+    When the fileContent textarea opening tag is located,
+    Then it contains the readonly attribute. (Pre-fix the tag had no readonly, so
+      this assertion FAILS on the old markup and passes only after it.)
+    """
+    body = webui.get(_LOG_PAGE).text
+    m = re.search(r"<textarea\b[^>]*\bname=([\"'])fileContent\1[^>]*>", body)
+    assert m is not None, "log page is missing the 'fileContent' textarea"
+    tag = m.group(0)
+    assert re.search(r"\breadonly\b", tag), f"'fileContent' textarea is editable (no readonly): {tag}"
 
 
 def test_update_ajax_tail_returns_wellformed_json(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:


### PR DESCRIPTION
## Summary

Two independent bugs in the Logs tab's file viewer (`pfblockerng_log.php`), found while triaging a user report of literal `&lt;`/`&gt;` text in a log entry:

- **Escaping**: the `act=load` AJAX handler ran every line through `htmlspecialchars()` before base64-encoding it, but the only consumer is the `#fileContent` `<textarea>`'s JS `.val()` — a plain-text sink that never decodes HTML entities. Net effect: raw content (e.g. an unescaped Python exception repr) rendered as literal `&lt;...&gt;` text on screen, and content already escaped once at write time (`pfb_validate_log_line`, ADR-48) got escaped a second time. Fix: stop escaping at read time — `.val()` never needed it, and any future `.html()`/`innerHTML` consumer should escape at that point instead (documented inline).
- **Editability**: the viewer toggled jQuery's `disabled` prop, never `readonly`, so a successfully-loaded log was fully editable — a user could delete/type over the displayed content. Same fix already exists for the Update page's `pfb_status`/`pfb_output` viewers (`test_update_log_textareas_are_readonly`); this mirrors it for the Logs tab.

## Test plan

- [x] `php -l`, `vendor/bin/phpcs`, `vendor/bin/phpstan`, `vendor/bin/phpunit` all clean
- [x] `ruff check`/`ruff format --check`/`mypy tests/` clean
- [x] Red→green proven via live-VM CI dispatch (not just local reasoning):
  - Escape fix: `test_load_does_not_html_escape_content` + `test_load_does_not_double_escape_write_time_escaped_lines` FAILED pre-fix (run [28933938931](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28933938931)) with the exact expected `&lt;`/`&amp;lt;` mismatch, PASSED post-fix (run [28934417282](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28934417282))
  - Readonly fix: `test_log_page_textarea_is_readonly` FAILED pre-fix (same run 28934417282, pasted the real rendered markup with no `readonly` attribute), PASSED post-fix (run [28934692696](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28934692696))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Log file contents now display correctly without unwanted HTML escaping or double-escaping.
  * The log viewer’s text area is now clearly read-only, reducing the chance of accidental edits.

* **Tests**
  * Added end-to-end checks to confirm log content is shown exactly as stored.
  * Added coverage to verify the log viewer remains read-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->