### PR TITLE
scripts: make the varver/ABI/image-name guards collation-immune

### DIFF
--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -211,12 +211,13 @@ jobs:
           set -eu
           # Compose the untagged image from the namespace var + per-matrix image_name.
           # Fallback: lowercased owner (GHCR refs MUST be lowercase).
-          case "$MATRIX_IMAGE_NAME" in
-            ''|*[!a-z0-9._-]*)
-              echo "::error::invalid matrix.image_name: '$MATRIX_IMAGE_NAME'"
-              exit 1
-              ;;
-          esac
+          # issue #1148: LC_ALL=C tr, not a `case` range — a collating locale
+          # lets [a-z] admit uppercase/accented letters, defeating the guard.
+          if [ -z "$MATRIX_IMAGE_NAME" ] || \
+             [ -n "$(printf '%s' "$MATRIX_IMAGE_NAME" | LC_ALL=C tr -d 'a-z0-9._-')" ]; then
+            echo "::error::invalid matrix.image_name: '$MATRIX_IMAGE_NAME'"
+            exit 1
+          fi
           REPO="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
           IMAGE="${REPO%/}/${MATRIX_IMAGE_NAME}"
           printf 'image=%s\n' "$IMAGE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -211,10 +211,11 @@ jobs:
           set -eu
           # Compose the untagged image from the namespace var + per-matrix image_name.
           # Fallback: lowercased owner (GHCR refs MUST be lowercase).
-          # issue #1148: LC_ALL=C tr, not a `case` range — a collating locale
-          # lets [a-z] admit uppercase/accented letters, defeating the guard.
+          # issue #1148: LC_ALL=C tr + '/' sentinel, not a `case` range — a
+          # collating locale lets [a-z] admit uppercase/accented letters, and
+          # an emptiness check would let $(...) strip a trailing newline.
           if [ -z "$MATRIX_IMAGE_NAME" ] || \
-             [ -n "$(printf '%s' "$MATRIX_IMAGE_NAME" | LC_ALL=C tr -d 'a-z0-9._-')" ]; then
+             [ "$(printf '%s/' "$MATRIX_IMAGE_NAME" | LC_ALL=C tr -d 'a-z0-9._-')" != '/' ]; then
             echo "::error::invalid matrix.image_name: '$MATRIX_IMAGE_NAME'"
             exit 1
           fi

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -110,9 +110,11 @@ fi
 [ -d "$IN" ] || { echo "build-repo: --in is not a directory: $IN" >&2; exit 1; }
 # The varver becomes a path segment (rm -rf'd + rebuilt) — same safety rule as ABIs.
 # issue #1148: class check via LC_ALL=C tr, not a `case` range — a collating
-# locale lets [a-z] admit uppercase/accented letters, defeating the guard.
+# locale lets [a-z] admit uppercase/accented letters, defeating the guard. The
+# '/' sentinel (outside the class) survives tr, so the remainder is compared
+# against it — an emptiness check would let $(...) strip a trailing newline.
 if [ -z "$VARVER" ] || [ "${VARVER#*..}" != "$VARVER" ] || \
-   [ -n "$(printf '%s' "$VARVER" | LC_ALL=C tr -d 'a-z0-9.-')" ]; then
+   [ "$(printf '%s/' "$VARVER" | LC_ALL=C tr -d 'a-z0-9.-')" != '/' ]; then
     echo "build-repo: unsafe or invalid --varver: '$VARVER' (expect e.g. ce-2.8 / plus-26.03)" >&2
     exit 2
 fi
@@ -192,9 +194,10 @@ done
 # name (${OUT}/${abi}) that is `rm -rf`'d + rebuilt, so `..` / `/` / odd chars could
 # escape $OUT. FreeBSD ABIs look like `FreeBSD:15:amd64` (the `:` is allowed).
 validate_abi() {
-    # issue #1148: LC_ALL=C tr, not a `case` range — see the --varver guard.
+    # issue #1148: LC_ALL=C tr + '/' sentinel, not a `case` range — see the
+    # --varver guard for both traps (locale collation; trailing-newline strip).
     if [ -z "$1" ] || [ "${1#*..}" != "$1" ] || \
-       [ -n "$(printf '%s' "$1" | LC_ALL=C tr -d 'A-Za-z0-9:._+-')" ]; then
+       [ "$(printf '%s/' "$1" | LC_ALL=C tr -d 'A-Za-z0-9:._+-')" != '/' ]; then
         echo "build-repo: unsafe or invalid ABI in package metadata: '$1'" >&2
         exit 1
     fi

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -109,12 +109,13 @@ fi
 }
 [ -d "$IN" ] || { echo "build-repo: --in is not a directory: $IN" >&2; exit 1; }
 # The varver becomes a path segment (rm -rf'd + rebuilt) — same safety rule as ABIs.
