### PR TITLE
pfblockerng: purge stale change-detect probe bodies at install (#1098)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12420,6 +12420,17 @@ function pfb_hash_write($base, $path) {
 	return $ok;
 }
 
+// issue #1098: a pre-#1072 corrupted probe body (.md5.raw) would be reused verbatim by
+// the next sync ingest — purge at install/upgrade.
+function pfb_purge_probe_bodies() {
+	global $pfb;
+	foreach (array($pfb['origdir'], $pfb['dnsorigdir']) as $dir) {
+		foreach (glob("{$dir}/*.md5.raw") ?: array() as $probe_body) {
+			unlink_if_exists($probe_body);
+		}
+	}
+}
+
 // ADR-42: map a probe ('change_detect' mode) download path to the feed's persisted
 // conditional-GET validator baseline.  The detector (pfb_update_check) persists the
 // ETag/Last-Modified sidecars at {header}.orig (pfb_validator_write on its $local_file),

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12424,9 +12424,14 @@ function pfb_hash_write($base, $path) {
 // the next sync ingest — purge at install/upgrade.
 function pfb_purge_probe_bodies() {
 	global $pfb;
-	foreach (array($pfb['origdir'], $pfb['dnsorigdir']) as $dir) {
+	foreach (array($pfb['origdir'] ?? '', $pfb['dnsorigdir'] ?? '') as $dir) {
+		if ($dir === '' || !is_dir($dir)) {	// never glob an empty dir value (would sweep '/')
+			continue;
+		}
+		// Direct @unlink, NOT unlink_if_exists(): the latter re-globs its argument, so a
+		// metachar-named leftover could survive; glob() already resolved a literal path.
 		foreach (glob("{$dir}/*.md5.raw") ?: array() as $probe_body) {
-			unlink_if_exists($probe_body);
+			@unlink($probe_body);
 		}
 	}
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -582,6 +582,10 @@ if (file_exists('/var/db/pfblockerng/dnsbl_info') &&
 }
 unlink_if_exists('/var/db/pfblockerng/dnsbl_info');
 
+// issue #1098: purge any leftover change-detect probe body ({header}.md5.raw) so a
+// pre-#1072 corrupted one is never reused verbatim by the next sync ingest.
+pfb_purge_probe_bodies();
+
 // Move dnsbl_levent.sqlite -> /var/unbound folder
 $ufound = FALSE;
 if (file_exists('/var/db/pfblockerng/dnsbl_levent.sqlite') && !file_exists($pfb['dnsbl_resolver'])) {

--- a/tests/php/CreateSuppressionFileTest.php
+++ b/tests/php/CreateSuppressionFileTest.php
@@ -115,6 +115,9 @@ final class CreateSuppressionFileTest extends TestCase
 	{
 		$warnings = [];
 		set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+			if ((error_reporting() & $errno) === 0) {
+				return true; // @-suppressed (production-silent, e.g. unlink_if_exists' @unlink) -- not a finding
+			}
 			$warnings[] = $errstr;
 			return true; // swallow -- we assert on the collected list instead
 		}, E_WARNING);

--- a/tests/php/ProbeBodyPurgeTest.php
+++ b/tests/php/ProbeBodyPurgeTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1098: purge stale change-detect probe bodies ({header}.md5.raw) at
+ * install/upgrade, so a pre-#1072 corrupted probe body left on disk can never be
+ * reused verbatim by the next sync ingest (pfb_download's reuse fork trusts any
+ * existing .md5.raw — see pfblockerng.inc's "re-utilize instead of downloading
+ * twice" branch).
+ */
+#[CoversFunction('pfb_purge_probe_bodies')]
+final class ProbeBodyPurgeTest extends TestCase
+{
+	private string $dir;
+	private string $origdir;
+	private string $dnsorigdir;
+	private ?string $savedOrigdir;
+	private ?string $savedDnsorigdir;
+
+	protected function setUp(): void
+	{
+		$base = sys_get_temp_dir() . '/pfb_probe_purge_test_' . getmypid() . '_' . mt_rand(0, 0xffff);
+		$this->dir = $base;
+		$this->origdir = "{$base}/original";
+		$this->dnsorigdir = "{$base}/dnsblorig";
+		if (!mkdir($this->origdir, 0777, TRUE) || !mkdir($this->dnsorigdir, 0777, TRUE)) {
+			$this->fail("Could not create temp dirs under: {$base}");
+		}
+
+		$this->savedOrigdir = $GLOBALS['pfb']['origdir'] ?? NULL;
+		$this->savedDnsorigdir = $GLOBALS['pfb']['dnsorigdir'] ?? NULL;
+		$GLOBALS['pfb']['origdir'] = $this->origdir;
+		$GLOBALS['pfb']['dnsorigdir'] = $this->dnsorigdir;
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->savedOrigdir === NULL) {
+			unset($GLOBALS['pfb']['origdir']);
+		} else {
+			$GLOBALS['pfb']['origdir'] = $this->savedOrigdir;
+		}
+		if ($this->savedDnsorigdir === NULL) {
+			unset($GLOBALS['pfb']['dnsorigdir']);
+		} else {
+			$GLOBALS['pfb']['dnsorigdir'] = $this->savedDnsorigdir;
+		}
+
+		$it = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($this->dir, FilesystemIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($it as $f) {
+			$f->isDir() ? rmdir($f->getPathname()) : unlink($f->getPathname());
+		}
+		rmdir($this->dir);
+	}
+
+	/**
+	 * R1: a planted {h}.md5.raw in origdir is purged.
+	 *
+	 *  GIVEN a stale probe body sitting in origdir;
+	 *   WHEN pfb_purge_probe_bodies() is called;
+	 *   THEN the probe body no longer exists.
+	 */
+	public function test_purges_stale_probe_body_in_origdir(): void
+	{
+		$probe = "{$this->origdir}/feedA.md5.raw";
+		file_put_contents($probe, 'corrupted probe body bytes');
+		$this->assertFileExists($probe, 'Precondition: probe body must exist before purge');
+
+		pfb_purge_probe_bodies();
+
+		$this->assertFileDoesNotExist(
+			$probe,
+			'pfb_purge_probe_bodies() must remove a stale .md5.raw probe body from origdir'
+		);
+	}
+
+	/**
+	 * R2: a planted {h}.md5.raw in dnsorigdir is purged.
+	 *
+	 *  GIVEN a stale probe body sitting in dnsorigdir;
+	 *   WHEN pfb_purge_probe_bodies() is called;
+	 *   THEN the probe body no longer exists.
+	 */
+	public function test_purges_stale_probe_body_in_dnsorigdir(): void
+	{
+		$probe = "{$this->dnsorigdir}/feedB.md5.raw";
+		file_put_contents($probe, 'corrupted probe body bytes');
+		$this->assertFileExists($probe, 'Precondition: probe body must exist before purge');
+
+		pfb_purge_probe_bodies();
+
+		$this->assertFileDoesNotExist(
+			$probe,
+			'pfb_purge_probe_bodies() must remove a stale .md5.raw probe body from dnsorigdir'
+		);
+	}
+
+	/**
+	 * R3: sibling artifacts survive the purge in both dirs — only the exact
+	 * '*.md5.raw' probe-body glob is in scope; the ingest body, the finalised
+	 * baseline, and every sidecar format must remain untouched.
+	 *
+	 *  GIVEN a probe body plus its non-probe siblings (.orig, legacy .md5,
+	 *        .xxhash128, .etag, .lastmod, and a bare .raw ingest body) in both
+	 *        origdir and dnsorigdir;
+	 *   WHEN pfb_purge_probe_bodies() is called;
+	 *   THEN every sibling file still exists (only the .md5.raw is gone).
+	 */
+	public function test_leaves_sibling_artifacts_untouched_in_both_dirs(): void
+	{
+		$siblingSuffixes = array('.orig', '.md5', '.xxhash128', '.etag', '.lastmod', '.raw');
+
+		foreach (array($this->origdir, $this->dnsorigdir) as $dir) {
+			file_put_contents("{$dir}/feedC.md5.raw", 'stale probe body');
+			foreach ($siblingSuffixes as $sfx) {
+				file_put_contents("{$dir}/feedC{$sfx}", "sibling artifact {$sfx}");
+			}
+		}
+
+		pfb_purge_probe_bodies();
+
+		foreach (array($this->origdir, $this->dnsorigdir) as $dir) {
+			$this->assertFileDoesNotExist(
+				"{$dir}/feedC.md5.raw",
+				"the probe body in {$dir} must be purged"
+			);
+			foreach ($siblingSuffixes as $sfx) {
+				$this->assertFileExists(
+					"{$dir}/feedC{$sfx}",
+					"sibling artifact feedC{$sfx} in {$dir} must survive the purge (not a .md5.raw probe body)"
+				);
+			}
+		}
+	}
+
+	/**
+	 * R4: a nonexistent dir produces no error/warning — glob() on a missing path
+	 * returns FALSE, which the `?: array()` fallback must absorb silently.
+	 *
+	 *  GIVEN origdir points at a path that does not exist on disk;
+	 *   WHEN pfb_purge_probe_bodies() is called;
+	 *   THEN it completes without raising a warning/error.
+	 */
+	public function test_nonexistent_dir_completes_without_error(): void
+	{
+		$GLOBALS['pfb']['origdir'] = "{$this->dir}/does_not_exist";
+
+		$raised = NULL;
+		set_error_handler(function (int $errno, string $errstr) use (&$raised): bool {
+			$raised = $errstr;
+			return TRUE;
+		});
+		pfb_purge_probe_bodies();
+		restore_error_handler();
+
+		$this->assertNull(
+			$raised,
+			sprintf('pfb_purge_probe_bodies() must not raise a warning/error for a missing dir, got: %s', $raised)
+		);
+	}
+
+	/**
+	 * R5: a hostile filename (embedded space) is purged correctly — glob()/unlink()
+	 * are native filesystem calls, not shell, so no escaping is required or possible
+	 * to bypass.
+	 *
+	 *  GIVEN a probe body named with an embedded space;
+	 *   WHEN pfb_purge_probe_bodies() is called;
+	 *   THEN that file is removed.
+	 */
+	public function test_purges_probe_body_with_embedded_space_in_filename(): void
+	{
+		$probe = "{$this->origdir}/weird name.md5.raw";
+		file_put_contents($probe, 'stale probe body');
+		$this->assertFileExists($probe, 'Precondition: probe body with embedded space must exist before purge');
+
+		pfb_purge_probe_bodies();
+
+		$this->assertFileDoesNotExist(
+			$probe,
+			'pfb_purge_probe_bodies() must purge a probe body whose filename has an embedded space'
+		);
+	}
+
+	/**
+	 * R6: source-pin (install.inc is not loadable by the unit harness — see
+	 * InstallDnsblMoveRestartGuardTest). Pins the install-time wiring the harness
+	 * cannot execute: pfb_purge_probe_bodies() must actually be called.
+	 *
+	 *  GIVEN the pfblockerng_install.inc source;
+	 *   THEN it contains the literal call 'pfb_purge_probe_bodies();'.
+	 */
+	public function test_install_inc_calls_purge_probe_bodies(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
+		$src = @file_get_contents($path);
+		$this->assertIsString($src, "could not read {$path}");
+
+		$this->assertStringContainsString(
+			'pfb_purge_probe_bodies();',
+			$src,
+			'pfblockerng_install.inc must call pfb_purge_probe_bodies() at install/upgrade'
+		);
+	}
+}

--- a/tests/php/ProbeBodyPurgeTest.php
+++ b/tests/php/ProbeBodyPurgeTest.php
@@ -141,8 +141,8 @@ final class ProbeBodyPurgeTest extends TestCase
 	}
 
 	/**
-	 * R4: a nonexistent dir produces no error/warning — glob() on a missing path
-	 * returns FALSE, which the `?: array()` fallback must absorb silently.
+	 * R4: a nonexistent dir is skipped by the is_dir guard — the purge completes
+	 * silently without raising a warning/error.
 	 *
 	 *  GIVEN origdir points at a path that does not exist on disk;
 	 *   WHEN pfb_purge_probe_bodies() is called;
@@ -157,8 +157,11 @@ final class ProbeBodyPurgeTest extends TestCase
 			$raised = $errstr;
 			return TRUE;
 		});
-		pfb_purge_probe_bodies();
-		restore_error_handler();
+		try {
+			pfb_purge_probe_bodies();
+		} finally {
+			restore_error_handler();
+		}
 
 		$this->assertNull(
 			$raised,
@@ -167,9 +170,45 @@ final class ProbeBodyPurgeTest extends TestCase
 	}
 
 	/**
-	 * R5: a hostile filename (embedded space) is purged correctly — glob()/unlink()
-	 * are native filesystem calls, not shell, so no escaping is required or possible
-	 * to bypass.
+	 * R7: an UNSET dir key is skipped silently (no "Undefined array key" warning) and
+	 * must not abort the sweep of the other dir — an unset/empty value must never
+	 * widen the glob towards '/'.
+	 *
+	 *  GIVEN $pfb['origdir'] is unset and a stale probe body sits in dnsorigdir;
+	 *   WHEN pfb_purge_probe_bodies() is called;
+	 *   THEN no warning is raised AND the dnsorigdir probe body is still purged.
+	 */
+	public function test_unset_dir_key_skipped_and_other_dir_still_purged(): void
+	{
+		unset($GLOBALS['pfb']['origdir']);
+		$probe = "{$this->dnsorigdir}/feedD.md5.raw";
+		file_put_contents($probe, 'stale probe body');
+		$this->assertFileExists($probe, 'Precondition: probe body must exist before purge');
+
+		$raised = NULL;
+		set_error_handler(function (int $errno, string $errstr) use (&$raised): bool {
+			$raised = $errstr;
+			return TRUE;
+		});
+		try {
+			pfb_purge_probe_bodies();
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertNull(
+			$raised,
+			sprintf('pfb_purge_probe_bodies() must not warn on an unset dir key, got: %s', $raised)
+		);
+		$this->assertFileDoesNotExist(
+			$probe,
+			'an unset origdir must not stop the dnsorigdir sweep'
+		);
+	}
+
+	/**
+	 * R5: a hostile filename (embedded space) is purged correctly — glob() and
+	 * unlink() take literal paths here, no shell is involved.
 	 *
 	 *  GIVEN a probe body named with an embedded space;
 	 *   WHEN pfb_purge_probe_bodies() is called;
@@ -190,12 +229,44 @@ final class ProbeBodyPurgeTest extends TestCase
 	}
 
 	/**
+	 * R8: a glob-metacharacter filename is purged, alongside a coincidental sibling
+	 * the bracket pattern would match. Pins the direct-@unlink contract: re-globbing
+	 * the resolved path (unlink_if_exists() behaviour) would delete only the sibling
+	 * and leave the bracket-named leftover on disk.
+	 *
+	 *  GIVEN probe bodies 'weird[z].md5.raw' and 'weirdz.md5.raw' in origdir
+	 *        ('[' sorts before 'z', so the sweep reaches the bracket name first);
+	 *   WHEN pfb_purge_probe_bodies() is called;
+	 *   THEN both files are removed.
+	 */
+	public function test_purges_glob_metachar_filename_and_its_glob_decoy(): void
+	{
+		$target = "{$this->origdir}/weird[z].md5.raw";
+		$decoy  = "{$this->origdir}/weirdz.md5.raw";
+		file_put_contents($target, 'stale probe body (bracket name)');
+		file_put_contents($decoy, 'stale probe body (decoy)');
+		$this->assertFileExists($target, 'Precondition: bracket-named probe body must exist before purge');
+		$this->assertFileExists($decoy, 'Precondition: decoy probe body must exist before purge');
+
+		pfb_purge_probe_bodies();
+
+		$this->assertFileDoesNotExist(
+			$target,
+			'a glob-metachar-named probe body must be unlinked literally, not re-globbed away'
+		);
+		$this->assertFileDoesNotExist(
+			$decoy,
+			'the decoy probe body matches *.md5.raw and must be purged too'
+		);
+	}
+
+	/**
 	 * R6: source-pin (install.inc is not loadable by the unit harness — see
 	 * InstallDnsblMoveRestartGuardTest). Pins the install-time wiring the harness
-	 * cannot execute: pfb_purge_probe_bodies() must actually be called.
+	 * cannot execute: a LIVE (uncommented) pfb_purge_probe_bodies() call.
 	 *
 	 *  GIVEN the pfblockerng_install.inc source;
-	 *   THEN it contains the literal call 'pfb_purge_probe_bodies();'.
+	 *   THEN a line calls pfb_purge_probe_bodies(); with no comment marker before it.
 	 */
 	public function test_install_inc_calls_purge_probe_bodies(): void
 	{
@@ -203,10 +274,10 @@ final class ProbeBodyPurgeTest extends TestCase
 		$src = @file_get_contents($path);
 		$this->assertIsString($src, "could not read {$path}");
 
-		$this->assertStringContainsString(
-			'pfb_purge_probe_bodies();',
+		$this->assertMatchesRegularExpression(
+			'/^[ \t]*pfb_purge_probe_bodies\(\);/m',
 			$src,
-			'pfblockerng_install.inc must call pfb_purge_probe_bodies() at install/upgrade'
+			'pfblockerng_install.inc must contain a live (uncommented, statement-position) pfb_purge_probe_bodies() call'
 		);
 	}
 }

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -207,11 +207,18 @@ if (!function_exists('rmdir_recursive')) {
 }
 
 if (!function_exists('unlink_if_exists')) {
-	function unlink_if_exists($path) {
-		if (is_file($path) || is_link($path)) {
-			return @unlink($path);
+	// Mirrors the real pfSense util.inc implementation: the argument is a glob
+	// PATTERN, not a literal path — matches are unlinked, an empty match falls
+	// back to a literal @unlink. Tests must model that re-glob behaviour.
+	function unlink_if_exists($fn) {
+		$to_do = glob($fn);
+		if (is_array($to_do) && count($to_do) > 0) {
+			$results = @array_map("unlink", $to_do);
+			$result = !in_array(false, $results, true);
+		} else {
+			$result = @unlink($fn);
 		}
-		return false;
+		return $result;
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1098. PR #1095 stopped `pfb_download()`'s cURL retry loop from producing a corrupted (partial+full concatenated) body going forward, but a corrupted `{header}.md5.raw` probe body left on disk by a **pre-fix** run survives the upgrade: `pfb_download()`'s reuse fork ("re-utilize instead of downloading twice") feeds it verbatim into the next sync ingest before the end-of-call cleanup removes it.

Hash-verifying the reuse path against the ADR-42 sidecar cannot discriminate here — the probe computed its hash over the already-corrupted body, and a mismatch against the persisted baseline is precisely the "changed" signal that scheduled the ingest. The effective fix is invalidating the artifact class once at upgrade.

## Fix

New `pfb_purge_probe_bodies()` (`pfblockerng.inc`, beside the ADR-42 sidecar helpers) sweeps `{origdir,dnsorigdir}/*.md5.raw`, called from `pfblockerng_install.inc` next to the existing legacy-artifact cleanup. Purging is fail-safe: a missing `.md5.raw` simply makes the sync ingest download fresh; sibling artifacts (`.orig`, `.md5`, `.xxhash128`, `.etag`, `.lastmod`, bare `.raw`) are untouched.

## Tests

New `tests/php/ProbeBodyPurgeTest.php` (6 tests):

- purge in `origdir` / purge in `dnsorigdir` (before-state asserted);
- all six sibling artifact suffixes survive in both dirs (real planted fixtures);
- nonexistent dir completes without a warning (`glob() ?: array()`);
- hostile filename with an embedded space is purged (native glob+unlink, no shell);
- source-level pin that `pfblockerng_install.inc` calls `pfb_purge_probe_bodies();` (install.inc is not loadable by the unit harness — same approach as `InstallDnsblMoveRestartGuardTest`).

Red→green executed (source files reverted, tests kept): red = `Tests: 6, Errors: 5, Failures: 1` (undefined function + missing install.inc call); green = `OK (6 tests, 23 assertions)`.

Gates: `php -l` both files clean · `phpunit` 2671 tests / 19474 assertions OK · `phpstan` no errors · `phpcs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMandwby8X7gcMiUBQpPbG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Install and upgrade processes now remove stale probe body files.
  * Prevents corrupted data from being reused during subsequent synchronization.
  * Cleanup safely handles missing directories and filenames containing spaces.

* **Tests**
  * Added coverage to verify targeted cleanup while preserving unrelated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->