### PR TITLE
pfblockerng_log: reject NUL-byte paths in pfb_validate_filepath() (#1126)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -193,6 +193,13 @@ if ($pfb['blconfig'] &&
 // Function to validate file/path
 function pfb_validate_filepath($validate, $pfb_logtypes) {
 
+	// issue #1126: a NUL rides the basename, unseen by the dirname check below, and
+	// throws at fopen()/glob()/unlink() -- an @-unsuppressible ValueError raised
+	// INSIDE the call, so no FALSE-return guard can catch it. Reject ahead of them.
+	if (str_contains($validate, "\0")) {
+		return FALSE;
+	}
+
 	$allowed_path = array();
 	foreach ($pfb_logtypes as $type) {
 		$allowed_path[$type['logdir']] = '';

--- a/tests/php/LogPageLoader.php
+++ b/tests/php/LogPageLoader.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Shared off-appliance loader for pfb_validate_filepath() (pfblockerng_log.php).
+ *
+ * Unlike AlertsPageLoader.php/UpdatePageLoader.php, this function takes
+ * $pfb_logtypes as a plain PARAMETER (not a global read) and calls no pfSense
+ * runtime function -- so no surrounding top-level wiring or fixture is needed:
+ * extract just the function's own span (its `function` line up to the next
+ * top-level statement, `$pconfig = array();`) and eval it.
+ */
+function pfb_test_load_log_page_functions(): void
+{
+	if (function_exists('pfb_validate_filepath')) {
+		return;
+	}
+	$src = file_get_contents(
+		dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_log.php'
+	);
+	if ($src === false) {
+		throw new RuntimeException('failed to read pfblockerng_log.php');
+	}
+	$start = strpos($src, "\nfunction pfb_validate_filepath");
+	$end   = strpos($src, "\n\$pconfig = array();");
+	if ($start === false || $end === false || $end <= $start) {
+		throw new RuntimeException('could not locate pfb_validate_filepath() in pfblockerng_log.php');
+	}
+	eval("\n" . substr($src, $start + 1, $end - $start - 1));
+}

--- a/tests/php/LogPageLoader.php
+++ b/tests/php/LogPageLoader.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
  * $pfb_logtypes as a plain PARAMETER (not a global read) and calls no pfSense
  * runtime function -- so no surrounding top-level wiring or fixture is needed:
  * extract just the function's own span (its `function` line up to the next
- * top-level statement, `$pconfig = array();`) and eval it.
+ * top-level statement, `$pconfig = ...`) and eval it. The end marker stops at the
+ * assignment operator, like AlertsPageLoader's, so rewriting the initialiser
+ * (array() -> []) cannot strand it.
  */
 function pfb_test_load_log_page_functions(): void
 {
@@ -23,7 +25,7 @@ function pfb_test_load_log_page_functions(): void
 		throw new RuntimeException('failed to read pfblockerng_log.php');
 	}
 	$start = strpos($src, "\nfunction pfb_validate_filepath");
-	$end   = strpos($src, "\n\$pconfig = array();");
+	$end   = strpos($src, "\n\$pconfig = ");
 	if ($start === false || $end === false || $end <= $start) {
 		throw new RuntimeException('could not locate pfb_validate_filepath() in pfblockerng_log.php');
 	}

