### PR TITLE
pfblockerng: reject headers reserved by DNSBLIP/GeoIP continents

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -16653,7 +16653,8 @@ function sync_package_pfblockerng($cron='') {
 
 							// issue #1270: normalize (same \W-strip as before) + reject a header
 							// colliding with a package-owned name; the DNSBLIP synthesized row is exempt.
-							$pfb_norm_hdr = pfb_normalize_row_header($row['header']);
+							// Cast: a row missing 'header' (foreign config) is NULL, which TypeErrors below.
+							$pfb_norm_hdr = pfb_normalize_row_header((string) ($row['header'] ?? ''));
 							if ($pfb_norm_hdr['reserved_error'] !== '' && $key !== $dnsblip_lists_key) {
 								$pfb_reserved_skips[] = "{$pfb_norm_hdr['header']} ({$ltype})";
 								continue;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -18890,7 +18890,7 @@ function sync_package_pfblockerng($cron='') {
 						// issue #1270: a header colliding with a reserved package-owned name (e.g.
 						// foreign config that bypassed GUI validation) must not download+write to
 						// that name's own file; the synthesized DNSBLIP list (below) is exempt.
-						if (!isset($list['dnsblip']) && pfb_header_reserved_error($row['header'] ?? '') !== '') {
+						if (pfb_reserved_header_skip_active(isset($list['dnsblip']), $row['header'] ?? '')) {
 							pfb_logger("\n Reserved Header:{$row['header']}, *skipping*", 1);
 							continue;
 						}
@@ -19713,6 +19713,14 @@ function sync_package_pfblockerng($cron='') {
 					if (isset($list['row'])) {
 						foreach ($list['row'] as $row) {
 							if (!empty($row['url']) && $row['state'] != 'Disabled') {
+
+								// issue #1270: this loop reads config independently of the
+								// download loop above -- a reserved header must not be read
+								// into an alias/firewall rule here either.
+								if (pfb_reserved_header_skip_active(isset($list['dnsblip']), $row['header'] ?? '')) {
+									pfb_logger("\n Reserved Header:{$row['header']}, *skipping*", 1);
+									continue;
+								}
 
 								$header = "{$row['header']}{$vtype}";
 								if (empty(pfb_filter($header, PFB_FILTER_WORD, 'Configure Aliases and Firewall Rules'))) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -18886,6 +18886,15 @@ function sync_package_pfblockerng($cron='') {
 
 				foreach	($list['row'] as $row) {
 					if (!empty($row['url']) && $row['state'] != 'Disabled') {
+
+						// issue #1270: a header colliding with a reserved package-owned name (e.g.
+						// foreign config that bypassed GUI validation) must not download+write to
+						// that name's own file; the synthesized DNSBLIP list (below) is exempt.
+						if (!isset($list['dnsblip']) && pfb_header_reserved_error($row['header'] ?? '') !== '') {
+							pfb_logger("\n Reserved Header:{$row['header']}, *skipping*", 1);
+							continue;
+						}
+
 						$header = "{$row['header']}{$list['vtype']}";	// Capture Header/Label name
 						if (empty(pfb_filter($header, PFB_FILTER_WORD, 'Download and Collect IPv4/IPv6 lists'))) {
 							pfb_logger("\n Invalid Aliasname:{$list['aliasname']}{$list['vtype']} | Header:{$row['header']}{$list['vtype']}, *skipping*", 1);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -16593,8 +16593,10 @@ function sync_package_pfblockerng($cron='') {
 					);
 
 		$pfb_invalid = FALSE;
+		$pfb_reserved_skips = array();	// issue #1270: headers skipped as reserved (batched into one notice below)
 		foreach ($list_types as $ltype => $vtype) {
 			$lists = array();
+			$dnsblip_lists_key = NULL;	// issue #1270: exempts the package's OWN synthesized DNSBLIP row below
 
 			$type_config = config_get_path("installedpackages/{$ltype}/config");
 			if (!empty($type_config) && $pfb['enable'] == 'on') {
@@ -16625,6 +16627,7 @@ function sync_package_pfblockerng($cron='') {
 							'url'		=> "{$pfb['dbdir']}/DNSBLIP{$vtype}.txt",
 							'header'	=> 'DNSBLIP');
 				$lists[] = $list;
+				$dnsblip_lists_key = array_key_last($lists);
 			}
 
 			if (!empty($lists)) {
@@ -16648,10 +16651,17 @@ function sync_package_pfblockerng($cron='') {
 
 						foreach ($list['row'] as $hkey => $row) {
 
-							// Remove any spaces or special characters in existing Header names
-							if (preg_match("/\W/", $row['header'])) {
+							// issue #1270: normalize (same \W-strip as before) + reject a header
+							// colliding with a package-owned name; the DNSBLIP synthesized row is exempt.
+							$pfb_norm_hdr = pfb_normalize_row_header($row['header']);
+							if ($pfb_norm_hdr['reserved_error'] !== '' && $key !== $dnsblip_lists_key) {
+								$pfb_reserved_skips[] = "{$pfb_norm_hdr['header']} ({$ltype})";
+								continue;
+							}
+
+							if ($pfb_norm_hdr['changed']) {
 								$pfb_invalid	= TRUE;
-								$row['header']	= preg_replace("/\W/", '', $row['header']);
+								$row['header']	= $pfb_norm_hdr['header'];
 								config_set_path("installedpackages/{$ltype}/config/{$key}/row/{$hkey}/header", $row['header']);
 							}
 
@@ -16688,6 +16698,13 @@ function sync_package_pfblockerng($cron='') {
 		// Save any existing Alias/Header names that have spaces or special characters
 		if ($pfb_invalid) {
 			write_config('pfBlockerNG: Remove spaces/special characters in Alias/Header names');
+		}
+
+		// issue #1270: one batched notice for every header skipped as reserved this pass
+		if (!empty($pfb_reserved_skips)) {
+			$pfb_reserved_msg = 'pfBlockerNG: skipped reserved header(s) (collides with a package-owned name): ' . implode(', ', $pfb_reserved_skips);
+			pfb_logger("\n\nURGENT:\n    {$pfb_reserved_msg}\n", 1);
+			file_notice('pfBlockerNG Header', $pfb_reserved_msg, 'pfBlockerNG', '/pfblockerng/pfblockerng_category_edit.php', 2);
 		}
 
 		// If 'TLD' enabled and TLD Blacklists are defined, add to enabled DNSBL lists

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1921,6 +1921,25 @@ function pfb_normalize_row_header(string $header): array
 	];
 }
 
+/**
+ * pfb_reserved_header_skip_active — TRUE iff a list-row Header collides with a
+ * reserved package-owned name (issue #1270) and the row is NOT the package's
+ * own synthesized entry for that name. sync_package_pfblockerng() reads
+ * config independently in more than one loop (the download loop and the
+ * alias/firewall-rule loop, besides the header-normalize loop); each must
+ * refuse the same collision, so the check is one shared, directly-callable
+ * predicate rather than re-inlined per loop.
+ *
+ * @param  bool   $is_reserved_owner  TRUE for the loop's OWN synthesized
+ *                                     DNSBLIP row (its `isset($list['dnsblip'])`
+ *                                     marker) — exempt from its own guard.
+ * @param  string $header             The row's raw Header value.
+ */
+function pfb_reserved_header_skip_active(bool $is_reserved_owner, string $header): bool
+{
+	return !$is_reserved_owner && pfb_header_reserved_error($header) !== '';
+}
+
 // ---------------------------------------------------------------------------
 // ADR-38: pure key=value syslog event formatters (pfb_syslog_format_ip() etc.) — the fixed
 // key order, empty-value omission rules, and quoting/escaping are specified in

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1871,6 +1871,56 @@ function pfb_adv_alias_field_errors(array $post): array
 	return $errors;
 }
 
+/**
+ * pfb_header_reserved_error — reject a source Header that collides with a
+ * package-synthesized name (issue #1270): DNSBL-IP and the 9 GeoIP continent
+ * aliases write to the SAME <header><vtype>.txt path a user list's Header
+ * would use (pfb_determine_list_detail() folder routing), so an identical
+ * Header silently collides last-writer-wins on disk. Unconditional (not
+ * action-scoped) — the collision does not depend on which action/folder the
+ * offending list itself routes to.
+ *
+ * The reserved set is read from $pfb['continents'] (its 9 VALUES) — never
+ * $pfb['continent_list'], which is missing pfB_PS — so a future continent
+ * addition is automatically covered.
+ *
+ * @param  string $header  Candidate Header value (already normalised by the
+ *                          caller when judging a stored/imported value).
+ * @return string          Human-readable error, or '' when not reserved.
+ */
+function pfb_header_reserved_error(string $header): string
+{
+	if ($header === '') {
+		return '';
+	}
+	global $pfb;
+	$reserved = array_merge(['DNSBLIP'], array_values($pfb['continents']));
+	if (in_array($header, $reserved, TRUE)) {
+		return "Header field '{$header}' is reserved by pfBlockerNG (DNSBL-IP or a GeoIP continent alias) and cannot be used.";
+	}
+	return '';
+}
+
+/**
+ * pfb_normalize_row_header — apply the SAME \W-strip sync_package_pfblockerng()
+ * persists onto a stored list-row Header, then judge the RESULT against
+ * pfb_header_reserved_error() (issue #1270): a Header arriving via config
+ * import/HA-sync (never through the GUI) can normalise onto a reserved name
+ * with no save-time check ever having run.
+ *
+ * @param  string $header  Raw (possibly punctuated) stored Header.
+ * @return array{header: string, changed: bool, reserved_error: string}
+ */
+function pfb_normalize_row_header(string $header): array
+{
+	$normalized = preg_replace('/\W/', '', $header);
+	return [
+		'header'         => $normalized,
+		'changed'        => $normalized !== $header,
+		'reserved_error' => pfb_header_reserved_error($normalized),
+	];
+}
+
 // ---------------------------------------------------------------------------
 // ADR-38: pure key=value syslog event formatters (pfb_syslog_format_ip() etc.) — the fixed
 // key order, empty-value omission rules, and quoting/escaping are specified in

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -544,9 +544,18 @@ if ($_POST && isset($_POST['save'])) {
 				$input_errors[] = "{$type} Source Definitions, Line {$line}: Header field must be defined.";
 			}
 
-			if ($value != 'Disabled' && preg_match("/\W/", $_POST["header-{$key_1}"])) {
+			if (!empty($_POST["header-{$key_1}"]) && preg_match("/\W/", $_POST["header-{$key_1}"])) {
 				$input_errors[] = "{$type} Source Definitions, Line {$line}: "
 							. "Header field cannot contain spaces, special or international characters.";
+			}
+
+			// issue #1270: reserved regardless of row state -- a Disabled row's raw header still
+			// reaches disk unvalidated via config import/HA-sync (pfb_normalize_row_header()).
+			if (!empty($_POST["header-{$key_1}"])) {
+				$pfb_header_reserved = pfb_header_reserved_error($_POST["header-{$key_1}"]);
+				if ($pfb_header_reserved !== '') {
+					$input_errors[] = "{$type} Source Definitions, Line {$line}: {$pfb_header_reserved}";
+				}
 			}
 
 			if ($value != 'Disabled' && strpos($_POST["url-{$key_1}"], '_API_KEY_') !== FALSE) {
@@ -556,7 +565,9 @@ if ($_POST && isset($_POST['save'])) {
 
 			// issue #1104: reject control chars + HTML-breakout <>" in url-N for
 			// every format -- geoip/asn gate only a PREFIX below, leaving this the sole gate.
-			if ($value != 'Disabled' && preg_match('/[\p{C}<>"]/u', $_POST["url-{$key_1}"]) !== 0) {
+			// issue #1270: non-empty-gated (not state-gated) -- a Disabled row's raw url still
+			// persists unvalidated.
+			if (!empty($_POST["url-{$key_1}"]) && preg_match('/[\p{C}<>"]/u', $_POST["url-{$key_1}"]) !== 0) {
 				$input_errors[] = "{$type} Source Definitions, Line {$line}: "
 							. "Source field contains a disallowed character (control character or < > \")!";
 			}

--- a/tests/php/CategoryEditReservedHeaderTest.php
+++ b/tests/php/CategoryEditReservedHeaderTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Category-edit save-time validation must fire regardless of row state
+ * (issue #1270): the header \W-format check, the issue-#1104 URL
+ * control-char check, and the NEW reserved-header check were all gated on
+ * $value != 'Disabled', so a row saved while Disabled skipped validation
+ * entirely and its RAW value reached config storage -- where
+ * sync_package_pfblockerng()'s periodic sync could later normalise it onto
+ * (or find it already equal to) a package-owned reserved name with no check
+ * ever having run.
+ *
+ * Like CategoryEditPostGuardTest, the page carries top-level execution and
+ * cannot be require()d off-appliance, so the rowhelper state-loop region is
+ * eval-extracted verbatim from the REAL source, anchored on text stable
+ * across the pre-fix and post-fix code -- the same test proves red on the
+ * old code and green on the new.
+ */
+final class CategoryEditReservedHeaderTest extends TestCase
+{
+	private array $savedPost = [];
+	private mixed $savedPfb = null;
+
+	public static function setUpBeforeClass(): void
+	{
+		$continents = $GLOBALS['pfb']['continents'] ?? null;
+		if (!is_array($continents) || count($continents) !== 9) {
+			throw new RuntimeException('$pfb[continents] must have exactly 9 entries; got: ' . var_export($continents, true));
+		}
+
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
+		}
+
+		if (!function_exists('pfb_category_oracle_reserved_header_state_loop')) {
+			if (!preg_match(
+				'/(\tforeach \(\$_POST as \$key => \$value\) \{\n.*?\n\t\})\n\n\n\t\/\/ Validate Adv\. firewall rule settings/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: state validation loop not found');
+			}
+			eval(
+				'function pfb_category_oracle_reserved_header_state_loop(string $type): array {'
+				. ' global $pfb; $input_errors = array(); $line = 1;'
+				. $m[1]
+				. ' return $input_errors; }'
+			);
+		}
+	}
+
+	protected function setUp(): void
+	{
+		$this->savedPost = $_POST;
+		$this->savedPfb  = $GLOBALS['pfb'] ?? null;
+		$_POST = [];
+		// Satisfied MaxMind creds so a geoip-format row would never ALSO trip the
+		// unrelated credential-notice input error (mirrors CategoryEditPostGuardTest).
+		$GLOBALS['pfb']['maxmind_key']     = 'test-key';
+		$GLOBALS['pfb']['maxmind_account'] = 'test-account';
+	}
+
+	protected function tearDown(): void
+	{
+		$_POST = $this->savedPost;
+		$GLOBALS['pfb'] = $this->savedPfb;
+	}
+
+	/** @param array<int, string> $errors */
+	private static function hasErrorContaining(array $errors, string $needle): bool
+	{
+		foreach ($errors as $error) {
+			if (str_contains($error, $needle)) {
+				return TRUE;
+			}
+		}
+		return FALSE;
+	}
+
+	private function makeRow(string $state, string $header, string $url): void
+	{
+		$_POST = [
+			'state-0'  => $state,
+			'header-0' => $header,
+			'url-0'    => $url,
+			'format-0' => 'auto',
+		];
+	}
+
+	// --- Reserved-header check (issue #1270) -----------------------------
+
+	public function testDisabledRowWithReservedHeaderIsRejected(): void
+	{
+		$this->makeRow('Disabled', 'DNSBLIP', 'http://192.0.2.1/feed');
+		$errors = pfb_category_oracle_reserved_header_state_loop('Test');
+		$this->assertTrue(
+			self::hasErrorContaining($errors, 'reserved'),
+			'expected a reserved-header error; got: ' . implode(' | ', $errors)
+		);
+	}
+
+	public function testEnabledRowWithReservedHeaderIsRejected(): void
+	{
+		$this->makeRow('Enabled', 'DNSBLIP', 'http://192.0.2.1/feed');
+		$errors = pfb_category_oracle_reserved_header_state_loop('Test');
+		$this->assertTrue(
+			self::hasErrorContaining($errors, 'reserved'),
+			'expected a reserved-header error; got: ' . implode(' | ', $errors)
+		);
+	}
+
+	// --- \W-format + disallowed-char checks broadened to non-empty-gated -
+
+	public function testDisabledRowWithControlCharUrlIsRejected(): void
+	{
+		$this->makeRow('Disabled', 'MyBlocklist', "http://192.0.2.1/\x01feed");
+		$errors = pfb_category_oracle_reserved_header_state_loop('Test');
+		$this->assertTrue(
+			self::hasErrorContaining($errors, 'disallowed character'),
+			'expected a disallowed-character error; got: ' . implode(' | ', $errors)
+		);
+	}
+
+	public function testDisabledRowWithPunctuatedHeaderIsRejectedForFormat(): void
+	{
+		$this->makeRow('Disabled', 'de-dup', 'http://192.0.2.1/feed');
+		$errors = pfb_category_oracle_reserved_header_state_loop('Test');
+		$this->assertTrue(
+			self::hasErrorContaining($errors, 'Header field cannot contain spaces'),
+			'expected a \W-format error; got: ' . implode(' | ', $errors)
+		);
+	}
+
+	// --- Regression guards: unchanged before AND after --------------------
+
+	public function testDisabledRowEmptyHeaderAndUrlHasNoHeaderOrUrlErrors(): void
+	{
+		$this->makeRow('Disabled', '', '');
+		$errors = pfb_category_oracle_reserved_header_state_loop('Test');
+		$this->assertFalse(self::hasErrorContaining($errors, 'reserved'), 'draft row: ' . implode(' | ', $errors));
+		$this->assertFalse(self::hasErrorContaining($errors, 'Header field cannot contain spaces'), 'draft row: ' . implode(' | ', $errors));
+		$this->assertFalse(self::hasErrorContaining($errors, 'disallowed character'), 'draft row: ' . implode(' | ', $errors));
+		$this->assertFalse(self::hasErrorContaining($errors, 'must be defined'), 'draft row: ' . implode(' | ', $errors));
+	}
+
+	public function testEnabledRowEmptyHeaderStillFlaggedEmpty(): void
+	{
+		$this->makeRow('Enabled', '', '');
+		$errors = pfb_category_oracle_reserved_header_state_loop('Test');
+		$this->assertTrue(
+			self::hasErrorContaining($errors, 'Header field must be defined'),
+			'existing emptiness gating must be unchanged: ' . implode(' | ', $errors)
+		);
+	}
+}

--- a/tests/php/HeaderReservedErrorTest.php
+++ b/tests/php/HeaderReservedErrorTest.php
@@ -85,32 +85,4 @@ final class HeaderReservedErrorTest extends TestCase
 	{
 		$this->assertSame('', pfb_header_reserved_error($header));
 	}
-
-	/**
-	 * issue #1270: pfblockerng.inc's SEPARATE "Download and Collect IPv4/IPv6
-	 * lists" loop reads config independently of the normalize loop and skips a
-	 * row via `!isset($list['dnsblip']) && pfb_header_reserved_error(...) !== ''`
-	 * -- pins that exact guard expression for a real user row, the exempt
-	 * synthesized DNSBLIP row, and an ordinary row.
-	 */
-	public function testDownloadLoopGuardSkipsReservedNonSyntheticRow(): void
-	{
-		$userList = ['aliasname' => 'MyEvilList', 'row' => [['header' => 'DNSBLIP']]];
-		$header = $userList['row'][0]['header'] ?? '';
-		$this->assertTrue(!isset($userList['dnsblip']) && pfb_header_reserved_error($header) !== '');
-	}
-
-	public function testDownloadLoopGuardExemptsSynthesizedDnsblipRow(): void
-	{
-		$synthesizedList = ['aliasname' => 'DNSBLIP', 'dnsblip' => '', 'row' => [['header' => 'DNSBLIP']]];
-		$header = $synthesizedList['row'][0]['header'] ?? '';
-		$this->assertFalse(!isset($synthesizedList['dnsblip']) && pfb_header_reserved_error($header) !== '');
-	}
-
-	public function testDownloadLoopGuardAllowsOrdinaryHeader(): void
-	{
-		$userList = ['aliasname' => 'MyBlocklist', 'row' => [['header' => 'MyBlocklist']]];
-		$header = $userList['row'][0]['header'] ?? '';
-		$this->assertFalse(!isset($userList['dnsblip']) && pfb_header_reserved_error($header) !== '');
-	}
 }

--- a/tests/php/HeaderReservedErrorTest.php
+++ b/tests/php/HeaderReservedErrorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for pfb_header_reserved_error() (issue #1270).
+ *
+ * pfBlockerNG synthesizes several lists whose header/filename the package
+ * itself picks -- DNSBLIP and the 9 GeoIP continent aliases -- into the SAME
+ * folder+namespace a user Deny/Permit/Match/Native list Header can collide
+ * with (pfb_determine_list_detail() routes by <header><vtype>.txt,
+ * last-writer-wins). Pure, brand-new function (no pre-existing behaviour to
+ * pin -- CLAUDE.md Test coverage #1 exception 2).
+ */
+#[CoversFunction('pfb_header_reserved_error')]
+final class HeaderReservedErrorTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		// Self-encapsulated: fail loudly rather than silently mis-grade on a
+		// corrupted bootstrap -- $pfb['continents'] is 9 name=>alias pairs
+		// (pfblockerng.inc:165-174).
+		$continents = $GLOBALS['pfb']['continents'] ?? null;
+		if (!is_array($continents) || count($continents) !== 9) {
+			throw new RuntimeException('$pfb[continents] must have exactly 9 entries; got: ' . var_export($continents, true));
+		}
+	}
+
+	/** Transcribed from $pfb['continents']' values (pfblockerng.inc:165-174) -- all 9, none dropped. */
+	public static function reservedHeadersProvider(): array
+	{
+		return [
+			'DNSBLIP'                    => ['DNSBLIP'],
+			'pfB_Top (Top Spammers)'     => ['pfB_Top'],
+			'pfB_Africa'                 => ['pfB_Africa'],
+			'pfB_Antarctica'             => ['pfB_Antarctica'],
+			'pfB_Asia'                   => ['pfB_Asia'],
+			'pfB_Europe'                 => ['pfB_Europe'],
+			'pfB_NAmerica'               => ['pfB_NAmerica'],
+			'pfB_Oceania'                => ['pfB_Oceania'],
+			'pfB_SAmerica'               => ['pfB_SAmerica'],
+			'pfB_PS (Proxy and Satellite)' => ['pfB_PS'],
+		];
+	}
+
+	#[DataProvider('reservedHeadersProvider')]
+	public function testReservedHeaderIsRejected(string $header): void
+	{
+		$this->assertNotSame('', pfb_header_reserved_error($header), "header={$header} must be reserved");
+	}
+
+	/** issue #1270: $pfb['continent_list'] omits pfB_PS -- proves the function
+	 * reads $pfb['continents'] (9 entries), never continent_list (8, no PS). */
+	public function testContinentListOmitsPfBPsButFunctionStillRejectsIt(): void
+	{
+		$this->assertArrayNotHasKey(
+			'pfB_PS',
+			$GLOBALS['pfb']['continent_list'] ?? [],
+			'fixture check: continent_list must omit pfB_PS for this test to be meaningful'
+		);
+		$this->assertNotSame('', pfb_header_reserved_error('pfB_PS'));
+	}
+
+	public static function notReservedProvider(): array
+	{
+		return [
+			'empty string'                                              => [''],
+			'ordinary header'                                           => ['MyBlocklist'],
+			'ordinary header 2'                                         => ['ThreatFeed'],
+			"'dedup' -- resolved by #1250, out of #1270 scope"          => ['dedup'],
+			"'matchdedup' -- unrelated name"                            => ['matchdedup'],
+			'DNSBLIPX (suffix, not an exact match)'                     => ['DNSBLIPX'],
+			'XDNSBLIP (prefix, not an exact match)'                     => ['XDNSBLIP'],
+			'dnsblip (lowercase -- FreeBSD UFS/ZFS is case-sensitive)'  => ['dnsblip'],
+			"pfBAfrica (no underscore, distinct from 'pfB_Africa')"     => ['pfBAfrica'],
+		];
+	}
+
+	#[DataProvider('notReservedProvider')]
+	public function testNonReservedHeaderIsAllowed(string $header): void
+	{
+		$this->assertSame('', pfb_header_reserved_error($header));
+	}
+}

--- a/tests/php/HeaderReservedErrorTest.php
+++ b/tests/php/HeaderReservedErrorTest.php
@@ -85,4 +85,32 @@ final class HeaderReservedErrorTest extends TestCase
 	{
 		$this->assertSame('', pfb_header_reserved_error($header));
 	}
+
+	/**
+	 * issue #1270: pfblockerng.inc's SEPARATE "Download and Collect IPv4/IPv6
+	 * lists" loop reads config independently of the normalize loop and skips a
+	 * row via `!isset($list['dnsblip']) && pfb_header_reserved_error(...) !== ''`
+	 * -- pins that exact guard expression for a real user row, the exempt
+	 * synthesized DNSBLIP row, and an ordinary row.
+	 */
+	public function testDownloadLoopGuardSkipsReservedNonSyntheticRow(): void
+	{
+		$userList = ['aliasname' => 'MyEvilList', 'row' => [['header' => 'DNSBLIP']]];
+		$header = $userList['row'][0]['header'] ?? '';
+		$this->assertTrue(!isset($userList['dnsblip']) && pfb_header_reserved_error($header) !== '');
+	}
+
+	public function testDownloadLoopGuardExemptsSynthesizedDnsblipRow(): void
+	{
+		$synthesizedList = ['aliasname' => 'DNSBLIP', 'dnsblip' => '', 'row' => [['header' => 'DNSBLIP']]];
+		$header = $synthesizedList['row'][0]['header'] ?? '';
+		$this->assertFalse(!isset($synthesizedList['dnsblip']) && pfb_header_reserved_error($header) !== '');
+	}
+
+	public function testDownloadLoopGuardAllowsOrdinaryHeader(): void
+	{
+		$userList = ['aliasname' => 'MyBlocklist', 'row' => [['header' => 'MyBlocklist']]];
+		$header = $userList['row'][0]['header'] ?? '';
+		$this->assertFalse(!isset($userList['dnsblip']) && pfb_header_reserved_error($header) !== '');
+	}
 }

--- a/tests/php/NormalizeRowHeaderTest.php
+++ b/tests/php/NormalizeRowHeaderTest.php
@@ -70,9 +70,12 @@ final class NormalizeRowHeaderTest extends TestCase
 	public function testUnguardedMissingHeaderKeyThrowsTypeError(): void
 	{
 		$row = ['url' => 'http://example.test'];
+		// Isolates the hazard from the missing-key access itself: $missing is the
+		// SAME null a bare $row['header'] would yield, without an extra warning.
+		$missing = $row['header'] ?? null;
 		$this->expectException(\TypeError::class);
 		/** @phpstan-ignore-next-line intentionally uncast -- reproduces the pre-fix call site */
-		pfb_normalize_row_header($row['header']);
+		pfb_normalize_row_header($missing);
 	}
 
 	/** The call-site's guard pattern -- (string) ($row['header'] ?? '') -- is safe. */

--- a/tests/php/NormalizeRowHeaderTest.php
+++ b/tests/php/NormalizeRowHeaderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for pfb_normalize_row_header() (issue #1270).
+ *
+ * sync_package_pfblockerng()'s periodic sync \W-strips a stored list-row
+ * Header and persists the normalised value via config_set_path() +
+ * write_config(), with NO reserved-name check -- so a Header arriving via
+ * config import/XML restore/HA-sync (never through the GUI) can normalise
+ * onto (or already equal) a reserved package-owned name and silently collide
+ * on disk. This is the pure normalise-then-judge decision the runtime wiring
+ * calls. Pure, brand-new function (no pre-existing behaviour to pin --
+ * CLAUDE.md Test coverage #1 exception 2).
+ */
+#[CoversFunction('pfb_normalize_row_header')]
+final class NormalizeRowHeaderTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		$continents = $GLOBALS['pfb']['continents'] ?? null;
+		if (!is_array($continents) || count($continents) !== 9) {
+			throw new RuntimeException('$pfb[continents] must have exactly 9 entries; got: ' . var_export($continents, true));
+		}
+	}
+
+	public static function casesProvider(): array
+	{
+		return [
+			'already-reserved, no \W'                             => ['DNSBLIP', 'DNSBLIP', FALSE, TRUE],
+			'strips onto reserved (DNSBL-IP -> DNSBLIP)'          => ['DNSBL-IP', 'DNSBLIP', TRUE, TRUE],
+			"strips onto 'dedup' (out of #1270 scope, not reserved)" => ['de-dup', 'dedup', TRUE, FALSE],
+			'underscore is \w -- no strip needed'                 => ['de_dup', 'de_dup', FALSE, FALSE],
+			"strips to 'pfBAfrica', NOT the continent literal 'pfB_Africa'" => ['pfB.Africa', 'pfBAfrica', TRUE, FALSE],
+			'clean, ordinary header'                              => ['MyBlocklist', 'MyBlocklist', FALSE, FALSE],
+			'empty header'                                        => ['', '', FALSE, FALSE],
+		];
+	}
+
+	#[DataProvider('casesProvider')]
+	public function testNormalizeAndJudge(string $header, string $expectHeader, bool $expectChanged, bool $expectReserved): void
+	{
+		$out = pfb_normalize_row_header($header);
+
+		$this->assertSame($expectHeader, $out['header'], "header for input '{$header}'");
+		$this->assertSame($expectChanged, $out['changed'], "changed for input '{$header}'");
+		if ($expectReserved) {
+			$this->assertNotSame('', $out['reserved_error'], "reserved_error for input '{$header}'");
+		} else {
+			$this->assertSame('', $out['reserved_error'], "reserved_error for input '{$header}'");
+		}
+	}
+
+	public function testReturnShapeHasExactlyTheThreeContractedKeys(): void
+	{
+		$out = pfb_normalize_row_header('x');
+		$this->assertSame(['header', 'changed', 'reserved_error'], array_keys($out));
+	}
+}

--- a/tests/php/NormalizeRowHeaderTest.php
+++ b/tests/php/NormalizeRowHeaderTest.php
@@ -61,4 +61,27 @@ final class NormalizeRowHeaderTest extends TestCase
 		$out = pfb_normalize_row_header('x');
 		$this->assertSame(['header', 'changed', 'reserved_error'], array_keys($out));
 	}
+
+	/**
+	 * issue #1270: a config row missing 'header' (foreign/malformed config --
+	 * exactly the audience this fix defends against) evaluates to NULL, which
+	 * TypeErrors on the strict $header param -- pins WHY the call site casts.
+	 */
+	public function testUnguardedMissingHeaderKeyThrowsTypeError(): void
+	{
+		$row = ['url' => 'http://example.test'];
+		$this->expectException(\TypeError::class);
+		/** @phpstan-ignore-next-line intentionally uncast -- reproduces the pre-fix call site */
+		pfb_normalize_row_header($row['header']);
+	}
+
+	/** The call-site's guard pattern -- (string) ($row['header'] ?? '') -- is safe. */
+	public function testCallSiteCastPatternHandlesMissingHeaderKeySafely(): void
+	{
+		$row = ['url' => 'http://example.test'];
+		$this->assertSame(
+			['header' => '', 'changed' => FALSE, 'reserved_error' => ''],
+			pfb_normalize_row_header((string) ($row['header'] ?? ''))
+		);
+	}
 }

--- a/tests/php/ReservedHeaderSkipActiveTest.php
+++ b/tests/php/ReservedHeaderSkipActiveTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for pfb_reserved_header_skip_active() (issue #1270).
+ *
+ * sync_package_pfblockerng() reads list-row config independently in more than
+ * one loop (the download loop and the alias/firewall-rule loop, besides the
+ * header-normalize loop). Each calls this SAME predicate at its own
+ * config-read site, so a regression in the guard (a dropped `!`, the wrong
+ * marker key, `&&` flipped to `||`) fails every call site's test, not an
+ * inline copy no production code executes. Pure, brand-new function (no
+ * pre-existing behaviour to pin -- CLAUDE.md Test coverage #1 exception 2).
+ */
+#[CoversFunction('pfb_reserved_header_skip_active')]
+final class ReservedHeaderSkipActiveTest extends TestCase
+{
+	/** A real user row whose Header collides with a reserved name must skip. */
+	public function testRealUserRowWithReservedHeaderSkips(): void
+	{
+		$this->assertTrue(pfb_reserved_header_skip_active(FALSE, 'DNSBLIP'));
+	}
+
+	/** The package's OWN synthesized DNSBLIP row is exempt from its own guard. */
+	public function testSynthesizedDnsblipRowIsExempt(): void
+	{
+		$this->assertFalse(pfb_reserved_header_skip_active(TRUE, 'DNSBLIP'));
+	}
+
+	/** An ordinary, non-reserved Header never skips, real row or synthesized. */
+	public function testOrdinaryHeaderNeverSkips(): void
+	{
+		$this->assertFalse(pfb_reserved_header_skip_active(FALSE, 'MyBlocklist'));
+		$this->assertFalse(pfb_reserved_header_skip_active(TRUE, 'MyBlocklist'));
+	}
+
+	/** A reserved continent alias on a real user row also skips (not DNSBLIP-only). */
+	public function testRealUserRowWithReservedContinentAliasSkips(): void
+	{
+		$this->assertTrue(pfb_reserved_header_skip_active(FALSE, 'pfB_Africa'));
+	}
+
+	/** An empty Header (draft/incomplete row) never skips. */
+	public function testEmptyHeaderNeverSkips(): void
+	{
+		$this->assertFalse(pfb_reserved_header_skip_active(FALSE, ''));
+	}
+}

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -27,9 +27,10 @@ cannot faithfully reproduce, so these flows do NOT route through
 ``__csrf_magic`` token, then POSTs a FULLY-enumerated payload via
 ``webui.session.post`` (every field the handler reads is supplied a valid value,
 so no select coerces and no rowhelper row is dropped). The single placeholder
-source row is posted ``state-0='Disabled'`` so the URL/header validation arm
-(``$value != 'Disabled'``) is skipped -- a clean, hermetic save with no feed
-download.
+source row is posted ``state-0='Disabled'`` with an empty header/url, so the
+non-empty-gated format checks skip (nothing to check) and the state-gated
+checks skip too (``$value != 'Disabled'``) -- a clean, hermetic save with no
+feed download.
 """
 
 from __future__ import annotations
@@ -116,9 +117,10 @@ def _dnsbl_payload(rowid: int, aliasname: str, **overrides: str) -> dict[str, st
     Every <select> the validator inspects (action/cron/dow/sort/order/logging +
     the ip-only ones) is given a value that is a KEY of its options map, so the
     select-coercion loop (lines 478-488) never rewrites it; the lone source row is
-    ``state-0='Disabled'`` so the URL/header validation arm is skipped. ``custom``
-    is empty so the custom-list validator is skipped and ``pfb_determine_list_detail``
-    is NOT triggered (the base64('')=='' "unchanged" branch).
+    ``state-0='Disabled'`` with an empty header/url, so every header/url check
+    skips (empty -> the non-empty-gated ones; Disabled -> the state-gated ones).
+    ``custom`` is empty so the custom-list validator is skipped and
+    ``pfb_determine_list_detail`` is NOT triggered (the base64('')=='' "unchanged" branch).
     """
     payload = {
         "type": "dnsbl",

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -227,14 +227,8 @@ def test_dnsbl_disabled_row_reserved_header_rejected_leaves_config_unchanged(
 ) -> None:
     """A Disabled row's Header='DNSBLIP' aborts the save -> config UNCHANGED (issue #1270).
 
-    Before #1270, the header-format/reserved checks were gated on
-    ``state-N != 'Disabled'`` (pfblockerng_category_edit.php), so a row saved
-    while Disabled skipped validation entirely and a raw 'DNSBLIP' header could
-    reach config.xml unvalidated -- colliding with the package's own
-    DNSBLIP_v4.txt/_v6.txt list on disk. ``pfb_header_reserved_error()`` now
-    runs whenever the field is non-empty, regardless of row state; this is the
-    ONLY tier that can observe it (save-time POST behaviour, invisible to a
-    GET-only ui_render check).
+    Tier B only: this is save-time POST behaviour, invisible to a GET-only
+    Tier-A ``ui_render`` check.
 
     Given:
         A known-good DNSBL alias with one Disabled placeholder row (header

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -221,6 +221,50 @@ def test_dnsbl_alias_bad_name_rejected_leaves_config_unchanged(
         _del_rowid(vm, CFG_DNSBL, rowid)
 
 
+def test_dnsbl_disabled_row_reserved_header_rejected_leaves_config_unchanged(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A Disabled row's Header='DNSBLIP' aborts the save -> config UNCHANGED (issue #1270).
+
+    Before #1270, the header-format/reserved checks were gated on
+    ``state-N != 'Disabled'`` (pfblockerng_category_edit.php), so a row saved
+    while Disabled skipped validation entirely and a raw 'DNSBLIP' header could
+    reach config.xml unvalidated -- colliding with the package's own
+    DNSBLIP_v4.txt/_v6.txt list on disk. ``pfb_header_reserved_error()`` now
+    runs whenever the field is non-empty, regardless of row state; this is the
+    ONLY tier that can observe it (save-time POST behaviour, invisible to a
+    GET-only ui_render check).
+
+    Given:
+        A known-good DNSBL alias with one Disabled placeholder row (header
+        empty) is saved at a free rowid (the precondition asserted).
+    When:
+        The SAME rowid is re-posted with the still-Disabled row's
+        header-0 = 'DNSBLIP'.
+    Then:
+        The reserved-header guard aborts the whole save, so ``row/0/header``
+        in config.xml stays empty -- UNCHANGED.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_DNSBL)
+    base = f"{CFG_DNSBL}/{rowid}"
+    good = "smokereservedok"
+    try:
+        # Seed a valid alias with an empty Disabled placeholder row (precondition).
+        _post_form(webui, _dnsbl_payload(rowid, good))
+        assert helpers.config_get(vm, f"{base}/aliasname") == good, "precondition: valid alias did not persist"
+        assert helpers.config_get(vm, f"{base}/row/0/header") == "", "precondition: placeholder header not empty"
+
+        # REJECT: a reserved Header on a Disabled row must abort the save (header UNCHANGED).
+        _post_form(webui, _dnsbl_payload(rowid, good, **{"header-0": "DNSBLIP"}))
+        assert helpers.config_get(vm, f"{base}/row/0/header") == "", (
+            "a Disabled row's reserved Header ('DNSBLIP') must abort the save (row/0/header unchanged), but it changed"
+        )
+    finally:
+        _del_rowid(vm, CFG_DNSBL, rowid)
+
+
 # --------------------------------------------------------------------------- #
 # issue #1104: the save-time url-N character guard, end-to-end through a real
 # CSRF POST + config.xml round-trip. format=geoip is deliberate -- its OWN


### PR DESCRIPTION
## Summary

Fixes #1270 — the reserved-list-header set was limited to nothing (see correction below) even though pfBlockerNG synthesizes several package-owned lists (`DNSBLIP`, the 9 GeoIP continent aliases) into the same folder+namespace a user-created Deny/Permit/Match/Native list Header can collide with, last-writer-wins. Also closes a runtime bypass: `pfblockerng.inc`'s periodic sync `\W`-stripped and persisted a stored Header with no reserved-name check, and the category-edit GUI gated its header/URL *format* checks on the row's `Disabled` state, so a Disabled row's raw value reached `config.xml` without any format validation at all.

**Correction to the issue text**: the issue describes `pfb_header_reserved_error()` as an existing helper (from PR #1253) that already rejects `'dedup'`. That PR was closed without merging — superseded by #1250, which independently eliminated the original `dedup`/`matchdedup_v4.txt` collision via a separate `matchgendir` namespace. The helper does not exist on `devel`. This PR introduces it fresh, and its reserved set is exactly `{DNSBLIP} ∪ {the 9 $pfb['continents'] values}` — `'dedup'` is deliberately **not** included (no live collision remains for it).

## Changes

- `pfb_header_reserved_error(string $header): string` + `pfb_normalize_row_header(string $header): array` (new, pure) in `pfblockerng_extra.inc`.
- `sync_package_pfblockerng()`'s row loop now normalizes+checks every header; a reserved collision is skipped (never persisted, never collected) and batched into one `file_notice()`/`pfb_logger()` per sync pass. The package's own synthesized `DNSBLIP` pseudo-row is exempted (a local, non-persisted index check) so DNSBL-IP blocking doesn't self-reject.
- `pfblockerng_category_edit.php`'s save-time `\W`-format check, the issue-#1104 URL control-char check, and a new reserved-header check now run whenever the field is non-empty, regardless of row state — closing the Disabled-row carve-out. Emptiness checks stay state-gated (draft UX unaffected).

## Test plan

- [x] `tests/php/HeaderReservedErrorTest.php` — all 9 continents + DNSBLIP enumerated from `$pfb['continents']`; proves `$pfb['continent_list']` (missing `pfB_PS`) is NOT the source; hostile near-misses (`dnsblip` lowercase, `pfBAfrica`, `dedup`) confirmed NOT reserved.
- [x] `tests/php/NormalizeRowHeaderTest.php` — strip+reserved-check composition (`DNSBL-IP`→`DNSBLIP` reserved; `de-dup`→`dedup` NOT reserved; `pfB.Africa`→`pfBAfrica` NOT reserved).
- [x] `tests/php/CategoryEditReservedHeaderTest.php` — eval-extraction of the GUI save loop; red→green proven against the pre-fix loop (4 failures pre-fix, all pass post-fix); before-state regression guard confirms a Disabled draft row (empty header/url) still saves cleanly.
- [x] Full `vendor/bin/phpunit`, `composer phpstan`, `composer phpcs`, `php -l` all clean.
- [x] Independent Sonnet verifier re-ran every gate + the red→green proof from a fresh context (`scripts/agent/verify-red-proof.sh`) and read the full diff against the brief's 10 constraints + 8 coverage-matrix rows — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gr4Sj3PTxg6CCSEMo2KtNk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reserved-header collision handling for DNSBL/GeoIP synthesized package names, including header normalization to avoid conflicts.

- **Bug Fixes**
  - Skips reserved colliding headers during processing and emits a single consolidated alert summarizing all skipped items.
  - Prevents reserved header collisions from being written or loaded into alias/firewall rule configuration.
  - Category edit validation now applies whenever header/URL fields are non-empty, including Disabled rows.

- **Tests**
  - Added unit tests for reserved-header rejection, header normalization, and reserved-skip behavior.
  - Added category-edit and UI smoke tests verifying reserved header rejection leaves `config.xml` unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->