### PR TITLE
pfblockerng: stop the log download/clear handler reusing the success code for a rejection

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -287,7 +287,7 @@ if (isset($pconfig['logFile']) && !empty($pconfig['logFile']) && (isset($pconfig
 	
 	$s_logfile = htmlspecialchars($pconfig['logFile']);
 	if (!pfb_validate_filepath($s_logfile, $pfb_logtypes)) {
-		print ("|0|" . gettext('Invalid filename/path') . ".|");
+		print ("|3|" . gettext('Invalid filename/path') . "|IA==|");
 		exit;
 	}
 

--- a/tests/smoke/ui/test_log.py
+++ b/tests/smoke/ui/test_log.py
@@ -496,9 +496,11 @@ def test_download_streams_file_with_attachment_header(webui: WebUI, smoke_vm: he
 def test_download_rejects_path_outside_allowed_dirs(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
     """Download of a path outside the allowed dirs is refused, source untouched.
 
-    The same validator gates download. ``/etc/passwd`` -> the ``|0|Invalid
-    filename/path.|`` reject envelope (NOT the file's bytes). Transition rigor:
-    snapshot before and assert the file is byte-for-byte unchanged after.
+    The same validator gates download. ``/etc/passwd`` -> the ``|3|Invalid
+    filename/path|IA==|`` reject envelope (NOT the file's bytes) -- code '3' is the
+    handler's dedicated reject code (issue #991: this branch used to reuse '0', the
+    success code, for the rejection). Transition rigor: snapshot before and assert
+    the file is byte-for-byte unchanged after.
     """
     vm = smoke_vm
     before = _cat(vm, EVIL_PATH)
@@ -510,6 +512,8 @@ def test_download_rejects_path_outside_allowed_dirs(webui: WebUI, smoke_vm: help
     # The reject envelope -- emphatically NOT the file's contents (no root: line).
     assert "Invalid filename/path" in resp.text, f"reject envelope missing the message: {resp.text!r}"
     assert "root:" not in resp.text, f"download leaked /etc/passwd content: {resp.text!r}"
+    code = resp.text.split("|")[1] if resp.text.startswith("|") else ""
+    assert code == "3", f"reject envelope reused a non-reject code (issue #991): {resp.text!r}"
     assert _cat(vm, EVIL_PATH) == before, "/etc/passwd changed after a rejected download (must be untouched)"
 
 
@@ -608,7 +612,9 @@ def test_clear_rejects_path_outside_allowed_dirs(webui: WebUI, smoke_vm: helpers
 
     The most safety-critical branch: an unvalidated clear would unlink/truncate an
     arbitrary file. The validator must refuse ``/etc/passwd`` with the
-    ``|0|Invalid filename/path.|`` envelope and NOT remove or empty it.
+    ``|3|Invalid filename/path|IA==|`` envelope and NOT remove or empty it -- code
+    '3' is the handler's dedicated reject code (issue #991: this branch used to
+    reuse '0', the success code, for the rejection).
 
     Transition rigor: snapshot the file's content + size BEFORE, POST the rejected
     clear, then assert it still EXISTS, is the SAME size, and the SAME bytes.
@@ -623,6 +629,8 @@ def test_clear_rejects_path_outside_allowed_dirs(webui: WebUI, smoke_vm: helpers
     resp = _post_clear(webui, token, EVIL_PATH)
     assert not looks_like_login_page(resp.text), "clear POST returned the login form (session lost)"
     assert "Invalid filename/path" in resp.text, f"reject envelope missing the message: {resp.text!r}"
+    code = resp.text.split("|")[1] if resp.text.startswith("|") else ""
+    assert code == "3", f"reject envelope reused a non-reject code (issue #991): {resp.text!r}"
     # AFTER (oracle): the protected file is wholly intact -- not unlinked, not truncated.
     assert _exists(vm, EVIL_PATH), "/etc/passwd was removed by a rejected clear (validator failed!)"
     assert _size(vm, EVIL_PATH) == before_size, "/etc/passwd was truncated by a rejected clear (validator failed!)"

--- a/tests/smoke/ui/test_log.py
+++ b/tests/smoke/ui/test_log.py
@@ -512,7 +512,7 @@ def test_download_rejects_path_outside_allowed_dirs(webui: WebUI, smoke_vm: help
     # The reject envelope -- emphatically NOT the file's contents (no root: line).
     assert "Invalid filename/path" in resp.text, f"reject envelope missing the message: {resp.text!r}"
     assert "root:" not in resp.text, f"download leaked /etc/passwd content: {resp.text!r}"
-    code = resp.text.split("|")[1] if resp.text.startswith("|") else ""
+    code, _ = _decode_load_body(resp.text)
     assert code == "3", f"reject envelope reused a non-reject code (issue #991): {resp.text!r}"
     assert _cat(vm, EVIL_PATH) == before, "/etc/passwd changed after a rejected download (must be untouched)"
 
@@ -629,7 +629,7 @@ def test_clear_rejects_path_outside_allowed_dirs(webui: WebUI, smoke_vm: helpers
     resp = _post_clear(webui, token, EVIL_PATH)
     assert not looks_like_login_page(resp.text), "clear POST returned the login form (session lost)"
     assert "Invalid filename/path" in resp.text, f"reject envelope missing the message: {resp.text!r}"
-    code = resp.text.split("|")[1] if resp.text.startswith("|") else ""
+    code, _ = _decode_load_body(resp.text)
     assert code == "3", f"reject envelope reused a non-reject code (issue #991): {resp.text!r}"
     # AFTER (oracle): the protected file is wholly intact -- not unlinked, not truncated.
     assert _exists(vm, EVIL_PATH), "/etc/passwd was removed by a rejected clear (validator failed!)"


### PR DESCRIPTION
## Summary

pfblockerng_log.php's download/clear POST handler printed envelope code `"0"` (the ajax load handler's success code) for its path-validation rejection — the same anti-pattern already fixed for the sibling `action=='load'` handler by #979/#989. Changes it to the file's dedicated reject code `"3"` and 4-field envelope shape, matching the sibling literal exactly (line 229).

## Test plan

- [x] `php -l` on the touched file
- [x] `vendor/bin/phpunit` (2440 tests, all green)
- [x] `vendor/bin/phpstan analyse` (no errors)
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist src/` (clean)
- [x] Added a code-field assertion to the two existing Tier-B (`ui_e2e`) tests covering this exact rejection path (`test_download_rejects_path_outside_allowed_dirs`, `test_clear_rejects_path_outside_allowed_dirs`)
- [x] Red→green proved live on the smoke VM pool: reverted only the PHP fix on top of the new assertions → both tests FAIL with the pre-fix `|0|Invalid filename/path.|` envelope; restored the fix → both PASS

Fixes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)
