### PR TITLE
www: guard the custom-list update flag against a folderless action (#1080)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -796,7 +796,11 @@ if ($_POST && isset($_POST['save'])) {
 			$aname  = $_POST['aliasname'];
 
 			pfb_determine_list_detail($action, '', $conf_type, $rowid);
-			touch("{$pfbarr['folder']}/{$aname}_custom{$suffix}.update");
+			// issue #1080: an action with no list folder (Disabled) leaves the
+			// detail array empty; an unguarded touch() landed the flag at "/".
+			if (!empty($pfbarr['folder'])) {
+				touch("{$pfbarr['folder']}/{$aname}_custom{$suffix}.update");
+			}
 		}
 
 		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/custom", base64_encode($_POST['custom']) ?: '');

--- a/tests/php/CategoryEditCustomFlagTest.php
+++ b/tests/php/CategoryEditCustomFlagTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Category-edit custom-list update flag placement (issue #1080).
+ *
+ * When a saved alias's Custom List changed, the page touch()ed
+ * "{$pfbarr['folder']}/{$aname}_custom{$suffix}.update" -- but an action with
+ * no list folder (Disabled) leaves pfb_determine_list_detail()'s array empty,
+ * so the flag landed at the FILESYSTEM ROOT ("/{$aname}_custom.update"; the
+ * WebGUI runs as root, so the write succeeds). The touch is now guarded on a
+ * non-empty folder.
+ *
+ * Like WidgetSubmitPostGuardTest, the page carries top-level execution and
+ * cannot be require()d off-appliance, so the REAL custom-flag block is
+ * eval-extracted verbatim (its leading comment and the following
+ * config_set_path('.../custom', ...) line are the unique anchors).
+ */
+final class CategoryEditCustomFlagTest extends TestCase
+{
+	/** Saved globals, restored in tearDown. */
+	private mixed $savedPfb = null;
+	private mixed $savedPfbarr = null;
+	private array $savedPost = [];
+	private mixed $savedConfig = null;
+
+	private string $workdir = '';
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
+		}
+
+		if (!function_exists('pfb_category_edit_oracle_customflag')) {
+			if (!preg_match(
+				'/\/\/ Set flag to update CustomList on next Cron.*?\n(.*?)(?=\n\n\t\tconfig_set_path\("installedpackages\/\{\$conf_type\}\/config\/\{\$rowid\}\/custom",)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: custom-flag block not found in category_edit source');
+			}
+			eval(
+				'function pfb_category_edit_oracle_customflag(string $conf_type, int $rowid, string $suffix): void {'
+				. ' global $pfb, $pfbarr; ' . $m[1] . ' }'
+			);
+		}
+	}
+
+	protected function setUp(): void
+	{
+		global $pfb, $pfbarr;
+		$this->savedPfb    = $pfb ?? null;
+		$this->savedPfbarr = $pfbarr ?? null;
+		$this->savedPost   = $_POST;
+		$this->savedConfig = $GLOBALS['config'] ?? null;
+		$GLOBALS['config'] = [];
+
+		$workdir = tempnam(sys_get_temp_dir(), 'pfbcat');
+		$this->assertNotFalse($workdir);
+		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
+		$this->workdir = $workdir;
+	}
+
+	protected function tearDown(): void
+	{
+		global $pfb, $pfbarr;
+		$pfb    = $this->savedPfb;
+		$pfbarr = $this->savedPfbarr;
+		$_POST  = $this->savedPost;
+		if ($this->savedConfig === null) {
+			unset($GLOBALS['config']);
+		} else {
+			$GLOBALS['config'] = $this->savedConfig;
+		}
+		// Sweep any stray root flag a pre-guard run under root may have written.
+		@unlink('/Cat1080_custom.update');
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			foreach ((array) glob("{$this->workdir}/*") as $f) {
+				@unlink((string) $f);
+			}
+			rmdir($this->workdir);
+		}
+	}
+
+	/** Run the extracted block, returning every PHP warning it raised. */
+	private function runFlagBlock(string $action, string $custom, string $suffix = ''): array
+	{
+		global $pfb;
+		$_POST['action']    = $action;
+		$_POST['aliasname'] = 'Cat1080';
+		$_POST['custom']    = $custom;
+		$pfb['reuse_dnsbl'] = $pfb['reuse_dnsbl'] ?? '';
+		// The real save handler writes the full config row before the flag block
+		// runs; pfb_determine_list_detail reads these keys from it. Seed the row
+		// so the oracle sees the page's real pre-state (absent keys only add PHP 8
+		// warning noise unrelated to the flag placement under test).
+		foreach (['_in', '_out'] as $dir) {
+			foreach (['autoproto', 'autonot', 'autoaddrnot', 'agateway', 'autoports', 'autoaddr'] as $k) {
+				config_set_path("installedpackages/pfblockerngdnsbl/config/0/{$k}{$dir}", '');
+			}
+		}
+		$warnings = [];
+		set_error_handler(
+			static function (int $errno, string $errstr) use (&$warnings): bool {
+				$warnings[] = $errstr;
+				return true;
+			},
+			E_WARNING | E_NOTICE
+		);
+		try {
+			pfb_category_edit_oracle_customflag('pfblockerngdnsbl', 0, $suffix);
+		} finally {
+			restore_error_handler();
+		}
+		return $warnings;
+	}
+
+	public function testDisabledActionWritesNoRootFlagAndNoWarning(): void
+	{
+		// Given: no stored custom list, an incoming non-empty one, action Disabled
+		// (no list folder). Before the guard this touch()ed /Cat1080_custom.update
+		// (as root) or raised a touch() permission warning (as an unprivileged uid).
+		$warnings = $this->runFlagBlock('Disabled', "custom.example.com\n");
+
+		$this->assertFileDoesNotExist('/Cat1080_custom.update', 'no flag may land at the filesystem root');
+		$this->assertSame([], $warnings, 'the guarded skip must be silent');
+	}
+
+	public function testFolderedActionStillWritesTheUpdateFlag(): void
+	{
+		// Behaviour-preserving pin: an action WITH a folder keeps writing the flag.
+		global $pfb;
+		$pfb['dnsdir'] = $this->workdir;
+		$warnings = $this->runFlagBlock('unbound', "custom.example.com\n");
+
+		$this->assertFileExists("{$this->workdir}/Cat1080_custom.update");
+		$this->assertSame([], $warnings);
+	}
+
+	public function testUnchangedCustomListSkipsTheFlagEntirely(): void
+	{
+		// The branch only fires when the stored and posted lists differ.
+		global $pfb;
+		$pfb['dnsdir'] = $this->workdir;
+		config_set_path(
+			'installedpackages/pfblockerngdnsbl/config/0/custom',
+			base64_encode("custom.example.com\n")
+		);
+		$warnings = $this->runFlagBlock('unbound', "custom.example.com\n");
+
+		$this->assertFileDoesNotExist("{$this->workdir}/Cat1080_custom.update");
+		$this->assertSame([], $warnings);
+	}
+}

