### PR TITLE
pfblockerng: guarantee newline-terminated feeds so cat never welds records (#1263)

### DIFF
--- a/scripts/bench_ip_recompute.sh
+++ b/scripts/bench_ip_recompute.sh
@@ -47,7 +47,7 @@ scenario() { # $1 name  $2 nfeeds  $3 rows  $4 shared
 	sh_file="$d/.shared"; gen_range 0 "$4" > "$sh_file"
 	own=$(( $3 - $4 )); i=1
 	while [ "$i" -le "$2" ]; do
-		{ cat "$sh_file"; gen_range "$(( $4 + i * own ))" "$own"; } \
+		{ awk 1 "$sh_file"; gen_range "$(( $4 + i * own ))" "$own"; } \
 			| LC_ALL=C sort -u > "$d/feed$(printf %02d "$i")_v4.txt"
 		i=$(( i + 1 ))
 	done

--- a/scripts/bench_ip_recompute.sh
+++ b/scripts/bench_ip_recompute.sh
@@ -159,7 +159,8 @@ measure() { # $1 label  $2... runner+args
 # a fully-pruned feed with the placeholder IP; recompute leaves it empty and
 # the production caller runs emptyfiles() itself — not a membership difference.
 union_cksum() {
-	cat "$1"/*.txt 2>/dev/null | grep -v '^127\.1\.7\.7$' | LC_ALL=C sort -u | cksum
+	# issue #1263: awk 1, not cat -- an unterminated member file must not weld into its neighbour.
+	awk 1 "$1"/*.txt 2>/dev/null | grep -v '^127\.1\.7\.7$' | LC_ALL=C sort -u | cksum
 }
 
 echo "generating data..."; gen_all

--- a/scripts/misc/bench_aggregate_union.sh
+++ b/scripts/misc/bench_aggregate_union.sh
@@ -148,7 +148,7 @@ if [ "${use_iprange}" -eq 1 ]; then
 	# per-family. We split, aggregate each, recombine — matching production.
 	grep -F ':' "${union_sorted}" > "${workdir}/u6.txt" || true
 	grep -Fv ':' "${union_sorted}" > "${workdir}/u4.txt" || true
-	run_timed sh -c "\"${pathaggregate}\" \"${workdir}/u4.txt\" > \"${workdir}/a4.txt\"; \"${pathaggregate}\" \"${workdir}/u6.txt\" > \"${workdir}/a6.txt\"; cat \"${workdir}/a4.txt\" \"${workdir}/a6.txt\" > \"${union_agg}\""
+	run_timed sh -c "\"${pathaggregate}\" \"${workdir}/u4.txt\" > \"${workdir}/a4.txt\"; \"${pathaggregate}\" \"${workdir}/u6.txt\" > \"${workdir}/a6.txt\"; awk 1 \"${workdir}/a4.txt\" \"${workdir}/a6.txt\" > \"${union_agg}\""
 else
 	# Portable stand-in: identical collapse semantics via ipaddress.
 	run_timed python3 - "${union_sorted}" "${union_agg}" <<'PY'

--- a/scripts/misc/bench_aggregate_union.sh
+++ b/scripts/misc/bench_aggregate_union.sh
@@ -122,15 +122,17 @@ for fh in fhs:
 print(f"      wrote {members} member files, {n} IPv4 + {m} IPv6 lines")
 PY
 
-input_count="$(cat "${memberdir}"/deny_*.txt | grep -c ^)"
+# issue #1263: awk 1, not cat -- an unterminated member file must not weld into its neighbour.
+input_count="$(awk 1 "${memberdir}"/deny_*.txt | grep -c ^)"
 echo "      total input lines (with duplicates/overlap): ${input_count}"
 echo
 
-# --- 2. union: cat -> sort -u (the dedup half) -------------------------------
-echo "[2/4] cat members -> sort -u ..."
+# --- 2. union: awk 1 -> sort -u (the dedup half) ------------------------------
+echo "[2/4] concat members -> sort -u ..."
 union_sorted="${workdir}/union.sorted"
-# `sort` is a base utility (bare per CLAUDE.md shell rules).
-run_timed sh -c "cat \"${memberdir}\"/deny_*.txt | LC_ALL=C sort -u > \"${union_sorted}\""
+# `sort`/`awk` are base utilities (bare per CLAUDE.md shell rules).
+# issue #1263: awk 1, not cat -- an unterminated member file must not weld into its neighbour.
+run_timed sh -c "awk 1 \"${memberdir}\"/deny_*.txt | LC_ALL=C sort -u > \"${union_sorted}\""
 sortu_wall="$(awk '/^WALL/{w=$2} END{print w}' "${time_log}")"
 sortu_rss="$(awk '/^MAXRSS_BYTES/{r=$2} END{print r}' "${time_log}")"
 sortu_count="$(grep -c ^ "${union_sorted}")"

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1105,7 +1105,9 @@ function pfb_ensure_trailing_newline(string $path): bool {
 	}
 	$last = @fread($fh, 1);
 	fclose($fh);
-	if ($last === "\n") {
+	// A failed/short read can't tell terminated from not -- leave the file alone
+	// rather than risk a spurious append.
+	if ($last === FALSE || $last === '' || $last === "\n") {
 		return FALSE;
 	}
 
@@ -1113,9 +1115,11 @@ function pfb_ensure_trailing_newline(string $path): bool {
 	if ($ap === FALSE) {
 		return FALSE;
 	}
-	fwrite($ap, "\n");
+	$written = @fwrite($ap, "\n");
 	fclose($ap);
-	return TRUE;
+	// Only a full 1-byte write counts as success -- else a failed append would
+	// report TRUE, masking the exact unterminated-file condition this exists to fix.
+	return $written !== FALSE && $written === 1;
 }
 
 // ADR-49: content-sanity gate for a downloaded text feed's first 64-KiB chunk; pinned by
@@ -18662,6 +18666,9 @@ function sync_package_pfblockerng($cron='') {
 
 								if ($continent != 'md5_0') {
 									@rename("{$pfb['geoip_tmp']}", "{$pfborig}/{$cc_alias}.orig");
+									// issue #1263: this GeoIP continent builder writes '.orig'
+									// outside pfb_download(), bypassing its newline guarantee.
+									pfb_ensure_trailing_newline("{$pfborig}/{$cc_alias}.orig");
 									@copy("{$pfborig}/{$cc_alias}.orig", "{$pfbfolder}/{$cc_alias}.txt");
 
 									// Call Aggregate process
@@ -18986,6 +18993,9 @@ function sync_package_pfblockerng($cron='') {
 											$file_dwn_esc = escapeshellarg("{$file_dwn}.raw");
 											$file_org_esc = escapeshellarg("{$file_dwn}.orig");
 											exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$file_org_esc}");
+											// issue #1263: this reuse path rebuilds '.orig' outside pfb_download(),
+											// bypassing its normal newline-termination guarantee.
+											pfb_ensure_trailing_newline("{$file_dwn}.orig");
 										}
 										exec("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}");
 									}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1090,6 +1090,34 @@ function pfb_utf16_transcode_file(string $path): bool {
 	return TRUE;
 }
 
+// issue #1263: append '\n' if the stored file's last byte isn't one -- cat
+// concatenates bytes, not records, and welds an unterminated feed's last line
+// onto the next file's first downstream. Only reads the last byte (feeds can
+// be tens of MB). Empty/unreadable file -> FALSE, untouched (nothing to weld).
+function pfb_ensure_trailing_newline(string $path): bool {
+	$fh = @fopen($path, 'rb');
+	if ($fh === FALSE) {
+		return FALSE;
+	}
+	if (@fseek($fh, -1, SEEK_END) !== 0) {
+		fclose($fh);
+		return FALSE;
+	}
+	$last = @fread($fh, 1);
+	fclose($fh);
+	if ($last === "\n") {
+		return FALSE;
+	}
+
+	$ap = @fopen($path, 'ab');
+	if ($ap === FALSE) {
+		return FALSE;
+	}
+	fwrite($ap, "\n");
+	fclose($ap);
+	return TRUE;
+}
+
 // ADR-49: content-sanity gate for a downloaded text feed's first 64-KiB chunk; pinned by
 // PfbTextSanityTest. Reason order (first hit wins): 'nul_bytes' (any NUL byte) >
 // 'html_error_page' (opens as HTML AND no line is blocklist-shaped: an IPv4/IPv6/CIDR
@@ -3300,6 +3328,18 @@ function pfb_count_lines(string $path): ?int {
 	}
 
 	return $lines + ($last_byte === '' || $last_byte === "\n" ? 0 : 1);
+}
+
+// issue #1263: per-file pfb_count_lines() sum over a '*.txt' glob, replacing
+// `cat *.txt | grep -c ^` -- cat welds an unterminated file's last line onto
+// the next file's first, undercounting; summing per-file counts cannot weld.
+// Missing dir / empty glob -> 0, never a warning or TypeError.
+function pfb_dnsbl_feed_count(string $dir): int {
+	$total = 0;
+	foreach ((glob("{$dir}/*.txt") ?: array()) as $file) {
+		$total += pfb_count_lines($file) ?? 0;
+	}
+	return $total;
 }
 
 // issue #1109/#1258: ONE unified high-water guard for both pfb_log_mgmt()
@@ -9395,7 +9435,10 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython) {
 		restart_service('pfb_dnsbl');
 	}
 
-	$dnsbl_cnt = exec("/bin/cat {$pfb['dnsdir']}/*.txt 2>/dev/null | {$pfb['grep']} -c ^");
+	// issue #1263: per-file sum, not cat|grep -c ^ -- differs from the old count
+	// when a stored feed lacks a trailing newline (the old command welded two
+	// records into one and undercounted); the sum is the correct total.
+	$dnsbl_cnt = pfb_dnsbl_feed_count($pfb['dnsdir']);
 
 	// ADR-06: pfb_py_count is now Python-emitted and means the LOADED entry total
 	// (len(dataDB)+len(zoneDB)), written by pfb_unbound.py dnsbl_emit_count(). The
@@ -11831,6 +11874,12 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			// change-probe's wire hash and re-ingest the feed every cron. No-op (FALSE,
 			// file untouched) for every feed that isn't UTF-16/32-BOM-marked.
 			pfb_utf16_transcode_file("{$orig_download}");
+
+			// issue #1263: guarantee a trailing newline on the STORED .orig -- after
+			// transcode (operates on final bytes) and after the hash write (ADR-42
+			// digest must stay over the untouched wire/raw body, same reasoning as
+			// the transcode-ordering comment above).
+			pfb_ensure_trailing_newline("{$orig_download}");
 
 			// Process Emerging Threats IQRisk if required
 			if (strpos($list_url, 'iprepdata.txt') !== FALSE) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -717,7 +717,9 @@ pfb_aggregate() {
 	fi
 	while IFS= read -r agg_member; do
 		[ -z "${agg_member}" ] && continue
-		[ -f "${agg_member}" ] && cat "${agg_member}" >> "${tempfile}"
+		# issue #1263: awk 1 supplies a record terminator cat doesn't -- an
+		# unterminated member no longer welds onto the next member's first line.
+		[ -f "${agg_member}" ] && awk 1 "${agg_member}" >> "${tempfile}"
 	done < "${agg_memberlist}"
 	if ! LC_ALL=C sort -u "${tempfile}" > "${dedupfile}"; then
 		log="aggregate [ ${agg_family} ]: union sort of [ ${tempfile} ] failed; keeping existing."
@@ -1888,7 +1890,9 @@ EOF
 		# result = rc 1" quirk -- non-zero is a real error) so a failed dedup
 		# can't truncate masterfile via an unconditional mv.
 		awk 'FNR==NR{a[$0];next}!($0 in a)' "${tempfile}" "${masterfile}" > "${tempfile2}" && mv -f "${tempfile2}" "${masterfile}"
-		cat "${addfile}" >> "${masterfile}"
+		# issue #1263: awk 1 guarantees masterfile stays newline-terminated --
+		# cat would silently inherit addfile's bare tail if it lacked one.
+		awk 1 "${addfile}" >> "${masterfile}"
 		cut -d ' ' -f2 "${masterfile}" > "${mastercat}"
 
 		echo; echo '  Removed the following IP ranges:'
@@ -1956,13 +1960,15 @@ processet() {
 			case ", ${etblock}, " in
 				*", ${list}, "*)
 					printf "%-10s %-25s\n" '  Block: ' "${list}"
-					cat "${etdir}/${list}.txt" >> "${tempfile}"
+					# issue #1263: awk 1 supplies a record terminator cat doesn't --
+					# a category file no longer welds onto the next one accumulated.
+					awk 1 "${etdir}/${list}.txt" >> "${tempfile}"
 					;;
 			esac
 			case ", ${etmatch}, " in
 				*", ${list}, "*)
 					printf "%-10s %-25s\n" '  Match: ' "${list}"
-					cat "${etdir}/${list}.txt" >> "${tempfile2}"
+					awk 1 "${etdir}/${list}.txt" >> "${tempfile2}"
 					;;
 			esac
 		done

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1970,7 +1970,9 @@ processet() {
 
 		if [ -f "${tempfile}" ]; then mv -f "${tempfile}" "${pfborig}${alias}.orig"; fi
 		if [ "${etmatch}" != 'x' ]; then mv -f "${tempfile2}" "${pfbmatchgen}pfB_Match_ET_v4.txt"; fi
-		counto="$(cat "${etdir}"/ET_* | grep -cv '^#\|^$')"; countf="$(grep -cv "^${ip_placeholder2}$" "${pfborig}${alias}.orig")"
+		# issue #1263: awk 1 supplies a record terminator cat doesn't -- an
+		# unterminated ET_* file no longer welds its last row onto the next file's first.
+		counto="$(awk 1 "${etdir}"/ET_* | grep -cv '^#\|^$')"; countf="$(grep -cv "^${ip_placeholder2}$" "${pfborig}${alias}.orig")"
 		echo; echo "All ET Folder count [ ${counto} ]  Final count [ ${countf} ]"
 	else
 		echo; echo 'No ET .orig File Found!'
@@ -2009,9 +2011,12 @@ closingprocess() {
 		# Sum the per-feed aggregated "Original" counts written by pfb_ip_recompute_write_snapshot()
 		# (pfblockerng.inc) -- these reflect the CIDR-aggregated input when aggregation ran. Fall back
 		# to the raw *_v4.orig total when no sidecars exist (no snapshot was ever written this pass).
-		counto="$(find "${pfborig}"*_v4.aggcount 2>/dev/null | xargs cat 2>/dev/null | awk '{s += $1} END {print s + 0}')"
+		# issue #1263: awk 1 (not cat) supplies a missing record terminator --
+		# a welded pair of unterminated counts would otherwise concatenate
+		# digits (e.g. "100" + "200" -> "100200") instead of summing to 300.
+		counto="$(find "${pfborig}"*_v4.aggcount 2>/dev/null | xargs awk 1 2>/dev/null | awk '{s += $1} END {print s + 0}')"
 		if [ "${counto}" -eq 0 ]; then
-			counto="$(find "${pfborig}"*_v4.orig 2>/dev/null | xargs cat | grep -cv '^#\|^$')"
+			counto="$(find "${pfborig}"*_v4.orig 2>/dev/null | xargs awk 1 | grep -cv '^#\|^$')"
 		fi
 	fi
 
@@ -2028,9 +2033,10 @@ closingprocess() {
 		# (v6 Deny joined cross-list dedup) -- the deny-folder re-scan (s2/s4) must
 		# include v6 Deny files too, else the family mismatch alone fails sanity.
 		s1="$(grep -cv "^${ip_placeholder2}$" "${mastercat}")"
-		s2="$(find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs cat | grep -cv "^${ip_placeholder2}$")"
+		# issue #1263: awk 1 -- an unterminated deny file no longer welds into its neighbour.
+		s2="$(find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | grep -cv "^${ip_placeholder2}$")"
 		s3="$(sort "${mastercat}" | uniq -d | tail -30)"
-		s4="$(find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs cat | sort | uniq -d | tail -30 | grep -v "^${ip_placeholder2}$")"
+		s4="$(find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | sort | uniq -d | tail -30 | grep -v "^${ip_placeholder2}$")"
 	else
 		echo "   [ Original IP count   ]  [ ${counto} ]"
 	fi

--- a/tests/php/DnsblFeedCountTest.php
+++ b/tests/php/DnsblFeedCountTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_dnsbl_feed_count() -- issue #1263: replaces `cat *.txt | grep -c ^`
+ * (exec'd at the DNSBL feed-count site) with a per-file pfb_count_lines()
+ * sum. This is an INTENDED behaviour change on unterminated input: cat welds
+ * an unterminated file's last record onto the next file's first and
+ * undercounts; the per-file sum cannot weld and is the correct total.
+ * Brand-new function -- tests assert real behaviour, not mere existence.
+ */
+#[CoversFunction('pfb_dnsbl_feed_count')]
+final class DnsblFeedCountTest extends TestCase
+{
+	private string $dir;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_dnsbl_feed_count_' . uniqid();
+		mkdir($this->dir);
+	}
+
+	protected function tearDown(): void
+	{
+		array_map('unlink', glob("{$this->dir}/*") ?: array());
+		rmdir($this->dir);
+	}
+
+	public function testSumsPerFileCountsAcrossAnUnterminatedFileNeverWeldingRecords(): void
+	{
+		// The reported defect, reproduced directly: an old cat|grep -c ^ over these
+		// two files would weld "5.6.7.8" onto "9.9.9.9" into ONE fused record and
+		// report 2, not the true 3.
+		file_put_contents("{$this->dir}/FeedA.txt", "1.2.3.4\n5.6.7.8"); // unterminated
+		file_put_contents("{$this->dir}/FeedB.txt", "9.9.9.9\n");
+		$this->assertSame(3, pfb_dnsbl_feed_count($this->dir),
+			'the per-file sum must count the true 3 records, never the welded 2');
+	}
+
+	public function testTerminatedFilesSumNormally(): void
+	{
+		file_put_contents("{$this->dir}/FeedA.txt", "1.2.3.4\n5.6.7.8\n");
+		file_put_contents("{$this->dir}/FeedB.txt", "9.9.9.9\n");
+		$this->assertSame(3, pfb_dnsbl_feed_count($this->dir));
+	}
+
+	public function testEmptyDirectoryCountsZero(): void
+	{
+		$this->assertSame(0, pfb_dnsbl_feed_count($this->dir), 'no matching files -- zero, not a warning or TypeError');
+	}
+
+	public function testMissingDirectoryCountsZero(): void
+	{
+		$missing = $this->dir . '-does-not-exist';
+		$this->assertSame(0, pfb_dnsbl_feed_count($missing), 'a missing directory -- zero, not a warning or TypeError');
+	}
+
+	public function testNonTxtFilesAreIgnored(): void
+	{
+		file_put_contents("{$this->dir}/FeedA.txt", "1.2.3.4\n");
+		file_put_contents("{$this->dir}/FeedA.manifest", "should not be counted\nat all\n");
+		$this->assertSame(1, pfb_dnsbl_feed_count($this->dir));
+	}
+}

--- a/tests/php/DnsblFeedCountWiringTest.php
+++ b/tests/php/DnsblFeedCountWiringTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1263: pfb_update_unbound()'s DNSBL feed-count site must call
+ * pfb_dnsbl_feed_count($pfb['dnsdir']) -- the old `/bin/cat *.txt | grep -c ^`
+ * exec() shell-out is gone entirely. pfb_update_unbound() restarts real
+ * services, so this is a source-inspection pin (same technique as
+ * DownloadExtractionExitCodeTest); pfb_dnsbl_feed_count()'s own behaviour is
+ * proven directly in DnsblFeedCountTest.
+ */
+final class DnsblFeedCountWiringTest extends TestCase
+{
+	private static string $body;
+
+	public static function setUpBeforeClass(): void
+	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
+		);
+		if ($source === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		}
+
+		$start = strpos($source, 'function pfb_update_unbound(');
+		if ($start === false) {
+			throw new RuntimeException('test bootstrap: function pfb_update_unbound( not found');
+		}
+
+		if (!preg_match('/^function\s+\w+/m', $source, $m, PREG_OFFSET_CAPTURE, $start + 20)) {
+			throw new RuntimeException('test bootstrap: end-of-function boundary not found');
+		}
+		$end = $m[0][1];
+
+		self::$body = substr($source, $start, $end - $start);
+	}
+
+	public function testCallsPfbDnsblFeedCountOnTheDnsdir(): void
+	{
+		$this->assertStringContainsString("pfb_dnsbl_feed_count(\$pfb['dnsdir'])", self::$body,
+			'the per-file sum must replace the exec()d cat|grep -c ^ shell-out');
+	}
+
+	public function testNoLongerShellsOutToCatGrepForTheDnsblCount(): void
+	{
+		$this->assertDoesNotMatchRegularExpression('/exec\(\s*"\/bin\/cat/', self::$body,
+			'the cat|grep -c ^ exec() shell-out must be gone -- an unterminated feed file welds into the next '
+			. 'one and undercounts through it');
+	}
+}

--- a/tests/php/DownloadTrailingNewlineWiringTest.php
+++ b/tests/php/DownloadTrailingNewlineWiringTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1263: pfb_download()'s finalizer must call pfb_ensure_trailing_newline()
+ * on the stored '.orig' -- AFTER the ADR-42 hash write (digest stays over the
+ * untouched wire/raw body) and AFTER the UTF-16 transcode (operates on the
+ * final bytes). pfb_download() drives real cURL + appliance exec before any
+ * site under test runs, so this is a source-inspection pin (same technique as
+ * DownloadExtractionExitCodeTest), not a behavioural exercise -- the actual
+ * newline-append behaviour is proven directly in EnsureTrailingNewlineTest.
+ */
+final class DownloadTrailingNewlineWiringTest extends TestCase
+{
+	private static string $body;
+
+	public static function setUpBeforeClass(): void
+	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
+		);
+		if ($source === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		}
+
+		$start = strpos($source, 'function pfb_download(');
+		if ($start === false) {
+			throw new RuntimeException('test bootstrap: function pfb_download( not found');
+		}
+
+		if (!preg_match('/^function\s+\w+/m', $source, $m, PREG_OFFSET_CAPTURE, $start + 20)) {
+			throw new RuntimeException('test bootstrap: end-of-function boundary not found');
+		}
+		$end = $m[0][1];
+
+		self::$body = substr($source, $start, $end - $start);
+	}
+
+	public function testEnsureTrailingNewlineIsCalledOnOrigDownload(): void
+	{
+		$this->assertStringContainsString('pfb_ensure_trailing_newline("{$orig_download}")', self::$body,
+			'the finalizer must normalize the stored .orig -- else a feed served without a trailing newline stays welded downstream');
+	}
+
+	public function testEnsureTrailingNewlineRunsAfterTheHashWrite(): void
+	{
+		$hashPos = strpos(self::$body, 'pfb_hash_write("{$orig_download}"');
+		$this->assertNotFalse($hashPos, 'vacuity: the ADR-42 hash-write site must exist');
+
+		$normalizePos = strpos(self::$body, 'pfb_ensure_trailing_newline("{$orig_download}")');
+		$this->assertNotFalse($normalizePos, 'vacuity: the trailing-newline call must exist');
+
+		$this->assertGreaterThan($hashPos, $normalizePos,
+			'appending a newline BEFORE the hash write would change the ADR-42 digest away from the raw wire body');
+	}
+
+	public function testEnsureTrailingNewlineRunsAfterTheUtf16Transcode(): void
+	{
+		$transcodePos = strpos(self::$body, 'pfb_utf16_transcode_file("{$orig_download}")');
+		$this->assertNotFalse($transcodePos, 'vacuity: the UTF-16 transcode site must exist');
+
+		$normalizePos = strpos(self::$body, 'pfb_ensure_trailing_newline("{$orig_download}")');
+		$this->assertNotFalse($normalizePos, 'vacuity: the trailing-newline call must exist');
+
+		$this->assertGreaterThan($transcodePos, $normalizePos,
+			'normalizing before the transcode risks the rewrite silently dropping/duplicating the appended byte -- '
+			. 'run last, on the final bytes');
+	}
+}

