### PR TITLE
tests/smoke: live-VM coverage for the batch IP recompute flow (#1084 follow-up)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1362,8 +1362,9 @@ def set_ip_reputation(
     the dMax/pMax repmode selectors); ``dmax``/``pmax`` -> ``p24_dmax_var``/``p24_pmax_var``
     (the per-/24 offender-count thresholds); ``ccwhite``/``ccblack``/``ccexclude`` -> the
     GeoIP classify action + exempt-country CSV (unused by pMax's GeoIP-free block-only path,
-    ``pfblockerng.sh`` ``pfb_recompute_rep_actionmap``). A full REPLACE (not merge) of the
-    config root, so a prior test's values can never leak into this one.
+    ``pfblockerng.sh`` ``pfb_recompute_rep_actionmap``). Every knob above is written on every
+    call, so a prior test's values never leak; the section's other keys (``et_header``) are
+    merged through untouched.
     """
     settings = {
         "enable_dedup": "on" if drep else "",
@@ -1374,8 +1375,11 @@ def set_ip_reputation(
         "ccblack": ccblack,
         "ccexclude": ccexclude,
     }
+    assigns = "".join(f"$rep[{_php_str(k)}] = {_php_str(v)};\n" for k, v in settings.items())
     snippet = (
-        f"config_set_path({_php_str(CFG_IP_REPUTATION)}, {_php_kv_array(settings)});\n"
+        f"$rep = config_get_path({_php_str(CFG_IP_REPUTATION)}, array());\n"
+        f"{assigns}"
+        f"config_set_path({_php_str(CFG_IP_REPUTATION)}, $rep);\n"
         "write_config('pfBlockerNG smoke: IP reputation knobs');\n"
         "echo 'OK';"
     )

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -92,6 +92,8 @@ CFG_DNSBL_LISTS = "installedpackages/pfblockerngdnsbl/config"
 CFG_IP_V4_LISTS = "installedpackages/pfblockernglistsv4/config"
 CFG_IP_V6_LISTS = "installedpackages/pfblockernglistsv6/config"
 CFG_IP_SETTINGS = "installedpackages/pfblockerngipsettings/config/0"
+# issue #1084: dRep/pRep/dMax/pMax knobs the batch `recompute` matrix reads (pfblockerng.inc ~15746).
+CFG_IP_REPUTATION = "installedpackages/pfblockerngreputation/config/0"
 # DNS-Resolver Host Overrides: control names go here (see set_control_records).
 CFG_UNBOUND_HOSTS = "unbound/hosts"
 
@@ -1321,6 +1323,95 @@ def set_pfb_keep(vm: SmokeVM, keep: bool, *, timeout: float = 60.0) -> None:
     result = php_eval(vm, snippet, timeout=timeout)
     if result.returncode != 0 or "OK" not in result.stdout:
         raise RuntimeError(f"set_pfb_keep({keep}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def set_ip_dedup(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
+    """Toggle IP-side Deduplication (``enable_dup`` -> ``$pfb['dup']``) at ``CFG_IP_SETTINGS``.
+
+    issue #1084: ``dup=='on'`` drives the batch ``recompute`` verb for BOTH v4+v6
+    (``pfb_ip_recompute_matrix()``); dedup off + dRep/pRep alone still recomputes v4-only.
+    """
+    val = "on" if on else ""
+    snippet = (
+        f"$ip = config_get_path({_php_str(CFG_IP_SETTINGS)}, array());\n"
+        f"$ip['enable_dup'] = {_php_str(val)};\n"
+        f"config_set_path({_php_str(CFG_IP_SETTINGS)}, $ip);\n"
+        "write_config('pfBlockerNG smoke: toggle enable_dup');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"set_ip_dedup({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def set_ip_reputation(
+    vm: SmokeVM,
+    *,
+    drep: bool = False,
+    prep: bool = False,
+    dmax: int = 0,
+    pmax: int = 0,
+    ccwhite: str = "off",
+    ccblack: str = "off",
+    ccexclude: str = "",
+    timeout: float = 60.0,
+) -> None:
+    """Set the batch-``recompute`` reputation knobs (issue #1084) at ``CFG_IP_REPUTATION``.
+
+    ``drep``/``prep`` -> ``enable_dedup``/``enable_pdup`` (``$pfb['drep']``/``$pfb['prep']``,
+    the dMax/pMax repmode selectors); ``dmax``/``pmax`` -> ``p24_dmax_var``/``p24_pmax_var``
+    (the per-/24 offender-count thresholds); ``ccwhite``/``ccblack``/``ccexclude`` -> the
+    GeoIP classify action + exempt-country CSV (unused by pMax's GeoIP-free block-only path,
+    ``pfblockerng.sh`` ``pfb_recompute_rep_actionmap``). A full REPLACE (not merge) of the
+    config root, so a prior test's values can never leak into this one.
+    """
+    settings = {
+        "enable_dedup": "on" if drep else "",
+        "enable_pdup": "on" if prep else "",
+        "p24_dmax_var": str(dmax),
+        "p24_pmax_var": str(pmax),
+        "ccwhite": ccwhite,
+        "ccblack": ccblack,
+        "ccexclude": ccexclude,
+    }
+    snippet = (
+        f"config_set_path({_php_str(CFG_IP_REPUTATION)}, {_php_kv_array(settings)});\n"
+        "write_config('pfBlockerNG smoke: IP reputation knobs');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"set_ip_reputation failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def set_ip_suppression(
+    vm: SmokeVM,
+    *,
+    enabled: bool = False,
+    v4: list[str] | None = None,
+    v6: list[str] | None = None,
+    timeout: float = 60.0,
+) -> None:
+    """Toggle the global "Enable Suppression" checkbox + set BOTH v4/v6 customlists at
+    ``CFG_IP_SETTINGS`` (``suppression``/``v4suppression``/``v6suppression``).
+
+    Every suppression line needs an explicit CIDR mask (a bare host is rejected) --
+    ``f"{ip}/32"``/``f"{ip}/128"``. Always writes all three keys (never a merge), so a
+    prior test's toggle/list can never leak into this one -- same shape as
+    ``test_smoke_suppression.py``'s own module-local ``_set_suppression``.
+    """
+    snippet = (
+        f"$ip = config_get_path({_php_str(CFG_IP_SETTINGS)}, array());\n"
+        f"$ip['suppression'] = {_php_str('on' if enabled else '')};\n"
+        f"$ip['v4suppression'] = {_php_str(_b64_textarea(v4 or []))};\n"
+        f"$ip['v6suppression'] = {_php_str(_b64_textarea(v6 or []))};\n"
+        f"config_set_path({_php_str(CFG_IP_SETTINGS)}, $ip);\n"
+        "write_config('pfBlockerNG smoke: IP suppression');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"set_ip_suppression failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
 
 
 def set_dnsbl_interface(vm: SmokeVM, iface: str, *, timeout: float = 60.0) -> None:

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -1,0 +1,472 @@
+"""issue #1084 live-VM smoke: the batch IP `recompute` flow end-to-end.
+
+pfBlockerNG's batch ``recompute`` verb (``pfblockerng.sh``, invoked from
+``pfblockerng.inc`` ~19060-19135) replaces the old incremental duplicate()/dMax/pMax
+pass: real feeds parse -> a pristine post-preprocessing snapshot per header
+(``pfb_ip_recompute_write_snapshot``) -> a per-family memberlist -> ONE
+``pfblockerng.sh recompute`` call that rewrites EVERY alias of that family from its
+snapshot -> the rewritten deny files load into their pf tables. This module drives
+that whole pipeline through the real CLI (``helpers.reload``) on a real pfSense VM
+and observes the on-box deny/master files + live ``pfctl`` tables — the CI-runnable,
+credential-free half (Part 1 of issue #1170); Continent/GeoIP-dependent rows are
+Part 2.
+
+WHAT THIS FILE AUTOMATES:
+
+* **R1 — cross-feed dedup ownership** — two overlapping v4 Deny feeds (a
+  CIDR-containment overlap + an exact repeat, dedup ON): the higher-priority feed
+  (config order) keeps the overlap in BOTH the on-box deny file and its pf table;
+  the lower-priority feed keeps only its unique row.
+* **R2 — v6 snapshot round-trip** — a v6 Deny feed's pristine post-preprocessing
+  snapshot (``.snap``) is written on first ingest, and its content round-trips
+  byte-identical into a SECOND pass's deny file/pf table when the feed is held
+  static (recompute re-emits the same snapshot unchanged).
+* **R4 — unchanged-sibling survives a family-wide rewrite** — one alias's feed
+  genuinely changes (a real re-download, via ``force_ip_refetch``); an untouched
+  sibling alias (never reprocessed this pass) still shows correct, unperturbed
+  content after recompute rewrites the whole family from the memberlist.
+* **R5 / R9 — closing-pass placeholder refill, both branches of
+  ``pfb_ip_closing_pass_active()``** — dup=ON (R5, unconditional closing) and
+  dup=OFF+pRep=ON (R9, closing fires only because recompute genuinely ran): an
+  alias that collapses to ZERO rows (suppression for R5; a pMax /24 offender
+  divert for R9 — GeoIP-free, unlike dMax/match modes) gets the deny placeholder,
+  never a stale 0-byte file.
+* **R6 — suppression realigns across a sibling's recompute (regression pin,
+  the #1084-review resurrection bug)** — an IP suppressed on alias A stays
+  suppressed even after an UNRELATED sibling B's genuine change drives a
+  family-wide recompute that rewrites A too (recompute's snapshot is a
+  PRE-suppression capture, so a stale suppression gate would resurrect it).
+
+Reload-scope note: R1/R2/R5/R9 are single-pass (or repeat-input) cases and use
+``reload(scope='updateip')`` — its ``force=true`` sets ``$pfb['reuse']='on'`` for the
+WHOLE pass, so every configured Deny alias is genuinely reprocessed (never the
+early "exists, skip" cache) without needing a marker touch (see
+``test_smoke_suppression.py``'s identical rationale). R4/R6 need to distinguish "this
+alias's OWN feed did not change" from "recompute ran anyway" — the exact axis
+`force=true` collapses (every alias becomes `$feed_changed` every pass) — so they use
+the ADR-40-proven two-pass shape instead: ``reload(scope='update')`` (respects the
+per-alias reuse-skip) + ``force_ip_refetch()`` on ONLY the alias that must genuinely
+re-ingest.
+
+WHAT STAYS FOR STEP 2 (Continent/GeoIP-dependent, per the issue #1170 brief):
+
+* R3/R7/R8 — anything requiring a real MaxMind GeoIP database (dMax/match-mode
+  country classification, Continent-list interaction with recompute).
+
+DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke``). Run via
+the smoke workflow or locally::
+
+    python -m pytest tests/smoke -m smoke --override-ini="addopts="
+
+Requires the booted ``smoke_vm`` fixture and the branch ``.pkg`` (``SMOKE_PKG``);
+without it the module fixture skips cleanly. Pure IP-side (no DNSBL, no DNS probe) —
+mirrors the minimal ``test_smoke_suppression.py``/``test_smoke_714_asn_geoip.py``
+deploy shape.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM
+
+pytestmark = pytest.mark.smoke
+
+CFG_IP_SETTINGS = h.CFG_IP_SETTINGS
+DENYDIR = f"{h.PFB_DBDIR}/deny"
+SNAPDIR = f"{h.PFB_DBDIR}/snapshot"
+MASTERFILE = f"{h.PFB_DBDIR}/masterfile"
+
+# A fixed, known placeholder (default is PHP-side only — pfblockerng.sh reads the RAW
+# config node via read_xml_tag.sh, with no fallback — see pfb['ip_ph']'s pfb_filter
+# default vs. the shell's direct XML read) so R5/R9's collapse assertion compares
+# against an EXACT string instead of an ambiguous default.
+PLACEHOLDER_IP = "127.1.7.7"
+
+
+@pytest.fixture(scope="module")
+def deployed_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """Deploy the branch .pkg once for the issue #1084 recompute module.
+
+    Pure IP-side: the batch recompute pipeline runs inside the IP-scope reload path
+    only (no DNSBL, no DNS probe needed) -- mirrors the minimal
+    ``test_smoke_suppression.py``/``test_smoke_714_asn_geoip.py`` shape.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    try:
+        yield smoke_vm
+    finally:
+        # Leave no dedup/reputation/suppression knob set for the next module's reloads.
+        h.set_ip_dedup(smoke_vm, False)
+        h.set_ip_reputation(smoke_vm)
+        h.set_ip_suppression(smoke_vm, enabled=False)
+        h.collect_host_diagnostics(smoke_vm)
+
+
+def _set_placeholder(vm: SmokeVM, value: str) -> None:
+    """Set ``ip_placeholder`` at ``CFG_IP_SETTINGS`` -- a local one-off (not promoted to
+    helpers.py; only R5/R9 in this module need a deterministic placeholder value)."""
+    snippet = (
+        f"$ip = config_get_path({h._php_str(CFG_IP_SETTINGS)}, array());\n"
+        f"$ip['ip_placeholder'] = {h._php_str(value)};\n"
+        f"config_set_path({h._php_str(CFG_IP_SETTINGS)}, $ip);\n"
+        "write_config('pfBlockerNG smoke: ip_placeholder');\n"
+        "echo 'OK';"
+    )
+    result = h.php_eval(vm, snippet)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"_set_placeholder failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def _lines(vm: SmokeVM, path: str) -> list[str]:
+    """Non-blank lines of an on-box file (mirrors test_smoke_suppression.py's
+    ``_member_lines`` -- generalised here to any deny/master/snapshot file)."""
+    result = vm.ssh("cat", path)
+    return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+
+
+# --------------------------------------------------------------------------- #
+# R1 -- cross-feed dedup ownership (CIDR containment + exact repeat)
+# --------------------------------------------------------------------------- #
+
+
+def test_recompute_dedup_ownership_across_overlapping_feeds(deployed_vm: SmokeVM) -> None:
+    """dedup ON: the higher-priority feed keeps a containment overlap AND an exact
+    repeat; the lower-priority feed keeps only its unique row -- on-box AND pf table.
+
+    Scenario: two v4 Deny feeds sharing real overlap, not disjoint IPs.
+      Given feed A (config order 1st, so highest recompute priority) lists a /24
+        network (``203.0.113.0/24``) and a bare host (``198.51.100.211``), and
+        feed B (2nd) lists a host INSIDE A's /24 (``203.0.113.44``, a CIDR-containment
+        overlap), an EXACT repeat of A's bare host (``198.51.100.211``), and its own
+        unique host (``198.51.100.212``),
+      When dedup is ON and a single ``updateip`` reload runs,
+      Then A's deny file/table is UNCHANGED (both its original rows, priority owns
+        ties) while B's deny file/table holds ONLY its unique row -- both overlap
+        classes pruned from B, mirroring the shellspec unit suite's own adversarial
+        shapes (never a disjoint-IP pair, which would pass vacuously).
+    """
+    h.set_ip_dedup(deployed_vm, True)
+    h.set_ip_reputation(deployed_vm)
+    h.set_ip_suppression(deployed_vm, enabled=False)
+
+    feed_a = h.write_local_feed(deployed_vm, "r1_feed_a.txt", "203.0.113.0/24\n198.51.100.211\n")
+    feed_b = h.write_local_feed(deployed_vm, "r1_feed_b.txt", "203.0.113.44\n198.51.100.211\n198.51.100.212\n")
+    spec_a = h.IpCase(aliasname="r1a", feed_url=feed_a, header="r1a", action="Deny_Both")
+    spec_b = h.IpCase(aliasname="r1b", feed_url=feed_b, header="r1b", action="Deny_Both")
+    # Order matters: A first = highest recompute priority (config order == memberlist
+    # priority, pfb_ip_recompute_family_headers()).
+    h.inject_ip_lists(deployed_vm, [spec_a, spec_b])
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    a_lines = _lines(deployed_vm, f"{DENYDIR}/r1a_v4.txt")
+    b_lines = _lines(deployed_vm, f"{DENYDIR}/r1b_v4.txt")
+    assert set(a_lines) == {"203.0.113.0/24", "198.51.100.211"}, f"feed A perturbed: {a_lines}"
+    assert set(b_lines) == {"198.51.100.212"}, f"feed B ownership wrong (overlap not pruned): {b_lines}"
+
+    master = _lines(deployed_vm, MASTERFILE)
+    assert "r1a_v4 203.0.113.0/24" in master, f"masterfile missing A's /24 row: {master}"
+    assert "r1a_v4 198.51.100.211" in master, f"masterfile missing A's exact-repeat winner: {master}"
+    assert "r1b_v4 198.51.100.212" in master, f"masterfile missing B's unique row: {master}"
+    assert "r1b_v4 203.0.113.44" not in master, f"masterfile kept B's pruned containment row: {master}"
+    assert "r1b_v4 198.51.100.211" not in master, f"masterfile kept B's pruned exact-repeat row: {master}"
+
+    a_members = h.wait_pfctl_table(deployed_vm, spec_a.alias)
+    b_members = h.wait_pfctl_table(deployed_vm, spec_b.alias)
+    assert h.member_present(a_members, "198.51.100.211"), (
+        f"pf table {spec_a.alias} missing exact-repeat winner: {a_members}"
+    )
+    assert h.member_covers(a_members, "203.0.113.44"), f"pf table {spec_a.alias} missing its /24 coverage: {a_members}"
+    assert h.member_present(b_members, "198.51.100.212"), f"pf table {spec_b.alias} missing unique row: {b_members}"
+    assert not h.member_present(b_members, "198.51.100.211"), (
+        f"pf table {spec_b.alias} kept the exact-repeat row it should have lost: {b_members}"
+    )
+    assert not h.member_covers(b_members, "203.0.113.44"), (
+        f"pf table {spec_b.alias} kept the containment-overlap row it should have lost: {b_members}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# R2 -- v6 snapshot write + round-trip across a static pass
+# --------------------------------------------------------------------------- #
+
+
+def test_recompute_v6_snapshot_round_trips_across_static_pass(deployed_vm: SmokeVM) -> None:
+    """A v6 Deny feed's pristine snapshot round-trips unchanged into a SECOND pass
+    when the feed is held static.
+
+    Scenario: one v6 Deny feed, two successive updateip passes with no edit between.
+      Given a v6 Deny feed (a /64 network + a bare host inside a DIFFERENT /64),
+      When the first ``updateip`` pass runs,
+      Then the ``.snap`` file exists under the snapshot dir with exactly the fed
+        rows, and the deny file/pf table match,
+      When a SECOND ``updateip`` pass runs with the feed held static (updateip's
+        force=true reprocesses every alias from its cached raw body regardless),
+      Then the deny file is BYTE-IDENTICAL to the first pass and the pf table still
+        holds both rows (recompute re-emits the same snapshot unchanged).
+    """
+    h.set_ip_dedup(deployed_vm, True)  # dup=on is required to invoke the v6 family at all.
+    h.set_ip_reputation(deployed_vm)
+    h.set_ip_suppression(deployed_vm, enabled=False)
+
+    body = "2001:db8:5678::/64\n2001:db8:5678:1::42\n"
+    feed = h.write_local_feed(deployed_vm, "r2_feed_v6.txt", body)
+    spec = h.IpCase(aliasname="r2v6", feed_url=feed, header="r2v6", action="Deny_Both", family="v6")
+    h.inject_ip_lists(deployed_vm, [spec])
+
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+    snap_lines = _lines(deployed_vm, f"{SNAPDIR}/r2v6_v6.snap")
+    deny_lines_pass1 = _lines(deployed_vm, f"{DENYDIR}/r2v6_v6.txt")
+    expected = {"2001:db8:5678::/64", "2001:db8:5678:1::42"}
+    assert set(snap_lines) == expected, f"snapshot content wrong after first ingest: {snap_lines}"
+    assert set(deny_lines_pass1) == expected, f"deny file content wrong after first ingest: {deny_lines_pass1}"
+    members_pass1 = h.wait_pfctl_table(deployed_vm, spec.alias)
+    assert h.member_present(members_pass1, "2001:db8:5678:1::42"), f"pf table missing bare host: {members_pass1}"
+    assert h.member_covers(members_pass1, "2001:db8:5678::1"), f"pf table missing /64 coverage: {members_pass1}"
+
+    # Held static: no edit, no force_ip_refetch -- updateip's force=true alone
+    # reprocesses this alias again from its cached raw body.
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+    deny_lines_pass2 = _lines(deployed_vm, f"{DENYDIR}/r2v6_v6.txt")
+    assert set(deny_lines_pass2) == set(deny_lines_pass1), (
+        f"deny file changed across a static pass: pass1={deny_lines_pass1} pass2={deny_lines_pass2}"
+    )
+    master = _lines(deployed_vm, MASTERFILE)
+    assert "r2v6_v6 2001:db8:5678::/64" in master, f"masterfile missing v6 /64 row after round-trip: {master}"
+    assert "r2v6_v6 2001:db8:5678:1::42" in master, f"masterfile missing v6 host row after round-trip: {master}"
+    members_pass2 = h.wait_pfctl_table(deployed_vm, spec.alias)
+    assert h.member_present(members_pass2, "2001:db8:5678:1::42"), (
+        f"pf table lost bare host after round-trip: {members_pass2}"
+    )
+    assert h.member_covers(members_pass2, "2001:db8:5678::1"), (
+        f"pf table lost /64 coverage after round-trip: {members_pass2}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# R4 -- an unchanged sibling survives a family-wide recompute rewrite
+# --------------------------------------------------------------------------- #
+
+
+def test_recompute_rewrites_unchanged_sibling_across_passes(deployed_vm: SmokeVM) -> None:
+    """A genuinely unprocessed sibling alias still shows correct content after
+    recompute rewrites the WHOLE family (not just the alias that changed).
+
+    Scenario: two v4 Deny feeds; only one is genuinely re-ingested on pass 2.
+      Given (BEFORE) alias A (``198.51.100.31``) and alias B (``198.51.100.41``)
+        both settle correctly on the first ``update`` pass,
+      When A's feed is rewritten to ADD a row and force-refetched (a REAL
+        re-download, via ``force_ip_refetch``), while B is left completely
+        untouched (no edit, no refetch marker -- B is genuinely SKIPPED this pass
+        by the reuse-cache, never re-added to the "feed changed" set) and a second
+        ``update`` runs,
+      Then A's deny file gains the new row AND B's deny file/pf table are STILL
+        correct -- proving recompute reads B from its (unchanged) memberlist
+        snapshot rather than silently dropping an alias nothing "touched" this pass.
+    """
+    h.set_ip_dedup(deployed_vm, True)
+    h.set_ip_reputation(deployed_vm)
+    h.set_ip_suppression(deployed_vm, enabled=False)
+
+    feed_a = h.write_local_feed(deployed_vm, "r4_feed_a.txt", "198.51.100.31\n")
+    feed_b = h.write_local_feed(deployed_vm, "r4_feed_b.txt", "198.51.100.41\n")
+    spec_a = h.IpCase(aliasname="r4a", feed_url=feed_a, header="r4a", action="Deny_Both")
+    spec_b = h.IpCase(aliasname="r4b", feed_url=feed_b, header="r4b", action="Deny_Both")
+    h.inject_ip_lists(deployed_vm, [spec_a, spec_b])
+    h.reload(deployed_vm, "update")
+
+    # BEFORE: both settle correctly.
+    a_before = _lines(deployed_vm, f"{DENYDIR}/r4a_v4.txt")
+    b_before = _lines(deployed_vm, f"{DENYDIR}/r4b_v4.txt")
+    assert set(a_before) == {"198.51.100.31"}, f"A did not settle before the change: {a_before}"
+    assert set(b_before) == {"198.51.100.41"}, f"B did not settle before the change: {b_before}"
+
+    # CHANGE: A gains a row via a REAL re-download; B is left completely alone.
+    h.write_local_feed(deployed_vm, "r4_feed_a.txt", "198.51.100.31\n198.51.100.32\n")
+    h.force_ip_refetch(deployed_vm, "r4a_v4")
+    h.reload(deployed_vm, "update")
+
+    a_after = _lines(deployed_vm, f"{DENYDIR}/r4a_v4.txt")
+    b_after = _lines(deployed_vm, f"{DENYDIR}/r4b_v4.txt")
+    assert set(a_after) == {"198.51.100.31", "198.51.100.32"}, f"A's change was not applied: {a_after}"
+    assert set(b_after) == {"198.51.100.41"}, (
+        f"B (never touched) was dropped/perturbed by the family rewrite: {b_after}"
+    )
+
+    master = _lines(deployed_vm, MASTERFILE)
+    assert "r4a_v4 198.51.100.32" in master, f"masterfile missing A's new row: {master}"
+    assert "r4b_v4 198.51.100.41" in master, f"masterfile missing B's unchanged row after the family rewrite: {master}"
+
+    b_members = h.wait_pfctl_table(deployed_vm, spec_b.alias)
+    assert h.member_present(b_members, "198.51.100.41"), f"pf table {spec_b.alias} lost its member: {b_members}"
+
+
+# --------------------------------------------------------------------------- #
+# R5 -- closing-pass placeholder refill, dup=ON branch (suppression collapse)
+# --------------------------------------------------------------------------- #
+
+
+def test_recompute_closing_refills_placeholder_dup_on(deployed_vm: SmokeVM) -> None:
+    """dup=ON: an alias that collapses to ZERO rows via suppression gets the deny
+    placeholder, never a stale 0-byte file (``pfb_ip_closing_pass_active()``'s
+    unconditional ``(TRUE, 'on')`` branch).
+
+    Scenario: one v4 Deny feed whose sole IP is fully suppressed.
+      Given a Deny feed with ONE public (non-reserved -- Suppression drops
+        RFC 5737/3849 unconditionally when on, issue #760) IP, and that exact
+        IP is the ONLY suppression-list entry,
+      When dedup is ON and a single ``updateip`` reload runs,
+      Then the alias's deny file equals the placeholder EXACTLY (not empty, not
+        the raw IP -- a broken suppression pass would leave the raw IP; a broken
+        closing pass would leave 0 bytes) and the pf table carries the placeholder.
+    """
+    h.set_ip_dedup(deployed_vm, True)
+    h.set_ip_reputation(deployed_vm)
+    ip = "172.104.90.10"
+    h.set_ip_suppression(deployed_vm, enabled=True, v4=[f"{ip}/32"])
+    _set_placeholder(deployed_vm, PLACEHOLDER_IP)
+
+    feed = h.write_local_feed(deployed_vm, "r5_feed.txt", f"{ip}\n")
+    spec = h.IpCase(aliasname="r5", feed_url=feed, header="r5", action="Deny_Both")
+    h.inject_ip_lists(deployed_vm, [spec])
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    deny_lines = _lines(deployed_vm, f"{DENYDIR}/r5_v4.txt")
+    assert deny_lines == [PLACEHOLDER_IP], f"suppression-collapsed alias not placeholder-refilled: {deny_lines}"
+    members = h.wait_pfctl_table(deployed_vm, spec.alias)
+    assert h.member_present(members, PLACEHOLDER_IP), f"pf table missing the placeholder: {members}"
+
+
+# --------------------------------------------------------------------------- #
+# R9 -- closing-pass placeholder refill, dup=OFF + pRep=ON branch (pMax collapse)
+# --------------------------------------------------------------------------- #
+
+
+def test_recompute_closing_refills_placeholder_dup_off_pmax(deployed_vm: SmokeVM) -> None:
+    """dup=OFF + pRep=ON: an alias whose rows ALL migrate to a higher-priority
+    sibling's collapsed /24 (pMax offender divert) gets the deny placeholder --
+    the ``alias_arg='off'`` branch of ``pfb_ip_closing_pass_active()`` fires only
+    because ``recompute_ran_v4`` is TRUE (dup is OFF, so it is NOT unconditional).
+
+    pMax is GeoIP-free (unconditional block, ``pfblockerng.sh
+    pfb_recompute_rep_actionmap``) -- unlike dMax/match mode, no MaxMind database
+    is needed, so this row is in-scope for the credential-free CI leg.
+
+    Scenario: two v4 Deny feeds sharing one /24, over the pMax threshold.
+      Given anchor (config order 1st, highest priority) lists ONE host in
+        ``192.0.2.0/24``, and collapse (2nd) lists TWO more hosts in the SAME /24
+        (combined count 3 > pmax=2 -> the whole /24 is an offender),
+      When dedup is OFF, pRep is ON with pmax=2, and a single ``updateip`` reload
+        runs,
+      Then anchor's deny file holds the collapsed ``192.0.2.0/24`` supernet (proving
+        the offender mechanism genuinely fired) and collapse's deny file -- now
+        holding NOTHING of its own -- equals the placeholder, not 0 bytes.
+    """
+    h.set_ip_dedup(deployed_vm, False)
+    h.set_ip_reputation(deployed_vm, prep=True, pmax=2)
+    h.set_ip_suppression(deployed_vm, enabled=False)
+    _set_placeholder(deployed_vm, PLACEHOLDER_IP)
+
+    feed_anchor = h.write_local_feed(deployed_vm, "r9_feed_anchor.txt", "192.0.2.21\n")
+    feed_collapse = h.write_local_feed(deployed_vm, "r9_feed_collapse.txt", "192.0.2.22\n192.0.2.23\n")
+    spec_anchor = h.IpCase(aliasname="r9hi", feed_url=feed_anchor, header="r9hi", action="Deny_Both")
+    spec_collapse = h.IpCase(aliasname="r9lo", feed_url=feed_collapse, header="r9lo", action="Deny_Both")
+    # Order matters: anchor first = highest recompute priority, so it absorbs the
+    # collapsed /24; "collapse" (listed 2nd) is the one that ends up empty.
+    h.inject_ip_lists(deployed_vm, [spec_anchor, spec_collapse])
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    anchor_lines = _lines(deployed_vm, f"{DENYDIR}/r9hi_v4.txt")
+    collapse_lines = _lines(deployed_vm, f"{DENYDIR}/r9lo_v4.txt")
+    assert anchor_lines == ["192.0.2.0/24"], f"pMax offender did not collapse to the anchor's /24: {anchor_lines}"
+    assert collapse_lines == [PLACEHOLDER_IP], f"pMax-collapsed alias not placeholder-refilled: {collapse_lines}"
+
+    collapse_members = h.wait_pfctl_table(deployed_vm, spec_collapse.alias)
+    assert h.member_present(collapse_members, PLACEHOLDER_IP), f"pf table missing the placeholder: {collapse_members}"
+    anchor_members = h.wait_pfctl_table(deployed_vm, spec_anchor.alias)
+    assert h.member_covers(anchor_members, "192.0.2.21"), (
+        f"pf table lost the anchor's own offending host: {anchor_members}"
+    )
+    assert h.member_covers(anchor_members, "192.0.2.22"), (
+        f"pf table missing the absorbed sibling host: {anchor_members}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# R6 -- suppression realigns across a SIBLING's recompute (regression pin)
+# --------------------------------------------------------------------------- #
+
+
+def test_recompute_suppression_realigns_across_sibling_change(deployed_vm: SmokeVM) -> None:
+    """A suppressed IP stays suppressed even after an UNRELATED sibling's genuine
+    change drives a family-wide recompute that rewrites the suppressed alias too.
+
+    Regression pin for the #1084-review resurrection bug: ``pfb_recompute()``'s
+    snapshot is a PRE-suppression capture (issue #1084 review comment,
+    pfblockerng.inc ~5065), so recompute alone would resurrect a suppressed IP on
+    ANY pass that rewrites that alias -- ``pfb_ip_suppress_body_active()``'s
+    ``$feed_changed || $recompute_ran`` clause is what re-applies suppression even
+    when the SUPPRESSED alias's OWN feed did not change.
+
+    Uses ``reload(scope='update')`` (not 'updateip'): 'updateip' force=true makes
+    EVERY alias `$feed_changed` on EVERY pass (see the module docstring), which
+    would make this scenario impossible to construct -- A's own feed must
+    genuinely NOT be reprocessed this pass for the regression to be exercisable.
+
+    Scenario: alias A (one suppressed IP + one surviving IP) + sibling alias B.
+      Given (BEFORE, after settling) X (suppressed) is ABSENT from A's deny file
+        while Z (not suppressed) is present,
+      When B's feed is rewritten and force-refetched (a REAL re-download -- B's
+        OWN change) while A is left completely untouched, and a second ``update``
+        runs,
+      Then X is STILL absent from A's deny file/pf table (re-suppression re-ran
+        for A even though A's own feed did not change) and Z is still present, AND
+        B's deny file reflects its new content (proving the sibling's change
+        genuinely happened and drove this pass).
+    """
+    h.set_ip_dedup(deployed_vm, True)
+    h.set_ip_reputation(deployed_vm)
+    suppressed_ip = "172.104.91.20"
+    survivor_ip = "172.104.91.21"
+    h.set_ip_suppression(deployed_vm, enabled=True, v4=[f"{suppressed_ip}/32"])
+
+    feed_a = h.write_local_feed(deployed_vm, "r6_feed_a.txt", f"{suppressed_ip}\n{survivor_ip}\n")
+    feed_b = h.write_local_feed(deployed_vm, "r6_feed_b.txt", "172.104.92.30\n")
+    spec_a = h.IpCase(aliasname="r6a", feed_url=feed_a, header="r6a", action="Deny_Both")
+    spec_b = h.IpCase(aliasname="r6b", feed_url=feed_b, header="r6b", action="Deny_Both")
+    h.inject_ip_lists(deployed_vm, [spec_a, spec_b])
+    h.reload(deployed_vm, "update")
+
+    # BEFORE: the suppressed IP is genuinely absent (not merely "never checked").
+    a_before = _lines(deployed_vm, f"{DENYDIR}/r6a_v4.txt")
+    assert suppressed_ip not in a_before, f"suppression did not remove {suppressed_ip} on settle: {a_before}"
+    assert survivor_ip in a_before, f"unrelated survivor {survivor_ip} wrongly removed on settle: {a_before}"
+
+    # CHANGE: ONLY B's feed genuinely changes (a real re-download); A is untouched.
+    h.write_local_feed(deployed_vm, "r6_feed_b.txt", "172.104.92.31\n")
+    h.force_ip_refetch(deployed_vm, "r6b_v4")
+    h.reload(deployed_vm, "update")
+
+    a_after = _lines(deployed_vm, f"{DENYDIR}/r6a_v4.txt")
+    assert suppressed_ip not in a_after, (
+        f"REGRESSION (#1084 resurrection bug): {suppressed_ip} resurfaced in A after an UNRELATED "
+        f"sibling's recompute -- suppression did not re-run for a feed-unchanged alias: {a_after}"
+    )
+    assert survivor_ip in a_after, (
+        f"unrelated survivor {survivor_ip} dropped by the sibling-triggered rewrite: {a_after}"
+    )
+
+    a_members = h.wait_pfctl_table(deployed_vm, spec_a.alias)
+    assert not h.member_present(a_members, suppressed_ip), (
+        f"pf table {spec_a.alias} still carries the suppressed IP: {a_members}"
+    )
+    assert h.member_present(a_members, survivor_ip), f"pf table {spec_a.alias} lost the survivor: {a_members}"
+
+    b_after = _lines(deployed_vm, f"{DENYDIR}/r6b_v4.txt")
+    assert b_after == ["172.104.92.31"], f"B's own change was not applied -- the sibling trigger is not real: {b_after}"

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -101,10 +101,11 @@ def deployed_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
     try:
         yield smoke_vm
     finally:
-        # Leave no dedup/reputation/suppression knob set for the next module's reloads.
+        # Leave no dedup/reputation/suppression/placeholder knob set for the next module.
         h.set_ip_dedup(smoke_vm, False)
         h.set_ip_reputation(smoke_vm)
         h.set_ip_suppression(smoke_vm, enabled=False)
+        _set_placeholder(smoke_vm, "")
         h.collect_host_diagnostics(smoke_vm)
 
 

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -130,6 +130,11 @@ def _lines(vm: SmokeVM, path: str) -> list[str]:
     return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
 
 
+def _raw(vm: SmokeVM, path: str) -> str:
+    """Raw on-box file content -- for byte-identity checks a line-set cannot make."""
+    return vm.ssh("cat", path).stdout
+
+
 # --------------------------------------------------------------------------- #
 # R1 -- cross-feed dedup ownership (CIDR containment + exact repeat)
 # --------------------------------------------------------------------------- #
@@ -166,8 +171,8 @@ def test_recompute_dedup_ownership_across_overlapping_feeds(deployed_vm: SmokeVM
 
     a_lines = _lines(deployed_vm, f"{DENYDIR}/r1a_v4.txt")
     b_lines = _lines(deployed_vm, f"{DENYDIR}/r1b_v4.txt")
-    assert set(a_lines) == {"203.0.113.0/24", "198.51.100.211"}, f"feed A perturbed: {a_lines}"
-    assert set(b_lines) == {"198.51.100.212"}, f"feed B ownership wrong (overlap not pruned): {b_lines}"
+    assert sorted(a_lines) == sorted(["203.0.113.0/24", "198.51.100.211"]), f"feed A perturbed: {a_lines}"
+    assert b_lines == ["198.51.100.212"], f"feed B ownership wrong (overlap not pruned): {b_lines}"
 
     master = _lines(deployed_vm, MASTERFILE)
     assert "r1a_v4 203.0.113.0/24" in master, f"masterfile missing A's /24 row: {master}"
@@ -222,9 +227,10 @@ def test_recompute_v6_snapshot_round_trips_across_static_pass(deployed_vm: Smoke
     h.reload(deployed_vm, "updateip", wait_unbound=False)
     snap_lines = _lines(deployed_vm, f"{SNAPDIR}/r2v6_v6.snap")
     deny_lines_pass1 = _lines(deployed_vm, f"{DENYDIR}/r2v6_v6.txt")
-    expected = {"2001:db8:5678::/64", "2001:db8:5678:1::42"}
-    assert set(snap_lines) == expected, f"snapshot content wrong after first ingest: {snap_lines}"
-    assert set(deny_lines_pass1) == expected, f"deny file content wrong after first ingest: {deny_lines_pass1}"
+    deny_raw_pass1 = _raw(deployed_vm, f"{DENYDIR}/r2v6_v6.txt")
+    expected = sorted(["2001:db8:5678::/64", "2001:db8:5678:1::42"])
+    assert sorted(snap_lines) == expected, f"snapshot content wrong after first ingest: {snap_lines}"
+    assert sorted(deny_lines_pass1) == expected, f"deny file content wrong after first ingest: {deny_lines_pass1}"
     members_pass1 = h.wait_pfctl_table(deployed_vm, spec.alias)
     assert h.member_present(members_pass1, "2001:db8:5678:1::42"), f"pf table missing bare host: {members_pass1}"
     assert h.member_covers(members_pass1, "2001:db8:5678::1"), f"pf table missing /64 coverage: {members_pass1}"
@@ -232,9 +238,9 @@ def test_recompute_v6_snapshot_round_trips_across_static_pass(deployed_vm: Smoke
     # Held static: no edit, no force_ip_refetch -- updateip's force=true alone
     # reprocesses this alias again from its cached raw body.
     h.reload(deployed_vm, "updateip", wait_unbound=False)
-    deny_lines_pass2 = _lines(deployed_vm, f"{DENYDIR}/r2v6_v6.txt")
-    assert set(deny_lines_pass2) == set(deny_lines_pass1), (
-        f"deny file changed across a static pass: pass1={deny_lines_pass1} pass2={deny_lines_pass2}"
+    deny_raw_pass2 = _raw(deployed_vm, f"{DENYDIR}/r2v6_v6.txt")
+    assert deny_raw_pass2 == deny_raw_pass1, (
+        f"deny file not byte-identical across a static pass: pass1={deny_raw_pass1!r} pass2={deny_raw_pass2!r}"
     )
     master = _lines(deployed_vm, MASTERFILE)
     assert "r2v6_v6 2001:db8:5678::/64" in master, f"masterfile missing v6 /64 row after round-trip: {master}"
@@ -283,8 +289,8 @@ def test_recompute_rewrites_unchanged_sibling_across_passes(deployed_vm: SmokeVM
     # BEFORE: both settle correctly.
     a_before = _lines(deployed_vm, f"{DENYDIR}/r4a_v4.txt")
     b_before = _lines(deployed_vm, f"{DENYDIR}/r4b_v4.txt")
-    assert set(a_before) == {"198.51.100.31"}, f"A did not settle before the change: {a_before}"
-    assert set(b_before) == {"198.51.100.41"}, f"B did not settle before the change: {b_before}"
+    assert a_before == ["198.51.100.31"], f"A did not settle before the change: {a_before}"
+    assert b_before == ["198.51.100.41"], f"B did not settle before the change: {b_before}"
 
     # CHANGE: A gains a row via a REAL re-download; B is left completely alone.
     h.write_local_feed(deployed_vm, "r4_feed_a.txt", "198.51.100.31\n198.51.100.32\n")
@@ -293,10 +299,8 @@ def test_recompute_rewrites_unchanged_sibling_across_passes(deployed_vm: SmokeVM
 
     a_after = _lines(deployed_vm, f"{DENYDIR}/r4a_v4.txt")
     b_after = _lines(deployed_vm, f"{DENYDIR}/r4b_v4.txt")
-    assert set(a_after) == {"198.51.100.31", "198.51.100.32"}, f"A's change was not applied: {a_after}"
-    assert set(b_after) == {"198.51.100.41"}, (
-        f"B (never touched) was dropped/perturbed by the family rewrite: {b_after}"
-    )
+    assert sorted(a_after) == sorted(["198.51.100.31", "198.51.100.32"]), f"A's change was not applied: {a_after}"
+    assert b_after == ["198.51.100.41"], f"B (never touched) was dropped/perturbed by the family rewrite: {b_after}"
 
     master = _lines(deployed_vm, MASTERFILE)
     assert "r4a_v4 198.51.100.32" in master, f"masterfile missing A's new row: {master}"

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -411,9 +411,9 @@ def test_recompute_suppression_realigns_across_sibling_change(deployed_vm: Smoke
     change drives a family-wide recompute that rewrites the suppressed alias too.
 
     Regression pin for the #1084-review resurrection bug: ``pfb_recompute()``'s
-    snapshot is a PRE-suppression capture (issue #1084 review comment,
-    pfblockerng.inc ~5065), so recompute alone would resurrect a suppressed IP on
-    ANY pass that rewrites that alias -- ``pfb_ip_suppress_body_active()``'s
+    snapshot is a PRE-suppression capture (see ``pfb_ip_suppress_body_active()``'s
+    docblock in pfblockerng.inc), so recompute alone would resurrect a suppressed IP
+    on ANY pass that rewrites that alias -- ``pfb_ip_suppress_body_active()``'s
     ``$feed_changed || $recompute_ran`` clause is what re-applies suppression even
     when the SUPPRESSED alias's OWN feed did not change.
 

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -81,10 +81,9 @@ DENYDIR = f"{h.PFB_DBDIR}/deny"
 SNAPDIR = f"{h.PFB_DBDIR}/snapshot"
 MASTERFILE = f"{h.PFB_DBDIR}/masterfile"
 
-# A fixed, known placeholder (default is PHP-side only — pfblockerng.sh reads the RAW
-# config node via read_xml_tag.sh, with no fallback — see pfb['ip_ph']'s pfb_filter
-# default vs. the shell's direct XML read) so R5/R9's collapse assertion compares
-# against an EXACT string instead of an ambiguous default.
+# Pin ip_placeholder explicitly (PHP and pfblockerng.sh both default to this value) so
+# R5/R9's collapse assertion compares against an exact string no matter what an earlier
+# module left in the shared config.
 PLACEHOLDER_IP = "127.1.7.7"
 
 
@@ -324,7 +323,12 @@ def test_recompute_closing_refills_placeholder_dup_on(deployed_vm: SmokeVM) -> N
       When dedup is ON and a single ``updateip`` reload runs,
       Then the alias's deny file equals the placeholder EXACTLY (not empty, not
         the raw IP -- a broken suppression pass would leave the raw IP; a broken
-        closing pass would leave 0 bytes) and the pf table carries the placeholder.
+        closing pass would leave 0 bytes).
+
+    No pf-table assertion: the alias loop reads the still-empty deny file and unlinks
+    the aliastables mirror for a brand-new alias (pfblockerng.inc, empty $alias_ips +
+    empty $pfctlck) BEFORE the closing pass writes the placeholder, so no table exists
+    this pass.
     """
     h.set_ip_dedup(deployed_vm, True)
     h.set_ip_reputation(deployed_vm)
