### PR TITLE
pfblockerng: persist hook stdout into pfblockerng.log during a live run

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4135,9 +4135,9 @@ function pfb_mirror_hook_output(string $logfile, int $offset): void {
 
 
 /*
- * issue #973: restores ADR-12's persistence promise -- pfb_run_hooks() redirects hook stdout to
- * runlog during an active run, so copy the same delta back into $pfb['log']. No-op when $logfile
- * IS $pfb['log'] already (outside a run) -- else this would duplicate its own tail into itself.
+ * issue #973: restores ADR-12's persistence promise for the normal cron/manual/Run-Now pass --
+ * copies the delta a hook wrote to runlog back into $pfb['log']. No-op when $logfile IS
+ * $pfb['log'] already (outside a run) -- else this would duplicate its own tail into itself.
  */
 function pfb_persist_hook_output(string $logfile, int $offset): void {
 	global $pfb;
@@ -4281,9 +4281,9 @@ function pfb_run_hooks($when, $ctx = array()) {
 		$retval  = 0;
 
 		if (empty($pfb['hook_lifecycle'])) {
-			// Normal cron/manual/Run-Now pass: unchanged synchronous path. The Update page's own
-			// AJAX tail already streams $logtarget (the per-run log) straight to the browser, so
-			// no extra streaming/mirroring is needed here.
+			// Normal cron/manual/Run-Now pass: unchanged synchronous exec(). The Update page's own
+			// AJAX tail already streams $logtarget (the per-run log) live, so no extra STREAMING
+			// mirror is needed here -- issue #973's pfb_persist_hook_output() below only persists.
 			exec($cmd, $discard, $retval);
 			pfb_persist_hook_output($logtarget, $hook_log_offset);
 		} else {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4135,6 +4135,29 @@ function pfb_mirror_hook_output(string $logfile, int $offset): void {
 
 
 /*
+ * issue #973: restores ADR-12's persistence promise -- pfb_run_hooks() redirects hook stdout to
+ * runlog during an active run, so copy the same delta back into $pfb['log']. No-op when $logfile
+ * IS $pfb['log'] already (outside a run) -- else this would duplicate its own tail into itself.
+ */
+function pfb_persist_hook_output(string $logfile, int $offset): void {
+	global $pfb;
+
+	if ($logfile === '' || $logfile === $pfb['log']) {
+		return;
+	}
+	clearstatcache(TRUE, $logfile);
+	$end = @filesize($logfile);
+	if ($end === FALSE || $end <= $offset) {
+		return;
+	}
+	$body = @file_get_contents($logfile, FALSE, NULL, $offset, $end - $offset);
+	if (is_string($body) && $body !== '') {
+		@file_put_contents($pfb['log'], $body, FILE_APPEND);
+	}
+}
+
+
+/*
  * Run every enabled hook matching $when, in list order, as root.
  *
  * $ctx is a flat name => value map exported to each hook as PFB_* environment
@@ -4262,6 +4285,7 @@ function pfb_run_hooks($when, $ctx = array()) {
 			// AJAX tail already streams $logtarget (the per-run log) straight to the browser, so
 			// no extra streaming/mirroring is needed here.
 			exec($cmd, $discard, $retval);
+			pfb_persist_hook_output($logtarget, $hook_log_offset);
 		} else {
 			// pkg install/upgrade/uninstall (lifecycle callback): STREAM the hook's own output to
 			// the pkg Software page AS it runs, instead of one block after it exits.

--- a/tests/php/PfbHookOutputPersistTest.php
+++ b/tests/php/PfbHookOutputPersistTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #973: during a live run (empty($pfb['hook_lifecycle'])), pfb_run_hooks() redirects a
+ * hook's stdout/stderr to pfb_run_log_target() -- $pfb['runlog'] while a run is active -- so the
+ * Update tab shows it live. But nothing ever copied that output into $pfb['log'], breaking ADR-12's
+ * "stdout/stderr captured to the pfBlockerNG log" promise for the persisted Logs tab.
+ *
+ * pfb_persist_hook_output() closes that gap: it reads back the delta the hook appended to the
+ * runlog (offset..EOF, same shape as pfb_mirror_hook_output()) and appends it to $pfb['log']. A
+ * plain file read/append, never a pipe/tee -- reintroducing a pipe here would reopen #662 (a
+ * daemon the hook spawns inherits the fd and would hang exec() waiting on it).
+ *
+ * Branch coverage: real delta copied, no-new-bytes silent hook, self-copy guard ($logfile IS
+ * $pfb['log'], i.e. outside a run), and the empty-path guard.
+ *
+ * No hostile-input matrix: this function only ever reads a byte range off a local file it is
+ * called with from pfb_run_hooks() -- no external/attacker-controlled string parsing, no regex,
+ * no shell metacharacters, no encoding to defend against.
+ */
+#[CoversFunction('pfb_persist_hook_output')]
+final class PfbHookOutputPersistTest extends TestCase
+{
+	private string $runlog = '';
+	private string $origLog = '';
+
+	protected function setUp(): void
+	{
+		global $pfb;
+		$this->runlog = (string) tempnam(sys_get_temp_dir(), 'pfb_hook_persist_run_');
+		$this->origLog = $pfb['log'];
+		$pfb['log'] = (string) tempnam(sys_get_temp_dir(), 'pfb_hook_persist_log_');
+	}
+
+	protected function tearDown(): void
+	{
+		global $pfb;
+		if ($this->runlog !== '') {
+			@unlink($this->runlog);
+		}
+		if ($pfb['log'] !== '') {
+			@unlink($pfb['log']);
+		}
+		$pfb['log'] = $this->origLog;
+	}
+
+	/** Write the "framing marker" already there before the hook runs, then return the pre-exec offset. */
+	private function seedAndOffset(string $file, string $preamble): int
+	{
+		@file_put_contents($file, $preamble);
+		clearstatcache(TRUE, $file);
+		return (int) filesize($file);
+	}
+
+	public function testCopiesOnlyTheAppendedDeltaFromRunlogIntoTheCumulativeLog(): void
+	{
+		global $pfb;
+		// Given the runlog already carries a pre-existing header (offset) before the hook runs...
+		$offset = $this->seedAndOffset($this->runlog, "[ pfB Hook ] post haproxy (hook_post_haproxy.sh)\n");
+		@file_put_contents($this->runlog, "Firing up HAProxy ACL update hook\nNo changes detected. Resuming...\n", FILE_APPEND);
+		@file_put_contents($pfb['log'], "prior cumulative-log content\n");
+
+		pfb_persist_hook_output($this->runlog, $offset);
+
+		$logged = (string) @file_get_contents($pfb['log']);
+		$this->assertStringContainsString(
+			"Firing up HAProxy ACL update hook\nNo changes detected. Resuming...\n",
+			$logged,
+			'the exact bytes the hook appended past the offset must land in pfblockerng.log'
+		);
+		$this->assertStringNotContainsString(
+			'[ pfB Hook ] post haproxy',
+			$logged,
+			'the pre-offset header must NOT be duplicated -- only the delta past the offset copies'
+		);
+		$this->assertStringContainsString('prior cumulative-log content', $logged, 'must APPEND, not overwrite');
+	}
+
+	public function testSilentHookWithNoNewBytesLeavesTheCumulativeLogUnchanged(): void
+	{
+		global $pfb;
+		$offset = $this->seedAndOffset($this->runlog, "header only, hook wrote nothing new\n");
+		@file_put_contents($pfb['log'], 'unchanged baseline');
+
+		pfb_persist_hook_output($this->runlog, $offset);
+
+		$this->assertSame(
+			'unchanged baseline',
+			(string) @file_get_contents($pfb['log']),
+			'offset === EOF must be a true no-op, not even an empty append'
+		);
+	}
+
+	public function testSelfCopyGuardSkipsWhenLogfileIsAlreadyTheCumulativeLog(): void
+	{
+		global $pfb;
+		// Outside a run, pfb_run_log_target() already returns $pfb['log'] itself. Even though
+		// $offset is behind the current EOF, copying the file onto itself must never happen.
+		@file_put_contents($pfb['log'], "already-persisted line one\nalready-persisted line two\n");
+		$offset = 0;
+
+		pfb_persist_hook_output($pfb['log'], $offset);
+
+		$this->assertSame(
+			"already-persisted line one\nalready-persisted line two\n",
+			(string) @file_get_contents($pfb['log']),
+			'logfile === $pfb[log] must no-op -- else the tail would duplicate into itself'
+		);
+	}
+
+	public function testEmptyLogPathIsANoOp(): void
+	{
+		global $pfb;
+		@file_put_contents($pfb['log'], 'baseline');
+
+		pfb_persist_hook_output('', 0);
+
+		$this->assertSame('baseline', (string) @file_get_contents($pfb['log']));
+	}
+}


### PR DESCRIPTION
## Summary

During a live Update run, `pfb_run_hooks()` redirects a hook's own stdout/stderr straight to
the per-run log (`$pfb['runlog']`) so the live Update-tab tail shows it — but nothing ever
copied that content back into the cumulative, persisted `pfblockerng.log`. Result: the Logs
tab is permanently missing the hook's own output lines, breaking ADR-12's original
"stdout/stderr captured to the pfBlockerNG log" promise (a side effect of the #680 live-tail
fix that traded persistence for live visibility instead of keeping both).

`pfb_persist_hook_output()` closes the gap: after `exec()` returns, it reads back just the
bytes the hook appended to the runlog (tracked via the pre-exec offset, already computed for
the sibling `pfb_mirror_hook_output()` mechanism) and appends that exact delta to
`$pfb['log']` via a plain file read/append — never a pipe/tee, preserving the #662 fix (a
hook that restarts a daemon which inherits a pipe fd would otherwise hang `exec()`).

Scoped to the normal cron/manual/Run-Now path only (`empty($pfb['hook_lifecycle'])`) — the
pkg install/upgrade/uninstall lifecycle path (`else` branch) is deliberately untouched here.

**Correction (post-review):** this PR originally claimed that lifecycle path had "no gap."
That claim was **wrong** — an adversarial review empirically proved `runlog_active` IS set
during install/upgrade/uninstall too (`sync_package_pfblockerng()` calls `pfb_runlog_begin()`
unconditionally), so the same persistence bug also reproduces there. It is a genuine,
**pre-existing**, separate gap this PR does not introduce or regress — tracked in #988 rather
than folded into this fix.

Fixes #973

## Test plan

- [x] New `tests/php/PfbHookOutputPersistTest.php`, 4 tests covering: real delta copied,
      silent-hook no-op, self-copy guard (outside a run), empty-path guard
- [x] `vendor/bin/phpunit` — full suite green
- [x] `vendor/bin/phpstan` — no errors
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist src/` — clean
- [x] Red→green proven: new test file fails with `Call to undefined function
      pfb_persist_hook_output()` on `HEAD~1`, passes on `HEAD`
