### PR TITLE
www: add rel="noopener noreferrer" to every target="_blank" link + tripwire

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -54,6 +54,7 @@ staged_has() { printf '%s\n' "$staged" | grep -qE "$1"; }
 staged_py=0;  staged_has '\.py$'        && staged_py=1
 staged_md=0;  staged_has '\.md$'        && staged_md=1
 staged_php=0; staged_has '\.(php|inc)$' && staged_php=1
+staged_xml=0; staged_has '\.xml$'       && staged_xml=1
 staged_sh=0;  staged_has '\.sh$'        && staged_sh=1
 # Spec plumbing (helper, extensionless bin/ shims, fixtures) impacts every shellspec
 # run but need not end in .sh -- it must open the shell block on its own.
@@ -194,6 +195,18 @@ if [ "$staged_sh" = 1 ] || [ "$staged_md" = 1 ]; then
 		"$py_bin" scripts/check_url_encoding.py || failed 'url-encoding'
 	else
 		skip url-encoding
+	fi
+fi
+
+# --- Forbid a target="_blank" link with no adjacent rel="noopener noreferrer"
+#     (issue #1217, reverse-tabnabbing defence). Relevant to the Web UI surface:
+#     PHP/inc pages and the wizard XML under src/usr/local/www. ---
+if [ "$staged_php" = 1 ] || [ "$staged_xml" = 1 ]; then
+	if [ -n "$py_bin" ]; then
+		step 'noopener (target=_blank needs adjacent rel=noopener noreferrer)'
+		"$py_bin" scripts/check_noopener.py || failed 'noopener'
+	else
+		skip noopener
 	fi
 fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,6 +240,12 @@ jobs:
         # fences (the checker's defaults). ubuntu-latest ships python3.
         run: python3 scripts/check_url_encoding.py
 
+      - name: Forbid target="_blank" links with no adjacent rel="noopener noreferrer"
+        # Reverse-tabnabbing defence-in-depth (issue #1217): a new-tab link whose
+        # page can reach back via window.opener. Scans tracked src/usr/local/www
+        # .php/.inc/.xml (the checker's defaults). ubuntu-latest ships python3.
+        run: python3 scripts/check_noopener.py
+
       - name: Forbid Python on the pfSense appliance
         # The appliance ships python3.11 with no `python3` symlink, so a
         # `/usr/local/bin/python*` invocation is rc=127 (and silent under check=False

--- a/scripts/check_noopener.py
+++ b/scripts/check_noopener.py
@@ -35,7 +35,9 @@ args, resolves the file list via ``git ls-files`` — every tracked
 surface `target="_blank"` links live in; deliberately excludes ``tests/`` so
 this checker's own bad-input fixtures never trip its tree scan) — or scans
 the explicit paths passed as args. It prints ``path:line: <message>`` to
-stderr, exiting 1 if any violation is found.
+stderr, exiting 1 if any violation is found, or 2 if the default (argless)
+scan set could not be enumerated (git absent / not a checkout) — failing
+closed rather than silently passing a gate it could not run.
 
 This is dev-only tooling (release archives contain only ``src/``); it lives
 under ``scripts/`` and is wired into ``.githooks/pre-commit`` and CI.
@@ -115,7 +117,8 @@ def _scan_path(path: str) -> list[Violation]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI entry point. Returns 0 (clean) or 1 (violations found)."""
+    """CLI entry point. Returns 0 (clean), 1 (violations found), or 2 (the argless
+    default scan set could not be enumerated — fail-closed)."""
     args = list(sys.argv[1:] if argv is None else argv)
     if args:
         paths = args

--- a/scripts/check_noopener.py
+++ b/scripts/check_noopener.py
@@ -53,8 +53,11 @@ from typing import NamedTuple
 _TARGET_BLANK_RE = re.compile(r'(?<![\w-])target=(?P<q>["\']?)_blank(?P=q)')
 
 # `rel="noopener…"` (or single-quoted / unquoted), immediately after `target=…`
-# with only whitespace between -- the strict-adjacency house convention.
-_REL_NOOPENER_ADJACENT_RE = re.compile(r'\s+rel=(["\']?)noopener\b')
+# with only whitespace between -- the strict-adjacency house convention. The
+# `(?![\w-])` token-end guard (not `\b`) is required so `rel="noopener-evil"` -- a
+# DIFFERENT rel token that grants none of noopener's protection -- is NOT accepted
+# (a `\b` boundary treats the hyphen as a token end and would pass it).
+_REL_NOOPENER_ADJACENT_RE = re.compile(r'\s+rel=(["\']?)noopener(?![\w-])')
 
 # Escape hatch, mirroring check_comment_narration.py's `narration-ok`.
 _ESCAPE_MARKER = "noopener-ok"
@@ -114,7 +117,21 @@ def _scan_path(path: str) -> list[Violation]:
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point. Returns 0 (clean) or 1 (violations found)."""
     args = list(sys.argv[1:] if argv is None else argv)
-    paths = args if args else _git_tracked_www()
+    if args:
+        paths = args
+    else:
+        paths = _git_tracked_www()
+        # Fail CLOSED: an empty default scan set means `git ls-files` could not
+        # enumerate the Web UI tree (git absent / not a checkout) -- this repo always
+        # has such files -- so error rather than exit 0 and silently skip the gate.
+        if not paths:
+            print(
+                "check_noopener: `git ls-files src/usr/local/www` returned nothing "
+                "(git unavailable or not a checkout) -- failing closed rather than "
+                "skipping the gate.",
+                file=sys.stderr,
+            )
+            return 2
 
     violations: list[Violation] = []
     for path in paths:

--- a/scripts/check_noopener.py
+++ b/scripts/check_noopener.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Forbid a `target="_blank"` link with no adjacent `rel="noopener…"`.
+
+PROBLEM
+-------
+A link opened with `target="_blank"` and no `rel="noopener noreferrer"` lets
+the new tab's page run JavaScript that reaches back into `window.opener` and
+repoints the ORIGINATING tab (reverse tabnabbing) — a real risk when the href
+is attacker-influenced, and cheap defence-in-depth even when it is not
+(issue #1217). Every external/new-tab link in the Web UI must carry the
+`rel` value.
+
+HEURISTIC (deliberately strict-adjacency, not an HTML parser)
+---------------------------------------------------------------
+A `target=…_blank…` occurrence (double/single/no quotes; a `(?<![\\w-])`
+guard excludes `data-target="_blank"`) is a VIOLATION unless it is
+IMMEDIATELY followed — only whitespace between — by `rel=["']?noopener`.
+That is the house convention this codebase now follows: `rel` sits directly
+after `target`, so it survives even the multi-line PHP string-concatenation
+tag shape (`'target="_blank"' . ' rel="noopener noreferrer"'` would NOT be
+adjacent on one physical line and is intentionally out of the convention —
+every current site keeps both attributes on the same line). `rel` BEFORE
+`target`, or a `rel` with the wrong value (e.g. `rel="opener"`), still flags:
+this checker enforces the convention's exact shape, not just noopener's
+presence somewhere on the tag.
+
+Escape hatch: a line containing the substring `noopener-ok` is never
+scanned (mirrors `check_comment_narration.py`'s `narration-ok`) — for a
+tag genuinely exempt (e.g. a `target=…` inside a `<textarea>` code sample).
+
+The detection logic lives in :func:`find_violations` (pure, importable) so it
+is unit-tested directly without a subprocess. The :func:`main` CLI, with no
+args, resolves the file list via ``git ls-files`` — every tracked
+``src/usr/local/www/**`` file ending ``.php``/``.inc``/``.xml`` (the Web UI
+surface `target="_blank"` links live in; deliberately excludes ``tests/`` so
+this checker's own bad-input fixtures never trip its tree scan) — or scans
+the explicit paths passed as args. It prints ``path:line: <message>`` to
+stderr, exiting 1 if any violation is found.
+
+This is dev-only tooling (release archives contain only ``src/``); it lives
+under ``scripts/`` and is wired into ``.githooks/pre-commit`` and CI.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from typing import NamedTuple
+
+# `target=…_blank…` in any of the three HTML quote forms. `(?<![\w-])` excludes
+# a `data-target="_blank"` tail (word/hyphen boundary before `target`).
+_TARGET_BLANK_RE = re.compile(r'(?<![\w-])target=(?P<q>["\']?)_blank(?P=q)')
+
+# `rel="noopener…"` (or single-quoted / unquoted), immediately after `target=…`
+# with only whitespace between -- the strict-adjacency house convention.
+_REL_NOOPENER_ADJACENT_RE = re.compile(r'\s+rel=(["\']?)noopener\b')
+
+# Escape hatch, mirroring check_comment_narration.py's `narration-ok`.
+_ESCAPE_MARKER = "noopener-ok"
+
+
+class Violation(NamedTuple):
+    """One `target=_blank` site missing its adjacent `rel="noopener…"`."""
+
+    source: str  # file path
+    line: int  # 1-based line number
+    snippet: str  # the offending line (trimmed)
+
+
+def find_violations(text: str, source: str) -> list[Violation]:
+    """Find every `target=…_blank…` site with no adjacent `rel="noopener…"`.
+
+    Scanned per physical line — every current/expected site keeps `target`
+    and its `rel` on the same line (see module docstring). A line carrying
+    the `noopener-ok` escape marker is skipped entirely.
+    """
+    violations: list[Violation] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if _ESCAPE_MARKER in line:
+            continue
+        for m in _TARGET_BLANK_RE.finditer(line):
+            rest = line[m.end() :]
+            if _REL_NOOPENER_ADJACENT_RE.match(rest):
+                continue
+            violations.append(Violation(source=source, line=line_no, snippet=line.strip()))
+    return violations
+
+
+def _git_tracked_www() -> list[str]:
+    """Return tracked src/usr/local/www files ending .php/.inc/.xml (sorted)."""
+    try:
+        out = subprocess.run(
+            ["git", "ls-files", "-z", "src/usr/local/www"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return []
+    return sorted(p for p in out.split("\0") if p and p.endswith((".php", ".inc", ".xml")))
+
+
+def _scan_path(path: str) -> list[Violation]:
+    """Scan one file; unreadable files are skipped silently."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+    except OSError:
+        return []
+    return find_violations(text, path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns 0 (clean) or 1 (violations found)."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    paths = args if args else _git_tracked_www()
+
+    violations: list[Violation] = []
+    for path in paths:
+        violations.extend(_scan_path(path))
+
+    for v in violations:
+        print(
+            f'{v.source}:{v.line}: target=_blank with no adjacent rel="noopener noreferrer" '
+            "(reverse-tabnabbing defence; rel must sit directly after target)",
+            file=sys.stderr,
+        )
+        print(f"    {v.snippet}", file=sys.stderr)
+
+    if violations:
+        print(
+            f"\n{len(violations)} target=_blank violation(s). "
+            'Add rel="noopener noreferrer" (matching the target attribute\'s quote '
+            "style) directly after target, or mark a genuine exemption with "
+            "`noopener-ok` on the line.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1920,16 +1920,16 @@ $section = new Form_Section("Continent - {$continent_display}");
 $section->addInput(new Form_StaticText(
 	'Links',
 	'<small>'
-	. '<a href="/firewall_aliases.php" target="_blank">Firewall Alias</a>&emsp;'
-	. '<a href="/firewall_rules.php" target="_blank">Firewall Rules</a>&emsp;'
-	. '<a href="/status_logs_filter.php" target="_blank">Firewall Logs</a></small>'
+	. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Alias</a>&emsp;'
+	. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
+	. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
 ));
 
 $section->addInput(new Form_StaticText(
 	'NOTES:',
 	'GeoIP data by MaxMind Inc. - GeoLite2<br />'
 	. 'Click here for IMPORTANT info&emsp;-->&emsp;'
-	. '<a target="_blank" href="https://dev.maxmind.com/geoip/whats-new-in-geoip2/">'
+	. '<a target="_blank" rel="noopener noreferrer" href="https://dev.maxmind.com/geoip/whats-new-in-geoip2/">'
 	. '<span class="text-danger"><strong>What\'s new in GeoIP2</strong></span></a>'
 
 	. '<hr style="height: 1px; border: none; background-color: #d6d6d6;"/>'
@@ -2124,7 +2124,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 		"Custom {$custom_location}",
 		'text',
 		$pconfig['aliasaddr_' . $advmode]
-	))->sethelp('<a target="_blank" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
+	))->sethelp('<a target="_blank" rel="noopener noreferrer" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
 		. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the address-type (Host/Network/URL/URL Table) Alias name.<br />'
 		. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)"
 	)->setWidth(8);
@@ -2457,9 +2457,9 @@ $section = new Form_Section('IPv4 Reputation');
 $section->addInput(new Form_StaticText(
 	'Links',
 	'<small>'
-	. '<a href="/firewall_aliases.php" target="_blank">Firewall Alias</a>&emsp;'
-	. '<a href="/firewall_rules.php" target="_blank">Firewall Rules</a>&emsp;'
-	. '<a href="/status_logs_filter.php" target="_blank">Firewall Logs</a></small>'
+	. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Alias</a>&emsp;'
+	. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
+	. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
 ));
 
 $section->addInput(new Form_StaticText(
@@ -2608,7 +2608,7 @@ $section->addInput(new Form_StaticText(
 	. '<ul>https://rules.emergingthreatspro.com/XXXXXXXXXXXXXXXX/reputation/iprepdata.txt.gz</ul>'
 	. 'Select the <strong>Auto</strong> format. The URL should use the .gz File type.<br />'
 	. 'Enter your "ETPRO" code in URL. Further information can be found @ '
-	. '<a target="_blank" href="https://www.proofpoint.com/us/solutions/products/threat-intelligence">Proofpoint IQRisk</a><br /><br />'
+	. '<a target="_blank" rel="noopener noreferrer" href="https://www.proofpoint.com/us/solutions/products/threat-intelligence">Proofpoint IQRisk</a><br /><br />'
 	. 'To use <strong>Match</strong> Lists, Create a new Alias and select one of the <strong>'
 	. 'Action Match</strong> Formats and <br />'
 	. 'enter the <strong>Localfile</strong> as: <ul>/var/db/pfblockerng/match/ETMatch.txt</ul>'

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2614,7 +2614,7 @@ function convert_dnsbl_log($mode, $fields) {
 	// Threat Lookup Icon
 	$alert_dom = '';
 	if ($fields[6] != 'Unknown') {
-		$alert_dom = '<a class="fa-solid fa-info icon-pointer" title="Click for Threat Domain Lookup." target="_blank" ' .
+		$alert_dom = '<a class="fa-solid fa-info icon-pointer" title="Click for Threat Domain Lookup." target="_blank" rel="noopener noreferrer" ' .
 				'href="/pfblockerng/pfblockerng_threats.php?domain=' . pfb_hsc($qdomain) . '"></a>';
 	}
 
@@ -2743,7 +2743,7 @@ function convert_dns_reply_log($mode, $fields) {
 		list($supp_dom, $ex_dom, $isWhitelist_found) = dnsbl_whitelist_type($dns_fields, $clists, $isExclusion, FALSE, $fields[6]);
 
 		// Threat Lookup Icon
-		$icons = '<a class="fa-solid fa-info icon-pointer" title="Click for Threat Domain Lookup." target="_blank" ' .
+		$icons = '<a class="fa-solid fa-info icon-pointer" title="Click for Threat Domain Lookup." target="_blank" rel="noopener noreferrer" ' .
 				'href="/pfblockerng/pfblockerng_threats.php?domain=' . pfb_hsc($fields[6]) . '"></a>';
 
 		if (!empty($supp_dom)) {
@@ -3164,7 +3164,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	$h_eval_ip	= pfb_hsc($eval_ip);
 	$h_table	= pfb_hsc($table);
 
-	$alert_ip = '<a class="fa-solid fa-info icon-pointer" target="_blank" href="/pfblockerng/pfblockerng_threats.php?host=' .
+	$alert_ip = '<a class="fa-solid fa-info icon-pointer" target="_blank" rel="noopener noreferrer" href="/pfblockerng/pfblockerng_threats.php?host=' .
 			$h_host . '" title="Click for Threat source IP Lookup for [ ' . $h_host . ' ]"></a>';
 
 	// Suppression Icon -- any family, any mask (ADR-53 follow-up, issue #422).
@@ -3294,7 +3294,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	$query_port = '';
 	if ($p_query_port != $fields[10]) {
 		$h_dstport_q = pfb_hsc($fields[10]);
-		$query_port = '<a class="fa-solid fa-search icon-pointer" target="_blank" '
+		$query_port = '<a class="fa-solid fa-search icon-pointer" target="_blank" rel="noopener noreferrer" '
 				. 'href="/pfblockerng/pfblockerng_threats.php?port=' . $h_dstport_q
 				. '" title="Click for Threat Port Lookup [ ' . $h_dstport_q . ' ]"></a>';
 	}
@@ -3536,9 +3536,9 @@ if ($alert_summary && strpos($alert_view, 'ip_') !== FALSE) {
 	$section->addInput(new Form_StaticText(
 		'Links',
 		'<small>'
-		. '<a href="/firewall_aliases.php" target="_blank">Firewall Alias</a>&emsp;'
-		. '<a href="/firewall_rules.php" target="_blank">Firewall Rules</a>&emsp;'
-		. '<a href="/status_logs_filter.php" target="_blank">Firewall Logs</a></small>'
+		. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Alias</a>&emsp;'
+		. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
+		. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
 		. "{$extra_txt}"
 	));
 	$form->add($section);
@@ -4142,7 +4142,7 @@ if (!$alert_summary) {
 		'',
 		'( Save disabled during <strong>Apply Filter</strong>)'
 		. '&emsp;<div class="infoblock">'
-		. '<h6>Regex Style Matching Only! Do not prefix/suffix field with a backslash! <a href="https://regexr.com/" target="_blank">Regular Expression Help link</a>. '
+		. '<h6>Regex Style Matching Only! Do not prefix/suffix field with a backslash! <a href="https://regexr.com/" target="_blank" rel="noopener noreferrer">Regular Expression Help link</a>. '
 		. 'Precede with exclamation (!) as first character to exclude match.)</h6>'
 		. '<h6>Example: ( ^80$ - Match Port 80, ^80$|^8080$ - Match both port 80 & 8080 )</h6>'
 		. '</div>'
@@ -4203,14 +4203,14 @@ if (!$alert_summary):
 							. '" title="Re-Lock ' . htmlspecialchars($data[1]) . ': [ ' . htmlspecialchars($entry) . ' ] back into Aliastable [ '
 							. htmlspecialchars($type) . ' ]? "></i>';
 
-					$alert = '<a class="fa-solid fa-info icon-pointer" target="_blank"'
+					$alert = '<a class="fa-solid fa-info icon-pointer" target="_blank" rel="noopener noreferrer"'
 							. ' href="/pfblockerng/pfblockerng_threats.php?host='
 							. htmlspecialchars($entry) . '" title="Click for Threat source IP Lookup for [ ' . htmlspecialchars($entry) . ' ]"></a>';
 				} else {
 					$unlock = '<i class="fa-solid fa-unlock text-primary" id="DNSBL_LCK|' . htmlspecialchars($entry) . '|' . htmlspecialchars($type)
 							. '" title="Re-Lock ' . htmlspecialchars($data[1]) . ': [ ' . htmlspecialchars($entry) . ' ] back into DNSBL? "></i>';
 
-					$alert = '<a class="fa-solid fa-info icon-pointer" target="_blank"'
+					$alert = '<a class="fa-solid fa-info icon-pointer" target="_blank" rel="noopener noreferrer"'
 							. ' href="/pfblockerng/pfblockerng_threats.php?domain='
 							. htmlspecialchars($entry) . '" title="Click for Threat source Domain Lookup for [ ' . htmlspecialchars($entry) . ' ]"></a>';
 				}
@@ -5106,7 +5106,7 @@ foreach ($stats as $stat_type => $stype):
 								// issue #1069: $data rides a URL query segment -- rawurlencode,
 								// not HTML-encode.
 								$alert_event = '<a class="fa-solid fa-info icon-pointer"'
-										. ' title="Click for Threat Lookup." target="_blank"'
+										. ' title="Click for Threat Lookup." target="_blank" rel="noopener noreferrer"'
 										. ' href="/pfblockerng/pfblockerng_threats.php?' . $stype[4] . '=' . rawurlencode($data) . '"></a>';
 							}
 
@@ -5141,7 +5141,7 @@ foreach ($stats as $stat_type => $stype):
 
 							if ($stat_type == 'ipdstport') {
 								// issue #1069: href segment rawurlencode'd; title HTML-encoded.
-								$query_port = '&nbsp;<a class="fa-solid fa-search icon-pointer" target="_blank"'
+								$query_port = '&nbsp;<a class="fa-solid fa-search icon-pointer" target="_blank" rel="noopener noreferrer"'
 										. ' href="/pfblockerng/pfblockerng_threats.php?port=' . rawurlencode($data)
 										. '" title="Click for Threat Port Lookup [ ' . pfb_hsc($data) . ' ]"></a>';
 							}

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -344,9 +344,9 @@ $section = new Form_Section('Blacklist Category settings');
 $section->addInput(new Form_StaticText(
 	'Links',
 	'<small>'
-	. '<a href="/firewall_aliases.php" target="_blank">Firewall Aliases</a>&emsp;'
-	. '<a href="/firewall_rules.php" target="_blank">Firewall Rules</a>&emsp;'
-	. '<a href="/status_logs_filter.php" target="_blank">Firewall Logs</a></small>'
+	. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Aliases</a>&emsp;'
+	. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
+	. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
 ));
 
 $section->addInput(new Form_Select(

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -603,7 +603,7 @@ if (isset($savemsg)) {
 <?php
 if ($gtype == 'geoip') {
 	print_callout('GeoIP database GeoLite2 distributed under the Creative Commons Attribution-ShareAlike 4.0 International License by:
-			<a target="_blank" href="https://www.maxmind.com">MaxMind Inc.</a><br /><br />
+			<a target="_blank" rel="noopener noreferrer" href="https://www.maxmind.com">MaxMind Inc.</a><br /><br />
 			The GeoIP database is automatically updated each day at a random hour.<br /><br />
 
 			<span class="text-danger"><strong>Note:&emsp;</strong></span>

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -976,9 +976,9 @@ $section = new Form_Section('Info');
 $section->addInput(new Form_StaticText(
 	'Links',
 	'<small>'
-	. '<a href="/firewall_aliases.php" target="_blank">Firewall Aliases</a>&emsp;'
-	. '<a href="/firewall_rules.php" target="_blank">Firewall Rules</a>&emsp;'
-	. '<a href="/status_logs_filter.php" target="_blank">Firewall Logs</a></small>'
+	. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Aliases</a>&emsp;'
+	. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
+	. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
 ));
 
 $group = new Form_Group('Name / Description');
@@ -1203,9 +1203,9 @@ $infotxt .= '	</dd>
 
 if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 	$infotxt .= '			<dd>External link to source&emsp;(ie:&nbsp;
-						<a target="_blank" href="https://rules.emergingthreats.net/blockrules/compromised-ips.txt">ET Compromised</a>,
-						<a target="_blank" href="https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt">ET Blocked</a>,
-						<a target="_blank" href="https://www.spamhaus.org/drop/drop.txt">Spamhaus Drop</a>)
+						<a target="_blank" rel="noopener noreferrer" href="https://rules.emergingthreats.net/blockrules/compromised-ips.txt">ET Compromised</a>,
+						<a target="_blank" rel="noopener noreferrer" href="https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt">ET Blocked</a>,
+						<a target="_blank" rel="noopener noreferrer" href="https://www.spamhaus.org/drop/drop.txt">Spamhaus Drop</a>)
 					</dd>
 				<dt>Local file:</dt>
 					<dd>http(s)://127.0.0.1/filename
@@ -1219,15 +1219,15 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 				<dt>Whois:</dt><dd>Domain name to IP Address&emsp;(ie: facebook.com)<br />
 					Note: This will only return a partial list of resolved IPs for each Domain!</dd>
 				<dt>ASN:</dt><dd>ASN to IP Address&emsp;(ie: AS32934)
-						&emsp;(<a target="_blank" href="https://asn.cymru.com/">Click for IP<->ASN Lookup via Team Cymru.com</a>)</dd>
+						&emsp;(<a target="_blank" rel="noopener noreferrer" href="https://asn.cymru.com/">Click for IP<->ASN Lookup via Team Cymru.com</a>)</dd>
 			</dl>
 		</dd>';
 }
 else {
 	$infotxt .= '			<dd>External link to source&emsp;(ie:&nbsp;
-						<a target="_blank" href="https://pgl.yoyo.org/adservers/serverlist.php?hostformat=;showintro=0">yoyo</a>,&nbsp;
-						<a target="_blank" href="https://someonewhocares.org/hosts/hosts">SomeoneWhoCares</a>,&nbsp;
-						<a target="_blank" href="https://adaway.org/hosts.txt">Adaway</a>)
+						<a target="_blank" rel="noopener noreferrer" href="https://pgl.yoyo.org/adservers/serverlist.php?hostformat=;showintro=0">yoyo</a>,&nbsp;
+						<a target="_blank" rel="noopener noreferrer" href="https://someonewhocares.org/hosts/hosts">SomeoneWhoCares</a>,&nbsp;
+						<a target="_blank" rel="noopener noreferrer" href="https://adaway.org/hosts.txt">Adaway</a>)
 					</dd>
 				<dt>Local file:</dt>
 					<dd>http(s)://127.0.0.1/filename &emsp;<strong>or</strong>&emsp; /var/db/pfblockerng/filename
@@ -1452,7 +1452,7 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 			'Custom Port',
 			'text',
 			$pconfig["aliasports_{$advmode}"]
-		))->setHelp('<a target="_blank" href="/firewall_aliases.php?tab=port">Click Here to add/edit Aliases</a>
+		))->setHelp('<a target="_blank" rel="noopener noreferrer" href="/firewall_aliases.php?tab=port">Click Here to add/edit Aliases</a>
 				Do not manually enter port numbers.<br />Do not use \'pfB_\' in the Port Alias name.<br />Must be a Port-type alias.')
 		  ->setWidth(8);
 		$section->add($group);
@@ -1485,7 +1485,7 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 			"Custom {$custom_location}",
 			'text',
 			$pconfig['aliasaddr_' . $advmode]
-		))->sethelp('<a target="_blank" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
+		))->sethelp('<a target="_blank" rel="noopener noreferrer" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
 			. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the address-type (Host/Network/URL/URL Table) Alias name.<br />'
 			. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)<br />Must be an address-type (Host, Network, URL or URL Table) alias.")
 		  ->setWidth(8);

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -986,9 +986,9 @@ $section = new Form_Section('DNSBL');
 $section->addInput(new Form_StaticText(
 	'Links',
 	'<small>'
-	. '<a href="/firewall_aliases.php" target="_blank">Firewall Aliases</a>&emsp;'
-	. '<a href="/firewall_rules.php" target="_blank">Firewall Rules</a>&emsp;'
-	. '<a href="/status_logs_filter.php" target="_blank">Firewall Logs</a></small>'
+	. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Aliases</a>&emsp;'
+	. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
+	. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
 ));
 
 $dnsbl_text = '<div class="infoblock">
@@ -2684,11 +2684,11 @@ $section->addInput(new Form_Checkbox(
 		. '<div id="dnsbl_python_tld_allow_text">'
 		. '<strong>By default</strong> \'ARPA\' and the pfSense TLD \'' . strtoupper($local_tld) . '\' are allowed.<br />'
 		. 'If no TLDs are selected, the following are added by default [ COM, NET, ORG, EDU, CA, CO, IO ]<br /><br />'
-		. 'Detailed TLD listings : <a target=_blank href="http://www.iana.org/domains/root/db">Root Zone Top-Level Domains.</a><br />'
+		. 'Detailed TLD listings : <a target=_blank rel="noopener noreferrer" href="http://www.iana.org/domains/root/db">Root Zone Top-Level Domains.</a><br />'
 		. 'Changes to this option will require a Force Update to take effect.<br /><br />'
 		. '<strong>Legend</strong>:<br />'
 		. '(*) TLD is used by atleast one DNSBL Feed in the Feeds Tab. Confirm the TLDs used by the selected Feeds.<br />'
-		. '(!) TLD is listed by <a target=_blank href="https://www.spamhaus.org/statistics/tlds/">Spamhaus (Most Abused TLDs)</a><br /></div>'
+		. '(!) TLD is listed by <a target=_blank rel="noopener noreferrer" href="https://www.spamhaus.org/statistics/tlds/">Spamhaus (Most Abused TLDs)</a><br /></div>'
 		);
 
 $section->addInput(new Form_Checkbox(
@@ -2903,7 +2903,7 @@ $section->addInput(new Form_Input(
 	$pconfig['dnsbl_redir_exclude'],
 	['placeholder' => 'Firewall alias name (optional)']
 ))->setHelp('Optional. Name of an existing Firewall Alias. Hosts/subnets in this alias bypass the DNS redirect.<br />'
-		. 'The alias must be created separately at <a href="/firewall_aliases.php" target="_blank">Firewall &gt; Aliases</a>.');
+		. 'The alias must be created separately at <a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall &gt; Aliases</a>.');
 
 $form->add($section);
 
@@ -2925,7 +2925,7 @@ $group->add(new Form_Checkbox(
 		. 'DoH is addressed by the DoH-IP feed and DNSBL domain blocking.<br />'
 		. 'The firewall itself is always exempt. Hosts in the exception alias are also exempt.<br />'
 		. 'The exception alias must exist at '
-		. '<a href="/firewall_aliases.php" target="_blank">Firewall &gt; Aliases</a> before use.');
+		. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall &gt; Aliases</a> before use.');
 
 // [ ADR-37 ] Quick-fill interface union -- identical to the ADR-36 DNS Redirect fill above
 // ($options_dnsbl_dot_block_int is the same interface list as $options_dnsbl_redir_int), so
@@ -2949,7 +2949,7 @@ $section->addInput(new Form_Input(
 	$pconfig['dnsbl_dot_block_exclude'],
 	['placeholder' => 'Firewall alias name (optional)']
 ))->setHelp('Optional. Name of an existing Firewall Alias. Hosts/subnets in this alias bypass the DoT/DoQ block.<br />'
-		. 'The alias must be created separately at <a href="/firewall_aliases.php" target="_blank">Firewall &gt; Aliases</a>.');
+		. 'The alias must be created separately at <a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall &gt; Aliases</a>.');
 
 $section->addInput(new Form_Select(
 	'dnsbl_dot_block_action',
@@ -2983,7 +2983,7 @@ $section->addInput(new Form_Select(
 	$options_safesearch_doh
 ))->setHelp('Block well-known DNS over HTTPS/TLS/QUIC (DoH/DoT/DoQ) providers. Modern browsers and devices often use encrypted DNS that bypasses DNSBL; blocking these providers keeps clients on the local resolver so DNSBL stays effective.<br />'
 		. 'DNS requests to these domains will return NXDOMAIN.<br />'
-		. 'A DoH/DoT/DoQ <a href="/pfblockerng/pfblockerng_feeds.php" target="_blank">Feed</a> may cover more providers and update more often than this built-in list.')
+		. 'A DoH/DoT/DoQ <a href="/pfblockerng/pfblockerng_feeds.php" target="_blank" rel="noopener noreferrer">Feed</a> may cover more providers and update more often than this built-in list.')
   ->setAttribute('style', 'width: auto');
 
 $section->addInput(new Form_Select(
@@ -3115,7 +3115,7 @@ $pfb_vip_help = 'Select the DNSBL VIP address — rejected DNS requests are forw
 	. 'It should be in an isolated range not already used on the network.<br />'
 	. 'Enable <strong>Create VIPs automatically</strong> to have pfBlockerNG manage it, or select one '
 	. 'manually — create it first at '
-	. '<a target="_blank" href="/firewall_virtual_ip.php">Firewall &gt; Virtual IPs</a>.';
+	. '<a target="_blank" rel="noopener noreferrer" href="/firewall_virtual_ip.php">Firewall &gt; Virtual IPs</a>.';
 if ($pfb_auto_exhausted) {
 	$pfb_vip_help .= '<br /><i class="fa fa-exclamation-triangle text-warning"></i> '
 		. '<span class="text-warning">No free auto-create address is available — free one in the '
@@ -3260,16 +3260,16 @@ $top1m_text = 'The TOP1M feed can be used to whitelist the most popular Domain n
 		Whitelist(s) available:<br />
 
 		<ul>
-			<li><a target="_blank" href="https://tranco-list.eu/">Tranco TOP1M</a></li>
-			<li><a target="_blank" href="https://s3-us-west-1.amazonaws.com/umbrella-static/index.html">Cisco Umbrella TOP1M</a></li>
-			<li><a target="_blank" href="https://openpagerank.keywordseverywhere.com/top-10-million-domains">OpenPageRank TOP1M</a></li>
-			<li><a target="_blank" href="https://majestic.com/reports/majestic-million">Majestic Million TOP1M</a> --
+			<li><a target="_blank" rel="noopener noreferrer" href="https://tranco-list.eu/">Tranco TOP1M</a></li>
+			<li><a target="_blank" rel="noopener noreferrer" href="https://s3-us-west-1.amazonaws.com/umbrella-static/index.html">Cisco Umbrella TOP1M</a></li>
+			<li><a target="_blank" rel="noopener noreferrer" href="https://openpagerank.keywordseverywhere.com/top-10-million-domains">OpenPageRank TOP1M</a></li>
+			<li><a target="_blank" rel="noopener noreferrer" href="https://majestic.com/reports/majestic-million">Majestic Million TOP1M</a> --
 				distributed under the <strong>Creative Commons Attribution (CC BY) 3.0</strong> License by:
-				<a target="_blank" href="https://majestic.com">Majestic</a>, attribution required.</li>
-			<li><a target="_blank" href="https://radar.cloudflare.com/domains">Cloudflare Radar</a> --
+				<a target="_blank" rel="noopener noreferrer" href="https://majestic.com">Majestic</a>, attribution required.</li>
+			<li><a target="_blank" rel="noopener noreferrer" href="https://radar.cloudflare.com/domains">Cloudflare Radar</a> --
 				distributed under the <strong>Creative Commons Attribution-NonCommercial (CC BY-NC) 4.0</strong> License by:
-				<a target="_blank" href="https://www.cloudflare.com">Cloudflare</a>, non-commercial use, attribution required.
-				Requires a free <a target="_blank" href="https://developers.cloudflare.com/fundamentals/api/get-started/create-token/">Cloudflare API Token</a>
+				<a target="_blank" rel="noopener noreferrer" href="https://www.cloudflare.com">Cloudflare</a>, non-commercial use, attribution required.
+				Requires a free <a target="_blank" rel="noopener noreferrer" href="https://developers.cloudflare.com/fundamentals/api/get-started/create-token/">Cloudflare API Token</a>
 				entered below.</li>
 		</ul>
 		To use this feature, select the number of \'Top Domains\' to whitelist. You can also \'include\' which TLDs to whitelist.
@@ -3329,7 +3329,7 @@ $section->addInput(new Form_Select(
 	TRUE
 ))->setHelp('Select the TLDs for Whitelist. (Only showing the Top 150 TLDs)<br />'
 		. '<strong>Default: COM, NET, ORG, CA, CO, IO</strong><br /><br />'
-		. 'Detailed listing : <a target=_blank href="http://www.iana.org/domains/root/db">Root Zone Top-Level Domains.</a>'
+		. 'Detailed listing : <a target=_blank rel="noopener noreferrer" href="http://www.iana.org/domains/root/db">Root Zone Top-Level Domains.</a>'
 )->setAttribute('size', '20')
  ->setWidth(3);
 
@@ -3521,7 +3521,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 		"Custom {$custom_location}",
 		'text',
 		$pconfig['aliasaddr_' . $advmode]
-	))->sethelp('<a target="_blank" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
+	))->sethelp('<a target="_blank" rel="noopener noreferrer" href="/firewall_aliases.php?tab=ip">Click Here to add/edit Aliases</a>'
 		. 'Do not manually enter Addresses(es).<br />Do not use \'pfB_\' in the address-type (Host/Network/URL/URL Table) Alias name.<br />'
 		. "Select 'invert' to invert the sense of the match. ie - Not (!) {$custom_location} Address(es)"
 	)->setWidth(8)

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -544,7 +544,7 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 
 			<td>
 				<?=$feed_alternate;?>
-				<a target="_blank" href="<?=$feed['website'];?>"><?=$feed['feed'];?></a>
+				<a target="_blank" rel="noopener noreferrer" href="<?=$feed['website'];?>"><?=$feed['feed'];?></a>
 					<?php
 						// Add any Alternate Feed icons
 						if (!empty($feed_alternate)) {
@@ -585,7 +585,7 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 
 			<td>
 				<?=$feed_radio;?>
-				<a target="_blank" href="<?=$feed['url'];?>"
+				<a target="_blank" rel="noopener noreferrer" href="<?=$feed['url'];?>"
 					onclick="return confirm('Download feed [ <?=$feed['url'];?> ] ?')"><?=$feed_header;?>
 				</a>
 			</td>
@@ -674,9 +674,9 @@ print ($section);
 		<h2 class="panel-title"><?=gettext("Pre-defined Alias/Group/Feeds")?></h2>
 	</div>
 
-	&emsp;Links:&emsp;<small><a href="/firewall_aliases.php" target="_blank">Firewall Aliases</a>&emsp;
-	<a href="/firewall_rules.php" target="_blank">Firewall Rules</a>&emsp;
-	<a href="/status_logs_filter.php" target="_blank">Firewall Logs</a></small><br /><br />
+	&emsp;Links:&emsp;<small><a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Aliases</a>&emsp;
+	<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;
+	<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small><br /><br />
 
 	<div class="panel-body bg-info">
 		<div style="margin: 10px 10px 10px 30px;">

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -274,9 +274,9 @@ $section = new Form_Section('General Settings');
 $section->addInput(new Form_StaticText(
 	'Links',
 	'<small>'
-	. '<a href="/firewall_aliases.php" target="_blank">Firewall Aliases</a>&emsp;'
-	. '<a href="/firewall_rules.php" target="_blank">Firewall Rules</a>&emsp;'
-	. '<a href="/status_logs_filter.php" target="_blank">Firewall Logs</a></small>'
+	. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Aliases</a>&emsp;'
+	. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
+	. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
 ));
 
 $section->addInput(new Form_Checkbox(
@@ -450,27 +450,27 @@ $section->addInput(new Form_StaticText(
 <div>
 <div style="width: 75%; height: 180px; float: left;">
 	<strong>pfBlockerNG</strong> is created, designed, developed, supported and maintained by:
-	<a target="_blank" href="https://forum.netgate.com/user/bbcan177">BBcan177</a><br />
+	<a target="_blank" rel="noopener noreferrer" href="https://forum.netgate.com/user/bbcan177">BBcan177</a><br />
 
 	<ul class="list-inline" style="margin-top: 4px; margin-bottom: -2px; border-style: outset; border-bottom-color: #8B181B; border-right-color: #8B181B; border-width: 2px;">
-		<li class="list-inline-item"><a target="_blank" href="http://pfblockerng.com">
+		<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="http://pfblockerng.com">
 			<span style="color: #8B181B;" class="fa-solid fa-globe"></span> HomePage</a></li>
-		<li class="list-inline-item"><a target="_blank" href="https://twitter.com/intent/follow?screen_name=BBcan177">
+		<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://twitter.com/intent/follow?screen_name=BBcan177">
 			<span style="color: #8B181B;" class="fa-brands fa-twitter"></span> Follow on X formerly Twitter</a></li>
-		<li class="list-inline-item"><a target="_blank" href="https://www.reddit.com/r/pfBlockerNG/new/">
+		<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://www.reddit.com/r/pfBlockerNG/new/">
 			<span style="color: #8B181B;" class="fa-brands fa-reddit"></span> Reddit</a></li>
-		<li class="list-inline-item"><a target="_blank" href="https://infosec.exchange/@BBcan177#">
+		<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://infosec.exchange/@BBcan177#">
 			<span style="color: #8B181B;" class="fa-solid fa-globe"></span> Mastodon</a></li>
-		<li class="list-inline-item"><a target="_blank" href="https://github.com/BBcan177">
+		<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://github.com/BBcan177">
 			<span style="color: #8B181B;" class="fa-brands fa-github"></span> GitHub</a></li>
-		<li class="list-inline-item"><a target="_blank" href="mailto:bbcan177@gmail.com?Subject=pfBlockerNG%20Support">
+		<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="mailto:bbcan177@gmail.com?Subject=pfBlockerNG%20Support">
 			<span style="color: #8B181B;" class="fa-regular fa-envelope"></span> Contact Us</a></li>
 	</ul>
 	<span class="pull-right"><small>Based upon pfBlocker by Marcello Coutinho and Tom Schaefer.</small></span>
 </div>
 
 <div style="width: 25%; height: 170px; float: right;">
-	<a target="_blank" href="http://pfblockerng.com">
+	<a target="_blank" rel="noopener noreferrer" href="http://pfblockerng.com">
 
 <svg width="180.0pt" height="180.0pt" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="30 225 560 470" style="enable-background:new 30 225 560 470;" xml:space="preserve">

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -327,9 +327,9 @@ $section = new Form_Section('IP Configuration');
 $section->addInput(new Form_StaticText(
 	'Links',
 	'<small>'
-	. '<a href="/firewall_aliases.php" target="_blank">Firewall Aliases</a>&emsp;'
-	. '<a href="/firewall_rules.php" target="_blank">Firewall Rules</a>&emsp;'
-	. '<a href="/status_logs_filter.php" target="_blank">Firewall Logs</a></small>'
+	. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Aliases</a>&emsp;'
+	. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
+	. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
 ));
 
 $section->addInput(new Form_Checkbox(
@@ -443,7 +443,7 @@ $section->addInput(new Form_StaticText(
 	'Attribution',
 	'<small>'
 	. 'ASN database distributed under the Creative Commons Attribution-ShareAlike 4.0 International License by: '
-	. '<a target="_blank" href="https://ipinfo.io">IPinfo</a><br />'
+	. '<a target="_blank" rel="noopener noreferrer" href="https://ipinfo.io">IPinfo</a><br />'
 	. 'The ASN database is automatically updated each day at a random hour.</small>'
 ));
 
@@ -463,7 +463,7 @@ $section->addInput(new Form_Input(
         $pconfig['asn_token'],
         ['placeholder' => 'Enter your IPinfo Token']
 ))->setHelp('To utilize the free IPinfo ASN functionality, you must first register for a free IPinfo user account. Visit the following '
-        . '<a href="https://ipinfo.io/signup" target="_blank">Link to Register</a> for a free IPinfo user account. '
+        . '<a href="https://ipinfo.io/signup" target="_blank" rel="noopener noreferrer">Link to Register</a> for a free IPinfo user account. '
         . '<strong>NOTE: If you use Snort/Suricata, check for IPinfo blocked events!</strong>')
   ->setAttribute('autocomplete', 'off');
 
@@ -474,7 +474,7 @@ $section->addInput(new Form_StaticText(
         'Attribution',
         '<small>'
         . 'GeoIP database GeoLite2 distributed under the Creative Commons Attribution-ShareAlike 4.0 International License by: '
-	. '<a target="_blank" href="https://www.maxmind.com">MaxMind Inc.</a><br />'
+	. '<a target="_blank" rel="noopener noreferrer" href="https://www.maxmind.com">MaxMind Inc.</a><br />'
 	. 'The GeoIP database is automatically updated each day at a random hour.</small>'
 ));
 
@@ -485,7 +485,7 @@ $section->addInput(new Form_Input(
 	$pconfig['maxmind_account'],
 	['placeholder' => 'Enter your MaxMind GeoLite2 Account ID']
 ))->setHelp('To utilize the free MaxMind GeoLite2 GeoIP functionality, you must first register for a free MaxMind user account. Visit the following '
-	. '<a href="https://www.maxmind.com/en/geolite2/signup" target="_blank">Link to Register</a> for a free MaxMind user account. '
+	. '<a href="https://www.maxmind.com/en/geolite2/signup" target="_blank" rel="noopener noreferrer">Link to Register</a> for a free MaxMind user account. '
 	. '<strong>Use the GeoIP Update version 3.1.1 or newer registration option.</strong>')
   ->setAttribute('autocomplete', 'off');
 
@@ -496,7 +496,7 @@ $section->addInput(new Form_Input(
 	$pconfig['maxmind_key'] ?? '',
 	['placeholder' => 'Enter your MaxMind GeoLite2 License Key -- leave blank to keep the current key']
 ))->setHelp('To utilize the free MaxMind GeoLite2 GeoIP functionality, you must first register for a free MaxMind user account. Visit the following '
-	. '<a href="https://www.maxmind.com/en/geolite2/signup" target="_blank">Link to Register</a> for a free MaxMind user account. '
+	. '<a href="https://www.maxmind.com/en/geolite2/signup" target="_blank" rel="noopener noreferrer">Link to Register</a> for a free MaxMind user account. '
 	. '<strong>Utilize the GeoIP Update version 3.1.1 or newer registration option.</strong>'
 	. ' The stored key is never displayed here; leaving this field blank on Save keeps the existing key unchanged.')
   ->setAttribute('autocomplete', 'off');

--- a/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
@@ -118,9 +118,9 @@ $section = new Form_Section('SafeSearch settings');
 $section->addInput(new Form_StaticText(
 	'Links',
 	'<small>'
-	. '<a href="/firewall_aliases.php" target="_blank">Firewall Aliases</a>&emsp;'
-	. '<a href="/firewall_rules.php" target="_blank">Firewall Rules</a>&emsp;'
-	. '<a href="/status_logs_filter.php" target="_blank">Firewall Logs</a></small>'
+	. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Aliases</a>&emsp;'
+	. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
+	. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
 ));
 
 $section->addInput(new Form_StaticText(
@@ -144,7 +144,7 @@ $section->addInput(new Form_Select(
 	$pconfig['safesearch_youtube'],
 	$options_safesearch_youtube
 ))->setHelp('Select YouTube Restrictions. You can check it by visiting: '
-		. '<a target="_blank" href="https://www.youtube.com/check_content_restrictions">Check Youtube Content Restrictions</a>.')
+		. '<a target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/check_content_restrictions">Check Youtube Content Restrictions</a>.')
   ->setAttribute('style', 'width: auto');
 $form->add($section);
 print($form);

--- a/src/usr/local/www/pfblockerng/pfblockerng_sync.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_sync.php
@@ -205,9 +205,9 @@ $section = new Form_Section('XMLRPC Sync Settings');
 $section->addInput(new Form_StaticText(
 	'Links',
 	'<small>'
-	. '<a href="/firewall_aliases.php" target="_blank">Firewall Aliases</a>&emsp;'
-	. '<a href="/firewall_rules.php" target="_blank">Firewall Rules</a>&emsp;'
-	. '<a href="/status_logs_filter.php" target="_blank">Firewall Logs</a></small>'
+	. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Aliases</a>&emsp;'
+	. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
+	. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
 ));
 
 $section->addInput(new Form_Select(

--- a/src/usr/local/www/pfblockerng/pfblockerng_threats.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_threats.php
@@ -90,172 +90,172 @@ $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblo
 				<!-- IP threat source links -->
 				<tr>
 					<td><span style="color: blue;">Threat Lookups</span><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="http://www.ipvoid.com/scan/<?=$host;?>/">
+					<td><a target="_blank" rel="noopener noreferrer" href="http://www.ipvoid.com/scan/<?=$host;?>/">
 						<?=gettext("IPVOID");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://dnslytics.com/ip/<?=$host;?>/">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://dnslytics.com/ip/<?=$host;?>/">
 						<?=gettext("DNSlytics");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>	
-					<td><a target="_blank" href="http://www.ip-tracker.org/locator/ip-lookup.php?ip=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="http://www.ip-tracker.org/locator/ip-lookup.php?ip=<?=$host;?>">
 						<?=gettext("IP Tracker");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.fortiguard.com/webfilter?q=<?=$host;?>&version=8">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.fortiguard.com/webfilter?q=<?=$host;?>&version=8">
 						<?=gettext("FortiGuard");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.projecthoneypot.org/ip_<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.projecthoneypot.org/ip_<?=$host;?>">
 						<?=gettext("Project HoneyPot");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.virustotal.com/en/ip-address/<?=$host;?>/information">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.virustotal.com/en/ip-address/<?=$host;?>/information">
 						<?=gettext("VirusTotal Info");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.trustedsource.org/en/feedback/url">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.trustedsource.org/en/feedback/url">
 						<?=gettext("Trusted Score (McAfee)");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://opentip.kaspersky.com/<?=$host;?>/">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://opentip.kaspersky.com/<?=$host;?>/">
 						<?=gettext("Kaspersky Threat Intelligence");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://sitecheck.sucuri.net/results/<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://sitecheck.sucuri.net/results/<?=$host;?>">
 						<?=gettext("Securi SiteCheck");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://isc.sans.edu/ipinfo.html?ip=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://isc.sans.edu/ipinfo.html?ip=<?=$host;?>">
 						<?=gettext("Internet Storm Center");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://isc.sans.edu/api/ip/<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://isc.sans.edu/api/ip/<?=$host;?>">
 						<?=gettext("Internet Storm Center API summary");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.mywot.com/en/scorecard/<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.mywot.com/en/scorecard/<?=$host;?>">
 						<?=gettext("Web of Trust (WOT) Scorecard");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://quttera.com/sitescan/<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://quttera.com/sitescan/<?=$host;?>">
 						<?=gettext("Quattera");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.iblocklist.com/search.php?string=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.iblocklist.com/search.php?string=<?=$host;?>">
 						<?=gettext("I-Block List");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.threatminer.org/host.php?q=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.threatminer.org/host.php?q=<?=$host;?>">
 						<?=gettext("ThreatMiner");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.threatcrowd.org/ip.php?ip=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.threatcrowd.org/ip.php?ip=<?=$host;?>">
 						<?=gettext("Threat Crowd");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.shodan.io/search?query=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.shodan.io/search?query=<?=$host;?>">
 						<?=gettext("Shodan");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="http://viewdns.info/reverseip/?host=<?=$host;?>&t=1">
+					<td><a target="_blank" rel="noopener noreferrer" href="http://viewdns.info/reverseip/?host=<?=$host;?>&t=1">
 						<?=gettext("ViewDNS.info Reverse IP Lookup");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://support.proofpoint.com/rbl-lookup.cgi?ip=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://support.proofpoint.com/rbl-lookup.cgi?ip=<?=$host;?>">
 						<?=gettext("Proofpoint Dynamic Reputation - IP Lookup");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="http://www.reputationauthority.org/lookup.php?ip=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="http://www.reputationauthority.org/lookup.php?ip=<?=$host;?>">
 						<?=gettext("WatchGuard - Reputation Authority");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.robtex.com/ip-lookup/<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.robtex.com/ip-lookup/<?=$host;?>">
 						<?=gettext("Robtex: IP Blacklists");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.talosintelligence.com/reputation_center/lookup?search=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.talosintelligence.com/reputation_center/lookup?search=<?=$host;?>">
 						<?=gettext("Talos Threat Intelligence");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://censys.io/ipv4/<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://censys.io/ipv4/<?=$host;?>">
 						<?=gettext("Censys search engine");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://securitytrails.com/list/ip/<?=$host;?>?page=1">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://securitytrails.com/list/ip/<?=$host;?>?page=1">
 						<?=gettext("SecurityTrails");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://pulsedive.com/indicator/?ioc=<?=base64_encode($host);?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://pulsedive.com/indicator/?ioc=<?=base64_encode($host);?>">
 						<?=gettext("PulseDive");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.abuseipdb.com/check/<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.abuseipdb.com/check/<?=$host;?>">
 						<?=gettext("AbuseIPDB");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://bgp.he.net/ip/<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://bgp.he.net/ip/<?=$host;?>">
 						<?=gettext("Hurricane Electric BGP Toolkit");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://myip.ms/info/whois/<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://myip.ms/info/whois/<?=$host;?>">
 						<?=gettext("MYIP.MS");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://viz.greynoise.io/query/?gnql=ip%3A<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://viz.greynoise.io/query/?gnql=ip%3A<?=$host;?>">
 						<?=gettext("Grey Noise");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://api.mnemonic.no/pdns/v3/<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://api.mnemonic.no/pdns/v3/<?=$host;?>">
 						<?=gettext("mnemonic passiveDNS API");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://api.stopforumspam.org/api?ip=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://api.stopforumspam.org/api?ip=<?=$host;?>">
 						<?=gettext("Stop Forum Spam");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://onyphe.io/search/?query=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://onyphe.io/search/?query=<?=$host;?>">
 						<?=gettext("ONYPHE");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="http://rbluri.interserver.net/ip.php?ip=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="http://rbluri.interserver.net/ip.php?ip=<?=$host;?>">
 						<?=gettext("InterServer.net");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://spyse.com/target/ip/<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://spyse.com/target/ip/<?=$host;?>">
 						<?=gettext("SpySe.com");?></a></td>
 				</tr>
 
@@ -264,27 +264,27 @@ $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblo
 				<!-- Mail Server threat source links -->
 				<tr>
 					<td><span style="color: blue;">Mail Server Lookups</span><i class="fa-solid fa-envelope pull-right"></i></td>
-					<td><a target="_blank" href="https://senderscore.org/lookup.php?lookup=<?=$host;?>&ipLookup=Go">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://senderscore.org/lookup.php?lookup=<?=$host;?>&ipLookup=Go">
 						<?=gettext("SenderScore");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-envelope pull-right"></i></td>
-					<td><a target="_blank" href="https://www.spamhaus.org/query/bl?ip=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.spamhaus.org/query/bl?ip=<?=$host;?>">
 						<?=gettext("Spamhaus Blocklist");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-envelope pull-right"></i></td>
-					<td><a target="_blank" href="https://www.spamcop.net/w3m?action=checkblock&ip=<?=$host;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.spamcop.net/w3m?action=checkblock&ip=<?=$host;?>">
 						<?=gettext("SPAMcop Blocklist");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-envelope pull-right"></i></td>
-					<td><a target="_blank" href="http://multirbl.valli.org/lookup/<?=$host;?>.html">
+					<td><a target="_blank" rel="noopener noreferrer" href="http://multirbl.valli.org/lookup/<?=$host;?>.html">
 						<?=gettext("multirbl RBL Lookup");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-envelope pull-right"></i></td>
-					<td><a target="_blank" href="https://mxtoolbox.com/SuperTool.aspx?action=blacklist%3a<?=$host;?>&run=toolpage">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://mxtoolbox.com/SuperTool.aspx?action=blacklist%3a<?=$host;?>&run=toolpage">
 						<?=gettext("MXToolbox");?></a></td>
 				</tr>
 
@@ -293,162 +293,162 @@ $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblo
 				<!-- Domain threat source links -->
 				<tr>
 					<td>Domain Lookups<i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.talosintelligence.com/reputation_center/lookup?search=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.talosintelligence.com/reputation_center/lookup?search=<?=$domain;?>">
 						<?=gettext("Talos Threat Intelligence");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://safeweb.norton.com/report/show?url=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://safeweb.norton.com/report/show?url=<?=$domain;?>">
 						<?=gettext("Norton Safe Web");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://opentip.kaspersky.com/<?=$domain;?>/">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://opentip.kaspersky.com/<?=$domain;?>/">
 						<?=gettext("Kaspersky Threat Intelligence");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.herdprotect.com/domain-<?=$domain;?>.aspx">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.herdprotect.com/domain-<?=$domain;?>.aspx">
 						<?=gettext("HerdProtect");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://sitecheck.sucuri.net/results/<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://sitecheck.sucuri.net/results/<?=$domain;?>">
 						<?=gettext("Sucuri");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://dnslytics.com/domain/<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://dnslytics.com/domain/<?=$domain;?>">
 						<?=gettext("DNSlytics");?></a></td>
 				</tr>
 				<tr>
                                         <td><i class="fa-solid fa-globe pull-right"></i></td>
-                                        <td><a target="_blank" href="https://transparencyreport.google.com/safe-browsing/search?url=<?=$domain;?>">
+                                        <td><a target="_blank" rel="noopener noreferrer" href="https://transparencyreport.google.com/safe-browsing/search?url=<?=$domain;?>">
                                                 <?=gettext("Google SafeBrowsing");?></a></td>
                                 </tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://yandex.com/safety/?url=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://yandex.com/safety/?url=<?=$domain;?>">
 						<?=gettext("Yandex Safe Browsing");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://toolbar.netcraft.com/site_report?url=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://toolbar.netcraft.com/site_report?url=<?=$domain;?>">
 						<?=gettext("Netcraft Site Report");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.threatminer.org/domain.php?q=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.threatminer.org/domain.php?q=<?=$domain;?>">
 						<?=gettext("ThreatMiner");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.trustedsource.org/en/feedback/url">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.trustedsource.org/en/feedback/url">
 						<?=gettext("Trusted Score (McAfee)");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.threatcrowd.org/domain.php?domain=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.threatcrowd.org/domain.php?domain=<?=$domain;?>">
 						<?=gettext("Threat Crowd");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://api.mnemonic.no/pdns/v3/<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://api.mnemonic.no/pdns/v3/<?=$domain;?>">
 						<?=gettext("mnemonic passiveDNS API");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://urlscan.io/domain/<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://urlscan.io/domain/<?=$domain;?>">
 						<?=gettext("URL Scan");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.virustotal.com/en/domain/<?=$domain;?>/information/">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.virustotal.com/en/domain/<?=$domain;?>/information/">
 						<?=gettext("Virus Total");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://otx.alienvault.com/browse/pulses/?q=<?=$domain;?>&sort=-modified">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://otx.alienvault.com/browse/pulses/?q=<?=$domain;?>&sort=-modified">
 						<?=gettext("OTX Alienvault");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="http://viewdns.info/reverseip/?host=<?=$domain;?>&t=1">
+					<td><a target="_blank" rel="noopener noreferrer" href="http://viewdns.info/reverseip/?host=<?=$domain;?>&t=1">
 						<?=gettext("ViewDNS.info Reverse Domain Lookup");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="http://viewdns.info/iphistory/?domain=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="http://viewdns.info/iphistory/?domain=<?=$domain;?>">
 						<?=gettext("ViewDNS.info Domain IP History Lookup");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="http://www.reputationauthority.org/domain_lookup.php?ip=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="http://www.reputationauthority.org/domain_lookup.php?ip=<?=$domain;?>">
 						<?=gettext("WatchGuard - Reputation Authority");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.robtex.com/dns-lookup/<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.robtex.com/dns-lookup/<?=$domain;?>">
 						<?=gettext("Robtex: Summary");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://pgl.yoyo.org/adservers/details.php?hostname=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://pgl.yoyo.org/adservers/details.php?hostname=<?=$domain;?>">
 						<?=gettext("Yoyo Domain Lookup");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://censys.io/domain?q=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://censys.io/domain?q=<?=$domain;?>">
 						<?=gettext("Censys search engine");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://securitytrails.com/domain/<?=$domain;?>/dns">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://securitytrails.com/domain/<?=$domain;?>/dns">
 						<?=gettext("SecurityTrails");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.google.ca/search?q=site%3A<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.google.ca/search?q=site%3A<?=$domain;?>">
 						<?=gettext("Google Site: Search");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://pulsedive.com/indicator/?ioc=<?=base64_encode($domain);?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://pulsedive.com/indicator/?ioc=<?=base64_encode($domain);?>">
 						<?=gettext("PulseDive");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.abuseipdb.com/check/<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.abuseipdb.com/check/<?=$domain;?>">
 						<?=gettext("AbuseIPDB");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.fortiguard.com/webfilter?q=<?=$domain;?>&version=8">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.fortiguard.com/webfilter?q=<?=$domain;?>&version=8">
 						<?=gettext("FortiGuard");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.shodan.io/search?query=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.shodan.io/search?query=<?=$domain;?>">
 						<?=gettext("Shodan");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://viz.greynoise.io/query/?gnql=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://viz.greynoise.io/query/?gnql=<?=$domain;?>">
 						<?=gettext("Grey Noise");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://onyphe.io/search/?query=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://onyphe.io/search/?query=<?=$domain;?>">
 						<?=gettext("ONYPHE");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="http://rbluri.interserver.net/domain.php?domain=<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="http://rbluri.interserver.net/domain.php?domain=<?=$domain;?>">
 						<?=gettext("InterServer.net");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://spyse.com/target/domain/<?=$domain;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://spyse.com/target/domain/<?=$domain;?>">
 						<?=gettext("SpySe.com");?></a></td>
 				</tr>
 
@@ -457,17 +457,17 @@ $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblo
 				<!-- Port threat links -->
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://isc.sans.edu/port.html?port=<?=$port;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://isc.sans.edu/port.html?port=<?=$port;?>">
 						<?=gettext("ISC - Internet Storm Center");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://www.speedguide.net/port.php?port=<?=$port;?>">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://www.speedguide.net/port.php?port=<?=$port;?>">
 						<?=gettext("Speed Guide - Port database");?></a></td>
 				</tr>
 				<tr>
 					<td><i class="fa-solid fa-globe pull-right"></i></td>
-					<td><a target="_blank" href="https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers">
+					<td><a target="_blank" rel="noopener noreferrer" href="https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers">
 						<?=gettext("Wikipedia List of TCP/UDP Ports");?></a></td>
 				</tr>
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -334,9 +334,9 @@ $section = new Form_Section('Update Settings');
 $section->addInput(new Form_StaticText(
 	'Links',
 	'<small>'
-	. '<a href="/firewall_aliases.php" target="_blank">Firewall Aliases</a>&emsp;'
-	. '<a href="/firewall_rules.php" target="_blank">Firewall Rules</a>&emsp;'
-	. '<a href="/status_logs_filter.php" target="_blank">Firewall Logs</a></small>'
+	. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Aliases</a>&emsp;'
+	. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
+	. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
 ));
 
 // Run Scope selector (ip / dnsbl / both)

--- a/src/usr/local/www/pfblockerng/www/dnsbl_default.php
+++ b/src/usr/local/www/pfblockerng/www/dnsbl_default.php
@@ -153,7 +153,7 @@
 				</tbody>
 			</table>
 			<div>Powered by: <strong>pfBlockerNG DNSBL</strong>&emsp;
-				<a target="_blank" href="http://pfblockerng.com">pfBlockerNG.com</a>
+				<a target="_blank" rel="noopener noreferrer" href="http://pfblockerng.com">pfBlockerNG.com</a>
 			</div>
 		</div>
 	</div>

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -929,7 +929,7 @@ function pfBlockerNG_get_header($mode='') {
 
 			// Print 'Click to Open Logs tab' icon
 			if ($key == 0) {
-				print("{$tab5}<td>\n{$tab6}<a target='_blank' href='pfblockerng/pfblockerng_log.php' "
+				print("{$tab5}<td>\n{$tab6}<a target='_blank' rel='noopener noreferrer' href='pfblockerng/pfblockerng_log.php' "
 					. "title='" . gettext("Click to open Logs tab") . "'>\n{$tab7}<i class='fa-regular fa-rectangle-list'></i>\n{$tab5}</a></td>\n"
 					. "{$tab4}</tr>");
 			}

--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -32,29 +32,29 @@
 			<p><h4>Welcome to pfBlockerNG!</h4></p>
 			<p>This wizard will configure an entry level configuration of pfBlockerNG for IP and DNSBL.</p>
 			<p><strong>pfBlockerNG</strong> is developed and maintained by
-				<a target="_blank" href="https://forum.netgate.com/user/bbcan177">BBcan177</a><br />
+				<a target="_blank" rel="noopener noreferrer" href="https://forum.netgate.com/user/bbcan177">BBcan177</a><br />
 
 			<ul class="list-inline" style="margin-top: 4px; margin-bottom: -2px; border-style: outset; border-bottom-color: #8B181B; border-right-color: #8B181B; border-width: 2px;">
-				<li class="list-inline-item"><a target="_blank" href="http://pfblockerng.com">
+				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="http://pfblockerng.com">
 					<span style="color: #8B181B;" class="fa-solid fa-globe"></span> HomePage</a></li>
-				<li class="list-inline-item"><a target="_blank" href="https://twitter.com/intent/follow?screen_name=BBcan177">
+				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://twitter.com/intent/follow?screen_name=BBcan177">
 					<span style="color: #8B181B;" class="fa-brands fa-twitter"></span> Follow on Twitter</a></li>
-				<li class="list-inline-item"><a target="_blank" href="https://www.reddit.com/r/pfBlockerNG/new/">
+				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://www.reddit.com/r/pfBlockerNG/new/">
 					<span style="color: #8B181B;" class="fa-brands fa-reddit"></span> Reddit</a></li>
-				<li class="list-inline-item"><a target="_blank" href="https://infosec.exchange/@BBcan177#">
+				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://infosec.exchange/@BBcan177#">
 					<span style="color: #8B181B;" class="fa-solid fa-globe"></span> Mastodon</a></li>
-				<li class="list-inline-item"><a target="_blank" href="https://github.com/BBcan177">
+				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://github.com/BBcan177">
 					<span style="color: #8B181B;" class="fa-brands fa-github"></span> GitHub</a></li>
-				<li class="list-inline-item"><a target="_blank" href="mailto:bbcan177@gmail.com?Subject=pfBlockerNG%20Support">
+				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="mailto:bbcan177@gmail.com?Subject=pfBlockerNG%20Support">
 					<span style="color: #8B181B;" class="fa-regular fa-envelope"></span> Contact us</a></li>
-				<li class="list-inline-item"><a target="_blank" href="https://www.youtube.com/@LAWRENCESYSTEMS/search?query=pfblockerng">
+				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/@LAWRENCESYSTEMS/search?query=pfblockerng">
 					<span style="color: #8B181B;" class="fa-solid fa-globe"></span> Tom Lawrence Youtube channel</a></li>
-				<li class="list-inline-item"><a target="_blank" href="https://www.vikash.nl/setup-pfblockerng-python-mode-with-pfsense/">
+				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://www.vikash.nl/setup-pfblockerng-python-mode-with-pfsense/">
 					<span style="color: #8B181B;" class="fa-solid fa-globe"></span> Vikash.nl - Advanced Python mode tutorial</a></li>
 			</ul>
 		</div>
 		<div style="width: 25%; height: 170px; float: right;">
-			<a target="_blank" href="http://pfblockerng.com">
+			<a target="_blank" rel="noopener noreferrer" href="http://pfblockerng.com">
 		<svg width="180.0pt" height="180.0pt" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="120 225 560 470" style="enable-background:new 120 225 560 470;" xml:space="preserve">
 		<style type="text/css">
 			.st0{fill:#8B181B;}
@@ -158,7 +158,7 @@
 				<dd>Utilizing the DNS Resolver, ADverts and the worst known malicious domains will be blocked.</dd>
 			</dl>
 			<ul>
-				<li>A VIP on the Localhost interface can be configured manually at <a target="_blank" href="/firewall_virtual_ip.php">Firewall &gt; Virtual IPs</a>, or pfBlockerNG can create one automatically in the DNSBL step.</li>
+				<li>A VIP on the Localhost interface can be configured manually at <a target="_blank" rel="noopener noreferrer" href="/firewall_virtual_ip.php">Firewall &gt; Virtual IPs</a>, or pfBlockerNG can create one automatically in the DNSBL step.</li>
 			</ul>
 		</div>
 		]]>
@@ -249,7 +249,7 @@
 <step>
 	<id>4</id>
 	<title>pfBlockerNG DNSBL Component Configuration</title>
-	<description><![CDATA[On this screen the pfBlockerNG DNSBL Category parameters will be set.<br />Enable <strong>Create VIPs automatically</strong> below to have pfBlockerNG manage the DNSBL sinkhole Virtual IP, or configure a VIP on the Localhost interface manually first at <a target="_blank" href="/firewall_virtual_ip.php">Firewall &gt; Virtual IPs</a>.]]></description>
+	<description><![CDATA[On this screen the pfBlockerNG DNSBL Category parameters will be set.<br />Enable <strong>Create VIPs automatically</strong> below to have pfBlockerNG manage the DNSBL sinkhole Virtual IP, or configure a VIP on the Localhost interface manually first at <a target="_blank" rel="noopener noreferrer" href="/firewall_virtual_ip.php">Firewall &gt; Virtual IPs</a>.]]></description>
 	<fields>
 		<field>
 			<name>DNSBL Webserver Configuration</name>

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -360,6 +360,37 @@ def test_page_renders_clean(page: Page, webui: WebUI, php_error_log_guard: PhpEr
     assert result.ok, f"render oracle failed for {page.name} ({path}): {result.detail}"
 
 
+# issue #1217: pfBlockerNG-OWNED external new-tab links that must render with the
+# reverse-tabnabbing rel. Scoped to specific pfBlockerNG hrefs on purpose -- the
+# pfSense framework chrome (head.inc menu/footer, on every page) carries its own
+# out-of-scope target="_blank" links, so a whole-body sweep would false-positive.
+# Each url is a stable href in the named page's source.
+_NOOPENER_RENDER_CASES: tuple[tuple[str, str], ...] = (
+    ("/pfblockerng/pfblockerng_general.php", "http://pfblockerng.com"),
+    ("/pfblockerng/pfblockerng_general.php", "https://forum.netgate.com/user/bbcan177"),
+    # ?type=geoip: the MaxMind attribution callout only prints in the category page's
+    # GeoIP view (source guards it with `$gtype == 'geoip'`).
+    ("/pfblockerng/pfblockerng_category.php?type=geoip", "https://www.maxmind.com"),
+    ("/pfblockerng/pfblockerng_ip.php", "https://ipinfo.io"),
+)
+
+
+@pytest.mark.parametrize(("path", "url"), _NOOPENER_RENDER_CASES, ids=lambda v: v)
+def test_pfblockerng_new_tab_link_renders_with_noopener_rel(path: str, url: str, webui: WebUI) -> None:
+    """A pfBlockerNG-owned target="_blank" link renders with rel="noopener noreferrer" (#1217).
+
+    Tier-A render-layer proof that the source tripwire's rel actually reaches the SHIPPED
+    HTML. Scoped to pfBlockerNG's OWN external links -- the pfSense framework chrome carries
+    its own out-of-scope new-tab links, so a whole-body sweep would false-positive. Asserts
+    the link renders (non-vacuity) THEN that its anchor carries the rel adjacent to target.
+    """
+    body = webui.get(path).text
+    assert f'href="{url}"' in body, f"pfBlockerNG link {url} did not render on {path}"
+    assert f'target="_blank" rel="noopener noreferrer" href="{url}"' in body, (
+        f'link {url} on {path} renders without the adjacent rel="noopener noreferrer"'
+    )
+
+
 # ADR-11: the IP page's pfb_agg_types multi-select must render with ALL FOUR
 # option branches (Deny/Permit/Match/Native) AND its no-rule help caveat. Asserting
 # every option proves each branch of the select is emitted (not just the label), and the

--- a/tests/test_noopener_check.py
+++ b/tests/test_noopener_check.py
@@ -121,6 +121,14 @@ def test_row13_noopener_with_hyphen_suffix_is_flagged() -> None:
     assert len(v) == 1
 
 
+def test_row14_noopener_with_wordchar_suffix_is_flagged() -> None:
+    # Pins the `\w` half of the `(?![\w-])` guard independently of the hyphen half
+    # (test_row13): `noopener_evil` is a distinct, unprotected token and must flag.
+    # Without this, a guard narrowed to hyphen-only would pass the suite yet accept it.
+    v = _find('<a target="_blank" rel="noopener_evil" href="x">')
+    assert len(v) == 1
+
+
 # --------------------------------------------------------------------------- #
 # Additional branch coverage: line numbers, multiple violations, quote forms
 # --------------------------------------------------------------------------- #

--- a/tests/test_noopener_check.py
+++ b/tests/test_noopener_check.py
@@ -113,6 +113,14 @@ def test_row12_wrong_rel_value_is_flagged() -> None:
     assert len(v) == 1
 
 
+def test_row13_noopener_with_hyphen_suffix_is_flagged() -> None:
+    # `noopener-evil` is a DIFFERENT rel token, not `noopener` -- a browser grants it
+    # none of noopener's protection, so the tripwire must flag it (fail-safe). Guards
+    # against a `\b` boundary that would treat the hyphen as a token end and pass it.
+    v = _find('<a target="_blank" rel="noopener-evil" href="x">')
+    assert len(v) == 1
+
+
 # --------------------------------------------------------------------------- #
 # Additional branch coverage: line numbers, multiple violations, quote forms
 # --------------------------------------------------------------------------- #
@@ -158,6 +166,18 @@ def test_main_returns_0_on_clean_file(tmp_path: Path, capsys: pytest.CaptureFixt
     rc = cno.main([str(f)])
     assert rc == 0
     assert capsys.readouterr().err == ""
+
+
+def test_main_fails_closed_when_default_scan_set_unenumerable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A policy gate must FAIL CLOSED: when `git ls-files` cannot enumerate the default
+    # scan set (git absent / not a checkout), main() must error instead of exiting 0
+    # and silently passing. Reproduce by running argless main() from a non-git dir.
+    monkeypatch.chdir(tmp_path)
+    rc = cno.main([])
+    assert rc == 2
+    assert "failing closed" in capsys.readouterr().err
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_noopener_check.py
+++ b/tests/test_noopener_check.py
@@ -1,0 +1,189 @@
+"""Tests for scripts/check_noopener.py.
+
+Covers BOTH branches per dimension per CLAUDE.md's test-coverage rules: every
+case that flags a violation is paired with the corresponding correct form that
+must stay clean. `test_www_tree_clean` is the issue #1217 fix's red->green
+proof: RED against the unfixed tree (179 unfixed `target=_blank` sites),
+GREEN once every site carries its adjacent `rel="noopener noreferrer"`.
+
+The checker is a hyphen-free, underscore-named script under scripts/, so it is
+importable directly by path via importlib.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Load the script as a module.
+# --------------------------------------------------------------------------- #
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TOOL = _REPO_ROOT / "scripts" / "check_noopener.py"
+_spec = importlib.util.spec_from_file_location("check_noopener", _TOOL)
+assert _spec is not None and _spec.loader is not None
+cno = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = cno
+_spec.loader.exec_module(cno)
+
+
+def _find(text: str, source: str = "t.php") -> list[Any]:
+    return cno.find_violations(text, source)
+
+
+# --------------------------------------------------------------------------- #
+# Hostile-input rows 1-12 (brief issue #1217) -- bad (flagged) vs good (clean)
+# --------------------------------------------------------------------------- #
+
+
+def test_row1_double_quoted_no_rel_is_flagged() -> None:
+    v = _find('<a target="_blank" href="x">')
+    assert len(v) == 1
+    assert v[0].line == 1
+    assert v[0].source == "t.php"
+
+
+def test_row2_single_quoted_no_rel_is_flagged() -> None:
+    v = _find("<a target='_blank' href='x'>")
+    assert len(v) == 1
+
+
+def test_row3_no_quote_no_rel_is_flagged() -> None:
+    v = _find('<a target=_blank href="x">')
+    assert len(v) == 1
+
+
+def test_row4_double_quoted_with_rel_is_clean() -> None:
+    assert _find('<a target="_blank" rel="noopener noreferrer" href="x">') == []
+
+
+def test_row5_single_quoted_with_rel_is_clean() -> None:
+    assert _find("<a target='_blank' rel='noopener noreferrer' href='x'>") == []
+
+
+def test_row6_no_quote_target_with_double_quoted_rel_is_clean() -> None:
+    assert _find('<a target=_blank rel="noopener noreferrer" href="x">') == []
+
+
+def test_row7_checker_is_idempotent_on_already_fixed_input() -> None:
+    fixed = '<a target="_blank" rel="noopener noreferrer" href="x">'
+    assert _find(fixed) == []
+    assert _find(fixed) == []  # calling twice must not accumulate state
+
+
+def test_row8_rel_before_target_is_flagged_with_convention_hint(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # rel BEFORE target does not satisfy the strict-adjacency convention.
+    v = _find('<a rel="noopener noreferrer" target="_blank">')
+    assert len(v) == 1
+
+    f = tmp_path / "page.php"
+    f.write_text('<a rel="noopener noreferrer" target="_blank">\n')
+    rc = cno.main([str(f)])
+    assert rc == 1
+    # main()'s printed message states the rel-after-target convention explicitly.
+    assert "rel must sit directly after target" in capsys.readouterr().err
+
+
+def test_row9_data_target_attribute_is_clean() -> None:
+    # word/hyphen boundary excludes a `data-target="_blank"` tail.
+    assert _find('<div data-target="_blank">') == []
+
+
+def test_row10_two_anchors_one_line_flags_only_the_bad_one() -> None:
+    line = '<a target="_blank" href="a"> <a target="_blank" rel="noopener noreferrer" href="b">'
+    v = _find(line)
+    assert len(v) == 1  # per-occurrence, not per-line
+
+
+def test_row11_noopener_ok_marker_escape_hatch_is_clean() -> None:
+    assert _find('<a target="_blank" href="x"> <!-- noopener-ok: exempt sample -->') == []
+
+
+def test_row12_wrong_rel_value_is_flagged() -> None:
+    # rel present but not "noopener" -- must still flag.
+    v = _find('<a target="_blank" rel="opener" href="x">')
+    assert len(v) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Additional branch coverage: line numbers, multiple violations, quote forms
+# --------------------------------------------------------------------------- #
+
+
+def test_line_number_reported_correctly_on_later_line() -> None:
+    v = _find('<div>\n<a target="_blank" href="x">\n</div>')
+    assert len(v) == 1
+    assert v[0].line == 2
+
+
+def test_multiple_violations_across_lines_all_reported() -> None:
+    text = '<a target="_blank" href="a">\n<a target=\'_blank\' href="b">\n'
+    v = _find(text)
+    assert len(v) == 2
+    assert [x.line for x in v] == [1, 2]
+
+
+def test_rel_noopener_only_no_referrer_still_clean() -> None:
+    # "noopener" alone (no "noreferrer") already satisfies the adjacency check --
+    # the checker enforces the noopener value, not the exact full string.
+    assert _find('<a target="_blank" rel="noopener" href="x">') == []
+
+
+# --------------------------------------------------------------------------- #
+# CLI (main) over real temp files -- exit codes both ways
+# --------------------------------------------------------------------------- #
+
+
+def test_main_returns_1_on_violation_and_prints_message(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    f = tmp_path / "page.php"
+    f.write_text('<a target="_blank" href="x">\n')
+    rc = cno.main([str(f)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "noopener" in err
+    assert f"{f}:1:" in err
+
+
+def test_main_returns_0_on_clean_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    f = tmp_path / "page.php"
+    f.write_text('<a target="_blank" rel="noopener noreferrer" href="x">\n')
+    rc = cno.main([str(f)])
+    assert rc == 0
+    assert capsys.readouterr().err == ""
+
+
+# --------------------------------------------------------------------------- #
+# Tree scan -- issue #1217 fix's red->green proof. RED: 179 unfixed sites
+# across the 16 files enumerated in the brief's coverage matrix. GREEN: 0.
+# --------------------------------------------------------------------------- #
+
+
+def test_www_tree_clean() -> None:
+    """Every tracked src/usr/local/www .php/.inc/.xml file is noopener-clean."""
+    out = subprocess.run(
+        ["git", "ls-files", "-z", "src/usr/local/www"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    files = sorted(p for p in out.split("\0") if p and p.endswith((".php", ".inc", ".xml")))
+    assert len(files) >= 16  # sanity: the coverage-matrix file set must be present
+
+    all_violations: list[Any] = []
+    for rel_path in files:
+        text = (_REPO_ROOT / rel_path).read_text(encoding="utf-8", errors="replace")
+        all_violations.extend(cno.find_violations(text, rel_path))
+
+    assert all_violations == [], (
+        f'{len(all_violations)} target=_blank site(s) missing rel="noopener noreferrer": '
+        + ", ".join(f"{v.source}:{v.line}" for v in all_violations[:20])
+    )


### PR DESCRIPTION
## Summary

Fixes #1217. Adds `rel="noopener noreferrer"` to every `target="_blank"` link in the Web UI (reverse-tabnabbing defence-in-depth) and lands a source tripwire so the class cannot silently reappear.

## Scope — re-enumerated from source

The issue's `target="_blank"` (double-quote) grep under-enumerated the class. The corrected, source-verified matrix is **179 sites across 16 files, in three quote forms**:

| Quote form | Sites |
| ---------- | ----- |
| `target="_blank"` | 175 |
| `target='_blank'` (widget, single-quoted) | 1 |
| `target=_blank` (no quotes, `pfblockerng_dnsbl.php`) | 3 |

Every site now carries `rel` with the target's own quote style (double-quoted `rel` where the target is unquoted, since those sit inside PHP single-quoted strings). Attribute order is irrelevant in HTML, so multi-line concatenated anchors (e.g. `pfblockerng_alerts.php`) are handled uniformly.

## Tripwire — `scripts/check_noopener.py`

New policy checker (same shape as `scripts/check_url_encoding.py`): a `target=…_blank…` occurrence — in any of the three quote forms, with a `(?<![\w-])` guard that excludes `data-target="_blank"` — is a violation unless immediately followed by `rel=["']?noopener`. The strict-adjacency ("rel directly after target") rule needs no HTML parser and survives multi-line PHP string concatenation, since the fix keeps both attributes on the same physical line. A line carrying the `noopener-ok` marker is exempt (mirrors `check_comment_narration.py`'s `narration-ok`).

Wired into `.githooks/pre-commit` (gated on staged `*.php`/`*.inc`/`*.xml`) and CI (`test.yml`), beside the sibling checkers.

Design note: the checker enforces the security-load-bearing `noopener` token (what actually closes reverse-tabnabbing). It never passes an unsafe link (fail-safe direction); a hypothetical future `rel="noreferrer"`-only link would be flagged (over-strict, escapable via `noopener-ok`) rather than passed.

## Tests

`tests/test_noopener_check.py` — 12 hostile-input rows (all three quote forms flagged when bare / clean when fixed; rel-before-target flagged; `data-target` boundary; wrong-value `rel="opener"` flagged; per-occurrence on a two-anchor line; idempotency; the `noopener-ok` escape) plus a `test_www_tree_clean` tree-scan that is the fix's red→green oracle: it reports the 179 unfixed sites against the base tree (RED) and 0 after (GREEN).

## Verification

- `python3 -m pytest tests/test_noopener_check.py` → 18 passed
- Full suite → 2690 passed, 4 skipped
- `python3 scripts/check_noopener.py` over the tree → rc 0
- `ruff` / `ruff format` / `mypy` clean; `php -l` clean on all 15 touched PHP files; wizard XML still well-formed; `phpunit` / `phpstan` / `phpcs` pass
- Red→green re-verified via `verify-red-proof.sh` (revert the 16 www files → tree-scan fails → restore → passes)

Tier-A `ui_render` coverage already covers all touched pages; the change is an invisible attribute addition (no new page, no structural/visual change), so no Tier B is required.
