### PR TITLE
ci: run shellspec under dash — the strict-POSIX stand-in for FreeBSD sh

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -145,9 +145,16 @@ if [ "$staged_sh" = 1 ]; then
 	fi
 
 	# shellspec functional suite (gated on the tool, like shellcheck).
+	# Run under dash when available: strict-POSIX ash sibling of FreeBSD
+	# /bin/sh (the appliance shell). bash-as-sh (macOS) masks divergences —
+	# e.g. a special-builtin redirection error aborts ash/dash but not bash.
 	if have shellspec; then
 		step 'shellspec'
-		shellspec || failed 'shellspec'
+		if have dash; then
+			shellspec --shell "$(command -v dash)" || failed 'shellspec (dash)'
+		else
+			shellspec || failed 'shellspec'
+		fi
 	else
 		skip shellspec
 	fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -274,9 +274,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install jq
-        # jq drives the ip_pre_AWS_*.sh region filters (required).
-        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Install jq and dash
+        # jq drives the ip_pre_AWS_*.sh region filters (required). dash is
+        # installed explicitly — the shellspec run below pins it as the test
+        # shell; never rely on the runner image happening to carry it.
+        run: sudo apt-get update && sudo apt-get install -y jq dash
 
       - name: Install iprange
         # Real `iprange --except` set-subtraction (ADR-53 P3): the same
@@ -293,8 +295,22 @@ jobs:
           echo "$PWD/shellspec-0.28.1" >> "$GITHUB_PATH"
 
       - name: Run shellspec
-        # Config in .shellspec (--shell sh). Functional gate for the shell scripts.
-        run: shellspec
+        # Functional gate for the shell scripts, pinned to dash — the
+        # strict-POSIX ash sibling of FreeBSD /bin/sh (the appliance shell) —
+        # instead of relying on the runner's /bin/sh happening to be dash.
+        # bash-as-sh masks ash divergences (e.g. a special-builtin
+        # redirection error aborts ash/dash but not bash).
+        # Red canary: prove dash exhibits the divergence this pin exists to
+        # catch, in the same run block, before the real suite. The trailing
+        # SURVIVED marker discriminates a genuine mid-script abort from a
+        # permissive shell (bash prints it) or a missing binary (guarded
+        # separately) — a bare nonzero rc cannot tell those apart.
+        run: |
+          DASH="$(command -v dash)"
+          [ -n "$DASH" ] || { echo 'red canary failed: dash not found'; exit 1; }
+          out="$("$DASH" -c ': > /tmp; echo SURVIVED' 2>/dev/null)" || true
+          [ "$out" != "SURVIVED" ] || { echo 'red canary failed: dash did not abort on special-builtin redirection error'; exit 1; }
+          shellspec --shell "$DASH"
 
       - name: Run parity-guard on .github/workflows
         # PG-1: gate that no workflow bypasses the shared build/smoke scripts.
@@ -351,10 +367,10 @@ jobs:
       - name: Coverage (kcov) — informational
         # Informational only (no floor yet, mirroring #38); never gates CI. Guard on
         # kcov being present so a missing tool does not leave an error annotation.
-        # shellspec's kcov integration refuses .shellspec's `--shell sh` ("Require to
+        # shellspec's kcov integration refuses a plain POSIX shell ("Require to
         # use bash/zsh/ksh to run kcov") — override to bash for this re-run only; the
-        # gating `shellspec` run above stays on sh, and the POSIX specs run unchanged
-        # under bash (a superset) purely to collect coverage.
+        # gating `shellspec` run above stays pinned to dash, and the POSIX specs run
+        # unchanged under bash (a superset) purely to collect coverage.
         continue-on-error: true
         run: |
           if command -v kcov >/dev/null 2>&1; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ the gate report's wording, never to which checks run.
 | ------- | --------------------- |
 | Python (`*.py`) | `python3 -m pytest` · `ruff check .` · `ruff format --check .` · `mypy tests/` |
 | PHP (`*.php`/`*.inc`) | `php -l` per touched file · `vendor/bin/phpunit` · `composer phpstan` · `composer phpcs -- --standard=phpcs.xml.dist src/` |
