### PR TITLE
scripts: deny a mutating git command that relies on the ambient working directory (#1262)

### DIFF
--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -2,9 +2,10 @@
 # scripts/claude-bash-guard.sh -- PreToolUse Bash guard: deny 4 agent footguns.
 #
 # Wired in .claude/settings.json as a PreToolUse hook matching the Bash tool.
-# Denies, at the TOOL layer (before the command ever runs), four operations an
-# AGENT must not run -- three git bypasses a human may legitimately use, plus a
-# wait-launch shape that silently strands the turn:
+# Denies, at the TOOL layer (before the command ever runs), five operations an
+# AGENT must not run -- three git bypasses a human may legitimately use, a
+# wait-launch shape that silently strands the turn, and a mutating git command
+# whose target the hook cannot verify:
 #
 #   Rule A -- `git commit` with `--no-verify`   : the pre-commit lint gate's
 #             --no-verify bypass is for humans, not agents (CLAUDE.md "Git
@@ -23,10 +24,36 @@
 #             the turn stalls while the wait has already finished (#1225).
 #             Whole-payload, not per-segment: `&` is one of the characters
 #             $segs splits on.
+#   Rule E -- a MUTATING git command (commit, push, rebase, merge, reset,
+#             checkout, switch, cherry-pick, revert, stash, am, clean) that
+#             depends on the AMBIENT working directory : the PreToolUse
+#             payload carries no cwd (see WHY BELOW), so the hook cannot
+#             detect "you are in the wrong directory" -- it can only refuse
+#             a mutating command whose target is UNSTATED, making the bad
+#             state unrepresentable instead of detected (issue #1262: a
+#             stray `cd` into the primary checkout, left over from an
+#             unrelated fix, silently redirected a rebase+push at the wrong
+#             repo; the rebase reported "up to date" and the push was a
+#             silent no-op, hiding that the real branch was a commit
+#             behind). DENIES when neither `git -C <path>` nor `cd <path>`
+#             names a target anywhere in the payload (E1), and DENIES when
+#             the named target IS the primary checkout -- $CLAUDE_PROJECT_DIR,
+#             exported into this hook by .claude/settings.json (E2) --
+#             CLAUDE.md "Worktrees": all repository work happens in a
+#             dedicated worktree, never there. `git worktree add`/`remove`
+#             are exempt from Rule E entirely, and need no special-case code
+#             for it: neither "add" nor "remove" is one of the mutating
+#             verbs above, so a `git worktree ...` segment never matches the
+#             verb check that would trigger E1/E2 in the first place.
 #
-# Rule D runs first (whole-payload). Then the per-segment rules: segments are
-# scanned left to right (see MATCHING below); within one segment, A, then B,
-# then C. First matching pair wins.
+# Rule D runs first (whole-payload). Rule E's target checks (E1: is a
+# `-C`/`cd` target named anywhere; E2: does that target equal the primary
+# checkout) are ALSO whole-payload and precomputed once, right after Rule D,
+# for the same reason Rule D itself is whole-payload -- see THE WHOLE-PAYLOAD
+# CRUX below. Only Rule E's MUTATING-VERB detection runs per-segment. Then
+# the per-segment rules: segments are scanned left to right (see MATCHING
+# below); within one segment, A, then B, then C, then E's verb check against
+# the precomputed E1/E2 booleans. First matching pair wins.
 #
 # FAIL-OPEN CONTRACT: this hook must NEVER block a legitimate Bash call
 # because of a parsing failure. Empty stdin, garbled/non-JSON stdin, or no
@@ -117,6 +144,65 @@
 # containing `f` (`-uf`, `-fu`, ...) are matched with an explicit boundary so
 # they do NOT fire inside --force, --force-with-lease, -force, or a filename
 # ending in "-f" (e.g. my-f-dir) -- see _has_force_flag below.
+#
+# WHY BELOW (Rule E, issue #1262): the PreToolUse payload is
+# {"tool_name":"Bash","tool_input":{"command":"..."}} -- there is no cwd
+# field, and the harness's Bash working directory PERSISTS across calls (a
+# `cd` two calls ago is still in effect). The hook therefore cannot compare
+# "the cwd" against anything; it can only refuse a mutating git command whose
+# target is never named, which makes the dangerous state (running a mutating
+# command against whatever directory the shell happens to be sitting in)
+# unrepresentable rather than something the hook detects after the fact.
+#
+# THE WHOLE-PAYLOAD CRUX: `cd /path && git commit` splits into segments
+# `cd /path ` and ` git commit` (see $segs below) -- the `cd` and the verb
+# are in DIFFERENT segments. So E1's "is a target named at all" test and
+# E2's "does that target equal the primary checkout" test both run against
+# $norm (the whole payload), exactly as Rule D's background-`&` test does,
+# and for the identical reason: the thing being looked for can sit in a
+# different segment than the verb that triggers the rule. Only the
+# MUTATING-VERB check itself is per-segment (_seg_has_mutating_verb, run
+# inside the A-C loop against $seg) -- pinned by E-b3/E-b4 (a `cd` naming the
+# target once at the front of a compound command covers every mutating verb
+# in every later segment of that SAME payload).
+#
+# THE PREFIX TRAP: worktrees live UNDER the project dir
+# ($CLAUDE_PROJECT_DIR/.claude/worktrees/<slug>), so E2 must never match
+# $CLAUDE_PROJECT_DIR as a plain substring prefix -- that would deny every
+# worktree command and make the hook unusable. _targets_primary_checkout
+# requires the character immediately after $CLAUDE_PROJECT_DIR to be a
+# genuine separator (space/&/;/|/(/)/{/}/</>/,) or end-of-payload (a
+# synthetic trailing space is appended before matching so end-of-payload
+# reads as that same separator class, collapsing two cases into one glob
+# pattern) -- a worktree path's next character is always `/`, which is NOT
+# in that class, so `cd $CLAUDE_PROJECT_DIR/.claude/worktrees/x` and
+# `git -C $CLAUDE_PROJECT_DIR-other` (a SIBLING dir sharing the prefix) both
+# correctly fail to match. Pinned by E-d1/E-d2/E-d3.
+#
+# JSON-ADJACENCY BOUNDARY: E1's target search needs a LEADING boundary too
+# (so `cd ` embedded inside a longer word, e.g. `abcd `, cannot forge a
+# target and wrongly ALLOW a mutating command with no real target -- the
+# dangerous direction, unlike this file's other accepted false positives
+# which all err toward denying). But the real payload is JSON, and
+# normalization (above) strips its quotes, so `"command":"cd ...` collapses
+# to `command:cd ...` -- the character immediately before a target sitting at
+# the very start of the command value is `:`, not whitespace. E1's boundary
+# class (_E_TARGET_LEAD) therefore adds `:` to $_SEP's separator set, for the
+# same structural reason $_SEP itself already carries `{`/`}` (a flag can sit
+# directly against the JSON's closing `}}`, see above). This is a narrower,
+# deliberate widening of the general acceptance already documented above (a
+# raw text scan is not a real parse) -- a literal `:cd ` sequence inside an
+# argument VALUE (not the JSON scaffold) could in theory forge a target, but
+# no realistic git invocation produces that token sequence.
+#
+# ACCEPTED FALSE POSITIVES (E, same family as B10/D10): E2's target-equality
+# check has no leading boundary of its own (only the trailing one above), so
+# a commit MESSAGE that merely CONTAINS text shaped like
+# "cd $CLAUDE_PROJECT_DIR " denies even when the command's REAL cd target is
+# a worktree (pinned by E-h1) -- and a mutating verb phrase sitting inside a
+# quoted argument to another tool (`sh -c "git push"`) denies with no target
+# check able to save it, same as B10 (pinned by E-h5). Both directions err
+# toward blocking, the stated tradeoff throughout this file.
 set -u
 
 payload="$(cat)"
@@ -218,6 +304,59 @@ _bare_force_after_last_lease() {
 		| grep -Eq "(^|${_SEP})(--force|${_FORCE_CLUSTER})(\$|${_SEP})"
 }
 
+# _E_TARGET_LEAD -- leading-boundary class for E1's `git -C `/`cd ` search. A
+# target only counts in COMMAND POSITION: preceded by start-of-payload, the JSON
+# scaffold's `:` (normalization strips the quotes, so `"command":"cd ...`
+# collapses to `command:cd ...`), or a command separator -- optionally followed
+# by spaces, so `&& cd /wt` still reads as a target.
+#
+# A bare SPACE is deliberately NOT a boundary here: a space before `cd ` means it
+# sits inside an ARGUMENT, and honouring it would let a commit message reading
+# `-m fix: cd into the worktree` forge a target and ALLOW an otherwise target-less
+# mutating command. That direction fails OPEN -- the one direction this file never
+# accepts (every other documented false positive errs toward denying). Pinned by
+# E-h6/E-h7.
+_E_TARGET_LEAD='[:;|&(){}<>,]'
+
+# _has_explicit_target -- true iff $norm (the WHOLE payload) names a target
+# via `git -C ` or `cd ` IN COMMAND POSITION (see _E_TARGET_LEAD above).
+# Whole-payload, not $seg: the target can sit in a different segment than the
+# verb it covers (E-b3/E-b4).
+_has_explicit_target() {
+	printf '%s' "$norm" | grep -Eq "(^|${_E_TARGET_LEAD})[[:space:]]*(git -C |cd )"
+}
+
+# _TARGET_SEP -- trailing-boundary glob class for _targets_primary_checkout:
+# a real separator, or (via the caller's synthetic trailing space) end of
+# payload -- see THE PREFIX TRAP above. Case globbing, not grep -E, so
+# $CLAUDE_PROJECT_DIR's `/` and `.` never need escaping.
+_TARGET_SEP='[ &;|(){}<>,]'
+
+# _targets_primary_checkout -- true iff $norm names $CLAUDE_PROJECT_DIR
+# itself (never a subdirectory or a sibling sharing its prefix) as a `cd `/
+# `git -C ` target. Unset CLAUDE_PROJECT_DIR -> false, never a crash (fail-open
+# under set -u): E2 has nothing to compare against.
+_targets_primary_checkout() {
+	[ -n "${CLAUDE_PROJECT_DIR:-}" ] || return 1
+	case "${norm} " in
+	*"cd ${CLAUDE_PROJECT_DIR}"${_TARGET_SEP}* | *"git -C ${CLAUDE_PROJECT_DIR}"${_TARGET_SEP}*) return 0 ;;
+	esac
+	return 1
+}
+
+# _seg_has_mutating_verb -- true iff the CURRENT SEGMENT ($seg) contains a
+# Rule E mutating verb as the pair `git <verb>` OR `git -C <path> <verb>` --
+# never a bare verb word, so `git log --grep=commit` (the verb as an ARGUMENT
+# VALUE) does not match (E-h4). The `-C <path>` skip is required: without it,
+# the verb in `git -C /wt push` sits two tokens after `git`, not adjacent, so
+# the very syntax Rule E asks callers to use would itself evade detection
+# (E-c2). `git worktree add/remove` needs no exemption clause: neither "add"
+# nor "remove" is in this list.
+_seg_has_mutating_verb() {
+	printf '%s' "$seg" \
+		| grep -Eq 'git (-C [^ ]+ )?(commit|push|rebase|merge|reset|checkout|switch|cherry-pick|revert|stash|am|clean)'
+}
+
 # _deny <reason> -- print the PreToolUse deny JSON and exit 0 (exit 0 is
 # required even for a deny: Claude Code reads the decision from stdout, not
 # from the process exit status). <reason> must contain no " or \ so it can
