### PR TITLE
scripts: rewire token-savior MCP for real utilization

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,9 +2,7 @@
   "effortLevel": "xhigh",
   "env": {
     "SHELL": "bash",
-    "MCP_TIMEOUT": "120000",
-    "TS_BASH_COMPACT": "0",
-    "TS_BASH_REWRITE": "1"
+    "MCP_TIMEOUT": "120000"
   },
   "enableAllProjectMcpServers": true,
   "statusLine": {
@@ -49,11 +47,6 @@
           },
           {
             "type": "command",
-            "command": "sh \"${CLAUDE_PROJECT_DIR:-.}/scripts/ts-hook.sh\" bash_rewriter_hook",
-            "timeout": 2000
-          },
-          {
-            "type": "command",
             "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && python3 scripts/check_retired_tokens.py --claude-hook || true"
           }
         ]
@@ -61,7 +54,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|WebFetch|Read|Grep|mcp__playwright__.*|mcp__token-savior-recall__(search_codebase|get_function_source|get_class_source)",
+        "matcher": "Bash|WebFetch|Read|Grep|mcp__playwright__.*",
         "hooks": [
           {
             "type": "command",
@@ -120,7 +113,7 @@
           },
           {
             "type": "command",
-            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"DISCIPLINE (CLAUDE.md, every turn): (1) Evidence before conclusion — a claim without a run artifact is ASSUMED; probe environmental facts before writing them into code/comments/workflows. (2) Debugging: >=2 hypotheses + a discriminating probe BEFORE any fix edit. (3) Scope: enumerate EVERY sibling axis (v4/v6, ports, CE/Plus versions, callers, parse modes) from grep or the version matrix — never from memory; never hardcode env-derived values. (4) Done = executed verification with pasted output; red->green is run, never reasoned. (5) No self-exemption from MUST rules — deviation requires quoting the authorizing user message. (6) Delegation follows CLAUDE.md The delegation contract (brief/handoff/gate fields). (7) Output stays caveman-terse + ponytail-lazy; terse prose, FULL checks.\"}}'"
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"DISCIPLINE (CLAUDE.md, every turn): (1) Evidence before conclusion — a claim without a run artifact is ASSUMED; probe environmental facts before writing them into code/comments/workflows. (2) Debugging: >=2 hypotheses + a discriminating probe BEFORE any fix edit. (3) Scope: enumerate EVERY sibling axis (v4/v6, ports, CE/Plus versions, callers, parse modes) from grep or the version matrix — never from memory; never hardcode env-derived values. (4) Done = executed verification with pasted output; red->green is run, never reasoned. (5) No self-exemption from MUST rules — deviation requires quoting the authorizing user message. (6) Delegation follows CLAUDE.md The delegation contract (brief/handoff/gate fields). (7) Output stays caveman-terse + ponytail-lazy; terse prose, FULL checks. (8) CODE LOOKUP — prefer the token-savior-recall MCP tools (search_codebase, find_symbol, get_function_source, get_call_chain; load via ToolSearch) over raw Grep/Read whole-file dumps when locating a symbol or reading a single function/class body; fall back to Grep/Read only for files the index does not cover.\"}}'"
           }
         ]
       }

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -21,12 +21,22 @@
 set -eu
 
 venv="${TS_VENV:-${XDG_CACHE_HOME:-$HOME/.cache}/token-savior/venv}"
-# The rebuild path below rm -rf's $venv — refuse anything but an absolute,
-# non-root path so a mis-set TS_VENV ('.', '', '/') can never aim it wrong.
+# Trim trailing slashes so the lock and dirname derivations below treat $venv
+# as the final path component (a trailing slash once nested the lock inside
+# the not-yet-created venv and broke every fresh install).
+while :; do case "$venv" in */) venv="${venv%/}" ;; *) break ;; esac; done
+# The rebuild path below rm -rf's $venv — string checks never resolve '..'
+# (only the kernel does, at rm time), so refuse '..' segments and '//' along
+# with anything non-absolute ('.', '', '/', relative paths).
 case "$venv" in
