### PR TITLE
agent: keep run-gates.sh command loop intact past stdin-reading gates

### DIFF
--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -68,7 +68,9 @@ run_gate() {
 		[ "$allow_missing" -eq 1 ] || overall=1
 		return 0
 	fi
-	if (cd "$worktree" && sh -c "$1" >/dev/null 2>&1); then
+	# issue #1194: </dev/null -- a stdin-reading gate (full PHPUnit) otherwise eats
+	# the command loop's remaining gate lines, silently skipping those gates.
+	if (cd "$worktree" && sh -c "$1" </dev/null >/dev/null 2>&1); then
 		printf 'GATE PASS: %s\n' "$1"
 	else
 		printf 'GATE FAIL: %s\n' "$1"

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -128,4 +128,19 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     The output should not include 'gone.sh'
     The output should include 'GATES: PASS'
   End
+
+  # issue #1194: a gate command that reads stdin (the full PHPUnit suite does) must
+  # not consume the command loop's remaining gate lines — they silently vanished
+  # with neither a GATE line nor a SKIP, and GATES: PASS still printed.
+  It 'runs the gates queued after a stdin-reading gate command'
+    stdin_eating_gate() {
+      printf '#!/bin/sh\ncat >/dev/null\nexit 0\n' > "$stubdir/shellcheck"
+      sh "$script" --worktree "$repo" --diff "$base_sha"
+    }
+    When call stdin_eating_gate
+    The status should equal 0
+    The output should include 'GATE PASS: shellcheck kept.sh'
+    The output should include 'GATE PASS: shellspec'
+    Assert [ -e "$marker" ]
+  End
 End


### PR DESCRIPTION
## Summary

Fixes #1194: `run_gate` executed each gate with `sh -c "$1"` inheriting the command loop's pipe as stdin. A gate command that reads stdin — the full PHPUnit suite does — consumed the remaining gate lines, so on any PHP-touching diff `composer phpstan` and `composer phpcs` were silently dropped (no GATE line, not even SKIP) while `GATES: PASS` still printed.

## Fix

One line: feed the gate command `</dev/null`. Discriminating probe that confirmed the cause (a `--filter`ed phpunit run does NOT eat stdin; the full suite does) is in the issue.

## Test (red-first)

New case in `tests/shell/agent_run_gates_spec.sh`: a stub `shellcheck` gate that eats stdin (`cat >/dev/null`, the phpunit analogue) must not stop the queued `shellspec` gate from running. Executed RED before the fix (12 examples, 1 failure — the shellspec gate line and its ran-marker missing), frozen byte-identical (red-time blob `d1b3767d` = committed blob), GREEN zero-edits after (12/12).

## End-to-end validation

Fixed runner over a real PHP-touching diff (`--diff origin/devel~1`) now prints all six PHP gate lines — `composer phpstan` / `composer phpcs` included — plus the shell rows, all PASS. Sibling-axis grep: the pattern (command-exec inside a stdin-fed read loop) exists nowhere else under `scripts/agent/` (`verify-red-proof.sh` runs its `sh -c` sequentially with no later stdin reads; `wait-*.sh` have no exec loops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBkLQcR4cz5QCq6AVjdzuM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gate execution so commands that read from standard input no longer interrupt or skip subsequent checks.
  * Ensured all queued gates continue running and report the correct overall result.

* **Tests**
  * Added coverage confirming later gates execute successfully after a stdin-consuming command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->