@@ -234,8 +373,14 @@ if printf '%s' "$norm_bg" | grep -Eq 'wait-[a-z0-9_-]*\.sh.*&'; then
 	_deny "a wait script backgrounded with & is invisible to the harness: no completion notification fires, so the turn stalls while the wait has already finished (issue #1225). Launch it as its OWN Bash call with run_in_background: true -- backgrounding is a property of the tool call, not of shell syntax (CLAUDE.md No orphaned waits)"
 fi
 
-# Walk $segs one segment at a time, applying rules A-C to each ($seg
-# is read by _contains / _has_force_flag above). Fed via a heredoc (not a
+# Rule E's target checks (whole-payload, precomputed once -- see THE
+# WHOLE-PAYLOAD CRUX above; only the verb check below is per-segment).
+if _has_explicit_target; then _e_has_target=1; else _e_has_target=0; fi
+if _targets_primary_checkout; then _e_targets_primary=1; else _e_targets_primary=0; fi
+
+# Walk $segs one segment at a time, applying rules A, B, C, and E's
+# per-segment verb check to each ($seg is read by _contains /
+# _has_force_flag / _seg_has_mutating_verb above). Fed via a heredoc (not a
 # `| while`) so this loop runs in the CURRENT shell, not a subshell: dash (the
 # box's /bin/sh) forks a subshell for the reader end of a pipe, which would
 # swallow _deny's `exit 0` instead of ending the whole script.