--- a/tests/php/EnsureTrailingNewlineTest.php
+++ b/tests/php/EnsureTrailingNewlineTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_ensure_trailing_newline() -- issue #1263: cat concatenates bytes, not
+ * records. A downloaded/extracted feed with no trailing newline welds its
+ * last line onto the next file's first line in every downstream multi-file
+ * `cat` pipeline. This guarantees the stored '.orig' always ends in '\n'.
+ * Brand-new function (no prior behaviour to be wrong) -- tests assert real
+ * behaviour, not mere existence.
+ */
+#[CoversFunction('pfb_ensure_trailing_newline')]
+final class EnsureTrailingNewlineTest extends TestCase
+{
+	private string $tmpFile;
+
+	protected function setUp(): void
+	{
+		$this->tmpFile = (string) tempnam(sys_get_temp_dir(), 'pfb_ensure_nl_');
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_file($this->tmpFile)) {
+			unlink($this->tmpFile);
+		}
+	}
+
+	public function testAppendsNewlineWhenLastLineIsUnterminated(): void
+	{
+		file_put_contents($this->tmpFile, "1.2.3.4\n5.6.7.8");
+		$this->assertTrue(pfb_ensure_trailing_newline($this->tmpFile), 'an unterminated file must be reported as changed');
+		$this->assertSame("1.2.3.4\n5.6.7.8\n", file_get_contents($this->tmpFile), 'content must be preserved with exactly one appended newline');
+	}
+
+	public function testSingleByteFileNoNewlineGetsTerminated(): void
+	{
+		file_put_contents($this->tmpFile, 'x');
+		$this->assertTrue(pfb_ensure_trailing_newline($this->tmpFile));
+		$this->assertSame("x\n", file_get_contents($this->tmpFile));
+	}
+
+	public function testAlreadyTerminatedFileIsUntouched(): void
+	{
+		file_put_contents($this->tmpFile, "a\nb\n");
+		$this->assertFalse(pfb_ensure_trailing_newline($this->tmpFile), 'an already-terminated file must report no change');
+		$this->assertSame("a\nb\n", file_get_contents($this->tmpFile), 'content must be byte-identical -- no double newline');
+	}
+
+	public function testEmptyFileIsUntouched(): void
+	{
+		file_put_contents($this->tmpFile, '');
+		$this->assertFalse(pfb_ensure_trailing_newline($this->tmpFile), 'an empty file has nothing to weld -- must not gain a spurious blank line');
+		$this->assertSame('', file_get_contents($this->tmpFile));
+	}
+
+	public function testMissingPathReturnsFalseWithoutError(): void
+	{
+		$missing = $this->tmpFile . '-does-not-exist';
+		$this->assertFalse(pfb_ensure_trailing_newline($missing));
+	}
+
+	public function testDirectoryPathReturnsFalseWithoutError(): void
+	{
+		// Probed: fopen(dir, 'rb') succeeds and fseek(-1, SEEK_END) even returns 0,
+		// but fopen(dir, 'ab') fails -- the append branch is the real guard here.
+		$dir = sys_get_temp_dir() . '/pfb_ensure_nl_dir_' . uniqid();
+		mkdir($dir);
+		try {
+			$this->assertFalse(pfb_ensure_trailing_newline($dir), 'a directory must never be written to');
+		} finally {
+			rmdir($dir);
+		}
+	}
+
+	public function testLoneNewlineByteIsUntouched(): void
+	{
+		file_put_contents($this->tmpFile, "\n");
+		$this->assertFalse(pfb_ensure_trailing_newline($this->tmpFile));
+		$this->assertSame("\n", file_get_contents($this->tmpFile));
+	}
+}

