### PR TITLE
pfblockerng: wire Clear Failed Downloads icon to the ADR-61 sync-status ledger (#999)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ ignore = [
 "tests/smoke/test_pkg_op_teardown.py"           = ["F811"]
 "tests/smoke/test_lifecycle_hook_visibility.py" = ["F811"]
 "tests/smoke/test_hook_stream_visibility.py"    = ["F811"]
+# issue #999: imports the `clean_ledger` fixture from test_render_widget_ledger.py
+"tests/smoke/ui/test_widget_clear_failed.py"    = ["F811"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["pfb_unbound"]

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -178,6 +178,9 @@ if ($_POST) {
 	// Clear widget Failed downloads
 	elseif ($_POST['pfblockerngack']) {
 		exec("{$pfb['sed']} -i '' 's/FAIL/Fail/g' /var/log/pfblockerng/error.log");
+		// issue #999: ADR-61 moved the reporting list to the sync-status ledger --
+		// close the entries it actually reads, not just the retired error.log.
+		pfBlockerNG_clearfailed($pfb['dbdir']);
 		header("Location: /");
 		exit(0);
 	}
@@ -439,6 +442,16 @@ function pfBlockerNG_update_table() {
 		$pfb_table = array_merge($pfb_table, $pfb_dtable);
 	}
 	return $pfb_table;
+}
+
+
+// Close every open PHP-owned sync-status ledger entry (both facilities) -- the
+// "Clear Failed Downloads" icon's manual dismiss. issue #999: never touches the
+// python-owned ledger (pfb_unbound.py's exclusive writer).
+function pfBlockerNG_clearfailed($ledger_dir) {
+	foreach (pfb_sync_status_list_open($ledger_dir) as $entry) {
+		pfb_sync_status_close($entry['facility'], $entry['item'], $entry['stage'], $ledger_dir);
+	}
 }
 
 

--- a/tests/php/PfbWidgetOracleTest.php
+++ b/tests/php/PfbWidgetOracleTest.php
@@ -33,6 +33,11 @@ use PHPUnit\Framework\TestCase;
  *                     path) item renders as plain text, no link attempted, no
  *                     crash; an empty ledger falls back to the MaxMind version
  *                     line exactly as today.
+ *   (d) pfBlockerNG_clearfailed() — issue #999: the "Clear Failed Downloads"
+ *                     icon closes every open PHP-owned ledger entry (facility
+ *                     'ip' and 'dnsbl' alike, single or multiple), never
+ *                     touches the Python-owned ledger, and is a safe no-op on
+ *                     an empty or corrupt ledger.
  */
 final class PfbWidgetOracleTest extends TestCase
 {
@@ -72,9 +77,19 @@ final class PfbWidgetOracleTest extends TestCase
 			}
 			eval($m[0]);
 		}
+
+		if (!function_exists('pfBlockerNG_clearfailed')) {
+			if (!preg_match('/function\s+pfBlockerNG_clearfailed\s*\([^)]*\).*?\n\}/s', $src, $m)) {
+				throw new RuntimeException('test bootstrap: pfBlockerNG_clearfailed() not found in widget source');
+			}
+			eval($m[0]);
+		}
 	}
 
 	private string $dir;
+
+	/** A SEPARATE ledger dir, used only by the pfBlockerNG_clearfailed() python-owned-isolation test. */
+	private ?string $pyDir = null;
 
 	/** Saved $GLOBALS['pfb']/['config'], restored in tearDown (repo convention). */
 	private bool $hadPfb = false;
@@ -99,6 +114,14 @@ final class PfbWidgetOracleTest extends TestCase
 			@unlink($file);
 		}
 		@rmdir($this->dir);
+
+		if ($this->pyDir !== null) {
+			foreach (glob($this->pyDir . '/*') ?: [] as $file) {
+				@unlink($file);
+			}
+			@rmdir($this->pyDir);
+			$this->pyDir = null;
+		}
 
 		if ($this->hadPfb) {
 			$GLOBALS['pfb'] = $this->savedPfb;
@@ -454,5 +477,91 @@ final class PfbWidgetOracleTest extends TestCase
 			'a Python-side file-path item must never attempt a deep link'
 		);
 		$this->assertStringContainsString('pfb_py_zone.txt', $html, 'the entry message must still render');