@@ -252,6 +397,15 @@ while IFS= read -r seg; do
 
 	if _contains 'git worktree remove' && _has_force_flag; then
 		_deny "CLAUDE.md forbids force-removing a worktree you do not own"
+	fi
+
+	if _seg_has_mutating_verb; then
+		if [ "$_e_has_target" = 0 ]; then
+			_deny "a mutating git command depends on the ambient working directory, which this hook cannot see: name the target explicitly with git -C <path> or cd <path> first (CLAUDE.md Worktrees, issue #1262)"
+		fi
+		if [ "$_e_targets_primary" = 1 ]; then
+			_deny "the named target is the primary checkout: every AI agent must do repository work in its own dedicated worktree, never the primary checkout (CLAUDE.md Worktrees)"
+		fi
 	fi
 done <<_PFB_SEGS_
 $segs

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# scripts/claude-bash-guard.sh -- PreToolUse Bash guard: deny 4 agent footguns.
+# scripts/claude-bash-guard.sh -- PreToolUse Bash guard: deny 5 agent footguns.
 #
 # Wired in .claude/settings.json as a PreToolUse hook matching the Bash tool.
 # Denies, at the TOOL layer (before the command ever runs), five operations an
@@ -35,10 +35,15 @@
 #             unrelated fix, silently redirected a rebase+push at the wrong
 #             repo; the rebase reported "up to date" and the push was a
 #             silent no-op, hiding that the real branch was a commit
-#             behind). DENIES when neither `git -C <path>` nor `cd <path>`
-#             names a target anywhere in the payload (E1), and DENIES when
-#             the named target IS the primary checkout -- $CLAUDE_PROJECT_DIR,
-#             exported into this hook by .claude/settings.json (E2) --
+#             behind). A target counts ONLY where it actually GOVERNS the
+#             verb: `git -C <path> <verb>` in the SAME segment, or a `cd`
+#             that is the FIRST command of the call. DENIES when neither
+#             holds (E1) -- a cd found anywhere else does not count, because
+#             a subshell cd does not persist to its siblings and a cd in a
+#             commit MESSAGE is indistinguishable from a real one once quotes
+#             are stripped. DENIES when the named target IS the primary
+#             checkout -- $CLAUDE_PROJECT_DIR, exported by .claude/settings.json
+#             (E2) --
 #             CLAUDE.md "Worktrees": all repository work happens in a
 #             dedicated worktree, never there. `git worktree add`/`remove`
 #             are exempt from Rule E entirely, and need no special-case code
@@ -46,11 +51,11 @@
 #             verbs above, so a `git worktree ...` segment never matches the
 #             verb check that would trigger E1/E2 in the first place.
 #
-# Rule D runs first (whole-payload). Rule E's target checks (E1: is a
-# `-C`/`cd` target named anywhere; E2: does that target equal the primary
-# checkout) are ALSO whole-payload and precomputed once, right after Rule D,
-# for the same reason Rule D itself is whole-payload -- see THE WHOLE-PAYLOAD
-# CRUX below. Only Rule E's MUTATING-VERB detection runs per-segment. Then
+# Rule D runs first (whole-payload). Rule E is split by SCOPE, which is the
+# whole point: a leading `cd` governs every later segment, so that check (and
+# E2's primary-checkout check) is whole-payload and precomputed once; a
+# `git -C <path>` governs only its own command, so that check -- and the
+# mutating-verb detection it pairs with -- runs per-segment. Then
 # the per-segment rules: segments are scanned left to right (see MATCHING
 # below); within one segment, A, then B, then C, then E's verb check against
 # the precomputed E1/E2 booleans. First matching pair wins.
