### PR TITLE
tests: fix stale Log Settings browser test after Max-days redesign

### DIFF
--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -219,10 +219,14 @@ def test_log_settings_grouped_layout(
     # bullets: the intro also wraps "Max lines"/"Max days" in <strong> (exact text nodes) and is
     # emitted before the header rows, so an unscoped exact match resolves to the intro via .first
     # and would pass even if a header StaticText child were missing or renamed. Scope the lookup
-    # into the header rows so a broken column header actually fails the test.
+    # into the header rows, and assert one header cell PER category (all three, matching the three
+    # .pfb-loghdr rows), so a column header dropped from any single category fails -- not just the
+    # first row.
     loghdr = page.locator(".pfb-loghdr")
     for col_header in ("Max lines", "Max days"):
-        expect(loghdr.get_by_text(col_header, exact=True).first).to_be_visible(timeout=JS_TIMEOUT_MS)
+        cells = loghdr.get_by_text(col_header, exact=True)
+        expect(cells).to_have_count(3, timeout=JS_TIMEOUT_MS)
+        expect(cells.first).to_be_visible(timeout=JS_TIMEOUT_MS)
 
     # The log_max_log control's enclosing form-group carries the per-log label "pfBlockerNG".
     log_max_log = page.locator('select[name="log_max_log"]')
@@ -242,11 +246,14 @@ def test_log_settings_grouped_layout(
     expect(_row_label("log_max_ip_blocklog")).to_have_text("Block", timeout=JS_TIMEOUT_MS)
     expect(_row_label("log_max_dnsreplylog")).to_have_text("Reply", timeout=JS_TIMEOUT_MS)
 
-    # EVERY log control carries a per-control mobile label (label-start, class form-label): two
-    # per log row -- a Max-lines select and a Max-days input. Count the actual controls on the
-    # page (the only label-start sources on the General page) and assert exactly that many
-    # form-labels, so the check tracks the real log list and proves every control is labelled,
-    # not merely some.
-    log_controls = page.locator('select[name^="log_max_"], input[name^="log_max_days_"]').count()
-    assert log_controls >= 2, f"expected Log Settings controls (log_max_* select/input), found {log_controls}"
-    expect(page.locator("label.form-label")).to_have_count(log_controls, timeout=JS_TIMEOUT_MS)
+    # Each log row carries BOTH a Max-lines select and a Max-days input; each control emits exactly
+    # one per-control mobile label (label-start, class form-label -- the only source of
+    # label.form-label on this page). Assert the two column families are present and equal-sized,
+    # so dropping either whole column fails (counting only their union would miss a symmetric loss),
+    # then that every control is labelled (one form-label per control).
+    max_lines = page.locator('select[name^="log_max_"]')
+    max_days = page.locator('input[name^="log_max_days_"]')
+    n_rows = max_lines.count()
+    assert n_rows >= 1, f"expected at least one Log Settings row (select[name^=log_max_]), found {n_rows}"
+    expect(max_days).to_have_count(n_rows, timeout=JS_TIMEOUT_MS)
+    expect(page.locator("label.form-label")).to_have_count(n_rows * 2, timeout=JS_TIMEOUT_MS)

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -215,11 +215,14 @@ def test_log_settings_grouped_layout(
     _open(page, webui, GENERAL_PAGE)
     _shot(page, screenshot_dir, "log_settings_grouped_layout")
 
-    # Column header texts visible (emitted by each category header Form_Group's StaticText
-    # children). exact=True + .first targets a header cell rather than the longer intro
-    # sentence ("Max lines -- rolling cap ...") that also contains the word as a substring.
+    # Column headers must come from the shaded category header rows (.pfb-loghdr), NOT the intro
+    # bullets: the intro also wraps "Max lines"/"Max days" in <strong> (exact text nodes) and is
+    # emitted before the header rows, so an unscoped exact match resolves to the intro via .first
+    # and would pass even if a header StaticText child were missing or renamed. Scope the lookup
+    # into the header rows so a broken column header actually fails the test.
+    loghdr = page.locator(".pfb-loghdr")
     for col_header in ("Max lines", "Max days"):
-        expect(page.get_by_text(col_header, exact=True).first).to_be_visible(timeout=JS_TIMEOUT_MS)
+        expect(loghdr.get_by_text(col_header, exact=True).first).to_be_visible(timeout=JS_TIMEOUT_MS)
 
     # The log_max_log control's enclosing form-group carries the per-log label "pfBlockerNG".
     log_max_log = page.locator('select[name="log_max_log"]')

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -184,28 +184,30 @@ def test_log_settings_grouped_layout(
 ) -> None:
     """Log Settings section renders with aligned per-category grouped rows in the live DOM.
 
-    Scenario: Log Settings regrouped into aligned per-log rows with category headers (issue #489).
+    Scenario: Log Settings grouped into aligned per-log rows with category headers (issue #489),
+      each row exposing the two per-log caps -- Max lines and Max days. (The Max-days column
+      replaced the earlier scheduled-reset controls, so the columns are no longer the retired
+      "Schedule"/"Keep lines" pair -- ADR-60.)
       Background: pfBlockerNG deployed; General page authenticated and settled.
 
     Given the General page is loaded in the authenticated browser,
 
-    When the DOM is inspected for the new grouped-column structure,
+    When the DOM is inspected for the grouped-column structure,
 
-    Then the three column-header texts are visible on the page ("Max lines", "Schedule",
-      "Keep lines") — emitted by the per-category header ``Form_StaticText`` children;
+    Then the two column-header texts are visible on the page ("Max lines", "Max days") --
+      emitted by the per-category header ``Form_StaticText`` children;
     And the ``log_max_log`` control is present and its enclosing ``.form-group`` left label
-      (``col-sm-2.control-label``) shows the log name "pfBlockerNG" — proving per-log rows
-      carry the individual log name as the left label.
-
-    Plus the issue #489 follow-up polish (this commit), each a before/after discriminator:
-    And each category header row is a SHADED divider — its ``.form-group`` carries the
-      ``pfb-loghdr`` class (absent in the pre-polish layout);
-    And the IP rows are renamed to bare "Block"/"Permit"/"Match": the ``log_max_ip_blocklog``
-      row's left label reads "Block", NOT the old "IP Block" (so it fails on the old layout);
-    And the DNS-Reply log is now folded into the merged "DNS" category as the "Reply" row:
-      the ``log_max_dnsreplylog`` row's left label reads "Reply", NOT the old "DNS Reply";
-    And every control carries a per-control ``label.form-label`` (the mobile column label) —
-      the pre-polish layout emitted none.
+      (``col-sm-2.control-label``) shows the log name "pfBlockerNG" -- proving per-log rows
+      carry the individual log name as the left label;
+    And each category header row is a SHADED divider -- its ``.form-group`` carries the
+      ``pfb-loghdr`` class -- and there are EXACTLY three (General / IP / DNS);
+    And the IP rows read bare "Block"/"Permit"/"Match": the ``log_max_ip_blocklog`` row's left
+      label reads "Block", NOT "IP Block";
+    And the DNS-Reply log sits in the merged "DNS" category as the "Reply" row: the
+      ``log_max_dnsreplylog`` row's left label reads "Reply", NOT "DNS Reply";
+    And every log control carries a per-control ``label.form-label`` (the mobile column label):
+      one per Max-lines select and one per Max-days input, so the label count equals the
+      control count.
 
     A full-page screenshot is saved as a human-review artifact (not an asserted baseline).
     """
@@ -213,10 +215,10 @@ def test_log_settings_grouped_layout(
     _open(page, webui, GENERAL_PAGE)
     _shot(page, screenshot_dir, "log_settings_grouped_layout")
 
-    # Column header texts visible (emitted by the header Form_Group's StaticText children).
-    # exact=True so the "Schedule" header is not shadowed by the hidden "Schedules" nav
-    # link (/firewall_schedule.php), whose substring match would pick a hidden element.
-    for col_header in ("Max lines", "Schedule", "Keep lines"):
+    # Column header texts visible (emitted by each category header Form_Group's StaticText
+    # children). exact=True + .first targets a header cell rather than the longer intro
+    # sentence ("Max lines -- rolling cap ...") that also contains the word as a substring.
+    for col_header in ("Max lines", "Max days"):
         expect(page.get_by_text(col_header, exact=True).first).to_be_visible(timeout=JS_TIMEOUT_MS)
 
     # The log_max_log control's enclosing form-group carries the per-log label "pfBlockerNG".
@@ -237,10 +239,11 @@ def test_log_settings_grouped_layout(
     expect(_row_label("log_max_ip_blocklog")).to_have_text("Block", timeout=JS_TIMEOUT_MS)
     expect(_row_label("log_max_dnsreplylog")).to_have_text("Reply", timeout=JS_TIMEOUT_MS)
 
-    # EVERY log control carries a per-control mobile label (Form_Input label-start): three per
-    # log row (Max lines / Schedule / Keep lines). Derive the row count from the page (one
-    # log_max_* select per row) so the assertion tracks the real log list, then assert the full
-    # label count rather than just one -- proving every control is labelled, not merely some.
-    log_rows = page.locator('select[name^="log_max_"]').count()
-    assert log_rows >= 1, f"expected at least one log row (select[name^=log_max_]), found {log_rows}"
-    expect(page.locator("label.form-label")).to_have_count(log_rows * 3, timeout=JS_TIMEOUT_MS)
+    # EVERY log control carries a per-control mobile label (label-start, class form-label): two
+    # per log row -- a Max-lines select and a Max-days input. Count the actual controls on the
+    # page (the only label-start sources on the General page) and assert exactly that many
+    # form-labels, so the check tracks the real log list and proves every control is labelled,
+    # not merely some.
+    log_controls = page.locator('select[name^="log_max_"], input[name^="log_max_days_"]').count()
+    assert log_controls >= 2, f"expected Log Settings controls (log_max_* select/input), found {log_controls}"
+    expect(page.locator("label.form-label")).to_have_count(log_controls, timeout=JS_TIMEOUT_MS)


### PR DESCRIPTION
## Summary

The nightly UI fan-out went red on `devel` (run 29004328565): the `browser` tier failed on both CE and Plus while `render` and `functional` passed. The single failing test — `test_log_settings_grouped_layout` in `tests/smoke/ui/test_browser_general.py` — timed out waiting for the `Schedule` column header:

```
Error: element(s) not found
  - waiting for get_by_text("Schedule", exact=True).first
===== 1 failed, 44 passed, 1 skipped, 264 deselected =====
```

## Root cause

The test still asserted the retired three-column Log Settings layout (`Max lines` / `Schedule` / `Keep lines`). Commit f895422f ("www: replace scheduled-reset controls with log_max_days_<type> in Log Settings", ADR-60 P8) redesigned the General page to two columns (`Max lines` / `Max days`). That commit updated the Tier-A render test and the PHP unit test but did not update this Tier-B browser test. Because the browser tier is schedule/dispatch-only and never gates a PR, the nightly caught the mismatch rather than the P8 PR.

## Fix

Update the two stale assertions in `test_log_settings_grouped_layout` to the shipped layout:

- Column headers now expect `("Max lines", "Max days")` instead of the retired trio.
- The per-control mobile-label count is derived from the actual controls on the page (one `Max lines` select + one `Max days` input per row) rather than the old `rows * 3` constant, so it holds at exactly one `label.form-label` per control.

The remaining assertions (three `pfb-loghdr` category headers, the `Block`/`Reply` row labels, the `pfBlockerNG` left label) are unchanged and still hold on the new layout; the docstring is updated to match.

## Verification

- `py_compile`, `ruff check`, `ruff format --check`, `mypy tests/` all clean.
- RED is the nightly artifact above; GREEN is confirmed by a dispatched `browser`-tier run on this branch across CE + Plus (the tier can't run off-appliance). The corrected assertions mirror the PHP source and the green Tier-A render test that asserts the same structure over HTTP.

Fixes #1044.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuLqhx8khdBeB2VaCzUD7R)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated browser test coverage for the log settings grouped layout to match the current interface.
  * Improved checks for displayed labels and per-log controls, ensuring the page layout is validated more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->