### PR TITLE
scripts: fix check_version_literals docstring detection so a string/comment triple-quote can't hide a literal (#1082)

### DIFF
--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -302,6 +302,11 @@ def _py_docstring_probe(line: str) -> str:
         if triple is not None:
             # content of an open triple span is blanked; only its matching close
             # delimiter is emitted, so a quote or "#" inside it can't mislead us.
+            if line[i] == "\\":
+                # Escapes work inside triple quotes too: \""" is an escaped quote
+                # + two quotes, not a close delimiter.
+                i += 2
+                continue
             if three == triple:
                 out.append(three)
                 triple = None

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -311,7 +311,10 @@ def _py_docstring_probe(line: str) -> str:
             continue
         if quote is not None:
             ch = line[i]
-            if quote == '"' and ch == "\\":
+            if ch == "\\":
+                # Python escapes inside BOTH '...' and "..." strings, so a \' or \"
+                # does not close the string and a following triple-quote token stays
+                # string content rather than a docstring delimiter.
                 i += 2
                 continue
             if ch == quote:

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -283,6 +283,58 @@ def _tracked_files(roots: tuple[str, ...]) -> list[Path]:
 _TRIPLE_QUOTE_TOKENS = ('"""', "'''")
 
 
+def _py_docstring_probe(line: str) -> str:
+    """Reduce ``line`` to its real triple-quote delimiters plus bare code.
+
+    issue #1082: a triple-quote token (``'''`` or its double-quote form) that
+    appears only inside a normal single-line ``'...'``/``"..."`` string or a
+    trailing ``#`` comment (e.g. ``SEP = "'''"``) must NOT count as a delimiter -- else it
+    opens a spurious docstring that swallows every following line. This blanks
+    normal-string content and the trailing comment while keeping delimiters, so
+    the caller's odd/even count sees only genuine triple-quote delimiters.
+    """
+    out: list[str] = []
+    quote: str | None = None  # inside a normal single-line '...'/"..." string
+    triple: str | None = None  # inside a triple-quoted span opened on THIS line
+    i, n = 0, len(line)
+    while i < n:
+        three = line[i : i + 3]
+        if triple is not None:
+            # content of an open triple span is blanked; only its matching close
+            # delimiter is emitted, so a quote or "#" inside it can't mislead us.
+            if three == triple:
+                out.append(three)
+                triple = None
+                i += 3
+                continue
+            i += 1
+            continue
+        if quote is not None:
+            ch = line[i]
+            if quote == '"' and ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if three in _TRIPLE_QUOTE_TOKENS:
+            out.append(three)
+            triple = three
+            i += 3
+            continue
+        ch = line[i]
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        if ch == "#":
+            break
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def _code_lines(lines: list[str], suffix: str) -> list[str | None]:
     """Return, per line, the code portion to scan -- or ``None`` for prose.
 
@@ -295,7 +347,8 @@ def _code_lines(lines: list[str], suffix: str) -> list[str | None]:
       the tree; a same-line `/*...*/` pair keeps its trailing code).
     * everything else: ``#`` line/trailing comments.
     * ``.py`` additionally tracks triple-quoted docstrings: an ODD number of
-      triple-quote tokens toggles the docstring state (a close-and-reopen on
+      real triple-quote delimiters (outside normal strings/comments, issue
+      #1082) toggles the docstring state (a close-and-reopen on
       one line therefore stays open), while an EVEN count on a non-docstring
       line falls through to the value scan, so a one-line triple-quoted
       assignment (X = triple-quoted token) is caught by the quoted-literal
@@ -329,9 +382,10 @@ def _code_lines(lines: list[str], suffix: str) -> list[str | None]:
             out.append(None)
             continue
         if is_python:
+            probe = _py_docstring_probe(line)
             opened = False
             for token in _TRIPLE_QUOTE_TOKENS:
-                if line.count(token) % 2 == 1:
+                if probe.count(token) % 2 == 1:
                     open_token = token
                     opened = True
                     break

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -950,3 +950,15 @@ def test_py_real_docstring_block_still_masks_prose(tmp_path: Path) -> None:
     # masks its prose, so a version token inside it stays clean (green before AND after).
     content = '"""' + "\n" + _FREEBSD15 + "\n" + '"""' + "\n"
     assert _find_py(tmp_path, content) == [], "a version token inside a real docstring must stay clean"
+
+
+def test_py_triple_quote_after_escaped_single_quote_does_not_swallow_next_line(tmp_path: Path) -> None:
+    # issue #1082: a single-quoted Python string may contain an escaped
+    # quote (\') before a triple-quote token, e.g. x = 'it\'s """'. The probe
+    # must honour the backslash escape (single quotes escape in Python, unlike POSIX
+    # sh) so the string does not close early and the """ inside it is not miscounted.
+    tricky = "x = 'it\\'s " + '"""' + "'\n"  # -> x = 'it\'s """'
+    abi_line = '_ABI = "' + _FREEBSD15 + '"\n'
+    violations = _find_py(tmp_path, tricky + abi_line)
+    assert len(violations) == 1, f"literal after an escaped-quote + triple-quote line must be flagged; got {violations}"
+    assert violations[0][1] == 2

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -917,3 +917,36 @@ def test_cli_diff_non_utf8_byte_does_not_crash_the_run(tmp_path: Path) -> None:
     assert res.returncode == 1, res.stderr
     assert "Traceback" not in res.stderr, res.stderr
     assert "scripts/b.sh:2" in res.stderr
