### PR TITLE
tests/php: widen LogArrayRequestGuardTest Region 5 through the downstream consumers (#1207)

### DIFF
--- a/tests/php/LogArrayRequestGuardTest.php
+++ b/tests/php/LogArrayRequestGuardTest.php
@@ -85,15 +85,27 @@ final class LogArrayRequestGuardTest extends TestCase
 			);
 		}
 
-		// Region 5: 'logtype' -> $selected -> $pfb_logtypes[$selected] offset.
+		// Region 5: 'logtype' -> $selected -> $pfb_logtypes[$selected] offset,
+		// through $logs/getlogs()/$clearable/$downloadable (issue #1207).
 		if (!function_exists('pfb_log_oracle_selected_logtype')) {
 			// issue #1198: non-greedy $selected assignment (+ optional leading
 			// comment) matches both the pre-fix !empty() and post-fix
-			// array_key_exists() source, so the region survives the fix.
+			// array_key_exists() source. The downstream text is byte-identical
+			// pre/post-fix, so it is matched literally (no wildcard needed).
 			if (!preg_match(
 				'/\/\/ Collect selected logs\n\$logs = array\(\);\n\$clearable = \$downloadable = FALSE;\n'
 				. '((?:\/\/[^\n]*\n)*\$selected = .*?;\n'
-				. '\$pfb_sel = \$pfb_logtypes\[\$selected\];)/',
+				. '\$pfb_sel = \$pfb_logtypes\[\$selected\];\n'
+				. '\n'
+				. 'if \(isset\(\$pfb_sel\[\'logs\'\]\)\) \{\n'
+				. '\t\$logs = \$pfb_sel\[\'logs\'\];\n'
+				. '\} else \{\n'
+				. '\t\$logs = getlogs\(\$pfb_sel\[\'logdir\'\], \$pfb_sel\[\'ext\'\]\);\n'
+				. '\}\n'
+				. '\n'
+				. '\$logdir\t\t= \$pfb_sel\[\'logdir\'\] \?: \'\/var\/db\/pfblockerng\';\n'
+				. '\$clearable\t= \$pfb_sel\[\'clear\'\] \?: FALSE;\n'
+				. '\$downloadable\t= \$pfb_sel\[\'download\'\] \?: FALSE;)/',
 				$src,
 				$m
 			)) {
@@ -102,7 +114,7 @@ final class LogArrayRequestGuardTest extends TestCase
 			eval(
 				'function pfb_log_oracle_selected_logtype(array $pconfig, array $pfb_logtypes): array { '
 				. $m[1]
-				. ' return $pfb_sel; }'
+				. ' return compact(\'pfb_sel\', \'logs\', \'clearable\', \'downloadable\'); }'
 			);
 		}
 	}
@@ -122,16 +134,20 @@ final class LogArrayRequestGuardTest extends TestCase
 		$_REQUEST = $this->savedRequest;
 	}
 
-	/** A $pfb_logtypes fixture shaped like the real page's (LogValidateFilepathNulByteTest sibling shape). */
+	/**
+	 * A $pfb_logtypes fixture shaped like the real page's (LogValidateFilepathNulByteTest
+	 * sibling shape). issue #1207: every entry carries 'logs'/'clear'/'download', like the
+	 * real page's defaultlogs/masterfiles -- keeps the getlogs() double unreachable on green.
+	 */
 	private function logtypes(): array
 	{
 		return [
-			'defaultlogs' => ['logdir' => '/var/log/pfblockerng/'],
-			'python'      => ['logdir' => '/var/unbound/'],
+			'defaultlogs' => ['logdir' => '/var/log/pfblockerng/', 'logs' => ['pfblockerng.log', 'error.log'], 'clear' => TRUE, 'download' => TRUE],
+			'python'      => ['logdir' => '/var/unbound/', 'logs' => ['py_error.log'], 'clear' => TRUE, 'download' => TRUE],
 			// mixed-case static key (real page has 'GeoIP') -- pins case-sensitivity.
-			'GeoIP'       => ['logdir' => '/var/db/pfblockerng/GeoIP/'],
+			'GeoIP'       => ['logdir' => '/var/db/pfblockerng/GeoIP/', 'logs' => ['GeoLite2-Country.mmdb'], 'clear' => FALSE, 'download' => TRUE],
 			// dynamic blacklist-title key shape (`<Title>logs`, merged in at :189).
-			'MyFeedlogs'  => ['logdir' => '/var/db/pfblockerng/myfeed/'],
+			'MyFeedlogs'  => ['logdir' => '/var/db/pfblockerng/myfeed/', 'logs' => ['myfeed.log'], 'clear' => TRUE, 'download' => FALSE],
 		];
 	}
 
