### PR TITLE
pfblockerng: align tld_analysis() master-list loader with the Python mirror's edge-line contract

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7780,13 +7780,18 @@ function tld_analysis() {
 	// Master TLD Domain list
 	if (($t_handle = @fopen("{$pfb['dnsbl_tld_data']}", 'r')) !== FALSE) {
 		while (($line = @fgets($t_handle)) !== FALSE) {
-			$line	= rtrim($line, "\x00..\x1F");
+			$line	= trim(rtrim($line, "\x00..\x1F"));
+			// issue #1116: match the Python mirror's contract -- skip comment and
+			// whitespace-only lines; '0' is a valid dot-less TLD key.
+			if ($line === '' || str_starts_with($line, '#')) {
+				continue;
+			}
 			$dot	= strrpos($line, '.');
 			// issue #1068: a dot-less line keys under its own full value
 			// (FALSE + 1 would substr off the first char)
 			$tld	= ($dot === FALSE) ? $line : substr($line, $dot + 1);
 
-			if (!empty($tld)) {
+			if ($tld !== '') {
 				if (!isset($tlds[$tld]) || !is_array($tlds[$tld])) {
 					$tlds[$tld] = array();
 				}

--- a/tests/php/TldAnalysisMasterKeyingTest.php
+++ b/tests/php/TldAnalysisMasterKeyingTest.php
@@ -52,12 +52,15 @@ final class TldAnalysisMasterKeyingTest extends TestCase
 		$pfb['tld_update']	= array();
 
 		// Master list: dot-less lines ('com', punycode 'xn--80ak6aa92e'), two
-		// dotted lines ('co.om', 'com.ac'), a single-space line (kept as an
-		// inert garbage bucket) and hostile rows (blank, trailing-dot-only,
-		// control-char only) that must never seed a bucket either way.
+		// dotted lines ('co.om', 'com.ac'), a whitespace-only line and comment
+		// lines (bare and leading-whitespace -- all SKIPPED, issue #1116's
+		// Python-mirror contract), a bare '0' TLD and a dotted-to-'0' line
+		// (both KEPT -- the !empty() footgun fix), and hostile rows (blank,
+		// trailing-dot-only, control-char only) that must never seed a bucket.
 		file_put_contents(
 			$pfb['dnsbl_tld_data'],
 			"com\nco.om\ncom.ac\nxn--80ak6aa92e\n \n\nbad.\n.\n\x01\n"
+			. "# comment\n  # leading space comment\n0\nexample.0\n"
 		);
 
 		file_put_contents(
@@ -110,15 +113,17 @@ final class TldAnalysisMasterKeyingTest extends TestCase
 	 * Scenario: the master-list loader buckets a dot-less line.
 	 *
 	 * Given:  a master list with dot-less lines ('com', punycode
-	 *         'xn--80ak6aa92e'), dotted siblings ('co.om', 'com.ac'), a
-	 *         single-space line, and hostile rows that carry no usable TLD
+	 *         'xn--80ak6aa92e'), dotted siblings ('co.om', 'com.ac'), comment
+	 *         lines, a whitespace-only line, a bare '0' TLD, a dotted-to-'0'
+	 *         line, and hostile rows that carry no usable TLD
 	 * When:   tld_analysis() loads the master list into $tlds
 	 * Then:   each dot-less line is keyed under its own full value, not
 	 *         truncated ('com' not 'om'); 'co.om' keys under 'om' alone (no
 	 *         'com' pollution); the dotted 'com.ac' line still keys under
-	 *         'ac'; the single-space line keeps its own inert bucket; the
-	 *         zero-TLD hostile rows seed no bucket; and the loader itself
-	 *         raises no diagnostic
+	 *         'ac'; comment and whitespace-only lines seed no bucket; a bare
+	 *         '0' line and a dotted-to-'0' line both key under '0' (the
+	 *         !empty() footgun fix); the remaining zero-TLD hostile rows seed
+	 *         no bucket; and the loader itself raises no diagnostic
 	 */
 	public function testDotLessMasterLineKeysUnderItsOwnFullValue(): void
 	{
@@ -152,22 +157,32 @@ final class TldAnalysisMasterKeyingTest extends TestCase
 			"'xn--80ak6aa92e' must key under its own full value; got tlds: " . var_export($tlds, TRUE)
 		);
 
-		// R4b: a single-space line keeps its own inert bucket (unreachable by
-		// tld_search; the shipped master file has no whitespace-only lines).
-		$this->assertSame(
-			array(' ' => ''),
-			$tlds[' '] ?? NULL,
-			'a single-space line must keep its own inert bucket; got: ' . var_export($tlds[' '] ?? NULL, TRUE)
+		// R4b: a whitespace-only line is SKIPPED (Python-mirror `.strip()`
+		// contract, issue #1116) -- it must seed no bucket at all.
+		$this->assertArrayNotHasKey(
+			' ',
+			$tlds,
+			'a whitespace-only line must not seed a bucket; got: ' . var_export($tlds[' '] ?? NULL, TRUE)
 		);
 
-		// R4c: zero-TLD rows (blank, 'bad.', '.', control-char-only) seed no
-		// bucket; exact keyset pins the whole load.
+		// R4c: zero-TLD rows (blank, 'bad.', '.', control-char-only, and both
+		// comment lines) seed no bucket; exact keyset pins the whole load.
+		// Note: PHP normalises the canonical-integer string key '0' to int 0.
 		$keys = array_keys($tlds);
 		sort($keys);
 		$this->assertSame(
-			array(' ', 'ac', 'com', 'om', 'xn--80ak6aa92e'),
+			array(0, 'ac', 'com', 'om', 'xn--80ak6aa92e'),
 			$keys,
 			'hostile master-list rows must not create extra buckets; got: ' . var_export($keys, TRUE)
+		);
+
+		// R6: the !empty("0") footgun -- a bare '0' line AND a dotted line
+		// whose suffix is '0' (e.g. 'example.0') both bucket under key '0'
+		// (int 0 per PHP's numeric-string key normalisation).
+		$this->assertSame(
+			array(0 => '', 'example.0' => ''),
+			$tlds['0'] ?? NULL,
+			"'0' bucket must hold the bare '0' line and 'example.0'; got: " . var_export($tlds['0'] ?? NULL, TRUE)
 		);
 
 		// R5: diagnostic hygiene -- the loader itself raises no PHP warnings.

--- a/tests/php/TldAnalysisMasterKeyingTest.php
+++ b/tests/php/TldAnalysisMasterKeyingTest.php
@@ -52,15 +52,18 @@ final class TldAnalysisMasterKeyingTest extends TestCase
 		$pfb['tld_update']	= array();
 
 		// Master list: dot-less lines ('com', punycode 'xn--80ak6aa92e'), two
-		// dotted lines ('co.om', 'com.ac'), a whitespace-only line and comment
-		// lines (bare and leading-whitespace -- all SKIPPED, issue #1116's
-		// Python-mirror contract), a bare '0' TLD and a dotted-to-'0' line
-		// (both KEPT -- the !empty() footgun fix), and hostile rows (blank,
-		// trailing-dot-only, control-char only) that must never seed a bucket.
+		// dotted lines ('co.om', 'com.ac'), a leading-whitespace real content
+		// line (trimmed and keyed clean, not the raw padded value), whitespace-
+		// only lines (single space AND tab-mixed) and comment lines (bare and
+		// leading-whitespace -- all SKIPPED, issue #1116's Python-mirror
+		// contract), a bare '0' TLD and a dotted-to-'0' line (both KEPT -- the
+		// !empty() footgun fix), and hostile rows (blank, trailing-dot-only,
+		// control-char only) that must never seed a bucket.
 		file_put_contents(
 			$pfb['dnsbl_tld_data'],
 			"com\nco.om\ncom.ac\nxn--80ak6aa92e\n \n\nbad.\n.\n\x01\n"
 			. "# comment\n  # leading space comment\n0\nexample.0\n"
+			. "\t \t\n indented.example.com\n"
 		);
 
 		file_put_contents(
@@ -113,14 +116,16 @@ final class TldAnalysisMasterKeyingTest extends TestCase
 	 * Scenario: the master-list loader buckets a dot-less line.
 	 *
 	 * Given:  a master list with dot-less lines ('com', punycode
-	 *         'xn--80ak6aa92e'), dotted siblings ('co.om', 'com.ac'), comment
-	 *         lines, a whitespace-only line, a bare '0' TLD, a dotted-to-'0'
+	 *         'xn--80ak6aa92e'), dotted siblings ('co.om', 'com.ac'), a
+	 *         leading-whitespace real content line, comment lines, whitespace-
+	 *         only lines (space and tab-mixed), a bare '0' TLD, a dotted-to-'0'
 	 *         line, and hostile rows that carry no usable TLD
 	 * When:   tld_analysis() loads the master list into $tlds
 	 * Then:   each dot-less line is keyed under its own full value, not
 	 *         truncated ('com' not 'om'); 'co.om' keys under 'om' alone (no
 	 *         'com' pollution); the dotted 'com.ac' line still keys under
-	 *         'ac'; comment and whitespace-only lines seed no bucket; a bare
+	 *         'ac'; leading whitespace on real content is trimmed before
+	 *         keying; comment and whitespace-only lines seed no bucket; a bare
 	 *         '0' line and a dotted-to-'0' line both key under '0' (the
 	 *         !empty() footgun fix); the remaining zero-TLD hostile rows seed
 	 *         no bucket; and the loader itself raises no diagnostic
@@ -144,6 +149,14 @@ final class TldAnalysisMasterKeyingTest extends TestCase
 			"'om' bucket must hold only 'co.om'; got: " . var_export($tlds['om'] ?? NULL, TRUE)
 		);
 
+		// R2b: leading whitespace on a real content line is trimmed BEFORE
+		// keying -- ' indented.example.com' keys as the clean, unpadded value.
+		$this->assertTrue(
+			isset($tlds['com']['indented.example.com']),
+			"leading whitespace must be trimmed before keying; got tlds['com']: "
+				. var_export($tlds['com'] ?? NULL, TRUE)
+		);
+
 		// R3: dotted-line regression pin -- 'com.ac' keys under 'ac' either way.
 		$this->assertTrue(
 			isset($tlds['ac']['com.ac']),
@@ -158,11 +171,18 @@ final class TldAnalysisMasterKeyingTest extends TestCase
 		);
 
 		// R4b: a whitespace-only line is SKIPPED (Python-mirror `.strip()`
-		// contract, issue #1116) -- it must seed no bucket at all.
+		// contract, issue #1116) -- it must seed no bucket at all. Covers both
+		// a single space and a tab-mixed line (CLAUDE.md hostile-input class).
 		$this->assertArrayNotHasKey(
 			' ',
 			$tlds,
 			'a whitespace-only line must not seed a bucket; got: ' . var_export($tlds[' '] ?? NULL, TRUE)
+		);
+		$this->assertArrayNotHasKey(
+			"\t \t",
+			$tlds,
+			'a tab-mixed whitespace-only line must not seed a bucket; got: '
+				. var_export($tlds["\t \t"] ?? NULL, TRUE)
 		);
 
 		// R4c: zero-TLD rows (blank, 'bad.', '.', control-char-only, and both

--- a/tests/test_branch_coverage_gaps.py
+++ b/tests/test_branch_coverage_gaps.py
@@ -202,6 +202,12 @@ class TestLoadTldMaster:
         assert "net" not in tlds  # excluded
         assert tlds == {"com": {"com": ""}}
 
+    def test_bare_zero_tld_is_kept(self) -> None:
+        # issue #1116: "0" is a valid dot-less TLD -- not falsy-string dropped.
+        tlds = _dnsbl_load_tld_master(["0", "com"], [], [])
+        assert "0" in tlds
+        assert tlds["0"] == {"0": ""}
+
 
 # --------------------------------------------------------------------------- #
 # ABP option / regex parse helpers


### PR DESCRIPTION
## Summary
`tld_analysis()`'s PHP master-TLD-list loader diverged from its Python mirror `_dnsbl_load_tld_master()` on three edge cases:
- A `#`-prefixed comment line was bucketed as garbage instead of skipped.
- A whitespace-only line kept an inert bucket instead of being skipped.
- Any line whose extracted TLD suffix is the literal `"0"` was silently dropped by the classic `!empty("0")` PHP falsy-string footgun (not limited to a bare dot-less `"0"` line — any suffix equal to `"0"`, e.g. `example.0`).

All three are latent today (the shipped master file has no such lines) — a cross-language consistency fix, not a live-bug hotfix.

Fixes #1116

## Test plan
- [x] `vendor/bin/phpunit` — full suite green, red→green re-verified independently for the whitespace-skip behaviour change
- [x] `vendor/bin/phpstan`, `vendor/bin/phpcs` clean
- [x] `python3 -m pytest`, `ruff check`, `ruff format --check`, `mypy tests/` clean