### PR TITLE
pfblockerng: publish DNSBL raw generations atomically

### DIFF
--- a/.ADRs/ADR_10_Zero_Downtime_DNSBL/ADR.md
+++ b/.ADRs/ADR_10_Zero_Downtime_DNSBL/ADR.md
@@ -60,7 +60,7 @@ Apply DNSBL updates **without restarting Unbound**: the running module rebuilds 
 
 | Area | Decision |
 | --- | --- |
-| **Publish protocol (the safety barrier)** | PHP/shell writes the new manifest + per-feed raw into a **staging dir**, `fsync`s, then **atomically `rename`s** into place, and finally **flips a single sentinel file** (`mtime` bump / write of the new generation id). The sentinel flip is the **all-or-nothing commit**: the plugin only ever reads a **fully-written, immutable** manifest set. This — *not* notify latency — is what guarantees "never read a file mid-write" (Context 8). |
+| **Publish protocol (the safety barrier)** | PHP writes and `fsync`s every raw into a sibling staging directory, renames the complete set to immutable `pfb_py_raw.<xxh128>`, then atomically replaces `pfb_py_sources.json`. That **manifest rename is the sole visibility commit**: readers see either the old complete generation or the new one. The later sentinel flip is notification/apply sequencing, not a second path commit. Old generations are collected only after watcher/restart convergence. Runtime rename atomicity is required; crash-durability wording remains narrower until #1357's FreeBSD parent-directory `fsync` probe is executed. |
 | **Trigger / watch** | A new **reload-watcher daemon thread** (started in `init_standard` next to `pfb_db_worker`/`pfb_async_worker`, `:728-744`) waits on the sentinel: **`select.kqueue` `EVFILT_VNODE`** on the sentinel's directory where available (FreeBSD; **`inotify` is Linux-only, not present on pfSense**), with a **low-frequency `mtime` poll fallback**. Notification is **best-effort**; correctness rides on the atomic publish + the generation id, so a missed/coalesced event only delays, never corrupts. On trigger → `rebuild_and_swap()`. |
 | **Atomic swap shape (single snapshot)** | Replace the four-plus separate globals (`:559-562`) with **one module-level reference** to a **frozen `Snapshot`** bundling *all* ADR-07 strata: `dataDB`, `zoneDB`, `whiteDB`, `regexDB`, `allowRegexDB`, `feedGroupIndexDB`, the `important_rules` flag, and the counts. `evaluate_domain`/`op` capture the **one** reference at query start and read every field off it — so a query is internally consistent even if a swap lands mid-query. The swap is a single `STORE_NAME` (GIL-atomic). **No lock in the per-query hot path.** |
 | **Background rebuild** | `rebuild_and_swap()` runs `build()`/`dnsbl_build_from_manifest()` (already pure, `:1966`/`:2118`) **on the watcher thread**, off the live snapshot. Query threads keep serving the **old** snapshot throughout the build (seconds for a big ABP list) → **zero downtime, briefly stale by design**. Only on a **successful** build is the snapshot ref rebound. Concurrent triggers are **coalesced** (a rebuild-in-progress flag / single-flight); a trigger during a build re-checks the generation id and rebuilds once more if it advanced. |
@@ -174,7 +174,18 @@ Prompt: `04_Watcher_Background_Swap.txt`
 
 Prompt: `05_PHP_Publish_FastPath_Flush.txt`
 
