### PR TITLE
stubs: fix file_notice() stub — 5th param is $priority, not $local_only

### DIFF
--- a/stubs/pfsense/logging.php
+++ b/stubs/pfsense/logging.php
@@ -29,14 +29,16 @@ function log_error(string $error): void {}
  * @param string $notice     Notice text displayed in the GUI.
  * @param string $category   Category label (e.g. 'General', 'Packages').
  * @param string $url        Optional URL to link from the notice.
- * @param int    $local_only 1 to suppress HA/XMLRPC sync of this notice.
+ * @param int    $priority   Notice severity: 0 = informational, 1 = warning, 2 = error.
+ * @param bool   $local_only Suppress HA/XMLRPC sync of this notice.
  */
 function file_notice(
     string $id,
     string $notice,
     string $category   = 'General',
     string $url        = '',
-    int    $local_only = 0
+    int    $priority   = 1,
+    bool   $local_only = false
 ): void {}
 
 /**


### PR DESCRIPTION
## Summary

Upstream `pfsense/pfsense` (`master` + all currently supported CE 2.8 / Plus 26.03 refs, verified via `src/etc/inc/notices.inc`) declares:

```php
function file_notice($id, $notice, $category = "General", $url = "", $priority = 1, $local_only = false)
```

`stubs/pfsense/logging.php`'s 5th param was misnamed/misdocumented as `$local_only` ("1 to suppress HA/XMLRPC sync of this notice"), and the real 6th param (`$local_only`) was missing entirely. Every call site in this repo passes exactly 5 args, with the 5th a priority value (`1`/`2`), matching the real signature — so this is IDE/PHPStan-only, no production behavior changed.

`stubs/pfsense/logging.php` is hand-crafted (excluded from `scripts/update-pfsense-stubs.py`'s regeneration set), so this is a direct hand-edit rather than a regeneration, contrary to the issue's suggested fix mechanism.

Fixes #977

## Test plan

- [x] `php -l` / `vendor/bin/phpstan` / `vendor/bin/phpunit` (2434/2434) / `vendor/bin/phpcs --standard=phpcs.xml.dist src/` all green
- [x] Verified upstream signature unchanged since before 2025-01 across all commits touching `notices.inc` up to current `master` tip
- [x] Confirmed no repo call site passes a 6th arg or a non-int 5th arg

🤖 Generated with [Claude Code](https://claude.com/claude-code)