### PR TITLE
scripts: agent-ops scripts — reviewer/CI waits, red-proof runner, gates runner, work-branch

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -55,6 +55,9 @@ staged_py=0;  staged_has '\.py$'        && staged_py=1
 staged_md=0;  staged_has '\.md$'        && staged_md=1
 staged_php=0; staged_has '\.(php|inc)$' && staged_php=1
 staged_sh=0;  staged_has '\.sh$'        && staged_sh=1
+# Spec plumbing (helper, extensionless bin/ shims, fixtures) impacts every shellspec
+# run but need not end in .sh -- it must open the shell block on its own.
+staged_specplumb=0; staged_has '^tests/shell/(spec_helper\.sh|bin/|fixtures/)' && staged_specplumb=1
 staged_yaml=0; staged_has '\.ya?ml$'    && staged_yaml=1
 staged_adrtxt=0; staged_has '^\.ADRs/.*\.txt$' && staged_adrtxt=1
 
@@ -112,7 +115,7 @@ if [ "$staged_md" = 1 ]; then
 fi
 
 # =============================== Shell (*.sh) =============================== #
-if [ "$staged_sh" = 1 ]; then
+if [ "$staged_sh" = 1 ] || [ "$staged_specplumb" = 1 ]; then
 	# Forbid bash shebangs. The repo is #!/bin/sh POSIX (the FreeBSD/pfSense target
 	# has no /bin/bash, and macOS /bin/bash is the ancient 3.2). Scans ALL tracked
 	# files, so it also covers tests/ (not lint-globbed below).
@@ -155,8 +158,7 @@ if [ "$staged_sh" = 1 ]; then
 	# e.g. a special-builtin redirection error aborts ash/dash but not bash.
 	if have shellspec; then
 		staged_shell=$(printf '%s\n' "$staged" | grep '\.sh$' || true)
