### PR TITLE
agent: wait-reviewer.sh distinguishes a stale-but-real review (TIMEOUT) from no engagement (NOTPRESENT)

### DIFF
--- a/scripts/agent/wait-reviewer.sh
+++ b/scripts/agent/wait-reviewer.sh
@@ -29,6 +29,7 @@
 
 repo='' pr='' handle='' mode='finished' since='' presence=10 interval=30 max_iter=''
 inline='' review='' issuec='' sinfo=''
+inline_any='' review_any='' issuec_any=''
 
 usage() {
 	echo "usage: wait-reviewer.sh --repo O/R --pr N --handle LOGIN [--until ack|finished] [--since ISO] [--presence N] [--interval S] [--max-iter N]" >&2
@@ -83,10 +84,11 @@ classify() {
 # a public account whose login merely CONTAINS the handle must not satisfy the wait,
 # and a verbatim bracketed login must match itself (no regex-metachar surface).
 jq_filter() {
-	# $1 = timestamp field name
+	# $1 = timestamp field name, $2 = "notime" to skip the --since floor.
+	# issue #1325: presence must survive a rebase moving $since past a real prior review.
 	# shellcheck disable=SC2016 # $l is jq syntax, not a shell expansion
 	m=$(printf '((.user.login|ascii_downcase) as $l | ($l == "%s") or ($l == "%s[bot]") or ($l | startswith("%s-")))' "$handle" "$handle" "$handle")
-	if [ -n "$since" ]; then
+	if [ -n "$since" ] && [ "$2" != "notime" ]; then
 		printf '.[] | select(%s) | select(.%s > "%s")' "$m" "$1" "$since"
 	else
 		printf '.[] | select(%s)' "$m"
@@ -97,6 +99,17 @@ fetch_state() {
 	inline=$(gh api "repos/$repo/pulls/$pr/comments" --paginate -q "$(jq_filter created_at) | .id" 2>/dev/null)
 	review=$(gh api "repos/$repo/pulls/$pr/reviews" --paginate -q "$(jq_filter submitted_at) | (.body // \"x\")" 2>/dev/null)
 	issuec=$(gh api "repos/$repo/issues/$pr/comments" --paginate -q "$(jq_filter updated_at) | (.body // \"\")" 2>/dev/null)
+	# Presence (any commit) vs content (since $since) split (issue #1325): only fetched
+	# when $since narrows the content query, else presence == content already.
+	if [ -n "$since" ]; then
+		inline_any=$(gh api "repos/$repo/pulls/$pr/comments" --paginate -q "$(jq_filter created_at notime) | .id" 2>/dev/null)
+		review_any=$(gh api "repos/$repo/pulls/$pr/reviews" --paginate -q "$(jq_filter submitted_at notime) | .id" 2>/dev/null)
+		issuec_any=$(gh api "repos/$repo/issues/$pr/comments" --paginate -q "$(jq_filter updated_at notime) | .id" 2>/dev/null)
+	else
+		inline_any=$inline
+		review_any=$review
+		issuec_any=$issuec
+	fi
 	if [ "$handle" = "snyk" ]; then
 		sha=$(gh pr view "$pr" --repo "$repo" --json headRefOid -q .headRefOid 2>/dev/null)
 		sinfo=$(gh api "repos/$repo/commits/$sha/status" \
@@ -145,7 +158,7 @@ main() {
 			break
 		fi
 		fetch_state
-		[ -n "${inline}${review}${issuec}$(printf '%s' "$sinfo" | tr -dc '[:lower:]')" ] && seen=1
+		[ -n "${inline_any}${review_any}${issuec_any}$(printf '%s' "$sinfo" | tr -dc '[:lower:]')" ] && seen=1
 		v=$(classify)
 		if [ -n "$v" ]; then
 			printf '%s\n' "$issuec" | head -c 3000

--- a/tests/shell/agent_wait_reviewer_spec.sh
+++ b/tests/shell/agent_wait_reviewer_spec.sh
@@ -174,7 +174,19 @@ End
 Describe 'wait-reviewer.sh loop verdicts (stub gh)'
   setup_stub() {
     stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/ghstub.XXXXXX")"
-    printf '#!/bin/sh\ncase "$*" in *pulls/*/comments*) cat "$GH_STUB_INLINE" 2>/dev/null;; *) exit 0;; esac\n' > "$stubdir/gh"
+    cat > "$stubdir/gh" <<'STUB'
+#!/bin/sh
+case "$*" in
+	*pulls/*/comments*) cat "$GH_STUB_INLINE" 2>/dev/null ;;
+	*pulls/*/reviews*)
+		case "$*" in
+			*'select(.submitted_at >'*) cat "$GH_STUB_REVIEW_SINCE" 2>/dev/null ;;
+			*) cat "$GH_STUB_REVIEW_ANY" 2>/dev/null ;;
+		esac
+		;;
+	*) exit 0 ;;
+esac
+STUB
     chmod +x "$stubdir/gh"
     PATH="$stubdir:$PATH"
   }
@@ -207,6 +219,13 @@ Describe 'wait-reviewer.sh loop verdicts (stub gh)'
     echo 42 > "$GH_STUB_INLINE"
     export PFB_WAIT_DEADLINE=1
     When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 3
+    The line 1 of output should equal 'TIMEOUT'
+  End
+
+  It 'treats a review posted before --since as presence: TIMEOUT, not NOTPRESENT (issue #1325)'
+    export GH_STUB_REVIEW_ANY="$stubdir/review_any.txt"
+    echo 99 > "$GH_STUB_REVIEW_ANY"
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 3 --presence 1
     The line 1 of output should equal 'TIMEOUT'
   End
 End


### PR DESCRIPTION
Fixes #1325.

`wait-reviewer.sh`'s `fetch_state()` baked the `--since` cutoff into the SAME query used to compute the `seen` presence flag. In finished mode, `since` defaults to the current head commit's `committedDate` — a review submitted against an EARLIER commit (including one made stale purely by a content-preserving rebase, new SHA same diff) was filtered out entirely, so `seen` stayed 0 and the script reported `NOTPRESENT` for a reviewer that had demonstrably already reviewed.

Fix: `jq_filter()` gains a presence-only `notime` mode; `fetch_state()` additionally fetches `inline_any`/`review_any`/`issuec_any` unfiltered by `--since`, and `seen` now derives from those instead of the since-filtered vars. A stale-but-real review now correctly reaches `TIMEOUT` (review exists, nothing fresh since the cutoff) instead of `NOTPRESENT` (never engaged) — the two are semantically distinct to every caller (`pr-comments`, `pr-merge-flow`).

Live repro (pasted in the issue): PR #1313, Copilot review submitted `03:42:51Z` against pre-rebase commit `193b672c`, filtered out by a `since` cutoff of `04:02:44Z` (the rebased head's commit time) — `wait-reviewer.sh --handle copilot --until finished` returned `NOTPRESENT` despite the review existing.

Tests: new shellspec case in `tests/shell/agent_wait_reviewer_spec.sh` reproducing the exact shape (review recorded against a superseded commit, `since` = a later commit's timestamp) — expects `TIMEOUT`, was `NOTPRESENT` pre-fix. Red confirmed against the pre-fix script, green after, zero edits to the test between. Full shellspec suite: 762 examples, 0 failures (8 pre-existing env-gated skips, unrelated).

---
🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reviewer presence detection when using time-based filtering.
  * Prevented existing reviews from being incorrectly reported as “not present”; they now correctly result in a timeout when appropriate.

* **Tests**
  * Added coverage for reviewer presence checks involving reviews posted before the selected time range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->