### PR TITLE
pfblockerng: dedup AWS IPv6 prefixes in the shared region pre-script (#1079)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/list_scripts/aws_region_prefixes.sh
+++ b/src/usr/local/pkg/pfblockerng/list_scripts/aws_region_prefixes.sh
@@ -66,7 +66,13 @@ if [ "${prefix}" = '_v4' ]; then
 		exit 1
 	fi
 else
-	mv -f "${rawfile}" "${tempfile}"
+	# issue #1079: raw jq output repeats a v6 prefix listed for several services;
+	# iprange dedups the v4 side, so dedup here too (ADR-26: LC_ALL=C byte order).
+	if ! LC_ALL=C sort -u "${rawfile}" > "${tempfile}"; then
+		echo "AWS pre-script: IPv6 dedup failed"
+		rm -f "${rawfile}" "${tempfile}"
+		exit 1
+	fi
 fi
 rm -f "${rawfile}"
 

--- a/tests/shell/ip_pre_aws_spec.sh
+++ b/tests/shell/ip_pre_aws_spec.sh
@@ -93,9 +93,9 @@ Describe 'aws_region_prefixes.sh failure handling'
   End
 End
 
-# The v6 path publishes raw jq output; the real ip-ranges.json lists the same
-# ipv6_prefix once per service, so the published list carried duplicates. The
-# v4 path never showed this because iprange aggregates (and so dedups).
+# The v6 path used to publish raw jq output; the real ip-ranges.json lists the
+# same ipv6_prefix once per service, so the published list carried duplicates.
+# The v4 path never showed this because iprange aggregates (and so dedups).
 Describe 'aws_region_prefixes.sh v6 dedup (issue #1079)'
   awswork=""
   setup()   { awswork="$(mktemp "${SHELLSPEC_TMPBASE:-/tmp}/awsdup.XXXXXX")"; }

--- a/tests/shell/ip_pre_aws_spec.sh
+++ b/tests/shell/ip_pre_aws_spec.sh
@@ -92,3 +92,23 @@ Describe 'aws_region_prefixes.sh failure handling'
     The contents of file "$awswork" should include '"region":"us-east-1"'
   End
 End
+
+# The v6 path publishes raw jq output; the real ip-ranges.json lists the same
+# ipv6_prefix once per service, so the published list carried duplicates. The
+# v4 path never showed this because iprange aggregates (and so dedups).
+Describe 'aws_region_prefixes.sh v6 dedup (issue #1079)'
+  awswork=""
+  setup()   { awswork="$(mktemp "${SHELLSPEC_TMPBASE:-/tmp}/awsdup.XXXXXX")"; }
+  cleanup() { rm -f "$awswork"; }
+  Before 'setup'
+  After 'cleanup'
+
+  It 'publishes a duplicated v6 prefix exactly once'
+    printf '%s' '{"prefixes":[],"ipv6_prefixes":[{"ipv6_prefix":"2001:db8:13::/48","region":"ap-south-1"},{"ipv6_prefix":"2001:db8:13::/48","region":"ap-south-1"},{"ipv6_prefix":"2001:db8:14::/48","region":"ap-south-1"}]}' > "$awswork"
+    When run sh "${PFB_PKGDIR}/list_scripts/ip_pre_AWS_AP_SOUTH.sh" "$awswork" _v6
+    The status should be success
+    The first line of contents of file "$awswork" should equal "2001:db8:13::/48"
+    The second line of contents of file "$awswork" should equal "2001:db8:14::/48"
+    The lines of contents of file "$awswork" should equal 2
+  End
+End


### PR DESCRIPTION
## Summary

Fixes #1079. `aws_region_prefixes.sh`'s IPv6 branch published the raw jq output straight into the alias file. The real `ip-ranges.json` lists the same `ipv6_prefix` once per service, so the published v6 list carried duplicates. The IPv4 branch never showed this because `iprange` aggregates (and therefore dedups) its input.

## Fix

Replace the `mv -f` publish with `LC_ALL=C sort -u` (ADR-26: byte-order collation on machine data), mirroring the v4 branch's status-checked shape — a failed sort cleans up and exits 1 instead of publishing a partial file. Applies to all 25 region wrappers through the shared script.

## Tests

New self-contained example in `tests/shell/ip_pre_aws_spec.sh`: a fixture with one duplicated + one unique v6 prefix (RFC 3849 data) run through `ip_pre_AWS_AP_SOUTH.sh _v6` must publish exactly two lines, each prefix once. Red/green executed by reverting the source only: 1 failure before (duplicate survives), 34/34 after. Full shellspec suite: 456 examples, 0 failures, 9 pre-existing skips.

Gates: `sh -n` · `shellcheck` clean on the touched script · `shellspec` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NviP9zgwweu471WhThw6U)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate IPv6 address prefixes from AWS region listings, preventing repeated entries in published output.

* **Tests**
  * Added coverage confirming IPv6 prefixes are deduplicated and that each distinct prefix appears only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->