-	/?*) ;;
-	*) echo "mcp-token-savior: refusing venv path '$venv' — TS_VENV must be an absolute path" >&2; exit 1 ;;
+	*//*|*/..|*/../*) venv_bad=1 ;;
+	/?*) venv_bad=0 ;;
+	*) venv_bad=1 ;;
 esac
+if [ "$venv_bad" = 1 ]; then
+	echo "mcp-token-savior: refusing venv path '$venv' — TS_VENV must be an absolute path without '..' or '//' segments" >&2
+	exit 1
+fi
 bin="$venv/bin/token-savior"
 stamp="$venv/.pfb-ts-source"
 TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp] @ git+https://github.com/andrebrait/token-savior@10aa65543995e4cfbc6aa341eae4d6dd31348da6}"

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -1,28 +1,40 @@
 #!/bin/sh
 # mcp-token-savior.sh — stdio launcher for the token-savior MCP server (wired via .mcp.json).
-# First run installs token-savior-recall[mcp] (https://github.com/Mibayy/token-savior) into a
-# per-user cached venv, then execs it; later runs exec directly. Requires python3 >= 3.11.
+# Installs TS_SOURCE into a per-user cached venv, then execs it. The default TS_SOURCE is the
+# andrebrait/token-savior fork's `integration` branch pinned by commit — it carries fixes and
+# language support not yet merged upstream (Mibayy/token-savior PRs #47 #53 #54 #57 #58 #59);
+# repoint to PyPI's token-savior-recall[mcp] once those merge. A TS_SOURCE change (e.g. a new
+# pinned commit) is detected via the .pfb-ts-source stamp and triggers a clean venv rebuild.
+# Requires python3 >= 3.11 and git (pip installs from a git URL).
 # Env (all optional):
 #   WORKSPACE_ROOTS        comma-separated project roots (default: current directory)
 #   TOKEN_SAVIOR_PROFILE   server tool profile (default: optimized)
 #   TS_VENV                venv location (default: ${XDG_CACHE_HOME:-$HOME/.cache}/token-savior/venv)
+#   TS_SOURCE              pip requirement to install (default: the pinned fork commit)
 #   INCLUDE_PATTERNS       colon-separated index globs; the default below REPLACES the
 #                          server's built-in list, which lacks .php/.inc/.sh — this repo's
 #                          main languages (globs from the git ls-files extension histogram)
+#   TOKEN_SAVIOR_MAX_FILE_SIZE  index size cap in bytes (default here 2000000 —
+#                          pfblockerng.inc is ~844 KB; the server's 500 KB default skips it)
 set -eu
 
 venv="${TS_VENV:-${XDG_CACHE_HOME:-$HOME/.cache}/token-savior/venv}"
 bin="$venv/bin/token-savior"
+stamp="$venv/.pfb-ts-source"
+TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp] @ git+https://github.com/andrebrait/token-savior@10aa65543995e4cfbc6aa341eae4d6dd31348da6}"
 
 # stdout is the MCP stdio channel — install chatter must stay on stderr
-if [ ! -x "$bin" ]; then
+if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then
+	rm -rf "$venv"
 	python3 -m venv "$venv" 1>&2
-	"$venv/bin/pip" install --quiet "token-savior-recall[mcp]" 1>&2
+	"$venv/bin/pip" install --quiet "$TS_SOURCE" 1>&2
+	printf '%s\n' "$TS_SOURCE" > "$stamp"
 fi
 
 WORKSPACE_ROOTS="${WORKSPACE_ROOTS:-$PWD}"
 TOKEN_SAVIOR_CLIENT="${TOKEN_SAVIOR_CLIENT:-claude-code}"
 TOKEN_SAVIOR_PROFILE="${TOKEN_SAVIOR_PROFILE:-optimized}"
 INCLUDE_PATTERNS="${INCLUDE_PATTERNS:-**/*.py:**/*.php:**/*.inc:**/*.sh:**/*.js:**/*.md:**/*.txt:**/*.json:**/*.jsonc:**/*.yml:**/*.yaml:**/*.xml:**/*.conf:**/*.toml:**/*.neon}"
