### PR TITLE
pfblockerng: validate Xmove anchor and Lmove keys before category row reorder

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -927,7 +927,7 @@ else {
 
 // Move selected table row(s) to anchor row
 // issue #1129: a stale/hostile Lmove or Xmove must not silently drop rows
-if (isset($Lmove) and isset($Xmove) && isset($rowdata[$rowid]['row'])
+if (isset($Lmove) && isset($Xmove) && isset($rowdata[$rowid]['row'])
 	&& is_array($Lmove) && !empty($Lmove)
 	&& is_scalar($Xmove) && array_key_exists($Xmove, $rowdata[$rowid]['row'])
 	&& !array_diff_key($Lmove, $rowdata[$rowid]['row'])) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -926,7 +926,11 @@ else {
 
 
 // Move selected table row(s) to anchor row
-if (isset($Lmove) and isset($Xmove) && isset($rowdata[$rowid]['row'])) {
+// issue #1129: a stale/hostile Lmove or Xmove must not silently drop rows
+if (isset($Lmove) and isset($Xmove) && isset($rowdata[$rowid]['row'])
+	&& is_array($Lmove) && !empty($Lmove)
+	&& is_scalar($Xmove) && array_key_exists($Xmove, $rowdata[$rowid]['row'])
+	&& !array_diff_key($Lmove, $rowdata[$rowid]['row'])) {
 
 	$disable_move	= TRUE;
 	$move = $final	= array();

--- a/tests/php/CategoryEditRowMoveTest.php
+++ b/tests/php/CategoryEditRowMoveTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Category-edit row-move (anchor) reorder guard (issue #1129).
+ *
+ * A stale/hostile Lmove or Xmove (a checkbox/anchor left over from a form
+ * gone stale in another tab, or a crafted request) let the reorder loop
+ * collect checked rows into $move for re-insertion, then never re-insert
+ * them because the anchor branch never fired -- the checked rows silently
+ * vanished from $final before it was persisted via config_set_path() +
+ * write_config(). The fix requires Lmove to be a non-empty array, Xmove to
+ * be a scalar that is literally an existing row key, and every checked
+ * Lmove key to exist in the row set -- otherwise the whole block is skipped
+ * (no move, no save) instead of rebuilding a row list that drops rows.
+ *
+ * Like CategoryEditPostGuardTest, the page carries top-level execution and
+ * cannot be require()d off-appliance: the reorder block is eval-extracted
+ * verbatim from the REAL source (anchored on text stable across both the
+ * pre-fix and post-fix code, so the same test file proves red on the old
+ * code and green on the new) up to the row-array assignment -- stopping
+ * before config_set_path()/write_config()/header()/exit() so the extracted
+ * function is a pure array transform.
+ */
+final class CategoryEditRowMoveTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
+		}
+
+		if (!function_exists('pfb_category_oracle_row_move')) {
+			if (!preg_match(
+				'/\/\/ Move selected table row\(s\) to anchor row\n(?:\/\/[^\n]*\n)*'
+				. '(if \(isset\(\$Lmove\).*?\$rowdata\[\$rowid\]\[\'row\'\] = \$final;\n)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: row-move reorder block not found');
+			}
+			eval(
+				'function pfb_category_oracle_row_move(array $rowdata, $rowid, $Lmove, $Xmove): array {'
+				. $m[1]
+				. '}'
+				. ' return $rowdata[$rowid][\'row\']; }'
+			);
+		}
+	}
+
+	private function rowdata(array $rows): array
+	{
+		return [0 => ['row' => $rows]];
+	}
+
+	/**
+	 * Runs the extracted reorder oracle, capturing any PHP warning/notice it
+	 * triggers instead of letting it escape (the pre-fix code path warns on
+	 * an undefined $pre/array key for some hostile inputs -- row 5).
+	 *
+	 * @return array{0: array<int, string>, 1: array<int, string>}
+	 */
+	private function runRowMove(array $rowdata, $rowid, $Lmove, $Xmove): array
+	{
+		$warnings = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+			$warnings[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$result = pfb_category_oracle_row_move($rowdata, $rowid, $Lmove, $Xmove);
+		} finally {
+			restore_error_handler();
+		}
+		return [$result, $warnings];
+	}
+
+	// --- Row 1: regression guard -- the pre-existing correct-move behaviour ----
+
+	public function testValidMoveRelocatesCheckedRowAfterAnchor(): void
+	{
+		// Given: three rows, row1 checked to move to anchor row2 (an existing key).
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2']);
+
+		// When: the reorder runs with a valid anchor.
+		[$result, ] = $this->runRowMove($rowdata, 0, [1 => '1'], 2);
+
+		// Then: row1 relocates immediately after row2 -- unchanged since before the fix.
+		$this->assertSame(['row0', 'row2', 'row1'], $result, 'row1 must relocate immediately after the anchor row2');
+	}
+
+	// --- Row 2: THE BUG -- a stale/out-of-range anchor must not drop rows ------
+
+	public function testStaleAnchorSkipsReorderInsteadOfDroppingCheckedRow(): void
+	{
+		// Given: row1 checked, but Xmove references no row key (stale form state).
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2']);
+
+		// When: the reorder runs with the stale anchor.
+		[$result, ] = $this->runRowMove($rowdata, 0, [1 => '1'], '999');
+
+		// Then: the whole reorder is skipped -- row1 is NOT silently dropped.
+		$this->assertSame(
+			['row0', 'row1', 'row2'],
+			$result,
+			'a stale/out-of-range Xmove anchor must skip the reorder, not drop the checked row'
+		);
+	}
+
+	// --- Row 3: array-valued Xmove (hostile) ------------------------------------
+
+	public function testArrayValuedAnchorSkipsReorderWithoutTypeError(): void
+	{
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2']);
+
+		try {
+			[$result, ] = $this->runRowMove($rowdata, 0, [1 => '1'], ['hostile']);
+		} catch (\TypeError $e) {
+			$this->fail('an array-valued Xmove must not TypeError: ' . $e->getMessage());
+		}
+
+		$this->assertSame(
+			['row0', 'row1', 'row2'],
+			$result,
+			'an array-valued Xmove must skip the reorder, not drop the checked row'
+		);
+	}
+
+	// --- Row 4: Lmove references a deleted/stale row key ------------------------
+
+	public function testStaleLmoveKeySkipsReorderInsteadOfCorruptingRowSet(): void
+	{
+		// Given: the checked row key 99 no longer exists in the current row set.
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2']);
+
+		// When: the reorder runs with a valid anchor but a stale checked key.
+		[$result, ] = $this->runRowMove($rowdata, 0, [99 => '1'], 0);
+
+		// Then: the reorder is skipped -- the row set (including the anchor row0) survives.
+		$this->assertSame(
+			['row0', 'row1', 'row2'],
+			$result,
+			'a checked Lmove key absent from the row set must skip the reorder'
+		);
+	}
+
+	// --- Row 5: empty Lmove -- nothing checked -----------------------------------
+
+	public function testEmptyLmoveSkipsReorderWithoutUndefinedVariableWarning(): void
+	{
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2']);
+
+		[$result, $warnings] = $this->runRowMove($rowdata, 0, [], 0);
+
+		$this->assertSame([], $warnings, 'an empty Lmove must not reach the undefined-$pre-variable code path');
+		$this->assertSame(
+			['row0', 'row1', 'row2'],
+			$result,
+			'an empty Lmove means nothing was checked -- the row set stays unchanged'
+		);
+	}
+
+	// --- Row 6: non-array Lmove (hostile) ----------------------------------------
+
+	public function testNonArrayLmoveSkipsReorderWithoutCrash(): void
+	{
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2']);
+
+		try {
+			[$result, ] = $this->runRowMove($rowdata, 0, 'x', 0);
+		} catch (\Throwable $e) {
+			$this->fail('a non-array Lmove must not crash the reorder: ' . get_class($e) . ': ' . $e->getMessage());
+		}
+
+		$this->assertSame(
+			['row0', 'row1', 'row2'],
+			$result,
+			'a non-array (hostile) Lmove must skip the reorder, not corrupt the row set'
+		);
+	}
+}

--- a/tests/php/CategoryEditRowMoveTest.php
+++ b/tests/php/CategoryEditRowMoveTest.php
@@ -83,7 +83,7 @@ final class CategoryEditRowMoveTest extends TestCase
 
 	// --- Row 1: regression guard -- the pre-existing correct-move behaviour ----
 
-	public function testValidMoveRelocatesCheckedRowAfterAnchor(): void
+	public function testValidMoveRelocatesCheckedRowNextToAnchor(): void
 	{
 		// Given: three rows, row1 checked to move to anchor row2 (an existing key).
 		$rowdata = $this->rowdata(['row0', 'row1', 'row2']);
@@ -91,8 +91,10 @@ final class CategoryEditRowMoveTest extends TestCase
 		// When: the reorder runs with a valid anchor.
 		[$result, ] = $this->runRowMove($rowdata, 0, [1 => '1'], 2);
 
-		// Then: row1 relocates immediately after row2 -- unchanged since before the fix.
-		$this->assertSame(['row0', 'row2', 'row1'], $result, 'row1 must relocate immediately after the anchor row2');
+		// Then: row1 lands adjacent to row2 -- pins the pre-existing, unchanged-by-this-fix
+		// placement rule (not a before/after claim; see the UI tooltip vs. actual algorithm
+		// discrepancy tracked separately).
+		$this->assertSame(['row0', 'row2', 'row1'], $result, 'row1 must land adjacent to the anchor row2, unchanged from pre-fix behaviour');
 	}
 
 	// --- Row 2: THE BUG -- a stale/out-of-range anchor must not drop rows ------

--- a/tests/smoke/ui/test_category_edit_row_move.py
+++ b/tests/smoke/ui/test_category_edit_row_move.py
@@ -1,0 +1,183 @@
+"""issue #1129 -- category-edit row-move (Lmove/Xmove anchor) reorder guard, live.
+
+``CategoryEditRowMoveTest`` (tests/php/) already pins the reorder algorithm as a
+pure array transform extracted off-appliance. This file proves the SAME guard
+end-to-end against the real box: a crafted POST that reaches the reorder block
+(category_edit.php:930, the ``else`` of ``isset($_POST['save'])`` at :452 --
+NOT the save handler) either persists a real reorder or, for a stale/hostile
+Xmove, causes NO mutation at all -- observable only by re-fetching the box's
+EFFECTIVE rendered state (never inferred from the algorithm alone), which is
+why this is Tier B (``ui_e2e``), not ``ui_render``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PhpErrorLogGuard
+from .test_category_edit import CFG_DNSBL, SAVE_TIMEOUT, _del_rowid, _dnsbl_payload, _free_rowid, _post_form
+from .webui import extract_csrf_token, looks_like_login_page, scrape_form_fields
+
+if TYPE_CHECKING:
+    import requests
+
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+CATEGORY_PAGE = "/pfblockerng/pfblockerng_category_edit.php"
+
+
+def _three_row_payload(rowid: int, aliasname: str, headers: tuple[str, str, str]) -> dict[str, str]:
+    """A 3-row, ``sort='no-sort'`` dnsbl save payload -- one Disabled row per header.
+
+    ``sort='no-sort'`` is what makes ``pfblockerng_category_edit.php`` render the
+    Lmove checkbox / Xmove anchor button per row (:1127) instead of auto-sorting
+    on every render (:1091) -- the real precondition for the anchor UI to exist,
+    confirmed by grep, not assumed. Extends ``_dnsbl_payload``'s one-row
+    convention to 3 rows sharing its field set.
+    """
+    payload = _dnsbl_payload(rowid, aliasname, sort="no-sort")
+    for i, header in enumerate(headers):
+        payload[f"format-{i}"] = "auto"
+        payload[f"state-{i}"] = "Disabled"
+        payload[f"url-{i}"] = ""
+        payload[f"header-{i}"] = header
+    return payload
+
+
+def _post_move(webui: WebUI, payload: dict[str, str]) -> requests.Response:
+    """POST an anchor-move request with NO ``save`` field (fresh CSRF harvested).
+
+    The reorder block lives in the ``else`` of ``isset($_POST['save'])``
+    (category_edit.php:452/871/930) -- unlike ``_post_form``, this must NOT set
+    ``save``, or the request routes into the SAVE handler instead of the move
+    branch and never reaches the guard under test.
+    """
+    get = webui.get(CATEGORY_PAGE, params={"type": payload.get("type", "dnsbl")})
+    assert not looks_like_login_page(get.text), "category GET returned the login form (session lost)"
+    token = extract_csrf_token(get.text)
+    data = dict(payload)
+    data["__csrf_magic"] = token
+    resp = webui.session.post(webui.url(CATEGORY_PAGE), data=data, verify=webui._verify, timeout=SAVE_TIMEOUT)
+    assert not looks_like_login_page(resp.text), "category move POST returned the login form (session lost)"
+    return resp
+
+
+def _headers(webui: WebUI, rowid: int) -> tuple[str, str, str]:
+    """Scrape ``header-0``/``header-1``/``header-2`` off a fresh GET of ``rowid``."""
+    resp = webui.get(CATEGORY_PAGE, params={"type": "dnsbl", "rowid": str(rowid)})
+    assert not looks_like_login_page(resp.text), "category GET (reload) returned the login form (session lost)"
+    fields = scrape_form_fields(resp.text)
+    return (fields.get("header-0", ""), fields.get("header-1", ""), fields.get("header-2", ""))
+
+
+# --------------------------------------------------------------------------- #
+# THE BUG, now fixed: a stale/hostile Xmove anchor must skip the whole reorder
+# -- never silently drop the checked row (issue #1129's exact repro).
+# --------------------------------------------------------------------------- #
+
+
+def test_stale_xmove_anchor_does_not_drop_checked_row(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Scenario: a checked row plus a stale (nonexistent) anchor key.
+
+    Given a 3-row no-sort DNSBL category with distinct headers per row,
+    When a reorder POST checks the middle row (``Lmove[1]='1'``) but anchors on
+      a row key that does not exist (``Xmove='999'`` -- the issue #1129 repro),
+    Then the request answers HTTP 200 with no PHP-error-log growth, and a
+      follow-up GET's ``header-0``/``header-1``/``header-2`` are IDENTICAL to
+      the pre-move values -- the checked row was NOT silently dropped.
+
+    Pre-fix, the reorder block had no anchor-existence guard: it entered
+    unconditionally on ``isset($Lmove) && isset($Xmove)``, collected the
+    checked row into ``$move`` for re-insertion, but the re-insertion branch
+    (``$Xmove == $key``) never fires because no row key equals '999' -- so the
+    checked row is skipped out of ``$final`` and never merged back in. The
+    resulting 2-row ``$final`` is written via ``config_set_path`` +
+    ``write_config()``: header-1 vanishes and header-2's slot shifts left. That
+    is exactly what this test's final assertion would catch.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_DNSBL)
+    headers = ("rowmoveA", "rowmoveB", "rowmoveC")
+    try:
+        _post_form(webui, _three_row_payload(rowid, "smokemvbug", headers))
+
+        # BEFORE: the 3 rows landed exactly as saved (no-sort -> no reorder yet).
+        before = _headers(webui, rowid)
+        assert before == headers, f"3-row create did not persist as saved: got {before!r}"
+
+        guard = PhpErrorLogGuard(vm)
+        guard.snapshot()
+
+        # WHEN: Lmove checks row key 1, Xmove anchors on a row key that does
+        # not exist -- the issue #1129 repro.
+        resp = _post_move(
+            webui,
+            {"type": "dnsbl", "rowid": str(rowid), "Lmove[1]": "1", "Xmove": "999"},
+        )
+        assert resp.status_code == 200, f"stale-anchor move POST -> HTTP {resp.status_code} (expected 200)"
+        guard.assert_no_growth()
+
+        # THEN: the row set is UNCHANGED -- the checked row was not dropped.
+        after = _headers(webui, rowid)
+        assert after == before, (
+            f"a stale Xmove anchor must leave the row set unchanged, but it changed: {before!r} -> {after!r}"
+        )
+    finally:
+        _del_rowid(vm, CFG_DNSBL, rowid)
+
+
+# --------------------------------------------------------------------------- #
+# Regression guard: a VALID anchor still performs the move (mirrors
+# CategoryEditRowMoveTest::testValidMoveRelocatesCheckedRowNextToAnchor).
+# --------------------------------------------------------------------------- #
+
+
+def test_valid_xmove_anchor_relocates_checked_row(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Scenario: a checked row plus a real, existing anchor key.
+
+    Given a 3-row no-sort DNSBL category with distinct headers per row,
+    When a reorder POST checks the middle row (``Lmove[1]='1'``) and anchors on
+      the LAST row's own key (``Xmove='2'``, an existing row),
+    Then the row set is REORDERED (not merely preserved): the checked row
+      relocates to just after the anchor row -- ``[row0, row2, row1]``, the
+      same placement ``CategoryEditRowMoveTest`` pins off-appliance -- proving
+      the #1129 fix's guard does not also block the legitimate case.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_DNSBL)
+    headers = ("rowmoveX", "rowmoveY", "rowmoveZ")
+    try:
+        _post_form(webui, _three_row_payload(rowid, "smokemvok", headers))
+
+        # BEFORE: the 3 rows landed exactly as saved.
+        before = _headers(webui, rowid)
+        assert before == headers, f"3-row create did not persist as saved: got {before!r}"
+
+        # WHEN: Lmove checks row key 1, Xmove anchors on row key 2 (exists).
+        resp = _post_move(
+            webui,
+            {"type": "dnsbl", "rowid": str(rowid), "Lmove[1]": "1", "Xmove": "2"},
+        )
+        assert resp.status_code == 200, f"valid move POST -> HTTP {resp.status_code} (expected 200)"
+
+        # THEN: row1 relocated to sit right after the anchor row2 -- all three
+        # headers survive, reordered (not the before-state -- proves the POST
+        # CAUSED the move, matching CategoryEditRowMoveTest's pinned placement).
+        after = _headers(webui, rowid)
+        assert after != before, "a valid anchor move must change the row order, but it stayed the same"
+        assert after == (headers[0], headers[2], headers[1]), (
+            f"row1 must land adjacent to anchor row2 ([h0, h2, h1]), got {after!r}"
+        )
+    finally:
+        _del_rowid(vm, CFG_DNSBL, rowid)


### PR DESCRIPTION
## Summary

Category Edit's row-move (anchor) feature silently drops checked rows from the
config when the `Xmove` anchor doesn't match any existing row key (a stale
form, or a crafted request). No error, no warning — the rows just vanish from
the persisted config.

Root cause: the reorder loop collects checked rows into `$move` for
re-insertion at the anchor, but the re-insertion branch only fires when
`$Xmove == $key` for some row — if no row matches, the collected rows are
never re-inserted anywhere.

## Fix

Extend the reorder block's guarding condition so it validates the anchor and
every checked-row key *before* running the reorder — if `Xmove` isn't a
scalar key present in the row set, or any checked `Lmove` key isn't present,
the whole reorder is skipped (page renders unchanged) instead of persisting a
list that lost rows.

## Test plan

- [x] New `tests/php/CategoryEditRowMoveTest.php`, eval-extraction pattern,
      covers: valid move (regression guard), stale anchor (the bug), array-valued
      anchor, stale `Lmove` key, empty `Lmove`, non-array `Lmove`
- [x] Red→green re-executed independently: 5/6 scenarios fail on unpatched code,
      pass after
- [x] `php -l`, `vendor/bin/phpunit`, `vendor/bin/phpstan`, `vendor/bin/phpcs` all green

Fixes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)