### PR TITLE
pfblockerng: fix row-move inner-loop warning and self-anchor duplication

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -927,10 +927,13 @@ else {
 
 // Move selected table row(s) to anchor row
 // issue #1129: a stale/hostile Lmove or Xmove must not silently drop rows
+// issue #1135: anchoring on a row that is itself checked is rejected -- it
+// is either a no-op (honest click) or duplicates the row (crafted mismatch)
 if (isset($Lmove) && isset($Xmove) && isset($rowdata[$rowid]['row'])
 	&& is_array($Lmove) && !empty($Lmove)
 	&& is_scalar($Xmove) && array_key_exists($Xmove, $rowdata[$rowid]['row'])
-	&& !array_diff_key($Lmove, $rowdata[$rowid]['row'])) {
+	&& !array_diff_key($Lmove, $rowdata[$rowid]['row'])
+	&& !isset($Lmove[$Xmove])) {
 
 	$disable_move	= TRUE;
 	$move = $final	= array();
@@ -953,13 +956,15 @@ if (isset($Lmove) && isset($Xmove) && isset($rowdata[$rowid]['row'])
 		}
 
 		if ($Xmove == $key) {
-			if ($pre && $Lmove[$key] != $Xmove) {
+			// issue #1135: $key is the anchor's own row -- not necessarily a checked
+			// Lmove key, so read it with a null-coalesce to avoid an undefined-key warning
+			if ($pre && ($Lmove[$key] ?? null) != $Xmove) {
 				$final[] = $row;
 			}
 
 			$final = array_merge($final, $move);
 
-			if (!$pre && $Lmove[$key] != $Xmove) {
+			if (!$pre && ($Lmove[$key] ?? null) != $Xmove) {
 				$final[] = $row;
 			}
 			continue;

--- a/tests/php/CategoryEditRowMoveTest.php
+++ b/tests/php/CategoryEditRowMoveTest.php
@@ -221,15 +221,8 @@ final class CategoryEditRowMoveTest extends TestCase
 		// When: the reorder runs with Xmove referencing the same checked row.
 		[$result, ] = $this->runRowMove($rowdata, 0, [1 => '1'], '1');
 
-		// Then: the row set is unchanged. This was already a no-duplicate no-op
-		// pre-fix (the honest Lmove[key]===key value keeps the merge from
-		// duplicating); post-fix the new outer-guard clause additionally makes
-		// this a clean whole-block skip. The extracted oracle stops before the
-		// side effects (config_set_path/write_config/header/exit) that would
-		// distinguish "entered, no-op" from "skipped", so this row's array
-		// assertion does not itself flip red-to-green -- it is a behaviour-
-		// preservation pin, the same distinction row 1 documents for its own
-		// baseline assertion.
+		// Then: the row set is unchanged -- pre-fix already a no-op here, post-fix
+		// the outer guard explicitly skips; a behaviour-preservation pin either way.
 		$this->assertSame(
 			['row0', 'row1', 'row2'],
 			$result,

--- a/tests/php/CategoryEditRowMoveTest.php
+++ b/tests/php/CategoryEditRowMoveTest.php
@@ -186,4 +186,74 @@ final class CategoryEditRowMoveTest extends TestCase
 			'a non-array (hostile) Lmove must skip the reorder, not corrupt the row set'
 		);
 	}
+
+	// --- Row 7: issue #1135 defect 1 -- ordinary move, anchor not itself checked ---
+
+	public function testOrdinaryMoveToUncheckedAnchorTriggersNoUndefinedKeyWarning(): void
+	{
+		// Given: row1 checked to move to anchor row2 -- row2 itself is NOT checked,
+		// the ordinary case, so $Lmove has no entry for the anchor's own key.
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2']);
+
+		// When: the reorder runs.
+		[$result, $warnings] = $this->runRowMove($rowdata, 0, [1 => '1'], 2);
+
+		// Then: the move result matches the pre-existing baseline (unchanged by this
+		// fix -- pins testValidMoveRelocatesCheckedRowNextToAnchor's outcome), AND no
+		// PHP warning fires reading $Lmove[$key] at the unset anchor key (the actual
+		// red-to-green signal for this row).
+		$this->assertSame(['row0', 'row2', 'row1'], $result, 'row1 must still land adjacent to anchor row2');
+		$this->assertSame(
+			[],
+			$warnings,
+			'reading $Lmove at the anchor row\'s own (unchecked) key must not emit an undefined-array-key warning'
+		);
+	}
+
+	// --- Row 8: issue #1135 defect 2 -- genuine self-click (honest Lmove[key]===key) ---
+
+	public function testGenuineSelfAnchorSkipsReorderCleanly(): void
+	{
+		// Given: row1 checked with the honest UI-generated value (Lmove[1] === '1',
+		// matching its own key) and anchored on itself.
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2']);
+
+		// When: the reorder runs with Xmove referencing the same checked row.
+		[$result, ] = $this->runRowMove($rowdata, 0, [1 => '1'], '1');
+
+		// Then: the row set is unchanged. This was already a no-duplicate no-op
+		// pre-fix (the honest Lmove[key]===key value keeps the merge from
+		// duplicating); post-fix the new outer-guard clause additionally makes
+		// this a clean whole-block skip. The extracted oracle stops before the
+		// side effects (config_set_path/write_config/header/exit) that would
+		// distinguish "entered, no-op" from "skipped", so this row's array
+		// assertion does not itself flip red-to-green -- it is a behaviour-
+		// preservation pin, the same distinction row 1 documents for its own
+		// baseline assertion.
+		$this->assertSame(
+			['row0', 'row1', 'row2'],
+			$result,
+			'a genuine self-anchored move must not duplicate or drop the checked row'
+		);
+	}
+
+	// --- Row 9: issue #1135 defect 2 -- THE BUG: crafted self-anchor mismatch ---
+
+	public function testCraftedSelfAnchorMismatchNoLongerDuplicatesRow(): void
+	{
+		// Given: row1 checked but with a TAMPERED Lmove value ('999', not its own
+		// key '1') and Xmove anchoring on that same checked row -- an authenticated
+		// attacker crafting Lmove[1]=999&Xmove=1, not a genuine UI click.
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2']);
+
+		// When: the reorder runs with the crafted mismatch.
+		[$result, ] = $this->runRowMove($rowdata, 0, [1 => '999'], '1');
+
+		// Then: the reorder is skipped entirely -- row1 appears exactly once.
+		$this->assertSame(
+			['row0', 'row1', 'row2'],
+			$result,
+			'a crafted Lmove/Xmove self-anchor mismatch must skip the reorder, not duplicate the checked row'
+		);
+	}
 }

--- a/tests/smoke/ui/test_category_edit_row_move.py
+++ b/tests/smoke/ui/test_category_edit_row_move.py
@@ -8,6 +8,9 @@ NOT the save handler) either persists a real reorder or, for a stale/hostile
 Xmove, causes NO mutation at all -- observable only by re-fetching the box's
 EFFECTIVE rendered state (never inferred from the algorithm alone), which is
 why this is Tier B (``ui_e2e``), not ``ui_render``.
+
+issue #1135 adds one more scenario below: a crafted self-anchor mismatch
+(``Lmove[1]=999`` while ``Xmove=1``) duplicating the checked row on the real box.
 """
 
 from __future__ import annotations
@@ -178,6 +181,68 @@ def test_valid_xmove_anchor_relocates_checked_row(
         assert after != before, "a valid anchor move must change the row order, but it stayed the same"
         assert after == (headers[0], headers[2], headers[1]), (
             f"row1 must land adjacent to anchor row2 ([h0, h2, h1]), got {after!r}"
+        )
+    finally:
+        _del_rowid(vm, CFG_DNSBL, rowid)
+
+
+# --------------------------------------------------------------------------- #
+# THE BUG (issue #1135): a crafted Lmove/Xmove self-anchor mismatch must not
+# duplicate the checked row -- never a genuine UI click (see
+# CategoryEditRowMoveTest::testCraftedSelfAnchorMismatchNoLongerDuplicatesRow).
+# --------------------------------------------------------------------------- #
+
+
+def test_crafted_self_anchor_mismatch_does_not_duplicate_row(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Scenario: a checked row whose Lmove value is TAMPERED to mismatch its own key.
+
+    Given a 3-row no-sort DNSBL category with distinct headers per row,
+    When a reorder POST checks row key 1 with a value OTHER than its own key
+      (``Lmove[1]='999'``, a crafted/tampered value -- an honest UI click always
+      sends ``Lmove[1]='1'``) and anchors on that SAME checked row
+      (``Xmove='1'``),
+    Then the request answers HTTP 200 with no PHP-error-log growth, and a
+      follow-up GET's headers are IDENTICAL to the pre-move values -- row1 was
+      NOT duplicated into the persisted row set.
+
+    Pre-fix, the outer guard did not reject an anchor that is itself a checked
+    Lmove key, and the mismatched value (``'999' != '1'``) satisfied both the
+    ``$pre``/``!$pre`` re-insertion checks, so ``$final`` gained BOTH the
+    anchor row's own copy AND the merged ``$move`` copy -- row1 appears twice,
+    row2 shifts into a new header-3 slot. That is exactly what this test's
+    final assertion would catch.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_DNSBL)
+    headers = ("rowmvdup1", "rowmvdup2", "rowmvdup3")
+    try:
+        _post_form(webui, _three_row_payload(rowid, "smokemvdup", headers))
+
+        # BEFORE: the 3 rows landed exactly as saved (no-sort -> no reorder yet).
+        before = _headers(webui, rowid)
+        assert before == headers, f"3-row create did not persist as saved: got {before!r}"
+
+        guard = PhpErrorLogGuard(vm)
+        guard.snapshot()
+
+        # WHEN: Lmove[1] carries a tampered value ('999', not row1's own key '1'),
+        # Xmove anchors on that same checked row (self-reference) -- the issue
+        # #1135 repro.
+        resp = _post_move(
+            webui,
+            {"type": "dnsbl", "rowid": str(rowid), "Lmove[1]": "999", "Xmove": "1"},
+        )
+        assert resp.status_code == 200, f"crafted self-anchor move POST -> HTTP {resp.status_code} (expected 200)"
+        guard.assert_no_growth()
+
+        # THEN: the row set is UNCHANGED -- row1 was not duplicated.
+        after = _headers(webui, rowid)
+        assert after == before, (
+            f"a crafted Lmove/Xmove self-anchor mismatch must leave the row set unchanged, "
+            f"but it changed: {before!r} -> {after!r}"
         )
     finally:
         _del_rowid(vm, CFG_DNSBL, rowid)


### PR DESCRIPTION
## Summary

Two pre-existing defects in Category Edit's row-move (anchor) reorder **inner loop**
(#1129/PR #1133 fixed this block's outer guard condition; these are separate defects
in the loop bodies that fix intentionally left untouched):

1. **Undefined-array-key warning on ordinary use.** `$Lmove[$key]` is read at the
   anchor row's own key with no guard — only set when the anchor row is *also*
   checked, which it normally isn't. Every ordinary "check row A, anchor row B"
   move emitted a PHP warning.
2. **Row duplication via a crafted anchor.** A request where `Lmove[N]`'s value
   doesn't match its own key (e.g. `Lmove[1]=999`) combined with `Xmove=1`
   (self-referencing the checked row) duplicated that row in the persisted config.

Note: the original issue's plain-English framing ("clicking that same row's own
anchor button duplicates the row") turned out to be inaccurate for a genuine UI
click — verified a real form submission always keeps `Lmove[key] === key`, under
which self-referencing does *not* duplicate. The real defect needs a crafted
mismatch, not ordinary use — narrowed and corrected during triage.

## Fix

- Null-coalesce the two `$Lmove[$key]` reads in the anchor branch.
- Extend the outer guard with `!isset($Lmove[$Xmove])` — an anchor that is itself
  a checked key now skips the whole reorder (same "render unchanged" idiom #1129
  established) instead of proceeding into an ill-defined case.

## Test plan

- [x] 3 new PHPUnit test methods, test-first: authored red, executed red against
      the pre-fix code (independently re-executed and pasted in the PR discussion),
      restored, green with zero edits
- [x] New Tier-B smoke case proving the crafted-mismatch fix live
- [x] `php -l`, `vendor/bin/phpunit`, `vendor/bin/phpstan`, `vendor/bin/phpcs`, coverage-pairing all green

Fixes #1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)