### PR TITLE
agent: run-gates.sh --diff sees uncommitted work too

### DIFF
--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -5,7 +5,8 @@
 #
 # Usage: run-gates.sh [--worktree PATH] [--diff BASE] [--plan] [--allow-missing]
 #   --worktree       repo checkout to run in (default: cwd's repo root)
-#   --diff BASE      compute touched files vs BASE (default origin/devel); merge-base diff
+#   --diff BASE      compute touched files: BASE...HEAD merge-base diff UNIONED with
+#                     any uncommitted (staged+unstaged) changes vs HEAD (default origin/devel)
 #   --plan           print the gate commands that WOULD run, one per line, and exit
 #   --allow-missing  a missing tool reports SKIP without failing the run (default: fails)
 #
@@ -101,7 +102,11 @@ main() {
 
 	# --diff-filter=ACMR: a pure deletion stages nothing to lint (same rule as the
 	# pre-commit hook) -- per-file gates against ghost paths would always fail.
-	files=$(git -C "$worktree" diff --name-only --diff-filter=ACMR "$base...HEAD") || exit 2
+	committed=$(git -C "$worktree" diff --name-only --diff-filter=ACMR "$base...HEAD") || exit 2
+	# issue #1293: union with uncommitted (staged+unstaged) changes vs HEAD -- else
+	# gates run pre-commit see nothing and print a vacuous bare GATES: PASS.
+	uncommitted=$(git -C "$worktree" diff --name-only --diff-filter=ACMR HEAD) || exit 2
+	files=$(printf '%s\n%s\n' "$committed" "$uncommitted" | LC_ALL=C sort -u | grep -v '^$')
 	# The shellspec gate must also fire when only spec files changed (cross-language
 	# consumers rule): specs are .sh files, so the extension mapping already covers it.
 	cmds=$(printf '%s\n' "$files" | gates_for)

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -103,10 +103,15 @@ main() {
 	# --diff-filter=ACMR: a pure deletion stages nothing to lint (same rule as the
 	# pre-commit hook) -- per-file gates against ghost paths would always fail.
 	committed=$(git -C "$worktree" diff --name-only --diff-filter=ACMR "$base...HEAD") || exit 2
-	# issue #1293: union with uncommitted (staged+unstaged) changes vs HEAD -- else
-	# gates run pre-commit see nothing and print a vacuous bare GATES: PASS.
-	uncommitted=$(git -C "$worktree" diff --name-only --diff-filter=ACMR HEAD) || exit 2
-	files=$(printf '%s\n%s\n' "$committed" "$uncommitted" | LC_ALL=C sort -u | grep -v '^$')
+	# issue #1293: union with uncommitted (staged+unstaged) changes -- else gates
+	# run pre-commit see nothing and print a vacuous bare GATES: PASS. Staged and
+	# unstaged are unioned SEPARATELY (not via a single `diff HEAD`): `git diff
+	# <commit>` compares the WORKING TREE to that commit, so a file staged then
+	# reverted back to HEAD's content in the working tree (index != HEAD, worktree
+	# == HEAD) is invisible to `diff HEAD` alone though `git status` still flags it.
+	staged=$(git -C "$worktree" diff --name-only --diff-filter=ACMR --cached) || exit 2
+	unstaged=$(git -C "$worktree" diff --name-only --diff-filter=ACMR) || exit 2
+	files=$(printf '%s\n%s\n%s\n' "$committed" "$staged" "$unstaged" | LC_ALL=C sort -u | grep -v '^$')
 	# The shellspec gate must also fire when only spec files changed (cross-language
 	# consumers rule): specs are .sh files, so the extension mapping already covers it.
 	cmds=$(printf '%s\n' "$files" | gates_for)

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -108,7 +108,9 @@ main() {
 	# reads the WORKING TREE, so a staged-then-worktree-reverted file is invisible.
 	staged=$(git -C "$worktree" diff --name-only --diff-filter=ACMR --cached) || exit 2
 	unstaged=$(git -C "$worktree" diff --name-only --diff-filter=ACMR) || exit 2
-	files=$(printf '%s\n%s\n%s\n' "$committed" "$staged" "$unstaged" | LC_ALL=C sort -u | grep -v '^$')
+	# neither diff form surfaces a brand-new file never `git add`ed.
+	untracked=$(git -C "$worktree" ls-files --others --exclude-standard) || exit 2
+	files=$(printf '%s\n%s\n%s\n%s\n' "$committed" "$staged" "$unstaged" "$untracked" | LC_ALL=C sort -u | grep -v '^$')
 	# The shellspec gate must also fire when only spec files changed (cross-language
 	# consumers rule): specs are .sh files, so the extension mapping already covers it.
 	cmds=$(printf '%s\n' "$files" | gates_for)

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -103,12 +103,9 @@ main() {
 	# --diff-filter=ACMR: a pure deletion stages nothing to lint (same rule as the
 	# pre-commit hook) -- per-file gates against ghost paths would always fail.
 	committed=$(git -C "$worktree" diff --name-only --diff-filter=ACMR "$base...HEAD") || exit 2
-	# issue #1293: union with uncommitted (staged+unstaged) changes -- else gates
-	# run pre-commit see nothing and print a vacuous bare GATES: PASS. Staged and
-	# unstaged are unioned SEPARATELY (not via a single `diff HEAD`): `git diff
-	# <commit>` compares the WORKING TREE to that commit, so a file staged then
-	# reverted back to HEAD's content in the working tree (index != HEAD, worktree
-	# == HEAD) is invisible to `diff HEAD` alone though `git status` still flags it.
+	# issue #1293: union with uncommitted changes, else gates see nothing pre-commit.
+	# staged/unstaged unioned SEPARATELY, not via one `diff HEAD` -- `diff <commit>`
+	# reads the WORKING TREE, so a staged-then-worktree-reverted file is invisible.
 	staged=$(git -C "$worktree" diff --name-only --diff-filter=ACMR --cached) || exit 2
 	unstaged=$(git -C "$worktree" diff --name-only --diff-filter=ACMR) || exit 2
 	files=$(printf '%s\n%s\n%s\n' "$committed" "$staged" "$unstaged" | LC_ALL=C sort -u | grep -v '^$')

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -6,7 +6,8 @@
 # Usage: run-gates.sh [--worktree PATH] [--diff BASE] [--plan] [--allow-missing]
 #   --worktree       repo checkout to run in (default: cwd's repo root)
 #   --diff BASE      compute touched files: BASE...HEAD merge-base diff UNIONED with
-#                     any uncommitted (staged+unstaged) changes vs HEAD (default origin/devel)
+#                     any uncommitted (staged+unstaged+untracked, .gitignore-filtered)
+#                     changes vs HEAD (default origin/devel)
 #   --plan           print the gate commands that WOULD run, one per line, and exit
 #   --allow-missing  a missing tool reports SKIP without failing the run (default: fails)
 #

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -179,4 +179,40 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     The output should include 'GATE PASS: shellspec'
     Assert [ -e "$marker" ]
   End
+
+  # issue #1293: --diff must see uncommitted work too, else running gates BEFORE
+  # committing (the normal iterate-while-working flow) plans zero gates and prints
+  # a bare, misleading GATES: PASS.
+  It 'plans gates for an uncommitted UNSTAGED edit even when the committed diff is empty'
+    head_sha=$(gitc rev-parse HEAD)
+    printf '#!/bin/sh\n# unstaged edit, never committed\ntrue\n' > "$repo/scripts/kept.sh"
+    When run sh "$script" --worktree "$repo" --diff "$head_sha"
+    The status should equal 0
+    The output should include 'GATE PASS: sh -n scripts/kept.sh'
+    The output should include 'GATE PASS: shellcheck scripts/kept.sh'
+    The line 4 of output should equal 'GATES: PASS'
+    The lines of output should equal 4
+  End
+
+  It 'plans gates for a STAGED (git add, not committed) edit identically'
+    head_sha=$(gitc rev-parse HEAD)
+    printf '#!/bin/sh\n# staged edit, never committed\ntrue\n' > "$repo/scripts/kept.sh"
+    gitc add scripts/kept.sh
+    When run sh "$script" --worktree "$repo" --diff "$head_sha"
+    The status should equal 0
+    The output should include 'GATE PASS: sh -n scripts/kept.sh'
+    The output should include 'GATE PASS: shellcheck scripts/kept.sh'
+    The line 4 of output should equal 'GATES: PASS'
+    The lines of output should equal 4
+  End
+
+  It 'lists a file touched by both a commit and a further uncommitted edit exactly once'
+    printf '#!/bin/sh\n# further uncommitted edit atop the committed one\ntrue\n' > "$repo/scripts/kept.sh"
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 0
+    The output should include 'GATE PASS: sh -n scripts/kept.sh'
+    The output should include 'GATE PASS: shellcheck scripts/kept.sh'
+    The line 4 of output should equal 'GATES: PASS'
+    The lines of output should equal 4
+  End
 End

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -216,10 +216,8 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     The lines of output should equal 4
   End
 
-  # A `git diff <commit>` (no --cached) compares the WORKING TREE to that commit,
-  # not the index -- so a file staged then reverted back to HEAD's content in the
-  # working tree (index != HEAD, worktree == HEAD) is invisible to a lone `diff
-  # HEAD`, though `git status`/`diff --cached` still show it as staged.
+  # See run-gates.sh's staged/unstaged split comment for why: a lone `diff HEAD`
+  # misses this shape.
   It 'plans gates for a staged edit whose working-tree copy was reverted back to HEAD'
     head_sha=$(gitc rev-parse HEAD)
     printf '#!/bin/sh\n# staged edit\ntrue\n' > "$repo/scripts/kept.sh"

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -245,4 +245,21 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     The line 4 of output should equal 'GATES: PASS'
     The lines of output should equal 4
   End
+
+  # Delta re-review of the untracked-files fix: --exclude-standard must respect
+  # .gitignore, not just "untracked" -- a gitignored scratch file must stay excluded
+  # even while a genuine untracked file alongside it gets planned.
+  It 'excludes a gitignored untracked file while still planning a real untracked one'
+    head_sha=$(gitc rev-parse HEAD)
+    printf 'ignored.sh\n' > "$repo/.gitignore"
+    printf '#!/bin/sh\n# would gate if not excluded\ntrue\n' > "$repo/scripts/ignored.sh"
+    printf '#!/bin/sh\n# real untracked file alongside the ignored one\ntrue\n' > "$repo/scripts/brand_new.sh"
+    When run sh "$script" --worktree "$repo" --diff "$head_sha"
+    The status should equal 0
+    The output should include 'GATE PASS: sh -n scripts/brand_new.sh'
+    The output should include 'GATE PASS: shellcheck scripts/brand_new.sh'
+    The output should not include 'ignored.sh'
+    The line 4 of output should equal 'GATES: PASS'
+    The lines of output should equal 4
+  End
 End

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -232,4 +232,17 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     The line 4 of output should equal 'GATES: PASS'
     The lines of output should equal 4
   End
+
+  # CodeRabbit review of #1293's fix: neither `diff --cached` nor bare `diff`
+  # surfaces a file that was never `git add`ed at all.
+  It 'plans gates for a brand-new file that was never git add-ed'
+    head_sha=$(gitc rev-parse HEAD)
+    printf '#!/bin/sh\n# never staged, never committed\ntrue\n' > "$repo/scripts/brand_new.sh"
+    When run sh "$script" --worktree "$repo" --diff "$head_sha"
+    The status should equal 0
+    The output should include 'GATE PASS: sh -n scripts/brand_new.sh'
+    The output should include 'GATE PASS: shellcheck scripts/brand_new.sh'
+    The line 4 of output should equal 'GATES: PASS'
+    The lines of output should equal 4
+  End
 End

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -215,4 +215,23 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     The line 4 of output should equal 'GATES: PASS'
     The lines of output should equal 4
   End
+
+  # A `git diff <commit>` (no --cached) compares the WORKING TREE to that commit,
+  # not the index -- so a file staged then reverted back to HEAD's content in the
+  # working tree (index != HEAD, worktree == HEAD) is invisible to a lone `diff
+  # HEAD`, though `git status`/`diff --cached` still show it as staged.
+  It 'plans gates for a staged edit whose working-tree copy was reverted back to HEAD'
+    head_sha=$(gitc rev-parse HEAD)
+    printf '#!/bin/sh\n# staged edit\ntrue\n' > "$repo/scripts/kept.sh"
+    gitc add scripts/kept.sh
+    # Direct overwrite, NOT `git checkout` (which would reset the index too):
+    # index keeps the staged edit, working tree goes back to HEAD's exact bytes.
+    printf '#!/bin/sh\ntrue\n' > "$repo/scripts/kept.sh"
+    When run sh "$script" --worktree "$repo" --diff "$head_sha"
+    The status should equal 0
+    The output should include 'GATE PASS: sh -n scripts/kept.sh'
+    The output should include 'GATE PASS: shellcheck scripts/kept.sh'
+    The line 4 of output should equal 'GATES: PASS'
+    The lines of output should equal 4
+  End
 End


### PR DESCRIPTION
Fixes #1293.

`run-gates.sh --diff <base>` computed touched files from the committed `base...HEAD` diff only. Running gates before committing (the normal iterate-while-working flow) planned zero gates and printed a misleading bare `GATES: PASS`.

Fix: union the committed diff with the uncommitted (staged+unstaged) diff against `HEAD`, deduped, so an in-progress edit is scanned exactly like a committed one.

Tests: 3 new shellspec cases in `tests/shell/agent_run_gates_spec.sh` — unstaged edit, staged edit, and a file touched by both a commit and a further uncommitted edit (dedup, not double-counted). Red confirmed against the pre-fix script (2/3 new cases failed), green after, zero edits to the tests between.

---
🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated diff-based gate selection to consider committed changes plus staged, unstaged, and untracked files (respecting ignore rules).
  * Prevented duplicate gate planning when the same file is modified across multiple repository states.
  * Ensured validation still runs correctly even when the committed baseline diff is empty.
* **Documentation**
  * Clarified `--diff` behavior in the command help text.
* **Tests**
  * Added shellspec coverage for unstaged edits, staged-but-uncommitted edits, overlapping changes, reverted working-tree content, never-added new files, and gitignored untracked file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->