### PR TITLE
pfblockerng: check rename() before dropping py_zone in pfb_dnsbl_py_swap() (#1241)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1956,16 +1956,14 @@ function pfb_dnsbl_py_swap(bool $dnsbl_tld, string $raw, string $py_data, string
 	if ($dnsbl_tld) {
 		return;
 	}
-	unlink_if_exists($py_data);
-	unlink_if_exists($py_zone);
-	// ADR-10: keep pfb_py_count across a feed/cron rebuild. The zero-downtime
-	// fast path's RAM gate (pfb_unbound_py_swap_fits_ram) reads this LIVE count
-	// to project the build's ~2x transient; removing it mid-update fail-closed the
-	// gate to a RESTART on EVERY feed/cron update, so the swap could never engage
-	// for the most common case. The Python build overwrites it with the new count
-	// on swap, so the stale value lives only for the brief publish->swap window.
-	// The clear-all-feeds path (DNSBL going empty -> restart) still clears it.
-	rename($raw, $py_data);
+	// issue #1241: rename() replaces py_data atomically; only a checked SUCCESS drops
+	// py_zone, so a failed publish leaves both live. ADR-10: pfb_py_count stays --
+	// the RAM gate (pfb_unbound_py_swap_fits_ram) reads it LIVE during the transient.
+	if (@rename($raw, $py_data)) {
+		unlink_if_exists($py_zone);
+		return;
+	}
+	pfb_logger("\nDNSBL: failed to publish [ {$py_data} ] -- keeping the live python data/zone", 2);
 }
 
 // Non-lite DNSBL host-munging pipeline, extracted pure out of the download/parse loop's

--- a/tests/php/PfbDnsblPySwapTest.php
+++ b/tests/php/PfbDnsblPySwapTest.php
@@ -112,9 +112,41 @@ final class PfbDnsblPySwapTest extends TestCase
 	}
 
 	/**
-	 * issue #1241: a FAILED rename() must never have already destroyed py_zone. Force a
-	 * real, unmocked rename() failure by occupying the destination py_data path with a
-	 * directory -- rename(file, existing dir) fails EISDIR/ENOTDIR even as root.
+	 * Run the swap and record every diagnostic it lets ESCAPE unsuppressed. PHP calls a
+	 * custom handler even for a '@'-suppressed diagnostic, so suppression is read off
+	 * error_reporting()'s mask -- which only discriminates under E_ALL, because PHPUnit's
+	 * own runtime mask already excludes E_WARNING.
+	 *
+	 * @return list<string> the escaped diagnostics, one "<errno>: <message>" per entry
+	 */
+	private function swapCapturingEscapedDiagnostics(
+		bool $dnsblTld,
+		string $raw,
+		string $pyData,
+		string $pyZone
+	): array {
+		$escaped  = [];
+		$prevMask = error_reporting(E_ALL);
+		set_error_handler(static function (int $errno, string $errstr) use (&$escaped): bool {
+			if ((error_reporting() & $errno) !== 0) {
+				$escaped[] = "{$errno}: {$errstr}";
+			}
+			return TRUE;
+		});
+		try {
+			pfb_dnsbl_py_swap($dnsblTld, $raw, $pyData, $pyZone);
+		} finally {
+			restore_error_handler();
+			error_reporting($prevMask);
+		}
+		return $escaped;
+	}
+
+	/**
+	 * issue #1241: a FAILED rename() must never have already destroyed py_zone, and must
+	 * not leak a raw PHP warning to the caller. Force a real, unmocked rename() failure by
+	 * occupying the destination py_data path with a directory -- rename(file, existing dir)
+	 * fails EISDIR/ENOTDIR even as root.
 	 */
 	public function testRenameFailurePreservesPyZoneAndRawWhenPyDataOccupiedByDirectory(): void
 	{
@@ -125,7 +157,7 @@ final class PfbDnsblPySwapTest extends TestCase
 		file_put_contents($pyZone, 'LIVE-PY-ZONE-ROW4');
 		$this->assertTrue(mkdir($pyData, 0700), 'setup: occupy py_data with a directory');
 
-		pfb_dnsbl_py_swap(FALSE, $raw, $pyData, $pyZone);
+		$escaped = $this->swapCapturingEscapedDiagnostics(FALSE, $raw, $pyData, $pyZone);
 
 		$this->assertSame(
 			'LIVE-PY-ZONE-ROW4',
@@ -134,6 +166,11 @@ final class PfbDnsblPySwapTest extends TestCase
 		);
 		$this->assertFileExists($raw, 'a failed rename must not consume the .raw source');
 		$this->assertDirectoryExists($pyData, 'the occupying py_data directory must survive a failed rename');
+		$this->assertSame(
+			[],
+			$escaped,
+			'a failed rename must be handled + logged by the swap, never leak a PHP warning'
+		);
 	}
 
 	/** issue #1241: same failed-rename path with py_zone absent -- must stay absent, not fabricated. */
