### PR TITLE
pfblockerng: replace the ten exec'd `grep -c ^` line counts with pfb_count_lines() (#1261)

### DIFF
--- a/docs/misc/alerts-reports-pipeline.md
+++ b/docs/misc/alerts-reports-pipeline.md
@@ -156,8 +156,9 @@ Page level:
 - the Unified loop reads the reversed log to EOF even after all row limits are filled
   (the converters no-op, but `fgetcsv` still parses every remaining line);
 - stat views (`*_stat`): ~14 `cut|sort|uniq|sed` pipelines over the full log per view.
-  The total is no longer a `grep -c ^` fork (issue #1261 — it is `pfb_count_lines()`, in-process),
-  but it is still recomputed inside the per-stat loop rather than once.
+  The total is no longer a `grep -c ^` fork (issue #1261 — it is `pfb_count_lines()`,
+  in-process), and it is computed once before the per-stat loop, not recomputed per
+  iteration (issue #809) — the loop body only assigns the precomputed value.
 
 ## Why load time varies day to day
 

--- a/docs/misc/alerts-reports-pipeline.md
+++ b/docs/misc/alerts-reports-pipeline.md
@@ -155,8 +155,9 @@ Page level:
 - one full `tail -r` log copy per table per load;
 - the Unified loop reads the reversed log to EOF even after all row limits are filled
   (the converters no-op, but `fgetcsv` still parses every remaining line);
-- stat views (`*_stat`): ~14 `cut|sort|uniq|sed` pipelines over the full log per view,
-  and the `grep -c ^` total recomputed inside the per-stat loop instead of once.
+- stat views (`*_stat`): ~14 `cut|sort|uniq|sed` pipelines over the full log per view.
+  The total is no longer a `grep -c ^` fork (issue #1261 — it is `pfb_count_lines()`, in-process),
+  but it is still recomputed inside the per-stat loop rather than once.
 
 ## Why load time varies day to day
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -13398,17 +13398,15 @@ function pfb_asn_cache_window(string $asn_reporting): string {
 }
 
 
-// Number of already-processed filter.log lines to skip on daemon (re)start, derived
-// from `grep -c ^ /var/log/filter.log`'s raw output. (int) casts so a grep error
-// string (e.g. filter.log momentarily absent between rotation and daemon restart)
-// coerces to 0 instead of throwing PHP 8's "Unsupported operand types: string - int"
-// TypeError out of the daemon (issue #713 -- a crash loop). Callers must also guard
-// with file_exists('/var/log/filter.log') so the exec() is skipped entirely when the
-// file is absent.
+// Number of already-processed filter.log lines to skip on daemon (re)start.
+// issue #713/#1261: $count is pfb_count_lines()'s ?int -- NULL (e.g. a TOCTOU
+// race between the caller's file_exists() guard and the read) means "count
+// unknown", so skip nothing: the daemon reprocesses the whole log rather than
+// silently dropping lines it never actually parsed.
 //
 // PURE -- no I/O, no globals, no side effects.
-function pfb_filterlog_skip_count(string $grep_output): int {
-	return max((int) $grep_output - 1, 0);
+function pfb_filterlog_skip_count(?int $count): int {
+	return $count === NULL ? 0 : max($count - 1, 0);
 }
 
 
@@ -13453,10 +13451,9 @@ function pfb_daemon_filterlog() {
 		if (!file_exists($pfb['ip_blocklog']) && !file_exists($pfb['ip_permitlog']) && !file_exists($pfb['ip_matchlog'])) {
 			$filter_cnt = 0;
 		} elseif (file_exists('/var/log/filter.log')) {
-			// issue #713: guarded by file_exists() -- an absent filter.log made exec()
-			// return a grep error string, and pfb_filterlog_skip_count() (int)-casts it
-			// so it can never throw the old bare-subtraction TypeError.
-			$filter_cnt = pfb_filterlog_skip_count(exec("{$pfb['grep']} -c ^ /var/log/filter.log 2>&1"));
+			// issue #713/#1261: pfb_count_lines() replaces the exec()+grep fork;
+			// pfb_filterlog_skip_count() treats its NULL (read failure) as skip-nothing.
+			$filter_cnt = pfb_filterlog_skip_count(pfb_count_lines('/var/log/filter.log'));
 		} else {
 			$filter_cnt = 0;
 		}
@@ -17174,11 +17171,10 @@ function sync_package_pfblockerng($cron='') {
 									$header, $alias, $logging_type,
 									$custom ? 'user' : 'feed',
 									$mode);
-								$file_esc		= escapeshellarg("{$pfbfolder}/{$header}.txt");
-								$list_cnt		= exec("{$pfb['grep']} -c ^ {$file_esc}");
-								// issue #1162: failed grep returns a non-numeric string -- (int) so it
-								// cannot reach + arithmetic (PHP 8 TypeError)
-								$alias_cnt		= $alias_cnt + (int) $list_cnt;
+								// issue #1162/#1261: pfb_count_lines() returns NULL on a read
+								// failure -- 0 preserves the exec()-era fallback.
+								$list_cnt		= pfb_count_lines("{$pfbfolder}/{$header}.txt") ?? 0;
+								$alias_cnt		= $alias_cnt + $list_cnt;
 							}
 							else {
 								// #1083: verbatim reuse was rejected ONLY for stale staging
@@ -17516,7 +17512,8 @@ function sync_package_pfblockerng($cron='') {
 								if (!empty($domain_data_ip)) {
 									$domain_data_ip = implode("\n", array_unique($domain_data_ip)) . "\n";
 									@file_put_contents("{$pfbfolder}/{$header}_v4.ip", $domain_data_ip, LOCK_EX);
-									$ip_cnt = exec("{$pfb['grep']} -c ^ " . escapeshellarg("{$pfbfolder}/{$header}_v4.ip"));
+									// issue #1261: display/log-gate only -- NULL (read failure) -> 0.
+									$ip_cnt = pfb_count_lines("{$pfbfolder}/{$header}_v4.ip") ?? 0;
 								}
 								else {
 									// Remove previous IP feed
@@ -17527,7 +17524,8 @@ function sync_package_pfblockerng($cron='') {
 								if (!empty($domain_data_ip6)) {
 									$domain_data_ip6 = implode("\n", array_unique($domain_data_ip6)) . "\n";
 									@file_put_contents("{$pfbfolder}/{$header}_v6.ip", $domain_data_ip6, LOCK_EX);
-									$ip_cnt6 = exec("{$pfb['grep']} -c ^ " . escapeshellarg("{$pfbfolder}/{$header}_v6.ip"));
+									// issue #1261: display/log-gate only -- NULL (read failure) -> 0.
+									$ip_cnt6 = pfb_count_lines("{$pfbfolder}/{$header}_v6.ip") ?? 0;
 								}
 								else {
 									// Remove previous IPv6 feed
@@ -17601,10 +17599,10 @@ function sync_package_pfblockerng($cron='') {
 									touch("{$pfbfolder}/{$header}.txt");
 								}
 
-								$list_cnt	= exec("{$pfb['grep']} -c ^ " . escapeshellarg("{$pfbfolder}/{$header}.txt"));
-								// issue #1162: failed grep returns a non-numeric string -- (int) so it
-								// cannot reach + arithmetic (PHP 8 TypeError)
-								$alias_cnt	= $alias_cnt + (int) $list_cnt;
+								// issue #1162/#1261: pfb_count_lines() returns NULL on a read
+								// failure -- 0 preserves the exec()-era fallback.
+								$list_cnt	= pfb_count_lines("{$pfbfolder}/{$header}.txt") ?? 0;
+								$alias_cnt	= $alias_cnt + $list_cnt;
 
 								// Remove update file indicator -- skip if this row fell through to
 								// the stale-.orig download-failure fallback, else a pending rebuild

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1410,7 +1410,8 @@ function pfblockerng_uc_countries() {
 										}
 
 										if (file_exists($iso_file)) {
-											$networks = exec("{$pfb['grep']} -c ^ {$iso_file_esc} 2>&1");
+											// issue #1261: display-only total -- NULL (read failure) -> 0.
+											$networks = pfb_count_lines($iso_file) ?? 0;
 											$iso_header  = "# Country: {$geoip['name']}{$geoip_id}\n";
 											$iso_header .= "# ISO Code: {$iso}\n";
 											$iso_header .= "# Total Networks: {$networks}\n";
@@ -1506,8 +1507,9 @@ function pfblockerng_get_countries() {
 				$file = str_replace('v4', 'v6', $file);
 			}
 
-			$file_esc		= escapeshellarg($file);
-			$lastline		= exec("{$pfb['grep']} -c ^ {$file_esc}") ?: 0;
+			// issue #1261: NULL (read failure) -> 0, matching the exec()-era `?: 0`
+			// fallback (a legitimately-empty file also yields 0).
+			$lastline		= pfb_count_lines($file) ?? 0;
 			$pfb['complete']	= FALSE;
 			$linenum		= 1;
 			$total			= 0;
@@ -1568,8 +1570,8 @@ function pfblockerng_get_countries() {
 					elseif (!str_starts_with($line, '#')) {
 						if (!empty(pfb_filter($isocode, PFB_FILTER_WORD, 'php'))) {
 							if ($cont == 'Top Spammers') {
-								$isocode_esc = escapeshellarg("{$pfb['ccdir']}/{$isocode}_v{$type}.txt");
-								$total = exec("{$pfb['grep']} -c ^ {$isocode_esc} 2>&1");
+								// issue #1261: display-only total -- NULL (read failure) -> 0.
+								$total = pfb_count_lines("{$pfb['ccdir']}/{$isocode}_v{$type}.txt") ?? 0;
 							} else {
 								$total++;
 								if (!empty($line)) {

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1410,8 +1410,10 @@ function pfblockerng_uc_countries() {
 										}
 
 										if (file_exists($iso_file)) {
-											// issue #1261: display-only total -- NULL (read failure) -> 0.
-											$networks = pfb_count_lines($iso_file) ?? 0;
+											// issue #1261: NULL (read failure) -> 'ERROR', not 0 -- "0" trips the
+											// placeholder-blank branch below and would empty a country's list on
+											// a transient read error.
+											$networks = pfb_count_lines($iso_file) ?? 'ERROR';
 											$iso_header  = "# Country: {$geoip['name']}{$geoip_id}\n";
 											$iso_header .= "# ISO Code: {$iso}\n";
 											$iso_header .= "# Total Networks: {$networks}\n";

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1826,7 +1826,9 @@ if ($alert_summary) {
 	// below stays IN the loop body -- if every stat type is hidden the loop body
 	// never runs, so $alert_stats['count'] must stay unset for this view exactly
 	// as it does today.
-	$alert_log_total_count = file_exists($alert_log) ? (exec("{$pfb['grep']} -c ^ {$alert_log} 2>&1") ?: 0) : 0;
+	// issue #1261: display-only total -- NULL (read failure) -> 0, same as the
+	// exec()-era `?: 0` fallback (a legitimately-empty file also yields 0).
+	$alert_log_total_count = file_exists($alert_log) ? (pfb_count_lines($alert_log) ?? 0) : 0;
 
 	foreach ($stat_info as $stat_type => $column) {
 		if (isset($stat_hidden[$stat_type])) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -247,13 +247,12 @@ if (isset($_REQUEST) && isset($_REQUEST['ajax'])) {
 		}
 		elseif (($fhandle = @fopen("{$pfb_logfilename}", 'r')) !== FALSE) {
 
-			$pfb_logfilename_esc = escapeshellarg($pfb_logfilename);
-			$linecnt = exec("{$pfb['grep']} -c ^ {$pfb_logfilename_esc} 2>&1");
+			$linecnt = pfb_count_lines($pfb_logfilename);
 
-			// issue #1156: 2>&1 puts grep errors in $linecnt; non-numeric must not reach
-			// the subtraction, and silently skipping the cap would stream the whole file --
-			// answer with the handler's error convention instead.
-			if (!is_numeric($linecnt)) {
+			// issue #1156/#1261: pfb_count_lines() returns NULL on a read failure (e.g.
+			// a TOCTOU race after the fopen() above); silently skipping the cap would
+			// stream the whole file unbounded, so answer with the handler's error convention.
+			if ($linecnt === NULL) {
 				print ("|2|" . gettext('Failed to determine log line count') . "|IA==|");
 				exit;
 			}

--- a/tests/php/AliasCntGrepCountGuardTest.php
+++ b/tests/php/AliasCntGrepCountGuardTest.php
@@ -6,18 +6,20 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * $alias_cnt accumulation from `grep -c ^ <file>` output (issue #1162).
+ * $alias_cnt accumulation from a per-file line count (issue #1162; issue
+ * #1261: the exec("grep -c ^ <file>") fork is replaced by pfb_count_lines()).
  *
- * sync_package_pfblockerng() has two sites that feed a raw exec("grep -c ^
- * <file>") result straight into `+` arithmetic: `$alias_cnt = $alias_cnt +
- * $list_cnt;`. exec() on a failed grep (no 2>&1 capture) returns "" (or a
- * non-numeric error string), and PHP 8's `+` operator throws TypeError:
- * "Unsupported operand types: string + int" on a non-numeric string operand
- * -- fatalling the whole sync pass. Both sites are inside
- * sync_package_pfblockerng(), not unit-reachable directly -- pinned here via
- * source-inspection (house precedent: tests/php/DownloadRetvalFailsafeTest.php)
- * plus a mirrored-expression data provider (house precedent:
- * tests/php/IpRegexPrefilterGuardTest.php).
+ * sync_package_pfblockerng() has two sites that feed a file's line count into
+ * `+` arithmetic: `$alias_cnt = $alias_cnt + $list_cnt;`. Before #1261,
+ * $list_cnt came from exec()'s raw output (a non-numeric string on a failed
+ * grep, needing an inline (int) cast). Now pfb_count_lines() returns ?int
+ * directly, and NULL (read failure) is coerced to 0 at the assignment
+ * (`?? 0`) -- so $list_cnt is always a plain int by the time it reaches the
+ * accumulation, and the accumulation itself needs no cast. Both sites are
+ * inside sync_package_pfblockerng(), not unit-reachable directly -- pinned
+ * here via source-inspection (house precedent:
+ * tests/php/DownloadRetvalFailsafeTest.php) plus a mirrored-expression data
+ * provider (house precedent: tests/php/IpRegexPrefilterGuardTest.php).
  */
 final class AliasCntGrepCountGuardTest extends TestCase
 {
@@ -34,16 +36,13 @@ final class AliasCntGrepCountGuardTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// Source-inspection pin -- both $alias_cnt accumulation sites exist,
-	// both cast $list_cnt to int, and no uncast form survives.
+	// Source-inspection pin -- both $alias_cnt accumulation sites exist, both
+	// feed from pfb_count_lines() with a `?? 0` NULL fallback, and no exec()
+	// grep fork survives at either site.
 	// -----------------------------------------------------------------------
 
-	/**
-	 * `$alias_cnt = $alias_cnt + $list_cnt;` (uncast) or
-	 * `$alias_cnt = $alias_cnt + (int) $list_cnt;` (cast) -- matches either
-	 * form so the count assertion holds both before and after the fix.
-	 */
-	private const ACCUMULATION_RE = '/\$alias_cnt\s*=\s*\$alias_cnt\s*\+\s*(\(int\)\s*)?\$list_cnt\s*;/';
+	private const ACCUMULATION_RE = '/\$alias_cnt\s*=\s*\$alias_cnt\s*\+\s*\$list_cnt\s*;/';
+	private const COUNT_ASSIGN_RE = '/\$list_cnt\s*=\s*pfb_count_lines\([^;]*\)\s*\?\?\s*0\s*;/';
 
 	public function testVacuityExactlyTwoAccumulationSitesExist(): void
 	{
@@ -53,24 +52,20 @@ final class AliasCntGrepCountGuardTest extends TestCase
 			. "(list-reuse branch and downloaded/rebuilt branch); found {$count}");
 	}
 
-	public function testBothAccumulationSitesCastListCntToInt(): void
+	public function testBothSitesAssignListCntFromPfbCountLinesWithNullFallback(): void
 	{
-		preg_match_all(self::ACCUMULATION_RE, self::$src, $m);
-		$this->assertCount(2, $m[0], 'vacuity re-check: exactly 2 accumulation sites must be found');
-		foreach ($m[0] as $i => $statement) {
-			$this->assertNotSame('', $m[1][$i],
-				"accumulation site #{$i} does not cast \$list_cnt with (int) -- "
-				. 'PHP 8 TypeError hazard on a failed grep (issue #1162); statement: ' . $statement);
-		}
+		$count = preg_match_all(self::COUNT_ASSIGN_RE, self::$src);
+		$this->assertSame(2, $count,
+			'expected exactly 2 `$list_cnt = pfb_count_lines(...) ?? 0;` assignments feeding '
+			. "the accumulation sites (issue #1261); found {$count}");
 	}
 
-	public function testNoUncastAccumulationSurvives(): void
+	public function testNoExecGrepForkSurvivesForListCnt(): void
 	{
 		$this->assertDoesNotMatchRegularExpression(
-			'/\$alias_cnt\s*=\s*\$alias_cnt\s*\+\s*\$list_cnt\s*;/',
+			'/\$list_cnt\s*=\s*exec\(/',
 			self::$src,
-			'an uncast $alias_cnt = $alias_cnt + $list_cnt; accumulation remains -- '
-			. 'PHP 8 TypeError hazard on a failed grep (issue #1162)'
+			'a $list_cnt = exec(...) fork survives -- issue #1261 must replace it with pfb_count_lines()'
 		);
 	}
 
@@ -79,62 +74,22 @@ final class AliasCntGrepCountGuardTest extends TestCase
 	// the happy path). Mirrors the production expressions exactly.
 	// -----------------------------------------------------------------------
 
-	public static function unguardedRows(): array
+	public static function accumulationRows(): array
 	{
 		return [
-			'empty exec result (grep failure)' => ['', TRUE],
-			'grep error string (no such file)' => ['grep: /x: No such file or directory', TRUE],
-			'happy path count'                 => ['42', FALSE],
-			'zero count'                       => ['0', FALSE],
-			'exec() total failure (FALSE)'     => [FALSE, FALSE],
+			'NULL count (pfb_count_lines() read failure)' => [NULL, 0],
+			'happy path count'                             => [42, 42],
+			'zero count (empty file)'                      => [0, 0],
 		];
 	}
 
-	/** Unguarded mirror of the pre-fix `$alias_cnt = $alias_cnt + $list_cnt;`. */
-	#[DataProvider('unguardedRows')]
-	public function testUnguardedMirrorThrowsOnlyForNonNumericGrepOutput(string|bool $listCnt, bool $expectThrow): void
-	{
-		if ($expectThrow) {
-			$this->expectException(TypeError::class);
-			$this->expectExceptionMessage('Unsupported operand types');
-		}
-		$alias_cnt = 0;
-		$alias_cnt = $alias_cnt + $listCnt;
-		if (!$expectThrow) {
-			$this->assertIsInt($alias_cnt);
-		}
-	}
-
-	public static function guardedRows(): array
-	{
-		return [
-			'empty exec result (grep failure)' => ['', 0],
-			'grep error string (no such file)' => ['grep: /x: No such file or directory', 0],
-			'happy path count'                 => ['42', 42],
-			'zero count'                       => ['0', 0],
-			'exec() total failure (FALSE)'     => [FALSE, 0],
-		];
-	}
-
-	/** Guarded mirror of the post-fix `$alias_cnt = $alias_cnt + (int) $list_cnt;` -- never throws. */
-	#[DataProvider('guardedRows')]
-	public function testGuardedMirrorCoercesNonNumericGrepOutputToZero(string|bool $listCnt, int $expect): void
+	/** Mirror of the post-#1261 `$list_cnt = pfb_count_lines(...) ?? 0; $alias_cnt = $alias_cnt + $list_cnt;`. */
+	#[DataProvider('accumulationRows')]
+	public function testAccumulationNeverThrowsAndCoercesNullToZero(?int $pfbCountLinesResult, int $expect): void
 	{
 		$alias_cnt = 0;
-		$alias_cnt = $alias_cnt + (int) $listCnt;
+		$list_cnt  = $pfbCountLinesResult ?? 0;
+		$alias_cnt = $alias_cnt + $list_cnt;
 		$this->assertSame($expect, $alias_cnt);
-	}
-
-	// -----------------------------------------------------------------------
-	// Motivating-semantics assertion -- the exact PHP 8 hazard the (int)
-	// casts defend against.
-	// -----------------------------------------------------------------------
-
-	public function testEmptyStringPlusIntThrowsTypeErrorBackingTheGuard(): void
-	{
-		$this->expectException(TypeError::class);
-		$this->expectExceptionMessage('Unsupported operand types');
-		// phpcs:ignore -- deliberately unguarded: this IS the hazard the (int) cast defends against.
-		$unused = 0 + '';
 	}
 }

--- a/tests/php/CountLinesTest.php
+++ b/tests/php/CountLinesTest.php
@@ -106,6 +106,23 @@ final class CountLinesTest extends TestCase
 		$this->assertNull(pfb_count_lines($missing), 'a missing/unopenable path must return NULL, not a hardcoded default');
 	}
 
+	public function testUnreadableFileReturnsNullNotZero(): void
+	{
+		// A file that EXISTS but cannot be opened must fail the same way a missing one does.
+		// Returning 0 here would read as "no lines" -- a count every caller would believe.
+		if (function_exists('posix_getuid') && posix_getuid() === 0) {
+			$this->markTestSkipped('root bypasses file permissions; cannot simulate an unreadable file');
+		}
+
+		file_put_contents($this->tmpFile, "a\nb\nc\n");
+		chmod($this->tmpFile, 0000);
+		try {
+			$this->assertNull(pfb_count_lines($this->tmpFile), 'an unreadable file must return NULL, never a count');
+		} finally {
+			chmod($this->tmpFile, 0644);
+		}
+	}
+
 	public function testShortReadThatNeverReachesEofReturnsNull(): void
 	{
 		// issue #1257 B2: a read that stalls/aborts mid-stream (feof() never goes TRUE)

--- a/tests/php/CountryNetworksCountGuardTest.php
+++ b/tests/php/CountryNetworksCountGuardTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * $networks / $total -- the per-ISO "Total Networks" line count in
+ * pfblockerng.php's continent-file rebuild (issue #1261).
+ *
+ * $networks (line ~1414) is NOT display-only: it is written into a header
+ * line that is later re-parsed, and "Total Networks: 0" or "...: NA" trips a
+ * placeholder branch that BLANKS the country's IP list (transient read
+ * failure treated as "genuinely empty" is silent data loss). $total (line
+ * ~1574) only ever renders as "(N)" in a dropdown -- display-only, so its
+ * `?? 0` NULL fallback is the safe, correct direction and needs no fix, only
+ * a mirror test (house precedent: tests/php/AliasCntGrepCountGuardTest.php).
+ *
+ * The file carries top-level execution and cannot be require()d
+ * off-appliance. The $networks header block is eval-extracted verbatim
+ * (PfbReflectorGuardTest.php precedent) into an oracle driven by REAL
+ * pfb_count_lines() calls against real fixtures -- a directory path (exists,
+ * unreadable as a file -> NULL) and a real empty file (exists, 0 lines) --
+ * so the same test file proves red on the pre-fix `?? 0` and green after,
+ * with zero mocking of pfb_count_lines() itself. The placeholder-blank
+ * condition is likewise eval-extracted, not hardcoded, so a change to that
+ * condition is caught too.
+ *
+ * Feature: a country's IP list is blanked only for a genuinely-zero or
+ *          NA network count, never for a count that could not be read
+ *
+ *   Scenario: pfb_count_lines() read failure (NULL) -> placeholder must NOT fire
+ *   Scenario: a genuinely empty ISO file (0)        -> placeholder MUST fire
+ */
+final class CountryNetworksCountGuardTest extends TestCase
+{
+	private static string $src;
+	private static string $tmpDir;
+
+	public static function setUpBeforeClass(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php';
+		$src = file_get_contents($path);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.php');
+		}
+		self::$src = $src;
+
+		self::$tmpDir = sys_get_temp_dir() . '/pfb_country_networks_' . getmypid();
+		@mkdir(self::$tmpDir, 0777, TRUE);
+
+		// Oracle 1: the $iso_file header-building block, anchored on text
+		// stable across both the pre-fix `?? 0` and the fixed fallback.
+		if (!function_exists('pfb_networks_header_oracle')) {
+			if (!preg_match(
+				'/(if \(file_exists\(\$iso_file\)\) \{.*?\$iso_header \.= "# Total Networks: \{\$networks\}\\\\n";)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('oracle extraction failed: the $iso_file header block was not found in pfblockerng.php');
+			}
+			eval(
+				'function pfb_networks_header_oracle(string $iso_file): string {'
+				. ' $geoip = ["name" => "Testland"]; $geoip_id = ""; $iso = "TL"; $iso_header = "";'
+				. $m[1]
+				// close the extracted block's own opening "if (file_exists(...)) {"
+				. ' } return $iso_header; }'
+			);
+		}
+
+		// Oracle 2: the placeholder-blank condition itself -- untouched by
+		// this fix, pinned so a future change to it is still caught.
+		if (!function_exists('pfb_placeholder_branch_fires_oracle')) {
+			if (!preg_match(
+				'/strpos\(\$line, \'Total Networks: 0\'\) !== FALSE \|\| strpos\(\$line, \'Total Networks: NA\'\) !== FALSE/',
+				$src,
+				$m2
+			)) {
+				throw new RuntimeException('oracle extraction failed: the placeholder-blank condition was not found in pfblockerng.php');
+			}
+			eval('function pfb_placeholder_branch_fires_oracle(string $line): bool { return (' . $m2[0] . '); }');
+		}
+	}
+
+	public static function tearDownAfterClass(): void
+	{
+		foreach (glob(self::$tmpDir . '/*') ?: [] as $f) {
+			is_dir($f) ? @rmdir($f) : @unlink($f);
+		}
+		@rmdir(self::$tmpDir);
+	}
+
+	private function totalNetworksLine(string $header): string
+	{
+		$lines = explode("\n", trim($header));
+		return end($lines);
+	}
+
+	// -----------------------------------------------------------------------
+	// Rows 1+2: the point is both together -- a fix that merely disables the
+	// placeholder branch would pass row 1 alone without proving anything.
+	// -----------------------------------------------------------------------
+
+	public function testReadFailureDoesNotTripZeroNetworksPlaceholder(): void
+	{
+		// A directory: file_exists() is TRUE, but pfb_count_lines()'s fopen('rb')
+		// fails -- a real, unmocked read failure (NULL), not chmod-based (chmod
+		// denial tests are meaningless under root; a directory fails everywhere).
+		$dir = self::$tmpDir . '/unreadable_dir_v4';
+		@mkdir($dir, 0777, TRUE);
+		$this->assertNull(pfb_count_lines($dir), 'fixture must reproduce a real pfb_count_lines() read failure');
+
+		$line = $this->totalNetworksLine(pfb_networks_header_oracle($dir));
+		$this->assertStringStartsWith('# Total Networks: ', $line, 'header must still carry a Total Networks line on a read failure');
+		$this->assertFalse(
+			pfb_placeholder_branch_fires_oracle($line),
+			"a read failure must not render as '{$line}' -- it must not match the 0/NA placeholder-blank branch and silently empty the country's list"
+		);
+	}
+
+	public function testGenuinelyEmptyIsoFileStillTripsZeroNetworksPlaceholder(): void
+	{
+		$empty = self::$tmpDir . '/empty_v4.txt';
+		touch($empty);
+		$this->assertSame(0, pfb_count_lines($empty), 'fixture must reproduce a real genuinely-empty file');
+
+		$line = $this->totalNetworksLine(pfb_networks_header_oracle($empty));
+		$this->assertSame('# Total Networks: 0', $line);
+		$this->assertTrue(
+			pfb_placeholder_branch_fires_oracle($line),
+			'a genuinely empty ISO file must still trip the placeholder-blank branch -- this is the intended behaviour'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Source-inspection: no exec() grep fork survives, and the fallback is
+	// never bare `?? 0` again (that shape is exactly the reintroduced bug).
+	// -----------------------------------------------------------------------
+
+	public function testNetworksNeverFallsBackToBareZero(): void
+	{
+		$this->assertDoesNotMatchRegularExpression(
+			'/\$networks\s*=\s*pfb_count_lines\(\$iso_file\)\s*\?\?\s*0\s*;/',
+			self::$src,
+			'$networks must not fall back to a bare 0 on NULL -- that string collides with the placeholder-blank branch (issue #1261)'
+		);
+	}
+
+	public function testNoExecGrepForkSurvivesForNetworks(): void
+	{
+		$this->assertDoesNotMatchRegularExpression(
+			'/\$networks\s*=\s*exec\(/',
+			self::$src,
+			'a $networks = exec(...) fork survives -- issue #1261 must replace it with pfb_count_lines()'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Rows 3+4: $total (line ~1574) -- display-only, `?? 0` is correct as-is.
+	// -----------------------------------------------------------------------
+
+	public function testTotalAssignedFromPfbCountLinesWithZeroFallback(): void
+	{
+		$this->assertMatchesRegularExpression(
+			'/\$total\s*=\s*pfb_count_lines\([^;]*\)\s*\?\?\s*0\s*;/',
+			self::$src,
+			'$total must be assigned from pfb_count_lines(...) ?? 0 (display-only, issue #1261)'
+		);
+	}
+
+	public function testNoExecGrepForkSurvivesForTotal(): void
+	{
+		$this->assertDoesNotMatchRegularExpression(
+			'/\$total\s*=\s*exec\(/',
+			self::$src,
+			'a $total = exec(...) fork survives -- issue #1261 must replace it with pfb_count_lines()'
+		);
+	}
+
+	public static function totalRenderRows(): array
+	{
+		return [
+			'NULL count (pfb_count_lines() read failure)' => [NULL, '(0)'],
+			'happy path count'                             => [5, '(5)'],
+		];
+	}
+
+	/** Mirror of the coptions dropdown render: "{$country} {$isocode} ({$total})". */
+	#[DataProvider('totalRenderRows')]
+	public function testTotalRendersAsParenthesisedCount(?int $pfbCountLinesResult, string $expectRendered): void
+	{
+		$total = $pfbCountLinesResult ?? 0;
+		$this->assertSame($expectRendered, "({$total})");
+	}
+}

--- a/tests/php/CountryNetworksCountGuardTest.php
+++ b/tests/php/CountryNetworksCountGuardTest.php
@@ -6,8 +6,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * $networks / $total -- the per-ISO "Total Networks" line count in
- * pfblockerng.php's continent-file rebuild (issue #1261).
+ * $networks / $total / $lastline -- the per-ISO "Total Networks" line counts
+ * in pfblockerng.php's continent-file rebuild (issue #1261).
  *
  * $networks (line ~1414) is NOT display-only: it is written into a header
  * line that is later re-parsed, and "Total Networks: 0" or "...: NA" trips a
@@ -176,6 +176,44 @@ final class CountryNetworksCountGuardTest extends TestCase
 			self::$src,
 			'a $total = exec(...) fork survives -- issue #1261 must replace it with pfb_count_lines()'
 		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Rows 5+6: $lastline (line ~1514) -- the EOF-flush trigger
+	// (`$linenum == $lastline`). `?? 0` preserves the exec()-era `?: 0`: a
+	// failed count yields 0, which $linenum (starts at 1) can never equal, so
+	// the flush stays unreachable -- and the fopen() of the same file fails
+	// too, so the loop never runs.
+	// -----------------------------------------------------------------------
+
+	public function testLastlineAssignedFromPfbCountLinesWithZeroFallback(): void
+	{
+		$this->assertMatchesRegularExpression(
+			'/\$lastline\s*=\s*pfb_count_lines\(\$file\)\s*\?\?\s*0\s*;/',
+			self::$src,
+			'$lastline must be assigned from pfb_count_lines($file) ?? 0 (EOF-flush trigger, issue #1261)'
+		);
+	}
+
+	public function testNoExecGrepForkSurvivesForLastline(): void
+	{
+		$this->assertDoesNotMatchRegularExpression(
+			'/\$lastline\s*=\s*exec\(/',
+			self::$src,
+			'a $lastline = exec(...) fork survives -- issue #1261 must replace it with pfb_count_lines()'
+		);
+	}
+
+	/** A real, unmocked read failure (a directory) must fall back to 0, never
+	 *  NULL/error text reaching the `$linenum == $lastline` comparison. */
+	public function testLastlineReadFailureFallsBackToZero(): void
+	{
+		$dir = self::$tmpDir . '/unreadable_dir_lastline';
+		@mkdir($dir, 0777, TRUE);
+		$this->assertNull(pfb_count_lines($dir), 'fixture must reproduce a real pfb_count_lines() read failure');
+
+		$lastline = pfb_count_lines($dir) ?? 0;
+		$this->assertSame(0, $lastline, 'a failed count must fall back to 0 (the exec()-era behaviour): the EOF flush stays unreachable');
 	}
 
 	public static function totalRenderRows(): array

--- a/tests/php/DnsblIpCountGuardTest.php
+++ b/tests/php/DnsblIpCountGuardTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * $ip_cnt / $ip_cnt6 -- the IPv4/IPv6 line counts extracted from a DNSBL
+ * domain feed's `_v4.ip`/`_v6.ip` sidecar files inside
+ * sync_package_pfblockerng() (issue #1261). Both gate only a log line
+ * (`if ($ip_cnt > 0) pfb_logger(...)`), never arithmetic -- display-only, so
+ * a pfb_count_lines() NULL (read failure) must fall back to 0, exactly as
+ * exec()'s falsy "" fell through the pre-#1261 `> 0` comparison. Not
+ * unit-reachable directly (deep inside sync_package_pfblockerng()) -- pinned
+ * via source-inspection, house precedent: tests/php/AliasCntGrepCountGuardTest.php.
+ */
+final class DnsblIpCountGuardTest extends TestCase
+{
+	private static string $src;
+
+	public static function setUpBeforeClass(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+		$src = file_get_contents($path);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		}
+		self::$src = $src;
+	}
+
+	public function testIpCntAssignedFromPfbCountLinesWithNullFallback(): void
+	{
+		$this->assertMatchesRegularExpression(
+			'/\$ip_cnt\s*=\s*pfb_count_lines\([^;]*_v4\.ip[^;]*\)\s*\?\?\s*0\s*;/',
+			self::$src,
+			'$ip_cnt must be assigned from pfb_count_lines(..._v4.ip) ?? 0 (issue #1261)'
+		);
+	}
+
+	public function testIpCnt6AssignedFromPfbCountLinesWithNullFallback(): void
+	{
+		$this->assertMatchesRegularExpression(
+			'/\$ip_cnt6\s*=\s*pfb_count_lines\([^;]*_v6\.ip[^;]*\)\s*\?\?\s*0\s*;/',
+			self::$src,
+			'$ip_cnt6 must be assigned from pfb_count_lines(..._v6.ip) ?? 0 (issue #1261)'
+		);
+	}
+
+	public function testNoExecGrepForkSurvivesForIpCnt(): void
+	{
+		$this->assertDoesNotMatchRegularExpression(
+			'/\$ip_cnt6?\s*=\s*exec\(/',
+			self::$src,
+			'an $ip_cnt/$ip_cnt6 = exec(...) fork survives -- issue #1261 must replace it with pfb_count_lines()'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Mirrored-expression hostile-input rows: the `> 0` log-gate must never
+	// throw and must treat a NULL (read failure) as "nothing to log".
+	// -----------------------------------------------------------------------
+
+	public static function gateRows(): array
+	{
+		return [
+			'NULL count (pfb_count_lines() read failure)' => [NULL, FALSE],
+			'zero count (empty file)'                      => [0, FALSE],
+			'happy path count'                              => [7, TRUE],
+		];
+	}
+
+	#[DataProvider('gateRows')]
+	public function testLogGateNeverThrowsAndSkipsOnNullOrZero(?int $pfbCountLinesResult, bool $expectGateOpen): void
+	{
+		$ip_cnt = $pfbCountLinesResult ?? 0;
+		$this->assertSame($expectGateOpen, $ip_cnt > 0);
+	}
+}

--- a/tests/php/FilterlogSkipCountTest.php
+++ b/tests/php/FilterlogSkipCountTest.php
@@ -6,34 +6,31 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests for pfb_filterlog_skip_count() — the pure parser for
- * `grep -c ^ /var/log/filter.log`'s raw exec() output (issue #713, bug 14).
+ * Tests for pfb_filterlog_skip_count() -- the pure "lines to skip on daemon
+ * (re)start" derivation (issue #713, bug 14; issue #1261: input is now
+ * pfb_count_lines()'s ?int, not exec()'s raw string).
  *
- * The old call site computed `max(exec(...) - 1, 0)` with no cast: when
- * filter.log is momentarily absent (log rotation racing the daemon restart),
- * the merged 2>&1 output is a grep error STRING, and PHP 8 throws
- * "Unsupported operand types: string - int" out of the daemon -- a crash loop.
- * (int) casting the exec() output first makes any non-numeric string coerce to
- * 0 instead of throwing.
+ * pfb_count_lines() returns NULL when it cannot read filter.log (e.g. a
+ * TOCTOU race between the caller's file_exists() guard and the read). NULL
+ * must skip nothing -- the daemon reprocesses the whole log rather than
+ * silently dropping lines it never actually parsed.
  *
  * Scenario A: a normal numeric count -> count - 1
  * Scenario B: a zero count -> 0 (never negative)
- * Scenario C: empty output -> 0
- * Scenario D: the grep error string (filter.log absent) -> 0, no exception
+ * Scenario C: NULL (pfb_count_lines() read failure) -> 0, no exception
  */
 #[CoversFunction('pfb_filterlog_skip_count')]
 final class FilterlogSkipCountTest extends TestCase
 {
-	// ---------- Scenario A — normal numeric grep count ----------
+	// ---------- Scenario A — normal numeric count ----------
 
 	public function testNumericCount_ReturnsCountMinusOne(): void
 	{
-		// Given: grep -c reports 1234 matching lines (includes the trailing
-		// blank-line artifact the call site's "-1" already accounted for).
-		$grepOutput = '1234';
+		// Given: pfb_count_lines() read 1234 matching lines.
+		$count = 1234;
 
 		// When
-		$skip = pfb_filterlog_skip_count($grepOutput);
+		$skip = pfb_filterlog_skip_count($count);
 
 		// Then
 		$this->assertSame(1233, $skip,
@@ -45,50 +42,34 @@ final class FilterlogSkipCountTest extends TestCase
 	public function testZeroCount_ReturnsZeroNotNegative(): void
 	{
 		// Given
-		$grepOutput = '0';
+		$count = 0;
 
 		// When
-		$skip = pfb_filterlog_skip_count($grepOutput);
+		$skip = pfb_filterlog_skip_count($count);
 
 		// Then: max(0 - 1, 0) = 0, never -1.
 		$this->assertSame(0, $skip,
 			"expected: 0 (clamped, never negative);\nactual: {$skip}");
 	}
 
-	// ---------- Scenario C — empty output ----------
-
-	public function testEmptyOutput_ReturnsZero(): void
-	{
-		// Given
-		$grepOutput = '';
-
-		// When
-		$skip = pfb_filterlog_skip_count($grepOutput);
-
-		// Then
-		$this->assertSame(0, $skip,
-			"expected: 0 (empty output);\nactual: {$skip}");
-	}
-
-	// ---------- Scenario D — the regression: grep's error string must not throw ----------
+	// ---------- Scenario C — the regression: a read failure must not throw ----------
 
 	/**
 	 * The regression this bug fixes: when filter.log is momentarily absent,
-	 * exec()'s merged 2>&1 output is grep's error text, not a number. The old
-	 * un-cast `$output - 1` threw a PHP 8 TypeError for this exact input,
-	 * crash-looping the daemon. This must return 0 with no exception.
+	 * pfb_count_lines() returns NULL. The old string-typed signature could
+	 * only represent that as a magic string (or, called with NULL under
+	 * strict_types, a TypeError) -- this must return 0 with no exception.
 	 */
-	public function testGrepErrorString_ReturnsZeroWithoutThrowing(): void
+	public function testNullCount_ReturnsZeroWithoutThrowing(): void
 	{
-		// Given: filter.log does not exist, so grep -c wrote its error to stderr,
-		// merged into $output by the caller's 2>&1.
-		$grepOutput = 'grep: /var/log/filter.log: No such file or directory';
+		// Given: pfb_count_lines('/var/log/filter.log') could not read the file.
+		$count = NULL;
 
-		// When / Then: must not throw (the old bare `$output - 1` did).
-		$skip = pfb_filterlog_skip_count($grepOutput);
+		// When / Then: must not throw.
+		$skip = pfb_filterlog_skip_count($count);
 
 		$this->assertSame(0, $skip,
-			"expected: 0, and no TypeError, for a non-numeric grep error string;\n"
+			"expected: 0, and no TypeError, for a NULL (unreadable file) count;\n"
 			. "actual: {$skip}");
 	}
 }

--- a/tests/php/LogLinecountGuardTest.php
+++ b/tests/php/LogLinecountGuardTest.php
@@ -5,32 +5,33 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfblockerng_log.php AJAX 'load' handler line-count guard (issue #1156).
+ * pfblockerng_log.php AJAX 'load' handler line-count guard (issue #1156;
+ * issue #1261: exec("grep -c ^ ... 2>&1") is replaced by pfb_count_lines()).
  *
- * `exec("{$pfb['grep']} -c ^ ... 2>&1")` puts a grep error string into
- * $linecnt on failure (removed-file race, unreadable path). PHP 8 then
- * compares that string to an int as strings ($linecnt > $maxcnt can be
- * TRUE for non-numeric text) and a subsequent $linecnt - $maxcnt on a
- * non-numeric string is a fatal TypeError. Silently skipping the cap
- * would be worse than the fatal: the fgets() loop would stream the
- * WHOLE file unbounded, defeating the 10k-line cap exactly when grep
- * cannot be trusted — so a non-numeric count must answer with the
- * handler's own '|2|' error convention and stop.
+ * Before #1261, a removed-file race or unreadable path put grep's error
+ * string into $linecnt, and PHP 8 comparing/subtracting that string against
+ * an int was a TypeError hazard -- an `is_numeric($linecnt)` guard caught it.
+ * pfb_count_lines() now returns ?int directly: no shell, no error string, so
+ * the guard is a plain `$linecnt === NULL` check. Silently skipping the cap
+ * would still be worse than failing: the fgets() loop would stream the WHOLE
+ * file unbounded, defeating the 10k-line cap exactly when the count is
+ * unknown -- so a NULL count must still answer with the handler's own '|2|'
+ * error convention and stop.
  *
  * The file executes top-level code on include (needs a live pfSense
- * session — $pfb, $_REQUEST routing, real file I/O) and cannot be
+ * session -- $pfb, $_REQUEST routing, real file I/O) and cannot be
  * require()d off-appliance. Per the PfbReflectorGuardTest.php eval-oracle
  * precedent, the guard + cap block is extracted verbatim from the real
- * source into a callable oracle (exec output injected as the argument;
- * print captured; exit becomes an early return), so the branch logic is
- * exercised behaviourally, not just shape-matched.
+ * source into a callable oracle (the count injected as the argument, print
+ * captured, exit becomes an early return), so the branch logic is exercised
+ * behaviourally, not just shape-matched.
  *
- * Feature: a non-numeric grep count fails loudly instead of fatal or
- *          unbounded streaming; numeric counts keep the 10k tail window
+ * Feature: a NULL line count fails loudly instead of fatal or unbounded
+ *          streaming; numeric counts keep the 10k tail window
  *
  *   Scenario: numeric under/at the cap  -> no window, no error
  *   Scenario: numeric over the cap      -> window armed, skip count exact
- *   Scenario: non-numeric (grep error)  -> '|2|' error response, no window,
+ *   Scenario: NULL (read failure)       -> '|2|' error response, no window,
  *             no TypeError
  */
 final class LogLinecountGuardTest extends TestCase
@@ -46,12 +47,12 @@ final class LogLinecountGuardTest extends TestCase
 		}
 		self::$src = $src;
 
-		// Oracle: the block from the non-numeric guard through the cap window,
-		// exactly as committed. print -> capture, exit -> early return, gettext
+		// Oracle: the block from the NULL guard through the cap window, exactly
+		// as committed. print -> capture, exit -> early return, gettext
 		// stripped (plain PHP string stays). If extraction fails the guard block
-		// changed shape — fail loudly rather than skip.
+		// changed shape -- fail loudly rather than skip.
 		if (!function_exists('pfb_log_linecount_oracle')
-			&& preg_match('/(if \(!is_numeric\(\$linecnt\)\).*?Displaying last.*?\n[\t ]*\})\n/s', $src, $m)) {
+			&& preg_match('/(if \(\$linecnt === NULL\).*?Displaying last.*?\n[\t ]*\})\n/s', $src, $m)) {
 			$block = strtr($m[1], [
 				'print ('  => '$out .= (',
 				'exit;'    => 'return array($out, NULL, NULL, NULL);',
@@ -66,10 +67,10 @@ final class LogLinecountGuardTest extends TestCase
 		}
 	}
 
-	private function oracle(string $linecnt): array
+	private function oracle(?int $linecnt): array
 	{
 		if (!function_exists('pfb_log_linecount_oracle')) {
-			$this->fail('oracle extraction failed: the is_numeric guard block was not found in pfblockerng_log.php — see testNonNumericGuardAnswersWithErrorConvention\'s source assertion');
+			$this->fail('oracle extraction failed: the $linecnt === NULL guard block was not found in pfblockerng_log.php — see testNullGuardAnswersWithErrorConvention\'s source assertion');
 		}
 		return pfb_log_linecount_oracle($linecnt);
 	}
@@ -78,13 +79,22 @@ final class LogLinecountGuardTest extends TestCase
 	// Source-shape vacuity guards (the oracle depends on these constructs)
 	// --------------------------------------------------------------------------
 
-	public function testGrepLineCountExecCallExistsExactlyOnce(): void
+	public function testLinecntAssignedFromPfbCountLinesExactlyOnce(): void
 	{
-		$count = preg_match_all('/\$linecnt\s*=\s*exec\(.*-c\s+\^.*\);/', self::$src);
+		$count = preg_match_all('/\$linecnt\s*=\s*pfb_count_lines\(.*\);/', self::$src);
 		$this->assertSame(
 			1,
 			$count,
-			'expected exactly one grep -c line-count exec() call in the AJAX load handler'
+			'expected exactly one pfb_count_lines() assignment in the AJAX load handler (issue #1261)'
+		);
+	}
+
+	public function testNoExecGrepForkSurvivesForLinecnt(): void
+	{
+		$this->assertDoesNotMatchRegularExpression(
+			'/\$linecnt\s*=\s*exec\(/',
+			self::$src,
+			'a $linecnt = exec(...) fork survives -- issue #1261 must replace it with pfb_count_lines()'
 		);
 	}
 
@@ -99,14 +109,14 @@ final class LogLinecountGuardTest extends TestCase
 
 	/**
 	 * The red row for the loud-failure behaviour: on code that silently
-	 * skips the cap for a non-numeric count, this shape is absent.
+	 * skips the cap for a NULL count, this shape is absent.
 	 */
-	public function testNonNumericGuardAnswersWithErrorConvention(): void
+	public function testNullGuardAnswersWithErrorConvention(): void
 	{
 		$this->assertMatchesRegularExpression(
-			'/if\s*\(\s*!is_numeric\(\s*\$linecnt\s*\)\s*\)\s*\{\s*\n\s*print \("\|2\|"/',
+			'/if\s*\(\s*\$linecnt\s*===\s*NULL\s*\)\s*\{\s*\n\s*print \("\|2\|"/',
 			self::$src,
-			'a non-numeric $linecnt must answer with the handler\'s |2| error convention before any cap math'
+			'a NULL $linecnt must answer with the handler\'s |2| error convention before any cap math'
 		);
 	}
 
@@ -116,7 +126,7 @@ final class LogLinecountGuardTest extends TestCase
 
 	public function testNumericUnderCapKeepsFullView(): void
 	{
-		[$out, $validate, $skipcnt, $line_limit] = $this->oracle('500');
+		[$out, $validate, $skipcnt, $line_limit] = $this->oracle(500);
 
 		$this->assertSame('', $out, 'no error response expected for a numeric under-cap count');
 		$this->assertFalse($validate, 'the tail window must stay disarmed under the cap');
@@ -127,7 +137,7 @@ final class LogLinecountGuardTest extends TestCase
 	public function testNumericAtCapBoundaryKeepsFullView(): void
 	{
 		// Pins the comparison operator: exactly-at-cap is NOT over the cap.
-		[$out, $validate] = $this->oracle('10000');
+		[$out, $validate] = $this->oracle(10000);
 
 		$this->assertSame('', $out, 'no error response expected at the cap boundary');
 		$this->assertFalse($validate, 'exactly-at-cap must not arm the tail window (> not >=)');
@@ -135,7 +145,7 @@ final class LogLinecountGuardTest extends TestCase
 
 	public function testNumericOverCapArmsTailWindowWithExactSkipCount(): void
 	{
-		[$out, $validate, $skipcnt, $line_limit] = $this->oracle('10500');
+		[$out, $validate, $skipcnt, $line_limit] = $this->oracle(10500);
 
 		$this->assertSame('', $out, 'no error response expected for a numeric over-cap count');
 		$this->assertTrue($validate, 'an over-cap count must arm the tail window');
@@ -147,37 +157,22 @@ final class LogLinecountGuardTest extends TestCase
 		);
 	}
 
-	public function testNonNumericGrepErrorFailsLoudlyWithoutTypeErrorOrStreaming(): void
+	public function testNullReadFailureFailsLoudlyWithoutTypeErrorOrStreaming(): void
 	{
 		try {
-			[$out, $validate] = $this->oracle('grep: no such file or directory');
+			[$out, $validate] = $this->oracle(NULL);
 		} catch (\TypeError $e) {
-			$this->fail('a non-numeric grep count must not reach the subtraction: ' . $e->getMessage());
+			$this->fail('a NULL line count must not reach the subtraction: ' . $e->getMessage());
 		}
 
 		$this->assertStringStartsWith(
 			'|2|',
 			$out,
-			'a non-numeric grep count must produce the |2| error response, got ' . var_export($out, true)
+			'a NULL line count must produce the |2| error response, got ' . var_export($out, true)
 		);
 		$this->assertNull(
 			$validate,
 			'the handler must stop at the error response — reaching the cap logic means the unbounded-stream path is open'
 		);
-	}
-
-	/**
-	 * Documentation test pinning the PHP 8 language semantics the guard
-	 * defends against — NOT a substitute for the rows above.
-	 */
-	public function testGrepErrorStringSemanticsMotivatingTheGuard(): void
-	{
-		$this->assertTrue(
-			'grep: no such file' > 10000,
-			'PHP 8 compares int vs non-numeric string as strings — the old comparison let error text through'
-		);
-
-		$this->expectException(\TypeError::class);
-		(static fn () => 'grep: no such file' - 10000)();
 	}
 }

--- a/tests/smoke/ui/test_alerts_total_event_count.py
+++ b/tests/smoke/ui/test_alerts_total_event_count.py
@@ -1,0 +1,142 @@
+"""Tier-A ``ui_render`` coverage for the Alerts stats page's "Total event(s)"
+count (issue #1261: ``$alert_log_total_count`` moves from ``exec("grep -c ^
+... 2>&1")`` to ``pfb_count_lines()``).
+
+``pfblockerng_alerts.php?view=dnsbl_stat`` renders ``Total event(s): [ N ]``
+from ``$alert_stats['count'][$alert_view]`` (pfblockerng_alerts.php:4860),
+fed by the exec()-replaced line at :1829/1831. This module seeds ``dnsbl.log``
+with an EXACT, controlled line count (never appended to an unknown baseline,
+unlike ``test_alerts_stat_render.py``'s fixture) and asserts the rendered
+``[ N ]`` matches it precisely -- not merely that the page renders 200
+(CLAUDE.md test mandate #4).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+DNSBL_LOG = "/var/log/pfblockerng/dnsbl.log"
+ALERTS_DNSBL_STAT_PAGE = "/pfblockerng/pfblockerng_alerts.php?view=dnsbl_stat"
+
+# Fixed, clearly-synthetic date (never the wall clock) so these rows are
+# unambiguous in diagnostics and can't collide with any real entry.
+_DAY = "2030-02-20"
+_ROW = f"DNSBL-python,{_DAY} 10:00:00,ic1261-a.com,203.0.113.30,Python,DNSBL,IC1261Group,Match,IC1261Feed,+,A\n"
+
+
+@pytest.fixture
+def _dnsbl_log_backup(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
+    """Move ``dnsbl.log`` aside so a test can write an EXACT byte content, then restore it.
+
+    Self-encapsulated (CLAUDE.md): no ``ui_e2e``/``ui_browser`` marker, so the shared
+    isolation fixture does not run for this module -- teardown restores the exact
+    pre-test file (or its absence) and FAILS LOUDLY if that didn't take.
+    """
+    vm = smoke_vm
+    had_file = vm.ssh("test", "-f", DNSBL_LOG, timeout=15).returncode == 0
+    backup = f"{DNSBL_LOG}.bak-1261"
+    if had_file:
+        mv = vm.ssh("mv", DNSBL_LOG, backup, timeout=15)
+        assert mv.returncode == 0, f"failed to back up {DNSBL_LOG}: {mv.stderr!r}"
+
+    yield vm
+
+    vm.ssh("rm", "-f", DNSBL_LOG, timeout=15)
+    if had_file:
+        restore = vm.ssh("mv", backup, DNSBL_LOG, timeout=15)
+        assert restore.returncode == 0, f"failed to restore {DNSBL_LOG}: {restore.stderr!r}"
+    still_backed_up = vm.ssh("test", "-f", backup, timeout=15).returncode == 0
+    assert not still_backed_up, f"{DNSBL_LOG} restore did not take -- backup {backup} still present"
+
+
+def _write_log(vm: SmokeVM, content: str) -> None:
+    log_dir = DNSBL_LOG.rsplit("/", 1)[0]
+    ensure = vm.ssh(f"mkdir -p {log_dir}", timeout=15)
+    assert ensure.returncode == 0, f"failed to ensure {log_dir}: {ensure.stderr!r}"
+    write = subprocess.run(
+        vm.ssh_argv("tee", DNSBL_LOG),
+        input=content,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert write.returncode == 0, f"failed to write {DNSBL_LOG}: stderr={write.stderr!r}"
+
+
+def test_alerts_total_event_count_matches_exact_seeded_line_count(webui: WebUI, _dnsbl_log_backup: SmokeVM) -> None:
+    """The displayed "Total event(s): [ N ]" is the EXACT line count, including a dangling final line.
+
+    Scenario: three newline-terminated rows.
+      Given dnsbl.log holds exactly 3 complete rows,
+      When  GET the DNSBL Block Stats view,
+      Then  the render oracle passes AND "[ 3 ]" is the rendered total.
+
+    Scenario: a dangling (unterminated) final row -- the #1257/#1261 line the
+    old `wc -l`-shaped bugs and the new pfb_count_lines() must agree on.
+      Given a 4th row appended WITHOUT a trailing newline,
+      When  GET the same view again,
+      Then  "[ 4 ]" renders -- the dangling row IS counted (grep -c ^ semantics).
+    """
+    vm = _dnsbl_log_backup
+    guard = PhpErrorLogGuard(vm)
+    guard.snapshot()
+
+    # Scenario: three newline-terminated rows.
+    _write_log(vm, _ROW * 3)
+    resp = webui.get(ALERTS_DNSBL_STAT_PAGE)
+    result = evaluate_render(ALERTS_DNSBL_STAT_PAGE, resp.status_code, resp.text, ("DNSBL Block Stats",))
+    assert result.ok, f"Tier-A render oracle failed for the DNSBL stats page: {result.detail}"
+    assert "[ 3 ]" in resp.text, (
+        f'expected "Total event(s): [ 3 ]" for 3 seeded rows, not found in body (status={resp.status_code})'
+    )
+
+    # Scenario: + one dangling (unterminated) final row -> must still be counted.
+    _write_log(vm, _ROW * 3 + _ROW.rstrip("\n"))
+    resp = webui.get(ALERTS_DNSBL_STAT_PAGE)
+    result = evaluate_render(ALERTS_DNSBL_STAT_PAGE, resp.status_code, resp.text, ("DNSBL Block Stats",))
+    assert result.ok, f"Tier-A render oracle failed for the DNSBL stats page: {result.detail}"
+    assert "[ 4 ]" in resp.text, (
+        'expected "Total event(s): [ 4 ]" (3 terminated + 1 dangling row) -- '
+        f"a dangling final line must still be counted, not found in body (status={resp.status_code})"
+    )
+
+    guard.assert_no_growth()
+
+
+def test_alerts_total_event_count_is_zero_when_log_absent(webui: WebUI, _dnsbl_log_backup: SmokeVM) -> None:
+    """A missing dnsbl.log renders "Total event(s): [ 0 ]", never a PHP warning or a wrong number.
+
+    Given dnsbl.log does not exist (the fixture removed it),
+    When  GET the DNSBL Block Stats view,
+    Then  the render oracle passes (no PHP diagnostic in the body, no new
+          php_error.log line) AND the total renders "[ 0 ]".
+    """
+    vm = _dnsbl_log_backup
+    exists = vm.ssh("test", "-f", DNSBL_LOG, timeout=15).returncode == 0
+    assert not exists, f"test setup bug: {DNSBL_LOG} unexpectedly exists before the missing-file scenario"
+
+    guard = PhpErrorLogGuard(vm)
+    guard.snapshot()
+
+    resp = webui.get(ALERTS_DNSBL_STAT_PAGE)
+    result = evaluate_render(ALERTS_DNSBL_STAT_PAGE, resp.status_code, resp.text, ("DNSBL Block Stats",))
+    assert result.ok, f"Tier-A render oracle failed for the DNSBL stats page: {result.detail}"
+    assert "[ 0 ]" in resp.text, (
+        f'expected "Total event(s): [ 0 ]" for a missing log, not found in body (status={resp.status_code})'
+    )
+
+    guard.assert_no_growth()


### PR DESCRIPTION
Fixes #1261

Ten PHP sites shelled out to `grep -c ^` to count one file's lines. `pfb_count_lines(string $path): ?int` (landed in #1257) has exactly `grep -c ^` semantics with no fork. All ten now use it.

## This is a correctness fix, not a micro-optimisation

**Five of the ten piped `2>&1`**, so grep's *error text* landed in the count. That already caused a real outage: `pfb_filterlog_skip_count()` existed **only** to `(int)`-cast the result, because a grep error string reached arithmetic and crash-looped the daemon with PHP 8's `TypeError: Unsupported operand types: string - int` (#713).

And the cast's own fallback is the quiet part: `(int)"grep: … No such file or directory"` → **`0`**. A missing or unreadable file silently read as *zero entries*. With `?int` there is no error channel to leak into the data channel, because there is no shell.

It is also simply faster — the `fork`+`exec` floor (~6 ms) dwarfs the counting:

```text
   20,000 lines   pfb_count_lines  0.18 ms    exec grep -c ^   6.11 ms   (33x)
2,000,000 lines   pfb_count_lines 18.63 ms    exec grep -c ^ 124.92 ms   (6.7x)
```

## Every site names its own failure direction

`pfb_count_lines()` returns `NULL` on failure and deliberately does **not** pick a direction — the caller does, at the call site, with a comment saying why it is safe there:

- **Site 1** (`filter.log` skip count) → `NULL` means **skip 0**, i.e. reprocess the whole log. Reprocessing is safe; silently *skipping* lines is not. This preserves #713's exact fallback. `pfb_filterlog_skip_count()` survives, now taking `?int`; its `-1` / `max(…, 0)` semantics stay pinned.
- **Sites 2–9** (accumulators, log gates, displayed totals) → `?? 0`, matching what a failed `exec` already produced, so behaviour is preserved. The `?: 0` idiom at sites 7 and 9 is preserved exactly (an empty file yielded `0` either way).
- **Site 10** (`pfblockerng_log.php` AJAX) → `NULL` routes to the pre-existing `|2|` error response. Silently skipping the 10k-line cap on an unknown count would stream the whole file unbounded (#1156's reasoning, unchanged).

## Out of scope

`pfblockerng.inc:9127` — the `cat {dnsdir}/*.txt | grep -c ^` **glob** — is untouched (verified byte-identical). It is owned by **#1263**, which is fixing a live record-welding bug there.

## Tests

Test-first red→green, freeze-verified. Coverage where there was close to none: `alert_log_total_count` had **zero** tests; sites 3 & 4 had none.

- `FilterlogSkipCountTest` rewritten for the `?int` contract; new `DnsblIpCountGuardTest`; `AliasCntGrepCountGuardTest` / `LogLinecountGuardTest` rewritten (their premise — "exec can return a non-numeric string, guard inline" — no longer exists).
- **Tier-A `ui_render`** (three `www/` files touched): new `test_alerts_total_event_count.py` asserts the **exact displayed total** for 3 seeded rows, for a **dangling (unterminated) final row**, and for a missing log — not merely HTTP 200. Executed on a leased pfSense VM.
- A hostile row this PR's own gate caught as missing: an **unreadable** file (`chmod 0000`) must return `NULL`, never `0` — because `0` reads as "no lines", a count every caller would believe. Root-skipped, since root bypasses file permissions.

Suite: 3225 green. PHPStan, PHPCS, markdownlint, comment-narration clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Vv1F4fW9zu39cSJ69Jn7f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log and feed line counting, including reliable handling of unreadable or missing files.
  * Alerts and reports now display accurate event totals, including logs without trailing newlines.
  * Prevented incorrect zero counts and calculation errors when log data cannot be read.
  * Improved country network totals and log viewing error handling.

* **Tests**
  * Added regression coverage for line-count failures, feed totals, country statistics, filtering, and alert displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->