-case "$VARVER" in
-    ""|*/*|*".."*|*[!a-z0-9.-]*)
-        echo "build-repo: unsafe or invalid --varver: '$VARVER' (expect e.g. ce-2.8 / plus-26.03)" >&2
-        exit 2
-        ;;
-esac
+# issue #1148: class check via LC_ALL=C tr, not a `case` range — a collating
+# locale lets [a-z] admit uppercase/accented letters, defeating the guard.
+if [ -z "$VARVER" ] || [ "${VARVER#*..}" != "$VARVER" ] || \
+   [ -n "$(printf '%s' "$VARVER" | LC_ALL=C tr -d 'a-z0-9.-')" ]; then
+    echo "build-repo: unsafe or invalid --varver: '$VARVER' (expect e.g. ce-2.8 / plus-26.03)" >&2
+    exit 2
+fi
 
 command -v "$PKG_BIN" >/dev/null 2>&1 || {
     echo "build-repo: '$PKG_BIN' not found on PATH — need a libpkg \`pkg\` binary (set PKG_BIN)" >&2
@@ -191,12 +192,12 @@ done
 # name (${OUT}/${abi}) that is `rm -rf`'d + rebuilt, so `..` / `/` / odd chars could
 # escape $OUT. FreeBSD ABIs look like `FreeBSD:15:amd64` (the `:` is allowed).
 validate_abi() {
-    case "$1" in
-        ""|*/*|*".."*|*[!A-Za-z0-9:._+-]*)
-            echo "build-repo: unsafe or invalid ABI in package metadata: '$1'" >&2
-            exit 1
-            ;;
-    esac
+    # issue #1148: LC_ALL=C tr, not a `case` range — see the --varver guard.
+    if [ -z "$1" ] || [ "${1#*..}" != "$1" ] || \
+       [ -n "$(printf '%s' "$1" | LC_ALL=C tr -d 'A-Za-z0-9:._+-')" ]; then
+        echo "build-repo: unsafe or invalid ABI in package metadata: '$1'" >&2
+        exit 1
+    fi
 }
 
 # ── Lay out the varver bucket + run `pkg repo` ─────────────────────────────────

--- a/tests/shell/build_repo_layout_spec.sh
+++ b/tests/shell/build_repo_layout_spec.sh
@@ -123,6 +123,23 @@ EOF
     End
   End
 
+  Describe 'trailing-newline bypass'
+    # A TRAILING newline is deleted by $(...) stripping, so an emptiness check
+    # on the tr remainder silently accepts it — the guards compare against a
+    # sentinel instead. Values built via printf: Parameters cannot carry \n.
+    # Only --varver gets a row: argv delivers a raw newline, while an ABI rides
+    # line-based metadata extraction (sed -n 's/^abi=//p'), which cannot emit
+    # one — validate_abi() carries the same sentinel purely as parity.
+    It 'rejects a --varver with a trailing newline'
+      hostile="$(printf 'ce-2.8\nZ')"; hostile="${hostile%Z}"
+      fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
+      When call run_build --varver "$hostile"
+      The status should equal 2
+      The stderr should include 'unsafe or invalid --varver'
+      The path "${work}/out/release" should not be exist
+    End
+  End
+
   It 'fails loud on a mixed-ABI input instead of mixing editions in one bucket'
     fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
     fake_pkg b.pkg pfSense-pkg-pfBlockerNG 4.0.1_1 FreeBSD:16:amd64 php85

--- a/tests/shell/build_repo_layout_spec.sh
+++ b/tests/shell/build_repo_layout_spec.sh
@@ -103,6 +103,26 @@ EOF
     End
   End
 
+  Describe 'hostile ABI metadata'
+    # validate_abi(): the ABI becomes a path segment that is rm -rf'd +
+    # rebuilt. The guard must reject under ANY ambient locale (issue #1148: a
+    # collating UTF-8 locale lets a case-range class admit accented letters).
+    Parameters
+      'FreeBSD:15:amdé64'
+      'FreeBSD/15/amd64'
+      'FreeBSD:..:amd64'
+    End
+
+    It "rejects hostile ABI metadata: $1"
+      fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 "$1" php83
+      When call run_build --varver ce-2.8
+      The status should equal 1
+      The stderr should include 'unsafe or invalid ABI'
+      # validate_abi() runs before the bucket is laid out.
+      The path "${work}/out/release" should not be exist
+    End
+  End
+
   It 'fails loud on a mixed-ABI input instead of mixing editions in one bucket'
     fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
     fake_pkg b.pkg pfSense-pkg-pfBlockerNG 4.0.1_1 FreeBSD:16:amd64 php85


### PR DESCRIPTION
Fixes #1148.

A POSIX `case` character range like `[a-z]` collates by the ambient locale. Under a collating UTF-8 locale (macOS `en_US.UTF-8`), the three negated-class input guards accepted values that C-collation rejects — probed before and after:

| Guard | Hostile input | Before (en_US.UTF-8) | After |
| ----- | ------------- | -------------------- | ----- |
| `build-repo.sh` `--varver` | `CE-2.8` | ACCEPT | reject |
| `build-repo.sh` `validate_abi()` | `FreeBSD:15:amdé64` | ACCEPT | reject |
| `image-refresh.yml` `matrix.image_name` | `MyImage` | ACCEPT | reject |

Both `build-repo.sh` values become path segments that are `rm -rf`'d + rebuilt (the ABI comes from package metadata), so the guards are load-bearing. The fix validates with `LC_ALL=C tr -d '<allowed-class>'` — C collation makes the ranges ASCII-exact, and unlike a line-anchored `grep` the check cannot be bypassed by an embedded newline. Legit values (`ce-2.8`, `FreeBSD:15:amd64`, `pfsense-smoke-ce`) still accept (probed).

**Red→green (test-first, frozen `b4fdc4e7`):** the existing hostile-varver spec row (`CE-2.8`) was already red on a collating-locale box, plus a new hostile-ABI Describe (`é` / `/` / `..` rows) executed red before the fix; both green after, zero test edits. Full `shellspec` under the collating locale: 483 examples, 0 failures (previously blocked `.githooks/pre-commit` on every shell commit on such boxes). `sh -n`, `shellcheck`, `actionlint` clean.

Found while landing #1084 step 2 (unrelated branch); surveyed the whole tree for the class — the `*[!0-9]*` digit guards and a dev-only awk `/^[a-z]/` are collation-stable and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
