### PR TITLE
pfblockerng: drop whitespace-only lines from cumulative dedup stream

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -956,7 +956,7 @@ pfb_recompute() {
 			# as empty), so a later alias hits grepcidr with a pattern-free file,
 			# which prints NOTHING for -vf (not "keep everything"): it would wipe
 			# every row of every lower-priority feed sharing this pass.
-			if ! awk '$0 != ""' "${rec_ownedfile}" >> "${rec_cumulative}"; then
+			if ! awk 'NF' "${rec_ownedfile}" >> "${rec_cumulative}"; then
 				log="recompute [ ${rec_family} ]: could not extend cumulative dedup stream for [ ${rec_alias} ]; aborting pass, cleaning up partial artifacts"
 				echo "${log}" | tee -a "${errorlog}"
 				pfb_recompute_clean_new

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -951,11 +951,12 @@ pfb_recompute() {
 		fi
 
 		if [ "${rec_dedup}" = 'on' ]; then
-			# issue #1084: blank-filtered -- an unfiltered blank line still gives
-			# the cumulative nonzero size (the `-s` guard above no longer sees it
-			# as empty), so a later alias hits grepcidr with a pattern-free file,
-			# which prints NOTHING for -vf (not "keep everything"): it would wipe
-			# every row of every lower-priority feed sharing this pass.
+			# issue #1084/#1279: blank/whitespace-filtered -- an unfiltered blank
+			# OR whitespace-only line still gives the cumulative nonzero size (the
+			# `-s` guard above no longer sees it as empty), so a later alias hits
+			# grepcidr with a pattern-free file, which prints NOTHING for -vf (not
+			# "keep everything"): it would wipe every row of every lower-priority
+			# feed sharing this pass.
 			if ! awk 'NF' "${rec_ownedfile}" >> "${rec_cumulative}"; then
 				log="recompute [ ${rec_family} ]: could not extend cumulative dedup stream for [ ${rec_alias} ]; aborting pass, cleaning up partial artifacts"
 				echo "${log}" | tee -a "${errorlog}"

--- a/tests/shell/pfblockerng_recompute_spec.sh
+++ b/tests/shell/pfblockerng_recompute_spec.sh
@@ -281,8 +281,8 @@ Describe 'pfb_recompute() v4 cross-feed dedup (Stage A/B/D/E)'
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
 		The status should be success
 		# the whitespace-only row's OWN emitted file is governed by the unrelated,
-		# out-of-scope :1053/:1221 blank-filter sites -- only the cumulative-dedup
-		# wipe of the disjoint feed is this fix's contract.
+		# out-of-scope per-alias direct-emit/reputation-keep blank filters -- only
+		# the cumulative-dedup wipe of the disjoint feed is this fix's contract.
 		The contents of file "${pfbdeny}Disjoint_v4.txt" should equal '198.51.100.71'
 		The contents of file "$countsfile" should include 'Disjoint_v4 1'
 	End
@@ -297,13 +297,19 @@ Describe 'pfb_recompute() v4 cross-feed dedup (Stage A/B/D/E)'
 		The contents of file "$countsfile" should include 'Disjoint_v4 1'
 	End
 
-	It 'a whitespace-only line mixed with a valid row in the same snapshot never wipes a later disjoint feed (issue #1279)'
+	It 'a whitespace-only line mixed with a valid row in the same snapshot never wipes a later disjoint feed, and the valid row still dedups (issue #1279)'
 		printf '203.0.113.50\n   \n' > "${snap}/Mixed_v4.orig"
 		printf '198.51.100.73\n' > "${snap}/Disjoint_v4.orig"
-		printf '%s\n%s\n' "${snap}/Mixed_v4.orig" "${snap}/Disjoint_v4.orig" > "$memberlist"
+		# a third, lowest-priority repeat of Mixed's OWN valid row: proves that row
+		# reached rec_cumulative (not just that Disjoint survived) -- a bad fix that
+		# skips a whole owned-file on any embedded blank line would leave this repeat
+		# undeduped instead of empty.
+		printf '203.0.113.50\n' > "${snap}/Repeat_v4.orig"
+		printf '%s\n%s\n%s\n' "${snap}/Mixed_v4.orig" "${snap}/Disjoint_v4.orig" "${snap}/Repeat_v4.orig" > "$memberlist"
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
 		The status should be success
 		The contents of file "${pfbdeny}Disjoint_v4.txt" should equal '198.51.100.73'
+		The contents of file "${pfbdeny}Repeat_v4.txt" should equal ''
 	End
 
 	It 'a pattern row with surrounding whitespace still counts as valid content and dedups a later feed exact repeat (issue #1279 -- do not over-fix into stripping valid rows)'

--- a/tests/shell/pfblockerng_recompute_spec.sh
+++ b/tests/shell/pfblockerng_recompute_spec.sh
@@ -9,9 +9,11 @@
 # `-vf <patternfile> <targetfile>` -> target lines whose address is NOT
 # inside ANY pattern CIDR/host, via portable integer arithmetic. Fidelity
 # probed against the real binary: a pattern file with ZERO parseable
-# patterns (blank lines only, or empty) prints NOTHING and exits 1 --
-# never "no patterns matched, so keep every line" -- so `n == 0` short-
-# circuits to that outcome before the per-line filter ever runs.
+# patterns (blank OR whitespace-only lines, or empty) prints NOTHING and
+# exits 1 -- never "no patterns matched, so keep every line" -- so a
+# whitespace-only pattern line is skipped like a blank one (issue #1279)
+# and `n == 0` short-circuits to that outcome before the per-line filter
+# ever runs.
 make_grepcidr_stub() {
 	cat > "$1" <<'EOF'
 #!/bin/sh
@@ -26,7 +28,7 @@ function net(ipint, bits,   div) {
 }
 BEGIN {
 	while ((getline line < patfile) > 0) {
-		if (line == "") continue
+		if (line ~ /^[ \t]*$/) continue
 		split(line, parts, "/")
 		n++
 		pbits[n] = (parts[2] == "" ? 32 : parts[2])
@@ -270,6 +272,47 @@ Describe 'pfb_recompute() v4 cross-feed dedup (Stage A/B/D/E)'
 		The contents of file "${pfbdeny}OnlyBlank_v4.txt" should equal ''
 		The contents of file "${pfbdeny}Disjoint_v4.txt" should equal '198.51.100.70'
 		The contents of file "$countsfile" should include 'Disjoint_v4 1'
+	End
+
+	It 'never lets a whitespace-only (spaces) high-priority snapshot poison the cumulative dedup stream into eating a disjoint lower feed (issue #1279)'
+		printf '   \n' > "${snap}/OnlySpaces_v4.orig"
+		printf '198.51.100.71\n' > "${snap}/Disjoint_v4.orig"
+		printf '%s\n%s\n' "${snap}/OnlySpaces_v4.orig" "${snap}/Disjoint_v4.orig" > "$memberlist"
+		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
+		The status should be success
+		# the whitespace-only row's OWN emitted file is governed by the unrelated,
+		# out-of-scope :1053/:1221 blank-filter sites -- only the cumulative-dedup
+		# wipe of the disjoint feed is this fix's contract.
+		The contents of file "${pfbdeny}Disjoint_v4.txt" should equal '198.51.100.71'
+		The contents of file "$countsfile" should include 'Disjoint_v4 1'
+	End
+
+	It 'never lets a whitespace-only (tabs) high-priority snapshot poison the cumulative dedup stream into eating a disjoint lower feed (issue #1279)'
+		printf '\t\t\n' > "${snap}/OnlyTabs_v4.orig"
+		printf '198.51.100.72\n' > "${snap}/Disjoint_v4.orig"
+		printf '%s\n%s\n' "${snap}/OnlyTabs_v4.orig" "${snap}/Disjoint_v4.orig" > "$memberlist"
+		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
+		The status should be success
+		The contents of file "${pfbdeny}Disjoint_v4.txt" should equal '198.51.100.72'
+		The contents of file "$countsfile" should include 'Disjoint_v4 1'
+	End
+
+	It 'a whitespace-only line mixed with a valid row in the same snapshot never wipes a later disjoint feed (issue #1279)'
+		printf '203.0.113.50\n   \n' > "${snap}/Mixed_v4.orig"
+		printf '198.51.100.73\n' > "${snap}/Disjoint_v4.orig"
+		printf '%s\n%s\n' "${snap}/Mixed_v4.orig" "${snap}/Disjoint_v4.orig" > "$memberlist"
+		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
+		The status should be success
+		The contents of file "${pfbdeny}Disjoint_v4.txt" should equal '198.51.100.73'
+	End
+
+	It 'a pattern row with surrounding whitespace still counts as valid content and dedups a later feed exact repeat (issue #1279 -- do not over-fix into stripping valid rows)'
+		printf '  198.51.100.75  \n' > "${snap}/Padded_v4.orig"
+		printf '198.51.100.75\n198.51.100.76\n' > "${snap}/PaddedLower_v4.orig"
+		printf '%s\n%s\n' "${snap}/Padded_v4.orig" "${snap}/PaddedLower_v4.orig" > "$memberlist"
+		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
+		The status should be success
+		The contents of file "${pfbdeny}PaddedLower_v4.txt" should equal '198.51.100.76'
 	End
 
 	It 'dedups an internal repeat within a single feed snapshot (within-feed dupes, issue #1084 review)'


### PR DESCRIPTION
## Summary

A whitespace-only line surviving into the Stage A cumulative-dedup stream
(`rec_cumulative`) made `grepcidr -vf` print nothing (rc=1, below the
module's own abort threshold) instead of "keep everything," silently
wiping every row of every lower-priority feed sharing that family's
recompute pass. `awk '$0 != ""'` only drops fully-empty lines; switched
to `awk 'NF'`, which also drops whitespace-only lines.

- `src/usr/local/pkg/pfblockerng/pfblockerng.sh:959` — the one-line fix,
  at the sole call site that feeds `rec_cumulative` (the other two
  `awk '$0 != ""'` occurrences in this file, at `:1053`/`:1221`, feed
  unrelated per-alias emit paths and are untouched — confirmed by
  tracing every writer/reader of `rec_cumulative`).
- `tests/shell/pfblockerng_recompute_spec.sh` — fixed a fidelity gap in
  `make_grepcidr_stub()` (it previously let a whitespace-only pattern
  line degrade into a bogus counted pattern instead of rejecting it,
  which would have made a naive red-proof test pass on unfixed code),
  and added 4 new examples: two red-proof rows (whitespace-only spaces
  / tabs wiping a disjoint lower-priority feed) plus two non-regression
  guards (mixed valid+whitespace content; padded-but-valid IP content).

## Out of scope (known, deliberate)

- A CRLF-only line (`\r\n`) is not reliably dropped by `awk 'NF'` either
  (the trailing `\r` can survive as a non-whitespace field) — a
  narrower, separate hazard than this issue's literal ask
  (whitespace-only lines); not fixed here.
- The two untouched `awk '$0 != ""'` sites (`:1053`/`:1221`) still let
  a whitespace-only line survive into an alias's *own* emitted deny
  file — lower severity (no cross-feed wipe there), not fixed here.
- `make_grepcidr_v6_stub()` (v6 test fixture) has the same pre-existing
  whitespace-fidelity gap the v4 stub had before this PR; production is
  unaffected (the fix is family-parametrized, not family-branched) —
  a pure test-infra gap, not fixed here.

Tracking issues to follow for the three items above.

## Test plan

- [x] Red-proof: 2 new examples FAIL on unmodified `pfblockerng.sh`
      (disjoint feed's owned file ends up empty) — re-executed
      independently via `scripts/agent/verify-red-proof.sh`.
- [x] Green: same file unedited, `60 examples, 0 failures` post-fix.
- [x] Full spec-file regression: pre-existing examples (blank-line,
      empty-snapshot) stay green.
- [x] `sh -n`, `shellcheck` (src/), `shellspec --shell dash` all pass.
- [x] Full impacted shellspec suite: 765 examples, 0 failures, 8
      pre-existing unrelated env-gated skips.

Fixes #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
