### PR TITLE
pfb_unbound: close orphaned parse-stage ledger entries on early return

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -913,6 +913,7 @@ def _load_zone_db(feed_group_db: defaultdict[str, int], feed_group_index: int) -
     advanced ``feed_group_index`` (shared with ``_load_data_db`` across both files).
     Behaviour-preserving: same parse rules, same ``pfb["zoneDB"]`` flag."""
     if not os.path.isfile(pfb["pfb_py_zone"]):
+        pfb_py_status_close("dnsbl", pfb["pfb_py_zone"], "parse")
         return feed_group_index
     try:
         with open(pfb["pfb_py_zone"]) as csv_file:
@@ -951,6 +952,7 @@ def _load_data_db(feed_group_db: defaultdict[str, int], feed_group_index: int) -
     when the ADR-06 manifest already built it. Same extraction rationale/shape as
     ``_load_zone_db`` (shares ``feed_group_db``/``feed_group_index`` with it)."""
     if not os.path.isfile(pfb["pfb_py_data"]):
+        pfb_py_status_close("dnsbl", pfb["pfb_py_data"], "parse")
         return feed_group_index
     try:
         with open(pfb["pfb_py_data"]) as csv_file:
@@ -989,6 +991,7 @@ def _load_whitelist_db() -> None:
     ``whiteDB`` -- skipped when the ADR-06 manifest already built it. Same
     extraction rationale as ``_load_zone_db``."""
     if not os.path.isfile(pfb["pfb_py_whitelist"]):
+        pfb_py_status_close("dnsbl", pfb["pfb_py_whitelist"], "parse")
         return
     try:
         with open(pfb["pfb_py_whitelist"]) as csv_file:
@@ -1020,6 +1023,7 @@ def _load_hsts_db() -> None:
     gated on ``pfb["python_hsts"]`` (not on the ADR-06 manifest: hstsDB is NOT
     part of the manifest build). Same extraction rationale as ``_load_zone_db``."""
     if not (pfb["python_hsts"] and os.path.isfile(pfb["pfb_py_hsts"])):
+        pfb_py_status_close("dnsbl", pfb["pfb_py_hsts"], "parse")
         return
     try:
         with open(pfb["pfb_py_hsts"]) as hsts:
@@ -1041,6 +1045,7 @@ def _load_ini_config() -> ConfigParser | None:
     through into the caller's ``has_section()`` checks, exactly as the original
     inline try/except (no early return on the read failure)."""
     if not os.path.isfile(pfb["pfb_unbound.ini"]):
+        pfb_py_status_close("dnsbl", pfb["pfb_unbound.ini"], "parse")
         return None
     config = ConfigParser()
     try:
@@ -6201,6 +6206,8 @@ def _load_safesearch_db() -> None:
             # load failure diagnostic at the wrong file.
             sys.stderr.write("[pfBlockerNG]: Failed to load: {}: {}".format(pfb["pfb_py_ss"], e))
             pfb_py_status_open("dnsbl", pfb["pfb_py_ss"], "parse", "Failed to load: {}: {}".format(pfb["pfb_py_ss"], e))
+    else:
+        pfb_py_status_close("dnsbl", pfb["pfb_py_ss"], "parse")
 
 
 def safesearch_entry(q_name_original: str) -> Any:

--- a/tests/test_adr61_py_status.py
+++ b/tests/test_adr61_py_status.py
@@ -276,6 +276,31 @@ class TestLoadZoneDbLedgerWiring:
         assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
         assert pfb_unbound.zoneDB["evil.com"]["log"] == "1"
 
+    def test_file_removed_after_failure_closes_the_orphaned_entry(self, tmp_path: Any, monkeypatch: Any) -> None:
+        zone_path = tmp_path / "pfb_py_zone.txt"
+        zone_path.write_text("a,b,c,d,e,f\n", encoding="utf-8")
+        pfb_unbound.pfb["pfb_py_zone"] = str(zone_path)
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+
+        real_open = open
+
+        def _boom_open(path: Any, *a: Any, **k: Any) -> Any:
+            if str(path) == str(zone_path):
+                raise OSError("simulated read failure")
+            return real_open(path, *a, **k)
+
+        monkeypatch.setattr("builtins.open", _boom_open)
+        pfb_unbound._load_zone_db(_new_feed_group_db(), 0)
+        # Before-state: the entry is genuinely open first.
+        assert len(_read_status_file(pfb_unbound.pfb["pfb_py_status"])) == 1
+
+        monkeypatch.undo()
+        os.remove(zone_path)
+
+        pfb_unbound._load_zone_db(_new_feed_group_db(), 0)
+
+        assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
+
     def test_no_file_present_leaves_ledger_untouched(self, tmp_path: Any) -> None:
         pfb_unbound.pfb["pfb_py_zone"] = str(tmp_path / "does_not_exist.txt")
         pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
@@ -343,6 +368,31 @@ class TestLoadDataDbLedgerWiring:
         assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
         assert pfb_unbound.dataDB["evil.com"]["log"] == "1"
 
+    def test_file_removed_after_failure_closes_the_orphaned_entry(self, tmp_path: Any, monkeypatch: Any) -> None:
+        data_path = tmp_path / "pfb_py_data.txt"
+        data_path.write_text("a,b,c,d,e,f\n", encoding="utf-8")
+        pfb_unbound.pfb["pfb_py_data"] = str(data_path)
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+
+        real_open = open
+
+        def _boom_open(path: Any, *a: Any, **k: Any) -> Any:
+            if str(path) == str(data_path):
+                raise OSError("simulated read failure")
+            return real_open(path, *a, **k)
+
+        monkeypatch.setattr("builtins.open", _boom_open)
+        pfb_unbound._load_data_db(_new_feed_group_db(), 0)
+        # Before-state: the entry is genuinely open first.
+        assert len(_read_status_file(pfb_unbound.pfb["pfb_py_status"])) == 1
+
+        monkeypatch.undo()
+        os.remove(data_path)
+
+        pfb_unbound._load_data_db(_new_feed_group_db(), 0)
+
+        assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
+
 
 class TestLoadWhitelistDbLedgerWiring:
     """_load_whitelist_db(): fail-before/pass-after."""
@@ -397,6 +447,31 @@ class TestLoadWhitelistDbLedgerWiring:
 
         assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
         assert pfb_unbound.whiteDB["a"] == {"wildcard": True, "important": True}
+
+    def test_file_removed_after_failure_closes_the_orphaned_entry(self, tmp_path: Any, monkeypatch: Any) -> None:
+        wl_path = tmp_path / "pfb_py_whitelist.txt"
+        wl_path.write_text("a,1\n", encoding="utf-8")
+        pfb_unbound.pfb["pfb_py_whitelist"] = str(wl_path)
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+
+        real_open = open
+
+        def _boom_open(path: Any, *a: Any, **k: Any) -> Any:
+            if str(path) == str(wl_path):
+                raise OSError("simulated read failure")
+            return real_open(path, *a, **k)
+
+        monkeypatch.setattr("builtins.open", _boom_open)
+        pfb_unbound._load_whitelist_db()
+        # Before-state: the entry is genuinely open first.
+        assert len(_read_status_file(pfb_unbound.pfb["pfb_py_status"])) == 1
+
+        monkeypatch.undo()
+        os.remove(wl_path)
+
+        pfb_unbound._load_whitelist_db()
+
+        assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
 
 
 class TestLoadHstsDbLedgerWiring:
@@ -455,6 +530,56 @@ class TestLoadHstsDbLedgerWiring:
 
         assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
         assert "bad.example" in pfb_unbound.hstsDB
+
+    def test_file_removed_after_failure_closes_the_orphaned_entry(self, tmp_path: Any, monkeypatch: Any) -> None:
+        hsts_path = tmp_path / "pfb_py_hsts.txt"
+        hsts_path.write_text("bad.example\n", encoding="utf-8")
+        pfb_unbound.pfb["pfb_py_hsts"] = str(hsts_path)
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+
+        real_open = open
+
+        def _boom_open(path: Any, *a: Any, **k: Any) -> Any:
+            if str(path) == str(hsts_path):
+                raise OSError("simulated read failure")
+            return real_open(path, *a, **k)
+
+        monkeypatch.setattr("builtins.open", _boom_open)
+        pfb_unbound._load_hsts_db()
+        # Before-state: the entry is genuinely open first.
+        assert len(_read_status_file(pfb_unbound.pfb["pfb_py_status"])) == 1
+
+        monkeypatch.undo()
+        os.remove(hsts_path)
+
+        pfb_unbound._load_hsts_db()
+
+        assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
+
+    def test_feature_disabled_after_failure_closes_the_orphaned_entry(self, tmp_path: Any, monkeypatch: Any) -> None:
+        hsts_path = tmp_path / "pfb_py_hsts.txt"
+        hsts_path.write_text("bad.example\n", encoding="utf-8")
+        pfb_unbound.pfb["pfb_py_hsts"] = str(hsts_path)
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+
+        real_open = open
+
+        def _boom_open(path: Any, *a: Any, **k: Any) -> Any:
+            if str(path) == str(hsts_path):
+                raise OSError("simulated read failure")
+            return real_open(path, *a, **k)
+
+        monkeypatch.setattr("builtins.open", _boom_open)
+        pfb_unbound._load_hsts_db()
+        # Before-state: the entry is genuinely open first.
+        assert len(_read_status_file(pfb_unbound.pfb["pfb_py_status"])) == 1
+
+        monkeypatch.undo()
+        pfb_unbound.pfb["python_hsts"] = False
+
+        pfb_unbound._load_hsts_db()
+
+        assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
 
     def test_hsts_disabled_never_opens_an_entry(self, tmp_path: Any) -> None:
         # python_hsts OFF must never touch pfb_py_hsts, even if it exists.
@@ -528,6 +653,31 @@ class TestLoadSafeSearchDbLedgerWiring:
         assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
         assert pfb_unbound.safeSearchDB["forcesafe.com"] == {"A": "1.2.3.4", "AAAA": "::1"}
 
+    def test_file_removed_after_failure_closes_the_orphaned_entry(self, tmp_path: Any, monkeypatch: Any) -> None:
+        ss_path = tmp_path / "pfb_py_ss.txt"
+        ss_path.write_text("forcesafe.com,1.2.3.4,::1\n", encoding="utf-8")
+        pfb_unbound.pfb["pfb_py_ss"] = str(ss_path)
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+
+        real_open = open
+
+        def _boom_open(path: Any, *a: Any, **k: Any) -> Any:
+            if str(path) == str(ss_path):
+                raise OSError("simulated read failure")
+            return real_open(path, *a, **k)
+
+        monkeypatch.setattr("builtins.open", _boom_open)
+        pfb_unbound._load_safesearch_db()
+        # Before-state: the entry is genuinely open first.
+        assert len(_read_status_file(pfb_unbound.pfb["pfb_py_status"])) == 1
+
+        monkeypatch.undo()
+        os.remove(ss_path)
+
+        pfb_unbound._load_safesearch_db()
+
+        assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
+
     def test_no_file_present_leaves_ledger_untouched(self, tmp_path: Any) -> None:
         pfb_unbound.pfb["pfb_py_ss"] = str(tmp_path / "does_not_exist.txt")
         pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
@@ -586,6 +736,21 @@ class TestLoadIniConfigLedgerWiring:
 
         assert config is not None
         assert config.has_section("MAIN") is True
+        assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
+
+    def test_file_removed_after_failure_closes_the_orphaned_entry(self, tmp_path: Any) -> None:
+        ini_path = tmp_path / "pfb_unbound.ini"
+        ini_path.write_text("bogus_line_with_no_section_header\n", encoding="utf-8")
+        pfb_unbound.pfb["pfb_unbound.ini"] = str(ini_path)
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+
+        pfb_unbound._load_ini_config()
+        # Before-state: the entry is genuinely open first.
+        assert len(_read_status_file(pfb_unbound.pfb["pfb_py_status"])) == 1
+
+        os.remove(ini_path)
+
+        assert pfb_unbound._load_ini_config() is None
         assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
 
 


### PR DESCRIPTION
## Summary

Fixes the Python-side half of #1014: the 6 DNSBL loader functions (`_load_zone_db`, `_load_data_db`, `_load_whitelist_db`, `_load_hsts_db`, `_load_ini_config`, `_load_safesearch_db`) only called `pfb_py_status_close()` on their success path. If a loader had previously opened a `parse`-stage ledger entry (source file existed but failed to parse) and the source later disappeared or the feature got disabled, the early-return guard left that entry open forever — a stale dashboard signal until Unbound's chroot tmpfs cleared on reboot.

`pfb_py_status_close()` is a documented safe no-op on an absent key, so this adds the call unconditionally on each early-return guard, closing the gap without touching the "nothing to close" fast path.

The IP-alias-rename/delete half of #1014 (PHP-side `pfb_sync_status_*` ledger) is a separate follow-up issue — it needs its own design decision (event hook vs. periodic reconciliation) and a possible ADR-61 semantics update, per the reporter's own two independent "fix directions."

## Test plan

- [x] 7 new pinning tests (one per loader, `_load_hsts_db` split into "file removed" / "feature disabled" sub-cases) in `tests/test_adr61_py_status.py`, each proving the entry was genuinely open before, then closed after the fix
- [x] Verified RED on pre-fix code (`git checkout HEAD~1 -- src/.../pfb_unbound.py`), GREEN after restore — re-executed independently, not just trusted
- [x] Existing 3 "nothing to close" regression guards (`test_no_file_present_leaves_ledger_untouched` ×2, `test_missing_file_returns_none_and_never_opens_an_entry`, `test_hsts_disabled_never_opens_an_entry`) still pass unmodified
- [x] `python3 -m pytest` — 2479 passed, 4 skipped (pre-existing, unrelated)
- [x] `ruff check` / `ruff format --check` / `mypy tests/` — all clean

Fixes part of #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkjWYvoEUHTKibFM14jkgG