### PR TITLE
ci: reject untested code in release walk-back

### DIFF
--- a/scripts/release-ci-gate.sh
+++ b/scripts/release-ci-gate.sh
@@ -34,7 +34,12 @@ fi
 
 CONCLUSION=""
 CHECK_SHA=""
-for sha in $(git rev-list --first-parent -n 20 HEAD); do
+if ! sha=$(git rev-parse --verify HEAD); then
+	echo "::error::Could not resolve HEAD; cannot verify CI state."
+	exit 1
+fi
+walked=0
+while [ "$walked" -lt 20 ]; do
 	if ! c=$(gh api \
 		"repos/${REPO}/commits/${sha}/check-runs?check_name=All%20tests%20passed&per_page=100" \
 		--jq '[.check_runs[] | select(.name == "All tests passed")]
@@ -46,6 +51,31 @@ for sha in $(git rev-list --first-parent -n 20 HEAD); do
 		exit 1
 	fi
 	if [ -n "$c" ]; then CONCLUSION="$c"; CHECK_SHA="$sha"; break; fi
+	if ! parent=$(git rev-parse --verify "${sha}^" 2>/dev/null); then
+		root=$(git rev-list --max-parents=0 -n 1 "$sha" 2>/dev/null)
+		if [ "$root" = "$sha" ]; then break; fi
+		echo "::error::Could not classify skipped commit ${sha}; cannot verify whether an older check-run applies."
+		exit 1
+	fi
+	git diff --quiet "$parent" "$sha" -- '.' \
+		':(top,exclude,glob)**/*.md' \
+		':(top,exclude,glob)*.md' \
+		':(top,exclude,glob)docs/**' \
+		':(top,exclude,literal).claude/skills/ponytail/LICENSE' \
+		':(top,exclude,literal).claude/skills/ponytail/UPSTREAM' \
+		':(top,exclude,literal).claude/skills/caveman/LICENSE' \
+		':(top,exclude,literal).claude/skills/caveman/UPSTREAM' 2>/dev/null
+	diff_status=$?
+	if [ "$diff_status" -eq 1 ]; then
+		echo "::error::Skipped commit ${sha} changes CI-relevant paths; cannot rely on an older check-run."
+		exit 1
+	fi
+	if [ "$diff_status" -ne 0 ]; then
+		echo "::error::Could not classify skipped commit ${sha}; cannot verify whether an older check-run applies."
+		exit 1
+	fi
+	sha="$parent"
+	walked=$((walked + 1))
 done
 if [ -z "$CONCLUSION" ]; then
 	echo "::error::No 'All tests passed' check-run found on HEAD or its recent ancestors."

--- a/tests/shell/release_ci_gate_spec.sh
+++ b/tests/shell/release_ci_gate_spec.sh
@@ -88,11 +88,6 @@ EOF
     shift
     commit_index_paths "$message" 100644 "$@"
   }
