### PR TITLE
Fix the 48h-review findings from the ADR-60/ADR-61 window (10 issues)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1036,6 +1036,49 @@ def _load_hsts_db() -> None:
         pfb_py_status_open("dnsbl", pfb["pfb_py_hsts"], "parse", "Failed to load: {}: {}".format(pfb["pfb_py_hsts"], e))
 
 
+def _load_zone_and_data_dbs(dnsbl_built: bool, feed_group_db: defaultdict[str, int], feed_group_index: int) -> int:
+    """Run the legacy zone/data CSV loaders when the ADR-06 manifest build did NOT
+    already supply them; otherwise close the parse-stage entries they would own --
+    a manifest-built init means neither loader ran this pass (issue #1049)."""
+    if not dnsbl_built:
+        feed_group_index = _load_zone_db(feed_group_db, feed_group_index)
+        feed_group_index = _load_data_db(feed_group_db, feed_group_index)
+    else:
+        pfb_py_status_close("dnsbl", pfb["pfb_py_zone"], "parse")
+        pfb_py_status_close("dnsbl", pfb["pfb_py_data"], "parse")
+    return feed_group_index
+
+
+def _load_whitelist_and_hsts_dbs(dnsbl_built: bool) -> None:
+    """Run whitelist/HSTS loading when the blacklist gate is on -- whitelist is
+    skipped when the manifest already built it (ADR-06); otherwise (blacklist
+    OFF) close both parse-stage entries, since neither loader runs this pass
+    (issue #1049)."""
+    if pfb["python_blacklist"]:
+        if not dnsbl_built:
+            _load_whitelist_db()
+        else:
+            pfb_py_status_close("dnsbl", pfb["pfb_py_whitelist"], "parse")
+        _load_hsts_db()
+    else:
+        pfb_py_status_close("dnsbl", pfb["pfb_py_whitelist"], "parse")
+        pfb_py_status_close("dnsbl", pfb["pfb_py_hsts"], "parse")
+
+
+def _close_dnsbl_loader_entries_when_disabled() -> None:
+    """python_enable OFF skips every DNSBL loader this pass -- close every
+    parse-stage entry a prior init could have left open (issue #1049)."""
+    for item in (
+        pfb["pfb_py_sources"],
+        pfb["pfb_py_zone"],
+        pfb["pfb_py_data"],
+        pfb["pfb_py_whitelist"],
+        pfb["pfb_py_hsts"],
+        pfb["pfb_py_ss"],
+    ):
+        pfb_py_status_close("dnsbl", item, "parse")
+
+
 def _load_ini_config() -> ConfigParser | None:
     """Parse ``pfb["pfb_unbound.ini"]`` -- extracted out of ``init_standard`` (same
     extraction rationale as ``_load_zone_db``) so the load -- and its failure
@@ -1634,25 +1677,14 @@ def init_standard(id: int, env: module_env) -> bool:
             # While reading 'data|zone' CSV files: Replace 'Feed/Group' pairs with an index value (Memory performance)
             feedGroup_index = 0
 
-            # Zone dicts
-            if not dnsbl_built:
-                feedGroup_index = _load_zone_db(feedGroupDB, feedGroup_index)
-
-            # Data dicts
-            if not dnsbl_built:
-                feedGroup_index = _load_data_db(feedGroupDB, feedGroup_index)
+            # Zone/Data dicts -- or close their entries when the manifest built them.
+            feedGroup_index = _load_zone_and_data_dbs(dnsbl_built, feedGroupDB, feedGroup_index)
 
             # Clear temporary Feed/Group/Index list
             feedGroupDB.clear()
 
-            if pfb["python_blacklist"]:
-                # Collect user-defined Whitelist (legacy CSV path -- the build()
-                # already loaded whiteDB from the manifest config when dnsbl_built).
-                if not dnsbl_built:
-                    _load_whitelist_db()
-
-                # HSTS dicts
-                _load_hsts_db()
+            # Whitelist/HSTS dicts -- or close their entries when the blacklist gate is off.
+            _load_whitelist_and_hsts_dbs(dnsbl_built)
 
             # ADR-07: emit the ADMITTED regex total for the DNSBL_Regex UI alias
             # (inc:8329). regexDB now holds USER regex (REGEX-ini) + FEED block regex
@@ -1690,6 +1722,10 @@ def init_standard(id: int, env: module_env) -> bool:
                 except Exception as e:
                     sys.stderr.write("[pfBlockerNG]: Failed to open MaxMind DB: {}".format(e))
                     pass
+        else:
+            # issue #1049: python_enable OFF skips every DNSBL loader above --
+            # close their parse-stage entries instead of stranding them open.
+            _close_dnsbl_loader_entries_when_disabled()
     else:
         log_info("[pfBlockerNG]: Failed to load ini configuration. Ini file missing.")
 
@@ -5248,6 +5284,9 @@ def dnsbl_build_from_manifest(manifest_path: str) -> BuildResult | None:
     CSV load -- shell/PHP still produce those files for that fallback).
     """
     if not os.path.isfile(manifest_path):
+        # issue #1049: close an orphaned prior parse-stage entry -- mirrors the
+        # 6 CSV-loader sites' absent-file close (af3da0ec).
+        pfb_py_status_close("dnsbl", manifest_path, "parse")
         return None
 
     try:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2971,6 +2971,30 @@ function pfb_log_age_trim_write_ok($written, string $content): bool {
 	return $written !== FALSE && $written === strlen($content);
 }
 
