### PR TITLE
pfblockerng: stop capturing hosts-dialect '##' comments as ABP rows

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -3972,6 +3972,10 @@ def _dnsbl_is_abp_rule_line(line: str) -> bool:
     comments by feed convention, never ``/re/`` regex rules. A leading ``,``
     is never valid ABP syntax (empty first cosmetic domain-list entry) and
     is excluded up front.
+
+    issue #1276: a marker AT position 0 also needs a non-whitespace char right
+    after it -- else a hosts-dialect '## Section' whole-line comment is
+    wrongly captured as a rule.
     """
     # issue #1067: a leading comma is never valid ABP syntax (empty first cosmetic
     # domain-list entry) -- a comma-first verbatim capture would collide with the
@@ -3981,10 +3985,15 @@ def _dnsbl_is_abp_rule_line(line: str) -> bool:
     if line.startswith("||") or line.startswith("@@"):
         return True
     if "#" in line:
-        positions = [p for p in (line.find(m) for m in _DNSBL_ELEMENT_HIDING_MARKERS) if p != -1]
-        if positions:
-            first = min(positions)
-            if first == 0 or all(c in _DNSBL_ABP_COSMETIC_PREFIX_CHARS for c in line[:first]):
+        hits = [(line.find(m), len(m)) for m in _DNSBL_ELEMENT_HIDING_MARKERS]
+        hits = [(p, marker_len) for p, marker_len in hits if p != -1]
+        if hits:
+            first, marker_len = min(hits)
+            if first == 0:
+                after = line[marker_len : marker_len + 1]
+                if after and after not in (" ", "\t"):
+                    return True
+            elif all(c in _DNSBL_ABP_COSMETIC_PREFIX_CHARS for c in line[:first]):
                 return True
     if line.startswith("/") and not line.startswith("//"):
         if line.endswith("/") and len(line) > 1:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -3991,7 +3991,7 @@ def _dnsbl_is_abp_rule_line(line: str) -> bool:
             first, marker_len = min(hits)
             if first == 0:
                 after = line[marker_len : marker_len + 1]
-                if after and after not in (" ", "\t"):
+                if after and not after.isspace():
                     return True
             elif all(c in _DNSBL_ABP_COSMETIC_PREFIX_CHARS for c in line[:first]):
                 return True

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7696,15 +7696,26 @@ function pfb_dnsbl_is_abp_rule_line(string $line): bool {
 	}
 	if (str_contains($line, '#')) {
 		$first = FALSE;
+		$marker_len = 0;
 		foreach (array('##', '#@#', '#?#', '#%#', '#$#') as $eh_marker) {
 			$pos = strpos($line, $eh_marker);
 			if ($pos !== FALSE && ($first === FALSE || $pos < $first)) {
 				$first = $pos;
+				$marker_len = strlen($eh_marker);
 			}
 		}
-		if ($first !== FALSE &&
-		    ($first === 0 || strspn($line, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._,~*-') >= $first)) {
-			return TRUE;
+		if ($first !== FALSE) {
+			if ($first === 0) {
+				// issue #1276: a hosts-dialect '## Section' comment shares the
+				// marker-at-position-0 shape with a real cosmetic rule -- require
+				// a non-whitespace char immediately after the marker.
+				$after = substr($line, $marker_len, 1);
+				if ($after !== '' && $after !== ' ' && $after !== "\t") {
+					return TRUE;
+				}
+			} elseif (strspn($line, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._,~*-') >= $first) {
+				return TRUE;
+			}
 		}
 	}
 	if (str_starts_with($line, '/') && !str_starts_with($line, '//')) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7708,9 +7708,10 @@ function pfb_dnsbl_is_abp_rule_line(string $line): bool {
 			if ($first === 0) {
 				// issue #1276: a hosts-dialect '## Section' comment shares the
 				// marker-at-position-0 shape with a real cosmetic rule -- require
-				// a non-whitespace char (ctype_space) immediately after the marker.
+				// a non-whitespace char (ctype_space, or a UTF-8 NBSP) after the marker.
 				$after = substr($line, $marker_len, 1);
-				if ($after !== '' && !ctype_space($after)) {
+				$after_nbsp = substr($line, $marker_len, 2) === "\xC2\xA0";
+				if ($after !== '' && !ctype_space($after) && !$after_nbsp) {
 					return TRUE;
 				}
 			} elseif (strspn($line, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._,~*-') >= $first) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7707,11 +7707,12 @@ function pfb_dnsbl_is_abp_rule_line(string $line): bool {
 		if ($first !== FALSE) {
 			if ($first === 0) {
 				// issue #1276: a hosts-dialect '## Section' comment shares the
-				// marker-at-position-0 shape with a real cosmetic rule -- require
-				// a non-whitespace char (ctype_space, or a UTF-8 NBSP) after the marker.
+				// marker-at-position-0 shape with a cosmetic rule -- require a
+				// non-whitespace char after it (explicit set, not ctype_space: ADR-26).
 				$after = substr($line, $marker_len, 1);
-				$after_nbsp = substr($line, $marker_len, 2) === "\xC2\xA0";
-				if ($after !== '' && !ctype_space($after) && !$after_nbsp) {
+				$after_is_content = $after !== '' && strspn($after, " \t\n\r\x0B\x0C") === 0;
+				$after_is_nbsp = substr($line, $marker_len, 2) === "\xC2\xA0";
+				if ($after_is_content && !$after_is_nbsp) {
 					return TRUE;
 				}
 			} elseif (strspn($line, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._,~*-') >= $first) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7708,9 +7708,9 @@ function pfb_dnsbl_is_abp_rule_line(string $line): bool {
 			if ($first === 0) {
 				// issue #1276: a hosts-dialect '## Section' comment shares the
 				// marker-at-position-0 shape with a real cosmetic rule -- require
-				// a non-whitespace char immediately after the marker.
+				// a non-whitespace char (ctype_space) immediately after the marker.
 				$after = substr($line, $marker_len, 1);
-				if ($after !== '' && $after !== ' ' && $after !== "\t") {
+				if ($after !== '' && !ctype_space($after)) {
 					return TRUE;
 				}
 			} elseif (strspn($line, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._,~*-') >= $first) {

--- a/tests/php/Adr62DnsblIsAbpRuleLineTest.php
+++ b/tests/php/Adr62DnsblIsAbpRuleLineTest.php
@@ -71,6 +71,15 @@ final class Adr62DnsblIsAbpRuleLineTest extends TestCase
 			'comma-prefixed network anchor'          => [',||x^', false],
 			'bare comma'                             => [',', false],
 			'comma-prefixed, marker at position 1'   => [',,##x', false],
+			// issue #1276: a hosts-dialect whole-line comment ('## Section', a
+			// marker at position 0 followed by whitespace) shares its shape with
+			// a real generic cosmetic rule ('##selector') -- must stay on the
+			// plain '#'-comment path, not be captured as an ABP element-hiding row.
+			'hosts-dialect header, marker+space'         => ['## Section header', false],
+			'hosts-dialect header, marker+tab'           => ["##\tSection", false],
+			'sibling marker hosts-dialect, marker+space' => ['#@# note', false],
+			'sibling marker exception rule, no space'    => ['#@#selector', true],
+			'bare marker, nothing after'                 => ['##', false],
 		];
 	}
 

--- a/tests/php/Adr62DnsblIsAbpRuleLineTest.php
+++ b/tests/php/Adr62DnsblIsAbpRuleLineTest.php
@@ -80,6 +80,11 @@ final class Adr62DnsblIsAbpRuleLineTest extends TestCase
 			'sibling marker hosts-dialect, marker+space' => ['#@# note', false],
 			'sibling marker exception rule, no space'    => ['#@#selector', true],
 			'bare marker, nothing after'                 => ['##', false],
+			// PR #1343 review: the space/tab guard missed other whitespace a malformed
+			// feed can embed mid-line (CR/VT/FF survive the caller's edge-only trim).
+			'hosts-dialect header, marker+CR'            => ["##\rSection", false],
+			'hosts-dialect header, marker+vertical tab'  => ["##\x0Bsection", false],
+			'hosts-dialect header, marker+form feed'     => ["##\x0Csection", false],
 		];
 	}
 

--- a/tests/php/Adr62DnsblIsAbpRuleLineTest.php
+++ b/tests/php/Adr62DnsblIsAbpRuleLineTest.php
@@ -85,6 +85,18 @@ final class Adr62DnsblIsAbpRuleLineTest extends TestCase
 			'hosts-dialect header, marker+CR'            => ["##\rSection", false],
 			'hosts-dialect header, marker+vertical tab'  => ["##\x0Bsection", false],
 			'hosts-dialect header, marker+form feed'     => ["##\x0Csection", false],
+			// PR #1343 review: a copy-pasted NBSP (U+00A0, UTF-8 "\xC2\xA0") right
+			// after the marker must count as whitespace too, matching the call
+			// site's own trim() charlist and Python's .isspace() on the same input.
+			'hosts-dialect header, marker+NBSP'          => ["##\xC2\xA0Section", false],
+			// PR #1343 review: every element-hiding marker sibling gets a position-0
+			// row, not just '##'/'#@#' -- the guard branch is shared by all five.
+			'sibling marker #?#, hosts-dialect'          => ['#?# note', false],
+			'sibling marker #?#, no space'                => ['#?#selector', true],
+			'sibling marker #%#, hosts-dialect'          => ['#%# note', false],
+			'sibling marker #%#, no space'                => ['#%#selector', true],
+			'sibling marker #$#, hosts-dialect'          => ['#$# note', false],
+			'sibling marker #$#, no space'                => ['#$#selector', true],
 		];
 	}
 

--- a/tests/php/Adr62DnsblIsAbpRuleLineTest.php
+++ b/tests/php/Adr62DnsblIsAbpRuleLineTest.php
@@ -80,16 +80,16 @@ final class Adr62DnsblIsAbpRuleLineTest extends TestCase
 			'sibling marker hosts-dialect, marker+space' => ['#@# note', false],
 			'sibling marker exception rule, no space'    => ['#@#selector', true],
 			'bare marker, nothing after'                 => ['##', false],
-			// PR #1343 review: the space/tab guard missed other whitespace a malformed
-			// feed can embed mid-line (CR/VT/FF survive the caller's edge-only trim).
+			// issue #1276: other whitespace a malformed feed can embed mid-line
+			// (CR/VT/FF survive the caller's edge-only trim) is a comment too.
 			'hosts-dialect header, marker+CR'            => ["##\rSection", false],
 			'hosts-dialect header, marker+vertical tab'  => ["##\x0Bsection", false],
 			'hosts-dialect header, marker+form feed'     => ["##\x0Csection", false],
-			// PR #1343 review: a copy-pasted NBSP (U+00A0, UTF-8 "\xC2\xA0") right
+			// issue #1276: a copy-pasted NBSP (U+00A0, UTF-8 "\xC2\xA0") right
 			// after the marker must count as whitespace too, matching the call
 			// site's own trim() charlist and Python's .isspace() on the same input.
 			'hosts-dialect header, marker+NBSP'          => ["##\xC2\xA0Section", false],
-			// PR #1343 review: every element-hiding marker sibling gets a position-0
+			// issue #1276: every element-hiding marker sibling gets a position-0
 			// row, not just '##'/'#@#' -- the guard branch is shared by all five.
 			'sibling marker #?#, hosts-dialect'          => ['#?# note', false],
 			'sibling marker #?#, no space'                => ['#?#selector', true],

--- a/tests/test_adr62_parity_oracle.py
+++ b/tests/test_adr62_parity_oracle.py
@@ -460,6 +460,11 @@ def test_cosmetic_prefix_guard_matches_php_row_for_row() -> None:
         "##\tSection",
         "#@# note",
         "##",  # marker alone, nothing after -- no non-whitespace char to require
+        # PR #1343 review: the space/tab guard missed other whitespace a malformed
+        # feed can embed mid-line (CR/VT/FF survive the caller's edge-only trim).
+        "##\rSection",
+        "##\x0bsection",
+        "##\x0csection",
     ]
     capturable = [
         "####################",  # marker at pos 0: generic-rule shape (documented latent)

--- a/tests/test_adr62_parity_oracle.py
+++ b/tests/test_adr62_parity_oracle.py
@@ -460,13 +460,13 @@ def test_cosmetic_prefix_guard_matches_php_row_for_row() -> None:
         "##\tSection",
         "#@# note",
         "##",  # marker alone, nothing after -- no non-whitespace char to require
-        # PR #1343 review: the space/tab guard missed other whitespace a malformed
-        # feed can embed mid-line (CR/VT/FF survive the caller's edge-only trim).
+        # issue #1276: other whitespace a malformed feed can embed mid-line
+        # (CR/VT/FF survive the caller's edge-only trim) is a comment too.
         "##\rSection",
         "##\x0bsection",
         "##\x0csection",
         "##\xa0Section",  # NBSP right after the marker -- .isspace() already catches it
-        # PR #1343 review: every element-hiding marker sibling gets a position-0
+        # issue #1276: every element-hiding marker sibling gets a position-0
         # row, not just '##'/'#@#' -- the guard branch is shared by all five.
         "#?# note",
         "#%# note",

--- a/tests/test_adr62_parity_oracle.py
+++ b/tests/test_adr62_parity_oracle.py
@@ -453,6 +453,13 @@ def test_cosmetic_prefix_guard_matches_php_row_for_row() -> None:
         ",||x^",
         ",",
         ",,##x",
+        # issue #1276: a hosts-dialect whole-line comment ('## Section', a marker
+        # at position 0 followed by whitespace) shares its shape with a real
+        # generic cosmetic rule -- must stay on the plain '#'-comment path.
+        "## Section header",
+        "##\tSection",
+        "#@# note",
+        "##",  # marker alone, nothing after -- no non-whitespace char to require
     ]
     capturable = [
         "####################",  # marker at pos 0: generic-rule shape (documented latent)
@@ -464,6 +471,7 @@ def test_cosmetic_prefix_guard_matches_php_row_for_row() -> None:
         "EXAMPLE.com##.ad",
         "/re/",
         "/re/$important",
+        "#@#selector",  # marker+non-space, no space -- proves guard scope isn't a marker-family regression
     ]
     for line in not_capturable:
         assert _dnsbl_is_abp_rule_line(line) is False, f"must NOT capture: {line!r}"

--- a/tests/test_adr62_parity_oracle.py
+++ b/tests/test_adr62_parity_oracle.py
@@ -465,6 +465,12 @@ def test_cosmetic_prefix_guard_matches_php_row_for_row() -> None:
         "##\rSection",
         "##\x0bsection",
         "##\x0csection",
+        "##\xa0Section",  # NBSP right after the marker -- .isspace() already catches it
+        # PR #1343 review: every element-hiding marker sibling gets a position-0
+        # row, not just '##'/'#@#' -- the guard branch is shared by all five.
+        "#?# note",
+        "#%# note",
+        "#$# note",
     ]
     capturable = [
         "####################",  # marker at pos 0: generic-rule shape (documented latent)
@@ -477,6 +483,9 @@ def test_cosmetic_prefix_guard_matches_php_row_for_row() -> None:
         "/re/",
         "/re/$important",
         "#@#selector",  # marker+non-space, no space -- proves guard scope isn't a marker-family regression
+        "#?#selector",
+        "#%#selector",
+        "#$#selector",
     ]
     for line in not_capturable:
         assert _dnsbl_is_abp_rule_line(line) is False, f"must NOT capture: {line!r}"


### PR DESCRIPTION
## Summary

`pfb_dnsbl_is_abp_rule_line()` (PHP) and its Python mirror `_dnsbl_is_abp_rule_line()` wrongly captured a hosts-dialect whole-line comment like `## Section header` (a `##`/`#@#`/`#?#`/`#%#`/`#$#` marker at line position 0, followed by whitespace) as a real ABP element-hiding cosmetic rule — inflating `$alias_cnt`/widget stats and getting re-parsed and dropped by Python on every build. A real generic cosmetic rule (`##selector`, no space after the marker) must still classify TRUE, and does.

Fix: a marker at position 0 now also requires a non-whitespace, non-empty character immediately after it before the capture guard claims the line. The domain-prefixed branch (marker not at position 0) is untouched. Applied in lockstep to both the PHP predicate and its Python mirror, per ADR-62.

Fixes #1276

## Test plan

- [x] Red: `tests/php/Adr62DnsblIsAbpRuleLineTest.php` — 5 new DataProvider rows fail pre-fix (4 false-expecting rows return true)
- [x] Red: `tests/test_adr62_parity_oracle.py::test_cosmetic_prefix_guard_matches_php_row_for_row` — new rows fail pre-fix
- [x] Green: same tests, zero edits, pass post-fix
- [x] `vendor/bin/phpunit` full suite: 3355 tests, 0 failures
- [x] `composer phpstan`: no errors
- [x] `composer phpcs -- --standard=phpcs.xml.dist src/`: clean
- [x] `python3 -m pytest` full suite: 2876 passed, 4 skipped
- [x] `ruff check .` / `ruff format --check .`: clean
- [x] `mypy tests/`: no issues
- [x] Independent Sonnet verifier re-ran every gate + the red→green proof via `scripts/agent/verify-red-proof.sh` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gr4Sj3PTxg6CCSEMo2KtNk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of ad-blocking cosmetic rules to avoid incorrectly classifying hosts-dialect `## ...` whole-line comments as rules when the marker is at the start of a line.
  - Markers at line start are now treated as rules only when the character immediately after the marker is not whitespace (including correct handling for NBSP); preserved prior validation for non-start markers.

- **Tests**
  - Expanded ABP-rule-shape and parity-oracle coverage with additional non-capturable/capturable cases, including whitespace edge cases and sibling marker variants (`#@#`, `#?#`, `#%#`, `#$#`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->