@@ -148,7 +164,7 @@ final class LogArrayRequestGuardTest extends TestCase
 			return TRUE;
 		}, E_WARNING | E_DEPRECATED);
 		try {
-			$pfb_sel = pfb_log_oracle_selected_logtype($pconfig, $pfb_logtypes);
+			$result = pfb_log_oracle_selected_logtype($pconfig, $pfb_logtypes);
 		} catch (\TypeError $e) {
 			$this->fail('an unknown/hostile logtype must not TypeError the $pfb_logtypes[] offset: ' . $e->getMessage());
 		} finally {
@@ -157,7 +173,7 @@ final class LogArrayRequestGuardTest extends TestCase
 			restore_error_handler();
 		}
 		$this->assertSame([], $warnings, 'an unknown/hostile logtype must emit zero warnings, got: ' . implode('; ', $warnings));
-		return $pfb_sel;
+		return $result;
 	}
 
 	// --- ajax 'file' -> htmlspecialchars() ----------------------------------
@@ -350,13 +366,13 @@ final class LogArrayRequestGuardTest extends TestCase
 		$_POST['logtype'] = ['y'];
 		$pconfig = pfb_log_oracle_pconfig();
 		try {
-			$pfb_sel = pfb_log_oracle_selected_logtype($pconfig, $this->logtypes());
+			$result = pfb_log_oracle_selected_logtype($pconfig, $this->logtypes());
 		} catch (\TypeError $e) {
 			$this->fail('an array logtype value must not TypeError the $pfb_logtypes[] offset: ' . $e->getMessage());
 		}
 		$this->assertSame(
 			$this->logtypes()['defaultlogs'],
-			$pfb_sel,
+			$result['pfb_sel'],
 			'an array logtype value must fall back to defaultlogs'
 		);
 	}
@@ -365,8 +381,8 @@ final class LogArrayRequestGuardTest extends TestCase
 	{
 		$_POST['logtype'] = 'python';
 		$pconfig = pfb_log_oracle_pconfig();
-		$pfb_sel = pfb_log_oracle_selected_logtype($pconfig, $this->logtypes());
-		$this->assertSame($this->logtypes()['python'], $pfb_sel, 'a scalar logtype value must still resolve its own entry');
+		$result = pfb_log_oracle_selected_logtype($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['python'], $result['pfb_sel'], 'a scalar logtype value must still resolve its own entry');
 	}
 
 	// --- issue #1198: unknown-scalar coverage matrix + hostile inputs -------
@@ -375,36 +391,41 @@ final class LogArrayRequestGuardTest extends TestCase
 	{
 		// No $_POST at all -- ingress leaves $pconfig['logtype'] === ''.
 		$pconfig = pfb_log_oracle_pconfig();
-		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
-		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+		$result = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $result['pfb_sel']);
 	}
 
 	public function testSelectedLogtypeEmptyStringFallsBackToDefaultNoWarnings(): void
 	{
 		$_POST['logtype'] = '';
 		$pconfig = pfb_log_oracle_pconfig();
-		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
-		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+		$result = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $result['pfb_sel']);
 	}
 
 	public function testSelectedLogtypeDefaultLogsKeyResolvesItsOwnEntryNoWarnings(): void
 	{
 		$_POST['logtype'] = 'defaultlogs';
 		$pconfig = pfb_log_oracle_pconfig();
-		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
-		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+		$result = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $result['pfb_sel']);
 	}
 
 	public function testSelectedLogtypeDynamicKeyResolvesItsOwnEntryNoWarnings(): void
 	{
 		$_POST['logtype'] = 'MyFeedlogs';
 		$pconfig = pfb_log_oracle_pconfig();
-		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$result = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
 		$this->assertSame(
 			$this->logtypes()['MyFeedlogs'],
-			$pfb_sel,
+			$result['pfb_sel'],
 			'a valid dynamic-title logtype key must resolve its own entry, not be clobbered to defaultlogs'
 		);
+		// issue #1207: own-entry resolution -- $logs/$clearable/$downloadable must come
+		// from MyFeedlogs, not leak a defaultlogs fallback.
+		$this->assertSame($this->logtypes()['MyFeedlogs']['logs'], $result['logs']);
+		$this->assertSame($this->logtypes()['MyFeedlogs']['clear'], $result['clearable']);
+		$this->assertSame($this->logtypes()['MyFeedlogs']['download'], $result['downloadable']);
 	}
 
 	public function testSelectedLogtypeUnknownScalarFallsBackToDefaultNoWarnings(): void
