### PR TITLE
pfblockerng: extract pfb_dnsbl_csv_extract() DNSBL CSV parsing helper (#1118)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7146,6 +7146,140 @@ function pfb_dnsbl_collect_feed_ip(string $guard_value, string $candidate_value,
 }
 
 
+// issue #1118: the 6-type upstream-CSV classify/extract switch, pulled pure out of
+// the download/parse loop's `if ($csv_parser) { ... }` block (mirrors
+// pfb_dnsbl_extract_host()'s sentinel-action pattern). $csv_parser=FALSE is a pure
+// passthrough (nothing ran in the original block either). Every `continue 2` site
+// becomes action='skip' -- the caller's own `continue` replaces it, same as the
+// fail-path (pfb_parsed_fail() moved in here, mirroring pfb_dnsbl_scheme_line()'s
+// own logging inside pfb_dnsbl_extract_host()).
+function pfb_dnsbl_csv_extract(string $line, array $csvline, string $csv_type, bool $csv_parser,
+	bool $run_once, array $alienvault_types, bool $dnsbl_ip_enabled, bool $custom,
+	array &$domain_data_ip, array &$domain_data_ip6, string $header, string $oline,
+	int $dnsbl_lineno, string $parse_err): array {
+
+	$result = function (string $action, bool $ip_collected = FALSE) use (&$line, &$csv_type,
+		&$csv_parser, &$run_once): array {
+		return ['action' => $action, 'line' => $line, 'csv_type' => $csv_type,
+			'csv_parser' => $csv_parser, 'run_once' => $run_once, 'ip_collected' => $ip_collected];
+	};
+
+	if (!$csv_parser) {
+		return $result('use');
+	}
+
+	$csv_found = FALSE;
+	$csv_count = count($csvline);
+	$ip_collected = FALSE;
+
+	switch ($csv_type) {
+		case 'pt':
+			if ($csv_count == 8) {
+				if (strpos($csvline[1], ' ') !== FALSE) {
+					$line = str_replace(' ', '', $csvline[1]);
+				} else {
+					$line = $csvline[1];
+				}
+				$csv_found = TRUE;
+			}
+			break;
+		case 'bbc':
+			if ($csv_count == 4) {
+				$line		= $csvline[0];
+				$csv_found	= TRUE;
+			}
+			break;
+		case 'h3x':
+			if ($csv_count == 8) {
+				$line		= $csvline[2];
+				if (strpos($line, 'btc://') !== FALSE) {
+					return $result('skip');
+				}
+				$csv_found	= TRUE;
+			}
+			break;
+		case 'otx':
+			if ($csv_count == 3) {
+				if (isset($alienvault_types[$csvline[0]])) {
+					$line		= $csvline[1];
+					$csv_found	= TRUE;
+				} else {
+					return $result('skip');
+				}
+			}
+			break;
+		case 'pon':
+			if ($csv_count == 9) {
+				$line		= $csvline[2];
+				$csv_found	= TRUE;
+
+				// Collect additional IP csv entry (guard value is
+				// csvline[0], the collected value is line).
+				if ($dnsbl_ip_enabled &&
+				    pfb_dnsbl_collect_feed_ip($csvline[0], $line, $custom, $domain_data_ip, $domain_data_ip6)) {
+					$ip_collected = TRUE;
+				}
+			}
+			break;
+		case 'et':
+			if ($csv_count == 3) {
+				$line		= $csvline[0];
+				$csv_found	= TRUE;
+			}
+			break;
+		default:
+
+			// Parse Phishtank Feed
+			if (strpos($line, 'phish_id,url,'
+					. 'phish_detail_url') !== FALSE) {
+				$csv_type = 'pt';
+				return $result('skip');
+			}
+
+			// Parse Bambenek Consulting Feed
+			elseif (strpos($csvline[3], 'osint.'
+				. 'bambenekconsulting.com') !== FALSE) {
+				$csv_type	= 'bbc';
+				$line		= $csvline[0];
+				$csv_found	= TRUE;
+			}
+
+			// Parse Alienvault OTX pulse Feed
+			elseif ($line == 'Indicator type,Indicator,'
+					. 'Description') {
+				$csv_type	= 'otx';
+				return $result('skip');
+			}
+
+			// Parse Ponomocup Feed
+			elseif (strpos($csvline[0], 'timestamp') !== FALSE) {
+				$csv_type	= 'pon';
+				return $result('skip');
+			}
+
+			// Parse Proofpoint/ET IQRisk IPRep Feed
+			elseif ($line == 'domain, category, score') {
+				$csv_type	= 'et';
+				return $result('skip');
+			}
+
+			// Reset variables for CSV determination
+			else {
+				$csv_parser = $run_once = FALSE;
+			}
+			break;
+	}
+
+	// Record Failed CSV Parse event
+	if (!$csv_found || empty($csv_type)) {
+		pfb_parsed_fail($header, '', $oline, $parse_err, $dnsbl_lineno);
+		return $result('skip');
+	}
+
+	return $result('use', $ip_collected);
+}
+
+
 // ADR-62 §2 Decision 4: the universal plain-path control-line skip. Mirrors
 // pfb_is_blank_or_comment_line's contract: blank detection is an exact '' match, so
 // the CALLER must trim() first. Deliberately excludes '#' -- pfb_dnsbl_hash_line_
