### PR TITLE
scripts: harden noopener target matching

### DIFF
--- a/scripts/check_noopener.py
+++ b/scripts/check_noopener.py
@@ -12,8 +12,9 @@ is attacker-influenced, and cheap defence-in-depth even when it is not
 
 HEURISTIC (deliberately strict-adjacency, not an HTML parser)
 ---------------------------------------------------------------
-A `target=…_blank…` occurrence (double/single/no quotes; a `(?<![\\w-])`
-guard excludes `data-target="_blank"`) is a VIOLATION unless it is
+A `target … = … _blank…` occurrence (HTML ASCII case; double/single/no quotes;
+spaces/tabs around `=`; a `(?<![\\w-])` guard excludes `data-target="_blank"`)
+is a VIOLATION unless it is
 IMMEDIATELY followed — only whitespace between — by `rel=["']?noopener`.
 That is the house convention this codebase now follows: `rel` sits directly
 after `target`, so it survives even the multi-line PHP string-concatenation
@@ -50,9 +51,11 @@ import subprocess
 import sys
 from typing import NamedTuple
 
-# `target=…_blank…` in any of the three HTML quote forms. `(?<![\w-])` excludes
-# a `data-target="_blank"` tail (word/hyphen boundary before `target`).
-_TARGET_BLANK_RE = re.compile(r'(?<![\w-])target=(?P<q>["\']?)_blank(?P=q)')
+# HTML ASCII case/whitespace only. The unquoted branch must leave its separator
+# untouched for the adjacent-rel matcher; quoted trailing spaces/tabs are included.
+_TARGET_BLANK_RE = re.compile(
+    r'(?<![\w-])(?ai:target)[ \t]*=[ \t]*(?:(?P<q>["\'])(?ai:_blank)[ \t]*(?P=q)|(?ai:_blank))'
+)
 
 # `rel="noopener…"` (or single-quoted / unquoted), immediately after `target=…`
 # with only whitespace between -- the strict-adjacency house convention. The
@@ -74,7 +77,7 @@ class Violation(NamedTuple):
 
 
 def find_violations(text: str, source: str) -> list[Violation]:
-    """Find every `target=…_blank…` site with no adjacent `rel="noopener…"`.
+    """Find every HTML ASCII `target=…_blank…` spelling with no adjacent `rel="noopener…"`.
 
     Scanned per physical line — every current/expected site keeps `target`
     and its `rel` on the same line (see module docstring). A line carrying

--- a/scripts/check_noopener.py
+++ b/scripts/check_noopener.py
@@ -51,10 +51,11 @@ import subprocess
 import sys
 from typing import NamedTuple
 
-# HTML ASCII case/whitespace only. The unquoted branch must leave its separator
-# untouched for the adjacent-rel matcher; quoted trailing spaces/tabs are included.
+# HTML ASCII case/whitespace only. The unquoted branch requires a value delimiter
+# and leaves it untouched for the adjacent-rel matcher; quoted trailing spaces/tabs
+# are included.
 _TARGET_BLANK_RE = re.compile(
-    r'(?<![\w-])(?ai:target)[ \t]*=[ \t]*(?:(?P<q>["\'])(?ai:_blank)[ \t]*(?P=q)|(?ai:_blank))'
+    r'(?<![\w-])(?ai:target)[ \t]*=[ \t]*(?:(?P<q>["\'])(?ai:_blank)[ \t]*(?P=q)|(?ai:_blank)(?=[ \t>]|$))'
 )
 
 # `rel="noopener…"` (or single-quoted / unquoted), immediately after `target=…`

--- a/tests/test_noopener_check.py
+++ b/tests/test_noopener_check.py
@@ -130,6 +130,112 @@ def test_row14_noopener_with_wordchar_suffix_is_flagged() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Issue #1294: HTML ASCII target spelling and whitespace variants
+# --------------------------------------------------------------------------- #
+
+_IN_SCOPE_SUFFIXES = ("php", "inc", "xml")
+
+
+@pytest.mark.parametrize("suffix", _IN_SCOPE_SUFFIXES)
+@pytest.mark.parametrize(
+    ("case_name", "target_attribute"),
+    (
+        ("double_quoted", 'target="_blank"'),
+        ("single_quoted", "target='_blank'"),
+        ("unquoted", "target=_blank"),
+        ("uppercase_attribute", 'TARGET="_blank"'),
+        ("mixed_case_keyword", 'target="_Blank"'),
+    ),
+    ids=lambda value: value if isinstance(value, str) and "=" not in value else None,
+)
+def test_target_case_variants_require_adjacent_rel(suffix: str, case_name: str, target_attribute: str) -> None:
+    source = f"page.{suffix}"
+    violations = _find(f'<a {target_attribute} href="x">', source)
+    assert len(violations) == 1, f"{case_name} in {source}: expected one violation, got {violations!r}"
+    assert violations[0].source == source
+
+    clean = f'<a {target_attribute} rel="noopener noreferrer" href="x">'
+    assert _find(clean, source) == [], f"{case_name} in {source}: adjacent noopener rel was not clean"
+
+
+@pytest.mark.parametrize("suffix", _IN_SCOPE_SUFFIXES)
+@pytest.mark.parametrize(
+    ("case_name", "target_attribute"),
+    (
+        ("space_before_equals", 'target ="_blank"'),
+        ("space_after_equals", 'target= "_blank"'),
+        ("space_both_sides", 'target = "_blank"'),
+        ("tabs_around_equals", 'target\t=\t"_blank"'),
+        ("consecutive_spaces", 'target  =  "_blank"'),
+        ("quoted_trailing_space", 'target="_blank "'),
+        ("quoted_trailing_tab", 'target="_blank\t"'),
+        ("unquoted_spaced_equals", "target = _blank"),
+    ),
+    ids=lambda value: value if isinstance(value, str) and "=" not in value else None,
+)
+def test_target_whitespace_variants_require_adjacent_rel(suffix: str, case_name: str, target_attribute: str) -> None:
+    source = f"page.{suffix}"
+    violations = _find(f'<a {target_attribute} href="x">', source)
+    assert len(violations) == 1, f"{case_name} in {source}: expected one violation, got {violations!r}"
+
+    clean = f'<a {target_attribute} rel="noopener noreferrer" href="x">'
+    assert _find(clean, source) == [], f"{case_name} in {source}: adjacent noopener rel was not clean"
+
+
+_HOSTILE_CLEAN_ROWS = (
+    ("data_target", '<div data-target="_blank">'),
+    ("data_target_ascii_case", '<div data-TARGET="_Blank">'),
+    ("identifier_prefix", '<div mytarget="_blank">'),
+    ("unicode_identifier_prefix", '<div étarget="_blank">'),
+    ("unicode_casefold_keyword", '<a target="_blanK">'),
+    ("nbsp_around_equals", '<a target\u00a0=\u00a0"_blank">'),
+    ("zero_width_around_equals", '<a target\u200b=\u200b"_blank">'),
+    ("empty_target", '<a target="">'),
+    ("missing_target_value", "<a target=>"),
+    ("mismatched_quotes", "<a target=\"_blank'>"),
+    ("shell_shaped_value", '<a target="$(_blank)">'),
+    ("bracketed_value", '<a target="[_blank]">'),
+    ("target_equals_split", '<a target\n="_blank" rel="noopener noreferrer">'),
+    ("adjacent_noopener", '<a target="_blank" rel="noopener noreferrer">'),
+    ("escape_marker", '<a target="_blank" href="x"> <!-- noopener-ok: sample -->'),
+)
+
+
+@pytest.mark.parametrize("suffix", _IN_SCOPE_SUFFIXES)
+@pytest.mark.parametrize(("case_name", "text"), _HOSTILE_CLEAN_ROWS, ids=[row[0] for row in _HOSTILE_CLEAN_ROWS])
+def test_target_matcher_hostile_clean_inputs_stay_clean(suffix: str, case_name: str, text: str) -> None:
+    source = f"page.{suffix}"
+    assert _find(text, source) == [], f"{case_name} in {source}: non-target input was flagged"
+
+
+_HOSTILE_VIOLATION_ROWS = (
+    ("rel_before_target", '<a rel="noopener noreferrer" target="_blank">'),
+    ("intervening_attribute", '<a target="_blank" href="x" rel="noopener noreferrer">'),
+    ("rel_next_line", '<a target="_blank"\nrel="noopener noreferrer">'),
+    ("wrong_rel", '<a target="_blank" rel="opener">'),
+    ("hyphen_rel_suffix", '<a target="_blank" rel="noopener-evil">'),
+    ("word_rel_suffix", '<a target="_blank" rel="noopener_evil">'),
+)
+
+
+@pytest.mark.parametrize("suffix", _IN_SCOPE_SUFFIXES)
+@pytest.mark.parametrize(
+    ("case_name", "text"), _HOSTILE_VIOLATION_ROWS, ids=[row[0] for row in _HOSTILE_VIOLATION_ROWS]
+)
+def test_target_matcher_hostile_violations_remain_flagged(suffix: str, case_name: str, text: str) -> None:
+    source = f"page.{suffix}"
+    violations = _find(text, source)
+    assert len(violations) == 1, f"{case_name} in {source}: expected one violation, got {violations!r}"
+
+
+@pytest.mark.parametrize("suffix", _IN_SCOPE_SUFFIXES)
+def test_target_matcher_hostile_oversized_non_target_stays_clean(suffix: str) -> None:
+    long_value = "x" * 8192
+    text = f'<div data-prefix="{long_value}" data-target="_blank" data-suffix="{long_value}">'
+    assert _find(text, f"page.{suffix}") == []
+
+
+# --------------------------------------------------------------------------- #
 # Additional branch coverage: line numbers, multiple violations, quote forms
 # --------------------------------------------------------------------------- #
 

