### PR TITLE
pfblockerng: persist pkg-lifecycle hook stdout into pfblockerng.log

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4347,12 +4347,11 @@ function pfb_run_hooks($when, $ctx = array()) {
 				}
 				proc_close($proc);
 			}
-
-			// issue #988: this branch streams to $logtarget same as the normal pass does --
-			// persist its delta into $pfb['log'] too (covers both the proc_open and the
-			// exec() fallback sub-paths above; no-op outside a run).
-			pfb_persist_hook_output($logtarget, $hook_log_offset);
 		}
+
+		// issue #988: the lifecycle branch above streams to $logtarget same as the normal
+		// pass does -- persist its delta into $pfb['log'] too (no-op outside a run).
+		pfb_persist_hook_output($logtarget, $hook_log_offset);
 
 		if ($retval === 124) {
 			pfb_logger("[ pfB Hook ] {$when} {$label} TIMED OUT after {$timeout}s (killed); continuing\n", 2);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4347,11 +4347,12 @@ function pfb_run_hooks($when, $ctx = array()) {
 				}
 				proc_close($proc);
 			}
-		}
 
-		// issue #988: the lifecycle branch above streams to $logtarget same as the normal
-		// pass does -- persist its delta into $pfb['log'] too (no-op outside a run).
-		pfb_persist_hook_output($logtarget, $hook_log_offset);
+			// issue #988: this branch streams to $logtarget same as the normal pass does --
+			// persist its delta into $pfb['log'] too (covers both the proc_open and the
+			// exec() fallback sub-paths above; no-op outside a run).
+			pfb_persist_hook_output($logtarget, $hook_log_offset);
+		}
 
 		if ($retval === 124) {
 			pfb_logger("[ pfB Hook ] {$when} {$label} TIMED OUT after {$timeout}s (killed); continuing\n", 2);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4349,6 +4349,10 @@ function pfb_run_hooks($when, $ctx = array()) {
 			}
 		}
 
+		// issue #988: the lifecycle branch above streams to $logtarget same as the normal
+		// pass does -- persist its delta into $pfb['log'] too (no-op outside a run).
+		pfb_persist_hook_output($logtarget, $hook_log_offset);
+
 		if ($retval === 124) {
 			pfb_logger("[ pfB Hook ] {$when} {$label} TIMED OUT after {$timeout}s (killed); continuing\n", 2);
 		} elseif ($retval !== 0) {

--- a/tests/smoke/test_lifecycle_hook_visibility.py
+++ b/tests/smoke/test_lifecycle_hook_visibility.py
@@ -14,6 +14,9 @@ process's own captured stdout/stderr) cover:
   this file proves that output actually SURVIVES the drop+tee and lands in the file the
   GUI would render.
 
+Both tests also assert (issue #988) that a hook's stdout during a lifecycle callback lands
+in the PERSISTED ``pfblockerng.log`` (``h.PFB_LOG``), not only the GUI's live stream.
+
 Both tests drive ``/usr/local/sbin/pfSense-upgrade`` directly (the same binary
 ``pkg_mgr_install.php`` shells out to for "Update now" / "Remove"), reproducing what the
 GUI page shows WITHOUT a browser (Tier B territory otherwise). NOT A SMOKE TEST — like
@@ -154,6 +157,8 @@ def test_update_hooks_fire_and_are_gui_visible_on_reinstall(repo_vm: SmokeVM) ->
         assert not h.hook_marker_exists(vm, post_marker), "post marker present before reinstall (stale state?)"
 
         # ---- WHEN (terminal): pkg install -f -y <name> (op 'reinstall') ----------- #
+        log_pre_before = h.count_log_marker(vm, h.PFB_LOG, pre_line)
+        log_post_before = h.count_log_marker(vm, h.PFB_LOG, post_line)
         proc = vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "install", "-f", "-y", PKG_NAME, timeout=600)
         combined = proc.stdout + proc.stderr
 
@@ -177,12 +182,24 @@ def test_update_hooks_fire_and_are_gui_visible_on_reinstall(repo_vm: SmokeVM) ->
             f"terminal `pkg install -f` output is missing the post hook's stdout marker "
             f"{post_line!r}:\n{combined[-3000:]}"
         )
+        # issue #988: the lifecycle branch's hook stdout must also reach the PERSISTED
+        # pfblockerng.log, not only the pkg Software page's live stream.
+        assert h.count_log_marker(vm, h.PFB_LOG, pre_line) > log_pre_before, (
+            f"pre hook stdout marker {pre_line!r} did not reach the persisted {h.PFB_LOG} "
+            f"after the terminal pkg install"
+        )
+        assert h.count_log_marker(vm, h.PFB_LOG, post_line) > log_post_before, (
+            f"post hook stdout marker {post_line!r} did not reach the persisted {h.PFB_LOG} "
+            f"after the terminal pkg install"
+        )
 
         # ---- WHEN (GUI): pfSense-upgrade -i <name> -f ("Update now" shortcut) ------ #
         h.clear_hook_markers(vm, token)
         assert not h.hook_marker_exists(vm, pre_marker), "pre marker present before GUI reinstall (stale state?)"
         assert not h.hook_marker_exists(vm, post_marker), "post marker present before GUI reinstall (stale state?)"
 
+        log_pre_before_gui = h.count_log_marker(vm, h.PFB_LOG, pre_line)
+        log_post_before_gui = h.count_log_marker(vm, h.PFB_LOG, post_line)
         gui_proc = vm.ssh(PFSENSE_UPGRADE, "-y", "-l", GUI_LOG_REINSTALL, "-i", PKG_NAME, "-f", timeout=600)
         gui_log = _gui_log_tail(vm, GUI_LOG_REINSTALL)
         assert gui_proc.returncode == 0, (
@@ -211,6 +228,14 @@ def test_update_hooks_fire_and_are_gui_visible_on_reinstall(repo_vm: SmokeVM) ->
         )
         assert post_line in gui_log, (
             f"the post hook's stdout marker {post_line!r} is MISSING from the GUI log ({GUI_LOG_REINSTALL}):\n{gui_log}"
+        )
+        # issue #988: same persist call fires on the GUI-driven reinstall (same lifecycle
+        # branch, same call site as the terminal `pkg install -f` above).
+        assert h.count_log_marker(vm, h.PFB_LOG, pre_line) > log_pre_before_gui, (
+            f"pre hook stdout marker {pre_line!r} did not reach the persisted {h.PFB_LOG} after the GUI reinstall"
+        )
+        assert h.count_log_marker(vm, h.PFB_LOG, post_line) > log_post_before_gui, (
+            f"post hook stdout marker {post_line!r} did not reach the persisted {h.PFB_LOG} after the GUI reinstall"
         )
     finally:
         h.clear_update_hooks(vm)
@@ -283,6 +308,8 @@ def test_uninstall_runs_hook_tears_down_and_is_gui_visible(repo_vm: SmokeVM) -> 
         assert not h.hook_marker_exists(vm, post_marker), "post marker present before uninstall (stale state?)"
 
         # ---- WHEN: GUI delete path (op 'delete' -> pre-deinstall disable pass) ---- #
+        log_pre_before = h.count_log_marker(vm, h.PFB_LOG, pre_line)
+        log_post_before = h.count_log_marker(vm, h.PFB_LOG, post_line)
         gui_proc = vm.ssh(PFSENSE_UPGRADE, "-y", "-l", GUI_LOG_DELETE, "-r", PKG_NAME, timeout=600)
         gui_log = _gui_log_tail(vm, GUI_LOG_DELETE)
         diag = f"pfSense-upgrade -r rc={gui_proc.returncode}\nGUI log tail:\n{gui_log}\n{h.deinstall_debug(vm)}"
@@ -319,6 +346,14 @@ def test_uninstall_runs_hook_tears_down_and_is_gui_visible(repo_vm: SmokeVM) -> 
         )
         assert post_line in gui_log, (
             f"the post hook's stdout marker {post_line!r} is MISSING from the GUI log ({GUI_LOG_DELETE}):\n{gui_log}"
+        )
+        # issue #988: same lifecycle-branch call site as the reinstall test (only the
+        # PFB_PRE_UNINSTALL context value differs) — same persist call fires here too.
+        assert h.count_log_marker(vm, h.PFB_LOG, pre_line) > log_pre_before, (
+            f"pre hook stdout marker {pre_line!r} did not reach the persisted {h.PFB_LOG} after the GUI uninstall"
+        )
+        assert h.count_log_marker(vm, h.PFB_LOG, post_line) > log_post_before, (
+            f"post hook stdout marker {post_line!r} did not reach the persisted {h.PFB_LOG} after the GUI uninstall"
         )
     finally:
         h.clear_update_hooks(vm)

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -683,6 +683,7 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
     h.set_update_hooks(deployed_vm, [post_hook])
     h.wait_no_active_pfb_task(deployed_vm)  # clean baseline — no prior pass in flight
     persisted_before = h.count_log_marker(deployed_vm, h.PFB_LOG, stream_marker)
+    persisted_before_done = h.count_log_marker(deployed_vm, h.PFB_LOG, done_marker)
 
     try:
         # Dispatch DETACHED (mirrors the GUI's mwexec_bg): returns at once; observe via the log.
