### PR TITLE
scripts: claude-bash-guard -- catch -n commit bypass + +refspec force push

### DIFF
--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -6,13 +6,17 @@
 # AGENT must not run -- three git bypasses a human may legitimately use, plus a
 # wait-launch shape that silently strands the turn:
 #
-#   Rule A -- `git commit` with `--no-verify`   : the pre-commit lint gate's
-#             --no-verify bypass is for humans, not agents (CLAUDE.md "Git
-#             hooks").
-#   Rule B -- `git push` with a force flag (--force, --force-with-lease,
-#             standalone -f, or a clustered short flag like -uf/-fu) and
-#             WITHOUT --force-with-lease        : the rebase-only landing
-#             flow uses --force-with-lease exclusively; a bare force-push can
+#   Rule A -- `git commit` with `--no-verify` (long flag, standalone -n, or a
+#             clustered short flag like -an/-anm)   : the pre-commit lint
+#             gate's --no-verify bypass is for humans, not agents (CLAUDE.md
+#             "Git hooks").
+#   Rule B -- `git push` with EITHER a force flag (--force,
+#             --force-with-lease, standalone -f, or a clustered short flag
+#             like -uf/-fu) WITHOUT --force-with-lease, OR a `+`-prefixed
+#             force REFSPEC (`git push origin +branch:branch`) -- git's
+#             OTHER force syntax, with no flag at all and NEVER
+#             --force-with-lease-protected : the rebase-only landing flow
+#             uses --force-with-lease exclusively; a bare force-push can
 #             clobber another session's in-flight PR (CLAUDE.md "Worktrees").
 #   Rule C -- `git worktree remove` with a force flag : CLAUDE.md forbids
 #             force-removing a worktree an agent does not own.
@@ -117,6 +121,13 @@
 # containing `f` (`-uf`, `-fu`, ...) are matched with an explicit boundary so
 # they do NOT fire inside --force, --force-with-lease, -force, or a filename
 # ending in "-f" (e.g. my-f-dir) -- see _has_force_flag below.
+#
+# Standalone `-n` (short form of --no-verify on `git commit`) and a clustered
+# short flag containing `n` (`-an`, `-anm`, ...) use the IDENTICAL boundary
+# mechanism -- see _has_noverify_flag below. A `+`-prefixed force refspec
+# (`git push origin +branch:branch`) is git's OTHER force syntax on `git
+# push`, independent of any flag and NEVER --force-with-lease-protected --
+# see _has_force_refspec below (issue #1292).
 set -u
 
 payload="$(cat)"
@@ -218,6 +229,37 @@ _bare_force_after_last_lease() {
 		| grep -Eq "(^|${_SEP})(--force|${_FORCE_CLUSTER})(\$|${_SEP})"
 }
 
+# _has_noverify_flag -- true iff the CURRENT SEGMENT ($seg) carries a
+# --no-verify bypass on `git commit`:
+#   * the literal substring --no-verify, OR
+#   * a single-dash short-flag CLUSTER containing n (-n, -an, -anm, ...) --
+#     -n is git's own short form of --no-verify on `git commit` (`git
+#     commit -h`), and clusters exactly like _has_force_flag's f-cluster
+#     (issue #1292). The same mandatory single leading dash is why this
+#     never matches --no-verify/--amend -- identical double-dash-boundary
+#     argument as _FORCE_CLUSTER above.
+_NOVERIFY_CLUSTER="-[a-z0-9]*n[a-z0-9]*"
+_has_noverify_flag() {
+	_contains '--no-verify' && return 0
+	printf '%s' "$seg" | grep -Eq "(^|${_SEP})${_NOVERIFY_CLUSTER}(\$|${_SEP})"
+}
+
+# _SEP_NOT -- the complement of _SEP: any character that is NOT a boundary
+# separator. Used by _has_force_refspec so the character right after a
+# leading `+` must belong to a ref-name token, not another separator (a bare
+# `+`, or one glued mid-token, doesn't match).
+_SEP_NOT='[^[:space:];|&(){}<>,]'
+
+# _has_force_refspec -- true iff the CURRENT SEGMENT ($seg) carries a
+# `+`-prefixed force REFSPEC on `git push` (`git push origin
+# +branch:branch`) -- git's OTHER force syntax, with no flag at all (`git
+# help push`: a leading `+` on a refspec forces a non-fast-forward update).
+# NEVER --force-with-lease-protected -- the lease guards a FLAG, not this
+# refspec shorthand, so callers must check it unconditionally (issue #1292).
+_has_force_refspec() {
+	printf '%s' "$seg" | grep -Eq "(^|${_SEP})\\+${_SEP_NOT}"
+}
+
 # _deny <reason> -- print the PreToolUse deny JSON and exit 0 (exit 0 is
 # required even for a deny: Claude Code reads the decision from stdout, not
 # from the process exit status). <reason> must contain no " or \ so it can
