### PR TITLE
tests/smoke: add live-VM Tier-B proof for the DNSBL block page (#1013)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1066,7 +1066,11 @@ def ensure_dnsbl_vip(vm: SmokeVM, *, ip4: str = DEFAULT_DNSBL_VIP4, timeout: flo
     be realized for ``pfb_get_vips`` (-> ``get_specialnet``) to list it —
     config-only left it "invalid IPv4 VIP". ``interface_vip_configure`` lives in
     ``interfaces.inc`` (not auto-loaded by pfSsh.php), so require_once it first
-    and guard the call so a missing symbol can't abort the eval.
+    and guard the call so a missing symbol can't abort the eval. Verified via
+    ``ifconfig`` with a direct-alias fallback (issue #1013): on this image
+    ``interface_vip_configure()`` alone left the OS-level alias absent even
+    though config.xml was correct, so a caller needing a REACHABLE (not just
+    resolvable) VIP could not rely on this returning cleanly meaning "live".
     """
     vip = {
         "mode": "ipalias",
@@ -1096,6 +1100,16 @@ def ensure_dnsbl_vip(vm: SmokeVM, *, ip4: str = DEFAULT_DNSBL_VIP4, timeout: flo
         "write_config('pfBlockerNG smoke: DNSBL VIP');\n"
         "require_once('interfaces.inc');\n"
         f"if (function_exists('interface_vip_configure')) {{ interface_vip_configure({_php_kv_array(vip)}); }}\n"
+        # issue #1013: interface_vip_configure() has been observed to leave config.xml
+        # updated but the OS-level alias absent (ifconfig lo0 shows no `ip4` after the
+        # call) -- verify directly and add the alias ourselves if it didn't take, so a
+        # caller that needs a REACHABLE (not just resolvable) VIP can rely on this.
+        f"$vipif = escapeshellarg({_php_str(SMOKE_VIP_IFACE)});\n"
+        f"$vipaddr = escapeshellarg({_php_str(ip4)} . '/32');\n"
+        "$vipup = shell_exec('/sbin/ifconfig ' . $vipif . ' 2>/dev/null');\n"
+        f"if (strpos((string) $vipup, 'inet ' . {_php_str(ip4)} . ' ') === FALSE) {{\n"
+        "  exec('/sbin/ifconfig ' . $vipif . ' alias ' . $vipaddr);\n"
+        "}\n"
         "echo 'OK';"
     )
     result = php_eval(vm, snippet, timeout=timeout)

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1106,9 +1106,19 @@ def ensure_dnsbl_vip(vm: SmokeVM, *, ip4: str = DEFAULT_DNSBL_VIP4, timeout: flo
         # caller that needs a REACHABLE (not just resolvable) VIP can rely on this.
         f"$vipif = escapeshellarg({_php_str(SMOKE_VIP_IFACE)});\n"
         f"$vipaddr = escapeshellarg({_php_str(ip4)} . '/32');\n"
+        f"$viptoken = 'inet ' . {_php_str(ip4)} . ' ';\n"
         "$vipup = shell_exec('/sbin/ifconfig ' . $vipif . ' 2>/dev/null');\n"
-        f"if (strpos((string) $vipup, 'inet ' . {_php_str(ip4)} . ' ') === FALSE) {{\n"
+        "if (strpos((string) $vipup, $viptoken) === FALSE) {\n"
         "  exec('/sbin/ifconfig ' . $vipif . ' alias ' . $vipaddr);\n"
+        # Re-check: the fallback itself can fail (permissions, a bad interface) and would
+        # otherwise report 'OK' with the VIP still unreachable -- a much less diagnostic
+        # failure surfaces later (a bare connect timeout) instead of here, with a reason.
+        "  $vipup = shell_exec('/sbin/ifconfig ' . $vipif . ' 2>/dev/null');\n"
+        "  if (strpos((string) $vipup, $viptoken) === FALSE) {\n"
+        "    fwrite(STDERR, 'ensure_dnsbl_vip: alias fallback did not bring up ' . $viptoken . "
+        "'on ' . $vipif . \"\\n\");\n"
+        "    exit(1);\n"
+        "  }\n"
         "}\n"
         "echo 'OK';"
     )

--- a/tests/smoke/ui/test_dnsbl_block_page.py
+++ b/tests/smoke/ui/test_dnsbl_block_page.py
@@ -115,9 +115,9 @@ def test_dnsbl_block_page_shows_real_correlation_detail(deployed_vm: helpers.Smo
                 f"lighttpd_pfb/:80 snapshot (rc={diag.returncode}):\n{diag.stdout}{diag.stderr}"
             )
 
+        # The block marker is already guaranteed by the fail-path above (its condition's
+        # negation), so no separate assertion here -- re-asserting it would be dead code.
         body = result.stdout
-        assert "Site blocked via DNSBL" in body, f"sinkhole page missing its block marker; body:\n{body}"
-
         cells = re.findall(r"<td>(.*?)</td>", body, re.DOTALL)
         assert len(cells) == 6, (
             f"expected 6 <td> cells (Referer/Client/Type/Group/Evaluated Domain/Feed), got {len(cells)}: {cells}"

--- a/tests/smoke/ui/test_dnsbl_block_page.py
+++ b/tests/smoke/ui/test_dnsbl_block_page.py
@@ -47,7 +47,12 @@ def test_dnsbl_block_page_shows_real_correlation_detail(deployed_vm: helpers.Smo
         aliasname="uidnsblpage", feed_url=feed_path, header="uidnsblpage", mode=helpers.DnsblMode.VIP
     )
 
-    with helpers.CaseContext(deployed_vm, spec):
+    # scope="update" (not CaseContext's default "updatednsbl"): pfb_create_dnsbl()
+    # (pfblockerng.inc:5671) -- the NAT/lighttpd-conf/restart_service('pfb_dnsbl')
+    # pass that actually starts the sinkhole -- only runs reliably off a FULL
+    # update pass; test_functional.py's dnsvip_auto test documents the same split
+    # ("a bare update with no DNSBL list does NOT reach the VIP-provisioning pass").
+    with helpers.CaseContext(deployed_vm, spec, scope="update"):
         # BEFORE (transition-test discipline): the real DNS query both proves the
         # block itself is real AND writes the dnsbl.log correlator line -- the
         # HTTP probe below only makes sense once this is asserted true.

--- a/tests/smoke/ui/test_dnsbl_block_page.py
+++ b/tests/smoke/ui/test_dnsbl_block_page.py
@@ -82,7 +82,7 @@ def test_dnsbl_block_page_shows_real_correlation_detail(deployed_vm: helpers.Smo
         # whole budget on one attempt.
         curl_argv = (
             helpers.GUEST_CURL,
-            "-s",
+            "-sS",  # silent but keep stderr -- a bare -s leaves stderr empty on failure
             "--connect-timeout",
             "3",
             "--max-time",

--- a/tests/smoke/ui/test_dnsbl_block_page.py
+++ b/tests/smoke/ui/test_dnsbl_block_page.py
@@ -99,7 +99,13 @@ def test_dnsbl_block_page_shows_real_correlation_detail(deployed_vm: helpers.Smo
             # this log, no second CI dispatch + diagnostics-archaeology round trip.
             diag = deployed_vm.ssh(
                 "ps auxww | grep -i '[l]ighttpd_pfb'; "
-                "/usr/bin/sockstat -4 -l 2>/dev/null | grep ':8081' || echo NO_LISTENER",
+                "/usr/bin/sockstat -4 -l 2>/dev/null | grep ':8081' || echo NO_LISTENER; "
+                # issue #1013 round 4: NO_LISTENER survived a confirmed-live VIP, so the
+                # remaining suspects are the lighttpd/lighttpd_pfb hardlink pfb_create_dnsbl()
+                # makes (pfblockerng.inc ~5786-5788) and whether the rc script's own daemon
+                # actually ran -- both are cheap to confirm directly rather than guess again.
+                "/bin/ls -la /usr/local/sbin/lighttpd /usr/local/sbin/lighttpd_pfb 2>&1; "
+                "/usr/bin/grep -i lighttpd_pfb /var/log/system.log 2>/dev/null | tail -20",
                 timeout=15.0,
             )
             pytest.fail(

--- a/tests/smoke/ui/test_dnsbl_block_page.py
+++ b/tests/smoke/ui/test_dnsbl_block_page.py
@@ -1,0 +1,88 @@
+"""Live-VM proof the DNSBL sinkhole page correlates a real block (issue #1013).
+
+``tests/php/LogFormatConsumersTest.php`` proves off-box that ``index.php``'s
+``dnsbl.log`` correlation grep tolerates the ISO-8601 timestamp format (ADR-60
+Phase 5), but nothing drives the real script end-to-end: a genuine DNS block, a
+genuine ``dnsbl.log`` line, a genuine HTTP hit on the sinkhole, and a genuine
+Type/Group/Evaluated-Domain/Feed render -- as opposed to the ``-`` placeholders
+``index.php`` falls back to when the correlation grep misses.
+
+Tier B (``ui_e2e``): the sinkhole listener (lighttpd on the DNSBL VIP, port
+8081) is outside the authenticated webConfigurator's reach, so Tier A
+(``ui_render``) cannot exercise it -- see ``test_render_smoke.py``'s
+``EXCLUDED_FROM_TIER_A["dnsbl_vip_sinkhole_pages"]``. This test causes a real
+DNS block and a real HTTP correlation (mutating, slow) -- daily/on-demand
+only, never the PR gate.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+import pytest
+
+from .. import helpers
+
+pytestmark = pytest.mark.ui_e2e
+
+
+def test_dnsbl_block_page_shows_real_correlation_detail(deployed_vm: helpers.SmokeVM) -> None:
+    """Scenario: a real DNSBL block correlates into the sinkhole page's detail row.
+
+    Given a DNSBL feed listing one unique test domain (VIP mode).
+    When the domain is force-updated into the block list, resolved (the real DNS
+    query that both proves the block AND writes the ``dnsbl.log`` correlator
+    line), then fetched from the sinkhole webserver with that domain as the
+    ``Host`` header.
+    Then the page renders "Site blocked via DNSBL" AND its 6-cell detail row's
+    Type/Group/Evaluated-Domain/Feed cells are populated from the real
+    ``dnsbl.log`` match -- never the ``-`` fallback -- with the Evaluated Domain
+    cell equal to the queried name.
+    """
+    domain = helpers.unique_domain("dnsblpage")
+    feed_path = helpers.write_local_feed(deployed_vm, "ui_dnsbl_block_page.txt", f"{domain}\n")
+    spec = helpers.DnsblCase(
+        aliasname="uidnsblpage", feed_url=feed_path, header="uidnsblpage", mode=helpers.DnsblMode.VIP
+    )
+
+    with helpers.CaseContext(deployed_vm, spec):
+        # BEFORE (transition-test discipline): the real DNS query both proves the
+        # block itself is real AND writes the dnsbl.log correlator line -- the
+        # HTTP probe below only makes sense once this is asserted true.
+        answer = helpers.dns_probe(deployed_vm, domain)
+        assert helpers.is_vip(answer), f"expected VIP block for {domain!r}, got answer: {answer!r}"
+
+        # THEN: an on-box curl to the sinkhole (the DNSBL VIP is a loopback-scoped
+        # lo0 IP-alias, unreachable from the runner) with Host set to the
+        # just-blocked domain -- the access recipe test_render_smoke.py documents
+        # for reaching index.php/dnsbl_default.php outside the webConfigurator.
+        # Runs inside CaseContext so the dnsbl.log line is guaranteed fresh and
+        # egress being blocked here doesn't matter (the curl is loopback-local).
+        result = subprocess.run(
+            deployed_vm.ssh_argv(
+                helpers.GUEST_CURL, "-s", "-H", f"Host: {domain}", f"http://{helpers.DEFAULT_DNSBL_VIP4}:8081/"
+            ),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"on-box curl to the DNSBL sinkhole failed: rc={result.returncode} stderr={result.stderr!r}"
+        )
+
+        body = result.stdout
+        assert "Site blocked via DNSBL" in body, f"sinkhole page missing its block marker; body:\n{body}"
+
+        cells = re.findall(r"<td>(.*?)</td>", body, re.DOTALL)
+        assert len(cells) == 6, (
+            f"expected 6 <td> cells (Referer/Client/Type/Group/Evaluated Domain/Feed), got {len(cells)}: {cells}"
+        )
+
+        _referer, _client, ptype, group, evald, feed = cells
+        for label, value in (("Type", ptype), ("Group", group), ("Evaluated Domain", evald), ("Feed", feed)):
+            assert value != "-", (
+                f"{label} cell fell back to the '-' placeholder -- dnsbl.log correlation missed for "
+                f"{domain!r}; full cells: {cells}"
+            )
+        assert evald == domain, f"Evaluated Domain cell expected {domain!r}, got {evald!r} (cells: {cells})"

--- a/tests/smoke/ui/test_dnsbl_block_page.py
+++ b/tests/smoke/ui/test_dnsbl_block_page.py
@@ -8,7 +8,7 @@ Type/Group/Evaluated-Domain/Feed render -- as opposed to the ``-`` placeholders
 ``index.php`` falls back to when the correlation grep misses.
 
 Tier B (``ui_e2e``): the sinkhole listener (lighttpd on the DNSBL VIP, port
-8081) is outside the authenticated webConfigurator's reach, so Tier A
+80) is outside the authenticated webConfigurator's reach, so Tier A
 (``ui_render``) cannot exercise it -- see ``test_render_smoke.py``'s
 ``EXCLUDED_FROM_TIER_A["dnsbl_vip_sinkhole_pages"]``. This test causes a real
 DNS block and a real HTTP correlation (mutating, slow) -- daily/on-demand
@@ -66,13 +66,20 @@ def test_dnsbl_block_page_shows_real_correlation_detail(deployed_vm: helpers.Smo
         # Runs inside CaseContext so the dnsbl.log line is guaranteed fresh and
         # egress being blocked here doesn't matter (the curl is loopback-local).
         #
-        # issue #1013: pfb_create_dnsbl() (pfblockerng.inc ~5793) restarts the
-        # sinkhole via restart_service('pfb_dnsbl'), whose rc script forks
-        # lighttpd_pfb -- lighttpd self-daemonizes (pfblockerng.inc ~2587-2591,
-        # issue #662), so the rc script -- and reload() -- can return before the
-        # forked child finishes binding :8081. Poll instead of one unbounded curl,
-        # with a short per-attempt timeout so a dropped-not-refused SYN fails fast
-        # rather than hanging the whole budget on one attempt.
+        # issue #1013: pfb_create_lighttpd() (pfblockerng.inc:5459-5460) binds the
+        # sinkhole to port 80 (443 for TLS) when dnsbl_iface=='lo0' (this harness's
+        # VIP mode) -- NAT is skipped entirely for lo0 (pfb_dnsbl_nat_enabled()), so
+        # dnsbl_port/dnsbl_port_ssl (8081/8443) never apply here; on a real interface
+        # they're the internal NAT local-port, never externally reachable either. The
+        # externally-reachable port is always 80/443.
+        #
+        # pfb_create_dnsbl() (pfblockerng.inc ~5793) restarts the sinkhole via
+        # restart_service('pfb_dnsbl'), whose rc script forks lighttpd_pfb --
+        # lighttpd self-daemonizes (pfblockerng.inc ~2587-2591, issue #662), so the
+        # rc script -- and reload() -- can return before the forked child finishes
+        # binding. Poll instead of one unbounded curl, with a short per-attempt
+        # timeout so a dropped-not-refused SYN fails fast rather than hanging the
+        # whole budget on one attempt.
         curl_argv = (
             helpers.GUEST_CURL,
             "-s",
@@ -82,7 +89,7 @@ def test_dnsbl_block_page_shows_real_correlation_detail(deployed_vm: helpers.Smo
             "8",
             "-H",
             f"Host: {domain}",
-            f"http://{helpers.DEFAULT_DNSBL_VIP4}:8081/",
+            f"http://{helpers.DEFAULT_DNSBL_VIP4}/",
         )
         attempts, delay = 10, 1.5  # lighttpd's post-fork bind is normally sub-second; generous headroom
         result: subprocess.CompletedProcess[str] | None = None
@@ -99,19 +106,13 @@ def test_dnsbl_block_page_shows_real_correlation_detail(deployed_vm: helpers.Smo
             # this log, no second CI dispatch + diagnostics-archaeology round trip.
             diag = deployed_vm.ssh(
                 "ps auxww | grep -i '[l]ighttpd_pfb'; "
-                "/usr/bin/sockstat -4 -l 2>/dev/null | grep ':8081' || echo NO_LISTENER; "
-                # issue #1013 round 4: NO_LISTENER survived a confirmed-live VIP, so the
-                # remaining suspects are the lighttpd/lighttpd_pfb hardlink pfb_create_dnsbl()
-                # makes (pfblockerng.inc ~5786-5788) and whether the rc script's own daemon
-                # actually ran -- both are cheap to confirm directly rather than guess again.
-                "/bin/ls -la /usr/local/sbin/lighttpd /usr/local/sbin/lighttpd_pfb 2>&1; "
-                "/usr/bin/grep -i lighttpd_pfb /var/log/system.log 2>/dev/null | tail -20",
+                "/usr/bin/sockstat -4 -l 2>/dev/null | grep -E ':80([[:space:]]|$)' || echo NO_LISTENER",
                 timeout=15.0,
             )
             pytest.fail(
                 f"sinkhole curl never succeeded after {attempts} attempts: "
                 f"rc={result.returncode} stderr={result.stderr!r}\n"
-                f"lighttpd_pfb/:8081 snapshot (rc={diag.returncode}):\n{diag.stdout}{diag.stderr}"
+                f"lighttpd_pfb/:80 snapshot (rc={diag.returncode}):\n{diag.stdout}{diag.stderr}"
             )
 
         body = result.stdout

--- a/tests/smoke/ui/test_dnsbl_block_page.py
+++ b/tests/smoke/ui/test_dnsbl_block_page.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import time
 
 import pytest
 
@@ -33,8 +34,8 @@ def test_dnsbl_block_page_shows_real_correlation_detail(deployed_vm: helpers.Smo
     Given a DNSBL feed listing one unique test domain (VIP mode).
     When the domain is force-updated into the block list, resolved (the real DNS
     query that both proves the block AND writes the ``dnsbl.log`` correlator
-    line), then fetched from the sinkhole webserver with that domain as the
-    ``Host`` header.
+    line), then fetched (polled -- the sinkhole restart is async, see below) from
+    the sinkhole webserver with that domain as the ``Host`` header.
     Then the page renders "Site blocked via DNSBL" AND its 6-cell detail row's
     Type/Group/Evaluated-Domain/Feed cells are populated from the real
     ``dnsbl.log`` match -- never the ``-`` fallback -- with the Evaluated Domain
@@ -59,17 +60,48 @@ def test_dnsbl_block_page_shows_real_correlation_detail(deployed_vm: helpers.Smo
         # for reaching index.php/dnsbl_default.php outside the webConfigurator.
         # Runs inside CaseContext so the dnsbl.log line is guaranteed fresh and
         # egress being blocked here doesn't matter (the curl is loopback-local).
-        result = subprocess.run(
-            deployed_vm.ssh_argv(
-                helpers.GUEST_CURL, "-s", "-H", f"Host: {domain}", f"http://{helpers.DEFAULT_DNSBL_VIP4}:8081/"
-            ),
-            capture_output=True,
-            text=True,
-            timeout=30,
+        #
+        # issue #1013: pfb_create_dnsbl() (pfblockerng.inc ~5793) restarts the
+        # sinkhole via restart_service('pfb_dnsbl'), whose rc script forks
+        # lighttpd_pfb -- lighttpd self-daemonizes (pfblockerng.inc ~2587-2591,
+        # issue #662), so the rc script -- and reload() -- can return before the
+        # forked child finishes binding :8081. Poll instead of one unbounded curl,
+        # with a short per-attempt timeout so a dropped-not-refused SYN fails fast
+        # rather than hanging the whole budget on one attempt.
+        curl_argv = (
+            helpers.GUEST_CURL,
+            "-s",
+            "--connect-timeout",
+            "3",
+            "--max-time",
+            "8",
+            "-H",
+            f"Host: {domain}",
+            f"http://{helpers.DEFAULT_DNSBL_VIP4}:8081/",
         )
-        assert result.returncode == 0, (
-            f"on-box curl to the DNSBL sinkhole failed: rc={result.returncode} stderr={result.stderr!r}"
-        )
+        attempts, delay = 10, 1.5  # lighttpd's post-fork bind is normally sub-second; generous headroom
+        result: subprocess.CompletedProcess[str] | None = None
+        for attempt in range(attempts):
+            result = deployed_vm.ssh(*curl_argv, timeout=15.0)
+            if result.returncode == 0 and "Site blocked via DNSBL" in result.stdout:
+                break
+            if attempt < attempts - 1:
+                time.sleep(delay)
+        assert result is not None  # attempts >= 1, loop always assigns
+
+        if result.returncode != 0 or "Site blocked via DNSBL" not in result.stdout:
+            # Self-diagnosing failure: confirms/refutes the restart race straight from
+            # this log, no second CI dispatch + diagnostics-archaeology round trip.
+            diag = deployed_vm.ssh(
+                "ps auxww | grep -i '[l]ighttpd_pfb'; "
+                "/usr/bin/sockstat -4 -l 2>/dev/null | grep ':8081' || echo NO_LISTENER",
+                timeout=15.0,
+            )
+            pytest.fail(
+                f"sinkhole curl never succeeded after {attempts} attempts: "
+                f"rc={result.returncode} stderr={result.stderr!r}\n"
+                f"lighttpd_pfb/:8081 snapshot (rc={diag.returncode}):\n{diag.stdout}{diag.stderr}"
+            )
 
         body = result.stdout
         assert "Site blocked via DNSBL" in body, f"sinkhole page missing its block marker; body:\n{body}"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -230,15 +230,21 @@ EXCLUDED_FROM_TIER_A: tuple[ExcludedPage, ...] = (
         path="/index.php and /dnsbl_default.php under www/ (DNSBL VIP webserver)",
         reason=(
             "www/index.php + dnsbl_default.php are served by the DNSBL sinkhole lighttpd on the "
-            "DNSBL VIP (ports 8081/8443), NOT the main webConfigurator: no guiconfig auth, and "
-            "index.php exit()s unless HTTP_HOST is a valid hostname and REQUEST_URI=='/' (otherwise "
-            "it returns a 1x1 GIF). dnsbl_default.php is a template INCLUDED by dnsbl_active.php, "
-            "never served standalone. The authenticated session on :8080 cannot reach them."
+            "DNSBL VIP, NOT the main webConfigurator: no guiconfig auth, and index.php exit()s "
+            "unless HTTP_HOST is a valid hostname and REQUEST_URI=='/' (otherwise it returns a "
+            "1x1 GIF). dnsbl_default.php is a template INCLUDED by dnsbl_active.php, never served "
+            "standalone. The authenticated session on :8080 cannot reach them. issue #1013: the "
+            "sinkhole listens on ports 80/443, NOT the configured dnsbl_port/dnsbl_port_ssl "
+            "(8081/8443 by default) -- those are the NAT local-port pfb_create_lighttpd() binds "
+            "127.0.0.1 to on a real interface (pfblockerng.inc:5459-5460); on lo0 (this harness's "
+            "VIP mode) NAT is skipped entirely (pfb_dnsbl_nat_enabled()) and lighttpd binds the "
+            "VIP directly on 80/443 -- either way the externally-reachable port is 80/443."
         ),
         access_note=(
-            "Phase 5: fetch the VIP sinkhole directly -- http://<DNSBL_VIP>:8081/ with a Host header "
-            "set to a blocked hostname and REQUEST_URI '/' to get the DNSBL-Full block page; the "
-            "marker is 'Site blocked via DNSBL' (dnsbl_default.php <title>). No webConfigurator login."
+            "Phase 5: fetch the VIP sinkhole directly -- http://<DNSBL_VIP>/ (port 80, NOT the "
+            "configured dnsbl_port) with a Host header set to a blocked hostname and REQUEST_URI "
+            "'/' to get the DNSBL-Full block page; the marker is 'Site blocked via DNSBL' "
+            "(dnsbl_default.php <title>). No webConfigurator login."
         ),
         markers=("Site blocked via DNSBL",),
     ),


### PR DESCRIPTION
## Summary

- Adds `tests/smoke/ui/test_dnsbl_block_page.py`, a live-VM Tier-B (`ui_e2e`) test proving the real `www/index.php` DNSBL block page correlates a genuine block into its rendered Type/Group/Evaluated-Domain/Feed detail (not the `-` placeholder fallback) — closing the coverage gap ADR-60 Phase 5's off-box-only proof (`tests/php/LogFormatConsumersTest.php`) left open.
- Along the way, live-VM iteration surfaced and fixed two real, previously-undetected bugs in the shared smoke-test harness (neither is a pfBlockerNG production defect):
  - `ensure_dnsbl_vip()` wrote `config.xml` correctly but never actually bound the VIP address to `lo0` (`interface_vip_configure()` alone didn't realize it). Invisible to every existing DNSBL test because Python-mode DNSBL answers a query with the *configured* VIP value regardless of whether it's actually bound to an interface. Fixed with a verify+fallback `ifconfig alias`.
  - The sinkhole's externally-reachable port is always **80/443**, never the configured `dnsbl_port`/`dnsbl_port_ssl` (8081/8443 by default) — those are purely the internal NAT local-port for a real-interface deployment, and NAT is skipped entirely when `dnsbl_iface=='lo0'` (`pfblockerng.inc:5459-5460`, `pfb_dnsbl_nat_enabled()`). `test_render_smoke.py`'s `EXCLUDED_FROM_TIER_A` access-note recipe (which this issue's own report cited) carried the same wrong assumption — corrected it too.

## Test plan

- [x] `ruff check` / `ruff format --check` / `mypy tests/` — all green
- [x] `python3 -m pytest tests/smoke --collect-only` — full smoke tree (617 tests) still collects cleanly
- [x] Live-VM execution (`gh workflow run ui-tests.yml -f pytest_filter=test_dnsbl_block_page_shows_real_correlation_detail`): run https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/28986757930 — `1 passed, 303 deselected in 57.98s`

Fixes #1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)