@@ -733,6 +734,12 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
         persisted_delta = h.count_log_marker(deployed_vm, h.PFB_LOG, stream_marker) - persisted_before
         assert persisted_delta == 1, (
             f"hook marker {stream_marker!r} was persisted into {h.PFB_LOG} {persisted_delta} time(s) "
+            "for one hook run (expected exactly 1 — pfb_persist_hook_output double-fired):\n"
+            f"{deployed_vm.ssh('cat', h.PFB_LOG).stdout[-4000:]}"
+        )
+        persisted_delta_done = h.count_log_marker(deployed_vm, h.PFB_LOG, done_marker) - persisted_before_done
+        assert persisted_delta_done == 1, (
+            f"hook marker {done_marker!r} was persisted into {h.PFB_LOG} {persisted_delta_done} time(s) "
             "for one hook run (expected exactly 1 — pfb_persist_hook_output double-fired):\n"
             f"{deployed_vm.ssh('cat', h.PFB_LOG).stdout[-4000:]}"
         )

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -661,6 +661,11 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
     later read of the per-run log) sees NOTHING — the failing assertion, mirroring the missing
     live-view output. (Window << the 12s sleep; if a loaded runner ever flakes, raise the sleep
     AND the window together.)
+
+    Also proves (issue #988): the normal-pass branch's #973 persist call
+    (``pfb_persist_hook_output``) fires exactly ONCE for this hook into the PERSISTED
+    ``pfblockerng.log`` — a stray second call (a wrongly-placed lifecycle-branch persist
+    call sitting outside its own branch) would double the marker count there.
     """
     token = "stream"
     stream_marker = f"STREAM_{token}_MARK"
@@ -677,6 +682,7 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
     }
     h.set_update_hooks(deployed_vm, [post_hook])
     h.wait_no_active_pfb_task(deployed_vm)  # clean baseline — no prior pass in flight
+    persisted_before = h.count_log_marker(deployed_vm, h.PFB_LOG, stream_marker)
 
     try:
         # Dispatch DETACHED (mirrors the GUI's mwexec_bg): returns at once; observe via the log.
@@ -722,6 +728,14 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
         )
     finally:
         h.wait_no_active_pfb_task(deployed_vm, timeout=40.0)
+        # issue #988: exactly ONE persisted copy per hook run — a duplicate here means
+        # pfb_persist_hook_output() double-fired on the normal-pass branch.
+        persisted_delta = h.count_log_marker(deployed_vm, h.PFB_LOG, stream_marker) - persisted_before
+        assert persisted_delta == 1, (
+            f"hook marker {stream_marker!r} was persisted into {h.PFB_LOG} {persisted_delta} time(s) "
+            "for one hook run (expected exactly 1 — pfb_persist_hook_output double-fired):\n"
+            f"{deployed_vm.ssh('cat', h.PFB_LOG).stdout[-4000:]}"
+        )
         h.clear_update_hooks(deployed_vm)
 
 


### PR DESCRIPTION
## Summary

Issue #988 is the pkg install/upgrade/uninstall counterpart of #973 (PR #984, merged):
`pfb_run_hooks()`'s `hook_lifecycle` branch (pkg install/upgrade/uninstall) streams a hook's
stdout to `$pfb['runlog']` the same way the normal-pass branch does, but never copied that
delta into the persisted `pfblockerng.log`. Adds one call to the already-existing
`pfb_persist_hook_output()` (from #973) inside that branch, right after its
`proc_open`-success / `exec()`-fallback sub-paths converge — covers both without touching
either.

**Self-caught regression during review:** the first delegated implementation placed the new
call *outside* the whole `if (empty($pfb['hook_lifecycle'])) {...} else {...}` block instead
of inside the `else` only, so a **normal** cron/manual/Run-Now hook run called
`pfb_persist_hook_output()` **twice** — duplicating every hook's stdout in `pfblockerng.log`.
Caught while reading the full diff (not just the live-VM green result, which only exercised
the lifecycle path and couldn't see this). Fixed the placement, then added and live
red-then-green-proved a duplicate-persist regression guard for the normal-pass path too.

## Test plan

- [x] `tests/smoke/test_lifecycle_hook_visibility.py`: both existing live-VM lifecycle tests
      (`test_update_hooks_fire_and_are_gui_visible_on_reinstall`,
      `test_uninstall_runs_hook_tears_down_and_is_gui_visible`) now also assert each hook's
      stdout marker reaches `pfblockerng.log`, not just the GUI-tailed log
- [x] Live red→green (reinstall test, `scripts/local-smoke.sh`): FAILED pre-fix (marker count
      0 in `pfblockerng.log`), PASSED post-fix
- [x] `tests/smoke/test_smoke_hooks.py::test_post_hook_output_streams_into_runlog_during_run`:
      new regression guard — both the `stream_marker` and `done_marker` occurrence counts in
      `pfblockerng.log` must be exactly 1 per hook run (guards the double-persist bug above)
- [x] Live red→green for the regression guard, both markers independently isolated: FAILED
      against the reintroduced buggy placement (count 2 for each), PASSED against the fix
- [x] `vendor/bin/phpunit` (2440 tests) / `phpstan` / `phpcs` / `ruff` / `mypy` /
      `check_comment_narration.py` all green

Fixes #988


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hook output is now reliably saved to the persistent log during lifecycle actions and live runs.
  * Fixed an issue where hook markers could appear in the on-screen log without being fully recorded in the saved log.
  * Improved consistency so hook messages are stored exactly once per run, reducing duplicate log entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->