### PR TITLE
pfblockerng: correct pfb_idn registry comment — canonical token is 'on', not 'all' (#1078)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -897,9 +897,10 @@ function pfb_cfg_registry(): array
 		// ADR-08: IDN mode — adopted into the gateway as a PfbIdnMode enum (ADR-28
 		// reframe: preserve behaviour on upgrade, not byte-identical storage). Read
 		// normalises legacy 'on' -> All; write persists the canonical token
-		// ('all'|'confusable'|'off'), so a stored legacy 'on'/'' migrates on next save
-		// to a behaviour-equivalent value. Downgrade-safe: older releases string-compared
-		// these tokens, so an unknown token falls through to their off default.
+		// ('on'=All | 'confusable' | 'off'), reusing the pre-4.0.0 'on' token so All
+		// round-trips with zero migration. Legacy '' and the 4.0.0-alpha 'all' token
+		// read as Off. Downgrade-safe: older releases string-compared these tokens,
+		// so an unknown token falls through to their off default.
 		// See ADR-28 §2.2 + CfgAdaptersTest + RollbackContractTest.
 		'pfb_idn' => [
 			'section'       => $dnsbl,


### PR DESCRIPTION
## Summary

Fixes #1078. The `PfbConfig` registry comment for `pfb_idn` named the persisted canonical token as `'all'`, but the write adapter `pfb_cfg_idn_mode_write()` and the vocabulary comment (both in `pfblockerng_extra.inc`) persist `'on'` (=All) — reusing the pre-4.0.0 token so All round-trips with zero migration; the 4.0.0-alpha `'all'` token and legacy `''` read as Off. The comment's "legacy `'on'`/`''` migrates on next save" claim was also wrong: `'on'` *is* the canonical form, not a value migrated away from.

A maintainer extending IDN handling from this comment would have built on the wrong token.

## Fix

Comment-only. Correct the canonical token to `'on'=All | 'confusable' | 'off'` and drop the false migration claim, matching the adapter docstrings (`pfblockerng_extra.inc:366-367`, `:1585-1586`) and the vocabulary comment (`:120-121`). The ADR text and adapters are already correct, so no ADR amendment is needed.

## Tests

No behaviour change (comment only). The existing `CfgAdaptersTest` and `RollbackContractTest` already pin the real token vocabulary (`'on'`=All, `''`/`'all'` → Off) — they are the oracle proving the corrected comment accurate and stay green.

Gates: `php -l` clean · `phpcs --standard=phpcs.xml.dist` clean · `phpstan` — no errors · `phpunit --filter "IdnMode|CfgAdapters|Rollback"` → 134 passed.

no-test-needed: comment-only correction of an existing code comment; no runtime behaviour changes. The existing CfgAdaptersTest and RollbackContractTest already pin the pfb_idn token vocabulary this comment documents.
