### PR TITLE
scripts: retired-token completeness guard — flag stragglers when a literal token is retired tree-wide (issue #1059)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,10 @@
             "type": "command",
             "command": "sh \"${CLAUDE_PROJECT_DIR:-.}/scripts/ts-hook.sh\" bash_rewriter_hook",
             "timeout": 2000
+          },
+          {
+            "type": "command",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && python3 scripts/check_retired_tokens.py --claude-hook || true"
           }
         ]
       }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -209,8 +209,15 @@ fi
 #     rollout -- a partial retirement can be a deliberate staged migration. ---
 if [ -n "$py_bin" ]; then
 	step 'retired-tokens (stragglers of a tree-wide token removal; advisory)'
-	"$py_bin" scripts/check_retired_tokens.py --staged \
-		|| printf 'WARN: retired-token stragglers reported above are ADVISORY (issue #1059 rollout) -- commit not blocked.\n'
+	rt_rc=0
+	"$py_bin" scripts/check_retired_tokens.py --staged || rt_rc=$?
+	if [ "$rt_rc" -eq 1 ]; then
+		printf 'WARN: retired-token stragglers reported above are ADVISORY (issue #1059 rollout) -- commit not blocked.\n'
+	elif [ "$rt_rc" -ne 0 ]; then
+		# rc>=2 = the checker itself failed to run -- distinct message so a broken
+		# guard is visible instead of masquerading as a straggler warning.
+		printf 'WARN: check_retired_tokens.py did not run (exit %s) -- retired-token guard skipped this commit.\n' "$rt_rc"
+	fi
 else
 	skip retired-tokens
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -203,6 +203,18 @@ else
 	skip comment-narration
 fi
 
+# --- Retired-token completeness guard (issue #1059): a quoted literal removed on
+#     >=3 staged scan-root lines and re-added nowhere is a retirement; any site
+#     surviving in the index is a straggler (the #1047 class). WARN-ONLY during
+#     rollout -- a partial retirement can be a deliberate staged migration. ---
+if [ -n "$py_bin" ]; then
+	step 'retired-tokens (stragglers of a tree-wide token removal; advisory)'
+	"$py_bin" scripts/check_retired_tokens.py --staged \
+		|| printf 'WARN: retired-token stragglers reported above are ADVISORY (issue #1059 rollout) -- commit not blocked.\n'
+else
+	skip retired-tokens
+fi
+
 # --- ADR phase prompts: post-contract prompts (ADR >= 60) must carry the
 #     delegation-contract blocks (VERIFICATION, HANDOFF->RESULTS, test mode,
 #     reality-override). Older ADRs are grandfathered by the script itself. ---

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -216,7 +216,7 @@ if [ -n "$py_bin" ]; then
 	elif [ "$rt_rc" -ne 0 ]; then
 		# rc>=2 = the checker itself failed to run -- distinct message so a broken
 		# guard is visible instead of masquerading as a straggler warning.
-		printf 'WARN: check_retired_tokens.py did not run (exit %s) -- retired-token guard skipped this commit.\n' "$rt_rc"
+		printf 'WARN: check_retired_tokens.py failed (exit %s) -- retired-token guard skipped this commit.\n' "$rt_rc"
 	fi
 else
 	skip retired-tokens

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -707,6 +707,36 @@ jobs:
           git fetch --no-tags origin "$BASE:refs/remotes/origin/$BASE"
           python3 scripts/check_comment_narration.py --diff "origin/$BASE"
 
+  # ── Retired-token completeness guard (issue #1059) ──
+  # PR-only, diff-scoped: a quoted literal removed on >=3 lines under the scan
+  # roots and re-added nowhere is a RETIREMENT; any surviving occurrence is a
+  # straggler the same PR should have removed (the #1047 class: 29 sites fixed
+  # in pfblockerng.inc, 9 missed in pfblockerng.php). WARN-ONLY during rollout —
+  # a partial retirement can be a deliberate staged migration; promote to
+  # blocking once the observed false-positive rate is near zero. On push it is
+  # skipped and folds into all-tests-passed as a pass, same shape as
+  # comment-narration above.
+  retired-tokens:
+    name: Retired tokens (no stragglers after a tree-wide token removal)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need the merge-base with the PR base ref for the three-dot diff
+
+      - name: Report stragglers of retired tokens (advisory)
+        # ubuntu-latest ships python3. Escape hatches: `# retired-token-ok: <reason>`
+        # on an intentional survivor line, or --token-allowlist for a staged migration.
+        env:
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -eu
+          git fetch --no-tags origin "$BASE:refs/remotes/origin/$BASE"
+          python3 scripts/check_retired_tokens.py --diff "origin/$BASE" \
+            || echo "::warning::retired-token stragglers found (ADVISORY during issue #1059 rollout — see step log above)"
+
   # Single stable job name for branch-protection required-status-checks.
   # Must use if: always() so it runs (and fails) even when 'test' fails.
   all-tests-passed:
@@ -718,7 +748,7 @@ jobs:
     # The ADR-14 UI suite (`ui-suite`) IS folded in: it is skipped (== pass) on an
     # unlabeled PR / push, and only a `ui-tests`-labeled PR whose UI suite FAILS
     # blocks here — that is how the opt-in label gates a merge.
-    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, ui-suite, coverage-pairing, comment-narration]
+    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, ui-suite, coverage-pairing, comment-narration, retired-tokens]
     runs-on: ubuntu-latest
     steps:
       - name: Check matrix results
@@ -792,4 +822,11 @@ jobs:
           case "${{ needs.comment-narration.result }}" in
             success|skipped) ;;
             *) echo "Comment-narration gate (no process narration in new comments) failed or was cancelled."; exit 1 ;;
+          esac
+          # Retired-token guard (issue #1059): warn-only during rollout, so only
+          # a cancelled/errored job (never a finding) can land here as non-success;
+          # 'skipped' (push, no PR base) is a PASS.
+          case "${{ needs.retired-tokens.result }}" in
+            success|skipped) ;;
+            *) echo "Retired-token guard job errored or was cancelled."; exit 1 ;;
           esac

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -734,8 +734,16 @@ jobs:
         run: |
           set -eu
           git fetch --no-tags origin "$BASE:refs/remotes/origin/$BASE"
-          python3 scripts/check_retired_tokens.py --diff "origin/$BASE" \
-            || echo "::warning::retired-token stragglers found (ADVISORY during issue #1059 rollout — see step log above)"
+          rc=0
+          python3 scripts/check_retired_tokens.py --diff "origin/$BASE" || rc=$?
+          if [ "$rc" -eq 1 ]; then
+            echo "::warning::retired-token stragglers found (ADVISORY during issue #1059 rollout — see step log above)"
+          elif [ "$rc" -ne 0 ]; then
+            # rc>=2 = the checker itself failed to run; only FINDINGS are advisory —
+            # a broken guard must fail loudly, never masquerade as a warning.
+            echo "::error::check_retired_tokens.py failed to run (exit $rc)"
+            exit "$rc"
+          fi
 
   # Single stable job name for branch-protection required-status-checks.
   # Must use if: always() so it runs (and fails) even when 'test' fails.
@@ -823,9 +831,10 @@ jobs:
             success|skipped) ;;
             *) echo "Comment-narration gate (no process narration in new comments) failed or was cancelled."; exit 1 ;;
           esac
-          # Retired-token guard (issue #1059): warn-only during rollout, so only
-          # a cancelled/errored job (never a finding) can land here as non-success;
-          # 'skipped' (push, no PR base) is a PASS.
+          # Retired-token guard (issue #1059): findings are warn-only during
+          # rollout, so only a tool error (checker exit >=2), cancellation, or
+          # job error can land here as non-success; 'skipped' (push, no PR
+          # base) is a PASS.
           case "${{ needs.retired-tokens.result }}" in
             success|skipped) ;;
             *) echo "Retired-token guard job errored or was cancelled."; exit 1 ;;

