### PR TITLE
pfblockerng: don't clear .update marker on stale-.orig download fallback (#1022)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1901,6 +1901,13 @@ function pfb_ip_reuse_skip_active(bool $reuse_on, bool $orig_exists, bool $is_dn
 	return $reuse_on && $orig_exists && !$is_dnsblip;
 }
 
+// A stale-.orig download-failure fallback never refreshed the row's content, so the
+// '.update' reprocess marker must survive it -- else a pending rebuild/refresh is
+// stranded exactly like #1002, but reached via the download-failure path. (#1022)
+function pfb_ip_update_marker_clear_active(bool $orig_content_stale): bool {
+	return !$orig_content_stale;
+}
+
 // v6 stays OPTIONAL (ADR-13 §7 pivot): a missing v6 VIP never fails validation, even when
 // the resolver listens on IPv6 — pfb_global surfaces that as a non-blocking warning, not a
 // force-disable. The validator only checks the VIPs that ARE configured (existence,
@@ -17769,6 +17776,7 @@ function sync_package_pfblockerng($cron='') {
 							}
 							pfb_logger("{$log}", 1);
 							$file_dwn = "{$pfborig}/{$header}";
+							$orig_content_stale = FALSE;
 
 							// Force 'Alias Native' setting to any Alias with 'Advanced Inbound/Outbound -Invert src/dst' settings.
 							// This will bypass Deduplication and Reputation features.
@@ -17836,6 +17844,7 @@ function sync_package_pfblockerng($cron='') {
 										if (file_exists("{$pfbfolder}/{$header}.fail") &&
 										    file_exists("{$file_dwn}.orig")) {
 											pfb_logger("\n  Restoring previously downloaded file contents...", 2);
+											$orig_content_stale = TRUE;
 										}
 										else {
 											if ($pfbadv) {
@@ -18251,8 +18260,12 @@ function sync_package_pfblockerng($cron='') {
 							}
 							unset($ip_data);
 
-							// Remove update file indicator
-							unlink_if_exists("{$pfbfolder}/{$header}.update");
+							// Remove update file indicator -- skip if this row fell through to the
+							// stale-.orig download-failure fallback, else a pending rebuild is
+							// stranded like #1002 but via the download-failure path. (#1022)
+							if (pfb_ip_update_marker_clear_active($orig_content_stale)) {
+								unlink_if_exists("{$pfbfolder}/{$header}.update");
+							}
 
 							// Restore Original Downloaded file after Post Script function
 							if (file_exists("{$file_dwn}.orig.post")) {

--- a/tests/php/PfbIpUpdateMarkerClearActiveTest.php
+++ b/tests/php/PfbIpUpdateMarkerClearActiveTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1022 -- the IP-feed loop's download-failure path can fall through to a stale-.orig
+ * fallback ("Restoring previously downloaded file contents") instead of `continue`-ing the
+ * row. Execution then still reaches the unconditional '.update' marker cleanup at the bottom
+ * of the row, clearing the reprocess marker even though the row's content was never actually
+ * refreshed -- stranding a pending rebuild/refresh (DNSBLIP rebuild, GeoIP/ASN DB refresh)
+ * exactly like #1002, but reached via the download-failure path instead of the reuse-skip
+ * path.
+ *
+ * Feature: the marker may be cleared iff the row's .orig content is NOT stale.
+ *   Full truth table over the single boolean input (orig_content_stale):
+ *     * Row 1 -- THE #1022 BUG PIN: stale fallback taken -> must NOT clear (FALSE). Before
+ *       the fix, wiring was absent and the marker was cleared unconditionally regardless.
+ *     * Row 2: no stale fallback (success, reuse-skip, or first-ever download) -> must clear
+ *       (TRUE), the pre-existing, unchanged behaviour for every other path.
+ */
+#[CoversFunction('pfb_ip_update_marker_clear_active')]
+final class PfbIpUpdateMarkerClearActiveTest extends TestCase
+{
+	/**
+	 * Row 1 -- THE #1022 BUG PIN: stale-.orig download-failure fallback was taken, so the
+	 * row's content was never refreshed. Must return FALSE (do NOT clear the marker), else a
+	 * pending rebuild/refresh that touched this row's '.update' marker is silently stranded.
+	 */
+	public function testRow1StaleFallbackTakenDoesNotClearMarkerTheBugFix(): void
+	{
+		$this->assertFalse(
+			pfb_ip_update_marker_clear_active(TRUE),
+			"orig_content_stale=TRUE -> FALSE (#1022: stale fallback must not clear the marker)\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 2: no stale fallback (successful download, reuse-skip-active, or first-ever
+	 * download all leave orig_content_stale FALSE). Must return TRUE (clear the marker),
+	 * exactly the pre-existing/unchanged behaviour -- proves the fix doesn't strand the
+	 * marker on the normal case too.
+	 */
+	public function testRow2NoStaleFallbackClearsMarkerUnchangedBehaviour(): void
+	{
+		$this->assertTrue(
+			pfb_ip_update_marker_clear_active(FALSE),
+			"orig_content_stale=FALSE -> TRUE (normal case, unchanged)\n" .
+			"expected: true\n" .
+			"got:      false"
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1022. `sync_package_pfblockerng()`'s IP-feed download loop: when `pfb_download()`
fails for a row and a prior `.fail` marker already exists alongside a prior `.orig`, the
code takes the "Restoring previously downloaded file contents" stale-`.orig` fallback and
falls through instead of `continue`-ing. Execution then still reaches the unconditional
`.update` reprocess-marker cleanup at the bottom of the row's processing, clearing it even
though the row's content was never actually refreshed — stranding a pending rebuild/refresh
(DNSBLIP rebuild, or a GeoIP/ASN DB refresh that touched the row) exactly like #1002, but
reached via the download-failure path instead of the reuse-skip path.

Mirrors this file's own established idiom for the sibling #1002 bug: extract a pure
predicate (`pfb_ip_update_marker_clear_active()`), wire it at the one call site, pin it
with a dedicated PHPUnit truth-table test (`PfbIpUpdateMarkerClearActiveTest`).

Out of scope: an identical fallthrough + unconditional-unlink shape exists in the sibling
DNSBL-domain loop (`pfblockerng.inc` ~16660-16709). Its `.update`-marker producer/trigger
is unverified and needs its own triage before a fix — filed as a follow-up issue rather
than bundled here.

## Test plan

- [x] `php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc`
- [x] `vendor/bin/phpunit tests/php/PfbIpUpdateMarkerClearActiveTest.php` (both truth-table rows)
- [x] Red→green re-executed independently: reverted the `.inc` change, test fatals with
      `Call to undefined function`; reapplied, test passes.
- [x] `vendor/bin/phpunit` full suite green (2500/2500)
- [x] `vendor/bin/phpstan` clean
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist src/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
