### PR TITLE
pfblockerng: remove the $liteparser DNSBL fast-path flag + extract host-munging helper (#1117)

### DIFF
--- a/.ADRs/ADR_21_ABP_Header_Agnostic_Detection/ADR.md
+++ b/.ADRs/ADR_21_ABP_Header_Agnostic_Detection/ADR.md
@@ -209,7 +209,8 @@ contract (CSV dialects, IP extraction, IDN) — out of ADR-21's scope; a candida
 - Cosmetic rules (`x.com##.ad`) in undetected feeds keep today's behaviour (the
   `#`-fragment strip yields a plain block for `x.com`). The broadened sniff shrinks this
   pre-existing hazard to title-less feeds; a per-line cosmetic guard is out of scope.
-- The `$liteparser` PHP variable and lite/non-lite path are NOT changed.
+- The `$liteparser` PHP variable and lite/non-lite path are NOT changed. *(Scope note for
+  ADR-21 only; `$liteparser` was later removed entirely by issue #1117.)*
 - PHP DNSBL-IP extraction for non-ABP feeds (lines 9710–9731) is NOT changed.
 - **Existing `test_adr07_*` tests are a frozen regression oracle:** no existing test
   function in any `test_adr07_*.py` file is modified, renamed, deleted, re-parametrized,

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1938,6 +1938,59 @@ function pfb_dnsbl_concat_files(string $dest, array $sources): bool {
 	return FALSE;
 }
 
+// Non-lite DNSBL host-munging pipeline, extracted pure out of the download/parse loop's
+// `if (!$lite)` branch. Order is load-bearing: scheme strip -> '/'/'#'/'?' truncation ->
+// ';'-parse_url -> trailing-port strip -> IPv6-unbracket LAST. Returns FALSE when
+// pfb_dnsbl_scheme_line rejects (strict mode) -- caller must skip the line.
+function pfb_dnsbl_extract_host(string $line, bool $strict, string $header, string $oline,
+	int $dnsbl_lineno, string &$parse_err, int &$scheme_skipped): string|false {
+
+	// ADR-22: strip the '<scheme>://' prefix. Lenient (toggle ON, the migrated/legacy
+	// default) keeps today's permissive strip; strict (toggle OFF, the new-install default)
+	// validates the scheme against RFC 3986 and rejects URL paths -- a rejected line is
+	// skipped, recorded per-line in the parse-error log, and counted for the once-per-feed
+	// summary WARNING below.
+	$line = pfb_dnsbl_scheme_line($line, $strict, $header, $oline, $dnsbl_lineno, $parse_err,
+		$scheme_skipped);
+	if ($line === FALSE) {
+		return FALSE;
+	}
+
+	// If '/' character found, remove characters after '/'
+	if (strpos($line, '/') !== FALSE) {
+		$line = strstr($line, '/', TRUE);
+	}
+
+	// If '#' character found, remove characters after '#'
+	if (strpos($line, '#') !== FALSE) {
+		$line = strstr($line, '#', TRUE);
+	}
+
+	// If '?' character found, remove characters after '?'
+	if (strpos($line, '?') !== FALSE) {
+		$line = strstr($line, '?', TRUE);
+	}
+
+	// If special characters found, parse line for host
+	if (strpos($line, ';') !== FALSE) {
+		$host = parse_url($line);
+		if (isset($host['host'])) {
+			$line = $host['host'];
+		} else {
+			$line = strstr($line, ';', TRUE);
+		}
+	}
+
+	// Remove any Port numbers at end of line (IPv6-safe:
+	// never mangle a bare IPv6 literal's trailing hextet).
+	$line = pfb_strip_trailing_port($line);
+
+	// Issue #938: unwrap a bracketed IPv6 literal (e.g. a
+	// URI-style '[2604:2dc0::]') so the is_ipaddrv6($line)
+	// collection branch below recognises it.
+	return pfb_dnsbl_unbracket_ip6($line);
+}
+
 /**
  * NDJSON interchange schema v1 (#1083). STRICT: fixed vocabulary, no version field, no
  * forward-compat mechanism. One JSON object per line, two kinds only:
@@ -17250,53 +17303,12 @@ function sync_package_pfblockerng($cron='') {
 											}
 
 											if (!$lite) {
-
-												// ADR-22: strip the '<scheme>://' prefix. Lenient (toggle ON,
-												// the migrated/legacy default) keeps today's permissive strip;
-												// strict (toggle OFF, the new-install default) validates the
-												// scheme against RFC 3986 and rejects URL paths -- a rejected
-												// line is skipped, recorded per-line in the parse-error log, and
-												// counted for the once-per-feed summary WARNING below.
 												$strict = ($pfb['dnsbl_lenient'] !== PfbLenient::On);
-												$line = pfb_dnsbl_scheme_line($line, $strict, $header, $oline,
+												$line = pfb_dnsbl_extract_host($line, $strict, $header, $oline,
 													$dnsbl_lineno, $pfb['dnsbl_parse_err'], $pfb_scheme_skipped);
 												if ($line === FALSE) {
 													continue;
 												}
-
-												// If '/' character found, remove characters after '/'
-												if (strpos($line, '/') !== FALSE) {
-													$line = strstr($line, '/', TRUE);
-												}
-
-												// If '#' character found, remove characters after '#'
-												if (strpos($line, '#') !== FALSE) {
-													$line = strstr($line, '#', TRUE);
-												}
-
-												// If '?' character found, remove characters after '?'
-												if (strpos($line, '?') !== FALSE) {
-													$line = strstr($line, '?', TRUE);
-												}
-
-												// If special characters found, parse line for host
-												if (strpos($line, ';') !== FALSE) {
-													$host = parse_url($line);
-													if (isset($host['host'])) {
-														$line = $host['host'];
-													} else {
-														$line = strstr($line, ';', TRUE);
-													}
-												}
-
-												// Remove any Port numbers at end of line (IPv6-safe:
-												// never mangle a bare IPv6 literal's trailing hextet).
-												$line = pfb_strip_trailing_port($line);
-
-												// Issue #938: unwrap a bracketed IPv6 literal (e.g. a
-												// URI-style '[2604:2dc0::]') so the is_ipaddrv6($line)
-												// collection branch below recognises it.
-												$line = pfb_dnsbl_unbracket_ip6($line);
 											}
 											$line = trim($line);
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1943,7 +1943,7 @@ function pfb_dnsbl_concat_files(string $dest, array $sources): bool {
 // ';'-parse_url -> trailing-port strip -> IPv6-unbracket LAST. Returns FALSE when
 // pfb_dnsbl_scheme_line rejects (strict mode) -- caller must skip the line.
 function pfb_dnsbl_extract_host(string $line, bool $strict, string $header, string $oline,
-	int $dnsbl_lineno, string &$parse_err, int &$scheme_skipped): string|false {
+	int $dnsbl_lineno, string $parse_err, int &$scheme_skipped): string|false {
 
 	// ADR-22: strip the '<scheme>://' prefix. Lenient (toggle ON, the migrated/legacy
 	// default) keeps today's permissive strip; strict (toggle OFF, the new-install default)

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -16825,7 +16825,6 @@ function sync_package_pfblockerng($cron='') {
 							}
 							$header_esc	= escapeshellarg($header);
 
-							$liteparser	= FALSE;	// Minimal DNSBL Parser
 							$rev_format	= FALSE;	// Host style format is reversed
 							$domain_data_ip	= array();	// Array of IPs found in feed
 							$domain_data_ip6 = array();	// Array of IPv6 IPs found in feed
@@ -16985,7 +16984,6 @@ function sync_package_pfblockerng($cron='') {
 									$custom_list = pfbng_text_area_decode($row['custom'], FALSE, TRUE, TRUE);
 									@file_put_contents("{$file_dwn}.orig", $custom_list, LOCK_EX);
 									unset($custom_list);
-									$liteparser = TRUE;
 								}
 
 								$run_once = $csv_parser = FALSE;
@@ -17198,28 +17196,24 @@ function sync_package_pfblockerng($cron='') {
 															$csv_type	= 'bbc';
 															$line		= $csvline[0];
 															$csv_found	= TRUE;
-															$liteparser	= TRUE;
 														}
 
 														// Parse Alienvault OTX pulse Feed
 														elseif ($line == 'Indicator type,Indicator,'
 																. 'Description') {
 															$csv_type	= 'otx';
-															$liteparser	= FALSE;
 															continue 2;
 														}
 
 														// Parse Ponomocup Feed
 														elseif (strpos($csvline[0], 'timestamp') !== FALSE) {
 															$csv_type	= 'pon';
-															$liteparser	= TRUE;
 															continue 2;
 														}
 
 														// Parse Proofpoint/ET IQRisk IPRep Feed
 														elseif ($line == 'domain, category, score') {
 															$csv_type	= 'et';
-															$liteparser	= TRUE;
 															continue 2;
 														}
 
@@ -17249,15 +17243,9 @@ function sync_package_pfblockerng($cron='') {
 											}
 
 											// Determine if line contains only an alpha-numeric Domain name
-											if (!$liteparser) {
-
-												$lite = FALSE;
-												if (strpos($line, '.') !== FALSE &&
-												    ctype_alnum(str_replace('.', '', $line))) {
-													$lite = TRUE;
-												}
-											}
-											else {
+											$lite = FALSE;
+											if (strpos($line, '.') !== FALSE &&
+											    ctype_alnum(str_replace('.', '', $line))) {
 												$lite = TRUE;
 											}
 
@@ -17348,9 +17336,6 @@ function sync_package_pfblockerng($cron='') {
 
 											// Domain Validation
 											if (empty(pfb_filter($line, PFB_FILTER_DOMAIN, 'DNSBL_Download'))) {
-
-												// Reset lite parser
-												$liteparser = FALSE;
 
 												// Skip yHost '@' prefixed lines
 												if (str_starts_with($line, '@')) {

--- a/tests/fixtures/dnsbl_corpus/feeds.json
+++ b/tests/fixtures/dnsbl_corpus/feeds.json
@@ -6,7 +6,7 @@
 	{"header": "csv_otx",             "group": "grp_csv",    "log": "1", "format": "plain", "provenance": "feed", "row": "CSV type otx (3-col, post-extraction)"},
 	{"header": "csv_pon",             "group": "grp_csv",    "log": "1", "format": "plain", "provenance": "feed", "row": "CSV type pon (9-col, post-extraction)"},
 	{"header": "csv_et",              "group": "grp_csv",    "log": "1", "format": "plain", "provenance": "feed", "row": "CSV type et (3-col, post-extraction)"},
-	{"header": "custom_list",         "group": "grp_custom", "log": "1", "format": "plain", "provenance": "user", "row": "custom (liteparser) list"},
+	{"header": "custom_list",         "group": "grp_custom", "log": "1", "format": "plain", "provenance": "user", "row": "custom (user-entered) list"},
 	{"header": "abp_feed",            "group": "grp_abp",    "log": "1", "format": "plain", "provenance": "feed", "row": "former-ABP feed post-classifier-deletion: ||, @@||, /re/, @@/re/, $important, $badfilter, ##-element-hiding (skip) verbatim-captured; bare registrable-parent + bare deeper-sub (delta D1, plain classify() path)"},
 	{"header": "mixed_plain",         "group": "grp_mixed",  "log": "1", "format": "plain", "provenance": "feed", "row": "mixed plain feed: ADR-21 stray ||anchor + delta D2 verbatim capture (##, /re/, /re/$important, @@/re/)"},
 	{"header": "permit_feed",         "group": "grp_permit", "log": "1", "format": "plain", "provenance": "feed", "mode": "permit", "row": "permit-mode feed (ADR-31): host->allow + delta D4 ##-verbatim capture skipped by the permit loop"},

--- a/tests/php/PfbDnsblExtractHostTest.php
+++ b/tests/php/PfbDnsblExtractHostTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_extract_host() -- issue #1119 (folded into #1117) extraction of the DNSBL
+ * download/parse loop's `if (!$lite)` host-munging branch into a pure, unit-testable
+ * helper. Pins the pipeline's load-bearing ORDER (scheme strip -> '/'/'#'/'?' truncation
+ * -> ';'-parse_url -> trailing-port strip -> IPv6-unbracket LAST -- issue #938) and the
+ * FALSE-propagation contract when pfb_dnsbl_scheme_line() rejects a strict-mode URL path.
+ */
+#[CoversFunction('pfb_dnsbl_extract_host')]
+final class PfbDnsblExtractHostTest extends TestCase
+{
+	private string $parseErr = '';
+
+	protected function setUp(): void
+	{
+		$this->parseErr = tempnam(sys_get_temp_dir(), 'pfbextracthost') . '.log';
+		@unlink($this->parseErr);
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->parseErr !== '' && is_file($this->parseErr)) {
+			unlink($this->parseErr);
+		}
+	}
+
+	private function extract(string $line, bool $strict, int &$skipped = 0): string|false
+	{
+		$skipped = 0;
+		return pfb_dnsbl_extract_host($line, $strict, 'hdr', $line, 5, $this->parseErr, $skipped);
+	}
+
+	// -- scheme strip -----------------------------------------------------------------
+
+	public function testSchemeStripLenientPermitsAnySchemeShape(): void
+	{
+		// Lenient (strict=FALSE) strips through the first '://' unconditionally, even a
+		// non-RFC-3986 leading-digit scheme.
+		$this->assertSame('d.com', $this->extract('http://d.com/path', FALSE));
+		$this->assertSame('d.com', $this->extract('123://d.com', FALSE));
+	}
+
+	public function testSchemeStripStrictAcceptsRfc3986SchemeWithNoPath(): void
+	{
+		$this->assertSame('d.com', $this->extract('https://d.com', TRUE));
+	}
+
+	public function testSchemeStripStrictRejectsNonRfc3986SchemeAndRecordsSideEffects(): void
+	{
+		// Given: a leading-digit scheme, invalid under RFC 3986.
+		$skipped = 0;
+		$result  = $this->extract('123://d.com', TRUE, $skipped);
+
+		// Then: the helper returns FALSE and the by-ref parse-error/skip-counter sinks
+		// are updated -- the caller's `continue` depends on this contract.
+		$this->assertFalse($result, 'a non-RFC-3986 scheme must be rejected in strict mode');
+		$this->assertSame(1, $skipped, 'the per-feed skip counter must be incremented');
+		$this->assertStringContainsString(
+			'123://d.com',
+			(string) file_get_contents($this->parseErr),
+			'the rejected line must be recorded in the parse-error log'
+		);
+	}
+
+	public function testSchemeStripStrictRejectsUrlPathAndRecordsSideEffects(): void
+	{
+		// A URL path survives past the scheme check itself (valid scheme) but is
+		// rejected by pfb_dnsbl_strip_scheme()'s strict path-detection.
+		$skipped = 0;
+		$result  = $this->extract('http://d.com/path', TRUE, $skipped);
+
+		$this->assertFalse($result, 'a URL path must be rejected in strict mode');
+		$this->assertSame(1, $skipped);
+		$this->assertStringContainsString('http://d.com/path', (string) file_get_contents($this->parseErr));
+	}
+
+	// -- '/', '#', '?' truncation (both modes -- scheme-less lines are strict-invariant) --
+
+	public function testSlashTruncation(): void
+	{
+		$this->assertSame('d.com', $this->extract('d.com/a/b', FALSE));
+		$this->assertSame('d.com', $this->extract('d.com/a/b', TRUE));
+	}
+
+	public function testHashTruncation(): void
+	{
+		$this->assertSame('d.com', $this->extract('d.com#frag', FALSE));
+		$this->assertSame('d.com', $this->extract('d.com#frag', TRUE));
+	}
+
+	public function testQuestionMarkTruncation(): void
+	{
+		$this->assertSame('d.com', $this->extract('d.com?q=1', FALSE));
+		$this->assertSame('d.com', $this->extract('d.com?q=1', TRUE));
+	}
+
+	// -- ';' parse_url host branch ------------------------------------------------------
+
+	public function testSemicolonWithoutParseUrlHostFallsBackToStrstr(): void
+	{
+		// parse_url('d.com;jsessionid=x') has no scheme/authority marker, so it never
+		// sets 'host' -- the strstr-before-';' fallback is the branch actually taken.
+		$this->assertSame('d.com', $this->extract('d.com;jsessionid=x', FALSE));
+		$this->assertSame('d.com', $this->extract('d.com;jsessionid=x', TRUE));
+	}
+
+	// -- trailing port (IPv6-safe) -------------------------------------------------------
+
+	public function testTrailingPortIsStripped(): void
+	{
+		$this->assertSame('d.com', $this->extract('d.com:8080', FALSE));
+		$this->assertSame('d.com', $this->extract('d.com:8080', TRUE));
+	}
+
+	public function testBareIpv6LiteralTrailingHextetIsNotMangled(): void
+	{
+		// is_ipaddrv6() gates pfb_strip_trailing_port() -- a bare v6 literal's final
+		// hextet must survive, unlike a real ':<port>' suffix.
+		$this->assertSame('2604:2dc0::', $this->extract('2604:2dc0::', FALSE));
+		$this->assertSame('2604:2dc0::', $this->extract('2604:2dc0::', TRUE));
+	}
+
+	// -- IPv6 unbracket (LAST -- issue #938) ---------------------------------------------
+
+	public function testBracketedIpv6IsUnwrappedLast(): void
+	{
+		$this->assertSame('2604:2dc0::', $this->extract('[2604:2dc0::]', FALSE));
+		$this->assertSame('2604:2dc0::', $this->extract('[2604:2dc0::]', TRUE));
+	}
+
+	// -- scheme-less bare domain identity -------------------------------------------------
+
+	public function testBareDomainIdentityAcrossHyphenUnderscoreDigitLabels(): void
+	{
+		foreach (['my-domain.com', 'my_domain-2_test.example.com', '123.example.com'] as $domain) {
+			$this->assertSame($domain, $this->extract($domain, FALSE), "{$domain} lenient");
+			$this->assertSame($domain, $this->extract($domain, TRUE), "{$domain} strict");
+		}
+	}
+
+	// -- IDN raw bytes passthrough (no punycode conversion here) --------------------------
+
+	public function testRawUtf8LabelIsPassedThroughUnconverted(): void
+	{
+		// idn_to_ascii() conversion happens LATER in the download loop, outside this
+		// helper -- a raw non-ASCII UTF-8 label must survive byte-for-byte.
+		$raw = "\xE4\xBE\x8B\xE3\x81\x88.com";
+		$this->assertSame($raw, $this->extract($raw, FALSE));
+		$this->assertSame($raw, $this->extract($raw, TRUE));
+	}
+
+	// -- empty result after truncation -----------------------------------------------------
+
+	public function testTruncationToEmptyStringReturnsEmptyNotFalse(): void
+	{
+		// '?foo' truncates entirely at the '?' step -- the real (pinned) result is an
+		// empty STRING, not FALSE (FALSE is reserved for the scheme-reject contract).
+		$this->assertSame('', $this->extract('?foo', FALSE));
+	}
+
+	// -- ordering invariant: scheme -> trunc -> ';' -> port -> unbracket ------------------
+
+	public function testOrderingInvariantSchemeBeforeTruncationBeforePortStrip(): void
+	{
+		$this->assertSame('d.com', $this->extract('https://d.com:8080/p#f?q', FALSE));
+	}
+
+	public function testOrderingInvariantHoldsUnderStrictRejection(): void
+	{
+		// The same shape, but strict mode: the scheme is valid, yet the '/p' remainder
+		// after the port is a URL path -- rejected before any trunc/port/unbracket step
+		// runs, proving scheme-check happens FIRST.
+		$skipped = 0;
+		$result  = $this->extract('https://d.com:8080/p#f', TRUE, $skipped);
+		$this->assertFalse($result);
+		$this->assertSame(1, $skipped);
+	}
+}

