### PR TITLE
local-smoke: fetch a bare commit SHA via a full-fetch fallback

### DIFF
--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -163,13 +163,17 @@ fi
 #      bare `git checkout <ref>`, which lands the box's possibly-stale LOCAL branch
 #      (a clone whose local devel predates an upstream commit would miss files added
 #      since, e.g. scripts/smoke-on-box.sh itself → "cannot open" + no run).
+#      A branch/tag name fetches directly; a bare commit SHA is refused by
+#      `git fetch origin <sha>` (the server won't advertise it), so fall back to a
+#      full fetch + checkout of the (now-reachable) commit — this lets a red→green
+#      probe target HEAD~N of a pushed branch without minting a throwaway ref.
 #   3. exec smoke-on-box.sh (which re-fetches + re-execs at that ref's version)
 # Ref-stable: the one-liner is the only part that has to work across refs;
 # smoke-on-box.sh handles everything else.
 # shellcheck disable=SC2089  # quoting: _ob_flags is pre-encoded for remote sh
 _bootstrap="cd /root/pfBlockerNG \
- && git fetch --quiet origin '$_REF_Q' \
- && git checkout --quiet --force FETCH_HEAD \
+ && if git fetch --quiet origin '$_REF_Q' 2>/dev/null; then git checkout --quiet --force FETCH_HEAD; \
+ else git fetch --quiet origin && git checkout --quiet --force '$_REF_Q'; fi \
  && exec sh scripts/smoke-on-box.sh $_ob_flags"
 
 printf 'local-smoke: leasing box (REF=%s marker=%s%s)\n' \

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -98,8 +98,15 @@ if [ "${PFB_ONBOX_REEXEC:-}" != "1" ]; then
         # Check out the FETCHED TIP, not a bare `git checkout <ref>` — the latter
         # lands the box's possibly-stale LOCAL branch (git fetch only moves the
         # remote-tracking ref), which can predate files added upstream.
-        git fetch --quiet origin "$_REF"
-        git checkout --quiet --force FETCH_HEAD
+        # A branch/tag name fetches directly; a bare commit SHA is refused by
+        # `git fetch origin <sha>`, so fall back to a full fetch + checkout of the
+        # (now-reachable) commit.
+        if git fetch --quiet origin "$_REF" 2>/dev/null; then
+            git checkout --quiet --force FETCH_HEAD
+        else
+            git fetch --quiet origin
+            git checkout --quiet --force "$_REF"
+        fi
     fi
 
     # Re-exec the now-checked-out version with properly quoted args.

--- a/tests/shell/local_smoke_spec.sh
+++ b/tests/shell/local_smoke_spec.sh
@@ -182,4 +182,18 @@ FAKEEOF
     End
   End
 
+  # ── SHA ref: fetch-by-SHA falls back to a full fetch + checkout ──────────── #
+  # `git fetch origin <sha>` is refused (the server won't advertise a bare
+  # commit), so the bootstrap must fall back to a full fetch then check the
+  # reachable commit out — otherwise a red->green probe on HEAD~N of a pushed
+  # branch dies with "couldn't find remote ref <sha>".
+  Describe 'bootstrap tolerates a bare commit SHA ref'
+    It 'emits an if/else that falls back to a full fetch + checkout of the ref'
+      When call run_and_diag --ref 0123abc --shards 1
+      The line 1 of output should equal 'exit=0'
+      The output should include "if git fetch --quiet origin '0123abc'"
+      The output should include "else git fetch --quiet origin && git checkout --quiet --force '0123abc'"
+    End
+  End
+
 End


### PR DESCRIPTION
## Summary

The live-smoke box bootstrap fetched a ref with
`git fetch --quiet origin <ref> && git checkout --force FETCH_HEAD`. That works for a
branch/tag name, but a **bare commit SHA** is refused — the server won't advertise an
arbitrary commit as a fetch "want", so `git fetch origin <sha>` dies with
`couldn't find remote ref <sha>`. A red→green probe that wants to target `HEAD~N` of a
pushed branch (e.g. proving a UI test fails on the pre-fix commit) therefore had to mint a
throwaway branch just to give the commit a name.

## Change

In **both** fetch sites — the `local-smoke.sh` bootstrap string and `smoke-on-box.sh`'s
on-box re-fetch — fall back, when the direct fetch fails, to a full `git fetch origin` +
`git checkout --force <ref>`: the full fetch pulls every branch so the (reachable) commit
becomes local, then the checkout lands it detached. Branch/tag names still take the fast
direct path unchanged.

## Tests

- `tests/shell/local_smoke_spec.sh`: new case asserting the bootstrap emits the if/else
  SHA fallback (red→green under dash — fails on the pre-fix single-fetch bootstrap, passes
  after).
- **Live proof:** `local-smoke.sh --ref <bare-40-hex> --marker ui_render` on a leased CE
  2.8 box — the run fetched the SHA (zero `couldn't find remote ref`), the on-box re-fetch
  logged `fetching + checking out ref <sha>`, and pytest ran to `3 passed`.

Gates: `sh -n`, ShellCheck, shellspec (dash) — all green.
