### PR TITLE
Fix the five open bug issues #1051, #1058, #1060, #1063, #1064

### DIFF
--- a/scripts/check_comment_narration.py
+++ b/scripts/check_comment_narration.py
@@ -100,7 +100,8 @@ def find_violations(diff_text: str) -> list[Violation]:
                         violations.append(Violation(path, lineno, line.strip(), reason))
                         break
             lineno += 1
-        elif not raw.startswith("-"):
+        elif not raw.startswith(("-", "\\")):
+            # issue #1051: "\ No newline at end of file" is a marker, not content
             lineno += 1  # context line (absent under --unified=0, tolerated)
     return violations
 

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -435,7 +435,8 @@ def _added_lines_by_path(diff_text: str) -> dict[str, set[int]]:
             if path is not None:
                 added.setdefault(path, set()).add(lineno)
             lineno += 1
-        elif not raw.startswith("-"):
+        elif not raw.startswith(("-", "\\")):
+            # issue #1051: "\ No newline at end of file" is a marker, not content
             lineno += 1  # context line (absent under --unified=0, tolerated)
     return added
 

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -148,12 +148,9 @@ _has_force_flag() {
 	printf '%s' "$seg" | grep -Eq "(^|${_SEP})${_FORCE_CLUSTER}(\$|${_SEP})"
 }
 
