### PR TITLE
pfblockerng: unlink truncated DNSBLIP destination on write failure

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1987,6 +1987,9 @@ function pfb_dnsbl_concat_files(string $dest, array $sources): bool {
 					if (!pfb_dnsbl_concat_write_ok(@fwrite($out, $line), $line)) {
 						@fclose($in);
 						@fclose($out);
+						// issue #1275: fopen() above already truncated $dest -- leaving it
+						// behind stalls every retry gate that checks file_exists($dest).
+						unlink_if_exists($dest);
 						pfb_logger("\nDNSBL: write failed for [ {$dest} ] -- assembly aborted", 2);
 						return FALSE;
 					}

--- a/tests/php/PfbDnsblConcatFilesTest.php
+++ b/tests/php/PfbDnsblConcatFilesTest.php
@@ -18,6 +18,72 @@ use PHPUnit\Framework\TestCase;
  * The unwritable destination is modeled as a NON-EXISTENT directory (fopen fails for any
  * uid, unlike a chmod fixture, which root bypasses).
  */
+
+/**
+ * Stream wrapper simulating fopen($dest, 'w') SUCCEEDING (unlike the case-A test's
+ * missing-directory fopen failure) followed by a mid-loop fwrite() failure -- the
+ * confirmed-truncation case (issue #1275). Accepts exactly $writeBudget real writes
+ * (so the destination genuinely holds partial bytes at the moment of failure), then
+ * fails every write after; records whether unlink() was ever invoked on it. Single
+ * consumer, so it lives in this file (unlike the shared PfbTruncatedReadStreamWrapper).
+ */
+final class PfbFailingWriteStreamWrapper
+{
+	/** @var resource|null */
+	public $context;
+	private static int $writeBudget = 0;
+	private static int $calls = 0;
+	public static string $written = '';
+	public static bool $unlinkCalled = FALSE;
+
+	public static function reset(int $writeBudget): void
+	{
+		self::$writeBudget  = $writeBudget;
+		self::$calls        = 0;
+		self::$written      = '';
+		self::$unlinkCalled = FALSE;
+	}
+
+	public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+	{
+		return TRUE;
+	}
+
+	public function stream_write(string $data): int|false
+	{
+		self::$calls++;
+		if (self::$calls > self::$writeBudget) {
+			return FALSE;
+		}
+		self::$written .= $data;
+		return strlen($data);
+	}
+
+	public function stream_eof(): bool
+	{
+		return FALSE;
+	}
+
+	public function stream_close(): void
+	{
+	}
+
+	/** @return array<string,int> */
+	public function url_stat(string $path, int $flags): array
+	{
+		return array_fill_keys(
+			['dev', 'ino', 'mode', 'nlink', 'uid', 'gid', 'rdev', 'size', 'atime', 'mtime', 'ctime', 'blksize', 'blocks'],
+			0
+		);
+	}
+
+	public function unlink(string $path): bool
+	{
+		self::$unlinkCalled = TRUE;
+		return TRUE;
+	}
+}
+
 #[CoversFunction('pfb_dnsbl_concat_files')]
 #[CoversFunction('pfb_dnsbl_concat_write_ok')]
 final class PfbDnsblConcatFilesTest extends TestCase
@@ -98,6 +164,43 @@ final class PfbDnsblConcatFilesTest extends TestCase
 			$logged,
 			'the skip must be operator-visible, not silent'
 		);
