### PR TITLE
www: reject array-valued POST fields in the settings-save handlers (#1070)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1226,6 +1226,14 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 		}
 	}
 
+	// issue #1070: only the FILE_MIME family consumes an array $input; every other
+	// filter type does scalar string ops (htmlspecialchars/preg_match) below that
+	// PHP 8 TypeErrors on an array, so a crafted array POST ('field[]=x') routed
+	// through pfb_filter would 500 the page. Reject an array as invalid up front.
+	if (is_array($input) && !in_array($type, array(PFB_FILTER_FILE_MIME_COMPARE, PFB_FILTER_FILE_MIME, PFB_FILTER_FILE_MIME_COMPRESSED))) {
+		return $return_type;
+	}
+
 	$result = FALSE;
 	switch ($type) {
 		case PFB_FILTER_HTML:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1226,10 +1226,9 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 		}
 	}
 
-	// issue #1070: only the FILE_MIME family consumes an array $input; every other
-	// filter type does scalar string ops (htmlspecialchars/preg_match) below that
-	// PHP 8 TypeErrors on an array, so a crafted array POST ('field[]=x') routed
-	// through pfb_filter would 500 the page. Reject an array as invalid up front.
+	// issue #1070: every non-FILE_MIME type runs scalar string ops below (htmlspecialchars/
+	// preg_match) that PHP 8 TypeErrors on an array, so a crafted array POST ('field[]=x')
+	// would 500 the page -- reject an array up front for those types.
 	if (is_array($input) && !in_array($type, array(PFB_FILTER_FILE_MIME_COMPARE, PFB_FILTER_FILE_MIME, PFB_FILTER_FILE_MIME_COMPRESSED))) {
 		return $return_type;
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -168,6 +168,13 @@ if ($_POST) {
 			$_POST[$dkey] = (string) $v;
 		}
 
+		// issue #1070: an array-valued POST ('pfb_feed_internal_allowlist[]=x')
+		// throws a PHP 8 TypeError in trim()/base64_encode() below; reject it
+		// here so the save gate blocks and the stored allowlist is preserved.
+		if (!is_string($_POST['pfb_feed_internal_allowlist'] ?? '')) {
+			$input_errors[] = gettext('Invalid feed-host allowlist value.');
+		}
+
 		if (!$input_errors) {
 
 			$pfb['gconfig']['enable_cb']			= pfb_filter($_POST['enable_cb'], PFB_FILTER_ON_OFF, 'general', '');

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -254,9 +254,12 @@ if ($_POST) {
 						(array) ($_POST['pfb_agg_types'] ?? array())));
 			PfbConfig::write('pfb_agg_types', implode(',', $agg_types_post));
 
-			// ADR-40: alias-table apply mode (gateway-registered scalar).
-			$delta_mode_post = array_key_exists($_POST['pfb_alias_delta_mode'] ?? '', $options_pfb_alias_delta_mode)
-				? $_POST['pfb_alias_delta_mode']
+			// ADR-40: alias-table apply mode (gateway-registered scalar). issue #1070:
+			// array_key_exists() TypeErrors on an array key, so coerce a crafted
+			// array POST to the 'auto' default via the is_scalar guard.
+			$delta_mode_raw = $_POST['pfb_alias_delta_mode'] ?? '';
+			$delta_mode_post = (is_scalar($delta_mode_raw) && array_key_exists($delta_mode_raw, $options_pfb_alias_delta_mode))
+				? $delta_mode_raw
 				: 'auto';
 			PfbConfig::write('pfb_alias_delta_mode', $delta_mode_post);
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -153,6 +153,18 @@ if ($_POST) {
 			$input_errors[] = 'IPinfo Token Invalid';
 		}
 
+		// issue #1070: an array-valued textarea POST ('v4suppression[]=x') throws a
+		// PHP 8 TypeError in explode()/base64_encode() before the input-errors gate;
+		// reject it and blank the field so every later read stays scalar.
+		foreach (array('v4suppression', 'v6suppression') as $pfb_sfield) {
+			$pfb_sval = $_POST[$pfb_sfield] ?? '';
+			if (!is_string($pfb_sval)) {
+				$input_errors[] = gettext('Invalid suppression list value.');
+				$pfb_sval = '';
+			}
+			$_POST[$pfb_sfield] = $pfb_sval;
+		}
+
 		$v4suppression = explode("\r\n", $_POST['v4suppression']);
 		if (!empty($v4suppression)) {
 			foreach ($v4suppression as $line) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_sync.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_sync.php
@@ -66,6 +66,13 @@ if ($_POST) {
 
 			// Parse 'rowhelper' fields and save new values
 			if (strpos($key, '-') !== FALSE) {
+				// issue #1070: the scalar validators below (preg_match/strlen/is_port)
+				// throw a PHP 8 TypeError on an array value ('field-0[]=x') before the
+				// input-errors gate. Reject non-scalars up front (mirrors hooks.php).
+				if (!is_scalar($value)) {
+					$input_errors[] = gettext('Invalid sync field value.');
+					continue;
+				}
 				$k_field = explode('-', $key);
 
 				// Collect all rowhelper keys

--- a/src/usr/local/www/pfblockerng/pfblockerng_sync.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_sync.php
@@ -66,17 +66,21 @@ if ($_POST) {
 
 			// Parse 'rowhelper' fields and save new values
 			if (strpos($key, '-') !== FALSE) {
+				$k_field = explode('-', $key);
+
+				// Collect all rowhelper keys. Register the row BEFORE the scalar
+				// check so a rejected value still tracks its row -- else the
+				// "remove undefined rowhelpers" loop below would drop an existing
+				// target whose only posted field was invalid.
+				$rowhelper_exist[$k_field[1]] = '';
+
 				// issue #1070: the scalar validators below (preg_match/strlen/is_port)
 				// throw a PHP 8 TypeError on an array value ('field-0[]=x') before the
-				// input-errors gate. Reject non-scalars up front (mirrors hooks.php).
+				// input-errors gate. Reject non-scalars here (mirrors hooks.php).
 				if (!is_scalar($value)) {
 					$input_errors[] = gettext('Invalid sync field value.');
 					continue;
 				}
-				$k_field = explode('-', $key);
-
-				// Collect all rowhelper keys
-				$rowhelper_exist[$k_field[1]] = '';
 
 				switch ($k_field[0]) {
 					case 'syncinterfaces':

--- a/tests/php/PfbFilterTest.php
+++ b/tests/php/PfbFilterTest.php
@@ -135,6 +135,29 @@ final class PfbFilterTest extends TestCase
 		$this->assertSame($expected, pfb_filter($input, PFB_FILTER_NUM));
 	}
 
+	/**
+	 * issue #1070: a crafted array POST ('field[]=x') routed through pfb_filter
+	 * must return the default, not TypeError in the scalar string ops
+	 * (htmlspecialchars/preg_match) -- every scalar-expecting filter type.
+	 *
+	 * @return array<string, array{int, mixed}>
+	 */
+	public static function scalarTypeProvider(): array
+	{
+		return [
+			'ON_OFF' => [PFB_FILTER_ON_OFF, ''],
+			'WORD'   => [PFB_FILTER_WORD, ''],
+			'NUM'    => [PFB_FILTER_NUM, ''],
+			'DOMAIN' => [PFB_FILTER_DOMAIN, ''],
+		];
+	}
+
+	#[DataProvider('scalarTypeProvider')]
+	public function testArrayInputReturnsDefaultInsteadOfThrowing(int $type, string $default): void
+	{
+		$this->assertSame($default, pfb_filter(['x'], $type, 'test', $default));
+	}
+
 	public static function tokenProvider(): array
 	{
 		return [

--- a/tests/php/PfbFilterTest.php
+++ b/tests/php/PfbFilterTest.php
@@ -149,6 +149,9 @@ final class PfbFilterTest extends TestCase
 			'WORD'   => [PFB_FILTER_WORD, ''],
 			'NUM'    => [PFB_FILTER_NUM, ''],
 			'DOMAIN' => [PFB_FILTER_DOMAIN, ''],
+			// Non-empty default proves the rejected array returns the CALLER'S default,
+			// not a hardcoded '' -- a bare '' row alone cannot distinguish the two.
+			'WORD non-empty default' => [PFB_FILTER_WORD, 'PFB_ARRAY_REJECT_SENTINEL'],
 		];
 	}
 

--- a/tests/php/SyncRowhelperGuardTest.php
+++ b/tests/php/SyncRowhelperGuardTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Sync page rowhelper array-POST guard + row-tracking (issue #1070).
+ *
+ * The XMLRPC-sync save loop ran scalar validators (preg_match/strlen/is_port)
+ * on each rowhelper field; a PHP 8 array value ('varsyncusername-0[]=x')
+ * threw TypeError before the input-errors gate (HTTP 500). The fix rejects a
+ * non-scalar as an input error -- but it must still REGISTER the row in
+ * $rowhelper_exist first, or the "remove all undefined rowhelpers" loop drops
+ * an existing replication target whose only posted field was the invalid one.
+ *
+ * Like WidgetSubmitPostGuardTest, the page carries top-level execution and
+ * cannot be require()d off-appliance, so the REAL rowhelper loop (through the
+ * remove-undefined-rowhelpers loop) is eval-extracted verbatim.
+ */
+final class SyncRowhelperGuardTest extends TestCase
+{
+	private array $savedPost = [];
+	private mixed $savedPfb = null;
+	private mixed $savedConfig = null;
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_sync.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_sync.php');
+		}
+
+		if (!function_exists('pfb_sync_oracle_rowloop')) {
+			if (!preg_match(
+				'/\$rowhelper_exist = array\(\);\n(.*?)(?=\n\n\t\tif \(!\$input_errors\))/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: sync rowhelper loop not found');
+			}
+			eval(
+				'function pfb_sync_oracle_rowloop(): array {'
+				. ' global $pfb; $input_errors = array(); $rowhelper_exist = array(); '
+				. $m[1]
+				. ' return array($input_errors, array_keys($pfb[\'sconfig\'][\'row\'] ?? array())); }'
+			);
+		}
+	}
+
+	protected function setUp(): void
+	{
+		$this->savedPost   = $_POST;
+		$this->savedPfb    = $GLOBALS['pfb'] ?? null;
+		$this->savedConfig = $GLOBALS['config'] ?? null;
+		$GLOBALS['config'] = [];
+		// A pre-existing replication target at row index 0.
+		$GLOBALS['pfb']['sconfig']['row'] = [
+			0 => ['varsyncusername' => 'admin', 'varsyncdestinenable' => 'on'],
+		];
+		$_POST = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$_POST = $this->savedPost;
+		$GLOBALS['pfb'] = $this->savedPfb;
+		if ($this->savedConfig === null) {
+			unset($GLOBALS['config']);
+		} else {
+			$GLOBALS['config'] = $this->savedConfig;
+		}
+	}
+
+	public function testArrayRowhelperValueIsRejectedWithoutThrowing(): void
+	{
+		// A crafted array value for the only posted rowhelper field of row 0.
+		$_POST['varsyncusername-0'] = ['x'];
+
+		[$errors, $rows] = pfb_sync_oracle_rowloop();
+
+		// The array value is rejected as an input error (no TypeError 500)...
+		$this->assertNotEmpty($errors, 'the array value must be rejected as an input error');
+		// ...and row 0 is STILL tracked, so the remove loop does not delete the
+		// pre-existing replication target (the Copilot-found regression).
+		$this->assertContains(0, $rows, 'the existing replication target must survive an invalid field');
+	}
+
+	public function testValidRowhelperFieldStillSaves(): void
+	{
+		// Behaviour-preserving pin: a scalar username saves and the row survives.
+		$_POST['varsyncusername-0'] = 'operator';
+
+		[$errors, $rows] = pfb_sync_oracle_rowloop();
+
+		$this->assertSame([], $errors);
+		$this->assertContains(0, $rows);
+		$this->assertSame('operator', $GLOBALS['pfb']['sconfig']['row'][0]['varsyncusername']);
+	}
+}

--- a/tests/smoke/ui/test_post_array_scalar_guards.py
+++ b/tests/smoke/ui/test_post_array_scalar_guards.py
@@ -1,20 +1,19 @@
 """issue #1070 -- array-valued $_POST fields must not 500 the settings saves.
 
-Three settings-save handlers passed request fields straight into string
-functions with no scalar coercion; in PHP 8 an array argument
-(``field[]=x``, valid CSRF) throws ``TypeError`` BEFORE the input-errors
-gate -- an HTTP 500 plus a fatal in ``php_error.log``:
+The Sync/IP/General settings handlers passed request fields into string
+functions with no scalar coercion; in PHP 8 an array argument (``field[]=x``,
+valid CSRF) throws ``TypeError`` BEFORE the input-errors gate -- an HTTP 500
+plus a fatal in ``php_error.log``. Two guard layers close the theme:
 
-* ``pfblockerng_sync.php`` rowhelper loop (``varsyncusername-0[]=x`` hit
-  ``preg_match``/``strlen``) -- now rejects non-scalars up front, mirroring
-  the ``hooks.php`` guard;
-* ``pfblockerng_ip.php`` suppression textareas (``explode``/``base64_encode``)
-  -- now rejected as an input error and blanked;
-* ``pfblockerng_general.php`` feed-host allowlist (``trim``) -- now rejected
-  as an input error before the save gate.
+* the shared ``pfb_filter()`` rejects an array as invalid up front, so every
+  ``ON_OFF``/``WORD``/``NUM``-filtered field (the bulk of the sites) is safe
+  in one place;
+* the three fields that bypass ``pfb_filter`` (the sync rowhelper loop, the IP
+  suppression textareas' ``explode``/``base64_encode``, the General allowlist
+  ``trim``) plus the IP ``array_key_exists`` site get inline scalar guards.
 
-Each save must instead respond like any validation failure: HTTP 200, no
-login bounce, and NOT ONE new byte in any candidate ``php_error.log``.
+Each save must respond like any validation failure: HTTP 200, no login
+bounce, and NOT ONE new byte in any candidate ``php_error.log``.
 """
 
 from __future__ import annotations
@@ -75,13 +74,22 @@ def _post_with_array_field(
     guard.assert_no_growth()
 
 
-def test_sync_rowhelper_array_field_rejected_gracefully(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
-    _post_with_array_field(webui, smoke_vm, "/pfblockerng/pfblockerng_sync.php", "varsyncusername-0")
+# (page, field) covering every array-TypeError class the theme spans (issue #1070):
+# the 3 directly-guarded fields (explode/base64/trim), plus representatives of the
+# pfb_filter-routed classes closed by the shared guard -- ON_OFF, WORD, NUM -- and
+# the array_key_exists site. All resolve to the same graceful-reject assertion.
+_ARRAY_FIELD_CASES = [
+    ("/pfblockerng/pfblockerng_sync.php", "varsyncusername-0"),  # rowhelper loop
+    ("/pfblockerng/pfblockerng_sync.php", "varsynctimeout"),  # pfb_filter NUM (pre-loop)
+    ("/pfblockerng/pfblockerng_ip.php", "v4suppression"),  # explode/base64
+    ("/pfblockerng/pfblockerng_ip.php", "enable_dup"),  # pfb_filter ON_OFF
+    ("/pfblockerng/pfblockerng_ip.php", "asn_token"),  # pfb_filter WORD
+    ("/pfblockerng/pfblockerng_ip.php", "pfb_alias_delta_mode"),  # array_key_exists
+    ("/pfblockerng/pfblockerng_general.php", "pfb_feed_internal_allowlist"),  # trim
+    ("/pfblockerng/pfblockerng_general.php", "enable_cb"),  # pfb_filter ON_OFF
+]
 
 
-def test_ip_suppression_array_field_rejected_gracefully(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
-    _post_with_array_field(webui, smoke_vm, "/pfblockerng/pfblockerng_ip.php", "v4suppression")
-
-
-def test_general_allowlist_array_field_rejected_gracefully(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
-    _post_with_array_field(webui, smoke_vm, "/pfblockerng/pfblockerng_general.php", "pfb_feed_internal_allowlist")
+@pytest.mark.parametrize(("page", "field"), _ARRAY_FIELD_CASES)
+def test_array_valued_field_rejected_gracefully(webui: WebUI, smoke_vm: helpers.SmokeVM, page: str, field: str) -> None:
+    _post_with_array_field(webui, smoke_vm, page, field)

--- a/tests/smoke/ui/test_post_array_scalar_guards.py
+++ b/tests/smoke/ui/test_post_array_scalar_guards.py
@@ -3,7 +3,7 @@
 The Sync/IP/General settings handlers passed request fields into string
 functions with no scalar coercion; in PHP 8 an array argument (``field[]=x``,
 valid CSRF) throws ``TypeError`` BEFORE the input-errors gate -- an HTTP 500
-plus a fatal in ``php_error.log``. Two guard layers close the theme:
+plus a fatal in ``php_error.log``. Two guard layers close it for these pages:
 
 * the shared ``pfb_filter()`` rejects an array as invalid up front, so every
   ``ON_OFF``/``WORD``/``NUM``-filtered field (the bulk of the sites) is safe
@@ -11,6 +11,11 @@ plus a fatal in ``php_error.log``. Two guard layers close the theme:
 * the three fields that bypass ``pfb_filter`` (the sync rowhelper loop, the IP
   suppression textareas' ``explode``/``base64_encode``, the General allowlist
   ``trim``) plus the IP ``array_key_exists`` site get inline scalar guards.
+
+Scope: this closes issue #1070's enumerated pages plus the ``pfb_filter``
+root for every filter-routed caller. ``pfblockerng_category_edit.php`` has a
+separate cluster of direct-string sinks that bypass ``pfb_filter`` -- tracked
+in #1106, not covered here.
 
 Each save must respond like any validation failure: HTTP 200, no login
 bounce, and NOT ONE new byte in any candidate ``php_error.log``.

--- a/tests/smoke/ui/test_post_array_scalar_guards.py
+++ b/tests/smoke/ui/test_post_array_scalar_guards.py
@@ -1,0 +1,87 @@
+"""issue #1070 -- array-valued $_POST fields must not 500 the settings saves.
+
+Three settings-save handlers passed request fields straight into string
+functions with no scalar coercion; in PHP 8 an array argument
+(``field[]=x``, valid CSRF) throws ``TypeError`` BEFORE the input-errors
+gate -- an HTTP 500 plus a fatal in ``php_error.log``:
+
+* ``pfblockerng_sync.php`` rowhelper loop (``varsyncusername-0[]=x`` hit
+  ``preg_match``/``strlen``) -- now rejects non-scalars up front, mirroring
+  the ``hooks.php`` guard;
+* ``pfblockerng_ip.php`` suppression textareas (``explode``/``base64_encode``)
+  -- now rejected as an input error and blanked;
+* ``pfblockerng_general.php`` feed-host allowlist (``trim``) -- now rejected
+  as an input error before the save gate.
+
+Each save must instead respond like any validation failure: HTTP 200, no
+login bounce, and NOT ONE new byte in any candidate ``php_error.log``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PhpErrorLogGuard
+from .webui import looks_like_login_page, scrape_form_fields
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+# Tier B: mutating POST flows whose failure mode (a logged fatal + HTTP 500)
+# is observable only end-to-end against the live php_error.log. Tier A render
+# coverage of all three pages already exists (test_render_smoke.py).
+pytestmark = pytest.mark.ui_e2e
+
+_POST_TIMEOUT = 120.0
+
+
+def _post_with_array_field(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    page: str,
+    array_field: str,
+) -> None:
+    """Scrape the page's own form, replace one field with an array value, POST.
+
+    Scenario: an authenticated save whose ``{array_field}[]`` carries an array.
+      Given the page's own scraped field set (valid CSRF token included),
+      When the field is re-sent in PHP array syntax and the save is POSTed,
+      Then the handler answers HTTP 200 (a normal validation reject, never a
+        TypeError-driven 500), the session survives, and no candidate
+        ``php_error.log`` gained a byte during the request.
+    """
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    got = webui.get(page)
+    assert got.status_code == 200, f"GET {page} -> HTTP {got.status_code}"
+    assert not looks_like_login_page(got.text), f"GET {page} bounced to the login form"
+
+    payload = scrape_form_fields(got.text)
+    payload.pop(array_field, None)
+    payload[f"{array_field}[]"] = "crafted"
+    payload["save"] = "Save"
+
+    resp = webui.session.post(webui.url(page), data=payload, verify=webui._verify, timeout=_POST_TIMEOUT)
+
+    assert resp.status_code == 200, (
+        f"POST {page} with {array_field}[]=crafted -> HTTP {resp.status_code} "
+        "(expected a graceful validation reject, not a TypeError 500)"
+    )
+    assert not looks_like_login_page(resp.text), f"POST {page} bounced to the login form"
+    guard.assert_no_growth()
+
+
+def test_sync_rowhelper_array_field_rejected_gracefully(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    _post_with_array_field(webui, smoke_vm, "/pfblockerng/pfblockerng_sync.php", "varsyncusername-0")
+
+
+def test_ip_suppression_array_field_rejected_gracefully(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    _post_with_array_field(webui, smoke_vm, "/pfblockerng/pfblockerng_ip.php", "v4suppression")
+
+
+def test_general_allowlist_array_field_rejected_gracefully(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    _post_with_array_field(webui, smoke_vm, "/pfblockerng/pfblockerng_general.php", "pfb_feed_internal_allowlist")


### PR DESCRIPTION
## Summary

Fixes #1070 (theme, 3 sites). Several settings-save handlers passed `$_POST` fields straight into string functions with no scalar coercion; in PHP 8 an array argument (`field[]=x`, valid CSRF) throws `TypeError` **before** the `$input_errors` gate — an HTTP 500 plus a fatal in `php_error.log`. Sibling `pfblockerng_hooks.php` already guards with `is_scalar()`.

## Fix

- `pfblockerng_sync.php` — the XMLRPC rowhelper loop rejects non-scalars up front (`Invalid sync field value.` + `continue`), mirroring the `hooks.php` guard verbatim (`varsyncusername-0[]=x` previously hit `preg_match`/`strlen`).
- `pfblockerng_ip.php` — the `v4suppression`/`v6suppression` textareas are checked before the first `explode()`; an array value is rejected as an input error and the field blanked so every later read (validation loop, `base64_encode` in the error-gated save) stays scalar. An absent field also coerces to `''` (no PHP 8.1 `explode(NULL)` deprecation).
- `pfblockerng_general.php` — the feed-host allowlist is checked before the `if (!$input_errors)` save gate, so an array value blocks the save and the **stored** allowlist is preserved (previously `trim()` threw inside the save block).

## Tests

`tests/smoke/ui/test_post_array_scalar_guards.py` — UI Tier B, one test per handler: scrape the page's own form (valid CSRF), re-send one field in PHP array syntax (`field[]=crafted`), POST, and assert HTTP 200 (a normal validation reject, never a TypeError 500), no login bounce, and **not one new byte** in any candidate `php_error.log` (the `PhpErrorLogGuard` oracle). The failure mode (a logged fatal + 500) is observable only end-to-end against the live VM — the same shape as the #1056/#1064 precedents for this crafted-POST class; Tier A render coverage of all three pages already exists.

Gates: `php -l` clean ×3 · `phpunit` → 2597 tests, 0 failures · `phpstan` no errors · `phpcs` clean · `ruff`/`mypy` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NviP9zgwweu471WhThw6U)_