--- a/tests/test_noopener_check.py
+++ b/tests/test_noopener_check.py
@@ -145,6 +145,7 @@ _IN_SCOPE_SUFFIXES = ("php", "inc", "xml")
         ("unquoted", "target=_blank"),
         ("uppercase_attribute", 'TARGET="_blank"'),
         ("mixed_case_keyword", 'target="_Blank"'),
+        ("mixed_case_unquoted_keyword", "target=_Blank"),
     ),
     ids=lambda value: value if isinstance(value, str) and "=" not in value else None,
 )
@@ -195,6 +196,8 @@ _HOSTILE_CLEAN_ROWS = (
     ("mismatched_quotes", "<a target=\"_blank'>"),
     ("shell_shaped_value", '<a target="$(_blank)">'),
     ("bracketed_value", '<a target="[_blank]">'),
+    ("unquoted_word_suffix", "<a target=_blank_evil>"),
+    ("unquoted_hyphen_suffix", "<a target=_blank-evil>"),
     ("target_equals_split", '<a target\n="_blank" rel="noopener noreferrer">'),
     ("adjacent_noopener", '<a target="_blank" rel="noopener noreferrer">'),
     ("escape_marker", '<a target="_blank" href="x"> <!-- noopener-ok: sample -->'),


### PR DESCRIPTION
## Summary

- Detect ASCII case variants of `target` and `_blank`, ASCII space/tab around `=`, and quoted trailing space/tab near-matches.
- Preserve strict adjacent-`rel="noopener"` policy, Unicode boundaries, unquoted separators, scan scope, and CLI behavior.
- Add bad/clean and hostile-input coverage across the checker’s `.php`, `.inc`, and `.xml` surfaces.

## Verification

- Test-first proof: `30 failed, 75 passed` against the untouched matcher; `105 passed` after the fix with frozen test hash `422a3fddfaa4f754734a6dc5f9042cc25463c232`.
- Focused checker suite: `126 passed`.
- Canonical Python gates: pytest, Ruff check/format, and mypy all passed.
- Independent verifier replayed the red proof and killed five matcher mutants covering case, equals whitespace, quoted trailing whitespace, Unicode broadening, and unquoted separator consumption.
- Live FreeBSD/UI smoke: not applicable; this changes only dev-only `scripts/` and unit tests, with no shipped `src/`, Web UI, or smoke surface.

Fixes #1294

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of `target="_blank"` patterns to handle variations in HTML attribute casing, whitespace, and quoting.
  * Ensured checks still require `rel="noopener noreferrer"` to be directly adjacent.
  * Reduced false positives, including cases with misleading or non-matching attribute content and very large values.
* **Tests**
  * Expanded coverage with additional valid, invalid, hostile, and oversized-attribute scenarios to verify correct behavior across variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->