### PR TITLE
tests: pin the AA ASIA/EUROPE UNDEFINED continent buckets (#1246)

### DIFF
--- a/tests/php/GeoipContinentUndefinedBucketTest.php
+++ b/tests/php/GeoipContinentUndefinedBucketTest.php
@@ -12,8 +12,8 @@ use PHPUnit\Framework\TestCase;
  * existing suite.
  *
  * The file carries top-level execution and cannot be require()d
- * off-appliance (house precedent: CountryNetworksCountGuardTest.php). The
- * two-statement block is eval-extracted verbatim so the oracle tracks
+ * off-appliance (house precedent: CountryNetworksCountGuardTest.php). Each
+ * bucket assignment is eval-extracted independently so the oracle tracks
  * whichever literal is actually in source.
  *
  * Feature: the Asia/Europe "undefined" pseudo-country buckets are built
@@ -24,41 +24,39 @@ use PHPUnit\Framework\TestCase;
  */
 final class GeoipContinentUndefinedBucketTest extends TestCase
 {
-	private static string $src;
-
-	public static function setUpBeforeClass(): void
+	// Oracle: each hardcoded bucket-assignment statement extracted independently
+	// (not as one adjacency-bound pair), so an unrelated edit between the two
+	// real lines can't spuriously break this test.
+	private static function extractBucketOracle(string $geonameId): array
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php';
-		$src = file_get_contents($path);
-		if ($src === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng.php');
-		}
-		self::$src = $src;
-
-		// Oracle: the two hardcoded bucket-assignment statements, extracted
-		// verbatim so the test tracks whichever literal is actually in source.
-		if (!function_exists('pfb_geoip_undefined_continent_oracle')) {
+		$fn = "pfb_geoip_undefined_continent_oracle_{$geonameId}";
+		if (!function_exists($fn)) {
+			$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php';
+			$src = file_get_contents($path);
+			if ($src === FALSE) {
+				throw new RuntimeException('test bootstrap: failed to read pfblockerng.php');
+			}
 			if (!preg_match(
-				'/\$pfb_geoip\[\'country\'\]\[\'6255147\'\]\s*=\s*array\(.*?\);'
-				. '\s*\$pfb_geoip\[\'country\'\]\[\'6255148\'\]\s*=\s*array\(.*?\);/s',
+				'/\$pfb_geoip\[\'country\'\]\[\'' . preg_quote($geonameId, '/') . '\'\]\s*=\s*array\(.*?\);/s',
 				$src,
 				$m
 			)) {
-				throw new RuntimeException('oracle extraction failed: the 6255147/6255148 bucket assignments were not found in pfblockerng.php');
+				throw new RuntimeException("oracle extraction failed: the {$geonameId} bucket assignment was not found in pfblockerng.php");
 			}
 			eval(
-				'function pfb_geoip_undefined_continent_oracle(): array {'
+				"function {$fn}(): array {"
 				. ' $pfb_geoip = ["country" => []];'
 				. ' ' . $m[0]
 				. ' return $pfb_geoip["country"];'
 				. ' }'
 			);
 		}
+		return $fn();
 	}
 
 	public function testAsiaUndefinedBucketShape(): void
 	{
-		$country = pfb_geoip_undefined_continent_oracle();
+		$country = self::extractBucketOracle('6255147');
 		$this->assertArrayHasKey(
 			'6255147',
 			$country,
@@ -72,7 +70,7 @@ final class GeoipContinentUndefinedBucketTest extends TestCase
 
 	public function testEuropeUndefinedBucketShape(): void
 	{
-		$country = pfb_geoip_undefined_continent_oracle();
+		$country = self::extractBucketOracle('6255148');
 		$this->assertArrayHasKey(
 			'6255148',
 			$country,

--- a/tests/php/GeoipContinentUndefinedBucketTest.php
+++ b/tests/php/GeoipContinentUndefinedBucketTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1246: pfblockerng_uc_countries() hardcodes two continent-level
+ * pseudo-country bucket entries (geoname_ids 6255147/6255148) so MaxMind's
+ * continent-only Locations rows still resolve to a synthetic pseudo-country
+ * instead of hitting an undefined-array-key warning. Unexercised by the
+ * existing suite.
+ *
+ * The file carries top-level execution and cannot be require()d
+ * off-appliance (house precedent: CountryNetworksCountGuardTest.php). The
+ * two-statement block is eval-extracted verbatim so the oracle tracks
+ * whichever literal is actually in source.
+ *
+ * Feature: the Asia/Europe "undefined" pseudo-country buckets are built
+ *          with their expected continent, name, iso and continent_en
+ *
+ *   Scenario: geoname_id 6255147 (Asia continent-only rows)
+ *   Scenario: geoname_id 6255148 (Europe continent-only rows)
+ */
+final class GeoipContinentUndefinedBucketTest extends TestCase
+{
+	private static string $src;
+
+	public static function setUpBeforeClass(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php';
+		$src = file_get_contents($path);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.php');
+		}
+		self::$src = $src;
+
+		// Oracle: the two hardcoded bucket-assignment statements, extracted
+		// verbatim so the test tracks whichever literal is actually in source.
+		if (!function_exists('pfb_geoip_undefined_continent_oracle')) {
+			if (!preg_match(
+				'/\$pfb_geoip\[\'country\'\]\[\'6255147\'\]\s*=\s*array\(.*?\);'
+				. '\s*\$pfb_geoip\[\'country\'\]\[\'6255148\'\]\s*=\s*array\(.*?\);/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('oracle extraction failed: the 6255147/6255148 bucket assignments were not found in pfblockerng.php');
+			}
+			eval(
+				'function pfb_geoip_undefined_continent_oracle(): array {'
+				. ' $pfb_geoip = ["country" => []];'
+				. ' ' . $m[0]
+				. ' return $pfb_geoip["country"];'
+				. ' }'
+			);
+		}
+	}
+
+	public function testAsiaUndefinedBucketShape(): void
+	{
+		$country = pfb_geoip_undefined_continent_oracle();
+		$this->assertArrayHasKey(
+			'6255147',
+			$country,
+			'issue #1246: geoname_id 6255147 (Asia continent-only rows) must resolve to a pseudo-country bucket'
+		);
+		$this->assertSame(
+			['continent' => 'Asia', 'name' => 'AA ASIA UNDEFINED', 'iso' => ['6255147'], 'continent_en' => 'Asia'],
+			$country['6255147']
+		);
+	}
+
+	public function testEuropeUndefinedBucketShape(): void
+	{
+		$country = pfb_geoip_undefined_continent_oracle();
+		$this->assertArrayHasKey(
+			'6255148',
+			$country,
+			'issue #1246: geoname_id 6255148 (Europe continent-only rows) must resolve to a pseudo-country bucket'
+		);
+		$this->assertSame(
+			['continent' => 'Europe', 'name' => 'AA EUROPE UNDEFINED', 'iso' => ['6255148'], 'continent_en' => 'Europe'],
+			$country['6255148']
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `tests/php/GeoipContinentUndefinedBucketTest.php`, pinning the two hardcoded
  continent-level pseudo-country bucket entries in `pfblockerng_uc_countries()`
  (`src/usr/local/www/pfblockerng/pfblockerng.php`) — geoname_id `6255147` ("AA ASIA
  UNDEFINED") and `6255148` ("AA EUROPE UNDEFINED"). These let MaxMind's continent-only
  Locations/Blocks rows (~700 real networks: 539 IPv4 + 158 IPv6) still resolve instead of
  hitting an undefined-array-key warning. Nothing tested this construction before.
- Coverage-only change — **zero production code touched**. Uses the codebase's established
  eval-extraction-oracle pattern for this top-level-execution file (house precedent:
  `CountryNetworksCountGuardTest.php`, `GeoipContinentCatStderrGuardTest.php`).

## Scope note

Issue #1246's own tracking comment (from the repo owner) folds the **full** end-to-end fix —
a fixture Locations/Blocks CSV addendum row, the alias-file build
(`6255147_v4.txt`/`6255148_v4.txt`), and live-VM smoke — into **ADR-64**
(`.ADRs/ADR_64_GeoIP_Truth_Table/`, currently Status: Proposed, no phases landed) Phases 1 and
6, explicitly noting the issue is "**kept open until Phase 6 lands**". This PR only closes the
narrower "bucket construction is unexercised" gap with a unit test; it deliberately does not
touch `tests/smoke/fixtures/` or `scripts/update-geoip-fixtures.py`, since that's ADR-64 Phase
1's planned job (see `01_Oracle_Capture.txt` action item 3) — duplicating it here would create
rework when that phase lands.

**Part of #1246** — not closing it (per the owner's own "kept open" note above); ADR-64 Phase
6 owns the full close-out.

## Test plan

- [x] `php -l tests/php/GeoipContinentUndefinedBucketTest.php`
- [x] `vendor/bin/phpunit --filter GeoipContinentUndefinedBucketTest` → `OK (2 tests, 4 assertions)`
- [x] Full `vendor/bin/phpunit` suite green (delta vs base: exactly +2 tests/+4 assertions,
      pre-existing deprecation/notice/skip counts unchanged)
- [x] `composer phpstan` clean
- [x] `composer phpcs -- --standard=phpcs.xml.dist src/` clean (no-op, no `src/` changes)
- [x] Vacuity proof (no production bug to fix, so no real red/green pair exists — proven
      instead by deliberate source mutation, independently re-derived by a separate
      verification pass with a *different* mutation than the implementer used): corrupting
      either hardcoded bucket value in a scratch edit trips exactly the test method that
      covers it, while the sibling method stays green — proving the two assertions are
      independent, not a shared vacuous check. Reverted before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage to verify that undefined Asia and Europe GeoIP continent buckets are created with the expected entries and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->