-		if printf '%s\n' "$staged_shell" | grep -q '^src/' ||
-		   printf '%s\n' "$staged" | grep -qE '^tests/shell/(spec_helper\.sh|bin/|fixtures/)'; then
+		if printf '%s\n' "$staged_shell" | grep -q '^src/' || [ "$staged_specplumb" = 1 ]; then
 			specs=$(ls tests/shell/*_spec.sh)
 		else
 			specs=$(printf '%s\n' "$staged_shell" | grep '^tests/shell/.*_spec\.sh$' || true)

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -146,18 +146,25 @@ if [ "$staged_sh" = 1 ]; then
 
 	# shellspec functional suite (gated on the tool, like shellcheck), scoped to the
 	# IMPACTED specs: staged spec files plus any spec that names a staged script's
-	# basename. The full suite runs minutes (and an interrupted run can strand
-	# spec-mutated state); CI remains the full-suite hard gate.
+	# basename. The basename heuristic is blind to the pfb_source indirection, so a
+	# staged src/ shell script — or any staged spec-plumbing file (spec_helper, bin/,
+	# fixtures/) — runs the FULL suite instead. The full suite runs minutes (and an
+	# interrupted run can strand spec-mutated state); CI remains the full-suite hard gate.
 	# Run under dash when available: strict-POSIX ash sibling of FreeBSD
 	# /bin/sh (the appliance shell). bash-as-sh (macOS) masks divergences —
 	# e.g. a special-builtin redirection error aborts ash/dash but not bash.
 	if have shellspec; then
 		staged_shell=$(printf '%s\n' "$staged" | grep '\.sh$' || true)
-		specs=$(printf '%s\n' "$staged_shell" | grep '^tests/shell/.*_spec\.sh$' || true)
-		for f in $(printf '%s\n' "$staged_shell" | grep -v '^tests/shell/'); do
-			specs="$specs
+		if printf '%s\n' "$staged_shell" | grep -q '^src/' ||
+		   printf '%s\n' "$staged" | grep -qE '^tests/shell/(spec_helper\.sh|bin/|fixtures/)'; then
+			specs=$(ls tests/shell/*_spec.sh)
+		else
+			specs=$(printf '%s\n' "$staged_shell" | grep '^tests/shell/.*_spec\.sh$' || true)
+			for f in $(printf '%s\n' "$staged_shell" | grep -v '^tests/shell/'); do
+				specs="$specs
 $(grep -l -F "$(basename "$f")" tests/shell/*_spec.sh 2>/dev/null || true)"
-		done
+			done
+		fi
 		specs=$(printf '%s\n' "$specs" | grep -v '^$' | sort -u)
 		if [ -n "$specs" ]; then
 			step 'shellspec (impacted)'

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -144,16 +144,32 @@ if [ "$staged_sh" = 1 ]; then
 		skip shellcheck
 	fi
 
-	# shellspec functional suite (gated on the tool, like shellcheck).
+	# shellspec functional suite (gated on the tool, like shellcheck), scoped to the
+	# IMPACTED specs: staged spec files plus any spec that names a staged script's
+	# basename. The full suite runs minutes (and an interrupted run can strand
+	# spec-mutated state); CI remains the full-suite hard gate.
 	# Run under dash when available: strict-POSIX ash sibling of FreeBSD
 	# /bin/sh (the appliance shell). bash-as-sh (macOS) masks divergences —
 	# e.g. a special-builtin redirection error aborts ash/dash but not bash.
 	if have shellspec; then
-		step 'shellspec'
-		if have dash; then
-			shellspec --shell "$(command -v dash)" || failed 'shellspec (dash)'
+		staged_shell=$(printf '%s\n' "$staged" | grep '\.sh$' || true)
+		specs=$(printf '%s\n' "$staged_shell" | grep '^tests/shell/.*_spec\.sh$' || true)
+		for f in $(printf '%s\n' "$staged_shell" | grep -v '^tests/shell/'); do
+			specs="$specs
+$(grep -l -F "$(basename "$f")" tests/shell/*_spec.sh 2>/dev/null || true)"
+		done
+		specs=$(printf '%s\n' "$specs" | grep -v '^$' | sort -u)
+		if [ -n "$specs" ]; then
+			step 'shellspec (impacted)'
+			if have dash; then
+				# shellcheck disable=SC2086 # specs is a newline list of repo paths
+				shellspec --shell "$(command -v dash)" $specs || failed 'shellspec (dash)'
+			else
+				# shellcheck disable=SC2086
+				shellspec $specs || failed 'shellspec'
+			fi
 		else
-			shellspec || failed 'shellspec'
+			skip 'shellspec(no-impacted-specs)'
 		fi
 	else
 		skip shellspec

--- a/scripts/agent/agent_env.sh
+++ b/scripts/agent/agent_env.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# agent_env.sh -- shared environment probe for the agent-ops scripts in this directory.
+#
+# AGENT-MAINTAINED: these scripts encode environment mechanics that drift (managed cloud
+# sessions, proxies, tool availability). When an environment change breaks one, the agent
+# fixes the script in the same session and lands it via the normal flow -- never works
+# around it silently in a transcript.
+#
+# Portability contract:
+#   - All GitHub/network access goes through the `gh` and `git` CLIs, never raw endpoints:
+#     managed environments route git/ssh/https through a localhost proxy that only those
+#     CLIs inherit.
+#   - `gh` absent (some managed environments): exit 3 with a GH-UNAVAILABLE message; the
+#     caller falls back to the session's mcp__github__* tools with wakeup-paced checks
+#     (CLAUDE.md "No orphaned waits" section 4). MCP tools are harness tools, unreachable
+#     from inside a shell, so the fallback CANNOT live in these scripts.
+#   - Any other required tool missing: exit 4 with TOOL-MISSING.
+#
+# Exit codes reserved across scripts/agent/: 0 verdict/success, 1 check failed,
+# 2 usage/precondition, 3 gh unavailable (use MCP fallback), 4 tool missing.
+
+require_gh() {
+	if ! command -v gh >/dev/null 2>&1; then
+		echo "GH-UNAVAILABLE: gh CLI not found (managed environment?)." >&2
+		echo "Fall back to mcp__github__* tools with wakeup-paced checks (CLAUDE.md 'No orphaned waits' #4)." >&2
+		exit 3
+	fi
+}
+
+require_tool() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		echo "TOOL-MISSING: $1" >&2
+		exit 4
+	fi
+}
+
+# ADR-47: under a git hook, exported GIT_DIR/GIT_INDEX_FILE would aim every git op
+# at the hook's repo instead of the --worktree the caller named. Git-touching scripts
+# call this first. $1 = the calling script's $0 (to locate the shared lib).
+scrub_git_env() {
+	# shellcheck source=scripts/lib/git-env-scrub.sh
+	. "$(dirname "$1")/../lib/git-env-scrub.sh"
+	pfb_scrub_git_env
+}

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -29,11 +29,14 @@ gates_for() {
 	out=''
 	nl='
 '
-	# Per-file commands are re-parsed by run_gate's `sh -c`; a diff filename carrying
-	# shell metacharacters would inject there. Replace its gates with a loud failure.
-	unsafe=$(printf '%s\n' "$files" | grep '[^A-Za-z0-9._/-]' || true)
-	files=$(printf '%s\n' "$files" | grep -v '[^A-Za-z0-9._/-]' || true)
+	# Per-file commands (php -l / sh -n / shellcheck) are re-parsed by run_gate's
+	# `sh -c`; a diff filename carrying shell metacharacters would inject there.
+	# The guard applies ONLY to those buckets -- aggregate gates (.py/.md suites)
+	# and gate-less file types never embed the filename, so an unusual name there
+	# must neither fail the run nor drop the aggregate gates.
+	unsafe=$(printf '%s\n' "$files" | grep -E '\.(php|inc|sh)$' | grep '[^A-Za-z0-9._/-]' || true)
 	if [ -n "$unsafe" ]; then
+		files=$(printf '%s\n' "$files" | grep -v '[^A-Za-z0-9._/-]' || true)
 		out="${out}printf 'unsafe filename in diff\\n' >&2; false${nl}"
 	fi
 	if printf '%s\n' "$files" | grep -q '\.py$'; then

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -82,7 +82,9 @@ main() {
 	require_tool git
 	[ -n "$worktree" ] || worktree=$(git rev-parse --show-toplevel) || exit 2
 
-	files=$(git -C "$worktree" diff --name-only "$base...HEAD") || exit 2
+	# --diff-filter=ACMR: a pure deletion stages nothing to lint (same rule as the
+	# pre-commit hook) -- per-file gates against ghost paths would always fail.
+	files=$(git -C "$worktree" diff --name-only --diff-filter=ACMR "$base...HEAD") || exit 2
 	# The shellspec gate must also fire when only spec files changed (cross-language
 	# consumers rule): specs are .sh files, so the extension mapping already covers it.
 	cmds=$(printf '%s\n' "$files" | gates_for)
@@ -94,7 +96,7 @@ main() {
 
 	# Pipelines run in subshells under POSIX sh, so `overall` cannot propagate out of a
 	# `| while` loop -- run the loop in one subshell and carry the flag in its output.
-	report=$(printf '%s' "$cmds" | {
+	report=$(printf '%s\n' "$cmds" | {
 		overall=0
 		while IFS= read -r c; do
 			[ -n "$c" ] && run_gate "$c"

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# run-gates.sh -- run the CLAUDE.md canonical gates for whatever a diff touches.
+# Mechanical runner for the "Canonical gates" table (CLAUDE.md stays the documented
+# source; this script implements it -- change them together).
+#
+# Usage: run-gates.sh [--worktree PATH] [--diff BASE] [--plan] [--allow-missing]
+#   --worktree       repo checkout to run in (default: cwd's repo root)
+#   --diff BASE      compute touched files vs BASE (default origin/devel); merge-base diff
+#   --plan           print the gate commands that WOULD run, one per line, and exit
+#   --allow-missing  a missing tool reports SKIP without failing the run (default: fails)
+#
+# Per-gate lines `GATE PASS|FAIL|SKIP: <cmd>`; final line `GATES: PASS|FAIL`. Exit 0 only
+# when nothing failed (and nothing skipped without --allow-missing). A diff touching
+# www/ additionally prints a REMINDER that Tier-A ui_render coverage is a judgment gate
+# this script cannot run (test mandate #4).
+
+worktree='' base='origin/devel' plan=0 allow_missing=0
+overall=0
+
+usage() {
+	echo "usage: run-gates.sh [--worktree PATH] [--diff BASE] [--plan] [--allow-missing]" >&2
+	exit 2
+}
+
+# Map a touched-file list (stdin, one path per line) to gate commands (stdout, one per
+# line). Per-file gates (php -l, sh -n, shellcheck) emit one command per touched file.
+gates_for() {
+	files=$(cat)
+	out=''
+	nl='
+'
+	if printf '%s\n' "$files" | grep -q '\.py$'; then
+		out="${out}python3 -m pytest${nl}ruff check .${nl}ruff format --check .${nl}mypy tests/${nl}"
+	fi
+	if printf '%s\n' "$files" | grep -Eq '\.(php|inc)$'; then
+		for f in $(printf '%s\n' "$files" | grep -E '\.(php|inc)$'); do
+			out="${out}php -l $f${nl}"
+		done
+		out="${out}vendor/bin/phpunit${nl}composer phpstan${nl}composer phpcs -- --standard=phpcs.xml.dist src/${nl}"
+	fi
+	if printf '%s\n' "$files" | grep -q '\.sh$'; then
+		for f in $(printf '%s\n' "$files" | grep '\.sh$'); do
+			out="${out}sh -n $f${nl}shellcheck $f${nl}"
+		done
+		out="${out}shellspec --shell \$(command -v dash)${nl}"
+	fi
+	if printf '%s\n' "$files" | grep -q '\.md$'; then
+		out="${out}npx markdownlint-cli2${nl}"
+	fi
+	printf '%s' "$out"
+}
+
+run_gate() {
+	# $1 = command line
+	tool=${1%% *}
+	if ! (cd "$worktree" && { command -v "$tool" >/dev/null 2>&1 || [ -x "$tool" ]; }); then
+		printf 'GATE SKIP: %s (TOOL-MISSING: %s)\n' "$1" "$tool"
+		[ "$allow_missing" -eq 1 ] || overall=1
+		return 0
+	fi
+	if (cd "$worktree" && sh -c "$1" >/dev/null 2>&1); then
+		printf 'GATE PASS: %s\n' "$1"
+	else
+		printf 'GATE FAIL: %s\n' "$1"
+		overall=1
+	fi
+}
+
+main() {
+	# shellcheck source=scripts/agent/agent_env.sh
+	. "$(dirname "$0")/agent_env.sh"
+	scrub_git_env "$0"
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--worktree) worktree=$2; shift 2 ;;
+			--diff) base=$2; shift 2 ;;
+			--plan) plan=1; shift ;;
+			--allow-missing) allow_missing=1; shift ;;
+			*) usage ;;
+		esac
+	done
+	require_tool git
+	[ -n "$worktree" ] || worktree=$(git rev-parse --show-toplevel) || exit 2
+
+	files=$(git -C "$worktree" diff --name-only "$base...HEAD") || exit 2
+	# The shellspec gate must also fire when only spec files changed (cross-language
+	# consumers rule): specs are .sh files, so the extension mapping already covers it.
+	cmds=$(printf '%s\n' "$files" | gates_for)
+
+	if [ "$plan" -eq 1 ]; then
+		printf '%s' "$cmds"
+		exit 0
+	fi
+
+	# Pipelines run in subshells under POSIX sh, so `overall` cannot propagate out of a
+	# `| while` loop -- run the loop in one subshell and carry the flag in its output.
+	report=$(printf '%s' "$cmds" | {
+		overall=0
+		while IFS= read -r c; do
+			[ -n "$c" ] && run_gate "$c"
+		done
+		echo "OVERALL=$overall"
+	})
+	printf '%s\n' "$report" | grep -v '^OVERALL='
+	if printf '%s\n' "$files" | grep -q '^src/usr/local/www/'; then
+		printf 'REMINDER: www/ touched -- Tier-A ui_render coverage is required and cannot be script-checked (test mandate #4)\n'
+	fi
+	if printf '%s\n' "$report" | grep -q 'OVERALL=0'; then
+		printf 'GATES: PASS\n'
+		exit 0
+	fi
+	printf 'GATES: FAIL\n'
+	exit 1
+}
+
+case "${AGENT_SOURCE_ONLY:-0}" in
+	1) ;;
+	*) main "$@" ;;
+esac

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -29,6 +29,13 @@ gates_for() {
 	out=''
 	nl='
 '
+	# Per-file commands are re-parsed by run_gate's `sh -c`; a diff filename carrying
+	# shell metacharacters would inject there. Replace its gates with a loud failure.
+	unsafe=$(printf '%s\n' "$files" | grep '[^A-Za-z0-9._/-]' || true)
+	files=$(printf '%s\n' "$files" | grep -v '[^A-Za-z0-9._/-]' || true)
+	if [ -n "$unsafe" ]; then
+		out="${out}printf 'unsafe filename in diff\\n' >&2; false${nl}"
+	fi
 	if printf '%s\n' "$files" | grep -q '\.py$'; then
 		out="${out}python3 -m pytest${nl}ruff check .${nl}ruff format --check .${nl}mypy tests/${nl}"
 	fi
@@ -42,7 +49,7 @@ gates_for() {
 		for f in $(printf '%s\n' "$files" | grep '\.sh$'); do
 			out="${out}sh -n $f${nl}shellcheck $f${nl}"
 		done
-		out="${out}shellspec --shell \$(command -v dash)${nl}"
+		out="${out}shellspec --shell \$(command -v dash || command -v sh)${nl}"
 	fi
 	if printf '%s\n' "$files" | grep -q '\.md$'; then
 		out="${out}npx markdownlint-cli2${nl}"

--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -36,7 +36,14 @@ main() {
 		case "$1" in
 			--worktree) worktree=$2; shift 2 ;;
 			--test-cmd) test_cmd=$2; shift 2 ;;
-			--src) srcs="$srcs $2"; shift 2 ;;
+			--src)
+				# $srcs is later word-split into git pathspecs and an expanded trap --
+				# reject anything outside the safe filename set at the door.
+				case "$2" in *[!A-Za-z0-9._/-]*|'')
+					echo "unsafe --src path: $2" >&2
+					exit 2 ;;
+				esac
+				srcs="$srcs $2"; shift 2 ;;
 			--hash) hashes="$hashes $2"; shift 2 ;;
 			*) usage ;;
 		esac

--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -48,7 +48,7 @@ main() {
 			*) usage ;;
 		esac
 	done
-	[ -n "$worktree" ] && [ -n "$test_cmd" ] && [ -n "$srcs" ] || usage
+	{ [ -n "$worktree" ] && [ -n "$test_cmd" ] && [ -n "$srcs" ]; } || usage
 	require_tool git
 
 	if [ -n "$(git -C "$worktree" status --porcelain)" ]; then

--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# verify-red-proof.sh -- mechanically re-execute a red->green proof (CLAUDE.md "THE GATE"
+# item 2): freeze-hash check, revert the src paths to HEAD~1 (tests stay), expect the
+# pinning test to FAIL, restore, expect it to PASS. The single implementation the
+# gh-issue / adr-phase / delegate gates and the phase-step verifier reference.
+#
+# Usage: verify-red-proof.sh --worktree PATH --test-cmd 'CMD' --src PATH [--src PATH ...]
+#                            [--hash FILE=SHA ...]
+#   --test-cmd  run via `sh -c` from the worktree root; nonzero exit = red, zero = green
+#   --src       production path(s) reverted to HEAD~1 for the red run (repo-relative)
+#   --hash      committed reproduction-test freeze check: `git hash-object FILE` must
+#               equal SHA (the handoff's red-time hash) -- an edited test proves nothing
+#
+# Prints FREEZE-OK / RED-OK / GREEN-OK step lines, then final `VERDICT: PASS`.
+# Any step failing prints the failing step + `VERDICT: FAIL` and exits 1. Requires a
+# clean tree (exit 2 otherwise); the src paths are restored on every exit path.
+
+worktree='' test_cmd=''
+srcs='' hashes=''
+
+usage() {
+	echo "usage: verify-red-proof.sh --worktree PATH --test-cmd 'CMD' --src PATH [--src ...] [--hash FILE=SHA ...]" >&2
+	exit 2
+}
+
+fail() {
+	printf '%s\nVERDICT: FAIL\n' "$1"
+	exit 1
+}
+
+main() {
+	# shellcheck source=scripts/agent/agent_env.sh
+	. "$(dirname "$0")/agent_env.sh"
+	scrub_git_env "$0"
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--worktree) worktree=$2; shift 2 ;;
+			--test-cmd) test_cmd=$2; shift 2 ;;
+			--src) srcs="$srcs $2"; shift 2 ;;
+			--hash) hashes="$hashes $2"; shift 2 ;;
+			*) usage ;;
+		esac
+	done
+	[ -n "$worktree" ] && [ -n "$test_cmd" ] && [ -n "$srcs" ] || usage
+	require_tool git
+
+	if [ -n "$(git -C "$worktree" status --porcelain)" ]; then
+		echo "DIRTY-TREE: the gate re-derives from committed state; commit or clean first." >&2
+		exit 2
+	fi
+
+	for pair in $hashes; do
+		file=${pair%%=*}
+		want=${pair#*=}
+		got=$(git -C "$worktree" hash-object "$file") || fail "FREEZE-FAIL: cannot hash $file"
+		if [ "$got" != "$want" ]; then
+			fail "FREEZE-FAIL: $file is $got, red-time hash was $want (test edited between red and green)"
+		fi
+		printf 'FREEZE-OK: %s\n' "$file"
+	done
+
+	# shellcheck disable=SC2086 # srcs is a space-separated path list by construction
+	git -C "$worktree" checkout HEAD~1 -- $srcs || fail "REVERT-FAIL: could not check out HEAD~1 src paths"
+	# shellcheck disable=SC2064,SC2086 # expand now: restore exactly these paths on any exit
+	trap "git -C '$worktree' checkout HEAD -- $srcs" EXIT
+
+	if (cd "$worktree" && sh -c "$test_cmd" >/dev/null 2>&1); then
+		fail "RED-FAIL: test passed against HEAD~1 src -- it does not pin the defect"
+	fi
+	printf 'RED-OK: test fails against HEAD~1 src\n'
+
+	# shellcheck disable=SC2086
+	git -C "$worktree" checkout HEAD -- $srcs || fail "RESTORE-FAIL"
+	trap - EXIT
+
+	if ! (cd "$worktree" && sh -c "$test_cmd" >/dev/null 2>&1); then
+		fail "GREEN-FAIL: test fails against HEAD -- the fix does not satisfy its own pin"
+	fi
+	printf 'GREEN-OK: test passes against HEAD\nVERDICT: PASS\n'
+}
+
+case "${AGENT_SOURCE_ONLY:-0}" in
+	1) ;;
+	*) main "$@" ;;
+esac

--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -61,8 +61,12 @@ main() {
 
 	# shellcheck disable=SC2086 # srcs is a space-separated path list by construction
 	git -C "$worktree" checkout HEAD~1 -- $srcs || fail "REVERT-FAIL: could not check out HEAD~1 src paths"
-	# shellcheck disable=SC2064,SC2086 # expand now: restore exactly these paths on any exit
+	# shellcheck disable=SC2064,SC2086 # expand now: restore exactly these paths on any exit.
+	# INT/TERM trapped explicitly: under dash (Linux /bin/sh) an EXIT trap does NOT run
+	# on an untrapped signal, which would strand the src paths at HEAD~1.
 	trap "git -C '$worktree' checkout HEAD -- $srcs" EXIT
+	# shellcheck disable=SC2064,SC2086 # expand now, deliberately (same paths as above)
+	trap "git -C '$worktree' checkout HEAD -- $srcs; trap - EXIT; exit 130" INT TERM
 
 	if (cd "$worktree" && sh -c "$test_cmd" >/dev/null 2>&1); then
 		fail "RED-FAIL: test passed against HEAD~1 src -- it does not pin the defect"
@@ -71,7 +75,7 @@ main() {
 
 	# shellcheck disable=SC2086
 	git -C "$worktree" checkout HEAD -- $srcs || fail "RESTORE-FAIL"
-	trap - EXIT
+	trap - EXIT INT TERM
 
 	if ! (cd "$worktree" && sh -c "$test_cmd" >/dev/null 2>&1); then
 		fail "GREEN-FAIL: test fails against HEAD -- the fix does not satisfy its own pin"

--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# wait-checks.sh -- poll a PR's checks until every non-excluded check completes.
+# The single implementation of the CI wait the pr-merge skill used to inline.
+#
+# Usage: wait-checks.sh --repo OWNER/REPO --pr N [options]
+#   --exclude REGEX    case-insensitive check-name exclusion (default 'coderabbit|snyk' --
+#                      both are advisory and must never gate a merge)
+#   --interval SECONDS poll interval (default 30)
+#   --max-iter N       hard iteration cap (default 80, ~40 min at 30s)
+#
+# The LAST stdout line is the verdict: PASS | FAIL | TIMEOUT. On PASS/FAIL the relevant
+# checks JSON precedes it as detail. `bucket` semantics: skipping counts as done-not-
+# failed; PASS requires at least one relevant check registered (never green-by-absence).
+# Exit codes: see agent_env.sh. Self-terminating (CLAUDE.md "No orphaned waits" #1).
+
+repo='' pr='' exclude='coderabbit|snyk' interval=30 max_iter=80
+
+usage() {
+	echo "usage: wait-checks.sh --repo O/R --pr N [--exclude REGEX] [--interval S] [--max-iter N]" >&2
+	exit 2
+}
+
+# Reduce one checks-JSON snapshot to PASS / FAIL / PENDING / EMPTY (prints verdict).
+evaluate_checks() {
+	# $1 = checks JSON array of {name, bucket}
+	rel=$(printf '%s' "$1" | jq -c "[.[] | select((.name|ascii_downcase|test(\"$exclude\"))|not)]")
+	total=$(printf '%s' "$rel" | jq 'length')
+	fail=$(printf '%s' "$rel" | jq '[.[] | select(.bucket=="fail" or .bucket=="cancel")] | length')
+	pend=$(printf '%s' "$rel" | jq '[.[] | select(.bucket=="pending")] | length')
+	if [ "$fail" -gt 0 ]; then
+		printf 'FAIL'
+	elif [ "$total" -eq 0 ]; then
+		printf 'EMPTY'
+	elif [ "$pend" -eq 0 ]; then
+		printf 'PASS'
+	else
+		printf 'PENDING'
+	fi
+}
+
+main() {
+	# shellcheck source=scripts/agent/agent_env.sh
+	. "$(dirname "$0")/agent_env.sh"
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--repo) repo=$2; shift 2 ;;
+			--pr) pr=$2; shift 2 ;;
+			--exclude) exclude=$2; shift 2 ;;
+			--interval) interval=$2; shift 2 ;;
+			--max-iter) max_iter=$2; shift 2 ;;
+			*) usage ;;
+		esac
+	done
+	[ -n "$repo" ] && [ -n "$pr" ] || usage
+	require_gh
+	require_tool jq
+
+	i=0
+	while [ "$i" -lt "$max_iter" ]; do
+		json=$(gh pr checks "$pr" --repo "$repo" --json name,bucket 2>/dev/null)
+		[ -n "$json" ] || json='[]'
+		v=$(evaluate_checks "$json")
+		case "$v" in
+			PASS|FAIL)
+				printf '%s' "$json" | jq -c "[.[] | select((.name|ascii_downcase|test(\"$exclude\"))|not)]"
+				printf '%s\n' "$v"
+				exit 0
+				;;
+		esac
+		i=$((i + 1))
+		sleep "$interval"
+	done
+	printf 'TIMEOUT\n'
+}
+
+case "${AGENT_SOURCE_ONLY:-0}" in
+	1) ;;
+	*) main "$@" ;;
+esac

--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -11,7 +11,9 @@
 # The LAST stdout line is the verdict: PASS | FAIL | TIMEOUT. On PASS/FAIL the relevant
 # checks JSON precedes it as detail. `bucket` semantics: skipping counts as done-not-
 # failed; PASS requires at least one relevant check registered (never green-by-absence).
-# Exit codes: see agent_env.sh. Self-terminating (CLAUDE.md "No orphaned waits" #1).
+# Exit codes: see agent_env.sh. Self-terminating: iteration cap AND wall-clock deadline
+# (max-iter x interval + 300 s slack; PFB_WAIT_DEADLINE overrides) per CLAUDE.md
+# "No orphaned waits" #1.
 
 repo='' pr='' exclude='coderabbit|snyk' interval=30 max_iter=80
 
@@ -55,8 +57,14 @@ main() {
 	require_gh
 	require_tool jq
 
+	# Wall-clock deadline alongside the cap (CLAUDE.md "No orphaned waits" #1);
+	# PFB_WAIT_DEADLINE (epoch seconds) overrides for tests/ops.
+	deadline=${PFB_WAIT_DEADLINE:-$(( $(date +%s) + max_iter * interval + 300 ))}
 	i=0
 	while [ "$i" -lt "$max_iter" ]; do
+		if [ "$(date +%s)" -ge "$deadline" ]; then
+			break
+		fi
 		json=$(gh pr checks "$pr" --repo "$repo" --json name,bucket 2>/dev/null)
 		[ -n "$json" ] || json='[]'
 		v=$(evaluate_checks "$json")

--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -53,7 +53,7 @@ main() {
 			*) usage ;;
 		esac
 	done
-	[ -n "$repo" ] && [ -n "$pr" ] || usage
+	{ [ -n "$repo" ] && [ -n "$pr" ]; } || usage
 	require_gh
 	require_tool jq
 

--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -61,11 +61,24 @@ main() {
 	# PFB_WAIT_DEADLINE (epoch seconds) overrides for tests/ops.
 	deadline=${PFB_WAIT_DEADLINE:-$(( $(date +%s) + max_iter * interval + 300 ))}
 	i=0
+	ghfail=0
 	while [ "$i" -lt "$max_iter" ]; do
 		if [ "$(date +%s)" -ge "$deadline" ]; then
 			break
 		fi
-		json=$(gh pr checks "$pr" --repo "$repo" --json name,bucket 2>/dev/null)
+		if ! json=$(gh pr checks "$pr" --repo "$repo" --json name,bucket 2>&1); then
+			# 3 consecutive gh failures = a real problem (bad repo/pr, auth, outage),
+			# not "no checks yet" -- fail loudly instead of polling to a blind TIMEOUT.
+			ghfail=$((ghfail + 1))
+			if [ "$ghfail" -ge 3 ]; then
+				printf 'GH-ERROR\n%s\n' "$json"
+				exit 1
+			fi
+			i=$((i + 1))
+			sleep "$interval"
+			continue
+		fi
+		ghfail=0
 		[ -n "$json" ] || json='[]'
 		v=$(evaluate_checks "$json")
 		case "$v" in

--- a/scripts/agent/wait-reviewer.sh
+++ b/scripts/agent/wait-reviewer.sh
@@ -14,13 +14,17 @@
 #
 # The LAST stdout line is the verdict; recent handle comments precede it as detail:
 #   ACK | NOACK | FINISHED | QUOTA <mins> | DECLINE | PAUSE | NOTPRESENT | TIMEOUT
-# Handle matching is a case-insensitive substring of the login, so `--handle copilot`
-# matches copilot-pull-request-reviewer[bot] and `coderabbitai` matches coderabbitai[bot].
+# Handle matching is case-insensitive and ANCHORED, so `--handle copilot` matches
+# copilot-pull-request-reviewer[bot] and `coderabbitai` matches coderabbitai[bot], but a
+# login that merely CONTAINS the handle does not count.
 # `--handle snyk` reads the head-SHA commit status/check-runs instead of comments (Snyk
 # posts no review comments); its `error` state reports QUOTA, never a clean pass.
+# Login match is ANCHORED: == handle, == handle[bot], or startswith(handle-).
+# A wall-clock deadline (max-iter x interval + 300 s slack; PFB_WAIT_DEADLINE overrides)
+# bounds the wait even when individual gh calls stall.
 # Exit codes: see agent_env.sh (0 verdict, 2 usage, 3 gh unavailable -> MCP fallback).
-# Self-terminating by construction (CLAUDE.md "No orphaned waits" #1): the cap and the
-# interval bound total wall clock; run it in the background and read the verdict.
+# Self-terminating by construction (CLAUDE.md "No orphaned waits" #1): iteration cap AND
+# wall-clock deadline; run it in the background and read the verdict.
 
 repo='' pr='' handle='' mode='finished' since='' presence=10 interval=30 max_iter=''
 inline='' review='' issuec='' sinfo=''
@@ -66,20 +70,25 @@ classify() {
 		printf 'DECLINE'
 		return 0
 	fi
-	if printf '%s' "$issuec" | grep -Eqi 'reviews? paused|paused .*review|review.*paused'; then
+	if printf '%s' "$issuec" | grep -Eqi 'reviews? paused|paused .*review|review.*paused|⏸'; then
 		printf 'PAUSE'
 		return 0
 	fi
 	return 0
 }
 
-# jq filter for one comment source: substring login match + optional time floor.
+# jq filter for one comment source: ANCHORED login match + optional time floor.
+# Anchored (== handle, == handle[bot], startswith(handle-)) rather than free substring:
+# a public account whose login merely CONTAINS the handle must not satisfy the wait,
+# and a verbatim bracketed login must match itself (no regex-metachar surface).
 jq_filter() {
 	# $1 = timestamp field name
+	# shellcheck disable=SC2016 # $l is jq syntax, not a shell expansion
+	m=$(printf '((.user.login|ascii_downcase) as $l | ($l == "%s") or ($l == "%s[bot]") or ($l | startswith("%s-")))' "$handle" "$handle" "$handle")
 	if [ -n "$since" ]; then
-		printf '.[] | select((.user.login|ascii_downcase)|test("%s")) | select(.%s > "%s")' "$handle" "$1" "$since"
+		printf '.[] | select(%s) | select(.%s > "%s")' "$m" "$1" "$since"
 	else
-		printf '.[] | select((.user.login|ascii_downcase)|test("%s"))' "$handle"
+		printf '.[] | select(%s)' "$m"
 	fi
 }
 
@@ -124,9 +133,16 @@ main() {
 		since=$(gh pr view "$pr" --repo "$repo" --json commits -q '.commits[-1].committedDate' 2>/dev/null)
 	fi
 
+	# Wall-clock deadline alongside the iteration cap (CLAUDE.md "No orphaned waits" #1):
+	# stalled gh calls must not stretch the wait past its budget. PFB_WAIT_DEADLINE
+	# (epoch seconds) overrides for tests/ops.
+	deadline=${PFB_WAIT_DEADLINE:-$(( $(date +%s) + max_iter * interval + 300 ))}
 	i=0
 	seen=0
 	while [ "$i" -lt "$max_iter" ]; do
+		if [ "$(date +%s)" -ge "$deadline" ]; then
+			break
+		fi
 		fetch_state
 		[ -n "${inline}${review}${issuec}$(printf '%s' "$sinfo" | tr -dc '[:lower:]')" ] && seen=1
 		v=$(classify)

--- a/scripts/agent/wait-reviewer.sh
+++ b/scripts/agent/wait-reviewer.sh
@@ -12,7 +12,8 @@
 #   --interval SECONDS    poll interval (default 30)
 #   --max-iter N          hard iteration cap (default: 20 ack / 60 finished)
 #
-# The LAST stdout line is the verdict; recent handle comments precede it as detail:
+# The LAST stdout line is the verdict; the handle's recent ISSUE comments (the notice
+# bodies the verdicts parse) precede it as detail:
 #   ACK | NOACK | FINISHED | QUOTA <mins> | DECLINE | PAUSE | NOTPRESENT | TIMEOUT
 # Handle matching is case-insensitive and ANCHORED, so `--handle copilot` matches
 # copilot-pull-request-reviewer[bot] and `coderabbitai` matches coderabbitai[bot], but a
@@ -57,7 +58,7 @@ classify() {
 		printf 'FINISHED'
 		return 0
 	fi
-	if printf '%s' "$issuec" | grep -Eqi 'run out of usage credits|review limit reached|rate limited by coderabbit|reached your .*review rate limit'; then
+	if printf '%s' "$issuec" | grep -Eqi 'run out of usage credits|review limit reached|rate limited by coderabbit|reached your .*review (rate )?limit'; then
 		mins=$(printf '%s' "$issuec" | grep -oEi 'available in:.{0,10}[0-9]+ *(minute|hour)' | grep -oE '[0-9]+' | head -1)
 		if printf '%s' "$issuec" | grep -oEi 'available in:.{0,10}[0-9]+ *hour' | grep -q .; then
 			mins=$(( ${mins:-1} * 60 ))

--- a/scripts/agent/wait-reviewer.sh
+++ b/scripts/agent/wait-reviewer.sh
@@ -123,7 +123,7 @@ main() {
 			*) usage ;;
 		esac
 	done
-	[ -n "$repo" ] && [ -n "$pr" ] && [ -n "$handle" ] || usage
+	{ [ -n "$repo" ] && [ -n "$pr" ] && [ -n "$handle" ]; } || usage
 	case "$mode" in ack|finished) ;; *) usage ;; esac
 	require_gh
 

--- a/scripts/agent/wait-reviewer.sh
+++ b/scripts/agent/wait-reviewer.sh
@@ -1,0 +1,151 @@
+#!/bin/sh
+# wait-reviewer.sh -- poll a PR until a bot/human reviewer engages or finishes.
+# The single implementation of the reviewer-wait state machine the pr-comments /
+# pr-merge-flow skills used to inline (content-first FINISHED, CodeRabbit QUOTA with
+# resume minutes, DECLINE/PAUSE, Snyk status handling, NOTPRESENT presence window).
+#
+# Usage: wait-reviewer.sh --repo OWNER/REPO --pr N --handle LOGIN [options]
+#   --until ack|finished  ack = ANY message from the handle counts (default: finished)
+#   --since ISO8601       only activity after this instant counts (default: the PR head
+#                         commit time in finished mode; unset = all activity in ack mode)
+#   --presence N          polls with zero engagement before NOTPRESENT (default 10; 0=off)
+#   --interval SECONDS    poll interval (default 30)
+#   --max-iter N          hard iteration cap (default: 20 ack / 60 finished)
+#
+# The LAST stdout line is the verdict; recent handle comments precede it as detail:
+#   ACK | NOACK | FINISHED | QUOTA <mins> | DECLINE | PAUSE | NOTPRESENT | TIMEOUT
+# Handle matching is a case-insensitive substring of the login, so `--handle copilot`
+# matches copilot-pull-request-reviewer[bot] and `coderabbitai` matches coderabbitai[bot].
+# `--handle snyk` reads the head-SHA commit status/check-runs instead of comments (Snyk
+# posts no review comments); its `error` state reports QUOTA, never a clean pass.
+# Exit codes: see agent_env.sh (0 verdict, 2 usage, 3 gh unavailable -> MCP fallback).
+# Self-terminating by construction (CLAUDE.md "No orphaned waits" #1): the cap and the
+# interval bound total wall clock; run it in the background and read the verdict.
+
+repo='' pr='' handle='' mode='finished' since='' presence=10 interval=30 max_iter=''
+inline='' review='' issuec='' sinfo=''
+
+usage() {
+	echo "usage: wait-reviewer.sh --repo O/R --pr N --handle LOGIN [--until ack|finished] [--since ISO] [--presence N] [--interval S] [--max-iter N]" >&2
+	exit 2
+}
+
+# Decide the verdict from the currently fetched state; prints nothing = keep polling.
+# Order is load-bearing: real review content is checked BEFORE any quota phrase, so a
+# transient/stale rate-limit notice sitting beside actual comments never masks them.
+classify() {
+	if [ "$handle" = "snyk" ]; then
+		if printf '%s' "$sinfo" | grep -Eqi 'limit reached|^(error|action_required|timed_out|cancelled|stale)'; then
+			printf 'QUOTA 999'
+			return 0
+		fi
+		if printf '%s' "$sinfo" | grep -Eqi '^(success|failure|neutral|completed)'; then
+			printf 'FINISHED'
+			return 0
+		fi
+		return 0
+	fi
+	if [ "$mode" = "ack" ]; then
+		[ -n "${inline}${review}${issuec}" ] && printf 'ACK'
+		return 0
+	fi
+	if [ -n "$inline" ] || [ -n "$review" ] || printf '%s' "$issuec" | grep -qiE 'actionable comments posted|no actionable comments'; then
+		printf 'FINISHED'
+		return 0
+	fi
+	if printf '%s' "$issuec" | grep -Eqi 'run out of usage credits|review limit reached|rate limited by coderabbit|reached your .*review rate limit'; then
+		mins=$(printf '%s' "$issuec" | grep -oEi 'available in:.{0,10}[0-9]+ *(minute|hour)' | grep -oE '[0-9]+' | head -1)
+		if printf '%s' "$issuec" | grep -oEi 'available in:.{0,10}[0-9]+ *hour' | grep -q .; then
+			mins=$(( ${mins:-1} * 60 ))
+		fi
+		printf 'QUOTA %s' "${mins:-999}"
+		return 0
+	fi
+	if printf '%s' "$issuec" | grep -qi 'review skipped' &&
+	   printf '%s' "$issuec" | grep -Eqi 'base branch|base branches|default branch'; then
+		printf 'DECLINE'
+		return 0
+	fi
+	if printf '%s' "$issuec" | grep -Eqi 'reviews? paused|paused .*review|review.*paused'; then
+		printf 'PAUSE'
+		return 0
+	fi
+	return 0
+}
+
+# jq filter for one comment source: substring login match + optional time floor.
+jq_filter() {
+	# $1 = timestamp field name
+	if [ -n "$since" ]; then
+		printf '.[] | select((.user.login|ascii_downcase)|test("%s")) | select(.%s > "%s")' "$handle" "$1" "$since"
+	else
+		printf '.[] | select((.user.login|ascii_downcase)|test("%s"))' "$handle"
+	fi
+}
+
+fetch_state() {
+	inline=$(gh api "repos/$repo/pulls/$pr/comments" --paginate -q "$(jq_filter created_at) | .id" 2>/dev/null)
+	review=$(gh api "repos/$repo/pulls/$pr/reviews" --paginate -q "$(jq_filter submitted_at) | (.body // \"x\")" 2>/dev/null)
+	issuec=$(gh api "repos/$repo/issues/$pr/comments" --paginate -q "$(jq_filter updated_at) | (.body // \"\")" 2>/dev/null)
+	if [ "$handle" = "snyk" ]; then
+		sha=$(gh pr view "$pr" --repo "$repo" --json headRefOid -q .headRefOid 2>/dev/null)
+		sinfo=$(gh api "repos/$repo/commits/$sha/status" \
+			-q '.statuses[] | select((.context|ascii_downcase)|test("snyk")) | "\(.state) \(.description)"' 2>/dev/null)
+		sinfo="$sinfo
+$(gh api "repos/$repo/commits/$sha/check-runs" --paginate \
+			-q '.check_runs[] | select((.name|ascii_downcase)|test("snyk")) | "\(.conclusion // .status) \(.output.title // "")"' 2>/dev/null)"
+	fi
+}
+
+main() {
+	# shellcheck source=scripts/agent/agent_env.sh
+	. "$(dirname "$0")/agent_env.sh"
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--repo) repo=$2; shift 2 ;;
+			--pr) pr=$2; shift 2 ;;
+			--handle) handle=$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]'); shift 2 ;;
+			--until) mode=$2; shift 2 ;;
+			--since) since=$2; shift 2 ;;
+			--presence) presence=$2; shift 2 ;;
+			--interval) interval=$2; shift 2 ;;
+			--max-iter) max_iter=$2; shift 2 ;;
+			*) usage ;;
+		esac
+	done
+	[ -n "$repo" ] && [ -n "$pr" ] && [ -n "$handle" ] || usage
+	case "$mode" in ack|finished) ;; *) usage ;; esac
+	require_gh
+
+	if [ -z "$max_iter" ]; then
+		if [ "$mode" = "ack" ]; then max_iter=20; else max_iter=60; fi
+	fi
+	if [ -z "$since" ] && [ "$mode" = "finished" ] && [ "$handle" != "snyk" ]; then
+		since=$(gh pr view "$pr" --repo "$repo" --json commits -q '.commits[-1].committedDate' 2>/dev/null)
+	fi
+
+	i=0
+	seen=0
+	while [ "$i" -lt "$max_iter" ]; do
+		fetch_state
+		[ -n "${inline}${review}${issuec}$(printf '%s' "$sinfo" | tr -dc '[:lower:]')" ] && seen=1
+		v=$(classify)
+		if [ -n "$v" ]; then
+			printf '%s\n' "$issuec" | head -c 3000
+			printf '\n%s\n' "$v"
+			exit 0
+		fi
+		if [ "$seen" -eq 0 ] && [ "$presence" -gt 0 ] && [ "$i" -ge "$presence" ]; then
+			printf 'NOTPRESENT\n'
+			exit 0
+		fi
+		i=$((i + 1))
+		sleep "$interval"
+	done
+	if [ "$mode" = "ack" ]; then printf 'NOACK\n'; else printf 'TIMEOUT\n'; fi
+}
+
+case "${AGENT_SOURCE_ONLY:-0}" in
+	1) ;;
+	*) main "$@" ;;
+esac

--- a/scripts/agent/work-branch.sh
+++ b/scripts/agent/work-branch.sh
@@ -24,9 +24,16 @@ slugify() {
 	s=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | LC_ALL=C tr -c 'a-z0-9' '-' \
 		| LC_ALL=C sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//')
 	if [ "${#s}" -gt 30 ]; then
-		s=$(printf '%.30s' "$s")
-		case "$s" in
-			*-*) s=${s%-*} ;;   # drop the truncated last token: cut back to the last '-'
+		head30=$(printf '%.30s' "$s")
+		rest=${s#"$head30"}
+		case "$rest" in
+			-*) s=$head30 ;;   # the cut lands exactly on a token boundary: keep the prefix
+			*)
+				case "$head30" in
+					*-*) s=${head30%-*} ;;   # drop the straddling token: back to the last '-'
+					*) s=$head30 ;;
+				esac
+				;;
 		esac
 		s=$(printf '%s' "$s" | LC_ALL=C sed 's/-$//')
 	fi

--- a/scripts/agent/work-branch.sh
+++ b/scripts/agent/work-branch.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# work-branch.sh -- derive the canonical work-item branch name (CLAUDE.md "Branch naming"
+# sanitiser, implemented once so it is never hand-derived) and optionally cut the
+# worktree for it.
+#
+# Usage: work-branch.sh <issue|adr> <NN> [TITLE ...] [--worktree] [--path PATH] [--base REF]
+#   Prints the branch name (`issue/NN-slug` / `adr/NN-slug`; empty slug -> bare `type/NN`).
+#   --worktree  also `git fetch origin` + `git worktree add -b BRANCH PATH BASE` at an
+#               ABSOLUTE path (default <repo>/.claude/worktrees/<type>-<NN>); an existing
+#               branch or path gets a `-<epoch>` suffix (collision rule). Prints
+#               `BRANCH<TAB>PATH` instead.
+#   --base REF  worktree base (default origin/devel)
+#
+# Sanitiser (pinned by tests/shell/agent_work_branch_spec.sh): lowercase; every
+# non-[a-z0-9] run collapses to one '-'; trim leading/trailing '-'; truncate to <=30
+# chars at a '-' boundary (never a trailing '-').
+
+usage() {
+	echo "usage: work-branch.sh <issue|adr> <NN> [TITLE ...] [--worktree] [--path PATH] [--base REF]" >&2
+	exit 2
+}
+
+slugify() {
+	s=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | LC_ALL=C tr -c 'a-z0-9' '-' \
+		| LC_ALL=C sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//')
+	if [ "${#s}" -gt 30 ]; then
+		s=$(printf '%.30s' "$s")
+		case "$s" in
+			*-*) s=${s%-*} ;;   # drop the truncated last token: cut back to the last '-'
+		esac
+		s=$(printf '%s' "$s" | LC_ALL=C sed 's/-$//')
+	fi
+	printf '%s' "$s"
+}
+
+main() {
+	# shellcheck source=scripts/agent/agent_env.sh
+	. "$(dirname "$0")/agent_env.sh"
+	scrub_git_env "$0"
+	kind='' nn='' title='' do_worktree=0 path='' base='origin/devel'
+	case "$1" in issue|adr) kind=$1; shift ;; *) usage ;; esac
+	case "$1" in *[!0-9]*|'') usage ;; *) nn=$1; shift ;; esac
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			--worktree) do_worktree=1; shift ;;
+			--path) path=$2; shift 2 ;;
+			--base) base=$2; shift 2 ;;
+			*) title="$title $1"; shift ;;
+		esac
+	done
+
+	slug=$(slugify "$title")
+	branch="$kind/$nn${slug:+-$slug}"
+
+	if [ "$do_worktree" -eq 0 ]; then
+		printf '%s\n' "$branch"
+		exit 0
+	fi
+
+	require_tool git
+	root=$(git rev-parse --show-toplevel) || exit 2
+	git fetch origin >/dev/null 2>&1
+	if git show-ref --verify -q "refs/heads/$branch" ||
+	   git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+		branch="$branch-$(date +%s)"
+	fi
+	[ -n "$path" ] || path="$root/.claude/worktrees/$kind-$nn"
+	case "$path" in /*) ;; *) path="$root/$path" ;; esac   # worktree add needs ABSOLUTE paths
+	[ -e "$path" ] && path="$path-$(date +%s)"
+	git worktree add -b "$branch" "$path" "$base" >/dev/null || exit 1
+	printf '%s\t%s\n' "$branch" "$path"
+}
+
+case "${AGENT_SOURCE_ONLY:-0}" in
+	1) ;;
+	*) main "$@" ;;
+esac

--- a/scripts/agent/work-branch.sh
+++ b/scripts/agent/work-branch.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
-# work-branch.sh -- derive the canonical work-item branch name (CLAUDE.md "Branch naming"
-# sanitiser, implemented once so it is never hand-derived) and optionally cut the
-# worktree for it.
+# work-branch.sh -- derive the canonical work-item branch name (the CLAUDE.md
+# "Branch naming" sanitiser) and optionally cut the worktree for it.
 #
 # Usage: work-branch.sh <issue|adr> <NN> [TITLE ...] [--worktree] [--path PATH] [--base REF]
 #   Prints the branch name (`issue/NN-slug` / `adr/NN-slug`; empty slug -> bare `type/NN`).
@@ -50,8 +49,8 @@ main() {
 	while [ $# -gt 0 ]; do
 		case "$1" in
 			--worktree) do_worktree=1; shift ;;
-			--path) path=$2; shift 2 ;;
-			--base) base=$2; shift 2 ;;
+			--path) [ $# -ge 2 ] || usage; path=$2; shift 2 ;;
+			--base) [ $# -ge 2 ] || usage; base=$2; shift 2 ;;
 			*) title="$title $1"; shift ;;
 		esac
 	done

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -38,7 +38,7 @@ Describe 'run-gates.sh gates_for()'
     The line 1 of output should equal 'sh -n scripts/agent/x.sh'
     The line 2 of output should equal 'shellcheck scripts/agent/x.sh'
     # shellcheck disable=SC2016 # the literal $( ) is the pinned command text
-    The line 3 of output should equal 'shellspec --shell $(command -v dash)'
+    The line 3 of output should equal 'shellspec --shell $(command -v dash || command -v sh)'
     The lines of output should equal 3
   End
 
@@ -56,6 +56,12 @@ Describe 'run-gates.sh gates_for()'
     When call gates_for
     The output should include 'python3 -m pytest'
     The output should include 'shellcheck b.sh'
+  End
+
+  It 'refuses to build a command from a path with shell metacharacters'
+    Data "evil\$(touch pwned).sh"
+    When call gates_for
+    The line 1 of output should equal "printf 'unsafe filename in diff\\n' >&2; false"
   End
 
   It 'emits nothing for file types with no gates'

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -58,10 +58,27 @@ Describe 'run-gates.sh gates_for()'
     The output should include 'shellcheck b.sh'
   End
 
-  It 'refuses to build a command from a path with shell metacharacters'
+  It 'refuses to build a command from an unsafe path that feeds a per-file gate'
     Data "evil\$(touch pwned).sh"
     When call gates_for
     The line 1 of output should equal "printf 'unsafe filename in diff\\n' >&2; false"
+  End
+
+  It 'keeps aggregate gates for an unsafe-named Python file (no per-file interpolation)'
+    Data "my file.py"
+    When call gates_for
+    The line 1 of output should equal 'python3 -m pytest'
+    The lines of output should equal 4
+  End
+
+  It 'ignores an unsafe-named file that has no gates at all'
+    Data
+      #|.ADRs/ADR_04/07_Unbound_(next_only).txt
+      #|scripts/ok.py
+    End
+    When call gates_for
+    The line 1 of output should equal 'python3 -m pytest'
+    The output should not include 'unsafe filename'
   End
 
   It 'emits nothing for file types with no gates'
@@ -77,7 +94,7 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rungates.XXXXXX")"
     git -C "$repo" init -q
-    printf '#!/bin/sh\ntrue\n' > "$repo/gone.sh"
+    printf '#!/bin/sh\n# gone-marker: content distinct from kept.sh so git reports a\n# genuine deletion (identical content collapses to an R100 rename)\ntrue\n' > "$repo/gone.sh"
     gitc add -A; gitc commit -qm base
     base_sha=$(gitc rev-parse HEAD)
     gitc rm -q gone.sh

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -64,3 +64,45 @@ Describe 'run-gates.sh gates_for()'
     The output should equal ''
   End
 End
+
+Describe 'run-gates.sh main (fixture repo, stubbed tools)'
+  gitc() { git -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+  make_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rungates.XXXXXX")"
+    git -C "$repo" init -q
+    printf '#!/bin/sh\ntrue\n' > "$repo/gone.sh"
+    gitc add -A; gitc commit -qm base
+    base_sha=$(gitc rev-parse HEAD)
+    gitc rm -q gone.sh
+    printf '#!/bin/sh\ntrue\n' > "$repo/kept.sh"
+    gitc add -A; gitc commit -qm head
+    # Tool stubs: the LAST planned gate (shellspec) records that it actually ran.
+    stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gatestub.XXXXXX")"
+    marker="$stubdir/last-gate-ran"
+    printf '#!/bin/sh\ntouch "%s"\n' "$marker" > "$stubdir/shellspec"
+    printf '#!/bin/sh\nexit 0\n' > "$stubdir/shellcheck"
+    chmod +x "$stubdir/shellspec" "$stubdir/shellcheck"
+    PATH="$stubdir:$PATH"
+  }
+  cleanup() { rm -rf "$repo" "$stubdir"; }
+  Before 'make_repo'
+  After 'cleanup'
+  script="scripts/agent/run-gates.sh"
+
+  It 'executes EVERY planned gate including the last one, and passes'
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 0
+    The output should include 'GATE PASS: sh -n kept.sh'
+    The output should include 'GATE PASS: shellspec'
+    The line 4 of output should equal 'GATES: PASS'
+    Assert [ -e "$marker" ]
+  End
+
+  It 'ignores deleted files instead of failing on their ghosts'
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 0
+    The output should not include 'gone.sh'
+    The output should include 'GATES: PASS'
+  End
+End

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -1,0 +1,66 @@
+#shellcheck shell=sh
+# run-gates.sh gates_for(): the touched-file-type -> canonical-gate-command mapping
+# (CLAUDE.md "Canonical gates" table). Pins per-file gates (php -l / sh -n / shellcheck
+# emit one command per file), whole-suite gates firing once, and empty input -> no gates.
+
+Describe 'run-gates.sh gates_for()'
+  # shellcheck disable=SC2034 # consumed by the Included script's source-only guard
+  AGENT_SOURCE_ONLY=1
+  Include scripts/agent/run-gates.sh
+
+  It 'maps a Python file to the four Python gates'
+    Data "tests/test_x.py"
+    When call gates_for
+    The line 1 of output should equal 'python3 -m pytest'
+    The line 2 of output should equal 'ruff check .'
+    The line 3 of output should equal 'ruff format --check .'
+    The line 4 of output should equal 'mypy tests/'
+    The lines of output should equal 4
+  End
+
+  It 'maps PHP files to per-file lint plus the three suite gates'
+    Data
+      #|src/a.inc
+      #|src/b.php
+    End
+    When call gates_for
+    The line 1 of output should equal 'php -l src/a.inc'
+    The line 2 of output should equal 'php -l src/b.php'
+    The line 3 of output should equal 'vendor/bin/phpunit'
+    The line 4 of output should equal 'composer phpstan'
+    The line 5 of output should equal 'composer phpcs -- --standard=phpcs.xml.dist src/'
+    The lines of output should equal 5
+  End
+
+  It 'maps shell files to per-file sh -n + shellcheck plus the dash-pinned shellspec'
+    Data "scripts/agent/x.sh"
+    When call gates_for
+    The line 1 of output should equal 'sh -n scripts/agent/x.sh'
+    The line 2 of output should equal 'shellcheck scripts/agent/x.sh'
+    # shellcheck disable=SC2016 # the literal $( ) is the pinned command text
+    The line 3 of output should equal 'shellspec --shell $(command -v dash)'
+    The lines of output should equal 3
+  End
+
+  It 'maps Markdown to markdownlint'
+    Data "docs/misc/notes.md"
+    When call gates_for
+    The output should equal 'npx markdownlint-cli2'
+  End
+
+  It 'combines gate families for a mixed diff'
+    Data
+      #|a.py
+      #|b.sh
+    End
+    When call gates_for
+    The output should include 'python3 -m pytest'
+    The output should include 'shellcheck b.sh'
+  End
+
+  It 'emits nothing for file types with no gates'
+    Data "src/usr/local/pkg/pfblockerng/info.xml"
+    When call gates_for
+    The output should equal ''
+  End
+End

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -1,0 +1,68 @@
+#shellcheck shell=sh
+# verify-red-proof.sh end-to-end against fixture git repos: a genuine red->green proof
+# passes; a test already green at HEAD~1 is rejected (RED-FAIL); an edited reproduction
+# test is rejected (FREEZE-FAIL); a dirty tree aborts before touching anything.
+
+Describe 'verify-red-proof.sh'
+  script="scripts/agent/verify-red-proof.sh"
+
+  gitc() { git -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+
+  make_repo() {
+    # $1 = HEAD~1 src content, $2 = HEAD src content
+    # ADR-47: under the pre-commit hook, exported GIT_DIR/GIT_INDEX_FILE would
+    # aim every fixture git op at the REAL repo -- scrub before any git runs.
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof.XXXXXX")"
+    git -C "$repo" init -q
+    printf '%s\n' "$1" > "$repo/src.txt"
+    printf 'grep -q GOOD src.txt\n' > "$repo/test_pin.sh"
+    gitc add -A
+    gitc commit -qm v1
+    printf '%s\n' "$2" > "$repo/src.txt"
+    echo other > "$repo/other.txt"   # v2 always has a change even when src is unchanged
+    gitc add -A
+    gitc commit -qm v2
+    pin_hash=$(gitc hash-object test_pin.sh)
+  }
+  cleanup() { rm -rf "$repo"; }
+  After 'cleanup'
+
+  It 'passes a genuine red->green proof and restores the tree'
+    make_repo BAD GOOD
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' \
+      --src src.txt --hash "test_pin.sh=$pin_hash"
+    The status should equal 0
+    The output should include 'FREEZE-OK: test_pin.sh'
+    The output should include 'RED-OK'
+    The output should include 'GREEN-OK'
+    The line 4 of output should equal 'VERDICT: PASS'
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'rejects a test that already passes against HEAD~1 (pins nothing)'
+    make_repo GOOD GOOD
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt
+    The status should equal 1
+    The output should include 'RED-FAIL'
+    The output should include 'VERDICT: FAIL'
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'rejects an edited reproduction test via the freeze hash'
+    make_repo BAD GOOD
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' \
+      --src src.txt --hash 'test_pin.sh=0000000000000000000000000000000000000000'
+    The status should equal 1
+    The output should include 'FREEZE-FAIL'
+    The output should include 'test edited between red and green'
+  End
+
+  It 'refuses a dirty tree (the gate re-derives from committed state)'
+    make_repo BAD GOOD
+    echo scratch > "$repo/uncommitted.txt"
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt
+    The status should equal 2
+    The stderr should include 'DIRTY-TREE'
+  End
+End

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -72,6 +72,23 @@ Describe 'verify-red-proof.sh'
     The output should equal ''
   End
 
+  It 'rejects a fix that does not satisfy its own pin (GREEN-FAIL)'
+    make_repo BAD BAD
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt
+    The status should equal 1
+    The output should include 'RED-OK'
+    The output should include 'GREEN-FAIL'
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'rejects a --src path with shell metacharacters at parse time'
+    make_repo BAD GOOD
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src 'src.txt; touch PWNED'
+    The status should equal 2
+    The stderr should include 'unsafe'
+    Assert [ ! -e "$repo/PWNED" ]
+  End
+
   It 'refuses a dirty tree (the gate re-derives from committed state)'
     make_repo BAD GOOD
     echo scratch > "$repo/uncommitted.txt"

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -58,6 +58,20 @@ Describe 'verify-red-proof.sh'
     The output should include 'test edited between red and green'
   End
 
+  It 'restores the src paths when SIGTERM interrupts the red run (dash semantics)'
+    make_repo BAD GOOD
+    interrupt_case() {
+      dash "$script" --worktree "$repo" --test-cmd 'sleep 30' --src src.txt >/dev/null 2>&1 &
+      pid=$!
+      sleep 1
+      kill -TERM "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      git -C "$repo" status --porcelain
+    }
+    When call interrupt_case
+    The output should equal ''
+  End
+
   It 'refuses a dirty tree (the gate re-derives from committed state)'
     make_repo BAD GOOD
     echo scratch > "$repo/uncommitted.txt"

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -49,3 +49,29 @@ Describe 'wait-checks.sh evaluate_checks()'
     The output should equal 'EMPTY'
   End
 End
+
+Describe 'wait-checks.sh loop verdicts (stub gh)'
+  setup_stub() {
+    stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/ghstub.XXXXXX")"
+    printf '#!/bin/sh\necho "$GH_STUB_CHECKS"\n' > "$stubdir/gh"
+    chmod +x "$stubdir/gh"
+    PATH="$stubdir:$PATH"
+  }
+  cleanup_stub() { rm -rf "$stubdir"; }
+  Before 'setup_stub'
+  After 'cleanup_stub'
+  script="scripts/agent/wait-checks.sh"
+
+  It 'reports TIMEOUT when checks stay pending through the cap'
+    export GH_STUB_CHECKS='[{"name":"pytest","bucket":"pending"}]'
+    When run sh "$script" --repo o/r --pr 1 --interval 0 --max-iter 2
+    The line 1 of output should equal 'TIMEOUT'
+  End
+
+  It 'honours the wall-clock deadline even when a verdict would be reached'
+    export GH_STUB_CHECKS='[{"name":"pytest","bucket":"pass"}]'
+    export PFB_WAIT_DEADLINE=1
+    When run sh "$script" --repo o/r --pr 1 --interval 0 --max-iter 3
+    The line 1 of output should equal 'TIMEOUT'
+  End
+End

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -1,0 +1,51 @@
+#shellcheck shell=sh
+#shellcheck disable=SC2034 # spec-set globals are consumed by the Included evaluate_checks()
+# wait-checks.sh evaluate_checks(): the CI-wait verdict reduction. Pins: fail/cancel win,
+# skipping counts as done-not-failed, PASS requires at least one relevant check (never
+# green-by-absence), and the coderabbit|snyk exclusion is honoured.
+
+Describe 'wait-checks.sh evaluate_checks()'
+  AGENT_SOURCE_ONLY=1
+  Include scripts/agent/wait-checks.sh
+  exclude='coderabbit|snyk'
+
+  It 'reports PASS when every relevant check passed'
+    When call evaluate_checks '[{"name":"pytest","bucket":"pass"},{"name":"ShellCheck","bucket":"pass"}]'
+    The output should equal 'PASS'
+  End
+
+  It 'reports PASS with skipping checks (done-not-failed)'
+    When call evaluate_checks '[{"name":"pytest","bucket":"pass"},{"name":"UI fan-out","bucket":"skipping"}]'
+    The output should equal 'PASS'
+  End
+
+  It 'reports FAIL on any fail bucket'
+    When call evaluate_checks '[{"name":"pytest","bucket":"fail"},{"name":"ShellCheck","bucket":"pass"}]'
+    The output should equal 'FAIL'
+  End
+
+  It 'reports FAIL on a cancelled check'
+    When call evaluate_checks '[{"name":"pytest","bucket":"cancel"}]'
+    The output should equal 'FAIL'
+  End
+
+  It 'reports PENDING while anything is still running'
+    When call evaluate_checks '[{"name":"pytest","bucket":"pending"},{"name":"ShellCheck","bucket":"pass"}]'
+    The output should equal 'PENDING'
+  End
+
+  It 'ignores excluded advisory bots -- a CodeRabbit fail never gates'
+    When call evaluate_checks '[{"name":"CodeRabbit","bucket":"fail"},{"name":"pytest","bucket":"pass"}]'
+    The output should equal 'PASS'
+  End
+
+  It 'ignores a Snyk error status the same way'
+    When call evaluate_checks '[{"name":"code/snyk (pfBlockerNG)","bucket":"fail"},{"name":"pytest","bucket":"pass"}]'
+    The output should equal 'PASS'
+  End
+
+  It 'reports EMPTY when no relevant check has registered (never green-by-absence)'
+    When call evaluate_checks '[{"name":"CodeRabbit","bucket":"pass"}]'
+    The output should equal 'EMPTY'
+  End
+End

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -53,7 +53,7 @@ End
 Describe 'wait-checks.sh loop verdicts (stub gh)'
   setup_stub() {
     stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/ghstub.XXXXXX")"
-    printf '#!/bin/sh\necho "$GH_STUB_CHECKS"\n' > "$stubdir/gh"
+    printf '#!/bin/sh\n[ -n "${GH_STUB_FAIL:-}" ] && exit 1\necho "$GH_STUB_CHECKS"\n' > "$stubdir/gh"
     chmod +x "$stubdir/gh"
     PATH="$stubdir:$PATH"
   }
@@ -73,5 +73,23 @@ Describe 'wait-checks.sh loop verdicts (stub gh)'
     export PFB_WAIT_DEADLINE=1
     When run sh "$script" --repo o/r --pr 1 --interval 0 --max-iter 3
     The line 1 of output should equal 'TIMEOUT'
+  End
+End
+
+Describe 'wait-checks.sh gh-failure detection'
+  setup_stub() {
+    stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/ghstub.XXXXXX")"
+    printf '#!/bin/sh\nexit 1\n' > "$stubdir/gh"
+    chmod +x "$stubdir/gh"
+    PATH="$stubdir:$PATH"
+  }
+  cleanup_stub() { rm -rf "$stubdir"; }
+  Before 'setup_stub'
+  After 'cleanup_stub'
+
+  It 'reports GH-ERROR after repeated gh failures instead of polling to a blind TIMEOUT'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 10
+    The status should equal 1
+    The line 1 of output should equal 'GH-ERROR'
   End
 End

--- a/tests/shell/agent_wait_reviewer_spec.sh
+++ b/tests/shell/agent_wait_reviewer_spec.sh
@@ -51,6 +51,31 @@ Describe 'wait-reviewer.sh classify()'
     The output should equal 'QUOTA 999'
   End
 
+  It 'reports QUOTA on the PR-review-limit phrasing (no "rate" in the notice)'
+    issuec='@user, you have reached your PR review limit. Next review available in: **46 minutes**'
+    When call classify
+    The output should equal 'QUOTA 46'
+  End
+
+  It 'reports QUOTA on the rate-limited-by-coderabbit phrasing'
+    issuec='This PR is rate limited by CodeRabbit.'
+    When call classify
+    The output should equal 'QUOTA 999'
+  End
+
+  Parameters
+    action_required
+    timed_out
+    cancelled
+    stale
+  End
+  It "reports QUOTA for the non-verdict Snyk state $1"
+    handle='snyk'
+    sinfo="$1 scan did not complete"
+    When call classify
+    The output should equal 'QUOTA 999'
+  End
+
   It 'reports DECLINE on a review-skipped-for-base-branch notice'
     issuec='Review skipped: reviews are limited to specific base branches.'
     When call classify

--- a/tests/shell/agent_wait_reviewer_spec.sh
+++ b/tests/shell/agent_wait_reviewer_spec.sh
@@ -63,6 +63,12 @@ Describe 'wait-reviewer.sh classify()'
     The output should equal 'PAUSE'
   End
 
+  It 'reports PAUSE on the emoji-only pause marker'
+    issuec='⏸ CodeRabbit'
+    When call classify
+    The output should equal 'PAUSE'
+  End
+
   It 'keeps polling (empty verdict) on unrelated chatter'
     issuec='Walkthrough coming soon...'
     When call classify
@@ -103,5 +109,79 @@ Describe 'wait-reviewer.sh gh-unavailable contract'
     The status should equal 3
     The stderr should include 'GH-UNAVAILABLE'
     The stderr should include 'mcp__github__'
+  End
+End
+
+Describe 'wait-reviewer.sh login matching (anchored substring)'
+  # shellcheck disable=SC2034
+  AGENT_SOURCE_ONLY=1
+  Include scripts/agent/wait-reviewer.sh
+  since=''
+
+  match_ids() {
+    # $1 = handle, $2 = fixture JSON; prints matched ids via the REAL jq filter
+    handle=$1
+    printf '%s' "$2" | jq "[$(jq_filter created_at) | .id] | join(\",\")" -r
+  }
+  FIXTURE='[{"user":{"login":"coderabbitai[bot]"},"id":1},{"user":{"login":"not-coderabbitai"},"id":2},{"user":{"login":"copilot-pull-request-reviewer[bot]"},"id":3}]'
+
+  It 'matches the [bot]-suffixed login from the bare handle'
+    When call match_ids coderabbitai "$FIXTURE"
+    The output should equal '1'
+  End
+
+  It 'matches the prefixed bot login from the short handle'
+    When call match_ids copilot "$FIXTURE"
+    The output should equal '3'
+  End
+
+  It 'matches a full bracketed login given verbatim (no regex-metachar breakage)'
+    When call match_ids 'copilot-pull-request-reviewer[bot]' "$FIXTURE"
+    The output should equal '3'
+  End
+
+  It 'does NOT match a login that merely contains the handle (anchored, not free substring)'
+    When call match_ids coderabbitai '[{"user":{"login":"not-coderabbitai"},"id":2}]'
+    The output should equal ''
+  End
+End
+
+Describe 'wait-reviewer.sh loop verdicts (stub gh)'
+  setup_stub() {
+    stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/ghstub.XXXXXX")"
+    printf '#!/bin/sh\ncase "$*" in *pulls/*/comments*) cat "$GH_STUB_INLINE" 2>/dev/null;; *) exit 0;; esac\n' > "$stubdir/gh"
+    chmod +x "$stubdir/gh"
+    PATH="$stubdir:$PATH"
+  }
+  cleanup_stub() { rm -rf "$stubdir"; }
+  Before 'setup_stub'
+  After 'cleanup_stub'
+  script="scripts/agent/wait-reviewer.sh"
+
+  It 'reports NOACK when the cap expires in ack mode with zero engagement'
+    unset GH_STUB_INLINE
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until ack --interval 0 --max-iter 2 --presence 0
+    The line 1 of output should equal 'NOACK'
+  End
+
+  It 'reports NOTPRESENT after the presence window with zero engagement'
+    unset GH_STUB_INLINE
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 9 --presence 1
+    The line 1 of output should equal 'NOTPRESENT'
+  End
+
+  It 'reports FINISHED when an inline comment id appears'
+    export GH_STUB_INLINE="$stubdir/inline.txt"
+    echo 42 > "$GH_STUB_INLINE"
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 3
+    The output should include 'FINISHED'
+  End
+
+  It 'honours the wall-clock deadline even when content would be found (No-orphaned-waits #1)'
+    export GH_STUB_INLINE="$stubdir/inline.txt"
+    echo 42 > "$GH_STUB_INLINE"
+    export PFB_WAIT_DEADLINE=1
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 3
+    The line 1 of output should equal 'TIMEOUT'
   End
 End

