### PR TITLE
www: guard array-valued request fields in pfblockerng_log.php

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -220,10 +220,12 @@ if ($_POST) {
 	$pconfig = $_POST;
 }
 
-if (!isset($pconfig['logtype'])) {
+// issue #1183: an array-valued logtype/logFile POST field reaches string
+// sinks (htmlspecialchars(), an array offset) below -- normalize here.
+if (!isset($pconfig['logtype']) || !is_string($pconfig['logtype'])) {
 	$pconfig['logtype'] = '';
 }
-if (!isset($pconfig['logFile'])) {
+if (!isset($pconfig['logFile']) || !is_string($pconfig['logFile'])) {
 	$pconfig['logFile'] = '';
 }
 
@@ -231,7 +233,8 @@ if (!isset($pconfig['logFile'])) {
 if (isset($_REQUEST) && isset($_REQUEST['ajax'])) {
 
 	clearstatcache();
-	$pfb_logfilename = htmlspecialchars($_REQUEST['file']);
+	// issue #1183: an array-valued file request field TypeErrors htmlspecialchars() -- guard it.
+	$pfb_logfilename = htmlspecialchars(is_string($_REQUEST['file'] ?? null) ? $_REQUEST['file'] : '');
 	if (!pfb_validate_filepath($pfb_logfilename, $pfb_logtypes)) {
 		print ("|3|" . gettext('Invalid filename/path') . "|IA==|");
 		exit;

--- a/tests/php/LogArrayRequestGuardTest.php
+++ b/tests/php/LogArrayRequestGuardTest.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfblockerng_log.php array-valued request-field guard (issue #1183).
+ *
+ * A crafted request submitting an array-valued 'file' (ajax GET), 'logFile',
+ * or 'logtype' field reached strictly-typed string sinks (htmlspecialchars(),
+ * an array-offset access) before any type check, TypeError-ing the page
+ * (HTTP 500). The fix normalizes 'logtype'/'logFile' to '' right after the
+ * $pconfig = $_POST; ingress (one guard covers every downstream sink) and
+ * guards $_REQUEST['file'] at its own ajax sink, mirroring the is_string
+ * idiom landed for #1106/#1125/#1128.
+ *
+ * The page carries top-level execution and cannot be require()d
+ * off-appliance, so each region below is eval-extracted verbatim from the
+ * REAL source, anchored on text stable across both the pre-fix and post-fix
+ * code so the same test file proves red on the old code and green on the new.
+ */
+final class LogArrayRequestGuardTest extends TestCase
+{
+	private array $savedPost = [];
+	private array $savedGet = [];
+	private array $savedRequest = [];
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/LogPageLoader.php';
+		pfb_test_load_log_page_functions();
+
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_log.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_log.php');
+		}
+
+		// Region 1: $_POST ingress -> $pconfig['logtype']/'logFile' defaults.
+		if (!function_exists('pfb_log_oracle_pconfig')) {
+			if (!preg_match('/\$pconfig = array\(\);\n(.*?)\n\n\/\/ Send logfile to screen/s', $src, $m)) {
+				throw new RuntimeException('test bootstrap: pconfig ingress region not found');
+			}
+			eval('function pfb_log_oracle_pconfig(): array { $pconfig = array(); ' . $m[1] . ' return $pconfig; }');
+		}
+
+		// Region 2: ajax 'file' -> $pfb_logfilename (site :234).
+		if (!function_exists('pfb_log_oracle_ajax_filename')) {
+			if (!preg_match(
+				'/\/\/ Send logfile to screen\nif \(isset\(\$_REQUEST\) && isset\(\$_REQUEST\[\'ajax\'\]\)\) \{\n\n'
+				. '(.*?)\n\tif \(!pfb_validate_filepath\(\$pfb_logfilename, \$pfb_logtypes\)\)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: ajax filename region not found');
+			}
+			eval('function pfb_log_oracle_ajax_filename(): string { ' . $m[1] . ' return $pfb_logfilename; }');
+		}
+
+		// Region 3: ajax 'action' == 'load' loose compare -- array-safe, no guard needed.
+		if (!function_exists('pfb_log_oracle_action_is_load')) {
+			if (!preg_match('/\t\/\/ Load log\n(\tif \(\$_REQUEST\[\'action\'\] == \'load\'\) \{)/', $src, $m)) {
+				throw new RuntimeException('test bootstrap: action-is-load region not found');
+			}
+			eval('function pfb_log_oracle_action_is_load(): bool { ' . $m[1] . ' return TRUE; } return FALSE; }');
+		}
+
+		// Region 4: 'logFile' download/clear gate + htmlspecialchars() sink (site :303/:435).
+		if (!function_exists('pfb_log_oracle_logfile_sink')) {
+			if (!preg_match(
+				'/\/\/ Download\/Clear logfile\n(if \(isset\(\$pconfig\[\'logFile\'\]\) && !empty\(\$pconfig\[\'logFile\'\]\) && '
+				. '\(isset\(\$pconfig\[\'download\'\]\) \|\| isset\(\$pconfig\[\'clear\'\]\)\)\) \{\n\t\n\t\$s_logfile = '
+				. 'htmlspecialchars\(\$pconfig\[\'logFile\'\]\);)\n\tif \(!pfb_validate_filepath/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: logFile sink region not found');
+			}
+			eval(
+				'function pfb_log_oracle_logfile_sink(array $pconfig): string { '
+				. $m[1]
+				. ' return $s_logfile; } $s_logfile = \'\'; return $s_logfile; }'
+			);
+		}
+
+		// Region 5: 'logtype' -> $selected -> $pfb_logtypes[$selected] offset (site :406-407).
+		if (!function_exists('pfb_log_oracle_selected_logtype')) {
+			if (!preg_match(
+				'/\/\/ Collect selected logs\n\$logs = array\(\);\n\$clearable = \$downloadable = FALSE;\n'
+				. '(\$selected = !empty\(\$pconfig\[\'logtype\'\]\) \? \$pconfig\[\'logtype\'\] : \'defaultlogs\';\n'
+				. '\$pfb_sel = \$pfb_logtypes\[\$selected\];)/',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: selected-logtype region not found');
+			}
+			eval(
+				'function pfb_log_oracle_selected_logtype(array $pconfig, array $pfb_logtypes): array { '
+				. $m[1]
+				. ' return $pfb_sel; }'
+			);
+		}
+	}
+
+	protected function setUp(): void
+	{
+		$this->savedPost    = $_POST;
+		$this->savedGet     = $_GET;
+		$this->savedRequest = $_REQUEST;
+		$_POST = $_GET = $_REQUEST = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$_POST    = $this->savedPost;
+		$_GET     = $this->savedGet;
+		$_REQUEST = $this->savedRequest;
+	}
+
+	/** A $pfb_logtypes fixture shaped like the real page's (LogValidateFilepathNulByteTest sibling shape). */
+	private function logtypes(): array
+	{
+		return [
+			'defaultlogs' => ['logdir' => '/var/log/pfblockerng/'],
+			'python'      => ['logdir' => '/var/unbound/'],
+		];
+	}
+
+	// --- site :234 -- ajax 'file' -> htmlspecialchars() ---------------------
+
+	public function testAjaxFileArrayValueDoesNotThrowAndFailsValidation(): void
+	{
+		$_REQUEST['file'] = ['x'];
+		try {
+			$filename = pfb_log_oracle_ajax_filename();
+		} catch (\TypeError $e) {
+			$this->fail('an array file value must not TypeError htmlspecialchars(): ' . $e->getMessage());
+		}
+		$this->assertSame('', $filename, 'an array file value must be blanked to the empty string');
+		$this->assertFalse(
+			pfb_validate_filepath($filename, $this->logtypes()),
+			'the blanked file value must fail validation, riding the existing reject path'
+		);
+	}
+
+	public function testAjaxFileNestedArrayValueDoesNotThrowAndFailsValidation(): void
+	{
+		parse_str('file[a][b]=x', $parsed);
+		$_REQUEST['file'] = $parsed['file'];
+		try {
+			$filename = pfb_log_oracle_ajax_filename();
+		} catch (\TypeError $e) {
+			$this->fail('a nested array file value must not TypeError htmlspecialchars(): ' . $e->getMessage());
+		}
+		$this->assertSame('', $filename, 'a nested array file value must be blanked to the empty string');
+		$this->assertFalse(pfb_validate_filepath($filename, $this->logtypes()));
+	}
+
+	public function testAjaxFileAbsentKeyDoesNotThrowOrEmitDeprecation(): void
+	{
+		unset($_REQUEST['file']);
+		$warnings = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+			$warnings[] = $errstr;
+			return TRUE;
+		}, E_DEPRECATED | E_WARNING);
+		try {
+			$filename = pfb_log_oracle_ajax_filename();
+		} catch (\TypeError $e) {
+			restore_error_handler();
+			$this->fail('a missing file key must not TypeError: ' . $e->getMessage());
+		}
+		restore_error_handler();
+		$this->assertSame('', $filename, 'a missing file key must yield the blank filename');
+		$this->assertSame(
+			[],
+			$warnings,
+			'a missing file key must not emit a deprecation/warning from htmlspecialchars(null)'
+		);
+		$this->assertFalse(pfb_validate_filepath($filename, $this->logtypes()));
+	}
+
+	public function testAjaxFileScalarValueIsUnaffectedByTheGuard(): void
+	{
+		$_REQUEST['file'] = '/var/log/pfblockerng/ok.log';
+		$filename = pfb_log_oracle_ajax_filename();
+		$this->assertSame(
+			'/var/log/pfblockerng/ok.log',
+			$filename,
+			'a scalar file value must survive the guard unmodified'
+		);
+		$this->assertTrue(pfb_validate_filepath($filename, $this->logtypes()));
+	}
+
+	// --- site :241 -- 'action' loose compare, array-safe, no guard needed ---
+
+	public function testActionArrayValueIsNotLoadWithoutThrowing(): void
+	{
+		$_REQUEST['action'] = ['load'];
+		try {
+			$isLoad = pfb_log_oracle_action_is_load();
+		} catch (\TypeError $e) {
+			$this->fail('an array action value must not TypeError the loose == compare: ' . $e->getMessage());
+		}
+		$this->assertFalse($isLoad, 'an array action value must not be treated as the load action');
+	}
+
+	public function testActionScalarLoadValueEntersLoadBranch(): void
+	{
+		$_REQUEST['action'] = 'load';
+		$this->assertTrue(pfb_log_oracle_action_is_load(), 'a scalar "load" action must still enter the load branch');
+	}
+
+	public function testActionScalarOtherValueDoesNotEnterLoadBranch(): void
+	{
+		$_REQUEST['action'] = 'other';
+		$this->assertFalse(
+			pfb_log_oracle_action_is_load(),
+			'a non-"load" scalar action must not enter the load branch'
+		);
+	}
+
+	// --- ingress -- $_POST -> $pconfig['logtype']/'logFile' normalization ---
+
+	public function testPconfigLogFileArrayValueIsNormalizedToEmptyString(): void
+	{
+		$_POST['logFile'] = ['x'];
+		$pconfig = pfb_log_oracle_pconfig();
+		$this->assertSame('', $pconfig['logFile'], 'an array logFile POST value must be normalized to the empty string');
+	}
+
+	public function testPconfigLogtypeArrayValueIsNormalizedToEmptyString(): void
+	{
+		$_POST['logtype'] = ['y'];
+		$pconfig = pfb_log_oracle_pconfig();
+		$this->assertSame('', $pconfig['logtype'], 'an array logtype POST value must be normalized to the empty string');
+	}
+
+	public function testPconfigBothLogtypeAndLogFileArrayValuesAreNormalized(): void
+	{
+		$_POST['logtype'] = ['y'];
+		$_POST['logFile'] = ['x'];
+		$pconfig = pfb_log_oracle_pconfig();
+		$this->assertSame('', $pconfig['logtype']);
+		$this->assertSame('', $pconfig['logFile']);
+	}
+
+	public function testPconfigScalarValuesSurviveNormalizationUnmodified(): void
+	{
+		$_POST['logtype'] = 'defaultlogs';
+		$_POST['logFile'] = '/var/log/pfblockerng/ok.log';
+		$pconfig = pfb_log_oracle_pconfig();
+		$this->assertSame('defaultlogs', $pconfig['logtype'], 'a scalar logtype value must survive the guard unmodified');
+		$this->assertSame(
+			'/var/log/pfblockerng/ok.log',
+			$pconfig['logFile'],
+			'a scalar logFile value must survive the guard unmodified'
+		);
+	}
+
+	public function testPconfigMissingKeysStillDefaultToEmptyString(): void
+	{
+		// Before-state control: the pre-existing !isset() defaults must survive the fix untouched.
+		$pconfig = pfb_log_oracle_pconfig();
+		$this->assertSame('', $pconfig['logtype']);
+		$this->assertSame('', $pconfig['logFile']);
+	}
+
+	// --- site :303/:435 -- download/clear gate + htmlspecialchars() sink ----
+
+	public function testLogfileArrayValueWithClearSetDoesNotThrowAndSkipsGate(): void
+	{
+		$_POST['logFile'] = ['x'];
+		$_POST['clear'] = '1';
+		$pconfig = pfb_log_oracle_pconfig();
+		try {
+			$s_logfile = pfb_log_oracle_logfile_sink($pconfig);
+		} catch (\TypeError $e) {
+			$this->fail('an array logFile value (clear) must not TypeError htmlspecialchars(): ' . $e->getMessage());
+		}
+		$this->assertSame('', $s_logfile, 'the normalized empty logFile must skip the download/clear gate entirely');
+	}
+
+	public function testLogfileArrayValueWithDownloadSetDoesNotThrowAndSkipsGate(): void
+	{
+		$_POST['logFile'] = ['x'];
+		$_POST['download'] = '1';
+		$pconfig = pfb_log_oracle_pconfig();
+		try {
+			$s_logfile = pfb_log_oracle_logfile_sink($pconfig);
+		} catch (\TypeError $e) {
+			$this->fail('an array logFile value (download) must not TypeError htmlspecialchars(): ' . $e->getMessage());
+		}
+		$this->assertSame('', $s_logfile, 'the normalized empty logFile must skip the download/clear gate entirely');
+	}
+
+	public function testLogfileScalarValueWithClearSetStillReachesTheSink(): void
+	{
+		// Behaviour-preserving control: a genuine scalar logFile must still enter
+		// the gate and reach htmlspecialchars(), unaffected by the ingress guard.
+		$_POST['logFile'] = '/var/log/pfblockerng/ok.log';
+		$_POST['clear'] = '1';
+		$pconfig = pfb_log_oracle_pconfig();
+		$s_logfile = pfb_log_oracle_logfile_sink($pconfig);
+		$this->assertSame(
+			'/var/log/pfblockerng/ok.log',
+			$s_logfile,
+			'a scalar logFile value must still reach the sink unmodified'
+		);
+	}
+
+	// --- site :406-407 -- $pfb_logtypes[$selected] array-offset access ------
+
+	public function testSelectedLogtypeArrayValueDoesNotThrowAndFallsBackToDefault(): void
+	{
+		$_POST['logtype'] = ['y'];
+		$pconfig = pfb_log_oracle_pconfig();
+		try {
+			$pfb_sel = pfb_log_oracle_selected_logtype($pconfig, $this->logtypes());
+		} catch (\TypeError $e) {
+			$this->fail('an array logtype value must not TypeError the $pfb_logtypes[] offset: ' . $e->getMessage());
+		}
+		$this->assertSame(
+			$this->logtypes()['defaultlogs'],
+			$pfb_sel,
+			'an array logtype value must fall back to defaultlogs'
+		);
+	}
+
+	public function testSelectedLogtypeScalarValueStillResolvesItsOwnEntry(): void
+	{
+		$_POST['logtype'] = 'python';
+		$pconfig = pfb_log_oracle_pconfig();
+		$pfb_sel = pfb_log_oracle_selected_logtype($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['python'], $pfb_sel, 'a scalar logtype value must still resolve its own entry');
+	}
+}

--- a/tests/php/LogArrayRequestGuardTest.php
+++ b/tests/php/LogArrayRequestGuardTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  * (HTTP 500). The fix normalizes 'logtype'/'logFile' to '' right after the
  * $pconfig = $_POST; ingress (one guard covers every downstream sink) and
  * guards $_REQUEST['file'] at its own ajax sink, mirroring the is_string
- * idiom landed for #1106/#1125/#1128.
+ * idiom landed for #1106/#1128/#1139.
  *
  * The page carries top-level execution and cannot be require()d
  * off-appliance, so each region below is eval-extracted verbatim from the
@@ -46,7 +46,7 @@ final class LogArrayRequestGuardTest extends TestCase
 			eval('function pfb_log_oracle_pconfig(): array { $pconfig = array(); ' . $m[1] . ' return $pconfig; }');
 		}
 
-		// Region 2: ajax 'file' -> $pfb_logfilename (site :234).
+		// Region 2: ajax 'file' -> $pfb_logfilename sink.
 		if (!function_exists('pfb_log_oracle_ajax_filename')) {
 			if (!preg_match(
 				'/\/\/ Send logfile to screen\nif \(isset\(\$_REQUEST\) && isset\(\$_REQUEST\[\'ajax\'\]\)\) \{\n\n'
@@ -67,7 +67,7 @@ final class LogArrayRequestGuardTest extends TestCase
 			eval('function pfb_log_oracle_action_is_load(): bool { ' . $m[1] . ' return TRUE; } return FALSE; }');
 		}
 
-		// Region 4: 'logFile' download/clear gate + htmlspecialchars() sink (site :303/:435).
+		// Region 4: 'logFile' download/clear gate + htmlspecialchars() sink.
 		if (!function_exists('pfb_log_oracle_logfile_sink')) {
 			if (!preg_match(
 				'/\/\/ Download\/Clear logfile\n(if \(isset\(\$pconfig\[\'logFile\'\]\) && !empty\(\$pconfig\[\'logFile\'\]\) && '
@@ -85,7 +85,7 @@ final class LogArrayRequestGuardTest extends TestCase
 			);
 		}
 
-		// Region 5: 'logtype' -> $selected -> $pfb_logtypes[$selected] offset (site :406-407).
+		// Region 5: 'logtype' -> $selected -> $pfb_logtypes[$selected] offset.
 		if (!function_exists('pfb_log_oracle_selected_logtype')) {
 			if (!preg_match(
 				'/\/\/ Collect selected logs\n\$logs = array\(\);\n\$clearable = \$downloadable = FALSE;\n'
@@ -128,7 +128,7 @@ final class LogArrayRequestGuardTest extends TestCase
 		];
 	}
 
-	// --- site :234 -- ajax 'file' -> htmlspecialchars() ---------------------
+	// --- ajax 'file' -> htmlspecialchars() ----------------------------------
 
 	public function testAjaxFileArrayValueDoesNotThrowAndFailsValidation(): void
 	{
@@ -194,7 +194,7 @@ final class LogArrayRequestGuardTest extends TestCase
 		$this->assertTrue(pfb_validate_filepath($filename, $this->logtypes()));
 	}
 
-	// --- site :241 -- 'action' loose compare, array-safe, no guard needed ---
+	// --- 'action' loose compare, array-safe, no guard needed ----------------
 
 	public function testActionArrayValueIsNotLoadWithoutThrowing(): void
 	{
@@ -268,7 +268,7 @@ final class LogArrayRequestGuardTest extends TestCase
 		$this->assertSame('', $pconfig['logFile']);
 	}
 
-	// --- site :303/:435 -- download/clear gate + htmlspecialchars() sink ----
+	// --- download/clear gate + htmlspecialchars() sink ----------------------
 
 	public function testLogfileArrayValueWithClearSetDoesNotThrowAndSkipsGate(): void
 	{
@@ -311,7 +311,7 @@ final class LogArrayRequestGuardTest extends TestCase
 		);
 	}
 
-	// --- site :406-407 -- $pfb_logtypes[$selected] array-offset access ------
+	// --- $pfb_logtypes[$selected] array-offset access -----------------------
 
 	public function testSelectedLogtypeArrayValueDoesNotThrowAndFallsBackToDefault(): void
 	{

--- a/tests/smoke/ui/test_post_array_scalar_guards.py
+++ b/tests/smoke/ui/test_post_array_scalar_guards.py
@@ -25,7 +25,10 @@ reflector's ``is_string()`` guard on ``$_REQUEST['pfb']`` (exercised via an
 on-box curl -- unreachable through ``webui``'s SLIRP-hostfwd session, since
 its gate requires literal ``REMOTE_ADDR == 127.0.0.1``). The sibling
 ``ip_remove`` site (also #1128) lives in ``test_alerts.py`` beside its own
-``_post_action``-based elseif-chain siblings.
+``_post_action``-based elseif-chain siblings. Issue #1183's
+``pfblockerng_log.php`` cluster closes the ``$pconfig['logtype']``/``logFile``
+ingress normalization (POST) and the ajax ``$_REQUEST['file']``
+``htmlspecialchars()`` sink (GET query).
 
 Each save/GET must respond like any validation failure: HTTP 200, no login
 bounce, and NOT ONE new byte in any candidate ``php_error.log``.
@@ -141,6 +144,11 @@ _ARRAY_FIELD_CASES: list[tuple[str, str, dict[str, str] | None]] = [
     ("/pfblockerng/pfblockerng_dnsbl.php", "suppression", None),  # explode
     ("/pfblockerng/pfblockerng_dnsbl.php", "tldexclusion", None),  # explode
     ("/pfblockerng/pfblockerng_dnsbl.php", "tldblacklist", None),  # explode
+    # issue #1183: pfblockerng_log.php's $pconfig ingress normalizes logtype/logFile
+    # to '' for a non-string value -- 'clear' mirrors the page's own JS
+    # ($('#clear').val('clear')) so the download/clear gate is exercised too.
+    ("/pfblockerng/pfblockerng_log.php", "logFile", {"clear": "clear"}),  # ingress normalize + clear gate
+    ("/pfblockerng/pfblockerng_log.php", "logtype", None),  # ingress normalize + $pfb_logtypes[] offset
 ]
 
 
@@ -161,6 +169,8 @@ def test_array_valued_field_rejected_gracefully(
 _GET_ARRAY_QUERY_CASES = [
     "/pfblockerng/pfblockerng_category_edit.php?type=dnsbl&savemsg[]=crafted",
     "/pfblockerng/pfblockerng_category_edit.php?type=dnsbl&atype[]=crafted",
+    # issue #1183: the ajax 'file' sink guards a non-string value at htmlspecialchars().
+    "/pfblockerng/pfblockerng_log.php?ajax=1&file[]=crafted",
 ]
 
 


### PR DESCRIPTION
Fixes #1183 — fifth member of the array-`$_POST` TypeError class tracked under #1143 (#1070 → #1106 → #1128 → #1139).

## What

An array-valued request field on the Log Browser page raises a PHP 8 `TypeError` → HTTP 500 at three ingress paths:

- `htmlspecialchars($_REQUEST['file'])` in the ajax branch — reachable by an authenticated **GET** `?ajax=1&file[]=x` (no CSRF token involved);
- `htmlspecialchars($pconfig['logFile'])` behind a `!empty()` gate an array passes;
- `$pconfig['logtype']` used as an array offset (`$pfb_logtypes[$selected]`) — a third path the issue's own enumeration missed, found during triage.

## Fix

The class's landed `is_string()` idiom (PRs #1102/#1125/#1146), applied at the ingress rather than per sink:

- `logtype`/`logFile` normalized to `''` in the existing `$pconfig` defaults block right after `$pconfig = $_POST;` — one guard covering all downstream sinks; `''` rides the page's existing conventions (branch skipped / `defaultlogs` fallback).
- `$_REQUEST['file']` guarded inline at its ajax sink; `''` falls into the existing `pfb_validate_filepath()` → `|3|Invalid filename/path` reject (also removes the `htmlspecialchars(null)` deprecation when `file` is absent).

`pfb_validate_filepath()` internals (#1126's NUL guard) and `tests/php/LogPageLoader.php` anchors are untouched.

## Tests

- New `tests/php/LogArrayRequestGuardTest.php` (17 tests, eval-extraction idiom per `DnsblPostGuardTest.php`): test-first red→green — 9 reproduction tests executed RED against the unguarded page (exact `TypeError` shapes pasted in the run), frozen byte-identical, GREEN zero-edits post-fix; plus array-safe `action` and scalar happy-path controls.
- Three Tier-B rows in `tests/smoke/ui/test_post_array_scalar_guards.py` (`logFile`+clear gate, `logtype`, ajax `file[]` GET), mirroring the prior members' rows. Tier-A `ui_render` coverage of the page already exists (`test_render_smoke.py`).

Gates: full PHPUnit suite (3027 tests), PHPStan, PHPCS, `php -l`, ruff, mypy, full pytest — all green; independently re-run by the step verifier, red proof re-executed with freeze-hash check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8cr16xTZ9ixtbJndKKjrd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved log browser handling of unexpected array-valued form and query inputs.
  - Prevented type errors and HTTP 500 responses when invalid log file or log type values are submitted.
  - Invalid AJAX file requests now receive a safe validation response without affecting normal scalar inputs.

- **Tests**
  - Added automated coverage for malformed requests, validation behavior, and download/clear actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->