### PR TITLE
tests: fix vacuous DNSBL restart-fallback ledger test (#1015)

### DIFF
--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -306,10 +306,9 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 
 		$region = substr($source, $start, $end - $start);
 
-		// \s*\( (not a literal "(") so neither call is evadable by reformatting with
-		// whitespace before the parenthesis; pfb_sync_status_open/close are the only
-		// two ledger-mutating primitives (grepped -- no pfb_sync_status_refresh() or
-		// similar exists), so this pair is exhaustive.
+		// \s*\( (not a literal "(") so neither call is evadable via whitespace before
+		// the parenthesis; pfb_sync_status_open/close are the only two ledger-mutating
+		// primitives (grepped -- no pfb_sync_status_refresh() exists), exhaustive.
 		$this->assertDoesNotMatchRegularExpression('/pfb_sync_status_open\s*\(/', $region,
 			'a restart-fallback branch must never open a ledger entry directly -- only the shared tail may');
 		$this->assertDoesNotMatchRegularExpression('/pfb_sync_status_close\s*\(/', $region,

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -210,7 +210,7 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// pfb_reload_unbound() end-to-end -- restart-fallback opens nothing alone
+	// pfb_reload_unbound() end-to-end -- restart-fallback reaches a converged tail
 	// -----------------------------------------------------------------------
 
 	/**
@@ -298,17 +298,21 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 
 		$start = strpos($source, 'function pfb_reload_unbound(');
 		$this->assertNotFalse($start, 'pfb_reload_unbound() must exist');
-		// The shared restart path (both the fallback branches AND the zero-downtime
-		// success return fall through to it) always opens with this tempnam() call --
+		// The three fallback branches all fall through to this tempnam() call (the
+		// zero-downtime SUCCESS path instead `return`s early, before reaching it) --
 		// a stable, unique boundary marking the end of the fallback-branches region.
 		$end = strpos($source, "\$cache_dumpfile = tempnam(", $start);
 		$this->assertNotFalse($end, 'the shared restart path boundary marker must exist');
 
 		$region = substr($source, $start, $end - $start);
 
-		$this->assertStringNotContainsString('pfb_sync_status_open(', $region,
+		// \s*\( (not a literal "(") so neither call is evadable by reformatting with
+		// whitespace before the parenthesis; pfb_sync_status_open/close are the only
+		// two ledger-mutating primitives (grepped -- no pfb_sync_status_refresh() or
+		// similar exists), so this pair is exhaustive.
+		$this->assertDoesNotMatchRegularExpression('/pfb_sync_status_open\s*\(/', $region,
 			'a restart-fallback branch must never open a ledger entry directly -- only the shared tail may');
-		$this->assertStringNotContainsString('pfb_sync_status_close(', $region,
+		$this->assertDoesNotMatchRegularExpression('/pfb_sync_status_close\s*\(/', $region,
 			'a restart-fallback branch must never close a ledger entry directly -- only the shared tail may');
 	}
 }

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -11,10 +11,14 @@ use PHPUnit\Framework\TestCase;
  * The apply-stage decision (pfb_dnsbl_apply_ledger_update(), built on
  * pfb_dnsbl_converged()) is tested directly for the open/close/refresh
  * contract, and separately end-to-end through the REAL pfb_reload_unbound()
- * to prove its swap-not-confirmed restart-fallback branch does not, by
- * itself, leave a ledger entry behind (ADR SS1.3: "NOT an error: fail-safe
- * by design"). The feed-download pair (pfb_dnsbl_download_ledger_update())
- * mirrors the IP side's PfbSyncStatusIpWritersTest Pair 1.
+ * to prove its swap-not-confirmed restart-fallback path reaches the shared
+ * tail and converges (ADR SS1.3: "NOT an error: fail-safe by design"). That
+ * the three restart-fallback branches never call a ledger function directly
+ * is a SEPARATE, source-inspection-only invariant (the tail's write is
+ * deterministic/idempotent-by-key, so no end-state assertion can prove it) --
+ * see testRestartFallbackBranchesNeverCallLedgerFunctionsDirectly. The
+ * feed-download pair (pfb_dnsbl_download_ledger_update()) mirrors the IP
+ * side's PfbSyncStatusIpWritersTest Pair 1.
  *
  * Functions under test:
  *   pfb_dnsbl_apply_ledger_update(): void
@@ -210,19 +214,24 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 	// -----------------------------------------------------------------------
 
 	/**
-	 * Drives the REAL swap-not-confirmed -> restart-fallback branch: the
-	 * zero-downtime eligibility gate passes, but the sentinel flip itself
-	 * fails (dnsbldir made read-only), so pfb_reload_unbound() falls through
-	 * to the shared restart path exactly as it would on a genuine stuck
-	 * watcher. Neither fallback branch calls any ledger function -- only the
-	 * TAIL's pfb_dnsbl_apply_ledger_update() does, and it is proven
-	 * (PfbDnsblConvergedTest) to correctly read "converged" once the
-	 * sentinel/applied pair (both absent -> 0 == 0), Unbound liveness, and
-	 * unbound.conf all agree -- so this test's PASSING assertion is a real
-	 * proof that the fallback branch itself never wrote an entry, not an
-	 * artifact of the tail masking one.
+	 * Drives the REAL swap-not-confirmed -> restart-fallback branch (dnsbldir
+	 * made read-only, so the sentinel flip itself fails) through to the
+	 * shared tail, exactly as a genuine stuck watcher would. Proves ONLY:
+	 * (1) the fallback + shared restart path runs to completion without
+	 * crashing/hanging ($calls sanity check), and (2) the tail's
+	 * pfb_dnsbl_apply_ledger_update() correctly reflects the REAL final
+	 * convergence outcome once Unbound is back up.
+	 *
+	 * Does NOT prove the fallback branch itself never calls a ledger
+	 * function: the tail's write is deterministic/idempotent-by-key (see
+	 * testConvergedClosesEntry / testNotConvergedTwiceRefreshesWithoutDuplicating),
+	 * so it unconditionally overwrites the (dnsbl,dnsbl,apply) key regardless
+	 * of what ran earlier in the same call -- a stray open() inside the
+	 * fallback branch would be silently masked here. See
+	 * testRestartFallbackBranchesNeverCallLedgerFunctionsDirectly for that
+	 * invariant, pinned by source inspection instead.
 	 */
-	public function testRestartFallbackAloneOpensNoEntry(): void
+	public function testRestartFallbackPathReachesTailWithConvergedState(): void
 	{
 		if (function_exists('posix_getuid') && posix_getuid() === 0) {
 			$this->markTestSkipped('root bypasses directory permissions -- cannot simulate the sentinel-flip failure.');
@@ -275,5 +284,31 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 			'the restart-fallback + shared restart path must have actually run (sanity check on the call-count assumption)');
 		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'),
 			'a swap-not-confirmed restart-fallback that ultimately converges must not leave a dnsbl apply entry open');
+	}
+
+	/**
+	 * Source-inspection pin (mirrors testDnsblDownloadCallSitesKeyOnTheAliasNotTheHeader):
+	 * the tail's ledger write is deterministic/idempotent-by-key, so no end-state
+	 * assertion can prove a fallback branch stayed silent -- only reading the source can.
+	 */
+	public function testRestartFallbackBranchesNeverCallLedgerFunctionsDirectly(): void
+	{
+		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
+		$this->assertNotFalse($source, 'pfblockerng.inc must be readable');
+
+		$start = strpos($source, 'function pfb_reload_unbound(');
+		$this->assertNotFalse($start, 'pfb_reload_unbound() must exist');
+		// The shared restart path (both the fallback branches AND the zero-downtime
+		// success return fall through to it) always opens with this tempnam() call --
+		// a stable, unique boundary marking the end of the fallback-branches region.
+		$end = strpos($source, "\$cache_dumpfile = tempnam(", $start);
+		$this->assertNotFalse($end, 'the shared restart path boundary marker must exist');
+
+		$region = substr($source, $start, $end - $start);
+
+		$this->assertStringNotContainsString('pfb_sync_status_open(', $region,
+			'a restart-fallback branch must never open a ledger entry directly -- only the shared tail may');
+		$this->assertStringNotContainsString('pfb_sync_status_close(', $region,
+			'a restart-fallback branch must never close a ledger entry directly -- only the shared tail may');
 	}
 }


