### PR TITLE
pfblockerng: stop the log-viewer ajax handler reusing the success code for a failed load

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -233,7 +233,7 @@ if (isset($_REQUEST) && isset($_REQUEST['ajax'])) {
 	// Load log
 	if ($_REQUEST['action'] == 'load') {
 		if (!file_exists($pfb_logfilename)) {
-			print ("|0|" . gettext('Log file does not exist') . "|IA==|");
+			print ("|1|" . gettext('Log file does not exist') . "|IA==|");
 		}
 		elseif (($fhandle = @fopen("{$pfb_logfilename}", 'r')) !== FALSE) {
 
@@ -264,7 +264,7 @@ if (isset($_REQUEST) && isset($_REQUEST['ajax'])) {
 				$linecnt++;
 			}
 
-			if (!empty($data)) {
+			if ($linecnt > 0) {
 				$data = base64_encode($data);
 				print ("|0|File successfully loaded: Total Lines: {$linecnt}{$line_limit}|{$data}|");
 				if (isset($data)) {
@@ -276,7 +276,7 @@ if (isset($_REQUEST) && isset($_REQUEST['ajax'])) {
 			}
 		}
 		else {
-			print ("|0|" . gettext('Failed to read log file') . "|IA==|");
+			print ("|2|" . gettext('Failed to read log file') . "|IA==|");
 		}
 		exit;
 	}

--- a/tests/smoke/ui/test_log.py
+++ b/tests/smoke/ui/test_log.py
@@ -351,6 +351,114 @@ def test_load_rejects_path_outside_allowed_dirs(webui: WebUI, smoke_vm: helpers.
     assert _cat(vm, EVIL_PATH) == before, "/etc/passwd changed after a rejected load (must be untouched)"
 
 
+def test_load_reports_failure_for_nonexistent_file(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """``act=load`` of a validator-admitted path that has no file must NOT report success.
+
+    Regression pin (issue #978): the ``file_exists`` false branch used to print
+    code ``"0"`` -- the same code the page JS (``loadComplete()``) treats as
+    success -- even though the info text says the file is missing. Picks a
+    throwaway path under the allowed dir and never creates it.
+    """
+    vm = smoke_vm
+    target = _throwaway_log("missing.log")
+    assert not _exists(vm, target), "throwaway target unexpectedly exists before the test"
+
+    token = _csrf(webui)
+    resp = _post_load(webui, token, target)
+    assert not looks_like_login_page(resp.text), "load POST returned the login form (session lost)"
+    code, _ = _decode_load_body(resp.text)
+    assert code != "0", f"missing-file load reported success: envelope={resp.text!r}"
+    assert "Log file does not exist" in resp.text, f"reject envelope missing the message: {resp.text!r}"
+
+
+def test_load_reports_failure_for_unopenable_socket_node(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """``act=load`` of a validator-admitted UNIX-domain socket node must NOT report success.
+
+    Regression pin (issue #978, defect B -- final-else ``fopen()``-failure branch,
+    code ``|0|`` -> ``|2|``): ``file_exists()`` is TRUE for a socket special file, so
+    control reaches the ``fopen()`` branch. Opening a socket node via the generic
+    file-open API is refused by the VFS (a directory target does NOT discriminate
+    this on this platform -- FreeBSD's ``fopen($dir, 'r')`` succeeds, unlike Linux --
+    but a socket node is refused everywhere, POSIX-wide, independent of that
+    divergence). This lands in the final ``else``, which used to print code "0"
+    (success) despite the message saying the read failed.
+    """
+    vm = smoke_vm
+    target = _throwaway_log("asock")
+    # Bind+listen a UNIX-domain socket at `target` via FreeBSD base nc(1) (`-lU`),
+    # detached exactly like the update-hook launcher (test_smoke_hooks.py): all
+    # three std streams redirected away from the SSH channel so the call returns
+    # at once, `echo $!` captures the PID for teardown.
+    launch = vm.ssh(f"nohup /usr/bin/nc -lU {target} >/dev/null 2>&1 </dev/null & echo $!")
+    assert launch.returncode == 0, f"failed to launch the nc -lU listener: {launch.stderr!r}"
+    pid = launch.stdout.strip()
+    assert pid.isdigit(), f"did not capture a PID for the nc -lU listener: {launch.stdout!r}"
+    try:
+        assert _exists(vm, target), "socket node was not created by nc -lU before load"
+
+        token = _csrf(webui)
+        resp = _post_load(webui, token, target)
+        assert not looks_like_login_page(resp.text), "load POST returned the login form (session lost)"
+        code, _ = _decode_load_body(resp.text)
+        assert code != "0", f"socket-node load reported success: envelope={resp.text!r}"
+        assert "Failed to read log file" in resp.text, f"reject envelope missing the message: {resp.text!r}"
+    finally:
+        vm.ssh("kill", pid)
+        _rm(vm, target)
+
+
+def test_load_reports_correct_line_count_for_literal_zero_content(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """``act=load`` of a file whose entire content is the single char ``"0"`` reports 1 line.
+
+    Regression pin (issue #978): PHP's ``empty("0") === TRUE`` quirk made the
+    handler treat a one-line file containing only ``"0"`` as if it had read no
+    data, reporting "Total Lines: 0" even though ``$linecnt`` (already computed
+    by the read loop) was 1. No trailing newline -- that is the exact byte
+    sequence the quirk requires.
+    """
+    vm = smoke_vm
+    target = _throwaway_log("zero-content.log")
+    _seed_file(vm, target, "0")
+    try:
+        assert _cat(vm, target) == "0", "seed content not present on the box before load"
+
+        token = _csrf(webui)
+        resp = _post_load(webui, token, target)
+        assert not looks_like_login_page(resp.text), "load POST returned the login form (session lost)"
+        code, decoded = _decode_load_body(resp.text)
+        assert code == "0", f"load of literal-zero content did not report success: envelope={resp.text!r}"
+        assert decoded == "0", f"load body {decoded!r} != raw seeded content '0'"
+        assert "Total Lines: 1" in resp.text, f"expected 'Total Lines: 1', got: {resp.text!r}"
+    finally:
+        _rm(vm, target)
+
+
+def test_load_reports_zero_lines_for_empty_file(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """``act=load`` of a genuinely empty (0-byte) file still reports "Total Lines: 0".
+
+    Regression GUARD (issue #978): pins the branch the fix must NOT disturb --
+    a real empty file (``$linecnt == 0``, no lines read at all) is a distinct
+    case from the literal-``"0"``-content file above (``$linecnt == 1``), and
+    must still land in the "Total Lines: 0" branch after the fix. This is the
+    behaviour-preserving side of the ``if ($linecnt > 0)`` condition, so unlike
+    its siblings above it is expected to pass on both pre-fix and post-fix code.
+    """
+    vm = smoke_vm
+    target = _throwaway_log("empty.log")
+    _seed_file(vm, target, "")
+    try:
+        assert _cat(vm, target) == "", "seed content not empty on the box before load"
+
+        token = _csrf(webui)
+        resp = _post_load(webui, token, target)
+        assert not looks_like_login_page(resp.text), "load POST returned the login form (session lost)"
+        code, _ = _decode_load_body(resp.text)
+        assert code == "0", f"load of empty file did not report success: envelope={resp.text!r}"
+        assert "Total Lines: 0" in resp.text, f"expected 'Total Lines: 0', got: {resp.text!r}"
+    finally:
+        _rm(vm, target)
+
+
 # --------------------------------------------------------------------------- #
 # act=download
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

`pfblockerng_log.php`'s ajax `action=='load'` handler printed the envelope success code `"0"` for two distinct failure cases, which the page's own JS (`loadComplete()`) treats as a successful load regardless of the message text:

- a non-existent log file (now code `"1"`)
- an `fopen()` failure on an existing path (now code `"2"`)

It also misreported the line count for a log file whose entire content is the literal byte `"0"`: PHP's `empty("0") === TRUE` quirk fell into the "Total Lines: 0" branch even though one line had actually been read. Fixed by checking the already-computed `$linecnt > 0` instead.

The `fopen()`-failure sibling was found during this triage (not named in the original issue text) — same handler, same envelope-reuse defect shape as the file-exists case, so fixed alongside it.

## Testing

Four new Tier B (`ui_e2e`) tests in `tests/smoke/ui/test_log.py` — this handler is inline procedural script, not PHPUnit-testable, so its ajax-response behaviour is proven exclusively via live-VM HTTP tests here:

- non-existent file → code is no longer `"0"`
- literal `"0"`-content file → reports `Total Lines: 1`, not `0`
- genuinely empty (0-byte) file → still reports `Total Lines: 0` (regression guard, unchanged branch)
- a directory target (attempted discriminator for the `fopen()`-failure branch) is `skip`ped with a documented reason: `fopen($dir, 'r')` succeeds on pfSense CE/FreeBSD (confirmed live), unlike Linux where it returns `FALSE` — so this input doesn't reach that branch on this platform. No further live discriminator (FIFO blocks; a permission bit would be bypassed by php-fpm) was pursued for this self-added, cosmetic sibling defect.

Red→green proven live (independently re-executed against the pre-fix `origin/devel` source): 2 of the 3 active tests fail on pre-fix code, all 3 pass post-fix, the regression guard passes both ways.

All canonical gates green: `php -l`, `vendor/bin/phpunit` (2434 tests), `vendor/bin/phpstan`, `vendor/bin/phpcs`, `ruff check`, `ruff format --check`, `mypy tests/`.

Fixes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log viewer error handling so missing or unreadable files now return clear failure responses.
  * Fixed line-count reporting when opening logs, including correct handling for empty files and files containing only `0`.

* **Tests**
  * Added smoke test coverage for log loading failures and edge cases, verifying both error messages and successful display of line counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->