### PR TITLE
pfblockerng: reject a Deny source header that collides with the reserved dedup filename (#1234)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -96,7 +96,6 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 	pfbdomain=/var/db/pfblockerng/dnsbl/
 	pfbdomainorig=/var/db/pfblockerng/dnsblorig/
 
-	# Store 'Match' d-dedups in matchdedup.txt file
 	matchdedup=matchdedup_v4.txt
 
 	# Create a private per-run temp directory (sets tempfile, tempfile2, ...,

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1861,6 +1861,15 @@ function pfb_adv_alias_field_errors(array $post): array
 	return $errors;
 }
 
+// issue #1234: 'dedup' header + a Deny action collides with the reserved
+// matchdedup_v4.txt recompute artifact (pfblockerng.sh) -- reject at save.
+function pfb_header_reserved_error(string $header, string $action): string {
+	if ($header === 'dedup' && strpos($action, 'Deny') !== FALSE) {
+		return "Header field cannot be 'dedup' when Action is set to Deny (reserved filename).";
+	}
+	return '';
+}
+
 // ---------------------------------------------------------------------------
 // ADR-38: pure key=value syslog event formatters (pfb_syslog_format_ip() etc.) — the fixed
 // key order, empty-value omission rules, and quoting/escaping are specified in

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -2559,7 +2559,7 @@ $section->addInput(new Form_StaticText(
 	. '\'<strong>ccblack</strong>\' are all other Countries that are not selected.<br /><br />'
 	. 'To use <strong>Match</strong> Lists, Create a new \'Alias\''
 	. 'and select one of the <strong>Action Match</strong> Formats and<br /> enter the <strong>Localfile</strong> as:'
-	. '<ul>/var/db/pfblockerng/match/matchdedup.txt</ul><br />' 
+	. '<ul>/var/db/pfblockerng/match/matchdedup_v4.txt</ul><br />'
 	. '<strong>These Country Code options are only available when the MaxMind key has been entered and MaxMind database has been downloaded and updated</strong>'
 	. '</div>'
 ));

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -549,6 +549,13 @@ if ($_POST && isset($_POST['save'])) {
 							. "Header field cannot contain spaces, special or international characters.";
 			}
 
