### PR TITLE
pfblockerng: drop dead rep parameter and decisionDB global reference

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2746,7 +2746,6 @@ def get_details_dnsbl(
     m_type: str,
     qinfo: query_info | None,
     qstate: module_qstate | None,
-    rep: reply_info | None,
     kwargs: dict[str, Any] | None,
     dnsbl: Any,  # DnsblDecision operate() served; UNSET is a defensive no-op guard
 ) -> bool:
@@ -2990,7 +2989,7 @@ def get_details_reply(
     rep: reply_info | None,
     kwargs: dict[str, Any] | None,
 ) -> bool:
-    global pfb, rcodeDB, decisionDB, noAAAADB, maxmindReader
+    global pfb, rcodeDB, noAAAADB, maxmindReader
 
     if qstate and qstate is not None:
         q_name = get_q_name_qstate(qstate)
@@ -6751,7 +6750,7 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                 # via get_details_dnsbl (which internally drops the log line for "4");
                 # not cached, for the same #43 reasons as the VIP/null path below.
                 if dnsbl.nxdomain:
-                    get_details_dnsbl("dnsbl", None, qstate, None, {"pfb_addr": q_ip}, dnsbl)
+                    get_details_dnsbl("dnsbl", None, qstate, {"pfb_addr": q_ip}, dnsbl)
                     qstate.return_rcode = RCODE_NXDOMAIN
                     qstate.no_cache_store = 1
                     qstate.ext_state[id] = MODULE_FINISHED
@@ -6775,10 +6774,7 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
 
                 # Log entry
                 kwargs = {"pfb_addr": q_ip}
-                if qstate.return_msg:
-                    get_details_dnsbl("dnsbl", None, qstate, qstate.return_msg.rep, kwargs, dnsbl)
-                else:
-                    get_details_dnsbl("dnsbl", None, qstate, None, kwargs, dnsbl)
+                get_details_dnsbl("dnsbl", None, qstate, kwargs, dnsbl)
 
                 qstate.return_rcode = RCODE_NOERROR
                 qstate.return_msg.rep.security = 2

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -870,7 +870,7 @@ class TestGetDetailsDnsblQtype:
         return lines
 
     def _block(self, qtype: str) -> None:
-        pfb_unbound.get_details_dnsbl("dnsbl", None, self._qstate(qtype), None, {"pfb_addr": "1.2.3.4"}, self._dnsbl())
+        pfb_unbound.get_details_dnsbl("dnsbl", None, self._qstate(qtype), {"pfb_addr": "1.2.3.4"}, self._dnsbl())
 
     @staticmethod
     def _dnsbl_fields(lines: list[tuple[str, str]]) -> list[list[str]]:
@@ -932,7 +932,7 @@ class TestGetDetailsDnsblQtype:
                 qinfo=types.SimpleNamespace(qname_str=name, qtype_str="A"),
                 return_msg=None,
             )
-            pfb_unbound.get_details_dnsbl("dnsbl", None, qstate, None, {"pfb_addr": "1.2.3.4"}, dec)
+            pfb_unbound.get_details_dnsbl("dnsbl", None, qstate, {"pfb_addr": "1.2.3.4"}, dec)
         a_fields, b_fields = self._dnsbl_fields(lines)
         assert a_fields[9] == "+"
         assert b_fields[9] == "+"
@@ -952,7 +952,7 @@ class TestGetDetailsDnsblQtype:
             qinfo=types.SimpleNamespace(qname_str="Blocked.COM.", qtype_str="A"),
             return_msg=None,
         )
-        pfb_unbound.get_details_dnsbl("dnsbl", None, qstate, None, {"pfb_addr": "1.2.3.4"}, self._dnsbl())
+        pfb_unbound.get_details_dnsbl("dnsbl", None, qstate, {"pfb_addr": "1.2.3.4"}, self._dnsbl())
         assert len(self._dnsbl_fields(lines)) == 1  # attributed despite mixed-case query
 
 
@@ -985,7 +985,7 @@ class TestGetDetailsDnsblNxdomain:
             return_msg=None,
         )
         # When the logger runs for that block
-        pfb_unbound.get_details_dnsbl("dnsbl", None, qstate, None, {"pfb_addr": "1.2.3.4"}, dnsbl)
+        pfb_unbound.get_details_dnsbl("dnsbl", None, qstate, {"pfb_addr": "1.2.3.4"}, dnsbl)
         return lines
 
     def test_nxdomain_logging_writes_a_line(self, monkeypatch: Any) -> None:
@@ -1015,7 +1015,7 @@ class TestGetDetailsDnsblUnsetGuard:
             return_msg=None,
         )
 
-        result = pfb_unbound.get_details_dnsbl("dnsbl", None, qstate, None, {"pfb_addr": "1.2.3.4"}, pfb_unbound.UNSET)
+        result = pfb_unbound.get_details_dnsbl("dnsbl", None, qstate, {"pfb_addr": "1.2.3.4"}, pfb_unbound.UNSET)
 
         assert result is True
         assert not any(path.endswith("dnsbl.log") for path, _ in lines), lines


### PR DESCRIPTION
## Summary
`get_details_dnsbl`'s `rep: reply_info | None` parameter was never read in the function body — removed it, which collapses the nxdomain/VIP call sites' `qstate.return_msg` branching (its only purpose was selecting which `rep` value to pass). Also drops `get_details_reply`'s unused `decisionDB` global declaration — the function never reads or writes it.

Behaviour-preserving cleanup, zero functional change.

Fixes #1124

## Test plan
- [x] `python3 -m pytest` — full suite green (2640 passed, 4 skipped)
- [x] `ruff check`, `ruff format --check`, `mypy tests/` clean
- [x] Fresh grep confirms no remaining 4th-arg call to `get_details_dnsbl` and `decisionDB` gone from `get_details_reply`'s global statement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and reliability of DNSBL event logging.
  * Preserved existing DNS filtering decisions and logged verdict behavior.

* **Tests**
  * Updated automated coverage to reflect the latest DNSBL logging behavior and verify existing results remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->