--- a/tests/php/LogValidateFilepathNulByteTest.php
+++ b/tests/php/LogValidateFilepathNulByteTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin pfb_validate_filepath() against a NUL byte anywhere in the candidate path
+ * (issue #1126): the function validates only pathinfo()'s DIRNAME against the
+ * logdir allowlist and never rejects an embedded "\0", so a NUL-laced basename
+ * passes validation and then reaches fopen()/glob()/unlink() -- each throws an
+ * uncaught PHP 8 ValueError ("must not contain any null bytes"), an
+ * @-unsuppressible fatal the validator's #1097 FALSE-return guards cannot
+ * intercept (it fires INSIDE the call, before any return value exists).
+ *
+ * The function is loaded off-appliance via LogPageLoader.php (it takes
+ * $pfb_logtypes as a plain parameter, so no page-level fixture/global is needed).
+ */
+#[CoversFunction('pfb_validate_filepath')]
+final class LogValidateFilepathNulByteTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/LogPageLoader.php';
+		pfb_test_load_log_page_functions();
+	}
+
+	/** A $pfb_logtypes fixture shaped like the real page's: 'logdir' keys carry a trailing slash. */
+	private function logtypes(): array
+	{
+		return [
+			'defaultlogs' => ['logdir' => '/var/log/pfblockerng/'],
+			'python'      => ['logdir' => '/var/unbound/'],
+		];
+	}
+
+	// --- Genuinely RED before the fix: a NUL anywhere in the FINAL path segment
+	// passes the allowlist because pathinfo(..., PATHINFO_DIRNAME) never sees it
+	// (the NUL lives in the basename, not the dirname the function checks). ---
+
+	public function testTrailingNulOnAllowedFileIsRejected(): void
+	{
+		// issue #1126's exact reported shape: logFile=<allowed-dir>/py_error.log%00
+		$this->assertFalse(
+			pfb_validate_filepath("/var/log/pfblockerng/py_error.log\0", $this->logtypes())
+		);
+	}
+
+	public function testNulPrefixingBasenameIsRejected(): void
+	{
+		$this->assertFalse(
+			pfb_validate_filepath("/var/log/pfblockerng/\0foo.log", $this->logtypes())
+		);
+	}
+
+	public function testNulEmbeddedMidBasenameIsRejected(): void
+	{
+		$this->assertFalse(
+			pfb_validate_filepath("/var/log/pfblockerng/py\0error.log", $this->logtypes())
+		);
+	}
+
+	// --- Before-state / no-regression controls (CLAUDE.md "assert the
+	// before-state", "branch coverage") -- unchanged by the fix. ---
+
+	public function testBareNulIsRejected(): void
+	{
+		$this->assertFalse(pfb_validate_filepath("\0", $this->logtypes()));
+	}
+
+	public function testCleanAllowedPathStillAccepted(): void
+	{
+		// Over-rejection control: the guard must not touch a clean, allowed path.
+		$this->assertTrue(
+			pfb_validate_filepath('/var/log/pfblockerng/ok.log', $this->logtypes())
+		);
+	}
+
+	public function testCleanDisallowedDirStillRejected(): void
+	{
+		$this->assertFalse(pfb_validate_filepath('/etc/passwd', $this->logtypes()));
+	}
+
+	public function testEmptyStringStillRejected(): void
+	{
+		$this->assertFalse(pfb_validate_filepath('', $this->logtypes()));
+	}
+
+	public function testNulPlusTraversalAlreadyRejectedByDirnameAllowlist(): void
+	{
+		// A NUL combined with a '../' traversal does NOT additionally defeat the
+		// allowlist: pathinfo()'s dirname computation never resolves '..', so the
+		// traversal segments stay literally in the dirname string and the isset()
+		// lookup already misses -- independent of, and unchanged by, the NUL guard.
+		$this->assertFalse(
+			pfb_validate_filepath('/var/log/pfblockerng/a' . "\0" . '/../../../etc/passwd', $this->logtypes())
+		);
+	}
+
+	public function testVarUnboundPfbPrefixedFileStillAccepted(): void
+	{
+		// The /var/unbound/ carve-out for pfb_-prefixed files must survive the
+		// guard: no NUL present, so this row's value is untouched by the fix.
+		$this->assertTrue(
+			pfb_validate_filepath('/var/unbound/pfb_dnsbl.log', $this->logtypes())
+		);
+	}
+
+	public function testVarUnboundNonPfbNonexistentFileStillRejected(): void
+	{
+		// Not pfb_-prefixed, and the CWD-relative file_exists() check (a
+		// pre-existing quirk of the carve-out, not this fix's concern) can't find
+		// it here, so the carve-out's early FALSE fires -- unchanged by the guard.
+		$this->assertFalse(
+			pfb_validate_filepath('/var/unbound/uuid-9f3e7c21-4a11-nonexistent', $this->logtypes())
+		);
+	}
+}

