### PR TITLE
pfblockerng: drop dead python_tld_seg min-segment computation, emit literal 1

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6393,12 +6393,6 @@ function pfb_unbound_python_whitelist($mode='') {
 					$line = substr($line, 4);
 				}
 
-				// Minimize the python whitelist queries to the smallest tld segment count
-				if (!isset($tld_segments)) {
-					$tld_segments = (substr_count($line, '.') +1);
-				}
-				$tld_segments = @min((array((substr_count($line, '.') +1), $tld_segments) ?: 1));
-
 				if (str_starts_with($line, '.')) {
 					$line = ltrim($line, '.');
 					$dnsbl_whitelist .= "{$line},1\n";
@@ -7464,10 +7458,6 @@ function pfb_unbound_python($mode) {
 			pfb_unbound_python_sources_whitelist();
 		}
 
-		if (!isset($tld_segments)) {
-			$tld_segments = '1';
-		}
-
 		$python_reply = 'off';
 		if ($pfb['dnsbl_py_reply'] == 'on') {
 			$python_reply = 'on';
@@ -7558,6 +7548,9 @@ function pfb_unbound_python($mode) {
 
 		$now = date('Y-m-d H:i:s', time());	// ISO-8601 (py_unbound.ini "File created" comment)
 
+		// issue #1155: fixed at 1 -- the min-segment optimization was computed-and-discarded
+		// in pfb_unbound_python_whitelist() since extraction; 1 is behaviourally identical
+		// (only wildcard entries can match the Python suffix walk it gates).
 		$pfb_py_conf = <<<EOF
 ; pfBlockerNG DNSBL Unbound python configuration file
 ; pfb_unbound.ini [ File created: {$now} ]
@@ -7572,7 +7565,7 @@ python_idn	= {$python_idn}
 idn_mode	= {$idn_mode}
 python_idn_block_malicious	= {$python_idn_block_malicious}
 python_idn_escalate_suspicious	= {$python_idn_escalate_suspicious}
-python_tld_seg	= {$tld_segments}
+python_tld_seg	= 1
 decisiondb_max	= {$decisiondb_max}
 python_tld	= {$python_tld}
 python_tlds	= {$python_tlds}

--- a/tests/php/PythonWhitelistTldSegTest.php
+++ b/tests/php/PythonWhitelistTldSegTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1155 — pfb_unbound_python_whitelist() computed a min-TLD-segment
+ * count into a function-LOCAL $tld_segments, then discarded it (only the CSV
+ * whitelist string is returned/written). pfb_unbound_python() separately ran
+ * `if (!isset($tld_segments)) { $tld_segments = '1'; }` on its OWN
+ * never-assigned local, so the manifest's python_tld_seg key ALWAYS emitted
+ * 1 regardless of the discarded computation. The Python consumer
+ * (whitelist_lookup_domain) gates a parent-suffix walk on this value and
+ * only wildcard suppression entries can match that walk, so a fixed literal
+ * 1 is behaviourally identical to the dead computation it replaces — this
+ * pins that both dead-code sites are gone, the manifest emits literal 1,
+ * and pfb_unbound_python_whitelist()'s own CSV output stays byte-identical
+ * (Oracle A) across the deletion.
+ */
+#[CoversFunction('pfb_unbound_python_whitelist')]
+#[CoversFunction('pfb_unbound_python')]
+final class PythonWhitelistTldSegTest extends TestCase
+{
+	private const SRC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+		$this->seedGlobalPrereqs();
+	}
+
+	/**
+	 * Seed the minimum config keys pfb_global() reads (mirrors
+	 * DnsblVipDisableNoticeTest::seedGlobalPrereqs() / TickEntrypointTest::
+	 * seedTickPrereqs() — the established minimum pfb_global() needs to run
+	 * warning-free off-box), since pfb_unbound_python_whitelist() calls
+	 * pfb_global() internally.
+	 */
+	private function seedGlobalPrereqs(): void
+	{
+		$gen   = 'installedpackages/pfblockerng/config/0';
+		$ip    = 'installedpackages/pfblockerngipsettings/config/0';
+		$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
+
+		config_set_path("{$gen}/pfb_min",        '0');
+		config_set_path("{$gen}/pfb_hour",       '0');
+		config_set_path("{$gen}/pfb_dailystart", '0');
+		config_set_path("{$gen}/skipfeed",       '0');
+
+		config_set_path("{$ip}/suppression",     '');
+		config_set_path("{$ip}/database_cc",     '');
+		config_set_path("{$ip}/maxmind_locale",  'en');
+		config_set_path("{$ip}/asn_reporting",   'disabled');
+		config_set_path("{$ip}/asn_token",       '');
+		config_set_path("{$ip}/maxmind_account", '');
+		config_set_path("{$ip}/maxmind_key",     '');
+
+		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
+
+		config_set_path("{$dnsbl}/pfb_dnsvip4",     '');
+		config_set_path("{$dnsbl}/pfb_dnsvip6",     '');
+		config_set_path("{$dnsbl}/pfb_dnsport",     '8081');
+		config_set_path("{$dnsbl}/pfb_dnsport_ssl", '8443');
+		config_set_path("{$dnsbl}/alexa_enable",    '');
+		config_set_path("{$dnsbl}/pfb_cache",       '');
+		config_set_path("{$dnsbl}/pfb_py_reply",    '');
+		config_set_path("{$dnsbl}/pfb_regex",       '');
+		config_set_path("{$dnsbl}/pfb_regex_list",  '');
+		config_set_path("{$dnsbl}/pfb_cname",       '');
+		config_set_path("{$dnsbl}/pfb_pytld",       '');
+		config_set_path("{$dnsbl}/pfb_py_nolog",    '');
+		config_set_path("{$dnsbl}/pfb_noaaaa",      '');
+		config_set_path("{$dnsbl}/pfb_noaaaa_list", '');
+		config_set_path("{$dnsbl}/pfb_gp",          '');
+		config_set_path("{$dnsbl}/pfb_gp_bypass_list", '');
+
+		if (!isset($GLOBALS['g']['unbound_chroot_path'])) {
+			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
+		}
+
+		PfbConfig::write('pfb_dnsbl', 'on');
+		PfbConfig::write('pfb_dnsvip_auto', '');
+		PfbConfig::write('dnsbl_interface', 'lo0');
+	}
+
+	private function setSuppression(string $decoded): void
+	{
+		config_set_path(
+			'installedpackages/pfblockerngdnsblsettings/config/0/suppression',
+			base64_encode($decoded)
+		);
+	}
+
+	// --- A: ORACLE — pfb_unbound_python_whitelist() output, pinned across the change ---
+
+	/**
+	 * Scenario: a mixed suppression list — bare domain, leading-dot wildcard,
+	 * www.-prefixed, and a blank line.
+	 * Then: the CSV output strips www., marks the wildcard ',1', everything
+	 *       else ',0', and drops the blank line — unaffected by removing the
+	 *       discarded min-segment computation.
+	 */
+	public function testMixedSuppressionListProducesExpectedCsv(): void
+	{
+		$this->setSuppression("example.com\r\n.wild.org\r\nwww.stripme.net\r\n\r\n");
+
+		$this->assertSame(
+			"example.com,0\nwild.org,1\nstripme.net,0\n",
+			pfb_unbound_python_whitelist()
+		);
+	}
+
+	public function testLeadingDotWildcardEntryGetsSuffixOne(): void
+	{
+		$this->setSuppression(".wild.org\r\n");
+		$this->assertSame("wild.org,1\n", pfb_unbound_python_whitelist());
+	}
+
+	public function testWwwPrefixIsStrippedAndSuffixedZero(): void
+	{
+		$this->setSuppression("www.stripme.net\r\n");
+		$this->assertSame("stripme.net,0\n", pfb_unbound_python_whitelist());
+	}
+
+	public function testEmptySuppressionReturnsEmptyString(): void
+	{
+		$this->setSuppression('');
+		$this->assertSame('', pfb_unbound_python_whitelist());
+	}
+
+	// --- B: SOURCE-SHAPE — the dead computation is GONE, manifest emits literal 1 ---
+
+	/**
+	 * Brace-counts from `function {$name}(` to its matching closing brace,
+	 * so the assertions below inspect ONLY that function's body — never a
+	 * neighbour (tld_analysis() has its own, differently-purposed
+	 * $tld_segments and must stay untouched).
+	 */
+	private function functionBody(string $name): string
+	{
+		$source = file_get_contents(self::SRC);
+		$this->assertNotFalse($source, 'failed to read pfblockerng.inc');
+
+		$needle = "\nfunction {$name}(";
+		$start = strpos($source, $needle);
+		$this->assertNotFalse($start, "function {$name}() not found in source");
+		$start++; // step past the leading \n onto 'function'
+
+		$braceOpen = strpos($source, '{', $start);
+		$this->assertNotFalse($braceOpen, "no opening brace found for {$name}()");
+
+		$depth = 0;
+		for ($i = $braceOpen, $len = strlen($source); $i < $len; $i++) {
+			if ($source[$i] === '{') {
+				$depth++;
+			} elseif ($source[$i] === '}') {
+				$depth--;
+				if ($depth === 0) {
+					$body = substr($source, $start, $i - $start + 1);
+					$this->assertNotSame('', trim($body), "empty body extracted for {$name}() -- vacuous extraction");
+					return $body;
+				}
+			}
+		}
+		$this->fail("no matching closing brace found for {$name}()");
+	}
+
+	public function testWhitelistFunctionHasNoTldSegmentsToken(): void
+	{
+		$body = $this->functionBody('pfb_unbound_python_whitelist');
+		$this->assertStringNotContainsString('tld_segments', $body,
+			'issue #1155: the min-segment computation must be deleted, not just unused');
+	}
+
+	public function testPythonFunctionHasNoIssetTldSegmentsGuard(): void
+	{
+		$body = $this->functionBody('pfb_unbound_python');
+		$this->assertDoesNotMatchRegularExpression('/isset\(\s*\$tld_segments\s*\)/', $body,
+			'issue #1155: the never-assigned isset($tld_segments) guard must be deleted');
+	}
+
+	public function testManifestEmitsLiteralPythonTldSegOne(): void
+	{
+		$body = $this->functionBody('pfb_unbound_python');
+		$this->assertMatchesRegularExpression('/python_tld_seg\s*=\s*1\b/', $body,
+			'issue #1155: python_tld_seg must emit the literal 1, not a variable');
+	}
+}


### PR DESCRIPTION
Fixes #1155.

## What

`pfb_unbound_python_whitelist()` computed a min-TLD-segment optimization into a function-local `$tld_segments` and discarded it; `pfb_unbound_python()` then defaulted its own never-assigned local to `'1'`, so the manifest's `python_tld_seg` has always emitted 1. The consumer (`whitelist_lookup_domain()` in `pfb_unbound.py`) only honours wildcard entries in its suffix walk, so always-1 is behaviourally correct — the computation was pure dead code. Plumbing it instead would have been risky: it counts the leading dot of `.example.com` entries, inflating the count and potentially causing whitelist misses if ever wired up.

The fix deletes the dead computation and the dead isset-default and emits `python_tld_seg = 1` literally (same key, same tab alignment — the manifest shape is unchanged; ADR-06 boundary untouched). The breadcrumb comment sits before the heredoc opener because the emission line lives inside the INI heredoc body, where a comment would be emitted into the generated file. `$tld_segments` in `tld_analysis()` serves a different purpose and is untouched (zero-hit grep outside it, retired-token discipline).

## Tests

`tests/php/PythonWhitelistTldSegTest.php` — behaviour-preserving change, so a two-part suite: (A) oracle tests pinning `pfb_unbound_python_whitelist()`'s CSV output byte-identical across the deletion (mixed list, leading-dot wildcard, `www.`-strip, empty suppression) — green before AND after; (B) source-shape rows asserting the dead tokens are gone and the manifest emits literal 1 — red before (3 failures), green after, zero edits, frozen at `ca56b4b6` (independently re-executed at gate).

## Gates

`php -l` clean · PHPUnit 2771 tests / 19663 assertions OK · `composer phpstan` no errors · `composer phpcs` clean · `python3 -m pytest`: 2635 passed (cross-language manifest consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWt2V3hW3hZDzFNzSAUevA