### PR TITLE
scripts+agent: give the red-proof gate an explicit pre-fix baseline (#1249)

### DIFF
--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -83,9 +83,11 @@ Terse prose, full checks; a skipped item is recorded SKIPPED with the reason:
    (plus any cross-language consumers the runner cannot infer).
 3. Re-execute the red proof yourself for behaviour changes
    (`sh scripts/agent/verify-red-proof.sh --worktree <path> --test-cmd '<test>' --src ...
-   --hash <test>=<red-hash>` — revert → named test FAILS;
-   `git -C <path> checkout HEAD -- .` → PASSES). Record both results; verify the freeze
-   (`git hash-object` of the committed reproduction test == the handoff's red-time hash).
+   --hash <test>=<red-hash> [--base-ref <pre-fix-commit>]` — revert to `--base-ref`
+   (default `HEAD~1`; pass the true pre-fix commit explicitly when the step landed more
+   than one commit) → named test FAILS; `git -C <path> checkout HEAD -- .` → PASSES).
+   Record both results; verify the freeze (`git hash-object` of the committed reproduction
+   test == the handoff's red-time hash).
 4. Read the FULL diff (`git show`, never `--stat` alone); tick every plan item and matrix
    row.
 5. Test honesty: vacuity check on negative assertions; no impossible monkeypatched faults;

--- a/.claude/workflows/phase-step.js
+++ b/.claude/workflows/phase-step.js
@@ -153,11 +153,11 @@ const redHashArgs = (handoff.red_green || [])
 const redProofText = redProof
   ? `RED PROOF (re-execute yourself, never accept the handoff's claim).
 
-FIRST, BASELINE SANITY — the script trusts whatever ref you hand it, so earn that trust before you run it: the handoff's base_sha (${baseSha}) must be a real commit, an ANCESTOR of HEAD, and NOT equal to HEAD — else the implementer captured it after editing and the red run would prove nothing. Check: git -C ${worktree} merge-base --is-ancestor ${baseSha} HEAD && [ "$(git -C ${worktree} rev-parse ${baseSha})" != "$(git -C ${worktree} rev-parse HEAD)" ]. Either check failing = FAIL this item; do not substitute HEAD~1 to make it pass.
+FIRST, BASELINE SANITY — the script trusts whatever ref you hand it, so earn that trust before you run it: the handoff's base_sha (${baseSha}) must be a real commit, an ANCESTOR of HEAD, and NOT equal to HEAD — else the implementer captured it after editing and the red run would prove nothing. Check: git -C ${shq(worktree)} merge-base --is-ancestor ${baseSha} HEAD && [ "$(git -C ${shq(worktree)} rev-parse ${baseSha})" != "$(git -C ${shq(worktree)} rev-parse HEAD)" ]. Either check failing = FAIL this item; do not substitute HEAD~1 to make it pass.
 
 THEN run the single implementation — do NOT hand-roll the checkout dance:
 
-  sh scripts/agent/verify-red-proof.sh --worktree ${worktree} --test-cmd ${shq(redProof.testCmd)} ${redProof.srcPaths.map(p => `--src ${safe(p, /^[A-Za-z0-9._/-]+$/, 'redProof.srcPaths')}`).join(' ')} ${redHashArgs} --base-ref ${baseSha}
+  sh scripts/agent/verify-red-proof.sh --worktree ${shq(worktree)} --test-cmd ${shq(redProof.testCmd)} ${redProof.srcPaths.map(p => `--src ${safe(p, /^[A-Za-z0-9._/-]+$/, 'redProof.srcPaths')}`).join(' ')} ${redHashArgs} --base-ref ${baseSha}
 
 It reverts the src paths to --base-ref (tests stay) and requires FAIL, restores HEAD and requires PASS, and enforces the freeze (git hash-object of each committed reproduction test == the handoff's red-time hash — a test edited between red and green, or with no red-time hash, proves nothing). Record its FREEZE-OK / RED-OK / GREEN-OK / VERDICT lines as evidence; a non-PASS verdict fails this item.`
   : 'This step is declared behaviour-preserving: confirm the oracle/pinned tests exist and stayed green; record which.'

--- a/.claude/workflows/phase-step.js
+++ b/.claude/workflows/phase-step.js
@@ -134,15 +134,17 @@ if (handoff.verdict === 'BLOCKED') {
 
 phase('Verify')
 
-// The handoff is agent-authored text that ends up inside a shell command the verifier runs:
-// anything interpolated below is shape-checked here, at the boundary, or the step dies.
+// The handoff is agent-authored text that ends up inside a shell command the verifier runs.
+// Identifier-shaped fields are shape-checked at the boundary or the step dies; testCmd is a
+// free-form command (spaces, quotes, $(...) are legitimate) so it gets quoted, not restricted.
 const safe = (value, pattern, field) => {
   if (typeof value !== 'string' || !pattern.test(value)) {
     throw new Error(`unsafe ${field} in handoff: ${JSON.stringify(value)}`)
   }
   return value
 }
-const baseSha = redProof ? safe(handoff.base_sha, /^[0-9a-f]{7,40}$/, 'base_sha') : ''
+const shq = s => `'${String(s).replace(/'/g, "'\\''")}'`
+const baseSha = redProof ? safe(handoff.base_sha, /^[0-9a-f]{40}$/, 'base_sha') : ''
 const redHashArgs = (handoff.red_green || [])
   .flatMap(e => e.red_test_hashes || [])
   .map(h => `--hash ${safe(h.file, /^[A-Za-z0-9._/-]+$/, 'red_test_hashes.file')}=${safe(h.hash, /^[0-9a-f]{40}$/, 'red_test_hashes.hash')}`)
@@ -155,7 +157,7 @@ FIRST, BASELINE SANITY — the script trusts whatever ref you hand it, so earn t
 
 THEN run the single implementation — do NOT hand-roll the checkout dance:
 
-  sh scripts/agent/verify-red-proof.sh --worktree ${worktree} --test-cmd '${redProof.testCmd}' ${redProof.srcPaths.map(p => `--src ${safe(p, /^[A-Za-z0-9._/-]+$/, 'redProof.srcPaths')}`).join(' ')} ${redHashArgs} --base-ref ${baseSha}
+  sh scripts/agent/verify-red-proof.sh --worktree ${worktree} --test-cmd ${shq(redProof.testCmd)} ${redProof.srcPaths.map(p => `--src ${safe(p, /^[A-Za-z0-9._/-]+$/, 'redProof.srcPaths')}`).join(' ')} ${redHashArgs} --base-ref ${baseSha}
 
 It reverts the src paths to --base-ref (tests stay) and requires FAIL, restores HEAD and requires PASS, and enforces the freeze (git hash-object of each committed reproduction test == the handoff's red-time hash — a test edited between red and green, or with no red-time hash, proves nothing). Record its FREEZE-OK / RED-OK / GREEN-OK / VERDICT lines as evidence; a non-PASS verdict fails this item.`
   : 'This step is declared behaviour-preserving: confirm the oracle/pinned tests exist and stayed green; record which.'

--- a/.claude/workflows/phase-step.js
+++ b/.claude/workflows/phase-step.js
@@ -45,7 +45,7 @@ const HANDOFF = {
   properties: {
     verdict: { type: 'string', enum: ['DONE', 'DONE-WITH-DEVIATION', 'BLOCKED'] },
     what_changed: { type: 'array', items: { type: 'object', required: ['file', 'why'], properties: { file: { type: 'string' }, why: { type: 'string' } } } },
-    base_sha: { type: 'string', description: 'git rev-parse HEAD captured BEFORE the first edit of this step — the true pre-fix baseline the verifier reverts src to. NOT HEAD~1: a step that lands a follow-up commit (doc/ADR reconciliation, a review fix) makes HEAD~1 the wrong baseline (issue #1249).' },
+    base_sha: { type: 'string', description: 'git rev-parse HEAD captured BEFORE the first edit of this step — the true pre-fix baseline the verifier reverts src to, or "" if BLOCKED before you ran it. NOT HEAD~1: a step that lands a follow-up commit (doc/ADR reconciliation, a review fix) makes HEAD~1 the wrong baseline (issue #1249).' },
     commit: { type: 'string', description: 'the commit hash, or "" when BLOCKED' },
     gates: { type: 'array', items: { type: 'object', required: ['cmd', 'output_tail'], properties: { cmd: { type: 'string' }, output_tail: { type: 'string', description: 'pasted output tail with pass/fail counts — never a bare claim' } } } },
     red_green: { type: 'array', minItems: 1, description: 'MANDATORY, one entry per behaviour-changing item: PASTED executed red output (run BEFORE any production edit), pasted green output, and git hash-object of each test file at red time. An item with no red run carries carve_out naming the CLAUDE.md exception (brand-new code / behaviour-preserving oracle) instead — never an empty entry. Implementers reliably drop this when optional; it is schema-required for that reason.', items: { type: 'object', required: ['item'], properties: { item: { type: 'string', description: 'which plan item this proves' }, red_output: { type: 'string' }, green_output: { type: 'string' }, red_test_hashes: { type: 'array', items: { type: 'object', required: ['file', 'hash'], properties: { file: { type: 'string' }, hash: { type: 'string', description: 'git hash-object at red-run time — must equal the committed file' } } } }, carve_out: { type: 'string', description: 'the named CLAUDE.md exception, ONLY when no red run applies to this item' } } } },
@@ -134,19 +134,30 @@ if (handoff.verdict === 'BLOCKED') {
 
 phase('Verify')
 
+// The handoff is agent-authored text that ends up inside a shell command the verifier runs:
+// anything interpolated below is shape-checked here, at the boundary, or the step dies.
+const safe = (value, pattern, field) => {
+  if (typeof value !== 'string' || !pattern.test(value)) {
+    throw new Error(`unsafe ${field} in handoff: ${JSON.stringify(value)}`)
+  }
+  return value
+}
+const baseSha = redProof ? safe(handoff.base_sha, /^[0-9a-f]{7,40}$/, 'base_sha') : ''
 const redHashArgs = (handoff.red_green || [])
   .flatMap(e => e.red_test_hashes || [])
-  .map(h => `--hash ${h.file}=${h.hash}`)
+  .map(h => `--hash ${safe(h.file, /^[A-Za-z0-9._/-]+$/, 'red_test_hashes.file')}=${safe(h.hash, /^[0-9a-f]{40}$/, 'red_test_hashes.hash')}`)
   .join(' ')
 
 const redProofText = redProof
-  ? `RED PROOF (re-execute yourself, never accept the handoff's claim). Run the single implementation — do NOT hand-roll the checkout dance:
+  ? `RED PROOF (re-execute yourself, never accept the handoff's claim).
 
-  sh scripts/agent/verify-red-proof.sh --worktree ${worktree} --test-cmd '${redProof.testCmd}' ${redProof.srcPaths.map(p => `--src ${p}`).join(' ')} ${redHashArgs} --base-ref ${handoff.base_sha}
+FIRST, BASELINE SANITY — the script trusts whatever ref you hand it, so earn that trust before you run it: the handoff's base_sha (${baseSha}) must be a real commit, an ANCESTOR of HEAD, and NOT equal to HEAD — else the implementer captured it after editing and the red run would prove nothing. Check: git -C ${worktree} merge-base --is-ancestor ${baseSha} HEAD && [ "$(git -C ${worktree} rev-parse ${baseSha})" != "$(git -C ${worktree} rev-parse HEAD)" ]. Either check failing = FAIL this item; do not substitute HEAD~1 to make it pass.
 
-It reverts the src paths to --base-ref (tests stay) and requires FAIL, restores HEAD and requires PASS, and enforces the freeze (git hash-object of each committed reproduction test == the handoff's red-time hash — a test edited between red and green, or with no red-time hash, proves nothing). Record its FREEZE-OK / RED-OK / GREEN-OK / VERDICT lines as evidence; a non-PASS verdict fails this item.
+THEN run the single implementation — do NOT hand-roll the checkout dance:
 
-BASELINE SANITY (the script trusts the ref you give it, so verify it first): the handoff's base_sha (${handoff.base_sha}) must be a real commit, an ANCESTOR of HEAD, and NOT equal to HEAD — else the implementer captured it after editing and the red run would prove nothing. Check: git -C ${worktree} merge-base --is-ancestor ${handoff.base_sha} HEAD && [ "$(git -C ${worktree} rev-parse ${handoff.base_sha})" != "$(git -C ${worktree} rev-parse HEAD)" ]. Either check failing = FAIL this item; do not substitute HEAD~1 to make it pass.`
+  sh scripts/agent/verify-red-proof.sh --worktree ${worktree} --test-cmd '${redProof.testCmd}' ${redProof.srcPaths.map(p => `--src ${safe(p, /^[A-Za-z0-9._/-]+$/, 'redProof.srcPaths')}`).join(' ')} ${redHashArgs} --base-ref ${baseSha}
+
+It reverts the src paths to --base-ref (tests stay) and requires FAIL, restores HEAD and requires PASS, and enforces the freeze (git hash-object of each committed reproduction test == the handoff's red-time hash — a test edited between red and green, or with no red-time hash, proves nothing). Record its FREEZE-OK / RED-OK / GREEN-OK / VERDICT lines as evidence; a non-PASS verdict fails this item.`
   : 'This step is declared behaviour-preserving: confirm the oracle/pinned tests exist and stayed green; record which.'
 
 const gateRecord = await agent(`You are an independent VERIFIER (CLAUDE.md "THE GATE") for one delegated step. You did not write this code; re-derive, never merely re-read. READ-ONLY except the red-proof checkout dance below (which you must fully restore). Worktree: ${worktree}.

--- a/.claude/workflows/phase-step.js
+++ b/.claude/workflows/phase-step.js
@@ -41,10 +41,11 @@ const BRIEF_RECORD = {
 
 const HANDOFF = {
   type: 'object',
-  required: ['verdict', 'what_changed', 'commit', 'gates', 'red_green', 'coverage_matrix', 'deviations', 'carry_forward'],
+  required: ['verdict', 'what_changed', 'base_sha', 'commit', 'gates', 'red_green', 'coverage_matrix', 'deviations', 'carry_forward'],
   properties: {
     verdict: { type: 'string', enum: ['DONE', 'DONE-WITH-DEVIATION', 'BLOCKED'] },
     what_changed: { type: 'array', items: { type: 'object', required: ['file', 'why'], properties: { file: { type: 'string' }, why: { type: 'string' } } } },
+    base_sha: { type: 'string', description: 'git rev-parse HEAD captured BEFORE the first edit of this step — the true pre-fix baseline the verifier reverts src to. NOT HEAD~1: a step that lands a follow-up commit (doc/ADR reconciliation, a review fix) makes HEAD~1 the wrong baseline (issue #1249).' },
     commit: { type: 'string', description: 'the commit hash, or "" when BLOCKED' },
     gates: { type: 'array', items: { type: 'object', required: ['cmd', 'output_tail'], properties: { cmd: { type: 'string' }, output_tail: { type: 'string', description: 'pasted output tail with pass/fail counts — never a bare claim' } } } },
     red_green: { type: 'array', minItems: 1, description: 'MANDATORY, one entry per behaviour-changing item: PASTED executed red output (run BEFORE any production edit), pasted green output, and git hash-object of each test file at red time. An item with no red run carries carve_out naming the CLAUDE.md exception (brand-new code / behaviour-preserving oracle) instead — never an empty entry. Implementers reliably drop this when optional; it is schema-required for that reason.', items: { type: 'object', required: ['item'], properties: { item: { type: 'string', description: 'which plan item this proves' }, red_output: { type: 'string' }, green_output: { type: 'string' }, red_test_hashes: { type: 'array', items: { type: 'object', required: ['file', 'hash'], properties: { file: { type: 'string' }, hash: { type: 'string', description: 'git hash-object at red-run time — must equal the committed file' } } } }, carve_out: { type: 'string', description: 'the named CLAUDE.md exception, ONLY when no red run applies to this item' } } } },
@@ -121,6 +122,7 @@ STANDING CONTRACT (CLAUDE.md "The delegation contract" — these override nothin
 - Red->green is TEST-FIRST and EXECUTED (CLAUDE.md Test coverage #1): author the reproduction test(s) BEFORE any production edit, run them -> FAIL for the defect's reason (paste output; record git hash-object of each test file in red_test_hashes), freeze them byte-identical (a temporary skip while developing is fine, but the committed file must match the red-run content exactly), implement, re-run the SAME tests with zero edits -> PASS (paste output). Only then add further tests. Never "reasoned through". Waived only for brand-new code whose sole possible red is a missing symbol (an existence test is coverage theater) — its tests still ship.
 - TRUST THE BRIEF — do NOT re-investigate it. The brief's facts were verified by the planner and carry their evidence; an independent verifier re-derives every gate item after you, and an adversarial review re-checks the PR. Your reading scope is: the brief itself, its named required-reading refs, and the code you are about to edit. Do NOT re-fetch the issue/ADR/PR from GitHub, do NOT re-run the brief's enumeration greps, do NOT re-derive its coverage matrix — that spends the step's budget re-doing the planner's work.
 - ESCALATE is REACTIVE, not an audit mandate: when code you are editing (or a probe you needed anyway) contradicts a brief claim, STOP and return verdict BLOCKED with the blocker field filled — never silently patch the plan. Encountering a contradiction triggers it; going looking for one does not.
+- FIRST, before any edit: run git -C ${worktree} rev-parse HEAD and report it verbatim as base_sha. That is the pre-fix baseline the verifier reverts to; it stays correct even if you land a follow-up commit on top of the fix, which HEAD~1 would not.
 - Commit as the brief instructs (single focused commit, repo commit style), then fill the structured handoff COMPLETELY — an empty field is a gate failure.`,
   { label: 'implement', phase: 'Implement', model: 'sonnet', effort: 'xhigh', schema: HANDOFF })
 
@@ -132,8 +134,19 @@ if (handoff.verdict === 'BLOCKED') {
 
 phase('Verify')
 
+const redHashArgs = (handoff.red_green || [])
+  .flatMap(e => e.red_test_hashes || [])
+  .map(h => `--hash ${h.file}=${h.hash}`)
+  .join(' ')
+
 const redProofText = redProof
-  ? `RED PROOF (re-execute yourself, never accept the handoff's claim): git -C ${worktree} checkout HEAD~1 -- ${redProof.srcPaths.join(' ')} (tests stay), run ${redProof.testCmd} -> expect FAIL; git -C ${worktree} checkout HEAD -- . , re-run -> expect PASS. Record both outputs as evidence. FREEZE CHECK: run git -C ${worktree} hash-object on each committed reproduction test file and compare against the handoff's red_test_hashes — a mismatch or missing hash means the test was edited between red and green (or the red run never preceded the fix): FAIL.`
+  ? `RED PROOF (re-execute yourself, never accept the handoff's claim). Run the single implementation — do NOT hand-roll the checkout dance:
+
+  sh scripts/agent/verify-red-proof.sh --worktree ${worktree} --test-cmd '${redProof.testCmd}' ${redProof.srcPaths.map(p => `--src ${p}`).join(' ')} ${redHashArgs} --base-ref ${handoff.base_sha}
+
+It reverts the src paths to --base-ref (tests stay) and requires FAIL, restores HEAD and requires PASS, and enforces the freeze (git hash-object of each committed reproduction test == the handoff's red-time hash — a test edited between red and green, or with no red-time hash, proves nothing). Record its FREEZE-OK / RED-OK / GREEN-OK / VERDICT lines as evidence; a non-PASS verdict fails this item.
+
+BASELINE SANITY (the script trusts the ref you give it, so verify it first): the handoff's base_sha (${handoff.base_sha}) must be a real commit, an ANCESTOR of HEAD, and NOT equal to HEAD — else the implementer captured it after editing and the red run would prove nothing. Check: git -C ${worktree} merge-base --is-ancestor ${handoff.base_sha} HEAD && [ "$(git -C ${worktree} rev-parse ${handoff.base_sha})" != "$(git -C ${worktree} rev-parse HEAD)" ]. Either check failing = FAIL this item; do not substitute HEAD~1 to make it pass.`
   : 'This step is declared behaviour-preserving: confirm the oracle/pinned tests exist and stayed green; record which.'
 
 const gateRecord = await agent(`You are an independent VERIFIER (CLAUDE.md "THE GATE") for one delegated step. You did not write this code; re-derive, never merely re-read. READ-ONLY except the red-proof checkout dance below (which you must fully restore). Worktree: ${worktree}.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,11 +207,14 @@ the gate report's wording, never to which checks run.
    changes runs regardless of its language).
 2. **Re-execute the red proof yourself** for behaviour changes — never accept the handoff's
    claim. Run `scripts/agent/verify-red-proof.sh --worktree <path> --test-cmd '<cmd>'
-   --src <path>... --hash <test>=<red-time-sha>...` — it reverts the src paths to HEAD~1
-   (tests stay), requires the test to FAIL, restores, requires PASS, and enforces the
-   freeze (`git hash-object` of each committed reproduction test equals the handoff's
-   red-time hash — a test edited between red and green, or with no red-time hash, proves
-   nothing). Record its verdict lines.
+   --src <path>... --hash <test>=<red-time-sha>... [--base-ref <pre-fix-commit>]` — it
+   reverts the src paths to `--base-ref` (default `HEAD~1`; tests stay), requires the test
+   to FAIL, restores, requires PASS, and enforces the freeze (`git hash-object` of each
+   committed reproduction test equals the handoff's red-time hash — a test edited between
+   red and green, or with no red-time hash, proves nothing). A step that lands more than
+   one commit (a follow-up doc/ADR reconciliation, a review fix) passes the true pre-fix
+   commit explicitly via `--base-ref` — `HEAD~1` then names the wrong baseline. Record its
+   verdict lines.
 3. **Read the full diff** (`git show` — never `--stat` alone) and tick **every** ACTION-PLAN
    item and **every** coverage-matrix row against what the diff actually does. `--stat` cannot
    see a hardcoded value, a stubbed branch, or a silently dropped plan item. A mechanism in

--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -72,7 +72,8 @@ main() {
 		printf 'FREEZE-OK: %s\n' "$file"
 	done
 
-	base_sha=$(git -C "$worktree" rev-parse --verify --quiet "${base_ref}^{commit}") || {
+	# --end-of-options: a ref is data, never a git option, whatever it looks like.
+	base_sha=$(git -C "$worktree" rev-parse --verify --quiet --end-of-options "${base_ref}^{commit}") || {
 		echo "BAD-BASE-REF: '$base_ref' does not resolve to a single existing commit" >&2
 		exit 2
 	}

--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -1,25 +1,30 @@
 #!/bin/sh
 # verify-red-proof.sh -- mechanically re-execute a red->green proof (CLAUDE.md "THE GATE"
-# item 2): freeze-hash check, revert the src paths to HEAD~1 (tests stay), expect the
-# pinning test to FAIL, restore, expect it to PASS. The single implementation the
-# gh-issue / adr-phase / delegate gates and the phase-step verifier reference.
+# item 2): freeze-hash check, revert the src paths to the pre-fix baseline (tests stay),
+# expect the pinning test to FAIL, restore, expect it to PASS. The single implementation
+# the gh-issue / adr-phase / delegate gates and the phase-step verifier reference.
 #
 # Usage: verify-red-proof.sh --worktree PATH --test-cmd 'CMD' --src PATH [--src PATH ...]
-#                            [--hash FILE=SHA ...]
+#                            [--hash FILE=SHA ...] [--base-ref REF]
 #   --test-cmd  run via `sh -c` from the worktree root; nonzero exit = red, zero = green
-#   --src       production path(s) reverted to HEAD~1 for the red run (repo-relative)
+#   --src       production path(s) reverted to --base-ref for the red run (repo-relative)
 #   --hash      committed reproduction-test freeze check: `git hash-object FILE` must
 #               equal SHA (the handoff's red-time hash) -- an edited test proves nothing
+#   --base-ref  the pre-fix baseline (default HEAD~1). Pass the true pre-fix commit
+#               explicitly whenever the step landed more than one commit (a follow-up
+#               doc/ADR reconciliation, a review fix) -- HEAD~1 then names the wrong
+#               commit. Omitting it keeps today's behaviour byte-identical.
 #
 # Prints FREEZE-OK / RED-OK / GREEN-OK step lines, then final `VERDICT: PASS`.
 # Any step failing prints the failing step + `VERDICT: FAIL` and exits 1. Requires a
-# clean tree (exit 2 otherwise); the src paths are restored on every exit path.
+# clean tree (exit 2 otherwise); the src paths are restored on every exit path. An
+# unresolvable --base-ref (not a single existing commit) also exits 2, tree untouched.
 
-worktree='' test_cmd=''
+worktree='' test_cmd='' base_ref='HEAD~1'
 srcs='' hashes=''
 
 usage() {
-	echo "usage: verify-red-proof.sh --worktree PATH --test-cmd 'CMD' --src PATH [--src ...] [--hash FILE=SHA ...]" >&2
+	echo "usage: verify-red-proof.sh --worktree PATH --test-cmd 'CMD' --src PATH [--src ...] [--hash FILE=SHA ...] [--base-ref REF]" >&2
 	exit 2
 }
 
@@ -45,6 +50,7 @@ main() {
 				esac
 				srcs="$srcs $2"; shift 2 ;;
 			--hash) hashes="$hashes $2"; shift 2 ;;
+			--base-ref) [ -n "$2" ] || usage; base_ref=$2; shift 2 ;;
 			*) usage ;;
 		esac
 	done
@@ -66,19 +72,23 @@ main() {
 		printf 'FREEZE-OK: %s\n' "$file"
 	done
 
+	base_sha=$(git -C "$worktree" rev-parse --verify --quiet "${base_ref}^{commit}") || {
+		echo "BAD-BASE-REF: '$base_ref' does not resolve to a single existing commit" >&2
+		exit 2
+	}
 	# shellcheck disable=SC2086 # srcs is a space-separated path list by construction
-	git -C "$worktree" checkout HEAD~1 -- $srcs || fail "REVERT-FAIL: could not check out HEAD~1 src paths"
+	git -C "$worktree" checkout "$base_sha" -- $srcs || fail "REVERT-FAIL: could not check out $base_ref src paths"
 	# shellcheck disable=SC2064,SC2086 # expand now: restore exactly these paths on any exit.
 	# INT/TERM trapped explicitly: under dash (Linux /bin/sh) an EXIT trap does NOT run
-	# on an untrapped signal, which would strand the src paths at HEAD~1.
+	# on an untrapped signal, which would strand the src paths at the base ref.
 	trap "git -C '$worktree' checkout HEAD -- $srcs" EXIT
 	# shellcheck disable=SC2064,SC2086 # expand now, deliberately (same paths as above)
 	trap "git -C '$worktree' checkout HEAD -- $srcs; trap - EXIT; exit 130" INT TERM
 
 	if (cd "$worktree" && sh -c "$test_cmd" >/dev/null 2>&1); then
-		fail "RED-FAIL: test passed against HEAD~1 src -- it does not pin the defect"
+		fail "RED-FAIL: test passed against $base_ref src -- it does not pin the defect"
 	fi
-	printf 'RED-OK: test fails against HEAD~1 src\n'
+	printf 'RED-OK: test fails against %s src\n' "$base_ref"
 
 	# shellcheck disable=SC2086
 	git -C "$worktree" checkout HEAD -- $srcs || fail "RESTORE-FAIL"

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -162,11 +162,15 @@ Describe 'verify-red-proof.sh'
     Assert [ -z "$(git -C "$repo" status --porcelain)" ]
   End
 
-  It 'rejects an empty --base-ref at parse time'
+  # An empty value is caught by the parse-time guard, NOT by the later rev-parse check:
+  # the absence of BAD-BASE-REF is what discriminates the two (drop the guard and the empty
+  # ref reaches rev-parse, which rejects it with that message instead).
+  It 'rejects an empty --base-ref at parse time, before the ref ever reaches git'
     make_repo BAD GOOD
     When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref ''
     The status should equal 2
     The stderr should include 'usage:'
+    The stderr should not include 'BAD-BASE-REF'
   End
 
   It 'rejects a nonexistent --base-ref'
@@ -177,17 +181,19 @@ Describe 'verify-red-proof.sh'
     Assert [ -z "$(git -C "$repo" status --porcelain)" ]
   End
 
-  It 'rejects a --base-ref that is a revision range, not a single ref ("HEAD~2..HEAD")'
-    make_repo BAD GOOD
+  # The 3-commit fixture is what makes these pin RANGE rejection rather than merely
+  # unknown-ref rejection: both endpoints resolve here, so only the range syntax is at fault.
+  It 'rejects a --base-ref that is a revision range whose endpoints both exist ("HEAD~2..HEAD")'
+    make_repo3 BAD GOOD FOLLOWUP
     When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref 'HEAD~2..HEAD'
     The status should equal 2
     The stderr should include 'BAD-BASE-REF'
     Assert [ -z "$(git -C "$repo" status --porcelain)" ]
   End
 
-  It 'rejects a --base-ref that is a revision range, not a single ref ("a...b")'
-    make_repo BAD GOOD
-    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref 'a...b'
+  It 'rejects a --base-ref that is a symmetric revision range whose endpoints both exist ("HEAD~2...HEAD")'
+    make_repo3 BAD GOOD FOLLOWUP
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref 'HEAD~2...HEAD'
     The status should equal 2
     The stderr should include 'BAD-BASE-REF'
     Assert [ -z "$(git -C "$repo" status --porcelain)" ]

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -25,6 +25,26 @@ Describe 'verify-red-proof.sh'
     gitc commit -qm v2
     pin_hash=$(gitc hash-object test_pin.sh)
   }
+  make_repo3() {
+    # $1 = v1 (pre-fix) src, $2 = v2 (the fix) src, $3 = v3 (unrelated follow-up,
+    # src.txt unchanged) -- mirrors PR #1247's da2d7820 (fix) + 501deb92 (follow-up).
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof3.XXXXXX")"
+    git -C "$repo" init -q
+    printf '%s\n' "$1" > "$repo/src.txt"
+    printf 'grep -q GOOD src.txt\n' > "$repo/test_pin.sh"
+    gitc add -A
+    gitc commit -qm v1
+    fix_base_sha=$(gitc rev-parse HEAD)
+    printf '%s\n' "$2" > "$repo/src.txt"
+    echo other > "$repo/other.txt"
+    gitc add -A
+    gitc commit -qm v2-fix
+    printf '%s\n' "$3" > "$repo/followup.txt"
+    gitc add -A
+    gitc commit -qm v3-followup
+    pin_hash=$(gitc hash-object test_pin.sh)
+  }
   cleanup() { rm -rf "$repo"; }
   After 'cleanup'
 
@@ -95,5 +115,81 @@ Describe 'verify-red-proof.sh'
     When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt
     The status should equal 2
     The stderr should include 'DIRTY-TREE'
+  End
+
+  It 'verifies a genuine red->green proof against an explicit --base-ref (3-commit fixture, mirrors PR #1247)'
+    make_repo3 BAD GOOD FOLLOWUP
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' \
+      --src src.txt --hash "test_pin.sh=$pin_hash" --base-ref "$fix_base_sha"
+    The status should equal 0
+    The output should include 'RED-OK'
+    The output should include 'GREEN-OK'
+    The line 4 of output should equal 'VERDICT: PASS'
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'without --base-ref, the same 3-commit fixture still falsely reports RED-FAIL (documents the default HEAD~1 bug)'
+    make_repo3 BAD GOOD FOLLOWUP
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' \
+      --src src.txt --hash "test_pin.sh=$pin_hash"
+    The status should equal 1
+    The output should include 'RED-FAIL'
+    The output should include 'VERDICT: FAIL'
+  End
+
+  It 'still enforces the freeze hash when --base-ref is passed'
+    make_repo3 BAD GOOD FOLLOWUP
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' \
+      --src src.txt --hash 'test_pin.sh=0000000000000000000000000000000000000000' \
+      --base-ref "$fix_base_sha"
+    The status should equal 1
+    The output should include 'FREEZE-FAIL'
+  End
+
+  It 'rejects a --base-ref that looks like a git option ("-q")'
+    make_repo BAD GOOD
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref '-q'
+    The status should equal 2
+    The stderr should include 'BAD-BASE-REF'
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'rejects a --base-ref that looks like a git option ("--force")'
+    make_repo BAD GOOD
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref '--force'
+    The status should equal 2
+    The stderr should include 'BAD-BASE-REF'
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'rejects an empty --base-ref at parse time'
+    make_repo BAD GOOD
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref ''
+    The status should equal 2
+    The stderr should include 'usage:'
+  End
+
+  It 'rejects a nonexistent --base-ref'
+    make_repo BAD GOOD
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref 'no-such-ref'
+    The status should equal 2
+    The stderr should include 'BAD-BASE-REF'
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'rejects a --base-ref that is a revision range, not a single ref ("HEAD~2..HEAD")'
+    make_repo BAD GOOD
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref 'HEAD~2..HEAD'
+    The status should equal 2
+    The stderr should include 'BAD-BASE-REF'
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'rejects a --base-ref that is a revision range, not a single ref ("a...b")'
+    make_repo BAD GOOD
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref 'a...b'
+    The status should equal 2
+    The stderr should include 'BAD-BASE-REF'
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
   End
 End


### PR DESCRIPTION
Fixes #1249.

`verify-red-proof.sh` reverted the `--src` paths to a hardcoded `HEAD~1` to produce the red run, which silently assumes *the fix is the last commit on the branch*. That breaks whenever a step legitimately lands a follow-up commit on top of the fix — a stale-doc reconciliation, an ADR amendment (CLAUDE.md requires amending overturned Accepted-ADR text in the same change), or a review fix. PR #1247 hit exactly this and got a spurious `RED-FAIL` against a genuinely-correct proof.

Triage found a **second, independent copy of the same assumption** that the issue did not: `.claude/workflows/phase-step.js`'s Verify stage never called the script at all — it re-implemented the checkout dance in its prompt to the verifier agent, hardcoding `git checkout HEAD~1` there too. That is the path **every** `/adr-phase` phase and **every** `/gh-issue --fix` step routes through, and its failure direction is the dangerous one: with a follow-up commit stacked on the fix, the "red" run happens against the post-fix tree, so it can pass or fail for the wrong reason while the gate reports PASS. Fixing only the script would have left it untouched, so both are fixed here.

## What changed

**`scripts/agent/verify-red-proof.sh`** — new `--base-ref REF`, default `HEAD~1`, so every existing caller and all 7 pre-existing spec cases are unaffected. The value is resolved through `git rev-parse --verify --quiet "REF^{commit}"` to a bare sha *before* any checkout sees it, which rejects an unresolvable ref, an empty value, a leading-dash git-option lookalike (`-q`, `--force`), and a revision range (`a..b`) in one step — the resolved output is hex, so a hostile value can never reach `git` as an option. The two restore traps and the explicit restore stay literal `HEAD`: they restore the current tip regardless of which baseline the red run used.

**`.claude/workflows/phase-step.js`** — the implementer already knows the true baseline (it is `HEAD` before its first edit), so the HANDOFF schema now requires `base_sha`, and the Verify stage invokes the shell script with `--base-ref <base_sha>` instead of re-implementing it. One implementation, and the baseline stays correct however many commits a step lands. The verifier first checks `base_sha` is a real commit, an ancestor of `HEAD`, and not `HEAD` itself, since the script trusts the ref it is given.

**`CLAUDE.md` / `.claude/skills/delegate/SKILL.md`** — the gate prose describing the script's contract, reconciled with the new flag.

## Tests

`tests/shell/agent_verify_red_proof_spec.sh`: +9 `It` blocks (7 → 16 examples), all 7 pre-existing ones untouched — they are the backward-compatibility contract. New `make_repo3` fixture builds the 3-commit shape (pre-fix → fix → follow-up) that mirrors PR #1247.

Red proof: the new cases were authored and run against the unmodified script first — 7 of 16 failed (`--base-ref` unrecognised → usage/exit 2) — then frozen byte-identical (`git hash-object 2a570e9c…`, equal to the committed file) and re-run green with zero edits, 16/16.

The branch itself ends up in the exact shape the bug needs (a fix commit plus a follow-up commit), so the gate was re-executed against the real repository:

```text
# without --base-ref -- HEAD~1 is the fix commit: the #1247 false FAIL, reproduced
RED-FAIL: test passed against HEAD~1 src -- it does not pin the defect
VERDICT: FAIL

# with the true pre-fix baseline
RED-OK: test fails against 7d6ee73c src
GREEN-OK: test passes against HEAD
VERDICT: PASS
```

Gates: `run-gates.sh --diff origin/devel` → PASS (`sh -n`, shellcheck, shellspec under dash, markdownlint).