### PR TITLE
pfblockerng: reject comma-prefixed lines in the ABP verbatim-capture predicates

### DIFF
--- a/.ADRs/ADR_62_DNSBL_Unified_Line_Parsing/ADR.md
+++ b/.ADRs/ADR_62_DNSBL_Unified_Line_Parsing/ADR.md
@@ -288,6 +288,16 @@ are never captured as `/re/` regex rules (on `origin/devel` a *header-classified
 a `//path/` line to `parse_abp` as a live regex; that accidental class is dropped with the
 classifier — cosmetically a sub-case of D1's "former-ABP feeds re-type" rule).
 
+**Leading-comma carve-out (issue #1067; both predicates, red→green pinned):** a line starting
+with `,` is never captured. A leading comma would be an empty first entry in the cosmetic
+domain-list (not valid ABP syntax), and a comma-first verbatim capture collides with the plain
+`,domain,,log,feed,group` CSV dialect downstream — a comma-first captured line with >=5 comma
+segments defeated `tld_analysis()`'s feed-column skip and was CSV-mangled into the python
+outputs. Companion hardening: `pfb_unbound_python_sources()`'s plain fallback skips any
+non-captured line still carrying `#` — such a line is stale verbatim residue from a pre-guard
+staging file, never a machine CSV row, and extracting its column 1 would over-block a real
+domain (pinned by `UnboundPythonSourcesTest`).
+
 ### Semantics that MUST be preserved (the contract — pin with tests before any swap)
 
 1. **Byte-identical domain set, modulo the delta table.** For every §"Coverage matrix" format,

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -77,8 +77,12 @@ element-hiding lines in plain feeds are now honoured via `parse_abp()` (D2); and
 feed's `||<IP>^` anchor now collects to the DNSBLIP firewall alias where it previously
 vanished (D6). The element-hiding capture requires an ABP cosmetic domain-list prefix
 (`[A-Za-z0-9._,~*-]`) before the first marker — a hosts line's mid-line `` ## `` inline
-comment, a `#`-led comment, or a CSV row's `#`-fragment URL is never captured — and `//`-led
-lines are comments, never `/re/` regex rules. Every line class outside the delta table is
+comment, a `#`-led comment, or a CSV row's `#`-fragment URL is never captured — a
+comma-first line is never captured either (issue #1067: a leading comma is not valid ABP
+syntax and would collide with the plain `,domain,,log,feed,group` CSV dialect downstream;
+the manifest writer's plain fallback likewise skips non-captured `#`-bearing residue lines
+instead of extracting a blockable column-1 "domain") — and `//`-led lines are comments,
+never `/re/` regex rules. Every line class outside the delta table is
 byte-identical to `origin/devel`, pinned by a corpus oracle (`tests/test_adr62_*`,
 `tests/php/Adr62*Test.php`) whose golden fixtures were captured by running the real
 functions at the pre-change base and are regenerated only through those same functions.

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -3936,8 +3936,15 @@ def _dnsbl_is_abp_rule_line(line: str) -> bool:
     ([A-Za-z0-9._,~*-]; empty = generic rule) so a mid-line `` ## `` inline
     comment, a ``#``-led comment mentioning ``##``, or a CSV row carrying a
     ``#``-fragment URL keeps its plain-path handling. ``//``-led lines are
-    comments by feed convention, never ``/re/`` regex rules.
+    comments by feed convention, never ``/re/`` regex rules. A leading ``,``
+    is never valid ABP syntax (empty first cosmetic domain-list entry) and
+    is excluded up front.
     """
+    # issue #1067: a leading comma is never valid ABP syntax (empty first cosmetic
+    # domain-list entry) -- a comma-first verbatim capture would collide with the
+    # plain CSV dialect downstream.
+    if line.startswith(","):
+        return False
     if line.startswith("||") or line.startswith("@@"):
         return True
     if "#" in line:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7188,8 +7188,11 @@ function pfb_unbound_python_sources($feeds) {
 				// 'plain': extract bare domains (col1) from the 6-col CSV; this is
 				// already IP-free (IPs went to the firewall path) and already
 				// cleaned/validated by the download loop.
+				// issue #1067: a non-captured line still carrying '#' is stale verbatim
+				// ABP residue from a pre-guard staging file, never a machine CSV row --
+				// skip it rather than extract col1 into a blockable "domain".
 				$cols = explode(',', $line, 3);
-				if (isset($cols[1]) && $cols[1] !== '') {
+				if (strpos($line, '#') === FALSE && isset($cols[1]) && $cols[1] !== '') {
 					@fwrite($raw_h, "{$cols[1]}\n");
 				}
 			}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6696,8 +6696,16 @@ function pfb_dnsbl_is_skippable_control_line(string $line): bool {
 // ' ## ' inline comment (hosts dialect), a '#'-led comment mentioning '##', or a CSV row
 // with a '#'-fragment URL is NOT a cosmetic rule and must keep its plain-path handling
 // (the '#'-classifier's side effects included). '//'-led lines are comments by feed
-// convention, never '/re/' regex rules. Kept in lockstep with _dnsbl_is_abp_rule_line().
+// convention, never '/re/' regex rules. A leading ',' is never valid ABP syntax (empty
+// first cosmetic domain-list entry), excluded up front. Kept in lockstep with
+// _dnsbl_is_abp_rule_line().
 function pfb_dnsbl_is_abp_rule_line(string $line): bool {
+	// issue #1067: a leading comma is never valid ABP syntax (empty first cosmetic
+	// domain-list entry) -- a comma-first verbatim capture would collide with the
+	// plain CSV dialect downstream.
+	if (str_starts_with($line, ',')) {
+		return FALSE;
+	}
 	if (str_starts_with($line, '||') || str_starts_with($line, '@@')) {
 		return TRUE;
 	}

--- a/tests/php/Adr62DnsblIsAbpRuleLineTest.php
+++ b/tests/php/Adr62DnsblIsAbpRuleLineTest.php
@@ -54,6 +54,7 @@ final class Adr62DnsblIsAbpRuleLineTest extends TestCase
 			'tab-led cosmetic rule (caller trims)' => ["\thost.example##.ad", false],
 			'all-hash banner (marker at pos 0)'   => ['####################', true],
 			'cosmetic rule, domain list'          => ['a.com,b.com##.ad', true],
+			'cosmetic rule, longer domain list'   => ['example.com,example.org##.ad', true],
 			'cosmetic rule, negated domain'       => ['~ex.com##.ad', true],
 			'cosmetic rule, mixed-case domain'    => ['EXAMPLE.com##.ad', true],
 			// '//'-led lines are comments by feed convention, never regex rules --

--- a/tests/php/Adr62DnsblIsAbpRuleLineTest.php
+++ b/tests/php/Adr62DnsblIsAbpRuleLineTest.php
@@ -61,6 +61,15 @@ final class Adr62DnsblIsAbpRuleLineTest extends TestCase
 			'comment with trailing slash'         => ['//cdn.example.com/ads/', false],
 			'bare double slash'                   => ['//', false],
 			'yhost @-prefix line'                 => ['@stray.example', false],
+			// issue #1067: a leading comma is never valid ABP syntax (an empty first
+			// cosmetic domain-list entry) -- left uncaught, a comma-first verbatim
+			// capture collides with the plain-CSV dialect on the read side.
+			'comma-prefixed cosmetic, 4 commas'      => [',a,b,c,d##x', false],
+			'comma-prefixed cosmetic domain list'    => [',example.com,example.org##.ad', false],
+			'comma-prefixed, mimics CSV field shape' => [',a,,1,RealFeed,x##y', false],
+			'comma-prefixed network anchor'          => [',||x^', false],
+			'bare comma'                             => [',', false],
+			'comma-prefixed, marker at position 1'   => [',,##x', false],
 		];
 	}
 

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -174,6 +174,33 @@ final class UnboundPythonSourcesTest extends TestCase
 		$this->assertSame("||ads.example^\n@@||good.example^\n", $raw);
 	}
 
+	/**
+	 * Scenario: stale pre-guard verbatim residue in a staged '.txt'.
+	 *
+	 * Given:  a '.txt' holding a comma-first cosmetic ABP line captured
+	 *         verbatim BEFORE the issue #1067 leading-comma capture guard,
+	 *         alongside a legit machine CSV row
+	 * When:   pfb_unbound_python_sources() rebuilds the per-feed raw
+	 * Then:   the residue line is skipped entirely — neither passed verbatim
+	 *         nor CSV-mangled into a bare 'domain' that Python would block —
+	 *         while the legit row still yields its domain
+	 */
+	public function testStaleCommaFirstAbpResidueIsSkippedNotExtracted(): void
+	{
+		file_put_contents("{$this->tmp}/dnsbl/stalefeed.txt",
+			"1,legit.example,a,b,c,d\n" .
+			",stale-block.example,stale2.example##.ad\n");
+		pfb_unbound_python_sources([
+			['header' => 'stalefeed', 'group' => 'g', 'log' => '1', 'format' => 'plain', 'provenance' => 'feed'],
+		]);
+		$raw = file_get_contents("{$this->tmp}/pfb_py_raw/stalefeed.raw");
+		$this->assertSame(
+			"legit.example\n",
+			$raw,
+			'stale comma-first ABP residue must not leak a blockable domain; got: ' . var_export($raw, TRUE)
+		);
+	}
+
 	public function testConfigBlockEmptyWhenUnconfigured(): void
 	{
 		$m = pfb_unbound_python_sources($this->feeds());

--- a/tests/test_adr62_parity_oracle.py
+++ b/tests/test_adr62_parity_oracle.py
@@ -446,12 +446,22 @@ def test_cosmetic_prefix_guard_matches_php_row_for_row() -> None:
         "//cdn.example.com/ads/",
         "//",
         "@stray.example",  # single-@ yHost prefix, not an '@@' allow anchor
+        # issue #1067: a leading comma is never valid ABP syntax (an empty first
+        # cosmetic domain-list entry) -- left uncaught, a comma-first verbatim
+        # capture collides with the plain-CSV dialect on the read side.
+        ",a,b,c,d##x",
+        ",example.com,example.org##.ad",
+        ",a,,1,RealFeed,x##y",  # crafted to mimic the plain-CSV field shape
+        ",||x^",
+        ",",
+        ",,##x",
     ]
     capturable = [
         "####################",  # marker at pos 0: generic-rule shape (documented latent)
         "##.ad",
         "example.com##.ad",
         "a.com,b.com##.ad",
+        "example.com,example.org##.ad",  # comma INSIDE the cosmetic prefix stays valid
         "~ex.com##.ad",
         "EXAMPLE.com##.ad",
         "/re/",


### PR DESCRIPTION
Fixes #1067

## What

A comma-prefixed line in `pfb_dnsbl.raw` with >=5 comma-separated segments defeats `tld_analysis()`'s plain-CSV skip (comma-first + non-empty 5th field) and is CSV-parsed as if it were a `,domain,,log,feed,group` row, producing a garbage row in the python data/zone outputs.

Since ADR-62, the only write path that can put a comma-first line into `.raw` verbatim is the capture predicate's element-hiding branch: its cosmetic domain-list prefix charset `[A-Za-z0-9._,~*-]` includes `,`, so a line like `,a,b,c,d##x` was captured verbatim. (The issue's original `$easylist` write path no longer exists; the literal `,strange-rule,b,c,d,e` repro is no longer capturable — the class survives only via the cosmetic capture.)

## Fix — write-side, at the single choke point

A leading `,` is never valid ABP syntax (it would be an empty first entry in a cosmetic domain-list), so both verbatim-capture predicates now reject comma-first lines up front:

- PHP `pfb_dnsbl_is_abp_rule_line()` (`pfblockerng.inc`) — inherited by both call sites: the download-loop verbatim capture and the `pfb_unbound_python_sources()` `.txt` → per-feed-raw pass-through.
- Python `_dnsbl_is_abp_rule_line()` (`pfb_unbound.py`) — kept in documented row-for-row lockstep.

Read-side field-shape checks were considered and rejected: an executed probe showed a crafted cosmetic prefix (`,a,,1,RealFeed,x##y`) can mimic any machine-CSV field shape, so no read-side heuristic is airtight; the write-side invariant ("a comma-first `.raw` line is always a machine-written CSV row") is.

## Tests (red→green executed, both languages)

- `tests/php/Adr62DnsblIsAbpRuleLineTest.php`: 6 new data-provider rows — `,a,b,c,d##x`, `,example.com,example.org##.ad`, `,a,,1,RealFeed,x##y` (crafted CSV-shape mimic), `,||x^`, bare `,`, `,,##x` — 4 red pre-fix, all green post-fix; comma-INSIDE-prefix regression pinned by the existing `a.com,b.com##.ad => true` row.
- `tests/test_adr62_parity_oracle.py`: the same rows added to the row-for-row cosmetic-prefix guard test (red pre-fix), plus `example.com,example.org##.ad` added to the capturable regression list.
- Parity/byte-identity corpora swept: no comma-first line containing `#` exists in any fixture, so no expected-delta.

## Stale-staging hardening (added on review)

The adversarial review showed the originally-documented residual was worse than stated: a stale pre-guard `.txt` line (e.g. `,example.com,example.org##.ad`, captured verbatim before this fix) would now fall to `pfb_unbound_python_sources()`'s plain fallback, which extracted column 1 (`example.com`) as an unvalidated "domain" — a dotted token passes Python's dotless-only gate and becomes an actively blocked domain (over-block). The fallback now skips any non-captured line still carrying `#`: every `.txt` writer field is filter-gated (`PFB_FILTER_DOMAIN` / `PFB_FILTER_WORD` / numeric log type), so a legitimate machine CSV row can never contain `#` — only stale verbatim ABP residue can. Pinned red→green by `UnboundPythonSourcesTest::testStaleCommaFirstAbpResidueIsSkippedNotExtracted`. ADR-62's "Capture-scope refinements" section and `docs/misc/architecture-notes.md` are amended in the same change (CLAUDE.md ADR-amendment rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMandwby8X7gcMiUBQpPbG
