### PR TITLE
tests: pin download failure guard polarity

### DIFF
--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -177,11 +177,9 @@ final class DownloadExtractionExitCodeTest extends TestCase
 				if ($depth === 0) {
 					break;
 				}
-			} elseif ($depth === 1
-				&& $tokens[$i]['id'] === T_RETURN
-				&& ($tokens[$i + 1] ?? NULL) === array('id' => T_STRING, 'text' => 'FALSE')
-				&& ($tokens[$i + 2]['text'] ?? '') === ';') {
-				return TRUE;
+			} elseif ($depth === 1 && $tokens[$i]['id'] === T_RETURN) {
+				return ($tokens[$i + 1] ?? NULL) === array('id' => T_STRING, 'text' => 'FALSE')
+					&& ($tokens[$i + 2]['text'] ?? '') === ';';
 			}
 		}
 
@@ -324,14 +322,12 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 	public function testUncompressedExtrasChecksRenameResult(): void
 	{
-		$renameCall = strpos(self::$body, '@rename("{$file_download}", "{$head_download}")');
-		$this->assertNotFalse($renameCall, 'vacuity: the uncompressed-extras rename site must exist');
-		$renamePos = strrpos(substr(self::$body, 0, $renameCall), "\n");
-		$renamePos = $renamePos === FALSE ? 0 : $renamePos + 1;
+		$branchPos = strpos(self::$body, '// Uncompressed file format.');
+		$this->assertNotFalse($branchPos, 'vacuity: the uncompressed-format branch must exist');
 
-		$nextBranch = strpos(self::$body, "elseif (\$type == 'blacklist') {", $renamePos);
+		$nextBranch = strpos(self::$body, "elseif (\$type == 'blacklist') {", $branchPos);
 		$this->assertNotFalse($nextBranch, 'vacuity: the uncompressed-blacklist sibling branch must exist');
-		$segment = substr(self::$body, $renamePos, $nextBranch - $renamePos);
+		$segment = substr(self::$body, $branchPos, $nextBranch - $branchPos);
 
 		$analysis = self::analyzeRenameGuard($segment, '$head_download');
 		$this->assertTrue($analysis['bound'],

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -62,14 +62,15 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	private static function hasNonzeroRetvalGuard(string $segment): bool
 	{
 		$tokens = self::significantTokens($segment);
-		for ($i = 0, $last = count($tokens) - 6; $i <= $last; $i++) {
+		for ($i = 0, $last = count($tokens) - 7; $i <= $last; $i++) {
 			if ($tokens[$i]['id'] === T_IF
 				&& $tokens[$i + 1]['text'] === '('
 				&& $tokens[$i + 2] === array('id' => T_VARIABLE, 'text' => '$retval')
 				&& $tokens[$i + 3]['id'] === T_IS_NOT_EQUAL
 				&& $tokens[$i + 4] === array('id' => T_LNUMBER, 'text' => '0')
 				&& $tokens[$i + 5]['text'] === ')') {
-				return TRUE;
+				return $tokens[$i + 6]['text'] === '{'
+					&& self::hasDirectFalseReturn($tokens, $i + 6);
 			}
 		}
 
@@ -84,8 +85,14 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$tokens = self::significantTokens($segment);
 		$count = count($tokens);
 		for ($i = 0; $i < $count; $i++) {
-			if ($tokens[$i] !== array('id' => T_STRING, 'text' => 'rename')
-				|| ($tokens[$i + 1]['text'] ?? '') !== '(') {
+			$previousId = $tokens[$i - 1]['id'] ?? NULL;
+			$isGlobalRename = ($tokens[$i]['id'] === T_STRING
+					&& strcasecmp($tokens[$i]['text'], 'rename') === 0)
+				|| ($tokens[$i]['id'] === T_NAME_FULLY_QUALIFIED
+					&& strcasecmp($tokens[$i]['text'], '\\rename') === 0);
+			if (!$isGlobalRename
+				|| ($tokens[$i + 1]['text'] ?? '') !== '('
+				|| in_array($previousId, [T_OBJECT_OPERATOR, T_NULLSAFE_OBJECT_OPERATOR, T_DOUBLE_COLON, T_NEW, T_FUNCTION], TRUE)) {
 				continue;
 			}
 
@@ -93,8 +100,11 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			if (($tokens[$assignment]['text'] ?? '') === '@') {
 				$assignment--;
 			}
+			$lhs = $assignment - 1;
+			$boundary = $tokens[$lhs - 1]['text'] ?? NULL;
 			if (($tokens[$assignment]['text'] ?? '') !== '='
-				|| ($tokens[$assignment - 1] ?? NULL) !== array('id' => T_VARIABLE, 'text' => '$renamed')) {
+				|| ($tokens[$lhs] ?? NULL) !== array('id' => T_VARIABLE, 'text' => '$renamed')
+				|| ($boundary !== NULL && !in_array($boundary, [';', '{', '}'], TRUE))) {
 				return array('bound' => FALSE, 'directReturn' => FALSE);
 			}
 
@@ -343,10 +353,10 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 	public function testGenericUncompressedRenameResultChecked(): void
 	{
-		$commentPos = strpos(self::$body, "Rename file to 'orig' format");
+		$commentPos = strpos(self::$body, "// Rename file to 'orig' format");
 		$this->assertNotFalse($commentPos, 'vacuity: the generic-uncompressed orig-rename comment must exist');
 
-		$secondPos = strpos(self::$body, "Rename file to 'orig' format", $commentPos + 1);
+		$secondPos = strpos(self::$body, "// Rename file to 'orig' format", $commentPos + 1);
 		$this->assertFalse($secondPos, 'vacuity: "Rename file to \'orig\' format" must appear exactly once');
 
 		$gatePos = strpos(self::$body, 'if ($retval == 0) {', $commentPos);

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -84,24 +84,24 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$tokens = self::significantTokens($segment);
 		$count = count($tokens);
 		for ($i = 0; $i < $count; $i++) {
-			if ($tokens[$i] !== array('id' => T_VARIABLE, 'text' => '$renamed')
-				|| ($tokens[$i + 1]['text'] ?? '') !== '=') {
+			if ($tokens[$i] !== array('id' => T_STRING, 'text' => 'rename')
+				|| ($tokens[$i + 1]['text'] ?? '') !== '(') {
 				continue;
 			}
 
-			$call = $i + 2;
-			if (($tokens[$call]['text'] ?? '') === '@') {
-				$call++;
+			$assignment = $i - 1;
+			if (($tokens[$assignment]['text'] ?? '') === '@') {
+				$assignment--;
 			}
-			if (($tokens[$call] ?? NULL) !== array('id' => T_STRING, 'text' => 'rename')
-				|| ($tokens[$call + 1]['text'] ?? '') !== '(') {
-				continue;
+			if (($tokens[$assignment]['text'] ?? '') !== '='
+				|| ($tokens[$assignment - 1] ?? NULL) !== array('id' => T_VARIABLE, 'text' => '$renamed')) {
+				return array('bound' => FALSE, 'directReturn' => FALSE);
 			}
 
 			$args = array(array());
 			$depth = 1;
 			$close = NULL;
-			for ($j = $call + 2; $j < $count; $j++) {
+			for ($j = $i + 2; $j < $count; $j++) {
 				if ($tokens[$j]['text'] === '(') {
 					$depth++;
 				} elseif ($tokens[$j]['text'] === ')') {
@@ -117,14 +117,14 @@ final class DownloadExtractionExitCodeTest extends TestCase
 				$args[array_key_last($args)][] = $tokens[$j];
 			}
 
-			$variables = array_map(
-				static fn(array $arg): array => array_values(array_map(
+			$argumentText = array_map(
+				static fn(array $arg): string => implode('', array_map(
 					static fn(array $token): string => $token['text'],
-					array_filter($arg, static fn(array $token): bool => $token['id'] === T_VARIABLE)
+					$arg
 				)),
 				$args
 			);
-			if ($close === NULL || $variables !== [['$file_download'], [$destination]]) {
+			if ($close === NULL || $argumentText !== ['"{$file_download}"', '"{' . $destination . '}"']) {
 				return array('bound' => FALSE, 'directReturn' => FALSE);
 			}
 

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -39,6 +39,155 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		self::$body = substr($source, $start, $end - $start);
 	}
 
+	/**
+	 * @return list<array{id: int|null, text: string}>
+	 */
+	private static function significantTokens(string $source): array
+	{
+		$tokens = array();
+		foreach (token_get_all('<?php ' . $source) as $token) {
+			if (is_array($token)) {
+				if (in_array($token[0], [T_OPEN_TAG, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], TRUE)) {
+					continue;
+				}
+				$tokens[] = array('id' => $token[0], 'text' => $token[1]);
+			} else {
+				$tokens[] = array('id' => NULL, 'text' => $token);
+			}
+		}
+
+		return $tokens;
+	}
+
+	private static function hasNonzeroRetvalGuard(string $segment): bool
+	{
+		$tokens = self::significantTokens($segment);
+		for ($i = 0, $last = count($tokens) - 6; $i <= $last; $i++) {
+			if ($tokens[$i]['id'] === T_IF
+				&& $tokens[$i + 1]['text'] === '('
+				&& $tokens[$i + 2] === array('id' => T_VARIABLE, 'text' => '$retval')
+				&& $tokens[$i + 3]['id'] === T_IS_NOT_EQUAL
+				&& $tokens[$i + 4] === array('id' => T_LNUMBER, 'text' => '0')
+				&& $tokens[$i + 5]['text'] === ')') {
+				return TRUE;
+			}
+		}
+
+		return FALSE;
+	}
+
+	/**
+	 * @return array{bound: bool, directReturn: bool}
+	 */
+	private static function analyzeRenameGuard(string $segment, string $destination): array
+	{
+		$tokens = self::significantTokens($segment);
+		$count = count($tokens);
+		for ($i = 0; $i < $count; $i++) {
+			if ($tokens[$i] !== array('id' => T_VARIABLE, 'text' => '$renamed')
+				|| ($tokens[$i + 1]['text'] ?? '') !== '=') {
+				continue;
+			}
+
+			$call = $i + 2;
+			if (($tokens[$call]['text'] ?? '') === '@') {
+				$call++;
+			}
+			if (($tokens[$call] ?? NULL) !== array('id' => T_STRING, 'text' => 'rename')
+				|| ($tokens[$call + 1]['text'] ?? '') !== '(') {
+				continue;
+			}
+
+			$args = array(array());
+			$depth = 1;
+			$close = NULL;
+			for ($j = $call + 2; $j < $count; $j++) {
+				if ($tokens[$j]['text'] === '(') {
+					$depth++;
+				} elseif ($tokens[$j]['text'] === ')') {
+					$depth--;
+					if ($depth === 0) {
+						$close = $j;
+						break;
+					}
+				} elseif ($tokens[$j]['text'] === ',' && $depth === 1) {
+					$args[] = array();
+					continue;
+				}
+				$args[array_key_last($args)][] = $tokens[$j];
+			}
+
+			$variables = array_map(
+				static fn(array $arg): array => array_values(array_map(
+					static fn(array $token): string => $token['text'],
+					array_filter($arg, static fn(array $token): bool => $token['id'] === T_VARIABLE)
+				)),
+				$args
+			);
+			if ($close === NULL || $variables !== [['$file_download'], [$destination]]) {
+				return array('bound' => FALSE, 'directReturn' => FALSE);
+			}
+
+			$guard = $close + 2;
+			$bound = ($tokens[$close + 1]['text'] ?? '') === ';'
+				&& ($tokens[$guard]['id'] ?? NULL) === T_IF
+				&& ($tokens[$guard + 1]['text'] ?? '') === '('
+				&& ($tokens[$guard + 2]['text'] ?? '') === '!'
+				&& ($tokens[$guard + 3] ?? NULL) === array('id' => T_VARIABLE, 'text' => '$renamed')
+				&& ($tokens[$guard + 4]['text'] ?? '') === ')'
+				&& ($tokens[$guard + 5]['text'] ?? '') === '{';
+			if (!$bound) {
+				return array('bound' => FALSE, 'directReturn' => FALSE);
+			}
+
+			return array(
+				'bound' => TRUE,
+				'directReturn' => self::hasDirectFalseReturn($tokens, $guard + 5)
+			);
+		}
+
+		return array('bound' => FALSE, 'directReturn' => FALSE);
+	}
+
+	/**
+	 * @param list<array{id: int|null, text: string}> $tokens
+	 */
+	private static function hasDirectFalseReturn(array $tokens, int $openingBrace): bool
+	{
+		$depth = 1;
+		$interpolationDepth = 0;
+		$count = count($tokens);
+		for ($i = $openingBrace + 1; $i < $count; $i++) {
+			if ($tokens[$i]['id'] === T_CURLY_OPEN || $tokens[$i]['id'] === T_DOLLAR_OPEN_CURLY_BRACES) {
+				$interpolationDepth++;
+				continue;
+			}
+			if ($interpolationDepth > 0) {
+				if ($tokens[$i]['text'] === '{') {
+					$interpolationDepth++;
+				} elseif ($tokens[$i]['text'] === '}') {
+					$interpolationDepth--;
+				}
+				continue;
+			}
+			if ($tokens[$i]['text'] === '{') {
+				$depth++;
+			} elseif ($tokens[$i]['text'] === '}') {
+				$depth--;
+				if ($depth === 0) {
+					break;
+				}
+			} elseif ($depth === 1
+				&& $tokens[$i]['id'] === T_RETURN
+				&& ($tokens[$i + 1] ?? NULL) === array('id' => T_STRING, 'text' => 'FALSE')
+				&& ($tokens[$i + 2]['text'] ?? '') === ';') {
+				return TRUE;
+			}
+		}
+
+		return FALSE;
+	}
+
 	// -----------------------------------------------------------------------
 	// Row 1 -- gzip geoip: /usr/bin/tar -xzf site.
 	// -----------------------------------------------------------------------
@@ -50,11 +199,13 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 		$returnTrue = strpos(self::$body, 'return TRUE;', $tarPos);
 		$this->assertNotFalse($returnTrue, 'vacuity: gzip-geoip site must reach a return TRUE;');
-		$segment = substr(self::$body, $tarPos, $returnTrue + strlen('return TRUE;') - $tarPos);
+		$segmentStart = strrpos(substr(self::$body, 0, $tarPos), "\n");
+		$segmentStart = $segmentStart === FALSE ? 0 : $segmentStart + 1;
+		$segment = substr(self::$body, $segmentStart, $returnTrue + strlen('return TRUE;') - $segmentStart);
 
 		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segment,
 			'gzip-geoip tar -xzf must capture $output, $retval -- a corrupt archive currently reports success unconditionally');
-		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*!=\s*0\s*\)|if\s*\(\s*\$retval\s*<>\s*0\s*\)/', $segment,
+		$this->assertTrue(self::hasNonzeroRetvalGuard($segment),
 			'gzip-geoip must check nonzero $retval before its return TRUE -- a nonzero exit must not report success');
 	}
 
@@ -100,7 +251,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($returnTrue, 'vacuity: gzip-top1m site must reach a return TRUE;');
 		$segment = substr(self::$body, $gunzip, $returnTrue + strlen('return TRUE;') - $gunzip);
 
-		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*!=\s*0\s*\)|if\s*\(\s*\$retval\s*<>\s*0\s*\)/', $segment,
+		$this->assertTrue(self::hasNonzeroRetvalGuard($segment),
 			'gzip-top1m must check nonzero $retval before its return TRUE -- a nonzero gunzip exit must not report success; '
 			. 'segment: ' . json_encode($segment));
 	}
@@ -162,7 +313,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$segSingleToReturn = substr(self::$body, $single, $returnTrue + strlen('return TRUE;') - $single);
 		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segSingleToReturn,
 			'zip single-member tar -xOf must capture $output, $retval; segment: ' . json_encode($segSingleToReturn));
-		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*!=\s*0\s*\)|if\s*\(\s*\$retval\s*<>\s*0\s*\)/', $segSingleToReturn,
+		$this->assertTrue(self::hasNonzeroRetvalGuard($segSingleToReturn),
 			'zip extras must check nonzero $retval before their shared return TRUE; segment: '
 			. json_encode($segSingleToReturn));
 	}
@@ -173,21 +324,19 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 	public function testUncompressedExtrasChecksRenameResult(): void
 	{
-		$renamePos = strpos(self::$body, '$renamed = @rename("{$file_download}", "{$head_download}");');
-		$this->assertNotFalse($renamePos, 'vacuity: the uncompressed-extras rename site must exist');
+		$renameCall = strpos(self::$body, '@rename("{$file_download}", "{$head_download}")');
+		$this->assertNotFalse($renameCall, 'vacuity: the uncompressed-extras rename site must exist');
+		$renamePos = strrpos(substr(self::$body, 0, $renameCall), "\n");
+		$renamePos = $renamePos === FALSE ? 0 : $renamePos + 1;
 
 		$nextBranch = strpos(self::$body, "elseif (\$type == 'blacklist') {", $renamePos);
 		$this->assertNotFalse($nextBranch, 'vacuity: the uncompressed-blacklist sibling branch must exist');
 		$segment = substr(self::$body, $renamePos, $nextBranch - $renamePos);
 
-		$matched = preg_match(
-			'/^\h*\$renamed\s*=\s*@rename\([^;]*\);\R\h*if\s*\(\s*!\s*\$renamed\s*\)\s*\{\R(?<failure>.*?)^\h*\}/ms',
-			$segment,
-			$match
-		);
-		$this->assertSame(1, $matched,
+		$analysis = self::analyzeRenameGuard($segment, '$head_download');
+		$this->assertTrue($analysis['bound'],
 			'uncompressed extras must check !$renamed before return TRUE; segment: ' . json_encode($segment));
-		$this->assertStringContainsString('return FALSE', $match['failure'] ?? '',
+		$this->assertTrue($analysis['directReturn'],
 			'a failed rename() must have a return FALSE path; segment: ' . json_encode($segment));
 	}
 
@@ -209,15 +358,11 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 		$segment = substr(self::$body, $commentPos, $gatePos - $commentPos);
 
-		$matched = preg_match(
-			'/^\h*\$renamed\s*=\s*@rename\([^;]*\);\R\h*if\s*\(\s*!\s*\$renamed\s*\)\s*\{\R(?<failure>.*?)^\h*\}/ms',
-			$segment,
-			$match
-		);
-		$this->assertSame(1, $matched,
+		$analysis = self::analyzeRenameGuard($segment, '$orig_download');
+		$this->assertTrue($analysis['bound'],
 			'generic uncompressed feeds must check !$renamed before the $retval == 0 success gate; segment: '
 			. json_encode($segment));
-		$this->assertStringContainsString('return FALSE', $match['failure'] ?? '',
+		$this->assertTrue($analysis['directReturn'],
 			'a failed rename() must have a return FALSE path before the success gate; segment: ' . json_encode($segment));
 	}
 }

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -62,8 +62,11 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	private static function hasNonzeroRetvalGuard(string $segment): bool
 	{
 		$tokens = self::significantTokens($segment);
+		$depths = self::structuralDepths($tokens);
+		$outerDepth = $depths === array() ? 0 : min($depths);
 		for ($i = 0, $last = count($tokens) - 7; $i <= $last; $i++) {
-			if ($tokens[$i]['id'] === T_IF
+			if ($depths[$i] === $outerDepth
+				&& $tokens[$i]['id'] === T_IF
 				&& $tokens[$i + 1]['text'] === '('
 				&& $tokens[$i + 2] === array('id' => T_VARIABLE, 'text' => '$retval')
 				&& $tokens[$i + 3]['id'] === T_IS_NOT_EQUAL
@@ -80,9 +83,10 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	/**
 	 * @return array{bound: bool, directReturn: bool}
 	 */
-	private static function analyzeRenameGuard(string $segment, string $destination): array
+	private static function analyzeRenameGuard(string $segment, string $destination, int $outerDepth = 0): array
 	{
 		$tokens = self::significantTokens($segment);
+		$depths = self::structuralDepths($tokens);
 		$count = count($tokens);
 		for ($i = 0; $i < $count; $i++) {
 			$previousId = $tokens[$i - 1]['id'] ?? NULL;
@@ -95,6 +99,9 @@ final class DownloadExtractionExitCodeTest extends TestCase
 				|| in_array($previousId, [T_OBJECT_OPERATOR, T_NULLSAFE_OBJECT_OPERATOR, T_DOUBLE_COLON, T_NEW, T_FUNCTION], TRUE)) {
 				continue;
 			}
+			if ($depths[$i] !== $outerDepth) {
+				continue;
+			}
 
 			$assignment = $i - 1;
 			if (($tokens[$assignment]['text'] ?? '') === '@') {
@@ -104,6 +111,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			$boundary = $tokens[$lhs - 1]['text'] ?? NULL;
 			if (($tokens[$assignment]['text'] ?? '') !== '='
 				|| ($tokens[$lhs] ?? NULL) !== array('id' => T_VARIABLE, 'text' => '$renamed')
+				|| ($depths[$assignment] ?? NULL) !== $outerDepth
+				|| ($depths[$lhs] ?? NULL) !== $outerDepth
 				|| ($boundary !== NULL && !in_array($boundary, [';', '{', '}'], TRUE))) {
 				return array('bound' => FALSE, 'directReturn' => FALSE);
 			}
@@ -140,7 +149,9 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 			$guard = $close + 2;
 			$bound = ($tokens[$close + 1]['text'] ?? '') === ';'
+				&& ($depths[$close] ?? NULL) === $outerDepth
 				&& ($tokens[$guard]['id'] ?? NULL) === T_IF
+				&& ($depths[$guard] ?? NULL) === $outerDepth
 				&& ($tokens[$guard + 1]['text'] ?? '') === '('
 				&& ($tokens[$guard + 2]['text'] ?? '') === '!'
 				&& ($tokens[$guard + 3] ?? NULL) === array('id' => T_VARIABLE, 'text' => '$renamed')
@@ -157,6 +168,39 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		}
 
 		return array('bound' => FALSE, 'directReturn' => FALSE);
+	}
+
+	/**
+	 * @param list<array{id: int|null, text: string}> $tokens
+	 * @return list<int>
+	 */
+	private static function structuralDepths(array $tokens): array
+	{
+		$depth = 0;
+		$interpolationDepth = 0;
+		$depths = array();
+		foreach ($tokens as $token) {
+			$depths[] = $depth;
+			if ($token['id'] === T_CURLY_OPEN || $token['id'] === T_DOLLAR_OPEN_CURLY_BRACES) {
+				$interpolationDepth++;
+				continue;
+			}
+			if ($interpolationDepth > 0) {
+				if ($token['text'] === '{') {
+					$interpolationDepth++;
+				} elseif ($token['text'] === '}') {
+					$interpolationDepth--;
+				}
+				continue;
+			}
+			if ($token['text'] === '{') {
+				$depth++;
+			} elseif ($token['text'] === '}') {
+				$depth--;
+			}
+		}
+
+		return $depths;
 	}
 
 	/**
@@ -339,7 +383,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($nextBranch, 'vacuity: the uncompressed-blacklist sibling branch must exist');
 		$segment = substr(self::$body, $branchPos, $nextBranch - $branchPos);
 
-		$analysis = self::analyzeRenameGuard($segment, '$head_download');
+		$analysis = self::analyzeRenameGuard($segment, '$head_download', 1);
 		$this->assertTrue($analysis['bound'],
 			'uncompressed extras must check !$renamed before return TRUE; segment: ' . json_encode($segment));
 		$this->assertTrue($analysis['directReturn'],

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -173,16 +173,21 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 	public function testUncompressedExtrasChecksRenameResult(): void
 	{
-		$renamePos = strpos(self::$body, '@rename("{$file_download}", "{$head_download}");');
+		$renamePos = strpos(self::$body, '$renamed = @rename("{$file_download}", "{$head_download}");');
 		$this->assertNotFalse($renamePos, 'vacuity: the uncompressed-extras rename site must exist');
 
 		$nextBranch = strpos(self::$body, "elseif (\$type == 'blacklist') {", $renamePos);
 		$this->assertNotFalse($nextBranch, 'vacuity: the uncompressed-blacklist sibling branch must exist');
 		$segment = substr(self::$body, $renamePos, $nextBranch - $renamePos);
 
-		$this->assertMatchesRegularExpression('/if\s*\(\s*!\s*\$renamed\s*\)/', $segment,
+		$matched = preg_match(
+			'/^\h*\$renamed\s*=\s*@rename\([^;]*\);\R\h*if\s*\(\s*!\s*\$renamed\s*\)\s*\{\R(?<failure>.*?)^\h*\}/ms',
+			$segment,
+			$match
+		);
+		$this->assertSame(1, $matched,
 			'uncompressed extras must check !$renamed before return TRUE; segment: ' . json_encode($segment));
-		$this->assertStringContainsString('return FALSE', $segment,
+		$this->assertStringContainsString('return FALSE', $match['failure'] ?? '',
 			'a failed rename() must have a return FALSE path; segment: ' . json_encode($segment));
 	}
 
@@ -204,10 +209,15 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 		$segment = substr(self::$body, $commentPos, $gatePos - $commentPos);
 
-		$this->assertMatchesRegularExpression('/if\s*\(\s*!\s*\$renamed\s*\)/', $segment,
+		$matched = preg_match(
+			'/^\h*\$renamed\s*=\s*@rename\([^;]*\);\R\h*if\s*\(\s*!\s*\$renamed\s*\)\s*\{\R(?<failure>.*?)^\h*\}/ms',
+			$segment,
+			$match
+		);
+		$this->assertSame(1, $matched,
 			'generic uncompressed feeds must check !$renamed before the $retval == 0 success gate; segment: '
 			. json_encode($segment));
-		$this->assertStringContainsString('return FALSE', $segment,
+		$this->assertStringContainsString('return FALSE', $match['failure'] ?? '',
 			'a failed rename() must have a return FALSE path before the success gate; segment: ' . json_encode($segment));
 	}
 }

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -54,8 +54,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segment,
 			'gzip-geoip tar -xzf must capture $output, $retval -- a corrupt archive currently reports success unconditionally');
-		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval/', $segment,
-			'gzip-geoip must check $retval before its return TRUE -- a nonzero exit must not report success');
+		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*!=\s*0\s*\)|if\s*\(\s*\$retval\s*<>\s*0\s*\)/', $segment,
+			'gzip-geoip must check nonzero $retval before its return TRUE -- a nonzero exit must not report success');
 	}
 
 	// -----------------------------------------------------------------------
@@ -100,8 +100,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($returnTrue, 'vacuity: gzip-top1m site must reach a return TRUE;');
 		$segment = substr(self::$body, $gunzip, $returnTrue + strlen('return TRUE;') - $gunzip);
 
-		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval/', $segment,
-			'gzip-top1m must check $retval before its return TRUE -- a nonzero gunzip exit must not report success; '
+		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*!=\s*0\s*\)|if\s*\(\s*\$retval\s*<>\s*0\s*\)/', $segment,
+			'gzip-top1m must check nonzero $retval before its return TRUE -- a nonzero gunzip exit must not report success; '
 			. 'segment: ' . json_encode($segment));
 	}
 
@@ -162,8 +162,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$segSingleToReturn = substr(self::$body, $single, $returnTrue + strlen('return TRUE;') - $single);
 		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segSingleToReturn,
 			'zip single-member tar -xOf must capture $output, $retval; segment: ' . json_encode($segSingleToReturn));
-		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval/', $segSingleToReturn,
-			'zip extras must check $retval before their shared return TRUE; segment: '
+		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*!=\s*0\s*\)|if\s*\(\s*\$retval\s*<>\s*0\s*\)/', $segSingleToReturn,
+			'zip extras must check nonzero $retval before their shared return TRUE; segment: '
 			. json_encode($segSingleToReturn));
 	}
 
@@ -180,9 +180,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($nextBranch, 'vacuity: the uncompressed-blacklist sibling branch must exist');
 		$segment = substr(self::$body, $renamePos, $nextBranch - $renamePos);
 
-		$this->assertDoesNotMatchRegularExpression('/@rename\([^;]*\);\s*return TRUE;/', $segment,
-			'a bare @rename(...); return TRUE; ignores rename()\'s own failure -- a failed rename must not '
-			. 'report success; segment: ' . json_encode($segment));
+		$this->assertMatchesRegularExpression('/if\s*\(\s*!\s*\$renamed\s*\)/', $segment,
+			'uncompressed extras must check !$renamed before return TRUE; segment: ' . json_encode($segment));
 		$this->assertStringContainsString('return FALSE', $segment,
 			'a failed rename() must have a return FALSE path; segment: ' . json_encode($segment));
 	}
@@ -205,9 +204,9 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 		$segment = substr(self::$body, $commentPos, $gatePos - $commentPos);
 
-		$this->assertDoesNotMatchRegularExpression('/@rename\([^;]*\);\s*\$retval\s*=\s*0;/', $segment,
-			'a bare @rename(...); $retval = 0; ignores rename()\'s own failure -- a failed rename must not '
-			. 'enter the $retval == 0 success gate; segment: ' . json_encode($segment));
+		$this->assertMatchesRegularExpression('/if\s*\(\s*!\s*\$renamed\s*\)/', $segment,
+			'generic uncompressed feeds must check !$renamed before the $retval == 0 success gate; segment: '
+			. json_encode($segment));
 		$this->assertStringContainsString('return FALSE', $segment,
 			'a failed rename() must have a return FALSE path before the success gate; segment: ' . json_encode($segment));
 	}


### PR DESCRIPTION
## Summary

- tighten three extraction exit-code assertions to require a nonzero guard
- require failure polarity for both uncompressed-feed rename guards
- keep production byte-identical and preserve all existing vacuity anchors

## Evidence

- before: five independent guard inversions survived their focused tests
- after: real source passes `8 tests, 33 assertions`; all five mutants fail their single focused test
- canonical PHP gates: syntax, full PHPUnit, PHPStan, and PHPCS pass
- independent phase verifier: PASS across all eight coverage-matrix rows

## Smoke

Skipped proportionately: this changes only an off-appliance source-inspection test and has no shipped or appliance runtime surface.

Fixes #1295

---

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened automated checks for download extraction failure handling, ensuring failures correctly follow the existing failure paths.
  * Improved validation of rename failure behavior and the surrounding control flow, including direct return behavior.
  * Reworked static inspection logic to use token-based analysis for more reliable coverage across gzip, zip, tar, and uncompressed downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->