### PR TITLE
pfblockerng: surface IP-recompute memberlist write failure

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5101,6 +5101,15 @@ function pfb_ip_recompute_memberlist_content(array $paths): string {
 	return $paths ? implode("\n", $paths) . "\n" : '';
 }
 
+// issue #1184: log a failed memberlist write -- a silent failure re-ran the full recompute every tick.
+function pfb_ip_recompute_memberlist_write(string $memberlist_path, array $paths): int|false {
+	$result = @file_put_contents($memberlist_path, pfb_ip_recompute_memberlist_content($paths), LOCK_EX);
+	if ($result === FALSE) {
+		pfb_logger("\nIP-Recompute: write failed for [ {$memberlist_path} ] -- recompute still runs this pass", 2);
+	}
+	return $result;
+}
+
 /**
  * issue #1173: a pure IPv4/IPv6 Deny-list priority reorder flips no feed-change repcheck --
  * no feed content changed -- yet recompute ownership follows memberlist ORDER
@@ -19064,7 +19073,7 @@ function sync_package_pfblockerng($cron='') {
 		}
 		$pfb_rec_memberlist = "{$pfb['dbdir']}/pfb_recompute_{$pfb_rec_family}.members";
 		$pfb_rec_countsfile = "{$pfb['dbdir']}/pfb_recompute_{$pfb_rec_family}.counts";
-		@file_put_contents($pfb_rec_memberlist, pfb_ip_recompute_memberlist_content($pfb_rec_paths), LOCK_EX);
+		pfb_ip_recompute_memberlist_write($pfb_rec_memberlist, $pfb_rec_paths);
 
 		// Reputation is v4-only (§1.2); the v6 pass is always a dedup-only passthrough.
 		$pfb_rec_repmode = ($pfb_rec_family === 'v4') ? $pfb_rec_matrix['repmode'] : 'off';

--- a/tests/php/IpRecomputeOrderChangeTest.php
+++ b/tests/php/IpRecomputeOrderChangeTest.php
@@ -216,14 +216,98 @@ EOT;
 	{
 		$source = $this->source();
 		$this->assertStringContainsString(
-			"\t\t@file_put_contents(\$pfb_rec_memberlist, pfb_ip_recompute_memberlist_content(\$pfb_rec_paths), LOCK_EX);",
+			"\t\tpfb_ip_recompute_memberlist_write(\$pfb_rec_memberlist, \$pfb_rec_paths);",
 			$source,
-			'the invocation loop must write the memberlist through the shared helper, not an inline implode'
+			'the invocation loop must write the memberlist through the failure-checked helper (issue #1184)'
+		);
+		$this->assertStringNotContainsString(
+			'@file_put_contents($pfb_rec_memberlist',
+			$source,
+			'the raw suppressed write must be gone -- a write failure must be logged, not silently swallowed'
 		);
 		$this->assertStringNotContainsString(
 			"\$pfb_rec_paths ? (implode(\"\\n\", \$pfb_rec_paths) . \"\\n\") : ''",
 			$source,
 			'the old inline implode ternary must be gone -- otherwise the checker and the writer could drift out of format sync'
 		);
+	}
+
+	// --- Part C: pfb_ip_recompute_memberlist_write() behaviour rows (issue #1184) --------
+
+	/** Count of $marker in the CURRENT log (see AliasDeltaApplyTest::countLogMarker). */
+	private function countLogMarker(string $marker): int
+	{
+		global $pfb;
+		@mkdir($pfb['logdir'], 0777, TRUE);
+		$contents = @file_get_contents($pfb['log'] ?? '');
+		if ($contents === FALSE || $contents === '') {
+			return 0;
+		}
+		return substr_count($contents, $marker);
+	}
+
+	public function testWriteSucceedsSilentlyAndRoundTripsThroughOrderChanged(): void
+	{
+		$headers = array('FeedA_v4', 'FeedB_v4');
+		$paths   = array();
+		foreach ($headers as $header) {
+			$paths[] = pfb_ip_recompute_snapshot_path($this->snapdir, $header);
+		}
+		$marker = "write failed for [ {$this->memberlist} ]";
+		$before = $this->countLogMarker($marker);
+
+		$got = pfb_ip_recompute_memberlist_write($this->memberlist, $paths);
+
+		$this->assertNotFalse($got, 'a writable target must not report failure');
+		$this->assertSame($before, $this->countLogMarker($marker), 'a successful write must not log a failure');
+		$this->assertSame(
+			pfb_ip_recompute_memberlist_content($paths),
+			file_get_contents($this->memberlist),
+			'the written content must be exactly the shared serialization'
+		);
+		$this->assertFalse(
+			pfb_ip_recompute_order_changed($headers, $this->snapdir, $this->memberlist),
+			'the just-written memberlist must round-trip as unchanged against its own headers'
+		);
+	}
+
+	public function testWriteToNonexistentParentDirLogsTheTargetPath(): void
+	{
+		$target = "{$this->root}/missing-parent/pfb_recompute_v4.members";
+		$marker = "write failed for [ {$target} ]";
+		$before = $this->countLogMarker($marker);
+
+		$got = pfb_ip_recompute_memberlist_write($target, array('a'));
+
+		$this->assertFalse($got, 'a nonexistent parent directory must fail the write');
+		$this->assertSame($before + 1, $this->countLogMarker($marker), 'the failure must be logged with the target path');
+	}
+
+	public function testWriteToReadOnlyTargetLogsFailure(): void
+	{
+		if (function_exists('posix_getuid') && posix_getuid() === 0) {
+			$this->markTestSkipped('root bypasses file permissions; cannot simulate a write-denied target');
+		}
+		file_put_contents($this->memberlist, 'stale');
+		chmod($this->memberlist, 0444);
+		$marker = "write failed for [ {$this->memberlist} ]";
+		$before = $this->countLogMarker($marker);
+
+		$got = pfb_ip_recompute_memberlist_write($this->memberlist, array('a'));
+
+		$this->assertFalse($got, 'a 0444 target must fail the write');
+		$this->assertSame($before + 1, $this->countLogMarker($marker), 'the failure must be logged');
+	}
+
+	public function testEmptyPathsWritesZeroByteContentWithoutLogging(): void
+	{
+		$marker = "write failed for [ {$this->memberlist} ]";
+		$before = $this->countLogMarker($marker);
+
+		$got = pfb_ip_recompute_memberlist_write($this->memberlist, array());
+
+		$this->assertSame(0, $got, 'file_put_contents of an empty string returns int 0, not FALSE');
+		$this->assertNotFalse($got, 'int 0 must not be misread as a failure by a loose comparison');
+		$this->assertSame($before, $this->countLogMarker($marker), 'int 0 (zero bytes written) must never be logged as a failure');
 	}
 }

