### PR TITLE
scripts: make docstring close detection escape-aware in check_version_literals

### DIFF
--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -283,6 +283,27 @@ def _tracked_files(roots: tuple[str, ...]) -> list[Path]:
 _TRIPLE_QUOTE_TOKENS = ('"""', "'''")
 
 
+def _py_triple_close_count(line: str, token: str) -> int:
+    """Count real, escape-aware ``token`` occurrences in an OPEN docstring line.
+
+    issue #1090: a backslash-escaped delimiter (``\\` + token``) is body text,
+    not a close -- mirrors ``_py_docstring_probe``'s in-triple escape handling,
+    restricted to counting the already-known open token.
+    """
+    count = 0
+    i, n = 0, len(line)
+    while i < n:
+        if line[i] == "\\":
+            i += 2
+            continue
+        if line[i : i + 3] == token:
+            count += 1
+            i += 3
+            continue
+        i += 1
+    return count
+
+
 def _py_docstring_probe(line: str) -> str:
     """Reduce ``line`` to its real triple-quote delimiters plus bare code.
 
@@ -383,7 +404,7 @@ def _code_lines(lines: list[str], suffix: str) -> list[str | None]:
     for line in lines:
         if open_token:
             out.append(None)
-            if line.count(open_token) % 2 == 1:
+            if _py_triple_close_count(line, open_token) % 2 == 1:
                 open_token = ""
             continue
         if line.lstrip().startswith("#"):

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -286,7 +286,7 @@ _TRIPLE_QUOTE_TOKENS = ('"""', "'''")
 def _py_triple_close_count(line: str, token: str) -> int:
     """Count real, escape-aware ``token`` occurrences in an OPEN docstring line.
 
-    issue #1090: a backslash-escaped delimiter (``\\` + token``) is body text,
+    issue #1090: a backslash-escaped delimiter (a backslash before ``token``) is body text,
     not a close -- mirrors ``_py_docstring_probe``'s in-triple escape handling,
     restricted to counting the already-known open token.
     """

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -981,3 +981,132 @@ def test_py_escaped_quote_keeps_triple_span_open(tmp_path: Path) -> None:
     # version token there must stay masked until the real close.
     content = 'x = """abc \\"""\n' + '_ABI = "' + _FREEBSD15 + '"\n' + '"""\n'
     assert _find_py(tmp_path, content) == [], "prose inside a still-open escape-carrying triple string must stay masked"