+// issue #1052: probe-before-copy for the 'nolimit'+age-cap path -- log lines are
+// chronologically appended, so an unexpired FIRST line means nothing in $path can
+// be expired; the caller skips its whole copy()+age-trim pass this tick. An
+// unparseable/legacy first line falls through to TRUE (pass must run), matching
+// pfb_log_age_cutoff()'s own "unparseable = expired" rule.
+function pfb_log_age_nolimit_pass_needed(string $path, int $agedays, string $logtype): bool {
+	$fh = @fopen($path, 'r');
+	if ($fh === FALSE) {
+		return TRUE;
+	}
+	$first = fgets($fh);
+	fclose($fh);
+	if ($first === FALSE) {
+		return TRUE; // empty file -- let the existing pass handle it (no-op either way)
+	}
+
+	$ts = pfb_log_line_timestamp(rtrim($first, "\r\n"), pfb_log_age_field_mode($logtype));
+	if ($ts === NULL) {
+		return TRUE; // unparseable/legacy first line -- must run the full pass
+	}
+
+	return $ts < (time() - ($agedays * 86400));
+}
+
 // Manage log files line limit + age-based retention (ADR-60)
 function pfb_log_mgmt() {
 	global $g, $pfb;
@@ -3007,6 +3031,13 @@ function pfb_log_mgmt() {
 				}
 
 				if (file_exists($final_log_file)) {
+					// issue #1052: 'nolimit'+age-cap -- skip the whole copy()+age-trim
+					// pass this tick when the first (oldest) line hasn't expired yet.
+					if ($logmax === 'nolimit' && !pfb_log_age_nolimit_pass_needed($final_log_file, $agedays, $logtype)) {
+						unlink_if_exists($temp);
+						continue;
+					}
+
 					// Truncate in place to preserve the inode (#264): mv replaces the
 					// inode, so a remote syslog shipper keyed on (inode, offset) treats
 					// it as a rotation and re-sends the whole log. cat over '>' keeps the
@@ -3039,6 +3070,11 @@ function pfb_log_mgmt() {
 			}
 			else {
 				$temp = tempnam("{$g['tmp_path']}/", 'pfb_log_');
+				// issue #1052: same nolimit+age-cap skip as the chroot branch above.
+				if ($logmax === 'nolimit' && !pfb_log_age_nolimit_pass_needed($pfb[$logtype], $agedays, $logtype)) {
+					unlink_if_exists($temp);
+					continue;
+				}
 				// Truncate in place to preserve the inode (#264) - see above. Gate on
 				// each exit code so a failed tail/cat cannot truncate the live log.
 				if ($logmax === 'nolimit') {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2961,7 +2961,14 @@ function pfb_log_age_trim_temp(string $temp, int $days, string $logtype, bool $u
 	}
 	$kept = pfb_log_age_cutoff($lines, $cutoff_ts, $field_mode);
 	$content = $kept ? implode("\n", $kept) . "\n" : '';
-	return file_put_contents($temp, $content) !== FALSE;
+	return pfb_log_age_trim_write_ok(file_put_contents($temp, $content), $content);
+}
+
+// issue #1053: a short (partial, non-FALSE) write must count as failure -- else a
+// disk-full write silently truncates the candidate that then gets cat-ed over the
+// live log. Mirrors pfb_prefetch_pattern_file_write_ok()'s decision shape.
+function pfb_log_age_trim_write_ok($written, string $content): bool {
+	return $written !== FALSE && $written === strlen($content);
 }
 
 // Manage log files line limit + age-based retention (ADR-60)

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -16119,6 +16119,9 @@ function sync_package_pfblockerng($cron='') {
 				$pfb['aliasupdate']	= FALSE;		// Flag to signal changes to alias
 				$pfb['domain_clear']	= FALSE;		// Flag to signal no Aliases defined or all Aliases disabled.
 				$alias_cnt		= 0;
+				// issue #1048: per-alias-pass failure flag -- a sibling feed's success must
+				// never close a DIFFERENT feed's still-open download-failure ledger entry.
+				$pfb_dl_failed		= FALSE;
 
 				if ($list['action'] != 'Disabled' && isset($list['row'])) {
 					$alias				= "DNSBL_{$list['aliasname']}";
@@ -16261,6 +16264,9 @@ function sync_package_pfblockerng($cron='') {
 											pfb_download_failure($alias, $header, $pfbfolder, $row['url'], $row['format'], '');
 											// ADR-61: keyed on $alias (pfB_/DNSBL_-prefixed), not $header --
 											// the widget's deep-link match needs that prefix (issue #998).
+											// issue #1048: close moves to once-per-alias-pass below, so a
+											// sibling feed's success can never mask this failure.
+											$pfb_dl_failed = TRUE;
 											pfb_dnsbl_download_ledger_update(FALSE, $alias, "[ {$alias} - {$header} ] Download FAIL", $pfb['dbdir']);
 
 											// Utilize previously download file (If 'fail' marker exists)
@@ -16275,7 +16281,6 @@ function sync_package_pfblockerng($cron='') {
 										else {
 											// Clear any previous download fail marker
 											unlink_if_exists("{$pfbfolder}/{$header}.fail");
-											pfb_dnsbl_download_ledger_update(TRUE, $alias, '', $pfb['dbdir']);
 										}
 									}
 								}
@@ -16890,6 +16895,13 @@ function sync_package_pfblockerng($cron='') {
 								}
 							}
 						}
+					}
+
+					// issue #1048: close the download ledger entry once for the WHOLE
+					// alias-pass, iff no row in it failed -- a per-row close let a later
+					// feed's success mask an earlier feed's still-live failure.
+					if (!$pfb_dl_failed) {
+						pfb_dnsbl_download_ledger_update(TRUE, $alias, '', $pfb['dbdir']);
 					}
 
 					// ADR-12: record GENUINELY-changed DNSBL groups for
@@ -17835,6 +17847,9 @@ function sync_package_pfblockerng($cron='') {
 					pfb_logger("\n Invalid Aliasname:{$list['aliasname']}{$list['vtype']}, *skipping*", 1);
 					continue;
 				}
+				// issue #1048: per-alias-pass failure flag -- a sibling feed's success must
+				// never close a DIFFERENT feed's still-open download-failure ledger entry.
+				$pfb_dl_failed = FALSE;
 
 				foreach	($list['row'] as $row) {
 					if (!empty($row['url']) && $row['state'] != 'Disabled') {
@@ -18011,6 +18026,9 @@ function sync_package_pfblockerng($cron='') {
 										// $alias (the pfB_*-prefixed table name), not $header (the per-row label,
 										// never prefixed) -- the widget's deep-link recognition matches on the
 										// pfB_/DNSBL_ prefix, so keying on $header would leave every entry unlinked.
+										// issue #1048: close moves to once-per-alias-pass below, so a
+										// sibling feed's success can never mask this failure.
+										$pfb_dl_failed = TRUE;
 										pfb_ip_download_ledger_update(FALSE, $alias, "[ {$alias} - {$header} ] Download FAIL", $pfb['dbdir']);
 
 										// Utilize previously download file (If 'fail' marker exists)
@@ -18030,7 +18048,6 @@ function sync_package_pfblockerng($cron='') {
 									else {
 										// Clear any previous download fail marker
 										unlink_if_exists("{$pfbfolder}/{$header}.fail");
-										pfb_ip_download_ledger_update(TRUE, $alias, '', $pfb['dbdir']);
 										pfb_logger('.', 1);
 									}
 								}
@@ -18453,6 +18470,13 @@ function sync_package_pfblockerng($cron='') {
 							}
 						}
 					}
+				}
+
+				// issue #1048: close the download ledger entry once for the WHOLE
+				// alias-pass, iff no row in it failed -- a per-row close let a later
+				// feed's success mask an earlier feed's still-live failure.
+				if (!$pfb_dl_failed) {
+					pfb_ip_download_ledger_update(TRUE, $alias, '', $pfb['dbdir']);
 				}
 			}
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3152,10 +3152,12 @@ function pfb_filterlog_timestamp(array $f, string $log_type, int $now): string {
 }
 
 // issue #1054: TRUE when $path's NEXT pfb_logger() write starts a new physical
-// line -- the file is absent/empty, or its last byte is "\n". Called once per
-// path per process; pfb_logger_format_for_target()'s static cache takes over
-// after that from each write's own outcome.
+// line -- the file is absent/empty, or its last byte is "\n". Probed on EVERY
+// write, never cached: other writers append to these same files in-process
+// (hook-output persistence :4250, pfb_open_sqlite() errlog writes) and a
+// short write can leave the file mid-line, so only the real last byte is safe.
 function pfb_logger_target_starts_at_bol(string $path): bool {
+	clearstatcache(FALSE, $path);
 	if (!file_exists($path) || @filesize($path) === 0) {
 		return TRUE;
 	}
@@ -3177,18 +3179,9 @@ function pfb_logger_target_starts_at_bol(string $path): bool {
 // leading run of "\n" always forces BOL for what follows (it just ended the
 // previous line), matching the existing leading-newline convention.
 function pfb_logger_format_for_target(string $path, string $raw, int $lead, string $now): string {
-	static $bol = array();
-
-	if (!array_key_exists($path, $bol)) {
-		$bol[$path] = pfb_logger_target_starts_at_bol($path);
-	}
-
-	$formatted = ($lead > 0 || $bol[$path])
+	return ($lead > 0 || pfb_logger_target_starts_at_bol($path))
 		? substr($raw, 0, $lead) . "{$now} " . substr($raw, $lead)
 		: $raw;
-
-	$bol[$path] = (substr($formatted, -1) === "\n");
-	return $formatted;
 }
 
 function pfb_logger($log, $logtype) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3151,6 +3151,46 @@ function pfb_filterlog_timestamp(array $f, string $log_type, int $now): string {
 	return ($ts === FALSE) ? pfb_log_iso_timestamp() : date('Y-m-d H:i:s', $ts);
 }
 
+// issue #1054: TRUE when $path's NEXT pfb_logger() write starts a new physical
+// line -- the file is absent/empty, or its last byte is "\n". Called once per
+// path per process; pfb_logger_format_for_target()'s static cache takes over
+// after that from each write's own outcome.
+function pfb_logger_target_starts_at_bol(string $path): bool {
+	if (!file_exists($path) || @filesize($path) === 0) {
+		return TRUE;
+	}
+	$fh = @fopen($path, 'rb');
+	if ($fh === FALSE) {
+		return TRUE;
+	}
+	fseek($fh, -1, SEEK_END);
+	$last = fread($fh, 1);
+	fclose($fh);
+	return $last === "\n";
+}
+
+// issue #1054 (ADR-60's stamped-unit contract: the physical LINE, not the
+// write): decide + apply the ISO stamp for ONE target file, independently of
+// every other sink pfb_logger() writes -- a sub-line progress fragment (e.g.
+// pfb_logger('.', 1)) must not get a mid-line stamp just because a DIFFERENT
+// target happens to be at BOL. $raw is the caller's unstamped message; a
+// leading run of "\n" always forces BOL for what follows (it just ended the
+// previous line), matching the existing leading-newline convention.
+function pfb_logger_format_for_target(string $path, string $raw, int $lead, string $now): string {
+	static $bol = array();
+
+	if (!array_key_exists($path, $bol)) {
+		$bol[$path] = pfb_logger_target_starts_at_bol($path);
+	}
+
+	$formatted = ($lead > 0 || $bol[$path])
+		? substr($raw, 0, $lead) . "{$now} " . substr($raw, $lead)
+		: $raw;
+
+	$bol[$path] = (substr($formatted, -1) === "\n");
+	return $formatted;
+}
+
 function pfb_logger($log, $logtype) {
 	global $g, $pfb;
 
@@ -3160,8 +3200,6 @@ function pfb_logger($log, $logtype) {
 	// (among other callers) uses a leading "\n" as a separator from the PREVIOUS
 	// write, not this line's content.
 	$lead = strspn($log, "\n");
-	$log = substr($log, 0, $lead) . "{$now} " . substr($log, $lead);
-	$elog = $log;
 
 	// Mirror the main-log lines into the per-run log while a run is active (set by
 	// sync_package_pfblockerng). The live Update viewer tails this file; the cumulative log is
@@ -3169,46 +3207,54 @@ function pfb_logger($log, $logtype) {
 	// call from a normal page never pollutes it.
 	$runlog = (!empty($pfb['runlog']) && !empty($pfb['runlog_active'])) ? $pfb['runlog'] : '';
 
+	// issue #1054: $log_out mirrors whatever was decided for $pfb['log'] (cases 1/2)
+	// to the STDOUT copy below -- STDOUT isn't a probed target of its own, it only
+	// ever echoes the SAME bytes already committed to the main log file.
+	$log_out = $log;
+
 	switch ($logtype) {
 
 		// Print to pfBlockerNG log
 		case 1:
-			@file_put_contents("{$pfb['log']}", "{$log}", FILE_APPEND);
+			$log_out = pfb_logger_format_for_target($pfb['log'], $log, $lead, $now);
+			@file_put_contents("{$pfb['log']}", "{$log_out}", FILE_APPEND);
 			if ($runlog !== '') {
-				@file_put_contents($runlog, "{$log}", FILE_APPEND);
+				@file_put_contents($runlog, pfb_logger_format_for_target($runlog, $log, $lead, $now), FILE_APPEND);
 			}
 			break;
 
 		// Print to pfBlockerNG log and Error log
 		case 2:
-			@file_put_contents("{$pfb['log']}", "{$log}", FILE_APPEND);
-			@file_put_contents("{$pfb['errlog']}", "{$elog}", FILE_APPEND);
+			$log_out = pfb_logger_format_for_target($pfb['log'], $log, $lead, $now);
+			@file_put_contents("{$pfb['log']}", "{$log_out}", FILE_APPEND);
+			@file_put_contents("{$pfb['errlog']}", pfb_logger_format_for_target($pfb['errlog'], $log, $lead, $now), FILE_APPEND);
 			if ($runlog !== '') {
-				@file_put_contents($runlog, "{$log}", FILE_APPEND);
+				@file_put_contents($runlog, pfb_logger_format_for_target($runlog, $log, $lead, $now), FILE_APPEND);
 			}
 			break;
 
 		// Print to Extras log
 		case 3:
-			@file_put_contents("{$pfb['extraslog']}", "{$log}", FILE_APPEND);
+			@file_put_contents("{$pfb['extraslog']}", pfb_logger_format_for_target($pfb['extraslog'], $log, $lead, $now), FILE_APPEND);
 			break;
 
 		// Print to screen and Extras log
 		case 4:
+			$extras_out = pfb_logger_format_for_target($pfb['extraslog'], $log, $lead, $now);
 			if (!$g['pfblockerng_install'] && !$pfb['extras_update']) {
-				print "{$log}";
+				print "{$extras_out}";
 			}
-			@file_put_contents("{$pfb['extraslog']}", "{$log}", FILE_APPEND);
+			@file_put_contents("{$pfb['extraslog']}", "{$extras_out}", FILE_APPEND);
 			break;
 
 		// Print to debugger
 		case 5:
-			@file_put_contents("/tmp/pfb_debug", "{$elog}", FILE_APPEND);
+			@file_put_contents("/tmp/pfb_debug", pfb_logger_format_for_target('/tmp/pfb_debug', $log, $lead, $now), FILE_APPEND);
 			break;
 
 		// Print to Error log
 		case 6:
-			@file_put_contents("{$pfb['errlog']}", "{$elog}", FILE_APPEND);
+			@file_put_contents("{$pfb['errlog']}", pfb_logger_format_for_target($pfb['errlog'], $log, $lead, $now), FILE_APPEND);
 			break;
 		default:
 			break;
@@ -3228,7 +3274,7 @@ function pfb_logger($log, $logtype) {
 	// gap with no separate keepalive, since that wait already logs via case 1. The redirected update
 	// hooks and the detached rc.d daemons are untouched -- visibility only, not the process-safety.
 	if (($logtype == 1 || $logtype == 2) && pfb_run_streams_to_stdout()) {
-		print "{$log}";
+		print "{$log_out}";
 	}
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2985,13 +2985,30 @@ function pfb_dnsbl_download_ledger_update(bool $download_ok, string $item, strin
  */
 function pfb_sync_status_dedup_check(string $log_path, string $ledger_dir): void
 {
-	$lines = @file($log_path, FILE_IGNORE_NEW_LINES);
-	if (!is_array($lines)) {
+	// issue #1052: bounded tail read, not @file() of the WHOLE log -- a 'nolimit'
+	// log has no size cap. The sanity line is written every dedup pass, so the
+	// last match always sits within this trailing window.
+	$tail_bytes = 65536;
+
+	$fh = @fopen($log_path, 'rb');
+	if ($fh === FALSE) {
+		return;
+	}
+	$stat   = fstat($fh);
+	$size   = ($stat !== FALSE) ? $stat['size'] : 0;
+	$offset = ($size > $tail_bytes) ? $size - $tail_bytes : 0;
+	if (fseek($fh, $offset) === -1) {
+		fclose($fh);
+		return;
+	}
+	$tail = stream_get_contents($fh);
+	fclose($fh);
+	if ($tail === FALSE) {
 		return;
 	}
 
 	$last = '';
-	foreach ($lines as $line) {
+	foreach (explode("\n", $tail) as $line) {
 		if (strpos($line, 'Sanity check') !== FALSE) {
 			$last = $line;
 		}

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -414,7 +414,7 @@ if (in_array($argv[1], array('update', 'updateip', 'updatednsbl', 'dc', 'dcc', '
 function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $format, $vtype, $srcint=FALSE) {
 	global $pfb;
 
-	$log = "[ {$header} ] [ NOW ]\n";
+	$log = "[ {$header} ]\n";
 	pfb_logger("{$log}", 1);
 	$pfb['cron_update'] = FALSE;
 
@@ -630,7 +630,7 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 		$logtype = 4;
 	}
 
-	pfb_logger("\nDownload Process Starting [ NOW ]\n", $logtype);
+	pfb_logger("\nDownload Process Starting\n", $logtype);
 	foreach ($pfb['extras'] as $feed) {
 
 		if (empty($feed)) {
@@ -683,7 +683,7 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 			}
 		}
 	}
-	pfb_logger("Download Process Ended [ NOW ]\n\n", $logtype);
+	pfb_logger("Download Process Ended\n\n", $logtype);
 
 	if ($type == 'blacklist') {
 		print "{$pfb_return}";
@@ -709,7 +709,7 @@ function pfblockerng_sync_cron($force_all = FALSE, $scope = 'both') {
 	$hour = date('G');
 	$dow  = date('N');
 	$pfb['update_cron'] = FALSE;
-	$log = " CRON  PROCESS  START [ " . pfb_pkg_ver() . " ] [ NOW ]\n";
+	$log = " CRON  PROCESS  START [ " . pfb_pkg_ver() . " ]\n";
 	pfb_logger("{$log}", 1);
 
 	$list_type = array('pfblockernglistsv4' => '_v4', 'pfblockernglistsv6' => '_v6', 'pfblockerngdnsbl' => '_v4');
@@ -829,12 +829,12 @@ function pfblockerng_uc_countries() {
 		safe_mkdir ("{$folder}", 0755);
 	}
 
-	$log = "Country code update Start [ NOW ]\n";
+	$log = "Country code update Start\n";
 	pfb_logger("{$log}", 4);
 
 	$maxmind_cont = "{$pfb['geoipshare']}/GeoLite2-Country-Locations-{$pfb['maxmind_locale']}.csv";
 	if (!file_exists($maxmind_cont)) {
-		$log = " [ MAXMIND UPDATE FAIL, Language File Missing, using previous Country code database ] [ NOW ]\n";
+		$log = " [ MAXMIND UPDATE FAIL, Language File Missing, using previous Country code database ]\n";
 		pfb_logger("{$log}", 4); 
 		return;
 	}
@@ -1194,7 +1194,7 @@ function pfblockerng_uc_countries() {
 	// Collect Country ISO data and sort to Continent arrays (IPv4 and IPv6)
 	foreach (array('4', '6') as $type) {
 	
-		$log = " Processing ISO IPv{$type} Continent/Country Data [ NOW ]\n";
+		$log = " Processing ISO IPv{$type} Continent/Country Data\n";
 		pfb_logger("{$log}", 4);
 
 		$geoip_dup = 0;		// Count of Geoname_ids which have both a different 'Registered and Represented' geoname_id
@@ -1471,7 +1471,7 @@ function pfblockerng_get_countries() {
 				$tab = "\t";
 			}
 
-			$log = " IPv{$type} {$cont}{$tab} [ NOW ]\n";
+			$log = " IPv{$type} {$cont}{$tab}\n";
 			pfb_logger("{$log}", 4);
 
 			if ($type == '6') {
@@ -2193,7 +2193,7 @@ EOF;
 	//Build Reputation Tab
 	pfb_build_reputation_tab($et_options);
 
-	$log = "Country Code Update Ended [ NOW ]\n\n";
+	$log = "Country Code Update Ended\n\n";
 	pfb_logger("{$log}", 4);
 
 	// Unset arrays

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1841,14 +1841,17 @@ if ($alert_summary) {
 				case 'replydate':
 					// ISO date/time has 1 space token (not the old 3-token
 					// 'M j H:i:s'); the day bucket is the date field alone.
-					exec("{$cut_cmd} {$alert_log} | cut -d ' ' -f1 | uniq -c 2>&1", $stats);
+					// issue #1057: grep skips pre-ISO legacy lines (no digit-year prefix).
+					exec("{$cut_cmd} {$alert_log} | {$pfb['grep']} -E '^[0-9]{4}-' | cut -d ' ' -f1 | uniq -c 2>&1", $stats);
 					$stats = array_reverse($stats);
 					break;
 				case 'dnsbldatehr':
-					exec("{$cut_cmd} {$alert_log} | cut -d ':' -f1 | sort | uniq -c | sort -nr 2>&1", $stats);
+					// issue #1057: grep skips pre-ISO legacy lines (no digit-year prefix).
+					exec("{$cut_cmd} {$alert_log} | {$pfb['grep']} -E '^[0-9]{4}-' | cut -d ':' -f1 | sort | uniq -c | sort -nr 2>&1", $stats);
 					break;
 				case 'dnsbldatehrmin':
-					exec("{$cut_cmd} {$alert_log} | cut -d ':' -f1,2 | sort | uniq -c | sort -nr 2>&1", $stats);
+					// issue #1057: grep skips pre-ISO legacy lines (no digit-year prefix).
+					exec("{$cut_cmd} {$alert_log} | {$pfb['grep']} -E '^[0-9]{4}-' | cut -d ':' -f1,2 | sort | uniq -c | sort -nr 2>&1", $stats);
 					break;
 				case 'dnsblchart':
 				case 'replychart':
@@ -5070,8 +5073,9 @@ foreach ($stats as $stat_type => $stype):
 							if ($stat_type == 'dnsbldatehr' || $stat_type == 'dnsbldatehrmin') {
 								// ISO bucket key is 2 space-tokens (date, hour[:min]), not the
 								// old 3-token "Mon D HH" shape -- label as "date (hour[:min])".
+								// issue #1057: a truncated/corrupt key has no 2nd token.
 								$d = explode (' ', $data);
-								$data = "{$d[0]}&emsp;({$d[1]})";
+								$data = isset($d[1]) ? "{$d[0]}&emsp;({$d[1]})" : $d[0];
 							}
 
 							if (!empty($data) && $data != 'Not available for HTTPS alerts') {

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -161,8 +161,11 @@ if ($_POST) {
 			$dkey = 'log_max_days_' . $log_suffix;
 			$v = $_POST[$dkey] ?? '0';
 			if (is_array($v) || !ctype_digit((string) $v)) {
-				$_POST[$dkey] = '0';
+				$v = '0';
 			}
+			// issue #1056: assign back unconditionally -- a POST missing this key left
+			// $_POST[$dkey] unset, so the persist step below raised an undefined-key warning.
+			$_POST[$dkey] = (string) $v;
 		}
 
 		if (!$input_errors) {

--- a/src/usr/local/www/widgets/include/widget-pfblockerng.inc
+++ b/src/usr/local/www/widgets/include/widget-pfblockerng.inc
@@ -24,4 +24,14 @@
 $pfblockerng_title = '<span title="Click to open Unified Log tab">pfBlockerNG</span>';
 $pfblockerng_title_link = 'pfblockerng/pfblockerng_alerts.php?view=unified';
 
+// issue #1050: the widget sets $nocsrf=TRUE (csrf-magic never runs here), so a
+// mutating POST handler gates on this instead. Fails OPEN on an absent header
+// (a legacy browser sending no Sec-Fetch-Site at all) -- session auth still applies.
+function pfb_widget_post_allowed(array $server): bool {
+	if (!isset($server['HTTP_SEC_FETCH_SITE'])) {
+		return TRUE;
+	}
+	return in_array($server['HTTP_SEC_FETCH_SITE'], array('same-origin', 'none'), TRUE);
+}
+
 ?>

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -188,7 +188,7 @@ if ($_POST) {
 	}
 
 	// Clear widget IP/DNSBL Packet Counts
-	elseif ($_POST['pfblockerngclearall']) {
+	elseif (!empty($_POST['pfblockerngclearall']) && pfb_widget_post_allowed($_SERVER)) {
 		pfBlockerNG_clearip();
 		pfBlockerNG_clearsqlite('clearip');
 		pfBlockerNG_clearsqlite('cleardnsbl');
@@ -197,7 +197,7 @@ if ($_POST) {
 	}
 
 	// Clear widget IP Packet Counts
-	elseif ($_POST['pfblockerngclearip']) {
+	elseif (!empty($_POST['pfblockerngclearip']) && pfb_widget_post_allowed($_SERVER)) {
 		pfBlockerNG_clearip();
 		pfBlockerNG_clearsqlite('clearip');
 		header("Location: /");
@@ -205,7 +205,7 @@ if ($_POST) {
 	}
 
 	// Clear widget DNSBL Packet Counts
-	elseif ($_POST['pfblockerngcleardnsbl']) {
+	elseif (!empty($_POST['pfblockerngcleardnsbl']) && pfb_widget_post_allowed($_SERVER)) {
 		pfBlockerNG_clearsqlite('cleardnsbl');
 		header("Location: /");
 		exit(0);

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -178,7 +178,7 @@ if ($_POST) {
 
 	// Clear widget Failed downloads
 	// issue #1050: $nocsrf=TRUE means csrf-magic never runs here -- gate the mutation itself.
-	elseif ($_POST['pfblockerngack'] && pfb_widget_post_allowed($_SERVER)) {
+	elseif (!empty($_POST['pfblockerngack']) && pfb_widget_post_allowed($_SERVER)) {
 		exec("{$pfb['sed']} -i '' 's/FAIL/Fail/g' /var/log/pfblockerng/error.log");
 		// issue #999: ADR-61 moved the reporting list to the sync-status ledger --
 		// close the entries it actually reads, not just the retired error.log.

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -71,7 +71,8 @@ if ($_GET) {
 if ($_POST) {
 
 	// Save widget customizations
-	if (isset($_POST['pfb_submit'])) {
+	// issue #1050: $nocsrf=TRUE means csrf-magic never runs here -- gate the mutation itself.
+	if (isset($_POST['pfb_submit']) && pfb_widget_post_allowed($_SERVER)) {
 		$pfb['wglobal']['widget-popup']			= pfb_filter($_POST['pfb_popup'], PFB_FILTER_ON_OFF, 'widget');
 		$pfb['wglobal']['widget-sortmix']		= pfb_filter($_POST['pfb_sortmix'], PFB_FILTER_ON_OFF, 'widget');
 		$pfb['wglobal']['widget-show_agg']		= pfb_filter($_POST['pfb_show_agg'], PFB_FILTER_ON_OFF, 'widget');
@@ -176,7 +177,8 @@ if ($_POST) {
 	}
 
 	// Clear widget Failed downloads
-	elseif ($_POST['pfblockerngack']) {
+	// issue #1050: $nocsrf=TRUE means csrf-magic never runs here -- gate the mutation itself.
+	elseif ($_POST['pfblockerngack'] && pfb_widget_post_allowed($_SERVER)) {
 		exec("{$pfb['sed']} -i '' 's/FAIL/Fail/g' /var/log/pfblockerng/error.log");
 		// issue #999: ADR-61 moved the reporting list to the sync-status ledger --
 		// close the entries it actually reads, not just the retired error.log.

--- a/tests/php/LiveLogStdoutTest.php
+++ b/tests/php/LiveLogStdoutTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -57,6 +58,16 @@ final class LiveLogStdoutTest extends TestCase
 		return (string) ob_get_clean();
 	}
 
+	/**
+	 * issue #1054: pfb_logger()'s stamp decision is now tracked per-target-path
+	 * for the WHOLE process (beginning-of-line tracking), so this test's own
+	 * setUp() truncating the SHARED bootstrap log via file_put_contents()
+	 * (bypassing pfb_logger()) can leave a stale "mid-line" entry from an
+	 * earlier test's write to the same path. RunInSeparateProcess gives the
+	 * truncate-then-write sequence a fresh process, so the lazy BOL probe
+	 * correctly sees the just-emptied file.
+	 */
+	#[RunInSeparateProcess]
 	public function testMainLogMirrorsToStdoutDuringALifecycleCallback(): void
 	{
 		global $pfb;
@@ -90,6 +101,12 @@ final class LiveLogStdoutTest extends TestCase
 		$this->assertStringContainsString('Removing pfBlockerNG...', (string) @file_get_contents($pfb['log']));
 	}
 
+	/**
+	 * issue #1054: same cross-test static-BOL-cache isolation need as
+	 * testMainLogMirrorsToStdoutDuringALifecycleCallback above (this test
+	 * writes to the SHARED $pfb['errlog'] path via case 2).
+	 */
+	#[RunInSeparateProcess]
 	public function testOverrideForcesTheMirrorOnWithoutALifecycle(): void
 	{
 		global $pfb;

--- a/tests/php/LogFormatConsumersTest.php
+++ b/tests/php/LogFormatConsumersTest.php
@@ -188,11 +188,13 @@ final class LogFormatConsumersTest extends TestCase
 	/**
 	 * Green: the rebuilt day-bucket field selection (`cut -d ' ' -f1`) groups
 	 * ISO-format rows sharing a date into one bucket, regardless of their time.
+	 * issue #1057 added the `grep -E '^[0-9]{4}-'` gate right before it -- pinned
+	 * as part of the SAME tripwire so the two can never drift apart unnoticed.
 	 */
 	public function testDayBucketCutFieldSelectionGroupsIsoLinesByDate(): void
 	{
 		$source = (string) file_get_contents(self::ALERTS_PHP);
-		$needle = "cut -d ' ' -f1 | uniq -c";
+		$needle = "{\$pfb['grep']} -E '^[0-9]{4}-' | cut -d ' ' -f1 | uniq -c";
 		$this->assertStringContainsString($needle, $source, "pfblockerng_alerts.php's day-bucket cut changed -- update this oracle");
 		$this->assertStringNotContainsString("cut -d ' ' -f1-2", $source, 'the OLD 3-token field selection must be gone');
 
@@ -205,7 +207,7 @@ final class LogFormatConsumersTest extends TestCase
 		);
 
 		$cutField2 = "/usr/bin/cut -d ',' -f2 {$fixture}";
-		exec("{$cutField2} | cut -d ' ' -f1 | uniq -c", $stats);
+		exec("{$cutField2} | /usr/bin/grep -E '^[0-9]{4}-' | cut -d ' ' -f1 | uniq -c", $stats);
 
 		$this->assertCount(2, $stats, 'two distinct days must produce exactly two buckets');
 		$buckets = array_map(static fn (string $l): array => array_map('trim', explode(' ', trim($l), 2)), $stats);
@@ -296,21 +298,24 @@ EOT;
 	}
 
 	/**
-	 * Regression: `dnsbldatehr`/`dnsbldatehrmin` (`:'-split hour buckets) are
-	 * genuinely unaffected by the format change -- neither line was touched
-	 * this phase, and BOTH an old-format and a new-format sample bucket to the
-	 * same "<date> <hour[:min]>" shape, proving the mechanism is format-agnostic.
+	 * Regression: `dnsbldatehr`/`dnsbldatehrmin` (`:'-split hour buckets) formula
+	 * ITSELF is genuinely unaffected by the ISO format change -- neither line was
+	 * rewritten this phase, and BOTH an old-format and a new-format sample bucket
+	 * to the same "<date> <hour[:min]>" shape at this cut stage alone. issue #1057
+	 * later gated this formula's INPUT (a `grep -E '^[0-9]{4}-'`, pinned below) so
+	 * an old-format sample no longer REACHES it in production -- LogFormatConsumersTest's
+	 * mixed-fixture tests below cover that full-pipeline behaviour.
 	 */
 	public function testDnsblDateHrAndHrMinBucketsUnaffectedByFormatChange(): void
 	{
 		$source = (string) file_get_contents(self::ALERTS_PHP);
 		$this->assertStringContainsString(
-			"cut -d ':' -f1 | sort | uniq -c | sort -nr",
+			"{\$pfb['grep']} -E '^[0-9]{4}-' | cut -d ':' -f1 | sort | uniq -c | sort -nr",
 			$source,
 			'dnsbldatehr\'s cut formula changed -- update this oracle'
 		);
 		$this->assertStringContainsString(
-			"cut -d ':' -f1,2 | sort | uniq -c | sort -nr",
+			"{\$pfb['grep']} -E '^[0-9]{4}-' | cut -d ':' -f1,2 | sort | uniq -c | sort -nr",
 			$source,
 			'dnsbldatehrmin\'s cut formula changed -- update this oracle'
 		);
@@ -331,6 +336,196 @@ EOT;
 				"{$label}: dnsbldatehrmin must end in the correct hour:minute"
 			);
 			$hrOut = $hrMinOut = [];
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// issue #1057 -- legacy pre-ISO lines surviving an upgrade must not
+	// pollute the day/hour buckets (mixed-format fixture, all 3 pipelines).
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A dnsbl.log with 2 ISO rows (same day, different hours) plus 1 legacy
+	 * `M j H:i:s`-prefixed row (`Nov 31 14:30:15`, the exact shape the issue
+	 * reports rendering as "Nov (31)"), CSV field 2 (column for the dnsbl_stat
+	 * view's $stat_info), mirroring a real dnsbl.log's field layout.
+	 */
+	private function mixedFormatFixture(): string
+	{
+		$fixture = $this->tempFile('pfb_alerts_mixed_');
+		file_put_contents(
+			$fixture,
+			"DNSBL-python,2026-07-08 09:15:00,a.example,203.0.113.1,Python,VIP,G1,a.example,F1,+,A\n"
+			. "DNSBL-python,2026-07-08 10:20:00,b.example,203.0.113.2,Python,VIP,G1,b.example,F1,+,A\n"
+			. "DNSBL-python,Nov 31 14:30:15,legacy.example,203.0.113.9,Python,VIP,G1,legacy.example,F1,+,A\n"
+		);
+		return $fixture;
+	}
+
+	/**
+	 * Red proof: the PRE-#1057 day-bucket pipeline (no grep gate) buckets the
+	 * legacy row's bare month token "Nov" as if it were a day -- exactly the
+	 * issue's reported symptom.
+	 */
+	public function testMixedFormatDayBucketOldPipelinePollutesWithLegacyMonthToken(): void
+	{
+		$fixture = $this->mixedFormatFixture();
+		$cutField2 = "/usr/bin/cut -d ',' -f2 {$fixture}";
+		exec("{$cutField2} | cut -d ' ' -f1 | uniq -c", $stats);
+
+		$this->assertNotEmpty(
+			array_filter($stats, static fn (string $l): bool => str_contains($l, 'Nov')),
+			'the OLD (ungated) day-bucket pipeline must bucket the legacy row\'s bare "Nov" token (the live breakage)'
+		);
+	}
+
+	/**
+	 * Green: the NEW (`grep -E '^[0-9]{4}-'`-gated) day-bucket pipeline skips
+	 * the legacy row entirely -- only the 2 ISO rows bucket, by date.
+	 */
+	public function testMixedFormatDayBucketNewPipelineSkipsLegacyLines(): void
+	{
+		$fixture = $this->mixedFormatFixture();
+		$cutField2 = "/usr/bin/cut -d ',' -f2 {$fixture}";
+		exec("{$cutField2} | /usr/bin/grep -E '^[0-9]{4}-' | cut -d ' ' -f1 | uniq -c", $stats);
+
+		$this->assertEmpty(
+			array_filter($stats, static fn (string $l): bool => str_contains($l, 'Nov')),
+			'the NEW gated pipeline must never bucket the legacy row\'s "Nov" token; got: ' . implode(', ', $stats)
+		);
+		$this->assertCount(1, $stats, 'the 2 same-day ISO rows must collapse into exactly one bucket');
+		$this->assertStringContainsString('2026-07-08', $stats[0], "expected the ISO date bucket; got: {$stats[0]}");
+		$this->assertMatchesRegularExpression('/^\s*2\s/', $stats[0], "expected a count of 2; got: {$stats[0]}");
+	}
+
+	/**
+	 * Red proof: the PRE-#1057 dnsbldatehr pipeline buckets the legacy row as
+	 * "Nov 31 14" (month/day/hour all shifted one slot left of where an ISO
+	 * row's "date hour" bucket key would put them) -- the exact shape the
+	 * render loop later mangles into "Nov (31)".
+	 */
+	public function testMixedFormatDnsblDateHrOldPipelinePollutesWithLegacyBucket(): void
+	{
+		$fixture = $this->mixedFormatFixture();
+		$cutField2 = "/usr/bin/cut -d ',' -f2 {$fixture}";
+		exec("{$cutField2} | cut -d ':' -f1 | sort | uniq -c | sort -nr", $stats);
+
+		$this->assertNotEmpty(
+			array_filter($stats, static fn (string $l): bool => str_contains($l, 'Nov 31 14')),
+			'the OLD (ungated) dnsbldatehr pipeline must bucket the legacy row as "Nov 31 14" (the live breakage)'
+		);
+	}
+
+	/**
+	 * Green: the NEW gated dnsbldatehr pipeline skips the legacy row -- only
+	 * the 2 ISO "date hour" buckets survive.
+	 */
+	public function testMixedFormatDnsblDateHrNewPipelineSkipsLegacyLines(): void
+	{
+		$fixture = $this->mixedFormatFixture();
+		$cutField2 = "/usr/bin/cut -d ',' -f2 {$fixture}";
+		exec("{$cutField2} | /usr/bin/grep -E '^[0-9]{4}-' | cut -d ':' -f1 | sort | uniq -c | sort -nr", $stats);
+
+		$joined = implode(', ', $stats);
+		$this->assertStringNotContainsString('Nov', $joined, "legacy row must never survive the gate; got: {$joined}");
+		$this->assertStringContainsString('2026-07-08 09', $joined, "expected the 09:00 ISO bucket; got: {$joined}");
+		$this->assertStringContainsString('2026-07-08 10', $joined, "expected the 10:00 ISO bucket; got: {$joined}");
+		$this->assertCount(2, $stats, 'exactly the 2 distinct ISO hour buckets, no legacy pollution');
+	}
+
+	/**
+	 * Red proof: the PRE-#1057 dnsbldatehrmin pipeline buckets the legacy row
+	 * as "Nov 31 14:30".
+	 */
+	public function testMixedFormatDnsblDateHrMinOldPipelinePollutesWithLegacyBucket(): void
+	{
+		$fixture = $this->mixedFormatFixture();
+		$cutField2 = "/usr/bin/cut -d ',' -f2 {$fixture}";
+		exec("{$cutField2} | cut -d ':' -f1,2 | sort | uniq -c | sort -nr", $stats);
+
+		$this->assertNotEmpty(
+			array_filter($stats, static fn (string $l): bool => str_contains($l, 'Nov 31 14:30')),
+			'the OLD (ungated) dnsbldatehrmin pipeline must bucket the legacy row as "Nov 31 14:30" (the live breakage)'
+		);
+	}
+
+	/**
+	 * Green: the NEW gated dnsbldatehrmin pipeline skips the legacy row.
+	 */
+	public function testMixedFormatDnsblDateHrMinNewPipelineSkipsLegacyLines(): void
+	{
+		$fixture = $this->mixedFormatFixture();
+		$cutField2 = "/usr/bin/cut -d ',' -f2 {$fixture}";
+		exec("{$cutField2} | /usr/bin/grep -E '^[0-9]{4}-' | cut -d ':' -f1,2 | sort | uniq -c | sort -nr", $stats);
+
+		$joined = implode(', ', $stats);
+		$this->assertStringNotContainsString('Nov', $joined, "legacy row must never survive the gate; got: {$joined}");
+		$this->assertStringContainsString('2026-07-08 09:15', $joined, "expected the 09:15 ISO bucket; got: {$joined}");
+		$this->assertStringContainsString('2026-07-08 10:20', $joined, "expected the 10:20 ISO bucket; got: {$joined}");
+		$this->assertCount(2, $stats, 'exactly the 2 distinct ISO hour:min buckets, no legacy pollution');
+	}
+
+	// -----------------------------------------------------------------------
+	// issue #1057 -- the $d[1] undefined-array-key exposure on a truncated/
+	// corrupt bucket key (no space at all in $data).
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Red proof: the PRE-#1057 render line (no `isset()` guard), reproduced
+	 * verbatim, raises "Undefined array key 1" when $data has no space --
+	 * exactly the truncated/corrupt-key exposure the issue reports.
+	 */
+	public function testBucketLabelOldCodeWarnsOnKeyWithoutSpace(): void
+	{
+		$warnings = [];
+		set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
+			$warnings[] = $errstr;
+			return true;
+		});
+		try {
+			$data = '14'; // corrupt/truncated key: no space, so explode() yields only index 0.
+			$d = explode(' ', $data);
+			$data = "{$d[0]}&emsp;({$d[1]})"; // the OLD (unguarded) shape reproduced verbatim.
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertNotEmpty($warnings, 'the OLD unguarded access must raise a PHP warning on a spaceless key');
+		$this->assertStringContainsString('Undefined array key', $warnings[0] ?? '', "got: " . implode(', ', $warnings));
+	}
+
+	/**
+	 * Green: the NEW `isset($d[1])`-guarded render line, pinned by source
+	 * tripwire then reproduced verbatim, raises NO warning on a spaceless key
+	 * (falls back to the bare $d[0]) and keeps the normal "date (hour)" shape
+	 * for a well-formed key.
+	 */
+	public function testBucketLabelIssetGuardPreventsWarningOnKeyWithoutSpace(): void
+	{
+		$source = (string) file_get_contents(self::ALERTS_PHP);
+		$needle = '$data = isset($d[1]) ? "{$d[0]}&emsp;({$d[1]})" : $d[0];';
+		$this->assertStringContainsString($needle, $source, 'the $d[1] render guard changed -- update this oracle');
+
+		foreach (
+			[
+				'well-formed key'   => ['2026-07-08 09', '2026-07-08&emsp;(09)'],
+				'spaceless (corrupt) key' => ['14', '14'],
+			] as $label => [$data, $expected]
+		) {
+			$warnings = [];
+			set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
+				$warnings[] = $errstr;
+				return true;
+			});
+			try {
+				$d = explode(' ', $data);
+				$data = isset($d[1]) ? "{$d[0]}&emsp;({$d[1]})" : $d[0]; // the NEW (guarded) shape, reproduced verbatim.
+			} finally {
+				restore_error_handler();
+			}
+
+			$this->assertSame([], $warnings, "{$label}: the guarded access must never warn; got: " . implode(', ', $warnings));
+			$this->assertSame($expected, $data, "{$label}: unexpected rendered bucket label");
 		}
 	}
 }

--- a/tests/php/LogMgmtAgeCutoffTest.php
+++ b/tests/php/LogMgmtAgeCutoffTest.php
@@ -264,6 +264,9 @@ final class LogMgmtAgeCutoffTest extends TestCase
 	 * nolimit x set -- THE INDEPENDENCE FIX: 'nolimit' opts out of the
 	 * LINE-COUNT step only; the age cap still trims. Exercises the
 	 * copy()-based whole-file candidate path (no tail(1) step at all).
+	 * Issue #1052 coverage row "first-line expired (run)": the first line
+	 * ($old1) is expired, so the pass must still run -- the sibling pin for
+	 * testNolimitWithAgeSetSkipsPassWhenFirstLineIsFresh below.
 	 *
 	 * Scenario:
 	 *   Given log_max_log='nolimit'; log_max_days_log='30'.
@@ -299,6 +302,91 @@ final class LogMgmtAgeCutoffTest extends TestCase
 		);
 		$this->assertSame($inodeBefore, fileinode($logPath),
 			'the copy()-based nolimit+age path must preserve the inode (in-place cat-over)'
+		);
+	}
+
+	/**
+	 * Issue #1052, coverage row "first-line fresh (skip)": lines are
+	 * chronologically appended, so an unexpired FIRST line means nothing in
+	 * the file can be expired -- the whole copy()+age-trim pass must be
+	 * SKIPPED this tick, not just a no-op trim of an untouched candidate.
+	 * RED-PROVABLE: pre-fix code @copy()s + cat-overwrites the live log
+	 * every idle tick regardless, which rewrites (and would bump) the mtime.
+	 *
+	 * Scenario:
+	 *   Given log_max_log='nolimit'; log_max_days_log='30'.
+	 *   And   5 lines, ALL fresh (today) -- the first line is nowhere near
+	 *         expired.
+	 *   Before: 5 lines; mtime M.
+	 *   When  pfb_log_mgmt() is called.
+	 *   Then  content AND mtime are BOTH unchanged (the pass never ran).
+	 */
+	public function testNolimitWithAgeSetSkipsPassWhenFirstLineIsFresh(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('log', 'nolimit', '30');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('log');
+		$content = implode("\n", [
+			$this->now() . ' a',
+			$this->now() . ' b',
+			$this->now() . ' c',
+			$this->now() . ' d',
+			$this->now() . ' e',
+		]) . "\n";
+		file_put_contents($logPath, $content);
+		$mtimeBefore = filemtime($logPath);
+
+		// A real filesystem mtime tick so an accidental rewrite would be visible.
+		usleep(1_100_000);
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$this->assertSame($content, file_get_contents($logPath),
+			'a fresh-first-line nolimit+age-cap file must be byte-identical (whole pass skipped)'
+		);
+		$this->assertSame($mtimeBefore, filemtime($logPath),
+			'a fresh-first-line nolimit+age-cap file must not even be rewritten (mtime unchanged) -- '
+			. 'the copy()+cat pass must be skipped entirely, not run as a no-op'
+		);
+	}
+
+	/**
+	 * Issue #1052, coverage row "first-line unparseable-legacy (run)": an
+	 * unparseable FIRST line must NOT trigger the skip -- the probe falls
+	 * through to "pass needed" so the legacy line is still correctly dropped
+	 * (S2.2 "unparseable = expired"), matching pre-#1052 behaviour exactly.
+	 *
+	 * Scenario:
+	 *   Given log_max_log='nolimit'; log_max_days_log='30'.
+	 *   And   1 legacy line (no timestamp) + 2 fresh ISO lines.
+	 *   Before: 3 lines.
+	 *   When  pfb_log_mgmt() is called.
+	 *   Then  only the 2 fresh lines survive (the pass ran, dropping the legacy line).
+	 */
+	public function testNolimitWithAgeSetStillRunsWhenFirstLineIsUnparseableLegacy(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('log', 'nolimit', '30');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('log');
+		$legacy = 'pre-ADR-60 legacy line, no timestamp';
+		$fresh1 = $this->now() . ' fresh-one';
+		$fresh2 = $this->now() . ' fresh-two';
+		file_put_contents($logPath, implode("\n", [$legacy, $fresh1, $fresh2]) . "\n");
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$linesAfter = array_values(array_filter(explode("\n", (string) file_get_contents($logPath)), 'strlen'));
+		$this->assertSame([$fresh1, $fresh2], $linesAfter,
+			'an unparseable legacy first line must not skip the pass -- only it gets dropped, got '
+			. var_export($linesAfter, TRUE)
 		);
 	}
 

--- a/tests/php/LogMgmtAgeCutoffTest.php
+++ b/tests/php/LogMgmtAgeCutoffTest.php
@@ -755,4 +755,30 @@ final class LogMgmtAgeCutoffTest extends TestCase
 			chmod($logPath, 0644);
 		}
 	}
+
+	/**
+	 * Issue #1053: pfb_log_age_trim_temp()'s array path must treat a SHORT
+	 * (partial, non-FALSE) file_put_contents() write as failure, not success --
+	 * a genuine disk-full short write cannot be forced deterministically/
+	 * portably in a unit test (same constraint documented at
+	 * DnsblPrefetchTest::test_write_complete_helper_flags_a_short_write_as_incomplete),
+	 * so this pins the extracted write-outcome predicate directly with
+	 * fabricated byte counts -- the "testable shape" fallback for an
+	 * unforceable OS failure. The predicate is new code: it does not exist
+	 * pre-fix (calling it errors on the old source), so red<->green here is
+	 * "did not exist" -> "exists and rules correctly" for every input shape.
+	 */
+	public function testAgeTrimWriteOkFlagsAShortWriteAsIncomplete(): void
+	{
+		$content = "line-one\nline-two\n";
+
+		$short = pfb_log_age_trim_write_ok(strlen($content) - 3, $content);
+		$this->assertFalse($short, 'expected a short byte count to be flagged as an incomplete write');
+
+		$failed = pfb_log_age_trim_write_ok(FALSE, $content);
+		$this->assertFalse($failed, 'expected FALSE to be flagged as an incomplete write');
+
+		$complete = pfb_log_age_trim_write_ok(strlen($content), $content);
+		$this->assertTrue($complete, 'expected an exact full-length write to be flagged as complete');
+	}
 }

--- a/tests/php/LogNowTokenRetiredTest.php
+++ b/tests/php/LogNowTokenRetiredTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1008 retired pfb_logger()'s '[ NOW ]' opt-in scrub (LogTimestampBaselineTest
+ * pins the writer side); issue #1047 found 9 pfblockerng.php call sites still carrying
+ * the literal ' [ NOW ]' token, so it printed verbatim (no substitution left to hide
+ * it). Tree-wide tripwire: no tracked src/ file may contain the literal token outside
+ * a documented comment-only mention (ALLOWLIST below).
+ */
+final class LogNowTokenRetiredTest extends TestCase
+{
+	private const NOW_TOKEN = ' [ NOW ]';
+
+	/**
+	 * file:line -> reason, for a genuine comment-only historical mention.
+	 * Empty: every current tracked src/ file is clean.
+	 *
+	 * @var array<string,string>
+	 */
+	private const ALLOWLIST = [];
+
+	public function testNoTrackedSrcFileContainsLiteralNowToken(): void
+	{
+		$repoRoot = dirname(__DIR__, 2);
+
+		exec('git -C ' . escapeshellarg($repoRoot) . ' ls-files -- src 2>&1', $files, $exit);
+		$this->assertSame(0, $exit, 'git ls-files must succeed to enumerate tracked src/ files; got: ' . implode("\n", $files));
+
+		$violations = [];
+		foreach ($files as $relpath) {
+			$path = "{$repoRoot}/{$relpath}";
+			if (!is_file($path)) {
+				continue;
+			}
+			$lines = explode("\n", (string) file_get_contents($path));
+			foreach ($lines as $i => $line) {
+				if (!str_contains($line, self::NOW_TOKEN)) {
+					continue;
+				}
+				$key = "{$relpath}:" . ($i + 1);
+				if (!array_key_exists($key, self::ALLOWLIST)) {
+					$violations[] = $key;
+				}
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$violations,
+			"the literal '" . self::NOW_TOKEN . "' token must be deleted from every tracked src/ file "
+			. "(pfb_logger() no longer substitutes it -- it would print verbatim); found: " . implode(', ', $violations)
+		);
+	}
+}

--- a/tests/php/PfbLoggerIsoTimestampTest.php
+++ b/tests/php/PfbLoggerIsoTimestampTest.php
@@ -10,13 +10,15 @@ use PHPUnit\Framework\TestCase;
  * ambiguous US 'm/j/y H:i:s' (issue: American-style dates in user-facing logs).
  *
  * ADR-60 P2: every write is now unconditionally stamped -- the legacy opt-in
- * '[ NOW ]' token + same-second '$pfb[pnow]' dedup is retired. issue #1008: every
- * caller's literal '[ NOW ]' token was deleted and the scrub removed entirely
+ * '[ NOW ]' token + same-second '$pfb[pnow]' dedup is retired. issue #1008 deleted
+ * every pfblockerng.inc caller's literal '[ NOW ]' token and the scrub itself
  * (LogTimestampBaselineTest::testLogMessageContainingNowSubstringIsPreservedVerbatim
- * pins that a message containing 'NOW' is no longer mangled). The shipped
- * pfb_logger() is exercised against a temp log file so the on-disk side-effect is
- * asserted (not coverage theater). The shared $GLOBALS['pfb'] keys are
- * saved/restored so the suite stays order-independent.
+ * pins that a message containing 'NOW' is no longer mangled); issue #1047 found the
+ * token still live in 9 pfblockerng.php (www UI) call sites and deleted those too --
+ * LogNowTokenRetiredTest now tripwires the WHOLE tracked src/ tree, not just one file.
+ * The shipped pfb_logger() is exercised against a temp log file so the on-disk
+ * side-effect is asserted (not coverage theater). The shared $GLOBALS['pfb'] keys
+ * are saved/restored so the suite stays order-independent.
  */
 #[CoversFunction('pfb_logger')]
 #[CoversFunction('pfb_failures')]

--- a/tests/php/PfbLoggerIsoTimestampTest.php
+++ b/tests/php/PfbLoggerIsoTimestampTest.php
@@ -114,4 +114,64 @@ final class PfbLoggerIsoTimestampTest extends TestCase
 			. var_export($GLOBALS['pfb']['failed'] ?? [], true)
 		);
 	}
+
+	/**
+	 * Issue #1054 (ADR-60's stamped-unit contract amended to the physical LINE,
+	 * not the write): a full line, then two sub-line progress fragments ('.',
+	 * ' completed .'), then a line break followed by another full line -- only
+	 * the writes that actually START a new physical line get a stamp; the
+	 * fragments continuing mid-line must carry NONE. RED on pre-fix code: every
+	 * write got its own stamp, so the fragments would each carry one too.
+	 */
+	public function testMidLineFragmentsCarryNoStampOnlyLineStartsDo(): void
+	{
+		$log = tempnam(sys_get_temp_dir(), 'pfb_logtest_');
+		$this->assertNotFalse($log, 'could not create temp log file');
+		$this->tmpfiles[] = $log;
+		$GLOBALS['pfb']['log'] = $log;
+
+		pfb_logger("Downloading feed", 1);
+		pfb_logger('.', 1);
+		pfb_logger(' completed .', 1);
+		pfb_logger("\nNext [ x ]\n", 1);
+
+		$written = (string) file_get_contents($log);
+		$isoRe   = '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}';
+		$this->assertMatchesRegularExpression(
+			"/^{$isoRe} Downloading feed\\. completed \\.\n{$isoRe} Next \\[ x \\]\n\$/",
+			$written,
+			"stamps must land exactly at line starts, never mid-line on a progress fragment; got: {$written}"
+		);
+		// Explicit negative check on the fragments themselves (vacuity guard): neither
+		// sub-line write ('.', ' completed .') may carry its own embedded stamp --
+		// exactly one stamp per physical line (2 lines here), never a 3rd mid-line one.
+		$this->assertSame(2, preg_match_all("/{$isoRe}/", $written),
+			"exactly one stamp per physical line (2 lines here) -- got: {$written}"
+		);
+	}
+
+	/**
+	 * Issue #1054, coverage row "fragment at BOL is stamped": a sub-line
+	 * progress fragment written as the VERY FIRST write to a fresh (absent)
+	 * target file starts a new physical line by definition, so it IS stamped --
+	 * proving the BOL tracker's lazy-init (file absent/empty => TRUE), not just
+	 * the leading-newline special case.
+	 */
+	public function testFragmentWrittenFirstToAFreshFileIsStamped(): void
+	{
+		$log = tempnam(sys_get_temp_dir(), 'pfb_logtest_');
+		$this->assertNotFalse($log, 'could not create temp log file');
+		unlink($log); // tempnam() creates it -- start truly absent, per the BOL contract's "absent" case.
+		$this->tmpfiles[] = $log;
+		$GLOBALS['pfb']['log'] = $log;
+
+		pfb_logger('.', 1);
+
+		$written = (string) file_get_contents($log);
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \.$/',
+			$written,
+			"a fragment written first to an absent/fresh target must be stamped (it starts a new line); got: {$written}"
+		);
+	}
 }

--- a/tests/php/PfbLoggerIsoTimestampTest.php
+++ b/tests/php/PfbLoggerIsoTimestampTest.php
@@ -176,4 +176,42 @@ final class PfbLoggerIsoTimestampTest extends TestCase
 			"a fragment written first to an absent/fresh target must be stamped (it starts a new line); got: {$written}"
 		);
 	}
+
+	/**
+	 * CodeRabbit on PR #1061 (issue #1054 follow-up): other writers append to
+	 * the SAME log file in-process (hook output via pfb_persist_hook_output()),
+	 * so the BOL decision must come from the file's real last byte at write
+	 * time -- never from remembered state a foreign append silently outdated.
+	 */
+	public function testForeignAppendBetweenWritesCannotDesyncTheBolDecision(): void
+	{
+		$log = tempnam(sys_get_temp_dir(), 'pfb_logtest_');
+		$this->assertNotFalse($log, 'could not create temp log file');
+		$this->tmpfiles[] = $log;
+		$GLOBALS['pfb']['log'] = $log;
+
+		// Given: a stamped full line, leaving the target at BOL.
+		pfb_logger("First line\n", 1);
+		// And: a foreign writer appends an UNTERMINATED fragment directly
+		// (same shape as hook-output persistence) -- the file is now mid-line.
+		file_put_contents($log, 'hook-tail-without-newline', FILE_APPEND);
+
+		// When: pfb_logger writes a fragment -- stale remembered state would say
+		// BOL (the last pfb_logger write ended with \n) and stamp it mid-line.
+		pfb_logger('.', 1);
+		// And: a foreign writer terminates the line; the next write starts one.
+		file_put_contents($log, "\n", FILE_APPEND);
+		pfb_logger("Second line\n", 1);
+
+		$written = (string) file_get_contents($log);
+		$isoRe   = '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}';
+		$this->assertMatchesRegularExpression(
+			"/^{$isoRe} First line\nhook-tail-without-newline\\.\n{$isoRe} Second line\n\$/",
+			$written,
+			"the BOL decision must track the file's REAL last byte across foreign appends; got: {$written}"
+		);
+		$this->assertSame(2, preg_match_all("/{$isoRe}/", $written),
+			"exactly the two pfb_logger line starts are stamped -- got: {$written}"
+		);
+	}
 }

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -209,6 +209,124 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		);
 	}
 
+	/**
+	 * Issue #1048: source-inspection pin -- the per-row download loop must never
+	 * close the ledger entry directly from a row's success branch (that let a
+	 * later feed's success mask an earlier feed's still-open failure); the close
+	 * must be gated by the once-per-alias-pass $pfb_dl_failed flag instead. RED on
+	 * pre-fix code: the per-row close call is present, the gated call is absent.
+	 */
+	public function testDnsblDownloadCloseFiresOncePerAliasPassNotPerRow(): void
+	{
+		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
+		$this->assertNotFalse($source, 'pfblockerng.inc must be readable');
+
+		$this->assertDoesNotMatchRegularExpression(
+			'/unlink_if_exists\("\{\$pfbfolder\}\/\{\$header\}\.fail"\);\s*\n\s*pfb_dnsbl_download_ledger_update\(TRUE,/',
+			$source,
+			'a row\'s success branch must not close the download ledger directly -- masks a sibling row\'s failure'
+		);
+		$this->assertMatchesRegularExpression(
+			'/if \(!\$pfb_dl_failed\) \{\s*\n\s*pfb_dnsbl_download_ledger_update\(TRUE, \$alias, \'\', \$pfb\[\'dbdir\'\]\);/',
+			$source,
+			'the close call must be gated by the once-per-alias-pass $pfb_dl_failed flag'
+		);
+	}
+
+	/**
+	 * Mirrors the row-loop's per-alias-pass contract (issue #1048): the FALSE
+	 * (open) ledger call fires per failing row, and the TRUE (close) call fires
+	 * ONCE after all rows -- iff none failed. Drives the REAL production ledger
+	 * helper in the exact call pattern the fixed loop now follows (the loop
+	 * itself has no PHPUnit harness -- too heavy to invoke, see the class
+	 * docblock -- so this is the primary functional proof of the contract,
+	 * supplemented by the source-inspection pin above).
+	 *
+	 * @param bool[] $rowOutcomes TRUE = row succeeded, FALSE = row failed, in order.
+	 */
+	private function runDnsblAliasPass(string $alias, array $rowOutcomes): void
+	{
+		$failed = FALSE;
+		foreach ($rowOutcomes as $i => $ok) {
+			if (!$ok) {
+				$failed = TRUE;
+				pfb_dnsbl_download_ledger_update(FALSE, $alias, "[ {$alias} - row{$i} ] Download FAIL", $this->dir);
+			}
+		}
+		if (!$failed) {
+			pfb_dnsbl_download_ledger_update(TRUE, $alias, '', $this->dir);
+		}
+	}
+
+	public function testAliasPassFailThenSucceedLeavesEntryOpen(): void
+	{
+		$this->runDnsblAliasPass('DNSBL_Example', [FALSE, TRUE]);
+
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'dnsbl'),
+			'a failing row followed by a succeeding sibling row must leave the entry OPEN -- a per-row close would mask this'
+		);
+	}
+
+	public function testAliasPassSucceedThenFailLeavesEntryOpen(): void
+	{
+		$this->runDnsblAliasPass('DNSBL_Example', [TRUE, FALSE]);
+
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'dnsbl'),
+			'a succeeding row followed by a failing sibling row must leave the entry OPEN'
+		);
+	}
+
+	public function testAliasPassAllSuccessMultiFeedClosesEntry(): void
+	{
+		// Before-state: genuinely open first, so the close below is a real transition.
+		$this->runDnsblAliasPass('DNSBL_Example', [FALSE]);
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'dnsbl'));
+
+		$this->runDnsblAliasPass('DNSBL_Example', [TRUE, TRUE, TRUE]);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'),
+			'an all-success multi-feed pass must close the entry'
+		);
+	}
+
+	public function testAliasPassSingleFeedFailOpensEntry(): void
+	{
+		$this->runDnsblAliasPass('DNSBL_Example', [FALSE]);
+
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'dnsbl'),
+			'a single-feed alias with one failing row must open the entry'
+		);
+	}
+
+	public function testAliasPassSingleFeedSuccessClosesEntry(): void
+	{
+		// Before-state: genuinely open first (regression pin for the pre-#1048 behaviour).
+		$this->runDnsblAliasPass('DNSBL_Example', [FALSE]);
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'dnsbl'));
+
+		$this->runDnsblAliasPass('DNSBL_Example', [TRUE]);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'),
+			'a single-feed alias with its one row succeeding must close the entry (regression)'
+		);
+	}
+
+	public function testAliasPassAllReusedClosesPreviouslyOpenEntry(): void
+	{
+		// Before-state: genuinely open first.
+		$this->runDnsblAliasPass('DNSBL_Example', [FALSE]);
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'dnsbl'));
+
+		// An all-reused pass makes ZERO ledger calls inside the loop (no row ever
+		// hits the download branch) -- $pfb_dl_failed stays FALSE the whole pass,
+		// so the post-loop close still fires.
+		$this->runDnsblAliasPass('DNSBL_Example', []);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'),
+			'an all-reused pass (zero download attempts) must still close a previously-open entry'
+		);
+	}
+
 	// -----------------------------------------------------------------------
 	// pfb_reload_unbound() end-to-end -- restart-fallback reaches a converged tail
 	// -----------------------------------------------------------------------

--- a/tests/php/PfbSyncStatusIpWritersTest.php
+++ b/tests/php/PfbSyncStatusIpWritersTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -223,6 +224,56 @@ final class PfbSyncStatusIpWritersTest extends TestCase
 
 		$open = pfb_sync_status_list_open($this->dir, 'ip');
 		$this->assertCount(1, $open, 'the LAST sanity-check line in the log must win, matching the widget\'s tail -1 read');
+	}
+
+	/**
+	 * Issue #1052: pfb_sync_status_dedup_check() must not @file() the WHOLE
+	 * pfblockerng.log into memory -- a 'nolimit' log has no size cap. A
+	 * several-MB multi-chunk log with the Sanity check line near the end
+	 * (within the bounded tail window) must resolve the SAME verdict as a
+	 * small log, AND the memory_get_peak_usage(true) delta must stay far
+	 * below the file size -- the old @file()-array approach scales its
+	 * memory with file size, the bounded-tail read does not (same proof
+	 * shape as LogAgeCutoffStreamTest::testStreamingTrimStaysMemoryBounded...).
+	 * Bound justification (measured this session on this machine): the old
+	 * @file()-array approach costs a +7,065,600 byte (~6.7 MiB) delta on this
+	 * exact fixture; the bounded-tail read costs 0 bytes. 1 MiB sits
+	 * comfortably between the two, cleanly separating old-code-fails from
+	 * new-code-passes.
+	 */
+	#[RunInSeparateProcess]
+	public function testDedupSanityCheckStaysMemoryBoundedOnLargeLog(): void
+	{
+		$log = tempnam(sys_get_temp_dir(), 'pfb_dedup_big_log_');
+		$this->tmpfiles[] = $log;
+
+		$fh = fopen($log, 'w');
+		// ~3 MiB of filler lines (well outside the 64 KiB tail window) before
+		// the sanity line -- proves only the trailing window is ever read.
+		for ($i = 0; $i < 40000; $i++) {
+			fwrite($fh, 'filler line number ' . $i . ' of irrelevant log content padding out the file' . "\n");
+		}
+		fwrite($fh, "Database Sanity check [  FAILED  ] ** These two counts should match! **\n");
+		fclose($fh);
+
+		clearstatcache(TRUE, $log);
+		$this->assertGreaterThan(1_000_000, filesize($log), 'Before: fixture must be several MB');
+
+		gc_collect_cycles();
+		$memBefore = memory_get_peak_usage(TRUE);
+
+		pfb_sync_status_dedup_check($log, $this->dir);
+
+		$memDelta = memory_get_peak_usage(TRUE) - $memBefore;
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open, 'a FAILED sanity-check line within the tail window must open the dedup entry, got '
+			. var_export($open, true));
+		$this->assertStringContainsString('FAILED', $open[0]['message']);
+
+		$this->assertLessThan(1024 * 1024, $memDelta,
+			"dedup check's memory_get_peak_usage(true) delta must stay under 1 MiB on a several-MB log, got {$memDelta} bytes"
+		);
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/PfbSyncStatusIpWritersTest.php
+++ b/tests/php/PfbSyncStatusIpWritersTest.php
@@ -169,6 +169,125 @@ final class PfbSyncStatusIpWritersTest extends TestCase
 		);
 	}
 
