### PR TITLE
scripts: fix build-repo.sh fallback catalog layout — varver keying + hyphenated names (#1081)

### DIFF
--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -1,23 +1,27 @@
 #!/bin/sh
-# build-repo.sh — turn a directory of pfBlockerNG .pkg files into a per-ABI
-# FreeBSD `pkg` repository tree (ADR-17): reads each .pkg's ABI FROM THE
-# PACKAGE (never the filename), buckets it under <out>/release/<ABI>/
-# (symmetric with the nightly/ subtree, ADR-20), and runs unsigned `pkg repo`
-# per bucket (NONE-signed trust model, ADR §2). Deterministic + re-runnable +
-# no network: each ABI bucket is wiped and rebuilt every run. A flavor
-# collision (same name+version+ABI, different php/py flavor) fails loud — see
-# the guard below. `pkg` must be a real libpkg build on PATH (override PKG_BIN).
+# build-repo.sh — turn a directory of ONE variant/version's pfBlockerNG .pkg
+# files into a FreeBSD `pkg` repository tree (ADR-17): reads each .pkg's ABI
+# FROM THE PACKAGE (never the filename), lays the catalog out under
+# <out>/release/<varver>/<arch>/ (the ADR-20 varver keying — an ABI is NOT
+# 1:1 with an edition/version, so the varver cannot be derived from the
+# package and is supplied by the caller), and runs unsigned `pkg repo` on the
+# bucket (NONE-signed trust model, ADR §2). Deterministic + re-runnable + no
+# network: the bucket is wiped and rebuilt every run. A flavor collision
+# (same name+version+ABI, different php/py flavor) or a mixed-ABI input
+# fails loud — see the guards below. `pkg` must be a real libpkg build on
+# PATH (override PKG_BIN).
 #
 # Usage:
-#   build-repo.sh --in <dir-of-.pkg> --out <dir>      # build the per-ABI tree
-#   build-repo.sh --print-conf [--base-url <url>]     # print the client repo-conf
+#   build-repo.sh --in <dir-of-.pkg> --out <dir> --varver <varver>
+#   build-repo.sh --print-conf --catalog-path <varver>/<arch> [--base-url <url>]
 #
 # Options:
 #   --in DIR          directory holding the input .pkg files (searched, non-recursive)
-#   --out DIR         output root; one release/<ABI>/ catalog subtree is created per ABI
+#   --out DIR         output root; the catalog is created at release/<varver>/<arch>/
+#   --varver NAME     catalog key, e.g. ce-2.8 / plus-26.03 (ADR-20; required with --in)
 #   --print-conf      print the client repo-conf template to stdout and exit
-#   --base-url URL    base URL for --print-conf (default: the ADR Pages base);
-#                     the conf appends the literal ${ABI} pkg variable to it
+#   --catalog-path P  <varver>/<arch> path the printed conf's url resolves to
+#   --base-url URL    base URL for --print-conf (default: the ADR Pages base)
 #
 # Env:
 #   PKG_BIN           the pkg binary to use (default: pkg)
@@ -69,15 +73,18 @@ BASE_URL="$DEFAULT_BASE_URL"
 CATALOG_PATH=""
 PKG_BIN="${PKG_BIN:-pkg}"
 
+VARVER=""
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --in)            IN="$2"; shift 2 ;;
         --out)           OUT="$2"; shift 2 ;;
+        --varver)        VARVER="$2"; shift 2 ;;
         --print-conf)    PRINT_CONF=1; shift ;;
         --base-url)      BASE_URL="$2"; shift 2 ;;
         --catalog-path)  CATALOG_PATH="$2"; shift 2 ;;
         -h|--help)
-            sed -n '11,25p' "$0"   # the Usage/Options/Env block from the header
+            sed -n '14,29p' "$0"   # the Usage/Options/Env block from the header
             exit 0 ;;
         *) echo "build-repo: unknown arg: $1" >&2; exit 2 ;;
     esac
@@ -96,11 +103,18 @@ fi
 # Pure precondition test; the || branch (usage + exit) is the intended else and
 # the && chain is side-effect-free, so SC2015's caveat does not apply.
 # shellcheck disable=SC2015