@@ -146,9 +183,14 @@ final class PfbDnsblPySwapTest extends TestCase
 		$this->assertTrue(mkdir($pyData, 0700), 'setup: occupy py_data with a directory');
 		$this->assertFileDoesNotExist($pyZone, 'before-state: no py_zone');
 
-		pfb_dnsbl_py_swap(FALSE, $raw, $pyData, $pyZone);
+		$escaped = $this->swapCapturingEscapedDiagnostics(FALSE, $raw, $pyData, $pyZone);
 
 		$this->assertFileDoesNotExist($pyZone, 'py_zone must not be fabricated by a failed swap');
 		$this->assertFileExists($raw, 'a failed rename must not consume the .raw source');
+		$this->assertSame(
+			[],
+			$escaped,
+			'a failed rename must be handled + logged by the swap, never leak a PHP warning'
+		);
 	}
 }

--- a/tests/php/PfbDnsblPySwapTest.php
+++ b/tests/php/PfbDnsblPySwapTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\TestCase;
  *     * dnsbl_tld=TRUE  -> no-op: .raw, py_data, py_zone all untouched
  *     * dnsbl_tld=FALSE, py_data/py_zone pre-existing -> both dropped, .raw renamed in
  *     * dnsbl_tld=FALSE, py_data/py_zone absent -> unlink_if_exists no-ops, rename still lands
+ *     * issue #1241: dnsbl_tld=FALSE, rename() FAILS (py_data occupied by a directory,
+ *       EISDIR) -> py_zone/.raw must survive untouched, whether py_zone pre-exists or not
  */
 #[CoversFunction('pfb_dnsbl_py_swap')]
 final class PfbDnsblPySwapTest extends TestCase
@@ -35,7 +37,8 @@ final class PfbDnsblPySwapTest extends TestCase
 	{
 		if ($this->workdir !== '' && is_dir($this->workdir)) {
 			foreach ((array) glob("{$this->workdir}/*") as $f) {
-				@unlink((string) $f);
+				$f = (string) $f;
+				is_dir($f) ? @rmdir($f) : @unlink($f);
 			}
 			rmdir($this->workdir);
 		}
@@ -106,5 +109,46 @@ final class PfbDnsblPySwapTest extends TestCase
 			file_get_contents($pyData),
 			'rename must still succeed when py_data/py_zone never existed'
 		);