+	/**
+	 * Issue #1048: source-inspection pin -- the per-row download loop must never
+	 * close the ledger entry directly from a row's success branch (that let a
+	 * later feed's success mask an earlier feed's still-open failure); the close
+	 * must be gated by the once-per-alias-pass $pfb_dl_failed flag instead. RED on
+	 * pre-fix code: the per-row close call is present, the gated call is absent.
+	 */
+	public function testIpDownloadCloseFiresOncePerAliasPassNotPerRow(): void
+	{
+		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
+		$this->assertNotFalse($source, 'pfblockerng.inc must be readable');
+
+		$this->assertDoesNotMatchRegularExpression(
+			'/unlink_if_exists\("\{\$pfbfolder\}\/\{\$header\}\.fail"\);\s*\n\s*pfb_ip_download_ledger_update\(TRUE,/',
+			$source,
+			'a row\'s success branch must not close the download ledger directly -- masks a sibling row\'s failure'
+		);
+		$this->assertMatchesRegularExpression(
+			'/if \(!\$pfb_dl_failed\) \{\s*\n\s*pfb_ip_download_ledger_update\(TRUE, \$alias, \'\', \$pfb\[\'dbdir\'\]\);/',
+			$source,
+			'the close call must be gated by the once-per-alias-pass $pfb_dl_failed flag'
+		);
+	}
+
+	/**
+	 * Mirrors the row-loop's per-alias-pass contract (issue #1048): the FALSE
+	 * (open) ledger call fires per failing row, and the TRUE (close) call fires
+	 * ONCE after all rows -- iff none failed. Drives the REAL production ledger
+	 * helper in the exact call pattern the fixed loop now follows
+	 * (sync_package_pfblockerng() itself has no PHPUnit harness -- too heavy to
+	 * invoke, see testDownloadCallSitesKeyOnTheAliasNotTheHeader's docblock --
+	 * so this is the primary functional proof of the contract, supplemented by
+	 * the source-inspection pin above).
+	 *
+	 * @param bool[] $rowOutcomes TRUE = row succeeded, FALSE = row failed, in order.
+	 */
+	private function runIpAliasPass(string $alias, array $rowOutcomes): void
+	{
+		$failed = FALSE;
+		foreach ($rowOutcomes as $i => $ok) {
+			if (!$ok) {
+				$failed = TRUE;
+				pfb_ip_download_ledger_update(FALSE, $alias, "[ {$alias} - row{$i} ] Download FAIL", $this->dir);
+			}
+		}
+		if (!$failed) {
+			pfb_ip_download_ledger_update(TRUE, $alias, '', $this->dir);
+		}
+	}
+
+	public function testAliasPassFailThenSucceedLeavesEntryOpen(): void
+	{
+		$this->runIpAliasPass('pfB_Example_v4', [FALSE, TRUE]);
+
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'),
+			'a failing row followed by a succeeding sibling row must leave the entry OPEN -- a per-row close would mask this'
+		);
+	}
+
+	public function testAliasPassSucceedThenFailLeavesEntryOpen(): void
+	{
+		$this->runIpAliasPass('pfB_Example_v4', [TRUE, FALSE]);
+
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'),
+			'a succeeding row followed by a failing sibling row must leave the entry OPEN'
+		);
+	}
+
+	public function testAliasPassAllSuccessMultiFeedClosesEntry(): void
+	{
+		// Before-state: genuinely open first, so the close below is a real transition.
+		$this->runIpAliasPass('pfB_Example_v4', [FALSE]);
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		$this->runIpAliasPass('pfB_Example_v4', [TRUE, TRUE, TRUE]);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'ip'),
+			'an all-success multi-feed pass must close the entry'
+		);
+	}
+
+	public function testAliasPassSingleFeedFailOpensEntry(): void
+	{
+		$this->runIpAliasPass('pfB_Example_v4', [FALSE]);
+
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'),
+			'a single-feed alias with one failing row must open the entry'
+		);
+	}
+
+	public function testAliasPassSingleFeedSuccessClosesEntry(): void
+	{
+		// Before-state: genuinely open first (regression pin for the pre-#1048 behaviour).
+		$this->runIpAliasPass('pfB_Example_v4', [FALSE]);
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		$this->runIpAliasPass('pfB_Example_v4', [TRUE]);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'ip'),
+			'a single-feed alias with its one row succeeding must close the entry (regression)'
+		);
+	}
+
+	public function testAliasPassAllReusedClosesPreviouslyOpenEntry(): void
+	{
+		// Before-state: genuinely open first.
+		$this->runIpAliasPass('pfB_Example_v4', [FALSE]);
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		// An all-reused pass makes ZERO ledger calls inside the loop (no row ever
+		// hits the download branch) -- $pfb_dl_failed stays FALSE the whole pass,
+		// so the post-loop close still fires.
+		$this->runIpAliasPass('pfB_Example_v4', []);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'ip'),
+			'an all-reused pass (zero download attempts) must still close a previously-open entry'
+		);
+	}
+
 	// -----------------------------------------------------------------------
 	// Pair 2 — dedup sanity FAILED/PASSED (pfb_sync_status_dedup_check)
 	// -----------------------------------------------------------------------

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -252,26 +252,40 @@ final class PfbSyncStatusLedgerTest extends TestCase
 			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
 		}
 
