### PR TITLE
pfblockerng: wire DNSBL feed-download failures to the sync-status ledger

### DIFF
--- a/.ADRs/ADR_61_Sync_Status_Ledger/ADR.md
+++ b/.ADRs/ADR_61_Sync_Status_Ledger/ADR.md
@@ -4,11 +4,12 @@
   PHPUnit + pytest green, PHPCS/PHPStan clean. Phases 3-6 carried DONE-WITH-DEVIATION
   verdicts — each a disclosed, reasoned engineering choice, not a defect (Phase 6's first
   attempt separately failed its own gate on 2 real defects, both fixed in a corrective
-  round; see `RESULTS/06_Results.txt`). Two known, tracked gaps remain open (not blockers
-  to this status, but not silently accepted as done either): the DNSBL feed-download stage
-  was never wired to the ledger (only IP was), and the DNSBL tick-retry is a sentinel-reflip
-  only, not the full restart path, so a genuinely stuck DNSBL condition does not always
-  self-heal via tick alone. See `docs/misc/architecture-notes.md` "Sync-status ledger
+  round; see `RESULTS/06_Results.txt`). One known, tracked gap remains open (not a blocker
+  to this status, but not silently accepted as done either): the DNSBL tick-retry is a
+  sentinel-reflip only, not the full restart path, so a genuinely stuck DNSBL condition
+  does not always self-heal via tick alone (issue #998's DNSBL feed-download gap closed —
+  `pfb_dnsbl_download_ledger_update()` now mirrors the IP call site). See
+  `docs/misc/architecture-notes.md` "Sync-status ledger
   (ADR-61)" for the as-built system and §7 below for the live-VM acceptance checklist that
   flips this to **Accepted**.
 - **Date:** 2026-07-08

