### PR TITLE
pfblockerng: close orphaned download ledger entries on WebUI alias rename/delete (#1014, #1019)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,8 @@ ignore = [
 "tests/smoke/test_hook_stream_visibility.py"    = ["F811"]
 # issue #999: imports the `clean_ledger` fixture from test_render_widget_ledger.py
 "tests/smoke/ui/test_widget_clear_failed.py"    = ["F811"]
+# issue #1014/#1019: imports the `clean_ledger` fixture from test_render_widget_ledger.py
+"tests/smoke/ui/test_category_ledger_close.py"  = ["F811"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["pfb_unbound"]

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3008,6 +3008,42 @@ function pfb_sync_status_dedup_check(string $log_path, string $ledger_dir): void
 }
 
 /**
+ * pfb_sync_status_close_removed_alias — close the stage=download ledger entry for an
+ * IP/DNSBL alias removed by our own WebUI (renamed or deleted). $gtype selects the
+ * download-key shape (pfb_ip/dnsbl_download_ledger_update's own prefix/suffix rules);
+ * an empty $aliasname or an unrecognized $gtype (e.g. 'geoip') is a no-op.
+ *
+ * Only the download stage closes -- apply/parse/dedup stay tick-managed (issue
+ * #1014/#1019; ADR-61 §2.2 symmetric ownership).
+ *
+ * @param string $gtype     'ipv4' | 'ipv6' | 'dnsbl' (any other value is a no-op).
+ * @param string $aliasname The REMOVED alias's raw aliasname (empty = no-op).
+ * @param string $ledger_dir Directory that contains pfb_sync_status.json.
+ * @return void
+ */
+function pfb_sync_status_close_removed_alias(string $gtype, string $aliasname, string $ledger_dir): void
+{
+	if ($aliasname === '') {
+		return;
+	}
+
+	switch ($gtype) {
+		case 'ipv4':
+			pfb_sync_status_close('ip', "pfB_{$aliasname}_v4", 'download', $ledger_dir);
+			break;
+		case 'ipv6':
+			pfb_sync_status_close('ip', "pfB_{$aliasname}_v6", 'download', $ledger_dir);
+			break;
+		case 'dnsbl':
+			pfb_sync_status_close('dnsbl', "DNSBL_{$aliasname}", 'download', $ledger_dir);
+			break;
+		default:
+			// unknown gtype (e.g. 'geoip') -- no download ledger key shape defined, no-op
+			break;
+	}
+}
+
+/**
  * pfb_py_sync_status_list_open — read-only reader for Python's OWN status ledger
  * (pfb_py_status.json, written EXCLUSIVELY by pfb_unbound.py -- this function never
  * writes it), returning entries in the SAME shape as pfb_sync_status_list_open() so

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -154,6 +154,9 @@ if (!empty($action) && isset($gtype) && isset($rowid)) {
 			// Delete Table row (via POST)
 			$name = pfb_filter($rowdata[$rowid]['aliasname'], PFB_FILTER_WORD, 'Category');
 			if (!empty($name) && isset($rowdata[$rowid])) {
+				// issue #1014/#1019: close the deleted alias's stage=download ledger entry
+				// before the row config node is gone -- else it orphans forever.
+				pfb_sync_status_close_removed_alias($gtype, $rowdata[$rowid]['aliasname'] ?? '', $pfb['dbdir']);
 				unset($rowdata[$rowid]);
 				if (isset($rowdata_path)) {
 					config_del_path("{$rowdata_path}/{$rowid}");

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -156,7 +156,7 @@ if (!empty($action) && isset($gtype) && isset($rowid)) {
 			if (!empty($name) && isset($rowdata[$rowid])) {
 				// issue #1014/#1019: close the deleted alias's stage=download ledger entry
 				// before the row config node is gone -- else it orphans forever.
-				pfb_sync_status_close_removed_alias($gtype, $rowdata[$rowid]['aliasname'] ?? '', $pfb['dbdir']);
+				pfb_sync_status_close_removed_alias($gtype, $name, $pfb['dbdir']);
 				unset($rowdata[$rowid]);
 				if (isset($rowdata_path)) {
 					config_del_path("{$rowdata_path}/{$rowid}");

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -730,6 +730,13 @@ if ($_POST && isset($_POST['save'])) {
 	}
 
 	if (!$input_errors) {
+		// issue #1014/#1019: close the OLD alias's stage=download ledger entry before
+		// the aliasname is overwritten below -- a renamed alias must not orphan it.
+		$pfb_old_aliasname = config_get_path("installedpackages/{$conf_type}/config/{$rowid}/aliasname", '');
+		if ($pfb_old_aliasname !== '' && $pfb_old_aliasname !== ($_POST['aliasname'] ?: '')) {
+			pfb_sync_status_close_removed_alias($gtype, $pfb_old_aliasname, $pfb['dbdir']);
+		}
+
 		// foreign structure: pfblockernglistsv4/v6/dnsbl per-row keys are not in registry
 		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/aliasname", $_POST['aliasname'] ?: '');
 

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -40,6 +40,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_sync_status_read_all')]
 #[CoversFunction('pfb_sync_status_write_all')]
 #[CoversFunction('pfb_sync_status_locked')]
+#[CoversFunction('pfb_sync_status_close_removed_alias')]
 final class PfbSyncStatusLedgerTest extends TestCase
 {
 	private string $dir;
@@ -282,5 +283,87 @@ final class PfbSyncStatusLedgerTest extends TestCase
 			$elapsed,
 			'pfb_sync_status_open() must block on the lock file until the real concurrent holder releases it -- a near-instant return means the read-modify-write span is not actually protected'
 		);
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_sync_status_close_removed_alias() — issue #1014/#1019: close an
+	// orphaned stage=download entry when our own WebUI renames/deletes an alias.
+	// -----------------------------------------------------------------------
+
+	public function testCloseRemovedAliasIpv4ClosesDownloadEntry(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+		// Before-state: the download entry is genuinely open first.
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		pfb_sync_status_close_removed_alias('ipv4', 'Foo', $this->dir);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'ipv4 removal must close pfB_Foo_v4/download');
+	}
+
+	public function testCloseRemovedAliasIpv6ClosesDownloadEntry(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_Foo_v6', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		pfb_sync_status_close_removed_alias('ipv6', 'Foo', $this->dir);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'ipv6 removal must close pfB_Foo_v6/download');
+	}
+
+	public function testCloseRemovedAliasDnsblClosesDownloadEntry(): void
+	{
+		pfb_sync_status_open('dnsbl', 'DNSBL_Foo', 'download', 'timeout', $this->dir, self::clockAt(1000));
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'dnsbl'));
+
+		pfb_sync_status_close_removed_alias('dnsbl', 'Foo', $this->dir);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'dnsbl removal must close DNSBL_Foo/download');
+	}
+
+	public function testCloseRemovedAliasEmptyAliasnameIsNoOp(): void
+	{
+		pfb_sync_status_close_removed_alias('ipv4', '', $this->dir);
+
+		$this->assertFileDoesNotExist($this->dir . '/pfb_sync_status.json', 'an empty aliasname must not write a ledger file');
+	}
+
+	public function testCloseRemovedAliasUnknownGtypeIsNoOp(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		// 'geoip' has no download ledger key shape -- must no-op, never crash.
+		pfb_sync_status_close_removed_alias('geoip', 'Foo', $this->dir);
+
+		$open = pfb_sync_status_list_open($this->dir);
+		$this->assertCount(1, $open, 'an unknown gtype must leave an unrelated open entry untouched');
+		$this->assertSame('pfB_Foo_v4', $open[0]['item']);
+	}
+
+	public function testCloseRemovedAliasOnlyClosesDownloadStageNeverApply(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'apply', '[pfctl] failed', $this->dir, self::clockAt(1000));
+		// Before-state: both stages genuinely open.
+		$this->assertCount(2, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		pfb_sync_status_close_removed_alias('ipv4', 'Foo', $this->dir);
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open, 'only the download stage must close -- apply is tick-managed');
+		$this->assertSame('apply', $open[0]['stage'], 'the surviving entry must be the apply stage');
+	}
+
+	public function testCloseRemovedAliasKeyPrecisionLeavesOtherAliasesOpen(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_Other_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		pfb_sync_status_close_removed_alias('ipv4', 'Foo', $this->dir);
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open, 'closing Foo must not touch a different alias key (Other)');
+		$this->assertSame('pfB_Other_v4', $open[0]['item']);
 	}
 }

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -323,9 +323,17 @@ final class PfbSyncStatusLedgerTest extends TestCase
 
 	public function testCloseRemovedAliasEmptyAliasnameIsNoOp(): void
 	{
+		// pfb_sync_status_close() already no-ops on an absent key, so the ONLY fixture that
+		// discriminates "empty-guard present" from "absent" is a pre-opened pfB__v4 entry --
+		// the exact key the un-guarded switch ('ipv4' + '') would build and wrongly close.
+		pfb_sync_status_open('ip', 'pfB__v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+
 		pfb_sync_status_close_removed_alias('ipv4', '', $this->dir);
 
-		$this->assertFileDoesNotExist($this->dir . '/pfb_sync_status.json', 'an empty aliasname must not write a ledger file');
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open, 'an empty aliasname must be a no-op even when pfB__v4 happens to be open');
+		$this->assertSame('pfB__v4', $open[0]['item']);
 	}
 
 	public function testCloseRemovedAliasUnknownGtypeIsNoOp(): void
@@ -357,13 +365,16 @@ final class PfbSyncStatusLedgerTest extends TestCase
 
 	public function testCloseRemovedAliasKeyPrecisionLeavesOtherAliasesOpen(): void
 	{
-		pfb_sync_status_open('ip', 'pfB_Other_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
-		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+		// Prefix-adjacent sibling proves EXACT-key match, not a prefix/substring match:
+		// closing 'Foo' must close only pfB_Foo_v4 and leave pfB_FooBar_v4 open.
+		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+		pfb_sync_status_open('ip', 'pfB_FooBar_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(2000));
+		$this->assertCount(2, pfb_sync_status_list_open($this->dir, 'ip'));
 
 		pfb_sync_status_close_removed_alias('ipv4', 'Foo', $this->dir);
 
 		$open = pfb_sync_status_list_open($this->dir, 'ip');
-		$this->assertCount(1, $open, 'closing Foo must not touch a different alias key (Other)');
-		$this->assertSame('pfB_Other_v4', $open[0]['item']);
+		$this->assertCount(1, $open, 'closing Foo must close only its exact key, leaving prefix-adjacent FooBar open');
+		$this->assertSame('pfB_FooBar_v4', $open[0]['item']);
 	}
 }

--- a/tests/smoke/ui/test_category_ledger_close.py
+++ b/tests/smoke/ui/test_category_ledger_close.py
@@ -1,0 +1,286 @@
+"""issue #1014/#1019 -- Tier-B coverage: WebUI alias rename/delete closes the
+orphaned sync-status ledger ``stage=download`` entry (ADR-61 mechanism: a WebUI
+event hook, NOT tick reconciliation).
+
+Before this fix, deleting or renaming an IP/DNSBL alias via pfBlockerNG's OWN
+category pages left its ``facility=ip|dnsbl stage=download`` ledger entry open
+forever -- nothing else ever closes a download key for a REMOVED alias (the
+tick only ever re-opens/closes keys for aliases that still EXIST). The new
+``pfb_sync_status_close_removed_alias()`` call at both WebUI mutation sites
+closes exactly that key.
+
+Ledger seeding/probing reuses ``test_render_widget_ledger.py``'s own
+conventions (``_ledger_open()`` over the REAL ``pfb_sync_status_open()``,
+``clean_ledger`` for backup/restore) -- the KILL-GATE mandate that a
+render/behaviour test reflect a manually-seeded entry via the production
+writer, not a hand-rolled JSON blob. Row seeding/mutation reuses
+``test_category.py``'s AJAX ``act=del`` drive (direct ``webui.session.post``,
+NOT the form-scrape helper -- the row's own JS-fired AJAX envelope) and
+``test_category_edit.py``'s full-form-POST save drive for the rename case.
+
+Every flow is a TRUE transition test (CLAUDE.md): it seeds a row + opens its
+download ledger entry, asserts OPEN, drives the WebUI mutation, then asserts
+CLOSED -- proving the mutation CAUSED the close, not that the ledger merely
+started empty. ``clean_ledger`` wipes+restores the ledger files around every
+test regardless of outcome, so a failed assertion never leaks an open entry
+into a sibling test.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .test_category import (
+    AJAX_TIMEOUT,
+    CATEGORY_PAGE,
+    _ajax_post,
+    _restore_lists,
+    _seed_single_ipv4_row,
+    _snapshot_lists,
+)
+from .test_category_edit import CFG_IPV4 as _CE_CFG_IPV4
+from .test_category_edit import _del_rowid as _ce_del_rowid
+from .test_category_edit import _free_rowid as _ce_free_rowid
+from .test_category_edit import _ipv4_payload as _ce_ipv4_payload
+from .test_category_edit import _post_form as _ce_post_form
+from .test_render_widget_ledger import (  # noqa: F401 -- clean_ledger used as a fixture arg
+    _LEDGER_DIR,
+    _ledger_open,
+    clean_ledger,
+)
+from .webui import extract_csrf_token, looks_like_login_page
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+DNSBL_LISTS = "installedpackages/pfblockerngdnsbl/config"
+
+_SNAP_OPEN = "<<<SNAP>>>"
+_SNAP_CLOSE = "<<<SNAPEND>>>"
+
+
+def _snapshot_node(vm: helpers.SmokeVM, path: str) -> str:
+    """Return a base64(serialize()) blob of the whole config node at ``path``.
+
+    Generic sibling of ``test_category.py``'s own ``_snapshot_lists`` (which is
+    hardcoded to the IPv4-lists node) -- used here for the DNSBL-lists node so
+    that node can be restored byte-for-byte in teardown.
+    """
+    snippet = (
+        f"echo {helpers._php_str(_SNAP_OPEN)} . "
+        f"base64_encode(serialize(config_get_path({helpers._php_str(path)}, array()))) . "
+        f"{helpers._php_str(_SNAP_CLOSE)};"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=AJAX_TIMEOUT)
+    out = result.stdout
+    start = out.find(_SNAP_OPEN)
+    end = out.find(_SNAP_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(f"_snapshot_node({path!r}): no delimited blob: rc={result.returncode} out={out!r}")
+    return out[start + len(_SNAP_OPEN) : end]
+
+
+def _restore_node(vm: helpers.SmokeVM, path: str, blob: str) -> None:
+    """Rewrite the config node at ``path`` from a :func:`_snapshot_node` blob."""
+    snippet = (
+        f"config_set_path({helpers._php_str(path)}, "
+        f"unserialize(base64_decode({helpers._php_str(blob)})));\n"
+        "write_config('pfBlockerNG smoke: restore category ledger-close test node');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=AJAX_TIMEOUT)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"_restore_node({path!r}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def _seed_single_dnsbl_row(vm: helpers.SmokeVM, aliasname: str, action: str) -> None:
+    """Replace the DNSBL-groups node with exactly ONE known row (index 0).
+
+    Sibling of ``test_category.py``'s ``_seed_single_ipv4_row`` for the DNSBL
+    conf_type (``pfblockerngdnsbl``, not an IP list) -- ``aliasname`` must be
+    word-only (``PFB_FILTER_WORD``), same as the IP del handler requires.
+    """
+    row = {
+        "aliasname": aliasname,
+        "action": action,
+        "cron": "Never",
+        "logging": "enabled",
+        "description": "pfBlockerNG smoke ledger-close dnsbl row",
+    }
+    snippet = (
+        f"$list = {helpers._php_kv_array(row)};\n"
+        f"config_set_path({helpers._php_str(DNSBL_LISTS)}, array($list));\n"
+        "write_config('pfBlockerNG smoke: seed DNSBL category row');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=AJAX_TIMEOUT)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_seed_single_dnsbl_row failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def _ajax_post_typed(webui: WebUI, page_type: str, data: dict[str, str]) -> str:
+    """Drive a DIRECT CSRF-authenticated POST to the Category AJAX endpoint for ``page_type``.
+
+    Generic sibling of ``test_category.py``'s own ``_ajax_post`` (hardcoded to
+    the IPv4 page) -- GETs ``CATEGORY_PAGE?type=<page_type>`` for a fresh
+    ``__csrf_magic`` token before posting, so the DNSBL tab's own render is what
+    seeds the token.
+    """
+    page = webui.get(f"{CATEGORY_PAGE}?type={page_type}")
+    assert not looks_like_login_page(page.text), "Category GET returned the login form (session lost)"
+    token = extract_csrf_token(page.text)
+    payload = dict(data)
+    payload["__csrf_magic"] = token
+    resp = webui.session.post(
+        webui.url(CATEGORY_PAGE),
+        data=payload,
+        verify=webui._verify,
+        timeout=AJAX_TIMEOUT,
+    )
+    assert not looks_like_login_page(resp.text), "Category POST returned the login form (session lost)"
+    return resp.text
+
+
+def _ledger_is_open(vm: helpers.SmokeVM, facility: str, item: str, stage: str) -> bool:
+    """True iff ``{facility,item,stage}`` is currently OPEN in the REAL sync-status ledger.
+
+    Reads through the production ``pfb_sync_status_list_open()`` (KILL-GATE
+    mandate: probe the extracted ledger logic itself, never a hand-parsed
+    ledger file).
+    """
+    snippet = (
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
+        f"$open = pfb_sync_status_list_open({helpers._php_str(_LEDGER_DIR)}, {helpers._php_str(facility)});\n"
+        "$hit = 'NO';\n"
+        "foreach ($open as $e) {\n"
+        f"  if ($e['item'] === {helpers._php_str(item)} && $e['stage'] === {helpers._php_str(stage)}) {{\n"
+        "    $hit = 'YES';\n"
+        "  }\n"
+        "}\n"
+        "echo $hit;"
+    )
+    result = helpers.php_eval(vm, snippet)
+    assert result.returncode == 0, f"_ledger_is_open({facility!r}, {item!r}, {stage!r}) failed: {result.stderr!r}"
+    if "YES" in result.stdout:
+        return True
+    if "NO" in result.stdout:
+        return False
+    raise RuntimeError(f"_ledger_is_open: unexpected pfSsh.php output {result.stdout!r}")
+
+
+# --------------------------------------------------------------------------- #
+# IPv4 DELETE -- act=del closes the removed alias's orphaned download entry.
+# --------------------------------------------------------------------------- #
+
+
+def test_category_delete_closes_orphaned_ipv4_download_ledger_entry(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    clean_ledger: None,
+) -> None:
+    """``act=del`` on an IPv4 alias closes its orphaned ``ip``/``download`` entry.
+
+    Before this fix, nothing ever closed ``pfB_<alias>_v4``'s download key once
+    the alias itself was gone -- it stayed open in the ledger/widget forever.
+    """
+    vm = smoke_vm
+    alias = f"pfbldg{uuid.uuid4().hex[:8]}"
+    item = f"pfB_{alias}_v4"
+    snap = _snapshot_lists(vm)
+    try:
+        _seed_single_ipv4_row(vm, alias, "Deny_Both")
+        _ledger_open(vm, "ip", item, "download", "smoke: synthetic download failure")
+        # BEFORE: the download entry is genuinely open first.
+        assert _ledger_is_open(vm, "ip", item, "download"), "seed did not open the download ledger entry"
+
+        _ajax_post(webui, {"act": "del", "type": "ipv4", "rowid": "0"})
+
+        assert not _ledger_is_open(vm, "ip", item, "download"), (
+            "act=del must close the removed alias's orphaned stage=download entry"
+        )
+    finally:
+        _restore_lists(vm, snap)
+
+
+# --------------------------------------------------------------------------- #
+# IPv4 RENAME -- category_edit save closes the OLD name's orphaned entry.
+# --------------------------------------------------------------------------- #
+
+
+def test_category_edit_rename_closes_orphaned_ipv4_download_ledger_entry(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    clean_ledger: None,
+) -> None:
+    """Renaming an IPv4 alias in category_edit closes the OLD name's orphaned download entry.
+
+    True lifecycle transition: save the alias under its OLD name, open the OLD
+    name's download entry, assert OPEN, re-save the SAME rowid under a NEW
+    aliasname, assert the OLD key is CLOSED -- nothing else re-keys or closes a
+    download entry on an aliasname change.
+    """
+    vm = smoke_vm
+    rowid = _ce_free_rowid(vm, _CE_CFG_IPV4)
+    old_alias = f"pfbldgold{uuid.uuid4().hex[:6]}"
+    new_alias = f"pfbldgnew{uuid.uuid4().hex[:6]}"
+    old_item = f"pfB_{old_alias}_v4"
+    try:
+        _ce_post_form(webui, _ce_ipv4_payload(rowid, old_alias, action="Deny_Both"))
+        assert helpers.config_get(vm, f"{_CE_CFG_IPV4}/{rowid}/aliasname") == old_alias, (
+            "seed save did not land the old aliasname"
+        )
+        _ledger_open(vm, "ip", old_item, "download", "smoke: synthetic download failure")
+        # BEFORE: the OLD alias's download entry is genuinely open first.
+        assert _ledger_is_open(vm, "ip", old_item, "download"), "seed did not open the old alias's download entry"
+
+        _ce_post_form(webui, _ce_ipv4_payload(rowid, new_alias, action="Deny_Both"))
+        assert helpers.config_get(vm, f"{_CE_CFG_IPV4}/{rowid}/aliasname") == new_alias, (
+            "rename save did not land the new aliasname"
+        )
+
+        assert not _ledger_is_open(vm, "ip", old_item, "download"), (
+            "renaming the alias must close the OLD name's orphaned stage=download entry"
+        )
+    finally:
+        _ce_del_rowid(vm, _CE_CFG_IPV4, rowid)
+
+
+# --------------------------------------------------------------------------- #
+# DNSBL DELETE -- sibling axis: the download key has NO _v4/_v6 suffix.
+# --------------------------------------------------------------------------- #
+
+
+def test_category_delete_closes_orphaned_dnsbl_download_ledger_entry(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    clean_ledger: None,
+) -> None:
+    """``act=del`` on a DNSBL group closes its orphaned ``dnsbl``/``download`` entry.
+
+    Sibling axis to the IPv4 delete case, proving the helper's facility='dnsbl'
+    branch: the DNSBL download key is ``DNSBL_<alias>`` (no _v4/_v6 suffix).
+    """
+    vm = smoke_vm
+    alias = f"pfbldg{uuid.uuid4().hex[:8]}"
+    item = f"DNSBL_{alias}"
+    snap = _snapshot_node(vm, DNSBL_LISTS)
+    try:
+        _seed_single_dnsbl_row(vm, alias, "unbound")
+        _ledger_open(vm, "dnsbl", item, "download", "smoke: synthetic download failure")
+        assert _ledger_is_open(vm, "dnsbl", item, "download"), "seed did not open the download ledger entry"
+
+        _ajax_post_typed(webui, "dnsbl", {"act": "del", "type": "dnsbl", "rowid": "0"})
+
+        assert not _ledger_is_open(vm, "dnsbl", item, "download"), (
+            "act=del must close the removed DNSBL group's orphaned stage=download entry"
+        )
+    finally:
+        _restore_node(vm, DNSBL_LISTS, snap)


### PR DESCRIPTION
## Summary

Fixes the IP-side (and, for completeness, the DNSBL-side) half of #1014, tracked as #1019: ADR-61's `stage=download` sync-status ledger entries never clear when an IP or DNSBL list alias is **renamed or deleted through pfBlockerNG's own WebUI**.

`pfb_ip_download_ledger_update()` / `pfb_dnsbl_download_ledger_update()` key the `facility=ip|dnsbl stage=download` entry on the `pfB_*` / `DNSBL_*` alias name. The tick reconciler touches only `stage=apply` (ADR-61 Semantics #5), and a download entry only closes on a later success of that *exact same key*. When our WebUI renames or deletes the alias, that key is never called again, so the entry orphans forever (harmless — display-only, self-clears on reboot — but a stale, misleading yellow dashboard signal in the meantime).

The Python parse-stage half of #1014 already landed in #1018; this is the remaining PHP/IP side.

## Approach

Per the maintainer decision on #1019, this uses the **WebUI event-hook** mechanism (not tick-time reconciliation), which restores ADR-61 §2.2 *symmetric ownership* — the alias's lifecycle-end (rename/delete) closes its own ledger entry — and leaves Semantics #5 (and the ADR document) untouched. Only our own WebUI is a supported mutation surface; manual `config.xml` edits and renames via pfSense's Firewall/Aliases page are out of scope.

Because the very same category editor/list pages mutate all three gtypes, the identical orphan on the **DNSBL** facility is fixed in the same shared hook, avoiding a fix-one-leave-the-sibling gap.

## Changes

- **New helper** `pfb_sync_status_close_removed_alias($gtype, $aliasname, $ledger_dir)` in `pfblockerng_extra.inc` — maps `gtype` to the download-key shape (`pfB_<alias>_v4` / `pfB_<alias>_v6` for `ip`, `DNSBL_<alias>` for `dnsbl`) and closes **only** the `download` stage. Empty aliasname or an unrecognized gtype (e.g. `geoip`) is a safe no-op. `apply`/`parse`/`dedup` are never touched (they stay tick-managed).
- **Rename hook** in `pfblockerng_category_edit.php` — before the aliasname is overwritten, reads the old aliasname and closes its entry iff it changed (new-row and unchanged-name paths are no-ops).
- **Delete hook** in `pfblockerng_category.php` (`act=del`) — closes the deleted row's entry before its config node is removed.

## Test plan

- **7 new PHPUnit cases** in `PfbSyncStatusLedgerTest.php` covering the full gtype axis (ipv4/ipv6/dnsbl close), empty-aliasname and unknown-gtype no-ops, **download-only isolation** (a seeded `apply` entry survives the call), and **key precision** (a sibling alias is left open). Each transition test asserts the open before-state first.
- Red→green verified by reverting the helper source: the 7 cases fail with `Call to undefined function pfb_sync_status_close_removed_alias()`, then pass after restore.
- **3 new Tier B (`ui_e2e`) smoke tests** in `tests/smoke/ui/test_category_ledger_close.py` drive the real WebUI POST (IPv4 delete, IPv4 rename, DNSBL delete) and assert the orphaned entry is closed — the behavior is observable only end-to-end. These are VM-gated and run on the live-VM smoke dispatch. No new Tier A test: the change alters no GET-rendered output, so the existing category render coverage already guards these pages.
- `php -l`, `vendor/bin/phpunit` (2529 passed, 10 skipped), `vendor/bin/phpstan` (no errors), `vendor/bin/phpcs`, `ruff check` / `ruff format --check`, `python3 -m pytest` — all green.

Fixes #1014
Fixes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZ3wMCKHisJY1Hzn5Yu4tU)_