--- a/tests/shell/agent_wait_reviewer_spec.sh
+++ b/tests/shell/agent_wait_reviewer_spec.sh
@@ -1,0 +1,107 @@
+#shellcheck shell=sh
+#shellcheck disable=SC2034 # spec-set globals are consumed by the Included classify()
+# wait-reviewer.sh classify(): the reviewer-wait state machine's verdicts. Pins the
+# content-first rule (real review content beats a co-present quota notice), the QUOTA
+# resume-minutes parse (hours convert), DECLINE/PAUSE detection, ack-mode semantics,
+# Snyk status handling, and the gh-unavailable exit-3 contract.
+
+Describe 'wait-reviewer.sh classify()'
+  AGENT_SOURCE_ONLY=1
+  Include scripts/agent/wait-reviewer.sh
+
+  reset_state() {
+    mode='finished' handle='coderabbitai' inline='' review='' issuec='' sinfo=''
+  }
+  Before 'reset_state'
+
+  It 'reports FINISHED on inline comments even when a quota notice is also present'
+    inline='123'
+    issuec='You have reached your PR review limit. Next review available in: **46 minutes**'
+    When call classify
+    The output should equal 'FINISHED'
+  End
+
+  It 'reports FINISHED on the actionable-comments summary header'
+    issuec='Actionable comments posted: 3'
+    When call classify
+    The output should equal 'FINISHED'
+  End
+
+  It 'reports FINISHED on a clean no-actionable-comments pass'
+    issuec='No actionable comments were generated.'
+    When call classify
+    The output should equal 'FINISHED'
+  End
+
+  It 'reports QUOTA with the notice-stated minutes when no content exists'
+    issuec='Review limit reached. Next review available in: **46 minutes**'
+    When call classify
+    The output should equal 'QUOTA 46'
+  End
+
+  It 'converts an hours-denominated quota resume time to minutes'
+    issuec='Review limit reached. Next review available in: **2 hours**'
+    When call classify
+    The output should equal 'QUOTA 120'
+  End
+
+  It 'reports QUOTA 999 when the resume time is unparsable'
+    issuec='You have run out of usage credits.'
+    When call classify
+    The output should equal 'QUOTA 999'
+  End
+
+  It 'reports DECLINE on a review-skipped-for-base-branch notice'
+    issuec='Review skipped: reviews are limited to specific base branches.'
+    When call classify
+    The output should equal 'DECLINE'
+  End
+
+  It 'reports PAUSE when reviews are paused'
+    issuec='Reviews paused because the branch is too active.'
+    When call classify
+    The output should equal 'PAUSE'
+  End
+
+  It 'keeps polling (empty verdict) on unrelated chatter'
+    issuec='Walkthrough coming soon...'
+    When call classify
+    The output should equal ''
+  End
+
+  It 'reports ACK in ack mode on any handle message'
+    mode='ack'
+    issuec='anything at all'
+    When call classify
+    The output should equal 'ACK'
+  End
+
+  It 'stays silent in ack mode with zero engagement'
+    mode='ack'
+    When call classify
+    The output should equal ''
+  End
+
+  It 'reports QUOTA 999 for a Snyk error status (a skipped scan is never a clean pass)'
+    handle='snyk'
+    sinfo='error Code test limit reached'
+    When call classify
+    The output should equal 'QUOTA 999'
+  End
+
+  It 'reports FINISHED for a terminal Snyk verdict'
+    handle='snyk'
+    sinfo='success Scan completed'
+    When call classify
+    The output should equal 'FINISHED'
+  End
+End
+
+Describe 'wait-reviewer.sh gh-unavailable contract'
+  It 'exits 3 with the MCP fallback pointer when gh is absent'
+    When run sh -c 'PATH=/dev/null; . scripts/agent/agent_env.sh; require_gh'
+    The status should equal 3
+    The stderr should include 'GH-UNAVAILABLE'
+    The stderr should include 'mcp__github__'
+  End
+End

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -63,4 +63,9 @@ Describe 'work-branch.sh slugify() truncation edges'
     When call slugify "ip-recompute-a-priority-reorder"
     The output should equal 'ip-recompute-a-priority'
   End
