### PR TITLE
tests: convert Top1mPreserveOnEmptyFeedTest @dataProvider doc-comments to attributes

### DIFF
--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -795,9 +796,8 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 * the tightened alternative -- RED against the first-cut widening
 	 * (`xn--[A-Za-z0-9-]{2,}`, which accepted it), GREEN with the
 	 * alnum-first form (`xn--[A-Za-z0-9][A-Za-z0-9-]+`).
-	 *
-	 * @dataProvider malformedPunycodeTldRows
 	 */
+	#[DataProvider('malformedPunycodeTldRows')]
 	public function testCsvModeStillRejectsMalformedPunycodeTldRow(string $domain): void
 	{
 		// Given: a prior good whitelist and an OpenPageRank-shaped row whose Domain
@@ -869,9 +869,8 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 * row below carries a numeric rank column (satisfies the rank-only check by itself) but
 	 * a domain field that fails the hostname-shape regex in a different way. Every one must
 	 * still be rejected now that the regex applies to rank_domain rows too.
-	 *
-	 * @dataProvider rankDomainHostileRows
 	 */
+	#[DataProvider('rankDomainHostileRows')]
 	public function testRankDomainRejectsNonHostnameDomainFieldRow(string $csvLine): void
 	{
 		// Given: a prior good whitelist and a single-row rank_domain-shaped feed whose


### PR DESCRIPTION
## Summary

`vendor/bin/phpunit` reported 2 test-runner deprecations naming the last 2 doc-comment `@dataProvider` annotations in `tests/php/Top1mPreserveOnEmptyFeedTest.php` (unsupported once the suite runs under PHPUnit 12). Converts both to the modern `#[DataProvider('...')]` attribute, matching every other test file in the suite (e.g. `CfgGatewayTest.php`).

- Added `use PHPUnit\Framework\Attributes\DataProvider;`
- `testCsvModeStillRejectsMalformedPunycodeTldRow`: `@dataProvider malformedPunycodeTldRows` → `#[DataProvider('malformedPunycodeTldRows')]`
- `testRankDomainRejectsNonHostnameDomainFieldRow`: `@dataProvider rankDomainHostileRows` → `#[DataProvider('rankDomainHostileRows')]`

Pure annotation-syntax swap, zero behavior change — the two data-provider methods and every assertion are untouched.

Fixes #1038

## Test plan

- [x] `php -l tests/php/Top1mPreserveOnEmptyFeedTest.php` — no syntax errors
- [x] `vendor/bin/phpunit` (full suite) — same pass/assertion counts as before (2521 tests / 18992 assertions / 10 skipped), 0 PHPUnit deprecations (down from 2)
- [x] `vendor/bin/phpstan` — no errors
- [x] `vendor/bin/phpcs --standard=phpcs.xml.dist src/` — clean
- [x] `git grep -n '@dataProvider' -- tests/php/` — 0 hits repo-wide (was the last straggler)
- [x] Red→green re-executed independently: reverting the file reproduces the 2 deprecation warnings (`Tests: 30, Assertions: 288, PHPUnit Deprecations: 2`); restoring it clears them with identical test/assertion counts, confirming behaviour-preservation


---
_Generated by [Claude Code](https://claude.ai/code/session_01LrNfnv7ydaJGAnjE6RCwTp)_