### PR TITLE
tests: cover pfb_unbound_py_marker_generation + pfb_reload_unbound ledger branches

### DIFF
--- a/tests/php/PfbDnsblConvergedTest.php
+++ b/tests/php/PfbDnsblConvergedTest.php
@@ -22,8 +22,9 @@ use PHPUnit\Framework\TestCase;
  * (absent, unreadable, blank, non-digit), only "non-digit" is independently
  * observable via a return-value assertion -- "absent"/"unreadable"/"blank" all
  * funnel through the SAME downstream ctype_digit('')-is-FALSE catch-all, so no
- * assertion can attribute their shared 0 result to one specific guard over another
- * (each still gets its own regression-pinning test below, honestly scoped as such).
+ * assertion can attribute their shared 0 result to one specific guard over another.
+ * "unreadable" and "blank" each still get an honestly-scoped regression-pinning test
+ * below; "absent" continues to rely on the truth table's own indirect coverage above.
  *
  * Functions under test: pfb_dnsbl_converged(): bool,
  * pfb_unbound_py_marker_generation(string $path): int (pfblockerng.inc).
@@ -214,6 +215,23 @@ final class PfbDnsblConvergedTest extends TestCase
 
 		$this->assertSame(0, pfb_unbound_py_marker_generation($path),
 			'a non-digit first line must fail ctype_digit() and read as generation 0, never a garbage leading-digit int cast');
+	}
+
+	public function testMarkerGenerationSignPrefixedFirstLine_returnsZero(): void
+	{
+		// ctype_digit() is strict digits-only, unlike the looser is_numeric() (which
+		// accepts a sign/exponent) -- this fixture would survive an accidental
+		// ctype_digit() -> is_numeric() swap if it only asserted "12abc" above.
+		$positive = "{$this->dir}/plus_marker";
+		file_put_contents($positive, "+5\n");
+
+		$negative = "{$this->dir}/minus_marker";
+		file_put_contents($negative, "-3\n");
+
+		$this->assertSame(0, pfb_unbound_py_marker_generation($positive),
+			'a sign-prefixed first line must fail ctype_digit() and read as generation 0');
+		$this->assertSame(0, pfb_unbound_py_marker_generation($negative),
+			'a negative first line must fail ctype_digit() and read as generation 0');
 	}
 
 	public function testMarkerGenerationValidDigitFirstLine_returnsParsedInt(): void

--- a/tests/php/PfbDnsblConvergedTest.php
+++ b/tests/php/PfbDnsblConvergedTest.php
@@ -16,9 +16,16 @@ use PHPUnit\Framework\TestCase;
  * with the LATER conditions deliberately left passing, to prove the EARLIER
  * failing condition alone forces FALSE.
  *
