### PR TITLE
pfblockerng: never reuse-skip DNSBLIP's local resync (#1002)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -17760,8 +17760,11 @@ function sync_package_pfblockerng($cron='') {
 							pfb_logger("{$log}", 1);
 						}
 						else {
+							// Short-circuit: skip the stat() below when reuse is off (ADR-28);
+							// FALSE here is truth-functionally identical since the callee ANDs $reuse_on anyway.
 							$pfbreuse_on = $pfbreuse == 'on';
-							if (pfb_ip_reuse_skip_active($pfbreuse_on, $pfbreuse_on && file_exists("{$pfborig}/{$header}.orig"), isset($list['dnsblip']))) {
+							$orig_exists_if_reused = $pfbreuse_on && file_exists("{$pfborig}/{$header}.orig");
+							if (pfb_ip_reuse_skip_active($pfbreuse_on, $orig_exists_if_reused, isset($list['dnsblip']))) {
 								$log = "\n[ {$header} ]{$logtab} Reload";
 							} else {
 								$log = "\n[ {$header} ]{$logtab} Downloading update";
@@ -17804,7 +17807,8 @@ function sync_package_pfblockerng($cron='') {
 								}
 
 								// Determine if	list needs to be downloaded or reuse previously downloaded file.
-								if (pfb_ip_reuse_skip_active($pfbreuse_on, $pfbreuse_on && file_exists("{$file_dwn}.orig"), isset($list['dnsblip']))) {
+								$orig_exists_if_reused = $pfbreuse_on && file_exists("{$file_dwn}.orig");
+								if (pfb_ip_reuse_skip_active($pfbreuse_on, $orig_exists_if_reused, isset($list['dnsblip']))) {
 									// File exists/reuse
 
 									// Process Emerging Threats IQRisk if required

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1894,6 +1894,13 @@ function pfb_dnsblip_mark_reprocess($action, string $vtype): void {
 	}
 }
 
+// DNSBLIP's "download" is a local-file copy of a just-rebuilt source, not a network
+// fetch -- the reuse-skip optimization (meant for real feeds) must never apply to it,
+// or a same-pass rebuild is silently stranded until the next .ip source change. (#1002)
+function pfb_ip_reuse_skip_active(bool $reuse_on, bool $orig_exists, bool $is_dnsblip): bool {
+	return $reuse_on && $orig_exists && !$is_dnsblip;
+}
+
 // v6 stays OPTIONAL (ADR-13 §7 pivot): a missing v6 VIP never fails validation, even when
 // the resolver listens on IPv6 — pfb_global surfaces that as a non-blocking warning, not a
 // force-disable. The validator only checks the VIPs that ARE configured (existence,
@@ -17753,7 +17760,7 @@ function sync_package_pfblockerng($cron='') {
 							pfb_logger("{$log}", 1);
 						}
 						else {
-							if ($pfbreuse == 'on' && file_exists("{$pfborig}/{$header}.orig")) {
+							if (pfb_ip_reuse_skip_active($pfbreuse == 'on', file_exists("{$pfborig}/{$header}.orig"), isset($list['dnsblip']))) {
 								$log = "\n[ {$header} ]{$logtab} Reload";
 							} else {
 								$log = "\n[ {$header} ]{$logtab} Downloading update";
@@ -17796,7 +17803,7 @@ function sync_package_pfblockerng($cron='') {
 								}
 
 								// Determine if	list needs to be downloaded or reuse previously downloaded file.
-								if ($pfbreuse == 'on' && file_exists("{$file_dwn}.orig")) {
+								if (pfb_ip_reuse_skip_active($pfbreuse == 'on', file_exists("{$file_dwn}.orig"), isset($list['dnsblip']))) {
 									// File exists/reuse
 
 									// Process Emerging Threats IQRisk if required

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -17760,7 +17760,8 @@ function sync_package_pfblockerng($cron='') {
 							pfb_logger("{$log}", 1);
 						}
 						else {
-							if (pfb_ip_reuse_skip_active($pfbreuse == 'on', file_exists("{$pfborig}/{$header}.orig"), isset($list['dnsblip']))) {
+							$pfbreuse_on = $pfbreuse == 'on';
+							if (pfb_ip_reuse_skip_active($pfbreuse_on, $pfbreuse_on && file_exists("{$pfborig}/{$header}.orig"), isset($list['dnsblip']))) {
 								$log = "\n[ {$header} ]{$logtab} Reload";
 							} else {
 								$log = "\n[ {$header} ]{$logtab} Downloading update";
@@ -17803,7 +17804,7 @@ function sync_package_pfblockerng($cron='') {
 								}
 
 								// Determine if	list needs to be downloaded or reuse previously downloaded file.
-								if (pfb_ip_reuse_skip_active($pfbreuse == 'on', file_exists("{$file_dwn}.orig"), isset($list['dnsblip']))) {
+								if (pfb_ip_reuse_skip_active($pfbreuse_on, $pfbreuse_on && file_exists("{$file_dwn}.orig"), isset($list['dnsblip']))) {
 									// File exists/reuse
 
 									// Process Emerging Threats IQRisk if required

--- a/tests/php/PfbIpReuseSkipActiveTest.php
+++ b/tests/php/PfbIpReuseSkipActiveTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1002 -- the IP-feed loop's "reuse previous download" skip optimization exists to
+ * avoid re-fetching a REAL network feed. DNSBLIP's "download" is actually a near-instant
+ * local-file copy of the just-rebuilt {$pfb['dbdir']}/DNSBLIP{$vtype}.txt source, so the
+ * optimization must never apply to it: Force Reload forces $pfbreuse to 'on' regardless of
+ * the pfb_reuse tunable, and when a prior .orig already exists the row wrongly took the
+ * reuse-skip branch instead of re-copying -- so a rebuild that happened earlier in the SAME
+ * pass (which touches DNSBLIP's '.update' reprocess marker) never propagated into .orig
+ * before the marker was unconditionally deleted, leaving the alias stale indefinitely.
+ *
+ * Feature: reuse-skip is active iff reuse is wanted, an .orig already exists, AND the row
+ *   is NOT the DNSBLIP pseudo-feed.
+ *   Full 2x2x2 truth table over (reuse_on, orig_exists, is_dnsblip):
+ *     * Rows 1-4 (is_dnsblip=FALSE) pin the pre-existing, UNCHANGED real-feed behaviour --
+ *       row 4 (reuse=TRUE, orig=TRUE) is the only TRUE case, exactly the reuse-skip a real
+ *       feed relies on to avoid a wasteful re-fetch. A regression here silently breaks
+ *       reuse-mode for every non-DNSBLIP IP list.
+ *     * Rows 5-8 (is_dnsblip=TRUE) always resolve FALSE -- the DNSBLIP row must always take
+ *       the real download (local-copy) path. Row 8 (reuse=TRUE, orig=TRUE, is_dnsblip=TRUE)
+ *       is the #1002 bug pin: before the fix this combination wrongly returned TRUE.
+ */
+#[CoversFunction('pfb_ip_reuse_skip_active')]
+final class PfbIpReuseSkipActiveTest extends TestCase
+{
+	/**
+	 * Row 1: reuse off, no prior .orig, real feed -- nothing to reuse, must download.
+	 */
+	public function testRow1ReuseOffNoOrigRealFeedIsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_ip_reuse_skip_active(FALSE, FALSE, FALSE),
+			"reuse=FALSE, orig=FALSE, dnsblip=FALSE -> FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 2: reuse off, prior .orig DOES exist, real feed -- the reuse flag being off makes
+	 * the existing .orig irrelevant.
+	 */
+	public function testRow2ReuseOffOrigExistsRealFeedIsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_ip_reuse_skip_active(FALSE, TRUE, FALSE),
+			"reuse=FALSE, orig=TRUE, dnsblip=FALSE -> FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 3: reuse on, no prior .orig, real feed -- reuse is wanted but there is nothing
+	 * yet to reuse, so a real download must happen.
+	 */
+	public function testRow3ReuseOnNoOrigRealFeedIsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_ip_reuse_skip_active(TRUE, FALSE, FALSE),
+			"reuse=TRUE, orig=FALSE, dnsblip=FALSE -> FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 4: reuse on, prior .orig exists, real feed -- the pre-existing, correct,
+	 * UNCHANGED reuse-skip a real feed relies on. Must stay TRUE or every non-DNSBLIP IP
+	 * list's reuse-mode silently breaks.
+	 */
+	public function testRow4ReuseOnOrigExistsRealFeedIsTrue(): void
+	{
+		$this->assertTrue(
+			pfb_ip_reuse_skip_active(TRUE, TRUE, FALSE),
+			"reuse=TRUE, orig=TRUE, dnsblip=FALSE -> TRUE (real-feed reuse-skip, unchanged)\n" .
+			"expected: true\n" .
+			"got:      false"
+		);
+	}
+
+	/**
+	 * Row 5: reuse off, no prior .orig, DNSBLIP row -- always FALSE for DNSBLIP.
+	 */
+	public function testRow5ReuseOffNoOrigDnsblipIsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_ip_reuse_skip_active(FALSE, FALSE, TRUE),
+			"reuse=FALSE, orig=FALSE, dnsblip=TRUE -> FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 6: reuse off, prior .orig exists, DNSBLIP row -- still FALSE.
+	 */
+	public function testRow6ReuseOffOrigExistsDnsblipIsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_ip_reuse_skip_active(FALSE, TRUE, TRUE),
+			"reuse=FALSE, orig=TRUE, dnsblip=TRUE -> FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 7: reuse on, no prior .orig, DNSBLIP row -- still FALSE.
+	 */
+	public function testRow7ReuseOnNoOrigDnsblipIsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_ip_reuse_skip_active(TRUE, FALSE, TRUE),
+			"reuse=TRUE, orig=FALSE, dnsblip=TRUE -> FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 8 -- THE #1002 BUG PIN: reuse on (Force Reload forces $pfbreuse to 'on'
+	 * regardless of the pfb_reuse tunable), a prior .orig already on disk (from before the
+	 * in-pass rebuild), DNSBLIP row. Before the fix this wrongly returned TRUE (reuse-skip),
+	 * so a rebuild that happened earlier in the SAME pass -- which touches DNSBLIP's
+	 * '.update' reprocess marker -- never got propagated into .orig before the marker was
+	 * unconditionally deleted at the end of row processing, leaving the alias stale
+	 * indefinitely. Must return FALSE: DNSBLIP always takes the real (local-copy) download.
+	 */
+	public function testRow8ReuseOnOrigExistsDnsblipIsFalseTheBugFix(): void
+	{
+		$this->assertFalse(
+			pfb_ip_reuse_skip_active(TRUE, TRUE, TRUE),
+			"reuse=TRUE, orig=TRUE, dnsblip=TRUE -> FALSE (#1002: DNSBLIP must never reuse-skip)\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+}


### PR DESCRIPTION
## Summary

`DNSBLIP_v4`/`DNSBLIP_v6`'s IP-feed loop treated the synthetic DNSBLIP pseudo-feed the
same as any real network-fetched feed when deciding whether to skip a "download" and
reuse the previous `.orig`. DNSBLIP's "download" is actually a near-instant local file
copy of its just-rebuilt source (`{$pfb['dbdir']}/DNSBLIP{$vtype}.txt`) — the reuse-skip
optimization exists to avoid expensive re-fetches, which doesn't apply here.

When a Force Reload forces `$pfbreuse` to `'on'` (independent of the configured
`pfb_reuse` tunable) and a prior `.orig` already exists, the row wrongly took the
"File exists/reuse" skip branch instead of re-copying — so a rebuild that happened
earlier in the *same* pass (which touches DNSBLIP's `.update` reprocess marker) never
got propagated into `.orig` before that marker was unconditionally deleted at the end
of row processing. The alias then stayed stale indefinitely, until the underlying
`*_v<fam>.ip` source set changed again.

## Fix

Extracted the reuse-vs-download decision into a pure predicate,
`pfb_ip_reuse_skip_active(bool $reuse_on, bool $orig_exists, bool $is_dnsblip): bool`,
mirroring the existing `pfb_supp_update_active()` pattern for testable predicates
pulled out of `sync_package_pfblockerng()`. DNSBLIP (`isset($list['dnsblip'])`, the
existing house idiom) never takes the reuse-skip path, regardless of `$pfbreuse` —
every other feed's reuse behaviour is unchanged.

Wired into both call sites that inlined the old 2-variable condition: the log-text
choice and the actual behavioural branch.

## Testing

New `tests/php/PfbIpReuseSkipActiveTest.php` pins the full 2×2×2 truth table (8 cases).
Row 8 (`reuse=TRUE, orig_exists=TRUE, is_dnsblip=TRUE → FALSE`) pins the #1002 bug; row 4
(`reuse=TRUE, orig_exists=TRUE, is_dnsblip=FALSE → TRUE`) pins the unchanged real-feed
reuse-skip behaviour. Red→green re-executed independently: pre-fix the function doesn't
exist (`Call to undefined function`, all 8 error); post-fix all 8 pass.

`vendor/bin/phpunit` (full suite), `vendor/bin/phpstan`, `vendor/bin/phpcs` all green.

Fixes #1002

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update handling so reuse behavior only applies when the required previous file is available.
  * Fixed DNSBLIP entries to always avoid the reuse-skip path, helping ensure downloads are processed correctly.
  * Added test coverage for the reuse decision logic to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->