### PR TITLE
pfblockerng_log: fall back to defaultlogs for an unknown logtype (#1198)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -406,7 +406,8 @@ $section->addInput(new Form_Select(
 // Collect selected logs
 $logs = array();
 $clearable = $downloadable = FALSE;
-$selected = !empty($pconfig['logtype']) ? $pconfig['logtype'] : 'defaultlogs';
+// issue #1198: array_key_exists() rejects an unknown scalar (subsumes !empty()'s '' and '0' rejects too).
+$selected = array_key_exists($pconfig['logtype'], $pfb_logtypes) ? $pconfig['logtype'] : 'defaultlogs';
 $pfb_sel = $pfb_logtypes[$selected];
 
 if (isset($pfb_sel['logs'])) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -406,7 +406,7 @@ $section->addInput(new Form_Select(
 // Collect selected logs
 $logs = array();
 $clearable = $downloadable = FALSE;
-// issue #1198: array_key_exists() rejects an unknown scalar (subsumes !empty()'s '' and '0' rejects too).
+// issue #1198: a scalar logtype that is not a key here warns at the offset below -- fall back.
 $selected = array_key_exists($pconfig['logtype'], $pfb_logtypes) ? $pconfig['logtype'] : 'defaultlogs';
 $pfb_sel = $pfb_logtypes[$selected];
 

--- a/tests/php/LogArrayRequestGuardTest.php
+++ b/tests/php/LogArrayRequestGuardTest.php
@@ -87,9 +87,12 @@ final class LogArrayRequestGuardTest extends TestCase
 
 		// Region 5: 'logtype' -> $selected -> $pfb_logtypes[$selected] offset.
 		if (!function_exists('pfb_log_oracle_selected_logtype')) {
+			// issue #1198: non-greedy $selected assignment (+ optional leading
+			// comment) matches both the pre-fix !empty() and post-fix
+			// array_key_exists() source, so the region survives the fix.
 			if (!preg_match(
 				'/\/\/ Collect selected logs\n\$logs = array\(\);\n\$clearable = \$downloadable = FALSE;\n'
-				. '(\$selected = !empty\(\$pconfig\[\'logtype\'\]\) \? \$pconfig\[\'logtype\'\] : \'defaultlogs\';\n'
+				. '((?:\/\/[^\n]*\n)*\$selected = .*?;\n'
 				. '\$pfb_sel = \$pfb_logtypes\[\$selected\];)/',
 				$src,
 				$m
@@ -125,7 +128,34 @@ final class LogArrayRequestGuardTest extends TestCase
 		return [
 			'defaultlogs' => ['logdir' => '/var/log/pfblockerng/'],
 			'python'      => ['logdir' => '/var/unbound/'],
+			// mixed-case static key (real page has 'GeoIP') -- pins case-sensitivity.
+			'GeoIP'       => ['logdir' => '/var/db/pfblockerng/GeoIP/'],
+			// dynamic blacklist-title key shape (`<Title>logs`, merged in at :189).
+			'MyFeedlogs'  => ['logdir' => '/var/db/pfblockerng/myfeed/'],
 		];
+	}
+
+	/**
+	 * Runs Region 5 capturing E_WARNING/E_DEPRECATED; fails loudly on a
+	 * TypeError (the pre-#1198 undefined-array-key -> non-nullable return-type
+	 * mismatch an unknown/hostile logtype throws).
+	 */
+	private function runSelectedLogtypeExpectingNoWarnings(array $pconfig, array $pfb_logtypes): array
+	{
+		$warnings = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+			$warnings[] = $errstr;
+			return TRUE;
+		}, E_WARNING | E_DEPRECATED);
+		try {
+			$pfb_sel = pfb_log_oracle_selected_logtype($pconfig, $pfb_logtypes);
+		} catch (\TypeError $e) {
+			restore_error_handler();
+			$this->fail('an unknown/hostile logtype must not TypeError the $pfb_logtypes[] offset: ' . $e->getMessage());
+		}
+		restore_error_handler();
+		$this->assertSame([], $warnings, 'an unknown/hostile logtype must emit zero warnings, got: ' . implode('; ', $warnings));
+		return $pfb_sel;
 	}
 
 	// --- ajax 'file' -> htmlspecialchars() ----------------------------------
@@ -335,5 +365,103 @@ final class LogArrayRequestGuardTest extends TestCase
 		$pconfig = pfb_log_oracle_pconfig();
 		$pfb_sel = pfb_log_oracle_selected_logtype($pconfig, $this->logtypes());
 		$this->assertSame($this->logtypes()['python'], $pfb_sel, 'a scalar logtype value must still resolve its own entry');
+	}
+
+	// --- issue #1198: unknown-scalar coverage matrix + hostile inputs -------
+
+	public function testSelectedLogtypeAbsentLogtypeFallsBackToDefaultNoWarnings(): void
+	{
+		// No $_POST at all -- ingress leaves $pconfig['logtype'] === ''.
+		$pconfig = pfb_log_oracle_pconfig();
+		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+	}
+
+	public function testSelectedLogtypeEmptyStringFallsBackToDefaultNoWarnings(): void
+	{
+		$_POST['logtype'] = '';
+		$pconfig = pfb_log_oracle_pconfig();
+		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+	}
+
+	public function testSelectedLogtypeDefaultLogsKeyResolvesItsOwnEntryNoWarnings(): void
+	{
+		$_POST['logtype'] = 'defaultlogs';
+		$pconfig = pfb_log_oracle_pconfig();
+		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+	}
+
+	public function testSelectedLogtypeDynamicKeyResolvesItsOwnEntryNoWarnings(): void
+	{
+		$_POST['logtype'] = 'MyFeedlogs';
+		$pconfig = pfb_log_oracle_pconfig();
+		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame(
+			$this->logtypes()['MyFeedlogs'],
+			$pfb_sel,
+			'a valid dynamic-title logtype key must resolve its own entry, not be clobbered to defaultlogs'
+		);
+	}
+
+	public function testSelectedLogtypeUnknownScalarFallsBackToDefaultNoWarnings(): void
+	{
+		// issue #1198: the reported defect -- a scalar but unknown logtype.
+		$_POST['logtype'] = 'zzz';
+		$pconfig = pfb_log_oracle_pconfig();
+		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+	}
+
+	public function testSelectedLogtypeNumericZeroStringDoesNotDivergeFromOldGuard(): void
+	{
+		// '0' is the one value where !empty() and array_key_exists() could
+		// have disagreed (empty('0') === TRUE); pins that neither matches.
+		$_POST['logtype'] = '0';
+		$pconfig = pfb_log_oracle_pconfig();
+		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+	}
+
+	public function testSelectedLogtypeLowercaseCaseVariantFallsBackToDefaultNoWarnings(): void
+	{
+		// keys are case-sensitive; a real key is mixed-case ('GeoIP').
+		$_POST['logtype'] = 'geoip';
+		$pconfig = pfb_log_oracle_pconfig();
+		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+	}
+
+	public function testSelectedLogtypeTrailingSpaceNearMissFallsBackToDefaultNoWarnings(): void
+	{
+		$_POST['logtype'] = 'defaultlogs ';
+		$pconfig = pfb_log_oracle_pconfig();
+		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+	}
+
+	public function testSelectedLogtypeEmbeddedNulFallsBackToDefaultNoWarnings(): void
+	{
+		$_POST['logtype'] = "zz\0z";
+		$pconfig = pfb_log_oracle_pconfig();
+		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+	}
+
+	public function testSelectedLogtypeOversizedValueFallsBackToDefaultNoWarnings(): void
+	{
+		$_POST['logtype'] = str_repeat('a', 8192);
+		$pconfig = pfb_log_oracle_pconfig();
+		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+	}
+
+	public function testSelectedLogtypePathTraversalMetacharsFallsBackToDefaultNoWarnings(): void
+	{
+		$_POST['logtype'] = '../../etc/passwd';
+		$pconfig = pfb_log_oracle_pconfig();
+		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
 	}
 }

--- a/tests/php/LogArrayRequestGuardTest.php
+++ b/tests/php/LogArrayRequestGuardTest.php
@@ -150,10 +150,12 @@ final class LogArrayRequestGuardTest extends TestCase
 		try {
 			$pfb_sel = pfb_log_oracle_selected_logtype($pconfig, $pfb_logtypes);
 		} catch (\TypeError $e) {
-			restore_error_handler();
 			$this->fail('an unknown/hostile logtype must not TypeError the $pfb_logtypes[] offset: ' . $e->getMessage());
+		} finally {
+			// finally, not the happy path: any other throwable would otherwise leak the
+			// handler into sibling tests (self-encapsulation).
+			restore_error_handler();
 		}
-		restore_error_handler();
 		$this->assertSame([], $warnings, 'an unknown/hostile logtype must emit zero warnings, got: ' . implode('; ', $warnings));
 		return $pfb_sel;
 	}

