### PR TITLE
tests: bring smoke suite under canonical mypy gate (#1265)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,8 +169,8 @@ jobs:
 
       - name: mypy tests/
         # Config in pyproject.toml: the tests.* override requires
-        # disallow_untyped_defs/disallow_incomplete_defs, tests/smoke is excluded,
-        # and follow_imports=silent keeps production (incremental) typing out of scope.
+        # disallow_untyped_defs/disallow_incomplete_defs, including tests/smoke;
+        # follow_imports=silent keeps production (incremental) typing out of scope.
         run: mypy tests/
 
   ruff:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,12 +92,10 @@ mypy_path            = "stubs/python"
 # pfb_unbound.py) for their types but does NOT fail on their own incremental-typing
 # errors -- the gate judges the test suite, not production.
 follow_imports       = "silent"
-# tests/smoke is the dispatch-only live-VM suite (ADR-04): it needs third-party
-# deps that are not installed in the lint/CI type-check env, and is excluded from
-# the default pytest run too (--ignore=tests/smoke). Keep it out of the gate.
-exclude              = ['^tests/smoke/']
+# tests/smoke is the dispatch-only live-VM suite (ADR-04), but its annotations
+# remain checkable without importing its runtime-only third-party dependencies.
 
-# The test suite, by contrast, IS fully type-annotated, and `mypy tests/` is a CI
+# The complete test suite IS fully type-annotated, and `mypy tests/` is a CI
 # + pre-commit gate (see .github/workflows/test.yml, .githooks/pre-commit) that
 # keeps it that way. This override makes that requirement explicit/strict for the
 # test modules only; production stays incremental (above).

--- a/tests/smoke/_matrix.py
+++ b/tests/smoke/_matrix.py
@@ -20,6 +20,7 @@ import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -88,6 +89,7 @@ def matrix_variants() -> list[Variant]:
             "version matrix unavailable (set SMOKE_MATRIX_JSON, or make the ci-metadata ref "
             "readable by scripts/read-version-matrix.sh) — cannot derive the variant topology"
         )
