### PR TITLE
chore: rebase stale session branches onto devel at session start

### DIFF
--- a/.claude/hooks/session-branch-sync.sh
+++ b/.claude/hooks/session-branch-sync.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# SessionStart hook: bring the checkout's current branch up to date with its base.
+#
+# Why this exists: the repo merges rebase-only, which rewrites commit hashes. A
+# leftover session branch (claude/*, issue/*, adr/*) whose PR already landed
+# still shows its commits as "unmerged" under every hash-based check
+# (git log origin/devel..HEAD, merge-base --is-ancestor) -- so agents rebuild or
+# stack on already-merged work. git rebase is the native cure: rebasing onto
+# origin/devel drops the already-applied commits by patch-id and replays only
+# the genuinely-new ones. This hook runs it every session so no agent has to
+# remember, and reports what happened.
+#
+#   base branch (devel/main) -> pull --rebase its own remote (fast-forward)
+#   session branch           -> rebase onto origin/devel: merged commits drop,
+#                               new commits replay on the live base
+#   dirty tree               -> touch nothing; tell the agent to sync by hand
+#   rebase conflict (~1%)    -> abort cleanly; tell the agent to resolve by hand
+#
+# ponytail: base is origin/devel for every non-base branch -- the documented
+# branch point for adr/issue/claude branches. A rare main-targeting branch
+# rebases onto devel; the agent corrects that by hand.
+
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+branch=$(git symbolic-ref --short HEAD 2>/dev/null) || exit 0   # detached -> skip
+
+git fetch --quiet origin >/dev/null 2>&1 || true
+
+emit() {
+	printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$1"
+}
+
+case "$branch" in
+	devel | main) base="origin/${branch}" ;;
+	*) base="origin/devel" ;;
+esac
+
+git rev-parse --verify --quiet "$base" >/dev/null 2>&1 || exit 0
+
+# Nothing to do if already at/behind-only with no divergence for base branches,
+# or already sitting on the live base for session branches.
+before=$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)
+behind=$(git rev-list --count "HEAD..${base}" 2>/dev/null || echo 0)
+[ "$before" -eq 0 ] && [ "$behind" -eq 0 ] && exit 0
+
+if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+	emit "SESSION BRANCH '${branch}': ${before} commit(s) ahead of ${base}, ${behind} behind, but the working tree is DIRTY so it was left untouched. Commit or discard your changes, then run: git rebase ${base}  (or, on a base branch, git pull --rebase). Rebasing onto ${base} drops any already-merged commits by patch-id -- do NOT trust git log ${base}..HEAD, which overcounts them after a rebase-merge."
+	exit 0
+fi
+
+case "$branch" in
+	devel | main)
+		if git merge --ff-only --quiet "$base" >/dev/null 2>&1; then
+			emit "BASE BRANCH '${branch}': fast-forwarded ${behind} commit(s) up to ${base}. Checkout is current."
+		else
+			emit "BASE BRANCH '${branch}': has ${before} local commit(s) not on ${base} and could not fast-forward. This branch is meant to be PR-only -- reconcile by hand (git pull --rebase) before starting work."
+		fi
+		;;
+	*)
+		if git rebase "$base" >/dev/null 2>&1; then
+			after=$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)
+			dropped=$((before - after))
+			if [ "$after" -eq 0 ]; then
+				emit "SESSION BRANCH '${branch}': all ${dropped} commit(s) were already merged into devel (rebase dropped them by patch-id despite rebase-rewritten hashes). Branch now equals ${base} -- a clean, current base. Do NOT rebuild the old commits; the prior tip is in the reflog. Cut a fresh worktree for new work if the skill calls for one."
+			else
+				emit "SESSION BRANCH '${branch}': rebased onto ${base}; dropped ${dropped} already-merged commit(s) and replayed ${after} genuinely-new one(s) on the live base. Push with --force-with-lease. (Hash-based git log ${base}..HEAD had reported ${before}, overcounting the merged ones.)"
+			fi
+		else
+			git rebase --abort >/dev/null 2>&1
+			emit "SESSION BRANCH '${branch}': rebase onto ${base} hit a conflict and was ABORTED -- branch is unchanged. Resolve by hand: git rebase ${base}  then --force-with-lease push. The conflict is the ~1% case rebase cannot auto-resolve."
+		fi
+		;;
+esac

--- a/.claude/hooks/session-branch-sync.sh
+++ b/.claude/hooks/session-branch-sync.sh
@@ -10,7 +10,8 @@
 # the genuinely-new ones. This hook runs it every session so no agent has to
 # remember, and reports what happened.
 #
