### PR TITLE
tests: fix audit honesty and isolation (#1298)

### DIFF
--- a/tests/php/CategoryEditPostGuardTest.php
+++ b/tests/php/CategoryEditPostGuardTest.php
@@ -506,19 +506,6 @@ final class CategoryEditPostGuardTest extends TestCase
 		$this->assertSame($value, $_POST['url-0']);
 	}
 
-	public function testUrlSaveGuardDnsblGtypeAutoFormatRejectsScriptInQuery(): void
-	{
-		// Same code path as ipv4/ipv6 auto (single file; gtype only changes
-		// the format dropdown) -- prove the guard fires on the dnsbl tab too.
-		$this->assertGuardRejects([
-			'aliasname' => 'validname',
-			'state-0'   => 'Enabled',
-			'header-0'  => 'validheader',
-			'url-0'     => 'http://192.0.2.1/?x=<script>alert(1)</script>',
-			'format-0'  => 'auto',
-		], 'DNSBL', 'dnsbl');
-	}
-
 	// -- issue #1104: the remaining format-N axis rows (regex/rsync/whois-reject) --
 
 	public function testUrlSaveGuardRegexFormatRejectsScriptInQuery(): void

--- a/tests/php/IpRecomputeRanWiringTest.php
+++ b/tests/php/IpRecomputeRanWiringTest.php
@@ -29,15 +29,25 @@ final class IpRecomputeRanWiringTest extends TestCase
 	public function testInvocationLoopRecordsWhetherRecomputeRanPerFamily(): void
 	{
 		$source = $this->source();
-		$this->assertStringContainsString(
-			'$pfb_recompute_ran_v4',
+		$this->assertMatchesRegularExpression(
+			'/^\s*\$pfb_recompute_ran_v4 = FALSE;$/m',
 			$source,
-			'the v4 recompute-ran flag must exist so the suppression/closing gates can consume it'
+			'the v4 recompute-ran flag must initialize FALSE in executable code'
 		);
-		$this->assertStringContainsString(
-			'$pfb_recompute_ran_v6',
+		$this->assertMatchesRegularExpression(
+			'/^\s*\$pfb_recompute_ran_v6 = FALSE;$/m',
 			$source,
-			'the v6 recompute-ran flag must exist so the suppression gate can consume it'
+			'the v6 recompute-ran flag must initialize FALSE in executable code'
+		);
+		$this->assertMatchesRegularExpression(
+			'/^\s*\$pfb_recompute_ran_v4 = TRUE;$/m',
+			$source,
+			'the v4 recompute-ran flag must become TRUE after the recompute exec'
+		);
+		$this->assertMatchesRegularExpression(
+			'/^\s*\$pfb_recompute_ran_v6 = TRUE;$/m',
+			$source,
+			'the v6 recompute-ran flag must become TRUE after the recompute exec'
 		);
 	}
 

--- a/tests/php/IpRecomputeRanWiringTest.php
+++ b/tests/php/IpRecomputeRanWiringTest.php
@@ -13,9 +13,9 @@ use PHPUnit\Framework\TestCase;
  * pure helpers (pfb_ip_suppress_body_active(), pfb_ip_closing_pass_active()) rather than
  * their old feed-changed-only / dedup-only conditions.
  *
- * Each assertion is a real substring check against the CURRENT file content, so it fails
- * for as long as the old condition (or no condition at all) is what is actually wired --
- * a stale rename/refactor of any of these lines fails this oracle immediately.
+	 * Assertions scan the CURRENT file content with PHP comments removed, so comment-only
+	 * identifiers cannot satisfy the wiring oracle. A stale rename/refactor of any pinned
+	 * line fails this oracle immediately.
  */
 final class IpRecomputeRanWiringTest extends TestCase
 {
@@ -23,7 +23,17 @@ final class IpRecomputeRanWiringTest extends TestCase
 
 	private function source(): string
 	{
-		return (string) file_get_contents(self::PFBLOCKERNG_INC);
+		$source = '';
+		foreach (token_get_all((string) file_get_contents(self::PFBLOCKERNG_INC)) as $token) {
+			if (is_array($token)) {
+				if (in_array($token[0], [T_COMMENT, T_DOC_COMMENT], TRUE)) {
+					continue;
+				}
+				$token = $token[1];
+			}
+			$source .= $token;
+		}
+		return $source;
 	}
 
 	public function testInvocationLoopRecordsWhetherRecomputeRanPerFamily(): void

--- a/tests/php/SanitizeIpaddrTest.php
+++ b/tests/php/SanitizeIpaddrTest.php
@@ -16,10 +16,24 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('sanitize_ipaddr')]
 final class SanitizeIpaddrTest extends TestCase
 {
+	private bool $hadSupp;
+	private mixed $savedSupp;
+
 	protected function setUp(): void
 	{
+		$this->hadSupp   = array_key_exists('supp', $GLOBALS['pfb'] ?? []);
+		$this->savedSupp = $GLOBALS['pfb']['supp'] ?? null;
 		// Default: suppression OFF (no reserved/private filtering).
 		$GLOBALS['pfb']['supp'] = 'off';
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadSupp) {
+			$GLOBALS['pfb']['supp'] = $this->savedSupp;
+		} else {
+			unset($GLOBALS['pfb']['supp']);
+		}
 	}
 
 	// --- Normalisation (suppression off) -------------------------------------

--- a/tests/php/SanitizeIpaddrV6Test.php
+++ b/tests/php/SanitizeIpaddrV6Test.php
@@ -19,10 +19,24 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('sanitize_ipaddr_v6')]
 final class SanitizeIpaddrV6Test extends TestCase
 {
+	private bool $hadSupp;
+	private mixed $savedSupp;
+
 	protected function setUp(): void
 	{
+		$this->hadSupp   = array_key_exists('supp', $GLOBALS['pfb'] ?? []);
+		$this->savedSupp = $GLOBALS['pfb']['supp'] ?? null;
 		// Default: suppression OFF (no reserved/private filtering).
 		$GLOBALS['pfb']['supp'] = 'off';
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadSupp) {
+			$GLOBALS['pfb']['supp'] = $this->savedSupp;
+		} else {
+			unset($GLOBALS['pfb']['supp']);
+		}
 	}
 
 	// --- Suppression on: reserved/private/loopback dropped -------------------

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -384,6 +384,15 @@ Describe 'claude-bash-guard.sh'
       The output should equal ""
     End
 
+    It 'P16 (issue #1298): bare force BETWEEN two leases -> PASS (the final lease wins)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease --force --force-with-lease"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
     It 'P15 (issue #1058): --force-with-lease --force-if-includes -> PASS (lease companion, not a bare force)'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease --force-if-includes"}}

--- a/tests/shell/pfblockerng_whoisconvert_asn_spec.sh
+++ b/tests/shell/pfblockerng_whoisconvert_asn_spec.sh
@@ -88,7 +88,7 @@ EOF
   Before 'setup'
   After 'cleanup'
 
-  It 'keeps the FIRST ASN range when a second ASN entry follows'
+  It 'accumulates BOTH ASN ranges across the two ASN entries'
     When call whoisconvert
     The status should be success
     The stdout should include 'Collecting ASN: AS64501'

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -765,7 +765,10 @@ def test_recompute_geoip_outage_preserves_match_artifacts(deployed_vm: SmokeVM) 
         )
     finally:
         if stashed:
-            deployed_vm.ssh("/bin/mv", stash_path, mmdb_path)
+            restored = deployed_vm.ssh("/bin/mv", stash_path, mmdb_path)
+            assert restored.returncode == 0, (
+                f"could not restore {mmdb_path}: rc={restored.returncode} stderr={restored.stderr!r}"
+            )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_adr62_parity_oracle.py
+++ b/tests/test_adr62_parity_oracle.py
@@ -363,7 +363,7 @@ def test_hostile_regex_shapes_route_to_parse_abp() -> None:
     )
     assert _blocked(result, "re1.example")
     assert _allowed(result, "re2.example")
-    assert result.zone_db.get("re3.example", {}).get("important") is True or "re3.example" in result.data_db
+    assert result.data_db["re3.example"]["important"] is True
 
 
 def test_hostile_banded_rules_preserve_domain() -> None:


### PR DESCRIPTION
Fixes #1298

## Summary

- replace a vacuous ADR-62 assertion with a direct `$important` pin
- remove one exact duplicate PHP guard row and add missing shell/recompute mutation coverage
- restore sanitizer global state for both IP families and make GeoIP smoke cleanup fail loudly
- correct the WHOIS multi-ASN test title without changing its assertions

## Verification

- full canonical Python, PHP, and dash shell gates passed
- independent sanitizer base-RED/HEAD-GREEN proof passed
- independent mutations caught lost `$important`, first-lease stripping, comment-only v4/v6 assignments, and unchecked smoke restore failures
- focused tests: pytest `1 passed`; PHPUnit `119 tests, 165 assertions`; shellspec `94 examples, 0 failures`
- live pfSense smoke passed twice on leased boxes (`.31` and `.34`), with both leases released

## Audit

- test-only diff: eight planned files, `+59/-22`
- signed commit; independent phase-step verifier passed every matrix, honesty, convention, and clean-restoration check
- rebased onto current `origin/devel`; intervening base commits touched none of the cited issue paths

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