+
+  It 'keeps a token whose end lands exactly on the 30-character cut'
+    When call slugify "aaaaaaaaaa-bbbbbbbbbb-cccccccc-ddd"
+    The output should equal 'aaaaaaaaaa-bbbbbbbbbb-cccccccc'
+  End
 End

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -36,6 +36,12 @@ Describe 'work-branch.sh branch naming'
     The output should equal 'issue/99'
   End
 
+  It 'rejects --base given without a value'
+    When run sh "$script" issue 5 title --base
+    The status should equal 2
+    The stderr should include 'usage'
+  End
+
   It 'rejects a non-numeric issue number'
     When run sh "$script" issue abc "title"
     The status should equal 2

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -1,0 +1,66 @@
+#shellcheck shell=sh
+# work-branch.sh: the CLAUDE.md branch-name sanitiser, pinned so it is never hand-derived
+# again. Covers both CLAUDE.md examples, the 30-char boundary truncation, emoji/non-ASCII
+# stripping, and the empty-slug bare form.
+
+Describe 'work-branch.sh branch naming'
+  script="scripts/agent/work-branch.sh"
+
+  It 'derives the CLAUDE.md issue example'
+    When run sh "$script" issue 43 "TLD-Allow KeyError on ..."
+    The output should equal 'issue/43-tld-allow-keyerror-on'
+  End
+
+  It 'derives the CLAUDE.md ADR example'
+    When run sh "$script" adr 10 "Zero_Downtime_DNSBL"
+    The output should equal 'adr/10-zero-downtime-dnsbl'
+  End
+
+  It 'truncates at a dash boundary, never mid-token and never trailing a dash'
+    When run sh "$script" issue 1173 "IP recompute: a priority reorder alone never triggers recompute"
+    The output should equal 'issue/1173-ip-recompute-a-priority'
+  End
+
+  It 'keeps a slug of exactly 30 characters intact'
+    When run sh "$script" issue 1 "abcde-fghij-klmno-pqrst-uvwxyz"
+    The output should equal 'issue/1-abcde-fghij-klmno-pqrst-uvwxyz'
+  End
+
+  It 'strips emoji and collapses the runs they leave'
+    When run sh "$script" issue 7 "🔥 Hot fix!!"
+    The output should equal 'issue/7-hot-fix'
+  End
+
+  It 'omits an empty slug (bare type/NN)'
+    When run sh "$script" issue 99 "🎉🎉🎉"
+    The output should equal 'issue/99'
+  End
+
+  It 'rejects a non-numeric issue number'
+    When run sh "$script" issue abc "title"
+    The status should equal 2
+    The stderr should include 'usage'
+  End
+
+  It 'rejects an unknown work-item kind'
+    When run sh "$script" bug 5 "title"
+    The status should equal 2
+    The stderr should include 'usage'
+  End
+End
+
+Describe 'work-branch.sh slugify() truncation edges'
+  # shellcheck disable=SC2034 # consumed by the Included script's source-only guard
+  AGENT_SOURCE_ONLY=1
+  Include scripts/agent/work-branch.sh
+
+  It 'keeps a single over-long token cut at 30 characters (no boundary exists)'
+    When call slugify "abcdefghijklmnopqrstuvwxyzabcdefghij"
+    The output should equal 'abcdefghijklmnopqrstuvwxyzabcd'
+  End
+
+  It 'drops a token that straddles the 30-character cut'
+    When call slugify "ip-recompute-a-priority-reorder"
+    The output should equal 'ip-recompute-a-priority'
+  End
+End