--- a/tests/smoke/ui/test_post_array_scalar_guards.py
+++ b/tests/smoke/ui/test_post_array_scalar_guards.py
@@ -28,7 +28,10 @@ its gate requires literal ``REMOTE_ADDR == 127.0.0.1``). The sibling
 ``_post_action``-based elseif-chain siblings. Issue #1183's
 ``pfblockerng_log.php`` cluster closes the ``$pconfig['logtype']``/``logFile``
 ingress normalization (POST) and the ajax ``$_REQUEST['file']``
-``htmlspecialchars()`` sink (GET query).
+``htmlspecialchars()`` sink (GET query). Issue #1198 closes a DIFFERENT input
+class on the same page: a *scalar but unknown* ``logtype`` (e.g. ``zzz``)
+passes #1183's ``is_string()`` guard yet still hit an unguarded
+``$pfb_logtypes[$selected]`` offset -- 6 warnings per request.
 
 Each save/GET must respond like any validation failure: HTTP 200, no login
 bounce, and NOT ONE new byte in any candidate ``php_error.log``.
@@ -161,6 +164,37 @@ def test_array_valued_field_rejected_gracefully(
     extra_fields: dict[str, str] | None,
 ) -> None:
     _post_with_array_field(webui, smoke_vm, page, field, extra_fields)