@@ -240,7 +282,7 @@ fi
 # box's /bin/sh) forks a subshell for the reader end of a pipe, which would
 # swallow _deny's `exit 0` instead of ending the whole script.
 while IFS= read -r seg; do
-	if _contains 'git commit' && _contains '--no-verify'; then
+	if _contains 'git commit' && _has_noverify_flag; then
 		_deny "the pre-commit lint gate's --no-verify bypass is for humans, not agents (CLAUDE.md)"
 	fi
 
@@ -248,6 +290,12 @@ while IFS= read -r seg; do
 		if ! _contains '--force-with-lease' || _bare_force_after_last_lease; then
 			_deny "the rebase-only landing flow uses --force-with-lease exclusively; a bare force-push can clobber another session's PR (CLAUDE.md)"
 		fi
+	fi
+
+	# A `+` force refspec (issue #1292) is NEVER lease-protected -- unconditional,
+	# unlike the flag check above which --force-with-lease can clear.
+	if _contains 'git push' && _has_force_refspec; then
+		_deny "the rebase-only landing flow uses --force-with-lease exclusively; a bare force-push can clobber another session's PR (CLAUDE.md)"
 	fi
 
 	if _contains 'git worktree remove' && _has_force_flag; then

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -179,6 +179,27 @@ Describe 'claude-bash-guard.sh'
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
 
+    It 'B16 (#1292, documented accepted false-positive): -n inside the commit MESSAGE text -> DENY'
+      # Same accepted class as B10, one letter over: a message quoting a real
+      # -n flag from another tool (grep -n, sed -n, ...) also denies -- the
+      # guard cannot distinguish "the flag" from "prose about a flag".
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -am \"use grep -n to show line numbers\""}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H20 (#1292 F3 clustered short flag, n FIRST): git commit -na -m x -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -na -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
     It 'P3: normal commit, no --no-verify (git commit -m x) -> PASS'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}
@@ -416,6 +437,18 @@ Describe 'claude-bash-guard.sh'
       The status should be success
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
+
+    It 'B17 (#1292, documented accepted false-positive): a `+` opening a push option VALUE -> DENY'
+      # `-o "+1 note"` is a normal push option whose value happens to start
+      # with +. Double-quote stripping (normalization) exposes it at a
+      # segment boundary, same accepted class as B10/B16 one char over.
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push origin main -o \"+1 note\""}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
   End
 
   # ── Rule C: git worktree remove + force flag ────────────────────────────────
@@ -605,6 +638,24 @@ Describe 'claude-bash-guard.sh'
     It 'C10 (#1292, no leak): a literal + in an unrelated segment does not force an unforced push -> PASS'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"echo +1 && git push origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'C11 (#1292, still caught): git status && a -n commit bypass in its own segment -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git status && git commit -n -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'C12 (#1292, no leak): a literal -n in an unrelated segment does not bypass an unforced commit -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"echo -n && git commit -m x"}}
       End
       When run script "$GUARD"
       The status should be success

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -9,13 +9,20 @@
 # asserts the exit status + stdout shape.
 #
 # Contracts pinned here:
-#   Rule A  -- git commit + --no-verify                       -> DENY
-#   Rule B  -- git push + force flag (--force / standalone -f /
+#   Rule A  -- git commit + --no-verify (long flag, standalone -n, or a
+#              clustered short flag like -an, -anm)            -> DENY
+#              (#1292: -n is git's own short form of --no-verify on
+#              `git commit`, and clusters exactly like Rule B's f-cluster)
+#   Rule B  -- git push + EITHER a force flag (--force / standalone -f /
 #              a clustered short flag like -uf, -fu, -4f)
-#              WITHOUT --force-with-lease                     -> DENY
+#              WITHOUT --force-with-lease, OR a `+`-prefixed force
+#              REFSPEC (`git push origin +branch:branch`)      -> DENY
 #              (lease present AND no bare force flag after the LAST
 #              --force-with-lease -> PASS; git honors the last force
-#              flag, so a bare force AFTER the lease still denies, #1058)
+#              flag, so a bare force AFTER the lease still denies, #1058.
+#              #1292: a `+` refspec is git's OTHER force syntax -- no flag
+#              at all, and NEVER lease-protected, so it denies even
+#              alongside --force-with-lease)
 #   Rule C  -- git worktree remove + force flag                -> DENY
 #   fail-open -- empty / garbled stdin, no rule match           -> PASS
 #   -f boundary -- standalone -f / an f-bearing short-flag cluster,
@@ -112,6 +119,51 @@ Describe 'claude-bash-guard.sh'
       When run script "$GUARD"
       The status should be success
       The output should equal '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"the pre-commit lint gate'"'"'s --no-verify bypass is for humans, not agents (CLAUDE.md)"}}'
