### PR TITLE
tests: dedup canonical log-type list across CfgGatewayTest/RollbackContractTest

### DIFF
--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/LogTypesFixture.php';
+
 /**
  * ADR-29 Phase 1 — PfbConfig gateway + field registry tests.
  *
@@ -1485,10 +1487,8 @@ final class CfgGatewayTest extends TestCase
 	public function testLogMaxDaysFieldsAreRegistered(): void
 	{
 		$registry  = pfb_cfg_registry();
-		$log_types = [
-			'log', 'errlog', 'extraslog', 'ip_blocklog', 'ip_permitlog',
-			'ip_matchlog', 'ip_parse_err', 'dnslog', 'dnsbl_parse_err', 'dnsreplylog', 'unilog',
-		];
+		$log_types = pfb_test_log_types();
+		$this->assertNotEmpty($log_types, 'pfb_test_log_types() must not be empty');
 
 		foreach ($log_types as $type) {
 			$key = 'log_max_days_' . $type;
@@ -1499,16 +1499,29 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	/**
+	 * Pin pfb_test_log_types() to the known 11-item vocabulary so a broken
+	 * derivation (e.g. an empty/partial result) fails loudly here instead of
+	 * silently under-testing every consumer via a vacuous foreach.
+	 */
+	public function testLogTypesFixtureMatchesCanonicalVocabulary(): void
+	{
+		$expected = [
+			'log', 'errlog', 'extraslog', 'ip_blocklog', 'ip_permitlog',
+			'ip_matchlog', 'ip_parse_err', 'dnslog', 'dnsbl_parse_err', 'dnsreplylog', 'unilog',
+		];
+		$this->assertSame($expected, pfb_test_log_types(),
+			'pfb_test_log_types() must match the canonical 11 log types exactly'
+		);
+	}
+
+	/**
 	 * Data provider — all 11 log_max_days_<type> keys × canonical numeric tokens.
 	 *
 	 * @return array<string, array{string, string}>
 	 */
 	public static function logMaxDaysVocabularyProvider(): array
 	{
-		$log_types = [
-			'log', 'errlog', 'extraslog', 'ip_blocklog', 'ip_permitlog',
-			'ip_matchlog', 'ip_parse_err', 'dnslog', 'dnsbl_parse_err', 'dnsreplylog', 'unilog',
-		];
+		$log_types = pfb_test_log_types();
 		$vocab  = ['0', '30', '365'];
 		$cases  = [];
 		foreach ($log_types as $type) {
@@ -1570,10 +1583,8 @@ final class CfgGatewayTest extends TestCase
 	 */
 	public function testLogMaxDaysFieldAbsentKeyReturnsDefaultZero(): void
 	{
-		$log_types = [
-			'log', 'errlog', 'extraslog', 'ip_blocklog', 'ip_permitlog',
-			'ip_matchlog', 'ip_parse_err', 'dnslog', 'dnsbl_parse_err', 'dnsreplylog', 'unilog',
-		];
+		$log_types = pfb_test_log_types();
+		$this->assertNotEmpty($log_types, 'pfb_test_log_types() must not be empty');
 
 		foreach ($log_types as $type) {
 			$key  = 'log_max_days_' . $type;

--- a/tests/php/LogTypesFixture.php
+++ b/tests/php/LogTypesFixture.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Canonical log-type vocabulary, derived from pfb_cfg_registry()'s
+ * log_max_<type> keys (pfblockerng_extra.inc) so CfgGatewayTest and
+ * RollbackContractTest's log_max_days_<type> coverage can never silently
+ * drift from the production registry (issue #1037).
+ *
+ * @return list<string>
+ */
+function pfb_test_log_types(): array
+{
+	$types = [];
+	foreach (array_keys(pfb_cfg_registry()) as $key) {
+		if (str_starts_with($key, 'log_max_') && !str_starts_with($key, 'log_max_days_')) {
+			$types[] = substr($key, strlen('log_max_'));
+		}
+	}
+	return $types;
+}

--- a/tests/php/RollbackContractTest.php
+++ b/tests/php/RollbackContractTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/LogTypesFixture.php';
+
 /**
  * ADR-29 Phase 3 — Rollback / backward-compat contract.
  *
@@ -1117,10 +1119,7 @@ final class RollbackContractTest extends TestCase
 	 */
 	public static function logMaxDaysVocabularyProvider(): array
 	{
-		$log_types = [
-			'log', 'errlog', 'extraslog', 'ip_blocklog', 'ip_permitlog',
-			'ip_matchlog', 'ip_parse_err', 'dnslog', 'dnsbl_parse_err', 'dnsreplylog', 'unilog',
-		];
+		$log_types = pfb_test_log_types();
 		$vocab  = ['0', '30', '365'];
 		$cases  = [];
 		foreach ($log_types as $type) {
@@ -1185,10 +1184,8 @@ final class RollbackContractTest extends TestCase
 	 */
 	public function testLogMaxDaysFieldAbsentKeyReturnsZeroDefault(): void
 	{
-		$log_types = [
-			'log', 'errlog', 'extraslog', 'ip_blocklog', 'ip_permitlog',
-			'ip_matchlog', 'ip_parse_err', 'dnslog', 'dnsbl_parse_err', 'dnsreplylog', 'unilog',
-		];
+		$log_types = pfb_test_log_types();
+		$this->assertNotEmpty($log_types, 'pfb_test_log_types() must not be empty');
 
 		foreach ($log_types as $type) {
 			$key  = 'log_max_days_' . $type;


### PR DESCRIPTION
## Summary

The 11-item log-type vocabulary (`'log', 'errlog', 'extraslog', 'ip_blocklog', 'ip_permitlog', 'ip_matchlog', 'ip_parse_err', 'dnslog', 'dnsbl_parse_err', 'dnsreplylog', 'unilog'`) was hardcoded in **five** places (the issue's report counted four — it missed `RollbackContractTest::testLogMaxDaysFieldAbsentKeyReturnsZeroDefault`, which also had its own copy):

- `tests/php/CfgGatewayTest.php` — `testLogMaxDaysFieldsAreRegistered`, `logMaxDaysVocabularyProvider`, `testLogMaxDaysFieldAbsentKeyReturnsDefaultZero`
- `tests/php/RollbackContractTest.php` — `logMaxDaysVocabularyProvider`, `testLogMaxDaysFieldAbsentKeyReturnsZeroDefault`

## Change

- New `tests/php/LogTypesFixture.php` defines `pfb_test_log_types()`, derived directly from `pfb_cfg_registry()`'s `log_max_<type>` keys (`pfblockerng_extra.inc`) — the production registry itself, not a re-copied list, so the vocabulary can never silently drift from what's actually registered.
- All five call sites now call `pfb_test_log_types()` instead of restating the array.
- Added one pinning test (`testLogTypesFixtureMatchesCanonicalVocabulary`) asserting the derived list equals the known 11-item vocabulary exactly, plus `assertNotEmpty` guards on the two plain-loop consumers — so a broken derivation (e.g. an empty result) fails loudly instead of silently turning every consuming test into a vacuous no-op. The two data-provider consumers are already covered by `phpunit.xml`'s `failOnRisky="true"` (an empty data provider fails the suite).

Behavior-preserving refactor — no functional/runtime change; existing tests pin the behavior and stay green across the change.

## Test plan

- [x] `php -l` on all three touched files
- [x] `vendor/bin/phpunit` — full suite green (2522 tests, 18996 assertions; only 2 pre-existing, unrelated PHPUnit deprecations in `Top1mPreserveOnEmptyFeedTest`, confirmed present on `origin/devel` before this change — tracked separately as #1038)
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist src/` — clean

Fixes #1037


---
_Generated by [Claude Code](https://claude.ai/code/session_01VSNt2bw2oLXkiFMA4bG88N)_