-| Shell (`*.sh`) | `sh -n` · `shellcheck` · `shellspec` (where specs exist) |
+| Shell (`*.sh`) | `sh -n` · `shellcheck` · `shellspec --shell "$(command -v dash)"` (where specs exist; dash = strict-POSIX ash sibling of FreeBSD sh — bash-as-sh masks appliance divergences. Dash missing ⇒ the substitution goes empty and shellspec silently auto-detects — INSTALL dash (`brew`/`apt install dash`) instead of dropping the pin; plain `shellspec` is a last resort and says so in the handoff) |
 | Markdown (`*.md`) | `npx markdownlint-cli2` |
 | `www/` | Tier-A `ui_render` coverage exists for the change (test mandate #4) |
 
@@ -419,6 +419,10 @@ lands); escape a genuine need inline with `# narration-ok: <reason>`.
 ### Shell
 
 - POSIX sh only (`#!/bin/sh`); no bash-isms (`[[`, arrays, `$RANDOM`). Quote all expansions.
+  **POSIX-compliant means correct under strict-POSIX SEMANTICS (ash/dash), not merely free of
+  bashisms** — e.g. a redirection error on a special built-in (`:`, `exec`, `set`) exits a
+  non-interactive ash/dash shell entirely while bash continues. bash-as-sh acceptance is not
+  evidence; the shellspec gate executes under dash for exactly this reason.
 - Absolute paths for add-on/privileged binaries (`iprange`/`grepcidr`/`mmdblookup`/`jq`/
   `pfctl`) as `path*` vars (see `pfblockerng.sh`); base utilities may be bare.
 - AWS region pre-scripts: 25 thin wrappers over the shared


### PR DESCRIPTION
Mechanically enforces "shellspec runs under a strict-POSIX shell" instead of relying on convention or the runner image.

## Why

bash-as-`sh` (the macOS default) masks ash/dash divergences, so local runs pass while FreeBSD `/bin/sh` (ash-derived, the appliance shell) would abort. This shipped as a real bug on the PR #1171 branch: a redirection error on a special built-in (`: > file`) exits non-interactive ash/dash entirely — skipping every cleanup path — while bash prints an error and continues. Only CI caught it, and only because ubuntu's `/bin/sh` *happens* to be dash.

## What

- **CI (`test.yml` shellspec job):** dash installed explicitly (never assumed from the image) and the suite pinned to `--shell "$(command -v dash)"`. A red canary in the same `run:` block proves dash exhibits the special-builtin abort divergence before the real suite runs, per the CLAUDE.md red-canary rule.
- **Pre-commit hook:** prefers `dash` when installed (macOS ships `/bin/dash` since Ventura; `brew install dash` also works), falling back to plain `shellspec` with the existing behaviour otherwise.
- **CLAUDE.md canonical-gates table:** the shell row now names the dash-pinned invocation, so every delegated brief inherits it mechanically.

## Verification (executed)

- Discriminator: `dash -c ': > /tmp'` → shell exits rc=2; same under bash continues (output in the session log).
- RED: `shellspec --shell "$(command -v dash)" tests/shell/pfblockerng_recompute_spec.sh:558` against the pre-fix PR #1171 head (63ac46e8) → FAILED (example aborted), i.e. the pinned gate catches the exact shipped bug class.
- GREEN: full suite on this branch under brew dash → `484 examples, 0 failures, 8 skips`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Shell verification now runs under the POSIX-compliant `dash` shell when available.
  * Automated checks confirm expected error-handling behavior and continue to preserve existing failure and skip conditions.
  * Coverage testing clarifies which shell specifications are re-run under Bash.

* **Documentation**
  * Updated shell verification guidance to emphasize strict POSIX compatibility and `dash`-based testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->