### PR TITLE
pfblockerng: never network-fetch a Hold feed with no .orig baseline (#1278)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2217,9 +2217,9 @@ function pfb_dnsbl_stale_rebuild_converge_txt(bool $stale_generation_rebuild, st
 	}
 }
 
-// issue #1278: Hold means "download once, never again" (mirrors pfblockerng.php:766-769's
-// unconditional Hold bypass) -- a stale-generation rebuild (#1083) must never fall through
-// to the network when no '.orig' baseline survives to reparse locally.
+// issue #1278: Hold means "download once, never again" (mirrors pfblockerng.php's
+// Hold bypass) -- a stale-generation rebuild (#1083) must never fall through to the
+// network when no '.orig' baseline survives to reparse locally.
 function pfb_dnsbl_hold_stale_rebuild_skip(bool $stale_generation_rebuild, bool $is_hold, bool $orig_exists): bool {
 	return $stale_generation_rebuild && $is_hold && !$orig_exists;
 }
@@ -17513,7 +17513,7 @@ function sync_package_pfblockerng($cron='') {
 								// issue #1278: Hold means "download once, never again" -- skip the network
 								// fallback entirely and retry next pass; staging stays untouched.
 								if (pfb_dnsbl_hold_stale_rebuild_skip($stale_generation_rebuild, $row['state'] == 'Hold', file_exists("{$file_dwn}.orig"))) {
-									pfb_logger(" -- Hold: no baseline, will not fetch.\n", 1);
+									pfb_logger(" -- Hold: staying held, no baseline to reparse.\n", 1);
 									continue;
 								}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2217,6 +2217,13 @@ function pfb_dnsbl_stale_rebuild_converge_txt(bool $stale_generation_rebuild, st
 	}
 }
 
+// issue #1278: Hold means "download once, never again" (mirrors pfblockerng.php:766-769's
+// unconditional Hold bypass) -- a stale-generation rebuild (#1083) must never fall through
+// to the network when no '.orig' baseline survives to reparse locally.
+function pfb_dnsbl_hold_stale_rebuild_skip(bool $stale_generation_rebuild, bool $is_hold, bool $orig_exists): bool {
+	return $stale_generation_rebuild && $is_hold && !$orig_exists;
+}
+
 // v6 stays OPTIONAL (ADR-13 §7 pivot): a missing v6 VIP never fails validation, even when
 // the resolver listens on IPv6 — pfb_global surfaces that as a non-blocking warning, not a
 // force-disable. The validator only checks the VIPs that ARE configured (existence,