--- a/tests/php/EnsureTrailingNewlineTest.php
+++ b/tests/php/EnsureTrailingNewlineTest.php
@@ -13,6 +13,61 @@ use PHPUnit\Framework\TestCase;
  * Brand-new function (no prior behaviour to be wrong) -- tests assert real
  * behaviour, not mere existence.
  */
+/**
+ * Seekable stream whose every read returns '' -- the fread()-after-fseek()
+ * short-read shape (a racing truncation, a device path). Records fopen()
+ * modes so a test can assert no append-mode reopen happens. Single-consumer,
+ * so it lives in this file (unlike the shared PfbTruncatedReadStreamWrapper).
+ */
+final class PfbEmptyReadSeekableStream
+{
+	/** @var resource|null */
+	public $context;
+	/** @var list<string> */
+	public static array $openModes = [];
+
+	public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+	{
+		self::$openModes[] = $mode;
+		return TRUE;
+	}
+
+	public function stream_read(int $count): string
+	{
+		return '';
+	}
+
+	public function stream_write(string $data): int
+	{
+		return strlen($data);
+	}
+
+	public function stream_seek(int $offset, int $whence = SEEK_SET): bool
+	{
+		return TRUE;
+	}
+
+	public function stream_tell(): int
+	{
+		return 0;
+	}
+
+	public function stream_eof(): bool
+	{
+		return TRUE;
+	}
+
+	/** @return array<string,int> */
+	public function stream_stat(): array
+	{
+		return [];
+	}
+
+	public function stream_close(): void
+	{
+	}
+}
+
 #[CoversFunction('pfb_ensure_trailing_newline')]
 final class EnsureTrailingNewlineTest extends TestCase
 {
@@ -82,5 +137,27 @@ final class EnsureTrailingNewlineTest extends TestCase
 		file_put_contents($this->tmpFile, "\n");
 		$this->assertFalse(pfb_ensure_trailing_newline($this->tmpFile));
 		$this->assertSame("\n", file_get_contents($this->tmpFile));
+	}
+
+	/** A short/failed last-byte read (fread '' after a successful open+seek --
+	 *  probed via the wrapper above) cannot tell terminated from not: the file
+	 *  must be left alone and never reopened for append. */
+	public function testShortReadLeavesFileAloneAndReportsNoChange(): void
+	{
+		stream_wrapper_register('pfbemptyread', PfbEmptyReadSeekableStream::class);
+		try {
+			PfbEmptyReadSeekableStream::$openModes = [];
+			$this->assertFalse(
+				pfb_ensure_trailing_newline('pfbemptyread://feed'),
+				'a failed/short read must report no change -- a spurious append here would corrupt a stored feed'
+			);
+			$this->assertSame(
+				['rb'],
+				PfbEmptyReadSeekableStream::$openModes,
+				'the file must never be reopened for append after a failed/short last-byte read'
+			);
+		} finally {
+			stream_wrapper_unregister('pfbemptyread');
+		}
 	}
 }