-		$lockPath = $this->dir . '/pfb_sync_status.json.lock';
-		$pid      = pcntl_fork();
+		$lockPath   = $this->dir . '/pfb_sync_status.json.lock';
+		$markerPath = $this->dir . '/child_locked.marker';
+		$pid        = pcntl_fork();
 		if ($pid === -1) {
 			$this->markTestSkipped('pcntl_fork() failed.');
 		}
 
 		if ($pid === 0) {
-			// Child: acquire the SAME lock file pfb_sync_status_locked() uses, hold it
-			// briefly (simulating a still-running backgrounded pass mid read-modify-write),
-			// then release. A fresh fopen() (not an inherited fd) makes this a genuine
-			// second, independent lock holder -- the real multi-process scenario.
+			// Child: acquire the SAME lock file pfb_sync_status_locked() uses, signal
+			// readiness (issue #1055 -- a marker file, not a guessed sleep), hold the
+			// lock briefly (simulating a still-running backgrounded pass mid
+			// read-modify-write), then release. A fresh fopen() (not an inherited fd)
+			// makes this a genuine second, independent lock holder.
 			$fp = fopen($lockPath, 'c');
 			flock($fp, LOCK_EX);
+			touch($markerPath);
 			usleep(500000);
 			flock($fp, LOCK_UN);
 			fclose($fp);
 			exit(0);
 		}
 
