### PR TITLE
pfblockerng: guard the 5 unguarded destination fopen() sites (#1097)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1902,6 +1902,13 @@ function pfb_dnsblip_mark_reprocess($action, string $vtype): void {
 	}
 }
 
+// Only an exact full-length fwrite() counts as written -- FALSE or a short (disk-full)
+// write must fail the assembly, or a truncated destination would advance the rebuild
+// bookkeeping as current. Same rule as pfb_prefetch_pattern_file_write_ok().
+function pfb_dnsbl_concat_write_ok($written, string $line): bool {
+	return $written !== FALSE && $written === strlen($line);
+}
+
 // issue #1097: fwrite(FALSE)/fclose(FALSE) throw TypeError on PHP 8 ('@' only
 // silences warnings) -- guard both the destination and each source open. An
 // empty $src is skipped before fopen(): PHP 8 throws ValueError for it too.
@@ -1911,7 +1918,12 @@ function pfb_dnsbl_concat_files(string $dest, array $sources): bool {
 			$src = (string) $src;
 			if ($src !== '' && ($in = @fopen($src, 'r')) !== FALSE) {
 				while (($line = @fgets($in)) !== FALSE) {
-					@fwrite($out, $line);
+					if (!pfb_dnsbl_concat_write_ok(@fwrite($out, $line), $line)) {
+						@fclose($in);
+						@fclose($out);
+						pfb_logger("\nDNSBL: write failed for [ {$dest} ] -- assembly aborted", 2);
+						return FALSE;
+					}
 				}
 				@fclose($in);
 			}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -17077,17 +17077,22 @@ function sync_package_pfblockerng($cron='') {
 		list($pfb_dnsblip_rebuild, $pfb_dnsblip_fp) = pfb_dnsblip_rebuild_check($dnsblip_v4, $dnsbl_ip, "{$dnsblip_v4}.fp");
 
 		if ($pfb_dnsblip_rebuild) {
+			$pfb_dnsblip_built = TRUE;
 			if (!empty($dnsbl_ip)) {
-				pfb_dnsbl_concat_files($dnsblip_v4, $dnsbl_ip);
+				$pfb_dnsblip_built = pfb_dnsbl_concat_files($dnsblip_v4, $dnsbl_ip);
 			}
 
 			// Add empty placeholder IP
 			else {
 				@file_put_contents($dnsblip_v4, "{$pfb['ip_ph']}\n", LOCK_EX);
 			}
-			@file_put_contents("{$dnsblip_v4}.fp", $pfb_dnsblip_fp, LOCK_EX);
-			unlink_if_exists($pfb['ip_cache']);
-			pfb_dnsblip_mark_reprocess($pfb['dnsbl_ip'], '_v4');
+			// issue #1097: a failed rebuild must not advance the fingerprint -- a stamped
+			// .fp marks the stale output current and suppresses every future retry.
+			if ($pfb_dnsblip_built) {
+				@file_put_contents("{$dnsblip_v4}.fp", $pfb_dnsblip_fp, LOCK_EX);
+				unlink_if_exists($pfb['ip_cache']);
+				pfb_dnsblip_mark_reprocess($pfb['dnsbl_ip'], '_v4');
+			}
 		}
 	}
 
@@ -17109,17 +17114,21 @@ function sync_package_pfblockerng($cron='') {
 		list($pfb_dnsblip_rebuild, $pfb_dnsblip_fp) = pfb_dnsblip_rebuild_check($dnsblip_v6, $dnsbl_ip, "{$dnsblip_v6}.fp");
 
 		if ($pfb_dnsblip_rebuild) {
+			$pfb_dnsblip_built = TRUE;
 			if (!empty($dnsbl_ip)) {
-				pfb_dnsbl_concat_files($dnsblip_v6, $dnsbl_ip);
+				$pfb_dnsblip_built = pfb_dnsbl_concat_files($dnsblip_v6, $dnsbl_ip);
 			}
 
 			// Add empty placeholder IP
 			else {
 				@file_put_contents($dnsblip_v6, "::{$pfb['ip_ph']}\n", LOCK_EX);
 			}
-			@file_put_contents("{$dnsblip_v6}.fp", $pfb_dnsblip_fp, LOCK_EX);
-			unlink_if_exists($pfb['ip_cache']);
-			pfb_dnsblip_mark_reprocess($pfb['dnsbl_ip'], '_v6');
+			// issue #1097: same retry-preserving gate as the v4 path above.
+			if ($pfb_dnsblip_built) {
+				@file_put_contents("{$dnsblip_v6}.fp", $pfb_dnsblip_fp, LOCK_EX);
+				unlink_if_exists($pfb['ip_cache']);
+				pfb_dnsblip_mark_reprocess($pfb['dnsbl_ip'], '_v6');
+			}
 		}
 	}
 
@@ -17146,28 +17155,35 @@ function sync_package_pfblockerng($cron='') {
 				static fn(string $current_list): string => "{$pfb['dnsdir']}/{$current_list}",
 				$lists_dnsbl_all
 			);
-			pfb_dnsbl_concat_files("{$pfb['dnsbl_file']}.raw", $pfb_dnsbl_sources);
-			pfb_logger("... completed", 1);
+			// issue #1097: a failed assembly must keep the live python data/zone files --
+			// deleting them ahead of a rename() of a never-created .raw destroys blocking
+			// data the next tick would otherwise keep serving until the rebuild succeeds.
+			if (pfb_dnsbl_concat_files("{$pfb['dnsbl_file']}.raw", $pfb_dnsbl_sources)) {
+				pfb_logger("... completed", 1);
 
-			// DNSBL Python blocking mode, if TLD is not enabled
-			if (!$pfb['dnsbl_tld']) {
-				unlink_if_exists($pfb['unbound_py_data']);
-				unlink_if_exists($pfb['unbound_py_zone']);
-				// ADR-10: keep pfb_py_count across a feed/cron rebuild. The zero-downtime
-				// fast path's RAM gate (pfb_unbound_py_swap_fits_ram) reads this LIVE count
-				// to project the build's ~2x transient; removing it mid-update fail-closed the
-				// gate to a RESTART on EVERY feed/cron update, so the swap could never engage
-				// for the most common case. The Python build overwrites it with the new count
-				// on swap, so the stale value lives only for the brief publish->swap window.
-				// The clear-all-feeds path (DNSBL going empty -> restart) still clears it.
-				rename("{$pfb['dnsbl_file']}.raw", $pfb['unbound_py_data']);
+				// DNSBL Python blocking mode, if TLD is not enabled
+				if (!$pfb['dnsbl_tld']) {
+					unlink_if_exists($pfb['unbound_py_data']);
+					unlink_if_exists($pfb['unbound_py_zone']);
+					// ADR-10: keep pfb_py_count across a feed/cron rebuild. The zero-downtime
+					// fast path's RAM gate (pfb_unbound_py_swap_fits_ram) reads this LIVE count
+					// to project the build's ~2x transient; removing it mid-update fail-closed the
+					// gate to a RESTART on EVERY feed/cron update, so the swap could never engage
+					// for the most common case. The Python build overwrites it with the new count
+					// on swap, so the stale value lives only for the brief publish->swap window.
+					// The clear-all-feeds path (DNSBL going empty -> restart) still clears it.
+					rename("{$pfb['dnsbl_file']}.raw", $pfb['unbound_py_data']);
+				}
+
+				// ADR-06: Write the per-feed manifest + IP-stripped raw that the Python
+				// plugin's init builds the DNSBL structures from. Python then owns
+				// parse/normalise/classify (the dropped shell/PHP passes) and emits
+				// pfb_py_count itself.
+				pfb_unbound_python_sources($pfb_py_feeds);
 			}
-
-			// ADR-06: Write the per-feed manifest + IP-stripped raw that the Python
-			// plugin's init builds the DNSBL structures from. Python then owns
-			// parse/normalise/classify (the dropped shell/PHP passes) and emits
-			// pfb_py_count itself.
-			pfb_unbound_python_sources($pfb_py_feeds);
+			else {
+				pfb_logger("\nDNSBL not Updated!\n", 1);
+			}
 		}
 
 		else {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -17084,7 +17084,7 @@ function sync_package_pfblockerng($cron='') {
 
 			// Add empty placeholder IP
 			else {
-				@file_put_contents($dnsblip_v4, "{$pfb['ip_ph']}\n", LOCK_EX);
+				$pfb_dnsblip_built = (@file_put_contents($dnsblip_v4, "{$pfb['ip_ph']}\n", LOCK_EX) !== FALSE);
 			}
 			// issue #1097: a failed rebuild must not advance the fingerprint -- a stamped
 			// .fp marks the stale output current and suppresses every future retry.
@@ -17121,7 +17121,7 @@ function sync_package_pfblockerng($cron='') {
 
 			// Add empty placeholder IP
 			else {
-				@file_put_contents($dnsblip_v6, "::{$pfb['ip_ph']}\n", LOCK_EX);
+				$pfb_dnsblip_built = (@file_put_contents($dnsblip_v6, "::{$pfb['ip_ph']}\n", LOCK_EX) !== FALSE);
 			}
 			// issue #1097: same retry-preserving gate as the v4 path above.
 			if ($pfb_dnsblip_built) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1902,6 +1902,27 @@ function pfb_dnsblip_mark_reprocess($action, string $vtype): void {
 	}
 }
 
+// issue #1097: fwrite(FALSE)/fclose(FALSE) throw TypeError on PHP 8 ('@' only
+// silences warnings) -- guard both the destination and each source open. An
+// empty $src is skipped before fopen(): PHP 8 throws ValueError for it too.
+function pfb_dnsbl_concat_files(string $dest, array $sources): bool {
+	if (($out = @fopen($dest, 'w')) !== FALSE) {
+		foreach ($sources as $src) {
+			$src = (string) $src;
+			if ($src !== '' && ($in = @fopen($src, 'r')) !== FALSE) {
+				while (($line = @fgets($in)) !== FALSE) {
+					@fwrite($out, $line);
+				}
+				@fclose($in);
+			}
+		}
+		@fclose($out);
+		return TRUE;
+	}
+	pfb_logger("\nDNSBL: failed to open [ {$dest} ] for writing", 2);
+	return FALSE;
+}
+
 // DNSBLIP's "download" is a local-file copy of a just-rebuilt source, not a network
 // fetch -- the reuse-skip optimization (meant for real feeds) must never apply to it,
 // or a same-pass rebuild is silently stranded until the next .ip source change. (#1002)
@@ -17057,20 +17078,7 @@ function sync_package_pfblockerng($cron='') {
 
 		if ($pfb_dnsblip_rebuild) {
 			if (!empty($dnsbl_ip)) {
-				$pfb_ips = @fopen($dnsblip_v4, 'w');
-				foreach ($dnsbl_ip as $d_ip) {
-					if (($handle = @fopen("{$d_ip}", 'r')) !== FALSE) {
-						while (($line = @fgets($handle)) !== FALSE) {
-							@fwrite($pfb_ips, $line);
-						}
-					}
-					if ($handle) {
-						@fclose($handle);
-					}
-				}
-				if ($pfb_ips) {
-					@fclose($pfb_ips);
-				}
+				pfb_dnsbl_concat_files($dnsblip_v4, $dnsbl_ip);
 			}
 
 			// Add empty placeholder IP
@@ -17102,20 +17110,7 @@ function sync_package_pfblockerng($cron='') {
 
 		if ($pfb_dnsblip_rebuild) {
 			if (!empty($dnsbl_ip)) {
-				$pfb_ips = @fopen($dnsblip_v6, 'w');
-				foreach ($dnsbl_ip as $d_ip) {
-					if (($handle = @fopen("{$d_ip}", 'r')) !== FALSE) {
-						while (($line = @fgets($handle)) !== FALSE) {
-							@fwrite($pfb_ips, $line);
-						}
-					}
-					if ($handle) {
-						@fclose($handle);
-					}
-				}
-				if ($pfb_ips) {
-					@fclose($pfb_ips);
-				}
+				pfb_dnsbl_concat_files($dnsblip_v6, $dnsbl_ip);
 			}
 
 			// Add empty placeholder IP
@@ -17147,20 +17142,11 @@ function sync_package_pfblockerng($cron='') {
 
 			pfb_logger('Assembling DNSBL database...', 1);
 			unlink_if_exists("{$pfb['dnsbl_file']}.raw");
-			$pfb_output = @fopen("{$pfb['dnsbl_file']}.raw", 'w');
-			foreach ($lists_dnsbl_all as $current_list) {
-				if (($handle = @fopen("{$pfb['dnsdir']}/{$current_list}", 'r')) !== FALSE) {
-					while (($line = @fgets($handle)) !== FALSE) {
-						@fwrite($pfb_output, $line);
-					}
-				}
-				if ($handle) {
-					@fclose($handle);
-				}
-			}
-			if ($pfb_output) {
-				@fclose($pfb_output);
-			}
+			$pfb_dnsbl_sources = array_map(
+				static fn(string $current_list): string => "{$pfb['dnsdir']}/{$current_list}",
+				$lists_dnsbl_all
+			);
+			pfb_dnsbl_concat_files("{$pfb['dnsbl_file']}.raw", $pfb_dnsbl_sources);
 			pfb_logger("... completed", 1);
 
 			// DNSBL Python blocking mode, if TLD is not enabled

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -322,7 +322,10 @@ if (isset($pconfig['logFile']) && !empty($pconfig['logFile']) && (isset($pconfig
 			// issue #1097: a lost TOCTOU race must skip headers/exit, not throw on fpassthru(FALSE)
 			if (($fd = @fopen($s_logfile, "rb")) !== FALSE) {
 				header("Content-Type: application/octet-stream");
-				header("Content-Length: " . filesize($s_logfile));
+				// issue #1097: size from the open handle -- the path can vanish after fopen()
+				if (($fd_stat = fstat($fd)) !== FALSE) {
+					header("Content-Length: " . $fd_stat['size']);
+				}
 				header("Content-Disposition: attachment; filename=\"" .
 					trim(htmlentities(basename($s_logfile))) . "\"");
 				if (isset($_SERVER['HTTPS'])) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -296,9 +296,11 @@ if (isset($pconfig['logFile']) && !empty($pconfig['logFile']) && (isset($pconfig
 
 		// Python log file must be truncated to not lose python file pointer
 		if (strpos($s_logfile, 'py_error.log') !== FALSE) {
-			$fp = @fopen("{$s_logfile}", 'r+');
-			@ftruncate($fp, 0);
-			@fclose($fp);
+			// issue #1097: 'r+' never creates -- ftruncate(FALSE) throws TypeError on PHP 8, '@' only silences warnings
+			if (($fp = @fopen("{$s_logfile}", 'r+')) !== FALSE) {
+				@ftruncate($fp, 0);
+				@fclose($fp);
+			}
 		} else {
 			unlink_if_exists($s_logfile);
 
@@ -317,21 +319,23 @@ if (isset($pconfig['logFile']) && !empty($pconfig['logFile']) && (isset($pconfig
 	elseif($pconfig['download']) {
 		if (file_exists($s_logfile)) {
 			session_cache_limiter('public');
-			$fd = @fopen($s_logfile, "rb");
-			header("Content-Type: application/octet-stream");
-			header("Content-Length: " . filesize($s_logfile));
-			header("Content-Disposition: attachment; filename=\"" .
-				trim(htmlentities(basename($s_logfile))) . "\"");
-			if (isset($_SERVER['HTTPS'])) {
-				header('Pragma: ');
-				header('Cache-Control: ');
-			} else {
-				header("Pragma: private");
-				header("Cache-Control: private, must-revalidate");
+			// issue #1097: a lost TOCTOU race must skip headers/exit, not throw on fpassthru(FALSE)
+			if (($fd = @fopen($s_logfile, "rb")) !== FALSE) {
+				header("Content-Type: application/octet-stream");
+				header("Content-Length: " . filesize($s_logfile));
+				header("Content-Disposition: attachment; filename=\"" .
+					trim(htmlentities(basename($s_logfile))) . "\"");
+				if (isset($_SERVER['HTTPS'])) {
+					header('Pragma: ');
+					header('Cache-Control: ');
+				} else {
+					header("Pragma: private");
+					header("Cache-Control: private, must-revalidate");
+				}
+				@fpassthru($fd);
+				@fclose($fd);
+				exit;
 			}
-			@fpassthru($fd);
-			@fclose($fd);
-			exit;
 		}
 	}
 } else {

--- a/tests/php/PfbDnsblConcatFilesTest.php
+++ b/tests/php/PfbDnsblConcatFilesTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
  * uid, unlike a chmod fixture, which root bypasses).
  */
 #[CoversFunction('pfb_dnsbl_concat_files')]
+#[CoversFunction('pfb_dnsbl_concat_write_ok')]
 final class PfbDnsblConcatFilesTest extends TestCase
 {
 	private string $workdir = '';
@@ -130,6 +131,32 @@ final class PfbDnsblConcatFilesTest extends TestCase
 			"1.example.com\n",
 			file_get_contents($dest),
 			'an empty-string source must be skipped, never passed to fopen unguarded'
+		);
+	}
+
+	/**
+	 * The write-outcome predicate must flag a SHORT (partial, non-FALSE) fwrite as a
+	 * failure -- not just a bare FALSE -- so a truncated destination can never advance
+	 * the rebuild bookkeeping as current. A genuine disk-full short write cannot be
+	 * forced deterministically/portably in a unit test (same constraint documented at
+	 * DnsblPrefetchTest::test_write_complete_helper_flags_a_short_write_as_incomplete),
+	 * so this pins the extracted decision predicate directly with fabricated byte counts.
+	 */
+	public function testWriteOkPredicateFlagsShortAndFailedWritesAsIncomplete(): void
+	{
+		$line = "1.example.com\n";
+
+		$this->assertFalse(
+			pfb_dnsbl_concat_write_ok(strlen($line) - 3, $line),
+			'a short byte count must be flagged as an incomplete write'
+		);
+		$this->assertFalse(
+			pfb_dnsbl_concat_write_ok(FALSE, $line),
+			'FALSE must be flagged as an incomplete write'
+		);
+		$this->assertTrue(
+			pfb_dnsbl_concat_write_ok(strlen($line), $line),
+			'an exact full-length write must be flagged as complete'
 		);
 	}
 

--- a/tests/php/PfbDnsblConcatFilesTest.php
+++ b/tests/php/PfbDnsblConcatFilesTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_concat_files() unchecked-fopen guard (issue #1097).
+ *
+ * Three DNSBL assembly loops in sync_package_pfblockerng() (DNSBLIP_v4, DNSBLIP_v6, the
+ * master .raw) opened their destination without checking the return, then unconditionally
+ * fwrote/fclosed it. On PHP 8, fwrite(FALSE)/fclose(FALSE) throw TypeError ('@' only
+ * silences warnings), so an unwritable destination directory aborted the whole DNSBL
+ * update. The extracted helper guards the destination open (skip + log on failure) and
+ * each source open (skip a vanished/empty source, keep going).
+ *
+ * The unwritable destination is modeled as a NON-EXISTENT directory (fopen fails for any
+ * uid, unlike a chmod fixture, which root bypasses).
+ */
+#[CoversFunction('pfb_dnsbl_concat_files')]
+final class PfbDnsblConcatFilesTest extends TestCase
+{
+	private string $workdir = '';
+
+	/** @var array<string,mixed> saved $pfb keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
+	protected function setUp(): void
+	{
+		$workdir = tempnam(sys_get_temp_dir(), 'pfbconcat');
+		$this->assertNotFalse($workdir);
+		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
+		$this->workdir = $workdir;
+
+		foreach (['log', 'errlog', 'runlog', 'runlog_active'] as $k) {
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
+		}
+		$GLOBALS['pfb']['log']    = "{$workdir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$workdir}/error.log";
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === false) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			foreach ((array) glob("{$this->workdir}/*") as $f) {
+				@unlink((string) $f);
+			}
+			rmdir($this->workdir);
+		}
+	}
+
+	public function testConcatenatesSourcesInOrderByteExact(): void
+	{
+		// Given: two sources; the LAST one has NO trailing newline, pinning fgets copy
+		// fidelity (no trimming/normalization may be introduced).
+		$src1 = "{$this->workdir}/one.txt";
+		$src2 = "{$this->workdir}/two.txt";
+		file_put_contents($src1, "1.example.com\n2.example.com\n");
+		file_put_contents($src2, "3.example.com");
+		$dest = "{$this->workdir}/dest.txt";
+
+		$result = pfb_dnsbl_concat_files($dest, [$src1, $src2]);
+
+		$this->assertTrue($result, 'a writable destination must return TRUE');
+		$this->assertSame(
+			"1.example.com\n2.example.com\n3.example.com",
+			file_get_contents($dest),
+			'sources must land concatenated, in order, with byte-exact fidelity'
+		);
+	}
+
+	public function testUnwritableDestinationDegradesInsteadOfThrowing(): void
+	{
+		// Given: the destination directory does not exist, so the destination fopen fails.
+		$dest = "{$this->workdir}/does-not-exist/dest.txt";
+		$src  = "{$this->workdir}/one.txt";
+		file_put_contents($src, "1.example.com\n");
+
+		// When/Then: before the guard this threw TypeError from fwrite(FALSE) (PHP 8;
+		// '@' does not suppress it) and aborted the whole DNSBL assembly pass.
+		$result = pfb_dnsbl_concat_files($dest, [$src]);
+
+		$this->assertFalse($result, 'a failed destination open must return FALSE, not throw');
+		$this->assertFileDoesNotExist($dest);
+		$logged = @file_get_contents($GLOBALS['pfb']['errlog']) . @file_get_contents($GLOBALS['pfb']['log']);
+		$this->assertStringContainsString(
+			'failed to open',
+			$logged,
+			'the skip must be operator-visible, not silent'
+		);
+	}
+
+	public function testVanishedSourceIsSkippedNotFatal(): void
+	{
+		// Given: one existing and one missing source (a list vanished mid-loop).
+		$src = "{$this->workdir}/one.txt";
+		file_put_contents($src, "1.example.com\n");
+		$dest = "{$this->workdir}/dest.txt";
+
+		$result = pfb_dnsbl_concat_files($dest, [$src, "{$this->workdir}/gone.txt"]);
+
+		$this->assertTrue($result);
+		$this->assertSame(
+			"1.example.com\n",
+			file_get_contents($dest),
+			'the existing source must still be copied when a sibling vanished'
+		);
+	}
+
+	public function testEmptyStringSourcePathIsSkippedGracefully(): void
+	{
+		// Given: an empty-string entry in the sources array (never a valid path).
+		$src = "{$this->workdir}/one.txt";
+		file_put_contents($src, "1.example.com\n");
+		$dest = "{$this->workdir}/dest.txt";
+
+		$result = pfb_dnsbl_concat_files($dest, ['', $src]);
+
+		$this->assertTrue($result);
+		$this->assertSame(
+			"1.example.com\n",
+			file_get_contents($dest),
+			'an empty-string source must be skipped, never passed to fopen unguarded'
+		);
+	}
+
+	public function testEmptySourcesArrayCreatesEmptyDestination(): void
+	{
+		// Given: no sources at all.
+		$dest = "{$this->workdir}/dest.txt";
+
+		$result = pfb_dnsbl_concat_files($dest, []);
+
+		$this->assertTrue($result, 'fopen "w" truncate semantics must still apply with zero sources');
+		$this->assertSame('', file_get_contents($dest), 'the destination must exist and be empty');
+	}
+}

--- a/tests/smoke/ui/test_log.py
+++ b/tests/smoke/ui/test_log.py
@@ -64,6 +64,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from .. import helpers
+from .render_oracle import body_has_php_error
 from .webui import extract_csrf_token, looks_like_login_page
 
 if TYPE_CHECKING:
@@ -575,6 +576,38 @@ def test_clear_py_error_truncates_in_place(webui: WebUI, smoke_vm: helpers.Smoke
         assert _size(vm, target) == 0, f"py_error.log not truncated to 0 after clear (size={_size(vm, target)})"
     finally:
         _rm(vm, target)
+
+
+def test_clear_absent_py_error_log_degrades_without_php_fatal(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Clearing an ABSENT py_error.log must not throw a PHP fatal (issue #1097).
+
+    Before the #1097 guard, the py_error.log branch opened the target with
+    ``fopen(..., 'r+')`` -- a mode that never creates -- so a rotated/never-written
+    log made ``@fopen`` return FALSE, and the un-guarded ``ftruncate($fp, 0)`` threw
+    a TypeError on PHP 8 (``@`` only silences warnings/notices, not a thrown
+    exception), producing a PHP fatal in the POST response.
+
+    Transition: BEFORE-state asserts the throwaway target is absent (never seeded),
+    POST clear, then AFTER asserts no PHP diagnostic rendered into the response,
+    the file is still absent (silent no-op, not a crash), and the page still
+    renders on a follow-up GET (the fatal did not wedge the session/handler).
+    """
+    vm = smoke_vm
+    target = _throwaway_log("py_error.log")
+    # BEFORE: never seeded -- the absent-file precondition this test exercises.
+    assert not _exists(vm, target), "throwaway py_error.log target unexpectedly exists before clear"
+
+    token = _csrf(webui)
+    resp = _post_clear(webui, token, target)
+    assert not looks_like_login_page(resp.text), "clear POST returned the login form (session lost)"
+    assert resp.status_code == 200, f"clear of an absent py_error.log did not return 200: {resp.status_code}"
+    # AFTER (oracle): no rendered PHP diagnostic -- the pre-#1097 TypeError fatal is gone.
+    diagnostic = body_has_php_error(resp.text)
+    assert diagnostic is None, f"clear of an absent py_error.log rendered a PHP diagnostic: {diagnostic!r}"
+    # AFTER: silent no-op -- nothing to clear, nothing created.
+    assert not _exists(vm, target), "clearing an absent py_error.log unexpectedly created the file"
+    # AFTER: the handler did not wedge the session -- the page still renders normally.
+    _csrf(webui)
 
 
 def test_clear_dnsbl_log_unlinks_then_retouches_empty(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:


### PR DESCRIPTION
Fixes #1097.

On PHP 8, `fwrite(FALSE)`/`ftruncate(FALSE)`/`fpassthru(FALSE)`/`fclose(FALSE)` throw `TypeError`, which `@` does not suppress. Five destination `fopen()` sites used their handle without a `!== FALSE` guard — the same class as #1073 (fixed by #1096). The class was re-enumerated from source at the current `devel` tip (all 50 `fopen` sites under `src/` context-checked, plus a `popen`/`gzopen`/`tmpfile` sweep): exactly these 5 sites were unguarded, everything else already carries a guard.

## The five sites

| Site | Failure before | Fix |
| ---- | -------------- | --- |
| `pfblockerng.inc` DNSBLIP v4 copy loop | unwritable `dbdir` → `fwrite(FALSE)` aborts the sync | routed through new guarded helper |
| `pfblockerng.inc` DNSBLIP v6 copy loop | same | same |
| `pfblockerng.inc` DNSBL master `.raw` assembly | unwritable `dnsdir` → same abort | same |
| `pfblockerng_log.php` Clear (py_error.log branch) | `'r+'` never creates → clearing an absent/rotated log → `ftruncate(FALSE)` → HTTP 500 | handle guard, silent no-op (pre-PHP-8 behaviour) |
| `pfblockerng_log.php` Download | `file_exists()` TOCTOU only → lost race → `fpassthru(FALSE)` after headers | whole header+passthru+exit block inside the handle guard; lost race falls through to the page render |

## Changes

- `pfb_dnsbl_concat_files(string $dest, array $sources): bool` — the three identical copy loops in `sync_package_pfblockerng()` extracted into one guarded helper (mirrors the #1073 fix in `dnsbl_alias_update`; the sites themselves are not unit-callable off-appliance, the helper is). Skips empty-string source paths (`fopen('')` throws `ValueError` on PHP 8 — found by the hostile-input row's executed test).
- `pfblockerng_log.php` — both handles guarded per the #1096 pattern; success paths byte-identical.

## Tests

- `tests/php/PfbDnsblConcatFilesTest.php` (5 tests): byte-exact ordered concat, unwritable destination degrades + logs instead of throwing (modeled as a non-existent directory — fails for any uid), vanished source skipped, empty-string source skipped, empty source list truncates. Red→green executed: pre-change src → 5 errors; post-change → `OK (5 tests, 21 assertions)`.
- `tests/smoke/ui/test_log.py::test_clear_absent_py_error_log_degrades_without_php_fatal` (Tier B, `ui_e2e`): clear an absent `<uuid>-py_error.log` → 200, no PHP diagnostic in the body, file stays absent, page still renders. **Live red→green executed on real pfSense VMs** (local smoke, two leased boxes): unfixed code → `did not return 200: 500` (1 failed / 19 passed); fixed branch → 20/20 passed including the existing truncate/download regression pins.

Deferral: the download-branch TOCTOU race (file_exists passes, fopen fails) is not deterministically triggerable (www runs as root; needs a concurrent unlink) — guarded by class, green path exercised by the existing download test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMandwby8X7gcMiUBQpPbG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when rebuilding DNSBL data, preventing incomplete updates from advancing status or clearing caches.
  * Missing or inaccessible source files are handled gracefully during DNSBL processing.
  * Improved log clearing and downloading when files are unavailable or inaccessible.
  * Prevented PHP errors during attempts to clear an absent Python error log.

* **Tests**
  * Added coverage for DNSBL file assembly and resilient log-clearing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->