### PR TITLE
pfblockerng: make DNSBL Wildcard Blocking (TLD) toggle effective on the Python path (#1255)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1246,6 +1246,10 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["python_tld"] = False
     pfb["python_tlds"] = []
     pfb["python_tld_seg"] = 0
+    # issue #1255: DNSBL Wildcard Blocking (TLD) -- a DIFFERENT feature from
+    # python_tld ("TLD Allow") above. Gates the public-suffix oracle exactly like
+    # python_hsts/pfb_py_hsts below (shipped file + ini enable flag).
+    pfb["python_tld_wildcard"] = False
     # Max entries in the per-domain decision cache (LRU); 0 = unbounded. WebUI-configurable.
     pfb["decisiondb_max"] = 10000
     pfb["python_hsts"] = False
@@ -1278,6 +1282,9 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["pfb_py_zone"] = "pfb_py_zone.txt"
     pfb["pfb_py_data"] = "pfb_py_data.txt"
     pfb["pfb_py_hsts"] = "pfb_py_hsts.txt"
+    # issue #1255: shipped TLD-Wildcard public-suffix oracle -- staged by
+    # dnsbl_cache_stage() exactly like pfb_py_hsts above.
+    pfb["pfb_py_tld"] = "pfb_py_tld.txt"
     pfb["pfb_py_ss"] = "pfb_py_ss.txt"
     # ADR-06: per-feed manifest (the new shell->Python boundary) and the
     # Python-emitted entry count. When the manifest is present, init builds the
@@ -1418,6 +1425,8 @@ def init_standard(id: int, env: module_env) -> bool:
                 pfb["python_blocking"] = config.getboolean("MAIN", "python_blocking")
             if config.has_option("MAIN", "python_hsts"):
                 pfb["python_hsts"] = config.getboolean("MAIN", "python_hsts")
+            if config.has_option("MAIN", "python_tld_wildcard"):
+                pfb["python_tld_wildcard"] = config.getboolean("MAIN", "python_tld_wildcard")
             if config.has_option("MAIN", "python_idn"):
                 pfb["python_idn"] = config.getboolean("MAIN", "python_idn")
             # ADR-08: the IDN mode. The PHP ini writer emits an explicit
@@ -4301,7 +4310,14 @@ def classify(domain: str, tlds: dict[str, dict[str, str]], exclusion: set[str]) 
     wildcard ZONE; a deeper sub-domain whose parent is not a known public suffix ->
     exact DATA; a whole-domain TLD exclusion forces exact DATA (transparent, not
     wildcarded).
+
+    issue #1255: an empty ``tlds`` (TLD-Wildcard OFF, or no oracle staged) forces
+    exact DATA for every domain -- defense-in-depth, since the dcnt==2 branch below
+    never consults ``tlds`` (a 2-label name is trivially its own registrable form).
     """
+    if not tlds:
+        return DNSBL_CLASS_DATA, domain
+
     dparts = domain.split(".")
     dcnt = len(dparts)
     tld = dparts[-1]
@@ -5282,29 +5298,26 @@ def _dnsbl_file_line_reader(base_dir: str) -> Callable[[str], Iterable[str]]:
 def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict[str, Any]:
     """Shape the manifest's ``config`` block into the build() config blob.
 
-    The on-box manifest carries ``tld_master`` as a FILE PATH (the public-suffix
-    oracle); the build takes the suffix LINES directly (pure, filesystem-decoupled),
-    so read the file here. ``tld_blacklist`` / ``tld_exclusion`` / ``user_whitelist``
-    / ``user_unlock`` / ``top1m_list`` are passed through as lists. Missing keys default
-    empty so a partial manifest still builds.
+    issue #1255: the public-suffix oracle (``tld_master`` suffix lines) is NOT part
+    of the manifest -- HSTS parity: a SHIPPED file (``pfb["pfb_py_tld"]``) gated by
+    ``pfb["python_tld_wildcard"]``, mirroring ``pfb["pfb_py_hsts"]``/
+    ``pfb["python_hsts"]``. A manifest ``config.tld_master`` key (a stale pre-#1255
+    shape) is ignored entirely -- an absent oracle is expected, not a warning.
+    ``tld_blacklist`` / ``tld_exclusion`` / ``user_whitelist`` / ``user_unlock`` /
+    ``top1m_list`` are passed through as lists. Missing keys default empty so a
+    partial manifest still builds.
     """
     config = manifest.get("config", {})
 
     tld_master_lines: list[str] = []
-    tld_master = config.get("tld_master")
-    if isinstance(tld_master, list):
-        tld_master_lines = list(tld_master)
-    elif isinstance(tld_master, str) and tld_master:
-        path = tld_master if os.path.isabs(tld_master) else os.path.join(base_dir, tld_master)
-        if not _dnsbl_path_within_base(path, base_dir):
-            # The tld_master path escapes the manifest directory -- skip it (do not open).
-            sys.stderr.write("[pfBlockerNG]: Refusing tld_master outside base dir: '{}'".format(path))
-        else:
+    if pfb.get("python_tld_wildcard", False):
+        tld_path = pfb.get("pfb_py_tld", "")
+        if tld_path and os.path.isfile(tld_path):
             try:
-                with open(path, encoding="utf-8", errors="replace") as fh:
+                with open(tld_path, encoding="utf-8", errors="replace") as fh:
                     tld_master_lines = fh.read().splitlines()
             except OSError as e:
-                sys.stderr.write("[pfBlockerNG]: Failed to read tld_master '{}': {}".format(path, e))
+                sys.stderr.write("[pfBlockerNG]: Failed to read TLD-Wildcard oracle '{}': {}".format(tld_path, e))
 
     # ADR-07: the static-cap flag reaches build() via the ini-derived pfb setting
     # (the cap setting lives in pfb_unbound.ini MAIN, not the manifest); a manifest

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -127,6 +127,7 @@ $pfb['unbound_py_data']	= '/var/unbound/pfb_py_data.txt';
 $pfb['unbound_py_zone'] = '/var/unbound/pfb_py_zone.txt';
 $pfb['unbound_py_ss']	= '/var/unbound/pfb_py_ss.txt';
 $pfb['unbound_py_hsts']	= '/var/unbound/pfb_py_hsts.txt';	// SHIPPED file re-staged by dnsbl_cache_stage() cp -f; fingerprinted so a package update ships a new list and triggers a zero-downtime reload
+$pfb['unbound_py_tld']	= '/var/unbound/pfb_py_tld.txt';	// issue #1255: SHIPPED TLD-Wildcard public-suffix oracle, staged/fingerprinted exactly like unbound_py_hsts above
 $pfb['unbound_py_count']= '/var/unbound/pfb_py_count';
 $pfb['unbound_py_regex_count']= '/var/unbound/pfb_py_regex_count';	// ADR-07: Python-emitted ADMITTED (cap-filtered) feed+user regex total for the DNSBL_Regex alias
 $pfb['unbound_py_reject_stats']= '/var/unbound/pfb_py_reject_stats.json';	// ADR-48: Python-emitted per-entry reject tally (issue #789), read by pfb_emit_entry_reject_stats()
@@ -1827,9 +1828,23 @@ function pfb_dnsbl_loaded_input_paths(array $pfb): array {
 	$raw_files = glob("{$pfb['unbound_py_rawdir']}/*.raw") ?: array();
 	sort($raw_files, SORT_STRING);
 	return array_merge(
-		array($pfb['unbound_py_data'], $pfb['unbound_py_zone'], $pfb['unbound_py_wh'], $pfb['unbound_py_sources'], $pfb['unbound_py_hsts']),
+		array($pfb['unbound_py_data'], $pfb['unbound_py_zone'], $pfb['unbound_py_wh'], $pfb['unbound_py_sources'], $pfb['unbound_py_hsts'], $pfb['unbound_py_tld']),
 		$raw_files
 	);
+}
+
+/* issue #1255: the reload fingerprint, narrowed for TLD mode. tld_analysis() rewrites
+   unbound_py_data/unbound_py_zone INSIDE pfb_update_unbound(), strictly AFTER this
+   fingerprint is taken (both the fp_old and fp_new call sites run before that), so
+   their content is unrelated to THIS pass and is excluded when dnsbl_tld is on; every
+   other input (the TLD-Wildcard oracle included) still gates the reload normally.
+   Pure (no global access). */
+function pfb_dnsbl_reload_fingerprint(array $pfb): string {
+	$paths = pfb_dnsbl_loaded_input_paths($pfb);
+	if ($pfb['dnsbl_tld']) {
+		$paths = array_diff($paths, array($pfb['unbound_py_data'], $pfb['unbound_py_zone']));
+	}
+	return pfb_dnsbl_loaded_fingerprint($paths);
 }
 
 /* TRUE iff genuine FEED-derived DNSBL content is currently loaded — i.e. a non-empty
@@ -6863,6 +6878,7 @@ function pfb_unbound_dnsbl($mode) {
 			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound.py");
 			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
 			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_hsts.txt");
+			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_tld.txt");
 		}
 
 		// Save changes to unbound.conf
@@ -7898,25 +7914,23 @@ function pfb_unbound_python_sources($feeds) {
 		}
 	}
 
-	$tld_blacklist	= pfbng_text_area_decode($pfb['dnsblconfig']['tldblacklist'], TRUE, FALSE, TRUE) ?: array();
-	$tld_exclusion	= pfbng_text_area_decode($pfb['dnsblconfig']['tldexclusion'], TRUE, FALSE, TRUE) ?: array();
-
-	// Embed the public-suffix master list as LINES, not a path: pfb_unbound.py runs
-	// chrooted in /var/unbound and cannot read /usr/local/pkg/... (outside the
-	// chroot). _dnsbl_config_from_manifest() accepts tld_master as a list. Empty
-	// when the file is absent (the TLD feature then simply has no suffixes).
-	$tld_master_lines = array();
-	if (file_exists($pfb['dnsbl_tld_data'])) {
-		$tld_master_file = @file($pfb['dnsbl_tld_data'], FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-		if (is_array($tld_master_file)) {
-			$tld_master_lines = $tld_master_file;
-		}
+	// issue #1255: TLD-Wildcard toggle gates the WHOLE wildcard-blocking contribution --
+	// tld_blacklist/tld_exclusion (user config, stay in the manifest) are emptied when
+	// off, even if configured. The public-suffix oracle itself (tld_master) no longer
+	// rides the manifest at all: it is a SHIPPED file (unbound_py_tld) gated by the same
+	// toggle's ini flag (python_tld_wildcard), mirroring HSTS (unbound_py_hsts /
+	// python_hsts) -- see pfb_unbound_python()'s ini emit and pfb_unbound.py's
+	// _dnsbl_config_from_manifest().
+	$tld_blacklist = array();
+	$tld_exclusion = array();
+	if (!empty($pfb['dnsbl_tld'])) {
+		$tld_blacklist = pfbng_text_area_decode($pfb['dnsblconfig']['tldblacklist'], TRUE, FALSE, TRUE) ?: array();
+		$tld_exclusion = pfbng_text_area_decode($pfb['dnsblconfig']['tldexclusion'], TRUE, FALSE, TRUE) ?: array();
 	}
 
 	$manifest = array(
 		'version'	=> 1,
 		'config'	=> array(
-			'tld_master'	=> array_values($tld_master_lines),
 			'tld_blacklist'	=> array_values($tld_blacklist),
 			'tld_exclusion'	=> array_values($tld_exclusion),
 			'user_whitelist'=> pfb_dnsbl_whitelist_lines(),
@@ -8095,6 +8109,14 @@ function pfb_unbound_python($mode) {
 			$python_hsts = 'on';
 		}
 
+		// issue #1255: DNSBL Wildcard Blocking (TLD) -- HSTS parity (shipped file +
+		// ini enable flag). $pfb['dnsbl_tld'] is used as a bare truthy check elsewhere
+		// (tld_analysis() gate, pfb_dnsbl_py_swap()), not an == 'on' comparison.
+		$python_tld_wildcard = 'off';
+		if ($pfb['dnsbl_tld']) {
+			$python_tld_wildcard = 'on';
+		}
+
 		// ADR-08: emit the IDN mode + the legacy python_idn flag + the Confusable sub-toggles.
 		// python_idn = on ONLY for All-IDN, so the legacy flag (and its blacklist side-effect)
 		// stays byte-identical to today; Confusable rides the explicit idn_mode key instead.
@@ -8186,6 +8208,7 @@ python_enable	= {$python_enable}
 python_reply	= {$python_reply}
 python_blocking	= {$python_blocking}
 python_hsts	= {$python_hsts}
+python_tld_wildcard	= {$python_tld_wildcard}
 python_idn	= {$python_idn}
 idn_mode	= {$idn_mode}
 python_idn_block_malicious	= {$python_idn_block_malicious}
@@ -16557,7 +16580,7 @@ function sync_package_pfblockerng($cron='') {
 	$pfb['updateip']		= FALSE;	// Flag to signal updates to DNSBL IP lists
 	$pfb_py_feeds			= array();	// ADR-06: per-feed manifest rows [header,group,log] for pfb_unbound_python_sources()
 	$safesearch_update		= FALSE;	// Flag: SafeSearch CSV changed -> force an Unbound restart (issue #149)
-	$pfb_fp_old			= null;		// Fingerprint of loaded input files BEFORE this pass (null => TLD mode or DNSBL not active)
+	$pfb_fp_old			= null;		// Fingerprint of loaded input files BEFORE this pass (null => DNSBL not active this pass)
 
 	$dnsbl_error = FALSE;
 	if ($pfb['enable'] == 'on' && $pfb['dnsbl'] == 'on' && !$pfb['save']) {
@@ -16787,10 +16810,10 @@ function sync_package_pfblockerng($cron='') {
 			pfb_logger("{$s_log}{$CNAME_LOG}", 1);
 
 			// Fingerprint the Python-loaded input files BEFORE this pass rewrites them.
-			// TLD mode builds data/zone inside pfb_update_unbound (after the gate), so
-			// the fingerprint can't see those writes yet — leave null and fall back to the
-			// domain_update / domain_clear flags for the gate decision.
-			$pfb_fp_old = $pfb['dnsbl_tld'] ? null : pfb_dnsbl_loaded_fingerprint(pfb_dnsbl_loaded_input_paths($pfb));
+			// issue #1255: pfb_dnsbl_reload_fingerprint() narrows the path set (excludes
+			// data/zone) in TLD mode instead of nulling the whole comparison -- see its
+			// docblock.
+			$pfb_fp_old = pfb_dnsbl_reload_fingerprint($pfb);
 
 			// Collect Whitelist, create string, and save to file (for grep -vF -f cmd)
 			pfb_logger("\n Loading DNSBL Whitelist...", 1);
@@ -18129,12 +18152,11 @@ function sync_package_pfblockerng($cron='') {
 
 	// Fingerprint the loaded input files AFTER this pass rebuilt them.
 	// Equal fingerprints => Python would produce a byte-identical blocklist => skip reload.
-	// TLD mode (fp_old === null): tld_analysis() writes data/zone INSIDE pfb_update_unbound
-	// (after this gate), so the post fingerprint can't see those writes yet — fall back to
-	// domain_update / domain_clear as before.
+	// fp_old === null => DNSBL was not active this pass (the block above never ran) --
+	// fall back to domain_update / domain_clear as before.
 	// The all-missing stable sentinel means empty→empty always yields equal fingerprints,
 	// so an unchanged no-feeds steady state no longer triggers a reload every pass.
-	$pfb_fp_new = ($pfb_fp_old === null) ? null : pfb_dnsbl_loaded_fingerprint(pfb_dnsbl_loaded_input_paths($pfb));
+	$pfb_fp_new = ($pfb_fp_old === null) ? null : pfb_dnsbl_reload_fingerprint($pfb);
 	$pfb_data_changed = ($pfb_fp_old === null || $pfb_fp_new === null)
 		? ($pfb['domain_update'] || $pfb['domain_clear'])
 		: ($pfb_fp_old !== $pfb_fp_new);
@@ -20240,6 +20262,7 @@ function pfblockerng_php_pre_deinstall_command() {
 	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound.py");
 	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
 	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_hsts.txt");
+	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_tld.txt");
 
 	// Remove widget (code from Snort deinstall)
 	$pfb['widgets'] = config_get_path('widgets/sequence', '');

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -317,7 +317,9 @@ aliastables() {
 # (re-run on every save/restore, never restored stale); save = stage then archive ONLY the
 # GENERATED set (pfb_unbound*/pfb_py_*/pfb_unbound.ini); restore = boot earlyshellcmd, untar
 # the generated set THEN stage. Naming contract: a new generated file MUST keep the
-# pfb_unbound*/pfb_py_* prefix; a new shipped file goes in PFB_PY_SHIPPED + pkg-plist wiring.
+# pfb_unbound*/pfb_py_* prefix; a new shipped file goes in PFB_PY_SHIPPED + pkg-plist wiring
+# (a NAME-MAPPED shipped file -- source basename != chroot basename -- is the sole
+# exception: it needs its own explicit stage/save handling instead; see pfb_py_tld.txt).
 dnsbl_cache() {
 	# Overridable for unit tests; default to the live locations.
 	pfbchroot="${pfbchroot:-/var/unbound}"
@@ -341,6 +343,13 @@ dnsbl_cache() {
 				chown -f unbound:unbound "${pfbchroot}/${_f}"
 			fi
 		done
+		# issue #1255: the TLD-Wildcard public-suffix oracle -- NAME-MAPPED (source
+		# basename 'dnsbl_tld' stays as-is; chroot copy is 'pfb_py_tld.txt'), so it
+		# cannot ride PFB_PY_SHIPPED's same-basename cp loop above.
+		if [ -f "${pfbpkgdir}/dnsbl_tld" ]; then
+			cp -f "${pfbpkgdir}/dnsbl_tld" "${pfbchroot}/pfb_py_tld.txt"
+			chown -f unbound:unbound "${pfbchroot}/pfb_py_tld.txt"
+		fi
 	}
 
 	case "${1}" in
@@ -360,6 +369,10 @@ dnsbl_cache() {
 				for _s in ${PFB_PY_SHIPPED}; do
 					[ "${_g}" = "${pfbchroot}/${_s}" ] && _skip=1 && break
 				done
+				# issue #1255: the name-mapped TLD oracle (source 'dnsbl_tld' isn't in
+				# PFB_PY_SHIPPED since its chroot basename differs) -- shipped, not
+				# generated, so it is excluded the same way.
+				[ "${_g}" = "${pfbchroot}/pfb_py_tld.txt" ] && _skip=1
 				[ -z "${_skip}" ] && set -- "$@" "${_g}"
 			done
 			if [ "$#" -gt 0 ]; then

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -1037,15 +1037,15 @@ $dnsbl_text = 'This is an <strong>Advanced process</strong> to determine if all 
 		To exclude a TLD/Domain from the TLD process, add the TLD/Domain to the <strong>TLD Exclusion</strong> custom list:<br />
 		&#8226&emsp;This only excludes the domain from the TLD process, it doesn\'t whitelist the domain.<br />
 		&#8226&emsp;Only the specific Sub-Domains/Domains listed in the DNSBL Feeds will be blocked.<br />
-		&#8226&emsp;A Force Reload - DNSBL, is required after manually adding to the TLD Exclusion<br /><br />
+		&#8226&emsp;Changes to the TLD Exclusion take effect on the next DNSBL update.<br /><br />
 		<strong>Note:</strong>
-		&emsp;Whitelisting a "sub-Domain" for a TLD Blocked "Domain" in the <strong>Custom Domain Whitelist</strong>
-		will not whitelist a TLD Wildcard Blocked domain!<br />
-		&emsp;&emsp;&emsp;&emsp;Either add the domain to the TLD Exclusion, or wildcard Whitelist the whole domain.<br /><br />
+		&emsp;A specific sub-Domain added to the <strong>Custom Domain Whitelist</strong> is exempted from a TLD
+		Wildcard Blocked domain (that exact name resolves).<br />
+		&emsp;&emsp;&emsp;&emsp;To exempt the whole domain (all sub-Domains), add it to the TLD Exclusion, or add a wildcard Whitelist entry for the domain.<br /><br />
 
 		<strong>TLD Blacklist</strong>, can be used to block whole TLDs. &emsp;IE: <strong>xyz</strong><br />
 
-		When Enabling/Disabling this option, a <strong>Force Reload - DNSBL</strong> is required.<br /><br />
+		Enabling or disabling this option takes effect on the next DNSBL update.<br /><br />
 
 	</div>';
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,9 @@ def reset_pfb_globals() -> None:
         "python_hsts": False,
         "python_idn": False,
         "python_tld": False,
+        # issue #1255: DNSBL Wildcard Blocking (TLD) gate -- distinct from python_tld
+        # (a DIFFERENT feature, "TLD Allow"); mirrors python_hsts's shipped-file gate.
+        "python_tld_wildcard": False,
         "python_maxmind": False,
         "python_tld_seg": 2,
         "python_tlds": [],

--- a/tests/php/DnsblLoadedFingerprintTest.php
+++ b/tests/php/DnsblLoadedFingerprintTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversFunction('pfb_dnsbl_loaded_fingerprint')]
 #[CoversFunction('pfb_dnsbl_loaded_input_paths')]
+#[CoversFunction('pfb_dnsbl_reload_fingerprint')]
 final class DnsblLoadedFingerprintTest extends TestCase
 {
 	private string $tmpDir;
@@ -204,6 +205,7 @@ final class DnsblLoadedFingerprintTest extends TestCase
 			'unbound_py_wh'      => "{$this->tmpDir}/pfb_py_whitelist.txt",
 			'unbound_py_sources' => "{$this->tmpDir}/pfb_py_sources.json",
 			'unbound_py_hsts'    => "{$this->tmpDir}/pfb_py_hsts.txt",
+			'unbound_py_tld'     => "{$this->tmpDir}/pfb_py_tld.txt",
 			'unbound_py_rawdir'  => $rawDir,
 			// Keys that must NOT appear in the result:
 			'unbound_py_count'       => "{$this->tmpDir}/pfb_py_count",
@@ -213,12 +215,13 @@ final class DnsblLoadedFingerprintTest extends TestCase
 
 		$result = pfb_dnsbl_loaded_input_paths($pfb);
 
-		// The five flat inputs must be present (incl. HSTS shipped list — #520 fix).
+		// The six flat inputs must be present (incl. HSTS + TLD-Wildcard oracle).
 		$this->assertContains($pfb['unbound_py_data'],    $result, 'unbound_py_data must be in the path list');
 		$this->assertContains($pfb['unbound_py_zone'],    $result, 'unbound_py_zone must be in the path list');
 		$this->assertContains($pfb['unbound_py_wh'],      $result, 'unbound_py_wh must be in the path list');
 		$this->assertContains($pfb['unbound_py_sources'], $result, 'unbound_py_sources must be in the path list');
 		$this->assertContains($pfb['unbound_py_hsts'],    $result, 'unbound_py_hsts must be in the path list (shipped HSTS preload; #520)');
+		$this->assertContains($pfb['unbound_py_tld'],     $result, 'unbound_py_tld must be in the path list (shipped TLD-Wildcard oracle; issue #1255)');
 
 		// Both .raw files must be present.
 		$this->assertContains("{$rawDir}/aa_feed.raw", $result, 'aa_feed.raw must be in the path list');
@@ -237,11 +240,11 @@ final class DnsblLoadedFingerprintTest extends TestCase
 	}
 
 	/**
-	 * Scenario: empty rawdir — no .raw files, just the five flat inputs (incl. HSTS).
+	 * Scenario: empty rawdir — no .raw files, just the six flat inputs (incl. HSTS + TLD).
 	 *
 	 * Given:  a rawdir that is empty (no .raw files)
 	 * When:   pfb_dnsbl_loaded_input_paths() is called
-	 * Then:   result has exactly 5 entries (the flat inputs only, including HSTS)
+	 * Then:   result has exactly 6 entries (the flat inputs only, including HSTS + TLD)
 	 */
 	public function testEmptyRawdirReturnsOnlyFlatInputs(): void
 	{
@@ -251,6 +254,7 @@ final class DnsblLoadedFingerprintTest extends TestCase
 			'unbound_py_wh'      => "{$this->tmpDir}/pfb_py_whitelist.txt",
 			'unbound_py_sources' => "{$this->tmpDir}/pfb_py_sources.json",
 			'unbound_py_hsts'    => "{$this->tmpDir}/pfb_py_hsts.txt",
+			'unbound_py_tld'     => "{$this->tmpDir}/pfb_py_tld.txt",
 			'unbound_py_rawdir'  => "{$this->tmpDir}/raw",
 			'unbound_py_count'       => "{$this->tmpDir}/pfb_py_count",
 			'unbound_py_regex_count' => "{$this->tmpDir}/pfb_py_regex_count",
@@ -259,7 +263,7 @@ final class DnsblLoadedFingerprintTest extends TestCase
 
 		$result = pfb_dnsbl_loaded_input_paths($pfb);
 
-		$this->assertCount(5, $result, 'With no .raw files, exactly the five flat inputs are returned (data/zone/wh/sources/hsts)');
+		$this->assertCount(6, $result, 'With no .raw files, exactly the six flat inputs are returned (data/zone/wh/sources/hsts/tld)');
 	}
 
 	/**
@@ -287,6 +291,7 @@ final class DnsblLoadedFingerprintTest extends TestCase
 			'unbound_py_wh'      => "{$this->tmpDir}/pfb_py_whitelist.txt",
 			'unbound_py_sources' => "{$this->tmpDir}/pfb_py_sources.json",
 			'unbound_py_hsts'    => $hsts,
+			'unbound_py_tld'     => "{$this->tmpDir}/pfb_py_tld.txt",
 			'unbound_py_rawdir'  => "{$this->tmpDir}/raw",
 		];
 
@@ -324,6 +329,7 @@ final class DnsblLoadedFingerprintTest extends TestCase
 			'unbound_py_wh'      => "{$this->tmpDir}/pfb_py_whitelist.txt",
 			'unbound_py_sources' => "{$this->tmpDir}/pfb_py_sources.json",
 			'unbound_py_hsts'    => $hsts,
+			'unbound_py_tld'     => "{$this->tmpDir}/pfb_py_tld.txt",
 			'unbound_py_rawdir'  => "{$this->tmpDir}/raw",
 		];
 
@@ -331,5 +337,139 @@ final class DnsblLoadedFingerprintTest extends TestCase
 		$fp2 = pfb_dnsbl_loaded_fingerprint(pfb_dnsbl_loaded_input_paths($pfb));
 
 		$this->assertSame($fp1, $fp2, 'Unchanged HSTS file must not cause a spurious fingerprint change');
+	}
+
+	/**
+	 * Scenario: TLD-Wildcard oracle content change is detected by the fingerprint —
+	 * issue #1255, HSTS-parity (#520) applied to the public-suffix oracle.
+	 *
+	 * The shipped pfb_py_tld.txt is re-staged by dnsbl_cache_stage() (cp -f) between
+	 * the $pfb_fp_old and $pfb_fp_new snapshots, exactly like pfb_py_hsts.txt. A
+	 * package update shipping a new TLD oracle must flip the fingerprint so the
+	 * zero-downtime reload picks it up.
+	 *
+	 * Given:  a TLD oracle file included in the path set via pfb_dnsbl_loaded_input_paths()
+	 * When:   the file content changes (simulating a package update staging a new oracle)
+	 * Then:   the fingerprint differs (reload is triggered)
+	 */
+	public function testTldOracleFileChangeChangesFingerprint(): void
+	{
+		$tld = "{$this->tmpDir}/pfb_py_tld.txt";
+		file_put_contents($tld, "com\nnet\n");
+
+		$pfb = [
+			'unbound_py_data'    => "{$this->tmpDir}/pfb_py_data.txt",
+			'unbound_py_zone'    => "{$this->tmpDir}/pfb_py_zone.txt",
+			'unbound_py_wh'      => "{$this->tmpDir}/pfb_py_whitelist.txt",
+			'unbound_py_sources' => "{$this->tmpDir}/pfb_py_sources.json",
+			'unbound_py_hsts'    => "{$this->tmpDir}/pfb_py_hsts.txt",
+			'unbound_py_tld'     => $tld,
+			'unbound_py_rawdir'  => "{$this->tmpDir}/raw",
+		];
+
+		// Before: record fingerprint with the original oracle content.
+		$fp_before = pfb_dnsbl_loaded_fingerprint(pfb_dnsbl_loaded_input_paths($pfb));
+
+		// Simulate dnsbl_cache_stage() cp -f staging a new shipped oracle.
+		file_put_contents($tld, "com\nnet\norg\n");
+
+		// After: fingerprint must differ (reload fires).
+		$fp_after = pfb_dnsbl_loaded_fingerprint(pfb_dnsbl_loaded_input_paths($pfb));
+
+		$this->assertNotSame(
+			$fp_before,
+			$fp_after,
+			'A change to pfb_py_tld.txt must produce a different fingerprint (issue #1255: shipped TLD oracle update must trigger a zero-downtime reload)'
+		);
+	}
+
+	/**
+	 * Scenario: TLD-Wildcard oracle appearing (absent -> present) is detected.
+	 *
+	 * Given:  a path set with the oracle ABSENT
+	 * When:   the oracle file is created and the fingerprint recomputed
+	 * Then:   the fingerprint differs (a first-seen shipped oracle is detected)
+	 */
+	public function testTldOracleAbsentVsPresentChangesFingerprint(): void
+	{
+		$tld = "{$this->tmpDir}/pfb_py_tld.txt";
+		$pfb = [
+			'unbound_py_data'    => "{$this->tmpDir}/pfb_py_data.txt",
+			'unbound_py_zone'    => "{$this->tmpDir}/pfb_py_zone.txt",
+			'unbound_py_wh'      => "{$this->tmpDir}/pfb_py_whitelist.txt",
+			'unbound_py_sources' => "{$this->tmpDir}/pfb_py_sources.json",
+			'unbound_py_hsts'    => "{$this->tmpDir}/pfb_py_hsts.txt",
+			'unbound_py_tld'     => $tld,
+			'unbound_py_rawdir'  => "{$this->tmpDir}/raw",
+		];
+
+		// Before: the oracle file does not exist.
+		$fp_absent = pfb_dnsbl_loaded_fingerprint(pfb_dnsbl_loaded_input_paths($pfb));
+
+		file_put_contents($tld, "com\n");
+		$fp_present = pfb_dnsbl_loaded_fingerprint(pfb_dnsbl_loaded_input_paths($pfb));
+
+		$this->assertNotSame($fp_absent, $fp_present, 'The oracle appearing on disk must flip the fingerprint');
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_dnsbl_reload_fingerprint (issue #1255)
+	//
+	// The dnsbl_tld fp_old bypass (@16793) used to null the WHOLE fingerprint in
+	// TLD mode because tld_analysis() rewrites unbound_py_data/unbound_py_zone
+	// INSIDE pfb_update_unbound(), strictly AFTER the fingerprint is taken -- so
+	// a package update shipping a new TLD oracle (fingerprinted like HSTS) never
+	// triggered a reload. This helper narrows instead of nulling: excludes ONLY
+	// unbound_py_data/unbound_py_zone when dnsbl_tld is on; every other input
+	// (the oracle included) still gates normally.
+	// -----------------------------------------------------------------------
+
+	private function reloadFpBasePfb(): array
+	{
+		return [
+			'unbound_py_data'    => "{$this->tmpDir}/pfb_py_data.txt",
+			'unbound_py_zone'    => "{$this->tmpDir}/pfb_py_zone.txt",
+			'unbound_py_wh'      => "{$this->tmpDir}/pfb_py_whitelist.txt",
+			'unbound_py_sources' => "{$this->tmpDir}/pfb_py_sources.json",
+			'unbound_py_hsts'    => "{$this->tmpDir}/pfb_py_hsts.txt",
+			'unbound_py_tld'     => "{$this->tmpDir}/pfb_py_tld.txt",
+			'unbound_py_rawdir'  => "{$this->tmpDir}/raw",
+		];
+	}
+
+	public function testTldModeIgnoresDataZoneChangeButOracleChangeStillTriggersReload(): void
+	{
+		$pfb = $this->reloadFpBasePfb();
+		$pfb['dnsbl_tld'] = 'on';
+		file_put_contents($pfb['unbound_py_data'], 'stale-legacy-data');
+		file_put_contents($pfb['unbound_py_tld'], "com\n");
+
+		$fp_before = pfb_dnsbl_reload_fingerprint($pfb);
+
+		// tld_analysis()'s late write to data/zone must NOT move the fingerprint...
+		file_put_contents($pfb['unbound_py_data'], 'a-different-late-tld-analysis-write');
+		$fp_after_data_write = pfb_dnsbl_reload_fingerprint($pfb);
+		$this->assertSame($fp_before, $fp_after_data_write,
+			'TLD mode must exclude unbound_py_data -- tld_analysis() rewrites it after this fingerprint is taken');
+
+		// ...but a staged oracle content change (dnsbl_cache_stage cp -f) MUST.
+		file_put_contents($pfb['unbound_py_tld'], "com\nnet\n");
+		$fp_after_oracle_change = pfb_dnsbl_reload_fingerprint($pfb);
+		$this->assertNotSame($fp_after_data_write, $fp_after_oracle_change,
+			'issue #1255: a TLD oracle content change must still flip the fingerprint in TLD mode (the upgrade requirement)');
+	}
+
+	public function testNonTldModeIncludesDataZoneChange(): void
+	{
+		$pfb = $this->reloadFpBasePfb();
+		$pfb['dnsbl_tld'] = '';
+		file_put_contents($pfb['unbound_py_data'], 'v1');
+
+		$fp_before = pfb_dnsbl_reload_fingerprint($pfb);
+		file_put_contents($pfb['unbound_py_data'], 'v2');
+		$fp_after = pfb_dnsbl_reload_fingerprint($pfb);
+
+		$this->assertNotSame($fp_before, $fp_after,
+			'Non-TLD mode must NOT narrow the path set -- unbound_py_data changes gate the reload normally');
 	}
 }

--- a/tests/php/PfbSyncStatusIpWritersTest.php
+++ b/tests/php/PfbSyncStatusIpWritersTest.php
@@ -354,11 +354,15 @@ final class PfbSyncStatusIpWritersTest extends TestCase
 	 * below the file size -- the old @file()-array approach scales its
 	 * memory with file size, the bounded-tail read does not (same proof
 	 * shape as LogAgeCutoffStreamTest::testStreamingTrimStaysMemoryBounded...).
-	 * Bound justification (measured this session on this machine): the old
-	 * @file()-array approach costs a +7,065,600 byte (~6.7 MiB) delta on this
-	 * exact fixture; the bounded-tail read costs 0 bytes. 1 MiB sits
-	 * comfortably between the two, cleanly separating old-code-fails from
-	 * new-code-passes.
+	 * Bound justification: the old @file()-array approach costs a +7,065,600
+	 * byte (~6.7 MiB) memory_get_peak_usage(true) delta on this exact fixture;
+	 * the bounded-tail read costs ~0. The bound is 4 MiB, not 1: (true) reports
+	 * real memory in 2 MiB emalloc chunks, so the bounded read shows either 0
+	 * or one 2 MiB chunk depending on where $memBefore sits relative to a chunk
+	 * boundary -- 4 MiB clears that quantization noise yet stays well under the
+	 * ~6.7 MiB old cost, keeping old-code-fails / new-code-passes cleanly split.
+	 * issue #1255: the old 1 MiB bound flaked on PHP 8.5 when an unrelated
+	 * baseline shift tipped $memBefore across a chunk boundary.
 	 */
 	#[RunInSeparateProcess]
 	public function testDedupSanityCheckStaysMemoryBoundedOnLargeLog(): void
@@ -390,8 +394,8 @@ final class PfbSyncStatusIpWritersTest extends TestCase
 			. var_export($open, true));
 		$this->assertStringContainsString('FAILED', $open[0]['message']);
 
-		$this->assertLessThan(1024 * 1024, $memDelta,
-			"dedup check's memory_get_peak_usage(true) delta must stay under 1 MiB on a several-MB log, got {$memDelta} bytes"
+		$this->assertLessThan(4 * 1024 * 1024, $memDelta,
+			"dedup check's memory_get_peak_usage(true) delta must stay under 4 MiB on a several-MB log, got {$memDelta} bytes"
 		);
 	}
 

--- a/tests/php/PythonTldWildcardIniEmitTest.php
+++ b/tests/php/PythonTldWildcardIniEmitTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1255 — pfb_unbound_python() must emit the `python_tld_wildcard` ini
+ * flag, derived from $pfb['dnsbl_tld'] via the SAME on/off pattern as the
+ * sibling `python_hsts` key (HSTS parity: a shipped static file + an ini
+ * boolean enable flag). pfb_unbound_python() needs a live pfSense/VIP/DNS
+ * environment to execute end-to-end (no lighter harness exists for ANY of
+ * its ini keys — python_hsts/python_idn/python_cname are pinned the same
+ * source-inspection way in PythonWhitelistTldSegTest.php; true end-to-end
+ * ini + Python behaviour is proven by the live-VM smoke suite), so this pins
+ * the wiring at the source level: the derivation reads dnsbl_tld and the
+ * heredoc emits the key.
+ */
+final class PythonTldWildcardIniEmitTest extends TestCase
+{
+	private const SRC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+
+	/**
+	 * Brace-counts from `function {$name}(` to its matching closing brace, so the
+	 * assertions below inspect ONLY that function's body (mirrors
+	 * PythonWhitelistTldSegTest::functionBody()).
+	 */
+	private function functionBody(string $name): string
+	{
+		$source = file_get_contents(self::SRC);
+		$this->assertNotFalse($source, 'failed to read pfblockerng.inc');
+
+		$needle = "\nfunction {$name}(";
+		$start = strpos($source, $needle);
+		$this->assertNotFalse($start, "function {$name}() not found in source");
+		$start++; // step past the leading \n onto 'function'
+
+		$braceOpen = strpos($source, '{', $start);
+		$this->assertNotFalse($braceOpen, "no opening brace found for {$name}()");
+
+		$depth = 0;
+		for ($i = $braceOpen, $len = strlen($source); $i < $len; $i++) {
+			if ($source[$i] === '{') {
+				$depth++;
+			} elseif ($source[$i] === '}') {
+				$depth--;
+				if ($depth === 0) {
+					$body = substr($source, $start, $i - $start + 1);
+					$this->assertNotSame('', trim($body), "empty body extracted for {$name}() -- vacuous extraction");
+					return $body;
+				}
+			}
+		}
+		$this->fail("no matching closing brace found for {$name}()");
+	}
+
+	public function testPythonTldWildcardDerivedFromDnsblTld(): void
+	{
+		$body = $this->functionBody('pfb_unbound_python');
+		$this->assertMatchesRegularExpression(
+			"/\\\$python_tld_wildcard\s*=\s*'off';.*if\s*\(\s*\\\$pfb\['dnsbl_tld'\]/s",
+			$body,
+			'issue #1255: python_tld_wildcard must default off and flip on $pfb[\'dnsbl_tld\'] (mirrors python_hsts @ $pfb[\'dnsbl_hsts\'])'
+		);
+	}
+
+	public function testManifestEmitsPythonTldWildcardKey(): void
+	{
+		$body = $this->functionBody('pfb_unbound_python');
+		$this->assertMatchesRegularExpression(
+			'/python_tld_wildcard\s*=\s*\{\$python_tld_wildcard\}/',
+			$body,
+			'issue #1255: the ini heredoc must carry a python_tld_wildcard key'
+		);
+	}
+}

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -57,6 +57,8 @@ final class UnboundPythonSourcesTest extends TestCase
 			'dnsbl_top1m'        => 'off',
 			'dnsbl_tld_data'     => "{$this->tmp}/does_not_exist",
 			'dnsbl_unlock'       => "{$this->tmp}/dnsbl_unlock",
+			// issue #1255: DNSBL Wildcard Blocking (TLD) toggle; OFF by default here.
+			'dnsbl_tld'          => '',
 			'dnsblconfig'        => [
 				'tldblacklist' => '',
 				'tldexclusion' => '',
@@ -213,11 +215,43 @@ final class UnboundPythonSourcesTest extends TestCase
 	public function testConfigBlockEmptyWhenUnconfigured(): void
 	{
 		$m = pfb_unbound_python_sources($this->feeds());
-		$this->assertSame([], $m['config']['tld_master']);
+		// issue #1255: the public-suffix oracle is no longer carried in the manifest
+		// (HSTS parity -- a shipped static file + ini flag instead); the key is absent.
+		$this->assertArrayNotHasKey('tld_master', $m['config']);
 		$this->assertSame([], $m['config']['tld_blacklist']);
 		$this->assertSame([], $m['config']['user_whitelist']);
 		$this->assertSame([], $m['config']['user_unlock']);
 		$this->assertFalse($m['config']['top1m_enabled']);
+	}
+
+	// issue #1255: the TLD-Wildcard oracle leaves the manifest entirely (HSTS parity) --
+	// present regardless of the dnsbl_tld toggle. tld_blacklist/tld_exclusion STAY (user
+	// config data) but are gated: OFF empties them even when the operator configured them,
+	// so the toggle gates the WHOLE wildcard-blocking contribution, not just the oracle.
+	public function testTldMasterKeyAbsentAndBlacklistExclusionEmptyWhenDnsblTldOff(): void
+	{
+		$GLOBALS['pfb']['dnsbl_tld'] = '';
+		$GLOBALS['pfb']['dnsblconfig']['tldblacklist'] = base64_encode('evil-tld');
+		$GLOBALS['pfb']['dnsblconfig']['tldexclusion'] = base64_encode('good.example');
+
+		$m = pfb_unbound_python_sources($this->feeds());
+
+		$this->assertArrayNotHasKey('tld_master', $m['config'], 'tld_master must never appear in the manifest');
+		$this->assertSame([], $m['config']['tld_blacklist'], 'OFF must empty tld_blacklist even though it was configured');
+		$this->assertSame([], $m['config']['tld_exclusion'], 'OFF must empty tld_exclusion even though it was configured');
+	}
+
+	public function testTldBlacklistAndExclusionPopulatedWhenDnsblTldOn(): void
+	{
+		$GLOBALS['pfb']['dnsbl_tld'] = 'on';
+		$GLOBALS['pfb']['dnsblconfig']['tldblacklist'] = base64_encode('evil-tld');
+		$GLOBALS['pfb']['dnsblconfig']['tldexclusion'] = base64_encode('good.example');
+
+		$m = pfb_unbound_python_sources($this->feeds());
+
+		$this->assertArrayNotHasKey('tld_master', $m['config'], 'tld_master must never appear in the manifest, even ON');
+		$this->assertSame(['evil-tld'], $m['config']['tld_blacklist'], 'ON must populate tld_blacklist from config');
+		$this->assertSame(['good.example'], $m['config']['tld_exclusion'], 'ON must populate tld_exclusion from config');
 	}
 
 	public function testManifestIsWrittenAsJson(): void

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -44,6 +44,10 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     echo 'PY-CODE-v1' > "${pfbpkgdir}/pfb_unbound.py"
     echo 'INC-CODE-v1' > "${pfbpkgdir}/pfb_unbound_include.inc"
     echo 'HSTS-v1' > "${pfbpkgdir}/pfb_py_hsts.txt"
+    # issue #1255: the TLD-Wildcard public-suffix oracle -- name-mapped (source
+    # basename 'dnsbl_tld', chroot copy 'pfb_py_tld.txt'), NOT in PFB_PY_SHIPPED
+    # (whose same-basename cp -f loop cannot rename).
+    echo 'TLD-ORACLE-v1' > "${pfbpkgdir}/dnsbl_tld"
   }
 
   cleanup_sandbox() {
@@ -76,6 +80,25 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     cleanup_sandbox
   End
 
+  It 'stage copies the TLD oracle from dnsbl_tld to pfb_py_tld.txt (name-mapped, issue #1255)'
+    setup_sandbox
+    When call dc stage
+    The contents of file "${pfbchroot}/pfb_py_tld.txt" should equal 'TLD-ORACLE-v1'
+    # The shipped file itself is NEVER renamed (PFB_PY_SHIPPED's same-basename cp
+    # loop is untouched -- this is a separate, explicit name-mapped copy).
+    The contents of file "${pfbpkgdir}/dnsbl_tld" should equal 'TLD-ORACLE-v1'
+    cleanup_sandbox
+  End
+
+  It 'stage is a no-op for the TLD oracle when the shipped file is absent'
+    setup_sandbox
+    rm -f "${pfbpkgdir}/dnsbl_tld"
+    When call dc stage
+    The status should be success
+    The path "${pfbchroot}/pfb_py_tld.txt" should not be exist
+    cleanup_sandbox
+  End
+
   It 'save archives the generated set only (never the shipped files)'
     setup_sandbox
     dc stage
@@ -93,6 +116,9 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     # ... and NOT the shipped files (re-staged from /usr/local on restore).
     The result of "tar_list()" should not include 'pfb_py_hsts.txt'
     The result of "tar_list()" should not include 'pfb_unbound_include.inc'
+    # ... nor the name-mapped TLD oracle (issue #1255: matches the pfb_py_* glob
+    # but is shipped, not generated -- archiving it would reinstate a stale oracle).
+    The result of "tar_list()" should not include 'pfb_py_tld.txt'
     cleanup_sandbox
   End
 
@@ -129,6 +155,18 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     The contents of file "${pfbchroot}/pfb_unbound.py" should equal 'PY-CODE-v2'
     # Mount-point dirs are present again after restore.
     The path "${pfbchroot}/lib" should be directory
+    cleanup_sandbox
+  End
+
+  It 're-stages the CURRENT TLD oracle on restore, not a stale archived copy (issue #1255)'
+    setup_sandbox
+    dc stage
+    dc save
+    rm -rf "${pfbchroot}"
+    # Bump the shipped oracle to prove restore re-stages CURRENT code, like pfb_unbound.py.
+    echo 'TLD-ORACLE-v2' > "${pfbpkgdir}/dnsbl_tld"
+    When call dc restore
+    The contents of file "${pfbchroot}/pfb_py_tld.txt" should equal 'TLD-ORACLE-v2'
     cleanup_sandbox
   End
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1780,6 +1780,43 @@ def set_dnsbl_lenient(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
         )
 
 
+def set_dnsbl_tld_wildcard(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
+    """Toggle DNSBL Wildcard Blocking (TLD) (``pfb_tld`` -> ini ``python_tld_wildcard``).
+
+    issue #1255: ``pfb_tld`` is read as a bare truthy check (``$pfb['dnsbl_tld']``), so
+    off is the empty string, matching :func:`set_dnsbl_control`. On: the next reload's
+    ini carries ``python_tld_wildcard = on`` and the shipped public-suffix oracle
+    (``pfb_py_tld.txt``) gates classify()'s 2-label wildcard branch; off: the oracle is
+    never opened, so classify() forces exact DATA for every domain.
+    """
+    val = "on" if on else ""
+    snippet = (
+        f"$d = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
+        f"$d['pfb_tld'] = {_php_str(val)};\n"
+        f"config_set_path({_php_str(CFG_DNSBL_SETTINGS)}, $d);\n"
+        "write_config('pfBlockerNG smoke: toggle pfb_tld');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"set_dnsbl_tld_wildcard({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def assert_tld_wildcard_ini(vm: SmokeVM, *, on: bool, timeout: float = 30.0) -> None:
+    """Precondition guard: the generated ini's ``python_tld_wildcard`` matches ``on``.
+
+    issue #1255: attributes a wildcard-vs-exact drill assertion to the toggle's ini
+    gate (not a config-write miss) -- ``pfb_unbound.py`` reads
+    ``pfb['python_tld_wildcard']`` to decide whether to open the shipped oracle.
+    """
+    ini = vm.ssh("cat", UNBOUND_PFB_INI, timeout=timeout)
+    want = "on" if on else "off"
+    if not re.search(rf"(?im)^\s*python_tld_wildcard\s*=\s*{want}\b", ini.stdout):
+        raise AssertionError(f"python_tld_wildcard != {want} in {UNBOUND_PFB_INI}:\n{ini.stdout}")
+
+
 def read_log_file(vm: SmokeVM, path: str, *, timeout: float = 30.0) -> str:
     """Return the full text of a guest log file (empty string if absent).
 

--- a/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
+++ b/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
@@ -12,6 +12,13 @@ REPRODUCE-FIRST: assert the domain sinkholes BEFORE the reboot, then require it 
 still sinkhole AFTER a RAM-disk reboot (pfb_unbound.py re-staged + matcher rebuilt
 from the restored manifest), with NO manual update. Verified RED on pre-fix code.
 
+Issue #1255 rides the SAME reboot cycle: the shipped TLD-Wildcard public-suffix
+oracle (``pfb_py_tld.txt``) is archive-EXCLUDED (re-staged fresh from the package
+dir by ``dnsbl_cache_stage()``, like ``pfb_py_hsts.txt``) while the ini
+(``python_tld_wildcard = on``) rides the archived ``pfb_unbound*`` set -- so a
+wildcard-blocked sub-domain must ALSO still sinkhole post-reboot, proving both
+halves were restored.
+
 All slow VM I/O (inject -> reload -> reboot -> recovery poll) lives in the MODULE
 FIXTURE, never the test body: the smoke workflow caps the test BODY at 30s
 (``--timeout=30 timeout_func_only=true``) but fixtures are exempt (same reason the
@@ -39,6 +46,7 @@ pytestmark = pytest.mark.reboot
 
 VAR_WIPE_SENTINEL = "/var/PFB_SMOKE_468_WIPE"
 PFB_UNBOUND = "/var/unbound/pfb_unbound.py"
+PFB_PY_TLD = "/var/unbound/pfb_py_tld.txt"  # issue #1255: TLD-Wildcard oracle, archive-EXCLUDED, re-staged
 RECOVERY_DEADLINE = 240  # seconds to wait for DNSBL to self-heal post-reboot
 
 
@@ -53,6 +61,11 @@ class DnsblRebootObservation:
     var_unbound_ls: str
     recovered: bool
     recovered_after_s: int
+    # issue #1255: TLD-Wildcard blocking observed over the SAME reboot cycle.
+    wild_sub_domain: str
+    wild_sinkholes_before: bool
+    tld_oracle_staged_after: bool
+    wild_recovered: bool
 
 
 def _sinkholes(vm: SmokeVM, domain: str) -> bool:
@@ -98,24 +111,35 @@ def dnsbl_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]: 
 def reboot_observation(dnsbl_vm: SmokeVM) -> DnsblRebootObservation:
     """ALL slow VM I/O for the #468 scenario — runs in the fixture (no 30s body cap).
 
-    Given a DNSBL feed blocking a unique domain with RAM-disk /var enabled,
-      And the domain sinkholes (DNSBL works before the reboot),
+    Given a DNSBL feed blocking a unique domain (TLD-Wildcard ON, so a second listed
+      2-label domain wildcard-blocks a never-listed sub-domain too) with RAM-disk
+      /var enabled, and both sinkhole (DNSBL works before the reboot),
     When the guest is rebooted (MFS wipes /var/unbound; the boot re-stage runs),
-    Then capture: /var really wiped (MFS), pfb_unbound.py re-staged, and whether the
-      domain self-recovers to the sinkhole within RECOVERY_DEADLINE (no manual update).
+    Then capture: /var really wiped (MFS), pfb_unbound.py re-staged, the TLD-Wildcard
+      oracle re-staged, and whether the domain AND the wildcard sub-domain self-recover
+      to the sinkhole within RECOVERY_DEADLINE (no manual update).
     """
     vm = dnsbl_vm
     domain = h.unique_domain("pfb468")
+    # issue #1255: a 2-label registrable domain -- TLD-Wildcard ON wildcard-blocks it
+    # AND every sub-domain; `wild_sub_domain` is never itself listed, so it sinkholing
+    # proves the ZONE match survived the reboot, not a coincidental exact hit.
+    wild_domain = h.unique_domain("pfb468tld")
+    wild_sub_domain = "x." + wild_domain
 
-    # Given: RAM disks ON before the reload; a DNSBL feed blocking `domain`, applied.
+    # Given: RAM disks ON before the reload; a DNSBL feed blocking `domain` and
+    # `wild_domain`, TLD-Wildcard ON, applied.
     h.set_ramdisk(vm, True)
-    feed_url = h.write_local_feed(vm, "issue468.txt", f"{domain}\n")
-    spec = h.DnsblCase(aliasname="smoke468", feed_url=feed_url, header="smoke468", mode=h.DnsblMode.VIP)
+    feed_url = h.write_local_feed(vm, "issue468.txt", f"{domain}\n{wild_domain}\n")
+    spec = h.DnsblCase(
+        aliasname="smoke468", feed_url=feed_url, header="smoke468", mode=h.DnsblMode.VIP, tld_enabled=True
+    )
     h.inject(vm, spec)
     h.reload(vm, "update")
     h.wait_unbound_ready(vm)
 
     sinkholes_before = _sinkholes(vm, domain)
+    wild_sinkholes_before = _sinkholes(vm, wild_sub_domain)
 
     # MFS proof sentinel, then reboot.
     vm.ssh("/usr/bin/touch", VAR_WIPE_SENTINEL)
@@ -124,14 +148,18 @@ def reboot_observation(dnsbl_vm: SmokeVM) -> DnsblRebootObservation:
 
     var_wiped = vm.ssh("test", "-e", VAR_WIPE_SENTINEL).returncode != 0
     staged_after = vm.ssh("test", "-f", PFB_UNBOUND).returncode == 0
+    tld_oracle_staged_after = vm.ssh("test", "-f", PFB_PY_TLD).returncode == 0
     var_unbound_ls = vm.ssh("/bin/ls", "-la", "/var/unbound").stdout
 
-    # Poll for self-recovery (pfb_unbound.py staged AND sinkholing) with NO manual update.
+    # Poll for self-recovery (pfb_unbound.py staged AND both sinkholes) with NO manual update.
     waited = 0
     recovered = False
+    wild_recovered = False
     while waited <= RECOVERY_DEADLINE:
-        if vm.ssh("test", "-f", PFB_UNBOUND).returncode == 0 and _sinkholes(vm, domain):
-            recovered = True
+        staged_now = vm.ssh("test", "-f", PFB_UNBOUND).returncode == 0
+        recovered = recovered or (staged_now and _sinkholes(vm, domain))
+        wild_recovered = wild_recovered or (staged_now and _sinkholes(vm, wild_sub_domain))
+        if recovered and wild_recovered:
             break
         time.sleep(10)
         waited += 10
@@ -144,6 +172,10 @@ def reboot_observation(dnsbl_vm: SmokeVM) -> DnsblRebootObservation:
         var_unbound_ls=var_unbound_ls,
         recovered=recovered,
         recovered_after_s=waited,
+        wild_sub_domain=wild_sub_domain,
+        wild_sinkholes_before=wild_sinkholes_before,
+        tld_oracle_staged_after=tld_oracle_staged_after,
+        wild_recovered=wild_recovered,
     )
 
 