@@ -412,8 +433,12 @@ final class LogArrayRequestGuardTest extends TestCase
 		// issue #1198: the reported defect -- a scalar but unknown logtype.
 		$_POST['logtype'] = 'zzz';
 		$pconfig = pfb_log_oracle_pconfig();
-		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
-		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+		$result = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $result['pfb_sel']);
+		// issue #1207: the fallback must carry defaultlogs' own $logs/$clearable/$downloadable.
+		$this->assertSame($this->logtypes()['defaultlogs']['logs'], $result['logs']);
+		$this->assertSame($this->logtypes()['defaultlogs']['clear'], $result['clearable']);
+		$this->assertSame($this->logtypes()['defaultlogs']['download'], $result['downloadable']);
 	}
 
 	public function testSelectedLogtypeNumericZeroStringDoesNotDivergeFromOldGuard(): void
@@ -422,8 +447,8 @@ final class LogArrayRequestGuardTest extends TestCase
 		// have disagreed (empty('0') === TRUE); pins that neither matches.
 		$_POST['logtype'] = '0';
 		$pconfig = pfb_log_oracle_pconfig();
-		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
-		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+		$result = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $result['pfb_sel']);
 	}
 
 	public function testSelectedLogtypeLowercaseCaseVariantFallsBackToDefaultNoWarnings(): void
@@ -431,39 +456,39 @@ final class LogArrayRequestGuardTest extends TestCase
 		// keys are case-sensitive; a real key is mixed-case ('GeoIP').
 		$_POST['logtype'] = 'geoip';
 		$pconfig = pfb_log_oracle_pconfig();
-		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
-		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+		$result = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $result['pfb_sel']);
 	}
 
 	public function testSelectedLogtypeTrailingSpaceNearMissFallsBackToDefaultNoWarnings(): void
 	{
 		$_POST['logtype'] = 'defaultlogs ';
 		$pconfig = pfb_log_oracle_pconfig();
-		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
-		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+		$result = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $result['pfb_sel']);
 	}
 
 	public function testSelectedLogtypeEmbeddedNulFallsBackToDefaultNoWarnings(): void
 	{
 		$_POST['logtype'] = "zz\0z";
 		$pconfig = pfb_log_oracle_pconfig();
-		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
-		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+		$result = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $result['pfb_sel']);
 	}
 
 	public function testSelectedLogtypeOversizedValueFallsBackToDefaultNoWarnings(): void
 	{
 		$_POST['logtype'] = str_repeat('a', 8192);
 		$pconfig = pfb_log_oracle_pconfig();
-		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
-		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+		$result = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $result['pfb_sel']);
 	}
 
 	public function testSelectedLogtypePathTraversalMetacharsFallsBackToDefaultNoWarnings(): void
 	{
 		$_POST['logtype'] = '../../etc/passwd';
 		$pconfig = pfb_log_oracle_pconfig();
-		$pfb_sel = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
-		$this->assertSame($this->logtypes()['defaultlogs'], $pfb_sel);
+		$result = $this->runSelectedLogtypeExpectingNoWarnings($pconfig, $this->logtypes());
+		$this->assertSame($this->logtypes()['defaultlogs'], $result['pfb_sel']);
 	}
 }

