### PR TITLE
pfblockerng: extract testable DNSBL finalize helpers (pfb_dnsblip_finalize + pfb_dnsbl_py_swap) (#1127)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -17769,7 +17769,7 @@ function sync_package_pfblockerng($cron='') {
 			if (pfb_dnsbl_concat_files("{$pfb['dnsbl_file']}.raw", $pfb_dnsbl_sources)) {
 				pfb_logger("... completed", 1);
 
-				pfb_dnsbl_py_swap($pfb['dnsbl_tld'], "{$pfb['dnsbl_file']}.raw", $pfb['unbound_py_data'], $pfb['unbound_py_zone']);
+				pfb_dnsbl_py_swap((bool) $pfb['dnsbl_tld'], "{$pfb['dnsbl_file']}.raw", $pfb['unbound_py_data'], $pfb['unbound_py_zone']);
 
 				// ADR-06: Write the per-feed manifest + IP-stripped raw that the Python
 				// plugin's init builds the DNSBL structures from. Python then owns

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1905,10 +1905,9 @@ function pfb_dnsblip_mark_reprocess($action, string $vtype): void {
 	}
 }
 
-// issue #1097/#1127: DNSBLIP v4/v6 post-build bookkeeping, extracted verbatim out of the
-// two call sites so it is unit-testable. A failed rebuild ($built = FALSE) must not
-// advance the fingerprint -- a stamped .fp marks the stale output current and suppresses
-// every future retry.
+// DNSBLIP v4/v6 post-build bookkeeping (.fp stamp / ip_cache flush / reprocess marker).
+// issue #1097: a failed rebuild ($built = FALSE) must NOT advance the fingerprint -- a
+// stamped .fp marks the stale output current and suppresses every future retry.
 function pfb_dnsblip_finalize(string $dnsblip, string $fp, bool $built, string $ip_cache, $action, string $vtype): void {
 	if (!$built) {
 		return;
@@ -1951,8 +1950,8 @@ function pfb_dnsbl_concat_files(string $dest, array $sources): bool {
 	return FALSE;
 }
 
-// DNSBL Python blocking mode publish, if TLD is not enabled -- extracted verbatim out of
-// the concat-success branch (issue #1097/#1127) so it is unit-testable.
+// DNSBL Python blocking-mode publish (ADR-10 stage step), if TLD mode is off. issue #1097:
+// only ever called from the concat-success branch, so the rename source .raw exists.
 function pfb_dnsbl_py_swap(bool $dnsbl_tld, string $raw, string $py_data, string $py_zone): void {
 	if ($dnsbl_tld) {
 		return;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1905,6 +1905,19 @@ function pfb_dnsblip_mark_reprocess($action, string $vtype): void {
 	}
 }
 
+// issue #1097/#1127: DNSBLIP v4/v6 post-build bookkeeping, extracted verbatim out of the
+// two call sites so it is unit-testable. A failed rebuild ($built = FALSE) must not
+// advance the fingerprint -- a stamped .fp marks the stale output current and suppresses
+// every future retry.
+function pfb_dnsblip_finalize(string $dnsblip, string $fp, bool $built, string $ip_cache, $action, string $vtype): void {
+	if (!$built) {
+		return;
+	}
+	@file_put_contents("{$dnsblip}.fp", $fp, LOCK_EX);
+	unlink_if_exists($ip_cache);
+	pfb_dnsblip_mark_reprocess($action, $vtype);
+}
+
 // Only an exact full-length fwrite() counts as written -- FALSE or a short (disk-full)
 // write must fail the assembly, or a truncated destination would advance the rebuild
 // bookkeeping as current. Same rule as pfb_prefetch_pattern_file_write_ok().
@@ -1936,6 +1949,24 @@ function pfb_dnsbl_concat_files(string $dest, array $sources): bool {
 	}
 	pfb_logger("\nDNSBL: failed to open [ {$dest} ] for writing", 2);
 	return FALSE;
+}
+
+// DNSBL Python blocking mode publish, if TLD is not enabled -- extracted verbatim out of
+// the concat-success branch (issue #1097/#1127) so it is unit-testable.
+function pfb_dnsbl_py_swap(bool $dnsbl_tld, string $raw, string $py_data, string $py_zone): void {
+	if ($dnsbl_tld) {
+		return;
+	}
+	unlink_if_exists($py_data);
+	unlink_if_exists($py_zone);
+	// ADR-10: keep pfb_py_count across a feed/cron rebuild. The zero-downtime
+	// fast path's RAM gate (pfb_unbound_py_swap_fits_ram) reads this LIVE count
+	// to project the build's ~2x transient; removing it mid-update fail-closed the
+	// gate to a RESTART on EVERY feed/cron update, so the swap could never engage
+	// for the most common case. The Python build overwrites it with the new count
+	// on swap, so the stale value lives only for the brief publish->swap window.
+	// The clear-all-feeds path (DNSBL going empty -> restart) still clears it.
+	rename($raw, $py_data);
 }
 
 // Non-lite DNSBL host-munging pipeline, extracted pure out of the download/parse loop's
@@ -17674,13 +17705,7 @@ function sync_package_pfblockerng($cron='') {
 			else {
 				$pfb_dnsblip_built = (@file_put_contents($dnsblip_v4, "{$pfb['ip_ph']}\n", LOCK_EX) !== FALSE);
 			}
-			// issue #1097: a failed rebuild must not advance the fingerprint -- a stamped
-			// .fp marks the stale output current and suppresses every future retry.
-			if ($pfb_dnsblip_built) {
-				@file_put_contents("{$dnsblip_v4}.fp", $pfb_dnsblip_fp, LOCK_EX);
-				unlink_if_exists($pfb['ip_cache']);
-				pfb_dnsblip_mark_reprocess($pfb['dnsbl_ip'], '_v4');
-			}
+			pfb_dnsblip_finalize($dnsblip_v4, $pfb_dnsblip_fp, $pfb_dnsblip_built, $pfb['ip_cache'], $pfb['dnsbl_ip'], '_v4');
 		}
 	}
 
@@ -17711,12 +17736,7 @@ function sync_package_pfblockerng($cron='') {
 			else {
 				$pfb_dnsblip_built = (@file_put_contents($dnsblip_v6, "::{$pfb['ip_ph']}\n", LOCK_EX) !== FALSE);
 			}
-			// issue #1097: same retry-preserving gate as the v4 path above.
-			if ($pfb_dnsblip_built) {
-				@file_put_contents("{$dnsblip_v6}.fp", $pfb_dnsblip_fp, LOCK_EX);
-				unlink_if_exists($pfb['ip_cache']);
-				pfb_dnsblip_mark_reprocess($pfb['dnsbl_ip'], '_v6');
-			}
+			pfb_dnsblip_finalize($dnsblip_v6, $pfb_dnsblip_fp, $pfb_dnsblip_built, $pfb['ip_cache'], $pfb['dnsbl_ip'], '_v6');
 		}
 	}
 
@@ -17749,19 +17769,7 @@ function sync_package_pfblockerng($cron='') {
 			if (pfb_dnsbl_concat_files("{$pfb['dnsbl_file']}.raw", $pfb_dnsbl_sources)) {
 				pfb_logger("... completed", 1);
 
-				// DNSBL Python blocking mode, if TLD is not enabled
-				if (!$pfb['dnsbl_tld']) {
-					unlink_if_exists($pfb['unbound_py_data']);
-					unlink_if_exists($pfb['unbound_py_zone']);
-					// ADR-10: keep pfb_py_count across a feed/cron rebuild. The zero-downtime
-					// fast path's RAM gate (pfb_unbound_py_swap_fits_ram) reads this LIVE count
-					// to project the build's ~2x transient; removing it mid-update fail-closed the
-					// gate to a RESTART on EVERY feed/cron update, so the swap could never engage
-					// for the most common case. The Python build overwrites it with the new count
-					// on swap, so the stale value lives only for the brief publish->swap window.
-					// The clear-all-feeds path (DNSBL going empty -> restart) still clears it.
-					rename("{$pfb['dnsbl_file']}.raw", $pfb['unbound_py_data']);
-				}
+				pfb_dnsbl_py_swap($pfb['dnsbl_tld'], "{$pfb['dnsbl_file']}.raw", $pfb['unbound_py_data'], $pfb['unbound_py_zone']);
 
 				// ADR-06: Write the per-feed manifest + IP-stripped raw that the Python
 				// plugin's init builds the DNSBL structures from. Python then owns

--- a/tests/php/PfbDnsblPySwapTest.php
+++ b/tests/php/PfbDnsblPySwapTest.php
@@ -52,7 +52,11 @@ final class PfbDnsblPySwapTest extends TestCase
 
 		pfb_dnsbl_py_swap(TRUE, $raw, $pyData, $pyZone);
 
-		$this->assertFileExists($raw, 'TLD mode must leave the .raw untouched');
+		$this->assertSame(
+			'RAW-CONTENT',
+			file_get_contents($raw),
+			'TLD mode must leave the .raw untouched (byte-exact)'
+		);
 		$this->assertSame(
 			'OLD-PY-DATA',
 			file_get_contents($pyData),

--- a/tests/php/PfbDnsblPySwapTest.php
+++ b/tests/php/PfbDnsblPySwapTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_py_swap() master .raw -> Python py_data/py_zone publish (issue #1097/#1127).
+ *
+ * Extracted verbatim from the concat-success branch in sync_package_pfblockerng() so the
+ * !dnsbl_tld gate (drop the stale py_data/py_zone, rename the freshly-assembled .raw into
+ * py_data) is unit-testable without a live sync run.
+ *
+ * Feature: master .raw publish gate
+ *   Branch coverage (dnsbl_tld TRUE/FALSE) + the pre-existing/absent py_data+py_zone axis:
+ *     * dnsbl_tld=TRUE  -> no-op: .raw, py_data, py_zone all untouched
+ *     * dnsbl_tld=FALSE, py_data/py_zone pre-existing -> both dropped, .raw renamed in
+ *     * dnsbl_tld=FALSE, py_data/py_zone absent -> unlink_if_exists no-ops, rename still lands
+ */
+#[CoversFunction('pfb_dnsbl_py_swap')]
+final class PfbDnsblPySwapTest extends TestCase
+{
+	private string $workdir = '';
+
+	protected function setUp(): void
+	{
+		$workdir = tempnam(sys_get_temp_dir(), 'pfbpyswap');
+		$this->assertNotFalse($workdir);
+		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
+		$this->workdir = $workdir;
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			foreach ((array) glob("{$this->workdir}/*") as $f) {
+				@unlink((string) $f);
+			}
+			rmdir($this->workdir);
+		}
+	}
+
+	public function testTldEnabledIsANoOpLeavingRawPyDataAndPyZoneUntouched(): void
+	{
+		$raw    = "{$this->workdir}/dnsbl_file.raw";
+		$pyData = "{$this->workdir}/py_data";
+		$pyZone = "{$this->workdir}/py_zone";
+		file_put_contents($raw, 'RAW-CONTENT');
+		file_put_contents($pyData, 'OLD-PY-DATA');
+		file_put_contents($pyZone, 'OLD-PY-ZONE');
+
+		pfb_dnsbl_py_swap(TRUE, $raw, $pyData, $pyZone);
+
+		$this->assertFileExists($raw, 'TLD mode must leave the .raw untouched');
+		$this->assertSame(
+			'OLD-PY-DATA',
+			file_get_contents($pyData),
+			'TLD mode must leave py_data untouched'
+		);
+		$this->assertSame(
+			'OLD-PY-ZONE',
+			file_get_contents($pyZone),
+			'TLD mode must leave py_zone untouched'
+		);
+	}
+
+	public function testTldDisabledWithExistingPyDataAndZoneRenamesRawInAndRemovesZone(): void
+	{
+		$raw    = "{$this->workdir}/dnsbl_file.raw";
+		$pyData = "{$this->workdir}/py_data";
+		$pyZone = "{$this->workdir}/py_zone";
+		file_put_contents($raw, 'FRESH-RAW-CONTENT');
+		file_put_contents($pyData, 'OLD-PY-DATA');
+		file_put_contents($pyZone, 'OLD-PY-ZONE');
+
+		pfb_dnsbl_py_swap(FALSE, $raw, $pyData, $pyZone);
+
+		$this->assertFileDoesNotExist($raw, 'the .raw must be consumed by rename(), not left behind');
+		$this->assertFileDoesNotExist($pyZone, 'py_zone must be removed to let the Python init rebuild it');
+		$this->assertSame(
+			'FRESH-RAW-CONTENT',
+			file_get_contents($pyData),
+			'py_data must hold the byte-exact .raw content after the swap'
+		);
+	}
+
+	public function testTldDisabledWithAbsentPyDataAndZoneStillSwapsWithoutError(): void
+	{
+		$raw    = "{$this->workdir}/dnsbl_file.raw";
+		$pyData = "{$this->workdir}/py_data";
+		$pyZone = "{$this->workdir}/py_zone";
+		file_put_contents($raw, 'RAW-ONLY');
+		$this->assertFileDoesNotExist($pyData);
+		$this->assertFileDoesNotExist($pyZone);
+
+		pfb_dnsbl_py_swap(FALSE, $raw, $pyData, $pyZone);
+
+		$this->assertFileDoesNotExist($raw);
+		$this->assertSame(
+			'RAW-ONLY',
+			file_get_contents($pyData),
+			'rename must still succeed when py_data/py_zone never existed'
+		);
+	}
+}

--- a/tests/php/PfbDnsblipFinalizeTest.php
+++ b/tests/php/PfbDnsblipFinalizeTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsblip_finalize() DNSBLIP v4/v6 post-build bookkeeping gate (issue #1097/#1127).
+ *
+ * Extracted verbatim from the two identical finalize blocks in sync_package_pfblockerng()
+ * (the v4 and v6 DNSBLIP call sites) so the $built gate -- .fp fingerprint stamp,
+ * ip_cache flush, reprocess marker -- is unit-testable without a live sync run. The
+ * $built=FALSE branch pins the PR#1114 fix: a failed rebuild must leave the .fp and
+ * ip_cache untouched, or the stale output would look current and suppress every retry.
+ *
+ * Feature: DNSBLIP finalize gate
+ *   Branch coverage (built TRUE/FALSE) + suffix + overwrite + missing-cache no-op:
+ *     * built=TRUE  -> .fp stamped, ip_cache flushed, '.update' marker written
+ *     * built=FALSE -> ip_cache/.fp/marker all untouched (before-state asserted first)
+ *     * missing ip_cache pre-call -> unlink_if_exists no-ops, rest of the gate still runs
+ *     * pre-existing .fp content -> overwritten, not appended
+ *     * '_v4' vs '_v6' -> each drives the identically-shaped marker suffix
+ *     * empty-string fingerprint -> .fp written empty, no crash
+ */
+#[CoversFunction('pfb_dnsblip_finalize')]
+final class PfbDnsblipFinalizeTest extends TestCase
+{
+	private string $workdir = '';
+	private string $denydir = '';
+	private string $nativedir = '';
+
+	/** @var array<string,array{bool,mixed}> Saved globals to restore. */
+	private array $saved = [];
+
+	protected function setUp(): void
+	{
+		$workdir = tempnam(sys_get_temp_dir(), 'pfbfinalize');
+		$this->assertNotFalse($workdir);
+		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
+		$this->workdir = $workdir;
+
+		foreach (['pfb', 'pfbarr', 'config'] as $g) {
+			$this->saved[$g] = [array_key_exists($g, $GLOBALS), $GLOBALS[$g] ?? null];
+		}
+
+		// Real, isolated temp dirs so the reprocess-marker assertions see the actual
+		// on-disk location (mirrors DnsblipMarkerFolderTest's setup).
+		$this->denydir   = "{$this->workdir}/deny";
+		$this->nativedir = "{$this->workdir}/native";
+		mkdir($this->denydir, 0o777, TRUE);
+		mkdir($this->nativedir, 0o777, TRUE);
+
+		$GLOBALS['pfb']['denydir']   = $this->denydir;
+		$GLOBALS['pfb']['nativedir'] = $this->nativedir;
+		$GLOBALS['pfb']['origdir']   = "{$this->workdir}/orig";
+		$GLOBALS['pfb']['reuse']     = '';
+
+		// Advanced keys present but OFF, so the "Invert -> force Native" override never fires.
+		$off = [];
+		foreach (['autoproto', 'autonot', 'autoaddrnot', 'agateway', 'autoports', 'autoaddr'] as $k) {
+			$off["{$k}_in"]  = '';
+			$off["{$k}_out"] = '';
+		}
+		$GLOBALS['config'] = ['installedpackages' => ['pfblockerngdnsblsettings' => ['config' => [0 => $off]]]];
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->saved as $g => [$existed, $value]) {
+			if ($existed) {
+				$GLOBALS[$g] = $value;
+			} else {
+				unset($GLOBALS[$g]);
+			}
+		}
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			$this->rmrf($this->workdir);
+		}
+	}
+
+	private function rmrf(string $dir): void
+	{
+		foreach ((array) glob("{$dir}/*") as $entry) {
+			is_dir((string) $entry) ? $this->rmrf((string) $entry) : @unlink((string) $entry);
+		}
+		@rmdir($dir);
+	}
+
+	public function testBuiltTrueWritesFingerprintFlushesCacheAndMarksReprocess(): void
+	{
+		$dnsblip = "{$this->workdir}/DNSBLIP_v4.txt";
+		$ipCache = "{$this->workdir}/ip_cache.sqlite";
+		file_put_contents($ipCache, 'cache-bytes');
+
+		pfb_dnsblip_finalize($dnsblip, 'FPBYTES123', TRUE, $ipCache, 'Alias_Native', '_v4');
+
+		$this->assertSame(
+			'FPBYTES123',
+			file_get_contents("{$dnsblip}.fp"),
+			'the .fp must hold the exact fingerprint bytes'
+		);
+		$this->assertFileDoesNotExist($ipCache, 'ip_cache must be flushed on a successful build');
+		$this->assertFileExists(
+			"{$this->nativedir}/DNSBLIP_v4.update",
+			'a reprocess marker must land in the action-resolved folder'
+		);
+	}
+
+	public function testBuiltFalseLeavesCacheFpAndMarkerUntouched(): void
+	{
+		$dnsblip = "{$this->workdir}/DNSBLIP_v4.txt";
+		$ipCache = "{$this->workdir}/ip_cache.sqlite";
+		file_put_contents($ipCache, 'cache-bytes');
+
+		// Before: ip_cache exists prior to the call -- assert it so green proves the
+		// FALSE gate PRESERVED it, not merely that it ended up present by coincidence.
+		$this->assertFileExists($ipCache);
+
+		pfb_dnsblip_finalize($dnsblip, 'SHOULD-NOT-WRITE', FALSE, $ipCache, 'Alias_Native', '_v4');
+
+		// After: unchanged -- a failed rebuild must not advance the bookkeeping (#1097).
+		$this->assertFileExists($ipCache, 'ip_cache must survive a failed rebuild ($built=FALSE)');
+		$this->assertFileDoesNotExist("{$dnsblip}.fp", 'no .fp must be written on a failed rebuild');
+		$this->assertFileDoesNotExist(
+			"{$this->nativedir}/DNSBLIP_v4.update",
+			'no reprocess marker on a failed rebuild'
+		);
+	}
+
+	public function testMissingIpCacheIsANoOpNotAnError(): void
+	{
+		$dnsblip = "{$this->workdir}/DNSBLIP_v4.txt";
+		$ipCache = "{$this->workdir}/does-not-exist.sqlite";
+		$this->assertFileDoesNotExist($ipCache);
+
+		pfb_dnsblip_finalize($dnsblip, 'FP', TRUE, $ipCache, 'Alias_Native', '_v4');
+
+		$this->assertSame('FP', file_get_contents("{$dnsblip}.fp"), 'the rest of the gate must still run');
+		$this->assertFileExists("{$this->nativedir}/DNSBLIP_v4.update");
+	}
+
+	public function testPreExistingFpContentIsOverwrittenNotAppended(): void
+	{
+		$dnsblip = "{$this->workdir}/DNSBLIP_v4.txt";
+		file_put_contents("{$dnsblip}.fp", 'OLD-FINGERPRINT-LONGER-THAN-NEW');
+		$ipCache = "{$this->workdir}/ip_cache.sqlite";
+
+		pfb_dnsblip_finalize($dnsblip, 'NEW', TRUE, $ipCache, 'Alias_Native', '_v4');
+
+		$this->assertSame(
+			'NEW',
+			file_get_contents("{$dnsblip}.fp"),
+			'the .fp must be overwritten, not appended to'
+		);
+	}
+
+	public function testV4SuffixWritesV4MarkerOnly(): void
+	{
+		pfb_dnsblip_finalize(
+			"{$this->workdir}/DNSBLIP_v4.txt",
+			'FP',
+			TRUE,
+			"{$this->workdir}/nope",
+			'Alias_Native',
+			'_v4'
+		);
+
+		$this->assertFileExists("{$this->nativedir}/DNSBLIP_v4.update");
+		$this->assertFileDoesNotExist("{$this->nativedir}/DNSBLIP_v6.update");
+	}
+
+	public function testV6SuffixWritesV6MarkerOnly(): void
+	{
+		pfb_dnsblip_finalize(
+			"{$this->workdir}/DNSBLIP_v6.txt",
+			'FP',
+			TRUE,
+			"{$this->workdir}/nope",
+			'Alias_Native',
+			'_v6'
+		);
+
+		$this->assertFileExists("{$this->nativedir}/DNSBLIP_v6.update");
+		$this->assertFileDoesNotExist("{$this->nativedir}/DNSBLIP_v4.update");
+	}
+
+	public function testEmptyFingerprintWithBuiltTrueWritesEmptyFpWithoutCrashing(): void
+	{
+		$dnsblip = "{$this->workdir}/DNSBLIP_v4.txt";
+
+		pfb_dnsblip_finalize($dnsblip, '', TRUE, "{$this->workdir}/nope", 'Alias_Native', '_v4');
+
+		$this->assertSame(
+			'',
+			file_get_contents("{$dnsblip}.fp"),
+			'an empty fingerprint must still write an empty .fp file'
+		);
+	}
+}


### PR DESCRIPTION
## What

Extract the DNSBL rebuild-bookkeeping finalize steps in `sync_package_pfblockerng()` into two pure, unit-testable helpers — a #1097 / PR #1114 follow-up. Behaviour-preserving verbatim extractions:

- **`pfb_dnsblip_finalize(string $dnsblip, string $fp, bool $built, string $ip_cache, $action, string $vtype)`** — the DNSBLIP v4/v6 post-build bookkeeping (write the `.fp` fingerprint, flush `ip_cache`, mark the reprocess folder), gated on the `$built` flag. Both the v4 and v6 call sites now call the identical helper (args differ only in the path + `_v4`/`_v6` suffix); the `if ($built)` gate moved into the helper.
- **`pfb_dnsbl_py_swap(bool $dnsbl_tld, string $raw, string $py_data, string $py_zone)`** — the master-`.raw` → `pfb_py_data` publish step (ADR-10 stage half), gated on `!dnsbl_tld`, inside the concat-success branch. Carries the ADR-10 `pfb_py_count` comment.

## Why

PR #1114 gated this bookkeeping on the build result to fix the #1097 `fwrite`/`fclose` TypeError on an unwritable `dbdir` — but the gate ships with **no test**: `sync_package_pfblockerng()` isn't callable off-appliance, a `chmod` fixture can't simulate the failure (the sync runs as root, which bypasses file permissions), and disk-full isn't deterministic on a VM. The first version of that gate missed the placeholder branch (caught only by review, commit `946aa7ea`) — exactly the defect class a test would catch. Extracting the finalize logic into pure helpers makes each gate branch directly unit-testable with tempdir fixtures.

The `pfb_dnsbl_py_swap` helper is the ADR-10 **stage** step only — the sentinel flip that wakes the reload-watcher lives in the separate `pfb_reload_unbound()` and is untouched.

A second commit casts `$pfb['dnsbl_tld']` to `bool` at the `pfb_dnsbl_py_swap()` call site: the helper types its param `bool`, but `$pfb['dnsbl_tld']` is the raw config value (NULL when the TLD checkbox is unset — the default), so the typed helper threw a fatal `TypeError` on every TLD-off feed update. The original inline `if (!$pfb['dnsbl_tld'])` used it in boolean context (NULL-tolerant); the cast restores that at the boundary, matching every other read of this key. Caught by the DNSBLIP smoke backstop below (red→green).

## Testing

- **`PfbDnsblipFinalizeTest.php`** (7 tests): `built=TRUE` → `.fp` written byte-exact + `ip_cache` flushed + reprocess marker created; **`built=FALSE` → asserts the before-state (`ip_cache` present), then that it survives with no `.fp`/marker** — the exact PR #1114 branch this issue exists to pin; absent `ip_cache` no-ops; pre-existing `.fp` overwritten (not appended); v4/v6 marker suffix routing; empty-fingerprint hostile input.
- **`PfbDnsblPySwapTest.php`** (3 tests): `dnsbl_tld=TRUE` no-op (raw/py_data/py_zone untouched); `dnsbl_tld=FALSE` renames `.raw` byte-exact into `py_data`, removes `py_zone`; absent files no-op without error.
- Behaviour-preservation of the call-site rewiring proven live on a leased pfSense VM (no new smoke row — the existing suite already drives these call sites end-to-end). `test_dnsbl_feed_update_no_restart` went **red→green** across the `py_swap` cast fix (the TypeError above → pass), and `test_dnsblip_dual_stack_partition` correctly populates both `pfB_DNSBLIP_v4`/`_v6` alias tables (the finalize path works) — it fails only on a **pre-existing, unrelated** un-polled `rule_references()` flake that reproduces identically on unmodified `origin/devel` (tracked as #1239).
- Full PHPUnit (3116) + PHPStan + PHPCS green.

Fixes #1127


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNSBL rebuild handling so failed rebuilds do not advance tracking data.
  * Improved DNSBL publishing behavior when TLD mode is disabled, including reliable file replacement and cleanup.
  * Preserved existing data safely when DNSBL publishing is not applicable.

* **Tests**
  * Added coverage for successful and failed rebuilds, fingerprint updates, cache cleanup, reprocessing markers, and v4/v6 behavior.
  * Added coverage for DNSBL publishing with existing or missing output files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->