- * Function under test: pfb_dnsbl_converged(): bool (pfblockerng.inc).
+ * Also covers pfb_unbound_py_marker_generation()'s remaining return-0 shapes
+ * DIRECTLY (issue #1024): the truth table above only reaches it through the
+ * "neither marker file exists" case; the unreadable/blank/non-digit branches
+ * had no direct coverage.
+ *
+ * Functions under test: pfb_dnsbl_converged(): bool,
+ * pfb_unbound_py_marker_generation(string $path): int (pfblockerng.inc).
  */
 #[CoversFunction('pfb_dnsbl_converged')]
+#[CoversFunction('pfb_unbound_py_marker_generation')]
 final class PfbDnsblConvergedTest extends TestCase
 {
 	private string $dir;
@@ -149,5 +156,62 @@ final class PfbDnsblConvergedTest extends TestCase
 		} finally {
 			chmod("{$this->dir}/unbound.conf", 0644);
 		}
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_unbound_py_marker_generation() -- direct branch coverage (issue #1024)
+	// -----------------------------------------------------------------------
+
+	public function testMarkerGenerationUnreadableFile_returnsZeroInsteadOfCrashing(): void
+	{
+		if (function_exists('posix_getuid') && posix_getuid() === 0) {
+			$this->markTestSkipped('root bypasses file permissions -- cannot simulate an unreadable file.');
+		}
+
+		$path = "{$this->dir}/unreadable_marker";
+		file_put_contents($path, "5\n");
+		chmod($path, 0000);
+
+		try {
+			$this->assertSame(0, pfb_unbound_py_marker_generation($path),
+				'an existing-but-unreadable marker (file_get_contents() FALSE) must read as generation 0, never crash');
+		} finally {
+			chmod($path, 0644);
+		}
+	}
+
+	public function testMarkerGenerationBlankFirstLine_returnsZero(): void
+	{
+		$empty = "{$this->dir}/empty_marker";
+		file_put_contents($empty, '');
+
+		$whitespace = "{$this->dir}/whitespace_marker";
+		file_put_contents($whitespace, "   \n");
+
+		$this->assertSame(0, pfb_unbound_py_marker_generation($empty),
+			'a zero-byte marker file must read as generation 0');
+		$this->assertSame(0, pfb_unbound_py_marker_generation($whitespace),
+			'a whitespace-only first line must trim() to empty and read as generation 0');
+	}
+
+	public function testMarkerGenerationNonDigitFirstLine_returnsZero(): void
+	{
+		// Leading-digit-run input ("12abc"): a naive (int) cast without the ctype_digit()
+		// guard would silently yield 12, not 0 -- this fixture actually discriminates the
+		// guard, unlike a purely alphabetic string (which casts to 0 either way).
+		$path = "{$this->dir}/non_digit_marker";
+		file_put_contents($path, "12abc\n");
+
+		$this->assertSame(0, pfb_unbound_py_marker_generation($path),
+			'a non-digit first line must fail ctype_digit() and read as generation 0, never a garbage leading-digit int cast');
+	}
+
+	public function testMarkerGenerationValidDigitFirstLine_returnsParsedInt(): void
+	{
+		$path = "{$this->dir}/valid_marker";
+		file_put_contents($path, "42\nstray second line\n");
+
+		$this->assertSame(42, pfb_unbound_py_marker_generation($path),
+			'a valid digit first line must parse to its integer value, ignoring any later lines');
 	}
 }

--- a/tests/php/PfbDnsblConvergedTest.php
+++ b/tests/php/PfbDnsblConvergedTest.php
@@ -18,8 +18,12 @@ use PHPUnit\Framework\TestCase;
  *
  * Also covers pfb_unbound_py_marker_generation()'s remaining return-0 shapes
  * DIRECTLY (issue #1024): the truth table above only reaches it through the
- * "neither marker file exists" case; the unreadable/blank/non-digit branches
- * had no direct coverage.
+ * "neither marker file exists" case. Of the four input shapes named in #1024
+ * (absent, unreadable, blank, non-digit), only "non-digit" is independently
+ * observable via a return-value assertion -- "absent"/"unreadable"/"blank" all
+ * funnel through the SAME downstream ctype_digit('')-is-FALSE catch-all, so no
+ * assertion can attribute their shared 0 result to one specific guard over another
+ * (each still gets its own regression-pinning test below, honestly scoped as such).
  *
  * Functions under test: pfb_dnsbl_converged(): bool,
  * pfb_unbound_py_marker_generation(string $path): int (pfblockerng.inc).
@@ -161,6 +165,12 @@ final class PfbDnsblConvergedTest extends TestCase
 	// -----------------------------------------------------------------------
 	// pfb_unbound_py_marker_generation() -- direct branch coverage (issue #1024)
 	// -----------------------------------------------------------------------
+
+	// issue #1024: "unreadable file" and "blank/whitespace first line" have no test of
+	// their own beyond regression-pinning below. Both funnel through the SAME downstream
+	// ctype_digit('')-is-FALSE catch-all as every other degenerate shape -- confirmed via
+	// mutation that no return-value assertion can attribute the 0 result to one guard over
+	// another, so a "this specific branch" claim here would be coverage theater.
 
 	public function testMarkerGenerationUnreadableFile_returnsZeroInsteadOfCrashing(): void
 	{

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -314,4 +314,81 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		$this->assertDoesNotMatchRegularExpression('/pfb_sync_status_close\s*\(/', $region,
 			'a restart-fallback branch must never close a ledger entry directly -- only the shared tail may');
 	}
+
+	// -----------------------------------------------------------------------
+	// pfb_reload_unbound() -- zero-downtime swap SUCCESS early-return (issue #1024)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Drives the REAL zero-downtime swap all the way to its own SUCCESS
+	 * early-return (pfb_dnsbl_apply_ledger_update(); return;) -- distinct from
+	 * testRestartFallbackPathReachesTailWithConvergedState, which only reaches
+	 * the SHARED tail via the restart fallback. is_process_running('unbound')
+	 * is called exactly twice on this path (the fast-path eligibility check,
+	 * then pfb_dnsbl_converged() inside the ledger update this return makes) --
+	 * any other count means the restart path (>=5 calls, see the fallback
+	 * sibling above) ran instead.
+	 */
+	public function testZeroDowntimeSwapSuccessClosesLedgerViaEarlyReturn(): void
+	{
+		$this->writeUnboundConf(TRUE);
+		$GLOBALS['pfb']['dnsbl_file']            = "{$this->dir}/dnsbl_file";
+		$GLOBALS['pfb']['unbound_py_count']      = "{$this->dir}/unbound_py_count";
+		file_put_contents($GLOBALS['pfb']['unbound_py_count'], '10');
+		$GLOBALS['pfb']['chroot_cmd']            = '/bin/echo';
+		$GLOBALS['pfb']['dnsbl_python_unmount']  = FALSE;
+		$GLOBALS['config']['unbound']            = ['python' => 'on', 'python_script' => 'pfb_unbound'];
+
+		// No sentinel written yet -> flip_sentinel()'s cur=0 -> next=1; pre-write the
+		// applied marker to 1 so wait_applied(1) confirms on its FIRST read, never sleeping.
+		file_put_contents("{$this->dir}/pfb_py_reload.applied", "1\n");
+
+		$calls = 0;
+		$GLOBALS['pfb_test_process_running']['unbound'] = function () use (&$calls) {
+			$calls++;
+			return TRUE;
+		};
+
+		pfb_reload_unbound('enabled', FALSE, FALSE, TRUE, []);
+
+		$this->assertSame(2, $calls,
+			"the success path must call is_process_running('unbound') exactly twice (eligibility check + pfb_dnsbl_converged()); any other count means the restart path ran instead");
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'),
+			'a converged zero-downtime swap must close the dnsbl apply entry via its own early return');
+		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['dnsbl_file']}.sync",
+			'the success early-return must clear its own daemon-suppression marker before returning');
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_reload_unbound() -- non-'enabled' mode closes via the else branch (issue #1024)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Drives the shared tail's ELSE branch (mode != 'enabled' -> a direct
+	 * pfb_sync_status_close(), never pfb_dnsbl_apply_ledger_update()) with a
+	 * state that stays NON-converged even after the call (is_process_running
+	 * FALSE throughout, no unbound.conf) -- proving the close happens because
+	 * mode != 'enabled', not because convergence happened to be met.
+	 */
+	public function testDisabledModeClosesLedgerEntryViaElseBranchRegardlessOfConvergence(): void
+	{
+		// Before-state: a stale dnsbl-apply entry genuinely open first (mirrors
+		// testNotConvergedOpensEntry), so the close below is a real transition.
+		$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;
+		pfb_dnsbl_apply_ledger_update();
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'dnsbl'),
+			'a stale dnsbl apply entry must exist before the disabled-mode call under test');
+
+		$GLOBALS['g']['varrun_path']            = $this->dir;
+		$GLOBALS['pfb']['chroot_cmd']            = '/bin/echo';
+		$GLOBALS['pfb']['dnsbl_python_unmount']  = FALSE;
+		// is_process_running('unbound') stays FALSE for the whole call and no unbound.conf
+		// is ever written -- pfb_dnsbl_converged() would read FALSE too, but mode !=
+		// 'enabled' means it is never even reached on this path (confirmed by source read).
+
+		pfb_reload_unbound('disabled', FALSE, FALSE);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'),
+			'a disabled-mode reload must close the dnsbl apply entry via the unconditional else branch, even though the state never converged');
+	}
 }

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -331,6 +331,13 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 	 */
 	public function testZeroDowntimeSwapSuccessClosesLedgerViaEarlyReturn(): void
 	{
+		// Before-state: a stale dnsbl-apply entry genuinely open first (mirrors
+		// testConvergedClosesEntry), so the close asserted below is a real transition.
+		$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;
+		pfb_dnsbl_apply_ledger_update();
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'dnsbl'),
+			'a stale dnsbl apply entry must exist before the zero-downtime swap under test');
+
 		$this->writeUnboundConf(TRUE);
 		$GLOBALS['pfb']['dnsbl_file']            = "{$this->dir}/dnsbl_file";
 		$GLOBALS['pfb']['unbound_py_count']      = "{$this->dir}/unbound_py_count";

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -350,10 +350,14 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		// applied marker to 1 so wait_applied(1) confirms on its FIRST read, never sleeping.
 		file_put_contents("{$this->dir}/pfb_py_reload.applied", "1\n");
 