-export WORKSPACE_ROOTS TOKEN_SAVIOR_CLIENT TOKEN_SAVIOR_PROFILE INCLUDE_PATTERNS
+TOKEN_SAVIOR_MAX_FILE_SIZE="${TOKEN_SAVIOR_MAX_FILE_SIZE:-2000000}"
+export WORKSPACE_ROOTS TOKEN_SAVIOR_CLIENT TOKEN_SAVIOR_PROFILE INCLUDE_PATTERNS TOKEN_SAVIOR_MAX_FILE_SIZE
 exec "$bin"

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -6,6 +6,9 @@
 #   WORKSPACE_ROOTS        comma-separated project roots (default: current directory)
 #   TOKEN_SAVIOR_PROFILE   server tool profile (default: optimized)
 #   TS_VENV                venv location (default: ${XDG_CACHE_HOME:-$HOME/.cache}/token-savior/venv)
+#   INCLUDE_PATTERNS       colon-separated index globs; the default below REPLACES the
+#                          server's built-in list, which lacks .php/.inc/.sh — this repo's
+#                          main languages (globs from the git ls-files extension histogram)
 set -eu
 
 venv="${TS_VENV:-${XDG_CACHE_HOME:-$HOME/.cache}/token-savior/venv}"
@@ -20,5 +23,6 @@ fi
 WORKSPACE_ROOTS="${WORKSPACE_ROOTS:-$PWD}"
 TOKEN_SAVIOR_CLIENT="${TOKEN_SAVIOR_CLIENT:-claude-code}"
 TOKEN_SAVIOR_PROFILE="${TOKEN_SAVIOR_PROFILE:-optimized}"
-export WORKSPACE_ROOTS TOKEN_SAVIOR_CLIENT TOKEN_SAVIOR_PROFILE
+INCLUDE_PATTERNS="${INCLUDE_PATTERNS:-**/*.py:**/*.php:**/*.inc:**/*.sh:**/*.js:**/*.md:**/*.txt:**/*.json:**/*.jsonc:**/*.yml:**/*.yaml:**/*.xml:**/*.conf:**/*.toml:**/*.neon}"
+export WORKSPACE_ROOTS TOKEN_SAVIOR_CLIENT TOKEN_SAVIOR_PROFILE INCLUDE_PATTERNS
 exec "$bin"

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -2,15 +2,17 @@
 # mcp-token-savior.sh — stdio launcher for the token-savior MCP server (wired via .mcp.json).
 # Installs TS_SOURCE into a per-user cached venv, then execs it. The default TS_SOURCE is the
 # andrebrait/token-savior fork's `integration` branch pinned by commit — it carries fixes and
-# language support not yet merged upstream (Mibayy/token-savior PRs #47 #53 #54 #57 #58 #59);
-# repoint to PyPI's token-savior-recall[mcp] once those merge. A TS_SOURCE change (e.g. a new
-# pinned commit) is detected via the .pfb-ts-source stamp and triggers a clean venv rebuild.
-# Requires python3 >= 3.11 and git (pip installs from a git URL).
+# language support not yet merged upstream (Mibayy/token-savior PRs #47 #53 #54 #57 #58 #59
+# #60); repoint to PyPI's token-savior-recall[mcp] once those merge. A TS_SOURCE change (e.g. a
+# new pinned commit) is detected via the .pfb-ts-source stamp and triggers a clean venv rebuild;
+# a mkdir lock serializes concurrent sessions racing that rebuild (the venv is one shared
+# per-user cache). Requires python3 >= 3.11 and git (pip installs from a git URL).
 # Env (all optional):
 #   WORKSPACE_ROOTS        comma-separated project roots (default: current directory)
 #   TOKEN_SAVIOR_PROFILE   server tool profile (default: optimized)
 #   TS_VENV                venv location (default: ${XDG_CACHE_HOME:-$HOME/.cache}/token-savior/venv)
 #   TS_SOURCE              pip requirement to install (default: the pinned fork commit)
