### PR TITLE
pfblockerng: capture and route extraction exit codes in pfb_download() (#1166)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10997,12 +10997,21 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					unlink_if_exists($file_download);
 					return FALSE;
 				}
-				exec("/usr/bin/tar -xzf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1");
+				exec("/usr/bin/tar -xzf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1", $output, $retval);
 				unlink_if_exists($file_download);
+				if ($retval != 0) {
+					pfb_logger("\n[pfb_download] geoip extraction failed (tar exit {$retval})", 2);
+					return FALSE;
+				}
 				return TRUE;
 			}
 			elseif ($type == 'asn') {
 				exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);
+				if ($retval != 0) {
+					pfb_logger("\n[pfb_download] asn extraction failed (gunzip exit {$retval})", 2);
+					unlink_if_exists($file_download);
+					return FALSE;
+				}
 
 				// Update ASN Lookup table definitions
 				exec("{$pfb['script']} asn_table {$elog}");
@@ -11015,6 +11024,10 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				// the destination CSV pfblockerng_top1m() reads (no rename/staging).
 				exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);
 				unlink_if_exists($file_download);
+				if ($retval != 0) {
+					pfb_logger("\n[pfb_download] top1m extraction failed (gunzip exit {$retval})", 2);
+					return FALSE;
+				}
 				return TRUE;
 			}
 			elseif ($type == 'blacklist') {
@@ -11040,7 +11053,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					// Extract Blacklist categories from sub-folders into a single folder structure
 					$cmd = "--include='*domains' -s',.*/\\(.*\\)/\\(.*\\)/domains,{$filename}_\\1_\\2,' -s',.*/\\(.*\\)/domains,{$filename}_\\1,'";
 					$filename_esc = escapeshellarg("{$pfb['dbdir']}/{$filename}/");
-					exec("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " {$cmd} -C {$filename_esc} >/dev/null 2>&1");
+					exec("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " {$cmd} -C {$filename_esc} >/dev/null 2>&1", $output, $retval);
 
 					// Rename any Category files with dashes
 					$verifydir = "{$pfb['dbdir']}/{$filename}";
@@ -11056,8 +11069,9 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					}
 
 					// Create update file indicator for update process
-					touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
-					$retval = 0;
+					if ($retval == 0) {
+						touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
+					}
 				}
 				else {
 					pfb_logger("\n Invalid filename [{$filename}]", 1);
@@ -11109,11 +11123,16 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 						unlink_if_exists($file_download);
 						return FALSE;
 					}
-					exec("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1");
+					exec("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1", $output, $retval);
 				} else {
 					// ADR-46: stdout extraction -- member names never reach the
 					// filesystem, so no member-name guard is needed here.
-					exec("/usr/bin/tar -xOf {$file_dwn_esc} > {$header_esc}");
+					exec("/usr/bin/tar -xOf {$file_dwn_esc} > {$header_esc}", $output, $retval);
+				}
+				if ($retval != 0) {
+					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})", 2);
+					unlink_if_exists($file_download);
+					return FALSE;
 				}
 				return TRUE;
 			}
@@ -11191,7 +11210,11 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				// Extras - MaxMind/TOP1M/ASN downloads. ADR-59: a 'plain' container
 				// provider's body IS the destination CSV -- rename straight to it, same
 				// as geoip/asn (no intermediate '.orig' staging needed).