--- a/tests/php/GeoipOrigTrailingNewlineWiringTest.php
+++ b/tests/php/GeoipOrigTrailingNewlineWiringTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1263: the GeoIP continent builder rewrites a stored '.orig' via
+ * @rename() OUTSIDE pfb_download() -- its newline-termination guarantee never
+ * runs on this path either. Source-inspection pin, same rationale as
+ * GunzipTrailingNewlineWiringTest.
+ */
+final class GeoipOrigTrailingNewlineWiringTest extends TestCase
+{
+	private static string $source;
+
+	public static function setUpBeforeClass(): void
+	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
+		);
+		if ($source === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		}
+		self::$source = $source;
+	}
+
+	public function testEnsureTrailingNewlineRunsAfterTheGeoipRename(): void
+	{
+		$renamePos = strpos(self::$source, '@rename("{$pfb[\'geoip_tmp\']}", "{$pfborig}/{$cc_alias}.orig");');
+		$this->assertNotFalse($renamePos, 'vacuity: the GeoIP continent .orig rename site must exist');
+
+		$copyPos = strpos(
+			self::$source,
+			'@copy("{$pfborig}/{$cc_alias}.orig", "{$pfbfolder}/{$cc_alias}.txt");',
+			$renamePos
+		);
+		$this->assertNotFalse($copyPos, 'vacuity: the following .txt mirror copy must exist');
+
+		$between = substr(self::$source, $renamePos, $copyPos - $renamePos);
+		$this->assertStringContainsString('pfb_ensure_trailing_newline("{$pfborig}/{$cc_alias}.orig")', $between,
+			'the rebuilt .orig must be normalized before the .txt mirror copy propagates its raw bytes');
+	}
+}

--- a/tests/php/GunzipTrailingNewlineWiringTest.php
+++ b/tests/php/GunzipTrailingNewlineWiringTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1263: the ET-IQRisk reuse path rebuilds '.orig' via a raw gunzip exec()
+ * OUTSIDE pfb_download() -- pfb_download()'s own newline-termination guarantee
+ * (DownloadTrailingNewlineWiringTest) never runs on this path. Source-inspection
+ * pin (same technique as DownloadTrailingNewlineWiringTest): the surrounding
+ * sync_package_pfblockerng() is thousands of lines and drives real cURL/appliance
+ * exec, so this is not behaviourally exercised here -- the append behaviour itself
+ * is proven in EnsureTrailingNewlineTest.
+ */
+final class GunzipTrailingNewlineWiringTest extends TestCase
+{
+	private static string $source;
+
+	public static function setUpBeforeClass(): void
+	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
+		);
+		if ($source === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		}
+		self::$source = $source;
+	}
+
+	public function testEnsureTrailingNewlineRunsAfterTheGunzipExec(): void
+	{
+		$gunzipPos = strpos(self::$source, 'exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$file_org_esc}");');
+		$this->assertNotFalse($gunzipPos, 'vacuity: the ET-IQRisk gunzip exec site must exist');
+
+		$nextExecPos = strpos(self::$source, "exec(\"{\$pfb['script']} et {\$header_esc}", $gunzipPos);
+		$this->assertNotFalse($nextExecPos, 'vacuity: the following ET-processing exec must exist');
+
+		$between = substr(self::$source, $gunzipPos, $nextExecPos - $gunzipPos);
+		$this->assertStringContainsString('pfb_ensure_trailing_newline("{$file_dwn}.orig")', $between,
+			'the reuse path must normalize the rebuilt .orig -- else a gzip payload without a trailing '
+			. 'newline stays welded downstream, exactly like the pfb_download() path this bypasses');
+	}
+}