@@ -17172,116 +17306,23 @@ function sync_package_pfblockerng($cron='') {
 												continue;
 											}
 
-											// CSV parser
-											if ($csv_parser) {
-
-												$csv_found = FALSE;
-												$csv_count = count($csvline);
-
-												switch ($csv_type) {
-													case 'pt':
-														if ($csv_count == 8) {
-															if (strpos($csvline[1], ' ') !== FALSE) {
-																$line = str_replace(' ', '', $csvline[1]);
-															} else {
-																$line = $csvline[1];
-															}
-															$csv_found = TRUE;
-														}
-														break;
-													case 'bbc':
-														if ($csv_count == 4) {
-															$line		= $csvline[0];
-															$csv_found	= TRUE;
-														}
-														break;
-													case 'h3x':
-														if ($csv_count == 8) {
-															$line		= $csvline[2];
-															if (strpos($line, 'btc://') !== FALSE) {
-																continue 2;
-															}
-															$csv_found	= TRUE;
-														}
-														break;
-													case 'otx':
-														if ($csv_count == 3) {
-															if (isset($alienvault_types[$csvline[0]])) {
-																$line		= $csvline[1];
-																$csv_found	= TRUE;
-															} else {
-																continue 2;
-															}
-														}
-														break;
-													case 'pon':
-														if ($csv_count == 9) {
-															$line		= $csvline[2];
-															$csv_found	= TRUE;
-
-															// Collect additional IP csv entry (guard value is
-															// csvline[0], the collected value is line).
-															if ($pfb['dnsbl_ip'] != 'Disabled' &&
-															    pfb_dnsbl_collect_feed_ip($csvline[0], $line, $custom, $domain_data_ip, $domain_data_ip6)) {
-																$pfb['updateip'] = TRUE;
-																$ipcount++;
-															}
-														}
-														break;
-													case 'et':
-														if ($csv_count == 3) {
-															$line		= $csvline[0];
-															$csv_found	= TRUE;
-														}
-														break;
-													default:
-
-														// Parse Phishtank Feed
-														if (strpos($line, 'phish_id,url,'
-																. 'phish_detail_url') !== FALSE) {
-															$csv_type = 'pt';
-															continue 2;
-														}
-
-														// Parse Bambenek Consulting Feed
-														elseif (strpos($csvline[3], 'osint.'
-															. 'bambenekconsulting.com') !== FALSE) {
-															$csv_type	= 'bbc';
-															$line		= $csvline[0];
-															$csv_found	= TRUE;
-														}
-
-														// Parse Alienvault OTX pulse Feed
-														elseif ($line == 'Indicator type,Indicator,'
-																. 'Description') {
-															$csv_type	= 'otx';
-															continue 2;
-														}
-
-														// Parse Ponomocup Feed
-														elseif (strpos($csvline[0], 'timestamp') !== FALSE) {
-															$csv_type	= 'pon';
-															continue 2;
-														}
-
-														// Parse Proofpoint/ET IQRisk IPRep Feed
-														elseif ($line == 'domain, category, score') {
-															$csv_type	= 'et';
-															continue 2;
-														}
-
-														// Reset variables for CSV determination
-														else {
-															$csv_parser = $run_once = FALSE;
-														}
-														break;
-												}
-
-												// Record Failed CSV Parse event
-												if (!$csv_found || empty($csv_type)) {
-													pfb_parsed_fail($header, '', $oline, $pfb['dnsbl_parse_err'], $dnsbl_lineno);
-													continue;
-												}
+											// issue #1118: pfb_dnsbl_csv_extract() owns the whole upstream-CSV
+											// classify/extract switch (unit-tested off-appliance); action='skip'
+											// matches every one of the original block's `continue`/`continue 2` sites.
+											$csv_result = pfb_dnsbl_csv_extract($line, $csvline, $csv_type, $csv_parser,
+												$run_once, $alienvault_types, $pfb['dnsbl_ip'] != 'Disabled', $custom,
+												$domain_data_ip, $domain_data_ip6, $header, $oline, $dnsbl_lineno,
+												$pfb['dnsbl_parse_err']);
+											$line		= $csv_result['line'];
+											$csv_type	= $csv_result['csv_type'];
+											$csv_parser	= $csv_result['csv_parser'];
+											$run_once	= $csv_result['run_once'];
+											if ($csv_result['ip_collected']) {
+												$pfb['updateip'] = TRUE;
+												$ipcount++;
+											}
+											if ($csv_result['action'] === 'skip') {
+												continue;
 											}
 											$line = trim($line);
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7236,8 +7236,9 @@ function pfb_dnsbl_csv_extract(string $line, array $csvline, string $csv_type, b
 				return $result('skip');
 			}
 
-			// Parse Bambenek Consulting Feed
-			elseif (strpos($csvline[3], 'osint.'
+			// Parse Bambenek Consulting Feed (issue #1118: guard $csvline[3] -- the
+			// otx/et header lines that reach this sniff are only 3 columns).
+			elseif (strpos($csvline[3] ?? '', 'osint.'
 				. 'bambenekconsulting.com') !== FALSE) {
 				$csv_type	= 'bbc';
 				$line		= $csvline[0];

--- a/tests/php/PfbDnsblCsvExtractTest.php
+++ b/tests/php/PfbDnsblCsvExtractTest.php
@@ -315,4 +315,23 @@ final class PfbDnsblCsvExtractTest extends TestCase
 		$this->assertFalse($r['run_once'], 'no header match must reset run_once to FALSE');
 		$this->assertStringContainsString($line, (string) file_get_contents($this->parseErr));
 	}
+
+	// issue #1118: the real otx/et feed headers are 3-column lines, so the default
+	// case's bbc sniff must not access an undefined $csvline[3] (a spurious PHP
+	// warning on every otx/et feed's header line). Any E_WARNING fails this test.
+	public function testShortFirstLineDoesNotWarnOnBbcSniffColumnThree(): void
+	{
+		$line = 'Indicator type,Indicator,Description';   // real otx header: 3 fields, no $csvline[3]
+		$csvline = str_getcsv($line, ',', '"', '"');
+		set_error_handler(static function (int $errno, string $errstr): bool {
+			throw new \RuntimeException("unexpected PHP warning: {$errstr}");
+		}, E_WARNING);
+		try {
+			$r = $this->extract($line, $csvline, '', TRUE);
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame('skip', $r['action']);
+		$this->assertSame('otx', $r['csv_type'], 'the 3-column line must still classify as otx');
+	}
 }

--- a/tests/php/PfbDnsblCsvExtractTest.php
+++ b/tests/php/PfbDnsblCsvExtractTest.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_csv_extract() -- issue #1118 extraction of the DNSBL download/parse
+ * loop's 6-type upstream-CSV classify/extract switch (`if ($csv_parser) { ... }`)
+ * into a pure, unit-testable helper, mirroring pfb_dnsbl_extract_host()'s
+ * sentinel-action return contract. Pins every case's column-count guard + the
+ * extracted column, the h3x/otx skip-without-fail sites, the pon IP side-effect
+ * (via pfb_dnsbl_collect_feed_ip), the 5 header-autodetect sub-branches, and the
+ * no-match reset that re-arms the caller's autodetect from scratch.
+ */
+#[CoversFunction('pfb_dnsbl_csv_extract')]
+final class PfbDnsblCsvExtractTest extends TestCase
+{
+	private string $parseErr = '';
+	private array $alienvaultTypes;
+
+	protected function setUp(): void
+	{
+		$this->parseErr = tempnam(sys_get_temp_dir(), 'pfbcsvextract');
+		@unlink($this->parseErr);
+		$this->alienvaultTypes = array_flip(['domain', 'hostname', 'URL']);
+
+		// pon's IP collection routes through pfb_dnsbl_collect_feed_ip() ->
+		// sanitize_ipaddr(), which reads $pfb['supp'] -- suppression OFF matches
+		// Adr62DnsblCollectFeedIpTest's setUp.
+		$GLOBALS['pfb']['supp'] = 'off';
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->parseErr !== '' && is_file($this->parseErr)) {
+			unlink($this->parseErr);
+		}
+	}
+
+	private function extract(string $line, array $csvline, string $csvType, bool $csvParser,
+		bool $runOnce = TRUE, bool $dnsblIpEnabled = TRUE): array
+	{
+		$ip4 = [];
+		$ip6 = [];
+		return pfb_dnsbl_csv_extract($line, $csvline, $csvType, $csvParser, $runOnce,
+			$this->alienvaultTypes, $dnsblIpEnabled, FALSE, $ip4, $ip6, 'hdr', $line, 5, $this->parseErr);
+	}
+
+	// -- $csv_parser === FALSE: pure passthrough (mirrors "first line has <2 commas") --
+
+	public function testCsvParserFalseIsPureNoOp(): void
+	{
+		// Block A (the caller, untouched by this extraction) never flipped
+		// csv_parser TRUE -- the helper must do nothing at all.
+		$r = $this->extract('unrelated line', ['unrelated', 'line'], 'pt', FALSE, TRUE);
+		$this->assertSame('use', $r['action']);
+		$this->assertSame('unrelated line', $r['line']);
+		$this->assertSame('pt', $r['csv_type'], 'csv_type must pass through unchanged');
+		$this->assertFalse($r['csv_parser']);
+		$this->assertTrue($r['run_once']);
+		$this->assertFalse($r['ip_collected']);
+		$this->assertFileDoesNotExist($this->parseErr, 'a passthrough must never touch the parse-error log');
+	}
+
+	// -- pt (Phishtank): 8 columns, col-1, space-stripped -----------------------------
+
+	public function testPtWithEightColumnsAndSpaceInColumnOneStripsSpaces(): void
+	{
+		$csvline = ['1', 'http://evil example.com', 'detail', '', '', '', '', ''];
+		$r = $this->extract('raw', $csvline, 'pt', TRUE);
+		$this->assertSame('use', $r['action']);
+		$this->assertSame('http://evilexample.com', $r['line']);
+	}
+
+	public function testPtWithEightColumnsAndNoSpaceInColumnOneUsesAsIs(): void
+	{
+		$csvline = ['1', 'http://evil.example.com', 'detail', '', '', '', '', ''];
+		$r = $this->extract('raw', $csvline, 'pt', TRUE);
+		$this->assertSame('use', $r['action']);
+		$this->assertSame('http://evil.example.com', $r['line']);
+	}
+
+	public function testPtWithWrongColumnCountFails(): void
+	{
+		$csvline = ['1', 'http://x']; // 2 cols, not 8
+		$r = $this->extract('raw-pt', $csvline, 'pt', TRUE);
+		$this->assertSame('skip', $r['action']);
+		$this->assertStringContainsString('raw-pt', (string) file_get_contents($this->parseErr));
+	}
+
+	// -- bbc (Bambenek): 4 columns, col-0 ----------------------------------------------
+
+	public function testBbcWithFourColumnsExtractsColumnZero(): void
+	{
+		$csvline = ['bbc-malicious.example.com', 'x', 'y', 'z'];
+		$r = $this->extract('raw', $csvline, 'bbc', TRUE);
+		$this->assertSame('use', $r['action']);
+		$this->assertSame('bbc-malicious.example.com', $r['line']);
+	}
+
+	public function testBbcWithWrongColumnCountFails(): void
+	{
+		$csvline = ['bbc-malicious.example.com', 'x']; // 2 cols, not 4
+		$r = $this->extract('raw-bbc', $csvline, 'bbc', TRUE);
+		$this->assertSame('skip', $r['action']);
+		$this->assertStringContainsString('raw-bbc', (string) file_get_contents($this->parseErr));
+	}
+
+	// Hostile input: a quoted CSV field with an embedded comma is ONE column after
+	// str_getcsv() (the CALLER's job) -- the helper must read it verbatim, never
+	// re-split it.
+	public function testBbcColumnWithEmbeddedCommaFromQuotedFieldSurvivesIntact(): void
+	{
+		$csvline = str_getcsv('"sub,domain.example.com",x,y,z', ',', '"', '"');
+		$this->assertCount(4, $csvline, 'sanity: str_getcsv must merge the quoted comma into ONE field');
+		$r = $this->extract('raw', $csvline, 'bbc', TRUE);
+		$this->assertSame('use', $r['action']);
+		$this->assertSame('sub,domain.example.com', $r['line']);
+	}
+
+	// -- h3x (hostsfile): 8 columns, col-2, btc:// skip --------------------------------
+
+	public function testH3xWithEightColumnsExtractsColumnTwo(): void
+	{
+		$csvline = ['a', 'b', 'normal.example.com', 'd', 'e', 'f', 'g', 'h'];
+		$r = $this->extract('raw', $csvline, 'h3x', TRUE);
+		$this->assertSame('use', $r['action']);
+		$this->assertSame('normal.example.com', $r['line']);
+	}
+
+	public function testH3xBtcSchemeInColumnTwoSkipsWithoutFailRecord(): void
+	{
+		$csvline = ['a', 'b', 'btc://1abcDEF', 'd', 'e', 'f', 'g', 'h'];
+		$r = $this->extract('raw', $csvline, 'h3x', TRUE);
+		$this->assertSame('skip', $r['action']);
+		$this->assertFileDoesNotExist($this->parseErr, 'a btc:// skip must NOT record a parse-error');
+	}
+
+	public function testH3xWithWrongColumnCountFails(): void
+	{
+		$csvline = ['a', 'b', 'c']; // 3 cols, not 8
+		$r = $this->extract('raw-h3x', $csvline, 'h3x', TRUE);
+		$this->assertSame('skip', $r['action']);
+		$this->assertStringContainsString('raw-h3x', (string) file_get_contents($this->parseErr));
+	}
+
+	// -- otx (AlienVault OTX): 3 columns, col-1 gated by a known indicator type -------
+
+	public function testOtxWithKnownIndicatorTypeExtractsColumnOne(): void
+	{
+		$csvline = ['domain', 'malicious.example.com', 'desc'];
+		$r = $this->extract('raw', $csvline, 'otx', TRUE);
+		$this->assertSame('use', $r['action']);
+		$this->assertSame('malicious.example.com', $r['line']);
+	}
+
+	public function testOtxWithUnknownIndicatorTypeSkipsWithoutFailRecord(): void
+	{
+		$csvline = ['FileHash-MD5', 'deadbeef', 'desc'];
+		$r = $this->extract('raw', $csvline, 'otx', TRUE);
+		$this->assertSame('skip', $r['action']);
+		$this->assertFileDoesNotExist($this->parseErr, 'an unknown indicator type must NOT record a parse-error');
+	}
+
+	public function testOtxWithWrongColumnCountFails(): void
+	{
+		$csvline = ['domain', 'malicious.example.com']; // 2 cols, not 3
+		$r = $this->extract('raw-otx', $csvline, 'otx', TRUE);
+		$this->assertSame('skip', $r['action']);
+		$this->assertStringContainsString('raw-otx', (string) file_get_contents($this->parseErr));
+	}
+
+	// -- pon (Ponmocup): 9 columns, col-2, plus the col-0-guarded IP side-effect ------
+
+	public function testPonWithNineColumnsExtractsColumnTwoDomain(): void
+	{
+		// Typical shape: col-0 is a non-IP value (e.g. a timestamp), so
+		// pfb_dnsbl_collect_feed_ip()'s is_ipaddrv4/6($guard_value) family check
+		// never passes -- the domain is still extracted, nothing is collected.
+		$csvline = ['2024-01-01T00:00:00Z', 'x', 'malicious-pon.example.com', 'd', 'e', 'f', 'g', 'h', 'i'];
+		$ip4 = [];
+		$ip6 = [];
+		$r = pfb_dnsbl_csv_extract('raw', $csvline, 'pon', TRUE, TRUE, $this->alienvaultTypes,
+			TRUE, FALSE, $ip4, $ip6, 'hdr', 'raw', 5, $this->parseErr);
+		$this->assertSame('use', $r['action']);
+		$this->assertSame('malicious-pon.example.com', $r['line']);
+		$this->assertFalse($r['ip_collected']);
+		$this->assertSame([], $ip4);
+	}
+
+	public function testPonWithIpv4GuardAndCandidateCollectsTheCandidate(): void
+	{
+		// pfb_dnsbl_collect_feed_ip()'s asymmetry (Adr62DnsblCollectFeedIpTest):
+		// csvline[0] (guard) drives ONLY the family check; the appended value is
+		// the CANDIDATE (csvline[2], i.e. $line) -- proving the pon call site's
+		// guard-vs-candidate wiring survived the extraction unchanged.
+		$csvline = ['198.51.100.7', 'x', '198.51.100.20', 'd', 'e', 'f', 'g', 'h', 'i'];
+		$ip4 = [];
+		$ip6 = [];
+		$r = pfb_dnsbl_csv_extract('raw', $csvline, 'pon', TRUE, TRUE, $this->alienvaultTypes,
+			TRUE, FALSE, $ip4, $ip6, 'hdr', 'raw', 5, $this->parseErr);
+		$this->assertSame('use', $r['action']);
+		$this->assertSame('198.51.100.20', $r['line']);
+		$this->assertTrue($r['ip_collected']);
+		$this->assertSame(['198.51.100.20'], $ip4);
+	}
+
+	public function testPonIpCollectionGatedByDnsblIpEnabled(): void
+	{
+		$csvline = ['198.51.100.8', 'x', '198.51.100.21', 'd', 'e', 'f', 'g', 'h', 'i'];
+		$ip4 = [];
+		$ip6 = [];
+		$r = pfb_dnsbl_csv_extract('raw', $csvline, 'pon', TRUE, TRUE, $this->alienvaultTypes,
+			FALSE, FALSE, $ip4, $ip6, 'hdr', 'raw', 5, $this->parseErr);
+		$this->assertSame('use', $r['action']);
+		$this->assertFalse($r['ip_collected'], 'dnsbl_ip Disabled must gate the IP collection off');
+		$this->assertSame([], $ip4, 'no IP must land when dnsbl_ip is Disabled');
+	}
+
+	public function testPonWithWrongColumnCountFails(): void
+	{
+		$csvline = ['198.51.100.9', 'x', 'y']; // 3 cols, not 9
+		$ip4 = [];
+		$ip6 = [];
+		$r = pfb_dnsbl_csv_extract('raw-pon', $csvline, 'pon', TRUE, TRUE, $this->alienvaultTypes,
+			TRUE, FALSE, $ip4, $ip6, 'hdr', 'raw-pon', 5, $this->parseErr);
+		$this->assertSame('skip', $r['action']);
+		$this->assertStringContainsString('raw-pon', (string) file_get_contents($this->parseErr));
+	}
+
+	// -- et (Proofpoint/ET): 3 columns, col-0 ------------------------------------------
+
+	public function testEtWithThreeColumnsExtractsColumnZero(): void
+	{
+		$csvline = ['et-malicious.example.com', 'category', 'score'];
+		$r = $this->extract('raw', $csvline, 'et', TRUE);
+		$this->assertSame('use', $r['action']);
+		$this->assertSame('et-malicious.example.com', $r['line']);
+	}
+
+	public function testEtWithWrongColumnCountFails(): void
+	{
+		$csvline = ['et-malicious.example.com', 'category']; // 2 cols, not 3
+		$r = $this->extract('raw-et', $csvline, 'et', TRUE);
+		$this->assertSame('skip', $r['action']);
+		$this->assertStringContainsString('raw-et', (string) file_get_contents($this->parseErr));
+	}
+
+	// -- default: header autodetect (csv_type not yet known) ---------------------------
+
+	public function testDefaultDetectsPtHeaderAndSkipsWithoutFailRecord(): void
+	{
+		$line = 'phish_id,url,phish_detail_url,submission_time,verified,verification_time,online,target';
+		$csvline = str_getcsv($line, ',', '"', '"');
+		$r = $this->extract($line, $csvline, '', TRUE);
+		$this->assertSame('skip', $r['action']);
+		$this->assertSame('pt', $r['csv_type']);
+		$this->assertFileDoesNotExist($this->parseErr);
+	}
+
+	public function testDefaultDetectsBbcHeaderAndUsesColumnZero(): void
+	{
+		$line = 'bbc-detected.example.com,x,y,osint.bambenekconsulting.com';
+		$csvline = str_getcsv($line, ',', '"', '"');
+		$r = $this->extract($line, $csvline, '', TRUE);
+		$this->assertSame('use', $r['action']);
+		$this->assertSame('bbc', $r['csv_type']);
+		$this->assertSame('bbc-detected.example.com', $r['line']);
+	}
+
+	public function testDefaultDetectsOtxHeaderAndSkipsWithoutFailRecord(): void
+	{
+		$line = 'Indicator type,Indicator,Description';
+		$csvline = str_getcsv($line, ',', '"', '"');
+		$r = $this->extract($line, $csvline, '', TRUE);
+		$this->assertSame('skip', $r['action']);
+		$this->assertSame('otx', $r['csv_type']);
+		$this->assertFileDoesNotExist($this->parseErr);
+	}
+
+	public function testDefaultDetectsPonHeaderAndSkipsWithoutFailRecord(): void
+	{
+		$line = 'timestamp,ip,domain,x,y,z,a,b,c';
+		$csvline = str_getcsv($line, ',', '"', '"');
+		$r = $this->extract($line, $csvline, '', TRUE);
+		$this->assertSame('skip', $r['action']);
+		$this->assertSame('pon', $r['csv_type']);
+		$this->assertFileDoesNotExist($this->parseErr);
+	}
+
+	public function testDefaultDetectsEtHeaderAndSkipsWithoutFailRecord(): void
+	{
+		$line = 'domain, category, score';
+		$csvline = str_getcsv($line, ',', '"', '"');
+		$r = $this->extract($line, $csvline, '', TRUE);
+		$this->assertSame('skip', $r['action']);
+		$this->assertSame('et', $r['csv_type']);
+		$this->assertFileDoesNotExist($this->parseErr);
+	}
+
+	public function testDefaultWithNoHeaderMatchResetsStateAndFails(): void
+	{
+		// Autodetect's first-line false positive (issue #1118 brief): a
+		// comma-bearing but non-CSV domain line reaches here with csv_type still
+		// '' -- no header matches, so the helper resets csv_parser/run_once (the
+		// caller's autodetect must re-arm from scratch on the NEXT line) and
+		// records the parse failure for THIS line only.
+		$line = 'uuid-example.com,a,b,c';
+		$csvline = str_getcsv($line, ',', '"', '"');
+		$r = $this->extract($line, $csvline, '', TRUE, TRUE);
+		$this->assertSame('skip', $r['action']);
+		$this->assertFalse($r['csv_parser'], 'no header match must reset csv_parser to FALSE');
+		$this->assertFalse($r['run_once'], 'no header match must reset run_once to FALSE');
+		$this->assertStringContainsString($line, (string) file_get_contents($this->parseErr));
+	}
+}

--- a/tests/smoke/test_smoke_adr62.py
+++ b/tests/smoke/test_smoke_adr62.py
@@ -306,8 +306,9 @@ def test_adr62_bracketed_ipv6_dnsblip_vs_adblock_marker(deployed_vm: SmokeVM, cl
 # --------------------------------------------------------------------------- #
 # Row 5 — a representative CSV feed type (Bambenek Consulting 'bbc': 4-col CSV,
 # domain detected via csvline[3] containing 'osint.bambenekconsulting.com'). The
-# CSV switch (inc:16508-16609) is untouched by this ADR (§2 item 3, "Explicitly
-# kept / out of scope" — CSV column extraction stays in PHP unchanged).
+# CSV classify/extract switch is now pfb_dnsbl_csv_extract() (issue #1118),
+# unit-tested off-appliance by PfbDnsblCsvExtractTest; this row is its live
+# end-to-end wiring proof (the download loop has no other off-appliance driver).
 # --------------------------------------------------------------------------- #
 
 
@@ -317,9 +318,8 @@ def test_adr62_csv_bambenek_feed_blocks(deployed_vm: SmokeVM, client_vm: SmokeVM
 
     Given the CSV row's domain (col 0) RESOLVES via the stub before the feed loads.
     When a single-line 4-column CSV body (``domain,comment,date,url``, with col 3
-      containing ``osint.bambenekconsulting.com`` — the detection marker
-      ``pfblockerng.inc:16574-16580``) loads,
-    Then the domain is VIP-blocked — the CSV switch (untouched by this ADR)
+      containing ``osint.bambenekconsulting.com`` — the bbc detection marker) loads,
+    Then the domain is VIP-blocked — ``pfb_dnsbl_csv_extract()`` (issue #1118)
       extracts col 0 and the extracted domain flows through the SAME plain
       pipeline (host-prefix/scheme/IDN/pfb_filter) as any other domain line.
     """

--- a/tests/smoke/test_smoke_adr62.py
+++ b/tests/smoke/test_smoke_adr62.py
@@ -341,7 +341,7 @@ def test_adr62_csv_bambenek_feed_blocks(deployed_vm: SmokeVM, client_vm: SmokeVM
 
 # --------------------------------------------------------------------------- #
 # Row 6 — a raw (non-punycode) IDN feed line blocks under its punycode form.
-# PHP's idn_to_ascii() converts at parse time (pfblockerng.inc:16713); Python
+# PHP's idn_to_ascii() converts at parse time (pfblockerng.inc); Python
 # never converts (ADR §1.5) — the query MUST use the already-converted form.
 # ``café-adr62row6.com`` -> ``xn--caf-adr62row6-dhb.com``, verified against the
 # REAL idn_to_ascii() this session (`php -r 'echo idn_to_ascii(...)'`) — a fixed


### PR DESCRIPTION
## What

Extract the upstream-CSV feed parsing block out of the DNSBL download/parse loop in `sync_package_pfblockerng()` into a pure, unit-testable helper `pfb_dnsbl_csv_extract()` — the same behaviour-preserving move #1117 made for the host-munging pipeline (`pfb_dnsbl_extract_host()`) and ADR-62 Phase 2 made for the IP collector (`pfb_dnsbl_collect_feed_ip()`). Follows #1117.

Three commits:

1. **Extract `pfb_dnsbl_csv_extract()`** (behaviour-preserving). The ~130-line 6-type CSV switch (`pt`/`bbc`/`h3x`/`otx`/`pon`/`et` + the 5-branch header autodetect) moves verbatim into a pure helper placed beside its callees (`pfb_dnsbl_hash_line_classify()` / `pfb_dnsbl_collect_feed_ip()`). Every `continue 2` / fail-path `continue` becomes an `action='use'|'skip'` the caller applies with its own `continue` (a `switch` this shape cannot move into a function verbatim — a bare `continue` inside a function only exits the `switch`). The CSV state (`csv_parser`/`csv_type`/`run_once`) is returned for the caller to write back; the `pon` IP side-effect keeps reusing `pfb_dnsbl_collect_feed_ip()` unchanged; the autodetect and blank-line skip stay in the caller. No column index, count guard, header string, or ordering changed.

2. **Guard the `bbc` header sniff against a <4-column first line.** Surfaced by the new unit tests: the default-case Bambenek sniff reads `$csvline[3]`, but it runs *before* the `otx`/`et` sniffs, whose real feed headers (`Indicator type,Indicator,Description` and `domain, category, score`) are only 3 columns — so every `otx`/`et` feed's header line emitted an `Undefined array key 3` PHP warning. Pre-existing (verbatim-moved from the old inline block); the `?? ''` guard is behaviour-neutral on the parse result (the undefined value was already coerced to a non-match), it only removes the spurious warning.

3. **Refresh Row 5's stale smoke comment** (it cited the old inline switch's line range and called it "untouched" — now points at the helper + its unit test).

## Why

The CSV logic was reachable only through `sync_package_pfblockerng()`, which has no off-appliance test driver — every CSV-type branch was untestable in isolation. Extraction makes all 6 types, the header autodetect, the `continue 2` edges, and the `pon` IP side-effect directly unit-testable, and shrinks the loop body substantially.

## Testing

- **`PfbDnsblCsvExtractTest.php`** (26 tests): every type's column-count guard + extracted column (expected values derived from each CSV format, not from the new code), the `h3x` `btc://` and `otx` unknown-type skip-without-fail sites, the `pon` IP side-effect via `pfb_dnsbl_collect_feed_ip()`, all 5 header-autodetect sub-branches, the no-header-match state reset (the autodetect first-line false-positive edge), the `csv_parser=FALSE` passthrough, a quoted-embedded-comma hostile input, and the `<4-column` sniff-guard regression (red→green: `Undefined array key 3` before the guard, clean after).
- **Behaviour-preservation is proven live**: the `bbc` CSV smoke row (`test_adr62_csv_bambenek_feed_blocks`) — the only end-to-end driver of this switch, since the ADR-62 byte-identity corpus consumes already-post-extraction `.raw` fixtures and is structurally blind to it — was run GREEN on a live pfSense VM **before** the extraction (baseline) and GREEN **after**, unchanged.
- ADR-62 corpus oracles + full PHPUnit (3106) + PHPStan + PHPCS + pytest all green.

Fixes #1118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNSBL CSV parsing across supported feed formats.
  * Added safer automatic format detection and clearer handling of malformed or unsupported rows.
  * Prevented warnings when processing short or incomplete CSV headers.
  * Improved conditional IP address collection for applicable feeds.

* **Tests**
  * Added comprehensive coverage for CSV extraction, validation, format detection, error handling, and IP collection.
  * Updated smoke-test documentation to reflect the current CSV processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->