-# _bare_force_after_last_lease -- true iff a BARE force flag sits after the
-# last --force-with-lease in $seg. git honors the LAST force flag, so
-# `git push --force-with-lease --force` (or a trailing -f) is a bare force
-# push despite the lease (issue #1058). Exact-word --force only: the
-# remainder can't contain --force-with-lease (stripped past the last one),
-# and --force-if-includes -- a lease COMPANION flag -- must stay clean.
+# _bare_force_after_last_lease -- git honors the LAST force flag: a bare
+# --force (exact word) or f-cluster after the last --force-with-lease is a
+# bare force push (issue #1058); --force-if-includes stays clean.
 _bare_force_after_last_lease() {
 	printf '%s' "${seg##*--force-with-lease}" \
 		| grep -Eq "(^|${_SEP})(--force|${_FORCE_CLUSTER})(\$|${_SEP})"

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -132,18 +132,31 @@ _SEP='[[:space:];|&(){}<>,]'
 #   * the literal substring --force (covers --force and --force-with-lease
 #     alike; callers that must distinguish the two check --force-with-lease
 #     separately), OR
-#   * a single-dash short-flag CLUSTER containing f (-f, -uf, -fu, ...) --
-#     getopt clusters short flags, so `git push -uf origin main` force-pushes
-#     exactly like `-f`. The mandatory single leading dash (never --) is why
-#     this never matches --force/--force-with-lease: the character right
-#     after the boundary dash in "--force" is another dash, not [a-z], so the
-#     match can't start there, and the first dash itself has no valid
-#     boundary before it either. The only f-bearing short flag on `git push`
-#     / `git worktree remove` is force, so treating any single-dash
-#     f-cluster as force on those two subcommands is safe.
+#   * a single-dash short-flag CLUSTER containing f (-f, -uf, -fu, -4f, ...)
+#     -- getopt clusters short flags, so `git push -uf origin main`
+#     force-pushes exactly like `-f`, and digit short flags (`-4`/`-6`)
+#     cluster the same way (issue #1058). The mandatory single leading dash
+#     (never --) is why this never matches --force/--force-with-lease: the
+#     character right after the boundary dash in "--force" is another dash,
+#     not [a-z0-9], so the match can't start there, and the first dash
+#     itself has no valid boundary before it either. The only f-bearing
+#     short flag on `git push` / `git worktree remove` is force, so treating
+#     any single-dash f-cluster as force on those two subcommands is safe.
+_FORCE_CLUSTER="-[a-z0-9]*f[a-z0-9]*"
 _has_force_flag() {
 	_contains '--force' && return 0
-	printf '%s' "$seg" | grep -Eq "(^|${_SEP})-[a-z]*f[a-z]*(\$|${_SEP})"
+	printf '%s' "$seg" | grep -Eq "(^|${_SEP})${_FORCE_CLUSTER}(\$|${_SEP})"
+}
+
+# _bare_force_after_last_lease -- true iff a BARE force flag sits after the
+# last --force-with-lease in $seg. git honors the LAST force flag, so
+# `git push --force-with-lease --force` (or a trailing -f) is a bare force
+# push despite the lease (issue #1058). Exact-word --force only: the
+# remainder can't contain --force-with-lease (stripped past the last one),
+# and --force-if-includes -- a lease COMPANION flag -- must stay clean.
+_bare_force_after_last_lease() {
+	printf '%s' "${seg##*--force-with-lease}" \
+		| grep -Eq "(^|${_SEP})(--force|${_FORCE_CLUSTER})(\$|${_SEP})"
 }
 
 # _deny <reason> -- print the PreToolUse deny JSON and exit 0 (exit 0 is
@@ -166,7 +179,7 @@ while IFS= read -r seg; do
 	fi
 
 	if _contains 'git push' && _has_force_flag; then
-		if ! _contains '--force-with-lease'; then
+		if ! _contains '--force-with-lease' || _bare_force_after_last_lease; then
 			_deny "the rebase-only landing flow uses --force-with-lease exclusively; a bare force-push can clobber another session's PR (CLAUDE.md)"
 		fi
 	fi

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7814,15 +7814,18 @@ function tld_analysis() {
 				continue;
 			}
 
-			// ADR-07: skip ABP-feed lines (see note above). A plain CSV row is
-			// ',domain,,log,feed,group'; the feed name is column index 4. ABP raw
-			// lines lack this shape, so an unset/empty feed column also means skip --
-			// unconditionally: a plain feed can carry ADR-21 verbatim ABP lines with
-			// zero '.abp' markers present (issue #1060).
-			$fparts	= explode(',', $line, 6);
-			$lfeed	= isset($fparts[4]) ? $fparts[4] : '';
-			if ($lfeed === '' || isset($abp_feeds[$lfeed])) {
+			// ADR-07/ADR-21: plain CSV rows (',domain,,log,feed,group') always start
+			// with ','; ABP raw lines (||x^, @@||x^, /re/, '0.0.0.0 h') never do --
+			// skip by prefix, marker-independent (issue #1060; cheap, hot loop).
+			if (strncmp($line, ',', 1) !== 0) {
 				continue;
+			}
+			if (!empty($abp_feeds)) {
+				$fparts	= explode(',', $line, 6);
+				$lfeed	= isset($fparts[4]) ? $fparts[4] : '';
+				if ($lfeed === '' || isset($abp_feeds[$lfeed])) {
+					continue;
+				}
 			}
 
 			// Display progress indicator

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7815,8 +7815,8 @@ function tld_analysis() {
 			}
 
 			// ADR-07/ADR-21: plain CSV rows (',domain,,log,feed,group') always start
-			// with ','; ABP raw lines (||x^, @@||x^, /re/, '0.0.0.0 h') never do --
-			// skip by prefix, marker-independent (issue #1060; cheap, hot loop).
+			// with ','; the known ABP raw shapes (||x^, @@||x^, /re/, '0.0.0.0 h')
+			// don't -- skip those by prefix (issue #1060; cheap, hot loop).
 			if (strncmp($line, ',', 1) !== 0) {
 				continue;
 			}
@@ -7840,6 +7840,12 @@ function tld_analysis() {
 
 			// DNSBL python blocking mode
 			$eparts = explode(',', $line, 3);
+
+			// A well-formed row has all three parts; a degenerate comma-first
+			// line (e.g. bare ',') must not become a malformed output row.
+			if (!isset($eparts[2]) || $eparts[1] === '') {
+				continue;
+			}
 			$domain = $eparts[1];
 			$dparts = explode('.', $domain);
 			$dcnt   = count($dparts);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7816,13 +7816,13 @@ function tld_analysis() {
 
 			// ADR-07: skip ABP-feed lines (see note above). A plain CSV row is
 			// ',domain,,log,feed,group'; the feed name is column index 4. ABP raw
-			// lines lack this shape, so an unset/empty feed column also means skip.
-			if (!empty($abp_feeds)) {
-				$fparts	= explode(',', $line, 6);
-				$lfeed	= isset($fparts[4]) ? $fparts[4] : '';
-				if ($lfeed === '' || isset($abp_feeds[$lfeed])) {
-					continue;
-				}
+			// lines lack this shape, so an unset/empty feed column also means skip --
+			// unconditionally: a plain feed can carry ADR-21 verbatim ABP lines with
+			// zero '.abp' markers present (issue #1060).
+			$fparts	= explode(',', $line, 6);
+			$lfeed	= isset($fparts[4]) ? $fparts[4] : '';
+			if ($lfeed === '' || isset($abp_feeds[$lfeed])) {
+				continue;
 			}
 
 			// Display progress indicator

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -72,10 +72,11 @@ if ($_POST) {
 
 	// Save widget customizations
 	// issue #1050: $nocsrf=TRUE means csrf-magic never runs here -- gate the mutation itself.
+	// issue #1064: per-field reads use ?? '' -- a crafted POST (or an unchecked checkbox) omits keys.
 	if (isset($_POST['pfb_submit']) && pfb_widget_post_allowed($_SERVER)) {
-		$pfb['wglobal']['widget-popup']			= pfb_filter($_POST['pfb_popup'], PFB_FILTER_ON_OFF, 'widget');
-		$pfb['wglobal']['widget-sortmix']		= pfb_filter($_POST['pfb_sortmix'], PFB_FILTER_ON_OFF, 'widget');
-		$pfb['wglobal']['widget-show_agg']		= pfb_filter($_POST['pfb_show_agg'], PFB_FILTER_ON_OFF, 'widget');
+		$pfb['wglobal']['widget-popup']			= pfb_filter($_POST['pfb_popup'] ?? '', PFB_FILTER_ON_OFF, 'widget');
+		$pfb['wglobal']['widget-sortmix']		= pfb_filter($_POST['pfb_sortmix'] ?? '', PFB_FILTER_ON_OFF, 'widget');
+		$pfb['wglobal']['widget-show_agg']		= pfb_filter($_POST['pfb_show_agg'] ?? '', PFB_FILTER_ON_OFF, 'widget');
 		// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
 		config_set_path('installedpackages/pfblockerngglobal/widget-popup', $pfb['wglobal']['widget-popup']);
 		// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
@@ -83,27 +84,27 @@ if ($_POST) {
 		// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
 		config_set_path('installedpackages/pfblockerngglobal/widget-show_agg', $pfb['wglobal']['widget-show_agg']);
 
-		if (in_array($_POST['pfb_sortcolumn'], array('none', 'alias', 'count', 'packets', 'update'))) {
+		if (in_array($_POST['pfb_sortcolumn'] ?? '', array('none', 'alias', 'count', 'packets', 'update'))) {
 			$pfb['wglobal']['widget-sortcolumn']	= $_POST['pfb_sortcolumn'];
 			// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
 			config_set_path('installedpackages/pfblockerngglobal/widget-sortcolumn', $pfb['wglobal']['widget-sortcolumn']);
 		}
-		if (in_array($_POST['pfb_sortdir'], array('asc', 'des'))) {
+		if (in_array($_POST['pfb_sortdir'] ?? '', array('asc', 'des'))) {
 			$pfb['wglobal']['widget-sortdir']	= $_POST['pfb_sortdir'];
 			// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
 			config_set_path('installedpackages/pfblockerngglobal/widget-sortdir', $pfb['wglobal']['widget-sortdir']);
 		}
-		if (in_array($_POST['pfb_clearip'], array('never', 'daily', 'weekly'))) {
+		if (in_array($_POST['pfb_clearip'] ?? '', array('never', 'daily', 'weekly'))) {
 			$pfb['wglobal']['widget-clearip']	= $_POST['pfb_clearip'];
 			// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
 			config_set_path('installedpackages/pfblockerngglobal/widget-clearip', $pfb['wglobal']['widget-clearip']);
 		}
-		if (in_array($_POST['pfb_cleardnsbl'], array('never', 'daily', 'weekly'))) {
+		if (in_array($_POST['pfb_cleardnsbl'] ?? '', array('never', 'daily', 'weekly'))) {
 			$pfb['wglobal']['widget-cleardnsbl']	= $_POST['pfb_cleardnsbl'];
 			// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
 			config_set_path('installedpackages/pfblockerngglobal/widget-cleardnsbl', $pfb['wglobal']['widget-cleardnsbl']);
 		}
-		if (is_numeric($_POST['pfb_dnsblquery']) && $_POST['pfb_dnsblquery'] < 10000) {
+		if (is_numeric($_POST['pfb_dnsblquery'] ?? '') && $_POST['pfb_dnsblquery'] < 10000) {
 			$pfb['wglobal']['widget-dnsblquery']	= $_POST['pfb_dnsblquery'];
 			// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
 			config_set_path('installedpackages/pfblockerngglobal/widget-dnsblquery', $pfb['wglobal']['widget-dnsblquery']);
@@ -113,12 +114,12 @@ if ($_POST) {
 				restart_service('pfb_dnsbl');
 			}
 		}
-		if (is_numeric($_POST['pfb_maxfails']) && $_POST['pfb_maxfails'] < 100) {
+		if (is_numeric($_POST['pfb_maxfails'] ?? '') && $_POST['pfb_maxfails'] < 100) {
 			$pfb['wglobal']['widget-maxfails']	= $_POST['pfb_maxfails'];
 			// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
 			config_set_path('installedpackages/pfblockerngglobal/widget-maxfails', $pfb['wglobal']['widget-maxfails']);
 		}
-		if (is_numeric($_POST['pfb_maxheight']) && $_POST['pfb_maxheight'] < 10000) {
+		if (is_numeric($_POST['pfb_maxheight'] ?? '') && $_POST['pfb_maxheight'] < 10000) {
 			$pfb['wglobal']['widget-maxheight']	= $_POST['pfb_maxheight'];
 			// foreign key: pfblockerngglobal/widget-* are dashboard widget keys, not in registry
 			config_set_path('installedpackages/pfblockerngglobal/widget-maxheight', $pfb['wglobal']['widget-maxheight']);

--- a/tests/php/SoftwareUpdateCheckHygieneTest.php
+++ b/tests/php/SoftwareUpdateCheckHygieneTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/SoftwareUpdateCheckTest.php';
+
+/**
+ * Issue #1063: SoftwareUpdateCheckTest's tearDown() unset the bootstrap-seeded
+ * $GLOBALS['pfb']['dbdir'] (and $GLOBALS['config']) instead of restoring the
+ * prior values, leaking broken global state into every later suite — under
+ * --order-by=random, AliasDeltaApplyTest / PfctlTableOpTest then warn
+ * 'Undefined array key "dbdir"'. This pins the restore contract by driving
+ * the suite's own setUp()/tearDown() pair against sentinel globals.
+ */
+final class SoftwareUpdateCheckHygieneTest extends TestCase
+{
+	/** @var array{had: bool, val: mixed} */
+	private array $outerDbdir = ['had' => false, 'val' => null];
+	/** @var array{had: bool, val: mixed} */
+	private array $outerConfig = ['had' => false, 'val' => null];
+
+	protected function setUp(): void
+	{
+		$this->outerDbdir  = [
+			'had' => isset($GLOBALS['pfb']) && array_key_exists('dbdir', $GLOBALS['pfb']),
+			'val' => $GLOBALS['pfb']['dbdir'] ?? null,
+		];
+		$this->outerConfig = [
+			'had' => array_key_exists('config', $GLOBALS),
+			'val' => $GLOBALS['config'] ?? null,
+		];
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->outerDbdir['had']) {
+			$GLOBALS['pfb']['dbdir'] = $this->outerDbdir['val'];
+		} else {
+			unset($GLOBALS['pfb']['dbdir']);
+		}
+		if ($this->outerConfig['had']) {
+			$GLOBALS['config'] = $this->outerConfig['val'];
+		} else {
+			unset($GLOBALS['config']);
+		}
+	}
+
+	/** Run one full setUp()+tearDown() cycle of SoftwareUpdateCheckTest. */
+	private function runLifecycle(): void
+	{
+		$suite = new SoftwareUpdateCheckTest('testLifecycleProbe');
+		$ref   = new ReflectionClass($suite);
+		$setUp = $ref->getMethod('setUp');
+		$tear  = $ref->getMethod('tearDown');
+		$setUp->invoke($suite);
+		$tear->invoke($suite);
+	}
+
+	public function testDbdirRestoredAfterSuiteLifecycle(): void
+	{
+		$sentinel = '/nonexistent/pfb-dbdir-canary-1063';
+		$GLOBALS['pfb']['dbdir'] = $sentinel;
+
+		$this->runLifecycle();
+
+		$this->assertArrayHasKey(
+			'dbdir',
+			$GLOBALS['pfb'],
+			"tearDown must RESTORE the prior \$pfb['dbdir'], not unset it (issue #1063)"
+		);
+		$this->assertSame($sentinel, $GLOBALS['pfb']['dbdir']);
+	}
+
+	public function testConfigRestoredAfterSuiteLifecycle(): void
+	{
+		$sentinel = ['pfb_hygiene_canary_1063' => true];
+		$GLOBALS['config'] = $sentinel;
+
+		$this->runLifecycle();
+
+		$this->assertArrayHasKey(
+			'config',
+			$GLOBALS,
+			"tearDown must RESTORE the prior \$config, not unset it (issue #1063)"
+		);
+		$this->assertSame($sentinel, $GLOBALS['config']);
+	}
+}

--- a/tests/php/SoftwareUpdateCheckTest.php
+++ b/tests/php/SoftwareUpdateCheckTest.php
@@ -37,12 +37,21 @@ final class SoftwareUpdateCheckTest extends TestCase
 {
 	private string $dbdir = '';
 
+	/** Saved bootstrap-seeded globals, RESTORED in tearDown (issue #1063: an
+	 *  unset here leaked into later suites under --order-by=random). */
+	private bool $hadDbdir    = false;
+	private mixed $savedDbdir = null;
+	private bool $hadConfig    = false;
+	private mixed $savedConfig = null;
+
 	protected function setUp(): void
 	{
 		// Each test gets a private temp dbdir so the cache file is isolated and the
 		// orchestrator's $pfb['dbdir'] lookup resolves there.
 		$this->dbdir = sys_get_temp_dir() . '/pfb_adr19_' . uniqid('', true);
 		mkdir($this->dbdir, 0755, true);
+		$this->hadDbdir   = isset($GLOBALS['pfb']) && array_key_exists('dbdir', $GLOBALS['pfb']);
+		$this->savedDbdir = $GLOBALS['pfb']['dbdir'] ?? null;
 		$GLOBALS['pfb']['dbdir'] = $this->dbdir;
 
 		// Reset the test-driveable doubles to their permissive defaults.
@@ -52,6 +61,8 @@ final class SoftwareUpdateCheckTest extends TestCase
 
 		// No saved setting unless a test overrides it — exercises the DEFAULT (enabled)
 		// state of "Check for new versions" (pfb_software_check unset => enabled).
+		$this->hadConfig   = array_key_exists('config', $GLOBALS);
+		$this->savedConfig = $GLOBALS['config'] ?? null;
 		$GLOBALS['config'] = [];
 	}
 
@@ -65,12 +76,20 @@ final class SoftwareUpdateCheckTest extends TestCase
 			rmdir($this->dbdir);
 		}
 		unset(
-			$GLOBALS['pfb']['dbdir'],
 			$GLOBALS['pfb_test_file_notices'],
 			$GLOBALS['pfb_test_pkg_locked'],
-			$GLOBALS['pfb_test_dns_available'],
-			$GLOBALS['config']
+			$GLOBALS['pfb_test_dns_available']
 		);
+		if ($this->hadDbdir) {
+			$GLOBALS['pfb']['dbdir'] = $this->savedDbdir;
+		} else {
+			unset($GLOBALS['pfb']['dbdir']);
+		}
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->savedConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
 	}
 
 	private function cacheFile(): string

--- a/tests/php/TldAnalysisAbpVerbatimTest.php
+++ b/tests/php/TldAnalysisAbpVerbatimTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * tld_analysis() — ABP-line skipping in the concatenated pfb_dnsbl.raw.
+ *
+ * Issue #1060: a plain feed can carry ADR-21 verbatim ABP lines (||x^ /
+ * @@||x^) with ZERO '.abp' markers on disk. The empty/unset-feed-column skip
+ * must run unconditionally — gated on a non-empty marker set, the verbatim
+ * line reached the CSV explode and produced a malformed ',,' row in the
+ * python data output.
+ */
+#[CoversFunction('tld_analysis')]
+final class TldAnalysisAbpVerbatimTest extends TestCase
+{
+	private string $tmpDir;
+
+	protected function setUp(): void
+	{
+		global $pfb, $tlds;
+
+		$this->tmpDir = sys_get_temp_dir() . '/pfb_tld_abp_' . getmypid() . '_' . mt_rand();
+		mkdir($this->tmpDir, 0700, TRUE);
+		mkdir("{$this->tmpDir}/dnsdir", 0700, TRUE);
+
+		$tlds = array();
+		$pfb['dnsbl_file']	= "{$this->tmpDir}/pfb_dnsbl";
+		$pfb['dnsbl_tld_data']	= "{$this->tmpDir}/tld_master";
+		$pfb['unbound_py_data']	= "{$this->tmpDir}/pfb_py_data";
+		$pfb['unbound_py_zone']	= "{$this->tmpDir}/pfb_py_zone";
+		$pfb['dnsdir']		= "{$this->tmpDir}/dnsdir";
+		$pfb['dnsbl_tmpdir']	= "{$this->tmpDir}/tmpdir";
+		$pfb['dnsbl_tld_txt']	= "{$this->tmpDir}/dnsbl_tld.txt";
+		$pfb['dnsbl_tmp']	= "{$this->tmpDir}/dnsbl_tmp";
+		$pfb['dnsbl_info']	= "{$this->tmpDir}/dnsbl_info.db";
+		$pfb['errlog']		= "{$this->tmpDir}/error.log";
+		$pfb['log']		= "{$this->tmpDir}/pfblockerng.log";
+		$pfb['domain_max_cnt']	= 100000;
+		$pfb['sqlite_timeout']	= 5000;
+		$pfb['dnsblconfig']	= array('tldblacklist' => '', 'tldexclusion' => '');
+		$pfb['dnsbl_info_stats'] = array();
+		$pfb['alias_dnsbl_all']	= array();
+		$pfb['tld_update']	= array();
+
+		file_put_contents($pfb['dnsbl_tld_data'], "com\n");
+	}
+
+	protected function tearDown(): void
+	{
+		$files = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($this->tmpDir, FilesystemIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($files as $f) {
+			$f->isDir() ? rmdir((string) $f) : unlink((string) $f);
+		}
+		rmdir($this->tmpDir);
+	}
+
+	/**
+	 * Scenario: verbatim ABP lines in a plain feed, no ABP feed configured.
+	 *
+	 * Given:  pfb_dnsbl.raw holding one plain CSV row plus verbatim ||x^ and
+	 *         @@||x^ lines, and ZERO .abp markers in dnsdir
+	 * When:   tld_analysis() runs
+	 * Then:   the CSV row lands in the zone output and the verbatim lines are
+	 *         skipped — no malformed ',,' row in the data output
+	 */
+	public function testVerbatimAbpLinesSkippedWithZeroAbpMarkers(): void
+	{
+		global $pfb;
+
+		file_put_contents(
+			"{$pfb['dnsbl_file']}.raw",
+			",example.com,,1,PlainFeed,GroupA\n"
+			. "||evil-verbatim.example^\n"
+			. "@@||allow-verbatim.example^\n"
+		);
+
+		@tld_analysis();
+
+		$this->assertFileExists($pfb['unbound_py_zone']);
+		$zone = (string) file_get_contents($pfb['unbound_py_zone']);
+		$data = file_exists($pfb['unbound_py_data'])
+			? (string) file_get_contents($pfb['unbound_py_data']) : '';
+
+		$this->assertSame(
+			",example.com,,1,PlainFeed,GroupA\n",
+			$zone,
+			"zone output must carry exactly the plain CSV row; got: " . var_export($zone, TRUE)
+		);
+		$this->assertSame(
+			'',
+			$data,
+			"verbatim ABP lines must be skipped, not CSV-mangled; got: " . var_export($data, TRUE)
+		);
+	}
+
+	/**
+	 * Scenario: a marked ABP feed's comma-bearing line is still skipped by name.
+	 *
+	 * Given:  an AbpFeed.abp marker and a raw line whose column 4 says AbpFeed
+	 * When:   tld_analysis() runs
+	 * Then:   the marked feed's line is skipped; the plain row still processes
+	 *         (pins the marker-based skip across the #1060 refactor)
+	 */
+	public function testMarkedAbpFeedLineStillSkippedByFeedName(): void
+	{
+		global $pfb;
+
+		touch("{$pfb['dnsdir']}/AbpFeed.abp");
+		file_put_contents(
+			"{$pfb['dnsbl_file']}.raw",
+			",example.com,,1,PlainFeed,GroupA\n"
+			. ",abp-carried.example,,1,AbpFeed,GroupB\n"
+		);
+
+		@tld_analysis();
+
+		$this->assertFileExists($pfb['unbound_py_zone']);
+		$zone = (string) file_get_contents($pfb['unbound_py_zone']);
+
+		$this->assertStringContainsString(',example.com,', $zone);
+		$this->assertStringNotContainsString(
+			'abp-carried.example',
+			$zone,
+			"marked-feed line must be skipped by feed name; got: " . var_export($zone, TRUE)
+		);
+	}
+}

--- a/tests/php/TldAnalysisAbpVerbatimTest.php
+++ b/tests/php/TldAnalysisAbpVerbatimTest.php
@@ -100,12 +100,13 @@ final class TldAnalysisAbpVerbatimTest extends TestCase
 	 * Scenario: verbatim ABP lines in a plain feed, no ABP feed configured.
 	 *
 	 * Given:  pfb_dnsbl.raw holding one plain CSV row plus verbatim ||x^ and
-	 *         @@||x^ lines — one with >=5 comma-separated ABP options — and
-	 *         ZERO .abp markers in dnsdir
+	 *         @@||x^ lines — one with >=5 comma-separated ABP options, one a
+	 *         degenerate bare ',' line — and ZERO .abp markers in dnsdir
 	 * When:   tld_analysis() runs
-	 * Then:   the CSV row lands in the zone output and every verbatim line is
-	 *         skipped — no malformed row in the data output, no numeric
-	 *         undefined-array-key warning from the CSV explode
+	 * Then:   the CSV row lands in the zone output and every other line is
+	 *         skipped — no malformed row in the data output, and no numeric
+	 *         undefined-array-key warning from the CSV explode (the #1060
+	 *         warning class; the bare ',' row is the fixture that reds it)
 	 */
 	public function testVerbatimAbpLinesSkippedWithZeroAbpMarkers(): void
 	{
@@ -117,6 +118,7 @@ final class TldAnalysisAbpVerbatimTest extends TestCase
 			. "||evil-verbatim.example^\n"
 			. "@@||allow-verbatim.example^\n"
 			. "||opt-verbatim.example^\$script,third-party,domain=x.com,match-case,important,other\n"
+			. ",\n"
 		);
 
 		$warnings = $this->runTldAnalysis();

--- a/tests/php/TldAnalysisAbpVerbatimTest.php
+++ b/tests/php/TldAnalysisAbpVerbatimTest.php
@@ -19,9 +19,16 @@ final class TldAnalysisAbpVerbatimTest extends TestCase
 {
 	private string $tmpDir;
 
+	/** Saved bootstrap globals, restored in tearDown (issue #1063 hygiene). */
+	private mixed $savedPfb  = null;
+	private mixed $savedTlds = null;
+
 	protected function setUp(): void
 	{
 		global $pfb, $tlds;
+
+		$this->savedPfb  = $pfb ?? null;
+		$this->savedTlds = $tlds ?? null;
 
 		$this->tmpDir = sys_get_temp_dir() . '/pfb_tld_abp_' . getmypid() . '_' . mt_rand();
 		mkdir($this->tmpDir, 0700, TRUE);
@@ -51,6 +58,11 @@ final class TldAnalysisAbpVerbatimTest extends TestCase
 
 	protected function tearDown(): void
 	{
+		global $pfb, $tlds;
+
+		$pfb  = $this->savedPfb;
+		$tlds = $this->savedTlds;
+
 		$files = new RecursiveIteratorIterator(
 			new RecursiveDirectoryIterator($this->tmpDir, FilesystemIterator::SKIP_DOTS),
 			RecursiveIteratorIterator::CHILD_FIRST

--- a/tests/php/TldAnalysisAbpVerbatimTest.php
+++ b/tests/php/TldAnalysisAbpVerbatimTest.php
@@ -74,13 +74,38 @@ final class TldAnalysisAbpVerbatimTest extends TestCase
 	}
 
 	/**
+	 * Run tld_analysis() collecting every PHP diagnostic it raises (instead of
+	 * blanket-@-suppression, per PR #1066 review): callers assert on the list.
+	 *
+	 * @return list<string>
+	 */
+	private function runTldAnalysis(): array
+	{
+		$warnings = [];
+		set_error_handler(
+			static function (int $errno, string $errstr) use (&$warnings): bool {
+				$warnings[] = $errstr;
+				return TRUE;
+			}
+		);
+		try {
+			tld_analysis();
+		} finally {
+			restore_error_handler();
+		}
+		return $warnings;
+	}
+
+	/**
 	 * Scenario: verbatim ABP lines in a plain feed, no ABP feed configured.
 	 *
 	 * Given:  pfb_dnsbl.raw holding one plain CSV row plus verbatim ||x^ and
-	 *         @@||x^ lines, and ZERO .abp markers in dnsdir
+	 *         @@||x^ lines — one with >=5 comma-separated ABP options — and
+	 *         ZERO .abp markers in dnsdir
 	 * When:   tld_analysis() runs
-	 * Then:   the CSV row lands in the zone output and the verbatim lines are
-	 *         skipped — no malformed ',,' row in the data output
+	 * Then:   the CSV row lands in the zone output and every verbatim line is
+	 *         skipped — no malformed row in the data output, no numeric
+	 *         undefined-array-key warning from the CSV explode
 	 */
 	public function testVerbatimAbpLinesSkippedWithZeroAbpMarkers(): void
 	{
@@ -91,9 +116,10 @@ final class TldAnalysisAbpVerbatimTest extends TestCase
 			",example.com,,1,PlainFeed,GroupA\n"
 			. "||evil-verbatim.example^\n"
 			. "@@||allow-verbatim.example^\n"
+			. "||opt-verbatim.example^\$script,third-party,domain=x.com,match-case,important,other\n"
 		);
 
-		@tld_analysis();
+		$warnings = $this->runTldAnalysis();
 
 		$this->assertFileExists($pfb['unbound_py_zone']);
 		$zone = (string) file_get_contents($pfb['unbound_py_zone']);
@@ -109,6 +135,16 @@ final class TldAnalysisAbpVerbatimTest extends TestCase
 			'',
 			$data,
 			"verbatim ABP lines must be skipped, not CSV-mangled; got: " . var_export($data, TRUE)
+		);
+
+		$numeric = array_values(array_filter(
+			$warnings,
+			static fn (string $w): bool => preg_match('/Undefined array key \d/', $w) === 1
+		));
+		$this->assertSame(
+			[],
+			$numeric,
+			'no verbatim line may reach the CSV explode; got: ' . var_export($numeric, TRUE)
 		);
 	}
 
@@ -131,7 +167,7 @@ final class TldAnalysisAbpVerbatimTest extends TestCase
 			. ",abp-carried.example,,1,AbpFeed,GroupB\n"
 		);
 
-		@tld_analysis();
+		$this->runTldAnalysis();
 
 		$this->assertFileExists($pfb['unbound_py_zone']);
 		$zone = (string) file_get_contents($pfb['unbound_py_zone']);

--- a/tests/php/WidgetSubmitPostGuardTest.php
+++ b/tests/php/WidgetSubmitPostGuardTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1064 — the widget's pfb_submit branch must tolerate a POST with
+ * per-field keys omitted: the outer isset($_POST['pfb_submit']) gates the
+ * branch, not the keys, and a crafted POST (or a normal save with a checkbox
+ * unchecked — an unchecked checkbox posts no key) raised one PHP 8.3
+ * "Undefined array key" warning per missing field.
+ *
+ * Like PfbWidgetOracleTest, the widget file carries top-level page execution
+ * and cannot be require()d off-appliance, so this eval-extracts the REAL
+ * per-field section of the pfb_submit branch verbatim (up to the cron
+ * section, whose comment is the unique end-anchor) — no reimplementation.
+ */
+final class WidgetSubmitPostGuardTest extends TestCase
+{
+	/** Saved globals, restored in tearDown (issue #1063 hygiene). */
+	private mixed $savedPfb = null;
+	private array $savedPost = [];
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.widget.php');
+		}
+
+		if (!function_exists('pfb_widget_oracle_submit')) {
+			if (!preg_match(
+				'/pfb_widget_post_allowed\(\$_SERVER\)\) \{\n(.*?)(?=\n\n\t\t\/\/ Define pfBlockerNG clear)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: pfb_submit per-field section not found in widget source');
+			}
+			eval(
+				'function pfb_widget_oracle_submit(): array { global $pfb; ' . $m[1]
+				. ' return $pfb[\'wglobal\'] ?? []; }'
+			);
+		}
+	}
+
+	protected function setUp(): void
+	{
+		global $pfb;
+		$this->savedPfb  = $pfb ?? null;
+		$this->savedPost = $_POST;
+		$pfb['wglobal']    = [];
+		$pfb['dnsblquery'] = '60';
+	}
+
+	protected function tearDown(): void
+	{
+		global $pfb;
+		$pfb   = $this->savedPfb;
+		$_POST = $this->savedPost;
+	}
+
+	/** Run the extracted section, returning every PHP warning message it raised. */
+	private function runSubmit(array $post): array
+	{
+		$_POST = $post;
+		$warnings = [];
+		set_error_handler(
+			static function (int $errno, string $errstr) use (&$warnings): bool {
+				$warnings[] = $errstr;
+				return true;
+			},
+			E_WARNING | E_NOTICE
+		);
+		try {
+			pfb_widget_oracle_submit();
+		} finally {
+			restore_error_handler();
+		}
+		return $warnings;
+	}
+
+	/**
+	 * Scenario: crafted POST carrying only the submit marker.
+	 *
+	 * Given:  $_POST holding pfb_submit and none of the per-field keys
+	 * When:   the pfb_submit per-field section runs
+	 * Then:   no "Undefined array key" warning is raised for any field
+	 */
+	public function testCraftedPostMissingAllFieldsRaisesNoWarnings(): void
+	{
+		$warnings = $this->runSubmit(['pfb_submit' => 'save']);
+
+		$undefined = array_values(array_filter(
+			$warnings,
+			static fn (string $w): bool => str_contains($w, 'Undefined array key')
+		));
+		$this->assertSame(
+			[],
+			$undefined,
+			'per-field $_POST reads must tolerate omitted keys; got: ' . var_export($undefined, TRUE)
+		);
+	}
+
+	/**
+	 * Scenario: full well-formed POST still applies every field.
+	 *
+	 * Given:  $_POST holding pfb_submit plus every per-field key with a valid value
+	 * When:   the pfb_submit per-field section runs
+	 * Then:   each widget-* setting reflects the posted value (the ?? '' guards
+	 *         must not swallow present fields)
+	 */
+	public function testFullPostStillAppliesValues(): void
+	{
+		$this->runSubmit([
+			'pfb_submit'     => 'save',
+			'pfb_popup'      => 'on',
+			'pfb_sortmix'    => 'on',
+			'pfb_show_agg'   => 'on',
+			'pfb_sortcolumn' => 'alias',
+			'pfb_sortdir'    => 'asc',
+			'pfb_clearip'    => 'daily',
+			'pfb_cleardnsbl' => 'weekly',
+			'pfb_dnsblquery' => '60',
+			'pfb_maxfails'   => '5',
+			'pfb_maxheight'  => '200',
+		]);
+
+		global $pfb;
+		$expected = [
+			'widget-popup'      => 'on',
+			'widget-sortmix'    => 'on',
+			'widget-show_agg'   => 'on',
+			'widget-sortcolumn' => 'alias',
+			'widget-sortdir'    => 'asc',
+			'widget-clearip'    => 'daily',
+			'widget-cleardnsbl' => 'weekly',
+			'widget-dnsblquery' => '60',
+			'widget-maxfails'   => '5',
+			'widget-maxheight'  => '200',
+		];
+		foreach ($expected as $key => $value) {
+			$this->assertSame(
+				$value,
+				$pfb['wglobal'][$key] ?? null,
+				"widget setting {$key} must reflect the posted value"
+			);
+		}
+	}
+}

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -11,9 +11,11 @@
 # Contracts pinned here:
 #   Rule A  -- git commit + --no-verify                       -> DENY
 #   Rule B  -- git push + force flag (--force / standalone -f /
-#              a clustered short flag like -uf, -fu)
+#              a clustered short flag like -uf, -fu, -4f)
 #              WITHOUT --force-with-lease                     -> DENY
-#              (lease present -> PASS, lease wins even alongside a bare -f)
+#              (lease present AND no bare force flag after the LAST
+#              --force-with-lease -> PASS; git honors the last force
+#              flag, so a bare force AFTER the lease still denies, #1058)
 #   Rule C  -- git worktree remove + force flag                -> DENY
 #   fail-open -- empty / garbled stdin, no rule match           -> PASS
 #   -f boundary -- standalone -f / an f-bearing short-flag cluster,
@@ -273,9 +275,45 @@ Describe 'claude-bash-guard.sh'
       The output should equal ""
     End
 
-    It 'P13 (edge case): --force-with-lease alongside a bare -f -> PASS (lease wins)'
+    It 'P13 (issue #1058): bare -f AFTER --force-with-lease -> DENY (git honors the last force flag)'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease -f"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H13 (issue #1058): digit-bearing short-flag cluster (git push -4f origin main) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push -4f origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H14 (issue #1058): --force AFTER --force-with-lease -> DENY (last force flag wins)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease --force"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'P14 (issue #1058): bare force BEFORE --force-with-lease -> PASS (the lease, last, wins)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force --force-with-lease origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'P15 (issue #1058): --force-with-lease --force-if-includes -> PASS (lease companion, not a bare force)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease --force-if-includes"}}
       End
       When run script "$GUARD"
       The status should be success

--- a/tests/smoke/ui/test_widget_submit_missing_fields.py
+++ b/tests/smoke/ui/test_widget_submit_missing_fields.py
@@ -1,0 +1,79 @@
+"""issue #1064 -- the widget's ``pfb_submit`` save must survive a POST with per-field keys omitted.
+
+The ``pfb_submit`` branch (``pfblockerng.widget.php`` ~76-122) read every per-field
+key (``pfb_popup``, ``pfb_sortcolumn``, ``pfb_dnsblquery``, ...) unguarded: the outer
+``isset($_POST['pfb_submit'])`` gates the branch, not the keys, so a crafted POST
+missing a field -- or a NORMAL save with a checkbox unchecked (an unchecked checkbox
+posts no key at all) -- logged one PHP 8.3 "Undefined array key" warning per field.
+Same crafted-POST class as #1056 (this module mirrors its test) and the
+``pfblockerngack`` guard fixed on PR #1061.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PhpErrorLogGuard
+from .webui import looks_like_login_page, scrape_form_fields
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+# Tier B: a mutating POST flow whose failure mode is a logged-but-not-echoed PHP
+# warning -- observable only end-to-end against the live php_error.log. Tier A's
+# plain-GET render coverage of this page already exists (test_render_smoke.py).
+pytestmark = pytest.mark.ui_e2e
+
+WIDGET_PAGE = "/widgets/widgets/pfblockerng.widget.php"
+
+
+def test_widget_save_missing_per_field_keys_does_not_warn(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A ``pfb_submit`` POST with every per-field key omitted must not raise
+    "Undefined array key" PHP warnings (issue #1064).
+
+    Can't use ``WebUI.post()`` -- it always resends the page's OWN scraped field
+    set, so it can never OMIT one; this replicates its scrape-then-POST shape with
+    the per-field keys deleted first (mirrors ``test_browser_general.py``'s #1056
+    test and ``test_widget_clear_failed.py``'s no-CSRF POST: ``$nocsrf = TRUE`` on
+    this page means no ``__csrf_magic`` token exists to scrape).
+
+    Scenario: widget save survives a POST carrying only the submit marker.
+      Background: pfBlockerNG deployed; webConfigurator authenticated.
+
+    Given the widget page's own scraped field set,
+
+    When every ``pfb_*`` per-field key is deleted from it (simulating a crafted/
+      truncated client request; a real save with all checkboxes unchecked omits
+      the checkbox keys the same way) and ``pfb_submit`` alone is posted,
+
+    Then the response is a save success (the handler redirects to ``/``; never a
+      server error), the session is still authenticated (no bounce to the login
+      form), AND no candidate ``php_error.log`` gained a byte during the request
+      (the guard that catches a logged-but-not-echoed PHP warning).
+    """
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    page = webui.get(WIDGET_PAGE)
+    assert page.status_code == 200, f"GET {WIDGET_PAGE} -> HTTP {page.status_code} (expected 200)"
+    assert not looks_like_login_page(page.text), "pre-save GET bounced to the login page -- not authenticated"
+
+    payload = scrape_form_fields(page.text)
+    for key in [k for k in payload if k.startswith("pfb_")]:
+        del payload[key]
+    payload["pfb_submit"] = "save"
+
+    resp = webui.session.post(webui.url(WIDGET_PAGE), data=payload, timeout=30)
+
+    assert resp.status_code == 200, (
+        f"POST {WIDGET_PAGE} pfb_submit (fields omitted) -> HTTP {resp.status_code} "
+        "(expected 200 after the handler's redirect to /)"
+    )
+    assert not looks_like_login_page(resp.text), "save POST bounced to the login page -- session not authenticated"
+    guard.assert_no_growth()

--- a/tests/test_comment_narration_check.py
+++ b/tests/test_comment_narration_check.py
@@ -236,6 +236,25 @@ def test_cli_staged_and_diff_modes(tmp_path: Path) -> None:
     assert _run(tmp_path, "--diff", "devel~2").returncode == 0
 
 
+def test_cli_diff_replacing_no_eol_last_line_reports_correct_lineno(tmp_path: Path) -> None:
+    # Hostile input (issue #1051): when the OLD file's last line lacks a
+    # trailing newline, git emits "\ No newline at end of file" BETWEEN the
+    # "-" and "+" lines. Counting that marker as a content line shifts every
+    # following added line by one — the violation must be reported at its
+    # REAL line number, not real+1.
+    _git(tmp_path, "init", "-q", "-b", "devel")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/a.inc").write_bytes(b"// clean\n// tail")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base no eol")
+
+    (tmp_path / "src/a.inc").write_text("// clean\n// per RESULTS/03 SS1\n")
+    _git(tmp_path, "add", ".")
+    res = _run(tmp_path, "--staged")
+    assert res.returncode == 1, res.stderr
+    assert "src/a.inc:2" in res.stderr, f"expected src/a.inc:2, got: {res.stderr}"
+
+
 def test_cli_hostile_git_configs_cannot_bypass_the_gate(tmp_path: Path) -> None:
     # core.quotePath defaults true (octal-quotes non-ASCII paths) and
     # diff.mnemonicPrefix rewrites the +++ prefix — either must not blind the scan.

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -854,6 +854,26 @@ def test_cli_diff_added_line_at_eof_no_trailing_newline(tmp_path: Path) -> None:
     assert "scripts/tool.sh:2" in res.stderr
 
 
+def test_cli_diff_replacing_no_eol_last_line_is_flagged(tmp_path: Path) -> None:
+    # Hostile input (issue #1051): when the OLD file's last line lacks a
+    # trailing newline, git emits "\ No newline at end of file" BETWEEN the
+    # "-" and "+" lines. Counting that marker as a content line shifts every
+    # following added line by one, silently filtering out the real violation.
+    _git(tmp_path, "init", "-q", "-b", "devel")
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts/tool.sh").write_bytes(b"_CLEAN=1\n_TAIL=0")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base no eol")
+    base = _rev(tmp_path)
+
+    (tmp_path / "scripts/tool.sh").write_text(f'_CLEAN=1\n_ABI="{_FREEBSD15}"\n')
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "replace no-eol tail with literal")
+    res = _run(tmp_path, "--diff", base)
+    assert res.returncode == 1, res.stderr
+    assert "scripts/tool.sh:2" in res.stderr
+
+
 def test_cli_diff_plus_plus_prefixed_added_line_not_misparsed_as_header(tmp_path: Path) -> None:
     # Hostile input: an added content line starting with "++" renders in the
     # unified diff as "+++ ..." (marker '+' + content "++ ..."). It must NOT be


### PR DESCRIPTION
One commit per issue, each with an executed red→green proof.

## #1051 — diff-scoped checker parsers miscount `\ No newline at end of file`

Both `scripts/check_version_literals.py` (`--staged`/`--diff`) and `scripts/check_comment_narration.py` counted git's `\ No newline at end of file` marker as a content line. When the old file's last line lacked a trailing newline, the marker sits between the `-` and `+` lines, shifting every following added line by one: a **silent false negative** in the version-literal checker's diff modes and an off-by-one reported line number in the narration checker. `\`-prefixed lines are now no-ops in both parsers; regression tests pin the replace-a-no-eol-last-line shape in both test files (red pre-fix: exit 0 miss, `src/a.inc:3` instead of `:2`).

## #1058 — claude-bash-guard force-push bypasses

1. Digit-bearing short-flag clusters: git clusters digit short flags (`-4`/`-6`) like letters, so `git push -4f` force-pushed straight through the `-[a-z]*f[a-z]*` class. Widened to `-[a-z0-9]*f[a-z0-9]*`.
2. Lease/force precedence: git honors the **last** force flag, so `git push --force-with-lease --force` (or a trailing `-f`) is a bare force push, yet Rule B passed any segment containing a lease. Now denied when a bare force flag (exact-word `--force` or an f-cluster) follows the last `--force-with-lease`; `--force-if-includes` (a lease companion) and force-before-lease stay clean, pinned by new PASS cases. Spec case P13 flips to the corrected semantics. All three gaps probe-confirmed pre-fix; shellspec 50/50 after.

## #1060 — TLD analysis CSV-mangles verbatim ABP lines when no ABP feed is configured

`tld_analysis()`'s empty-feed-column skip was gated on `!empty($abp_feeds)` (at least one persisted `.abp` marker). With zero markers, a plain feed's ADR-21 verbatim `||domain^` line reached `explode(',', $line, 3)` — no index 1, an undefined-index read, and a malformed row in the python data output. The empty/unset-feed-column rule now runs unconditionally; the marker-based skip by feed name stays for marked feeds (full marker retirement remains ADR-62 Phase 5's). Red pre-fix: the new PHPUnit test observed literal `,,,,` in `pfb_py_data`; post-fix the verbatim lines are skipped and the plain CSV row still processes.

## #1063 — PHPUnit random-order `dbdir` global-state leak

Root cause: `SoftwareUpdateCheckTest::tearDown()` **unset** the bootstrap-seeded `$GLOBALS['pfb']['dbdir']` (and `$GLOBALS['config']`) instead of restoring the prior values. It sorts alphabetically after the affected suites, so the default-order gate never saw the leak; under `--order-by=random`, `AliasDeltaApplyTest`/`PfctlTableOpTest` then warned `Undefined array key "dbdir"` (reads at `pfblockerng.inc:4873/4875`). Fixed with save/restore in setUp/tearDown; `SoftwareUpdateCheckHygieneTest` pins the restore contract by driving the suite's own setUp/tearDown pair against sentinel globals (red pre-fix on both assertions). Repro seeds now clean: `--random-order-seed=1783634966` (full suite), `1783635147` (filtered). The new `TldAnalysisAbpVerbatimTest` ships with the same save/restore hygiene.

## #1064 — widget `pfb_submit` branch reads per-field `$_POST` keys unguarded

The outer `isset($_POST['pfb_submit'])` gates the branch, not the keys: a crafted POST missing a field — or a **normal save with a checkbox unchecked** (an unchecked checkbox posts no key) — logged one PHP 8.3 "Undefined array key" warning per field. Added `?? ''` at the ten first-read sites; the follow-up reads are reached only after `in_array()`/`is_numeric()` proved the key present. `WidgetSubmitPostGuardTest` eval-extracts the real per-field section (PfbWidgetOracleTest's pattern) and pins both directions: a submit-only POST raises no warnings (red pre-fix: all ten keys warned) and a full POST still applies every value. A Tier-B browser case mirrors #1056's (`pfb_submit` with per-field keys omitted under the `php_error.log` growth guard) — live-VM only, collect-verified locally, runs in CI.

## Gates

`python3 -m pytest` 2540 passed · PHPUnit 2593 passed (11 documented root-guard skips) · phpstan · phpcs · ruff check/format · mypy · shellcheck · shellspec 50/50 · `php -l` per touched file.

Fixes #1051
Fixes #1058
Fixes #1060
Fixes #1063
Fixes #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzuY3p85vwR4jACAo2Grqs

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzuY3p85vwR4jACAo2Grqs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protection against unsafe Git force-push commands, including complex short-flag combinations and conflicting force options.
  - Corrected feed processing for plain feeds containing verbatim ABP entries.
  - Prevented widget settings submissions with missing fields from generating warnings or applying invalid values.
  - Fixed line-number reporting in diff checks when files lack a trailing newline.

- **Tests**
  - Added regression coverage for widget submissions, feed parsing, force-push protection, diff checks, and test-state isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->