-		usleep(100000); // let the child actually acquire the lock first
+		// issue #1055: poll for the child's readiness marker instead of guessing a
+		// fixed delay -- a bounded poll is the accepted last resort across this
+		// fork boundary (no in-process signal reaches across processes).
+		$deadline = microtime(TRUE) + 2.0;
+		while (!file_exists($markerPath)) {
+			if (microtime(TRUE) >= $deadline) {
+				pcntl_waitpid($pid, $waitStatus);
+				$this->fail('child process never signalled lock acquisition (marker file never appeared) -- deadlock or fork failure?');
+			}
+			usleep(1000);
+		}
+
 		$start = microtime(TRUE);
 		pfb_sync_status_open('ip', 'pfB_Example_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
 		$elapsed = microtime(TRUE) - $start;

--- a/tests/php/WidgetPostAllowedTest.php
+++ b/tests/php/WidgetPostAllowedTest.php
@@ -10,8 +10,8 @@ use PHPUnit\Framework\TestCase;
  * pfb_widget_post_allowed() — the dashboard widget's CSRF stand-in (issue #1050).
  *
  * pfblockerng.widget.php sets $nocsrf=TRUE for the whole endpoint (its read-only
- * AJAX GETs need no token), so its two mutating POST handlers (pfb_submit,
- * pfblockerngack) gate on this instead: reject a cross-site-shaped POST via the
+ * AJAX GETs need no token), so its mutating POST handlers (pfb_submit,
+ * pfblockerngack, and the three packet-count clears) gate on this instead: reject a cross-site-shaped POST via the
  * Sec-Fetch-Site fetch metadata header, allow everything else -- including an
  * ABSENT header (a legacy browser sending none at all), a deliberate fail-open
  * documented at the call site.
