### PR TITLE
pfblockerng: remove write-only $tld_segments max from tld_analysis()

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8158,7 +8158,6 @@ function tld_analysis() {
 	if (!empty($tld_blacklist)) {
 
 		$tld_cnt	= 0;
-		$tld_segments	= 0;
 		pfb_logger(" Blocking full TLD/Sub-Domain(s)... |", 1);
 
 		foreach ($tld_blacklist as $tld => $key) {
@@ -8170,7 +8169,6 @@ function tld_analysis() {
 			// DNSBL python - TLD Blacklist (Set logging type to enabled '1')
 			$tld_cnt++;
 			$pfb_found = TRUE;
-			$tld_segments = @max((array((substr_count($tld, '.') +1), $tld_segments) ?: 1));
 
 			pfb_logger("{$tld}|", 1);
 			@fwrite($p_zone, pfb_dnsbl_ndjson_emit_domain_row($tld, '1', 'DNSBL_TLD', 'DNSBL_TLD'));

--- a/tests/php/PythonWhitelistTldSegTest.php
+++ b/tests/php/PythonWhitelistTldSegTest.php
@@ -135,8 +135,8 @@ final class PythonWhitelistTldSegTest extends TestCase
 	/**
 	 * Brace-counts from `function {$name}(` to its matching closing brace,
 	 * so the assertions below inspect ONLY that function's body — never a
-	 * neighbour (tld_analysis() has its own, differently-purposed
-	 * $tld_segments and must stay untouched).
+	 * neighbour (tld_analysis()'s own write-only $tld_segments was removed
+	 * by issue #1168, pinned by TldAnalysisTldSegTest).
 	 */
 	private function functionBody(string $name): string
 	{

--- a/tests/php/TldAnalysisTldSegTest.php
+++ b/tests/php/TldAnalysisTldSegTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1168 — tld_analysis() computed a per-TLD running max of label
+ * segments into a function-LOCAL $tld_segments, then discarded it: nothing
+ * reads the value, it feeds no output file, log line, or global (the
+ * blacklist branch's real outputs — the synthetic DNSBL_TLD row, $tld_cnt,
+ * $tlds pruning — are byte-pinned by DnsblNdjsonFlipTest). Dead-code
+ * sibling of issue #1155; this pins that the computation is gone.
+ */
+#[CoversFunction('tld_analysis')]
+final class TldAnalysisTldSegTest extends TestCase
+{
+	private const SRC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+
+	/**
+	 * Brace-counts from `function {$name}(` to its matching closing brace,
+	 * so the assertion below inspects ONLY tld_analysis()'s body — never a
+	 * neighbour's same-named local.
+	 */
+	private function functionBody(string $name): string
+	{
+		$source = file_get_contents(self::SRC);
+		$this->assertNotFalse($source, 'failed to read pfblockerng.inc');
+
+		$needle = "\nfunction {$name}(";
+		$start = strpos($source, $needle);
+		$this->assertNotFalse($start, "function {$name}() not found in source");
+		$start++; // step past the leading \n onto 'function'
+
+		$braceOpen = strpos($source, '{', $start);
+		$this->assertNotFalse($braceOpen, "no opening brace found for {$name}()");
+
+		$depth = 0;
+		for ($i = $braceOpen, $len = strlen($source); $i < $len; $i++) {
+			if ($source[$i] === '{') {
+				$depth++;
+			} elseif ($source[$i] === '}') {
+				$depth--;
+				if ($depth === 0) {
+					$body = substr($source, $start, $i - $start + 1);
+					$this->assertNotSame('', trim($body), "empty body extracted for {$name}() -- vacuous extraction");
+					return $body;
+				}
+			}
+		}
+		$this->fail("no matching closing brace found for {$name}()");
+	}
+
+	public function testTldAnalysisHasNoTldSegmentsToken(): void
+	{
+		$body = $this->functionBody('tld_analysis');
+		$this->assertStringNotContainsString('tld_segments', $body,
+			'issue #1168: the write-only $tld_segments max must be deleted, not just unused');
+	}
+}


### PR DESCRIPTION
## Summary

`tld_analysis()`'s TLD-blacklist branch computed a running max of TLD label segments into a function-local `$tld_segments` that nothing ever reads: the token appears 3 times in the whole function (verified via `token_get_all`), all inside the two write-only assignments; the function's only globals are `$pfb`/`$tlds`, so the value cannot escape. Dead-code sibling of #1155 (PR #1165), which removed the python-whitelist copies and explicitly deferred this one.

## Changes

- Delete the two write-only `$tld_segments` statements (init + per-iteration `@max`) from the `tld_blacklist` branch.
- New `tests/php/TldAnalysisTldSegTest.php`: source-shape assertion (brace-count-scoped to `tld_analysis()`, mirroring the #1155 precedent in `PythonWhitelistTldSegTest`) pinning the token gone. Authored and executed RED before the deletion, frozen byte-identical (red-time blob `f4be0d08` = committed blob), GREEN zero-edits after.
- Reconcile the now-stale docblock in `PythonWhitelistTldSegTest.php` that said tld_analysis's `$tld_segments` "must stay untouched".

## Behaviour preservation

No new behavioural oracle needed: `DnsblNdjsonFlipTest` already byte-pins the non-empty `tldblacklist` branch's outputs (synthetic DNSBL_TLD row, py_zone/py_data) — green before AND after the deletion. Retirement grep for `tld_segments` over `src/ scripts/ .github/workflows/` is zero-hit.

## Gates

- `php -l` per touched file, full `vendor/bin/phpunit`, `composer phpstan` ([OK] No errors), `composer phpcs` (exit 0)
- `verify-red-proof.sh`: FREEZE-OK / RED-OK / GREEN-OK / VERDICT: PASS

Fixes #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBkLQcR4cz5QCq6AVjdzuM