### PR TITLE
tests: replace stale pfblockerng.inc line-number citations with symbol refs

### DIFF
--- a/tests/fixtures/adr06_golden/config.json
+++ b/tests/fixtures/adr06_golden/config.json
@@ -2,13 +2,13 @@
   "_doc": "Config inputs to the CURRENT DNSBL pipeline for the golden oracle. These mirror dnsblconfig keys read by tld_analysis / pfb_unbound_python_whitelist and the python init flags. The oracle loads two scenarios off this single config: TOP1M disabled (default) and TOP1M enabled.",
 
   "tld_blacklist": ["zip"],
-  "_tld_blacklist_doc": "Whole-TLD block: every domain under .zip is wildcard-blocked via a synthetic DNSBL_TLD zone entry (inc:2740). .zip is also removed from the TLD master.",
+  "_tld_blacklist_doc": "Whole-TLD block: every domain under .zip is wildcard-blocked via a synthetic DNSBL_TLD zone entry (mirrors PHP's tld_analysis() whole-TLD write). .zip is also removed from the TLD master.",
 
   "tld_exclusion": ["excluded.com"],
-  "_tld_exclusion_doc": "Force exact DATA (transparent) classification for this whole domain even though as a 2-label registrable domain it would otherwise be a wildcard ZONE (inc:2855). Present in feed_extra.txt.",
+  "_tld_exclusion_doc": "Force exact DATA (transparent) classification for this whole domain even though as a 2-label registrable domain it would otherwise be a wildcard ZONE (mirrors PHP's tld_analysis() TLD-exclusion branch). Present in feed_extra.txt.",
 
   "user_whitelist": ["www.adblock.com", ".wildwhite.org", "phishing.net"],
-  "_user_whitelist_doc": "User DNSBL whitelist (dnsblconfig['suppression']). Normalised by pfb_unbound_python_whitelist (inc:2259): www-strip, leading-dot -> wildcard '1' else '0'. Applied at QUERY TIME via whiteDB (un-blocks), never as a build-time removal in ADR-06's target.",
+  "_user_whitelist_doc": "User DNSBL whitelist (dnsblconfig['suppression']). Normalised by PHP's pfb_unbound_python_whitelist(): www-strip, leading-dot -> wildcard '1' else '0'. Applied at QUERY TIME via whiteDB (un-blocks), never as a build-time removal in ADR-06's target.",
 
   "top1m_list": ["popularcdn.com"],
   "_top1m_doc": "TOP1M (Alexa/Tranco) popularity whitelist. Loaded into whiteDB ONLY when TOP1M is enabled; un-blocks popular domains at query time. When disabled, these domains block normally.",

--- a/tests/fixtures/adr06_golden/feed_abp.txt
+++ b/tests/fixtures/adr06_golden/feed_abp.txt
@@ -1,11 +1,11 @@
 [Adblock Plus 2.0]
 ! Title: Test basic-ABP feed
 ! Basic-ABP feed. Feed=AbpFeed Group=AbpAds  log_flag=1
-! The current PHP basic-ABP pass (pfblockerng.inc:7706-7717) keeps ONLY
+! The legacy basic-ABP pass (upgrade-compat only since ADR-62) keeps ONLY
 ! "||domain^" network lines and strips the ||, ^ tokens to a bare domain.
-! Everything below that is NOT a plain "||domain^" is IGNORED today:
+! Everything below that is NOT a plain "||domain^" is IGNORED by that pass:
 !   @@ exceptions, ## element-hiding, $options, *, /, regex.
-! This fixture pins that current (non-conformant) behaviour.
+! This fixture pins that legacy (non-conformant) behaviour.
 ||abpblocked.com^
 ||sub.abpzone.net^
 ||abpoptions.com^$third-party

--- a/tests/fixtures/adr06_golden/feed_nolog.txt
+++ b/tests/fixtures/adr06_golden/feed_nolog.txt
@@ -1,7 +1,8 @@
 # Plain-domain feed with log_flag '2' (block-but-skip-log).
 # Feed=NoLogFeed Group=NoLog  log_flag=2
 # Per Phase 1 (1b) + the matcher: log '2' still BLOCKS the domain, but
-# null_blocking stays True (only log '1' flips it to a null-route reply) and
+# null_blocking stays True (only log '1' flips it to False, serving the real
+# VIP instead), so the reply IS null-routed (0.0.0.0/::), and
 # get_details_dnsbl() skips the log line. This pins the
 # distinct "blocked, log '2'" decision shape.
 silentblock.com