@@ -59,5 +59,31 @@ final class WidgetPostAllowedTest extends TestCase
 			pfb_widget_post_allowed($server),
 			'pfb_widget_post_allowed(' . var_export($server, true) . ') expected ' . var_export($expected, true)
 		);
+	}
+
+	/**
+	 * Wiring pin (Sonnet review on PR #1061): EVERY mutating $_POST branch in
+	 * the widget's dispatch chain must call the guard -- a new handler added
+	 * without it silently reopens the cross-site hole #1050 closed.
+	 */
+	public function testEveryMutatingPostBranchCallsTheGuard(): void
+	{
+		$widget = (string) file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php'
+		);
+		// Dispatch branches sit at one tab of indentation; nested validation reads
+		// (in_array($_POST[...]) inside pfb_submit) are deeper and excluded.
+		preg_match_all('/^\t(?:if|elseif)\s*\(([^\n]*\$_POST\[[^\n]*)\)\s*\{/m', $widget, $m);
+		$branches = $m[1];
+		$this->assertNotEmpty($branches, 'no $_POST dispatch branches found -- extraction regex broke');
+		foreach ($branches as $cond) {
+			$this->assertStringContainsString(
+				'pfb_widget_post_allowed($_SERVER)',
+				$cond,
+				"unguarded mutating \$_POST branch in pfblockerng.widget.php: {$cond}"
+			);
+		}
+		$this->assertGreaterThanOrEqual(5, count($branches),
+			'expected at least the 5 known mutating branches (pfb_submit, ack, 3 clears); got ' . count($branches));
 	}
 }

