### PR TITLE
ci: fix the release CI-green gate validating an ancestor instead of the tip (#1077)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,35 +140,13 @@ jobs:
 
       - name: Require CI green on the branch tip
         # The tag will point at the current HEAD of the channel branch; assert that
-        # CI is green for the code being released. A docs-only tip (e.g. a committed
-        # release-notes commit) skips CI via test.yml's paths-ignore and carries NO
-        # 'All tests passed' check-run, so walk back first-parent ancestors to the most
-        # recent commit that actually ran it and assert THAT is success — the docs-only
-        # commits in between change no code, so the nearest CI'd ancestor is authoritative.
+        # CI is green for the code being released. The walk-back semantics + the
+        # issue #1077 pagination/pending fixes live in scripts/release-ci-gate.sh,
+        # pinned by tests/shell/release_ci_gate_spec.sh.
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          REPO="${{ github.repository }}"
-          CONCLUSION=""
-          CHECK_SHA=""
-          for sha in $(git rev-list --first-parent -n 20 HEAD); do
-            c=$(gh api \
-              "repos/${REPO}/commits/${sha}/check-runs" \
-              --jq '[.check_runs[] | select(.name == "All tests passed")]
-                    | sort_by(.completed_at) | last | .conclusion // ""')
-            if [ -n "$c" ]; then CONCLUSION="$c"; CHECK_SHA="$sha"; break; fi
-          done
-          if [ -z "$CONCLUSION" ]; then
-            echo "::error::No 'All tests passed' check-run found on HEAD or its recent ancestors."
-            echo "Push the commit to a branch first and wait for CI to pass before releasing."
-            exit 1
-          fi
-          if [ "$CONCLUSION" != "success" ]; then
-            echo "::error::'All tests passed' for ${CHECK_SHA} is '${CONCLUSION}'."
-            echo "Push the commit to a branch first and wait for CI to pass before releasing."
-            exit 1
-          fi
-          echo "CI green on ${CHECK_SHA} (conclusion: ${CONCLUSION})"
+          REPO:     ${{ github.repository }}
+        run: sh scripts/release-ci-gate.sh
 
       - name: Detect committed changelog
         id: detect

--- a/scripts/release-ci-gate.sh
+++ b/scripts/release-ci-gate.sh
@@ -19,18 +19,25 @@
 # fan-out legs cannot make the run fall off the page and green-light an
 # ancestor instead; and a PRESENT but not-yet-concluded run (conclusion null,
 # CI still running) fails loudly instead of reading as "no such check" and
-# falling through to the ancestor walk.
+# falling through to the ancestor walk. A failed query (rate limit, network,
+# auth) also aborts loudly -- an unverifiable tip must never read as "never
+# ran CI". Runs sort by started_at: a newer in-progress rerun has
+# completed_at null, which sorts FIRST, so a completed_at sort would let the
+# older completed run shadow it.
 
 set -u
 
 CONCLUSION=""
 CHECK_SHA=""
 for sha in $(git rev-list --first-parent -n 20 HEAD); do
-	c=$(gh api \
+	if ! c=$(gh api \
 		"repos/${REPO}/commits/${sha}/check-runs?check_name=All%20tests%20passed&per_page=100" \
 		--jq '[.check_runs[] | select(.name == "All tests passed")]
-		      | sort_by(.completed_at) | last
-		      | if . == null then "" elif .conclusion == null then "pending" else .conclusion end')
+		      | sort_by(.started_at) | last
+		      | if . == null then "" elif .conclusion == null then "pending" else .conclusion end'); then
+		echo "::error::check-runs query failed for ${sha} — cannot verify CI state; aborting instead of walking back."
+		exit 1
+	fi
 	if [ -n "$c" ]; then CONCLUSION="$c"; CHECK_SHA="$sha"; break; fi
 done
 if [ -z "$CONCLUSION" ]; then

--- a/scripts/release-ci-gate.sh
+++ b/scripts/release-ci-gate.sh
@@ -21,11 +21,16 @@
 # CI still running) fails loudly instead of reading as "no such check" and
 # falling through to the ancestor walk. A failed query (rate limit, network,
 # auth) also aborts loudly -- an unverifiable tip must never read as "never
-# ran CI". Runs sort by started_at: a newer in-progress rerun has
-# completed_at null, which sorts FIRST, so a completed_at sort would let the
-# older completed run shadow it.
+# ran CI". ANY unresolved run for the name reads as pending: recency proxies
+# (completed_at/started_at sorts) let a null-timestamped in-progress or queued
+# rerun sort first and be shadowed by an older completed run.
 
 set -u
+
+if [ -z "${REPO:-}" ]; then
+	echo "::error::REPO env var (owner/repo) is required."
+	exit 1
+fi
 
 CONCLUSION=""
 CHECK_SHA=""
@@ -33,8 +38,10 @@ for sha in $(git rev-list --first-parent -n 20 HEAD); do
 	if ! c=$(gh api \
 		"repos/${REPO}/commits/${sha}/check-runs?check_name=All%20tests%20passed&per_page=100" \
 		--jq '[.check_runs[] | select(.name == "All tests passed")]
-		      | sort_by(.started_at) | last
-		      | if . == null then "" elif .conclusion == null then "pending" else .conclusion end'); then
+		      | if length == 0 then ""
+		        elif any(.[]; .conclusion == null) then "pending"
+		        else (sort_by(.started_at) | last | .conclusion)
+		        end'); then
 		echo "::error::check-runs query failed for ${sha} — cannot verify CI state; aborting instead of walking back."
 		exit 1
 	fi

--- a/scripts/release-ci-gate.sh
+++ b/scripts/release-ci-gate.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# release-ci-gate.sh — assert CI is green for the commit a release will tag.
+#
+# The release tags the current HEAD of the channel branch. A docs-only tip
+# (e.g. a committed release-notes commit) skips CI via test.yml's paths-ignore
+# and carries NO 'All tests passed' check-run, so walk back first-parent
+# ancestors to the most recent commit that actually ran it and assert THAT is
+# success — the docs-only commits in between change no code, so the nearest
+# CI'd ancestor is authoritative.
+#
+# Usage: sh scripts/release-ci-gate.sh
+#   env REPO      owner/repo to query (required)
+#   env GH_TOKEN  token for gh api (required by gh)
+#   cwd           a checkout with HEAD at the commit to be tagged
+# Exit 0 iff the gate passes; 1 with a ::error:: line otherwise.
+#
+# issue #1077: the check-runs query filters server-side on the check name and
+# reads up to 100 runs, so a tip whose page 1 is crowded out by smoke/ui
+# fan-out legs cannot make the run fall off the page and green-light an
+# ancestor instead; and a PRESENT but not-yet-concluded run (conclusion null,
+# CI still running) fails loudly instead of reading as "no such check" and
+# falling through to the ancestor walk.
+
+set -u
+
+CONCLUSION=""
+CHECK_SHA=""
+for sha in $(git rev-list --first-parent -n 20 HEAD); do
+	c=$(gh api \
+		"repos/${REPO}/commits/${sha}/check-runs?check_name=All%20tests%20passed&per_page=100" \
+		--jq '[.check_runs[] | select(.name == "All tests passed")]
+		      | sort_by(.completed_at) | last
+		      | if . == null then "" elif .conclusion == null then "pending" else .conclusion end')
+	if [ -n "$c" ]; then CONCLUSION="$c"; CHECK_SHA="$sha"; break; fi
+done
+if [ -z "$CONCLUSION" ]; then
+	echo "::error::No 'All tests passed' check-run found on HEAD or its recent ancestors."
+	echo "Push the commit to a branch first and wait for CI to pass before releasing."
+	exit 1
+fi
+if [ "$CONCLUSION" = "pending" ]; then
+	echo "::error::'All tests passed' for ${CHECK_SHA} has not concluded yet — tip CI is still running; wait for it."
+	exit 1
+fi
+if [ "$CONCLUSION" != "success" ]; then
+	echo "::error::'All tests passed' for ${CHECK_SHA} is '${CONCLUSION}'."
+	echo "Push the commit to a branch first and wait for CI to pass before releasing."
+	exit 1
+fi
+echo "CI green on ${CHECK_SHA} (conclusion: ${CONCLUSION})"

--- a/tests/shell/release_ci_gate_spec.sh
+++ b/tests/shell/release_ci_gate_spec.sh
@@ -39,6 +39,10 @@ while [ $# -gt 0 ]; do
 	esac
 done
 sha="${url##*commits/}"; sha="${sha%%/*}"
+if [ -f "${GH_MOCK_DIR}/${sha}.gh-fail" ]; then
+	echo "gh: HTTP 403 rate limit exceeded" >&2
+	exit 1
+fi
 case "$url" in
 	*check_name=*) f="${GH_MOCK_DIR}/${sha}.filtered.json" ;;
 	*)             f="${GH_MOCK_DIR}/${sha}.unfiltered.json" ;;
@@ -126,5 +130,27 @@ EOF
     When call run_gate
     The status should be failure
     The output should include "No 'All tests passed' check-run found"
+  End
+
+  It 'aborts loudly when the check-runs query itself fails (never walks back)'
+    # A gh failure (rate limit/network/auth) used to read as "no such check",
+    # falling through to a green ancestor while the tip was unverifiable.
+    touch "${GH_MOCK_DIR}/${tip}.gh-fail"
+    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"}]}'
+    When call run_gate
+    The status should be failure
+    The output should include 'cannot verify CI state'
+    The output should not include "CI green on ${ancestor}"
+    The stderr should include 'rate limit'
+  End
+
+  It 'treats a newer in-progress rerun as pending despite an older completed success'
+    # completed_at is null on the in-progress rerun and null sorts FIRST, so a
+    # completed_at sort let the older success shadow it; sorting by started_at
+    # surfaces the newest attempt, which has not concluded.
+    payload "$tip" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"},{"name":"All tests passed","started_at":"2026-01-02T00:00:00Z","completed_at":null,"conclusion":null}]}'
+    When call run_gate
+    The status should be failure
+    The output should include 'has not concluded yet'
   End
 End

--- a/tests/shell/release_ci_gate_spec.sh
+++ b/tests/shell/release_ci_gate_spec.sh
@@ -145,12 +145,52 @@ EOF
   End
 
   It 'treats a newer in-progress rerun as pending despite an older completed success'
-    # completed_at is null on the in-progress rerun and null sorts FIRST, so a
-    # completed_at sort let the older success shadow it; sorting by started_at
-    # surfaces the newest attempt, which has not concluded.
+    # ANY unresolved run for the name must read as pending -- a recency sort on
+    # completed_at let the older success shadow the null-timestamped rerun.
     payload "$tip" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"},{"name":"All tests passed","started_at":"2026-01-02T00:00:00Z","completed_at":null,"conclusion":null}]}'
     When call run_gate
     The status should be failure
     The output should include 'has not concluded yet'
+  End
+
+  It 'treats a QUEUED rerun (null started_at) as pending despite an older completed success'
+    # A queued-but-not-started rerun has null started_at too, so even a
+    # started_at recency sort would let the completed success shadow it; only
+    # the any-unresolved rule catches it.
+    payload "$tip" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"},{"name":"All tests passed","started_at":null,"completed_at":null,"conclusion":null}]}'
+    When call run_gate
+    The status should be failure
+    The output should include 'has not concluded yet'
+  End
+
+  It 'reports a missing REPO env var, not a bogus no-check-run diagnostic'
+    payload "$tip" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"}]}'
+    run_gate_no_repo() {
+      ( cd "$repo" && PATH="${work}/bin:${PATH}" GH_TOKEN=x \
+          sh "${PFB_ROOT}/scripts/release-ci-gate.sh" )
+    }
+    When call run_gate_no_repo
+    The status should be failure
+    The output should include 'REPO env var'
+    The output should not include "No 'All tests passed'"
+  End
+
+  It 'does not walk back beyond the 20-commit window'
+    # The only matching run sits on commit 21 in first-parent order; the walk
+    # must exhaust at 20 and fail rather than validate an ancient ancestor.
+    deep="$repo-deep"
+    git init -q -b main "$deep"
+    ( cd "$deep" && for i in $(seq 1 22); do
+        git -c user.name=t -c user.email=t@t commit -q --allow-empty -m "c$i"
+      done )
+    old21="$(git -C "$deep" rev-parse HEAD~21)"
+    payload "$old21" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"}]}'
+    run_gate_deep() {
+      ( cd "$deep" && PATH="${work}/bin:${PATH}" REPO="own/repo" GH_TOKEN=x \
+          sh "${PFB_ROOT}/scripts/release-ci-gate.sh" )
+    }
+    When call run_gate_deep
+    The status should be failure
+    The output should include "No 'All tests passed' check-run found"
   End
 End

--- a/tests/shell/release_ci_gate_spec.sh
+++ b/tests/shell/release_ci_gate_spec.sh
@@ -1,0 +1,130 @@
+#shellcheck shell=sh
+# release-ci-gate.sh — the release workflow's "Require CI green on the branch
+# tip" gate (issue #1077).
+#
+# Two ancestor-green-lighting defects are pinned here:
+#
+#   1) The check-runs query used to read only the first unfiltered page, so a
+#      tip whose 'All tests passed' run was crowded off page 1 by smoke/ui
+#      fan-out legs read as "never ran CI" and the walk-back validated an
+#      ancestor instead of the tip. The query now filters server-side on the
+#      check name (+ per_page=100).
+#
+#   2) A PRESENT but not-yet-concluded run (conclusion null, CI still running)
+#      collapsed to "" -- indistinguishable from "no such check" -- and fell
+#      through to the ancestor walk. It now fails loudly ("still running").
+#
+# The gh(1) stub serves ${GH_MOCK_DIR}/<sha>.filtered.json when the query
+# carries the check_name filter and <sha>.unfiltered.json otherwise, applying
+# the real --jq expression with jq -r, so the fixtures model exactly what the
+# API would return for each query shape.
+
+Describe 'release-ci-gate.sh (issue #1077)'
+  setup() {
+    scrub_git_env
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/cigate.XXXXXX")"
+    export GH_MOCK_DIR="${work}/mock"
+    mkdir -p "${GH_MOCK_DIR}" "${work}/bin"
+
+    # gh stub: only `gh api <url> --jq <expr>` is served.
+    cat > "${work}/bin/gh" <<'EOF'
+#!/bin/sh
+[ "$1" = "api" ] || { echo "gh stub: unsupported: $*" >&2; exit 64; }
+url="$2"; shift 2
+jqexpr=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--jq) jqexpr="$2"; shift 2 ;;
+		*) shift ;;
+	esac
+done
+sha="${url##*commits/}"; sha="${sha%%/*}"
+case "$url" in
+	*check_name=*) f="${GH_MOCK_DIR}/${sha}.filtered.json" ;;
+	*)             f="${GH_MOCK_DIR}/${sha}.unfiltered.json" ;;
+esac
+[ -f "$f" ] || { echo '{"check_runs":[]}' | jq -r "$jqexpr"; exit 0; }
+jq -r "$jqexpr" < "$f"
+EOF
+    chmod +x "${work}/bin/gh"
+
+    # A 2-commit repo: ancestor then tip (first-parent walk = tip, ancestor).
+    repo="${work}/repo"
+    git init -q -b main "$repo"
+    ( cd "$repo" \
+      && git -c user.name=t -c user.email=t@t commit -q --allow-empty -m ancestor \
+      && git -c user.name=t -c user.email=t@t commit -q --allow-empty -m tip )
+    ancestor="$(git -C "$repo" rev-parse HEAD~1)"
+    tip="$(git -C "$repo" rev-parse HEAD)"
+  }
+  cleanup() { rm -rf "$work"; }
+  Before 'setup'
+  After 'cleanup'
+
+  # Both query shapes (filtered + legacy unfiltered) serve the same payload
+  # unless a case overrides one side explicitly.
+  payload() { # $1 sha, $2 json body
+    printf '%s' "$2" > "${GH_MOCK_DIR}/$1.filtered.json"
+    printf '%s' "$2" > "${GH_MOCK_DIR}/$1.unfiltered.json"
+  }
+  run_gate() {
+    ( cd "$repo" && PATH="${work}/bin:${PATH}" REPO="own/repo" GH_TOKEN=x \
+        sh "${PFB_ROOT}/scripts/release-ci-gate.sh" )
+  }
+
+  It 'passes on a green tip'
+    payload "$tip" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
+    When call run_gate
+    The status should be success
+    The output should include "CI green on ${tip}"
+  End
+
+  It 'fails loudly on a tip run that has not concluded (never walks back)'
+    # issue #1077 defect 2: conclusion null used to read as "no such check",
+    # falling through to the ancestor walk -- a green ancestor then passed the
+    # gate while the tip's CI was still running.
+    payload "$tip" '{"check_runs":[{"name":"All tests passed","completed_at":null,"conclusion":null}]}'
+    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
+    When call run_gate
+    The status should be failure
+    The output should include 'has not concluded yet'
+    The output should not include "CI green on ${ancestor}"
+  End
+
+  It 'finds the tip run via the server-side check_name filter (crowded page 1)'
+    # issue #1077 defect 1: the tip run exists but only the FILTERED query
+    # returns it (page 1 of the unfiltered listing is crowded out by fan-out
+    # legs). The legacy unfiltered query saw nothing and green-lit the
+    # ancestor; the gate must validate the TIP.
+    payload "$tip" '{"check_runs":[{"name":"other","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
+    printf '%s' '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}' \
+      > "${GH_MOCK_DIR}/${tip}.filtered.json"
+    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
+    When call run_gate
+    The status should be success
+    The output should include "CI green on ${tip}"
+  End
+
+  It 'walks back to the nearest CI-run ancestor for a docs-only tip'
+    # Preserved behaviour: a tip with genuinely NO matching run (docs-only
+    # commit, CI skipped) defers to the nearest ancestor that ran CI.
+    payload "$tip" '{"check_runs":[]}'
+    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
+    When call run_gate
+    The status should be success
+    The output should include "CI green on ${ancestor}"
+  End
+
+  It 'fails when a concluded run is not success'
+    payload "$tip" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"failure"}]}'
+    When call run_gate
+    The status should be failure
+    The output should include "is 'failure'"
+  End
+
+  It 'fails when no run exists anywhere in the walk window'
+    When call run_gate
+    The status should be failure
+    The output should include "No 'All tests passed' check-run found"
+  End
+End


