### PR TITLE
pfblockerng: guard _dnsbl_load_tld_master against empty extracted TLD

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4267,6 +4267,8 @@ def _dnsbl_load_tld_master(
         if not suffix or suffix.startswith("#"):
             continue
         tld = suffix.rsplit(".", 1)[-1]
+        if not tld:
+            continue
         if tld in blacklist or tld in exclusion_keys:
             continue
         tlds.setdefault(tld, {})[suffix] = ""

--- a/tests/test_branch_coverage_gaps.py
+++ b/tests/test_branch_coverage_gaps.py
@@ -199,8 +199,7 @@ class TestLoadTldMaster:
         # '' -- must be dropped like PHP's tld_analysis(), not seed a '' bucket.
         # 'com' (dot-less, unaffected) proves the guard is scoped to the empty case.
         tlds = _dnsbl_load_tld_master(["bad.", ".", "..", "com"], [], [])
-        assert "" not in tlds
-        assert tlds["com"] == {"com": ""}
+        assert tlds == {"com": {"com": ""}}
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_branch_coverage_gaps.py
+++ b/tests/test_branch_coverage_gaps.py
@@ -194,6 +194,14 @@ class TestLoadTldMaster:
         assert "0" in tlds
         assert tlds["0"] == {"0": ""}
 
+    def test_empty_extracted_tld_dropped(self) -> None:
+        # issue #1134: rsplit('.', 1)[-1] on a trailing-dot/bare-dot row extracts
+        # '' -- must be dropped like PHP's tld_analysis(), not seed a '' bucket.
+        # 'com' (dot-less, unaffected) proves the guard is scoped to the empty case.
+        tlds = _dnsbl_load_tld_master(["bad.", ".", "..", "com"], [], [])
+        assert "" not in tlds
+        assert tlds["com"] == {"com": ""}
+
 
 # --------------------------------------------------------------------------- #
 # ABP option / regex parse helpers


### PR DESCRIPTION
## Summary

- Python's `_dnsbl_load_tld_master()` had no guard for a suffix line whose extracted TLD (`suffix.rsplit(".", 1)[-1]`) is empty (e.g. `bad.`, `.`) — it seeded a divergent `''`-keyed bucket instead of dropping the row.
- PHP's `tld_analysis()` already filters `$tld !== ''` for the same input, pinned by `tests/php/TldAnalysisMasterKeyingTest.php`'s R4c case.
- Adds a one-line guard mirroring the PHP semantics; adds `test_empty_extracted_tld_dropped` covering `bad.`/`.`/`..` (dropped) and `com` (kept, unaffected).
- Currently latent in production: the shipped `dnsbl_tld` master file (7731 lines) has zero rows that trigger this — verified this session by scanning the file. This closes the cross-language parity gap and guards against a future master-list update reintroducing such rows.

Fixes #1134

## Test plan

- [x] `python3 -m pytest` — 2635 passed, 4 skipped
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `python3 -m mypy tests/` — clean
- [x] Red→green proven independently by both a fresh verifier agent and the orchestrator (checked out the pre-fix source with the new test present → FAILED for the exact reason described; restored → PASSED, zero test edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS blocklist processing by ignoring entries that do not contain a valid top-level domain.
  * Prevented malformed entries, such as trailing-dot or bare-dot records, from being added to the loaded blocklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->