+	}
+
+	// -----------------------------------------------------------------------
+	// (d) pfBlockerNG_clearfailed() — issue #999 coverage matrix.
+	// -----------------------------------------------------------------------
+
+	public function testClearfailedClosesASingleOpenIpEntry(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_Example_v4', 'apply', '[pfctl] op=replace failed', $this->dir);
+		$this->assertNotEmpty(pfb_sync_status_list_open($this->dir), 'before-state: the ip entry must be open');
+
+		pfBlockerNG_clearfailed($this->dir);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'the ip entry must be closed after clearfailed');
+	}
+
+	public function testClearfailedClosesASingleOpenDnsblEntry(): void
+	{
+		pfb_sync_status_open('dnsbl', 'dnsbl', 'apply', 'DNSBL apply not converged', $this->dir);
+		$this->assertNotEmpty(pfb_sync_status_list_open($this->dir), 'before-state: the dnsbl entry must be open');
+
+		pfBlockerNG_clearfailed($this->dir);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'the dnsbl entry must be closed after clearfailed');
+	}
+
+	public function testClearfailedClosesAllEntriesAcrossBothFacilitiesNoPartialClear(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_Example_v4', 'apply', 'apply failed', $this->dir);
+		pfb_sync_status_open('ip', 'dedup', 'dedup', 'Database Sanity check [ FAILED ]', $this->dir);
+		pfb_sync_status_open('dnsbl', 'dnsbl', 'apply', 'DNSBL apply not converged', $this->dir);
+		$this->assertCount(3, pfb_sync_status_list_open($this->dir), 'before-state: all three entries must be open');
+
+		pfBlockerNG_clearfailed($this->dir);
+
+		$this->assertSame(
+			[],
+			pfb_sync_status_list_open($this->dir),
+			'every entry across both facilities must be closed, no partial-clear / key-collision left behind'
+		);
+	}
+
+	public function testClearfailedOnEmptyLedgerIsASafeNoOp(): void
+	{
+		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'before-state: the ledger must start empty');
+
+		pfBlockerNG_clearfailed($this->dir);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'an empty ledger must stay empty, no warning/exception');
+	}
+
+	public function testClearfailedNeverTouchesThePythonOwnedLedger(): void
+	{
+		// A SEPARATE dir for the python-owned ledger -- pfBlockerNG_clearfailed()
+		// is called with ONLY the PHP ledger dir, exactly as the real handler does.
+		$this->pyDir = sys_get_temp_dir() . '/pfb_widget_oracle_py_' . getmypid() . '_' . uniqid();
+		mkdir($this->pyDir, 0777, TRUE);
+		file_put_contents(
+			$this->pyDir . '/pfb_py_status.json',
+			json_encode([
+				['facility' => 'dnsbl', 'item' => 'pfb_py_zone.txt', 'stage' => 'parse', 'message' => 'boom', 'first_seen' => 1, 'last_seen' => 1],
+			])
+		);
+		pfb_sync_status_open('ip', 'pfB_Example_v4', 'apply', 'apply failed', $this->dir);
+
+		pfBlockerNG_clearfailed($this->dir);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'the PHP-owned entry must be closed');
+		$this->assertCount(
+			1,
+			pfb_py_sync_status_list_open($this->pyDir),
+			'the python-owned entry must remain untouched -- PHP has no writer for that file'
+		);
+	}
+
+	public function testClearfailedOnCorruptLedgerJsonDoesNotThrow(): void
+	{
+		file_put_contents($this->dir . '/pfb_sync_status.json', 'this is not json{{{');
+
+		pfBlockerNG_clearfailed($this->dir);
+
+		$this->assertSame(
+			[],
+			pfb_sync_status_list_open($this->dir),
+			'a corrupt ledger file must read as empty (fail-open), never throw'
+		);
 	}
 }

--- a/tests/php/PfbWidgetOracleTest.php
+++ b/tests/php/PfbWidgetOracleTest.php
@@ -88,9 +88,6 @@ final class PfbWidgetOracleTest extends TestCase
 
 	private string $dir;
 
-	/** A SEPARATE ledger dir, used only by the pfBlockerNG_clearfailed() python-owned-isolation test. */
-	private ?string $pyDir = null;
-
 	/** Saved $GLOBALS['pfb']/['config'], restored in tearDown (repo convention). */
 	private bool $hadPfb = false;
 	private mixed $savedPfb = null;
@@ -114,14 +111,6 @@ final class PfbWidgetOracleTest extends TestCase
 			@unlink($file);
 		}
 		@rmdir($this->dir);