+	}
+
+	/**
+	 * issue #1241: a FAILED rename() must never have already destroyed py_zone. Force a
+	 * real, unmocked rename() failure by occupying the destination py_data path with a
+	 * directory -- rename(file, existing dir) fails EISDIR/ENOTDIR even as root.
+	 */
+	public function testRenameFailurePreservesPyZoneAndRawWhenPyDataOccupiedByDirectory(): void
+	{
+		$raw    = "{$this->workdir}/dnsbl_file.raw";
+		$pyData = "{$this->workdir}/py_data";
+		$pyZone = "{$this->workdir}/py_zone";
+		file_put_contents($raw, 'FRESH-RAW-CONTENT-ROW4');
+		file_put_contents($pyZone, 'LIVE-PY-ZONE-ROW4');
+		$this->assertTrue(mkdir($pyData, 0700), 'setup: occupy py_data with a directory');
+
+		pfb_dnsbl_py_swap(FALSE, $raw, $pyData, $pyZone);
+
+		$this->assertSame(
+			'LIVE-PY-ZONE-ROW4',
+			file_get_contents($pyZone),
+			'a failed rename must leave py_zone byte-identical, not pre-deleted'
+		);
+		$this->assertFileExists($raw, 'a failed rename must not consume the .raw source');
+		$this->assertDirectoryExists($pyData, 'the occupying py_data directory must survive a failed rename');
+	}
+
+	/** issue #1241: same failed-rename path with py_zone absent -- must stay absent, not fabricated. */
+	public function testRenameFailureWithAbsentPyZoneStaysAbsentAndRawSurvives(): void
+	{
+		$raw    = "{$this->workdir}/dnsbl_file.raw";
+		$pyData = "{$this->workdir}/py_data";
+		$pyZone = "{$this->workdir}/py_zone";
+		file_put_contents($raw, 'FRESH-RAW-CONTENT-ROW5');
+		$this->assertTrue(mkdir($pyData, 0700), 'setup: occupy py_data with a directory');
+		$this->assertFileDoesNotExist($pyZone, 'before-state: no py_zone');
+
+		pfb_dnsbl_py_swap(FALSE, $raw, $pyData, $pyZone);
+
+		$this->assertFileDoesNotExist($pyZone, 'py_zone must not be fabricated by a failed swap');
+		$this->assertFileExists($raw, 'a failed rename must not consume the .raw source');
 	}
 }


### PR DESCRIPTION
Fixes #1241.

## Problem

`pfb_dnsbl_py_swap()` — the ADR-10 DNSBL Python publish stage — unlinked the live `py_data` and `py_zone` **before** an unchecked `rename()` of the assembled `.raw`:

```php
unlink_if_exists($py_data);
unlink_if_exists($py_zone);
rename($raw, $py_data);
```

If the `rename()` fails after the unlinks (unwritable `/var/unbound`, ENOSPC, transient IO error), the previous Python data/zone are gone with no replacement until the next successful rebuild. Pre-existing behaviour, verbatim from the pre-#1127 inline code; the `if (pfb_dnsbl_concat_files(...))` success gate only closed the *never-created `.raw`* case (#1097), not the post-success `rename()` failure.

Triage correction to the issue's framing: with ADR-06 the per-feed manifest is the primary load path (`init_standard()` → `dnsbl_build_from_manifest()`), so a lost `py_data` degrades the fallback interchange file and the Alerts-page feed/group attribution rather than stopping live blocking outright — still a real crash-safety gap, and inconsistent with the codebase's own atomic-publish pattern.

## Fix

`rename()` first and check its result: on the same filesystem it already replaces `py_data` atomically, so the pre-unlink was never needed (the TLD-mode sibling swap at `pfblockerng.inc:8589` and `pfb_unbound_py_atomic_write()` already do it this way). `py_zone` is removed only after a verified success; a failure is logged and leaves both live files intact. `pfb_py_count` still deliberately survives the swap (the zero-downtime RAM gate reads it live).

## Tests

`tests/php/PfbDnsblPySwapTest.php` gains the two failing-rename rows the issue asks for. The failure is a real kernel EISDIR (the destination path is occupied by a directory) driven through the production surface — no mocked `rename()`:

- rename fails, `py_zone` pre-existing → `py_zone` survives byte-identical, `.raw` not consumed (**red before the fix**: `Failed asserting that false is identical to 'LIVE-PY-ZONE-ROW4'` — the old code had already unlinked it; green after, test file frozen byte-identical across the red/green runs)
- rename fails, `py_zone` absent → stays absent, `.raw` survives, no PHP warning escapes

The three existing success-path tests stay unedited and green as the regression pin.

Gates: `php -l`, `vendor/bin/phpunit` (3118 tests, 0 failures), `composer phpstan` (no errors), `composer phpcs` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBkLQcR4cz5QCq6AVjdzuM