### PR TITLE
tests/smoke: never let the guest's scheduled tick dispatch a pass during tests (#1179)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -83,6 +83,7 @@ PHP_BIN = "/usr/local/bin/php"
 # loaded + locked), so config_set_path/write_config persist a valid config.xml.
 PFSSH_BIN = "/usr/local/sbin/pfSsh.php"
 PFB_CLI = "/usr/local/www/pfblockerng/pfblockerng.php"
+PFB_EXTRA_INC = "/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 PFCTL = "/sbin/pfctl"
 
 # pfSense config API roots (see pfblockerng.inc).
@@ -1556,6 +1557,64 @@ def set_feed_sanity(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
     result = php_eval(vm, snippet, timeout=timeout)
     if result.returncode != 0 or "OK" not in result.stdout:
         raise RuntimeError(f"set_feed_sanity({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def set_feed_cron_interval(vm: SmokeVM, value: str, *, timeout: float = 60.0) -> None:
+    """Set Update Frequency (``pfb_interval``): an hour count as a string, or ``'Disabled'``.
+
+    ``'Disabled'`` short-circuits ``pfblockerng_tick()``'s feed-cron branch (its
+    ``!$cron_disabled`` guard), so no tick — the box's scheduled one or an explicit
+    ``tick`` verb — dispatches a feed pass. The ``cron`` VERB is unaffected: the CLI
+    coerces a non-numeric interval back to ``'1'`` (pfblockerng.inc). Pass an hour
+    count ('1', '4', …) to re-enable dispatch for a module that exercises scheduling.
+    """
+    snippet = (
+        f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
+        f"$g['pfb_interval'] = {_php_str(value)};\n"
+        f"config_set_path({_php_str(CFG_GLOBAL)}, $g);\n"
+        "write_config('pfBlockerNG smoke: set pfb_interval');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"set_feed_cron_interval({value!r}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def disable_scheduled_dispatch(vm: SmokeVM, *, timeout: float = 60.0) -> None:
+    """Stop the box's own ADR-43 tick from dispatching an update pass (issue #1179).
+
+    The guest runs a real ``*/pfb_tick_interval`` cron tick. Left armed, it fires
+    mid-test and dispatches a full feed pass — re-running update hooks a test just
+    registered, reloading aliases/DNSBL under a test's feet — a wall-clock flake no test
+    can defend against. The suite therefore drives scheduling ITSELF (every scheduling
+    test invokes the ``tick``/``cron`` verb directly), and this gate, applied by
+    :func:`deploy` for every module, closes all three of the tick's dispatch branches:
+    ``pfb_interval='Disabled'`` (feed cron) plus a far-future due-ledger entry for
+    ``dcc`` and ``bl``. That the tick IS scheduled is asserted separately
+    (``test_smoke_tick.test_tick_cron_entry_installed``).
+
+    Deleting the cron entry instead would not hold: every ``sync_package_pfblockerng()``
+    re-installs it while the package is enabled, and pfSense's ``configure_cron()``
+    restarts a stopped cron daemon — the tick's own config/ledger gates are the only
+    durable off switch. A module that EXERCISES the scheduler re-arms what it needs
+    (:func:`set_feed_cron_interval`).
+    """
+    set_feed_cron_interval(vm, "Disabled", timeout=timeout)
+    snippet = (
+        f"require_once({_php_str(PFB_EXTRA_INC)});\n"
+        "foreach (array('dcc', 'bl') as $job) {\n"
+        "  pfb_due_ledger_write_entry($job, array('last_run' => time(), "
+        f"'next_due' => time() + 86400, 'jitter' => 0), {_php_str(PFB_DBDIR)});\n"
+        "}\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"disable_scheduled_dispatch failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
 
 
 @timed_step("use_system_dns_upstream")

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2844,9 +2844,10 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
         the resolver config so the live daemon matches;
       * drops the derived state — ``clearip``/``cleardnsbl`` (tables/sqlite) then a blocking
         ``apply_filter_sync`` (pf rules);
-      * pushes every tick job out of due (:func:`seed_scheduled_jobs_not_due`) so the guest's
-        scheduled tick cannot dispatch a pass in the gap before the next module's deploy
-        re-applies :func:`disable_scheduled_dispatch` (issue #1179).
+      * pushes every tick job out of due (:func:`seed_scheduled_jobs_not_due`) **first**, so the
+        guest's scheduled tick cannot dispatch a pass once the wipe below puts ``pfb_interval``
+        back at its enabled default, nor in the gap before the next module's deploy re-applies
+        :func:`disable_scheduled_dispatch` (issue #1179).
 
     **Never leave a key set in ``config/0`` here** (that is why the gap above is closed with
     the ledger, a file, and not by writing ``pfb_interval`` back): the next module's ``pkg``
@@ -2860,6 +2861,12 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
     autouse teardown in ``conftest.py``; safe to call
     directly. Raises on a non-zero ``pfSsh.php`` eval so a broken baseline surfaces loudly.
     """
+    installed = pkg_installed(vm)
+    # BEFORE the wipe, not after: unsetting pfb_interval puts it back at its enabled default
+    # '1', so from that instant a due-or-pending job is dispatchable again. Seeding first
+    # means the ledger is already not-due when the key flips (issue #1179).
+    if installed:
+        seed_scheduled_jobs_not_due(vm)
     del_sections = "".join(f"config_del_path({_php_str(s)});\n" for s in _BASELINE_DEL_SECTIONS)
     unset_keys = "".join(f"unset($g[{_php_str(k)}]);\n" for k in _BASELINE_GLOBAL_KEYS)
     snippet = (
@@ -2892,15 +2899,13 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
     # pfBlockerNG derived state left to clear; the config-section wipe above ran via pfSsh.php
     # (core, no package needed). Without this guard the module-scoped teardown ERRORs after any
     # uninstall test that happens to be last in its module.
-    if pkg_installed(vm):
+    if installed:
         for verb in ("clearip", "cleardnsbl"):
             cleared = vm.ssh(PHP_BIN, PFB_CLI, verb, timeout=120.0)
             if cleared.returncode != 0:
                 raise RuntimeError(
                     f"reset_pfb_baseline {verb} failed: rc={cleared.returncode} stderr={cleared.stderr!r}"
                 )
-        # Same guard: the seed runs the package's own ledger writer, so it needs the package.
-        seed_scheduled_jobs_not_due(vm)
     apply_filter_sync(vm)
 
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2793,11 +2793,11 @@ _BASELINE_GLOBAL_KEYS = (
     "pfb_agg_types",
     "pfb_quiet_hours",
     "pfb_tick_interval",
-    # Update Frequency: deploy() writes 'Disabled' (disable_scheduled_dispatch) and the
-    # scheduling modules re-arm an hour count; unset here so each module's own deploy
-    # re-establishes the value it wants instead of inheriting the previous module's
-    # (a leaked 'Disabled' bit test_smoke_apply_on_change — issue #805).
-    "pfb_interval",
+    # NOT pfb_interval: it is harness-owned now (disable_scheduled_dispatch, issue #1179).
+    # Unsetting it would revert to the registry default '1' — re-arming the guest's
+    # scheduled feed-cron dispatch for the whole gap until the next module's deploy();
+    # this reset re-applies the gate instead, so a scheduling module's opt-in cannot leak
+    # forward either (a leaked value bit test_smoke_apply_on_change — issue #805).
     # ADR-40 apply-path mode: test_smoke_adr40 writes 'delta'/'auto'/'replace' via
     # PfbConfig (General section, issue #804); unset so later modules read the
     # box's own default (end-state is mode-invariant, but the apply path is not).
@@ -2830,7 +2830,9 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
         row cannot answer a later module's probe before the DNSBL module) and regenerates
         the resolver config so the live daemon matches;
       * drops the derived state — ``clearip``/``cleardnsbl`` (tables/sqlite) then a blocking
-        ``apply_filter_sync`` (pf rules).
+        ``apply_filter_sync`` (pf rules);
+      * re-applies :func:`disable_scheduled_dispatch` (issue #1179) — the scheduled tick must
+        stay gated across the module boundary too, not only from the next ``deploy()`` on.
 
     NO forced ``update``: the config is now empty, so there is nothing to rebuild — the next
     module's ``deployed_vm`` re-establishes the VIP/DNS/feed config it needs. (Like :func:`reset`,
@@ -2877,6 +2879,8 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
                 raise RuntimeError(
                     f"reset_pfb_baseline {verb} failed: rc={cleared.returncode} stderr={cleared.stderr!r}"
                 )
+        # Same guard: the gate reads the package's own ledger writer, so it needs the package.
+        disable_scheduled_dispatch(vm)
     apply_filter_sync(vm)
 
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -388,6 +388,10 @@ def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) 
     portable Linux build job (build-pkg-linux.yml); its path is ``pkg_path`` or ``SMOKE_PKG``.
     install-pkg.sh polls ``unbound-control status`` after POST-INSTALL, so on
     return Unbound is ready.
+
+    POST-INSTALL also arms the ADR-43 cron tick, so every deploy ends with
+    :func:`disable_scheduled_dispatch` — the suite drives scheduling explicitly (the
+    ``tick``/``cron`` verbs) and must never race the box's wall-clock one (issue #1179).
     """
     pkg = pkg_path or os.environ.get("SMOKE_PKG")
     if not pkg or not Path(pkg).is_file():
@@ -409,6 +413,7 @@ def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) 
         raise RuntimeError(
             f"install-pkg.sh failed (rc={result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
+    disable_scheduled_dispatch(vm)
 
 
 def pkg_installed(vm: SmokeVM, *, timeout: float = 30.0) -> bool:
@@ -2788,9 +2793,10 @@ _BASELINE_GLOBAL_KEYS = (
     "pfb_agg_types",
     "pfb_quiet_hours",
     "pfb_tick_interval",
-    # Update Frequency: test_log_rotate writes 'Disabled' to gate the tick's feed-cron
-    # dispatch; leaked forward it silently disables dispatch for every later module
-    # (bit test_smoke_apply_on_change — issue #805).
+    # Update Frequency: deploy() writes 'Disabled' (disable_scheduled_dispatch) and the
+    # scheduling modules re-arm an hour count; unset here so each module's own deploy
+    # re-establishes the value it wants instead of inheriting the previous module's
+    # (a leaked 'Disabled' bit test_smoke_apply_on_change — issue #805).
     "pfb_interval",
     # ADR-40 apply-path mode: test_smoke_adr40 writes 'delta'/'auto'/'replace' via
     # PfbConfig (General section, issue #804); unset so later modules read the

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1587,6 +1587,30 @@ def set_feed_cron_interval(vm: SmokeVM, value: str, *, timeout: float = 60.0) ->
         )
 
 
+def seed_scheduled_jobs_not_due(vm: SmokeVM, *, timeout: float = 60.0) -> None:
+    """Push every ADR-43 tick job's ``next_due`` a day out, clearing any pending flag.
+
+    The due-ledger is a FILE (``pfb_due_ledger.json``), not config — which is what makes
+    this safe to call at module teardown, where a config write is not (see
+    :func:`reset_pfb_baseline`). ``pfb_due_ledger_write_entry`` replaces the whole entry,
+    so a ``pending_apply`` a case left behind is dropped with it: a tick then finds every
+    job neither due nor pending and dispatches nothing, whatever ``pfb_interval`` says.
+    """
+    snippet = (
+        f"require_once({_php_str(PFB_EXTRA_INC)});\n"
+        "foreach (array('cron', 'dcc', 'bl') as $job) {\n"
+        "  pfb_due_ledger_write_entry($job, array('last_run' => time(), "
+        f"'next_due' => time() + 86400, 'jitter' => 0), {_php_str(PFB_DBDIR)});\n"
+        "}\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"seed_scheduled_jobs_not_due failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
 def disable_scheduled_dispatch(vm: SmokeVM, *, timeout: float = 60.0) -> None:
     """Stop the box's own ADR-43 tick from dispatching an update pass (issue #1179).
 
@@ -1596,7 +1620,7 @@ def disable_scheduled_dispatch(vm: SmokeVM, *, timeout: float = 60.0) -> None:
     can defend against. The suite therefore drives scheduling ITSELF (every scheduling
     test invokes the ``tick``/``cron`` verb directly), and this gate, applied by
     :func:`deploy` for every module, closes all three of the tick's dispatch branches:
-    ``pfb_interval='Disabled'`` (feed cron) plus a far-future due-ledger entry for
+    ``pfb_interval='Disabled'`` (feed cron) plus a not-due due-ledger for ``cron``,
     ``dcc`` and ``bl``. That the tick IS scheduled is asserted separately
     (``test_smoke_tick.test_tick_cron_entry_installed``).
 
@@ -1604,22 +1628,10 @@ def disable_scheduled_dispatch(vm: SmokeVM, *, timeout: float = 60.0) -> None:
     re-installs it while the package is enabled, and pfSense's ``configure_cron()``
     restarts a stopped cron daemon — the tick's own config/ledger gates are the only
     durable off switch. A module that EXERCISES the scheduler re-arms what it needs
-    (:func:`set_feed_cron_interval`).
+    (:func:`set_feed_cron_interval`) and forces its own ledger state.
     """
     set_feed_cron_interval(vm, "Disabled", timeout=timeout)
-    snippet = (
-        f"require_once({_php_str(PFB_EXTRA_INC)});\n"
-        "foreach (array('dcc', 'bl') as $job) {\n"
-        "  pfb_due_ledger_write_entry($job, array('last_run' => time(), "
-        f"'next_due' => time() + 86400, 'jitter' => 0), {_php_str(PFB_DBDIR)});\n"
-        "}\n"
-        "echo 'OK';"
-    )
-    result = php_eval(vm, snippet, timeout=timeout)
-    if result.returncode != 0 or "OK" not in result.stdout:
-        raise RuntimeError(
-            f"disable_scheduled_dispatch failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
-        )
+    seed_scheduled_jobs_not_due(vm, timeout=timeout)
 
 
 @timed_step("use_system_dns_upstream")
@@ -2793,11 +2805,12 @@ _BASELINE_GLOBAL_KEYS = (
     "pfb_agg_types",
     "pfb_quiet_hours",
     "pfb_tick_interval",
-    # NOT pfb_interval: it is harness-owned now (disable_scheduled_dispatch, issue #1179).
-    # Unsetting it would revert to the registry default '1' — re-arming the guest's
-    # scheduled feed-cron dispatch for the whole gap until the next module's deploy();
-    # this reset re-applies the gate instead, so a scheduling module's opt-in cannot leak
-    # forward either (a leaked value bit test_smoke_apply_on_change — issue #805).
+    # Update Frequency: deploy() writes 'Disabled' (disable_scheduled_dispatch) and the two
+    # scheduling modules re-arm an hour count; unset here so each module's own deploy
+    # re-establishes it (a leaked value bit test_smoke_apply_on_change — issue #805). The
+    # gap this leaves — the key is back at its default '1' until the next deploy — is
+    # covered by the ledger seed below, NOT by writing the key back (see the docstring).
+    "pfb_interval",
     # ADR-40 apply-path mode: test_smoke_adr40 writes 'delta'/'auto'/'replace' via
     # PfbConfig (General section, issue #804); unset so later modules read the
     # box's own default (end-state is mode-invariant, but the apply path is not).
@@ -2831,8 +2844,15 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
         the resolver config so the live daemon matches;
       * drops the derived state — ``clearip``/``cleardnsbl`` (tables/sqlite) then a blocking
         ``apply_filter_sync`` (pf rules);
-      * re-applies :func:`disable_scheduled_dispatch` (issue #1179) — the scheduled tick must
-        stay gated across the module boundary too, not only from the next ``deploy()`` on.
+      * pushes every tick job out of due (:func:`seed_scheduled_jobs_not_due`) so the guest's
+        scheduled tick cannot dispatch a pass in the gap before the next module's deploy
+        re-applies :func:`disable_scheduled_dispatch` (issue #1179).
+
+    **Never leave a key set in ``config/0`` here** (that is why the gap above is closed with
+    the ledger, a file, and not by writing ``pfb_interval`` back): the next module's ``pkg``
+    install grandfathers ``pfb_feed_internal_filter`` to ``'off'`` for any box whose General
+    section is a non-empty array without that key (``pfb_feed_filter_install_default``) — the
+    SSRF-guard cases then run with the guard silently disabled and pass for the wrong reason.
 
     NO forced ``update``: the config is now empty, so there is nothing to rebuild — the next
     module's ``deployed_vm`` re-establishes the VIP/DNS/feed config it needs. (Like :func:`reset`,
@@ -2879,8 +2899,8 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
                 raise RuntimeError(
                     f"reset_pfb_baseline {verb} failed: rc={cleared.returncode} stderr={cleared.stderr!r}"
                 )
-        # Same guard: the gate reads the package's own ledger writer, so it needs the package.
-        disable_scheduled_dispatch(vm)
+        # Same guard: the seed runs the package's own ledger writer, so it needs the package.
+        seed_scheduled_jobs_not_due(vm)
     apply_filter_sync(vm)
 
 

--- a/tests/smoke/test_log_age_retention.py
+++ b/tests/smoke/test_log_age_retention.py
@@ -48,8 +48,6 @@ pytestmark = pytest.mark.smoke
 PFB_LOGDIR = "/var/log/pfblockerng"
 PFB_DBDIR = "/var/db/pfblockerng"
 
-_PFB_EXTRA_INC = "/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
-
 # Host-side (non-chrooted) PHP-written CSV log; timestamp at CSV field 0.
 LOG_IP_BLOCKLOG = f"{PFB_LOGDIR}/ip_block.log"
 
@@ -76,17 +74,15 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     Mirrors the retired ADR-30 ``test_log_rotate.py``'s own ``deployed_vm``: age-based
     log retention runs from ``pfblockerng_tick()`` and needs neither DNSBL nor feed
     infrastructure, only ``enable_cb=on`` (so the tick body executes) and every tick in
-    this module being idle-only (Disabled feed cron + not-due dcc/bl), so
-    ``pfb_update_pass_running()``'s "nothing dispatched" gate stays open and
-    ``pfb_log_mgmt()`` runs on every ``tick`` call below.
+    this module being idle-only, so ``pfb_update_pass_running()``'s "nothing dispatched"
+    gate stays open and ``pfb_log_mgmt()`` runs on every ``tick`` call below. Idle-only
+    is the harness default: ``h.deploy`` -> ``disable_scheduled_dispatch`` closes all
+    three dispatch branches (Disabled feed cron + not-due dcc/bl).
     """
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
     _set_enable_cb(smoke_vm)
-    _set_pfb_interval_disabled(smoke_vm)
-    _seed_future_ledger_entry(smoke_vm, "dcc")
-    _seed_future_ledger_entry(smoke_vm, "bl")
     smoke_vm.ssh("/bin/mkdir", "-p", PFB_LOGDIR, timeout=30)
     smoke_vm.ssh("/bin/mkdir", "-p", PFB_DBDIR, timeout=30)
     try:
@@ -122,49 +118,6 @@ def _set_enable_cb(vm: SmokeVM, *, timeout: float = 60.0) -> None:
     result = h.php_eval(vm, snippet, timeout=timeout)
     if result.returncode != 0 or "OK" not in result.stdout:
         raise RuntimeError(f"_set_enable_cb failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
-
-
-def _set_pfb_interval_disabled(vm: SmokeVM, *, timeout: float = 60.0) -> None:
-    """Set pfb_interval='Disabled' so the tick's feed-cron branch never dispatches.
-
-    Part of making every tick in this module idle-only (see the ``deployed_vm`` fixture
-    docstring) — this is also the setting issue #573 fixed (log maintenance used to
-    silently stop with a Disabled Update Frequency).
-    """
-    snippet = (
-        f"$g = config_get_path({h._php_str(CFG_GENERAL)}, array());\n"
-        "$g['pfb_interval'] = 'Disabled';\n"
-        f"config_set_path({h._php_str(CFG_GENERAL)}, $g);\n"
-        "write_config('pfBlockerNG smoke: pfb_interval Disabled');\n"
-        "echo 'OK';"
-    )
-    result = h.php_eval(vm, snippet, timeout=timeout)
-    if result.returncode != 0 or "OK" not in result.stdout:
-        raise RuntimeError(
-            f"_set_pfb_interval_disabled failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
-        )
-
-
-def _seed_future_ledger_entry(vm: SmokeVM, job_key: str, *, timeout: float = 60.0) -> None:
-    """Seed a due-ledger entry for ``job_key`` whose next_due is far in the future.
-
-    Drives the box via PHP (CLAUDE.md hard constraint: no appliance python) —
-    ``pfb_due_ledger_write_entry()`` is the package's own ledger writer. Keeps
-    'dcc'/'bl' from dispatching on the 'tick' verb so every tick in this module is
-    maintenance-only.
-    """
-    snippet = (
-        f"require_once('{_PFB_EXTRA_INC}');"
-        f"pfb_due_ledger_write_entry({h._php_str(job_key)}, array("
-        "'last_run' => time(), 'next_due' => time() + 86400, 'jitter' => 0"
-        f"), {h._php_str(PFB_DBDIR)});"
-        "echo 'OK';"
-    )
-    result = h.php_eval(vm, snippet, timeout=timeout)
-    if result.returncode != 0 or "OK" not in result.stdout:
-        raise RuntimeError(
-            f"_seed_future_ledger_entry({job_key!r}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
-        )
 
 
 def _set_log_max_days(vm: SmokeVM, values: dict[str, str], *, timeout: float = 60.0) -> None:

--- a/tests/smoke/test_smoke_apply_on_change.py
+++ b/tests/smoke/test_smoke_apply_on_change.py
@@ -62,7 +62,6 @@ _PHP = "/usr/local/bin/php"
 _PFB_PHP = "/usr/local/www/pfblockerng/pfblockerng.php"
 # The ledger lives at $pfb['dbdir']/pfb_due_ledger.json (dbdir = /var/db/pfblockerng).
 _LEDGER_DIR = "/var/db/pfblockerng"
-_PFB_EXTRA = "/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 
 
 # ---------------------------------------------------------------------------
@@ -86,7 +85,7 @@ def _write_ledger_entry(vm, job_key: str, last_run: int, next_due: int, jitter: 
     ``pfb_due_ledger_write_entry()`` (PHP) is the right tool — not a here-doc Python snippet.
     """
     snippet = (
-        f"require_once('{_PFB_EXTRA}');"
+        f"require_once('{h.PFB_EXTRA_INC}');"
         f"pfb_due_ledger_write_entry('{job_key}', array("
         f"'last_run' => {int(last_run)}, 'next_due' => {int(next_due)}, 'jitter' => {int(jitter)}"
         f"), '{_LEDGER_DIR}');"
@@ -101,7 +100,7 @@ def _set_quiet_hours(vm, window: str) -> None:
     """Set pfb_quiet_hours in config.xml via pfSsh.php."""
     # Use the config gateway rather than direct xml munging.
     snippet = (
-        f"require_once('{_PFB_EXTRA}');"
+        f"require_once('{h.PFB_EXTRA_INC}');"
         f"PfbConfig::write('pfb_quiet_hours', {json.dumps(window)});"
         "write_config('ADR-43 smoke: set quiet-hours');"
         "echo 'OK';"
@@ -293,7 +292,7 @@ def test_apply_pending_cleared_by_window_open(deployed_vm: SmokeVM):
     _force_cron_due(vm)
     pend = h.php_eval(
         vm,
-        f"require_once('{_PFB_EXTRA}');pfb_due_ledger_set_pending('cron', '{_LEDGER_DIR}');echo 'OK';",
+        f"require_once('{h.PFB_EXTRA_INC}');pfb_due_ledger_set_pending('cron', '{_LEDGER_DIR}');echo 'OK';",
     )
     assert pend.returncode == 0 and "OK" in pend.stdout, (
         f"set_pending failed: rc={pend.returncode} {pend.stderr!r} {pend.stdout!r}"

--- a/tests/smoke/test_smoke_apply_on_change.py
+++ b/tests/smoke/test_smoke_apply_on_change.py
@@ -34,10 +34,16 @@ pytestmark = [pytest.mark.apply_on_change]
 
 @pytest.fixture(scope="module")
 def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
-    """Deploy the branch .pkg once for the apply_on_change module."""
+    """Deploy the branch .pkg once for the apply_on_change module, feed-cron dispatch re-armed.
+
+    ``h.deploy`` disables the tick's feed-cron dispatch for the suite (issue #1179); the
+    quiet-hours cases below drive exactly that branch, so this module opts back in with an
+    hour count (a leaked 'Disabled' already bit it once — issue #805).
+    """
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
+    h.set_feed_cron_interval(smoke_vm, "1")
     h.ensure_dnsbl_vip(smoke_vm)
     h.use_system_dns_upstream(smoke_vm)
     try:

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -1272,7 +1272,9 @@ def test_hooks_ip_changed_unlock_forced(deployed_vm: SmokeVM) -> None:
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.timeout(90)  # the negative proof below always burns its full settle window
+# Budget: two wait_no_active_pfb_task guards (90s + 60s worst case) plus the negative
+# proof's full 20s settle window — the default 30s per-test cap would abort the cleanup.
+@pytest.mark.timeout(180)
 def test_hooks_tick_cron_gate_suppresses_pending_refire(deployed_vm: SmokeVM) -> None:
     """A pending 'cron' due-ledger entry must NOT let a tick re-fire a registered hook.
 

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -1312,7 +1312,13 @@ def test_hooks_tick_cron_gate_suppresses_pending_refire(deployed_vm: SmokeVM) ->
             f"pfb_due_ledger_set_pending('cron') failed: rc={pend.returncode} {pend.stderr!r} {pend.stdout!r}"
         )
 
-        deployed_vm.ssh(h.PHP_BIN, h.PFB_CLI, "tick", timeout=60.0)
+        # rc is the positive control: a tick that never ran (SSH/CLI error, PHP fatal) would
+        # leave the marker absent and turn the negative proof below into a false green.
+        tick = deployed_vm.ssh(h.PHP_BIN, h.PFB_CLI, "tick", timeout=60.0)
+        assert tick.returncode == 0, (
+            f"the tick verb itself failed — the negative proof below would be vacuous: "
+            f"rc={tick.returncode} stdout={tick.stdout[-800:]!r} stderr={tick.stderr!r}"
+        )
 
         # extra.inc's cron dispatch is a detached background exec: poll for the marker
         # to APPEAR (proof of a re-fire) within a bounded settle window, rather than

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -664,8 +664,11 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
 
     Also proves (issue #988): the normal-pass branch's #973 persist call
     (``pfb_persist_hook_output``) fires exactly ONCE for this hook into the PERSISTED
-    ``pfblockerng.log`` — a stray second call (a wrongly-placed lifecycle-branch persist
-    call sitting outside its own branch) would double the marker count there.
+    ``pfblockerng.log``. A duplicate here has two possible causes: a wrongly-placed
+    lifecycle-branch persist call double-firing production code, or a scheduled
+    ADR-43 tick dispatching a feed-cron pass that re-fires this still-registered hook
+    mid-test (issue #1179's confirmed root cause; ``helpers.disable_scheduled_dispatch``
+    gates that dispatch off for the whole suite).
     """
     token = "stream"
     stream_marker = f"STREAM_{token}_MARK"
@@ -734,13 +737,15 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
         persisted_delta = h.count_log_marker(deployed_vm, h.PFB_LOG, stream_marker) - persisted_before
         assert persisted_delta == 1, (
             f"hook marker {stream_marker!r} was persisted into {h.PFB_LOG} {persisted_delta} time(s) "
-            "for one hook run (expected exactly 1 — pfb_persist_hook_output double-fired):\n"
+            "for one hook run (expected exactly 1 — either pfb_persist_hook_output double-fired or a "
+            "concurrent/tick-dispatched pass re-fired the hook: issue #1179):\n"
             f"{deployed_vm.ssh('cat', h.PFB_LOG).stdout[-4000:]}"
         )
         persisted_delta_done = h.count_log_marker(deployed_vm, h.PFB_LOG, done_marker) - persisted_before_done
         assert persisted_delta_done == 1, (
             f"hook marker {done_marker!r} was persisted into {h.PFB_LOG} {persisted_delta_done} time(s) "
-            "for one hook run (expected exactly 1 — pfb_persist_hook_output double-fired):\n"
+            "for one hook run (expected exactly 1 — either pfb_persist_hook_output double-fired or a "
+            "concurrent/tick-dispatched pass re-fired the hook: issue #1179):\n"
             f"{deployed_vm.ssh('cat', h.PFB_LOG).stdout[-4000:]}"
         )
         h.clear_update_hooks(deployed_vm)
@@ -1260,3 +1265,77 @@ def test_hooks_ip_changed_unlock_forced(deployed_vm: SmokeVM) -> None:
     )
 
     h.clear_update_hooks(deployed_vm)
+
+
+# --------------------------------------------------------------------------- #
+# 13) issue #1179 — a pending tick-cron pass must not re-fire a registered hook
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(90)  # the negative proof below always burns its full settle window
+def test_hooks_tick_cron_gate_suppresses_pending_refire(deployed_vm: SmokeVM) -> None:
+    """A pending 'cron' due-ledger entry must NOT let a tick re-fire a registered hook.
+
+    THE BUG (issue #1179): the box's own */15 tick can dispatch feed-cron
+    (``sync_package_pfblockerng('cron')`` -> ``pfb_run_hooks('post', ...)``) mid-module
+    whenever ``!$cron_disabled && ($due['cron'] || pfb_due_ledger_is_pending('cron',
+    $dbdir))`` (extra.inc's tick gate) — re-firing a hook another test just registered
+    and double-persisting its markers (misdiagnosed as a ``pfb_persist_hook_output``
+    double-fire in ``test_post_hook_output_streams_into_runlog_during_run`` before this
+    fix). This probe forces the PENDING branch deterministically (no real 15-minute
+    wait, via ``pfb_due_ledger_set_pending``) and fires ONE tick directly.
+
+    It pins the harness-wide gate (``helpers.disable_scheduled_dispatch``, applied by
+    ``helpers.deploy`` for every smoke module): with it, ``$cron_disabled`` is TRUE and
+    short-circuits the ``||`` gate regardless of due/pending — no dispatch, no marker.
+    Without it, the forced pending flag alone dispatches feed-cron, the hook fires and
+    the marker appears — this test FAILS, which is exactly the flake #1179 reported.
+    """
+    token = "tickgate"
+    marker = h.hook_marker_path(token, "post")
+
+    h.wait_no_active_pfb_task(deployed_vm)  # clean baseline before forcing pending
+    h.set_update_hooks(deployed_vm, [h.env_dump_hook(token, "post")])
+    h.clear_hook_markers(deployed_vm, token)
+    assert not h.hook_marker_exists(deployed_vm, marker), "marker present before the tick (stale state?)"
+
+    try:
+        pend = h.php_eval(
+            deployed_vm,
+            f"require_once({h._php_str(h.PFB_EXTRA_INC)});"
+            f"pfb_due_ledger_set_pending('cron', {h._php_str(h.PFB_DBDIR)});"
+            "echo 'OK';",
+        )
+        assert pend.returncode == 0 and "OK" in pend.stdout, (
+            f"pfb_due_ledger_set_pending('cron') failed: rc={pend.returncode} {pend.stderr!r} {pend.stdout!r}"
+        )
+
+        deployed_vm.ssh(h.PHP_BIN, h.PFB_CLI, "tick", timeout=60.0)
+
+        # extra.inc's cron dispatch is a detached background exec: poll for the marker
+        # to APPEAR (proof of a re-fire) within a bounded settle window, rather than
+        # reading it once right after tick returns (which would race a dispatch that
+        # simply hasn't started yet — "not dispatched" vs "not dispatched YET").
+        refired = h.wait_until(lambda: h.hook_marker_exists(deployed_vm, marker), timeout=20.0, interval=4.0)
+        assert not refired, (
+            "a pending 'cron' ledger entry re-fired the registered hook via a "
+            "tick-dispatched feed-cron pass (issue #1179): "
+            f"{deployed_vm.ssh('cat', h.PFB_LOG, timeout=30.0).stdout[-2000:]}"
+        )
+    finally:
+        # Let any dispatched pass finish before the next test's clean-baseline check.
+        h.wait_no_active_pfb_task(deployed_vm, timeout=60.0)
+        # The gated branch never consumes pending_apply itself — clear it with a
+        # wholesale ledger rewrite (the package's own writer) so it cannot leak forward.
+        cleanup = h.php_eval(
+            deployed_vm,
+            f"require_once({h._php_str(h.PFB_EXTRA_INC)});"
+            "pfb_due_ledger_write_entry('cron', array("
+            "'last_run' => time(), 'next_due' => time() + 86400, 'jitter' => 0"
+            f"), {h._php_str(h.PFB_DBDIR)});"
+            "echo 'OK';",
+        )
+        assert cleanup.returncode == 0 and "OK" in cleanup.stdout, (
+            f"cron ledger cleanup failed: rc={cleanup.returncode} {cleanup.stderr!r} {cleanup.stdout!r}"
+        )
+        h.clear_update_hooks(deployed_vm)

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -86,7 +86,6 @@ LEDGER_PATH = "/var/db/pfblockerng/pfb_due_ledger.json"
 _LEDGER_DIR = "/var/db/pfblockerng"
 _PHP = "/usr/local/bin/php"
 _PFB_PHP = "/usr/local/www/pfblockerng/pfblockerng.php"
-_PFB_EXTRA = "/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 _PFB_INC = "/usr/local/pkg/pfblockerng/pfblockerng.inc"
 
 # A throwaway marker dropped in /var right before the reboot in test_tick_reboot_persists_ledger.
@@ -119,7 +118,7 @@ def _write_ledger_entry(vm, job_key: str, last_run: int, next_due: int, jitter: 
     Python snippet, which silently no-op'd at rc=127 and left these writes ineffective.
     """
     snippet = (
-        f"require_once('{_PFB_EXTRA}');"
+        f"require_once('{h.PFB_EXTRA_INC}');"
         f"pfb_due_ledger_write_entry('{job_key}', array("
         f"'last_run' => {int(last_run)}, 'next_due' => {int(next_due)}, 'jitter' => {int(jitter)}"
         f"), '{_LEDGER_DIR}');"
@@ -230,7 +229,7 @@ def test_tick_cron_entry_installed(deployed_vm: SmokeVM):
 
     probe = h.php_eval(
         vm,
-        f"require_once('{_PFB_EXTRA}');"
+        f"require_once('{h.PFB_EXTRA_INC}');"
         "echo 'TICKMIN:' . pfb_tick_interval_clamp((string) PfbConfig::read('pfb_tick_interval')) . ':END';",
     )
     match = re.search(r"TICKMIN:(\d+):END", probe.stdout)

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -8,6 +8,7 @@ Dispatch (when ready):
     gh workflow run smoke.yml -f pytest_marker="tick"
 
 Tests:
+    test_tick_cron_entry_installed    — the tick is SCHEDULED (one */N root crontab entry)
     test_tick_dispatches_due_feed     — tick fires a due feed (ledger past)
     test_tick_skips_non_due_feed      — tick skips a feed whose next_due is future
     test_tick_wiped_ledger_jittered   — wiped ledger gives due-now but jittered next_due
@@ -17,6 +18,7 @@ Tests:
 
 import json
 import os
+import re
 from collections.abc import Iterator
 
 import pytest
@@ -38,10 +40,16 @@ pytestmark = [pytest.mark.tick]
 
 @pytest.fixture(scope="module")
 def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
-    """Deploy the branch .pkg once for the tick module."""
+    """Deploy the branch .pkg once for the tick module, with feed-cron dispatch re-armed.
+
+    ``h.deploy`` disables the tick's feed-cron dispatch for the suite (issue #1179) — this
+    module EXERCISES that dispatch, so it opts back in with an hour count. Every tick here
+    is still fired explicitly by the test, never by the box's own cron.
+    """
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
+    h.set_feed_cron_interval(smoke_vm, "1")
     h.ensure_dnsbl_vip(smoke_vm)
     h.use_system_dns_upstream(smoke_vm)
     try:
@@ -199,6 +207,49 @@ def _reset_ss_extdns(vm) -> None:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.tick
+def test_tick_cron_entry_installed(deployed_vm: SmokeVM):
+    """The tick IS scheduled: ONE ``*/pfb_tick_interval`` root crontab entry, from the sync.
+
+    This is the suite's only dependence on the real schedule. Everything else fires the
+    ``tick`` verb explicitly — the box's wall-clock dispatch is gated off for every module
+    (``helpers.disable_scheduled_dispatch``, issue #1179) because it raced tests. Given
+    this entry plus the tick-verb cases below, "the schedule runs the tick" follows.
+
+    Scenario:
+        Background: pfBlockerNG installed and enabled.
+            When /etc/crontab is read (the effective schedule cron actually runs).
+            Then exactly one entry runs ``pfblockerng.php tick`` as root, every
+            ``*/N`` minutes with N = the clamped ``pfb_tick_interval``, on every
+            mday/month/wday.
+    """
+    vm = deployed_vm
+
+    probe = h.php_eval(
+        vm,
+        f"require_once('{_PFB_EXTRA}');"
+        "echo 'TICKMIN:' . pfb_tick_interval_clamp((string) PfbConfig::read('pfb_tick_interval')) . ':END';",
+    )
+    match = re.search(r"TICKMIN:(\d+):END", probe.stdout)
+    assert match, f"could not read pfb_tick_interval from the box: rc={probe.returncode} stdout={probe.stdout!r}"
+    expected_minute = f"*/{match.group(1)}"
+
+    crontab = vm.ssh("/bin/cat", "/etc/crontab")
+    entries = [line.split(None, 6) for line in crontab.stdout.splitlines() if "pfblockerng.php tick" in line]
+    assert len(entries) == 1, (
+        f"expected exactly ONE 'pfblockerng.php tick' crontab entry, found {len(entries)}"
+        f" — install_cron_job() left the schedule wrong:\n{crontab.stdout}"
+    )
+    minute, hour, mday, month, wday, who, command = entries[0]
+    assert (minute, hour, mday, month, wday, who) == (expected_minute, "*", "*", "*", "*", "root"), (
+        "tick cron entry has the wrong schedule: expected "
+        f"({expected_minute!r}, '*', '*', '*', '*', 'root'), got "
+        f"({minute!r}, {hour!r}, {mday!r}, {month!r}, {wday!r}, {who!r})"
+    )
+    assert command.startswith(f"{_PHP} {_PFB_PHP} tick"), f"tick cron entry runs an unexpected command: {command!r}"
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Problem (issue #1179)

`test_post_hook_output_streams_into_runlog_during_run` intermittently saw a hook marker
persisted **twice**. The confirmed root cause is not a `pfb_persist_hook_output` double-fire:
the guest's own ADR-43 cron tick fired mid-module at a quarter-hour boundary, passed
`pfblockerng_extra.inc`'s gate

```php
if (!$cron_disabled && ($due['cron'] || pfb_due_ledger_is_pending('cron', $dbdir))) {
```

and dispatched a feed-cron pass — `sync_package_pfblockerng()` → `pfb_run_hooks('post')` —
re-firing the hook the test had just registered. The failing run's guest snapshot shows the
`CRON PROCESS START` banner and a second hook header at the 22:45:00 boundary. It is
wall-clock dependence, and every module that registers update hooks or counts log markers was
exposed to it, not only the hooks module.

## Fix — the suite drives scheduling itself; the guest's schedule never dispatches

`helpers.deploy()` (the one place every smoke and UI module installs the package) ends with
`disable_scheduled_dispatch()`, which closes all three of the tick's dispatch branches:

- feed cron — `pfb_interval='Disabled'` (the `!$cron_disabled` guard);
- `cron`/`dcc`/`bl` — a not-due due-ledger (`seed_scheduled_jobs_not_due()`: `next_due` a day
  out, any `pending_apply` dropped).

The scheduled tick therefore stays armed but idle, and no wall-clock pass can run under a
test. `reset_pfb_baseline()` re-seeds the ledger at module teardown so the gap between one
module's teardown and the next module's deploy is covered too.

Scheduling is still fully covered, by the two assertions that imply it:

1. **it IS scheduled** — new `test_smoke_tick.test_tick_cron_entry_installed` asserts exactly
   one `pfblockerng.php tick` entry in `/etc/crontab`, as root, at `*/N` with N the clamped
   `pfb_tick_interval`;
2. **the tick verb works** — the existing tick/quiet-hours cases, which invoke the verb
   directly. Those two modules (`test_smoke_tick`, `test_smoke_apply_on_change`) re-arm the
   feed cron explicitly (`h.set_feed_cron_interval(vm, "1")`).

### Two constraints this had to respect (both learned from live evidence)

- **The cron entry cannot simply be removed.** Every `sync_package_pfblockerng()` re-installs
  it while the package is enabled (`pfblockerng.inc`, "Define/Apply CRON Jobs"), and pfSense's
  `configure_cron()` restarts a stopped cron daemon (`services.inc`). The tick's own
  config/ledger gates are the only durable off switch.
- **The teardown gate must not write config.** An earlier revision re-applied the whole gate
  (a config write) at module teardown. That left `pfb_interval` set in the General section, so
  the next module's `pkg` install grandfathered `pfb_feed_internal_filter` to `'off'`
  (`pfb_feed_filter_install_default()`: a General section that exists as a non-empty array
  without that key is treated as an already-configured box) — silently disabling the feed-host
  SSRF guard for the rest of the session, which
  `test_feed_internal_filter_blocks_then_allowlist_exempts` caught (the internal mock feed
  downloaded with `200 OK`; the guest config ended with
  `<pfb_feed_internal_filter>off</pfb_feed_internal_filter>`). The boundary gap is closed with
  the due-ledger — a file, not config — and `reset_pfb_baseline` now documents the constraint.

`test_log_age_retention` had already hand-rolled this recipe (Disabled interval + future dcc/bl
entries) for its idle-tick cases; those copies are deleted — the harness default gives it the
same state.

## Regression test

`test_hooks_tick_cron_gate_suppresses_pending_refire` forces the pending-cron branch
deterministically (`pfb_due_ledger_set_pending`, no 15-minute wait), asserts the tick verb's
rc (so the negative proof cannot pass vacuously), fires one tick and asserts the registered
hook does **not** re-fire.

**Red** — live CE 2.8 VM, gate removed from the harness, reproduction test byte-identical to
the merged one (`git hash-object` = `a425ca28…`), run
[29162685740](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29162685740):

```text
E  AssertionError: a pending 'cron' ledger entry re-fired the registered hook via a
E  tick-dispatched feed-cron pass (issue #1179):
E    [ pfB Hook ] post smoke tickgate post (hook_post_tickgate.sh, timeout 60s)
E  assert not True
1 failed, 682 deselected in 63.19s
```

**Green** — full smoke fan-out (CE 2.8 + Plus 26.03), run
[29163384922](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29163384922): every
shard green except one pre-existing failure (below). Full UI tier (all tiers, CE + Plus):
run [29160774951](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29160774951), green.

**Known unrelated failure.** `test_smoke_apply_on_change::test_apply_inside_window_dispatches`
fails on this branch **and on a same-day `devel` control run**
([29162674395](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29162674395), same test,
same two shards) — the #1175 feed-pass-busy defer racing the module's own previous test. Filed
as #1202; not touched here.

## Coverage matrix (enumerated from `git grep`, not memory)

| Module | Relation to the scheduler | Outcome |
| --- | --- | --- |
| `test_smoke_hooks` | registers hooks; the #1179 flake | default gate + regression test |
| `test_hook_stream_visibility` | registers hooks | protected by the default gate |
| `test_lifecycle_hook_visibility` | registers hooks | protected by the default gate |
| `test_smoke_adr40` | registers hooks | protected by the default gate |
| `test_smoke_aggregate` | registers hooks | protected by the default gate |
| `ui/test_hooks` | registers hooks (UI deploy) | protected by the default gate |
| `test_smoke_tick` | exercises tick dispatch + ledger | opts in (`set_feed_cron_interval "1"`); new schedule-installed test |
| `test_smoke_apply_on_change` | exercises tick dispatch (quiet hours) | opts in (`set_feed_cron_interval "1"`) |
| `test_log_age_retention` | needs idle ticks | local Disabled/ledger helpers deleted — the default provides it |
| `test_smoke_feeds`, `test_smoke_adr62` | use the `cron` VERB | unaffected: the CLI coerces a non-numeric interval to `'1'`; the gate lives only in `pfblockerng_tick()` |
| `test_downgrade_prepare` | removes the tick cron ITEM | unaffected (cron items, not the interval) |
| `ui/test_functional` | asserts the crontab entry; POSTs `pfb_interval` | unaffected: reads/restores the original value, whatever it is |
| `ui/test_render_smoke` | writes its own ledger entry | unaffected (the seed only pushes next_due out) |

## Review findings folded in

- **Boundary gap** (adversarial review): the teardown left the tick re-armed until the next
  deploy — now covered by the ledger seed (and the config-write approach that first fixed it
  is the one the SSRF-guard regression above rejected).
- **Timeout headroom**: the probe's two `wait_no_active_pfb_task` guards (90 s + 60 s) plus the
  20 s negative-proof window exceeded its marker — raised to `@pytest.mark.timeout(180)`; the
  poll now matches the sibling shape (`timeout=20, interval=4`).
- **Vacuous negative proof** (Copilot): the `tick` invocation's rc is asserted, so a tick that
  never ran cannot make "the hook did not re-fire" pass.
- **Convention**: PHP snippets route through `h._php_str()`; the two scheduling modules use the
  shared `helpers.PFB_EXTRA_INC`.

Fixes #1179
