### PR TITLE
pfblockerng: cron-tick verb + .pfb_cron_disable flag, replacing the smoke scheduler gate (#1204)

### DIFF
--- a/.ADRs/ADR_25_Group_Policy_DNSBL/ADR.md
+++ b/.ADRs/ADR_25_Group_Policy_DNSBL/ADR.md
@@ -133,8 +133,9 @@ A standing feature request asks for **DNSBL blocking by schedule** — "enable/d
 during school hours". pfSense already ships a native scheduler: the `<schedules>` config
 section (Firewall > Schedules), referenced by firewall rules via a `sched` name and evaluated
 by `filter_get_time_based_rule_status()`. None of it is wired into the DNSBL decision path.
-(Updated 2026-07-03 for ADR-43: package scheduling is now **one cron tick** —
-`pfblockerng.php tick` every `pfb_tick_interval` minutes reading the due-ledger — and an
+(Updated 2026-07-03 for ADR-43, amended 2026-07-12 for issue #1204: package scheduling is now
+**one cron tick** — `pfblockerng.php cron-tick` every `pfb_tick_interval` minutes reading the
+due-ledger — and an
 already-landed PHP time-window evaluator exists, `pfb_quiet_hours` +
 `pfb_quiet_hours_in_window()` in `pfblockerng_extra.inc`, a precedent/possible reuse for this
 ADR's schedule serialisation. Both still govern *refresh/apply timing*, not whether blocking

--- a/.ADRs/ADR_43_Update_And_Scheduling_Revamp/ADR.md
+++ b/.ADRs/ADR_43_Update_And_Scheduling_Revamp/ADR.md
@@ -150,6 +150,13 @@ window, and revamp the Update page onto the clean API.
 | **F — Update page revamp** | Rebuild the Update tab on the new API: explicit **scope** (ip/dnsbl/both) + **force** toggles (replacing the opaque Force/Update/Cron/Reload buttons), a **per-feed/job "next run" view** read from the ledger, a **"run now"** that calls the new request, and a cleaned-up update-log pane. Focused functional cleanup, **not** a visual redesign. |
 | **G — Back-compat (config)** | Existing config (`pfb_interval`/`pfb_min`/`pfb_dailystart`, per-feed `freq`/`updatefreq`) is **read at the ADR-28/29 boundary** and **reinterpreted as ledger seed cadence** (a feed's `freq` becomes its next-due interval; the global interval seeds the default). No `config.xml` schema migration; the tick frequency is a new knob with a safe default. Any new registered field goes through `PfbConfig` (ADR-29). |
 
+**Amended 2026-07-12 (issue #1204).** Rows D/E still hold — one cron entry, no scheduling logic in
+crontab — but the entry now calls the cron-only wrapper verb **`pfblockerng.php cron-tick`**, which
+runs the tick unless `/var/db/pfblockerng/.pfb_cron_disable` exists (then it logs
+`[ Disabled by … ]` and dispatches nothing; the Update page reports the suppression). The direct
+`pfblockerng.php tick` verb and the tick's own semantics are unchanged. The cron generator's
+removal signatures are needle-tightened because `install_cron_job()` matches by **substring**.
+
 ### Semantics that MUST be preserved (the contract — pin with tests before changing)
 
 1. **Every old verb maps to exactly one documented request and still works.** `cron`/`update`/

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1170,7 +1170,11 @@ window. `PFB_TRIGGER` values are unchanged across the migration, so the ADR-12 h
 ### One trigger-tick + the due-ledger
 
 The four legacy cron families (`cron`/`dcc`/`bl`/`ss_refresh`) collapse to **one** crontab entry —
-`*/<pfb_tick_interval> … pfblockerng.php tick` (default every **15 min**). The tick carries **no**
+`*/<pfb_tick_interval> … pfblockerng.php cron-tick` (default every **15 min**). `cron-tick` is the
+cron-only wrapper: it runs the tick unless `/var/db/pfblockerng/.pfb_cron_disable` exists, in which
+case it logs `[ Disabled by … ]` and dispatches nothing (issue #1204 — the smoke suite's scheduler
+off switch; the Update page reports the suppression). The direct `pfblockerng.php tick` verb is
+never gated. The tick carries **no**
 scheduling logic: it reads the due-ledger, dispatches each **due** job through the new API
 (`pfb_trigger scope=both force=false trigger=cron` for the feed pass), runs `ss_refresh` every tick
 (cheap DNS re-resolution), then `mark_ran`s each dispatched job. `clearip`/`cleardnsbl` (ADR-30) and

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -159,9 +159,10 @@ reverse and that do **not** self-heal on an older release:
    `{ip,dnsbl}_{pre,post}_*.{sh,py}` scripts from the package root into `list_scripts/`. A
    pre-4.0.x release resolves list scripts against the package **root only**, so a moved script
    silently stops running after a downgrade.
-2. **The ADR-43 `tick` cron.** The `pfblockerng.php tick` entry replaced the older
-   `cron`/`dcc`/`ss_refresh`/`bl` fleet; an older release has no `tick` verb, so the entry becomes
-   an orphan and the update fleet is absent until the older release re-syncs.
+2. **The ADR-43 tick cron.** The `pfblockerng.php cron-tick` entry (issue #1204; `pfblockerng.php
+   tick` on a pre-#1204 build) replaced the older `cron`/`dcc`/`ss_refresh`/`bl` fleet; an older
+   release has neither verb, so the entry becomes an orphan and the update fleet is absent until
+   the older release re-syncs.
 
 Everything else the upgrade changed is already downgrade-safe: new-in-4.0.x config keys are
 **ignored** by an older release (inert, preserved for roll-forward), and the `.md5` →

--- a/scripts/pfb-downgrade-prep.sh
+++ b/scripts/pfb-downgrade-prep.sh
@@ -15,10 +15,10 @@
 #   1. Custom list pre/post scripts relocated into list_scripts/ on upgrade — a
 #      pre-4.0.x release resolves list scripts against the package ROOT only, so a
 #      moved script silently stops running. They are moved back to the root.
-#   2. The ADR-43 `pfblockerng.php tick` cron entry (which replaced the older
-#      cron/dcc/ss_refresh/bl fleet) is removed, so the downgraded release
-#      re-establishes its own schedule on its next sync instead of leaving an
-#      orphan tick cron behind that it has no verb to run.
+#   2. The ADR-43 scheduled-tick cron entry (`pfblockerng.php cron-tick`, or the
+#      legacy `pfblockerng.php tick` on an older build -- issue #1204) is removed, so
+#      the downgraded release re-establishes its own schedule on its next sync instead
+#      of leaving an orphan tick cron behind that it has no verb to run.
 #
 # Everything else the upgrade changed is already downgrade-safe: new-in-4.0.x config
 # keys are ignored by an older release (inert, preserved for roll-forward), and the
@@ -102,10 +102,13 @@ pfb_restore_list_scripts() {
 }
 
 # pfb_remove_tick_cron
-# Remove the ADR-43 `pfblockerng.php tick` cron entry via pfSsh.php, which calls the
-# shipped install_cron_job() so config.xml + the live crontab are rewritten cleanly.
-# Prints "removed" / "absent" to stdout; returns non-zero (and prints to stderr) if
-# pfSsh.php is unavailable.
+# Remove the ADR-43 scheduled-tick cron entry via pfSsh.php, which calls the shipped
+# install_cron_job() so config.xml + the live crontab are rewritten cleanly. Checks
+# BOTH the current `pfblockerng.php cron-tick` verb and the legacy pre-#1204
+# `pfblockerng.php tick` verb -- install_cron_job() matches by SUBSTRING and 'tick'
+# does not match 'cron-tick', so each needs its own needle. Prints "removed" /
+# "absent" to stdout; returns non-zero (and prints to stderr) if pfSsh.php is
+# unavailable.
 pfb_remove_tick_cron() {
 	if [ ! -f "$PFB_PFSSH" ]; then
 		echo "pfb-downgrade-prep: pfSsh.php not found at ${PFB_PFSSH}; cannot remove the tick cron" >&2
@@ -118,10 +121,17 @@ pfb_remove_tick_cron() {
 	_out=$(timeout 120 "$PFB_PFSSH" <<'PHP'
 $present = FALSE;
 foreach (config_get_path('cron/item', array()) as $i) {
-	if (strpos($i['command'] ?? '', 'pfblockerng.php tick') !== FALSE) { $present = TRUE; break; }
+	$cmd = $i['command'] ?? '';
+	if (strpos($cmd, 'pfblockerng.php cron-tick') !== FALSE || strpos($cmd, 'pfblockerng.php tick') !== FALSE) {
+		$present = TRUE;
+		break;
+	}
 }
-if ($present) { install_cron_job('pfblockerng.php tick', FALSE); echo "PFB_TICK_REMOVED\n"; }
-else { echo "PFB_TICK_ABSENT\n"; }
+if ($present) {
+	install_cron_job('pfblockerng.php cron-tick', FALSE);
+	install_cron_job('pfblockerng.php tick', FALSE);
+	echo "PFB_TICK_REMOVED\n";
+} else { echo "PFB_TICK_ABSENT\n"; }
 exec
 exit
 PHP

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14697,15 +14697,17 @@ function pfb_dnsbl_lastevent($p_group, $p_entry, $p_details) {
 function pfb_feed_task_running(): bool {
 	$result_ps = array();
 	exec('/bin/ps -wax', $result_ps);
-	return (bool) preg_grep('/pfblockerng[.]php\s+?(cron|update|pfb_trigger|tick|forcecheck)/', $result_ps);
+	return (bool) preg_grep('/pfblockerng[.]php\s+?(cron-tick|cron|update|pfb_trigger|tick|forcecheck)/', $result_ps);
 }
 
 
 // TRUE when a pfBlockerNG UPDATE pass (cron/update/pfb_trigger/forcecheck/dcc/bl) is
 // currently running -- deliberately narrower than pfb_feed_task_running() above:
-//   - EXCLUDES 'tick': the only caller is pfblockerng_tick() itself (the scheduled log
-//     maintenance gate at its tail), and a tick always sees its OWN process in `ps` --
-//     including it here would make the gate permanently closed.
+//   - EXCLUDES 'tick' AND 'cron-tick' (the scheduled tick's own verb): the only caller is
+//     pfblockerng_tick() itself (the scheduled log maintenance gate at its tail), and a tick
+//     always sees its OWN process in `ps` -- including it here would make the gate permanently
+//     closed. Hence (?![-\w]) rather than \b: a hyphen SATISFIES \b, so a bare 'cron' arm would
+//     match the 'cron-tick' process (issue #1204).
 //   - INCLUDES 'dcc'/'bl': both append to $pfb['extraslog'] for potentially minutes,
 //     the same log pfb_log_mgmt()'s tail-to-temp-then-cat-over trim can race and lose
 //     lines from, so a due-ledger-dispatched dcc/bl pass must also hold this gate closed.
@@ -14714,7 +14716,7 @@ function pfb_update_pass_running(?array $ps_lines = NULL): bool {
 	if ($ps_lines === NULL) {
 		exec('/bin/ps -wax', $ps_lines);
 	}
-	return (bool) preg_grep('/pfblockerng[.]php\s+?(cron|update(ip|dnsbl)?|pfb_trigger|forcecheck|dcc|bl)\b/', $ps_lines);
+	return (bool) preg_grep('/pfblockerng[.]php\s+?(cron|update(ip|dnsbl)?|pfb_trigger|forcecheck|dcc|bl)(?![-\w])/', $ps_lines);
 }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3958,6 +3958,18 @@ function pfb_software_provenance_ok(): bool {
 	return pfb_software_is_our_build(pfb_pkg_installed_repo(pfb_pkg_installed_name()));
 }
 
+// issue #1204: hidden dbdir sentinel suppressing the scheduled cron-tick verb without
+// touching config.xml (house pattern: PFB_SOFTWARE_PANEL_OVERRIDE above). Presence-only
+// -- the file's content is never read. $path/$dbdir are injectable for off-box tests.
+function pfb_cron_disable_path(?string $dbdir = NULL): string {
+	global $pfb;
+	return ($dbdir ?? $pfb['dbdir']) . '/.pfb_cron_disable';
+}
+
+function pfb_cron_disabled(?string $path = NULL): bool {
+	return is_file($path ?? pfb_cron_disable_path());
+}
+
 /*
  * Pending-changes flag. A save on a DEFERRED settings page (DNSBL/IP/Feeds) writes config.xml
  * but does NOT apply — only a real Update/cron pass applies it. The flag drives a GUI banner
@@ -5787,20 +5799,23 @@ function pfblockerng_cron_exists($pfb_cmd, $pfb_min, $pfb_hour, $pfb_mday, $pfb_
 // tick cron's install/teardown behaviour without driving the whole sync pass.
 function pfblockerng_configure_tick_cron(bool $enabled, int $tick_min, string $log): void {
 	$pfb_tick_min = '*/' . $tick_min;
-	$pfb_tick_cmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php tick >> {$log} 2>&1";
+	$pfb_tick_cmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron-tick >> {$log} 2>&1";
 
 	if ($enabled) {
 		if (!pfblockerng_cron_exists($pfb_tick_cmd, $pfb_tick_min, '*', '*', '*')) {
-			install_cron_job('pfblockerng.php tick', FALSE);	// remove stale tick (interval changed)
+			install_cron_job('pfblockerng.php cron-tick', FALSE);	// remove stale cron-tick (interval changed)
+			install_cron_job('pfblockerng.php tick', FALSE);	// remove legacy pre-#1204 entry
 			install_cron_job($pfb_tick_cmd, TRUE, $pfb_tick_min, '*', '*', '*', '*', 'root');
 		}
 	}
 	else {
+		install_cron_job('pfblockerng.php cron-tick', FALSE);
 		install_cron_job('pfblockerng.php tick', FALSE);
 	}
 
-	// Migration teardown: remove old fleet jobs from pre-ADR-43 installs.
-	install_cron_job('pfblockerng.php cron', FALSE);
+	// issue #1204: trailing space -- a bare 'pfblockerng.php cron' needle substring-matches
+	// 'pfblockerng.php cron-tick' and would delete the just-installed entry every sync.
+	install_cron_job('pfblockerng.php cron ', FALSE);
 	install_cron_job('pfblockerng.php dcc', FALSE);
 	install_cron_job('pfblockerng.php ss_refresh', FALSE);
 	install_cron_job('pfblockerng.php bl', FALSE);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5783,6 +5783,29 @@ function pfblockerng_cron_exists($pfb_cmd, $pfb_min, $pfb_hour, $pfb_mday, $pfb_
 	return FALSE;
 }
 
+// issue #1204: extracted from sync_package_pfblockerng() so PHPUnit can pin the
+// tick cron's install/teardown behaviour without driving the whole sync pass.
+function pfblockerng_configure_tick_cron(bool $enabled, int $tick_min, string $log): void {
+	$pfb_tick_min = '*/' . $tick_min;
+	$pfb_tick_cmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php tick >> {$log} 2>&1";
+
+	if ($enabled) {
+		if (!pfblockerng_cron_exists($pfb_tick_cmd, $pfb_tick_min, '*', '*', '*')) {
+			install_cron_job('pfblockerng.php tick', FALSE);	// remove stale tick (interval changed)
+			install_cron_job($pfb_tick_cmd, TRUE, $pfb_tick_min, '*', '*', '*', '*', 'root');
+		}
+	}
+	else {
+		install_cron_job('pfblockerng.php tick', FALSE);
+	}
+
+	// Migration teardown: remove old fleet jobs from pre-ADR-43 installs.
+	install_cron_job('pfblockerng.php cron', FALSE);
+	install_cron_job('pfblockerng.php dcc', FALSE);
+	install_cron_job('pfblockerng.php ss_refresh', FALSE);
+	install_cron_job('pfblockerng.php bl', FALSE);
+}
+
 
 // Calculate the cron task base hour setting
 function pfb_cron_base_hour($freq) {
@@ -19831,24 +19854,7 @@ function sync_package_pfblockerng($cron='') {
 	// A single */pfb_tick_interval cron entry fires; the tick reads the due-ledger
 	// and dispatches each job only when its entry says "due". clearip/cleardnsbl
 	// are out of scope (ADR-30 territory) and remain as separate jobs below.
-	$pfb_tick_min = '*/' . pfb_tick_interval_clamp(PfbConfig::read('pfb_tick_interval'));
-	$pfb_tick_cmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php tick >> {$pfb['log']} 2>&1";
-
-	if ($pfb['enable'] == 'on') {
-		if (!pfblockerng_cron_exists($pfb_tick_cmd, $pfb_tick_min, '*', '*', '*')) {
-			install_cron_job('pfblockerng.php tick', FALSE);	// remove stale tick (interval changed)
-			install_cron_job($pfb_tick_cmd, TRUE, $pfb_tick_min, '*', '*', '*', '*', 'root');
-		}
-	}
-	else {
-		install_cron_job('pfblockerng.php tick', FALSE);
-	}
-
-	// Migration teardown: remove old fleet jobs from pre-ADR-43 installs.
-	install_cron_job('pfblockerng.php cron', FALSE);
-	install_cron_job('pfblockerng.php dcc', FALSE);
-	install_cron_job('pfblockerng.php ss_refresh', FALSE);
-	install_cron_job('pfblockerng.php bl', FALSE);
+	pfblockerng_configure_tick_cron($pfb['enable'] == 'on', pfb_tick_interval_clamp(PfbConfig::read('pfb_tick_interval')), $pfb['log']);
 
 	// Define pfBlockerNG clear [ dnsbl and/or IP ] counter CRON job
 	foreach (array( 'clearip', 'cleardnsbl') as $type) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2575,8 +2575,9 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir): bool
  * Lives here (not in the www/ dispatcher script) rather than the reverse so the
  * PHPUnit bootstrap can load and call the real entrypoint off-appliance: the www
  * script is never require()'d by the test suite, so before this move the tick had
- * zero off-box coverage (review finding ADR43-5). The www dispatch
- * (`pfblockerng.php tick`) still just calls this function.
+ * zero off-box coverage (review finding ADR43-5). Both www dispatch verbs -- the direct
+ * `pfblockerng.php tick` and the crontab's `cron-tick` (gated by .pfb_cron_disable) -- just
+ * call this function.
  *
  * Apply-on-change (ADR-40 IP / ADR-10 DNSBL): a due job dispatches pfb_trigger, which
  * calls sync_package_pfblockerng() — ADR-40 gates alias apply on pfb_alias_set_different()

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -108,6 +108,17 @@ if (isset($argv[1])) {
 		pfblockerng_tick();
 		exit;
 	}
+	// issue #1204: cron-only verb the installed crontab entry calls. A present
+	// .pfb_cron_disable sentinel suppresses just this scheduled dispatch -- the
+	// direct 'tick' verb above stays fully live regardless.
+	elseif ($argv[1] == 'cron-tick') {
+		if (pfb_cron_disabled()) {
+			print '[ Disabled by ' . pfb_cron_disable_path() . " ]\n";
+			exit;
+		}
+		pfblockerng_tick();
+		exit;
+	}
 	// PFBL-03: root-only DNSBL-control entrypoint. Writes a validated command to the
 	// local privileged command channel consumed by pfb_unbound.py.
 	// Usage: pfblockerng.php dnsbl-control <disable [sec] | enable |

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -98,7 +98,8 @@ function pfb_runnow(string $scope, bool $force): void {
 	pfbupdate_status(gettext("Running: scope={$scope} force={$force_val}"));
 
 	// Remove the tick cron to prevent overlap; sync_package_pfblockerng() restores it.
-	install_cron_job('pfblockerng.php tick', FALSE);
+	install_cron_job('pfblockerng.php cron-tick', FALSE);
+	install_cron_job('pfblockerng.php tick', FALSE);	// issue #1204: legacy pre-#1204 entry, if present
 
 	pfb_logger("\n [ Run Now - scope={$scope} force={$force_val} trigger={$trigger} ]\n", 1);
 
@@ -149,7 +150,8 @@ function pfb_runnow_forcecheck(string $scope): void {
 
 	pfbupdate_status(gettext("Running: scope={$scope} force=download/both (on-demand detector)"));
 
-	install_cron_job('pfblockerng.php tick', FALSE);
+	install_cron_job('pfblockerng.php cron-tick', FALSE);
+	install_cron_job('pfblockerng.php tick', FALSE);	// issue #1204: legacy pre-#1204 entry, if present
 
 	pfb_logger("\n [ Force check - scope={$scope} ]\n", 1);
 
@@ -237,11 +239,16 @@ if (pfb_cfg_toggle_read($pfb['enable']) === PfbToggle::On) {
 	$nextcron	= "{$hour_final}:{$min_final}:{$sec_final}";
 }
 
-// Probe for the exact tick signature install_cron_job() registers in pfblockerng.inc, so an
-// installed tick is not misreported as "[ Missing cron task ]".
-$pfb_cmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php tick >> {$pfb['log']} 2>&1";
+// Probe for the exact cron-tick signature install_cron_job() registers in pfblockerng.inc, so
+// an installed cron-tick is not misreported as "[ Missing cron task ]".
+$pfb_cmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron-tick >> {$pfb['log']} 2>&1";
 
-if (pfb_cfg_toggle_read($pfb['enable']) === PfbToggle::On) {
+// issue #1204: the suppression sentinel outranks the enabled/missing-cron checks below, so a
+// stray .pfb_cron_disable file is always visible even on an otherwise-healthy schedule.
+if (pfb_cron_disabled()) {
+	$cronreal = ' [ Disabled by ' . pfb_cron_disable_path() . ' ]';
+	$nextcron = '--';
+} elseif (pfb_cfg_toggle_read($pfb['enable']) === PfbToggle::On) {
 	if (!pfblockerng_cron_exists($pfb_cmd, '*/' . $pfb_tick_min, '*', '*', '*')) {
 		$cronreal = ' [ Missing cron task ]';
 		$nextcron = '--';

--- a/tests/php/PfbUpdatePassRunningTest.php
+++ b/tests/php/PfbUpdatePassRunningTest.php
@@ -80,6 +80,23 @@ final class PfbUpdatePassRunningTest extends TestCase
 		$this->assertFalse(pfb_update_pass_running($this->psLine('tick')));
 	}
 
+	/**
+	 * The SCHEDULED tick runs as the 'cron-tick' verb (issue #1204) and must be excluded
+	 * for the same reason 'tick' is: it is the log-maintenance gate's own caller. A verb
+	 * prefix match ('cron' + a word boundary the hyphen satisfies) would leave the gate
+	 * permanently closed on every real box, silently stopping scheduled log maintenance.
+	 */
+	public function testCronTickLineIsNotRunning(): void
+	{
+		$this->assertFalse(pfb_update_pass_running($this->psLine('cron-tick')));
+	}
+
+	/** The legacy 'cron' verb still counts as a running pass, hyphen-suffix guard notwithstanding. */
+	public function testCronLineWithTrailingArgsIsRunning(): void
+	{
+		$this->assertTrue(pfb_update_pass_running($this->psLine('cron >> /var/log/pfblockerng/pfblockerng.log')));
+	}
+
 	public function testUnrelatedProcessLineIsNotRunning(): void
 	{
 		$this->assertFalse(pfb_update_pass_running(['  999  -  Ss    0:00.01 /usr/sbin/cron -s']));

--- a/tests/php/TickCronInstallTest.php
+++ b/tests/php/TickCronInstallTest.php
@@ -67,7 +67,7 @@ final class TickCronInstallTest extends TestCase
 	{
 		$this->assertSame([], $this->cronCommands());
 
-		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
 
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
 	}
@@ -76,12 +76,31 @@ final class TickCronInstallTest extends TestCase
 	{
 		// A pre-existing cron-tick entry at a DIFFERENT interval (interval changed
 		// 30 -> 15 across a settings save) must not linger alongside the fresh one.
+		// The MINUTE field is the discriminator: both entries carry the same command,
+		// so asserting the command alone would pass even if the stale */30 survived.
 		$this->seedCronItem(0, self::CRON_TICK_CMD, '*/30');
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
+		$this->assertSame('*/30', config_get_path('cron/item/0/minute'), 'before: the stale interval is in place');
 
-		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
 
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
+		$this->assertSame('*/15', config_get_path('cron/item/0/minute'), 'after: the entry carries the NEW interval');
+	}
+
+	public function testEnableReplacesACronTickEntryWhoseCommandChanged(): void
+	{
+		// The stale-cron-tick removal earns its keep here: install_cron_job() overwrites an
+		// entry its own command substring-matches, but a stored cron-tick command that DIFFERS
+		// (e.g. a log path change) is not matched by the new command -- without the removal it
+		// would linger beside the fresh entry.
+		$stale = '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron-tick >> /var/log/old-pfblockerng.log 2>&1';
+		$this->seedCronItem(0, $stale, '*/15');
+		$this->assertSame([$stale], $this->cronCommands());
+
+		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
+
+		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands(), 'the stale-command entry must not linger beside the fresh one');
 	}
 
 	public function testEnableUpgradesLegacyTickEntryToCronTick(): void
@@ -91,7 +110,7 @@ final class TickCronInstallTest extends TestCase
 		$this->seedCronItem(0, self::LEGACY_TICK_CMD, '*/15');
 		$this->assertSame([self::LEGACY_TICK_CMD], $this->cronCommands());
 
-		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
 
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
 	}
@@ -100,7 +119,7 @@ final class TickCronInstallTest extends TestCase
 	{
 		$this->seedCronItem(0, self::CRON_TICK_CMD, '*/15');
 
-		pfblockerng_configure_tick_cron(false, 15, self::LOG);
+		pfblockerng_configure_tick_cron(FALSE, 15, self::LOG);
 
 		$this->assertSame([], $this->cronCommands());
 	}
@@ -110,7 +129,7 @@ final class TickCronInstallTest extends TestCase
 		// A box that upgraded straight into 'disabled' must still lose its old tick entry.
 		$this->seedCronItem(0, self::LEGACY_TICK_CMD, '*/15');
 
-		pfblockerng_configure_tick_cron(false, 15, self::LOG);
+		pfblockerng_configure_tick_cron(FALSE, 15, self::LOG);
 
 		$this->assertSame([], $this->cronCommands());
 	}
@@ -124,10 +143,10 @@ final class TickCronInstallTest extends TestCase
 		// legacy entry left to absorb it) exposes a too-loose needle.
 		$this->seedCronItem(0, '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron >> ' . self::LOG . ' 2>&1', '0');
 
-		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands(), 'first sync: legacy cron removed, cron-tick installed');
 
-		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands(), 'steady-state resync: the cron-tick entry must survive the migration teardown');
 	}
 
@@ -138,7 +157,7 @@ final class TickCronInstallTest extends TestCase
 		$this->seedCronItem(2, '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php bl >> ' . self::LOG . ' 2>&1', '0');
 		$this->assertCount(3, $this->cronCommands());
 
-		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
 
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
 	}

--- a/tests/php/TickCronInstallTest.php
+++ b/tests/php/TickCronInstallTest.php
@@ -3,25 +3,46 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfblockerng_configure_tick_cron() (issue #1204) -- the ADR-43 scheduled-tick cron
- * install/teardown, extracted out of sync_package_pfblockerng() for testability.
+ * pfblockerng_configure_tick_cron() (issue #1204): the ADR-43 scheduled-tick cron
+ * install/teardown now installs the cron-tick verb (not tick), so the crontab
+ * entry is gateable by pfb_cron_disabled() without touching the direct tick verb.
+ * Also covers the migration-teardown strstr regression: 'pfblockerng.php cron'
+ * must NOT substring-match the just-installed 'pfblockerng.php cron-tick' entry.
  *
- * This file currently pins the PRE-#1204 behaviour (verb 'tick'; the extraction
- * itself is behaviour-preserving -- issue #1204's cron-tick verb + suppression
- * gate land in a later commit that edits these expectations forward).
+ * pfb_cron_disable_path()/pfb_cron_disabled(): the hidden dbdir sentinel that
+ * suppresses the scheduled dispatch (house pattern: PFB_SOFTWARE_PANEL_OVERRIDE /
+ * pfb_software_panel_override()). Presence-only -- content is never read; every
+ * hostile-input class from CLAUDE.md's coverage matrix gets its own assertion.
  */
 #[CoversFunction('pfblockerng_configure_tick_cron')]
+#[CoversFunction('pfb_cron_disable_path')]
+#[CoversFunction('pfb_cron_disabled')]
 final class TickCronInstallTest extends TestCase
 {
 	private const LOG = '/var/log/pfblockerng/pfblockerng.log';
-	private const TICK_CMD = '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php tick >> ' . self::LOG . ' 2>&1';
+	private const CRON_TICK_CMD = '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron-tick >> ' . self::LOG . ' 2>&1';
+	private const LEGACY_TICK_CMD = '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php tick >> ' . self::LOG . ' 2>&1';
+
+	/** @var string Per-test temp dir for the cron-disable sentinel tests. */
+	private string $tmp;
 
 	protected function setUp(): void
 	{
 		$GLOBALS['config'] = [];
+		$this->tmp = sys_get_temp_dir() . '/pfb_cron_disable_' . getmypid() . '_' . uniqid();
+		@mkdir($this->tmp, 0777, TRUE);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob("{$this->tmp}/*") ?: [] as $f) {
+			is_dir($f) ? @rmdir($f) : @unlink($f);
+		}
+		@rmdir($this->tmp);
 	}
 
 	private function cronCommands(): array
@@ -32,56 +53,153 @@ final class TickCronInstallTest extends TestCase
 		);
 	}
 
-	public function testEnableInstallsTickCommand(): void
+	private function seedCronItem(int $idx, string $command, string $minute = '*/30'): void
 	{
-		// Before: no cron/item at all.
+		config_set_path("cron/item/{$idx}", [
+			'minute' => $minute, 'hour' => '*', 'mday' => '*', 'month' => '*',
+			'wday' => '*', 'who' => 'root', 'command' => $command,
+		]);
+	}
+
+	// --- pfblockerng_configure_tick_cron() ------------------------------------
+
+	public function testEnableInstallsCronTickCommand(): void
+	{
 		$this->assertSame([], $this->cronCommands());
 
 		pfblockerng_configure_tick_cron(true, 15, self::LOG);
 
-		$this->assertSame([self::TICK_CMD], $this->cronCommands());
+		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
 	}
 
-	public function testEnableRemovesStaleTickBeforeReinstall(): void
+	public function testEnableRemovesStaleCronTickBeforeReinstall(): void
 	{
-		// A pre-existing tick entry at a DIFFERENT interval (e.g. interval changed
+		// A pre-existing cron-tick entry at a DIFFERENT interval (interval changed
 		// 30 -> 15 across a settings save) must not linger alongside the fresh one.
-		config_set_path('cron/item/0', [
-			'minute' => '*/30', 'hour' => '*', 'mday' => '*', 'month' => '*',
-			'wday' => '*', 'who' => 'root', 'command' => self::TICK_CMD,
-		]);
-		$this->assertSame([self::TICK_CMD], $this->cronCommands());
+		$this->seedCronItem(0, self::CRON_TICK_CMD, '*/30');
+		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
 
 		pfblockerng_configure_tick_cron(true, 15, self::LOG);
 
-		// Exactly ONE entry remains, and it is the (re-added) tick command.
-		$this->assertSame([self::TICK_CMD], $this->cronCommands());
+		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
 	}
 
-	public function testDisableRemovesTickEntry(): void
+	public function testEnableUpgradesLegacyTickEntryToCronTick(): void
 	{
-		config_set_path('cron/item/0', [
-			'minute' => '*/15', 'hour' => '*', 'mday' => '*', 'month' => '*',
-			'wday' => '*', 'who' => 'root', 'command' => self::TICK_CMD,
-		]);
-		$this->assertSame([self::TICK_CMD], $this->cronCommands());
+		// Upgrade case: a pre-#1204 build left a bare 'tick' entry. It must be
+		// replaced -- exactly ONE entry remains, and it is cron-tick.
+		$this->seedCronItem(0, self::LEGACY_TICK_CMD, '*/15');
+		$this->assertSame([self::LEGACY_TICK_CMD], $this->cronCommands());
+
+		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+
+		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
+	}
+
+	public function testDisableRemovesCronTickEntry(): void
+	{
+		$this->seedCronItem(0, self::CRON_TICK_CMD, '*/15');
 
 		pfblockerng_configure_tick_cron(false, 15, self::LOG);
 
 		$this->assertSame([], $this->cronCommands());
 	}
 
-	public function testMigrationTeardownRemovesLegacyCronDccSsRefreshBl(): void
+	public function testDisableRemovesLegacyTickEntry(): void
 	{
-		config_set_path('cron/item/0', ['minute' => '0', 'hour' => '0', 'mday' => '*', 'month' => '*', 'wday' => '*', 'who' => 'root', 'command' => '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron >> ' . self::LOG . ' 2>&1']);
-		config_set_path('cron/item/1', ['minute' => '0', 'hour' => '0', 'mday' => '*', 'month' => '*', 'wday' => '*', 'who' => 'root', 'command' => '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php dcc >> ' . self::LOG . ' 2>&1']);
-		config_set_path('cron/item/2', ['minute' => '0', 'hour' => '0', 'mday' => '*', 'month' => '*', 'wday' => '*', 'who' => 'root', 'command' => '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php ss_refresh >> ' . self::LOG . ' 2>&1']);
-		config_set_path('cron/item/3', ['minute' => '0', 'hour' => '0', 'mday' => '*', 'month' => '*', 'wday' => '*', 'who' => 'root', 'command' => '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php bl >> ' . self::LOG . ' 2>&1']);
-		$this->assertCount(4, $this->cronCommands());
+		// A box that upgraded straight into 'disabled' must still lose its old tick entry.
+		$this->seedCronItem(0, self::LEGACY_TICK_CMD, '*/15');
+
+		pfblockerng_configure_tick_cron(false, 15, self::LOG);
+
+		$this->assertSame([], $this->cronCommands());
+	}
+
+	public function testMigrationTeardownRemovesLegacyCronButSparesCronTick(): void
+	{
+		// strstr regression (issue #1204): the bare 'pfblockerng.php cron' needle must
+		// NOT substring-match 'pfblockerng.php cron-tick' and delete the just-installed entry.
+		$this->seedCronItem(0, '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron >> ' . self::LOG . ' 2>&1', '0');
 
 		pfblockerng_configure_tick_cron(true, 15, self::LOG);
 
-		// Every legacy fleet entry is gone; only the fresh tick entry remains.
-		$this->assertSame([self::TICK_CMD], $this->cronCommands());
+		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
+	}
+
+	public function testMigrationTeardownRemovesLegacyDccSsRefreshBlAndCronTickSurvives(): void
+	{
+		$this->seedCronItem(0, '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php dcc >> ' . self::LOG . ' 2>&1', '0');
+		$this->seedCronItem(1, '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php ss_refresh >> ' . self::LOG . ' 2>&1', '0');
+		$this->seedCronItem(2, '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php bl >> ' . self::LOG . ' 2>&1', '0');
+		$this->assertCount(3, $this->cronCommands());
+
+		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+
+		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
+	}
+
+	// --- pfb_cron_disable_path() / pfb_cron_disabled() ------------------------
+
+	public function testDisablePathBuildsFromInjectedDbdir(): void
+	{
+		$this->assertSame("{$this->tmp}/.pfb_cron_disable", pfb_cron_disable_path($this->tmp));
+	}
+
+	public function testDisablePathDefaultsToGlobalPfbDbdir(): void
+	{
+		$this->assertSame("{$GLOBALS['pfb']['dbdir']}/.pfb_cron_disable", pfb_cron_disable_path());
+	}
+
+	public function testCronNotDisabledWhenFlagAbsent(): void
+	{
+		$this->assertFalse(pfb_cron_disabled(pfb_cron_disable_path($this->tmp)));
+	}
+
+	public function testCronDisabledWhenFlagIsEmptyFile(): void
+	{
+		$path = pfb_cron_disable_path($this->tmp);
+		touch($path);
+
+		$this->assertTrue(pfb_cron_disabled($path));
+	}
+
+	/**
+	 * @return array<string, array{0:string}>
+	 */
+	public static function arbitraryFlagContentProvider(): array
+	{
+		return [
+			'off (content never overrides presence)' => ['off'],
+			'whitespace'                              => ["  \t\n  "],
+			'binary'                                  => ["\x00\x01\xff\xfe"],
+			'oversized'                                => [str_repeat('x', 65536)],
+		];
+	}
+
+	#[DataProvider('arbitraryFlagContentProvider')]
+	public function testCronDisabledIgnoresFlagContent(string $content): void
+	{
+		$path = pfb_cron_disable_path($this->tmp);
+		file_put_contents($path, $content);
+
+		$this->assertTrue(pfb_cron_disabled($path));
+	}
+
+	public function testCronNotDisabledWhenPathIsADirectory(): void
+	{
+		$path = pfb_cron_disable_path($this->tmp);
+		mkdir($path);
+
+		$this->assertFalse(pfb_cron_disabled($path));
+	}
+
+	public function testCronDisabledWhenFlagIsASymlinkToAFile(): void
+	{
+		$target = "{$this->tmp}/real-file";
+		touch($target);
+		$path = pfb_cron_disable_path($this->tmp);
+		symlink($target, $path);
+
+		$this->assertTrue(pfb_cron_disabled($path));
 	}
 }

--- a/tests/php/TickCronInstallTest.php
+++ b/tests/php/TickCronInstallTest.php
@@ -117,13 +117,18 @@ final class TickCronInstallTest extends TestCase
 
 	public function testMigrationTeardownRemovesLegacyCronButSparesCronTick(): void
 	{
-		// strstr regression (issue #1204): the bare 'pfblockerng.php cron' needle must
-		// NOT substring-match 'pfblockerng.php cron-tick' and delete the just-installed entry.
+		// strstr regression (issue #1204): the bare 'pfblockerng.php cron' needle must NOT
+		// substring-match 'pfblockerng.php cron-tick' and delete the just-installed entry.
+		// The SECOND call is what discriminates: on the first pass the legacy entry absorbs
+		// install_cron_job()'s first-match-wins removal, so only a steady-state resync (no
+		// legacy entry left to absorb it) exposes a too-loose needle.
 		$this->seedCronItem(0, '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron >> ' . self::LOG . ' 2>&1', '0');
 
 		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands(), 'first sync: legacy cron removed, cron-tick installed');
 
-		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
+		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands(), 'steady-state resync: the cron-tick entry must survive the migration teardown');
 	}
 
 	public function testMigrationTeardownRemovesLegacyDccSsRefreshBlAndCronTickSurvives(): void

--- a/tests/php/TickCronInstallTest.php
+++ b/tests/php/TickCronInstallTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfblockerng_configure_tick_cron() (issue #1204) -- the ADR-43 scheduled-tick cron
+ * install/teardown, extracted out of sync_package_pfblockerng() for testability.
+ *
+ * This file currently pins the PRE-#1204 behaviour (verb 'tick'; the extraction
+ * itself is behaviour-preserving -- issue #1204's cron-tick verb + suppression
+ * gate land in a later commit that edits these expectations forward).
+ */
+#[CoversFunction('pfblockerng_configure_tick_cron')]
+final class TickCronInstallTest extends TestCase
+{
+	private const LOG = '/var/log/pfblockerng/pfblockerng.log';
+	private const TICK_CMD = '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php tick >> ' . self::LOG . ' 2>&1';
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	private function cronCommands(): array
+	{
+		return array_map(
+			static fn ($item) => $item['command'],
+			config_get_path('cron/item', [])
+		);
+	}
+
+	public function testEnableInstallsTickCommand(): void
+	{
+		// Before: no cron/item at all.
+		$this->assertSame([], $this->cronCommands());
+
+		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+
+		$this->assertSame([self::TICK_CMD], $this->cronCommands());
+	}
+
+	public function testEnableRemovesStaleTickBeforeReinstall(): void
+	{
+		// A pre-existing tick entry at a DIFFERENT interval (e.g. interval changed
+		// 30 -> 15 across a settings save) must not linger alongside the fresh one.
+		config_set_path('cron/item/0', [
+			'minute' => '*/30', 'hour' => '*', 'mday' => '*', 'month' => '*',
+			'wday' => '*', 'who' => 'root', 'command' => self::TICK_CMD,
+		]);
+		$this->assertSame([self::TICK_CMD], $this->cronCommands());
+
+		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+
+		// Exactly ONE entry remains, and it is the (re-added) tick command.
+		$this->assertSame([self::TICK_CMD], $this->cronCommands());
+	}
+
+	public function testDisableRemovesTickEntry(): void
+	{
+		config_set_path('cron/item/0', [
+			'minute' => '*/15', 'hour' => '*', 'mday' => '*', 'month' => '*',
+			'wday' => '*', 'who' => 'root', 'command' => self::TICK_CMD,
+		]);
+		$this->assertSame([self::TICK_CMD], $this->cronCommands());
+
+		pfblockerng_configure_tick_cron(false, 15, self::LOG);
+
+		$this->assertSame([], $this->cronCommands());
+	}
+
+	public function testMigrationTeardownRemovesLegacyCronDccSsRefreshBl(): void
+	{
+		config_set_path('cron/item/0', ['minute' => '0', 'hour' => '0', 'mday' => '*', 'month' => '*', 'wday' => '*', 'who' => 'root', 'command' => '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron >> ' . self::LOG . ' 2>&1']);
+		config_set_path('cron/item/1', ['minute' => '0', 'hour' => '0', 'mday' => '*', 'month' => '*', 'wday' => '*', 'who' => 'root', 'command' => '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php dcc >> ' . self::LOG . ' 2>&1']);
+		config_set_path('cron/item/2', ['minute' => '0', 'hour' => '0', 'mday' => '*', 'month' => '*', 'wday' => '*', 'who' => 'root', 'command' => '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php ss_refresh >> ' . self::LOG . ' 2>&1']);
+		config_set_path('cron/item/3', ['minute' => '0', 'hour' => '0', 'mday' => '*', 'month' => '*', 'wday' => '*', 'who' => 'root', 'command' => '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php bl >> ' . self::LOG . ' 2>&1']);
+		$this->assertCount(4, $this->cronCommands());
+
+		pfblockerng_configure_tick_cron(true, 15, self::LOG);
+
+		// Every legacy fleet entry is gone; only the fresh tick entry remains.
+		$this->assertSame([self::TICK_CMD], $this->cronCommands());
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -1247,3 +1247,41 @@ if (!class_exists('Net_IPv6')) {
 		}
 	}
 }
+
+// --- services.inc cron doubles (issue #1204) ---
+//
+// pfblockerng_configure_tick_cron() (pfblockerng.inc) drives install_cron_job() to
+// install/remove the scheduled tick and tear down legacy verb entries. Faithful to
+// the real services.inc control flow: the FIRST cron/item whose command SUBSTRING-
+// matches $command (strstr, not equality) is "the" entry; $active=true installs or
+// overwrites it (appends when none matched); $active=false removes it and reindexes.
+
+if (!function_exists('configure_cron')) {
+	// pfSense services.inc: rewrites /etc/crontab from config/cron/item. Nothing to
+	// render off-appliance; tests assert state via config_get_path('cron/item').
+	function configure_cron() {
+	}
+}
+
+if (!function_exists('install_cron_job')) {
+	function install_cron_job($command, $active = false, $minute = '0', $hour = '*', $mday = '*', $month = '*', $wday = '*', $who = 'root', $write_config = true) {
+		$items = config_get_path('cron/item', []);
+		$found = null;
+		foreach ($items as $idx => $item) {
+			if (strstr($item['command'] ?? '', $command)) {
+				$found = $idx;
+				break;
+			}
+		}
+
+		if ($active) {
+			$entry = compact('minute', 'hour', 'mday', 'month', 'wday', 'who', 'command');
+			config_set_path('cron/item/' . ($found ?? count($items)), $entry);
+		} elseif ($found !== null) {
+			config_del_path("cron/item/{$found}");
+			config_set_path('cron/item', array_values(config_get_path('cron/item', [])));
+		}
+
+		configure_cron();
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -1266,7 +1266,7 @@ if (!function_exists('configure_cron')) {
 }
 
 if (!function_exists('install_cron_job')) {
-	function install_cron_job($command, $active = false, $minute = '0', $hour = '*', $mday = '*', $month = '*', $wday = '*', $who = 'root', $write_config = true) {
+	function install_cron_job($command, $active = FALSE, $minute = '0', $hour = '*', $mday = '*', $month = '*', $wday = '*', $who = 'root', $write_config = TRUE) {
 		$items = config_get_path('cron/item', []);
 		$found = null;
 		foreach ($items as $idx => $item) {

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -1254,7 +1254,9 @@ if (!class_exists('Net_IPv6')) {
 // install/remove the scheduled tick and tear down legacy verb entries. Faithful to
 // the real services.inc control flow: the FIRST cron/item whose command SUBSTRING-
 // matches $command (strstr, not equality) is "the" entry; $active=true installs or
-// overwrites it (appends when none matched); $active=false removes it and reindexes.
+// overwrites it (appends when none matched); $active=false removes it. The removal
+// reindexes (the real one leaves the hole) -- harmless: no caller indexes cron items,
+// they only iterate. write_config() is not called; these tests assert cron state only.
 
 if (!function_exists('configure_cron')) {
 	// pfSense services.inc: rewrites /etc/crontab from config/cron/item. Nothing to

--- a/tests/shell/pfb_downgrade_prep_spec.sh
+++ b/tests/shell/pfb_downgrade_prep_spec.sh
@@ -3,7 +3,9 @@
 #
 # Covers the file-move logic (restore user list scripts to the package root) and the
 # shipped-name gate, plus the tick-cron removal's OUTPUT PARSING via a fake pfSsh.php.
-# The real install_cron_job() effect of the tick removal is exercised on a live VM by
+# The fake ignores the piped PHP body (just echoes a fixed marker), so it exercises the
+# marker contract only -- not the real cron-tick + legacy-tick two-needle removal
+# (issue #1204), which install_cron_job() effect is exercised on a live VM by
 # tests/smoke/test_downgrade_prepare.py (this suite runs off-appliance, no pfSsh.php).
 #
 # The tool is sourced as a library: PFB_DOWNGRADE_PREP_SOURCED=1 makes its source guard

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3420,7 +3420,7 @@ def wait_boot_complete(vm: SmokeVM, *, timeout: float = 180.0, delay: float = 3.
 
 
 # Mirrors the Update page's active-task guard (pfblockerng_update.php pfb_active_task_running).
-_PFB_TASK_RE = re.compile(r"pfblockerng[.]php\s+(cron|update|pfb_trigger|tick|forcecheck)")
+_PFB_TASK_RE = re.compile(r"pfblockerng[.]php\s+(cron-tick|cron|update|pfb_trigger|tick|forcecheck)")
 
 
 def wait_no_active_pfb_task(vm: SmokeVM, *, timeout: float = 90.0, delay: float = 1.0) -> None:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -408,17 +408,29 @@ def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) 
         "--ssh-key",
         vm.ssh_key_path,
     ]
+    # BEFORE the installer: POST-INSTALL arms the cron entry, so a sentinel written only
+    # afterwards leaves a window in which the box's own cron-tick can dispatch a pass.
+    _write_cron_disable_flag(vm, timeout=timeout)
+
     result = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, check=False)
     if result.returncode != 0:
         raise RuntimeError(
             f"install-pkg.sh failed (rc={result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
-    # mkdir -p first: a fresh POST-INSTALL does not create dbdir (see write_local_feed).
-    flag = vm.ssh(f"/bin/mkdir -p {PFB_DBDIR} && /usr/bin/touch {PFB_CRON_DISABLE_PATH}", timeout=timeout)
-    if flag.returncode != 0:
+    # Re-assert after POST-INSTALL: idempotent, and it fails loudly if the install removed dbdir.
+    _write_cron_disable_flag(vm, timeout=timeout)
+
+
+def _write_cron_disable_flag(vm: SmokeVM, *, timeout: float = 60.0) -> None:
+    """Write the cron-disable sentinel on the guest, raising loudly on failure.
+
+    mkdir -p first: dbdir does not exist before the package's first install.
+    """
+    result = vm.ssh(f"/bin/mkdir -p {PFB_DBDIR} && /usr/bin/touch {PFB_CRON_DISABLE_PATH}", timeout=timeout)
+    if result.returncode != 0:
         raise RuntimeError(
-            f"deploy: failed to write {PFB_CRON_DISABLE_PATH}: rc={flag.returncode} "
-            f"stdout={flag.stdout!r} stderr={flag.stderr!r}"
+            f"deploy: failed to write {PFB_CRON_DISABLE_PATH}: rc={result.returncode} "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
         )
 
 
@@ -2745,7 +2757,7 @@ _BASELINE_GLOBAL_KEYS = (
     "pfb_agg_types",
     "pfb_quiet_hours",
     "pfb_tick_interval",
-    # Update Frequency: test_log_rotate writes 'Disabled' to gate the tick's feed-cron
+    # Update Frequency: test_log_age_retention writes 'Disabled' to gate the tick's feed-cron
     # dispatch; leaked forward it silently disables dispatch for every later module
     # (bit test_smoke_apply_on_change — issue #805).
     "pfb_interval",

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -83,7 +83,6 @@ PHP_BIN = "/usr/local/bin/php"
 # loaded + locked), so config_set_path/write_config persist a valid config.xml.
 PFSSH_BIN = "/usr/local/sbin/pfSsh.php"
 PFB_CLI = "/usr/local/www/pfblockerng/pfblockerng.php"
-PFB_EXTRA_INC = "/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 PFCTL = "/sbin/pfctl"
 
 # pfSense config API roots (see pfblockerng.inc).
@@ -388,10 +387,6 @@ def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) 
     portable Linux build job (build-pkg-linux.yml); its path is ``pkg_path`` or ``SMOKE_PKG``.
     install-pkg.sh polls ``unbound-control status`` after POST-INSTALL, so on
     return Unbound is ready.
-
-    POST-INSTALL also arms the ADR-43 cron tick, so every deploy ends with
-    :func:`disable_scheduled_dispatch` — the suite drives scheduling explicitly (the
-    ``tick``/``cron`` verbs) and must never race the box's wall-clock one (issue #1179).
     """
     pkg = pkg_path or os.environ.get("SMOKE_PKG")
     if not pkg or not Path(pkg).is_file():
@@ -413,7 +408,6 @@ def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) 
         raise RuntimeError(
             f"install-pkg.sh failed (rc={result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
-    disable_scheduled_dispatch(vm)
 
 
 def pkg_installed(vm: SmokeVM, *, timeout: float = 30.0) -> bool:
@@ -1562,76 +1556,6 @@ def set_feed_sanity(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
     result = php_eval(vm, snippet, timeout=timeout)
     if result.returncode != 0 or "OK" not in result.stdout:
         raise RuntimeError(f"set_feed_sanity({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
-
-
-def set_feed_cron_interval(vm: SmokeVM, value: str, *, timeout: float = 60.0) -> None:
-    """Set Update Frequency (``pfb_interval``): an hour count as a string, or ``'Disabled'``.
-
-    ``'Disabled'`` short-circuits ``pfblockerng_tick()``'s feed-cron branch (its
-    ``!$cron_disabled`` guard), so no tick — the box's scheduled one or an explicit
-    ``tick`` verb — dispatches a feed pass. The ``cron`` VERB is unaffected: the CLI
-    coerces a non-numeric interval back to ``'1'`` (pfblockerng.inc). Pass an hour
-    count ('1', '4', …) to re-enable dispatch for a module that exercises scheduling.
-    """
-    snippet = (
-        f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
-        f"$g['pfb_interval'] = {_php_str(value)};\n"
-        f"config_set_path({_php_str(CFG_GLOBAL)}, $g);\n"
-        "write_config('pfBlockerNG smoke: set pfb_interval');\n"
-        "echo 'OK';"
-    )
-    result = php_eval(vm, snippet, timeout=timeout)
-    if result.returncode != 0 or "OK" not in result.stdout:
-        raise RuntimeError(
-            f"set_feed_cron_interval({value!r}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
-        )
-
-
-def seed_scheduled_jobs_not_due(vm: SmokeVM, *, timeout: float = 60.0) -> None:
-    """Push every ADR-43 tick job's ``next_due`` a day out, clearing any pending flag.
-
-    The due-ledger is a FILE (``pfb_due_ledger.json``), not config — which is what makes
-    this safe to call at module teardown, where a config write is not (see
-    :func:`reset_pfb_baseline`). ``pfb_due_ledger_write_entry`` replaces the whole entry,
-    so a ``pending_apply`` a case left behind is dropped with it: a tick then finds every
-    job neither due nor pending and dispatches nothing, whatever ``pfb_interval`` says.
-    """
-    snippet = (
-        f"require_once({_php_str(PFB_EXTRA_INC)});\n"
-        "foreach (array('cron', 'dcc', 'bl') as $job) {\n"
-        "  pfb_due_ledger_write_entry($job, array('last_run' => time(), "
-        f"'next_due' => time() + 86400, 'jitter' => 0), {_php_str(PFB_DBDIR)});\n"
-        "}\n"
-        "echo 'OK';"
-    )
-    result = php_eval(vm, snippet, timeout=timeout)
-    if result.returncode != 0 or "OK" not in result.stdout:
-        raise RuntimeError(
-            f"seed_scheduled_jobs_not_due failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
-        )
-
-
-def disable_scheduled_dispatch(vm: SmokeVM, *, timeout: float = 60.0) -> None:
-    """Stop the box's own ADR-43 tick from dispatching an update pass (issue #1179).
-
-    The guest runs a real ``*/pfb_tick_interval`` cron tick. Left armed, it fires
-    mid-test and dispatches a full feed pass — re-running update hooks a test just
-    registered, reloading aliases/DNSBL under a test's feet — a wall-clock flake no test
-    can defend against. The suite therefore drives scheduling ITSELF (every scheduling
-    test invokes the ``tick``/``cron`` verb directly), and this gate, applied by
-    :func:`deploy` for every module, closes all three of the tick's dispatch branches:
-    ``pfb_interval='Disabled'`` (feed cron) plus a not-due due-ledger for ``cron``,
-    ``dcc`` and ``bl``. That the tick IS scheduled is asserted separately
-    (``test_smoke_tick.test_tick_cron_entry_installed``).
-
-    Deleting the cron entry instead would not hold: every ``sync_package_pfblockerng()``
-    re-installs it while the package is enabled, and pfSense's ``configure_cron()``
-    restarts a stopped cron daemon — the tick's own config/ledger gates are the only
-    durable off switch. A module that EXERCISES the scheduler re-arms what it needs
-    (:func:`set_feed_cron_interval`) and forces its own ledger state.
-    """
-    set_feed_cron_interval(vm, "Disabled", timeout=timeout)
-    seed_scheduled_jobs_not_due(vm, timeout=timeout)
 
 
 @timed_step("use_system_dns_upstream")
@@ -2805,11 +2729,9 @@ _BASELINE_GLOBAL_KEYS = (
     "pfb_agg_types",
     "pfb_quiet_hours",
     "pfb_tick_interval",
-    # Update Frequency: deploy() writes 'Disabled' (disable_scheduled_dispatch) and the two
-    # scheduling modules re-arm an hour count; unset here so each module's own deploy
-    # re-establishes it (a leaked value bit test_smoke_apply_on_change — issue #805). The
-    # gap this leaves — the key is back at its default '1' until the next deploy — is
-    # covered by the ledger seed below, NOT by writing the key back (see the docstring).
+    # Update Frequency: test_log_rotate writes 'Disabled' to gate the tick's feed-cron
+    # dispatch; leaked forward it silently disables dispatch for every later module
+    # (bit test_smoke_apply_on_change — issue #805).
     "pfb_interval",
     # ADR-40 apply-path mode: test_smoke_adr40 writes 'delta'/'auto'/'replace' via
     # PfbConfig (General section, issue #804); unset so later modules read the
@@ -2843,17 +2765,7 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
         row cannot answer a later module's probe before the DNSBL module) and regenerates
         the resolver config so the live daemon matches;
       * drops the derived state — ``clearip``/``cleardnsbl`` (tables/sqlite) then a blocking
-        ``apply_filter_sync`` (pf rules);
-      * pushes every tick job out of due (:func:`seed_scheduled_jobs_not_due`) **first**, so the
-        guest's scheduled tick cannot dispatch a pass once the wipe below puts ``pfb_interval``
-        back at its enabled default, nor in the gap before the next module's deploy re-applies
-        :func:`disable_scheduled_dispatch` (issue #1179).
-
-    **Never leave a key set in ``config/0`` here** (that is why the gap above is closed with
-    the ledger, a file, and not by writing ``pfb_interval`` back): the next module's ``pkg``
-    install grandfathers ``pfb_feed_internal_filter`` to ``'off'`` for any box whose General
-    section is a non-empty array without that key (``pfb_feed_filter_install_default``) — the
-    SSRF-guard cases then run with the guard silently disabled and pass for the wrong reason.
+        ``apply_filter_sync`` (pf rules).
 
     NO forced ``update``: the config is now empty, so there is nothing to rebuild — the next
     module's ``deployed_vm`` re-establishes the VIP/DNS/feed config it needs. (Like :func:`reset`,
@@ -2861,12 +2773,6 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
     autouse teardown in ``conftest.py``; safe to call
     directly. Raises on a non-zero ``pfSsh.php`` eval so a broken baseline surfaces loudly.
     """
-    installed = pkg_installed(vm)
-    # BEFORE the wipe, not after: unsetting pfb_interval puts it back at its enabled default
-    # '1', so from that instant a due-or-pending job is dispatchable again. Seeding first
-    # means the ledger is already not-due when the key flips (issue #1179).
-    if installed:
-        seed_scheduled_jobs_not_due(vm)
     del_sections = "".join(f"config_del_path({_php_str(s)});\n" for s in _BASELINE_DEL_SECTIONS)
     unset_keys = "".join(f"unset($g[{_php_str(k)}]);\n" for k in _BASELINE_GLOBAL_KEYS)
     snippet = (
@@ -2899,7 +2805,7 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
     # pfBlockerNG derived state left to clear; the config-section wipe above ran via pfSsh.php
     # (core, no package needed). Without this guard the module-scoped teardown ERRORs after any
     # uninstall test that happens to be last in its module.
-    if installed:
+    if pkg_installed(vm):
         for verb in ("clearip", "cleardnsbl"):
             cleared = vm.ssh(PHP_BIN, PFB_CLI, verb, timeout=120.0)
             if cleared.returncode != 0:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -387,6 +387,11 @@ def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) 
     portable Linux build job (build-pkg-linux.yml); its path is ``pkg_path`` or ``SMOKE_PKG``.
     install-pkg.sh polls ``unbound-control status`` after POST-INSTALL, so on
     return Unbound is ready.
+
+    Also writes the :data:`PFB_CRON_DISABLE_PATH` sentinel: the box's own wall-clock
+    cron-tick must never dispatch an update pass mid-suite (issue #1179's flake) — the
+    suite drives every dispatch explicitly via the ``tick``/``cron-tick`` verbs, which
+    the sentinel never gates (issue #1204).
     """
     pkg = pkg_path or os.environ.get("SMOKE_PKG")
     if not pkg or not Path(pkg).is_file():
@@ -407,6 +412,13 @@ def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) 
     if result.returncode != 0:
         raise RuntimeError(
             f"install-pkg.sh failed (rc={result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    # mkdir -p first: a fresh POST-INSTALL does not create dbdir (see write_local_feed).
+    flag = vm.ssh(f"/bin/mkdir -p {PFB_DBDIR} && /usr/bin/touch {PFB_CRON_DISABLE_PATH}", timeout=timeout)
+    if flag.returncode != 0:
+        raise RuntimeError(
+            f"deploy: failed to write {PFB_CRON_DISABLE_PATH}: rc={flag.returncode} "
+            f"stdout={flag.stdout!r} stderr={flag.stderr!r}"
         )
 
 
@@ -537,6 +549,10 @@ def deinstall_debug(vm: SmokeVM, *, timeout: float = 30.0) -> str:
 
 
 PFB_DBDIR = "/var/db/pfblockerng"
+# issue #1204: presence-only sentinel pfb_cron_disabled() checks — mirrors
+# pfb_cron_disable_path()'s default (pfblockerng.inc). Written by deploy() so the
+# guest's own wall-clock cron-tick never races the suite; never gates the tick verb.
+PFB_CRON_DISABLE_PATH = f"{PFB_DBDIR}/.pfb_cron_disable"
 
 
 def write_local_feed(vm: SmokeVM, name: str, contents: str, *, timeout: float = 30.0) -> str:

--- a/tests/smoke/test_downgrade_prepare.py
+++ b/tests/smoke/test_downgrade_prepare.py
@@ -15,14 +15,17 @@ with:
      an older release resolves list scripts against the package ROOT only, so a moved
      script silently stops running. They are moved back to the root (shipped AWS wrappers
      are left in place, recognised by name — no pkg query).
-  2. The ADR-43 ``pfblockerng.php tick`` cron entry is removed via ``pfSsh.php`` (the
-     shipped ``install_cron_job()``), so the downgraded release re-establishes its own
-     schedule instead of leaving an orphan tick cron behind.
+  2. The ADR-43 scheduled-tick cron entry — ``pfblockerng.php cron-tick`` (current,
+     issue #1204) or the legacy pre-#1204 ``pfblockerng.php tick`` (an un-upgraded box)
+     — is removed via ``pfSsh.php`` (the shipped ``install_cron_job()``), so the
+     downgraded release re-establishes its own schedule instead of leaving an orphan
+     tick cron behind.
 
 WHAT THIS PROVES on a REAL box that the off-box shellspec suite
 (``tests/shell/pfb_downgrade_prep_spec.sh``) cannot: the tool runs end-to-end on the
 appliance — it moves a real file inside the real package dir, LEAVES the shipped AWS
-wrapper in place, and removes the real tick cron from config.xml via ``install_cron_job``.
+wrapper in place, and removes the real tick-family cron entry from config.xml via
+``install_cron_job``.
 
 DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke`` in
 pyproject.toml). Run only via its own dispatch::
@@ -74,6 +77,15 @@ _USER_SCRIPT = "ip_pre_pfbdgsmoke.sh"
 _SHIPPED_SCRIPT = "ip_pre_AWS_US.sh"
 
 _TICK_CMD = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php tick >> /var/log/pfblockerng.log 2>&1"
+# issue #1204: the current shipped cron entry — the tool must remove this ONE too,
+# via its own second install_cron_job('pfblockerng.php cron-tick', FALSE) needle
+# (a bare 'pfblockerng.php tick' does not substring-match it — see
+# pfb-downgrade-prep.sh's pfb_remove_tick_cron).
+_CRON_TICK_CMD = (
+    "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron-tick >> /var/log/pfblockerng.log 2>&1"
+)
+_CRON_TICK_NEEDLE = "pfblockerng.php cron-tick"
+_LEGACY_TICK_NEEDLE = "pfblockerng.php tick"
 
 _TICK_OPEN = "<<<TICK>>>"
 _TICK_CLOSE = "<<<TICKEND>>>"
@@ -108,58 +120,66 @@ def _scp_to_guest(vm: SmokeVM, local: Path, remote: str) -> None:
         raise RuntimeError(f"scp {local} -> {remote} failed: rc={result.returncode} {result.stderr!r}")
 
 
-def _seed_tick_cron(vm: SmokeVM) -> None:
-    """Plant the ADR-43 tick cron item directly into config.xml (the precondition the
-    tool must remove). Direct config_set_path append — no dependency on install_cron_job
-    being reachable from the pfSsh.php context."""
+def _seed_tick_cron(vm: SmokeVM, cmd: str = _TICK_CMD) -> None:
+    """Plant a tick-family cron item directly into config.xml (the precondition the
+    tool must remove). ``cmd`` selects which entry shape — the legacy bare ``tick``
+    (default) or the current #1204 ``cron-tick`` (:data:`_CRON_TICK_CMD`) — since
+    the tool must remove EITHER (its own needle is an OR of both). Direct
+    config_set_path append — no dependency on install_cron_job being reachable from
+    the pfSsh.php context."""
     snippet = (
         "$items = config_get_path('cron/item', array());\n"
         "$items[] = array('minute' => '*/15', 'hour' => '*', 'mday' => '*', "
         "'month' => '*', 'wday' => '*', 'who' => 'root', "
-        f"'command' => {h._php_str(_TICK_CMD)});\n"
+        f"'command' => {h._php_str(cmd)});\n"
         "config_set_path('cron/item', $items);\n"
-        "write_config('pfBlockerNG downgrade smoke: seed ADR-43 tick cron');\n"
+        "write_config('pfBlockerNG downgrade smoke: seed a tick-family cron');\n"
         "echo 'OK';"
     )
     result = h.php_eval(vm, snippet, timeout=60.0)
     if result.returncode != 0 or "OK" not in result.stdout:
-        raise RuntimeError(f"_seed_tick_cron failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+        raise RuntimeError(
+            f"_seed_tick_cron({cmd!r}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
 
 
-def _tick_cron_present(vm: SmokeVM) -> bool:
-    """Scan config.xml cron items for the tick command."""
+def _tick_cron_present(vm: SmokeVM, needle: str = _LEGACY_TICK_NEEDLE) -> bool:
+    """Scan config.xml cron items for a command containing ``needle``."""
     snippet = (
         "$present = '0';\n"
         "foreach (config_get_path('cron/item', array()) as $i) {\n"
-        "    if (strpos($i['command'] ?? '', 'pfblockerng.php tick') !== false) { $present = '1'; break; }\n"
+        f"    if (strpos($i['command'] ?? '', {h._php_str(needle)}) !== false) {{ $present = '1'; break; }}\n"
         "}\n"
         f"echo {h._php_str(_TICK_OPEN)} . $present . {h._php_str(_TICK_CLOSE)};"
     )
     result = h.php_eval(vm, snippet, timeout=60.0)
     if result.returncode != 0:
-        raise RuntimeError(f"_tick_cron_present failed: rc={result.returncode} {result.stderr!r}")
+        raise RuntimeError(f"_tick_cron_present({needle!r}) failed: rc={result.returncode} {result.stderr!r}")
     out = result.stdout
     start = out.find(_TICK_OPEN)
     end = out.find(_TICK_CLOSE)
     if start == -1 or end == -1:
-        raise RuntimeError(f"_tick_cron_present: no delimited value in output: {out!r}")
+        raise RuntimeError(f"_tick_cron_present({needle!r}): no delimited value in output: {out!r}")
     return out[start + len(_TICK_OPEN) : end] == "1"
 
 
 def _remove_tick_cron(vm: SmokeVM) -> None:
-    """Strip any pfBlockerNG tick cron item from config.xml (teardown safety net).
+    """Strip any pfBlockerNG tick-family cron item from config.xml (teardown safety net).
 
-    The tool removes it on the happy path, but a body assertion that fires AFTER
-    ``_seed_tick_cron`` would otherwise leave the seeded item on the module-scoped
-    ``repo_vm`` — dirtying config.xml for a sibling test. Self-encapsulation.
+    Matches EITHER needle (legacy ``tick`` or the #1204 ``cron-tick``) — a body
+    assertion that fires AFTER ``_seed_tick_cron`` would otherwise leave a seeded
+    item on the module-scoped ``repo_vm`` — dirtying config.xml for a sibling test.
+    Self-encapsulation.
     """
     snippet = (
         "$kept = array();\n"
         "foreach (config_get_path('cron/item', array()) as $i) {\n"
-        "    if (strpos($i['command'] ?? '', 'pfblockerng.php tick') === false) { $kept[] = $i; }\n"
+        "    $cmd = $i['command'] ?? '';\n"
+        f"    if (strpos($cmd, {h._php_str(_LEGACY_TICK_NEEDLE)}) === false"
+        f" && strpos($cmd, {h._php_str(_CRON_TICK_NEEDLE)}) === false) {{ $kept[] = $i; }}\n"
         "}\n"
         "config_set_path('cron/item', $kept);\n"
-        "write_config('pfBlockerNG downgrade smoke: cleanup seeded tick cron');\n"
+        "write_config('pfBlockerNG downgrade smoke: cleanup seeded tick-family cron(s)');\n"
         "echo 'OK';"
     )
     h.php_eval(vm, snippet, timeout=60.0)
@@ -168,21 +188,24 @@ def _remove_tick_cron(vm: SmokeVM) -> None:
 @pytest.mark.timeout(600)  # one pkg install cycle + a few ssh probes > the 30s default cap
 def test_downgrade_tool_restores_scripts_and_removes_tick_cron(repo_vm: SmokeVM) -> None:
     """DOWNGRADE-PREPARATION CONTRACT: ``pfb-downgrade-prep.sh`` restores a relocated
-    custom list script to the package root and removes the ADR-43 tick cron, WITHOUT
-    moving a shipped AWS wrapper.
+    custom list script to the package root and removes BOTH the legacy tick cron AND
+    the current #1204 cron-tick entry, WITHOUT moving a shipped AWS wrapper.
 
     Scenario: an admin prepares a 4.0.x box for a downgrade to a pre-4.0.x release.
       Background: our NONE-signed file:// repo above the Netgate ``pfSense`` repo.
 
     Given the branch build installed, the dev tool staged on the box, a custom user
       script ``ip_pre_pfbdgsmoke.sh`` sitting in list_scripts/ (as a prior upgrade would
-      have relocated it), the shipped ``ip_pre_AWS_US.sh`` also in list_scripts/, and an
-      ADR-43 tick cron in config.xml,
+      have relocated it), the shipped ``ip_pre_AWS_US.sh`` also in list_scripts/, and
+      BOTH a legacy ``pfblockerng.php tick`` cron item AND a current
+      ``pfblockerng.php cron-tick`` cron item in config.xml (issue #1204 — a box
+      upgraded from a pre-#1204 release could carry the legacy entry; a #1204+ release
+      installs the cron-tick one — the tool must remove either shape it finds),
 
     When ``pfb-downgrade-prep.sh`` is run on the box as root,
 
     Then the custom script is back at the package ROOT and gone from list_scripts/, the
-      shipped AWS wrapper is left untouched in list_scripts/, and the tick cron entry is
+      shipped AWS wrapper is left untouched in list_scripts/, and BOTH cron entries are
       removed from config.xml.
     """
     pkg = os.environ.get("SMOKE_PKG")
@@ -222,13 +245,21 @@ def test_downgrade_tool_restores_scripts_and_removes_tick_cron(repo_vm: SmokeVM)
         repo_vm.ssh("/usr/bin/touch", list_user, timeout=30.0)
         repo_vm.ssh("/bin/chmod", "0755", list_user, timeout=30.0)
 
-        # Seed the ADR-43 tick cron.
-        _seed_tick_cron(repo_vm)
+        # Seed BOTH tick-family cron shapes (issue #1204: the legacy tick verb AND
+        # the current cron-tick verb) so the tool is proven to remove either.
+        _seed_tick_cron(repo_vm, _TICK_CMD)
+        _seed_tick_cron(repo_vm, _CRON_TICK_CMD)
 
-        # BEFORE: user script only in list_scripts/, not at the root; tick cron present.
+        # BEFORE: user script only in list_scripts/, not at the root; both tick-family
+        # cron entries present.
         assert _file_exists(repo_vm, list_user), f"precondition: {_USER_SCRIPT} must be in list_scripts/"
         assert not _file_exists(repo_vm, root_user), f"precondition: {_USER_SCRIPT} must NOT be at the package root yet"
-        assert _tick_cron_present(repo_vm), "precondition: the tick cron must be present before the tool runs"
+        assert _tick_cron_present(repo_vm, _LEGACY_TICK_NEEDLE), (
+            "precondition: the legacy tick cron must be present before the tool runs"
+        )
+        assert _tick_cron_present(repo_vm, _CRON_TICK_NEEDLE), (
+            "precondition: the cron-tick cron must be present before the tool runs"
+        )
 
         # ------------------------------------------------------------------ #
         # WHEN: the admin runs the downgrade-preparation tool as root         #
@@ -259,8 +290,13 @@ def test_downgrade_tool_restores_scripts_and_removes_tick_cron(repo_vm: SmokeVM)
         assert not _file_exists(repo_vm, root_shipped), (
             f"AFTER: shipped {_SHIPPED_SCRIPT} must NOT be moved to the package root"
         )
-        # Tick cron removed.
-        assert not _tick_cron_present(repo_vm), "AFTER: the ADR-43 tick cron must be removed from config.xml"
+        # Both tick-family cron entries removed.
+        assert not _tick_cron_present(repo_vm, _LEGACY_TICK_NEEDLE), (
+            "AFTER: the legacy tick cron must be removed from config.xml"
+        )
+        assert not _tick_cron_present(repo_vm, _CRON_TICK_NEEDLE), (
+            "AFTER: the cron-tick cron must be removed from config.xml"
+        )
 
     finally:
         # Remove the user script from both possible locations and the staged tool, strip

--- a/tests/smoke/test_log_age_retention.py
+++ b/tests/smoke/test_log_age_retention.py
@@ -48,6 +48,8 @@ pytestmark = pytest.mark.smoke
 PFB_LOGDIR = "/var/log/pfblockerng"
 PFB_DBDIR = "/var/db/pfblockerng"
 
+_PFB_EXTRA_INC = "/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
+
 # Host-side (non-chrooted) PHP-written CSV log; timestamp at CSV field 0.
 LOG_IP_BLOCKLOG = f"{PFB_LOGDIR}/ip_block.log"
 
@@ -74,15 +76,17 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     Mirrors the retired ADR-30 ``test_log_rotate.py``'s own ``deployed_vm``: age-based
     log retention runs from ``pfblockerng_tick()`` and needs neither DNSBL nor feed
     infrastructure, only ``enable_cb=on`` (so the tick body executes) and every tick in
-    this module being idle-only, so ``pfb_update_pass_running()``'s "nothing dispatched"
-    gate stays open and ``pfb_log_mgmt()`` runs on every ``tick`` call below. Idle-only
-    is the harness default: ``h.deploy`` -> ``disable_scheduled_dispatch`` closes all
-    three dispatch branches (Disabled feed cron + not-due dcc/bl).
+    this module being idle-only (Disabled feed cron + not-due dcc/bl), so
+    ``pfb_update_pass_running()``'s "nothing dispatched" gate stays open and
+    ``pfb_log_mgmt()`` runs on every ``tick`` call below.
     """
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
     _set_enable_cb(smoke_vm)
+    _set_pfb_interval_disabled(smoke_vm)
+    _seed_future_ledger_entry(smoke_vm, "dcc")
+    _seed_future_ledger_entry(smoke_vm, "bl")
     smoke_vm.ssh("/bin/mkdir", "-p", PFB_LOGDIR, timeout=30)
     smoke_vm.ssh("/bin/mkdir", "-p", PFB_DBDIR, timeout=30)
     try:
@@ -118,6 +122,49 @@ def _set_enable_cb(vm: SmokeVM, *, timeout: float = 60.0) -> None:
     result = h.php_eval(vm, snippet, timeout=timeout)
     if result.returncode != 0 or "OK" not in result.stdout:
         raise RuntimeError(f"_set_enable_cb failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def _set_pfb_interval_disabled(vm: SmokeVM, *, timeout: float = 60.0) -> None:
+    """Set pfb_interval='Disabled' so the tick's feed-cron branch never dispatches.
+
+    Part of making every tick in this module idle-only (see the ``deployed_vm`` fixture
+    docstring) — this is also the setting issue #573 fixed (log maintenance used to
+    silently stop with a Disabled Update Frequency).
+    """
+    snippet = (
+        f"$g = config_get_path({h._php_str(CFG_GENERAL)}, array());\n"
+        "$g['pfb_interval'] = 'Disabled';\n"
+        f"config_set_path({h._php_str(CFG_GENERAL)}, $g);\n"
+        "write_config('pfBlockerNG smoke: pfb_interval Disabled');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"_set_pfb_interval_disabled failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def _seed_future_ledger_entry(vm: SmokeVM, job_key: str, *, timeout: float = 60.0) -> None:
+    """Seed a due-ledger entry for ``job_key`` whose next_due is far in the future.
+
+    Drives the box via PHP (CLAUDE.md hard constraint: no appliance python) —
+    ``pfb_due_ledger_write_entry()`` is the package's own ledger writer. Keeps
+    'dcc'/'bl' from dispatching on the 'tick' verb so every tick in this module is
+    maintenance-only.
+    """
+    snippet = (
+        f"require_once('{_PFB_EXTRA_INC}');"
+        f"pfb_due_ledger_write_entry({h._php_str(job_key)}, array("
+        "'last_run' => time(), 'next_due' => time() + 86400, 'jitter' => 0"
+        f"), {h._php_str(PFB_DBDIR)});"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"_seed_future_ledger_entry({job_key!r}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
 
 
 def _set_log_max_days(vm: SmokeVM, values: dict[str, str], *, timeout: float = 60.0) -> None:

--- a/tests/smoke/test_smoke_apply_on_change.py
+++ b/tests/smoke/test_smoke_apply_on_change.py
@@ -40,6 +40,10 @@ def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM
     h.deploy(smoke_vm)
     h.ensure_dnsbl_vip(smoke_vm)
     h.use_system_dns_upstream(smoke_vm)
+    # Own this module's precondition instead of trusting the box default: a sibling module
+    # (test_log_age_retention) writes pfb_interval='Disabled' to make its ticks idle-only,
+    # and a leak forward silently stops every dispatch this module asserts (issue #805).
+    _set_pfb_interval(smoke_vm, "1")
     try:
         yield smoke_vm
     finally:
@@ -62,6 +66,32 @@ _PFB_EXTRA = "/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+_CFG_GENERAL = "installedpackages/pfblockerng/config/0"
+
+
+def _set_pfb_interval(vm: SmokeVM, value: str, *, timeout: float = 60.0) -> None:
+    """Set the feed-cron Update Frequency, so this module's ticks actually dispatch.
+
+    Verifies the write took: a silently-ignored value would turn every dispatch
+    assertion in this module into a false negative.
+    """
+    snippet = (
+        f"$g = config_get_path({h._php_str(_CFG_GENERAL)}, array());\n"
+        f"$g['pfb_interval'] = {h._php_str(value)};\n"
+        f"config_set_path({h._php_str(_CFG_GENERAL)}, $g);\n"
+        "write_config('pfBlockerNG smoke: pfb_interval');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"_set_pfb_interval({value!r}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+    readback = h.config_get(vm, f"{_CFG_GENERAL}/pfb_interval")
+    if readback != value:
+        raise RuntimeError(f"_set_pfb_interval({value!r}) did not take: config reads {readback!r}")
 
 
 def _read_ledger(vm) -> dict:

--- a/tests/smoke/test_smoke_apply_on_change.py
+++ b/tests/smoke/test_smoke_apply_on_change.py
@@ -34,16 +34,10 @@ pytestmark = [pytest.mark.apply_on_change]
 
 @pytest.fixture(scope="module")
 def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
-    """Deploy the branch .pkg once for the apply_on_change module, feed-cron dispatch re-armed.
-
-    ``h.deploy`` disables the tick's feed-cron dispatch for the suite (issue #1179); the
-    quiet-hours cases below drive exactly that branch, so this module opts back in with an
-    hour count (a leaked 'Disabled' already bit it once — issue #805).
-    """
+    """Deploy the branch .pkg once for the apply_on_change module."""
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
-    h.set_feed_cron_interval(smoke_vm, "1")
     h.ensure_dnsbl_vip(smoke_vm)
     h.use_system_dns_upstream(smoke_vm)
     try:
@@ -62,6 +56,7 @@ _PHP = "/usr/local/bin/php"
 _PFB_PHP = "/usr/local/www/pfblockerng/pfblockerng.php"
 # The ledger lives at $pfb['dbdir']/pfb_due_ledger.json (dbdir = /var/db/pfblockerng).
 _LEDGER_DIR = "/var/db/pfblockerng"
+_PFB_EXTRA = "/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 
 
 # ---------------------------------------------------------------------------
@@ -85,7 +80,7 @@ def _write_ledger_entry(vm, job_key: str, last_run: int, next_due: int, jitter: 
     ``pfb_due_ledger_write_entry()`` (PHP) is the right tool — not a here-doc Python snippet.
     """
     snippet = (
-        f"require_once('{h.PFB_EXTRA_INC}');"
+        f"require_once('{_PFB_EXTRA}');"
         f"pfb_due_ledger_write_entry('{job_key}', array("
         f"'last_run' => {int(last_run)}, 'next_due' => {int(next_due)}, 'jitter' => {int(jitter)}"
         f"), '{_LEDGER_DIR}');"
@@ -100,7 +95,7 @@ def _set_quiet_hours(vm, window: str) -> None:
     """Set pfb_quiet_hours in config.xml via pfSsh.php."""
     # Use the config gateway rather than direct xml munging.
     snippet = (
-        f"require_once('{h.PFB_EXTRA_INC}');"
+        f"require_once('{_PFB_EXTRA}');"
         f"PfbConfig::write('pfb_quiet_hours', {json.dumps(window)});"
         "write_config('ADR-43 smoke: set quiet-hours');"
         "echo 'OK';"
@@ -292,7 +287,7 @@ def test_apply_pending_cleared_by_window_open(deployed_vm: SmokeVM):
     _force_cron_due(vm)
     pend = h.php_eval(
         vm,
-        f"require_once('{h.PFB_EXTRA_INC}');pfb_due_ledger_set_pending('cron', '{_LEDGER_DIR}');echo 'OK';",
+        f"require_once('{_PFB_EXTRA}');pfb_due_ledger_set_pending('cron', '{_LEDGER_DIR}');echo 'OK';",
     )
     assert pend.returncode == 0 and "OK" in pend.stdout, (
         f"set_pending failed: rc={pend.returncode} {pend.stderr!r} {pend.stdout!r}"

--- a/tests/smoke/test_smoke_apply_on_change.py
+++ b/tests/smoke/test_smoke_apply_on_change.py
@@ -146,7 +146,14 @@ def _force_cron_due(vm) -> None:
 
 
 def _run_tick(vm) -> str:
-    """Fire one tick synchronously and return combined stdout+stderr."""
+    """Fire one tick synchronously and return combined stdout+stderr.
+
+    Drains any in-flight pfBlockerNG pass first: the tick defers its feed cron while
+    another feed pass holds the cross-process lock ("Tick: feed cron deferred (another
+    feed pass is running)"), which would silently turn this module's dispatch
+    assertions into false negatives (issue #1202).
+    """
+    h.wait_no_active_pfb_task(vm)
     return vm.ssh(f"{_PHP} {_PFB_PHP} tick 2>&1").stdout
 
 

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -664,11 +664,8 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
 
     Also proves (issue #988): the normal-pass branch's #973 persist call
     (``pfb_persist_hook_output``) fires exactly ONCE for this hook into the PERSISTED
-    ``pfblockerng.log``. A duplicate here has two possible causes: a wrongly-placed
-    lifecycle-branch persist call double-firing production code, or a scheduled
-    ADR-43 tick dispatching a feed-cron pass that re-fires this still-registered hook
-    mid-test (issue #1179's confirmed root cause; ``helpers.disable_scheduled_dispatch``
-    gates that dispatch off for the whole suite).
+    ``pfblockerng.log`` — a stray second call (a wrongly-placed lifecycle-branch persist
+    call sitting outside its own branch) would double the marker count there.
     """
     token = "stream"
     stream_marker = f"STREAM_{token}_MARK"
@@ -737,15 +734,13 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
         persisted_delta = h.count_log_marker(deployed_vm, h.PFB_LOG, stream_marker) - persisted_before
         assert persisted_delta == 1, (
             f"hook marker {stream_marker!r} was persisted into {h.PFB_LOG} {persisted_delta} time(s) "
-            "for one hook run (expected exactly 1 — either pfb_persist_hook_output double-fired or a "
-            "concurrent/tick-dispatched pass re-fired the hook: issue #1179):\n"
+            "for one hook run (expected exactly 1 — pfb_persist_hook_output double-fired):\n"
             f"{deployed_vm.ssh('cat', h.PFB_LOG).stdout[-4000:]}"
         )
         persisted_delta_done = h.count_log_marker(deployed_vm, h.PFB_LOG, done_marker) - persisted_before_done
         assert persisted_delta_done == 1, (
             f"hook marker {done_marker!r} was persisted into {h.PFB_LOG} {persisted_delta_done} time(s) "
-            "for one hook run (expected exactly 1 — either pfb_persist_hook_output double-fired or a "
-            "concurrent/tick-dispatched pass re-fired the hook: issue #1179):\n"
+            "for one hook run (expected exactly 1 — pfb_persist_hook_output double-fired):\n"
             f"{deployed_vm.ssh('cat', h.PFB_LOG).stdout[-4000:]}"
         )
         h.clear_update_hooks(deployed_vm)
@@ -1265,85 +1260,3 @@ def test_hooks_ip_changed_unlock_forced(deployed_vm: SmokeVM) -> None:
     )
 
     h.clear_update_hooks(deployed_vm)
-
-
-# --------------------------------------------------------------------------- #
-# 13) issue #1179 — a pending tick-cron pass must not re-fire a registered hook
-# --------------------------------------------------------------------------- #
-
-
-# Budget: two wait_no_active_pfb_task guards (90s + 60s worst case) plus the negative
-# proof's full 20s settle window — the default 30s per-test cap would abort the cleanup.
-@pytest.mark.timeout(180)
-def test_hooks_tick_cron_gate_suppresses_pending_refire(deployed_vm: SmokeVM) -> None:
-    """A pending 'cron' due-ledger entry must NOT let a tick re-fire a registered hook.
-
-    THE BUG (issue #1179): the box's own */15 tick can dispatch feed-cron
-    (``sync_package_pfblockerng('cron')`` -> ``pfb_run_hooks('post', ...)``) mid-module
-    whenever ``!$cron_disabled && ($due['cron'] || pfb_due_ledger_is_pending('cron',
-    $dbdir))`` (extra.inc's tick gate) — re-firing a hook another test just registered
-    and double-persisting its markers (misdiagnosed as a ``pfb_persist_hook_output``
-    double-fire in ``test_post_hook_output_streams_into_runlog_during_run`` before this
-    fix). This probe forces the PENDING branch deterministically (no real 15-minute
-    wait, via ``pfb_due_ledger_set_pending``) and fires ONE tick directly.
-
-    It pins the harness-wide gate (``helpers.disable_scheduled_dispatch``, applied by
-    ``helpers.deploy`` for every smoke module): with it, ``$cron_disabled`` is TRUE and
-    short-circuits the ``||`` gate regardless of due/pending — no dispatch, no marker.
-    Without it, the forced pending flag alone dispatches feed-cron, the hook fires and
-    the marker appears — this test FAILS, which is exactly the flake #1179 reported.
-    """
-    token = "tickgate"
-    marker = h.hook_marker_path(token, "post")
-
-    h.wait_no_active_pfb_task(deployed_vm)  # clean baseline before forcing pending
-    h.set_update_hooks(deployed_vm, [h.env_dump_hook(token, "post")])
-    h.clear_hook_markers(deployed_vm, token)
-    assert not h.hook_marker_exists(deployed_vm, marker), "marker present before the tick (stale state?)"
-
-    try:
-        pend = h.php_eval(
-            deployed_vm,
-            f"require_once({h._php_str(h.PFB_EXTRA_INC)});"
-            f"pfb_due_ledger_set_pending('cron', {h._php_str(h.PFB_DBDIR)});"
-            "echo 'OK';",
-        )
-        assert pend.returncode == 0 and "OK" in pend.stdout, (
-            f"pfb_due_ledger_set_pending('cron') failed: rc={pend.returncode} {pend.stderr!r} {pend.stdout!r}"
-        )
-
-        # rc is the positive control: a tick that never ran (SSH/CLI error, PHP fatal) would
-        # leave the marker absent and turn the negative proof below into a false green.
-        tick = deployed_vm.ssh(h.PHP_BIN, h.PFB_CLI, "tick", timeout=60.0)
-        assert tick.returncode == 0, (
-            f"the tick verb itself failed — the negative proof below would be vacuous: "
-            f"rc={tick.returncode} stdout={tick.stdout[-800:]!r} stderr={tick.stderr!r}"
-        )
-
-        # extra.inc's cron dispatch is a detached background exec: poll for the marker
-        # to APPEAR (proof of a re-fire) within a bounded settle window, rather than
-        # reading it once right after tick returns (which would race a dispatch that
-        # simply hasn't started yet — "not dispatched" vs "not dispatched YET").
-        refired = h.wait_until(lambda: h.hook_marker_exists(deployed_vm, marker), timeout=20.0, interval=4.0)
-        assert not refired, (
-            "a pending 'cron' ledger entry re-fired the registered hook via a "
-            "tick-dispatched feed-cron pass (issue #1179): "
-            f"{deployed_vm.ssh('cat', h.PFB_LOG, timeout=30.0).stdout[-2000:]}"
-        )
-    finally:
-        # Let any dispatched pass finish before the next test's clean-baseline check.
-        h.wait_no_active_pfb_task(deployed_vm, timeout=60.0)
-        # The gated branch never consumes pending_apply itself — clear it with a
-        # wholesale ledger rewrite (the package's own writer) so it cannot leak forward.
-        cleanup = h.php_eval(
-            deployed_vm,
-            f"require_once({h._php_str(h.PFB_EXTRA_INC)});"
-            "pfb_due_ledger_write_entry('cron', array("
-            "'last_run' => time(), 'next_due' => time() + 86400, 'jitter' => 0"
-            f"), {h._php_str(h.PFB_DBDIR)});"
-            "echo 'OK';",
-        )
-        assert cleanup.returncode == 0 and "OK" in cleanup.stdout, (
-            f"cron ledger cleanup failed: rc={cleanup.returncode} {cleanup.stderr!r} {cleanup.stdout!r}"
-        )
-        h.clear_update_hooks(deployed_vm)

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -8,7 +8,6 @@ Dispatch (when ready):
     gh workflow run smoke.yml -f pytest_marker="tick"
 
 Tests:
-    test_tick_cron_entry_installed    — the tick is SCHEDULED (one */N root crontab entry)
     test_tick_dispatches_due_feed     — tick fires a due feed (ledger past)
     test_tick_skips_non_due_feed      — tick skips a feed whose next_due is future
     test_tick_wiped_ledger_jittered   — wiped ledger gives due-now but jittered next_due
@@ -18,7 +17,6 @@ Tests:
 
 import json
 import os
-import re
 from collections.abc import Iterator
 
 import pytest
@@ -40,16 +38,10 @@ pytestmark = [pytest.mark.tick]
 
 @pytest.fixture(scope="module")
 def deployed_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
-    """Deploy the branch .pkg once for the tick module, with feed-cron dispatch re-armed.
-
-    ``h.deploy`` disables the tick's feed-cron dispatch for the suite (issue #1179) — this
-    module EXERCISES that dispatch, so it opts back in with an hour count. Every tick here
-    is still fired explicitly by the test, never by the box's own cron.
-    """
+    """Deploy the branch .pkg once for the tick module."""
     if not os.environ.get("SMOKE_PKG"):
         pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
     h.deploy(smoke_vm)
-    h.set_feed_cron_interval(smoke_vm, "1")
     h.ensure_dnsbl_vip(smoke_vm)
     h.use_system_dns_upstream(smoke_vm)
     try:
@@ -86,6 +78,7 @@ LEDGER_PATH = "/var/db/pfblockerng/pfb_due_ledger.json"
 _LEDGER_DIR = "/var/db/pfblockerng"
 _PHP = "/usr/local/bin/php"
 _PFB_PHP = "/usr/local/www/pfblockerng/pfblockerng.php"
+_PFB_EXTRA = "/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 _PFB_INC = "/usr/local/pkg/pfblockerng/pfblockerng.inc"
 
 # A throwaway marker dropped in /var right before the reboot in test_tick_reboot_persists_ledger.
@@ -118,7 +111,7 @@ def _write_ledger_entry(vm, job_key: str, last_run: int, next_due: int, jitter: 
     Python snippet, which silently no-op'd at rc=127 and left these writes ineffective.
     """
     snippet = (
-        f"require_once('{h.PFB_EXTRA_INC}');"
+        f"require_once('{_PFB_EXTRA}');"
         f"pfb_due_ledger_write_entry('{job_key}', array("
         f"'last_run' => {int(last_run)}, 'next_due' => {int(next_due)}, 'jitter' => {int(jitter)}"
         f"), '{_LEDGER_DIR}');"
@@ -206,49 +199,6 @@ def _reset_ss_extdns(vm) -> None:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.smoke
-@pytest.mark.tick
-def test_tick_cron_entry_installed(deployed_vm: SmokeVM):
-    """The tick IS scheduled: ONE ``*/pfb_tick_interval`` root crontab entry, from the sync.
-
-    This is the suite's only dependence on the real schedule. Everything else fires the
-    ``tick`` verb explicitly — the box's wall-clock dispatch is gated off for every module
-    (``helpers.disable_scheduled_dispatch``, issue #1179) because it raced tests. Given
-    this entry plus the tick-verb cases below, "the schedule runs the tick" follows.
-
-    Scenario:
-        Background: pfBlockerNG installed and enabled.
-            When /etc/crontab is read (the effective schedule cron actually runs).
-            Then exactly one entry runs ``pfblockerng.php tick`` as root, every
-            ``*/N`` minutes with N = the clamped ``pfb_tick_interval``, on every
-            mday/month/wday.
-    """
-    vm = deployed_vm
-
-    probe = h.php_eval(
-        vm,
-        f"require_once('{h.PFB_EXTRA_INC}');"
-        "echo 'TICKMIN:' . pfb_tick_interval_clamp((string) PfbConfig::read('pfb_tick_interval')) . ':END';",
-    )
-    match = re.search(r"TICKMIN:(\d+):END", probe.stdout)
-    assert match, f"could not read pfb_tick_interval from the box: rc={probe.returncode} stdout={probe.stdout!r}"
-    expected_minute = f"*/{match.group(1)}"
-
-    crontab = vm.ssh("/bin/cat", "/etc/crontab")
-    entries = [line.split(None, 6) for line in crontab.stdout.splitlines() if "pfblockerng.php tick" in line]
-    assert len(entries) == 1, (
-        f"expected exactly ONE 'pfblockerng.php tick' crontab entry, found {len(entries)}"
-        f" — install_cron_job() left the schedule wrong:\n{crontab.stdout}"
-    )
-    minute, hour, mday, month, wday, who, command = entries[0]
-    assert (minute, hour, mday, month, wday, who) == (expected_minute, "*", "*", "*", "*", "root"), (
-        "tick cron entry has the wrong schedule: expected "
-        f"({expected_minute!r}, '*', '*', '*', '*', 'root'), got "
-        f"({minute!r}, {hour!r}, {mday!r}, {month!r}, {wday!r}, {who!r})"
-    )
-    assert command.startswith(f"{_PHP} {_PFB_PHP} tick"), f"tick cron entry runs an unexpected command: {command!r}"
 
 
 @pytest.mark.smoke

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -205,6 +205,7 @@ def _reset_ss_extdns(vm) -> None:
 # trailing-space needle rationale (pfblockerng.inc).
 _CRON_TICK_NEEDLE = "pfblockerng.php cron-tick"
 _LEGACY_TICK_NEEDLE = "pfblockerng.php tick"
+_ENABLE_CB_CFG = "installedpackages/pfblockerng/config/0/enable_cb"
 
 
 # pfSsh.php prints a startup banner on stdout, so a snippet that READS a value must
@@ -261,6 +262,9 @@ def test_tick_cron_entry_installed(deployed_vm: SmokeVM):
                 cron-tick verb, and no legacy 'pfblockerng.php tick >>' entry survives.
     """
     vm = deployed_vm
+    # deployed_vm is module-scoped: restore the master switch to whatever this module
+    # was left in, never to a hardcoded state (the later tests here need it enabled).
+    original_enabled = h.config_get(vm, _ENABLE_CB_CFG)
     try:
         h.set_package_enabled(vm, False)
         h.reload(vm, "update")
@@ -278,7 +282,7 @@ def test_tick_cron_entry_installed(deployed_vm: SmokeVM):
             f"the legacy 'pfblockerng.php tick' entry must not survive; got {after[0]!r}"
         )
     finally:
-        h.set_package_enabled(vm, False)
+        h.set_package_enabled(vm, original_enabled == "on")
         h.reload(vm, "update")
 
 

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -8,11 +8,14 @@ Dispatch (when ready):
     gh workflow run smoke.yml -f pytest_marker="tick"
 
 Tests:
-    test_tick_dispatches_due_feed     — tick fires a due feed (ledger past)
-    test_tick_skips_non_due_feed      — tick skips a feed whose next_due is future
-    test_tick_wiped_ledger_jittered   — wiped ledger gives due-now but jittered next_due
-    test_tick_reboot_persists_ledger  — clean reboot with MFS /var keeps the schedule
-                                        (ledger restored via the #468 earlyshellcmd)
+    test_tick_cron_entry_installed         — the installed cron entry is the cron-tick verb (#1204)
+    test_cron_tick_respects_disable_flag   — cron-tick honours .pfb_cron_disable (#1204)
+    test_tick_verb_ignores_disable_flag    — the direct tick verb is never gated (#1204)
+    test_tick_dispatches_due_feed          — tick fires a due feed (ledger past)
+    test_tick_skips_non_due_feed           — tick skips a feed whose next_due is future
+    test_tick_wiped_ledger_jittered        — wiped ledger gives due-now but jittered next_due
+    test_tick_reboot_persists_ledger       — clean reboot with MFS /var keeps the schedule
+                                              (ledger restored via the #468 earlyshellcmd)
 """
 
 import json
@@ -196,9 +199,170 @@ def _reset_ss_extdns(vm) -> None:
         raise RuntimeError(f"_reset_ss_extdns failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
 
 
+# issue #1204: needles distinguishing the two possible installed cron commands.
+# 'pfblockerng.php tick' does NOT substring-match '...cron-tick' (a hyphen sits where
+# the legacy needle expects a space) -- mirrors pfblockerng_configure_tick_cron's own
+# trailing-space needle rationale (pfblockerng.inc).
+_CRON_TICK_NEEDLE = "pfblockerng.php cron-tick"
+_LEGACY_TICK_NEEDLE = "pfblockerng.php tick"
+
+
+def _read_pfb_tick_cron_items(vm) -> list[str]:
+    """Return the 'command' string of every config.xml cron/item naming the
+    tick-family verb (the current cron-tick, or the legacy bare tick)."""
+    snippet = (
+        "$out = array();\n"
+        "foreach (config_get_path('cron/item', array()) as $i) {\n"
+        "    $cmd = $i['command'] ?? '';\n"
+        f"    if (strpos($cmd, {h._php_str(_CRON_TICK_NEEDLE)}) !== FALSE"
+        f" || strpos($cmd, {h._php_str(_LEGACY_TICK_NEEDLE)}) !== FALSE) {{ $out[] = $cmd; }}\n"
+        "}\n"
+        "echo json_encode($out);"
+    )
+    result = h.php_eval(vm, snippet)
+    if result.returncode != 0:
+        raise RuntimeError(f"_read_pfb_tick_cron_items failed: rc={result.returncode} {result.stderr!r}")
+    return json.loads(result.stdout.strip())
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.tick
+@pytest.mark.timeout(180)  # two foreground sync passes (master switch off, then on)
+def test_tick_cron_entry_installed(deployed_vm: SmokeVM):
+    """The installed scheduled-tick cron entry is the #1204 cron-tick verb.
+
+    Guards pfblockerng_configure_tick_cron's trailing-space teardown needle
+    ('pfblockerng.php cron ', not the bare 'pfblockerng.php cron'): the bare needle
+    substring-matches the just-installed 'cron-tick' command too, so
+    install_cron_job() would delete it on every sync pass, leaving NO tick cron
+    installed at all.
+
+    Scenario:
+        Background: pfBlockerNG's master switch driven OFF then synced (before-state).
+            Given no tick-family cron/item entry exists,
+            When the master switch is turned ON and a sync pass runs,
+            Then EXACTLY ONE tick-family cron/item entry exists, its command is the
+                cron-tick verb, and no legacy 'pfblockerng.php tick >>' entry survives.
+    """
+    vm = deployed_vm
+    try:
+        h.set_package_enabled(vm, False)
+        h.reload(vm, "update")
+        before = _read_pfb_tick_cron_items(vm)
+        assert before == [], (
+            f"before: no tick-family cron/item entry should exist while pfBlockerNG is disabled; found {before}"
+        )
+
+        h.set_package_enabled(vm, True)
+        h.reload(vm, "update")
+        after = _read_pfb_tick_cron_items(vm)
+        assert len(after) == 1, f"after: expected exactly one tick-family cron/item entry, found {len(after)}: {after}"
+        assert _CRON_TICK_NEEDLE in after[0], f"the installed entry must be the cron-tick verb; got {after[0]!r}"
+        assert "pfblockerng.php tick >>" not in after[0], (
+            f"the legacy 'pfblockerng.php tick' entry must not survive; got {after[0]!r}"
+        )
+    finally:
+        h.set_package_enabled(vm, False)
+        h.reload(vm, "update")
+
+
+@pytest.mark.smoke
+@pytest.mark.tick
+@pytest.mark.timeout(120)
+def test_cron_tick_respects_disable_flag(deployed_vm: SmokeVM):
+    """The cron-tick verb honours the harness's .pfb_cron_disable sentinel.
+
+    Branch PAIR (CLAUDE.md branch coverage): the same due-ledger precondition is
+    replayed with the flag present, then absent, so a broken gate flips ONE side red.
+
+    Scenario:
+        Background: the 'cron' ledger entry is due (next_due in the past).
+            Given the harness flag PRESENT (deploy()'s default state),
+            When 'pfblockerng.php cron-tick' runs,
+            Then it prints the disabled banner and the ledger 'cron' entry is
+                UNCHANGED (no dispatch) -- the before-state that makes this pairing
+                non-vacuous.
+            Given the flag REMOVED,
+            When 'cron-tick' runs again,
+            Then it prints no banner and the ledger 'cron' entry ADVANCES (real
+                dispatch) -- proving the flag, not something else, gated the first call.
+        The flag is restored in a finally (issue #1179: a leaked removal re-arms the flake).
+    """
+    vm = deployed_vm
+    flag = h.PFB_CRON_DISABLE_PATH
+    assert vm.ssh("test", "-f", flag).returncode == 0, f"precondition: deploy() must have written {flag}"
+
+    try:
+        now_ts = int(vm.ssh("date +%s").stdout.strip())
+
+        # --- flag present: cron-tick must NOT dispatch. ---
+        _write_ledger_entry(vm, "cron", now_ts - 90000, now_ts - 1)
+        before = _read_ledger(vm)
+        result = vm.ssh(_PHP, _PFB_PHP, "cron-tick")
+        assert result.returncode == 0, f"cron-tick (flag present) rc={result.returncode} stderr={result.stderr!r}"
+        assert f"[ Disabled by {flag} ]" in result.stdout, (
+            f"cron-tick (flag present) must print the disabled banner; got {result.stdout!r}"
+        )
+        after = _read_ledger(vm)
+        assert after.get("cron") == before.get("cron"), (
+            f"cron-tick (flag present) must not dispatch -- ledger 'cron' entry changed: "
+            f"before={before.get('cron')} after={after.get('cron')}"
+        )
+
+        # --- flag absent: cron-tick DOES dispatch (the non-vacuous other half). ---
+        rm = vm.ssh("rm", "-f", flag)
+        assert rm.returncode == 0, f"failed to remove {flag}: rc={rm.returncode} {rm.stderr!r}"
+        result2 = vm.ssh(_PHP, _PFB_PHP, "cron-tick")
+        assert result2.returncode == 0, f"cron-tick (flag absent) rc={result2.returncode} stderr={result2.stderr!r}"
+        assert "[ Disabled by" not in result2.stdout, (
+            f"cron-tick (flag absent) must not print the disabled banner; got {result2.stdout!r}"
+        )
+        assert h.wait_until(
+            lambda: _read_ledger(vm).get("cron", {}).get("next_due", 0) > now_ts,
+            timeout=30,
+            interval=2,
+        ), f"cron-tick (flag absent) should dispatch the due feed cron; ledger={_read_ledger(vm)}"
+    finally:
+        touch = vm.ssh("/usr/bin/touch", flag)
+        if touch.returncode != 0:
+            raise AssertionError(f"failed to restore {flag}: rc={touch.returncode} {touch.stderr!r}")
+
+
+@pytest.mark.smoke
+@pytest.mark.tick
+@pytest.mark.timeout(90)
+def test_tick_verb_ignores_disable_flag(deployed_vm: SmokeVM):
+    """The direct 'tick' verb is NEVER gated by .pfb_cron_disable -- only 'cron-tick' is.
+
+    Scenario:
+        Background: the harness flag is PRESENT (its normal, always-on state during
+            the suite) and the 'cron' ledger entry is due.
+            When 'pfblockerng.php tick' runs directly,
+            Then it dispatches the due feed cron (ledger 'cron' next_due advances) and
+                prints no '[ Disabled by ... ]' banner.
+    """
+    vm = deployed_vm
+    flag = h.PFB_CRON_DISABLE_PATH
+    assert vm.ssh("test", "-f", flag).returncode == 0, f"precondition: {flag} must be present for this test"
+
+    now_ts = int(vm.ssh("date +%s").stdout.strip())
+    _write_ledger_entry(vm, "cron", now_ts - 90000, now_ts - 1)
+
+    result = vm.ssh(_PHP, _PFB_PHP, "tick")
+    assert result.returncode == 0, f"tick rc={result.returncode} stderr={result.stderr!r}"
+    assert "[ Disabled by" not in result.stdout, (
+        f"the direct 'tick' verb must never print the cron-tick disabled banner; got {result.stdout!r}"
+    )
+    assert h.wait_until(
+        lambda: _read_ledger(vm).get("cron", {}).get("next_due", 0) > now_ts,
+        timeout=30,
+        interval=2,
+    ), f"the direct 'tick' verb must dispatch the due feed cron regardless of the flag; ledger={_read_ledger(vm)}"
 
 
 @pytest.mark.smoke

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -207,6 +207,12 @@ _CRON_TICK_NEEDLE = "pfblockerng.php cron-tick"
 _LEGACY_TICK_NEEDLE = "pfblockerng.php tick"
 
 
+# pfSsh.php prints a startup banner on stdout, so a snippet that READS a value must
+# delimit it (helpers.php_eval's contract; same idiom as helpers.config_get).
+_CRON_JSON_OPEN = "<<<PFBCRON>>>"
+_CRON_JSON_CLOSE = "<<<ENDPFBCRON>>>"
+
+
 def _read_pfb_tick_cron_items(vm) -> list[str]:
     """Return the 'command' string of every config.xml cron/item naming the
     tick-family verb (the current cron-tick, or the legacy bare tick)."""
@@ -217,12 +223,17 @@ def _read_pfb_tick_cron_items(vm) -> list[str]:
         f"    if (strpos($cmd, {h._php_str(_CRON_TICK_NEEDLE)}) !== FALSE"
         f" || strpos($cmd, {h._php_str(_LEGACY_TICK_NEEDLE)}) !== FALSE) {{ $out[] = $cmd; }}\n"
         "}\n"
-        "echo json_encode($out);"
+        f"echo {h._php_str(_CRON_JSON_OPEN)} . json_encode($out) . {h._php_str(_CRON_JSON_CLOSE)};"
     )
     result = h.php_eval(vm, snippet)
     if result.returncode != 0:
         raise RuntimeError(f"_read_pfb_tick_cron_items failed: rc={result.returncode} {result.stderr!r}")
-    return json.loads(result.stdout.strip())
+    out = result.stdout
+    start = out.find(_CRON_JSON_OPEN)
+    end = out.find(_CRON_JSON_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(f"_read_pfb_tick_cron_items: no delimited value in pfSsh.php output: {out!r}")
+    return json.loads(out[start + len(_CRON_JSON_OPEN) : end])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -1671,10 +1671,18 @@ def test_update_page_cron_status_reports_scheduled_tick(
     pins the fix: with the tick installed, the page must report the next-tick
     wall-clock time and time-remaining instead.
 
+    issue #1204 renamed the installed verb to ``cron-tick`` and added the harness's
+    always-on ``.pfb_cron_disable`` sentinel (:func:`~tests.smoke.helpers.deploy`);
+    the sentinel outranks this page's enabled/missing-cron arms (it would otherwise
+    always show its own banner instead of the HH:MM time this test pins), so it is
+    removed for the render and restored in a finally.
+
     Scenario:
-      Given pfBlockerNG is enabled and a full reload has installed the tick cron,
-      And /etc/crontab actually contains the ``pfblockerng.php tick`` entry (precondition,
-        so "not Missing" is meaningful and not a false pass from a disabled box),
+      Given pfBlockerNG is enabled, a full reload has installed the cron-tick cron,
+        and the harness sentinel is removed,
+      And /etc/crontab actually contains the ``pfblockerng.php cron-tick`` entry
+        (precondition, so "not Missing" is meaningful and not a false pass from a
+        disabled box),
       When the Update page is rendered,
       Then the Cron Status shows "NEXT Scheduled CRON Event will run at" and does NOT
         contain "[ Missing cron task ]", and renders a HH:MM next-tick time (unless a
@@ -1684,17 +1692,20 @@ def test_update_page_cron_status_reports_scheduled_tick(
     minute/hour fields, so this asserted body still contained "[ Missing cron task ]".
     """
     vm = smoke_vm
+    flag = helpers.PFB_CRON_DISABLE_PATH
     original_enabled = helpers.config_get(vm, _ENABLE_CB_CFG)
     if original_enabled != "on":
         helpers.set_package_enabled(vm, True)
+    rm = vm.ssh("rm", "-f", flag)
+    assert rm.returncode == 0, f"failed to remove {flag}: rc={rm.returncode} {rm.stderr!r}"
     try:
-        # Install/refresh the tick cron via a full reload (no feeds configured => no egress).
+        # Install/refresh the cron-tick cron via a full reload (no feeds configured => no egress).
         helpers.reload(vm, "update")
 
-        # PRECONDITION (effective state, not the HTTP body): the tick IS in the crontab.
-        crontab = vm.ssh("/usr/bin/grep", "pfblockerng.php tick", "/etc/crontab")
-        assert crontab.returncode == 0 and "tick" in crontab.stdout, (
-            "tick cron absent from /etc/crontab after an enabled reload "
+        # PRECONDITION (effective state, not the HTTP body): the cron-tick IS in the crontab.
+        crontab = vm.ssh("/usr/bin/grep", "pfblockerng.php cron-tick", "/etc/crontab")
+        assert crontab.returncode == 0 and "cron-tick" in crontab.stdout, (
+            "cron-tick cron absent from /etc/crontab after an enabled reload "
             f"(rc={crontab.returncode} stdout={crontab.stdout!r}) — "
             "cannot assert the page reports a scheduled tick"
         )
@@ -1702,8 +1713,8 @@ def test_update_page_cron_status_reports_scheduled_tick(
         body = webui.get(UPDATE_PAGE).text
         assert not looks_like_login_page(body), "Update page GET returned the login form (session lost)"
         assert "Missing cron task" not in body, (
-            "Cron Status still shows '[ Missing cron task ]' although the tick cron IS "
-            "installed — the page must probe the */N tick signature, not the legacy "
+            "Cron Status still shows '[ Missing cron task ]' although the cron-tick cron IS "
+            "installed — the page must probe the */N cron-tick signature, not the legacy "
             "interval/min/24hour cron"
         )
         assert "NEXT Scheduled CRON Event will run at" in body, "Cron Status header missing from the Update page"
@@ -1715,6 +1726,9 @@ def test_update_page_cron_status_reports_scheduled_tick(
             f"no HH:MM next-tick time rendered in the Cron Status; excerpt={excerpt!r}"
         )
     finally:
+        touch = vm.ssh("/usr/bin/touch", flag)
+        if touch.returncode != 0:
+            raise AssertionError(f"failed to restore {flag}: rc={touch.returncode} {touch.stderr!r}")
         if original_enabled != "on":
             helpers.set_package_enabled(vm, False)
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -463,6 +463,75 @@ def test_update_hooks_subtab_relocation(webui: WebUI) -> None:
     assert _UPDATE_PAGE in body, "the General page no longer links the Update tab"
 
 
+def test_update_page_cron_status_reports_harness_disable_flag(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:  # noqa: ARG001
+    """The Update page's cron-status line names the harness's .pfb_cron_disable sentinel (#1204).
+
+    Read-only (no config write) — the flag is deploy()'s always-on harness state, so
+    this needs no ``ui_e2e`` isolation. Pairs with the flag-absent test below (branch
+    coverage): together they prove the flag outranks the enabled/missing-cron arms
+    of the cron-status line, not just that SOME text renders.
+
+    Given the harness flag present (deploy()'s default state),
+    When GET pfblockerng_update.php,
+    Then the cron-status line names the exact sentinel path.
+    """
+    flag = helpers.PFB_CRON_DISABLE_PATH
+    assert smoke_vm.ssh("test", "-f", flag).returncode == 0, (
+        f"precondition: {flag} must be present (deploy() writes it)"
+    )
+
+    resp = webui.get(_UPDATE_PAGE)
+    result = evaluate_render(_UPDATE_PAGE, resp.status_code, resp.text, ("NEXT Scheduled CRON Event",))
+    assert result.ok, f"Update page render oracle failed: {result.detail}"
+    assert f"[ Disabled by {flag} ]" in resp.text, (
+        f"Update page cron-status line is missing the harness disable banner for {flag}"
+    )
+
+
+@pytest.mark.ui_e2e
+def test_update_page_cron_status_without_flag_never_misreports_missing_cron(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:  # noqa: ARG001
+    """Without the flag, an enabled+synced pfBlockerNG never shows '[ Missing cron task ]' (#1204).
+
+    Guards step 2's probe-command fix (pfblockerng_update.php's ``pfblockerng_cron_exists``
+    check now targets the cron-tick command): the OLD probe still searched for the legacy
+    'pfblockerng.php tick' command while sync installs 'cron-tick', so a perfectly healthy,
+    enabled box misreported '[ Missing cron task ]' on every load. Drives enabled+synced
+    state itself (never relies on session-order state an earlier UI test may have left) —
+    the ``ui_e2e`` marker rides ``_ui_pfb_isolation``'s post-test config.xml restore, so no
+    manual config cleanup is needed; the harness flag (outside config.xml) still needs its
+    own restore.
+
+    Given the master switch ON, a fresh sync pass (installs the current cron-tick entry),
+        and the harness flag removed,
+    When GET pfblockerng_update.php,
+    Then the cron-status line shows neither the harness banner nor '[ Missing cron task ]'.
+    """
+    flag = helpers.PFB_CRON_DISABLE_PATH
+    helpers.set_package_enabled(smoke_vm, True)
+    helpers.reload(smoke_vm, "update")
+    rm = smoke_vm.ssh("rm", "-f", flag)
+    assert rm.returncode == 0, f"failed to remove {flag}: rc={rm.returncode} {rm.stderr!r}"
+    try:
+        resp = webui.get(_UPDATE_PAGE)
+        result = evaluate_render(_UPDATE_PAGE, resp.status_code, resp.text, ("NEXT Scheduled CRON Event",))
+        assert result.ok, f"Update page render oracle failed: {result.detail}"
+        assert f"[ Disabled by {flag} ]" not in resp.text, (
+            "Update page still shows the harness disable banner after the flag was removed"
+        )
+        assert "[ Missing cron task ]" not in resp.text, (
+            "Update page misreports '[ Missing cron task ]' on a healthy, enabled, synced box -- "
+            "the cron-tick probe-command fix regressed"
+        )
+    finally:
+        touch = smoke_vm.ssh("/usr/bin/touch", flag)
+        if touch.returncode != 0:
+            raise AssertionError(f"failed to restore {flag}: rc={touch.returncode} {touch.stderr!r}")
+
+
 def test_general_page_keep_help_upgrade_warning(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:  # noqa: ARG001
     """The General page's 'Keep Settings' help warns that keep=off wipes settings on a version upgrade (#697).
 


### PR DESCRIPTION
Fixes #1204. Follow-up to #1179 (PR #1199).

## What this does

Replaces the smoke suite's config+ledger scheduler gate with a single orthogonal off switch:

- **New cron-only verb `cron-tick`** (`pfblockerng.php`): runs the tick unless
  `/var/db/pfblockerng/.pfb_cron_disable` exists; if it does, it prints
  `[ Disabled by /var/db/pfblockerng/.pfb_cron_disable ]` and dispatches nothing. The direct `tick`
  verb is byte-for-byte unchanged and is never gated.
- **The crontab entry calls `cron-tick`**, with a working upgrade path: a box carrying the old
  `pfblockerng.php tick` entry ends up with exactly one entry, the `cron-tick` one.
- **The Update page reports the suppression** (`[ Disabled by … ]`) instead of a healthy next-run
  time, so a stray flag file is a visible failure rather than a silent one.
- **The smoke harness writes the flag in `helpers.deploy()`**; the config write + due-ledger seed
  (`disable_scheduled_dispatch`) is gone. A file in `dbdir` cannot be erased by a config wipe and
  grandfathers nothing — the two sharp edges that made the config/ledger gate risky.

The branch **starts by reverting PR #1199's six commits** wholesale rather than unpicking them, then
builds the new mechanism on the reverted tree.

## The blocking question, resolved from upstream

`install_cron_job()` matches by **substring**, not equality — `strstr($item['command'], $command)` in
pfSense `src/etc/inc/services.inc`, identical at every supported ref (master HEAD; RELENG_2_7_2; and
master resolved by release date: `7bfa6007` 2025-06, `691852a2` 2025-08, `523397ba` 2025-12,
`ddd366b3` 2026-04).

That has a sharp consequence: the migration teardown's `install_cron_job('pfblockerng.php cron', FALSE)`
substring-matches `…/pfblockerng.php cron-tick …` and would have **deleted the new entry on every
sync**, leaving no scheduled tick at all. The needle is therefore tightened to
`'pfblockerng.php cron '` (trailing space). That is safe and total: every producer of a legacy `cron`
entry stores `…/pfblockerng.php cron >> {log} 2>&1` (upstream FreeBSD-ports `pfblockerng.inc`, devel
and stable), and none emits the verb at end-of-string. Conversely `'pfblockerng.php tick'` does *not*
match `cron-tick`, so each site that must remove the installed entry now carries both needles.

## Regression this uncovered (would have shipped silently)

`pfb_update_pass_running()` deliberately excludes the tick verb — it is called from
`pfblockerng_tick()`'s own tail, so matching the tick's process would permanently close the idle-tick
log-maintenance gate. Its verb alternation ended in `\b`, **which a hyphen satisfies**, so the new
`cron-tick` process matched the `cron` arm: scheduled log maintenance would have silently stopped on
every real box, while the smoke suite (which drives the direct `tick` verb) stayed green. Anchored with
`(?![-\w])`, pinned by a red→green test.

## On the #1179 probe that the revert removes

Its premise dies with the workaround: under the new design a direct `tick` with a pending ledger
*should* dispatch — that is production behaviour. The flake protection now comes from the cron never
invoking the tick at all while the flag is present, so the equivalent protection is the flag-gate test
plus the harness writing the flag. `test_tick_cron_entry_installed` returns in the `cron-tick` shape.

## Coverage

- **PHPUnit** (`TickCronInstallTest`, 17 cases): cron-tick command installed; stale-entry and legacy-tick
  removal; disable branch; the migration-teardown strstr regression (legacy `cron` removed, `cron-tick`
  spared); dcc/ss_refresh/bl teardown; and the flag predicate's hostile inputs (absent, empty, arbitrary
  content incl. binary/oversized, directory-at-path, symlink, injected dbdir).
- **PHPUnit** (`PfbUpdatePassRunningTest`): `cron-tick` is not an update pass; legacy `cron` still is.
- **Smoke** (`test_smoke_tick.py`): the installed entry is cron-tick and unique; `cron-tick` honours the
  flag (branch pair: ledger unchanged with the flag, advances without it); the direct `tick` verb
  dispatches with the flag present.
- **UI Tier A + Tier B** (`ui/test_render_smoke.py`): the Update page names the sentinel with the flag
  present, and never misreports `[ Missing cron task ]` with it absent (that pins the page's probe
  command). The pre-existing `test_update_page_cron_status_reports_scheduled_tick` is updated.
- **Downgrade tool** (`pfb-downgrade-prep.sh` + its smoke test): strips both the `cron-tick` and the
  legacy `tick` entry.

ADR-43's decision text and ADR-25's ADR-43 note are amended for the new verb; architecture-notes and
config-gateway are reconciled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated scheduled **cron-tick** command for the package scheduling loop.
  * Added a **scheduled-dispatch disable flag** that suppresses only scheduled runs while manual execution continues unchanged.
  * Update UI cron status now explicitly reflects when scheduled dispatch is disabled.
* **Bug Fixes**
  * Improved handling of upgrades/downgrades and migration teardown across both legacy and cron-tick scheduling shapes.
  * Prevented cron lines from being misclassified as active update processes.
* **Documentation**
  * Refreshed architecture and downgrade/scheduling docs to match the new cron-tick behavior.
* **Tests**
  * Expanded unit and smoke coverage for cron-tick installation, disable-flag behavior, and UI reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->