### PR TITLE
pfblockerng: fix 3 more DNSBL/IP-list parse bugs found in v4.0.0.alpha.21

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6370,6 +6370,19 @@ function pfb_dnsbl_strip_scheme(string $line, bool $strict = FALSE): string|fals
 	}
 	if ($strict) {
 		$scheme = substr($line, 0, $pos);
+		if ($scheme === '') {
+			// A bare '://' (empty scheme) in front of a bracketed IPv6 literal is a
+			// known DandelionSprouts-style "block regardless of scheme" convention --
+			// let ONLY that exact shape through so pfb_dnsbl_unbracket_ip6() (which
+			// runs later in the caller) can unwrap it. Any other empty-scheme line is
+			// still an invalid URI and rejected, same as before.
+			$remainder = substr($line, $pos + 3);
+			if (str_starts_with($remainder, '[') && str_ends_with($remainder, ']') &&
+			    is_ipaddrv6(substr($remainder, 1, -1))) {
+				return $remainder;
+			}
+			return FALSE;
+		}
 		if (!preg_match('/^[a-zA-Z][a-zA-Z0-9+\-.]*$/', $scheme)) {
 			return FALSE;
 		}
@@ -18027,6 +18040,10 @@ function sync_package_pfblockerng($cron='') {
 													}
 												}
 											}
+											// Mirrors the IPv4 regex-parser sibling block above: without this,
+											// a line the regex already matched and collected still falls
+											// through to the parse-fail heuristic below and is double-counted.
+											continue;
 										}
 									}
 
@@ -18058,8 +18075,10 @@ function sync_package_pfblockerng($cron='') {
 							// line, e.g. "[!] Parse Errors [ 1 ]" through "[ 967 ]" for a single feed.
 							// Names the feed: this is logtype 2 (also written to the error log,
 							// which has no surrounding "[ header ] Reload..." context of its own).
+							// Leading \n: this always follows the unterminated "Reload . completed .."
+							// progress line above.
 							if ($parse_fail > 0) {
-								pfb_logger("[!] Parse Errors [ {$header} ]: {$parse_fail}\n", 2);
+								pfb_logger("\n[!] Parse Errors [ {$header} ]: {$parse_fail}\n", 2);
 							}
 							pfb_logger("\n", 1);
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6371,11 +6371,9 @@ function pfb_dnsbl_strip_scheme(string $line, bool $strict = FALSE): string|fals
 	if ($strict) {
 		$scheme = substr($line, 0, $pos);
 		if ($scheme === '') {
-			// A bare '://' (empty scheme) in front of a bracketed IPv6 literal is a
-			// known DandelionSprouts-style "block regardless of scheme" convention --
-			// let ONLY that exact shape through so pfb_dnsbl_unbracket_ip6() (which
-			// runs later in the caller) can unwrap it. Any other empty-scheme line is
-			// still an invalid URI and rejected, same as before.
+			// DandelionSprouts' "block regardless of scheme" shape: a bare '://' in
+			// front of a bracketed IPv6 literal. Let ONLY this exact form through for
+			// pfb_dnsbl_unbracket_ip6() to unwrap; any other empty scheme is rejected.
 			$remainder = substr($line, $pos + 3);
 			if (str_starts_with($remainder, '[') && str_ends_with($remainder, ']') &&
 			    is_ipaddrv6(substr($remainder, 1, -1))) {
@@ -18075,8 +18073,10 @@ function sync_package_pfblockerng($cron='') {
 							// line, e.g. "[!] Parse Errors [ 1 ]" through "[ 967 ]" for a single feed.
 							// Names the feed: this is logtype 2 (also written to the error log,
 							// which has no surrounding "[ header ] Reload..." context of its own).
-							// Leading \n: this always follows the unterminated "Reload . completed .."
-							// progress line above.
+							// Leading \n: closes the unterminated "Reload . completed .." progress
+							// line above (a rarely-configured per-list Pre Script tunable can print
+							// its own newline-terminated line first instead -- one harmless extra
+							// blank line in that case, not a rejoin).
 							if ($parse_fail > 0) {
 								pfb_logger("\n[!] Parse Errors [ {$header} ]: {$parse_fail}\n", 2);
 							}

--- a/tests/php/PfbDnsblStripSchemeTest.php
+++ b/tests/php/PfbDnsblStripSchemeTest.php
@@ -191,4 +191,40 @@ final class PfbDnsblStripSchemeTest extends TestCase
 		// No '://' -> returned unchanged regardless of toggle state.
 		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('evil.com', true));
 	}
+
+	// --- Empty scheme + bracketed IPv6: a known DandelionSprouts-style "block
+	//     regardless of scheme" convention. Confirmed live: 4 identical-shaped lines
+	//     in a real feed, each pairing with an adjacent hosts-format block entry for
+	//     the same campaign. ---
+
+	public function testEmptySchemeBracketedIpv6PassesThroughWhenStrict(): void
+	{
+		// The brackets are NOT unwrapped here -- that is pfb_dnsbl_unbracket_ip6()'s
+		// job, called later in the caller. This function only decides "is this a
+		// scheme-rejection", so it returns the remainder as-is.
+		$this->assertSame(
+			'[2604:2dc0:100:4ed8::]',
+			pfb_dnsbl_strip_scheme('://[2604:2dc0:100:4ed8::]', true)
+		);
+	}
+
+	public function testEmptySchemeNonBracketedStillRejectedWhenStrict(): void
+	{
+		// The special-case is narrow: an empty scheme with anything OTHER than an
+		// exact '[valid-ipv6]' remainder is still rejected, same as before.
+		$this->assertFalse(pfb_dnsbl_strip_scheme('://evil.com', true));
+	}
+
+	public function testEmptySchemeInvalidBracketContentRejectedWhenStrict(): void
+	{
+		// A bracket-wrapped string that is NOT a valid IPv6 literal does not qualify.
+		$this->assertFalse(pfb_dnsbl_strip_scheme('://[not-an-ipv6]', true));
+	}
+
+	public function testEmptySchemeBracketedIpv6WithTrailingJunkRejectedWhenStrict(): void
+	{
+		// Anything beyond the exact '[...]' shape (a path, trailing text) is still
+		// an invalid URI and rejected -- only the clean whole-line form is special-cased.
+		$this->assertFalse(pfb_dnsbl_strip_scheme('://[2604:2dc0:100:4ed8::]/path', true));
+	}
 }

--- a/tests/php/PfbDnsblStripSchemeTest.php
+++ b/tests/php/PfbDnsblStripSchemeTest.php
@@ -192,10 +192,8 @@ final class PfbDnsblStripSchemeTest extends TestCase
 		$this->assertSame('evil.com', pfb_dnsbl_strip_scheme('evil.com', true));
 	}
 
-	// --- Empty scheme + bracketed IPv6: a known DandelionSprouts-style "block
-	//     regardless of scheme" convention. Confirmed live: 4 identical-shaped lines
-	//     in a real feed, each pairing with an adjacent hosts-format block entry for
-	//     the same campaign. ---
+	// --- Empty scheme + bracketed IPv6: DandelionSprouts' "block regardless of
+	//     scheme" shape (confirmed live: 4 identical-shaped lines in a real feed). ---
 
 	public function testEmptySchemeBracketedIpv6PassesThroughWhenStrict(): void
 	{

--- a/tests/smoke/test_smoke_714_asn_geoip.py
+++ b/tests/smoke/test_smoke_714_asn_geoip.py
@@ -344,15 +344,15 @@ def test_714_b3_v6_regex_parser_success_not_double_counted(deployed_vm: SmokeVM)
     hex letter (a-f) never reaches the heuristic regardless of this bug.
 
     Given a v6 feed with two syntactically valid, hex-letter-free IPv6 addresses
-      (2000:0:0:0:0:0:0:1 / 2000:0:0:0:0:0:0:2 — outside the RFC 3849 documentation
-      range specifically because that range's 'db8' hextet contains hex letters),
-      via a URL with no path extension (forces $pftype='regex', matching the live
-      qfeeds_ip_list_v6 case),
+      (2000::1 / 2000::2 — outside the RFC 3849 documentation range specifically
+      because that range's 'db8' hextet contains hex letters), via a URL with no
+      path extension (forces $pftype='regex', matching the live qfeeds_ip_list_v6
+      case),
     When a Force IP reload parses the feed,
     Then the pfBlockerNG log gains NO "[!] Parse Errors" line for this feed — both
       addresses were collected, not flagged.
     """
-    good_lines = ["2000:0:0:0:0:0:0:1", "2000:0:0:0:0:0:0:2"]
+    good_lines = ["2000::1", "2000::2"]
     body = "\n".join(good_lines) + "\n"
     # No '.' in the name -> pathinfo() finds no extension -> $pftype='regex',
     # reproducing the live qfeeds_ip_list_v6 (query-string-only URL) case.
@@ -367,10 +367,13 @@ def test_714_b3_v6_regex_parser_success_not_double_counted(deployed_vm: SmokeVM)
         h.reload(deployed_vm, "update")
 
         # THEN: both addresses reached the pf table (proves they were actually parsed
-        # and collected, not silently dropped by some other mechanism).
+        # and collected, not silently dropped by some other mechanism). By-VALUE
+        # comparison (h.ip_in): pf/pfBlockerNG may render a compressed literal
+        # differently (e.g. an equivalent expanded form), which a substring check
+        # would miss.
         members = h.wait_pfctl_table(deployed_vm, spec.alias)
         for ip in good_lines:
-            assert any(ip in m for m in members), f"expected valid IPv6 {ip} in pf table {spec.alias}: {members}"
+            assert h.ip_in(ip, members), f"expected valid IPv6 {ip} in pf table {spec.alias}: {members}"
 
         # AND: no parse-error line was emitted for this feed.
         after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)

--- a/tests/smoke/test_smoke_714_asn_geoip.py
+++ b/tests/smoke/test_smoke_714_asn_geoip.py
@@ -314,3 +314,72 @@ def test_714_b2_parse_fail_counts_every_bad_line(deployed_vm: SmokeVM) -> None:
     finally:
         h.reset(deployed_vm)
         deployed_vm.ssh("/bin/rm", "-f", feed_url)
+
+
+# --------------------------------------------------------------------------- #
+# b3 — a hex-letter-free, syntactically valid IPv6 address in a '_v6' list running
+# in REGEX mode must NOT be double-counted as a parse failure once it has already
+# been collected. CI-RUNNABLE: no external credentials needed.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(300)
+def test_714_b3_v6_regex_parser_success_not_double_counted(deployed_vm: SmokeVM) -> None:
+    """sync_package_pfblockerng's IPv6 "regex fallback" parser must ``continue`` after
+    successfully collecting an address, mirroring its IPv4 sibling block — else a line
+    it already matched and validated still falls through to the parse-fail heuristic
+    and gets counted as an error.
+
+    RED before / GREEN after: confirmed live against a real feed (qfeeds_ip_list_v6,
+    format=auto but a query-string-only URL with no path extension resolves to
+    $pftype='regex' via the extension-fallback rule) — 97 syntactically valid,
+    hex-letter-free IPv6 addresses were all successfully extracted by
+    ``preg_match_all($pfb['ipv6'], ...)`` and collected into ``$ip_data``, yet the
+    "IPv6 Regex parser" block never ``continue``s (unlike the IPv4 regex-parser
+    sibling, which already does), so every one of them ALSO fell through to
+    "Check for parse failures" and was double-counted.
+
+    A hex-letter-free address is required to reproduce this: the parse-fail
+    heuristic itself only considers a-zA-Z-free lines, so an address with any
+    hex letter (a-f) never reaches the heuristic regardless of this bug.
+
+    Given a v6 feed with two syntactically valid, hex-letter-free IPv6 addresses
+      (2000:0:0:0:0:0:0:1 / 2000:0:0:0:0:0:0:2 — outside the RFC 3849 documentation
+      range specifically because that range's 'db8' hextet contains hex letters),
+      via a URL with no path extension (forces $pftype='regex', matching the live
+      qfeeds_ip_list_v6 case),
+    When a Force IP reload parses the feed,
+    Then the pfBlockerNG log gains NO "[!] Parse Errors" line for this feed — both
+      addresses were collected, not flagged.
+    """
+    good_lines = ["2000:0:0:0:0:0:0:1", "2000:0:0:0:0:0:0:2"]
+    body = "\n".join(good_lines) + "\n"
+    # No '.' in the name -> pathinfo() finds no extension -> $pftype='regex',
+    # reproducing the live qfeeds_ip_list_v6 (query-string-only URL) case.
+    feed_url = h.write_local_feed(deployed_vm, "smoke_714_b3_v6regex_ok", body)
+    spec = h.IpCase(aliasname="smoke714b3", feed_url=feed_url, header="smoke714b3", family="v6")
+    marker = f"[!] Parse Errors [ {spec.header}_{spec.family} ]"
+
+    try:
+        before = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+
+        h.inject(deployed_vm, spec)
+        h.reload(deployed_vm, "update")
+
+        # THEN: both addresses reached the pf table (proves they were actually parsed
+        # and collected, not silently dropped by some other mechanism).
+        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        for ip in good_lines:
+            assert any(ip in m for m in members), f"expected valid IPv6 {ip} in pf table {spec.alias}: {members}"
+
+        # AND: no parse-error line was emitted for this feed.
+        after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+        assert after == before, (
+            f"expected NO new {marker!r} line in {h.PFB_LOG} (before={before}, "
+            f"after={after}) — both lines were valid IPv6 addresses that got "
+            f"collected; the regex-parser success path must not also count them "
+            f"as parse failures"
+        )
+    finally:
+        h.reset(deployed_vm)
+        deployed_vm.ssh("/bin/rm", "-f", feed_url)


### PR DESCRIPTION
## Summary

Follow-up fixes found by SSH'ing into a live box (`root@10.0.0.1`) running `v4.0.0.alpha.21`
and comparing the update log against expectations — three real bugs, each confirmed against
live feed data before fixing:

- **Missing newline (regression from #996).** The generic IP-list per-feed
  `[!] Parse Errors [ header ]: N` summary lacked a leading `\n`, so it glued onto the
  preceding unterminated `Reload . completed ..` line — same bug class already fixed for
  DNSBL, just in the sibling print site added afterward.
- **Q-Feeds IPv6 false positives.** `qfeeds_ip_list_v6` (any `_v6`-typed list whose URL has
  no path extension, resolving to `$pftype='regex'`) reported dozens of false
  `Parse Errors` for perfectly valid, hex-letter-free IPv6 addresses. Root cause: the
  "IPv6 Regex parser" fallback successfully collects matches into `$ip_data` but never
  `continue`s afterward — unlike its IPv4 sibling, which already does — so every collected
  line also fell through to the parse-fail heuristic and got double-counted. Verified live:
  every flagged line in a real feed was confirmed a syntactically valid, already-collected
  address via the production regex + validator, run directly on the box.
- **DNSBL `://[ipv6]` rejection.** Strict-scheme validation rejected an empty scheme in
  front of a bracketed IPv6 literal as an invalid URI. Live feed inspection
  (DandelionSprouts) shows this shape used consistently for real block entries, paired with
  adjacent hosts-format lines for the same campaign — a "block regardless of scheme"
  convention, not corrupted data. `pfb_dnsbl_strip_scheme()` now lets only this exact shape
  through so the existing bracket-unwrap (#938) can collect it; every other empty-scheme
  line is still rejected exactly as before.

## Test plan

- `tests/php/PfbDnsblStripSchemeTest.php`: 4 new cases pin the strict-mode scheme fix
  directly (unit-testable, real seam).
- `tests/smoke/test_smoke_714_asn_geoip.py`: new live-VM test `b3` mirrors `b2`'s
  established shape — crafts two hex-letter-free IPv6 addresses in a `$pftype='regex'`
  feed, asserts both reach the pf table AND no `Parse Errors` line is emitted.
- The leading-`\n` fix has no extracted seam (same `sync_package_pfblockerng()` monolith
  constraint as #993) — deferred to that tracked gap, same as the prior PR.
- [x] `php -l` clean
- [x] `vendor/bin/phpunit` — 2453/2453
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist src/` clean
- [x] `vendor/bin/phpstan analyse` clean
- [x] `python3 scripts/check_comment_narration.py` clean
- [x] `ruff check` / `ruff format --check` clean

Related: #993 (tracks the untested-monolith gap this PR's b3 test partially closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2zqd3YhvNuyrUh5om1su7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of inputs with an empty scheme so valid bracketed IPv6 addresses can be accepted, while other malformed forms are still rejected.
  * Prevented IPv4/regex parsing from counting the same input error twice.
  * Adjusted parse-error log formatting for clearer output in feed and header processing.

* **Tests**
  * Added regression coverage for empty-scheme IPv6 cases and invalid variants.
  * Added a smoke test to verify IPv6 regex parsing works without false parse-error reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->