### PR TITLE
tests/smoke: tolerate a stalled probe transport in alias_rule_dump (#1252)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -545,12 +545,29 @@ def pf_state_dump(vm: SmokeVM, *, timeout: float = 30.0) -> str:
 _ALIAS_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
 
+def _pre_stall_text(buf: str | bytes | None) -> str:
+    """Decode what a probe wrote before it hung.
+
+    TimeoutExpired carries the pre-stall buffer UNDECODED (bytes) even under ``text=True``,
+    and the stall truncates at an arbitrary byte — so it routinely ends mid-UTF-8 sequence.
+    """
+    if buf is None:
+        return ""
+    return buf if isinstance(buf, str) else buf.decode("utf-8", errors="replace")
+
+
 def _tolerate_timeout(call: Callable[[], subprocess.CompletedProcess[str]]) -> subprocess.CompletedProcess[str]:
-    """issue #1252: a stalled TRANSPORT is a FAILED PROBE, not a raw exception wrecking the dump."""
+    """issue #1252: a stalled TRANSPORT is a FAILED PROBE, not a raw exception wrecking the dump.
+
+    rc 124 (the conventional timeout code) is what makes every rc-based verdict branch below
+    treat the stall as the failed probe it is. The partial output is kept: unusable as PROOF,
+    but it is precisely the diagnostic this dump exists to surface.
+    """
     try:
         return call()
     except subprocess.TimeoutExpired as exc:
-        return subprocess.CompletedProcess(exc.cmd, 124, "", f"transport timeout after {exc.timeout}s")
+        stderr = f"transport timeout after {exc.timeout}s: {_pre_stall_text(exc.stderr)}"
+        return subprocess.CompletedProcess(exc.cmd, 124, _pre_stall_text(exc.stdout), stderr)
 
 
 def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
@@ -574,11 +591,13 @@ def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
     applied it yet (genuine lag) or pfctl rejected the ruleset; present at all three ⇒ the
     poll read stale state.
 
-    A FAILED PROBE is never a missing rule: if the config read, the rules.debug grep or the
-    pfctl read errors out OR the transport stalls (``subprocess.TimeoutExpired``), the verdict
-    is ``UNPROVEN`` — a broken or stalled probe reads as an empty layer, and silently blaming
-    the product for a pfSsh.php error or a hung SSH is exactly the misdiagnosis this helper
-    exists to prevent (issue #1239, #1252).
+    A FAILED PROBE is never a missing rule: if one of the three VERDICT probes — the config
+    read, the rules.debug grep, or ``pfctl -sr`` — errors out OR its transport stalls
+    (``subprocess.TimeoutExpired``), the verdict is ``UNPROVEN``: a broken or stalled probe
+    reads as an empty layer, and silently blaming the product for a pfSsh.php error or a hung
+    SSH is exactly the misdiagnosis this helper exists to prevent (issue #1239, #1252). The
+    fourth probe, ``pfctl -sTables``, only annotates whether the table exists — a failure
+    there reports that line as ``UNKNOWN`` and leaves the verdict to the three layers.
 
     The ruleset layers use :func:`rule_line_references`, the same match rule
     :func:`rule_references` applies, so the dump cannot contradict the assertion it explains.

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -545,6 +545,14 @@ def pf_state_dump(vm: SmokeVM, *, timeout: float = 30.0) -> str:
 _ALIAS_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
 
+def _tolerate_timeout(call: Callable[[], subprocess.CompletedProcess[str]]) -> subprocess.CompletedProcess[str]:
+    """issue #1252: a stalled TRANSPORT is a FAILED PROBE, not a raw exception wrecking the dump."""
+    try:
+        return call()
+    except subprocess.TimeoutExpired as exc:
+        return subprocess.CompletedProcess(exc.cmd, 124, "", f"transport timeout after {exc.timeout}s")
+
+
 def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
     """Return a layered snapshot naming WHERE a pfB alias's auto-rule was lost.
 
@@ -567,9 +575,10 @@ def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
     poll read stale state.
 
     A FAILED PROBE is never a missing rule: if the config read, the rules.debug grep or the
-    pfctl read errors out, the verdict is ``UNPROVEN`` — a broken probe reads as an empty
-    layer, and silently blaming the product for a pfSsh.php error is exactly the
-    misdiagnosis this helper exists to prevent (issue #1239).
+    pfctl read errors out OR the transport stalls (``subprocess.TimeoutExpired``), the verdict
+    is ``UNPROVEN`` — a broken or stalled probe reads as an empty layer, and silently blaming
+    the product for a pfSsh.php error or a hung SSH is exactly the misdiagnosis this helper
+    exists to prevent (issue #1239, #1252).
 
     The ruleset layers use :func:`rule_line_references`, the same match rule
     :func:`rule_references` applies, so the dump cannot contradict the assertion it explains.
@@ -593,7 +602,7 @@ def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
         "}\n"
         "echo '<<CFG>>'.implode(' ## ',$o).'<<END>>';"
     )
-    cfg_res = php_eval(vm, snippet, timeout=timeout)
+    cfg_res = _tolerate_timeout(lambda: php_eval(vm, snippet, timeout=timeout))
     cfg = ""
     # The sentinels are the ONLY proof the snippet ran to completion: pfSsh.php exits 0 even
     # when the PHP inside it fatals, so rc alone cannot tell a clean empty result from a crash.
@@ -603,14 +612,14 @@ def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
 
     # grep: rc 0 = matched, rc 1 = no match (a real answer), rc >= 2 = the grep itself failed
     # (missing/unreadable /tmp/rules.debug) — only the last is an unusable probe.
-    dbg = vm.ssh("/usr/bin/grep", "-n", alias, "/tmp/rules.debug", timeout=timeout)
-    sr = vm.ssh(PFCTL, "-sr", timeout=timeout)
+    dbg = _tolerate_timeout(lambda: vm.ssh("/usr/bin/grep", "-n", alias, "/tmp/rules.debug", timeout=timeout))
+    sr = _tolerate_timeout(lambda: vm.ssh(PFCTL, "-sr", timeout=timeout))
     dbg_ok = dbg.returncode in (0, 1)
     sr_ok = sr.returncode == 0
     dbg_lines = [ln for ln in dbg.stdout.splitlines() if rule_line_references(ln, alias)]
     live = [ln for ln in sr.stdout.splitlines() if rule_line_references(ln, alias)]
 
-    tables_res = vm.ssh(PFCTL, "-sTables", timeout=timeout)
+    tables_res = _tolerate_timeout(lambda: vm.ssh(PFCTL, "-sTables", timeout=timeout))
     tables_ok = tables_res.returncode == 0
     table_exists = alias in [ln.strip() for ln in tables_res.stdout.splitlines()] if tables_ok else None
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -566,7 +566,7 @@ def _tolerate_timeout(call: Callable[[], subprocess.CompletedProcess[str]]) -> s
     try:
         return call()
     except subprocess.TimeoutExpired as exc:
-        stderr = f"transport timeout after {exc.timeout}s: {_pre_stall_text(exc.stderr)}"
+        stderr = f"transport timeout after {exc.timeout}s"
         return subprocess.CompletedProcess(exc.cmd, 124, _pre_stall_text(exc.stdout), stderr)
 
 

--- a/tests/test_smoke_alias_rule_dump.py
+++ b/tests/test_smoke_alias_rule_dump.py
@@ -51,29 +51,41 @@ class _FakeVM:
     grep_rc: int | None = None
     sr_rc: int = 0
     tables_rc: int = 0
+    # issue #1252: probe keys ("grep"/"sr"/"tables") whose ssh call stalls the transport
+    # instead of returning — TimeoutExpired, not a returncode.
+    timeout_on: frozenset[str] = field(default_factory=frozenset)
     calls: list[tuple[str, ...]] = field(default_factory=list)
 
     def ssh(self, *remote: str, timeout: float = 60.0) -> _FakeResult:
         self.calls.append(remote)
         if remote[0] == "/usr/bin/grep":
+            if "grep" in self.timeout_on:
+                raise subprocess.TimeoutExpired(cmd=list(remote), timeout=timeout)
             # grep exits 1 on no match — the dump must treat that as "absent", not as an error.
             rc = self.grep_rc if self.grep_rc is not None else (0 if self.rules_debug else 1)
             return _FakeResult(returncode=rc, stdout=self.rules_debug)
         if remote[:2] == (helpers.PFCTL, "-sr"):
+            if "sr" in self.timeout_on:
+                raise subprocess.TimeoutExpired(cmd=list(remote), timeout=timeout)
             return _FakeResult(returncode=self.sr_rc, stdout=self.live_rules)
         if remote[:2] == (helpers.PFCTL, "-sTables"):
+            if "tables" in self.timeout_on:
+                raise subprocess.TimeoutExpired(cmd=list(remote), timeout=timeout)
             return _FakeResult(returncode=self.tables_rc, stdout=self.tables)
         raise AssertionError(f"unexpected ssh command: {remote}")
 
 
-def _fake_php_eval(rows: str, *, returncode: int = 0, raw: str | None = None) -> object:
+def _fake_php_eval(rows: str, *, returncode: int = 0, raw: str | None = None, raises_timeout: bool = False) -> object:
     """Return a php_eval stand-in emitting the dump's ``<<CFG>>``-delimited config rows.
 
     ``raw`` replaces the whole stdout, so a test can simulate pfSsh.php fatalling before it
     printed the sentinels (it still exits 0 — the sentinels are the only completion proof).
+    ``raises_timeout`` (issue #1252) simulates the transport stalling instead.
     """
 
     def _run(_vm: object, _snippet: str, *, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+        if raises_timeout:
+            raise subprocess.TimeoutExpired(cmd=["/usr/local/sbin/pfSsh.php"], timeout=timeout)
         stdout = raw if raw is not None else f"banner\n<<CFG>>{rows}<<END>>\n"
         return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
 
@@ -192,6 +204,97 @@ def test_a_failed_probe_is_unproven_never_an_accusation(
     assert "UNPROVEN" in stage_line, f"a failed probe did not yield UNPROVEN: {stage_line!r}"
     assert broken in stage_line, f"the broken probe {broken!r} is not named: {stage_line!r}"
     assert "NEVER generated" not in stage_line, f"a failed probe accused the product: {stage_line!r}"
+
+
+def test_config_probe_timeout_is_unproven_not_a_raw_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given the pfSsh.php transport stalling (subprocess.TimeoutExpired)
+    When alias_rule_dump runs
+    Then the verdict is UNPROVEN naming CONFIG(pfSsh) — the exception must NOT escape and
+    wreck the other three layers' diagnostic output (issue #1252).
+    """
+    monkeypatch.setattr(helpers, "php_eval", _fake_php_eval(CFG_ROW, raises_timeout=True))
+    vm = _FakeVM(rules_debug=DEBUG_ROW, live_rules=LIVE_ROW, tables=ALIAS)
+
+    dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
+
+    stage_line = next(ln for ln in dump.splitlines() if ln.startswith("[STAGE LOST]"))
+    assert "UNPROVEN" in stage_line, f"a stalled probe did not yield UNPROVEN: {stage_line!r}"
+    assert "CONFIG(pfSsh)" in stage_line, f"the stalled probe is not named: {stage_line!r}"
+    assert "pfSsh=124" in stage_line, f"the timeout rc is not reported as 124: {stage_line!r}"
+
+
+def test_rules_debug_probe_timeout_is_unproven_not_a_raw_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given the rules.debug grep stalling
+    When alias_rule_dump runs
+    Then the verdict is UNPROVEN naming RULES.DEBUG(grep) (issue #1252).
+    """
+    monkeypatch.setattr(helpers, "php_eval", _fake_php_eval(CFG_ROW))
+    vm = _FakeVM(live_rules=LIVE_ROW, tables=ALIAS, timeout_on=frozenset({"grep"}))
+
+    dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
+
+    stage_line = next(ln for ln in dump.splitlines() if ln.startswith("[STAGE LOST]"))
+    assert "UNPROVEN" in stage_line, f"a stalled probe did not yield UNPROVEN: {stage_line!r}"
+    assert "RULES.DEBUG(grep)" in stage_line, f"the stalled probe is not named: {stage_line!r}"
+    assert "grep=124" in stage_line, f"the timeout rc is not reported as 124: {stage_line!r}"
+
+
+def test_live_pf_probe_timeout_is_unproven_not_a_raw_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given the ``pfctl -sr`` read stalling
+    When alias_rule_dump runs
+    Then the verdict is UNPROVEN naming LIVE PF(pfctl -sr) (issue #1252).
+    """
+    monkeypatch.setattr(helpers, "php_eval", _fake_php_eval(CFG_ROW))
+    vm = _FakeVM(rules_debug=DEBUG_ROW, tables=ALIAS, timeout_on=frozenset({"sr"}))
+
+    dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
+
+    stage_line = next(ln for ln in dump.splitlines() if ln.startswith("[STAGE LOST]"))
+    assert "UNPROVEN" in stage_line, f"a stalled probe did not yield UNPROVEN: {stage_line!r}"
+    assert "LIVE PF(pfctl -sr)" in stage_line, f"the stalled probe is not named: {stage_line!r}"
+    assert "pfctl-sr=124" in stage_line, f"the timeout rc is not reported as 124: {stage_line!r}"
+
+
+def test_table_existence_probe_timeout_does_not_flip_the_verdict_to_unproven(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given ONLY the ``pfctl -sTables`` read stalling, with the rule present at all 3 layers
+    When alias_rule_dump runs
+    Then the verdict stays the normal layer verdict (NONE here) — table existence is not one
+    of the three UNPROVEN causes today, and a stalled table read must not change that. A naive
+    "catch every TimeoutExpired into broken" implementation fails this (issue #1252).
+    """
+    monkeypatch.setattr(helpers, "php_eval", _fake_php_eval(CFG_ROW))
+    vm = _FakeVM(rules_debug=DEBUG_ROW, live_rules=LIVE_ROW, timeout_on=frozenset({"tables"}))
+
+    dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
+
+    stage_line = next(ln for ln in dump.splitlines() if ln.startswith("[STAGE LOST]"))
+    assert "UNPROVEN" not in stage_line, f"a stalled table read wrongly flipped the verdict: {stage_line!r}"
+    assert "NONE" in stage_line, f"expected the normal NONE verdict: {stage_line!r}"
+    assert "[pf table pfB_DNSBLIP_v4 exists] UNKNOWN (pfctl -sTables failed)" in dump, (
+        f"the stalled table read is not reported as UNKNOWN:\n{dump}"
+    )
+
+
+def test_all_three_verdict_probes_stalling_names_all_three(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given CONFIG, RULES.DEBUG and LIVE PF all stalling at once
+    When alias_rule_dump runs
+    Then the single UNPROVEN verdict names all three — mirrors today's multi-rc-failure
+    behaviour (issue #1252).
+    """
+    monkeypatch.setattr(helpers, "php_eval", _fake_php_eval(CFG_ROW, raises_timeout=True))
+    vm = _FakeVM(tables=ALIAS, timeout_on=frozenset({"grep", "sr"}))
+
+    dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
+
+    stage_line = next(ln for ln in dump.splitlines() if ln.startswith("[STAGE LOST]"))
+    assert "UNPROVEN" in stage_line, f"stalled probes did not yield UNPROVEN: {stage_line!r}"
+    for name in ("CONFIG(pfSsh)", "RULES.DEBUG(grep)", "LIVE PF(pfctl -sr)"):
+        assert name in stage_line, f"{name!r} missing from: {stage_line!r}"
+    assert "pfSsh=124" in stage_line and "grep=124" in stage_line and "pfctl-sr=124" in stage_line, (
+        f"not all rc fields report 124: {stage_line!r}"
+    )
 
 
 def test_a_rule_naming_the_alias_only_in_its_descr_does_not_count_as_a_reference() -> None:

--- a/tests/test_smoke_alias_rule_dump.py
+++ b/tests/test_smoke_alias_rule_dump.py
@@ -54,23 +54,29 @@ class _FakeVM:
     # issue #1252: probe keys ("grep"/"sr"/"tables") whose ssh call stalls the transport
     # instead of returning — TimeoutExpired, not a returncode.
     timeout_on: frozenset[str] = field(default_factory=frozenset)
+    # What the stalled probe had already written before it hung. CPython attaches this to
+    # TimeoutExpired UNDECODED (bytes) even under text=True, so bytes is the realistic value.
+    timeout_output: dict[str, bytes | str] = field(default_factory=dict)
     calls: list[tuple[str, ...]] = field(default_factory=list)
+
+    def _stall(self, key: str, remote: tuple[str, ...], timeout: float) -> None:
+        raise subprocess.TimeoutExpired(cmd=list(remote), timeout=timeout, output=self.timeout_output.get(key))
 
     def ssh(self, *remote: str, timeout: float = 60.0) -> _FakeResult:
         self.calls.append(remote)
         if remote[0] == "/usr/bin/grep":
             if "grep" in self.timeout_on:
-                raise subprocess.TimeoutExpired(cmd=list(remote), timeout=timeout)
+                self._stall("grep", remote, timeout)
             # grep exits 1 on no match — the dump must treat that as "absent", not as an error.
             rc = self.grep_rc if self.grep_rc is not None else (0 if self.rules_debug else 1)
             return _FakeResult(returncode=rc, stdout=self.rules_debug)
         if remote[:2] == (helpers.PFCTL, "-sr"):
             if "sr" in self.timeout_on:
-                raise subprocess.TimeoutExpired(cmd=list(remote), timeout=timeout)
+                self._stall("sr", remote, timeout)
             return _FakeResult(returncode=self.sr_rc, stdout=self.live_rules)
         if remote[:2] == (helpers.PFCTL, "-sTables"):
             if "tables" in self.timeout_on:
-                raise subprocess.TimeoutExpired(cmd=list(remote), timeout=timeout)
+                self._stall("tables", remote, timeout)
             return _FakeResult(returncode=self.tables_rc, stdout=self.tables)
         raise AssertionError(f"unexpected ssh command: {remote}")
 
@@ -294,6 +300,54 @@ def test_all_three_verdict_probes_stalling_names_all_three(monkeypatch: pytest.M
         assert name in stage_line, f"{name!r} missing from: {stage_line!r}"
     assert "pfSsh=124" in stage_line and "grep=124" in stage_line and "pfctl-sr=124" in stage_line, (
         f"not all rc fields report 124: {stage_line!r}"
+    )
+
+
+def test_output_written_before_a_stall_still_reaches_the_dump(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given a probe that printed part of its answer and THEN hung
+    When alias_rule_dump runs
+    Then the partial output still appears in its layer — a stalled probe is unusable as
+    PROOF (the verdict stays UNPROVEN), but what it did manage to say is exactly the
+    diagnostic this helper exists to surface, so it must not be thrown away (issue #1252).
+    """
+    monkeypatch.setattr(helpers, "php_eval", _fake_php_eval(CFG_ROW))
+    vm = _FakeVM(
+        live_rules=LIVE_ROW,
+        tables=ALIAS,
+        timeout_on=frozenset({"grep"}),
+        # CPython hands back the pre-stall buffer as raw BYTES even under text=True.
+        timeout_output={"grep": DEBUG_ROW.encode()},
+    )
+
+    dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
+
+    stage_line = next(ln for ln in dump.splitlines() if ln.startswith("[STAGE LOST]"))
+    assert "UNPROVEN" in stage_line, f"a stalled probe did not yield UNPROVEN: {stage_line!r}"
+    assert f"[RULES.DEBUG {ALIAS}: 1] {DEBUG_ROW}" in dump, (
+        f"the output the probe managed to write before stalling was discarded:\n{dump}"
+    )
+
+
+def test_a_stall_mid_utf8_sequence_does_not_crash_the_dump(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given a probe that hung mid-way through a multi-byte character
+    When alias_rule_dump runs
+    Then the dump still renders — a transport stall truncates at an arbitrary BYTE, so the
+    pre-stall buffer routinely ends inside a UTF-8 sequence and must never raise (issue #1252).
+    """
+    monkeypatch.setattr(helpers, "php_eval", _fake_php_eval(CFG_ROW))
+    vm = _FakeVM(
+        rules_debug=DEBUG_ROW,
+        tables=ALIAS,
+        timeout_on=frozenset({"sr"}),
+        timeout_output={"sr": LIVE_ROW.encode() + "é".encode()[:1]},  # dangling lead byte
+    )
+
+    dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
+
+    stage_line = next(ln for ln in dump.splitlines() if ln.startswith("[STAGE LOST]"))
+    assert "UNPROVEN" in stage_line, f"a stalled probe did not yield UNPROVEN: {stage_line!r}"
+    assert f"[LIVE PF -sr {ALIAS}: 1] {LIVE_ROW}" in dump, (
+        f"the decodable part of the pre-stall buffer was lost:\n{dump}"
     )
 
 


### PR DESCRIPTION
Fixes #1252.

`alias_rule_dump()` documents that a failed probe yields an `UNPROVEN` verdict rather than a false "the rule was never generated" accusation — but it only delivered that for the cases it checked: a non-zero return code and a missing `<<CFG>>`/`<<END>>` sentinel pair. A transport *stall* raised `subprocess.TimeoutExpired` straight out of the helper, so instead of the documented verdict you got a raw traceback and lost the other three layers' diagnostic output — exactly the misdiagnosis the helper exists to prevent.

All four probe calls (`php_eval` for CONFIG, and the `grep` / `pfctl -sr` / `pfctl -sTables` ssh reads) now route through a small `_tolerate_timeout()` wrapper that maps a `TimeoutExpired` to a synthetic `CompletedProcess` with rc 124 — the conventional timeout exit code. Every existing rc-based branch then handles it unchanged: `cfg_ok`/`dbg_ok`/`sr_ok` go false and feed the existing `broken` list into `UNPROVEN`, while a stalled `pfctl -sTables` keeps producing the existing `UNKNOWN (pfctl -sTables failed)` line without flipping the verdict (table existence is not one of the three verdict layers). The docstring is corrected to say so.

**Scope — this is option 2 of the three the issue lists.** Option 3 (catching at the `php_eval` / `SmokeVM.ssh` transport boundary, so every helper inherits the behaviour) is deliberately *not* taken here: four existing call sites depend on the exception propagating raw — `reboot_vm` twice (each producing a specific "the boot proof is incomplete" AssertionError), `wait_boot_complete` (which retries a slow probe within its own budget), and `test_bench_pfctl.py::_bench` (which records a timeout as a *valid* benchmark data point). Swallowing it at the boundary would silently turn all four into dead or wrong code, and the benchmark case would be a functional regression rather than a diagnostics one. The sibling helpers (`rule_references`, `wait_pfctl_table`, and friends) keep their current raw-crash-on-stall behaviour; they remain bounded by the per-test `pytest-timeout` budget.

## Tests

Five new cases in `tests/test_smoke_alias_rule_dump.py` (the existing off-appliance unit pin — no VM needed), authored and executed RED against the unchanged helper before any production edit, then green unmodified:

| Probe stalled | Expected |
| --- | --- |
| `php_eval` (CONFIG) | `UNPROVEN` naming `CONFIG(pfSsh)`, `pfSsh=124` |
| `grep` (RULES.DEBUG) | `UNPROVEN` naming `RULES.DEBUG(grep)`, `grep=124` |
| `pfctl -sr` (LIVE PF) | `UNPROVEN` naming `LIVE PF(pfctl -sr)`, `pfctl-sr=124` |
| `pfctl -sTables` only | verdict **not** UNPROVEN; `[pf table … exists] UNKNOWN (pfctl -sTables failed)` |
| all three verdict probes | one `UNPROVEN` line naming all three |

The `pfctl -sTables` row is the vacuity guard: a naive "catch every `TimeoutExpired` into `broken`" implementation passes the other four and fails that one.

Gates: `python3 -m pytest` (2752 passed, 4 skipped) · `ruff check .` · `ruff format --check .` · `mypy tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBkLQcR4cz5QCq6AVjdzuM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stalled diagnostic connections so they are reported as unproven results instead of causing errors or misleading failures.
  * Preserved available diagnostic output when a connection stalls, including safely handling incomplete text.
  * Distinguished which verification layer could not be confirmed, while treating table-check interruptions separately from the overall verdict.

* **Tests**
  * Added coverage for stalled configuration, rules, live firewall, and table probes, including simultaneous stalls and partial output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->