+		// TRUE only for the two expected success-path calls -- if a regression falls
+		// through to the restart path instead, is_process_running() resolves FALSE
+		// immediately so pfb_stop_start_unbound()'s 30-iteration wait loop never
+		// real-sleeps; the call-count assertion below still catches the regression.
 		$calls = 0;
 		$GLOBALS['pfb_test_process_running']['unbound'] = function () use (&$calls) {
 			$calls++;
-			return TRUE;
+			return $calls <= 2;
 		};
 
 		pfb_reload_unbound('enabled', FALSE, FALSE, TRUE, []);


### PR DESCRIPTION
## Summary

Closes a test-coverage gap flagged in #1024 (split off from #1015's triage):

- `PfbDnsblConvergedTest.php`: direct coverage for `pfb_unbound_py_marker_generation()`'s
  degenerate-input return-0 shapes (unreadable file, blank/whitespace first line, non-digit
  first line) plus a positive-control test for a valid digit. The blank/whitespace and
  unreadable-file cases are honestly documented as regression-pinning rather than
  independently-discriminating: empirical mutation testing showed both funnel through the
  same `ctype_digit('')`-is-FALSE catch-all as every other degenerate shape, so no
  return-value assertion can attribute the shared `0` result to one specific guard. Only
  the non-digit and valid-digit shapes are independently killable, and both are pinned.
- `PfbSyncStatusDnsblWritersTest.php`: drives the two previously-undriven
  `pfb_reload_unbound()` ledger call sites by name -- the zero-downtime swap's own SUCCESS
  early-return, and the shared tail's `else` branch (`$mode != 'enabled'`) that closes the
  ledger unconditionally, not via `pfb_dnsbl_apply_ledger_update()`'s convergence check.

No `src/` changes -- test-only, behaviour-preserving (CLAUDE.md Test coverage mandate #1's
exception).

## Test plan

- [x] `php -l` on both changed files
- [x] `vendor/bin/phpunit --filter 'PfbDnsblConvergedTest|PfbSyncStatusDnsblWritersTest'` -- 22/22 green
- [x] Full `vendor/bin/phpunit` -- 2527/2527 green, no regressions
- [x] Mutation-kill proof for every new test that claims to discriminate a specific branch
      (non-digit, valid-digit, zero-downtime-success, disabled-mode-else) -- each confirmed
      RED under a targeted local mutation, then restored to GREEN
- [x] PHPStan/PHPCS not applicable (both scoped to `src/`; this diff touches zero `src/` files)

Fixes #1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)