--- a/tests/php/WidgetPostAllowedTest.php
+++ b/tests/php/WidgetPostAllowedTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_widget_post_allowed() — the dashboard widget's CSRF stand-in (issue #1050).
+ *
+ * pfblockerng.widget.php sets $nocsrf=TRUE for the whole endpoint (its read-only
+ * AJAX GETs need no token), so its two mutating POST handlers (pfb_submit,
+ * pfblockerngack) gate on this instead: reject a cross-site-shaped POST via the
+ * Sec-Fetch-Site fetch metadata header, allow everything else -- including an
+ * ABSENT header (a legacy browser sending none at all), a deliberate fail-open
+ * documented at the call site.
+ *
+ * widget-pfblockerng.inc carries no top-level pfSense-dependent execution (just
+ * two title-string assignments plus this function), so it is require_once()d
+ * directly -- unlike pfblockerng.widget.php's eval-extraction (WidgetAliasHiddenTest),
+ * this file needs no page-runtime stripping.
+ */
+#[CoversFunction('pfb_widget_post_allowed')]
+final class WidgetPostAllowedTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		if (function_exists('pfb_widget_post_allowed')) {
+			return;
+		}
+		require_once dirname(__DIR__, 2) . '/src/usr/local/www/widgets/include/widget-pfblockerng.inc';
+	}
+
+	/**
+	 * Full truth table: absent, 'same-origin', 'none', 'cross-site', 'same-site',
+	 * empty string.
+	 *
+	 * @return array<string,array{array<string,string>,bool}>
+	 */
+	public static function truthTableProvider(): array
+	{
+		return [
+			'absent header -- fail-open (legacy browser)' => [[], true],
+			"'same-origin' -- allowed"                     => [['HTTP_SEC_FETCH_SITE' => 'same-origin'], true],
+			"'none' -- allowed (direct navigation/bookmark)" => [['HTTP_SEC_FETCH_SITE' => 'none'], true],
+			"'cross-site' -- blocked"                       => [['HTTP_SEC_FETCH_SITE' => 'cross-site'], false],
+			"'same-site' -- blocked (not in the allowed set)" => [['HTTP_SEC_FETCH_SITE' => 'same-site'], false],
+			'empty string -- present but not an allowed token, blocked' => [['HTTP_SEC_FETCH_SITE' => ''], false],
+		];
+	}
+
+	/** @param array<string,string> $server */
+	#[DataProvider('truthTableProvider')]
+	public function testTruthTable(array $server, bool $expected): void
+	{
+		$this->assertSame(
+			$expected,
+			pfb_widget_post_allowed($server),
+			'pfb_widget_post_allowed(' . var_export($server, true) . ') expected ' . var_export($expected, true)
+		);
+	}
+}

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -24,6 +24,8 @@ import pytest
 
 from .. import helpers
 from .conftest import mask_page_identity
+from .render_oracle import PhpErrorLogGuard
+from .webui import looks_like_login_page, scrape_form_fields
 
 sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not installed (Tier-B browser dep)")
 expect = sync_api.expect