### PR DESCRIPTION
Extracts the mechanical procedures that CLAUDE.md and the skills restated as prose (and re-derived per session) into five tested POSIX scripts under `scripts/agent/`, per the extraction plan discussed in-session.

## Scripts

- **`wait-reviewer.sh`** — the reviewer-wait state machine previously inlined in `pr-comments`/`pr-merge-flow` (~126 heredoc lines across three skills): content-first FINISHED (real review content beats a co-present quota notice — the exact bug class fixed once before in only one of the copies), CodeRabbit QUOTA with the notice's own resume minutes (hours convert), DECLINE/PAUSE, Snyk status handling (`error` = skipped scan, never a clean pass), ack mode, NOTPRESENT presence window.
- **`wait-checks.sh`** — the CI checks wait from `pr-merge`: advisory bots excluded, `skipping` counts as done, PASS requires a registered check (never green-by-absence).
- **`verify-red-proof.sh`** — mechanical red→green re-execution (CLAUDE.md THE GATE item 2): freeze-hash check, revert src to `HEAD~1` (tests stay), expect FAIL, restore, expect PASS; refuses a dirty tree; restores on every exit path.
- **`run-gates.sh`** — canonical-gates runner mapped from the diff's touched file types (the CLAUDE.md table implemented once; `--plan` prints the commands; missing tools reported loudly, `--allow-missing` to soften).
- **`work-branch.sh`** — the branch-name sanitiser (both CLAUDE.md examples pinned, 30-char boundary truncation, emoji stripping, bare-form fallback) + optional worktree cutter with collision `-epoch` suffixing.