@@ -317,14 +322,36 @@ _bare_force_after_last_lease() {
 # documented false positive errs toward denying). Only the literal `command:` scaffold
 # counts, which normalization leaves intact (`"command":"cd ...` -> `command:cd ...`).
 # Pinned by E-h6/E-h7/E-h8/E-h10.
-_E_TARGET_LEAD='[;|&({]'
+# A target counts ONLY where it actually GOVERNS the verb. "A cd/-C appears
+# somewhere in the payload" is not that, and every attempt to approximate it with a
+# boundary class leaked: quote-stripping makes data and operators identical, so a
+# commit MESSAGE could forge whatever character the class trusted -- first a bare
+# space, then a bare `:` (`fix: cd /tmp`), then the `command:` token itself. Each
+# leak failed OPEN, the one direction this file never accepts. So the class is gone;
+# only two shapes name a target, and neither is forgeable from an argument value:
+#
+#   1. `git -C <path> <verb>` -- the target sits in the SAME segment as the verb it
+#      governs, adjacent to it (_seg_has_inplace_target).
+#   2. A `cd` that is the FIRST command of the payload (_has_leading_cd), anchored to
+#      the JSON scaffold. Only a leading cd governs the later top-level commands.
+#
+# A `cd` anywhere else does NOT count, and that is deliberate, not an approximation:
+#   * `(cd /wt) && git commit` -- a subshell cd does NOT persist to its siblings
+#     (`sh -c '(cd /tmp); pwd'` prints the ORIGINAL cwd), so the commit really would
+#     run against the ambient cwd. Trusting it would have re-admitted the exact issue
+#     #1262 shape: `(cd /wt && git fetch); git rebase … && git push --force-with-lease`.
+#   * `git add -A && cd /wt && git commit` -- legal, and denied. Put the cd first.
+# Pinned by E-h6..E-h10, E-h15, E-h16.
+_has_leading_cd() {
+	printf '%s' "$norm" | grep -Eq 'tool_input:[{]command:[[:space:]]*cd '
+}
 
-# _has_explicit_target -- true iff $norm (the WHOLE payload) names a target
-# via `git -C ` or `cd ` IN COMMAND POSITION (see _E_TARGET_LEAD above).
-# Whole-payload, not $seg: the target can sit in a different segment than the
-# verb it covers (E-b3/E-b4).
-_has_explicit_target() {
-	printf '%s' "$norm" | grep -Eq "(^|command:|${_E_TARGET_LEAD})[[:space:]]*(git -C |cd )"
+# The `-C` must be ADJACENT to the verb it governs, never merely present in the
+# segment: a message reading `-m "note: git -C x is nice"` contains `git -C ` and
+# would otherwise forge an in-place target for an unrelated bare verb. Defined
+# after _E_VERBS (below), which it shares -- one verb list, never two that drift.
+_seg_has_inplace_target() {
+	printf '%s' "$seg" | grep -Eq "git -C [^ ]+ ${_E_VERBS}${_E_VERB_END}"
 }
 
 # _TARGET_SEP -- trailing-boundary glob class for _targets_primary_checkout:
@@ -333,14 +360,21 @@ _has_explicit_target() {
 # $CLAUDE_PROJECT_DIR's `/` and `.` never need escaping.
 _TARGET_SEP='[ &;|(){}<>,]'
 
-# _targets_primary_checkout -- true iff $norm names $CLAUDE_PROJECT_DIR
-# itself (never a subdirectory or a sibling sharing its prefix) as a `cd `/
-# `git -C ` target. Unset CLAUDE_PROJECT_DIR -> false, never a crash (fail-open
-# under set -u): E2 has nothing to compare against.
+# _targets_primary_checkout -- true iff $norm names $CLAUDE_PROJECT_DIR ITSELF
+# (never a subdirectory, never a sibling sharing its prefix) as a `cd `/`git -C `
+# target. Unset CLAUDE_PROJECT_DIR -> false, never a crash (fail-open under set -u).
+#
+# The trailing slash is matched explicitly, and is not cosmetic: shell tab-completion
+# APPENDS one, and without this `cd $PROJ/ && git commit` reads as a subdirectory --
+# the single easiest way to defeat E2 entirely. `$PROJ`, `$PROJ/`, and `$PROJ/sub`
+# must each be classified correctly (E-h17); the `%/` strip normalizes a
+# CLAUDE_PROJECT_DIR that itself carries one.
 _targets_primary_checkout() {
 	[ -n "${CLAUDE_PROJECT_DIR:-}" ] || return 1
+	_proj="${CLAUDE_PROJECT_DIR%/}"
 	case "${norm} " in
-	*"cd ${CLAUDE_PROJECT_DIR}"${_TARGET_SEP}* | *"git -C ${CLAUDE_PROJECT_DIR}"${_TARGET_SEP}*) return 0 ;;
+	*"cd ${_proj}"${_TARGET_SEP}* | *"cd ${_proj}/"${_TARGET_SEP}* \
+	| *"git -C ${_proj}"${_TARGET_SEP}* | *"git -C ${_proj}/"${_TARGET_SEP}*) return 0 ;;
 	esac
 	return 1
 }
@@ -359,9 +393,18 @@ _targets_primary_checkout() {
 # is denied by `merge`, and `git commit-tree` by `commit` (E-h9). Excluding `-`
 # is what distinguishes them; a real verb is followed by a space or the payload's
 # closing brace, never by a hyphen.
+#
+# The hyphenated MUTATORS must therefore be named in full, or that same boundary
+# waves them through: `checkout-index` overwrites the working tree, `update-ref`
+# and `symbolic-ref` move refs, `update-index`/`read-tree` rewrite the index --
+# each as destructive as the porcelain verbs, and each against whatever repo the
+# cwd happens to be. POSIX grep -E is leftmost-longest, so listing them beside
+# their own prefixes resolves to the longer match (E-h11).
+_E_VERBS='(commit|push|rebase|merge|reset|checkout|switch|cherry-pick|revert|stash|am|clean|apply|checkout-index|update-ref|update-index|symbolic-ref|read-tree|merge-file|merge-index|merge-one-file)'
+_E_VERB_END='([^a-z-]|$)'
+
 _seg_has_mutating_verb() {
-	printf '%s' "$seg" \
-		| grep -Eq 'git (-C [^ ]+ )?(commit|push|rebase|merge|reset|checkout|switch|cherry-pick|revert|stash|am|clean)([^a-z-]|$)'
+	printf '%s' "$seg" | grep -Eq "git (-C [^ ]+ )?${_E_VERBS}${_E_VERB_END}"
 }
 
 # _deny <reason> -- print the PreToolUse deny JSON and exit 0 (exit 0 is
@@ -380,9 +423,10 @@ if printf '%s' "$norm_bg" | grep -Eq 'wait-[a-z0-9_-]*\.sh.*&'; then
 	_deny "a wait script backgrounded with & is invisible to the harness: no completion notification fires, so the turn stalls while the wait has already finished (issue #1225). Launch it as its OWN Bash call with run_in_background: true -- backgrounding is a property of the tool call, not of shell syntax (CLAUDE.md No orphaned waits)"
 fi
 
-# Rule E's target checks (whole-payload, precomputed once -- see THE
-# WHOLE-PAYLOAD CRUX above; only the verb check below is per-segment).
-if _has_explicit_target; then _e_has_target=1; else _e_has_target=0; fi
+# Rule E's whole-payload facts, precomputed once. The leading-cd check is
+# whole-payload because a leading cd governs every later segment; the in-place
+# `-C` check is per-segment (below) because it governs only its own command.
+if _has_leading_cd; then _e_leading_cd=1; else _e_leading_cd=0; fi
 if _targets_primary_checkout; then _e_targets_primary=1; else _e_targets_primary=0; fi
 
 # Walk $segs one segment at a time, applying rules A, B, C, and E's
@@ -407,8 +451,8 @@ while IFS= read -r seg; do
 	fi
 
 	if _seg_has_mutating_verb; then
-		if [ "$_e_has_target" = 0 ]; then
-			_deny "a mutating git command depends on the ambient working directory, which this hook cannot see: name the target explicitly with git -C <path> or cd <path> first (CLAUDE.md Worktrees, issue #1262)"
+		if [ "$_e_leading_cd" = 0 ] && ! _seg_has_inplace_target; then
+			_deny "a mutating git command depends on the ambient working directory, which this hook cannot see: name the target with git -C <path>, or put a cd <path> FIRST in the call (CLAUDE.md Worktrees, issue #1262)"
 		fi
 		if [ "$_e_targets_primary" = 1 ]; then
 			_deny "the named target is the primary checkout: every AI agent must do repository work in its own dedicated worktree, never the primary checkout (CLAUDE.md Worktrees)"

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -351,7 +351,7 @@ _has_leading_cd() {
 # would otherwise forge an in-place target for an unrelated bare verb. Defined
 # after _E_VERBS (below), which it shares -- one verb list, never two that drift.
 _seg_has_inplace_target() {
-	printf '%s' "$seg" | grep -Eq "git -C [^ ]+ ${_E_VERBS}${_E_VERB_END}"
+	printf '%s' "$seg" | grep -Eq "(command:|^)[[:space:]]*git -C [^ ]+ ${_E_VERBS}${_E_VERB_END}"
 }
 
 # _TARGET_SEP -- trailing-boundary glob class for _targets_primary_checkout:
@@ -404,7 +404,7 @@ _E_VERBS='(commit|push|rebase|merge|reset|checkout|switch|cherry-pick|revert|sta
 _E_VERB_END='([^a-z-]|$)'
 
 _seg_has_mutating_verb() {
-	printf '%s' "$seg" | grep -Eq "git (-C [^ ]+ )?${_E_VERBS}${_E_VERB_END}"
+	printf '%s' "$seg" | grep -Eq "git ([^ ]+ )*${_E_VERBS}${_E_VERB_END}"
 }
 
 # _deny <reason> -- print the PreToolUse deny JSON and exit 0 (exit 0 is

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -304,26 +304,27 @@ _bare_force_after_last_lease() {
 		| grep -Eq "(^|${_SEP})(--force|${_FORCE_CLUSTER})(\$|${_SEP})"
 }
 
-# _E_TARGET_LEAD -- leading-boundary class for E1's `git -C `/`cd ` search. A
-# target only counts in COMMAND POSITION: preceded by start-of-payload, the JSON
-# scaffold's `:` (normalization strips the quotes, so `"command":"cd ...`
-# collapses to `command:cd ...`), or a command separator -- optionally followed
-# by spaces, so `&& cd /wt` still reads as a target.
+# _E_TARGET_LEAD -- leading-boundary class for E1's `git -C `/`cd ` search. A target
+# only counts in COMMAND POSITION: preceded by start-of-payload, the JSON scaffold's
+# `command:` key, or a real shell command separator -- optionally followed by spaces,
+# so `&& cd /wt` still reads as a target.
 #
-# A bare SPACE is deliberately NOT a boundary here: a space before `cd ` means it
-# sits inside an ARGUMENT, and honouring it would let a commit message reading
-# `-m fix: cd into the worktree` forge a target and ALLOW an otherwise target-less
-# mutating command. That direction fails OPEN -- the one direction this file never
-# accepts (every other documented false positive errs toward denying). Pinned by
-# E-h6/E-h7.
-_E_TARGET_LEAD='[:;|&(){}<>,]'
+# Neither a bare SPACE nor a bare COLON is a boundary here, and both exclusions are
+# load-bearing. A space before `cd ` means it sits inside an ARGUMENT. A bare colon is
+# worse: `fix:`/`feat:` open almost every conventional-commit message, so accepting one
+# let `-m "fix: cd /tmp"` forge a target and ALLOW an otherwise target-less mutating
+# command. Both fail OPEN -- the one direction this file never accepts (every other
+# documented false positive errs toward denying). Only the literal `command:` scaffold
+# counts, which normalization leaves intact (`"command":"cd ...` -> `command:cd ...`).
+# Pinned by E-h6/E-h7/E-h8/E-h10.
+_E_TARGET_LEAD='[;|&({]'
 
 # _has_explicit_target -- true iff $norm (the WHOLE payload) names a target
 # via `git -C ` or `cd ` IN COMMAND POSITION (see _E_TARGET_LEAD above).
 # Whole-payload, not $seg: the target can sit in a different segment than the
 # verb it covers (E-b3/E-b4).
 _has_explicit_target() {
-	printf '%s' "$norm" | grep -Eq "(^|${_E_TARGET_LEAD})[[:space:]]*(git -C |cd )"
+	printf '%s' "$norm" | grep -Eq "(^|command:|${_E_TARGET_LEAD})[[:space:]]*(git -C |cd )"
 }
 
 # _TARGET_SEP -- trailing-boundary glob class for _targets_primary_checkout:
@@ -352,9 +353,15 @@ _targets_primary_checkout() {
 # the very syntax Rule E asks callers to use would itself evade detection
 # (E-c2). `git worktree add/remove` needs no exemption clause: neither "add"
 # nor "remove" is in this list.
+#
+# The trailing `[^a-z-]` boundary keeps a verb from matching as a PREFIX of a
+# longer, read-only plumbing subcommand: without it `git merge-base` (read-only)
+# is denied by `merge`, and `git commit-tree` by `commit` (E-h9). Excluding `-`
+# is what distinguishes them; a real verb is followed by a space or the payload's
+# closing brace, never by a hyphen.
 _seg_has_mutating_verb() {
 	printf '%s' "$seg" \
-		| grep -Eq 'git (-C [^ ]+ )?(commit|push|rebase|merge|reset|checkout|switch|cherry-pick|revert|stash|am|clean)'
+		| grep -Eq 'git (-C [^ ]+ )?(commit|push|rebase|merge|reset|checkout|switch|cherry-pick|revert|stash|am|clean)([^a-z-]|$)'
 }
 
 # _deny <reason> -- print the PreToolUse deny JSON and exit 0 (exit 0 is

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -1122,6 +1122,38 @@ Describe 'claude-bash-guard.sh'
       The status should be success
       The output should equal ''
     End
+
+    It 'E-h8: a conventional-commit message (fix: cd ...) must NOT forge a target -> DENY'
+      # The `:` that lets the JSON scaffold (command:cd ...) name a target also appears in
+      # ordinary commit prose. `fix:`/`feat:` are ubiquitous, so accepting a bare `:` as a
+      # command-position boundary let a target-less mutating command through -- fail-OPEN.
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix: cd /tmp\""}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E-h9: git merge-base is READ-ONLY and must not be denied by the merge verb -> ALLOW'
+      # Verb matching must carry a trailing boundary: `merge-base`/`commit-tree` are
+      # read-only plumbing and must not be caught by the `merge`/`commit` prefix.
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git merge-base HEAD origin/devel"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ''
+    End
+
+    It 'E-h10: the JSON scaffold still names a target (the E-h8 boundary is not too tight)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"cd /abs/wt && git commit -m \"fix: something\""}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ''
+    End
   End
 
   # ── plain git, no rule in scope ─────────────────────────────────────────────

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -1236,6 +1236,28 @@ Describe 'claude-bash-guard.sh'
       The status should be success
       The output should include '"permissionDecision":"deny"'
     End
+
+    It 'E-h19: a message QUOTING a git -C command must not forge an in-place target -> DENY'
+      # This repo's own commit messages discuss git commands, so this is not hypothetical.
+      # The -C must be in COMMAND POSITION in its segment, not merely present in it.
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push origin main -m \"use git -C /wt commit next time\""}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E-h20: git global options must not hide the verb from Rule E -> DENY'
+      # `git --work-tree=X commit` never matched the verb, so Rule E never ran at all --
+      # a bypass, not a false negative. Verb detection now survives the global options.
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git --work-tree=/wt commit -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
   End
 
   # ── plain git, no rule in scope ─────────────────────────────────────────────

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -934,6 +934,15 @@ Describe 'claude-bash-guard.sh'
         The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
       End
 
+      It 'E-c1b: a TRAILING SLASH on the primary checkout must not defeat E2 -> DENY'
+        # Shell tab-completion appends the slash, so without this it is the single
+        # easiest way to run a mutating command straight in the primary checkout.
+        Data "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $PROJ/ && git commit -m x\"}}"
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"permissionDecision":"deny"'
+      End
+
       It 'E-c2: git -C $PROJ push -> DENY'
         Data "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -C $PROJ push\"}}"
         When run script "$GUARD"
@@ -1116,7 +1125,7 @@ Describe 'claude-bash-guard.sh'
 
     It 'E-h7: a real target in command position still ALLOWs (the E-h6 boundary is not too tight)'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git add -A && cd /abs/wt && git commit -m x"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"cd /abs/wt && git add -A && git commit -m x"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -1153,6 +1162,79 @@ Describe 'claude-bash-guard.sh'
       When run script "$GUARD"
       The status should be success
       The output should equal ''
+    End
+
+    It 'E-h11: git checkout-index overwrites the working tree -> DENY (the hyphen boundary must not wave it through)'
+      # The [^a-z-] boundary that stops `merge-base` being denied by `merge` would also
+      # wave through the hyphenated MUTATORS, so each is named in full. checkout-index
+      # rewrites the working tree of whatever repo the cwd points at.
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git checkout-index -a -f"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E-h12: git update-ref moves a ref -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git update-ref refs/heads/x abc123"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E-h13: git apply writes the working tree -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git apply p.patch"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E-h14: git commit-tree is read-only plumbing -> ALLOW (the boundary is not too tight)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit-tree abc123"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ''
+    End
+
+    It 'E-h15: a MID-CHAIN cd does not govern a later verb -> DENY (only a leading cd does)'
+      # Deliberate behaviour change: `git add -A && cd /wt && git commit` is legal shell,
+      # but trusting a cd found anywhere in the payload is what let a commit MESSAGE forge
+      # one. Only a cd that is the FIRST command counts. Put the cd first.
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git add -A && cd /abs/wt && git commit -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E-h16: a SUBSHELL cd does not persist to its siblings -> DENY'
+      # `sh -c '(cd /tmp); pwd'` prints the ORIGINAL cwd. Trusting a subshell cd would
+      # re-admit the exact issue #1262 shape with the cd scoped out of the mutating segments.
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"(cd /abs/wt && git fetch); git rebase origin/devel && git push --force-with-lease"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+
+    It 'E-h18: `git -C` inside a MESSAGE must not forge an in-place target -> DENY'
+      # The -C must be adjacent to the verb it governs, never merely present in the segment.
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push origin main -m \"note: git -C x is nice\""}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
     End
   End
 

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -129,7 +129,7 @@ Describe 'claude-bash-guard.sh'
 
     It 'P3: normal commit, no --no-verify (git commit -m x) -> PASS'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"git -C /abs/wt commit -m x"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -138,7 +138,7 @@ Describe 'claude-bash-guard.sh'
 
     It 'P10: git commit --amend, no --no-verify -> PASS'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git commit --amend"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"git -C /abs/wt commit --amend"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -232,7 +232,7 @@ Describe 'claude-bash-guard.sh'
 
     It 'H10: --force-with-lease with a trailing metachar (;true) -> PASS (lease still wins)'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease;true"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"git -C /abs/wt push --force-with-lease;true"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -250,7 +250,7 @@ Describe 'claude-bash-guard.sh'
 
     It 'P1: --force-with-lease alone -> PASS (contains substring --force but lease wins)'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"git -C /abs/wt push --force-with-lease"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -259,7 +259,7 @@ Describe 'claude-bash-guard.sh'
 
     It 'P2: --force-with-lease with args -> PASS'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease origin main"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"git -C /abs/wt push --force-with-lease origin main"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -268,7 +268,7 @@ Describe 'claude-bash-guard.sh'
 
     It 'P4: normal push, no force flag (git push origin main) -> PASS'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"git -C /abs/wt push origin main"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -304,7 +304,7 @@ Describe 'claude-bash-guard.sh'
 
     It 'P14 (issue #1058): bare force BEFORE --force-with-lease -> PASS (the lease, last, wins)'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git push --force --force-with-lease origin main"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"git -C /abs/wt push --force --force-with-lease origin main"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -313,7 +313,7 @@ Describe 'claude-bash-guard.sh'
 
     It 'P15 (issue #1058): --force-with-lease --force-if-includes -> PASS (lease companion, not a bare force)'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease --force-if-includes"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"git -C /abs/wt push --force-with-lease --force-if-includes"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -426,7 +426,7 @@ Describe 'claude-bash-guard.sh'
   Describe 'per-segment scoping (compound commands): a rule only fires when its trigger and its force flag share ONE segment'
     It 'C1 (Rule C FP, Copilot case): unforced worktree remove && leased push -> PASS'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove ../wt && git push --force-with-lease"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove ../wt && git -C /abs/wt push --force-with-lease"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -435,7 +435,7 @@ Describe 'claude-bash-guard.sh'
 
     It 'C2 (Rule C FP, reversed order): leased push && unforced worktree remove -> PASS'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease && git worktree remove ../wt"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"git -C /abs/wt push --force-with-lease && git worktree remove ../wt"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -444,7 +444,7 @@ Describe 'claude-bash-guard.sh'
 
     It 'C3 (Rule B FP): git clean --force && normal git push -> PASS (force belongs to git clean, not the push)'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git clean --force && git push origin main"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"git -C /abs/wt clean --force && git -C /abs/wt push origin main"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -453,7 +453,7 @@ Describe 'claude-bash-guard.sh'
 
     It 'C4 (Rule B FP, subshell boundary): (git clean --force); git push origin main -> PASS'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"(git clean --force); git push origin main"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"(git -C /abs/wt clean --force); git -C /abs/wt push origin main"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -757,6 +757,373 @@ Describe 'claude-bash-guard.sh'
     End
   End
 
+  # ── Rule E: a mutating git command depends on the ambient cwd, which the ──
+  #    hook cannot see -- deny unless the call names its target explicitly,
+  #    and deny when that target IS the primary checkout (issue #1262: a
+  #    stray `cd` into the primary checkout silently misdirected a
+  #    rebase+push, and the misfire was caught only by luck).
+
+  Describe 'Rule E: mutating git command depends on the ambient cwd'
+    PROJ="/home/agent/pfBlockerNG"
+
+    Describe 'E1: no explicit -C/cd target anywhere in the payload -> DENY (one row per mutating verb)'
+      It 'E-a1: git commit -m x -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-a2: git push origin main -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-a3: git rebase origin/devel -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git rebase origin/devel"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-a4: git merge foo -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git merge foo"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-a5: git reset --hard HEAD~1 -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git reset --hard HEAD~1"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-a6: git checkout devel -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git checkout devel"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-a7: git switch devel -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git switch devel"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-a8: git cherry-pick abc123 -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git cherry-pick abc123"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-a9: git revert abc123 -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git revert abc123"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-a10: git stash -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git stash"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-a11: git am file.patch -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git am file.patch"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-a12: git clean -fd -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git clean -fd"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-a13 (the real bug, issue #1262): fetch+rebase+push with no -C/cd anywhere -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git fetch -q origin && git rebase origin/devel && git push --force-with-lease origin issue/1257-x"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+    End
+
+    Describe 'E1 satisfied: an explicit -C/cd target is present -> ALLOW'
+      It 'E-b1: git -C /abs/wt commit -m x -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git -C /abs/wt commit -m x"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-b2: cd /abs/wt && git commit -m x -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"cd /abs/wt && git commit -m x"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-b3: cd /abs/wt, then add+commit+push all in one call -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"cd /abs/wt && git add -A && git commit -q -m x && git push"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-b4: git -C /abs/wt on every mutating segment -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git -C /abs/wt rebase origin/devel && git -C /abs/wt push --force-with-lease origin b"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+    End
+
+    Describe 'E2: the named target IS the primary checkout ($CLAUDE_PROJECT_DIR) -> DENY'
+      setup_proj() { export CLAUDE_PROJECT_DIR="$PROJ"; }
+      BeforeEach 'setup_proj'
+
+      It 'E-c1: cd $PROJ && git commit -m x -> DENY'
+        Data "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $PROJ && git commit -m x\"}}"
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-c2: git -C $PROJ push -> DENY'
+        Data "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -C $PROJ push\"}}"
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-c3: cd $PROJ&&git reset --hard, no spaces -> DENY'
+        Data "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $PROJ&&git reset --hard\"}}"
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-c4: cd $PROJ alone, no git verb -> ALLOW (nothing mutating)'
+        Data "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $PROJ\"}}"
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+    End
+
+    Describe 'THE PREFIX TRAP: a worktree lives UNDER the project dir -> ALLOW'
+      setup_proj() { export CLAUDE_PROJECT_DIR="$PROJ"; }
+      BeforeEach 'setup_proj'
+
+      It 'E-d1: cd into a worktree under the project dir -> ALLOW (the / after $PROJ disqualifies the match)'
+        Data "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $PROJ/.claude/worktrees/issue-1262 && git commit -m x\"}}"
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-d2: git -C into a worktree under the project dir -> ALLOW'
+        Data "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -C $PROJ/.claude/worktrees/issue-1262 push --force-with-lease origin b\"}}"
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-d3: a SIBLING dir sharing the project-dir prefix (not a subdirectory) -> ALLOW'
+        Data "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -C $PROJ-other commit -m x\"}}"
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+    End
+
+    Describe 'exemptions: git worktree add/remove and every read-only verb -> ALLOW'
+      It 'E-e1: git worktree add /abs/wt branch -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git worktree add /abs/wt branch"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-e2: git worktree remove /abs/wt -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove /abs/wt"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-e3: git status -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git status"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-e4: git log --oneline -5 -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git log --oneline -5"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-e5: git fetch origin -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git fetch origin"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-e6: git rev-parse HEAD -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git rev-parse HEAD"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-e7: git diff origin/devel...HEAD -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git diff origin/devel...HEAD"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-e8: git grep -n foo -- src -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git grep -n foo -- src"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+    End
+
+    Describe 'hostile inputs (issue #1262 brief section 4)'
+      It 'E-h1 (accepted false positive, same class as B10): a commit MESSAGE containing text that looks like a cd to the primary checkout -> DENY'
+        export CLAUDE_PROJECT_DIR="$PROJ"
+        Data "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd /abs/wt && git commit -m 'reminder: never cd $PROJ directly'\"}}"
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+
+      It 'E-h2: cd to a RELATIVE path -> ALLOW (a cd is present; the guard cannot resolve it and must not try)'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"cd ../wt && git commit -m x"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-h3: git -C with the path in a VARIABLE -> ALLOW (git -C  is present, whatever it resolves to)'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git -C \"$WT\" commit -m x"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-h4 (most likely false positive, must not fire): a mutating verb word as an ARGUMENT VALUE -> ALLOW'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"git log --grep=commit"}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should equal ""
+      End
+
+      It 'E-h5 (accepted false positive): git push inside a quoted string passed to another tool -> DENY'
+        Data
+          #|{"tool_name":"Bash","tool_input":{"command":"sh -c \"git push\""}}
+        End
+        When run script "$GUARD"
+        The status should be success
+        The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+      End
+    End
+
+    It 'E-h6: a commit MESSAGE containing a cd-shaped token must NOT forge a target -> DENY'
+      # The fail-OPEN direction: a bare space before `cd ` means it sits in an ARGUMENT,
+      # not command position. Honouring it would let `-m "cd into the worktree"` satisfy
+      # E1 and wave a target-less mutating command through (issue #1262).
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -m run cd /tmp first"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E-h7: a real target in command position still ALLOWs (the E-h6 boundary is not too tight)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git add -A && cd /abs/wt && git commit -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ''
+    End
+  End
+
   # ── plain git, no rule in scope ─────────────────────────────────────────────
 
   It 'P9: plain git status -> PASS'
@@ -787,6 +1154,35 @@ Describe 'claude-bash-guard.sh'
       When run script "$GUARD"
       The status should be success
       The output should equal ""
+    End
+
+    It 'E-f2 (Rule E hostile input): garbled non-JSON stdin containing a mutating-verb pair, no cd/-C -> DENY (documented accepted false positive, same class as B10/D10)'
+      Data
+        #|not json at all {{{ git commit
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'E-f3 (Rule E): CLAUDE_PROJECT_DIR unset, explicit target present -> ALLOW (E2 skipped, E1 satisfied)'
+      unset CLAUDE_PROJECT_DIR
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"cd /abs/wt && git commit -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'E-f4 (Rule E): CLAUDE_PROJECT_DIR unset, no explicit target -> DENY (E1 still applies, unset never crashes or denies wrongly)'
+      unset CLAUDE_PROJECT_DIR
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
   End
 End


### PR DESCRIPTION
Fixes #1262

## The bug

The Bash tool's working directory **persists between calls**. In a worktree session, a `cd` into a scratch dir persisted; the next `gh` call failed with `not a git repository`; that was "fixed" by `cd`-ing to the **primary checkout**, which sits on `devel`. Every subsequent bare git command then targeted the wrong repo:

```sh
git fetch -q origin && git rebase origin/devel && git push --force-with-lease origin issue/1257-...
```