+    entries = cast(tuple[dict, ...], entries)
     out: dict[tuple[str, str], Variant] = {}
     for e in entries:
         major = str(e.get("freebsd_major", "")).strip()

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -573,6 +573,7 @@ def smoke_vm(
     ssh_key_path = os.environ.get("SMOKE_SSH_KEY")
     if not ssh_key_path or not Path(ssh_key_path).is_file():
         pytest.skip("SMOKE_SSH_KEY not set or not a file — no guest SSH key")
+    ssh_key_path = cast(str, ssh_key_path)
 
     if not Path("/dev/kvm").exists():
         pytest.skip("/dev/kvm absent — KVM acceleration required for the smoke VM")
@@ -676,6 +677,7 @@ def client_vm(
     ssh_key_path = os.environ.get("SMOKE_SSH_KEY")
     if not ssh_key_path or not Path(ssh_key_path).is_file():
         pytest.skip("SMOKE_SSH_KEY not set or not a file — no guest SSH key")
+    ssh_key_path = cast(str, ssh_key_path)
 
     if not Path("/dev/kvm").exists():
         pytest.skip("/dev/kvm absent — KVM acceleration required for the smoke VM")

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -51,7 +51,7 @@ from email.utils import parsedate_to_datetime
 from functools import partial
 from http.server import BaseHTTPRequestHandler, SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO, cast
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
@@ -321,7 +321,7 @@ class BootHandle:
 
     process: subprocess.Popen[bytes]
     vm: SmokeVM
-    log_file: object = field(repr=False)
+    log_file: BinaryIO = field(repr=False)
 
 
 @timed_step("boot_and_probe")
@@ -579,7 +579,7 @@ def smoke_vm(
 
     # `oras` is only needed when we have to pull; a pre-pulled SMOKE_IMAGE_DIR
     # run (egress blocked) does not require it.
-    required = ("qemu-system-x86_64", "qemu-img", "ssh")
+    required: tuple[str, ...] = ("qemu-system-x86_64", "qemu-img", "ssh")
     if not image_dir:
         required = ("oras", *required)
     for binary in required:
@@ -593,6 +593,7 @@ def smoke_vm(
             raise RuntimeError(f"SMOKE_IMAGE_DIR must hold exactly one .qcow2, found {len(qcows)}: {qcows}")
         base_image = qcows[0]
     else:
+        assert image_ref is not None
         base_image = oras_pull_image(image_ref, work / "image")
 
     handle = boot_and_probe(
@@ -1510,7 +1511,7 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     ``-m two_vm`` / ``-m 'not two_vm'`` without a hardcoded list.
     """
     for item in items:
-        if _needs_two_vm(item.fixturenames):
+        if _needs_two_vm(cast(Any, item).fixturenames):
             item.add_marker("two_vm")
 
 
@@ -1518,7 +1519,7 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]) -> Generator[None, None, None]:
     """Stash each phase's report on the item so fixtures can read pass/fail."""
     outcome = yield
-    rep = outcome.get_result()
+    rep = cast(Any, outcome).get_result()
     setattr(item, f"_rep_{rep.when}", rep)
 
 

--- a/tests/smoke/stub_responses.py
+++ b/tests/smoke/stub_responses.py
@@ -11,6 +11,8 @@ Uses dnspython (a smoke-only dependency), so every consumer lives under ``tests/
 
 from __future__ import annotations
 
+from typing import cast
+
 STUB_DNS_A = "203.0.113.99"  # RFC 5737 documentation range
 STUB_DNS_AAAA = "2001:db8::99"  # RFC 3849 documentation range
 
@@ -94,11 +96,11 @@ def build_response(
             resp.flags |= dns.flags.AA
         if rec.get("ra"):
             resp.flags |= dns.flags.RA
-        ede_info_code = rec.get("ede_info_code")
+        ede_info_code = cast(int | None, rec.get("ede_info_code"))
         if ede_info_code is not None:
             # Attach an RFC 8914 EDE option so Unbound passes it upstream-side.
             ede_text = str(rec.get("ede_text", "")) or None
-            ede_opt = dns.edns.EDEOption(int(ede_info_code), text=ede_text)
+            ede_opt = dns.edns.EDEOption(cast("dns.edns.EDECode", int(ede_info_code)), text=ede_text)
             resp.use_edns(edns=0, options=[ede_opt])
         return resp.to_wire(), qlog
 

--- a/tests/smoke/test_bench_pfctl.py
+++ b/tests/smoke/test_bench_pfctl.py
@@ -75,6 +75,7 @@ import subprocess
 import threading
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TypedDict
 
 import pytest
 
@@ -474,7 +475,23 @@ def _parse_kv(text: str) -> dict[str, str]:
     return out
 
 
-def _parse_guest_row(kv: dict[str, str]) -> dict[str, object]:
+class _GuestRow(TypedDict):
+    op: str
+    size: int
+    churn: int
+    batch: str
+    wall_ms: int
+    epoch_start: float
+    epoch_end: float
+    ctrl_p50_ms: int
+    ctrl_p99_ms: int
+    ctrl_max_ms: int
+    ctrl_n: int
+    error: str
+    timed_out: bool
+
+
+def _parse_guest_row(kv: dict[str, str]) -> _GuestRow:
     return {
         "op": kv.get("op", ""),
         "size": int(kv.get("size", 0)),
@@ -1257,8 +1274,8 @@ def test_pfctl_knee_sweep(
     for sz, churn in _KNEE_CELLS:
         print(f"\n  == knee size={sz:,} churn={churn:,} ==")
         for batch in _KNEE_BATCHES:
-            key = (sz, churn, batch)
-            knee_rows[key] = []
+            knee_key = (sz, churn, batch)
+            knee_rows[knee_key] = []
             for rep in range(_REPS):
                 print(f"  delta {sz:,}/{churn:,}/batch={batch} rep={rep + 1}/{_REPS}", flush=True)
                 row = _measure_with_probe(
@@ -1269,13 +1286,13 @@ def test_pfctl_knee_sweep(
                     op_timeout_s=600.0,
                     interval_s=_KNEE_INTERVAL,
                 )
-                knee_rows[key].append(row)
+                knee_rows[knee_key].append(row)
             ps = _compute_pooled(
-                [r.icmp_during for r in knee_rows[key]],
-                [r.icmp_baseline for r in knee_rows[key]],
+                [r.icmp_during for r in knee_rows[knee_key]],
+                [r.icmp_baseline for r in knee_rows[knee_key]],
             )
-            knee_stats[key] = ps
-            med_wall = statistics.median(r.wall_ms for r in knee_rows[key])
+            knee_stats[knee_key] = ps
+            med_wall = statistics.median(r.wall_ms for r in knee_rows[knee_key])
             _print_pooled(f"delta {sz:,}/{churn:,}/batch={batch}", _REPS, med_wall, ps)
 
     # ------------------------------------------------------------------ #
@@ -1291,8 +1308,8 @@ def test_pfctl_knee_sweep(
     for sz, lbl, churn in _SMALL_CHURN_CELLS:
         print(f"\n  == small-churn size={sz:,} churn={churn:,} ({lbl}) ==")
         for batch in _SC_BATCHES:
-            key = (sz, lbl, churn, batch)
-            sc_rows[key] = []
+            small_churn_key = (sz, lbl, churn, batch)
+            sc_rows[small_churn_key] = []
             for rep in range(_REPS):
                 print(f"  delta {sz:,}/{churn:,}/batch={batch} rep={rep + 1}/{_REPS}", flush=True)
                 row = _measure_with_probe(
@@ -1303,13 +1320,13 @@ def test_pfctl_knee_sweep(
                     op_timeout_s=300.0,
                     interval_s=_KNEE_INTERVAL,
                 )
-                sc_rows[key].append(row)
+                sc_rows[small_churn_key].append(row)
             ps = _compute_pooled(
-                [r.icmp_during for r in sc_rows[key]],
-                [r.icmp_baseline for r in sc_rows[key]],
+                [r.icmp_during for r in sc_rows[small_churn_key]],
+                [r.icmp_baseline for r in sc_rows[small_churn_key]],
             )
-            sc_stats[key] = ps
-            med_wall = statistics.median(r.wall_ms for r in sc_rows[key])
+            sc_stats[small_churn_key] = ps
+            med_wall = statistics.median(r.wall_ms for r in sc_rows[small_churn_key])
             _print_pooled(f"delta {sz:,}/{churn:,}({lbl})/batch={batch}", _REPS, med_wall, ps)
 
     # ------------------------------------------------------------------ #
@@ -1350,18 +1367,18 @@ def test_pfctl_knee_sweep(
     for sz, churn in _KNEE_CELLS:
         print(f"  --- size={sz:,} churn={churn:,} ---")
         for batch in _KNEE_BATCHES:
-            key = (sz, churn, batch)
-            ps = knee_stats[key]
-            med_wall = statistics.median(r.wall_ms for r in knee_rows[key])
+            knee_key = (sz, churn, batch)
+            ps = knee_stats[knee_key]
+            med_wall = statistics.median(r.wall_ms for r in knee_rows[knee_key])
             print(_row_str("delta", sz, churn, batch, ps, med_wall))
 
     print("\n-- C: small-churn reference --")
     for sz, lbl, churn in _SMALL_CHURN_CELLS:
         print(f"  --- size={sz:,} churn={churn:,} ({lbl}) ---")
         for batch in _SC_BATCHES:
-            key = (sz, lbl, churn, batch)
-            ps = sc_stats[key]
-            med_wall = statistics.median(r.wall_ms for r in sc_rows[key])
+            small_churn_key = (sz, lbl, churn, batch)
+            ps = sc_stats[small_churn_key]
+            med_wall = statistics.median(r.wall_ms for r in sc_rows[small_churn_key])
             print(_row_str("delta", sz, churn, batch, ps, med_wall))
 
     print(
@@ -1714,8 +1731,8 @@ def test_pfctl_reject_loop(
             op = bench_args[0]
             sz = int(bench_args[1])
             churn = int(bench_args[2]) if len(bench_args) > 2 else 0
-            batch = bench_args[3] if len(bench_args) > 3 else "-"
-            print(_rst_row(rule_type, op, sz, churn, batch, ps, med_wall))
+            batch_label = bench_args[3] if len(bench_args) > 3 else "-"
+            print(_rst_row(rule_type, op, sz, churn, batch_label, ps, med_wall))
 
     if replace_stats_rst:
         print("\n-- A: replace baselines (floating) --")

--- a/tests/smoke/test_smoke_714_asn_geoip.py
+++ b/tests/smoke/test_smoke_714_asn_geoip.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterator
+from typing import cast
 
 import pytest
 
@@ -99,6 +100,7 @@ def test_714_c1_asn_table_logs_not_stray_file(deployed_vm: SmokeVM) -> None:
             f"{ASN_TOKEN_ENV} not set — the ASN database download needs a real, licensed "
             "IPinfo account token (absent from CI); dispatch-only, validate live (ADR-04 §7)"
         )
+    token = cast(str, token)
 
     try:
         # BEFORE: no stray numeric-logtype file yet.
@@ -184,6 +186,8 @@ def test_714_c8_geoip_single_ip_preserved(deployed_vm: SmokeVM) -> None:
             f"{GEOIP_KEY_ENV}/{GEOIP_ACCOUNT_ENV} not set — the GeoIP continent build needs a real, "
             "licensed MaxMind account (absent from CI); dispatch-only, validate live (ADR-04 §7)"
         )
+    key = cast(str, key)
+    account = cast(str, account)
 
     try:
         snippet_creds = (

--- a/tests/smoke/test_smoke_apply_on_change.py
+++ b/tests/smoke/test_smoke_apply_on_change.py
@@ -94,7 +94,7 @@ def _set_pfb_interval(vm: SmokeVM, value: str, *, timeout: float = 60.0) -> None
         raise RuntimeError(f"_set_pfb_interval({value!r}) did not take: config reads {readback!r}")
 
 
-def _read_ledger(vm) -> dict:
+def _read_ledger(vm: SmokeVM) -> dict:
     """Return the parsed ledger from the box (empty on absent/corrupt)."""
     raw = vm.ssh(f"cat {LEDGER_PATH} 2>/dev/null || echo '{{}}'").stdout
     try:
@@ -103,7 +103,7 @@ def _read_ledger(vm) -> dict:
         return {}
 
 
-def _write_ledger_entry(vm, job_key: str, last_run: int, next_due: int, jitter: int = 0) -> None:
+def _write_ledger_entry(vm: SmokeVM, job_key: str, last_run: int, next_due: int, jitter: int = 0) -> None:
     """Write a single ledger entry via the package's own PHP ledger writer.
 
     pfSense ships no ``python3``, and the product already owns the ledger format, so
@@ -121,7 +121,7 @@ def _write_ledger_entry(vm, job_key: str, last_run: int, next_due: int, jitter: 
         raise RuntimeError(f"_write_ledger_entry failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
 
 
-def _set_quiet_hours(vm, window: str) -> None:
+def _set_quiet_hours(vm: SmokeVM, window: str) -> None:
     """Set pfb_quiet_hours in config.xml via pfSsh.php."""
     # Use the config gateway rather than direct xml munging.
     snippet = (
@@ -135,17 +135,17 @@ def _set_quiet_hours(vm, window: str) -> None:
         raise RuntimeError(f"_set_quiet_hours({window!r}) failed: rc={result.returncode} {result.stderr!r}")
 
 
-def _clear_quiet_hours(vm) -> None:
+def _clear_quiet_hours(vm: SmokeVM) -> None:
     """Clear pfb_quiet_hours (reset to default '')."""
     _set_quiet_hours(vm, "")
 
 
-def _force_cron_due(vm) -> None:
+def _force_cron_due(vm: SmokeVM) -> None:
     """Force the cron job due-now by back-dating next_due to epoch 0."""
     _write_ledger_entry(vm, "cron", last_run=0, next_due=0)
 
 
-def _run_tick(vm) -> str:
+def _run_tick(vm: SmokeVM) -> str:
     """Fire one tick synchronously and return combined stdout+stderr.
 
     Drains any in-flight pfBlockerNG pass first: the tick defers its feed cron while
@@ -157,12 +157,12 @@ def _run_tick(vm) -> str:
     return vm.ssh(f"{_PHP} {_PFB_PHP} tick 2>&1").stdout
 
 
-def _cron_ledger(vm) -> dict | None:
+def _cron_ledger(vm: SmokeVM) -> dict | None:
     """Return the 'cron' entry from the ledger, or None if absent."""
     return _read_ledger(vm).get("cron")
 
 
-def _is_pending(vm) -> bool:
+def _is_pending(vm: SmokeVM) -> bool:
     """Return True iff the 'cron' ledger entry has pending_apply set."""
     entry = _cron_ledger(vm)
     return bool(entry and entry.get("pending_apply"))
@@ -175,7 +175,7 @@ def _is_pending(vm) -> bool:
 
 @pytest.mark.smoke
 @pytest.mark.apply_on_change
-def test_apply_no_window_dispatches_immediately(deployed_vm: SmokeVM):
+def test_apply_no_window_dispatches_immediately(deployed_vm: SmokeVM) -> None:
     """No quiet-hours window → tick dispatches a due job without deferral.
 
     Scenario:
@@ -217,7 +217,7 @@ def test_apply_no_window_dispatches_immediately(deployed_vm: SmokeVM):
 
 @pytest.mark.smoke
 @pytest.mark.apply_on_change
-def test_apply_inside_window_dispatches(deployed_vm: SmokeVM):
+def test_apply_inside_window_dispatches(deployed_vm: SmokeVM) -> None:
     """Window that covers now → tick dispatches, pending NOT set.
 
     Scenario:
@@ -252,7 +252,7 @@ def test_apply_inside_window_dispatches(deployed_vm: SmokeVM):
 
 @pytest.mark.smoke
 @pytest.mark.apply_on_change
-def test_apply_outside_window_defers(deployed_vm: SmokeVM):
+def test_apply_outside_window_defers(deployed_vm: SmokeVM) -> None:
     """Window that excludes now → tick defers (pending set, job NOT dispatched).
 
     Scenario:
@@ -302,7 +302,7 @@ def test_apply_outside_window_defers(deployed_vm: SmokeVM):
 
 @pytest.mark.smoke
 @pytest.mark.apply_on_change
-def test_apply_pending_cleared_by_window_open(deployed_vm: SmokeVM):
+def test_apply_pending_cleared_by_window_open(deployed_vm: SmokeVM) -> None:
     """Pending job is applied when window opens (pending cleared, last_run updated).
 
     Scenario:

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -97,7 +97,7 @@ _VAR_WIPE_SENTINEL = "/var/PFB_SMOKE_TICK_WIPE_SENTINEL"
 # ---------------------------------------------------------------------------
 
 
-def _read_ledger(vm) -> dict:
+def _read_ledger(vm: SmokeVM) -> dict:
     """Return the parsed ledger as a dict (empty on absent/corrupt)."""
     raw = vm.ssh(f"cat {LEDGER_PATH} 2>/dev/null || echo '{{}}'").stdout
     try:
@@ -106,7 +106,7 @@ def _read_ledger(vm) -> dict:
         return {}
 
 
-def _write_ledger_entry(vm, job_key: str, last_run: int, next_due: int, jitter: int = 0) -> None:
+def _write_ledger_entry(vm: SmokeVM, job_key: str, last_run: int, next_due: int, jitter: int = 0) -> None:
     """Merge one entry into the on-box ledger via the package's own PHP ledger writer.
 
     pfSense ships no ``python3`` (python3.11 only, no symlink), and the product already owns the
@@ -125,7 +125,7 @@ def _write_ledger_entry(vm, job_key: str, last_run: int, next_due: int, jitter: 
         raise RuntimeError(f"_write_ledger_entry failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
 
 
-def _run_tick(vm) -> str:
+def _run_tick(vm: SmokeVM) -> str:
     """Fire one tick synchronously and return its combined stdout+stderr."""
     return vm.ssh(f"{_PHP} {_PFB_PHP} tick 2>&1").stdout
 
@@ -134,7 +134,7 @@ _SS_EXTDNS_STUB = "192.168.89.2"  # WAN SLIRP host alias -> the stub_dns fixture
 _SS_EXTDNS_DEFAULT = "8.8.8.8"  # pfb_global()'s documented absent-default
 
 
-def _seed_ss_refresh_positive_control(vm, target: str, stale_v4: str) -> str:
+def _seed_ss_refresh_positive_control(vm: SmokeVM, target: str, stale_v4: str) -> str:
     """Point ss_refresh's resolver at the stub DNS and seed a CNAME row baked STALE.
 
     pfblockerng_ss_refresh() re-resolves each SafeSearch CNAME row's target and rewrites
@@ -165,7 +165,7 @@ def _seed_ss_refresh_positive_control(vm, target: str, stale_v4: str) -> str:
     return domain
 
 
-def _remove_ss_row(vm, domain: str) -> None:
+def _remove_ss_row(vm: SmokeVM, domain: str) -> None:
     """Strip the seeded SafeSearch CSV row again (issue #582 cleanup).
 
     Matched by the row's unique source domain — ss_refresh may have rewritten the
@@ -185,7 +185,7 @@ def _remove_ss_row(vm, domain: str) -> None:
         raise RuntimeError(f"_remove_ss_row failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
 
 
-def _reset_ss_extdns(vm) -> None:
+def _reset_ss_extdns(vm: SmokeVM) -> None:
     """Restore the 'pfbextdns' general setting to its documented default (issue #582 cleanup)."""
     snippet = (
         "$g = config_get_path('installedpackages/pfblockerngglobal', array());"
@@ -214,7 +214,7 @@ _CRON_JSON_OPEN = "<<<PFBCRON>>>"
 _CRON_JSON_CLOSE = "<<<ENDPFBCRON>>>"
 
 
-def _read_pfb_tick_cron_items(vm) -> list[str]:
+def _read_pfb_tick_cron_items(vm: SmokeVM) -> list[str]:
     """Return the 'command' string of every config.xml cron/item naming the
     tick-family verb (the current cron-tick, or the legacy bare tick)."""
     snippet = (
@@ -245,7 +245,7 @@ def _read_pfb_tick_cron_items(vm) -> list[str]:
 @pytest.mark.smoke
 @pytest.mark.tick
 @pytest.mark.timeout(180)  # two foreground sync passes (master switch off, then on)
-def test_tick_cron_entry_installed(deployed_vm: SmokeVM):
+def test_tick_cron_entry_installed(deployed_vm: SmokeVM) -> None:
     """The installed scheduled-tick cron entry is the #1204 cron-tick verb.
 
     Guards pfblockerng_configure_tick_cron's trailing-space teardown needle
@@ -289,7 +289,7 @@ def test_tick_cron_entry_installed(deployed_vm: SmokeVM):
 @pytest.mark.smoke
 @pytest.mark.tick
 @pytest.mark.timeout(120)
-def test_cron_tick_respects_disable_flag(deployed_vm: SmokeVM):
+def test_cron_tick_respects_disable_flag(deployed_vm: SmokeVM) -> None:
     """The cron-tick verb honours the harness's .pfb_cron_disable sentinel.
 
     Branch PAIR (CLAUDE.md branch coverage): the same due-ledger precondition is
@@ -351,7 +351,7 @@ def test_cron_tick_respects_disable_flag(deployed_vm: SmokeVM):
 @pytest.mark.smoke
 @pytest.mark.tick
 @pytest.mark.timeout(90)
-def test_tick_verb_ignores_disable_flag(deployed_vm: SmokeVM):
+def test_tick_verb_ignores_disable_flag(deployed_vm: SmokeVM) -> None:
     """The direct 'tick' verb is NEVER gated by .pfb_cron_disable -- only 'cron-tick' is.
 
     Scenario:
@@ -383,7 +383,7 @@ def test_tick_verb_ignores_disable_flag(deployed_vm: SmokeVM):
 @pytest.mark.smoke
 @pytest.mark.tick
 @pytest.mark.timeout(150)  # the cron pass is backgrounded; its CRON PROCESS marker lands async
-def test_tick_dispatches_due_feed(deployed_vm: SmokeVM):
+def test_tick_dispatches_due_feed(deployed_vm: SmokeVM) -> None:
     """Tick fires a due feed sync, dispatched THROUGH pfblockerng_sync_cron (issue #570).
 
     Two observables (the tick logs to syslog, not stdout, so we never assert on tick stdout):
@@ -442,7 +442,7 @@ def test_tick_dispatches_due_feed(deployed_vm: SmokeVM):
 @pytest.mark.smoke
 @pytest.mark.tick
 @pytest.mark.timeout(150)  # drain + bounded no-dispatch poll can exceed the 30s body cap
-def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer):
+def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
     """Tick does NOT dispatch a feed sync when the cron ledger entry is not yet due —
     yet the tick itself genuinely ran (issue #582 positive control).
 
@@ -518,7 +518,7 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
 
 @pytest.mark.smoke
 @pytest.mark.tick
-def test_tick_wiped_ledger_jittered(deployed_vm: SmokeVM):
+def test_tick_wiped_ledger_jittered(deployed_vm: SmokeVM) -> None:
     """After the ledger is wiped, the tick runs jobs but schedules them jittered.
 
     Scenario:
@@ -631,7 +631,7 @@ def mfs_var(deployed_vm: SmokeVM, request: pytest.FixtureRequest) -> Iterator[Sm
 # mfs_var fixture reboots twice more (arrange + teardown) — exempt from the func-only cap,
 # same as boot_reload's fixture reboots — so the body still contains exactly ONE reboot.
 @pytest.mark.timeout(300)
-def test_tick_reboot_persists_ledger(mfs_var: SmokeVM):
+def test_tick_reboot_persists_ledger(mfs_var: SmokeVM) -> None:
     """A clean reboot with MFS /var keeps the due-ledger (restored via #468 earlyshellcmd).
 
     Scenario:

--- a/tests/smoke/test_stub_shapes.py
+++ b/tests/smoke/test_stub_shapes.py
@@ -135,7 +135,7 @@ class TestStubResolvingBranches:
         assert len(resp.answer) == 0
 
     def test_cname_chain_resolves_to_target(self) -> None:
-        records = {
+        records: dict[str, dict[str, object]] = {
             "alias-267.example.": {"cname": "canon-267.example."},
             "canon-267.example.": {"a": ("203.0.113.8",)},
         }


### PR DESCRIPTION
## Summary

- remove the mypy exclusion that hid all of tests/smoke from the canonical gate
- resolve the existing smoke typing errors with annotations and local narrowing only
- keep smoke behavior, assertions, fixture lifecycle, markers, and dependencies unchanged

## Verification

- test-first scope canary: base checked 103 modules and missed the deliberate smoke error; fixed config checked 203 with the canary and reported exactly its one return-value error
- python3 -m pytest: 2901 passed, 4 skipped
- ruff check . and ruff format --check .
- python3 -m mypy tests/: 202 source files, no issues
- smoke collect-only: 793 tests
- independent phase-step verification: PASS, including mutation red proof and full diff audit

Closes #1265.

## AI audit

Implemented and independently gated through the repository phase-step contract. No production source or runtime behavior changed.

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded static type coverage across the smoke-test suite and CI type-check gate, including keeping smoke annotations checkable.
  * Strengthened typing for VM fixtures, DNS stub responses, smoke-test helpers, and benchmark result parsing for clearer, more consistent test data handling.
  * Preserved existing smoke-test behavior, assertions, and runtime logic while improving type clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->