## Portability contract (managed cloud environments)

`agent_env.sh` carries it: all network access rides the `gh`/`git` CLIs (managed environments proxy git/ssh via localhost — the CLIs inherit it, raw endpoints don't); `gh` absent → exit 3 with an explicit pointer to fall back to `mcp__github__*` wakeup-paced checks (MCP tools are harness tools, unreachable from a shell); other missing tools → exit 4. The scripts are agent-maintained: when an environment quirk breaks one, the agent fixes the script and lands it via the normal flow.

## Safety fix found while testing

The red-proof spec's fixture `git commit`, run under the pre-commit hook, inherited the hook-exported `GIT_DIR`/`GIT_INDEX_FILE` and operated on the real repository (stranding staged deletions when interrupted). Git-touching scripts and the spec now scrub the GIT_* env via the existing ADR-47 `scripts/lib/git-env-scrub.sh`; verified by running the spec under hook-style GIT_* env with a clean tree after.

## Pre-commit change

The shellspec step is now scoped to IMPACTED specs (staged spec files + specs naming a staged script's basename). The full suite runs minutes per commit and an interrupted run can strand spec-mutated state; CI remains the full-suite hard gate.

## Testing

Five shellspec specs (42 examples) run under dash, covering the classify/evaluate state machines (incl. QUOTA parsing, content-beats-quota, exclusion rules), red-proof end-to-end against fixture repos (PASS / RED-FAIL / FREEZE-FAIL / dirty-tree), the gates mapping, the sanitiser (both CLAUDE.md examples + truncation edges), and the gh-unavailable exit-3 contract. Full local suite: 585 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8cr16xTZ9ixtbJndKKjrd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added work-branch/worktree creation with safe, sanitized branch naming.
  * Added canonical “gates” runner that plans or executes checks based on changed files.
  * Added red→green proof verifier with freeze/hash validation and workspace restore.
  * Added CI check and reviewer polling helpers with clear, deterministic verdicts.
  * Added shared environment/tool availability checks to standardize script behavior.
* **Improvements**
  * ShellSpec gating now runs only impacted specs, with full-suite fallback for spec scaffolding.
* **Tests**
  * Added ShellSpec coverage for gates planning/execution, proof verifier scenarios, polling timeouts/failures, and branch-name edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->