### PR TITLE
tests/smoke: seed NDJSON interchange rows in alerts render-verify

### DIFF
--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -180,9 +180,9 @@ D5_DOMAIN = "rv809-up1.com"
 # brief's own suggestion of an underscore does NOT trigger this: PFB_FILTER_DOMAIN's
 # charset explicitly includes '_', so an underscore domain WOULD be covered/batched.
 # D7 is nowhere on disk (total miss -> Unknown); D8 below is its positive counterpart
-# (present verbatim in pfb_py_data.txt -- proves issue #837's per-row fixed-string
-# fallback actually FINDS a covered metachar domain, not just that an uncovered one
-# renders the same 'Unknown' shape as a covered total miss).
+# (its NDJSON row IS in pfb_py_data.txt, #1083/PR #1178 -- proves issue #837's per-row
+# needle fallback actually FINDS a covered metachar domain, not just that an uncovered
+# one renders the same 'Unknown' shape as a covered total miss).
 D7_DOMAIN = "rv809*m1.com"
 D8_DOMAIN = "rv809*p1.com"
 
@@ -393,14 +393,26 @@ def _unified_lines() -> list[str]:
     return lines
 
 
+def _ndjson_domain_row(domain: str, feed: str, group: str) -> str:
+    """Schema v1 domain row (#1189/#1083/PR #1178), byte-compatible with
+    pfb_dnsbl_ndjson_emit_domain_row(): compact, key order kind/domain/log/feed/group,
+    unescaped slashes/unicode -- Python's json.dumps defaults already match both.
+    """
+    row = {"kind": "domain", "domain": domain, "log": "1", "feed": feed, "group": group}
+    return json.dumps(row, separators=(",", ":"), ensure_ascii=False) + "\n"
+
+
 def _py_data_appendix() -> str:
-    lines = [f"x,{D2_DOMAIN},,A,{D2_DATA_FEED},{D2_DATA_GROUP}", f"x,{D8_DOMAIN},,A,{D8_DATA_FEED},{D8_DATA_GROUP}"]
-    lines += [f"x,{d},,A,{FILLER_DNSBL_FEED},{FILLER_DNSBL_GROUP}" for d in FILLER_DNSBL_DOMAINS]
-    return "\n".join(lines) + "\n"
+    lines = [
+        _ndjson_domain_row(D2_DOMAIN, D2_DATA_FEED, D2_DATA_GROUP),
+        _ndjson_domain_row(D8_DOMAIN, D8_DATA_FEED, D8_DATA_GROUP),
+    ]
+    lines += [_ndjson_domain_row(d, FILLER_DNSBL_FEED, FILLER_DNSBL_GROUP) for d in FILLER_DNSBL_DOMAINS]
+    return "".join(lines)
 
 
 def _py_zone_appendix() -> str:
-    return f"x,{D3_PARENT},,A,{D3_FEED},{D3_GROUP}\n"
+    return _ndjson_domain_row(D3_PARENT, D3_FEED, D3_GROUP)
 
 
 # --------------------------------------------------------------------------- #
