### PR TITLE
pfblockerng: render per-feed recompute stats table from the .counts artifact

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -455,6 +455,15 @@ this pass" (`$pfb_recompute_ran_v4`/`$pfb_recompute_ran_v6`), not "this alias's 
 changed", so a quiet alias whose content was rewritten by a sibling's trigger still gets
 suppression/reporting applied to it.
 
+**Per-feed update-log stats table (issue #1174).** After a successful swap,
+`pfb_recompute_render_stats()` renders the pass's own `.counts` artifact as a per-feed
+Alias/Original/Final table on stdout (the caller's `{$elog}` pipes it into the update log),
+restoring the table the retired `duplicate()` printed. Original comes from the same-pass
+`.aggcount` sidecar (falling back to the `.orig` row count, then `?`); the legacy Master
+column is retired — recompute appends deny rows to the masterfile verbatim, so Master always
+equals Final. Like the legacy table, the numbers are pre-suppression; `closingprocess()`
+keeps its own post-suppression re-reads and never consumes `.counts`.
+
 **Both dRep and pRep on: the execution order flipped.** The old incremental path ran pMax's
 `exec` first, then dMax's — the reverse of recompute's order: recompute applies dMax to every
 family alias first (inside its own `pfb_recompute()` pass), and the legacy pMax `exec` runs

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -784,7 +784,8 @@ pfb_aggregate() {
 #                  with the updated memberlist").
 #   $4 countsfile  Output path for the per-alias row-count artifact ("alias
 #                  count" lines, one per memberlist alias including 0),
-#                  replacing every caller's post-hoc `grep -c` re-read.
+#                  rendered at pass end by pfb_recompute_render_stats() as
+#                  the per-feed update-log stats table (issue #1174).
 #   $5 dedup       'on' | 'off'. 'on' runs the cumulative grepcidr
 #                  containment prune (Stage A) and emits masterfile/
 #                  mastercat; 'off' plain-copies every snapshot (overlaps

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1051,7 +1051,9 @@ pfb_recompute() {
 	fi
 
 	pfb_recompute_finish
-	return $?
+	rec_rc=$?
+	[ "${rec_rc}" -eq 0 ] && pfb_recompute_render_stats
+	return "${rec_rc}"
 }
 
 # One alias's final emit: per-alias sort into the .txt.new sibling, masterfile
@@ -1436,6 +1438,32 @@ pfb_recompute_finish() {
 	fi
 
 	echo "recompute [ ${rec_family} ]: ${rec_prio} feed(s) processed."
+}
+
+# issue #1174: renders the .counts artifact as a per-feed Original/Final table
+# on stdout (pre-suppression, like the retired duplicate() table) -- the PHP
+# caller already pipes recompute's stdout into the update log.
+pfb_recompute_render_stats() {
+	[ -f "${rec_countsfile}" ] || return 0
+
+	echo
+	echo "===[ Recompute Stats [ ${rec_family} ] ]====================="
+	echo '  ------------------------------------------------------'
+	printf '%-36s %-10s %-10s\n' '  Alias' 'Original' 'Final'
+	echo '  ------------------------------------------------------'
+	while IFS=' ' read -r rec_alias rec_countf; do
+		[ -z "${rec_alias}" ] && continue
+		if [ -f "${pfborig}${rec_alias}.aggcount" ]; then
+			rec_orig="$(cat "${pfborig}${rec_alias}.aggcount")"
+		elif [ -f "${pfborig}${rec_alias}.orig" ]; then
+			rec_orig="$(grep -cv '^#\|^$' "${pfborig}${rec_alias}.orig")"
+		else
+			rec_orig='?'
+		fi
+		printf '%-36s %-10s %-10s\n' "  ${rec_alias}" "${rec_orig}" "${rec_countf}"
+	done < "${rec_countsfile}"
+	echo '  ------------------------------------------------------'
+	return 0
 }
 
 

--- a/tests/shell/pfblockerng_recompute_spec.sh
+++ b/tests/shell/pfblockerng_recompute_spec.sh
@@ -1015,9 +1015,9 @@ Describe 'pfb_recompute() renders a per-feed Original/Final stats table on stdou
 	End
 
 	It 'a blank line in the .counts artifact is skipped -- never rendered as an empty/garbage row (hostile input)'
-		# shellcheck disable=SC2034  # rec_countsfile/rec_family read by the sourced renderer
 		rec_countsfile="${work}/hostile.counts"
 		printf 'Real_v4 3\n\n' > "$rec_countsfile"
+		# shellcheck disable=SC2034  # read by the sourced renderer
 		rec_family='v4'
 
 		When call pfb_recompute_render_stats

--- a/tests/shell/pfblockerng_recompute_spec.sh
+++ b/tests/shell/pfblockerng_recompute_spec.sh
@@ -932,3 +932,110 @@ Describe 'pfb_recompute() coverage-matrix gap rows (issue #1084 review: dedup=of
 		The contents of file "$countsfile" should include 'PlaceholderRow_v4 1'
 	End
 End
+
+Describe 'pfb_recompute() renders a per-feed Original/Final stats table on stdout from its own .counts artifact (issue #1174)'
+	# shellcheck disable=SC2034  # consumed by the sourced pfb_recompute()
+	setup() {
+		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/recstats.XXXXXX")"
+		snap="${work}/snap"; pfbdeny="${work}/deny/"; pfbmatch="${work}/match/"
+		pfborig="${work}/orig/"
+		mkdir -p "$snap" "$pfbdeny" "$pfbmatch" "$pfborig"
+		tmpdir="${work}/tmp"; mkdir -p "$tmpdir"
+		masterfile="${work}/master"; mastercat="${work}/mastercat"
+		errorlog="${work}/err.log"
+		ip_placeholder3='240.0.0'
+		pathgrepcidr="${work}/grepcidr"; make_grepcidr_stub "$pathgrepcidr"
+		memberlist="${work}/members"
+		countsfile="${work}/counts"
+	}
+	cleanup() { rm -rf "$work"; }
+	BeforeAll 'pfb_source'
+	Before 'setup'
+	After 'cleanup'
+
+	It 'v4: renders the title, the Alias/Original/Final header, and one row per fixture feed with its Original (.aggcount) and Final numbers'
+		printf '192.0.2.10\n192.0.2.11\n' > "${snap}/FeedA_v4.orig"
+		printf '192.0.2.10\n192.0.2.12\n' > "${snap}/FeedB_v4.orig"
+		printf '2\n' > "${pfborig}FeedA_v4.aggcount"
+		printf '2\n' > "${pfborig}FeedB_v4.aggcount"
+		printf '%s\n%s\n' "${snap}/FeedA_v4.orig" "${snap}/FeedB_v4.orig" > "$memberlist"
+		row_a="$(printf '%-36s %-10s %-10s' '  FeedA_v4' '2' '2')"
+		row_b="$(printf '%-36s %-10s %-10s' '  FeedB_v4' '2' '1')"
+
+		When call pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
+		The status should be success
+		The output should include '===[ Recompute Stats [ v4 ] ]'
+		The output should include "$(printf '%-36s %-10s %-10s' '  Alias' 'Original' 'Final')"
+		The output should include "$row_a"
+		The output should include "$row_b"
+	End
+
+	It 'v6: renders the same table shape for a v6 pass'
+		printf '2001:db8::/32\n' > "${snap}/SixA_v6.orig"
+		printf '1\n' > "${pfborig}SixA_v6.aggcount"
+		printf '%s\n' "${snap}/SixA_v6.orig" > "$memberlist"
+		row="$(printf '%-36s %-10s %-10s' '  SixA_v6' '1' '1')"
+
+		When call pfb_recompute recompute v6 "$memberlist" "$countsfile" on off
+		The status should be success
+		The output should include '===[ Recompute Stats [ v6 ] ]'
+		The output should include "$row"
+	End
+
+	It 'a zero-final-count feed still renders its row with Final 0 (Original also 0, from its .aggcount)'
+		: > "${snap}/ZeroFeed_v4.orig"
+		printf '0\n' > "${pfborig}ZeroFeed_v4.aggcount"
+		printf '%s\n' "${snap}/ZeroFeed_v4.orig" > "$memberlist"
+		row="$(printf '%-36s %-10s %-10s' '  ZeroFeed_v4' '0' '0')"
+
+		When call pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
+		The status should be success
+		The output should include "$row"
+	End
+
+	It 'falls back to the raw .orig row count when the .aggcount sidecar is missing (pre-1084 upgrade case)'
+		printf '192.0.2.20\n' > "${snap}/OrigOnly_v4.orig"
+		printf '192.0.2.20\n192.0.2.21\n192.0.2.22\n#comment\n\n' > "${pfborig}OrigOnly_v4.orig"
+		printf '%s\n' "${snap}/OrigOnly_v4.orig" > "$memberlist"
+		row="$(printf '%-36s %-10s %-10s' '  OrigOnly_v4' '3' '1')"
+
+		When call pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
+		The status should be success
+		The output should include "$row"
+	End
+
+	It "renders '?' for Original when neither .aggcount nor .orig exists for the alias"
+		printf '203.0.113.5\n' > "${snap}/NoOrigin_v4.orig"
+		printf '%s\n' "${snap}/NoOrigin_v4.orig" > "$memberlist"
+		row="$(printf '%-36s %-10s %-10s' '  NoOrigin_v4' '?' '1')"
+
+		When call pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
+		The status should be success
+		The output should include "$row"
+	End
+
+	It 'a blank line in the .counts artifact is skipped -- never rendered as an empty/garbage row (hostile input)'
+		# shellcheck disable=SC2034  # rec_countsfile/rec_family read by the sourced renderer
+		rec_countsfile="${work}/hostile.counts"
+		printf 'Real_v4 3\n\n' > "$rec_countsfile"
+		rec_family='v4'
+
+		When call pfb_recompute_render_stats
+		The status should be success
+		The output should include "$(printf '%-36s %-10s %-10s' '  Real_v4' '?' '3')"
+		The lines of output should equal 7
+	End
+
+	It 'aborts the whole pass (grepcidr rc>=2): the .counts artifact never gets swapped in, so no stats table renders and the failure status is unaffected'
+		printf '5.5.5.5\n' > "${snap}/A_v4.orig"
+		printf '9.9.9.9\n' > "${snap}/B_v4.orig"
+		printf '%s\n%s\n' "${snap}/A_v4.orig" "${snap}/B_v4.orig" > "$memberlist"
+		printf '#!/bin/sh\nexit 2\n' > "$pathgrepcidr"
+		chmod +x "$pathgrepcidr"
+
+		When call pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
+		The status should be failure
+		The output should not include '===[ Recompute Stats'
+		The path "$countsfile" should not be exist
+	End
+End


### PR DESCRIPTION
Fixes #1174.

PR #1171's batch recompute writes a per-family `pfb_recompute_<family>.counts` artifact that had zero consumers, and the per-feed Original/Master/Final stats table the retired `duplicate()` printed into the update log was lost — a user-visible log regression.

## What this does

- New `pfb_recompute_render_stats()` renders the pass's own `.counts` artifact as a per-feed **Alias / Original / Final** table on recompute stdout, which the PHP caller's `{$elog}` already pipes into the update log. It runs only after a successful `pfb_recompute_finish` swap and never alters the pass's exit code.
- **Original** comes from the same-pass `.aggcount` sidecar, falling back to the `.orig` row count (mirroring `closingprocess()`'s derivation), then `?` when neither exists.
- The legacy **Master** column is retired: recompute appends deny rows to the masterfile verbatim, so Master always equals Final. Per-feed sanity is likewise vacuous now; the pass-level `Database Sanity check` in `closingprocess()` still covers it.
- `closingprocess()` is untouched — its FINAL Processing report re-reads live files post-suppression by design, so substituting the pre-suppression `.counts` values there would change reported numbers.
- Docs reconciled: the `$4 countsfile` usage header no longer claims the artifact replaces the callers' post-hoc `grep -c` re-reads (that consumer was never built — the renderer is the consumer), and architecture-notes documents the table.

## Tests

Seven new ShellSpec examples in `tests/shell/pfblockerng_recompute_spec.sh` (run under dash): v4 + v6 table rendering with fixture-derived numbers, zero-count row, `.aggcount`-missing fallback, `?` case, blank-line-in-`.counts` hostile input (exact 7-line output pinned), and the abort-path guard (no table, failure status unaffected, `.counts` never swapped in). Six of seven executed red before the fix; red-time spec hash equals the committed file (verified by `verify-red-proof.sh`: revert src → FAIL, restore → PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxB6ePGeNCz6fJFXTvFHFg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-feed recompute statistics showing Original and Final counts for IPv4 and IPv6 feeds.
  * Statistics are displayed after successful processing and support feeds with zero results.

* **Bug Fixes**
  * Improved handling of missing count data and blank entries.
  * Prevented incomplete processing results from being published when validation fails.

* **Documentation**
  * Documented the new statistics table and count sources in the architecture notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->