### PR TITLE
scripts: anchor work-branch.sh worktrees at the primary checkout

### DIFF
--- a/scripts/agent/work-branch.sh
+++ b/scripts/agent/work-branch.sh
@@ -5,9 +5,10 @@
 # Usage: work-branch.sh <issue|adr> <NN> [TITLE ...] [--worktree] [--path PATH] [--base REF]
 #   Prints the branch name (`issue/NN-slug` / `adr/NN-slug`; empty slug -> bare `type/NN`).
 #   --worktree  also `git fetch origin` + `git worktree add -b BRANCH PATH BASE` at an
-#               ABSOLUTE path (default <repo>/.claude/worktrees/<type>-<NN>); an existing
-#               branch or path gets a `-<epoch>` suffix (collision rule). Prints
-#               `BRANCH<TAB>PATH` instead.
+#               ABSOLUTE path (default <primary checkout>/.claude/worktrees/<type>-<NN>;
+#               a relative --path anchors there too, even when invoked from a linked
+#               worktree); an existing branch or path gets a `-<epoch>` suffix
+#               (collision rule). Prints `BRANCH<TAB>PATH` instead.
 #   --base REF  worktree base (default origin/devel)
 #
 # Sanitiser (pinned by tests/shell/agent_work_branch_spec.sh): lowercase; every