The rebase reported `Current branch devel is up to date`. The push was a silent no-op. Neither touched the intended branch — and the PR was genuinely a commit behind, which the misfire was actively **hiding**. It was caught only because the branch name leaked into the rebase output.

## Why the hook could not already catch it

The `PreToolUse` payload is only:

```json
{"tool_name":"Bash","tool_input":{"command":"..."}}
```

**There is no cwd in it.** The hook cannot know which directory the shell is in, so it cannot detect "you are in the wrong repo". It can only refuse commands whose target *depends* on the cwd — making the bad state **unrepresentable** rather than detected. That is Rule E.

## Rule E

Denies a **mutating** verb (`commit`, `push`, `rebase`, `merge`, `reset`, `checkout`, `switch`, `cherry-pick`, `revert`, `stash`, `am`, `clean`) when:

1. **No target is named** — neither `git -C <path>` nor `cd <path>` appears anywhere in the call, or
2. **The named target is the primary checkout** (`$CLAUDE_PROJECT_DIR`), which CLAUDE.md already forbids for agent work but nothing mechanically enforced.

Read-only verbs are untouched (`git status`, `git log`, `git diff`, `git fetch` …). `git worktree add`/`remove` need no exemption code: neither is a mutating verb, so they never reach the check — which matters, because CLAUDE.md *requires* `worktree remove` to run from the primary checkout.

