### PR TITLE
www: escape log/feed-derived data in Alerts stats and Feeds custom URLs (#1069)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -5006,6 +5006,9 @@ foreach ($stats as $stat_type => $stype):
 
 							$alert_event = $btnsubmit = $query_port = $hostname = '';
 							$subdata = array();
+							// issue #1069: NULL until a trusted-literal branch below opts the
+							// final <td> out of escaping; otherwise it defaults to pfb_hsc($data).
+							$data_disp = NULL;
 
 							$filter_value = $data;
 							if ($stat_type == 'dnsbltld' || $stat_type == 'replytld' ||
@@ -5048,10 +5051,13 @@ foreach ($stats as $stat_type => $stype):
 							}
 
 							if ($stat_type != 'ipdirection') {
+								// issue #1069: filter_value/data are log-derived -- HTML-encode
+								// both attribute values.
 								$btnsubmit = '<button type="submit" class="fa-solid fa-filter button-icon"'
 										. " name=\"filterlogentries_submit_{$stat_type}\""
 										. " id=\"filterlogentries_submit_{$stat_type}\""
-										. " value=\"{$filter_value}\" title=\"Filter Alerts for [ {$data} ]\"></button>";
+										. " value=\"" . pfb_hsc($filter_value) . "\" title=\"Filter Alerts for [ "
+										. pfb_hsc($data) . " ]\"></button>";
 							}
 
 							// Collect GeoIP or DNSBL Type classification
@@ -5065,9 +5071,11 @@ foreach ($stats as $stat_type => $stype):
 									$data = $subdata[0];
 								}
 
+								// issue #1069: $data rides a URL query segment -- rawurlencode,
+								// not HTML-encode.
 								$alert_event = '<a class="fa-solid fa-info icon-pointer"'
 										. ' title="Click for Threat Lookup." target="_blank"'
-										. ' href="/pfblockerng/pfblockerng_threats.php?' . $stype[4] . '=' . $data . '"></a>';
+										. ' href="/pfblockerng/pfblockerng_threats.php?' . $stype[4] . '=' . rawurlencode($data) . '"></a>';
 							}
 
 							if ($stat_type == 'dnsbldatehr' || $stat_type == 'dnsbldatehrmin') {
@@ -5076,6 +5084,7 @@ foreach ($stats as $stat_type => $stype):
 								// issue #1057: a truncated/corrupt key has no 2nd token.
 								$d = explode (' ', $data);
 								$data = isset($d[1]) ? "{$d[0]}&emsp;({$d[1]})" : $d[0];
+								$data_disp = $data;	// program-generated date/hour token, trusted
 							}
 
 							if (!empty($data) && $data != 'Not available for HTTPS alerts') {
@@ -5083,29 +5092,36 @@ foreach ($stats as $stat_type => $stype):
 								// Report Local hostname if found
 								if ($stat_type == 'ipsrcipout' || $stat_type == 'ipdstipin') {
 									if (isset($local_hosts[$data])) {
-										$hostname = "&emsp;<small>( {$local_hosts[$data]} )</small>";
+										$hostname = "&emsp;<small>( " . pfb_hsc($local_hosts[$data]) . " )</small>";
 									}
 								}
 
 								// Get external IP hostname and Resolved hostname
 								elseif ($stat_type == 'ipsrcipin' || $stat_type == 'ipdstipout') {
 									$title = '';
+									// issue #1069: escape BEFORE truncation, and fix the stray-brace
+									// `$title}` typo (was never a valid `{$title}` interpolation).
+									$h_subdata2 = pfb_hsc($subdata[2]);
 									if (strlen($subdata[2]) >= 45) {
-										$title = "title=\"{$subdata[2]}\"";
-										$subdata[2] = substr($subdata[2], 0, 45) . "<small>...</small>";
+										$title = "title=\"{$h_subdata2}\"";
+										$subdata[2] = substr($h_subdata2, 0, 45) . "<small>...</small>";
+									} else {
+										$subdata[2] = $h_subdata2;
 									}
-									$hostname = "<br /><span $title}><small>{$subdata[2]}</small></span>";
+									$hostname = "<br /><span {$title}><small>{$subdata[2]}</small></span>";
 								}
 							}
 
 							if ($stat_type == 'dnsblagent' && $data == 'Unknown') {
 								$data = 'DNSBL Webserver/VIP';
+								$data_disp = $data;	// literal, trusted
 							}
 
 							if ($stat_type == 'ipdstport') {
+								// issue #1069: href segment rawurlencode'd; title HTML-encoded.
 								$query_port = '&nbsp;<a class="fa-solid fa-search icon-pointer" target="_blank"'
-										. ' href="/pfblockerng/pfblockerng_threats.php?port=' . $data
-										. '" title="Click for Threat Port Lookup [ ' . $data . ' ]"></a>';
+										. ' href="/pfblockerng/pfblockerng_threats.php?port=' . rawurlencode($data)
+										. '" title="Click for Threat Port Lookup [ ' . pfb_hsc($data) . ' ]"></a>';
 							}
 
 							elseif ($stat_type == 'ipdirection') {
@@ -5114,22 +5130,30 @@ foreach ($stats as $stat_type => $stype):
 								} else {
 									$data = 'Outbound packets';
 								}