+#   TS_LOCK_WAIT           max seconds to wait on another session's rebuild (default 300)
 #   INCLUDE_PATTERNS       colon-separated index globs; the default below REPLACES the
 #                          server's built-in list, which lacks .php/.inc/.sh — this repo's
 #                          main languages (globs from the git ls-files extension histogram)
@@ -19,16 +21,46 @@
 set -eu
 
 venv="${TS_VENV:-${XDG_CACHE_HOME:-$HOME/.cache}/token-savior/venv}"
+# The rebuild path below rm -rf's $venv — refuse anything but an absolute,
+# non-root path so a mis-set TS_VENV ('.', '', '/') can never aim it wrong.
+case "$venv" in
+	/?*) ;;
+	*) echo "mcp-token-savior: refusing venv path '$venv' — TS_VENV must be an absolute path" >&2; exit 1 ;;
+esac
 bin="$venv/bin/token-savior"
 stamp="$venv/.pfb-ts-source"
 TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp] @ git+https://github.com/andrebrait/token-savior@10aa65543995e4cfbc6aa341eae4d6dd31348da6}"
 
 # stdout is the MCP stdio channel — install chatter must stay on stderr
 if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then
-	rm -rf "$venv"
-	python3 -m venv "$venv" 1>&2
-	"$venv/bin/pip" install --quiet "$TS_SOURCE" 1>&2
-	printf '%s\n' "$TS_SOURCE" > "$stamp"
+	lock="${venv}.rebuild.lock"
+	mkdir -p "$(dirname "$venv")"
+	if mkdir "$lock" 2>/dev/null; then
+		# set -e: a failed install still fires the trap, so a crashed rebuild
+		# never leaves the lock behind for the next session to time out on.
+		trap 'rmdir "$lock" 2>/dev/null' EXIT
+		# Re-check under the lock — a concurrent session may have finished the
+		# same rebuild while this one waited on mkdir.
+		if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then
+			rm -rf "$venv"
+			python3 -m venv "$venv" 1>&2
+			"$venv/bin/pip" install --quiet "$TS_SOURCE" 1>&2
+			printf '%s\n' "$TS_SOURCE" > "$stamp"
+		fi
+		rmdir "$lock" 2>/dev/null
+		trap - EXIT
+	else
+		waited=0
+		max_wait="${TS_LOCK_WAIT:-300}"
+		while [ -d "$lock" ] && [ "$waited" -lt "$max_wait" ]; do
+			sleep 1
+			waited=$((waited + 1))
+		done
+		if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then
+			echo "mcp-token-savior: concurrent rebuild did not complete within ${max_wait}s — if no other session is installing, remove '$lock' and retry" >&2
+			exit 1
+		fi
+	fi
 fi
 
 WORKSPACE_ROOTS="${WORKSPACE_ROOTS:-$PWD}"

--- a/scripts/ts-hook.sh
+++ b/scripts/ts-hook.sh
@@ -4,10 +4,8 @@
 # scripts/mcp-token-savior.sh installs. Pass-through no-op when the venv is absent
 # (first session, before the MCP launcher has installed it).
 # Env (optional): TS_VENV — venv location (default: ${XDG_CACHE_HOME:-$HOME/.cache}/token-savior/venv).
-# TS_BASH_REWRITE/TS_BASH_COMPACT come from .claude/settings.json env (rewrite on,
-# compact off): the compact git compactors parse only human-format output, so combined
-# with the rewriter's porcelain/oneline forms they render dirty trees as "clean" and
-# diffs/logs as empty (token-savior-recall 4.4.1).
+# Only tool_capture_hook is wired in .claude/settings.json — the bash rewriter/compactors
+# stay unwired (Bash-output compaction is rtk's job now).
 set -eu
 
 py="${TS_VENV:-${XDG_CACHE_HOME:-$HOME/.cache}/token-savior/venv}/bin/python3"

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -154,4 +154,30 @@ EOF
     The stderr should include 'refusing'
     The file "${WORK}/sandbox/marker" should be exist
   End