+
+
+def test_unknown_scalar_logtype_rejected_gracefully(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """issue #1198: a scalar but UNKNOWN 'logtype' must fall back silently.
+
+    Given pfblockerng_log.php's own scraped form (valid CSRF token),
+    When 'logtype' is resubmitted as the plain scalar 'zzz' (not an array --
+      that class is #1183's row above; this is a DIFFERENT input class: a
+      string that passes the is_string() ingress guard but has no entry in
+      $pfb_logtypes),
+    Then the page still answers HTTP 200, the session survives, and no
+      candidate php_error.log gains a byte (pre-fix: 6 E_WARNINGs per
+      request from the unguarded $pfb_logtypes[$selected] offset).
+    """
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    page = "/pfblockerng/pfblockerng_log.php"
+    got = webui.get(page)
+    assert got.status_code == 200, f"GET {page} -> HTTP {got.status_code}"
+    assert not looks_like_login_page(got.text), f"GET {page} bounced to the login form"
+
+    payload = scrape_form_fields(got.text)
+    payload["logtype"] = "zzz"
+    payload["save"] = "Save"
+
+    resp = webui.session.post(webui.url(page), data=payload, verify=webui._verify, timeout=_POST_TIMEOUT)
+
+    assert resp.status_code == 200, f"POST {page} with logtype=zzz -> HTTP {resp.status_code}"
+    assert not looks_like_login_page(resp.text), f"POST {page} with logtype=zzz bounced to the login form"
+    guard.assert_no_growth()
 
 
 # issue #1106: 'atype' (GET) and '$_REQUEST[savemsg]' are read outside the save


### PR DESCRIPTION
Fixes #1198.

## Problem

An authenticated POST to `pfblockerng_log.php` carrying a **scalar but unknown** `logtype` value (e.g. `logtype=zzz`) passes the `is_string()` ingress guard landed for #1183 — correctly, since it *is* a string — and reaches the unguarded lookup at `:410`:

```php
$selected = !empty($pconfig['logtype']) ? $pconfig['logtype'] : 'defaultlogs';
$pfb_sel = $pfb_logtypes[$selected];   // E_WARNING: Undefined array key "zzz"
```

`$pfb_sel` becomes `null`, and the five downstream offsets (`['logs']`, `['logdir']`, `['ext']`, `['clear']`, `['download']`) each warn again — **six E_WARNINGs per request** into `php_error.log`. The page still renders via its fallbacks, so the only symptom is log noise.

This is reachable **without a crafted request**: `$pfb_logtypes` gains a dynamic `<Title>logs` key per enabled blacklist item (`array_merge` at `:189`). Select "Original Foo Files", then remove or rename that blacklist item, and an ordinary stale-form or browser-back POST now carries a `logtype` key that no longer exists.

Warning-level and pre-existing; distinct from the array-`$_POST` TypeError family (#1143).

## Fix

Validate membership rather than mere non-emptiness — the idiom already used for this exact bug class at `pfblockerng.php:1755` and `pfblockerng_blacklist.php:171`:

```php
$selected = array_key_exists($pconfig['logtype'], $pfb_logtypes) ? $pconfig['logtype'] : 'defaultlogs';
```

`array_key_exists()` subsumes the old `!empty()`: both `''` and `'0'` remain non-keys, so every currently-reachable input still resolves exactly as before. The #1183 ingress guard, the ajax branch, and the `Form_Select` are untouched.

## Tests

Red-first, frozen byte-identical between red and green (`git hash-object` = `60a26872…` at both ends), then re-executed independently by the gate.

**`tests/php/LogArrayRequestGuardTest.php`** — the coverage matrix (absent / array-valued / `''` / valid default key / valid non-default key / valid dynamic-title key / unknown scalar) plus hostile rows (`'0'`, lowercase case-variant against the real mixed-case `GeoIP` key, trailing-space near-miss, embedded NUL, 8 KiB oversized, path-traversal metachars). Each asserts both observables: the `defaultlogs` fallback *and* zero `E_WARNING`/`E_DEPRECATED` emissions.

Region 5's eval-extraction regex captured the two fix-site lines verbatim, so the fix would have broken the bootstrap and errored every test in the file rather than failing honestly. It is relaxed to match both the pre- and post-fix source while still binding the same two statements (`.` never crosses a newline, so it cannot swallow unrelated code).

Red on untouched production code — 22 pass, exactly the 6 unknown/hostile rows fail, which also proves the relaxed regex still matches the old source:

```text
Tests: 28, Assertions: 41, Failures: 6.
pfb_log_oracle_selected_logtype(): Return value must be of type array, null returned
```

Green after the fix, same frozen file, zero edits: `OK (28 tests, 47 assertions)`.

The five remaining matrix rows passed even pre-fix — confirming `array_key_exists()` does not diverge from `!empty()` on any currently-valid input.

**`tests/smoke/ui/test_post_array_scalar_guards.py`** — Tier-B pin `test_unknown_scalar_logtype_rejected_gracefully`: POSTs a scalar-but-unknown `logtype` (a different input class from the existing array-valued rows, whose helper appends `[]` to the field name) and asserts HTTP 200 plus `PhpErrorLogGuard.assert_no_growth()`. Tier-A render coverage of the page already exists and stays green.

## Gates

`php -l` · `vendor/bin/phpunit` (3042 tests, OK) · `composer phpstan` (no errors) · `composer phpcs` (clean) · `python3 -m pytest` (2672 passed) · `ruff check` · `ruff format --check` · `mypy tests/` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxB6ePGeNCz6fJFXTvFHFg