--- a/tests/smoke/ui/test_category_edit_custom_flag.py
+++ b/tests/smoke/ui/test_category_edit_custom_flag.py
@@ -1,0 +1,75 @@
+"""issue #1080 -- a Disabled-action alias save must not write its custom-list
+update flag at the filesystem root.
+
+When a saved alias's Custom List changed, ``pfblockerng_category_edit.php``
+touch()ed ``{$pfbarr['folder']}/{$aname}_custom{$suffix}.update`` -- but a
+Disabled action has no list folder, so ``pfb_determine_list_detail()`` leaves
+the array empty and the flag landed at ``/{$aname}_custom.update`` (the
+WebGUI runs as root, so the stray write succeeds). The touch is now guarded
+on a non-empty folder (off-appliance red/green pinned by
+``tests/php/CategoryEditCustomFlagTest.php``; this exercises the same save
+end-to-end through the real page).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .test_category_edit import CFG_DNSBL, _del_rowid, _dnsbl_payload, _free_rowid, _post_form
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+# Tier B: a mutating POST flow whose failure artifact (a stray file at the
+# guest's filesystem root) is observable only on-box. Tier A render coverage
+# of this page already exists (test_render_smoke.py / test_category_edit.py).
+pytestmark = pytest.mark.ui_e2e
+
+
+def _root_flag_exists(vm: helpers.SmokeVM, path: str) -> bool:
+    pre = f"$e = file_exists({helpers._php_str(path)}) ? 'YES' : 'NO';"
+    return helpers._php_read_scalar(vm, pre, "$e", timeout=120.0) == "YES"
+
+
+def test_disabled_action_custom_save_writes_no_root_flag(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Scenario: saving a Disabled-action DNSBL alias with a fresh Custom List.
+
+    Given a free alias slot and a payload whose ``action`` is ``Disabled`` and
+      whose ``custom`` list is non-empty (so the stored-vs-posted comparison
+      fires the update-flag branch),
+
+    When the category-edit save is POSTed,
+
+    Then no ``/{alias}_custom.update`` file appears at the guest's filesystem
+      root (before the guard, the WebGUI -- running as root -- created it).
+    """
+    rowid = _free_rowid(smoke_vm, CFG_DNSBL)
+    alias = f"RootFlag{rowid}"
+    root_flag = f"/{alias}_custom.update"
+
+    try:
+        payload = _dnsbl_payload(
+            rowid,
+            alias,
+            action="Disabled",
+            custom="custom-1080.example.com",
+        )
+        _post_form(webui, payload)
+
+        assert not _root_flag_exists(smoke_vm, root_flag), (
+            f"the Disabled-action save must not create {root_flag} at the filesystem root"
+        )
+    finally:
+        # Sweep the stray flag a pre-guard build may have written, then the slot.
+        helpers.php_eval(
+            smoke_vm,
+            f"@unlink({helpers._php_str(root_flag)}); echo 'OK';",
+            timeout=120.0,
+        )
+        _del_rowid(smoke_vm, CFG_DNSBL, rowid)


