### PR TITLE
pfblockerng: fix multi-row $pre placement vote loss in category-edit row-move (#1145)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -937,16 +937,19 @@ if (isset($Lmove) && isset($Xmove) && isset($rowdata[$rowid]['row'])
 
 	$disable_move	= TRUE;
 	$move = $final	= array();
+	$pre_votes = $post_votes = 0;
 	foreach ($rowdata[$rowid]['row'] as $key => $row) {
 		if (isset($Lmove[$key])) {
 			$move[] = $row;	// Collect row(s) to move
 
-			$pre = TRUE;
 			if ($Lmove[$key] > $Xmove) {
-				$pre = FALSE;
+				$post_votes++;
+			} else {
+				$pre_votes++;
 			}
 		}
 	}
+	$pre = ($post_votes > $pre_votes) ? FALSE : TRUE;
 
 	foreach ($rowdata[$rowid]['row'] as $key => $row) {
 

--- a/tests/php/CategoryEditRowMoveTest.php
+++ b/tests/php/CategoryEditRowMoveTest.php
@@ -249,4 +249,87 @@ final class CategoryEditRowMoveTest extends TestCase
 			'a crafted Lmove/Xmove self-anchor mismatch must skip the reorder, not duplicate the checked row'
 		);
 	}
+
+	// --- Row 10: issue #1145 -- multiple checked rows straddling the anchor ----
+
+	public function testStraddleTieDefaultsToPreTrue(): void
+	{
+		// Given: five rows, two checked (key1 before anchor, key3 after anchor) --
+		// an equal before/after vote split.
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2', 'row3', 'row4']);
+
+		// When: the reorder runs with the straddling checked set.
+		[$result, ] = $this->runRowMove($rowdata, 0, [1 => '1', 3 => '3'], 2);
+
+		// Then: a tied vote defaults to pre=TRUE (moved block lands after the anchor) --
+		// every checked row's own placement vote counts, not just the last-iterated one.
+		$this->assertSame(['row0', 'row2', 'row1', 'row3', 'row4'], $result, 'a tied before/after vote must default to pre=TRUE');
+	}
+
+	public function testStraddleMajorityBeforeWins(): void
+	{
+		// Given: three checked rows straddling the anchor, two voting before (0,1)
+		// and one voting after (3).
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2', 'row3', 'row4']);
+
+		// When: the reorder runs.
+		[$result, ] = $this->runRowMove($rowdata, 0, [0 => '0', 1 => '1', 3 => '3'], 2);
+
+		// Then: the before-majority wins -- moved block lands after the anchor.
+		$this->assertSame(['row2', 'row0', 'row1', 'row3', 'row4'], $result, 'a before-majority vote must win over a single after-voter');
+	}
+
+	public function testStraddleMajorityAfterWins(): void
+	{
+		// Given: three checked rows straddling the anchor, one voting before (1)
+		// and two voting after (3,4).
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2', 'row3', 'row4']);
+
+		// When: the reorder runs.
+		[$result, ] = $this->runRowMove($rowdata, 0, [1 => '1', 3 => '3', 4 => '4'], 2);
+
+		// Then: the after-majority wins -- moved block lands before the anchor.
+		$this->assertSame(['row0', 'row1', 'row3', 'row4', 'row2'], $result, 'an after-majority vote must win over a single before-voter');
+	}
+
+	public function testAllCheckedRowsBeforeAnchorUnaffectedByFix(): void
+	{
+		// Given: two checked rows, both before the anchor -- a unanimous vote,
+		// so majority-vote tallying must agree with the pre-existing behaviour.
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2', 'row3', 'row4']);
+
+		// When: the reorder runs.
+		[$result, ] = $this->runRowMove($rowdata, 0, [0 => '0', 1 => '1'], 3);
+
+		// Then: the moved block lands after the anchor, same as before this fix.
+		$this->assertSame(['row2', 'row3', 'row0', 'row1', 'row4'], $result, 'a unanimous before vote must be unaffected by the fix');
+	}
+
+	public function testAllCheckedRowsAfterAnchorUnaffectedByFix(): void
+	{
+		// Given: two checked rows, both after the anchor -- a unanimous vote,
+		// so majority-vote tallying must agree with the pre-existing behaviour.
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2', 'row3', 'row4']);
+
+		// When: the reorder runs.
+		[$result, ] = $this->runRowMove($rowdata, 0, [3 => '3', 4 => '4'], 1);
+
+		// Then: the moved block lands before the anchor, same as before this fix.
+		$this->assertSame(['row0', 'row3', 'row4', 'row1', 'row2'], $result, 'a unanimous after vote must be unaffected by the fix');
+	}
+
+	public function testSingleCheckedRowAfterAnchorMovesBeforeIt(): void
+	{
+		// Given: the mirror of testValidMoveRelocatesCheckedRowNextToAnchor --
+		// the single checked row (key3) is now AFTER the anchor (key1). Anchor is
+		// deliberately non-zero: a zero-keyed unchecked anchor hits an unrelated,
+		// pre-existing loose-comparison quirk in the untouched second loop.
+		$rowdata = $this->rowdata(['row0', 'row1', 'row2', 'row3']);
+
+		// When: the reorder runs.
+		[$result, ] = $this->runRowMove($rowdata, 0, [3 => '3'], 1);
+
+		// Then: row3 lands adjacent to the anchor, before it this time.
+		$this->assertSame(['row0', 'row3', 'row1', 'row2'], $result, 'a single checked row after the anchor must land adjacent to it, before it');
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #1145: in the Category Edit row-move (anchor) reorder block, `$pre`
(whether checked rows land before or after the anchor) was overwritten on
every iteration of the first loop that finds a checked (`Lmove`) key. With
multiple checked rows straddling the anchor on both sides, only the
last-iterated checked row's before/after comparison survived.

## Fix

Replaced the per-iteration `$pre` clobber with a majority vote: tally
before/after votes across all checked rows, decide `$pre` once after the
loop (`$post_votes > $pre_votes ? FALSE : TRUE`, tie defaults to `TRUE`,
matching the existing default-TRUE-unless-greater-than convention). Minimal
diff -- only the first loop changes; the guard, second loop, and persistence
calls are untouched.

## Tests

6 new PHPUnit methods in `tests/php/CategoryEditRowMoveTest.php` covering
the coverage matrix: tie straddle (the issue's own repro), majority-before
straddle, majority-after straddle, unanimous-before/-after (regression,
unaffected by the fix), and single-checked-row-after-anchor (mirrors the
existing before-anchor regression test). Red-before/green-after re-executed
independently by an adversarial gate agent via the checkout dance -- see
commit body / delegation records for the full evidence trail.

## Out of scope (filed separately)

While gating this fix, a distinct pre-existing bug was found in the same
block's untouched second loop: a loose (`!=`) comparison silently drops the
anchor row when `Xmove` is `0` (`null != 0` is `FALSE` in PHP). Filed as
#1149; not fixed here to keep this diff minimal and scoped to #1145.

Fixes #1145

---
🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