### PR DESCRIPTION
Fixes #1015

`testRestartFallbackAloneOpensNoEntry` claimed its passing assertion proved the DNSBL
restart-fallback branch itself never opens a sync-status ledger entry. It couldn't: the
shared tail's `pfb_dnsbl_apply_ledger_update()` call is deterministic/idempotent-by-key on
current convergence alone, so it overwrites whatever the fallback branch did regardless. No
convergence value at the tail can discriminate "fallback opened a stray entry" from "fallback
did nothing" via the ledger's own end-state.

- Renamed/rescoped the E2E test (`testRestartFallbackPathReachesTailWithConvergedState`) to
  state only what it actually proves: the fallback path reaches the tail without crashing and
  the tail's write reflects the real convergence outcome.
- Added `testRestartFallbackBranchesNeverCallLedgerFunctionsDirectly`, a source-inspection
  regression pin (mirrors the file's existing `testDnsblDownloadCallSitesKeyOnTheAliasNotTheHeader`
  technique) that is the actual real detector for the invariant the old test only claimed to
  prove.
- No production code change — `pfblockerng.inc` is untouched; only the test was wrong.

Proven via mutation testing (see commit): a stray ledger-open call injected into a fallback
branch is invisible to the old test but caught by the new one; reverting the mutation leaves
the whole suite green.

Two related gaps found but out of scope for this fix (marker-generation empty/non-digit
branches, two undriven `pfb_reload_unbound()` call sites) are tracked separately in #1024.