-
-		if ($this->pyDir !== null) {
-			foreach (glob($this->pyDir . '/*') ?: [] as $file) {
-				@unlink($file);
-			}
-			@rmdir($this->pyDir);
-			$this->pyDir = null;
-		}
 
 		if ($this->hadPfb) {
 			$GLOBALS['pfb'] = $this->savedPfb;
@@ -530,12 +519,10 @@ final class PfbWidgetOracleTest extends TestCase
 
 	public function testClearfailedNeverTouchesThePythonOwnedLedger(): void
 	{
-		// A SEPARATE dir for the python-owned ledger -- pfBlockerNG_clearfailed()
-		// is called with ONLY the PHP ledger dir, exactly as the real handler does.
-		$this->pyDir = sys_get_temp_dir() . '/pfb_widget_oracle_py_' . getmypid() . '_' . uniqid();
-		mkdir($this->pyDir, 0777, TRUE);
+		// Same dir passed to pfBlockerNG_clearfailed() -- proves isolation against
+		// the actual function under test, not an unrelated directory it never sees.
 		file_put_contents(
-			$this->pyDir . '/pfb_py_status.json',
+			$this->dir . '/pfb_py_status.json',
 			json_encode([
 				['facility' => 'dnsbl', 'item' => 'pfb_py_zone.txt', 'stage' => 'parse', 'message' => 'boom', 'first_seen' => 1, 'last_seen' => 1],
 			])
@@ -547,7 +534,7 @@ final class PfbWidgetOracleTest extends TestCase
 		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'the PHP-owned entry must be closed');
 		$this->assertCount(
 			1,
-			pfb_py_sync_status_list_open($this->pyDir),
+			pfb_py_sync_status_list_open($this->dir),
 			'the python-owned entry must remain untouched -- PHP has no writer for that file'
 		);
 	}

--- a/tests/smoke/ui/test_widget_clear_failed.py
+++ b/tests/smoke/ui/test_widget_clear_failed.py
@@ -1,0 +1,226 @@
+"""issue #999 -- Tier-B coverage for the dashboard widget's "Clear Failed Downloads" icon.
+
+``pfBlockerNG_clearfailed()`` (widget.php's ``pfblockerngack`` POST handler) closes
+every open PHP-owned sync-status ledger entry; the pre-existing (untouched)
+``sed -i 's/FAIL/Fail/g' error.log`` call still runs alongside it, feeding the
+separate ``pfb_failures()`` skip-download-threshold mechanism. This module proves
+BOTH survive the single POST handler, end to end over real HTTP against the ledger
+writers, complementing ``test_render_widget_ledger.py``'s render-only coverage
+(that module never POSTs; this one drives the actual dismiss action).
+
+Ledger seeding reuses ``test_render_widget_ledger.py``'s own conventions
+(``_ledger_open``/``_ledger_close`` over the REAL ``pfb_sync_status_open()``/
+``pfb_sync_status_close()``, ``clean_ledger`` for backup/restore) rather than
+hand-rolling a JSON blob -- the KILL-GATE mandate that render/behaviour tests
+reflect a manually-seeded entry via the production writer, not a fixture that
+merely resembles one.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PhpErrorLogGuard
+from .test_render_widget_ledger import (  # noqa: F401 -- clean_ledger used as a fixture arg
+    _LEDGER_DIR,
+    _ledger_close,
+    _ledger_open,
+    clean_ledger,
+)
+from .webui import looks_like_login_page
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from .webui import WebUI
+
+# Tier B: this module POSTs a dismiss action (a mutating, multi-step flow), which
+# is observable only end-to-end -- Tier A's plain-GET render coverage of this same
+# page already exists (test_render_smoke.py ~187-189).
+pytestmark = pytest.mark.ui_e2e
+
+WIDGET_PAGE = "/widgets/widgets/pfblockerng.widget.php"
+_GET_FAILED_URL = f"{WIDGET_PAGE}?getNewFailed=1"
+_ERROR_LOG_PATH = "/var/log/pfblockerng/error.log"
+
+
+@pytest.fixture(scope="module")
+def php_error_log_guard(smoke_vm: helpers.SmokeVM, webui: WebUI) -> Iterator[PhpErrorLogGuard]:  # noqa: ARG001
+    """Snapshot ``php_error.log`` once before this module's tests, assert no growth after.
+
+    Mirrors ``test_render_widget_ledger.py``'s own fixture -- the dismiss POST
+    touches two writers (the ledger close loop, the untouched sed) that could log
+    a diagnostic without changing the redirect response at all.
+    """
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+    yield guard
+    guard.assert_no_growth()
+
+
+def _get_failed_body(webui: WebUI) -> str:
+    resp = webui.get(_GET_FAILED_URL)
+    assert resp.status_code == 200, f"GET {_GET_FAILED_URL} -> HTTP {resp.status_code} (expected 200)"
+    return resp.text
+
+
+def _dismiss(webui: WebUI) -> None:
+    """POST the widget's dismiss action -- the exact payload the hidden 'formicons'
+    form's JS-driven submit sends (``pfblockerngack=1``); the handler redirects to
+    ``/`` on success (widget.php ~184-186)."""
+    resp = webui.post(WIDGET_PAGE, {"pfblockerngack": "1"})
+    assert resp.status_code == 200, f"POST {WIDGET_PAGE} pfblockerngack=1 -> HTTP {resp.status_code} (expected 200)"
+    assert not looks_like_login_page(resp.text), "dismiss POST bounced to the login page -- session not authenticated"
+
+
+def _write_error_log(vm: helpers.SmokeVM, contents: str) -> None:
+    """Overwrite ``error.log`` verbatim via ``tee`` over SSH (mirrors
+    ``test_render_widget_ledger.py``'s ``_write_remote_file``)."""
+    result = subprocess.run(
+        vm.ssh_argv("tee", _ERROR_LOG_PATH),
+        input=contents,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert result.returncode == 0, f"writing {_ERROR_LOG_PATH} failed: rc={result.returncode} {result.stderr!r}"
+
+
+def _seed_error_log_fail_line(vm: helpers.SmokeVM, alias: str) -> str:
+    """Append one ISO-8601-stamped 'Download FAIL' line, matching pfb_logger()'s stamp
+    (pfblockerng.inc:3005) and pfb_failures()'s expected shape (pfblockerng.inc:10706),
+    dated TODAY on the guest (never the runner's clock -- avoids a skew false-negative)."""
+    today = vm.ssh("date", "+%Y-%m-%d %H:%M:%S")
+    assert today.returncode == 0, f"reading guest date failed: rc={today.returncode} {today.stderr!r}"
+    stamp = today.stdout.strip()
+    line = f"{stamp} [ {alias} - smoke-header ] Download FAIL\n"
+    existing = helpers.read_log_file(vm, _ERROR_LOG_PATH)
+    _write_error_log(vm, existing + line)
+    return line
+
+
+@pytest.fixture
+def clean_error_log(smoke_vm: helpers.SmokeVM) -> Iterator[None]:
+    """Snapshot + restore ``error.log`` around a test, mirroring ``clean_ledger``'s
+    discipline for the OTHER file the dismiss handler touches."""
+    original = helpers.read_log_file(smoke_vm, _ERROR_LOG_PATH)
+    try:
+        yield
+    finally:
+        if original:
+            _write_error_log(smoke_vm, original)
+        else:
+            smoke_vm.ssh("rm", "-f", _ERROR_LOG_PATH, timeout=15)
+
+
+def test_dismiss_closes_single_open_ip_entry(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    clean_ledger: None,
+    php_error_log_guard: PhpErrorLogGuard,  # noqa: ARG001
+) -> None:
+    """One open facility='ip' entry: dismiss closes it, both via the AJAX reporting
+    list AND a direct ledger read -- proving the close loop, not just a stale render."""
+    vm = smoke_vm
+    item = f"pfB_SmokeDismiss_{uuid.uuid4().hex[:8]}_v4"
+    message = f"smoke: synthetic apply failure {uuid.uuid4().hex[:8]}"
+    _ledger_open(vm, "ip", item, "apply", message)
+
+    # BEFORE: the open entry's message is in the reporting-list fragment.
+    before = _get_failed_body(webui)
+    assert message in before, "seeded ledger entry's message missing from ?getNewFailed=1 before dismiss"
+
+    _dismiss(webui)
+
+    # AFTER (AJAX fragment): the message is gone.
+    after = _get_failed_body(webui)
+    assert message not in after, "dismiss POST did not remove the entry from ?getNewFailed=1"
+
+    # AFTER (direct ledger read): the raw JSON no longer names the item at all.
+    raw = helpers.read_log_file(vm, f"{_LEDGER_DIR}/pfb_sync_status.json")
+    assert item not in raw, f"dismiss POST left {item!r} in the raw ledger file"
+
+    # Idempotent cleanup: closing an already-closed key is a documented no-op.
+    _ledger_close(vm, "ip", item, "apply")
+
+
+def test_dismiss_closes_multiple_entries_across_facilities_in_one_post(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    clean_ledger: None,
+    php_error_log_guard: PhpErrorLogGuard,  # noqa: ARG001
+) -> None:
+    """Two open entries (one ip, one dnsbl) dismissed in ONE POST: BOTH close --
+    proves pfBlockerNG_clearfailed() loops every open entry, not just the first."""
+    vm = smoke_vm
+    ip_item = f"pfB_SmokeMulti_{uuid.uuid4().hex[:8]}_v4"
+    ip_message = f"smoke: synthetic ip apply failure {uuid.uuid4().hex[:8]}"
+    dnsbl_message = f"smoke: synthetic dnsbl apply failure {uuid.uuid4().hex[:8]}"
+    _ledger_open(vm, "ip", ip_item, "apply", ip_message)
+    _ledger_open(vm, "dnsbl", "dnsbl", "apply", dnsbl_message)
+
+    before = _get_failed_body(webui)
+    assert ip_message in before, "seeded ip entry's message missing before dismiss"
+    assert dnsbl_message in before, "seeded dnsbl entry's message missing before dismiss"
+
+    _dismiss(webui)
+
+    after = _get_failed_body(webui)
+    assert ip_message not in after, "dismiss POST left the ip-facility entry open"
+    assert dnsbl_message not in after, "dismiss POST left the dnsbl-facility entry open"
+
+    raw = helpers.read_log_file(vm, f"{_LEDGER_DIR}/pfb_sync_status.json")
+    assert ip_item not in raw, f"dismiss POST left {ip_item!r} in the raw ledger file"
+    assert "dnsbl" not in raw or dnsbl_message not in raw, "dismiss POST left the dnsbl message in the raw ledger file"
+
+    _ledger_close(vm, "ip", ip_item, "apply")
+    _ledger_close(vm, "dnsbl", "dnsbl", "apply")
+
+
+def test_dismiss_still_flips_legacy_error_log_fail_marker(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    clean_ledger: None,
+    clean_error_log: None,
+    php_error_log_guard: PhpErrorLogGuard,  # noqa: ARG001
+) -> None:
+    """Regression guard: the pre-existing, UNTOUCHED
+    ``sed -i 's/FAIL/Fail/g' error.log`` (feeds pfb_failures()'s separate
+    skip-download-threshold mechanism) still fires alongside the new ledger close --
+    Step 1 must not have silently dropped it."""
+    vm = smoke_vm
+    alias = f"SmokeSedRegress{uuid.uuid4().hex[:8]}"
+    line = _seed_error_log_fail_line(vm, alias)
+    assert "FAIL" in line
+
+    before = helpers.read_log_file(vm, _ERROR_LOG_PATH)
+    assert "FAIL" in before, "seeded error.log line missing its FAIL marker before dismiss"
+
+    _dismiss(webui)
+
+    after = helpers.read_log_file(vm, _ERROR_LOG_PATH)
+    assert alias in after, "seeded error.log line disappeared after dismiss (sed must edit in place, not truncate)"
+    assert "FAIL" not in after, "dismiss POST did not flip FAIL -> Fail (the untouched sed regressed)"
+    assert "Fail" in after, "dismiss POST did not produce the expected lowercase 'Fail' marker"
+
+
+def test_dismiss_with_no_open_entries_is_a_safe_noop(
+    webui: WebUI,
+    clean_ledger: None,
+    php_error_log_guard: PhpErrorLogGuard,  # noqa: ARG001
+) -> None:
+    """An empty ledger: dismiss is a safe no-op at the HTTP layer -- normal redirect
+    response, no error, no login-page bounce."""
+    before = _get_failed_body(webui)
+    assert "MaxMind:" in before, "empty ledger must fall back to the MaxMind version line before dismiss"
+
+    _dismiss(webui)
+
+    after = _get_failed_body(webui)
+    assert "MaxMind:" in after, "empty ledger must still fall back to the MaxMind version line after a no-op dismiss"

--- a/tests/smoke/ui/test_widget_clear_failed.py
+++ b/tests/smoke/ui/test_widget_clear_failed.py
@@ -204,8 +204,8 @@ def test_dismiss_still_flips_legacy_error_log_fail_marker(
 ) -> None:
     """Regression guard: the pre-existing, UNTOUCHED
     ``sed -i 's/FAIL/Fail/g' error.log`` (feeds pfb_failures()'s separate
-    skip-download-threshold mechanism) still fires alongside the new ledger close --
-    Step 1 must not have silently dropped it."""
+    skip-download-threshold mechanism) still fires alongside the new ledger close,
+    on the SAME dismiss POST."""
     vm = smoke_vm
     alias = f"SmokeSedRegress{uuid.uuid4().hex[:8]}"
     line = _seed_error_log_fail_line(vm, alias)

--- a/tests/smoke/ui/test_widget_clear_failed.py
+++ b/tests/smoke/ui/test_widget_clear_failed.py
@@ -32,7 +32,7 @@ from .test_render_widget_ledger import (  # noqa: F401 -- clean_ledger used as a
     _ledger_open,
     clean_ledger,
 )
-from .webui import looks_like_login_page
+from .webui import looks_like_login_page, scrape_form_fields
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -72,8 +72,20 @@ def _get_failed_body(webui: WebUI) -> str:
 def _dismiss(webui: WebUI) -> None:
     """POST the widget's dismiss action -- the exact payload the hidden 'formicons'
     form's JS-driven submit sends (``pfblockerngack=1``); the handler redirects to
-    ``/`` on success (widget.php ~184-186)."""
-    resp = webui.post(WIDGET_PAGE, {"pfblockerngack": "1"})
+    ``/`` on success (widget.php ~184-186).
+
+    Can't use ``WebUI.post()`` (it hard-requires a scraped ``__csrf_magic`` token):
+    ``$nocsrf = TRUE`` at the top of this page means csrf-magic's output filter
+    never injects one here at all (confirmed live -- the rendered form has no
+    hidden CSRF input), so this replicates ``post()``'s field-scrape-then-POST
+    shape without that requirement.
+    """
+    page = webui.get(WIDGET_PAGE)
+    assert page.status_code == 200, f"GET {WIDGET_PAGE} -> HTTP {page.status_code} (expected 200)"
+    assert not looks_like_login_page(page.text), "pre-dismiss GET bounced to the login page -- not authenticated"
+    payload = scrape_form_fields(page.text)
+    payload["pfblockerngack"] = "1"
+    resp = webui.session.post(webui.url(WIDGET_PAGE), data=payload, timeout=30)
     assert resp.status_code == 200, f"POST {WIDGET_PAGE} pfblockerngack=1 -> HTTP {resp.status_code} (expected 200)"
     assert not looks_like_login_page(resp.text), "dismiss POST bounced to the login page -- session not authenticated"
 


### PR DESCRIPTION
## Summary

Fixes #999. The dashboard widget's "Clear Failed Downloads" trash-can icon
(`pfblockerngack` POST handler) had gone functionally inert: ADR-61 Phase 6 moved
the reporting list to read the sync-status ledger, but the icon still only mutated
`error.log`, which the list no longer reads.

Per the product decision on the issue, this wires the icon to a manual dismiss:
it now closes every open PHP-owned sync-status ledger entry
(`pfBlockerNG_clearfailed()`, via the existing `pfb_sync_status_close()`) in
addition to the pre-existing `error.log` mutation, which is left untouched because
it still feeds a separate, unrelated mechanism (`pfb_failures()`'s per-feed
skip-download-after-N-failures threshold).

Python-owned ledger entries (`pfb_py_status.json`, written exclusively by
`pfb_unbound.py`) are intentionally left alone -- PHP has no writer for that file
by design; they clear themselves on the next successful run.

## Test plan

- [x] `tests/php/PfbWidgetOracleTest.php` -- 6-row PHPUnit coverage (ip-only,
      dnsbl-only, mixed multi-facility, empty-ledger no-op, python-owned-entry
      untouched, corrupt-JSON fail-open). Red-before/green-after verified.
- [x] `tests/smoke/ui/test_widget_clear_failed.py` -- new Tier-B live-VM coverage:
      single-entry dismiss, multi-facility dismiss in one POST, the untouched
      `error.log` sed regression guard, and the no-open-entries no-op. All 4
      passed live on a real box; red-before/green-after verified.
  - [x] Tier-A `ui_render` widget coverage reconfirmed green (pre-existing entry,
        unaffected by this diff's markers).
- [x] Full PHP gate suite (`phpunit`, `phpstan`, `phpcs`) green.
- [x] `ruff`/`mypy` clean on the new smoke test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
