### PR TITLE
pfblockerng: reject array-valued POSTs in pfb_filter() and the alerts filter-selection preprocessor

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1194,6 +1194,14 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 		}
 	}
 
+	// issue #1070: every non-FILE_MIME type runs scalar string ops below (htmlspecialchars/
+	// preg_match) that PHP 8 TypeErrors on an array -- reject an array up front, before any
+	// such op runs, for those types. issue #1139: must run before the control-char loop
+	// below, which itself TypeErrors on a nested (non-scalar) array element.
+	if (is_array($input) && !in_array($type, array(PFB_FILTER_FILE_MIME_COMPARE, PFB_FILTER_FILE_MIME, PFB_FILTER_FILE_MIME_COMPRESSED))) {
+		return $return_type;
+	}
+
 	// Check for control characters. The /u modifier is required: without it, \p{C}
 	// classifies each raw BYTE as a Latin-1 codepoint, so a valid multibyte UTF-8
 	// character (e.g. "€", "日") whose continuation byte falls in 0x80-0x9F is
@@ -1201,6 +1209,8 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 	// genuinely invalid-UTF-8 subject is silently accepted. With /u, preg_match()
 	// returns FALSE (not 0) on invalid UTF-8, so the check must reject on `!== 0`
 	// to fail closed (this is a PFBL-01 input-sanitisation gate) rather than open.
