### PR TITLE
pfblockerng: stamp DNSBL decision memos with their snapshot generation (#1074)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import csv
 import errno
+import itertools
 import json
 import logging
 import logging.handlers
@@ -2768,6 +2769,10 @@ def get_details_dnsbl(
     # path silently misses it -> per-feed under-count).
     q_name_key = q_name.lower()
     cached = decisionDB.get(q_name_key)
+    # No snap_gen check here (issue #1074): this path only ATTRIBUTES a block operate()
+    # already served for this query -- operate() refreshed the memo first, and gating on
+    # the live generation would drop the log line for a block genuinely served just
+    # before a swap landed.
     dnsbl = cached.dnsbl if cached is not None else UNSET
     if dnsbl is not UNSET and dnsbl.is_found and not dnsbl.in_whitelist:
         # If logging is disabled, do not log blocked DNSBL events (Utilize DNSBL Webserver)
@@ -3693,6 +3698,12 @@ class BuildResult:
     rejects: RejectTally = field(default_factory=dict)
 
 
+# issue #1074: every built Snapshot gets a unique, monotonically-advancing generation
+# so a decisionDB memo can be tied to the snapshot that produced it (id() is unusable:
+# a freed old snapshot's id can be reused by the new one).
+_snapshot_gen = itertools.count(1)
+
+
 @dataclass(frozen=True)
 class Snapshot:
     """ADR-10: the immutable bundle of every matcher stratum a DNS query reads.
@@ -3746,6 +3757,9 @@ class Snapshot:
     counts: int = 0
     regex_count: int = 0
     rejects: RejectTally = field(default_factory=dict)
+    # issue #1074: identity of this snapshot for decisionDB memo stamping; auto-assigned,
+    # never passed by builders.
+    gen: int = field(default_factory=lambda: next(_snapshot_gen))
 
     def containers(self) -> dict[str, Any]:
         """The per-query ``containers`` dict ``evaluate_domain`` reads (legacy keys).
@@ -5390,7 +5404,12 @@ def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_coun
       2. ``decisionDB.clear()`` -- the unified per-name LRU query memo (#67/#70/#72).
          It is otherwise reset only by ``init`` re-creating it, so a no-restart swap
          MUST clear it or ``operate()`` re-serves a STALE block/allow verdict on a cache
-         miss (a newly-added name would stay unblocked, a newly-removed name blocked);
+         miss (a newly-added name would stay unblocked, a newly-removed name blocked).
+         The clear alone is NOT sufficient (issue #1074): a query thread that captured
+         the OLD snapshot can memoize its verdict AFTER this clear, so every memo is
+         also stamped with its ``Snapshot.gen`` and a reader rejects a foreign-
+         generation entry -- the clear remains as eager eviction, the stamp is the
+         correctness guard;
       3. reset the DNSBL Reports cache through ``_db_reset_cache`` (``_db_lock``-
          serialized, parity with the init-time wipe -- never an off-thread file touch);
       4. re-emit ``pfb_py_count`` / ``pfb_py_regex_count`` (the ``DNSBL_Regex`` UI alias)
@@ -5629,13 +5648,20 @@ class Decision:
     dnsbl: Any = UNSET  # DnsblDecision once the DNSBL stratum evaluated the name
     noaaaa: Any = UNSET  # bool (AAAA-only): True = block, False = allow
     safesearch: Any = UNSET  # matched safeSearchDB {A,AAAA} entry, or None = no match
+    # issue #1074: Snapshot.gen this Decision was computed against. 0 (no real
+    # generation) never matches, so an unstamped entry always reads as stale.
+    snap_gen: int = 0
 
 
-def _decision_for(name: str) -> Decision:
+def _decision_for(name: str, snap_gen: int) -> Decision:
     # Get-or-create the one Decision entry for a name; axes are filled in by the caller.
+    # issue #1074: a memo is only valid for the snapshot generation that produced it --
+    # an entry stamped with another generation is replaced, never extended, so a write
+    # that lost a race with rebuild_and_swap's decisionDB.clear() cannot be extended
+    # into a fresh-looking verdict.
     dec = decisionDB.get(name)
-    if dec is None:
-        dec = Decision()
+    if dec is None or dec.snap_gen != snap_gen:
+        dec = Decision(snap_gen=snap_gen)
         decisionDB[name] = dec
     return dec
 
@@ -6261,7 +6287,7 @@ def safesearch_entry(q_name_original: str) -> Any:
     negative memo). Shared by the pre-resolution (NEW) and post-resolution
     (MODDONE, CNAME redirect) passes so both agree on the same memoized verdict.
     """
-    dec = _decision_for(q_name_original)
+    dec = _decision_for(q_name_original, _snapshot.gen)
     if dec.safesearch is UNSET:
         entry = safeSearchDB.get(q_name_original)
         # Validate 'www.' Domains
@@ -6433,7 +6459,7 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
         # axis): UNSET = not yet evaluated, True = block, False = allow (the old
         # excludeAAAADB negative memo). No separate excludeAAAADB / noAAAADB-memo.
         if qstate_valid and q_type == RR_TYPE_AAAA and pfb["noAAAADB"]:
-            dec = _decision_for(q_name_original)
+            dec = _decision_for(q_name_original, _snapshot.gen)
             if dec.noaaaa is UNSET:
                 dec.noaaaa = evaluate_noaaaa(q_name_original, noAAAADB)
 
@@ -6586,8 +6612,12 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
             # ("let Unbound resolve it" / whitelisted) -- both are decisions, both
             # are memoized. A repeat query (including a CNAME-blocked name, keyed on
             # the original) short-circuits here without re-resolving or re-evaluating.
+            # issue #1074: a memo stamped by ANOTHER snapshot generation is stale --
+            # a thread that raced rebuild_and_swap's clear() can re-insert an
+            # old-snapshot verdict after the swap, so the stamp, not mere presence,
+            # decides validity.
             dec = decisionDB.get(q_name)
-            dnsbl = dec.dnsbl if dec is not None else UNSET
+            dnsbl = dec.dnsbl if dec is not None and dec.snap_gen == snap.gen else UNSET
             if dnsbl is UNSET:
                 # The original query's TLD comes from qstate; a CNAME target (isCNAME)
                 # has its own TLD, so derive it from the target name being evaluated --
@@ -6647,8 +6677,9 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                     q_name = q_name_original
 
                 # Memoize the DNSBL verdict on the name's Decision (block OR allow), so
-                # this name is decided once; the other axes share the same entry.
-                _decision_for(q_name).dnsbl = dnsbl
+                # this name is decided once; the other axes share the same entry. The
+                # memo is stamped with THIS query's snapshot generation (issue #1074).
+                _decision_for(q_name, snap.gen).dnsbl = dnsbl
 
                 # Add domain data to DNSBL cache for Reports tab (fresh block only)
                 if dnsbl.is_found and not dnsbl.in_whitelist:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2769,10 +2769,9 @@ def get_details_dnsbl(
     # path silently misses it -> per-feed under-count).
     q_name_key = q_name.lower()
     cached = decisionDB.get(q_name_key)
-    # No snap_gen check here (issue #1074): this path only ATTRIBUTES a block operate()
-    # already served for this query -- operate() refreshed the memo first, and gating on
-    # the live generation would drop the log line for a block genuinely served just
-    # before a swap landed.
+    # No snap_gen check (issue #1074): this only ATTRIBUTES the block operate() served
+    # -- a live-gen gate would drop the log line for a block served just before a swap;
+    # worst case is a swap-race mis-attributed feed/group in the log, never the answer.
     dnsbl = cached.dnsbl if cached is not None else UNSET
     if dnsbl is not UNSET and dnsbl.is_found and not dnsbl.in_whitelist:
         # If logging is disabled, do not log blocked DNSBL events (Utilize DNSBL Webserver)
@@ -5655,11 +5654,14 @@ class Decision:
 
 def _decision_for(name: str, snap_gen: int) -> Decision:
     # Get-or-create the one Decision entry for a name; axes are filled in by the caller.
-    # issue #1074: a memo is only valid for the snapshot generation that produced it --
-    # an entry stamped with another generation is replaced, never extended, so a write
-    # that lost a race with rebuild_and_swap's decisionDB.clear() cannot be extended
-    # into a fresh-looking verdict.
+    # issue #1074: a memo is only valid for the generation that produced it -- a
+    # foreign-generation entry is replaced, never extended.
     dec = decisionDB.get(name)
+    if dec is not None and dec.snap_gen > snap_gen:
+        # An older-generation straggler neither evicts the newer entry nor extends it:
+        # it writes into a throwaway Decision no reader will ever see (gen advances
+        # monotonically, so its verdict can never become current again).
+        return Decision(snap_gen=snap_gen)
     if dec is None or dec.snap_gen != snap_gen:
         dec = Decision(snap_gen=snap_gen)
         decisionDB[name] = dec
@@ -6612,10 +6614,9 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
             # ("let Unbound resolve it" / whitelisted) -- both are decisions, both
             # are memoized. A repeat query (including a CNAME-blocked name, keyed on
             # the original) short-circuits here without re-resolving or re-evaluating.
-            # issue #1074: a memo stamped by ANOTHER snapshot generation is stale --
-            # a thread that raced rebuild_and_swap's clear() can re-insert an
-            # old-snapshot verdict after the swap, so the stamp, not mere presence,
-            # decides validity.
+            # issue #1074: a foreign-generation memo is stale -- a thread racing
+            # rebuild_and_swap's clear() can re-insert an old-snapshot verdict after
+            # the swap, so the stamp, not mere presence, decides validity.
             dec = decisionDB.get(q_name)
             dnsbl = dec.dnsbl if dec is not None and dec.snap_gen == snap.gen else UNSET
             if dnsbl is UNSET:

--- a/tests/test_adr10_swap.py
+++ b/tests/test_adr10_swap.py
@@ -113,6 +113,14 @@ class _CountingLock:
         self._lock.__exit__(*exc)
 
 
+def test_each_snapshot_gets_a_fresh_generation() -> None:
+    # issue #1074: the decisionDB memo stamp needs every built Snapshot to carry a
+    # unique, advancing generation -- two builds must never share one (id() reuse is
+    # exactly the trap this replaces).
+    a, b = _snapshot(), _snapshot()
+    assert b.gen > a.gen > 0
+
+
 # --------------------------------------------------------------------------- #
 # Success path: rebind + clear decisionDB + reset Reports + recount
 # --------------------------------------------------------------------------- #

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -118,15 +118,18 @@ def _dnsbl_decision(**kw: Any) -> Any:
 
 def allow_decision() -> Any:
     # A composed Decision whose DNSBL axis is a not-found (allow) verdict -- seeds the
-    # allow short-circuit path (the old excludeDB membership).
-    return pfb_unbound.Decision(dnsbl=_dnsbl_decision())
+    # allow short-circuit path (the old excludeDB membership). Stamped with the LIVE
+    # snapshot generation: a seeded memo plays a verdict the live snapshot produced
+    # (an unstamped/foreign-generation one reads as stale, issue #1074).
+    return pfb_unbound.Decision(dnsbl=_dnsbl_decision(), snap_gen=pfb_unbound._snapshot.gen)
 
 
 def block_decision(**kw: Any) -> Any:
     # A composed Decision whose DNSBL axis is a block; kw overrides DnsblDecision fields.
+    # Live-generation stamp: same contract as allow_decision above.
     base = {"is_found": True, "log_type": "1", "b_type": "DNSBL", "p_type": "Python", "feed": "F", "group": "G"}
     base.update(kw)
-    return pfb_unbound.Decision(dnsbl=_dnsbl_decision(**base))
+    return pfb_unbound.Decision(dnsbl=_dnsbl_decision(**base), snap_gen=pfb_unbound._snapshot.gen)
 
 
 class TestIsUnknown:
@@ -1344,7 +1347,7 @@ class TestOperateNoAAAA:
     def test_excluded_domain_not_blocked(self) -> None:
         add_noaaaa("example.com", wildcard=False)
         # A cached allow verdict (noaaaa False) short-circuits -- the old excludeAAAADB.
-        pfb_unbound.decisionDB["example.com"] = pfb_unbound.Decision(noaaaa=False)
+        pfb_unbound.decisionDB["example.com"] = pfb_unbound.Decision(noaaaa=False, snap_gen=pfb_unbound._snapshot.gen)
         qstate = make_qstate("example.com.", qtype=RR_AAAA)
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert qstate.ext_state[0] == MODULE_WAIT_MODULE
@@ -1510,6 +1513,49 @@ class TestOperateDnsbl:
         assert qstate.ext_state[0] == MODULE_FINISHED
         answers = DNSMessage.instances[-1].answer
         assert any(a.startswith("cached-block.com. ") for a in answers)
+
+    def test_stale_generation_memo_is_recomputed_not_served(self, monkeypatch: Any) -> None:
+        # issue #1074: a query thread that captured the OLD snapshot can memoize its
+        # verdict AFTER rebuild_and_swap()'s decisionDB.clear(), re-inserting a verdict
+        # the new generation no longer agrees with. Scenario: evil.com was blocked by
+        # the old lists, the new snapshot REMOVED it (not in any live list), and the
+        # old-snapshot block verdict sits in decisionDB without the live generation's
+        # stamp. operate() must recompute against the live snapshot -- the query
+        # resolves -- instead of re-serving the stale block.
+        self._enable(monkeypatch)
+        stale = pfb_unbound.Decision(
+            dnsbl=_dnsbl_decision(
+                is_found=True, log_type="1", b_type="DNSBL", p_type="Python", feed="F", group="G", b_eval="evil.com"
+            )
+        )
+        pfb_unbound.decisionDB["evil.com"] = stale
+        qstate = make_qstate("evil.com.", qtype=RR_A)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        # Before the fix this served the stale block (MODULE_FINISHED + a reply).
+        assert qstate.ext_state[0] == MODULE_WAIT_MODULE
+        # The memo was replaced by a live-generation allow verdict, so the stale one
+        # cannot be served on the next query either.
+        dec = pfb_unbound.decisionDB.get("evil.com")
+        assert dec is not None
+        assert dec.snap_gen == pfb_unbound._snapshot.gen
+        assert dec.dnsbl.is_found is False
+
+    def test_stale_generation_write_cannot_extend_a_live_memo(self, monkeypatch: Any) -> None:
+        # issue #1074, writer side: a late _decision_for() call carrying the OLD
+        # generation must REPLACE (restamp) the entry, never extend a live one -- and
+        # its verdict must then be invisible to a live-generation read.
+        self._enable(monkeypatch)
+        live_gen = pfb_unbound._snapshot.gen
+        old_gen = live_gen - 1
+        late = pfb_unbound._decision_for("evil.com", old_gen)
+        late.dnsbl = _dnsbl_decision(
+            is_found=True, log_type="1", b_type="DNSBL", p_type="Python", feed="F", group="G", b_eval="evil.com"
+        )
+        assert pfb_unbound.decisionDB.get("evil.com").snap_gen == old_gen
+        # A live-generation get-or-create sees the foreign stamp and starts fresh.
+        dec = pfb_unbound._decision_for("evil.com", live_gen)
+        assert dec.snap_gen == live_gen
+        assert dec.dnsbl is pfb_unbound.UNSET
 
     def test_group_policy_bypass(self, monkeypatch: Any) -> None:
         self._enable(monkeypatch)
@@ -2251,7 +2297,7 @@ class TestStage2UnifiedDecision:
         self._enable(monkeypatch)
         add_noaaaa("unrelated.com", wildcard=False)  # enable the path; x.com unlisted
         assert "x.com" not in pfb_unbound.noAAAADB  # absent from source -> only the cache can block
-        pfb_unbound.decisionDB["x.com"] = pfb_unbound.Decision(noaaaa=True)
+        pfb_unbound.decisionDB["x.com"] = pfb_unbound.Decision(noaaaa=True, snap_gen=pfb_unbound._snapshot.gen)
         qstate = make_qstate("x.com.", qtype=RR_AAAA)
         pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert qstate.ext_state[0] == MODULE_FINISHED
@@ -2262,7 +2308,9 @@ class TestStage2UnifiedDecision:
         self._enable(monkeypatch)
         pfb_unbound.pfb["safeSearchDB"] = True
         assert "x.com" not in pfb_unbound.safeSearchDB  # absent from source -> only the cache rewrites
-        pfb_unbound.decisionDB["x.com"] = pfb_unbound.Decision(safesearch={"A": "1.2.3.4", "AAAA": ""})
+        pfb_unbound.decisionDB["x.com"] = pfb_unbound.Decision(
+            safesearch={"A": "1.2.3.4", "AAAA": ""}, snap_gen=pfb_unbound._snapshot.gen
+        )
         qstate = make_qstate("x.com.", qtype=RR_A)
         rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
         assert rcd is True

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1541,12 +1541,16 @@ class TestOperateDnsbl:
         assert dec.dnsbl.is_found is False
 
     def test_stale_generation_write_cannot_extend_a_live_memo(self, monkeypatch: Any) -> None:
-        # issue #1074, writer side: a late _decision_for() call carrying the OLD
+        # issue #1074, writer side: a late _decision_for() call carrying a FOREIGN
         # generation must REPLACE (restamp) the entry, never extend a live one -- and
         # its verdict must then be invisible to a live-generation read.
         self._enable(monkeypatch)
         live_gen = pfb_unbound._snapshot.gen
-        old_gen = live_gen - 1
+        # A REAL generation drawn from the counter, never the live one: live_gen - 1
+        # would collide with the 0 "unstamped" sentinel when this test runs alone,
+        # exercising the wrong case.
+        old_gen = next(pfb_unbound._snapshot_gen)
+        assert old_gen > 0 and old_gen != live_gen
         late = pfb_unbound._decision_for("evil.com", old_gen)
         late.dnsbl = _dnsbl_decision(
             is_found=True, log_type="1", b_type="DNSBL", p_type="Python", feed="F", group="G", b_eval="evil.com"

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1561,6 +1561,25 @@ class TestOperateDnsbl:
         assert dec.snap_gen == live_gen
         assert dec.dnsbl is pfb_unbound.UNSET
 
+    def test_older_generation_straggler_neither_evicts_nor_extends(self, monkeypatch: Any) -> None:
+        # issue #1074 hardening: a straggler carrying an OLDER generation gets a
+        # throwaway Decision -- the newer resident entry is neither evicted (cache
+        # thrash) nor extended, and the straggler's verdict is invisible to readers.
+        self._enable(monkeypatch)
+        older_gen = pfb_unbound._snapshot.gen
+        newer_gen = next(pfb_unbound._snapshot_gen)
+        resident = pfb_unbound._decision_for("evil.com", newer_gen)
+        resident.dnsbl = _dnsbl_decision()  # a live not-found (allow) verdict
+        straggler = pfb_unbound._decision_for("evil.com", older_gen)
+        assert straggler is not resident
+        assert straggler.snap_gen == older_gen
+        straggler.dnsbl = _dnsbl_decision(
+            is_found=True, log_type="1", b_type="DNSBL", p_type="Python", feed="F", group="G", b_eval="evil.com"
+        )
+        stored = pfb_unbound.decisionDB.get("evil.com")
+        assert stored is resident
+        assert stored.dnsbl.is_found is False
+
     def test_group_policy_bypass(self, monkeypatch: Any) -> None:
         self._enable(monkeypatch)
         add_data("evil.com", log="1", index=0)
@@ -2321,6 +2340,31 @@ class TestStage2UnifiedDecision:
         assert qstate.ext_state[0] == MODULE_FINISHED
         answers = DNSMessage.instances[-1].answer
         assert any("1.2.3.4" in a for a in answers)
+
+    def test_stale_generation_noaaaa_memo_is_recomputed(self, monkeypatch: Any) -> None:
+        # issue #1074 sibling axis: a foreign-generation noaaaa=True memo for a name
+        # NOT in the live noAAAADB must be recomputed (query proceeds), not re-served
+        # as a block -- same staleness gate as the dnsbl axis.
+        self._enable(monkeypatch)
+        add_noaaaa("unrelated.com", wildcard=False)  # enable the path; x.com unlisted
+        assert "x.com" not in pfb_unbound.noAAAADB
+        pfb_unbound.decisionDB["x.com"] = pfb_unbound.Decision(noaaaa=True)  # unstamped -> stale
+        qstate = make_qstate("x.com.", qtype=RR_AAAA)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert qstate.ext_state[0] == MODULE_WAIT_MODULE
+
+    def test_stale_generation_safesearch_memo_is_recomputed(self, monkeypatch: Any) -> None:
+        # issue #1074 sibling axis: a foreign-generation safesearch memo for a name
+        # NOT in the live safeSearchDB must be recomputed (no rewrite), not re-served.
+        self._enable(monkeypatch)
+        pfb_unbound.pfb["safeSearchDB"] = True
+        assert "x.com" not in pfb_unbound.safeSearchDB
+        pfb_unbound.decisionDB["x.com"] = pfb_unbound.Decision(
+            safesearch={"A": "1.2.3.4", "AAAA": ""}  # unstamped -> stale
+        )
+        qstate = make_qstate("x.com.", qtype=RR_A)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert qstate.ext_state[0] == MODULE_WAIT_MODULE
 
     def test_operate_respects_decisiondb_cap(self, monkeypatch: Any) -> None:
         # decisionDB is the LRU; with cap 1, querying a second blocked name evicts the


### PR DESCRIPTION
## Summary

Fixes #1074. A query thread that captured the OLD snapshot ref can memoize its verdict into `decisionDB` AFTER `rebuild_and_swap()`'s `decisionDB.clear()`, re-inserting a verdict the newly-published generation no longer agrees with. A domain removed by the new lists kept returning its old block (or a newly-added one kept resolving) until the entry happened to be evicted — exactly the staleness the ADR-10 zero-downtime swap is meant to eliminate.

## Fix

- Every built `Snapshot` carries a unique, monotonically-advancing `gen` (auto-assigned via `itertools.count` in a `default_factory` — `id()` is unusable, a freed snapshot's id can be reused).
- Every `Decision` is stamped with the `snap_gen` that produced it; `_decision_for()` takes the generation and **replaces** (never extends) an entry stamped with a foreign generation. `snap_gen` defaults to 0, which never matches a real generation, so an unstamped entry always reads as stale.
- `operate()`'s memo read treats a foreign-generation entry as `UNSET` → recompute against the live snapshot + restamp. The pre-resolution noaaaa/safesearch memo sites stamp with the live generation (those strata are static per init, so any live-generation stamp is correct for them).
- The swap's `clear()` stays — eager eviction; the stamp is the correctness guard (docstring updated).
- Deliberate non-change: the inform-path logger (`get_details_dnsbl`) keeps a presence-only read. It attributes a block `operate()` already served for that query (operate refreshes the memo first), and a generation gate there would drop the log line for a block genuinely served just before a swap landed.

## Tests

- `test_stale_generation_memo_is_recomputed_not_served` — the issue's scenario end-to-end through `operate()`: an old-generation block memo for a name the live snapshot does NOT list must be recomputed (query resolves, `MODULE_WAIT_MODULE`) and the memo replaced with a live-stamped allow. **Red on pre-fix code for the exact reported reason**: the stale block was served (`MODULE_FINISHED`, `assert 6 == 2`).
- `test_stale_generation_write_cannot_extend_a_live_memo` — writer side: a late `_decision_for()` carrying the old generation restamps/replaces; a live-generation read then sees a fresh `UNSET` axis, never the stale verdict.
- `test_each_snapshot_gets_a_fresh_generation` — generation uniqueness/monotonicity pin.
- Existing memo-reuse pins updated to stamp their seeded memos with the live generation (the arrangement they always meant: "a verdict the live snapshot produced is reused").

Red/green executed by reverting the source only: 3 failed before / all pass after. Gates: `python3 -m pytest` → 2571 passed, 5 skipped · `ruff check` · `ruff format --check` · `mypy tests/` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NviP9zgwweu471WhThw6U)_