--- a/tests/shell/bench_cat_weld_spec.sh
+++ b/tests/shell/bench_cat_weld_spec.sh
@@ -1,0 +1,92 @@
+#shellcheck shell=sh
+# issue #1263, sites 7-9: dev-only benchmark tooling (scripts/bench_ip_recompute.sh,
+# scripts/misc/bench_aggregate_union.sh) hit the identical multi-file `cat` weld as
+# the production sites -- fixed with the same `awk 1` drop-in. Both scripts have
+# zero pre-existing test harness (heavy synthetic-data generation, `bench_aggregate_union.sh`
+# runs under `set -eu`) and are never invoked by CI, so a full-script run is out of
+# scope; each spec below extracts the exact COMMITTED text (never a hand-retyped
+# copy) of the isolable unit under test and exercises it directly against a
+# real weld fixture.
+
+Describe 'bench_ip_recompute.sh union_cksum(): the committed function never welds member records (issue #1263 site 7)'
+  extract_union_cksum() {
+    sed -n '/^union_cksum() {/,/^}/p' "$1"
+  }
+
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/ipru.XXXXXX")"
+    memberdir="${work}/members"; mkdir -p "$memberdir"
+    # All three unterminated -- deterministic single-line weld regardless of glob order.
+    printf '10.0.0.1' > "${memberdir}/a.txt"
+    printf '10.0.0.2' > "${memberdir}/b.txt"
+    printf '10.0.0.3' > "${memberdir}/c.txt"
+    funcsrc="$(extract_union_cksum "${PFB_ROOT}/scripts/bench_ip_recompute.sh")"
+    expected="$(printf '10.0.0.1\n10.0.0.2\n10.0.0.3\n' | LC_ALL=C sort -u | cksum)"
+  }
+  cleanup() { rm -rf "$work"; }
+  Before 'setup'
+  After 'cleanup'
+
+  It 'the committed function is extractable (vacuity guard)'
+    When call test -n "${funcsrc}"
+    The status should be success
+  End
+
+  It 'checksums the true 3-member set, never a welded/fused record'
+    eval "$funcsrc"
+    got="$(union_cksum "$memberdir")"
+    When call test "$got" = "$expected"
+    The status should be success
+  End
+End
+
+Describe 'bench_aggregate_union.sh member concat: the committed lines never weld member records (issue #1263 sites 8/9)'
+  extract_stmt() {
+    # $1 = file  $2 = anchor grep pattern
+    line="$(grep -n "$2" "$1" | head -n 1 | cut -d: -f1)"
+    [ -n "$line" ] || return 1
+    sed -n "${line}p" "$1"
+  }
+
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/aggu.XXXXXX")"
+    memberdir="${work}/members"; mkdir -p "$memberdir"
+    workdir="${work}/wd"; mkdir -p "$workdir"
+    union_sorted="${workdir}/union.sorted"
+    printf '10.0.0.1' > "${memberdir}/deny_a.txt"
+    printf '10.0.0.2' > "${memberdir}/deny_b.txt"
+    printf '10.0.0.3' > "${memberdir}/deny_c.txt"
+    countstmt="$(extract_stmt "${PFB_ROOT}/scripts/misc/bench_aggregate_union.sh" 'input_count="\$(')"
+    unionstmt="$(extract_stmt "${PFB_ROOT}/scripts/misc/bench_aggregate_union.sh" 'run_timed sh -c')"
+  }
+  cleanup() { rm -rf "$work"; }
+  Before 'setup'
+  After 'cleanup'
+
+  It 'both committed lines are extractable (vacuity guard)'
+    When call test -n "${countstmt}" -a -n "${unionstmt}"
+    The status should be success
+  End
+
+  It 'site 8: input_count is the true 3 lines, never a welded 1'
+    eval "$countstmt"
+    When call test "$input_count" = 3
+    The status should be success
+  End
+
+  It 'site 9: the written union file holds the true 3 unique members, never a fused record'
+    # run_timed isn't defined here (it just wraps timing) -- strip the
+    # wrapper and eval the inner `sh -c "..."` payload directly. The payload
+    # was written escaped for ITS OWN enclosing double quotes (\"...\"); undo
+    # that escaping now that those enclosing quotes are gone.
+    inner="$(printf '%s\n' "$unionstmt" | sed -e 's/^run_timed sh -c "//' -e 's/"$//' -e 's/\\"/"/g')"
+    eval "$inner"
+    The path "${union_sorted}" should be file
+    The contents of file "${union_sorted}" should include '10.0.0.1'
+    The contents of file "${union_sorted}" should include '10.0.0.2'
+    The contents of file "${union_sorted}" should include '10.0.0.3'
+    The contents of file "${union_sorted}" should not include '10.0.0.110.0.0.2'
+    linecount="$(grep -c ^ "${union_sorted}")"
+    The variable linecount should equal 3
+  End
+End

--- a/tests/shell/bench_cat_weld_spec.sh
+++ b/tests/shell/bench_cat_weld_spec.sh
@@ -48,8 +48,8 @@ End
 
 Describe 'bench_aggregate_union.sh member concat: the committed lines never weld member records (issue #1263, dev-tooling only -- NOT the production pfb_aggregate() site)'
   extract_stmt() {
-    # $1 = file  $2 = anchor grep pattern
-    line="$(grep -n "$2" "$1" | head -n 1 | cut -d: -f1)"
+    # $1 = file  $2 = literal anchor substring (-F: anchors are committed text, not regexes)
+    line="$(grep -Fn "$2" "$1" | head -n 1 | cut -d: -f1)"
     [ -n "$line" ] || return 1
     sed -n "${line}p" "$1"
   }
@@ -62,7 +62,7 @@ Describe 'bench_aggregate_union.sh member concat: the committed lines never weld
     printf '10.0.0.1' > "${memberdir}/deny_a.txt"
     printf '10.0.0.2' > "${memberdir}/deny_b.txt"
     printf '10.0.0.3' > "${memberdir}/deny_c.txt"