+	// The reject above already returned for every non-FILE_MIME type, so this array
+	// branch only ever sees FILE_MIME's flat literal-string arrays (ADR-48).
 	if (is_array($input)) {
 		foreach ($input as $vline) {
 			if (preg_match("/[\p{C}]+/u", $vline) !== 0) {
@@ -1224,13 +1234,6 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			}
 			return $return_type;
 		}
-	}
-
-	// issue #1070: every non-FILE_MIME type runs scalar string ops below (htmlspecialchars/
-	// preg_match) that PHP 8 TypeErrors on an array, so a crafted array POST ('field[]=x')
-	// would 500 the page -- reject an array up front for those types.
-	if (is_array($input) && !in_array($type, array(PFB_FILTER_FILE_MIME_COMPARE, PFB_FILTER_FILE_MIME, PFB_FILTER_FILE_MIME_COMPRESSED))) {
-		return $return_type;
 	}
 
 	$result = FALSE;

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -654,6 +654,12 @@ if (isset($_POST) && !empty($_POST)) {
 
 			foreach ($ftypes as $submit_type => $final_type) {
 				if (isset($_POST['filterlogentries_submit_' . $submit_type]) && !empty($_POST['filterlogentries_submit_' . $submit_type])) {
+					// issue #1139: an array-valued POST reaches explode()/pfb_filter() below
+					// with no scalar guard -- skip it instead of TypeError-ing the page.
+					if (!is_string($_POST['filterlogentries_submit_' . $submit_type])) {
+						continue;
+					}
+
 					$final_type = $ftypes[$submit_type];
 
 					// Split SRC/DST In/Outbound field into two filter fields (IP/GeoIP)

--- a/tests/php/AlertsPostGuardTest.php
+++ b/tests/php/AlertsPostGuardTest.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Alerts-page array-request guard (issue #1128).
+ * Alerts-page array-request guard (issue #1128, #1139).
  *
  * A crafted request submitting an array-valued 'save' or 'ip' field
  * ('save[]=x', 'ip[]=x') reached a strictly-typed string sink
@@ -13,6 +14,10 @@ use PHPUnit\Framework\TestCase;
  * (HTTP 500). The fix defaults 'save' to '' (matching the file's existing
  * default-on-bad-input style) and adds is_string() to the outer 'ip' strpos()
  * guard (the inner check at the nested preg_match() already had one).
+ *
+ * Issue #1139 adds region 3: the 'Filter selection' preprocessor's three
+ * explode(',', $_POST[...]) sinks TypeError the same way on an array-valued
+ * 'filterlogentries_submit_*' field.
  *
  * The page carries top-level execution and cannot be require()d off-appliance,
  * so each region below is eval-extracted verbatim from the REAL source,
@@ -62,6 +67,23 @@ final class AlertsPostGuardTest extends TestCase
 				. ' $ip = \'\';'
 				. $m[1]
 				. ' return $ip; }'
+			);
+		}
+
+		// Region 3: the 'Filter selection' preprocessor -> mutated $_POST.
+		if (!function_exists('pfb_alerts_oracle_filter_selection')) {
+			if (!preg_match(
+				'/\$filter_type = array\(\);\n(.*?)\n\t\/\/ Filter Alerts based on user defined/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: filter-selection region not found');
+			}
+			eval(
+				'function pfb_alerts_oracle_filter_selection(): array {'
+				. ' $filter_type = array();'
+				. $m[1]
+				. ' return $_POST; }'
 			);
 		}
 	}
@@ -153,5 +175,97 @@ final class AlertsPostGuardTest extends TestCase
 			$this->fail('a nested array ip value must not TypeError: ' . $e->getMessage());
 		}
 		$this->assertSame('', $ip, 'a nested array ip value must resolve to the blank/rejected ip');
+	}
+
+	// --- site 3: 'Filter selection' preprocessor -------------------------
+
+	public function testFilterSelectionReplySrcIpdArrayValueDoesNotThrowAndSkipsField(): void
+	{
+		$_POST['filterlogentries_submit_replysrcipd'] = ['x', 'y'];
+		try {
+			$post = pfb_alerts_oracle_filter_selection();
+		} catch (\TypeError $e) {
+			$this->fail('an array replysrcipd value must not TypeError explode(): ' . $e->getMessage());
+		}
+		$this->assertArrayNotHasKey('filterlogentries_submit', $post, 'an array value must not flip filterlogentries_submit to Apply Filter');
+		$this->assertArrayNotHasKey('filterlogentries_replydomain', $post, 'a skipped field must not set the split domain key');
+		$this->assertArrayNotHasKey('filterlogentries_replysrcip', $post, 'a skipped field must not set the split ip key');
+	}
+
+	public static function ipPairFieldProvider(): array
+	{
+		return [
+			'ipsrcipin'  => ['ipsrcipin', 'filterlogentries_ipsrcip'],
+			'ipsrcipout' => ['ipsrcipout', 'filterlogentries_ipsrcip'],
+			'ipdstipin'  => ['ipdstipin', 'filterlogentries_ipdstip'],
+			'ipdstipout' => ['ipdstipout', 'filterlogentries_ipdstip'],
+		];
+	}
+
+	#[DataProvider('ipPairFieldProvider')]
+	public function testFilterSelectionIpPairArrayValueDoesNotThrowAndSkipsField(string $submitType, string $finalKey): void
+	{
+		$_POST['filterlogentries_submit_' . $submitType] = ['x', 'y'];
+		try {
+			$post = pfb_alerts_oracle_filter_selection();
+		} catch (\TypeError $e) {
+			$this->fail("an array {$submitType} value must not TypeError explode(): " . $e->getMessage());
+		}
+		$this->assertArrayNotHasKey('filterlogentries_submit', $post, 'an array value must not flip filterlogentries_submit to Apply Filter');
+		$this->assertArrayNotHasKey($finalKey, $post, 'a skipped field must not set its split ip key');
+		$this->assertArrayNotHasKey('filterlogentries_ipgeoip', $post, 'a skipped field must not set the split geoip key');
+	}
+
+	public function testFilterSelectionNestedArrayValueDoesNotThrowAndSkipsField(): void
+	{
+		// A nested array ('...replysrcipd[0][]=x', parse_str-shaped) reaches the same
+		// explode() sink as the flat-array case -- covered separately since parse_str()
+		// shapes it differently than a literal PHP array.
+		parse_str('filterlogentries_submit_replysrcipd[0][]=x', $parsed);
+		$_POST['filterlogentries_submit_replysrcipd'] = $parsed['filterlogentries_submit_replysrcipd'];
+		try {
+			$post = pfb_alerts_oracle_filter_selection();
+		} catch (\TypeError $e) {
+			$this->fail('a nested array replysrcipd value must not TypeError explode(): ' . $e->getMessage());
+		}
+		$this->assertArrayNotHasKey('filterlogentries_submit', $post, 'a nested array value must not flip filterlogentries_submit to Apply Filter');
+	}
+
+	public function testFilterSelectionReplySrcIpdScalarValueStillSplits(): void
+	{
+		$_POST['filterlogentries_submit_replysrcipd'] = 'dom.com,1.2.3.4';
+		$post = pfb_alerts_oracle_filter_selection();
+		$this->assertSame('dom.com', $post['filterlogentries_replydomain'] ?? null, 'a scalar value must still split into the domain field');
+		$this->assertSame('1.2.3.4', $post['filterlogentries_replysrcip'] ?? null, 'a scalar value must still split into the ip field');
+		$this->assertSame('Apply Filter', $post['filterlogentries_submit'] ?? null, 'a scalar value must still flip filterlogentries_submit');
+	}
+
+	public function testFilterSelectionIpSrcIpInScalarValueStillSplits(): void
+	{
+		$_POST['filterlogentries_submit_ipsrcipin'] = '1.2.3.4,US';
+		$post = pfb_alerts_oracle_filter_selection();
+		$this->assertSame('1.2.3.4', $post['filterlogentries_ipsrcip'] ?? null, 'a scalar value must still split into the ip field');
+		$this->assertSame('US', $post['filterlogentries_ipgeoip'] ?? null, 'a scalar value must still split into the geoip field');
+		$this->assertSame('Apply Filter', $post['filterlogentries_submit'] ?? null, 'a scalar value must still flip filterlogentries_submit');
+	}
+
+	public function testFilterSelectionElseBranchScalarValueStillApplies(): void
+	{
+		$_POST['filterlogentries_submit_ipdate'] = 'Jul 10';
+		$post = pfb_alerts_oracle_filter_selection();
+		$this->assertSame('Jul 10', $post['filterlogentries_ipdate'] ?? null, 'a scalar value must still reach the else/pfb_filter branch');
+		$this->assertSame('Apply Filter', $post['filterlogentries_submit'] ?? null, 'a scalar value must still flip filterlogentries_submit');
+	}
+
+	public function testFilterSelectionElseBranchArrayValueSkipsFieldInsteadOfApplying(): void
+	{
+		// pfb_filter() is already array-safe post-#1070/#1139 (returns the caller
+		// default instead of throwing), so this is not a TypeError repro -- it pins
+		// that the new top-level guard skips the field instead of silently applying
+		// a blanked-out value and flipping filterlogentries_submit anyway.
+		$_POST['filterlogentries_submit_ipdate'] = ['x'];
+		$post = pfb_alerts_oracle_filter_selection();
+		$this->assertArrayNotHasKey('filterlogentries_ipdate', $post, 'an array value must not set the else-branch field, even to a blanked default');
+		$this->assertArrayNotHasKey('filterlogentries_submit', $post, 'an array value must not flip filterlogentries_submit to Apply Filter');
 	}
 }

