### PR TITLE
dev: block agent commits in the primary checkout (#1262)

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -22,15 +22,14 @@
 
 set -u
 
-# Agent worktree guard (issue #1262): an agent commit (CLAUDECODE=1) in the
-# PRIMARY checkout aborts — agents commit only in linked worktrees (CLAUDE.md
-# "Worktrees"). Lives HERE because this hook still runs when verification is
-# skipped. Git STATE decides (never command text): --git-dir equals
-# --git-common-dir only in the primary checkout. Skipped when the checkout is
-# agent-dedicated: managed-remote sessions (CLAUDE_CODE_USER_EMAIL set) or an
-# explicit `git config pfblockerng.allowprimarycommit true`.
+# Agent worktree guard (issue #1262): abort an agent commit (CLAUDECODE=1) in
+# the primary checkout (--git-dir == --git-common-dir; agents commit only in
+# linked worktrees). Lives in THIS hook because it still runs when verification
+# is skipped. Exempt: managed-remote sessions (CLAUDE_CODE_USER_EMAIL set) or an
+# explicit `git config pfblockerng.allowprimarycommit true` (agent-dedicated).
 if [ "${CLAUDECODE:-}" = "1" ] && [ -z "${CLAUDE_CODE_USER_EMAIL:-}" ] &&
 	[ "$(git config --bool --get pfblockerng.allowprimarycommit 2>/dev/null)" != "true" ]; then
+	unset CDPATH # a CDPATH hit makes cd echo the dir, corrupting $(cd ... && pwd -P)
 	git_dir=$(cd "$(git rev-parse --git-dir)" && pwd -P)
 	common_dir=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)
 	if [ "$git_dir" = "$common_dir" ]; then

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,5 +1,6 @@
 #!/bin/sh
-# prepare-commit-msg: credit the human owner as a Co-Authored-By trailer.
+# prepare-commit-msg: agent worktree guard, then credit the human owner as a
+# Co-Authored-By trailer.
 #
 # In agent / managed-remote environments the *committer* is the agent (e.g.
 # Claude) and GitHub attributes the commit — and the contribution credit it
@@ -20,6 +21,24 @@
 # Enable: git config core.hooksPath .githooks
 
 set -u
+
+# Agent worktree guard (issue #1262): an agent commit (CLAUDECODE=1) in the
+# PRIMARY checkout aborts — agents commit only in linked worktrees (CLAUDE.md
+# "Worktrees"). Lives HERE because this hook still runs when verification is
+# skipped. Git STATE decides (never command text): --git-dir equals
+# --git-common-dir only in the primary checkout. Skipped when the checkout is
+# agent-dedicated: managed-remote sessions (CLAUDE_CODE_USER_EMAIL set) or an
+# explicit `git config pfblockerng.allowprimarycommit true`.
+if [ "${CLAUDECODE:-}" = "1" ] && [ -z "${CLAUDE_CODE_USER_EMAIL:-}" ] &&
+	[ "$(git config --bool --get pfblockerng.allowprimarycommit 2>/dev/null)" != "true" ]; then
+	git_dir=$(cd "$(git rev-parse --git-dir)" && pwd -P)
+	common_dir=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)
+	if [ "$git_dir" = "$common_dir" ]; then
+		echo "prepare-commit-msg: agent commit in the primary checkout blocked — agents commit only in a linked worktree (issue #1262)." >&2
+		echo "If this checkout is dedicated to the agent: git config pfblockerng.allowprimarycommit true" >&2
+		exit 1
+	fi
+fi
 
 msg_file=$1
 msg_type=${2:-}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -592,9 +592,9 @@ Activate once after cloning: `sh scripts/setup-hooks.sh` (sets `core.hooksPath`)
 - **`prepare-commit-msg`** — first aborts an agent commit (`CLAUDECODE=1`) in the **primary
   checkout** (agents commit only in linked worktrees — issue #1262; state-checked via
   `--git-dir` vs `--git-common-dir`, never command text; agent-dedicated checkouts opt out
-  via `CLAUDE_CODE_USER_EMAIL` (managed-remote) or `git config
-  pfblockerng.allowprimarycommit true`), then appends the owner's `Co-authored-by:` trailer
-  (see Commit style); runs even under `--no-verify`.
+  via `CLAUDE_CODE_USER_EMAIL` (managed-remote) or
+  `git config pfblockerng.allowprimarycommit true`), then appends the owner's
+  `Co-authored-by:` trailer (see Commit style); runs even under `--no-verify`.
 - **`pre-push`** — enforces the release tag scheme via `scripts/release-version.sh`.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -589,8 +589,12 @@ Activate once after cloning: `sh scripts/setup-hooks.sh` (sets `core.hooksPath`)
   `*.sh`/`*.md` staged). NOT the unit suites — run `python3 -m pytest` yourself while
   iterating; CI is the hard gate. Missing tool = reported + skipped. The `--no-verify` bypass
   is for humans, not agents.