@@ -17502,6 +17509,13 @@ function sync_package_pfblockerng($cron='') {
 								pfb_logger("{$log}", 1);
 								$file_dwn = "{$pfborig}/{$header}";
 								$orig_content_stale = FALSE;
+
+								// issue #1278: Hold means "download once, never again" -- skip the network
+								// fallback entirely and retry next pass; staging stays untouched.
+								if (pfb_dnsbl_hold_stale_rebuild_skip($stale_generation_rebuild, $row['state'] == 'Hold', file_exists("{$file_dwn}.orig"))) {
+									pfb_logger(" -- Hold: no baseline, will not fetch.\n", 1);
+									continue;
+								}
 
 								if (!$custom) {
 									pfb_logger(' .', 1);

--- a/tests/php/DnsblStagingGenerationGuardTest.php
+++ b/tests/php/DnsblStagingGenerationGuardTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
  * #1083 P4 -- the DNSBL staging-generation guard. A field box upgrading with a
  * pre-NDJSON staging '.txt' on a never-redownloaded feed (group frequency 'Never',
  * row state 'Hold') must not verbatim-reuse it forever: pfb_unbound_python_sources()
- * silently skips every pre-#1083 line, blanking the feed. These three PURE helpers
+ * silently skips every pre-#1083 line, blanking the feed. These PURE helpers
  * (pfblockerng.inc, beside pfb_ip_reuse_skip_active()) are brand-new code (#1083
  * P4) -- no red run against pre-P4 code is possible (the symbols do not exist
  * there; an existence probe would be coverage theater per CLAUDE.md's carve-out).
@@ -293,45 +293,53 @@ final class DnsblStagingGenerationGuardTest extends TestCase
 	{
 		// The bug scenario: Hold + stale-generation rebuild + no '.orig' baseline
 		// must skip, never fall through to pfb_download().
-		$this->assertTrue(pfb_dnsbl_hold_stale_rebuild_skip(TRUE, TRUE, FALSE));
+		$result = pfb_dnsbl_hold_stale_rebuild_skip(TRUE, TRUE, FALSE);
+		$this->assertTrue($result, 'expected TRUE (skip), got ' . var_export($result, TRUE));
 	}
 
 	public function testStaleRebuildHoldWithOrigDoesNotSkip(): void
 	{
 		// '.orig' present -- the existing reparse-from-orig path already avoids
 		// the network; this guard must stay silent.
-		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(TRUE, TRUE, TRUE));
+		$result = pfb_dnsbl_hold_stale_rebuild_skip(TRUE, TRUE, TRUE);
+		$this->assertFalse($result, 'expected FALSE (no skip), got ' . var_export($result, TRUE));
 	}
 
 	public function testStaleRebuildNonHoldNoOrigDoesNotSkip(): void
 	{
-		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(TRUE, FALSE, FALSE));
+		$result = pfb_dnsbl_hold_stale_rebuild_skip(TRUE, FALSE, FALSE);
+		$this->assertFalse($result, 'expected FALSE (no skip), got ' . var_export($result, TRUE));
 	}
 
 	public function testStaleRebuildNonHoldWithOrigDoesNotSkip(): void
 	{
-		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(TRUE, FALSE, TRUE));
+		$result = pfb_dnsbl_hold_stale_rebuild_skip(TRUE, FALSE, TRUE);
+		$this->assertFalse($result, 'expected FALSE (no skip), got ' . var_export($result, TRUE));
 	}
 
 	public function testNoStaleRebuildHoldNoOrigDoesNotSkip(): void
 	{
 		// Not in the stale-generation-rebuild fork at all (plain Hold, current-
 		// generation staging) -- the verbatim-reuse fork already handles this.
-		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(FALSE, TRUE, FALSE));
+		$result = pfb_dnsbl_hold_stale_rebuild_skip(FALSE, TRUE, FALSE);
+		$this->assertFalse($result, 'expected FALSE (no skip), got ' . var_export($result, TRUE));
 	}
 
 	public function testNoStaleRebuildHoldWithOrigDoesNotSkip(): void
 	{
-		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(FALSE, TRUE, TRUE));
+		$result = pfb_dnsbl_hold_stale_rebuild_skip(FALSE, TRUE, TRUE);
+		$this->assertFalse($result, 'expected FALSE (no skip), got ' . var_export($result, TRUE));
 	}
 
 	public function testNoStaleRebuildNonHoldNoOrigDoesNotSkip(): void
 	{
-		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(FALSE, FALSE, FALSE));
+		$result = pfb_dnsbl_hold_stale_rebuild_skip(FALSE, FALSE, FALSE);
+		$this->assertFalse($result, 'expected FALSE (no skip), got ' . var_export($result, TRUE));
 	}
 
 	public function testNoStaleRebuildNonHoldWithOrigDoesNotSkip(): void
 	{
-		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(FALSE, FALSE, TRUE));
+		$result = pfb_dnsbl_hold_stale_rebuild_skip(FALSE, FALSE, TRUE);
+		$this->assertFalse($result, 'expected FALSE (no skip), got ' . var_export($result, TRUE));
 	}
 }

--- a/tests/php/DnsblStagingGenerationGuardTest.php
+++ b/tests/php/DnsblStagingGenerationGuardTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_dnsbl_staging_is_current_generation')]
 #[CoversFunction('pfb_dnsbl_staging_first_line')]
 #[CoversFunction('pfb_dnsbl_verbatim_reuse_active')]