--- a/.ADRs/ADR_61_Sync_Status_Ledger/ADR.md
+++ b/.ADRs/ADR_61_Sync_Status_Ledger/ADR.md
@@ -440,20 +440,18 @@ overrides this draft) and each row maps to a Phase-2/3/4 test or an explicit def
      ledger files read as absent/empty (Semantics #6, fail-open display) regardless of
      any pre-reboot open entry; a still-real underlying condition re-opens its entry on
      the pipeline's own next natural pass, not automatically at boot.
-  8. **DNSBL feed download failure — expected to FAIL today, tracked, not silently
-     accepted:** point a DNSBL feed at an unreachable/404 URL. Expected (current,
-     known-gap behavior): the DNSBL row does **not** turn yellow for this specific
-     failure (the DNSBL feed-download call site was never wired to the ledger — see
-     architecture-notes "Known gap"). This step exists so the gap is verified-real, not
-     assumed; closing it is a follow-up, not blocking this ADR's Accepted flip for the
-     stages that ARE wired.
+  8. **DNSBL feed download failure, then self-heal (issue #998 follow-up, now wired):**
+     point a DNSBL feed at an unreachable/404 URL, run an update pass. Expected: DNSBL
+     row turns yellow within that pass; the reporting list shows the entry with a
+     working deep link to the alias editor (`pfb_dnsbl_download_ledger_update()` keys
+     on the `DNSBL_`-prefixed `$alias`, mirroring step 2's IP behavior);
+     `error.log` gains the historical FAIL line and is left untouched. Fix the URL, run
+     again. Expected: entry clears, row returns to green (assuming no other open DNSBL
+     entry).
 
-- **Accepted** requires steps 1-7 green: a genuine DNSBL apply failure that fails to
+- **Accepted** requires steps 1-8 green: a genuine DNSBL apply failure that fails to
   self-heal via tick alone (step 5) is the EXPECTED, documented behavior, not a
-  regression — do not treat it as a smoke failure. Step 8's known gap is an accepted,
-  tracked limitation, not an acceptance blocker (CLAUDE.md "ADR acceptance": a
-  documented out-of-scope item is not a blocker), but it must remain tracked (issue
-  filed) rather than forgotten.
+  regression — do not treat it as a smoke failure.
 - **Reject criteria (already resolved, kept for record):** Phase 4's Python-side chroot
   status file proved straightforward to write from inside the jail — no chroot-boundary
   fallback was needed; the file mirrors the existing `pfb_py_reload`/`.applied` marker

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -961,14 +961,9 @@ next success. Open is idempotent-by-key: opening an already-open key refreshes
 | `ip` | `download` | `pfb_ip_download_ledger_update()` at the IP feed-download call site (`pfblockerng.inc`) | paired with the download success path |
 | `ip` | `dedup` | `pfb_sync_status_dedup_check()` (`pfblockerng_extra.inc`), reads the shell's `Sanity check [ PASSED / FAILED ]` line the same way the old widget grep did | replaces that grep entirely |
 | `ip` | `apply` | wired **inside** `pfb_pfctl_table_op()` itself (`pfblockerng.inc`) — a deliberate choice covering every one of that function's callers (delta apply, force-replace, aggregate build/teardown) at one choke point | issue #980's logging-level fix (level 2) is untouched; this ADR only adds the ledger write alongside it |
+| `dnsbl` | `download` | `pfb_dnsbl_download_ledger_update()` at the DNSBL feed-download call site (`pfblockerng.inc`) | paired with the download success path; issue #998 follow-up, mirrors the IP download writer |
 | `dnsbl` | `apply` | `pfb_dnsbl_apply_ledger_update()` + the pure `pfb_dnsbl_converged(): bool` helper (sentinel/applied generation match, Unbound running, `unbound.conf` still wires `pfb_unbound.py`), wired at `pfb_reload_unbound()`'s zero-downtime-success return and its shared-restart tail (mode-gated) | the swap-not-confirmed → restart-fallback branch never opens an entry by itself (fail-safe by design, not an error) |
 | `dnsbl` | `parse` | Python-owned, 8 sites in `pfb_unbound.py`: the zone/data/whitelist/hsts/SafeSearch loaders and the `pfb_unbound.ini` config read (each extracted into its own testable `_load_*` function) plus the DNSBL manifest load (`dnsbl_build_from_manifest()`, both its callers) | 7 further `sys.stderr.write` sites (module-capability imports, per-pattern REGEX-ini rows, background-thread bring-up) are deliberately left freetext-only — no stable per-run item identity / no natural clear site; still visible in `py_error.log` as before |
-
-**Known gap, not yet closed:** the ADR's own writer table calls for **IP + DNSBL** feed-download
-coverage, but only the IP call site got wired — the DNSBL feed-download call site
-(`pfb_download_failure()`'s DNSBL-branch caller) has no ledger writer today, so a DNSBL feed
-download failure is currently invisible to the ledger (still logged to `error.log` as always).
-Tracked as a follow-up, not silently accepted as done.
 
 ### Tick-driven reconciliation — apply stage only
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -16085,6 +16085,9 @@ function sync_package_pfblockerng($cron='') {
 
 											// Determine reason for download failure
 											pfb_download_failure($alias, $header, $pfbfolder, $row['url'], $row['format'], '');
+											// ADR-61: keyed on $alias (pfB_/DNSBL_-prefixed), not $header --
+											// the widget's deep-link match needs that prefix (issue #998).
+											pfb_dnsbl_download_ledger_update(FALSE, $alias, "[ {$alias} - {$header} ] Download FAIL", $pfb['dbdir']);
 
 											// Utilize previously download file (If 'fail' marker exists)
 											if (file_exists("{$pfbfolder}/{$header}.fail") &&
@@ -16097,6 +16100,7 @@ function sync_package_pfblockerng($cron='') {
 										else {
 											// Clear any previous download fail marker
 											unlink_if_exists("{$pfbfolder}/{$header}.fail");
+											pfb_dnsbl_download_ledger_update(TRUE, $alias, '', $pfb['dbdir']);
 										}
 									}
 								}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2945,6 +2945,26 @@ function pfb_ip_download_ledger_update(bool $download_ok, string $item, string $
 }
 
 /**
+ * pfb_dnsbl_download_ledger_update — translate one DNSBL feed's download result into
+ * the sync-status ledger. FALSE opens facility=dnsbl stage=download for $item; TRUE
+ * closes the same key. Mirrors pfb_ip_download_ledger_update() (issue #998).
+ *
+ * @param bool   $download_ok TRUE when pfb_download() succeeded for this item.
+ * @param string $item        The alias/feed header identifying this download.
+ * @param string $message     Human-readable failure text (ignored on success).
+ * @param string $ledger_dir  Directory that contains pfb_sync_status.json.
+ * @return void
+ */
+function pfb_dnsbl_download_ledger_update(bool $download_ok, string $item, string $message, string $ledger_dir): void
+{
+	if ($download_ok) {
+		pfb_sync_status_close('dnsbl', $item, 'download', $ledger_dir);
+	} else {
+		pfb_sync_status_open('dnsbl', $item, 'download', $message, $ledger_dir);
+	}
+}
+
+/**
  * pfb_sync_status_dedup_check — mirror the shell's "Sanity check" line (pfblockerng.sh's
  * closingprocess(), 'Database Sanity check [ PASSED / FAILED ]') into the IP dedup ledger
  * key -- the same LAST-line-wins read as the widget's `grep 'Sanity check' | tail -1`.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2950,7 +2950,8 @@ function pfb_ip_download_ledger_update(bool $download_ok, string $item, string $
  * closes the same key. Mirrors pfb_ip_download_ledger_update() (issue #998).
  *
  * @param bool   $download_ok TRUE when pfb_download() succeeded for this item.
- * @param string $item        The alias/feed header identifying this download.
+ * @param string $item        The pfB_/DNSBL_-prefixed alias, NOT the per-row $header --
+ *                             the widget's deep-link match depends on the prefix.
  * @param string $message     Human-readable failure text (ignored on success).
  * @param string $ledger_dir  Directory that contains pfb_sync_status.json.
  * @return void

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -6,21 +6,25 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * ADR-61 Phase 3 — DNSBL-side sync-status writer/clearer pairs.
+ * ADR-61 Phase 3 (+ #998 follow-up) — DNSBL-side sync-status writer/clearer pairs.
  *
  * The apply-stage decision (pfb_dnsbl_apply_ledger_update(), built on
  * pfb_dnsbl_converged()) is tested directly for the open/close/refresh
  * contract, and separately end-to-end through the REAL pfb_reload_unbound()
  * to prove its swap-not-confirmed restart-fallback branch does not, by
  * itself, leave a ledger entry behind (ADR SS1.3: "NOT an error: fail-safe
- * by design").
+ * by design"). The feed-download pair (pfb_dnsbl_download_ledger_update())
+ * mirrors the IP side's PfbSyncStatusIpWritersTest Pair 1.
  *
  * Functions under test:
  *   pfb_dnsbl_apply_ledger_update(): void
  *   pfb_reload_unbound(...) -- the zero-downtime swap + restart-fallback paths.
+ *   pfb_dnsbl_download_ledger_update(bool $download_ok, string $item, string $message,
+ *                                      string $ledger_dir): void
  */
 #[CoversFunction('pfb_dnsbl_apply_ledger_update')]
 #[CoversFunction('pfb_reload_unbound')]
+#[CoversFunction('pfb_dnsbl_download_ledger_update')]
 final class PfbSyncStatusDnsblWritersTest extends TestCase
 {
 	private string $dir;
@@ -138,6 +142,67 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 
 		$open = pfb_sync_status_list_open($this->dir, 'dnsbl');
 		$this->assertCount(1, $open, 'two consecutive non-converged reads must refresh, never duplicate');
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_dnsbl_download_ledger_update() -- feed download fail/success (#998)
+	// -----------------------------------------------------------------------
+
+	public function testDnsblDownloadFailureOpensEntry(): void
+	{
+		pfb_dnsbl_download_ledger_update(FALSE, 'DNSBL_Example', '[ DNSBL_Example - Example ] Download FAIL', $this->dir);
+
+		$open = pfb_sync_status_list_open($this->dir, 'dnsbl');
+		$this->assertCount(1, $open, 'a DNSBL download failure must open exactly one entry');
+		$this->assertSame('dnsbl', $open[0]['facility']);
+		$this->assertSame('DNSBL_Example', $open[0]['item']);
+		$this->assertSame('download', $open[0]['stage']);
+		$this->assertStringContainsString('Download FAIL', $open[0]['message']);
+	}
+
+	public function testDnsblDownloadSuccessClosesEntry(): void
+	{
+		pfb_dnsbl_download_ledger_update(FALSE, 'DNSBL_Example', 'Download FAIL', $this->dir);
+		// Before-state: the entry is genuinely open first, so the success close
+		// below is a real transition, not a no-op that happens to leave zero entries.
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'dnsbl'));
+
+		pfb_dnsbl_download_ledger_update(TRUE, 'DNSBL_Example', '', $this->dir);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'),
+			'a paired download success must close the SAME key');
+	}
+
+	public function testDnsblDownloadFailureTwiceRefreshesWithoutDuplicating(): void
+	{
+		pfb_dnsbl_download_ledger_update(FALSE, 'DNSBL_Example', 'HTTP 404', $this->dir);
+		pfb_dnsbl_download_ledger_update(FALSE, 'DNSBL_Example', 'HTTP 500', $this->dir);
+
+		$open = pfb_sync_status_list_open($this->dir, 'dnsbl');
+		$this->assertCount(1, $open, 'two consecutive failures on the SAME item must refresh, never duplicate');
+		$this->assertSame('HTTP 500', $open[0]['message'], 'message must be the LATEST refresh');
+	}
+
+	public function testDnsblDownloadCallSitesKeyOnTheAliasNotTheHeader(): void
+	{
+		// Regression pin (mirrors PfbSyncStatusIpWritersTest): the widget's deep-link
+		// recognition matches only the pfB_/DNSBL_-prefixed $alias, never $header, so
+		// keying on $header would silently drop the link for every entry. The DNSBL
+		// download loop has no PHPUnit harness of its own (too heavy to invoke), so
+		// this pins the exact call-site argument via source inspection.
+		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
+		$this->assertNotFalse($source, 'pfblockerng.inc must be readable');
+
+		$this->assertMatchesRegularExpression(
+			'/pfb_dnsbl_download_ledger_update\(FALSE, \$alias,/',
+			$source,
+			'the DNSBL download-fail call must key on $alias, not $header, or the widget deep link breaks'
+		);
+		$this->assertMatchesRegularExpression(
+			'/pfb_dnsbl_download_ledger_update\(TRUE, \$alias,/',
+			$source,
+			'the paired success-close call must key on the SAME $alias for symmetry'
+		);
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- ADR-61's sync-status ledger wired IP feed-download failures but not DNSBL's — Phase 3's brief scoped it to DNSBL apply-stage only and never carried the download-stage item forward.
- Adds `pfb_dnsbl_download_ledger_update()`, a structural mirror of `pfb_ip_download_ledger_update()`, wired at the DNSBL download call site (open on failure, close on success, keyed on `$alias`).
- Closes the "known, tracked gap" noted in ADR-61's status line and writer-site table.

Fixes #998

## Test plan
- [x] `vendor/bin/phpunit` — full suite green (2484 tests)
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist src/` — clean
- [x] Red→green proven: reverted the two source files, `PfbSyncStatusDnsblWritersTest` failed (3 undefined-function errors + 1 regex-pin failure); restored, all 8 tests (4 new + 4 existing) pass
- [x] `npx markdownlint-cli2` on the two doc edits — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkjWYvoEUHTKibFM14jkgG