### PR TITLE
pfblockerng: don't clear .update marker on stale-.orig download fallback in DNSBL-domain loop (#1031)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1908,6 +1908,13 @@ function pfb_ip_update_marker_clear_active(bool $orig_content_stale): bool {
 	return !$orig_content_stale;
 }
 
+// A stale-.orig download-failure fallback in the DNSBL-domain loop (e.g. a Blacklist
+// category row's local-file re-read) never refreshed the row's content, so the
+// '.update' reprocess marker must survive it, same class as #1022. (#1031)
+function pfb_dnsbl_update_marker_clear_active(bool $orig_content_stale): bool {
+	return !$orig_content_stale;
+}
+
 // v6 stays OPTIONAL (ADR-13 §7 pivot): a missing v6 VIP never fails validation, even when
 // the resolver listens on IPv6 — pfb_global surfaces that as a non-blocking warning, not a
 // force-disable. The validator only checks the VIPs that ARE configured (existence,
@@ -16076,6 +16083,7 @@ function sync_package_pfblockerng($cron='') {
 								}
 								pfb_logger("{$log}", 1);
 								$file_dwn = "{$pfborig}/{$header}";
+								$orig_content_stale = FALSE;
 
 								if (!$custom) {
 									pfb_logger(' .', 1);
@@ -16105,6 +16113,7 @@ function sync_package_pfblockerng($cron='') {
 											if (file_exists("{$pfbfolder}/{$header}.fail") &&
 											    file_exists("{$file_dwn}.orig")) {
 												pfb_logger("\n  Restoring previously downloaded file\n ", 2);
+												$orig_content_stale = TRUE;
 											} else {
 												continue;
 											}
@@ -16713,8 +16722,12 @@ function sync_package_pfblockerng($cron='') {
 								$list_cnt	= exec("{$pfb['grep']} -c ^ " . escapeshellarg("{$pfbfolder}/{$header}.txt"));
 								$alias_cnt	= $alias_cnt + $list_cnt;
 
-								// Remove update file indicator
-								unlink_if_exists("{$pfbfolder}/{$header}.update");
+								// Remove update file indicator -- skip if this row fell through to
+								// the stale-.orig download-failure fallback, else a pending rebuild
+								// is stranded like #1002 but via the download-failure path. (#1031)
+								if (pfb_dnsbl_update_marker_clear_active($orig_content_stale)) {
+									unlink_if_exists("{$pfbfolder}/{$header}.update");
+								}
 							}
 						}
 					}

--- a/tests/php/PfbDnsblUpdateMarkerClearActiveTest.php
+++ b/tests/php/PfbDnsblUpdateMarkerClearActiveTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1031 -- the DNSBL-domain loop's download-failure path can fall through to a
+ * stale-.orig fallback ("Restoring previously downloaded file") instead of `continue`-ing
+ * the row. Execution then still reaches the unconditional '.update' marker cleanup at the
+ * bottom of the row, clearing the reprocess marker even though the row's content was never
+ * actually refreshed. Genuinely producible for a "Blacklist" category feed (Shalla-style
+ * multi-category tar.gz): pfb_download()'s Blacklist branch touches a feed-level '.update'
+ * sentinel that the DNSBL-list-collection code propagates into a per-category
+ * `{title}_{category}.update` marker under $pfb['dnsdir'] -- the exact folder/header the
+ * domain loop then processes, with a local-file 'url' that takes the LOCALFILE download
+ * branch, the same transient-read-failure trigger shape as #1002/#1022's DNSBLIP case.
+ *
+ * Feature: the marker may be cleared iff the row's .orig content is NOT stale.
+ *   Full truth table over the single boolean input (orig_content_stale):
+ *     * Row 1 -- THE #1031 BUG PIN: stale fallback taken -> must NOT clear (FALSE). Before
+ *       the fix, wiring was absent and the marker was cleared unconditionally regardless.
+ *     * Row 2: no stale fallback (success, reuse-active, first-ever download, or custom
+ *       list) -> must clear (TRUE), the pre-existing, unchanged behaviour for every other
+ *       path.
+ */
+#[CoversFunction('pfb_dnsbl_update_marker_clear_active')]
+final class PfbDnsblUpdateMarkerClearActiveTest extends TestCase
+{
+	/**
+	 * Row 1 -- THE #1031 BUG PIN: stale-.orig download-failure fallback was taken (e.g. a
+	 * Blacklist-category row's local-file re-read failed), so the row's content was never
+	 * refreshed. Must return FALSE (do NOT clear the marker), else a pending
+	 * rebuild/refresh that touched this row's '.update' marker is silently stranded.
+	 */
+	public function testRow1StaleFallbackTakenDoesNotClearMarkerTheBugFix(): void
+	{
+		$this->assertFalse(
+			pfb_dnsbl_update_marker_clear_active(TRUE),
+			"orig_content_stale=TRUE -> FALSE (#1031: stale fallback must not clear the marker)\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 2: no stale fallback (successful download, reuse-active "File exists/reuse",
+	 * first-ever download, or a custom list all leave orig_content_stale FALSE). Must
+	 * return TRUE (clear the marker), exactly the pre-existing/unchanged behaviour --
+	 * proves the fix doesn't strand the marker on the normal case too.
+	 */
+	public function testRow2NoStaleFallbackClearsMarkerUnchangedBehaviour(): void
+	{
+		$this->assertTrue(
+			pfb_dnsbl_update_marker_clear_active(FALSE),
+			"orig_content_stale=FALSE -> TRUE (normal case, unchanged)\n" .
+			"expected: true\n" .
+			"got:      false"
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1031. The DNSBL-domain feed loop in `sync_package_pfblockerng()` has the same
bug #1022 fixed in the IP-feed loop: when `pfb_download()` fails and the row falls
through to the stale-`.orig` "Restoring previously downloaded file" fallback instead
of `continue`-ing, execution still reaches the unconditional `.update` reprocess-marker
cleanup at the bottom of the row, clearing it even though the content was never
refreshed.

**Verified reachable** (this issue was filed specifically because that was unverified
at #1022's triage time): traced the producer for a **Blacklist category feed** row
(the Shalla-style multi-category tar.gz archive feature). `pfb_download()`'s Blacklist
branch touches a feed-level `.update` sentinel after extracting a freshly-downloaded
archive; the DNSBL-list-collection code reads that sentinel and propagates it into a
per-category `{title}_{category}.update` marker under `$pfb['dnsdir']` — the exact
folder/header the domain loop then processes. The row's `url` is a local file path, so
`pfb_download()` takes the LOCALFILE branch for it, the same transient-read-failure
shape as DNSBLIP's in #1002/#1022.

Same fix idiom as #1022: extracted `pfb_dnsbl_update_marker_clear_active()` (mirrors
`pfb_ip_update_marker_clear_active()`, following this file's established `_ip_`/`_dnsbl_`
sibling-function naming pattern), wired at the one call site, pinned with a truth-table
PHPUnit test. The IP-feed loop and its #1022 fix are untouched (verified byte-identical).

## Test plan

- [x] `php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc`
- [x] `vendor/bin/phpunit tests/php/PfbDnsblUpdateMarkerClearActiveTest.php` (both truth-table rows)
- [x] Red→green re-executed independently: reverted the `.inc` change, test fatals with
      `Call to undefined function`; reapplied, test passes.
- [x] `vendor/bin/phpunit` full suite green (2503/2503), including the #1022 sibling tests unaffected
- [x] `vendor/bin/phpstan` clean
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist src/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