--- a/tests/fixtures/adr06_golden/feed_nolog.txt
+++ b/tests/fixtures/adr06_golden/feed_nolog.txt
@@ -2,6 +2,6 @@
 # Feed=NoLogFeed Group=NoLog  log_flag=2
 # Per Phase 1 (1b) + the matcher: log '2' still BLOCKS the domain, but
 # null_blocking stays True (only log '1' flips it to a null-route reply) and
-# get_details_dnsbl skips the log line (pfb_unbound.py:1134). This pins the
+# get_details_dnsbl() skips the log line. This pins the
 # distinct "blocked, log '2'" decision shape.
 silentblock.com

--- a/tests/test_adr06_golden_oracle.py
+++ b/tests/test_adr06_golden_oracle.py
@@ -216,15 +216,16 @@ class ReferencePipeline:
     # -- classify layer ----------------------------------------------------- #
 
     def _load_tld_master(self) -> None:
-        """Load the public-suffix master, minus blacklisted/excluded TLDs.
+        """Load the public-suffix master, minus blacklisted/single-label-excluded TLDs.
 
         Mirrors PHP's tld_analysis() master-list load loop, which builds
-        tlds[tld][full-suffix]; the TLD blacklist and TLD exclusion remove
-        entries from it.
+        tlds[tld][full-suffix]; the TLD blacklist removes entries from it. A
+        single-label TLD exclusion does too (tld_analysis()'s unset($tlds[$exclude])),
+        but a multi-label exclusion (e.g. "excluded.com") never matches a tld key here
+        -- it stays loaded and is instead force-classified to exact DATA later, in
+        _classify().
         """
         blacklist = {t.strip(".") for t in self.config.get("tld_blacklist", [])}
-        # Exclusions remove the WHOLE-domain key from tlds (tld_analysis()); only
-        # single-label exclusions would match a tld key, but we mirror the unset.
         exclusion_keys = {e.strip(".") for e in self.config.get("tld_exclusion", [])}
         for line in _read_lines("tld_master.txt"):
             suffix = line.strip()

--- a/tests/test_adr06_golden_oracle.py
+++ b/tests/test_adr06_golden_oracle.py
@@ -383,11 +383,12 @@ def _decision_label(d: pfb_unbound.DnsblDecision) -> str:
       * "pass"        -> not on any list; resolves normally (pass-through).
       * "whitelist"   -> on a list but un-blocked via whiteDB (resolves).
       * "hsts"        -> on a list but bypassed via HSTS (resolves real).
-      * "block-null"  -> blocked and null-routed to the DNSBL sinkhole IP
-                         (log_flag '1', not HSTS -> null_blocking flips to False).
+      * "block-null"  -> blocked and answered with the real DNSBL sinkhole VIP,
+                         NOT the 0.0.0.0/:: null route (log_flag '1', not HSTS ->
+                         null_blocking flips to False).
       * "block-nolog" -> blocked, but log_flag '2' (block-but-skip-log):
-                         null_blocking STAYS True (only log '1' flips it), so the
-                         reply is built but not null-routed and the hit is not
+                         null_blocking STAYS True (only log '1' flips it to False),
+                         so the reply IS null-routed (0.0.0.0/::) and the hit is not
                          logged (get_details_dnsbl()'s log_type suppression). Still a block, distinct
                          from HSTS (which sets in_hsts) and from whitelist.
     """

--- a/tests/test_adr06_golden_oracle.py
+++ b/tests/test_adr06_golden_oracle.py
@@ -28,21 +28,24 @@ WHAT MODELS "THE CURRENT PIPELINE"
 There is no live PHP/Unbound in CI (every prior ADR). So this file contains a
 pure-Python *reference preprocessor* (``ReferencePipeline``) that faithfully
 re-implements the CURRENT shell/PHP preprocessing semantics inventoried in
-Phase 1 (``RESULTS/01_Results.txt``), with file:line anchors in the docstrings:
+Phase 1 (``RESULTS/01_Results.txt``), with PHP-symbol anchors in the docstrings:
 
-  * per-format parse (hosts / plain / basic-ABP), incl. the current
-    basic-ABP token-strip and the rule that ``@@`` / ``##`` / ``$options`` / ``*``
-    / ``/`` / regex lines are IGNORED today (``pfblockerng.inc:7706-7717``);
-  * embedded-IP extraction -> firewall handoff set (generic bare-IP at
-    ``inc:7962-7973``), with IP lines stripped from what the domain build
-    receives. (PHP also extracts an embedded IP from CSV-format feeds via
-    ``pfb_dnsbl_collect_feed_ip()`` -- a separate, still-live PHP path this
-    oracle's fixtures don't currently exercise, so it isn't modelled here);
-  * domain validation + lower-casing (``inc:1138-1150``);
-  * data/zone classification via the public-suffix TLD master (``tld_analysis`` /
-    ``tld_search``, ``inc:2805-2877``), incl. TLD blacklist (whole-TLD zone,
-    ``inc:2740``) and TLD exclusion (force exact data, ``inc:2855``);
-  * user-whitelist normalisation (``pfb_unbound_python_whitelist``, ``inc:2259``:
+  * per-format parse (hosts / plain / basic-ABP), incl. the legacy basic-ABP
+    token-strip (upgrade-compat only since ADR-62 -- live ABP-shaped lines now
+    route verbatim to Python's richer ABP parser) and the rule that ``@@`` /
+    ``##`` / ``$options`` / ``*`` / ``/`` / regex lines are IGNORED by that
+    legacy strip;
+  * embedded-IP extraction -> firewall handoff set (generic bare-IP, handled
+    in ``sync_package_pfblockerng()``'s DNSBL download/parse loop), with IP
+    lines stripped from what the domain build receives. (PHP also extracts an
+    embedded IP from CSV-format feeds via ``pfb_dnsbl_collect_feed_ip()`` -- a
+    separate, still-live PHP path this oracle's fixtures don't currently
+    exercise, so it isn't modelled here);
+  * domain validation + lower-casing (``pfb_filter()``'s ``PFB_FILTER_DOMAIN`` case);
+  * data/zone classification via the public-suffix TLD master (``tld_analysis()``
+    / ``tld_search()``), incl. TLD blacklist (whole-TLD zone) and TLD exclusion
+    (force exact data);
+  * user-whitelist normalisation (``pfb_unbound_python_whitelist()``:
     www-strip, leading-dot -> wildcard) feeding the query-time ``whiteDB``; and
   * TOP1M -> ``whiteDB`` only when enabled.
 
@@ -92,9 +95,9 @@ def _load_json(name: str) -> dict[str, Any]:
 # Reference model of the CURRENT preprocessing pipeline (shell + PHP).
 #
 # Pure, stdlib-only. Re-implements the inventoried semantics so the oracle can run
-# in CI without live PHP/Unbound. Anchors to pfblockerng.inc / .sh line ranges are
-# in the method docstrings. This is the authoritative-today behaviour Phase 3 must
-# match at the DECISION level.
+# in CI without live PHP/Unbound. Anchors to pfblockerng.inc / .sh symbol names
+# are in the method docstrings. This is the authoritative-today behaviour Phase 3
+# must match at the DECISION level.
 # --------------------------------------------------------------------------- #
 
 
@@ -130,15 +133,16 @@ class ReferencePipeline:
 
         self._feed_group_db: dict[str, int] = {}
         self._next_index = 0
-        # Public-suffix oracle: tlds[tld][full-suffix] = '' (tld_analysis:2630-2642),
-        # minus any TLD that is blacklisted or excluded.
+        # Public-suffix oracle: tlds[tld][full-suffix] = '' (mirrors PHP's
+        # tld_analysis() master-list load loop), minus any TLD that is
+        # blacklisted or excluded.
         self._tlds: dict[str, dict[str, str]] = defaultdict(dict)
 
     # -- parse layer -------------------------------------------------------- #
 
     @staticmethod
     def _parse_abp_line(line: str) -> str | None:
-        """Current basic-ABP pass (pfblockerng.inc:7706-7717).
+        """Legacy basic-ABP token-strip, upgrade-compat only (ADR-62).
 
         Keep ONLY a plain ``||domain^`` network line; strip the ``||`` and ``^``
         tokens. IGNORE everything else: ``@@`` exceptions, ``##`` element rules,
@@ -152,7 +156,8 @@ class ReferencePipeline:
 
     @staticmethod
     def _strip_hosts_prefix(line: str) -> str:
-        """Hosts format: "<sink-ip> <domain>" -> take the domain token (inc:7899-7907)."""
+        """Hosts format: "<sink-ip> <domain>" -> take the domain token (approximates
+        sync_package_pfblockerng()'s 'Typical Host Feed format' pass)."""
         if " " in line:
             first, _, rest = line.partition(" ")
             rest = rest.strip()
@@ -168,7 +173,7 @@ class ReferencePipeline:
         Implements the per-format dispatch + the embedded-IP firewall detection of
         the current parse loop. A generic bare-IP line yields ``(None, ip)`` -- the
         IP goes to the firewall and the line is stripped from the domain build
-        (inc:7962-7973).
+        (``sync_package_pfblockerng()``'s DNSBL download/parse loop).
         """
         line = raw_line.strip()
         if not line:
@@ -188,19 +193,19 @@ class ReferencePipeline:
         line = line.strip().strip(".")
         if not line:
             return None, None
-        # Embedded bare-IP -> firewall path (inc:7962-7973); stripped from Python.
+        # Embedded bare-IP -> firewall path (sync_package_pfblockerng()); stripped from Python.
         if _is_ipv4(line):
             return None, line
         return line, None
 
     @staticmethod
     def _validate_domain(host: str) -> str | None:
-        """Lower-case + PFB_FILTER_DOMAIN shape gate (inc:1138-1150)."""
+        """Lower-case + PFB_FILTER_DOMAIN shape gate (mirrors pfb_filter()'s PFB_FILTER_DOMAIN case)."""
         host = host.strip().strip(".").lower()
         if "." not in host:
             return None
         # Representative domain-shape gate (labels of [a-z0-9_-], underscore per
-        # #723 — parity with PFB_FILTER_DOMAIN, pfblockerng.inc:1138-1150).
+        # #723 — parity with pfb_filter()'s PFB_FILTER_DOMAIN case).
         for label in host.split("."):
             if not label or label[0] == "-" or label[-1] == "-":
                 return None
@@ -213,11 +218,12 @@ class ReferencePipeline:
     def _load_tld_master(self) -> None:
         """Load the public-suffix master, minus blacklisted/excluded TLDs.
 
-        tld_analysis:2630-2642 builds tlds[tld][full-suffix]; the TLD blacklist
-        (inc:2749-2751) and TLD exclusion (inc:2791-2793) remove entries.
+        Mirrors PHP's tld_analysis() master-list load loop, which builds
+        tlds[tld][full-suffix]; the TLD blacklist and TLD exclusion remove
+        entries from it.
         """
         blacklist = {t.strip(".") for t in self.config.get("tld_blacklist", [])}
-        # Exclusions remove the WHOLE-domain key from tlds (inc:2791); only
+        # Exclusions remove the WHOLE-domain key from tlds (tld_analysis()); only
         # single-label exclusions would match a tld key, but we mirror the unset.
         exclusion_keys = {e.strip(".") for e in self.config.get("tld_exclusion", [])}
         for line in _read_lines("tld_master.txt"):
@@ -230,7 +236,7 @@ class ReferencePipeline:
             self._tlds[tld][suffix] = ""
 
     def _tld_search(self, tld: str, dparts: list[str], j: int, k: int) -> str | None:
-        """tld_search (inc:2595-2603): if the j-label suffix is a known public
+        """Mirrors PHP's tld_search(): if the j-label suffix is a known public
         suffix, the registrable parent is the k-label slice."""
         tld_query = ".".join(dparts[-j:])
         if tld_query in self._tlds.get(tld, {}):
@@ -240,7 +246,7 @@ class ReferencePipeline:
     def _classify(self, domain: str) -> tuple[str, str]:
         """Return ('zone', registrable-parent) or ('data', domain).
 
-        Mirrors tld_analysis:2832-2874: registrable-parent -> wildcard ZONE;
+        Mirrors PHP's tld_analysis() zone/data split: registrable-parent -> wildcard ZONE;
         deeper sub-domain -> exact DATA; TLD-exclusion -> force exact DATA.
         """
         dparts = domain.split(".")
@@ -271,9 +277,10 @@ class ReferencePipeline:
     # -- whitelist layer ---------------------------------------------------- #
 
     def _build_whitelist(self) -> None:
-        """User-whitelist normalisation (pfb_unbound_python_whitelist, inc:2259):
+        """User-whitelist normalisation (mirrors PHP's pfb_unbound_python_whitelist()):
         www-strip, leading-dot -> wildcard '1' else '0'. TOP1M -> whiteDB only when
-        enabled. whiteDB value is the wildcard bool the loader stores (inc:609-619)."""
+        enabled. whiteDB value is the wildcard bool pfb_unbound.py's
+        _load_whitelist_db() stores from that '1'/'0' encoding."""
         for line in self.config.get("user_whitelist", []):
             line = line.strip()
             if not line:
@@ -306,7 +313,8 @@ class ReferencePipeline:
 
     def _emit_tld_blacklist_zones(self) -> None:
         """Whole-TLD block: a blacklisted TLD becomes a synthetic DNSBL_TLD zone
-        entry (inc:2740 ``,<tld>,,1,DNSBL_TLD,DNSBL_TLD``)."""
+        entry, matching the row shape PHP's tld_analysis() writes for the same
+        case (``,<tld>,,1,DNSBL_TLD,DNSBL_TLD``)."""
         for tld in self.config.get("tld_blacklist", []):
             tld = tld.strip(".")
             if not tld:
@@ -379,7 +387,7 @@ def _decision_label(d: pfb_unbound.DnsblDecision) -> str:
       * "block-nolog" -> blocked, but log_flag '2' (block-but-skip-log):
                          null_blocking STAYS True (only log '1' flips it), so the
                          reply is built but not null-routed and the hit is not
-                         logged (pfb_unbound.py:1134). Still a block, distinct
+                         logged (get_details_dnsbl()'s log_type suppression). Still a block, distinct
                          from HSTS (which sets in_hsts) and from whitelist.
     """
     if not d.is_found:


### PR DESCRIPTION
## Summary

Same class of drift #1115 fixed in `pfb_unbound.py`: the ADR-06 golden-oracle
test (`tests/test_adr06_golden_oracle.py`) and its fixtures
(`tests/fixtures/adr06_golden/`) cited `pfblockerng.inc`/`tld_analysis`/
`pfb_unbound.py` line numbers that have since drifted — some to unrelated
code entirely (`pfb_unbound.py:1134` now points at unrelated init code;
`inc:609-619` now points at a DNS-redirect helper, not the whitelist
loader). Every citation was verified against `origin/devel` and replaced
with the PHP/Python symbol name (or contract fact) it actually refers to —
no line numbers anywhere.

- `tests/test_adr06_golden_oracle.py`: 25 citations across the module
  docstring, `ReferencePipeline` method docstrings/comments.
- `tests/fixtures/adr06_golden/config.json`: 3 citations in the `_doc`
  fields.
- `tests/fixtures/adr06_golden/feed_abp.txt`,
  `tests/fixtures/adr06_golden/feed_nolog.txt`: 2 more citations of the same
  class the issue's own grep (scoped to `config.json`) missed — caught by
  re-grepping the whole `adr06_golden/` fixtures directory per the
  coverage-matrix rule (never trust the finding's stated scope alone).

Also verified the one substantive drift beyond citations: the basic-ABP
token-strip is now legacy/upgrade-compat-only since ADR-62 (live ABP-shaped
lines route to Python's richer ABP parser instead) — reworded the two
places that called it "current" to say so, matching the correction already
made in `pfb_unbound.py` by #1115/PR #1140.

No behaviour change; comment/docstring/fixture-doc text only.

Fixes #1141

## Test plan

- [x] `python3 -m pytest tests/test_adr06_golden_oracle.py -q` — 10 passed
- [x] `python3 -m pytest -q` — 2635 passed, 4 skipped (baseline count, no
      change)
- [x] `ruff check .` — all checks passed
- [x] `ruff format --check .` — 218 files already formatted
- [x] `python3 -m mypy tests/` — no issues found in 90 source files
- [x] `grep -rnoE '[A-Za-z_]*:[0-9]{3,5}(-[0-9]{3,5})?' tests/test_adr06_golden_oracle.py tests/fixtures/adr06_golden/` — zero remaining hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated reference-pipeline comments and fixture descriptions to clarify current processing behavior, compatibility semantics, whitelist normalization, and domain classification.
  - Replaced outdated implementation-specific references with clearer, more maintainable terminology.

- **Tests**
  - Refreshed golden test fixtures and inline documentation to align with current expected behavior.
  - No executable test logic, assertions, or fixture rule data were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->