### PR TITLE
pfblockerng: guard dnsbl_alias_update file handles against fopen failure (#1073)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5531,16 +5531,19 @@ function dnsbl_alias_update($mode, $alias, $pfbfolder, $lists_dnsbl_current, $al
 
 		// Create master alias file
 		if ($lists_dnsbl_current != '') {
-			$pfb_output = @fopen("{$pfb['dnsalias']}/{$alias}", 'w');
-			foreach ($lists_dnsbl_current as $clist) {
-				if (($handle = @fopen("{$pfbfolder}/{$clist}.txt", 'r')) !== FALSE) {
-					while (($line = @fgets($handle)) !== FALSE) {
-						@fwrite($pfb_output, $line);
+			// issue #1073: fwrite(FALSE)/fclose(FALSE) throw TypeError on PHP 8 ('@'
+			// only silences warnings), so a failed open must skip its write/close.
+			if (($pfb_output = @fopen("{$pfb['dnsalias']}/{$alias}", 'w')) !== FALSE) {
+				foreach ($lists_dnsbl_current as $clist) {
+					if (($handle = @fopen("{$pfbfolder}/{$clist}.txt", 'r')) !== FALSE) {
+						while (($line = @fgets($handle)) !== FALSE) {
+							@fwrite($pfb_output, $line);
+						}
+						@fclose($handle);
 					}
 				}
-				@fclose($handle);
+				@fclose($pfb_output);
 			}
-			@fclose($pfb_output);
 		}
 
 		// Update DNSBL alias statistics

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5543,6 +5543,8 @@ function dnsbl_alias_update($mode, $alias, $pfbfolder, $lists_dnsbl_current, $al
 					}
 				}
 				@fclose($pfb_output);
+			} else {
+				pfb_logger("\nDNSBL [ {$alias} ]: failed to open master alias file for writing", 2);
 			}
 		}
 

--- a/tests/php/DnsblAliasUpdateTest.php
+++ b/tests/php/DnsblAliasUpdateTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * dnsbl_alias_update() unchecked-fopen guards (issue #1073).
+ *
+ * The master-alias copy loop opened its destination without checking the
+ * return and closed the per-list source handle outside its own open-check.
+ * On PHP 8, fwrite(FALSE)/fclose(FALSE) throw TypeError ('@' only silences
+ * warnings), so an unwritable destination directory or a vanished source
+ * file aborted the whole DNSBL update instead of degrading to a skipped
+ * copy. Both opens are now guarded; the stats bookkeeping after the copy
+ * must run either way.
+ *
+ * The unwritable destination is modeled as a NON-EXISTENT directory (fopen
+ * fails for any uid, unlike a chmod fixture, which root bypasses).
+ */
+#[CoversFunction('dnsbl_alias_update')]
+final class DnsblAliasUpdateTest extends TestCase
+{
+	private string $workdir = '';
+
+	/** @var array<string,mixed> saved $pfb keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
+	protected function setUp(): void
+	{
+		$workdir = tempnam(sys_get_temp_dir(), 'pfbdnsbl');
+		$this->assertNotFalse($workdir);
+		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
+		$this->workdir = $workdir;
+
+		foreach (['dnsalias', 'dnsbl_info_stats'] as $k) {
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
+		}
+		$GLOBALS['pfb']['dnsbl_info_stats'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === false) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			foreach ((array) glob("{$this->workdir}/*") as $f) {
+				@unlink((string) $f);
+			}
+			rmdir($this->workdir);
+		}
+	}
+
+	private function statsEntryFor(string $alias): ?array
+	{
+		foreach ($GLOBALS['pfb']['dnsbl_info_stats'] as $entry) {
+			if (($entry['groupname'] ?? '') === $alias) {
+				return $entry;
+			}
+		}
+		return null;
+	}
+
+	public function testUpdateConcatenatesSourcesAndRecordsStats(): void
+	{
+		// Given: a writable alias dir and two source lists.
+		$GLOBALS['pfb']['dnsalias'] = $this->workdir;
+		file_put_contents("{$this->workdir}/one.txt", "1.example.com\n");
+		file_put_contents("{$this->workdir}/two.txt", "2.example.com\n");
+
+		dnsbl_alias_update('update', 'TestGroup', $this->workdir, ['one', 'two'], 2);
+
+		$this->assertSame(
+			"1.example.com\n2.example.com\n",
+			file_get_contents("{$this->workdir}/TestGroup"),
+			'both source lists must land in the master alias file, in order'
+		);
+		$entry = $this->statsEntryFor('TestGroup');
+		$this->assertNotNull($entry, 'a stats entry must be recorded');
+		$this->assertSame('2', (string) $entry['entries']);
+	}
+
+	public function testUnwritableDestinationDegradesInsteadOfThrowing(): void
+	{
+		// Given: the alias dir does not exist, so the destination fopen fails.
+		$GLOBALS['pfb']['dnsalias'] = "{$this->workdir}/does-not-exist";
+		file_put_contents("{$this->workdir}/one.txt", "1.example.com\n");
+
+		// When/Then: before the guard this threw TypeError from fwrite(FALSE)
+		// (PHP 8; '@' does not suppress it) and aborted the DNSBL update.
+		dnsbl_alias_update('update', 'TestGroup', $this->workdir, ['one'], 1);
+
+		$this->assertFileDoesNotExist("{$this->workdir}/does-not-exist/TestGroup");
+		$this->assertNotNull(
+			$this->statsEntryFor('TestGroup'),
+			'the stats bookkeeping after the copy must still run on a failed open'
+		);
+	}
+
+	public function testVanishedSourceListIsSkippedNotFatal(): void
+	{
+		// Given: one existing and one missing source list (concurrent teardown).
+		$GLOBALS['pfb']['dnsalias'] = $this->workdir;
+		file_put_contents("{$this->workdir}/one.txt", "1.example.com\n");
+
+		// When/Then: before the fix the fclose(FALSE) outside the open-check
+		// threw TypeError for the missing list.
+		dnsbl_alias_update('update', 'TestGroup', $this->workdir, ['one', 'gone'], 1);
+
+		$this->assertSame(
+			"1.example.com\n",
+			file_get_contents("{$this->workdir}/TestGroup"),
+			'the existing list must still be copied when a sibling vanished'
+		);
+		$this->assertNotNull($this->statsEntryFor('TestGroup'));
+	}
+}

--- a/tests/php/DnsblAliasUpdateTest.php
+++ b/tests/php/DnsblAliasUpdateTest.php
@@ -34,10 +34,13 @@ final class DnsblAliasUpdateTest extends TestCase
 		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
 		$this->workdir = $workdir;
 
-		foreach (['dnsalias', 'dnsbl_info_stats'] as $k) {
+		foreach (['dnsalias', 'dnsbl_info_stats', 'log', 'errlog', 'runlog', 'runlog_active'] as $k) {
 			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
 		}
 		$GLOBALS['pfb']['dnsbl_info_stats'] = [];
+		$GLOBALS['pfb']['log']    = "{$workdir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$workdir}/error.log";
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
 	}
 
 	protected function tearDown(): void
@@ -101,6 +104,9 @@ final class DnsblAliasUpdateTest extends TestCase
 			$this->statsEntryFor('TestGroup'),
 			'the stats bookkeeping after the copy must still run on a failed open'
 		);
+		// The skip is loud: the operator can see the alias stopped updating.
+		$logged = @file_get_contents($GLOBALS['pfb']['errlog']) . @file_get_contents($GLOBALS['pfb']['log']);
+		$this->assertStringContainsString('failed to open master alias file', $logged);
 	}
 
 	public function testVanishedSourceListIsSkippedNotFatal(): void


### PR DESCRIPTION
## Summary

Fixes #1073. `dnsbl_alias_update()`'s master-alias copy loop opened its destination without checking the return and closed the per-list source handle **outside** its own open-check. On PHP 8, `fwrite(FALSE)`/`fclose(FALSE)` throw `TypeError` — and `@` only silences warnings — so an unwritable destination directory or a source list vanishing mid-loop (concurrent teardown) aborted the whole DNSBL update.

## Fix

Adopt the file's own guarded pattern: wrap the destination in `if (($pfb_output = @fopen(...)) !== FALSE) { … @fclose($pfb_output); }` and move the source `@fclose($handle)` inside its `!== FALSE` block. The stats bookkeeping after the copy runs either way (graceful degradation instead of a fatal).

## Tests

New `tests/php/DnsblAliasUpdateTest.php` (3 tests, driving the real function):

- happy path: two source lists concatenated in order into the master alias file + a stats entry recorded (green pin across the guard rework)
- **unwritable destination** (a non-existent directory — fails for any uid, unlike a `chmod` fixture that root bypasses): no throw, no file, stats still recorded — red before with `TypeError: fwrite(): Argument #1 ($stream) must be of type resource, false given`
- **vanished source list** among existing ones: the surviving list is still copied — red before with `TypeError: fclose(): …, false given`

Red/green executed by reverting the source only: 2 errors before (the exact TypeErrors the issue reports), 3/3 after.

Gates: `php -l` clean · `phpunit` → 2596 tests, 11 skipped, 0 failures · `phpstan` no errors · `phpcs` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NviP9zgwweu471WhThw6U)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when generating DNSBL alias files if the destination cannot be opened.
  * Prevented update failures when source lists are missing or unavailable.
  * Added clearer error reporting for alias file write failures.

* **Tests**
  * Added coverage for combining source lists, recording update statistics, handling unwritable destinations, and skipping unavailable source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->