@@ -339,8 +343,6 @@ def test_recompute_closing_refills_placeholder_dup_on(deployed_vm: SmokeVM) -> N
 
     deny_lines = _lines(deployed_vm, f"{DENYDIR}/r5_v4.txt")
     assert deny_lines == [PLACEHOLDER_IP], f"suppression-collapsed alias not placeholder-refilled: {deny_lines}"
-    members = h.wait_pfctl_table(deployed_vm, spec.alias)
-    assert h.member_present(members, PLACEHOLDER_IP), f"pf table missing the placeholder: {members}"
 
 
 # --------------------------------------------------------------------------- #
@@ -387,8 +389,9 @@ def test_recompute_closing_refills_placeholder_dup_off_pmax(deployed_vm: SmokeVM
     assert anchor_lines == ["192.0.2.0/24"], f"pMax offender did not collapse to the anchor's /24: {anchor_lines}"
     assert collapse_lines == [PLACEHOLDER_IP], f"pMax-collapsed alias not placeholder-refilled: {collapse_lines}"
 
-    collapse_members = h.wait_pfctl_table(deployed_vm, spec_collapse.alias)
-    assert h.member_present(collapse_members, PLACEHOLDER_IP), f"pf table missing the placeholder: {collapse_members}"
+    # No pf-table assertion for the collapsed alias: its mirror is unlinked while the
+    # deny file is still empty, before the closing pass refills the placeholder (see
+    # test_recompute_closing_refills_placeholder_dup_on).
     anchor_members = h.wait_pfctl_table(deployed_vm, spec_anchor.alias)
     assert h.member_covers(anchor_members, "192.0.2.21"), (
         f"pf table lost the anchor's own offending host: {anchor_members}"


### PR DESCRIPTION
Part 1 of #1170: the CI-runnable, credential-free rows of the batch `recompute` flow, end to
end on a real pfSense VM — real feeds through the parse loop → snapshot store → memberlist →
`pfblockerng.sh recompute` → pf table load.

## What lands

New `tests/smoke/test_smoke_ip_recompute.py` (6 tests) plus the config setters it needs in
`tests/smoke/helpers.py` (`CFG_IP_REPUTATION`, `set_ip_dedup`, `set_ip_reputation`,
`set_ip_suppression` — none existed).

| Row | Test |
| --- | ---- |
| Dedup ownership across overlapping feeds (CIDR containment + exact repeat) | `test_recompute_dedup_ownership_across_overlapping_feeds` |
| v6-Deny snapshot write + round-trip across a static pass | `test_recompute_v6_snapshot_round_trips_across_static_pass` |
| Memberlist completeness: an unchanged sibling survives the family-wide rewrite | `test_recompute_rewrites_unchanged_sibling_across_passes` |
| Closing-pass placeholder refill, dup=ON branch (suppression collapse) | `test_recompute_closing_refills_placeholder_dup_on` |
| Closing-pass placeholder refill, dup=OFF + pRep=ON branch (pMax collapse) | `test_recompute_closing_refills_placeholder_dup_off_pmax` |
| Suppression realigns across an unrelated sibling's recompute pass | `test_recompute_suppression_realigns_across_sibling_change` |

The last row pins the resurrection regression fixed in `c3fc39d3` (a suppressed IP resurrected
by a sibling feed's recompute pass). It deliberately uses `reload(scope='update')` +
`force_ip_refetch()` on the sibling only, not `updateip`: `scope='ip' && force=true` sets
`$pfb['reuse']='on'` for the whole pass, which makes every alias look feed-changed — under
`updateip` the `($feed_changed || $recompute_ran)` clause's right side would never be
load-bearing and the test would pass against the reverted, buggy code.

The two `pfb_ip_closing_pass_active()` branches both get a row: dup=ON is unconditional,
dup=OFF fires only when `recompute_ran_v4` is TRUE.

## Verification

Off-appliance gates: `python3 -m pytest` (2672 passed, 4 skipped) · `ruff check .` ·
`ruff format --check .` · `mypy tests/` — all green; the new module collects cleanly under
`-m smoke`.

The regression pin's teeth were demonstrated against a throwaway copy of `pfblockerng.inc`
with the `|| $recompute_ran` clause reverted: `IpSuppressBodyActiveTest::testDefectRowFeedUnchangedButRecomputeRanIsActive`
goes red there and green against the committed code.

**Live-VM validation is a smoke dispatch on this branch** (`smoke.yml` is dispatch-only, not a
PR trigger) — results will be posted here before merge.

## Not in this PR

The continent/GeoIP-dependent rows of #1170 (continent snapshot write, v6 continent snapshot
tracking across two regens, the dMax GeoIP-outage window) are Part 2: they need a real MaxMind
account and follow the credential-gated, dispatch-only pattern of `test_smoke_714_asn_geoip.py`
c8 (ADR-04 §7). #1170 stays open until they land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved IP feed recomputation for overlapping feeds, suppression changes, and family-wide updates.
  - Preserved IPv6 snapshots and unchanged sibling feeds during successive recomputations.
  - Ensured placeholder entries are restored when recomputation produces no results.
  - Maintained accurate deny files and firewall table contents after updates.

- **Tests**
  - Added credential-free end-to-end smoke coverage for IP deduplication, reputation settings, suppression, snapshots, and recomputation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->