-- Manifest writer: stage → `fsync` → atomic `rename` → flip the sentinel (generation id) — the all-or-nothing commit. `pfb_reload_unbound` gains the **data-only** fork: a DNSBL-data update in Python mode → publish + flip, **no `pfb_stop_start_unbound`**; config change / failed / disabled → restart fallback. **Data-only includes the user custom-list edits** — route the alerts Lock/Unlock and "add to whitelist" reloads (#51; `pfb_unbound_python_sources_unlock`/`_whitelist`) through the same no-restart fast path. Compute the **newly-blocked delta** (allow→block) and flush those names from Unbound's C-cache (`unbound-control flush`/`flush_zone`, coalesced, coordinated with the DNSBL-queries-daemon marker `:3211`); **block→allow needs no flush** (blocks not cached since #43, Context 7 — the `decisionDB` clear suffices). `php -l` + ShellCheck clean; default `pytest` unchanged.
+- Manifest writer: stage and `fsync` raw files → rename the complete set to immutable
+  `pfb_py_raw.<xxh128>` → atomically replace the manifest (the visibility commit) → flip the
+  sentinel (generation notification). Apply/restart convergence gates old-generation GC.
+  `pfb_reload_unbound` gains the **data-only** fork: a DNSBL-data update in Python mode →
+  publish + flip, **no `pfb_stop_start_unbound`**; config change / failed / disabled → restart
+  fallback. **Data-only includes the user custom-list edits** — route the alerts Lock/Unlock
+  and "add to whitelist" reloads (#51; `pfb_unbound_python_sources_unlock`/`_whitelist`)
+  through the same no-restart fast path. Compute the **newly-blocked delta** (allow→block)
+  and flush those names from Unbound's C-cache (`unbound-control flush`/`flush_zone`,
+  coalesced, coordinated with the DNSBL-queries-daemon marker `:3211`); **block→allow needs
+  no flush** (blocks not cached since #43, Context 7 — the `decisionDB` clear suffices).
+  `php -l` + ShellCheck clean; default `pytest` unchanged.
 
 ### Phase 6 — Validation, benchmark, manual smoke, DoD
 

--- a/.ADRs/ADR_10_Zero_Downtime_DNSBL/ADR.md
+++ b/.ADRs/ADR_10_Zero_Downtime_DNSBL/ADR.md
@@ -60,7 +60,7 @@ Apply DNSBL updates **without restarting Unbound**: the running module rebuilds 
 
 | Area | Decision |
 | --- | --- |
-| **Publish protocol (the safety barrier)** | PHP writes and `fsync`s every raw into a sibling staging directory, renames the complete set to immutable `pfb_py_raw.<xxh128>`, then atomically replaces `pfb_py_sources.json`. That **manifest rename is the sole visibility commit**: readers see either the old complete generation or the new one. The later sentinel flip is notification/apply sequencing, not a second path commit. Old generations are collected only after watcher/restart convergence. Runtime rename atomicity is required; crash-durability wording remains narrower until #1357's FreeBSD parent-directory `fsync` probe is executed. |
+| **Publish protocol (the safety barrier)** | PHP/shell writes the new manifest + per-feed raw into a **staging dir**, `fsync`s, then **atomically `rename`s** into place, and finally **flips a single sentinel file** (`mtime` bump / write of the new generation id). The sentinel flip is the **all-or-nothing commit**: the plugin only ever reads a **fully-written, immutable** manifest set. This — *not* notify latency — is what guarantees "never read a file mid-write" (Context 8). |
 | **Trigger / watch** | A new **reload-watcher daemon thread** (started in `init_standard` next to `pfb_db_worker`/`pfb_async_worker`, `:728-744`) waits on the sentinel: **`select.kqueue` `EVFILT_VNODE`** on the sentinel's directory where available (FreeBSD; **`inotify` is Linux-only, not present on pfSense**), with a **low-frequency `mtime` poll fallback**. Notification is **best-effort**; correctness rides on the atomic publish + the generation id, so a missed/coalesced event only delays, never corrupts. On trigger → `rebuild_and_swap()`. |
 | **Atomic swap shape (single snapshot)** | Replace the four-plus separate globals (`:559-562`) with **one module-level reference** to a **frozen `Snapshot`** bundling *all* ADR-07 strata: `dataDB`, `zoneDB`, `whiteDB`, `regexDB`, `allowRegexDB`, `feedGroupIndexDB`, the `important_rules` flag, and the counts. `evaluate_domain`/`op` capture the **one** reference at query start and read every field off it — so a query is internally consistent even if a swap lands mid-query. The swap is a single `STORE_NAME` (GIL-atomic). **No lock in the per-query hot path.** |
 | **Background rebuild** | `rebuild_and_swap()` runs `build()`/`dnsbl_build_from_manifest()` (already pure, `:1966`/`:2118`) **on the watcher thread**, off the live snapshot. Query threads keep serving the **old** snapshot throughout the build (seconds for a big ABP list) → **zero downtime, briefly stale by design**. Only on a **successful** build is the snapshot ref rebound. Concurrent triggers are **coalesced** (a rebuild-in-progress flag / single-flight); a trigger during a build re-checks the generation id and rebuilds once more if it advanced. |
@@ -174,18 +174,7 @@ Prompt: `04_Watcher_Background_Swap.txt`
 
 Prompt: `05_PHP_Publish_FastPath_Flush.txt`
 
-- Manifest writer: stage and `fsync` raw files → rename the complete set to immutable
-  `pfb_py_raw.<xxh128>` → atomically replace the manifest (the visibility commit) → flip the
-  sentinel (generation notification). Apply/restart convergence gates old-generation GC.
-  `pfb_reload_unbound` gains the **data-only** fork: a DNSBL-data update in Python mode →
-  publish + flip, **no `pfb_stop_start_unbound`**; config change / failed / disabled → restart
-  fallback. **Data-only includes the user custom-list edits** — route the alerts Lock/Unlock
-  and "add to whitelist" reloads (#51; `pfb_unbound_python_sources_unlock`/`_whitelist`)
-  through the same no-restart fast path. Compute the **newly-blocked delta** (allow→block)
-  and flush those names from Unbound's C-cache (`unbound-control flush`/`flush_zone`,
-  coalesced, coordinated with the DNSBL-queries-daemon marker `:3211`); **block→allow needs
-  no flush** (blocks not cached since #43, Context 7 — the `decisionDB` clear suffices).
-  `php -l` + ShellCheck clean; default `pytest` unchanged.
+- Manifest writer: stage → `fsync` → atomic `rename` → flip the sentinel (generation id) — the all-or-nothing commit. `pfb_reload_unbound` gains the **data-only** fork: a DNSBL-data update in Python mode → publish + flip, **no `pfb_stop_start_unbound`**; config change / failed / disabled → restart fallback. **Data-only includes the user custom-list edits** — route the alerts Lock/Unlock and "add to whitelist" reloads (#51; `pfb_unbound_python_sources_unlock`/`_whitelist`) through the same no-restart fast path. Compute the **newly-blocked delta** (allow→block) and flush those names from Unbound's C-cache (`unbound-control flush`/`flush_zone`, coalesced, coordinated with the DNSBL-queries-daemon marker `:3211`); **block→allow needs no flush** (blocks not cached since #43, Context 7 — the `decisionDB` clear suffices). `php -l` + ShellCheck clean; default `pytest` unchanged.
 
 ### Phase 6 — Validation, benchmark, manual smoke, DoD
 
@@ -238,3 +227,21 @@ whitelist removal) always perform an immediate targeted delta flush. User-trigge
 block→allow changes need only the `decisionDB` clear because blocked answers are not
 stored in Unbound's C cache. This addendum supersedes broader wording in the accepted
 body without changing the original record.
+
+---
+
+## Post-acceptance addendum (2026-07-15 — issue #1357)
+
+Issue #1357 hardened the accepted publish protocol without changing DNSBL decisions
+or the sentinel apply contract. PHP serializes full and scalar manifest writers with
+one publication lock, writes each accepted feed into a unique sibling staging
+directory, and publishes the complete raw set as an immutable content-addressed
+`pfb_py_raw.<xxh128>` generation. Atomic replacement of
+`pfb_py_sources.json` is the sole on-disk visibility commit; the later sentinel flip
+remains the notification/apply step. The previous generation remains available until
+a confirmed watcher or restart convergence, after which strict-name garbage
+collection may remove unreferenced generations and stages.
+
+The implementation claims runtime rename atomicity, not power-loss durability. The
+live FreeBSD probe confirmed that directory-stream `fsync()` is supported, but the
+shared atomic-write helper does not fsync the parent directory after rename.

--- a/.ADRs/ADR_65_DNSBL_Manifest_Single_Source/ADR.md
+++ b/.ADRs/ADR_65_DNSBL_Manifest_Single_Source/ADR.md
@@ -36,8 +36,8 @@
 ### 1.1 The manifest is the primary source; the interchange files are a failure-only fallback
 
 ADR-06 moved parse/normalise/classify into Python. `init_standard()` builds from the per-feed
-**manifest** (`pfb_py_sources.json` plus the per-feed IP-stripped raw files in an immutable
-`/var/unbound/pfb_py_raw.<xxh128>` generation, which the manifest references by path):
+**manifest** (`pfb_py_sources.json` plus the per-feed IP-stripped raw files under
+`/var/unbound/pfb_py_raw`, which the manifest references by path — `pfblockerng.inc:8184`):
 `dnsbl_build_from_manifest()` (`pfb_unbound.py:5351`, called at `:1658`) builds
 `dataDB`/`zoneDB`/`whiteDB`/`regexDB`/`allowRegexDB` via the pure `build()` layer, and only
 when it returns `None` — manifest **absent** (`:5365`), **unparseable** (`:5374`), or
@@ -227,12 +227,6 @@ result, unchecked today at the sources write (`:8258`), is checked and a write f
 serves stale data is false security; a loud "DNSBL not loaded" is correct for a security tool, and
 the ADR-10 generation + the `:16968-16972` rebuild trigger already self-heal on the next
 successful tick.
-
-Post-implementation amendment (#1357): a raw reference is part of the manifest's authority, not
-an optional row. If any feed reference is malformed, escapes the manifest directory, is missing,
-is not a readable regular file, or fails while being read, the **whole generation build returns
-`None`**, opens the parse ledger entry, and leaves ADR-10's last-good snapshot live. A partial
-`BuildResult` is never accepted.
 
 ### Accepted user-visible deltas (the ONLY permitted output changes)
 
@@ -527,3 +521,21 @@ PHP now passes already-computed per-group counts to
 entries, counters, stale-row handling, changed-group hooks, and reload timing without
 feed or manifest I/O. Install/upgrade and full-clear retain one-way cleanup of the
 legacy summary directory.
+
+---
+
+## 11. Post-implementation addendum (2026-07-15 — issue #1357)
+
+The schema-v1 manifest remains the single DNSBL authority, and each `feeds[*].raw`
+reference is part of one immutable content-addressed raw generation. A referenced raw
+is not an optional row: if any reference is malformed, escapes the manifest directory,
+is missing, is not a readable regular file, or fails during open/read, Python rejects
+the whole generation, returns `None`, and opens the ADR-61 parse-ledger entry. ADR-10
+therefore keeps the last-good live snapshot; a partial `BuildResult` is never accepted.
+Manifest-aware loaded-feed and fingerprint helpers use the same confined references.
+This changes neither manifest version 1 nor feed parsing, classification, query-time,
+or TLD decisions.
+
+The 1,000,000-line base-versus-branch benchmark stayed within the 10% gate: PHP
+publication was +6.97% wall / +0.19% peak RSS, while Python manifest build was -0.23%
+wall / -1.74% peak RSS.

--- a/.ADRs/ADR_65_DNSBL_Manifest_Single_Source/ADR.md
+++ b/.ADRs/ADR_65_DNSBL_Manifest_Single_Source/ADR.md
@@ -36,8 +36,8 @@
 ### 1.1 The manifest is the primary source; the interchange files are a failure-only fallback
 
 ADR-06 moved parse/normalise/classify into Python. `init_standard()` builds from the per-feed
-**manifest** (`pfb_py_sources.json` plus the per-feed IP-stripped raw files under
-`/var/unbound/pfb_py_raw`, which the manifest references by path — `pfblockerng.inc:8184`):
+**manifest** (`pfb_py_sources.json` plus the per-feed IP-stripped raw files in an immutable
+`/var/unbound/pfb_py_raw.<xxh128>` generation, which the manifest references by path):
 `dnsbl_build_from_manifest()` (`pfb_unbound.py:5351`, called at `:1658`) builds
 `dataDB`/`zoneDB`/`whiteDB`/`regexDB`/`allowRegexDB` via the pure `build()` layer, and only
 when it returns `None` — manifest **absent** (`:5365`), **unparseable** (`:5374`), or
@@ -227,6 +227,12 @@ result, unchecked today at the sources write (`:8258`), is checked and a write f
 serves stale data is false security; a loud "DNSBL not loaded" is correct for a security tool, and
 the ADR-10 generation + the `:16968-16972` rebuild trigger already self-heal on the next
 successful tick.
+
+Post-implementation amendment (#1357): a raw reference is part of the manifest's authority, not
+an optional row. If any feed reference is malformed, escapes the manifest directory, is missing,
+is not a readable regular file, or fails while being read, the **whole generation build returns
+`None`**, opens the parse ledger entry, and leaves ADR-10's last-good snapshot live. A partial
+`BuildResult` is never accepted.
 
 ### Accepted user-visible deltas (the ONLY permitted output changes)
 

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -107,7 +107,8 @@ lives in the Python manifest build):
 Every field is a **required, non-empty string**; a numeric/bool/null value or a missing key is a
 shape violation the reader rejects (returns `NULL`), never a partial read. This supersedes the
 pre-#1083 positional 6-column CSV dialect (`,domain,,log,feed,group`) and rides alongside ADR-62's
-retirement of the file-level `.abp` marker (above). The per-feed `pfb_py_raw/*.raw` files the
+retirement of the file-level `.abp` marker (above). The per-feed
+`pfb_py_raw.<xxh128>/*.raw` files the
 ADR-06 manifest (`pfb_py_sources.json`) references, and `dnsbl_build_from_manifest()`/`build()`
 that consume them, are **unaffected** — they stay the old bare-domain/verbatim-ABP-line format;
 `pfb_unbound_python_sources()` is the sole translator, reading NDJSON `.txt` and writing plain
@@ -221,12 +222,20 @@ holds the matcher strata as one frozen `Snapshot` behind a single module ref; a 
 daemon thread (`kqueue` `EVFILT_VNODE`, mtime-poll fallback) wakes on a generation **sentinel**
 (`/var/unbound/pfb_py_reload`), rebuilds off the live snapshot, and **atomically swaps** the
 single ref (GIL-atomic → visible to every query thread, no torn read, no dropped queries).
-PHP/shell **atomically publish** the manifest (stage → `fsync` → `rename`) then **flip the
-sentinel** (next integer) — the all-or-nothing commit. After flipping, PHP **waits (bounded)
+PHP writes and `fsync`s the raw set in a sibling staging directory, renames it to immutable
+`pfb_py_raw.<xxh128>`, then **atomically replaces the manifest as the sole visibility commit**.
+The sentinel flip (next integer) then notifies the watcher. After flipping, PHP **waits (bounded)
 for the watcher's applied-generation marker** to catch up, so the reload call returns only once
 the new lists are LIVE (queries keep flowing on the old snapshot during the wait — still
 zero-downtime; this restores the "lists live on return" invariant the restart had, so the
 ADR-12 `post` hook sees the new state).
+
+The full writer and scalar manifest patchers share one publication lock. Old raw generations
+and staging directories remain harmless until watcher/restart convergence, then strict-name GC
+removes everything except the manifest-referenced generation. Peak temporary disk is therefore
+approximately the old raw bytes plus the staged/new raw bytes (about 2× for similar generations),
+plus small per-feed metadata and the manifest. RAM-disk save archives final generations with the
+manifest and excludes stages; legacy fixed `pfb_py_raw/` manifests remain readable during upgrade.
 
 - **Data = swap; config = restart:** feed/cron updates AND the user custom-list edits (alerts
   Lock/Unlock + "add to whitelist" + customlist add/delete, #51) take the no-restart fast path;

--- a/scripts/bench_dnsbl_line_parsing.php
+++ b/scripts/bench_dnsbl_line_parsing.php
@@ -58,7 +58,9 @@ printf("isolated_max_seconds=%.4f\n", $durations[count($durations) - 1]);
 
 // Sanity: a missing/empty raw output means the pipeline never ran -- fail, never
 // report timings for a no-op (a broken worker must not read as a perf PASS).
-$rawFile = "{$sandbox}/pfb_py_raw/benchfeed.raw";
+$manifest = json_decode((string) file_get_contents("{$sandbox}/pfb_py_sources.json"), TRUE);
+$rawRef = $manifest['feeds'][0]['raw'] ?? '';
+$rawFile = "{$sandbox}/{$rawRef}";
 if (!is_file($rawFile) || filesize($rawFile) === 0) {
 	fwrite(STDERR, "benchmark output missing or empty: {$rawFile}\n");
 	exit(1);

--- a/scripts/bench_dnsbl_line_parsing.php
+++ b/scripts/bench_dnsbl_line_parsing.php
@@ -19,7 +19,7 @@ if ($iterations < 1) {
 
 require_once "{$worktree}/tests/php/bootstrap.php";
 
-@mkdir("{$sandbox}/db", 0777, true);
+@mkdir("{$sandbox}/db", 0777, TRUE);
 
 $GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
 	'log'                => "{$sandbox}/pfblockerng.log",
@@ -44,9 +44,9 @@ $feeds = [
 
 $durations = [];
 for ($i = 0; $i < $iterations; $i++) {
-	$t0 = microtime(true);
+	$t0 = microtime(TRUE);
 	pfb_unbound_python_sources($feeds);
-	$durations[] = microtime(true) - $t0;
+	$durations[] = microtime(TRUE) - $t0;
 	fwrite(STDERR, sprintf("[php] iter %d: %.4fs\n", $i, end($durations)));
 }
 sort($durations);
@@ -59,11 +59,17 @@ printf("isolated_max_seconds=%.4f\n", $durations[count($durations) - 1]);
 // Sanity: a missing/empty raw output means the pipeline never ran -- fail, never
 // report timings for a no-op (a broken worker must not read as a perf PASS).
 $manifest = json_decode((string) file_get_contents("{$sandbox}/pfb_py_sources.json"), TRUE);
-$rawRef = $manifest['feeds'][0]['raw'] ?? '';
-$rawFile = "{$sandbox}/{$rawRef}";
-if (!is_file($rawFile) || filesize($rawFile) === 0) {
-	fwrite(STDERR, "benchmark output missing or empty: {$rawFile}\n");
+$rawRef = $manifest['feeds'][0]['raw'] ?? NULL;
+$sandboxReal = realpath($sandbox);
+$rawFile = is_string($rawRef) && $rawRef !== '' && !str_contains($rawRef, "\0")
+	? "{$sandbox}/{$rawRef}" : '';
+$rawReal = $rawFile !== '' ? realpath($rawFile) : FALSE;
+if ($sandboxReal === FALSE || $rawReal === FALSE
+		|| ($rawReal !== $sandboxReal && !str_starts_with($rawReal, "{$sandboxReal}/"))
+		|| !is_file($rawReal) || filesize($rawReal) === 0) {
+	fwrite(STDERR, "benchmark output missing, empty, or outside sandbox: {$rawFile}\n");
 	exit(1);
 }
+$rawFile = $rawReal;
 $lineCount = (int) exec('wc -l < ' . escapeshellarg($rawFile));
 printf("raw_line_count=%d\n", $lineCount);

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5230,32 +5230,61 @@ def _dnsbl_path_within_base(path: str, base_dir: str) -> bool:
         return False
 
 
-def _dnsbl_file_line_reader(base_dir: str) -> Callable[[str], Iterable[str]]:
+class _DnsblGenerationError(Exception):
+    """A manifest generation member is invalid or unreadable."""
+
+
+def _dnsbl_validate_manifest_raws(manifest: dict[str, Any], base_dir: str) -> None:
+    feeds = manifest.get("feeds", [])
+    if not isinstance(feeds, list):
+        raise _DnsblGenerationError("DNSBL manifest feeds is not a list")
+    for feed in feeds:
+        if not isinstance(feed, dict) or not isinstance(feed.get("raw"), str) or not feed["raw"]:
+            raise _DnsblGenerationError("DNSBL manifest feed has no valid raw reference")
+        raw = feed["raw"]
+        path = raw if os.path.isabs(raw) else os.path.join(base_dir, raw)
+        if not _dnsbl_path_within_base(path, base_dir):
+            raise _DnsblGenerationError("DNSBL feed escapes manifest base: '{}'".format(path))
+        if not os.path.isfile(path):
+            raise _DnsblGenerationError("DNSBL feed is missing or not a regular file: '{}'".format(path))
+
+
+def _dnsbl_file_line_reader(base_dir: str, *, fail_closed: bool = False) -> Callable[[str], Iterable[str]]:
     """A file-backed ``line_reader`` for build(): map a feed_row["raw"] reference to
     its raw lines, streamed lazily so peak RAM stays at the dict floor.
 
     ``raw`` may be an absolute path or a name relative to ``base_dir`` (the directory
     holding the manifest). LF is the only record delimiter and actual CR characters
-    are removed from yielded lines. A missing/unreadable feed is logged to stderr and
-    yields nothing rather than aborting the whole build.
+    are removed from yielded lines. ``fail_closed`` turns any path/open/read failure into
+    a generation error for ``dnsbl_build_from_manifest``; direct diagnostic readers retain
+    the historical log-and-yield-nothing behavior.
     """
 
     def reader(raw: str) -> Iterable[str]:
         path = raw if os.path.isabs(raw) else os.path.join(base_dir, raw)
         if not _dnsbl_path_within_base(path, base_dir):
-            # The feed path escapes the manifest directory -- skip it (do not open).
-            sys.stderr.write("[pfBlockerNG]: Refusing DNSBL feed outside base dir: '{}'".format(path))
+            message = "Refusing DNSBL feed outside base dir: '{}'".format(path)
+            sys.stderr.write("[pfBlockerNG]: {}".format(message))
+            if fail_closed:
+                raise _DnsblGenerationError(message)
             return
         try:
             fh = open(path, encoding="utf-8", errors="replace", newline="\n")
         except OSError as e:
-            # A single missing/unreadable feed is logged and skipped -- it must not
-            # abort the whole build (the other feeds still load).
-            sys.stderr.write("[pfBlockerNG]: Failed to read DNSBL feed '{}': {}".format(path, e))
+            message = "Failed to read DNSBL feed '{}': {}".format(path, e)
+            sys.stderr.write("[pfBlockerNG]: {}".format(message))
+            if fail_closed:
+                raise _DnsblGenerationError(message) from e
             return
-        with fh:
-            for line in fh:
-                yield line.replace("\r", "").rstrip("\n")
+        try:
+            with fh:
+                for line in fh:
+                    yield line.replace("\r", "").rstrip("\n")
+        except OSError as e:
+            message = "Failed while reading DNSBL feed '{}': {}".format(path, e)
+            sys.stderr.write("[pfBlockerNG]: {}".format(message))
+            if fail_closed:
+                raise _DnsblGenerationError(message) from e
 
     return reader
 
@@ -5334,15 +5363,20 @@ def dnsbl_build_from_manifest(manifest_path: str) -> BuildResult | None:
         )
         return None
 
-    base_dir = os.path.dirname(os.path.abspath(manifest_path))
-    config = _dnsbl_config_from_manifest(manifest, base_dir)
-    top1m_enabled = bool(manifest.get("config", {}).get("top1m_enabled", False))
-
     try:
+        if not isinstance(manifest, dict):
+            raise _DnsblGenerationError("DNSBL manifest root is not an object")
+        base_dir = os.path.dirname(os.path.abspath(manifest_path))
+        _dnsbl_validate_manifest_raws(manifest, base_dir)
+        config = _dnsbl_config_from_manifest(manifest, base_dir)
+        manifest_config = manifest.get("config", {})
+        if not isinstance(manifest_config, dict):
+            raise _DnsblGenerationError("DNSBL manifest config is not an object")
+        top1m_enabled = bool(manifest_config.get("top1m_enabled", False))
         result = build(
             manifest,
             config,
-            line_reader=_dnsbl_file_line_reader(base_dir),
+            line_reader=_dnsbl_file_line_reader(base_dir, fail_closed=True),
             top1m_enabled=top1m_enabled,
         )
     except Exception as e:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5235,9 +5235,9 @@ class _DnsblGenerationError(Exception):
 
 
 def _dnsbl_validate_manifest_raws(manifest: dict[str, Any], base_dir: str) -> None:
-    feeds = manifest.get("feeds", [])
-    if not isinstance(feeds, list):
+    if "feeds" not in manifest or not isinstance(manifest["feeds"], list):
         raise _DnsblGenerationError("DNSBL manifest feeds is not a list")
+    feeds = manifest["feeds"]
     for feed in feeds:
         if not isinstance(feed, dict) or not isinstance(feed.get("raw"), str) or not feed["raw"]:
             raise _DnsblGenerationError("DNSBL manifest feed has no valid raw reference")
@@ -5299,7 +5299,7 @@ def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict
     shape) is ignored entirely -- an absent oracle is expected, not a warning.
     ``tld_wildcard_blacklist`` / ``tld_wildcard_exclusion`` / ``user_whitelist`` /
     ``user_unlock`` / ``top1m_list`` are passed through as lists. Missing keys
-    default empty so a partial manifest still builds.
+    within the required ``config`` object default empty.
     """
     config = manifest.get("config", {})
 
@@ -5367,11 +5367,11 @@ def dnsbl_build_from_manifest(manifest_path: str) -> BuildResult | None:
         if not isinstance(manifest, dict):
             raise _DnsblGenerationError("DNSBL manifest root is not an object")
         base_dir = os.path.dirname(os.path.abspath(manifest_path))
+        if "config" not in manifest or not isinstance(manifest["config"], dict):
+            raise _DnsblGenerationError("DNSBL manifest config is not an object")
+        manifest_config = manifest["config"]
         _dnsbl_validate_manifest_raws(manifest, base_dir)
         config = _dnsbl_config_from_manifest(manifest, base_dir)
-        manifest_config = manifest.get("config", {})
-        if not isinstance(manifest_config, dict):
-            raise _DnsblGenerationError("DNSBL manifest config is not an object")
         top1m_enabled = bool(manifest_config.get("top1m_enabled", False))
         result = build(
             manifest,

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8546,8 +8546,9 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 // ADR-06: patch a single scalar key of the manifest's config section in place
 // (shared by the whitelist/unlock in-place patchers below), without a full
 // feed re-enumeration. The query-time whiteDB is rebuilt from this on reload.
-function pfb_unbound_python_sources_patch($key, $values) {
-	$lock = pfb_unbound_py_publication_lock();
+function pfb_unbound_python_sources_patch($key, $values, array $publication_ops=array()) {
+	$lock_fn = $publication_ops['lock'] ?? static fn() => pfb_unbound_py_publication_lock();
+	$lock = $lock_fn();
 	if ($lock === FALSE) {
 		return FALSE;
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1885,7 +1885,7 @@ function pfb_unbound_py_normalize_absolute_path(string $path) {
 
 // ADR-65/#1357: resolve only manifest-authoritative raw refs under the manifest's
 // directory. Missing confined refs stay in the set so the reload fingerprint fails loud.
-function pfb_unbound_py_manifest_raw_paths(string $manifest_path): array {
+function pfb_unbound_py_manifest_raw_paths(string $manifest_path, bool $deduplicate=TRUE): array {
 	$json = @file_get_contents($manifest_path);
 	if ($json === FALSE) {
 		return array();
@@ -1910,6 +1910,9 @@ function pfb_unbound_py_manifest_raw_paths(string $manifest_path): array {
 		if (!is_array($feed) || !isset($feed['raw']) || !is_string($feed['raw']) || $feed['raw'] === '') {
 			continue;
 		}
+		if (str_contains($feed['raw'], "\0")) {
+			continue;
+		}
 		$path = $feed['raw'][0] === '/' ? $feed['raw'] : "{$base_normalized}/{$feed['raw']}";
 		$normalized = pfb_unbound_py_normalize_absolute_path($path);
 		if ($normalized === FALSE) {
@@ -1924,7 +1927,9 @@ function pfb_unbound_py_manifest_raw_paths(string $manifest_path): array {
 		$paths[] = $normalized;
 	}
 
-	$paths = array_values(array_unique($paths));
+	if ($deduplicate) {
+		$paths = array_values(array_unique($paths));
+	}
 	sort($paths, SORT_STRING);
 	return $paths;
 }
@@ -7784,7 +7789,8 @@ function pfb_unbound_py_atomic_write($path, $content, array $stream_ops=array())
 	@chown($tmp, 'unbound');
 	@chgrp($tmp, 'unbound');
 
-	if (!@rename($tmp, $path)) {
+	$rename_fn = $stream_ops['rename'] ?? static fn($from, $to) => @rename($from, $to);
+	if (!$rename_fn($tmp, $path)) {
 		@unlink($tmp);
 		pfb_logger("\nADR-10: failed to publish [ {$path} ]", 2);
 		return FALSE;
@@ -7871,7 +7877,7 @@ function pfb_unbound_py_gc(bool $converged): bool {
 		if (!is_array($manifest) || !isset($manifest['feeds']) || !is_array($manifest['feeds'])) {
 			return FALSE;
 		}
-		$raw_paths = pfb_unbound_py_manifest_raw_paths($pfb['unbound_py_sources']);
+		$raw_paths = pfb_unbound_py_manifest_raw_paths($pfb['unbound_py_sources'], FALSE);
 		if (count($raw_paths) !== count($manifest['feeds'])) {
 			return FALSE;
 		}
@@ -8290,7 +8296,7 @@ function pfb_unbound_py_generation_matches(string $dir, array $metadata): bool {
 	return TRUE;
 }
 
-function pfb_unbound_python_sources($feeds) {
+function pfb_unbound_python_sources($feeds, array $publication_ops=array()) {
 	$lock = pfb_unbound_py_publication_lock();
 	if ($lock === FALSE) {
 		$manifest_path = $GLOBALS['pfb']['unbound_py_sources'] ?? 'unknown path';
@@ -8300,13 +8306,13 @@ function pfb_unbound_python_sources($feeds) {
 		return FALSE;
 	}
 	try {
-		return pfb_unbound_python_sources_locked($feeds);
+		return pfb_unbound_python_sources_locked($feeds, $publication_ops);
 	} finally {
 		pfb_unbound_py_publication_unlock($lock);
 	}
 }
 
-function pfb_unbound_python_sources_locked($feeds) {
+function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array()) {
 	global $pfb;
 
 	if (!is_array($feeds)) {
@@ -8317,7 +8323,8 @@ function pfb_unbound_python_sources_locked($feeds) {
 	$raw_base = basename($pfb['unbound_py_rawdir']);
 	$stage_digest = hash('xxh128', uniqid('', TRUE) . ':' . getmypid());
 	$stage_dir = "{$raw_parent}/{$raw_base}.stage.{$stage_digest}";
-	if (!@mkdir($stage_dir, 0755)) {
+	$stage_mkdir = $publication_ops['stage_mkdir'] ?? static fn($dir, $mode) => @mkdir($dir, $mode);
+	if (!$stage_mkdir($stage_dir, 0755)) {
 		pfb_logger("\nDNSBL raw generation staging failed", 2);
 		return FALSE;
 	}
@@ -8428,6 +8435,7 @@ function pfb_unbound_python_sources_locked($feeds) {
 	$generation_digest = hash_final($generation_hash);
 	$generation_base = "{$raw_base}.{$generation_digest}";
 	$generation_dir = "{$raw_parent}/{$generation_base}";
+	$generation_created = FALSE;
 	if (file_exists($generation_dir) || is_link($generation_dir)) {
 		if (!pfb_unbound_py_generation_matches($generation_dir, $raw_metadata)) {
 			return $abort_generation('generation collision');
@@ -8436,9 +8444,23 @@ function pfb_unbound_python_sources_locked($feeds) {
 		if (file_exists($stage_dir)) {
 			return $abort_generation('duplicate stage cleanup');
 		}
-	} elseif (!@rename($stage_dir, $generation_dir)) {
-		return $abort_generation('generation publish');
+	} else {
+		$generation_rename = $publication_ops['generation_rename']
+			?? static fn($from, $to) => @rename($from, $to);
+		if (!$generation_rename($stage_dir, $generation_dir)) {
+			return $abort_generation('generation publish');
+		}
+		$generation_created = TRUE;
 	}
+	$discard_unpublished_generation = static function () use (&$generation_created, $generation_dir): void {
+		if (!$generation_created) {
+			return;
+		}
+		if (!pfb_unbound_py_remove_raw_artifact($generation_dir)) {
+			pfb_logger("\nDNSBL unpublished raw generation cleanup failed", 2);
+		}
+		$generation_created = FALSE;
+	};
 	foreach ($manifest_feeds as &$manifest_feed) {
 		$manifest_feed['raw'] = "{$generation_base}/{$manifest_feed['raw']}";
 	}
@@ -8501,7 +8523,10 @@ function pfb_unbound_python_sources_locked($feeds) {
 		// sentinel flip that ACTS on it is driven by pfb_reload_unbound's data
 		// fast path (so a full feed update advances the generation exactly once,
 		// after every manifest+raw file is in place), not here.
-		if (!pfb_unbound_py_atomic_write($pfb['unbound_py_sources'], $json)) {
+		$manifest_atomic_ops = isset($publication_ops['manifest_atomic'])
+			&& is_array($publication_ops['manifest_atomic']) ? $publication_ops['manifest_atomic'] : array();
+		if (!pfb_unbound_py_atomic_write($pfb['unbound_py_sources'], $json, $manifest_atomic_ops)) {
+			$discard_unpublished_generation();
 			// ADR-65: a swallowed publish failure left Python running on a stale/absent
 			// manifest with no operator-visible signal -- surface it like the existing
 			// MaxMind/VIP credential notices (issue #331 pattern).
@@ -8510,6 +8535,7 @@ function pfb_unbound_python_sources_locked($feeds) {
 			file_notice('pfBlockerNG DNSBL', $manifest_notice, 'pfBlockerNG', '/pfblockerng/pfblockerng_dnsbl.php', 2);
 		}
 	} else {
+		$discard_unpublished_generation();
 		pfb_logger("\nDNSBL manifest JSON encoding failed: " . json_last_error_msg(), 2);
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -136,7 +136,7 @@ $pfb['unbound_py_count']= '/var/unbound/pfb_py_count';
 $pfb['unbound_py_regex_count']= '/var/unbound/pfb_py_regex_count';	// ADR-07: Python-emitted ADMITTED (cap-filtered) feed+user regex total for the DNSBL_Regex alias
 $pfb['unbound_py_reject_stats']= '/var/unbound/pfb_py_reject_stats.json';	// ADR-48: Python-emitted per-entry reject tally (issue #789), read by pfb_emit_entry_reject_stats()
 $pfb['unbound_py_sources']= '/var/unbound/pfb_py_sources.json';	// ADR-06: per-feed manifest consumed by pfb_unbound.py init
-$pfb['unbound_py_rawdir']= '/var/unbound/pfb_py_raw';		// ADR-06: per-feed IP-stripped raw feeds referenced by the manifest
+$pfb['unbound_py_rawdir']= '/var/unbound/pfb_py_raw';		// #1357: basename for immutable per-feed raw generations
 
 $pfb['dnsbl_safesearch']		= '/usr/local/pkg/pfblockerng/pfb_dnsbl.safesearch.conf';
 $pfb['dnsbl_youtube_restrict']		= '/usr/local/pkg/pfblockerng/pfb_dnsbl.youtube_restrict.conf';
@@ -1861,9 +1861,76 @@ function pfb_resolve_list_script($name, $dirs = null) {
    md5 gate via $safesearch_update; double-gating would suppress SafeSearch restarts), and
    unbound_py_data/unbound_py_zone (ADR-65: retired writer targets, never written again).
    Pure (no global access): caller passes $pfb explicitly so tests can inject any paths. */
+function pfb_unbound_py_normalize_absolute_path(string $path) {
+	if ($path === '' || $path[0] !== '/') {
+		return FALSE;
+	}
+
+	$parts = array();
+	foreach (explode('/', $path) as $part) {
+		if ($part === '' || $part === '.') {
+			continue;
+		}
+		if ($part === '..') {
+			if (empty($parts)) {
+				return FALSE;
+			}
+			array_pop($parts);
+			continue;
+		}
+		$parts[] = $part;
+	}
+	return '/' . implode('/', $parts);
+}
+
+// ADR-65/#1357: resolve only manifest-authoritative raw refs under the manifest's
+// directory. Missing confined refs stay in the set so the reload fingerprint fails loud.
+function pfb_unbound_py_manifest_raw_paths(string $manifest_path): array {
+	$json = @file_get_contents($manifest_path);
+	if ($json === FALSE) {
+		return array();
+	}
+	$manifest = json_decode($json, TRUE);
+	if (!is_array($manifest) || !isset($manifest['feeds']) || !is_array($manifest['feeds'])) {
+		return array();
+	}
+
+	$base_path = dirname($manifest_path);
+	if ($base_path === '' || $base_path[0] !== '/') {
+		$base_path = getcwd() . "/{$base_path}";
+	}
+	$base_normalized = pfb_unbound_py_normalize_absolute_path($base_path);
+	$base_resolved = realpath($base_path);
+	if ($base_normalized === FALSE || $base_resolved === FALSE) {
+		return array();
+	}
+
+	$paths = array();
+	foreach ($manifest['feeds'] as $feed) {
+		if (!is_array($feed) || !isset($feed['raw']) || !is_string($feed['raw']) || $feed['raw'] === '') {
+			continue;
+		}
+		$path = $feed['raw'][0] === '/' ? $feed['raw'] : "{$base_normalized}/{$feed['raw']}";
+		$normalized = pfb_unbound_py_normalize_absolute_path($path);
+		if ($normalized === FALSE) {
+			continue;
+		}
+		$resolved = realpath($path);
+		$confined = $resolved !== FALSE ? $resolved : $normalized;
+		$confined_base = $resolved !== FALSE ? $base_resolved : $base_normalized;
+		if ($confined !== $confined_base && !str_starts_with($confined, "{$confined_base}/")) {
+			continue;
+		}
+		$paths[] = $normalized;
+	}
+
+	$paths = array_values(array_unique($paths));
+	sort($paths, SORT_STRING);
+	return $paths;
+}
+
 function pfb_dnsbl_loaded_input_paths(array $pfb): array {
-	$raw_files = glob("{$pfb['unbound_py_rawdir']}/*.raw") ?: array();
-	sort($raw_files, SORT_STRING);
+	$raw_files = pfb_unbound_py_manifest_raw_paths((string) ($pfb['unbound_py_sources'] ?? ''));
 	return array_merge(
 		array($pfb['unbound_py_wh'], $pfb['unbound_py_sources'], $pfb['unbound_py_hsts'], $pfb['unbound_py_tld']),
 		$raw_files
@@ -1886,7 +1953,12 @@ function pfb_dnsbl_reload_fingerprint(array $pfb): string {
    look "loaded" forever, triggering a clear+reload every cron pass (#546).
    Pure (no global access). */
 function pfb_dnsbl_has_loaded_feeds(array $pfb): bool {
-	return !empty(glob("{$pfb['unbound_py_rawdir']}/*.raw") ?: array());
+	foreach (pfb_unbound_py_manifest_raw_paths((string) ($pfb['unbound_py_sources'] ?? '')) as $raw_path) {
+		if (is_file($raw_path) && is_readable($raw_path)) {
+			return TRUE;
+		}
+	}
+	return FALSE;
 }
 
 /* Return a stable fingerprint of the given input-file set.
@@ -7669,14 +7741,20 @@ function pfb_dnsbl_is_abp_rule_line(string $line): bool {
 }
 
 
-// ADR-10: atomically publish a file to the chroot (/var/unbound). Stage into a
-// temp file ON THE SAME FILESYSTEM (same directory) -> flush + fsync the data ->
-// fix ownership -> atomic rename() over the final path. The plugin only ever reads
-// a fully-written, immutable file: a half-written manifest is never visible because
-// the rename is the all-or-nothing commit (POSIX rename(2) is atomic within a dir).
+// ADR-10: atomically publish a file to the chroot (/var/unbound). The same-directory
+// rename is the runtime visibility commit; crash durability needs the #1357 FreeBSD
+// parent-directory fsync probe and is not claimed by this helper.
 // Returns TRUE on success. No die()/exit(): a failure is logged + returned FALSE so
 // the caller can fall back to the restart path.
-function pfb_unbound_py_atomic_write($path, $content) {
+function pfb_unbound_py_stream_sync($fh, string $content, $write_fn=NULL, $flush_fn=NULL, $fsync_fn=NULL): bool {
+	$write_fn = $write_fn ?? static fn($stream, $bytes) => @fwrite($stream, $bytes);
+	$flush_fn = $flush_fn ?? static fn($stream) => @fflush($stream);
+	$fsync_fn = $fsync_fn ?? static fn($stream) => @fsync($stream);
+	$written = $write_fn($fh, $content);
+	return $written !== FALSE && $written === strlen($content) && $flush_fn($fh) && $fsync_fn($fh);
+}
+
+function pfb_unbound_py_atomic_write($path, $content, array $stream_ops=array()) {
 	$dir = dirname($path);
 	$tmp = @tempnam($dir, '.pfbpub_');
 	if ($tmp === FALSE) {
@@ -7691,14 +7769,9 @@ function pfb_unbound_py_atomic_write($path, $content) {
 		return FALSE;
 	}
 
-	$ok = (@fwrite($fh, $content) !== FALSE);
-	if ($ok) {
-		@fflush($fh);
-		// Durably persist the staged bytes before the rename so a crash between
-		// rename and the OS flush cannot expose a zero-length manifest.
-		@fsync($fh);
-	}
-	@fclose($fh);
+	$ok = pfb_unbound_py_stream_sync($fh, $content,
+		$stream_ops['write'] ?? NULL, $stream_ops['flush'] ?? NULL, $stream_ops['fsync'] ?? NULL);
+	$ok = @fclose($fh) && $ok;
 
 	if (!$ok) {
 		@unlink($tmp);
@@ -7706,8 +7779,8 @@ function pfb_unbound_py_atomic_write($path, $content) {
 		return FALSE;
 	}
 
-	// Ownership must match the consuming (chrooted) unbound user; set it on the
-	// staging file so the rename publishes a correctly-owned inode atomically.
+	// Preserve the helper's existing best-effort ownership semantics: test/dev hosts
+	// need not have an unbound account, while appliance writes still request it.
 	@chown($tmp, 'unbound');
 	@chgrp($tmp, 'unbound');
 
@@ -7718,6 +7791,132 @@ function pfb_unbound_py_atomic_write($path, $content) {
 	}
 
 	return TRUE;
+}
+
+// #1357: one exclusive lock serializes full-set publication, scalar manifest patches,
+// convergence-gated generation GC, and teardown. Python readers never take this lock.
+function pfb_unbound_py_publication_lock() {
+	global $pfb;
+
+	$manifest_path = $pfb['unbound_py_sources'] ?? '';
+	if ($manifest_path === '') {
+		pfb_logger("\nDNSBL publication lock path unavailable", 2);
+		return FALSE;
+	}
+	$lock = @fopen(dirname($manifest_path) . '/pfb_py_sources.lock', 'c');
+	if ($lock === FALSE || !@flock($lock, LOCK_EX)) {
+		if (is_resource($lock)) {
+			@fclose($lock);
+		}
+		pfb_logger("\nDNSBL publication lock unavailable", 2);
+		return FALSE;
+	}
+	return $lock;
+}
+
+function pfb_unbound_py_publication_unlock($lock): void {
+	if (is_resource($lock)) {
+		@flock($lock, LOCK_UN);
+		@fclose($lock);
+	}
+}
+
+// Strictly enumerate only #1357 generation/stage siblings; never broaden this prefix.
+function pfb_unbound_py_raw_artifacts(array $pfb): array {
+	$rawdir = $pfb['unbound_py_rawdir'] ?? '';
+	if ($rawdir === '' || $rawdir[0] !== '/') {
+		return array();
+	}
+	$parent = realpath(dirname($rawdir)) ?: dirname($rawdir);
+	$rawdir = "{$parent}/" . basename($rawdir);
+	$base = basename($rawdir);
+	$entries = @scandir($parent);
+	if ($entries === FALSE) {
+		return array();
+	}
+	$pattern = '/^' . preg_quote($base, '/') . '\.(?:[0-9a-f]{32}|stage\.[0-9a-f]{32})$/D';
+	$paths = (file_exists($rawdir) || is_link($rawdir)) ? array($rawdir) : array();
+	foreach ($entries as $entry) {
+		if (preg_match($pattern, $entry) === 1) {
+			$paths[] = "{$parent}/{$entry}";
+		}
+	}
+	sort($paths, SORT_STRING);
+	return $paths;
+}
+
+function pfb_unbound_py_remove_raw_artifact(string $path): bool {
+	if (is_dir($path) && !is_link($path)) {
+		rmdir_recursive($path);
+	} else {
+		@unlink($path);
+	}
+	return !file_exists($path) && !is_link($path);
+}
+
+// #1357: collect only after a watcher apply or restart has truly converged.
+function pfb_unbound_py_gc(bool $converged): bool {
+	global $pfb;
+
+	$lock = pfb_unbound_py_publication_lock();
+	if ($lock === FALSE) {
+		return FALSE;
+	}
+	try {
+		if (!$converged) {
+			return FALSE;
+		}
+		$json = @file_get_contents($pfb['unbound_py_sources']);
+		$manifest = $json !== FALSE ? json_decode($json, TRUE) : NULL;
+		if (!is_array($manifest) || !isset($manifest['feeds']) || !is_array($manifest['feeds'])) {
+			return FALSE;
+		}
+		$raw_paths = pfb_unbound_py_manifest_raw_paths($pfb['unbound_py_sources']);
+		if (count($raw_paths) !== count($manifest['feeds'])) {
+			return FALSE;
+		}
+		$protected = array();
+		foreach ($raw_paths as $raw_path) {
+			$raw_dir = realpath(dirname($raw_path));
+			if ($raw_dir === FALSE || !is_file($raw_path)) {
+				return FALSE;
+			}
+			$protected[$raw_dir] = TRUE;
+		}
+		$ok = TRUE;
+		foreach (pfb_unbound_py_raw_artifacts($pfb) as $artifact) {
+			if (isset($protected[$artifact])) {
+				continue;
+			}
+			if (!pfb_unbound_py_remove_raw_artifact($artifact)) {
+				pfb_logger("\nDNSBL raw generation cleanup failed", 2);
+				$ok = FALSE;
+			}
+		}
+		return $ok;
+	} finally {
+		pfb_unbound_py_publication_unlock($lock);
+	}
+}
+
+function pfb_unbound_py_teardown_raw_set(): bool {
+	global $pfb;
+
+	$lock = pfb_unbound_py_publication_lock();
+	if ($lock === FALSE) {
+		return FALSE;
+	}
+	try {
+		unlink_if_exists($pfb['unbound_py_sources']);
+		pfb_unbound_py_remove_raw_artifact($pfb['unbound_py_rawdir']);
+		$ok = TRUE;
+		foreach (pfb_unbound_py_raw_artifacts($pfb) as $artifact) {
+			$ok = pfb_unbound_py_remove_raw_artifact($artifact) && $ok;
+		}
+		return $ok;
+	} finally {
+		pfb_unbound_py_publication_unlock($lock);
+	}
 }
 
 
@@ -8066,18 +8265,72 @@ function pfb_feed_manifest_row(string $header, string $group, string $log_flag,
 // PFBL-01: RE-validates each header via pfb_sanitise_feed_header() (PFB_FILTER_WORD, not
 // DOMAIN); a failing row is SKIPPED + logged before any file touch; pinned by
 // tests/php/PfbFilterContractTest.php.
+function pfb_unbound_py_generation_matches(string $dir, array $metadata): bool {
+	$entries = @scandir($dir);
+	if ($entries === FALSE) {
+		return FALSE;
+	}
+	$actual = array_values(array_diff($entries, array('.', '..')));
+	$expected = array();
+	foreach ($metadata as $header => $meta) {
+		$expected[] = "{$header}.raw";
+	}
+	sort($actual, SORT_STRING);
+	sort($expected, SORT_STRING);
+	if ($actual !== $expected) {
+		return FALSE;
+	}
+	foreach ($metadata as $header => $meta) {
+		$path = "{$dir}/{$header}.raw";
+		if (is_link($path) || !is_file($path) || !is_readable($path) || filesize($path) !== $meta['bytes'] ||
+		    @hash_file('xxh128', $path) !== $meta['hash']) {
+			return FALSE;
+		}
+	}
+	return TRUE;
+}
+
 function pfb_unbound_python_sources($feeds) {
+	$lock = pfb_unbound_py_publication_lock();
+	if ($lock === FALSE) {
+		$manifest_path = $GLOBALS['pfb']['unbound_py_sources'] ?? 'unknown path';
+		$manifest_notice = "DNSBL manifest publication lock failed: {$manifest_path}";
+		file_notice('pfBlockerNG DNSBL', $manifest_notice, 'pfBlockerNG',
+			'/pfblockerng/pfblockerng_dnsbl.php', 2);
+		return FALSE;
+	}
+	try {
+		return pfb_unbound_python_sources_locked($feeds);
+	} finally {
+		pfb_unbound_py_publication_unlock($lock);
+	}
+}
+
+function pfb_unbound_python_sources_locked($feeds) {
 	global $pfb;
 
 	if (!is_array($feeds)) {
 		$feeds = array();
 	}
 
-	// Per-feed raw directory (recreated each build)
-	rmdir_recursive("{$pfb['unbound_py_rawdir']}");
-	safe_mkdir("{$pfb['unbound_py_rawdir']}");
+	$raw_parent = dirname($pfb['unbound_py_rawdir']);
+	$raw_base = basename($pfb['unbound_py_rawdir']);
+	$stage_digest = hash('xxh128', uniqid('', TRUE) . ':' . getmypid());
+	$stage_dir = "{$raw_parent}/{$raw_base}.stage.{$stage_digest}";
+	if (!@mkdir($stage_dir, 0755)) {
+		pfb_logger("\nDNSBL raw generation staging failed", 2);
+		return FALSE;
+	}
+	$abort_generation = static function (string $reason) use ($stage_dir) {
+		rmdir_recursive($stage_dir);
+		pfb_logger("\nDNSBL raw generation failed: {$reason}", 2);
+		file_notice('pfBlockerNG DNSBL', 'DNSBL raw generation publish failed', 'pfBlockerNG',
+			'/pfblockerng/pfblockerng_dnsbl.php', 2);
+		return FALSE;
+	};
 
 	$manifest_feeds = array();
+	$raw_metadata = array();
 	foreach ($feeds as $feed) {
 		$header	= isset($feed['header']) ? $feed['header'] : '';
 		$group	= isset($feed['group'])  ? $feed['group']  : '';
@@ -8097,35 +8350,50 @@ function pfb_unbound_python_sources($feeds) {
 		if (!file_exists($src)) {
 			continue;
 		}
+		if (!is_file($src)) {
+			return $abort_generation('source type');
+		}
 
-		$rawpath	= "{$pfb['unbound_py_rawdir']}/{$header}.raw";
-		$raw_h		= @fopen($rawpath, 'w');
+		$in_h = @fopen($src, 'r');
+		if ($in_h === FALSE) {
+			return $abort_generation('source open');
+		}
+		$rawpath = "{$stage_dir}/{$header}.raw";
+		$raw_h = @fopen($rawpath, 'wb');
 		if ($raw_h === FALSE) {
-			pfb_logger("\nFailed to create DNSBL python raw feed [ {$rawpath} ]", 2);
-			continue;
-		}
-		if (($in_h = @fopen($src, 'r')) !== FALSE) {
-			while (($line = @fgets($in_h)) !== FALSE) {
-				// #1083: an 'abp' row's raw payload (the download loop captured it
-				// verbatim) passes straight through to the '.raw' -- Python's build()
-				// routes it to parse_abp(). A 'domain' row extracts its bare domain,
-				// already IP-free and cleaned/validated by the download loop. NULL
-				// (undecodable, e.g. stale pre-flip residue) is silently skipped.
-				$row = pfb_dnsbl_ndjson_parse_row($line);
-				if ($row === NULL) {
-					continue;
-				}
-				if ($row['kind'] === 'abp') {
-					@fwrite($raw_h, "{$row['raw']}\n");
-				} else {
-					@fwrite($raw_h, "{$row['domain']}\n");
-				}
-			}
 			@fclose($in_h);
+			return $abort_generation('raw open');
 		}
-		if ($raw_h) {
-			@fclose($raw_h);
+		$raw_hash = hash_init('xxh128');
+		$raw_bytes = 0;
+		$raw_ok = TRUE;
+		while (($line = @fgets($in_h)) !== FALSE) {
+			// #1083: an 'abp' row's raw payload (the download loop captured it
+			// verbatim) passes straight through to the '.raw' -- Python's build()
+			// routes it to parse_abp(). A 'domain' row extracts its bare domain,
+			// already IP-free and cleaned/validated by the download loop. NULL
+			// (undecodable, e.g. stale pre-flip residue) is silently skipped.
+			$row = pfb_dnsbl_ndjson_parse_row($line);
+			if ($row === NULL) {
+				continue;
+			}
+			$raw_line = $row['kind'] === 'abp' ? "{$row['raw']}\n" : "{$row['domain']}\n";
+			$written = @fwrite($raw_h, $raw_line);
+			if ($written === FALSE || $written !== strlen($raw_line)) {
+				$raw_ok = FALSE;
+				break;
+			}
+			hash_update($raw_hash, $raw_line);
+			$raw_bytes += $written;
 		}
+		$raw_ok = $raw_ok && feof($in_h);
+		$raw_ok = @fclose($in_h) && $raw_ok;
+		$raw_ok = $raw_ok && @fflush($raw_h) && @fsync($raw_h);
+		$raw_ok = @fclose($raw_h) && $raw_ok;
+		if (!$raw_ok) {
+			return $abort_generation('raw write');
+		}
+		$raw_metadata[$header] = array('bytes' => $raw_bytes, 'hash' => hash_final($raw_hash));
 
 		// Store the raw path RELATIVE to the manifest's directory. pfb_unbound.py
 		// runs inside Unbound's chroot (/var/unbound), so an absolute HOST path
@@ -8135,7 +8403,7 @@ function pfb_unbound_python_sources($feeds) {
 		// joins a relative path against the manifest's dir (the chroot root), which
 		// resolves correctly both chrooted and not.
 		$manifest_feeds[] = array(
-			'raw'		=> basename($pfb['unbound_py_rawdir']) . "/{$header}.raw",
+			'raw'		=> "{$header}.raw",
 			'feed'		=> $header,
 			'group'		=> $group,
 			'provenance'	=> (isset($feed['provenance']) && $feed['provenance'] === 'user') ? 'user' : 'feed',
@@ -8150,6 +8418,31 @@ function pfb_unbound_python_sources($feeds) {
 			$manifest_feeds[count($manifest_feeds) - 1]['mode'] = 'permit';
 		}
 	}
+
+	$generation_hash = hash_init('xxh128');
+	ksort($raw_metadata, SORT_STRING);
+	foreach ($raw_metadata as $header => $meta) {
+		hash_update($generation_hash,
+			strlen($header) . ":{$header}:{$meta['bytes']}:{$meta['hash']}\n");
+	}
+	$generation_digest = hash_final($generation_hash);
+	$generation_base = "{$raw_base}.{$generation_digest}";
+	$generation_dir = "{$raw_parent}/{$generation_base}";
+	if (file_exists($generation_dir) || is_link($generation_dir)) {
+		if (!pfb_unbound_py_generation_matches($generation_dir, $raw_metadata)) {
+			return $abort_generation('generation collision');
+		}
+		rmdir_recursive($stage_dir);
+		if (file_exists($stage_dir)) {
+			return $abort_generation('duplicate stage cleanup');
+		}
+	} elseif (!@rename($stage_dir, $generation_dir)) {
+		return $abort_generation('generation publish');
+	}
+	foreach ($manifest_feeds as &$manifest_feed) {
+		$manifest_feed['raw'] = "{$generation_base}/{$manifest_feed['raw']}";
+	}
+	unset($manifest_feed);
 
 	// Synthetic whole-TLD blacklist feed (DNSBL_TLD): the Python build emits these
 	// as whole-TLD ZONE entries from config.tld_wildcard_blacklist, so no raw file is needed.
@@ -8203,9 +8496,8 @@ function pfb_unbound_python_sources($feeds) {
 
 	$json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
 	if ($json !== FALSE) {
-		// ADR-10: atomic publish (stage -> fsync -> rename). The per-feed raw
-		// files were already (re)written into unbound_py_rawdir above; the manifest
-		// rename is the point at which the new immutable set becomes readable. The
+		// #1357: every raw is complete in an immutable content-addressed directory;
+		// this manifest rename is the sole visibility commit for the complete set. The
 		// sentinel flip that ACTS on it is driven by pfb_reload_unbound's data
 		// fast path (so a full feed update advances the generation exactly once,
 		// after every manifest+raw file is in place), not here.
@@ -8229,6 +8521,18 @@ function pfb_unbound_python_sources($feeds) {
 // (shared by the whitelist/unlock in-place patchers below), without a full
 // feed re-enumeration. The query-time whiteDB is rebuilt from this on reload.
 function pfb_unbound_python_sources_patch($key, $values) {
+	$lock = pfb_unbound_py_publication_lock();
+	if ($lock === FALSE) {
+		return FALSE;
+	}
+	try {
+		return pfb_unbound_python_sources_patch_locked($key, $values);
+	} finally {
+		pfb_unbound_py_publication_unlock($lock);
+	}
+}
+
+function pfb_unbound_python_sources_patch_locked($key, $values) {
 	global $pfb;
 
 	if (!file_exists($pfb['unbound_py_sources'])) {
@@ -8872,16 +9176,18 @@ function pfb_dnsbl_converged(): bool {
 // pfb_reload_unbound() where convergence might settle (the zero-downtime swap's own
 // success return, and the shared restart path's completion). Kept separate from
 // pfb_dnsbl_converged() so it stays directly unit-testable.
-function pfb_dnsbl_apply_ledger_update(): void {
+function pfb_dnsbl_apply_ledger_update(): bool {
 	global $pfb;
 
-	if (pfb_dnsbl_converged()) {
+	$converged = pfb_dnsbl_converged();
+	if ($converged) {
 		pfb_sync_status_close('dnsbl', 'dnsbl', 'apply', $pfb['dbdir']);
 	} else {
 		pfb_sync_status_open('dnsbl', 'dnsbl', 'apply',
 			'DNSBL apply not converged -- Unbound not fully live with pfb_unbound.py; see error.log',
 			$pfb['dbdir']);
 	}
+	return $converged;
 }
 
 // ADR-61: tick-driven reconciliation for a stuck (dnsbl,dnsbl,apply) ledger entry.
@@ -8978,7 +9284,8 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 					unlink_if_exists("{$pfb['dnsbl_file']}.sync");
 					// ADR-61: this swap just confirmed applied == sentinel -- a second,
 					// independent convergence point besides the restart path's completion.
-					pfb_dnsbl_apply_ledger_update();
+					$converged = pfb_dnsbl_apply_ledger_update();
+					pfb_unbound_py_gc($converged);
 					return;
 				}
 
@@ -9082,7 +9389,8 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 	// a deliberate 'disabled' teardown clears any stale entry rather than flagging its
 	// own (expected) non-convergence as a failure.
 	if ($mode == 'enabled') {
-		pfb_dnsbl_apply_ledger_update();
+		$converged = pfb_dnsbl_apply_ledger_update();
+		pfb_unbound_py_gc($converged);
 	} else {
 		pfb_sync_status_close('dnsbl', 'dnsbl', 'apply', $pfb['dbdir']);
 	}
@@ -17516,8 +17824,7 @@ function sync_package_pfblockerng($cron='') {
 					@unlink($pfb_file);
 				}
 			}
-			unlink_if_exists($pfb['unbound_py_sources']);
-			rmdir_recursive("{$pfb['unbound_py_rawdir']}");
+			pfb_unbound_py_teardown_raw_set();
 		}
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -371,6 +371,9 @@ dnsbl_cache() {
 			for _g in "${pfbchroot}"/pfb_unbound* "${pfbchroot}"/pfb_py_*; do
 				[ -e "${_g}" ] || continue
 				_skip=''
+				case "${_g}" in
+					"${pfbchroot}"/pfb_py_raw.stage.*|"${pfbchroot}"/pfb_py_sources.lock) _skip=1 ;;
+				esac
 				for _s in ${PFB_PY_SHIPPED}; do
 					[ "${_g}" = "${pfbchroot}/${_s}" ] && _skip=1 && break
 				done

--- a/tests/php/Adr62DnsblCorpusManifestTest.php
+++ b/tests/php/Adr62DnsblCorpusManifestTest.php
@@ -110,13 +110,16 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 	 */
 	public function testEveryCorpusFeedRawMatchesGolden(): void
 	{
-		pfb_unbound_python_sources($this->feedRows());
+		$manifest = pfb_unbound_python_sources($this->feedRows());
+		$this->assertIsArray($manifest);
+		$rawByHeader = array_column($manifest['feeds'], 'raw', 'feed');
 
 		foreach ($this->feeds as $f) {
 			$header = $f['header'];
 			$golden = self::CORPUS_DIR . "/raw/{$header}.raw";
 			$this->assertFileExists($golden, "missing golden fixture for [ {$header} ] ({$f['row']})");
-			$produced = file_get_contents("{$this->tmp}/pfb_py_raw/{$header}.raw");
+			$this->assertArrayHasKey($header, $rawByHeader);
+			$produced = file_get_contents("{$this->tmp}/{$rawByHeader[$header]}");
 			$this->assertSame(
 				file_get_contents($golden),
 				$produced,

--- a/tests/php/DnsblHasLoadedFeedsTest.php
+++ b/tests/php/DnsblHasLoadedFeedsTest.php
@@ -153,8 +153,12 @@ final class DnsblHasLoadedFeedsTest extends TestCase
 		// Before: empty rawdir → FALSE.
 		$this->assertFalse(pfb_dnsbl_has_loaded_feeds($pfb), 'Before: empty rawdir → FALSE');
 
-		// Drop a raw file (pfb_unbound_python_sources() writes these for each feed).
+		// Publish one manifest-authoritative raw reference.
 		file_put_contents("{$this->rawDir}/some_feed.raw", "blocked.example.com\n");
+		file_put_contents($pfb['unbound_py_sources'], json_encode([
+			'version' => 1,
+			'feeds' => [['raw' => 'raw/some_feed.raw']],
+		]));
 
 		// After: *.raw present → TRUE.
 		$this->assertTrue(pfb_dnsbl_has_loaded_feeds($pfb), '*.raw in rawdir → TRUE');

--- a/tests/php/DnsblHasLoadedFeedsTest.php
+++ b/tests/php/DnsblHasLoadedFeedsTest.php
@@ -138,13 +138,14 @@ final class DnsblHasLoadedFeedsTest extends TestCase
 	}
 
 	/**
-	 * Scenario: at least one *.raw in rawdir → feeds are loaded.
+	 * Scenario: at least one manifest-authoritative raw file → feeds are loaded.
 	 *
-	 * Given:  a single *.raw file exists in the rawdir
+	 * Given:  a single raw file is referenced by the live manifest
 	 * When:   pfb_dnsbl_has_loaded_feeds() is called
 	 * Then:   returns TRUE
 	 *
-	 * Before-state assertion (empty rawdir → FALSE) proves the raw file caused the flip.
+	 * Before-state assertions prove neither an empty directory nor an orphan raw file
+	 * is treated as loaded.
 	 */
 	public function testRawFilePresentReturnsTrue(): void
 	{
@@ -153,15 +154,18 @@ final class DnsblHasLoadedFeedsTest extends TestCase
 		// Before: empty rawdir → FALSE.
 		$this->assertFalse(pfb_dnsbl_has_loaded_feeds($pfb), 'Before: empty rawdir → FALSE');
 
-		// Publish one manifest-authoritative raw reference.
+		// A raw file alone is not authoritative.
 		file_put_contents("{$this->rawDir}/some_feed.raw", "blocked.example.com\n");
+		$this->assertFalse(pfb_dnsbl_has_loaded_feeds($pfb), 'Unreferenced raw file must remain unloaded');
+
+		// Publish one manifest-authoritative raw reference.
 		file_put_contents($pfb['unbound_py_sources'], json_encode([
 			'version' => 1,
 			'feeds' => [['raw' => 'raw/some_feed.raw']],
 		]));
 
-		// After: *.raw present → TRUE.
-		$this->assertTrue(pfb_dnsbl_has_loaded_feeds($pfb), '*.raw in rawdir → TRUE');
+		// After: the live manifest references the raw file → TRUE.
+		$this->assertTrue(pfb_dnsbl_has_loaded_feeds($pfb), 'manifest-authoritative raw → TRUE');
 	}
 
 	/**

--- a/tests/php/DnsblInterchangeRetirementTest.php
+++ b/tests/php/DnsblInterchangeRetirementTest.php
@@ -12,8 +12,8 @@ use PHPUnit\Framework\TestCase;
  * the interchange files -- classification now lives solely in the manifest
  * build (pfb_unbound_python_sources() / pfb_unbound.py). R2/R3: a stale
  * on-disk copy of the retired files, alone, no longer counts as "loaded feeds"
- * nor moves the reload fingerprint -- only a rawdir *.raw (the manifest's own
- * artefact) does, in EITHER TLD toggle state.
+ * nor moves the reload fingerprint -- only a raw referenced by the published
+ * manifest does, in EITHER TLD toggle state.
  */
 #[CoversFunction('pfb_dnsbl_tld_stats_finalize')]
 #[CoversFunction('pfb_dnsbl_has_loaded_feeds')]
@@ -125,17 +125,17 @@ final class DnsblInterchangeRetirementTest extends TestCase
 		);
 	}
 
-	/** Vacuity twin: the SAME stale files, plus a genuine rawdir *.raw -> TRUE. */
+	/** Vacuity twin: the SAME stale files, plus a manifest-referenced raw -> TRUE. */
 	public function testHasLoadedFeedsVacuityTwinRawFileStillCounts(): void
 	{
 		$pfb = $this->makeLoadedFeedsPfb();
 		file_put_contents($pfb['unbound_py_data'], "stale.example,1\n");
 		file_put_contents($pfb['unbound_py_zone'], "stale-zone.example\n");
-		file_put_contents("{$pfb['unbound_py_rawdir']}/feed.raw", "blocked.example\n");
+		$this->publishRawFixture($pfb, "blocked.example\n");
 
 		$this->assertTrue(
 			pfb_dnsbl_has_loaded_feeds($pfb),
-			'sanity: a genuine rawdir *.raw file must still count as loaded (proves the FALSE assertion above can fail)'
+			'sanity: a manifest-referenced raw must still count as loaded (proves the FALSE assertion above can fail)'
 		);
 	}
 
@@ -144,6 +144,7 @@ final class DnsblInterchangeRetirementTest extends TestCase
 		return [
 			'unbound_py_data'   => "{$this->tmp}/pfb_py_data.txt",
 			'unbound_py_zone'   => "{$this->tmp}/pfb_py_zone.txt",
+			'unbound_py_sources'=> "{$this->tmp}/pfb_py_sources.json",
 			'unbound_py_rawdir' => "{$this->tmp}/raw",
 		];
 	}
@@ -167,15 +168,15 @@ final class DnsblInterchangeRetirementTest extends TestCase
 		);
 	}
 
-	/** Vacuity twin: a rawdir *.raw mutation between the SAME two snapshots MUST move it. */
+	/** Vacuity twin: a manifest-referenced raw mutation between snapshots MUST move it. */
 	public function testReloadFingerprintVacuityTwinRawMutationStillMovesIt(): void
 	{
 		$pfb = $this->makeFingerprintPfb();
 		$pfb['dnsbl_tld_wildcard'] = '';
-		file_put_contents("{$pfb['unbound_py_rawdir']}/feed.raw", 'v1');
+		$rawPath = $this->publishRawFixture($pfb, 'v1');
 
 		$fp_before = pfb_dnsbl_reload_fingerprint($pfb);
-		file_put_contents("{$pfb['unbound_py_rawdir']}/feed.raw", 'v2-mutated');
+		file_put_contents($rawPath, 'v2-mutated');
 		$fp_after = pfb_dnsbl_reload_fingerprint($pfb);
 
 		$this->assertNotSame(
@@ -196,5 +197,23 @@ final class DnsblInterchangeRetirementTest extends TestCase
 			'unbound_py_tld'     => "{$this->tmp}/pfb_py_tld.txt",
 			'unbound_py_rawdir'  => "{$this->tmp}/raw",
 		];
+	}
+
+	private function publishRawFixture(array $pfb, string $contents): string
+	{
+		$rawPath = "{$pfb['unbound_py_rawdir']}/feed.raw";
+		file_put_contents($rawPath, $contents);
+		$manifest = [
+			'version' => 1,
+			'config' => [],
+			'feeds' => [[
+				'raw' => 'raw/feed.raw',
+				'feed' => 'feed',
+				'group' => 'test',
+				'log_flag' => '1',
+			]],
+		];
+		file_put_contents($pfb['unbound_py_sources'], json_encode($manifest));
+		return $rawPath;
 	}
 }

--- a/tests/php/DnsblLineParsingBenchmarkTest.php
+++ b/tests/php/DnsblLineParsingBenchmarkTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class DnsblLineParsingBenchmarkTest extends TestCase
+{
+	private string $tmp;
+
+	protected function setUp(): void
+	{
+		$this->tmp = sys_get_temp_dir() . '/pfb_benchmark_' . uniqid('', TRUE);
+		mkdir("{$this->tmp}/dnsbl", 0777, TRUE);
+	}
+
+	protected function tearDown(): void
+	{
+		$files = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($this->tmp, FilesystemIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($files as $file) {
+			$file->isDir() ? rmdir((string) $file) : unlink((string) $file);
+		}
+		rmdir($this->tmp);
+	}
+
+	public function testWorkerReportsLineCountFromVersionedManifestReference(): void
+	{
+		$root = dirname(__DIR__, 2);
+		file_put_contents("{$this->tmp}/dnsbl/benchfeed.txt",
+			pfb_dnsbl_ndjson_emit_domain_row('one.example', '1', 'benchfeed', 'grp') .
+			pfb_dnsbl_ndjson_emit_domain_row('two.example', '1', 'benchfeed', 'grp'));
+
+		$command = implode(' ', array_map('escapeshellarg', [
+			PHP_BINARY,
+			"{$root}/scripts/bench_dnsbl_line_parsing.php",
+			$root,
+			$this->tmp,
+			'1',
+		]));
+		exec("{$command} 2>&1", $output, $status);
+
+		$this->assertSame(0, $status, implode("\n", $output));
+		$this->assertContains('raw_line_count=2', $output);
+		$manifest = json_decode((string) file_get_contents("{$this->tmp}/pfb_py_sources.json"), TRUE);
+		$this->assertIsArray($manifest);
+		$raw = $manifest['feeds'][0]['raw'] ?? NULL;
+		$this->assertIsString($raw);
+		$this->assertMatchesRegularExpression(
+			'#^pfb_py_raw\.[0-9a-f]{32}/benchfeed\.raw$#',
+			$raw
+		);
+		$this->assertFileExists("{$this->tmp}/{$raw}");
+	}
+}

--- a/tests/php/DnsblLoadedFingerprintTest.php
+++ b/tests/php/DnsblLoadedFingerprintTest.php
@@ -200,6 +200,13 @@ final class DnsblLoadedFingerprintTest extends TestCase
 		$rawDir = "{$this->tmpDir}/raw";
 		file_put_contents("{$rawDir}/zz_feed.raw", 'z');
 		file_put_contents("{$rawDir}/aa_feed.raw", 'a');
+		file_put_contents("{$this->tmpDir}/pfb_py_sources.json", json_encode([
+			'version' => 1,
+			'feeds' => [
+				['raw' => 'raw/zz_feed.raw'],
+				['raw' => 'raw/aa_feed.raw'],
+			],
+		]));
 
 		$pfb = [
 			'unbound_py_data'    => "{$this->tmpDir}/pfb_py_data.txt",
@@ -269,6 +276,29 @@ final class DnsblLoadedFingerprintTest extends TestCase
 		$result = pfb_dnsbl_loaded_input_paths($pfb);
 
 		$this->assertCount(4, $result, 'With no .raw files, exactly the four flat inputs are returned (wh/sources/hsts/tld)');
+	}
+
+	public function testManifestPathsIncludeMissingConfinedRefButRejectEscapesAndSymlinks(): void
+	{
+		$outside = dirname($this->tmpDir) . '/pfb_outside_' . uniqid() . '.raw';
+		file_put_contents($outside, 'outside');
+		symlink($outside, "{$this->tmpDir}/raw/link.raw");
+		$manifest = "{$this->tmpDir}/pfb_py_sources.json";
+		file_put_contents($manifest, json_encode([
+			'version' => 1,
+			'feeds' => [
+				['raw' => 'raw/missing.raw'],
+				['raw' => '../' . basename($outside)],
+				['raw' => 'raw/link.raw'],
+				['raw' => ['/wrong/type']],
+				['feed' => 'missing-key'],
+			],
+		]));
+
+		$paths = pfb_unbound_py_manifest_raw_paths($manifest);
+
+		$this->assertSame(["{$this->tmpDir}/raw/missing.raw"], $paths);
+		@unlink($outside);
 	}
 
 	/**

--- a/tests/php/DnsblLoadedFingerprintTest.php
+++ b/tests/php/DnsblLoadedFingerprintTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_dnsbl_loaded_fingerprint')]
 #[CoversFunction('pfb_dnsbl_loaded_input_paths')]
 #[CoversFunction('pfb_dnsbl_reload_fingerprint')]
+#[CoversFunction('pfb_unbound_py_manifest_raw_paths')]
 final class DnsblLoadedFingerprintTest extends TestCase
 {
 	private string $tmpDir;
@@ -290,6 +291,7 @@ final class DnsblLoadedFingerprintTest extends TestCase
 				['raw' => 'raw/missing.raw'],
 				['raw' => '../' . basename($outside)],
 				['raw' => 'raw/link.raw'],
+				['raw' => "raw/\0hostile.raw"],
 				['raw' => ['/wrong/type']],
 				['feed' => 'missing-key'],
 			],

--- a/tests/php/DnsblLoadedFingerprintTest.php
+++ b/tests/php/DnsblLoadedFingerprintTest.php
@@ -189,18 +189,20 @@ final class DnsblLoadedFingerprintTest extends TestCase
 
 	/**
 	 * Scenario: returns the four flat inputs (incl. HSTS + TLD oracle) plus sorted
-	 * *.raw from rawdir -- NOT the retired unbound_py_data/unbound_py_zone (ADR-65).
+	 * manifest-authoritative raw files -- NOT orphan raw files or the retired
+	 * unbound_py_data/unbound_py_zone (ADR-65).
 	 *
-	 * Given:  a $pfb array with the standard keys and two .raw files in rawdir
+	 * Given:  a $pfb array with two referenced raw files and one orphan raw file
 	 * When:   pfb_dnsbl_loaded_input_paths() is called
-	 * Then:   result contains wh/sources/hsts/tld plus both .raw paths, in sorted
-	 *         order, and excludes the retired data/zone paths
+	 * Then:   result contains wh/sources/hsts/tld plus both referenced paths, in
+	 *         sorted order, and excludes the orphan and retired data/zone paths
 	 */
 	public function testReturnsFlatInputsPlusSortedRaws(): void
 	{
 		$rawDir = "{$this->tmpDir}/raw";
 		file_put_contents("{$rawDir}/zz_feed.raw", 'z');
 		file_put_contents("{$rawDir}/aa_feed.raw", 'a');
+		file_put_contents("{$rawDir}/orphan.raw", 'orphan');
 		file_put_contents("{$this->tmpDir}/pfb_py_sources.json", json_encode([
 			'version' => 1,
 			'feeds' => [
@@ -238,6 +240,7 @@ final class DnsblLoadedFingerprintTest extends TestCase
 		// Both .raw files must be present.
 		$this->assertContains("{$rawDir}/aa_feed.raw", $result, 'aa_feed.raw must be in the path list');
 		$this->assertContains("{$rawDir}/zz_feed.raw", $result, 'zz_feed.raw must be in the path list');
+		$this->assertNotContains("{$rawDir}/orphan.raw", $result, 'unreferenced raw files must be excluded');
 
 		// Excluded output keys must NOT appear.
 		$this->assertNotContains($pfb['unbound_py_count'],       $result, 'unbound_py_count must be excluded (Python-emitted output)');
@@ -282,25 +285,27 @@ final class DnsblLoadedFingerprintTest extends TestCase
 	public function testManifestPathsIncludeMissingConfinedRefButRejectEscapesAndSymlinks(): void
 	{
 		$outside = dirname($this->tmpDir) . '/pfb_outside_' . uniqid() . '.raw';
-		file_put_contents($outside, 'outside');
-		symlink($outside, "{$this->tmpDir}/raw/link.raw");
-		$manifest = "{$this->tmpDir}/pfb_py_sources.json";
-		file_put_contents($manifest, json_encode([
-			'version' => 1,
-			'feeds' => [
-				['raw' => 'raw/missing.raw'],
-				['raw' => '../' . basename($outside)],
-				['raw' => 'raw/link.raw'],
-				['raw' => "raw/\0hostile.raw"],
-				['raw' => ['/wrong/type']],
-				['feed' => 'missing-key'],
-			],
-		]));
+		try {
+			file_put_contents($outside, 'outside');
+			symlink($outside, "{$this->tmpDir}/raw/link.raw");
+			$manifest = "{$this->tmpDir}/pfb_py_sources.json";
+			file_put_contents($manifest, json_encode([
+				'version' => 1,
+				'feeds' => [
+					['raw' => 'raw/missing.raw'],
+					['raw' => '../' . basename($outside)],
+					['raw' => 'raw/link.raw'],
+					['raw' => "raw/\0hostile.raw"],
+					['raw' => ['/wrong/type']],
+					['feed' => 'missing-key'],
+				],
+			]));
 
-		$paths = pfb_unbound_py_manifest_raw_paths($manifest);
-
-		$this->assertSame(["{$this->tmpDir}/raw/missing.raw"], $paths);
-		@unlink($outside);
+			$paths = pfb_unbound_py_manifest_raw_paths($manifest);
+			$this->assertSame(["{$this->tmpDir}/raw/missing.raw"], $paths);
+		} finally {
+			@unlink($outside);
+		}
 	}
 
 	/**

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -227,14 +227,18 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		$patchPid = pcntl_fork();
 		if ($patchPid === 0) {
 			fclose($patchParent);
-			fwrite($patchChild, "STARTED\n");
-			$ok = pfb_unbound_python_sources_patch('user_unlock', ['allow.example']);
+			$ok = pfb_unbound_python_sources_patch('user_unlock', ['allow.example'], [
+				'lock' => static function () use ($patchChild) {
+					fwrite($patchChild, "ATTEMPT\n");
+					return pfb_unbound_py_publication_lock();
+				},
+			]);
 			fwrite($patchChild, $ok ? "DONE\n" : "FAILED\n");
 			fclose($patchChild);
 			exit($ok ? 0 : 1);
 		}
 		fclose($patchChild);
-		$this->assertSame("STARTED\n", fgets($patchParent));
+		$this->assertSame("ATTEMPT\n", fgets($patchParent));
 		$read = [$patchParent];
 		$write = NULL;
 		$except = NULL;

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+#[CoversFunction('pfb_unbound_python_sources')]
+#[CoversFunction('pfb_unbound_python_sources_patch')]
+#[CoversFunction('pfb_unbound_py_gc')]
+#[CoversFunction('pfb_unbound_py_teardown_raw_set')]
+final class DnsblManifestAtomicGenerationTest extends TestCase
+{
+	private string $tmp;
+	private array $originalPfb = [];
+	private bool $hadPfb = FALSE;
+
+	protected function setUp(): void
+	{
+		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->tmp = sys_get_temp_dir() . '/pfb_generation_' . uniqid('', TRUE);
+		mkdir("{$this->tmp}/dnsbl", 0777, TRUE);
+		mkdir("{$this->tmp}/db", 0777, TRUE);
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'log'                => "{$this->tmp}/pfblockerng.log",
+			'errlog'             => "{$this->tmp}/error.log",
+			'dnsbldir'           => $this->tmp,
+			'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
+			'dnsdir'             => "{$this->tmp}/dnsbl",
+			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
+			'dbdir'              => "{$this->tmp}/db",
+			'dnsbl_top1m'        => 'off',
+			'dnsbl_tld_data'     => "{$this->tmp}/does_not_exist",
+			'dnsbl_unlock'       => "{$this->tmp}/dnsbl_unlock",
+			'dnsbl_tld_wildcard' => '',
+			'dnsblconfig'        => ['tldblacklist' => '', 'tldexclusion' => '', 'suppression' => ''],
+		]);
+		$this->writeFeed('one.example');
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['pfb_test_process_running']);
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		rmdir_recursive($this->tmp);
+	}
+
+	private function writeFeed(string $domain): void
+	{
+		file_put_contents("{$this->tmp}/dnsbl/feed1.txt",
+			pfb_dnsbl_ndjson_emit_domain_row($domain, '1', 'Feed', 'Group'));
+	}
+
+	private function publish(): array|false
+	{
+		return pfb_unbound_python_sources([
+			['header' => 'feed1', 'group' => 'Group', 'log' => '1', 'provenance' => 'feed'],
+		]);
+	}
+
+	private function manifestRaw(array $manifest): string
+	{
+		return "{$this->tmp}/{$manifest['feeds'][0]['raw']}";
+	}
+
+	private function versionDirs(): array
+	{
+		$dirs = glob("{$this->tmp}/pfb_py_raw.*") ?: [];
+		return array_values(array_filter($dirs,
+			static fn(string $path): bool => preg_match('/pfb_py_raw\.[0-9a-f]{32}$/D', $path) === 1));
+	}
+
+	public function testSuccessfulPublicationKeepsOldSetAndCommitsOneCompleteGeneration(): void
+	{
+		mkdir($GLOBALS['pfb']['unbound_py_rawdir']);
+		file_put_contents("{$GLOBALS['pfb']['unbound_py_rawdir']}/old.raw", 'old-bytes');
+		$oldManifest = json_encode(['version' => 1, 'config' => [], 'feeds' => [
+			['raw' => 'pfb_py_raw/old.raw', 'feed' => 'Old'],
+		]], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+		file_put_contents($GLOBALS['pfb']['unbound_py_sources'], $oldManifest);
+
+		$manifest = $this->publish();
+
+		$this->assertIsArray($manifest);
+		$this->assertMatchesRegularExpression('/^pfb_py_raw\.[0-9a-f]{32}\/feed1\.raw$/D', $manifest['feeds'][0]['raw']);
+		$this->assertSame("one.example\n", file_get_contents($this->manifestRaw($manifest)));
+		$this->assertSame('old-bytes', file_get_contents("{$GLOBALS['pfb']['unbound_py_rawdir']}/old.raw"));
+		$this->assertSame($manifest, json_decode((string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']), TRUE));
+		$this->assertSame([], glob("{$this->tmp}/pfb_py_raw.stage.*") ?: []);
+		$diskBytes = filesize("{$GLOBALS['pfb']['unbound_py_rawdir']}/old.raw")
+			+ filesize($this->manifestRaw($manifest)) + filesize($GLOBALS['pfb']['unbound_py_sources']);
+		$this->assertSame(9 + 12 + filesize($GLOBALS['pfb']['unbound_py_sources']), $diskBytes);
+	}
+
+	public function testExactExistingGenerationIsReusedWithoutStageLeak(): void
+	{
+		$first = $this->publish();
+		$this->assertIsArray($first);
+		$firstRaw = $this->manifestRaw($first);
+		$inode = fileinode($firstRaw);
+
+		$second = $this->publish();
+
+		$this->assertSame($first['feeds'][0]['raw'], $second['feeds'][0]['raw']);
+		$this->assertSame($inode, fileinode($this->manifestRaw($second)));
+		$this->assertCount(1, $this->versionDirs());
+		$this->assertSame([], glob("{$this->tmp}/pfb_py_raw.stage.*") ?: []);
+	}
+
+	public function testCorruptExistingGenerationFailsWithoutChangingOldPublication(): void
+	{
+		$old = $this->publish();
+		$this->assertIsArray($old);
+		$oldJson = (string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
+		$oldRaw = (string) file_get_contents($this->manifestRaw($old));
+
+		$this->writeFeed('two.example');
+		$new = $this->publish();
+		$this->assertIsArray($new);
+		file_put_contents($this->manifestRaw($new), 'corrupt');
+		file_put_contents($GLOBALS['pfb']['unbound_py_sources'], $oldJson);
+
+		$this->assertFalse($this->publish());
+		$this->assertSame($oldJson, file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
+		$this->assertSame($oldRaw, file_get_contents($this->manifestRaw($old)));
+		$this->assertSame('corrupt', file_get_contents($this->manifestRaw($new)), 'immutable collision target must not be changed');
+		$this->assertSame([], glob("{$this->tmp}/pfb_py_raw.stage.*") ?: []);
+	}
+
+	public function testLockAndSourceFailuresLeavePublishedStateUntouched(): void
+	{
+		$old = $this->publish();
+		$this->assertIsArray($old);
+		$oldJson = (string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
+		$oldRaw = (string) file_get_contents($this->manifestRaw($old));
+
+		$originalManifestPath = $GLOBALS['pfb']['unbound_py_sources'];
+		file_put_contents("{$this->tmp}/not-a-directory", 'x');
+		$GLOBALS['pfb']['unbound_py_sources'] = "{$this->tmp}/not-a-directory/manifest.json";
+		$this->assertFalse($this->publish(), 'lock parent regular file must fail closed');
+		$GLOBALS['pfb']['unbound_py_sources'] = $originalManifestPath;
+
+		unlink("{$this->tmp}/dnsbl/feed1.txt");
+		mkdir("{$this->tmp}/dnsbl/feed1.txt");
+		$this->assertFalse($this->publish(), 'source open/read failure must abort the generation');
+		$this->assertSame($oldJson, file_get_contents($originalManifestPath));
+		$this->assertSame($oldRaw, file_get_contents($this->manifestRaw($old)));
+		$this->assertSame([], glob("{$this->tmp}/pfb_py_raw.stage.*") ?: []);
+	}
+
+	public function testScalarPatchPreservesRawReferencesAndSerializesOnPublicationLock(): void
+	{
+		$manifest = $this->publish();
+		$this->assertIsArray($manifest);
+		$rawRefs = array_column($manifest['feeds'], 'raw');
+		[$holderParent, $holderChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+		stream_set_timeout($holderParent, 5);
+		stream_set_timeout($holderChild, 5);
+		$holderPid = pcntl_fork();
+		if ($holderPid === 0) {
+			fclose($holderParent);
+			$lock = pfb_unbound_py_publication_lock();
+			fwrite($holderChild, "LOCKED\n");
+			fgets($holderChild);
+			pfb_unbound_py_publication_unlock($lock);
+			fclose($holderChild);
+			exit(0);
+		}
+		fclose($holderChild);
+		$this->assertSame("LOCKED\n", fgets($holderParent));
+
+		[$patchParent, $patchChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+		stream_set_timeout($patchParent, 5);
+		stream_set_timeout($patchChild, 5);
+		$patchPid = pcntl_fork();
+		if ($patchPid === 0) {
+			fclose($patchParent);
+			fwrite($patchChild, "STARTED\n");
+			$ok = pfb_unbound_python_sources_patch('user_unlock', ['allow.example']);
+			fwrite($patchChild, $ok ? "DONE\n" : "FAILED\n");
+			fclose($patchChild);
+			exit($ok ? 0 : 1);
+		}
+		fclose($patchChild);
+		$this->assertSame("STARTED\n", fgets($patchParent));
+		fwrite($holderParent, "RELEASE\n");
+		$this->assertSame("DONE\n", fgets($patchParent));
+		pcntl_waitpid($holderPid, $holderStatus);
+		pcntl_waitpid($patchPid, $patchStatus);
+		$this->assertTrue(pcntl_wifexited($holderStatus) && pcntl_wexitstatus($holderStatus) === 0);
+		$this->assertTrue(pcntl_wifexited($patchStatus) && pcntl_wexitstatus($patchStatus) === 0);
+		$patched = json_decode((string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']), TRUE);
+		$this->assertSame($rawRefs, array_column($patched['feeds'], 'raw'));
+		$this->assertSame(['allow.example'], $patched['config']['user_unlock']);
+	}
+
+	public function testGarbageCollectionRequiresConvergenceAndProtectsCurrentGeneration(): void
+	{
+		$first = $this->publish();
+		$this->assertIsArray($first);
+		$this->writeFeed('two.example');
+		$second = $this->publish();
+		$this->assertIsArray($second);
+		$stage = "{$this->tmp}/pfb_py_raw.stage.abcdef0123456789abcdef0123456789";
+		mkdir($stage);
+
+		$this->assertFalse(pfb_unbound_py_gc(FALSE));
+		$this->assertDirectoryExists(dirname($this->manifestRaw($first)));
+		$this->assertDirectoryExists($stage);
+
+		$GLOBALS['pfb_test_process_running'] = ['unbound' => TRUE];
+		file_put_contents("{$this->tmp}/unbound.conf", "python-script: /var/unbound/pfb_unbound.py\n");
+		$this->assertTrue(pfb_dnsbl_converged());
+		$this->assertTrue(pfb_unbound_py_gc(TRUE));
+		$this->assertDirectoryDoesNotExist(dirname($this->manifestRaw($first)));
+		$this->assertDirectoryDoesNotExist($stage);
+		$this->assertSame("two.example\n", file_get_contents($this->manifestRaw($second)));
+	}
+
+	public function testTeardownRemovesOnlyStrictRawArtifactsAndManifest(): void
+	{
+		$manifest = $this->publish();
+		$this->assertIsArray($manifest);
+		mkdir($GLOBALS['pfb']['unbound_py_rawdir']);
+		mkdir("{$this->tmp}/pfb_py_raw.stage.abcdef0123456789abcdef0123456789");
+		mkdir("{$this->tmp}/pfb_py_raw.neighbor");
+
+		$this->assertTrue(pfb_unbound_py_teardown_raw_set());
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['unbound_py_sources']);
+		$this->assertDirectoryDoesNotExist(dirname($this->manifestRaw($manifest)));
+		$this->assertDirectoryDoesNotExist($GLOBALS['pfb']['unbound_py_rawdir']);
+		$this->assertSame([], glob("{$this->tmp}/pfb_py_raw.stage.*") ?: []);
+		$this->assertDirectoryExists("{$this->tmp}/pfb_py_raw.neighbor");
+	}
+}

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -56,11 +56,11 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			pfb_dnsbl_ndjson_emit_domain_row($domain, '1', 'Feed', 'Group'));
 	}
 
-	private function publish(): array|false
+	private function publish(array $publicationOps = []): array|false
 	{
 		return pfb_unbound_python_sources([
 			['header' => 'feed1', 'group' => 'Group', 'log' => '1', 'provenance' => 'feed'],
-		]);
+		], $publicationOps);
 	}
 
 	private function manifestRaw(array $manifest): string
@@ -153,6 +153,53 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		$this->assertSame([], glob("{$this->tmp}/pfb_py_raw.stage.*") ?: []);
 	}
 
+	public function testInjectedPublicationBoundariesPreservePriorGeneration(): void
+	{
+		$old = $this->publish();
+		$this->assertIsArray($old);
+		$oldJson = (string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
+		$oldRaw = (string) file_get_contents($this->manifestRaw($old));
+		$oldDirs = $this->versionDirs();
+		$this->writeFeed('two.example');
+
+		$this->assertFalse($this->publish([
+			'stage_mkdir' => static fn(string $dir, int $mode): bool => FALSE,
+		]), 'staging failure must abort');
+		$this->assertFalse($this->publish([
+			'generation_rename' => static fn(string $from, string $to): bool => FALSE,
+		]), 'generation rename failure must abort');
+		$this->assertIsArray($this->publish([
+			'manifest_atomic' => [
+				'rename' => static fn(string $from, string $to): bool => FALSE,
+			],
+		]), 'manifest rename failure still returns the generated in-memory manifest');
+
+		$this->assertSame($oldJson, file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
+		$this->assertSame($oldRaw, file_get_contents($this->manifestRaw($old)));
+		$this->assertSame($oldDirs, $this->versionDirs(), 'failed boundaries must not leak raw generations');
+		$this->assertSame([], glob("{$this->tmp}/pfb_py_raw.stage.*") ?: []);
+	}
+
+	public function testRepeatedEncodeFailuresDoNotAccumulateUnreferencedGenerations(): void
+	{
+		$old = $this->publish();
+		$this->assertIsArray($old);
+		$oldJson = (string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
+		$oldRaw = (string) file_get_contents($this->manifestRaw($old));
+		$oldDirs = $this->versionDirs();
+
+		foreach (['two.example', 'three.example'] as $domain) {
+			$this->writeFeed($domain);
+			$generated = pfb_unbound_python_sources([
+				['header' => 'feed1', 'group' => NAN, 'log' => '1', 'provenance' => 'feed'],
+			]);
+			$this->assertIsArray($generated);
+			$this->assertSame($oldJson, file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
+			$this->assertSame($oldRaw, file_get_contents($this->manifestRaw($old)));
+			$this->assertSame($oldDirs, $this->versionDirs(), 'encode failure leaked a raw generation');
+		}
+	}
+
 	public function testScalarPatchPreservesRawReferencesAndSerializesOnPublicationLock(): void
 	{
 		$manifest = $this->publish();
@@ -188,6 +235,11 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		}
 		fclose($patchChild);
 		$this->assertSame("STARTED\n", fgets($patchParent));
+		$read = [$patchParent];
+		$write = NULL;
+		$except = NULL;
+		$this->assertSame(0, stream_select($read, $write, $except, 0, 200000),
+			'patch completed before the publication lock was released');
 		fwrite($holderParent, "RELEASE\n");
 		$this->assertSame("DONE\n", fgets($patchParent));
 		pcntl_waitpid($holderPid, $holderStatus);
@@ -219,6 +271,28 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		$this->assertTrue(pfb_unbound_py_gc(TRUE));
 		$this->assertDirectoryDoesNotExist(dirname($this->manifestRaw($first)));
 		$this->assertDirectoryDoesNotExist($stage);
+		$this->assertSame("two.example\n", file_get_contents($this->manifestRaw($second)));
+	}
+
+	public function testGarbageCollectionAcceptsDuplicateValidRawReferences(): void
+	{
+		$feeds = [
+			['header' => 'feed1', 'group' => 'Group A', 'log' => '1', 'provenance' => 'feed'],
+			['header' => 'feed1', 'group' => 'Group B', 'log' => '1', 'provenance' => 'feed'],
+		];
+		$first = pfb_unbound_python_sources($feeds);
+		$this->assertIsArray($first);
+		$this->assertCount(2, $first['feeds']);
+		$this->assertSame($first['feeds'][0]['raw'], $first['feeds'][1]['raw']);
+
+		$this->writeFeed('two.example');
+		$second = pfb_unbound_python_sources($feeds);
+		$this->assertIsArray($second);
+		$this->assertCount(2, $this->versionDirs());
+
+		$this->assertTrue(pfb_unbound_py_gc(TRUE));
+		$this->assertDirectoryDoesNotExist(dirname($this->manifestRaw($first)));
+		$this->assertDirectoryExists(dirname($this->manifestRaw($second)));
 		$this->assertSame("two.example\n", file_get_contents($this->manifestRaw($second)));
 	}
 

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -205,51 +205,77 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		$manifest = $this->publish();
 		$this->assertIsArray($manifest);
 		$rawRefs = array_column($manifest['feeds'], 'raw');
-		[$holderParent, $holderChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
-		stream_set_timeout($holderParent, 5);
-		stream_set_timeout($holderChild, 5);
-		$holderPid = pcntl_fork();
-		if ($holderPid === 0) {
-			fclose($holderParent);
-			$lock = pfb_unbound_py_publication_lock();
-			fwrite($holderChild, "LOCKED\n");
-			fgets($holderChild);
-			pfb_unbound_py_publication_unlock($lock);
+		$holderPid = NULL;
+		$patchPid = NULL;
+		$holderParent = NULL;
+		$patchParent = NULL;
+		try {
+			[$holderParent, $holderChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+			stream_set_timeout($holderParent, 5);
+			stream_set_timeout($holderChild, 5);
+			$holderPid = pcntl_fork();
+			if ($holderPid === 0) {
+				fclose($holderParent);
+				$lock = pfb_unbound_py_publication_lock();
+				fwrite($holderChild, "LOCKED\n");
+				fgets($holderChild);
+				pfb_unbound_py_publication_unlock($lock);
+				fclose($holderChild);
+				exit(0);
+			}
+			$this->assertGreaterThan(0, $holderPid);
 			fclose($holderChild);
-			exit(0);
-		}
-		fclose($holderChild);
-		$this->assertSame("LOCKED\n", fgets($holderParent));
+			$this->assertSame("LOCKED\n", fgets($holderParent));
 
-		[$patchParent, $patchChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
-		stream_set_timeout($patchParent, 5);
-		stream_set_timeout($patchChild, 5);
-		$patchPid = pcntl_fork();
-		if ($patchPid === 0) {
-			fclose($patchParent);
-			$ok = pfb_unbound_python_sources_patch('user_unlock', ['allow.example'], [
-				'lock' => static function () use ($patchChild) {
-					fwrite($patchChild, "ATTEMPT\n");
-					return pfb_unbound_py_publication_lock();
-				},
-			]);
-			fwrite($patchChild, $ok ? "DONE\n" : "FAILED\n");
+			[$patchParent, $patchChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+			stream_set_timeout($patchParent, 5);
+			stream_set_timeout($patchChild, 5);
+			$patchPid = pcntl_fork();
+			if ($patchPid === 0) {
+				fclose($patchParent);
+				$ok = pfb_unbound_python_sources_patch('user_unlock', ['allow.example'], [
+					'lock' => static function () use ($patchChild) {
+						fwrite($patchChild, "ATTEMPT\n");
+						return pfb_unbound_py_publication_lock();
+					},
+				]);
+				fwrite($patchChild, $ok ? "DONE\n" : "FAILED\n");
+				fclose($patchChild);
+				exit($ok ? 0 : 1);
+			}
+			$this->assertGreaterThan(0, $patchPid);
 			fclose($patchChild);
-			exit($ok ? 0 : 1);
+			$this->assertSame("ATTEMPT\n", fgets($patchParent));
+			$read = [$patchParent];
+			$write = NULL;
+			$except = NULL;
+			$this->assertSame(0, stream_select($read, $write, $except, 0, 200000),
+				'patch completed before the publication lock was released');
+			fwrite($holderParent, "RELEASE\n");
+			$this->assertSame("DONE\n", fgets($patchParent));
+			pcntl_waitpid($holderPid, $holderStatus);
+			$holderPid = NULL;
+			pcntl_waitpid($patchPid, $patchStatus);
+			$patchPid = NULL;
+			$this->assertTrue(pcntl_wifexited($holderStatus) && pcntl_wexitstatus($holderStatus) === 0);
+			$this->assertTrue(pcntl_wifexited($patchStatus) && pcntl_wexitstatus($patchStatus) === 0);
+		} finally {
+			if (is_resource($holderParent)) {
+				@fwrite($holderParent, "RELEASE\n");
+				fclose($holderParent);
+			}
+			if (is_resource($patchParent)) {
+				fclose($patchParent);
+			}
+			foreach ([$holderPid, $patchPid] as $pid) {
+				if (is_int($pid) && $pid > 0) {
+					if (pcntl_waitpid($pid, $childStatus, WNOHANG) === 0 && function_exists('posix_kill')) {
+						posix_kill($pid, SIGKILL);
+					}
+					pcntl_waitpid($pid, $childStatus);
+				}
+			}
 		}
-		fclose($patchChild);
-		$this->assertSame("ATTEMPT\n", fgets($patchParent));
-		$read = [$patchParent];
-		$write = NULL;
-		$except = NULL;
-		$this->assertSame(0, stream_select($read, $write, $except, 0, 200000),
-			'patch completed before the publication lock was released');
-		fwrite($holderParent, "RELEASE\n");
-		$this->assertSame("DONE\n", fgets($patchParent));
-		pcntl_waitpid($holderPid, $holderStatus);
-		pcntl_waitpid($patchPid, $patchStatus);
-		$this->assertTrue(pcntl_wifexited($holderStatus) && pcntl_wexitstatus($holderStatus) === 0);
-		$this->assertTrue(pcntl_wifexited($patchStatus) && pcntl_wexitstatus($patchStatus) === 0);
 		$patched = json_decode((string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']), TRUE);
 		$this->assertSame($rawRefs, array_column($patched['feeds'], 'raw'));
 		$this->assertSame(['allow.example'], $patched['config']['user_unlock']);

--- a/tests/php/DnsblManifestPublishFailureNoticeTest.php
+++ b/tests/php/DnsblManifestPublishFailureNoticeTest.php
@@ -6,14 +6,13 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * ADR-65: a DNSBL manifest publish failure (the atomic write pfb_unbound_python_sources()
- * performs) must surface loudly -- pfb_logger() + file_notice(), mirroring the existing
+ * ADR-65: a DNSBL manifest publication failure (including its serialization lock)
+ * must surface loudly -- pfb_logger() + file_notice(), mirroring the existing
  * MaxMind/VIP credential-notice pattern (issue #331) -- never silently swallowed as it was
  * before this phase.
  *
- * Drives the REAL pfb_unbound_python_sources(array()) (the no-feeds shape, so no raw file
- * is written -- only the manifest publish itself is exercised) with 'unbound_py_sources'
- * pointed at a read-only directory, so the underlying tempnam()/fopen() genuinely fails.
+ * Drives the REAL pfb_unbound_python_sources(array()) with 'unbound_py_sources' pointed
+ * at a read-only directory, so publication-lock creation genuinely fails.
  */
 #[CoversFunction('pfb_unbound_python_sources')]
 final class DnsblManifestPublishFailureNoticeTest extends TestCase
@@ -71,7 +70,7 @@ final class DnsblManifestPublishFailureNoticeTest extends TestCase
 
 	public function testPublishFailureIntoReadOnlyDirFiresANotice(): void
 	{
-		pfb_unbound_python_sources(array());
+		$this->assertFalse(pfb_unbound_python_sources(array()));
 
 		$this->assertCount(1, $GLOBALS['pfb_test_file_notices'], 'exactly one notice raised on publish failure');
 		$notice = $GLOBALS['pfb_test_file_notices'][0];

--- a/tests/php/DnsblStagingGenerationGuardTest.php
+++ b/tests/php/DnsblStagingGenerationGuardTest.php
@@ -196,10 +196,11 @@ final class DnsblStagingGenerationGuardTest extends TestCase
 		try {
 			// Given: the fork VERBATIM-REUSED this stale file (today's pre-guard
 			// behaviour) -- pfb_unbound_python_sources() reads it as-is.
-			pfb_unbound_python_sources([
+			$manifest = pfb_unbound_python_sources([
 				['header' => $header, 'group' => 'G', 'log' => '1', 'provenance' => 'feed'],
 			]);
-			$raw = @file_get_contents("{$tmp}/pfb_py_raw/{$header}.raw");
+			$this->assertIsArray($manifest);
+			$raw = @file_get_contents("{$tmp}/{$manifest['feeds'][0]['raw']}");
 			$this->assertSame('', $raw, 'old-dialect verbatim reuse silently blanks the feed (#1105)');
 
 			// Then: the guard's decision for this exact file vetoes that reuse.

--- a/tests/php/UnboundPyPublishTest.php
+++ b/tests/php/UnboundPyPublishTest.php
@@ -23,15 +23,15 @@ final class UnboundPyPublishTest extends TestCase
 {
 	private string $tmp;
 	private array $originalPfb = [];
-	private bool $hadPfb = false;
+	private bool $hadPfb = FALSE;
 
 	protected function setUp(): void
 	{
 		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
 
-		$this->tmp = sys_get_temp_dir() . '/pfb_publish_' . uniqid('', true);
-		mkdir($this->tmp, 0777, true);
+		$this->tmp = sys_get_temp_dir() . '/pfb_publish_' . uniqid('', TRUE);
+		mkdir($this->tmp, 0777, TRUE);
 
 		// dnsbldir is the chroot root; the sentinel lives at "{dnsbldir}/pfb_py_reload".
 		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
@@ -134,10 +134,12 @@ final class UnboundPyPublishTest extends TestCase
 		$short = static fn($stream, string $bytes): int => strlen($bytes) - 1;
 		$yes = static fn($stream): bool => TRUE;
 		$no = static fn($stream): bool => FALSE;
+		$renameNo = static fn(string $from, string $to): bool => FALSE;
 		$failures = [
 			'short write' => ['write' => $short, 'flush' => $yes, 'fsync' => $yes],
 			'flush' => ['write' => $full, 'flush' => $no, 'fsync' => $yes],
 			'fsync' => ['write' => $full, 'flush' => $yes, 'fsync' => $no],
+			'rename' => ['rename' => $renameNo],
 		];
 
 		foreach ($failures as $label => $ops) {

--- a/tests/php/UnboundPyPublishTest.php
+++ b/tests/php/UnboundPyPublishTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
  * Run against a temp $pfb sandbox (no live box, no chroot).
  */
 #[CoversFunction('pfb_unbound_py_atomic_write')]
+#[CoversFunction('pfb_unbound_py_stream_sync')]
 #[CoversFunction('pfb_unbound_py_flip_sentinel')]
 #[CoversFunction('pfb_unbound_py_wait_applied')]
 final class UnboundPyPublishTest extends TestCase
@@ -108,6 +109,43 @@ final class UnboundPyPublishTest extends TestCase
 		$this->assertFalse(
 			pfb_unbound_py_atomic_write("{$this->tmp}/nope/deep/manifest.json", 'x')
 		);
+	}
+
+	public function testStreamSyncRejectsShortWriteFlushAndFsyncFailures(): void
+	{
+		$fh = tmpfile();
+		$this->assertIsResource($fh);
+		$full = static fn($stream, string $bytes): int => strlen($bytes);
+		$short = static fn($stream, string $bytes): int => strlen($bytes) - 1;
+		$yes = static fn($stream): bool => TRUE;
+		$no = static fn($stream): bool => FALSE;
+
+		$this->assertFalse(pfb_unbound_py_stream_sync($fh, 'abc', $short, $yes, $yes));
+		$this->assertFalse(pfb_unbound_py_stream_sync($fh, 'abc', $full, $no, $yes));
+		$this->assertFalse(pfb_unbound_py_stream_sync($fh, 'abc', $full, $yes, $no));
+		$this->assertTrue(pfb_unbound_py_stream_sync($fh, 'abc', $full, $yes, $yes));
+		fclose($fh);
+	}
+
+	public function testAtomicWriteFailuresKeepOldFileAndCleanTemporaryFile(): void
+	{
+		$path = "{$this->tmp}/manifest.json";
+		$full = static fn($stream, string $bytes): int => strlen($bytes);
+		$short = static fn($stream, string $bytes): int => strlen($bytes) - 1;
+		$yes = static fn($stream): bool => TRUE;
+		$no = static fn($stream): bool => FALSE;
+		$failures = [
+			'short write' => ['write' => $short, 'flush' => $yes, 'fsync' => $yes],
+			'flush' => ['write' => $full, 'flush' => $no, 'fsync' => $yes],
+			'fsync' => ['write' => $full, 'flush' => $yes, 'fsync' => $no],
+		];
+
+		foreach ($failures as $label => $ops) {
+			file_put_contents($path, 'OLD');
+			$this->assertFalse(pfb_unbound_py_atomic_write($path, 'NEW', $ops), $label);
+			$this->assertSame('OLD', file_get_contents($path), "{$label} changed the published file");
+			$this->assertSame([], glob("{$this->tmp}/.pfbpub_*") ?: [], "{$label} leaked a temp file");
+		}
 	}
 
 	// --- sentinel flip (the generation contract) ----------------------------

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -34,8 +34,10 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_dnsbl_whitelist_lines')]
 final class UnboundPythonSourcesTest extends TestCase
 {
+	private const OLD_GENERATION = 'pfb_py_raw.0123456789abcdef0123456789abcdef';
+
 	private string $tmp;
-	private bool $hadPfb = false;
+	private bool $hadPfb = FALSE;
 	private array $originalPfb = [];
 
 	protected function setUp(): void
@@ -45,9 +47,9 @@ final class UnboundPythonSourcesTest extends TestCase
 		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
 
-		$this->tmp = sys_get_temp_dir() . '/pfb_sources_' . uniqid('', true);
-		mkdir("{$this->tmp}/dnsbl", 0777, true);
-		mkdir("{$this->tmp}/db", 0777, true);
+		$this->tmp = sys_get_temp_dir() . '/pfb_sources_' . uniqid('', TRUE);
+		mkdir("{$this->tmp}/dnsbl", 0777, TRUE);
+		mkdir("{$this->tmp}/db", 0777, TRUE);
 
 		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
 			'log'                => "{$this->tmp}/pfblockerng.log",
@@ -271,7 +273,7 @@ final class UnboundPythonSourcesTest extends TestCase
 	{
 		$m = pfb_unbound_python_sources($this->feeds());
 		$json = file_get_contents("{$this->tmp}/pfb_py_sources.json");
-		$this->assertSame($m, json_decode($json, true));
+		$this->assertSame($m, json_decode($json, TRUE));
 	}
 
 	// #51: a FULL build CLEARS the temporary unlock set even when the live store has
@@ -306,7 +308,7 @@ final class UnboundPythonSourcesTest extends TestCase
 		file_put_contents("{$this->tmp}/dnsbl_unlock", "evil.com,python\nfoo.org,python\n");
 		$this->assertTrue(pfb_unbound_python_sources_unlock());
 
-		$patched = json_decode(file_get_contents("{$this->tmp}/pfb_py_sources.json"), true);
+		$patched = json_decode(file_get_contents("{$this->tmp}/pfb_py_sources.json"), TRUE);
 		$this->assertSame(['evil.com', 'foo.org'], $patched['config']['user_unlock']);
 		// The feeds and the rest of config are untouched by the in-place patch.
 		$this->assertSame($m['feeds'], $patched['feeds']);
@@ -326,7 +328,7 @@ final class UnboundPythonSourcesTest extends TestCase
 
 		unlink("{$this->tmp}/dnsbl_unlock");           // store emptied (lock / Cron / Force)
 		$this->assertTrue(pfb_unbound_python_sources_unlock());
-		$patched = json_decode(file_get_contents("{$this->tmp}/pfb_py_sources.json"), true);
+		$patched = json_decode(file_get_contents("{$this->tmp}/pfb_py_sources.json"), TRUE);
 		$this->assertSame([], $patched['config']['user_unlock']);
 	}
 
@@ -360,7 +362,7 @@ final class UnboundPythonSourcesTest extends TestCase
 				'user_unlock' => [],
 			],
 			'feeds' => [[
-				'raw' => 'pfb_py_raw/old.raw',
+				'raw' => self::OLD_GENERATION . '/old.raw',
 				'feed' => 'old-feed-secret',
 			]],
 		];
@@ -406,8 +408,9 @@ final class UnboundPythonSourcesTest extends TestCase
 	#[DataProvider('malformedUtf8Values')]
 	public function testFullManifestSubstitutesMalformedUtf8AndPublishes(string $invalid): void
 	{
-		mkdir($GLOBALS['pfb']['unbound_py_rawdir'], 0777, true);
-		file_put_contents("{$GLOBALS['pfb']['unbound_py_rawdir']}/old.raw", 'old-raw-secret');
+		$old_generation = dirname($GLOBALS['pfb']['unbound_py_rawdir']) . '/' . self::OLD_GENERATION;
+		mkdir($old_generation, 0777, TRUE);
+		file_put_contents("{$old_generation}/old.raw", 'old-raw-secret');
 		$old = $this->seedManifest();
 		$GLOBALS['pfb']['dnsbl_top1m'] = 'on';
 		file_put_contents("{$this->tmp}/db/pfbalexawhitelist.txt", $invalid . "\n");
@@ -415,22 +418,23 @@ final class UnboundPythonSourcesTest extends TestCase
 		pfb_unbound_python_sources([]);
 
 		$published = (string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
-		$decoded = json_decode($published, true);
+		$decoded = json_decode($published, TRUE);
 		$this->assertSame(JSON_ERROR_NONE, json_last_error(), 'the replacement manifest must be valid JSON');
 		$this->assertNotSame($old, $published, 'the stale manifest must be replaced');
 		$this->assertSame(["\u{FFFD}"], $decoded['config']['top1m_list']);
 		$this->assertSame(1, substr_count($published, '\\ufffd'), 'one malformed sequence must emit one replacement');
 		$this->assertSame(
 			'old-raw-secret',
-			file_get_contents("{$GLOBALS['pfb']['unbound_py_rawdir']}/old.raw"),
+			file_get_contents("{$old_generation}/old.raw"),
 			'the old generation remains readable until confirmed-apply garbage collection'
 		);
 	}
 
 	public function testFullManifestResidualEncodingFailureLogsGenericErrorAndKeepsOldManifest(): void
 	{
-		mkdir($GLOBALS['pfb']['unbound_py_rawdir'], 0777, true);
-		file_put_contents("{$GLOBALS['pfb']['unbound_py_rawdir']}/old.raw", 'old-raw-secret');
+		$old_generation = dirname($GLOBALS['pfb']['unbound_py_rawdir']) . '/' . self::OLD_GENERATION;
+		mkdir($old_generation, 0777, TRUE);
+		file_put_contents("{$old_generation}/old.raw", 'old-raw-secret');
 		$old = $this->seedManifest();
 
 		$manifest = pfb_unbound_python_sources([
@@ -440,7 +444,7 @@ final class UnboundPythonSourcesTest extends TestCase
 
 		$this->assertTrue(is_nan($manifest['feeds'][0]['group']), 'the full writer must keep returning the generated manifest');
 		$this->assertSame($old, file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
-		$this->assertSame('old-raw-secret', file_get_contents("{$GLOBALS['pfb']['unbound_py_rawdir']}/old.raw"));
+		$this->assertSame('old-raw-secret', file_get_contents("{$old_generation}/old.raw"));
 		$published = json_decode((string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']), TRUE);
 		$this->assertIsArray($published);
 		foreach ($published['feeds'] as $feed) {
@@ -474,7 +478,7 @@ final class UnboundPythonSourcesTest extends TestCase
 	public function testManifestPatchValidInputsKeepLegacyJsonBytes(string $key, array $values): void
 	{
 		$old = $this->seedManifest();
-		$expected = json_decode($old, true);
+		$expected = json_decode($old, TRUE);
 		$expected['config'][$key] = $values;
 		$legacy = json_encode($expected, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
@@ -505,7 +509,7 @@ final class UnboundPythonSourcesTest extends TestCase
 		$this->assertTrue(pfb_unbound_python_sources_patch($key, [$invalid]));
 
 		$published = (string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
-		$decoded = json_decode($published, true);
+		$decoded = json_decode($published, TRUE);
 		$this->assertSame(JSON_ERROR_NONE, json_last_error(), 'the patched manifest must be valid JSON');
 		$this->assertSame(["\u{FFFD}"], $decoded['config'][$key]);
 		$this->assertSame(1, substr_count($published, '\\ufffd'), 'one malformed sequence must emit one replacement');

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -100,6 +100,16 @@ final class UnboundPythonSourcesTest extends TestCase
 		];
 	}
 
+	private function rawPath(array $manifest, string $feed): string
+	{
+		foreach ($manifest['feeds'] as $row) {
+			if ($row['feed'] === $feed) {
+				return dirname($GLOBALS['pfb']['unbound_py_sources']) . "/{$row['raw']}";
+			}
+		}
+		$this->fail("manifest has no feed row for {$feed}");
+	}
+
 	public function testManifestStructureAndTagging(): void
 	{
 		$m = pfb_unbound_python_sources($this->feeds());
@@ -117,8 +127,7 @@ final class UnboundPythonSourcesTest extends TestCase
 		$this->assertSame($closedKeySet, array_keys(array_diff_key($plain, ['mode' => NULL])));
 		$this->assertSame('feed', $plain['provenance']);
 		$this->assertSame('1', $plain['log_flag']);
-		// chroot-relative: basename(rawdir)/<feed>.raw, never host-absolute.
-		$this->assertSame('pfb_py_raw/feed1.raw', $plain['raw']);
+		$this->assertMatchesRegularExpression('/^pfb_py_raw\.[0-9a-f]{32}\/feed1\.raw$/D', $plain['raw']);
 
 		// The 'abpfeed' NDJSON rows are 'abp'-kind; the writer routes their raw payload
 		// verbatim purely from the NDJSON kind tag, independent of any feed-level format.
@@ -126,7 +135,8 @@ final class UnboundPythonSourcesTest extends TestCase
 		$this->assertSame($closedKeySet, array_keys(array_diff_key($abp, ['mode' => NULL])));
 		$this->assertSame('user', $abp['provenance']);
 		$this->assertSame('0', $abp['log_flag']);
-		$this->assertSame('pfb_py_raw/abpfeed.raw', $abp['raw']);
+		$this->assertSame(dirname($plain['raw']), dirname($abp['raw']), 'all feed raws must share one generation');
+		$this->assertSame('abpfeed.raw', basename($abp['raw']));
 	}
 
 	public function testProvenanceDefaultsToFeedWhenUnset(): void
@@ -175,15 +185,15 @@ final class UnboundPythonSourcesTest extends TestCase
 
 	public function testPlainRawIsBareDomainColumn(): void
 	{
-		pfb_unbound_python_sources($this->feeds());
-		$raw = file_get_contents("{$this->tmp}/pfb_py_raw/feed1.raw");
+		$manifest = pfb_unbound_python_sources($this->feeds());
+		$raw = file_get_contents($this->rawPath($manifest, 'feed1'));
 		$this->assertSame("example.com\nfoo.com\n", $raw);
 	}
 
 	public function testAbpRawIsVerbatim(): void
 	{
-		pfb_unbound_python_sources($this->feeds());
-		$raw = file_get_contents("{$this->tmp}/pfb_py_raw/abpfeed.raw");
+		$manifest = pfb_unbound_python_sources($this->feeds());
+		$raw = file_get_contents($this->rawPath($manifest, 'abpfeed'));
 		$this->assertSame("||ads.example^\n@@||good.example^\n", $raw);
 	}
 
@@ -203,10 +213,10 @@ final class UnboundPythonSourcesTest extends TestCase
 		file_put_contents("{$this->tmp}/dnsbl/stalefeed.txt",
 			pfb_dnsbl_ndjson_emit_domain_row('legit.example', '1', 'f', 'g') .
 			"not valid ndjson,stale-block.example,stale2.example##.ad\n");
-		pfb_unbound_python_sources([
+		$manifest = pfb_unbound_python_sources([
 			['header' => 'stalefeed', 'group' => 'g', 'log' => '1', 'provenance' => 'feed'],
 		]);
-		$raw = file_get_contents("{$this->tmp}/pfb_py_raw/stalefeed.raw");
+		$raw = file_get_contents($this->rawPath($manifest, 'stalefeed'));
 		$this->assertSame(
 			"legit.example\n",
 			$raw,
@@ -410,9 +420,10 @@ final class UnboundPythonSourcesTest extends TestCase
 		$this->assertNotSame($old, $published, 'the stale manifest must be replaced');
 		$this->assertSame(["\u{FFFD}"], $decoded['config']['top1m_list']);
 		$this->assertSame(1, substr_count($published, '\\ufffd'), 'one malformed sequence must emit one replacement');
-		$this->assertFileDoesNotExist(
-			"{$GLOBALS['pfb']['unbound_py_rawdir']}/old.raw",
-			'the old manifest raw must still be removed before replacement publication'
+		$this->assertSame(
+			'old-raw-secret',
+			file_get_contents("{$GLOBALS['pfb']['unbound_py_rawdir']}/old.raw"),
+			'the old generation remains readable until confirmed-apply garbage collection'
 		);
 	}
 
@@ -429,7 +440,13 @@ final class UnboundPythonSourcesTest extends TestCase
 
 		$this->assertTrue(is_nan($manifest['feeds'][0]['group']), 'the full writer must keep returning the generated manifest');
 		$this->assertSame($old, file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
-		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['unbound_py_rawdir']}/old.raw");
+		$this->assertSame('old-raw-secret', file_get_contents("{$GLOBALS['pfb']['unbound_py_rawdir']}/old.raw"));
+		$published = json_decode((string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']), TRUE);
+		$this->assertIsArray($published);
+		foreach ($published['feeds'] as $feed) {
+			$raw_path = dirname($GLOBALS['pfb']['unbound_py_sources']) . "/{$feed['raw']}";
+			$this->assertFileExists($raw_path, "published raw reference must still resolve: {$feed['raw']}");
+		}
 		$this->assertSame('Inf and NaN cannot be JSON encoded', $error);
 		foreach ([$this->logContents(), $this->errorLogContents()] as $log) {
 			$this->assertStringContainsString('DNSBL manifest JSON encoding failed: ' . $error, $log);
@@ -539,11 +556,11 @@ final class UnboundPythonSourcesTest extends TestCase
 		$log = $this->logContents();
 		$this->assertStringContainsString('pfb_unbound_python_sources', $log);
 		$this->assertStringContainsString('Feed header failed validation', $log);
-		$this->assertFileDoesNotExist("{$this->tmp}/pfb_py_raw/bad.header.raw");
+		$this->assertFileDoesNotExist(dirname($this->rawPath($m, 'feed1')) . '/bad.header.raw');
 
 		// ... and the valid rows built exactly as in an all-valid run.
 		$this->assertSame("example.com\nfoo.com\n",
-			file_get_contents("{$this->tmp}/pfb_py_raw/feed1.raw"));
+			file_get_contents($this->rawPath($m, 'feed1')));
 	}
 
 	public function testAllValidHeadersBuildWithoutValidationLogging(): void

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -102,9 +102,14 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
   It 'save archives the generated set only (never the shipped files)'
     setup_sandbox
     dc stage
-    # A generated manifest + raw + ini present in the chroot.
-    echo '{"feeds":[]}' > "${pfbchroot}/pfb_py_sources.json"
-    echo 'rawdata' > "${pfbchroot}/pfb_py_raw"
+    # A generation-consistent manifest + versioned raw dir + stale stage.
+    generation='pfb_py_raw.0123456789abcdef0123456789abcdef'
+    stage='pfb_py_raw.stage.abcdef0123456789abcdef0123456789'
+    mkdir "${pfbchroot}/${generation}" "${pfbchroot}/${stage}"
+    echo 'rawdata' > "${pfbchroot}/${generation}/feed.raw"
+    echo 'partial' > "${pfbchroot}/${stage}/feed.raw"
+    echo "{\"feeds\":[{\"raw\":\"${generation}/feed.raw\"}]}" > "${pfbchroot}/pfb_py_sources.json"
+    : > "${pfbchroot}/pfb_py_sources.lock"
     echo 'ini' > "${pfbchroot}/pfb_unbound.ini"
     When call dc save
     # An archive was written (codec-agnostic).
@@ -112,6 +117,9 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     The path "$arc" should be exist
     # The archive carries the GENERATED files ...
     The result of "tar_list()" should include 'pfb_py_sources.json'
+    The result of "tar_list()" should include 'feed.raw'
+    The result of "tar_list()" should not include "${stage}"
+    The result of "tar_list()" should not include 'pfb_py_sources.lock'
     The result of "tar_list()" should include 'pfb_unbound.ini'
     # ... and NOT the shipped files (re-staged from /usr/local on restore).
     The result of "tar_list()" should not include 'pfb_py_hsts.txt'
@@ -155,6 +163,22 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     The contents of file "${pfbchroot}/pfb_unbound.py" should equal 'PY-CODE-v2'
     # Mount-point dirs are present again after restore.
     The path "${pfbchroot}/lib" should be directory
+    cleanup_sandbox
+  End
+
+  It 'restore round-trips a manifest with its referenced versioned raw generation'
+    setup_sandbox
+    dc stage
+    generation='pfb_py_raw.0123456789abcdef0123456789abcdef'
+    mkdir "${pfbchroot}/${generation}"
+    echo 'RAW-v1' > "${pfbchroot}/${generation}/feed.raw"
+    echo "{\"feeds\":[{\"raw\":\"${generation}/feed.raw\"}]}" > "${pfbchroot}/pfb_py_sources.json"
+    dc save
+    rm -rf "${pfbchroot}"
+    When call dc restore
+    The path "${pfbchroot}/${generation}" should be directory
+    The contents of file "${pfbchroot}/${generation}/feed.raw" should equal 'RAW-v1'
+    The contents of file "${pfbchroot}/pfb_py_sources.json" should include "${generation}/feed.raw"
     cleanup_sandbox
   End
 

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -64,6 +64,10 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     /usr/bin/tar -tf "$(pfb_spec_archive_path "${dnsblarchive}")" 2>/dev/null | sed 's#.*/##'
   }
 
+  tar_list_full() {
+    /usr/bin/tar -tf "$(pfb_spec_archive_path "${dnsblarchive}")" 2>/dev/null
+  }
+
   It 'stage copies the shipped files and creates the nullfs/devfs mount-point dirs'
     setup_sandbox
     # Before: the chroot does not exist at all (fresh MFS).
@@ -117,7 +121,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     The path "$arc" should be exist
     # The archive carries the GENERATED files ...
     The result of "tar_list()" should include 'pfb_py_sources.json'
-    The result of "tar_list()" should include 'feed.raw'
+    The result of "tar_list_full()" should include "${generation}/feed.raw"
     The result of "tar_list()" should not include "${stage}"
     The result of "tar_list()" should not include 'pfb_py_sources.lock'
     The result of "tar_list()" should include 'pfb_unbound.ini'

--- a/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
+++ b/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
@@ -32,7 +32,9 @@ reboot marker (destructive — reboots the shared session VM). Run::
 
 from __future__ import annotations
 
+import json
 import os
+import re
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -59,6 +61,9 @@ class DnsblRebootObservation:
     var_wiped: bool
     staged_after: bool
     var_unbound_ls: str
+    manifest_raw_refs: list[str]
+    manifest_missing_refs: list[str]
+    manifest_generation_dirs: list[str]
     recovered: bool
     recovered_after_s: int
     # issue #1255: TLD-Wildcard blocking observed over the SAME reboot cycle.
@@ -150,6 +155,25 @@ def reboot_observation(dnsbl_vm: SmokeVM) -> DnsblRebootObservation:
     staged_after = vm.ssh("test", "-f", PFB_UNBOUND).returncode == 0
     tld_oracle_staged_after = vm.ssh("test", "-f", PFB_PY_TLD).returncode == 0
     var_unbound_ls = vm.ssh("/bin/ls", "-la", "/var/unbound").stdout
+    manifest_probe = h.php_eval(
+        vm,
+        "$m = json_decode(@file_get_contents('/var/unbound/pfb_py_sources.json'), TRUE);\n"
+        "$refs = array(); $missing = array(); $dirs = array();\n"
+        "foreach (($m['feeds'] ?? array()) as $row) {\n"
+        "  $raw = $row['raw'] ?? '';\n"
+        "  if (!is_string($raw) || $raw === '') { $missing[] = '<invalid>'; continue; }\n"
+        "  $refs[] = $raw; $dirs[dirname($raw)] = TRUE;\n"
+        "  if (!is_file('/var/unbound/' . $raw)) { $missing[] = $raw; }\n"
+        "}\n"
+        "echo '<<PFB1357>>' . json_encode(array(\n"
+        "  'refs' => $refs, 'missing' => $missing, 'dirs' => array_keys($dirs)\n"
+        ")) . '<<END1357>>';",
+        timeout=30.0,
+    )
+    if manifest_probe.returncode != 0:
+        raise RuntimeError(f"#1357 post-MFS manifest probe failed: {manifest_probe.stderr}")
+    manifest_state = json.loads(manifest_probe.stdout.split("<<PFB1357>>", 1)[1].split("<<END1357>>", 1)[0])
+    print(f"[smoke] #1357 post-MFS manifest refs: {manifest_state}")
 
     # Poll for self-recovery (pfb_unbound.py staged AND both sinkholes) with NO manual update.
     waited = 0
@@ -170,6 +194,9 @@ def reboot_observation(dnsbl_vm: SmokeVM) -> DnsblRebootObservation:
         var_wiped=var_wiped,
         staged_after=staged_after,
         var_unbound_ls=var_unbound_ls,
+        manifest_raw_refs=manifest_state["refs"],
+        manifest_missing_refs=manifest_state["missing"],
+        manifest_generation_dirs=manifest_state["dirs"],
         recovered=recovered,
         recovered_after_s=waited,
         wild_sub_domain=wild_sub_domain,
@@ -193,6 +220,16 @@ def test_dnsbl_survives_ramdisk_var_reboot(reboot_observation: DnsblRebootObserv
     assert obs.staged_after, (
         f"#468: {PFB_UNBOUND} missing after RAM-disk reboot (not re-staged).\n/var/unbound:\n{obs.var_unbound_ls}"
     )
+    # #1357: the archive restores the manifest and its complete immutable raw set
+    # before the matcher can self-recover from that manifest.
+    assert obs.manifest_raw_refs, "#1357: restored DNSBL manifest has no feed raw references"
+    assert obs.manifest_missing_refs == [], (
+        f"#1357: restored manifest references missing raws: {obs.manifest_missing_refs!r}\n"
+        f"/var/unbound:\n{obs.var_unbound_ls}"
+    )
+    assert len(obs.manifest_generation_dirs) == 1 and re.fullmatch(
+        r"pfb_py_raw\.[0-9a-f]{32}", obs.manifest_generation_dirs[0]
+    ), f"#1357: restored raws are not one immutable generation: {obs.manifest_generation_dirs!r}"
     # #468 end-state: still sinkholing — matcher rebuilt from the restored manifest, no manual update.
     assert obs.recovered, (
         f"#468: {obs.domain} did not sinkhole again within {RECOVERY_DEADLINE}s of a RAM-disk reboot "

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -59,7 +59,9 @@ and the smoke deps; without them they skip cleanly.
 
 from __future__ import annotations
 
+import json
 import os
+import re
 import time
 from collections.abc import Iterator
 
@@ -826,6 +828,47 @@ def test_dnsbl_feed_update_no_restart(deployed_vm: SmokeVM, client_vm: SmokeVM, 
         # manifest and no swap fires). This is the config-clean data update the swap targets.
         h.force_dnsbl_refetch(deployed_vm, spec.header)
         h.reload(deployed_vm, "update", data_path=True)
+
+        fsync_probe = h.php_eval(
+            deployed_vm,
+            "$dir = '/var/unbound/.pfb1357-fsync-' . getmypid(); $step = 'mkdir';\n"
+            "$ok = @mkdir($dir, 0700);\n"
+            "if ($ok) { $step = 'write'; $ok = file_put_contents($dir . '/before', 'x') === 1; }\n"
+            "if ($ok) { $step = 'rename'; $ok = @rename($dir . '/before', $dir . '/after'); }\n"
+            "$fh = FALSE;\n"
+            "if ($ok) { $step = 'open-dir'; $fh = @fopen($dir, 'r'); $ok = $fh !== FALSE; }\n"
+            "if ($ok) { $step = 'fsync-dir'; $ok = @fsync($fh); }\n"
+            "$error = $ok ? NULL : error_get_last();\n"
+            "if (is_resource($fh)) { fclose($fh); }\n"
+            "@unlink($dir . '/before'); @unlink($dir . '/after'); @rmdir($dir);\n"
+            "echo '<<PFB1357>>' . json_encode(array('ok' => $ok, 'step' => $step, 'error' => $error)) . '<<END1357>>';",
+            timeout=30.0,
+        )
+        assert fsync_probe.returncode == 0, fsync_probe.stderr
+        fsync_result = json.loads(fsync_probe.stdout.split("<<PFB1357>>", 1)[1].split("<<END1357>>", 1)[0])
+        print(f"[smoke] #1357 FreeBSD directory fsync probe: {fsync_result}")
+        assert fsync_result["ok"] is True, f"FreeBSD directory fsync failed: {fsync_result!r}"
+
+        generation_probe = h.php_eval(
+            deployed_vm,
+            "$m = json_decode(file_get_contents('/var/unbound/pfb_py_sources.json'), TRUE);\n"
+            "$dirs = array(); $missing = array(); $staged = array();\n"
+            "foreach (($m['feeds'] ?? array()) as $row) {\n"
+            "  $raw = $row['raw'] ?? ''; $dir = dirname($raw); $dirs[$dir] = TRUE;\n"
+            "  if (strpos($raw, 'pfb_py_raw.stage.') !== FALSE) { $staged[] = $raw; }\n"
+            "  if (!is_file('/var/unbound/' . $raw)) { $missing[] = $raw; }\n"
+            "}\n"
+            "echo '<<PFB1357>>' . json_encode(array(\n"
+            "  'dirs' => array_keys($dirs), 'missing' => $missing, 'staged' => $staged\n"
+            ")) . '<<END1357>>';",
+            timeout=30.0,
+        )
+        assert generation_probe.returncode == 0, generation_probe.stderr
+        generation = json.loads(generation_probe.stdout.split("<<PFB1357>>", 1)[1].split("<<END1357>>", 1)[0])
+        assert len(generation["dirs"]) == 1, f"feed raws span generations: {generation!r}"
+        assert re.fullmatch(r"pfb_py_raw\.[0-9a-f]{32}", generation["dirs"][0]), generation
+        assert generation["missing"] == [], f"published manifest has missing raw refs: {generation!r}"
+        assert generation["staged"] == [], f"published manifest references staging: {generation!r}"
 
         # Clear the target's TTL-bounded prior resolved answer (feed/cron allow->block is
         # not targeted-flushed by PHP — RESULTS/05 SS3), then observe the swapped block.

--- a/tests/test_adr06_init_from_raw.py
+++ b/tests/test_adr06_init_from_raw.py
@@ -307,7 +307,9 @@ class TestManifestFallback:
             fh.write("{ this is not json")
         assert pfb_unbound.dnsbl_build_from_manifest(bad) is None
 
-    def test_missing_feed_file_rejects_the_whole_generation(self, tmp_path: Any) -> None:
+    def test_missing_feed_file_rejects_the_whole_generation(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # One missing member makes the manifest generation unusable: never expose a
         # partial build assembled from only the readable members.
         path = os.path.join(str(tmp_path), "m.json")
@@ -334,7 +336,7 @@ class TestManifestFallback:
         }
         with open(path, "w", encoding="utf-8") as fh:
             json.dump(manifest, fh)
-        pfb_unbound.pfb["pfb_py_status"] = status_path
+        monkeypatch.setitem(pfb_unbound.pfb, "pfb_py_status", status_path)
         result = pfb_unbound.dnsbl_build_from_manifest(path)
         assert result is None
         with open(status_path, encoding="utf-8") as fh:

--- a/tests/test_adr06_init_from_raw.py
+++ b/tests/test_adr06_init_from_raw.py
@@ -307,11 +307,11 @@ class TestManifestFallback:
             fh.write("{ this is not json")
         assert pfb_unbound.dnsbl_build_from_manifest(bad) is None
 
-    def test_missing_feed_file_is_skipped_not_fatal(self, tmp_path: Any) -> None:
-        # One feed references a non-existent raw file; the build must still load the
-        # OTHER feeds rather than aborting (the bad feed is logged + skipped). All
-        # referenced paths live UNDER the manifest dir (the production/confined shape).
+    def test_missing_feed_file_rejects_the_whole_generation(self, tmp_path: Any) -> None:
+        # One missing member makes the manifest generation unusable: never expose a
+        # partial build assembled from only the readable members.
         path = os.path.join(str(tmp_path), "m.json")
+        status_path = os.path.join(str(tmp_path), "pfb_py_status.json")
         _stage_tld_oracle(tmp_path)
         shutil.copyfile(os.path.join(FIXTURES, "feed_plain.txt"), os.path.join(str(tmp_path), "feed_plain.txt"))
         manifest = {
@@ -334,10 +334,14 @@ class TestManifestFallback:
         }
         with open(path, "w", encoding="utf-8") as fh:
             json.dump(manifest, fh)
+        pfb_unbound.pfb["pfb_py_status"] = status_path
         result = pfb_unbound.dnsbl_build_from_manifest(path)
-        assert result is not None
-        # The good feed's entries are present despite the missing one.
-        assert "malware.com" in result.zone_db
+        assert result is None
+        with open(status_path, encoding="utf-8") as fh:
+            entries = json.load(fh)
+        assert any(
+            entry["facility"] == "dnsbl" and entry["item"] == path and entry["stage"] == "parse" for entry in entries
+        )
 
     def test_empty_feeds_manifest_builds_empty(self, tmp_path: Any) -> None:
         # A manifest with no feeds still builds (TLD-blacklist zones + whiteDB only).

--- a/tests/test_issue1357_manifest_generation.py
+++ b/tests/test_issue1357_manifest_generation.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 import pfb_unbound
 
 
-def test_one_missing_raw_aborts_two_feed_manifest_and_opens_ledger(tmp_path: Path) -> None:
+def test_one_missing_raw_aborts_two_feed_manifest_and_opens_ledger(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     status_path = tmp_path / "pfb_py_status.json"
     manifest_path = tmp_path / "pfb_py_sources.json"
     (tmp_path / "present.raw").write_text("present.example\n", encoding="utf-8")
@@ -35,7 +39,7 @@ def test_one_missing_raw_aborts_two_feed_manifest_and_opens_ledger(tmp_path: Pat
         ),
         encoding="utf-8",
     )
-    pfb_unbound.pfb["pfb_py_status"] = str(status_path)
+    monkeypatch.setitem(pfb_unbound.pfb, "pfb_py_status", str(status_path))
 
     result = pfb_unbound.dnsbl_build_from_manifest(str(manifest_path))
 
@@ -43,5 +47,26 @@ def test_one_missing_raw_aborts_two_feed_manifest_and_opens_ledger(tmp_path: Pat
     entries = json.loads(status_path.read_text(encoding="utf-8"))
     assert len(entries) == 1
     assert entries[0]["facility"] == "dnsbl"
+    assert entries[0]["item"] == str(manifest_path)
+    assert entries[0]["stage"] == "parse"
+
+
+@pytest.mark.parametrize("present_keys", [(), ("feeds",), ("config",)])
+def test_missing_required_manifest_root_rejects_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, present_keys: tuple[str, ...]
+) -> None:
+    manifest: dict[str, object] = {"version": 1}
+    if "feeds" in present_keys:
+        manifest["feeds"] = []
+    if "config" in present_keys:
+        manifest["config"] = {}
+    manifest_path = tmp_path / "pfb_py_sources.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    status_path = tmp_path / "pfb_py_status.json"
+    monkeypatch.setitem(pfb_unbound.pfb, "pfb_py_status", str(status_path))
+
+    assert pfb_unbound.dnsbl_build_from_manifest(str(manifest_path)) is None
+    entries = json.loads(status_path.read_text(encoding="utf-8"))
+    assert len(entries) == 1
     assert entries[0]["item"] == str(manifest_path)
     assert entries[0]["stage"] == "parse"

--- a/tests/test_issue1357_manifest_generation.py
+++ b/tests/test_issue1357_manifest_generation.py
@@ -1,0 +1,47 @@
+"""Issue #1357: a DNSBL manifest generation fails as one unit."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pfb_unbound
+
+
+def test_one_missing_raw_aborts_two_feed_manifest_and_opens_ledger(tmp_path: Path) -> None:
+    status_path = tmp_path / "pfb_py_status.json"
+    manifest_path = tmp_path / "pfb_py_sources.json"
+    (tmp_path / "present.raw").write_text("present.example\n", encoding="utf-8")
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "config": {},
+                "feeds": [
+                    {
+                        "raw": "present.raw",
+                        "feed": "Present",
+                        "group": "Test",
+                        "log_flag": "1",
+                    },
+                    {
+                        "raw": "missing.raw",
+                        "feed": "Missing",
+                        "group": "Test",
+                        "log_flag": "1",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    pfb_unbound.pfb["pfb_py_status"] = str(status_path)
+
+    result = pfb_unbound.dnsbl_build_from_manifest(str(manifest_path))
+
+    assert result is None, "one missing generation member must reject the whole manifest"
+    entries = json.loads(status_path.read_text(encoding="utf-8"))
+    assert len(entries) == 1
+    assert entries[0]["facility"] == "dnsbl"
+    assert entries[0]["item"] == str(manifest_path)
+    assert entries[0]["stage"] == "parse"

--- a/tests/test_manifest_path_confinement.py
+++ b/tests/test_manifest_path_confinement.py
@@ -21,7 +21,9 @@ Scenario: confine manifest file references under base_dir
 
 from __future__ import annotations
 
+import json
 import os
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -63,6 +65,51 @@ class TestFeedPathConfinement:
         # Then nothing is yielded (the outside file is never opened) and it is logged.
         assert escaped == []
         assert "Refusing DNSBL feed outside base dir" in capsys.readouterr().err
+
+
+class TestManifestGenerationFailClosed:
+    @pytest.mark.parametrize(
+        "raw_kind",
+        ["missing", "directory", "traversal", "absolute", "symlink_escape", "missing_key", "wrong_type"],
+    )
+    def test_invalid_raw_member_rejects_whole_manifest_and_opens_ledger(
+        self,
+        tmp_path: Path,
+        raw_kind: str,
+    ) -> None:
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "outside.raw"
+        outside.write_text("outside.example\n", encoding="utf-8")
+        raw: object = "missing.raw"
+        if raw_kind == "directory":
+            (base / "directory.raw").mkdir()
+            raw = "directory.raw"
+        elif raw_kind == "traversal":
+            raw = "../outside.raw"
+        elif raw_kind == "absolute":
+            raw = str(outside)
+        elif raw_kind == "symlink_escape":
+            os.symlink(outside, base / "link.raw")
+            raw = "link.raw"
+        elif raw_kind == "wrong_type":
+            raw = ["feed.raw"]
+
+        row: dict[str, object] = {"raw": raw, "feed": "Bad", "group": "Test", "log_flag": "1"}
+        if raw_kind == "missing_key":
+            row.pop("raw")
+        manifest_path = base / "pfb_py_sources.json"
+        manifest_path.write_text(json.dumps({"version": 1, "config": {}, "feeds": [row]}), encoding="utf-8")
+        status_path = base / "pfb_py_status.json"
+        pfb_unbound.pfb["pfb_py_status"] = str(status_path)
+
+        result = pfb_unbound.dnsbl_build_from_manifest(str(manifest_path))
+
+        assert result is None, f"{raw_kind} raw reference unexpectedly produced a partial build"
+        entries = json.loads(status_path.read_text(encoding="utf-8"))
+        assert len(entries) == 1
+        assert entries[0]["item"] == str(manifest_path)
+        assert entries[0]["stage"] == "parse"
 
     def test_absolute_out_of_base_feed_is_skipped(self, tmp_path: Any, capsys: pytest.CaptureFixture[str]) -> None:
         # An absolute path pointing outside base_dir is refused too.

--- a/tests/test_manifest_path_confinement.py
+++ b/tests/test_manifest_path_confinement.py
@@ -76,6 +76,7 @@ class TestManifestGenerationFailClosed:
         self,
         tmp_path: Path,
         raw_kind: str,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         base = tmp_path / "base"
         base.mkdir()
@@ -101,7 +102,7 @@ class TestManifestGenerationFailClosed:
         manifest_path = base / "pfb_py_sources.json"
         manifest_path.write_text(json.dumps({"version": 1, "config": {}, "feeds": [row]}), encoding="utf-8")
         status_path = base / "pfb_py_status.json"
-        pfb_unbound.pfb["pfb_py_status"] = str(status_path)
+        monkeypatch.setitem(pfb_unbound.pfb, "pfb_py_status", str(status_path))
 
         result = pfb_unbound.dnsbl_build_from_manifest(str(manifest_path))
 


### PR DESCRIPTION
## Summary

- Publish each DNSBL raw set into an immutable content-addressed generation and make the manifest rename the sole visibility commit.
- Serialize publication, fail closed when a manifest generation is incomplete, preserve loaded/fingerprint semantics, and garbage-collect only generations no longer referenced.
- Extend RAM-disk lifecycle, directory durability, path-confinement, failure-injection, and appliance-smoke coverage for the versioned layout.

## Verification

- Frozen RED/GREEN publication proof: passed.
- Canonical repository gates: passed.
- One-million-entry benchmark: PHP +6.97%, Python -0.23% (both within the 10% limit).
- Exact-head appliance smoke: 2/2 passed, including manifest/raw consistency, DNS blocking recovery, FreeBSD directory `fsync`, generation cleanup, and no-restart reload.

Fixes #1357

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * DNSBL refresh now publishes immutable, content-addressed raw generations with per-feed staging to prevent mixed/incomplete datasets.
  * Publication is serialized with a shared lock; atomic manifest replacement remains the visibility commit, with safer post-publish convergence handling.
  * Stricter artifact lifecycle management reduces stale/staging leftovers after successful application.
* **Bug Fixes**
  * Fail-closed DNSBL manifest handling: invalid or unsafe raw feed references now abort the entire generation.
* **Documentation**
  * Updated architecture notes for versioned generation directories and zero-downtime swap ordering.
* **Tests**
  * Added/expanded coverage for atomic generation semantics, lock/convergence GC, manifest validation, cache/restore, and reboot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->