### PR TITLE
tests/smoke: continent + GeoIP-outage recompute rows, and fix the sweep that ate the reputation artifacts

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -16106,8 +16106,7 @@ function sync_package_pfblockerng($cron='') {
 
 		// issue #1232: recompute's per-alias reputation artifacts ('match<header>_<fam>.txt')
 		// sit in matchdir but are not Match-type lists -- keep them while their Deny alias
-		// exists, else this sweep reaps them before the GeoIP-outage branch can preserve them.
-		// An artifact whose alias is gone stays un-associated here, so it is still reaped.
+		// exists (a gone alias's artifact stays un-associated here, so it is still reaped).
 		if (!empty($pfb['existing']['deny'])) {
 			foreach ($pfb['existing']['deny'] as $pfb_deny_name) {
 				$pfb['existing']['match'][] = "match{$pfb_deny_name}";

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -16095,9 +16095,23 @@ function sync_package_pfblockerng($cron='') {
 			}
 		}
 
-		// Add 'Reputation - ccwhite Action' if found
-		if ($pfb['ccwhite'] == 'match' && file_exists("{$pfb['matchdir']}/matchdedup_v4.txt")) {
-			$pfb['existing']['match'][] = 'matchdedup_v4';
+		// Add 'Reputation - ccwhite Action' if found. Both families: only the v4 dedup file
+		// has a writer today, but a name for an absent file is a no-op, so the keep-list is
+		// not the place to hardcode that.
+		foreach (array('matchdedup_v4', 'matchdedup_v6') as $pfb_dedup) {
+			if ($pfb['ccwhite'] == 'match' && file_exists("{$pfb['matchdir']}/{$pfb_dedup}.txt")) {
+				$pfb['existing']['match'][] = $pfb_dedup;
+			}
+		}
+
+		// issue #1232: recompute's per-alias reputation artifacts ('match<header>_<fam>.txt')
+		// sit in matchdir but are not Match-type lists -- keep them while their Deny alias
+		// exists, else this sweep reaps them before the GeoIP-outage branch can preserve them.
+		// An artifact whose alias is gone stays un-associated here, so it is still reaped.
+		if (!empty($pfb['existing']['deny'])) {
+			foreach ($pfb['existing']['deny'] as $pfb_deny_name) {
+				$pfb['existing']['match'][] = "match{$pfb_deny_name}";
+			}
 		}
 
 		// Add enabled 'DNSBL Blacklist categories'

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1504,6 +1504,41 @@ def set_ip_suppression(
         raise RuntimeError(f"set_ip_suppression failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
 
 
+def set_ip_continent(
+    vm: SmokeVM,
+    continent: str,
+    *,
+    action: str = "Deny_Both",
+    countries4: str = "",
+    countries6: str = "",
+    timeout: float = 60.0,
+) -> None:
+    """Set one GeoIP continent's action/ISO lists at
+    ``installedpackages/pfblockerng<continent>/config/0`` (pfblockerng.inc:18147-18152's
+    ``$cont_key = 'pfblockerng' . strtolower(str_replace(' ', '', $continent))``).
+
+    ``continent`` is the GUI continent name (``$pfb['continents']`` keys, pfblockerng.inc:
+    160-169 -- e.g. ``'Africa'``, ``'North America'``); ``countries4``/``countries6`` are
+    comma-separated ISO codes (``$cont_types``, inc:15791). Read-modify-write like
+    :func:`set_ip_reputation` -- any other key already in the section survives untouched.
+    """
+    root = f"installedpackages/pfblockerng{continent.lower().replace(' ', '')}/config/0"
+    settings = {"action": action, "countries4": countries4, "countries6": countries6}
+    assigns = "".join(f"$c[{_php_str(k)}] = {_php_str(v)};\n" for k, v in settings.items())
+    snippet = (
+        f"$c = config_get_path({_php_str(root)}, array());\n"
+        f"{assigns}"
+        f"config_set_path({_php_str(root)}, $c);\n"
+        "write_config('pfBlockerNG smoke: continent config');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"set_ip_continent({continent!r}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
 def set_dnsbl_interface(vm: SmokeVM, iface: str, *, timeout: float = 60.0) -> None:
     """Set the DNSBL interface (``dnsbl_interface``) in the DNSBL-settings section.
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1514,13 +1514,13 @@ def set_ip_continent(
     timeout: float = 60.0,
 ) -> None:
     """Set one GeoIP continent's action/ISO lists at
-    ``installedpackages/pfblockerng<continent>/config/0`` (pfblockerng.inc:18147-18152's
-    ``$cont_key = 'pfblockerng' . strtolower(str_replace(' ', '', $continent))``).
+    ``installedpackages/pfblockerng<continent>/config/0`` -- pfblockerng.inc derives that root
+    as ``$cont_key = 'pfblockerng' . strtolower(str_replace(' ', '', $continent))``.
 
-    ``continent`` is the GUI continent name (``$pfb['continents']`` keys, pfblockerng.inc:
-    160-169 -- e.g. ``'Africa'``, ``'North America'``); ``countries4``/``countries6`` are
-    comma-separated ISO codes (``$cont_types``, inc:15791). Read-modify-write like
-    :func:`set_ip_reputation` -- any other key already in the section survives untouched.
+    ``continent`` is the GUI continent name (a ``$pfb['continents']`` key -- e.g. ``'Africa'``,
+    ``'North America'``); ``countries4``/``countries6`` are comma-separated ISO codes (the
+    ``$cont_types`` fields). Read-modify-write like :func:`set_ip_reputation` -- any other key
+    already in the section survives untouched.
     """
     root = f"installedpackages/pfblockerng{continent.lower().replace(' ', '')}/config/0"
     settings = {"action": action, "countries4": countries4, "countries6": countries6}

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -519,7 +519,8 @@ AFRICA_ISOS = "NG,ZA"
 
 def test_recompute_continent_snapshot_both_families(deployed_vm: SmokeVM) -> None:
     """A Deny_Both continent list writes a fresh recompute snapshot for its v4 alias
-    AND, independently, its v6 alias -- the ``$pfbadv`` gate (pfblockerng.inc:18272)
+    AND, independently, its v6 alias -- the continent loop's ``$pfbadv`` gate around
+    ``pfb_ip_recompute_write_snapshot()`` (pfblockerng.inc)
     carries no ``$vtype`` restriction, so BOTH families must snapshot, not just v4.
 
     Scenario: the Africa continent (NG + ZA) enabled for both families.

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -648,9 +648,10 @@ def _stage_match_file(vm: SmokeVM, rec_alias: str, contents: str, *, timeout: fl
 
 
 def test_recompute_geoip_outage_preserves_match_artifacts(deployed_vm: SmokeVM) -> None:
-    """dMax repmode with an offender present, but no ``GeoLite2-Country.mmdb`` on box
-    (the box's natural, never-baked state -- ``mmdblookup`` is baked, the database is
-    not): ``pfb_recompute_finish()`` must take the GeoIP-unavailable branch and leave
+    """dMax repmode with an offender present and no ``GeoLite2-Country.mmdb`` reachable
+    (the image bakes ``mmdblookup`` but never a database; a database a credentialed
+    sibling module downloaded into the shared VM is hidden for this pass and restored
+    after): ``pfb_recompute_finish()`` must take the GeoIP-unavailable branch and leave
     a PRE-EXISTING per-alias reputation match file untouched, never swap/remove it.
 
     STAGED PRECONDITION (documented, not a fake of the code path under test): this box
@@ -670,38 +671,46 @@ def test_recompute_geoip_outage_preserves_match_artifacts(deployed_vm: SmokeVM) 
         that would have swapped/removed it never ran) and the pfBlockerNG log gained
         the GeoIP-unavailable line.
     """
+    # The outage is the box's natural state (the image bakes mmdblookup, never a database),
+    # but a credentialed sibling module can have downloaded one into the session-shared VM --
+    # hide it for this pass and put it back, so the branch under test is reached either way.
     mmdb_path = f"{h.GEOIP_SHARE_DIR}/GeoLite2-Country.mmdb"
-    probe = deployed_vm.ssh("/bin/test", "-f", mmdb_path)
-    assert probe.returncode != 0, (
-        f"precondition violated: {mmdb_path} exists on this box -- R8-outage needs the box's "
-        "natural (never-baked) no-.mmdb state to exercise the GeoIP-unavailable branch"
-    )
+    stash_path = f"{mmdb_path}.r8-stash"
+    stashed = deployed_vm.ssh("/bin/test", "-f", mmdb_path).returncode == 0
+    if stashed:
+        moved = deployed_vm.ssh("/bin/mv", mmdb_path, stash_path)
+        assert moved.returncode == 0, f"could not hide {mmdb_path}: {moved.stderr!r}"
 
-    h.set_ip_dedup(deployed_vm, False)
-    h.set_ip_reputation(deployed_vm, drep=True, dmax=2)
-    h.set_ip_suppression(deployed_vm, enabled=False)
+    try:
+        h.set_ip_dedup(deployed_vm, False)
+        h.set_ip_reputation(deployed_vm, drep=True, dmax=2)
+        h.set_ip_suppression(deployed_vm, enabled=False)
 
-    feed = h.write_local_feed(deployed_vm, "r8_feed.txt", "198.51.100.10\n198.51.100.11\n198.51.100.12\n")
-    spec = h.IpCase(aliasname="r8", feed_url=feed, header="r8", action="Deny_Both")
-    h.inject_ip_lists(deployed_vm, [spec])
+        feed = h.write_local_feed(deployed_vm, "r8_feed.txt", "198.51.100.10\n198.51.100.11\n198.51.100.12\n")
+        spec = h.IpCase(aliasname="r8", feed_url=feed, header="r8", action="Deny_Both")
+        h.inject_ip_lists(deployed_vm, [spec])
 
-    # The reconcile keys on the memberlist's snapshot-derived name (<header>_<family>),
-    # never the pf table's pfB_* name -- staging under the latter could never fail.
-    rec_alias = f"{spec.header}_{spec.family}"
-    match_path = _stage_match_file(deployed_vm, rec_alias, _R8_MATCH_STAGE)
+        # The reconcile keys on the memberlist's snapshot-derived name (<header>_<family>),
+        # never the pf table's pfB_* name -- staging under the latter could never fail.
+        rec_alias = f"{spec.header}_{spec.family}"
+        match_path = _stage_match_file(deployed_vm, rec_alias, _R8_MATCH_STAGE)
 
-    # BEFORE: the staged artifact round-tripped exactly, and the outage line hasn't fired yet.
-    before_content = _raw(deployed_vm, match_path)
-    assert before_content == _R8_MATCH_STAGE, f"staged match file did not round-trip: {before_content!r}"
-    before_marker = h.count_log_marker(deployed_vm, h.PFB_LOG, GEOIP_OUTAGE_MARKER)
+        # BEFORE: the staged artifact round-tripped exactly, and the outage line hasn't fired yet.
+        before_content = _raw(deployed_vm, match_path)
+        assert before_content == _R8_MATCH_STAGE, f"staged match file did not round-trip: {before_content!r}"
+        before_marker = h.count_log_marker(deployed_vm, h.PFB_LOG, GEOIP_OUTAGE_MARKER)
 
-    h.reload(deployed_vm, "updateip", wait_unbound=False)
+        h.reload(deployed_vm, "updateip", wait_unbound=False)
 
-    after_content = _raw(deployed_vm, match_path)
-    assert after_content == before_content, (
-        f"GeoIP-outage pass perturbed the previous match artifact: before={before_content!r} after={after_content!r}"
-    )
-    after_marker = h.count_log_marker(deployed_vm, h.PFB_LOG, GEOIP_OUTAGE_MARKER)
-    assert after_marker > before_marker, (
-        f"expected a new {GEOIP_OUTAGE_MARKER!r} line in {h.PFB_LOG} (before={before_marker}, after={after_marker})"
-    )
+        after_content = _raw(deployed_vm, match_path)
+        assert after_content == before_content, (
+            f"GeoIP-outage pass perturbed the previous match artifact: "
+            f"before={before_content!r} after={after_content!r}"
+        )
+        after_marker = h.count_log_marker(deployed_vm, h.PFB_LOG, GEOIP_OUTAGE_MARKER)
+        assert after_marker > before_marker, (
+            f"expected a new {GEOIP_OUTAGE_MARKER!r} line in {h.PFB_LOG} (before={before_marker}, after={after_marker})"
+        )
+    finally:
+        if stashed:
+            deployed_vm.ssh("/bin/mv", stash_path, mmdb_path)

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -551,13 +551,14 @@ def test_recompute_continent_snapshot_both_families(deployed_vm: SmokeVM) -> Non
         f"v6 must carry 3 rows (NG's 2 + ZA's 1) vs v4's 2 -- got v4={v4_lines} v6={v6_lines}"
     )
 
-    v4_txt = _raw(deployed_vm, f"{DENYDIR}/{v4_alias}.txt")
-    v6_txt = _raw(deployed_vm, f"{DENYDIR}/{v6_alias}.txt")
-    v4_snap = _raw(deployed_vm, f"{SNAPDIR}/{v4_alias}.snap")
-    v6_snap = _raw(deployed_vm, f"{SNAPDIR}/{v6_alias}.snap")
-    assert v4_snap == v4_txt, f"v4 continent snapshot != its built .txt: snap={v4_snap!r} txt={v4_txt!r}"
-    assert v6_snap == v6_txt, (
-        f"v6 continent snapshot != its built .txt (v4-only snapshot-gate regression): snap={v6_snap!r} txt={v6_txt!r}"
+    # The snapshot is the PRISTINE pre-processing capture; the deny file is the emitted
+    # `LC_ALL=C sort -u` set. Same members, different line order -- so pin the member set,
+    # not the bytes (the counts below pin the v4/v6 asymmetry).
+    v4_snap = sorted(_lines(deployed_vm, f"{SNAPDIR}/{v4_alias}.snap"))
+    v6_snap = sorted(_lines(deployed_vm, f"{SNAPDIR}/{v6_alias}.snap"))
+    assert v4_snap == expected_v4, f"v4 continent snapshot members != its built .txt: {v4_snap}"
+    assert v6_snap == expected_v6, (
+        f"v6 continent snapshot members != its built .txt (v4-only snapshot-gate regression): {v6_snap}"
     )
     assert v6_snap != v4_snap, "v4/v6 snapshots must differ -- an identical pair cannot prove the v6 write happened"
 

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -10,8 +10,8 @@ that whole pipeline through the real CLI (``helpers.reload``) on a real pfSense 
 and observes the on-box deny/master files + live ``pfctl`` tables — the CI-runnable,
 credential-free half (Part 1 of issue #1170). Part 2 (R3/R7/R8-outage below) adds the
 Continent/GeoIP-adjacent rows that stay credential-free by riding the issue #1219
-``seed_geoip_dataset`` local-CSV fixture (R3/R7) or the box's natural no-``.mmdb``
-state (R8-outage) — never a real MaxMind account.
+``seed_geoip_dataset`` local-CSV fixture (R3/R7) or by hiding any GeoIP database for the
+pass (R8-outage) — never a real MaxMind account.
 
 WHAT THIS FILE AUTOMATES:
 
@@ -48,8 +48,9 @@ WHAT THIS FILE AUTOMATES:
   continent membership changes, proving the snapshot follows live regens rather
   than freezing at a one-time seed (issue #1084 review; ``c3fc39d3``).
 * **R8-outage — a GeoIP-unavailable pass preserves the reputation match
-  artifacts** — dMax with offenders present, on a box with no
-  ``GeoLite2-Country.mmdb`` (the box's natural, never-baked state):
+  artifacts** — dMax with offenders present and no ``GeoLite2-Country.mmdb``
+  reachable (the image bakes none; one a credentialed sibling downloaded into the
+  shared VM is hidden for the pass and restored after):
   ``pfb_recompute_finish()`` takes the GeoIP-unavailable branch and leaves a
   pre-existing per-alias match file byte-identical, never swapping/removing it.
   The RESTORED-GeoIP leg (the clean pass that clears ``matchdedup``) needs a real

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -85,6 +85,7 @@ deploy shape.
 from __future__ import annotations
 
 import os
+import subprocess
 from collections.abc import Iterator
 
 import pytest
@@ -529,7 +530,9 @@ def test_recompute_continent_snapshot_both_families(deployed_vm: SmokeVM) -> Non
         their own built ``.txt`` (not mere existence), each with the correct
         ``.aggcount`` line-count sidecar -- and the v6 content/count genuinely differs
         from v4's (NG's extra v6 row), proving the v6 write was read from the v6
-        source specifically, not a copy of v4's.
+        source specifically, not a copy of v4's. Member SETS are pinned (sorted lines,
+        not raw concatenation order) -- the continent build's own ISO-to-ISO join
+        order is an internal implementation detail this row does not pin.
     """
     h.seed_geoip_dataset(deployed_vm)
     h.set_package_enabled(deployed_vm, True)
@@ -538,13 +541,18 @@ def test_recompute_continent_snapshot_both_families(deployed_vm: SmokeVM) -> Non
 
     v4_alias = "pfB_Africa_v4"
     v6_alias = "pfB_Africa_v6"
+    v4_lines = _lines(deployed_vm, f"{DENYDIR}/{v4_alias}.txt")
+    v6_lines = _lines(deployed_vm, f"{DENYDIR}/{v6_alias}.txt")
+    expected_v4 = sorted(["192.0.2.0/28", "192.0.2.16/28"])
+    expected_v6 = sorted(["2001:db8:0::/36", "2001:db8:e::/36", "2001:db8:1::/36"])
+    assert sorted(v4_lines) == expected_v4, f"Africa v4 continent members wrong: {v4_lines}"
+    assert sorted(v6_lines) == expected_v6, f"Africa v6 continent members wrong (must include NG's 2nd row): {v6_lines}"
+    assert len(v6_lines) == 3 and len(v4_lines) == 2, (
+        f"v6 must carry 3 rows (NG's 2 + ZA's 1) vs v4's 2 -- got v4={v4_lines} v6={v6_lines}"
+    )
+
     v4_txt = _raw(deployed_vm, f"{DENYDIR}/{v4_alias}.txt")
     v6_txt = _raw(deployed_vm, f"{DENYDIR}/{v6_alias}.txt")
-    expected_v4 = "192.0.2.0/28\n192.0.2.16/28\n"
-    expected_v6 = "2001:db8:0::/36\n2001:db8:e::/36\n2001:db8:1::/36\n"
-    assert v4_txt == expected_v4, f"Africa v4 continent content wrong (NG then ZA): {v4_txt!r}"
-    assert v6_txt == expected_v6, f"Africa v6 continent content wrong (NG's 2 rows then ZA's 1): {v6_txt!r}"
-
     v4_snap = _raw(deployed_vm, f"{SNAPDIR}/{v4_alias}.snap")
     v6_snap = _raw(deployed_vm, f"{SNAPDIR}/{v6_alias}.snap")
     assert v4_snap == v4_txt, f"v4 continent snapshot != its built .txt: snap={v4_snap!r} txt={v4_txt!r}"
@@ -613,6 +621,27 @@ _R8_MATCH_STAGE = "198.51.100.0/24\n!198.51.100.10\n"
 GEOIP_OUTAGE_MARKER = "recompute [ v4 ]: GeoIP unavailable this pass -- keeping previous reputation match artifacts"
 
 
+def _stage_match_file(vm: SmokeVM, alias: str, contents: str, *, timeout: float = 30.0) -> str:
+    """Write ``contents`` verbatim to ``MATCHDIR/match<alias>.txt`` via ``tee`` (mirrors
+    ``write_local_feed``'s mkdir-then-tee). R8-outage's local one-off: a leading '!' line
+    (the real match-file format) sent through ``php_eval``/``file_put_contents`` gets
+    mangled -- pfSsh.php's REPL treats a '!'-led line as a raw shell-escape -- so this
+    writes bytes over SSH stdin instead, with no PHP-source line reinterpretation.
+    """
+    path = f"{MATCHDIR}/match{alias}.txt"
+    mk = subprocess.run(
+        vm.ssh_argv("/bin/mkdir", "-p", MATCHDIR), capture_output=True, text=True, timeout=timeout, check=False
+    )
+    if mk.returncode != 0:
+        raise RuntimeError(f"_stage_match_file: mkdir {MATCHDIR} failed: rc={mk.returncode} {mk.stderr!r}")
+    result = subprocess.run(
+        vm.ssh_argv("tee", path), input=contents, capture_output=True, text=True, timeout=timeout, check=False
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"_stage_match_file({path}) failed: rc={result.returncode} {result.stderr!r}")
+    return path
+
+
 def test_recompute_geoip_outage_preserves_match_artifacts(deployed_vm: SmokeVM) -> None:
     """dMax repmode with an offender present, but no ``GeoLite2-Country.mmdb`` on box
     (the box's natural, never-baked state -- ``mmdblookup`` is baked, the database is
@@ -651,14 +680,7 @@ def test_recompute_geoip_outage_preserves_match_artifacts(deployed_vm: SmokeVM) 
     spec = h.IpCase(aliasname="r8", feed_url=feed, header="r8", action="Deny_Both")
     h.inject_ip_lists(deployed_vm, [spec])
 
-    match_path = f"{MATCHDIR}/match{spec.alias}.txt"
-    stage_snippet = (
-        f"@mkdir({h._php_str(MATCHDIR)}, 0755, TRUE);\n"  # noqa: SLF001
-        f"file_put_contents({h._php_str(match_path)}, {h._php_str(_R8_MATCH_STAGE)});\n"  # noqa: SLF001
-        "echo 'OK';"
-    )
-    stage_res = h.php_eval(deployed_vm, stage_snippet)
-    assert "OK" in stage_res.stdout, f"could not stage the match artifact: {stage_res.stdout!r} {stage_res.stderr!r}"
+    match_path = _stage_match_file(deployed_vm, spec.alias, _R8_MATCH_STAGE)
 
     # BEFORE: the staged artifact round-tripped exactly, and the outage line hasn't fired yet.
     before_content = _raw(deployed_vm, match_path)

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -621,14 +621,17 @@ _R8_MATCH_STAGE = "198.51.100.0/24\n!198.51.100.10\n"
 GEOIP_OUTAGE_MARKER = "recompute [ v4 ]: GeoIP unavailable this pass -- keeping previous reputation match artifacts"
 
 
-def _stage_match_file(vm: SmokeVM, alias: str, contents: str, *, timeout: float = 30.0) -> str:
-    """Write ``contents`` verbatim to ``MATCHDIR/match<alias>.txt`` via ``tee`` (mirrors
-    ``write_local_feed``'s mkdir-then-tee). R8-outage's local one-off: a leading '!' line
-    (the real match-file format) sent through ``php_eval``/``file_put_contents`` gets
-    mangled -- pfSsh.php's REPL treats a '!'-led line as a raw shell-escape -- so this
-    writes bytes over SSH stdin instead, with no PHP-source line reinterpretation.
+def _stage_match_file(vm: SmokeVM, rec_alias: str, contents: str, *, timeout: float = 30.0) -> str:
+    """Write ``contents`` verbatim to ``MATCHDIR/match<rec_alias>.txt`` via ``tee`` (mirrors
+    ``write_local_feed``'s mkdir-then-tee). ``rec_alias`` is the SNAPSHOT-derived name
+    pfblockerng.sh reconciles on (``rec_alias="${rec_snap##*/}"; rec_alias="${rec_alias%%.*}"``,
+    pfblockerng.sh:896) -- i.e. ``<header>_<family>``, NOT the pf table's ``pfB_*`` name.
+
+    R8-outage's local one-off: a leading '!' line (the real match-file format) sent through
+    ``php_eval``/``file_put_contents`` gets mangled -- pfSsh.php's REPL treats a '!'-led line
+    as a raw shell-escape -- so this writes bytes over SSH stdin instead.
     """
-    path = f"{MATCHDIR}/match{alias}.txt"
+    path = f"{MATCHDIR}/match{rec_alias}.txt"
     mk = subprocess.run(
         vm.ssh_argv("/bin/mkdir", "-p", MATCHDIR), capture_output=True, text=True, timeout=timeout, check=False
     )
@@ -680,7 +683,10 @@ def test_recompute_geoip_outage_preserves_match_artifacts(deployed_vm: SmokeVM) 
     spec = h.IpCase(aliasname="r8", feed_url=feed, header="r8", action="Deny_Both")
     h.inject_ip_lists(deployed_vm, [spec])
 
-    match_path = _stage_match_file(deployed_vm, spec.alias, _R8_MATCH_STAGE)
+    # The reconcile keys on the memberlist's snapshot-derived name (<header>_<family>),
+    # never the pf table's pfB_* name -- staging under the latter could never fail.
+    rec_alias = f"{spec.header}_{spec.family}"
+    match_path = _stage_match_file(deployed_vm, rec_alias, _R8_MATCH_STAGE)
 
     # BEFORE: the staged artifact round-tripped exactly, and the outage line hasn't fired yet.
     before_content = _raw(deployed_vm, match_path)

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -8,8 +8,10 @@ pass: real feeds parse -> a pristine post-preprocessing snapshot per header
 snapshot -> the rewritten deny files load into their pf tables. This module drives
 that whole pipeline through the real CLI (``helpers.reload``) on a real pfSense VM
 and observes the on-box deny/master files + live ``pfctl`` tables — the CI-runnable,
-credential-free half (Part 1 of issue #1170); Continent/GeoIP-dependent rows are
-Part 2.
+credential-free half (Part 1 of issue #1170). Part 2 (R3/R7/R8-outage below) adds the
+Continent/GeoIP-adjacent rows that stay credential-free by riding the issue #1219
+``seed_geoip_dataset`` local-CSV fixture (R3/R7) or the box's natural no-``.mmdb``
+state (R8-outage) — never a real MaxMind account.
 
 WHAT THIS FILE AUTOMATES:
 
@@ -36,6 +38,23 @@ WHAT THIS FILE AUTOMATES:
   suppressed even after an UNRELATED sibling B's genuine change drives a
   family-wide recompute that rewrites A too (recompute's snapshot is a
   PRE-suppression capture, so a stale suppression gate would resurrect it).
+* **R3 — continent snapshot write, BOTH families** — a GeoIP Continent list
+  (Deny_Both, seeded from the issue #1219 fixture CSVs) writes a fresh ``.snap`` +
+  ``.aggcount`` for its v4 alias AND, independently, its v6 alias — pinned against
+  the fixture's asymmetric second-Nigeria v6 row so a v4-only snapshot bug (the
+  pre-fix state ``IpRecomputeRanWiringTest`` guards against) cannot pass vacuously.
+* **R7 — v6 continent snapshot TRACKING across two regens** — the same v6
+  ``.snap`` genuinely changes content across two passes when the underlying
+  continent membership changes, proving the snapshot follows live regens rather
+  than freezing at a one-time seed (issue #1084 review; ``c3fc39d3``).
+* **R8-outage — a GeoIP-unavailable pass preserves the reputation match
+  artifacts** — dMax with offenders present, on a box with no
+  ``GeoLite2-Country.mmdb`` (the box's natural, never-baked state):
+  ``pfb_recompute_finish()`` takes the GeoIP-unavailable branch and leaves a
+  pre-existing per-alias match file byte-identical, never swapping/removing it.
+  The RESTORED-GeoIP leg (the clean pass that clears ``matchdedup``) needs a real
+  binary ``.mmdb`` a CSV fixture cannot produce and stays real MaxMind
+  credential-gated — tracked as issue #1228, not attempted here.
 
 Reload-scope note: R1/R2/R5/R9 are single-pass (or repeat-input) cases and use
 ``reload(scope='updateip')`` — its ``force=true`` sets ``$pfb['reuse']='on'`` for the
@@ -46,12 +65,11 @@ alias's OWN feed did not change" from "recompute ran anyway" — the exact axis
 `force=true` collapses (every alias becomes `$feed_changed` every pass) — so they use
 the ADR-40-proven two-pass shape instead: ``reload(scope='update')`` (respects the
 per-alias reuse-skip) + ``force_ip_refetch()`` on ONLY the alias that must genuinely
-re-ingest.
-
-WHAT STAYS FOR STEP 2 (Continent/GeoIP-dependent, per the issue #1170 brief):
-
-* R3/R7/R8 — anything requiring a real MaxMind GeoIP database (dMax/match-mode
-  country classification, Continent-list interaction with recompute).
+re-ingest. R3/R7 use ``reload(scope='update')`` too (matches the
+``test_smoke_714_asn_geoip.py`` c8 precedent for continent builds — the continent
+loop's own md5-comparison change detector, not the feed-reuse cache, gates the
+snapshot write). R8-outage uses ``reload(scope='updateip')`` (matches R9's dMax/pMax
+sibling: `force=true` reliably fires `repcheck` without a marker touch).
 
 DESELECTED from the default ``python -m pytest`` (``--ignore=tests/smoke``). Run via
 the smoke workflow or locally::
@@ -80,6 +98,10 @@ CFG_IP_SETTINGS = h.CFG_IP_SETTINGS
 DENYDIR = f"{h.PFB_DBDIR}/deny"
 SNAPDIR = f"{h.PFB_DBDIR}/snapshot"
 MASTERFILE = f"{h.PFB_DBDIR}/masterfile"
+# pfblockerng.inc:50 $pfb['origdir'] -- the recompute snapshot's '.aggcount' sidecar dir (R3).
+ORIGDIR = f"{h.PFB_DBDIR}/original"
+# pfblockerng.sh:92 pfbmatch -- the dMax per-alias 'match<alias>.txt' reputation artifact dir (R8-outage).
+MATCHDIR = f"{h.PFB_DBDIR}/match"
 
 # Pin ip_placeholder explicitly (PHP and pfblockerng.sh both default to this value) so
 # R5/R9's collapse assertion compares against an exact string no matter what an earlier
@@ -101,11 +123,13 @@ def deployed_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
     try:
         yield smoke_vm
     finally:
-        # Leave no dedup/reputation/suppression/placeholder knob set for the next module.
+        # Leave no dedup/reputation/suppression/placeholder/continent knob set for the next module.
         h.set_ip_dedup(smoke_vm, False)
         h.set_ip_reputation(smoke_vm)
         h.set_ip_suppression(smoke_vm, enabled=False)
         _set_placeholder(smoke_vm, "")
+        h.set_ip_continent(smoke_vm, "Africa", action="Disabled")
+        h.set_ip_continent(smoke_vm, "Oceania", action="Disabled")
         h.collect_host_diagnostics(smoke_vm)
 
 
@@ -478,3 +502,176 @@ def test_recompute_suppression_realigns_across_sibling_change(deployed_vm: Smoke
 
     b_after = _lines(deployed_vm, f"{DENYDIR}/r6b_v4.txt")
     assert b_after == ["172.104.92.31"], f"B's own change was not applied -- the sibling trigger is not real: {b_after}"
+
+
+# --------------------------------------------------------------------------- #
+# R3 -- continent snapshot write, BOTH families (issue #1219 fixture, credential-free)
+# --------------------------------------------------------------------------- #
+
+# tests/smoke/fixtures/README.md "GeoIP continent-page fixtures": Africa = NG + ZA.
+# v4 Blocks has ONE direct row per ISO; v6 Blocks carries a SECOND Nigeria row on
+# purpose, so NG's v6 file (and therefore the built continent file) genuinely
+# differs in content AND line count from its v4 sibling -- the asymmetry this row
+# is built to distinguish (a v4-only snapshot bug could not pass this).
+AFRICA_ISOS = "NG,ZA"
+
+
+def test_recompute_continent_snapshot_both_families(deployed_vm: SmokeVM) -> None:
+    """A Deny_Both continent list writes a fresh recompute snapshot for its v4 alias
+    AND, independently, its v6 alias -- the ``$pfbadv`` gate (pfblockerng.inc:18272)
+    carries no ``$vtype`` restriction, so BOTH families must snapshot, not just v4.
+
+    Scenario: the Africa continent (NG + ZA) enabled for both families.
+      Given the issue #1219 GeoIP CSV fixtures are seeded and Africa's countries4/6
+        are both set to "NG,ZA",
+      When a single real update pass builds the continent,
+      Then BOTH the v4 and v6 continent ``.snap`` files exist with content matching
+        their own built ``.txt`` (not mere existence), each with the correct
+        ``.aggcount`` line-count sidecar -- and the v6 content/count genuinely differs
+        from v4's (NG's extra v6 row), proving the v6 write was read from the v6
+        source specifically, not a copy of v4's.
+    """
+    h.seed_geoip_dataset(deployed_vm)
+    h.set_package_enabled(deployed_vm, True)
+    h.set_ip_continent(deployed_vm, "Africa", action="Deny_Both", countries4=AFRICA_ISOS, countries6=AFRICA_ISOS)
+    h.reload(deployed_vm, "update", wait_unbound=False)
+
+    v4_alias = "pfB_Africa_v4"
+    v6_alias = "pfB_Africa_v6"
+    v4_txt = _raw(deployed_vm, f"{DENYDIR}/{v4_alias}.txt")
+    v6_txt = _raw(deployed_vm, f"{DENYDIR}/{v6_alias}.txt")
+    expected_v4 = "192.0.2.0/28\n192.0.2.16/28\n"
+    expected_v6 = "2001:db8:0::/36\n2001:db8:e::/36\n2001:db8:1::/36\n"
+    assert v4_txt == expected_v4, f"Africa v4 continent content wrong (NG then ZA): {v4_txt!r}"
+    assert v6_txt == expected_v6, f"Africa v6 continent content wrong (NG's 2 rows then ZA's 1): {v6_txt!r}"
+
+    v4_snap = _raw(deployed_vm, f"{SNAPDIR}/{v4_alias}.snap")
+    v6_snap = _raw(deployed_vm, f"{SNAPDIR}/{v6_alias}.snap")
+    assert v4_snap == v4_txt, f"v4 continent snapshot != its built .txt: snap={v4_snap!r} txt={v4_txt!r}"
+    assert v6_snap == v6_txt, (
+        f"v6 continent snapshot != its built .txt (v4-only snapshot-gate regression): snap={v6_snap!r} txt={v6_txt!r}"
+    )
+    assert v6_snap != v4_snap, "v4/v6 snapshots must differ -- an identical pair cannot prove the v6 write happened"
+
+    v4_aggcount = _raw(deployed_vm, f"{ORIGDIR}/{v4_alias}.aggcount")
+    v6_aggcount = _raw(deployed_vm, f"{ORIGDIR}/{v6_alias}.aggcount")
+    assert v4_aggcount == "2\n", f"v4 .aggcount sidecar wrong: {v4_aggcount!r}"
+    assert v6_aggcount == "3\n", f"v6 .aggcount sidecar wrong (must count NG's 2nd row): {v6_aggcount!r}"
+
+
+# --------------------------------------------------------------------------- #
+# R7 -- v6 continent snapshot TRACKS across two regens (not frozen at the seed)
+# --------------------------------------------------------------------------- #
+
+
+def test_recompute_continent_v6_snapshot_tracks_regens(deployed_vm: SmokeVM) -> None:
+    """The v6 continent snapshot follows the LIVE regenerated content across two
+    passes -- it must not freeze at whatever the first pass (or an upgrade seed)
+    wrote (issue #1084 review, ``c3fc39d3``).
+
+    Uses the Oceania continent (AU/NZ) so this test's continent config is
+    independent of R3's Africa config -- self-encapsulated, no order dependence.
+
+    Scenario: Oceania's countries6 swapped between two passes.
+      Given (BEFORE) countries6="AU" and a real update pass builds the continent,
+      Then the v6 snapshot holds ONLY AU's network,
+      When countries6 is changed to "NZ" (a genuinely different membership) and a
+        SECOND real update pass runs,
+      Then the v6 snapshot now holds ONLY NZ's network -- DIFFERENT from pass 1's
+        content, proving the snapshot tracks the regen rather than staying frozen.
+    """
+    h.seed_geoip_dataset(deployed_vm)
+    h.set_package_enabled(deployed_vm, True)
+    v6_alias = "pfB_Oceania_v6"
+
+    h.set_ip_continent(deployed_vm, "Oceania", action="Deny_Both", countries4="", countries6="AU")
+    h.reload(deployed_vm, "update", wait_unbound=False)
+    snap_pass1 = _raw(deployed_vm, f"{SNAPDIR}/{v6_alias}.snap")
+    assert snap_pass1 == "2001:db8:a::/36\n", f"pass 1 v6 snapshot wrong (AU only): {snap_pass1!r}"
+
+    h.set_ip_continent(deployed_vm, "Oceania", action="Deny_Both", countries4="", countries6="NZ")
+    h.reload(deployed_vm, "update", wait_unbound=False)
+    snap_pass2 = _raw(deployed_vm, f"{SNAPDIR}/{v6_alias}.snap")
+    assert snap_pass2 == "2001:db8:b::/36\n", f"pass 2 v6 snapshot wrong (NZ only): {snap_pass2!r}"
+    assert snap_pass2 != snap_pass1, (
+        f"v6 continent snapshot did not track the regenerated membership (frozen-snapshot "
+        f"regression): pass1={snap_pass1!r} pass2={snap_pass2!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# R8-outage -- GeoIP unavailable this pass: preserve the previous reputation
+# match artifacts, never swap/remove them (issue #1228 tracks the restored leg)
+# --------------------------------------------------------------------------- #
+
+# pfblockerng.sh's window-awk match-file format (pfb_recompute_rep_subset): one
+# "<pfx>.0/24" header line, then one "!<ip>" line per exempted/dup'd member. A
+# realistic prior-pass artifact for the SAME offending /24 this test's feed creates.
+_R8_MATCH_STAGE = "198.51.100.0/24\n!198.51.100.10\n"
+# pfblockerng.sh's pfb_recompute_finish() log line (rec_geoip_ok==0 branch) --
+# family-qualified so it cannot be confused with a sibling family's line.
+GEOIP_OUTAGE_MARKER = "recompute [ v4 ]: GeoIP unavailable this pass -- keeping previous reputation match artifacts"
+
+
+def test_recompute_geoip_outage_preserves_match_artifacts(deployed_vm: SmokeVM) -> None:
+    """dMax repmode with an offender present, but no ``GeoLite2-Country.mmdb`` on box
+    (the box's natural, never-baked state -- ``mmdblookup`` is baked, the database is
+    not): ``pfb_recompute_finish()`` must take the GeoIP-unavailable branch and leave
+    a PRE-EXISTING per-alias reputation match file untouched, never swap/remove it.
+
+    STAGED PRECONDITION (documented, not a fake of the code path under test): this box
+    can never produce a real ``match<alias>.txt`` through a GeoIP-UP pass (no
+    ``.mmdb`` ever exists here -- the restored-GeoIP leg needs real MaxMind
+    credentials to fetch a binary database a CSV fixture cannot substitute for;
+    tracked as issue #1228). The file staged below stands in for "what a prior pass
+    wrote while GeoIP was up" -- realistic content in the real on-disk format, not a
+    fabricated code path: the property under test is that THIS pass, with GeoIP
+    down, leaves it alone.
+
+    Scenario: one v4 Deny alias with an offending /24 (dmax=2, 3 members present).
+      Given (before) a pre-existing match file for that alias's own offending /24,
+      When dRep/dMax is on, an offender is present, and a real Force-IP pass runs
+        with no ``.mmdb`` on box,
+      Then the match file is BYTE-IDENTICAL afterwards (the rec_geoip_ok==1 reconcile
+        that would have swapped/removed it never ran) and the pfBlockerNG log gained
+        the GeoIP-unavailable line.
+    """
+    mmdb_path = f"{h.GEOIP_SHARE_DIR}/GeoLite2-Country.mmdb"
+    probe = deployed_vm.ssh("/bin/test", "-f", mmdb_path)
+    assert probe.returncode != 0, (
+        f"precondition violated: {mmdb_path} exists on this box -- R8-outage needs the box's "
+        "natural (never-baked) no-.mmdb state to exercise the GeoIP-unavailable branch"
+    )
+
+    h.set_ip_dedup(deployed_vm, False)
+    h.set_ip_reputation(deployed_vm, drep=True, dmax=2)
+    h.set_ip_suppression(deployed_vm, enabled=False)
+
+    feed = h.write_local_feed(deployed_vm, "r8_feed.txt", "198.51.100.10\n198.51.100.11\n198.51.100.12\n")
+    spec = h.IpCase(aliasname="r8", feed_url=feed, header="r8", action="Deny_Both")
+    h.inject_ip_lists(deployed_vm, [spec])
+
+    match_path = f"{MATCHDIR}/match{spec.alias}.txt"
+    stage_snippet = (
+        f"@mkdir({h._php_str(MATCHDIR)}, 0755, TRUE);\n"  # noqa: SLF001
+        f"file_put_contents({h._php_str(match_path)}, {h._php_str(_R8_MATCH_STAGE)});\n"  # noqa: SLF001
+        "echo 'OK';"
+    )
+    stage_res = h.php_eval(deployed_vm, stage_snippet)
+    assert "OK" in stage_res.stdout, f"could not stage the match artifact: {stage_res.stdout!r} {stage_res.stderr!r}"
+
+    # BEFORE: the staged artifact round-tripped exactly, and the outage line hasn't fired yet.
+    before_content = _raw(deployed_vm, match_path)
+    assert before_content == _R8_MATCH_STAGE, f"staged match file did not round-trip: {before_content!r}"
+    before_marker = h.count_log_marker(deployed_vm, h.PFB_LOG, GEOIP_OUTAGE_MARKER)
+
+    h.reload(deployed_vm, "updateip", wait_unbound=False)
+
+    after_content = _raw(deployed_vm, match_path)
+    assert after_content == before_content, (
+        f"GeoIP-outage pass perturbed the previous match artifact: before={before_content!r} after={after_content!r}"
+    )
+    after_marker = h.count_log_marker(deployed_vm, h.PFB_LOG, GEOIP_OUTAGE_MARKER)
+    assert after_marker > before_marker, (
+        f"expected a new {GEOIP_OUTAGE_MARKER!r} line in {h.PFB_LOG} (before={before_marker}, after={after_marker})"
+    )


### PR DESCRIPTION
Part 2 of #1170, and a production fix it uncovered (#1232).

## The tests (3 new rows, all credential-free)

The synthetic GeoIP CSV fixture from #1219 makes the continent path testable without a MaxMind
account: the `ugc` verb reads only local CSVs, and the MaxMind auto-download is gated on
`!empty($pfb['maxmind_key']) && !empty($pfb['maxmind_account'])`, so with no credentials
configured nothing can clobber the seeded data.

| Row | Test |
| --- | ---- |
| Continent snapshot write, BOTH families | `test_recompute_continent_snapshot_both_families` |
| v6 continent snapshot tracks across two regens | `test_recompute_continent_v6_snapshot_tracks_regens` |
| A GeoIP-unavailable pass preserves the reputation match artifacts | `test_recompute_geoip_outage_preserves_match_artifacts` |

Plus `helpers.set_ip_continent()` (no continent-config setter existed; `IpCase` writes a
different config root).

The first row rides the fixture's asymmetric second-Nigeria v6 row, so the v6 snapshot has 3
members against v4's 2 — a v4-only snapshot bug cannot pass it vacuously. The second swaps
Oceania's `countries6` between passes so pass 2's content genuinely differs from pass 1's; a
frozen snapshot fails.

## The production bug (#1232)

The third row failed on `devel`, and it was not the test's fault.

`pfb_recompute_finish()` has a branch that deliberately preserves the reputation match
artifacts when GeoIP is unavailable, logging *"keeping previous reputation match artifacts"*.
It never kept anything: the "Remove un-associated List(s)" sweep runs earlier in the same pass,
globs `matchdir/*.txt`, and unlinks everything it cannot match to a **configured Match list**.
Recompute's per-alias artifacts (`match<header>_<fam>.txt`) live in that directory but are not
lists, so every one of them was an orphan by that rule and was deleted on each pass. The code
already knew about the hazard — it whitelists `matchdedup_v4` right above — but the per-alias
artifacts got no such protection.

Those artifacts are what the Alerts page globs to attribute a matched IP back to its feed. While
GeoIP is up they are rewritten every pass, so the deletion is invisible; during an outage the
pass deliberately does not rewrite them, so the attribution data simply vanished for the duration
of the outage, and the preservation branch was dead code.

The fix keeps the artifact of every configured Deny alias, exactly as `matchdedup` already is. An
artifact whose alias is gone stays un-associated and is still reaped, so nothing leaks. The
`matchdedup` keep-list now covers both families — only v4 has a writer today, but a keep-list
entry for an absent file is a no-op, and that is not the place to hardcode the family.

## Red → green (executed on a leased live VM, ADR-47 box pool)

Same test file both runs, `git hash-object 6eceea37…`, zero edits between them.

RED — tests on unfixed `devel`:

```text
FAILED tests/smoke/test_smoke_ip_recompute.py::test_recompute_geoip_outage_preserves_match_artifacts
1 failed, 8 passed, 749 deselected in 100.70s

# from the box's own log, one pass:
12:25:01 [ Removing 'match' 	List(s) : matchr8_v4 ]
12:25:01 recompute [ v4 ]: GeoIP unavailable this pass -- keeping previous reputation match artifacts
E  AssertionError: GeoIP-outage pass perturbed the previous match artifact: before='198.51.100.0/24\n!198.51.100.10\n' after=''
```

GREEN — same tests, with the fix:

```text
9 passed, 749 deselected in 98.10s
```

Gates: `python3 -m pytest` (2672 passed) · `ruff check .` · `ruff format --check .` · `mypy tests/` ·
`php -l` · `composer phpstan` (no errors) · `composer phpcs` · `vendor/bin/phpunit` (3060 tests, OK).

## Out of scope

R8's *restored*-GeoIP leg (the clean pass that clears the consolidated `matchdedup` file) needs a
binary `GeoLite2-Country.mmdb`, which the CSV fixture cannot produce and the `bu` verb only
downloads with real MaxMind credentials — tracked as #1228.

Closes #1170.
Fixes #1232.