-  commit_executable_paths() {
-    message="$1"
-    shift
-    commit_index_paths "$message" 100755 "$@"
-  }
   commit_empty() {
     git -C "$repo" -c user.name=t -c user.email=t@t commit -q --allow-empty -m "$1"
     tip="$(git -C "$repo" rev-parse HEAD)"
@@ -181,18 +176,6 @@ EOF
     The output should not include "CI green on ${ancestor}"
   End
 
-  It 'rejects unchecked executable hooks under vendored plugin trees'
-    commit_executable_paths hooks \
-      '.claude/skills/ponytail/hooks/release.js' \
-      '.claude/skills/caveman/src/hooks/release.js'
-    hook_sha="$tip"
-    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
-    When call run_gate
-    The status should be failure
-    The output should include "Skipped commit ${hook_sha}"
-    The output should include 'changes CI-relevant paths'
-  End
-
   It 'rejects a near miss of an exact ignored plugin path'
     commit_paths near-miss '.claude/skills/ponytail/LICENSE.extra'
     near_miss_sha="$tip"
@@ -203,25 +186,30 @@ EOF
     The output should include 'changes CI-relevant paths'
   End
 
-  It 'rejects hostile and opaque names when their paths are CI-relevant'
-    tab_name="$(printf 'tab\tname')"
-    non_utf8="$(printf '\377')"
-    long_name="$(awk 'BEGIN { for (i = 0; i < 230; i++) printf "n" }')"
-    commit_paths hostile-code \
-      'scripts/space name' \
-      'scripts/two  spaces' \
-      "scripts/${tab_name}" \
-      'scripts/quote"name' \
-      'scripts/glob[*?]name' \
-      'scripts/pünicode' \
-      "scripts/${long_name}" \
-      "scripts/non-utf8-${non_utf8}"
-    code_sha="$tip"
-    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
-    When call run_gate
-    The status should be failure
-    The output should include "Skipped commit ${code_sha}"
-    The output should include 'changes CI-relevant paths'
+  Context 'individual CI-relevant deny paths'
+    Parameters
+      'single space'              100644 'scripts/space name'
+      'two consecutive spaces'    100644 'scripts/two  spaces'
+      'tab byte'                  100644 "scripts/$(printf '\t')name"
+      'double quote'              100644 'scripts/quote"name'
+      'glob metacharacters'       100644 'scripts/glob[*?]name'
+      'Unicode character'         100644 'scripts/pünicode'
+      '230-character name'        100644 "scripts/$(awk 'BEGIN { for (i = 0; i < 230; i++) printf "n" }')"
+      'non-UTF-8 FF byte'         100644 "scripts/non-utf8-$(printf '\377')"
+      'ponytail executable hook'  100755 '.claude/skills/ponytail/hooks/release.js'
+      'caveman executable hook'   100755 '.claude/skills/caveman/src/hooks/release.js'
+    End
+
+    It "rejects an isolated $1 path"
+      commit_index_paths "deny-$1" "$2" "$3"
+      denied_sha="$tip"
+      payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
+      When call run_gate
+      The status should be failure
+      The output should include "Skipped commit ${denied_sha}"
+      The output should include 'changes CI-relevant paths'
+      The output should not include "CI green on ${ancestor}"
+    End
   End
 
   It 'classifies every skipped commit before accepting a green ancestor'
@@ -302,22 +290,79 @@ EOF
     The output should not include "No 'All tests passed'"
   End
 
-  It 'does not walk back beyond the 20-commit window'
-    # The only matching run sits on commit 21 in first-parent order; the walk
-    # must exhaust at 20 and fail rather than validate an ancient ancestor.
-    deep="$repo-deep"
-    git init -q -b main "$deep"
-    ( cd "$deep" && for i in $(seq 1 22); do
-        git -c user.name=t -c user.email=t@t commit -q --allow-empty -m "c$i"
-      done )
-    old21="$(git -C "$deep" rev-parse HEAD~21)"
-    payload "$old21" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"}]}'
-    run_gate_deep() {
-      ( cd "$deep" && PATH="${work}/bin:${PATH}" REPO="own/repo" GH_TOKEN=x \
+  It 'accepts a green check on the 20th queried commit'
+    deep20="${work}/deep20"
+    git init -q -b main "$deep20"
+    i=1
+    while [ "$i" -le 20 ]; do
+      git -C "$deep20" -c user.name=t -c user.email=t@t commit -q --allow-empty -m "c$i"
+      i=$((i + 1))
+    done
+    green20="$(git -C "$deep20" rev-parse HEAD~19)"
+    payload "$green20" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"}]}'
+    run_gate_deep20() {
+      ( cd "$deep20" && PATH="${work}/bin:${PATH}" REPO="own/repo" GH_TOKEN=x \
           sh "${PFB_ROOT}/scripts/release-ci-gate.sh" )
     }
-    When call run_gate_deep
+    When call run_gate_deep20
+    The status should be success
+    The output should include "CI green on ${green20}"
+  End
+
+  It 'rejects a green check on the 21st commit outside the query window'
+    deep21="${work}/deep21"
+    git init -q -b main "$deep21"
+    i=1
+    while [ "$i" -le 21 ]; do
+      git -C "$deep21" -c user.name=t -c user.email=t@t commit -q --allow-empty -m "c$i"
+      i=$((i + 1))
+    done
+    green21="$(git -C "$deep21" rev-parse HEAD~20)"
+    payload "$green21" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"}]}'
+    run_gate_deep21() {
+      ( cd "$deep21" && PATH="${work}/bin:${PATH}" REPO="own/repo" GH_TOKEN=x \
+          sh "${PFB_ROOT}/scripts/release-ci-gate.sh" )
+    }
+    When call run_gate_deep21
     The status should be failure
     The output should include "No 'All tests passed' check-run found"
+    The output should not include "CI green on ${green21}"
+  End
+
+  It 'walks merge commits through the first parent before accepting green'
+    merge_repo="${work}/merge"
+    git init -q -b main "$merge_repo"
+    git -C "$merge_repo" -c user.name=t -c user.email=t@t commit -q --allow-empty -m root
+
+    code_blob="$(printf 'unchecked code\n' | git -C "$merge_repo" hash-object -w --stdin)"
+    printf '100644 %s\tscripts/unchecked.sh\0' "$code_blob" |
+      git -C "$merge_repo" update-index -z --index-info
+    git -C "$merge_repo" -c user.name=t -c user.email=t@t commit -q -m code
+    code_sha="$(git -C "$merge_repo" rev-parse HEAD)"
+
+    git -C "$merge_repo" checkout -q -b side
+    side_blob="$(printf 'side docs\n' | git -C "$merge_repo" hash-object -w --stdin)"
+    printf '100644 %s\tdocs/side.txt\0' "$side_blob" |
+      git -C "$merge_repo" update-index -z --index-info
+    git -C "$merge_repo" -c user.name=t -c user.email=t@t commit -q -m side-docs
+    side_sha="$(git -C "$merge_repo" rev-parse HEAD)"
+
+    git -C "$merge_repo" checkout -q main
+    main_blob="$(printf 'main docs\n' | git -C "$merge_repo" hash-object -w --stdin)"
+    printf '100644 %s\tdocs/main.txt\0' "$main_blob" |
+      git -C "$merge_repo" update-index -z --index-info
+    git -C "$merge_repo" -c user.name=t -c user.email=t@t commit -q -m main-docs
+    git -C "$merge_repo" -c user.name=t -c user.email=t@t merge -q --no-ff side -m merge
+
+    payload "$side_sha" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"}]}'
+    run_gate_merge() {
+      ( cd "$merge_repo" && PATH="${work}/bin:${PATH}" REPO="own/repo" GH_TOKEN=x \
+          sh "${PFB_ROOT}/scripts/release-ci-gate.sh" )
+    }
+    When call run_gate_merge
+    The status should be failure
+    The output should include "Skipped commit ${code_sha}"
+    The output should include 'changes CI-relevant paths'
+    The output should not include "CI green on ${side_sha}"
   End
 End

--- a/tests/shell/release_ci_gate_spec.sh
+++ b/tests/shell/release_ci_gate_spec.sh
@@ -190,7 +190,7 @@ EOF
     Parameters
       'single space'              100644 'scripts/space name'
       'two consecutive spaces'    100644 'scripts/two  spaces'
-      'tab byte'                  100644 "scripts/$(printf '\t')name"
+      'tab byte'                  100644 "scripts/tab$(printf '\t')name"
       'double quote'              100644 'scripts/quote"name'
       'glob metacharacters'       100644 'scripts/glob[*?]name'
       'Unicode character'         100644 'scripts/pünicode'

--- a/tests/shell/release_ci_gate_spec.sh
+++ b/tests/shell/release_ci_gate_spec.sh
@@ -71,6 +71,32 @@ EOF
     printf '%s' "$2" > "${GH_MOCK_DIR}/$1.filtered.json"
     printf '%s' "$2" > "${GH_MOCK_DIR}/$1.unfiltered.json"
   }
+  commit_index_paths() { # $1 message, $2 mode, remaining args are paths
+    message="$1"
+    mode="$2"
+    shift 2
+    blob="$(printf '%s\n' "$message" | git -C "$repo" hash-object -w --stdin)"
+    for path do
+      printf '%s %s\t%s\0' "$mode" "$blob" "$path" |
+        git -C "$repo" update-index -z --index-info
+    done
+    git -C "$repo" -c user.name=t -c user.email=t@t commit -q -m "$message"
+    tip="$(git -C "$repo" rev-parse HEAD)"
+  }
+  commit_paths() {
+    message="$1"
+    shift
+    commit_index_paths "$message" 100644 "$@"
+  }
+  commit_executable_paths() {
+    message="$1"
+    shift
+    commit_index_paths "$message" 100755 "$@"
+  }
+  commit_empty() {
+    git -C "$repo" -c user.name=t -c user.email=t@t commit -q --allow-empty -m "$1"
+    tip="$(git -C "$repo" rev-parse HEAD)"
+  }
   run_gate() {
     ( cd "$repo" && PATH="${work}/bin:${PATH}" REPO="own/repo" GH_TOKEN=x \
         sh "${PFB_ROOT}/scripts/release-ci-gate.sh" )
@@ -109,14 +135,114 @@ EOF
     The output should include "CI green on ${tip}"
   End
 
-  It 'walks back to the nearest CI-run ancestor for a docs-only tip'
-    # Preserved behaviour: a tip with genuinely NO matching run (docs-only
-    # commit, CI skipped) defers to the nearest ancestor that ran CI.
-    payload "$tip" '{"check_runs":[]}'
+  It 'walks across every exact CI-ignored path class and an empty commit'
+    commit_paths root-markdown 'README.md'
+    commit_paths nested-markdown 'notes/release/details.md'
+    commit_paths docs-non-markdown 'docs/release-notes.txt'
+    commit_paths ponytail-license '.claude/skills/ponytail/LICENSE'
+    commit_paths ponytail-upstream '.claude/skills/ponytail/UPSTREAM'
+    commit_paths caveman-license '.claude/skills/caveman/LICENSE'
+    commit_paths caveman-upstream '.claude/skills/caveman/UPSTREAM'
+    commit_empty empty
     payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
     When call run_gate
     The status should be success
     The output should include "CI green on ${ancestor}"
+  End
+
+  It 'allows hostile and opaque names when their paths are CI-ignored'
+    tab_name="$(printf 'tab\tname')"
+    non_utf8="$(printf '\377')"
+    long_name="$(awk 'BEGIN { for (i = 0; i < 230; i++) printf "n" }')"
+    commit_paths hostile-docs \
+      'docs/space name' \
+      'docs/two  spaces' \
+      "docs/${tab_name}" \
+      'docs/quote"name' \
+      'docs/glob[*?]name' \
+      'docs/pünicode' \
+      "docs/${long_name}" \
+      "docs/non-utf8-${non_utf8}" \
+      'root hostile [*?] name.md'
+    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
+    When call run_gate
+    The status should be success
+    The output should include "CI green on ${ancestor}"
+  End
+
+  It 'rejects an unchecked ordinary code commit'
+    commit_paths code 'scripts/changed.sh'
+    code_sha="$tip"
+    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
+    When call run_gate
+    The status should be failure
+    The output should include "Skipped commit ${code_sha}"
+    The output should include 'changes CI-relevant paths'
+    The output should not include "CI green on ${ancestor}"
+  End
+
+  It 'rejects unchecked executable hooks under vendored plugin trees'
+    commit_executable_paths hooks \
+      '.claude/skills/ponytail/hooks/release.js' \
+      '.claude/skills/caveman/src/hooks/release.js'
+    hook_sha="$tip"
+    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
+    When call run_gate
+    The status should be failure
+    The output should include "Skipped commit ${hook_sha}"
+    The output should include 'changes CI-relevant paths'
+  End
+
+  It 'rejects a near miss of an exact ignored plugin path'
+    commit_paths near-miss '.claude/skills/ponytail/LICENSE.extra'
+    near_miss_sha="$tip"
+    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
+    When call run_gate
+    The status should be failure
+    The output should include "Skipped commit ${near_miss_sha}"
+    The output should include 'changes CI-relevant paths'
+  End
+
+  It 'rejects hostile and opaque names when their paths are CI-relevant'
+    tab_name="$(printf 'tab\tname')"
+    non_utf8="$(printf '\377')"
+    long_name="$(awk 'BEGIN { for (i = 0; i < 230; i++) printf "n" }')"
+    commit_paths hostile-code \
+      'scripts/space name' \
+      'scripts/two  spaces' \
+      "scripts/${tab_name}" \
+      'scripts/quote"name' \
+      'scripts/glob[*?]name' \
+      'scripts/pünicode' \
+      "scripts/${long_name}" \
+      "scripts/non-utf8-${non_utf8}"
+    code_sha="$tip"
+    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
+    When call run_gate
+    The status should be failure
+    The output should include "Skipped commit ${code_sha}"
+    The output should include 'changes CI-relevant paths'
+  End
+
+  It 'classifies every skipped commit before accepting a green ancestor'
+    commit_paths unchecked-code 'scripts/changed.sh'
+    code_sha="$tip"
+    commit_paths docs-after-code 'docs/release-notes.txt'
+    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
+    When call run_gate
+    The status should be failure
+    The output should include "Skipped commit ${code_sha}"
+    The output should not include "CI green on ${ancestor}"
+  End
+
+  It 'fails closed when Git cannot classify a skipped commit'
+    parent_dir="$(printf '%.2s' "$ancestor")"
+    parent_file="$(printf '%s' "$ancestor" | cut -c3-)"
+    rm "${repo}/.git/objects/${parent_dir}/${parent_file}"
+    When call run_gate
+    The status should be failure
+    The output should include "Could not classify skipped commit ${tip}"
+    The output should not include 'CI green on'
   End
 
   It 'fails when a concluded run is not success'

--- a/tests/shell/release_ci_gate_spec.sh
+++ b/tests/shell/release_ci_gate_spec.sh
@@ -236,6 +236,7 @@ EOF
   End
 
   It 'fails closed when Git cannot classify a skipped commit'
+    payload "$ancestor" '{"check_runs":[{"name":"All tests passed","completed_at":"2026-01-01T00:00:00Z","conclusion":"success"}]}'
     parent_dir="$(printf '%.2s' "$ancestor")"
     parent_file="$(printf '%s' "$ancestor" | cut -c3-)"
     rm "${repo}/.git/objects/${parent_dir}/${parent_file}"


### PR DESCRIPTION
## Summary

- Reject release CI walk-back when any skipped commit changes a CI-relevant path.
- Match the exact documentation-only path classes from `test.yml` with Git-native pathspec exclusions.
- Fail closed on Git classification errors while preserving pagination, pending-run, rerun, and 20-commit behavior.

## Validation

- Test-first red proof: 18 examples, 6 expected failures on the original production script; final 18 examples, 0 failures.
- `sh scripts/agent/run-gates.sh --diff origin/devel`: PASS.
- Independent freeze/red/green verifier: PASS.
- Mutation gates killed changed-path bypass, HEAD-only classification, and widened exact-path exclusions.
- Live FreeBSD/UI smoke not applicable: no appliance, package, `src/`, or `www/` surface changed.
- Both commits are signed and verified.

Fixes #1291

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation by walking up to a bounded number of commits via parent traversal.
  * Ensures CI “green” results aren’t reused when intervening changes haven’t been validated.
  * More reliable handling of documentation-only commits, with clearer failures when a commit can’t be classified.
  * Correctly enforces classification/order rules and supports merge-commit history traversal.

* **Tests**
  * Expanded coverage for ignored-path rules, unusual filenames, non-UTF-8 bytes, executable vs non-executable files, empty commits, and fail-closed behavior.
  * Added assertions for commit query-window boundaries and merge-commit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->