### PR TITLE
Fix blacklist array-valued autosubmit handling

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -158,7 +158,7 @@ if ($_POST && !$_POST['enableall'] && !$_POST['disableall']) {
 	}
 
 	if (isset($_POST['blacklist_enable'])) {
-		if (!array_key_exists($_POST['blacklist_enable'], $options_blacklist_enable)) {
+		if (is_array($_POST['blacklist_enable']) || !array_key_exists($_POST['blacklist_enable'], $options_blacklist_enable)) {
 			$_POST['blacklist_enable'] = 'Disable';
 		}
 		$pfb['bconfig']['blacklist_enable'] = $_POST['blacklist_enable'];
@@ -168,7 +168,7 @@ if ($_POST && !$_POST['enableall'] && !$_POST['disableall']) {
 	}
 
 	if (isset($_POST['blacklist_lang'])) {
-		if (!array_key_exists($_POST['blacklist_lang'], $options_blacklist_lang)) {
+		if (is_array($_POST['blacklist_lang']) || !array_key_exists($_POST['blacklist_lang'], $options_blacklist_lang)) {
 			$_POST['blacklist_lang'] = 'EN';
 		}
 		$pfb['bconfig']['blacklist_lang'] = $_POST['blacklist_lang'];

--- a/tests/php/BlacklistPostGuardTest.php
+++ b/tests/php/BlacklistPostGuardTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1285 — blacklist enable/lang autosubmit handlers must tolerate arrays.
+ *
+ * The page cannot be required off-appliance, so both standalone handlers are
+ * eval-extracted verbatim from the real source using anchors stable across the
+ * guard change.
+ */
+final class BlacklistPostGuardTest extends TestCase
+{
+	private array $savedPost = [];
+	private mixed $savedPfb = null;
+	private mixed $savedConfig = null;
+	private bool $hadConfig = FALSE;
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php'
+		);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_blacklist.php');
+		}
+
+		if (!function_exists('pfb_blacklist_oracle_enable')) {
+			if (!preg_match(
+				'/\n\t(if \(isset\(\$_POST\[\'blacklist_enable\'\]\)\) \{.*?\n\t\})'
+				. '\n\n\tif \(isset\(\$_POST\[\'blacklist_lang\'\]\)\)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: blacklist_enable handler not found');
+			}
+			eval(
+				'function pfb_blacklist_oracle_enable(): array {'
+				. ' global $pfb; $config_mod = FALSE;'
+				. ' $options_blacklist_enable = [\'Disable\' => \'Disable\', \'Enable\' => \'Enable\'];'
+				. $m[1]
+				. ' return [\'config_mod\' => $config_mod, \'bconfig\' => $pfb[\'bconfig\'], \'post\' => $_POST]; }'
+			);
+		}
+
+		if (!function_exists('pfb_blacklist_oracle_lang')) {
+			if (!preg_match(
+				'/\n\t(if \(isset\(\$_POST\[\'blacklist_lang\'\]\)\) \{.*?\n\t\})'
+				. '\n\n\tif \(isset\(\$_POST\[\'save\'\]\)\)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: blacklist_lang handler not found');
+			}
+			eval(
+				'function pfb_blacklist_oracle_lang(): array {'
+				. ' global $pfb; $config_mod = FALSE;'
+				. ' $options_blacklist_lang = [\'EN\' => \'English\', \'DE\' => \'German\', \'FR\' => \'French\','
+				. ' \'IT\' => \'Italian\', \'NL\' => \'Dutch\', \'PT\' => \'Portuguese\','
+				. ' \'ES\' => \'Spanish\', \'RU\' => \'Russian\'];'
+				. $m[1]
+				. ' return [\'config_mod\' => $config_mod, \'bconfig\' => $pfb[\'bconfig\'], \'post\' => $_POST]; }'
+			);
+		}
+	}
+
+	protected function setUp(): void
+	{
+		global $pfb;
+		$this->savedPost  = $_POST;
+		$this->savedPfb   = $pfb ?? null;
+		$this->hadConfig  = array_key_exists('config', $GLOBALS);
+		$this->savedConfig = $GLOBALS['config'] ?? null;
+
+		$_POST = [];
+		$pfb = ['bconfig' => [
+			'blacklist_enable' => 'enable-sentinel',
+			'blacklist_lang'   => 'lang-sentinel',
+		]];
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		global $pfb;
+		$_POST = $this->savedPost;
+		$pfb   = $this->savedPfb;
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->savedConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+	}
+
+	public static function fieldProvider(): array
+	{
+		return [
+			'blacklist_enable' => [
+				'blacklist_enable',
+				'pfb_blacklist_oracle_enable',
+				'Disable',
+				'Enable',
+				'enable-sentinel',
+			],
+			'blacklist_lang' => [
+				'blacklist_lang',
+				'pfb_blacklist_oracle_lang',
+				'EN',
+				'DE',
+				'lang-sentinel',
+			],
+		];
+	}
+
+	public static function arrayValueProvider(): array
+	{
+		$rows = [];
+		foreach (self::fieldProvider() as $name => $field) {
+			foreach ([
+				'flat'   => ['crafted'],
+				'empty'  => [],
+				'nested' => ['outer' => ['inner' => 'crafted']],
+			] as $shape => $value) {
+				$rows["{$name}-{$shape}"] = [...$field, $value];
+			}
+		}
+		return $rows;
+	}
+
+	private function runOracle(string $oracle, string $field): array
+	{
+		try {
+			return $oracle();
+		} catch (\TypeError $e) {
+			$this->fail("an array {$field} value must not TypeError: " . $e->getMessage());
+		}
+	}
+
+	private function configPath(string $field): string
+	{
+		return "installedpackages/pfblockerngblacklist/{$field}";
+	}
+
+	#[DataProvider('arrayValueProvider')]
+	public function testArrayValuesNormalizeToExistingDefaultWithoutThrowing(
+		string $field,
+		string $oracle,
+		string $default,
+		string $valid,
+		string $sentinel,
+		array $value
+	): void {
+		$_POST[$field] = $value;
+		$result = $this->runOracle($oracle, $field);
+
+		$this->assertTrue($result['config_mod'], "array {$field} must ride the existing autosubmit write path");
+		$this->assertSame($default, $_POST[$field], "array {$field} must normalize to its existing default");
+		$this->assertSame($default, $result['bconfig'][$field]);
+		$this->assertSame($default, config_get_path($this->configPath($field)));
+	}
+
+	#[DataProvider('fieldProvider')]
+	public function testValidScalarIsPersistedUnchanged(
+		string $field,
+		string $oracle,
+		string $default,
+		string $valid,
+		string $sentinel
+	): void {
+		$_POST[$field] = $valid;
+		$result = $this->runOracle($oracle, $field);
+
+		$this->assertSame($valid, $_POST[$field]);
+		$this->assertSame($valid, $result['bconfig'][$field]);
+		$this->assertSame($valid, config_get_path($this->configPath($field)));
+	}
+
+	#[DataProvider('fieldProvider')]
+	public function testUnknownScalarNormalizesToExistingDefault(
+		string $field,
+		string $oracle,
+		string $default,
+		string $valid,
+		string $sentinel
+	): void {
+		$_POST[$field] = 'unknown-value';
+		$result = $this->runOracle($oracle, $field);
+
+		$this->assertSame($default, $_POST[$field]);
+		$this->assertSame($default, $result['bconfig'][$field]);
+		$this->assertSame($default, config_get_path($this->configPath($field)));
+	}
+
+	#[DataProvider('fieldProvider')]
+	public function testMissingFieldIsUntouchedAndNotWritten(
+		string $field,
+		string $oracle,
+		string $default,
+		string $valid,
+		string $sentinel
+	): void {
+		unset($_POST[$field]);
+		$result = $this->runOracle($oracle, $field);
+
+		$this->assertFalse($result['config_mod'], "missing {$field} must not mark config modified");
+		$this->assertArrayNotHasKey($field, $_POST);
+		$this->assertSame($sentinel, $result['bconfig'][$field], "missing {$field} must leave bconfig untouched");
+		$this->assertNull(config_get_path($this->configPath($field)), "missing {$field} must not write config");
+	}
+}

--- a/tests/smoke/ui/test_blacklist.py
+++ b/tests/smoke/ui/test_blacklist.py
@@ -98,6 +98,18 @@ def _csrf_token(webui: WebUI) -> str:
     return extract_csrf_token(resp.text)
 
 
+def _config_path_exists(vm: helpers.SmokeVM, path: str) -> bool:
+    """Return whether a scalar config path exists, distinguishing missing from empty."""
+    return (
+        helpers._php_read_scalar(
+            vm,
+            "",
+            f"config_get_path({helpers._php_str(path)}, null) === null ? '0' : '1'",
+        )
+        == "1"
+    )
+
+
 def _direct_post(webui: WebUI, data: dict[str, str], *, timeout: float = SAVE_TIMEOUT) -> requests.Response:
     """POST a FULLY-CONTROLLED payload to the blacklist page (token added here).
 
@@ -418,8 +430,8 @@ def test_blacklist_array_autosubmit_coerces_to_default_without_error(
     default: str,
 ) -> None:
     """An authenticated no-save array autosubmit persists the field default cleanly."""
+    original_present = _config_path_exists(smoke_vm, config_path)
     original = helpers.config_get(smoke_vm, config_path)
-    restore = original or default
     try:
         _direct_post(webui, {field: seed})
         assert helpers.config_get(smoke_vm, config_path) == seed, f"failed to seed {field}={seed!r}"
@@ -433,4 +445,19 @@ def test_blacklist_array_autosubmit_coerces_to_default_without_error(
         got = helpers.config_get(smoke_vm, config_path)
         assert got == default, f"array {field} should persist default {default!r}, got {got!r}"
     finally:
-        _direct_post(webui, {field: restore})
+        operation = (
+            f"config_set_path({helpers._php_str(config_path)}, {helpers._php_str(original)});"
+            if original_present
+            else f"config_del_path({helpers._php_str(config_path)});"
+        )
+        restored = helpers.php_eval(
+            smoke_vm,
+            f"{operation}\nwrite_config('pfBlockerNG smoke: restore blacklist scalar');\necho 'OK';",
+        )
+        assert restored.returncode == 0 and "OK" in restored.stdout, (
+            f"failed to restore {config_path!r}: stdout={restored.stdout!r} stderr={restored.stderr!r}"
+        )
+        assert helpers.config_get(smoke_vm, config_path) == original, f"failed to restore {config_path!r} value"
+        assert _config_path_exists(smoke_vm, config_path) is original_present, (
+            f"failed to restore {config_path!r} presence"
+        )

--- a/tests/smoke/ui/test_blacklist.py
+++ b/tests/smoke/ui/test_blacklist.py
@@ -51,13 +51,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-import requests
 
 from .. import helpers
 from .render_oracle import PhpErrorLogGuard
 from .webui import extract_csrf_token, looks_like_login_page
 
 if TYPE_CHECKING:
+    import requests
+
     from .webui import WebUI
 
 pytestmark = pytest.mark.ui_e2e

--- a/tests/smoke/ui/test_blacklist.py
+++ b/tests/smoke/ui/test_blacklist.py
@@ -51,8 +51,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+import requests
 
 from .. import helpers
+from .render_oracle import PhpErrorLogGuard
 from .webui import extract_csrf_token, looks_like_login_page
 
 if TYPE_CHECKING:
@@ -95,7 +97,7 @@ def _csrf_token(webui: WebUI) -> str:
     return extract_csrf_token(resp.text)
 
 
-def _direct_post(webui: WebUI, data: dict[str, str], *, timeout: float = SAVE_TIMEOUT) -> None:
+def _direct_post(webui: WebUI, data: dict[str, str], *, timeout: float = SAVE_TIMEOUT) -> requests.Response:
     """POST a FULLY-CONTROLLED payload to the blacklist page (token added here).
 
     Bypasses the form-scrape ``webui.post`` so the caller owns the EXACT field set
@@ -115,6 +117,7 @@ def _direct_post(webui: WebUI, data: dict[str, str], *, timeout: float = SAVE_TI
         allow_redirects=True,
     )
     assert not looks_like_login_page(resp.text), "blacklist POST returned the login form (session lost)"
+    return resp
 
 
 def _save_payload(**fields: str) -> dict[str, str]:
@@ -396,3 +399,37 @@ def test_blacklist_lang_autosubmit_persists_without_save(
         assert got == "EN", f"bogus blacklist_lang should coerce to default 'EN', got {got!r}"
     finally:
         _direct_post(webui, {"blacklist_lang": restore})
+
+
+@pytest.mark.parametrize(
+    ("field", "config_path", "seed", "default"),
+    [
+        ("blacklist_enable", CFG_ENABLE, "Enable", "Disable"),
+        ("blacklist_lang", CFG_LANG, "DE", "EN"),
+    ],
+)
+def test_blacklist_array_autosubmit_coerces_to_default_without_error(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    field: str,
+    config_path: str,
+    seed: str,
+    default: str,
+) -> None:
+    """An authenticated no-save array autosubmit persists the field default cleanly."""
+    original = helpers.config_get(smoke_vm, config_path)
+    restore = original or default
+    try:
+        _direct_post(webui, {field: seed})
+        assert helpers.config_get(smoke_vm, config_path) == seed, f"failed to seed {field}={seed!r}"
+
+        guard = PhpErrorLogGuard(smoke_vm)
+        guard.snapshot()
+        resp = _direct_post(webui, {f"{field}[]": "crafted"})
+        guard.assert_no_growth()
+
+        assert resp.status_code == 200, f"array {field} autosubmit -> HTTP {resp.status_code} (expected 200)"
+        got = helpers.config_get(smoke_vm, config_path)
+        assert got == default, f"array {field} should persist default {default!r}, got {got!r}"
+    finally:
+        _direct_post(webui, {field: restore})


### PR DESCRIPTION
## Summary

- guard array-valued `blacklist_enable` and `blacklist_lang` autosubmit inputs before `array_key_exists()`
- preserve the existing safe defaults (`Disable` and `EN`) for malformed values
- add extracted-handler unit coverage and authenticated appliance regression coverage

## Testing

- RED: 6 hostile array rows failed at the two real sinks before the production change
- GREEN: `BlacklistPostGuardTest.php` — 12 tests, 44 assertions
- full PHP unit suite — 3,461 tests, 21,275 assertions
- full Python suite — 2,928 passed, 5 skipped
- focused PHPStan, PHPCS, Ruff, format, mypy, PHP lint, and diff checks
- independent mutation gate: removing either guard fails exactly its three hostile rows
- appliance `ui_e2e`: 2 passed (`blacklist_enable`, `blacklist_lang`)
- appliance `ui_render`: blacklist page passed

Closes #1285

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blacklist autosubmit validation to safely handle array or invalid inputs.
  * Invalid values now revert to the appropriate defaults without causing errors.
  * Valid settings continue to save correctly, while missing fields remain unchanged.

* **Tests**
  * Added coverage for PHP handling and end-to-end autosubmit scenarios.
  * Verified successful responses and protection against PHP errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->