### PR TITLE
tests/smoke: fix the DNSBL-IP dual-stack order-dependence, and make the failure self-localising

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -574,7 +574,9 @@ def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
     The ruleset layers use :func:`rule_line_references`, the same match rule
     :func:`rule_references` applies, so the dump cannot contradict the assertion it explains.
     """
-    if not _ALIAS_RE.match(alias):
+    # fullmatch, not match: `$` also matches just before a TRAILING newline, so `match()` would
+    # admit "pfB_x\n" into the PHP string literal below.
+    if not _ALIAS_RE.fullmatch(alias):
         raise ValueError(f"alias must be a bare pf table name ([A-Za-z0-9_]+), got {alias!r}")
 
     # pfSsh.php, not `php -r`: only it can read the config.
@@ -2800,6 +2802,7 @@ def inject_dnsbl_lists(
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         "$g['enable_cb'] = 'on';\n"
         f"config_set_path({_php_str(CFG_GLOBAL)}, $g);\n"
+        f"{_dnsbl_ip_iface_php(primary_spec.dnsbl_ip_action)}"
         f"{_dnsbl_settings_replace_php(settings)}"
         f"config_set_path({_php_str(CFG_DNSBL_LISTS)}, array({lists_php}));\n"
         "write_config('pfBlockerNG smoke: DNSBL multi-list (ADR-31)');\n"
@@ -2808,6 +2811,25 @@ def inject_dnsbl_lists(
     result = php_eval(vm, snippet, timeout=timeout)
     if result.returncode != 0 or "OK" not in result.stdout:
         raise RuntimeError(f"inject_dnsbl_lists failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def _dnsbl_ip_iface_php(dnsbl_ip_action: str | None) -> str:
+    """PHP configuring the firewall interfaces a DNSBL-IP case needs — '' when it isn't one.
+
+    DNSBL-IP reuses the IP-side rule builder, so it needs the SAME inbound/outbound interface
+    config ``_ip_inject_snippet`` sets: without it pfBlockerNG builds the pfB_DNSBLIP_* tables
+    but NO rule (inc:10132). Shared by EVERY DNSBL-IP injection path, so a case can never
+    depend on an IpCase sibling having run first and left the interfaces in the shared config
+    (issue #1239). A domain-only DNSBL case emits nothing and leaves the firewall alone.
+    """
+    if not dnsbl_ip_action:
+        return ""
+    ipset = {"inbound_interface": SMOKE_IP_IFACE, "outbound_interface": SMOKE_IP_IFACE}
+    return (
+        f"$ip = config_get_path({_php_str(CFG_IP_SETTINGS)}, array());\n"
+        f"$ip = array_merge($ip, {_php_kv_array(ipset)});\n"
+        f"config_set_path({_php_str(CFG_IP_SETTINGS)}, $ip);\n"
+    )
 
 
 def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
@@ -2889,19 +2911,7 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
     if spec.custom_domains:
         crlf = "\r\n".join(spec.custom_domains)
         custom_line = f"$list['custom'] = base64_encode({_php_str(crlf)});\n"
-    # DNSBL-IP reuses the IP-side rule builder, so it needs the SAME inbound/outbound
-    # interface config `_ip_inject_snippet` sets: without it pfBlockerNG builds the
-    # pfB_DNSBLIP_* tables but NO rule (inc:10132). Setting it here — not in the tests —
-    # is what keeps a DNSBL-IP case from depending on an IpCase sibling having run first
-    # and left the interfaces behind in the shared config (issue #1239).
-    ip_iface_line = ""
-    if spec.dnsbl_ip_action:
-        ipset = {"inbound_interface": SMOKE_IP_IFACE, "outbound_interface": SMOKE_IP_IFACE}
-        ip_iface_line = (
-            f"$ip = config_get_path({_php_str(CFG_IP_SETTINGS)}, array());\n"
-            f"$ip = array_merge($ip, {_php_kv_array(ipset)});\n"
-            f"config_set_path({_php_str(CFG_IP_SETTINGS)}, $ip);\n"
-        )
+    ip_iface_line = _dnsbl_ip_iface_php(spec.dnsbl_ip_action)
     return (
         # pfBlockerNG must be globally enabled for the DNSBL (and DNSBL-IP)
         # paths to run (inc:793 reads enable_cb; inc:3389/9307 gate on it).

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -553,8 +553,10 @@ def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
     Two very different causes produce that, and only the layer that still has the rule
     tells them apart, so dump all three:
 
-      * CONFIG — ``filter/rule`` rows whose source/destination is ``alias`` (what the
-        pfBlockerNG sync wrote to config.xml);
+      * CONFIG — ``filter/rule`` rows whose source/destination address IS ``alias`` (what the
+        pfBlockerNG sync wrote to config.xml). A rule merely NAMING the alias in its ``descr``
+        does not count: descr is a label, and a label must never satisfy "a rule references
+        this table" — that would report the rule as generated when nothing enforces it;
       * RULES.DEBUG — ``alias`` in ``/tmp/rules.debug`` (what filter_configure emitted);
       * LIVE PF — ``alias`` in ``pfctl -sr``, plus whether the pf table itself exists.
 
@@ -564,40 +566,63 @@ def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
     applied it yet (genuine lag) or pfctl rejected the ruleset; present at all three ⇒ the
     poll read stale state.
 
-    issue #1239: this flake was filed with a fabricated cause ("rule_references does not
-    poll" — it does), so the NEXT occurrence must localise itself instead of being re-guessed.
+    A FAILED PROBE is never a missing rule: if the config read, the rules.debug grep or the
+    pfctl read errors out, the verdict is ``UNPROVEN`` — a broken probe reads as an empty
+    layer, and silently blaming the product for a pfSsh.php error is exactly the
+    misdiagnosis this helper exists to prevent (issue #1239).
+
+    The ruleset layers use :func:`rule_line_references`, the same match rule
+    :func:`rule_references` applies, so the dump cannot contradict the assertion it explains.
     """
     if not _ALIAS_RE.match(alias):
         raise ValueError(f"alias must be a bare pf table name ([A-Za-z0-9_]+), got {alias!r}")
 
-    # CONFIG: pfBlockerNG's auto-rules carry the table name in source/destination address
-    # (descr is a human label), so match the address fields — a descr-only match would miss
-    # a rule whose label was renamed. pfSsh.php, not `php -r`: only it can read the config.
+    # pfSsh.php, not `php -r`: only it can read the config.
     snippet = (
         f"$a='{alias}';\n"
         "$o=array();\n"
         "foreach(config_get_path('filter/rule',array()) as $r){\n"
         "  $s=(string)($r['source']['address']??'');\n"
         "  $d=(string)($r['destination']['address']??'');\n"
-        "  $c=(string)($r['descr']??'');\n"
-        "  if($s===$a||$d===$a||strpos($c,$a)!==FALSE){\n"
-        "    $o[]=$c.'|'.($r['type']??'').'|if='.($r['interface']??'').'|'.($r['ipprotocol']??'')\n"
-        "      .'|src='.$s.'|dst='.$d.'|disabled='.(isset($r['disabled'])?'1':'0');}\n"
+        "  if($s===$a||$d===$a){\n"
+        "    $o[]=(string)($r['descr']??'').'|'.($r['type']??'').'|if='.($r['interface']??'')\n"
+        "      .'|'.($r['ipprotocol']??'').'|src='.$s.'|dst='.$d\n"
+        "      .'|disabled='.(isset($r['disabled'])?'1':'0');}\n"
         "}\n"
         "echo '<<CFG>>'.implode(' ## ',$o).'<<END>>';"
     )
     cfg_res = php_eval(vm, snippet, timeout=timeout)
     cfg = ""
-    if "<<CFG>>" in cfg_res.stdout and "<<END>>" in cfg_res.stdout:
+    # The sentinels are the ONLY proof the snippet ran to completion: pfSsh.php exits 0 even
+    # when the PHP inside it fatals, so rc alone cannot tell a clean empty result from a crash.
+    cfg_ok = cfg_res.returncode == 0 and "<<CFG>>" in cfg_res.stdout and "<<END>>" in cfg_res.stdout
+    if cfg_ok:
         cfg = cfg_res.stdout.split("<<CFG>>", 1)[1].split("<<END>>", 1)[0]
 
+    # grep: rc 0 = matched, rc 1 = no match (a real answer), rc >= 2 = the grep itself failed
+    # (missing/unreadable /tmp/rules.debug) — only the last is an unusable probe.
     dbg = vm.ssh("/usr/bin/grep", "-n", alias, "/tmp/rules.debug", timeout=timeout)
     sr = vm.ssh(PFCTL, "-sr", timeout=timeout)
-    dbg_lines = [ln for ln in dbg.stdout.splitlines() if ln.strip()]
-    live = [ln for ln in sr.stdout.splitlines() if alias in ln]
-    table_exists = alias in pfctl_tables(vm, timeout=timeout)
+    dbg_ok = dbg.returncode in (0, 1)
+    sr_ok = sr.returncode == 0
+    dbg_lines = [ln for ln in dbg.stdout.splitlines() if rule_line_references(ln, alias)]
+    live = [ln for ln in sr.stdout.splitlines() if rule_line_references(ln, alias)]
 
-    if not cfg.strip():
+    tables_res = vm.ssh(PFCTL, "-sTables", timeout=timeout)
+    tables_ok = tables_res.returncode == 0
+    table_exists = alias in [ln.strip() for ln in tables_res.stdout.splitlines()] if tables_ok else None
+
+    broken = [
+        name
+        for name, ok in (("CONFIG(pfSsh)", cfg_ok), ("RULES.DEBUG(grep)", dbg_ok), ("LIVE PF(pfctl -sr)", sr_ok))
+        if not ok
+    ]
+    if broken:
+        stage = (
+            f"UNPROVEN — a probe FAILED ({', '.join(broken)}), so an empty layer below proves nothing. "
+            f"rc: pfSsh={cfg_res.returncode} grep={dbg.returncode} pfctl-sr={sr.returncode}"
+        )
+    elif not cfg.strip():
         stage = f"CONFIG — no filter/rule references {alias}: the rule was NEVER generated (product bug, not lag)"
     elif not dbg_lines:
         stage = "RULES.DEBUG — in config.xml but never emitted into the ruleset (rule generator dropped it)"
@@ -611,7 +636,7 @@ def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
         f"[CONFIG rows] {cfg.strip()}\n"
         f"[RULES.DEBUG {alias}: {len(dbg_lines)}] " + " || ".join(dbg_lines[:12]) + "\n"
         f"[LIVE PF -sr {alias}: {len(live)}] " + " || ".join(live[:6]) + "\n"
-        f"[pf table {alias} exists] {table_exists}"
+        f"[pf table {alias} exists] {'UNKNOWN (pfctl -sTables failed)' if table_exists is None else table_exists}"
     )
 
 