+#[CoversFunction('pfb_dnsbl_hold_stale_rebuild_skip')]
 final class DnsblStagingGenerationGuardTest extends TestCase
 {
 	// --- pfb_dnsbl_staging_is_current_generation() ---------------------------------
@@ -284,5 +285,53 @@ final class DnsblStagingGenerationGuardTest extends TestCase
 		} finally {
 			unlink_if_exists($path);
 		}
+	}
+
+	// --- pfb_dnsbl_hold_stale_rebuild_skip() --- (issue #1278)
+
+	public function testStaleRebuildHoldNoOrigSkipsFetch(): void
+	{
+		// The bug scenario: Hold + stale-generation rebuild + no '.orig' baseline
+		// must skip, never fall through to pfb_download().
+		$this->assertTrue(pfb_dnsbl_hold_stale_rebuild_skip(TRUE, TRUE, FALSE));
+	}
+
+	public function testStaleRebuildHoldWithOrigDoesNotSkip(): void
+	{
+		// '.orig' present -- the existing reparse-from-orig path already avoids
+		// the network; this guard must stay silent.
+		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(TRUE, TRUE, TRUE));
+	}
+
+	public function testStaleRebuildNonHoldNoOrigDoesNotSkip(): void
+	{
+		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(TRUE, FALSE, FALSE));
+	}
+
+	public function testStaleRebuildNonHoldWithOrigDoesNotSkip(): void
+	{
+		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(TRUE, FALSE, TRUE));
+	}
+
+	public function testNoStaleRebuildHoldNoOrigDoesNotSkip(): void
+	{
+		// Not in the stale-generation-rebuild fork at all (plain Hold, current-
+		// generation staging) -- the verbatim-reuse fork already handles this.
+		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(FALSE, TRUE, FALSE));
+	}
+
+	public function testNoStaleRebuildHoldWithOrigDoesNotSkip(): void
+	{
+		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(FALSE, TRUE, TRUE));
+	}
+
+	public function testNoStaleRebuildNonHoldNoOrigDoesNotSkip(): void
+	{
+		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(FALSE, FALSE, FALSE));
+	}
+
+	public function testNoStaleRebuildNonHoldWithOrigDoesNotSkip(): void
+	{
+		$this->assertFalse(pfb_dnsbl_hold_stale_rebuild_skip(FALSE, FALSE, TRUE));
 	}
 }


### PR DESCRIPTION
## Summary

- A stale-generation rebuild (#1083's NDJSON migration) for a Hold-state DNSBL feed whose `.orig` baseline is missing fell through to `pfb_download()`, bypassing Hold's "download once, never again" contract (mirrors the unconditional Hold bypass at `pfblockerng.php:766-769`).
- Adds a pure predicate `pfb_dnsbl_hold_stale_rebuild_skip()` and wires it into the sync loop just before the network-fallback fork; when a Hold feed has no `.orig` to reparse locally, the header is skipped this pass (staging untouched, no fetch) instead of downloading.
- Existing verbatim-reuse path (staging current-generation) and the reparse-from-`.orig` path (baseline present) are untouched — this closes only the one gap where neither applied.

## Test plan

- [x] Red-first: `vendor/bin/phpunit --filter DnsblStagingGenerationGuardTest` errored on all 8 new tests (`Call to undefined function`) before the production edit; frozen test file unchanged after.
- [x] Green: same filter, 27/27 pass after the fix.
- [x] Full suite: `vendor/bin/phpunit` — 0 failures/errors.
- [x] `composer phpstan` — no errors.
- [x] `composer phpcs -- --standard=phpcs.xml.dist src/` — clean.
- [x] `php -l` on both touched files — no syntax errors.
- [x] Independently re-executed by a fresh verifier agent (reverted `.inc` to pre-fix, confirmed red, restored, confirmed green) — see commit for detail.

Fixes #1278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gr4Sj3PTxg6CCSEMo2KtNk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary network downloads during stale-generation rebuilds when a feed is in **Hold** mode and no local baseline (`*.orig`) is available.
  - When the baseline is missing, staging is left untouched and the item is skipped immediately, with the reason recorded in logs.

- **Tests**
  - Added/expanded unit test coverage for the “Hold + stale-generation rebuild + baseline missing” decision to ensure skips happen only for that scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->