--- a/tests/php/IpRecomputeOrderChangeTest.php
+++ b/tests/php/IpRecomputeOrderChangeTest.php
@@ -16,8 +16,12 @@ use PHPUnit\Framework\TestCase;
  *   pfb_ip_recompute_order_changed()      TRUE when the family's would-be recompute
  *                                         memberlist order differs from the memberlist file
  *                                         the last recompute pass wrote (or none exists yet).
+ *   pfb_ip_recompute_memberlist_write()   the invocation loop's baseline write: LOCK_EX via
+ *                                         the shared serializer, strict FALSE check, logged
+ *                                         failure (issue #1184).
  *
- * Part A exercises both pure helpers directly. Part B is a source tripwire suite: the
+ * Part A exercises the pure helpers directly; Part C does the same for the write helper's
+ * success/failure/empty-content behaviour. Part B is a source tripwire suite: the
  * detection wiring lives in sync_package_pfblockerng(), thousands of lines of top-level
  * script code that PHPUnit cannot call as a function -- so wiring correctness is pinned by
  * exact substring assertions against the CURRENT file content (house pattern:
@@ -25,6 +29,7 @@ use PHPUnit\Framework\TestCase;
  * actually shipped.
  */
 #[CoversFunction('pfb_ip_recompute_memberlist_content')]
+#[CoversFunction('pfb_ip_recompute_memberlist_write')]
 #[CoversFunction('pfb_ip_recompute_order_changed')]
 final class IpRecomputeOrderChangeTest extends TestCase
 {


### PR DESCRIPTION
Fixes #1184.

The IP-recompute invocation loop wrote its per-family memberlist baseline via an @-suppressed `file_put_contents` with the return value unchecked. On a chronically unwritable dbdir (read-only fs, disk full) the write failed silently every pass; `pfb_ip_recompute_order_changed()`'s missing-baseline fail-safe TRUE then re-triggered the full recompute on every cron tick with no visible cause (reproduced off-appliance: stale 0444 baseline → `order_changed=true` + silent `false` write on three consecutive ticks).

Change (log-only, per the issue's scope — the recompute still runs on a failed write):

- New `pfb_ip_recompute_memberlist_write()` beside its `pfb_ip_recompute_*` siblings: writes via the shared serializer with `LOCK_EX`, checks strict `=== FALSE` (an empty family set legitimately returns int 0), logs `IP-Recompute: write failed for [ path ]` via `pfb_logger(..., 2)` on failure, returns the write result.
- The invocation-loop call site now routes through the helper; `pfb_ip_recompute_order_changed()`'s deliberate fail-safe read is untouched.
- Tests: updated the Part B source tripwire (red→green, test-first) and added four behaviour tests — success round-trip through `order_changed()`, missing parent dir, read-only target (root-skipped), and the empty-paths int-0-vs-FALSE row.

Gates: `php -l` clean, PHPUnit 3014 tests / 20226 assertions green, PHPStan clean, PHPCS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8cr16xTZ9ixtbJndKKjrd