+
+  It 'refuses a TS_VENV containing a .. traversal segment'
+    # Contained: an unguarded launcher resolves the .. at rm -rf time and
+    # deletes the sibling directory's contents.
+    mkdir -p "${WORK}/keep/other"
+    printf 'keep\n' > "${WORK}/keep/other/marker"
+    When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/keep/subdir/../other" sh "${SCRIPT}"
+    The status should be failure
+    The stderr should include 'refusing'
+    The file "${WORK}/keep/other/marker" should be exist
+  End
+
+  It 'refuses a TS_VENV containing a double slash'
+    When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}//venv2" sh "${SCRIPT}"
+    The status should be failure
+    The stderr should include 'refusing'
+  End
+
+  It 'accepts a trailing-slash TS_VENV and still installs fresh'
+    # A trailing slash once nested the lock inside the not-yet-created venv,
+    # sending an uncontended first install into the concurrent-wait failure.
+    When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv/" sh "${SCRIPT}"
+    The status should be success
+    The output should equal 'INSTALLED'
+    The stderr should equal ''
+  End
 End

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -1,21 +1,27 @@
 #shellcheck shell=sh
-# mcp-token-savior.sh — INCLUDE_PATTERNS wiring: the server's built-in index globs
-# lack .php/.inc/.sh (this repo's main languages), so the launcher must export a
-# repo-appropriate default while a caller-set INCLUDE_PATTERNS still wins.
+# mcp-token-savior.sh — env wiring + fork-pin install policy: the server's
+# built-in index globs lack .php/.inc/.sh and its 500 KB size cap skips
+# pfblockerng.inc (~844 KB), so the launcher must export repo-appropriate
+# defaults (caller-set values win); the package installs from the pinned
+# TS_SOURCE and a TS_SOURCE change must trigger a clean venv rebuild.
 
-Describe 'mcp-token-savior.sh INCLUDE_PATTERNS export'
+Describe 'mcp-token-savior.sh env exports'
   SCRIPT="${PFB_ROOT}/scripts/mcp-token-savior.sh"
 
   setup() {
     WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/mcpts.XXXXXX")"
     # Executable venv bin short-circuits the launcher's install path and echoes
-    # the one env var under test as seen by the exec'd server process.
+    # the env vars under test as seen by the exec'd server process. The stamp
+    # must match the launcher's default TS_SOURCE or it rebuilds the venv.
     mkdir -p "${WORK}/venv/bin"
     cat > "${WORK}/venv/bin/token-savior" << 'EOF'
 #!/bin/sh
 printf '%s\n' "${INCLUDE_PATTERNS:-UNSET}"
+printf '%s\n' "${TOKEN_SAVIOR_MAX_FILE_SIZE:-UNSET}"
 EOF
     chmod +x "${WORK}/venv/bin/token-savior"
+    default_source="$(sed -n 's/^TS_SOURCE="\${TS_SOURCE:-\(.*\)}"$/\1/p' "${SCRIPT}")"
+    printf '%s\n' "${default_source}" > "${WORK}/venv/.pfb-ts-source"
   }
 
   cleanup() { rm -rf "${WORK}"; }
@@ -34,6 +40,80 @@ EOF
   It 'lets a caller-set INCLUDE_PATTERNS win over the default'
     When run env INCLUDE_PATTERNS='**/*.only' TS_VENV="${WORK}/venv" sh "${SCRIPT}"
     The status should be success