@@ -257,3 +259,59 @@ def test_log_settings_grouped_layout(
     assert n_rows >= 1, f"expected at least one Log Settings row (select[name^=log_max_]), found {n_rows}"
     expect(max_days).to_have_count(n_rows, timeout=JS_TIMEOUT_MS)
     expect(page.locator("label.form-label")).to_have_count(n_rows * 2, timeout=JS_TIMEOUT_MS)
+
+
+# --------------------------------------------------------------------------- #
+# issue #1056 -- a crafted POST missing a log_max_days_* field must not warn
+# --------------------------------------------------------------------------- #
+
+
+def test_general_save_missing_log_max_days_field_does_not_warn(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A save POST missing ``log_max_days_log`` must not raise an "Undefined array
+    key" PHP warning (issue #1056).
+
+    ``pfblockerng_general.php``'s validation loop read ``$_POST[$dkey] ?? '0'`` but
+    only assigned back into ``$_POST[$dkey]`` on the INVALID branch; a well-formed-
+    but-absent field left the key unset, so the later unconditional
+    ``$_POST['log_max_days_' . $log_suffix] ?: '0'`` persist read raised the warning.
+    Can't use ``WebUI.post()`` here -- it always resends the page's OWN scraped
+    field set, so it can never OMIT one; this replicates its scrape-then-POST shape
+    with one key deleted first (mirrors ``test_widget_clear_failed.py``'s pattern for
+    the same reason).
+
+    Scenario: General save survives a POST missing an optional per-log field.
+      Background: pfBlockerNG deployed; webConfigurator authenticated.
+
+    Given the General page's own current field set (scraped, so every OTHER field
+      round-trips at its present value),
+
+    When ``log_max_days_log`` is deleted from that set before the save POST
+      (simulating a crafted/truncated client request),
+
+    Then the response is a save success (200 or a redirect, never a server error),
+      the session is still authenticated (no bounce to the login form), AND no
+      candidate ``php_error.log`` gained a byte during the request (the guard that
+      catches a logged-but-not-echoed PHP warning).
+    """
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    page = webui.get(GENERAL_PAGE)
+    assert page.status_code == 200, f"GET {GENERAL_PAGE} -> HTTP {page.status_code} (expected 200)"
+    assert not looks_like_login_page(page.text), "pre-save GET bounced to the login page -- not authenticated"
+
+    payload = scrape_form_fields(page.text)
+    assert "log_max_days_log" in payload, "fixture sanity: log_max_days_log must be a real scraped field"
+    del payload["log_max_days_log"]
+    payload["save"] = "save"
+
+    resp = webui.session.post(webui.url(GENERAL_PAGE), data=payload, timeout=_GENERAL_POST_TIMEOUT)
+
+    assert resp.status_code < 400, (
+        f"General save (missing log_max_days_log) -> HTTP {resp.status_code} (expected a save success)"
+    )
+    assert not looks_like_login_page(resp.text), "save POST bounced to the login page -- session not authenticated"
+    guard.assert_no_growth()

--- a/tests/smoke/ui/test_widget_clear_failed.py
+++ b/tests/smoke/ui/test_widget_clear_failed.py
@@ -69,7 +69,7 @@ def _get_failed_body(webui: WebUI) -> str:
     return resp.text
 
 
-def _dismiss(webui: WebUI) -> None:
+def _dismiss(webui: WebUI, headers: dict[str, str] | None = None) -> None:
     """POST the widget's dismiss action -- the exact payload the hidden 'formicons'
     form's JS-driven submit sends (``pfblockerngack=1``); the handler redirects to
     ``/`` on success (widget.php ~184-186).
@@ -79,13 +79,18 @@ def _dismiss(webui: WebUI) -> None:
     never injects one here at all (confirmed live -- the rendered form has no
     hidden CSRF input), so this replicates ``post()``'s field-scrape-then-POST
     shape without that requirement.
+
+    ``headers`` (issue #1050): extra request headers, e.g. a synthetic
+    ``Sec-Fetch-Site`` to drive ``pfb_widget_post_allowed()``'s gate -- the response
+    is still a normal 200 either way (blocked = the mutation is skipped and the
+    page falls through to its normal render, never a login bounce or a 4xx).
     """
     page = webui.get(WIDGET_PAGE)
     assert page.status_code == 200, f"GET {WIDGET_PAGE} -> HTTP {page.status_code} (expected 200)"
     assert not looks_like_login_page(page.text), "pre-dismiss GET bounced to the login page -- not authenticated"
     payload = scrape_form_fields(page.text)
     payload["pfblockerngack"] = "1"
-    resp = webui.session.post(webui.url(WIDGET_PAGE), data=payload, timeout=30)
+    resp = webui.session.post(webui.url(WIDGET_PAGE), data=payload, headers=headers, timeout=30)
     assert resp.status_code == 200, f"POST {WIDGET_PAGE} pfblockerngack=1 -> HTTP {resp.status_code} (expected 200)"
     assert not looks_like_login_page(resp.text), "dismiss POST bounced to the login page -- session not authenticated"
 
@@ -236,3 +241,40 @@ def test_dismiss_with_no_open_entries_is_a_safe_noop(
 
     after = _get_failed_body(webui)
     assert "MaxMind:" in after, "empty ledger must still fall back to the MaxMind version line after a no-op dismiss"
+
+
+def test_dismiss_cross_site_post_does_not_clear_ledger(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    clean_ledger: None,
+    php_error_log_guard: PhpErrorLogGuard,  # noqa: ARG001
+) -> None:
+    """issue #1050 (security, red case): a cross-site-shaped POST must NOT clear
+    the ledger.
+
+    ``$nocsrf=TRUE`` means csrf-magic never runs on this endpoint, so before this
+    fix ANY POST (session-authenticated or auto-submitted from a completely
+    unrelated site in the admin's browser) cleared every open ledger entry --
+    ``pfb_widget_post_allowed()`` now rejects a POST carrying
+    ``Sec-Fetch-Site: cross-site``. Reuses ``test_dismiss_closes_single_open_ip_entry``'s
+    seed/assert shape, with the opposite outcome: the entry SURVIVES.
+    """
+    vm = smoke_vm
+    item = f"pfB_SmokeCrossSite_{uuid.uuid4().hex[:8]}_v4"
+    message = f"smoke: synthetic cross-site-blocked failure {uuid.uuid4().hex[:8]}"
+    _ledger_open(vm, "ip", item, "apply", message)
+
+    # BEFORE: the seeded open entry is visible, same as any other dismiss test.
+    before = _get_failed_body(webui)
+    assert message in before, "seeded ledger entry's message missing before the blocked dismiss"
+
+    _dismiss(webui, headers={"Sec-Fetch-Site": "cross-site"})
+
+    # AFTER: the entry must SURVIVE -- proving the gate, not just "dismiss is a no-op".
+    after = _get_failed_body(webui)
+    assert message in after, "cross-site POST cleared the ledger entry -- pfb_widget_post_allowed() gate failed"
+
+    raw = helpers.read_log_file(vm, f"{_LEDGER_DIR}/pfb_sync_status.json")
+    assert item in raw, f"cross-site POST removed {item!r} from the raw ledger file"
+
+    _ledger_close(vm, "ip", item, "apply")

--- a/tests/test_adr61_py_status.py
+++ b/tests/test_adr61_py_status.py
@@ -394,6 +394,49 @@ class TestLoadDataDbLedgerWiring:
         assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
 
 
+class TestLoadZoneAndDataDbsLedgerWiring:
+    """_load_zone_and_data_dbs(): the 7th orphan site (issue #1049) -- a
+    manifest-built init (dnsbl_built=True) skips BOTH CSV loaders, so their
+    parse-stage entries must close instead of staying orphaned."""
+
+    def setup_method(self) -> None:
+        pfb_unbound.zoneDB = defaultdict(list)
+        pfb_unbound.dataDB = defaultdict(list)
+        pfb_unbound.feedGroupIndexDB = defaultdict(list)
+        pfb_unbound.pfb["zoneDB"] = False
+        pfb_unbound.pfb["dataDB"] = False
+        pfb_unbound.pfb["python_blacklist"] = False
+
+    def test_manifest_built_closes_preexisting_zone_and_data_entries(self, tmp_path: Any) -> None:
+        pfb_unbound.pfb["pfb_py_zone"] = str(tmp_path / "zone.txt")
+        pfb_unbound.pfb["pfb_py_data"] = str(tmp_path / "data.txt")
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+        pfb_unbound.pfb_py_status_open("dnsbl", pfb_unbound.pfb["pfb_py_zone"], "parse", "boom")
+        pfb_unbound.pfb_py_status_open("dnsbl", pfb_unbound.pfb["pfb_py_data"], "parse", "boom")
+        # Before-state: both entries are genuinely open first.
+        assert len(_read_status_file(pfb_unbound.pfb["pfb_py_status"])) == 2
+
+        pfb_unbound._load_zone_and_data_dbs(True, _new_feed_group_db(), 0)
+
+        assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
+
+    def test_manifest_not_built_still_runs_the_csv_loaders(self, tmp_path: Any) -> None:
+        # dnsbl_built=False must still reach the legacy loaders (wiring check --
+        # the manifest-built branch must not swallow the fallback path too).
+        zone_path = tmp_path / "zone.txt"
+        zone_path.write_text("evil.com,evil.com,0,1,FeedA,GroupA\n", encoding="utf-8")
+        data_path = tmp_path / "data.txt"
+        data_path.write_text("bad.com,bad.com,0,1,FeedB,GroupB\n", encoding="utf-8")
+        pfb_unbound.pfb["pfb_py_zone"] = str(zone_path)
+        pfb_unbound.pfb["pfb_py_data"] = str(data_path)
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+
+        pfb_unbound._load_zone_and_data_dbs(False, _new_feed_group_db(), 0)
+
+        assert pfb_unbound.zoneDB["evil.com"]["log"] == "1"
+        assert pfb_unbound.dataDB["bad.com"]["log"] == "1"
+
+
 class TestLoadWhitelistDbLedgerWiring:
     """_load_whitelist_db(): fail-before/pass-after."""
 
@@ -594,6 +637,70 @@ class TestLoadHstsDbLedgerWiring:
         assert not os.path.isfile(pfb_unbound.pfb["pfb_py_status"])
 
 
+class TestLoadWhitelistAndHstsDbsLedgerWiring:
+    """_load_whitelist_and_hsts_dbs(): issue #1049's other two skip axes --
+    (a) manifest-built skips only the whitelist loader; (b) python_blacklist OFF
+    skips both loaders. Either skip must close the owned entry, not orphan it."""
+
+    def setup_method(self) -> None:
+        pfb_unbound.whiteDB = defaultdict(str)
+        pfb_unbound.hstsDB = defaultdict(str)
+        pfb_unbound.pfb["whiteDB"] = False
+        pfb_unbound.pfb["hstsDB"] = False
+        pfb_unbound.pfb["python_hsts"] = True
+
+    def test_manifest_built_closes_preexisting_whitelist_entry_only(self, tmp_path: Any) -> None:
+        wl_path = tmp_path / "whitelist.txt"
+        hsts_path = tmp_path / "hsts.txt"
+        hsts_path.write_text("bad.example\n", encoding="utf-8")
+        pfb_unbound.pfb["pfb_py_whitelist"] = str(wl_path)
+        pfb_unbound.pfb["pfb_py_hsts"] = str(hsts_path)
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+        pfb_unbound.pfb["python_blacklist"] = True
+        pfb_unbound.pfb_py_status_open("dnsbl", str(wl_path), "parse", "boom")
+        # Before-state: the whitelist entry is genuinely open first.
+        assert len(_read_status_file(pfb_unbound.pfb["pfb_py_status"])) == 1
+
+        pfb_unbound._load_whitelist_and_hsts_dbs(True)
+
+        assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
+        # HSTS still ran normally -- only the manifest-shadowed whitelist load was skipped.
+        assert "bad.example" in pfb_unbound.hstsDB
+
+    def test_blacklist_off_closes_preexisting_whitelist_and_hsts_entries(self, tmp_path: Any) -> None:
+        wl_path = tmp_path / "whitelist.txt"
+        hsts_path = tmp_path / "hsts.txt"
+        pfb_unbound.pfb["pfb_py_whitelist"] = str(wl_path)
+        pfb_unbound.pfb["pfb_py_hsts"] = str(hsts_path)
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+        pfb_unbound.pfb["python_blacklist"] = False
+        pfb_unbound.pfb_py_status_open("dnsbl", str(wl_path), "parse", "boom")
+        pfb_unbound.pfb_py_status_open("dnsbl", str(hsts_path), "parse", "boom")
+        # Before-state: both entries are genuinely open first.
+        assert len(_read_status_file(pfb_unbound.pfb["pfb_py_status"])) == 2
+
+        pfb_unbound._load_whitelist_and_hsts_dbs(False)
+
+        assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
+
+    def test_blacklist_on_manifest_not_built_still_runs_both_loaders(self, tmp_path: Any) -> None:
+        # dnsbl_built=False + blacklist ON must still reach both legacy loaders
+        # (wiring check -- the skip branches must not swallow the normal path).
+        wl_path = tmp_path / "whitelist.txt"
+        wl_path.write_text("allow.example,0\n", encoding="utf-8")
+        hsts_path = tmp_path / "hsts.txt"
+        hsts_path.write_text("bad.example\n", encoding="utf-8")
+        pfb_unbound.pfb["pfb_py_whitelist"] = str(wl_path)
+        pfb_unbound.pfb["pfb_py_hsts"] = str(hsts_path)
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+        pfb_unbound.pfb["python_blacklist"] = True
+
+        pfb_unbound._load_whitelist_and_hsts_dbs(False)
+
+        assert pfb_unbound.whiteDB["allow.example"]["important"] is True
+        assert "bad.example" in pfb_unbound.hstsDB
+
+
 class TestLoadSafeSearchDbLedgerWiring:
     """_load_safesearch_db(): same fail-before/pass-after shape as the 4 mandatory
     sites, via a REAL open() OSError (not a monkeypatched csv.reader)."""
@@ -768,6 +875,19 @@ class TestDnsblBuildFromManifestLedgerWiring:
         assert pfb_unbound.dnsbl_build_from_manifest(manifest_path) is None
         assert not os.path.isfile(pfb_unbound.pfb["pfb_py_status"])
 
+    def test_missing_manifest_closes_a_preexisting_orphaned_entry(self, tmp_path: Any) -> None:
+        # issue #1049 site 7: an earlier corrupt-manifest run left this key open;
+        # the manifest is now gone -- the absent-manifest return must close it.
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+        manifest_path = str(tmp_path / "nope.json")
+        pfb_unbound.pfb_py_status_open("dnsbl", manifest_path, "parse", "boom")
+        # Before-state: the entry is genuinely open first.
+        assert len(_read_status_file(pfb_unbound.pfb["pfb_py_status"])) == 1
+
+        assert pfb_unbound.dnsbl_build_from_manifest(manifest_path) is None
+
+        assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
+
     def test_corrupt_json_opens_entry_and_keeps_freetext_log(self, tmp_path: Any, capsys: Any) -> None:
         manifest_path = tmp_path / "pfb_py_sources.json"
         manifest_path.write_text("{ this is not json", encoding="utf-8")
@@ -819,6 +939,51 @@ class TestDnsblBuildFromManifestLedgerWiring:
 
         assert result is not None
         assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
+
+
+class TestCloseDnsblLoaderEntriesWhenDisabled:
+    """_close_dnsbl_loader_entries_when_disabled(): issue #1049's 3rd skip axis --
+    python_enable OFF skips every DNSBL loader inside init_standard's guarded
+    block (reachable: python_enable is read from the ini and branched on within
+    the SAME init_standard call, so a prior True->False transition strands these)."""
+
+    def test_closes_every_preexisting_owned_entry(self, tmp_path: Any) -> None:
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+        pfb_unbound.pfb["pfb_py_sources"] = str(tmp_path / "sources.json")
+        pfb_unbound.pfb["pfb_py_zone"] = str(tmp_path / "zone.txt")
+        pfb_unbound.pfb["pfb_py_data"] = str(tmp_path / "data.txt")
+        pfb_unbound.pfb["pfb_py_whitelist"] = str(tmp_path / "whitelist.txt")
+        pfb_unbound.pfb["pfb_py_hsts"] = str(tmp_path / "hsts.txt")
+        pfb_unbound.pfb["pfb_py_ss"] = str(tmp_path / "ss.txt")
+        owned_items = (
+            pfb_unbound.pfb["pfb_py_sources"],
+            pfb_unbound.pfb["pfb_py_zone"],
+            pfb_unbound.pfb["pfb_py_data"],
+            pfb_unbound.pfb["pfb_py_whitelist"],
+            pfb_unbound.pfb["pfb_py_hsts"],
+            pfb_unbound.pfb["pfb_py_ss"],
+        )
+        for item in owned_items:
+            pfb_unbound.pfb_py_status_open("dnsbl", item, "parse", "boom")
+        # Before-state: all 6 entries are genuinely open first.
+        assert len(_read_status_file(pfb_unbound.pfb["pfb_py_status"])) == 6
+
+        pfb_unbound._close_dnsbl_loader_entries_when_disabled()
+
+        assert _read_status_file(pfb_unbound.pfb["pfb_py_status"]) == []
+
+    def test_no_preexisting_entries_is_a_safe_no_op(self, tmp_path: Any) -> None:
+        pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+        pfb_unbound.pfb["pfb_py_sources"] = str(tmp_path / "sources.json")
+        pfb_unbound.pfb["pfb_py_zone"] = str(tmp_path / "zone.txt")
+        pfb_unbound.pfb["pfb_py_data"] = str(tmp_path / "data.txt")
+        pfb_unbound.pfb["pfb_py_whitelist"] = str(tmp_path / "whitelist.txt")
+        pfb_unbound.pfb["pfb_py_hsts"] = str(tmp_path / "hsts.txt")
+        pfb_unbound.pfb["pfb_py_ss"] = str(tmp_path / "ss.txt")
+
+        pfb_unbound._close_dnsbl_loader_entries_when_disabled()
+
+        assert not os.path.isfile(pfb_unbound.pfb["pfb_py_status"])
 
 
 class TestPfbPyStatusRegisteredPath:

--- a/tests/test_adr61_py_status.py
+++ b/tests/test_adr61_py_status.py
@@ -124,37 +124,57 @@ class TestPfbPyStatusLock:
         self, tmp_path: Any, monkeypatch: Any
     ) -> None:
         import threading
-        import time
 
         status_path = str(tmp_path / "pfb_py_status.json")
         pfb_unbound.pfb["pfb_py_status"] = status_path
 
-        # Widen the window between read and write for thread "A" only, so an
-        # unlocked implementation has a real chance to interleave with thread "B"'s
-        # full read-modify-write cycle in between.
+        # issue #456: gate each thread's read on an Event instead of a fixed sleep --
+        # the patched read fires INSIDE "with _pfb_py_status_lock:", so thread A
+        # parked here genuinely HOLDS the lock (a real block, not a timing guess).
         real_read_all = pfb_unbound._pfb_py_status_read_all
+        read_done = {"A": threading.Event(), "B": threading.Event()}
+        resume = {"A": threading.Event(), "B": threading.Event()}
 
-        def slow_read_all() -> list[dict[str, Any]]:
+        def gated_read_all() -> list[dict[str, Any]]:
+            name = threading.current_thread().name
             data = real_read_all()
-            if threading.current_thread().name == "A":
-                time.sleep(0.3)
+            if name in read_done:
+                read_done[name].set()
+                if not resume[name].wait(timeout=5.0):
+                    raise AssertionError(f"thread {name} was never told to resume -- deadlock?")
             return data
 
-        monkeypatch.setattr(pfb_unbound, "_pfb_py_status_read_all", slow_read_all)
+        monkeypatch.setattr(pfb_unbound, "_pfb_py_status_read_all", gated_read_all)
 
         def open_a() -> None:
             pfb_unbound.pfb_py_status_open("dnsbl", "keyA", "parse", "A", clock_fn=lambda: 1000)
 
         def open_b() -> None:
-            time.sleep(0.05)  # let A start (and, if locked, acquire the lock) first
             pfb_unbound.pfb_py_status_open("dnsbl", "keyB", "parse", "B", clock_fn=lambda: 2000)
 
         thread_a = threading.Thread(target=open_a, name="A")
         thread_b = threading.Thread(target=open_b, name="B")
+
         thread_a.start()
+        assert read_done["A"].wait(timeout=5.0), "thread A never reached its read -- deadlock?"
+
         thread_b.start()
-        thread_a.join(timeout=5)
-        thread_b.join(timeout=5)
+        # Discriminating probe: a real lock keeps B blocked acquiring it (A still
+        # holds it, parked above) -- B never reaches its OWN read this soon. This
+        # construction cannot pass with the lock removed: an unlocked B races in,
+        # reads the SAME stale/empty state A already read, and one of the two
+        # writes clobbers the other's key below.
+        b_raced_in = read_done["B"].wait(timeout=0.5)
+
+        resume["A"].set()
+        if not b_raced_in:
+            assert read_done["B"].wait(timeout=5.0), "thread B never reached its read after A released the lock"
+        resume["B"].set()
+
+        thread_a.join(timeout=5.0)
+        thread_b.join(timeout=5.0)
+        assert not thread_a.is_alive(), "thread A did not finish -- deadlock?"
+        assert not thread_b.is_alive(), "thread B did not finish -- deadlock?"
 
         entries = _read_status_file(status_path)
         items = {entry["item"] for entry in entries}


### PR DESCRIPTION
## Summary

Fixes the ten defects the 48-hour post-merge review found in the ADR-60 (PR #1005) and ADR-61
(PR #1003) window, one commit per issue. Each commit body carries its `Fixes #NNNN`, so the
issues close on merge.

- **#1047** — deleted the 9 leftover literal `' [ NOW ]'` tokens in `pfblockerng.php`; new
  tree-wide `LogNowTokenRetiredTest` tripwire pins zero occurrences under `src/`.
- **#1048** — the download ledger now closes once per alias-pass, iff no feed row failed —
  a sibling feed's success can no longer mask an earlier feed's failure (both DNSBL and IP
  loops; per-alias key / #998 widget deep-link contract unchanged).
- **#1049** — `pfb_unbound.py` closes parse-stage ledger entries on the absent-manifest early
  return and on every skipped-loader path (manifest-built init, `python_blacklist` off,
  `python_enable` off — the last confirmed reachable), so stale entries no longer survive
  until reboot.
- **#1050** — the widget's two mutating POST handlers (settings save, Clear Failed Downloads)
  are gated by a `Sec-Fetch-Site` check (`pfb_widget_post_allowed()`), closing the cross-site
  auto-POST hole the page-wide `$nocsrf = TRUE` left open; read-only AJAX paths untouched.
- **#1052** — `pfb_sync_status_dedup_check()` reads a bounded 64 KiB tail instead of the whole
  (possibly `nolimit`-unbounded) log; the `nolimit`+age-cap trim skips its whole copy+trim pass
  when the first line hasn't expired.
- **#1053** — the array-path age-trim write now detects short writes (`strlen` compare), like
  the #1036 stream sibling.
- **#1054** — `pfb_logger()` stamps physical lines, not writes: per-target beginning-of-line
  tracking stops mid-line timestamps on progress fragments (`'.'`, `' completed .'`).
- **#1055** — the ADR-61 lock-contention tests coordinate via `threading.Event` / a child-ready
  marker file with loud deadlock guards instead of fixed sleeps (issue #456 rule).
- **#1056** — Log Settings save assigns `log_max_days_*` back to `$_POST` unconditionally, so a
  crafted POST missing a field no longer logs an "Undefined array key" warning.
- **#1057** — the Alerts/Reports day/hour bucket pipelines skip legacy pre-ISO lines
  (`grep -E '^[0-9]{4}-'`), so upgraded boxes no longer show "Nov (31)"-style buckets;
  `$d[1]` guarded against corrupt keys.

Also in this branch (already on devel via docs pushes): the ADR-60/ADR-61 §8 post-merge
amendment sections and the tree-wide-grep rule for class-shaped review findings.

## Test plan

- [x] `python3 -m pytest` — 2498 passed, 5 skipped
- [x] `vendor/bin/phpunit` — 2585 tests, 19155 assertions, 0 failures
- [x] `vendor/bin/phpstan` / `phpcs --standard=phpcs.xml.dist src/` — clean
- [x] `ruff check` / `ruff format --check` / `mypy tests/` — clean
- [x] Red→green executed and independently re-executed at the gate for every off-appliance-testable
      fix (#1047, #1048 source-pin, #1049, #1050 unit, #1052, #1053, #1054, #1055, #1057)
- [ ] Live-VM only (authored, ride the next smoke/UI dispatch): the #1050 cross-site dismiss red
      case (`test_widget_clear_failed.py`), the #1056 missing-field save case
      (`test_browser_general.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011V7CjsHkeLqnCtKsxGGMDi

---
_Generated by [Claude Code](https://claude.ai/code/session_011V7CjsHkeLqnCtKsxGGMDi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved logging consistency and alert/report summaries for cleaner, more accurate status output.
  * Added safer widget POST handling to reduce unwanted cross-site actions.

* **Bug Fixes**
  * Fixed several cases where logs, status entries, or retention checks could become stale, inaccurate, or warning-prone.
  * Improved handling of mixed or malformed log formats and reduced memory usage when reading large logs.
  * Corrected sync-status updates so failed downloads are tracked more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->