-#   base branch (devel/main) -> pull --rebase its own remote (fast-forward)
+#   base branch (devel/main) -> fast-forward only (ff-only) to its own remote;
+#                               a diverged base is surfaced, never rewritten
 #   session branch           -> rebase onto origin/devel: merged commits drop,
 #                               new commits replay on the live base
 #   dirty tree               -> touch nothing; tell the agent to sync by hand
@@ -21,17 +22,31 @@
 # rebases onto devel; the agent corrects that by hand.
 
 git rev-parse --git-dir >/dev/null 2>&1 || exit 0
-branch=$(git symbolic-ref --short HEAD 2>/dev/null) || exit 0   # detached -> skip
+# Detached HEAD (which includes a paused/in-progress rebase) -> skip untouched.
+# This guard is ALSO what keeps the hook from ever running `git rebase --abort`
+# on someone's in-progress rebase -- keep it (don't swap in `git branch
+# --show-current`, which returns "" instead of failing and would slip through).
+branch=$(git symbolic-ref --short HEAD 2>/dev/null) || exit 0
 
-git fetch --quiet origin >/dev/null 2>&1 || true
+# Bound the fetch so a SYN-dropping network can't hang session start: abort if
+# throughput stays under 1 KB/s for 15s. git config (portable) rather than a
+# timeout(1) wrapper (absent on some agent OSes); non-fatal either way.
+git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=15 fetch --quiet origin >/dev/null 2>&1 || true
 
+# Emit one SessionStart JSON object. A branch name is an arbitrary byte string
+# (git does not enforce UTF-8), so drop invalid sequences (iconv -c, when present)
+# and JSON-escape backslash then double quote -- either would otherwise produce
+# JSON a strict parser rejects, silently dropping the injected context.
 emit() {
-	printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$1"
+	msg=$1
+	command -v iconv >/dev/null 2>&1 && msg=$(printf '%s' "$msg" | iconv -f UTF-8 -t UTF-8 -c 2>/dev/null)
+	esc=$(printf '%s' "$msg" | sed 's/\\/\\\\/g; s/"/\\"/g')
+	printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$esc"
 }
 
 case "$branch" in
-	devel | main) base="origin/${branch}" ;;
-	*) base="origin/devel" ;;
+	devel | main) base="origin/${branch}"; kind="BASE BRANCH" ;;
+	*) base="origin/devel"; kind="SESSION BRANCH" ;;
 esac
 
 git rev-parse --verify --quiet "$base" >/dev/null 2>&1 || exit 0
@@ -43,16 +58,21 @@ behind=$(git rev-list --count "HEAD..${base}" 2>/dev/null || echo 0)
 [ "$before" -eq 0 ] && [ "$behind" -eq 0 ] && exit 0
 
 if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-	emit "SESSION BRANCH '${branch}': ${before} commit(s) ahead of ${base}, ${behind} behind, but the working tree is DIRTY so it was left untouched. Commit or discard your changes, then run: git rebase ${base}  (or, on a base branch, git pull --rebase). Rebasing onto ${base} drops any already-merged commits by patch-id -- do NOT trust git log ${base}..HEAD, which overcounts them after a rebase-merge."
+	emit "${kind} '${branch}': ${before} commit(s) ahead of ${base}, ${behind} behind, but the working tree is DIRTY so it was left untouched. Commit or discard your changes, then run: git rebase ${base}  (or, on a base branch, git merge --ff-only ${base}). Rebasing onto ${base} drops any already-merged commits by patch-id -- do NOT trust git log ${base}..HEAD, which overcounts them after a rebase-merge."
 	exit 0
 fi
 
 case "$branch" in
 	devel | main)
-		if git merge --ff-only --quiet "$base" >/dev/null 2>&1; then
+		# Branch on $before, not merge's exit code: a purely-ahead base branch
+		# (unpushed local commit, behind=0) makes `git merge --ff-only` succeed
+		# trivially ("Already up to date", rc 0), which would misreport an
+		# unpushed commit as "current". Any local commit not on the remote =>
+		# not current; only behind=0/ahead=0 (already filtered above) is clean.
+		if [ "$before" -gt 0 ]; then
+			emit "BASE BRANCH '${branch}': has ${before} local commit(s) not on ${base}. This branch is meant to be PR-only -- reconcile by hand before starting work (push them via a PR, or reset to ${base})."
+		elif git merge --ff-only --quiet "$base" >/dev/null 2>&1; then
 			emit "BASE BRANCH '${branch}': fast-forwarded ${behind} commit(s) up to ${base}. Checkout is current."