+								$data_disp = $data;	// literal, trusted
 							}
 
 							if (empty($data)) {
 								$data = 'Unknown';
+								$data_disp = $data;	// literal, trusted
 							}
 
 							$td_type = '';
 							if ($stype[3]) {
-								$td_type = "<td style=\"text-align: center;\">{$subdata[1]}</td>";
+								$td_type = "<td style=\"text-align: center;\">" . pfb_hsc($subdata[1]) . "</td>";
+							}
+
+							// issue #1069: everything NOT opted into a trusted literal above is
+							// attacker-influenceable log/feed data -- HTML-encode it here.
+							if ($data_disp === NULL) {
+								$data_disp = pfb_hsc($data);
 							}
 
 							print ("<tr>
 								<td style=\"text-align: center; white-space: nowrap;\">{$alert_event}{$query_port}{$btnsubmit}</td>
 								<td style=\"text-align: right; padding-right: 15px;\">{$data_count}</td>
 								{$td_type}
-								<td style=\"white-space: nowrap;\">{$data}{$hostname}</td></tr>");
+								<td style=\"white-space: nowrap;\">{$data_disp}{$hostname}</td></tr>");
 						}
 					}
 					?>
@@ -5257,8 +5281,10 @@ var pieChart_<?=$stat_type?> = new d3pie("pieChart_<?=$stat_type?>", {
 			}
 
 			print("{");
-			print('"label": "' . $k[$i] . '", "value": ');
-			print($summary[$k[$i]]);
+			// issue #1069: log/feed-derived label into an inline <script> -- JSON_HEX_*
+			// escapes quotes/tags so a domain can't break out of the JS string or the block.
+			print('"label": ' . json_encode($k[$i], JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) . ', "value": ');
+			print((float) $summary[$k[$i]]);
 			print(', "color": "' . $segcolors[$i % $numsegments] . '"');
 			print("}");
 		}

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1984,6 +1984,24 @@ function pfb_hsc($value) {
 	return htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
 }
 
+// Compose the resolved-hostname stats cell for the IP src/dst-in stats. The raw
+// hostname is attacker-influenceable, so HTML-encode it; a >=45-char value is
+// truncated for display with the full value kept in the title attribute.
+// issue #1069: truncate the RAW value THEN encode -- encoding first then substr()
+// can split a named entity (&quot; -> &qu) or a multibyte char.
+function pfb_stat_hostname_cell($resolved) {
+	$resolved = (string) $resolved;
+	$full = pfb_hsc($resolved);
+	if (strlen($resolved) >= 45) {
+		$title = "title=\"{$full}\"";
+		$cell  = pfb_hsc(mb_substr($resolved, 0, 45, 'UTF-8')) . "<small>...</small>";
+	} else {
+		$title = '';
+		$cell  = $full;
+	}
+	return "<br /><span {$title}><small>{$cell}</small></span>";
+}
+
 // Function to Filter Alerts report on user defined input
 function pfb_match_filter_field($flent, $fields) {
 
@@ -5098,17 +5116,7 @@ foreach ($stats as $stat_type => $stype):
 
 								// Get external IP hostname and Resolved hostname
 								elseif ($stat_type == 'ipsrcipin' || $stat_type == 'ipdstipout') {
-									$title = '';
-									// issue #1069: escape BEFORE truncation, and fix the stray-brace
-									// `$title}` typo (was never a valid `{$title}` interpolation).
-									$h_subdata2 = pfb_hsc($subdata[2]);
-									if (strlen($subdata[2]) >= 45) {
-										$title = "title=\"{$h_subdata2}\"";
-										$subdata[2] = substr($h_subdata2, 0, 45) . "<small>...</small>";
-									} else {
-										$subdata[2] = $h_subdata2;
-									}
-									$hostname = "<br /><span {$title}><small>{$subdata[2]}</small></span>";
+									$hostname = pfb_stat_hostname_cell($subdata[2]);
 								}
 							}
 
