### PR TITLE
scripts: fix check_comment_narration diff-parser header/UTF-8 bugs (#1029)

### DIFF
--- a/scripts/check_comment_narration.py
+++ b/scripts/check_comment_narration.py
@@ -74,19 +74,25 @@ def find_violations(diff_text: str) -> list[Violation]:
     violations: list[Violation] = []
     path: str | None = None
     lineno = 0
+    in_hunk = False
     for raw in diff_text.splitlines():
-        if raw.startswith("+++ "):
-            # _git_diff pins the b/ prefix; a space-bearing path still gets git's
-            # disambiguation tab appended — strip it. A control-char path stays
-            # quoted even under core.quotePath=false and is skipped (absurd corner).
+        if raw.startswith("diff --git"):
+            path = None
+            in_hunk = False
+            continue
+        if not in_hunk and raw.startswith("+++ "):
+            # Header only before a section's first @@ -- inside a hunk an added
+            # "++..." line renders identically and must be scanned, not misread
+            # as one. Strip git's disambiguation tab from a space-bearing path.
             name = raw[4:]
             path = name[2:].split("\t", 1)[0] if name.startswith("b/") else None
             continue
         if raw.startswith("@@"):
             m = re.match(r"@@ -\S+ \+(\d+)", raw)
             lineno = int(m.group(1)) if m else 0
+            in_hunk = True
             continue
-        if raw.startswith("+") and not raw.startswith("+++"):
+        if in_hunk and raw.startswith("+"):
             line = raw[1:]
             if path is not None and _in_scope(path) and _ESCAPE not in line.lower():
                 for pattern, reason in _PATTERNS:
@@ -119,7 +125,10 @@ def _git_diff(args: list[str]) -> str:
             *args,
         ],
         capture_output=True,
-        text=True,
+        # A non-UTF-8 byte anywhere in the diff must not crash the whole run
+        # with an UnicodeDecodeError -- decode lossily instead of raising.
+        encoding="utf-8",
+        errors="replace",
         check=True,
     )
     return out.stdout

--- a/tests/test_comment_narration_check.py
+++ b/tests/test_comment_narration_check.py
@@ -172,6 +172,24 @@ def test_clean_diff_yields_nothing() -> None:
     assert _find("src/a.inc", ["// pfb_foo(): guard empty input"]) == []
 
 
+def test_added_line_starting_with_plus_plus_is_not_misread_as_a_header() -> None:
+    # Hostile input (issue #1029): an added line whose own content starts
+    # with "++" renders in the diff as "+++ ..." -- must not be mistaken for
+    # a file header, which would drop it and every following added line.
+    diff = (
+        "diff --git a/scripts/tool.sh b/scripts/tool.sh\n"
+        "--- a/scripts/tool.sh\n"
+        "+++ b/scripts/tool.sh\n"
+        "@@ -0,0 +1,2 @@\n"
+        "+++ banner\n"
+        "+// per RESULTS/03 SS1\n"
+    )
+    v = ccn.find_violations(diff)
+    assert len(v) == 1
+    assert v[0].path == "scripts/tool.sh"
+    assert v[0].line == 2
+
+
 # --------------------------------------------------------------------------- #
 # CLI — the two production modes, end-to-end in a scratch repo
 # --------------------------------------------------------------------------- #
@@ -273,3 +291,21 @@ def test_cli_bad_ref_is_a_usage_error_not_a_traceback(tmp_path: Path) -> None:
     res = _run(tmp_path, "--diff", "no-such-ref")
     assert res.returncode == 2, res.stderr
     assert "git diff failed" in res.stderr
+
+
+def test_cli_staged_non_utf8_byte_does_not_crash_the_run(tmp_path: Path) -> None:
+    # Hostile input (issue #1029): a non-UTF-8 byte anywhere in the staged
+    # diff must not crash the run with a raw UnicodeDecodeError traceback --
+    # decode lossily and still report the real violation on its own line.
+    _git(tmp_path, "init", "-q", "-b", "devel")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/a.inc").write_text("// clean\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+
+    (tmp_path / "src/a.inc").write_bytes(b"// clean\n// note caf\xff\xfe\n// per RESULTS/03 SS1\n")
+    _git(tmp_path, "add", ".")
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 1, res.stderr
+    assert "Traceback" not in res.stderr, res.stderr
+    assert "src/a.inc:3" in res.stderr


### PR DESCRIPTION
## Summary

Fixes #1029.

`scripts/check_comment_narration.py`'s diff parser had the same two defects the adversarial review of #1026 found and fixed in the sibling `scripts/check_version_literals.py` (both checkers share the design, `check_comment_narration.py` predates it and was the model `check_version_literals.py` was built from):

1. **`+++`-prefixed added line misread as a file header.** An added content line whose own text starts with `++` renders in the unified diff as `+++ ...` (diff marker `+` + content `++...`). `find_violations()` treated ANY `+++ ` line as a `+++ b/<path>` header, so such a line reset `path` to `None` and dropped every following added line in that file's stanza — a banned-narration comment placed right after it was silently missed.
2. **Non-UTF-8 byte crashed the whole run.** `_git_diff()` ran `subprocess.run(..., text=True)` with no `errors=` mode; a single non-UTF-8 byte anywhere in the diff raised an uncaught `UnicodeDecodeError`, crashing `--staged`/`--diff` with a traceback instead of the checker's controlled exit codes.

Fix mirrors the pattern already landed for `check_version_literals.py`: gate `+++` header detection behind an `in_hunk` flag (reset per `diff --git` section, set at `@@`), and decode the diff with `errors="replace"`.

## Test plan

- [x] `test_added_line_starting_with_plus_plus_is_not_misread_as_a_header` — direct `find_violations()` unit test for defect 1.
- [x] `test_cli_staged_non_utf8_byte_does_not_crash_the_run` — CLI subprocess test for defect 2.
- [x] Both proven red on pre-fix source (pasted in the delegation handoff) and green after.
- [x] Full pre-existing suite (23 tests) unmodified and still green — `tests/test_comment_narration_check.py`: 25 passed.
- [x] `python3 -m pytest` (2480 passed, 4 skipped), `ruff check .`, `ruff format --check .`, `mypy tests/` all clean.

---
🤖 Generated with [Claude Code](https://claude.ai/code/session_01KMandwby8X7gcMiUBQpPbG)