--- a/scripts/check_retired_tokens.py
+++ b/scripts/check_retired_tokens.py
@@ -6,10 +6,12 @@ PROBLEM
 A change that RETIRES a quoted string-literal token tree-wide (e.g. removing
 a dead log-format marker from every call site) is easy to under-apply: the
 author fixes the file(s) they were looking at and misses a sibling file with
-the same token. Commit ``958e679f`` removed the ``' [ NOW ]'`` token from 29+
-call sites in ``pfblockerng.inc`` but missed 9 sibling sites in
-``www/pfblockerng/pfblockerng.php`` (issue #1047) -- caught only by a manual
-post-merge tree grep, not by review or CI.
+the same token. Commit ``958e679f`` removed a legacy bracketed ``NOW`` log
+marker from 29+ call sites in ``pfblockerng.inc`` but missed 9 sibling sites
+in ``www/pfblockerng/pfblockerng.php`` (issue #1047) -- caught only by a
+manual post-merge tree grep, not by review or CI. (The marker is deliberately
+not written out here: this docstring would otherwise be a permanent
+"surviving site" in its own tool's report.)
 
 WHAT THIS CHECKS
 -----------------

--- a/scripts/check_retired_tokens.py
+++ b/scripts/check_retired_tokens.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Detect a retirement signature in a diff and flag any surviving stragglers.
+
+PROBLEM
+-------
+A change that RETIRES a quoted string-literal token tree-wide (e.g. removing
+a dead log-format marker from every call site) is easy to under-apply: the
+author fixes the file(s) they were looking at and misses a sibling file with
+the same token. Commit ``958e679f`` removed the ``' [ NOW ]'`` token from 29+
+call sites in ``pfblockerng.inc`` but missed 9 sibling sites in
+``www/pfblockerng/pfblockerng.php`` (issue #1047) -- caught only by a manual
+post-merge tree grep, not by review or CI.
+
+WHAT THIS CHECKS
+-----------------
+Given a git diff, this tool infers which quoted tokens were RETIRED (removed
+tree-wide, never re-added) and then tree-greps the post-change tree for any
+occurrence still surviving -- a straggler the same commit should have caught.
+
+CANDIDATE RULE
+--------------
+From every REMOVED line under the scan roots (``src/``, ``scripts/``,
+``.github/workflows/``), extract each single- or double-quoted span's inner
+text. A candidate token is the raw (whitespace-preserving) inner text of one
+such span, kept only if its TRIMMED form is at least 4 characters long and
+contains at least one ASCII alphanumeric character (drops noise like bare
+punctuation or single-character quoting artefacts).
+
+A candidate is RETIRED iff it appears (plain substring, not regex) on at
+least 3 removed scan-root lines and on ZERO added scan-root lines -- a token
+that moved (removed here, re-added elsewhere) is not a retirement. Lines
+outside the scan roots (e.g. ``tests/``) never contribute to either count,
+matching the class of files the retiring commit itself was expected to fix.
+
+For each retired token, the post-change tree is searched with a fixed-string
+``git grep -F`` (never a regex) over the same scan roots. Every surviving hit
+is a straggler UNLESS its line carries the escape comment (see below).
+
+MODES
+-----
+``--staged``
+    Diff = ``git diff --cached --unified=0``; stragglers are searched in the
+    INDEX (``git grep --cached``) -- for a pre-commit hook.
+``--diff <base>``
+    Diff = ``git diff <base>...HEAD --unified=0``; stragglers are searched in
+    ``HEAD`` -- for CI/ad-hoc invocation against a PR branch.
+``--token-allowlist <token>`` (repeatable)
+    Skip a retired token entirely -- an escape hatch for a deliberate,
+    staged, multi-commit migration. Combines with ``--staged``/``--diff``.
+``--claude-hook``
+    A Claude Code PreToolUse hook (Bash tool) form. Reads the whole stdin
+    hook payload, normalizes it (strip ``"``/``\\``, collapse whitespace
+    runs to one space -- mirrors ``claude-bash-guard.sh``), and only runs
+    the ``--staged``-equivalent analysis when the normalized text contains
+    ``git commit`` (i.e. the agent is about to commit). Findings are
+    reported as ONE JSON line
+    (``{"hookSpecificOutput": {"hookEventName": "PreToolUse",
+    "additionalContext": <report>}}``) on stdout. FAIL-OPEN: any exception
+    (garbled stdin, no git, not a repo) or a clean result exits 0 with no
+    output -- this mode never blocks a commit and never exits nonzero.
+
+ESCAPE HATCHES
+---------------
+* A surviving line containing the substring ``retired-token-ok:`` is exempt
+  (any comment syntax; plain substring test) -- mark an intentional survivor
+  inline with ``# retired-token-ok: <reason>``.
+* ``--token-allowlist <token>`` skips a token for a staged migration.
+
+EXIT STATUS
+-----------
+``--staged``/``--diff``: 0 = clean, 1 = stragglers reported, 2 = usage or git
+error. ``--claude-hook``: always 0.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+
+# Tracked-tree roots a retiring commit is expected to have fixed everywhere.
+_SCAN_ROOTS = ("src", "scripts", ".github/workflows")
+
+# Mirrors check_version_literals._QUOTED_RE (double-quote escape-aware,
+# single-quote naive); extra/missed candidates from an edge-case quote
+# parse self-correct at the retirement-count stage below.
+_QUOTED_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|\'([^\']*)\'|`(?:[^`\\]|\\.)*`')
+
+_ASCII_ALNUM_RE = re.compile(r"[A-Za-z0-9]")
+
+_ESCAPE = "retired-token-ok:"
+
+_REPORT_HINT = (
+    "Fix the straggler(s) tree-wide, mark an intentional survivor with "
+    "`# retired-token-ok: <reason>`, or pass --token-allowlist for a staged migration."
+)
+
+
+class _GitError(Exception):
+    """Raised when a git subprocess exits with an unexpected (non 0/1) status."""
+
+
+def _in_scan_roots(path_str: str) -> bool:
+    """True if a diff path lives under a scan root."""
+    return any(path_str == root or path_str.startswith(f"{root}/") for root in _SCAN_ROOTS)
+
+
+def _quoted_literals(line: str) -> list[str]:
+    """Return the inner text of every single- or double-quoted span on ``line``."""
+    return [g for m in _QUOTED_RE.finditer(line) for g in m.groups() if g is not None]
+
+
+def _is_candidate(token: str) -> bool:
+    stripped = token.strip()
+    return len(stripped) >= 4 and bool(_ASCII_ALNUM_RE.search(stripped))
+
+
+def _parse_diff(diff_text: str) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Split a unified diff into per-path removed/added CONTENT lines (scan-root-scoped).
+
+    A deleted file's ``+++`` target is ``/dev/null``; its path comes from the
+    preceding ``--- a/<path>`` instead -- deleted files are prime retirement
+    sources and must still contribute their removed lines.
+    """
+    removed: dict[str, list[str]] = {}
+    added: dict[str, list[str]] = {}
+    path: str | None = None
+    a_path: str | None = None
+    in_hunk = False
+    for raw in diff_text.splitlines():
+        if raw.startswith("diff --git"):
+            path = None
+            a_path = None
+            in_hunk = False
+            continue
+        if raw.startswith("@@"):
+            in_hunk = True
+            continue
+        if not in_hunk:
+            if raw.startswith("--- "):
+                name = raw[4:]
+                if name.startswith("a/"):
+                    a_path = name[2:].split("\t", 1)[0]
+            elif raw.startswith("+++ "):
+                name = raw[4:]
+                if name.startswith("b/"):
+                    path = name[2:].split("\t", 1)[0]
+                elif name.split("\t", 1)[0] == "/dev/null":
+                    path = a_path
+            continue
+        if raw.startswith("\\"):
+            continue  # issue #1051: skip the backslash marker -- it is not content
+        if path is None or not _in_scan_roots(path):
+            continue
+        if raw.startswith("-"):
+            removed.setdefault(path, []).append(raw[1:])
+        elif raw.startswith("+"):
+            added.setdefault(path, []).append(raw[1:])
+    return removed, added
+
+
+def _candidate_tokens(removed: dict[str, list[str]]) -> set[str]:
+    return {lit for lines in removed.values() for line in lines for lit in _quoted_literals(line) if _is_candidate(lit)}
+
+
+def find_retired_tokens(removed: dict[str, list[str]], added: dict[str, list[str]]) -> list[str]:
+    """Return, sorted, every candidate token retired by this diff (>=3 removed, 0 added hits)."""
+    all_removed = [line for lines in removed.values() for line in lines]
+    all_added = [line for lines in added.values() for line in lines]
+    retired = []
+    for token in _candidate_tokens(removed):
+        removed_count = sum(1 for line in all_removed if token in line)
+        added_count = sum(1 for line in all_added if token in line)
+        if removed_count >= 3 and added_count == 0:
+            retired.append(token)
+    return sorted(retired)
+
+
+def _git_diff(args: list[str]) -> str:
+    # Same flag set as check_version_literals._git_diff: pin quotePath/prefixes/
+    # ext-diff so config/env cannot defeat the +++ b/ parse.
+    out = subprocess.run(
+        [
+            "git",
+            "-c",
+            "core.quotePath=false",
+            "diff",
+            "--unified=0",
+            "--no-color",
+            "--no-ext-diff",
+            "--src-prefix=a/",
+            "--dst-prefix=b/",
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    return out.stdout
+
+
+def _grep_token(token: str, cached: bool) -> list[str]:
+    """Fixed-string search the post-change tree for ``token``; exit 1 = clean, not an error."""
+    cmd = ["git", "grep", "-Fn"]
+    if cached:
+        cmd.append("--cached")
+    cmd += ["-e", token]
+    if not cached:
+        cmd.append("HEAD")
+    cmd += ["--", *_SCAN_ROOTS]
+    out = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    if out.returncode == 1:
+        return []
+    if out.returncode != 0:
+        raise _GitError(out.stderr.strip())
+    lines = out.stdout.splitlines()
+    if not cached:
+        lines = [ln.removeprefix("HEAD:") for ln in lines]
+    return [ln for ln in lines if _ESCAPE not in ln]
+
+
+def analyze_diff(diff_text: str, allowlist: set[str], cached: bool) -> dict[str, list[str]]:
+    """Return, per retired token still present post-change, its (exemption-filtered) hit lines."""
+    removed, added = _parse_diff(diff_text)
+    findings: dict[str, list[str]] = {}
+    for token in find_retired_tokens(removed, added):
+        if token in allowlist:
+            continue
+        hits = _grep_token(token, cached)
+        if hits:
+            findings[token] = hits
+    return findings
+
+
+def format_report(findings: dict[str, list[str]]) -> str:
+    lines: list[str] = []
+    for token in sorted(findings):
+        hits = sorted(findings[token])
+        lines.append(f"{token!r}: {len(hits)} site(s) remain:")
+        lines.extend(f"  {hit}" for hit in hits)
+    lines.append(_REPORT_HINT)
+    return "\n".join(lines)
+
+
+def _usage() -> int:
+    print(
+        "usage: check_retired_tokens.py --staged | --diff <base> [--token-allowlist <token> ...] | --claude-hook",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def _run_claude_hook() -> None:
+    try:
+        payload = sys.stdin.read()
+        normalized = re.sub(r"\s+", " ", payload.replace('"', "").replace("\\", ""))
+        if "git commit" not in normalized:
+            return
+        diff_text = _git_diff(["--cached"])
+        findings = analyze_diff(diff_text, allowlist=set(), cached=True)
+        if not findings:
+            return
+        report = format_report(findings)
+        print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": report}}))
+    except Exception:
+        return  # FAIL-OPEN: never block a commit on a parse/git failure
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--claude-hook":
+        _run_claude_hook()
+        return 0
+    mode: str | None = None
+    base: str | None = None
+    allowlist: set[str] = set()
+    it = iter(argv)
+    for arg in it:
+        if arg == "--staged":
+            if mode is not None:
+                return _usage()
+            mode = "staged"
+        elif arg == "--diff":
+            if mode is not None:
+                return _usage()
+            mode = "diff"
+            base = next(it, None)
+            if not base:
+                return _usage()
+        elif arg == "--token-allowlist":
+            token = next(it, None)
+            if token is None:
+                return _usage()
+            allowlist.add(token)
+        else:
+            return _usage()
+    if mode is None:
+        return _usage()
+    diff_args = ["--cached"] if mode == "staged" else [f"{base}...HEAD"]
+    try:
+        diff_text = _git_diff(diff_args)
+    except subprocess.CalledProcessError as exc:
+        print(f"git diff failed: {exc.stderr.strip()}", file=sys.stderr)
+        return 2
+    try:
+        findings = analyze_diff(diff_text, allowlist, cached=(mode == "staged"))
+    except _GitError as exc:
+        print(f"git grep failed: {exc}", file=sys.stderr)
+        return 2
+    if not findings:
+        return 0
+    print(format_report(findings))
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_retired_tokens.py
+++ b/scripts/check_retired_tokens.py
@@ -29,10 +29,14 @@ contains at least one ASCII alphanumeric character (drops noise like bare
 punctuation or single-character quoting artefacts).
 
 A candidate is RETIRED iff it appears (plain substring, not regex) on at
-least 3 removed scan-root lines and on ZERO added scan-root lines -- a token
-that moved (removed here, re-added elsewhere) is not a retirement. Lines
-outside the scan roots (e.g. ``tests/``) never contribute to either count,
-matching the class of files the retiring commit itself was expected to fix.
+least 3 removed scan-root lines AND is not re-added anywhere as the SAME
+quoted literal -- the added side matches exact single-/double-quoted spans,
+never raw substrings, so an added line that merely contains the token's
+bytes inside a longer unrelated string cannot silently suppress a genuine
+retirement. (A re-add inside a backtick span is not recognized -- backtick
+spans donate no candidates on either side.) Lines outside the scan roots
+(e.g. ``tests/``) never contribute to either side, matching the class of
+files the retiring commit itself was expected to fix.
 
 For each retired token, the post-change tree is searched with a fixed-string
 ``git grep -F`` (never a regex) over the same scan roots. Every surviving hit

--- a/scripts/check_retired_tokens.py
+++ b/scripts/check_retired_tokens.py
@@ -151,8 +151,6 @@ def _parse_diff(diff_text: str) -> tuple[dict[str, list[str]], dict[str, list[st
                 elif name.split("\t", 1)[0] == "/dev/null":
                     path = a_path
             continue
-        if raw.startswith("\\"):
-            continue  # issue #1051: skip the backslash marker -- it is not content
         if path is None or not _in_scan_roots(path):
             continue
         if raw.startswith("-"):
@@ -167,15 +165,21 @@ def _candidate_tokens(removed: dict[str, list[str]]) -> set[str]:
 
 
 def find_retired_tokens(removed: dict[str, list[str]], added: dict[str, list[str]]) -> list[str]:
-    """Return, sorted, every candidate token retired by this diff (>=3 removed, 0 added hits)."""
+    """Return, sorted, every candidate token retired by this diff.
+
+    Retired = the token appears (plain substring) on >=3 removed lines and is
+    not re-added anywhere as the SAME quoted literal. The added side matches
+    exact quoted spans, never raw substrings: an added line that merely
+    contains the token's bytes inside a longer, unrelated string must not
+    silently suppress a genuine retirement (a tree-wide false negative).
+    """
     all_removed = [line for lines in removed.values() for line in lines]
-    all_added = [line for lines in added.values() for line in lines]
-    retired = []
-    for token in _candidate_tokens(removed):
-        removed_count = sum(1 for line in all_removed if token in line)
-        added_count = sum(1 for line in all_added if token in line)
-        if removed_count >= 3 and added_count == 0:
-            retired.append(token)
+    added_spans = {lit for lines in added.values() for line in lines for lit in _quoted_literals(line)}
+    retired = [
+        token
+        for token in _candidate_tokens(removed)
+        if token not in added_spans and sum(1 for line in all_removed if token in line) >= 3
+    ]
     return sorted(retired)
 
 
@@ -237,12 +241,28 @@ def analyze_diff(diff_text: str, allowlist: set[str], cached: bool) -> dict[str,
     return findings
 
 
+def _hit_key(hit: str) -> tuple[str, int]:
+    """Sort key for a ``path:lineno:content`` grep line: numeric by line within a file."""
+    path, _, rest = hit.partition(":")
+    lineno = rest.partition(":")[0]
+    return (path, int(lineno) if lineno.isdigit() else 0)
+
+
 def format_report(findings: dict[str, list[str]]) -> str:
+    """Render findings; tokens with IDENTICAL hit sets merge into one block.
+
+    A retiring diff often donates near-duplicate candidates (a code token and
+    its comment-quoted variant) that grep to the same sites -- print those
+    sites once, under all their token reprs, instead of repeating the block.
+    """
+    by_hits: dict[tuple[str, ...], list[str]] = {}
+    for token, hits in findings.items():
+        by_hits.setdefault(tuple(sorted(hits, key=_hit_key)), []).append(token)
     lines: list[str] = []
-    for token in sorted(findings):
-        hits = sorted(findings[token])
-        lines.append(f"{token!r}: {len(hits)} site(s) remain:")
-        lines.extend(f"  {hit}" for hit in hits)
+    for hits_key, tokens in sorted(by_hits.items(), key=lambda kv: min(kv[1])):
+        reprs = ", ".join(repr(t) for t in sorted(tokens))
+        lines.append(f"{reprs}: {len(hits_key)} site(s) remain:")
+        lines.extend(f"  {hit}" for hit in hits_key)
     lines.append(_REPORT_HINT)
     return "\n".join(lines)
 

--- a/tests/test_retired_token_check.py
+++ b/tests/test_retired_token_check.py
@@ -2,12 +2,14 @@
 
 Every candidate/threshold rule is paired with the nearest form that must
 stay clean, so a green run proves the checker discriminates a genuine
-tree-wide retirement (issue #1047's ``' [ NOW ]'`` shape: >=3 removed sites,
-0 re-adds) from a rename/move, a partial edit, or noise -- rather than firing
-on any repeated quoted string.
+tree-wide retirement (issue #1047's bracketed NOW-marker shape: >=3 removed
+sites, 0 exact re-adds) from a rename/move, a partial edit, or noise --
+rather than firing on any repeated quoted string.
 
 Fixture tokens are assembled at runtime (string concatenation) so this
-tracked test file does not itself contain a flaggable literal, mirroring
+tracked test file does not itself contain a flaggable literal -- the exemplar
+marker is deliberately not written out either, else this file would be a
+permanent "surviving site" in its own tool's report. Mirrors
 tests/test_version_literal_check.py's convention.
 """
 
@@ -286,8 +288,10 @@ def test_r10_pure_punctuation_token_skipped() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# R11 -- '\ No newline at end of file' marker: not counted as content;
-# candidate math identical with vs without it present (issue #1051 lesson)
+# R11 -- '\ No newline at end of file' marker: not counted as content
+# (issue #1051 class). Pins the PROPERTY, not a mechanism: the current
+# prefix-dispatch parser skips the marker structurally; this test is the
+# tripwire for a future lineno/index-tracking rewrite counting it as content.
 # --------------------------------------------------------------------------- #
 
 
@@ -513,3 +517,134 @@ def test_r18_unquoted_token_never_becomes_a_candidate() -> None:
     diff = _diff_hunk("src/a.php", removed=[f"x = {tok};" for _ in range(3)], added=[])
     retired = _retired(diff)
     assert tok not in retired, f"an unquoted-only token must never seed a candidate; got retired={retired}"
+
+
+# --------------------------------------------------------------------------- #
+# R19 -- an ADDED line that merely CONTAINS the token's bytes inside a longer,
+# unrelated string must NOT suppress the retirement (suppression is exact
+# quoted-span re-adds only); a genuine exact re-add still suppresses (R3).
+# --------------------------------------------------------------------------- #
+
+
+def test_r19_substring_in_added_line_does_not_suppress(tmp_path: Path) -> None:
+    tok = "TOK" + "_R19_MARK"
+    _init_repo(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/a.php").write_text("\n".join(f"logger('{tok}');" for _ in range(3)) + "\n")
+    (tmp_path / "src/b.php").write_text(f"echo '{tok} survivor';\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+
+    (tmp_path / "src/a.php").write_text("logger();\n" * 3)
+    (tmp_path / "src/c.php").write_text(f"// unrelated: X{tok}X appears here by coincidence\n")
+    _git(tmp_path, "add", ".")
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 1, (
+        f"a coincidental substring on an added line must not silently kill the finding; "
+        f"got {res.returncode}, stdout={res.stdout!r}, stderr={res.stderr}"
+    )
+    assert "src/b.php:1" in res.stdout, f"the survivor must be reported; got stdout={res.stdout!r}"
+
+
+def test_r19_exact_quoted_readd_embedded_in_longer_string_does_not_suppress() -> None:
+    tok = "TOK" + "_R19B_MARK"
+    diff = _diff_hunk(
+        "src/a.php",
+        removed=[f"logger('{tok}');" for _ in range(3)],
+        added=[f'x = "prefix {tok} suffix";'],
+    )
+    retired = _retired(diff)
+    assert tok in retired, (
+        f"a token embedded inside a LONGER added quoted string is not a re-add of the same "
+        f"literal and must stay retired; got retired={retired}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# R20 -- the two non-src scan roots (scripts/, .github/workflows/) are in
+# scope for extraction AND for the straggler grep; a lookalike prefix
+# (.github/workflowsX/) is NOT a scan root.
+# --------------------------------------------------------------------------- #
+
+
+def test_r20_scripts_and_workflows_roots_in_scope(tmp_path: Path) -> None:
+    tok = "TOK" + "_R20_MARK"
+    _init_repo(tmp_path)
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / ".github/workflows").mkdir(parents=True)
+    (tmp_path / ".github/workflows/w.yml").write_text("\n".join(f"run: x '{tok}'" for _ in range(3)) + "\n")
+    (tmp_path / "scripts/s.sh").write_text(f"echo '{tok} survivor'\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+
+    (tmp_path / ".github/workflows/w.yml").write_text("run: x\n" * 3)
+    _git(tmp_path, "add", ".")
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 1, (
+        f"a retirement in .github/workflows with a survivor in scripts/ must flag; "
+        f"got {res.returncode}, stdout={res.stdout!r}, stderr={res.stderr}"
+    )
+    assert "scripts/s.sh:1" in res.stdout, f"the scripts/ survivor must be reported; got stdout={res.stdout!r}"
+
+
+def test_r20_lookalike_root_prefix_out_of_scope() -> None:
+    tok = "TOK" + "_R20B_MARK"
+    diff = _diff_hunk(".github/workflowsX/w.yml", removed=[f"run: x '{tok}'" for _ in range(3)], added=[])
+    retired = _retired(diff)
+    assert tok not in retired, f"a lookalike directory prefix must not count as a scan root; got retired={retired}"
+
+
+# --------------------------------------------------------------------------- #
+# R21 -- the git-error half of exit 2: an unresolvable --diff base fails
+# loudly (never a silent pass, never conflated with findings' exit 1).
+# --------------------------------------------------------------------------- #
+
+
+def test_r21_git_error_exits_2(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "f.txt").write_text("x\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+    res = _run(tmp_path, "--diff", "nonexistent-base-ref")
+    assert res.returncode == 2, f"a git failure must exit 2; got {res.returncode}, stdout={res.stdout!r}"
+    assert "git diff failed" in res.stderr, f"the git error must reach stderr; got stderr={res.stderr!r}"
+
+
+# --------------------------------------------------------------------------- #
+# R22 -- report hits sort NUMERICALLY by line within a file (417 before 2196),
+# not lexicographically ("2196" < "417" as strings).
+# --------------------------------------------------------------------------- #
+
+
+def test_r22_report_hits_sorted_numerically() -> None:
+    tok = "TOK" + "_R22_MARK"
+    report = crt.format_report({tok: [f"src/f.php:2196:x('{tok}');", f"src/f.php:417:y('{tok}');"]})
+    assert report.index(":417:") < report.index(":2196:"), (
+        f"hits must sort numerically by line number within a file; got report={report!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# R23 -- tokens whose surviving-hit sets are IDENTICAL (e.g. a code token and
+# its comment-quoted variant, both matching the same sites) merge into ONE
+# report block; distinct hit sets keep separate blocks.
+# --------------------------------------------------------------------------- #
+
+
+def test_r23_identical_hit_sets_merge_into_one_block() -> None:
+    tok_a = " [ TOK" + "_R23 ]"
+    tok_b = "[ TOK" + "_R23 ]"
+    hits = ["src/f.php:10:x", "src/f.php:20:y"]
+    report = crt.format_report({tok_a: list(hits), tok_b: list(hits)})
+    assert repr(tok_a) in report and repr(tok_b) in report, f"both token reprs must appear; got {report!r}"
+    assert report.count("src/f.php:10:x") == 1, (
+        f"identical hit sets must print once, merged under both tokens; got report={report!r}"
+    )
+    assert f"{len(hits)} site(s) remain:" in report
+
+
+def test_r23_distinct_hit_sets_stay_separate_blocks() -> None:
+    tok_a = "TOK" + "_R23A"
+    tok_b = "TOK" + "_R23B"
+    report = crt.format_report({tok_a: ["src/f.php:10:x"], tok_b: ["src/g.php:5:z"]})
+    assert report.count("site(s) remain:") == 2, f"distinct hit sets must keep separate blocks; got report={report!r}"

--- a/tests/test_retired_token_check.py
+++ b/tests/test_retired_token_check.py
@@ -1,0 +1,515 @@
+"""Tests for scripts/check_retired_tokens.py.
+
+Every candidate/threshold rule is paired with the nearest form that must
+stay clean, so a green run proves the checker discriminates a genuine
+tree-wide retirement (issue #1047's ``' [ NOW ]'`` shape: >=3 removed sites,
+0 re-adds) from a rename/move, a partial edit, or noise -- rather than firing
+on any repeated quoted string.
+
+Fixture tokens are assembled at runtime (string concatenation) so this
+tracked test file does not itself contain a flaggable literal, mirroring
+tests/test_version_literal_check.py's convention.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_retired_tokens.py"
+_spec = importlib.util.spec_from_file_location("check_retired_tokens", _TOOL)
+assert _spec is not None and _spec.loader is not None
+crt = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = crt
+_spec.loader.exec_module(crt)
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic-diff helpers (pure parsing/candidate rows -- no real git needed)
+# --------------------------------------------------------------------------- #
+
+
+def _diff_hunk(path: str, removed: list[str], added: list[str], old_path: str | None = None) -> str:
+    """One file's unified-diff section (mirrors ``git diff --unified=0`` shape)."""
+    a = old_path or path
+    lines = [f"diff --git a/{a} b/{path}", f"--- a/{a}", f"+++ b/{path}", "@@ -1,0 +1,0 @@"]
+    lines += [f"-{ln}" for ln in removed]
+    lines += [f"+{ln}" for ln in added]
+    return "\n".join(lines) + "\n"
+
+
+def _deleted_diff_hunk(path: str, removed: list[str]) -> str:
+    lines = [
+        f"diff --git a/{path} b/{path}",
+        "deleted file mode 100644",
+        f"--- a/{path}",
+        "+++ /dev/null",
+        "@@ -1,0 +0,0 @@",
+    ]
+    lines += [f"-{ln}" for ln in removed]
+    return "\n".join(lines) + "\n"
+
+
+def _diff_hunk_with_marker(path: str, removed: list[str]) -> str:
+    """A removed-only hunk followed by the ``\\ No newline`` marker (issue #1051 shape)."""
+    lines = [f"diff --git a/{path} b/{path}", f"--- a/{path}", f"+++ b/{path}", "@@ -1,0 +1,0 @@"]
+    lines += [f"-{ln}" for ln in removed]
+    lines.append("\\ No newline at end of file")
+    return "\n".join(lines) + "\n"
+
+
+def _retired(diff_text: str) -> list[str]:
+    removed, added = crt._parse_diff(diff_text)
+    return crt.find_retired_tokens(removed, added)
+
+
+# --------------------------------------------------------------------------- #
+# Real-git helpers (CLI-mode / grep-target rows -- mirrors
+# tests/test_version_literal_check.py's subprocess harness)
+# --------------------------------------------------------------------------- #
+
+
+def _init_repo(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True, capture_output=True)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(_TOOL), *args], cwd=repo, capture_output=True, text=True)
+
+
+def _run_hook(repo: Path, stdin_text: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_TOOL), "--claude-hook"], cwd=repo, input=stdin_text, capture_output=True, text=True
+    )
+
+
+def _rev(repo: Path) -> str:
+    out = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True)
+    return out.stdout.strip()
+
+
+def _seed_retirement_with_survivor(repo: Path, tok: str) -> None:
+    """Commit src/a.php (3 quoted ``tok`` sites) + src/b.php (1 untouched site), then STAGE a.php's retirement."""
+    _init_repo(repo)
+    (repo / "src").mkdir()
+    (repo / "src/a.php").write_text("\n".join(f"logger('{tok}');" for _ in range(3)) + "\n")
+    (repo / "src/b.php").write_text(f"echo '{tok} survivor';\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+    (repo / "src/a.php").write_text("logger();\n" * 3)
+    _git(repo, "add", ".")
+
+
+# --------------------------------------------------------------------------- #
+# R1 -- threshold-hit: 3 removed, 0 added, 1 surviving site -> flagged
+# --------------------------------------------------------------------------- #
+
+
+def test_r1_threshold_hit_staged(tmp_path: Path) -> None:
+    tok = "TOK" + "_R1S_MARK"
+    _seed_retirement_with_survivor(tmp_path, tok)
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 1, f"expected exit 1 (findings); got {res.returncode}, stderr={res.stderr}"
+    assert f"{tok!r}: 1 site(s) remain:" in res.stdout, f"expected exactly 1 site reported; got stdout={res.stdout!r}"
+    assert "src/b.php:1" in res.stdout, f"report must name the surviving site; got stdout={res.stdout!r}"
+
+
+def test_r1_threshold_hit_diff_mode_strips_head_prefix(tmp_path: Path) -> None:
+    tok = "TOK" + "_R1D_MARK"
+    _init_repo(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/a.php").write_text("\n".join(f"logger('{tok}');" for _ in range(3)) + "\n")
+    (tmp_path / "src/b.php").write_text(f"echo '{tok} survivor';\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+    base = _rev(tmp_path)
+
+    (tmp_path / "src/a.php").write_text("logger();\n" * 3)
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "retire token")
+    res = _run(tmp_path, "--diff", base)
+    assert res.returncode == 1, f"expected exit 1; got {res.returncode}, stderr={res.stderr}"
+    assert "HEAD:" not in res.stdout, f"the HEAD: revision prefix must be stripped; got stdout={res.stdout!r}"
+    assert "src/b.php:1" in res.stdout, f"report must name the surviving site; got stdout={res.stdout!r}"
+
+
+# --------------------------------------------------------------------------- #
+# R2 -- threshold-under: 2 removed lines only -> NOT flagged
+# --------------------------------------------------------------------------- #
+
+
+def test_r2_threshold_under_two_removed_lines_not_flagged() -> None:
+    tok = "TOK" + "_R2_MARK"
+    diff = _diff_hunk("src/a.php", removed=[f"logger('{tok}');" for _ in range(2)], added=[])
+    retired = _retired(diff)
+    assert tok not in retired, f"2 removed lines must be below the >=3 threshold; got retired={retired}"
+
+
+# --------------------------------------------------------------------------- #
+# R3 -- moved token: 3 removed + 1 added -> NOT flagged (a move, not a retirement)
+# --------------------------------------------------------------------------- #
+
+
+def test_r3_moved_token_not_flagged() -> None:
+    tok = "TOK" + "_R3_MARK"
+    diff = _diff_hunk("src/a.php", removed=[f"logger('{tok}');" for _ in range(3)], added=[f"logger('{tok}');"])
+    retired = _retired(diff)
+    assert tok not in retired, f"a token re-added elsewhere must not be treated as retired; got retired={retired}"
+
+
+# --------------------------------------------------------------------------- #
+# R4 -- added-outside-scan-roots: 3 removed (scan-root) + 1 added under tests/
+# -> STILL flagged (the 958e679f shape -- its only additions were test-only)
+# --------------------------------------------------------------------------- #
+
+
+def test_r4_added_outside_scan_roots_still_flagged() -> None:
+    tok = "TOK" + "_R4_MARK"
+    diff = _diff_hunk("src/a.php", removed=[f"logger('{tok}');" for _ in range(3)], added=[]) + _diff_hunk(
+        "tests/fixture.py", removed=[], added=[f"assert '{tok}' not in log"]
+    )
+    retired = _retired(diff)
+    assert tok in retired, f"an addition OUTSIDE scan roots must not block retirement; got retired={retired}"
+
+
+# --------------------------------------------------------------------------- #
+# R5 -- removed-outside-scan-roots only -> no candidate
+# --------------------------------------------------------------------------- #
+
+
+def test_r5_removed_outside_scan_roots_no_candidate() -> None:
+    tok = "TOK" + "_R5_MARK"
+    diff = _diff_hunk("tests/fixture.py", removed=[f"assert '{tok}' not in log" for _ in range(3)], added=[])
+    retired = _retired(diff)
+    assert tok not in retired, f"removed lines outside scan roots must never seed a candidate; got retired={retired}"
+
+
+# --------------------------------------------------------------------------- #
+# R6 -- zero remaining sites: retired, but nothing survives -> exit 0, NO output
+# --------------------------------------------------------------------------- #
+
+
+def test_r6_zero_remaining_sites_no_output(tmp_path: Path) -> None:
+    tok = "TOK" + "_R6_MARK"
+    _init_repo(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/a.php").write_text("\n".join(f"logger('{tok}');" for _ in range(3)) + "\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+
+    (tmp_path / "src/a.php").write_text("logger();\n" * 3)
+    _git(tmp_path, "add", ".")
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 0, f"a fully retired token with no stragglers must exit 0; got {res.returncode}"
+    assert res.stdout == "", f"a clean result must print nothing; got stdout={res.stdout!r}"
+
+
+# --------------------------------------------------------------------------- #
+# R7 -- escape comment: 2 surviving sites, 1 carries retired-token-ok -> only
+# the OTHER site is reported (vacuity guard: proves the exemption discriminates)
+# --------------------------------------------------------------------------- #
+
+
+def test_r7_escape_comment_exempts_only_that_site(tmp_path: Path) -> None:
+    tok = "TOK" + "_R7_MARK"
+    _init_repo(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/a.php").write_text("\n".join(f"logger('{tok}');" for _ in range(3)) + "\n")
+    (tmp_path / "src/b.php").write_text(f"echo '{tok} survivor';\n")
+    (tmp_path / "src/c.php").write_text(f"echo '{tok} kept';  # retired-token-ok: legacy fixture\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+
+    (tmp_path / "src/a.php").write_text("logger();\n" * 3)
+    _git(tmp_path, "add", ".")
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 1, f"one non-exempt straggler must still flag; got {res.returncode}, stderr={res.stderr}"
+    assert "src/b.php:1" in res.stdout, f"the non-exempt site must be reported; got stdout={res.stdout!r}"
+    assert "src/c.php" not in res.stdout, f"the escaped site must be exempt; got stdout={res.stdout!r}"
+    assert f"{tok!r}: 1 site(s) remain:" in res.stdout, f"expected exactly 1 surviving site; got stdout={res.stdout!r}"
+
+
+# --------------------------------------------------------------------------- #
+# R8 -- allowlist: retirement + straggler present, but token allowlisted
+# -> exit 0
+# --------------------------------------------------------------------------- #
+
+
+def test_r8_allowlist_skips_token(tmp_path: Path) -> None:
+    tok = "TOK" + "_R8_MARK"
+    _seed_retirement_with_survivor(tmp_path, tok)
+    res = _run(tmp_path, "--staged", "--token-allowlist", tok)
+    assert res.returncode == 0, (
+        f"an allowlisted retired token must not flag; got {res.returncode}, stdout={res.stdout!r}"
+    )
+    assert res.stdout == "", f"an allowlisted-clean result must print nothing; got stdout={res.stdout!r}"
+
+
+# --------------------------------------------------------------------------- #
+# R9 -- min-length gate: trimmed length 3 skipped, length 4 is a candidate
+# --------------------------------------------------------------------------- #
+
+
+def test_r9_min_length_gate_both_sides() -> None:
+    short = "AB1"  # trimmed length 3 -- below the gate
+    long_ = "AB12"  # trimmed length 4 -- at the gate
+    diff = _diff_hunk("src/a.php", removed=[f"x('{short}');" for _ in range(3)], added=[]) + _diff_hunk(
+        "src/b.php", removed=[f"y('{long_}');" for _ in range(3)], added=[]
+    )
+    retired = _retired(diff)
+    assert short not in retired, f"a length-3 token must be skipped; got retired={retired}"
+    assert long_ in retired, f"a length-4 token must be a candidate; got retired={retired}"
+
+
+# --------------------------------------------------------------------------- #
+# R10 -- pure-punctuation token (length >= 4, no alnum) -> skipped
+# --------------------------------------------------------------------------- #
+
+
+def test_r10_pure_punctuation_token_skipped() -> None:
+    punct = "-" * 4
+    diff = _diff_hunk("src/a.php", removed=[f"x('{punct}');" for _ in range(3)], added=[])
+    retired = _retired(diff)
+    assert punct not in retired, f"a no-alnum token must be skipped even at length >=4; got retired={retired}"
+
+
+# --------------------------------------------------------------------------- #
+# R11 -- '\ No newline at end of file' marker: not counted as content;
+# candidate math identical with vs without it present (issue #1051 lesson)
+# --------------------------------------------------------------------------- #
+
+
+def test_r11_no_newline_marker_not_counted_as_content() -> None:
+    tok = "TOK" + "_R11_MARK"
+    removed_lines = [f"x('{tok}');" for _ in range(3)]
+    with_marker = _retired(_diff_hunk_with_marker("src/a.php", removed_lines))
+    without_marker = _retired(_diff_hunk("src/a.php", removed=removed_lines, added=[]))
+    assert with_marker == without_marker, (
+        f"the no-newline marker must not change retirement math; "
+        f"with_marker={with_marker} without_marker={without_marker}"
+    )
+    assert tok in with_marker, f"expected {tok!r} retired even with the marker present; got {with_marker}"
+
+
+# --------------------------------------------------------------------------- #
+# R12 -- deleted-file diff: '+++ /dev/null', path taken from '--- a/'
+# --------------------------------------------------------------------------- #
+
+
+def test_r12_deleted_file_removed_lines_contribute_from_a_path() -> None:
+    tok = "TOK" + "_R12_MARK"
+    diff = _deleted_diff_hunk("src/gone.php", removed=[f"x('{tok}');" for _ in range(3)])
+    retired = _retired(diff)
+    assert tok in retired, f"a deleted file's removed lines must still seed candidates; got retired={retired}"
+
+
+# --------------------------------------------------------------------------- #
+# R13 -- header lines ('--- a/...' / '+++ b/...') never enter content lists
+# --------------------------------------------------------------------------- #
+
+
+def test_r13_header_lines_never_enter_content() -> None:
+    tok = "TOK" + "_R13_MARK"
+    # A path-like header line embedding a token-shaped quoted span, repeated
+    # across 3 files -- if header text were mistakenly scanned as content,
+    # this alone would satisfy the >=3-removed-lines threshold.
+    diff = (
+        "\n".join(
+            f'diff --git a/src/f{i}.sh b/src/f{i}.sh\n--- a/src/f{i}.sh "{tok}"\n'
+            f'+++ b/src/f{i}.sh "{tok}"\n@@ -1,0 +1,0 @@'
+            for i in range(3)
+        )
+        + "\n"
+    )
+    removed, added = crt._parse_diff(diff)
+    assert removed == {} and added == {}, (
+        f"header lines must never enter content lists; got removed={removed} added={added}"
+    )
+    assert tok not in crt.find_retired_tokens(removed, added), "header-only text must never be flagged as retired"
+
+
+# --------------------------------------------------------------------------- #
+# R14 -- hostile-input tokens
+# --------------------------------------------------------------------------- #
+
+
+def test_r14a_regex_metachar_token_matched_fixed_string(tmp_path: Path) -> None:
+    tok = ".*[$]()" + "A"  # regex metachars + one ASCII alnum char to pass the gate
+    _seed_retirement_with_survivor(tmp_path, tok)
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 1, (
+        f"a regex-metachar token must still be found via fixed-string grep; got {res.returncode}, stderr={res.stderr}"
+    )
+    assert "src/b.php:1" in res.stdout, f"expected the survivor site reported; got stdout={res.stdout!r}"
+
+
+def test_r14b_tab_and_consecutive_spaces_preserved(tmp_path: Path) -> None:
+    tok = "A" + "\t" + "B" + "   " + "C1"
+    _seed_retirement_with_survivor(tmp_path, tok)
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 1, f"expected findings; got {res.returncode}, stderr={res.stderr}"
+    assert repr(tok) in res.stdout, f"the report must preserve tab/space bytes exactly; got stdout={res.stdout!r}"
+
+
+def test_r14c_oversized_token_works(tmp_path: Path) -> None:
+    tok = "X" * 500
+    _seed_retirement_with_survivor(tmp_path, tok)
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 1, f"expected findings; got {res.returncode}, stderr={res.stderr}"
+    assert "src/b.php:1" in res.stdout, f"expected the survivor site reported; got stdout={res.stdout!r}"
+
+
+# --------------------------------------------------------------------------- #
+# R15 -- --claude-hook mode
+# --------------------------------------------------------------------------- #
+
+
+def test_r15a_hook_reports_findings_as_single_json_line(tmp_path: Path) -> None:
+    tok = "TOK" + "_R15A_MARK"
+    _seed_retirement_with_survivor(tmp_path, tok)
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": "git commit -m 'retire token'"}})
+    res = _run_hook(tmp_path, payload)
+    assert res.returncode == 0, f"hook mode must never exit nonzero; got {res.returncode}, stderr={res.stderr}"
+    out_lines = res.stdout.splitlines()
+    assert len(out_lines) == 1, f"expected exactly one stdout line; got {out_lines!r}"
+    parsed = json.loads(out_lines[0])
+    assert parsed["hookSpecificOutput"]["hookEventName"] == "PreToolUse", f"got {parsed!r}"
+    ctx = parsed["hookSpecificOutput"]["additionalContext"]
+    assert repr(tok) in ctx, f"additionalContext must show the token repr; got {ctx!r}"
+    assert "src/b.php:1" in ctx, f"additionalContext must name the surviving site; got {ctx!r}"
+
+
+def test_r15b_hook_skips_analysis_without_git_commit(tmp_path: Path) -> None:
+    tok = "TOK" + "_R15B_MARK"
+    _seed_retirement_with_survivor(tmp_path, tok)
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": "git status"}})
+    res = _run_hook(tmp_path, payload)
+    assert res.returncode == 0, f"hook mode must exit 0; got {res.returncode}"
+    assert res.stdout == "", (
+        f"no 'git commit' substring must print nothing even with a real retirement; got {res.stdout!r}"
+    )
+
+
+def test_r15c_hook_garbled_stdin_fails_open(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    res = _run_hook(tmp_path, "totally not json at all {{{ ]]] ***")
+    assert res.returncode == 0, f"garbled stdin must fail open; got {res.returncode}, stderr={res.stderr}"
+    assert res.stdout == "", f"garbled stdin (no 'git commit') must print nothing; got {res.stdout!r}"
+
+
+def test_r15_hook_not_a_git_repo_fails_open(tmp_path: Path) -> None:
+    # No `git init` -- tmp_path is NOT a repository, so the internal `git
+    # diff --cached` call must fail; the hook must swallow that, not crash.
+    payload = json.dumps({"tool_input": {"command": "git commit -m 'x'"}})
+    res = _run_hook(tmp_path, payload)
+    assert res.returncode == 0, (
+        f"a git failure inside the hook must fail open; got {res.returncode}, stderr={res.stderr}"
+    )
+    assert res.stdout == "", f"a git failure inside the hook must print nothing; got {res.stdout!r}"
+
+
+def test_r15d_hook_normalizes_double_space_before_git_commit(tmp_path: Path) -> None:
+    tok = "TOK" + "_R15D1_MARK"
+    _seed_retirement_with_survivor(tmp_path, tok)
+    payload = json.dumps({"tool_input": {"command": "git  commit -m 'x'"}})  # double space
+    res = _run_hook(tmp_path, payload)
+    assert res.returncode == 0, f"hook mode must exit 0; got {res.returncode}"
+    assert res.stdout != "", f"a double-spaced 'git  commit' must still trigger analysis; got stdout={res.stdout!r}"
+
+
+def test_r15d_hook_normalizes_escaped_quotes_before_git_commit(tmp_path: Path) -> None:
+    tok = "TOK" + "_R15D2_MARK"
+    _seed_retirement_with_survivor(tmp_path, tok)
+    # Raw payload with JSON-escaped quotes around "commit" (as if the shell
+    # command itself quoted the subcommand): git \"commit\" -m x
+    payload = '{"tool_input": {"command": "git \\"commit\\" -m x"}}'
+    res = _run_hook(tmp_path, payload)
+    assert res.returncode == 0, f"hook mode must exit 0; got {res.returncode}"
+    assert res.stdout != "", f"escaped quotes around 'commit' must still normalize+trigger; got stdout={res.stdout!r}"
+
+
+# --------------------------------------------------------------------------- #
+# R16 -- exit codes (findings=>1 is R1; clean=>0 is R6; usage errors here)
+# --------------------------------------------------------------------------- #
+
+
+def test_r16_unknown_flag_exits_2(tmp_path: Path) -> None:
+    res = _run(tmp_path, "--totally-bogus-flag")
+    assert res.returncode == 2, f"an unknown flag must exit 2; got {res.returncode}, stdout={res.stdout!r}"
+
+
+def test_r16_missing_diff_base_exits_2(tmp_path: Path) -> None:
+    res = _run(tmp_path, "--diff")
+    assert res.returncode == 2, f"a missing --diff base must exit 2; got {res.returncode}, stdout={res.stdout!r}"
+
+
+# --------------------------------------------------------------------------- #
+# R17 -- two distinct retired tokens -> both reported, deterministic order
+# --------------------------------------------------------------------------- #
+
+
+def test_r17_format_report_sorts_tokens_and_hits() -> None:
+    tok_late = "Z" + "_TOKEN_LATE"
+    tok_early = "A" + "_TOKEN_EARLY"
+    findings = {
+        tok_late: ["src/z.php:9: zzz", "src/a.php:1: aaa"],
+        tok_early: ["src/b.php:2: bbb"],
+    }
+    report = crt.format_report(findings)
+    early_idx = report.index(repr(tok_early))
+    late_idx = report.index(repr(tok_late))
+    assert early_idx < late_idx, f"tokens must be sorted; got report={report!r}"
+    aaa_idx = report.index("src/a.php:1")
+    zzz_idx = report.index("src/z.php:9")
+    assert aaa_idx < zzz_idx, f"hits within a token must be sorted; got report={report!r}"
+
+
+def test_r17_two_distinct_retired_tokens_both_reported(tmp_path: Path) -> None:
+    tok_a = "AAA" + "_R17_MARK"
+    tok_b = "ZZZ" + "_R17_MARK"
+    _init_repo(tmp_path)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/a.php").write_text(
+        "\n".join(f"logger('{tok_a}');" for _ in range(3))
+        + "\n"
+        + "\n".join(f"logger('{tok_b}');" for _ in range(3))
+        + "\n"
+    )
+    (tmp_path / "src/b.php").write_text(f"echo '{tok_a} survivor';\necho '{tok_b} survivor';\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+
+    (tmp_path / "src/a.php").write_text("logger();\n" * 6)
+    _git(tmp_path, "add", ".")
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 1, f"expected findings; got {res.returncode}, stderr={res.stderr}"
+    assert repr(tok_a) in res.stdout and repr(tok_b) in res.stdout, (
+        f"both tokens must be reported; got stdout={res.stdout!r}"
+    )
+    a_pos = res.stdout.index(repr(tok_a))
+    b_pos = res.stdout.index(repr(tok_b))
+    assert a_pos < b_pos, f"tokens must print in sorted order; got stdout={res.stdout!r}"
+
+
+# --------------------------------------------------------------------------- #
+# R18 -- unquoted-only text on removed lines -> no candidate
+# --------------------------------------------------------------------------- #
+
+
+def test_r18_unquoted_token_never_becomes_a_candidate() -> None:
+    tok = "TOK" + "_R18_MARK"
+    diff = _diff_hunk("src/a.php", removed=[f"x = {tok};" for _ in range(3)], added=[])
+    retired = _retired(diff)
+    assert tok not in retired, f"an unquoted-only token must never seed a candidate; got retired={retired}"


### PR DESCRIPTION
## What

Implements the retired-token completeness guard designed in #1059: `scripts/check_retired_tokens.py` detects a **retirement signature** in a diff — a quoted string literal appearing on ≥3 removed scan-root lines and on zero added scan-root lines — and reports every occurrence still surviving in the post-change tree (a straggler). This is the mechanical backstop for the #1047 failure class (the #1008 fix removed all 29 `pfblockerng.inc` call sites of a legacy log marker and missed the 9 sibling sites in `www/pfblockerng/pfblockerng.php`).

## How

**Commit 1 — the checker + its test suite** (`scripts: add retired-token completeness guard`):

- Modes: `--staged` (pre-commit; stragglers searched in the index), `--diff <base>` (CI-PR; searched in `HEAD`), `--token-allowlist <token>` (repeatable, staged-migration escape), and `--claude-hook` (fail-open PreToolUse form emitting a single `additionalContext` JSON line, always exit 0).
- Escape hatches: `# retired-token-ok: <reason>` on an intentional survivor line, or the allowlist flag.
- Candidate rule: raw inner text of single/double-quoted spans on removed lines; trimmed length ≥ 4 with at least one alphanumeric; fixed-string (`git grep -F`) matching throughout.
- Diff parser skips `\ No newline at end of file` markers (the open #1051 parser lesson, pinned by test) and takes a deleted file's path from `--- a/` (its `+++` is `/dev/null`).
- 28 tests covering the full 18-row matrix from the plan (thresholds both sides, moved-token, scan-root scoping both directions, escape/allowlist, hostile tokens with regex metacharacters/tabs/oversized, hook-mode JSON shape + fail-open, deterministic ordering, exit codes).

**Commit 2 — warn-only wiring** (`ci: wire retired-token guard …`):

- `.githooks/pre-commit`: advisory step after comment-narration; a finding prints the report plus a WARN line and never blocks the commit.
- `.github/workflows/test.yml`: PR-only `retired-tokens` job (same shape as `comment-narration`), `--diff origin/$BASE` with findings downgraded to a `::warning::` annotation; folded into `all-tests-passed` (skipped-on-push = pass).
- `.claude/settings.json`: second PreToolUse Bash hook invoking `--claude-hook`, so an agent about to `git commit` sees the straggler list as injected context while the change is still open.
- The checker's own docstring is reworded to not contain the exemplar marker verbatim — it would otherwise be a permanent "surviving site" in its own report.

Warn-only is deliberate (a partial retirement can be a legitimate staged migration); promotion to blocking follows once the observed false-positive rate is near zero, mirroring the #925 stop-guard rollout.

## Evidence

- **Real-history exemplar**: with `HEAD` at `958e679f`, `--diff 958e679f~1` flags the retired marker with exactly the 9 surviving `pfblockerng.php` sites from #1047, exit 1 (reproduced independently three times: implementer, verifier, orchestrator).
- **Red→green**: the 28-test suite collected/failed with the checker absent and passes with it present (re-executed at the gate, not just claimed).
- **Wiring red paths demonstrated in-session** against a donor-shaped staged retirement: pre-commit prints the report + WARN and exits 0; the exact PreToolUse hook command emits the one-line `additionalContext` JSON (and stays silent on garbled stdin and non-commit payloads); the CI `run:` block shape prints the report + `::warning::` and exits 0.
- Full gates green: `python3 -m pytest` (2524 passed, 4 skipped), `ruff check`, `ruff format --check`, `mypy tests/`, `sh -n`/ShellCheck on the touched hook, JSON validity of `settings.json`.

Note: the hook/settings wiring activates for local sessions once this lands on `devel` and the primary checkout updates (`core.hooksPath` is absolute, so worktree commits already run the primary checkout's hook today).

Related: #1047 (the live stragglers themselves — untouched here, still open), #1051 (sibling parsers' `\ No newline` bug — this checker ships with the fixed idiom; the siblings' fix stays in its own issue).

Fixes #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMandwby8X7gcMiUBQpPbG