+			if ($value != 'Disabled') {
+				$pfb_header_reserved = pfb_header_reserved_error($_POST["header-{$key_1}"], $_POST['action'] ?? '');
+				if ($pfb_header_reserved !== '') {
+					$input_errors[] = "{$type} Source Definitions, Line {$line}: {$pfb_header_reserved}";
+				}
+			}
+
 			if ($value != 'Disabled' && strpos($_POST["url-{$key_1}"], '_API_KEY_') !== FALSE) {
 				$input_errors[] = "{$type} Source Definitions, Line {$line}: "
 							. "API key not defined! Add your subscripton API Key to the Source field URL or disable/remove feed.";

--- a/tests/php/CategoryEditReservedHeaderTest.php
+++ b/tests/php/CategoryEditReservedHeaderTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Category-edit save-time rejection of a reserved source Header (issue #1234).
+ *
+ * A Deny-type list whose Header is literally 'dedup' collides with the
+ * reserved matchdedup_v4.txt recompute artifact (pfblockerng.sh
+ * pfb_recompute_finish() writes both the per-alias file and the dedup swap to
+ * the same path). This must be rejected at save.
+ *
+ * Like CategoryEditPostGuardTest, the page carries top-level execution and
+ * cannot be require()d off-appliance, so the rowhelper state-loop region is
+ * eval-extracted verbatim from the REAL source, anchored on text stable
+ * across the pre-fix and post-fix code -- the same test proves red on the old
+ * code and green on the new.
+ */
+final class CategoryEditReservedHeaderTest extends TestCase
+{
+	private array $savedPost = [];
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
+		}
+
+		if (!function_exists('pfb_category_oracle_reserved_header_state_loop')) {
+			if (!preg_match(
+				'/(\tforeach \(\$_POST as \$key => \$value\) \{\n.*?\n\t\})\n\n\n\t\/\/ Validate Adv\. firewall rule settings/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: state validation loop not found');
+			}
+			eval(
+				'function pfb_category_oracle_reserved_header_state_loop(string $type): array {'
+				. ' global $pfb; $input_errors = array(); $line = 1;'
+				. $m[1]
+				. ' return $input_errors; }'
+			);
+		}
+	}
+
+	protected function setUp(): void
+	{
+		$this->savedPost = $_POST;
+		$_POST = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$_POST = $this->savedPost;
+	}
+
+	/**
+	 * @param array<int, string> $errors
+	 */
+	private static function hasReservedError(array $errors): bool
+	{
+		foreach ($errors as $error) {
+			if (str_contains($error, 'reserved')) {
+				return TRUE;
+			}
+		}
+		return FALSE;
+	}
+
+	private function makeRow(string $action, string $header, string $state = 'Enabled'): void
+	{
+		$_POST = [
+			'action'   => $action,
+			'state-0'  => $state,
+			'header-0' => $header,
+			'url-0'    => 'http://192.0.2.1/feed',	// RFC 5737 literal -- avoids DNS resolution
+			'format-0' => 'auto',
+		];
+	}
+
+	// --- Action axis (enumerated from category_edit.php's $options_action) ----
+
+	public static function denyActionsProvider(): array
+	{
+		return [
+			'Deny_Inbound' => ['Deny_Inbound'],
+			'Deny_Outbound' => ['Deny_Outbound'],
+			'Deny_Both' => ['Deny_Both'],
+			'Alias_Deny' => ['Alias_Deny'],
+		];
+	}
+
+	#[DataProvider('denyActionsProvider')]
+	public function testDenyActionWithDedupHeaderIsRejected(string $action): void
+	{
+		$this->makeRow($action, 'dedup');
+		$errors = pfb_category_oracle_reserved_header_state_loop('IPv4');
+		$this->assertTrue(
+			self::hasReservedError($errors),
+			"action={$action} header=dedup must add a reserved-header input error; got: " . var_export($errors, TRUE)
+		);
+	}
+
+	public static function nonDenyActionsProvider(): array
+	{
+		return [
+			'Disabled'        => ['Disabled'],
+			'Permit_Inbound'  => ['Permit_Inbound'],
+			'Permit_Outbound' => ['Permit_Outbound'],
+			'Permit_Both'     => ['Permit_Both'],
+			'Match_Inbound'   => ['Match_Inbound'],
+			'Match_Outbound'  => ['Match_Outbound'],
+			'Match_Both'      => ['Match_Both'],
+			'Alias_Permit'    => ['Alias_Permit'],
+			'Alias_Match'     => ['Alias_Match'],
+			'Alias_Native'    => ['Alias_Native'],
+		];
+	}
+
+	#[DataProvider('nonDenyActionsProvider')]
+	public function testNonDenyActionWithDedupHeaderIsAllowed(string $action): void
+	{
+		$this->makeRow($action, 'dedup');
+		$errors = pfb_category_oracle_reserved_header_state_loop('IPv4');
+		$this->assertFalse(
+			self::hasReservedError($errors),
+			"action={$action} header=dedup must NOT add a reserved-header input error; got: " . var_export($errors, TRUE)
+		);
+	}
+
+	public function testDnsblActionWithDedupHeaderIsAllowed(): void
+	{
+		$this->makeRow('unbound', 'dedup');
+		$errors = pfb_category_oracle_reserved_header_state_loop('DNSBL');
+		$this->assertFalse(self::hasReservedError($errors));
+	}
+
+	public function testDisabledRowSkipsReservedCheckEvenWithDenyAction(): void
+	{
+		$this->makeRow('Deny_Both', 'dedup', 'Disabled');
+		$errors = pfb_category_oracle_reserved_header_state_loop('IPv4');
+		$this->assertSame([], $errors, 'a Disabled row must add no errors at all -- it is skipped entirely');
+	}
+
+	// --- Hostile-input rows (case sensitivity + near misses) -------------------
+
+	public static function caseAndNearMissProvider(): array
+	{
+		return [
+			'Dedup'      => ['Dedup'],
+			'DEDUP'      => ['DEDUP'],
+			'DeDuP'      => ['DeDuP'],
+			'dedupfoo'   => ['dedupfoo'],
+			'foodedup'   => ['foodedup'],
+			'xdedup'     => ['xdedup'],
+			'matchdedup' => ['matchdedup'],
+		];
+	}
+
+	#[DataProvider('caseAndNearMissProvider')]
+	public function testCaseVariantOrNearMissHeaderUnderDenyIsAllowed(string $header): void
+	{
+		$this->makeRow('Deny_Both', $header);
+		$errors = pfb_category_oracle_reserved_header_state_loop('IPv4');
+		$this->assertFalse(
+			self::hasReservedError($errors),
+			"header={$header} under Deny_Both must NOT be treated as reserved; got: " . var_export($errors, TRUE)
+		);
+	}
+
+	// --- Existing rules must still fire, and must not be duplicated ------------
+
+	public function testEmptyHeaderStillTriggersExistingEmptyRuleNotReservedRule(): void
+	{
+		$this->makeRow('Deny_Both', '');
+		$errors = pfb_category_oracle_reserved_header_state_loop('IPv4');
+		$this->assertNotEmpty(
+			array_filter($errors, static fn (string $e): bool => str_contains($e, 'must be defined')),
+			'the existing empty-header rule must still fire'
+		);
+		$this->assertFalse(self::hasReservedError($errors), 'an empty header must not also trip the reserved rule');
+	}
+
+	public static function nonWordHeaderProvider(): array
+	{
+		return [
+			'de-dup'        => ['de-dup'],
+			'de dup'        => ['de dup'],
+			'dedup!'        => ['dedup!'],
+			'leading space' => [' dedup'],
+			'trailing space' => ['dedup '],
+		];
+	}
+
+	#[DataProvider('nonWordHeaderProvider')]
+	public function testNonWordHeaderStillTriggersExistingWRuleNotReservedRule(string $header): void
+	{
+		$this->makeRow('Deny_Both', $header);
+		$errors = pfb_category_oracle_reserved_header_state_loop('IPv4');
+		$this->assertNotEmpty(
+			array_filter($errors, static fn (string $e): bool => str_contains($e, 'special or international')),
+			"the existing \\W rule must still fire for header={$header}"
+		);
+		$this->assertFalse(
+			self::hasReservedError($errors),
+			"header={$header} must not additionally trip the reserved rule (it never reaches a clean 'dedup' compare)"
+		);
+	}
+}

