### PR TITLE
pfblockerng: log pfctl table-op failures to error.log too (#980)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4718,7 +4718,7 @@ function pfb_pfctl_table_op(string $table, string $op, string $args = '', string
 	exec("{$pfctl_bin} -t {$table_esc} -T {$op}{$args_part} 2>&1", $out, $rc);
 	$stderr    = implode(' ', $out);
 	if (pfb_pfctl_op_failed($op, $rc, $stderr)) {
-		pfb_logger(pfb_pfctl_error_message($table, $op, $rc, $stderr) . "\n", 1);
+		pfb_logger(pfb_pfctl_error_message($table, $op, $rc, $stderr) . "\n", 2);
 	}
 	return ['out' => $out, 'rc' => $rc];
 }

--- a/tests/php/PfctlTableOpTest.php
+++ b/tests/php/PfctlTableOpTest.php
@@ -68,8 +68,11 @@ final class PfctlTableOpTest extends TestCase
 		$this->assertNotFalse($path, 'could not create temp mock pfctl script');
 		$this->tmpfiles[] = $path;
 		$stderr_esc = str_replace("'", "'\\''", $stderr);
-		file_put_contents($path, "#!/bin/sh\nprintf '%s\\n' '{$stderr_esc}' >&2\nexit {$rc}\n");
-		chmod($path, 0755);
+		$this->assertNotFalse(
+			file_put_contents($path, "#!/bin/sh\nprintf '%s\\n' '{$stderr_esc}' >&2\nexit {$rc}\n"),
+			"could not write mock pfctl script {$path}"
+		);
+		$this->assertTrue(chmod($path, 0755), "could not chmod mock pfctl script {$path} executable");
 		return $path;
 	}
 

--- a/tests/php/PfctlTableOpTest.php
+++ b/tests/php/PfctlTableOpTest.php
@@ -38,9 +38,12 @@ final class PfctlTableOpTest extends TestCase
 
 	protected function setUp(): void
 	{
-		foreach (['log', 'errlog'] as $k) {
+		foreach (['log', 'errlog', 'pnow', 'runlog', 'runlog_active'] as $k) {
 			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
 		}
+		// A stray 'runlog_active' from an earlier test must not mirror our writes
+		// into a third file this test never provisions.
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
 	}
 
 	protected function tearDown(): void

--- a/tests/php/PfctlTableOpTest.php
+++ b/tests/php/PfctlTableOpTest.php
@@ -6,16 +6,14 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests for the two pure helpers of pfb_pfctl_table_op():
+ * Tests for pfb_pfctl_table_op() and its two pure helpers:
  *   - pfb_pfctl_error_message() — the formatter that names a failed pfctl table
  *     operation (adding attribution to "pfctl: Table does not exist" floods that
- *     the original exec() call sites logged with no table/op info); and
+ *     the original exec() call sites logged with no table/op info);
  *   - pfb_pfctl_op_failed() — the predicate that decides WHETHER a completed op is
- *     a failure worth logging, exempting the idempotent absent-table `kill`.
- *
- * pfb_pfctl_table_op() wraps exec() and cannot be exercised off-appliance, so only
- * its pure helpers are tested here (exec doubles would add fragile complexity for no
- * new coverage benefit — the helpers are the testable invariants).
+ *     a failure worth logging, exempting the idempotent absent-table `kill`; and
+ *   - pfb_pfctl_table_op() itself, exercised via an injectable mock pfctl binary
+ *     (the same $pfctl_bin parameter AliasDeltaApplyTest uses for pfb_apply_alias_delta()).
  *
  * Scenarios:
  *   A — failure message contains table, op, rc, and trimmed stderr.
@@ -24,11 +22,57 @@ use PHPUnit\Framework\TestCase;
  *   D — empty stderr is represented cleanly (no trailing colon-space).
  *   E — pfb_pfctl_op_failed(): an absent-table `kill` is success (not logged); every
  *       other kill error, non-kill absent-table op, and clean success is classified right.