--- a/tests/smoke/ui/test_log.py
+++ b/tests/smoke/ui/test_log.py
@@ -668,3 +668,132 @@ def test_clear_rejects_path_outside_allowed_dirs(webui: WebUI, smoke_vm: helpers
     assert _exists(vm, EVIL_PATH), "/etc/passwd was removed by a rejected clear (validator failed!)"
     assert _size(vm, EVIL_PATH) == before_size, "/etc/passwd was truncated by a rejected clear (validator failed!)"
     assert _cat(vm, EVIL_PATH) == before, "/etc/passwd content changed after a rejected clear"
+
+
+# --------------------------------------------------------------------------- #
+# NUL-byte hostile paths (issue #1126) -- pfb_validate_filepath() validates only
+# pathinfo()'s DIRNAME, never rejecting an embedded "\x00", so pre-fix a
+# NUL-laced logFile/file reached a filesystem call (fopen()/glob()) that throws
+# an uncaught PHP 8 ValueError (@ cannot suppress it), an HTTP 500 PHP fatal.
+# Every row puts a real "\x00" in the Python form value: requests percent-encodes
+# it to "%00" in the urlencoded body and PHP's own form parsing decodes it back to
+# a raw NUL in $_POST/$_REQUEST. Passing the literal TEXT "%00" would NOT work --
+# the handler never URL-decodes its input a second time.
+# --------------------------------------------------------------------------- #
+
+
+def test_clear_rejects_nul_byte_path_without_php_fatal(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Clearing a plain log path with a trailing NUL byte is rejected -- no PHP fatal.
+
+    Pre-fix sink: the non-py_error ``else`` branch calls ``unlink_if_exists()`` ->
+    ``glob()``, which throws on a NUL-laced pattern. Transition: seed an
+    unrelated, NUL-free file under the same allowed dir (BEFORE), POST a
+    NUL-suffixed path, then assert (AFTER) the reject envelope, no PHP
+    diagnostic, and the neighboring seeded file untouched (the reject never
+    reached any real filesystem call).
+    """
+    vm = smoke_vm
+    clean_target = _throwaway_log("ip_block.log")
+    payload = f"pfb-ui-nul-clear-{helpers.unique_domain('nul')}\n"
+    _seed_file(vm, clean_target, payload)
+    try:
+        assert _cat(vm, clean_target) == payload, "seed not present on the box before the NUL clear POST"
+        before_size = _size(vm, clean_target)
+
+        token = _csrf(webui)
+        nul_target = clean_target + "\x00"
+        resp = _post_clear(webui, token, nul_target)
+        assert not looks_like_login_page(resp.text), "clear POST returned the login form (session lost)"
+        assert resp.status_code == 200, f"NUL-byte clear did not return 200: {resp.status_code}"
+        diagnostic = body_has_php_error(resp.text)
+        assert diagnostic is None, f"NUL-byte clear rendered a PHP diagnostic: {diagnostic!r}"
+        code, _ = _decode_load_body(resp.text)
+        assert code == "3", f"NUL-byte clear did not return the reject code: {resp.text!r}"
+        assert "Invalid filename/path" in resp.text, f"reject envelope missing the message: {resp.text!r}"
+        # AFTER: the neighboring seeded file (a DIFFERENT, NUL-free path) is untouched.
+        assert _exists(vm, clean_target), "neighboring seeded file vanished after a rejected NUL clear"
+        assert _size(vm, clean_target) == before_size, "neighboring seeded file size changed after a rejected NUL clear"
+        assert _cat(vm, clean_target) == payload, "neighboring seeded file content changed after a rejected NUL clear"
+    finally:
+        _rm(vm, clean_target)
+
+
+def test_clear_py_error_rejects_nul_byte_path_without_php_fatal(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Clearing a py_error.log-suffixed path with a trailing NUL is rejected -- no PHP fatal.
+
+    Distinct pre-fix sink from the plain-log case above: the py_error.log branch
+    reaches ``@fopen($s_logfile, 'r+')`` instead of ``unlink_if_exists()``/glob()
+    -- both throw an uncaught ValueError pre-fix, so this row proves the guard
+    closes BOTH reachable sinks, not just one.
+    """
+    vm = smoke_vm
+    clean_target = _throwaway_log("py_error.log")
+    payload = f"pfb-ui-nul-clear-py-{helpers.unique_domain('nulpy')}\n"
+    _seed_file(vm, clean_target, payload)
+    try:
+        assert _cat(vm, clean_target) == payload, "seed not present on the box before the NUL clear POST"
+        before_size = _size(vm, clean_target)
+
+        token = _csrf(webui)
+        nul_target = clean_target + "\x00"
+        resp = _post_clear(webui, token, nul_target)
+        assert not looks_like_login_page(resp.text), "clear POST returned the login form (session lost)"
+        assert resp.status_code == 200, f"NUL-byte clear did not return 200: {resp.status_code}"
+        diagnostic = body_has_php_error(resp.text)
+        assert diagnostic is None, f"NUL-byte clear rendered a PHP diagnostic: {diagnostic!r}"
+        code, _ = _decode_load_body(resp.text)
+        assert code == "3", f"NUL-byte clear did not return the reject code: {resp.text!r}"
+        assert "Invalid filename/path" in resp.text, f"reject envelope missing the message: {resp.text!r}"
+        assert _exists(vm, clean_target), "neighboring seeded py_error.log vanished after a rejected NUL clear"
+        assert _size(vm, clean_target) == before_size, (
+            "neighboring seeded py_error.log size changed after a rejected NUL clear"
+        )
+        assert _cat(vm, clean_target) == payload, (
+            "neighboring seeded py_error.log content changed after a rejected NUL clear"
+        )
+    finally:
+        _rm(vm, clean_target)
+
+
+def test_load_rejects_nul_byte_path(webui: WebUI) -> None:
+    """``act=load`` of a NUL-suffixed path is rejected by the validator -- code '3'.
+
+    Before the #1126 fix, ``file_exists()`` on the NUL-laced path merely returns
+    FALSE (no PHP fatal reaches this branch -- unlike the clear shapes above), so
+    the handler's OLD reply was the generic 'Log file does not exist' code '1',
+    not a reject. After the fix the validator refuses the NUL first, so the
+    reply is the dedicated '3' invalid-path envelope instead.
+    """
+    target = _throwaway_log("pfblockerng.log") + "\x00"
+
+    token = _csrf(webui)
+    resp = _post_load(webui, token, target)
+    assert not looks_like_login_page(resp.text), "load POST returned the login form (session lost)"
+    diagnostic = body_has_php_error(resp.text)
+    assert diagnostic is None, f"NUL-byte load rendered a PHP diagnostic: {diagnostic!r}"
+    code, _ = _decode_load_body(resp.text)
+    assert code == "3", f"NUL-byte load did not return the reject code: {resp.text!r}"
+    assert "Invalid filename/path" in resp.text, f"reject envelope missing the message: {resp.text!r}"
+
+
+def test_download_rejects_nul_byte_path(webui: WebUI) -> None:
+    """Download of a NUL-suffixed path is rejected by the validator -- code '3'.
+
+    Before the #1126 fix, ``file_exists()`` on the NUL-laced path returns FALSE,
+    so the download branch silently falls through (the page just re-renders, no
+    attachment, no fatal). After the fix the validator refuses the NUL up front,
+    so the reply is the dedicated '3' invalid-path envelope instead of a bare
+    silent no-op.
+    """
+    target = _throwaway_log("pfblockerng.log") + "\x00"
+
+    token = _csrf(webui)
+    resp = _post_download(webui, token, target)
+    assert not looks_like_login_page(resp.text), "download POST returned the login form (session lost)"
+    diagnostic = body_has_php_error(resp.text)
+    assert diagnostic is None, f"NUL-byte download rendered a PHP diagnostic: {diagnostic!r}"
+    assert "Invalid filename/path" in resp.text, f"reject envelope missing the message: {resp.text!r}"
+    code, _ = _decode_load_body(resp.text)
+    assert code == "3", f"NUL-byte download did not return the reject code: {resp.text!r}"
+    disp = resp.headers.get("Content-Disposition", "")
+    assert "attachment" not in disp, f"NUL-byte download unexpectedly streamed an attachment: {disp!r}"


### PR DESCRIPTION
Fixes #1126.

## Problem

`pfb_validate_filepath()` (`pfblockerng_log.php`) validates only the **dirname** of the submitted path against the logdir allowlist and never rejects an embedded NUL byte; `htmlspecialchars()` passes NUL through. On PHP 8 the downstream filesystem calls then throw an uncaught `ValueError` — which `@` does **not** suppress and which the #1097 FALSE-return handle guards cannot intercept, because it is raised *inside* the call, before any return value exists. An authenticated POST of `logFile=<allowed-dir>/…%00` + `clear` produces a PHP fatal (HTTP 500).

## Corrected reachable-branch set

Triage re-probed every sink on PHP 8 rather than trusting the report, and the issue's branch list turned out to be wrong in **both** directions:

| Entry point | Sink reached with a NUL path | Before | After |
| ----------- | --------------------------- | ------ | ----- |
| POST `clear`, plain log | `unlink_if_exists()` → `glob()` | **ValueError fatal** | `\|3\|Invalid filename/path\|` |
| POST `clear`, `py_error.log` | `@fopen(…, 'r+')` | **ValueError fatal** | `\|3\|Invalid filename/path\|` |
| POST `clear`, `dnsbl.log`/`unified.log`/`dns_reply.log` | `unlink_if_exists()` → `glob()` | **ValueError fatal** | `\|3\|Invalid filename/path\|` |
| ajax `load` | `file_exists()` → FALSE | `\|1\|Log file does not exist\|` — **no fatal** | `\|3\|Invalid filename/path\|` |
| POST `download` | `file_exists()` → FALSE | silent fall-through | `\|3\|Invalid filename/path\|` |

So the fatal is confined to the `clear` branch but hits **all three** of its shapes (the issue named only `py_error.log`), and `load` never reaches `fopen()` — `file_exists()` returns FALSE for a NUL-laced path rather than throwing, shielding it exactly as it shields `download` (the issue claimed `load` was a live fatal).

Probe evidence (PHP 8.5): `fopen`/`glob`/`unlink`/`touch`/`chown` all throw `ValueError: … must not contain any null bytes`; `file_exists` returns `FALSE`; `pathinfo(…, PATHINFO_DIRNAME)` returns the clean dirname, so the allowlist check passes.

## Fix

One guard at the top of `pfb_validate_filepath()`, ahead of `pathinfo()`/`basename()` and therefore ahead of every sink. Both call sites already gate on the validator and emit the `|3|` reject envelope, so the single site covers every branch above.

## Tests

- **`tests/php/LogValidateFilepathNulByteTest.php`** (new, + `tests/php/LogPageLoader.php` — an off-appliance eval-extraction loader following the existing `AlertsPageLoader`/`UpdatePageLoader` pattern): 10 rows. Red→green proof — the three NUL-in-basename rows fail on the untouched validator (`Failed asserting that true is false`) and pass after, with the test files frozen byte-identical across the run. The remaining rows are before-state/no-regression controls: clean allowed path still accepted (over-rejection control), disallowed dir, empty string, and both `/var/unbound/` carve-out branches unchanged.
- **`tests/smoke/ui/test_log.py`** (Tier-B `ui_e2e`): four hostile-input rows — `clear` on both distinct pre-fix sinks (plain `unlink_if_exists`→`glob` and `py_error.log`→`fopen`), plus `load` and `download`. Each asserts the `|3|` envelope and no PHP diagnostic (`body_has_php_error`). The two `clear` rows additionally assert unchanged on-box file state via a neighbouring seeded file; `load`/`download` have no on-box state to assert, since neither reaches a writing or deleting sink for a NUL-laced path in either the pre-fix or post-fix code (`file_exists()` returns FALSE and short-circuits both). The `dnsbl.log` clear shape is deliberately not duplicated: identical sink to the plain-log row, and post-fix the validator rejects before any clear shape runs.
- Tier-A `ui_render` for this page already exists and is unaffected (the GET render path is untouched).

## Related

`pfblockerng_log.php:227`/`:296` feed `htmlspecialchars()` straight from `$_REQUEST['file']`/`$_POST['logFile']` with no `is_string()` guard — an array-valued field is a separate PHP 8 `TypeError` (the #1143 class; #1128's enumeration missed this page). Filed as #1183 and deliberately left out of this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxHZgRTUrTaPPMRqLK8A7G