--- a/tests/php/PfbDnsblExtractHostTest.php
+++ b/tests/php/PfbDnsblExtractHostTest.php
@@ -19,7 +19,7 @@ final class PfbDnsblExtractHostTest extends TestCase
 
 	protected function setUp(): void
 	{
-		$this->parseErr = tempnam(sys_get_temp_dir(), 'pfbextracthost') . '.log';
+		$this->parseErr = tempnam(sys_get_temp_dir(), 'pfbextracthost');
 		@unlink($this->parseErr);
 	}
 

--- a/tests/smoke/test_smoke_adr62.py
+++ b/tests/smoke/test_smoke_adr62.py
@@ -774,3 +774,68 @@ def test_adr62_tld_enabled_run_keeps_plain_row_classification(deployed_vm: Smoke
             assert not h.resolves_to(ans, STUB_DNS_A), (
                 f"{name} still resolving with pfb_tld=on (TLD mode broke ordinary plain-row blocking): {ans}"
             )
+
+
+# --------------------------------------------------------------------------- #
+# Row 8 — issue #1117: the first line of a formerly-"liteparser"-trusted feed
+# that needs host-munging must be salvaged, not silently dropped.
+#
+# Pre-fix, $liteparser=TRUE (set when a feed autodetects as bbc/pon/et, or for a
+# user custom list) forced the per-line $lite fast path, skipping the ADR-22
+# scheme strip. So a trusted feed's FIRST line carrying a URL-form value in its
+# extracted domain column failed pfb_filter(PFB_FILTER_DOMAIN) on the raw string
+# and was dropped+logged; the failure flipped the flag FALSE, and a SECOND such
+# line was then munged and salvaged. This is the only end-to-end driver of that
+# bug: the ADR-62 corpus oracle consumes post-munging .raw fixtures, so it is
+# structurally blind to the PHP download/parse loop (its own docstring says so).
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(300)
+def test_adr62_liteparser_first_url_line_salvaged_not_dropped(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
+    """Row 8 (issue #1117): the FIRST URL-form line of a bbc-trusted feed blocks.
+
+    Scenario: the $liteparser fast path skipped host-munging for feeds it trusted
+      (custom/bbc/pon/et), silently dropping the first line munging would have fixed.
+    Given two bbc-CSV rows whose extracted domain (col 0) is a URL — ``https://<first>``
+      then ``https://<second>`` — both RESOLVING via the stub before the feed loads,
+    When the feed loads (col 3 carries the Bambenek marker that selects the formerly
+      liteparser-trusted 'bbc' type),
+    Then BOTH domains are VIP-blocked. Pre-#1117 the SECOND URL line was salvaged (the
+      adaptive reset had flipped the flag) while the FIRST was dropped — so the
+      second-line block is the control proving the feed loaded and the URL pipeline
+      works, and the first-line block is the fix.
+    """
+    first_dom = h.unique_domain("adr62r8first")  # first URL line — dropped pre-#1117
+    second_dom = h.unique_domain("adr62r8second")  # second URL line — salvaged pre-#1117 (control)
+    marker = "http://osint.bambenekconsulting.com/manual/index.php"  # bbc detector, pfblockerng.inc
+    body = (
+        f"https://{first_dom},bambenek-comment,20260101,{marker}\n"
+        f"https://{second_dom},bambenek-comment,20260102,{marker}\n"
+    )
+    feed_url = h.write_local_feed(deployed_vm, "smoke_adr62_row8.txt", body)
+    spec = h.DnsblCase(aliasname="adr62row8", feed_url=feed_url, header="adr62row8", mode=h.DnsblMode.VIP)
+
+    for name in (first_dom, second_dom):
+        before = h.dns_probe_client(client_vm, name, "A")
+        assert h.resolves_to(before, STUB_DNS_A), f"{name} should resolve via stub BEFORE listing, got {before}"
+
+    with h.CaseContext(deployed_vm, spec):
+        # Control: the SECOND URL line is salvaged even pre-fix. Poll it to VIP — this is
+        # the feed-load/settle transition; once it holds, the whole feed is in place.
+        h.flush_unbound_name(deployed_vm, second_dom)
+        ans_second = h.dns_probe_client_until(client_vm, second_dom, h.is_vip)
+        assert not h.resolves_to(ans_second, STUB_DNS_A), (
+            f"control: second URL line {second_dom} did not block — the feed failed to load, "
+            f"so this test cannot isolate the #1117 first-line bug: {ans_second}"
+        )
+        # The fix: with the feed settled, the FIRST line's block state is authoritative on
+        # the first read (smoke rule: do not loop for the expected value). Pre-#1117 it was
+        # dropped and stays resolving via the stub; after the fix it is VIP-blocked.
+        h.flush_unbound_name(deployed_vm, first_dom)
+        ans_first = h.dns_probe_client(client_vm, first_dom, "A")
+        assert h.is_vip(ans_first), (
+            f"issue #1117: first URL-form line {first_dom} was dropped, not salvaged — "
+            f"$liteparser skipped host-munging for the feed's first trusted line; "
+            f"expected VIP block, got {ans_first}"
+        )

--- a/tests/test_adr62_byte_identity_corpus.py
+++ b/tests/test_adr62_byte_identity_corpus.py
@@ -118,7 +118,7 @@ def test_csv_type_domains_are_blocked() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# 3. custom (liteparser) list -- provenance='user' -> USER block band
+# 3. custom (user-entered) list -- provenance='user' -> USER block band
 # --------------------------------------------------------------------------- #
 
 


### PR DESCRIPTION
## What

Remove the per-feed `$liteparser` fast-path flag from the DNSBL download/parse loop, and extract the host-munging pipeline into a pure, unit-testable helper (`pfb_dnsbl_extract_host()`). Two ordered commits:

1. **`$liteparser` removal (fixes a real bug).** The flag forced the per-line `$lite` fast path for feeds the loop trusted (user custom lists and the `bbc`/`pon`/`et` CSV types), skipping the ADR-22 scheme strip and the whole host-munging pipeline. A trusted feed's **first** line carrying a URL-form value in its extracted domain column — e.g. a Bambenek CSV whose col-0 is `https://domain` — then failed `pfb_filter(PFB_FILTER_DOMAIN)` on the raw string and was dropped + logged. The failure flipped the flag off, so a *second* such line was munged and salvaged: the first trusted line that munging would have fixed was silently, persistently lost (the flag resets per feed, so it recurred every sync).

   All 8 flag sites are deleted and `$lite` is now computed per line for every feed via the existing `ctype_alnum(str_replace('.', '', $line))` check, so every line takes the same munging path.

2. **Host-munging extraction (folds in #1119).** The `if (!$lite)` branch body (ADR-22 scheme strip → `/`/`#`/`?` truncation → `;`-`parse_url` host pick → trailing-port strip → IPv6 unbracket) moves verbatim into `pfb_dnsbl_extract_host()`, making that historically bug-prone area (issues #938, #1004, ADR-22) directly unit-testable with hostile inputs instead of only via corpus round-trips. Pure behaviour-preserving move; the `$lite` gate stays in the loop. Folded into this PR (rather than a separate one) to avoid two in-flight PRs editing the same loop region.

## Behaviour change (enumerated)

Preserving everywhere **except** one deliberate delta: a formerly-trusted feed's first munging-altered line (`scheme://`, path, `#frag`, `?query`, `;`, `:port`, embedded space) is now uniformly munged/salvaged instead of dropped. Munging is identity on schemeless bare domains under both ADR-22 modes (strict and lenient), so the non-delta class is byte-identical — proven by executed probe during triage and by the ADR-62 byte-identity corpus staying green.

## Testing

- **Live-VM smoke red→green** (`test_adr62_liteparser_first_url_line_salvaged_not_dropped`, `tests/smoke/test_smoke_adr62.py`): a two-line `bbc` CSV feed whose col-0 is `https://<first>` then `https://<second>`. The second-line block is the control (salvaged pre-fix after the adaptive reset); the first-line block is the fix. Executed on a live pfSense VM: **RED** before the removal (first line dropped, resolves to the stub), **GREEN** after, and stays GREEN after the extraction. This is the only end-to-end driver of the fix — the DNSBL download loop has no off-appliance driver, and the ADR-62 corpus oracle consumes post-munging `.raw` fixtures, so the unit suites are structurally blind to it.
- **`PfbDnsblExtractHostTest.php`** (16 tests): every munging step and hostile-input row against the helper's real behaviour — scheme strip (lenient/strict), strict-mode reject with parse-err/counter side effects, `/`/`#`/`?` truncation, `;`-fallback, trailing-port strip (IPv6-safe), bracketed-IPv6 unwrap (#938), bare-domain identity across hyphen/underscore/digit labels, raw-IDN passthrough, empty-result, and the scheme→truncation→port ordering invariant.
- ADR-62 byte-identity corpus oracles green before and after (behaviour-preserving proof for the extraction).

Fixes #1117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNSBL feed parsing for URLs, paths, ports, schemes, semicolons, and IPv6 addresses.
  * Prevented valid domains—particularly the first URL entry in supported CSV feeds—from being skipped.
  * Improved recognition of Alienvault OTX and Ponomocup feed formats.
  * Preserved valid custom-list and internationalized domain entries during processing.

* **Tests**
  * Added coverage for URL extraction, strict validation, truncation behavior, IPv6 handling, and CSV feed processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->