+ *   F — pfb_pfctl_table_op(): an attributed failure is logged to error.log too, not just
+ *       pfblockerng.log (issue #980); a clean success logs to neither.
  */
 #[CoversFunction('pfb_pfctl_error_message')]
 #[CoversFunction('pfb_pfctl_op_failed')]
+#[CoversFunction('pfb_pfctl_table_op')]
 final class PfctlTableOpTest extends TestCase
 {
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
+	/** @var string[] temp files to remove in tearDown */
+	private array $tmpfiles = [];
+
+	protected function setUp(): void
+	{
+		foreach (['log', 'errlog'] as $k) {
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
+		}
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === false) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+		$this->saved = [];
+		foreach ($this->tmpfiles as $f) {
+			if (is_file($f)) {
+				$this->assertTrue(unlink($f), "failed to remove temp file {$f}");
+			}
+		}
+		$this->tmpfiles = [];
+	}
+
+	/** Write an executable POSIX-sh mock pfctl that exits $rc, emitting $stderr on fd 2. */
+	private function mock_pfctl(int $rc, string $stderr): string
+	{
+		$path = tempnam(sys_get_temp_dir(), 'pfb_pfctl_mock_');
+		$this->assertNotFalse($path, 'could not create temp mock pfctl script');
+		$this->tmpfiles[] = $path;
+		$stderr_esc = str_replace("'", "'\\''", $stderr);
+		file_put_contents($path, "#!/bin/sh\nprintf '%s\\n' '{$stderr_esc}' >&2\nexit {$rc}\n");
+		chmod($path, 0755);
+		return $path;
+	}
+
 	// -----------------------------------------------------------------------
 	// Scenario A — standard failure: message contains all four fields
 	// -----------------------------------------------------------------------
@@ -218,5 +262,71 @@ final class PfctlTableOpTest extends TestCase
 			pfb_pfctl_op_failed('add', 0, ''),
 			'expected: rc=0 clean op classified as success (FALSE);\nactual: TRUE'
 		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Scenario F — pfb_pfctl_table_op(): a failing mutation is logged to
+	//              error.log too, not just pfblockerng.log
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario F (pinning) — an attributed op failure reaches error.log, not just
+	 * pfblockerng.log.
+	 *
+	 * Given: a mock pfctl exiting rc=1 with 'pfctl: EINVAL' on stderr — an
+	 *        op_failed()==TRUE shape.
+	 * When:  pfb_pfctl_table_op() runs the mutation against the mock.
+	 * Then:  the attributed failure line lands in BOTH pfblockerng.log and error.log
+	 *        (issue #980: a level-1 pfb_logger() call wrote pfblockerng.log only,
+	 *        leaving error.log consumers blind to the failure).
+	 */
+	public function testTableOpFailureIsLoggedToErrorLogToo(): void
+	{
+		$log    = tempnam(sys_get_temp_dir(), 'pfb_log_');
+		$errlog = tempnam(sys_get_temp_dir(), 'pfb_errlog_');
+		$this->assertNotFalse($log, 'could not create temp log file');
+		$this->assertNotFalse($errlog, 'could not create temp errlog file');
+		$this->tmpfiles[]         = $log;
+		$this->tmpfiles[]         = $errlog;
+		$GLOBALS['pfb']['log']    = $log;
+		$GLOBALS['pfb']['errlog'] = $errlog;
+		$pfctl_bin = $this->mock_pfctl(1, 'pfctl: EINVAL');
+
+		pfb_pfctl_table_op('pfB_Test_v4', 'replace', '', $pfctl_bin);
+
+		$log_content    = (string) file_get_contents($log);
+		$errlog_content = (string) file_get_contents($errlog);
+		$this->assertStringContainsString('op=replace', $log_content,
+			"expected: pfblockerng.log contains the attributed failure line;\nactual: '{$log_content}'");
+		$this->assertStringContainsString('op=replace', $errlog_content,
+			"expected: error.log ALSO contains the attributed failure line;\nactual (errlog): '{$errlog_content}'");
+	}
+
+	/**
+	 * Scenario F (control) — a clean success logs nothing to either file.
+	 *
+	 * Given: a mock pfctl exiting rc=0 with no stderr — an op_failed()==FALSE shape.
+	 * When:  pfb_pfctl_table_op() runs the mutation against the mock.
+	 * Then:  pfb_logger() is never called — pfblockerng.log and error.log both stay
+	 *        untouched, proving the log-level fix does not start logging successes too.
+	 */
+	public function testTableOpSuccessLogsNothing(): void
+	{
+		$log    = tempnam(sys_get_temp_dir(), 'pfb_log_');
+		$errlog = tempnam(sys_get_temp_dir(), 'pfb_errlog_');
+		$this->assertNotFalse($log, 'could not create temp log file');
+		$this->assertNotFalse($errlog, 'could not create temp errlog file');
+		$this->tmpfiles[]         = $log;
+		$this->tmpfiles[]         = $errlog;
+		$GLOBALS['pfb']['log']    = $log;
+		$GLOBALS['pfb']['errlog'] = $errlog;
+		$pfctl_bin = $this->mock_pfctl(0, '');
+
+		pfb_pfctl_table_op('pfB_Test_v4', 'add', '', $pfctl_bin);
+
+		$this->assertSame('', file_get_contents($log),
+			'expected: pfblockerng.log untouched on a clean pfctl success');
+		$this->assertSame('', file_get_contents($errlog),
+			'expected: error.log untouched on a clean pfctl success');
 	}
 }


### PR DESCRIPTION
## Summary

`pfb_pfctl_table_op()` logged a failed `pfctl -T` mutation (add/delete/replace, or a non-idempotent kill) at `pfb_logger()` level 1 — `pfblockerng.log` only. `error.log` consumers (the dashboard widget's failed-download reporting, anything else treating `error.log` as the error-of-record) never saw it, and the alias mirror could silently diverge from the live kernel table with no error-log trail.

Minimal fix per the issue: bump that one `pfb_logger()` call to level 2, so the attributed failure line also lands in `error.log`.

Out of scope (tracked separately under ADR-61): the alias-mirror-written-before-apply-checked ordering issue also mentioned in #980, and the dashboard widget's `grep 'FAIL'` casing (case-sensitive, won't match today's lowercase "failed" wording regardless of log level).

Fixes #980

## Test plan

- [x] Added Scenario F to `tests/php/PfctlTableOpTest.php`, exercising `pfb_pfctl_table_op()` itself via an injectable mock `pfctl` binary (same shape as `AliasDeltaApplyTest`'s `$pfctl_bin`): pinning test proves the failure line reaches both `pfblockerng.log` and `error.log`; control test proves a clean success logs to neither.
- [x] Red→green proven: reverting the one src line makes the pinning test fail for the stated reason (`error.log` empty); restoring makes it pass.
- [x] Full gates green: `php -l`, `vendor/bin/phpunit` (2436/2436), `vendor/bin/phpstan`, `vendor/bin/phpcs`.
