### PR TITLE
pfblockerng: clean aborted recompute staging

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5173,7 +5173,7 @@ function pfb_member_file_is_placeholder_only($path, $placeholder) {
  * @param string[] $existing_deny $pfb['existing']['deny'] -- '<header>_v4'/'<header>_v6' names.
  * @param bool     $ccwhite_match TRUE iff $pfb['ccwhite'] == 'match' (the exempt file's only writer).
  * @param string   $matchgendir   Absolute matchgendir path (no trailing slash).
- * @return string[] Basenames (no '.txt') actually reaped this pass.
+ * @return string[] Basenames actually reaped; staging artifacts retain their '.txt.new' suffix.
  */
 function pfb_matchgen_reap(array $existing_deny, bool $ccwhite_match, string $matchgendir): array {
 	// pfB_Match_ET_v4/_v6 are always kept: the reaper runs before processet() in
@@ -5199,6 +5199,13 @@ function pfb_matchgen_reap(array $existing_deny, bool $ccwhite_match, string $ma
 		if (!empty(pfb_filter($pfb_orphan, PFB_FILTER_WORD, 'Remove un-associated matchgen artifact'))) {
 			unlink_if_exists("{$matchgendir}/{$pfb_orphan}.txt");
 			$reaped[] = $pfb_orphan;
+		}
+	}
+	foreach (glob("{$matchgendir}/*.txt.new") ?: [] as $pfb_file) {
+		$pfb_orphan = basename($pfb_file, '.txt.new');
+		if (!empty(pfb_filter($pfb_orphan, PFB_FILTER_WORD, 'Remove stale matchgen staging artifact'))) {
+			unlink_if_exists($pfb_file);
+			$reaped[] = "{$pfb_orphan}.txt.new";
 		}
 	}
 	return $reaped;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1098,11 +1098,13 @@ pfb_recompute_clean_new() {
 		rm -f "${pfbdeny}${rec_alias}.txt.new"
 	done < "${rec_priority}"
 	rm -f "${rec_masterfile_new}" "${rec_mastercat_new}" "${rec_countsfile_new}"
+	pfb_recompute_clean_rep_new
 }
 
 # Same cleanup for the per-alias reputation artifacts' .new siblings (dMax emits
 # them into matchgendir); the consolidated exempt file's .new stays caller-owned.
 pfb_recompute_clean_rep_new() {
+	[ -n "${pfbmatchgen:-}" ] || return 0
 	while IFS=' ' read -r rec_alias _; do
 		rm -f "${pfbmatchgen}pfB_Match_Rep_${rec_alias}.txt.new"
 	done < "${rec_priority}"
@@ -1354,9 +1356,6 @@ pfb_recompute_rep_subset() {
 		log="recompute [ ${rec_family} ]: reinject pass failed; aborting pass, cleaning up partial artifacts"
 		echo "${log}" | tee -a "${errorlog}"
 		pfb_recompute_clean_new
-		if [ "${rec_repmode}" = 'dmax' ]; then
-			pfb_recompute_clean_rep_new
-		fi
 		return 1
 	fi
 
@@ -1374,9 +1373,6 @@ pfb_recompute_rep_subset() {
 			log="recompute [ ${rec_family} ]: emit pass failed for [ ${rec_alias} ]; aborting pass, cleaning up partial artifacts"
 			echo "${log}" | tee -a "${errorlog}"
 			pfb_recompute_clean_new
-			if [ "${rec_repmode}" = 'dmax' ]; then
-				pfb_recompute_clean_rep_new
-			fi
 			return 1
 		fi
 	done < "${rec_priority}"

--- a/tests/php/MatchGenReapTest.php
+++ b/tests/php/MatchGenReapTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\TestCase;
  *   H5 no cross-directory reach (a matchdir user file is untouched); H6 a stray artifact with
  *   no owning alias is reaped; H7 both v4 and v6 families are enumerated, not just v4.
  *   R1-R3: the ET/Exempt keep-list is family-complete (v4 AND v6), not v4-only.
+ *   H8 stale .txt.new staging is reaped without touching a configured alias's live artifact.
  */
 #[CoversFunction('pfb_matchgen_reap')]
 final class MatchGenReapTest extends TestCase
@@ -103,6 +104,25 @@ final class MatchGenReapTest extends TestCase
 
 		$this->assertFileDoesNotExist($artifact, 'a removed Deny alias leaves an orphan the sweep must reap');
 		$this->assertContains('pfB_Match_Rep_Spam_v4', $reaped);
+	}
+
+	/**
+	 * H8: a pass aborted after writing a staging sibling can outlive its removed Deny alias.
+	 * The orphan sweep removes that machine-owned staging file while preserving live artifacts.
+	 */
+	public function testReapsStaleNewArtifactWithoutTouchingLiveArtifact(): void
+	{
+		$live = $this->touchGen('pfB_Match_Rep_Live_v4');
+		$staged = "{$this->matchgendir}/pfB_Match_Rep_GONE_v4.txt.new";
+		$this->assertNotFalse(file_put_contents($staged, 'stale'));
+		$this->assertFileExists($staged, 'precondition: the orphan staging artifact exists');
+
+		$reaped = pfb_matchgen_reap(['Live_v4'], FALSE, $this->matchgendir);
+
+		$this->assertFileDoesNotExist($staged, 'a removed alias must not strand its staging artifact');
+		$this->assertFileExists($live, 'the configured alias live artifact must survive');
+		$this->assertContains('pfB_Match_Rep_GONE_v4.txt.new', $reaped);
+		$this->assertNotContains('pfB_Match_Rep_Live_v4', $reaped);
 	}
 
 	/**

--- a/tests/shell/pfblockerng_recompute_spec.sh
+++ b/tests/shell/pfblockerng_recompute_spec.sh
@@ -111,6 +111,37 @@ EOF
 	chmod +x "$1"
 }
 
+make_window_awk_fail_stub() {
+	realawk="$(command -v awk)"
+	mkdir -p "$1"
+	cat > "$1/awk" <<EOF
+#!/bin/sh
+window=0
+for arg do
+	case "\${arg}" in
+		*'pfB_Match_Rep_'*'.txt.new'*) window=1 ;;
+	esac
+done
+"${realawk}" "\$@"
+rc=\$?
+if [ "\${window}" -eq 1 ]; then
+	: > "$1/window-hit"
+	[ "\${rc}" -eq 0 ] && exit 74
+fi
+exit "\${rc}"
+EOF
+	chmod +x "$1/awk"
+}
+
+recompute_with_window_awk_failure() {
+	(
+		PATH="$1:${PATH}"
+		export PATH
+		shift
+		pfb_recompute "$@"
+	)
+}
+
 Describe 'pfb_recompute() v4 cross-feed dedup (Stage A/B/D/E)'
 	# shellcheck disable=SC2034  # consumed by the sourced pfb_recompute()
 	setup() {
@@ -533,6 +564,24 @@ Describe 'pfb_recompute() dMax match-mode + GeoIP-unavailable bail + pMax'
 	BeforeAll 'pfb_source'
 	Before 'setup'
 	After 'cleanup'
+
+	It 'cleans per-alias reputation staging when the window awk fails after writing it'
+		make_geoip_stub "$pathgeoip" 'Could not find an entry for this IP address'
+		printf '192.0.2.20\n192.0.2.21\n' > "${snap}/ONE_v4.orig"
+		printf '%s\n' "${snap}/ONE_v4.orig" > "$memberlist"
+		printf '198.51.100.1\n' > "${pfbdeny}ONE_v4.txt"
+		printf '198.51.100.0/24\n!198.51.100.1\n' > "${pfbmatchgen}pfB_Match_Rep_ONE_v4.txt"
+		awkshim="${work}/awkshim"
+		make_window_awk_fail_stub "$awkshim"
+
+		When call silently recompute_with_window_awk_failure "$awkshim" recompute v4 "$memberlist" "$countsfile" on dmax 1 US off match
+		The status should be failure
+		The path "${awkshim}/window-hit" should be exist
+		The contents of file "$errorlog" should include 'reputation-apply pass failed'
+		The path "${pfbmatchgen}pfB_Match_Rep_ONE_v4.txt.new" should not be exist
+		The contents of file "${pfbdeny}ONE_v4.txt" should equal '198.51.100.1'
+		The contents of file "${pfbmatchgen}pfB_Match_Rep_ONE_v4.txt" should equal "$(printf '198.51.100.0/24\n!198.51.100.1')"
+	End
 
 	It 'ccblack=match: leaves the stream untouched and writes pfB_Match_Rep_<alias>.txt (cidr + negated members)'
 		make_geoip_stub "$pathgeoip" 'Could not find an entry for this IP address'


### PR DESCRIPTION
## Summary

- clean per-alias reputation staging files from every recompute abort path
- reap abandoned match-generator `.txt.new` artifacts before generation
- preserve configured live artifacts and keep staged files out of Alerts attribution

## Verification

- independent phase gate: PASS
- focused recompute ShellSpec: 61 examples, 0 failures
- match-generator reaper PHPUnit: 10 tests, 41 assertions
- full ShellSpec: 826 examples, 0 failures, 8 environment skips
- PHP syntax, shell syntax, ShellCheck, PHPCS, and repository policy checks: clean
- full PHPUnit: 3,439 tests / 21,129 assertions; one unrelated sandbox loopback-bind failure reproduced in the primary checkout

Closes #1280

---

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