+
+
+# --- issue #1082: triple-quote inside a normal string/comment must not open a
+# --- spurious docstring that swallows a real version literal on later lines ----
+
+
+def _find_py(tmp_path: Path, content: str) -> list[Any]:
+    f = tmp_path / "sample.py"
+    f.write_text(content, encoding="utf-8")
+    return cvl.find_violations([f])
+
+
+def test_py_triple_quote_inside_string_does_not_swallow_next_line(tmp_path: Path) -> None:
+    # `SEP = "'''"` holds one `'''` INSIDE a normal string; before the fix its odd
+    # count opened a phantom docstring, masking the ABI literal on the next line.
+    sep_line = 'SEP = "' + "'''" + '"\n'  # SEP = "'''"
+    abi_line = '_ABI = "' + _FREEBSD15 + '"\n'
+    violations = _find_py(tmp_path, sep_line + abi_line)
+    assert len(violations) == 1, f"literal after a string-embedded triple-quote must be flagged; got {violations}"
+    assert violations[0][1] == 2
+
+
+def test_py_triple_quote_in_trailing_comment_does_not_swallow_next_line(tmp_path: Path) -> None:
+    violations = _find_py(tmp_path, "x = 1  # " + "'''" + "\n" + f'_ABI = "{_FREEBSD15}"\n')
+    assert len(violations) == 1, f"literal after a comment-embedded triple-quote must be flagged; got {violations}"
+    assert violations[0][1] == 2
+
+
+def test_py_real_docstring_block_still_masks_prose(tmp_path: Path) -> None:
+    # Behaviour-preserving oracle: a genuine triple-quoted docstring block still
+    # masks its prose, so a version token inside it stays clean (green before AND after).
+    content = '"""' + "\n" + _FREEBSD15 + "\n" + '"""' + "\n"
+    assert _find_py(tmp_path, content) == [], "a version token inside a real docstring must stay clean"

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -962,3 +962,22 @@ def test_py_triple_quote_after_escaped_single_quote_does_not_swallow_next_line(t
     violations = _find_py(tmp_path, tricky + abi_line)
     assert len(violations) == 1, f"literal after an escaped-quote + triple-quote line must be flagged; got {violations}"
     assert violations[0][1] == 2
+
+
+def test_py_escaped_quote_inside_triple_span_is_not_a_close(tmp_path: Path) -> None:
+    # Escapes also work INSIDE a same-line triple span: in x = """abc \""" def"""
+    # the \" is an escaped quote, so the string closes only at the final """ --
+    # one CLOSED string. The ABI literal on the next line must still be flagged.
+    tricky = 'x = """abc \\""" def"""\n'
+    abi_line = '_ABI = "' + _FREEBSD15 + '"\n'
+    violations = _find_py(tmp_path, tricky + abi_line)
+    assert len(violations) == 1, f"literal after a closed escape-carrying triple string: {violations}"
+    assert violations[0][1] == 2
+
+
+def test_py_escaped_quote_keeps_triple_span_open(tmp_path: Path) -> None:
+    # The inverse: x = """abc \""" never closes on its own line (the \" is
+    # escaped, leaving only two quotes), so the next line is string prose and a
+    # version token there must stay masked until the real close.
+    content = 'x = """abc \\"""\n' + '_ABI = "' + _FREEBSD15 + '"\n' + '"""\n'
+    assert _find_py(tmp_path, content) == [], "prose inside a still-open escape-carrying triple string must stay masked"


### PR DESCRIPTION
## Summary

Fixes #1082. `check_version_literals.py`'s `_code_lines` derived Python docstring state from a raw `line.count()` of triple-quote tokens. A `'''` (or the `"""` form) appearing inside a normal single-line string or a trailing `#` comment — e.g. `SEP = "'''"` — produced an odd count and flipped the scanner into a spurious docstring, masking every following line. A real version literal on a later line then escaped the gate (silent false negative).

## Fix

Count only *genuine* triple-quote delimiters (outside normal strings/comments) via a small per-line char scan (`_py_docstring_probe`) used solely for the open/close decision — the scanned line content is unchanged, so real literals inside one-line triple-quoted assignments are still caught.

The probe tracks both normal-string and triple-quote state within a line, so a quote inside a triple span cannot mislead it. That subtlety matters: a one-line docstring like `"""… when it's empty …"""` contains an apostrophe; a naive scan treats it as a normal-string start that swallows the closing `"""`. The in-line triple-state tracking handles it (verified against the full tree — `scripts/gen_landing.py`, `scripts/build-repo-portable.py` docstrings stay correctly masked).

## Tests

New cases in `tests/test_version_literal_check.py`:

- `test_py_triple_quote_inside_string_does_not_swallow_next_line` — `SEP = "'''"` followed by a banned ABI literal: the literal is now flagged (line 2).
- `test_py_triple_quote_in_trailing_comment_does_not_swallow_next_line` — same for a trailing-comment triple-quote.
- `test_py_real_docstring_block_still_masks_prose` — behaviour-preserving oracle: a version token inside a genuine docstring stays clean (green before and after).

Red/green verified by reverting the checker only: pre-change 2 failed / 2 passed, post-change all pass.

Gates: full-tree `check_version_literals.py` scan clean · `python3 -m pytest` → 2543 passed, 5 skipped · `ruff check` · `ruff format --check` · `mypy tests/` all clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_011VhmsbWUy3ufVPo34VSzpR)_