### PR TITLE
agent: scope run-gates.sh shellcheck to the hook + CI paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ change the table and the runner together.
 | ------- | --------------------- |
 | Python (`*.py`) | `python3 -m pytest` · `ruff check .` · `ruff format --check .` · `mypy tests/` |
 | PHP (`*.php`/`*.inc`) | `php -l` per touched file · `vendor/bin/phpunit` · `composer phpstan` · `composer phpcs -- --standard=phpcs.xml.dist src/` |
-| Shell (`*.sh`) | `sh -n` · `shellcheck` (only `src/`, `scripts/`, `.claude/hooks/` — the scope `.githooks/pre-commit` + CI use; `tests/` shellspec specs trip SC2034 false-positives) · `shellspec --shell "$(command -v dash)"` (where specs exist; dash = strict-POSIX ash sibling of FreeBSD sh — bash-as-sh masks appliance divergences. Dash missing ⇒ the substitution goes empty and shellspec silently auto-detects — INSTALL dash (`brew`/`apt install dash`) instead of dropping the pin; plain `shellspec` is a last resort and says so in the handoff) |
+| Shell (`*.sh`) | `sh -n` · `shellcheck` (only `src/`, `scripts/`, `.claude/hooks/` — the scope `.githooks/pre-commit` + CI use; `tests/` shellspec specs trip SC2034 false-positives) · `shellspec --shell "$(command -v dash)"` (where specs exist; dash = strict-POSIX ash sibling of FreeBSD sh — bash-as-sh masks appliance divergences. Dash missing ⇒ this hand-run substitution goes empty and shellspec silently auto-detects, while the runner's own `$(command -v dash \|\| command -v sh)` falls back to `sh` — either way, INSTALL dash (`brew`/`apt install dash`) instead of dropping the pin; plain `shellspec` is a last resort and says so in the handoff) |
 | Markdown (`*.md`) | `npx markdownlint-cli2` |
 | `www/` | Tier-A `ui_render` coverage exists for the change (test mandate #4) |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ change the table and the runner together.
 | ------- | --------------------- |
 | Python (`*.py`) | `python3 -m pytest` · `ruff check .` · `ruff format --check .` · `mypy tests/` |
 | PHP (`*.php`/`*.inc`) | `php -l` per touched file · `vendor/bin/phpunit` · `composer phpstan` · `composer phpcs -- --standard=phpcs.xml.dist src/` |
-| Shell (`*.sh`) | `sh -n` · `shellcheck` · `shellspec --shell "$(command -v dash)"` (where specs exist; dash = strict-POSIX ash sibling of FreeBSD sh — bash-as-sh masks appliance divergences. Dash missing ⇒ the substitution goes empty and shellspec silently auto-detects — INSTALL dash (`brew`/`apt install dash`) instead of dropping the pin; plain `shellspec` is a last resort and says so in the handoff) |
+| Shell (`*.sh`) | `sh -n` · `shellcheck` (only `src/`, `scripts/`, `.claude/hooks/` — the scope `.githooks/pre-commit` + CI use; `tests/` shellspec specs trip SC2034 false-positives) · `shellspec --shell "$(command -v dash)"` (where specs exist; dash = strict-POSIX ash sibling of FreeBSD sh — bash-as-sh masks appliance divergences. Dash missing ⇒ the substitution goes empty and shellspec silently auto-detects — INSTALL dash (`brew`/`apt install dash`) instead of dropping the pin; plain `shellspec` is a last resort and says so in the handoff) |
 | Markdown (`*.md`) | `npx markdownlint-cli2` |
 | `www/` | Tier-A `ui_render` coverage exists for the change (test mandate #4) |
 

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -50,7 +50,12 @@ gates_for() {
 	fi
 	if printf '%s\n' "$files" | grep -q '\.sh$'; then
 		for f in $(printf '%s\n' "$files" | grep '\.sh$'); do
-			out="${out}sh -n $f${nl}shellcheck $f${nl}"
+			out="${out}sh -n $f${nl}"
+			# issue #1210: shellcheck scope mirrors .githooks/pre-commit + test.yml
+			# (src, scripts, .claude/hooks); tests/ specs trip SC2034 false-positives.
+			case "$f" in
+			src/* | scripts/* | .claude/hooks/*) out="${out}shellcheck $f${nl}" ;;
+			esac
 		done
 		out="${out}shellspec --shell \$(command -v dash || command -v sh)${nl}"
 	fi

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -42,6 +42,39 @@ Describe 'run-gates.sh gates_for()'
     The lines of output should equal 3
   End
 
+  It 'syntax-checks an out-of-scope shell file but does not shellcheck it'
+    # The hook + CI shellcheck only src/, scripts/ and .claude/hooks/; tests/ specs and
+    # vendored skill scripts trip SC2034 false-positives, so the runner must skip them too.
+    Data
+      #|tests/shell/pfb_downgrade_prep_spec.sh
+      #|.claude/skills/ponytail/hooks/ponytail-statusline.sh
+    End
+    When call gates_for
+    The line 1 of output should equal 'sh -n tests/shell/pfb_downgrade_prep_spec.sh'
+    The line 2 of output should equal 'sh -n .claude/skills/ponytail/hooks/ponytail-statusline.sh'
+    # shellcheck disable=SC2016 # the literal $( ) is the pinned command text
+    The line 3 of output should equal 'shellspec --shell $(command -v dash || command -v sh)'
+    The lines of output should equal 3
+    The output should not include 'shellcheck'
+  End
+
+  It 'shellchecks only the in-scope files of a mixed in/out-of-scope shell diff'
+    Data
+      #|src/usr/local/pkg/pfblockerng/pfblockerng.sh
+      #|.claude/hooks/x.sh
+      #|tests/shell/y_spec.sh
+    End
+    When call gates_for
+    The line 1 of output should equal 'sh -n src/usr/local/pkg/pfblockerng/pfblockerng.sh'
+    The line 2 of output should equal 'shellcheck src/usr/local/pkg/pfblockerng/pfblockerng.sh'
+    The line 3 of output should equal 'sh -n .claude/hooks/x.sh'
+    The line 4 of output should equal 'shellcheck .claude/hooks/x.sh'
+    The line 5 of output should equal 'sh -n tests/shell/y_spec.sh'
+    # shellcheck disable=SC2016 # the literal $( ) is the pinned command text
+    The line 6 of output should equal 'shellspec --shell $(command -v dash || command -v sh)'
+    The lines of output should equal 6
+  End
+
   It 'maps Markdown to markdownlint'
     Data "docs/misc/notes.md"
     When call gates_for
@@ -51,11 +84,11 @@ Describe 'run-gates.sh gates_for()'
   It 'combines gate families for a mixed diff'
     Data
       #|a.py
-      #|b.sh
+      #|scripts/b.sh
     End
     When call gates_for
     The output should include 'python3 -m pytest'
-    The output should include 'shellcheck b.sh'
+    The output should include 'shellcheck scripts/b.sh'
   End
 
   It 'refuses to build a command from an unsafe path that feeds a per-file gate'
@@ -94,11 +127,14 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rungates.XXXXXX")"
     git -C "$repo" init -q
-    printf '#!/bin/sh\n# gone-marker: content distinct from kept.sh so git reports a\n# genuine deletion (identical content collapses to an R100 rename)\ntrue\n' > "$repo/gone.sh"
+    # Under scripts/ so the files are in shellcheck's scope (src, scripts, .claude/hooks).
+    mkdir -p "$repo/scripts"
+    printf '#!/bin/sh\n# gone-marker: content distinct from kept.sh so git reports a\n# genuine deletion (identical content collapses to an R100 rename)\ntrue\n' > "$repo/scripts/gone.sh"
     gitc add -A; gitc commit -qm base
     base_sha=$(gitc rev-parse HEAD)
-    gitc rm -q gone.sh
-    printf '#!/bin/sh\ntrue\n' > "$repo/kept.sh"
+    gitc rm -q scripts/gone.sh   # also prunes the now-empty scripts/ dir
+    mkdir -p "$repo/scripts"
+    printf '#!/bin/sh\ntrue\n' > "$repo/scripts/kept.sh"
     gitc add -A; gitc commit -qm head
     # Tool stubs: the LAST planned gate (shellspec) records that it actually ran.
     stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gatestub.XXXXXX")"
@@ -116,7 +152,7 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
   It 'executes EVERY planned gate including the last one, and passes'
     When run sh "$script" --worktree "$repo" --diff "$base_sha"
     The status should equal 0
-    The output should include 'GATE PASS: sh -n kept.sh'
+    The output should include 'GATE PASS: sh -n scripts/kept.sh'
     The output should include 'GATE PASS: shellspec'
     The line 4 of output should equal 'GATES: PASS'
     Assert [ -e "$marker" ]
@@ -139,7 +175,7 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     }
     When call stdin_eating_gate
     The status should equal 0
-    The output should include 'GATE PASS: shellcheck kept.sh'
+    The output should include 'GATE PASS: shellcheck scripts/kept.sh'
     The output should include 'GATE PASS: shellspec'
     Assert [ -e "$marker" ]
   End


### PR DESCRIPTION
Fixes #1210.

## Problem

`scripts/agent/run-gates.sh --diff <base>` emitted `shellcheck <file>` for **every** touched
`*.sh`, including shellspec specs under `tests/shell/`. The authoritative gates do not:
`.githooks/pre-commit` and `.github/workflows/test.yml` both scope shellcheck to
`find src scripts .claude/hooks -name '*.sh'`, because the specs trip SC2034/SC2016
false-positives.

A PR touching only a `tests/shell/*_spec.sh` file therefore got a spurious `GATE FAIL` from
the runner while the hook and CI were green — observed on PR #1208, whose only change to
`tests/shell/pfb_downgrade_prep_spec.sh` was a comment (shellcheck reports the same two
findings on that file at the untouched base).

## Fix

`gates_for()` now gates the per-file `shellcheck` emission on the same prefix set the hook and
CI use (`src/`, `scripts/`, `.claude/hooks/`). `sh -n` and the dash-pinned `shellspec` keep
their existing, broader scope. CLAUDE.md's canonical-gates table is updated in the same change,
per the rule that the table and the runner move together.

## Tests (test-first, red → green)

New rows in `tests/shell/agent_run_gates_spec.sh`, executed RED against the unmodified
`run-gates.sh` (`14 examples, 2 failures` — the runner emitted `shellcheck tests/shell/y_spec.sh`)
and GREEN, byte-identical, after the fix (`14 examples, 0 failures`):

- an out-of-scope diff (`tests/shell/*_spec.sh` + a vendored `.claude/skills/**/*.sh`) still gets
  `sh -n` and the shellspec gate, but no `shellcheck` at all;
- a mixed diff (`src/`, `.claude/hooks/`, `tests/shell/`) shellchecks only the in-scope files
  while `sh -n` still covers every file.

Existing rows that fed bare-root/out-of-scope fixtures (`b.sh`, the fixture repo's `kept.sh`) were
relocated under `scripts/` so their shellcheck assertions keep asserting rather than silently
going vacuous. Red proof re-verified independently with `scripts/agent/verify-red-proof.sh`
(FREEZE-OK / RED-OK / GREEN-OK).

Gates: `sh -n` · `shellcheck` · `shellspec --shell "$(command -v dash)"` · `npx markdownlint-cli2`
— all green via `scripts/agent/run-gates.sh --diff origin/devel`, whose own plan for this branch
now shows `sh -n` (but no `shellcheck`) for the touched spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shell validation now applies static analysis only to supported project scripts, while syntax checks continue across all changed shell files.
  * Improved handling of shell test files and environments where `dash` is unavailable.

* **Tests**
  * Added coverage for mixed in-scope and out-of-scope shell changes.
  * Updated validation scenarios for added, removed, and retained script files.

* **Documentation**
  * Clarified shell validation rules and `dash` installation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->