-    The output should equal '**/*.only'
+    The line 1 of output should equal '**/*.only'
+  End
+
+  It 'raises the index size cap so pfblockerng.inc (~844 KB) gets indexed'
+    When run env -u TOKEN_SAVIOR_MAX_FILE_SIZE TS_VENV="${WORK}/venv" sh "${SCRIPT}"
+    The status should be success
+    The line 2 of output should equal '2000000'
+  End
+
+  It 'lets a caller-set TOKEN_SAVIOR_MAX_FILE_SIZE win over the default'
+    When run env TOKEN_SAVIOR_MAX_FILE_SIZE=777 TS_VENV="${WORK}/venv" sh "${SCRIPT}"
+    The status should be success
+    The line 2 of output should equal '777'
+  End
+End
+
+Describe 'mcp-token-savior.sh fork-pin install policy'
+  SCRIPT="${PFB_ROOT}/scripts/mcp-token-savior.sh"
+
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/mcpts.XXXXXX")"
+    # python3 shim: emulates `python3 -m venv <dir>` by planting a pip shim
+    # that logs its final argument (the requirement string) and plants the
+    # server bin — so the install path runs without touching the network.
+    mkdir -p "${WORK}/shim"
+    cat > "${WORK}/shim/python3" << EOF
+#!/bin/sh
+venv="\$3"
+mkdir -p "\${venv}/bin"
+cat > "\${venv}/bin/pip" << 'PIPEOF'
+#!/bin/sh
+for last; do :; done
+printf '%s\n' "\${last}" >> "\$(dirname "\$0")/../pip-args.log"
+bin_dir="\$(dirname "\$0")"
+printf '#!/bin/sh\nprintf INSTALLED\n' > "\${bin_dir}/token-savior"
+chmod +x "\${bin_dir}/token-savior"
+PIPEOF
+chmod +x "\${venv}/bin/pip"
+EOF
+    chmod +x "${WORK}/shim/python3"
+  }
+
+  cleanup() { rm -rf "${WORK}"; }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'installs the pinned andrebrait/token-savior integration source on first run'
+    When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv" sh "${SCRIPT}"
+    The status should be success
+    The output should equal 'INSTALLED'
+    The stderr should equal ''
+    The contents of file "${WORK}/venv/pip-args.log" should include 'git+https://github.com/andrebrait/token-savior@'
+  End
+
+  It 'rebuilds the venv when the recorded TS_SOURCE stamp no longer matches'
+    # Pre-seed a venv installed from an OLD source: bin exists, stale stamp.
+    mkdir -p "${WORK}/venv/bin"
+    printf '#!/bin/sh\nprintf STALE\n' > "${WORK}/venv/bin/token-savior"
+    chmod +x "${WORK}/venv/bin/token-savior"
+    printf '%s\n' 'token-savior-recall[mcp]' > "${WORK}/venv/.pfb-ts-source"
+    When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv" sh "${SCRIPT}"
+    The status should be success
+    The output should equal 'INSTALLED'
+    The stderr should equal ''
+  End
+
+  It 'skips reinstall when bin exists and the stamp matches TS_SOURCE'
+    mkdir -p "${WORK}/venv/bin"
+    printf '#!/bin/sh\nprintf KEPT\n' > "${WORK}/venv/bin/token-savior"
+    chmod +x "${WORK}/venv/bin/token-savior"
+    printf '%s\n' 'custom-source' > "${WORK}/venv/.pfb-ts-source"
+    When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv" TS_SOURCE='custom-source' sh "${SCRIPT}"
+    The status should be success
+    The output should equal 'KEPT'
+    The file "${WORK}/venv/pip-args.log" should not be exist
   End
 End

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -1,0 +1,39 @@
+#shellcheck shell=sh
+# mcp-token-savior.sh — INCLUDE_PATTERNS wiring: the server's built-in index globs
+# lack .php/.inc/.sh (this repo's main languages), so the launcher must export a
+# repo-appropriate default while a caller-set INCLUDE_PATTERNS still wins.
+
+Describe 'mcp-token-savior.sh INCLUDE_PATTERNS export'
+  SCRIPT="${PFB_ROOT}/scripts/mcp-token-savior.sh"
+
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/mcpts.XXXXXX")"
+    # Executable venv bin short-circuits the launcher's install path and echoes
+    # the one env var under test as seen by the exec'd server process.
+    mkdir -p "${WORK}/venv/bin"
+    cat > "${WORK}/venv/bin/token-savior" << 'EOF'
+#!/bin/sh
+printf '%s\n' "${INCLUDE_PATTERNS:-UNSET}"
+EOF
+    chmod +x "${WORK}/venv/bin/token-savior"
+  }
+
+  cleanup() { rm -rf "${WORK}"; }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'exports an index-glob default covering the languages the server misses'
+    When run env -u INCLUDE_PATTERNS TS_VENV="${WORK}/venv" sh "${SCRIPT}"
+    The status should be success
+    The output should include '**/*.php'
+    The output should include '**/*.inc'
+    The output should include '**/*.sh'
+    The output should include '**/*.py'
+  End
+
+  It 'lets a caller-set INCLUDE_PATTERNS win over the default'
+    When run env INCLUDE_PATTERNS='**/*.only' TS_VENV="${WORK}/venv" sh "${SCRIPT}"
+    The status should be success
+    The output should equal '**/*.only'
+  End
+End

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -21,15 +21,18 @@ printf '%s\n' "${TOKEN_SAVIOR_MAX_FILE_SIZE:-UNSET}"
 EOF
     chmod +x "${WORK}/venv/bin/token-savior"
     default_source="$(sed -n 's/^TS_SOURCE="\${TS_SOURCE:-\(.*\)}"$/\1/p' "${SCRIPT}")"