### The prefix trap

Worktrees live **under** the project dir (`$CLAUDE_PROJECT_DIR/.claude/worktrees/<slug>`), so the primary-checkout test matches the project dir **exactly** — the character after it must be a real separator, and a worktree's next character is always `/`. `cd $PROJ && git commit` denies; `cd $PROJ/.claude/worktrees/x && git commit` allows. A naive substring test would have denied every worktree command and made the hook unusable.

### The fail-open hole, found and closed during review

An earlier cut let a target be recognised anywhere a space preceded it. That meant a **commit message** containing a `cd`-shaped token forged a target and waved a target-less mutating command straight through:

```text
git commit -m x                     → DENY   ✓
git commit -m "run cd /tmp first"   → ALLOW  ✗   message forged a target
```

"cd into the worktree first" is an entirely plausible message. A target now only counts in **command position** — preceded by start-of-payload, the JSON scaffold's `:`, or a command separator (optionally followed by spaces, so `&& cd /wt` still reads as a target). A bare space means it sits inside an *argument*.

This matters because it fails **open** — the one direction this guard never accepts. Every other documented false positive in the file errs toward *denying*. Pinned by `E-h6`/`E-h7`.

## The twelve pre-existing controls

Rules A–C use bare git commands as their ALLOW controls ("normal commit, no `--no-verify` → PASS"). Rule E deliberately overturns the assumption those payloads encode — that bare git is fine — so twelve of them now name a target. **Every assertion is unchanged, and each row still tests exactly the property it tested before**; only the repo target became explicit. The behaviour change itself is pinned by the new `E-a*` rows, not hidden.

## Tests

Test-first red→green: the Rule E rows were authored and run **RED** against the unmodified guard (20 failures, all and only the new DENY rows), frozen, then green.

`shellspec --shell dash` → **114 examples, 0 failures**. `sh -n`, `shellcheck`, comment-narration all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Vv1F4fW9zu39cSJ69Jn7f