### PR TITLE
tests: extract pfb_filterlog_timestamp() for real behavioural coverage

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3012,9 +3012,9 @@ function pfb_log_iso_timestamp(): string {
 	return date('Y-m-d H:i:s', time());
 }
 
-// BSD: year-infers strtotime("$f[0] $f[1] $f[2]", $now); rolls back one year if
-// >6h ahead of $now. Non-BSD (syslog): keeps $f[1]'s real year verbatim. Both
-// fall back to pfb_log_iso_timestamp() on strtotime()===FALSE, never epoch 0.
+// BSD year-infers vs $now, rolling back a year past a 6h skew (rollback reparse
+// unchecked -- mirrors pre-extraction behaviour). Syslog keeps $f[1]'s real year.
+// Either falls back to pfb_log_iso_timestamp() on the initial strtotime()===FALSE.
 function pfb_filterlog_timestamp(array $f, string $log_type, int $now): string {
 	if ($log_type == 'BSD') {
 		$ts = strtotime("{$f[0]} {$f[1]} {$f[2]}", $now);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3012,9 +3012,9 @@ function pfb_log_iso_timestamp(): string {
 	return date('Y-m-d H:i:s', time());
 }
 
-// BSD year-infers vs $now, rolling back a year past a 6h skew (rollback reparse
-// unchecked -- mirrors pre-extraction behaviour). Syslog keeps $f[1]'s real year.
-// Either falls back to pfb_log_iso_timestamp() on the initial strtotime()===FALSE.
+// ADR-60 S2.1: BSD year-infers vs $now, rolling back a year past a 6h skew
+// (rollback reparse unchecked -- mirrors pre-extraction behaviour); syslog keeps
+// $f[1]'s real year. Both fall back to pfb_log_iso_timestamp() on initial FALSE.
 function pfb_filterlog_timestamp(array $f, string $log_type, int $now): string {
 	if ($log_type == 'BSD') {
 		$ts = strtotime("{$f[0]} {$f[1]} {$f[2]}", $now);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3012,6 +3012,24 @@ function pfb_log_iso_timestamp(): string {
 	return date('Y-m-d H:i:s', time());
 }
 
+// BSD: year-infers strtotime("$f[0] $f[1] $f[2]", $now); rolls back one year if
+// >6h ahead of $now. Non-BSD (syslog): keeps $f[1]'s real year verbatim. Both
+// fall back to pfb_log_iso_timestamp() on strtotime()===FALSE, never epoch 0.
+function pfb_filterlog_timestamp(array $f, string $log_type, int $now): string {
+	if ($log_type == 'BSD') {
+		$ts = strtotime("{$f[0]} {$f[1]} {$f[2]}", $now);
+		if ($ts === FALSE) {
+			return pfb_log_iso_timestamp();
+		}
+		if ($ts > $now + 6 * 3600) {
+			$ts = strtotime("{$f[0]} {$f[1]} {$f[2]} " . ((int) date('Y', $now) - 1), $now);
+		}
+		return date('Y-m-d H:i:s', $ts);
+	}
+	$ts = strtotime($f[1]);
+	return ($ts === FALSE) ? pfb_log_iso_timestamp() : date('Y-m-d H:i:s', $ts);
+}
+
 function pfb_logger($log, $logtype) {
 	global $g, $pfb;
 
@@ -12875,27 +12893,7 @@ function pfb_daemon_filterlog() {
 					}
 
 					// Log: "Date timestamp/Tracker ID/Interface/Interface Name/Action/IP Version"
-					if ($log_type == 'BSD') {
-						// ADR-60 S2.1: BSD syslog carries no year; infer from now, roll back
-						// a year if the result lands in the future (year-less-syslog fix).
-						// ponytail: 6h skew tolerance -- avoids misreading a same-day line as "next year" near midnight/DST.
-						$bsd_now = time();
-						$ts = strtotime("{$f[0]} {$f[1]} {$f[2]}", $bsd_now);
-						if ($ts === FALSE) {
-							$ts_formatted = pfb_log_iso_timestamp();
-						} else {
-							if ($ts > $bsd_now + 6 * 3600) {
-								$ts = strtotime("{$f[0]} {$f[1]} {$f[2]} " . ((int) date('Y', $bsd_now) - 1), $bsd_now);
-							}
-							$ts_formatted = date('Y-m-d H:i:s', $ts);
-						}
-					} else {
-						// RFC-5424's $f[1] already carries a real year -- keep it verbatim.
-						// A parse failure must fall back like the BSD branch, never stamp
-						// 1970 (which the age-cutoff would then treat as always-expired).
-						$ts = strtotime($f[1]);
-						$ts_formatted = ($ts === FALSE) ? pfb_log_iso_timestamp() : date('Y-m-d H:i:s', $ts);
-					}
+					$ts_formatted = pfb_filterlog_timestamp($f, $log_type, time());
 					$log = "{$ts_formatted},{$d[3]},{$d[4]},{$int},{$d[6]},{$d[8]},";
 
 					// Details:	"Direction/GeoIP/Aliasname/IP evaluated/Feed Name/Resolved Hostname/Client Hostname/ASN/Duplicate status"

--- a/tests/php/LogTimestampBaselineTest.php
+++ b/tests/php/LogTimestampBaselineTest.php
@@ -14,15 +14,16 @@ use PHPUnit\Framework\TestCase;
  *
  * pfb_daemon_filterlog() reads php://stdin in an unbounded daemon loop and is
  * not directly callable from a unit test; its 'BSD'/'syslog' timestamp branch
- * (§1.3's ip_blocklog/ip_permitlog/ip_matchlog row) is pinned via (a) a grep
- * tripwire on the exact current source line, so this oracle goes red the
- * moment the formula changes again, and (b) a reproduction of that exact
- * formula against synthetic fixtures. pfb_log_event() (§1.8's dnsbl.log twin
- * writer) IS directly callable and is exercised for real below.
+ * (§1.3's ip_blocklog/ip_permitlog/ip_matchlog row) was extracted into the
+ * pure, directly-callable pfb_filterlog_timestamp() and is exercised for real
+ * below. Only the REST of pfb_daemon_filterlog() -- the stdin daemon loop
+ * itself -- remains untestable directly. pfb_log_event() (§1.8's dnsbl.log
+ * twin writer) IS directly callable and is exercised for real below too.
  */
 #[CoversFunction('pfb_logger')]
 #[CoversFunction('pfb_parsed_fail')]
 #[CoversFunction('pfb_log_iso_timestamp')]
+#[CoversFunction('pfb_filterlog_timestamp')]
 #[CoversFunction('pfb_open_sqlite')]
 #[CoversFunction('pfb_log_event')]
 final class LogTimestampBaselineTest extends TestCase
@@ -255,47 +256,30 @@ final class LogTimestampBaselineTest extends TestCase
 	// -----------------------------------------------------------------------
 	// §1.3 row: ip_blocklog/ip_permitlog/ip_matchlog -- ADR-60 P3:
 	// pfb_daemon_filterlog()'s 'BSD' branch year-infers, 'syslog' keeps its
-	// already-real year. Not directly callable (stdin daemon loop); pinned via
-	// a source tripwire + a reproduction of the exact formula.
+	// already-real year. Extracted into pfb_filterlog_timestamp() and called
+	// directly below -- no more source tripwire / formula reproduction.
 	// -----------------------------------------------------------------------
 
 	public function testFilterlogBsdBranchYearInfersFromNow(): void
 	{
-		$source = (string) file_get_contents(self::PFBLOCKERNG_INC);
-		$this->assertStringContainsString(
-			'$ts = strtotime("{$f[0]} {$f[1]} {$f[2]}", $bsd_now);',
-			$source,
-			"pfb_daemon_filterlog()'s 'BSD' branch formula changed -- update this baseline oracle"
-		);
-
 		// A classic BSD syslog triple has no year field at all -- infer it from $now.
 		// A line timestamped for "today" (a few hours before $now, the live-tailing
 		// daemon's normal case) must pick $now's own year, no rollback.
 		$now = strtotime('2026-07-08 10:00:00 UTC');
 		$f = ['Jul', '8', '07:00:00'];
-		$ts = strtotime("{$f[0]} {$f[1]} {$f[2]}", $now);
-		if ($ts > $now + 6 * 3600) {
-			$ts = strtotime("{$f[0]} {$f[1]} {$f[2]} " . ((int) date('Y', $now) - 1), $now);
-		}
 
-		$this->assertSame('2026-07-08 07:00:00', date('Y-m-d H:i:s', $ts), 'BSD triple must year-infer against $now, unrolled');
+		$ts_formatted = pfb_filterlog_timestamp($f, 'BSD', $now);
+
+		$this->assertSame('2026-07-08 07:00:00', $ts_formatted, 'BSD triple must year-infer against $now, unrolled');
 	}
 
 	public function testFilterlogSyslogBranchKeepsRealYear(): void
 	{
-		$source = (string) file_get_contents(self::PFBLOCKERNG_INC);
-		$this->assertStringContainsString(
-			'$ts = strtotime($f[1]);',
-			$source,
-			"pfb_daemon_filterlog()'s 'syslog' branch formula changed -- update this baseline oracle"
-		);
-
 		// A synthetic RFC-5424 timestamp field -- it DOES carry a year, verbatim.
 		$f = [1 => '2024-11-05T13:30:45+00:00'];
 		$this->assertStringContainsString('2024', $f[1], 'fixture sanity: the RFC-5424 source must carry a year');
 
-		$ts = strtotime($f[1]);
-		$ts_formatted = ($ts === FALSE) ? pfb_log_iso_timestamp() : date('Y-m-d H:i:s', $ts);
+		$ts_formatted = pfb_filterlog_timestamp($f, 'syslog', time());
 
 		$this->assertSame('2024-11-05 13:30:45', $ts_formatted, "the 'syslog' branch must keep \$f[1]'s real year verbatim, not discard it");
 	}
@@ -310,10 +294,9 @@ final class LogTimestampBaselineTest extends TestCase
 	public function testFilterlogSyslogBranchUnparseableFallsBackToIsoNow(): void
 	{
 		$f = [1 => 'not-a-valid-rfc5424-timestamp'];
-		$ts = strtotime($f[1]);
-		$this->assertFalse($ts, 'fixture sanity: the garbage $f[1] must fail to parse (FALSE)');
+		$this->assertFalse(strtotime($f[1]), 'fixture sanity: the garbage $f[1] must fail to parse (FALSE)');
 
-		$ts_formatted = ($ts === FALSE) ? pfb_log_iso_timestamp() : date('Y-m-d H:i:s', $ts);
+		$ts_formatted = pfb_filterlog_timestamp($f, 'syslog', time());
 
 		$this->assertMatchesRegularExpression(
 			'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
@@ -330,11 +313,12 @@ final class LogTimestampBaselineTest extends TestCase
 	public function testFilterlogSyslogBranchPreservesYearAcrossBoundary(): void
 	{
 		$f = [1 => '2025-12-31T23:59:59+00:00'];
-		$ts = date('Y-m-d H:i:s', strtotime($f[1]));
+
+		$ts_formatted = pfb_filterlog_timestamp($f, 'syslog', time());
 
 		$this->assertSame(
 			'2025-12-31 23:59:59',
-			$ts,
+			$ts_formatted,
 			'a syslog line spanning a year boundary must keep its verbatim source year, never year-inferred'
 		);
 	}
@@ -348,12 +332,12 @@ final class LogTimestampBaselineTest extends TestCase
 		$now = strtotime('2026-01-05 10:00:00 UTC');
 		$f = ['Dec', '31', '23:00:00'];
 
-		$ts = strtotime("{$f[0]} {$f[1]} {$f[2]}", $now);
-		$this->assertGreaterThan($now + 6 * 3600, $ts, 'fixture sanity: the naive same-year parse must land in the future');
+		$naiveTs = strtotime("{$f[0]} {$f[1]} {$f[2]}", $now);
+		$this->assertGreaterThan($now + 6 * 3600, $naiveTs, 'fixture sanity: the naive same-year parse must land in the future');
 
-		$ts = strtotime("{$f[0]} {$f[1]} {$f[2]} " . ((int) date('Y', $now) - 1), $now);
+		$ts_formatted = pfb_filterlog_timestamp($f, 'BSD', $now);
 
-		$this->assertSame('2025-12-31 23:00:00', date('Y-m-d H:i:s', $ts), 'a December BSD line read in January must roll back exactly one year');
+		$this->assertSame('2025-12-31 23:00:00', $ts_formatted, 'a December BSD line read in January must roll back exactly one year');
 	}
 
 	/**
@@ -368,23 +352,21 @@ final class LogTimestampBaselineTest extends TestCase
 	{
 		$bsdNow = strtotime('2026-07-08 12:00:00 UTC');
 
-		$infer = static function (string $f0, string $f1, string $f2, int $bsdNow): string {
-			$ts = strtotime("{$f0} {$f1} {$f2}", $bsdNow);
-			if ($ts > $bsdNow + 6 * 3600) {
-				$ts = strtotime("{$f0} {$f1} {$f2} " . ((int) date('Y', $bsdNow) - 1), $bsdNow);
-			}
-			return date('Y-m-d H:i:s', $ts);
-		};
-
 		// 5h59m ahead: AT/under tolerance -- no rollback, current year kept.
-		$this->assertSame('2026-07-08 17:59:00', $infer('Jul', '8', '17:59:00', $bsdNow),
-			'just under the 6h tolerance must NOT roll back the year');
+		$this->assertSame(
+			'2026-07-08 17:59:00',
+			pfb_filterlog_timestamp(['Jul', '8', '17:59:00'], 'BSD', $bsdNow),
+			'just under the 6h tolerance must NOT roll back the year'
+		);
 
 		// 6h01m ahead: OVER tolerance -- the guard fires and rolls back a year
 		// (the heuristic applies uniformly, not only at a literal Dec/Jan boundary --
 		// a documented, already-shipped characteristic, pinned here, not redesigned).
-		$this->assertSame('2025-07-08 18:01:00', $infer('Jul', '8', '18:01:00', $bsdNow),
-			'just over the 6h tolerance must roll back the year');
+		$this->assertSame(
+			'2025-07-08 18:01:00',
+			pfb_filterlog_timestamp(['Jul', '8', '18:01:00'], 'BSD', $bsdNow),
+			'just over the 6h tolerance must roll back the year'
+		);
 	}
 
 	/**
@@ -393,29 +375,19 @@ final class LogTimestampBaselineTest extends TestCase
 	 */
 	public function testFilterlogBsdBranchUnparseableFallsBackToIsoNow(): void
 	{
-		$source = (string) file_get_contents(self::PFBLOCKERNG_INC);
-		$this->assertStringContainsString(
-			'$ts_formatted = pfb_log_iso_timestamp();',
-			$source,
-			"pfb_daemon_filterlog()'s FALSE-parse fallback changed -- update this baseline oracle"
-		);
-
 		$warnings = [];
 		set_error_handler(function ($errno, $errstr) use (&$warnings) {
 			$warnings[] = $errstr;
 			return true;
 		});
 		$f = ['Foo', '99', '99:99:99'];
-		$ts = strtotime("{$f[0]} {$f[1]} {$f[2]}", time());
+		$ts_formatted = pfb_filterlog_timestamp($f, 'BSD', time());
 		restore_error_handler();
 
-		$this->assertSame([], $warnings, 'strtotime() on garbage BSD fields must never raise a PHP warning');
-		$this->assertFalse($ts, 'garbage BSD fields must fail to parse (FALSE), triggering the fallback');
-
-		$fallback = pfb_log_iso_timestamp();
+		$this->assertSame([], $warnings, 'pfb_filterlog_timestamp() on garbage BSD fields must never raise a PHP warning');
 		$this->assertMatchesRegularExpression(
 			'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
-			$fallback,
+			$ts_formatted,
 			"the FALSE-parse fallback must be pfb_log_iso_timestamp()'s ISO-8601 \"now\" shape"
 		);
 	}

--- a/tests/php/LogTimestampBaselineTest.php
+++ b/tests/php/LogTimestampBaselineTest.php
@@ -254,10 +254,8 @@ final class LogTimestampBaselineTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// §1.3 row: ip_blocklog/ip_permitlog/ip_matchlog -- ADR-60 P3:
-	// pfb_daemon_filterlog()'s 'BSD' branch year-infers, 'syslog' keeps its
-	// already-real year. Extracted into pfb_filterlog_timestamp() and called
-	// directly below -- no more source tripwire / formula reproduction.
+	// §1.3 row: ip_blocklog/ip_permitlog/ip_matchlog -- pfb_filterlog_timestamp()'s
+	// 'BSD' branch year-infers, 'syslog' keeps its already-real year.
 	// -----------------------------------------------------------------------
 
 	public function testFilterlogBsdBranchYearInfersFromNow(): void
@@ -390,6 +388,7 @@ final class LogTimestampBaselineTest extends TestCase
 			$ts_formatted,
 			"the FALSE-parse fallback must be pfb_log_iso_timestamp()'s ISO-8601 \"now\" shape"
 		);
+		$this->assertStringStartsNotWith('1970-01-01', $ts_formatted, 'must never silently stamp the Unix epoch on a parse failure');
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`pfb_daemon_filterlog()`'s BSD/syslog timestamp branch had no real behavioural test — only a source-string tripwire plus a self-referential reproduction of the exact formula, asserted against itself. A production regression there would pass every gate.

Extracts the branch into a pure, directly-callable `pfb_filterlog_timestamp(array $f, string $log_type, int $now): string`, and converts the 8 filterlog-timestamp tests in `LogTimestampBaselineTest.php` from formula-reproduction to real calls into it. Behaviour-preserving — production output is byte-identical before and after (the call site is now a single `pfb_filterlog_timestamp($f, $log_type, time())`).

The `6h` skew-tolerance boundary sub-ask from the issue was already fixed in a prior commit (98493cb5); this PR converts that test to a real call too, no formula change.

Fixes #1010

## Test plan

- [x] `vendor/bin/phpunit --filter LogTimestampBaselineTest` — 19/19 green
- [x] Red→green proven: reverting only the `src/` extraction (test file at HEAD) makes 7 tests fail with `Call to undefined function pfb_filterlog_timestamp()`; restoring the extraction makes all 19 pass
- [x] `vendor/bin/phpunit` full suite — 2498/2498 (4 documented root-uid skips)
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist src/` — clean
- [x] `php -l` on both touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkjWYvoEUHTKibFM14jkgG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log timestamp handling so entries are parsed more consistently across BSD and non-BSD formats.
  * Better handles year rollover and near-future timestamps, reducing incorrect dates in displayed logs.
  * Falls back more gracefully when a timestamp can’t be parsed, helping avoid misleading log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->