### PR TITLE
pfblockerng: family-gate reputation reconciliation

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1432,7 +1432,7 @@ pfb_recompute_finish() {
 
 	pfb_recompute_swap_mv "${rec_countsfile_new}" "${rec_countsfile}" 'countsfile.new' || return 1
 
-	if [ "${rec_repmode}" = 'dmax' ]; then
+	if [ "${rec_do_rep}" -eq 1 ] && [ "${rec_repmode}" = 'dmax' ]; then
 		if [ "${rec_geoip_ok:-1}" -eq 1 ]; then
 			# GeoIP ran (or there were no offenders to classify) -- a missing ".new"
 			# genuinely means "no reputation match for this alias this pass", so
@@ -2038,8 +2038,8 @@ closingprocess() {
 		s1="$(grep -cv "^${ip_placeholder2}$" "${mastercat}")"
 		# issue #1263: awk 1 -- an unterminated deny file no longer welds into its neighbour.
 		s2="$(find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | grep -cv "^${ip_placeholder2}$")"
-		s3="$(sort "${mastercat}" | uniq -d | tail -30)"
-		s4="$(find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | sort | uniq -d | tail -30 | grep -v "^${ip_placeholder2}$")"
+		s3="$(LC_ALL=C sort "${mastercat}" | LC_ALL=C uniq -d | tail -30)"
+		s4="$(find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | LC_ALL=C sort | LC_ALL=C uniq -d | tail -30 | grep -v "^${ip_placeholder2}$")"
 	else
 		echo "   [ Original IP count   ]  [ ${counto} ]"
 	fi

--- a/tests/shell/pfblockerng_adr26_locale_spec.sh
+++ b/tests/shell/pfblockerng_adr26_locale_spec.sh
@@ -100,6 +100,14 @@ Describe 'ADR-26 — pfblockerng.sh locale/portability source invariants (Phases
     When call has "LC_ALL=C sort -t ' ' -k2,2 -s \"\${rec_new_stream}\""
     The status should be success
   End
+  It 'prefixes both commands in the s3 mastercat duplicate probe with LC_ALL=C'
+    When call has 's3="$(LC_ALL=C sort "${mastercat}" | LC_ALL=C uniq -d | tail -30)"'
+    The status should be success
+  End
+  It 'prefixes both commands in the s4 deny-folder duplicate probe with LC_ALL=C'
+    When call has 's4="$(find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | LC_ALL=C sort | LC_ALL=C uniq -d | tail -30 | grep -v "^${ip_placeholder2}$")"'
+    The status should be success
+  End
 
   # Gate 2 — locale is per-command, NEVER exported process-wide.
   It 'never exports LC_ALL process-wide'

--- a/tests/shell/pfblockerng_recompute_spec.sh
+++ b/tests/shell/pfblockerng_recompute_spec.sh
@@ -973,6 +973,26 @@ Describe 'pfb_recompute() finish-arm reputation reconcile (issue #1084 review: s
 		countsfile="${work}/counts"
 	}
 	cleanup() { rm -rf "$work"; }
+	artifact_is_unchanged() {
+		expected="$1"; actual="$2"; label="$3"
+		cmp -s "$expected" "$actual" && return 0
+		printf '%s artifact changed (expected: %s; actual: %s)\n' \
+			"$label" "$expected" "$actual" >&2
+		printf '%s\n' '--- expected contents ---' >&2
+		if [ -f "$expected" ]; then cat "$expected" >&2; else printf '%s\n' '<missing>' >&2; fi
+		printf '%s\n' '--- actual contents ---' >&2
+		if [ -f "$actual" ]; then cat "$actual" >&2; else printf '%s\n' '<missing>' >&2; fi
+		if [ -f "$expected" ] && [ -f "$actual" ]; then diff -u "$expected" "$actual" >&2 || :; fi
+		return 1
+	}
+	recompute_v6_and_check_match_artifacts() {
+		rec_geoip_ok=1
+		pfb_recompute recompute v6 "$memberlist" "$countsfile" on dmax 1 US match off >/dev/null || return
+		artifact_is_unchanged "${work}/exempt.before" \
+			"${pfbmatchgen}pfB_Match_Exempt_v4.txt" 'v4 exempt' || return
+		artifact_is_unchanged "${work}/rep.before" \
+			"${pfbmatchgen}pfB_Match_Rep_Six_v6.txt" 'v6 reputation'
+	}
 	BeforeAll 'pfb_source'
 	Before 'setup'
 	After 'cleanup'
@@ -1007,6 +1027,19 @@ Describe 'pfb_recompute() finish-arm reputation reconcile (issue #1084 review: s
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 100 US match off
 		The status should be success
 		The path "${pfbmatchgen}pfB_Match_Exempt_v4.txt" should not be exist
+	End
+
+	It 'keeps v4 exempt and v6 reputation artifacts byte-identical when a direct v6 call carries dmax arguments'
+		printf '1.1.1.0/24\n!1.1.1.1\n' > "${pfbmatchgen}pfB_Match_Exempt_v4.txt"
+		printf '2a01:db8::/64\n!2a01:db8::1\n' > "${pfbmatchgen}pfB_Match_Rep_Six_v6.txt"
+		cp "${pfbmatchgen}pfB_Match_Exempt_v4.txt" "${work}/exempt.before"
+		cp "${pfbmatchgen}pfB_Match_Rep_Six_v6.txt" "${work}/rep.before"
+		printf '2001:db8::1\n' > "${snap}/Six_v6.orig"
+		printf '%s\n' "${snap}/Six_v6.orig" > "$memberlist"
+
+		When call recompute_v6_and_check_match_artifacts
+		The status should be success
+		The contents of file "${pfbdeny}Six_v6.txt" should equal '2001:db8::1'
 	End
 End
 


### PR DESCRIPTION
## Summary

- prevent a direct IPv6+dMax recompute from reconciling IPv4 reputation artifacts
- make both closing duplicate probes byte-locale deterministic
- cover the latent family path and both inline locale contracts in ShellSpec

## Verification

- independent phase gate: PASS, including mutation checks
- focused ShellSpec: 81 examples, 0 failures, 2 environment skips
- full ShellSpec: 829 examples, 0 failures, 8 expected skips
- shell syntax, ShellCheck, diff checks, and repository gate runner: clean

The production caller already passes reputation mode `off` for IPv6; this hardens the sourced function’s own contract without changing caller behavior or IPv4 reconciliation.

Closes #1281

---

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reputation-related artifact reconciliation to run only when reputation matching is enabled for the pass during IPv6 recomputation.
  * Improved determinism of duplicate IP-range detection by enforcing a consistent locale for the duplicate analysis pipeline.
* **Tests**
  * Added regression coverage to ensure exempt and reputation match artifacts remain byte-identical after a direct IPv6 recompute.
  * Added new locale-invariance assertions for both duplicate-probe pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->