### PR TITLE
scripts: reject single-quoted guard bypasses

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/scripts/claude-bash-guard.sh\" 7a776a40f47d000f1d4db4a1ff0bdc7602c3c5944f751307066f46ac103667c8 && exec sh \"$root/scripts/claude-bash-guard.sh\"",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/scripts/claude-bash-guard.sh\" 5d764049dd28e5964de46167b313faa28681e6052ef0f8986288da6b88d7b7e3 && exec sh \"$root/scripts/claude-bash-guard.sh\"",
             "timeout": 10,
             "statusMessage": "Checking repository Git policy"
           },

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -66,8 +66,8 @@
 #      "--no-verify" (`git commit -m 'handle the --no-verify flag'`) also
 #      denies, because the guard cannot distinguish "the flag" from "prose
 #      about the flag" without a real parse.
-#   2. Normalization (below) strips quotes/backslashes and collapses
-#      whitespace BEFORE splitting into segments, specifically so
+#   2. Normalization (below) strips single/double quotes and backslashes,
+#      then collapses whitespace BEFORE splitting into segments, specifically so
 #      whitespace/quoting variance in the invoking command can't evade a
 #      rule -- but matching still runs over a segment's full text, so the
 #      same phrase-anywhere-in-segment caveat holds after normalization too.
@@ -108,8 +108,8 @@
 #
 # NORMALIZATION (issue #923 review F1): rather than matching rules against
 # the raw payload, everything matches against $norm, built by:
-#   1. Deleting every `"` and `\` character -- collapses JSON-escaped quotes
-#      and a quoted subcommand token alike (`git \"commit\"` -> `git commit`).
+#   1. Deleting every `'`, `"`, and `\` character -- collapses JSON-escaped quotes
+#      and a quoted subcommand token alike (`git 'commit'` -> `git commit`).
 #   2. Collapsing every run of whitespace (space/tab/newline) to one space --
 #      defeats `git  commit` (double space) or a literal tab between tokens.
 # Fail-open holds through normalization: empty/garbled input still normalizes
@@ -133,9 +133,9 @@ set -u
 payload="$(cat)"
 
 # norm -- the single normalized view every rule matches against (see
-# NORMALIZATION above): strip " and \, then collapse whitespace runs to one
+# NORMALIZATION above): strip ', ", and \, then collapse whitespace runs to one
 # space.
-norm="$(printf '%s' "$payload" | tr -d '\\"' | tr -s '[:space:]' ' ')"
+norm="$(printf '%s' "$payload" | tr -d "\\\\\"'" | tr -s '[:space:]' ' ')"
 
 # segs -- $norm split into newline-separated SEGMENTS on shell
 # command-separator metacharacters (`; & | ( )`). Each rule below matches
@@ -148,8 +148,9 @@ norm="$(printf '%s' "$payload" | tr -d '\\"' | tr -s '[:space:]' ' ')"
 # delimiter here is unambiguous.
 segs="$(printf '%s' "$norm" | tr ';&|()' '\n')"
 
-# norm_bg -- the view Rule D matches on: $norm (quotes/backslashes stripped, whitespace
-# collapsed) with the two `&` LOOKALIKES neutralized -- a redirection (`2>&1`, `>&2`,
+# norm_bg -- the view Rule D matches on: $norm (single/double quotes and
+# backslashes stripped, whitespace collapsed) with the two `&` LOOKALIKES
+# neutralized -- a redirection (`2>&1`, `>&2`,
 # `&>`) and the `&&` list operator -- so a surviving `&` is unambiguously a background.
 # Never $segs: `&` is one of the characters $segs splits on, so backgrounding is
 # invisible per-segment.

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -112,6 +112,15 @@ Describe 'claude-bash-guard.sh'
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
 
+    It 'H22 (#1339): single-quoted subcommand token (git '\''commit'\'' -n -m x) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git 'commit' -n -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
     It 'H12a (F5 full JSON validity): exact deny JSON for Rule A'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git commit --no-verify -m x"}}
@@ -130,9 +139,27 @@ Describe 'claude-bash-guard.sh'
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
 
