### PR TITLE
www: point the GeoIP2 doc link at MaxMind's current path

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1929,7 +1929,7 @@ $section->addInput(new Form_StaticText(
 	'NOTES:',
 	'GeoIP data by MaxMind Inc. - GeoLite2<br />'
 	. 'Click here for IMPORTANT info&emsp;-->&emsp;'
-	. '<a target="_blank" href="https://dev.maxmind.com/geoip/geoip2/whats-new-in-geoip2/">'
+	. '<a target="_blank" href="https://dev.maxmind.com/geoip/whats-new-in-geoip2/">'
 	. '<span class="text-danger"><strong>What\'s new in GeoIP2</strong></span></a>'
 
 	. '<hr style="height: 1px; border: none; background-color: #d6d6d6;"/>'

--- a/tests/php/GeoipDocLinkTest.php
+++ b/tests/php/GeoipDocLinkTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1215 — the GeoIP continent page's NOTES section links out to MaxMind's
+ * "What's new in GeoIP2" document. MaxMind retired the `/geoip/geoip2/...` path
+ * in a site restructure, so the shipped link 404'd. This is a source tripwire:
+ * the page must carry the live document path and must not reintroduce the
+ * retired one (external liveness itself cannot be asserted in CI — the check is
+ * that the retired path stays gone).
+ */
+final class GeoipDocLinkTest extends TestCase
+{
+	private const PFBLOCKERNG_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng.php';
+
+	private const LIVE_DOC_URL    = 'https://dev.maxmind.com/geoip/whats-new-in-geoip2/';
+	private const RETIRED_DOC_URL = 'https://dev.maxmind.com/geoip/geoip2/whats-new-in-geoip2/';
+
+	private function pageSource(): string
+	{
+		$source = file_get_contents(self::PFBLOCKERNG_PHP);
+		$this->assertNotFalse($source, 'failed to read pfblockerng.php');
+		return $source;
+	}
+
+	public function testGeoipNotesLinkUsesTheLiveMaxmindDocPath(): void
+	{
+		$this->assertStringContainsString(
+			'href="' . self::LIVE_DOC_URL . '"',
+			$this->pageSource(),
+			"issue #1215: the \"What's new in GeoIP2\" link must point at MaxMind's current doc path"
+		);
+	}
+
+	public function testRetiredMaxmindDocPathIsGone(): void
+	{
+		$this->assertStringNotContainsString(
+			self::RETIRED_DOC_URL,
+			$this->pageSource(),
+			'issue #1215: the retired /geoip/geoip2/ doc path 404s and must not come back'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1215. The "What's new in GeoIP2" link in the GeoIP continent page's NOTES section (`src/usr/local/www/pfblockerng/pfblockerng.php:1932`) pointed at a MaxMind documentation path that no longer exists — MaxMind dropped the `/geoip2/` segment in a site restructure.

## Evidence (probed this session)

```text
https://dev.maxmind.com/geoip/geoip2/whats-new-in-geoip2/ -> 404
https://dev.maxmind.com/geoip/whats-new-in-geoip2/        -> 200 (no redirect)
```

## Scope

Enumerated every MaxMind URL under `src/`, `scripts/`, `docs/`, `README.md`, `.github/` — 7 total, only this one is dead. The other user-facing links (`www.maxmind.com`, `/en/contact`, `/en/geolite2/signup`, `/en/high-risk-ip-sample-list`) all return 200; the two `download.maxmind.com` entries are authenticated database-download endpoints, not doc links.

## Test

New `tests/php/GeoipDocLinkTest.php` — a source tripwire in the house pattern of `TimestampCosmeticNormalizationTest`: the page must carry the live doc path and must not reintroduce the retired one (external liveness itself is not assertable in CI). Authored and executed RED before the fix (2 tests, 2 failures: live URL absent, retired URL present), frozen byte-identical (blob `6a0561e7` at red time = committed blob), GREEN with zero edits after (2 tests, 4 assertions).

## Gates

`php -l` per touched file, `vendor/bin/phpunit`, `composer phpstan`, `composer phpcs` — all PASS.

**Tier A (`ui_render`) — documented exclusion, not coverage.** Correcting an earlier claim in this PR: the touched line is **not** Tier-A-coverable, and `geoip_continent_views` is not a covered page — it is an entry in `EXCLUDED_FROM_TIER_A` (`tests/smoke/ui/test_render_smoke.py:212-228`), asserted excluded by `test_page_table_covers_every_pfblockerng_page`. The line sits inside the `$php_data` heredoc (opens :1681, closes :2184) that `pfblockerng.php` writes out with `file_put_contents` to `pfblockerng_<Continent>.php` **only after a keyed MaxMind GeoIP download**, so those pages do not exist on a fresh box and cannot render hermetically — a pre-existing architectural exclusion this PR neither introduces nor can close.

The PHPUnit source tripwire (`GeoipDocLinkTest`) is the coverage for this change: it asserts the shipped template carries the live doc path and cannot regress to the retired one. Tier B (Phase 5, egress-allowed leg) is where these pages could render at all, and is not triggered here — the change is an `href` attribute value in existing static text, not a page, flow, or layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBkLQcR4cz5QCq6AVjdzuM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GeoIP “What’s new in GeoIP2” help link to MaxMind’s current documentation page.
  * Removed the outdated documentation URL.

* **Tests**
  * Added automated checks to verify the current link is displayed and the retired URL is no longer present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


no-test-needed: Tier-A `ui_render` coverage is architecturally impossible for this file, not merely absent. The touched line lives inside the `$php_data` heredoc (`pfblockerng.php:1681-2184`) that is `file_put_contents`-written to `pfblockerng_<Continent>.php` only after a keyed MaxMind GeoIP download, so the continent pages do not exist on a fresh box and cannot render hermetically — which is why `geoip_continent_views` is a documented entry in `EXCLUDED_FROM_TIER_A` (`tests/smoke/ui/test_render_smoke.py:212-228`), asserted excluded by `test_page_table_covers_every_pfblockerng_page`. A GET of `pfblockerng.php` itself runs the template path, not a settings page, so it is not a Tier-A target either. The change ships its coverage as a PHPUnit source tripwire instead (`tests/php/GeoipDocLinkTest.php`, red→green proven): the shipped template must carry the live doc path and cannot regress to the retired one. Escape applies to the www↔ui pairing only — the src↔tests pairing is satisfied by that test.
