### PR TITLE
dev: deny an agent force-push over unfetched remote history (#1307)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,11 +1,16 @@
 #!/bin/sh
-# Enforces the release tag scheme before any push reaches the remote.
-# Single source of truth for the scheme: scripts/release-version.sh.
+# Enforces the release tag scheme before any push reaches the remote, and — for
+# agent pushes — force-with-lease semantics by EFFECT (issue #1307).
+# Single source of truth for the tag scheme: scripts/release-version.sh.
 #
 # Rules:
 #   - vX.Y.Z                       -> commit must be reachable from origin/main   (stable)
 #   - vX.Y.Z.alpha.N|.beta.N|.rc.N -> commit on origin/devel but NOT origin/main  (prerelease)
 #   - neither branch, or a malformed version tag -> rejected
+#   - agent (CLAUDECODE=1) branch push rewriting remote history -> allowed only
+#     when the advertised remote oid equals the local remote-tracking ref, i.e.
+#     the history being overwritten was fetched (--force-with-lease's check,
+#     applied to the push's effect regardless of how it was spelled)
 #
 # Enable: git config core.hooksPath .githooks
 
@@ -13,7 +18,10 @@ z40="0000000000000000000000000000000000000000"
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || ROOT="."
 CLASSIFY="${ROOT}/scripts/release-version.sh"
 
-while IFS=' ' read -r local_ref local_sha remote_ref _remote_sha; do
+# Both loops below consume the per-ref update list, so capture stdin once.
+updates=$(cat)
+
+while IFS=' ' read -r _local_ref local_sha remote_ref _remote_sha; do
     # Only inspect tag pushes
     case "$remote_ref" in refs/tags/*) ;; *) continue ;; esac
 
@@ -55,6 +63,33 @@ while IFS=' ' read -r local_ref local_sha remote_ref _remote_sha; do
         printf '%s\n' "$err" | sed 's/^/       /' >&2
         exit 1
     fi
-done
+done <<PFB_TAG_UPDATES
+$updates
+PFB_TAG_UPDATES
+
+# Agent lease-by-effect guard (issue #1307): a branch push whose advertised
+# remote oid is NOT an ancestor of the local oid rewrites remote history; an
+# agent may do that only over history it has fetched (remote oid == the
+# remote-tracking ref). An unknown remote oid fails the ancestor check and,
+# never fetched, the tracking match too -> deny. Humans are untouched.
+if [ "${CLAUDECODE:-}" = "1" ]; then
+    remote_name="${1:-origin}"
+    while IFS=' ' read -r _lref lsha rref rsha; do
+        case "$rref" in refs/heads/*) ;; *) continue ;; esac
+        [ "$lsha" = "$z40" ] && continue   # branch deletion
+        [ "$rsha" = "$z40" ] && continue   # branch creation
+        git merge-base --is-ancestor "$rsha" "$lsha" 2>/dev/null && continue
+        branch="${rref#refs/heads/}"
+        tracking=$(git rev-parse --verify "refs/remotes/${remote_name}/${branch}" 2>/dev/null) || tracking=""
+        if [ "$rsha" != "$tracking" ]; then
+            echo "error: agent force-push over unfetched history of '${branch}' blocked (issue #1307)." >&2
+            echo "       The remote moved past your remote-tracking ref: run 'git fetch ${remote_name}'," >&2
+            echo "       rebase onto the new tip, then push with --force-with-lease." >&2
+            exit 1
+        fi
+    done <<PFB_LEASE_UPDATES
+$updates
+PFB_LEASE_UPDATES
+fi
 
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -67,22 +67,19 @@ done <<PFB_TAG_UPDATES
 $updates
 PFB_TAG_UPDATES
 
-# Agent lease-by-effect guard (issue #1307): a branch push whose advertised
-# remote oid is NOT an ancestor of the local oid rewrites remote history; an
-# agent may do that only over history it has fetched (remote oid == the
-# remote-tracking ref). An unknown remote oid fails the ancestor check and,
-# never fetched, the tracking match too -> deny. Humans are untouched.
+# Agent lease-by-effect guard (issue #1307): deny an agent branch rewrite over
+# remote history it never fetched (advertised remote oid != remote-tracking ref).
 if [ "${CLAUDECODE:-}" = "1" ]; then
     remote_name="${1:-origin}"
-    while IFS=' ' read -r _lref lsha rref rsha; do
-        case "$rref" in refs/heads/*) ;; *) continue ;; esac
-        [ "$lsha" = "$z40" ] && continue   # branch deletion
-        [ "$rsha" = "$z40" ] && continue   # branch creation
-        git merge-base --is-ancestor "$rsha" "$lsha" 2>/dev/null && continue
-        branch="${rref#refs/heads/}"
+    while IFS=' ' read -r _local_ref local_sha remote_ref remote_sha; do
+        case "$remote_ref" in refs/heads/*) ;; *) continue ;; esac
+        [ "$local_sha" = "$z40" ] && continue   # branch deletion
+        [ "$remote_sha" = "$z40" ] && continue  # branch creation
+        git merge-base --is-ancestor "$remote_sha" "$local_sha" 2>/dev/null && continue
+        branch="${remote_ref#refs/heads/}"
         tracking=$(git rev-parse --verify "refs/remotes/${remote_name}/${branch}" 2>/dev/null) || tracking=""
-        if [ "$rsha" != "$tracking" ]; then
-            echo "error: agent force-push over unfetched history of '${branch}' blocked (issue #1307)." >&2
+        if [ "$remote_sha" != "$tracking" ]; then
+            echo "error: agent push would rewrite unfetched history of '${branch}' (issue #1307)." >&2
             echo "       The remote moved past your remote-tracking ref: run 'git fetch ${remote_name}'," >&2
             echo "       rebase onto the new tip, then push with --force-with-lease." >&2
             exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -595,7 +595,10 @@ Activate once after cloning: `sh scripts/setup-hooks.sh` (sets `core.hooksPath`)
   via `CLAUDE_CODE_USER_EMAIL` (managed-remote) or
   `git config pfblockerng.allowprimarycommit true`), then appends the owner's
   `Co-authored-by:` trailer (see Commit style); runs even under `--no-verify`.
-- **`pre-push`** — enforces the release tag scheme via `scripts/release-version.sh`.
+- **`pre-push`** — enforces the release tag scheme via `scripts/release-version.sh`; also
+  denies an agent (`CLAUDECODE=1`) branch push that would rewrite remote history the agent
+  never fetched (advertised remote oid must equal the remote-tracking ref — issue #1307,
+  `--force-with-lease`'s check enforced by effect).
 
 ---
 

--- a/tests/shell/githooks_pre_push_lease_spec.sh
+++ b/tests/shell/githooks_pre_push_lease_spec.sh
@@ -1,0 +1,157 @@
+#shellcheck shell=sh
+# .githooks/pre-push agent lease-by-effect guard (issue #1307): an agent
+# (CLAUDECODE=1) push that rewrites a remote branch's history is allowed only
+# when the hook's advertised remote oid equals the local remote-tracking ref —
+# i.e. the agent has fetched the history it is about to overwrite. That is
+# --force-with-lease's check, enforced on the push's EFFECT, so an alias or a
+# script that never spells a force flag is still caught. Fast-forwards, branch
+# creations/deletions, tag refs, and humans (no CLAUDECODE) pass untouched.
+#
+# Fixture: a bare remote, clone A (the agent, whose tracking ref goes stale),
+# and clone B (another session that advances the remote behind A's back).
+# Direct rows feed the hook its stdin contract ("<lref> <lsha> <rref> <rsha>")
+# from A; the integration rows run a real `git push --force` through
+# core.hooksPath with a human control proving the deny is caused by the guard.
+
+Describe 'pre-push agent lease-by-effect guard (issue #1307)'
+  hook="${PFB_ROOT}/.githooks/pre-push"
+  Z40="0000000000000000000000000000000000000000"
+
+  setup() {
+    scrub_git_env
+    base="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/prepushlease.XXXXXX")"
+    git init -q --bare "${base}/remote.git"
+    git clone -q "${base}/remote.git" "${base}/A" 2>/dev/null
+    git -C "${base}/A" config user.email a@example.com
+    git -C "${base}/A" config user.name A
+    ( cd "${base}/A" && git checkout -q -b devel && echo one > f \
+        && git add f && git commit -q -m c1 && git push -q origin devel )
+    git clone -q "${base}/remote.git" "${base}/B" 2>/dev/null
+    git -C "${base}/B" config user.email b@example.com
+    git -C "${base}/B" config user.name B
+    ( cd "${base}/B" && git checkout -q devel && echo two >> f \
+        && git add f && git commit -q -m c2-other && git push -q origin devel )
+    # A now diverges; its tracking ref still holds c1 while the remote is at c2.
+    ( cd "${base}/A" && git commit -q --amend -m c1-amended )
+    a_local="$(git -C "${base}/A" rev-parse devel)"
+    a_tracking="$(git -C "${base}/A" rev-parse refs/remotes/origin/devel)"
+    remote_tip="$(git -C "${base}/remote.git" rev-parse refs/heads/devel)"
+  }
+
+  cleanup() {
+    rm -rf "$base"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  remote_tip_now() {
+    git -C "${base}/remote.git" rev-parse refs/heads/devel
+  }
+
+  # Feed one stdin line to the hook from inside clone A, agent env explicit
+  # per row (the suite itself may run under CLAUDECODE=1).
+  agent_hook() {
+    cd "${base}/A" && printf '%s\n' "$1" \
+      | env -u CLAUDE_CODE_USER_EMAIL CLAUDECODE=1 sh "$hook" origin "${base}/remote.git"
+  }
+  human_hook() {
+    cd "${base}/A" && printf '%s\n' "$1" \
+      | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL sh "$hook" origin "${base}/remote.git"
+  }
+
+  It 'denies an agent history rewrite when the remote moved past the tracking ref'
+    When run agent_hook "refs/heads/devel $a_local refs/heads/devel $remote_tip"
+    The status should equal 1
+    The stderr should include 'unfetched'
+    The stderr should include 'git fetch origin'
+  End
+
+  It 'allows the same rewrite once the tracking ref matches the advertised remote'
+    git -C "${base}/A" fetch -q origin
+    fresh_tracking() {
+      tracking="$(git -C "${base}/A" rev-parse refs/remotes/origin/devel)"
+      [ "$tracking" = "$remote_tip" ] || { echo "tracking=$tracking != remote=$remote_tip" >&2; return 1; }
+      agent_hook "refs/heads/devel $a_local refs/heads/devel $remote_tip"
+    }
+    When run fresh_tracking
+    The status should equal 0
+    The stderr should equal ''
+  End
+
+  It 'allows an agent fast-forward push with a stale tracking ref'
+    ff_push() {
+      cd "${base}/A" && git fetch -q origin \
+        && git update-ref refs/remotes/origin/devel "$a_tracking" \
+        && git checkout -q -B devel "$remote_tip" && echo three >> f \
+        && git add f && git commit -q -m c3 \
+        && agent_hook "refs/heads/devel $(git rev-parse devel) refs/heads/devel $remote_tip"
+    }
+    When run ff_push
+    The status should equal 0
+    The stderr should equal ''
+  End
+
+  It 'allows an agent branch creation'
+    When run agent_hook "refs/heads/new $a_local refs/heads/new $Z40"
+    The status should equal 0
+    The stderr should equal ''
+  End
+
+  It 'allows an agent branch deletion'
+    When run agent_hook "refs/heads/devel $Z40 refs/heads/devel $remote_tip"
+    The status should equal 0
+    The stderr should equal ''
+  End
+
+  It 'ignores tag refs (a non-version tag passes untouched)'
+    When run agent_hook "refs/tags/scratch $a_local refs/tags/scratch $remote_tip"
+    The status should equal 0
+    The stderr should equal ''
+  End
+
+  It 'denies a multi-ref push whose second ref is the stale rewrite'
+    two_refs() {
+      cd "${base}/A" && printf '%s\n%s\n' \
+        "refs/heads/new $a_local refs/heads/new $Z40" \
+        "refs/heads/devel $a_local refs/heads/devel $remote_tip" \
+        | env -u CLAUDE_CODE_USER_EMAIL CLAUDECODE=1 sh "$hook" origin "${base}/remote.git"
+    }
+    When run two_refs
+    The status should equal 1
+    The stderr should include 'unfetched'
+  End
+
+  It 'leaves a human history rewrite to git itself'
+    When run human_hook "refs/heads/devel $a_local refs/heads/devel $remote_tip"
+    The status should equal 0
+    The stderr should equal ''
+  End
+
+  # The money rows: a REAL bare force push through core.hooksPath. The human
+  # control proves the abort is caused by the guard, not the harness setup.
+  It 'blocks a real agent force-push and leaves the remote tip untouched'
+    real_force() {
+      cd "${base}/A" \
+        && git config core.hooksPath "${PFB_ROOT}/.githooks" \
+        && [ "$(remote_tip_now)" = "$remote_tip" ] \
+        && env -u CLAUDE_CODE_USER_EMAIL CLAUDECODE=1 git push --force origin devel
+    }
+    When run real_force
+    The status should not equal 0
+    The stderr should include 'unfetched'
+    The result of function remote_tip_now should equal "$remote_tip"
+  End
+
+  It 'lands the same real force-push for a human (control)'
+    real_force_human() {
+      cd "${base}/A" \
+        && git config core.hooksPath "${PFB_ROOT}/.githooks" \
+        && [ "$(remote_tip_now)" = "$remote_tip" ] \
+        && env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL git push --force origin devel
+    }
+    When run real_force_human
+    The status should equal 0
+    The result of function remote_tip_now should equal "$a_local"
+  End
+End

--- a/tests/shell/githooks_pre_push_tag_scheme_spec.sh
+++ b/tests/shell/githooks_pre_push_tag_scheme_spec.sh
@@ -1,0 +1,38 @@
+#shellcheck shell=sh
+# .githooks/pre-push tag-scheme oracle: pins that the release-tag validation
+# loop still consumes the per-ref update list after the capture-once stdin
+# refactor (issue #1307) — a silently empty feed would disable tag enforcement
+# with no other test noticing. Behaviour-preserving pin: green before and after.
+
+Describe 'pre-push tag-scheme loop still consumes the update list (issue #1307)'
+  hook="${PFB_ROOT}/.githooks/pre-push"
+
+  setup() {
+    scrub_git_env
+    base="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/prepushtag.XXXXXX")"
+    git init -q -b devel "${base}/repo"
+    git -C "${base}/repo" config user.email t@example.com
+    git -C "${base}/repo" config user.name T
+    ( cd "${base}/repo" && echo one > f && git add f && git commit -q -m c1 )
+    sha="$(git -C "${base}/repo" rev-parse HEAD)"
+  }
+
+  cleanup() {
+    rm -rf "$base"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'still rejects a versioned tag unreachable from origin/main and origin/devel'
+    push_tag() {
+      # No origin/main or origin/devel exists here, so a versioned tag must
+      # hit the reachability error — proving the loop actually read the line.
+      cd "${base}/repo" && printf '%s\n' "refs/tags/v9.9.9 $sha refs/tags/v9.9.9 0000000000000000000000000000000000000000" \
+        | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL sh "$hook" origin "${base}/repo"
+    }
+    When run push_tag
+    The status should equal 1
+    The stderr should include 'reachable'
+  End
+End


### PR DESCRIPTION
Closes #1307. Companion to PR #1304 (the #1262 rules-review follow-ups).

`claude-bash-guard.sh` Rule B judges the *spelling* of a push; this adds the operation-layer backstop that judges its *effect*. The pre-push hook receives each ref's advertised remote oid (probed in-session: it is the remote's true tip even when the local remote-tracking ref is stale, and a client-side lease rejection removes the ref from the hook's list entirely — so the hook only sees pushes that would actually land). For an agent (`CLAUDECODE=1`) branch push that rewrites remote history, the guard requires the advertised remote oid to equal `refs/remotes/<remote>/<branch>` — exactly the lease flag's check, enforced regardless of how the push was spelled (a bare force flag, an alias, a script). An unfetched remote oid fails both the ancestor check and the tracking match, so it denies with "fetch first" guidance.

Untouched: fast-forwards, branch creations, deletions, tag refs, and humans (no `CLAUDECODE`). The Rule B text scan stays — it denies at the tool layer before anything executes; this hook is the layer an evasion cannot reach. POSIX sh, dash-clean, no git version cliffs.

## Refactor note

The existing tag-scheme loop consumed the hook's stdin; the guard needs the same lines, so stdin is captured once and both loops are heredoc-fed. Tag validation logic itself is untouched, and a new oracle spec (`githooks_pre_push_tag_scheme_spec.sh`) pins that the loop still consumes the update list — verified green against both the pre-refactor (devel) and post-refactor hook in-session.

## Tests (red → green, frozen)

`tests/shell/githooks_pre_push_lease_spec.sh` — 10 rows: stale-rewrite deny, fresh-tracking allow, fast-forward / creation / deletion / tag-ref / human passes, a multi-ref deny, and a real forced-push integration pair (agent blocked with the remote tip pinned unchanged; human control lands, proving causation). Authored and run RED before the hook edit (3 deny rows failed: the scratch remote was clobbered), frozen at `git hash-object` `22abc616b8c54f9546d47b48c63fdd9025fdff2a`, green 10/10 zero-edits after; `verify-red-proof.sh`: FREEZE-OK / RED-OK / GREEN-OK / PASS.

Meta note: while opening this very PR, Rule B's documented prose false-positive fired on the draft PR body (it described forced pushes next to a push command in the same tool payload) — the third in-session demonstration of why enforcement is moving to layers that do not parse command text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7sfuRjNkeeArgQhrpb1mW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards for automated force-pushes, preventing overwrites when the remote branch has changed unexpectedly.
  * Safe fast-forward pushes, branch creation, and branch deletion continue to work as expected.
* **Bug Fixes**
  * Improved pre-push validation for versioned tags and multi-reference pushes.
  * Preserved tag policy enforcement when multiple updates are pushed together.
* **Tests**
  * Added coverage for lease protection, tag validation, and real push scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->