### PR TITLE
pfblockerng: relocate machine match artifacts to match/generated/ (BREAKING CHANGE) (#1250)

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -442,7 +442,8 @@ missing `.new` sibling away as "no match this pass" — that reconcile is only s
 actually ran. A dropped GeoIP feed cannot silently erase yesterday's match files.
 
 **Match-mode multi-alias emission (a deliberate delta).** `ccblack=match` writes
-`match<alias>.txt` for **every** member alias sharing an offender `/24` window, not just one.
+`pfB_Match_Rep_<alias>.txt` (under `matchdir/generated` — issue #1250) for **every** member
+alias sharing an offender `/24` window, not just one.
 The old `reputation_dmax()` wrote only the first alias in glob order (whichever the filesystem
 happened to enumerate first); the recompute window pass iterates every alias present in that
 window's `winaliases` set, so a shared offender is now visible to every alias whose rows are in

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -152,14 +152,19 @@ when `SMOKE_PKG`/`repo_vm` is absent.
 ## Downgrade-preparation tool — structural reversals the config layer can't cover
 
 The adapter/rollback contract above covers **config.xml scalar values**. A 4.0.x → pre-4.0.x
-downgrade also has two **structural** (filesystem / cron) changes that a config adapter cannot
+downgrade also has three **structural** (filesystem / cron) changes that a config adapter cannot
 reverse and that do **not** self-heal on an older release:
 
 1. **Relocated custom list scripts.** On upgrade, `pfblockerng_install.inc` moves a user's
    `{ip,dnsbl}_{pre,post}_*.{sh,py}` scripts from the package root into `list_scripts/`. A
    pre-4.0.x release resolves list scripts against the package **root only**, so a moved script
    silently stops running after a downgrade.
-2. **The ADR-43 tick cron.** The `pfblockerng.php cron-tick` entry (issue #1204; `pfblockerng.php
+2. **Relocated machine match artifacts (issue #1250).** On upgrade, `pfblockerng_install.inc`
+   moves the machine-owned match artifacts into `match/generated/` under `pfB_Match_*` names. A
+   pre-4.0.x release knows only the old names in the match-folder root, and the leftover
+   `generated/` subdirectory pollutes its alerts glob and permanently satisfies its `ls -A`
+   matchdir presence check.
+3. **The ADR-43 tick cron.** The `pfblockerng.php cron-tick` entry (issue #1204; `pfblockerng.php
    tick` on a pre-#1204 build) replaced the older `cron`/`dcc`/`ss_refresh`/`bl` fleet; an older
    release has neither verb, so the entry becomes an orphan and the update fleet is absent until
    the older release re-syncs.
@@ -169,7 +174,7 @@ Everything else the upgrade changed is already downgrade-safe: new-in-4.0.x conf
 `.xxhash128` feed sidecars and the `.tar.bz2` → `.tar.zst` MFS archive **self-heal** on the next
 feed update / rebuild.
 
-**`scripts/pfb-downgrade-prep.sh`** reverses exactly those two non-self-healing changes. It is a
+**`scripts/pfb-downgrade-prep.sh`** reverses exactly those three non-self-healing changes. It is a
 **dev/ops-only** POSIX-sh tool — **not shipped** in the package (release archives are `src/` only) —
 that an operator copies to the appliance and runs as **root, before** the `pkg` downgrade (never
 fired automatically — a normal upgrade or uninstall must not trigger it):
@@ -179,6 +184,11 @@ fired automatically — a normal upgrade or uninstall must not trigger it):
   so a shipped AWS wrapper is never moved. No pkg query is involved. Caveat: a user script named
   exactly like a shipped wrapper is treated as shipped and left in place — the shipped namespace is
   reserved.
+- Restores the machine match artifacts to their pre-4.0.x names in the match-folder root
+  (`pfB_Match_ET_v4.txt` → `ETMatch.txt`, `pfB_Match_Exempt_v4.txt` → `matchdedup_v4.txt`,
+  `pfB_Match_Rep_<H>_<fam>.txt` → `match<H>_<fam>.txt`), never clobbering a same-named user file,
+  deletes `*.txt.new` strays, and removes `generated/` once emptied (a blocked removal is reported,
+  not forced).
 - Removes the `tick` cron via `pfSsh.php` (the shipped `install_cron_job()`), so config.xml and the
   live crontab are rewritten cleanly.
 
@@ -186,9 +196,10 @@ It is **idempotent** (a second run restores nothing and reports the tick cron al
 prints a short report of what it did.
 
 Coverage: `tests/shell/pfb_downgrade_prep_spec.sh` (shellspec — the file-move logic, the shipped-name
-gate, before/after, idempotency, skip-shipped, skip-existing, and the tick-cron output parsing via a
-fake `pfSsh.php`) and `tests/smoke/test_downgrade_prepare.py` (the tool end-to-end on a live VM,
-`repo` marker — real file moves + real `install_cron_job` tick removal).
+gate, the matchgen reverse-rename map with its no-clobber/stray/rmdir rules, before/after,
+idempotency, skip-shipped, skip-existing, and the tick-cron output parsing via a fake `pfSsh.php`)
+and `tests/smoke/test_downgrade_prepare.py` (the tool end-to-end on a live VM, `repo` marker — real
+file moves, the matchgen reversal, + real `install_cron_job` tick removal).
 
 ## Foreign-key exclusion list (use `config_*_path` directly — NOT via `PfbConfig`)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -177,7 +177,7 @@ in `read-version-matrix.sh`.
 | --- | --- |
 | [`install-from-repo.sh`](install-from-repo.sh) | **First-time install** onto a clean pfSense from `src/` — no Netgate pkg. |
 | [`deploy.sh`](deploy.sh) | Fast code update of an **already-installed** pfBlockerNG: rsync `src/` + restart unbound/nginx. |
-| [`pfb-downgrade-prep.sh`](pfb-downgrade-prep.sh) | **Before rolling the package back** to a pre-4.0.x release: run on the box as root to reverse the two non-self-healing 4.0.x changes — restore custom `list_scripts/` pre/post scripts to the package root, and remove the ADR-43 `tick` cron. |
+| [`pfb-downgrade-prep.sh`](pfb-downgrade-prep.sh) | **Before rolling the package back** to a pre-4.0.x release: run on the box as root to reverse the three non-self-healing 4.0.x changes — restore custom `list_scripts/` pre/post scripts to the package root, restore the machine match artifacts from `match/generated/` to their pre-4.0.x names, and remove the ADR-43 `tick` cron. |
 | [`setup-hooks.sh`](setup-hooks.sh) | Point git at `.githooks` (run once after cloning). |
 | [`git-no-docs.sh`](git-no-docs.sh) | Local doc-free history views: run a read-only git command (default `log -p`) with the `.gitattributes` `linguist-documentation` trees (`.ADRs/`, `docs/`) excluded from its pathspec. |
 | [`update-pfsense-stubs.py`](update-pfsense-stubs.py) | Regenerate `stubs/pfsense/` after a CE bump. |

--- a/scripts/pfb-downgrade-prep.sh
+++ b/scripts/pfb-downgrade-prep.sh
@@ -9,13 +9,21 @@
 #   ssh root@<box> 'sh /tmp/pfb-downgrade-prep.sh'
 #   ssh root@<box> 'pkg delete pfSense-pkg-pfBlockerNG-devel && pkg install <older>'
 #
-# It reverses the two 4.0.x changes a pre-4.0.x release cannot cope with and that do
+# It reverses the three 4.0.x changes a pre-4.0.x release cannot cope with and that do
 # NOT self-heal:
 #
 #   1. Custom list pre/post scripts relocated into list_scripts/ on upgrade — a
 #      pre-4.0.x release resolves list scripts against the package ROOT only, so a
 #      moved script silently stops running. They are moved back to the root.
-#   2. The ADR-43 scheduled-tick cron entry (`pfblockerng.php cron-tick`, or the
+#   2. Machine-owned match artifacts relocated + renamed from the match folder into
+#      its generated/ subdirectory on upgrade (issue #1250) — a pre-4.0.x release
+#      resolves match artifacts against the match folder ROOT only, under their old
+#      names; a leftover generated/ subdirectory pollutes its `*` glob and
+#      permanently satisfies its `ls -A` presence check. Recognised artifacts are
+#      moved back under their pre-4.0.x names, any `*.txt.new` write-in-progress
+#      stray is deleted (the old release has no cleaner for it), and generated/ is
+#      removed once emptied.
+#   3. The ADR-43 scheduled-tick cron entry (`pfblockerng.php cron-tick`, or the
 #      legacy `pfblockerng.php tick` on an older build -- issue #1204) is removed, so
 #      the downgraded release re-establishes its own schedule on its next sync instead
 #      of leaving an orphan tick cron behind that it has no verb to run.
@@ -25,8 +33,8 @@
 # .md5 -> .xxhash128 feed sidecars and the .tar.bz2 -> .tar.zst MFS archive self-heal
 # on the next feed update / rebuild.
 #
-# Idempotent: a second run restores nothing (scripts already at the root) and reports
-# the tick cron already gone.
+# Idempotent: a second run restores nothing (scripts and match artifacts already at
+# their pre-4.0.x locations) and reports the tick cron already gone.
 #
 # Tests: tests/shell/pfb_downgrade_prep_spec.sh (shellspec — the file-move logic and
 # the shipped-name gate) and tests/smoke/test_downgrade_prepare.py (the live tool
@@ -35,6 +43,8 @@
 # Paths are env-overridable so the pure functions are unit-testable off-appliance.
 PFB_PKGDIR="${PFB_PKGDIR:-/usr/local/pkg/pfblockerng}"
 PFB_LISTDIR="${PFB_LISTDIR:-${PFB_PKGDIR}/list_scripts}"
+PFB_MATCHDIR="${PFB_MATCHDIR:-/var/db/pfblockerng/match}"
+PFB_MATCHGENDIR="${PFB_MATCHGENDIR:-${PFB_MATCHDIR}/generated}"
 PFB_PFSSH="${PFB_PFSSH:-/usr/local/sbin/pfSsh.php}"
 
 # The {ip,dnsbl}_{pre,post}_*.{sh,py} name space, enumerated (POSIX sh has no brace
@@ -101,6 +111,59 @@ pfb_restore_list_scripts() {
 	return "$_rc"
 }
 
+# pfb_restore_matchgen_artifacts
+# Reverse the 4.0.x matchdir->matchgendir relocation (issue #1250): move recognised
+# machine-owned match artifacts (pfB_Match_ET_v4 / _Exempt_v4 / _Rep_<header>_<fam>)
+# from matchgendir back to their pre-4.0.x matchdir names, deleting `*.txt.new`
+# write-in-progress strays first (the old release has no cleaner for them). An
+# unrecognised file is left in place and reported; matchgendir is removed once
+# emptied, else left with a report (not a failure). Prints the number restored to
+# stdout; diagnostics go to stderr. Returns non-zero iff a move/delete actually
+# failed; a no-clobber skip is NOT a failure.
+pfb_restore_matchgen_artifacts() {
+	_restored=0
+	_rc=0
+	[ -d "$PFB_MATCHGENDIR" ] || { echo "$_restored"; return 0; }
+
+	for _stray in "$PFB_MATCHGENDIR"/*.txt.new; do
+		[ -f "$_stray" ] || continue
+		if ! rm -f "$_stray"; then
+			echo "pfb-downgrade-prep: failed to remove stray ${_stray}" >&2
+			_rc=1
+		fi
+	done
+
+	for _src in "$PFB_MATCHGENDIR"/*.txt; do
+		[ -f "$_src" ] || continue
+		_name=$(basename "$_src")
+		case "$_name" in
+			pfB_Match_ET_v4.txt) _dest_name=ETMatch.txt ;;
+			pfB_Match_Exempt_v4.txt) _dest_name=matchdedup_v4.txt ;;
+			pfB_Match_Rep_*.txt) _dest_name="match${_name#pfB_Match_Rep_}" ;;
+			*) continue ;;
+		esac
+		_dest="${PFB_MATCHDIR}/${_dest_name}"
+		if [ -e "$_dest" ]; then
+			echo "pfb-downgrade-prep: not overwriting existing ${_dest}; left ${_name} in matchgendir/" >&2
+			continue
+		fi
+		if mv "$_src" "$_dest"; then
+			_restored=$((_restored + 1))
+		else
+			echo "pfb-downgrade-prep: failed to move ${_src} -> ${_dest}" >&2
+			_rc=1
+		fi
+	done
+
+	if ! rmdir "$PFB_MATCHGENDIR" 2>/dev/null; then
+		_leftover=$(find "$PFB_MATCHGENDIR" -mindepth 1 -maxdepth 1 -exec basename {} \; 2>/dev/null | tr '\n' ' ')
+		echo "pfb-downgrade-prep: matchgendir not empty after restore; left in place -- remove manually before the downgrade if desired: ${_leftover}" >&2
+	fi
+
+	echo "$_restored"
+	return "$_rc"
+}
+
 # pfb_remove_tick_cron
 # Remove the ADR-43 scheduled-tick cron entry via pfSsh.php, which calls the shipped
 # install_cron_job() so config.xml + the live crontab are rewritten cleanly. Checks
@@ -163,6 +226,7 @@ pfb_downgrade_prep_main() {
 
 	_rc=0
 	_restored=$(pfb_restore_list_scripts) || _rc=1
+	_matchgen=$(pfb_restore_matchgen_artifacts) || _rc=1
 	if _tick=$(pfb_remove_tick_cron); then
 		:
 	else
@@ -172,6 +236,7 @@ pfb_downgrade_prep_main() {
 
 	echo "pfBlockerNG downgrade preparation:"
 	echo "  Custom list scripts restored to package root: ${_restored}"
+	echo "  Machine match artifacts restored to the match folder: ${_matchgen}"
 	echo "  ADR-43 tick cron entry: ${_tick}"
 	return "$_rc"
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5363,7 +5363,7 @@ function pfb_matchdir_config_headers(array $lists_by_vtype, array $dnsbl_config,
  * @param array<int,array{list:string,header:string,url:string}> $rows Flattened
  *        pfblockernglistsv4/v6 rows (any action, any state -- any alias can consume a local file).
  * @param string   $matchdir        The OLD matchdir path (no trailing slash).
- * @param string[] $moved_basenames Basenames (with '.txt') pfb_matchdir_migrate_plan() actually moved this run.
+ * @param string[] $moved_basenames Basenames (with '.txt') pfb_matchdir_apply_moves() actually moved this run.
  * @return array<int,array{list:string,header:string,url:string}> The rows that reference one of them.
  */
 function pfb_matchdir_stale_localfile_refs(array $rows, string $matchdir, array $moved_basenames): array {
@@ -5401,7 +5401,6 @@ function pfb_matchdir_apply_moves(array $moves, string $matchdir, string $matchg
 	}
 	return $applied;
 }
-
 
 // issue #1084: batch IP dedup/reputation recompute -- caller-side helpers. pfb_recompute()
 // (pfblockerng.sh) replaces duplicate()/dmax/pmax's incremental masterfile surgery with one

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5171,12 +5171,14 @@ function pfb_member_file_is_placeholder_only($path, $placeholder) {
  * @return string[] Basenames (no '.txt') actually reaped this pass.
  */
 function pfb_matchgen_reap(array $existing_deny, bool $ccwhite_match, string $matchgendir): array {
-	// pfB_Match_ET_v4 is always kept: the reaper runs before processet() in
+	// pfB_Match_ET_v4/_v6 are always kept: the reaper runs before processet() in
 	// sync_package_pfblockerng(), so gating on "did ET run this pass" reaped a live file
-	// on any pass ET did not execute (issue #1269).
-	$keep = array('pfB_Match_ET_v4');
+	// on any pass ET did not execute (issue #1269). Family-complete: a keep entry for an
+	// absent file is a no-op, a MISSING entry is a deletion the day a v6 writer lands.
+	$keep = array('pfB_Match_ET_v4', 'pfB_Match_ET_v6');
 	if ($ccwhite_match) {
 		$keep[] = 'pfB_Match_Exempt_v4';
+		$keep[] = 'pfB_Match_Exempt_v6';
 	}
 	foreach ($existing_deny as $pfb_deny_name) {
 		$keep[] = "pfB_Match_Rep_{$pfb_deny_name}";
@@ -5214,7 +5216,7 @@ function pfb_matchgen_reap(array $existing_deny, bool $ccwhite_match, string $ma
  * @param bool     $ccwhite_match     TRUE iff $pfb['ccwhite'] == 'match'.
  * @param string[] $matchgendir_files Basenames (with '.txt') already in matchgendir (no-clobber).
  * @return array{move: array<string,string>, leave: string[],
- *               undecidable: array<int,array{file:string,candidate_a:string,candidate_b:string}>}
+ *               undecidable: array<int,array{file:string,candidates:string[]}>}
  */
 function pfb_matchdir_migrate_plan(array $matchdir_files, array $existing_deny, array $existing_match, bool $ccwhite_match, array $matchgendir_files): array {
 	$plan = array('move' => array(), 'leave' => array(), 'undecidable' => array());
@@ -5242,43 +5244,36 @@ function pfb_matchdir_migrate_plan(array $matchdir_files, array $existing_deny, 
 			continue;
 		}
 
-		if ($pfb_stem === 'matchdedup_v4' || $pfb_stem === 'matchdedup_v6') {
-			if ($pfb_stem !== 'matchdedup_v4') {
-				// Only the _v4 stem has ever had a writer -- _v6 can only be a user file.
-				$plan['leave'][] = $pfb_file;
-				continue;
-			}
-			$match_has_dedup = in_array('matchdedup_v4', $existing_match, TRUE);
-			if ($match_has_dedup && $ccwhite_match) {
-				$plan['undecidable'][] = array(
-					'file'        => $pfb_file,
-					'candidate_a' => 'the consolidated ccwhite Exempt write',
-					'candidate_b' => 'Match list "matchdedup"',
-				);
-			} elseif ($match_has_dedup) {
-				$plan['leave'][] = $pfb_file;
-			} else {
-				$plan_move($pfb_file, 'pfB_Match_Exempt_v4.txt');
-			}
-			continue;
-		}
-
 		// Anchored at the end, so an embedded underscore in the header (e.g.
-		// 'match_Spam_Feed_v4') never gets mis-split at the FIRST underscore.
+		// 'match_Spam_Feed_v4') never gets mis-split at the FIRST underscore. 'dedup_v4' is
+		// not special-cased separately: the consolidated ccwhite Exempt write is just a
+		// third candidate source alongside Deny/Match, cross-referenced the same way
+		// (issue #1250 F2 -- the old special case ignored Deny/ccwhite state entirely).
 		if (preg_match('/^match(.*)_(v4|v6)$/', $pfb_stem, $pfb_m)) {
-			$pfb_header    = $pfb_m[1];
-			$pfb_fam       = $pfb_m[2];
-			$pfb_deny_hit  = in_array("{$pfb_header}_{$pfb_fam}", $existing_deny, TRUE);
-			$pfb_match_hit = in_array("match{$pfb_header}_{$pfb_fam}", $existing_match, TRUE);
+			$pfb_header     = $pfb_m[1];
+			$pfb_fam        = $pfb_m[2];
+			$pfb_deny_hit   = in_array("{$pfb_header}_{$pfb_fam}", $existing_deny, TRUE);
+			$pfb_match_hit  = in_array("match{$pfb_header}_{$pfb_fam}", $existing_match, TRUE);
+			// The consolidated write only ever produced the _v4 stem -- _v6 never collides.
+			$pfb_exempt_hit = ($pfb_header === 'dedup' && $pfb_fam === 'v4' && $ccwhite_match);
 
-			if ($pfb_deny_hit && $pfb_match_hit) {
-				$plan['undecidable'][] = array(
-					'file'        => $pfb_file,
-					'candidate_a' => "Deny list \"{$pfb_header}\"",
-					'candidate_b' => "Match list \"match{$pfb_header}\"",
-				);
+			$pfb_candidates = array();
+			if ($pfb_deny_hit) {
+				$pfb_candidates[] = "Deny list \"{$pfb_header}\"";
+			}
+			if ($pfb_match_hit) {
+				$pfb_candidates[] = "Match list \"match{$pfb_header}\"";
+			}
+			if ($pfb_exempt_hit) {
+				$pfb_candidates[] = 'the consolidated ccwhite Exempt write';
+			}
+
+			if (count($pfb_candidates) >= 2) {
+				$plan['undecidable'][] = array('file' => $pfb_file, 'candidates' => $pfb_candidates);
 			} elseif ($pfb_deny_hit) {
 				$plan_move($pfb_file, "pfB_Match_Rep_{$pfb_header}_{$pfb_fam}.txt");
+			} elseif ($pfb_exempt_hit) {
+				$plan_move($pfb_file, 'pfB_Match_Exempt_v4.txt');
 			} else {
 				// Match-only (the user's file) or neither (an orphan -- the matchgendir
 				// reaper's problem, never re-homed into the namespace it'd be reaped from).
@@ -5294,24 +5289,92 @@ function pfb_matchdir_migrate_plan(array $matchdir_files, array $existing_deny, 
 }
 
 /**
+ * issue #1250: upgrade migration -- build the Deny/Match header-name sets and the flattened
+ * real-row list pfb_matchdir_migrate_plan() and pfb_matchdir_stale_localfile_refs() need,
+ * mirroring sync_package_pfblockerng()'s own header build ("{header}{vtype}", \W-stripped;
+ * the '<alias>_custom' / DNSBLIP / GeoIP-continent synthetic rows) so the migration is fed the
+ * SAME names the disk actually contains -- install.inc runs standalone, before any sync pass
+ * populates $pfb['existing']. Match-set membership ignores list/row Disabled state: a stale
+ * user file's own list may since have been disabled or retyped, so its history is unknowable
+ * and every configured name must count (issue #1250 F3). Pure: no filesystem/config writes.
+ *
+ * @param array<string,array<int,array<string,mixed>>> $lists_by_vtype ['_v4' => v4 list
+ *        config rows, '_v6' => v6 list config rows] -- installedpackages/pfblockernglistsv{4,6}/config.
+ * @param array<string,mixed>              $dnsbl_config      installedpackages/pfblockerngdnsblsettings/config/0.
+ * @param array<string,array<string,mixed>> $continent_configs Continent alias => its config/0 (or []).
+ * @return array{deny: string[], match: string[], rows: array<int,array{list:string,header:string,url:string}>}
+ */
+function pfb_matchdir_config_headers(array $lists_by_vtype, array $dnsbl_config, array $continent_configs): array {
+	$deny  = array();
+	$match = array();
+	$rows  = array();
+
+	foreach ($lists_by_vtype as $pfb_vtype => $pfb_lists) {
+		foreach ($pfb_lists as $pfb_list) {
+			$pfb_is_deny = strpos((string) ($pfb_list['action'] ?? ''), 'Deny') !== FALSE;
+
+			if (!empty($pfb_list['custom'])) {
+				$pfb_alias_norm = preg_replace('/\W/', '', (string) ($pfb_list['aliasname'] ?? ''));
+				if ($pfb_alias_norm !== '') {
+					$match[] = "{$pfb_alias_norm}_custom{$pfb_vtype}";
+					if ($pfb_is_deny) {
+						$deny[] = "{$pfb_alias_norm}_custom{$pfb_vtype}";
+					}
+				}
+			}
+
+			foreach ($pfb_list['row'] ?? [] as $pfb_row) {
+				$pfb_header_norm = preg_replace('/\W/', '', (string) ($pfb_row['header'] ?? ''));
+				if ($pfb_header_norm !== '') {
+					$match[] = "{$pfb_header_norm}{$pfb_vtype}";
+					if ($pfb_is_deny) {
+						$deny[] = "{$pfb_header_norm}{$pfb_vtype}";
+					}
+				}
+				if (!empty($pfb_row['url'])) {
+					$rows[] = array('list' => $pfb_list['aliasname'] ?? '', 'header' => $pfb_row['header'] ?? '', 'url' => $pfb_row['url']);
+				}
+			}
+		}
+	}
+
+	if (strpos((string) ($dnsbl_config['action'] ?? ''), 'Deny') !== FALSE) {
+		$deny[] = 'DNSBLIP_v4';
+		$deny[] = 'DNSBLIP_v6';
+	}
+
+	foreach ($continent_configs as $pfb_alias => $pfb_cont_config) {
+		if (strpos((string) ($pfb_cont_config['action'] ?? ''), 'Deny') !== FALSE) {
+			$deny[] = "{$pfb_alias}_v4";
+			$deny[] = "{$pfb_alias}_v6";
+		}
+	}
+
+	return array('deny' => $deny, 'match' => $match, 'rows' => $rows);
+}
+
+/**
  * issue #1250: upgrade migration -- find every configured IP-list row whose Localfile/`url`
- * still points at an OLD matchdir artifact path. The GUI once instructed admins to point a
- * Match alias's Localfile at e.g. '/var/db/pfblockerng/match/ETMatch.txt'; any such row breaks
- * the moment that artifact moves, and we do not rewrite the admin's config for them. Pure.
+ * still points at a matchdir artifact THIS RUN ACTUALLY MOVED. The GUI once instructed admins
+ * to point a Match alias's Localfile at e.g. '/var/db/pfblockerng/match/ETMatch.txt'; any such
+ * row breaks the moment that artifact moves, and we do not rewrite the admin's config for
+ * them. Keyed on the plan's actual move list, not a filename shape (F6) -- a same-shaped user
+ * file that was never moved must never trigger a repoint warning for a path that still exists.
+ * Pure.
  *
  * @param array<int,array{list:string,header:string,url:string}> $rows Flattened
- *        pfblockernglistsv4/v6 rows (any action -- any alias can consume a local file).
- * @param string $matchdir The OLD matchdir path (no trailing slash).
- * @return array<int,array{list:string,header:string,url:string}> The rows that reference it.
+ *        pfblockernglistsv4/v6 rows (any action, any state -- any alias can consume a local file).
+ * @param string   $matchdir        The OLD matchdir path (no trailing slash).
+ * @param string[] $moved_basenames Basenames (with '.txt') pfb_matchdir_migrate_plan() actually moved this run.
+ * @return array<int,array{list:string,header:string,url:string}> The rows that reference one of them.
  */
-function pfb_matchdir_stale_localfile_refs(array $rows, string $matchdir): array {
+function pfb_matchdir_stale_localfile_refs(array $rows, string $matchdir, array $moved_basenames): array {
 	$hits = array();
 	foreach ($rows as $pfb_row) {
 		if (empty($pfb_row['url']) || dirname($pfb_row['url']) !== $matchdir) {
 			continue;
 		}
-		$pfb_basename = basename($pfb_row['url']);
-		if ($pfb_basename === 'ETMatch.txt' || preg_match('/^match.*_v[46]\.txt$/', $pfb_basename)) {
+		if (in_array(basename($pfb_row['url']), $moved_basenames, TRUE)) {
 			$hits[] = $pfb_row;
 		}
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5158,6 +5158,46 @@ function pfb_member_file_is_placeholder_only($path, $placeholder) {
 }
 
 
+/**
+ * issue #1250: sweep matchgendir's machine-generated artifacts -- Reputation dMax's per-alias
+ * 'pfB_Match_Rep_<header>_<fam>.txt', the ccwhite consolidated exempt file, and the ET/
+ * Proofpoint match file all moved off pfbmatch, so the generic per-type reaper (keyed on
+ * config headers) can never reap them; this is their own keep-list + sweep, extracted so it
+ * is unit-testable outside sync_package_pfblockerng() (MatchGenReapTest).
+ *
+ * @param string[] $existing_deny $pfb['existing']['deny'] -- '<header>_v4'/'<header>_v6' names.
+ * @param bool     $ccwhite_match TRUE iff $pfb['ccwhite'] == 'match' (the exempt file's only writer).
+ * @param string   $matchgendir   Absolute matchgendir path (no trailing slash).
+ * @return string[] Basenames (no '.txt') actually reaped this pass.
+ */
+function pfb_matchgen_reap(array $existing_deny, bool $ccwhite_match, string $matchgendir): array {
+	// pfB_Match_ET_v4 is always kept: the reaper runs before processet() in
+	// sync_package_pfblockerng(), so gating on "did ET run this pass" reaped a live file
+	// on any pass ET did not execute (issue #1269).
+	$keep = array('pfB_Match_ET_v4');
+	if ($ccwhite_match) {
+		$keep[] = 'pfB_Match_Exempt_v4';
+	}
+	foreach ($existing_deny as $pfb_deny_name) {
+		$keep[] = "pfB_Match_Rep_{$pfb_deny_name}";
+	}
+
+	$actual = array();
+	foreach (glob("{$matchgendir}/*.txt") ?: [] as $pfb_file) {
+		$actual[] = basename($pfb_file, '.txt');
+	}
+
+	$reaped = array();
+	foreach (array_diff($actual, $keep) as $pfb_orphan) {
+		if (!empty(pfb_filter($pfb_orphan, PFB_FILTER_WORD, 'Remove un-associated matchgen artifact'))) {
+			unlink_if_exists("{$matchgendir}/{$pfb_orphan}.txt");
+			$reaped[] = $pfb_orphan;
+		}
+	}
+	return $reaped;
+}
+
+
 // issue #1084: batch IP dedup/reputation recompute -- caller-side helpers. pfb_recompute()
 // (pfblockerng.sh) replaces duplicate()/dmax/pmax's incremental masterfile surgery with one
 // deterministic pass per family over pristine per-feed snapshots; these functions decide WHEN
@@ -9758,7 +9798,9 @@ function pfb_ip_render_query(array $fields): array {
 	} elseif ($fields[3] == 'pass') {
 		$folder = "{$pfb['permitdir']}/*.txt {$pfb['nativedir']}/*.txt";
 	} elseif ($fields[3] == 'match') {
-		$folder = "{$pfb['matchdir']}/*.txt {$pfb['nativedir']}/*.txt";
+		// issue #1250: reputation artifacts now live in matchgendir -- include it so a
+		// Deny-list match event still attributes to its feed.
+		$folder = "{$pfb['matchdir']}/*.txt {$pfb['matchgendir']}/*.txt {$pfb['nativedir']}/*.txt";
 	}
 
 	// Determine if event IP still exists in Feed Aliastable -- builds the exact validate
@@ -13661,7 +13703,9 @@ function pfb_daemon_filterlog() {
 					}
 					elseif ($d[6] == 'unkn(%u)') {
 						$d[6]	= 'match';
-						$folder = "{$pfb['matchdir']}/* {$pfb['nativedir']}/*";
+						// issue #1250: matchdir now nests matchgendir -- glob '.txt' so grep
+						// never opens the subdirectory entry itself; include matchgendir too.
+						$folder = "{$pfb['matchdir']}/*.txt {$pfb['matchgendir']}/*.txt {$pfb['nativedir']}/*";
 						$iplog	= "{$pfb['ip_matchlog']}";
 						$l_type = 'Match';
 					}
@@ -16364,23 +16408,9 @@ function sync_package_pfblockerng($cron='') {
 			}
 		}
 
-		// Add 'Reputation - ccwhite Action' if found. Both families: only the v4 dedup file
-		// has a writer today, but a name for an absent file is a no-op, so the keep-list is
-		// not the place to hardcode that.
-		foreach (array('matchdedup_v4', 'matchdedup_v6') as $pfb_dedup) {
-			if ($pfb['ccwhite'] == 'match' && file_exists("{$pfb['matchdir']}/{$pfb_dedup}.txt")) {
-				$pfb['existing']['match'][] = $pfb_dedup;
-			}
-		}
-
-		// issue #1232: recompute's per-alias reputation artifacts ('match<header>_<fam>.txt')
-		// sit in matchdir but are not Match-type lists -- keep them while their Deny alias
-		// exists (a gone alias's artifact stays un-associated here, so it is still reaped).
-		if (!empty($pfb['existing']['deny'])) {
-			foreach ($pfb['existing']['deny'] as $pfb_deny_name) {
-				$pfb['existing']['match'][] = "match{$pfb_deny_name}";
-			}
-		}
+		// issue #1250: matchgendir artifacts (dMax outputs, ccwhite exempt, ET match) match no
+		// config header, so the per-type sweep below can't reap them -- own keep-list/sweep.
+		pfb_matchgen_reap($pfb['existing']['deny'], $pfb['ccwhite'] == 'match', $pfb['matchgendir']);
 
 		// Add enabled 'DNSBL Blacklist categories'
 		if (isset($pfb['blconfig']) &&

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5379,6 +5379,29 @@ function pfb_matchdir_stale_localfile_refs(array $rows, string $matchdir, array 
 	return $hits;
 }
 
+/**
+ * issue #1250: upgrade migration -- apply the plan's renames with a live no-clobber
+ * re-check (the plan's check ran against a snapshot; this is the guard at the actual
+ * rename()). Returns the OLD basenames actually renamed: the stale-Localfile warning and
+ * the 'Moved:' banner must be keyed on real outcomes, never the planned set -- a skipped
+ * rename leaves the old file live and valid, so warning on it would be a false alarm.
+ *
+ * @param array<string,string> $moves       Old basename => new basename (the plan's 'move').
+ * @param string               $matchdir    Source dir (no trailing slash).
+ * @param string               $matchgendir Destination dir (no trailing slash).
+ * @return string[] The old basenames whose rename actually succeeded.
+ */
+function pfb_matchdir_apply_moves(array $moves, string $matchdir, string $matchgendir): array {
+	$applied = array();
+	foreach ($moves as $pfb_old => $pfb_new) {
+		$pfb_dest = "{$matchgendir}/{$pfb_new}";
+		if (!file_exists($pfb_dest) && @rename("{$matchdir}/{$pfb_old}", $pfb_dest)) {
+			$applied[] = $pfb_old;
+		}
+	}
+	return $applied;
+}
+
 
 // issue #1084: batch IP dedup/reputation recompute -- caller-side helpers. pfb_recompute()
 // (pfblockerng.sh) replaces duplicate()/dmax/pmax's incremental masterfile surgery with one
@@ -16598,8 +16621,12 @@ function sync_package_pfblockerng($cron='') {
 		}
 
 		// issue #1250: matchgendir artifacts (dMax outputs, ccwhite exempt, ET match) match no
-		// config header, so the per-type sweep below can't reap them -- own keep-list/sweep.
-		pfb_matchgen_reap($pfb['existing']['deny'], $pfb['ccwhite'] == 'match', $pfb['matchgendir']);
+		// config header, so the per-type sweep below can't reap them -- own keep-list/sweep,
+		// logged like that sweep so orphan cleanup stays visible in pfblockerng.log.
+		$pfb_matchgen_reaped = pfb_matchgen_reap($pfb['existing']['deny'], $pfb['ccwhite'] == 'match', $pfb['matchgendir']);
+		if (!empty($pfb_matchgen_reaped)) {
+			pfb_logger("\n[ Removing 'matchgen' \tArtifact(s) : " . implode(',', $pfb_matchgen_reaped) . ' ]', 1);
+		}
 
 		// Add enabled 'DNSBL Blacklist categories'
 		if (isset($pfb['blconfig']) &&

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5245,10 +5245,8 @@ function pfb_matchdir_migrate_plan(array $matchdir_files, array $existing_deny, 
 		}
 
 		// Anchored at the end, so an embedded underscore in the header (e.g.
-		// 'match_Spam_Feed_v4') never gets mis-split at the FIRST underscore. 'dedup_v4' is
-		// not special-cased separately: the consolidated ccwhite Exempt write is just a
-		// third candidate source alongside Deny/Match, cross-referenced the same way
-		// (issue #1250 F2 -- the old special case ignored Deny/ccwhite state entirely).
+		// 'match_Spam_Feed_v4') never gets mis-split at the FIRST underscore; the ccwhite
+		// Exempt write is just a third candidate source cross-referenced like Deny/Match.
 		if (preg_match('/^match(.*)_(v4|v6)$/', $pfb_stem, $pfb_m)) {
 			$pfb_header     = $pfb_m[1];
 			$pfb_fam        = $pfb_m[2];
@@ -5296,7 +5294,7 @@ function pfb_matchdir_migrate_plan(array $matchdir_files, array $existing_deny, 
  * SAME names the disk actually contains -- install.inc runs standalone, before any sync pass
  * populates $pfb['existing']. Match-set membership ignores list/row Disabled state: a stale
  * user file's own list may since have been disabled or retyped, so its history is unknowable
- * and every configured name must count (issue #1250 F3). Pure: no filesystem/config writes.
+ * and every configured name must count (issue #1250). Pure: no filesystem/config writes.
  *
  * @param array<string,array<int,array<string,mixed>>> $lists_by_vtype ['_v4' => v4 list
  *        config rows, '_v6' => v6 list config rows] -- installedpackages/pfblockernglistsv{4,6}/config.
@@ -5358,7 +5356,7 @@ function pfb_matchdir_config_headers(array $lists_by_vtype, array $dnsbl_config,
  * still points at a matchdir artifact THIS RUN ACTUALLY MOVED. The GUI once instructed admins
  * to point a Match alias's Localfile at e.g. '/var/db/pfblockerng/match/ETMatch.txt'; any such
  * row breaks the moment that artifact moves, and we do not rewrite the admin's config for
- * them. Keyed on the plan's actual move list, not a filename shape (F6) -- a same-shaped user
+ * them. Keyed on the plan's actual move list, not a filename shape -- a same-shaped user
  * file that was never moved must never trigger a repoint warning for a path that still exists.
  * Pure.
  *

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9863,6 +9863,17 @@ function pfb_match_reported_cidr(array $result, string $ip, bool $v4_type): ?arr
 }
 
 
+// issue #1250: the feed dirs a 'match' event is attributed against -- matchdir holds the user's
+// own Match lists, matchgendir the machine-generated reputation/ET artifacts. Globs '.txt'
+// because matchdir NESTS matchgendir: a bare '/*' would hand grep the subdirectory itself.
+// Callers append their own nativedir glob (the two call sites differ in its suffix).
+function pfb_ip_match_folders(): string {
+	global $pfb;
+
+	return "{$pfb['matchdir']}/*.txt {$pfb['matchgendir']}/*.txt";
+}
+
+
 // issue #809: the exact per-row query derivation convert_ip_log() (pfblockerng_alerts.php)
 // needs before validating/re-locating a reported IP — extracted VERBATIM so the batched
 // prefetch pass (pfb_ip_prefetch()) derives IDENTICAL lookup groups from the same $fields.
@@ -9919,9 +9930,7 @@ function pfb_ip_render_query(array $fields): array {
 	} elseif ($fields[3] == 'pass') {
 		$folder = "{$pfb['permitdir']}/*.txt {$pfb['nativedir']}/*.txt";
 	} elseif ($fields[3] == 'match') {
-		// issue #1250: reputation artifacts now live in matchgendir -- include it so a
-		// Deny-list match event still attributes to its feed.
-		$folder = "{$pfb['matchdir']}/*.txt {$pfb['matchgendir']}/*.txt {$pfb['nativedir']}/*.txt";
+		$folder = pfb_ip_match_folders() . " {$pfb['nativedir']}/*.txt";
 	}
 
 	// Determine if event IP still exists in Feed Aliastable -- builds the exact validate
@@ -13824,9 +13833,7 @@ function pfb_daemon_filterlog() {
 					}
 					elseif ($d[6] == 'unkn(%u)') {
 						$d[6]	= 'match';
-						// issue #1250: matchdir now nests matchgendir -- glob '.txt' so grep
-						// never opens the subdirectory entry itself; include matchgendir too.
-						$folder = "{$pfb['matchdir']}/*.txt {$pfb['matchgendir']}/*.txt {$pfb['nativedir']}/*";
+						$folder = pfb_ip_match_folders() . " {$pfb['nativedir']}/*";
 						$iplog	= "{$pfb['ip_matchlog']}";
 						$l_type = 'Match';
 					}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5198,6 +5198,127 @@ function pfb_matchgen_reap(array $existing_deny, bool $ccwhite_match, string $ma
 }
 
 
+/**
+ * issue #1250: upgrade migration -- decide the fate of every top-level *.txt in the OLD
+ * matchdir before machine-owned artifacts move into matchgendir under pfB_Match_* names. A
+ * user's own Match-list file always carries a family suffix ('<header>_v4'/'_v6',
+ * pfblockerng.inc's Download/Collect header build), so the un-suffixed 'ETMatch.txt' is
+ * unambiguous; 'matchdedup_v4'/'match<header>_<fam>' can collide with a same-named user list
+ * and are cross-referenced against the configured Deny/Match headers -- same shape as
+ * pfb_matchgen_reap()'s keep-list, extended with the Match side for the collision check.
+ * Pure: no filesystem writes, so the whole decision table is unit-testable.
+ *
+ * @param string[] $matchdir_files    Top-level basenames (with '.txt') found in matchdir.
+ * @param string[] $existing_deny     $pfb['existing']['deny'] -- '<header>_v4'/'<header>_v6'.
+ * @param string[] $existing_match    $pfb['existing']['match'] -- same shape, Match lists.
+ * @param bool     $ccwhite_match     TRUE iff $pfb['ccwhite'] == 'match'.
+ * @param string[] $matchgendir_files Basenames (with '.txt') already in matchgendir (no-clobber).
+ * @return array{move: array<string,string>, leave: string[],
+ *               undecidable: array<int,array{file:string,candidate_a:string,candidate_b:string}>}
+ */
+function pfb_matchdir_migrate_plan(array $matchdir_files, array $existing_deny, array $existing_match, bool $ccwhite_match, array $matchgendir_files): array {
+	$plan = array('move' => array(), 'leave' => array(), 'undecidable' => array());
+
+	// No-clobber: record the move unless the destination already exists in matchgendir --
+	// covers both a genuine name clash and a re-run against an already-migrated file.
+	$plan_move = function (string $src, string $dest) use (&$plan, $matchgendir_files): void {
+		if (in_array($dest, $matchgendir_files, TRUE)) {
+			$plan['leave'][] = $src;
+		} else {
+			$plan['move'][$src] = $dest;
+		}
+	};
+
+	foreach ($matchdir_files as $pfb_file) {
+		if (substr($pfb_file, -4) !== '.txt') {
+			$plan['leave'][] = $pfb_file;
+			continue;
+		}
+		$pfb_stem = substr($pfb_file, 0, -4);
+
+		if ($pfb_stem === 'ETMatch') {
+			// No family suffix: unreachable by any user list -- always the ET artifact.
+			$plan_move($pfb_file, 'pfB_Match_ET_v4.txt');
+			continue;
+		}
+
+		if ($pfb_stem === 'matchdedup_v4' || $pfb_stem === 'matchdedup_v6') {
+			if ($pfb_stem !== 'matchdedup_v4') {
+				// Only the _v4 stem has ever had a writer -- _v6 can only be a user file.
+				$plan['leave'][] = $pfb_file;
+				continue;
+			}
+			$match_has_dedup = in_array('matchdedup_v4', $existing_match, TRUE);
+			if ($match_has_dedup && $ccwhite_match) {
+				$plan['undecidable'][] = array(
+					'file'        => $pfb_file,
+					'candidate_a' => 'the consolidated ccwhite Exempt write',
+					'candidate_b' => 'Match list "matchdedup"',
+				);
+			} elseif ($match_has_dedup) {
+				$plan['leave'][] = $pfb_file;
+			} else {
+				$plan_move($pfb_file, 'pfB_Match_Exempt_v4.txt');
+			}
+			continue;
+		}
+
+		// Anchored at the end, so an embedded underscore in the header (e.g.
+		// 'match_Spam_Feed_v4') never gets mis-split at the FIRST underscore.
+		if (preg_match('/^match(.*)_(v4|v6)$/', $pfb_stem, $pfb_m)) {
+			$pfb_header    = $pfb_m[1];
+			$pfb_fam       = $pfb_m[2];
+			$pfb_deny_hit  = in_array("{$pfb_header}_{$pfb_fam}", $existing_deny, TRUE);
+			$pfb_match_hit = in_array("match{$pfb_header}_{$pfb_fam}", $existing_match, TRUE);
+
+			if ($pfb_deny_hit && $pfb_match_hit) {
+				$plan['undecidable'][] = array(
+					'file'        => $pfb_file,
+					'candidate_a' => "Deny list \"{$pfb_header}\"",
+					'candidate_b' => "Match list \"match{$pfb_header}\"",
+				);
+			} elseif ($pfb_deny_hit) {
+				$plan_move($pfb_file, "pfB_Match_Rep_{$pfb_header}_{$pfb_fam}.txt");
+			} else {
+				// Match-only (the user's file) or neither (an orphan -- the matchgendir
+				// reaper's problem, never re-homed into the namespace it'd be reaped from).
+				$plan['leave'][] = $pfb_file;
+			}
+			continue;
+		}
+
+		$plan['leave'][] = $pfb_file;
+	}
+
+	return $plan;
+}
+
+/**
+ * issue #1250: upgrade migration -- find every configured IP-list row whose Localfile/`url`
+ * still points at an OLD matchdir artifact path. The GUI once instructed admins to point a
+ * Match alias's Localfile at e.g. '/var/db/pfblockerng/match/ETMatch.txt'; any such row breaks
+ * the moment that artifact moves, and we do not rewrite the admin's config for them. Pure.
+ *
+ * @param array<int,array{list:string,header:string,url:string}> $rows Flattened
+ *        pfblockernglistsv4/v6 rows (any action -- any alias can consume a local file).
+ * @param string $matchdir The OLD matchdir path (no trailing slash).
+ * @return array<int,array{list:string,header:string,url:string}> The rows that reference it.
+ */
+function pfb_matchdir_stale_localfile_refs(array $rows, string $matchdir): array {
+	$hits = array();
+	foreach ($rows as $pfb_row) {
+		if (empty($pfb_row['url']) || dirname($pfb_row['url']) !== $matchdir) {
+			continue;
+		}
+		$pfb_basename = basename($pfb_row['url']);
+		if ($pfb_basename === 'ETMatch.txt' || preg_match('/^match.*_v[46]\.txt$/', $pfb_basename)) {
+			$hits[] = $pfb_row;
+		}
+	}
+	return $hits;
+}
+
+
 // issue #1084: batch IP dedup/reputation recompute -- caller-side helpers. pfb_recompute()
 // (pfblockerng.sh) replaces duplicate()/dmax/pmax's incremental masterfile surgery with one
 // deterministic pass per family over pristine per-feed snapshots; these functions decide WHEN

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -46,6 +46,9 @@ $pfb['etdir']		= "{$pfb['dbdir']}/ET";
 $pfb['nativedir']	= "{$pfb['dbdir']}/native";
 $pfb['denydir']		= "{$pfb['dbdir']}/deny";
 $pfb['matchdir']	= "{$pfb['dbdir']}/match";
+// issue #1250: machine-generated match artifacts, kept out of matchdir so a
+// user-chosen Match-list header can never collide with them.
+$pfb['matchgendir']	= "{$pfb['matchdir']}/generated";
 $pfb['permitdir']	= "{$pfb['dbdir']}/permit";
 $pfb['origdir']		= "{$pfb['dbdir']}/original";
 $pfb['snapdir']		= "{$pfb['dbdir']}/snapshot";	// issue #1084: pristine post-preprocessing feed snapshots (recompute memberlist inputs)
@@ -72,7 +75,8 @@ $pfb['wc']	= '/usr/bin/wc';
 // Folder Array
 $pfb['folder_array'] = array(	"{$pfb['dbdir']}", "{$pfb['logdir']}", "{$pfb['ccdir']}", "{$pfb['origdir']}", "{$pfb['nativedir']}",
 				"{$pfb['denydir']}", "{$pfb['matchdir']}","{$pfb['permitdir']}", "{$pfb['aliasdir']}",
-				"{$pfb['dnsdir']}", "{$pfb['dnsorigdir']}", "{$pfb['dnsalias']}", "{$pfb['snapdir']}");
+				"{$pfb['dnsdir']}", "{$pfb['dnsorigdir']}", "{$pfb['dnsalias']}", "{$pfb['snapdir']}",
+				"{$pfb['matchgendir']}");
 
 // Files
 $pfb['log']		= "{$pfb['logdir']}/pfblockerng.log";

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1011,9 +1011,7 @@ pfb_recompute() {
 	# prior pass, or a window-awk failure mid-write) BEFORE this pass runs -- else
 	# it can survive to be wrongly promoted by a LATER pass that never actually
 	# recomputed reputation for that alias.
-	while IFS=' ' read -r rec_alias _; do
-		rm -f "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt.new"
-	done < "${rec_priority}"
+	pfb_recompute_clean_rep_new
 	rm -f "${pfbmatchgen}${rec_matchexemptfile}.new"
 
 	rec_do_rep=0
@@ -1097,6 +1095,14 @@ pfb_recompute_clean_new() {
 		rm -f "${pfbdeny}${rec_alias}.txt.new"
 	done < "${rec_priority}"
 	rm -f "${rec_masterfile_new}" "${rec_mastercat_new}" "${rec_countsfile_new}"
+}
+
+# Same cleanup for the per-alias reputation artifacts' .new siblings (dMax emits
+# them into matchgendir); the consolidated exempt file's .new stays caller-owned.
+pfb_recompute_clean_rep_new() {
+	while IFS=' ' read -r rec_alias _; do
+		rm -f "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt.new"
+	done < "${rec_priority}"
 }
 
 # Offender detect + classify into rec_actionmap ("<prefix> <action>" rows).
@@ -1251,9 +1257,7 @@ pfb_recompute_rep_subset() {
 	# pfB_Match_Rep_<alias>.txt is a dMax-owned artifact; start every candidate
 	# fresh so the window awk's append-only writes never carry stale content.
 	if [ "${rec_repmode}" = 'dmax' ]; then
-		while IFS=' ' read -r rec_alias _; do
-			rm -f "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt.new"
-		done < "${rec_priority}"
+		pfb_recompute_clean_rep_new
 	fi
 
 	# Window pass over the diverted subset: block-mode offenders collapse to
@@ -1348,9 +1352,7 @@ pfb_recompute_rep_subset() {
 		echo "${log}" | tee -a "${errorlog}"
 		pfb_recompute_clean_new
 		if [ "${rec_repmode}" = 'dmax' ]; then
-			while IFS=' ' read -r rec_alias _; do
-				rm -f "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt.new"
-			done < "${rec_priority}"
+			pfb_recompute_clean_rep_new
 		fi
 		return 1
 	fi
@@ -1370,9 +1372,7 @@ pfb_recompute_rep_subset() {
 			echo "${log}" | tee -a "${errorlog}"
 			pfb_recompute_clean_new
 			if [ "${rec_repmode}" = 'dmax' ]; then
-				while IFS=' ' read -r rec_alias _; do
-					rm -f "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt.new"
-				done < "${rec_priority}"
+				pfb_recompute_clean_rep_new
 			fi
 			return 1
 		fi

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2038,9 +2038,12 @@ closingprocess() {
 		echo; echo '===[ Permit List IP Counts ]========================='; echo
 		wc -l "${pfbpermit}"*.txt 2>/dev/null | sort -n -r
 	fi
-	if [ -d "${pfbmatch}" ] && [ "$(ls -A "${pfbmatch}")" ]; then
+	# issue #1250: key on the .txt files themselves -- `ls -A "${pfbmatch}"` is now always
+	# non-empty (the generated/ subdir always exists), and `wc -l` emits a "total" line
+	# even when every glob is unmatched. The generated artifacts still belong in this count.
+	if [ -n "$(ls -A "${pfbmatch}"*.txt "${pfbmatchgen}"*.txt 2>/dev/null)" ]; then
 		echo; echo '===[ Match List IP Counts ]=========================='; echo
-		wc -l "${pfbmatch}"*.txt 2>/dev/null | sort -n -r
+		wc -l "${pfbmatch}"*.txt "${pfbmatchgen}"*.txt 2>/dev/null | sort -n -r
 	fi
 	if [ -d "${pfbdeny}" ] && [ "$(ls -A "${pfbdeny}")" ]; then
 		echo; echo '===[ Deny List IP Counts ]==========================='; echo

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -90,6 +90,9 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 	pfbdeny=/var/db/pfblockerng/deny/
 	pfborig=/var/db/pfblockerng/original/
 	pfbmatch=/var/db/pfblockerng/match/
+	# issue #1250: machine-generated match artifacts, kept out of pfbmatch so a
+	# user-chosen Match-list header can never collide with them.
+	pfbmatchgen=/var/db/pfblockerng/match/generated/
 	pfbpermit=/var/db/pfblockerng/permit/
 	pfbnative=/var/db/pfblockerng/native/
 	pfsensealias=/var/db/aliastables/
@@ -120,6 +123,7 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 	if [ ! -d "${pfbdb}" ]; then mkdir "${pfbdb}"; fi
 	if [ ! -d "${pfsensealias}" ]; then mkdir "${pfsensealias}"; fi
 	if [ ! -d "${pfbmatch}" ]; then mkdir "${pfbmatch}"; fi
+	if [ ! -d "${pfbmatchgen}" ]; then mkdir "${pfbmatchgen}"; fi
 	if [ ! -d "${pfbsnap}" ]; then mkdir "${pfbsnap}"; fi
 	if [ ! -d "${etdir}" ]; then mkdir "${etdir}"; fi
 	# tmpxlsx is a fresh subdir of the private mktemp -d tmpdir -- no existence
@@ -1007,9 +1011,9 @@ pfb_recompute() {
 	# it can survive to be wrongly promoted by a LATER pass that never actually
 	# recomputed reputation for that alias.
 	while IFS=' ' read -r rec_alias _; do
-		rm -f "${pfbmatch}match${rec_alias}.txt.new"
+		rm -f "${pfbmatchgen}match${rec_alias}.txt.new"
 	done < "${rec_priority}"
-	rm -f "${pfbmatch}${rec_matchdedup}.new"
+	rm -f "${pfbmatchgen}${rec_matchdedup}.new"
 
 	rec_do_rep=0
 	if [ "${rec_family}" = 'v4' ]; then
@@ -1247,7 +1251,7 @@ pfb_recompute_rep_subset() {
 	# fresh so the window awk's append-only writes never carry stale content.
 	if [ "${rec_repmode}" = 'dmax' ]; then
 		while IFS=' ' read -r rec_alias _; do
-			rm -f "${pfbmatch}match${rec_alias}.txt.new"
+			rm -f "${pfbmatchgen}match${rec_alias}.txt.new"
 		done < "${rec_priority}"
 	fi
 
@@ -1257,7 +1261,7 @@ pfb_recompute_rep_subset() {
 	rec_new_stream="${rec_scratch}/new_stream"
 	true > "${rec_new_stream}"
 	awk -v actionfile="${rec_actionmap}" -v priofile="${rec_priority}" \
-			-v newstream="${rec_new_stream}" -v matchdir="${pfbmatch}" \
+			-v newstream="${rec_new_stream}" -v matchdir="${pfbmatchgen}" \
 			-v mexcidr="${rec_matchexemptcidr}" -v mexmem="${rec_matchexemptmembers}" '
 			BEGIN {
 				while ((getline line < actionfile) > 0) {
@@ -1344,7 +1348,7 @@ pfb_recompute_rep_subset() {
 		pfb_recompute_clean_new
 		if [ "${rec_repmode}" = 'dmax' ]; then
 			while IFS=' ' read -r rec_alias _; do
-				rm -f "${pfbmatch}match${rec_alias}.txt.new"
+				rm -f "${pfbmatchgen}match${rec_alias}.txt.new"
 			done < "${rec_priority}"
 		fi
 		return 1
@@ -1366,7 +1370,7 @@ pfb_recompute_rep_subset() {
 			pfb_recompute_clean_new
 			if [ "${rec_repmode}" = 'dmax' ]; then
 				while IFS=' ' read -r rec_alias _; do
-					rm -f "${pfbmatch}match${rec_alias}.txt.new"
+					rm -f "${pfbmatchgen}match${rec_alias}.txt.new"
 				done < "${rec_priority}"
 			fi
 			return 1
@@ -1408,7 +1412,7 @@ pfb_recompute_finish() {
 	# ALONE (mirrors reputation_max()'s own asymmetric gate), even though a
 	# 'matchexempt' action can also be reached via ccblack='match'.
 	if [ "${rec_repmode}" = 'dmax' ] && [ "${rec_ccwhite}" = 'match' ] && [ -s "${rec_matchexemptcidr}" ]; then
-		rec_matchdedup_new="${pfbmatch}${rec_matchdedup}.new"
+		rec_matchdedup_new="${pfbmatchgen}${rec_matchdedup}.new"
 		cat "${rec_matchexemptcidr}" > "${rec_matchdedup_new}"
 		cat "${rec_matchexemptmembers}" >> "${rec_matchdedup_new}"
 	fi
@@ -1434,16 +1438,16 @@ pfb_recompute_finish() {
 			# genuinely means "no reputation match for this alias this pass", so
 			# reconciling away a stale live file here is correct, not destructive.
 			while IFS=' ' read -r rec_alias _; do
-				if [ -f "${pfbmatch}match${rec_alias}.txt.new" ]; then
-					pfb_recompute_swap_mv "${pfbmatch}match${rec_alias}.txt.new" "${pfbmatch}match${rec_alias}.txt" "match${rec_alias}.txt.new" || return 1
+				if [ -f "${pfbmatchgen}match${rec_alias}.txt.new" ]; then
+					pfb_recompute_swap_mv "${pfbmatchgen}match${rec_alias}.txt.new" "${pfbmatchgen}match${rec_alias}.txt" "match${rec_alias}.txt.new" || return 1
 				else
-					rm -f "${pfbmatch}match${rec_alias}.txt"
+					rm -f "${pfbmatchgen}match${rec_alias}.txt"
 				fi
 			done < "${rec_priority}"
-			if [ -f "${pfbmatch}${rec_matchdedup}.new" ]; then
-				pfb_recompute_swap_mv "${pfbmatch}${rec_matchdedup}.new" "${pfbmatch}${rec_matchdedup}" "${rec_matchdedup}.new" || return 1
+			if [ -f "${pfbmatchgen}${rec_matchdedup}.new" ]; then
+				pfb_recompute_swap_mv "${pfbmatchgen}${rec_matchdedup}.new" "${pfbmatchgen}${rec_matchdedup}" "${rec_matchdedup}.new" || return 1
 			elif [ "${rec_ccwhite}" = 'match' ]; then
-				rm -f "${pfbmatch}${rec_matchdedup}"
+				rm -f "${pfbmatchgen}${rec_matchdedup}"
 			fi
 		else
 			log="recompute [ ${rec_family} ]: GeoIP unavailable this pass -- keeping previous reputation match artifacts"
@@ -1756,14 +1760,13 @@ EOF
 	fi
 
 	# If no matches found remove previous matchoutfile if exists.
-	# Derive header from $alias (in scope), matching reputation_pmax()'s own
-	# header derivation; do not rely on a stale $header global, and operate on
-	# the absolute ${pfbmatch} path rather than a relative one (issue #27).
+	# Derive header from $alias (mirrors reputation_pmax()); operate on the
+	# absolute ${pfbmatchgen} path, not a relative one (issue #27).
 	header="${alias##*/}"; header="${header%%.*}"
 	matchoutfile="match${header}.txt"
-	if [ ! -s "${tempmatchfile}" ] && [ -f "${pfbmatch}${matchoutfile}" ]; then rm -f "${pfbmatch}${matchoutfile}"; fi
+	if [ ! -s "${tempmatchfile}" ] && [ -f "${pfbmatchgen}${matchoutfile}" ]; then rm -f "${pfbmatchgen}${matchoutfile}"; fi
 	# Move match file to the match folder by individual blocklist name
-	if [ -s "${tempmatchfile}" ]; then mv -f "${tempmatchfile}" "${pfbmatch}${matchoutfile}"; fi
+	if [ -s "${tempmatchfile}" ]; then mv -f "${tempmatchfile}" "${pfbmatchgen}${matchoutfile}"; fi
 
 	# Find repeat offenders in each individual blocklist outfile
 	if [ -s "${dupfile}" ]; then
@@ -1965,7 +1968,7 @@ processet() {
 		echo '-------------------------------------------'
 
 		if [ -f "${tempfile}" ]; then mv -f "${tempfile}" "${pfborig}${alias}.orig"; fi
-		if [ "${etmatch}" != 'x' ]; then mv -f "${tempfile2}" "${pfbmatch}/ETMatch.txt"; fi
+		if [ "${etmatch}" != 'x' ]; then mv -f "${tempfile2}" "${pfbmatchgen}ETMatch.txt"; fi
 		counto="$(cat "${etdir}"/ET_* | grep -cv '^#\|^$')"; countf="$(grep -cv "^${ip_placeholder2}$" "${pfborig}${alias}.orig")"
 		echo; echo "All ET Folder count [ ${counto} ]  Final count [ ${countf} ]"
 	else

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1266,7 +1266,7 @@ pfb_recompute_rep_subset() {
 	rec_new_stream="${rec_scratch}/new_stream"
 	true > "${rec_new_stream}"
 	awk -v actionfile="${rec_actionmap}" -v priofile="${rec_priority}" \
-			-v newstream="${rec_new_stream}" -v matchdir="${pfbmatchgen}" \
+			-v newstream="${rec_new_stream}" -v matchgendir="${pfbmatchgen}" \
 			-v mexcidr="${rec_matchexemptcidr}" -v mexmem="${rec_matchexemptmembers}" '
 			BEGIN {
 				while ((getline line < actionfile) > 0) {
@@ -1294,7 +1294,7 @@ pfb_recompute_rep_subset() {
 					for (i = 1; i <= wincount; i++) print winrows[i] >> newstream
 					if (curact == "matchdup") {
 						for (a in winaliases) {
-							mfile = matchdir "pfB_Match_Rep_" a ".txt.new"
+							mfile = matchgendir "pfB_Match_Rep_" a ".txt.new"
 							print curpfx ".0/24" >> mfile
 							for (i = 1; i <= wincount; i++) {
 								if (winalias[i] == a) print "!" winip[i] >> mfile

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -99,8 +99,9 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 	pfbdomain=/var/db/pfblockerng/dnsbl/
 	pfbdomainorig=/var/db/pfblockerng/dnsblorig/
 
-	# Store 'Match' d-dedups in matchdedup.txt file
-	matchdedup=matchdedup_v4.txt
+	# issue #1250: repeat offenders in the selected/exempt (ccwhite=match)
+	# countries, consolidated into one file
+	matchexemptfile=pfB_Match_Exempt_v4.txt
 
 	# Create a private per-run temp directory (sets tempfile, tempfile2, ...,
 	# tmpxlsx).
@@ -837,8 +838,8 @@ pfb_aggregate() {
 #     "x.y.z.0/24" row owned by the HIGHEST-PRIORITY alias among that
 #     window's members (a documented delta from today's incidental glob-
 #     order attribution); match-mode offenders pass their rows through and
-#     additionally emit match<alias>.txt (ccblack=match) / the single
-#     matchdedup file (ccwhite=match, cc-list hits only -- mirrors today's
+#     additionally emit pfB_Match_Rep_<alias>.txt (ccblack=match) / the single
+#     pfB_Match_Exempt_v4.txt file (ccwhite=match, cc-list hits only -- mirrors today's
 #     asymmetric gate). Survivors/collapsed rows are reinjected into their
 #     owners' keep sets, then the per-alias emit runs identically to the
 #     direct path -- reputation cost scales with offender rows, not class
@@ -901,7 +902,7 @@ pfb_recompute() {
 
 	rec_cumulative="${rec_scratch}/cumulative"
 	rec_priority="${rec_scratch}/priority"
-	rec_matchdedup="${matchdedup:-matchdedup_v4.txt}"
+	rec_matchexemptfile="${matchexemptfile:-pfB_Match_Exempt_v4.txt}"
 	true > "${rec_cumulative}"
 	true > "${rec_priority}"
 
@@ -1011,9 +1012,9 @@ pfb_recompute() {
 	# it can survive to be wrongly promoted by a LATER pass that never actually
 	# recomputed reputation for that alias.
 	while IFS=' ' read -r rec_alias _; do
-		rm -f "${pfbmatchgen}match${rec_alias}.txt.new"
+		rm -f "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt.new"
 	done < "${rec_priority}"
-	rm -f "${pfbmatchgen}${rec_matchdedup}.new"
+	rm -f "${pfbmatchgen}${rec_matchexemptfile}.new"
 
 	rec_do_rep=0
 	if [ "${rec_family}" = 'v4' ]; then
@@ -1247,11 +1248,11 @@ pfb_recompute_rep_subset() {
 		return 1
 	fi
 
-	# match<alias>.txt is a dMax-owned artifact; start every candidate
+	# pfB_Match_Rep_<alias>.txt is a dMax-owned artifact; start every candidate
 	# fresh so the window awk's append-only writes never carry stale content.
 	if [ "${rec_repmode}" = 'dmax' ]; then
 		while IFS=' ' read -r rec_alias _; do
-			rm -f "${pfbmatchgen}match${rec_alias}.txt.new"
+			rm -f "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt.new"
 		done < "${rec_priority}"
 	fi
 
@@ -1289,7 +1290,7 @@ pfb_recompute_rep_subset() {
 					for (i = 1; i <= wincount; i++) print winrows[i] >> newstream
 					if (curact == "matchdup") {
 						for (a in winaliases) {
-							mfile = matchdir "match" a ".txt.new"
+							mfile = matchdir "pfB_Match_Rep_" a ".txt.new"
 							print curpfx ".0/24" >> mfile
 							for (i = 1; i <= wincount; i++) {
 								if (winalias[i] == a) print "!" winip[i] >> mfile
@@ -1348,7 +1349,7 @@ pfb_recompute_rep_subset() {
 		pfb_recompute_clean_new
 		if [ "${rec_repmode}" = 'dmax' ]; then
 			while IFS=' ' read -r rec_alias _; do
-				rm -f "${pfbmatchgen}match${rec_alias}.txt.new"
+				rm -f "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt.new"
 			done < "${rec_priority}"
 		fi
 		return 1
@@ -1370,7 +1371,7 @@ pfb_recompute_rep_subset() {
 			pfb_recompute_clean_new
 			if [ "${rec_repmode}" = 'dmax' ]; then
 				while IFS=' ' read -r rec_alias _; do
-					rm -f "${pfbmatchgen}match${rec_alias}.txt.new"
+					rm -f "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt.new"
 				done < "${rec_priority}"
 			fi
 			return 1
@@ -1412,9 +1413,9 @@ pfb_recompute_finish() {
 	# ALONE (mirrors reputation_max()'s own asymmetric gate), even though a
 	# 'matchexempt' action can also be reached via ccblack='match'.
 	if [ "${rec_repmode}" = 'dmax' ] && [ "${rec_ccwhite}" = 'match' ] && [ -s "${rec_matchexemptcidr}" ]; then
-		rec_matchdedup_new="${pfbmatchgen}${rec_matchdedup}.new"
-		cat "${rec_matchexemptcidr}" > "${rec_matchdedup_new}"
-		cat "${rec_matchexemptmembers}" >> "${rec_matchdedup_new}"
+		rec_matchexemptfile_new="${pfbmatchgen}${rec_matchexemptfile}.new"
+		cat "${rec_matchexemptcidr}" > "${rec_matchexemptfile_new}"
+		cat "${rec_matchexemptmembers}" >> "${rec_matchexemptfile_new}"
 	fi
 
 	# Swap: each artifact's ".new" sibling is moved into place in sequence,
@@ -1438,16 +1439,16 @@ pfb_recompute_finish() {
 			# genuinely means "no reputation match for this alias this pass", so
 			# reconciling away a stale live file here is correct, not destructive.
 			while IFS=' ' read -r rec_alias _; do
-				if [ -f "${pfbmatchgen}match${rec_alias}.txt.new" ]; then
-					pfb_recompute_swap_mv "${pfbmatchgen}match${rec_alias}.txt.new" "${pfbmatchgen}match${rec_alias}.txt" "match${rec_alias}.txt.new" || return 1
+				if [ -f "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt.new" ]; then
+					pfb_recompute_swap_mv "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt.new" "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt" "pfB_Match_Rep_${rec_alias}.txt.new" || return 1
 				else
-					rm -f "${pfbmatchgen}match${rec_alias}.txt"
+					rm -f "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt"
 				fi
 			done < "${rec_priority}"
-			if [ -f "${pfbmatchgen}${rec_matchdedup}.new" ]; then
-				pfb_recompute_swap_mv "${pfbmatchgen}${rec_matchdedup}.new" "${pfbmatchgen}${rec_matchdedup}" "${rec_matchdedup}.new" || return 1
+			if [ -f "${pfbmatchgen}${rec_matchexemptfile}.new" ]; then
+				pfb_recompute_swap_mv "${pfbmatchgen}${rec_matchexemptfile}.new" "${pfbmatchgen}${rec_matchexemptfile}" "${rec_matchexemptfile}.new" || return 1
 			elif [ "${rec_ccwhite}" = 'match' ]; then
-				rm -f "${pfbmatchgen}${rec_matchdedup}"
+				rm -f "${pfbmatchgen}${rec_matchexemptfile}"
 			fi
 		else
 			log="recompute [ ${rec_family} ]: GeoIP unavailable this pass -- keeping previous reputation match artifacts"
@@ -1763,7 +1764,7 @@ EOF
 	# Derive header from $alias (mirrors reputation_pmax()); operate on the
 	# absolute ${pfbmatchgen} path, not a relative one (issue #27).
 	header="${alias##*/}"; header="${header%%.*}"
-	matchoutfile="match${header}.txt"
+	matchoutfile="pfB_Match_Rep_${header}.txt"
 	if [ ! -s "${tempmatchfile}" ] && [ -f "${pfbmatchgen}${matchoutfile}" ]; then rm -f "${pfbmatchgen}${matchoutfile}"; fi
 	# Move match file to the match folder by individual blocklist name
 	if [ -s "${tempmatchfile}" ]; then mv -f "${tempmatchfile}" "${pfbmatchgen}${matchoutfile}"; fi
@@ -1968,7 +1969,7 @@ processet() {
 		echo '-------------------------------------------'
 
 		if [ -f "${tempfile}" ]; then mv -f "${tempfile}" "${pfborig}${alias}.orig"; fi
-		if [ "${etmatch}" != 'x' ]; then mv -f "${tempfile2}" "${pfbmatchgen}ETMatch.txt"; fi
+		if [ "${etmatch}" != 'x' ]; then mv -f "${tempfile2}" "${pfbmatchgen}pfB_Match_ET_v4.txt"; fi
 		counto="$(cat "${etdir}"/ET_* | grep -cv '^#\|^$')"; countf="$(grep -cv "^${ip_placeholder2}$" "${pfborig}${alias}.orig")"
 		echo; echo "All ET Folder count [ ${counto} ]  Final count [ ${countf} ]"
 	else

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -286,23 +286,18 @@ if (is_dir($pfb['matchdir'])) {
 	$pfb_plan = pfb_matchdir_migrate_plan($pfb_matchdir_listing, $pfb_deny_headers, $pfb_match_headers,
 		($pfb_rep_config['ccwhite'] ?? '') === 'match', $pfb_matchgendir_listing);
 
-	$pfb_moved_match = 0;
-	foreach ($pfb_plan['move'] as $pfb_old => $pfb_new) {
-		// Live re-check mirrors the list_scripts relocation above: the plan's no-clobber
-		// check ran against a snapshot, this is the guard at the actual rename() (issue #1250).
-		$pfb_dest = "{$pfb['matchgendir']}/{$pfb_new}";
-		if (!file_exists($pfb_dest) && @rename("{$pfb['matchdir']}/{$pfb_old}", $pfb_dest)) {
-			$pfb_moved_match++;
-		}
-	}
+	// Warnings below are keyed on the renames that actually happened, never the plan --
+	// a rename skipped by the live no-clobber guard leaves the old file valid (issue #1250).
+	$pfb_moved_files = pfb_matchdir_apply_moves($pfb_plan['move'], $pfb['matchdir'], $pfb['matchgendir']);
+	$pfb_moved_match = count($pfb_moved_files);
 
-	$pfb_stale_refs = pfb_matchdir_stale_localfile_refs($pfb_list_rows, $pfb['matchdir'], array_keys($pfb_plan['move']));
+	$pfb_stale_refs = pfb_matchdir_stale_localfile_refs($pfb_list_rows, $pfb['matchdir'], $pfb_moved_files);
 
 	if ($pfb_moved_match > 0 || !empty($pfb_plan['undecidable']) || !empty($pfb_stale_refs)) {
 		$pfb_matchgen_warn[] = 'BREAKING CHANGE: machine-generated match artifacts moved from';
 		$pfb_matchgen_warn[] = "  {$pfb['matchdir']}  to  {$pfb['matchgendir']}  (renamed to pfB_Match_*).";
-		if (!empty($pfb_plan['move'])) {
-			$pfb_matchgen_warn[] = 'Moved: ' . implode(', ', array_keys($pfb_plan['move']));
+		if (!empty($pfb_moved_files)) {
+			$pfb_matchgen_warn[] = 'Moved: ' . implode(', ', $pfb_moved_files);
 		}
 		foreach ($pfb_plan['undecidable'] as $pfb_u) {
 			$pfb_matchgen_warn[] = "AMBIGUOUS, left in place: {$pfb_u['file']} could belong to " . implode(' OR ', $pfb_u['candidates']) . ' -- rename one to disambiguate.';

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -254,30 +254,24 @@ if (is_dir($pfb['matchdir'])) {
 	}
 
 	// Same config sections + header-build rule sync_package_pfblockerng() uses (header =
-	// "{$row['header']}{$vtype}") -- install.inc runs standalone, before any sync pass
-	// populates $pfb['existing'].
-	$pfb_deny_headers  = array();
-	$pfb_match_headers = array();
-	$pfb_list_rows     = array();
-	foreach (array('pfblockernglistsv4' => '_v4', 'pfblockernglistsv6' => '_v6') as $pfb_ltype => $pfb_vtype) {
-		foreach (config_get_path("installedpackages/{$pfb_ltype}/config", []) as $pfb_list) { // foreign key — out of ADR-29 gateway scope
-			if (empty($pfb_list['row']) || ($pfb_list['action'] ?? '') === 'Disabled') {
-				continue;
-			}
-			foreach ($pfb_list['row'] as $pfb_row) {
-				if (empty($pfb_row['url']) || ($pfb_row['state'] ?? '') === 'Disabled') {
-					continue;
-				}
-				$pfb_header = "{$pfb_row['header']}{$pfb_vtype}";
-				if (strpos($pfb_list['action'], 'Match') !== FALSE) {
-					$pfb_match_headers[] = $pfb_header;
-				} elseif (strpos($pfb_list['action'], 'Deny') !== FALSE) {
-					$pfb_deny_headers[] = $pfb_header;
-				}
-				$pfb_list_rows[] = array('list' => $pfb_list['aliasname'] ?? '', 'header' => $pfb_row['header'], 'url' => $pfb_row['url']);
-			}
-		}
+	// "{$row['header']}{$vtype}", \W-stripped, plus the custom/DNSBLIP/continent synthetic
+	// names) -- install.inc runs standalone, before any sync pass populates $pfb['existing'].
+	$pfb_continent_configs = array();
+	foreach ($pfb['continents'] as $pfb_cont_name => $pfb_cont_alias) {
+		$pfb_cont_key = 'pfblockerng' . strtolower(str_replace(' ', '', $pfb_cont_name));
+		$pfb_continent_configs[$pfb_cont_alias] = config_get_path("installedpackages/{$pfb_cont_key}/config/0", []); // foreign key — out of ADR-29 gateway scope
 	}
+	$pfb_headers = pfb_matchdir_config_headers(
+		array(
+			'_v4' => config_get_path('installedpackages/pfblockernglistsv4/config', []), // foreign key — out of ADR-29 gateway scope
+			'_v6' => config_get_path('installedpackages/pfblockernglistsv6/config', []), // foreign key — out of ADR-29 gateway scope
+		),
+		config_get_path('installedpackages/pfblockerngdnsblsettings/config/0', []), // foreign key — out of ADR-29 gateway scope
+		$pfb_continent_configs
+	);
+	$pfb_deny_headers  = $pfb_headers['deny'];
+	$pfb_match_headers = $pfb_headers['match'];
+	$pfb_list_rows     = $pfb_headers['rows'];
 	$pfb_rep_config = config_get_path('installedpackages/pfblockerngreputation/config/0', []); // foreign key — out of ADR-29 gateway scope, static display section (no registered keys)
 
 	$pfb_matchdir_listing = array();
@@ -302,7 +296,7 @@ if (is_dir($pfb['matchdir'])) {
 		}
 	}
 
-	$pfb_stale_refs = pfb_matchdir_stale_localfile_refs($pfb_list_rows, $pfb['matchdir']);
+	$pfb_stale_refs = pfb_matchdir_stale_localfile_refs($pfb_list_rows, $pfb['matchdir'], array_keys($pfb_plan['move']));
 
 	if ($pfb_moved_match > 0 || !empty($pfb_plan['undecidable']) || !empty($pfb_stale_refs)) {
 		$pfb_matchgen_warn[] = 'BREAKING CHANGE: machine-generated match artifacts moved from';
@@ -311,7 +305,7 @@ if (is_dir($pfb['matchdir'])) {
 			$pfb_matchgen_warn[] = 'Moved: ' . implode(', ', array_keys($pfb_plan['move']));
 		}
 		foreach ($pfb_plan['undecidable'] as $pfb_u) {
-			$pfb_matchgen_warn[] = "AMBIGUOUS, left in place: {$pfb_u['file']} could belong to {$pfb_u['candidate_a']} OR {$pfb_u['candidate_b']} -- rename one to disambiguate.";
+			$pfb_matchgen_warn[] = "AMBIGUOUS, left in place: {$pfb_u['file']} could belong to " . implode(' OR ', $pfb_u['candidates']) . ' -- rename one to disambiguate.';
 		}
 		foreach ($pfb_stale_refs as $pfb_r) {
 			$pfb_matchgen_warn[] = "List \"{$pfb_r['list']}\" (header \"{$pfb_r['header']}\") Localfile still points at the OLD path {$pfb_r['url']} -- you must repoint it yourself.";

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -228,6 +228,107 @@ foreach (glob("{$pfb_pkgdir}/{ip,dnsbl}_{pre,post}_*.{sh,py}", GLOB_BRACE) ?: []
 }
 update_status(($pfb_moved > 0 ? " moved {$pfb_moved} ... done.\n" : " none ... done.\n"));
 
+// issue #1250: BREAKING CHANGE -- relocate machine-owned match artifacts (ETMatch.txt,
+// matchdedup_v4.txt, match<Header>_<fam>.txt) into matchgendir under their new pfB_Match_*
+// names; a same-named user Match-list file is left in place. See pfb_matchdir_migrate_plan().
+update_status(" Relocating machine-generated match artifacts...");
+$pfb_matchgen_warn = array();
+if (is_dir($pfb['matchdir'])) {
+	// pfb_global() (above) already safe_mkdir()'d matchgendir at 0755 via folder_array, so
+	// the perm-sync below runs unconditionally rather than gated on "did I just create it" --
+	// it still ends up matching matchdir's LIVE mode/owner/group either way.
+	if (!is_dir($pfb['matchgendir'])) {
+		@mkdir($pfb['matchgendir'], 0755, TRUE);
+	}
+	$pfb_mg_mode = @fileperms($pfb['matchdir']);
+	if ($pfb_mg_mode !== FALSE) {
+		@chmod($pfb['matchgendir'], $pfb_mg_mode & 0777);
+	}
+	$pfb_mg_uid = @fileowner($pfb['matchdir']);
+	if ($pfb_mg_uid !== FALSE) {
+		@chown($pfb['matchgendir'], $pfb_mg_uid);
+	}
+	$pfb_mg_gid = @filegroup($pfb['matchdir']);
+	if ($pfb_mg_gid !== FALSE) {
+		@chgrp($pfb['matchgendir'], $pfb_mg_gid);
+	}
+
+	// Same config sections + header-build rule sync_package_pfblockerng() uses (header =
+	// "{$row['header']}{$vtype}") -- install.inc runs standalone, before any sync pass
+	// populates $pfb['existing'].
+	$pfb_deny_headers  = array();
+	$pfb_match_headers = array();
+	$pfb_list_rows     = array();
+	foreach (array('pfblockernglistsv4' => '_v4', 'pfblockernglistsv6' => '_v6') as $pfb_ltype => $pfb_vtype) {
+		foreach (config_get_path("installedpackages/{$pfb_ltype}/config", []) as $pfb_list) { // foreign key — out of ADR-29 gateway scope
+			if (empty($pfb_list['row']) || ($pfb_list['action'] ?? '') === 'Disabled') {
+				continue;
+			}
+			foreach ($pfb_list['row'] as $pfb_row) {
+				if (empty($pfb_row['url']) || ($pfb_row['state'] ?? '') === 'Disabled') {
+					continue;
+				}
+				$pfb_header = "{$pfb_row['header']}{$pfb_vtype}";
+				if (strpos($pfb_list['action'], 'Match') !== FALSE) {
+					$pfb_match_headers[] = $pfb_header;
+				} elseif (strpos($pfb_list['action'], 'Deny') !== FALSE) {
+					$pfb_deny_headers[] = $pfb_header;
+				}
+				$pfb_list_rows[] = array('list' => $pfb_list['aliasname'] ?? '', 'header' => $pfb_row['header'], 'url' => $pfb_row['url']);
+			}
+		}
+	}
+	$pfb_rep_config = config_get_path('installedpackages/pfblockerngreputation/config/0', []); // foreign key — out of ADR-29 gateway scope, static display section (no registered keys)
+
+	$pfb_matchdir_listing = array();
+	foreach (glob("{$pfb['matchdir']}/*.txt") ?: [] as $pfb_f) {
+		$pfb_matchdir_listing[] = basename($pfb_f);
+	}
+	$pfb_matchgendir_listing = array();
+	foreach (glob("{$pfb['matchgendir']}/*.txt") ?: [] as $pfb_f) {
+		$pfb_matchgendir_listing[] = basename($pfb_f);
+	}
+
+	$pfb_plan = pfb_matchdir_migrate_plan($pfb_matchdir_listing, $pfb_deny_headers, $pfb_match_headers,
+		($pfb_rep_config['ccwhite'] ?? '') === 'match', $pfb_matchgendir_listing);
+
+	$pfb_moved_match = 0;
+	foreach ($pfb_plan['move'] as $pfb_old => $pfb_new) {
+		// Live re-check mirrors the list_scripts relocation above: the plan's no-clobber
+		// check ran against a snapshot, this is the guard at the actual rename() (issue #1250).
+		$pfb_dest = "{$pfb['matchgendir']}/{$pfb_new}";
+		if (!file_exists($pfb_dest) && @rename("{$pfb['matchdir']}/{$pfb_old}", $pfb_dest)) {
+			$pfb_moved_match++;
+		}
+	}
+
+	$pfb_stale_refs = pfb_matchdir_stale_localfile_refs($pfb_list_rows, $pfb['matchdir']);
+
+	if ($pfb_moved_match > 0 || !empty($pfb_plan['undecidable']) || !empty($pfb_stale_refs)) {
+		$pfb_matchgen_warn[] = 'BREAKING CHANGE: machine-generated match artifacts moved from';
+		$pfb_matchgen_warn[] = "  {$pfb['matchdir']}  to  {$pfb['matchgendir']}  (renamed to pfB_Match_*).";
+		if (!empty($pfb_plan['move'])) {
+			$pfb_matchgen_warn[] = 'Moved: ' . implode(', ', array_keys($pfb_plan['move']));
+		}
+		foreach ($pfb_plan['undecidable'] as $pfb_u) {
+			$pfb_matchgen_warn[] = "AMBIGUOUS, left in place: {$pfb_u['file']} could belong to {$pfb_u['candidate_a']} OR {$pfb_u['candidate_b']} -- rename one to disambiguate.";
+		}
+		foreach ($pfb_stale_refs as $pfb_r) {
+			$pfb_matchgen_warn[] = "List \"{$pfb_r['list']}\" (header \"{$pfb_r['header']}\") Localfile still points at the OLD path {$pfb_r['url']} -- you must repoint it yourself.";
+		}
+	}
+}
+update_status(($pfb_moved_match ?? 0) > 0 ? " moved {$pfb_moved_match} ... done.\n" : " none ... done.\n");
+
+if (!empty($pfb_matchgen_warn)) {
+	$pfb_warn_text = implode("\n", $pfb_matchgen_warn);
+	update_status("\n****************************************************************\n");
+	update_status("*  BREAKING CHANGE -- pfBlockerNG match artifacts relocated!      *\n");
+	update_status("****************************************************************\n");
+	update_status("{$pfb_warn_text}\n\n");
+	file_notice('pfBlockerNG Match', $pfb_warn_text, 'pfBlockerNG', '/pfblockerng/pfblockerng_ip.php', 2);
+}
+
 // ADR-12 update hooks live in their own dir (PFB_HOOK_SCRIPT_DIR = hooks/), separate
 // from list_scripts/. No files ship there (hooks are admin-authored), so create the
 // empty dir here for the picker to scan and admins to drop scripts into.

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -2563,7 +2563,7 @@ $section->addInput(new Form_StaticText(
 	. '\'<strong>ccblack</strong>\' are all other Countries that are not selected.<br /><br />'
 	. 'To use <strong>Match</strong> Lists, Create a new \'Alias\''
 	. 'and select one of the <strong>Action Match</strong> Formats and<br /> enter the <strong>Localfile</strong> as:'
-	. '<ul>/var/db/pfblockerng/match/matchdedup.txt</ul><br />' 
+	. '<ul>/var/db/pfblockerng/match/generated/pfB_Match_Exempt_v4.txt</ul><br />'
 	. '<strong>These Country Code options are only available when the MaxMind key has been entered and MaxMind database has been downloaded and updated</strong>'
 	. '</div>'
 ));
@@ -2615,7 +2615,7 @@ $section->addInput(new Form_StaticText(
 	. '<a target="_blank" rel="noopener noreferrer" href="https://www.proofpoint.com/us/solutions/products/threat-intelligence">Proofpoint IQRisk</a><br /><br />'
 	. 'To use <strong>Match</strong> Lists, Create a new Alias and select one of the <strong>'
 	. 'Action Match</strong> Formats and <br />'
-	. 'enter the <strong>Localfile</strong> as: <ul>/var/db/pfblockerng/match/ETMatch.txt</ul>'
+	. 'enter the <strong>Localfile</strong> as: <ul>/var/db/pfblockerng/match/generated/pfB_Match_ET_v4.txt</ul>'
 	. 'ET IQRisk Individual Match Lists can be found in the following folder:<br />'
 	. '<ul>/var/db/pfblockerng/ET</ul>'
 ));

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -125,6 +125,13 @@ $pfb_logtypes = array(	'defaultlogs'	=> array('name'		=> 'Log Files',
 						'download'	=> TRUE,
 						'clear'		=> TRUE
 						),
+			// issue #1250: machine-generated match artifacts, relocated off matchdir.
+			'matchgenlogs'	=> array('name'		=> 'Match Generated Files',
+						'ext'		=> 'txt',
+						'logdir'	=> "{$pfb['matchgendir']}/",
+						'download'	=> TRUE,
+						'clear'		=> TRUE
+						),
 			'nativelogs'	=> array('name'		=> 'Native Files',
 						'ext'		=> 'txt',
 						'logdir'	=> "{$pfb['nativedir']}/",

--- a/tests/php/AggregateMemberListTest.php
+++ b/tests/php/AggregateMemberListTest.php
@@ -62,6 +62,11 @@ final class AggregateMemberListTest extends TestCase
 		foreach ($it as $f) {
 			@unlink($f);
 		}
+		// issue #1250: the matchgendir-exclusion test nests 'generated' under match/.
+		foreach (@glob("{$this->root}/match/generated/*") ?: [] as $f) {
+			@unlink($f);
+		}
+		@rmdir("{$this->root}/match/generated");
 		foreach (['deny', 'permit', 'match', 'native'] as $d) {
 			@rmdir("{$this->root}/{$d}");
 		}
@@ -297,6 +302,32 @@ final class AggregateMemberListTest extends TestCase
 
 		$got = pfb_aggregate_member_list('Deny', 'v4');
 		$this->assertSame([$a, $m, $z], $got, 'members returned in sorted (ascending path) order');
+	}
+
+	/**
+	 * R6 (issue #1250): a machine-generated Reputation artifact staged under matchdir's
+	 * 'generated' subdirectory must NOT enter the Match aggregate merely because its name also
+	 * matches '*_v4.txt' -- glob() does not descend into subdirectories, so relocating those
+	 * artifacts off matchdir's top level (steps 1/1b) already excludes them; this pins that
+	 * membership as a deliberate, user-visible narrowing (a reputation artifact was never a
+	 * genuine Match-type list).
+	 *
+	 *   Given matchdir holds a genuine user Match-list member AND matchdir/generated holds a
+	 *         reputation artifact that also matches '*_v4.txt'
+	 *   When  the Match/v4 member list is computed
+	 *   Then  the before-state is asserted first (the user member IS present), then the
+	 *         artifact is confirmed ABSENT -- proving exclusion, not an accidentally-empty result.
+	 */
+	public function testMatchExcludesGeneratedReputationArtifact(): void
+	{
+		$userMember = $this->touchMember('matchdir', 'userlist_v4.txt');
+		$genDir = "{$GLOBALS['pfb']['matchdir']}/generated";
+		@mkdir($genDir, 0777, true);
+		$this->assertNotFalse(@file_put_contents("{$genDir}/pfB_Match_Rep_Spam_v4.txt", ''));
+
+		$got = pfb_aggregate_member_list('Match', 'v4');
+		$this->assertContains($userMember, $got, 'precondition: the genuine user Match-list member is present');
+		$this->assertSame([$userMember], $got, 'a matchgendir artifact must NOT enter the Match aggregate');
 	}
 
 	/**

--- a/tests/php/AlertsIpConvertPrefetchParityTest.php
+++ b/tests/php/AlertsIpConvertPrefetchParityTest.php
@@ -43,6 +43,8 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 	private string $ccdir;
 	private string $etdir;
 	private string $aliasdir;
+	private string $matchdir;
+	private string $matchgendir;
 
 	/** @var array<string, mixed> */
 	private array $savedGlobals = [];
@@ -70,12 +72,24 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 		$this->ccdir     = "{$this->tmpDir}/geoip";
 		$this->etdir     = "{$this->tmpDir}/et";
 		$this->aliasdir  = "{$this->tmpDir}/alias";
-		foreach ([$this->denydir, $this->nativedir, $this->ccdir, $this->etdir, $this->aliasdir] as $d) {
+		$this->matchdir  = "{$this->tmpDir}/match";
+		// issue #1250: a real subdirectory of matchdir (mirrors production -- matchdir
+		// nests matchgendir on-disk), distinct enough to prove the 'match' folder
+		// derivation names BOTH, not just one.
+		$this->matchgendir = "{$this->matchdir}/generated";
+		foreach ([
+			$this->denydir, $this->nativedir, $this->ccdir, $this->etdir, $this->aliasdir,
+			$this->matchdir, $this->matchgendir,
+		] as $d) {
 			mkdir($d, 0777, TRUE);
 		}
-		// Keeps nativedir non-empty (avoids the shell literal-glob edge case on an
-		// otherwise-empty dir); mirrors IpPrefetchTest's fixtures/ip_prefetch/native.
+		// Keeps nativedir/matchdir/matchgendir non-empty (avoids the shell literal-glob
+		// edge case on an otherwise-empty dir); mirrors IpPrefetchTest's
+		// fixtures/ip_prefetch/native. Every 'match'-action case below adds its own file
+		// to ONE of matchdir/matchgendir, leaving the other empty otherwise.
 		file_put_contents("{$this->nativedir}/NativePlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->matchdir}/MatchPlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->matchgendir}/MatchGenPlaceholder.txt", "placeholder\n");
 		// ccdir/etdir/aliasdir each need a SECOND, non-matching file: grep only
 		// prefixes a matched line with "path:" when >1 file is searched, and
 		// find_reported_header()'s pfb_parse_query() (feed/alias name split) and
@@ -90,8 +104,9 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 			'grep'             => '/usr/bin/grep',
 			'denydir'          => $this->denydir,
 			'nativedir'        => $this->nativedir,
-			'permitdir'        => "{$this->tmpDir}/permit",	// unused by these cases (Action is always 'block')
-			'matchdir'         => "{$this->tmpDir}/match",	// unused by these cases
+			'permitdir'        => "{$this->tmpDir}/permit",	// unused by these cases (Action is 'block' or 'match')
+			'matchdir'         => $this->matchdir,
+			'matchgendir'      => $this->matchgendir,
 			'etdir'            => $this->etdir,
 			'ccdir'            => $this->ccdir,
 			'aliasdir'         => $this->aliasdir,
@@ -457,6 +472,69 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 			'pfB_LoneNewAlias_v4',
 			$html,
 			"expected the rendered row to show the real new alias name 'pfB_LoneNewAlias_v4', got:\n{$html}"
+		);
+	}
+
+	/**
+	 * Case 10 -- issue #1250: a 'match' event whose IP was relocated to a matchgendir
+	 * reputation artifact (the logged feed name is the OLD one, before the relocation
+	 * renamed/moved it -- same "moved feed" shape as case 3, but over the branch that
+	 * was widened to search matchgendir).
+	 *
+	 * Given: the reported IP lives ONLY in a matchgendir artifact
+	 *        (pfB_Match_Rep_Spam_v4.txt), not under the event's originally-logged feed
+	 *        name.
+	 * When: convert_ip_log() renders the 'match' event, both prefetch-seeded and cold.
+	 * Then: parity holds, AND the rendered HTML attributes the event to the real
+	 *       matchgendir feed -- not "Not listed!" (which is what a folder derivation
+	 *       missing matchgendir would render).
+	 */
+	public function test_match_event_reputation_artifact_in_matchgendir_attributes_to_that_feed(): void
+	{
+		file_put_contents("{$this->matchgendir}/pfB_Match_Rep_Spam_v4.txt", "192.0.2.60\n");
+
+		$fields = $this->rawFields([
+			4 => 'match', 8 => '192.0.2.60', 15 => '192.0.2.60',
+			14 => 'pfB_OldMatchAlias_v4', 16 => 'MatchFeedOldSpam',
+		]);
+
+		$html = $this->assertParity($fields, 'Match', 'match event, reputation artifact relocated to matchgendir');
+
+		$this->assertStringContainsString(
+			'pfB_Match_Rep_Spam_v4',
+			$html,
+			"expected the rendered row to attribute this match event to the matchgendir feed "
+				. "'pfB_Match_Rep_Spam_v4' (issue #1250), got:\n{$html}"
+		);
+	}
+
+	/**
+	 * Case 11 -- issue #1250: a 'match' event caused by a user-chosen Match-list still
+	 * attributes correctly -- the widening that added matchgendir must not have
+	 * regressed the pre-existing matchdir half of the branch (same "still-listed"
+	 * shape as case 1).
+	 *
+	 * Given: the reported IP is still an exact line in its logged user Match-list file
+	 *        (Ads_v4.txt), which stays in matchdir (never relocated).
+	 * When: convert_ip_log() renders the 'match' event, both prefetch-seeded and cold.
+	 * Then: parity holds, AND the rendered HTML still attributes to the logged feed.
+	 */
+	public function test_match_event_user_list_in_matchdir_still_attributes_to_that_feed(): void
+	{
+		file_put_contents("{$this->matchdir}/Ads_v4.txt", "198.51.100.77\n");
+
+		$fields = $this->rawFields([
+			4 => 'match', 8 => '198.51.100.77', 15 => '198.51.100.77',
+			14 => 'pfB_Ads_v4', 16 => 'Ads_v4',
+		]);
+
+		$html = $this->assertParity($fields, 'Match', 'match event, user Match-list in matchdir');
+
+		$this->assertStringContainsString(
+			'Ads_v4',
+			$html,
+			"expected the rendered row to still attribute this match event to the matchdir feed "
+				. "'Ads_v4', got:\n{$html}"
 		);
 	}
 }

--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -89,6 +89,7 @@ use PHPUnit\Framework\TestCase;
  *     correctly SEEDED instead of merely left alone.
  */
 #[CoversFunction('pfb_match_reported_cidr')]
+#[CoversFunction('pfb_ip_match_folders')]
 #[CoversFunction('pfb_ip_render_query')]
 #[CoversFunction('pfb_ip_render_memos')]
 #[CoversFunction('pfb_ip_render_memos_reset')]
@@ -116,14 +117,17 @@ final class IpPrefetchTest extends TestCase
 		// these keys; a minimal $pfb is enough (unlike the Alerts page itself, which reads
 		// many more unrelated keys at load time).
 		$GLOBALS['pfb'] = [
-			'grep'       => '/usr/bin/grep',
-			'denydir'    => "{$this->fixturesDir}/deny",
-			'nativedir'  => "{$this->fixturesDir}/native",
-			'permitdir'  => "{$this->fixturesDir}/deny",	// unused by these tests' rows
-			'matchdir'   => "{$this->fixturesDir}/deny",	// unused by these tests' rows
-			'etdir'      => "{$this->fixturesDir}/deny",	// unused by these tests' rows
-			'ccdir'      => "{$this->fixturesDir}/geoip",
-			'aliasdir'   => "{$this->fixturesDir}/alias",
+			'grep'        => '/usr/bin/grep',
+			'denydir'     => "{$this->fixturesDir}/deny",
+			'nativedir'   => "{$this->fixturesDir}/native",
+			'permitdir'   => "{$this->fixturesDir}/deny",	// unused by these tests' rows
+			'matchdir'    => "{$this->fixturesDir}/deny",	// unused by these tests' rows
+			// issue #1250: distinct from matchdir/nativedir so the folder-derivation
+			// test below can prove all three are present, not just two.
+			'matchgendir' => "{$this->fixturesDir}/deny/generated",
+			'etdir'       => "{$this->fixturesDir}/deny",	// unused by these tests' rows
+			'ccdir'       => "{$this->fixturesDir}/geoip",
+			'aliasdir'    => "{$this->fixturesDir}/alias",
 		];
 
 		// Same continents registry pfblockerng_alerts.php builds (array_flip of the
@@ -661,6 +665,29 @@ final class IpPrefetchTest extends TestCase
 			$memos['miss'][$missKey],
 			'expected [pfb_query, raw_validate] to be ' . var_export([['DenyFeed', '192.0.2.0/24'], $expectedRawValidate], true)
 				. ', got ' . var_export($memos['miss'][$missKey], true)
+		);
+	}
+
+	/**
+	 * issue #1250: reputation/dMax artifacts relocated to matchgendir -- a 'match'
+	 * event's folder set must still search matchdir/nativedir (unchanged) AND now
+	 * also matchgendir (widened), or an event caused by a relocated artifact
+	 * attributes to nothing on the Alerts page.
+	 */
+	public function test_match_action_folder_includes_matchdir_matchgendir_and_nativedir(): void
+	{
+		$fields = $this->buildBlockFields('192.0.2.90');
+		$fields[3] = 'match';	// Action -- the branch under test
+
+		$rq = pfb_ip_render_query($fields);
+
+		// Then: the derived folder glob names all three dirs -- dropping matchgendir
+		// silences attribution for every reputation-artifact match; dropping matchdir
+		// or nativedir would silence the pre-existing two.
+		$this->assertSame(
+			"{$GLOBALS['pfb']['matchdir']}/*.txt {$GLOBALS['pfb']['matchgendir']}/*.txt {$GLOBALS['pfb']['nativedir']}/*.txt",
+			$rq['folder'],
+			"expected the 'match' folder to be matchdir+matchgendir+nativedir, got: {$rq['folder']}"
 		);
 	}
 

--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -691,6 +691,21 @@ final class IpPrefetchTest extends TestCase
 		);
 	}
 
+	/**
+	 * issue #1250: the match-artifact dirs are defined ONCE, in pfb_ip_match_folders(), and
+	 * shared by the Alerts query (above) and pfb_daemon_filterlog()'s live tail. The daemon
+	 * copy sits inside an unbounded php://stdin loop that cannot be unit-tested, so pinning
+	 * the shared helper is what covers it -- the daemon's correctness reduces to calling this.
+	 */
+	public function test_match_folders_helper_names_both_match_dirs_and_nothing_else(): void
+	{
+		$this->assertSame(
+			"{$GLOBALS['pfb']['matchdir']}/*.txt {$GLOBALS['pfb']['matchgendir']}/*.txt",
+			pfb_ip_match_folders(),
+			'expected pfb_ip_match_folders() to name matchdir + matchgendir, got: ' . pfb_ip_match_folders()
+		);
+	}
+
 	public function test_prefetch_seeds_an_empty_aliastables_result_on_a_genuine_total_miss(): void
 	{
 		$fields = $this->buildBlockFields('198.51.100.222');

--- a/tests/php/MatchGenReapTest.php
+++ b/tests/php/MatchGenReapTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1250 — pin pfb_matchgen_reap(), the matchgendir orphan sweep extracted so it is
+ * unit-testable outside sync_package_pfblockerng(). matchgendir holds ONLY machine-generated
+ * Reputation/ET artifacts (never a user Match-list file), so its keep-list is built from
+ * config state (Deny aliases, ccwhite action), not from Match-type list headers.
+ *
+ * Feature: matchgendir orphan reaping
+ *   Background:
+ *     Given matchgendir holds 'pfB_Match_Rep_<Header>_<fam>.txt' / 'pfB_Match_Exempt_v4.txt' /
+ *           'pfB_Match_ET_v4.txt' files
+ *     And   the sweep keeps a file iff its owning config state still exists
+ *
+ * Branch/hostile-input coverage (brief section 5, H1-H7):
+ *   H1 live Deny alias artifact kept; H2 removed Deny alias artifact reaped (the leak this
+ *   fix prevents); H3 ccwhite='match' exempt file kept; H4 ET file always kept (issue #1269);
+ *   H5 no cross-directory reach (a matchdir user file is untouched); H6 a stray artifact with
+ *   no owning alias is reaped; H7 both v4 and v6 families are enumerated, not just v4.
+ */
+#[CoversFunction('pfb_matchgen_reap')]
+final class MatchGenReapTest extends TestCase
+{
+	/** @var string Per-test sandbox root; one fresh dir tree per test. */
+	private string $root;
+	private string $matchgendir;
+	private string $matchdir;
+
+	protected function setUp(): void
+	{
+		$this->root = sys_get_temp_dir() . '/pfb_matchgen_' . getmypid() . '_' . uniqid();
+		$this->matchgendir = "{$this->root}/generated";
+		$this->matchdir = $this->root;
+		@mkdir($this->matchgendir, 0777, true);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob("{$this->matchgendir}/*") ?: [] as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->matchgendir);
+		foreach (glob("{$this->matchdir}/*.txt") ?: [] as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->matchdir);
+	}
+
+	/** Drop an empty file at <matchgendir>/<name>.txt, asserting the write succeeded. */
+	private function touchGen(string $name): string
+	{
+		$path = "{$this->matchgendir}/{$name}.txt";
+		$this->assertNotFalse(@file_put_contents($path, ''), "could not create {$path}");
+		return $path;
+	}
+
+	/** Drop an empty file at <matchdir>/<name>.txt (the SIBLING top-level dir), for H5. */
+	private function touchMatch(string $name): string
+	{
+		$path = "{$this->matchdir}/{$name}.txt";
+		$this->assertNotFalse(@file_put_contents($path, ''), "could not create {$path}");
+		return $path;
+	}
+
+	/**
+	 * H1: a Deny alias's own reputation artifact survives while the alias is still configured.
+	 *
+	 *   Given Deny alias 'Spam_v4' is configured and its artifact exists
+	 *   When  the sweep runs
+	 *   Then  the artifact is KEPT and NOT reported as reaped.
+	 */
+	public function testKeepsLiveDenyAliasArtifact(): void
+	{
+		$artifact = $this->touchGen('pfB_Match_Rep_Spam_v4');
+
+		$reaped = pfb_matchgen_reap(['Spam_v4'], FALSE, $this->matchgendir);
+
+		$this->assertFileExists($artifact, 'a live Deny alias artifact must survive the sweep');
+		$this->assertNotContains('pfB_Match_Rep_Spam_v4', $reaped);
+	}
+
+	/**
+	 * H2: the leak this fix exists to close — once a Deny alias is removed from config, its
+	 * orphaned reputation artifact is reaped instead of living forever in matchgendir.
+	 *
+	 *   Given Deny alias 'Spam_v4' was configured (artifact on disk) but is REMOVED from config
+	 *   When  the sweep runs with an existing-deny list that no longer names it
+	 *   Then  the before-state (file present) is asserted first, then the file is gone and
+	 *         reported as reaped.
+	 */
+	public function testReapsArtifactOfRemovedDenyAlias(): void
+	{
+		$artifact = $this->touchGen('pfB_Match_Rep_Spam_v4');
+		$this->assertFileExists($artifact, 'precondition: the orphan artifact exists before the sweep');
+
+		$reaped = pfb_matchgen_reap([], FALSE, $this->matchgendir);
+
+		$this->assertFileDoesNotExist($artifact, 'a removed Deny alias leaves an orphan the sweep must reap');
+		$this->assertContains('pfB_Match_Rep_Spam_v4', $reaped);
+	}
+
+	/**
+	 * H3: the ccwhite consolidated exempt file is kept ONLY while ccwhite is the 'match' action
+	 * — the sole config state that can produce it.
+	 *
+	 *   Given the exempt file exists and ccwhite IS 'match'
+	 *   When  the sweep runs
+	 *   Then  it is kept.
+	 *   But   (contrast) when ccwhite is NOT 'match', the same file is reaped — proving the
+	 *         gate is real, not a permanent keep.
+	 */
+	public function testKeepsExemptFileOnlyWhenCcwhiteIsMatch(): void
+	{
+		$artifact = $this->touchGen('pfB_Match_Exempt_v4');
+
+		$reaped = pfb_matchgen_reap([], TRUE, $this->matchgendir);
+		$this->assertFileExists($artifact, 'ccwhite=match must keep the consolidated exempt file');
+		$this->assertNotContains('pfB_Match_Exempt_v4', $reaped);
+
+		// Recreate for the contrast leg (the prior call left it in place).
+		$reaped = pfb_matchgen_reap([], FALSE, $this->matchgendir);
+		$this->assertFileDoesNotExist($artifact, 'ccwhite off must reap a now-orphaned exempt file');
+		$this->assertContains('pfB_Match_Exempt_v4', $reaped);
+	}
+
+	/**
+	 * H4 / issue #1269: the ET/Proofpoint match file is ALWAYS kept, regardless of Deny/ccwhite
+	 * state — the reaper runs before processet() in sync_package_pfblockerng(), so gating this
+	 * on "did ET run this pass" reaped a live file on every pass ET did not execute.
+	 *
+	 *   Given the ET match file exists and NO Deny alias / ccwhite state names it
+	 *   When  the sweep runs
+	 *   Then  it is kept unconditionally.
+	 */
+	public function testAlwaysKeepsEtMatchFile(): void
+	{
+		$artifact = $this->touchGen('pfB_Match_ET_v4');
+
+		$reaped = pfb_matchgen_reap([], FALSE, $this->matchgendir);
+
+		$this->assertFileExists($artifact, 'the ET match file must survive every pass, ET-enabled or not');
+		$this->assertNotContains('pfB_Match_ET_v4', $reaped);
+	}
+
+	/**
+	 * H5: issue #1250's exact collision, now benign — a user Match-list file named 'matchSpam'
+	 * (matchdir) and a Deny alias 'Spam' (matchgendir) coexist; the sweep only ever touches
+	 * matchgendir, so the sibling matchdir file is untouched regardless of what it is named.
+	 *
+	 *   Given matchdir holds 'matchSpam_v4.txt' (a genuine user Match list) and matchgendir
+	 *         holds 'pfB_Match_Rep_Spam_v4.txt' (Deny alias 'Spam_v4' artifact)
+	 *   When  the sweep runs
+	 *   Then  BOTH survive, each in its own directory.
+	 */
+	public function testDoesNotReachIntoMatchdirForACollidingUserListName(): void
+	{
+		$userList = $this->touchMatch('matchSpam_v4');
+		$repArtifact = $this->touchGen('pfB_Match_Rep_Spam_v4');
+
+		$reaped = pfb_matchgen_reap(['Spam_v4'], FALSE, $this->matchgendir);
+
+		$this->assertFileExists($userList, 'a matchdir user list must never be touched by the matchgendir sweep');
+		$this->assertFileExists($repArtifact, "the Deny alias's own artifact must survive");
+		$this->assertSame([], $reaped, 'nothing should be reaped when both owners are live');
+	}
+
+	/**
+	 * H6: a stray artifact with no owning Deny alias at all is reaped.
+	 *
+	 *   Given 'pfB_Match_Rep_GONE_v4.txt' exists and no Deny alias named it, ever
+	 *   When  the sweep runs
+	 *   Then  it is reaped.
+	 */
+	public function testReapsStrayArtifactWithNoOwningDenyAlias(): void
+	{
+		$artifact = $this->touchGen('pfB_Match_Rep_GONE_v4');
+
+		$reaped = pfb_matchgen_reap(['Spam_v4'], FALSE, $this->matchgendir);
+
+		$this->assertFileDoesNotExist($artifact);
+		$this->assertContains('pfB_Match_Rep_GONE_v4', $reaped);
+	}
+
+	/**
+	 * H7: the family axis is enumerated — a v6-only configured Deny alias keeps its OWN v6
+	 * artifact without needing a v4 sibling to exist.
+	 *
+	 *   Given Deny alias 'Spam_v6' is configured (existing-deny names it with the '_v6' suffix)
+	 *         and its artifact exists; NO 'Spam_v4' artifact exists
+	 *   When  the sweep runs
+	 *   Then  the v6 artifact is kept.
+	 */
+	public function testKeepsV6FamilyArtifactForAV6OnlyConfiguredAlias(): void
+	{
+		$artifact = $this->touchGen('pfB_Match_Rep_Spam_v6');
+
+		$reaped = pfb_matchgen_reap(['Spam_v6'], FALSE, $this->matchgendir);
+
+		$this->assertFileExists($artifact, 'the v6 family axis must be enumerated, not just v4');
+		$this->assertNotContains('pfB_Match_Rep_Spam_v6', $reaped);
+	}
+}

--- a/tests/php/MatchGenReapTest.php
+++ b/tests/php/MatchGenReapTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\TestCase;
  *   fix prevents); H3 ccwhite='match' exempt file kept; H4 ET file always kept (issue #1269);
  *   H5 no cross-directory reach (a matchdir user file is untouched); H6 a stray artifact with
  *   no owning alias is reaped; H7 both v4 and v6 families are enumerated, not just v4.
+ *   R1-R3: the ET/Exempt keep-list is family-complete (v4 AND v6), not v4-only.
  */
 #[CoversFunction('pfb_matchgen_reap')]
 final class MatchGenReapTest extends TestCase
@@ -203,5 +204,46 @@ final class MatchGenReapTest extends TestCase
 
 		$this->assertFileExists($artifact, 'the v6 family axis must be enumerated, not just v4');
 		$this->assertNotContains('pfB_Match_Rep_Spam_v6', $reaped);
+	}
+
+	/**
+	 * R1 / issue #1250 P2: pfB_Match_ET_v6.txt -- the keep-list was v4-only, so the day a v6 ET
+	 * writer lands its first artifact was silently unlinked. Same unconditional keep as v4 (H4).
+	 *
+	 *   Given the ET v6 match file exists and NO Deny alias / ccwhite state names it
+	 *   When  the sweep runs
+	 *   Then  it is kept unconditionally.
+	 */
+	public function testAlwaysKeepsEtMatchFileV6Family(): void
+	{
+		$artifact = $this->touchGen('pfB_Match_ET_v6');
+
+		$reaped = pfb_matchgen_reap([], FALSE, $this->matchgendir);
+
+		$this->assertFileExists($artifact, 'the v6 ET match file must survive too, not just v4');
+		$this->assertNotContains('pfB_Match_ET_v6', $reaped);
+	}
+
+	/**
+	 * R2 + R3 / issue #1250 P2: the ccwhite exempt file's v6 family gets the SAME gate as v4
+	 * (H3) -- kept while ccwhite='match', reaped once ccwhite stops being 'match'.
+	 *
+	 *   Given the v6 exempt file exists and ccwhite IS 'match'
+	 *   When  the sweep runs
+	 *   Then  it is kept.
+	 *   But   (contrast) when ccwhite is NOT 'match', the same v6 file is reaped.
+	 */
+	public function testKeepsExemptFileOnlyWhenCcwhiteIsMatchV6Family(): void
+	{
+		$artifact = $this->touchGen('pfB_Match_Exempt_v6');
+
+		$reaped = pfb_matchgen_reap([], TRUE, $this->matchgendir);
+		$this->assertFileExists($artifact, 'ccwhite=match must keep the v6 consolidated exempt file too');
+		$this->assertNotContains('pfB_Match_Exempt_v6', $reaped);
+
+		// Recreate for the contrast leg (the prior call left it in place).
+		$reaped = pfb_matchgen_reap([], FALSE, $this->matchgendir);
+		$this->assertFileDoesNotExist($artifact, 'ccwhite off must reap a now-orphaned v6 exempt file');
+		$this->assertContains('pfB_Match_Exempt_v6', $reaped);
 	}
 }

--- a/tests/php/MatchdirApplyMovesTest.php
+++ b/tests/php/MatchdirApplyMovesTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1250 — pin pfb_matchdir_apply_moves(), the upgrade-time application of the
+ * migration plan's renames. Its return value (the OLD basenames actually renamed) feeds
+ * the stale-Localfile warning and the 'Moved:' banner, so it must report real outcomes:
+ * a rename skipped by the live no-clobber guard (destination appeared between the plan's
+ * snapshot and the rename) or failed outright leaves the old file live and valid — warning
+ * the admin to "repoint" such a file would break a working list.
+ *
+ * Feature: migration plan application
+ *   Scenario outline: T1 clean rename applied+reported; T2 no-clobber race skips + keeps
+ *   both files; T3 vanished source not reported; T4 mixed batch reports only successes;
+ *   T5 end-to-end with pfb_matchdir_stale_localfile_refs(): a never-moved file is not
+ *   flagged even though the plan wanted to move it.
+ */
+#[CoversFunction('pfb_matchdir_apply_moves')]
+final class MatchdirApplyMovesTest extends TestCase
+{
+	private string $matchdir;
+	private string $matchgendir;
+
+	protected function setUp(): void
+	{
+		$this->matchdir = sys_get_temp_dir() . '/pfb_applymoves_' . getmypid() . '_' . uniqid();
+		$this->matchgendir = "{$this->matchdir}/generated";
+		mkdir($this->matchgendir, 0777, TRUE);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ((glob("{$this->matchgendir}/*") ?: []) as $pfb_f) {
+			@unlink($pfb_f);
+		}
+		@rmdir($this->matchgendir);
+		foreach ((glob("{$this->matchdir}/*") ?: []) as $pfb_f) {
+			@unlink($pfb_f);
+		}
+		@rmdir($this->matchdir);
+	}
+
+	/** T1: a clean planned rename is applied and reported. */
+	public function testCleanRenameIsAppliedAndReported(): void
+	{
+		file_put_contents("{$this->matchdir}/matchSpam_v4.txt", "192.0.2.0/24\n");
+
+		$applied = pfb_matchdir_apply_moves(
+			['matchSpam_v4.txt' => 'pfB_Match_Rep_Spam_v4.txt'], $this->matchdir, $this->matchgendir);
+
+		$this->assertSame(['matchSpam_v4.txt'], $applied);
+		$this->assertFileDoesNotExist("{$this->matchdir}/matchSpam_v4.txt");
+		$this->assertSame("192.0.2.0/24\n", file_get_contents("{$this->matchgendir}/pfB_Match_Rep_Spam_v4.txt"));
+	}
+
+	/**
+	 * T2: the live no-clobber guard — destination appeared AFTER the plan's snapshot.
+	 * The rename is skipped, NOT reported as applied, and both files keep their content.
+	 */
+	public function testNoClobberRaceSkipsAndKeepsBothFiles(): void
+	{
+		file_put_contents("{$this->matchdir}/matchSpam_v4.txt", "192.0.2.0/24\n");
+		file_put_contents("{$this->matchgendir}/pfB_Match_Rep_Spam_v4.txt", "198.51.100.0/24\n");
+
+		$applied = pfb_matchdir_apply_moves(
+			['matchSpam_v4.txt' => 'pfB_Match_Rep_Spam_v4.txt'], $this->matchdir, $this->matchgendir);
+
+		$this->assertSame([], $applied, 'a no-clobber skip must not be reported as moved');
+		$this->assertSame("192.0.2.0/24\n", file_get_contents("{$this->matchdir}/matchSpam_v4.txt"));
+		$this->assertSame("198.51.100.0/24\n", file_get_contents("{$this->matchgendir}/pfB_Match_Rep_Spam_v4.txt"));
+	}
+
+	/** T3: a source that vanished between plan and apply fails the rename and is not reported. */
+	public function testVanishedSourceIsNotReported(): void
+	{
+		$applied = pfb_matchdir_apply_moves(
+			['matchGone_v4.txt' => 'pfB_Match_Rep_Gone_v4.txt'], $this->matchdir, $this->matchgendir);
+
+		$this->assertSame([], $applied);
+		$this->assertFileDoesNotExist("{$this->matchgendir}/pfB_Match_Rep_Gone_v4.txt");
+	}
+
+	/** T4: a mixed batch reports only the renames that actually succeeded, in plan order. */
+	public function testMixedBatchReportsOnlySuccesses(): void
+	{
+		file_put_contents("{$this->matchdir}/matchA_v4.txt", "192.0.2.0/24\n");
+		file_put_contents("{$this->matchdir}/matchB_v4.txt", "192.0.2.128/25\n");
+		file_put_contents("{$this->matchgendir}/pfB_Match_Rep_B_v4.txt", "198.51.100.0/24\n");
+		file_put_contents("{$this->matchdir}/ETMatch.txt", "203.0.113.0/24\n");
+
+		$applied = pfb_matchdir_apply_moves([
+			'matchA_v4.txt' => 'pfB_Match_Rep_A_v4.txt',
+			'matchB_v4.txt' => 'pfB_Match_Rep_B_v4.txt',
+			'ETMatch.txt'   => 'pfB_Match_ET_v4.txt',
+		], $this->matchdir, $this->matchgendir);
+
+		$this->assertSame(['matchA_v4.txt', 'ETMatch.txt'], $applied);
+	}
+
+	/**
+	 * T5: the false-alarm regression, end-to-end through both real functions. The plan
+	 * wants to move matchSpam_v4.txt, the no-clobber guard skips it, and the admin's
+	 * Localfile row pointing at the still-live old path must NOT be flagged as stale.
+	 */
+	public function testSkippedRenameNeverFlagsTheStillValidLocalfileRef(): void
+	{
+		file_put_contents("{$this->matchdir}/matchSpam_v4.txt", "192.0.2.0/24\n");
+		file_put_contents("{$this->matchgendir}/pfB_Match_Rep_Spam_v4.txt", "198.51.100.0/24\n");
+		$pfb_rows = [['list' => 'MyAlias', 'header' => 'matchSpam', 'url' => "{$this->matchdir}/matchSpam_v4.txt"]];
+
+		$applied = pfb_matchdir_apply_moves(
+			['matchSpam_v4.txt' => 'pfB_Match_Rep_Spam_v4.txt'], $this->matchdir, $this->matchgendir);
+		$stale = pfb_matchdir_stale_localfile_refs($pfb_rows, $this->matchdir, $applied);
+
+		$this->assertSame([], $stale, sprintf(
+			'a never-moved file must not trigger the repoint warning; applied=%s stale=%s',
+			var_export($applied, TRUE), var_export($stale, TRUE)));
+		$this->assertFileExists("{$this->matchdir}/matchSpam_v4.txt");
+	}
+}

--- a/tests/php/MatchdirConfigHeadersTest.php
+++ b/tests/php/MatchdirConfigHeadersTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1250 — pin pfb_matchdir_config_headers(), the migration's header-set builder. It
+ * mirrors sync_package_pfblockerng()'s own composition (Download/Collect: \W-stripped
+ * "{header}{vtype}"; the '<alias>_custom' / DNSBLIP / GeoIP-continent synthetic rows) so the
+ * install-time migration plan is fed the SAME names the disk actually contains — under- or
+ * over-enumerating either set mis-routes a real machine artifact. Pure, brand-new function
+ * (no pre-existing behaviour to pin — CLAUDE.md Test coverage #1 exception 2).
+ *
+ * Feature: matchdir migration config-header enumeration
+ *   Given the raw pfblockernglistsv4/v6 config, the DNSBL settings section, and a map of
+ *         continent alias -> its config section
+ *   When  the helper walks every configured list/row + synthetic source
+ *   Then  it returns the deny set, the match set, and the flattened real-row list the
+ *         migration plan and stale-ref detector need.
+ */
+#[CoversFunction('pfb_matchdir_config_headers')]
+final class MatchdirConfigHeadersTest extends TestCase
+{
+	/** One list config entry with a single row, minimal shape. */
+	private function list(string $alias, string $action, string $header, string $url = '/x', string $rowState = 'Enabled', string $custom = ''): array
+	{
+		$list = array('aliasname' => $alias, 'action' => $action, 'row' => array(
+			array('header' => $header, 'url' => $url, 'state' => $rowState),
+		));
+		if ($custom !== '') {
+			$list['custom'] = $custom;
+		}
+		return $list;
+	}
+
+	/** H1: an enabled Deny list's row header lands in BOTH sets, and the row is collected. */
+	public function testH1DenyListRowInBothSets(): void
+	{
+		$v4 = array($this->list('Spam', 'Deny', 'Spam'));
+		$v6 = array($this->list('Spam', 'Deny', 'Spam'));
+
+		$out = pfb_matchdir_config_headers(array('_v4' => $v4, '_v6' => $v6), [], []);
+
+		$this->assertContains('Spam_v4', $out['deny']);
+		$this->assertContains('Spam_v6', $out['deny']);
+		$this->assertContains('Spam_v4', $out['match']);
+		$this->assertContains('Spam_v6', $out['match']);
+		$this->assertCount(2, $out['rows']);
+	}
+
+	/** H2: an enabled Match list's row header lands in the match set ONLY. */
+	public function testH2MatchListRowInMatchSetOnly(): void
+	{
+		$v4 = array($this->list('Ads', 'Match', 'Ads'));
+
+		$out = pfb_matchdir_config_headers(array('_v4' => $v4), [], []);
+
+		$this->assertContains('Ads_v4', $out['match']);
+		$this->assertNotContains('Ads_v4', $out['deny']);
+	}
+
+	/** H3 / issue #1250 F3: a Disabled LIST's row still counts toward the match set (a stale user file must never adopt), but not deny. */
+	public function testH3DisabledListRowInMatchSetOnlyRowsStillCollected(): void
+	{
+		$v4 = array($this->list('Spam', 'Disabled', 'Spam'));
+
+		$out = pfb_matchdir_config_headers(array('_v4' => $v4), [], []);
+
+		$this->assertContains('Spam_v4', $out['match']);
+		$this->assertNotContains('Spam_v4', $out['deny']);
+		$this->assertCount(1, $out['rows']);
+	}
+
+	/** H4 / issue #1250 F3: a Disabled ROW inside an ENABLED Deny list still counts toward BOTH sets and is still collected. */
+	public function testH4DisabledRowInsideEnabledDenyListStillCounted(): void
+	{
+		$v4 = array($this->list('Spam', 'Deny', 'Spam', '/x', 'Disabled'));
+
+		$out = pfb_matchdir_config_headers(array('_v4' => $v4), [], []);
+
+		$this->assertContains('Spam_v4', $out['deny']);
+		$this->assertContains('Spam_v4', $out['match']);
+		$this->assertCount(1, $out['rows']);
+	}
+
+	/** H5: a header with punctuation is \W-stripped the SAME way sync_package_pfblockerng() strips it; the raw header survives in rows[]. */
+	public function testH5PunctuatedHeaderIsNormalisedInSetsButRawInRows(): void
+	{
+		$v4 = array($this->list('DD', 'Deny', 'de-dup'));
+
+		$out = pfb_matchdir_config_headers(array('_v4' => $v4), [], []);
+
+		$this->assertContains('dedup_v4', $out['deny']);
+		$this->assertContains('dedup_v4', $out['match']);
+		$this->assertSame('de-dup', $out['rows'][0]['header']);
+	}
+
+	/** H6: custom text on a Deny list lands the '<alias>_custom<vtype>' name in BOTH sets; a Match list's custom lands in match only. */
+	public function testH6CustomTextRoutedByListAction(): void
+	{
+		$denyList = $this->list('Blk', 'Deny', 'Blk', '/x', 'Enabled', 'custom-text');
+		$matchList = $this->list('Wht', 'Match', 'Wht', '/x', 'Enabled', 'custom-text');
+
+		$out = pfb_matchdir_config_headers(array('_v4' => array($denyList, $matchList)), [], []);
+
+		$this->assertContains('Blk_custom_v4', $out['deny']);
+		$this->assertContains('Blk_custom_v4', $out['match']);
+		$this->assertNotContains('Wht_custom_v4', $out['deny']);
+		$this->assertContains('Wht_custom_v4', $out['match']);
+	}
+
+	/** H7 hostile: an aliasname with spaces/punctuation is \W-stripped before '_custom' is appended. */
+	public function testH7PunctuatedAliasnameNormalisedBeforeCustomSuffix(): void
+	{
+		$list = $this->list('my alias!', 'Match', 'x', '/x', 'Enabled', 'custom-text');
+
+		$out = pfb_matchdir_config_headers(array('_v4' => array($list)), [], []);
+
+		$this->assertContains('myalias_custom_v4', $out['match']);
+	}
+
+	/** H8: the DNSBL IP-blocking action gates a synthetic 'DNSBLIP_v4'/'_v6' pair in the deny set. */
+	public function testH8DnsblDenyActionAddsDnsblipBothFamilies(): void
+	{
+		$out = pfb_matchdir_config_headers([], array('action' => 'Deny_Both'), []);
+
+		$this->assertContains('DNSBLIP_v4', $out['deny']);
+		$this->assertContains('DNSBLIP_v6', $out['deny']);
+	}
+
+	/** H8 contrast: a non-Deny (or absent) DNSBL action adds nothing. */
+	public function testH8DnsblNonDenyActionAddsNothing(): void
+	{
+		$this->assertSame([], pfb_matchdir_config_headers([], array('action' => 'Match_Both'), [])['deny']);
+		$this->assertSame([], pfb_matchdir_config_headers([], [], [])['deny']);
+	}
+
+	/**
+	 * H9: a continent whose config action contains 'Deny' adds its OWN alias, both families --
+	 * exercised on two distinct fabricated aliases to prove the enumeration is caller-supplied,
+	 * not a hardcoded 9-continent list inside the helper.
+	 */
+	public function testH9ContinentDenyActionAddsBothFamiliesForCallerSuppliedAliases(): void
+	{
+		$out = pfb_matchdir_config_headers([], [], array(
+			'pfB_Africa' => array('action' => 'Deny'),
+			'pfB_FakeContinent' => array('action' => 'Deny'),
+		));
+
+		$this->assertContains('pfB_Africa_v4', $out['deny']);
+		$this->assertContains('pfB_Africa_v6', $out['deny']);
+		$this->assertContains('pfB_FakeContinent_v4', $out['deny']);
+		$this->assertContains('pfB_FakeContinent_v6', $out['deny']);
+	}
+
+	/** H9 contrast: Match / Disabled / empty continent config adds nothing for that alias. */
+	public function testH9ContinentNonDenyActionAddsNothing(): void
+	{
+		$out = pfb_matchdir_config_headers([], [], array(
+			'pfB_Europe' => array('action' => 'Match'),
+			'pfB_Asia'   => array('action' => 'Disabled'),
+			'pfB_Top'    => [],
+		));
+
+		$this->assertSame([], $out['deny']);
+	}
+
+	/** H10 hostile: a normalised-empty header ('!!!' strips to '') contributes to NEITHER set, even though the row (url present) is still collected. */
+	public function testH10EmptyNormalisedHeaderContributesToNeitherSet(): void
+	{
+		$v4 = array($this->list('X', 'Deny', '!!!'));
+
+		$out = pfb_matchdir_config_headers(array('_v4' => $v4), [], []);
+
+		$this->assertSame([], $out['deny'], 'an empty-header row must never widen the deny set to a bare "_v4"');
+		$this->assertSame([], $out['match'], 'an empty-header row must never widen the match set to a bare "_v4"');
+		$this->assertCount(1, $out['rows']);
+	}
+
+	/** H11: a row with no url at all is never added to rows[], but its header still counts toward the sets. */
+	public function testH11RowWithoutUrlSkipsRowsButStillCountsHeader(): void
+	{
+		$v4 = array($this->list('X', 'Deny', 'Spam', ''));
+
+		$out = pfb_matchdir_config_headers(array('_v4' => $v4), [], []);
+
+		$this->assertSame([], $out['rows']);
+		$this->assertContains('Spam_v4', $out['deny']);
+		$this->assertContains('Spam_v4', $out['match']);
+	}
+
+	/** H12: nothing configured anywhere -> a fully empty result on all three keys. */
+	public function testH12EmptyInputYieldsEmptyResult(): void
+	{
+		$out = pfb_matchdir_config_headers([], [], []);
+
+		$this->assertSame(array('deny' => [], 'match' => [], 'rows' => []), $out);
+	}
+}

--- a/tests/php/MatchdirConfigHeadersTest.php
+++ b/tests/php/MatchdirConfigHeadersTest.php
@@ -61,7 +61,7 @@ final class MatchdirConfigHeadersTest extends TestCase
 		$this->assertNotContains('Ads_v4', $out['deny']);
 	}
 
-	/** H3 / issue #1250 F3: a Disabled LIST's row still counts toward the match set (a stale user file must never adopt), but not deny. */
+	/** H3 / issue #1250: a Disabled LIST's row still counts toward the match set (a stale user file must never adopt), but not deny. */
 	public function testH3DisabledListRowInMatchSetOnlyRowsStillCollected(): void
 	{
 		$v4 = array($this->list('Spam', 'Disabled', 'Spam'));
@@ -73,7 +73,7 @@ final class MatchdirConfigHeadersTest extends TestCase
 		$this->assertCount(1, $out['rows']);
 	}
 
-	/** H4 / issue #1250 F3: a Disabled ROW inside an ENABLED Deny list still counts toward BOTH sets and is still collected. */
+	/** H4 / issue #1250: a Disabled ROW inside an ENABLED Deny list still counts toward BOTH sets and is still collected. */
 	public function testH4DisabledRowInsideEnabledDenyListStillCounted(): void
 	{
 		$v4 = array($this->list('Spam', 'Deny', 'Spam', '/x', 'Disabled'));

--- a/tests/php/MatchdirMigratePlanTest.php
+++ b/tests/php/MatchdirMigratePlanTest.php
@@ -192,7 +192,7 @@ final class MatchdirMigratePlanTest extends TestCase
 	}
 
 	/**
-	 * M15 / issue #1250 F2: NO candidate at all (ccwhite off, no Deny "dedup", no Match
+	 * M15 / issue #1250: NO candidate at all (ccwhite off, no Deny "dedup", no Match
 	 * "matchdedup") -> a plain orphan, LEFT -- not a silent move-then-reap through Exempt.
 	 */
 	public function testM15DedupLeftAsOrphanWhenNoCandidateExists(): void
@@ -205,7 +205,7 @@ final class MatchdirMigratePlanTest extends TestCase
 	}
 
 	/**
-	 * M16 / issue #1250 F2: a Deny list literally headed 'dedup' is configured (ccwhite off,
+	 * M16 / issue #1250: a Deny list literally headed 'dedup' is configured (ccwhite off,
 	 * no Match) -> the Deny Rep artifact, never Exempt -- the old code ignored Deny here.
 	 */
 	public function testM16DedupMovesToRepWhenOnlyDenyDedupConfigured(): void
@@ -216,7 +216,7 @@ final class MatchdirMigratePlanTest extends TestCase
 		$this->assertSame([], $plan['undecidable']);
 	}
 
-	/** M17 / issue #1250 F2: the v6 stem gets the SAME Deny-Rep treatment as v4, not an unconditional leave. */
+	/** M17 / issue #1250: the v6 stem gets the SAME Deny-Rep treatment as v4, not an unconditional leave. */
 	public function testM17DedupV6MovesToRepWhenDenyDedupV6Configured(): void
 	{
 		$plan = pfb_matchdir_migrate_plan(['matchdedup_v6.txt'], ['dedup_v6'], [], FALSE, []);
@@ -226,7 +226,7 @@ final class MatchdirMigratePlanTest extends TestCase
 	}
 
 	/**
-	 * M18 / issue #1250 F2: ccwhite ON AND a Deny list "dedup" both exist -> undecidable
+	 * M18 / issue #1250: ccwhite ON AND a Deny list "dedup" both exist -> undecidable
 	 * between the Exempt write and the Deny Rep artifact, never silently moved to Exempt.
 	 */
 	public function testM18DedupExemptAndDenyBothCandidateIsUndecidable(): void
@@ -242,7 +242,7 @@ final class MatchdirMigratePlanTest extends TestCase
 		$this->assertStringContainsString('Exempt', $pfb_joined);
 	}
 
-	/** M19 / issue #1250 F2: Deny "dedup" + Match "matchdedup" + ccwhite ON -> all THREE candidates, none dropped. */
+	/** M19 / issue #1250: Deny "dedup" + Match "matchdedup" + ccwhite ON -> all THREE candidates, none dropped. */
 	public function testM19DedupAllThreeCandidatesIsUndecidable(): void
 	{
 		$plan = pfb_matchdir_migrate_plan(['matchdedup_v4.txt'], ['dedup_v4'], ['matchdedup_v4'], TRUE, []);

--- a/tests/php/MatchdirMigratePlanTest.php
+++ b/tests/php/MatchdirMigratePlanTest.php
@@ -85,8 +85,10 @@ final class MatchdirMigratePlanTest extends TestCase
 		$this->assertArrayNotHasKey('matchSpam_v4.txt', $plan['move']);
 		$this->assertCount(1, $plan['undecidable']);
 		$this->assertSame('matchSpam_v4.txt', $plan['undecidable'][0]['file']);
-		$this->assertStringContainsString('Spam', $plan['undecidable'][0]['candidate_a']);
-		$this->assertStringContainsString('matchSpam', $plan['undecidable'][0]['candidate_b']);
+		$this->assertCount(2, $plan['undecidable'][0]['candidates']);
+		$pfb_joined = implode('|', $plan['undecidable'][0]['candidates']);
+		$this->assertStringContainsString('Spam', $pfb_joined);
+		$this->assertStringContainsString('matchSpam', $pfb_joined);
 	}
 
 	/** M6: neither configured -> an orphan; left for the matchgendir reaper's problem, never re-homed. */
@@ -116,7 +118,8 @@ final class MatchdirMigratePlanTest extends TestCase
 		$this->assertSame([], $plan['move']);
 		$this->assertCount(1, $plan['undecidable']);
 		$this->assertSame('matchdedup_v4.txt', $plan['undecidable'][0]['file']);
-		$this->assertStringContainsString('matchdedup', $plan['undecidable'][0]['candidate_b']);
+		$this->assertCount(2, $plan['undecidable'][0]['candidates']);
+		$this->assertStringContainsString('matchdedup', implode('|', $plan['undecidable'][0]['candidates']));
 	}
 
 	/** M9: ccwhite is NOT 'match' -> only the user's file is possible, left silently. */
@@ -188,6 +191,81 @@ final class MatchdirMigratePlanTest extends TestCase
 		$this->assertSame(['move' => [], 'leave' => [], 'undecidable' => []], $second);
 	}
 
+	/**
+	 * M15 / issue #1250 F2: NO candidate at all (ccwhite off, no Deny "dedup", no Match
+	 * "matchdedup") -> a plain orphan, LEFT -- not a silent move-then-reap through Exempt.
+	 */
+	public function testM15DedupLeftAsOrphanWhenNoCandidateExists(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchdedup_v4.txt'], [], [], FALSE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertContains('matchdedup_v4.txt', $plan['leave']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/**
+	 * M16 / issue #1250 F2: a Deny list literally headed 'dedup' is configured (ccwhite off,
+	 * no Match) -> the Deny Rep artifact, never Exempt -- the old code ignored Deny here.
+	 */
+	public function testM16DedupMovesToRepWhenOnlyDenyDedupConfigured(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchdedup_v4.txt'], ['dedup_v4'], [], FALSE, []);
+
+		$this->assertSame(['matchdedup_v4.txt' => 'pfB_Match_Rep_dedup_v4.txt'], $plan['move']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/** M17 / issue #1250 F2: the v6 stem gets the SAME Deny-Rep treatment as v4, not an unconditional leave. */
+	public function testM17DedupV6MovesToRepWhenDenyDedupV6Configured(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchdedup_v6.txt'], ['dedup_v6'], [], FALSE, []);
+
+		$this->assertSame(['matchdedup_v6.txt' => 'pfB_Match_Rep_dedup_v6.txt'], $plan['move']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/**
+	 * M18 / issue #1250 F2: ccwhite ON AND a Deny list "dedup" both exist -> undecidable
+	 * between the Exempt write and the Deny Rep artifact, never silently moved to Exempt.
+	 */
+	public function testM18DedupExemptAndDenyBothCandidateIsUndecidable(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchdedup_v4.txt'], ['dedup_v4'], [], TRUE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertCount(1, $plan['undecidable']);
+		$this->assertSame('matchdedup_v4.txt', $plan['undecidable'][0]['file']);
+		$pfb_joined = implode('|', $plan['undecidable'][0]['candidates']);
+		$this->assertCount(2, $plan['undecidable'][0]['candidates']);
+		$this->assertStringContainsString('dedup', $pfb_joined);
+		$this->assertStringContainsString('Exempt', $pfb_joined);
+	}
+
+	/** M19 / issue #1250 F2: Deny "dedup" + Match "matchdedup" + ccwhite ON -> all THREE candidates, none dropped. */
+	public function testM19DedupAllThreeCandidatesIsUndecidable(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchdedup_v4.txt'], ['dedup_v4'], ['matchdedup_v4'], TRUE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertCount(1, $plan['undecidable']);
+		$this->assertCount(3, $plan['undecidable'][0]['candidates']);
+		$pfb_joined = implode('|', $plan['undecidable'][0]['candidates']);
+		$this->assertStringContainsString('dedup', $pfb_joined);
+		$this->assertStringContainsString('matchdedup', $pfb_joined);
+		$this->assertStringContainsString('Exempt', $pfb_joined);
+	}
+
+	/** M20: the v6 dedup stem never gets an Exempt candidate -- that writer only ever produced _v4. */
+	public function testM20DedupV6NeverGetsAnExemptCandidate(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchdedup_v6.txt'], [], [], TRUE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertContains('matchdedup_v6.txt', $plan['leave']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
 	// --- Hostile-input rows: the stem parser is a parser, treat it as one. ---
 
 	/** H-a: stem exactly 'match_v4' (empty header) with neither side configured -> parses cleanly, left as an orphan. */
@@ -244,5 +322,17 @@ final class MatchdirMigratePlanTest extends TestCase
 
 		$this->assertSame([], $plan['move']);
 		$this->assertContains('ETMatch', $plan['leave']);
+	}
+
+	/**
+	 * H-g / A12: the '.txt' suffix check is case-sensitive (basename() is byte-exact on the
+	 * appliance's case-sensitive filesystem) -- an uppercase extension never matches, always left.
+	 */
+	public function testHostileUppercaseExtensionIsNeverACandidate(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['MATCHFOO_V4.TXT'], ['FOO_V4'], [], FALSE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertContains('MATCHFOO_V4.TXT', $plan['leave']);
 	}
 }

--- a/tests/php/MatchdirMigratePlanTest.php
+++ b/tests/php/MatchdirMigratePlanTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1250 — pin pfb_matchdir_migrate_plan(), the upgrade-time decision of which
+ * top-level matchdir *.txt files are machine-owned artifacts (move into matchgendir under
+ * their new pfB_Match_* name) vs a same-named user Match-list file (leave in place). A
+ * user's own Match-list file always carries a family suffix ('<header>_v4'/'_v6' — the
+ * Download/Collect header build in pfblockerng.inc), so the un-suffixed 'ETMatch.txt' is
+ * unreachable by any user list and always the ET artifact; 'matchdedup_*' and
+ * 'match<Header>_<fam>' can collide with a same-named user list and are cross-referenced
+ * against the configured Deny/Match header sets. Pure: no filesystem I/O.
+ *
+ * Feature: matchdir->matchgendir migration planning
+ *   Background:
+ *     Given a top-level listing of matchdir's *.txt files
+ *     And   the configured Deny-action and Match-action header sets (per family)
+ *     And   the ccwhite='match' flag (the exempt file's only writer)
+ *   Scenario outline: decision table (brief section 4), one row each M1-M14
+ *
+ * Never delete: every case either moves, leaves, or marks undecidable — never drops a file.
+ */
+#[CoversFunction('pfb_matchdir_migrate_plan')]
+final class MatchdirMigratePlanTest extends TestCase
+{
+	/** M1: ETMatch.txt has no family suffix — unreachable by any user list, always moved. */
+	public function testM1EtMatchAlwaysMoves(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['ETMatch.txt'], [], [], FALSE, []);
+
+		$this->assertSame(['ETMatch.txt' => 'pfB_Match_ET_v4.txt'], $plan['move']);
+		$this->assertSame([], $plan['leave']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/**
+	 * M2: the fact that makes ETMatch unambiguous — a user Match list headed 'ETMatch'
+	 * produces 'ETMatch_v4.txt' (WITH the family suffix), never a collision with the
+	 * un-suffixed machine artifact. Both files present: ETMatch.txt moves, ETMatch_v4.txt
+	 * (the user's file) is left, even though a Match list named 'ETMatch' is configured.
+	 */
+	public function testM2EtMatchMovesWhileUserListOfSameNameIsLeft(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(
+			['ETMatch.txt', 'ETMatch_v4.txt'],
+			[],
+			['ETMatch_v4'],
+			FALSE,
+			[]
+		);
+
+		$this->assertSame(['ETMatch.txt' => 'pfB_Match_ET_v4.txt'], $plan['move']);
+		$this->assertContains('ETMatch_v4.txt', $plan['leave']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/** M3: a Deny list's reputation artifact, no colliding Match list -> moved. */
+	public function testM3RepArtifactMovesWhenOnlyDenyHeaderConfigured(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchSpam_v4.txt'], ['Spam_v4'], [], FALSE, []);
+
+		$this->assertSame(['matchSpam_v4.txt' => 'pfB_Match_Rep_Spam_v4.txt'], $plan['move']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/** M4: only the colliding Match list is configured -> it is the user's own file, left. */
+	public function testM4LeftWhenOnlyMatchHeaderConfigured(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchSpam_v4.txt'], [], ['matchSpam_v4'], FALSE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertContains('matchSpam_v4.txt', $plan['leave']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/** M5: BOTH a Deny list 'Spam' and a Match list 'matchSpam' configured -> undecidable, needs a human. */
+	public function testM5BothConfiguredIsUndecidableNotMoved(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchSpam_v4.txt'], ['Spam_v4'], ['matchSpam_v4'], FALSE, []);
+
+		$this->assertArrayNotHasKey('matchSpam_v4.txt', $plan['move']);
+		$this->assertCount(1, $plan['undecidable']);
+		$this->assertSame('matchSpam_v4.txt', $plan['undecidable'][0]['file']);
+		$this->assertStringContainsString('Spam', $plan['undecidable'][0]['candidate_a']);
+		$this->assertStringContainsString('matchSpam', $plan['undecidable'][0]['candidate_b']);
+	}
+
+	/** M6: neither configured -> an orphan; left for the matchgendir reaper's problem, never re-homed. */
+	public function testM6NeitherConfiguredIsLeftAsOrphan(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchSpam_v4.txt'], [], [], FALSE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertContains('matchSpam_v4.txt', $plan['leave']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/** M7: the ccwhite consolidated exempt write, no colliding Match list -> moved. */
+	public function testM7ExemptFileMovesWhenNoCollidingMatchList(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchdedup_v4.txt'], [], [], TRUE, []);
+
+		$this->assertSame(['matchdedup_v4.txt' => 'pfB_Match_Exempt_v4.txt'], $plan['move']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/** M8: ccwhite='match' AND a Match list literally headed 'matchdedup' -> undecidable. */
+	public function testM8DedupBothConfiguredIsUndecidable(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchdedup_v4.txt'], [], ['matchdedup_v4'], TRUE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertCount(1, $plan['undecidable']);
+		$this->assertSame('matchdedup_v4.txt', $plan['undecidable'][0]['file']);
+		$this->assertStringContainsString('matchdedup', $plan['undecidable'][0]['candidate_b']);
+	}
+
+	/** M9: ccwhite is NOT 'match' -> only the user's file is possible, left silently. */
+	public function testM9DedupLeftWhenCcwhiteIsNotMatch(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchdedup_v4.txt'], [], ['matchdedup_v4'], FALSE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertContains('matchdedup_v4.txt', $plan['leave']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/** M10: the family axis — a v6 Deny header's reputation artifact moves too, not just v4. */
+	public function testM10RepArtifactMovesForV6Family(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchSpam_v6.txt'], ['Spam_v6'], [], FALSE, []);
+
+		$this->assertSame(['matchSpam_v6.txt' => 'pfB_Match_Rep_Spam_v6.txt'], $plan['move']);
+	}
+
+	/** M11: an ordinary user Match list, no 'match' prefix shape at all -> always left. */
+	public function testM11OrdinaryUserListAlwaysLeft(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['Ads_v4.txt'], ['Ads_v4'], ['Ads_v4'], TRUE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertContains('Ads_v4.txt', $plan['leave']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/** M12: no-clobber — the destination already exists in matchgendir; source is left + skipped, never overwritten. */
+	public function testM12NoClobberLeavesSourceWhenDestinationExists(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(
+			['matchSpam_v4.txt'],
+			['Spam_v4'],
+			[],
+			FALSE,
+			['pfB_Match_Rep_Spam_v4.txt']
+		);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertContains('matchSpam_v4.txt', $plan['leave']);
+	}
+
+	/** M13: an empty matchdir listing -> an entirely empty plan (a fresh install prints no banner). */
+	public function testM13EmptyMatchdirYieldsEmptyPlan(): void
+	{
+		$plan = pfb_matchdir_migrate_plan([], ['Spam_v4'], ['matchSpam_v4'], TRUE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertSame([], $plan['leave']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/**
+	 * M14: idempotence — re-running the plan against the POST-migration matchdir listing
+	 * (the moved file is physically gone; only orphans/user files remain) moves nothing.
+	 */
+	public function testM14SecondRunAgainstPostMigrationStateIsEmpty(): void
+	{
+		$first = pfb_matchdir_migrate_plan(['matchSpam_v4.txt'], ['Spam_v4'], [], FALSE, []);
+		$this->assertNotEmpty($first['move'], 'precondition: the first pass actually planned a move');
+
+		// The file named in $first['move'] no longer exists in matchdir after the real
+		// rename(); the caller's listing on the next run reflects that directly.
+		$second = pfb_matchdir_migrate_plan([], ['Spam_v4'], [], FALSE, array_values($first['move']));
+
+		$this->assertSame(['move' => [], 'leave' => [], 'undecidable' => []], $second);
+	}
+
+	// --- Hostile-input rows: the stem parser is a parser, treat it as one. ---
+
+	/** H-a: stem exactly 'match_v4' (empty header) with neither side configured -> parses cleanly, left as an orphan. */
+	public function testHostileEmptyHeaderStemNeitherConfiguredIsLeft(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['match_v4.txt'], [], [], FALSE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertContains('match_v4.txt', $plan['leave']);
+		$this->assertSame([], $plan['undecidable']);
+	}
+
+	/** H-e: the same empty-header stem, but the empty Deny header IS configured -> moves correctly (no crash on H=""). */
+	public function testHostileEmptyHeaderStemMovesWhenEmptyDenyHeaderConfigured(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['match_v4.txt'], ['_v4'], [], FALSE, []);
+
+		$this->assertSame(['match_v4.txt' => 'pfB_Match_Rep__v4.txt'], $plan['move']);
+	}
+
+	/** H-b: stem 'match' with no family suffix at all -> does not match the pattern, left untouched. */
+	public function testHostileMatchWithNoFamilySuffixIsLeft(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['match.txt'], ['match'], ['match'], FALSE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertContains('match.txt', $plan['leave']);
+	}
+
+	/** H-c: stem 'matchdedup' with no family suffix -> does not match the dedup special-case either, left. */
+	public function testHostileMatchdedupWithNoFamilySuffixIsLeft(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['matchdedup.txt'], [], [], TRUE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertContains('matchdedup.txt', $plan['leave']);
+	}
+
+	/**
+	 * H-d: a header containing an underscore — the '_v4' split must come from the RIGHT
+	 * (string end), never the first underscore, or 'Spam_Feed' would be mis-split.
+	 */
+	public function testHostileUnderscoreInHeaderSplitsFromTheRight(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['match_Spam_Feed_v4.txt'], ['_Spam_Feed_v4'], [], FALSE, []);
+
+		$this->assertSame(['match_Spam_Feed_v4.txt' => 'pfB_Match_Rep__Spam_Feed_v4.txt'], $plan['move']);
+	}
+
+	/** H-f: a file with no .txt extension at all -> never treated as a candidate, always left. */
+	public function testHostileNonTxtFileIsLeft(): void
+	{
+		$plan = pfb_matchdir_migrate_plan(['ETMatch'], [], [], FALSE, []);
+
+		$this->assertSame([], $plan['move']);
+		$this->assertContains('ETMatch', $plan['leave']);
+	}
+}

--- a/tests/php/MatchdirStaleLocalfileRefsTest.php
+++ b/tests/php/MatchdirStaleLocalfileRefsTest.php
@@ -10,24 +10,27 @@ use PHPUnit\Framework\TestCase;
  * GUI once instructed admins to point a Match alias's Localfile at e.g.
  * '/var/db/pfblockerng/match/ETMatch.txt' — an OLD machine-generated artifact path. The
  * migration does NOT rewrite that config for them, so every list row whose 'url' still
- * points there is surfaced instead. Pure.
+ * points at a file THIS RUN ACTUALLY MOVED is surfaced instead. Pure.
  *
  * Feature: stale Localfile-reference detection
- *   Given a flattened list of configured IP-list rows (any action)
- *   When  a row's 'url' resolves to matchdir + an OLD artifact filename shape
- *   Then  that row is reported; anything else is not.
+ *   Given a flattened list of configured IP-list rows (any action, any state)
+ *   And   the basenames the migration actually moved this run
+ *   When  a row's 'url' resolves to matchdir + one of those basenames
+ *   Then  that row is reported; anything else — including a same-shaped file that was NOT
+ *         moved (a live user list) — is not (issue #1250 F6: shape-keying false-flagged a
+ *         working, never-moved user list).
  */
 #[CoversFunction('pfb_matchdir_stale_localfile_refs')]
 final class MatchdirStaleLocalfileRefsTest extends TestCase
 {
 	private const MATCHDIR = '/var/db/pfblockerng/match';
 
-	/** A row whose Localfile points at the OLD ETMatch.txt artifact path is reported. */
+	/** S2: a row whose Localfile points at the OLD ETMatch.txt artifact, WHICH WAS MOVED, is reported. */
 	public function testRowPointingAtOldEtMatchPathIsReported(): void
 	{
 		$row = array('list' => 'MyETConsumer', 'header' => 'MyETConsumer', 'url' => self::MATCHDIR . '/ETMatch.txt');
 
-		$hits = pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR);
+		$hits = pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR, ['ETMatch.txt']);
 
 		$this->assertSame([$row], $hits);
 	}
@@ -37,7 +40,7 @@ final class MatchdirStaleLocalfileRefsTest extends TestCase
 	{
 		$row = array('list' => 'Ads', 'header' => 'Ads', 'url' => self::MATCHDIR . '/Ads_v4.txt');
 
-		$this->assertSame([], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR));
+		$this->assertSame([], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR, ['ETMatch.txt']));
 	}
 
 	/** A row pointing at an unrelated path entirely (not under matchdir) is NOT reported. */
@@ -45,15 +48,15 @@ final class MatchdirStaleLocalfileRefsTest extends TestCase
 	{
 		$row = array('list' => 'Other', 'header' => 'Other', 'url' => '/root/mylist.txt');
 
-		$this->assertSame([], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR));
+		$this->assertSame([], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR, ['ETMatch.txt']));
 	}
 
-	/** The ccwhite exempt artifact's OLD name is also caught by the general 'match*_v4/6.txt' shape. */
+	/** S4: a row pointing at matchdedup_v4.txt IS reported once that file was actually moved this run. */
 	public function testRowPointingAtOldDedupPathIsReported(): void
 	{
 		$row = array('list' => 'ExemptConsumer', 'header' => 'ExemptConsumer', 'url' => self::MATCHDIR . '/matchdedup_v4.txt');
 
-		$this->assertSame([$row], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR));
+		$this->assertSame([$row], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR, ['matchdedup_v4.txt']));
 	}
 
 	/** An empty url is skipped without error, never a stray match. */
@@ -61,6 +64,54 @@ final class MatchdirStaleLocalfileRefsTest extends TestCase
 	{
 		$row = array('list' => 'Blank', 'header' => 'Blank', 'url' => '');
 
-		$this->assertSame([], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR));
+		$this->assertSame([], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR, ['ETMatch.txt']));
+	}
+
+	/**
+	 * S1 / issue #1250 F6 [RED]: a user's OWN never-moved 'matchFoo_v4.txt' Localfile ref must
+	 * NOT be flagged just because its NAME has the old machine-artifact shape -- only an
+	 * actually-moved basename triggers the warning. The pre-fix shape-regex flagged this and
+	 * sent the admin to break a working list by repointing it at a path that never existed.
+	 */
+	public function testRowPointingAtShapedButNeverMovedUserFileIsNotReported(): void
+	{
+		$row = array('list' => 'Foo', 'header' => 'Foo', 'url' => self::MATCHDIR . '/matchFoo_v4.txt');
+
+		$hits = pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR, ['ETMatch.txt', 'pfB_Match_Rep_Spam_v4.txt']);
+
+		$this->assertSame([], $hits, 'a shaped-but-never-moved file must not trigger the repoint warning');
+	}
+
+	/** S5: the synthetic custom-list url 'custom' is not under matchdir at all -- never flagged. */
+	public function testCustomListSyntheticUrlIsNotReported(): void
+	{
+		$row = array('list' => 'Stuff', 'header' => 'Stuff_custom', 'url' => 'custom');
+
+		$this->assertSame([], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR, ['Stuff_custom_v4.txt']));
+	}
+
+	/**
+	 * S6: this pure function does not look at row/list state at all -- a row config marks
+	 * disabled is still reported if its url matches a moved basename (the "regardless of
+	 * state" guarantee is enforced by the CALLER collecting disabled rows too, tested at the
+	 * pfb_matchdir_config_headers level).
+	 */
+	public function testDisabledRowStillReportedWhenItsFileWasMoved(): void
+	{
+		$row = array('list' => 'Old', 'header' => 'Old', 'url' => self::MATCHDIR . '/ETMatch.txt', 'state' => 'Disabled');
+
+		$this->assertSame([$row], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR, ['ETMatch.txt']));
+	}
+
+	/**
+	 * Hostile: a directory-traversal-shaped url. dirname() is a pure string operation (no
+	 * realpath, no filesystem) -- comparison against matchdir is intentionally exact-string,
+	 * so a '..'-laden path never resolves to a matchdir hit even though it points there.
+	 */
+	public function testHostileDirectoryTraversalUrlIsNotReported(): void
+	{
+		$row = array('list' => 'Sneaky', 'header' => 'Sneaky', 'url' => self::MATCHDIR . '/../match/ETMatch.txt');
+
+		$this->assertSame([], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR, ['ETMatch.txt']));
 	}
 }

--- a/tests/php/MatchdirStaleLocalfileRefsTest.php
+++ b/tests/php/MatchdirStaleLocalfileRefsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1250 — pin pfb_matchdir_stale_localfile_refs(), the BREAKING CHANGE detector: the
+ * GUI once instructed admins to point a Match alias's Localfile at e.g.
+ * '/var/db/pfblockerng/match/ETMatch.txt' — an OLD machine-generated artifact path. The
+ * migration does NOT rewrite that config for them, so every list row whose 'url' still
+ * points there is surfaced instead. Pure.
+ *
+ * Feature: stale Localfile-reference detection
+ *   Given a flattened list of configured IP-list rows (any action)
+ *   When  a row's 'url' resolves to matchdir + an OLD artifact filename shape
+ *   Then  that row is reported; anything else is not.
+ */
+#[CoversFunction('pfb_matchdir_stale_localfile_refs')]
+final class MatchdirStaleLocalfileRefsTest extends TestCase
+{
+	private const MATCHDIR = '/var/db/pfblockerng/match';
+
+	/** A row whose Localfile points at the OLD ETMatch.txt artifact path is reported. */
+	public function testRowPointingAtOldEtMatchPathIsReported(): void
+	{
+		$row = array('list' => 'MyETConsumer', 'header' => 'MyETConsumer', 'url' => self::MATCHDIR . '/ETMatch.txt');
+
+		$hits = pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR);
+
+		$this->assertSame([$row], $hits);
+	}
+
+	/** A row pointing anywhere else (its OWN matchdir-stored user list) is NOT reported. */
+	public function testRowPointingAtAPlainUserListIsNotReported(): void
+	{
+		$row = array('list' => 'Ads', 'header' => 'Ads', 'url' => self::MATCHDIR . '/Ads_v4.txt');
+
+		$this->assertSame([], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR));
+	}
+
+	/** A row pointing at an unrelated path entirely (not under matchdir) is NOT reported. */
+	public function testRowPointingOutsideMatchdirIsNotReported(): void
+	{
+		$row = array('list' => 'Other', 'header' => 'Other', 'url' => '/root/mylist.txt');
+
+		$this->assertSame([], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR));
+	}
+
+	/** The ccwhite exempt artifact's OLD name is also caught by the general 'match*_v4/6.txt' shape. */
+	public function testRowPointingAtOldDedupPathIsReported(): void
+	{
+		$row = array('list' => 'ExemptConsumer', 'header' => 'ExemptConsumer', 'url' => self::MATCHDIR . '/matchdedup_v4.txt');
+
+		$this->assertSame([$row], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR));
+	}
+
+	/** An empty url is skipped without error, never a stray match. */
+	public function testRowWithEmptyUrlIsNotReported(): void
+	{
+		$row = array('list' => 'Blank', 'header' => 'Blank', 'url' => '');
+
+		$this->assertSame([], pfb_matchdir_stale_localfile_refs([$row], self::MATCHDIR));
+	}
+}

--- a/tests/php/MatchdirStaleLocalfileRefsTest.php
+++ b/tests/php/MatchdirStaleLocalfileRefsTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  *   And   the basenames the migration actually moved this run
  *   When  a row's 'url' resolves to matchdir + one of those basenames
  *   Then  that row is reported; anything else — including a same-shaped file that was NOT
- *         moved (a live user list) — is not (issue #1250 F6: shape-keying false-flagged a
+ *         moved (a live user list) — is not (issue #1250: shape-keying false-flagged a
  *         working, never-moved user list).
  */
 #[CoversFunction('pfb_matchdir_stale_localfile_refs')]
@@ -68,7 +68,7 @@ final class MatchdirStaleLocalfileRefsTest extends TestCase
 	}
 
 	/**
-	 * S1 / issue #1250 F6 [RED]: a user's OWN never-moved 'matchFoo_v4.txt' Localfile ref must
+	 * S1 / issue #1250: a user's OWN never-moved 'matchFoo_v4.txt' Localfile ref must
 	 * NOT be flagged just because its NAME has the old machine-artifact shape -- only an
 	 * actually-moved basename triggers the warning. The pre-fix shape-regex flagged this and
 	 * sent the admin to break a working list by repointing it at a path that never existed.

--- a/tests/shell/pfb_downgrade_prep_spec.sh
+++ b/tests/shell/pfb_downgrade_prep_spec.sh
@@ -20,7 +20,9 @@ Describe 'pfb-downgrade-prep.sh'
     PFBDG_WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbdg.XXXXXX")"
     PFB_PKGDIR="${PFBDG_WORK}/pkg"
     PFB_LISTDIR="${PFB_PKGDIR}/list_scripts"
-    mkdir -p "${PFB_LISTDIR}"
+    PFB_MATCHDIR="${PFBDG_WORK}/match"
+    PFB_MATCHGENDIR="${PFB_MATCHDIR}/generated"
+    mkdir -p "${PFB_LISTDIR}" "${PFB_MATCHGENDIR}"
   }
   cleanup() { rm -rf "${PFBDG_WORK}"; }
   BeforeEach 'setup'
@@ -124,6 +126,100 @@ EOF
     End
   End
 
+  Describe 'pfb_restore_matchgen_artifacts'
+    It 'restores the ET match artifact to its pre-4.0.x name, content byte-identical'
+      printf ET-CONTENT > "${PFB_MATCHGENDIR}/pfB_Match_ET_v4.txt"
+      When call pfb_restore_matchgen_artifacts
+      The output should equal 1
+      The path "${PFB_MATCHDIR}/ETMatch.txt" should be file
+      The contents of file "${PFB_MATCHDIR}/ETMatch.txt" should equal ET-CONTENT
+      The path "${PFB_MATCHGENDIR}/pfB_Match_ET_v4.txt" should not be exist
+    End
+
+    It 'restores the consolidated exempt artifact to its pre-4.0.x name'
+      touch "${PFB_MATCHGENDIR}/pfB_Match_Exempt_v4.txt"
+      When call pfb_restore_matchgen_artifacts
+      The output should equal 1
+      The path "${PFB_MATCHDIR}/matchdedup_v4.txt" should be file
+    End
+
+    It 'restores a v4 reputation artifact to its pre-4.0.x name'
+      touch "${PFB_MATCHGENDIR}/pfB_Match_Rep_Spam_v4.txt"
+      When call pfb_restore_matchgen_artifacts
+      The output should equal 1
+      The path "${PFB_MATCHDIR}/matchSpam_v4.txt" should be file
+    End
+
+    It 'restores a v6 reputation artifact the same as v4 (family-agnostic rule)'
+      touch "${PFB_MATCHGENDIR}/pfB_Match_Rep_Spam_v6.txt"
+      When call pfb_restore_matchgen_artifacts
+      The output should equal 1
+      The path "${PFB_MATCHDIR}/matchSpam_v6.txt" should be file
+    End
+
+    It 'strips only the fixed prefix, never field-splitting an embedded underscore'
+      touch "${PFB_MATCHGENDIR}/pfB_Match_Rep_Spam_Feed_v4.txt"
+      When call pfb_restore_matchgen_artifacts
+      The output should equal 1
+      The path "${PFB_MATCHDIR}/matchSpam_Feed_v4.txt" should be file
+    End
+
+    It 'never clobbers a same-named file already in the match folder'
+      printf OLD > "${PFB_MATCHDIR}/matchSpam_v4.txt"
+      touch "${PFB_MATCHGENDIR}/pfB_Match_Rep_Spam_v4.txt"
+      When call pfb_restore_matchgen_artifacts
+      The output should equal 0
+      The contents of file "${PFB_MATCHDIR}/matchSpam_v4.txt" should equal OLD
+      The path "${PFB_MATCHGENDIR}/pfB_Match_Rep_Spam_v4.txt" should be file
+      The stderr should include 'not overwriting'
+      The stderr should include "${PFB_MATCHDIR}/matchSpam_v4.txt"
+      The stderr should include 'pfB_Match_Rep_Spam_v4.txt'
+    End
+
+    It 'deletes a stray *.txt.new file without counting it as restored'
+      touch "${PFB_MATCHGENDIR}/pfB_Match_Rep_Spam_v4.txt.new"
+      When call pfb_restore_matchgen_artifacts
+      The output should equal 0
+      The path "${PFB_MATCHGENDIR}/pfB_Match_Rep_Spam_v4.txt.new" should not be exist
+    End
+
+    It 'leaves an unrecognised file in place and reports the blocked rmdir'
+      touch "${PFB_MATCHGENDIR}/pfB_Match_ET_v6.txt" "${PFB_MATCHGENDIR}/other.txt"
+      When call pfb_restore_matchgen_artifacts
+      The output should equal 0
+      The path "${PFB_MATCHGENDIR}/pfB_Match_ET_v6.txt" should be file
+      The path "${PFB_MATCHGENDIR}/other.txt" should be file
+      The path "${PFB_MATCHGENDIR}" should be directory
+      The stderr should include 'not empty'
+      The stderr should include 'pfB_Match_ET_v6.txt'
+      The stderr should include 'other.txt'
+    End
+
+    It 'removes matchgendir once emptied; a re-run afterward is idempotent'
+      touch "${PFB_MATCHGENDIR}/pfB_Match_ET_v4.txt"
+      pfb_restore_matchgen_artifacts >/dev/null   # first run: moves the file, rmdir's the empty dir
+      When call pfb_restore_matchgen_artifacts    # second run: matchgendir already gone
+      The output should equal 0
+      The status should be success
+      The path "${PFB_MATCHDIR}/ETMatch.txt" should be file
+      The path "${PFB_MATCHGENDIR}" should not be exist
+    End
+
+    It 'restores a filename containing a space intact (quoting proof)'
+      touch "${PFB_MATCHGENDIR}/pfB_Match_Rep_a b_v4.txt"
+      When call pfb_restore_matchgen_artifacts
+      The output should equal 1
+      The path "${PFB_MATCHDIR}/matcha b_v4.txt" should be file
+    End
+
+    It 'is a no-op when matchgendir is absent'
+      rm -rf "${PFB_MATCHGENDIR}"
+      When call pfb_restore_matchgen_artifacts
+      The output should equal 0
+      The status should be success
+    End
+  End
+
   Describe 'pfb_remove_tick_cron (output parsing)'
     It 'reports "removed" when pfSsh.php signals removal'
       PFB_PFSSH="$(fake_pfssh removed PFB_TICK_REMOVED)"
@@ -183,6 +279,29 @@ EOF
       The stderr should include 'pfSsh.php not found'
       # The script restore still happened; only the exit status signals the partial failure.
       The path "${PFB_PKGDIR}/ip_pre_custom.sh" should be file
+    End
+
+    It 'reports the machine match artifacts restored line'
+      shim_id 0
+      touch "${PFB_MATCHGENDIR}/pfB_Match_Rep_Spam_v4.txt"
+      PFB_PFSSH="$(fake_pfssh matchgen PFB_TICK_REMOVED)"
+      When call pfb_downgrade_prep_main
+      The status should be success
+      The output should include 'Machine match artifacts restored to the match folder: 1'
+      The path "${PFB_MATCHDIR}/matchSpam_v4.txt" should be file
+    End
+
+    It 'fails (non-zero exit) when the matchgen restore fails'
+      shim_id 0
+      touch "${PFB_MATCHGENDIR}/pfB_Match_Rep_Spam_v4.txt"
+      PFB_MATCHDIR="${PFBDG_WORK}/nonexistent-match"   # dest dir missing -> forced mv failure
+      PFB_PFSSH="$(fake_pfssh matchgenfail PFB_TICK_REMOVED)"
+      When call pfb_downgrade_prep_main
+      The status should be failure
+      The stderr should include 'failed to move'
+      # The other two reversals still ran and are still reported; only the exit status
+      # signals the partial failure.
+      The output should include 'match folder: 0'
     End
   End
 End

--- a/tests/shell/pfblockerng_et_category_match_spec.sh
+++ b/tests/shell/pfblockerng_et_category_match_spec.sh
@@ -16,7 +16,8 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
     pfborig="${work}/orig/"
     etdir="${work}/ET"
     pfbmatch="${work}/match"
-    mkdir -p "$pfborig" "$etdir" "$pfbmatch"
+    pfbmatchgen="${work}/match/generated/"
+    mkdir -p "$pfborig" "$etdir" "$pfbmatch" "$pfbmatchgen"
     tempfile="${work}/t1"; tempfile2="${work}/t2"
     alias='MYLIST'
     ip_placeholder='240.0.0.0'
@@ -67,9 +68,9 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
       # (matching the etblock case's stdout check + closing the shellspec output gap).
       The stdout should include 'Match:   ET_P2Pcnc'
       The stdout should not include 'Match:   ET_P2P '
-      The path "${pfbmatch}/ETMatch.txt" should be file
-      The contents of file "${pfbmatch}/ETMatch.txt" should include '10.0.0.31'
-      The contents of file "${pfbmatch}/ETMatch.txt" should not include '10.0.0.15'
+      The path "${pfbmatchgen}/ETMatch.txt" should be file
+      The contents of file "${pfbmatchgen}/ETMatch.txt" should include '10.0.0.31'
+      The contents of file "${pfbmatchgen}/ETMatch.txt" should not include '10.0.0.15'
     End
   End
 
@@ -87,9 +88,31 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
       # (closes the shellspec unchecked-output gap for the sentinel case).
       The stdout should not include 'Block:'
       The stdout should not include 'Match:'
-      The path "${pfbmatch}/ETMatch.txt" should not be exist
+      The path "${pfbmatchgen}/ETMatch.txt" should not be exist
       The contents of file "${pfborig}${alias}.orig" should not include '10.0.0.15'
       The contents of file "${pfborig}${alias}.orig" should not include '10.0.0.31'
+    End
+  End
+
+  # issue #1250: a user Match-type list literally headed 'ETMatch' collides
+  # with processet()'s own ETMatch.txt artifact under the single ${pfbmatch}
+  # namespace -- the ET write must never touch a pre-existing user file, and
+  # lands in ${pfbmatchgen} instead.
+  Describe 'a pre-existing user Match-list ETMatch.txt survives processet() (issue #1250)'
+    It 'leaves the user file byte-unchanged and writes the ET output to pfbmatchgen instead'
+      etblock='x'
+      etmatch='ET_P2Pcnc'
+      # The user's OWN Match-type list content -- RFC 5737, unrelated to any ET IP.
+      printf '203.0.113.77\n' > "${pfbmatch}/ETMatch.txt"
+      before_content="$(cat "${pfbmatch}/ETMatch.txt")"
+
+      When call processet
+      The status should be success
+      The stdout should include 'Match:   ET_P2Pcnc'
+      The value "$before_content" should equal '203.0.113.77'
+      The contents of file "${pfbmatch}/ETMatch.txt" should equal '203.0.113.77'
+      The contents of file "${pfbmatchgen}/ETMatch.txt" should include '10.0.0.31'
+      The contents of file "${pfbmatchgen}/ETMatch.txt" should not include '10.0.0.15'
     End
   End
 End

--- a/tests/shell/pfblockerng_et_category_match_spec.sh
+++ b/tests/shell/pfblockerng_et_category_match_spec.sh
@@ -68,9 +68,9 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
       # (matching the etblock case's stdout check + closing the shellspec output gap).
       The stdout should include 'Match:   ET_P2Pcnc'
       The stdout should not include 'Match:   ET_P2P '
-      The path "${pfbmatchgen}/ETMatch.txt" should be file
-      The contents of file "${pfbmatchgen}/ETMatch.txt" should include '10.0.0.31'
-      The contents of file "${pfbmatchgen}/ETMatch.txt" should not include '10.0.0.15'
+      The path "${pfbmatchgen}/pfB_Match_ET_v4.txt" should be file
+      The contents of file "${pfbmatchgen}/pfB_Match_ET_v4.txt" should include '10.0.0.31'
+      The contents of file "${pfbmatchgen}/pfB_Match_ET_v4.txt" should not include '10.0.0.15'
     End
   End
 
@@ -79,7 +79,7 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
   # category is ever literally named 'x', but a naive unpadded anchor could still
   # accidentally line up on a bare 'x' substring somewhere in a real token.
   Describe 'the x no-selection sentinel'
-    It 'blocks nothing and writes no ETMatch.txt when neither is selected'
+    It 'blocks nothing and writes no pfB_Match_ET_v4.txt when neither is selected'
       etblock='x'
       etmatch='x'
       When call processet
@@ -88,16 +88,16 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
       # (closes the shellspec unchecked-output gap for the sentinel case).
       The stdout should not include 'Block:'
       The stdout should not include 'Match:'
-      The path "${pfbmatchgen}/ETMatch.txt" should not be exist
+      The path "${pfbmatchgen}/pfB_Match_ET_v4.txt" should not be exist
       The contents of file "${pfborig}${alias}.orig" should not include '10.0.0.15'
       The contents of file "${pfborig}${alias}.orig" should not include '10.0.0.31'
     End
   End
 
   # issue #1250: a user Match-type list literally headed 'ETMatch' collides
-  # with processet()'s own ETMatch.txt artifact under the single ${pfbmatch}
-  # namespace -- the ET write must never touch a pre-existing user file, and
-  # lands in ${pfbmatchgen} instead.
+  # with processet()'s own ET artifact under the single ${pfbmatch} namespace
+  # -- the ET write must never touch a pre-existing user file, and lands in
+  # ${pfbmatchgen} instead.
   Describe 'a pre-existing user Match-list ETMatch.txt survives processet() (issue #1250)'
     It 'leaves the user file byte-unchanged and writes the ET output to pfbmatchgen instead'
       etblock='x'
@@ -111,8 +111,8 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
       The stdout should include 'Match:   ET_P2Pcnc'
       The value "$before_content" should equal '203.0.113.77'
       The contents of file "${pfbmatch}/ETMatch.txt" should equal '203.0.113.77'
-      The contents of file "${pfbmatchgen}/ETMatch.txt" should include '10.0.0.31'
-      The contents of file "${pfbmatchgen}/ETMatch.txt" should not include '10.0.0.15'
+      The contents of file "${pfbmatchgen}/pfB_Match_ET_v4.txt" should include '10.0.0.31'
+      The contents of file "${pfbmatchgen}/pfB_Match_ET_v4.txt" should not include '10.0.0.15'
     End
   End
 End

--- a/tests/shell/pfblockerng_match_counts_report_spec.sh
+++ b/tests/shell/pfblockerng_match_counts_report_spec.sh
@@ -41,7 +41,7 @@ Describe 'closingprocess() Match List IP Counts section (#1250)'
     # Given one user Match-type list file and one machine-generated artifact,
     # each now living in its own directory.
     printf '198.51.100.0/24\n' > "${pfbmatch}Ads_v4.txt"
-    printf '192.0.2.0/24\n'    > "${pfbmatchgen}matchSpam_v4.txt"
+    printf '192.0.2.0/24\n'    > "${pfbmatchgen}pfB_Match_Rep_Spam_v4.txt"
 
     # When the final report runs.
     When call closingprocess
@@ -51,6 +51,6 @@ Describe 'closingprocess() Match List IP Counts section (#1250)'
     The status should be success
     The stdout should include 'Match List IP Counts'
     The stdout should include 'Ads_v4.txt'
-    The stdout should include 'matchSpam_v4.txt'
+    The stdout should include 'pfB_Match_Rep_Spam_v4.txt'
   End
 End

--- a/tests/shell/pfblockerng_match_counts_report_spec.sh
+++ b/tests/shell/pfblockerng_match_counts_report_spec.sh
@@ -1,0 +1,56 @@
+#shellcheck shell=sh
+# closingprocess()'s "Match List IP Counts" section must stay keyed on the match
+# .txt files that actually exist, and must still count the machine-generated
+# artifacts after issue #1250 moved them into match/generated/. The section's
+# guard used to test the match dir for ANY entry, which the always-present
+# generated/ subdir alone satisfies -- printing an empty section forever.
+
+Describe 'closingprocess() Match List IP Counts section (#1250)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/matchcounts.XXXXXX")"
+    pfborig="${work}/orig/"; pfbdeny="${work}/deny/"
+    pfbpermit="${work}/permit/"; pfbmatch="${work}/match/"; pfbnative="${work}/native/"
+    # Production creates the generated/ subdir unconditionally on every run
+    # (pfblockerng.sh), so the sandbox has it too -- that is the whole point.
+    pfbmatchgen="${pfbmatch}generated/"
+    mkdir -p "$pfborig" "$pfbdeny" "$pfbpermit" "$pfbmatch" "$pfbnative" "$pfbmatchgen"
+    masterfile="${work}/masterfile"; mastercat="${work}/mastercat"
+    tempfile="${work}/t1"; errorlog="${work}/err.log"; now="now"
+    ip_placeholder2="127.0.0.1"
+    alias="off"
+    pathpfctl="${work}/pfctl"; printf '#!/bin/sh\n' > "$pathpfctl"; chmod +x "$pathpfctl"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'omits the section entirely when no Match list and no generated artifact exists'
+    # Given a box with no Match-type lists at all -- only the empty generated/
+    # subdir production always creates.
+
+    # When the final report runs.
+    When call closingprocess
+
+    # Then no Match section is printed: an empty subdir is not a Match list.
+    The status should be success
+    The stdout should not include 'Match List IP Counts'
+  End
+
+  It "counts a user's Match list and a generated artifact side by side"
+    # Given one user Match-type list file and one machine-generated artifact,
+    # each now living in its own directory.
+    printf '198.51.100.0/24\n' > "${pfbmatch}Ads_v4.txt"
+    printf '192.0.2.0/24\n'    > "${pfbmatchgen}matchSpam_v4.txt"
+
+    # When the final report runs.
+    When call closingprocess
+
+    # Then the section appears and names BOTH -- the relocation must not drop the
+    # reputation counts out of the update log.
+    The status should be success
+    The stdout should include 'Match List IP Counts'
+    The stdout should include 'Ads_v4.txt'
+    The stdout should include 'matchSpam_v4.txt'
+  End
+End

--- a/tests/shell/pfblockerng_recompute_spec.sh
+++ b/tests/shell/pfblockerng_recompute_spec.sh
@@ -468,7 +468,8 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 	setup() {
 		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/recdmaxmatch.XXXXXX")"
 		snap="${work}/snap"; pfbdeny="${work}/deny/"; pfbmatch="${work}/match/"
-		mkdir -p "$snap" "$pfbdeny" "$pfbmatch"
+		pfbmatchgen="${work}/match/generated/"
+		mkdir -p "$snap" "$pfbdeny" "$pfbmatch" "$pfbmatchgen"
 		tmpdir="${work}/tmp"; mkdir -p "$tmpdir"
 		masterfile="${work}/master"; mastercat="${work}/mastercat"
 		errorlog="${work}/err.log"
@@ -492,9 +493,9 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US off match
 		The status should be success
 		The contents of file "${pfbdeny}ONE_v4.txt" should equal "$(printf '192.0.2.20\n192.0.2.21')"
-		The contents of file "${pfbmatch}matchONE_v4.txt" should include '192.0.2.0/24'
-		The contents of file "${pfbmatch}matchONE_v4.txt" should include '!192.0.2.20'
-		The contents of file "${pfbmatch}matchONE_v4.txt" should include '!192.0.2.21'
+		The contents of file "${pfbmatchgen}matchONE_v4.txt" should include '192.0.2.0/24'
+		The contents of file "${pfbmatchgen}matchONE_v4.txt" should include '!192.0.2.20'
+		The contents of file "${pfbmatchgen}matchONE_v4.txt" should include '!192.0.2.21'
 	End
 
 	It "ccwhite=match on a cc-list hit: writes the consolidated matchdedup file, leaves the stream untouched"
@@ -505,8 +506,8 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US match off
 		The status should be success
 		The contents of file "${pfbdeny}EX_v4.txt" should equal "$(printf '198.51.100.20\n198.51.100.21')"
-		The contents of file "${pfbmatch}${matchdedup}" should include '198.51.100.0/24'
-		The contents of file "${pfbmatch}${matchdedup}" should include '!198.51.100.20'
+		The contents of file "${pfbmatchgen}${matchdedup}" should include '198.51.100.0/24'
+		The contents of file "${pfbmatchgen}${matchdedup}" should include '!198.51.100.20'
 	End
 
 	It 'ccwhite passed uppercase (MATCH) still fires the exempt-match path on a cc-list hit (issue #1084 review, case-fold parity with the legacy verb init)'
@@ -516,8 +517,8 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US MATCH off
 		The status should be success
-		The contents of file "${pfbmatch}${matchdedup}" should include '198.51.100.0/24'
-		The contents of file "${pfbmatch}${matchdedup}" should include '!198.51.100.40'
+		The contents of file "${pfbmatchgen}${matchdedup}" should include '198.51.100.0/24'
+		The contents of file "${pfbmatchgen}${matchdedup}" should include '!198.51.100.40'
 	End
 
 	It 'ccblack=match emits match<alias>.txt for EVERY member alias sharing an offender /24 (issue #1084: multi-alias delta from the legacy single-owner write)'
@@ -528,11 +529,11 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 2 US off match
 		The status should be success
-		The contents of file "${pfbmatch}matchFirst_v4.txt" should include '192.0.2.0/24'
-		The contents of file "${pfbmatch}matchFirst_v4.txt" should include '!192.0.2.30'
-		The contents of file "${pfbmatch}matchSecond_v4.txt" should include '192.0.2.0/24'
-		The contents of file "${pfbmatch}matchSecond_v4.txt" should include '!192.0.2.31'
-		The contents of file "${pfbmatch}matchSecond_v4.txt" should include '!192.0.2.32'
+		The contents of file "${pfbmatchgen}matchFirst_v4.txt" should include '192.0.2.0/24'
+		The contents of file "${pfbmatchgen}matchFirst_v4.txt" should include '!192.0.2.30'
+		The contents of file "${pfbmatchgen}matchSecond_v4.txt" should include '192.0.2.0/24'
+		The contents of file "${pfbmatchgen}matchSecond_v4.txt" should include '!192.0.2.31'
+		The contents of file "${pfbmatchgen}matchSecond_v4.txt" should include '!192.0.2.32'
 	End
 
 	It "ccblack=match (not ccwhite) on a cc-list hit: logs nowhere -- no matchdedup file is written (today's asymmetric gate)"
@@ -542,7 +543,7 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US off match
 		The status should be success
-		The path "${pfbmatch}${matchdedup}" should not be exist
+		The path "${pfbmatchgen}${matchdedup}" should not be exist
 	End
 
 	It 'GeoIP unavailable: dMax bails like reputation_depends, the pass still completes with no reputation applied'
@@ -565,7 +566,47 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 		The status should be success
 		The contents of file "${pfbdeny}PALIAS_v4.txt" should equal '198.51.100.0/24'
 		The contents of file "$masterfile" should include 'PALIAS_v4 198.51.100.0/24'
-		The path "${pfbmatch}matchPALIAS_v4.txt" should not be exist
+		The path "${pfbmatchgen}matchPALIAS_v4.txt" should not be exist
+	End
+
+	# issue #1250: a Match-type list and a Deny-type list can share the same
+	# header, so their on-disk artifacts collided under the single ${pfbmatch}
+	# namespace -- the reputation-apply write must never touch a pre-existing
+	# user Match-list file, and lands in ${pfbmatchgen} instead.
+	It "a pre-existing user Match-list file at pfbmatch survives a same-named Deny alias's reputation match write (issue #1250)"
+		make_geoip_stub "$pathgeoip" 'Could not find an entry for this IP address'
+		# Two hosts in the same /24 (> max=1) so the Deny alias is a genuine
+		# offender and the reputation-apply write actually fires.
+		printf '192.0.2.50\n192.0.2.51\n' > "${snap}/Spam_v4.orig"
+		printf '%s\n' "${snap}/Spam_v4.orig" > "$memberlist"
+		# The user's OWN Match-type list content -- RFC 5737, unrelated to the
+		# reputation output the Deny alias 'Spam_v4' is about to produce.
+		printf '203.0.113.99\n' > "${pfbmatch}matchSpam_v4.txt"
+		before_content="$(cat "${pfbmatch}matchSpam_v4.txt")"
+
+		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US off match
+		The status should be success
+		The value "$before_content" should equal '203.0.113.99'
+		The contents of file "${pfbmatch}matchSpam_v4.txt" should equal '203.0.113.99'
+		The contents of file "${pfbmatchgen}matchSpam_v4.txt" should include '192.0.2.0/24'
+		The contents of file "${pfbmatchgen}matchSpam_v4.txt" should include '!192.0.2.50'
+		The contents of file "${pfbmatchgen}matchSpam_v4.txt" should include '!192.0.2.51'
+	End
+
+	It 'a pre-existing user Match-list file headed matchdedup survives the ccwhite=match consolidated write (issue #1250)'
+		make_geoip_stub "$pathgeoip" 'xx iso_code: "US" xx'
+		# Alias name deliberately avoids any "dedup" substring: on a case-insensitive
+		# filesystem match<ALIAS>.txt.new would collide with matchdedup_v4.txt.new.
+		printf '198.51.100.50\n198.51.100.51\n' > "${snap}/CCHIT_v4.orig"
+		printf '%s\n' "${snap}/CCHIT_v4.orig" > "$memberlist"
+		printf '203.0.113.88\n' > "${pfbmatch}${matchdedup}"
+		before_content="$(cat "${pfbmatch}${matchdedup}")"
+
+		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US match off
+		The status should be success
+		The value "$before_content" should equal '203.0.113.88'
+		The contents of file "${pfbmatch}${matchdedup}" should equal '203.0.113.88'
+		The contents of file "${pfbmatchgen}${matchdedup}" should include '198.51.100.0/24'
 	End
 End
 
@@ -823,7 +864,8 @@ Describe 'pfb_recompute() finish-arm reputation reconcile (issue #1084 review: s
 	setup() {
 		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/recfinisharm.XXXXXX")"
 		snap="${work}/snap"; pfbdeny="${work}/deny/"; pfbmatch="${work}/match/"
-		mkdir -p "$snap" "$pfbdeny" "$pfbmatch"
+		pfbmatchgen="${work}/match/generated/"
+		mkdir -p "$snap" "$pfbdeny" "$pfbmatch" "$pfbmatchgen"
 		tmpdir="${work}/tmp"; mkdir -p "$tmpdir"
 		masterfile="${work}/master"; mastercat="${work}/mastercat"
 		errorlog="${work}/err.log"
@@ -840,35 +882,35 @@ Describe 'pfb_recompute() finish-arm reputation reconcile (issue #1084 review: s
 	After 'cleanup'
 
 	It 'never promotes a crash-leftover match<alias>.txt.new debris on a clean no-offender dmax pass (GeoIP healthy)'
-		printf '9.9.9.0/24\n!9.9.9.9\n' > "${pfbmatch}matchSTALE_v4.txt.new"
+		printf '9.9.9.0/24\n!9.9.9.9\n' > "${pfbmatchgen}matchSTALE_v4.txt.new"
 		printf '192.0.2.1\n' > "${snap}/STALE_v4.orig"
 		printf '%s\n' "${snap}/STALE_v4.orig" > "$memberlist"
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 100 US off block
 		The status should be success
-		The path "${pfbmatch}matchSTALE_v4.txt" should not be exist
+		The path "${pfbmatchgen}matchSTALE_v4.txt" should not be exist
 	End
 
 	It 'keeps ALL previous match artifacts (+ logs) when GeoIP is unavailable this pass, instead of destructively reconciling them away'
 		rm -f "$pathgeoip" "$pathgeoipdat"
-		printf '5.5.5.0/24\n!5.5.5.5\n' > "${pfbmatch}matchALIAS_v4.txt"
+		printf '5.5.5.0/24\n!5.5.5.5\n' > "${pfbmatchgen}matchALIAS_v4.txt"
 		printf '192.0.2.1\n192.0.2.2\n192.0.2.3\n' > "${snap}/ALIAS_v4.orig"
 		printf '%s\n' "${snap}/ALIAS_v4.orig" > "$memberlist"
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US off block
 		The status should be success
-		The contents of file "${pfbmatch}matchALIAS_v4.txt" should equal "$(printf '5.5.5.0/24\n!5.5.5.5')"
+		The contents of file "${pfbmatchgen}matchALIAS_v4.txt" should equal "$(printf '5.5.5.0/24\n!5.5.5.5')"
 		The contents of file "${errorlog}" should include 'GeoIP unavailable'
 	End
 
 	It 'clears a stale consolidated matchdedup file once a clean (offender-free) dmax pass confirms zero cc-list matches (matchdedup symmetry, issue #1084 review)'
-		printf '1.1.1.0/24\n!1.1.1.1\n' > "${pfbmatch}matchdedup_v4.txt"
+		printf '1.1.1.0/24\n!1.1.1.1\n' > "${pfbmatchgen}matchdedup_v4.txt"
 		printf '192.0.2.1\n' > "${snap}/CLEAN_v4.orig"
 		printf '%s\n' "${snap}/CLEAN_v4.orig" > "$memberlist"
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 100 US match off
 		The status should be success
-		The path "${pfbmatch}matchdedup_v4.txt" should not be exist
+		The path "${pfbmatchgen}matchdedup_v4.txt" should not be exist
 	End
 End
 

--- a/tests/shell/pfblockerng_recompute_spec.sh
+++ b/tests/shell/pfblockerng_recompute_spec.sh
@@ -478,14 +478,14 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 		pathgeoip="${work}/mmdblookup"; pathgeoipdat="${work}/geo.mmdb"; touch "$pathgeoipdat"
 		memberlist="${work}/members"
 		countsfile="${work}/counts"
-		matchdedup='matchdedup_v4.txt'
+		matchexemptfile='pfB_Match_Exempt_v4.txt'
 	}
 	cleanup() { rm -rf "$work"; }
 	BeforeAll 'pfb_source'
 	Before 'setup'
 	After 'cleanup'
 
-	It 'ccblack=match: leaves the stream untouched and writes match<alias>.txt (cidr + negated members)'
+	It 'ccblack=match: leaves the stream untouched and writes pfB_Match_Rep_<alias>.txt (cidr + negated members)'
 		make_geoip_stub "$pathgeoip" 'Could not find an entry for this IP address'
 		printf '192.0.2.20\n192.0.2.21\n' > "${snap}/ONE_v4.orig"
 		printf '%s\n' "${snap}/ONE_v4.orig" > "$memberlist"
@@ -493,12 +493,12 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US off match
 		The status should be success
 		The contents of file "${pfbdeny}ONE_v4.txt" should equal "$(printf '192.0.2.20\n192.0.2.21')"
-		The contents of file "${pfbmatchgen}matchONE_v4.txt" should include '192.0.2.0/24'
-		The contents of file "${pfbmatchgen}matchONE_v4.txt" should include '!192.0.2.20'
-		The contents of file "${pfbmatchgen}matchONE_v4.txt" should include '!192.0.2.21'
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_ONE_v4.txt" should include '192.0.2.0/24'
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_ONE_v4.txt" should include '!192.0.2.20'
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_ONE_v4.txt" should include '!192.0.2.21'
 	End
 
-	It "ccwhite=match on a cc-list hit: writes the consolidated matchdedup file, leaves the stream untouched"
+	It "ccwhite=match on a cc-list hit: writes the consolidated exempt file, leaves the stream untouched"
 		make_geoip_stub "$pathgeoip" 'xx iso_code: "US" xx'
 		printf '198.51.100.20\n198.51.100.21\n' > "${snap}/EX_v4.orig"
 		printf '%s\n' "${snap}/EX_v4.orig" > "$memberlist"
@@ -506,8 +506,8 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US match off
 		The status should be success
 		The contents of file "${pfbdeny}EX_v4.txt" should equal "$(printf '198.51.100.20\n198.51.100.21')"
-		The contents of file "${pfbmatchgen}${matchdedup}" should include '198.51.100.0/24'
-		The contents of file "${pfbmatchgen}${matchdedup}" should include '!198.51.100.20'
+		The contents of file "${pfbmatchgen}${matchexemptfile}" should include '198.51.100.0/24'
+		The contents of file "${pfbmatchgen}${matchexemptfile}" should include '!198.51.100.20'
 	End
 
 	It 'ccwhite passed uppercase (MATCH) still fires the exempt-match path on a cc-list hit (issue #1084 review, case-fold parity with the legacy verb init)'
@@ -517,11 +517,11 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US MATCH off
 		The status should be success
-		The contents of file "${pfbmatchgen}${matchdedup}" should include '198.51.100.0/24'
-		The contents of file "${pfbmatchgen}${matchdedup}" should include '!198.51.100.40'
+		The contents of file "${pfbmatchgen}${matchexemptfile}" should include '198.51.100.0/24'
+		The contents of file "${pfbmatchgen}${matchexemptfile}" should include '!198.51.100.40'
 	End
 
-	It 'ccblack=match emits match<alias>.txt for EVERY member alias sharing an offender /24 (issue #1084: multi-alias delta from the legacy single-owner write)'
+	It 'ccblack=match emits pfB_Match_Rep_<alias>.txt for EVERY member alias sharing an offender /24 (issue #1084: multi-alias delta from the legacy single-owner write)'
 		make_geoip_stub "$pathgeoip" 'Could not find an entry for this IP address'
 		printf '192.0.2.30\n' > "${snap}/First_v4.orig"
 		printf '192.0.2.31\n192.0.2.32\n' > "${snap}/Second_v4.orig"
@@ -529,21 +529,21 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 2 US off match
 		The status should be success
-		The contents of file "${pfbmatchgen}matchFirst_v4.txt" should include '192.0.2.0/24'
-		The contents of file "${pfbmatchgen}matchFirst_v4.txt" should include '!192.0.2.30'
-		The contents of file "${pfbmatchgen}matchSecond_v4.txt" should include '192.0.2.0/24'
-		The contents of file "${pfbmatchgen}matchSecond_v4.txt" should include '!192.0.2.31'
-		The contents of file "${pfbmatchgen}matchSecond_v4.txt" should include '!192.0.2.32'
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_First_v4.txt" should include '192.0.2.0/24'
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_First_v4.txt" should include '!192.0.2.30'
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_Second_v4.txt" should include '192.0.2.0/24'
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_Second_v4.txt" should include '!192.0.2.31'
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_Second_v4.txt" should include '!192.0.2.32'
 	End
 
-	It "ccblack=match (not ccwhite) on a cc-list hit: logs nowhere -- no matchdedup file is written (today's asymmetric gate)"
+	It "ccblack=match (not ccwhite) on a cc-list hit: logs nowhere -- no exempt file is written (today's asymmetric gate)"
 		make_geoip_stub "$pathgeoip" 'xx iso_code: "US" xx'
 		printf '198.51.100.30\n198.51.100.31\n' > "${snap}/EX2_v4.orig"
 		printf '%s\n' "${snap}/EX2_v4.orig" > "$memberlist"
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US off match
 		The status should be success
-		The path "${pfbmatchgen}${matchdedup}" should not be exist
+		The path "${pfbmatchgen}${matchexemptfile}" should not be exist
 	End
 
 	It 'GeoIP unavailable: dMax bails like reputation_depends, the pass still completes with no reputation applied'
@@ -566,7 +566,7 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 		The status should be success
 		The contents of file "${pfbdeny}PALIAS_v4.txt" should equal '198.51.100.0/24'
 		The contents of file "$masterfile" should include 'PALIAS_v4 198.51.100.0/24'
-		The path "${pfbmatchgen}matchPALIAS_v4.txt" should not be exist
+		The path "${pfbmatchgen}pfB_Match_Rep_PALIAS_v4.txt" should not be exist
 	End
 
 	# issue #1250: a Match-type list and a Deny-type list can share the same
@@ -588,25 +588,23 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 		The status should be success
 		The value "$before_content" should equal '203.0.113.99'
 		The contents of file "${pfbmatch}matchSpam_v4.txt" should equal '203.0.113.99'
-		The contents of file "${pfbmatchgen}matchSpam_v4.txt" should include '192.0.2.0/24'
-		The contents of file "${pfbmatchgen}matchSpam_v4.txt" should include '!192.0.2.50'
-		The contents of file "${pfbmatchgen}matchSpam_v4.txt" should include '!192.0.2.51'
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_Spam_v4.txt" should include '192.0.2.0/24'
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_Spam_v4.txt" should include '!192.0.2.50'
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_Spam_v4.txt" should include '!192.0.2.51'
 	End
 
-	It 'a pre-existing user Match-list file headed matchdedup survives the ccwhite=match consolidated write (issue #1250)'
+	It 'a pre-existing user Match-list file literally named matchdedup_v4.txt survives the ccwhite=match consolidated write (issue #1250)'
 		make_geoip_stub "$pathgeoip" 'xx iso_code: "US" xx'
-		# Alias name deliberately avoids any "dedup" substring: on a case-insensitive
-		# filesystem match<ALIAS>.txt.new would collide with matchdedup_v4.txt.new.
 		printf '198.51.100.50\n198.51.100.51\n' > "${snap}/CCHIT_v4.orig"
 		printf '%s\n' "${snap}/CCHIT_v4.orig" > "$memberlist"
-		printf '203.0.113.88\n' > "${pfbmatch}${matchdedup}"
-		before_content="$(cat "${pfbmatch}${matchdedup}")"
+		printf '203.0.113.88\n' > "${pfbmatch}matchdedup_v4.txt"
+		before_content="$(cat "${pfbmatch}matchdedup_v4.txt")"
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US match off
 		The status should be success
 		The value "$before_content" should equal '203.0.113.88'
-		The contents of file "${pfbmatch}${matchdedup}" should equal '203.0.113.88'
-		The contents of file "${pfbmatchgen}${matchdedup}" should include '198.51.100.0/24'
+		The contents of file "${pfbmatch}matchdedup_v4.txt" should equal '203.0.113.88'
+		The contents of file "${pfbmatchgen}${matchexemptfile}" should include '198.51.100.0/24'
 	End
 End
 
@@ -881,36 +879,36 @@ Describe 'pfb_recompute() finish-arm reputation reconcile (issue #1084 review: s
 	Before 'setup'
 	After 'cleanup'
 
-	It 'never promotes a crash-leftover match<alias>.txt.new debris on a clean no-offender dmax pass (GeoIP healthy)'
-		printf '9.9.9.0/24\n!9.9.9.9\n' > "${pfbmatchgen}matchSTALE_v4.txt.new"
+	It 'never promotes a crash-leftover pfB_Match_Rep_<alias>.txt.new debris on a clean no-offender dmax pass (GeoIP healthy)'
+		printf '9.9.9.0/24\n!9.9.9.9\n' > "${pfbmatchgen}pfB_Match_Rep_STALE_v4.txt.new"
 		printf '192.0.2.1\n' > "${snap}/STALE_v4.orig"
 		printf '%s\n' "${snap}/STALE_v4.orig" > "$memberlist"
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 100 US off block
 		The status should be success
-		The path "${pfbmatchgen}matchSTALE_v4.txt" should not be exist
+		The path "${pfbmatchgen}pfB_Match_Rep_STALE_v4.txt" should not be exist
 	End
 
 	It 'keeps ALL previous match artifacts (+ logs) when GeoIP is unavailable this pass, instead of destructively reconciling them away'
 		rm -f "$pathgeoip" "$pathgeoipdat"
-		printf '5.5.5.0/24\n!5.5.5.5\n' > "${pfbmatchgen}matchALIAS_v4.txt"
+		printf '5.5.5.0/24\n!5.5.5.5\n' > "${pfbmatchgen}pfB_Match_Rep_ALIAS_v4.txt"
 		printf '192.0.2.1\n192.0.2.2\n192.0.2.3\n' > "${snap}/ALIAS_v4.orig"
 		printf '%s\n' "${snap}/ALIAS_v4.orig" > "$memberlist"
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 1 US off block
 		The status should be success
-		The contents of file "${pfbmatchgen}matchALIAS_v4.txt" should equal "$(printf '5.5.5.0/24\n!5.5.5.5')"
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_ALIAS_v4.txt" should equal "$(printf '5.5.5.0/24\n!5.5.5.5')"
 		The contents of file "${errorlog}" should include 'GeoIP unavailable'
 	End
 
-	It 'clears a stale consolidated matchdedup file once a clean (offender-free) dmax pass confirms zero cc-list matches (matchdedup symmetry, issue #1084 review)'
-		printf '1.1.1.0/24\n!1.1.1.1\n' > "${pfbmatchgen}matchdedup_v4.txt"
+	It 'clears a stale consolidated exempt file once a clean (offender-free) dmax pass confirms zero cc-list matches (exempt-file symmetry, issue #1084 review)'
+		printf '1.1.1.0/24\n!1.1.1.1\n' > "${pfbmatchgen}pfB_Match_Exempt_v4.txt"
 		printf '192.0.2.1\n' > "${snap}/CLEAN_v4.orig"
 		printf '%s\n' "${snap}/CLEAN_v4.orig" > "$memberlist"
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 100 US match off
 		The status should be success
-		The path "${pfbmatchgen}matchdedup_v4.txt" should not be exist
+		The path "${pfbmatchgen}pfB_Match_Exempt_v4.txt" should not be exist
 	End
 End
 

--- a/tests/shell/pfblockerng_reputation_max_spec.sh
+++ b/tests/shell/pfblockerng_reputation_max_spec.sh
@@ -28,21 +28,21 @@ Describe 'reputation_max() match output (issue #27)'
     max=999999
     printf '1.2.3.4\n1.2.3.5\n9.9.9.9\n' > "${pfbdeny}${alias}.txt"
     # Stale match output the run must clean up at its absolute ${pfbmatchgen} path.
-    printf 'old\n' > "${pfbmatchgen}match${alias}.txt"
+    printf 'old\n' > "${pfbmatchgen}pfB_Match_Rep_${alias}.txt"
     When call reputation_max
     The status should be success
-    The path "${pfbmatchgen}match${alias}.txt" should not be exist
+    The path "${pfbmatchgen}pfB_Match_Rep_${alias}.txt" should not be exist
   End
 
-  It 'writes match output to ${pfbmatchgen}match<alias>.txt (repeat offenders, ccwhite=match)'
+  It 'writes match output to ${pfbmatchgen}pfB_Match_Rep_<alias>.txt (repeat offenders, ccwhite=match)'
     alias="MYLIST"
     max=1
     make_geoip_stub "$pathgeoip" 'xx iso_code: "US" xx'
     printf '1.2.3.4\n1.2.3.5\n1.2.3.6\n' > "${pfbdeny}${alias}.txt"
     When call reputation_max
     The status should be success
-    The path "${pfbmatchgen}match${alias}.txt" should be file
-    The contents of file "${pfbmatchgen}match${alias}.txt" should include "1.2.3.0/24"
+    The path "${pfbmatchgen}pfB_Match_Rep_${alias}.txt" should be file
+    The contents of file "${pfbmatchgen}pfB_Match_Rep_${alias}.txt" should include "1.2.3.0/24"
     The stdout should include "Reputation -Max Stats"
   End
 
@@ -65,7 +65,7 @@ Describe 'reputation_max() match output (issue #27)'
     When call reputation_max
     The status should be success
     # Not matched/whitelisted: no match-output file is produced for this alias.
-    The path "${pfbmatchgen}match${alias}.txt" should not be exist
+    The path "${pfbmatchgen}pfB_Match_Rep_${alias}.txt" should not be exist
     # Counted as a blocked repeat-offender range (the block branch ran).
     The stdout should include "Reputation -Max Stats"
   End

--- a/tests/shell/pfblockerng_reputation_max_spec.sh
+++ b/tests/shell/pfblockerng_reputation_max_spec.sh
@@ -1,14 +1,15 @@
 #shellcheck shell=sh
 # reputation_max() match-output filename — locks the issue #27 fix (the pre-fix
 # code built the match filename from a stale $header global and removed a stale
-# file via a relative path instead of the absolute ${pfbmatch} path).
+# file via a relative path instead of the absolute ${pfbmatchgen} path).
 
 Describe 'reputation_max() match output (issue #27)'
   setup() {
     work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/repmax.XXXXXX")"
     pfbdeny="${work}/deny/"
     pfbmatch="${work}/match/"
-    mkdir -p "$pfbdeny" "$pfbmatch"
+    pfbmatchgen="${work}/match/generated/"
+    mkdir -p "$pfbdeny" "$pfbmatch" "$pfbmatchgen"
     tempfile="${work}/t1"; tempfile2="${work}/t2"
     dupfile="${work}/t3"; matchfile="${work}/t7"; tempmatchfile="${work}/t8"
     pathgeoip="${work}/mmdblookup"
@@ -22,26 +23,26 @@ Describe 'reputation_max() match output (issue #27)'
   Before 'setup'
   After 'cleanup'
 
-  It 'cleans a stale match file by alias-derived name under ${pfbmatch} (no repeat offenders)'
+  It 'cleans a stale match file by alias-derived name under ${pfbmatchgen} (no repeat offenders)'
     alias="MYLIST"
     max=999999
     printf '1.2.3.4\n1.2.3.5\n9.9.9.9\n' > "${pfbdeny}${alias}.txt"
-    # Stale match output the run must clean up at its absolute ${pfbmatch} path.
-    printf 'old\n' > "${pfbmatch}match${alias}.txt"
+    # Stale match output the run must clean up at its absolute ${pfbmatchgen} path.
+    printf 'old\n' > "${pfbmatchgen}match${alias}.txt"
     When call reputation_max
     The status should be success
-    The path "${pfbmatch}match${alias}.txt" should not be exist
+    The path "${pfbmatchgen}match${alias}.txt" should not be exist
   End
 
-  It 'writes match output to ${pfbmatch}match<alias>.txt (repeat offenders, ccwhite=match)'
+  It 'writes match output to ${pfbmatchgen}match<alias>.txt (repeat offenders, ccwhite=match)'
     alias="MYLIST"
     max=1
     make_geoip_stub "$pathgeoip" 'xx iso_code: "US" xx'
     printf '1.2.3.4\n1.2.3.5\n1.2.3.6\n' > "${pfbdeny}${alias}.txt"
     When call reputation_max
     The status should be success
-    The path "${pfbmatch}match${alias}.txt" should be file
-    The contents of file "${pfbmatch}match${alias}.txt" should include "1.2.3.0/24"
+    The path "${pfbmatchgen}match${alias}.txt" should be file
+    The contents of file "${pfbmatchgen}match${alias}.txt" should include "1.2.3.0/24"
     The stdout should include "Reputation -Max Stats"
   End
 
@@ -64,7 +65,7 @@ Describe 'reputation_max() match output (issue #27)'
     When call reputation_max
     The status should be success
     # Not matched/whitelisted: no match-output file is produced for this alias.
-    The path "${pfbmatch}match${alias}.txt" should not be exist
+    The path "${pfbmatchgen}match${alias}.txt" should not be exist
     # Counted as a blocked repeat-offender range (the block branch ran).
     The stdout should include "Reputation -Max Stats"
   End

--- a/tests/shell/pfblockerng_truncate_survival_spec.sh
+++ b/tests/shell/pfblockerng_truncate_survival_spec.sh
@@ -327,7 +327,8 @@ STUB
     setup() {
       work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/truncF.XXXXXX")"
       pfborig="${work}/orig/"; pfbmatch="${work}/match/"; etdir="${work}/ET"
-      mkdir -p "${pfborig}" "${pfbmatch}" "${etdir}"
+      pfbmatchgen="${work}/match/generated/"
+      mkdir -p "${pfborig}" "${pfbmatch}" "${pfbmatchgen}" "${etdir}"
       alias='WipeF'
       ip_placeholder2=''
       now='now'
@@ -351,7 +352,7 @@ STUB
       The output should include 'SURVIVED_F'
       The contents of file "${errorlog}" should include 'cannot create'
       The contents of file "${pfborig}${alias}.orig" should equal "${expected_orig}"
-      The path "${pfbmatch}/ETMatch.txt" should not be exist
+      The path "${pfbmatchgen}/ETMatch.txt" should not be exist
     End
   End
 End

--- a/tests/shell/pfblockerng_truncate_survival_spec.sh
+++ b/tests/shell/pfblockerng_truncate_survival_spec.sh
@@ -323,7 +323,7 @@ STUB
     End
   End
 
-  Describe 'processet(): tempfile2 debris corrupts ETMatch.txt into a directory'
+  Describe 'processet(): tempfile2 debris corrupts pfB_Match_ET_v4.txt into a directory'
     setup() {
       work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/truncF.XXXXXX")"
       pfborig="${work}/orig/"; pfbmatch="${work}/match/"; etdir="${work}/ET"
@@ -346,13 +346,13 @@ STUB
     Before 'setup'
     After 'cleanup'
 
-    It 'aborts ET processing, leaving the .orig file unchanged and never creating ETMatch.txt'
+    It 'aborts ET processing, leaving the .orig file unchanged and never creating pfB_Match_ET_v4.txt'
       When run _truncF_run
       The status should be success
       The output should include 'SURVIVED_F'
       The contents of file "${errorlog}" should include 'cannot create'
       The contents of file "${pfborig}${alias}.orig" should equal "${expected_orig}"
-      The path "${pfbmatchgen}/ETMatch.txt" should not be exist
+      The path "${pfbmatchgen}/pfB_Match_ET_v4.txt" should not be exist
     End
   End
 End

--- a/tests/smoke/test_downgrade_prepare.py
+++ b/tests/smoke/test_downgrade_prepare.py
@@ -8,14 +8,20 @@ rolling the package back to a pre-4.0.x release clean — and carries the ``repo
 
 THE TOOL (``scripts/pfb-downgrade-prep.sh``) is a dev/ops-only script — NOT shipped in
 the package — that an operator copies to the appliance and runs as root before the
-``pkg`` downgrade. It reverses the two 4.0.x changes a pre-4.0.x release cannot cope
+``pkg`` downgrade. It reverses the three 4.0.x changes a pre-4.0.x release cannot cope
 with:
 
   1. Custom list pre/post transform scripts relocated into ``list_scripts/`` on upgrade —
      an older release resolves list scripts against the package ROOT only, so a moved
      script silently stops running. They are moved back to the root (shipped AWS wrappers
      are left in place, recognised by name — no pkg query).
-  2. The ADR-43 scheduled-tick cron entry — ``pfblockerng.php cron-tick`` (current,
+  2. Machine-owned match artifacts relocated + renamed from the match folder into its
+     ``generated/`` subdirectory on upgrade (issue #1250) — an older release resolves
+     match artifacts against the match folder ROOT only, under their old names, and a
+     leftover ``generated/`` subdirectory pollutes its glob. Recognised artifacts are
+     moved back under their pre-4.0.x names; a stray ``*.txt.new`` write-in-progress
+     file is deleted; ``generated/`` is removed once emptied.
+  3. The ADR-43 scheduled-tick cron entry — ``pfblockerng.php cron-tick`` (current,
      issue #1204) or the legacy pre-#1204 ``pfblockerng.php tick`` (an un-upgraded box)
      — is removed via ``pfSsh.php`` (the shipped ``install_cron_job()``), so the
      downgraded release re-establishes its own schedule instead of leaving an orphan
@@ -40,6 +46,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import uuid
 from pathlib import Path
 
 import pytest
@@ -76,6 +83,16 @@ _USER_SCRIPT = "ip_pre_pfbdgsmoke.sh"
 # A shipped AWS region wrapper — the tool must leave it in list_scripts/ (name gate).
 _SHIPPED_SCRIPT = "ip_pre_AWS_US.sh"
 
+# Machine match artifacts (issue #1250): matchdir/matchgendir and inert RFC 5737
+# TEST-NET-3 fixture content, one distinguishable line per artifact.
+_MATCHDIR = "/var/db/pfblockerng/match"
+_MATCHGENDIR = f"{_MATCHDIR}/generated"
+_ET_CONTENT = "203.0.113.10\n"
+_EXEMPT_CONTENT = "203.0.113.11\n"
+_REP_CONTENT = "203.0.113.12\n"
+_COLLISION_OLD_CONTENT = "203.0.113.13\n"  # already at the pre-4.0.x name in matchdir
+_COLLISION_NEW_CONTENT = "203.0.113.14\n"  # the generated/ file that must be LEFT
+
 _TICK_CMD = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php tick >> /var/log/pfblockerng.log 2>&1"
 # issue #1204: the current shipped cron entry — the tool must remove this ONE too,
 # via its own second install_cron_job('pfblockerng.php cron-tick', FALSE) needle
@@ -94,6 +111,28 @@ _TICK_CLOSE = "<<<TICKEND>>>"
 def _file_exists(vm: SmokeVM, path: str) -> bool:
     """TRUE iff ``path`` is a regular file on the guest (driven via /bin/sh -c by ssh)."""
     return vm.ssh("test", "-f", path, timeout=30.0).returncode == 0
+
+
+def _dir_exists(vm: SmokeVM, path: str) -> bool:
+    """TRUE iff ``path`` is a directory on the guest."""
+    return vm.ssh("test", "-d", path, timeout=30.0).returncode == 0
+
+
+def _write_guest_file(vm: SmokeVM, path: str, contents: str, *, timeout: float = 30.0) -> None:
+    """Write ``contents`` to ``path`` on the guest via ``tee`` over SSH (parent dir must exist)."""
+    result = subprocess.run(
+        vm.ssh_argv("tee", path), input=contents, capture_output=True, text=True, timeout=timeout, check=False
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"_write_guest_file({path}) failed: rc={result.returncode} {result.stderr!r}")
+
+
+def _read_guest_file(vm: SmokeVM, path: str) -> str:
+    """Read ``path`` on the guest and return its content (raises on a missing file/rc!=0)."""
+    result = vm.ssh("/bin/cat", path, timeout=30.0)
+    if result.returncode != 0:
+        raise RuntimeError(f"_read_guest_file({path}) failed: rc={result.returncode} {result.stderr!r}")
+    return result.stdout
 
 
 def _scp_to_guest(vm: SmokeVM, local: Path, remote: str) -> None:
@@ -308,5 +347,133 @@ def test_downgrade_tool_restores_scripts_and_removes_tick_cron(repo_vm: SmokeVM)
             _remove_tick_cron(repo_vm)
         except Exception as exc:  # noqa: BLE001 -- cleanup must not mask the real test outcome
             print(f"[smoke] _remove_tick_cron failed (non-fatal): {exc}")
+        pkg_delete(repo_vm)
+        repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)
+
+
+@pytest.mark.timeout(600)  # one pkg install cycle + a few ssh probes > the 30s default cap
+def test_downgrade_tool_reverses_matchgen_relocation(repo_vm: SmokeVM) -> None:
+    """DOWNGRADE-PREPARATION CONTRACT (issue #1250): ``pfb-downgrade-prep.sh`` reverses the
+    matchdir->matchgendir relocation — recognised machine artifacts move back to their
+    pre-4.0.x names in the match folder ROOT, a stray write-in-progress file is deleted,
+    and a genuine name collision is left in place (never silently overwritten).
+
+    Scenario: an admin prepares a 4.0.x box for a downgrade to a pre-4.0.x release.
+      Background: our NONE-signed file:// repo above the Netgate ``pfSense`` repo.
+
+    Given the branch build installed and, staged directly in
+      matchdir/generated/ (as a prior upgrade migration would have left them): the ET
+      match artifact, the consolidated exempt artifact, a per-alias reputation
+      artifact (a fresh uuid-suffixed alias name), a stray ``*.txt.new``
+      write-in-progress file, AND a genuine name collision — a file already sitting at
+      the OLD name in matchdir plus a same-mapping file in generated/,
+
+    When ``pfb-downgrade-prep.sh`` is run on the box as root,
+
+    Then the ET/exempt/reputation artifacts are back at their pre-4.0.x names in
+      matchdir with byte-identical content and gone from generated/, the stray
+      ``*.txt.new`` is deleted, the collision is left untouched on BOTH sides with a
+      stderr report naming both paths, and generated/ still exists (not emptied — the
+      collision file remains inside).
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file — repo_vm already gated this"
+    assert _TOOL_SRC.is_file(), f"dev tool not found at {_TOOL_SRC}"
+
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+
+    rep_alias = f"uuidalias{uuid.uuid4().hex[:8]}"
+    gen_et, old_et = f"{_MATCHGENDIR}/pfB_Match_ET_v4.txt", f"{_MATCHDIR}/ETMatch.txt"
+    gen_exempt, old_exempt = f"{_MATCHGENDIR}/pfB_Match_Exempt_v4.txt", f"{_MATCHDIR}/matchdedup_v4.txt"
+    gen_rep, old_rep = f"{_MATCHGENDIR}/pfB_Match_Rep_{rep_alias}_v4.txt", f"{_MATCHDIR}/match{rep_alias}_v4.txt"
+    stray = f"{_MATCHGENDIR}/foo.txt.new"
+    gen_collision, old_collision = f"{_MATCHGENDIR}/pfB_Match_Rep_Spam_v4.txt", f"{_MATCHDIR}/matchSpam_v4.txt"
+
+    try:
+        # ------------------------------------------------------------------ #
+        # GIVEN: branch build installed; tool staged; matchgen fixtures seeded #
+        # ------------------------------------------------------------------ #
+        pkg_delete(repo_vm)
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [Path(pkg)])
+        write_repo_conf(repo_vm, UPGRADE_REPO_DIR, ours_priority=pfsense_prio + 100)
+        pkg_update(repo_vm)
+        pkg_install_from_repo(repo_vm)
+        installed = pkg_installed_version(repo_vm)
+        expected = read_compact_version(Path(pkg))
+        assert installed == expected, f"expected branch build {expected!r} installed, got {installed!r}"
+
+        _scp_to_guest(repo_vm, _TOOL_SRC, _TOOL_DEST)
+
+        repo_vm.ssh("/bin/mkdir", "-p", _MATCHGENDIR, timeout=30.0)
+        _write_guest_file(repo_vm, gen_et, _ET_CONTENT)
+        _write_guest_file(repo_vm, gen_exempt, _EXEMPT_CONTENT)
+        _write_guest_file(repo_vm, gen_rep, _REP_CONTENT)
+        _write_guest_file(repo_vm, stray, "stray write-in-progress\n")
+        _write_guest_file(repo_vm, old_collision, _COLLISION_OLD_CONTENT)
+        _write_guest_file(repo_vm, gen_collision, _COLLISION_NEW_CONTENT)
+
+        # BEFORE: every fixture at its GENERATED location; none at its pre-4.0.x name
+        # (except the deliberate collision, which already occupies the old name).
+        for gen_path in (gen_et, gen_exempt, gen_rep, stray, gen_collision):
+            assert _file_exists(repo_vm, gen_path), f"precondition: {gen_path} must be staged in generated/"
+        assert not _file_exists(repo_vm, old_et), f"precondition: {old_et} must NOT exist yet"
+        assert not _file_exists(repo_vm, old_exempt), f"precondition: {old_exempt} must NOT exist yet"
+        assert not _file_exists(repo_vm, old_rep), f"precondition: {old_rep} must NOT exist yet"
+
+        # ------------------------------------------------------------------ #
+        # WHEN: the admin runs the downgrade-preparation tool as root         #
+        # ------------------------------------------------------------------ #
+        proc = repo_vm.ssh("/bin/sh", _TOOL_DEST, timeout=120.0)
+        assert proc.returncode == 0, (
+            f"pfb-downgrade-prep.sh failed: rc={proc.returncode} stdout={proc.stdout[-2000:]!r} stderr={proc.stderr!r}"
+        )
+        assert "Machine match artifacts restored to the match folder: 3" in proc.stdout, (
+            f"tool did not report restoring exactly 3 matchgen artifacts: {proc.stdout!r}"
+        )
+
+        # ------------------------------------------------------------------ #
+        # THEN: recognised artifacts restored; stray gone; collision left     #
+        # ------------------------------------------------------------------ #
+        et_content = _read_guest_file(repo_vm, old_et)
+        assert et_content == _ET_CONTENT, f"AFTER {old_et}: expected {_ET_CONTENT!r}, got {et_content!r}"
+        assert not _file_exists(repo_vm, gen_et), f"AFTER: {gen_et} must be gone from generated/"
+
+        exempt_content = _read_guest_file(repo_vm, old_exempt)
+        assert exempt_content == _EXEMPT_CONTENT, (
+            f"AFTER {old_exempt}: expected {_EXEMPT_CONTENT!r}, got {exempt_content!r}"
+        )
+        assert not _file_exists(repo_vm, gen_exempt), f"AFTER: {gen_exempt} must be gone from generated/"
+
+        rep_content = _read_guest_file(repo_vm, old_rep)
+        assert rep_content == _REP_CONTENT, f"AFTER {old_rep}: expected {_REP_CONTENT!r}, got {rep_content!r}"
+        assert not _file_exists(repo_vm, gen_rep), f"AFTER: {gen_rep} must be gone from generated/"
+
+        assert not _file_exists(repo_vm, stray), f"AFTER: stray {stray} must be deleted"
+
+        # Collision: neither side moved; the pre-existing matchdir file keeps its OWN
+        # content, and the generated/ collider is left for the operator to resolve.
+        collision_content = _read_guest_file(repo_vm, old_collision)
+        assert collision_content == _COLLISION_OLD_CONTENT, (
+            f"AFTER {old_collision}: no-clobber must leave the pre-existing content — "
+            f"expected {_COLLISION_OLD_CONTENT!r}, got {collision_content!r}"
+        )
+        assert _file_exists(repo_vm, gen_collision), f"AFTER: collider {gen_collision} must remain in generated/"
+        assert "not overwriting" in proc.stderr, f"tool did not report the no-clobber skip: {proc.stderr!r}"
+        assert old_collision in proc.stderr, f"no-clobber report must name the matchdir path: {proc.stderr!r}"
+        assert "pfB_Match_Rep_Spam_v4.txt" in proc.stderr, (
+            f"no-clobber report must name the generated/ file: {proc.stderr!r}"
+        )
+
+        # generated/ is NOT emptied (the collision file is still inside) -> left in place.
+        assert _dir_exists(repo_vm, _MATCHGENDIR), (
+            "AFTER: generated/ must still exist — the collision file blocks its removal"
+        )
+
+    finally:
+        # Self-encapsulation: leave no state for a sibling. The tick-cron/list-script
+        # reversals are exercised by the sibling test above; this leg only seeds/cleans
+        # matchdir/generated/.
+        repo_vm.ssh("/bin/rm", "-rf", _MATCHDIR, timeout=30.0)
+        repo_vm.ssh("/bin/rm", "-f", _TOOL_DEST, timeout=30.0)
         pkg_delete(repo_vm)
         repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -56,9 +56,15 @@ WHAT THIS FILE AUTOMATES:
   pre-existing per-alias match file byte-identical, never swapping/removing it.
 * **R8-restored — a clean pass with GeoIP UP clears the reputation match
   artifacts (issue #1228)** — with a real binary ``.mmdb`` seeded, a cc-list HIT
-  (``ccwhite=match``) writes the consolidated ``matchdedup`` file and a SIBLING
-  cc-list MISS (``ccblack=match``) writes a per-alias ``match<alias>.txt``; a
-  SECOND pass whose cc-list matches neither offender reconciles BOTH away.
+  (``ccwhite=match``) writes the consolidated ``pfB_Match_Exempt_v4.txt`` file
+  and a SIBLING cc-list MISS (``ccblack=match``) writes a per-alias
+  ``pfB_Match_Rep_<alias>.txt``; a SECOND pass whose cc-list matches neither
+  offender reconciles BOTH away.
+* **R10 — Alerts attribution rides the relocated artifact (issue #1250)** — the
+  Alerts page's ``find_reported_header()`` reader (fed by
+  ``pfb_ip_match_folders()``) attributes a reported IP to a staged
+  ``pfB_Match_Rep_<alias>.txt`` artifact under matchgendir — a direct PHP probe
+  of the reader path, no reload needed.
 
 Reload-scope note: R1/R2/R5/R9 are single-pass (or repeat-input) cases and use
 ``reload(scope='updateip')`` — its ``force=true`` sets ``$pfb['reuse']='on'`` for the
@@ -90,6 +96,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import uuid
 from collections.abc import Iterator
 
 import pytest
@@ -105,8 +112,11 @@ SNAPDIR = f"{h.PFB_DBDIR}/snapshot"
 MASTERFILE = f"{h.PFB_DBDIR}/masterfile"
 # pfblockerng.inc:50 $pfb['origdir'] -- the recompute snapshot's '.aggcount' sidecar dir (R3).
 ORIGDIR = f"{h.PFB_DBDIR}/original"
-# pfblockerng.sh:92 pfbmatch -- the dMax per-alias 'match<alias>.txt' reputation artifact dir (R8-outage).
+# pfblockerng.sh:92 pfbmatch -- the user's own Match List feed dir.
 MATCHDIR = f"{h.PFB_DBDIR}/match"
+# pfblockerng.sh:95 pfbmatchgen -- the dMax per-alias 'pfB_Match_Rep_<alias>.txt' reputation
+# artifact dir (R8-outage) + the consolidated 'pfB_Match_Exempt_v4.txt' (R8-restored).
+MATCHGENDIR = f"{MATCHDIR}/generated"
 
 # Pin ip_placeholder explicitly (PHP and pfblockerng.sh both default to this value) so
 # R5/R9's collapse assertion compares against an exact string no matter what an earlier
@@ -639,21 +649,21 @@ GEOIP_OUTAGE_MARKER = "recompute [ v4 ]: GeoIP unavailable this pass -- keeping 
 
 
 def _stage_match_file(vm: SmokeVM, rec_alias: str, contents: str, *, timeout: float = 30.0) -> str:
-    """Write ``contents`` verbatim to ``MATCHDIR/match<rec_alias>.txt`` via ``tee`` (mirrors
-    ``write_local_feed``'s mkdir-then-tee). ``rec_alias`` is the SNAPSHOT-derived name
+    """Write ``contents`` verbatim to ``MATCHGENDIR/pfB_Match_Rep_<rec_alias>.txt`` via ``tee``
+    (mirrors ``write_local_feed``'s mkdir-then-tee). ``rec_alias`` is the SNAPSHOT-derived name
     pfblockerng.sh reconciles on (``rec_alias="${rec_snap##*/}"; rec_alias="${rec_alias%%.*}"``,
-    pfblockerng.sh:896) -- i.e. ``<header>_<family>``, NOT the pf table's ``pfB_*`` name.
+    pfblockerng.sh:901) -- i.e. ``<header>_<family>``, NOT the pf table's ``pfB_*`` name.
 
     R8-outage's local one-off: a leading '!' line (the real match-file format) sent through
     ``php_eval``/``file_put_contents`` gets mangled -- pfSsh.php's REPL treats a '!'-led line
     as a raw shell-escape -- so this writes bytes over SSH stdin instead.
     """
-    path = f"{MATCHDIR}/match{rec_alias}.txt"
+    path = f"{MATCHGENDIR}/pfB_Match_Rep_{rec_alias}.txt"
     mk = subprocess.run(
-        vm.ssh_argv("/bin/mkdir", "-p", MATCHDIR), capture_output=True, text=True, timeout=timeout, check=False
+        vm.ssh_argv("/bin/mkdir", "-p", MATCHGENDIR), capture_output=True, text=True, timeout=timeout, check=False
     )
     if mk.returncode != 0:
-        raise RuntimeError(f"_stage_match_file: mkdir {MATCHDIR} failed: rc={mk.returncode} {mk.stderr!r}")
+        raise RuntimeError(f"_stage_match_file: mkdir {MATCHGENDIR} failed: rc={mk.returncode} {mk.stderr!r}")
     result = subprocess.run(
         vm.ssh_argv("tee", path), input=contents, capture_output=True, text=True, timeout=timeout, check=False
     )
@@ -670,7 +680,7 @@ def test_recompute_geoip_outage_preserves_match_artifacts(deployed_vm: SmokeVM) 
     a PRE-EXISTING per-alias reputation match file untouched, never swap/remove it.
 
     STAGED PRECONDITION (documented, not a fake of the code path under test): this box
-    can never produce a real ``match<alias>.txt`` through a GeoIP-UP pass (no
+    can never produce a real ``pfB_Match_Rep_<alias>.txt`` through a GeoIP-UP pass (no
     ``.mmdb`` ever exists here -- the restored-GeoIP leg needs real MaxMind
     credentials to fetch a binary database a CSV fixture cannot substitute for;
     tracked as issue #1228). The file staged below stands in for "what a prior pass
@@ -739,15 +749,17 @@ def test_recompute_geoip_outage_preserves_match_artifacts(deployed_vm: SmokeVM) 
 
 def test_recompute_geoip_restored_clears_match_artifacts(deployed_vm: SmokeVM) -> None:
     """dMax with GeoIP UP: a clean pass (no cc-list match for any offender)
-    reconciles away BOTH the consolidated ``matchdedup`` file and a per-alias
-    ``match<alias>.txt`` -- ``pfb_recompute_finish()``'s ``rec_geoip_ok=1`` branch
-    (issue #1228; the CSV-only fixture could never reach this leg).
+    reconciles away BOTH the consolidated ``pfB_Match_Exempt_v4.txt`` file and a
+    per-alias ``pfB_Match_Rep_<alias>.txt`` -- ``pfb_recompute_finish()``'s
+    ``rec_geoip_ok=1`` branch (issue #1228; the CSV-only fixture could never
+    reach this leg).
 
     Two offending /24s classify to DIFFERENT actions in the SAME pass -- a cc-list
-    HIT can only ever emit ``matchexempt`` (-> the consolidated ``matchdedup``
-    file), never a per-alias file (pfblockerng.sh's classify ``case``); only a
-    cc-list MISS with ``ccblack=match`` emits ``matchdup`` (-> the per-alias file).
-    Both offenders are needed to pin BOTH artifacts' clearing in one pass.
+    HIT can only ever emit ``matchexempt`` (-> the consolidated
+    ``pfB_Match_Exempt_v4.txt`` file), never a per-alias file (pfblockerng.sh's
+    classify ``case``); only a cc-list MISS with ``ccblack=match`` emits
+    ``matchdup`` (-> the per-alias file). Both offenders are needed to pin BOTH
+    artifacts' clearing in one pass.
 
     Scenario: GeoIP is available; the cc-list stops matching either offender.
       Given a v4 Deny feed with two offending /24s whose ``.1`` resolve in the
@@ -756,24 +768,24 @@ def test_recompute_geoip_restored_clears_match_artifacts(deployed_vm: SmokeVM) -
         ``ccblack='match'``, ``ccexclude='BT'`` (a HIT for the first, a MISS for
         the second),
       When a real update pass runs,
-      Then (BEFORE-STATE, asserted) ``matchdedup_v4.txt`` EXISTS carrying the
-        HIT offender's /24 (the ``matchexempt`` action) and the per-alias
-        ``match<alias>.txt`` EXISTS carrying the MISS offender's /24 (the
+      Then (BEFORE-STATE, asserted) ``pfB_Match_Exempt_v4.txt`` EXISTS carrying
+        the HIT offender's /24 (the ``matchexempt`` action) and the per-alias
+        ``pfB_Match_Rep_d2_v4.txt`` EXISTS carrying the MISS offender's /24 (the
         ``matchdup`` action), and the GeoIP-unavailable log line did NOT fire
         (this pass had GeoIP),
       When ``ccexclude`` is changed to a country neither offender is in
         (``GI``) and ``ccblack`` is turned off (so neither offender classifies
         into ANY action -- a genuinely clean pass) and a SECOND real pass runs,
-      Then both ``matchdedup_v4.txt`` and the per-alias ``match<alias>.txt`` are
-        GONE -- the clean pass reconciled them away, and the GeoIP-unavailable
-        line STILL did not fire.
+      Then both ``pfB_Match_Exempt_v4.txt`` and the per-alias
+        ``pfB_Match_Rep_d2_v4.txt`` are GONE -- the clean pass reconciled them
+        away, and the GeoIP-unavailable line STILL did not fire.
     """
     h.seed_geoip_dataset(deployed_vm)
     h.set_ip_dedup(deployed_vm, False)
     h.set_ip_suppression(deployed_vm, enabled=False)
 
-    matchdedup_path = f"{MATCHDIR}/matchdedup_v4.txt"
-    match_alias_path = f"{MATCHDIR}/matchd2_v4.txt"
+    matchdedup_path = f"{MATCHGENDIR}/pfB_Match_Exempt_v4.txt"
+    match_alias_path = f"{MATCHGENDIR}/pfB_Match_Rep_d2_v4.txt"
     # A stale artifact from an earlier module run would make the before-state
     # assertion below meaningless -- start clean, loudly.
     for stale in (matchdedup_path, match_alias_path):
@@ -788,7 +800,7 @@ def test_recompute_geoip_restored_clears_match_artifacts(deployed_vm: SmokeVM) -
     spec = h.IpCase(aliasname="d2", feed_url=feed, header="d2", action="Deny_Both")
     h.inject_ip_lists(deployed_vm, [spec])
 
-    # PASS 1: ccexclude="BT" -- a HIT for 67.43.156 (-> matchexempt/matchdedup),
+    # PASS 1: ccexclude="BT" -- a HIT for 67.43.156 (-> matchexempt/pfB_Match_Exempt),
     # a MISS for 111.235.160 with ccblack='match' (-> matchdup/per-alias file).
     h.set_ip_reputation(deployed_vm, drep=True, dmax=2, ccwhite="match", ccblack="match", ccexclude="BT")
     before_marker = h.count_log_marker(deployed_vm, h.PFB_LOG, GEOIP_OUTAGE_MARKER)
@@ -796,11 +808,12 @@ def test_recompute_geoip_restored_clears_match_artifacts(deployed_vm: SmokeVM) -
 
     matchdedup_pass1 = _raw(deployed_vm, matchdedup_path)
     assert matchdedup_pass1 == "67.43.156.0/24\n!67.43.156.10\n!67.43.156.11\n!67.43.156.12\n", (
-        f"matchdedup_v4.txt wrong after the HIT pass (expected the BT offender's /24 + members): {matchdedup_pass1!r}"
+        f"pfB_Match_Exempt_v4.txt wrong after the HIT pass (expected the BT offender's /24 + members): "
+        f"{matchdedup_pass1!r}"
     )
     match_alias_pass1 = _raw(deployed_vm, match_alias_path)
     assert match_alias_pass1 == "111.235.160.0/24\n!111.235.160.10\n!111.235.160.11\n!111.235.160.12\n", (
-        f"per-alias match file wrong after the MISS+ccblack=match pass (expected the CN offender's "
+        f"pfB_Match_Rep_d2_v4.txt wrong after the MISS+ccblack=match pass (expected the CN offender's "
         f"/24 + members): {match_alias_pass1!r}"
     )
     marker_pass1 = h.count_log_marker(deployed_vm, h.PFB_LOG, GEOIP_OUTAGE_MARKER)
@@ -814,14 +827,65 @@ def test_recompute_geoip_restored_clears_match_artifacts(deployed_vm: SmokeVM) -
     h.reload(deployed_vm, "updateip", wait_unbound=False)
 
     assert not _exists(deployed_vm, matchdedup_path), (
-        f"matchdedup_v4.txt survived a clean pass (no cc-list match) -- reconcile did not fire: "
+        f"pfB_Match_Exempt_v4.txt survived a clean pass (no cc-list match) -- reconcile did not fire: "
         f"content={_raw(deployed_vm, matchdedup_path)!r}"
     )
     assert not _exists(deployed_vm, match_alias_path), (
-        f"per-alias match file survived a clean pass (no cc-list match) -- reconcile did not fire: "
+        f"pfB_Match_Rep_d2_v4.txt survived a clean pass (no cc-list match) -- reconcile did not fire: "
         f"content={_raw(deployed_vm, match_alias_path)!r}"
     )
     marker_pass2 = h.count_log_marker(deployed_vm, h.PFB_LOG, GEOIP_OUTAGE_MARKER)
     assert marker_pass2 == before_marker, (
         f"GeoIP-unavailable line fired on the restored/clean pass: before={before_marker} after={marker_pass2}"
     )
+
+
+# --------------------------------------------------------------------------- #
+# R10 -- end-to-end match-event attribution through the relocated artifact
+# (issue #1250: the Alerts page's find_reported_header() reader must resolve a
+# staged pfB_Match_Rep_<alias>.txt exactly as it used to resolve match<alias>.txt)
+# --------------------------------------------------------------------------- #
+
+
+def test_find_reported_header_attributes_relocated_match_rep_artifact(deployed_vm: SmokeVM) -> None:
+    """``find_reported_header()`` (the Alerts page's reader, fed by
+    ``pfb_ip_match_folders()``) attributes a reported IP to a staged
+    ``pfB_Match_Rep_<alias>.txt`` artifact -- pinning the user-visible rename
+    end-to-end: the Alerts column used to render ``match<alias>_v4`` and now
+    renders ``pfB_Match_Rep_<alias>_v4``.
+
+    A direct PHP probe of the reader path -- no reload, no live feed needed.
+
+    Scenario: one reported IP inside a freshly staged reputation CIDR.
+      Given (BEFORE) no artifact exists yet for a fresh, uuid-scoped alias,
+      When ``find_reported_header()`` queries a host inside the CIDR the
+        artifact WILL cover,
+      Then attribution MISSES this alias (nothing staged to match),
+      When a ``pfB_Match_Rep_<alias>.txt`` artifact carrying an RFC 5737 /24
+        (``203.0.113.0/24`` -- distinct from every OTHER match-artifact test in
+        this module, so a stale sibling artifact can never cause a false match)
+        is staged under matchgendir and the SAME query re-runs,
+      Then the returned header names THIS artifact's stem.
+    """
+    rec_alias = f"r10attr{uuid.uuid4().hex[:10]}_v4"
+    artifact_stem = f"pfB_Match_Rep_{rec_alias}"
+    host_ip = "203.0.113.99"
+    pre = "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\npfb_global();\n"
+    query = f"implode('|', find_reported_header({h._php_str(host_ip)}, pfb_ip_match_folders()))"
+
+    # BEFORE: nothing staged under this uuid-scoped alias yet.
+    before = h._php_read_scalar(deployed_vm, pre, query)
+    assert artifact_stem not in before, f"attribution matched an artifact never staged: {before!r}"
+
+    match_path = None
+    try:
+        match_path = _stage_match_file(deployed_vm, rec_alias, "203.0.113.0/24\n")
+
+        after = h._php_read_scalar(deployed_vm, pre, query)
+        assert artifact_stem in after, (
+            f"find_reported_header() did not attribute {host_ip} to the staged {artifact_stem}.txt "
+            f"via pfb_ip_match_folders(): before={before!r} after={after!r}"
+        )
+    finally:
+        if match_path is not None:
+            deployed_vm.ssh("/bin/rm", "-f", match_path)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2255,6 +2255,45 @@ def test_page_table_covers_every_pfblockerng_page() -> None:
     assert "dnsbl_vip_sinkhole_pages" in excluded_names
 
 
+def test_reputation_page_help_text_names_relocated_matchgen_paths(
+    webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:  # noqa: ARG001
+    """issue #1250: the Reputation page's ccwhite/ET help text pointed at the machine-generated
+    artifacts' OLD matchdir names/location; both moved under matchdir/generated with new names.
+
+    Scenario: Reputation page help text names the relocated matchgen paths.
+      Given the Reputation page (written by pfblockerng.php's `ugc`, pfblockerng.php:2562/2614)
+            renders cleanly
+      When  the body is inspected
+      Then  it names the NEW matchgendir paths for the ccwhite exempt file and the ET match
+            file, and does NOT name either OLD matchdir path (before/after: the old paths were
+            the literal help text prior to this change; `matchdedup.txt` was never a real
+            filename any writer produced, only `matchdedup_v4.txt` -- so the old help text was
+            already unfollowable, not merely stale).
+    """
+    resp = webui.get("/pfblockerng/pfblockerng_reputation.php")
+    result = evaluate_render(
+        "/pfblockerng/pfblockerng_reputation.php",
+        resp.status_code,
+        resp.text,
+        ("IPv4 Reputation", "Individual List Reputation"),
+    )
+    assert result.ok, f"Reputation page render oracle failed: {result.detail}"
+    body = resp.text
+
+    for needle in (
+        "/var/db/pfblockerng/match/generated/pfB_Match_Exempt_v4.txt",
+        "/var/db/pfblockerng/match/generated/pfB_Match_ET_v4.txt",
+    ):
+        assert needle in body, f"relocated matchgen path {needle!r} missing from Reputation help text"
+
+    for needle in (
+        "/var/db/pfblockerng/match/matchdedup.txt",
+        "/var/db/pfblockerng/match/ETMatch.txt",
+    ):
+        assert needle not in body, f"stale pre-#1250 matchdir path {needle!r} still present in help text"
+
+
 # ---------------------------------------------------------------------------
 # Tier-B tests — ui_e2e marker; schedule/dispatch-only, NOT PR-blocking.
 # These require VM state setup (seeding files or multi-step POST → GET flows).


### PR DESCRIPTION
# BREAKING CHANGE: relocate machine-generated match artifacts to `match/generated/` under `pfB_Match_*` names

Closes #1250. Closes #1269 (fixed structurally: the machine artifacts now have their own keep-list-guarded directory, so the generic matchdir sweep can never reap `ETMatch.txt` again).

## The problem

`/var/db/pfblockerng/match/` held two overlapping namespaces: a user's **Match**-type list writes `match/<Header>_<fam>.txt`, while a **Deny**-type list headed `H` makes the reputation recompute write `match/match<H>_<fam>.txt`. A Match list headed `matchSpam` and a Deny list headed `Spam` therefore resolve to the **same path** — last writer wins. Reserved-prefix validation cannot fix this class (any prefix is itself a legal `\w+` header), so the machine-owned artifacts move out of the user's namespace entirely.

## What ships

| Old (in `match/`) | New (in `match/generated/`) |
| --- | --- |
| `match<H>_<fam>.txt` (reputation per-alias) | `pfB_Match_Rep_<H>_<fam>.txt` |
| `matchdedup_v4.txt` (ccwhite consolidated exempt) | `pfB_Match_Exempt_v4.txt` |
| `ETMatch.txt` (ET/Proofpoint) | `pfB_Match_ET_v4.txt` |

("Rep" and "Exempt" are the codebase's own words — `$pfb['rep']`, the `matchexempt` action. "dedup" was always a misnomer: that file is the country-code exempt consolidated match file, unrelated to the dedup feature.)

- **All 14 machine-owned writer sites repointed** (batch recompute + its awk writer, legacy `reputation_max()`, `processet()`, stale-`.new` pre-cleans), plus the readers: both alerts-attribution globs (`pfb_ip_match_folders()`), the Match List IP Counts report, the GUI help text, and a new "Match Generated Files" log viewer.
- **`pfb_matchgen_reap()`**: the `generated/` orphan sweep (family-complete keep-list, v4+v6), so a departed Deny list's artifact cannot leak disk.
- **Upgrade migration** (`pfblockerng_install.inc`): creates `generated/` with matchdir's live perms/ownership and moves the legacy files in. The decision table is pure and pinned (`pfb_matchdir_migrate_plan()`): a file is moved only when exactly one candidate writer explains it; a name that could equally be a user's list file is **left in place** and reported as ambiguous — the migration never adopts, never deletes. Header cross-references are built from **configured** (not merely enabled) lists, include the synthetic header classes (`DNSBLIP`, `<alias>_custom`, the GeoIP continents), and are `\W`-normalised exactly like sync does (`pfb_matchdir_config_headers()`).
- **Prominent upgrade warning** (update log + `file_notice`) listing what moved, what was ambiguous, and every configured Localfile row that pointed at a path this run actually moved — **admins repoint those themselves; config is never rewritten.**
- **Downgrade**: `scripts/pfb-downgrade-prep.sh` now reverses the relocation too (reverse renames with no-clobber, `.txt.new` cleanup, `rmdir` of `generated/` once emptied).

## User-visible behaviour changes

- **ADR-11 aggregate membership**: `pfB_Match_Aggregated_v{4,6}` no longer sweeps in the reputation artifacts — a reputation side-product was never a Match list. Membership is pinned by test.
- **Alerts feed column** renders `pfB_Match_Rep_<alias>_<fam>` where it previously rendered `match<alias>_<fam>` (pinned end-to-end on a live VM).
- A Localfile pointing at an old artifact path breaks on upgrade and must be repointed by the admin (the upgrade warning lists the exact rows).

## Accepted coupling (deliberate)

The Reputation page help text instructs pointing a Localfile at `/var/db/pfblockerng/match/generated/pfB_Match_Exempt_v4.txt` — a future rename would repeat this stale-refs dance. Accepted consciously: a stable alias/indirection layer is not worth the machinery for a dev-visible path that has now moved once in the package's history.

## Verification

- PHPUnit: 3291 tests / 20911 assertions green (includes red-first reproduction tests for every migration defect class: wrong-identity adoption, disabled-list adoption, synthetic-header deletion, raw-header cross-references, false repoint warnings, v6 reaper holes).
- Shellspec (dash): downgrade tool suite incl. no-clobber, stray cleanup, quoting (space-in-filename), idempotence.
- Live-VM smoke (local `PFB_BOXES` leases): recompute/reconcile module repointed + green, downgrade end-to-end leg green, full Tier-A `ui_render` green.
- PHPStan, PHPCS, ruff, mypy, markdownlint: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8cr16xTZ9ixtbJndKKjrd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Machine-generated match artifacts now use a dedicated generated location and consistent filenames, reducing conflicts with user-created match lists.
  * Added a log view for downloading and clearing generated match files.
  * Match reports and IP attribution now include generated artifacts.

* **Bug Fixes**
  * Upgrade migrations avoid overwriting existing files and identify localfile references requiring updates.
  * Downgrade preparation now restores generated match artifacts, removes temporary files, and safely handles collisions.

* **Documentation**
  * Updated architecture, configuration, script, and UI help documentation for the new artifact paths and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->