+    It 'B18 (#1339): single-quoted standalone short flag (git commit '\''-n'\'' -m x) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit '-n' -m x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
     It 'B12 (#1292): clustered short flag, n mid-cluster (git commit -anm x) -> DENY'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git commit -anm x"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B19 (#1339): single-quoted short-flag cluster (git commit '\''-an'\'' -m x) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit '-an' -m x"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -240,6 +267,24 @@ Describe 'claude-bash-guard.sh'
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
 
+    It 'B20 (#1339): single-quoted standalone short flag (git push '\''-f'\'' origin main) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push '-f' origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B21 (#1339): single-quoted push subcommand token (git '\''push'\'' -f origin main) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git 'push' -f origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
     It 'B6: flag after args (git push origin main --force) -> DENY'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git push origin main --force"}}
@@ -288,6 +333,15 @@ Describe 'claude-bash-guard.sh'
     It 'H7 (F3 clustered short flag): git push -uf origin main -> DENY'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git push -uf origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H23 (#1339): single-quoted short-flag cluster (git push '\''-uf'\'' origin main) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push '-uf' origin main"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -357,6 +411,15 @@ Describe 'claude-bash-guard.sh'
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
 
+    It 'B22 (#1339): single-quoted -f AFTER --force-with-lease -> DENY (last force flag wins)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease '-f' origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
     It 'H13 (issue #1058): digit-bearing short-flag cluster (git push -4f origin main) -> DENY'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git push -4f origin main"}}
@@ -378,6 +441,15 @@ Describe 'claude-bash-guard.sh'
     It 'P14 (issue #1058): bare force BEFORE --force-with-lease -> PASS (the lease, last, wins)'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git push --force --force-with-lease origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'P17 (#1339): single-quoted -f BEFORE --force-with-lease -> PASS (the lease, last, wins)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push '-f' --force-with-lease origin main"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -447,6 +519,42 @@ Describe 'claude-bash-guard.sh'
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
 
+    It 'H24 (#1339): a single-quoted force refspec (git push origin '\''+branch:branch'\'') -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push origin '+branch:branch'"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'H25 (#1339): a leased single-quoted force refspec still DENIES'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease origin '+branch:branch'"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'P18 (#1339): a bare + token is not a force refspec -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push origin '+'"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'P19 (#1339): a mid-token + is not a force refspec -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push origin 'branch+branch'"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
     It 'B17 (#1292, documented accepted false-positive): a `+` opening a push option VALUE -> DENY'
       # `-o "+1 note"` is a normal push option whose value happens to start
       # with +. Double-quote stripping (normalization) exposes it at a
@@ -475,6 +583,15 @@ Describe 'claude-bash-guard.sh'
     It 'B9: short flag (git worktree remove -f ../wt) -> DENY'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove -f ../wt"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B23 (#1339): single-quoted short flag (git worktree remove '\''-f'\'' ../wt) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove '-f' ../wt"}}
       End
       When run script "$GUARD"
       The status should be success


### PR DESCRIPTION
## Summary

- Normalize ordinary single quotes with the guard's existing double-quote and backslash normalization, closing quoted short-flag, refspec, and subcommand bypasses.
- Add frozen regression coverage across Rule A, Rule B force/lease/refspec handling, Rule C, benign plus-token controls, and the unchanged Rule-D oracle.
- Refresh the Codex hook-integrity digest for the final guard bytes.

## Verification

- Test-first RED: 103 examples, exactly the 10 new DENY rows failed against base production; the three new PASS controls stayed green.
- Frozen GREEN: 103 examples, 0 failures; test blob `16f78eb31601477ad126f1b2dcdf36dd947c49b0`.
- Fresh independent verifier: `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`.
- Canonical shell gates and Codex integrity oracle passed; direct and exact Codex-wrapper hostile/benign canaries matched expected DENY/PASS outcomes.
- Appliance smoke was not applicable because no shipped or appliance surface changed.

Fixes #1339

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command safety checks to recognize risky Git operations even when commands, options, or refspecs are enclosed in single quotes.
  - Added more consistent handling for force-related Git flags and worktree removal commands.
  - Updated command integrity verification to use the latest guard validation.

- **Tests**
  - Expanded coverage for quoted command tokens, force-push variations, force refspecs, and quoted worktree removal options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->