### PR TITLE
scripts: normalize JSON escaped tabs

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/scripts/claude-bash-guard.sh\" 5d764049dd28e5964de46167b313faa28681e6052ef0f8986288da6b88d7b7e3 && exec sh \"$root/scripts/claude-bash-guard.sh\"",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/scripts/claude-bash-guard.sh\" 0ef35542a4a8deeb8bdfd039dee4a7ecfe5512af9ab7faab46b5f43f63678705 && exec sh \"$root/scripts/claude-bash-guard.sh\"",
             "timeout": 10,
             "statusMessage": "Checking repository Git policy"
           },

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -108,9 +108,11 @@
 #
 # NORMALIZATION (issue #923 review F1): rather than matching rules against
 # the raw payload, everything matches against $norm, built by:
-#   1. Deleting every `'`, `"`, and `\` character -- collapses JSON-escaped quotes
+#   1. Converting odd-parity JSON `\t` escapes to tabs while leaving even-parity
+#      literal backslash+t data intact.
+#   2. Deleting every `'`, `"`, and `\` character -- collapses JSON-escaped quotes
 #      and a quoted subcommand token alike (`git 'commit'` -> `git commit`).
-#   2. Collapsing every run of whitespace (space/tab/newline) to one space --
+#   3. Collapsing every run of whitespace (space/tab/newline) to one space --
 #      defeats `git  commit` (double space) or a literal tab between tokens.
 # Fail-open holds through normalization: empty/garbled input still normalizes
 # to a string with no rule match, i.e. exit 0. $norm is then split into
@@ -133,9 +135,14 @@ set -u
 payload="$(cat)"
 
 # norm -- the single normalized view every rule matches against (see
-# NORMALIZATION above): strip ', ", and \, then collapse whitespace runs to one
-# space.
-norm="$(printf '%s' "$payload" | tr -d "\\\\\"'" | tr -s '[:space:]' ' ')"
+# NORMALIZATION above): decode odd-parity JSON tab escapes, strip ', ", and \,
+# then collapse whitespace runs to one space.
+tab="$(printf '\t')"
+norm="$(printf '%s' "$payload" | sed -E "
+:a
+s/(^|[^\\\\])((\\\\\\\\)*)\\\\t/\\1\\2${tab}/g
+ta
+" | tr -d "\\\\\"'" | tr -s '[:space:]' ' ')"
 
 # segs -- $norm split into newline-separated SEGMENTS on shell
 # command-separator metacharacters (`; & | ( )`). Each rule below matches

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -29,9 +29,9 @@
 #                  never matching inside --force/-force/a token
 #                  like foo-f                                   -> PASS
 #   normalization (#923 review F1) -- every rule matches against a
-#              normalized view (quotes/backslashes stripped, whitespace
-#              runs collapsed to one space), so double/tab whitespace and a
-#              quoted subcommand token can't evade a rule               -> DENY
+#              normalized view (JSON tab escapes decoded, quotes/backslashes
+#              stripped, whitespace runs collapsed to one space), so double/tab
+#              whitespace and a quoted subcommand token can't evade a rule -> DENY
 #   force-flag boundary (#923 review F2/F3) -- a shell metacharacter
 #              (`; | & ( ) < > ,`) directly after -f, or a clustered short
 #              flag (-uf/-fu), still counts as force                    -> DENY
@@ -94,9 +94,18 @@ Describe 'claude-bash-guard.sh'
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
 
-    It 'H2 (F1 whitespace evasion): a literal TAB between git and commit -> DENY'
+    It 'A1 (#1375): a serialized tab between git and commit with short -n -> DENY'
       Data
-        #|{"tool_name":"Bash","tool_input":{"command":"git	commit --no-verify"}}
+        #|{"tool_name":"Bash","tool_input":{"command":"git\tcommit -n"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'A2 (#1375): a serialized tab between commit and short -n -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git commit\t-n"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -429,6 +438,60 @@ Describe 'claude-bash-guard.sh'
       The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
     End
 
+    It 'B1 (#1375): a serialized tab between git and push with clustered -4f -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git\tpush -4f origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B2 (#1375): a serialized tab between push and clustered -4f -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git push\t-4f origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'B3 (#1375): serialized tabs with single-quoted push and flag tokens -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git\t'push'\t'-4f' origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'T1 (#1375): consecutive serialized tabs collapse to a token boundary -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git\t\tpush -4f origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'T2 (#1375): a serialized literal backslash-t remains data -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git\\tpush -4f origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'T3 (#1375): a backslash before a serialized tab retains tab whitespace semantics -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git\\\tpush -4f origin main"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
     It 'H14 (issue #1058): --force AFTER --force-with-lease -> DENY (last force flag wins)'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease --force"}}
@@ -601,6 +664,33 @@ Describe 'claude-bash-guard.sh'
     It 'H9 (F1 whitespace evasion): double space (git worktree  remove --force ../wt) -> DENY'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git worktree  remove --force ../wt"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'C1 (#1375): a serialized tab between git and worktree -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git\tworktree remove -f ../wt"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'C2 (#1375): a serialized tab between worktree and remove -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree\tremove -f ../wt"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"'
+    End
+
+    It 'C3 (#1375): a serialized tab between remove and short -f -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree remove\t-f ../wt"}}
       End
       When run script "$GUARD"
       The status should be success
@@ -800,6 +890,15 @@ Describe 'claude-bash-guard.sh'
     It 'D1: wait-checks.sh backgrounded, output redirected -> DENY'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"sh scripts/agent/wait-checks.sh --repo o/r --pr 1 > /tmp/ci.txt 2>&1 &"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'D1-tab (#1375): a serialized tab before a wait option remains DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"sh scripts/agent/wait-checks.sh\t--repo o/r --pr 1 > /tmp/ci.txt 2>&1 &"}}
       End
       When run script "$GUARD"
       The status should be success


### PR DESCRIPTION
## Summary

- normalize odd-parity JSON escaped tab sequences before guard matching
- preserve even-parity literal backslash-plus-t input
- replace invalid raw-tab coverage with valid serialized payloads and refresh the Codex integrity pin

## Verification

- test-first RED: 114 examples, 10 expected escaped-tab failures
- GREEN: guard shellspec 114/114; integrity shellspec 21/21
- independent frozen red proof: FREEZE-OK, RED-OK, GREEN-OK, PASS
- canonical shell gates: PASS
- signed commit: 5ea2a04b117b4b9a7e373acca1fc901c3d23ff14

Fixes #1375

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.