-				@rename("{$file_download}", "{$head_download}");
+				$renamed = @rename("{$file_download}", "{$head_download}");
+				if (!$renamed) {
+					pfb_logger("\n[pfb_download] {$type} rename to destination failed", 2);
+					return FALSE;
+				}
 				return TRUE;
 			}
 			elseif ($type == 'blacklist') {

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_download()'s extraction sites must route a nonzero exec() exit to the
+ * function's existing failure paths (issue #1166), not report success blind.
+ *
+ * Same off-appliance constraint as DownloadRetvalFailsafeTest: pfb_download()
+ * drives real cURL + appliance exec before any site under test runs, so this
+ * is a source-inspection pin, not a behavioural exercise.
+ */
+final class DownloadExtractionExitCodeTest extends TestCase
+{
+	private static string $body;
+
+	public static function setUpBeforeClass(): void
+	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
+		);
+		if ($source === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		}
+
+		$start = strpos($source, 'function pfb_download(');
+		if ($start === false) {
+			throw new RuntimeException('test bootstrap: function pfb_download( not found');
+		}
+
+		if (!preg_match('/^function\s+\w+/m', $source, $m, PREG_OFFSET_CAPTURE, $start + 20)) {
+			throw new RuntimeException('test bootstrap: end-of-function boundary not found');
+		}
+		$end = $m[0][1];
+
+		self::$body = substr($source, $start, $end - $start);
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 1 -- gzip geoip: /usr/bin/tar -xzf site.
+	// -----------------------------------------------------------------------
+
+	public function testGzipGeoipTarCapturesRetvalAndIsCheckedBeforeReturnTrue(): void
+	{
+		$tarPos = strpos(self::$body, "/usr/bin/tar -xzf {\$file_dwn_esc} --strip=1 -C {\$pfb['geoipshare']}");
+		$this->assertNotFalse($tarPos, 'vacuity: the gzip-geoip tar -xzf site must exist for this test to mean anything');
+
+		$returnTrue = strpos(self::$body, 'return TRUE;', $tarPos);
+		$this->assertNotFalse($returnTrue, 'vacuity: gzip-geoip site must reach a return TRUE;');
+		$segment = substr(self::$body, $tarPos, $returnTrue + strlen('return TRUE;') - $tarPos);
+
+		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segment,
+			'gzip-geoip tar -xzf must capture $output, $retval -- a corrupt archive currently reports success unconditionally');
+		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval/', $segment,
+			'gzip-geoip must check $retval before its return TRUE -- a nonzero exit must not report success');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 2 -- gzip asn: gunzip already captures $retval but never checks it
+	// before the asn_table rebuild runs off a possibly-partial file.
+	// -----------------------------------------------------------------------
+
+	public function testGzipAsnChecksRetvalBeforeRebuildingAsnTable(): void
+	{
+		$asnAnchor = strpos(self::$body, "\$type == 'asn'");
+		$this->assertNotFalse($asnAnchor, 'vacuity: the gzip-asn branch must exist');
+
+		$gunzip = strpos(self::$body, 'exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}"', $asnAnchor);
+		$this->assertNotFalse($gunzip, 'vacuity: gzip-asn gunzip exec must exist');
+
+		$asnTable = strpos(self::$body, 'asn_table', $gunzip);
+		$this->assertNotFalse($asnTable, 'vacuity: the asn_table rebuild exec must exist after the gunzip');
+
+		$segment = substr(self::$body, $gunzip, $asnTable - $gunzip);
+
+		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*!=\s*0\s*\)|if\s*\(\s*\$retval\s*<>\s*0\s*\)/', $segment,
+			'gzip-asn must check $retval and bail BEFORE the asn_table exec -- else a failed decompress '
+			. 'rebuilds the ASN table from a stale/partial file; found between gunzip and asn_table: '
+			. json_encode($segment));
+		$this->assertStringContainsString('return FALSE', $segment,
+			'gzip-asn nonzero-retval path must return FALSE before asn_table runs');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 3 -- gzip top1m: same gunzip-capture-but-ignored shape as asn.
+	// -----------------------------------------------------------------------
+
+	public function testGzipTop1mChecksRetvalBeforeReturnTrue(): void
+	{
+		$top1mAnchor = strpos(self::$body, "\$type == 'top1m'");
+		$this->assertNotFalse($top1mAnchor, 'vacuity: the gzip-top1m branch must exist');
+
+		$gunzip = strpos(self::$body, 'exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}"', $top1mAnchor);
+		$this->assertNotFalse($gunzip, 'vacuity: gzip-top1m gunzip exec must exist');
+
+		$returnTrue = strpos(self::$body, 'return TRUE;', $gunzip);
+		$this->assertNotFalse($returnTrue, 'vacuity: gzip-top1m site must reach a return TRUE;');
+		$segment = substr(self::$body, $gunzip, $returnTrue + strlen('return TRUE;') - $gunzip);
+
+		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval/', $segment,
+			'gzip-top1m must check $retval before its return TRUE -- a nonzero gunzip exit must not report success; '
+			. 'segment: ' . json_encode($segment));
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 4 -- gzip blacklist: THE reported defect. tar exec must capture
+	// $output/$retval; the .update touch must be guarded by $retval == 0;
+	// the unconditional $retval = 0; must be gone from the touch window.
+	// -----------------------------------------------------------------------
+
+	public function testGzipBlacklistTarCapturesRetval(): void
+	{
+		$tarPos = strpos(self::$body, 'exec("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}")');
+		$this->assertNotFalse($tarPos, 'vacuity: the gzip-blacklist tar -xf site must exist');
+
+		$window = substr(self::$body, $tarPos, 150);
+		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $window,
+			'gzip-blacklist tar -xf must capture $output, $retval -- issue #1166 (a corrupt/partial UT1-style '
+			. 'archive currently reports success unconditionally); found: ' . json_encode($window));
+	}
+
+	public function testGzipBlacklistUpdateTouchGuardedByRetvalNotUnconditionalAssignment(): void
+	{
+		$touchPos = strpos(self::$body, '{$filename}/{$filename}.update');
+		$this->assertNotFalse($touchPos, 'vacuity: the .update touch marker must be locatable');
+
+		$preWindow = substr(self::$body, max(0, $touchPos - 100), 100);
+		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*==\s*0\s*\)/', $preWindow,
+			'the .update touch must be guarded by if ($retval == 0) -- a failed extraction must not stage the '
+			. 'update indicator; found before touch: ' . json_encode($preWindow));
+
+		$postWindow = substr(self::$body, $touchPos, 150);
+		$this->assertDoesNotMatchRegularExpression('/\$retval\s*=\s*0\s*;/', $postWindow,
+			'no unconditional $retval = 0; may remain in the touch window -- success must come from the tar '
+			. 'exec\'s real exit code, not a hardcoded assignment; found: ' . json_encode($postWindow));
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 5 & 6 -- zip extras: both the multi-member (-xf) and single-member
+	// (-xOf) tar sites must capture $retval; a check must gate their shared
+	// return TRUE.
+	// -----------------------------------------------------------------------
+
+	public function testZipExtrasBothTarSitesCaptureRetvalAndAreCheckedBeforeReturnTrue(): void
+	{
+		$multi = strpos(self::$body, 'exec("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc}');
+		$this->assertNotFalse($multi, 'vacuity: the zip multi-member tar -xf site must exist');
+
+		$single = strpos(self::$body, 'exec("/usr/bin/tar -xOf {$file_dwn_esc} > {$header_esc}"', $multi);
+		$this->assertNotFalse($single, 'vacuity: the zip single-member tar -xOf site must exist');
+
+		$returnTrue = strpos(self::$body, 'return TRUE;', $single);
+		$this->assertNotFalse($returnTrue, 'vacuity: zip extras must reach a shared return TRUE;');
+
+		$segMulti = substr(self::$body, $multi, $single - $multi);
+		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segMulti,
+			'zip multi-member tar -xf must capture $output, $retval; segment: ' . json_encode($segMulti));
+
+		$segSingleToReturn = substr(self::$body, $single, $returnTrue + strlen('return TRUE;') - $single);
+		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segSingleToReturn,
+			'zip single-member tar -xOf must capture $output, $retval; segment: ' . json_encode($segSingleToReturn));
+		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval/', $segSingleToReturn,
+			'zip extras must check $retval before their shared return TRUE; segment: '
+			. json_encode($segSingleToReturn));
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 7 -- uncompressed extras: @rename() result must be checked.
+	// -----------------------------------------------------------------------
+
+	public function testUncompressedExtrasChecksRenameResult(): void
+	{
+		$renamePos = strpos(self::$body, '@rename("{$file_download}", "{$head_download}");');
+		$this->assertNotFalse($renamePos, 'vacuity: the uncompressed-extras rename site must exist');
+
+		$nextBranch = strpos(self::$body, "elseif (\$type == 'blacklist') {", $renamePos);
+		$this->assertNotFalse($nextBranch, 'vacuity: the uncompressed-blacklist sibling branch must exist');
+		$segment = substr(self::$body, $renamePos, $nextBranch - $renamePos);
+
+		$this->assertDoesNotMatchRegularExpression('/@rename\([^;]*\);\s*return TRUE;/', $segment,
+			'a bare @rename(...); return TRUE; ignores rename()\'s own failure -- a failed rename must not '
+			. 'report success; segment: ' . json_encode($segment));
+		$this->assertStringContainsString('return FALSE', $segment,
+			'a failed rename() must have a return FALSE path; segment: ' . json_encode($segment));
+	}
+}

