### PR TITLE
pfblockerng: disallow row reorder on the GeoIP tab (issue #1201)

### DIFF
--- a/.ADRs/ADR_63_Category_Reorder_UX/ADR.md
+++ b/.ADRs/ADR_63_Category_Reorder_UX/ADR.md
@@ -156,6 +156,14 @@ row ids needed. The server diff on this page is **pure deletion** of the old mec
   `geoip` case** (`ipv4`/`ipv6`/`dnsbl`-default; `category.php` renders no edit link for
   geoip rows), so the §2 gtype axis is `{ipv4, ipv6, dnsbl}` wherever it crosses
   `category_edit.php`.
+- **Amendment (issue #1201, 2026-07-12):** the GeoIP order-persist no-op above was resolved
+  by *disallowing* reorder on the GeoIP tab rather than persisting it — the maintainer's call
+  ("disallow ordering in the GeoIP tab at all"). `category.php` now drops the row-level
+  `class="sortable"` drag marker for `gtype == 'geoip'` (the reorder `<th>` and the
+  drag/anchor-click wiring were already GeoIP-gated), so GeoIP rows **are** now
+  `gtype`-excluded from the reorder DOM path. This supersedes the "not `gtype`-excluded" claim
+  here, the §2 matrix "no exclusions" note, and Semantics #7 "behave identically" — for
+  `category.php` only. GeoIP entries added on the IPv4/IPv6 tabs remain orderable there.
 
 ### 1.5 Existing test coverage this ADR must reconcile
 
@@ -297,13 +305,16 @@ design driven by core's own repeatable-row machinery (`renumber()` on every stag
    qualification:* identical at the UI/code-path level; on `category.php` the GeoIP
    order-persist sink is a pre-existing silent no-op (pinned, issue #1201 — §1.4) and stays
    byte-unchanged, and `category_edit.php` has no `geoip` gtype at all (§1.4).
+   *Superseded for `category.php` by issue #1201 (2026-07-12, §1.4 amendment):* GeoIP rows are
+   now `gtype`-excluded from the reorder path (no row `class="sortable"`), so "no carve-out /
+   behave identically" no longer holds there.
 
 ### Coverage matrix (Phase-1 re-derives from source; every row maps to a phase/test)
 
 | Axis | Values | Notes |
 | --- | --- | --- |
 | Page | `pfblockerng_category.php`, `pfblockerng_category_edit.php` | different persistence shapes (§1.3) |
-| `gtype` | `ipv4`, `ipv6`, `geoip`, `dnsbl` | §1.4 — no exclusions |
+| `gtype` | `ipv4`, `ipv6`, `geoip`, `dnsbl` | §1.4 — GeoIP later `gtype`-excluded from `category.php` reorder (issue #1201 amendment) |
 | `sort` (category_edit only) | `sort` (unchanged, Semantics #2), `no-sort` (new UI) | category.php has no such field |
 | Reorder input | drag, anchor-click (single row), anchor-click (multiple rows straddling the anchor), mixed drag+anchor in one session | all must persist the visual order |
 | `roworderdragging` | unset (both offered), set (anchor-click only) | the SET case includes a full reorder + **Save** on both pages (§1.8 serialize trap), not a render check alone |

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -652,7 +652,9 @@ issue #1149), the `$disable_move` flag, and the `move_anchor` checkbox + `type="
 anchor UI — is **deleted**, not re-fixed. Retiring its array-reject-loop exemption
 restored the full #1106 array-field guard. `pfblockerng_category.php`'s `ids[]`
 hostile-order validation gap is **deliberately out of ADR-63 scope** (issue #1152); its
-GeoIP order-persist is a pre-existing silent no-op (issue #1201).
+GeoIP order-persist was a silent no-op, resolved by issue #1201 (2026-07-12) by disallowing
+reorder on the GeoIP tab — `category.php` drops the row `class="sortable"` marker for
+`gtype == 'geoip'`.
 
 ---
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -426,7 +426,7 @@ if (isset($savemsg)) {
 				<?php if (!empty($rowdata) && !empty($rowdata[0])):
 					foreach ($rowdata as $r_id => $row): ?>
 
-				<tr style="vertical-align: top" class="sortable" id="pfb_r<?=$r_id;?>">
+				<tr style="vertical-align: top"<?php if ($gtype != 'geoip'): ?> class="sortable"<?php endif; ?> id="pfb_r<?=$r_id;?>">
 					<td>
 					<?php
 						$row['aliasname'] = htmlspecialchars($row['aliasname']);

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1395,10 +1395,11 @@ def test_category_page_renders_reorder_wiring(
     Hermetic. GET the page and assert: (1) ``pfb_reorder_init(`` (the component
     call, ADR-63) is present; (2) the ``pfb_drag_enabled`` boolean var (mirrors
     ``system/webgui/roworderdragging``) is emitted -- both unconditional, so
-    they render on every gtype including GeoIP; (3) the new reorder ``<th>``
-    column is gated ``$gtype != 'geoip'`` (branch coverage: present on
-    ipv4/dnsbl, ABSENT on GeoIP, whose container never receives the injected
-    controls -- issue #1201).
+    they render on every gtype including GeoIP; (3) the reorder ``<th>`` column
+    is gated ``$gtype != 'geoip'`` (branch coverage: present on ipv4/dnsbl,
+    ABSENT on GeoIP); (4) the row ``class="sortable"`` drag marker is gated the
+    same way -- GeoIP rows must NOT carry it, so the GeoIP tab offers no reorder
+    (issue #1201: reorder disallowed on GeoIP, whose order never persisted).
     """
     resp = webui.get(path)
     assert resp.status_code == 200, f"GET {path} -> HTTP {resp.status_code} (expected 200)"
@@ -1406,10 +1407,18 @@ def test_category_page_renders_reorder_wiring(
     assert "pfb_reorder_init(" in body, f"pfb_reorder_init( wiring call missing on {path}"
     assert "pfb_drag_enabled" in body, f"pfb_drag_enabled boolean var missing on {path}"
     has_reorder_th = "<!----- Reorder -----></th>" in body
+    # The <tr> drag marker rendered as ``class="sortable" id="pfb_rN"`` for a
+    # reorderable row (anchored to the id so the table's own
+    # ``sortable-theme-bootstrap`` class can't false-match).
+    sortable_row = 'class="sortable" id="pfb_r' in body
     if expect_reorder_th:
         assert has_reorder_th, f"reorder <th> column missing on {path}"
     else:
         assert not has_reorder_th, f"GeoIP page must NOT render the reorder <th> column, found on {path}"
+        # Non-vacuous: GeoIP always renders built-in continent rows -- assert they
+        # exist, then that NONE is a sortable (drag-reorderable) row (issue #1201).
+        assert 'id="pfb_r' in body, f"GeoIP page rendered no continent rows on {path}"
+        assert not sortable_row, f'GeoIP rows must NOT carry class="sortable" (reorder disallowed, issue #1201): {path}'
 
 
 # ADR-63 Phase 4 (issue #1147): pfblockerng_category_edit.php's staged reorder


### PR DESCRIPTION
## Summary

Fixes #1201 — on `pfblockerng_category.php`, a GeoIP row drag-reorder Save was a
silent no-op: GeoIP rows are rebuilt from `$pfb['continents']` on every request
and never read a persist sink, so the order POST fired `write_config()` and
re-rendered the built-in continent order unchanged.

Per the maintainer decision on the issue ("disallow ordering in the GeoIP tab at
all"), this removes the reorder affordance rather than trying to persist it.

## Change

The reorder column header and the drag/anchor-click wiring were **already** gated
off for GeoIP (the container `id` never matches the reorder init selector). The
only leftover reorder marker was the row-level `class="sortable"`, which rendered
unconditionally for every gtype. Gate it on `$gtype != 'geoip'`, so GeoIP
continent rows are no longer drag-reorderable and the tab offers no reorder it
cannot persist.

GeoIP entries added on the IPv4/IPv6 tabs remain orderable there — unchanged.

```diff
-<tr style="vertical-align: top" class="sortable" id="pfb_r<?=$r_id;?>">
+<tr style="vertical-align: top"<?php if ($gtype != 'geoip'): ?> class="sortable"<?php endif; ?> id="pfb_r<?=$r_id;?>">
```

## Tests (Tier-A `ui_render`)

`test_category_page_renders_reorder_wiring` now asserts the row `class="sortable"`
drag marker follows the same `$gtype != 'geoip'` gate: GeoIP continent rows render
(non-vacuous) but carry no `class="sortable"`, while ipv4/dnsbl keep it.

Live-VM red→green (local-smoke, `--marker ui_render`, CE 2.8 guest):

- **RED** (test only, src unpatched): `1 failed, 2 passed` — `geoip` param fails
  (`assert not True`), `ipv4`/`dnsbl` pass.
- **GREEN** (test + fix): `3 passed`.

Static gates green: `php -l`, PHPCS, PHPStan, PHPUnit (3058), `ruff check`,
`ruff format --check`, `mypy tests/`.