+    # Loud guard: an empty extraction (launcher assignment reformatted) would
+    # silently send every example down the slow venv-rebuild path.
+    [ -n "${default_source}" ] || { echo "TS_SOURCE extraction failed — launcher line reformatted?" >&2; return 1; }
     printf '%s\n' "${default_source}" > "${WORK}/venv/.pfb-ts-source"
   }
 
-  cleanup() { rm -rf "${WORK}"; }
+  cleanup() { [ -n "${WORK}" ] && rm -rf "${WORK}"; [ ! -d "${WORK}" ] || return 1; }
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
   It 'exports an index-glob default covering the languages the server misses'
-    When run env -u INCLUDE_PATTERNS TS_VENV="${WORK}/venv" sh "${SCRIPT}"
+    When run env INCLUDE_PATTERNS="" TS_VENV="${WORK}/venv" sh "${SCRIPT}"
     The status should be success
     The output should include '**/*.php'
     The output should include '**/*.inc'
@@ -44,7 +47,7 @@ EOF
   End
 
   It 'raises the index size cap so pfblockerng.inc (~844 KB) gets indexed'
-    When run env -u TOKEN_SAVIOR_MAX_FILE_SIZE TS_VENV="${WORK}/venv" sh "${SCRIPT}"
+    When run env TOKEN_SAVIOR_MAX_FILE_SIZE="" TS_VENV="${WORK}/venv" sh "${SCRIPT}"
     The status should be success
     The line 2 of output should equal '2000000'
   End
@@ -82,7 +85,7 @@ EOF
     chmod +x "${WORK}/shim/python3"
   }
 
-  cleanup() { rm -rf "${WORK}"; }
+  cleanup() { [ -n "${WORK}" ] && rm -rf "${WORK}"; [ ! -d "${WORK}" ] || return 1; }
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
@@ -115,5 +118,40 @@ EOF
     The status should be success
     The output should equal 'KEPT'
     The file "${WORK}/venv/pip-args.log" should not be exist
+  End
+
+  It 'waits on a concurrent rebuild lock and proceeds once the holder finishes'
+    # Holder simulation: a background job plants the finished venv and releases
+    # the lock; the launcher must wait instead of racing the rebuild.
+    When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv" TS_SOURCE='custom-source' TS_LOCK_WAIT=10 sh -c '
+      mkdir -p "${TS_VENV}.rebuild.lock"
+      (
+        sleep 1
+        mkdir -p "${TS_VENV}/bin"
+        printf "#!/bin/sh\nprintf WAITED\n" > "${TS_VENV}/bin/token-savior"
+        chmod +x "${TS_VENV}/bin/token-savior"
+        printf "%s\n" "custom-source" > "${TS_VENV}/.pfb-ts-source"
+        rmdir "${TS_VENV}.rebuild.lock"
+      ) &
+      exec sh "$1"' _ "${SCRIPT}"
+    The status should be success
+    The output should equal 'WAITED'
+  End
+
+  It 'fails loudly when a concurrent rebuild lock never clears'
+    mkdir -p "${WORK}/venv.rebuild.lock"
+    When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv" TS_LOCK_WAIT=1 sh "${SCRIPT}"
+    The status should be failure
+    The stderr should include 'concurrent rebuild'
+  End
+
+  It 'refuses a non-absolute TS_VENV instead of rm -rf-ing a relative path'
+    # Contained sandbox: an unguarded launcher would rm -rf . right here.
+    mkdir -p "${WORK}/sandbox"
+    printf 'keep\n' > "${WORK}/sandbox/marker"
+    When run sh -c 'cd "$1" && PATH="$3" TS_VENV=. exec sh "$2"' _ "${WORK}/sandbox" "${SCRIPT}" "${WORK}/shim:${PATH}"
+    The status should be failure
+    The stderr should include 'refusing'
+    The file "${WORK}/sandbox/marker" should be exist
   End
 End