--- a/tests/php/DownloadRetvalFailsafeTest.php
+++ b/tests/php/DownloadRetvalFailsafeTest.php
@@ -20,6 +20,13 @@ use PHPUnit\Framework\TestCase;
  * exist: the ZIP xlsx-conversion-failure branch (the reported defect -- a
  * failed conversion must FAIL, not succeed) and the gzip 'blacklist' success
  * branch (which must keep succeeding under the new fail-safe default).
+ *
+ * issue #1166: the gzip-blacklist branch's unconditional `$retval = 0;` after
+ * the .update touch is itself a defect superseding this file's original pin
+ * -- it reported success even when the preceding tar extraction failed. The
+ * route now derives $retval from tar's real captured exit code and guards
+ * the .update touch with it; see DownloadExtractionExitCodeTest for the full
+ * per-site exit-code coverage.
  */
 final class DownloadRetvalFailsafeTest extends TestCase
 {
@@ -96,18 +103,23 @@ final class DownloadRetvalFailsafeTest extends TestCase
 	// Red row B -- Route 2 (gzip-blacklist) keeps succeeding under the new default.
 	// -----------------------------------------------------------------------
 
-	public function testGzipBlacklistSuccessExplicitlyAssignsZeroAfterUpdateTouch(): void
+	public function testGzipBlacklistUpdateTouchGuardedByCapturedRetvalNotUnconditionalAssignment(): void
 	{
 		$touchPos = strpos(self::$body, '{$filename}/{$filename}.update');
 		$this->assertNotFalse($touchPos, 'the .update touch marker must be locatable (vacuity re-check)');
 
-		// Whitespace-tolerant proximity window: the touch call's closing ");"
-		// through ~200 chars ahead must contain an explicit $retval = 0;
-		// (mirrors the uncompressed-blacklist sibling at pfblockerng.inc:10874).
+		// issue #1166: success no longer comes from a hardcoded $retval = 0;
+		// after the touch -- it comes from the tar extraction's own captured
+		// exit code, and the touch itself is now gated on that code being 0.
+		$preWindow = substr(self::$body, max(0, $touchPos - 100), 100);
+		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*==\s*0\s*\)/', $preWindow,
+			'the .update touch must be guarded by if ($retval == 0); found before touch: '
+			. json_encode($preWindow));
+
 		$window = substr(self::$body, $touchPos, 200);