@@ -64,7 +65,11 @@ main() {
 	fi
 
 	require_tool git
-	root=$(git rev-parse --show-toplevel) || exit 2
+	# Anchor at the PRIMARY checkout: rc-mode/managed sessions run inside a linked
+	# session worktree, where --show-toplevel would nest the new worktree in a tree
+	# whose lifecycle the harness owns (pinned by agent_work_branch_spec.sh).
+	common=$(git rev-parse --git-common-dir) || exit 2
+	root=$(cd "$common/.." && pwd -P) || exit 2
 	git fetch origin >/dev/null 2>&1
 	if git show-ref --verify -q "refs/heads/$branch" ||
 	   git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then

--- a/scripts/agent/work-branch.sh
+++ b/scripts/agent/work-branch.sh
@@ -69,7 +69,12 @@ main() {
 	# session worktree, where --show-toplevel would nest the new worktree in a tree
 	# whose lifecycle the harness owns (pinned by agent_work_branch_spec.sh).
 	common=$(git rev-parse --git-common-dir) || exit 2
-	root=$(cd "$common/.." && pwd -P) || exit 2
+	# CDPATH= : a CDPATH hit would echo the dir and hijack a relative cd.
+	root=$(CDPATH='' cd "$common/.." && pwd -P) || exit 2
+	if [ ! -e "$root/.git" ]; then
+		echo "work-branch.sh: cannot locate the primary checkout from '$common' (unsupported layout, e.g. --separate-git-dir)" >&2
+		exit 2
+	fi
 	git fetch origin >/dev/null 2>&1
 	if git show-ref --verify -q "refs/heads/$branch" ||
 	   git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -97,6 +97,30 @@ Describe 'work-branch.sh --worktree anchors at the primary checkout'
     The output should equal "$(printf 'issue/9-tld\t%s/.claude/worktrees/issue-9' "$primary")"
     The stderr should include 'Preparing worktree'
   End
+
+  It 'is immune to an inherited CDPATH when resolving the primary root'
+    # A CDPATH hit makes cd echo the destination AND resolve relative to the
+    # CDPATH entry instead of $PWD — either corrupts the derived root.
+    When run sh -c 'mkdir -p "$3/.git" && cd "$1" && CDPATH=$3 exec sh "$2" issue 10 tld --worktree --base HEAD' _ "$primary" "$script_abs" "$fixture/decoy"
+    The status should equal 0
+    The output should equal "$(printf 'issue/10-tld\t%s/.claude/worktrees/issue-10' "$primary")"
+    The stderr should include 'Preparing worktree'
+  End
+
+  It 'refuses a --separate-git-dir layout instead of anchoring outside the checkout'
+    When run sh -c 'git init -q --separate-git-dir "$1/gitmeta" "$1/sep" &&
+      git -C "$1/sep" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q --allow-empty -m init &&
+      cd "$1/sep" && exec sh "$2" issue 11 tld --worktree --base HEAD' _ "$fixture" "$script_abs"
+    The status should equal 2
+    The stderr should include 'separate-git-dir'
+  End
+
+  It 'leaves an absolute --path untouched when run from a linked worktree'
+    When run sh -c 'cd "$1" && exec sh "$2" issue 12 tld --worktree --base HEAD --path "$3"' _ "$fixture/session" "$script_abs" "$fixture/abs-target"
+    The status should equal 0
+    The output should equal "$(printf 'issue/12-tld\t%s/abs-target' "$fixture")"
+    The stderr should include 'Preparing worktree'
+  End
 End
 
 Describe 'work-branch.sh slugify() truncation edges'

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -55,6 +55,50 @@ Describe 'work-branch.sh branch naming'
   End
 End
 
+Describe 'work-branch.sh --worktree anchors at the primary checkout'
+  # rc-mode / managed sessions run inside a linked session worktree; a new
+  # worktree must land under the PRIMARY root, never nested in the session tree.
+  script_abs="${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/work-branch.sh"
+
+  setup() {
+    # Under a git hook, exported GIT_DIR/GIT_INDEX_FILE would aim the fixture's
+    # nested git calls at the hook's repo (see scripts/lib/git-env-scrub.sh).
+    . "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/lib/git-env-scrub.sh"
+    pfb_scrub_git_env
+    fixture=$(mktemp -d "${TMPDIR:-/tmp}/wb_spec.XXXXXX") || return 1
+    fixture=$(cd "$fixture" && pwd -P) || return 1
+    primary="$fixture/primary"
+    git init -q "$primary" &&
+      git -C "$primary" -c user.email=t@t -c user.name=t -c commit.gpgsign=false \
+        commit -q --allow-empty -m init &&
+      git -C "$primary" worktree add -q --detach "$fixture/session" >/dev/null 2>&1
+  }
+  cleanup() { rm -rf "$fixture"; }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'defaults the path under the primary root when run from a linked worktree'
+    When run sh -c 'cd "$1" && exec sh "$2" issue 7 tld --worktree --base HEAD' _ "$fixture/session" "$script_abs"
+    The status should equal 0
+    The output should equal "$(printf 'issue/7-tld\t%s/.claude/worktrees/issue-7' "$primary")"
+    The stderr should include 'Preparing worktree'
+  End
+
+  It 'anchors a relative --path at the primary root when run from a linked worktree'
+    When run sh -c 'cd "$1" && exec sh "$2" issue 8 tld --worktree --base HEAD --path wt/x' _ "$fixture/session" "$script_abs"
+    The status should equal 0
+    The output should equal "$(printf 'issue/8-tld\t%s/wt/x' "$primary")"
+    The stderr should include 'Preparing worktree'
+  End
+
+  It 'keeps the primary-checkout default placement unchanged'
+    When run sh -c 'cd "$1" && exec sh "$2" issue 9 tld --worktree --base HEAD' _ "$primary" "$script_abs"
+    The status should equal 0
+    The output should equal "$(printf 'issue/9-tld\t%s/.claude/worktrees/issue-9' "$primary")"
+    The stderr should include 'Preparing worktree'
+  End
+End
+
 Describe 'work-branch.sh slugify() truncation edges'
   # shellcheck disable=SC2034 # consumed by the Included script's source-only guard
   AGENT_SOURCE_ONLY=1


### PR DESCRIPTION
## What

`work-branch.sh --worktree` derived its root from `git rev-parse --show-toplevel`. Invoked from inside a linked worktree — which is where every rc-mode session (one auto-worktree per session at `.claude/worktrees/bridge-<session-id>`) and managed session runs — that names the *session* worktree, so the new per-item worktree nested inside a tree whose lifecycle the harness owns, and a session-worktree cleanup would take the per-item tree (and its unpushed work) with it.

The root is now the parent of `git rev-parse --git-common-dir`, which names the primary checkout from anywhere: default placement and relative `--path` values both anchor there. Behaviour when invoked from the primary checkout is unchanged (`--git-common-dir` = `.git` ⇒ same root as before).

## Tests (red-first)

Three new shellspec rows in `tests/shell/agent_work_branch_spec.sh` build a primary + linked-worktree fixture repo:

- default path from inside a linked worktree lands under the primary root — **red** before the fix (landed under the session tree), green after;
- relative `--path` from inside a linked worktree anchors at the primary root — **red** before, green after;
- default path from the primary checkout is unchanged — green before and after (regression pin).

Red run: 15 examples, 2 failures (the two rows above). Green run, spec byte-identical (`git hash-object` `c93004ca` at red and at commit): 15 examples, 0 failures. The fixture sources `scripts/lib/git-env-scrub.sh` so its nested git calls survive the pre-commit hook's exported `GIT_DIR`/`GIT_INDEX_FILE` (the ADR-47 trap).

Gates: `run-gates.sh --diff origin/devel` → PASS (sh -n, shellcheck, shellspec under dash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree path handling when creating branches from linked checkouts.
  * Ensured default and relative custom paths consistently anchor to the primary checkout.
  * Preserved existing collision handling and output behavior.

* **Tests**
  * Added coverage for worktree creation from both primary and linked checkouts, including default and custom paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->