### PR TITLE
pfblockerng: check rename() result in the generic uncompressed-feed branch (#1188)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11222,7 +11222,11 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			}
 			else {
 				// Rename file to 'orig' format
-				@rename("{$file_download}", "{$orig_download}");
+				$renamed = @rename("{$file_download}", "{$orig_download}");
+				if (!$renamed) {
+					pfb_logger("\n[pfb_download] rename to .orig failed", 2);
+					return FALSE;
+				}
 				$retval = 0;
 			}
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11224,7 +11224,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				// Rename file to 'orig' format
 				$renamed = @rename("{$file_download}", "{$orig_download}");
 				if (!$renamed) {
-					pfb_logger("\n[pfb_download] rename to .orig failed", 2);
+					pfb_logger("\n[pfb_download] {$header} rename to .orig failed", 2);
 					return FALSE;
 				}
 				$retval = 0;

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_download()'s extraction sites must route a nonzero exec() exit to the
+ * pfb_download()'s extraction sites must route a nonzero exec() exit -- and,
+ * for the uncompressed branches, a failed @rename() (issue #1188) -- to the
  * function's existing failure paths (issue #1166), not report success blind.
  *
  * Same off-appliance constraint as DownloadRetvalFailsafeTest: pfb_download()
@@ -184,5 +185,30 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			. 'report success; segment: ' . json_encode($segment));
 		$this->assertStringContainsString('return FALSE', $segment,
 			'a failed rename() must have a return FALSE path; segment: ' . json_encode($segment));
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 8 -- generic uncompressed feeds: @rename() to .orig result must be
+	// checked before the branch falls into the $retval == 0 success gate.
+	// -----------------------------------------------------------------------
+
+	public function testGenericUncompressedRenameResultChecked(): void
+	{
+		$commentPos = strpos(self::$body, "Rename file to 'orig' format");
+		$this->assertNotFalse($commentPos, 'vacuity: the generic-uncompressed orig-rename comment must exist');
+
+		$secondPos = strpos(self::$body, "Rename file to 'orig' format", $commentPos + 1);
+		$this->assertFalse($secondPos, 'vacuity: "Rename file to \'orig\' format" must appear exactly once');
+
+		$gatePos = strpos(self::$body, 'if ($retval == 0) {', $commentPos);
+		$this->assertNotFalse($gatePos, 'vacuity: the $retval == 0 success gate must follow the generic-uncompressed branch');
+
+		$segment = substr(self::$body, $commentPos, $gatePos - $commentPos);
+
+		$this->assertDoesNotMatchRegularExpression('/@rename\([^;]*\);\s*\$retval\s*=\s*0;/', $segment,
+			'a bare @rename(...); $retval = 0; ignores rename()\'s own failure -- a failed rename must not '
+			. 'enter the $retval == 0 success gate; segment: ' . json_encode($segment));
+		$this->assertStringContainsString('return FALSE', $segment,
+			'a failed rename() must have a return FALSE path before the success gate; segment: ' . json_encode($segment));
 	}
 }


### PR DESCRIPTION
Fixes #1188.

Sibling of #1166 (PR #1186), surfaced by that PR's adversarial review: the generic (non-extras) uncompressed-feed branch of `pfb_download()` hardcoded `$retval = 0` after an unchecked `@rename()`. A failed rename still entered the `$retval == 0` success gate — refreshing the content-hash sidecar and running the UTF-16 transcode against a missing or stale `.orig`, then returning `TRUE` — so the caller treated the feed as freshly ingested.

## Change

Capture the rename result and route failure to a level-2 log + `return FALSE`, mirroring the extras-branch fix from #1166. The uncompressed `blacklist` arm (bare `$retval = 0;`, no filesystem operation) and all other `$retval` sites are untouched.

## Tests

New `testGenericUncompressedRenameResultChecked` in `tests/php/DownloadExtractionExitCodeTest.php` (same anchor/window source-pin pattern as its sibling rows). Red-first: exactly the new method failed against the untouched source (bare `@rename(...); $retval = 0;` matched), all pre-existing methods stayed green; frozen byte-identical (hash `1569e4bb`); green with zero edits after the fix. Red→green re-executed independently at the gate.

## Verification

Full gates green: `php -l`, `vendor/bin/phpunit` (2999 tests, 0 failures), `composer phpstan` [OK], `composer phpcs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBkLQcR4cz5QCq6AVjdzuM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download processing by detecting and reporting failures when renaming files.
  * Failed rename operations now stop processing instead of being treated as successful.

* **Tests**
  * Added coverage to verify that rename failures follow the expected error-handling path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->