--- a/tests/php/LogArrayRequestGuardTest.php
+++ b/tests/php/LogArrayRequestGuardTest.php
@@ -152,9 +152,9 @@ final class LogArrayRequestGuardTest extends TestCase
 	}
 
 	/**
-	 * Runs Region 5 capturing E_WARNING/E_DEPRECATED; fails loudly on a
-	 * TypeError (the pre-#1198 undefined-array-key -> non-nullable return-type
-	 * mismatch an unknown/hostile logtype throws).
+	 * Runs Region 5 capturing E_WARNING/E_DEPRECATED; fails loudly on a TypeError,
+	 * which now only a non-string $selected reaching the $pfb_logtypes[] offset can
+	 * throw -- issue #1183's ingress guard is what keeps that unreachable.
 	 */
 	private function runSelectedLogtypeExpectingNoWarnings(array $pconfig, array $pfb_logtypes): array
 	{

--- a/tests/php/LogPageLoader.php
+++ b/tests/php/LogPageLoader.php
@@ -15,6 +15,14 @@ declare(strict_types=1);
  */
 function pfb_test_load_log_page_functions(): void
 {
+	// issue #1207: getlogs() (pfblockerng_log.php:45) is defined ABOVE pfb_validate_filepath
+	// and never loaded below -- a minimal double lets Region 5's oracle observe the downstream
+	// warnings on a hostile logtype instead of fataling on an undefined function.
+	if (!function_exists('getlogs')) {
+		function getlogs($logdir, $log_extentions = array('log')) {
+			return array('a.log');
+		}
+	}
 	if (function_exists('pfb_validate_filepath')) {
 		return;
 	}

--- a/tests/php/LogPageLoader.php
+++ b/tests/php/LogPageLoader.php
@@ -17,7 +17,7 @@ function pfb_test_load_log_page_functions(): void
 {
 	// issue #1207: getlogs() (pfblockerng_log.php:45) is defined ABOVE pfb_validate_filepath
 	// and never loaded below -- a minimal double lets Region 5's oracle observe the downstream
-	// warnings on a hostile logtype instead of fataling on an undefined function.
+	// warnings on a hostile logtype instead of dying on a call to an undefined function.
 	if (!function_exists('getlogs')) {
 		function getlogs($logdir, $log_extentions = array('log')) {
 			return array('a.log');


### PR DESCRIPTION
Fixes #1207.

## What

`LogArrayRequestGuardTest`'s Region 5 eval-extraction stopped at `$pfb_sel = $pfb_logtypes[$selected];` (`pfblockerng_log.php:411`), so its zero-warning assertion could only ever observe the **first** of the 6 `E_WARNING`s the pre-fix unknown-scalar-`logtype` bug (#1198) emits. The remaining 5 (`Trying to access array offset on null`, from the `getlogs()` call and the `clear`/`download` ternaries at `:413-421`) were argued away indirectly.

The region now extends through the `$downloadable = …` line, so all 6 warning sites execute inside the oracle and the 11 hostile-input rows prove the #1198 fix **directly**.

## How

- **Region 5 regex** widened through `:421`. The downstream text is byte-identical pre/post-#1198-fix, so it is matched literally; the `$selected` assignment stays non-greedy so the region still matches both the pre-fix `!empty()` and post-fix `array_key_exists()` shapes.
- **Oracle return** changed from bare `$pfb_sel` to `compact('pfb_sel', 'logs', 'clearable', 'downloadable')` — widening the observed scope without widening the assertions would have been coverage theater, so the fallback row and the own-entry-resolution row now assert the downstream values too.
- **Fixture** (`logtypes()`) gains `logs`/`clear`/`download` on every entry, mirroring the real page's `defaultlogs`/`masterfiles` shape. This keeps the green run off the `getlogs()` branch entirely.
- **`getlogs()` double** (`LogPageLoader.php`, `function_exists`-guarded). Required: pre-fix, an unknown key makes `$pfb_sel` **null**, so `isset(null['logs'])` is false regardless of fixture shape and the `else` branch always fires — and `getlogs()` is defined only inside `pfblockerng_log.php`, so the red run would otherwise die on `Call to undefined function` after one warning instead of accumulating six. The 6 warnings still originate in the eval'd **production** lines (argument evaluation at `:416`, the reads at `:418-420`); the double is never reached on green (verified by making it throw — the suite stays green).

## Evidence

RED — committed tests against the pre-#1198 page (`b2cf8600^`):

```text
Tests: 28, Assertions: 44, Failures: 6.
+    0 => 'Undefined array key "../../etc/passwd"',
+    1 => 'Trying to access array offset on null',   (x5)
```

The 6 failures are exactly the genuinely-unknown-key rows (unknown-scalar, lowercase variant, trailing space, embedded NUL, oversized, path-traversal). The other rows resolve a real fixture key pre-fix and correctly stay green.

GREEN — same test files, zero edits, current `devel` page:

```text
OK (28 tests, 53 assertions)
```

Full suite `OK` (3060 tests); phpstan, phpcs, `php -l` clean.

## Note on the issue's premise

#1207's text says elimination of the 5 downstream warnings is proven "end-to-end by the Tier-B smoke test `test_unknown_scalar_logtype_rejected_gracefully`". That is **not** true: the smoke guest runs at `E_ALL ^ (E_WARNING | E_NOTICE | E_DEPRECATED)`, so a `php_error.log`-growth assertion cannot observe this warning class at all. Filed as #1218. It makes this PHPUnit widening the *only* real oracle for the class, rather than a redundancy.