+
+
+# --- issue #1090: escaped delimiter inside an open docstring body must not be
+# --- miscounted as a genuine close by _code_lines' CLOSE-side parity check ----
+
+
+def test_py_escaped_delim_inside_open_docstring_does_not_falsely_close(tmp_path: Path) -> None:
+    # issue #1090: a backslash-escaped """ inside an OPEN docstring body is body
+    # text, not a close -- the value-shaped prose line right after it must stay
+    # masked, and only the real code literal after the real close is flagged
+    # (pre-fix: raw count=1 on the escaped line wrongly closed the docstring
+    # there and flagged the prose line instead).
+    content = (
+        '"""Doc.\n'
+        + "escaped: \\"
+        + '"""'
+        + "\n"
+        + 'VERSION = "'
+        + _CE28
+        + '"\n'
+        + '"""\n'
+        + '_ABI = "'
+        + _FREEBSD15
+        + '"\n'
+    )
+    violations = _find_py(tmp_path, content)
+    assert len(violations) == 1, f"expected exactly the real code literal flagged; got {violations}"
+    assert violations[0][1] == 5, f"expected lineno 5 (real code), got {violations[0][1]}"
+
+
+def test_py_escaped_delim_then_real_close_on_same_line_still_closes(tmp_path: Path) -> None:
+    # issue #1090: an escaped """ earlier on the line must not count toward
+    # parity -- only the later REAL """ closes the docstring, so the code right
+    # after it is flagged (pre-fix: raw count=2 on this line kept it "open",
+    # masking the code line -- a parity inversion / false negative).
+    content = '"""Doc.\n' + "\\" + '"""' + " real " + '"""' + "\n" + '_ABI = "' + _FREEBSD15 + '"\n'
+    violations = _find_py(tmp_path, content)
+    assert len(violations) == 1, f"expected the code literal on line 3 flagged; got {violations}"
+    assert violations[0][1] == 3
+
+
+def test_py_escaped_backslash_then_real_close_still_closes(tmp_path: Path) -> None:
+    # Green oracle: an escaped backslash (\\) just before """ does not consume
+    # the delimiter, so the REAL close still closes and code after it is
+    # flagged -- pins that the escape-skip does not overcount (must hold both
+    # pre- and post-fix).
+    content = '"""Doc.\n' + "\\\\" + '"""' + "\n" + '_ABI = "' + _FREEBSD15 + '"\n'
+    violations = _find_py(tmp_path, content)
+    assert len(violations) == 1, f"expected the code literal on line 3 flagged; got {violations}"
+    assert violations[0][1] == 3
+
+
+def test_py_escaped_backslash_then_escaped_quote_keeps_docstring_open(tmp_path: Path) -> None:
+    # issue #1090: \\\" (an escaped backslash, then an escaped quote) leaves
+    # only two bare quotes -- not a close. The docstring stays open, so the
+    # value-shaped prose line right after it must stay masked entirely
+    # (pre-fix: raw count=1 on this line wrongly closed it and flagged the
+    # prose line).
+    content = '"""Doc.\n' + "\\" * 3 + '"""' + "\n" + 'VERSION = "' + _CE28 + '"\n' + '"""\n'
+    violations = _find_py(tmp_path, content)
+    assert violations == [], f"prose after a still-open docstring must stay masked; got {violations}"
+
+
+def test_py_escaped_delim_inside_open_raw_docstring_does_not_falsely_close(tmp_path: Path) -> None:
+    # issue #1090, prefix-transparency: a raw-string docstring (r\"\"\") gets the
+    # same escape-aware close count as a plain one -- the escaped delimiter
+    # inside its body must not falsely close it either.
+    content = (
+        'r"""Doc.\n' + "\\" + '"""' + "\n" + 'VERSION = "' + _CE28 + '"\n' + '"""\n' + '_ABI = "' + _FREEBSD15 + '"\n'
+    )
+    violations = _find_py(tmp_path, content)
+    assert len(violations) == 1, f"expected only the last-line code literal flagged; got {violations}"
+    assert violations[0][1] == 5
+
+
+def test_py_escaped_delim_inside_open_single_quote_docstring_does_not_falsely_close(tmp_path: Path) -> None:
+    # issue #1090, single-quote-token sibling of the """ rows above: the
+    # escaped delimiter sits alone at line start; the same escape-aware count
+    # applies to ''' as it does to """.
+    content = (
+        "'''Doc.\n" + "\\" + "'''" + "\n" + 'VERSION = "' + _CE28 + '"\n' + "'''\n" + '_ABI = "' + _FREEBSD15 + '"\n'
+    )
+    violations = _find_py(tmp_path, content)
+    assert len(violations) == 1, f"expected only the last-line code literal flagged; got {violations}"
+    assert violations[0][1] == 5
+
+
+def test_py_close_and_reopen_on_one_line_still_stays_open(tmp_path: Path) -> None:
+    # Green oracle: two REAL """ on one line (close + reopen) is an EVEN count,
+    # so the docstring stays open per the existing parity semantics -- untouched
+    # by the escape-aware fix. Must hold both pre- and post-fix.
+    content = (
+        '"""Doc.\n'
+        + '"""'
+        + " reopened "
+        + '"""'
+        + "\n"
+        + 'VERSION = "'
+        + _CE28
+        + '"\n'
+        + '"""\n'
+        + '_ABI = "'
+        + _FREEBSD15
+        + '"\n'
+    )
+    violations = _find_py(tmp_path, content)
+    assert len(violations) == 1, f"expected only the code line flagged; got {violations}"
+    assert violations[0][1] == 5
+
+
+def test_py_trailing_backslash_in_open_docstring_does_not_crash(tmp_path: Path) -> None:
+    # Green oracle: a body line ending in a single bare backslash must not
+    # crash the escape-skip (it runs past end-of-line); the docstring stays
+    # open until the real close, then the real code literal is flagged.
+    content = (
+        '"""Doc.\n'
+        + "trailing backslash \\"
+        + "\n"
+        + 'VERSION = "'
+        + _CE28
+        + '"\n'
+        + '"""\n'
+        + '_ABI = "'
+        + _FREEBSD15
+        + '"\n'
+    )
+    violations = _find_py(tmp_path, content)
+    assert len(violations) == 1, f"expected only the code line flagged; got {violations}"
+    assert violations[0][1] == 5

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -1069,14 +1069,15 @@ def test_py_escaped_delim_inside_open_single_quote_docstring_does_not_falsely_cl
 
 
 def test_py_close_and_reopen_on_one_line_still_stays_open(tmp_path: Path) -> None:
-    # Green oracle: two REAL """ on one line (close + reopen) is an EVEN count,
-    # so the docstring stays open per the existing parity semantics -- untouched
-    # by the escape-aware fix. Must hold both pre- and post-fix.
+    # Green oracle: two REAL """ on one line (docstring close + a new triple
+    # string reopening) is an EVEN count, so the span stays open per the
+    # existing parity semantics -- untouched by the escape-aware fix. Also pins
+    # an EMPTY line inside the open span staying masked. Must hold both pre-
+    # and post-fix.
     content = (
         '"""Doc.\n'
-        + '"""'
-        + " reopened "
-        + '"""'
+        + '""";y = """'
+        + "\n"
         + "\n"
         + 'VERSION = "'
         + _CE28
@@ -1088,7 +1089,7 @@ def test_py_close_and_reopen_on_one_line_still_stays_open(tmp_path: Path) -> Non
     )
     violations = _find_py(tmp_path, content)
     assert len(violations) == 1, f"expected only the code line flagged; got {violations}"
-    assert violations[0][1] == 5
+    assert violations[0][1] == 6
 
 
 def test_py_trailing_backslash_in_open_docstring_does_not_crash(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #1090.

## Problem

`_code_lines` in `scripts/check_version_literals.py` detected the close of a multi-line Python docstring with a raw parity count (`line.count(open_token) % 2 == 1`). Unlike the open-side probe (escape-aware since PR #1086 / issue #1082), this treated a backslash-escaped delimiter inside the docstring body as a genuine close. Both directions were confirmed by executed repro with `ast.parse` as the ground-truth oracle:

- **False positive:** a body line containing `\"""` prematurely "closes" the docstring, so the remaining docstring prose is scanned as code — a value-shaped prose line like `VERSION = "2.8"` gets flagged.
- **False negative (parity inversion):** an escaped delimiter followed by a real close on the same line (`\""" ... """`) counts as 2 → even → the checker keeps the docstring "open", masking real version literals in the code that follows.

Not currently exploitable in-tree (the full scan is clean), but the checker is itself a pre-commit + CI gate, so a false positive blocks a legitimate commit and a false negative silently waives the gate.

## Fix

New escape-aware helper `_py_triple_close_count(line, token)` — mirroring `_py_docstring_probe`'s in-triple escape handling, restricted to the already-known open token: a backslash skips two characters; a 3-character token match counts one. `_code_lines`'s close branch now uses it; the parity semantics themselves (a close-and-reopen on one line stays open) are unchanged. No raw-/f-prefix special-casing is needed: Python tokenization forbids a backslash from preceding a closing quote even in raw strings, and prefix characters never reach this branch.

## Tests (hostile-input matrix, red→green executed)

Eight new tests in `tests/test_version_literal_check.py` (issue #1090 section, joining the #1082 siblings). The five behaviour-changing rows fail on the pre-fix checker for exactly the enumerated reasons (`5 failed, 76 passed`) and pass after (`81 passed`); re-executed independently by the orchestrator gate via `git checkout HEAD~1 -- scripts/check_version_literals.py`.

| Row | Input (inside an open docstring) | Expected | Pre-fix |
| --- | --- | --- | --- |
| H1 | body line with escaped delimiter `\"""` | does not close; only the real code literal after the real close is flagged | RED (flagged the prose line) |
| H2 | `\""" … """` (escaped + real close, same line) | closes; following code literal flagged | RED (masked) |
| H3 | `\\"""` (escaped backslash + real close) | closes | green oracle |
| H4 | `\\\"""` (escaped backslash + escaped quote) | stays open; prose stays masked | RED (flagged the prose line) |
| H5 | raw-string docstring (`r"""`), body `\"""` | same as H1 (prefix-transparent) | RED |
| H6 | `'''`-token sibling, `\'''` at line start | same as H1 | RED |
| H7 | `""";y = """` (docstring close + a new triple string reopening on one line, plus an empty body line) | stays open (parity semantics preserved); empty line stays masked | green oracle |
| H8 | body line ending in a bare trailing `\` | no crash; stays open | green oracle |

Deferred rows: f-prefix (identical code path — prefix chars never inspected; H5 pins prefix-transparency); close-at-line-start (pinned by the existing `test_py_real_docstring_block_still_masks_prose`); open-side escapes (pinned by the existing #1082 tests, untouched).

The adversarial review found the original H7 fixture was not valid Python (STRING/NAME juxtaposition); it was replaced with a parseable equivalent verified against `ast.parse`, proven green under both the pre-fix and post-fix checker (true oracle) and red under a parity-breaking mutation (failable).

## Gates

`python3 -m pytest` (2635 passed, 4 skipped) · `ruff check .` · `ruff format --check .` · `mypy tests/` · `python3 scripts/check_version_literals.py` (full scan, rc 0) · `python3 scripts/check_version_literals.py --diff origin/devel` (rc 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMandwby8X7gcMiUBQpPbG