-[ -n "$IN" ] && [ -n "$OUT" ] || {
-    echo "Usage: $0 --in <dir-of-.pkg> --out <dir>   |   $0 --print-conf [--base-url <url>]" >&2
+[ -n "$IN" ] && [ -n "$OUT" ] && [ -n "$VARVER" ] || {
+    echo "Usage: $0 --in <dir-of-.pkg> --out <dir> --varver <varver>   |   $0 --print-conf --catalog-path <varver>/<arch> [--base-url <url>]" >&2
     exit 2
 }
 [ -d "$IN" ] || { echo "build-repo: --in is not a directory: $IN" >&2; exit 1; }
+# The varver becomes a path segment (rm -rf'd + rebuilt) — same safety rule as ABIs.
+case "$VARVER" in
+    ""|*/*|*".."*|*[!a-z0-9.-]*)
+        echo "build-repo: unsafe or invalid --varver: '$VARVER' (expect e.g. ce-2.8 / plus-26.03)" >&2
+        exit 2
+        ;;
+esac
 
 command -v "$PKG_BIN" >/dev/null 2>&1 || {
     echo "build-repo: '$PKG_BIN' not found on PATH — need a libpkg \`pkg\` binary (set PKG_BIN)" >&2
@@ -125,8 +139,10 @@ pkg_flavor_sig() {
 }
 
 pkg_nv() {
-    # "<name> <version>" of a .pkg.
-    "$PKG_BIN" query -F "$1" '%n %v' 2>/dev/null
+    # "<name>-<version>" of a .pkg — the hyphenated form `pkg repo` records in
+    # the catalog and clients fetch (issue #1081: a space here broke the served
+    # path).
+    "$PKG_BIN" query -F "$1" '%n-%v' 2>/dev/null
 }
 
 # ── Enumerate inputs ───────────────────────────────────────────────────────────
@@ -183,23 +199,28 @@ validate_abi() {
     esac
 }
 
-# ── Lay out per-ABI buckets + run `pkg repo` ───────────────────────────────────
-# The release channel is nested under <out>/release/<ABI>/ (ADR-20, symmetric with the
-# nightly/ subtree), so a client conf whose url carries
-# the explicit `release/${ABI}` prefix resolves against <out> as the base.
-CHANNEL_ROOT="${OUT}/release"
-mkdir -p "$CHANNEL_ROOT"
-# Track which ABI buckets we (re)built, so each is wiped exactly once for
-# determinism even when several .pkg share an ABI.
-built=""
+# ── Lay out the varver bucket + run `pkg repo` ─────────────────────────────────
+# The release channel is nested under <out>/release/<varver>/<arch>/ (ADR-20:
+# the catalog is keyed by varver, matching build-repo-portable.py and this
+# script's own --print-conf url; issue #1081 — the old <out>/release/<ABI>/
+# layout served nothing a printed conf could resolve). One varver per
+# invocation: a mixed-ABI input would silently mix editions, so it fails loud.
+bucket_abi=""
 for f in "$@"; do
     abi="$(pkg_abi "$f")"
     validate_abi "$abi"
-    dir="${CHANNEL_ROOT}/${abi}"
-    case " $built " in
-        *" $abi "*) : ;;                 # already wiped this run
-        *) rm -rf "$dir"; mkdir -p "$dir"; built="$built $abi" ;;
-    esac
+    if [ -z "$bucket_abi" ]; then
+        bucket_abi="$abi"
+    elif [ "$abi" != "$bucket_abi" ]; then
+        echo "build-repo: mixed ABIs in one --varver run ('$bucket_abi' vs '$abi') — run once per varver" >&2
+        exit 1
+    fi
+done
+arch="${bucket_abi##*:}"
+dir="${OUT}/release/${VARVER}/${arch}"
+rm -rf "$dir"
+mkdir -p "$dir"
+for f in "$@"; do
     # Copy under the CANONICAL `<name>-<version>.pkg` name (never the staging input
     # filename), so the catalog path is clean and an identical name+version from
     # another source (branch + release artifact) overwrites to a single file (dedup;
@@ -208,12 +229,9 @@ for f in "$@"; do
     cp "$f" "${dir}/${nv}.pkg"
 done
 
-for abi in $built; do
-    dir="${CHANNEL_ROOT}/${abi}"
-    echo "==> pkg repo ${dir}" >&2
-    # No key argument => an unsigned (NONE-signed) catalog. ASSUME_ALWAYS_YES so
-    # pkg never prompts in CI.
-    env ASSUME_ALWAYS_YES=yes "$PKG_BIN" repo "$dir"
-done
+echo "==> pkg repo ${dir}" >&2
+# No key argument => an unsigned (NONE-signed) catalog. ASSUME_ALWAYS_YES so
+# pkg never prompts in CI.
+env ASSUME_ALWAYS_YES=yes "$PKG_BIN" repo "$dir"
 
-echo "==> built catalogs (release channel) for ABI:${built}" >&2
+echo "==> built catalog (release channel) at release/${VARVER}/${arch}" >&2

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -200,11 +200,9 @@ validate_abi() {
 }
 
 # ── Lay out the varver bucket + run `pkg repo` ─────────────────────────────────
-# The release channel is nested under <out>/release/<varver>/<arch>/ (ADR-20:
-# the catalog is keyed by varver, matching build-repo-portable.py and this
-# script's own --print-conf url; issue #1081 — the old <out>/release/<ABI>/
-# layout served nothing a printed conf could resolve). One varver per
-# invocation: a mixed-ABI input would silently mix editions, so it fails loud.
+# issue #1081: the catalog lives at <out>/release/<varver>/<arch>/ (ADR-20 varver
+# keying, matching build-repo-portable.py and this script's own --print-conf
+# url); one ABI per invocation — a mixed input would silently mix editions.
 bucket_abi=""
 for f in "$@"; do
     abi="$(pkg_abi "$f")"
@@ -212,7 +210,7 @@ for f in "$@"; do
     if [ -z "$bucket_abi" ]; then
         bucket_abi="$abi"
     elif [ "$abi" != "$bucket_abi" ]; then
-        echo "build-repo: mixed ABIs in one --varver run ('$bucket_abi' vs '$abi') — run once per varver" >&2
+        echo "build-repo: mixed ABIs in one run ('$bucket_abi' vs '$abi') — filter --in to one ABI and invoke once per ABI/arch (keep the same --varver for one edition)" >&2
         exit 1
     fi
 done

--- a/tests/shell/build_repo_layout_spec.sh
+++ b/tests/shell/build_repo_layout_spec.sh
@@ -1,0 +1,100 @@
+#shellcheck shell=sh
+# build-repo.sh fallback catalog layout (issue #1081).
+#
+# Two defects are pinned here:
+#
+#   1) The canonical .pkg copy was named "<name> <version>.pkg" (a SPACE --
+#      pkg_nv used '%n %v'), but `pkg repo` records and clients fetch the
+#      hyphenated "<name>-<version>.pkg"; the served path never resolved.
+#
+#   2) The catalog was laid out under release/<ABI>/, contradicting ADR-20's
+#      varver keying AND this script's own --print-conf url
+#      (release/<varver>/<arch>). The varver cannot be derived from the
+#      package (an ABI is not 1:1 with an edition/version), so the build mode
+#      now REQUIRES --varver and lays out release/<varver>/<arch>/.
+#
+# The pkg(8) stub serves `query -F` from key=value lines inside the fake .pkg
+# and materialises `pkg repo <dir>` as a packagesite.pkg marker, so the layout
+# is asserted without a libpkg binary.
+
+Describe 'build-repo.sh catalog layout (issue #1081)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/brlayout.XXXXXX")"
+    mkdir -p "${work}/bin" "${work}/in" "${work}/out"
+
+    cat > "${work}/bin/pkg" <<'EOF'
+#!/bin/sh
+cmd="$1"; shift
+case "$cmd" in
+	query)
+		[ "$1" = "-F" ] || exit 64
+		f="$2"; fmt="$3"
+		name="$(sed -n 's/^name=//p' "$f")"
+		version="$(sed -n 's/^version=//p' "$f")"
+		abi="$(sed -n 's/^abi=//p' "$f")"
+		case "$fmt" in
+			'%q')    printf '%s\n' "$abi" ;;
+			'%n %v') printf '%s %s\n' "$name" "$version" ;;
+			'%n-%v') printf '%s-%s\n' "$name" "$version" ;;
+			'%dn')   sed -n 's/^dep=//p' "$f" ;;
+			*) exit 64 ;;
+		esac ;;
+	repo)
+		touch "$1/packagesite.pkg" ;;
+	*) exit 64 ;;
+esac
+EOF
+    chmod +x "${work}/bin/pkg"
+  }
+  cleanup() { rm -rf "$work"; }
+  Before 'setup'
+  After 'cleanup'
+
+  fake_pkg() { # $1 file, $2 name, $3 version, $4 abi, $5.. deps
+    _f="${work}/in/$1"; shift
+    { printf 'name=%s\nversion=%s\nabi=%s\n' "$1" "$2" "$3"; shift 3
+      for d in "$@"; do printf 'dep=%s\n' "$d"; done
+    } > "$_f"
+  }
+  run_build() {
+    PATH="${work}/bin:${PATH}" PKG_BIN=pkg \
+      sh "${PFB_ROOT}/scripts/build-repo.sh" --in "${work}/in" --out "${work}/out" "$@"
+  }
+
+  It 'lays the catalog out under release/<varver>/<arch>/ with hyphenated names'
+    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
+    fake_pkg b.pkg pfSense-pkg-pfBlockerNG 4.0.2 FreeBSD:15:amd64 php83
+    When call run_build --varver ce-2.8
+    The status should be success
+    The stderr should include 'release/ce-2.8/amd64'
+    # Hyphenated canonical names (defect 1) in the varver bucket (defect 2)...
+    The path "${work}/out/release/ce-2.8/amd64/pfSense-pkg-pfBlockerNG-4.0.1.pkg" should be exist
+    The path "${work}/out/release/ce-2.8/amd64/pfSense-pkg-pfBlockerNG-4.0.2.pkg" should be exist
+    # ...pkg repo ran on the bucket, and no ABI-keyed dir was created.
+    The path "${work}/out/release/ce-2.8/amd64/packagesite.pkg" should be exist
+    The path "${work}/out/release/FreeBSD:15:amd64" should not be exist
+  End
+
+  It 'requires --varver in build mode (the key cannot be derived from the package)'
+    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
+    When call run_build
+    The status should equal 2
+    The stderr should include '--varver'
+  End
+
+  It 'fails loud on a mixed-ABI input instead of mixing editions in one bucket'
+    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
+    fake_pkg b.pkg pfSense-pkg-pfBlockerNG 4.0.1_1 FreeBSD:16:amd64 php85
+    When call run_build --varver ce-2.8
+    The status should equal 1
+    The stderr should include 'mixed ABIs'
+  End
+
+  It 'still fails loud on a same-name+version+ABI flavor collision'
+    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
+    fake_pkg b.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php85
+    When call run_build --varver ce-2.8
+    The status should equal 1
+    The stderr should include 'FLAVOR COLLISION'
+  End
+End

--- a/tests/shell/build_repo_layout_spec.sh
+++ b/tests/shell/build_repo_layout_spec.sh
@@ -82,6 +82,27 @@ EOF
     The stderr should include '--varver'
   End
 
+  Describe 'hostile --varver values'
+    # The value becomes a directory that is rm -rf'd + rebuilt, so anything but
+    # a plain lowercase segment must be rejected before any filesystem work.
+    Parameters
+      '../etc'
+      'ce/2.8'
+      'CE-2.8'
+      'ce_2.8'
+      'ce-2.8;rm -rf x'
+    End
+
+    It "rejects hostile --varver value: $1"
+      fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
+      When call run_build --varver "$1"
+      The status should equal 2
+      The stderr should include 'unsafe or invalid --varver'
+      # No filesystem layout may happen for a rejected value.
+      The path "${work}/out/release" should not be exist
+    End
+  End
+
   It 'fails loud on a mixed-ABI input instead of mixing editions in one bucket'
     fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
     fake_pkg b.pkg pfSense-pkg-pfBlockerNG 4.0.1_1 FreeBSD:16:amd64 php85

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -117,16 +117,16 @@ NETGATE_REPO_NAME = "pfSense"  # the real base-system Netgate repo (left enabled
 GUEST_FILE_LIST = f"{GUEST_SPIKE_DIR}/installed_files.txt"
 
 # Phase-2 (ADR-17) catalog generator under test. ``build-repo.sh`` is the real,
-# reusable per-ABI catalog tool the Phase-3 publish job runs; here it is staged to
-# the guest and run with the guest's libpkg to prove the SCRIPT's output (an
-# <ABI>/ catalog tree it lays out) is accepted by a real pfSense ``pkg update`` +
-# install. (The libpkg-on-Linux half of the build-side premise — that the SAME
-# script + the SAME ``pkg repo`` op runs on a Linux runner — is proven locally in
+# reusable catalog fallback tool; here it is staged to the guest and run with the
+# guest's libpkg to prove the SCRIPT's output (the release/<varver>/<arch>/ tree
+# it lays out, ADR-20) is accepted by a real pfSense ``pkg update`` + install.
+# (The libpkg-on-Linux half of the build-side premise — that the SAME script +
+# the SAME ``pkg repo`` op runs on a Linux runner — is proven locally in
 # RESULTS/02; the script is identical regardless of which libpkg invokes it.)
 BUILD_REPO_SH = Path(__file__).resolve().parents[2] / "scripts" / "build-repo.sh"
 GUEST_BUILD_REPO_SH = f"{GUEST_SPIKE_DIR}/build-repo.sh"
 GUEST_PKG_IN_DIR = f"{GUEST_SPIKE_DIR}/pkg_in"  # the input dir of .pkg for build-repo.sh
-SCRIPT_REPO_ROOT = f"{GUEST_SPIKE_DIR}/script_catalog"  # build-repo.sh --out (per-ABI tree)
+SCRIPT_REPO_ROOT = f"{GUEST_SPIKE_DIR}/script_catalog"  # build-repo.sh --out (varver tree)
 
 # Phase-3a (ADR-17) PURE-PYTHON catalog generator under test. Unlike build-repo.sh
 # (which needs a libpkg ``pkg`` binary), ``build-repo-portable.py`` builds the
@@ -249,17 +249,19 @@ def build_repo_via_script(vm: SmokeVM, pkg_files: list[Path]) -> str:
     """Run the Phase-2 ``scripts/build-repo.sh`` on the guest over ``pkg_files``.
 
     Stages the real ``build-repo.sh`` and the input ``.pkg`` to the guest, runs
-    ``build-repo.sh --in <pkg_in> --out <script_catalog>`` with the guest's own
-    libpkg, then returns the single per-ABI catalog directory it produced. The
-    script lays the release channel under ``<out>/release/<ABI>/`` (ADR-20, symmetric
-    with nightly), so ``<out>`` is the base a ``file://`` repo conf points at and the
-    conf's ``release/${ABI}`` url resolves to the returned dir.
+    ``build-repo.sh --in <pkg_in> --out <script_catalog> --varver <varver>`` with
+    the guest's own libpkg, then returns the catalog directory it produced. The
+    script lays the release channel under ``<out>/release/<varver>/<arch>/``
+    (ADR-20 varver keying, issue #1081 — matching ``build-repo-portable.py`` and
+    the printed conf), so ``<out>`` is the base a ``file://`` repo conf points at
+    and the conf's ``release/<varver>/<arch>`` url resolves to the returned dir.
+    The varver/arch come from the box itself via the ``_box_real_catalog`` oracle.
 
-    This validates the SCRIPT's output (the bucketed ``release/<ABI>/`` tree + the
-    catalog triple ``pkg repo`` emits) is accepted by a real pfSense box, the live
-    half of the build-side premise. The branch ``.pkg`` is a single ABI
-    (``FreeBSD:15:amd64``), so exactly one ``<ABI>/`` dir is expected.
+    This validates the SCRIPT's output (the ``release/<varver>/<arch>/`` tree +
+    the catalog triple ``pkg repo`` emits) is accepted by a real pfSense box, the
+    live half of the build-side premise.
     """
+    real_varver, real_arch = _box_real_catalog(vm).rsplit("/", 1)
     _ssh_check(vm, "/bin/rm", "-rf", GUEST_PKG_IN_DIR, SCRIPT_REPO_ROOT)
     _ssh_check(vm, "/bin/mkdir", "-p", GUEST_PKG_IN_DIR, GUEST_SPIKE_DIR)
     _scp_to_guest(vm, BUILD_REPO_SH, GUEST_BUILD_REPO_SH)
@@ -277,19 +279,16 @@ def build_repo_via_script(vm: SmokeVM, pkg_files: list[Path]) -> str:
         GUEST_PKG_IN_DIR,
         "--out",
         SCRIPT_REPO_ROOT,
+        "--varver",
+        real_varver,
         timeout=240.0,
     )
-    # The script nests the release channel under release/, then buckets by ABI; the
-    # branch .pkg is one ABI -> one release/<ABI>/ subdir.
-    release_root = f"{SCRIPT_REPO_ROOT}/release"
-    listing = _ssh_check(vm, "/bin/ls", "-1", release_root).stdout.split()
-    assert len(listing) == 1, f"build-repo.sh produced {listing!r} ABI buckets under release/, expected exactly 1"
-    abi_dir = f"{release_root}/{listing[0]}"
+    catalog_dir = f"{SCRIPT_REPO_ROOT}/release/{real_varver}/{real_arch}"
     # The catalog triple must be present (what `pkg update` consumes).
     for fname in ("meta.conf", "packagesite.pkg", "data.pkg"):
-        present = vm.ssh("/bin/test", "-f", f"{abi_dir}/{fname}")
-        assert present.returncode == 0, f"build-repo.sh did not emit {fname} under {abi_dir}"
-    return abi_dir
+        present = vm.ssh("/bin/test", "-f", f"{catalog_dir}/{fname}")
+        assert present.returncode == 0, f"build-repo.sh did not emit {fname} under {catalog_dir}"
+    return catalog_dir
 
 
 def build_repo_via_portable(vm: SmokeVM, pkg_files: list[Path], tmp_path: Path) -> str:
@@ -904,7 +903,8 @@ def test_build_repo_script_catalog_is_accepted(repo_vm: SmokeVM) -> None:
     ``pkg repo`` op are identical regardless of which libpkg runs them).
 
     Given the package ABSENT and a catalog produced by ``build-repo.sh`` over the
-      branch ``.pkg`` (its ``<ABI>/`` bucket holds meta.conf/packagesite.pkg/data.pkg),
+      branch ``.pkg`` (its ``release/<varver>/<arch>/`` bucket holds
+      meta.conf/packagesite.pkg/data.pkg),
       enabled via a NONE-signed ``file://`` repo above the pfSense repo,
     When ``pkg update`` reads it and ``pkg install -y`` runs (NO ``-r``, NO ``-f``),
     Then ``pkg update`` accepts the script-generated catalog AND the install comes


### PR DESCRIPTION
## Summary

Fixes #1081. Two defects in the retained FreeBSD-fidelity fallback builder (`scripts/build-repo.sh`; `build-repo-portable.py` remains the CI/release builder — the fallback is kept by design as the `pkg repo` fidelity path and the `--print-conf` template source, so removal was not an option):

1. **Space-named canonical .pkg** — `pkg_nv` used `'%n %v'`, so the canonical copy was `<name> <version>.pkg` while `pkg repo` records and clients fetch `<name>-<version>.pkg`; the served path never resolved.
2. **ABI-keyed layout** — the catalog landed under `release/<ABI>/`, contradicting ADR-20's hard varver-keying rule AND the script's own `--print-conf` url (`release/<varver>/<arch>`).

## Fix

- `pkg_nv` emits the hyphenated `'%n-%v'` form.
- The build mode now **requires `--varver`** (e.g. `ce-2.8`) — the varver cannot be derived from the package, an ABI is not 1:1 with an edition/version (that is ADR-20's point) — and lays the catalog out at `release/<varver>/<arch>/` (arch from the packages' ABI), matching `build-repo-portable.py` and the printed conf. One varver per invocation: a **mixed-ABI input fails loud** instead of silently mixing editions. The varver is path-validated like ABIs (it is `rm -rf`'d + rebuilt).
- `--print-conf` untouched (byte-identity with `add-repo.sh`/portable stays pinned by `tests/test_add_repo_conf.py`, re-run green).

## Tests

New `tests/shell/build_repo_layout_spec.sh` (4 examples) with a `pkg(8)` stub serving `query -F` from key=value fixture packages and materialising `pkg repo` as a marker:

- catalog lands at `release/ce-2.8/amd64/` with hyphenated names, `pkg repo` ran, no ABI dir (both defects — red on devel)
- missing `--varver` is a usage error (red on devel: the old script silently built the broken layout)
- mixed-ABI input fails loud (red on devel: silently built two ABI dirs)
- flavor collision still fails loud (behaviour pin on the reworked flow)

Red/green executed by reverting the script only. Full shellspec suite: 475 examples, 0 failures, 9 pre-existing skips. `sh -n` · `shellcheck` clean · `--help` block re-anchored and verified · `pytest` (incl. conf byte-identity + portable-builder suites) green.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NviP9zgwweu471WhThw6U)_