-- **`prepare-commit-msg`** — appends the owner's `Co-authored-by:` trailer (see Commit
-  style); runs even under `--no-verify`.
+- **`prepare-commit-msg`** — first aborts an agent commit (`CLAUDECODE=1`) in the **primary
+  checkout** (agents commit only in linked worktrees — issue #1262; state-checked via
+  `--git-dir` vs `--git-common-dir`, never command text; agent-dedicated checkouts opt out
+  via `CLAUDE_CODE_USER_EMAIL` (managed-remote) or `git config
+  pfblockerng.allowprimarycommit true`), then appends the owner's `Co-authored-by:` trailer
+  (see Commit style); runs even under `--no-verify`.
 - **`pre-push`** — enforces the release tag scheme via `scripts/release-version.sh`.
 
 ---

--- a/tests/shell/githooks_prepare_commit_msg_guard_spec.sh
+++ b/tests/shell/githooks_prepare_commit_msg_guard_spec.sh
@@ -1,0 +1,116 @@
+#shellcheck shell=sh
+# .githooks/prepare-commit-msg agent worktree guard (issue #1262): an agent
+# commit (CLAUDECODE=1) in the PRIMARY checkout aborts; a linked-worktree
+# commit, a human commit, and an agent-dedicated checkout (managed-remote
+# marker CLAUDE_CODE_USER_EMAIL, or the pfblockerng.allowprimarycommit valve)
+# all pass. Enforced in prepare-commit-msg because that hook still runs when
+# verification is skipped — the verify-skip row below is the point.
+#
+# The guard discriminates on git STATE (--git-dir vs --git-common-dir), never
+# on command text, so nothing here exercises payload parsing: these rows pin
+# the operation-layer contract that replaced the rejected Rule E text scan.
+
+Describe 'prepare-commit-msg agent worktree guard (issue #1262)'
+  hook="${PFB_ROOT}/.githooks/prepare-commit-msg"
+
+  setup() {
+    scrub_git_env
+    base="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pcmguard.XXXXXX")"
+    primary="${base}/primary"
+    wt="${base}/wt"
+    git init -q -b devel "$primary"
+    git -C "$primary" config user.email human@example.com
+    git -C "$primary" config user.name Human
+    ( cd "$primary" && echo seed > seed.txt && git add seed.txt \
+        && git commit -q -m seed )
+    git -C "$primary" worktree add -q "$wt" -b spec-branch
+    printf '%s\n' 'msg' > "${primary}/.git/PCM_MSG"
+    printf '%s\n' 'msg' > "${primary}/.git/worktrees/wt/PCM_MSG"
+  }
+
+  cleanup() {
+    rm -rf "$base"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  commit_count() {
+    git -C "$primary" rev-list --count HEAD
+  }
+
+  # Direct hook invocations: cwd selects primary vs linked worktree; env is
+  # set explicitly per row because the suite itself may run under CLAUDECODE=1.
+  agent_hook_in() {
+    cd "$1" && env -u CLAUDE_CODE_USER_EMAIL CLAUDECODE=1 \
+      sh "$hook" "$2"
+  }
+  human_hook_in() {
+    cd "$1" && env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL \
+      sh "$hook" "$2"
+  }
+
+  It 'blocks an agent commit in the primary checkout'
+    When run agent_hook_in "$primary" .git/PCM_MSG
+    The status should equal 1
+    The stderr should include 'primary checkout'
+    The stderr should include 'worktree'
+  End
+
+  It 'passes an agent commit in a linked worktree'
+    When run agent_hook_in "$wt" ../primary/.git/worktrees/wt/PCM_MSG
+    The status should equal 0
+    The stderr should equal ''
+  End
+
+  It 'passes a human commit in the primary checkout'
+    When run human_hook_in "$primary" .git/PCM_MSG
+    The status should equal 0
+    The stderr should equal ''
+  End
+
+  It 'passes an agent commit when the valve marks the checkout agent-dedicated'
+    git -C "$primary" config pfblockerng.allowprimarycommit true
+    When run agent_hook_in "$primary" .git/PCM_MSG
+    The status should equal 0
+    The stderr should equal ''
+  End
+
+  It 'passes an agent commit in a managed-remote session (owner email marker set)'
+    managed_hook() {
+      cd "$primary" && env CLAUDECODE=1 CLAUDE_CODE_USER_EMAIL=owner@example.com \
+        sh "$hook" .git/PCM_MSG
+    }
+    When run managed_hook
+    The status should equal 0
+    The stderr should equal ''
+  End
+
+  # The money rows: a REAL verify-skipping commit (git commit -n skips
+  # pre-commit/commit-msg but not prepare-commit-msg). The human control row
+  # proves the abort is CAUSED by the agent guard, not by the harness setup.
+  It 'aborts a verify-skipping agent commit in the primary checkout'
+    real_commit() {
+      cd "$primary" \
+        && git config core.hooksPath "${PFB_ROOT}/.githooks" \
+        && echo change >> seed.txt && git add seed.txt \
+        && env -u CLAUDE_CODE_USER_EMAIL CLAUDECODE=1 git commit -n -m blocked
+    }
+    When run real_commit
+    The status should not equal 0
+    The stderr should include 'primary checkout'
+    The result of function commit_count should equal 1
+  End
+
+  It 'lands the same verify-skipping commit for a human (control)'
+    real_commit_human() {
+      cd "$primary" \
+        && git config core.hooksPath "${PFB_ROOT}/.githooks" \
+        && echo change >> seed.txt && git add seed.txt \
+        && env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL git commit -n -m allowed
+    }
+    When run real_commit_human
+    The status should equal 0
+    The result of function commit_count should equal 2
+  End
+End


### PR DESCRIPTION
Closes #1262.

Operation-layer replacement for the rejected Rule E text scan. The six fail-open forges killed regex over the *utterance* (the PreToolUse payload); this enforces at the *operation* instead: `.githooks/prepare-commit-msg` aborts an agent commit (`CLAUDECODE=1`) in the primary checkout, however the command was spelled (`-C`, `--work-tree`, subshell `cd`, alias, script). Nothing parses command text, so prose, docs, and commit messages that mention git commands can never trip it — the forgery class has nothing to forge.

## How it decides

Pure git state: inside the hook run, `git rev-parse --git-dir` equals `--git-common-dir` only in the primary checkout (linked worktrees resolve to `.git/worktrees/<name>`). Paths are normalized with `cd`/`pwd -P` — no `--path-format`, which needs git ≥ 2.31 (Ubuntu 20.04 ships 2.25) — so any contributor git from 2.5 up works. POSIX sh, shellcheck-clean.

It lives in `prepare-commit-msg` because that hook still runs when verification is skipped and its nonzero exit aborts the commit (probed in-session on git 2.55), closing the one accident-shaped bypass that skips `pre-commit`.

## Who is exempt

- Humans (no `CLAUDECODE`) — untouched.
- Managed-remote sessions (`CLAUDE_CODE_USER_EMAIL` set, the marker this hook already documents): the whole checkout is agent-dedicated, there is no human working tree to protect.
- Any checkout explicitly marked `git config pfblockerng.allowprimarycommit true`.

## Tests (red → green, frozen)

New `tests/shell/githooks_prepare_commit_msg_guard_spec.sh` — 7 rows: block in primary, pass in worktree, pass for humans, both exemptions, plus a real `git commit -n` integration pair (agent blocked with the commit count pinned at 1; human control lands, proving the abort is caused by the guard). Authored and run RED before the hook edit (the two guard rows failed: the commit landed), frozen at `git hash-object` `97bf03dc08b24ec2184c9b1d2e6843e276712424`, green 7/7 zero-edits after; `verify-red-proof.sh` re-verified mechanically (FREEZE-OK / RED-OK / GREEN-OK / PASS). This branch's own commit was made from a linked worktree under the new hook — the pass path is dogfooded.

## Accepted residuals (documented in #1262)

Other cwd-relying mutations (`reset --hard`, `clean`, `stash`) have no vetoing hook; plumbing (`commit-tree` + `update-ref`) and `-c core.hooksPath=` bypass hooks entirely — deliberate circumvention, the same accepted class as the alias limitation in `claude-bash-guard.sh`. Protected-branch pushes remain the server's layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7sfuRjNkeeArgQhrpb1mW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards to prevent agent-created commits from being made in the primary checkout unless explicitly permitted.
  * Agent commits remain supported in linked worktrees and approved managed environments.

* **Documentation**
  * Updated commit-hook documentation to describe the new safeguards and allowed exceptions.

* **Tests**
  * Added coverage for blocked and permitted agent commits, human commits, override settings, and verification-skipping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->