### PR TITLE
pfblockerng: extract testable DNSBL/IP parse seams (#993, #995)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4498,6 +4498,14 @@ function pfb_ip_parsed_fail($header, $line, $oline, $logfile, $lineno) {
 }
 
 
+// issue #993: per-feed parse-error summary wrapper extracted for unit coverage.
+function pfb_ip_parse_fail_warn($parse_fail, $header) {
+	if ($parse_fail > 0) {
+		pfb_logger("\n[!] Parse Errors [ {$header} ]: {$parse_fail}\n", 2);
+	}
+}
+
+
 // Record failed IP/DNSBL Feed parse errors
 // issue #1004: trailing optional $lineno keeps existing 4-arg callers call-safe.
 function pfb_parsed_fail($header, $line='', $oline, $logfile, $lineno = '') {
@@ -4519,6 +4527,14 @@ function pfb_parsed_fail($header, $line='', $oline, $logfile, $lineno = '') {
 // a v4 list reading the v4 section instead of the stale v6 one (#709).
 function pfb_list_section_for_vtype(string $vtype): string {
 	return ($vtype === '_v6') ? 'pfblockernglistsv6' : 'pfblockernglistsv4';
+}
+
+
+// issue #993: opposite-family predicate extracted for unit coverage. A syntactically
+// valid address of the list's OTHER family is not a parse failure (mixed-family feeds).
+function pfb_ip_is_opposite_family(string $line, string $vtype): bool {
+	return ($vtype === '_v4' && str_contains($line, ':') && validate_ipv6($line)) ||
+		($vtype === '_v6' && !str_contains($line, ':') && validate_ipv4($line));
 }
 
 // Drop the Blacklist categories whose download Failed, matching by feed NAME in the
@@ -6539,6 +6555,20 @@ function pfb_dnsbl_is_abp_header($line) {
 	return (str_starts_with($hline, '[Adblock') ||
 		str_starts_with($hline, '[uBlock') ||
 		str_starts_with($hline, '! Title:'));
+}
+
+
+// issue #995: DNSBL '#'-marker classifier extracted for unit coverage. Flags are
+// report-only (never clear a caller's existing state) -- a plain '#' comment line
+// returns all-false/null and the caller must leave rev_format/csv_type untouched.
+function pfb_dnsbl_hash_line_classify(string $line): array {
+	if (str_contains($line, 'Append critical updates below')) {
+		return ['stop' => TRUE, 'rev_format' => FALSE, 'csv_type' => NULL, 'csv_parser' => FALSE];
+	}
+	$rev_format = str_contains($line, 'The Spamhaus Project Ltd');
+	$csv_type = ($line === '#family,type,url,status,first_seen,'
+			. 'first_active,last_active,last_update') ? 'h3x' : NULL;
+	return ['stop' => FALSE, 'rev_format' => $rev_format, 'csv_type' => $csv_type, 'csv_parser' => ($csv_type === 'h3x')];
 }
 
 
@@ -16355,19 +16385,21 @@ function sync_package_pfblockerng($cron='') {
 												// BEFORE the generic '!'/'//' skip below since these side effects
 												// (hpHosts end marker, Spamhaus format, h3x CSV header) must run.
 												if (str_starts_with($line, '#')) {
+													$pfb_hash_class = pfb_dnsbl_hash_line_classify($line);
 													// Exit (hpHosts) when end of domain names found.
-													if (strpos($line, 'Append critical updates below') !== FALSE) {
+													if ($pfb_hash_class['stop']) {
 														break;
 													}
 
 													// Spamhaus format validation
-													if (strpos($line, 'The Spamhaus Project Ltd') !== FALSE) {
+													if ($pfb_hash_class['rev_format']) {
 														$rev_format = TRUE;
 													}
 
-													if ($line == '#family,type,url,status,first_seen,'
-															. 'first_active,last_active,last_update') {
-														$csv_type	= 'h3x';
+													if ($pfb_hash_class['csv_type'] !== NULL) {
+														$csv_type	= $pfb_hash_class['csv_type'];
+													}
+													if ($pfb_hash_class['csv_parser']) {
 														$csv_parser	= TRUE;
 													}
 													continue;
@@ -18237,9 +18269,7 @@ function sync_package_pfblockerng($cron='') {
 										// common, and the family this list doesn't collect is silently
 										// skipped either way (same as any hex-lettered opposite-family
 										// address already is, uncounted). Only flag genuine garbage.
-										$other_family_addr =
-											($list['vtype'] == '_v4' && str_contains($line, ':') && validate_ipv6($line)) ||
-											($list['vtype'] == '_v6' && !str_contains($line, ':') && validate_ipv4($line));
+										$other_family_addr = pfb_ip_is_opposite_family($line, $list['vtype']);
 
 										if (!$other_family_addr) {
 											$parse_fail++;
@@ -18261,9 +18291,7 @@ function sync_package_pfblockerng($cron='') {
 							// line above (a rarely-configured per-list Pre Script tunable can print
 							// its own newline-terminated line first instead -- one harmless extra
 							// blank line in that case, not a rejoin).
-							if ($parse_fail > 0) {
-								pfb_logger("\n[!] Parse Errors [ {$header} ]: {$parse_fail}\n", 2);
-							}
+							pfb_ip_parse_fail_warn($parse_fail, $header);
 							pfb_logger("\n", 1);
 
 							// IP v4/6 Advanced Tunable - (Post Script processing)

--- a/tests/php/PfbDnsblHashLineClassifyTest.php
+++ b/tests/php/PfbDnsblHashLineClassifyTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_hash_line_classify() -- issue #995. Pure classifier for a DNSBL feed's
+ * '#'-prefixed line: hpHosts end marker (stop), Spamhaus format banner (rev_format),
+ * and the exact h3x CSV header (csv_type/csv_parser). Flags are report-only -- the
+ * caller only WRITES a flag when the classifier reports it, so a plain comment line
+ * must leave the caller's existing rev_format/csv_type/csv_parser state untouched.
+ */
+#[CoversFunction('pfb_dnsbl_hash_line_classify')]
+final class PfbDnsblHashLineClassifyTest extends TestCase
+{
+	public function testHpHostsMarkerStopsRegardlessOfOtherContent(): void
+	{
+		// hpHosts end marker is checked FIRST and short-circuits the rest.
+		$c = pfb_dnsbl_hash_line_classify('# Append critical updates below this line');
+		$this->assertTrue($c['stop']);
+		$this->assertFalse($c['rev_format']);
+		$this->assertNull($c['csv_type']);
+		$this->assertFalse($c['csv_parser']);
+	}
+
+	public function testSpamhausLineSetsRevFormat(): void
+	{
+		$c = pfb_dnsbl_hash_line_classify('# Copyright (c) The Spamhaus Project Ltd');
+		$this->assertFalse($c['stop']);
+		$this->assertTrue($c['rev_format']);
+		$this->assertNull($c['csv_type']);
+		$this->assertFalse($c['csv_parser']);
+	}
+
+	public function testExactH3xHeaderSetsCsvTypeAndParser(): void
+	{
+		$c = pfb_dnsbl_hash_line_classify(
+			'#family,type,url,status,first_seen,first_active,last_active,last_update'
+		);
+		$this->assertFalse($c['stop']);
+		$this->assertFalse($c['rev_format']);
+		$this->assertSame('h3x', $c['csv_type']);
+		$this->assertTrue($c['csv_parser']);
+	}
+
+	public function testPlainCommentLineIsSkipOnlyNoFlagsSet(): void
+	{
+		// A plain '#' comment: caller must not overwrite existing rev_format/csv_type/
+		// csv_parser state -- this predicate reports nothing so the caller writes nothing.
+		$c = pfb_dnsbl_hash_line_classify('# just a regular comment line');
+		$this->assertFalse($c['stop']);
+		$this->assertFalse($c['rev_format']);
+		$this->assertNull($c['csv_type']);
+		$this->assertFalse($c['csv_parser']);
+	}
+
+	public function testNearMissH3xHeaderMissingColumnDoesNotSetCsvType(): void
+	{
+		// Defeats vacuity on the exact-equality guard: one column dropped.
+		$c = pfb_dnsbl_hash_line_classify(
+			'#family,type,url,status,first_seen,first_active,last_active'
+		);
+		$this->assertNull($c['csv_type']);
+		$this->assertFalse($c['csv_parser']);
+	}
+
+	public function testNearMissH3xHeaderExtraColumnDoesNotSetCsvType(): void
+	{
+		// Defeats vacuity on the exact-equality guard: one column added.
+		$c = pfb_dnsbl_hash_line_classify(
+			'#family,type,url,status,first_seen,first_active,last_active,last_update,extra'
+		);
+		$this->assertNull($c['csv_type']);
+		$this->assertFalse($c['csv_parser']);
+	}
+}

--- a/tests/php/PfbIpOppositeFamilyTest.php
+++ b/tests/php/PfbIpOppositeFamilyTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_ip_is_opposite_family() -- issue #993. A syntactically valid address of the
+ * list's OTHER family (colon-bearing IPv6 in a '_v4' list, or dotted IPv4 in a
+ * '_v6' list) is not a parse failure -- mixed-family feeds are common. Inputs are
+ * letter-free (production only reaches this predicate for lines that already
+ * passed the caller's no-letters regex guard).
+ *
+ * Scenario: both families x {collected, opposite, garbage}.
+ */
+#[CoversFunction('pfb_ip_is_opposite_family')]
+final class PfbIpOppositeFamilyTest extends TestCase
+{
+	public static function cases(): array
+	{
+		return [
+			'_v4 list, collected v4 address'  => ['_v4', '1.2.3.4', false],
+			'_v4 list, opposite v6 address'   => ['_v4', '2000::1', true],
+			'_v4 list, garbage'               => ['_v4', '999.999.999.999', false],
+			'_v6 list, collected v6 address'  => ['_v6', '2000::1', false],
+			'_v6 list, opposite v4 address'   => ['_v6', '1.2.3.4', true],
+			'_v6 list, garbage'               => ['_v6', '1.2.3', false],
+		];
+	}
+
+	#[DataProvider('cases')]
+	public function testOppositeFamilyClassification(string $vtype, string $line, bool $expected): void
+	{
+		$this->assertSame($expected, pfb_ip_is_opposite_family($line, $vtype));
+	}
+}

--- a/tests/php/PfbIpParseFailWarnTest.php
+++ b/tests/php/PfbIpParseFailWarnTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_ip_parse_fail_warn() -- issue #993. Per-feed IP parse-error summary: one
+ * WARNING line naming the feed + the final count, emitted only when $parse_fail>0
+ * (the fix that replaced one spammed log line PER failed line). logtype 2 writes
+ * both the main pfBlockerNG log ($pfb['log']) and the Error log ($pfb['errlog']);
+ * both are pointed at temp files so the guard is asserted on the primary log.
+ */
+#[CoversFunction('pfb_ip_parse_fail_warn')]
+final class PfbIpParseFailWarnTest extends TestCase
+{
+	/** @var string[] temp files to remove in tearDown */
+	private array $tmpfiles = [];
+
+	private mixed $prevLog = false;
+	private mixed $prevErrLog = false;
+
+	protected function setUp(): void
+	{
+		$this->prevLog = array_key_exists('log', $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb']['log'] : false;
+		$this->prevErrLog = array_key_exists('errlog', $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb']['errlog'] : false;
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->prevLog === false) {
+			unset($GLOBALS['pfb']['log']);
+		} else {
+			$GLOBALS['pfb']['log'] = $this->prevLog;
+		}
+		if ($this->prevErrLog === false) {
+			unset($GLOBALS['pfb']['errlog']);
+		} else {
+			$GLOBALS['pfb']['errlog'] = $this->prevErrLog;
+		}
+		foreach ($this->tmpfiles as $f) {
+			if (is_file($f)) {
+				$this->assertTrue(unlink($f), "failed to remove temp file {$f}");
+			}
+		}
+		$this->tmpfiles = [];
+	}
+
+	private function mktemp(string $prefix): string
+	{
+		$path = tempnam(sys_get_temp_dir(), $prefix);
+		$this->assertNotFalse($path, "tempnam({$prefix}) failed");
+		$this->tmpfiles[] = $path;
+		$this->assertNotFalse(file_put_contents($path, ''), "could not truncate {$path}");
+		return $path;
+	}
+
+	private function readFile(string $path): string
+	{
+		$raw = file_get_contents($path);
+		$this->assertNotFalse($raw, "could not read {$path}");
+		return (string) $raw;
+	}
+
+	public function testNoWarningWrittenWhenParseFailIsZero(): void
+	{
+		$mainlog = $this->mktemp('pfb_main_log_');
+		$errlog  = $this->mktemp('pfb_err_log_');
+		$GLOBALS['pfb']['log']    = $mainlog;
+		$GLOBALS['pfb']['errlog'] = $errlog;
+
+		pfb_ip_parse_fail_warn(0, 'TestFeed_v4');
+
+		$this->assertSame('', $this->readFile($mainlog));
+		$this->assertSame('', $this->readFile($errlog));
+	}
+
+	public function testWarningWrittenOnceWithFeedAndCountWhenParseFailPositive(): void
+	{
+		$mainlog = $this->mktemp('pfb_main_log_');
+		$errlog  = $this->mktemp('pfb_err_log_');
+		$GLOBALS['pfb']['log']    = $mainlog;
+		$GLOBALS['pfb']['errlog'] = $errlog;
+
+		pfb_ip_parse_fail_warn(5, 'TestFeed_v4');
+
+		$logged = $this->readFile($mainlog);
+		$this->assertStringContainsString('[!] Parse Errors [ TestFeed_v4 ]: 5', $logged);
+		$this->assertSame(1, substr_count($logged, 'Parse Errors ['));
+	}
+}


### PR DESCRIPTION
## Summary

Picks off the highest-risk per-line parsing pieces of the `sync_package_pfblockerng()` monolith into small pure helpers, each pinned with dedicated PHPUnit coverage — the established escape hatch (`pfb_dnsbl_scheme_line()`, `pfb_is_blank_or_comment_line()`, the `*HelpersTest.php` suites) applied to the newest, most bug-prone branches. Behaviour is preserved byte-for-byte at all three call sites; the full existing suite staying green is the preservation proof.

Three extractions:

- **`pfb_dnsbl_hash_line_classify(string $line): array`** — the DNSBL hosts-format `#`-prefix block that mixed a skip decision with format side effects (hpHosts end-of-list `break`, Spamhaus `$rev_format` detection, h3x CSV-header sniffing). This is the exact block quoted in #995. The classifier is pure and report-only: a plain `#` comment returns all-false/null so the caller never clobbers existing `rev_format`/`csv_type`/`csv_parser` state, and the exact two-part h3x header literal is preserved.
- **`pfb_ip_is_opposite_family(string $line, string $vtype): bool`** — the mixed-family parse-failure guard (`$other_family_addr`, PR #996), which previously had zero test references anywhere. A syntactically valid opposite-family address (a hex-letter-free IPv6 line in a `_v4` list, or an IPv4 line in a `_v6` list) is not counted as a parse failure.
- **`pfb_ip_parse_fail_warn($parse_fail, $header)`** — the per-feed `[!] Parse Errors [ N ]` summary emission (mirrors the existing `pfb_dnsbl_scheme_skip_warn()`), pinning the `> 0` guard that replaced the old one-line-per-failure spam.

## Tests

New `tests/php/` suites, one per helper (14 tests / 45 assertions):

- `PfbDnsblHashLineClassifyTest` — hpHosts stop, Spamhaus `rev_format`, exact h3x header, plain-comment no-op, and two near-miss headers (missing/extra column) that defeat vacuity on the exact-equality guard.
- `PfbIpOppositeFamilyTest` — both families × {collected, opposite, garbage}.
- `PfbIpParseFailWarnTest` — `$parse_fail = 0` emits nothing (the guarded branch), positive count emits exactly one feed-named summary line; captures logtype-2's dual `log` + `errlog` fan-out.

These are behaviour-preserving oracle tests; non-vacuity was verified by reverting each new helper's body and observing the corresponding assertion go red, then restoring to green.

## Verification

`php -l`, `vendor/bin/phpunit` (2550 tests, green), `vendor/bin/phpstan` (no errors), and `vendor/bin/phpcs --standard=phpcs.xml.dist src/` (clean) all pass.

## Scope

Fixes #993 — the highest-risk, newest parse branches named there now have direct PHPUnit coverage: the opposite-family exclusion (E2, the concrete PR #996 instance the maintainer's follow-up flagged as the priority to cover), the per-feed Parse-Errors summary (E3), plus #995's flagship `#`-classifier (E1). The generic IP-list `!`-comment skip also named in #993 was already covered pre-existing (`pfb_is_blank_or_comment_line()` + `BlankOrCommentLineTest`).

One branch #993 lists is intentionally left for a future increment: the DNSBL **body-loop** `!`/`//` comment skip (`pfblockerng.inc` ~16412), a trivial two-condition inline predicate. It is not silently dropped — it is tracked under #995, which stays open as the standing tracker for this function's overall size and its continued per-line-parsing extraction. Three small pure extractions do not meaningfully reduce a 4400+-line function, so #995 remains the ongoing home for that work.