### PR TITLE
pfblockerng: drop unreachable TypeError fallback in make_timestamp()

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2857,12 +2857,7 @@ def _log_upstream_block(q_name: str, q_ip: str, result: UpstreamBlock, q_type: s
 
 
 def make_timestamp() -> str:
-    for _ in range(2):
-        try:
-            return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        except TypeError:
-            continue
-    return ""
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 
 def _log_entry_direct(line: str, log: str) -> None:

--- a/tests/test_pfb_unbound_log_timestamp_baseline.py
+++ b/tests/test_pfb_unbound_log_timestamp_baseline.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 import re
 
-import pytest
-
 import pfb_unbound
 
 
@@ -22,23 +20,3 @@ def test_make_timestamp_matches_iso8601_format() -> None:
     result = pfb_unbound.make_timestamp()
 
     assert re.match(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$", result), result
-
-
-def test_make_timestamp_returns_empty_string_after_two_type_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-    """§1.3: a real code path -- '%Y'/'%d'/etc. raising TypeError twice falls back to
-    "" (the ``for _ in range(2)`` loop shape), never propagating the exception. The
-    format string changed (ADR-60 P4); this fallback shape did not.
-    """
-
-    class _RaisingNow:
-        def strftime(self, _fmt: str) -> str:
-            raise TypeError("simulated strftime failure")
-
-    class _FakeDatetime:
-        @staticmethod
-        def now() -> _RaisingNow:
-            return _RaisingNow()
-
-    monkeypatch.setattr(pfb_unbound, "datetime", _FakeDatetime)
-
-    assert pfb_unbound.make_timestamp() == ""


### PR DESCRIPTION
## Summary

After ADR-60 Phase 4, `make_timestamp()` formats with `strftime("%Y-%m-%d %H:%M:%S")` — no platform-specific directive (`%-d`/`%-j`) that could raise `TypeError`. The two-iteration retry loop and its `""` fallback were therefore unreachable dead code, and the companion test injected a fault the format string can no longer produce (coverage theater per CLAUDE.md's "no red-run manufactured by monkeypatching a fault production cannot produce").

## Changes

- `src/usr/local/pkg/pfblockerng/pfb_unbound.py`: collapse `make_timestamp()` to the single `return datetime.now().strftime(...)`.
- `tests/test_pfb_unbound_log_timestamp_baseline.py`: delete `test_make_timestamp_returns_empty_string_after_two_type_errors` (and its now-unused `pytest` import). The ISO-8601 format test remains as the behaviour oracle.

This is behaviour-preserving (the removed branch never executed), so the remaining format test pins the intended output and stays green across the change.

## Verification

- `pytest` full suite: 2465 passed, 5 skipped
- `ruff check .` · `ruff format --check` · `mypy tests/` — clean
- comment-narration / appliance-python / version-literal checkers — clean

Fixes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0145bGDnzhGhZFTkY7Nc4knd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timestamp values are now generated consistently in `YYYY-MM-DD HH:MM:SS` format.
  * Removed the rare fallback behavior that could return an empty timestamp, improving reliability.

* **Tests**
  * Updated timestamp coverage to focus on the expected output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->