### PR TITLE
pfblockerng: return bare address from pfb_dnsbl_strip_scheme's IPv6 carve-out

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6372,12 +6372,14 @@ function pfb_dnsbl_strip_scheme(string $line, bool $strict = FALSE): string|fals
 		$scheme = substr($line, 0, $pos);
 		if ($scheme === '') {
 			// DandelionSprouts' "block regardless of scheme" shape: a bare '://' in
-			// front of a bracketed IPv6 literal. Let ONLY this exact form through for
-			// pfb_dnsbl_unbracket_ip6() to unwrap; any other empty scheme is rejected.
+			// front of a bracketed IPv6 literal. Return the bare address directly
+			// (already unwrapped and validated here); any other empty scheme is rejected.
 			$remainder = substr($line, $pos + 3);
-			if (str_starts_with($remainder, '[') && str_ends_with($remainder, ']') &&
-			    is_ipaddrv6(substr($remainder, 1, -1))) {
-				return $remainder;
+			if (str_starts_with($remainder, '[') && str_ends_with($remainder, ']')) {
+				$inner = substr($remainder, 1, -1);
+				if (is_ipaddrv6($inner)) {
+					return $inner;
+				}
 			}
 			return FALSE;
 		}

--- a/tests/php/PfbDnsblStripSchemeTest.php
+++ b/tests/php/PfbDnsblStripSchemeTest.php
@@ -195,13 +195,13 @@ final class PfbDnsblStripSchemeTest extends TestCase
 	// --- Empty scheme + bracketed IPv6: DandelionSprouts' "block regardless of
 	//     scheme" shape (confirmed live: 4 identical-shaped lines in a real feed). ---
 
-	public function testEmptySchemeBracketedIpv6PassesThroughWhenStrict(): void
+	public function testEmptySchemeBracketedIpv6ReturnsBareAddressWhenStrict(): void
 	{
-		// The brackets are NOT unwrapped here -- that is pfb_dnsbl_unbracket_ip6()'s
-		// job, called later in the caller. This function only decides "is this a
-		// scheme-rejection", so it returns the remainder as-is.
+		// Returns the bare address, not the bracketed remainder -- the validation
+		// this branch already did (is_ipaddrv6 on the unwrapped content) would
+		// otherwise be redone by pfb_dnsbl_unbracket_ip6() downstream for nothing.
 		$this->assertSame(
-			'[2604:2dc0:100:4ed8::]',
+			'2604:2dc0:100:4ed8::',
 			pfb_dnsbl_strip_scheme('://[2604:2dc0:100:4ed8::]', true)
 		);
 	}


### PR DESCRIPTION
## Summary

Simplification follow-up to #997, caught in review before deploying: `pfb_dnsbl_strip_scheme()`'s
empty-scheme + bracketed-IPv6 carve-out already computes and validates the unwrapped address
(`is_ipaddrv6(substr($remainder, 1, -1))`) but discarded that result and returned the bracketed
remainder instead — forcing the caller's very next step, `pfb_dnsbl_unbracket_ip6()`, to redo the
identical `substr` + `is_ipaddrv6` work for nothing.

Now returns the already-validated bare address directly. `pfb_dnsbl_unbracket_ip6()` is then a
correct no-op passthrough for it (its own `str_starts_with($line, '[')` check fails on a
bracket-free string) — traced the full downstream chain (`/`/`#`/`?`/`;` strips,
`pfb_strip_trailing_port`, the `is_ipaddrv6($line)` collection branch) to confirm nothing else
depended on the bracketed form.

## Test plan

- `tests/php/PfbDnsblStripSchemeTest.php`: updated the one affected test
  (`testEmptySchemeBracketedIpv6ReturnsBareAddressWhenStrict`) to assert the bare address instead
  of the bracketed remainder.
- [x] `php -l` clean
- [x] `vendor/bin/phpunit` — 2453/2453 (`PfbDnsblStripSchemeTest.php` 27/27 in isolation)
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist src/` clean
- [x] `vendor/bin/phpstan analyse` clean
- [x] `python3 scripts/check_comment_narration.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2zqd3YhvNuyrUh5om1su7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of IPv6 addresses in URLs with an empty scheme, returning the normalized IPv6 address without surrounding brackets.
  * Updated strict-mode behavior so bracketed IPv6 inputs are validated and unwrapped consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->