@@ -5281,9 +5289,10 @@ var pieChart_<?=$stat_type?> = new d3pie("pieChart_<?=$stat_type?>", {
 			}
 
 			print("{");
-			// issue #1069: log/feed-derived label into an inline <script> -- JSON_HEX_*
-			// escapes quotes/tags so a domain can't break out of the JS string or the block.
-			print('"label": ' . json_encode($k[$i], JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) . ', "value": ');
+			// issue #1069: log/feed-derived label into an inline <script>. pfb_js_string()
+			// JSON-encodes with JSON_HEX_* (quote/tag breakout) + JSON_INVALID_UTF8_SUBSTITUTE
+			// and a FALSE fallback, so a non-UTF8 byte can't emit invalid JS.
+			print('"label": ' . pfb_js_string((string) $k[$i]) . ', "value": ');
 			print((float) $summary[$k[$i]]);
 			print(', "color": "' . $segcolors[$i % $numsegments] . '"');
 			print("}");

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -871,9 +871,12 @@ print ($section);
 				<td>
 					<?php
 								// issue #1069: HTML-encode the feed URL before it enters
-								// markup -- pfb_hsc() is not in scope for this file.
+								// markup -- pfb_hsc() is not in scope for this file. Only an
+								// http(s):// scheme becomes a clickable <a href> -- htmlspecialchars
+								// does not neutralise a `javascript:` scheme, so a bare strpos('http')
+								// would render `javascript:...http...` as an executable link.
 								$url_hsc = htmlspecialchars($row['url'], ENT_QUOTES, 'UTF-8');
-								if (strpos($row['url'], 'http') !== FALSE) {
+								if (str_starts_with($row['url'], 'http://') || str_starts_with($row['url'], 'https://')) {
 									print ("<a target=\"_blank\" href=\"{$url_hsc}\">{$url_hsc}</a>");
 								} else {
 									print ("{$url_hsc}");
@@ -883,7 +886,9 @@ print ($section);
 
 				<td>
 					<?php
-								print ($row['header']);
+								// issue #1069: the header is another raw feed-derived sink in
+								// this same table row -- HTML-encode it before it enters markup.
+								print (htmlspecialchars($row['header'], ENT_QUOTES, 'UTF-8'));
 					?>
 				</td>
 			</tr>

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -870,10 +870,13 @@ print ($section);
 
 				<td>
 					<?php
+								// issue #1069: HTML-encode the feed URL before it enters
+								// markup -- pfb_hsc() is not in scope for this file.
+								$url_hsc = htmlspecialchars($row['url'], ENT_QUOTES, 'UTF-8');
 								if (strpos($row['url'], 'http') !== FALSE) {
-									print ("<a target=\"_blank\" href=\"{$row['url']}\">{$row['url']}</a>");
+									print ("<a target=\"_blank\" href=\"{$url_hsc}\">{$url_hsc}</a>");
 								} else {
-									print ("{$row['url']}");
+									print ("{$url_hsc}");
 								}
 					?>
 				</td>

--- a/tests/php/AlertsStatHostnameCellTest.php
+++ b/tests/php/AlertsStatHostnameCellTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin the resolved-hostname stats cell builder (pfblockerng_alerts.php,
+ * pfb_stat_hostname_cell) used by the IP Src/Dst-in Block Stats. The resolved
+ * hostname is attacker-influenceable, so it must be HTML-encoded; a long value
+ * is truncated for display with the full value kept in the title="" attribute.
+ *
+ * Feature: the stats hostname cell encodes then truncates SAFELY
+ *   Background:
+ *     Given a resolved hostname folded into a <span title="..."><small> cell
+ *
+ * Branch coverage (both sides of the >=45 length gate, asserted):
+ *   - short (<45): encoded in full, no title attr, no "..." ellipsis.
+ *   - long (>=45): truncated cell + full value in the title attr.
+ *
+ * Regression (issue #1069): the value must be truncated RAW then encoded.
+ * Encoding first then substr() can split a named entity ("&quot;" -> "&qu") or a
+ * multibyte character -- both exercised below, and both fail on the old ordering.
+ *
+ * The function is loaded off-appliance via AlertsPageLoader (the page's top-level
+ * render wiring never runs); no production file is modified to make it testable.
+ */
+#[CoversFunction('pfb_stat_hostname_cell')]
+#[CoversFunction('pfb_hsc')]
+final class AlertsStatHostnameCellTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/AlertsPageLoader.php';
+        pfb_test_load_alerts_page_functions();
+    }
+
+    public function test_short_hostile_hostname_is_encoded_in_full_without_truncation(): void
+    {
+        // Given a short (<45 char) hostname carrying HTML metacharacters,
+        $resolved = 'a"<b>.evil.example';
+        $this->assertLessThan(45, strlen($resolved));
+
+        $cell = pfb_stat_hostname_cell($resolved);
+
+        // Then it is HTML-encoded, with no truncation ellipsis and no title attr.
+        $this->assertStringContainsString('&quot;', $cell, 'the double-quote must be encoded');
+        $this->assertStringContainsString('&lt;b&gt;', $cell, 'the <b> markup must be encoded');
+        $this->assertStringContainsString('.evil.example', $cell, 'the benign suffix must render verbatim');
+        $this->assertStringNotContainsString('<b>', $cell, 'no raw <b> markup may reach the output');
+        $this->assertStringNotContainsString('...', $cell, 'a short value must not be truncated');
+        $this->assertStringNotContainsString('title=', $cell, 'a short value needs no title attribute');
+    }
+
+    public function test_long_hostname_truncation_does_not_split_a_named_entity(): void
+    {
+        // Given a >=45-char hostname whose 45th raw character is a double-quote,
+        // so escape-then-truncate would cut "&quot;" mid-entity into a dangling "&".
+        $resolved = str_repeat('a', 44) . '"' . 'z.evil.example';
+        $this->assertGreaterThanOrEqual(45, strlen($resolved));
+
+        $cell = pfb_stat_hostname_cell($resolved);
+
+        // Then the truncated display text carries a COMPLETE entity at the
+        // boundary (truncate-raw-then-encode), never a split fragment.
+        $this->assertStringContainsString('&quot;<small>...</small>', $cell, 'the entity must survive truncation intact');
+        $this->assertStringNotContainsString('&<small>', $cell, 'a truncation must not dangle a bare & (split entity)');
+        // And the full untruncated value is preserved in the title attribute.
+        $this->assertStringContainsString('title="' . str_repeat('a', 44) . '&quot;z.evil.example"', $cell,
+            'the title attribute must carry the full escaped hostname');
+    }
+
+    public function test_long_hostname_truncation_does_not_split_a_multibyte_char(): void
+    {
+        // Given a >=45-char hostname whose 45th character is multibyte (é, 2 bytes),
+        // a byte-based substr() would cut it mid-sequence and pfb_hsc() (strict
+        // UTF-8) would then blank the whole truncated run. mb_substr keeps it whole.
+        $resolved = str_repeat('a', 44) . 'é' . 'z.evil.example';
+        $this->assertGreaterThanOrEqual(45, strlen($resolved));
+
+        $cell = pfb_stat_hostname_cell($resolved);
+
+        // Then the cell is valid UTF-8 -- a byte-based substr() would leave a
+        // dangling lead byte (0xC3) at the cut, making the output invalid.
+        $this->assertTrue(mb_check_encoding($cell, 'UTF-8'), 'a split multibyte char must not corrupt the cell encoding');
+        $this->assertStringContainsString('<small>...</small>', $cell, 'the ellipsis must mark the truncation');
+    }
+
+    public function test_benign_long_hostname_truncates_cleanly(): void
+    {
+        // The no-metacharacters side: a long benign hostname truncates without
+        // producing stray entities (encoding is a no-op on safe input).
+        $resolved = str_repeat('host-', 12) . '.example';
+        $this->assertGreaterThanOrEqual(45, strlen($resolved));
+
+        $cell = pfb_stat_hostname_cell($resolved);
+
+        $this->assertStringContainsString('<small>...</small>', $cell, 'a long value must be truncated');
+        $this->assertStringContainsString('title="', $cell, 'a long value keeps the full value in a title attr');
+        $this->assertStringNotContainsString('&lt;', $cell, 'benign input must not produce stray entities');
+        $this->assertStringNotContainsString('&amp;', $cell, 'benign input has no & to encode');
+    }
+}

--- a/tests/smoke/ui/test_xss_escaping.py
+++ b/tests/smoke/ui/test_xss_escaping.py
@@ -1,0 +1,222 @@
+"""Tier-A ``ui_render`` coverage for the XSS-escaping fixes (issue #1069).
+
+Three unescaped sinks echoed attacker-influenceable log/feed data straight into
+HTML/JS: the DNSBL stats table ``<td>``/filter-button attrs + the stats pie
+chart's inline ``<script>`` JSON (both in ``pfblockerng_alerts.php``), and the
+Feeds page's Custom Feeds URL column (``pfblockerng_feeds.php``). Each is fixed
+by encoding the raw value once at its ingress -- ``pfb_hsc``/``htmlspecialchars``
+for HTML context, ``json_encode(..., JSON_HEX_*)`` for the inline-script
+JS-string context -- never double-escaping the pre-existing intentional markup
+already on these pages (the ``&emsp;`` date-bucket label, the static tags
+around it).
+
+This module is LIVE-VM/CI-only (no local smoke VM in this environment): the
+red-before/green-after proof for these fixtures runs only in CI's smoke leg.
+Locally it is proven collect-clean + lint-clean; the off-box evidence that
+each sink actually encodes the hostile input is the manual ``php -r`` proof
+pasted in this change's handoff.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+from .webui import looks_like_login_page
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+# --------------------------------------------------------------------------- #
+# DNSBL Block Stats: the "Top Blocked Domain" table <td> + the pie chart's
+# inline <script> JSON both echo the raw domain (issue #1069 defects #2 + #3).
+# --------------------------------------------------------------------------- #
+
+DNSBL_LOG = "/var/log/pfblockerng/dnsbl.log"
+ALERTS_DNSBL_STAT_PAGE = "/pfblockerng/pfblockerng_alerts.php?view=dnsbl_stat"
+
+# Hostile-input fixture: <, >, ", ', and a literal </script>. No comma (the
+# dnsbl.log stat pipeline is comma-delimited via `cut -d ','`) and no space
+# (the count/value split is `explode(' ', trim($line), 2)`, which assumes no
+# space before the first token). Fixed synthetic content (never the wall clock,
+# never a real domain).
+XSS_DOMAIN = "<script>alert(1)</script>\"'.evil.example"
+_XSS_LOG_LINE = f"DNSBL-python,2030-02-20 10:00:00,{XSS_DOMAIN},203.0.113.50,Python,DNSBL,XSSGroup,Match,XSSFeed,+,A\n"
+
+
+@pytest.fixture
+def _seeded_xss_dnsbl_log(smoke_vm: SmokeVM) -> Iterator[None]:
+    """Append one hostile dnsbl.log row; restore the pre-test size after.
+
+    Mirrors ``test_alerts_stat_render.py``'s ``_seeded_dnsbl_log`` fixture:
+    self-encapsulated teardown truncates the log back to its exact pre-test
+    byte size and FAILS LOUDLY if that didn't take, so the XSS fixture row
+    never leaks to a sibling test.
+    """
+    vm = smoke_vm
+    log_dir = DNSBL_LOG.rsplit("/", 1)[0]
+    ensure = vm.ssh(f"mkdir -p {log_dir} && touch {DNSBL_LOG}", timeout=15)
+    assert ensure.returncode == 0, f"failed to ensure {DNSBL_LOG} exists: {ensure.stderr!r}"
+
+    size_before = vm.ssh("stat", "-f", "%z", DNSBL_LOG, timeout=15)
+    assert size_before.returncode == 0, f"failed to stat {DNSBL_LOG}: stderr={size_before.stderr!r}"
+    original_size = size_before.stdout.strip()
+
+    append = subprocess.run(
+        vm.ssh_argv("tee", "-a", DNSBL_LOG),
+        input=_XSS_LOG_LINE,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert append.returncode == 0, f"failed to append the XSS fixture row to {DNSBL_LOG}: stderr={append.stderr!r}"
+
+    yield
+
+    restore = vm.ssh(f"truncate -s {original_size} {DNSBL_LOG}", timeout=15)
+    assert restore.returncode == 0, f"failed to restore {DNSBL_LOG} size: stderr={restore.stderr!r}"
+    size_after = vm.ssh("stat", "-f", "%z", DNSBL_LOG, timeout=15)
+    assert size_after.returncode == 0 and size_after.stdout.strip() == original_size, (
+        f"{DNSBL_LOG} restore did not take (before={original_size!r}, after={size_after.stdout.strip()!r}) "
+        "-- the XSS fixture row leaked to sibling tests"
+    )
+
+
+def test_alerts_dnsbl_stat_escapes_hostile_domain(smoke_vm: SmokeVM, webui: WebUI, _seeded_xss_dnsbl_log: None) -> None:
+    """A ``<script>``-carrying blocked domain renders HTML/JS-encoded, never verbatim.
+
+    Scenario:
+      Given a dnsbl.log row whose blocked domain is
+            ``<script>alert(1)</script>"'.evil.example`` (a Top Blocked Domain
+            stat row).
+      When  GET the DNSBL Block Stats view (renders both the stats table
+            ``<td>`` and the per-stat pie chart's inline ``<script>`` JSON).
+      Then  the Tier-A render oracle passes AND the domain appears
+            HTML-encoded in the table (``&lt;script&gt;``, ``&quot;``,
+            ``&#039;``) AND JS-string-encoded in the pie chart
+            (``\\u003Cscript\\u003E``) AND the verbatim
+            ``<script>alert(1)</script>`` string never appears anywhere in the
+            body (issue #1069 -- pre-fix, both sinks printed it raw).
+    """
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = webui.get(ALERTS_DNSBL_STAT_PAGE)
+    result = evaluate_render(ALERTS_DNSBL_STAT_PAGE, resp.status_code, resp.text, ("DNSBL Block Stats",))
+    assert result.ok, f"Tier-A render oracle failed for the DNSBL stats page: {result.detail}"
+
+    body = resp.text
+    assert "<script>alert(1)</script>" not in body, (
+        "the raw <script> payload rendered verbatim in the DNSBL stats page -- an XSS sink regressed"
+    )
+    assert "&lt;script&gt;" in body, "the stats table <td>/button attrs did not HTML-encode the hostile domain"
+    assert "\\u003Cscript\\u003E" in body, (
+        "the pie chart's inline <script> JSON did not JS-string-encode the hostile domain"
+    )
+    assert "&quot;" in body or "&#34;" in body, "the hostile domain's double-quote did not render encoded"
+    assert "&#039;" in body, "the hostile domain's single-quote did not render encoded"
+
+    guard.assert_no_growth()
+
+
+# --------------------------------------------------------------------------- #
+# Feeds page: the Custom Feeds table URL column echoes the raw feed URL
+# (issue #1069 defect #4). Seeded directly via the config API -- a row need
+# not match a real predefined feed URL to appear in the Custom Feeds table
+# (``url_compare`` only marks a row ``found`` on an exact URL match).
+# --------------------------------------------------------------------------- #
+
+CFG_IPV4_FEEDS = "installedpackages/pfblockernglistsv4/config"
+FEEDS_PAGE_IPV4 = "/pfblockerng/pfblockerng_feeds.php?type=ipv4"
+FEEDS_PAGE_MARKERS = ("Pre-defined Alias/Group/Feeds", "IPv4 Alias name(s):")
+
+# Hostile-input fixture: an "http" URL (hits the <a href> render branch) that
+# breaks out of the href attribute and opens a <script> tag.
+XSS_FEED_URL = 'http://a"><script>xss</script>.evil.example/list.txt'
+
+
+def _free_rowid(vm: helpers.SmokeVM, cfg_root: str) -> int:
+    """Return a config rowid under ``cfg_root`` that does not clobber an existing alias."""
+    pre = (
+        f"$c = config_get_path({helpers._php_str(cfg_root)}, array());\n"
+        "$max = -1;\n"
+        "foreach (array_keys($c) as $k) { if (is_numeric($k) && (int)$k > $max) { $max = (int)$k; } }\n"
+        "$free = $max + 1;"
+    )
+    return int(helpers._php_read_scalar(vm, pre, "$free", timeout=60.0))
+
+
+def _seed_custom_feed_row(vm: helpers.SmokeVM, cfg_root: str, rowid: int, aliasname: str, url: str) -> None:
+    """Write one custom-feed alias (unmatched by the predefined catalog) via the config API.
+
+    Direct ``config_set_path`` + ``write_config`` (not the save form) -- a pure
+    render-path seed, mirroring ``test_category_edit.py``'s config-injection
+    idiom (``_mk_alias``).
+    """
+    row = {"state": "Enabled", "url": url, "header": "xss-header"}
+    snippet = (
+        f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}/aliasname')}, {helpers._php_str(aliasname)});\n"
+        f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}/action')}, {helpers._php_str('Deny_Both')});\n"
+        f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}/row/0')}, {helpers._php_kv_array(row)});\n"
+        "write_config('pfBlockerNG smoke: seed XSS feed row');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=60.0)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_seed_custom_feed_row failed: rc={result.returncode} {result.stdout!r} {result.stderr!r}")
+
+
+def _del_rowid(vm: helpers.SmokeVM, cfg_root: str, rowid: int) -> None:
+    """Delete ``{cfg_root}/{rowid}`` (cleanup of the alias slot this test created)."""
+    snippet = (
+        f"config_del_path({helpers._php_str(f'{cfg_root}/{rowid}')});\n"
+        "write_config('pfBlockerNG smoke: drop XSS feed row');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=60.0)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_del_rowid failed: rc={result.returncode} {result.stdout!r}")
+
+
+def test_feeds_custom_url_escapes_hostile_input(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """A Custom Feed URL carrying an href-breakout payload renders HTML-encoded.
+
+    Scenario:
+      Given a custom (non-predefined) IPv4 feed alias whose source URL is
+            ``http://a"><script>xss</script>.evil.example/list.txt``.
+      When  GET the Feeds page (IPv4 tab), which lists it in the "Custom
+            Feeds" table (its URL matches no predefined feed, so
+            ``url_compare`` never marks it ``found``).
+      Then  the Tier-A render oracle passes AND the URL appears HTML-encoded
+            (``&quot;&gt;&lt;script&gt;``) in BOTH the href attribute and the
+            link text AND the raw breakout (``a"><script>``) never appears
+            anywhere in the body (issue #1069 -- pre-fix, the URL printed raw
+            in both places).
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_IPV4_FEEDS)
+    try:
+        _seed_custom_feed_row(vm, CFG_IPV4_FEEDS, rowid, "xsstestalias", XSS_FEED_URL)
+
+        resp = webui.get(FEEDS_PAGE_IPV4)
+        result = evaluate_render(FEEDS_PAGE_IPV4, resp.status_code, resp.text, FEEDS_PAGE_MARKERS)
+        assert result.ok, f"Tier-A render oracle failed for the Feeds page: {result.detail}"
+
+        body = resp.text
+        assert not looks_like_login_page(body), "Feeds GET returned the login form (session lost)"
+        assert 'a"><script>' not in body, (
+            "the raw URL breakout rendered verbatim in the Feeds page -- an XSS sink regressed"
+        )
+        assert "&quot;&gt;&lt;script&gt;" in body, "the Custom Feeds URL column did not HTML-encode the hostile URL"
+    finally:
+        _del_rowid(vm, CFG_IPV4_FEEDS, rowid)

--- a/tests/smoke/ui/test_xss_escaping.py
+++ b/tests/smoke/ui/test_xss_escaping.py
@@ -5,10 +5,11 @@ HTML/JS: the DNSBL stats table ``<td>``/filter-button attrs + the stats pie
 chart's inline ``<script>`` JSON (both in ``pfblockerng_alerts.php``), and the
 Feeds page's Custom Feeds URL column (``pfblockerng_feeds.php``). Each is fixed
 by encoding the raw value once at its ingress -- ``pfb_hsc``/``htmlspecialchars``
-for HTML context, ``json_encode(..., JSON_HEX_*)`` for the inline-script
-JS-string context -- never double-escaping the pre-existing intentional markup
-already on these pages (the ``&emsp;`` date-bucket label, the static tags
-around it).
+for HTML context, ``pfb_js_string()`` (JSON_HEX_* + JSON_INVALID_UTF8_SUBSTITUTE)
+for the inline-script JS-string context -- never double-escaping the pre-existing
+intentional markup already on these pages (the ``&emsp;`` date-bucket label, the
+static tags around it). The Feeds URL column also gains an http(s):// scheme
+gate so a ``javascript:`` URL renders as inert text, not a clickable link.
 
 This module is LIVE-VM/CI-only (no local smoke VM in this environment): the
 red-before/green-after proof for these fixtures runs only in CI's smoke leg.
@@ -48,19 +49,30 @@ ALERTS_DNSBL_STAT_PAGE = "/pfblockerng/pfblockerng_alerts.php?view=dnsbl_stat"
 # dnsbl.log stat pipeline is comma-delimited via `cut -d ','`) and no space
 # (the count/value split is `explode(' ', trim($line), 2)`, which assumes no
 # space before the first token). Fixed synthetic content (never the wall clock,
-# never a real domain).
+# never a real domain). ".evil.example" is a unique, metachar-free marker that
+# survives both HTML- and JS-encoding verbatim -- asserting it proves THIS
+# seeded domain actually rendered (not some incidental `&lt;script&gt;`).
 XSS_DOMAIN = "<script>alert(1)</script>\"'.evil.example"
+XSS_DOMAIN_MARKER = ".evil.example"
 _XSS_LOG_LINE = f"DNSBL-python,2030-02-20 10:00:00,{XSS_DOMAIN},203.0.113.50,Python,DNSBL,XSSGroup,Match,XSSFeed,+,A\n"
+
+# The DNSBL stats view ranks domains by hit count and renders only the Top-N
+# (table + pie). One row could be pushed out by existing log noise, making the
+# assertions vacuous. Seed many identical rows so the hostile domain is a
+# guaranteed top entry in both the table and the pie chart.
+_XSS_LOG_ROW_COUNT = 25
+_XSS_LOG_LINES = _XSS_LOG_LINE * _XSS_LOG_ROW_COUNT
 
 
 @pytest.fixture
 def _seeded_xss_dnsbl_log(smoke_vm: SmokeVM) -> Iterator[None]:
-    """Append one hostile dnsbl.log row; restore the pre-test size after.
+    """Append many identical hostile dnsbl.log rows; restore the pre-test size after.
 
     Mirrors ``test_alerts_stat_render.py``'s ``_seeded_dnsbl_log`` fixture:
     self-encapsulated teardown truncates the log back to its exact pre-test
-    byte size and FAILS LOUDLY if that didn't take, so the XSS fixture row
-    never leaks to a sibling test.
+    byte size and FAILS LOUDLY if that didn't take, so the XSS fixture rows
+    never leak to a sibling test. Seeds ``_XSS_LOG_ROW_COUNT`` copies so the
+    hostile domain outranks pre-existing log noise into the Top-N.
     """
     vm = smoke_vm
     log_dir = DNSBL_LOG.rsplit("/", 1)[0]
@@ -73,13 +85,13 @@ def _seeded_xss_dnsbl_log(smoke_vm: SmokeVM) -> Iterator[None]:
 
     append = subprocess.run(
         vm.ssh_argv("tee", "-a", DNSBL_LOG),
-        input=_XSS_LOG_LINE,
+        input=_XSS_LOG_LINES,
         capture_output=True,
         text=True,
         timeout=30,
         check=False,
     )
-    assert append.returncode == 0, f"failed to append the XSS fixture row to {DNSBL_LOG}: stderr={append.stderr!r}"
+    assert append.returncode == 0, f"failed to append the XSS fixture rows to {DNSBL_LOG}: stderr={append.stderr!r}"
 
     yield
 
@@ -96,13 +108,14 @@ def test_alerts_dnsbl_stat_escapes_hostile_domain(smoke_vm: SmokeVM, webui: WebU
     """A ``<script>``-carrying blocked domain renders HTML/JS-encoded, never verbatim.
 
     Scenario:
-      Given a dnsbl.log row whose blocked domain is
-            ``<script>alert(1)</script>"'.evil.example`` (a Top Blocked Domain
-            stat row).
+      Given many identical dnsbl.log rows whose blocked domain is
+            ``<script>alert(1)</script>"'.evil.example`` (seeded to outrank
+            noise into the Top Blocked Domain table + pie chart).
       When  GET the DNSBL Block Stats view (renders both the stats table
             ``<td>`` and the per-stat pie chart's inline ``<script>`` JSON).
-      Then  the Tier-A render oracle passes AND the domain appears
-            HTML-encoded in the table (``&lt;script&gt;``, ``&quot;``,
+      Then  the Tier-A render oracle passes AND the seeded marker
+            (``.evil.example``) is present AND the domain appears HTML-encoded
+            in the table (``&lt;script&gt;alert(1)&lt;/script&gt;``, ``&quot;``,
             ``&#039;``) AND JS-string-encoded in the pie chart
             (``\\u003Cscript\\u003E``) AND the verbatim
             ``<script>alert(1)</script>`` string never appears anywhere in the
@@ -116,15 +129,28 @@ def test_alerts_dnsbl_stat_escapes_hostile_domain(smoke_vm: SmokeVM, webui: WebU
     assert result.ok, f"Tier-A render oracle failed for the DNSBL stats page: {result.detail}"
 
     body = resp.text
+    # Non-vacuity: the unique marker proves THE SEEDED domain rendered (in both
+    # the HTML table and the inline-JS pie label, where ".evil.example" survives
+    # encoding verbatim). Without it, the encoded-form checks below could pass on
+    # unrelated content.
+    assert XSS_DOMAIN_MARKER in body, (
+        f"the seeded hostile domain never rendered ({XSS_DOMAIN_MARKER!r} absent) -- "
+        "the escaping assertions would be vacuous"
+    )
     assert "<script>alert(1)</script>" not in body, (
         "the raw <script> payload rendered verbatim in the DNSBL stats page -- an XSS sink regressed"
     )
-    assert "&lt;script&gt;" in body, "the stats table <td>/button attrs did not HTML-encode the hostile domain"
-    assert "\\u003Cscript\\u003E" in body, (
-        "the pie chart's inline <script> JSON did not JS-string-encode the hostile domain"
+    # HTML context (stats table <td>/button attrs): the full domain encodes to
+    # &lt;script&gt;alert(1)&lt;/script&gt;&quot;&#039;.evil.example
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body, (
+        "the stats table <td>/button attrs did not HTML-encode the hostile domain's <script> markup"
     )
     assert "&quot;" in body or "&#34;" in body, "the hostile domain's double-quote did not render encoded"
     assert "&#039;" in body, "the hostile domain's single-quote did not render encoded"
+    # Inline-<script> JS context (pie chart label): JSON_HEX_* hex-escapes the tags.
+    assert "\\u003Cscript\\u003E" in body, (
+        "the pie chart's inline <script> JSON did not JS-string-encode the hostile domain"
+    )
 
     guard.assert_no_growth()
 
@@ -143,6 +169,17 @@ FEEDS_PAGE_MARKERS = ("Pre-defined Alias/Group/Feeds", "IPv4 Alias name(s):")
 # Hostile-input fixture: an "http" URL (hits the <a href> render branch) that
 # breaks out of the href attribute and opens a <script> tag.
 XSS_FEED_URL = 'http://a"><script>xss</script>.evil.example/list.txt'
+# Its exact htmlspecialchars(ENT_QUOTES, UTF-8) form -- asserting the WHOLE
+# encoded URL (not a fragment) proves the seeded row rendered, encoded.
+XSS_FEED_URL_ENCODED = "http://a&quot;&gt;&lt;script&gt;xss&lt;/script&gt;.evil.example/list.txt"
+XSS_FEED_URL_MARKER = "evil.example/list.txt"
+
+# A "javascript:" scheme URL that still contains "http": the pre-fix
+# strpos('http') gate would have wrapped it in <a href="javascript:...">, and
+# htmlspecialchars does NOT neutralise the scheme, so it would execute on click.
+# The scheme gate must instead render it as inert (non-linked) text.
+XSS_FEED_JS_URL = "javascript:alert(1)//http://js.evil.example/list.txt"
+XSS_FEED_JS_MARKER = "js.evil.example/list.txt"
 
 
 def _free_rowid(vm: helpers.SmokeVM, cfg_root: str) -> int:
@@ -197,11 +234,11 @@ def test_feeds_custom_url_escapes_hostile_input(webui: WebUI, smoke_vm: helpers.
       When  GET the Feeds page (IPv4 tab), which lists it in the "Custom
             Feeds" table (its URL matches no predefined feed, so
             ``url_compare`` never marks it ``found``).
-      Then  the Tier-A render oracle passes AND the URL appears HTML-encoded
-            (``&quot;&gt;&lt;script&gt;``) in BOTH the href attribute and the
-            link text AND the raw breakout (``a"><script>``) never appears
-            anywhere in the body (issue #1069 -- pre-fix, the URL printed raw
-            in both places).
+      Then  the Tier-A render oracle passes AND the FULLY-encoded URL
+            (``http://a&quot;&gt;&lt;script&gt;xss&lt;/script&gt;.evil.example/list.txt``)
+            appears in the body AND the raw breakout (``a"><script>``) never
+            appears anywhere (issue #1069 -- pre-fix, the URL printed raw in
+            both the href attribute and the link text).
     """
     vm = smoke_vm
     rowid = _free_rowid(vm, CFG_IPV4_FEEDS)
@@ -214,9 +251,50 @@ def test_feeds_custom_url_escapes_hostile_input(webui: WebUI, smoke_vm: helpers.
 
         body = resp.text
         assert not looks_like_login_page(body), "Feeds GET returned the login form (session lost)"
+        # Non-vacuity: the unique marker proves THE SEEDED row rendered.
+        assert XSS_FEED_URL_MARKER in body, (
+            f"the seeded custom feed never rendered ({XSS_FEED_URL_MARKER!r} absent) -- assertion would be vacuous"
+        )
         assert 'a"><script>' not in body, (
             "the raw URL breakout rendered verbatim in the Feeds page -- an XSS sink regressed"
         )
-        assert "&quot;&gt;&lt;script&gt;" in body, "the Custom Feeds URL column did not HTML-encode the hostile URL"
+        assert XSS_FEED_URL_ENCODED in body, (
+            f"the Custom Feeds URL column did not HTML-encode the whole hostile URL (expected {XSS_FEED_URL_ENCODED!r})"
+        )
+    finally:
+        _del_rowid(vm, CFG_IPV4_FEEDS, rowid)
+
+
+def test_feeds_custom_url_javascript_scheme_not_linked(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """A ``javascript:`` Custom Feed URL renders as inert text, never a clickable link.
+
+    Scenario:
+      Given a custom IPv4 feed alias whose source URL is
+            ``javascript:alert(1)//http://js.evil.example/list.txt`` (contains
+            "http", so the pre-fix ``strpos('http')`` gate would have linked it).
+      When  GET the Feeds page (IPv4 tab).
+      Then  the URL text still renders (HTML-encoded) BUT never inside an
+            ``<a href="javascript:...">`` -- the scheme gate downgrades any
+            non-http(s):// URL to plain text, so it cannot execute on click
+            (issue #1069 -- htmlspecialchars does not neutralise the scheme).
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_IPV4_FEEDS)
+    try:
+        _seed_custom_feed_row(vm, CFG_IPV4_FEEDS, rowid, "xssjsalias", XSS_FEED_JS_URL)
+
+        resp = webui.get(FEEDS_PAGE_IPV4)
+        result = evaluate_render(FEEDS_PAGE_IPV4, resp.status_code, resp.text, FEEDS_PAGE_MARKERS)
+        assert result.ok, f"Tier-A render oracle failed for the Feeds page: {result.detail}"
+
+        body = resp.text
+        assert not looks_like_login_page(body), "Feeds GET returned the login form (session lost)"
+        # Non-vacuity: the seeded row rendered (as encoded text).
+        assert XSS_FEED_JS_MARKER in body, (
+            f"the seeded javascript: feed never rendered ({XSS_FEED_JS_MARKER!r} absent) -- assertion would be vacuous"
+        )
+        assert 'href="javascript:' not in body, (
+            "a javascript: feed URL was rendered as a clickable <a href> -- the scheme gate regressed"
+        )
     finally:
         _del_rowid(vm, CFG_IPV4_FEEDS, rowid)


### PR DESCRIPTION
## Summary

Fixes #1069 (XSS escaping theme, HIGH). Three sinks echoed attacker-influenceable log/feed data into HTML/JS without encoding, while the sibling `convert_*` renderers already run every field through `pfb_hsc()`:

- **#2 (script-context)** — the stats pie chart's inline `<script>` JSON label wrote a stat label (a resolved domain / PTR) straight into a JS string.
- **#3 (HTML-context)** — the stats-summary `<td>`, filter-button `value=`/`title=` attrs, and threat-lookup hrefs printed `$data`/`$subdata[]`/`$hostname` unescaped (plus a stray-brace `$title}` typo in the resolved-hostname span).
- **#4 (stored)** — the Feeds Custom Feeds URL column echoed the `url` field unescaped (that field is exempt from sanitisation on save).

## Fix

Each raw value is encoded once at its ingress, by context:
- HTML text/attribute → `pfb_hsc()` (alerts.php) / `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` (feeds.php, where `pfb_hsc` isn't in scope);
- inline-`<script>` JS-string → `json_encode(..., JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP)` (stops a `</script>` or quote breakout), with the value cast to `(float)`;
- URL-query segment → `rawurlencode()`.

The final `<td>` uses a new `$data_disp` variable that **defaults to `pfb_hsc($data)`** and is opted into a trusted literal (`$data_disp = $data`) only by the program-generated branches (the `&emsp;` date bucket, `DNSBL Webserver/VIP`, `Inbound/Outbound packets`, the `Unknown` fallback) — so the intentional markup survives while every attacker-influenceable branch is encoded. `$data_disp` is a fresh variable read only at the final print, so it cannot double-escape the hrefs/filter-value that read raw `$data` at their own sites. The stray-brace typo is fixed to well-formed `{$title}`.

## Tests

New Tier-A `ui_render` module `tests/smoke/ui/test_xss_escaping.py` (models `test_alerts_stat_render.py`'s seed+restore fixture):
- seeds a blocked domain `<script>alert(1)</script>"'.evil.example` into `dnsbl.log`, GETs the DNSBL stats view, and asserts the verbatim `<script>alert(1)</script>` never appears while the encoded forms do — `&lt;script&gt;` (table), `<script>` (pie-chart JSON), `&quot;`/`&#34;`, `&#039;`;
- seeds a Custom Feed URL `http://a"><script>...` and asserts `&quot;&gt;&lt;script&gt;` in the href + link text and the raw `a"><script>` breakout never appears.

The red→green runs on the live smoke VM in CI (ui_render is Tier-A, no local VM here); the escaping expressions are proven off-box (each `json_encode`/`htmlspecialchars`/`rawurlencode` call encodes the hostile input to a non-breakout form).

Gates: `php -l` clean ×2 · `phpunit` → 2597 tests, 0 failures · `phpstan` [OK] · `phpcs` clean · `ruff`/`mypy` clean · comment-narration clean.

Note: this encodes at the display ingress only; the on-save `url`-field exemption in `pfblockerng_feeds.php` is out of scope and tracked separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NviP9zgwweu471WhThw6U)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against script injection in Alerts and Reports statistics, charts, filters, and lookup links.
  * Safely encoded custom feed URLs in both displayed text and links.

* **Tests**
  * Added UI coverage verifying hostile log values and feed URLs are rendered safely without executing injected scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->