### PR TITLE
pfblockerng: stream nolimit log age-cutoff trim to bound memory

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2873,8 +2873,8 @@ function pfb_log_line_timestamp(string $line, string $field_mode): ?int {
 // ADR-60 S2.2 age-cutoff scan: log lines are chronologically appended, so this
 // walks from the top and stops at the first non-expired line -- everything from
 // there on is kept without re-checking. An unparseable/corrupted timestamp
-// counts as expired (safe: only ever runs on the already line-capped candidate,
-// or the whole file when log_max_<type>=='nolimit'). PURE.
+// counts as expired (safe: only ever runs on the already line-capped candidate --
+// issue #1012 moved the 'nolimit' whole-file case off this array-based path). PURE.
 function pfb_log_age_cutoff(array $lines, int $cutoff_ts, string $field_mode): array {
 	foreach ($lines as $i => $line) {
 		$ts = pfb_log_line_timestamp($line, $field_mode);
@@ -2885,17 +2885,73 @@ function pfb_log_age_cutoff(array $lines, int $cutoff_ts, string $field_mode): a
 	return array();
 }
 
+// Same leading-run drop as pfb_log_age_cutoff(), streamed line-by-line into a
+// scratch file instead of an in-memory array -- issue #1012: a 'nolimit' log
+// has no line-count cap, so the candidate can be the whole unbounded file.
+function pfb_log_age_trim_temp_stream(string $temp, int $cutoff_ts, string $field_mode): bool {
+	$in = @fopen($temp, 'r');
+	if ($in === FALSE) {
+		return FALSE;
+	}
+
+	$scratch = @tempnam(dirname($temp), 'pfb_logtrim_');
+	$out = ($scratch !== FALSE) ? @fopen($scratch, 'w') : FALSE;
+	if ($out === FALSE) {
+		fclose($in);
+		if ($scratch !== FALSE) {
+			unlink_if_exists($scratch);
+		}
+		return FALSE;
+	}
+
+	$kept = FALSE;
+	$ok = TRUE;
+	while (($line = fgets($in)) !== FALSE) {
+		if (!$kept) {
+			$ts = pfb_log_line_timestamp(rtrim($line, "\r\n"), $field_mode);
+			if ($ts === NULL || $ts < $cutoff_ts) {
+				continue;
+			}
+			$kept = TRUE;
+		}
+		if (fwrite($out, $line) === FALSE) {
+			$ok = FALSE;
+			break;
+		}
+	}
+	fclose($in);
+	fclose($out);
+
+	if ($ok) {
+		$ok = @rename($scratch, $temp);
+	}
+	if (!$ok) {
+		unlink_if_exists($scratch);
+		return FALSE;
+	}
+	return TRUE;
+}
+
 // Rewrite the truncation-candidate file $temp in place, keeping only lines
 // within the last $days (ADR-60 S2.2) per $logtype's field position. Returns
 // FALSE on any read/write failure so the caller can gate its exec chain on it,
 // exactly like the existing tail/cat steps -- a failed pass must never reach
 // the final cat-over-the-live-log step with truncated/garbage content.
-function pfb_log_age_trim_temp(string $temp, int $days, string $logtype): bool {
+// $unbounded_candidate (issue #1012): route 'nolimit' through the streaming
+// helper -- the array/@file() path below stays exact for the line-capped case.
+function pfb_log_age_trim_temp(string $temp, int $days, string $logtype, bool $unbounded_candidate = FALSE): bool {
+	$field_mode = pfb_log_age_field_mode($logtype);
+	$cutoff_ts = time() - ($days * 86400);
+
+	if ($unbounded_candidate) {
+		return pfb_log_age_trim_temp_stream($temp, $cutoff_ts, $field_mode);
+	}
+
 	$lines = @file($temp, FILE_IGNORE_NEW_LINES);
 	if ($lines === FALSE) {
 		return FALSE;
 	}
-	$kept = pfb_log_age_cutoff($lines, time() - ($days * 86400), pfb_log_age_field_mode($logtype));
+	$kept = pfb_log_age_cutoff($lines, $cutoff_ts, $field_mode);
 	$content = $kept ? implode("\n", $kept) . "\n" : '';
 	return file_put_contents($temp, $content) !== FALSE;
 }
@@ -2951,7 +3007,7 @@ function pfb_log_mgmt() {
 					}
 					if ($ret !== 0) {
 						pfb_logger("\npfb_log_mgmt: failed to produce {$final_log_file}'s truncation candidate", 2);
-					} elseif ($agedays > 0 && !pfb_log_age_trim_temp($temp, $agedays, $logtype)) {
+					} elseif ($agedays > 0 && !pfb_log_age_trim_temp($temp, $agedays, $logtype, $logmax === 'nolimit')) {
 						pfb_logger("\npfb_log_mgmt: failed to age-trim {$final_log_file}'s truncation candidate", 2);
 						$ret = 1;
 					}
@@ -2977,7 +3033,7 @@ function pfb_log_mgmt() {
 				}
 				if ($ret !== 0) {
 					pfb_logger("\npfb_log_mgmt: failed to produce {$pfb[$logtype]}'s truncation candidate", 2);
-				} elseif ($agedays > 0 && !pfb_log_age_trim_temp($temp, $agedays, $logtype)) {
+				} elseif ($agedays > 0 && !pfb_log_age_trim_temp($temp, $agedays, $logtype, $logmax === 'nolimit')) {
 					pfb_logger("\npfb_log_mgmt: failed to age-trim {$pfb[$logtype]}'s truncation candidate", 2);
 					$ret = 1;
 				}

--- a/tests/php/LogAgeCutoffStreamTest.php
+++ b/tests/php/LogAgeCutoffStreamTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1012: pfb_log_age_trim_temp()'s 'nolimit' candidate has no
+ * line-count cap, so @file()-ing it into a PHP array (ADR-60 S2.2's
+ * assumption of "an already line-capped (small) candidate") can materialize
+ * the whole unbounded log in memory. These pin the streaming
+ * (fgets/fwrite-to-scratch) replacement's memory boundedness and its own
+ * I/O failure gating; functional/field-mode coverage for the streaming path
+ * lives in LogMgmtAgeCutoffTest.php.
+ */
+final class LogAgeCutoffStreamTest extends TestCase
+{
+	/** Mirrors LogMgmtAgeCutoffTest::seedMinimalConfig() -- see there for why each key is needed. */
+	private function seedMinimalConfig(): void
+	{
+		$GLOBALS['config'] = [];
+		$gen   = 'installedpackages/pfblockerng/config/0';
+		$ip    = 'installedpackages/pfblockerngipsettings/config/0';
+		$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
+
+		config_set_path("{$gen}/pfb_min",        '0');
+		config_set_path("{$gen}/pfb_hour",       '0');
+		config_set_path("{$gen}/pfb_dailystart", '0');
+		config_set_path("{$gen}/skipfeed",       '0');
+
+		config_set_path("{$ip}/suppression",     '');
+		config_set_path("{$ip}/database_cc",     '');
+		config_set_path("{$ip}/maxmind_locale",  'en');
+		config_set_path("{$ip}/asn_reporting",   'disabled');
+		config_set_path("{$ip}/asn_token",       '');
+		config_set_path("{$ip}/maxmind_account", '');
+		config_set_path("{$ip}/maxmind_key",     '');
+
+		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
+
+		config_set_path("{$dnsbl}/pfb_dnsvip4",     '');
+		config_set_path("{$dnsbl}/pfb_dnsvip6",     '');
+		config_set_path("{$dnsbl}/pfb_dnsport",     '8081');
+		config_set_path("{$dnsbl}/pfb_dnsport_ssl", '8443');
+		config_set_path("{$dnsbl}/alexa_enable",    '');
+		config_set_path("{$dnsbl}/pfb_cache",       '');
+		config_set_path("{$dnsbl}/pfb_py_reply",    '');
+		config_set_path("{$dnsbl}/pfb_regex",       '');
+		config_set_path("{$dnsbl}/pfb_regex_list",  '');
+		config_set_path("{$dnsbl}/pfb_cname",       '');
+		config_set_path("{$dnsbl}/pfb_pytld",       '');
+		config_set_path("{$dnsbl}/pfb_py_nolog",    '');
+		config_set_path("{$dnsbl}/pfb_noaaaa",      '');
+		config_set_path("{$dnsbl}/pfb_noaaaa_list", '');
+		config_set_path("{$dnsbl}/pfb_gp",          '');
+		config_set_path("{$dnsbl}/pfb_gp_bypass_list", '');
+
+		if (!isset($GLOBALS['g']['unbound_chroot_path'])) {
+			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
+		}
+	}
+
+	private function ensureLogDir(): void
+	{
+		$logdir = $GLOBALS['pfb']['logdir'];
+		if (!is_dir($logdir)) {
+			@mkdir($logdir, 0755, TRUE);
+		}
+	}
+
+	/**
+	 * Writes $expiredCount lines timestamped $expiredDaysAgo days ago,
+	 * followed by $freshCount lines timestamped now, directly to $path via
+	 * fwrite() (never held as one in-memory array/string) -- mirrors the
+	 * 'prefix' field-mode shape ('log' type). Returns the fresh lines, in
+	 * order, for the post-trim assertion.
+	 *
+	 * @return string[]
+	 */
+	private function writeLargeLogFixture(string $path, int $expiredCount, int $freshCount, int $expiredDaysAgo): array
+	{
+		$fh = fopen($path, 'w');
+		$expiredTs = date('Y-m-d H:i:s', time() - ($expiredDaysAgo * 86400));
+		for ($i = 0; $i < $expiredCount; $i++) {
+			fwrite($fh, $expiredTs . ' expired-line-' . $i . "\n");
+		}
+		$nowTs = date('Y-m-d H:i:s');
+		$freshLines = [];
+		for ($i = 0; $i < $freshCount; $i++) {
+			$line = $nowTs . ' fresh-line-' . $i;
+			fwrite($fh, $line . "\n");
+			$freshLines[] = $line;
+		}
+		fclose($fh);
+		return $freshLines;
+	}
+
+	/**
+	 * THE pinning test for issue #1012. A 200,000-line / several-MB 'log'
+	 * file, all but 5 lines 40 days old (expired), 'log_max_log'='nolimit' +
+	 * 'log_max_days_log' set -- the age-cutoff candidate is the WHOLE file,
+	 * no line-count cap exists to shrink it first. Also covers the
+	 * all-expired-leading-run case (ADR.md S2.6): the entire 199,995-line
+	 * expired run must be dropped via the streaming path.
+	 *
+	 * Bound justification (measured this session on this machine): the old
+	 * @file()-array approach costs a +24,690,688 byte (~23.5 MiB)
+	 * memory_get_peak_usage(true) delta on this exact fixture; the streaming
+	 * fgets()/fwrite() approach costs 0 bytes. 5 MiB sits an order of
+	 * magnitude below the old cost and comfortably above the streaming
+	 * overhead, cleanly separating old-code-fails from new-code-passes.
+	 *
+	 * Scenario:
+	 *   Given log_max_log='nolimit'; log_max_days_log='30'.
+	 *   And   199,995 lines 40 days old + 5 fresh lines (today).
+	 *   Before: 200,000 lines.
+	 *   When  pfb_log_age_trim_temp() is called with $unbounded_candidate=TRUE.
+	 *   Then  only the 5 fresh lines survive AND the memory_get_peak_usage(true)
+	 *         delta across the call stays under 5 MiB.
+	 */
+	#[RunInSeparateProcess]
+	public function testStreamingTrimStaysMemoryBoundedOnLargeMostlyExpiredFile(): void
+	{
+		$this->seedMinimalConfig();
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $GLOBALS['pfb']['log'];
+		// 199,995 expired + 5 fresh = 200,000 lines (>= the 150,000-line floor).
+		$freshLines = $this->writeLargeLogFixture($logPath, 199995, 5, 40);
+
+		clearstatcache(TRUE, $logPath);
+		$this->assertGreaterThan(1_000_000, filesize($logPath), 'Before: fixture must be several MB');
+
+		gc_collect_cycles();
+		$memBefore = memory_get_peak_usage(TRUE);
+
+		$ok = pfb_log_age_trim_temp($logPath, 30, 'log', TRUE);
+
+		$memDelta = memory_get_peak_usage(TRUE) - $memBefore;
+
+		$this->assertTrue($ok, 'the streaming trim must succeed');
+
+		clearstatcache(TRUE, $logPath);
+		$linesAfter = array_values(array_filter(explode("\n", (string) file_get_contents($logPath)), 'strlen'));
+		$this->assertSame($freshLines, $linesAfter,
+			'only the 5 fresh lines must survive (the whole 199,995-line expired run dropped), got '
+			. count($linesAfter) . ' lines'
+		);
+
+		$this->assertLessThan(5 * 1024 * 1024, $memDelta,
+			"streaming trim's memory_get_peak_usage(true) delta must stay under 5 MiB on a 200k-line file, got {$memDelta} bytes"
+		);
+	}
+
+	/**
+	 * Streaming I/O failure gating, branch 1: $temp does not exist at all --
+	 * fopen($temp, 'r') fails -- the streaming helper must return FALSE
+	 * without touching anything (there is nothing to touch).
+	 */
+	public function testStreamingHelperFailsWhenTempFileMissing(): void
+	{
+		$this->seedMinimalConfig();
+		$this->ensureLogDir();
+		pfb_global();
+
+		$missing = $GLOBALS['pfb']['logdir'] . '/does-not-exist-' . uniqid() . '.log';
+		$this->assertFileDoesNotExist($missing, 'Before: the path must not exist');
+
+		$ok = pfb_log_age_trim_temp($missing, 30, 'log', TRUE);
+
+		$this->assertFalse($ok, 'a missing $temp must make the streaming trim return FALSE');
+		$this->assertFileDoesNotExist($missing, 'a failed trim must never create $temp');
+	}
+
+	/**
+	 * Streaming I/O failure gating, branch 2: $temp's directory is read-only.
+	 * Probed this session: tempnam()/fopen($scratch,'w') do NOT fail here --
+	 * tempnam() silently falls back to the system temp dir -- so the failure
+	 * actually surfaces at the final rename($scratch, $temp) (destination dir
+	 * not writable). Still proves the same contract: FALSE returned, $temp
+	 * byte-for-byte untouched, and the now-orphaned-directory scratch file
+	 * cleaned up. Root bypasses directory permissions, so this cannot be
+	 * simulated there (mirrors testFailedCatNeverCorruptsLiveLogEvenWithAgeCutoffActive).
+	 */
+	public function testStreamingHelperFailsAndLeavesTempUntouchedWhenDestinationDirReadOnly(): void
+	{
+		if (function_exists('posix_getuid') && posix_getuid() === 0) {
+			$this->markTestSkipped('root bypasses directory permissions; cannot simulate an unwritable scratch dir');
+		}
+
+		$this->seedMinimalConfig();
+		$this->ensureLogDir();
+		pfb_global();
+
+		$roDir = $GLOBALS['pfb']['logdir'] . '/ro-' . uniqid();
+		mkdir($roDir, 0755);
+		$temp = $roDir . '/candidate.log';
+		$content = date('Y-m-d H:i:s') . " fresh line\n";
+		file_put_contents($temp, $content);
+		chmod($roDir, 0555);
+
+		try {
+			$ok = pfb_log_age_trim_temp($temp, 30, 'log', TRUE);
+
+			$this->assertFalse($ok, 'a read-only destination dir must make the streaming trim return FALSE');
+			clearstatcache(TRUE, $temp);
+			$this->assertSame($content, file_get_contents($temp),
+				'a failed rename() back onto $temp must leave it byte-for-byte untouched'
+			);
+		} finally {
+			chmod($roDir, 0755);
+		}
+	}
+}

--- a/tests/php/LogMgmtAgeCutoffTest.php
+++ b/tests/php/LogMgmtAgeCutoffTest.php
@@ -439,6 +439,30 @@ final class LogMgmtAgeCutoffTest extends TestCase
 	}
 
 	/**
+	 * Empty file, NOLIMIT (issue #1012): testEmptyFileStaysEmpty above only
+	 * exercises the DEFAULT/bounded '20000' line-cap path -- this pins the
+	 * streaming trim's empty-input case (fopen($temp,'r') on a 0-byte file,
+	 * no fgets() iterations, rename empty scratch over $temp).
+	 */
+	public function testEmptyFileStaysEmptyUnderNolimit(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('log', 'nolimit', '30');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('log');
+		file_put_contents($logPath, '');
+
+		$this->assertSame(0, filesize($logPath), 'Before: file must be empty');
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$this->assertSame(0, filesize($logPath), 'an empty file under nolimit must stay empty, not error or grow');
+	}
+
+	/**
 	 * Realistic upgrade scenario: a file with legacy (pre-ADR-60, unparseable)
 	 * lines from before the operator opted in, followed by new-format ISO
 	 * lines. Only the legacy lines are dropped (S2.2 "unparseable = expired").
@@ -587,6 +611,36 @@ final class LogMgmtAgeCutoffTest extends TestCase
 	}
 
 	/**
+	 * field0 mode, NOLIMIT (issue #1012): same as
+	 * testFieldZeroModeAgeCutoffTrimsIpBlocklog but log_max_ip_blocklog is
+	 * also 'nolimit' -- exercises the streaming trim path with field0 CSV
+	 * timestamps instead of the array/@file() path.
+	 */
+	public function testFieldZeroModeNolimitAgeCutoffTrimsIpBlocklog(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('ip_blocklog', 'nolimit', '10');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('ip_blocklog');
+		$old   = $this->daysAgo(40) . ',1,em0,WAN,block,4,17,UDP,10.0.0.1,10.0.0.2,1234,53,in,US,-,-,-,-,-,+';
+		$fresh = $this->now()       . ',2,em0,WAN,block,4,17,UDP,10.0.0.3,10.0.0.4,1235,53,in,US,-,-,-,-,-,+';
+		file_put_contents($logPath, $old . "\n" . $fresh . "\n");
+
+		$inodeBefore = fileinode($logPath);
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$linesAfter = array_values(array_filter(explode("\n", (string) file_get_contents($logPath)), 'strlen'));
+		$this->assertSame([$fresh], $linesAfter,
+			'field0 nolimit streaming trim must drop the 40-day-old CSV row, got ' . var_export($linesAfter, TRUE)
+		);
+		$this->assertSame($inodeBefore, fileinode($logPath), 'inode must be unchanged (in-place)');
+	}
+
+	/**
 	 * field1 mode ('dnslog'): field 0 is a type label ('DNSBL-python'), the
 	 * timestamp is CSV column 1. Also exercises the chroot-branch code path
 	 * (dnslog/dnsreplylog/unilog) -- the chroot dir is absent on this runner,
@@ -620,6 +674,36 @@ final class LogMgmtAgeCutoffTest extends TestCase
 		$linesAfter = array_values(array_filter(explode("\n", (string) file_get_contents($logPath)), 'strlen'));
 		$this->assertSame([$fresh], $linesAfter,
 			'field1 age cutoff must drop the 40-day-old row, got ' . var_export($linesAfter, TRUE)
+		);
+		$this->assertSame($inodeBefore, fileinode($logPath), 'inode must be unchanged (in-place)');
+	}
+
+	/**
+	 * field1 mode, NOLIMIT (issue #1012): same as
+	 * testFieldOneModeAgeCutoffTrimsDnslog but log_max_dnslog is also
+	 * 'nolimit' -- exercises the streaming trim path with field1 CSV
+	 * timestamps, also under the chroot-branch code path.
+	 */
+	public function testFieldOneModeNolimitAgeCutoffTrimsDnslog(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('dnslog', 'nolimit', '10');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('dnslog');
+		$old   = 'DNSBL-python,' . $this->daysAgo(40) . ',old.example.com,127.0.0.1,Python,Block,Feed,eval,feed,+,A';
+		$fresh = 'DNSBL-python,' . $this->now()       . ',new.example.com,127.0.0.1,Python,Block,Feed,eval,feed,+,A';
+		file_put_contents($logPath, $old . "\n" . $fresh . "\n");
+
+		$inodeBefore = fileinode($logPath);
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$linesAfter = array_values(array_filter(explode("\n", (string) file_get_contents($logPath)), 'strlen'));
+		$this->assertSame([$fresh], $linesAfter,
+			'field1 nolimit streaming trim must drop the 40-day-old row, got ' . var_export($linesAfter, TRUE)
 		);
 		$this->assertSame($inodeBefore, fileinode($logPath), 'inode must be unchanged (in-place)');
 	}


### PR DESCRIPTION
## Summary

Fixes #1012. `pfb_log_age_trim_temp()` loaded the whole truncation candidate into a PHP array via `@file()` before scanning for the age cutoff. That's fine for the numeric line-cap case (the `tail -n N` candidate is genuinely small, per ADR-60 S2.2's design assumption), but when `log_max_<type>==='nolimit'` there is no line-count cap, so the candidate can be the entire unbounded log — a large memory read on every cron tick for an operator who has opted into both `nolimit` and an age-based cap.

Adds a streaming (`fgets`/`fwrite` to a scratch file, then `rename()`) path used only for the `nolimit` case; the existing array-based path for the numeric line-cap case is untouched.

## Test plan

- [x] New pinning test proves the memory bound: 200k-line/~7.9MB fixture, RED pre-fix (24.7MB peak delta, over a 5MiB bound), GREEN post-fix
- [x] New coverage for the previously-untested `nolimit` × field0/field1 combinations (`ip_blocklog`, `dnslog`)
- [x] New empty-file-under-nolimit + streaming I/O failure-gating tests
- [x] Full existing suite green, unmodified assertions (`vendor/bin/phpunit`: 2504 tests, 0 failures)
- [x] `phpstan`, `phpcs --standard=phpcs.xml.dist src/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRWyWQKCBuNt7ZxgBwssBS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of large log files when age-based cleanup is used with unlimited log size settings.
  * Added coverage for empty logs and multiple log formats to ensure trimming still works as expected.

* **Bug Fixes**
  * Reduced memory usage during log cleanup by processing eligible entries in a streaming manner.
  * Improved reliability when cleanup encounters missing files or unwritable destinations, with safer cleanup behavior.

* **Tests**
  * Added automated tests for large-file trimming, failure handling, and retention behavior across supported log formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->