### PR DESCRIPTION
## Summary

Fixes #1080. When a saved alias's Custom List changed, `pfblockerng_category_edit.php` touch()ed `{$pfbarr['folder']}/{$aname}_custom{$suffix}.update`. A **Disabled** action has no list folder — `pfb_determine_list_detail('Disabled', …)` leaves the detail array empty — so the flag landed at the filesystem root (`/{$aname}_custom.update`; the WebGUI runs as root, so the stray write succeeds).

## Fix

Touch the flag only when the action resolved to a non-empty folder.

## Tests

- **PHPUnit** `tests/php/CategoryEditCustomFlagTest.php` — eval-extracts the REAL custom-flag block verbatim (the `WidgetSubmitPostGuardTest` pattern; the page carries top-level execution and cannot be `require()`d). Three tests: Disabled action writes NO root flag and stays silent (**red before: `Failed asserting that file "/Cat1080_custom.update" does not exist`** — the suite runs as root here, exactly mirroring the WebGUI); a foldered action still writes its update flag (behaviour-preserving pin); an unchanged custom list skips the branch entirely. Red/green executed by reverting the page source only.
- **UI Tier B** `tests/smoke/ui/test_category_edit_custom_flag.py` — the same save end-to-end through the real page on the live VM: POST a Disabled-action alias with a fresh custom list, assert no `/{alias}_custom.update` appears at the guest's filesystem root (on-box artifact — observable only in Tier B; Tier A render coverage of this page already exists).

Gates: `php -l` clean · `phpunit` → 2596 tests, 0 failures · `phpstan` no errors · `phpcs` clean · `ruff`/`mypy` clean on the ui test · full pytest 2574 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NviP9zgwweu471WhThw6U)_