### PR TITLE
www: vet alt_selected tokens before using them as config keys (#1076)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -131,8 +131,16 @@ if ($_POST) {
 			foreach ($selected as $value) {
 
 				if (!empty($value)) {
+					// issue #1076: the token becomes a config_set_path() KEY below -- vet
+					// it like the alt_ value, or a crafted request splices path separators
+					// into the config tree (feed_alt_a/b writes a nested node).
+					$value = pfb_filter($value, PFB_FILTER_WORD, 'feeds');
+					if (empty($value)) {
+						$input_errors[] = 'Invalid Alternative Alias Name';
+						continue;
+					}
 					// Save Alternative Aliasnames to pfblockerngglobal in config.xml
-					$post = pfb_filter($_POST['alt_' . $value], PFB_FILTER_WORD, 'feeds');
+					$post = pfb_filter($_POST['alt_' . $value] ?? '', PFB_FILTER_WORD, 'feeds');
 					if (!empty($post)) {
 						$value					= strtolower($value);		// config XML tag needs to be lowercase
 						${"feed_alt_$value"}			= $post;

--- a/tests/php/FeedsAltSelectedKeyTest.php
+++ b/tests/php/FeedsAltSelectedKeyTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Feeds page alt_selected config-key vetting (issue #1076).
+ *
+ * The save handler exploded the request field ``alt_selected`` and used each
+ * raw token as part of a config_set_path() KEY
+ * (``installedpackages/pfblockerngglobal/feed_alt_{$value}``). Only the
+ * alt_ VALUE was filtered; a crafted token like ``a/b`` spliced a path
+ * separator into the config tree, writing an unintended nested node. Each
+ * token is now vetted through PFB_FILTER_WORD (every shipped feed header is
+ * word-charset; audited against pfblockerng_feeds.json) before any key use.
+ *
+ * Like WidgetSubmitPostGuardTest, the page carries top-level execution and
+ * cannot be require()d off-appliance, so the REAL alt_selected block is
+ * eval-extracted verbatim (its leading comment and the following
+ * ``if ($config_mod)`` line are the unique anchors).
+ */
+final class FeedsAltSelectedKeyTest extends TestCase
+{
+	private array $savedPost = [];
+	private mixed $savedConfig = null;
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_feeds.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_feeds.php');
+		}
+
+		if (!function_exists('pfb_feeds_oracle_alt_selected')) {
+			if (!preg_match(
+				'/\/\/ Save all .selected. Alternate URL feeds\.\n(.*?)(?=\n\n\t\tif \(\$config_mod\))/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: alt_selected block not found in feeds source');
+			}
+			eval(
+				'function pfb_feeds_oracle_alt_selected(): array {'
+				. ' $fconfig = array(); $input_errors = array(); $config_mod = FALSE; '
+				. $m[1]
+				. ' return $input_errors; }'
+			);
+		}
+	}
+
+	protected function setUp(): void
+	{
+		$this->savedPost   = $_POST;
+		$this->savedConfig = $GLOBALS['config'] ?? null;
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$_POST = $this->savedPost;
+		if ($this->savedConfig === null) {
+			unset($GLOBALS['config']);
+		} else {
+			$GLOBALS['config'] = $this->savedConfig;
+		}
+	}
+
+	private function globalNodes(): array
+	{
+		$nodes = config_get_path('installedpackages/pfblockerngglobal');
+		return is_array($nodes) ? $nodes : [];
+	}
+
+	public function testPathBearingTokenWritesNoConfigNode(): void
+	{
+		// Given: a crafted token carrying a path separator, with a matching
+		// filtered-clean alt_ value so only the KEY vetting can stop the write.
+		$_POST['alt_selected'] = 'a/b';
+		$_POST['alt_a/b']      = 'EvilWord';
+
+		$errors = pfb_feeds_oracle_alt_selected();
+
+		// Then: nothing lands under pfblockerngglobal (before the fix, the raw
+		// token spliced config_set_path into a nested feed_alt_a/b node) and the
+		// token is rejected loudly.
+		$this->assertSame([], $this->globalNodes(), 'a path-bearing token must write no config node');
+		$this->assertNotEmpty($errors, 'the crafted token must be rejected as an input error');
+	}
+
+	public function testValidTokenStillSavesLowercasedKey(): void
+	{
+		// Behaviour-preserving pin, with empty CSV entries skipped on the way.
+		$_POST['alt_selected']  = ',EasyList,';
+		$_POST['alt_EasyList']  = 'EasyListAlt';
+
+		$errors = pfb_feeds_oracle_alt_selected();
+
+		$this->assertSame([], $errors);
+		$this->assertSame(
+			'EasyListAlt',
+			config_get_path('installedpackages/pfblockerngglobal/feed_alt_easylist')
+		);
+	}
+
+	public function testWordTokenWithMissingAltFieldIsRejectedNotFatal(): void
+	{
+		// A word-charset token with no matching alt_ field must produce the
+		// existing 'Invalid Alternative Alias Name' error (and no PHP 8
+		// undefined-key warning turned fatal by a handler).
+		$_POST['alt_selected'] = 'GhostAlias';
+		unset($_POST['alt_GhostAlias']);
+
+		$errors = pfb_feeds_oracle_alt_selected();
+
+		$this->assertSame([], $this->globalNodes());
+		$this->assertNotEmpty($errors);
+	}
+}

--- a/tests/php/FeedsAltSelectedKeyTest.php
+++ b/tests/php/FeedsAltSelectedKeyTest.php
@@ -74,6 +74,24 @@ final class FeedsAltSelectedKeyTest extends TestCase
 		return is_array($nodes) ? $nodes : [];
 	}
 
+	/** Run the oracle while capturing PHP warnings/notices (PHPUnit passes them by default). */
+	private function runOracleCapturingWarnings(array &$warnings): array
+	{
+		$warnings = [];
+		set_error_handler(
+			static function (int $errno, string $errstr) use (&$warnings): bool {
+				$warnings[] = $errstr;
+				return true;
+			},
+			E_WARNING | E_NOTICE
+		);
+		try {
+			return pfb_feeds_oracle_alt_selected();
+		} finally {
+			restore_error_handler();
+		}
+	}
+
 	public function testPathBearingTokenWritesNoConfigNode(): void
 	{
 		// Given: a crafted token carrying a path separator, with a matching
@@ -108,14 +126,17 @@ final class FeedsAltSelectedKeyTest extends TestCase
 	public function testWordTokenWithMissingAltFieldIsRejectedNotFatal(): void
 	{
 		// A word-charset token with no matching alt_ field must produce the
-		// existing 'Invalid Alternative Alias Name' error (and no PHP 8
-		// undefined-key warning turned fatal by a handler).
+		// existing 'Invalid Alternative Alias Name' error -- with NO PHP 8
+		// "Undefined array key" warning (PHPUnit passes warnings by default,
+		// so they are captured and asserted explicitly).
 		$_POST['alt_selected'] = 'GhostAlias';
 		unset($_POST['alt_GhostAlias']);
 
-		$errors = pfb_feeds_oracle_alt_selected();
+		$warnings = [];
+		$errors = $this->runOracleCapturingWarnings($warnings);
 
 		$this->assertSame([], $this->globalNodes());
 		$this->assertNotEmpty($errors);
+		$this->assertSame([], $warnings, 'the missing alt_ field read must not warn');
 	}
 }

--- a/tests/smoke/ui/test_feeds_alt_selected.py
+++ b/tests/smoke/ui/test_feeds_alt_selected.py
@@ -46,22 +46,29 @@ def test_path_bearing_alt_selected_token_writes_no_config_node(
       (oracle: config.xml over SSH, never the HTTP body).
     """
     vm = smoke_vm
-    spliced_parent = "installedpackages/pfblockerngglobal/feed_alt_a"
+    # A test-unique token so the spliced parent cannot collide with anything a
+    # sibling flow (or an earlier run on the shared VM) left in config.xml.
+    token = "iss1076crafted/b"
+    spliced_parent = "installedpackages/pfblockerngglobal/feed_alt_iss1076crafted"
 
+    # Clean baseline: drop any node a pre-guard build may have left behind.
+    _config_del(vm, spliced_parent)
     try:
+        assert helpers.config_get(vm, spliced_parent) == "", f"{spliced_parent} not empty before the POST"
+
         resp = webui.post(
             FEEDS_PAGE_IPV4,
-            {"alt_selected": "a/b", "alt_a/b": "EvilWord"},
+            {"alt_selected": token, f"alt_{token}": "EvilWord"},
             timeout=120.0,
         )
         assert not looks_like_login_page(resp.text), "Feeds alt_selected POST returned the login form"
 
         assert helpers.config_get(vm, spliced_parent) == "", (
-            "a path-bearing alt_selected token must not splice a feed_alt_a node into config.xml"
+            f"a path-bearing alt_selected token must not splice {spliced_parent} into config.xml"
         )
         assert helpers.config_get(vm, f"{spliced_parent}/b") == "", (
-            "no nested child may appear under the spliced parent either"
+            f"no nested child may appear under {spliced_parent} either"
         )
     finally:
-        # Sweep any node a pre-guard build may have written on the shared VM.
+        # Sweep whatever this run may have written on the shared VM.
         _config_del(vm, spliced_parent)

--- a/tests/smoke/ui/test_feeds_alt_selected.py
+++ b/tests/smoke/ui/test_feeds_alt_selected.py
@@ -1,0 +1,67 @@
+"""issue #1076 -- a crafted ``alt_selected`` token must not become a config key.
+
+The Feeds save handler exploded ``alt_selected`` and used each raw token as
+part of a ``config_set_path()`` KEY
+(``installedpackages/pfblockerngglobal/feed_alt_{$value}``); only the alt_
+VALUE was filtered, so a token like ``a/b`` spliced a path separator into the
+config tree and wrote an unintended nested node. Tokens are now vetted
+through ``PFB_FILTER_WORD`` before any key use (off-appliance red/green
+pinned by ``tests/php/FeedsAltSelectedKeyTest.php``; this exercises the same
+save end-to-end through the real page).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .test_feeds import FEEDS_PAGE_IPV4, _config_del
+from .webui import looks_like_login_page
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+# Tier B: a mutating POST flow whose failure artifact (a spliced config.xml
+# node) is observable only on-box. Tier A render coverage of this page already
+# exists (test_render_smoke.py / test_feeds.py).
+pytestmark = pytest.mark.ui_e2e
+
+
+def test_path_bearing_alt_selected_token_writes_no_config_node(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Scenario: a save POST carrying ``alt_selected=a/b`` with a clean value.
+
+    Given the Feeds IPv4 tab and a POST whose ``alt_selected`` token carries a
+      path separator while its matching ``alt_a/b`` value is filter-clean (so
+      only the KEY vetting can stop the write),
+
+    When the save is POSTed through the real CSRF form,
+
+    Then config.xml gains NO node under ``pfblockerngglobal`` for the token --
+      neither the spliced nested ``feed_alt_a`` parent nor a literal child
+      (oracle: config.xml over SSH, never the HTTP body).
+    """
+    vm = smoke_vm
+    spliced_parent = "installedpackages/pfblockerngglobal/feed_alt_a"
+
+    try:
+        resp = webui.post(
+            FEEDS_PAGE_IPV4,
+            {"alt_selected": "a/b", "alt_a/b": "EvilWord"},
+            timeout=120.0,
+        )
+        assert not looks_like_login_page(resp.text), "Feeds alt_selected POST returned the login form"
+
+        assert helpers.config_get(vm, spliced_parent) == "", (
+            "a path-bearing alt_selected token must not splice a feed_alt_a node into config.xml"
+        )
+        assert helpers.config_get(vm, f"{spliced_parent}/b") == "", (
+            "no nested child may appear under the spliced parent either"
+        )
+    finally:
+        # Sweep any node a pre-guard build may have written on the shared VM.
+        _config_del(vm, spliced_parent)


### PR DESCRIPTION
## Summary

Fixes #1076. The Feeds save handler exploded the request field `alt_selected` and used each raw token as part of a `config_set_path()` **key** (`installedpackages/pfblockerngglobal/feed_alt_{$value}`). Only the `alt_` VALUE was filtered — a crafted token like `a/b` spliced a path separator into the config tree, writing an unintended nested node (config-shape corruption by an authenticated POST).

## Fix

Vet each token through `PFB_FILTER_WORD` before any key use, rejecting non-conforming tokens with the page's existing 'Invalid Alternative Alias Name' error. Regression-checked against reality: all 292 shipped feed headers in `pfblockerng_feeds.json` are word-charset, so no legitimate token is affected. The `alt_` field read also tolerates a missing key (`?? ''` — a vetted-but-unknown token no longer raises a PHP 8 undefined-key warning).

## Tests

- **PHPUnit** `tests/php/FeedsAltSelectedKeyTest.php` — eval-extracts the REAL `alt_selected` block verbatim (the established page-block pattern). Three tests: a path-bearing token writes **no** config node and errors loudly (**red before**: the spliced `feed_alt_a/b` node was written); a valid token still saves its lowercased key with empty CSV entries skipped (behaviour pin); a word-charset token with no matching `alt_` field is rejected without a PHP 8 warning (**red before**: `Undefined array key "alt_GhostAlias"`). Red/green executed by reverting the page source only.
- **UI Tier B** `tests/smoke/ui/test_feeds_alt_selected.py` — the same save end-to-end through the real CSRF form on the live VM: POST `alt_selected=a/b` + a clean value, assert config.xml gains neither the spliced `feed_alt_a` parent nor its nested child (oracle: config.xml over SSH).

Gates: `php -l` clean · `phpunit` → 2600 tests, 0 failures · `phpstan` no errors · `phpcs` clean · `ruff`/`mypy` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NviP9zgwweu471WhThw6U)_