@@ -1055,15 +1067,15 @@ def test_d8_covered_metachar_domain_found_via_per_row_fallback(
     """D8: a metachar domain the per-row fallback CAN find, unlike D7's total miss.
 
     Given: 'rv809*p1.com' contains '*' so it also fails PFB_FILTER_DOMAIN and is
-    excluded from the batched prefetch, exactly like D7 -- but unlike D7 it IS
-    present verbatim in pfb_py_data.txt.
+    excluded from the batched prefetch, exactly like D7 -- but unlike D7 its
+    NDJSON row IS present in pfb_py_data.txt.
     When: the alert view renders.
-    Then: pfb_dnsbl_parse_compute()'s per-row fixed-string fallback (issue #837:
-    `grep -F` on the raw domain, not a hand-escaped BRE) actually FINDS its own
-    entry -- the row struck-shows the logged group/feed and displays the
-    data-file ones, never 'Unknown'. Red on a pre-#837 package (the per-row BRE
-    mis-escapes the '*' and misses the domain's own data-file line -> Unknown),
-    green post-fix; the offline red->green proof is
+    Then: pfb_dnsbl_parse_compute()'s per-row fallback (issue #837/#1083: `grep -F`
+    on the NDJSON "domain" field needle, not a hand-escaped BRE on the raw domain)
+    actually FINDS its own entry -- the row struck-shows the logged group/feed and
+    displays the data-file ones, never 'Unknown'. Red on a pre-#837 package (the
+    per-row BRE mis-escapes the '*' and misses the domain's own data-file line ->
+    Unknown), green post-fix; the offline red->green proof is
     tests/php/DnsblParseComputeMetacharTest.php.
     """
     body = render_diff_state["captures"]["alert"].body

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -395,8 +395,9 @@ def _unified_lines() -> list[str]:
 
 def _ndjson_domain_row(domain: str, feed: str, group: str) -> str:
     """Schema v1 domain row (#1189/#1083/PR #1178), byte-compatible with
-    pfb_dnsbl_ndjson_emit_domain_row(): compact, key order kind/domain/log/feed/group,
-    unescaped slashes/unicode -- Python's json.dumps defaults already match both.
+    pfb_dnsbl_ndjson_emit_domain_row(): key order kind/domain/log/feed/group; the explicit
+    separators + ensure_ascii=False give the compact, unescaped-unicode shape of PHP's
+    JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE (json.dumps leaves slashes unescaped anyway).
     """
     row = {"kind": "domain", "domain": domain, "log": "1", "feed": feed, "group": group}
     return json.dumps(row, separators=(",", ":"), ensure_ascii=False) + "\n"


### PR DESCRIPTION
Fixes #1189.

Three Alerts render-verify cases (`test_d2_data_hit_drift_renders_data_feed`, `test_d3_zone_hit_renders_tld_mode`, `test_d8_covered_metachar_domain_found_via_per_row_fallback`) fail on devel's live-VM `ui-tests` functional tier, both CE and Plus legs.

**Root cause** (not the issue's original lead): PR #1178 (issue #1083, ADR-62) flipped the DNSBL interchange files `pfb_py_data.txt`/`pfb_py_zone.txt` from positional CSV to strict NDJSON schema v1; the smoke module still seeded positional-CSV rows into those live files, so every consumer lookup (batched prefetch grep, batched zone grep, per-row fallback grep on the `"domain":"<d>"` needle) missed the seeded rows and the render degraded the affected rows to "Feed: Unknown". Reproduced off-appliance with byte-extracted `pfb_dnsbl_ndjson_*` functions: the CSV row shape fails needle/parse/verify for all three fixture domains, while a schema-v1 control row passes all three.

Two corrections to the issue's record:

- The regression window is 07-09 → 07-11, not 07-08 → 07-09: run 29004328565's *functional* jobs passed on both legs (its red was the browser tier). PR #1178 merged 2026-07-10T23:15Z, inside the corrected window, touching zero smoke files.
- The `PFB_FILTER_DOMAIN` "Failed validation" log lines are by design: the `*` fixture domains intentionally fail the filter to force the per-row fallback. They are not the defect.

**Change** (harness-only; production untouched): the module's seeders now emit schema-v1 NDJSON rows byte-identical to PHP's `pfb_dnsbl_ndjson_emit_domain_row()` (compact JSON, key order `kind,domain,log,feed,group`, `log:"1"`), via a new `_ndjson_domain_row()` helper; stale CSV/raw-grep comments reconciled. Negative controls D4/D7 are untouched (dnsbl.log-only scenarios).

**Verification**: off-appliance PHP round-trip probe — rows from the actual edited seeders pass needle+parse+verify for D2/D3-zone/D8/filler and are byte-identical to the PHP emit output; origin/devel's CSV seeders fail the same probe (counterfactual red). Off-appliance gates green (pytest 2672 passed, ruff, mypy). Live-VM green: targeted `ui-tests.yml` dispatch on this branch (this host has no local smoke-box pool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8cr16xTZ9ixtbJndKKjrd