### PR TITLE
www: reject array-valued request fields in category_edit string sinks (#1106)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -99,7 +99,7 @@ if (isset($_GET)) {
 			$action = 'addgroup';
 		}
 	}
-	if (isset($_GET['atype']) && !empty($_GET['atype'])) {
+	if (isset($_GET['atype']) && !empty($_GET['atype']) && is_string($_GET['atype'])) {
 		$raw_atype = $_GET['atype'];
 		if (str_starts_with($raw_atype, 'Whitelist|')) {
 			$atype = pfb_filter_whitelist_atype($raw_atype);
@@ -138,7 +138,7 @@ if (isset($_POST)) {
 			$action = 'addgroup';
 		}
 	}
-	if (isset($_POST['atype']) && !empty($_POST['atype'])) {
+	if (isset($_POST['atype']) && !empty($_POST['atype']) && is_string($_POST['atype'])) {
 		$raw_atype = $_POST['atype'];
 		if (str_starts_with($raw_atype, 'Whitelist|')) {
 			$atype = pfb_filter_whitelist_atype($raw_atype);
@@ -496,6 +496,19 @@ if ($_POST && isset($_POST['save'])) {
 		}
 		elseif (is_array(${"options_$s_option"}) && !array_key_exists($_POST[$s_option], ${"options_$s_option"})) {
 			$_POST[$s_option] = $s_default;
+		}
+	}
+
+	// issue #1106: reject an array-valued field ('aliasname[]=x') before any string
+	// sink below TypeErrors on it. 'Lmove' is the page's one legitimate array field
+	// (row-move checkboxes, checked-then-Save posts it alongside 'save') and stays exempt.
+	foreach ($_POST as $pfb_post_key => $pfb_post_value) {
+		if ($pfb_post_key === 'Lmove') {
+			continue;
+		}
+		if (!is_scalar($pfb_post_value)) {
+			$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars((string) $pfb_post_key);
+			$_POST[$pfb_post_key] = '';
 		}
 	}
 
@@ -1003,7 +1016,7 @@ if (isset($savemsg)) {
 	print_info_box($savemsg);
 }
 
-if (isset($_REQUEST['savemsg'])) {
+if (isset($_REQUEST['savemsg']) && is_string($_REQUEST['savemsg'])) {
 	$savemsg = htmlspecialchars($_REQUEST['savemsg']);
 	print_info_box($savemsg);
 }

--- a/tests/php/CategoryEditPostGuardTest.php
+++ b/tests/php/CategoryEditPostGuardTest.php
@@ -385,8 +385,9 @@ final class CategoryEditPostGuardTest extends TestCase
 		} catch (\TypeError $e) {
 			$this->fail('an array custom value must not TypeError explode(): ' . $e->getMessage());
 		}
-		// R10: base64_encode() (save-success path, line ~806) is unreachable with
-		// an empty string too -- shadowed by this same guard, not separately tested.
+		// R10/R11: both save-success sinks -- base64_encode('custom') and the
+		// asn-format htmlentities(url-N) -- are unreachable once the guard raises
+		// input errors (the save block requires empty $input_errors); not separately tested.
 		$this->assertSame([], $errors, 'a blanked custom value adds no further validation errors');
 		$this->assertSame('', $_POST['custom']);
 	}

--- a/tests/php/CategoryEditPostGuardTest.php
+++ b/tests/php/CategoryEditPostGuardTest.php
@@ -1,0 +1,425 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Category-edit page array-POST guard (issue #1106).
+ *
+ * A crafted request submitting an array-valued field ('aliasname[]=x',
+ * 'atype[]=x', 'savemsg[]=x', a rowhelper 'url-0[]=x', ...) reached a
+ * strictly-typed string sink (preg_match/strlen/strpos/explode/
+ * str_starts_with) before the input-errors gate, TypeError-ing the page
+ * (HTTP 500). The fix rejects a non-scalar $_POST field with an input error
+ * and blanks it to '' right after the select-option normalisation loop, so
+ * every later read in the save block stays scalar; 'atype' (GET+POST) and
+ * '$_REQUEST[savemsg]' get their own is_string() guard since they run
+ * outside the save block. 'Lmove' (row-move checkboxes) is the page's one
+ * legitimate array field and is exempt -- a user who checks a row then
+ * clicks Save posts Lmove[] alongside save=Save.
+ *
+ * Like SyncRowhelperGuardTest, the page carries top-level execution and
+ * cannot be require()d off-appliance, so each region below is eval-extracted
+ * verbatim from the REAL source, anchored on text stable across both the
+ * pre-fix and post-fix code so the same test file proves red on the old
+ * code and green on the new.
+ */
+final class CategoryEditPostGuardTest extends TestCase
+{
+	private array $savedPost = [];
+	private array $savedGet = [];
+	private array $savedRequest = [];
+	private mixed $savedPfb = null;
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
+		}
+
+		if (!function_exists('print_info_box')) {
+			// Not doubled in pfsense_doubles.php (out of scope for this issue) -- a
+			// no-op is enough since the guard tests only assert on $savemsg/errors.
+			function print_info_box($msg): void
+			{
+			}
+		}
+
+		// Region 1: select_options-normalisation close through the ingress guard,
+		// the aliasname checks and the CIDR checks -- up to the state-loop foreach.
+		if (!function_exists('pfb_category_oracle_aliasname_region')) {
+			if (!preg_match(
+				'/\$_POST\[\$s_option\] = \$s_default;\n\t\t\}\n\t\}\n(.*?)(?=\n\tforeach \(\$_POST as \$key => \$value\) \{)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: aliasname/CIDR region not found');
+			}
+			eval(
+				'function pfb_category_oracle_aliasname_region(string $gtype): array {'
+				. ' $input_errors = array();'
+				. $m[1]
+				. ' return $input_errors; }'
+			);
+		}
+
+		// Region 2: the rowhelper state-loop (URL/header/format validation).
+		if (!function_exists('pfb_category_oracle_state_loop')) {
+			if (!preg_match(
+				'/(\tforeach \(\$_POST as \$key => \$value\) \{\n.*?\n\t\})\n\n\n\t\/\/ Validate Adv\. firewall rule settings/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: state validation loop not found');
+			}
+			eval(
+				'function pfb_category_oracle_state_loop(string $type): array {'
+				. ' global $pfb; $input_errors = array(); $line = 1;'
+				. $m[1]
+				. ' return $input_errors; }'
+			);
+		}
+
+		// Region 3: the custom-list block.
+		if (!function_exists('pfb_category_oracle_custom_block')) {
+			if (!preg_match(
+				'/(\t\/\/ Validate Custom List\n\tif \(!empty\(\$_POST\[\'custom\'\]\)\) \{\n.*?\n\t\})\n\n\tif \(!\$input_errors\) \{/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: custom-list block not found');
+			}
+			eval(
+				'function pfb_category_oracle_custom_block(string $gtype): array {'
+				. ' $input_errors = array();'
+				. $m[1]
+				. ' return $input_errors; }'
+			);
+		}
+
+		// Region 4: the GET 'atype' ingress block.
+		if (!function_exists('pfb_category_oracle_get_atype')) {
+			if (!preg_match(
+				'/(\tif \(isset\(\$_GET\[\'atype\'\]\).*?\n\t\})\n\}\n\nif \(isset\(\$_POST\)\) \{/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: GET atype block not found');
+			}
+			eval(
+				'function pfb_category_oracle_get_atype(): string {'
+				. ' $atype = \'\';'
+				. $m[1]
+				. ' return $atype; }'
+			);
+		}
+
+		// Region 5: the POST 'atype' ingress block.
+		if (!function_exists('pfb_category_oracle_post_atype')) {
+			if (!preg_match(
+				'/(\tif \(isset\(\$_POST\[\'atype\'\]\).*?\n\t\})\n\tif \(isset\(\$_POST\[\'chgstate\'\]\)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: POST atype block not found');
+			}
+			eval(
+				'function pfb_category_oracle_post_atype(): string {'
+				. ' $atype = \'\';'
+				. $m[1]
+				. ' return $atype; }'
+			);
+		}
+
+		// Region 6: the '$_REQUEST[savemsg]' render-time block.
+		if (!function_exists('pfb_category_oracle_savemsg')) {
+			if (!preg_match(
+				'/if \(isset\(\$savemsg\)\) \{\n\tprint_info_box\(\$savemsg\);\n\}\n\n(if \(isset\(\$_REQUEST\[\'savemsg\'\]\).*?\n\})\n\n\$form = new Form\(/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: savemsg block not found');
+			}
+			eval(
+				'function pfb_category_oracle_savemsg(): ?string {'
+				. ' ' . $m[1]
+				. ' return $savemsg ?? null; }'
+			);
+		}
+	}
+
+	protected function setUp(): void
+	{
+		$this->savedPost    = $_POST;
+		$this->savedGet     = $_GET;
+		$this->savedRequest = $_REQUEST;
+		$this->savedPfb     = $GLOBALS['pfb'] ?? null;
+		$_POST = $_GET = $_REQUEST = [];
+		// Satisfied MaxMind credentials so the state-loop's geoip-format row
+		// doesn't also trip the (unrelated) credential-notice input error.
+		$GLOBALS['pfb']['maxmind_key']     = 'test-key';
+		$GLOBALS['pfb']['maxmind_account'] = 'test-account';
+	}
+
+	protected function tearDown(): void
+	{
+		$_POST    = $this->savedPost;
+		$_GET     = $this->savedGet;
+		$_REQUEST = $this->savedRequest;
+		$GLOBALS['pfb'] = $this->savedPfb;
+	}
+
+	// --- R1/R2: atype (POST/GET) ------------------------------------------------
+
+	public function testPostAtypeArrayValueIsIgnoredWithoutThrowing(): void
+	{
+		$_POST['atype'] = ['x'];
+		try {
+			$atype = pfb_category_oracle_post_atype();
+		} catch (\TypeError $e) {
+			$this->fail('an array atype POST value must not TypeError: ' . $e->getMessage());
+		}
+		$this->assertSame('', $atype, 'an array atype must be silently ignored (stays unset/blank)');
+	}
+
+	public function testPostAtypeScalarValueStillResolves(): void
+	{
+		// Branch coverage: the new is_string() clause's TRUE side still resolves.
+		$_POST['atype'] = 'Whitelist|1.2.3.4|test';
+		$atype = pfb_category_oracle_post_atype();
+		$this->assertStringStartsWith('Whitelist|', $atype, 'a scalar Whitelist atype must still resolve');
+	}
+
+	public function testGetAtypeArrayValueIsIgnoredWithoutThrowing(): void
+	{
+		$_GET['atype'] = ['x'];
+		try {
+			$atype = pfb_category_oracle_get_atype();
+		} catch (\TypeError $e) {
+			$this->fail('an array atype GET value must not TypeError: ' . $e->getMessage());
+		}
+		$this->assertSame('', $atype, 'an array atype must be silently ignored (stays unset/blank)');
+	}
+
+	// --- R3/R4: aliasname ---------------------------------------------------
+
+	public function testAliasnameArrayValueDoesNotThrowForDnsbl(): void
+	{
+		$_POST = ['aliasname' => ['x']];
+		try {
+			$errors = pfb_category_oracle_aliasname_region('dnsbl');
+		} catch (\TypeError $e) {
+			$this->fail('an array aliasname must not TypeError (dnsbl): ' . $e->getMessage());
+		}
+		$this->assertNotEmpty($errors, 'an array aliasname must be rejected as an input error');
+		$this->assertSame('', $_POST['aliasname'], 'the guard must blank the array value to an empty string');
+	}
+
+	public function testAliasnameArrayValueDoesNotThrowForIpv4(): void
+	{
+		// gtype=ipv4 additionally exercises the strlen() 24-char limit check (line ~525).
+		$_POST = ['aliasname' => ['x'], 'suppression_cidr' => '24'];
+		try {
+			$errors = pfb_category_oracle_aliasname_region('ipv4');
+		} catch (\TypeError $e) {
+			$this->fail('an array aliasname must not TypeError (ipv4/strlen): ' . $e->getMessage());
+		}
+		$this->assertNotEmpty($errors);
+		$this->assertSame('', $_POST['aliasname']);
+	}
+
+	// --- R15: Lmove exemption + no false positive ---------------------------
+
+	public function testLmoveArrayFieldIsExemptFromGuard(): void
+	{
+		// Given: a valid Save submission where the user also checked a row-move
+		// checkbox (Lmove posts as an array alongside save=Save in real usage).
+		$_POST = ['aliasname' => 'validname', 'Lmove' => [0 => '0']];
+
+		// When: the ingress guard runs.
+		$errors = pfb_category_oracle_aliasname_region('dnsbl');
+
+		// Then: no error is raised for Lmove and its array value survives untouched.
+		$this->assertSame([], $errors, 'Lmove must not be flagged as an invalid field');
+		$this->assertSame([0 => '0'], $_POST['Lmove'], 'Lmove must survive the guard unmodified');
+	}
+
+	public function testFullyScalarValidPostAddsNoGuardErrors(): void
+	{
+		$_POST = ['aliasname' => 'validname', 'description' => 'd', 'action' => 'Disabled'];
+		$errors = pfb_category_oracle_aliasname_region('dnsbl');
+		$this->assertSame([], $errors, 'an all-scalar POST must add zero guard errors');
+	}
+
+	public static function hostileArrayShapeProvider(): array
+	{
+		return [
+			'single element' => [['x']],
+			'multi element'  => [['a', 'b']],
+			'nested'         => [[['x']]],
+			'empty array'    => [[]],
+		];
+	}
+
+	#[DataProvider('hostileArrayShapeProvider')]
+	public function testHostileArrayShapeUnderRowhelperKeyIsRejectedWithoutThrowing(array $shape): void
+	{
+		$_POST = ['aliasname' => 'validname', 'url-0' => $shape];
+		try {
+			$errors = pfb_category_oracle_aliasname_region('dnsbl');
+		} catch (\TypeError $e) {
+			$this->fail("shape " . var_export($shape, true) . " under 'url-0' must not TypeError: " . $e->getMessage());
+		}
+		$this->assertNotEmpty($errors);
+		$this->assertSame('', $_POST['url-0']);
+	}
+
+	#[DataProvider('hostileArrayShapeProvider')]
+	public function testHostileArrayShapeUnderUnknownKeyIsRejectedWithoutThrowing(array $shape): void
+	{
+		$_POST = ['aliasname' => 'validname', 'zzz' => $shape];
+		try {
+			$errors = pfb_category_oracle_aliasname_region('dnsbl');
+		} catch (\TypeError $e) {
+			$this->fail("shape " . var_export($shape, true) . " under an unknown key must not TypeError: " . $e->getMessage());
+		}
+		$this->assertNotEmpty($errors);
+		$this->assertSame('', $_POST['zzz']);
+	}
+
+	// --- R5-R8: rowhelper state-loop (run AFTER the ingress guard, mirroring
+	// the real script's execution order: guard mutates $_POST, then the state
+	// loop reads it) ----------------------------------------------------------
+
+	public function testStateLoopHeaderArrayValueDoesNotThrow(): void
+	{
+		$_POST = [
+			'aliasname' => 'validname',
+			'state-0'   => 'Enabled',
+			'header-0'  => ['x'],
+			'url-0'     => 'http://192.0.2.1/feed',	// RFC 5737 literal -- avoids DNS resolution
+			'format-0'  => 'auto',
+		];
+		pfb_category_oracle_aliasname_region('dnsbl');	// runs the ingress guard
+		try {
+			pfb_category_oracle_state_loop('DNSBL');
+		} catch (\TypeError $e) {
+			$this->fail('an array header-0 must not TypeError the state loop: ' . $e->getMessage());
+		}
+		$this->assertSame('', $_POST['header-0'], 'the guard must blank the array header value');
+	}
+
+	public function testStateLoopUrlArrayValueDoesNotThrow(): void
+	{
+		$_POST = [
+			'aliasname' => 'validname',
+			'state-0'   => 'Enabled',
+			'header-0'  => 'validheader',
+			'url-0'     => ['x'],
+			'format-0'  => 'auto',
+		];
+		$guardErrors = pfb_category_oracle_aliasname_region('dnsbl');
+		try {
+			pfb_category_oracle_state_loop('DNSBL');
+		} catch (\TypeError $e) {
+			$this->fail('an array url-0 must not TypeError the state loop: ' . $e->getMessage());
+		}
+		// R11: the guard itself produced an input error for the array url-0 field.
+		$this->assertNotEmpty(
+			array_filter($guardErrors, static fn (string $e): bool => str_contains($e, 'url-0')),
+			'the guard must report the array url-0 field as invalid'
+		);
+		// R12: url-0 is blanked to a scalar, never left as an array to reach config_set_path().
+		$this->assertSame('', $_POST['url-0'], 'the guard must blank the array url value');
+	}
+
+	public function testStateLoopGeoipFormatUrlArrayDoesNotThrow(): void
+	{
+		$_POST = [
+			'aliasname' => 'validname',
+			'state-0'   => 'Enabled',
+			'header-0'  => 'validheader',
+			'url-0'     => ['x'],
+			'format-0'  => 'geoip',
+		];
+		pfb_category_oracle_aliasname_region('dnsbl');
+		try {
+			pfb_category_oracle_state_loop('DNSBL');
+		} catch (\TypeError $e) {
+			$this->fail('format=geoip with an array url-0 must not TypeError: ' . $e->getMessage());
+		}
+		$this->assertSame('', $_POST['url-0']);
+	}
+
+	public function testStateLoopAsnFormatUrlArrayDoesNotThrow(): void
+	{
+		$_POST = [
+			'aliasname' => 'validname',
+			'state-0'   => 'Enabled',
+			'header-0'  => 'validheader',
+			'url-0'     => ['x'],
+			'format-0'  => 'asn',
+		];
+		pfb_category_oracle_aliasname_region('dnsbl');
+		try {
+			pfb_category_oracle_state_loop('DNSBL');
+		} catch (\TypeError $e) {
+			$this->fail('format=asn with an array url-0 must not TypeError: ' . $e->getMessage());
+		}
+		$this->assertSame('', $_POST['url-0']);
+	}
+
+	// --- R9/R10: custom list --------------------------------------------------
+
+	public function testCustomArrayValueDoesNotThrow(): void
+	{
+		$_POST = ['aliasname' => 'validname', 'custom' => ['x']];
+		pfb_category_oracle_aliasname_region('dnsbl');	// guard blanks 'custom' to ''
+		try {
+			$errors = pfb_category_oracle_custom_block('dnsbl');
+		} catch (\TypeError $e) {
+			$this->fail('an array custom value must not TypeError explode(): ' . $e->getMessage());
+		}
+		// R10: base64_encode() (save-success path, line ~806) is unreachable with
+		// an empty string too -- shadowed by this same guard, not separately tested.
+		$this->assertSame([], $errors, 'a blanked custom value adds no further validation errors');
+		$this->assertSame('', $_POST['custom']);
+	}
+
+	public function testCustomBlockStillValidatesInvalidIpv4Entry(): void
+	{
+		// Behaviour-preserving: the extraction still runs the REAL validation,
+		// not a stub that always returns clean.
+		$_POST = ['custom' => 'not-an-ip', 'whois_convert' => ''];
+		$errors = pfb_category_oracle_custom_block('ipv4');
+		$this->assertNotEmpty(
+			array_filter($errors, static fn (string $e): bool => str_contains($e, 'Invalid IPv4 entry')),
+			'a bad IPv4 custom-list entry must still be rejected'
+		);
+	}
+
+	// --- R13: savemsg ---------------------------------------------------------
+
+	public function testSavemsgArrayValueIsIgnoredWithoutThrowing(): void
+	{
+		$_REQUEST['savemsg'] = ['x'];
+		try {
+			$savemsg = pfb_category_oracle_savemsg();
+		} catch (\TypeError $e) {
+			$this->fail('an array savemsg must not TypeError htmlspecialchars(): ' . $e->getMessage());
+		}
+		$this->assertNull($savemsg, 'an array savemsg must be ignored -- $savemsg stays unset');
+	}
+
+	public function testSavemsgScalarValueIsEscaped(): void
+	{
+		$_REQUEST['savemsg'] = 'ok <b>';
+		$savemsg = pfb_category_oracle_savemsg();
+		$this->assertSame(htmlspecialchars('ok <b>'), $savemsg, 'a scalar savemsg is still HTML-escaped and rendered');
+	}
+}

--- a/tests/smoke/ui/test_post_array_scalar_guards.py
+++ b/tests/smoke/ui/test_post_array_scalar_guards.py
@@ -13,11 +13,13 @@ plus a fatal in ``php_error.log``. Two guard layers close it for these pages:
   ``trim``) plus the IP ``array_key_exists`` site get inline scalar guards.
 
 Scope: this closes issue #1070's enumerated pages plus the ``pfb_filter``
-root for every filter-routed caller. ``pfblockerng_category_edit.php`` has a
-separate cluster of direct-string sinks that bypass ``pfb_filter`` -- tracked
-in #1106, not covered here.
+root for every filter-routed caller, AND issue #1106's
+``pfblockerng_category_edit.php`` cluster of direct-string sinks that bypass
+``pfb_filter`` (an ingress guard blanks any non-scalar POST field; ``atype``
+and ``$_REQUEST[savemsg]`` get their own ``is_string()`` guard since they run
+outside the save block, reachable via a plain GET query).
 
-Each save must respond like any validation failure: HTTP 200, no login
+Each save/GET must respond like any validation failure: HTTP 200, no login
 bounce, and NOT ONE new byte in any candidate ``php_error.log``.
 """
 
@@ -47,15 +49,23 @@ def _post_with_array_field(
     smoke_vm: helpers.SmokeVM,
     page: str,
     array_field: str,
+    extra_fields: dict[str, str] | None = None,
 ) -> None:
     """Scrape the page's own form, replace one field with an array value, POST.
 
     Scenario: an authenticated save whose ``{array_field}[]`` carries an array.
       Given the page's own scraped field set (valid CSRF token included),
-      When the field is re-sent in PHP array syntax and the save is POSTed,
+      When the field is re-sent in PHP array syntax and the save is POSTed
+        (``extra_fields``, if given, overrides sibling scalar fields so the
+        crafted field's own validation line is actually reached -- e.g. a
+        rowhelper ``state-N`` must be non-``Disabled`` before its sibling
+        ``url-N``/``header-N`` are read),
       Then the handler answers HTTP 200 (a normal validation reject, never a
         TypeError-driven 500), the session survives, and no candidate
-        ``php_error.log`` gained a byte during the request.
+        ``php_error.log`` gained a byte during the request. Every crafted
+        aliasname/custom/url-0 case here is rejected by validation before
+        ``write_config()`` (an empty/invalid aliasname at rowid 0), so the
+        box is never mutated.
     """
     guard = PhpErrorLogGuard(smoke_vm)
     guard.snapshot()
@@ -67,6 +77,8 @@ def _post_with_array_field(
     payload = scrape_form_fields(got.text)
     payload.pop(array_field, None)
     payload[f"{array_field}[]"] = "crafted"
+    if extra_fields:
+        payload.update(extra_fields)
     payload["save"] = "Save"
 
     resp = webui.session.post(webui.url(page), data=payload, verify=webui._verify, timeout=_POST_TIMEOUT)
@@ -79,22 +91,68 @@ def _post_with_array_field(
     guard.assert_no_growth()
 
 
-# (page, field) covering every array-TypeError class the theme spans (issue #1070):
-# the 3 directly-guarded fields (explode/base64/trim), plus representatives of the
-# pfb_filter-routed classes closed by the shared guard -- ON_OFF, WORD, NUM -- and
-# the array_key_exists site. All resolve to the same graceful-reject assertion.
-_ARRAY_FIELD_CASES = [
-    ("/pfblockerng/pfblockerng_sync.php", "varsyncusername-0"),  # rowhelper loop
-    ("/pfblockerng/pfblockerng_sync.php", "varsynctimeout"),  # pfb_filter NUM (pre-loop)
-    ("/pfblockerng/pfblockerng_ip.php", "v4suppression"),  # explode/base64
-    ("/pfblockerng/pfblockerng_ip.php", "enable_dup"),  # pfb_filter ON_OFF
-    ("/pfblockerng/pfblockerng_ip.php", "asn_token"),  # pfb_filter WORD
-    ("/pfblockerng/pfblockerng_ip.php", "pfb_alias_delta_mode"),  # array_key_exists
-    ("/pfblockerng/pfblockerng_general.php", "pfb_feed_internal_allowlist"),  # trim
-    ("/pfblockerng/pfblockerng_general.php", "enable_cb"),  # pfb_filter ON_OFF
+# (page, field, extra_fields) covering every array-TypeError class the theme spans
+# (issue #1070): the 3 directly-guarded fields (explode/base64/trim), plus
+# representatives of the pfb_filter-routed classes closed by the shared guard --
+# ON_OFF, WORD, NUM -- and the array_key_exists site; plus (issue #1106) the
+# category_edit ingress-guard cluster. All resolve to the same graceful-reject
+# assertion. extra_fields is None everywhere except the url-0 case, which needs a
+# non-Disabled sibling state-N before its own validation line is reached.
+_ARRAY_FIELD_CASES: list[tuple[str, str, dict[str, str] | None]] = [
+    ("/pfblockerng/pfblockerng_sync.php", "varsyncusername-0", None),  # rowhelper loop
+    ("/pfblockerng/pfblockerng_sync.php", "varsynctimeout", None),  # pfb_filter NUM (pre-loop)
+    ("/pfblockerng/pfblockerng_ip.php", "v4suppression", None),  # explode/base64
+    ("/pfblockerng/pfblockerng_ip.php", "enable_dup", None),  # pfb_filter ON_OFF
+    ("/pfblockerng/pfblockerng_ip.php", "asn_token", None),  # pfb_filter WORD
+    ("/pfblockerng/pfblockerng_ip.php", "pfb_alias_delta_mode", None),  # array_key_exists
+    ("/pfblockerng/pfblockerng_general.php", "pfb_feed_internal_allowlist", None),  # trim
+    ("/pfblockerng/pfblockerng_general.php", "enable_cb", None),  # pfb_filter ON_OFF
+    # issue #1106: category_edit's own ingress guard (bypasses pfb_filter entirely).
+    ("/pfblockerng/pfblockerng_category_edit.php?type=dnsbl", "aliasname", None),  # preg_match/strlen
+    ("/pfblockerng/pfblockerng_category_edit.php?type=dnsbl", "custom", None),  # explode
+    ("/pfblockerng/pfblockerng_category_edit.php?type=dnsbl", "atype", None),  # str_starts_with
+    (
+        "/pfblockerng/pfblockerng_category_edit.php?type=dnsbl",
+        "url-0",  # strpos/pfb_filter(URL) in the rowhelper state-loop
+        {"state-0": "Enabled", "header-0": "hdr", "format-0": "auto"},
+    ),
 ]
 
 
-@pytest.mark.parametrize(("page", "field"), _ARRAY_FIELD_CASES)
-def test_array_valued_field_rejected_gracefully(webui: WebUI, smoke_vm: helpers.SmokeVM, page: str, field: str) -> None:
-    _post_with_array_field(webui, smoke_vm, page, field)
+@pytest.mark.parametrize(("page", "field", "extra_fields"), _ARRAY_FIELD_CASES)
+def test_array_valued_field_rejected_gracefully(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    page: str,
+    field: str,
+    extra_fields: dict[str, str] | None,
+) -> None:
+    _post_with_array_field(webui, smoke_vm, page, field, extra_fields)
+
+
+# issue #1106: 'atype' (GET) and '$_REQUEST[savemsg]' are read outside the save
+# block via a plain query string -- unreachable through _post_with_array_field's
+# scraped-form POST, so exercised directly as GET queries.
+_GET_ARRAY_QUERY_CASES = [
+    "/pfblockerng/pfblockerng_category_edit.php?type=dnsbl&savemsg[]=crafted",
+    "/pfblockerng/pfblockerng_category_edit.php?type=dnsbl&atype[]=crafted",
+]
+
+
+@pytest.mark.parametrize("page", _GET_ARRAY_QUERY_CASES)
+def test_get_query_array_value_rejected_gracefully(webui: WebUI, smoke_vm: helpers.SmokeVM, page: str) -> None:
+    """Scenario: a crafted GET query carries an array-valued scalar param.
+
+    Given a page normally read with a scalar 'savemsg'/'atype' query value,
+    When the param is sent in PHP array syntax ('param[]=x'),
+    Then the page still answers HTTP 200 (never a TypeError 500), the session
+      survives, and no candidate ``php_error.log`` gained a byte.
+    """
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = webui.get(page)
+
+    assert resp.status_code == 200, f"GET {page} -> HTTP {resp.status_code}"
+    assert not looks_like_login_page(resp.text), f"GET {page} bounced to the login form"
+    guard.assert_no_growth()


### PR DESCRIPTION
Fixes #1106

## Problem

`pfblockerng_category_edit.php` contains a cluster of string sinks that consume raw `$_POST`/`$_GET`/`$_REQUEST` values without routing through `pfb_filter()`. A crafted request with an array-valued field (`field[]=x`, valid CSRF) reaches them with an `array` argument and PHP 8 raises `TypeError` before the input-errors gate — an HTTP 500 plus a fatal in `php_error.log`. Sibling pages were fixed in #1070 / PR #1102; this page was out of that PR's scope.

## Sink enumeration (re-derived from source, not from the issue text)

The issue's ten enumerated sites are all confirmed. Re-enumeration from the source found **three more** in the same class, plus one adjacent non-crash harm:

| Sink | Field | In issue #1106? |
| ---- | ----- | --------------- |
| `preg_match`/`strlen` (aliasname checks) | `aliasname` | yes |
| `preg_match`/`strpos`/`strstr` (state-loop cross-refs) | `header-N`, `url-N` (auto/geoip/asn) | yes |
| `explode`/`base64_encode` | `custom` | yes |
| `htmlentities` (save loop, format=asn) | `url-N` | yes |
| `str_starts_with` + `pfb_filter_whitelist_atype(string)` — runs on EVERY POST | `atype` (POST) | **no — new** |
| same shape on the GET path | `atype` (GET) | **no — new** |
| `htmlspecialchars($_REQUEST['savemsg'])` — plain GET `?savemsg[]=x` | `savemsg` | **no — new** |
| array written into `config.xml` url field (silent corruption, no crash) | `url-N` (format≠asn) | no — closed by the same guard |

Verified non-sinks: `ctype_digit` sites (returns `FALSE` on array, and select-normalized first), all loose `==` comparisons, every `pfb_filter`-routed field (hardened at the root by PR #1102), `pfb_adv_alias_field_errors()` (already `is_string`-guarded internally), the AJAX `$_GET['term']` block (already guarded).

## Fix (PR #1102 pattern)

- **Save-block ingress guard**, placed after the select-options normalization loop: every non-scalar `$_POST` value is rejected as an input error and blanked to `''`, so all later reads (validation, save loop, and the error-path `$pconfig`/`$rowdata` restore that feeds render-time sinks) stay scalar. **`Lmove` is exempt** — it is the page's one legitimate array field (row-move checkboxes, posted alongside `save`).
- **`is_string()` added to both `atype` ingress gates** (POST + GET) — they run outside the save block on every request; an array is silently ignored, as invalid `atype` already is.
- **`is_string()` on the `$_REQUEST['savemsg']` render gate.**

## Tests

- `tests/php/CategoryEditPostGuardTest.php` (new): eval-extracts six real page regions (SyncRowhelperGuardTest pattern) — 23 tests incl. hostile array shapes (`['x']`, `['a','b']`, nested, empty) under both a rowhelper key and an unknown key, the Lmove exemption pin, a no-false-positive pin, and scalar-branch coverage for the atype/savemsg gates. **Red→green executed**: 18 failures on the pre-fix page (10 uncaught TypeErrors at the real sinks + 8 missing-guard assertion failures from the hostile-shape sweeps) → 23/23 green post-fix; independently re-executed at the gate.
- `tests/smoke/ui/test_post_array_scalar_guards.py`: four category_edit POST rows (aliasname, custom, atype, url-0 with scalar companions so the sink line is reached) + a parametrized GET test for `savemsg[]`/`atype[]`. All hostile cases are rejected by validation before `write_config()`, so the box is never mutated. Tier-A render coverage of the page already exists (`test_render_smoke.py`).

Tier-B cases were run against a live pfSense VM via the local smoke runner (results in the PR conversation).