-		else
-			emit "BASE BRANCH '${branch}': has ${before} local commit(s) not on ${base} and could not fast-forward. This branch is meant to be PR-only -- reconcile by hand (git pull --rebase) before starting work."
 		fi
 		;;
 	*)
@@ -64,9 +84,10 @@ case "$branch" in
 			else
 				emit "SESSION BRANCH '${branch}': rebased onto ${base}; dropped ${dropped} already-merged commit(s) and replayed ${after} genuinely-new one(s) on the live base. Push with --force-with-lease. (Hash-based git log ${base}..HEAD had reported ${before}, overcounting the merged ones.)"
 			fi
+		elif git rebase --abort >/dev/null 2>&1; then
+			emit "SESSION BRANCH '${branch}': rebase onto ${base} FAILED and was ABORTED -- branch is unchanged (stderr was suppressed, so the cause is unshown). Re-run by hand to see why: git rebase ${base}  (most often a merge conflict, the ~1% rebase cannot auto-resolve), then --force-with-lease push."
 		else
-			git rebase --abort >/dev/null 2>&1
-			emit "SESSION BRANCH '${branch}': rebase onto ${base} hit a conflict and was ABORTED -- branch is unchanged. Resolve by hand: git rebase ${base}  then --force-with-lease push. The conflict is the ~1% case rebase cannot auto-resolve."
+			emit "SESSION BRANCH '${branch}': rebase onto ${base} FAILED and the --abort ALSO failed -- the repo may be stuck mid-rebase. Inspect by hand: git status; git rebase --abort."
 		fi
 		;;
 esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,10 @@
           },
           {
             "type": "command",
+            "command": "sh \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/session-branch-sync.sh\""
+          },
+          {
+            "type": "command",
             "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"MANDATORY: this repo has a CLAUDE.md — read it and follow it, especially Working principles (investigate, do not assume; confirm genuine forks before building) and Code standards. docs/misc/workflow-reference.md is a POLICY ANNEX of CLAUDE.md — its sections are binding; read the relevant section whenever the task touches one CLAUDE.md points there. Activate BOTH modes: ponytail at full (/ponytail:ponytail plugin form or /ponytail vendored form, whichever exists — laziest working solution) and /caveman (terse, no filler, full technical accuracy); when only one mode exists, activate it alone. This step CANNOT be skipped. Exception for external or public-facing text and documentation (GitHub issue and PR/MR comments, PR bodies, commit messages, docs): stay concise and to the point but use normal professional grammar, toning the caveman style down. Org rule: in ANY pfBlockerNG-org repository, the pfBlockerNG/pfBlockerNG CLAUDE.md and its project plus user settings are the default way of working unless that repo overrides a rule in its own CLAUDE.md; the pfBlockerNG-package-specific mechanics and language or runtime specifics do not carry over.\"}}'"
           }
         ]


### PR DESCRIPTION
## Summary

Adds a matcher-less `SessionStart` hook that reconciles the checkout's current branch with its base at the start of every session (startup / clear / resume / compact).

**Why:** rebase-only merges rewrite commit hashes, so a leftover session branch whose PR already landed still shows its commits as "unmerged" under hash-based checks (`git log origin/devel..HEAD`, `git merge-base --is-ancestor`). Agents then rebuild or stack on top of already-merged work. `git rebase` onto `origin/devel` is the native cure: it drops the already-applied commits by patch-id and replays only the genuinely-new ones. Running it every session and injecting a correct verdict into context means no agent has to remember to do it by hand.

**Safety:**

- A dirty working tree or a rebase conflict leaves the branch untouched and tells the agent to reconcile manually — the hook never rewrites over uncommitted or conflicting state.
- Base branches (`devel`/`main`) are fast-forward only, never rebased.

## Changes

- `.claude/hooks/session-branch-sync.sh` — the hook (rebase-or-report logic).
- `.claude/settings.json` — wires it into the `SessionStart` event.

Dev-tooling only (`.claude/`); nothing ships to users.

## Test plan

- [x] Verified on this very session: the hook rebased the reused session branch onto the current `origin/devel`, dropped the already-merged #1000/#1029/#1031 commits by patch-id, and replayed only this genuinely-new hook commit — the session-start context note reported the correct count.
- [x] `shellcheck` / `sh -n` clean on the hook script (pre-commit).

---
_Generated by [Claude Code](https://claude.ai/code/session_0145bGDnzhGhZFTkY7Nc4knd)_