### PR TITLE
scripts: bump token-savior pin to integration@162aa299, ignore its cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ test-results/
 
 # ── AI-agent worktrees (per-task, never committed) ───────────────────────────
 .claude/worktrees/
+
+# token-savior MCP server index cache (one per project root / worktree)
+.token-savior-cache.json

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -3,7 +3,7 @@
 # Installs TS_SOURCE into a per-user cached venv, then execs it. The default TS_SOURCE is the
 # andrebrait/token-savior fork's `integration` branch pinned by commit — it carries fixes and
 # language support not yet merged upstream (Mibayy/token-savior PRs #47 #53 #54 #57 #58 #59
-# #60); repoint to PyPI's token-savior-recall[mcp,memory-vector] once those merge. A TS_SOURCE change (e.g. a
+# #60 #62); repoint to PyPI's token-savior-recall[mcp,memory-vector] once those merge. A TS_SOURCE change (e.g. a
 # new pinned commit) is detected via the .pfb-ts-source stamp and triggers a clean venv rebuild;
 # a mkdir lock serializes concurrent sessions racing that rebuild (the venv is one shared
 # per-user cache). Requires python3 >= 3.11 and git (pip installs from a git URL).
@@ -39,7 +39,7 @@ if [ "$venv_bad" = 1 ]; then
 fi
 bin="$venv/bin/token-savior"
 stamp="$venv/.pfb-ts-source"
-TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp,memory-vector] @ git+https://github.com/andrebrait/token-savior@10aa65543995e4cfbc6aa341eae4d6dd31348da6}"
+TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp,memory-vector] @ git+https://github.com/andrebrait/token-savior@162aa29947fc98da8dfc5319e9fd59b11bdfed34}"
 
 # stdout is the MCP stdio channel — install chatter must stay on stderr
 if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then


### PR DESCRIPTION
## Why

First reconnect after #1311 exposed an upstream defect: the token-savior index cache is validated by a version int only, so the upgraded server silently answered from the stale 4.4.1-era index (PHP/shell symbols missing, old file count) until `.token-savior-cache.json` was deleted by hand. Fixed upstream-style in Mibayy/token-savior#62 (filed as Mibayy/token-savior#61): cache keyed by env configuration + package version, cache-hit indexers resolve env patterns like `build()`, and the cache files are excluded from indexing themselves.

## What

- `scripts/mcp-token-savior.sh`: `TS_SOURCE` pin bumped `10aa655` → `162aa299` (fork `integration` + cherry-picked #62; full upstream suite there: 1896 passed, 0 failed). Header PR list gains #62. The `[mcp,memory-vector]` extras from 24fea8b6 ride the pin unchanged.
- `.gitignore`: `.token-savior-cache.json` — the server writes one per project root (each worktree gets its own, since `WORKSPACE_ROOTS` defaults to the launcher's cwd); it was showing as untracked noise.

## Verification

- `shellspec --shell dash tests/shell/mcp_token_savior_spec.sh`: 13 examples, 0 failures (the pin/stamp rows extract the default from the script, so the bump is covered without spec edits).
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS.
- Live E2E: stamp mismatch triggered a clean venv rebuild from the new pin (`.pfb-ts-source` now records `…@162aa299`), memory-vector extras present (sqlite-vec, fastembed, onnxruntime), server boots `profile=optimized tools=15/69`.
- `git check-ignore .token-savior-cache.json` → ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTosXpNzKNTxHyY9gwkRKZ