### PR TITLE
pfblockerng: stop HTML-escaping pfb_validate_log_line() reject lines

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -877,13 +877,15 @@ function pfb_archive_missing_tool(string $canonical_type, ?callable $checker = N
 // greppable line naming feed/stage/reason + raw detected detail. $stage is one of
 // mime|structural|inner|member|plaintext|entries (caller-owned vocabulary, unvalidated here).
 // Shape: "\npfb_validate: REJECT feed=<feed> stage=<stage> reason=<reason> detected=<detail>"
-// (leading "\n" per pfb_logger() convention). Each value is escaped independently: control
-// bytes -> space (blocks forging/splitting the line via attacker-influenced detail), then
-// htmlspecialchars(). Pure: string in, string out, no I/O, no globals.
+// (leading "\n" per pfb_logger() convention). Each value has control bytes -> space (blocks
+// forging/splitting the line via attacker-influenced detail) — HTML-escaping is NOT applied
+// here: the sole renderer of this line (the Logs tab's #fileContent textarea) never parses
+// HTML, so escaping here only mangled the operator's view of the real bytes. Pure: string in,
+// string out, no I/O, no globals.
 function pfb_validate_log_line(string $feed, string $stage, string $reason, string $detail = ''): string {
 	[$feed, $stage, $reason, $detail] = array_map(
 		static function (string $value): string {
-			return htmlspecialchars(preg_replace('/[\x00-\x1F\x7F]/', ' ', $value) ?? '');
+			return preg_replace('/[\x00-\x1F\x7F]/', ' ', $value) ?? '';
 		},
 		[$feed, $stage, $reason, $detail]
 	);

--- a/tests/php/PfbValidateLogLineTest.php
+++ b/tests/php/PfbValidateLogLineTest.php
@@ -13,19 +13,20 @@ use PHPUnit\Framework\TestCase;
  *
  *   \npfb_validate: REJECT feed=<feed> stage=<stage> reason=<reason> detected=<detail>
  *
- * Every one of the four values is escaped independently: control bytes in
- * [\x00-\x1F\x7F] are first neutralised to a single space (these values may carry
- * attacker-influenced file(1) output, and a raw "\n"/"\r" would forge or split the
- * greppable line), THEN htmlspecialchars() is applied. Pure function: string in,
- * string out, no I/O, no globals.
+ * Every one of the four values has control bytes in [\x00-\x1F\x7F] neutralised to a
+ * single space (these values may carry attacker-influenced file(1) output, and a raw
+ * "\n"/"\r" would forge or split the greppable line). No HTML-escaping is applied: the
+ * sole renderer (the Logs tab's #fileContent textarea) never parses HTML, so the raw
+ * bytes are preserved for an accurate operator view. Pure function: string in, string
+ * out, no I/O, no globals.
  */
 #[CoversFunction('pfb_validate_log_line')]
 final class PfbValidateLogLineTest extends TestCase
 {
 	// --- Canonical shape, one exact-string oracle per stage token in the fixed
 	// vocabulary (mime | structural | inner | member | plaintext | entries). None of
-	// these values carry hostile bytes -- they pin the SHAPE; escaping is separately
-	// pinned below.
+	// these values carry hostile bytes -- they pin the SHAPE; control-byte neutralising
+	// is separately pinned below.
 
 	public function testCanonicalLineForStageMime(): void
 	{
@@ -98,9 +99,10 @@ final class PfbValidateLogLineTest extends TestCase
 	// carrying a NUL byte, "\n", and HTML metacharacters -- including an embedded
 	// fake "pfb_validate: REJECT" line, an attempt to forge a second greppable
 	// entry -- must collapse to a SINGLE line (no "\n" past the leading one), with
-	// every control byte turned into a space and <, >, & escaped.
+	// every control byte turned into a space and <, >, & preserved VERBATIM (no
+	// HTML-escaping -- the sole renderer is a textarea that never parses HTML).
 
-	public function testHostileDetailNeutralisedToSingleEscapedLine(): void
+	public function testHostileDetailNeutralisedButNotEscaped(): void
 	{
 		$hostileDetail = "app\x00lication/zip\nfake pfb_validate: REJECT x <b>&";
 
@@ -108,7 +110,7 @@ final class PfbValidateLogLineTest extends TestCase
 
 		$this->assertSame(
 			"\npfb_validate: REJECT feed=FeedZ stage=mime reason=hostile-detail detected="
-			. 'app lication/zip fake pfb_validate: REJECT x &lt;b&gt;&amp;',
+			. 'app lication/zip fake pfb_validate: REJECT x <b>&',
 			$result
 		);
 		// Defensive: only the pinned leading "\n" may appear -- a hostile detail can
@@ -120,29 +122,29 @@ final class PfbValidateLogLineTest extends TestCase
 		);
 	}
 
-	// --- Hostile feed/reason/stage: same escaping code path as detail: one case
+	// --- Hostile feed/reason/stage: same neutralising code path as detail: one case
 	// each is enough to prove it applies uniformly to all four values.
 
-	public function testHostileFeedIsNeutralisedAndEscaped(): void
+	public function testHostileFeedIsNeutralisedButNotEscaped(): void
 	{
 		$this->assertSame(
-			"\npfb_validate: REJECT feed=Feed &lt;Name&gt;&amp; stage=mime reason=r detected=d",
+			"\npfb_validate: REJECT feed=Feed <Name>& stage=mime reason=r detected=d",
 			pfb_validate_log_line("Feed\x01<Name>&", 'mime', 'r', 'd')
 		);
 	}
 
-	public function testHostileReasonIsNeutralisedAndEscaped(): void
+	public function testHostileReasonIsNeutralisedButNotEscaped(): void
 	{
 		$this->assertSame(
-			"\npfb_validate: REJECT feed=f stage=mime reason=bad reason&amp;x detected=d",
+			"\npfb_validate: REJECT feed=f stage=mime reason=bad reason&x detected=d",
 			pfb_validate_log_line('f', 'mime', "bad\x1freason&x", 'd')
 		);
 	}
 
-	public function testHostileStageIsNeutralisedAndEscaped(): void
+	public function testHostileStageIsNeutralisedButNotEscaped(): void
 	{
 		$this->assertSame(
-			"\npfb_validate: REJECT feed=f stage=mi me&lt;x&gt; reason=r detected=d",
+			"\npfb_validate: REJECT feed=f stage=mi me<x> reason=r detected=d",
 			pfb_validate_log_line('f', "mi\x7fme<x>", 'r', 'd')
 		);
 	}

--- a/tests/php/PfbValidateLogTest.php
+++ b/tests/php/PfbValidateLogTest.php
@@ -124,18 +124,17 @@ final class PfbValidateLogTest extends TestCase
 	/**
 	 * ADR-48 Phase 2: the four ADR-45 structural-probe call sites in pfb_download()
 	 * build detail as `"{$file_type} " . basename($file_download)` and pass it
-	 * RAW (no pre-htmlspecialchars) to pfb_validate_log($header, 'structural',
-	 * 'probe_failed', $detail) -- pfb_download() itself is not off-appliance
-	 * unit-testable (curl/exec), so this pins the exact call-site detail SHAPE and
-	 * proves it is escaped exactly ONCE at the sink (never pre-escaped by the
-	 * caller then escaped again by the formatter). Phase 3 smoke covers the true
-	 * end-to-end four lines on the live VM.
+	 * RAW to pfb_validate_log($header, 'structural', 'probe_failed', $detail) --
+	 * pfb_download() itself is not off-appliance unit-testable (curl/exec), so
+	 * this pins the exact call-site detail SHAPE and proves it reaches the sink
+	 * completely VERBATIM -- pfb_validate_log_line() no longer HTML-escapes (its
+	 * sole renderer, the Logs-tab textarea, never parses HTML). Phase 3 smoke
+	 * covers the true end-to-end four lines on the live VM.
 	 */
-	public function testStructuralStageCallSiteShapeIsSinglyEscapedInSink(): void
+	public function testStructuralStageCallSiteShapeIsUnescapedInSink(): void
 	{
 		// Given: an empty sink and the exact detail-construction expression used
-		// at the call sites, fed a raw (unescaped) '&' -- as file(1) output could
-		// carry one.
+		// at the call sites, fed a raw '&' -- as file(1) output could carry one.
 		$log = $this->tempFile('pfb_validate_structural_log_');
 		$GLOBALS['pfb']['log'] = $log;
 		$this->assertSame('', file_get_contents($log), 'pfB log must start empty');
@@ -147,17 +146,17 @@ final class PfbValidateLogTest extends TestCase
 		// When: the call-site swap emits through pfb_validate_log().
 		pfb_validate_log('pfB_Feed7', 'structural', 'probe_failed', $detail);
 
-		// Then: the sink carries the canonical line, with '&' escaped EXACTLY
-		// once ("&amp;", never "&amp;amp;") -- the call site passes the raw
-		// value straight through; pfb_validate_log_line() is the sole escaper.
+		// Then: the sink carries the canonical line with '&' verbatim (never
+		// "&amp;") -- the call site passes the raw value straight through, and
+		// the formatter no longer escapes it either.
 		$expectedLine = pfb_validate_log_line('pfB_Feed7', 'structural', 'probe_failed', $detail);
 		$logged       = (string) file_get_contents($log);
 		$this->assertStringContainsString($expectedLine, $logged);
-		$this->assertStringContainsString('application/x-gzip&amp;evil', $logged);
+		$this->assertStringContainsString('application/x-gzip&evil', $logged);
 		$this->assertStringNotContainsString(
-			'&amp;amp;',
+			'&amp;',
 			$logged,
-			"detail was double-escaped in <{$logged}>"
+			"detail was HTML-escaped in <{$logged}>"
 		);
 	}
 }

--- a/tests/smoke/ui/test_log.py
+++ b/tests/smoke/ui/test_log.py
@@ -291,21 +291,22 @@ def test_load_does_not_html_escape_content(webui: WebUI, smoke_vm: helpers.Smoke
 
 
 def test_load_does_not_double_escape_write_time_escaped_lines(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
-    """``act=load`` must not add a SECOND escape layer atop write-time-escaped lines.
+    """``act=load`` must not add a SECOND escape layer atop already-escaped-looking text.
 
-    ``pfb_validate_log_line()`` (ADR-48, pfblockerng.inc) already htmlspecialchars()s
-    reject-line fields at WRITE time for pfblockerng.log/error.log -- that write-time
-    escape is untouched by this fix and stays correct. Before this fix, load()'s OWN
-    htmlspecialchars() ran a SECOND time over that already-escaped text, turning
-    "&lt;" into "&amp;lt;" -- a genuine double-escape distinct from the never-escaped
-    case above. Seeds a line shaped like pfb_validate_log_line's output (pre-escaped
-    '&lt;'/'&amp;') and asserts it survives load() with no additional escaping.
+    Regression pin for a defect that existed when ``pfb_validate_log_line()`` (ADR-48,
+    pfblockerng.inc) still htmlspecialchars()'d reject-line fields at WRITE time: load()'s
+    OWN htmlspecialchars() ran a SECOND time over that already-escaped text, turning "&lt;"
+    into "&amp;lt;". pfb_validate_log_line() no longer escapes (a later follow-up dropped
+    that call for the same reason load() dropped its own -- the sole renderer is a textarea
+    that never parses HTML), so this fixture is now synthetic rather than something the
+    current write path actually produces; it's kept as a general invariant pin: load() must
+    never re-escape text that merely LOOKS pre-escaped, regardless of its source.
     """
     vm = smoke_vm
     target = _throwaway_log("error.log")
     marker = helpers.unique_domain("dblesc")
-    # Mirrors pfb_validate_log_line()'s write-time-escaped shape for a REJECT line
-    # whose detail field originally contained '<' '>' '&'.
+    # Synthetic: shaped like pfb_validate_log_line's OLD write-time-escaped output (a REJECT
+    # line whose detail field originally contained '<' '>' '&') -- see docstring above.
     expected = f"pfb_validate: REJECT feed=x stage=y reason=z detected=&lt;{marker}&gt; &amp; done\n"
     _seed_file(vm, target, expected)
     try:


### PR DESCRIPTION
## Summary

Follow-up to #974. That PR fixed `pfblockerng_log.php`'s read-time `htmlspecialchars()` on the Logs-tab AJAX load response — dead weight, since the sole consumer is `#fileContent`'s `.val()`, a plain-text sink that never decodes HTML entities.

Same root cause exists one layer up: `pfb_validate_log_line()` (ADR-48) HTML-escapes each field of a download-validation reject line at *write* time, before it ever reaches `pfblockerng.log`/`error.log`. Those files are viewed through the exact same Logs-tab textarea. Before #974, this caused genuine double-escaping (`&lt;` → `&amp;lt;`); after #974, it means the operator sees literal `&lt;`/`&gt;`/`&amp;` text instead of the real characters — accurate escaping serving no purpose, at the cost of an accurate view of the log.

Verified no other consumer needs the write-time escape: the widget's `pfBlockerNG_get_failed()` (`pfblockerng.widget.php:467`) greps `error.log` for the literal string `"FAIL"` and applies its **own** independent `htmlspecialchars()` on whatever raw bytes it finds, unconditionally — it never relies on write-time escaping for safety. (Correction from adversarial review: a REJECT line *can* intersect that grep in ordinary use — e.g. a feed literally named `FAIL_LIST`, or the companion `"Download FAIL [ NOW ]"` line `pfb_download_failure()` writes to `error.log` right after `pfb_download()` returns `FALSE`, which happens exactly when `pfb_validate_log()` just fired. Doesn't matter either way: the widget re-escapes independently regardless of what it matches.)

## Change

`pfb_validate_log_line()` (`pfblockerng.inc:876-891`) keeps the control-byte stripping (`preg_replace '/[\x00-\x1F\x7F]/'` → space — still load-bearing, blocks forging/splitting the greppable line via attacker-influenced detail) and drops the `htmlspecialchars()` call.

Updated to match:
- `tests/php/PfbValidateLogLineTest.php` — the 4 hostile-input tests now assert the neutralised-but-unescaped shape (renamed from `*NeutralisedAndEscaped` to `*NeutralisedButNotEscaped`).
- `tests/php/PfbValidateLogTest.php` — `testStructuralStageCallSiteShapeIsSinglyEscapedInSink` renamed/updated to `testStructuralStageCallSiteShapeIsUnescapedInSink`.
- `tests/smoke/ui/test_log.py` — corrected a docstring that claimed `pfb_validate_log_line()` still escapes at write time (stale after this PR); the test itself is unaffected (its fixture is synthetic, not computed from the real function).

## Test plan

- [x] `php -l`, `vendor/bin/phpcs` (clean on touched lines — 2 pre-existing lowercase-`false` findings in untouched `setUp()` are outside this diff), `vendor/bin/phpstan`, `vendor/bin/phpunit` (2434 tests, 0 failures) all clean
- [x] `ruff check`/`ruff format --check`/`mypy tests/` clean
- [x] Red→green proven locally (PHP is off-appliance testable, no live-VM dispatch needed): reverted just the `pfb_validate_log_line()` change, ran the updated tests → 5 FAILED with the exact escaped-vs-raw mismatch pasted (`&lt;b&gt;&amp;` vs `<b>&`, etc.); reapplied the fix → all 5 PASSED, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Log lines now keep special characters like `<`, `>`, and `&` visible instead of converting them into HTML entities.
  * Control characters and newlines are still normalized so log output remains readable and single-line.

* **Tests**
  * Updated log validation checks to match the new output format.
  * Clarified test notes around synthetic escaped-looking input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