--- a/tests/php/HeaderReservedErrorTest.php
+++ b/tests/php/HeaderReservedErrorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for pfb_header_reserved_error() (issue #1234).
+ *
+ * A Deny-type list whose source Header is literally 'dedup' makes
+ * pfb_recompute_finish() (pfblockerng.sh) write the per-alias artifact to the
+ * same path as the reserved ccwhite-dedup file (matchdedup_v4.txt), so the
+ * dedup swap silently overwrites or deletes it. This is save-time-only
+ * (config import/HA-sync bypasses it via the \W-stripping normaliser) --
+ * pfb_header_reserved_error() itself is pure and only judges what it is given.
+ */
+#[CoversFunction('pfb_header_reserved_error')]
+final class HeaderReservedErrorTest extends TestCase
+{
+	public static function reservedRowsProvider(): array
+	{
+		return [
+			'Deny_Inbound rejects dedup'  => ['dedup', 'Deny_Inbound', TRUE],
+			'Deny_Outbound rejects dedup' => ['dedup', 'Deny_Outbound', TRUE],
+			'Deny_Both rejects dedup'     => ['dedup', 'Deny_Both', TRUE],
+			'Alias_Deny rejects dedup'    => ['dedup', 'Alias_Deny', TRUE],
+		];
+	}
+
+	#[DataProvider('reservedRowsProvider')]
+	public function testDenyActionWithDedupHeaderIsReserved(string $header, string $action, bool $expectReserved): void
+	{
+		$error = pfb_header_reserved_error($header, $action);
+		if ($expectReserved) {
+			$this->assertNotSame('', $error, "action={$action} header={$header} must be reserved");
+		} else {
+			$this->assertSame('', $error);
+		}
+	}
+
+	public static function allowedActionsProvider(): array
+	{
+		return [
+			'Disabled'        => ['Disabled'],
+			'Permit_Inbound'  => ['Permit_Inbound'],
+			'Permit_Outbound' => ['Permit_Outbound'],
+			'Permit_Both'     => ['Permit_Both'],
+			'Match_Inbound'   => ['Match_Inbound'],
+			'Match_Outbound'  => ['Match_Outbound'],
+			'Match_Both'      => ['Match_Both'],
+			'Alias_Permit'    => ['Alias_Permit'],
+			'Alias_Match'     => ['Alias_Match'],
+			'Alias_Native'    => ['Alias_Native'],
+			'unbound (DNSBL)' => ['unbound'],
+		];
+	}
+
+	#[DataProvider('allowedActionsProvider')]
+	public function testNonDenyActionWithDedupHeaderIsAllowed(string $action): void
+	{
+		$this->assertSame(
+			'',
+			pfb_header_reserved_error('dedup', $action),
+			"action={$action} must not reserve the 'dedup' header"
+		);
+	}
+
+	public static function caseAndNearMissProvider(): array
+	{
+		return [
+			'Dedup (mixed case)'    => ['Dedup'],
+			'DEDUP (upper case)'    => ['DEDUP'],
+			'DeDuP (mixed case)'    => ['DeDuP'],
+			'dedupfoo (suffix)'     => ['dedupfoo'],
+			'foodedup (prefix)'     => ['foodedup'],
+			'xdedup (prefix)'       => ['xdedup'],
+			'matchdedup (distinct)' => ['matchdedup'],
+		];
+	}
+
+	#[DataProvider('caseAndNearMissProvider')]
+	public function testCaseVariantAndNearMissHeaderIsNotReservedEvenUnderDeny(string $header): void
+	{
+		// FreeBSD UFS/ZFS are case-sensitive: 'matchDedup_v4.txt' != 'matchdedup_v4.txt'.
+		// A lowercase-compare would reject a legitimate header for no reason.
+		$this->assertSame('', pfb_header_reserved_error($header, 'Deny_Both'));
+	}
+}


### PR DESCRIPTION
Fixes #1234.

## The collision

`pfb_recompute_finish()` (`pfblockerng.sh`) writes each Deny alias's reputation artifact to `match<header>_<fam>.txt`, and the reserved reputation ccwhite-dedup file in the same directory is `matchdedup_v4.txt`. A Deny-type list whose *source Header* is literally `dedup` therefore resolves to the identical path.

The header is raw user text — `pfblockerng.inc:16286` builds it as `"{$row['header']}{$vtype}"`, and the only sanitisation is a `\W` strip, so `dedup` reaches the filesystem verbatim. (The `pfB_` prefix applies to alias *names*, not to source headers.)

Both writers live in the same function and the same swap block: the per-alias loop runs first, then the dedup swap, so the dedup file either overwrites the alias's artifact or — when there are no exempt CIDRs — `rm -f`s it. The Alerts page, which globs `matchdir/*.txt` to attribute a matched IP to its feed, then cannot tell the two apart.

## The fix

`pfb_header_reserved_error()` (`pfblockerng_extra.inc`, modelled on the sibling `pfb_adv_alias_field_errors()`) rejects the header at config-save time when the list's action includes `Deny`. The match is exact and case-sensitive: FreeBSD's filesystems are case-sensitive, so `Dedup` produces a distinct filename and rejecting it would refuse a legitimate header for no reason.

The four rejecting actions (`Deny_Inbound`, `Deny_Outbound`, `Deny_Both`, `Alias_Deny`) are exactly those matching the `strpos($action, 'Deny')` test that `pfblockerng.inc:16285` uses to populate the deny set recompute reads.

## Help-text correction

The Country-Code infoblock told users to point an Alias `Localfile` at `/var/db/pfblockerng/match/matchdedup.txt` — a filename **no writer anywhere produces**. Corrected to `matchdedup_v4.txt`, and the stale comment in `pfblockerng.sh` naming the bare form is removed, so the token is fully retired (zero-hit tree grep).

Deliberately **not** documenting a `matchdedup_v6.txt`: reputation is v4-only by design (`pfblockerng.inc:19176` forces `repmode` to `off` for the v6 family), so no v6 dedup file is ever written and advertising one would send users to a path that never exists.

## Scope

Narrow on purpose. Relocating or re-prefixing the recompute artifacts would kill the whole collision class, but those files feed the Alerts attribution glob and users may reference them in floating Match-rule setups, so moving them is a user-visible change that needs its own design pass. Filed as #1250, together with two related items this fix does not close:

- a Match list header `matchH` collides with a Deny list `H`'s artifact (same overlap, no reserved name involved);
- `pfblockerng.inc:16265-16269` strips `\W` from a stored header at *runtime*, so a config arriving by import or HA sync as `de-dup` normalises to `dedup` and still collides behind this save-time check.

## Tests

- `CategoryEditReservedHeaderTest` — the red-proof/wiring test. Eval-extracts the real page's validation region verbatim (the `CategoryEditPostGuardTest` technique, since the page carries top-level execution and cannot be `require()`d off-appliance), so one file proves red on the old code and green on the new. Verified with `verify-red-proof.sh`: FREEZE-OK / RED-OK / GREEN-OK.
- `HeaderReservedErrorTest` — unit coverage of the helper across the full action axis (4 reject, 10 allow, plus DNSBL `unbound`) and the hostile-input rows: case variants, near-misses (`dedupfoo`, `matchdedup`), empty, `\W`, and a disabled row.

Both the empty and `\W` rows assert that the *existing* error still fires and the reserved rule does not additionally trip, so the negative assertions cannot pass vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxB6ePGeNCz6fJFXTvFHFg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent the exact reserved `dedup` header from being used with Deny actions.
  * Validation applies only to active feed/list entries and preserves existing checks for invalid or empty headers.
  * Non-Deny actions, DNSBL actions, disabled entries, and case or spelling variations remain supported.

* **Documentation**
  * Updated the country-code de-duplication example to reference the correct IPv4 match list file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->