### PR TITLE
Fix the six production-consequence defects behind the PHPStan level-2 baseline (#1154-#1159)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,12 +13,6 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Binary operation "\-" between 32 and string results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Call to function unset\(\) contains undefined variable \$output\.$#'
 			identifier: unset.variable
 			count: 3
@@ -33,25 +27,7 @@ parameters:
 		-
 			message: '#^Call to function unset\(\) contains undefined variable \$retval\.$#'
 			identifier: unset.variable
-			count: 4
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Call to method setConnectionData\(\) on an unknown class pfsense_xmlrpc_client\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Call to method xmlrpc_method\(\) on an unknown class pfsense_xmlrpc_client\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Call to static method isInNetmask\(\) on an unknown class Net_IPv6\.$#'
-			identifier: class.notFound
-			count: 1
+			count: 3
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -105,12 +81,6 @@ parameters:
 		-
 			message: '#^Deprecated in PHP 8\.0\: Required parameter \$src_ip follows optional parameter \$mode\.$#'
 			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Instantiated class pfsense_xmlrpc_client not found\.$#'
-			identifier: class.notFound
 			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
@@ -325,12 +295,6 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$retval might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Variable \$rs in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1
@@ -351,12 +315,6 @@ parameters:
 		-
 			message: '#^Variable \$tld_list in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$tld_segments in isset\(\) is never defined\.$#'
-			identifier: isset.variable
 			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
@@ -425,60 +383,6 @@ parameters:
 			identifier: variable.undefined
 			count: 3
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Variable \$pflex might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:addGlobal\(\)\.$#'
-			identifier: method.notFound
-			count: 16
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:setAction\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Call to an undefined method Form_Button\:\:removeClass\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 62
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 21
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Parameter Form of print cannot be converted to string\.$#'
-			identifier: print.nonString
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
 
 		-
 			message: '#^Variable \$_GET in isset\(\) always exists and is not nullable\.$#'
@@ -661,54 +565,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
 
 		-
-			message: '#^Binary operation "\." between Form_Button and ''&emsp;'' results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-
-		-
-			message: '#^Call to an undefined method Form_Button\:\:removeClass\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 9
-			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addPassword\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-
-		-
-			message: '#^Parameter Form of print cannot be converted to string\.$#'
-			identifier: print.nonString
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-
-		-
 			message: '#^Variable \$blacklist_types in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 2
@@ -731,18 +587,6 @@ parameters:
 			identifier: variable.undefined
 			count: 3
 			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-
-		-
-			message: '#^Call to an undefined method Form_Select\:\:setWidth\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
-
-		-
-			message: '#^Parameter Form_Select of print cannot be converted to string\.$#'
-			identifier: print.nonString
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
 
 		-
 			message: '#^Variable \$_GET in isset\(\) always exists and is not nullable\.$#'
@@ -787,74 +631,8 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
 
 		-
-			message: '#^Binary operation "\." between Form_Button and ''&emsp;'' results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 7
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:addGlobal\(\)\.$#'
-			identifier: method.notFound
-			count: 5
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Call to an undefined method Form_Button\:\:removeClass\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 17
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:addClass\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 7
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 24
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Function phpsession_begin not found\.$#'
-			identifier: function.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Function phpsession_end not found\.$#'
-			identifier: function.notFound
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
 			message: '#^Parameter \#1 \$string of function str_pad expects string, \(float\|int\) given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Parameter Form of print cannot be converted to string\.$#'
-			identifier: print.nonString
 			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
 
@@ -931,50 +709,8 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
 
 		-
-			message: '#^Call to an undefined method Form\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 15
-			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
-
-		-
-			message: '#^Call to an undefined method Form_Checkbox\:\:setAttribute\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 14
-			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:setHelp\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 8
-			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 55
-			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
-
-		-
 			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
-
-		-
-			message: '#^Parameter Form of print cannot be converted to string\.$#'
-			identifier: print.nonString
 			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
 
@@ -985,26 +721,8 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
 
 		-
-			message: '#^Call to an undefined method Form_Button\:\:removeClass\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
-
-		-
 			message: '#^Deprecated in PHP 8\.0\: Required parameter \$a_key follows optional parameter \$alt_register\.$#'
 			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
-
-		-
-			message: '#^Parameter Form_Section of print cannot be converted to string\.$#'
-			identifier: print.nonString
 			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
 
@@ -1019,48 +737,6 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 8
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:addClass\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Call to an undefined method Form_Input\:\:setAttribute\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 9
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Parameter Form of print cannot be converted to string\.$#'
-			identifier: print.nonString
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
 
 		-
 			message: '#^Variable \$options_log_max_dnsbl_parse_err might not be defined\.$#'
@@ -1129,112 +805,10 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
 
 		-
-			message: '#^Call to an undefined method Form\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_hooks.php
-
-		-
-			message: '#^Call to an undefined method Form_Button\:\:removeClass\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_hooks.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 7
-			path: src/usr/local/www/pfblockerng/pfblockerng_hooks.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:addClass\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_hooks.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_hooks.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 5
-			path: src/usr/local/www/pfblockerng/pfblockerng_hooks.php
-
-		-
-			message: '#^Parameter Form of print cannot be converted to string\.$#'
-			identifier: print.nonString
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_hooks.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 6
-			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 25
-			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
-
-		-
-			message: '#^Parameter Form of print cannot be converted to string\.$#'
-			identifier: print.nonString
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
-
-		-
 			message: '#^Variable \$v4suppression in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
-
-		-
-			message: '#^Binary operation "\-" between string and 10000 results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_log.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_log.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:addGlobal\(\)\.$#'
-			identifier: method.notFound
-			count: 5
-			path: src/usr/local/www/pfblockerng/pfblockerng_log.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 5
-			path: src/usr/local/www/pfblockerng/pfblockerng_log.php
-
-		-
-			message: '#^Parameter Form of print cannot be converted to string\.$#'
-			identifier: print.nonString
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_log.php
 
 		-
 			message: '#^Variable \$_REQUEST in isset\(\) always exists and is not nullable\.$#'
@@ -1249,142 +823,10 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_log.php
 
 		-
-			message: '#^Call to an undefined method Form\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 4
-			path: src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
-
-		-
-			message: '#^Parameter Form of print cannot be converted to string\.$#'
-			identifier: print.nonString
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_software.php
-
-		-
-			message: '#^Call to an undefined method Form_Button\:\:addClass\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_software.php
-
-		-
-			message: '#^Call to an undefined method Form_Button\:\:removeClass\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_software.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 9
-			path: src/usr/local/www/pfblockerng/pfblockerng_software.php
-
-		-
-			message: '#^Parameter Form of print cannot be converted to string\.$#'
-			identifier: print.nonString
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_software.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_sync.php
-
-		-
-			message: '#^Call to an undefined method Form_Button\:\:removeClass\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_sync.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 8
-			path: src/usr/local/www/pfblockerng/pfblockerng_sync.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:addClass\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_sync.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_sync.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 5
-			path: src/usr/local/www/pfblockerng/pfblockerng_sync.php
-
-		-
-			message: '#^Parameter Form of print cannot be converted to string\.$#'
-			identifier: print.nonString
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_sync.php
-
-		-
 			message: '#^Variable \$_REQUEST in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng_threats.php
-
-		-
-			message: '#^Binary operation "\." between Form_Button and Form_Button results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
-
-		-
-			message: '#^Call to an undefined method Form\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
-
-		-
-			message: '#^Call to an undefined method Form_Button\:\:removeClass\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 8
-			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
-
-		-
-			message: '#^Call to an undefined method Form_Group\:\:setHelp\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:add\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
-
-		-
-			message: '#^Call to an undefined method Form_Section\:\:addInput\(\)\.$#'
-			identifier: method.notFound
-			count: 7
-			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
 
 		-
 			message: '#^Parameter \#1 \$string of function str_pad expects string, int given\.$#'
@@ -1396,12 +838,6 @@ parameters:
 			message: '#^Parameter \#1 \$string of function str_pad expects string, int\<\-59, 59\> given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
-
-		-
-			message: '#^Parameter Form of print cannot be converted to string\.$#'
-			identifier: print.nonString
-			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
 
 		-
@@ -1437,12 +873,6 @@ parameters:
 		-
 			message: '#^Deprecated in PHP 8\.0\: Required parameter \$pfb_table follows optional parameter \$mode\.$#'
 			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
-
-		-
-			message: '#^Function pfSense_get_pf_rules not found\.$#'
-			identifier: function.notFound
 			count: 1
 			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9039,6 +9039,11 @@ function pfb_match_reported_cidr(array $result, string $ip, bool $v4_type): ?arr
 			$validate = FALSE;
 			if ($v4_type) {
 				list($addr, $mask) = explode('/', $line[1]);
+				// issue #1157: skip malformed CIDR candidates -- a bad mask fataled
+				// (TypeError/negative shift) here
+				if (!ctype_digit((string) $mask) || (int) $mask > 32 || !is_ipaddrv4($addr)) {
+					continue;
+				}
 				$mask = (0xffffffff << (32 - $mask)) & 0xffffffff;
 				$validate = ((ip2long($ip) & $mask) == (ip2long($addr) & $mask));
 			}
@@ -9047,6 +9052,10 @@ function pfb_match_reported_cidr(array $result, string $ip, bool $v4_type): ?arr
 				 * https://redmine.pfsense.org/issues/14256
 				 */
 				list($prefix, $length) = explode('/', $line[1]);
+				// issue #1157: skip malformed CIDR candidates -- a bad length false-matched here
+				if (!ctype_digit((string) $length) || (int) $length > 128 || !is_ipaddrv6($prefix)) {
+					continue;
+				}
 				$prefix = gen_subnetv6($prefix, $length);
 				$subnet = "{$prefix}/{$length}";
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10608,7 +10608,9 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 
 	if (file_exists($file_download) && ($http_status == '200' || $http_status == '221' || $http_status == '226')) {
 
-		unset($retval);
+		// issue #1158: fail-safe default -- with unset(), paths that assigned nothing fell
+		// through $retval == 0 as success
+		$retval = 1;
 
 		// Validate File Mime-type
 		$reject_detail = array();
@@ -10743,6 +10745,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 
 					// Create update file indicator for update process
 					touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
+					$retval = 0;
 				}
 				else {
 					pfb_logger("\n Invalid filename [{$filename}]", 1);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6393,12 +6393,6 @@ function pfb_unbound_python_whitelist($mode='') {
 					$line = substr($line, 4);
 				}
 
-				// Minimize the python whitelist queries to the smallest tld segment count
-				if (!isset($tld_segments)) {
-					$tld_segments = (substr_count($line, '.') +1);
-				}
-				$tld_segments = @min((array((substr_count($line, '.') +1), $tld_segments) ?: 1));
-
 				if (str_starts_with($line, '.')) {
 					$line = ltrim($line, '.');
 					$dnsbl_whitelist .= "{$line},1\n";
@@ -7464,10 +7458,6 @@ function pfb_unbound_python($mode) {
 			pfb_unbound_python_sources_whitelist();
 		}
 
-		if (!isset($tld_segments)) {
-			$tld_segments = '1';
-		}
-
 		$python_reply = 'off';
 		if ($pfb['dnsbl_py_reply'] == 'on') {
 			$python_reply = 'on';
@@ -7558,6 +7548,9 @@ function pfb_unbound_python($mode) {
 
 		$now = date('Y-m-d H:i:s', time());	// ISO-8601 (py_unbound.ini "File created" comment)
 
+		// issue #1155: fixed at 1 -- the min-segment optimization was computed-and-discarded
+		// in pfb_unbound_python_whitelist() since extraction; 1 is behaviourally identical
+		// (only wildcard entries can match the Python suffix walk it gates).
 		$pfb_py_conf = <<<EOF
 ; pfBlockerNG DNSBL Unbound python configuration file
 ; pfb_unbound.ini [ File created: {$now} ]
@@ -7572,7 +7565,7 @@ python_idn	= {$python_idn}
 idn_mode	= {$idn_mode}
 python_idn_block_malicious	= {$python_idn_block_malicious}
 python_idn_escalate_suspicious	= {$python_idn_escalate_suspicious}
-python_tld_seg	= {$tld_segments}
+python_tld_seg	= 1
 decisiondb_max	= {$decisiondb_max}
 python_tld	= {$python_tld}
 python_tlds	= {$python_tlds}

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -750,16 +750,18 @@ function pfblockerng_sync_cron($force_all = FALSE, $scope = 'both') {
 							continue;
 						}
 
+						// Allow cURL SSL downgrade if user configured. $pflex must be derived
+						// per-row before any update-check call below — PHP loop variables
+						// persist across iterations (issue #1154).
+						$pflex = FALSE;
+						if ($row['state'] == 'Flex') {
+							$pflex = TRUE;
+						}
+
 						// Attempt download, when a previous 'fail' file marker is found.
 						if (file_exists("{$pfbfolder}/{$header}.fail")) {
 							pfb_update_check($header, $row['url'], $pfbfolder, $pfborig, $pflex, $row['format'], $vtype, $srcint);
 							continue;
-						}
-
-						// Allow cURL SSL downgrade if user configured.
-						$pflex = FALSE;
-						if ($row['state'] == 'Flex') {
-							$pflex = TRUE;
 						}
 
 						if ($force_all) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -239,6 +239,14 @@ if (isset($_REQUEST) && isset($_REQUEST['ajax'])) {
 
 			$pfb_logfilename_esc = escapeshellarg($pfb_logfilename);
 			$linecnt = exec("{$pfb['grep']} -c ^ {$pfb_logfilename_esc} 2>&1");
+
+			// issue #1156: 2>&1 puts grep errors in $linecnt; non-numeric must not reach
+			// the subtraction, and silently skipping the cap would stream the whole file --
+			// answer with the handler's error convention instead.
+			if (!is_numeric($linecnt)) {
+				print ("|2|" . gettext('Failed to determine log line count') . "|IA==|");
+				exit;
+			}
 			$maxcnt = 10000; // Max line limit
 
 			$validate = FALSE;

--- a/stubs/pfsense/forms.php
+++ b/stubs/pfsense/forms.php
@@ -2,43 +2,133 @@
 /**
  * pfSense WebUI form-builder class stubs — static analysis only (PHPStan / Intelephense).
  *
- * HAND-MAINTAINED (not produced by scripts/update-pfsense-stubs.py): these are the
- * /usr/local/www/classes/Form/* widget classes the WebUI pages instantiate. PHPStan
- * level 0 only needs the symbols to exist; a variadic constructor plus a __call that
- * returns $this faithfully model the widgets' fluent API without pinning every method
- * signature — e.g. (new Form_Input(...))->setHelp(...)->setAttribute(...),
- * $section->addInput(...), $group->add(...), $form->add($section).
- *
- * This lets PHPStan resolve the WebUI pages instead of baselining every "Instantiated
- * class Form_* not found" — see CLAUDE.md "stub over baseline".
+ * HAND-MAINTAINED (not produced by scripts/update-pfsense-stubs.py): the
+ * /usr/local/www/classes/Form/* widget classes the WebUI pages instantiate.
+ * PHPStan level 2 needs REAL method declarations — a variadic __call (level 0's
+ * trick) is not honoured: it still reports "Call to an undefined method" for
+ * every call site regardless. Method names/params/return types below mirror
+ * pfSense CE 2.8.0's dated commit ed6c2eb8 (2025-05-28 — the mirror carries no
+ * RELENG_2_8_0 tag/branch): src/usr/local/www/classes/Form.class.php and
+ * Form/{Element,Section,Group,Input,Button,Select,Checkbox,StaticText,
+ * Textarea}.class.php; only members pfBlockerNG's WebUI actually calls are
+ * declared (verified by grep over src/usr/local/www/pfblockerng) — upstream
+ * has more, unused ones are omitted (issue #1159).
  *
  * Not shipped — stubs/ is excluded from release archives.
  */
 
-abstract class _PfbFormWidgetStub
+// @codingStandardsIgnoreFile
+
+class Form_Element
 {
     public function __construct(mixed ...$args) {}
 
-    public function __call(string $name, array $arguments): static
+    public function addClass(string ...$classes): static
+    {
+        return $this;
+    }
+
+    public function removeClass(string $class): static
+    {
+        return $this;
+    }
+
+    public function setAttribute(string $key, mixed $value = null): static
+    {
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return '';
+    }
+}
+
+class Form extends Form_Element
+{
+    public function add(Form_Section $section): Form_Section
+    {
+        return $section;
+    }
+
+    public function setAction(string $url): static
+    {
+        return $this;
+    }
+
+    public function addGlobal(Form_Input $input): Form_Input
+    {
+        return $input;
+    }
+}
+
+class Form_Section extends Form_Element
+{
+    public function add(Form_Group $group): Form_Group
+    {
+        return $group;
+    }
+
+    /** Shortcut: wraps $input in its own Form_Group and adds that. */
+    public function addInput(Form_Input $input): Form_Input
+    {
+        return $input;
+    }
+
+    /** Shortcut: wraps $input (+ an optional confirm field) in its own Form_Group. */
+    public function addPassword(Form_Input $input, bool $confirmfield = true): Form_Input
+    {
+        return $input;
+    }
+}
+
+class Form_Group extends Form_Element
+{
+    /**
+     * Returns its own argument (upstream: `return $input;`) — templated so a
+     * chained call on the caller's own Form_Input subtype (e.g. displayAsRadio()
+     * on a Form_Checkbox) still resolves.
+     *
+     * @template TInput of Form_Input
+     * @param TInput $input
+     * @return TInput
+     */
+    public function add(Form_Input $input): Form_Input
+    {
+        return $input;
+    }
+
+    public function setHelp(mixed ...$args): static
     {
         return $this;
     }
 }
 
-class Form extends _PfbFormWidgetStub {}
+class Form_Input extends Form_Element
+{
+    public function setHelp(mixed ...$args): static
+    {
+        return $this;
+    }
 
-class Form_Section extends _PfbFormWidgetStub {}
+    public function setWidth(int|float $size): static
+    {
+        return $this;
+    }
+}
 
-class Form_Group extends _PfbFormWidgetStub {}
+class Form_Select extends Form_Input {}
 
-class Form_Input extends _PfbFormWidgetStub {}
+class Form_Checkbox extends Form_Input
+{
+    public function displayAsRadio(?string $id = null): static
+    {
+        return $this;
+    }
+}
 
-class Form_Select extends _PfbFormWidgetStub {}
+class Form_Button extends Form_Input {}
 
-class Form_Checkbox extends _PfbFormWidgetStub {}
+class Form_StaticText extends Form_Input {}
 
-class Form_Button extends _PfbFormWidgetStub {}
-
-class Form_StaticText extends _PfbFormWidgetStub {}
-
-class Form_Textarea extends _PfbFormWidgetStub {}
+class Form_Textarea extends Form_Input {}

--- a/stubs/pfsense/supplemental.php
+++ b/stubs/pfsense/supplemental.php
@@ -2,10 +2,13 @@
 /**
  * pfSense supplemental stubs — IDE/PHPStan static analysis only.
  *
- * Hand-maintained. Holds pfSense functions that pfBlockerNG calls on its
- * supported target (CE 2.8) but which are ABSENT from the pinned stub-source
- * version used by scripts/update-pfsense-stubs.py (currently 2.7.2 — the newest
- * public pfSense source; Netgate's GitHub mirror has no RELENG_2_8_0 ref).
+ * Hand-maintained. Holds pfSense functions AND classes that pfBlockerNG calls
+ * on its supported target (CE 2.8) but which are ABSENT from the pinned
+ * stub-source version used by scripts/update-pfsense-stubs.py (currently
+ * 2.7.2 — the newest public pfSense source; Netgate's GitHub mirror has no
+ * RELENG_2_8_0 ref) — plus symbols the generator can never cover: a bundled
+ * third-party library pfSense's core requires (Net_IPv6) and a native PHP
+ * extension function with no PHP source at all (pfSense_get_pf_rules).
  *
  * The generator never overwrites this file (it is not a STUB_MODULES output),
  * and its symbols seed the generator's cross-file dedup set. Drop an entry once
@@ -21,3 +24,43 @@ function config_read_file(bool $use_backup = false, bool $use_cache = true): arr
 
 /** Return true if the current logged-in user may access $page, per their privilege match list (priv.inc). */
 function isAllowedPage($page) {}
+
+/**
+ * HA/XMLRPC config-sync client (etc/inc/xmlrpc_client.inc; stable CE 2.8.0..master,
+ * dated commit ed6c2eb8 2025-05-28 — mirror carries no RELENG_2_8_0 ref). Upstream
+ * has more members (xmlrpc_exec_php/get_error/getUrl); only what pfBlockerNG
+ * calls is declared.
+ */
+class pfsense_xmlrpc_client
+{
+    public function __construct() {}
+
+    public function setConnectionData(mixed $syncip, mixed $port, mixed $username, mixed $password, mixed $scheme = ''): void {}
+
+    public function xmlrpc_method(string $method, mixed $parameter = '', int $timeout = 240): mixed {}
+}
+
+/**
+ * PEAR Net_IPv6 (etc/inc/util.inc: require_once('Net/IPv6.php')) — a bundled
+ * third-party library, not pfSense-authored; https://github.com/pear/Net_IPv6.
+ * Only the member pfBlockerNG calls is declared.
+ */
+class Net_IPv6
+{
+    public static function isInNetmask(string $ip, string $netmask, mixed $bits = null): bool {}
+}
+
+/**
+ * Begin/end a buffered PHP session (etc/inc/phpsessionmanager.inc; stable
+ * CE 2.8.0..master, dated commit ed6c2eb8 2025-05-28).
+ */
+function phpsession_begin(): void {}
+
+function phpsession_end(bool $write = false): void {}
+
+/**
+ * Native PHP extension function (pfSense-utils; no PHP source to cite) —
+ * returns the live pf ruleset with packet/byte counters, one row per rule.
+ * Shape inferred from its sole call site in pfblockerng.widget.php.
+ */
+function pfSense_get_pf_rules(mixed ...$args): array {}

--- a/tests/php/DownloadRetvalFailsafeTest.php
+++ b/tests/php/DownloadRetvalFailsafeTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_download()'s $retval fail-safe default (issue #1158).
+ *
+ * pfb_download() drives real cURL + the appliance exec pipeline before any of
+ * the sites under test run, so behaviourally exercising the function off-appliance
+ * is infeasible -- this is a source-inspection pin instead (house precedent:
+ * tests/php/PfbSyncStatusDnsblWritersTest.php's
+ * testRestartFallbackBranchesNeverCallLedgerFunctionsDirectly()).
+ *
+ * The bug: `unset($retval);` left $retval undefined on any code path that fell
+ * through the decompression switch without assigning it. PHP's loose `== 0`
+ * then treats NULL as equal to 0, so an unassigned $retval silently reads as
+ * the SUCCESS gate (`if ($retval == 0)`) instead of failure. Two such paths
+ * exist: the ZIP xlsx-conversion-failure branch (the reported defect -- a
+ * failed conversion must FAIL, not succeed) and the gzip 'blacklist' success
+ * branch (which must keep succeeding under the new fail-safe default).
+ */
+final class DownloadRetvalFailsafeTest extends TestCase
+{
+	private static string $body;
+
+	public static function setUpBeforeClass(): void
+	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
+		);
+		if ($source === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		}
+
+		$start = strpos($source, 'function pfb_download(');
+		if ($start === false) {
+			throw new RuntimeException('test bootstrap: function pfb_download( not found');
+		}
+
+		// Whitespace-tolerant: the next top-of-line 'function <name>' declaration
+		// (an indented closure inside the body, e.g. the CURLOPT_HEADERFUNCTION
+		// callback, never matches '^function' since it is never at column 0).
+		if (!preg_match('/^function\s+\w+/m', $source, $m, PREG_OFFSET_CAPTURE, $start + 20)) {
+			throw new RuntimeException('test bootstrap: end-of-function boundary not found');
+		}
+		$end = $m[0][1];
+
+		self::$body = substr($source, $start, $end - $start);
+	}
+
+	// -----------------------------------------------------------------------
+	// Vacuity guards -- each marker this test's assertions depend on must
+	// actually be present, or the assertions below prove nothing.
+	// -----------------------------------------------------------------------
+
+	public function testVacuityRetvalGateExists(): void
+	{
+		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*==\s*0\s*\)/', self::$body,
+			'the $retval == 0 success gate must exist for this test to mean anything');
+	}
+
+	public function testVacuityXlsxExecMarkerExists(): void
+	{
+		$this->assertStringContainsString("{\$pfb['script']} xlsx {\$header_esc}", self::$body,
+			'the xlsx-conversion exec call must exist -- this is the reported defect route');
+	}
+
+	public function testVacuityUpdateTouchMarkerExists(): void
+	{
+		$this->assertStringContainsString('{$filename}/{$filename}.update', self::$body,
+			'the gzip-blacklist .update touch marker must exist -- Route 2 pins against it');
+	}
+
+	public function testVacuityAtLeastFourExecSitesAssignRetval(): void
+	{
+		$count = substr_count(self::$body, ', $output, $retval)');
+		$this->assertGreaterThanOrEqual(4, $count,
+			"expected >= 4 exec(...,\$output,\$retval) sites (gzip-default/asn/top1m, bzip2, zip-pipeline, 7z); found {$count}");
+	}
+
+	// -----------------------------------------------------------------------
+	// Red row A -- the fail-safe default itself.
+	// -----------------------------------------------------------------------
+
+	public function testRetvalDefaultsToOneNotUnset(): void
+	{
+		$this->assertStringNotContainsString('unset($retval);', self::$body,
+			'unset($retval) must be gone -- it let an unassigned path read as 0 == success');
+		$this->assertMatchesRegularExpression('/\$retval\s*=\s*1\s*;/', self::$body,
+			'a $retval = 1 fail-safe default must replace the unset() -- unassigned must mean FAILURE');
+	}
+
+	// -----------------------------------------------------------------------
+	// Red row B -- Route 2 (gzip-blacklist) keeps succeeding under the new default.
+	// -----------------------------------------------------------------------
+
+	public function testGzipBlacklistSuccessExplicitlyAssignsZeroAfterUpdateTouch(): void
+	{
+		$touchPos = strpos(self::$body, '{$filename}/{$filename}.update');
+		$this->assertNotFalse($touchPos, 'the .update touch marker must be locatable (vacuity re-check)');
+
+		// Whitespace-tolerant proximity window: the touch call's closing ");"
+		// through ~200 chars ahead must contain an explicit $retval = 0;
+		// (mirrors the uncompressed-blacklist sibling at pfblockerng.inc:10874).
+		$window = substr(self::$body, $touchPos, 200);
+		$this->assertMatchesRegularExpression('/\$retval\s*=\s*0\s*;/', $window,
+			"gzip-blacklist success must explicitly set \$retval = 0 after its .update touch "
+			. "(preserving its outcome under the new fail-safe default); found near touch: "
+			. json_encode($window));
+	}
+
+	// -----------------------------------------------------------------------
+	// Additional semantics pin -- the hazard this fail-safe defends against.
+	// -----------------------------------------------------------------------
+
+	public function testNullEqualsZeroHazardBackingTheFailsafe(): void
+	{
+		// phpcs:ignore -- deliberately loose comparison: this IS the hazard.
+		$this->assertTrue(null == 0,
+			"PHP's loose '==' treats an unassigned (NULL) \$retval as equal to 0, "
+			. 'so any code path that falls through without assigning $retval silently '
+			. '"succeeds" at the if ($retval == 0) gate -- this is exactly the bug '
+			. '$retval = 1 (fail-safe default) defends against');
+	}
+}

--- a/tests/php/LogLinecountGuardTest.php
+++ b/tests/php/LogLinecountGuardTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfblockerng_log.php AJAX 'load' handler line-count guard (issue #1156).
+ *
+ * `exec("{$pfb['grep']} -c ^ ... 2>&1")` puts a grep error string into
+ * $linecnt on failure (removed-file race, unreadable path). PHP 8 then
+ * compares that string to an int as strings ($linecnt > $maxcnt can be
+ * TRUE for non-numeric text) and a subsequent $linecnt - $maxcnt on a
+ * non-numeric string is a fatal TypeError. Silently skipping the cap
+ * would be worse than the fatal: the fgets() loop would stream the
+ * WHOLE file unbounded, defeating the 10k-line cap exactly when grep
+ * cannot be trusted — so a non-numeric count must answer with the
+ * handler's own '|2|' error convention and stop.
+ *
+ * The file executes top-level code on include (needs a live pfSense
+ * session — $pfb, $_REQUEST routing, real file I/O) and cannot be
+ * require()d off-appliance. Per the PfbReflectorGuardTest.php eval-oracle
+ * precedent, the guard + cap block is extracted verbatim from the real
+ * source into a callable oracle (exec output injected as the argument;
+ * print captured; exit becomes an early return), so the branch logic is
+ * exercised behaviourally, not just shape-matched.
+ *
+ * Feature: a non-numeric grep count fails loudly instead of fatal or
+ *          unbounded streaming; numeric counts keep the 10k tail window
+ *
+ *   Scenario: numeric under/at the cap  -> no window, no error
+ *   Scenario: numeric over the cap      -> window armed, skip count exact
+ *   Scenario: non-numeric (grep error)  -> '|2|' error response, no window,
+ *             no TypeError
+ */
+final class LogLinecountGuardTest extends TestCase
+{
+	private static string $src;
+
+	public static function setUpBeforeClass(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_log.php';
+		$src = file_get_contents($path);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_log.php');
+		}
+		self::$src = $src;
+
+		// Oracle: the block from the non-numeric guard through the cap window,
+		// exactly as committed. print -> capture, exit -> early return, gettext
+		// stripped (plain PHP string stays). If extraction fails the guard block
+		// changed shape — fail loudly rather than skip.
+		if (!function_exists('pfb_log_linecount_oracle')
+			&& preg_match('/(if \(!is_numeric\(\$linecnt\)\).*?Displaying last.*?\n\t{3}\})\n/s', $src, $m)) {
+			$block = strtr($m[1], [
+				'print ('  => '$out .= (',
+				'exit;'    => 'return array($out, NULL, NULL, NULL);',
+				'gettext(' => '(',
+			]);
+			eval(
+				'function pfb_log_linecount_oracle($linecnt) {'
+				. ' $out = \'\'; $maxcnt = 0; $validate = NULL; $line_limit = NULL; $skipcnt = NULL;'
+				. $block
+				. ' return array($out, $validate, $skipcnt, $line_limit); }'
+			);
+		}
+	}
+
+	private function oracle(string $linecnt): array
+	{
+		if (!function_exists('pfb_log_linecount_oracle')) {
+			$this->fail('oracle extraction failed: the is_numeric guard block was not found in pfblockerng_log.php — see testNonNumericGuardAnswersWithErrorConvention\'s source assertion');
+		}
+		return pfb_log_linecount_oracle($linecnt);
+	}
+
+	// --------------------------------------------------------------------------
+	// Source-shape vacuity guards (the oracle depends on these constructs)
+	// --------------------------------------------------------------------------
+
+	public function testGrepLineCountExecCallExistsExactlyOnce(): void
+	{
+		$count = preg_match_all('/\$linecnt\s*=\s*exec\(.*-c\s+\^.*\);/', self::$src);
+		$this->assertSame(
+			1,
+			$count,
+			'expected exactly one grep -c line-count exec() call in the AJAX load handler'
+		);
+	}
+
+	public function testLinecntMaxcntSubtractionStillPresent(): void
+	{
+		$this->assertMatchesRegularExpression(
+			'/\$linecnt\s*-\s*\$maxcnt/',
+			self::$src,
+			'the tail-window subtraction this guard protects must still exist'
+		);
+	}
+
+	/**
+	 * The red row for the loud-failure behaviour: on code that silently
+	 * skips the cap for a non-numeric count, this shape is absent.
+	 */
+	public function testNonNumericGuardAnswersWithErrorConvention(): void
+	{
+		$this->assertMatchesRegularExpression(
+			'/if\s*\(\s*!is_numeric\(\s*\$linecnt\s*\)\s*\)\s*\{\s*\n\s*print \("\|2\|"/',
+			self::$src,
+			'a non-numeric $linecnt must answer with the handler\'s |2| error convention before any cap math'
+		);
+	}
+
+	// --------------------------------------------------------------------------
+	// Behavioural rows through the extracted oracle
+	// --------------------------------------------------------------------------
+
+	public function testNumericUnderCapKeepsFullView(): void
+	{
+		[$out, $validate, $skipcnt, $line_limit] = $this->oracle('500');
+
+		$this->assertSame('', $out, 'no error response expected for a numeric under-cap count');
+		$this->assertFalse($validate, 'the tail window must stay disarmed under the cap');
+		$this->assertNull($skipcnt, 'no skip count expected under the cap');
+		$this->assertSame('', $line_limit, 'no truncation notice expected under the cap');
+	}
+
+	public function testNumericAtCapBoundaryKeepsFullView(): void
+	{
+		// Pins the comparison operator: exactly-at-cap is NOT over the cap.
+		[$out, $validate] = $this->oracle('10000');
+
+		$this->assertSame('', $out, 'no error response expected at the cap boundary');
+		$this->assertFalse($validate, 'exactly-at-cap must not arm the tail window (> not >=)');
+	}
+
+	public function testNumericOverCapArmsTailWindowWithExactSkipCount(): void
+	{
+		[$out, $validate, $skipcnt, $line_limit] = $this->oracle('10500');
+
+		$this->assertSame('', $out, 'no error response expected for a numeric over-cap count');
+		$this->assertTrue($validate, 'an over-cap count must arm the tail window');
+		$this->assertSame(500, $skipcnt, 'skip count must be linecnt - maxcnt');
+		$this->assertStringContainsString(
+			'Displaying last 10000 lines only',
+			(string) $line_limit,
+			'the truncation notice must name the cap'
+		);
+	}
+
+	public function testNonNumericGrepErrorFailsLoudlyWithoutTypeErrorOrStreaming(): void
+	{
+		try {
+			[$out, $validate] = $this->oracle('grep: no such file or directory');
+		} catch (\TypeError $e) {
+			$this->fail('a non-numeric grep count must not reach the subtraction: ' . $e->getMessage());
+		}
+
+		$this->assertStringStartsWith(
+			'|2|',
+			$out,
+			'a non-numeric grep count must produce the |2| error response, got ' . var_export($out, true)
+		);
+		$this->assertNull(
+			$validate,
+			'the handler must stop at the error response — reaching the cap logic means the unbounded-stream path is open'
+		);
+	}
+
+	/**
+	 * Documentation test pinning the PHP 8 language semantics the guard
+	 * defends against — NOT a substitute for the rows above.
+	 */
+	public function testGrepErrorStringSemanticsMotivatingTheGuard(): void
+	{
+		$this->assertTrue(
+			'grep: no such file' > 10000,
+			'PHP 8 compares int vs non-numeric string as strings — the old comparison let error text through'
+		);
+
+		$this->expectException(\TypeError::class);
+		(static fn () => 'grep: no such file' - 10000)();
+	}
+}

--- a/tests/php/LogLinecountGuardTest.php
+++ b/tests/php/LogLinecountGuardTest.php
@@ -51,7 +51,7 @@ final class LogLinecountGuardTest extends TestCase
 		// stripped (plain PHP string stays). If extraction fails the guard block
 		// changed shape — fail loudly rather than skip.
 		if (!function_exists('pfb_log_linecount_oracle')
-			&& preg_match('/(if \(!is_numeric\(\$linecnt\)\).*?Displaying last.*?\n\t{3}\})\n/s', $src, $m)) {
+			&& preg_match('/(if \(!is_numeric\(\$linecnt\)\).*?Displaying last.*?\n[\t ]*\})\n/s', $src, $m)) {
 			$block = strtr($m[1], [
 				'print ('  => '$out .= (',
 				'exit;'    => 'return array($out, NULL, NULL, NULL);',

--- a/tests/php/MatchReportedCidrHostileInputTest.php
+++ b/tests/php/MatchReportedCidrHostileInputTest.php
@@ -1,0 +1,413 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_match_reported_cidr() -- hostile-input coverage for issue #1157.
+ *
+ * The CIDR candidates this function walks come from grep output over feed files
+ * (semi-trusted external input) and are shape-checked only via strpos('/') before this
+ * test's fix. A malformed mask/length (empty, non-numeric, oversized, negative-looking)
+ * reaches raw arithmetic ("32 - $mask" / a left shift) and either fatals (TypeError,
+ * ArithmeticError) or -- on the v6 side, via the off-appliance gen_subnetv6()/Net_IPv6
+ * doubles -- returns a false-positive match. A malformed candidate must be silently
+ * skipped (issue #843's existing skip pattern), never fatal, never a false match, and
+ * never abort the scan of the remaining candidates.
+ *
+ * Feature: pfb_match_reported_cidr() treats a malformed CIDR candidate as "not a
+ *          match candidate", not as a fatal error or an always-true stub
+ *
+ *   Scenario: v4 malformed masks
+ *     empty mask, non-numeric mask, and oversized mask (>32) yield NULL with no thrown
+ *     error -- pre-fix all three fatal (TypeError / ArithmeticError) and are reproduced
+ *     here as genuine red rows. A leading '-' mask ('-1') did NOT fatal pre-fix: 32-(-1)
+ *     is a positive 33-bit shift whose & 0xffffffff wrap degenerates to mask 0, silently
+ *     matching EVERY v4 host -- the guard now rejects it.
+ *
+ *   Scenario: v4 valid rows keep their existing behaviour (before-state preserved)
+ *     a real /24 containment hit, a real miss, and the boundary mask '/0' (0 is a
+ *     legal mask -- the new guard must not reject it) all behave exactly as before
+ *     the fix.
+ *
+ *   Scenario: v4 malformed address
+ *     a non-IP address is rejected by the address predicate, not by the arithmetic.
+ *     'banana/24' happened to be safe pre-fix (masked compare misses) -- preserved
+ *     behaviour; 'banana/0' was the match-everything false positive (ip2long FALSE
+ *     degenerates to 0 == 0 under mask 0) and is the red-class row of this scenario.
+ *
+ *   Scenario: mask/length boundaries pin the guard's comparison operators
+ *     v4 '/32' and v6 '/128' are legal maxima (a future '>' -> '>=' typo must fail
+ *     here); v4 '/33' and v6 '/129' are the true off-by-one rejects; v6 '/0' is legal
+ *     like its v4 sibling.
+ *
+ *   Scenario: v6 malformed lengths
+ *     empty length and non-numeric length are the false-positive-producing rows this
+ *     issue names (pre-fix they return a spurious match against the off-appliance
+ *     gen_subnetv6()/Net_IPv6 doubles). An oversized length (>200) was already rejected
+ *     pre-fix by gen_subnetv6()'s own bits>128 check -- preserved behaviour, now
+ *     guaranteed by the guard instead of the double's internals.
+ *
+ *   Scenario: v6 valid rows keep their existing behaviour (before-state preserved)
+ *     a real /32 containment hit and a real miss behave exactly as before the fix.
+ *
+ *   Scenario: v6 malformed prefix
+ *     a non-IP prefix paired with an otherwise well-formed length is rejected by the
+ *     address predicate -- 'banana/32' yields NULL, no throw (safe pre-fix too:
+ *     pfb_ip_in_cidr() fails closed on inet_pton -- preserved behaviour).
+ *
+ *   Scenario: skip, don't abort
+ *     a malformed candidate followed by a real matching candidate in the same $result
+ *     array still returns the real match -- the guard must `continue`, not stop the scan.
+ */
+#[CoversFunction('pfb_match_reported_cidr')]
+final class MatchReportedCidrHostileInputTest extends TestCase
+{
+	// A bare E_WARNING is not fatal to PHPUnit by default; escalating it to an exception
+	// makes an unguarded "32 - $mask" / bad-shift path deterministically visible as a red
+	// run instead of a silently-passed warning. TypeError/ArithmeticError are already
+	// uncaught Throwables and need no such escalation.
+	private function assertNeverWarnsOrThrows(callable $call): mixed
+	{
+		set_error_handler(static function (int $errno, string $errstr): bool {
+			throw new \ErrorException($errstr, 0, $errno);
+		}, E_WARNING);
+
+		try {
+			return $call();
+		} finally {
+			restore_error_handler();
+		}
+	}
+
+	// ------------------------------------------------------------------------------
+	// v4 -- malformed masks
+	// ------------------------------------------------------------------------------
+
+	public function test_v4_empty_mask_yields_null_without_throwing(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:1.2.3.0/'];
+
+		$match = $this->assertNeverWarnsOrThrows(
+			fn () => pfb_match_reported_cidr($result, '1.2.3.4', TRUE)
+		);
+
+		$this->assertNull($match, 'expected an empty v4 mask to be skipped as NULL, got ' . var_export($match, true));
+	}
+
+	public function test_v4_non_numeric_mask_yields_null_without_throwing(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:1.2.3.0/xx'];
+
+		$match = $this->assertNeverWarnsOrThrows(
+			fn () => pfb_match_reported_cidr($result, '1.2.3.4', TRUE)
+		);
+
+		$this->assertNull(
+			$match,
+			'expected a non-numeric v4 mask to be skipped as NULL, got ' . var_export($match, true)
+		);
+	}
+
+	public function test_v4_oversize_mask_yields_null_without_throwing(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:1.2.3.0/99'];
+
+		$match = $this->assertNeverWarnsOrThrows(
+			fn () => pfb_match_reported_cidr($result, '1.2.3.4', TRUE)
+		);
+
+		$this->assertNull(
+			$match,
+			'expected an oversized (>32) v4 mask to be skipped as NULL, got ' . var_export($match, true)
+		);
+	}
+
+	public function test_v4_negative_mask_yields_null_without_throwing(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:1.2.3.0/-1'];
+
+		$match = $this->assertNeverWarnsOrThrows(
+			fn () => pfb_match_reported_cidr($result, '1.2.3.4', TRUE)
+		);
+
+		$this->assertNull(
+			$match,
+			'expected a negative-looking v4 mask to be skipped as NULL, got ' . var_export($match, true)
+		);
+	}
+
+	// ------------------------------------------------------------------------------
+	// v4 -- valid rows keep their existing behaviour
+	// ------------------------------------------------------------------------------
+
+	public function test_v4_valid_24_mask_matches_host_inside(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:1.2.3.0/24'];
+
+		$match = pfb_match_reported_cidr($result, '1.2.3.4', TRUE);
+
+		$this->assertSame(
+			['DenyFeed', '1.2.3.0/24'],
+			$match,
+			'expected 1.2.3.4 (inside the /24) to match, got ' . var_export($match, true)
+		);
+	}
+
+	public function test_v4_valid_24_mask_rejects_host_outside(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:1.2.3.0/24'];
+
+		$match = pfb_match_reported_cidr($result, '9.9.9.9', TRUE);
+
+		$this->assertNull(
+			$match,
+			'expected 9.9.9.9 (outside the /24) NOT to match, got ' . var_export($match, true)
+		);
+	}
+
+	public function test_v4_zero_mask_is_a_legal_mask_not_rejected_by_the_guard(): void
+	{
+		// '/0' is a legal mask (matches every address) -- the ctype_digit guard must
+		// not treat a falsy-looking '0' as malformed.
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:1.2.3.0/0'];
+
+		$match = pfb_match_reported_cidr($result, '203.0.113.5', TRUE);
+
+		$this->assertSame(
+			['DenyFeed', '1.2.3.0/0'],
+			$match,
+			'expected a /0 mask to match any host, got ' . var_export($match, true)
+		);
+	}
+
+	// ------------------------------------------------------------------------------
+	// v4 -- malformed address
+	// ------------------------------------------------------------------------------
+
+	public function test_v4_garbage_address_yields_null_without_throwing(): void
+	{
+		// Preserved behaviour: '/24' masked the compare into a miss even pre-fix.
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:banana/24'];
+
+		$match = $this->assertNeverWarnsOrThrows(
+			fn () => pfb_match_reported_cidr($result, '1.2.3.4', TRUE)
+		);
+
+		$this->assertNull(
+			$match,
+			'expected a non-IP v4 address to be skipped as NULL, got ' . var_export($match, true)
+		);
+	}
+
+	public function test_v4_garbage_address_with_zero_mask_never_matches_every_host(): void
+	{
+		// Pre-fix this was the worst input in the class: ip2long('banana') === FALSE
+		// degenerates to 0, and mask 0 turns the compare into 0 == 0 -- the candidate
+		// matched EVERY IPv4 host. Two unrelated IPs pin the "not a match-everything
+		// stub" property, not just a single lucky miss.
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:banana/0'];
+
+		foreach (['203.0.113.99', '8.8.8.8'] as $ip) {
+			$match = $this->assertNeverWarnsOrThrows(
+				fn () => pfb_match_reported_cidr($result, $ip, TRUE)
+			);
+
+			$this->assertNull(
+				$match,
+				"expected 'banana/0' NOT to match {$ip}, got " . var_export($match, true)
+			);
+		}
+	}
+
+	// ------------------------------------------------------------------------------
+	// v4 -- mask boundaries
+	// ------------------------------------------------------------------------------
+
+	public function test_v4_max_mask_32_boundary_is_legal(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:1.2.3.4/32'];
+
+		$this->assertSame(
+			['DenyFeed', '1.2.3.4/32'],
+			pfb_match_reported_cidr($result, '1.2.3.4', TRUE),
+			'expected the /32 boundary mask to be accepted and match its exact host'
+		);
+
+		$this->assertNull(
+			pfb_match_reported_cidr($result, '1.2.3.5', TRUE),
+			'expected the /32 boundary mask NOT to match a neighbouring host'
+		);
+	}
+
+	public function test_v4_mask_33_off_by_one_rejected(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:1.2.3.0/33'];
+
+		$match = $this->assertNeverWarnsOrThrows(
+			fn () => pfb_match_reported_cidr($result, '1.2.3.4', TRUE)
+		);
+
+		$this->assertNull(
+			$match,
+			'expected the /33 off-by-one mask to be rejected as NULL, got ' . var_export($match, true)
+		);
+	}
+
+	// ------------------------------------------------------------------------------
+	// v6 -- malformed lengths
+	// ------------------------------------------------------------------------------
+
+	public function test_v6_empty_length_yields_null_not_a_false_positive_match(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:2001:db8::/'];
+
+		$match = pfb_match_reported_cidr($result, '2001:db8::1', FALSE);
+
+		$this->assertNull(
+			$match,
+			'expected an empty v6 length to be skipped as NULL, got ' . var_export($match, true)
+		);
+	}
+
+	public function test_v6_non_numeric_length_yields_null_not_a_false_positive_match(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:2001:db8::/zz'];
+
+		$match = pfb_match_reported_cidr($result, '2001:db8::1', FALSE);
+
+		$this->assertNull(
+			$match,
+			'expected a non-numeric v6 length to be skipped as NULL, got ' . var_export($match, true)
+		);
+	}
+
+	public function test_v6_oversize_length_yields_null(): void
+	{
+		// Preserved behaviour: gen_subnetv6()'s own bits>128 check already rejected
+		// this pre-fix; the guard now owns the reject.
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:2001:db8::/200'];
+
+		$match = pfb_match_reported_cidr($result, '2001:db8::1', FALSE);
+
+		$this->assertNull(
+			$match,
+			'expected an oversized (>128) v6 length to be skipped as NULL, got ' . var_export($match, true)
+		);
+	}
+
+	// ------------------------------------------------------------------------------
+	// v6 -- length boundaries
+	// ------------------------------------------------------------------------------
+
+	public function test_v6_zero_length_is_legal_and_matches_any_host(): void
+	{
+		// '::/0' is the v6 sibling of the v4 '/0' legality row: the guard's
+		// ctype_digit must not treat the falsy-looking '0' as malformed.
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:::/0'];
+
+		$this->assertSame(
+			['DenyFeed', '::/0'],
+			pfb_match_reported_cidr($result, '2001:db8::1', FALSE),
+			'expected the legal ::/0 candidate to match any v6 host'
+		);
+	}
+
+	public function test_v6_max_length_128_boundary_is_legal(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:2001:db8::1/128'];
+
+		$this->assertSame(
+			['DenyFeed', '2001:db8::1/128'],
+			pfb_match_reported_cidr($result, '2001:db8::1', FALSE),
+			'expected the /128 boundary length to be accepted and match its exact host'
+		);
+	}
+
+	public function test_v6_length_129_off_by_one_rejected(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:2001:db8::/129'];
+
+		$match = pfb_match_reported_cidr($result, '2001:db8::1', FALSE);
+
+		$this->assertNull(
+			$match,
+			'expected the /129 off-by-one length to be rejected as NULL, got ' . var_export($match, true)
+		);
+	}
+
+	// ------------------------------------------------------------------------------
+	// v6 -- valid rows keep their existing behaviour
+	// ------------------------------------------------------------------------------
+
+	public function test_v6_valid_32_length_matches_host_inside(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:2001:db8::/32'];
+
+		$match = pfb_match_reported_cidr($result, '2001:db8::1', FALSE);
+
+		$this->assertSame(
+			['DenyFeed', '2001:db8::/32'],
+			$match,
+			'expected 2001:db8::1 (inside the /32) to match, got ' . var_export($match, true)
+		);
+	}
+
+	public function test_v6_valid_32_length_rejects_host_outside(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:2001:db8::/32'];
+
+		$match = pfb_match_reported_cidr($result, '2001:dead::1', FALSE);
+
+		$this->assertNull(
+			$match,
+			'expected 2001:dead::1 (outside the /32) NOT to match, got ' . var_export($match, true)
+		);
+	}
+
+	// ------------------------------------------------------------------------------
+	// v6 -- malformed prefix
+	// ------------------------------------------------------------------------------
+
+	public function test_v6_garbage_prefix_yields_null_without_throwing(): void
+	{
+		$result = ['/var/db/pfblockerng/deny/DenyFeed.txt:banana/32'];
+
+		$match = $this->assertNeverWarnsOrThrows(
+			fn () => pfb_match_reported_cidr($result, '2001:db8::1', FALSE)
+		);
+
+		$this->assertNull(
+			$match,
+			'expected a non-IP v6 prefix to be skipped as NULL, got ' . var_export($match, true)
+		);
+	}
+
+	// ------------------------------------------------------------------------------
+	// skip, don't abort
+	// ------------------------------------------------------------------------------
+
+	public function test_malformed_candidate_does_not_abort_scan_of_later_valid_candidate(): void
+	{
+		// Given: a malformed v4 candidate FIRST in $result, followed by a real matching one.
+		$result = [
+			'/var/db/pfblockerng/deny/BadFeed.txt:1.2.3.0/xx',
+			'/var/db/pfblockerng/deny/GoodFeed.txt:1.2.3.0/24',
+		];
+
+		$match = $this->assertNeverWarnsOrThrows(
+			fn () => pfb_match_reported_cidr($result, '1.2.3.4', TRUE)
+		);
+
+		// Then: the scan continues past the malformed row and still finds the real match --
+		// proves the guard `continue`s the loop rather than aborting it.
+		$this->assertSame(
+			['GoodFeed', '1.2.3.0/24'],
+			$match,
+			'expected the malformed candidate to be skipped and GoodFeed\'s /24 to still match, got '
+				. var_export($match, true)
+		);
+	}
+}

--- a/tests/php/PythonWhitelistTldSegTest.php
+++ b/tests/php/PythonWhitelistTldSegTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1155 — pfb_unbound_python_whitelist() computed a min-TLD-segment
+ * count into a function-LOCAL $tld_segments, then discarded it (only the CSV
+ * whitelist string is returned/written). pfb_unbound_python() separately ran
+ * `if (!isset($tld_segments)) { $tld_segments = '1'; }` on its OWN
+ * never-assigned local, so the manifest's python_tld_seg key ALWAYS emitted
+ * 1 regardless of the discarded computation. The Python consumer
+ * (whitelist_lookup_domain) gates a parent-suffix walk on this value and
+ * only wildcard suppression entries can match that walk, so a fixed literal
+ * 1 is behaviourally identical to the dead computation it replaces — this
+ * pins that both dead-code sites are gone, the manifest emits literal 1,
+ * and pfb_unbound_python_whitelist()'s own CSV output stays byte-identical
+ * (Oracle A) across the deletion.
+ */
+#[CoversFunction('pfb_unbound_python_whitelist')]
+#[CoversFunction('pfb_unbound_python')]
+final class PythonWhitelistTldSegTest extends TestCase
+{
+	private const SRC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+		$this->seedGlobalPrereqs();
+	}
+
+	/**
+	 * Seed the minimum config keys pfb_global() reads (mirrors
+	 * DnsblVipDisableNoticeTest::seedGlobalPrereqs() / TickEntrypointTest::
+	 * seedTickPrereqs() — the established minimum pfb_global() needs to run
+	 * warning-free off-box), since pfb_unbound_python_whitelist() calls
+	 * pfb_global() internally.
+	 */
+	private function seedGlobalPrereqs(): void
+	{
+		$gen   = 'installedpackages/pfblockerng/config/0';
+		$ip    = 'installedpackages/pfblockerngipsettings/config/0';
+		$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
+
+		config_set_path("{$gen}/pfb_min",        '0');
+		config_set_path("{$gen}/pfb_hour",       '0');
+		config_set_path("{$gen}/pfb_dailystart", '0');
+		config_set_path("{$gen}/skipfeed",       '0');
+
+		config_set_path("{$ip}/suppression",     '');
+		config_set_path("{$ip}/database_cc",     '');
+		config_set_path("{$ip}/maxmind_locale",  'en');
+		config_set_path("{$ip}/asn_reporting",   'disabled');
+		config_set_path("{$ip}/asn_token",       '');
+		config_set_path("{$ip}/maxmind_account", '');
+		config_set_path("{$ip}/maxmind_key",     '');
+
+		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
+
+		config_set_path("{$dnsbl}/pfb_dnsvip4",     '');
+		config_set_path("{$dnsbl}/pfb_dnsvip6",     '');
+		config_set_path("{$dnsbl}/pfb_dnsport",     '8081');
+		config_set_path("{$dnsbl}/pfb_dnsport_ssl", '8443');
+		config_set_path("{$dnsbl}/alexa_enable",    '');
+		config_set_path("{$dnsbl}/pfb_cache",       '');
+		config_set_path("{$dnsbl}/pfb_py_reply",    '');
+		config_set_path("{$dnsbl}/pfb_regex",       '');
+		config_set_path("{$dnsbl}/pfb_regex_list",  '');
+		config_set_path("{$dnsbl}/pfb_cname",       '');
+		config_set_path("{$dnsbl}/pfb_pytld",       '');
+		config_set_path("{$dnsbl}/pfb_py_nolog",    '');
+		config_set_path("{$dnsbl}/pfb_noaaaa",      '');
+		config_set_path("{$dnsbl}/pfb_noaaaa_list", '');
+		config_set_path("{$dnsbl}/pfb_gp",          '');
+		config_set_path("{$dnsbl}/pfb_gp_bypass_list", '');
+
+		if (!isset($GLOBALS['g']['unbound_chroot_path'])) {
+			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
+		}
+
+		PfbConfig::write('pfb_dnsbl', 'on');
+		PfbConfig::write('pfb_dnsvip_auto', '');
+		PfbConfig::write('dnsbl_interface', 'lo0');
+	}
+
+	private function setSuppression(string $decoded): void
+	{
+		config_set_path(
+			'installedpackages/pfblockerngdnsblsettings/config/0/suppression',
+			base64_encode($decoded)
+		);
+	}
+
+	// --- A: ORACLE — pfb_unbound_python_whitelist() output, pinned across the change ---
+
+	/**
+	 * Scenario: a mixed suppression list — bare domain, leading-dot wildcard,
+	 * www.-prefixed, and a blank line.
+	 * Then: the CSV output strips www., marks the wildcard ',1', everything
+	 *       else ',0', and drops the blank line — unaffected by removing the
+	 *       discarded min-segment computation.
+	 */
+	public function testMixedSuppressionListProducesExpectedCsv(): void
+	{
+		$this->setSuppression("example.com\r\n.wild.org\r\nwww.stripme.net\r\n\r\n");
+
+		$this->assertSame(
+			"example.com,0\nwild.org,1\nstripme.net,0\n",
+			pfb_unbound_python_whitelist()
+		);
+	}
+
+	public function testLeadingDotWildcardEntryGetsSuffixOne(): void
+	{
+		$this->setSuppression(".wild.org\r\n");
+		$this->assertSame("wild.org,1\n", pfb_unbound_python_whitelist());
+	}
+
+	public function testWwwPrefixIsStrippedAndSuffixedZero(): void
+	{
+		$this->setSuppression("www.stripme.net\r\n");
+		$this->assertSame("stripme.net,0\n", pfb_unbound_python_whitelist());
+	}
+
+	public function testEmptySuppressionReturnsEmptyString(): void
+	{
+		$this->setSuppression('');
+		$this->assertSame('', pfb_unbound_python_whitelist());
+	}
+
+	// --- B: SOURCE-SHAPE — the dead computation is GONE, manifest emits literal 1 ---
+
+	/**
+	 * Brace-counts from `function {$name}(` to its matching closing brace,
+	 * so the assertions below inspect ONLY that function's body — never a
+	 * neighbour (tld_analysis() has its own, differently-purposed
+	 * $tld_segments and must stay untouched).
+	 */
+	private function functionBody(string $name): string
+	{
+		$source = file_get_contents(self::SRC);
+		$this->assertNotFalse($source, 'failed to read pfblockerng.inc');
+
+		$needle = "\nfunction {$name}(";
+		$start = strpos($source, $needle);
+		$this->assertNotFalse($start, "function {$name}() not found in source");
+		$start++; // step past the leading \n onto 'function'
+
+		$braceOpen = strpos($source, '{', $start);
+		$this->assertNotFalse($braceOpen, "no opening brace found for {$name}()");
+
+		$depth = 0;
+		for ($i = $braceOpen, $len = strlen($source); $i < $len; $i++) {
+			if ($source[$i] === '{') {
+				$depth++;
+			} elseif ($source[$i] === '}') {
+				$depth--;
+				if ($depth === 0) {
+					$body = substr($source, $start, $i - $start + 1);
+					$this->assertNotSame('', trim($body), "empty body extracted for {$name}() -- vacuous extraction");
+					return $body;
+				}
+			}
+		}
+		$this->fail("no matching closing brace found for {$name}()");
+	}
+
+	public function testWhitelistFunctionHasNoTldSegmentsToken(): void
+	{
+		$body = $this->functionBody('pfb_unbound_python_whitelist');
+		$this->assertStringNotContainsString('tld_segments', $body,
+			'issue #1155: the min-segment computation must be deleted, not just unused');
+	}
+
+	public function testPythonFunctionHasNoIssetTldSegmentsGuard(): void
+	{
+		$body = $this->functionBody('pfb_unbound_python');
+		$this->assertDoesNotMatchRegularExpression('/isset\(\s*\$tld_segments\s*\)/', $body,
+			'issue #1155: the never-assigned isset($tld_segments) guard must be deleted');
+	}
+
+	public function testManifestEmitsLiteralPythonTldSegOne(): void
+	{
+		$body = $this->functionBody('pfb_unbound_python');
+		$this->assertMatchesRegularExpression('/python_tld_seg\s*=\s*1\b/', $body,
+			'issue #1155: python_tld_seg must emit the literal 1, not a variable');
+	}
+}

--- a/tests/php/SyncCronPflexOrderTest.php
+++ b/tests/php/SyncCronPflexOrderTest.php
@@ -8,9 +8,11 @@ use PHPUnit\Framework\TestCase;
  * issue #1154 — pfblockerng_sync_cron()'s .fail-marker retry called
  * pfb_update_check() BEFORE the per-row `$pflex` derivation ran that
  * iteration. PHP loop variables persist across iterations, so the retry
- * used the PREVIOUS row's $pflex (null on the first row): a Flex feed's
- * retry skipped its configured SSL downgrade, and a non-Flex feed retried
- * right after a Flex row inherited the downgrade it never asked for.
+ * read the PREVIOUS row's $pflex — undefined on the first row, emitting a
+ * PHP undefined-variable warning per cron run. The stale value is never
+ * CONSUMED (pfb_update_check() returns on its own .fail check before any
+ * $pflex use), so this pins warning hygiene and the per-row invariant,
+ * not a TLS behaviour change.
  *
  * pfblockerng.php carries top-level execution and is never require()'d
  * off-appliance (the PHPUnit bootstrap doesn't load www/ dispatcher
@@ -20,6 +22,8 @@ use PHPUnit\Framework\TestCase;
  * instead reads the function's source text and pins the ORDER of the two
  * statements: the first `$pflex = FALSE` derivation line must precede the
  * first `pfb_update_check(` call site (the .fail retry) textually.
+ * Whole-line comments are stripped before scanning so a comment mentioning
+ * either token cannot satisfy or break the ordering assertion.
  */
 final class SyncCronPflexOrderTest extends TestCase
 {
@@ -42,7 +46,9 @@ final class SyncCronPflexOrderTest extends TestCase
 			throw new RuntimeException('test bootstrap: pfblockerng_sync_cron() body not found');
 		}
 
-		self::$functionBody = $m[0];
+		// Scan code only: a whole-line comment naming either token must not
+		// shift the first-occurrence offsets (bit this PR once mid-review).
+		self::$functionBody = preg_replace('#^\s*//.*$#m', '', $m[0]);
 	}
 
 	public function testDerivationAndCallSiteBothPresentExactlyOnceAndTwoOrMoreTimes(): void

--- a/tests/php/SyncCronPflexOrderTest.php
+++ b/tests/php/SyncCronPflexOrderTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1154 — pfblockerng_sync_cron()'s .fail-marker retry called
+ * pfb_update_check() BEFORE the per-row `$pflex` derivation ran that
+ * iteration. PHP loop variables persist across iterations, so the retry
+ * used the PREVIOUS row's $pflex (null on the first row): a Flex feed's
+ * retry skipped its configured SSL downgrade, and a non-Flex feed retried
+ * right after a Flex row inherited the downgrade it never asked for.
+ *
+ * pfblockerng.php carries top-level execution and is never require()'d
+ * off-appliance (the PHPUnit bootstrap doesn't load www/ dispatcher
+ * scripts), and pfb_update_check() performs real network downloads, so
+ * driving pfblockerng_sync_cron() behaviourally is infeasible here. Per
+ * the TickEntrypointTest/PfbReflectorGuardTest house precedent, this suite
+ * instead reads the function's source text and pins the ORDER of the two
+ * statements: the first `$pflex = FALSE` derivation line must precede the
+ * first `pfb_update_check(` call site (the .fail retry) textually.
+ */
+final class SyncCronPflexOrderTest extends TestCase
+{
+	private static string $functionBody;
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.php');
+		}
+
+		if (!preg_match(
+			'/function pfblockerng_sync_cron\b.*?(?=\nfunction )/s',
+			$src,
+			$m
+		)) {
+			throw new RuntimeException('test bootstrap: pfblockerng_sync_cron() body not found');
+		}
+
+		self::$functionBody = $m[0];
+	}
+
+	public function testDerivationAndCallSiteBothPresentExactlyOnceAndTwoOrMoreTimes(): void
+	{
+		$body = self::$functionBody;
+
+		$derivationCount = substr_count($body, '$pflex = FALSE');
+		$this->assertSame(
+			1,
+			$derivationCount,
+			"expected exactly 1 occurrence of '\$pflex = FALSE' in pfblockerng_sync_cron(), found {$derivationCount} -- "
+			. 'the derivation must not have been duplicated or removed by the fix'
+		);
+
+		$callSiteCount = substr_count($body, 'pfb_update_check(');
+		$this->assertGreaterThanOrEqual(
+			2,
+			$callSiteCount,
+			"expected at least 2 'pfb_update_check(' call sites in pfblockerng_sync_cron(), found {$callSiteCount} -- "
+			. 'the .fail retry site plus at least one cron-schedule site must both still exist'
+		);
+	}
+
+	/**
+	 * Scenario: pfblockerng_sync_cron() processes a row whose .fail marker
+	 * exists (the retry branch).
+	 * Given the per-row $pflex derivation and the .fail retry's
+	 *   pfb_update_check() call both live in the same loop iteration,
+	 * When the retry branch reads $pflex,
+	 * Then it must read THIS row's own flag, which requires the
+	 *   derivation to execute (textually precede) before the retry's call
+	 *   site -- never the previous iteration's leftover value.
+	 */
+	public function testPflexDerivationPrecedesEveryUpdateCheckCallSite(): void
+	{
+		$body = self::$functionBody;
+
+		$derivationPos = strpos($body, '$pflex = FALSE');
+		$callSitePos   = strpos($body, 'pfb_update_check(');
+
+		if ($derivationPos === false || $callSitePos === false) {
+			$this->fail('precondition failed: derivation or call site missing -- see the vacuity-guard test');
+		}
+
+		$snippet = static function (string $body, int $pos): string {
+			$start = max(0, $pos - 60);
+			return substr($body, $start, 120);
+		};
+
+		$this->assertLessThan(
+			$callSitePos,
+			$derivationPos,
+			"expected \$pflex derivation offset ({$derivationPos}) < first pfb_update_check() call offset ({$callSitePos})\n"
+			. "--- around derivation (offset {$derivationPos}) ---\n" . $snippet($body, $derivationPos) . "\n"
+			. "--- around first call site (offset {$callSitePos}) ---\n" . $snippet($body, $callSitePos)
+		);
+	}
+}


### PR DESCRIPTION
One PR, one commit per issue plus one test-hardening follow-up for #1154 (consolidated from PRs #1160/#1161/#1163/#1164/#1165 per review of the batch — those are closed with pointers here). All six issues are sub-issues of the #1144 baseline burn-down and were found by a triage of `phpstan-baseline.neon` for entries with real production consequences.

Fixes #1154. Fixes #1155. Fixes #1156. Fixes #1157. Fixes #1158. Fixes #1159.

## Commits (one per issue)

1. **#1154 — `$pflex` derived per-row before the `.fail` retry** (`pfblockerng_sync_cron()`). The retry read the previous iteration's value (undefined on the first row → a PHP warning per cron run). Adversarial review traced the callee and proved the stale value is never consumed — `pfb_update_check()` returns on its own `.fail` check before any `$pflex` use — so this is warning hygiene + invariant, **not** the TLS-downgrade issue #1154 originally claimed; the issue is annotated accordingly. Pinned by `SyncCronPflexOrderTest` (source-order scan over comment-stripped code).
2. **#1157 — malformed CIDR candidates skipped in `pfb_match_reported_cidr()`**. Feed-derived candidates fataled (TypeError / ArithmeticError) on bad v4 masks, and `banana/0`-class candidates silently matched **every** IPv4 host; malformed v6 lengths false-matched. Guards: digit mask ≤ 32 + `is_ipaddrv4`, digit length ≤ 128 + `is_ipaddrv6`. 21 behavioural tests including the match-everything class and both guards' exact 32/33 and 128/129 boundaries.
3. **#1156 — Log Browser fails loudly on a non-numeric grep count**. PHP 8 string/int comparison let grep error text (via `2>&1`) through the cap check into a fatal subtraction; silently skipping the cap would instead stream the whole file unbounded. A non-numeric count now answers with the handler's `|2|` error convention. Guard + cap block exercised behaviourally via an eval-extracted oracle (under-cap, at-cap boundary, over-cap skip count, error path).
4. **#1158 — fail-safe `$retval` default in `pfb_download()`**. `unset($retval)` + loose `null == 0` let a failed ZIP xlsx conversion take the success path (remote-stamp touch + ADR-42 sidecar refresh + `return TRUE` — change-detection poisoning). The first implementation attempt ESCALATED correctly: the gzip-blacklist success path (UT1 feed) relied on the same coincidence and is now assigned explicitly, preserving its behaviour. Follow-up for its uncaptured tar exit: #1166.
5. **#1155 — dead `python_tld_seg` min-segment computation dropped, literal 1 emitted**. The computed optimization never reached the manifest (function-local, discarded); always-1 is behaviourally identical (only wildcard entries can match the Python suffix walk). Whitelist CSV output pinned byte-identical by an oracle; manifest shape unchanged.
6. **#1159 — real Form stub signatures + missing pfSense symbols; baseline regenerated**. `__call` only satisfied level 0. Methods mirrored from upstream pfSense at the min-CE ref; `Form_Element::__toString()`; `pfsense_xmlrpc_client`, `Net_IPv6`, `phpsession_begin/end`, `pfSense_get_pf_rules` added. Baseline regenerated **on top of the five fixes**: 246 → 151 message entries, every removal explained by a stub or a fix in this PR; the remaining entries are the new burn-down floor for #1144.

## Review already applied

Each change carried its own Sonnet adversarial review before consolidation; every finding was applied or answered on the closed PRs: the #1154 impact correction, the `banana/0` + boundary coverage on #1157, the loud-failure + behavioural oracle on #1156 (review had flagged the silent-cap-skip as an unbounded-stream risk), the stale-baseline deletions (subsumed by the final regeneration), and #1164's APPROVE with the #1166 deferral. Red→green was executed test-first for every behaviour change and independently re-executed at each gate; freeze hashes verified.

no-test-needed: the two www/ files touched carry no rendered-page change (a cron-dispatcher statement move and an AJAX error response); both are pinned by PHPUnit tests per the `TickEntrypointTest`/`PfbReflectorGuardTest` precedents, and existing Tier-A `ui_render` coverage of those pages remains the render gate.

## Gates (combined branch)

`php -l` clean on all touched files · PHPUnit **2809 tests / 19717 assertions OK** · `composer phpstan` no errors (regenerated baseline) · `composer phpcs` clean · `python3 -m pytest` 2635 passed · narration/version-literal diff checkers clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWt2V3hW3hZDzFNzSAUevA
