### PR TITLE
pfblockerng: fail-safe $retval default in pfb_download; assign success explicitly in gzip-blacklist

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10599,7 +10599,9 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 
 	if (file_exists($file_download) && ($http_status == '200' || $http_status == '221' || $http_status == '226')) {
 
-		unset($retval);
+		// issue #1158: fail-safe default -- with unset(), paths that assigned nothing fell
+		// through $retval == 0 as success
+		$retval = 1;
 
 		// Validate File Mime-type
 		$reject_detail = array();
@@ -10734,6 +10736,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 
 					// Create update file indicator for update process
 					touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
+					$retval = 0;
 				}
 				else {
 					pfb_logger("\n Invalid filename [{$filename}]", 1);

--- a/tests/php/DownloadRetvalFailsafeTest.php
+++ b/tests/php/DownloadRetvalFailsafeTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_download()'s $retval fail-safe default (issue #1158).
+ *
+ * pfb_download() drives real cURL + the appliance exec pipeline before any of
+ * the sites under test run, so behaviourally exercising the function off-appliance
+ * is infeasible -- this is a source-inspection pin instead (house precedent:
+ * tests/php/PfbSyncStatusDnsblWritersTest.php's
+ * testRestartFallbackBranchesNeverCallLedgerFunctionsDirectly()).
+ *
+ * The bug: `unset($retval);` left $retval undefined on any code path that fell
+ * through the decompression switch without assigning it. PHP's loose `== 0`
+ * then treats NULL as equal to 0, so an unassigned $retval silently reads as
+ * the SUCCESS gate (`if ($retval == 0)`) instead of failure. Two such paths
+ * exist: the ZIP xlsx-conversion-failure branch (the reported defect -- a
+ * failed conversion must FAIL, not succeed) and the gzip 'blacklist' success
+ * branch (which must keep succeeding under the new fail-safe default).
+ */
+final class DownloadRetvalFailsafeTest extends TestCase
+{
+	private static string $body;
+
+	public static function setUpBeforeClass(): void
+	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
+		);
+		if ($source === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		}
+
+		$start = strpos($source, 'function pfb_download(');
+		if ($start === false) {
+			throw new RuntimeException('test bootstrap: function pfb_download( not found');
+		}
+
+		// Whitespace-tolerant: the next top-of-line 'function <name>' declaration
+		// (an indented closure inside the body, e.g. the CURLOPT_HEADERFUNCTION
+		// callback, never matches '^function' since it is never at column 0).
+		if (!preg_match('/^function\s+\w+/m', $source, $m, PREG_OFFSET_CAPTURE, $start + 20)) {
+			throw new RuntimeException('test bootstrap: end-of-function boundary not found');
+		}
+		$end = $m[0][1];
+
+		self::$body = substr($source, $start, $end - $start);
+	}
+
+	// -----------------------------------------------------------------------
+	// Vacuity guards -- each marker this test's assertions depend on must
+	// actually be present, or the assertions below prove nothing.
+	// -----------------------------------------------------------------------
+
+	public function testVacuityRetvalGateExists(): void
+	{
+		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*==\s*0\s*\)/', self::$body,
+			'the $retval == 0 success gate must exist for this test to mean anything');
+	}
+
+	public function testVacuityXlsxExecMarkerExists(): void
+	{
+		$this->assertStringContainsString("{\$pfb['script']} xlsx {\$header_esc}", self::$body,
+			'the xlsx-conversion exec call must exist -- this is the reported defect route');
+	}
+
+	public function testVacuityUpdateTouchMarkerExists(): void
+	{
+		$this->assertStringContainsString('{$filename}/{$filename}.update', self::$body,
+			'the gzip-blacklist .update touch marker must exist -- Route 2 pins against it');
+	}
+
+	public function testVacuityAtLeastFourExecSitesAssignRetval(): void
+	{
+		$count = substr_count(self::$body, ', $output, $retval)');
+		$this->assertGreaterThanOrEqual(4, $count,
+			"expected >= 4 exec(...,\$output,\$retval) sites (gzip-default/asn/top1m, bzip2, zip-pipeline, 7z); found {$count}");
+	}
+
+	// -----------------------------------------------------------------------
+	// Red row A -- the fail-safe default itself.
+	// -----------------------------------------------------------------------
+
+	public function testRetvalDefaultsToOneNotUnset(): void
+	{
+		$this->assertStringNotContainsString('unset($retval);', self::$body,
+			'unset($retval) must be gone -- it let an unassigned path read as 0 == success');
+		$this->assertMatchesRegularExpression('/\$retval\s*=\s*1\s*;/', self::$body,
+			'a $retval = 1 fail-safe default must replace the unset() -- unassigned must mean FAILURE');
+	}
+
+	// -----------------------------------------------------------------------
+	// Red row B -- Route 2 (gzip-blacklist) keeps succeeding under the new default.
+	// -----------------------------------------------------------------------
+
+	public function testGzipBlacklistSuccessExplicitlyAssignsZeroAfterUpdateTouch(): void
+	{
+		$touchPos = strpos(self::$body, '{$filename}/{$filename}.update');
+		$this->assertNotFalse($touchPos, 'the .update touch marker must be locatable (vacuity re-check)');
+
+		// Whitespace-tolerant proximity window: the touch call's closing ");"
+		// through ~200 chars ahead must contain an explicit $retval = 0;
+		// (mirrors the uncompressed-blacklist sibling at pfblockerng.inc:10874).
+		$window = substr(self::$body, $touchPos, 200);
+		$this->assertMatchesRegularExpression('/\$retval\s*=\s*0\s*;/', $window,
+			"gzip-blacklist success must explicitly set \$retval = 0 after its .update touch "
+			. "(preserving its outcome under the new fail-safe default); found near touch: "
+			. json_encode($window));
+	}
+
+	// -----------------------------------------------------------------------
+	// Additional semantics pin -- the hazard this fail-safe defends against.
+	// -----------------------------------------------------------------------
+
+	public function testNullEqualsZeroHazardBackingTheFailsafe(): void
+	{
+		// phpcs:ignore -- deliberately loose comparison: this IS the hazard.
+		$this->assertTrue(null == 0,
+			"PHP's loose '==' treats an unassigned (NULL) \$retval as equal to 0, "
+			. 'so any code path that falls through without assigning $retval silently '
+			. '"succeeds" at the if ($retval == 0) gate -- this is exactly the bug '
+			. '$retval = 1 (fail-safe default) defends against');
+	}
+}


