### PR TITLE
pfblockerng: fix DNSBL/IP-list parse-log bugs found in v4.0.0.alpha.20

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6425,7 +6425,8 @@ function pfb_dnsbl_unbracket_ip6(string $line): string {
 // '!' (ABP/uBlock), '//' (C-style) -- the three conventions feeds in this ecosystem mix
 // together regardless of the list's own declared format. Callers whose '#' handling
 // carries side effects (hpHosts/Spamhaus/CSV-header sniffing in the DNSBL hosts-format
-// branch) check '#' themselves first and do not route it through here.
+// branch) check '#' themselves first and do not route it through here. Blank detection is
+// empty($line) -- callers MUST trim() first, or a whitespace-only line won't match.
 function pfb_is_blank_or_comment_line(string $line): bool {
 	return empty($line) ||
 		str_starts_with($line, '#') ||
@@ -18792,11 +18793,9 @@ function sync_package_pfblockerng($cron='') {
 							$pfb_delta_batch,
 							$force_rpl
 						);
-						$log = '';
 					} else {
-						$log = " Updating [ {$final} ]: Aliastable file not found\n";
+						pfb_logger(" Updating [ {$final} ]: Aliastable file not found\n", 1);
 					}
-					pfb_logger("{$log}", 1);
 				}
 				pfb_logger("\n", 1);
 				unset($pfb_delta_mode, $pfb_delta_batch, $desired, $previous, $mirror_path, $force_rpl);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5153,7 +5153,7 @@ function pfb_apply_alias_delta(
 		// issue #722: nothing else on a live box distinguishes the delta path from a
 		// replace (pfb_pfctl_table_op logs only on error) — this line is the sole apply-path
 		// oracle the smoke suite (and a human reading the log) can grep for.
-		pfb_logger(" ADR-40 apply [ {$table} ]: replace\n", 1);
+		pfb_logger(" Updating [ {$table} ]: replace\n", 1);
 		pfb_pfctl_table_op($table, 'replace', "-f {$table_file_esc}", $pfctl_bin);
 		return FALSE;
 	}
@@ -5167,14 +5167,14 @@ function pfb_apply_alias_delta(
 
 	// Churn-ratio fallback: auto mode with large churn → replace.
 	if ($mode === 'auto' && $table_size > 0 && ($churn / $table_size) >= PFB_DELTA_CHURN_THRESHOLD) {
-		pfb_logger(" ADR-40 apply [ {$table} ]: replace\n", 1);
+		pfb_logger(" Updating [ {$table} ]: replace\n", 1);
 		pfb_pfctl_table_op($table, 'replace', "-f {$table_file_esc}", $pfctl_bin);
 		return FALSE;
 	}
 
 	// issue #722: log the delta decision (incl. the zero-churn idempotent no-op below) so the
 	// delta path is just as observable on a live box as the replace path logged above.
-	pfb_logger(" ADR-40 apply [ {$table} ]: delta +" . count($add_set) . '/-' . count($del_set) . "\n", 1);
+	pfb_logger(" Updating [ {$table} ]: delta +" . count($add_set) . '/-' . count($del_set) . "\n", 1);
 
 	// Idempotence: empty delta → zero pfctl calls.
 	if (empty($add_set) && empty($del_set)) {
@@ -6418,6 +6418,19 @@ function pfb_dnsbl_unbracket_ip6(string $line): string {
 		}
 	}
 	return $line;
+}
+
+
+// A blank line, or one led by a well-known full-line comment marker: '#' (hosts-style),
+// '!' (ABP/uBlock), '//' (C-style) -- the three conventions feeds in this ecosystem mix
+// together regardless of the list's own declared format. Callers whose '#' handling
+// carries side effects (hpHosts/Spamhaus/CSV-header sniffing in the DNSBL hosts-format
+// branch) check '#' themselves first and do not route it through here.
+function pfb_is_blank_or_comment_line(string $line): bool {
+	return empty($line) ||
+		str_starts_with($line, '#') ||
+		str_starts_with($line, '!') ||
+		str_starts_with($line, '//');
 }
 
 
@@ -16166,7 +16179,9 @@ function sync_package_pfblockerng($cron='') {
 													$line = str_replace('%20', '', $line);
 												}
 
-												// Remove comment lines and special format considerations
+												// Remove comment lines and special format considerations. Checked
+												// BEFORE the generic '!'/'//' skip below since these side effects
+												// (hpHosts end marker, Spamhaus format, h3x CSV header) must run.
 												if (str_starts_with($line, '#')) {
 													// Exit (hpHosts) when end of domain names found.
 													if (strpos($line, 'Append critical updates below') !== FALSE) {
@@ -16186,8 +16201,11 @@ function sync_package_pfblockerng($cron='') {
 													continue;
 												}
 
-												// Remove slash comment lines
-												if (str_starts_with($line, '//')) {
+												// '!' (ABP/uBlock, e.g. DandelionSprouts' mid-body '!#if'/'!#endif' --
+												// the header-scan above only skips these before $validate_header flips
+												// TRUE) and '//' (C-style) comment lines. Neither carries side effects,
+												// unlike '#' above -- safe to merge into one plain skip.
+												if (str_starts_with($line, '!') || str_starts_with($line, '//')) {
 													continue;
 												}
 
@@ -16502,6 +16520,13 @@ function sync_package_pfblockerng($cron='') {
 									@fclose($fhandle);
 								}
 
+								// Close the "Reload . completed ." progress line with its trailing dot
+								// BEFORE the strict-parsing WARNING below, else the warning's own
+								// leading/trailing newlines strand this dot on its own line.
+								if (!empty($domain_data)) {
+									pfb_logger(".\n", 1);
+								}
+
 								// ADR-22: one WARNING per feed summarising strict-mode skips (silent
 								// when none -- lenient never increments the counter).
 								pfb_dnsbl_scheme_skip_warn($pfb_scheme_skipped, $header);
@@ -16541,8 +16566,6 @@ function sync_package_pfblockerng($cron='') {
 									$conf .= "pidfile: \"/var/run/unbound.pid\"\n";
 									$conf .= "server:include: {$pfbfolder}/{$header}.bk";
 									@file_put_contents("{$pfb['dnsbldir']}/check.conf", $conf, LOCK_EX);
-
-									pfb_logger(".\n", 1);
 
 									// ADR-06: The build-time De-Duplication / user-whitelist /
 									// TOP1M removal passes (dnsbl_scrub) are DROPPED. The Python
@@ -17814,8 +17837,10 @@ function sync_package_pfblockerng($cron='') {
 									// Remove any leading/trailing whitespaces
 									$line = trim($line);
 
-									// Remove commentlines and blank lines
-									if (str_starts_with($line, '#') || empty($line)) {
+									// Remove commentlines and blank lines (mirrors the DNSBL hosts-
+									// format skip -- feeds mix '#'/'!'/'//' comment conventions
+									// regardless of the list's own declared format).
+									if (pfb_is_blank_or_comment_line($line)) {
 										continue;
 									}
 
@@ -18006,14 +18031,34 @@ function sync_package_pfblockerng($cron='') {
 
 									// Check for parse failures
 									if (!empty($line) && !preg_match('/[a-zA-Z,;|\"\'?]/', $line)) {
-										$parse_fail++;
-										$log = "[!] Parse Errors [ {$parse_fail} ]\n";
-										pfb_logger("{$log}", 2);
+
+										// A syntactically valid address of the list's OTHER family (a
+										// hex-letter-free IPv6 line in a '_v4' list, or an IPv4 line in
+										// a '_v6' list) is not a parse failure -- mixed-family feeds are
+										// common, and the family this list doesn't collect is silently
+										// skipped either way (same as any hex-lettered opposite-family
+										// address already is, uncounted). Only flag genuine garbage.
+										$other_family_addr =
+											($list['vtype'] == '_v4' && str_contains($line, ':') && validate_ipv6($line)) ||
+											($list['vtype'] == '_v6' && !str_contains($line, ':') && validate_ipv4($line));
+
+										if (!$other_family_addr) {
+											$parse_fail++;
+										}
 									}
 								}
 							}
 							if ($fhandle) {
 								@fclose($fhandle);
+							}
+
+							// One summary line per feed with the final count (mirrors the DNSBL
+							// strict-scheme WARNING) -- was previously one spammed line PER failed
+							// line, e.g. "[!] Parse Errors [ 1 ]" through "[ 967 ]" for a single feed.
+							// Names the feed: this is logtype 2 (also written to the error log,
+							// which has no surrounding "[ header ] Reload..." context of its own).
+							if ($parse_fail > 0) {
+								pfb_logger("[!] Parse Errors [ {$header} ]: {$parse_fail}\n", 2);
 							}
 							pfb_logger("\n", 1);
 
@@ -18722,8 +18767,6 @@ function sync_package_pfblockerng($cron='') {
 				$pfb_delta_batch = pfb_alias_delta_batch_clamp((string) PfbConfig::read('pfb_alias_delta_batch'));
 
 				foreach ($final_alias as $final) {
-					$log = " Updating: {$final}\n";	// trailing \n only — a leading \n put a blank line before each entry
-					pfb_logger("{$log}", 1);
 					if (file_exists("{$pfb['aliasdir']}/{$final}.txt")) {
 						// ADR-40: compute delta from the stashed previous canonical set.
 						// Two cases always get force_rpl = TRUE here:
@@ -18751,7 +18794,7 @@ function sync_package_pfblockerng($cron='') {
 						);
 						$log = '';
 					} else {
-						$log = "Aliastable file not found\n";
+						$log = " Updating [ {$final} ]: Aliastable file not found\n";
 					}
 					pfb_logger("{$log}", 1);
 				}

--- a/tests/php/AliasDeltaApplyTest.php
+++ b/tests/php/AliasDeltaApplyTest.php
@@ -152,7 +152,7 @@ SH
 	 * issue #722: count occurrences of $marker in the CURRENT pfBlockerNG log
 	 * (global $pfb['log'], seeded to a writable sandbox path by tests/php/bootstrap.php).
 	 *
-	 * pfb_apply_alias_delta() is the ONLY thing under test that writes ADR-40 apply-path
+	 * pfb_apply_alias_delta() is the ONLY thing under test that writes the apply-path
 	 * markers, so a before/after delta around a single call isolates that call's decision
 	 * even though the log file is shared process-wide across every test in this run —
 	 * the same before/after-count discipline the live-VM smoke suite uses on its log.
@@ -260,7 +260,7 @@ SH
 	 * Before: pfb_apply_alias_delta returns FALSE (we'll verify the path).
 	 * When mode='auto' and churn_ratio=0.001 < PFB_DELTA_CHURN_THRESHOLD.
 	 * Then returns TRUE (delta path taken) AND (issue #722) the ONLY on-box signal that
-	 *   distinguishes delta from replace — the " ADR-40 apply [ <table> ]: delta …" log
+	 *   distinguishes delta from replace — the " Updating [ <table> ]: delta …" log
 	 *   line — was emitted for this table (not the "…: replace" shape).
 	 */
 	public function testSmallChurnAutoModeUsesDeltaPath(): void
@@ -289,8 +289,8 @@ SH
 		@unlink($this->pfctl_call_log);
 
 		// issue #722: before-state — no delta/replace apply-path marker logged yet for this table.
-		$delta_marker   = ' ADR-40 apply [ pfB_Large_v4 ]: delta +';
-		$replace_marker = ' ADR-40 apply [ pfB_Large_v4 ]: replace';
+		$delta_marker   = ' Updating [ pfB_Large_v4 ]: delta +';
+		$replace_marker = ' Updating [ pfB_Large_v4 ]: replace';
 		$delta_before   = $this->countLogMarker($delta_marker);
 		$replace_before = $this->countLogMarker($replace_marker);
 
@@ -307,7 +307,7 @@ SH
 		$delta_after   = $this->countLogMarker($delta_marker);
 		$replace_after = $this->countLogMarker($replace_marker);
 		$this->assertSame($delta_before + 1, $delta_after,
-			"expected: one new ' ADR-40 apply [ pfB_Large_v4 ]: delta +…' log line "
+			"expected: one new ' Updating [ pfB_Large_v4 ]: delta +…' log line "
 			. "(before={$delta_before}, after={$delta_after}) — apply-path observability regressed");
 		$this->assertSame($replace_before, $replace_after,
 			"expected: NO new '…: replace' log line for a delta apply "
@@ -337,7 +337,7 @@ SH
 
 		// Before: no calls, no apply-path marker logged yet for this table.
 		$this->assertFileDoesNotExist($this->pfctl_call_log, 'before: no pfctl calls yet');
-		$replace_marker = " ADR-40 apply [ {$table} ]: replace";
+		$replace_marker = " Updating [ {$table} ]: replace";
 		$replace_before = $this->countLogMarker($replace_marker);
 
 		// When
@@ -360,7 +360,7 @@ SH
 		// Then (issue #722) — the auto-mode large-churn fallback logged the replace marker.
 		$replace_after = $this->countLogMarker($replace_marker);
 		$this->assertSame($replace_before + 1, $replace_after,
-			"expected: one new ' ADR-40 apply [ {$table} ]: replace' log line from the auto-mode "
+			"expected: one new ' Updating [ {$table} ]: replace' log line from the auto-mode "
 			. "large-churn fallback (before={$replace_before}, after={$replace_after}) — "
 			. "apply-path observability regressed");
 	}
@@ -375,7 +375,7 @@ SH
 	 * Given any churn level.
 	 * When mode='replace'.
 	 * Then returns FALSE (replace path) regardless of churn ratio, AND (issue #722) the
-	 *   " ADR-40 apply [ <table> ]: replace" apply-path marker is logged — the sole
+	 *   " Updating [ <table> ]: replace" apply-path marker is logged — the sole
 	 *   on-box signal a live-VM smoke test (or a human) can use to prove replace, not
 	 *   delta, actually ran (pfb_pfctl_table_op itself logs only on error).
 	 *
@@ -393,7 +393,7 @@ SH
 		// Before: asserting that mode=auto would take delta (churn ratio matters less here
 		// since table_size=1, churn=1/1=100%, but let's use mode=replace explicitly).
 		// The key assertion is: mode=replace → replace.
-		$replace_marker = " ADR-40 apply [ {$table} ]: replace";
+		$replace_marker = " Updating [ {$table} ]: replace";
 		$replace_before = $this->countLogMarker($replace_marker);
 
 		$used_delta = pfb_apply_alias_delta(
@@ -412,7 +412,7 @@ SH
 		// Then (issue #722) — the replace apply-path marker was logged for this table.
 		$replace_after = $this->countLogMarker($replace_marker);
 		$this->assertSame($replace_before + 1, $replace_after,
-			"expected: one new ' ADR-40 apply [ {$table} ]: replace' log line "
+			"expected: one new ' Updating [ {$table} ]: replace' log line "
 			. "(before={$replace_before}, after={$replace_after}) — apply-path observability regressed");
 	}
 

--- a/tests/php/BlankOrCommentLineTest.php
+++ b/tests/php/BlankOrCommentLineTest.php
@@ -6,16 +6,20 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_is_blank_or_comment_line() — the shared blank/comment-prefix predicate used by
- * the generic IP-list parser wholesale, and by the DNSBL hosts-format branch for its
- * side-effect-free '!'/'//' prefixes (its '#' handling carries side effects -- hpHosts
- * end marker, Spamhaus format detection, h3x CSV header sniff -- and is checked by the
- * caller itself, never routed through here).
+ * pfb_is_blank_or_comment_line() — the blank/comment-prefix predicate for the generic
+ * IP-list parser (its one production call site). The DNSBL hosts-format branch does
+ * NOT call this function: it hand-inlines the equivalent '!'/'//' skip instead, kept
+ * deliberately separate because its '#' handling carries side effects (hpHosts end
+ * marker, Spamhaus format detection, h3x CSV header sniff) that must run BEFORE the
+ * generic skip decision -- routing '#' through this predicate would skip those lines
+ * before the side effects fire. The two are conceptually the same rule, not shared code.
  *
- * Regression pin for the DandelionSprouts bug: a hosts-format feed embeds ABP-style
- * '!#if'/'!#endif' directives mid-body; before this predicate existed, only '#'/'//'
- * were recognised as comment prefixes in that branch, so a bang-comment line fell
- * through into "typical host feed" column-stripping and got logged as a parse error.
+ * Regression pin for the DandelionSprouts bug (the DNSBL branch's own inlined check,
+ * exercised indirectly here since it mirrors this predicate's '!'/'//' logic exactly):
+ * a hosts-format feed embeds ABP-style '!#if'/'!#endif' directives mid-body; before
+ * that inlined check existed, only '#'/'//' were recognised as comment prefixes there,
+ * so a bang-comment line fell through into "typical host feed" column-stripping and
+ * got logged as a parse error.
  *
  * Also pins that a scheme-less bracketed-IPv6 line ('://[...]', no leading '#'/'!'/'//')
  * is NOT swallowed here -- it must keep flowing to the strict-scheme validator, which is
@@ -33,7 +37,7 @@ final class BlankOrCommentLineTest extends TestCase
 	public function testUntrimmedWhitespaceOnlyStringIsNotBlank(): void
 	{
 		// empty('   ') is FALSE in PHP -- this predicate relies on the caller having
-		// already trim()'d $line (both call sites do), matching every other
+		// already trim()'d $line (its one call site does), matching every other
 		// empty($line) check in this file rather than reimplementing trim-and-check.
 		// Pins the contract explicitly instead of leaving it an unstated assumption.
 		$this->assertFalse(pfb_is_blank_or_comment_line('   '));

--- a/tests/php/BlankOrCommentLineTest.php
+++ b/tests/php/BlankOrCommentLineTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_is_blank_or_comment_line() — the shared blank/comment-prefix predicate used by
+ * the generic IP-list parser wholesale, and by the DNSBL hosts-format branch for its
+ * side-effect-free '!'/'//' prefixes (its '#' handling carries side effects -- hpHosts
+ * end marker, Spamhaus format detection, h3x CSV header sniff -- and is checked by the
+ * caller itself, never routed through here).
+ *
+ * Regression pin for the DandelionSprouts bug: a hosts-format feed embeds ABP-style
+ * '!#if'/'!#endif' directives mid-body; before this predicate existed, only '#'/'//'
+ * were recognised as comment prefixes in that branch, so a bang-comment line fell
+ * through into "typical host feed" column-stripping and got logged as a parse error.
+ *
+ * Also pins that a scheme-less bracketed-IPv6 line ('://[...]', no leading '#'/'!'/'//')
+ * is NOT swallowed here -- it must keep flowing to the strict-scheme validator, which is
+ * the correct place to reject it (empty scheme before '://' is invalid URI syntax; this
+ * is a separate, upstream-feed-defect concern from comment-line skipping).
+ */
+#[CoversFunction('pfb_is_blank_or_comment_line')]
+final class BlankOrCommentLineTest extends TestCase
+{
+	public function testEmptyStringIsBlank(): void
+	{
+		$this->assertTrue(pfb_is_blank_or_comment_line(''));
+	}
+
+	public function testUntrimmedWhitespaceOnlyStringIsNotBlank(): void
+	{
+		// empty('   ') is FALSE in PHP -- this predicate relies on the caller having
+		// already trim()'d $line (both call sites do), matching every other
+		// empty($line) check in this file rather than reimplementing trim-and-check.
+		// Pins the contract explicitly instead of leaving it an unstated assumption.
+		$this->assertFalse(pfb_is_blank_or_comment_line('   '));
+	}
+
+	public function testHashCommentIsSkipped(): void
+	{
+		$this->assertTrue(pfb_is_blank_or_comment_line('# a hosts-style comment'));
+		$this->assertTrue(pfb_is_blank_or_comment_line('#'));
+	}
+
+	public function testBangCommentIsSkipped(): void
+	{
+		$this->assertTrue(pfb_is_blank_or_comment_line('!#if !env_mv3'));
+		$this->assertTrue(pfb_is_blank_or_comment_line('!#endif'));
+	}
+
+	public function testSlashSlashCommentIsSkipped(): void
+	{
+		$this->assertTrue(pfb_is_blank_or_comment_line('// a C-style comment'));
+	}
+
+	public function testSingleSlashIsNotACommentPrefix(): void
+	{
+		// A lone leading '/' (e.g. a path-shaped line) must NOT match '//' by accident.
+		$this->assertFalse(pfb_is_blank_or_comment_line('/etc/foo'));
+	}
+
+	public function testOrdinaryDomainLineIsNotSkipped(): void
+	{
+		$this->assertFalse(pfb_is_blank_or_comment_line('example.com'));
+	}
+
+	public function testOrdinaryIpLineIsNotSkipped(): void
+	{
+		$this->assertFalse(pfb_is_blank_or_comment_line('192.0.2.1'));
+	}
+
+	public function testSchemeLessBracketedIpv6IsNotSwallowedAsAComment(): void
+	{
+		// ':' is not '#'/'!'/'//' -- must fall through to the strict-scheme validator,
+		// which is the correct layer to reject this (empty scheme before '://').
+		$this->assertFalse(pfb_is_blank_or_comment_line('://[2604:2dc0:100:4ed8::]'));
+	}
+}

--- a/tests/smoke/test_smoke_714_asn_geoip.py
+++ b/tests/smoke/test_smoke_714_asn_geoip.py
@@ -259,11 +259,14 @@ def test_714_b2_parse_fail_counts_every_bad_line(deployed_vm: SmokeVM) -> None:
     RED before / GREEN after (no external credentials needed): pre-fix, the "Check for
     parse failures" block sat OUTSIDE the ``while (fgets...)`` loop, so it ran exactly
     ONCE using whatever ``$line`` the loop last left behind — the LAST line read, our
-    single VALID trailing IP (non-empty, letter-free) — so the log would show
-    ``[!] Parse Errors [ 1 ]`` even though 3 lines actually failed to parse. Post-fix
-    the block is the last statement INSIDE the loop, evaluating every line that fell
-    through without a ``continue`` (every failed parse); the trailing valid IP
-    ``continue``s before reaching it — so the log shows ``[!] Parse Errors [ 3 ]``.
+    single VALID trailing IP (non-empty, letter-free) — so the log would show a count of
+    1 even though 3 lines actually failed to parse. Post-fix the block is the last
+    statement INSIDE the loop, evaluating every line that fell through without a
+    ``continue`` (every failed parse); the trailing valid IP ``continue``s before
+    reaching it — so the counter reaches 3. The counter is reported once per feed, after
+    the loop, as ``[!] Parse Errors [ <header> ]: <count>`` (naming the feed matters: this
+    line is logtype 2, also written to the error log, which has no surrounding
+    "[ header ] Reload..." context of its own).
 
     NOTE: this is the IP-side ``$parse_fail`` counter in the MAIN pfBlockerNG log —
     distinct from the DNSBL per-line parse-error CSV (``pfb_parsed_fail()`` →
@@ -274,9 +277,9 @@ def test_714_b2_parse_fail_counts_every_bad_line(deployed_vm: SmokeVM) -> None:
       fallback cannot silently ``continue`` past the check) followed by ONE valid
       RFC 5737 IP as the LAST line,
     When a Force IP reload parses the feed,
-    Then the pfBlockerNG log gains a ``[!] Parse Errors [ 3 ]`` line — the counter
-      reached the number of bad lines, not merely "1" (the pre-fix last-line-only
-      count).
+    Then the pfBlockerNG log gains a ``[!] Parse Errors [ smoke714b2 ]: 3`` line — the
+      counter reached the number of bad lines, not merely "1" (the pre-fix
+      last-line-only count).
     """
     # Each has only TWO dots, so it fails IPv4 parsing AND is skipped by the regex
     # fallback (which requires >=3 dots) — guaranteeing it falls through to the
@@ -286,7 +289,7 @@ def test_714_b2_parse_fail_counts_every_bad_line(deployed_vm: SmokeVM) -> None:
     good_line = "198.51.100.7"  # RFC 5737 TEST-NET-2 — the trailing VALID line (must not count)
     body = "\n".join([*bad_lines, good_line]) + "\n"
     feed_url = h.write_local_feed(deployed_vm, "smoke_714_b2_parsefail.txt", body)
-    marker = "[!] Parse Errors [ 3 ]"
+    marker = "[!] Parse Errors [ smoke714b2 ]: 3"
     spec = h.IpCase(aliasname="smoke714b2", feed_url=feed_url, header="smoke714b2", family="v4")
 
     try:

--- a/tests/smoke/test_smoke_714_asn_geoip.py
+++ b/tests/smoke/test_smoke_714_asn_geoip.py
@@ -277,9 +277,12 @@ def test_714_b2_parse_fail_counts_every_bad_line(deployed_vm: SmokeVM) -> None:
       fallback cannot silently ``continue`` past the check) followed by ONE valid
       RFC 5737 IP as the LAST line,
     When a Force IP reload parses the feed,
-    Then the pfBlockerNG log gains a ``[!] Parse Errors [ smoke714b2 ]: 3`` line — the
-      counter reached the number of bad lines, not merely "1" (the pre-fix
-      last-line-only count).
+    Then the pfBlockerNG log gains a ``[!] Parse Errors [ smoke714b2_v4 ]: 3`` line —
+      the counter reached the number of bad lines, not merely "1" (the pre-fix
+      last-line-only count). The feed HEADER in that line carries the family
+      suffix (``pfblockerng.inc``'s ``$header = "{$row['header']}{$list['vtype']}"``),
+      same gotcha ``force_ip_refetch()`` already documents for the on-disk feed
+      filename — it is NOT the bare ``IpCase.header`` value.
     """
     # Each has only TWO dots, so it fails IPv4 parsing AND is skipped by the regex
     # fallback (which requires >=3 dots) — guaranteeing it falls through to the
@@ -289,8 +292,10 @@ def test_714_b2_parse_fail_counts_every_bad_line(deployed_vm: SmokeVM) -> None:
     good_line = "198.51.100.7"  # RFC 5737 TEST-NET-2 — the trailing VALID line (must not count)
     body = "\n".join([*bad_lines, good_line]) + "\n"
     feed_url = h.write_local_feed(deployed_vm, "smoke_714_b2_parsefail.txt", body)
-    marker = "[!] Parse Errors [ smoke714b2 ]: 3"
     spec = h.IpCase(aliasname="smoke714b2", feed_url=feed_url, header="smoke714b2", family="v4")
+    # $header at the print site is "{row.header}{vtype}", e.g. "smoke714b2_v4" -- NOT
+    # the bare IpCase.header (see docstring).
+    marker = f"[!] Parse Errors [ {spec.header}_{spec.family} ]: 3"
 
     try:
         # BEFORE: this exact marker has never appeared (a fresh aliasname/header pair).

--- a/tests/smoke/test_smoke_adr40.py
+++ b/tests/smoke/test_smoke_adr40.py
@@ -307,19 +307,19 @@ def test_adr40_content_gate_fires_on_change(adr40_vm: SmokeVM) -> None:
 
     # The content change ran the no-rule-change reload path, which logs:
     #   "Alias table changes detected, updating:\n"
-    # immediately followed by per-alias " Updating: <alias>" lines, all CONTIGUOUS (one per
-    # line, no blank lines between them). The sub-header is the anchor; without it the block
-    # reads as a contradiction after "No changes to Firewall rules".
+    # immediately followed by per-alias " Updating [ <alias> ]: <replace|delta ...>" lines,
+    # all CONTIGUOUS (one per line, no blank lines between them). The sub-header is the
+    # anchor; without it the block reads as a contradiction after "No changes to Firewall rules".
     reload_log = adr40_vm.ssh("cat", h.PFB_LOG).stdout[log_len_before:]
     assert "Alias table changes detected, updating:" in reload_log, (
         "expected 'Alias table changes detected, updating:' sub-header in the reload log "
         f"after a content change (no-rule-change path):\n{reload_log[-1500:]}"
     )
-    assert " Updating:" in reload_log, (
-        f"expected a per-alias ' Updating:' line in the reload log after a content change:\n{reload_log[-1500:]}"
+    assert " Updating [" in reload_log, (
+        f"expected a per-alias ' Updating [' line in the reload log after a content change:\n{reload_log[-1500:]}"
     )
-    assert "\n\n Updating:" not in reload_log, (
-        "per-alias ' Updating:' log lines are blank-separated (a leading newline in the log "
+    assert "\n\n Updating [" not in reload_log, (
+        "per-alias ' Updating [' log lines are blank-separated (a leading newline in the log "
         f"format) — they must be contiguous:\n{reload_log[-1500:]}"
     )
 
@@ -393,7 +393,7 @@ def test_adr40_delta_apply_small_churn(adr40_vm: h.SmokeVM) -> None:
     — ``test_adr40_delta_replace_mode`` produces the identical pf-table end-state, so a
     regression that silently routed this "delta" run through -T replace would pass every
     assertion above unnoticed. ``pfb_apply_alias_delta()`` now logs a
-    " ADR-40 apply [ <table> ]: delta +N/-M" / "…: replace" marker naming the actual
+    " Updating [ <table> ]: delta +N/-M" / "…: replace" marker naming the actual
     apply path taken (pfblockerng.inc ~4711-4736) — the ONLY on-box signal that
     discriminates the two (``pfb_pfctl_table_op()`` itself logs only on error). This test
     asserts the DELTA marker fired for this table and the REPLACE marker did NOT.
@@ -434,8 +434,8 @@ def test_adr40_delta_apply_small_churn(adr40_vm: h.SmokeVM) -> None:
         # issue #722: capture the apply-path markers for THIS table right before the change
         # reload, isolating its own delta/replace decision from the settling reload above
         # (which force-replaces on first creation) and from any other table in the run.
-        delta_marker = f" ADR-40 apply [ {ip_spec.alias} ]: delta "
-        replace_marker = f" ADR-40 apply [ {ip_spec.alias} ]: replace"
+        delta_marker = f" Updating [ {ip_spec.alias} ]: delta "
+        replace_marker = f" Updating [ {ip_spec.alias} ]: replace"
         delta_before = h.count_log_marker(adr40_vm, h.PFB_LOG, delta_marker)
         replace_before = h.count_log_marker(adr40_vm, h.PFB_LOG, replace_marker)
 
@@ -561,8 +561,8 @@ def test_adr40_delta_replace_mode(adr40_vm: h.SmokeVM) -> None:
         # issue #722: capture the apply-path markers for THIS table right before the change
         # reload (the settling reload above already force-replaces on first creation, so it
         # must NOT be counted as evidence of this change's own decision).
-        delta_marker = f" ADR-40 apply [ {ip_spec.alias} ]: delta "
-        replace_marker = f" ADR-40 apply [ {ip_spec.alias} ]: replace"
+        delta_marker = f" Updating [ {ip_spec.alias} ]: delta "
+        replace_marker = f" Updating [ {ip_spec.alias} ]: replace"
         delta_before = h.count_log_marker(adr40_vm, h.PFB_LOG, delta_marker)
         replace_before = h.count_log_marker(adr40_vm, h.PFB_LOG, replace_marker)
 


### PR DESCRIPTION
## Summary

Several small parse/log defects found while reading a live `v4.0.0.alpha.20` update log
(root cause confirmed live against `root@10.0.0.1`, not guessed):

- ADR-40's alias-apply log line said `ADR-40 apply [ table ]: ...` — a dev-facing ADR
  reference leaking into a user-visible log. Renamed to `Updating [ table ]: ...` and
  merged the redundant separate `Updating: table` pre-print into the same line.
- DNSBL hosts-format feeds (e.g. DandelionSprouts) embed ABP-style `!#if`/`!#endif`
  preprocessor directives mid-body. Only the header-scan phase skipped `!`-prefixed
  lines; a mid-body one fell through into "typical host feed" column-stripping and got
  logged as a bogus parse error.
- The DNSBL per-feed progress line's trailing dot printed AFTER the strict-scheme WARNING
  instead of before, stranding it on its own line when the warning fired.
- The generic (non-DNSBL) IP-list parser only recognized `#` as a comment prefix; added
  `!` and `//` (also extracted the combined blank-or-comment check into
  `pfb_is_blank_or_comment_line()`, reused by both parsers).
- The generic IP-list parser counted a syntactically valid address of the list's OTHER
  family (e.g. a hex-letter-free IPv6 line in a `_v4` list) as a parse failure —
  mixed-family feeds are common (confirmed live: `qfeeds_ip_list_v4` has 2151 IPv6 lines
  mixed into a `_v4`-typed feed), and that family is silently uncollected either way;
  only genuine garbage should count as an error.
- The per-feed `[!] Parse Errors [ N ]` line was spammed once PER bad line (up to 967 in
  one observed feed) instead of once with the final count, and didn't name the feed — the
  message is also written to the error log, which has no surrounding
  `[ header ] Reload...` context of its own.

## Test plan

- New `tests/php/BlankOrCommentLineTest.php` pins the extracted
  `pfb_is_blank_or_comment_line()` predicate directly (9 tests), including the
  `://[ipv6]` hostile-input case — an empty-scheme URL, correctly NOT treated as a
  comment; it must keep flowing to strict-scheme rejection. Red-before/green-after
  proven against a read-only pre-session snapshot (function undefined → 9 errors;
  current tree → 9 passes).
- Updated `AliasDeltaApplyTest.php` (16 log-marker assertions) and the two live-VM smoke
  tests (`test_smoke_adr40.py`, `test_smoke_714_asn_geoip.py`) that assert on the changed
  log-string literals.
- `sync_package_pfblockerng()` itself has no PHPUnit coverage (tracked in #993) and is
  4437 lines / 743 branches (tracked in #995, filed alongside this fix) — the end-to-end
  DNSBL/IP-list log-output behavior is hand-verified against a live box plus the
  extracted-helper unit test; it still needs live-VM smoke coverage as a follow-up.
- [x] `php -l` clean
- [x] `vendor/bin/phpunit` — 2449/2449 (post-rebase onto origin/devel)
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist` clean
- [x] `vendor/bin/phpstan analyse` clean
- [x] `python3 scripts/check_comment_narration.py` clean
- [x] `ruff check` clean on the two touched smoke test files

Related: #993, #995 (both filed during this investigation, not fixed by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2zqd3YhvNuyrUh5om1su7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed parsing to handle blank lines and common comment styles more consistently.
  * Reduced false parse errors for mixed IPv4/IPv6 content and changed error reporting to a single summary per feed.
  * Updated update-status logs and missing-file messages for clearer, more consistent progress output.

* **Tests**
  * Updated automated coverage to match the revised log output and parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->