### PR DESCRIPTION
## Why

Token Savior was effectively blind in this repo: its default include patterns lack `.php`/`.inc`/`.sh` (the main languages here), its 500 KB size cap silently skips the 844 KB `pfblockerng.inc`, and its PostToolUse capture hook crashed with `AttributeError: 'list' object has no attribute 'get'` on every token-savior MCP call. Root causes were fixed upstream via Mibayy/token-savior PRs #53 (hook crash), #54 (dead `TOKEN_SAVIOR_MAX_FILE_SIZE`/`MAX_FILES` env overrides), #58 (shell annotator), #59 (PHP annotator), #57 (env-var docs), #60 (daemon-test AF_UNIX fix); until they merge, the fork branch `andrebrait/token-savior@integration` (also carrying the pre-existing #47 compactor fix) consolidates them on top of upstream 4.8.0.

## What

- **`scripts/mcp-token-savior.sh`**: install from the pinned fork commit (`TS_SOURCE`, overridable); a `TS_SOURCE` change triggers a clean venv rebuild via a `.pfb-ts-source` stamp; export a repo-appropriate `INCLUDE_PATTERNS` default (from the `git ls-files` extension histogram) and `TOKEN_SAVIOR_MAX_FILE_SIZE=2000000`. Caller-set values always win.
- **`.claude/settings.json`**: drop the token-savior MCP tools from the PostToolUse capture matcher; unwire the Bash rewriter hook and its `TS_BASH_REWRITE`/`TS_BASH_COMPACT` env (Bash-output compaction moves to rtk); add a per-turn CODE LOOKUP clause steering symbol/function reads to the token-savior tools.
- **`scripts/ts-hook.sh`**: header reflects the rewiring.
- **`tests/shell/mcp_token_savior_spec.sh`** (new): 7 examples pinning the include-pattern default + override, the size-cap default + override, the pinned-fork install argument, the stamp-mismatch venv rebuild, and the stamp-match skip path.

## Verification

- Red→green (executed): the INCLUDE_PATTERNS default, size-cap export, pinned-install and stamp-rebuild rows all fail against the pre-change launcher and pass after, spec byte-identical (red-time hashes `39199e9a` / `750266eb`).
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS.
- Live E2E on this machine: launcher rebuilt the cached venv from the pinned fork commit (server boots, `profile=optimized tools=15/69`); the previously-crashing hook payload now returns `{"continue": true}` rc 0; `pfblockerng.inc` indexes with 377 PHP functions (`sync_package_pfblockerng`, `pfb_ensure_trailing_newline` with correct lines/params/return type); `pfblockerng.sh` yields 36 shell functions. Dropping `TOKEN_SAVIOR_MAX_FILE_SIZE` reproduces the skip — the export is load-bearing.

Settings-only changes (`.claude/settings.json`) have no test surface; the launcher behaviour is covered by the new spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTosXpNzKNTxHyY9gwkRKZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved code lookup guidance to favor indexed token-saving tools, with a fallback option.
  * Added configurable file patterns and maximum file-size limits for code indexing.
  * Improved automatic setup and refresh of the code lookup service when its source changes.

* **Bug Fixes**
  * Prevented unnecessary service reinstallation when the configured source is unchanged.
  * Narrowed tool events that trigger post-action processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->