### PR DESCRIPTION
Fixes #1158.

## What

`pfb_download()` ran `unset($retval);` before its per-format extraction dispatch and gated success on `if ($retval == 0)`. Two routes reached that gate with `$retval` unset, "succeeding" via PHP's loose `null == 0`:

1. **ZIP `.xlsx` conversion failure** (the reported defect): a failed conversion took the success path — remote timestamp touched, the ADR-42 content-hash sidecar refreshed for an ingest that produced no file, and `TRUE` returned to the caller, poisoning feed change detection.
2. **gzip `blacklist` success path** (found by the first implementation attempt's ESCALATE — e.g. the UT1 `blacklists.tar.gz` feed): a bare `exec(tar -xf)` with no retval argument, falling through to the gate unset. This path's *current success outcome* had to be preserved.

Two edits, same commit: `unset($retval)` → fail-safe `$retval = 1;` (an extraction branch that assigns nothing is a failure), and an explicit `$retval = 0;` after the gzip-blacklist branch's `.update` touch, mirroring the uncompressed-blacklist sibling. The xlsx-fail route now reaches the existing "Decompression Failed" handling and returns `FALSE`.

## Tests

`tests/php/DownloadRetvalFailsafeTest.php` — source-inspection pin (behavioural drive of `pfb_download()` is infeasible off-appliance: real cURL + appliance exec pipeline precede the sites; docblock documents this). Four vacuity guards, two red rows (fail-safe default present + `unset` gone; `$retval = 0` follows the blacklist `.update` touch), and a `null == 0` semantics pin. Red→green executed test-first: red = exactly the two rows failing on untouched code; green 7/7 zero-edits; frozen at `9006c518`, independently re-executed at gate. The full-function `$retval` route enumeration (all 6 exec-assign sites, explicit-zero sites, early-return branches) was re-verified byte-for-byte before editing.

## Gates

`php -l` clean · PHPUnit 2771 tests / 19654 assertions OK · `composer phpstan` no errors · `composer phpcs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWt2V3hW3hZDzFNzSAUevA