@@ -2864,12 +2889,26 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
     if spec.custom_domains:
         crlf = "\r\n".join(spec.custom_domains)
         custom_line = f"$list['custom'] = base64_encode({_php_str(crlf)});\n"
+    # DNSBL-IP reuses the IP-side rule builder, so it needs the SAME inbound/outbound
+    # interface config `_ip_inject_snippet` sets: without it pfBlockerNG builds the
+    # pfB_DNSBLIP_* tables but NO rule (inc:10132). Setting it here — not in the tests —
+    # is what keeps a DNSBL-IP case from depending on an IpCase sibling having run first
+    # and left the interfaces behind in the shared config (issue #1239).
+    ip_iface_line = ""
+    if spec.dnsbl_ip_action:
+        ipset = {"inbound_interface": SMOKE_IP_IFACE, "outbound_interface": SMOKE_IP_IFACE}
+        ip_iface_line = (
+            f"$ip = config_get_path({_php_str(CFG_IP_SETTINGS)}, array());\n"
+            f"$ip = array_merge($ip, {_php_kv_array(ipset)});\n"
+            f"config_set_path({_php_str(CFG_IP_SETTINGS)}, $ip);\n"
+        )
     return (
         # pfBlockerNG must be globally enabled for the DNSBL (and DNSBL-IP)
         # paths to run (inc:793 reads enable_cb; inc:3389/9307 gate on it).
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         "$g['enable_cb'] = 'on';\n"
         f"config_set_path({_php_str(CFG_GLOBAL)}, $g);\n"
+        f"{ip_iface_line}"
         f"{_dnsbl_settings_replace_php(settings)}"
         f"$list = {_php_kv_array(listcfg)};\n"
         f"$list['row'] = {rows_php};\n"
@@ -4671,16 +4710,23 @@ def rule_references(vm: SmokeVM, alias: str, *, timeout: float = 30.0, attempts:
     a baked ``CI HARNESS RULE`` or the floating ``REJECT ALL OUT MGT1``. A non-``pfB_``
     alias is still honoured, via the exact table-reference match alone.
     """
-    pfb_owned = alias.startswith("pfB_")
     for attempt in range(attempts):
         result = vm.ssh(PFCTL, "-sr", timeout=timeout)
         if result.returncode != 0:
             raise RuntimeError(f"pfctl -sr failed: rc={result.returncode} stderr={result.stderr!r}")
-        if any(f"<{alias}>" in line or (pfb_owned and alias in line) for line in result.stdout.splitlines()):
+        if any(rule_line_references(line, alias) for line in result.stdout.splitlines()):
             return True
         if attempt < attempts - 1:
             time.sleep(delay)
     return False
+
+
+def rule_line_references(line: str, alias: str) -> bool:
+    """True iff one ruleset line references table ``alias`` — the match rule of
+    :func:`rule_references`, shared so :func:`alias_rule_dump` (which exists to EXPLAIN a
+    rule_references failure) cannot disagree with it about what "references" means.
+    """
+    return f"<{alias}>" in line or (alias.startswith("pfB_") and alias in line)
 
 
 def wait_until(predicate: Callable[[], bool], *, timeout: float = 12.0, interval: float = 2.0) -> bool:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -542,6 +542,79 @@ def pf_state_dump(vm: SmokeVM, *, timeout: float = 30.0) -> str:
     )
 
 
+_ALIAS_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
+    """Return a layered snapshot naming WHERE a pfB alias's auto-rule was lost.
+
+    :func:`rule_references` already polls, so its failure does NOT mean "we read too
+    early" — no rule naming ``alias`` reached live pf within the whole poll window.
+    Two very different causes produce that, and only the layer that still has the rule
+    tells them apart, so dump all three:
+
+      * CONFIG — ``filter/rule`` rows whose source/destination is ``alias`` (what the
+        pfBlockerNG sync wrote to config.xml);
+      * RULES.DEBUG — ``alias`` in ``/tmp/rules.debug`` (what filter_configure emitted);
+      * LIVE PF — ``alias`` in ``pfctl -sr``, plus whether the pf table itself exists.
+
+    The reported ``[STAGE LOST]`` is the verdict: absent from CONFIG ⇒ the rule was never
+    generated (a product bug, NOT reload lag); in CONFIG but not RULES.DEBUG ⇒ the pfSense
+    rule generator dropped it; in RULES.DEBUG but not LIVE PF ⇒ filter_configure has not
+    applied it yet (genuine lag) or pfctl rejected the ruleset; present at all three ⇒ the
+    poll read stale state.
+
+    issue #1239: this flake was filed with a fabricated cause ("rule_references does not
+    poll" — it does), so the NEXT occurrence must localise itself instead of being re-guessed.
+    """
+    if not _ALIAS_RE.match(alias):
+        raise ValueError(f"alias must be a bare pf table name ([A-Za-z0-9_]+), got {alias!r}")
+
+    # CONFIG: pfBlockerNG's auto-rules carry the table name in source/destination address
+    # (descr is a human label), so match the address fields — a descr-only match would miss
+    # a rule whose label was renamed. pfSsh.php, not `php -r`: only it can read the config.
+    snippet = (
+        f"$a='{alias}';\n"
+        "$o=array();\n"
+        "foreach(config_get_path('filter/rule',array()) as $r){\n"
+        "  $s=(string)($r['source']['address']??'');\n"
+        "  $d=(string)($r['destination']['address']??'');\n"
+        "  $c=(string)($r['descr']??'');\n"
+        "  if($s===$a||$d===$a||strpos($c,$a)!==FALSE){\n"
+        "    $o[]=$c.'|'.($r['type']??'').'|if='.($r['interface']??'').'|'.($r['ipprotocol']??'')\n"
+        "      .'|src='.$s.'|dst='.$d.'|disabled='.(isset($r['disabled'])?'1':'0');}\n"
+        "}\n"
+        "echo '<<CFG>>'.implode(' ## ',$o).'<<END>>';"
+    )
+    cfg_res = php_eval(vm, snippet, timeout=timeout)
+    cfg = ""
+    if "<<CFG>>" in cfg_res.stdout and "<<END>>" in cfg_res.stdout:
+        cfg = cfg_res.stdout.split("<<CFG>>", 1)[1].split("<<END>>", 1)[0]
+
+    dbg = vm.ssh("/usr/bin/grep", "-n", alias, "/tmp/rules.debug", timeout=timeout)
+    sr = vm.ssh(PFCTL, "-sr", timeout=timeout)
+    dbg_lines = [ln for ln in dbg.stdout.splitlines() if ln.strip()]
+    live = [ln for ln in sr.stdout.splitlines() if alias in ln]
+    table_exists = alias in pfctl_tables(vm, timeout=timeout)
+
+    if not cfg.strip():
+        stage = f"CONFIG — no filter/rule references {alias}: the rule was NEVER generated (product bug, not lag)"
+    elif not dbg_lines:
+        stage = "RULES.DEBUG — in config.xml but never emitted into the ruleset (rule generator dropped it)"
+    elif not live:
+        stage = "LIVE PF — emitted but not loaded: filter_configure has not applied it yet (lag), or pfctl refused it"
+    else:
+        stage = "NONE — the rule is present at all three layers; the poll read stale state"
+
+    return (
+        f"[STAGE LOST] {stage}\n"
+        f"[CONFIG rows] {cfg.strip()}\n"
+        f"[RULES.DEBUG {alias}: {len(dbg_lines)}] " + " || ".join(dbg_lines[:12]) + "\n"
+        f"[LIVE PF -sr {alias}: {len(live)}] " + " || ".join(live[:6]) + "\n"
+        f"[pf table {alias} exists] {table_exists}"
+    )
+
+
 def deinstall_debug(vm: SmokeVM, *, timeout: float = 30.0) -> str:
     """Return deinstall-sweep evidence for the uninstall-survival failures.
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2864,26 +2864,12 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
     if spec.custom_domains:
         crlf = "\r\n".join(spec.custom_domains)
         custom_line = f"$list['custom'] = base64_encode({_php_str(crlf)});\n"
-    # DNSBL-IP reuses the IP-side rule builder, so it needs the SAME inbound/outbound
-    # interface config `_ip_inject_snippet` sets: without it pfBlockerNG builds the
-    # pfB_DNSBLIP_* tables but NO rule (inc:10132). Setting it here — not in the tests —
-    # is what keeps a DNSBL-IP case from depending on an IpCase sibling having run first
-    # and left the interfaces behind in the shared config (issue #1239).
-    ip_iface_line = ""
-    if spec.dnsbl_ip_action:
-        ipset = {"inbound_interface": SMOKE_IP_IFACE, "outbound_interface": SMOKE_IP_IFACE}
-        ip_iface_line = (
-            f"$ip = config_get_path({_php_str(CFG_IP_SETTINGS)}, array());\n"
-            f"$ip = array_merge($ip, {_php_kv_array(ipset)});\n"
-            f"config_set_path({_php_str(CFG_IP_SETTINGS)}, $ip);\n"
-        )
     return (
         # pfBlockerNG must be globally enabled for the DNSBL (and DNSBL-IP)
         # paths to run (inc:793 reads enable_cb; inc:3389/9307 gate on it).
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         "$g['enable_cb'] = 'on';\n"
         f"config_set_path({_php_str(CFG_GLOBAL)}, $g);\n"
-        f"{ip_iface_line}"
         f"{_dnsbl_settings_replace_php(settings)}"
         f"$list = {_php_kv_array(listcfg)};\n"
         f"$list['row'] = {rows_php};\n"

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2864,12 +2864,26 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
     if spec.custom_domains:
         crlf = "\r\n".join(spec.custom_domains)
         custom_line = f"$list['custom'] = base64_encode({_php_str(crlf)});\n"
+    # DNSBL-IP reuses the IP-side rule builder, so it needs the SAME inbound/outbound
+    # interface config `_ip_inject_snippet` sets: without it pfBlockerNG builds the
+    # pfB_DNSBLIP_* tables but NO rule (inc:10132). Setting it here — not in the tests —
+    # is what keeps a DNSBL-IP case from depending on an IpCase sibling having run first
+    # and left the interfaces behind in the shared config (issue #1239).
+    ip_iface_line = ""
+    if spec.dnsbl_ip_action:
+        ipset = {"inbound_interface": SMOKE_IP_IFACE, "outbound_interface": SMOKE_IP_IFACE}
+        ip_iface_line = (
+            f"$ip = config_get_path({_php_str(CFG_IP_SETTINGS)}, array());\n"
+            f"$ip = array_merge($ip, {_php_kv_array(ipset)});\n"
+            f"config_set_path({_php_str(CFG_IP_SETTINGS)}, $ip);\n"
+        )
     return (
         # pfBlockerNG must be globally enabled for the DNSBL (and DNSBL-IP)
         # paths to run (inc:793 reads enable_cb; inc:3389/9307 gate on it).
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         "$g['enable_cb'] = 'on';\n"
         f"config_set_path({_php_str(CFG_GLOBAL)}, $g);\n"
+        f"{ip_iface_line}"
         f"{_dnsbl_settings_replace_php(settings)}"
         f"$list = {_php_kv_array(listcfg)};\n"
         f"$list['row'] = {rows_php};\n"

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -169,6 +169,39 @@ def test_ip_probe_membership_and_rule(deployed_vm: SmokeVM, mock_feeds: object) 
         assert h.rule_references(deployed_vm, spec.alias), f"no rule references {spec.alias}"
 
 
+# The dump's own body runs two full three-layer probes on top of the case reload, so the
+# 30s default cap would kill it mid-probe (issue #1239).
+@pytest.mark.timeout(180)
+def test_alias_rule_dump_localises_a_present_and_an_absent_rule(deployed_vm: SmokeVM, mock_feeds: object) -> None:
+    """``alias_rule_dump``'s [STAGE LOST] verdict must be right against the REAL box.
+
+    A future rule_references failure will be BELIEVED on this verdict — "the rule was never
+    generated" accuses the product, "not loaded yet" accuses the test — so the verdict is
+    pinned on the live surface, where the pfSsh.php config read, the rules.debug grep and the
+    pfctl reads must genuinely work (fakes cannot prove any of those three).
+
+    Scenario: the two verdicts that decide the accusation.
+      Given a fed IP list whose alias HAS a loaded rule
+      Then the dump reports STAGE NONE, carrying the rule as evidence
+      And given an alias pfBlockerNG never created
+      Then it reports STAGE CONFIG — the rule was never generated.
+    The PAIRING is the point: a dump that always said CONFIG would "confirm" a product bug
+    on every lag, so the present-rule case is what proves the verdict discriminates.
+    """
+    feed_url = h.write_local_feed(deployed_vm, "smoke_dump_selftest.txt", "198.51.100.9\n")
+    spec = h.IpCase(aliasname="smokedump", feed_url=feed_url, header="smokedump")
+    with h.CaseContext(deployed_vm, spec):
+        assert h.wait_pfctl_table(deployed_vm, spec.alias), f"{spec.alias} never populated"
+        assert h.rule_references(deployed_vm, spec.alias), f"no rule references {spec.alias}"
+
+        present = h.alias_rule_dump(deployed_vm, spec.alias)
+        assert "[STAGE LOST] NONE" in present, f"a rule loaded at every layer was misreported:\n{present}"
+        assert spec.alias in present, f"dump carries no evidence rows for {spec.alias}:\n{present}"
+
+        absent = h.alias_rule_dump(deployed_vm, "pfB_NeverCreated_v4")
+        assert "[STAGE LOST] CONFIG" in absent, f"an alias that was never generated was misreported:\n{absent}"
+
+
 # --------------------------------------------------------------------------- #
 # 6) ABP harness extensions (ADR-07) — PURE, no VM
 #    Pin the feed-body builder + the config-injection snippet so a regression in

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -993,6 +993,10 @@ def test_dnsbl_fail_closed_broken_manifest(
 # --------------------------------------------------------------------------- #
 
 
+# The 30s default body cap cannot cover reload + two 30s table polls + two ~20s
+# rule_references polls + the on-failure dump: it kills the diagnostic before it prints
+# (issue #1239). The budget is a deadlock guard here, not a pacer.
+@pytest.mark.timeout(180)
 def test_dnsblip_dual_stack_partition(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """A DNSBL feed with BOTH families -> pfB_DNSBLIP_v4 AND pfB_DNSBLIP_v6.
 
@@ -1046,9 +1050,15 @@ def test_dnsblip_dual_stack_partition(deployed_vm: SmokeVM, mock_feeds: _MockFee
         assert any(":" in m for m in v6_members), f"no IPv6 in pfB_DNSBLIP_v6: {v6_members}"
         assert not any(_is_v4_literal(m) for m in v6_members), f"IPv4 leaked into pfB_DNSBLIP_v6: {v6_members}"
 
-        # Then: inet/inet6 rules reference the matching per-family table.
-        assert h.rule_references(deployed_vm, "pfB_DNSBLIP_v4"), "no rule references pfB_DNSBLIP_v4"
-        assert h.rule_references(deployed_vm, "pfB_DNSBLIP_v6"), "no rule references pfB_DNSBLIP_v6"
+        # Then: inet/inet6 rules reference the matching per-family table. rule_references
+        # already polls, so a False here is NOT an early read — dump the three layers so the
+        # failure says WHICH one lost the rule (issue #1239) instead of being re-guessed.
+        assert h.rule_references(deployed_vm, "pfB_DNSBLIP_v4"), (
+            "no rule references pfB_DNSBLIP_v4\n" + h.alias_rule_dump(deployed_vm, "pfB_DNSBLIP_v4")
+        )
+        assert h.rule_references(deployed_vm, "pfB_DNSBLIP_v6"), (
+            "no rule references pfB_DNSBLIP_v6\n" + h.alias_rule_dump(deployed_vm, "pfB_DNSBLIP_v6")
+        )
 
 
 def _is_v4_literal(member: str) -> bool:

--- a/tests/test_smoke_alias_rule_dump.py
+++ b/tests/test_smoke_alias_rule_dump.py
@@ -241,8 +241,34 @@ def test_ruleset_layers_use_the_same_match_rule_as_the_assertion_they_explain() 
 
 @pytest.mark.parametrize(
     "hostile",
-    ["pfB_x'; system('id'); $z='", "pfB_x\nfoo", "pfB-x", "", "pfB_x; rm -rf /", "pfB_x'", "../etc/passwd"],
-    ids=["php-quote-break", "newline", "dash", "empty", "shell-metachars", "bare-quote", "path-traversal"],
+    [
+        "pfB_x'; system('id'); $z='",
+        "pfB_x\nfoo",
+        # A TRAILING newline is the shape a `$`-anchored re.match() silently admits (it matches
+        # just before a final \n) — the guard must use fullmatch, so this rejects too.
+        "pfB_x\n",
+        "pfB-x",
+        "",
+        "pfB_x; rm -rf /",
+        "pfB_x'",
+        "../etc/passwd",
+        "pfB_$var",
+        "pfB_x\\",
+        "pfB_ünïcode",
+    ],
+    ids=[
+        "php-quote-break",
+        "embedded-newline",
+        "trailing-newline",
+        "dash",
+        "empty",
+        "shell-metachars",
+        "bare-quote",
+        "path-traversal",
+        "php-var-interpolation",
+        "backslash",
+        "unicode",
+    ],
 )
 def test_alias_is_validated_before_it_reaches_the_php_snippet(hostile: str) -> None:
     """Given an alias carrying quotes, newlines, shell metacharacters or path separators

--- a/tests/test_smoke_alias_rule_dump.py
+++ b/tests/test_smoke_alias_rule_dump.py
@@ -48,25 +48,34 @@ class _FakeVM:
     rules_debug: str = ""
     live_rules: str = ""
     tables: str = ""
+    grep_rc: int | None = None
+    sr_rc: int = 0
+    tables_rc: int = 0
     calls: list[tuple[str, ...]] = field(default_factory=list)
 
     def ssh(self, *remote: str, timeout: float = 60.0) -> _FakeResult:
         self.calls.append(remote)
         if remote[0] == "/usr/bin/grep":
             # grep exits 1 on no match — the dump must treat that as "absent", not as an error.
-            return _FakeResult(returncode=0 if self.rules_debug else 1, stdout=self.rules_debug)
+            rc = self.grep_rc if self.grep_rc is not None else (0 if self.rules_debug else 1)
+            return _FakeResult(returncode=rc, stdout=self.rules_debug)
         if remote[:2] == (helpers.PFCTL, "-sr"):
-            return _FakeResult(stdout=self.live_rules)
+            return _FakeResult(returncode=self.sr_rc, stdout=self.live_rules)
         if remote[:2] == (helpers.PFCTL, "-sTables"):
-            return _FakeResult(stdout=self.tables)
+            return _FakeResult(returncode=self.tables_rc, stdout=self.tables)
         raise AssertionError(f"unexpected ssh command: {remote}")
 
 
-def _fake_php_eval(rows: str) -> object:
-    """Return a php_eval stand-in emitting the dump's ``<<CFG>>``-delimited config rows."""
+def _fake_php_eval(rows: str, *, returncode: int = 0, raw: str | None = None) -> object:
+    """Return a php_eval stand-in emitting the dump's ``<<CFG>>``-delimited config rows.
+
+    ``raw`` replaces the whole stdout, so a test can simulate pfSsh.php fatalling before it
+    printed the sentinels (it still exits 0 — the sentinels are the only completion proof).
+    """
 
     def _run(_vm: object, _snippet: str, *, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(args=[], returncode=0, stdout=f"banner\n<<CFG>>{rows}<<END>>\n", stderr="")
+        stdout = raw if raw is not None else f"banner\n<<CFG>>{rows}<<END>>\n"
+        return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
 
     return _run
 
@@ -145,6 +154,89 @@ def test_missing_pf_table_is_reported_rather_than_assumed(monkeypatch: pytest.Mo
     dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
 
     assert "[pf table pfB_DNSBLIP_v4 exists] False" in dump, f"absent table not reported:\n{dump}"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "vm_kwargs", "broken"),
+    [
+        # pfSsh.php exits 0 even when the PHP inside it fatals, so a missing sentinel — not
+        # the return code — is what proves the config read never completed.
+        ({"raw": "banner\nPHP Fatal error: something\n"}, {}, "CONFIG(pfSsh)"),
+        ({"returncode": 1}, {}, "CONFIG(pfSsh)"),
+        # grep rc>=2 = the grep itself failed (e.g. /tmp/rules.debug missing); rc 1 is a real
+        # "no match" answer and must NOT be treated as a broken probe (covered elsewhere).
+        ({}, {"grep_rc": 2}, "RULES.DEBUG(grep)"),
+        ({}, {"sr_rc": 1}, "LIVE PF(pfctl -sr)"),
+    ],
+    ids=["pfssh-fatal", "pfssh-nonzero-rc", "grep-error", "pfctl-error"],
+)
+def test_a_failed_probe_is_unproven_never_an_accusation(
+    monkeypatch: pytest.MonkeyPatch,
+    kwargs: dict[str, object],
+    vm_kwargs: dict[str, object],
+    broken: str,
+) -> None:
+    """Given a probe that ERRORS rather than returning an answer
+    When alias_rule_dump runs
+    Then the verdict is UNPROVEN and names the broken probe — it must NEVER read a failed
+    probe's empty output as "the rule was never generated". Blaming the product for a
+    pfSsh.php error is precisely the misdiagnosis this helper exists to prevent, so the
+    accusing CONFIG verdict must be absent.
+    """
+    monkeypatch.setattr(helpers, "php_eval", _fake_php_eval(CFG_ROW, **kwargs))  # type: ignore[arg-type]
+    vm = _FakeVM(rules_debug=DEBUG_ROW, live_rules=LIVE_ROW, tables=ALIAS, **vm_kwargs)  # type: ignore[arg-type]
+
+    dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
+
+    stage_line = next(ln for ln in dump.splitlines() if ln.startswith("[STAGE LOST]"))
+    assert "UNPROVEN" in stage_line, f"a failed probe did not yield UNPROVEN: {stage_line!r}"
+    assert broken in stage_line, f"the broken probe {broken!r} is not named: {stage_line!r}"
+    assert "NEVER generated" not in stage_line, f"a failed probe accused the product: {stage_line!r}"
+
+
+def test_a_rule_naming_the_alias_only_in_its_descr_does_not_count_as_a_reference() -> None:
+    """The CONFIG layer must match the source/destination ADDRESS, never the descr label.
+
+    A rule whose descr merely mentions the table enforces nothing. Counting it would report
+    the rule as generated while no traffic is actually filtered — the exact false-negative
+    that would have hidden #1239's real defect. Pinned on the emitted PHP, which is where
+    the matching happens.
+    """
+    php = _php_snippet_for(ALIAS)
+
+    assert "$s===$a||$d===$a" in php, f"CONFIG no longer matches on the address fields:\n{php}"
+    assert "strpos" not in php, f"CONFIG still admits a descr substring match:\n{php}"
+
+
+def _php_snippet_for(alias: str) -> str:
+    """Capture the PHP the dump feeds pfSsh.php (the snippet is built inline, not exported)."""
+    captured: list[str] = []
+
+    def _capture(_vm: object, snippet: str, *, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+        captured.append(snippet)
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="<<CFG>><<END>>", stderr="")
+
+    original = helpers.php_eval
+    helpers.php_eval = _capture  # type: ignore[assignment]
+    try:
+        helpers.alias_rule_dump(_FakeVM(), alias)  # type: ignore[arg-type]
+    finally:
+        helpers.php_eval = original  # type: ignore[assignment]
+    return captured[0]
+
+
+def test_ruleset_layers_use_the_same_match_rule_as_the_assertion_they_explain() -> None:
+    """The dump explains a rule_references failure, so it must not disagree with it.
+
+    If the dump applied a looser (or stricter) match than rule_references, it could report
+    the rule as PRESENT at live pf on the very run where rule_references declared it absent —
+    a self-contradicting diagnostic. Both route through rule_line_references.
+    """
+    assert helpers.rule_line_references(f"block drop in quick from <{ALIAS}> to any", ALIAS)
+    assert not helpers.rule_line_references("block drop in quick from <pfB_Other_v4> to any", ALIAS)
+    # A non-pfB_ alias gets the exact table-reference match ONLY — a bare token must not
+    # match a foreign rule (the baked CI harness rules mention plenty of generic words).
+    assert not helpers.rule_line_references("block drop in quick on em0 # mentions harness", "harness")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_smoke_alias_rule_dump.py
+++ b/tests/test_smoke_alias_rule_dump.py
@@ -1,0 +1,162 @@
+"""``alias_rule_dump`` must name WHICH layer lost a pfB alias's auto-rule.
+
+Issue #1239 filed a ``rule_references`` smoke flake with a fabricated cause ("the check
+does not poll" — it has polled since PR #133). The real cause is still unknown, and the two
+candidates demand opposite responses: the rule was never written to config.xml (a PRODUCT
+bug — a populated block table with nothing enforcing it) versus the rule was written and
+emitted but pf had not loaded it yet (a genuine reload lag, i.e. a test-only flake).
+
+Only the layer that still holds the rule tells them apart, so the on-failure dump reports a
+``[STAGE LOST]`` verdict across CONFIG -> RULES.DEBUG -> LIVE PF. This module pins that
+verdict for every layer combination off-VM (``tests.smoke.helpers`` is import-safe —
+precedent: ``test_smoke_unbound_ready.py``), so the next live occurrence localises itself
+instead of being re-guessed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+
+import pytest
+
+from tests.smoke import helpers
+
+ALIAS = "pfB_DNSBLIP_v4"
+CFG_ROW = "pfB_DNSBLIP_v4 auto rule|block|if=wan|inet|src=pfB_DNSBLIP_v4|dst=any|disabled=0"
+DEBUG_ROW = "412:block drop in quick on em0 from <pfB_DNSBLIP_v4> to any"
+LIVE_ROW = "block drop in quick on em0 from <pfB_DNSBLIP_v4> to any"
+
+
+@dataclass
+class _FakeResult:
+    """Stand-in for ``subprocess.CompletedProcess[str]`` (the shape ``SmokeVM.ssh`` returns)."""
+
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class _FakeVM:
+    """Fake ``vm.ssh(*remote, ...)`` dispatching on the command, not on call order.
+
+    Order-independent by construction: the dump may reorder its probes without silently
+    turning these fixtures into the wrong layer's answer.
+    """
+
+    rules_debug: str = ""
+    live_rules: str = ""
+    tables: str = ""
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+
+    def ssh(self, *remote: str, timeout: float = 60.0) -> _FakeResult:
+        self.calls.append(remote)
+        if remote[0] == "/usr/bin/grep":
+            # grep exits 1 on no match — the dump must treat that as "absent", not as an error.
+            return _FakeResult(returncode=0 if self.rules_debug else 1, stdout=self.rules_debug)
+        if remote[:2] == (helpers.PFCTL, "-sr"):
+            return _FakeResult(stdout=self.live_rules)
+        if remote[:2] == (helpers.PFCTL, "-sTables"):
+            return _FakeResult(stdout=self.tables)
+        raise AssertionError(f"unexpected ssh command: {remote}")
+
+
+def _fake_php_eval(rows: str) -> object:
+    """Return a php_eval stand-in emitting the dump's ``<<CFG>>``-delimited config rows."""
+
+    def _run(_vm: object, _snippet: str, *, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=f"banner\n<<CFG>>{rows}<<END>>\n", stderr="")
+
+    return _run
+
+
+@pytest.mark.parametrize(
+    ("cfg_rows", "rules_debug", "live_rules", "expected_stage"),
+    [
+        # Scenario: the rule never reached config.xml -> pfBlockerNG never generated it.
+        # This is the PRODUCT-bug verdict: the block table can be populated with no rule
+        # enforcing it, which no amount of extra polling would ever fix.
+        ("", "", "", "CONFIG"),
+        # Scenario: written to config.xml, but filter_configure never emitted it into the
+        # generated ruleset -> the pfSense rule generator dropped it (a rule-shape problem).
+        (CFG_ROW, "", "", "RULES.DEBUG"),
+        # Scenario: emitted into rules.debug but not yet loaded into pf -> the genuine
+        # reload-lag verdict (or a pfctl load rejection), i.e. a test-only flake.
+        (CFG_ROW, DEBUG_ROW, "", "LIVE PF"),
+        # Scenario: present at all three layers -> rule_references' poll read stale state;
+        # the rule IS there, so the assertion, not the product, is what to look at.
+        (CFG_ROW, DEBUG_ROW, LIVE_ROW, "NONE"),
+    ],
+    ids=["never-generated", "generator-dropped-it", "emitted-not-loaded", "present-everywhere"],
+)
+def test_stage_lost_names_the_layer_that_lost_the_rule(
+    monkeypatch: pytest.MonkeyPatch,
+    cfg_rows: str,
+    rules_debug: str,
+    live_rules: str,
+    expected_stage: str,
+) -> None:
+    """Given a box where the alias's rule survives only up to a given layer
+    When alias_rule_dump runs
+    Then its [STAGE LOST] verdict names THAT layer — the one discriminator that decides
+    whether the flake is a product bug (rule never generated) or a reload lag.
+    """
+    monkeypatch.setattr(helpers, "php_eval", _fake_php_eval(cfg_rows))
+    vm = _FakeVM(rules_debug=rules_debug, live_rules=live_rules, tables=f"{ALIAS}\npfB_DNSBLIP_v6\n")
+
+    dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
+
+    stage_line = next(ln for ln in dump.splitlines() if ln.startswith("[STAGE LOST]"))
+    assert expected_stage in stage_line, f"expected stage {expected_stage!r} in: {stage_line!r}"
+    # The verdict must be unambiguous — exactly one layer named, never two.
+    others = {"CONFIG", "RULES.DEBUG", "LIVE PF", "NONE"} - {expected_stage}
+    # "CONFIG" is a substring of nothing else here, but "LIVE PF"/"RULES.DEBUG" could co-occur
+    # in a sloppy verdict string; assert the others are absent so a catch-all message fails.
+    assert not [o for o in others if o in stage_line.split("—")[0]], f"verdict is ambiguous: {stage_line!r}"
+
+
+def test_dump_carries_the_underlying_evidence_not_just_the_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given a box holding the rule at every layer
+    When alias_rule_dump runs
+    Then the raw per-layer evidence is printed too — a verdict with no evidence behind it
+    cannot be audited when the verdict itself is what turns out to be wrong (issue #1239).
+    """
+    monkeypatch.setattr(helpers, "php_eval", _fake_php_eval(CFG_ROW))
+    vm = _FakeVM(rules_debug=DEBUG_ROW, live_rules=LIVE_ROW, tables=f"{ALIAS}\n")
+
+    dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
+
+    assert CFG_ROW in dump, f"config row missing from dump:\n{dump}"
+    assert DEBUG_ROW in dump, f"rules.debug row missing from dump:\n{dump}"
+    assert LIVE_ROW in dump, f"live pf row missing from dump:\n{dump}"
+    assert "[pf table pfB_DNSBLIP_v4 exists] True" in dump, f"table existence missing from dump:\n{dump}"
+
+
+def test_missing_pf_table_is_reported_rather_than_assumed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given a box where the pf table itself does not exist
+    When alias_rule_dump runs
+    Then it reports the table as absent — a rule referencing a table that was never loaded
+    is a different failure from a table that exists but is unreferenced.
+    """
+    monkeypatch.setattr(helpers, "php_eval", _fake_php_eval(""))
+    vm = _FakeVM(tables="pfB_Something_Else_v4\n")
+
+    dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
+
+    assert "[pf table pfB_DNSBLIP_v4 exists] False" in dump, f"absent table not reported:\n{dump}"
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["pfB_x'; system('id'); $z='", "pfB_x\nfoo", "pfB-x", "", "pfB_x; rm -rf /", "pfB_x'", "../etc/passwd"],
+    ids=["php-quote-break", "newline", "dash", "empty", "shell-metachars", "bare-quote", "path-traversal"],
+)
+def test_alias_is_validated_before_it_reaches_the_php_snippet(hostile: str) -> None:
+    """Given an alias carrying quotes, newlines, shell metacharacters or path separators
+    When alias_rule_dump is called with it
+    Then it raises ValueError instead of interpolating it into the pfSsh.php snippet — the
+    alias crosses into a PHP string literal, so the bare-table-name shape is a trust boundary.
+    """
+    with pytest.raises(ValueError, match="bare pf table name"):
+        helpers.alias_rule_dump(_FakeVM(), hostile)  # type: ignore[arg-type]

--- a/tests/test_smoke_dnsbl_ip_iface.py
+++ b/tests/test_smoke_dnsbl_ip_iface.py
@@ -17,31 +17,68 @@ every PR rather than only when the live smoke lane runs.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from types import SimpleNamespace
+
 import pytest
 
 from tests.smoke import helpers
 
 
-def _snippet(**kwargs: object) -> str:
-    spec = helpers.DnsblCase(
+def _case(**kwargs: object) -> helpers.DnsblCase:
+    return helpers.DnsblCase(
         aliasname="smokedualip",
         feed_url="http://127.0.0.1:1/feed.txt",
         header="smokedualip",
         mode=helpers.DnsblMode.NULL,
         **kwargs,  # type: ignore[arg-type]
     )
-    return helpers._dnsbl_inject_snippet(spec)
 
 
+def _single_list_snippet(**kwargs: object) -> str:
+    return helpers._dnsbl_inject_snippet(_case(**kwargs))
+
+
+def _multi_list_snippet(**kwargs: object) -> str:
+    """The PHP `inject_dnsbl_lists` feeds pfSsh.php (it injects directly, so capture it)."""
+    captured: list[str] = []
+
+    class _FakeVM:
+        def ssh(self, *_remote: str, **_kw: object) -> object:
+            raise AssertionError("inject_dnsbl_lists must not shell out here")
+
+    def _capture(_vm: object, snippet: str, *, timeout: float = 60.0) -> object:
+        captured.append(snippet)
+        return SimpleNamespace(returncode=0, stdout="OK", stderr="")
+
+    original = helpers.php_eval
+    helpers.php_eval = _capture  # type: ignore[assignment]
+    try:
+        helpers.inject_dnsbl_lists(_FakeVM(), [(_case(**kwargs), "Deny")])  # type: ignore[arg-type]
+    finally:
+        helpers.php_eval = original  # type: ignore[assignment]
+    return captured[0]
+
+
+# BOTH injection paths, not just the one issue #1239 happened to surface: inject_dnsbl_lists
+# also honours dnsbl_ip_action, so leaving it out would let the identical order-dependent
+# flake return through the multi-list door the moment a test combines the two.
+INJECTORS = [
+    pytest.param(_single_list_snippet, id="single-list(_dnsbl_inject_snippet)"),
+    pytest.param(_multi_list_snippet, id="multi-list(inject_dnsbl_lists)"),
+]
+
+
+@pytest.mark.parametrize("build_snippet", INJECTORS)
 @pytest.mark.parametrize("action", ["Deny_Both", "Deny_Inbound", "Deny_Outbound"])
-def test_dnsbl_ip_case_sets_the_firewall_interfaces_itself(action: str) -> None:
-    """Given a DNSBL case that enables the DNSBL-IP firewall feature
+def test_dnsbl_ip_case_sets_the_firewall_interfaces_itself(build_snippet: Callable[..., str], action: str) -> None:
+    """Given a DNSBL case that enables the DNSBL-IP firewall feature (via EITHER injector)
     When its config-injection snippet is built
     Then the snippet writes the inbound/outbound interface into the IP settings — the
     precondition pfBlockerNG requires to emit the rule at all — so the case never depends
     on an IpCase sibling having left those interfaces behind in the shared config.
     """
-    snippet = _snippet(dnsbl_ip_action=action)
+    snippet = build_snippet(dnsbl_ip_action=action)
 
     assert helpers.CFG_IP_SETTINGS in snippet, f"DNSBL-IP case never touches the IP settings:\n{snippet}"
     assert f"'inbound_interface' => '{helpers.SMOKE_IP_IFACE}'" in snippet, (
@@ -52,14 +89,15 @@ def test_dnsbl_ip_case_sets_the_firewall_interfaces_itself(action: str) -> None:
     )
 
 
-def test_plain_dnsbl_case_leaves_the_firewall_interfaces_alone() -> None:
+@pytest.mark.parametrize("build_snippet", INJECTORS)
+def test_plain_dnsbl_case_leaves_the_firewall_interfaces_alone(build_snippet: Callable[..., str]) -> None:
     """Given a DNSBL case that does NOT enable the DNSBL-IP firewall feature
     When its config-injection snippet is built
     Then it does not touch the IP settings at all — the interfaces are a DNSBL-IP
     precondition, not a blanket DNSBL one, so a domain-only case must not quietly
     reconfigure the firewall out from under an unrelated test.
     """
-    snippet = _snippet()
+    snippet = build_snippet()
 
     assert helpers.CFG_IP_SETTINGS not in snippet, f"a domain-only DNSBL case rewrote the IP settings:\n{snippet}"
     assert "inbound_interface" not in snippet, f"a domain-only DNSBL case configured a firewall interface:\n{snippet}"

--- a/tests/test_smoke_dnsbl_ip_iface.py
+++ b/tests/test_smoke_dnsbl_ip_iface.py
@@ -1,0 +1,65 @@
+"""A DNSBL-IP case must configure its own firewall interfaces — never inherit a sibling's.
+
+Issue #1239: ``test_dnsblip_dual_stack_partition`` asserts that a pf rule references
+``pfB_DNSBLIP_v4``/``_v6``. pfBlockerNG only builds that rule when an inbound/outbound
+interface is configured (``helpers.SMOKE_IP_IFACE``, inc:10132 "Inbound interface option
+not configured") — the alias TABLE builds regardless. ``_ip_inject_snippet`` sets those
+interfaces; ``_dnsbl_inject_snippet`` did not, so a DNSBL-IP case only found them in the
+shared config when some IpCase sibling had already run and left them there.
+
+That made the test pass in a full ordered run and fail deterministically in isolation (a
+``-k`` filter, or selective dispatch) — reported as an intermittent flake. CLAUDE.md:
+"Self-encapsulated — never order-dependent. No test may depend on a sibling running first."
+
+These pins are pure (no VM): the snippet is a string builder, so the contract is enforced on
+every PR rather than only when the live smoke lane runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.smoke import helpers
+
+
+def _snippet(**kwargs: object) -> str:
+    spec = helpers.DnsblCase(
+        aliasname="smokedualip",
+        feed_url="http://127.0.0.1:1/feed.txt",
+        header="smokedualip",
+        mode=helpers.DnsblMode.NULL,
+        **kwargs,  # type: ignore[arg-type]
+    )
+    return helpers._dnsbl_inject_snippet(spec)
+
+
+@pytest.mark.parametrize("action", ["Deny_Both", "Deny_Inbound", "Deny_Outbound"])
+def test_dnsbl_ip_case_sets_the_firewall_interfaces_itself(action: str) -> None:
+    """Given a DNSBL case that enables the DNSBL-IP firewall feature
+    When its config-injection snippet is built
+    Then the snippet writes the inbound/outbound interface into the IP settings — the
+    precondition pfBlockerNG requires to emit the rule at all — so the case never depends
+    on an IpCase sibling having left those interfaces behind in the shared config.
+    """
+    snippet = _snippet(dnsbl_ip_action=action)
+
+    assert helpers.CFG_IP_SETTINGS in snippet, f"DNSBL-IP case never touches the IP settings:\n{snippet}"
+    assert f"'inbound_interface' => '{helpers.SMOKE_IP_IFACE}'" in snippet, (
+        f"inbound_interface not configured — pfBlockerNG would build the table but NO rule:\n{snippet}"
+    )
+    assert f"'outbound_interface' => '{helpers.SMOKE_IP_IFACE}'" in snippet, (
+        f"outbound_interface not configured — pfBlockerNG would build the table but NO rule:\n{snippet}"
+    )
+
+
+def test_plain_dnsbl_case_leaves_the_firewall_interfaces_alone() -> None:
+    """Given a DNSBL case that does NOT enable the DNSBL-IP firewall feature
+    When its config-injection snippet is built
+    Then it does not touch the IP settings at all — the interfaces are a DNSBL-IP
+    precondition, not a blanket DNSBL one, so a domain-only case must not quietly
+    reconfigure the firewall out from under an unrelated test.
+    """
+    snippet = _snippet()
+
+    assert helpers.CFG_IP_SETTINGS not in snippet, f"a domain-only DNSBL case rewrote the IP settings:\n{snippet}"
+    assert "inbound_interface" not in snippet, f"a domain-only DNSBL case configured a firewall interface:\n{snippet}"


### PR DESCRIPTION
Fixes #1239.

## The reported cause was wrong

#1239 attributes the `test_dnsblip_dual_stack_partition` flake to the `rule_references()`
assertions being un-polled, and proposes wrapping them in a bounded poll.

`rule_references()` has polled since PR #133 (`helpers.py`, `attempts=10, delay=2.0`) —
including at the very commit the report cites as its reproduction. Its own docstring says
"poll rather than read once". The proposed fix is work that already merged five weeks ago,
and no amount of extra polling could have fixed the real defect.

## The actual root cause: order-dependence, confirmed on a live box

pfBlockerNG only builds the IP deny rule when an inbound/outbound interface is configured
(`inc:10132`, "Inbound interface option not configured"); the alias **table** builds
regardless — a fact `helpers.py` already documented. `_ip_inject_snippet` sets those
interfaces. `_dnsbl_inject_snippet` never did.

So a DNSBL-IP case only found the interfaces in the shared session config when an `IpCase`
sibling had already run and left them behind. In a full ordered run the test passed; run in
isolation — a `-k` filter, or selective dispatch — it failed **deterministically**. That is
what surfaced as an "intermittent" flake. It reproduced 2/2 in isolation on a leased box.

CLAUDE.md: *"Self-encapsulated — never order-dependent. No test may depend on a sibling
running first."*

## What changed

1. **`_dnsbl_inject_snippet` sets the firewall interfaces itself** when the case enables
   DNSBL-IP — in the shared injection helper every DNSBL-IP caller routes through, not in
   the one test that happened to notice.
2. **`alias_rule_dump()`** — a three-layer `CONFIG -> RULES.DEBUG -> LIVE PF` localiser for
   any pfB alias, mirroring the existing `pf_state_dump()`. Both `rule_references`
   assertions print it on failure, so a future occurrence names the layer that lost the rule
   instead of being re-guessed. It earned its keep immediately: on the first live failure it
   reported `[STAGE LOST] CONFIG — the rule was NEVER generated`, with the pf table present
   and populated, which is what pointed straight at rule generation rather than at timing.
3. **Per-test timeout override** so the 30s default body cap cannot kill the dump before it
   prints.

## Tests

* `tests/test_smoke_dnsbl_ip_iface.py` — pins the order-independence contract off-box (pure
  string-builder pins, so they guard every PR without a VM), across all three DNSBL-IP
  actions, plus a negative control proving a domain-only DNSBL case does **not** reconfigure
  the firewall.
* `tests/test_smoke_alias_rule_dump.py` — pins the `[STAGE LOST]` verdict for every layer
  combination, plus the alias-validation guard (the alias crosses into a PHP string literal).
* `tests/smoke/test_smoke_helpers.py` — pins the dump's verdict against the **real** box
  (present-rule -> `NONE`, never-created alias -> `CONFIG`); the fakes cannot prove the
  pfSsh.php / grep / pfctl transport actually works.

### Red -> green (executed, live)

Before the fix, in isolation: **FAILED 2/2**, `[STAGE LOST] CONFIG — no filter/rule
references pfB_DNSBLIP_v4: the rule was NEVER generated`, `[pf table pfB_DNSBLIP_v4 exists]
True`.

After the fix, same isolated invocation: **2 passed**.

Off-box pins: red 3 failed / 1 passed on the unfixed helper, green 4 passed with the test
file byte-identical (`git hash-object 422582d2…` unchanged across both runs).

Gates: `python3 -m pytest` (2733 passed), `ruff check`, `ruff format --check`,
`mypy tests/` all green.