+    End
+
+    It 'B11 (#1292): standalone short flag (git commit -n -m x) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -n -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B12 (#1292): clustered short flag, n mid-cluster (git commit -anm x) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -anm x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H15 (#1292 F3 clustered short flag, other order): git commit -an -m x -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -an -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H16 (#1292 F1 whitespace evasion): double space before a short -n (git  commit -n -m x) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git  commit -n -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H17 (#1292 F2 metachar boundary): git commit -n;true -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit -n;true"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
 
     It 'B10 (documented accepted false-positive): --no-verify inside the commit MESSAGE text -> DENY'
@@ -319,6 +371,51 @@ Describe 'claude-bash-guard.sh'
       The status should be success
       The output should equal ""
     End
+
+    It 'B13 (#1292): + force refspec, no flag at all (git push origin +branch:branch) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push origin +branch:branch"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B14 (#1292): + force refspec, src != dst (git push origin +feature:main) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push origin +feature:main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B15 (#1292, load-bearing): + force refspec ALONGSIDE --force-with-lease still DENIES (the lease never protects it)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease origin +branch:branch"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H18 (#1292 F2 metachar boundary): git push origin +branch:branch;true -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push origin +branch:branch;true"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H19 (#1292 F1 quoting evasion): a quoted refspec (git push origin \"+branch:branch\") -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push origin \"+branch:branch\""}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
   End
 
   # ── Rule C: git worktree remove + force flag ────────────────────────────────
@@ -494,6 +591,24 @@ Describe 'claude-bash-guard.sh'
       When run script "$GUARD"
       The status should be success
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'C9 (#1292, still caught): git status && a + force refspec push in its own segment -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git status && git push origin +branch:branch"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'C10 (#1292, no leak): a literal + in an unrelated segment does not force an unforced push -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"echo +1 && git push origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
     End
   End
 


### PR DESCRIPTION
## Summary

Fixes #1292 — two coverage gaps in `scripts/claude-bash-guard.sh` found by the post-merge audit of the 2026-07-10..07-13 devel batch. Both are misses inside existing rules' stated intent (no new rule classes):

- **Rule A** (`git commit` + `--no-verify` bypass) matched only the literal long flag. It missed the short form `-n` — git's actual short flag for `--no-verify` on `git commit` — alone or clustered with other short flags (e.g. `-anm "msg"`). Rule B already treats a clustered short flag as equivalent to its long form for `--force`; Rule A doing literal-substring-only was inconsistent with that.
- **Rule B** (`git push` force detection) checked force *flags* only. It missed git's other force syntax: a refspec argument starting with `+` (`git push origin +branch:branch`), which force-pushes with no flag at all and is never `--force-with-lease`-protected.

## Changes

- `scripts/claude-bash-guard.sh`: new `_has_noverify_flag()` (mirrors `_has_force_flag`'s cluster-boundary logic, new `_NOVERIFY_CLUSTER` pattern) wired into Rule A; new `_has_force_refspec()` (new `_SEP_NOT` boundary-complement class) wired into Rule B as an unconditional second check (a `+refspec` is never lease-protected). Header + inline rule documentation updated to match.
- `tests/shell/claude_bash_guard_spec.sh`: 12 new examples (B11-B15, H15-H19, C9-C10) covering the standalone/clustered `-n` bypass, the `+refspec` force push (including alongside `--force-with-lease`, and per-segment scoping), plus regression re-verification that all existing PASS/DENY cases are unaffected.

## Test plan

- [x] Red-first: reverted the script to pre-fix, ran the frozen (byte-identical, hash-pinned) new test cases — 11 failures, exactly the 11 new DENY-expecting examples; the 12th new (PASS/no-leak) case was already green pre-fix.
- [x] Green: restored the fix, same test file zero edits — 84 examples, 0 failures.
- [x] `sh -n scripts/claude-bash-guard.sh` clean.
- [x] `shellcheck scripts/claude-bash-guard.sh` clean.
- [x] `shellspec --shell dash tests/shell/claude_bash_guard_spec.sh` — 84/84 pass.
- [x] `check_comment_narration.py`, `check_retired_tokens.py`, `check_url_encoding.py`, `check_version_literals.py` all clean on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gr4Sj3PTxg6CCSEMo2KtNk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened detection to prevent bypassing commit verification using `--no-verify` and clustered `-n` short-flag variants, with boundary-aware matching.
  * Improved force-push protections by handling `+`-prefixed force refspecs, including quoted forms and edge cases around command options and boundaries.
  * Enhanced per-command-segment isolation to avoid unrelated text influencing security decisions, reducing similar-text false positives.
* **Tests**
  * Added new cases for `git commit -n` variants, whitespace/metachar boundaries, `+` force refspec behavior, and multi-command segment scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->