+	}
+
+	/**
+	 * issue #1275: fopen($dest, 'w') SUCCEEDS here (unlike the case-A test above), so
+	 * 'w' mode already truncated $dest before the mid-loop write failure. Two 2-line
+	 * sources, wrapper accepts exactly 3 real writes then fails the 4th -- proving
+	 * genuine partial bytes landed (not merely an empty file) at the moment of failure.
+	 * A left-behind truncated $dest is otherwise stuck "current" until an unrelated
+	 * source-content change (issue #1275): the caller's !file_exists($dest) retry gate
+	 * and pfb_dnsblip_rebuild_check()'s !is_file($output) gate both need $dest gone.
+	 */
+	public function testWriteFailureUnlinksTheTruncatedDestination(): void
+	{
+		$src1 = "{$this->workdir}/one.txt";
+		$src2 = "{$this->workdir}/two.txt";
+		file_put_contents($src1, "1.example.com\n2.example.com\n");
+		file_put_contents($src2, "3.example.com\n4.example.com\n");
+
+		PfbFailingWriteStreamWrapper::reset(3);
+		stream_wrapper_register('pfbfailwrite', PfbFailingWriteStreamWrapper::class);
+
+		try {
+			$result = pfb_dnsbl_concat_files('pfbfailwrite://sink', [$src1, $src2]);
+
+			$this->assertFalse($result, 'a mid-loop write failure must return FALSE');
+			$this->assertSame(
+				"1.example.com\n2.example.com\n3.example.com\n",
+				PfbFailingWriteStreamWrapper::$written,
+				'real bytes must have been flushed before the failure -- proves the destination was truncated, not merely empty'
+			);
+			$this->assertTrue(
+				PfbFailingWriteStreamWrapper::$unlinkCalled,
+				'a confirmed write-failure truncation (fopen already succeeded) must unlink the destination so the next pass retries'
+			);
+		} finally {
+			stream_wrapper_unregister('pfbfailwrite');
+		}
 	}
 
 	public function testVanishedSourceIsSkippedNotFatal(): void


### PR DESCRIPTION
## Summary

`pfb_dnsbl_concat_files()` opens its destination with `fopen($dest, 'w')`, which truncates it immediately. If a later `fwrite()` inside the copy loop fails, the function closes the handles and returns `FALSE`, but leaves the now-truncated destination on disk. Both DNSBLIP callers (`DNSBLIP_v4.txt` / `DNSBLIP_v6.txt`) gate their rebuild on `($pfb['updateip'] || !file_exists($dest))`, so the truncated file "existing" blocks every retry until an unrelated source-content change flips `updateip`. Worse: if the `.ip` source set later reverts to exactly the fingerprint stamped in `.fp` by the last *successful* build, `pfb_dnsblip_rebuild_check()` also declares the (truncated) output current, since a failed build never re-stamps `.fp`.

Fix: `unlink_if_exists($dest)` in the write-failure branch **only** — the one place where truncation is confirmed (`fopen` succeeded, meaning `$dest` was already truncated before the write failed). The separate fopen-failure branch (`fopen($dest, 'w')` itself returning `FALSE`) is left untouched, since in that case `$dest` was never opened and may still hold a good pre-existing file from an earlier successful build.

Once the truncated destination is unlinked, the next pass's outer gate (`!file_exists($dest)`) is true regardless of `updateip`, and the inner `pfb_dnsblip_rebuild_check()`'s `!is_file($output)` is also true regardless of a stale `.fp` match — both corners described in the issue are fixed by the one change. `pfb_dnsbl_concat_files()` is also used by the DNSBL_file `.raw` assembly path; the fix applies there too, harmlessly (that `.raw` file is only ever consumed on the success branch and is already unconditionally re-unlinked before every pass).

Fixes #1275

## Test plan

- [x] New PHPUnit test `testWriteFailureUnlinksTheTruncatedDestination` (`tests/php/PfbDnsblConcatFilesTest.php`) using a custom write-failing stream wrapper (`PfbFailingWriteStreamWrapper`, mirroring the house `PfbTruncatedReadStreamWrapper` read-side pattern): destination open succeeds, several real bytes are accepted (proving genuine partial content, not an empty file), then a later write fails — asserts the destination's `unlink()` is actually invoked.
- [x] Existing `testUnwritableDestinationDegradesInsteadOfThrowing` (the *other* failure branch — `fopen` fails outright) re-run unmodified and confirmed still green, proving no regression: a good pre-existing file in that branch is never deleted.
- [x] Full `vendor/bin/phpunit` (3350 tests, 0 failures), `composer phpstan` (no errors), `composer phpcs` (clean), `php -l` on both touched files.
- [x] Red→green proof executed and independently re-derived by a fresh verifier via `scripts/agent/verify-red-proof.sh` (FREEZE-OK / RED-OK / GREEN-OK / VERDICT: PASS).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DNSBL file write failures leaving behind truncated files that could block subsequent retry attempts.
  * Failed writes now clean up incomplete destination files automatically.

* **Tests**
  * Added coverage to verify partial writes return an error and remove the incomplete file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->