### PR TITLE
pfblockerng: serialize feed passes with a cross-process lock (#1175)

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1129,6 +1129,16 @@ scheduling logic: it reads the due-ledger, dispatches each **due** job through t
 non-pfB cron jobs are left untouched; install/teardown stays idempotent via `pfblockerng_cron_exists`,
 and a pre-ADR-43 install's old fleet jobs are removed on the next `sync_package_pfblockerng()`.
 
+**Feed-pass serialization (issue #1175):** feed passes are mutually exclusive via a cross-process,
+non-blocking flock (`pfb_feed_pass.lock` under `$pfb['dbdir']`; helpers `pfb_feed_pass_*` in
+`pfblockerng.inc`). Both funnels — `sync_package_pfblockerng()` and `pfblockerng_sync_cron()` —
+acquire it at entry (`pfb_feed_pass_begin()`) and skip with a logged message when another pass
+holds it; the tick pre-checks a busy probe and **defers** (not skips) a busy feed-cron dispatch via
+the existing `pending` mechanism, so the run retries next tick. The `bl`/`bls`/`dcc` download verbs
+are deliberately unguarded (`bls` runs synchronously inside a pass — a pass-level lock there would
+deadlock the parent). The lock is kernel-released on process death; a crashed pass never wedges
+scheduling.
+
 **The due-ledger** is a single JSON sidecar `pfb_due_ledger.json` under `$pfb['dbdir']`, one entry
 per job/feed: `{last_run, next_due, jitter}`. Pure, clock+seed-injectable helpers in
 `pfblockerng_extra.inc` (`pfb_due_ledger_*`); the tick wrapper `pfb_tick_due_jobs()` decides due-ness:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14657,6 +14657,78 @@ function pfb_update_autotail(bool $task_running, bool $run_dispatch, bool $logvi
 }
 
 
+// issue #1175: cross-process, non-blocking mutual exclusion for a feed pass --
+// pfb_feed_task_running()/pfb_update_pass_running() above are ps-scan guards
+// (advisory-by-process-list); this flock-based sibling actually serializes two
+// overlapping passes so they cannot corrupt shared recompute staging. Reentrant
+// within a process: a second acquire by the same process is a no-op success.
+function pfb_feed_pass_acquire(): bool {
+	global $pfb;
+
+	if (isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock'])) {
+		return TRUE;
+	}
+
+	$lockpath = "{$pfb['dbdir']}/pfb_feed_pass.lock";
+	$lock = @fopen($lockpath, 'c');	// 'c': create if absent, no truncate
+	if ($lock === FALSE) {
+		// An unwritable dbdir must never block legitimate work -- fail open.
+		pfb_logger("\nFeed pass lock: open failed [ {$lockpath} ], proceeding unlocked", 2);
+		return TRUE;
+	}
+	if (!@flock($lock, LOCK_EX | LOCK_NB)) {
+		@fclose($lock);
+		return FALSE;
+	}
+
+	$GLOBALS['pfb_feed_pass_lock'] = $lock;
+	if (empty($GLOBALS['pfb_feed_pass_lock_shutdown_registered'])) {
+		// flock also auto-releases on process death (kernel); this just keeps
+		// the window tight in a long-lived web worker that acquired but never
+		// explicitly released.
+		register_shutdown_function('pfb_feed_pass_release');
+		$GLOBALS['pfb_feed_pass_lock_shutdown_registered'] = TRUE;
+	}
+	return TRUE;
+}
+
+// Release the lock acquired by pfb_feed_pass_acquire(). No-op unless this
+// process holds it -- safe to call from an unconditional cleanup path.
+function pfb_feed_pass_release(): void {
+	if (!isset($GLOBALS['pfb_feed_pass_lock']) || !is_resource($GLOBALS['pfb_feed_pass_lock'])) {
+		return;
+	}
+	@flock($GLOBALS['pfb_feed_pass_lock'], LOCK_UN);
+	@fclose($GLOBALS['pfb_feed_pass_lock']);
+	unset($GLOBALS['pfb_feed_pass_lock']);
+}
+
+// TRUE iff ANOTHER process currently holds the feed-pass lock. This process's
+// own hold (via pfb_feed_pass_acquire()) never reads as busy to itself. The
+// probe takes a momentary LOCK_NB hold to test contention, then releases
+// immediately -- never left locked.
+function pfb_feed_pass_busy(): bool {
+	global $pfb;
+
+	if (isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock'])) {
+		return FALSE;
+	}
+
+	$lockpath = "{$pfb['dbdir']}/pfb_feed_pass.lock";
+	$probe = @fopen($lockpath, 'c');
+	if ($probe === FALSE) {
+		return FALSE;	// fail open: an unwritable dbdir never reports busy
+	}
+	if (!@flock($probe, LOCK_EX | LOCK_NB)) {
+		@fclose($probe);
+		return TRUE;
+	}
+	@flock($probe, LOCK_UN);
+	@fclose($probe);
+	return FALSE;
+}
+
+
 // Encode a string as a JavaScript string literal (including the surrounding double quotes) for
 // assignment to a textarea's plain-text .value. json_encode gives correct JS-string escaping --
 // unlike htmlspecialchars(), which HTML-entity-escapes (so a '>' would render as a literal

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14728,6 +14728,18 @@ function pfb_feed_pass_busy(): bool {
 	return FALSE;
 }
 
+// issue #1175: acquire-or-log-skip choke point both sync funnels call, so a
+// busy pass is skipped with the SAME logged message regardless of dispatcher.
+function pfb_feed_pass_begin(string $label): bool {
+	if (pfb_feed_pass_acquire()) {
+		return TRUE;
+	}
+	pfb_logger("\nFeed pass [ {$label} ] skipped -- another pfBlockerNG feed pass is running.\n", 1);
+	logger(LOG_NOTICE, localize_text('Feed pass skipped - another pfBlockerNG feed pass is running.'),
+		LOG_PREFIX_PKG_PFBLOCKERNG);
+	return FALSE;
+}
+
 
 // Encode a string as a JavaScript string literal (including the surrounding double quotes) for
 // assignment to a textarea's plain-text .value. json_encode gives correct JS-string escaping --
@@ -15434,6 +15446,13 @@ function sync_package_pfblockerng($cron='') {
 	global $g, $pfb, $pfbarr;
 	pfb_global();
 
+	// issue #1175: serialize feed passes. Capture ownership BEFORE acquiring -- only the
+	// invocation that transitions the lock releases it (a nested reentrant call no-ops).
+	$pfb_feed_pass_owner = !isset($GLOBALS['pfb_feed_pass_lock']);
+	if (!pfb_feed_pass_begin('sync')) {
+		return;
+	}
+
 	// Open the per-run log window for the live viewer (no-op if pfblockerng_sync_cron() already
 	// opened it for a Force Check / cron pass -- see pfb_runlog_begin).
 	pfb_runlog_begin();
@@ -15506,6 +15525,9 @@ function sync_package_pfblockerng($cron='') {
 		$log = 'Sync terminated during boot process.';
 		pfb_logger("\n{$log}\nUPDATE PROCESS ENDED\n", 1);
 		logger(LOG_INFO, localize_text($log), LOG_PREFIX_PKG_PFBLOCKERNG);
+		if ($pfb_feed_pass_owner) {
+			pfb_feed_pass_release();
+		}
 		return;
 	}
 
@@ -19919,6 +19941,11 @@ function sync_package_pfblockerng($cron='') {
 
 	if ($pfb['enable'] == 'on' && !$pfb['save'] || $pfb['summary']) {
 		pfb_logger("\n UPDATE PROCESS ENDED\n", 1);
+	}
+
+	// issue #1175: release only if this call transitioned the lock (see head of function).
+	if ($pfb_feed_pass_owner) {
+		pfb_feed_pass_release();
 	}
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14735,7 +14735,7 @@ function pfb_feed_pass_begin(string $label): bool {
 		return TRUE;
 	}
 	pfb_logger("\nFeed pass [ {$label} ] skipped -- another pfBlockerNG feed pass is running.\n", 1);
-	logger(LOG_NOTICE, localize_text('Feed pass skipped - another pfBlockerNG feed pass is running.'),
+	logger(LOG_NOTICE, localize_text('Feed pass [ %s ] skipped - another pfBlockerNG feed pass is running.', $label),
 		LOG_PREFIX_PKG_PFBLOCKERNG);
 	return FALSE;
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2642,7 +2642,13 @@ function pfblockerng_tick(): void
 	// fast. The scheduled log trim no longer rides this dispatch (issue #573) --
 	// see pfb_log_mgmt() at the end of this function.
 	if (!$cron_disabled && ($due['cron'] || pfb_due_ledger_is_pending('cron', $dbdir))) {
-		if ($in_win) {
+		if ($in_win && pfb_feed_pass_busy()) {
+			// issue #1175: another feed pass is already running -- dispatching a
+			// second one would race the shared recompute staging. Defer via the
+			// existing pending mechanism so the NEXT tick retries.
+			logger(LOG_INFO, localize_text('Tick: feed cron deferred (update pass running).'), LOG_PREFIX_PKG_PFBLOCKERNG);
+			pfb_due_ledger_set_pending('cron', $dbdir);
+		} elseif ($in_win) {
 			logger(LOG_NOTICE, localize_text('Tick: dispatching feed cron.'), LOG_PREFIX_PKG_PFBLOCKERNG);
 			exec("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron >> {$pfb['runlog']} 2>&1 &");
 			pfb_due_ledger_mark_ran_anchored('cron', $cron_secs, $now, $seed, 0, $dbdir);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2643,10 +2643,10 @@ function pfblockerng_tick(): void
 	// see pfb_log_mgmt() at the end of this function.
 	if (!$cron_disabled && ($due['cron'] || pfb_due_ledger_is_pending('cron', $dbdir))) {
 		if ($in_win && pfb_feed_pass_busy()) {
-			// issue #1175: another feed pass is already running -- dispatching a
-			// second one would race the shared recompute staging. Defer via the
-			// existing pending mechanism so the NEXT tick retries.
-			logger(LOG_INFO, localize_text('Tick: feed cron deferred (update pass running).'), LOG_PREFIX_PKG_PFBLOCKERNG);
+			// issue #1175: a running feed pass would race the shared recompute staging --
+			// defer via pending so the NEXT tick retries. busy() is advisory only: the
+			// child's atomic begin() may still lose a dispatcher race and skip one cycle.
+			logger(LOG_INFO, localize_text('Tick: feed cron deferred (another feed pass is running).'), LOG_PREFIX_PKG_PFBLOCKERNG);
 			pfb_due_ledger_set_pending('cron', $dbdir);
 		} elseif ($in_win) {
 			logger(LOG_NOTICE, localize_text('Tick: dispatching feed cron.'), LOG_PREFIX_PKG_PFBLOCKERNG);

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -703,6 +703,13 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 function pfblockerng_sync_cron($force_all = FALSE, $scope = 'both') {
 	global $pfb, $pfbarr;
 
+	// issue #1175: serialize feed passes -- same ownership discipline as
+	// sync_package_pfblockerng(); its tail call below reenters the SAME lock.
+	$pfb_feed_pass_owner = !isset($GLOBALS['pfb_feed_pass_lock']);
+	if (!pfb_feed_pass_begin('cron')) {
+		return;
+	}
+
 	// Open the per-run log window BEFORE the first log line so the live viewer mirrors the whole
 	// feed pass. Force Check / cron dispatch through here (not sync_package_pfblockerng directly,
 	// which is only reached at the very end); without this the tail would stay silent until then.
@@ -820,6 +827,12 @@ function pfblockerng_sync_cron($force_all = FALSE, $scope = 'both') {
 	// not affect the feed cron timing/outcome. Provenance-gated: a no-op on a
 	// Netgate-installed build.
 	pfb_software_update_check();
+
+	// issue #1175: release only if this call transitioned the lock (see head of function) --
+	// the tail sync_package_pfblockerng() calls above reentered the SAME lock and no-op'd.
+	if ($pfb_feed_pass_owner) {
+		pfb_feed_pass_release();
+	}
 }
 
 

--- a/tests/php/FeedPassLockTest.php
+++ b/tests/php/FeedPassLockTest.php
@@ -303,4 +303,91 @@ final class FeedPassLockTest extends TestCase
 			$this->assertSame(0, $exitCode, 'the child process must have exited cleanly');
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// issue #1175 STEP 2 -- pfb_feed_pass_begin(), the acquire-or-log-skip
+	// choke point both sync funnels (sync_package_pfblockerng(),
+	// pfblockerng_sync_cron()) call. Brand-new code (CLAUDE.md Test coverage
+	// #1 exception): asserts real behaviour directly, no red-first proof.
+	// -----------------------------------------------------------------------
+
+	// Coverage-matrix row 10 -- begin() on a free lock.
+	public function testBeginOnFreeLockReturnsTrueAndHoldsTheLock(): void
+	{
+		$this->assertTrue(pfb_feed_pass_begin('sync'), 'begin() on a free lock must return TRUE');
+		$this->assertTrue($this->rawProbeStillLocked(),
+			'a second raw-fd flock(LOCK_EX|LOCK_NB) must fail while begin() holds the lock');
+	}
+
+	// Coverage-matrix row 11 -- begin() while another handle holds it: FALSE + a
+	// logged skip line (failable -- asserts actual log content, not just the return).
+	public function testBeginWhileAnotherHandleHoldsReturnsFalseAndLogsSkip(): void
+	{
+		$holder = fopen($this->lockPath(), 'c');
+		$this->rawFps[] = $holder;
+		$this->assertTrue(flock($holder, LOCK_EX), 'test setup: failed to flock the holder fd');
+
+		$this->assertFalse(pfb_feed_pass_begin('sync'), 'begin() must FALSE while another handle holds the lock');
+
+		$this->assertFileExists($GLOBALS['pfb']['log'], 'a skip must write to the main pfBlockerNG log');
+		$this->assertStringContainsString(
+			'skipped',
+			(string) file_get_contents($GLOBALS['pfb']['log']),
+			'the skip line must record that the pass was skipped'
+		);
+
+		// Holder undisturbed: the skip never touches the lock the other side owns.
+		$this->assertTrue(flock($holder, LOCK_EX | LOCK_NB),
+			'the original holder must remain able to operate on its own lock afterwards');
+	}
+
+	// Coverage-matrix row 12 -- ownership discipline: mirrors the exact pattern the
+	// two funnels use ($owner = !isset($GLOBALS['pfb_feed_pass_lock']); begin(); ...;
+	// if ($owner) release();). A nested (reentrant) call's owner flag is FALSE, so its
+	// guarded release must NOT free the lock; only the outer, transitioning call's does.
+	public function testNestedBeginOwnershipOnlyTheTransitioningCallReleases(): void
+	{
+		$outerOwner = !isset($GLOBALS['pfb_feed_pass_lock']);
+		$this->assertTrue($outerOwner, 'test setup: process must not already hold the lock');
+		$this->assertTrue(pfb_feed_pass_begin('sync'), 'outer begin() must acquire the free lock');
+
+		// Simulates sync_package_pfblockerng() being reentered from inside
+		// pfblockerng_sync_cron() -- the inner call observes the lock already held.
+		$innerOwner = !isset($GLOBALS['pfb_feed_pass_lock']);
+		$this->assertFalse($innerOwner, 'inner call must observe the lock already held by this process');
+		$this->assertTrue(pfb_feed_pass_begin('cron'), 'reentrant inner begin() must no-op TRUE');
+
+		if ($innerOwner) {
+			pfb_feed_pass_release();
+		}
+		$this->assertTrue($this->rawProbeStillLocked(),
+			'the inner guarded release (owner flag FALSE) must NOT free the lock');
+
+		if ($outerOwner) {
+			pfb_feed_pass_release();
+		}
+		$this->assertFalse($this->rawProbeStillLocked(),
+			'the outer guarded release (owner flag TRUE) must free the lock');
+	}
+
+	// Hostile row -- lock file unopenable: begin() inherits acquire()'s fail-open
+	// (an unwritable dbdir must never block a legitimate pass).
+	public function testBeginFailsOpenWhenLockFileUnopenable(): void
+	{
+		if (function_exists('posix_getuid') && posix_getuid() === 0) {
+			$this->markTestSkipped('root bypasses directory permissions; cannot simulate an unwritable dbdir');
+		}
+
+		$denydir = "{$this->dbdir}/deny_begin";
+		mkdir($denydir, 0755, TRUE);
+		$GLOBALS['pfb']['dbdir'] = $denydir;
+		chmod($denydir, 0555);
+
+		try {
+			$this->assertTrue(pfb_feed_pass_begin('sync'),
+				'an unwritable dbdir must fail OPEN -- begin() returns TRUE rather than blocking legitimate work');
+		} finally {
+			chmod($denydir, 0755);
+		}
+	}
 }

--- a/tests/php/FeedPassLockTest.php
+++ b/tests/php/FeedPassLockTest.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1175 — cross-process, non-blocking feed-pass mutual exclusion.
+ *
+ * Functions under test: pfb_feed_pass_acquire(), pfb_feed_pass_release(),
+ * pfb_feed_pass_busy() in pfblockerng.inc -- siblings of pfb_feed_task_running()
+ * and pfb_update_pass_running() (ps-scan guards), but flock-based and exclusive
+ * rather than advisory-by-process-list. Lock file: "{dbdir}/pfb_feed_pass.lock".
+ *
+ * flock(2) semantics this suite relies on: a lock belongs to the OPEN FILE
+ * DESCRIPTION, not the process, so two separate fopen() handles on the SAME
+ * path conflict even within one process -- that is what makes the same-process
+ * contention tests below (Rows 1/2/5/6) valid without a second process. The
+ * kernel releases the lock automatically when the holding process dies, so a
+ * crashed feed pass can never wedge the system (Row 10 exercises this via a
+ * real child process rather than asserting it abstractly).
+ *
+ * Brand-new code (CLAUDE.md Test coverage #1 exception): pfb_feed_pass_* did
+ * not exist before this change, so there is no pre-existing behaviour to pin
+ * red-first -- these tests assert real behaviour against the finished
+ * implementation directly.
+ */
+final class FeedPassLockTest extends TestCase
+{
+	private string $dbdir = '';
+	private bool $hadPfb = FALSE;
+	private array $originalPfb = [];
+
+	/** Raw fds opened directly by a test (bypassing the helpers) -- closed in tearDown. */
+	private array $rawFps = [];
+
+	protected function setUp(): void
+	{
+		$this->hadPfb      = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+
+		$this->dbdir = sys_get_temp_dir() . '/pfb_feedpass_lock_' . uniqid('', TRUE);
+		mkdir($this->dbdir, 0755, TRUE);
+
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'dbdir'  => $this->dbdir,
+			'log'    => "{$this->dbdir}/pfblockerng.log",
+			'errlog' => "{$this->dbdir}/error.log",
+		]);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->rawFps as $fp) {
+			if (is_resource($fp)) {
+				@flock($fp, LOCK_UN);
+				@fclose($fp);
+			}
+		}
+		$this->rawFps = [];
+
+		// Never leave this process holding the lock across tests (self-encapsulation).
+		pfb_feed_pass_release();
+
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		$this->rrmdir($this->dbdir);
+	}
+
+	private function rrmdir(string $dir): void
+	{
+		if (!is_dir($dir)) {
+			return;
+		}
+		foreach (scandir($dir) as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+			$path = "{$dir}/{$entry}";
+			is_dir($path) ? $this->rrmdir($path) : @unlink($path);
+		}
+		@rmdir($dir);
+	}
+
+	private function lockPath(): string
+	{
+		return "{$this->dbdir}/pfb_feed_pass.lock";
+	}
+
+	/** A second, independent fd probing the lock -- proves whether it is held. */
+	private function rawProbeStillLocked(): bool
+	{
+		$fp = fopen($this->lockPath(), 'c');
+		$this->assertNotFalse($fp, 'test probe: failed to open the lock file');
+		$this->rawFps[] = $fp;
+		$got = flock($fp, LOCK_EX | LOCK_NB);
+		if ($got) {
+			flock($fp, LOCK_UN);	// don't leave our own probe holding it
+		}
+		return !$got;
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 1 -- acquire on a free lock.
+	// -----------------------------------------------------------------------
+
+	public function testAcquireOnFreeLockSucceedsAndHoldsTheLock(): void
+	{
+		$this->assertTrue(pfb_feed_pass_acquire(), 'acquire on a free lock must return TRUE');
+		$this->assertTrue($this->rawProbeStillLocked(),
+			'a second raw-fd flock(LOCK_EX|LOCK_NB) must fail while the helper holds the lock');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 2 -- acquire while another handle holds it.
+	// -----------------------------------------------------------------------
+
+	public function testAcquireWhileAnotherHandleHoldsReturnsFalseAndHolderUndisturbed(): void
+	{
+		$holder = fopen($this->lockPath(), 'c');
+		$this->rawFps[] = $holder;
+		$this->assertTrue(flock($holder, LOCK_EX), 'test setup: failed to flock the holder fd');
+
+		$this->assertFalse(pfb_feed_pass_acquire(), 'acquire must FALSE while another handle holds the lock');
+
+		// Holder undisturbed: it can still explicitly re-affirm/extend its own lock.
+		$this->assertTrue(flock($holder, LOCK_EX | LOCK_NB),
+			'the original holder must remain able to operate on its own lock afterwards');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 3 -- reentrant acquire.
+	// -----------------------------------------------------------------------
+
+	public function testReentrantAcquireReturnsTrueWithoutReopeningAndOneReleaseFrees(): void
+	{
+		$this->assertTrue(pfb_feed_pass_acquire());
+		$firstHandle = $GLOBALS['pfb_feed_pass_lock'];
+
+		$this->assertTrue(pfb_feed_pass_acquire(), 'a second acquire in the same process must return TRUE');
+		$this->assertSame($firstHandle, $GLOBALS['pfb_feed_pass_lock'],
+			'a reentrant acquire must not open/replace the held handle');
+
+		// Still held after two acquires.
+		$this->assertTrue($this->rawProbeStillLocked(), 'the lock must still be held after the reentrant acquire');
+
+		// ONE release fully frees it (no reference counting).
+		pfb_feed_pass_release();
+		$this->assertFalse($this->rawProbeStillLocked(), 'a single release must fully free a reentrantly-held lock');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 4 -- release without holding; double release.
+	// -----------------------------------------------------------------------
+
+	public function testReleaseWithoutHoldingIsSilentNoOp(): void
+	{
+		pfb_feed_pass_release();	// must not throw/warn
+		$this->assertFalse($this->rawProbeStillLocked(), 'releasing an unheld lock must leave it free');
+	}
+
+	public function testDoubleReleaseIsSafe(): void
+	{
+		$this->assertTrue(pfb_feed_pass_acquire());
+		pfb_feed_pass_release();
+		pfb_feed_pass_release();	// second call must not throw/warn
+		$this->assertFalse($this->rawProbeStillLocked(), 'the lock must stay free after a double release');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 5 -- busy() with no holder.
+	// -----------------------------------------------------------------------
+
+	public function testBusyWithNoHolderReturnsFalseAndLeavesTheLockFree(): void
+	{
+		$this->assertFalse(pfb_feed_pass_busy(), 'busy() must be FALSE when nothing holds the lock');
+		$this->assertFalse($this->rawProbeStillLocked(),
+			'busy()\'s momentary probe must release before returning -- a subsequent raw flock must succeed');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 6 -- busy() while another handle holds it.
+	// -----------------------------------------------------------------------
+
+	public function testBusyWhileAnotherHandleHoldsReturnsTrue(): void
+	{
+		$holder = fopen($this->lockPath(), 'c');
+		$this->rawFps[] = $holder;
+		$this->assertTrue(flock($holder, LOCK_EX));
+
+		$this->assertTrue(pfb_feed_pass_busy(), 'busy() must be TRUE while another handle holds the lock');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 7 -- busy() while THIS process holds it via the helper.
+	// -----------------------------------------------------------------------
+
+	public function testBusyWhileThisProcessHoldsViaHelperReturnsFalse(): void
+	{
+		$this->assertTrue(pfb_feed_pass_acquire());
+		$this->assertFalse(pfb_feed_pass_busy(), 'this process\'s own hold must not read as "busy" to itself');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 8 -- fail-open on an unwritable dbdir.
+	// -----------------------------------------------------------------------
+
+	public function testFailOpenOnUnwritableDbdirAcquireTrueWarnsBusyFalse(): void
+	{
+		if (function_exists('posix_getuid') && posix_getuid() === 0) {
+			$this->markTestSkipped('root bypasses directory permissions; cannot simulate an unwritable dbdir');
+		}
+
+		$denydir = "{$this->dbdir}/deny";
+		mkdir($denydir, 0755, TRUE);
+		$GLOBALS['pfb']['dbdir'] = $denydir;
+		chmod($denydir, 0555);
+
+		try {
+			$this->assertTrue(pfb_feed_pass_acquire(),
+				'an unwritable dbdir must fail OPEN -- acquire returns TRUE rather than blocking legitimate work');
+			$this->assertFileExists($GLOBALS['pfb']['errlog'], 'the fail-open path must log a warning');
+			$this->assertStringContainsString('lock', strtolower((string) file_get_contents($GLOBALS['pfb']['errlog'])),
+				'the warning must reference the lock failure');
+
+			$this->assertFalse(pfb_feed_pass_busy(),
+				'busy() must also fail OPEN (FALSE, never reports busy) on an unwritable dbdir');
+		} finally {
+			chmod($denydir, 0755);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 9 -- pre-existing garbage content in the lock file.
+	// -----------------------------------------------------------------------
+
+	public function testGarbageLockFileContentDoesNotAffectBehaviour(): void
+	{
+		file_put_contents($this->lockPath(), "not json {{{ garbage \x00 bytes");
+
+		$this->assertTrue(pfb_feed_pass_acquire(), 'flock ignores file content -- acquire must still succeed');
+		$this->assertSame(
+			"not json {{{ garbage \x00 bytes",
+			file_get_contents($this->lockPath()),
+			"fopen('c') must not truncate -- content is unchanged"
+		);
+		pfb_feed_pass_release();
+		$this->assertFalse(pfb_feed_pass_busy(), 'busy() must behave identically regardless of file content');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 10 -- cross-process contention via a real child process.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Spawns a real child PHP process that flocks the SAME lock path, signals
+	 * readiness over its stdout pipe (no fixed sleeps -- the parent blocks on
+	 * fgets() until the child writes "ready\n"), then waits on its stdin for
+	 * EOF before releasing and exiting. The parent probes acquire()/busy()
+	 * while the child holds the lock, then closes the child's stdin to let it
+	 * exit cleanly.
+	 */
+	public function testCrossProcessChildHoldingLockBlocksParentAcquireAndReportsBusy(): void
+	{
+		$childCode = <<<'PHP'
+			$fp = fopen($argv[1], 'c');
+			if ($fp === false) { fwrite(STDOUT, "openfail\n"); exit(1); }
+			if (!flock($fp, LOCK_EX)) { fwrite(STDOUT, "lockfail\n"); exit(1); }
+			fwrite(STDOUT, "ready\n");
+			fflush(STDOUT);
+			fgets(STDIN);	// blocks until the parent closes our stdin (EOF)
+			flock($fp, LOCK_UN);
+			fclose($fp);
+			exit(0);
+			PHP;
+
+		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$proc = proc_open([PHP_BINARY, '-r', $childCode, $this->lockPath()], $descriptors, $pipes);
+		$this->assertTrue(is_resource($proc), 'test setup: failed to spawn the child process');
+
+		try {
+			// Deadlock guard: the child must announce readiness within 10s -- fail loudly,
+			// never hang. stream_select, NOT stream_set_timeout: the latter is a no-op on
+			// proc_open pipes (returns FALSE; fgets blocks past it, timed_out stays FALSE).
+			$read = [$pipes[1]];
+			$write = $except = NULL;
+			$this->assertSame(1, stream_select($read, $write, $except, 10),
+				'deadlock guard: child never signalled readiness within 10s');
+			$line = fgets($pipes[1]);
+			$this->assertSame("ready\n", $line, 'child did not report holding the lock');
+
+			$this->assertFalse(pfb_feed_pass_acquire(),
+				'the parent process must NOT acquire while the CHILD process holds the lock');
+			$this->assertTrue(pfb_feed_pass_busy(),
+				'busy() must report TRUE while a real child process holds the lock');
+		} finally {
+			fclose($pipes[0]);	// EOF -> the child's fgets(STDIN) unblocks and it exits
+			fclose($pipes[1]);
+			$exitCode = proc_close($proc);
+			$this->assertSame(0, $exitCode, 'the child process must have exited cleanly');
+		}
+	}
+}

--- a/tests/php/FeedPassLockTest.php
+++ b/tests/php/FeedPassLockTest.php
@@ -17,8 +17,8 @@ use PHPUnit\Framework\TestCase;
  * path conflict even within one process -- that is what makes the same-process
  * contention tests below (Rows 1/2/5/6) valid without a second process. The
  * kernel releases the lock automatically when the holding process dies, so a
- * crashed feed pass can never wedge the system (Row 10 exercises this via a
- * real child process rather than asserting it abstractly).
+ * crashed feed pass can never wedge the system (Row 10b SIGKILLs a real
+ * holder child and asserts the lock frees).
  *
  * Brand-new code (CLAUDE.md Test coverage #1 exception): pfb_feed_pass_* did
  * not exist before this change, so there is no pre-existing behaviour to pin
@@ -389,5 +389,57 @@ final class FeedPassLockTest extends TestCase
 		} finally {
 			chmod($denydir, 0755);
 		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 10b -- crash release: SIGKILL the holder, the kernel frees the lock.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A feed pass that dies without releasing (crash, OOM-kill) must never
+	 * wedge the box: the kernel drops a flock with its last open descriptor.
+	 * Spawns the same holder child, SIGKILLs it mid-hold, and asserts the
+	 * lock becomes acquirable again (bounded poll that fails loudly -- a
+	 * deadlock guard, never a fixed wait).
+	 */
+	public function testCrossProcessLockReleasedWhenHolderKilled(): void
+	{
+		$childCode = <<<'PHP'
+			$fp = fopen($argv[1], 'c');
+			if ($fp === false) { fwrite(STDOUT, "openfail\n"); exit(1); }
+			if (!flock($fp, LOCK_EX)) { fwrite(STDOUT, "lockfail\n"); exit(1); }
+			fwrite(STDOUT, "ready\n");
+			fflush(STDOUT);
+			fgets(STDIN);	// never EOF'd in this test -- the parent kills us instead
+			PHP;
+
+		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$proc = proc_open([PHP_BINARY, '-r', $childCode, $this->lockPath()], $descriptors, $pipes);
+		$this->assertTrue(is_resource($proc), 'test setup: failed to spawn the child process');
+
+		$read = [$pipes[1]];
+		$write = $except = NULL;
+		$this->assertSame(1, stream_select($read, $write, $except, 10),
+			'deadlock guard: child never signalled readiness within 10s');
+		$this->assertSame("ready\n", fgets($pipes[1]), 'child did not report holding the lock');
+		$this->assertTrue($this->rawProbeStillLocked(), 'child must genuinely hold the lock before the kill');
+
+		proc_terminate($proc, 9);	// SIGKILL: no cleanup path runs in the child
+
+		// Kernel releases the flock with the process; poll acquire under a 10s
+		// deadline that fails loudly (deadlock guard, not a fixed wait).
+		$deadline = microtime(TRUE) + 10.0;
+		$freed = FALSE;
+		while (microtime(TRUE) < $deadline) {
+			if (pfb_feed_pass_acquire()) {
+				$freed = TRUE;
+				break;
+			}
+			usleep(50000);
+		}
+		fclose($pipes[0]);
+		fclose($pipes[1]);
+		proc_close($proc);
+		$this->assertTrue($freed, 'the lock must be released by the kernel when the holder is SIGKILLed');
 	}
 }

--- a/tests/php/TickFeedPassDeferralTest.php
+++ b/tests/php/TickFeedPassDeferralTest.php
@@ -1,0 +1,390 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1175 — pfblockerng_tick() must DEFER its feed-cron dispatch when a feed
+ * pass is already running, instead of dispatching a second overlapping pass that
+ * races the shared recompute staging files (masterfile.new etc.).
+ *
+ * Drives the REAL pfblockerng_tick() entrypoint (TickEntrypointTest's sandbox
+ * pattern: a private $pfb['dbdir']/runlog/extraslog per test, restored on
+ * teardown -- see that suite's setUp() comment for why: pfblockerng_tick()
+ * reads/writes the due-ledger at $pfb['dbdir'] (not injectable), and a
+ * dispatching branch's exec() redirect opens $pfb['runlog']/['extraslog'] for
+ * real regardless of whether /usr/local/bin/php exists on this dev box).
+ *
+ * The running pass is simulated WITHOUT the pfb_feed_pass_* helpers under test
+ * in the deferral cases below (they must hold across the RED run, where they do
+ * not exist yet): this suite fopen()s the lock file itself and flock(LOCK_EX)s
+ * it on its OWN handle -- a second, independent open file description
+ * contending for the SAME file. flock(2) locks belong to the open file
+ * description, not the process, so two handles in one process genuinely
+ * contend, and the kernel drops the lock on process death (a crashed pass can
+ * never wedge the system).
+ *
+ * Red->green: before this change pfblockerng_tick()'s feed-cron dispatch branch
+ * had no running-pass check -- it always exec()'d and mark_ran_anchored()'d the
+ * ledger, even while another pass held the lock. testDueCronDefersWhenFeedPassLockIsHeld
+ * drives that branch with a due 'cron' job while the lock is held and pins (a)
+ * the ledger entry's next_due is untouched (no dispatch) and (b) pending_apply
+ * is set so the next tick retries.
+ */
+final class TickFeedPassDeferralTest extends TestCase
+{
+	/** Per-test private sandbox for $pfb['dbdir'] -- see TickEntrypointTest::setUp(). */
+	private string $dbdir = '';
+
+	private bool $hadDbdir = FALSE;
+	private mixed $originalDbdir = NULL;
+	private bool $hadRunlog = FALSE;
+	private mixed $originalRunlog = NULL;
+	private bool $hadExtraslog = FALSE;
+	private mixed $originalExtraslog = NULL;
+
+	/** Raw fd simulating another process holding the feed-pass lock. */
+	private $lockFp = NULL;
+
+	protected function setUp(): void
+	{
+		$this->hadDbdir      = array_key_exists('dbdir', $GLOBALS['pfb'] ?? []);
+		$this->originalDbdir = $GLOBALS['pfb']['dbdir'] ?? NULL;
+
+		$this->hadRunlog      = array_key_exists('runlog', $GLOBALS['pfb'] ?? []);
+		$this->originalRunlog = $GLOBALS['pfb']['runlog'] ?? NULL;
+
+		$this->hadExtraslog      = array_key_exists('extraslog', $GLOBALS['pfb'] ?? []);
+		$this->originalExtraslog = $GLOBALS['pfb']['extraslog'] ?? NULL;
+
+		$this->dbdir = sys_get_temp_dir() . '/pfb_tick_feedpass_' . uniqid('', TRUE);
+		mkdir($this->dbdir, 0755, TRUE);
+		$GLOBALS['pfb']['dbdir']     = $this->dbdir;
+		$GLOBALS['pfb']['runlog']    = "{$this->dbdir}/pfblockerng_run.log";
+		$GLOBALS['pfb']['extraslog'] = "{$this->dbdir}/extras.log";
+
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_resource($this->lockFp)) {
+			@flock($this->lockFp, LOCK_UN);
+			@fclose($this->lockFp);
+			$this->lockFp = NULL;
+		}
+		// Reset this process's own hold, if the fix under test acquired one --
+		// self-encapsulation: a leaked hold would wedge every later test's probe.
+		if (function_exists('pfb_feed_pass_release')) {
+			pfb_feed_pass_release();
+		}
+
+		if ($this->hadDbdir) {
+			$GLOBALS['pfb']['dbdir'] = $this->originalDbdir;
+		} else {
+			unset($GLOBALS['pfb']['dbdir']);
+		}
+		if ($this->hadRunlog) {
+			$GLOBALS['pfb']['runlog'] = $this->originalRunlog;
+		} else {
+			unset($GLOBALS['pfb']['runlog']);
+		}
+		if ($this->hadExtraslog) {
+			$GLOBALS['pfb']['extraslog'] = $this->originalExtraslog;
+		} else {
+			unset($GLOBALS['pfb']['extraslog']);
+		}
+		$this->rrmdir($this->dbdir);
+	}
+
+	private function rrmdir(string $dir): void
+	{
+		if (!is_dir($dir)) {
+			return;
+		}
+		foreach (scandir($dir) as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+			$path = "{$dir}/{$entry}";
+			is_dir($path) ? $this->rrmdir($path) : @unlink($path);
+		}
+		@rmdir($dir);
+	}
+
+	/** Mirrors TickEntrypointTest::seedTickPrereqs() -- the minimum pfb_global() needs. */
+	private function seedTickPrereqs(string $rawInterval, string $quietHours = ''): void
+	{
+		$gen   = 'installedpackages/pfblockerng/config/0';
+		$ip    = 'installedpackages/pfblockerngipsettings/config/0';
+		$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
+
+		config_set_path("{$gen}/pfb_min",        '0');
+		config_set_path("{$gen}/pfb_hour",       '0');
+		config_set_path("{$gen}/pfb_dailystart", '0');
+		config_set_path("{$gen}/skipfeed",       '0');
+
+		config_set_path("{$ip}/suppression",     '');
+		config_set_path("{$ip}/database_cc",     '');
+		config_set_path("{$ip}/maxmind_locale",  'en');
+		config_set_path("{$ip}/asn_reporting",   'disabled');
+		config_set_path("{$ip}/asn_token",       '');
+		config_set_path("{$ip}/maxmind_account", '');
+		config_set_path("{$ip}/maxmind_key",     '');
+
+		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
+
+		config_set_path("{$dnsbl}/pfb_dnsvip4",     '');
+		config_set_path("{$dnsbl}/pfb_dnsvip6",     '');
+		config_set_path("{$dnsbl}/pfb_dnsport",     '8081');
+		config_set_path("{$dnsbl}/pfb_dnsport_ssl", '8443');
+		config_set_path("{$dnsbl}/alexa_enable",    '');
+		config_set_path("{$dnsbl}/pfb_cache",       '');
+		config_set_path("{$dnsbl}/pfb_py_reply",    '');
+		config_set_path("{$dnsbl}/pfb_regex",       '');
+		config_set_path("{$dnsbl}/pfb_regex_list",  '');
+		config_set_path("{$dnsbl}/pfb_cname",       '');
+		config_set_path("{$dnsbl}/pfb_pytld",       '');
+		config_set_path("{$dnsbl}/pfb_py_nolog",    '');
+		config_set_path("{$dnsbl}/pfb_noaaaa",      '');
+		config_set_path("{$dnsbl}/pfb_noaaaa_list", '');
+		config_set_path("{$dnsbl}/pfb_gp",          '');
+		config_set_path("{$dnsbl}/pfb_gp_bypass_list", '');
+
+		if (!isset($GLOBALS['g']['unbound_chroot_path'])) {
+			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
+		}
+
+		config_set_path("{$gen}/pfb_interval",    $rawInterval);
+		config_set_path("{$gen}/pfb_quiet_hours", $quietHours);
+
+		config_set_path("{$gen}/log_max_log", '3');
+	}
+
+	private function seedFutureLedgerEntry(string $jobKey, int $now): void
+	{
+		pfb_due_ledger_write_entry($jobKey, [
+			'last_run' => $now - 3600,
+			'next_due' => $now + 3600,
+			'jitter'   => 0,
+		], $GLOBALS['pfb']['dbdir']);
+	}
+
+	/** Hold the feed-pass lock as ANOTHER process would -- a second, independent fd. */
+	private function holdLockAsAnotherProcess(): void
+	{
+		$this->lockFp = fopen("{$this->dbdir}/pfb_feed_pass.lock", 'c');
+		$this->assertNotFalse($this->lockFp, 'test setup: failed to open the lock file');
+		$this->assertTrue(flock($this->lockFp, LOCK_EX), 'test setup: failed to flock the lock file');
+	}
+
+	/**
+	 * A "HH:MM-HH:MM" window guaranteed to exclude the CURRENT wall-clock minute
+	 * (needed because pfblockerng_tick() calls time() internally -- $now is not
+	 * injectable): starts 2 minutes from now, ends 4 minutes from now, so "now"
+	 * is always strictly before the window regardless of hour/day wrap.
+	 */
+	private function outsideWindowNow(): string
+	{
+		$cur   = ((int) date('G') * 60) + (int) date('i');
+		$start = ($cur + 2) % 1440;
+		$end   = ($cur + 4) % 1440;
+		return sprintf('%02d:%02d-%02d:%02d', intdiv($start, 60), $start % 60, intdiv($end, 60), $end % 60);
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 11 (coverage matrix) -- the RED->GREEN pinning test.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario:
+	 *   Given a due 'cron' ledger entry (10s past due) and pfb_interval='24'.
+	 *   And   ANOTHER process holds the feed-pass lock (simulated raw flock).
+	 *   Before: the 'cron' entry's next_due is 10s in the past (due).
+	 *   When  pfblockerng_tick() runs.
+	 *   Then  the feed cron is NOT dispatched -- next_due is UNCHANGED (no
+	 *         mark_ran/mark_ran_anchored) -- AND pending_apply is set so the
+	 *         next tick retries the deferred dispatch.
+	 */
+	public function testDueCronDefersWhenFeedPassLockIsHeld(): void
+	{
+		$this->seedTickPrereqs('24');
+		pfb_global();
+		if (!is_dir($GLOBALS['pfb']['logdir'])) {
+			@mkdir($GLOBALS['pfb']['logdir'], 0755, TRUE);
+		}
+
+		$now      = time();
+		$interval = 86400;
+
+		pfb_due_ledger_write_entry('cron', [
+			'last_run' => $now - $interval - 10,
+			'next_due' => $now - 10,	// 10s past due -- would dispatch this tick
+			'jitter'   => 0,
+		], $GLOBALS['pfb']['dbdir']);
+
+		$this->seedFutureLedgerEntry('dcc', $now);
+		$this->seedFutureLedgerEntry('bl',  $now);
+
+		$this->holdLockAsAnotherProcess();
+
+		$before = pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']);
+		$this->assertNotNull($before, 'test setup: cron ledger entry must exist before the tick');
+		$this->assertSame($now - 10, $before['next_due'], 'test setup sanity: cron ledger entry pre-seeded due');
+
+		// Act.
+		pfblockerng_tick();
+
+		$after = pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']);
+		$this->assertNotNull($after, 'cron ledger entry must still exist after the tick');
+		$this->assertSame($now - 10, $after['next_due'],
+			'cron next_due must be UNCHANGED (no dispatch while a feed pass is running): expected '
+			. ($now - 10) . " got {$after['next_due']}");
+		$this->assertTrue(!empty($after['pending_apply']),
+			'cron ledger entry must be marked pending_apply so the NEXT tick retries the deferred dispatch');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 12 -- regression pin: a due cron dispatches normally when the lock
+	// is free (the new check must not block legitimate work).
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario:
+	 *   Given a due 'cron' ledger entry and pfb_interval='24'; NO other process
+	 *   holds the feed-pass lock.
+	 *   When  pfblockerng_tick() runs.
+	 *   Then  the feed cron IS dispatched -- next_due advances by exactly the
+	 *         interval from its own previous next_due (mark_ran_anchored), and
+	 *         no pending_apply flag is left set.
+	 */
+	public function testDueCronDispatchesWhenFeedPassLockIsFree(): void
+	{
+		$this->seedTickPrereqs('24');
+		pfb_global();
+		if (!is_dir($GLOBALS['pfb']['logdir'])) {
+			@mkdir($GLOBALS['pfb']['logdir'], 0755, TRUE);
+		}
+
+		$now      = time();
+		$interval = 86400;
+		$oldNextDue = $now - 10;
+
+		pfb_due_ledger_write_entry('cron', [
+			'last_run' => $oldNextDue - $interval,
+			'next_due' => $oldNextDue,
+			'jitter'   => 0,
+		], $GLOBALS['pfb']['dbdir']);
+
+		$this->seedFutureLedgerEntry('dcc', $now);
+		$this->seedFutureLedgerEntry('bl',  $now);
+
+		// Act -- no lock held anywhere.
+		pfblockerng_tick();
+
+		$after = pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']);
+		$this->assertNotNull($after, 'cron ledger entry must exist after the tick');
+		$this->assertSame($oldNextDue + $interval, $after['next_due'],
+			'cron next_due must advance by exactly the interval when the lock is free: expected '
+			. ($oldNextDue + $interval) . " got {$after['next_due']}");
+		$this->assertTrue(empty($after['pending_apply']),
+			'a dispatched cron must not be left pending_apply');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 13 -- retry: a job deferred by a prior tick's busy lock dispatches
+	// on the NEXT tick once the lock has freed.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario:
+	 *   Given a 'cron' ledger entry left pending_apply=TRUE by a prior deferred
+	 *   tick (next_due still in the past, untouched by that deferral).
+	 *   And   the feed-pass lock is now FREE.
+	 *   When  pfblockerng_tick() runs.
+	 *   Then  the feed cron IS dispatched this time -- next_due advances and
+	 *         pending_apply is cleared (mark_ran_anchored writes a clean entry).
+	 */
+	public function testPendingFromPriorDeferralDispatchesOnceLockFrees(): void
+	{
+		$this->seedTickPrereqs('24');
+		pfb_global();
+		if (!is_dir($GLOBALS['pfb']['logdir'])) {
+			@mkdir($GLOBALS['pfb']['logdir'], 0755, TRUE);
+		}
+
+		$now      = time();
+		$interval = 86400;
+		$oldNextDue = $now - 10;
+
+		// Simulates the Row-11 outcome: still due, left pending by a prior tick.
+		pfb_due_ledger_write_entry('cron', [
+			'last_run'      => $oldNextDue - $interval,
+			'next_due'      => $oldNextDue,
+			'jitter'        => 0,
+			'pending_apply' => TRUE,
+		], $GLOBALS['pfb']['dbdir']);
+
+		$this->seedFutureLedgerEntry('dcc', $now);
+		$this->seedFutureLedgerEntry('bl',  $now);
+
+		// Act -- lock is free this time.
+		pfblockerng_tick();
+
+		$after = pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']);
+		$this->assertNotNull($after, 'cron ledger entry must exist after the retry tick');
+		$this->assertSame($oldNextDue + $interval, $after['next_due'],
+			'the retried cron must dispatch and advance next_due by the interval: expected '
+			. ($oldNextDue + $interval) . " got {$after['next_due']}");
+		$this->assertTrue(empty($after['pending_apply']),
+			'a successfully retried dispatch must clear pending_apply');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 14 -- quiet-hours interaction: outside the apply window, the
+	// existing quiet-hours defer path wins regardless of lock state.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario:
+	 *   Given a due 'cron' entry, pfb_quiet_hours set to a window that excludes
+	 *   "now", AND another process holds the feed-pass lock.
+	 *   When  pfblockerng_tick() runs.
+	 *   Then  no exception -- the tick defers via the quiet-hours branch (the
+	 *         lock check is inside the in-window arm, never reached here) and
+	 *         pending_apply is set exactly once.
+	 */
+	public function testDueCronOutsideQuietHoursDefersRegardlessOfLockState(): void
+	{
+		$window = $this->outsideWindowNow();
+		$this->seedTickPrereqs('24', $window);
+		pfb_global();
+		if (!is_dir($GLOBALS['pfb']['logdir'])) {
+			@mkdir($GLOBALS['pfb']['logdir'], 0755, TRUE);
+		}
+
+		$now      = time();
+		$interval = 86400;
+
+		pfb_due_ledger_write_entry('cron', [
+			'last_run' => $now - $interval - 10,
+			'next_due' => $now - 10,
+			'jitter'   => 0,
+		], $GLOBALS['pfb']['dbdir']);
+
+		$this->seedFutureLedgerEntry('dcc', $now);
+		$this->seedFutureLedgerEntry('bl',  $now);
+
+		$this->holdLockAsAnotherProcess();
+
+		// Act -- must not throw.
+		pfblockerng_tick();
+
+		$after = pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']);
+		$this->assertNotNull($after, 'cron ledger entry must exist after the tick');
+		$this->assertTrue(!empty($after['pending_apply']),
+			'outside the quiet-hours window the tick must defer via pending_apply, whether or not '
+			. 'a feed pass is running');
+	}
+}

--- a/tests/smoke/test_feed_pass_lock.py
+++ b/tests/smoke/test_feed_pass_lock.py
@@ -91,7 +91,11 @@ def _log_size(vm: SmokeVM) -> int:
 
 def _log_delta(vm: SmokeVM, offset: int) -> str:
     """Log content appended after byte ``offset`` (whole log when it rotated shorter)."""
-    result = vm.ssh(f"[ -f {_PFB_LOG} ] && tail -c +{offset + 1} {_PFB_LOG} || true")
+    result = vm.ssh(
+        f"[ -f {_PFB_LOG} ] || exit 0; "
+        f'if [ "$(wc -c < {_PFB_LOG})" -ge {offset} ]; then tail -c +{offset + 1} {_PFB_LOG}; '
+        f"else cat {_PFB_LOG}; fi"
+    )
     return result.stdout
 
 

--- a/tests/smoke/test_feed_pass_lock.py
+++ b/tests/smoke/test_feed_pass_lock.py
@@ -1,0 +1,147 @@
+"""issue #1175 — feed-pass serialization smoke tests (live pfSense CE VM).
+
+Feed passes are serialized by a cross-process flock (``pfb_feed_pass.lock``
+under ``/var/db/pfblockerng``): every dispatch path funnels through
+``pfblockerng_sync_cron()`` / ``sync_package_pfblockerng()``, whose entry guard
+(``pfb_feed_pass_begin()``) skips the pass with a logged message when another
+pass already holds the lock — instead of running two overlapping passes that
+corrupt the shared recompute staging (``masterfile.new`` et al.).
+
+These tests drive the REAL ``pfblockerng.php cron`` verb on the guest while the
+lock is genuinely held by another on-box process (a real flock holder, not a
+mock), pinning the end-to-end wiring the PHPUnit suite cannot reach
+(``sync_package_pfblockerng()`` has no off-appliance driver — issue #993).
+
+Dispatch:
+    gh workflow run smoke.yml -f pytest_filter="feed_pass_lock"
+
+Tests:
+    test_cron_verb_skips_while_feed_pass_lock_held — second pass skips + logs
+    test_cron_verb_proceeds_when_lock_free         — normal pass unaffected
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM
+
+pytestmark = pytest.mark.smoke
+
+_PHP = "/usr/local/bin/php"
+_PFB_PHP = "/usr/local/www/pfblockerng/pfblockerng.php"
+_PFB_LOG = "/var/log/pfblockerng/pfblockerng.log"
+
+_HOLDER = "/tmp/pfb_smoke_lock_holder.php"
+_READY = "/tmp/pfb_smoke_lock_ready"
+_STOP = "/tmp/pfb_smoke_lock_stop"
+
+# The two discriminating log lines (see pfb_feed_pass_begin() and
+# pfblockerng_sync_cron()): the skip line appears ONLY on a refused pass, the
+# CRON START banner ONLY on a proceeding one — each test asserts one present
+# and the other absent, so neither negative assertion can pass vacuously.
+_SKIP_LINE = "Feed pass [ cron ] skipped -- another pfBlockerNG feed pass is running"
+_START_LINE = "CRON  PROCESS  START"
+
+# Real on-box lock holder: acquires the SAME flock the funnels use, signals
+# readiness, then waits for the stop file. Self-terminating (120 s deadline)
+# so an orphaned holder can never wedge the box; the flock itself dies with
+# the process regardless.
+_HOLDER_PHP = f"""<?php
+require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
+require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');
+pfb_global();
+if (!pfb_feed_pass_acquire()) {{
+    exit(2);
+}}
+touch('{_READY}');
+for ($i = 0; $i < 1200 && !file_exists('{_STOP}'); $i++) {{
+    usleep(100000);
+}}
+@unlink('{_READY}');
+"""
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """Deploy the branch .pkg once for this module."""
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        h.collect_host_diagnostics(smoke_vm)
+
+
+def _guest_file_exists(vm: SmokeVM, path: str) -> bool:
+    return vm.ssh("test", "-f", path).returncode == 0
+
+
+def _log_size(vm: SmokeVM) -> int:
+    """Current byte size of the pfBlockerNG log (0 when absent)."""
+    result = vm.ssh(f"[ -f {_PFB_LOG} ] && wc -c < {_PFB_LOG} || echo 0")
+    assert result.returncode == 0, f"log size probe failed: rc={result.returncode} {result.stderr!r}"
+    return int(result.stdout.strip())
+
+
+def _log_delta(vm: SmokeVM, offset: int) -> str:
+    """Log content appended after byte ``offset`` (whole log when it rotated shorter)."""
+    result = vm.ssh(f"[ -f {_PFB_LOG} ] && tail -c +{offset + 1} {_PFB_LOG} || true")
+    return result.stdout
+
+
+def _stop_holder(vm: SmokeVM) -> None:
+    """Signal the holder to exit and wait until it has released (ready file gone)."""
+    vm.ssh("touch", _STOP)
+    released = h.wait_until(lambda: not _guest_file_exists(vm, _READY), timeout=30.0)
+    assert released, "lock holder did not exit within 30s of the stop signal"
+
+
+def test_cron_verb_skips_while_feed_pass_lock_held(deployed_vm: SmokeVM) -> None:
+    """Scenario: a feed pass is running (its process holds the feed-pass lock).
+
+    Given another on-box process holds pfb_feed_pass.lock,
+    When the cron verb is dispatched,
+    Then it logs the skip line and never starts the pass (no CRON START banner).
+    """
+    vm = deployed_vm
+    h.wait_no_active_pfb_task(vm)
+
+    vm.ssh(f"rm -f {_READY} {_STOP}; cat > {_HOLDER} << 'PFBEOF'\n{_HOLDER_PHP}\nPFBEOF")
+    vm.ssh(f"nohup {_PHP} {_HOLDER} >/dev/null 2>&1 &")
+    acquired = h.wait_until(lambda: _guest_file_exists(vm, _READY), timeout=30.0)
+    assert acquired, "test setup: on-box holder never acquired the feed-pass lock"
+
+    try:
+        offset = _log_size(vm)
+        run = vm.ssh(f"{_PHP} {_PFB_PHP} cron", timeout=120.0)
+        assert run.returncode == 0, f"cron verb must exit cleanly on a skip: rc={run.returncode} {run.stderr!r}"
+        delta = _log_delta(vm, offset)
+        assert _SKIP_LINE in delta, f"expected skip line {_SKIP_LINE!r} in log delta, got: {delta!r}"
+        assert _START_LINE not in delta, f"pass must NOT start while the lock is held, log delta: {delta!r}"
+    finally:
+        _stop_holder(vm)
+
+
+def test_cron_verb_proceeds_when_lock_free(deployed_vm: SmokeVM) -> None:
+    """Scenario: no feed pass is running — serialization must not block normal work.
+
+    Given the feed-pass lock is free,
+    When the cron verb is dispatched,
+    Then the pass starts (CRON START banner) and no skip line is logged.
+    """
+    vm = deployed_vm
+    h.wait_no_active_pfb_task(vm)
+
+    offset = _log_size(vm)
+    run = vm.ssh(f"{_PHP} {_PFB_PHP} cron", timeout=240.0)
+    assert run.returncode == 0, f"cron verb failed: rc={run.returncode} {run.stderr!r}"
+    delta = _log_delta(vm, offset)
+    assert _START_LINE in delta, f"expected {_START_LINE!r} in log delta, got: {delta!r}"
+    assert _SKIP_LINE not in delta, f"a free lock must not produce a skip, log delta: {delta!r}"
+    h.wait_no_active_pfb_task(vm)


### PR DESCRIPTION
Fixes #1175

## What

Feed passes were not serialized: the ADR-43 tick dispatched `pfblockerng.php cron` in the background with no running-pass check, so two concurrent passes could overlap and silently corrupt the shared batch-recompute staging (`masterfile.new`, `mastercat.new`, per-alias `.txt.new` — executed probe S6 in the PR #1171 review). The full dispatch surface (9 entries, only the GUI's TOCTOU-racy ps-scan guarded) is enumerated in the [issue comment](https://github.com/pfBlockerNG/pfBlockerNG/issues/1175#issuecomment-4943375184).

## How

Three commits:

1. **Lock primitive + tick deferral** — `pfb_feed_pass_acquire()/release()/busy()`: a cross-process, non-blocking flock on `{dbdir}/pfb_feed_pass.lock` (kernel-released on process death, so a crashed pass can never wedge the box), reentrant in-process, fail-open on an unopenable lock file. `pfblockerng_tick()` now probes the lock before dispatching the feed cron and defers via the existing due-ledger `pending` mechanism — a deferred run retries next tick, never lost. Tick's `dcc`/`bl` dispatches stay unguarded (downloads only, outside the corruption class).
2. **Funnel serialization** — `pfb_feed_pass_begin()` (acquire-or-log-skip) wired into the two functions every dispatch path funnels through: `sync_package_pfblockerng()` and `pfblockerng_sync_cron()`, with owner-release discipline (only the call that transitioned the lock releases it; the cron pass's tail re-entry into sync no-ops). A busy pass skips with a logged `Feed pass [ <label> ] skipped -- another pfBlockerNG feed pass is running.` before touching the run-log window. The `bl`/`bls`/`dcc` download verbs are deliberately not guarded — `bls` is exec'd synchronously from inside a running pass and a pass-level lock there would deadlock the parent.
3. **Live-VM smoke coverage** — `tests/smoke/test_feed_pass_lock.py`: a real on-box flock holder + the `cron` verb, pinning skip-when-held and proceed-when-free end-to-end (the funnel has no off-appliance PHPUnit driver — issue #993).

Design decision (confirmed with the maintainer): the General-page save / pkg-resync / HA-resync / deinstall `sync_package_pfblockerng()` calls also skip-and-log when a pass is running — config is already written and applies on the next pass.

## Tests

- `TickFeedPassDeferralTest` — red→green pinning test (executed red before the fix: tick dispatched + advanced the ledger despite a held lock), frozen byte-identical.
- `FeedPassLockTest` — 15 tests: same-process/second-fd and real cross-process (proc_open) contention, reentrancy, ownership discipline, fail-open (root-skipped chmod fixture), garbage lock-file content.
- Smoke: `gh workflow run smoke.yml -f pytest_filter="feed_pass_lock"` — [live run](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29145440532).
- Full suites green: PHPUnit 2962, pytest 2672, PHPStan, PHPCS, ruff, mypy.

Tier-A note: the `www/` change is confined to `pfblockerng.php` (CLI/localhost dispatcher, no rendered surface); `ui_render` suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping feed updates when scheduled tasks run concurrently.
  * Deferred feed updates when another pass is active, automatically retrying them on the next available tick.
  * Preserved normal processing for downloads and other independent operations.

* **Documentation**
  * Documented feed-pass serialization and deferred scheduling behavior.

* **Tests**
  * Added coverage for concurrent, deferred, nested, interrupted, and normal feed-update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

no-test-needed: the `www/` change is confined to the CLI/localhost dispatcher block of `pfblockerng/pfblockerng.php` (`pfblockerng_sync_cron()` entry guard) — no rendered surface changes, so no Tier-A `ui_render` delta; the change's executable coverage is `tests/smoke/test_feed_pass_lock.py` (live-VM, run 29146445109's sibling 29145440532) plus the PHPUnit suites.