--- a/tests/php/PfbFilterTest.php
+++ b/tests/php/PfbFilterTest.php
@@ -161,6 +161,39 @@ final class PfbFilterTest extends TestCase
 		$this->assertSame($default, pfb_filter(['x'], $type, 'test', $default));
 	}
 
+	/**
+	 * issue #1139: the control-character loop iterates array elements as
+	 * scalars (preg_match($vline, ...)) and previously ran BEFORE the issue
+	 * #1070 array reject -- a nested array element ('field[0][]=x') is
+	 * itself an array, so it TypeErrors inside that loop instead of ever
+	 * reaching the reject. The reject must run first for every array shape,
+	 * not just a flat one.
+	 *
+	 * @return array<string, array{mixed, int, string}>
+	 */
+	public static function nestedArrayProvider(): array
+	{
+		return [
+			'nested one level'       => [[['x']], PFB_FILTER_WORD, ''],
+			'nested, custom default' => [[['x']], PFB_FILTER_WORD, 'SENTINEL'],
+			'deeply nested'          => [[[['deep']]], PFB_FILTER_HTML, ''],
+			'assoc of arrays'        => [['a' => ['b']], PFB_FILTER_HTML, ''],
+		];
+	}
+
+	#[DataProvider('nestedArrayProvider')]
+	public function testNestedArrayInputReturnsDefaultInsteadOfThrowing(array $input, int $type, string $default): void
+	{
+		$this->assertSame($default, pfb_filter($input, $type, 'test', $default));
+	}
+
+	public function testNestedArrayInputHitsUrlFalseSentinelNotDefault(): void
+	{
+		// PFB_FILTER_URL overrides $return_type to FALSE regardless of the
+		// caller's $default -- a nested array must hit that same override.
+		$this->assertSame(FALSE, pfb_filter([['x']], PFB_FILTER_URL, 'test'));
+	}
+
 	public static function tokenProvider(): array
 	{
 		return [

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -276,6 +276,29 @@ def test_ip_remove_rejects_array_valued_ip(webui: WebUI, smoke_vm: helpers.Smoke
     guard.assert_no_growth()
 
 
+def test_filter_selection_rejects_array_valued_submit_field(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """issue #1139: the 'Filter selection' preprocessor guards an array submit field.
+
+    Given the ``foreach ($ftypes as ...)`` loop (alerts.php, runs only when
+    no ``save`` and no ``filterlogentries_submit`` key are posted -- the
+    'Alert Statistics' Filter-action shape, not the settings-save form),
+    When ``filterlogentries_submit_replysrcipd`` rides PHP array syntax
+    instead of a scalar,
+    Then the page answers HTTP 200 (never a TypeError-driven 500), the
+    session survives, and no candidate ``php_error.log`` gains a byte. The
+    block only populates ``$_POST``/render state, never ``write_config()``,
+    so no teardown is needed.
+    """
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = _post_action(webui, {"filterlogentries_submit_replysrcipd[]": "crafted"})
+
+    assert resp.status_code == 200, f"filter-selection array POST -> HTTP {resp.status_code}"
+    assert not looks_like_login_page(resp.text), "filter-selection array POST bounced to the login form"
+    guard.assert_no_growth()
+
+
 # --------------------------------------------------------------------------- #
 # addwhitelistdom (alerts.php:947): adds a domain to the DNSBL Whitelist
 # (``suppression`` node) when ``dnsbl_exclude != 'true'``, OR to the TLD Exclusion


### PR DESCRIPTION
Fixes #1139. Two fixes for the array-valued-POST TypeError class (tracker #1143):

1. **`pfb_filter()` array-reject now runs before its own control-character loop**
   (`pfblockerng.inc`). The issue #1070 `is_array()` early-reject sat *after* the
   control-char `foreach`, so a nested array (`field[0][]=x`) still reached
   `preg_match()` with a non-string element and threw. Moving the reject above the
   loop closes every `pfb_filter($_POST[...])` call site at once (~50 across `www/`),
   including the alerts `table` field named in the issue. The loop's array branch
   still serves the FILE_MIME types, whose seven callers all pass internal literal
   string arrays — never raw POST.

2. **The alerts "Filter selection" preprocessor skips non-string
   `filterlogentries_submit_*` values** (`pfblockerng_alerts.php`). Its three
   `explode(',', $_POST[...])` branches had no scalar guard; a single crafted
   `filterlogentries_submit_replysrcipd[]=x` POST (no `save` key) threw before any
   validation. One `is_string()` guard at the top of the `$ftypes` foreach body covers
   all four branches uniformly.

Test evidence (both steps red-first, frozen byte-identical red→green):

- `PfbFilterTest`: nested-array rows (`[['x']]` per filter type, deep/assoc shapes,
  caller-default and URL-`FALSE` sentinels) — red with the `preg_match()` TypeError,
  green zero-edits after the reorder.
- `AlertsPostGuardTest` Region 3 (eval-extracted verbatim from the real page, anchors
  stable across pre/post-fix): array + nested rows for `replysrcipd` and all four
  `ipsrcip*/ipdstip*` fields red with the `explode()` TypeError; the else-branch array
  row is a genuine behavioural red (pre-fix it silently blanked the field AND flipped
  `filterlogentries_submit` to `Apply Filter`); three scalar happy-path pins preserve
  the split semantics.
- Tier B smoke: `test_filter_selection_rejects_array_valued_submit_field`
  (`tests/smoke/ui/test_alerts.py`, `_post_action` bare POST — the shared
  `_post_with_array_field` helper adds `save`, which would exit in the save handler
  before reaching this block) asserts HTTP 200, no login bounce, zero
  `php_error.log` growth. Tier A render coverage for the page already exists.

Notes: the `replydstipd` elseif is confirmed dead code (`replydstipd` is not a key in
any `$ftypes` map), left untouched; the new guard covers it structurally.
`pfb_filter()`'s FILE_MIME types still iterate arrays by design — a nested array
there remains a (caller-unreachable) TypeError, recorded as a deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed filter inputs, including array and nested-array values.
  - Prevented PHP errors when invalid filter selections are submitted.
  - Invalid values are safely ignored while valid scalar filters continue to work as expected.
  - Filter pages now remain accessible instead of returning server errors for these inputs.

- **Tests**
  - Added regression coverage for affected filter types, scalar behavior, and UI submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->