### PR TITLE
pfblockerng: reset the download body before every cURL retry attempt (#1072)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10336,6 +10336,11 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					// Attempt 3 Downloads before failing.
 					$hop_ok = FALSE;
 					for ($retries = 1; $retries <= 3; $retries++) {
+						// issue #1072: a failed attempt can leave a partial body in the
+						// file with the write offset at its end; reset so a retry cannot
+						// append and hand off a corrupted concatenation as the download.
+						ftruncate($fhandle, 0);
+						rewind($fhandle);
 						if (curl_exec($ch)) {
 							// Collect remote timestamp.
 							$raw_filetime = curl_getinfo($ch, CURLINFO_FILETIME);

--- a/tests/php/DownloadRetryBodyResetTest.php
+++ b/tests/php/DownloadRetryBodyResetTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_download() retry-attempt body reset (issue #1072).
+ *
+ * A failed curl_exec() attempt can leave a PARTIAL body in the download file
+ * with the write offset at its end; the retry then APPENDS its (complete)
+ * response after the garbage, and the corrupted concatenation is handed off as
+ * the download. The retry loop now truncates + rewinds the handle before every
+ * attempt (mirroring the existing per-hop redirect reset).
+ *
+ * Exercised through the REAL pfb_download() against a local `php -S` server
+ * whose first response is truncated mid-body (Content-Length 64, 16 bytes
+ * sent -> curl error 18) and whose second response is the full body. The
+ * `type='change_detect'` probe mode returns right after the download loop,
+ * before the MIME/decompress stages that are not off-appliance testable.
+ * The feed host is a non-local name resolved to 127.0.0.1 through the
+ * $GLOBALS['pfb_test_resolve_map'] hook: the self-IP carve-out admits it and
+ * the fetch is pinned (CURLOPT_RESOLVE) to the loopback fixture server -- a
+ * literal 127.0.0.1 URL would take the localfile (file_get_contents) path and
+ * never reach the cURL retry loop under test.
+ */
+#[CoversFunction('pfb_download')]
+final class DownloadRetryBodyResetTest extends TestCase
+{
+	private const FULL_BODY = 'ABCDEFGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOP';
+
+	/** @var resource|null the php -S server process */
+	private $server = null;
+
+	private string $workdir = '';
+	private int $port = 0;
+
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
+	protected function setUp(): void
+	{
+		if (!extension_loaded('curl')) {
+			$this->markTestSkipped('curl extension not available');
+		}
+		$workdir = tempnam(sys_get_temp_dir(), 'pfbdl');
+		$this->assertNotFalse($workdir);
+		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
+		$this->workdir = $workdir;
+
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_configured_ips'] = [];
+		// Loopback FIRST (it becomes the pinned connection address, admitted by the
+		// self-IP carve-out) plus a public address so the host is NOT classified
+		// self-hosted (that classification would take the localfile path instead
+		// of the cURL loop under test).
+		$GLOBALS['pfb_test_resolve_map'] = [
+			'flaky-feed.example.' => [
+				['type' => 'A', 'data' => '127.0.0.1'],
+				['type' => 'A', 'data' => '203.0.113.20'],
+			],
+		];
+
+		foreach (['log', 'errlog', 'pnow', 'runlog', 'runlog_active'] as $k) {
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
+		}
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
+		$GLOBALS['pfb']['log']    = "{$workdir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$workdir}/error.log";
+		$GLOBALS['pfb']['pnow']   = 'now';
+
+		$this->startFlakyServer();
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_resource($this->server)) {
+			proc_terminate($this->server);
+			proc_close($this->server);
+		}
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === false) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+		unset($GLOBALS['config'], $GLOBALS['pfb_test_resolve_map'], $GLOBALS['pfb_test_configured_ips']);
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			foreach ((array) glob("{$this->workdir}/*") as $f) {
+				@unlink((string) $f);
+			}
+			rmdir($this->workdir);
+		}
+	}
+
+	/**
+	 * First request: Content-Length 64 but only 16 bytes sent (curl error 18,
+	 * the partial bytes already written through CURLOPT_FILE). Later requests:
+	 * the full 64-byte body.
+	 */
+	private function startFlakyServer(): void
+	{
+		$router = "{$this->workdir}/router.php";
+		$body   = self::FULL_BODY;
+		$this->assertSame(64, strlen($body));
+		$routerSrc = <<<PHP
+<?php
+\$state = getenv('FLAKY_STATE');
+header('Content-Length: 64');
+if (!file_exists(\$state)) {
+	touch(\$state);
+	echo substr('{$body}', 0, 16);
+	flush();
+	exit;
+}
+echo '{$body}';
+PHP;
+		$this->assertNotFalse(file_put_contents($router, $routerSrc));
+
+		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		for ($try = 0; $try < 10; $try++) {
+			$port = random_int(20000, 60000);
+			$proc = proc_open(
+				['php', '-S', "127.0.0.1:{$port}", $router],
+				$descriptors,
+				$pipes,
+				$this->workdir,
+				['FLAKY_STATE' => "{$this->workdir}/state.flag", 'PATH' => (string) getenv('PATH')]
+			);
+			if (!is_resource($proc)) {
+				continue;
+			}
+			// Poll readiness instead of a fixed wait (up to ~2s).
+			for ($i = 0; $i < 40; $i++) {
+				$sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.05);
+				if ($sock !== false) {
+					fclose($sock);
+					$this->server = $proc;
+					$this->port = $port;
+					return;
+				}
+				usleep(50000);
+			}
+			proc_terminate($proc);
+			proc_close($proc);
+		}
+		$this->fail('could not start the flaky php -S fixture server');
+	}
+
+	public function testRetryAfterPartialBodyYieldsExactFinalBody(): void
+	{
+		$file_dwn = "{$this->workdir}/feed.txt";
+		$url      = "http://flaky-feed.example:{$this->port}/feed.txt";
+		$meta     = [];
+
+		// When: the first attempt is cut mid-body (curl error 18) and the retry
+		// succeeds. (The production retry path sleeps 5s once here.)
+		$result = pfb_download($url, $file_dwn, false, 'RetryFeed', '', 1, '', 30, 'change_detect', '', '', false, $meta);
+
+		// Then: the download succeeds and the file holds EXACTLY the final
+		// response body -- before the fix it held the 16 partial bytes with the
+		// full body appended after them (80 bytes of corrupted concatenation).
+		$this->assertTrue($result, 'retry download must succeed');
+		$this->assertSame('200', $meta['status'] ?? '', 'probe metadata must carry the final 200');
+		// pfb_download() writes the body to {file_dwn}.raw.
+		$got = file_get_contents("{$file_dwn}.raw");
+		$this->assertNotFalse($got);
+		$this->assertSame(
+			self::FULL_BODY,
+			$got,
+			'the retried download must contain only the final response body, got ' . strlen($got) . ' bytes'
+		);
+	}
+}

--- a/tests/php/PfbDownloadEntryVettingSkipLogTest.php
+++ b/tests/php/PfbDownloadEntryVettingSkipLogTest.php
@@ -17,8 +17,10 @@ use PHPUnit\Framework\TestCase;
  * the update flow actually hits; the live #811 fixup) -- landing the line in
  * the MAIN log iff the guard is why vetting failed.
  *
- * pfb_download() as a whole is not off-appliance unit-testable (curl/exec),
- * but its entry early-return path needs neither, so it is exercised directly.
+ * pfb_download()'s post-download stages (MIME/decompress) are not off-appliance
+ * unit-testable (exec); the entry early-return path needs none of that, so it is
+ * exercised directly here (the cURL loop itself is driven for real by
+ * DownloadRetryBodyResetTest against a loopback fixture server).
  * pfb_update_check() lives in a www script the harness cannot load -- its call
  * site is covered by the helper-direct tests plus the live smoke test
  * (test_feed_internal_filter_blocks_then_allowlist_exempts).


### PR DESCRIPTION
## Summary

Fixes #1072. A failed `curl_exec()` attempt in `pfb_download()`'s 3-try retry loop can leave a partial response body in the feed file with the write offset at its end (`CURLOPT_FILE` streams as it receives). The retry then **appends** its complete response after the garbage, and the corrupted concatenation is handed off as the download.

## Fix

Truncate + rewind `$fhandle` at the top of every retry attempt, mirroring the existing per-hop redirect reset a few lines below. The success path is byte-identical (the file is freshly opened `'w'` on attempt 1 and already truncated by the hop reset on later hops).

## Tests

New `tests/php/DownloadRetryBodyResetTest.php` — exercises the **real** `pfb_download()` end-to-end against a local `php -S` fixture server whose first response is truncated mid-body (`Content-Length: 64`, 16 bytes sent → curl error 18) and whose second response is the full 64-byte body:

- the feed host is a non-local name resolved to `[127.0.0.1, 203.0.113.20]` through the existing `$GLOBALS['pfb_test_resolve_map']` hook: the loopback-first ordering makes it the pinned connection address (admitted by the self-IP carve-out) while the public second address keeps the host from being classified self-hosted (which would take the `file_get_contents` localfile path and never reach the cURL loop);
- `type='change_detect'` probe mode returns right after the download loop, before the MIME/decompress stages that are not off-appliance testable;
- asserts the download succeeds AND the file holds exactly the final response body.

Red/green executed by reverting the source only — the red failure is the exact reported corruption:

```text
-'ABCDEFGHIJKLMNOP…' (64 bytes)
+'ABCDEFGHIJKLMNOPABCDEFGHIJKLMNOP…' (80 bytes: 16 partial + 64 appended)
```

The environmental claims (php -S serves the truncated body verbatim; PHP `curl_exec` returns FALSE with errno 18 on it) were probed in-session before the test was written. The test takes ~5s (the production retry path's `sleep(5)`).

Gates: `php -l` clean · `phpunit` → 2594 tests, 11 skipped (1 pre-existing `CURLOPT_SSL_VERIFYHOST => TRUE` coercion notice, first surfaced because no earlier test exercised `curl_setopt_array`) · `phpstan` no errors · `phpcs` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NviP9zgwweu471WhThw6U)_