@@ -165,4 +197,33 @@ def test_dnsbl_survives_ramdisk_var_reboot(reboot_observation: DnsblRebootObserv
     assert obs.recovered, (
         f"#468: {obs.domain} did not sinkhole again within {RECOVERY_DEADLINE}s of a RAM-disk reboot "
         f"(staged_after={obs.staged_after}); DNSBL stays down until a manual update"
+    )
+
+
+def test_dnsbl_tld_wildcard_survives_ramdisk_var_reboot(reboot_observation: DnsblRebootObservation) -> None:
+    """issue #1255: TLD-Wildcard blocking (oracle + ini) survives a RAM-disk /var reboot.
+
+    Given TLD-Wildcard ON wildcard-blocks a never-listed sub-domain of a listed
+    2-label domain BEFORE the reboot,
+    When the RAM-disk /var reboot wipes /var/unbound,
+    Then the shipped oracle is re-staged fresh (``dnsbl_cache_stage()``, archive-
+    EXCLUDED like ``pfb_py_hsts.txt``) and the archived ini (``python_tld_wildcard =
+    on``) is restored, so the sub-domain STILL sinkholes with NO manual update.
+    """
+    obs = reboot_observation
+
+    # Precondition: the wildcard ZONE covered the sub-domain BEFORE the reboot.
+    assert obs.wild_sinkholes_before, (
+        f"precondition: {obs.wild_sub_domain} must sinkhole (TLD-Wildcard ON) before the reboot"
+    )
+    # issue #1255 core: the shipped oracle re-staged into the chroot after the wipe.
+    assert obs.tld_oracle_staged_after, (
+        f"issue #1255: {PFB_PY_TLD} missing after RAM-disk reboot (TLD-Wildcard oracle not re-staged)."
+        f"\n/var/unbound:\n{obs.var_unbound_ls}"
+    )
+    # End-state: still sinkholing — the wildcard ZONE survived the reboot, no manual update.
+    assert obs.wild_recovered, (
+        f"issue #1255: {obs.wild_sub_domain} did not sinkhole again within {RECOVERY_DEADLINE}s of a "
+        f"RAM-disk reboot (oracle_staged={obs.tld_oracle_staged_after}); TLD-Wildcard blocking stays "
+        "down until a manual update"
     )

--- a/tests/smoke/test_smoke_tld_wildcard.py
+++ b/tests/smoke/test_smoke_tld_wildcard.py
@@ -1,0 +1,122 @@
+"""Live-VM smoke for issue #1255 -- DNSBL Wildcard Blocking (TLD) toggle.
+
+``pfb_tld`` (ini ``python_tld_wildcard``) gates whether ``pfb_unbound.py``'s
+``classify()`` opens the shipped public-suffix oracle (``pfb_py_tld.txt``, staged
+from ``dnsbl_tld`` by ``dnsbl_cache_stage()``, mirroring HSTS). ON: a listed 2-label
+registrable domain (e.g. ``label-<uuid>.com``) classifies into a wildcard ZONE, which
+blocks the domain AND every sub-domain at any depth. OFF: the oracle is never opened
+(``tlds`` is empty), so ``classify()`` forces EXACT DATA for every domain -- only the
+literally-listed name blocks; an unlisted sub-domain resolves normally.
+
+The toggle applies on the NEXT NORMAL Update (``reload(vm, "update")`` -- scope=both
+force=false trigger=cron), NOT a Force Reload: ``pfb_unbound_python()`` rewrites the
+ini, the ini content differs, ``$pfbpython = TRUE``, and ``pfb_update_unbound()``
+restarts the DNSBL python integration re-reading it.
+
+Probed via a real LAN client (``dns_probe_client``, mirrors ``test_smoke_dnsbl_control.py``):
+a not-blocked sub-domain must RESOLVE to a KNOWN, observable answer, not just "not
+VIP" -- ``use_system_dns_upstream`` + the ``stub_dns`` server give a deterministic
+``STUB_DNS_A`` sentinel for anything pfSense forwards (ADR-16 Part C's RESOLVE-PROOF
+pattern), so a false-green from a real-DNS NXDOMAIN/timeout is impossible.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import STUB_DNS_A, SmokeVM, _StubDnsServer
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.fixture(scope="module")
+def tld_vm(smoke_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[tuple[SmokeVM, str]]:
+    """Deploy once with DNSBL Wildcard Blocking (TLD) ON and one 2-label domain listed.
+
+    A single local feed pins a unique registrable domain (``label-<uuid>.com``) to a
+    VIP block; ``tld_enabled=True`` on the case writes ``pfb_tld = on`` at inject time
+    (``inject()``'s DNSBL-settings replace, same as ``control``/``hsts`` -- #588).
+    System DNS is pointed at the controlled stub so a not-blocked probe has a known
+    answer. Yields ``(vm, domain)``.
+    """
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+    h.deploy(smoke_vm)
+    h.ensure_dnsbl_vip(smoke_vm)
+    h.use_system_dns_upstream(smoke_vm)
+
+    domain = h.unique_domain("tldwild")
+    feed = h.write_local_feed(smoke_vm, "smoke_tldwild_feed.txt", f"{domain}\n")
+    spec = h.DnsblCase(
+        aliasname="smoketldwild", feed_url=feed, header="smoketldwild", mode=h.DnsblMode.VIP, tld_enabled=True
+    )
+    h.inject(smoke_vm, spec)
+    h.reload(smoke_vm, "update")
+    # No assert_tld_wildcard_ini guard here (unlike sibling assert_control_ini
+    # fixtures): the ini key is BRAND-NEW (#1255) -- a hard guard would abort setup
+    # on pre-fix code, masking the test's own (deferred) red discriminator.
+    h.assert_link_health(client_vm, smoke_vm, control_name=h.unique_domain())
+    try:
+        yield smoke_vm, domain
+    finally:
+        h.unblock_egress()
+        try:
+            h.clear_dnsbl_settings(smoke_vm)
+        except Exception as cleanup_exc:  # noqa: BLE001
+            print(f"[smoke] clear_dnsbl_settings failed on tld-wildcard teardown (suppressed): {cleanup_exc!r}")
+        h.collect_host_diagnostics(smoke_vm)
+
+
+def test_tld_wildcard_toggle_governs_subdomain_blocking(tld_vm: tuple[SmokeVM, str], client_vm: SmokeVM) -> None:
+    """Scenario: the TLD-Wildcard toggle governs sub-domain blocking, not the listed name.
+
+    Background: DNSBL Wildcard Blocking (TLD) is ON (the fixture baseline) and
+    ``domain`` (a 2-label registrable ``uuid-*.com``) is feed-listed; ``sub`` (a fresh
+    label prepended to ``domain``) is never itself listed.
+    Given TLD-Wildcard ON, ``domain`` is VIP-blocked AND ``sub`` is ALSO VIP-blocked --
+    the wildcard ZONE covers it (the before-state, so the toggle's effect below is
+    provably causal, not a pre-existing accident).
+    When TLD-Wildcard is turned OFF and a NORMAL Update runs (``reload(vm, "update")``
+    -- force=false, NOT a Force Reload),
+    Then ``domain`` STAYS VIP-blocked (the exact DATA entry survives the toggle) but
+    ``sub`` now RESOLVES via the controlled stub upstream -- proving OFF collapses to
+    exact-only matching, no wildcard.
+    """
+    vm, domain = tld_vm
+    sub = "x." + domain
+
+    # GIVEN: TLD-Wildcard ON -- domain AND its never-listed sub-domain both VIP-blocked.
+    before_domain = h.dns_probe_client(client_vm, domain, "A")
+    assert h.is_vip(before_domain), f"{domain} expected VIP block with TLD-Wildcard on, got {before_domain}"
+    before_sub = h.dns_probe_client(client_vm, sub, "A")
+    assert h.is_vip(before_sub), f"{sub} expected VIP block (wildcard ZONE) with TLD-Wildcard on, got {before_sub}"
+
+    # WHEN: TLD-Wildcard OFF + a NORMAL Update (scope=update -> force=false; never Force Reload).
+    h.set_dnsbl_tld_wildcard(vm, False)
+    h.reload(vm, "update")
+    # Defend against a stale cached answer surviving the reload regardless of whether
+    # it took the restart or in-place-reinit path -- flush before the after-state probes.
+    h.flush_unbound_cache(vm)
+
+    # THEN: domain (the exact DATA entry) is UNCHANGED -- still VIP-blocked.
+    after_domain = h.dns_probe_client(client_vm, domain, "A")
+    assert h.is_vip(after_domain), (
+        f"{domain} should STAY VIP-blocked (exact DATA) with TLD-Wildcard off, got {after_domain}"
+    )
+
+    # AND: sub now resolves via the stub -- the PRIMARY discriminator (the wildcard
+    # zone no longer applies). This is the assertion that must fail on pre-fix code.
+    after_sub = h.dns_probe_client(client_vm, sub, "A")
+    assert h.resolves_to(after_sub, STUB_DNS_A), (
+        f"{sub} should resolve via the stub with TLD-Wildcard off, got {after_sub}"
+    )
+    assert not h.is_vip(after_sub), f"{sub} unexpectedly still VIP-blocked with TLD-Wildcard off: {after_sub}"
+    assert not h.is_null_ip(after_sub), f"{sub} unexpectedly NULL-blocked with TLD-Wildcard off: {after_sub}"
+
+    # Attribution (reached only once the behavioural transition above is proven): the
+    # ini reflects the OFF state -- a real config-write, not an accidental resolve.
+    h.assert_tld_wildcard_ini(vm, on=False)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -102,6 +102,9 @@ PAGE_TABLE: tuple[Page, ...] = (
             "Interface(s)",
             "no-AAAA",
             "pfb_dnsbl_nonat",  # issue-#381 NAT opt-out checkbox (name= attr in rendered HTML)
+            # issue #1255: corrected Wildcard Blocking (TLD) help — no more stale "Force
+            # Reload required" claim; toggling now applies on the next DNSBL update.
+            "Enabling or disabling this option takes effect on the next DNSBL update",
             "pfB_DNSBLIP_v4",  # DNSBL IPs help text names the real alias (was stale 'pfB_DNSBL_IP')
             # Permit-rules help renders as one flowing sentence — a stray <br /> split
             # "...to access<br />the DNSBL Webserver", so this space-joined phrase is the

--- a/tests/test_adr06_init_from_raw.py
+++ b/tests/test_adr06_init_from_raw.py
@@ -13,9 +13,9 @@ new init-from-raw path is decision-equivalent to BOTH:
 over the golden fixtures -- for both TOP1M scenarios, the noAAAA surface, and the
 no-IP-leak guarantee. It also pins the on-box wiring:
 
-  * ``dnsbl_build_from_manifest`` reads a per-feed manifest JSON whose ``config``
-    block carries ``tld_master`` as a FILE PATH (read here, not a Python list) and
-    whose feeds reference raw files relative to the manifest dir;
+  * ``dnsbl_build_from_manifest`` reads a per-feed manifest JSON whose feeds
+    reference raw files relative to the manifest dir; the public-suffix oracle
+    (issue #1255) is a SHIPPED file gated by an ini flag, not a manifest key;
   * ``top1m_enabled`` is driven by ``config["top1m_enabled"]`` in the manifest;
   * ``dnsbl_emit_count`` writes the LOADED total (len(dataDB)+len(zoneDB)) to
     ``pfb_py_count`` in the format the UI reads (pfblockerng.inc:3149); and
@@ -53,7 +53,6 @@ from tests.test_adr06_golden_oracle import (
     _decision_label,
     _evaluate,
     _load_json,
-    _read_lines,
 )
 
 # --------------------------------------------------------------------------- #
@@ -64,16 +63,27 @@ from tests.test_adr06_golden_oracle import (
 # --------------------------------------------------------------------------- #
 
 
+def _stage_tld_oracle(tmp_path: Any) -> None:
+    """issue #1255: stage the public-suffix oracle the way dnsbl_cache_stage() does
+    (a shipped file) and flip the ini flag -- the manifest no longer carries
+    tld_master at all (HSTS parity)."""
+    oracle = os.path.join(str(tmp_path), "pfb_py_tld.txt")
+    shutil.copyfile(os.path.join(FIXTURES, "tld_master.txt"), oracle)
+    pfb_unbound.pfb["python_tld_wildcard"] = True
+    pfb_unbound.pfb["pfb_py_tld"] = oracle
+
+
 def _write_onbox_manifest(tmp_path: Any, *, top1m_enabled: bool) -> str:
     """Write a single manifest JSON (feeds + config) with its raw files copied under
     the manifest directory.
 
     This mirrors the PRODUCTION shape (pfblockerng.inc): the manifest lives at the
-    chroot root and every feed ``raw`` / ``tld_master`` it references resolves UNDER
-    that directory (the build now confines manifest paths to the manifest's base dir,
-    so an out-of-base reference is skipped). The committed fixtures are copied into a
-    ``pfb_py_raw/`` subdir of tmp_path and referenced RELATIVELY, and ``tld_master``
-    is copied alongside and referenced by name -- the build reads it as a PATH.
+    chroot root and every feed ``raw`` it references resolves UNDER that directory
+    (the build confines manifest paths to the manifest's base dir, so an out-of-base
+    reference is skipped). The committed fixtures are copied into a ``pfb_py_raw/``
+    subdir of tmp_path and referenced RELATIVELY. issue #1255: the public-suffix
+    oracle (formerly ``config.tld_master``) is staged as a shipped file + ini flag
+    instead (``_stage_tld_oracle``) -- the manifest no longer carries it.
     """
     src_manifest = _load_json("manifest.json")
     src_config = _load_json("config.json")
@@ -94,12 +104,11 @@ def _write_onbox_manifest(tmp_path: Any, *, top1m_enabled: bool) -> str:
             }
         )
 
-    shutil.copyfile(os.path.join(FIXTURES, "tld_master.txt"), os.path.join(str(tmp_path), "tld_master.txt"))
+    _stage_tld_oracle(tmp_path)
 
     manifest = {
         "version": 1,
         "config": {
-            "tld_master": "tld_master.txt",  # PATH (in-base), read on build
             "tld_blacklist": src_config.get("tld_blacklist", []),
             "tld_exclusion": src_config.get("tld_exclusion", []),
             "user_whitelist": src_config.get("user_whitelist", []),
@@ -303,11 +312,11 @@ class TestManifestFallback:
         # OTHER feeds rather than aborting (the bad feed is logged + skipped). All
         # referenced paths live UNDER the manifest dir (the production/confined shape).
         path = os.path.join(str(tmp_path), "m.json")
-        shutil.copyfile(os.path.join(FIXTURES, "tld_master.txt"), os.path.join(str(tmp_path), "tld_master.txt"))
+        _stage_tld_oracle(tmp_path)
         shutil.copyfile(os.path.join(FIXTURES, "feed_plain.txt"), os.path.join(str(tmp_path), "feed_plain.txt"))
         manifest = {
             "version": 1,
-            "config": {"tld_master": "tld_master.txt"},
+            "config": {},
             "feeds": [
                 {
                     "raw": "does_not_exist.txt",
@@ -408,38 +417,28 @@ class TestInitGlobalAssignment:
         assert _decision_label(dec) == "whitelist"
 
 
-class TestTldMasterPath:
-    def test_tld_master_path_is_read(self, tmp_path: Any) -> None:
-        # With the public-suffix master read from the PATH, co.uk classifies as a
-        # multi-label public suffix -> shop.co.uk is a ZONE (registrable parent).
+class TestTldWildcardOracleWiring:
+    """issue #1255: the public-suffix oracle is a SHIPPED file gated by
+    ``python_tld_wildcard`` (staged by ``_stage_tld_oracle``), never a manifest
+    key -- end-to-end through the real ``dnsbl_build_from_manifest`` path."""
+
+    def test_oracle_staged_and_on_classifies_public_suffix_as_zone(self, tmp_path: Any) -> None:
+        # With the oracle staged and the flag on, co.uk classifies as a multi-label
+        # public suffix -> shop.co.uk is a ZONE (registrable parent).
         result = _build_from_manifest(tmp_path, top1m_enabled=False)
         assert "shop.co.uk" in result.zone_db
         assert "tracker.org" in result.zone_db
 
-    def test_tld_master_lines_also_supported(self) -> None:
-        # The build config also accepts tld_master as a list of lines directly
-        # (used by the Phase-3 unit tests); the path form must be equivalent.
-        manifest = {
-            "version": 1,
-            "config": {
-                "tld_master": _read_lines("tld_master.txt"),
-                "tld_blacklist": [],
-                "tld_exclusion": [],
-                "user_whitelist": [],
-                "top1m_list": [],
-            },
-            "feeds": [
-                {
-                    "raw": os.path.join(FIXTURES, "feed_plain.txt"),
-                    "feed": "PlainFeed",
-                    "group": "Malware",
-                    "log_flag": "1",
-                }
-            ],
-        }
-        # Reach into the helper that shapes config so the list path is exercised.
-        config = pfb_unbound._dnsbl_config_from_manifest(manifest, FIXTURES)
-        assert config["tld_master"] == _read_lines("tld_master.txt")
+    def test_oracle_off_forces_exact_data_even_when_file_is_staged(self, tmp_path: Any) -> None:
+        # Before-state: ON classifies as ZONE (proven above). With the SAME staged
+        # file but the flag OFF, the domain must flip to exact DATA -- the toggle
+        # gates the WHOLE wildcard-blocking contribution (the bug issue #1255 fixes).
+        manifest_path = _write_onbox_manifest(tmp_path, top1m_enabled=False)
+        pfb_unbound.pfb["python_tld_wildcard"] = False  # override the helper's ON default
+        result = pfb_unbound.dnsbl_build_from_manifest(manifest_path)
+        assert result is not None
+        assert "shop.co.uk" in result.data_db
+        assert "shop.co.uk" not in result.zone_db
 
 
 class TestUserUnlockManifest:
@@ -450,7 +449,6 @@ class TestUserUnlockManifest:
         manifest = {
             "version": 1,
             "config": {
-                "tld_master": [],
                 "user_unlock": ["evil.com", ".wild.net"],
             },
             "feeds": [],
@@ -471,7 +469,6 @@ class TestUserUnlockManifest:
         manifest = {
             "version": 1,
             "config": {
-                "tld_master": _read_lines("tld_master.txt"),
                 "user_unlock": ["evil.com"],
             },
             "feeds": [{"raw": "feed.raw", "feed": "F", "group": "G", "log_flag": "1"}],
@@ -487,9 +484,10 @@ class TestUserUnlockManifest:
             "important": True,
             "band": pfb_unbound.PRIO_USER_ALLOW,
         }
-        # The feed still records the block (evil.com is a registrable zone); the
-        # allow overrides it at query time.
-        assert "evil.com" in result.zone_db
+        # issue #1255: no oracle staged here -> exact DATA (not a wildcard zone); the
+        # feed still records the block either way -- the allow overrides at query time.
+        assert "evil.com" in result.data_db
+        assert "evil.com" not in result.zone_db
         config = pfb_unbound._dnsbl_config_from_manifest(manifest, str(tmp_path))
         got = _evaluate_result(result, {**config, "hsts_domains": []}, "evil.com")
         assert got["decision"] == "whitelist"

--- a/tests/test_adr06_php_boundary.py
+++ b/tests/test_adr06_php_boundary.py
@@ -99,14 +99,16 @@ def _write_plain_boundary_manifest(tmp_path: Any, *, top1m_enabled: bool) -> tup
             }
         )
 
-    # tld_master must resolve UNDER the manifest dir (the build confines manifest
-    # paths to their base dir) -- copy it alongside the feeds and reference by name.
-    shutil.copyfile(os.path.join(FIXTURES, "tld_master.txt"), os.path.join(str(tmp_path), "tld_master.txt"))
+    # issue #1255: the public-suffix oracle is a SHIPPED file gated by an ini flag,
+    # not a manifest key (HSTS parity) -- stage it exactly like dnsbl_cache_stage().
+    oracle = os.path.join(str(tmp_path), "pfb_py_tld.txt")
+    shutil.copyfile(os.path.join(FIXTURES, "tld_master.txt"), oracle)
+    pfb_unbound.pfb["python_tld_wildcard"] = True
+    pfb_unbound.pfb["pfb_py_tld"] = oracle
 
     manifest = {
         "version": 1,
         "config": {
-            "tld_master": "tld_master.txt",
             "tld_blacklist": src_config.get("tld_blacklist", []),
             "tld_exclusion": src_config.get("tld_exclusion", []),
             "user_whitelist": src_config.get("user_whitelist", []),

--- a/tests/test_adr10_concurrency.py
+++ b/tests/test_adr10_concurrency.py
@@ -19,7 +19,9 @@ Mechanism map (each produced via the manifest/ini/config; bands per ADR-07 SS2)
 -----------------------------------------------------------------------------------
 BLOCK (gen1 blocked, gen2 allowed -- except the per-mechanism CONTROL, still blocked):
   m1 generic exact   -> dataDB  band 1  (plain feed, 3-part name -> classify DATA)
-  m2 generic zone    -> zoneDB  band 1  (plain feed, 2-part name + tld_master -> ZONE)
+  m2 generic exact   -> dataDB  band 1  (plain feed, 2-part name; issue #1255: the
+                                          oracle is no longer manifest-driven, so this
+                                          lane now exercises dataDB, not zoneDB)
   m3 abp anchored    -> dataDB  band 1  (||sub.d.com^, 3-part -> DATA)
   m4 abp regex       -> regexDB band 1  (irreducible /re/)
   m5 abp $important  -> dataDB  band 3  (||sub.d.com^$important)

--- a/tests/test_adr62_byte_identity_corpus.py
+++ b/tests/test_adr62_byte_identity_corpus.py
@@ -93,10 +93,14 @@ def _allowed(result: P.BuildResult, domain: str) -> bool:
 
 
 def test_plain_hosts_feed_domains_are_blocked() -> None:
+    # issue #1255: this corpus's tld_master is empty (TLD-Wildcard OFF) -- a 2-label
+    # domain no longer auto-zones; it lands in data_db (exact), same as any other
+    # domain with no known public-suffix parent.
     result = _run_corpus_build()
     for domain in ("plainhost1.example", "plainhost2.example"):
         assert _blocked(result, domain), domain
-        assert domain in result.zone_db, f"{domain}: 2-label domain must auto-zone"
+        assert domain in result.data_db, f"{domain}: exact DATA with an empty (TLD-Wildcard OFF) oracle"
+        assert domain not in result.zone_db
 
 
 # --------------------------------------------------------------------------- #
@@ -181,17 +185,19 @@ def test_abp_feed_element_hiding_line_produces_no_domain() -> None:
     assert not _allowed(result, "some.abp.example")
 
 
-def test_abp_feed_bare_registrable_parent_stays_zone_delta_d1() -> None:
+def test_abp_feed_bare_registrable_parent_stays_data_delta_d1() -> None:
     """delta D1 (ADR.md SS2), registrable-parent case: a bare 2-label line in a
     feed that WAS header-classified ABP used to reach a wildcard ZONE via
     parse_abp (#718); the classifier is now deleted, so the same line takes
-    the plain classify() path -- a 2-label domain is UNCONDITIONALLY its own
-    registrable parent, so the observable stays ZONE (same as before)."""
+    the plain classify() path. issue #1255: this corpus's tld_master is empty
+    (TLD-Wildcard OFF), so classify()'s top guard forces exact DATA -- the same
+    outcome as any other domain with no known public-suffix parent."""
     result = _run_corpus_build()
-    assert "abproot.example" in result.zone_db, (
-        "delta D1: a registrable-parent bare line in a former-ABP feed must still "
-        "land in zone_db under the plain classify() path"
+    assert "abproot.example" in result.data_db, (
+        "delta D1 + issue #1255: a registrable-parent bare line in a former-ABP feed "
+        "is exact DATA under the plain classify() path with an empty (OFF) oracle"
     )
+    assert "abproot.example" not in result.zone_db
 
 
 def test_abp_feed_bare_deeper_subdomain_flips_zone_to_data_delta_d1() -> None:

--- a/tests/test_branch_coverage_gaps.py
+++ b/tests/test_branch_coverage_gaps.py
@@ -42,7 +42,6 @@ from pfb_unbound import (
     NameVerdict,
     Rule,
     _dnsbl_classify_options,
-    _dnsbl_config_from_manifest,
     _dnsbl_load_tld_master,
     _dnsbl_normalise_whitelist,
     _dnsbl_parse_abp_regex,
@@ -526,10 +525,10 @@ class TestBuildBranches:
 # manifest I/O error branches
 # --------------------------------------------------------------------------- #
 class TestManifestErrorBranches:
-    def test_config_from_manifest_unreadable_tld_master_yields_empty(self) -> None:
-        # A tld_master FILE path that cannot be opened -> logged + empty list (no raise).
-        cfg = _dnsbl_config_from_manifest({"config": {"tld_master": "/no/such/file/xyz"}}, "/tmp")
-        assert cfg["tld_master"] == []
+    # issue #1255: tld_master is no longer read from the manifest at all (retired
+    # with the manifest-path confinement mechanism) -- the oracle's own
+    # missing/unreadable-file fail-safe is pinned in
+    # test_manifest_path_confinement.py::TestTldWildcardOracleGating.
 
     def test_build_from_manifest_returns_none_when_build_raises(self, tmp_path: Path) -> None:
         # A feeds row missing the "feed" key makes build() raise KeyError -> the

--- a/tests/test_manifest_path_confinement.py
+++ b/tests/test_manifest_path_confinement.py
@@ -1,12 +1,16 @@
-"""Manifest path confinement: a feed ``raw`` / ``tld_master`` path that resolves
-OUTSIDE the manifest's base directory is skipped and logged, never opened.
+"""Manifest path confinement: a feed ``raw`` path that resolves OUTSIDE the
+manifest's base directory is skipped and logged, never opened.
 
-The manifest is published next to its raw feeds, so every referenced file must
-resolve under the manifest directory. A row whose resolved real path escapes that
-directory (``..`` traversal, an absolute path elsewhere, or a symlink pointing out)
-is refused. Both branches are pinned for each sink (``_dnsbl_file_line_reader`` for
-feed ``raw`` paths, ``_dnsbl_config_from_manifest`` for ``tld_master``):
-in-base content is read; out-of-base content is skipped with a stderr log line.
+The manifest is published next to its raw feeds, so every referenced ``raw`` file
+must resolve under the manifest directory. A row whose resolved real path escapes
+that directory (``..`` traversal, an absolute path elsewhere, or a symlink pointing
+out) is refused (``_dnsbl_file_line_reader``): in-base content is read; out-of-base
+content is skipped with a stderr log line.
+
+issue #1255: ``_dnsbl_config_from_manifest`` no longer reads ``tld_master`` from the
+manifest at all (HSTS parity -- a shipped static file gated by ``python_tld_wildcard``
+instead), so its confinement coverage retired with that mechanism; see
+``TestTldWildcardOracleGating`` for the replacement contract.
 
 Scenario: confine manifest file references under base_dir
   Background: a base dir holding an in-base file, and an out-of-base file alongside
@@ -88,38 +92,54 @@ class TestPathWithinBaseHelper:
         assert pfb_unbound._dnsbl_path_within_base("/etc/passwd", "/var/unbound/pfb") is False
 
 
-class TestTldMasterPathConfinement:
-    def test_in_base_tld_master_is_read(self, tmp_path: Any) -> None:
-        # Given a tld_master file inside the base dir, referenced by name.
-        base = tmp_path / "base"
-        base.mkdir()
-        (base / "tlds.txt").write_text("com\nnet\n", encoding="utf-8")
-        manifest = {"config": {"tld_master": "tlds.txt"}}
+class TestTldWildcardOracleGating:
+    """issue #1255: the public-suffix oracle (``tld_master`` suffix lines fed to
+    ``_dnsbl_load_tld_master``) is sourced from a SHIPPED file
+    (``pfb["pfb_py_tld"]``) gated by ``pfb["python_tld_wildcard"]`` -- HSTS parity
+    -- never from the manifest. A manifest carrying a stale/malicious
+    ``config.tld_master`` key (an old install, or a crafted manifest) is ignored
+    entirely; the flag is the sole gate.
+    """
 
-        # When the config is shaped from the manifest.
-        config = pfb_unbound._dnsbl_config_from_manifest(manifest, str(base))
+    def setup_method(self) -> None:
+        pfb_unbound.pfb["python_tld_wildcard"] = False
+        pfb_unbound.pfb["pfb_py_tld"] = ""
 
-        # Then the in-base suffix lines are loaded.
+    def test_oracle_not_loaded_when_flag_off_even_if_file_exists(self, tmp_path: Any) -> None:
+        oracle = tmp_path / "pfb_py_tld.txt"
+        oracle.write_text("com\nnet\n", encoding="utf-8")
+        pfb_unbound.pfb["python_tld_wildcard"] = False
+        pfb_unbound.pfb["pfb_py_tld"] = str(oracle)
+
+        config = pfb_unbound._dnsbl_config_from_manifest({"config": {}}, str(tmp_path))
+
+        assert config["tld_master"] == [], "OFF must never load the oracle, even though the file exists"
+
+    def test_oracle_loaded_when_flag_on_and_file_present(self, tmp_path: Any) -> None:
+        oracle = tmp_path / "pfb_py_tld.txt"
+        oracle.write_text("com\nnet\n", encoding="utf-8")
+        pfb_unbound.pfb["python_tld_wildcard"] = True
+        pfb_unbound.pfb["pfb_py_tld"] = str(oracle)
+
+        config = pfb_unbound._dnsbl_config_from_manifest({"config": {}}, str(tmp_path))
+
         assert config["tld_master"] == ["com", "net"]
 
-    def test_out_of_base_tld_master_is_skipped_and_logged(
-        self, tmp_path: Any, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        # Given a tld_master file OUTSIDE the base dir, reached via traversal.
-        base = tmp_path / "base"
-        base.mkdir()
-        (tmp_path / "tlds.txt").write_text("evil\n", encoding="utf-8")
+    def test_oracle_empty_when_flag_on_but_file_missing(self, tmp_path: Any) -> None:
+        # Fail-safe: ON but no oracle staged yet -> empty, never a raise/crash.
+        pfb_unbound.pfb["python_tld_wildcard"] = True
+        pfb_unbound.pfb["pfb_py_tld"] = str(tmp_path / "does_not_exist.txt")
 
-        # Before-state: an in-base tld_master of the same name IS loaded.
-        (base / "tlds.txt").write_text("com\n", encoding="utf-8")
-        inbase = pfb_unbound._dnsbl_config_from_manifest({"config": {"tld_master": "tlds.txt"}}, str(base))
-        assert inbase["tld_master"] == ["com"]
-        capsys.readouterr()
+        config = pfb_unbound._dnsbl_config_from_manifest({"config": {}}, str(tmp_path))
 
-        # When the manifest points tld_master at an escaping path.
-        manifest = {"config": {"tld_master": os.path.join("..", "tlds.txt")}}
-        config = pfb_unbound._dnsbl_config_from_manifest(manifest, str(base))
-
-        # Then no suffix lines are loaded and the refusal is logged.
         assert config["tld_master"] == []
-        assert "Refusing tld_master outside base dir" in capsys.readouterr().err
+
+    def test_manifest_tld_master_key_is_ignored_regardless_of_flag(self, tmp_path: Any) -> None:
+        # A manifest embedding tld_master (stale pre-#1255 shape, or crafted) must
+        # never feed the oracle -- the flag + shipped file are the sole source.
+        pfb_unbound.pfb["python_tld_wildcard"] = False
+        manifest = {"config": {"tld_master": "/etc/passwd"}}
+
+        config = pfb_unbound._dnsbl_config_from_manifest(manifest, str(tmp_path))
+
+        assert config["tld_master"] == []

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -37,7 +37,11 @@ from unboundmodule import (
 
 import pfb_unbound
 from pfb_unbound import (
+    DNSBL_CLASS_DATA,
+    DNSBL_CLASS_ZONE,
+    _dnsbl_load_tld_master,
     _parse_ini_int,
+    classify,
     convert_ipv4,
     convert_ipv6,
     convert_other,
@@ -3686,3 +3690,63 @@ class TestADR02PythonOnlyBlocking:
         assert entry is not None
         assert entry.dnsbl.b_type == "TLD"
         assert entry.dnsbl.feed == "ZoneFeed"
+
+
+class TestClassifyTldWildcardOffEmptyOracle:
+    """issue #1255: DNSBL Wildcard Blocking (TLD) OFF must force EXACT matching
+    for every domain, including a bare 2-label registrable name -- the dcnt==2
+    branch never consulted ``tlds``, so an empty oracle alone did not gate it.
+
+    Scenario: TLD-Wildcard toggled OFF (empty oracle) vs ON (oracle loaded)
+      Given a 2-label domain (evil.com) and a 3-label public-suffix domain
+        (example.co.uk)
+      When the oracle is empty (OFF)  Then both classify as exact DATA
+      When the oracle is populated (ON)  Then both classify as wildcard ZONE
+        (unchanged, proving the guard only fires when the oracle is empty)
+    """
+
+    def test_tld_wildcard_off_empty_oracle_two_label_is_data(self) -> None:
+        # Before the #1255 fix this returned (DNSBL_CLASS_ZONE, "evil.com") --
+        # the RED proof: the dcnt==2 branch never consulted tlds.
+        assert classify("evil.com", {}, set()) == (DNSBL_CLASS_DATA, "evil.com")
+
+    def test_tld_wildcard_off_empty_oracle_public_suffix_is_data(self) -> None:
+        assert classify("example.co.uk", {}, set()) == (DNSBL_CLASS_DATA, "example.co.uk")
+
+    def test_two_label_domain_stays_zone_when_oracle_populated(self) -> None:
+        # Before-state proven above (empty oracle -> DATA); with the SAME domain
+        # and a populated oracle, the guard must not fire -- ON-side is unchanged.
+        tlds = _dnsbl_load_tld_master(["com"], [], [])
+        assert classify("evil.com", tlds, set()) == (DNSBL_CLASS_ZONE, "evil.com")
+
+
+class TestAbpWildcardUnaffectedByTldWildcardToggle:
+    """issue #1255: reconcile()/ABP explicit-wildcard classification (||host^) is
+    driven by the ABP anchor shape (parse_abp), never by ``tlds`` -- the
+    TLD-Wildcard toggle (an empty vs. populated oracle) must leave it unchanged
+    in BOTH states, proving no ABP regression from the classify() guard.
+
+    Scenario: TLD-Wildcard toggled OFF (empty oracle) vs ON (oracle populated)
+      Given an ABP feed line ``||evil.com^`` (explicit wildcard anchor)
+      When the oracle is empty (OFF)  Then it still lands in zone_db
+      When the oracle is populated (ON)  Then it still lands in zone_db (unchanged)
+    """
+
+    def _build(self, tld_master: list[str]) -> pfb_unbound.BuildResult:
+        manifest = {"feeds": [{"raw": "f.raw", "feed": "F", "group": "G", "log_flag": "1"}]}
+        config: dict[str, object] = {
+            "tld_master": tld_master,
+            "tld_blacklist": [],
+            "tld_exclusion": [],
+            "user_whitelist": [],
+            "top1m_list": [],
+        }
+        return pfb_unbound.build(manifest, config, line_reader=lambda raw: ["||evil.com^"])
+
+    def test_abp_explicit_wildcard_is_zone_with_oracle_empty(self) -> None:
+        result = self._build([])
+        assert "evil.com" in result.zone_db, "||evil.com^ must stay ZONE with an empty oracle (TLD-Wildcard OFF)"
+
+    def test_abp_explicit_wildcard_is_zone_with_oracle_populated(self) -> None:
+        result = self._build(["com"])
+        assert "evil.com" in result.zone_db, "||evil.com^ must stay ZONE with a populated oracle (TLD-Wildcard ON)"


### PR DESCRIPTION
## Summary

Fixes #1255.

The DNSBL **Wildcard Blocking (TLD)** toggle (`$pfb['dnsbl_tld']`, config key `pfb_tld`) was
inert on the Python/manifest path. With the toggle **off**, registrable domains from plain
feeds were still promoted to wildcard blocks, so every sub-domain of a listed name was blocked
too — over-blocking the user had explicitly turned off.

This was a regression from the ADR-06 manifest port: the toggle's gate used to live at the PHP
call site that classified feed lines, and it was dropped when classification moved into
`pfb_unbound.py`'s `build()`/`classify()`. The Python side always opened the public-suffix
oracle and always promoted 2-label registrable names to wildcard zones, regardless of the
toggle.

## Fix — HSTS-parity oracle

The public-suffix oracle now follows exactly the same shipped-file + ini-flag pattern as HSTS,
rather than being embedded in the manifest:

- **Always-staged shipped file.** `pfb_py_tld.txt` is staged into the Unbound chroot from
  `dnsbl_tld` by `dnsbl_cache_stage()`, mirroring `pfb_py_hsts.txt`. It is name-mapped and
  archive-excluded (re-staged like every shipped file), so it survives a RAM-disk reboot
  (#468) and is refreshed on package upgrade.
- **Ini boolean flag.** `pfb_unbound_python()` emits `python_tld_wildcard` into
  `pfb_unbound.ini`, mirroring `python_hsts`. `pfb_unbound.py` reads it with
  `config.getboolean(...)`; when **off**, `classify()` never opens the oracle (`tlds` is
  empty) and forces exact `DATA` for every domain — only the literally-listed name blocks.
- **Toggle applies on the next normal DNSBL update, not a Force Reload.** Flipping the toggle
  changes the ini content, which sets `$pfbpython = TRUE`; `pfb_update_unbound()` then restarts
  the DNSBL Python integration re-reading the ini. The help text is corrected to say so.
- **Manifest slimmed.** The manifest writer no longer slurps the 97 KB oracle via `@file()`
  into `pfb_py_sources.json`; `tld_blacklist` / `tld_exclusion` stay in the manifest but are
  gated empty when the toggle is off.
- **Change-detection aware.** The oracle path is part of the DNSBL fingerprint input set, and
  `pfb_dnsbl_reload_fingerprint()` narrows the reload fingerprint so a toggle flip is caught by
  the existing zero-downtime reload path.

## Naming note

`python_tld_wildcard` is deliberately distinct from the pre-existing `python_tld` / TLD-Allow
feature (config `pfb_pytld`) — a different setting that shares the "TLD" word. This aligns with
the ADR-66 disambiguation (`tld_wildcard` vs `tld_allow`).

## Tests

- **Unit (red→green, test-first).** `tests/test_pfb_unbound.py` —
  `test_tld_wildcard_off_empty_oracle_two_label_is_data` reproduces the bug (a 2-label domain
  wrongly classified into a wildcard zone with the oracle empty) and pins the fix;
  `TestAbpWildcardUnaffectedByTldWildcardToggle` proves ABP wildcard entries are untouched by
  the toggle.
- **PHP.** `PythonTldWildcardIniEmitTest` (new) pins the ini emission;
  `UnboundPythonSourcesTest` / `DnsblLoadedFingerprintTest` cover the manifest slim-down and the
  narrowed reload fingerprint.
- **Shell.** `pfblockerng_dnsbl_cache_spec.sh` pins the name-mapped stage + archive exclusion.
- **Front-end.** `pfblockerng_dnsbl.php` help-text correction carries a Tier-A `ui_render`
  marker in `test_render_smoke.py`.
- **Live-VM smoke.** `test_smoke_tld_wildcard.py::test_tld_wildcard_toggle_governs_subdomain_blocking`
  and the extended #468 RAM-disk reboot module prove the behaviour end-to-end on a real pfSense
  VM. Proven on leased boxes: **RED** (pre-fix — a never-listed sub-domain is still VIP-blocked)
  → **GREEN** (fix — the sub-domain resolves via the controlled stub after a normal Update, the
  listed domain stays exact-blocked) → **REBOOT** (fix — the oracle re-stages and the wildcard
  block survives a RAM-disk `/var` reboot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