-    countstmt="$(extract_stmt "${PFB_ROOT}/scripts/misc/bench_aggregate_union.sh" 'input_count="\$(')"
+    countstmt="$(extract_stmt "${PFB_ROOT}/scripts/misc/bench_aggregate_union.sh" 'input_count="$(')"
     unionstmt="$(extract_stmt "${PFB_ROOT}/scripts/misc/bench_aggregate_union.sh" 'run_timed sh -c')"
   }
   cleanup() { rm -rf "$work"; }

--- a/tests/shell/bench_cat_weld_spec.sh
+++ b/tests/shell/bench_cat_weld_spec.sh
@@ -90,3 +90,43 @@ Describe 'bench_aggregate_union.sh member concat: the committed lines never weld
     The variable linecount should equal 3
   End
 End
+
+Describe 'bench_aggregate_union.sh: the iprange recombine never welds v4 onto v6 (issue #1263 site 10)'
+  # The straggler the brief's own enumeration missed: `cat a4.txt a6.txt > union_agg`
+  # recombines the per-family aggregates. An unterminated a4.txt welds its last IPv4
+  # CIDR onto a6.txt's first IPv6 CIDR, fusing a garbage record into the union.
+  # $pathaggregate is an external binary and is not invoked here -- the CONCAT is the
+  # unit under test, so its exact committed text is extracted and exercised directly.
+  extract_recombine() {
+    grep -F 'a4.txt' "$1" | sed -e 's/.*; *//' -e 's/\\"/"/g' -e 's/"$//'
+  }
+
+  setup() {
+    workdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/bau.XXXXXX")"
+    union_agg="${workdir}/union.agg"
+    # a4 UNTERMINATED -- its last record welds onto a6's first without the fix.
+    printf '192.0.2.0/24\n198.51.100.0/24' > "${workdir}/a4.txt"
+    printf '2001:db8::/32\n' > "${workdir}/a6.txt"
+    stmt="$(extract_recombine "${PFB_ROOT}/scripts/misc/bench_aggregate_union.sh")"
+  }
+  cleanup() { rm -rf "$workdir"; }
+  Before 'setup'
+  After 'cleanup'
+
+  It 'the committed recombine statement is extractable (vacuity guard)'
+    When call test -n "${stmt}"
+    The status should be success
+  End
+
+  It 'the union holds all three real CIDRs and no fused v4/v6 record'
+    eval "$stmt"
+    The path "${union_agg}" should be file
+    The contents of file "${union_agg}" should include '192.0.2.0/24'
+    The contents of file "${union_agg}" should include '198.51.100.0/24'
+    The contents of file "${union_agg}" should include '2001:db8::/32'
+    The contents of file "${union_agg}" should not include '198.51.100.0/242001:db8::/32'
+    linecount="$(grep -c ^ "${union_agg}")"
+    The variable linecount should equal 3
+  End
+End
+

--- a/tests/shell/bench_cat_weld_spec.sh
+++ b/tests/shell/bench_cat_weld_spec.sh
@@ -1,14 +1,20 @@
 #shellcheck shell=sh
-# issue #1263, sites 7-9: dev-only benchmark tooling (scripts/bench_ip_recompute.sh,
+# issue #1263: dev-only benchmark tooling (scripts/bench_ip_recompute.sh,
 # scripts/misc/bench_aggregate_union.sh) hit the identical multi-file `cat` weld as
-# the production sites -- fixed with the same `awk 1` drop-in. Both scripts have
-# zero pre-existing test harness (heavy synthetic-data generation, `bench_aggregate_union.sh`
-# runs under `set -eu`) and are never invoked by CI, so a full-script run is out of
-# scope; each spec below extracts the exact COMMITTED text (never a hand-retyped
-# copy) of the isolable unit under test and exercises it directly against a
-# real weld fixture.
+# the production sites -- fixed with the same `awk 1` drop-in. These scripts are
+# NOT pfBlockerNG production code and are never invoked by CI; this file's
+# coverage is a courtesy for dev tooling only. It is NOT a substitute for the
+# real ADR-11 union site (pfb_aggregate() in pfblockerng.sh, covered by
+# pfblockerng_aggregate_weld_spec.sh) -- a prior revision of this file mislabeled
+# the bench_aggregate_union.sh coverage below as counting toward the production
+# site enumeration, which let the real pfb_aggregate() site ship unfixed.
+# Both scripts have zero pre-existing test harness (heavy synthetic-data
+# generation, `bench_aggregate_union.sh` runs under `set -eu`), so a full-script
+# run is out of scope; each spec below extracts the exact COMMITTED text (never a
+# hand-retyped copy) of the isolable unit under test and exercises it directly
+# against a real weld fixture.
 
-Describe 'bench_ip_recompute.sh union_cksum(): the committed function never welds member records (issue #1263 site 7)'
+Describe 'bench_ip_recompute.sh union_cksum(): the committed function never welds member records (issue #1263, dev-tooling only)'
   extract_union_cksum() {
     sed -n '/^union_cksum() {/,/^}/p' "$1"
   }
@@ -40,7 +46,7 @@ Describe 'bench_ip_recompute.sh union_cksum(): the committed function never weld
   End
 End
 
-Describe 'bench_aggregate_union.sh member concat: the committed lines never weld member records (issue #1263 sites 8/9)'
+Describe 'bench_aggregate_union.sh member concat: the committed lines never weld member records (issue #1263, dev-tooling only -- NOT the production pfb_aggregate() site)'
   extract_stmt() {
     # $1 = file  $2 = anchor grep pattern
     line="$(grep -n "$2" "$1" | head -n 1 | cut -d: -f1)"
@@ -68,13 +74,13 @@ Describe 'bench_aggregate_union.sh member concat: the committed lines never weld
     The status should be success
   End
 
-  It 'site 8: input_count is the true 3 lines, never a welded 1'
+  It 'input_count is the true 3 lines, never a welded 1'
     eval "$countstmt"
     When call test "$input_count" = 3
     The status should be success
   End
 
-  It 'site 9: the written union file holds the true 3 unique members, never a fused record'
+  It 'the written union file holds the true 3 unique members, never a fused record'
     # run_timed isn't defined here (it just wraps timing) -- strip the
     # wrapper and eval the inner `sh -c "..."` payload directly. The payload
     # was written escaped for ITS OWN enclosing double quotes (\"...\"); undo
@@ -91,7 +97,7 @@ Describe 'bench_aggregate_union.sh member concat: the committed lines never weld
   End
 End
 
-Describe 'bench_aggregate_union.sh: the iprange recombine never welds v4 onto v6 (issue #1263 site 10)'
+Describe 'bench_aggregate_union.sh: the iprange recombine never welds v4 onto v6 (issue #1263, dev-tooling only)'
   # The straggler the brief's own enumeration missed: `cat a4.txt a6.txt > union_agg`
   # recombines the per-family aggregates. An unterminated a4.txt welds its last IPv4
   # CIDR onto a6.txt's first IPv6 CIDR, fusing a garbage record into the union.

--- a/tests/shell/pfblockerng_aggregate_weld_spec.sh
+++ b/tests/shell/pfblockerng_aggregate_weld_spec.sh
@@ -8,6 +8,8 @@
 Describe 'pfb_aggregate() member union never welds records across an unterminated file (issue #1263)'
   setup() {
     work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/aggweld.XXXXXX")"
+    # tempfile/dedupfile/errorlog deliberately shadow pfb_aggregate()'s own globals
+    # (normally seeded by pfb_make_tmpdir(), which PFB_SOURCED=1 sourcing skips).
     tempfile="${work}/t1"
     dedupfile="${work}/dedup"
     errorlog="${work}/err.log"

--- a/tests/shell/pfblockerng_aggregate_weld_spec.sh
+++ b/tests/shell/pfblockerng_aggregate_weld_spec.sh
@@ -1,0 +1,40 @@
+#shellcheck shell=sh
+# issue #1263 (PR #1271 gap): pfb_aggregate()'s member-file union still ran a bare
+# `cat` over the memberlist -- an unterminated member welds its last line onto the
+# next member's first line, silently dropping a real address and inventing a bogus
+# one. This is the REAL ADR-11 union site (pfblockerng.sh), not the
+# scripts/misc/bench_aggregate_union.sh benchmark stand-in PR #1271 fixed instead.
+
+Describe 'pfb_aggregate() member union never welds records across an unterminated file (issue #1263)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/aggweld.XXXXXX")"
+    tempfile="${work}/t1"
+    dedupfile="${work}/dedup"
+    errorlog="${work}/err.log"
+    memberlist="${work}/members"
+    aggout="${work}/agg.txt"
+    consumer="${work}/agg.lst"
+  }
+  cleanup() { rm -rf "${work}"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'unions an unterminated member with a terminated one into TWO real lines, never a welded record'
+    # Member 1 has NO trailing newline; member 2 is properly terminated.
+    printf '1.1.1.1' > "${work}/m1"
+    printf '2.2.2.2\n' > "${work}/m2"
+    printf '%s\n%s\n' "${work}/m1" "${work}/m2" > "${memberlist}"
+
+    When call pfb_aggregate agg v6 "${memberlist}" "${aggout}" "${consumer}"
+
+    The status should be success
+    # The welded run logs "union 1 -> 1 CIDRs" -- the reported count is itself the bug signal.
+    The stdout should include 'union 2 -> 2 CIDRs'
+    The contents of file "${aggout}" should include '1.1.1.1'
+    The contents of file "${aggout}" should include '2.2.2.2'
+    The contents of file "${aggout}" should not include '1.1.1.12.2.2.2'
+    linecount="$(grep -c ^ "${aggout}")"
+    The variable linecount should equal 2
+  End
+End

--- a/tests/shell/pfblockerng_cat_weld_more_spec.sh
+++ b/tests/shell/pfblockerng_cat_weld_more_spec.sh
@@ -1,0 +1,100 @@
+#shellcheck shell=sh
+# issue #1263: a tree-wide re-enumeration found further bare multi-file/append
+# `cat` concat sites in pfblockerng.sh. Same drop-in fix as the rest of the
+# file: `awk 1` (a record terminator is guaranteed on every emitted line, even
+# when the source lacked one). Each statement is extracted verbatim from the
+# committed file (never a hand-retyped copy) and exercised directly, mirroring
+# the technique already used by pfblockerng_processet_weld_spec.sh and
+# bench_cat_weld_spec.sh for concat statements embedded in functions too heavy
+# to invoke wholesale.
+#
+# pfb_recompute_finish()'s matchexempt concat is deliberately NOT covered here:
+# both its inputs are written by awk/grep, which always terminate their own
+# output, so it cannot weld. Left untouched to avoid colliding with the
+# in-flight matchdedup work on that function.
+
+extract_stmt() {
+  # $1 = file  $2 = literal anchor substring
+  line="$(grep -Fn "$2" "$1" | head -n 1 | cut -d: -f1)"
+  [ -n "$line" ] || return 1
+  sed -n "${line}p" "$1" | sed 's/^[[:space:]]*//'
+}
+
+Describe 'reputation_pmax() masterfile append: addfile concat always leaves masterfile newline-terminated (issue #1263)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/addfileweld.XXXXXX")"
+    addfile="${work}/add.txt"
+    masterfile="${work}/masterfile"
+    # masterfile mirrors the real upstream invariant: it was just rebuilt by the
+    # preceding `awk ... > tempfile2 && mv -f tempfile2 masterfile` (awk always
+    # terminates its own last emitted record), so it enters this append terminated.
+    printf 'x 192.0.2.10\n' > "${masterfile}"
+    # addfile is the adversarial input: no trailing newline.
+    printf 'y 192.0.2.20' > "${addfile}"
+    stmt="$(extract_stmt "${PFB_PKGDIR}/pfblockerng.sh" '"${addfile}" >> "${masterfile}"')"
+  }
+  cleanup() { rm -rf "$work"; }
+  Before 'setup'
+  After 'cleanup'
+
+  It 'the committed line is extractable (vacuity guard)'
+    When call test -n "${stmt}"
+    The status should be success
+  End
+
+  It 'masterfile stays newline-terminated, never inheriting addfile bare tail'
+    eval "$stmt"
+    The contents of file "${masterfile}" should include 'x 192.0.2.10'
+    The contents of file "${masterfile}" should include 'y 192.0.2.20'
+    tail_byte="$(tail -c1 "${masterfile}" | od -An -tx1 | tr -d ' ')"
+    The variable tail_byte should equal '0a'
+  End
+End
+
+Describe 'processet() etblock/etmatch tempfile accumulation: multi-category concat never welds records (issue #1263)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/etaccum.XXXXXX")"
+    etdir="${work}/ET"; mkdir -p "$etdir"
+    tempfile="${work}/t1"
+    tempfile2="${work}/t2"
+    : > "$tempfile"
+    : > "$tempfile2"
+    # Two selected categories, the first unterminated -- deterministic single-line
+    # weld pre-fix regardless of iteration order (both accumulators are seeded
+    # identically so the same fixture drives both the block and match statements).
+    printf '1.2.3.4' > "${etdir}/ET_Cnc.txt"
+    printf '5.6.7.8\n' > "${etdir}/ET_Bot.txt"
+    blockstmt="$(extract_stmt "${PFB_PKGDIR}/pfblockerng.sh" '"${etdir}/${list}.txt" >> "${tempfile}"')"
+    matchstmt="$(extract_stmt "${PFB_PKGDIR}/pfblockerng.sh" '"${etdir}/${list}.txt" >> "${tempfile2}"')"
+  }
+  cleanup() { rm -rf "$work"; }
+  Before 'setup'
+  After 'cleanup'
+
+  It 'both committed lines are extractable (vacuity guard)'
+    When call test -n "${blockstmt}" -a -n "${matchstmt}"
+    The status should be success
+  End
+
+  It 'etblock accumulation holds both real category files as TWO lines, never a fused record'
+    for list in ET_Cnc ET_Bot; do
+      eval "$blockstmt"
+    done
+    The contents of file "${tempfile}" should include '1.2.3.4'
+    The contents of file "${tempfile}" should include '5.6.7.8'
+    The contents of file "${tempfile}" should not include '1.2.3.45.6.7.8'
+    linecount="$(grep -c ^ "${tempfile}")"
+    The variable linecount should equal 2
+  End
+
+  It 'etmatch accumulation holds both real category files as TWO lines, never a fused record'
+    for list in ET_Cnc ET_Bot; do
+      eval "$matchstmt"
+    done
+    The contents of file "${tempfile2}" should include '1.2.3.4'
+    The contents of file "${tempfile2}" should include '5.6.7.8'
+    The contents of file "${tempfile2}" should not include '1.2.3.45.6.7.8'
+    linecount="$(grep -c ^ "${tempfile2}")"
+    The variable linecount should equal 2
+  End
+End

--- a/tests/shell/pfblockerng_cat_weld_more_spec.sh
+++ b/tests/shell/pfblockerng_cat_weld_more_spec.sh
@@ -9,9 +9,8 @@
 # to invoke wholesale.
 #
 # pfb_recompute_finish()'s matchexempt concat is deliberately NOT covered here:
-# both its inputs are written by awk/grep, which always terminate their own
-# output, so it cannot weld. Left untouched to avoid colliding with the
-# in-flight matchdedup work on that function.
+# both its inputs are written exclusively by awk `print ... >> file`, which
+# terminates every record, so it cannot weld.
 
 extract_stmt() {
   # $1 = file  $2 = literal anchor substring

--- a/tests/shell/pfblockerng_cat_weld_spec.sh
+++ b/tests/shell/pfblockerng_cat_weld_spec.sh
@@ -1,0 +1,149 @@
+#shellcheck shell=sh
+# issue #1263: cat concatenates BYTES, not records. When a multi-file `cat`
+# pipeline's non-final input lacks a trailing newline, its last line welds
+# onto the next file's first line -- corrupting a record and undercounting.
+# closingprocess()/processet() switched every multi-file `cat` to `awk 1`
+# (a drop-in that supplies the missing terminator at no extra fork).
+#
+# Fixtures below use files that ALL lack a trailing newline (not just the
+# first) so the weld reproduces deterministically regardless of `find`'s
+# filesystem enumeration order between same-directory files -- with only ONE
+# file unterminated, whether IT lands first or last in `find`'s listing (and
+# therefore whether a weld occurs at all) depends on that order.
+
+Describe 'closingprocess() Original IP count: aggcount sum never welds digits together (issue #1263 site 3)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/aggweld.XXXXXX")"
+    pfborig="${work}/orig/"; pfbdeny="${work}/deny/"
+    pfbpermit="${work}/permit/"; pfbmatch="${work}/match/"; pfbnative="${work}/native/"
+    mkdir -p "$pfborig" "$pfbdeny" "$pfbpermit" "$pfbmatch" "$pfbnative"
+    masterfile="${work}/masterfile"; mastercat="${work}/mastercat"
+    tempfile="${work}/t1"; errorlog="${work}/err.log"; now="now"
+    ip_placeholder2="127.0.0.1"
+    pathpfctl="${work}/pfctl"; printf '#!/bin/sh\n' > "$pathpfctl"; chmod +x "$pathpfctl"
+    alias="off"
+    # Three sidecars, ALL unterminated -- true sum is 600; a cat weld glues
+    # at least two of them into one bogus number (e.g. the nine-character
+    # concatenation of "100"+"200"+"300" in whatever order `find` returns
+    # them), never 600.
+    printf '100' > "${pfborig}FeedA_v4.aggcount"
+    printf '200' > "${pfborig}FeedB_v4.aggcount"
+    printf '300' > "${pfborig}FeedC_v4.aggcount"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'sums 100+200+300=600, never a digit-welded number'
+    When call closingprocess
+    The status should be success
+    The stdout should include '[ Original IP count   ]  [ 600 ]'
+  End
+End
+
+Describe 'closingprocess() Original IP count: raw *_v4.orig fallback never welds lines together (issue #1263 site 4)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/origweld.XXXXXX")"
+    pfborig="${work}/orig/"; pfbdeny="${work}/deny/"
+    pfbpermit="${work}/permit/"; pfbmatch="${work}/match/"; pfbnative="${work}/native/"
+    mkdir -p "$pfborig" "$pfbdeny" "$pfbpermit" "$pfbmatch" "$pfbnative"
+    masterfile="${work}/masterfile"; mastercat="${work}/mastercat"
+    tempfile="${work}/t1"; errorlog="${work}/err.log"; now="now"
+    ip_placeholder2="127.0.0.1"
+    pathpfctl="${work}/pfctl"; printf '#!/bin/sh\n' > "$pathpfctl"; chmod +x "$pathpfctl"
+    alias="off"
+    # No .aggcount sidecars -> counto's first pass sums to 0 -> the raw
+    # *_v4.orig fallback runs. Three feeds, ALL unterminated (one IP each);
+    # true count is 3. A cat weld fuses all three into ONE line (there is no
+    # newline anywhere in the concatenated stream), reporting 1.
+    printf '1.1.1.1' > "${pfborig}FeedA_v4.orig"
+    printf '2.2.2.2' > "${pfborig}FeedB_v4.orig"
+    printf '3.3.3.3' > "${pfborig}FeedC_v4.orig"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'counts the true 3 records, never the welded 1'
+    When call closingprocess
+    The status should be success
+    The stdout should include '[ Original IP count   ]  [ 3 ]'
+    The stdout should not include '[ Original IP count   ]  [ 1 ]'
+  End
+End
+
+Describe 'closingprocess() Database Sanity check: deny-folder re-scan never welds records together (issue #1263 sites 5/6)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/denyweld.XXXXXX")"
+    pfborig="${work}/orig/"; pfbdeny="${work}/deny/"
+    pfbpermit="${work}/permit/"; pfbmatch="${work}/match/"; pfbnative="${work}/native/"
+    mkdir -p "$pfborig" "$pfbdeny" "$pfbpermit" "$pfbmatch" "$pfbnative"
+    masterfile="${work}/masterfile"; mastercat="${work}/mastercat"
+    tempfile="${work}/t1"; errorlog="${work}/err.log"; now="now"
+    ip_placeholder2="127.0.0.1"
+    pathpfctl="${work}/pfctl"; printf '#!/bin/sh\n' > "$pathpfctl"; chmod +x "$pathpfctl"
+    alias="on"
+    # mastercat (s1's source) is a clean, properly-terminated 3-row file --
+    # the true membership the deny folder must match.
+    printf 'FeedA_v4 192.0.2.1\nFeedB_v4 192.0.2.2\nFeedC_v4 192.0.2.3\n' > "$masterfile"
+    printf '192.0.2.1\n192.0.2.2\n192.0.2.3\n' > "$mastercat"
+    # The deny folder re-scan (s2/s4) -- 3 files, ALL unterminated. A cat
+    # weld fuses all three IPs into ONE bogus record (no true IP survives
+    # verbatim), so s2 undercounts to 1 and the sanity check spuriously FAILS
+    # even though the real membership matches.
+    printf '192.0.2.1' > "${pfbdeny}FeedA_v4.txt"
+    printf '192.0.2.2' > "${pfbdeny}FeedB_v4.txt"
+    printf '192.0.2.3' > "${pfbdeny}FeedC_v4.txt"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'passes the sanity check -- s2 counts the true 3 deny records, no fused garbage record'
+    When call closingprocess
+    The status should be success
+    The stdout should include 'Database Sanity check [  PASSED  ]'
+    The stdout should not include 'FAILED'
+  End
+End
+
+# A2 (data-producing site): the s4 "Deny folder/Masterfile uniq check" cross-file
+# duplicate detector (sort | uniq -d) is itself a real regression channel for the
+# weld -- a fused garbage line is unique (it appears once), so a genuine
+# cross-file duplicate that gets welded away is SILENTLY MISSED, not merely
+# miscounted. Both deny files hold the identical IP so the weld's output is
+# deterministic regardless of find's enumeration order between them (same glued
+# string either way): the true duplicate is invisible pre-fix, caught post-fix.
+Describe 'closingprocess() deny-folder duplicate detection: a real cross-file duplicate is never hidden by a weld (issue #1263 site 6)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/denydup.XXXXXX")"
+    pfborig="${work}/orig/"; pfbdeny="${work}/deny/"
+    pfbpermit="${work}/permit/"; pfbmatch="${work}/match/"; pfbnative="${work}/native/"
+    mkdir -p "$pfborig" "$pfbdeny" "$pfbpermit" "$pfbmatch" "$pfbnative"
+    masterfile="${work}/masterfile"; mastercat="${work}/mastercat"
+    tempfile="${work}/t1"; errorlog="${work}/err.log"; now="now"
+    ip_placeholder2="127.0.0.1"
+    pathpfctl="${work}/pfctl"; printf '#!/bin/sh\n' > "$pathpfctl"; chmod +x "$pathpfctl"
+    alias="on"
+    printf 'x 1.1.1.1\n' > "$masterfile"
+    printf '1.1.1.1\n' > "$mastercat"
+    # The SAME IP in both deny files, unterminated -- a real cross-file
+    # duplicate that `sort | uniq -d` must report.
+    printf '192.0.2.5' > "${pfbdeny}FeedA_v4.txt"
+    printf '192.0.2.5' > "${pfbdeny}FeedB_v4.txt"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'reports the real duplicate IP -- the weld cannot hide it inside a fused record'
+    When call closingprocess
+    The status should be success
+    The stdout should include 'Deny folder/Masterfile uniq check'
+    The stdout should include '192.0.2.5'
+  End
+End

--- a/tests/shell/pfblockerng_processet_weld_spec.sh
+++ b/tests/shell/pfblockerng_processet_weld_spec.sh
@@ -1,0 +1,45 @@
+#shellcheck shell=sh
+# issue #1263, site 2: processet()'s `counto="$(cat "${etdir}"/ET_* | grep -cv ...)"`
+# welds an unterminated ET_*.txt onto its neighbour, same as the other 8
+# `cat`-of-a-multi-file-glob sites. processet() itself REGENERATES etdir/ET_*.txt
+# from '.orig' via grep+cut at every call, so a fixture can't durably plant an
+# unterminated derived file through the public processet() entry point.
+# Extracting the counto assignment's literal, currently-committed text (never a
+# hand-retyped copy -- avoids testing a stale/wrong shape) and eval'ing it
+# against a directly-crafted etdir proves the exact shipped pipeline, order-
+# independent (both fixture files lack a trailing newline, so the weld -- one
+# fused line, zero internal newlines -- is deterministic regardless of which
+# file `awk`/`cat` reads first).
+
+Describe 'processet() ET_* count line: the exact committed pipeline never welds records (issue #1263 site 2)'
+  extract_counto_assignment() {
+    # $1 = path to pfblockerng.sh
+    line="$(grep -n 'ET_\* | grep -cv' "$1" | head -n 1 | cut -d: -f1)"
+    [ -n "$line" ] || return 1
+    sed -n "${line}p" "$1" | sed 's/;.*//'
+  }
+
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/etweld.XXXXXX")"
+    etdir="${work}/ET"
+    mkdir -p "$etdir"
+    # Both unterminated -- deterministic single-line weld regardless of glob order.
+    printf '1.2.3.4' > "${etdir}/ET_A.txt"
+    printf '5.6.7.8' > "${etdir}/ET_B.txt"
+    stmt="$(extract_counto_assignment "${PFB_PKGDIR}/pfblockerng.sh")"
+  }
+  cleanup() { rm -rf "$work"; }
+  Before 'setup'
+  After 'cleanup'
+
+  It 'the committed counto line exists and is extractable (vacuity guard)'
+    When call test -n "${stmt}"
+    The status should be success
+  End
+
+  It 'counts the true 2 ET records, never the welded 1'
+    When call eval "${stmt}"
+    The status should be success
+    The variable counto should equal '2'
+  End
+End


### PR DESCRIPTION
Fixes #1263

## The bug is LIVE, not latent

`cat` concatenates **bytes**, not records. If a file does not end with a newline, its last record is **welded** onto the next file's first record:

```text
f1.txt = "1.2.3.4\n5.6.7.8"   (no trailing newline)
f2.txt = "9.9.9.9\n"

cat f1 f2   →  1.2.3.4
               5.6.7.89.9.9.9    ← two IPs fused into ONE garbage record
count       →  2   (truth: 3)
```

The first task of this work was to prove whether that is reachable, rather than assume it. **It is.** `pfb_download()`'s finalizer never guaranteed a trailing newline on the stored `.orig` — every content branch propagates the upstream bytes verbatim:

- uncompressed: `@rename($file_download, $orig_download)` (raw curl bytes)
- gzip: `gunzip -c … > $file_org`
- bzip2: `bzip2 -dkc … > $file_org`
- 7z: `7z e -so … > $file_org`

A remote blocklist is under no obligation to end with `\n`, and plenty don't. So the downstream `cat` pipelines over `.orig`/`ET_*` content weld records **in production today**.

The nastiest shape is the `.aggcount` sum (`awk '{s += $1}'`): welding `100` and `200` yields **`100200`**, not a lost record. The duplicate-detection pipeline is worse in kind — the weld *hides* a real cross-file duplicate, so it is a data-loss channel, not just a miscount.

## The fix: one choke point, not eleven patches

**Root cause — normalize on ingest.** `pfb_ensure_trailing_newline()` is called once in `pfb_download()`'s finalizer, so no downstream `cat` can ever weld. That fixes every current site *and every future one*.

Ordering is the subtle part and was verified, not assumed: the call sits **after** the ADR-42 hash write (the digest must stay over the untouched wire body — otherwise appending a newline would make every feed look permanently changed and re-ingest on every cron) and **after** the UTF-16 transcode (it operates on final bytes). This is the same ordering discipline the existing transcode call site already documents.

**Belt-and-braces at the pipelines.** `awk 1` is a drop-in for `cat` that supplies the missing terminator at no extra fork. Applied to every multi-stream concatenation, and `pfblockerng.inc`'s `cat *.txt | grep -c ^` **shell-out is retired entirely** in favour of `pfb_dnsbl_feed_count()` — a per-file `pfb_count_lines()` sum with no fork.

Note the per-file sum is **not** equivalent to `cat`-then-count on unterminated input — that *is* the bug. It is an intended behaviour change (the sum is the correct number) and is pinned by its own test, not slipped in as a refactor.

## Two stragglers the enumeration missed

The gate re-derived the class from source instead of trusting the list it was handed, and found two more:

- `bench_aggregate_union.sh` — `cat a4.txt a6.txt > union_agg` recombines the per-family aggregates; an unterminated a4 welds its last IPv4 CIDR onto a6's first IPv6 CIDR.
- `bench_ip_recompute.sh` — `{ cat "$sh_file"; gen_range …; }` concatenates two streams in a **brace group**: different syntax, identical hazard, and invisible to a pattern that only looks for a multi-file `cat`.

Both are dev-only tooling, but that is the same "likely safe" reasoning already overridden when the other bench sites were hardened for parity.

## Tests

Test-first red→green throughout, freeze-verified, every reproduction proven failable against the unfixed code:

- The shell weld specs drive the **real** `closingprocess()` and extract the **exact committed** pipeline lines (never a hand-retyped copy), each behind an extractability vacuity guard.
- Red showed the genuine fused records — e.g. `198.51.100.0/242001:db8::/32`, and a `[ Original IP count ] [ 1 ]` where 3 is correct — and the duplicate-detection spec caught the weld *hiding* a real duplicate.
- Ingest normalization is asserted on the **stored bytes**: a feed served without a trailing newline is stored terminated.

Suite: 3244 PHPUnit green, 692 shellspec green (under `dash`), PHPStan / PHPCS / comment-narration clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Vv1F4fW9zu39cSJ69Jn7f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed inaccurate feed and deny-list record counts when files lack trailing newlines.
  - Prevented records from different files from being merged during aggregation, checksum generation, and validation.
  - Ensured downloaded feed files consistently end with a newline.
  - Improved handling of empty, missing, and non-feed files during counting.

- **Tests**
  - Added coverage for feed counting, newline handling, aggregation, checksums, and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->