-		$this->assertMatchesRegularExpression('/\$retval\s*=\s*0\s*;/', $window,
-			"gzip-blacklist success must explicitly set \$retval = 0 after its .update touch "
-			. "(preserving its outcome under the new fail-safe default); found near touch: "
+		$this->assertDoesNotMatchRegularExpression('/\$retval\s*=\s*0\s*;/', $window,
+			'no unconditional $retval = 0; may remain near the .update touch -- the new fail-safe default is '
+			. 'satisfied by tar\'s own captured exit code, not a hardcoded override; found near touch: '
 			. json_encode($window));
 	}
 


### PR DESCRIPTION
Fixes #1166.

The gzip `blacklist` branch of `pfb_download()` (UT1-style `.tar.gz` category feeds) ran its `tar -xf` extraction without capturing the exit code, then unconditionally assigned `$retval = 0` (from #1158) and touched the category `.update` indicator — so a corrupt or partially-extracted archive still reported success and staged the update. The gzip/zip/uncompressed `geoip`/`asn`/`top1m` extras branches shared the same defect class, returning `TRUE` regardless of their own extraction's outcome.

## Change

Every previously-unguarded extraction site now captures its real exit code via `exec()`'s third argument and routes nonzero to the existing failure paths (log at level 2 + cleanup + `return FALSE`):

- gzip geoip `tar -xzf`; gzip asn `gunzip` (failure now also skips the `asn_table` rebuild); gzip top1m `gunzip`
- gzip blacklist `tar -xf` (the reported defect): the unconditional `$retval = 0` is gone, the `.update` touch is guarded by `$retval == 0`, and a nonzero exit flows to the existing `Decompression Failed` gate — preserving #1158's fail-safe-default intent with the real exit code
- both zip extras `tar` sites (multi-member `-xf` and single-member `-xOf`)
- uncompressed extras: `rename()`'s result is now checked

Already-safe sites (gzip-default, bzip2, zip xlsx, zip pipefail pipeline, 7z) and the pre-decompression `.update` markers are untouched. The extras caller already handles a `FALSE` return (logs `Failed to Download`, sets `$pfb_error` for the GeoLite2 zip).

## Tests

- New `tests/php/DownloadExtractionExitCodeTest.php`: source-inspection pins for all 7 sites (vacuity-guarded anchors), red-first — 8 failures against the untouched source for the exact defect reasons, green with zero edits after (files frozen byte-identical, hashes `3581b335` / `b33de7da`), re-executed independently by the gate.
- `tests/php/DownloadRetvalFailsafeTest.php`: the gzip-blacklist pin deliberately superseded per this issue — now pins the `$retval == 0` guard and the absence of the unconditional assignment (itself red pre-fix); all other pins in the file unchanged.

## Verification

Full gates green post-rebase: `php -l`, `vendor/bin/phpunit` (2978 tests, 0 failures), `composer phpstan` [OK], `composer phpcs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBkLQcR4cz5QCq6AVjdzuM