### PR TITLE
pfblockerng: add a hysteresis margin to the log-retention trim (#1109)

### DIFF
--- a/.ADRs/ADR_60_Age_Based_Log_Retention/ADR.md
+++ b/.ADRs/ADR_60_Age_Based_Log_Retention/ADR.md
@@ -572,3 +572,38 @@ left as written for the historical record; **this section is the authoritative c
 
 Related, same window: the array-path short-write gap the stream sibling already guarded
 (#1053) and the Log Settings absent-POST-key warning (#1056).
+
+**2026-07-13 — issue #1109: a hysteresis margin on both trim caps.**
+
+1. **`pfb_log_trim_margin_pct` — a single global percent (0-1000, default `'0'`), applying
+   uniformly to both caps.** High-water **trigger**, low-water **cut**: the margin only
+   delays *when* a trim fires (the file is left alone until its line count or oldest-line
+   age exceeds `cap × (1 + margin/100)`); once it fires, the trim still cuts back to the
+   **exact** cap, exactly as before. `margin=0` reproduces today's trigger point verbatim.
+   Deliberately **not** per-log-type and **not** per-cap-unit: one field, both caps.
+2. **Why a percentage, not an absolute count.** One global knob has to widen both a *line*
+   count (Max lines) and a *days* count (Max days) with the same value; a percentage is the
+   only unit expressible against either. An absolute offset (`+N lines` / `+N days`) would
+   need two separate fields, reintroducing the per-cap-unit split item 1 rejects.
+3. **The `margin=0` nuance — a byte-identical CONTENT change in I/O behaviour, not output.**
+   §2.2's original line high-water was implicit at "any excess" per tick; `pfb_log_trim_needed()`
+   now checks line count strictly `>` the cap (matching the age arm's existing strict `>`), so
+   a file already sitting exactly at its cap is no longer rewritten every idle tick. The
+   trimmed log's CONTENT is unchanged byte-for-byte in either case; only a redundant no-op
+   full-file rewrite (and its mtime bump) is elided. Nothing in this codebase keys on a log
+   file's mtime — ADR-42's content hashing covers feed sidecars, not logs.
+4. **`pfb_log_age_nolimit_pass_needed()` renamed to `pfb_log_age_trim_needed()`.** #1052's
+   probe (2026-07-09 item 3 above) was framed `nolimit`-only; the margin makes it the general age-trim
+   decision for every type, `nolimit` or capped. **`pfb_log_trim_needed()` is now the single
+   guard called from both `pfb_log_mgmt()` branches**, replacing the two duplicated #1052
+   skip lines with one call each; `margin=0` on the age arm is exactly #1052's original case.
+5. **Read cost is bounded and asymmetric with the write it replaces.** The line high-water
+   probe reads the whole file once per tick to decide; that is a read, not a write. Flash/SSD
+   wear is write-dominated, so a per-tick full-file read traded for an elided per-tick
+   full-file write is the intended trade, not an oversight.
+6. **Rejected alternatives (do not re-litigate).** In-place head eviction (`memmove` +
+   `ftruncate` on the line cap) was rejected: it opens a torn-write window §1.5 doesn't cover
+   today and is a materially different write path from the existing tail-and-replace trim.
+   A calendar-boundary or marker-file scheme (e.g. "only trim once per UTC day") was rejected
+   because it reintroduces exactly the mtime/marker-file fragility §1.1 and §2.1 deleted this
+   ADR to get away from, plus ADR-30's clock-skew sawtooth (§1.2).

--- a/.ADRs/ADR_60_Age_Based_Log_Retention/ADR.md
+++ b/.ADRs/ADR_60_Age_Based_Log_Retention/ADR.md
@@ -600,7 +600,12 @@ Related, same window: the array-path short-write gap the stream sibling already 
 5. **Read cost is bounded and asymmetric with the write it replaces.** The line high-water
    probe reads the whole file once per tick to decide; that is a read, not a write. Flash/SSD
    wear is write-dominated, so a per-tick full-file read traded for an elided per-tick
-   full-file write is the intended trade, not an oversight.
+   full-file write is the intended trade, not an oversight. **`pfb_log_line_count()` counts a
+   line the way `tail(1)` does** — an unterminated trailing chunk is a line, not a fragment —
+   because the count gates a `tail`-based rewrite and the two must agree. Counting bare `\n`
+   bytes undercounts a log left mid-line (the state `pfb_logger('.', 1)`'s progress fragments
+   leave, and what `pfb_logger_target_starts_at_bol()` exists to detect), which reads as "at
+   cap" when the log is really over it and silently skips a trim the write path would perform.
 6. **Rejected alternatives (do not re-litigate).** In-place head eviction (`memmove` +
    `ftruncate` on the line cap) was rejected: it opens a torn-write window §1.5 doesn't cover
    today and is a materially different write path from the existing tail-and-replace trim.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3064,6 +3064,18 @@ function pfb_log_max_days($raw): int {
 	return 0;
 }
 
+// Resolve a stored 'pfb_log_trim_margin_pct' config value to the hysteresis
+// margin percent pfb_log_trim_needed() applies (issue #1109). Mirrors
+// pfb_log_max_days()'s fallback shape: non-numeric/garbage/absent -> 0 (off). PURE.
+function pfb_log_trim_margin_pct($raw): int {
+	if (is_scalar($raw) && preg_match('/^[0-9]+$/', (string) $raw)) {
+		// Clamp: 1000% keeps the age high-water arithmetic exact well under
+		// PHP_INT_MAX even at pfb_log_max_days()'s own 3650000-day clamp.
+		return min((int) $raw, 1000);
+	}
+	return 0;
+}
+
 // ADR-60 S2.1: where a log type's Y-m-d H:i:s timestamp lives in a line -- a
 // leading line-prefix for the free-text logs, else a fixed CSV field (verified
 // per writer: pfb_logger()/pfb_daemon_filterlog()/pfb_parsed_fail()/dnsbl.log's
@@ -3221,12 +3233,10 @@ function pfb_log_age_trim_write_ok($written, string $content): bool {
 	return $written !== FALSE && $written === strlen($content);
 }
 
-// issue #1052: probe-before-copy for the 'nolimit'+age-cap path -- log lines are
-// chronologically appended, so an unexpired FIRST line means nothing in $path can
-// be expired; the caller skips its whole copy()+age-trim pass this tick. An
-// unparseable/legacy first line falls through to TRUE (pass must run), matching
-// pfb_log_age_cutoff()'s own "unparseable = expired" rule.
-function pfb_log_age_nolimit_pass_needed(string $path, int $agedays, string $logtype): bool {
+// issue #1052/#1109: probe-before-copy for the age-cap pass (both branches) --
+// an unexpired FIRST line means nothing is expired (skip this tick); unparseable/
+// empty/unopenable fall through TRUE. $margin_pct widens the cutoff (0=exact).
+function pfb_log_age_trim_needed(string $path, int $agedays, string $logtype, int $margin_pct = 0): bool {
 	$fh = @fopen($path, 'r');
 	if ($fh === FALSE) {
 		return TRUE;
@@ -3242,7 +3252,41 @@ function pfb_log_age_nolimit_pass_needed(string $path, int $agedays, string $log
 		return TRUE; // unparseable/legacy first line -- must run the full pass
 	}
 
-	return $ts < (time() - ($agedays * 86400));
+	$window = (int) ($agedays * 86400 * (1 + $margin_pct / 100));
+	return $ts < (time() - $window);
+}
+
+// issue #1109: pure PHP '\n' count (no exec()/wc -- off-appliance-testable, no
+// per-tick process spawn across 11 log types). Fail (unopenable/short read) ->
+// PHP_INT_MAX so the high-water guard FIRES -- same fail-open direction as #1052.
+function pfb_log_line_count(string $path): int {
+	$fh = @fopen($path, 'r');
+	if ($fh === FALSE) {
+		return PHP_INT_MAX;
+	}
+
+	$lines = 0;
+	while (($chunk = fread($fh, 1048576)) !== FALSE && $chunk !== '') {
+		$lines += substr_count($chunk, "\n");
+	}
+	$ok = feof($fh);
+	fclose($fh);
+
+	return $ok ? $lines : PHP_INT_MAX;
+}
+
+// issue #1109: ONE unified high-water guard for both pfb_log_mgmt() branches --
+// fires iff an active cap is past its margin-widened high-water mark. Float math
+// (ADR-28 #2 short-circuit): $logmax is unclamped so intdiv() could get a float.
+function pfb_log_trim_needed(int|string $logmax, int $agedays, string $path, string $logtype, int $margin_pct): bool {
+	if ($logmax !== 'nolimit') {
+		$high_water = (float) $logmax * (1.0 + ($margin_pct / 100.0));
+		if ((float) pfb_log_line_count($path) > $high_water) {
+			return TRUE;
+		}
+	}
+
+	return $agedays > 0 && pfb_log_age_trim_needed($path, $agedays, $logtype, $margin_pct);
 }
 
 // Manage log files line limit + age-based retention (ADR-60)
@@ -3251,6 +3295,8 @@ function pfb_log_mgmt() {
 	pfb_global();
 
 	$chroot_folder = '/var/unbound';
+	// issue #1109: global hysteresis margin, read once for every log type.
+	$margin_pct = pfb_log_trim_margin_pct($pfb['config']['pfb_log_trim_margin_pct'] ?? '');
 
 	foreach (array(	'log', 'errlog', 'extraslog', 'ip_blocklog', 'ip_permitlog', 'ip_matchlog',
 			'ip_parse_err', 'dnslog', 'dnsbl_parse_err', 'dnsreplylog', 'unilog') as $logtype) {
@@ -3281,9 +3327,9 @@ function pfb_log_mgmt() {
 				}
 
 				if (file_exists($final_log_file)) {
-					// issue #1052: 'nolimit'+age-cap -- skip the whole copy()+age-trim
-					// pass this tick when the first (oldest) line hasn't expired yet.
-					if ($logmax === 'nolimit' && !pfb_log_age_nolimit_pass_needed($final_log_file, $agedays, $logtype)) {
+					// issue #1109: skip this tick's whole pass unless an active cap is
+					// past its margin-widened high-water mark (the hysteresis trigger).
+					if (!pfb_log_trim_needed($logmax, $agedays, $final_log_file, $logtype, $margin_pct)) {
 						unlink_if_exists($temp);
 						continue;
 					}
@@ -3320,8 +3366,8 @@ function pfb_log_mgmt() {
 			}
 			else {
 				$temp = tempnam("{$g['tmp_path']}/", 'pfb_log_');
-				// issue #1052: same nolimit+age-cap skip as the chroot branch above.
-				if ($logmax === 'nolimit' && !pfb_log_age_nolimit_pass_needed($pfb[$logtype], $agedays, $logtype)) {
+				// issue #1109: same unified high-water guard as the chroot branch above.
+				if (!pfb_log_trim_needed($logmax, $agedays, $pfb[$logtype], $logtype, $margin_pct)) {
 					unlink_if_exists($temp);
 					continue;
 				}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3256,9 +3256,12 @@ function pfb_log_age_trim_needed(string $path, int $agedays, string $logtype, in
 	return $ts < (time() - $window);
 }
 
-// issue #1109: pure PHP '\n' count (no exec()/wc -- off-appliance-testable, no
+// issue #1109: pure PHP line count (no exec()/wc -- off-appliance-testable, no
 // per-tick process spawn across 11 log types). Fail (unopenable/short read) ->
 // PHP_INT_MAX so the high-water guard FIRES -- same fail-open direction as #1052.
+// Counts as tail(1) does -- an unterminated trailing chunk IS a line (the state
+// pfb_logger('.', 1)'s progress fragments leave) -- else the guard undercounts a
+// mid-line log by one, reads "at cap" for "over cap", and skips a needed trim.
 function pfb_log_line_count(string $path): int {
 	$fh = @fopen($path, 'r');
 	if ($fh === FALSE) {
@@ -3272,7 +3275,11 @@ function pfb_log_line_count(string $path): int {
 	$ok = feof($fh);
 	fclose($fh);
 
-	return $ok ? $lines : PHP_INT_MAX;
+	if (!$ok) {
+		return PHP_INT_MAX;
+	}
+
+	return $lines + (pfb_logger_target_starts_at_bol($path) ? 0 : 1);
 }
 
 // issue #1109: ONE unified high-water guard for both pfb_log_mgmt() branches --

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3259,9 +3259,8 @@ function pfb_log_age_trim_needed(string $path, int $agedays, string $logtype, in
 // issue #1109: pure PHP line count (no exec()/wc -- off-appliance-testable, no
 // per-tick process spawn across 11 log types). Fail (unopenable/short read) ->
 // PHP_INT_MAX so the high-water guard FIRES -- same fail-open direction as #1052.
-// Counts as tail(1) does -- an unterminated trailing chunk IS a line (the state
-// pfb_logger('.', 1)'s progress fragments leave) -- else the guard undercounts a
-// mid-line log by one, reads "at cap" for "over cap", and skips a needed trim.
+// Counts a line as tail(1) does (ADR-60 S8 item 5): an unterminated trailing
+// chunk IS a line, so track the final byte of the read we already do.
 function pfb_log_line_count(string $path): int {
 	$fh = @fopen($path, 'r');
 	if ($fh === FALSE) {
@@ -3269,8 +3268,10 @@ function pfb_log_line_count(string $path): int {
 	}
 
 	$lines = 0;
+	$last_byte = '';
 	while (($chunk = fread($fh, 1048576)) !== FALSE && $chunk !== '') {
 		$lines += substr_count($chunk, "\n");
+		$last_byte = $chunk[-1];
 	}
 	$ok = feof($fh);
 	fclose($fh);
@@ -3279,7 +3280,7 @@ function pfb_log_line_count(string $path): int {
 		return PHP_INT_MAX;
 	}
 
-	return $lines + (pfb_logger_target_starts_at_bol($path) ? 0 : 1);
+	return $lines + ($last_byte === '' || $last_byte === "\n" ? 0 : 1);
 }
 
 // issue #1109: ONE unified high-water guard for both pfb_log_mgmt() branches --

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -623,6 +623,16 @@ function pfb_cfg_registry(): array
 
 	$registry = $registry + [
 
+		// issue #1109: log-retention trim hysteresis margin percent (global,
+		// applies uniformly to both the line-count and age caps). Default '0'.
+		'pfb_log_trim_margin_pct' => [
+			'section'       => $gen,
+			'default'       => '0',
+			'read_adapter'  => NULL,
+			'write_adapter' => NULL,
+			'since'         => '4.0.0',
+		],
+
 		// Software update check last-seen version (string or null). Default ''.
 		'pfb_software_check' => [
 			'section'       => $gen,

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -91,6 +91,10 @@ foreach ($log_suffixes as $log_suffix) {
 // log_syslog uses the PfbToggle adapter — extract the scalar .value for pfb_cfg_toggle_read().
 $pconfig['log_syslog']			= PfbConfig::read('log_syslog')->value;
 
+// issue #1109: log-trim hysteresis margin (percent, global). Read via PfbConfig::read so
+// the registered default ('0') applies when the key is absent (new install / upgrade).
+$pconfig['pfb_log_trim_margin_pct']	= PfbConfig::read('pfb_log_trim_margin_pct');
+
 // Select field options
 $options_pfb_interval	= [	'1' => 'Every hour',
 				'2' => 'Every 2 hours',
@@ -168,6 +172,14 @@ if ($_POST) {
 			$_POST[$dkey] = (string) $v;
 		}
 
+		// issue #1109: validate the log-trim hysteresis margin the same way (non-negative
+		// integer string; the backend parser independently clamps it to 0-1000).
+		$margin_v = $_POST['pfb_log_trim_margin_pct'] ?? '0';
+		if (is_array($margin_v) || !ctype_digit((string) $margin_v)) {
+			$margin_v = '0';
+		}
+		$_POST['pfb_log_trim_margin_pct'] = (string) $margin_v;
+
 		// issue #1070: an array-valued POST ('pfb_feed_internal_allowlist[]=x')
 		// throws a PHP 8 TypeError in trim()/base64_encode() below; reject it
 		// here so the save gate blocks and the stored allowlist is preserved.
@@ -214,6 +226,11 @@ if ($_POST) {
 			foreach ($log_suffixes as $log_suffix) {
 				$pfb['gconfig']['log_max_days_' . $log_suffix]	= $_POST['log_max_days_' . $log_suffix]	?: '0';
 			}
+
+			// issue #1109: persist the log-trim hysteresis margin (validated above; default
+			// '0'). Written into $pfb['gconfig'] so writeSection() below includes it -- a bare
+			// PfbConfig::write() would be overwritten by writeSection.
+			$pfb['gconfig']['pfb_log_trim_margin_pct']	= $_POST['pfb_log_trim_margin_pct']	?: '0';
 
 			// ADR-38: persist syslog export toggle. Written into $pfb['gconfig'] so the
 			// writeSection() call below includes it; a bare PfbConfig::write() before
@@ -393,8 +410,26 @@ $section->addInput(new Form_StaticText(
 	. '<li><strong>Max lines</strong> &mdash; rolling cap; the log keeps only its most recent N lines.</li>'
 	. '<li><strong>Max days</strong> &mdash; trims lines older than this many days (0 = disabled); '
 	. 'independent of Max lines &mdash; whichever cap is more restrictive wins.</li>'
+	. '<li><strong>Trim Margin</strong> &mdash; percent tolerance above whichever cap is active; '
+	. 'the log is rewritten only once it drifts past cap + margin% (0 = trim as soon as exceeded), '
+	. 'then trimmed back to the exact cap &mdash; a larger margin means fewer, larger rewrites and '
+	. 'less flash/SSD wear.</li>'
 	. '</ul>'
 ));
+
+// issue #1109: log-trim hysteresis margin -- a single global percentage applying to both
+// the line and age caps (see the intro list above for the trigger/cut semantics).
+$section->addInput((new Form_Input(
+	'pfb_log_trim_margin_pct',
+	'Trim Margin',
+	'number',
+	$pconfig['pfb_log_trim_margin_pct']
+))->setAttribute('min', '0')->setAttribute('max', '1000'))->setHelp(
+	'Percent tolerance above whichever cap (Max lines or Max days) is active. The log is '
+	. 'rewritten only once it drifts past cap + margin%, then trimmed back to the exact cap. '
+	. '<strong>0</strong> (default) trims as soon as the cap is exceeded. A larger margin means '
+	. 'fewer, larger rewrites &mdash; less flash/SSD wear.'
+);
 
 foreach ($log_types as $logdescr => $logtype) {
 	// Header row: shaded category divider; the StaticText children label the columns on

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -172,13 +172,10 @@ if ($_POST) {
 			$_POST[$dkey] = (string) $v;
 		}
 
-		// issue #1109: validate the log-trim hysteresis margin the same way (non-negative
-		// integer string; the backend parser independently clamps it to 0-1000).
-		$margin_v = $_POST['pfb_log_trim_margin_pct'] ?? '0';
-		if (is_array($margin_v) || !ctype_digit((string) $margin_v)) {
-			$margin_v = '0';
-		}
-		$_POST['pfb_log_trim_margin_pct'] = (string) $margin_v;
+		// issue #1109: canonicalize the log-trim hysteresis margin through the same parser
+		// the backend reads it with, so the STORED value is the effective one -- storing an
+		// out-of-range '999999999' would render a number the runtime clamp never uses.
+		$_POST['pfb_log_trim_margin_pct'] = (string) pfb_log_trim_margin_pct($_POST['pfb_log_trim_margin_pct'] ?? '0');
 
 		// issue #1070: an array-valued POST ('pfb_feed_internal_allowlist[]=x')
 		// throws a PHP 8 TypeError in trim()/base64_encode() below; reject it

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -730,6 +730,60 @@ final class CfgGatewayTest extends TestCase
 			"write(read('02:00-06:00'))=='02:00-06:00' for pfb_quiet_hours");
 	}
 
+	// -----------------------------------------------------------------------
+	// issue #1109 — pfb_log_trim_margin_pct (global hysteresis margin percent)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * pfb_log_trim_margin_pct absent key returns the registered default '0'
+	 * (no hysteresis -- today's exact-cap trim behaviour).
+	 *
+	 * Scenario:
+	 *   Background: pfb_log_trim_margin_pct is a plain-string field; default = '0'.
+	 *     Given no stored value.
+	 *     When PfbConfig::read('pfb_log_trim_margin_pct').
+	 *     Then '0' is returned.
+	 */
+	public function testPfbLogTrimMarginPctAbsentKeyReturnsDefaultZero(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct';
+
+		// Before: absent.
+		$this->assertNull(config_get_path($path), 'before: pfb_log_trim_margin_pct must be absent');
+
+		// When/Then: absent -> default '0'.
+		$result = PfbConfig::read('pfb_log_trim_margin_pct');
+		$this->assertSame('0', $result, 'pfb_log_trim_margin_pct absent -> default 0');
+	}
+
+	/**
+	 * pfb_log_trim_margin_pct round-trips losslessly for a non-default value.
+	 *
+	 * Scenario:
+	 *   Background: pfb_log_trim_margin_pct is a plain-string field (no adapter).
+	 *     Given stored = '50'.
+	 *     When PfbConfig::write('pfb_log_trim_margin_pct', PfbConfig::read('pfb_log_trim_margin_pct')).
+	 *     Then stored string == '50' (write(read('50')) == '50').
+	 */
+	public function testPfbLogTrimMarginPctRoundTrip(): void
+	{
+		$path = 'installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct';
+
+		// Given: '50' stored.
+		$this->seedConfig($path, '50');
+
+		// Before: raw value is '50'.
+		$this->assertSame('50', config_get_path($path), "before: pfb_log_trim_margin_pct seed is '50'");
+
+		// When: read -> write.
+		$val = PfbConfig::read('pfb_log_trim_margin_pct');
+		$this->assertSame('50', $val, "read: pfb_log_trim_margin_pct '50' -> '50'");
+
+		// After: write back produces '50'.
+		PfbConfig::write('pfb_log_trim_margin_pct', $val);
+		$this->assertSame('50', config_get_path($path), "write(read('50'))=='50' for pfb_log_trim_margin_pct");
+	}
+
 	// ADR-38 — log_syslog (toggle; Amendment 1: facility/priority removed)
 	// -----------------------------------------------------------------------
 
@@ -974,6 +1028,8 @@ final class CfgGatewayTest extends TestCase
 			// ADR-43: tick-cron dispatch interval + apply-on-change window
 			'pfb_tick_interval',
 			'pfb_quiet_hours',
+			// issue #1109: log-retention trim hysteresis margin percent
+			'pfb_log_trim_margin_pct',
 			// ADR-38: syslog export toggle
 			'log_syslog',
 

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -794,7 +794,7 @@ final class CfgGatewayTest extends TestCase
 		$this->seedConfig($path, '0');
 		$this->assertSame('0', config_get_path($path), "before: pfb_log_trim_margin_pct seed is '0'");
 
-		// The exact shape pfblockerng_general.php uses (:52 read, :243 write).
+		// The exact readSection/writeSection shape pfblockerng_general.php saves with.
 		$gen = 'installedpackages/pfblockerng/config/0';
 		$section = PfbConfig::readSection($gen);
 		$section['pfb_log_trim_margin_pct'] = '50';

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -784,6 +784,28 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('50', config_get_path($path), "write(read('50'))=='50' for pfb_log_trim_margin_pct");
 	}
 
+	public function testPfbLogTrimMarginPctSurvivesSectionWrite(): void
+	{
+		// The UI saves the whole section (writeSection), never a per-field write, so the
+		// per-field round-trip above cannot catch a key dropped on the section path. Tier-B
+		// covers the real save, but it is schedule-only -- this is the PR-gated guard.
+		$path = 'installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct';
+
+		$this->seedConfig($path, '0');
+		$this->assertSame('0', config_get_path($path), "before: pfb_log_trim_margin_pct seed is '0'");
+
+		// The exact shape pfblockerng_general.php uses (:52 read, :243 write).
+		$gen = 'installedpackages/pfblockerng/config/0';
+		$section = PfbConfig::readSection($gen);
+		$section['pfb_log_trim_margin_pct'] = '50';
+		PfbConfig::writeSection($gen, $section);
+
+		$this->assertSame('50', config_get_path($path),
+			'the section write must carry pfb_log_trim_margin_pct -- a key dropped here saves nothing from the UI'
+		);
+		$this->assertSame('50', PfbConfig::read('pfb_log_trim_margin_pct'), 'and the gateway must read it back');
+	}
+
 	// ADR-38 — log_syslog (toggle; Amendment 1: facility/priority removed)
 	// -----------------------------------------------------------------------
 

--- a/tests/php/LogAgeTrimNeededTest.php
+++ b/tests/php/LogAgeTrimNeededTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_log_age_trim_needed() -- issue #1052/#1109: probe-before-copy for the
+ * age-cap pass, renamed+generalised from pfb_log_age_nolimit_pass_needed
+ * (which only ever gated the 'nolimit' branch) to also gate the numeric-cap
+ * branch via pfb_log_trim_needed(). $margin_pct widens the cutoff window;
+ * margin=0 is byte-identical to the pre-#1109 pfb_log_age_nolimit_pass_needed
+ * formula, so every #1052 case is re-pinned here at margin=0.
+ */
+#[CoversFunction('pfb_log_age_trim_needed')]
+final class LogAgeTrimNeededTest extends TestCase
+{
+	private string $tmpFile;
+
+	protected function setUp(): void
+	{
+		$this->tmpFile = (string) tempnam(sys_get_temp_dir(), 'pfb_age_trim_needed_');
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_file($this->tmpFile)) {
+			unlink($this->tmpFile);
+		}
+	}
+
+	private function daysAgo(int $days): string
+	{
+		return date('Y-m-d H:i:s', time() - ($days * 86400));
+	}
+
+	/** margin=0, oldest line NOT expired -- identical to #1052 today. */
+	public function testMarginZeroOldestUnexpiredReturnsFalse(): void
+	{
+		file_put_contents($this->tmpFile, $this->daysAgo(5) . " fresh-enough\n");
+		$this->assertFalse(
+			pfb_log_age_trim_needed($this->tmpFile, 10, 'log', 0),
+			'margin=0: a 5-day-old first line under a 10-day cap must not need a pass'
+		);
+	}
+
+	/** margin=0, oldest line expired -- identical to #1052 today. */
+	public function testMarginZeroOldestExpiredReturnsTrue(): void
+	{
+		file_put_contents($this->tmpFile, $this->daysAgo(15) . " too-old\n");
+		$this->assertTrue(
+			pfb_log_age_trim_needed($this->tmpFile, 10, 'log', 0),
+			'margin=0: a 15-day-old first line past a 10-day cap must need a pass'
+		);
+	}
+
+	/** margin=50, oldest past the cap but inside the 1.5x window -- the new hysteresis. */
+	public function testMarginFiftyWithinHighWaterWindowReturnsFalse(): void
+	{
+		// cap=10 days, margin=50 -> window=15 days; 12 days old is past the cap
+		// but still inside the widened window.
+		file_put_contents($this->tmpFile, $this->daysAgo(12) . " past-cap-in-window\n");
+		$this->assertFalse(
+			pfb_log_age_trim_needed($this->tmpFile, 10, 'log', 50),
+			'margin=50: a 12-day-old first line (cap=10, window=15) must not need a pass'
+		);
+	}
+
+	/** margin=50, oldest past the 1.5x window -- must fire. */
+	public function testMarginFiftyBeyondHighWaterWindowReturnsTrue(): void
+	{
+		file_put_contents($this->tmpFile, $this->daysAgo(20) . " past-window\n");
+		$this->assertTrue(
+			pfb_log_age_trim_needed($this->tmpFile, 10, 'log', 50),
+			'margin=50: a 20-day-old first line (cap=10, window=15) must need a pass'
+		);
+	}
+
+	/** empty file -- fallthrough preserved regardless of margin. */
+	public function testEmptyFileReturnsTrueRegardlessOfMargin(): void
+	{
+		file_put_contents($this->tmpFile, '');
+		$this->assertTrue(
+			pfb_log_age_trim_needed($this->tmpFile, 10, 'log', 50),
+			'an empty file must fall through to TRUE (let the no-op pass run)'
+		);
+	}
+
+	/** unparseable/legacy first line -- fallthrough preserved regardless of margin. */
+	public function testUnparseableFirstLineReturnsTrueRegardlessOfMargin(): void
+	{
+		file_put_contents($this->tmpFile, "pre-ADR-60 legacy line, no timestamp\n");
+		$this->assertTrue(
+			pfb_log_age_trim_needed($this->tmpFile, 10, 'log', 50),
+			'an unparseable/legacy first line must fall through to TRUE'
+		);
+	}
+
+	/** unopenable path -- fallthrough preserved regardless of margin. */
+	public function testUnopenablePathReturnsTrueRegardlessOfMargin(): void
+	{
+		$missing = $this->tmpFile . '-does-not-exist';
+		$this->assertTrue(
+			pfb_log_age_trim_needed($missing, 10, 'log', 50),
+			'an unopenable path must fall through to TRUE'
+		);
+	}
+}

--- a/tests/php/LogAgeTrimNeededTest.php
+++ b/tests/php/LogAgeTrimNeededTest.php
@@ -7,11 +7,10 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * pfb_log_age_trim_needed() -- issue #1052/#1109: probe-before-copy for the
- * age-cap pass, renamed+generalised from pfb_log_age_nolimit_pass_needed
- * (which only ever gated the 'nolimit' branch) to also gate the numeric-cap
- * branch via pfb_log_trim_needed(). $margin_pct widens the cutoff window;
- * margin=0 is byte-identical to the pre-#1109 pfb_log_age_nolimit_pass_needed
- * formula, so every #1052 case is re-pinned here at margin=0.
+ * age-cap pass, renamed+generalised from the original #1052 'nolimit'-only
+ * probe to also gate the numeric-cap branch via pfb_log_trim_needed().
+ * $margin_pct widens the cutoff window; margin=0 is byte-identical to the
+ * pre-#1109 formula, so every #1052 case is re-pinned here at margin=0.
  */
 #[CoversFunction('pfb_log_age_trim_needed')]
 final class LogAgeTrimNeededTest extends TestCase

--- a/tests/php/LogLineCountTest.php
+++ b/tests/php/LogLineCountTest.php
@@ -6,11 +6,13 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_log_line_count() -- issue #1109: pure-PHP '\n' byte count feeding
- * pfb_log_trim_needed()'s line-cap high-water check (no exec()/wc). Any
- * probe failure (unopenable path, short/failed read) -> PHP_INT_MAX so the
- * guard FIRES -- fail-open, same direction as #1052's probe: a probe failure
- * must never silently disable retention.
+ * pfb_log_line_count() -- issue #1109: pure-PHP, tail(1)-compatible line count
+ * feeding pfb_log_trim_needed()'s line-cap high-water check (no exec()/wc). It
+ * gates a tail(1) rewrite, so it counts a line as tail does: an unterminated
+ * trailing chunk IS a line (ADR-60 S8 item 5). Any probe failure (unopenable
+ * path, short/failed read) -> PHP_INT_MAX so the guard FIRES -- fail-open, same
+ * direction as #1052's probe: a probe failure must never silently disable
+ * retention.
  */
 #[CoversFunction('pfb_log_line_count')]
 final class LogLineCountTest extends TestCase

--- a/tests/php/LogLineCountTest.php
+++ b/tests/php/LogLineCountTest.php
@@ -44,6 +44,15 @@ final class LogLineCountTest extends TestCase
 		$this->assertSame(3, pfb_log_line_count($this->tmpFile), '3 lines with no trailing newline must count as 3');
 	}
 
+	public function testSingleUnterminatedLineNoNewlineCountsAsOne(): void
+	{
+		// The boundary between "empty" and "one dangling line": zero newline bytes,
+		// but tail(1) (and grep -c '^') both call this one line. Counting newlines
+		// alone would call it zero and never trim a single-line-over-cap log.
+		file_put_contents($this->tmpFile, 'abc');
+		$this->assertSame(1, pfb_log_line_count($this->tmpFile), 'one unterminated line with no newline must count as 1');
+	}
+
 	public function testEmptyFileCountsZero(): void
 	{
 		file_put_contents($this->tmpFile, '');

--- a/tests/php/LogLineCountTest.php
+++ b/tests/php/LogLineCountTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_log_line_count() -- issue #1109: pure-PHP '\n' byte count feeding
+ * pfb_log_trim_needed()'s line-cap high-water check (no exec()/wc). Any
+ * probe failure (unopenable path, short/failed read) -> PHP_INT_MAX so the
+ * guard FIRES -- fail-open, same direction as #1052's probe: a probe failure
+ * must never silently disable retention.
+ */
+#[CoversFunction('pfb_log_line_count')]
+final class LogLineCountTest extends TestCase
+{
+	private string $tmpFile;
+
+	protected function setUp(): void
+	{
+		$this->tmpFile = (string) tempnam(sys_get_temp_dir(), 'pfb_line_count_');
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_file($this->tmpFile)) {
+			unlink($this->tmpFile);
+		}
+	}
+
+	public function testTrailingNewlineCountsExactLines(): void
+	{
+		file_put_contents($this->tmpFile, "a\nb\nc\n");
+		$this->assertSame(3, pfb_log_line_count($this->tmpFile), '3 newline-terminated lines must count as 3');
+	}
+
+	public function testNoTrailingNewlineUndercountsByOneHarmlessly(): void
+	{
+		// Documented, harmless undercount at a cap x (1+margin) threshold --
+		// pinned as intended (issue #1109); no added complexity to fix it.
+		file_put_contents($this->tmpFile, "a\nb\nc");
+		$this->assertSame(2, pfb_log_line_count($this->tmpFile), '3 lines with no trailing newline must count as 2');
+	}
+
+	public function testEmptyFileCountsZero(): void
+	{
+		file_put_contents($this->tmpFile, '');
+		$this->assertSame(0, pfb_log_line_count($this->tmpFile), 'an empty file must count as 0');
+	}
+
+	public function testMissingPathReturnsPhpIntMaxSoGuardFires(): void
+	{
+		$missing = $this->tmpFile . '-does-not-exist';
+		$this->assertSame(
+			PHP_INT_MAX,
+			pfb_log_line_count($missing),
+			'a missing/unopenable path must return PHP_INT_MAX so the high-water guard fires'
+		);
+	}
+}

--- a/tests/php/LogLineCountTest.php
+++ b/tests/php/LogLineCountTest.php
@@ -35,12 +35,13 @@ final class LogLineCountTest extends TestCase
 		$this->assertSame(3, pfb_log_line_count($this->tmpFile), '3 newline-terminated lines must count as 3');
 	}
 
-	public function testNoTrailingNewlineUndercountsByOneHarmlessly(): void
+	public function testDanglingLastLineCountsAsALineLikeTail(): void
 	{
-		// Documented, harmless undercount at a cap x (1+margin) threshold --
-		// pinned as intended (issue #1109); no added complexity to fix it.
+		// The count gates a tail(1)-based rewrite, so it must agree with tail's
+		// own notion of a line: an unterminated trailing chunk IS a line. Counting
+		// bare "\n" bytes undercounts it and silently skips a needed trim (#1109).
 		file_put_contents($this->tmpFile, "a\nb\nc");
-		$this->assertSame(2, pfb_log_line_count($this->tmpFile), '3 lines with no trailing newline must count as 2');
+		$this->assertSame(3, pfb_log_line_count($this->tmpFile), '3 lines with no trailing newline must count as 3');
 	}
 
 	public function testEmptyFileCountsZero(): void

--- a/tests/php/LogMgmtAgeCutoffTest.php
+++ b/tests/php/LogMgmtAgeCutoffTest.php
@@ -113,6 +113,12 @@ final class LogMgmtAgeCutoffTest extends TestCase
 		config_set_path("{$gen}/log_max_days_{$logtype}", $maxDays);
 	}
 
+	/** Set the GLOBAL hysteresis margin percent (issue #1109; applies to every log type). */
+	private function setMarginPct(string $pct): void
+	{
+		config_set_path('installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct', $pct);
+	}
+
 	private function logPath(string $logtype): string
 	{
 		return $GLOBALS['pfb'][$logtype];
@@ -868,5 +874,298 @@ final class LogMgmtAgeCutoffTest extends TestCase
 
 		$complete = pfb_log_age_trim_write_ok(strlen($content), $content);
 		$this->assertTrue($complete, 'expected an exact full-length write to be flagged as complete');
+	}
+
+	// -----------------------------------------------------------------------
+	// issue #1109 -- pfb_log_trim_margin_pct hysteresis, wired through the
+	// real pfb_log_mgmt() on both the plain and chroot-fallback branches.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * RED->GREEN PROOF (line-cap hysteresis, plain branch): a file at 1.2x its
+	 * numeric line cap, margin=50 (high-water=1.5x), must be left untouched.
+	 *
+	 * Fails pre-#1109: today's code has no margin concept and always
+	 * tail -n's a numeric cap unconditionally -- 12 lines would be cut to 10.
+	 *
+	 * Scenario:
+	 *   Given log_max_log='10'; pfb_log_trim_margin_pct='50'.
+	 *   And   12 lines (1.2x cap, under the 1.5x high-water).
+	 *   Before: 12 lines; inode = I.
+	 *   When  pfb_log_mgmt() is called.
+	 *   Then  content is BYTE-IDENTICAL (still 12 lines) and inode is unchanged.
+	 */
+	public function testMarginHysteresisSkipsLineCapTrimWithinHighWaterPlainBranch(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('log', '10', '0');
+		$this->setMarginPct('50');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('log');
+		$lines = [];
+		for ($i = 0; $i < 12; $i++) {
+			$lines[] = "l{$i}";
+		}
+		$content = implode("\n", $lines) . "\n";
+		file_put_contents($logPath, $content);
+		$inodeBefore = fileinode($logPath);
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$this->assertSame($content, file_get_contents($logPath),
+			'12 lines (1.2x a 10-line cap) under the 1.5x margin high-water must be left byte-identical'
+		);
+		$this->assertSame($inodeBefore, fileinode($logPath), 'inode must be unchanged when the pass is skipped');
+	}
+
+	/**
+	 * Same proof as above on the CHROOT-fallback branch ('dnslog') -- Matrix
+	 * row E: every behavioural row exercised through both pfb_log_mgmt()
+	 * branches (chroot dir absent off-appliance -> falls back to the host
+	 * path, per LogRotateResetTest's established note).
+	 */
+	public function testMarginHysteresisSkipsLineCapTrimWithinHighWaterChrootBranch(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('dnslog', '10', '0');
+		$this->setMarginPct('50');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('dnslog');
+		$lines = [];
+		for ($i = 0; $i < 12; $i++) {
+			$lines[] = 'DNSBL-python,' . $this->now() . ",d{$i}.example.com,127.0.0.1,Python,Block,Feed,eval,feed,+,A";
+		}
+		$content = implode("\n", $lines) . "\n";
+		file_put_contents($logPath, $content);
+		$inodeBefore = fileinode($logPath);
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$this->assertSame($content, file_get_contents($logPath),
+			'chroot branch: 12 rows (1.2x a 10-row cap) under the 1.5x margin high-water must be byte-identical'
+		);
+		$this->assertSame($inodeBefore, fileinode($logPath), 'inode must be unchanged when the pass is skipped');
+	}
+
+	/**
+	 * Pinning companion (NOT a red proof -- pre-#1109 code already tails a
+	 * numeric cap to the exact count unconditionally, so this result is
+	 * unchanged before/after): once the high-water fires, the LOW-WATER cut
+	 * is still exact -- 16 lines (1.6x cap, over the 1.5x high-water) trim
+	 * down to precisely the 10-line cap, not to 15.
+	 */
+	public function testMarginHysteresisFiresLineCapTrimOverHighWaterCutsToExactCapPlainBranch(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('log', '10', '0');
+		$this->setMarginPct('50');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('log');
+		$lines = [];
+		for ($i = 0; $i < 16; $i++) {
+			$lines[] = "l{$i}";
+		}
+		file_put_contents($logPath, implode("\n", $lines) . "\n");
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$linesAfter = array_values(array_filter(explode("\n", (string) file_get_contents($logPath)), 'strlen'));
+		$this->assertSame(array_slice($lines, 6), $linesAfter,
+			'16 lines over the 1.5x high-water must cut to EXACTLY the 10-line cap (low-water), got '
+			. var_export($linesAfter, TRUE)
+		);
+	}
+
+	/**
+	 * RED->GREEN PROOF (age-cap hysteresis, plain branch): 'nolimit' + an age
+	 * cap, head past the cap but inside the margin-widened window, must be
+	 * left untouched.
+	 *
+	 * Fails pre-#1109: the pre-rename #1052 probe ignores margin -- a
+	 * 12-day-old head past a 10-day cap is judged expired, the pass runs,
+	 * and the old line is dropped.
+	 *
+	 * Scenario:
+	 *   Given log_max_log='nolimit'; log_max_days_log='10'; margin='50' (window=15d).
+	 *   And   1 line 12 days old (past cap, inside window) + 1 fresh line.
+	 *   Before: 2 lines.
+	 *   When  pfb_log_mgmt() is called.
+	 *   Then  content is BYTE-IDENTICAL (both lines survive).
+	 */
+	public function testMarginHysteresisSkipsAgeCapTrimWithinWindowPlainBranch(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('log', 'nolimit', '10');
+		$this->setMarginPct('50');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('log');
+		$old = $this->daysAgo(12) . ' still-in-window';
+		$new = $this->now() . ' fresh';
+		$content = $old . "\n" . $new . "\n";
+		file_put_contents($logPath, $content);
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$this->assertSame($content, file_get_contents($logPath),
+			'a 12-day-old head (age-cap=10d, margin=50 -> window=15d) must be left byte-identical'
+		);
+	}
+
+	/** Same proof as above on the CHROOT-fallback branch ('dnslog'). */
+	public function testMarginHysteresisSkipsAgeCapTrimWithinWindowChrootBranch(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('dnslog', 'nolimit', '10');
+		$this->setMarginPct('50');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('dnslog');
+		$old = 'DNSBL-python,' . $this->daysAgo(12) . ',old.example.com,127.0.0.1,Python,Block,Feed,eval,feed,+,A';
+		$new = 'DNSBL-python,' . $this->now()       . ',new.example.com,127.0.0.1,Python,Block,Feed,eval,feed,+,A';
+		$content = $old . "\n" . $new . "\n";
+		file_put_contents($logPath, $content);
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$this->assertSame($content, file_get_contents($logPath),
+			'chroot branch: a 12-day-old head within the margin window must be left byte-identical'
+		);
+	}
+
+	/**
+	 * Pinning companion (NOT a red proof -- pre-#1109 code already drops a
+	 * head past the exact cap; a head past the WIDENED window is past the
+	 * exact cap too, so this result is unchanged before/after): a head
+	 * beyond the 1.5x window still fires and is dropped.
+	 */
+	public function testMarginHysteresisFiresAgeCapTrimBeyondWindowPlainBranch(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('log', 'nolimit', '10');
+		$this->setMarginPct('50');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('log');
+		$old = $this->daysAgo(20) . ' past-window';
+		$new = $this->now() . ' fresh';
+		file_put_contents($logPath, $old . "\n" . $new . "\n");
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$linesAfter = array_values(array_filter(explode("\n", (string) file_get_contents($logPath)), 'strlen'));
+		$this->assertSame([$new], $linesAfter,
+			'a 20-day-old head beyond the 15-day window must still be dropped, got ' . var_export($linesAfter, TRUE)
+		);
+	}
+
+	/**
+	 * RED->GREEN PROOF (the elision itself -- headline row): a file already
+	 * within its numeric cap, margin='0', no age cap, must not even be
+	 * REWRITTEN this tick -- asserted via mtime (a rewrite bumps it to now)
+	 * so the proof cannot pass on today's code (unconditional rewrite) and
+	 * cannot flake on sub-second timing (an old, force-set mtime is compared
+	 * for exact equality, never a "did it change recently" window).
+	 *
+	 * Scenario:
+	 *   Given log_max_log='10'; log_max_days_log unset (0, off); margin='0'.
+	 *   And   5 lines (under cap); mtime forced to 1 hour ago.
+	 *   Before: mtime = M (1h ago).
+	 *   When  pfb_log_mgmt() is called.
+	 *   Then  mtime is STILL M and content is byte-identical (pass never ran).
+	 */
+	public function testMarginElisionLeavesFileUntouchedIncludingMtime(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('log', '10', '0');
+		$this->setMarginPct('0');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('log');
+		$content = "l0\nl1\nl2\nl3\nl4\n";
+		file_put_contents($logPath, $content);
+		$forcedMtime = time() - 3600;
+		touch($logPath, $forcedMtime);
+		clearstatcache(TRUE, $logPath);
+		$this->assertSame($forcedMtime, filemtime($logPath), 'before: forced mtime must take');
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$this->assertSame($content, file_get_contents($logPath), 'content must be byte-identical (pass never ran)');
+		$this->assertSame($forcedMtime, filemtime($logPath),
+			'a file already within its cap must not even be rewritten (mtime unchanged) -- '
+			. 'today\'s code rewrites unconditionally and would bump this to "now"'
+		);
+	}
+
+	/**
+	 * Mandatory hostile row: an unclamped absurd log_max_log value (numeric
+	 * but saturates pfb_log_max_lines() to PHP_INT_MAX) combined with a
+	 * margin must never crash pfb_log_mgmt() (the intdiv()-on-float TypeError
+	 * trap the float-math design in pfb_log_trim_needed() avoids) and must
+	 * leave a normal-sized file untouched.
+	 */
+	public function testOversizedLogMaxWithMarginDoesNotCrash(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('log', '99999999999999999999999999999999', '0');
+		$this->setMarginPct('50');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('log');
+		$content = "l0\nl1\nl2\nl3\nl4\n";
+		file_put_contents($logPath, $content);
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$this->assertSame($content, file_get_contents($logPath),
+			'an absurd log_max_log value with a margin set must not crash, and must not touch a normal file'
+		);
+	}
+
+	/**
+	 * #1143 TypeError-class hostile row: an array raw config value for
+	 * pfb_log_trim_margin_pct (a crafted/corrupted config.xml) must parse to
+	 * 0 (is_scalar() guard) and must not crash pfb_log_mgmt() with a
+	 * TypeError. Bypasses the normal string-write path to inject the array
+	 * directly at the raw config path, as a hostile config.xml would.
+	 */
+	public function testMarginConfigValueAsArrayDoesNotCrash(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('log', '10', '0');
+		config_set_path('installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct', ['50']);
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('log');
+		$content = "l0\nl1\nl2\nl3\nl4\n";
+		file_put_contents($logPath, $content);
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$this->assertSame($content, file_get_contents($logPath),
+			'an array pfb_log_trim_margin_pct value must parse to 0 and must not crash pfb_log_mgmt()'
+		);
 	}
 }

--- a/tests/php/LogMgmtAgeCutoffTest.php
+++ b/tests/php/LogMgmtAgeCutoffTest.php
@@ -1116,6 +1116,51 @@ final class LogMgmtAgeCutoffTest extends TestCase
 	}
 
 	/**
+	 * Scenario: a log left ending mid-line still gets the trim it is owed.
+	 *
+	 * Given a log whose last line is unterminated (no trailing newline) -- the state
+	 *   pfb_logger('.', 1)'s sub-line progress fragments leave behind, and exactly what
+	 *   pfb_logger_target_starts_at_bol() exists to detect,
+	 * When  it sits one line over its line cap at margin=0,
+	 * Then  the trim FIRES and cuts to the same content tail(1) itself would keep.
+	 *
+	 * The high-water guard gates a tail(1) rewrite, so it must count lines the way
+	 * tail does: an unterminated trailing chunk IS a line. Counting bare "\n" bytes
+	 * undercounts by one, the guard reads "at cap" instead of "over cap", and the
+	 * needed trim is silently skipped -- the log overshoots its cap (#1109).
+	 */
+	public function testDanglingLastLineStillTrimsToTailsOwnResult(): void
+	{
+		$this->seedMinimalConfig();
+		$this->setLogCaps('log', '5', '0');
+		$this->setMarginPct('0');
+		$this->ensureLogDir();
+		pfb_global();
+
+		$logPath = $this->logPath('log');
+		// 5 newline-terminated lines + a 6th, unterminated -- tail(1) sees SIX lines.
+		file_put_contents($logPath, "l1\nl2\nl3\nl4\nl5\nDANGLING");
+
+		// The oracle is the real write path: whatever `tail -n 5` keeps is what the
+		// trim must leave behind. Captured BEFORE the trim overwrites the file.
+		$expected = shell_exec('/usr/bin/tail -n 5 ' . escapeshellarg($logPath));
+		$this->assertStringNotContainsString('l1', (string) $expected,
+			'before: tail -n 5 must already be dropping l1 -- else this fixture proves nothing'
+		);
+
+		pfb_log_mgmt();
+
+		clearstatcache(TRUE, $logPath);
+		$after = file_get_contents($logPath);
+		$this->assertSame($expected, $after,
+			'a log ending mid-line must be trimmed to exactly what tail(1) keeps -- '
+			. 'counting only "\n" bytes undercounts the dangling line and skips the trim'
+		);
+		$this->assertStringNotContainsString('l1', (string) $after, 'the over-cap head line must be gone');
+		$this->assertStringContainsString('DANGLING', (string) $after, 'the unterminated tail line must survive');
+	}
+
+	/**
 	 * Mandatory hostile row: an unclamped absurd log_max_log value (numeric
 	 * but saturates pfb_log_max_lines() to PHP_INT_MAX) combined with a
 	 * margin must never crash pfb_log_mgmt() (the intdiv()-on-float TypeError

--- a/tests/php/LogTrimMarginPctTest.php
+++ b/tests/php/LogTrimMarginPctTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_log_trim_margin_pct() -- issue #1109: resolves the stored global
+ * 'pfb_log_trim_margin_pct' config value to the hysteresis margin percent
+ * pfb_log_trim_needed() applies. Mirrors pfb_log_max_days()'s fallback shape
+ * (LogMaxDaysTest.php): non-numeric/garbage/absent/non-scalar -> 0 (off).
+ *
+ * Branch coverage: every hostile-input row for a global percent knob,
+ * including the #1143 TypeError class (an array config value reaching a
+ * string-typed sink) -- the is_scalar() guard is what stops it.
+ */
+#[CoversFunction('pfb_log_trim_margin_pct')]
+final class LogTrimMarginPctTest extends TestCase
+{
+	public function testEmptyStringResolvesToZero(): void
+	{
+		$this->assertSame(0, pfb_log_trim_margin_pct(''), "'' must resolve to 0 (off)");
+	}
+
+	public function testExplicitZeroResolvesToZero(): void
+	{
+		$this->assertSame(0, pfb_log_trim_margin_pct('0'), "'0' must resolve to 0 (off)");
+	}
+
+	public function testMidRangeValueResolvesToItself(): void
+	{
+		$this->assertSame(50, pfb_log_trim_margin_pct('50'), "'50' must resolve to 50");
+	}
+
+	public function testClampBoundaryValueResolvesToItself(): void
+	{
+		$this->assertSame(1000, pfb_log_trim_margin_pct('1000'), "'1000' (clamp boundary) must resolve to 1000");
+	}
+
+	public function testOversizedValueIsClampedToBoundary(): void
+	{
+		$this->assertSame(1000, pfb_log_trim_margin_pct('2000'), "'2000' must clamp down to 1000");
+	}
+
+	public function testHugeOversizedValueIsClampedToBoundary(): void
+	{
+		$this->assertSame(1000, pfb_log_trim_margin_pct('999999999'), "'999999999' must clamp down to 1000");
+	}
+
+	public function testNonNumericValueFallsBackToZero(): void
+	{
+		$this->assertSame(0, pfb_log_trim_margin_pct('abc'), "'abc' must fall back to 0");
+	}
+
+	public function testNegativeValueFallsBackToZero(): void
+	{
+		$this->assertSame(0, pfb_log_trim_margin_pct('-5'), "'-5' must fall back to 0");
+	}
+
+	public function testDecimalValueFallsBackToZero(): void
+	{
+		$this->assertSame(0, pfb_log_trim_margin_pct('1.5'), "'1.5' must fall back to 0");
+	}
+
+	public function testWhitespacePaddedValueFallsBackToZero(): void
+	{
+		$this->assertSame(0, pfb_log_trim_margin_pct('  50 '), "'  50 ' must fall back to 0 (not trimmed)");
+	}
+
+	public function testArrayValueFallsBackToZeroNotTypeError(): void
+	{
+		// #1143 TypeError class: an array config value reaching a string-typed
+		// sink. is_scalar() is what stops it here (see also #1109 integration
+		// coverage: LogMgmtAgeCutoffTest::testMarginConfigValueAsArrayDoesNotCrash).
+		$this->assertSame(0, pfb_log_trim_margin_pct(['50']), "an array raw value must fall back to 0, not TypeError");
+	}
+
+	public function testNullValueFallsBackToZero(): void
+	{
+		$this->assertSame(0, pfb_log_trim_margin_pct(NULL), 'NULL must fall back to 0');
+	}
+
+	/**
+	 * TRUE parses to 1 -- parity with pfb_log_max_days(TRUE), NOT a special
+	 * case: is_scalar(TRUE) is TRUE and (string) TRUE === '1', so both
+	 * siblings inherit the same behaviour by construction.
+	 */
+	public function testBooleanTrueParityWithSiblingParser(): void
+	{
+		$this->assertSame(1, pfb_log_trim_margin_pct(TRUE), 'TRUE must resolve to 1 (is_scalar+string-cast quirk)');
+		$this->assertSame(
+			pfb_log_max_days(TRUE),
+			pfb_log_trim_margin_pct(TRUE),
+			"must match pfb_log_max_days(TRUE)'s behaviour exactly (both share the is_scalar guard shape)"
+		);
+	}
+}

--- a/tests/php/LogTrimNeededTest.php
+++ b/tests/php/LogTrimNeededTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_log_trim_needed() -- issue #1109: the ONE unified high-water guard for
+ * BOTH pfb_log_mgmt() branches, replacing the two duplicated #1052 skip
+ * lines. Line-cap x age-cap x margin matrix (issue #1109's own table):
+ * numeric-cap-only, nolimit-only, and combined rows, each at margin 0 and 50.
+ *
+ * Float math throughout (never intdiv()): pfb_log_max_lines() applies no
+ * clamp, so $logmax can be an absurd int -- intdiv() throws TypeError on a
+ * float argument, and integer overflow promotes to float in PHP. The
+ * mandatory hostile row below pins that this never crashes.
+ */
+#[CoversFunction('pfb_log_trim_needed')]
+final class LogTrimNeededTest extends TestCase
+{
+	private string $tmpFile;
+
+	protected function setUp(): void
+	{
+		$this->tmpFile = (string) tempnam(sys_get_temp_dir(), 'pfb_trim_needed_');
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_file($this->tmpFile)) {
+			unlink($this->tmpFile);
+		}
+	}
+
+	private function daysAgo(int $days): string
+	{
+		return date('Y-m-d H:i:s', time() - ($days * 86400));
+	}
+
+	private function seedLines(int $count): void
+	{
+		$lines = [];
+		for ($i = 0; $i < $count; $i++) {
+			$lines[] = "l{$i}";
+		}
+		file_put_contents($this->tmpFile, implode("\n", $lines) . "\n");
+	}
+
+	/** $oldCount old (chronologically first) lines at $oldDays, then $freshCount lines dated today. */
+	private function seedAgedLines(int $oldCount, int $oldDays, int $freshCount): void
+	{
+		$lines = [];
+		for ($i = 0; $i < $oldCount; $i++) {
+			$lines[] = $this->daysAgo($oldDays) . " old{$i}";
+		}
+		for ($i = 0; $i < $freshCount; $i++) {
+			$lines[] = date('Y-m-d H:i:s') . " fresh{$i}";
+		}
+		file_put_contents($this->tmpFile, implode("\n", $lines) . "\n");
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 1/2 -- numeric cap, age off, margin 0.
+	// -----------------------------------------------------------------------
+
+	public function testNumericCapAgeOffMarginZeroUnderCapDoesNotFire(): void
+	{
+		$this->seedLines(8);
+		$this->assertFalse(
+			pfb_log_trim_needed(10, 0, $this->tmpFile, 'log', 0),
+			'8 lines under a 10-line cap must not need a trim -- the redundant-rewrite elision'
+		);
+	}
+
+	public function testNumericCapAgeOffMarginZeroOverCapFires(): void
+	{
+		$this->seedLines(12);
+		$this->assertTrue(
+			pfb_log_trim_needed(10, 0, $this->tmpFile, 'log', 0),
+			'12 lines over a 10-line cap must need a trim'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 3/4 -- numeric cap, age off, margin 50 (high-water = 1.5x cap).
+	// -----------------------------------------------------------------------
+
+	public function testNumericCapAgeOffMarginFiftyUnderHighWaterDoesNotFire(): void
+	{
+		$this->seedLines(12); // 1.2x of 10
+		$this->assertFalse(
+			pfb_log_trim_needed(10, 0, $this->tmpFile, 'log', 50),
+			'12 lines (1.2x cap) under the 1.5x high-water must not need a trim'
+		);
+	}
+
+	public function testNumericCapAgeOffMarginFiftyOverHighWaterFires(): void
+	{
+		$this->seedLines(16); // 1.6x of 10
+		$this->assertTrue(
+			pfb_log_trim_needed(10, 0, $this->tmpFile, 'log', 50),
+			'16 lines (1.6x cap) over the 1.5x high-water must need a trim'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 5 -- nolimit, age set, margin 0 (identical to #1052 today).
+	// -----------------------------------------------------------------------
+
+	public function testNolimitAgeSetMarginZeroHeadUnexpiredDoesNotFire(): void
+	{
+		file_put_contents($this->tmpFile, $this->daysAgo(5) . " a\n");
+		$this->assertFalse(
+			pfb_log_trim_needed('nolimit', 10, $this->tmpFile, 'log', 0),
+			'margin=0: unexpired head must not need a trim (identical to #1052)'
+		);
+	}
+
+	public function testNolimitAgeSetMarginZeroHeadExpiredFires(): void
+	{
+		file_put_contents($this->tmpFile, $this->daysAgo(15) . " a\n");
+		$this->assertTrue(
+			pfb_log_trim_needed('nolimit', 10, $this->tmpFile, 'log', 0),
+			'margin=0: expired head must need a trim (identical to #1052)'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 6 -- nolimit, age set, margin 50 (window = 1.5x cap days).
+	// -----------------------------------------------------------------------
+
+	public function testNolimitAgeSetMarginFiftyHeadInWindowDoesNotFire(): void
+	{
+		file_put_contents($this->tmpFile, $this->daysAgo(12) . " a\n"); // cap=10, window=15
+		$this->assertFalse(
+			pfb_log_trim_needed('nolimit', 10, $this->tmpFile, 'log', 50),
+			'margin=50: a 12-day head under the 15-day window must not need a trim'
+		);
+	}
+
+	public function testNolimitAgeSetMarginFiftyHeadBeyondWindowFires(): void
+	{
+		file_put_contents($this->tmpFile, $this->daysAgo(20) . " a\n"); // cap=10, window=15
+		$this->assertTrue(
+			pfb_log_trim_needed('nolimit', 10, $this->tmpFile, 'log', 50),
+			'margin=50: a 20-day head over the 15-day window must need a trim'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 7 -- numeric cap AND age set, margin 0: fires iff lines>cap OR head expired.
+	// -----------------------------------------------------------------------
+
+	public function testNumericAndAgeMarginZeroNeitherExceedsDoesNotFire(): void
+	{
+		$this->seedAgedLines(0, 0, 5); // 5 fresh lines; cap=10, age-cap=10 days
+		$this->assertFalse(
+			pfb_log_trim_needed(10, 10, $this->tmpFile, 'log', 0),
+			'5 fresh lines under a 10-line cap with an unexpired head must not fire'
+		);
+	}
+
+	public function testNumericAndAgeMarginZeroLineExceedsFires(): void
+	{
+		// All FRESH timestamps (not merely unparseable) -- isolates the
+		// line-cap trigger: if the short-circuit broke, the age check alone
+		// would return FALSE (unexpired), not accidentally TRUE via the
+		// unparseable-first-line fallthrough.
+		$this->seedAgedLines(0, 0, 12); // 12 fresh lines > 10-line cap
+		$this->assertTrue(
+			pfb_log_trim_needed(10, 10, $this->tmpFile, 'log', 0),
+			'line cap alone exceeding must fire regardless of a fresh (unexpired) age head'
+		);
+	}
+
+	public function testNumericAndAgeMarginZeroAgeExceedsFires(): void
+	{
+		$this->seedAgedLines(1, 15, 2); // 3 total lines (well under cap); head 15d old > 10d age-cap
+		$this->assertTrue(
+			pfb_log_trim_needed(10, 10, $this->tmpFile, 'log', 0),
+			'age cap alone exceeding must fire regardless of line count'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 8 -- numeric cap AND age set, margin 50: fires iff EITHER cap is
+	// over ITS OWN high-water.
+	// -----------------------------------------------------------------------
+
+	public function testNumericAndAgeMarginFiftyNeitherExceedsOwnHighWaterDoesNotFire(): void
+	{
+		// line: 11 total (1 old head + 10 fresh) < 1.5x10=15 high-water.
+		// age: head 12d old, cap=10d -> window=15d; 12<15, not expired.
+		$this->seedAgedLines(1, 12, 10);
+		$this->assertFalse(
+			pfb_log_trim_needed(10, 10, $this->tmpFile, 'log', 50),
+			'neither the 1.2x-cap line count nor the 12d/15d-window age head must fire'
+		);
+	}
+
+	public function testNumericAndAgeMarginFiftyLineExceedsOwnHighWaterFiresEvenIfAgeWithinWindow(): void
+	{
+		$this->seedAgedLines(0, 0, 17); // 17 lines > 1.5x10=15; head is TODAY (well within any age window)
+		$this->assertTrue(
+			pfb_log_trim_needed(10, 10, $this->tmpFile, 'log', 50),
+			'the line cap exceeding its own 1.5x high-water must fire even with a fresh age head'
+		);
+	}
+
+	public function testNumericAndAgeMarginFiftyAgeExceedsOwnWindowFiresEvenIfLineWithinHighWater(): void
+	{
+		$this->seedAgedLines(1, 20, 4); // 5 total lines, well under 15 high-water; head 20d > 15d window
+		$this->assertTrue(
+			pfb_log_trim_needed(10, 10, $this->tmpFile, 'log', 50),
+			'the age head exceeding its own 15-day window must fire even with a small line count'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Mandatory hostile row: an unclamped absurd numeric cap must not crash
+	// (the intdiv()-on-a-float TypeError trap this float-math design avoids).
+	// -----------------------------------------------------------------------
+
+	public function testAbsurdLogMaxDoesNotCrashAndReturnsFalseForNormalFile(): void
+	{
+		$this->seedLines(5);
+		$result = pfb_log_trim_needed(PHP_INT_MAX, 0, $this->tmpFile, 'log', 50);
+		$this->assertFalse($result, 'an absurd cap must never fire for a normal-sized file, and must not throw');
+	}
+}

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -103,6 +103,8 @@ class RequireConfigGatewaySniff implements Sniff
 		// ADR-43: tick-cron dispatch interval + apply-on-change window
 		'installedpackages/pfblockerng/config/0/pfb_tick_interval',
 		'installedpackages/pfblockerng/config/0/pfb_quiet_hours',
+		// issue #1109: log-retention trim hysteresis margin percent
+		'installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct',
 		// installedpackages/pfblockerngdnsblsettings/config/0 (DNSBL settings)
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto',

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -746,20 +746,21 @@ def test_general_log_trim_margin_pct_hostile_digit_guard_coerces_to_default(
     assert got == "0", f"bogus pfb_log_trim_margin_pct={bogus!r} should coerce to default 0, got {got!r}"
 
 
-def test_general_log_trim_margin_pct_oversized_value_saves_without_crash(
+def test_general_log_trim_margin_pct_oversized_value_is_canonicalized_on_save(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
     margin_pct_original: str,  # noqa: ARG001 -- restore-and-prove fixture
 ) -> None:
-    """issue #1109: an oversized digit string passes ``ctype_digit`` and stores verbatim.
+    """issue #1109: an out-of-range margin is clamped when SAVED, not just when read.
 
-    The UI has no upper-bound rejection (by design -- the backend parser
-    ``pfb_log_trim_margin_pct()`` clamps to 1000 when it is READ, not at save time; already
-    pinned by ``LogTrimMarginPctTest``). This only proves the save/re-render round-trip
-    itself never crashes on an oversized value.
+    Storing it raw would leave config.xml claiming 999999999 while the runtime parser
+    clamps to 1000 -- and the field would re-render the raw value, so the page shows a
+    number the system does not actually use. The save canonicalizes through the same
+    ``pfb_log_trim_margin_pct()`` parser the backend reads with, so the stored value IS
+    the effective value.
     """
     got = _post_and_confirm_general(webui, smoke_vm, {"pfb_log_trim_margin_pct": "999999999"}, MARGIN_CFG)
-    assert got == "999999999", f"oversized pfb_log_trim_margin_pct should store verbatim, got {got!r}"
+    assert got == "1000", f"an oversized margin must be clamped to the 1000 bound on save, got {got!r}"
 
 
 def test_general_log_trim_margin_pct_save_preserves_log_max_days_sibling(

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -42,6 +42,8 @@ from .render_oracle import PhpErrorLogGuard
 from .webui import looks_like_login_page
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from .webui import WebUI
 
 pytestmark = pytest.mark.ui_e2e
@@ -683,9 +685,31 @@ def test_general_skipfeed_bogus_scalar_resets_to_default(
         webui.post(GENERAL_PAGE, {"skipfeed": original or "0"}, timeout=SAVE_TIMEOUT)
 
 
+MARGIN_CFG = "installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct"
+
+
+@pytest.fixture
+def margin_pct_original(webui: WebUI, smoke_vm: helpers.SmokeVM) -> Iterator[str]:
+    """Yield ``pfb_log_trim_margin_pct``'s pre-test value, then restore it and PROVE it took.
+
+    A silent restore is the order-dependency trap: a save that quietly fails leaks a stale
+    margin (say 999999999) into whatever runs next, and the leak surfaces as an unrelated
+    test's mystery failure. The post-yield re-read fails HERE instead, naming both values.
+    """
+    original = helpers.config_get(smoke_vm, MARGIN_CFG) or "0"
+    yield original
+    webui.post(GENERAL_PAGE, {"pfb_log_trim_margin_pct": original}, timeout=SAVE_TIMEOUT)
+    restored = helpers.config_get(smoke_vm, MARGIN_CFG) or "0"
+    assert restored == original, (
+        f"pfb_log_trim_margin_pct restore did not take: expected {original!r}, got {restored!r} "
+        f"-- a sibling test would inherit the stale value"
+    )
+
+
 def test_general_log_trim_margin_pct_valid_and_bogus_coerces_to_default(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
+    margin_pct_original: str,
 ) -> None:
     """issue #1109: ``pfb_log_trim_margin_pct`` persists a valid percent, coerces garbage to 0.
 
@@ -696,44 +720,36 @@ def test_general_log_trim_margin_pct_valid_and_bogus_coerces_to_default(
     (the save still SUCCEEDS -- soft coerce, not an abort).
     """
     vm = smoke_vm
-    cfg = "installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct"
-    original = helpers.config_get(vm, cfg)
-    try:
-        assert (original or "0") == "0", (
-            f"pfb_log_trim_margin_pct already non-default before the save (original={original!r})"
-        )
-        assert _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": "50"}, cfg) == "50"
-        assert _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": original or "0"}, cfg) == (
-            original or "0"
-        )
-        got = _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": "abc"}, cfg)
-        assert got == "0", f"bogus pfb_log_trim_margin_pct should coerce to default 0, got {got!r}"
-    finally:
-        webui.post(GENERAL_PAGE, {"pfb_log_trim_margin_pct": original or "0"}, timeout=SAVE_TIMEOUT)
+    assert margin_pct_original == "0", (
+        f"pfb_log_trim_margin_pct already non-default before the save (original={margin_pct_original!r})"
+    )
+    assert _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": "50"}, MARGIN_CFG) == "50"
+    assert (
+        _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": margin_pct_original}, MARGIN_CFG)
+        == margin_pct_original
+    )
+    got = _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": "abc"}, MARGIN_CFG)
+    assert got == "0", f"bogus pfb_log_trim_margin_pct should coerce to default 0, got {got!r}"
 
 
 @pytest.mark.parametrize("bogus", ["-5", "1.5", "  50 ", ""])
 def test_general_log_trim_margin_pct_hostile_digit_guard_coerces_to_default(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
+    margin_pct_original: str,  # noqa: ARG001 -- restore-and-prove fixture
     bogus: str,
 ) -> None:
     """issue #1109: every ``ctype_digit``-rejected shape (sign, decimal, padding, empty)
     coerces to the default '0' -- same guard, same outcome as the 'abc' case above.
     """
-    vm = smoke_vm
-    cfg = "installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct"
-    original = helpers.config_get(vm, cfg)
-    try:
-        got = _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": bogus}, cfg)
-        assert got == "0", f"bogus pfb_log_trim_margin_pct={bogus!r} should coerce to default 0, got {got!r}"
-    finally:
-        webui.post(GENERAL_PAGE, {"pfb_log_trim_margin_pct": original or "0"}, timeout=SAVE_TIMEOUT)
+    got = _post_and_confirm_general(webui, smoke_vm, {"pfb_log_trim_margin_pct": bogus}, MARGIN_CFG)
+    assert got == "0", f"bogus pfb_log_trim_margin_pct={bogus!r} should coerce to default 0, got {got!r}"
 
 
 def test_general_log_trim_margin_pct_oversized_value_saves_without_crash(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
+    margin_pct_original: str,  # noqa: ARG001 -- restore-and-prove fixture
 ) -> None:
     """issue #1109: an oversized digit string passes ``ctype_digit`` and stores verbatim.
 
@@ -742,28 +758,21 @@ def test_general_log_trim_margin_pct_oversized_value_saves_without_crash(
     pinned by ``LogTrimMarginPctTest``). This only proves the save/re-render round-trip
     itself never crashes on an oversized value.
     """
-    vm = smoke_vm
-    cfg = "installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct"
-    original = helpers.config_get(vm, cfg)
-    try:
-        got = _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": "999999999"}, cfg)
-        assert got == "999999999", f"oversized pfb_log_trim_margin_pct should store verbatim, got {got!r}"
-    finally:
-        webui.post(GENERAL_PAGE, {"pfb_log_trim_margin_pct": original or "0"}, timeout=SAVE_TIMEOUT)
+    got = _post_and_confirm_general(webui, smoke_vm, {"pfb_log_trim_margin_pct": "999999999"}, MARGIN_CFG)
+    assert got == "999999999", f"oversized pfb_log_trim_margin_pct should store verbatim, got {got!r}"
 
 
 def test_general_log_trim_margin_pct_save_preserves_log_max_days_sibling(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
+    margin_pct_original: str,  # noqa: ARG001 -- restore-and-prove fixture
 ) -> None:
     """The margin save must not disturb a sibling ``log_max_days_*`` value in the same POST
     (persist-loop ordering, #1109), and raises no new ``php_error.log`` line across the POST.
     """
     vm = smoke_vm
-    margin_cfg = "installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct"
     days_cfg = "installedpackages/pfblockerng/config/0/log_max_days_log"
-    margin_original = helpers.config_get(vm, margin_cfg)
-    days_original = helpers.config_get(vm, days_cfg)
+    days_original = helpers.config_get(vm, days_cfg) or "0"
     guard = PhpErrorLogGuard(vm)
     guard.snapshot()
     try:
@@ -773,14 +782,14 @@ def test_general_log_trim_margin_pct_save_preserves_log_max_days_sibling(
             timeout=SAVE_TIMEOUT,
         )
         assert not looks_like_login_page(resp.text), "POST to General page bounced to the login form"
-        assert helpers.config_get(vm, margin_cfg) == "25"
+        assert helpers.config_get(vm, MARGIN_CFG) == "25"
         assert helpers.config_get(vm, days_cfg) == "7", "log_max_days_log sibling was disturbed by the margin save"
         guard.assert_no_growth()
     finally:
-        webui.post(
-            GENERAL_PAGE,
-            {"pfb_log_trim_margin_pct": margin_original or "0", "log_max_days_log": days_original or "0"},
-            timeout=SAVE_TIMEOUT,
+        webui.post(GENERAL_PAGE, {"log_max_days_log": days_original}, timeout=SAVE_TIMEOUT)
+        days_restored = helpers.config_get(vm, days_cfg) or "0"
+        assert days_restored == days_original, (
+            f"log_max_days_log restore did not take: expected {days_original!r}, got {days_restored!r}"
         )
 
 

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from .. import helpers
+from .render_oracle import PhpErrorLogGuard
 from .webui import looks_like_login_page
 
 if TYPE_CHECKING:
@@ -680,6 +681,107 @@ def test_general_skipfeed_bogus_scalar_resets_to_default(
         assert got == "0", f"bogus skipfeed should reset to default 0, got {got!r}"
     finally:
         webui.post(GENERAL_PAGE, {"skipfeed": original or "0"}, timeout=SAVE_TIMEOUT)
+
+
+def test_general_log_trim_margin_pct_valid_and_bogus_coerces_to_default(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """issue #1109: ``pfb_log_trim_margin_pct`` persists a valid percent, coerces garbage to 0.
+
+    Save loop mirrors ``log_max_days_*``'s ``is_array()``/``!ctype_digit`` guard (a plain
+    number input, not a select -- no ``array_key_exists``). BEFORE: the registered default
+    is '0' on config/0, asserted first (transition-test rule). VALID '50' stores verbatim,
+    restored (asserted), THEN bogus 'abc' fails ``ctype_digit`` -> coerced to default '0'
+    (the save still SUCCEEDS -- soft coerce, not an abort).
+    """
+    vm = smoke_vm
+    cfg = "installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct"
+    original = helpers.config_get(vm, cfg)
+    try:
+        assert (original or "0") == "0", (
+            f"pfb_log_trim_margin_pct already non-default before the save (original={original!r})"
+        )
+        assert _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": "50"}, cfg) == "50"
+        assert _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": original or "0"}, cfg) == (
+            original or "0"
+        )
+        got = _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": "abc"}, cfg)
+        assert got == "0", f"bogus pfb_log_trim_margin_pct should coerce to default 0, got {got!r}"
+    finally:
+        webui.post(GENERAL_PAGE, {"pfb_log_trim_margin_pct": original or "0"}, timeout=SAVE_TIMEOUT)
+
+
+@pytest.mark.parametrize("bogus", ["-5", "1.5", "  50 ", ""])
+def test_general_log_trim_margin_pct_hostile_digit_guard_coerces_to_default(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    bogus: str,
+) -> None:
+    """issue #1109: every ``ctype_digit``-rejected shape (sign, decimal, padding, empty)
+    coerces to the default '0' -- same guard, same outcome as the 'abc' case above.
+    """
+    vm = smoke_vm
+    cfg = "installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct"
+    original = helpers.config_get(vm, cfg)
+    try:
+        got = _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": bogus}, cfg)
+        assert got == "0", f"bogus pfb_log_trim_margin_pct={bogus!r} should coerce to default 0, got {got!r}"
+    finally:
+        webui.post(GENERAL_PAGE, {"pfb_log_trim_margin_pct": original or "0"}, timeout=SAVE_TIMEOUT)
+
+
+def test_general_log_trim_margin_pct_oversized_value_saves_without_crash(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """issue #1109: an oversized digit string passes ``ctype_digit`` and stores verbatim.
+
+    The UI has no upper-bound rejection (by design -- the backend parser
+    ``pfb_log_trim_margin_pct()`` clamps to 1000 when it is READ, not at save time; already
+    pinned by ``LogTrimMarginPctTest``). This only proves the save/re-render round-trip
+    itself never crashes on an oversized value.
+    """
+    vm = smoke_vm
+    cfg = "installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct"
+    original = helpers.config_get(vm, cfg)
+    try:
+        got = _post_and_confirm_general(webui, vm, {"pfb_log_trim_margin_pct": "999999999"}, cfg)
+        assert got == "999999999", f"oversized pfb_log_trim_margin_pct should store verbatim, got {got!r}"
+    finally:
+        webui.post(GENERAL_PAGE, {"pfb_log_trim_margin_pct": original or "0"}, timeout=SAVE_TIMEOUT)
+
+
+def test_general_log_trim_margin_pct_save_preserves_log_max_days_sibling(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """The margin save must not disturb a sibling ``log_max_days_*`` value in the same POST
+    (persist-loop ordering, #1109), and raises no new ``php_error.log`` line across the POST.
+    """
+    vm = smoke_vm
+    margin_cfg = "installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct"
+    days_cfg = "installedpackages/pfblockerng/config/0/log_max_days_log"
+    margin_original = helpers.config_get(vm, margin_cfg)
+    days_original = helpers.config_get(vm, days_cfg)
+    guard = PhpErrorLogGuard(vm)
+    guard.snapshot()
+    try:
+        resp = webui.post(
+            GENERAL_PAGE,
+            {"pfb_log_trim_margin_pct": "25", "log_max_days_log": "7"},
+            timeout=SAVE_TIMEOUT,
+        )
+        assert not looks_like_login_page(resp.text), "POST to General page bounced to the login form"
+        assert helpers.config_get(vm, margin_cfg) == "25"
+        assert helpers.config_get(vm, days_cfg) == "7", "log_max_days_log sibling was disturbed by the margin save"
+        guard.assert_no_growth()
+    finally:
+        webui.post(
+            GENERAL_PAGE,
+            {"pfb_log_trim_margin_pct": margin_original or "0", "log_max_days_log": days_original or "0"},
+            timeout=SAVE_TIMEOUT,
+        )
 
 
 def _post_and_confirm_general(

--- a/tests/smoke/ui/test_post_array_scalar_guards.py
+++ b/tests/smoke/ui/test_post_array_scalar_guards.py
@@ -125,6 +125,7 @@ _ARRAY_FIELD_CASES: list[tuple[str, str, dict[str, str] | None]] = [
     ("/pfblockerng/pfblockerng_ip.php", "pfb_alias_delta_mode", None),  # array_key_exists
     ("/pfblockerng/pfblockerng_general.php", "pfb_feed_internal_allowlist", None),  # trim
     ("/pfblockerng/pfblockerng_general.php", "enable_cb", None),  # pfb_filter ON_OFF
+    ("/pfblockerng/pfblockerng_general.php", "pfb_log_trim_margin_pct", None),  # is_array/ctype_digit
     # issue #1106: category_edit's own ingress guard (bypasses pfb_filter entirely).
     ("/pfblockerng/pfblockerng_category_edit.php?type=dnsbl", "aliasname", None),  # preg_match/strlen
     ("/pfblockerng/pfblockerng_category_edit.php?type=dnsbl", "custom", None),  # explode

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -752,6 +752,42 @@ def test_general_page_renders_ip_parse_error_log_row(webui: WebUI, php_error_log
     )
 
 
+def test_general_page_renders_log_trim_margin_field(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:  # noqa: ARG001
+    """issue #1109 Step 2: the General page gains a single global ``pfb_log_trim_margin_pct``
+    hysteresis-margin field, section-level (outside the per-log-type loop).
+
+    Given the General page,
+    When GET,
+    Then the new field renders with its help copy, its row label is NOT hidden by the
+    desktop ``label.form-label { display: none; }`` media query (its label is the
+    Form_Group's own ``control-label``, not a per-control ``label-start``), and the
+    pre-existing 3-needle intro wording survives this edit unchanged.
+
+    Fail-before / pass-after: none of these markers exist in the pre-#1109 markup.
+    """
+    resp = webui.get(_GENERAL_PAGE)
+    body = resp.text
+    result = evaluate_render(_GENERAL_PAGE, resp.status_code, body, ("General Settings",))
+    assert result.ok, f"General page render oracle failed: {result.detail}"
+
+    assert 'name="pfb_log_trim_margin_pct"' in body, "General page is missing the pfb_log_trim_margin_pct field"
+    assert "less flash/SSD wear" in body, "General page is missing the Trim Margin help copy"
+
+    # §2d label-class probe: the field's row label must be a Form_Group control-label
+    # (visible on desktop), never a per-control label-start (hidden by the media query).
+    # Live-rendered markup (verified on-box): '<label class="col-sm-2 control-label">
+    # <span>Trim Margin</span></label>' -- no per-input label-start/form-label involved.
+    label_re = re.compile(r'<label class="col-sm-2 control-label">\s*<span>Trim Margin</span>\s*</label>')
+    assert label_re.search(body), (
+        "pfb_log_trim_margin_pct row label is not the expected visible control-label -- "
+        "check it is not hidden by the desktop label.form-label media query"
+    )
+
+    # the pre-existing intro needles must survive this edit unchanged (behaviour-preserving)
+    for needle in ("rolling cap", "trims lines older than", "whichever cap is more restrictive"):
+        assert needle in body, f"Log Settings intro wording {needle!r} regressed by the #1109 edit"
+
+
 def test_hooks_page_documents_lifecycle_env_vars(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:  # noqa: ARG001
     """The hooks page lists the PFB_POST_INSTALL / PFB_PRE_UNINSTALL env vars (#684 doc gap, #687).
 


### PR DESCRIPTION
Fixes #1109

## What

`pfb_log_mgmt()` trims each log with a *tail-to-temp-then-cat-over-the-live-file* step that preserves the inode (#264/#280) — and that `cat temp > file` rewrites the **entire retained body** of the log. Today it fires on essentially every idle tick:

- The line-count cap (`log_max_<type>`, default `20000`) is always on and had **no "already within cap" guard**, so a numeric cap ran `tail -n N > temp; cat temp > file` every tick regardless of whether anything changed.
- The age cap can't be helped by a naive "skip if nothing expired" check: at steady state the oldest line sits right at the cutoff, so ~15 minutes later `pfb_log_age_nolimit_pass_needed()` (#1052) reports work and the rewrite fires again. Evicting ~15 min of head means rewriting the whole N-day body — for a 1-day cap at 15-min ticks, roughly 96× the retained size written per day to shave slivers off the front.

This adds a single global knob, `pfb_log_trim_margin_pct` (default `'0'`), giving **both** caps a hysteresis band:

```text
rewrite this tick IFF:
      (line cap active AND line_count(file) >  log_max      * (1 + margin/100))
   OR (age  cap active AND oldest_line(file) older than log_max_days days * (1 + margin/100))
```

High-water **trigger**, low-water **cut**: when it fires, the existing write path is unchanged and still cuts to the *exact* cap. The log sawtooths between `cap` and `cap × (1 + margin/100)` — `margin=50` on a 1-day age cap fires about every 12 h instead of every tick.

## The `margin=0` nuance (intentional, not smuggled in)

With the default `margin=0` the line-count high-water equals the cap, so the guard **skips the rewrite when the file is already within the cap** — whereas the old code rewrote it unconditionally. The resulting **log content is byte-identical** (a file already ≤ N lines with no expired head produces an identical `tail`/`cat`); only the redundant no-op full-file rewrite and its mtime bump are elided. That is exactly the default-on line-count thrash this targets. Nothing keys on a log file's mtime (ADR-42 content-hashing covers feeds, not logs).

## How

- New pure parser `pfb_log_trim_margin_pct()`, mirroring `pfb_log_max_days()`'s shape (clamped to 1000).
- New `pfb_log_line_count()` — pure PHP, `PHP_INT_MAX` on any probe failure so a needed trim is never skipped (same fail-open direction as #1052).
- `pfb_log_age_nolimit_pass_needed()` → **`pfb_log_age_trim_needed()`** (the probe is no longer `nolimit`-only) with an `int $margin_pct = 0` parameter. Its empty-file / unparseable-first-line / unopenable fallthroughs are preserved verbatim.
- **`pfb_log_trim_needed()` is now the single guard for both `pfb_log_mgmt()` branches**, replacing the two duplicated #1052 skip lines. It subsumes #1052's skip as the `margin=0` age case.
- The line high-water uses float math deliberately: `pfb_log_max_lines()` applies no clamp, so `$logmax` can reach `PHP_INT_MAX` from a typo'd config, and `intdiv()` would receive a float (PHP promotes integer overflow to float) and throw a `TypeError` in the cron tick.
- Registry + `RequireConfigGateway` sniff + `CfgGatewayTest` round-trip, per ADR-29.
- UI: one section-level field in Log Settings, read/validated/persisted through `PfbConfig`, with the intro help text extended.
- Everything after the guard — `tail`/`copy`, the age trim, the `cat` over the live file, per-exec exit-code gating (#1061), the short-write guard (#1053), and `chown`/`chgrp unbound` (#264) — is byte-for-byte unchanged.

## Tests

Red→green, test-first: reproduction tests authored and executed RED against the untouched code (a 1.2×-cap file with `margin=50` gets truncated today, so content is the oracle; the elision row uses a forced-old mtime), frozen by hash, then GREEN with zero edits.

- `LogTrimMarginPctTest` (13 hostile/valid parser rows), `LogLineCountTest` (4), `LogAgeTrimNeededTest` (7), `LogTrimNeededTest` (14, incl. the absurd-`log_max` `TypeError` trap), `LogMgmtAgeCutoffTest` (+9 integration rows driving real `pfb_log_mgmt()` on **both** branches), `CfgGatewayTest` (+3).
- Tier-A `ui_render` and Tier-B `ui_e2e` executed on a live pfSense VM: the field renders, the save round-trips, every rejected shape plus an array-valued POST (the #1143 class) coerces to `0` without a `TypeError`, and an out-of-range value is clamped **on save** — the UI POST is canonicalized through the same `pfb_log_trim_margin_pct()` parser the backend reads with, so the stored value is always the effective one.

## ADR

Amends ADR-60 §8 in the same change (the hysteresis, why a percentage, the `margin=0` elision, the rename, the read-cost trade, and the rejected alternatives — in-place head eviction and any calendar-boundary/marker-file scheme).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Vv1F4fW9zu39cSJ69Jn7f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable log-trimming margin percentage, from 0–1000%, in General settings.
  * The margin applies to both line-count and age-based log limits.
  * Logs are trimmed back to the configured limits once trimming is triggered.

* **Bug Fixes**
  * Avoids unnecessary log rewrites when logs are already within configured limits.
  * Improved handling of invalid or unexpected setting values without errors.

* **Tests**
  * Added coverage for configuration validation, log trimming behavior, edge cases, and General page rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