### PR DESCRIPTION
## Summary

Fixes #1077. Two defects in `release.yml`'s "Require CI green on the branch tip" walk-back let it green-light an ancestor commit while the tip was unverified:

1. **Pagination** — the check-runs query read only the first unfiltered page (default ≤30). A tip whose `All tests passed` run was crowded off page 1 by smoke/ui fan-out legs read as "never ran CI", so the walk-back validated an ancestor instead.
2. **In-progress conclusion** — `.conclusion // ""` collapsed a present-but-unconcluded run (`conclusion=null`, CI still running) to `""`, indistinguishable from "no such check", falling through to the ancestor walk while the tip's CI was still running.

## Fix

The gate moves from an inline `run:` block to `scripts/release-ci-gate.sh` (single source, testable — the `release-version.sh` pattern):

- the query filters server-side (`check_name=All%20tests%20passed&per_page=100`), so page crowding cannot hide the tip's run;
- a present-but-unconcluded run maps to a `pending` sentinel that **fails loudly** ("tip CI is still running; wait for it") instead of walking back;
- the docs-only-tip walk-back to the nearest CI'd ancestor is preserved.

`release.yml` now just runs the script with `REPO`/`GH_TOKEN` in env.

## Tests

New `tests/shell/release_ci_gate_spec.sh` (6 examples) with a `gh` stub that serves different payloads for the filtered vs unfiltered query shape and applies the real `--jq` expression with `jq`:

- green tip passes; failed tip fails; no-run-anywhere fails (baseline pins)
- **pending tip run fails loudly and never walks back to a green ancestor** (defect 2 — red on the legacy logic: it green-lit the ancestor)
- **tip run visible only to the filtered query is validated at the TIP** (defect 1 — red on the legacy logic: it green-lit the ancestor)
- docs-only tip still defers to the nearest CI'd ancestor (behaviour-preserving pin)

Red/green executed by temporarily restoring the legacy query/jq into the script: 2 failures (exactly the two defect examples), 6/6 after. Full shellspec suite: 466 examples, 0 failures, 9 pre-existing skips.

Gates: `sh -n` · `shellcheck` clean on the new script · `shellspec` green (incl. the git-env-scrub guard).

---
_Generated by [Claude Code](https://claude.ai/code/session_017NviP9zgwweu471WhThw6U)_