### PR TITLE
Fix IP alert attribution across feed refreshes

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9973,6 +9973,17 @@ function validate_ipv6($ipaddr) {
 }
 
 
+// Return a BRE pattern for one complete validated IP/CIDR feed entry.
+// Invalid inputs return NULL so callers preserve no-pattern miss behaviour.
+function pfb_ip_exact_entry_pattern($entry): ?string {
+	if (!is_string($entry) || (!is_ipaddr($entry) && !is_subnet($entry))) {
+		return NULL;
+	}
+
+	return '^' . str_replace('.', '\.', $entry) . '$';
+}
+
+
 // Function to check for loopback addresses (IPv4 range: 127.0.0.0/8, excluding IPv6)
 function FILTER_FLAG_NO_LOOPBACK_RANGE($value) {
 	// http://www.php.net/manual/en/filter.filters.flags.php
@@ -10003,7 +10014,11 @@ function find_reported_header($ip, $pfbfolder, $geoip=FALSE) {
 	global $pfb;
 
 	// Find exact IP match
-	$q_ip	= escapeshellarg(str_replace('.', '\.', "^{$ip}"));
+	$q_ip = pfb_ip_exact_entry_pattern($ip);
+	if ($q_ip === NULL) {
+		return array('Unknown', 'Unknown');
+	}
+	$q_ip = escapeshellarg($q_ip);
 	// issue #833: /dev/null forces grep to always be given >=2 files, so it
 	// always emits the "path:" prefix -- even when $pfbfolder's glob resolves to
 	// exactly ONE .txt file. Without it, pfb_parse_query() gets an unprefixed
@@ -10191,11 +10206,13 @@ function pfb_ip_render_query(array $fields): array {
 	// validate exec at all).
 	$validate_file_cmd = NULL;
 	$validate_cmd	    = NULL;
+	$q_ip		    = NULL;
 	if ($fields[14] != 'Unknown' && $fields[15] != 'Unknown') {
-		$q_ip = str_replace('.', '\.', $fields[14]);
+		$q_ip = pfb_ip_exact_entry_pattern($fields[14]);
+	}
 
-		$q_ip_esc = escapeshellarg("^{$q_ip}");
-
+	if ($q_ip !== NULL) {
+		$q_ip_esc = escapeshellarg($q_ip);
 		// issue #832: the ET/Proofpoint branch above blanks $query/$query_host/
 		// $query_prefix (no filename filter -- every file under etdir is a
 		// candidate), so only append the filter tail when there IS one -- two
@@ -10300,25 +10317,27 @@ function pfb_ip_prefetch_grep_lines(string $cmd_prefix, string $cmd_suffix, arra
 
 
 // Attribute the LAST line in $lines (grep's original order is preserved regardless of pattern
-// order) that "belongs" to $raw_prefix — reproducing per-row exec()'s "last stdout line"
+// order) that exactly equals $raw_entry — reproducing per-row exec()'s "last stdout line"
 // semantics from a batched multi-pattern grep pass whose output interleaves every candidate's
 // matches. A line belongs under either grep shape: unprefixed (single file matched, line IS
 // the content) or file-prefixed ("path:content", path always contains '/', so the substring
-// after the FIRST ':' is the content) — preserving grep's own prefix-match quirk (`^1.2.3.4`
-// also matches `1.2.3.45`) for behaviour-identity with the exec it replaces. The colon-fallback
-// requires the segment BEFORE ':' to contain '/', else an unprefixed IPv6 line could misattribute.
-function pfb_ip_prefetch_last_match(array $lines, string $raw_prefix): ?string {
+// after the FIRST ':' is the content). The colon fallback requires the segment before ':' to
+// contain '/', else an unprefixed IPv6 line could be mistaken for path-prefixed output.
+function pfb_ip_prefetch_last_match(array $lines, string $raw_entry): ?string {
+	if (pfb_ip_exact_entry_pattern($raw_entry) === NULL) {
+		return NULL;
+	}
 
 	$match = NULL;
 	foreach ($lines as $line) {
-		if (str_starts_with($line, $raw_prefix)) {
+		if ($line === $raw_entry) {
 			$match = $line;
 			continue;
 		}
 		$colon_pos = strpos($line, ':');
 		if ($colon_pos !== FALSE &&
 		    strpos(substr($line, 0, $colon_pos), '/') !== FALSE &&
-		    str_starts_with(substr($line, $colon_pos + 1), $raw_prefix)) {
+		    substr($line, $colon_pos + 1) === $raw_entry) {
 			$match = $line;
 		}
 	}
@@ -10353,8 +10372,13 @@ function pfb_find_reported_headers(array $hosts, $pfbfolder, $geoip = FALSE, ?ar
 	// host's own LAST matching line from the shared batched output, reproducing what a
 	// per-row `exec()` (last-line-of-output) call would have returned for that host alone.
 	$patterns = array();
+	$valid_hosts = array();
 	foreach ($hosts as $host) {
-		$patterns[] = '^' . str_replace('.', '\.', $host);
+		$pattern = pfb_ip_exact_entry_pattern($host);
+		if ($pattern !== NULL) {
+			$patterns[] = $pattern;
+			$valid_hosts[$host] = TRUE;
+		}
 	}
 	// issue #833: /dev/null forces the same file-prefix output as find_reported_
 	// header()'s own exact-match exec, even for a single-file $pfbfolder glob.
@@ -10367,6 +10391,9 @@ function pfb_find_reported_headers(array $hosts, $pfbfolder, $geoip = FALSE, ?ar
 
 	$missed = array();
 	foreach ($hosts as $host) {
+		if (!isset($valid_hosts[$host])) {
+			continue;
+		}
 		$match = pfb_ip_prefetch_last_match($lines, $host);
 		if ($match !== NULL) {
 			$out[$host] = pfb_parse_query($match);
@@ -10472,7 +10499,10 @@ function pfb_ip_prefetch(array $rows): void {
 	foreach ($validate_groups as $group) {
 		$patterns = array();
 		foreach ($group['entries'] as $raw_ip) {
-			$patterns[] = '^' . str_replace('.', '\.', $raw_ip);
+			$pattern = pfb_ip_exact_entry_pattern($raw_ip);
+			if ($pattern !== NULL) {
+				$patterns[] = $pattern;
+			}
 		}
 		$patterns = array_values(array_unique($patterns));
 
@@ -10551,7 +10581,10 @@ function pfb_ip_prefetch(array $rows): void {
 		$pfb_query = $headers_by_host_folder[$miss_key];
 		$eval_new = ($pfb_query[1] == 'Unknown') ? 'Not listed!' : $pfb_query[1];
 		$eval_new_by_key[$miss_key] = $eval_new;
-		$alias_patterns[] = '^' . str_replace('.', '\.', $eval_new);
+		$pattern = pfb_ip_exact_entry_pattern($eval_new);
+		if ($pattern !== NULL) {
+			$alias_patterns[] = $pattern;
+		}
 	}
 	$alias_patterns = array_values(array_unique($alias_patterns));
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -19913,13 +19913,15 @@ function sync_package_pfblockerng($cron='') {
 	#################################
 
 	$log = '';
+	if ($pfb['filter_configure'] || !empty($pfb_feed_changed)) {
+		// Remove IP Cache file
+		unlink_if_exists($pfb['ip_cache']);
+	}
+
 	if ($pfb['filter_configure']) {
 
 		// Remove any IPs in Alerts unlock feature
 		unlink_if_exists("{$pfb['ip_unlock']}");
-
-		// Remove IP Cache file
-		unlink_if_exists($pfb['ip_cache']);
 
 		require_once('filter.inc');
 		filter_configure();

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9976,7 +9976,7 @@ function validate_ipv6($ipaddr) {
 // Return a BRE pattern for one complete validated IP/CIDR feed entry.
 // Invalid inputs return NULL so callers preserve no-pattern miss behaviour.
 function pfb_ip_exact_entry_pattern($entry): ?string {
-	if (!is_string($entry) || (!is_ipaddr($entry) && !is_subnet($entry))) {
+	if (!is_string($entry) || strpos($entry, "\0") !== FALSE || (!is_ipaddr($entry) && !is_subnet($entry))) {
 		return NULL;
 	}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2998,13 +2998,16 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 			$eval_new = ($pfb_query[1] == 'Unknown') ? 'Not listed!' : $pfb_query[1];
 
 			// Determine if IP is in a new Aliastable
-			$q_ip = str_replace('.', '\.', $eval_new);
-			$q_ip_esc = escapeshellarg("^{$q_ip}");
-			// issue #833: '/dev/null' gives xargs a permanent extra file arg, so
-			// grep always emits a "path:" prefix even when aliasdir holds exactly
-			// one .txt file -- the ltrim(strrchr(strstr(strstr(...)))) alias-name
-			// parse below requires that shape.
-			$raw_validate = exec("/usr/bin/find {$pfb['aliasdir']}/*.txt -type f | xargs {$pfb['grep']} {$q_ip_esc} /dev/null 2>&1");
+			$raw_validate = '';
+			$q_ip = pfb_ip_exact_entry_pattern($eval_new);
+			if ($q_ip !== NULL) {
+				$q_ip_esc = escapeshellarg($q_ip);
+				// issue #833: '/dev/null' gives xargs a permanent extra file arg, so
+				// grep always emits a "path:" prefix even when aliasdir holds exactly
+				// one .txt file -- the ltrim(strrchr(strstr(strstr(...)))) alias-name
+				// parse below requires that shape.
+				$raw_validate = exec("/usr/bin/find {$pfb['aliasdir']}/*.txt -type f | xargs {$pfb['grep']} {$q_ip_esc} /dev/null 2>&1");
+			}
 
 			return array($pfb_query, $raw_validate);
 		});

--- a/tests/php/AlertsIpConvertPrefetchParityTest.php
+++ b/tests/php/AlertsIpConvertPrefetchParityTest.php
@@ -416,6 +416,48 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 		$this->assertParity($fields, 'Block', 'aliastable-changed v4');
 	}
 
+	public function test_longer_logged_entry_detects_historical_feed_drift_prefetched_and_cold(): void
+	{
+		file_put_contents("{$this->denydir}/OldFeed.txt", "192.0.2.54\n");
+		file_put_contents("{$this->denydir}/NewFeed.txt", "192.0.2.5\n");
+
+		$fields = $this->rawFields([
+			8 => '192.0.2.5', 15 => '192.0.2.5',
+			14 => 'pfB_Historical_v4', 16 => 'OldFeed',
+		]);
+
+		$html = $this->assertParity($fields, 'Block', 'longer logged-entry collision reveals feed drift');
+		$this->assertStringContainsString(
+			'<s>OldFeed</s><br /><small><s>192.0.2.5</s></small><br />NewFeed<br /><small>192.0.2.5</small>',
+			$html,
+			"expected the old feed/match struck through and the exact current feed rendered, got:\n{$html}"
+		);
+	}
+
+	public function test_longer_alias_decoy_never_wins_over_exact_alias_prefetched_and_cold(): void
+	{
+		file_put_contents("{$this->denydir}/CurrentFeed.txt", "192.0.2.5\n");
+		file_put_contents("{$this->aliasdir}/A_pfB_Correct_v4.txt", "192.0.2.5\n");
+		file_put_contents("{$this->aliasdir}/Z_pfB_Decoy_v4.txt", "192.0.2.54\n");
+
+		$fields = $this->rawFields([
+			8 => '192.0.2.5', 15 => '192.0.2.5',
+			14 => 'pfB_OldAlias_v4', 16 => 'GoneFeed',
+		]);
+
+		$html = $this->assertParity($fields, 'Block', 'longer alias decoy cannot beat exact alias');
+		$this->assertStringContainsString(
+			'<s>pfB_OldAlias_v4</s><br />A_pfB_Correct_v4',
+			$html,
+			"expected exact current alias to replace the historical alias, got:\n{$html}"
+		);
+		$this->assertStringNotContainsString(
+			'Z_pfB_Decoy_v4',
+			$html,
+			"expected the longer-prefix alias decoy to stay absent, got:\n{$html}"
+		);
+	}
+
 	/**
 	 * Case 8 -- ET-header feed: a Proofpoint/IQRisk-style "Category:Feed" name routes
 	 * the folder to $pfb['etdir'] with no filename filter (the et_header branch of

--- a/tests/php/AlertsIpConvertPrefetchParityTest.php
+++ b/tests/php/AlertsIpConvertPrefetchParityTest.php
@@ -259,6 +259,15 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 			"[{$scenario}] expected pfb_ip_prefetch() to seed the exact validate_cmd key "
 				. "convert_ip_log() will look up: " . var_export($row['validate_cmd'], TRUE)
 		);
+		if (empty($seededMemos['validate'][$row['validate_cmd']])) {
+			$missKey = $row['host'] . '|' . $row['folder'];
+			$this->assertArrayHasKey(
+				$missKey,
+				$seededMemos['miss'],
+				"[{$scenario}] expected pfb_ip_prefetch() to seed the host/folder miss memo "
+					. "required after validation missed: " . var_export($missKey, TRUE)
+			);
+		}
 
 		// When: convert_ip_log() renders while the prefetch memos are seeded.
 		[$retSeeded, $htmlSeeded] = $this->render($fields, $rtype);

--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -555,7 +555,11 @@ final class IpPrefetchTest extends TestCase
 		$folder = "{$tmp}/*.txt";
 
 		try {
-			foreach (['', '.*', '[0-9]', '^$', '\\', '-1', '999.999.999.999'] as $host) {
+			foreach (['', '.*', '[0-9]', '^$', '\\', '-1', '999.999.999.999', "192.0.2.5\0junk", "2001:db8::1\0junk"] as $host) {
+				$this->assertNull(
+					pfb_ip_exact_entry_pattern($host),
+					"expected invalid host " . var_export($host, true) . ' to produce no exact-entry pattern'
+				);
 				$this->assertSame(
 					['Unknown', 'Unknown'],
 					find_reported_header($host, $folder),

--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -25,18 +25,16 @@ use PHPUnit\Framework\TestCase;
  *     direct unit tests, no exec: v4 mask math (both sides), v6 subnet math (both sides,
  *     via the Net_IPv6 double), and an empty $result array.
  *
- *   Scenario: pfb_ip_prefetch_last_match() -- the dual-prefix attribution test
+ *   Scenario: pfb_ip_prefetch_last_match() -- complete-entry attribution
  *     direct unit tests, no exec: an unprefixed (single-file) line, a file-prefixed
- *     ("path:content") line, a genuine miss, AND the grep prefix-match quirk (an anchored
- *     `^1.2.3.4`-style pattern also matching content beginning `1.2.3.45`) in both shapes --
- *     the per-row `exec()` this replaces has the identical quirk, so reproducing it (not an
- *     exact-match) is what keeps this behaviour-identical.
+ *     ("path:content") line, a genuine miss, longer textual prefixes in both shapes,
+ *     and last-duplicate semantics. Only complete raw entries are attributed.
  *
  *   Scenario: find_reported_header() vs the batched pfb_find_reported_headers() sibling
  *     Differential (oracle) scenarios over a real fixture feed dir, real grep/find exec:
  *     exact v4 hit, exact v6 hit, a v4 CIDR hit AND a miss sharing the same first-octet
  *     Round-B query group, a v6 CIDR hit AND a miss sharing the same prefix Round-B group,
- *     the exact-round prefix-match quirk, and two flavours of total miss (no CIDR
+ *     longer textual prefix collisions, and two flavours of total miss (no CIDR
  *     candidates at all; CIDR candidates present but none contain the host). A SEPARATE
  *     fixture dir/geoip=TRUE case proves the ccdir-redirect branch too.
  *
@@ -55,7 +53,7 @@ use PHPUnit\Framework\TestCase;
  *   Scenario: N1 -- pfb_ip_prefetch_last_match()'s colon-fallback false IPv6 attribution
  *     An UNPREFIXED IPv6 content line has ':' inside the address itself, not a grep
  *     "path:content" separator -- the fallback must not misattribute it merely because
- *     the tail after its first ':' happens to equal some host's raw_prefix.
+ *     the tail after its first ':' happens to equal some host's raw_entry.
  *
  *   Scenario: B3 -- a failed batched grep pass must never seed a false negative
  *     A child `php` process with `open_basedir` whitelisting only the repo tree (so
@@ -93,6 +91,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_ip_render_memos')]
 #[CoversFunction('pfb_ip_render_memos_reset')]
 #[CoversFunction('pfb_prefetch_pattern_file_write_ok')]
+#[CoversFunction('pfb_ip_exact_entry_pattern')]
 #[CoversFunction('pfb_ip_prefetch_grep_lines')]
 #[CoversFunction('pfb_ip_prefetch_last_match')]
 #[CoversFunction('pfb_find_reported_headers')]
@@ -288,7 +287,7 @@ final class IpPrefetchTest extends TestCase
 	public function test_last_match_unprefixed_single_file_shape(): void
 	{
 		$lines = ['203.0.113.0/28', '198.51.100.16/28'];
-		$match = pfb_ip_prefetch_last_match($lines, '203.0.113.0');
+		$match = pfb_ip_prefetch_last_match($lines, '203.0.113.0/28');
 		$this->assertSame('203.0.113.0/28', $match, 'expected the unprefixed line to be attributed, got ' . var_export($match, true));
 	}
 
@@ -298,7 +297,7 @@ final class IpPrefetchTest extends TestCase
 		// greps is an absolute glob) before the ':' separator -- see N1's docblock for
 		// why the '/' matters.
 		$lines = ['/var/db/pfblockerng/deny/DenyFeedA.txt:203.0.113.0/28', '/var/db/pfblockerng/deny/DenyFeedB.txt:198.51.100.16/28'];
-		$match = pfb_ip_prefetch_last_match($lines, '198.51.100.16');
+		$match = pfb_ip_prefetch_last_match($lines, '198.51.100.16/28');
 		$this->assertSame(
 			'/var/db/pfblockerng/deny/DenyFeedB.txt:198.51.100.16/28',
 			$match,
@@ -313,45 +312,45 @@ final class IpPrefetchTest extends TestCase
 		$this->assertNull($match, 'expected no attribution for an unrelated prefix, got ' . var_export($match, true));
 	}
 
-	public function test_last_match_preserves_the_grep_prefix_match_quirk(): void
+	public function test_last_match_rejects_longer_textual_prefixes(): void
 	{
-		// An anchored `^203\.0\.113\.4` pattern also matches content beginning
-		// "203.0.113.45" -- the per-row single-pattern exec() has this exact quirk (it is
-		// not `-w`/word-bounded), so the batched attribution must reproduce it, in BOTH
-		// output shapes grep can emit.
+		// Longer entries must not be attributed to a shorter address in either grep
+		// output shape.
 		$unprefixed = pfb_ip_prefetch_last_match(['203.0.113.45/32'], '203.0.113.4');
-		$this->assertSame(
-			'203.0.113.45/32',
+		$this->assertNull(
 			$unprefixed,
-			'expected the quirk to attribute an unprefixed longer-suffix line, got ' . var_export($unprefixed, true)
+			'expected an unprefixed longer entry not to be attributed, got ' . var_export($unprefixed, true)
 		);
 
-		// Realistic grep multi-file output: an ABSOLUTE path before the ':' separator.
 		$prefixed = pfb_ip_prefetch_last_match(['/var/db/pfblockerng/deny/DenyFeed.txt:203.0.113.45/32'], '203.0.113.4');
-		$this->assertSame(
-			'/var/db/pfblockerng/deny/DenyFeed.txt:203.0.113.45/32',
+		$this->assertNull(
 			$prefixed,
-			'expected the quirk to attribute a file-prefixed longer-suffix line, got ' . var_export($prefixed, true)
+			'expected a file-prefixed longer entry not to be attributed, got ' . var_export($prefixed, true)
 		);
 
-		// And the negative: a prefix that genuinely does not lead the content must NOT
-		// match (proves this is a real prefix test, not "contains").
-		$noHit = pfb_ip_prefetch_last_match(['203.0.113.99/32'], '203.0.113.4');
-		$this->assertNull($noHit, 'expected a non-leading occurrence NOT to match, got ' . var_export($noHit, true));
+		$duplicates = [
+			'/var/db/pfblockerng/deny/DenyFeedA.txt:203.0.113.4',
+			'/var/db/pfblockerng/deny/DenyFeedB.txt:203.0.113.4',
+		];
+		$this->assertSame(
+			$duplicates[1],
+			pfb_ip_prefetch_last_match($duplicates, '203.0.113.4'),
+			'expected the last duplicate complete entry to retain exec() last-line semantics'
+		);
 	}
 
 	/**
 	 * N1 (issue #809 review): the colon-fallback used to fire on ANY ':' in the line,
 	 * which misattributes an UNPREFIXED IPv6 content line (its OWN ':' is part of the
 	 * address, not a "path:content" separator) whenever the tail after that first ':'
-	 * happens to equal $raw_prefix. Guarded now by requiring the segment before that ':'
+	 * happens to equal $raw_entry. Guarded now by requiring the segment before that ':'
 	 * to look like a path (contain '/') -- true of every real grep path here, never true
 	 * of a bare IPv6 literal.
 	 */
 	public function test_last_match_does_not_misattribute_an_unprefixed_ipv6_content_line_via_the_colon_fallback(): void
 	{
 		// Given: an unprefixed IPv6 content line whose tail-after-first-colon equals a
-		// host's raw_prefix.
+		// host's raw_entry.
 		// When/Then: it must NOT be attributed via the colon-fallback.
 		$unprefixed = pfb_ip_prefetch_last_match(['2001:db8::1'], 'db8::1');
 		$this->assertNull(
@@ -361,7 +360,7 @@ final class IpPrefetchTest extends TestCase
 		);
 
 		// Given: a GENUINELY file-prefixed line (a real grep path, which always contains
-		// '/') for the SAME raw_prefix.
+		// '/') for the SAME raw_entry.
 		// When/Then: it still attributes correctly through the identical colon-fallback --
 		// proves the '/' guard does not break the real path-prefixed shape.
 		$prefixed = pfb_ip_prefetch_last_match(['/path/to/feed.txt:2001:db8::1'], '2001:db8::1');
@@ -422,7 +421,7 @@ final class IpPrefetchTest extends TestCase
 			'203.0.113.55',		// v4 CIDR miss -- SAME Round-B "203" group as the hit above
 			'2001:db8:1::5',	// v6 CIDR hit (inside 2001:db8:1::/64)
 			'2001:db8:9::5',	// v6 CIDR miss -- SAME Round-B "2001" group as the hit above
-			'198.51.100.4',		// exact-round prefix-match quirk (-> "198.51.100.45")
+			'198.51.100.4',		// longer textual prefix collision ("198.51.100.45")
 			'198.51.100.99',	// CIDR candidates present (198.51.100.16/28), none contain it
 			'192.0.2.222',		// no CIDR candidates in its group at all
 		];
@@ -434,12 +433,144 @@ final class IpPrefetchTest extends TestCase
 			'203.0.113.55'       => ['Unknown', 'Unknown'],
 			'2001:db8:1::5'      => ['ReportsFeedA', '2001:db8:1::/64'],
 			'2001:db8:9::5'      => ['Unknown', 'Unknown'],
-			'198.51.100.4'       => ['ReportsFeedB', '198.51.100.45'],
+			'198.51.100.4'       => ['Unknown', 'Unknown'],
 			'198.51.100.99'      => ['Unknown', 'Unknown'],
 			'192.0.2.222'        => ['Unknown', 'Unknown'],
 		];
 
 		$this->assertBatchedHeadersMatchPerRow($hosts, $folder, FALSE, $expected, 'reports fixture, non-geoip');
+	}
+
+	public function test_per_row_and_batch_require_complete_v4_v6_entries_across_orders_and_fallbacks(): void
+	{
+		$cases = [
+			['192.0.2.5', ['192.0.2.52', '192.0.2.54'], '192.0.2.0/24'],
+			['198.51.100.18', ['198.51.100.188'], '198.51.100.0/24'],
+			['203.0.113.4', ['203.0.113.48'], '203.0.113.0/24'],
+			['2001:db8::1', ['2001:db8::10', '2001:db8::12'], '2001:db8::/64'],
+		];
+		$tmp = sys_get_temp_dir() . '/pfb_1367_collisions_' . bin2hex(random_bytes(6));
+		mkdir($tmp, 0777, true);
+		$savedCcdir = $GLOBALS['pfb']['ccdir'];
+
+		try {
+			$GLOBALS['pfb']['ccdir'] = $tmp;
+			foreach ($cases as [$host, $collisions, $cidr]) {
+				foreach ([FALSE, TRUE] as $geoip) {
+					foreach ([FALSE, TRUE] as $collisionFirst) {
+						$first = $collisionFirst ? implode("\n", $collisions) : $host;
+						$second = $collisionFirst ? $host : implode("\n", $collisions);
+						file_put_contents("{$tmp}/A.txt", "{$first}\n");
+						file_put_contents("{$tmp}/B.txt", "{$second}\n");
+
+						$expectedFeed = $collisionFirst ? 'B' : 'A';
+						$this->assertBatchedHeadersMatchPerRow(
+							[$host],
+							"{$tmp}/*.txt",
+							$geoip,
+							[$host => [$expectedFeed, $host]],
+							"exact entry with collisions; geoip=" . ($geoip ? 'true' : 'false')
+						);
+
+						$first = $collisionFirst ? implode("\n", $collisions) : $cidr;
+						$second = $collisionFirst ? $cidr : implode("\n", $collisions);
+						file_put_contents("{$tmp}/A.txt", "{$first}\n");
+						file_put_contents("{$tmp}/B.txt", "{$second}\n");
+						$expectedFeed = $collisionFirst ? 'B' : 'A';
+						$this->assertBatchedHeadersMatchPerRow(
+							[$host],
+							"{$tmp}/*.txt",
+							$geoip,
+							[$host => [$expectedFeed, $cidr]],
+							"CIDR fallback with collisions; geoip=" . ($geoip ? 'true' : 'false')
+						);
+					}
+				}
+
+				file_put_contents("{$tmp}/A.txt", implode("\n", $collisions) . "\n");
+				@unlink("{$tmp}/B.txt");
+				$this->assertBatchedHeadersMatchPerRow(
+					[$host],
+					"{$tmp}/*.txt",
+					FALSE,
+					[$host => ['Unknown', 'Unknown']],
+					'single-file forced-prefix collision miss'
+				);
+			}
+		} finally {
+			$GLOBALS['pfb']['ccdir'] = $savedCcdir;
+			rmdir_recursive($tmp);
+		}
+	}
+
+	public function test_exact_entry_inputs_preserve_cidr_boundaries_ipv6_forms_and_strict_bytes(): void
+	{
+		$tmp = sys_get_temp_dir() . '/pfb_1367_entries_' . bin2hex(random_bytes(6));
+		mkdir($tmp, 0777, true);
+		$folder = "{$tmp}/*.txt";
+
+		try {
+			$exact = [
+				'192.0.2.5',
+				'2001:db8::1',
+				'2001:0db8:0:0:0:0:0:2',
+			];
+			file_put_contents("{$tmp}/Exact.txt", implode("\n", $exact) . "\n");
+			foreach ($exact as $host) {
+				$this->assertBatchedHeadersMatchPerRow(
+					[$host], $folder, FALSE, [$host => ['Exact', $host]], 'exact textual IPv4/IPv6 entry at EOL'
+				);
+			}
+
+			foreach ([
+				['203.0.113.9', '203.0.113.0/0'],
+				['192.0.2.5', '192.0.2.4/31'],
+				['192.0.2.5', '192.0.2.5/32'],
+				['2001:db8::9', '2001:db8::/0'],
+				['2001:db8::1', '2001:db8::/127'],
+				['2001:db8::1', '2001:db8::1/128'],
+			] as [$host, $cidr]) {
+				file_put_contents("{$tmp}/Exact.txt", "{$cidr}\n");
+				$this->assertBatchedHeadersMatchPerRow(
+					[$host], $folder, FALSE, [$host => ['Exact', $cidr]], "legal CIDR fallback {$cidr}"
+				);
+			}
+
+			file_put_contents("{$tmp}/Exact.txt", "192.0.2.5\r\n192.0.2.5 \n2001:db8::1\r\n2001:db8::1 \n");
+			foreach (['192.0.2.5', '2001:db8::1'] as $host) {
+				$this->assertBatchedHeadersMatchPerRow(
+					[$host], $folder, FALSE, [$host => ['Unknown', 'Unknown']], 'CRLF/trailing whitespace strict miss'
+				);
+			}
+		} finally {
+			rmdir_recursive($tmp);
+		}
+	}
+
+	public function test_invalid_hosts_cannot_expand_as_regex_or_shell_patterns(): void
+	{
+		$tmp = sys_get_temp_dir() . '/pfb_1367_invalid_' . bin2hex(random_bytes(6));
+		mkdir($tmp, 0777, true);
+		file_put_contents("{$tmp}/Feed.txt", "192.0.2.5\n2001:db8::1\n");
+		$folder = "{$tmp}/*.txt";
+
+		try {
+			foreach (['', '.*', '[0-9]', '^$', '\\', '-1', '999.999.999.999'] as $host) {
+				$this->assertSame(
+					['Unknown', 'Unknown'],
+					find_reported_header($host, $folder),
+					"expected invalid host " . var_export($host, true) . ' to be a safe per-row miss'
+				);
+				$batched = pfb_find_reported_headers([$host], $folder);
+				$this->assertSame(
+					['Unknown', 'Unknown'],
+					$batched[$host],
+					"expected invalid host " . var_export($host, true) . ' to be a safe batched miss'
+				);
+			}
+		} finally {
+			rmdir_recursive($tmp);
+		}
 	}
 
 	public function test_batched_headers_match_per_row_for_the_geoip_folder_variant(): void

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -32,6 +32,7 @@ the ``stub_dns`` fixture. Without these all cases skip cleanly.
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from collections.abc import Iterator
@@ -61,6 +62,8 @@ SYSTEM_LOG = "/var/log/system.log"
 PFB_LOGDIR = "/var/log/pfblockerng"
 DNSBL_LOG = f"{PFB_LOGDIR}/dnsbl.log"
 IP_BLOCK_LOG = f"{PFB_LOGDIR}/ip_block.log"
+UNIFIED_LOG = f"{PFB_LOGDIR}/unified.log"
+IP_CACHE = "/var/db/pfblockerng/ip_cache.sqlite"
 
 # Config path for the syslog export toggle (under the General settings section).
 CFG_GENERAL = "installedpackages/pfblockerng/config/0"
@@ -328,7 +331,7 @@ def syslog_export_state_snapshot(vm: SmokeVM) -> str:
     )
 
 
-def _trigger_ip_block(client: SmokeVM, *, timeout: float = 30.0) -> None:
+def _trigger_ip_block(client: SmokeVM, *, port: int = 80, timeout: float = 30.0) -> None:
     """Generate a pf-logged IP block by curling the blocked WAN IP FROM civm.
 
     The block must be triggered by PASS-THROUGH traffic — a client BEHIND the
@@ -346,8 +349,116 @@ def _trigger_ip_block(client: SmokeVM, *, timeout: float = 30.0) -> None:
         "-c",
         "dev=$(ip -4 -o addr show | awk '/192\\.168\\.1\\./{print $2; exit}'); "
         f'ip route replace {TEST_IP_BLOCK_DST}/32 via {PFSENSE_LAN_IP} dev "$dev" 2>/dev/null || true; '
-        f"curl --connect-timeout 2 --max-time 4 http://{TEST_IP_BLOCK_DST}/ >/dev/null 2>&1 || true",
+        f"curl --connect-timeout 2 --max-time 4 http://{TEST_IP_BLOCK_DST}:{port}/ >/dev/null 2>&1 || true",
         timeout=timeout,
+    )
+
+
+def _ip_cache_snapshot(vm: SmokeVM, *, timeout: float = 30.0) -> tuple[int, dict[str, tuple[str, str]]] | None:
+    """Return the cache inode plus host -> (feed, evaluated entry), or None when absent."""
+    open_marker = "<<<IPCACHE>>>"
+    close_marker = "<<<IPCACHEEND>>>"
+    snippet = (
+        f"$path = {h._php_str(IP_CACHE)};\n"
+        f"if (!file_exists($path)) {{ echo {h._php_str(open_marker + 'MISSING' + close_marker)}; }} else {{\n"
+        "$db = new SQLite3($path);\n"
+        "$rows = array();\n"
+        "$result = $db->query('SELECT host, q0, q1 FROM ipcache ORDER BY host');\n"
+        "while ($row = $result->fetchArray(SQLITE3_ASSOC)) { $rows[] = $row; }\n"
+        f"echo {h._php_str(open_marker)} . json_encode(array('inode' => fileinode($path), 'rows' => $rows))"
+        f" . {h._php_str(close_marker)};\n"
+        "$db->close();\n"
+        "}"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(f"IP cache snapshot failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+    start = result.stdout.find(open_marker)
+    end = result.stdout.find(close_marker, start + len(open_marker))
+    if start == -1 or end == -1:
+        raise RuntimeError(f"IP cache snapshot markers absent: {result.stdout!r}")
+    raw = result.stdout[start + len(open_marker) : end]
+    if raw == "MISSING":
+        return None
+    payload = json.loads(raw)
+    rows = {str(row["host"]): (str(row["q0"]), str(row["q1"])) for row in payload["rows"]}
+    return int(payload["inode"]), rows
+
+
+def _seed_ip_cache_row(vm: SmokeVM, host: str, feed: str, evaluated: str, *, timeout: float = 30.0) -> None:
+    """Add a second production-shaped cache row so a whole-file flush is observable."""
+    snippet = (
+        f"$db = new SQLite3({h._php_str(IP_CACHE)});\n"
+        "$stmt = $db->prepare('INSERT INTO ipcache (host, q0, q1, geoip, resolved_host) "
+        "VALUES (:host, :q0, :q1, :geoip, :resolved_host)');\n"
+        f"$stmt->bindValue(':host', {h._php_str(host)}, SQLITE3_TEXT);\n"
+        f"$stmt->bindValue(':q0', {h._php_str(feed)}, SQLITE3_TEXT);\n"
+        f"$stmt->bindValue(':q1', {h._php_str(evaluated)}, SQLITE3_TEXT);\n"
+        "$stmt->bindValue(':geoip', 'Unk', SQLITE3_TEXT);\n"
+        "$stmt->bindValue(':resolved_host', 'Unknown', SQLITE3_TEXT);\n"
+        "$ok = $stmt->execute();\n"
+        "echo $ok ? 'OK' : 'FAIL';\n"
+        "$db->close();"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"IP cache seed failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
+def _set_ip_attribution_rows(vm: SmokeVM, feed_a: str, feed_b: str, *, timeout: float = 60.0) -> None:
+    """Give the fixture's existing IP alias two attribution-source rows."""
+    row_a = {
+        "header": "pfb_syslog_ip",
+        "url": feed_a,
+        "state": "Enabled",
+        "format": "auto",
+    }
+    row_b = {
+        "header": "pfb_syslog_ip_b",
+        "url": feed_b,
+        "state": "Enabled",
+        "format": "auto",
+    }
+    snippet = (
+        f"$lists = config_get_path({h._php_str(h.CFG_IP_V4_LISTS)}, array());\n"
+        "$found = false;\n"
+        "foreach ($lists as &$list) {\n"
+        "if (($list['aliasname'] ?? '') === 'pfb_syslog_iptest') {\n"
+        f"$list['row'] = array({h._php_kv_array(row_a)}, {h._php_kv_array(row_b)});\n"
+        "$found = true;\n"
+        "}\n"
+        "}\n"
+        "unset($list);\n"
+        f"config_set_path({h._php_str(h.CFG_IP_V4_LISTS)}, $lists);\n"
+        "write_config('pfBlockerNG smoke: IP attribution source rows');\n"
+        "echo $found ? 'OK' : 'NOTFOUND';"
+    )
+    result = h.php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"IP attribution row setup failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+def _filterlog_pid(vm: SmokeVM, *, timeout: float = 30.0) -> str:
+    """Return the live filterlog daemon PID, failing loudly when it is absent."""
+    result = vm.ssh(
+        "/bin/sh",
+        "-c",
+        "/bin/ps -waxo pid,command | /usr/bin/awk '/[p]fblockerng.inc filterlog/{print $1; exit}'",
+        timeout=timeout,
+    )
+    pid = result.stdout.strip()
+    if result.returncode != 0 or not pid:
+        raise RuntimeError(f"filterlog daemon PID absent: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+    return pid
+
+
+def _last_log_line(vm: SmokeVM, path: str, *tokens: str) -> str:
+    """Return the newest line containing every token, or an empty string."""
+    return next(
+        (line for line in reversed(h.read_log_file(vm, path).splitlines()) if all(token in line for token in tokens)),
+        "",
     )
 
 
@@ -565,7 +676,233 @@ def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: Smok
 
 
 # --------------------------------------------------------------------------- #
-# Test 3: OFF ⇒ no new export records (LIVE toggle, before/after proof)
+# Test 3: event-time IP attribution cache follows successful feed ownership moves.
+# --------------------------------------------------------------------------- #
+
+
+def test_ip_attribution_cache_invalidated_after_feed_ownership_change(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
+    """A successful feed reparse invalidates cached event attribution without a rule reload.
+
+    Given: one blocked host belongs to FeedA, a second host belongs to FeedB, and an
+           event caches FeedA plus its evaluated CIDR for the blocked host.
+    When:  a no-op pass, an unlock-only pass, then a genuine refetch move the two
+           hosts between feeds while leaving the alias's final membership unchanged.
+    Then:  the no-op and unlock-only passes preserve the cache, but the refetch drops
+           the whole cache; the next event recomputes FeedB in CSV, unified, and syslog
+           output while the historical FeedA CSV row remains unchanged.
+    """
+    vm = deployed_vm
+    alias = "pfB_pfb_syslog_iptest_v4"
+    feed_a_header = "pfb_syslog_ip_v4"
+    feed_b_header = "pfb_syslog_ip_b_v4"
+    feed_a_path = h.write_local_feed(vm, "pfb_syslog_ip.txt", f"{TEST_IP_BLOCK_RANGE}\n")
+    control_ip = "198.51.100.240"
+    control_range = f"{control_ip}/32"
+    feed_b_path = h.write_local_feed(vm, "pfb_syslog_ip_b.txt", f"{control_range}\n")
+    sentinel_host = "203.0.113.250"
+    original_syslog = h.config_get(vm, CFG_GENERAL + "/log_syslog")
+    token = "ipattrcache"
+    marker = h.hook_marker_path(token, "post")
+
+    try:
+        _set_ip_attribution_rows(vm, feed_a_path, feed_b_path)
+        _set_syslog_enabled(vm, on=True)
+        h.set_update_hooks(vm, [h.env_dump_hook(token, "post")])
+        h.force_ip_refetch(vm, feed_a_header)
+        h.force_ip_refetch(vm, feed_b_header)
+        h.clear_hook_markers(vm, token)
+        h.reload(vm, "update")
+
+        table = vm.ssh("/sbin/pfctl", "-t", alias, "-T", "show", timeout=30)
+        assert table.returncode == 0, f"failed to read {alias}: rc={table.returncode} {table.stderr!r}"
+        membership_before = {line.strip() for line in table.stdout.splitlines() if line.strip()}
+        assert {TEST_IP_BLOCK_DST, control_ip} <= membership_before, (
+            f"setup alias membership missing fixture hosts: expected {TEST_IP_BLOCK_DST!r} and "
+            f"{control_ip!r}, got {sorted(membership_before)!r}"
+        )
+
+        # Missing-cache state: the first real event must recreate it naturally.
+        vm.ssh("/bin/rm", "-f", IP_CACHE, timeout=30)
+        assert _ip_cache_snapshot(vm) is None, "precondition: IP cache still exists after explicit removal"
+        daemon_pid = _filterlog_pid(vm)
+
+        events_before = len(_pfb_event_lines(vm))
+        _trigger_ip_block(client_vm, port=18080)
+        initial_syslog = _wait_for_event(
+            vm,
+            baseline_len=events_before,
+            want=(TEST_IP_BLOCK_DST, "dport=18080"),
+            any_of=IP_ACT_TOKENS,
+        )
+        assert initial_syslog, f"initial FeedA event absent\n{syslog_export_state_snapshot(vm)}"
+        assert f"feed={feed_a_header}" in initial_syslog, (
+            f"initial event did not attribute {TEST_IP_BLOCK_DST} to FeedA {feed_a_header!r}: {initial_syslog!r}"
+        )
+        initial_csv = _last_log_line(vm, IP_BLOCK_LOG, TEST_IP_BLOCK_DST, ",18080,")
+        initial_unified = _last_log_line(vm, UNIFIED_LOG, TEST_IP_BLOCK_DST, ",18080,")
+        for label, line in (("IP CSV", initial_csv), ("unified", initial_unified)):
+            assert feed_a_header in line and TEST_IP_BLOCK_DST in line, (
+                f"initial {label} attribution should contain FeedA={feed_a_header!r} and "
+                f"evaluated={TEST_IP_BLOCK_DST!r}, got {line!r}"
+            )
+
+        initial_cache = _ip_cache_snapshot(vm)
+        assert initial_cache is not None, "first event did not recreate the missing IP cache"
+        assert initial_cache[1].get(TEST_IP_BLOCK_DST) == (feed_a_header, TEST_IP_BLOCK_DST), (
+            f"initial cached q0/q1 mismatch: {initial_cache!r}"
+        )
+        _seed_ip_cache_row(vm, sentinel_host, "SentinelFeed", f"{sentinel_host}/32")
+        cached_before_noop = _ip_cache_snapshot(vm)
+        assert cached_before_noop is not None and sentinel_host in cached_before_noop[1], (
+            f"second host was not seeded into the shared cache: {cached_before_noop!r}"
+        )
+
+        # True reuse/no-op: both the inode and every row survive, and events still hit FeedA.
+        h.clear_hook_markers(vm, token)
+        h.reload(vm, "update")
+        env_noop = h.read_hook_env(vm, marker)
+        assert env_noop is not None, "post hook absent for no-op update"
+        assert env_noop.get("PFB_IP_CHANGED") == "0" and env_noop.get("PFB_CHANGED_IP_ALIASES") == "", (
+            f"expected a true no-op pass, got {env_noop!r}"
+        )
+        assert _ip_cache_snapshot(vm) == cached_before_noop, "no-op update changed the IP cache inode or rows"
+        assert _filterlog_pid(vm) == daemon_pid, "no-op update restarted the filterlog daemon"
+
+        events_before = len(_pfb_event_lines(vm))
+        _trigger_ip_block(client_vm, port=18081)
+        noop_syslog = _wait_for_event(
+            vm,
+            baseline_len=events_before,
+            want=(TEST_IP_BLOCK_DST, "dport=18081"),
+            any_of=IP_ACT_TOKENS,
+        )
+        assert f"feed={feed_a_header}" in noop_syslog, f"no-op cache hit lost FeedA attribution: {noop_syslog!r}"
+
+        # Unlock-only re-block widens alias reloads, but must not invalidate attribution.
+        unlock = h.php_eval(
+            vm,
+            f"file_put_contents('/tmp/ip_unlock', {h._php_str(TEST_IP_BLOCK_DST + ',' + alias + chr(10))}); echo 'OK';",
+        )
+        assert unlock.returncode == 0 and "OK" in unlock.stdout, (
+            f"failed to create unlock fixture: rc={unlock.returncode} {unlock.stderr!r} {unlock.stdout!r}"
+        )
+        h.clear_hook_markers(vm, token)
+        h.reload(vm, "update")
+        env_unlock = h.read_hook_env(vm, marker)
+        assert env_unlock is not None and env_unlock.get("PFB_IP_CHANGED") == "1", (
+            f"unlock-only pass did not report its re-block: {env_unlock!r}"
+        )
+        assert _ip_cache_snapshot(vm) == cached_before_noop, "unlock-only re-block changed the IP cache"
+        assert _filterlog_pid(vm) == daemon_pid, "unlock-only re-block restarted the filterlog daemon"
+
+        events_before = len(_pfb_event_lines(vm))
+        _trigger_ip_block(client_vm, port=18082)
+        unlock_syslog = _wait_for_event(
+            vm,
+            baseline_len=events_before,
+            want=(TEST_IP_BLOCK_DST, "dport=18082"),
+            any_of=IP_ACT_TOKENS,
+        )
+        assert f"feed={feed_a_header}" in unlock_syslog, (
+            f"unlock-only pass should retain cached FeedA attribution: {unlock_syslog!r}"
+        )
+        assert _ip_cache_snapshot(vm) == cached_before_noop, "cache-hit events changed the cached q0/q1 rows"
+
+        # Genuine refetch: swap ownership while preserving the exact final alias union.
+        h.write_local_feed(vm, "pfb_syslog_ip.txt", f"{control_range}\n")
+        h.write_local_feed(vm, "pfb_syslog_ip_b.txt", f"{TEST_IP_BLOCK_RANGE}\n")
+        h.force_ip_refetch(vm, feed_a_header)
+        h.force_ip_refetch(vm, feed_b_header)
+        h.clear_hook_markers(vm, token)
+        h.reload(vm, "update")
+        env_refresh = h.read_hook_env(vm, marker)
+        assert env_refresh is not None, "post hook absent for ownership-change update"
+        assert env_refresh.get("PFB_IP_CHANGED") == "0", (
+            f"ownership-only feed move unexpectedly reloaded firewall rules: {env_refresh!r}"
+        )
+        assert env_refresh.get("PFB_CHANGED_IP_ALIASES") == "", (
+            f"final alias union changed during ownership-only move: {env_refresh!r}"
+        )
+        assert _filterlog_pid(vm) == daemon_pid, "ownership-only content refresh restarted the filterlog daemon"
+
+        table = vm.ssh("/sbin/pfctl", "-t", alias, "-T", "show", timeout=30)
+        membership_after = {line.strip() for line in table.stdout.splitlines() if line.strip()}
+        assert table.returncode == 0 and membership_after == membership_before, (
+            f"ownership move changed pf enforcement: before={sorted(membership_before)!r} "
+            f"after={sorted(membership_after)!r} rc={table.returncode}"
+        )
+        feed_a_output = h.read_log_file(vm, f"{h.PFB_DBDIR}/deny/{feed_a_header}.txt")
+        feed_b_output = h.read_log_file(vm, f"{h.PFB_DBDIR}/deny/{feed_b_header}.txt")
+        assert TEST_IP_BLOCK_DST not in feed_a_output and TEST_IP_BLOCK_DST in feed_b_output, (
+            "refetched attribution sources did not move the host from FeedA to FeedB: "
+            f"FeedA={feed_a_output!r} FeedB={feed_b_output!r}"
+        )
+
+        events_before = len(_pfb_event_lines(vm))
+        _trigger_ip_block(client_vm, port=18083)
+        refreshed_syslog = _wait_for_event(
+            vm,
+            baseline_len=events_before,
+            want=(TEST_IP_BLOCK_DST, "dport=18083"),
+            any_of=IP_ACT_TOKENS,
+        )
+        assert f"feed={feed_b_header}" in refreshed_syslog, (
+            f"post-refresh event stayed stale instead of recomputing FeedB {feed_b_header!r}: "
+            f"actual={refreshed_syslog!r} cached_before={cached_before_noop!r}"
+        )
+        assert f"feed={feed_a_header}" not in refreshed_syslog, (
+            f"post-refresh syslog still contains removed FeedA attribution: {refreshed_syslog!r}"
+        )
+
+        refreshed_csv = _last_log_line(vm, IP_BLOCK_LOG, TEST_IP_BLOCK_DST, ",18083,")
+        refreshed_unified = _last_log_line(vm, UNIFIED_LOG, TEST_IP_BLOCK_DST, ",18083,")
+        for label, line in (("IP CSV", refreshed_csv), ("unified", refreshed_unified)):
+            assert feed_b_header in line and TEST_IP_BLOCK_DST in line and feed_a_header not in line, (
+                f"post-refresh {label} did not use recomputed FeedB/evaluated attribution: {line!r}"
+            )
+        assert initial_csv in h.read_log_file(vm, IP_BLOCK_LOG).splitlines(), (
+            f"historical FeedA CSV row was rewritten or lost: {initial_csv!r}"
+        )
+
+        refreshed_cache = _ip_cache_snapshot(vm)
+        assert refreshed_cache is not None, "post-refresh event did not recreate the IP cache"
+        assert refreshed_cache[1].get(TEST_IP_BLOCK_DST) == (feed_b_header, TEST_IP_BLOCK_DST), (
+            f"post-refresh cached q0/q1 mismatch: {refreshed_cache!r}"
+        )
+        assert sentinel_host not in refreshed_cache[1], (
+            f"content refresh did not invalidate the whole shared cache: {refreshed_cache!r}"
+        )
+    finally:
+        h.clear_update_hooks(vm)
+        vm.ssh("/bin/rm", "-f", "/tmp/ip_unlock", timeout=30)
+        h.write_local_feed(vm, "pfb_syslog_ip.txt", f"{TEST_IP_BLOCK_RANGE}\n")
+        h.inject(
+            vm,
+            h.IpCase(
+                aliasname="pfb_syslog_iptest",
+                feed_url=feed_a_path,
+                action="Deny_Outbound",
+                family="v4",
+                header="pfb_syslog_ip",
+            ),
+        )
+        _set_syslog_enabled(vm, on=original_syslog == "on")
+        h.force_ip_refetch(vm, feed_a_header)
+        h.reload(vm, "update")
+        vm.ssh(
+            "/bin/rm",
+            "-f",
+            IP_CACHE,
+            feed_b_path,
+            f"{h.PFB_DBDIR}/deny/{feed_b_header}.txt",
+            f"{h.PFB_DBDIR}/deny/{feed_b_header}.update",
+            f"{h.PFB_DBDIR}/deny/{feed_b_header}.fail",
+            timeout=30,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Test 4: OFF ⇒ no new export records (LIVE toggle, before/after proof)
 # --------------------------------------------------------------------------- #
 
 

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -143,7 +143,7 @@ S3_ALIAS = "RVAliasSC"
 S4_ALIAS = "RVAliasSD"
 S5_ALIAS = "pfB_Top_v4"  # continent alias -- routes pfb_geoip=TRUE (ADR-11 continent list)
 S6_ALIAS = "RVAliasSF"
-S8_ALIAS_LOGGED = "RVAliasSHOld"  # deliberately stale; ALIAS_OTHER's basename is the "new" one
+S8_ALIAS_LOGGED = "RVAliasSHOld"  # deliberately stale; ALIAS_S8_A's basename is the "new" one
 S9_ALIAS = "RVAliasSI"
 S10_ALIAS = "RVAliasSJ"
 FILLER_IP_ALIAS = "RVAliasFill"
@@ -523,7 +523,16 @@ def _seed_feed_files(vm: helpers.SmokeVM) -> None:
     )
     assert mkdir.returncode == 0, f"failed to mkdir feed dirs: rc={mkdir.returncode} stderr={mkdir.stderr!r}"
 
-    feed_a_lines = [S1_IP, "203.0.113.0/24", S6_IP, S8_IP, S9_IP, *IP_BLOCK_FILLER_IPS, *UNIFIED_ONLY_FILLER_IPS]
+    feed_a_lines = [
+        S1_IP,
+        f"{S3_IP}0",
+        "203.0.113.0/24",
+        S6_IP,
+        S8_IP,
+        S9_IP,
+        *IP_BLOCK_FILLER_IPS,
+        *UNIFIED_ONLY_FILLER_IPS,
+    ]
     files = {
         FEED_A: "\n".join(feed_a_lines) + "\n",
         FEED_B: f"{S3_IP}\n",

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -66,7 +66,7 @@ from urllib.parse import quote
 import pytest
 
 from .. import helpers
-from .render_oracle import evaluate_render
+from .render_oracle import PhpErrorLogGuard, evaluate_render
 from .webui import looks_like_login_page, row_containing
 
 if TYPE_CHECKING:
@@ -116,27 +116,22 @@ FEED_PERMIT = f"{PERMIT_DIR}/RVPermitFeed.txt"
 FEED_MATCH = f"{MATCH_DIR}/RVMatchFeed.txt"
 FEED_ET = f"{ET_DIR}/RVFeedS10.txt"
 FEED_GEO = f"{GEOIP_CC_DIR}/RVGeoFeed.txt"
-ALIAS_OTHER = f"{ALIASTABLES_DIR}/pfB_RVOther_v4.txt"
-# Decoy so the aliastables dir holds >= 2 .txt files: grep only emits "path:content"
-# filename prefixes with two or more file arguments, and S8's alias-changed cell can
-# only derive the NEW alias name from that path prefix (single-file output is the
-# pre-existing unprefixed quirk tracked in issue #833 -- deliberately not exercised).
-ALIAS_DECOY = f"{ALIASTABLES_DIR}/pfB_RVDecoy_v4.txt"
+ALIAS_S8_A = f"{ALIASTABLES_DIR}/pfB_RVAliasA_v4.txt"
+ALIAS_S8_Z = f"{ALIASTABLES_DIR}/pfB_RVAliasZ_v4.txt"
 
-SEEDED_FILES = (FEED_A, FEED_B, FEED_PERMIT, FEED_MATCH, FEED_ET, FEED_GEO, ALIAS_OTHER, ALIAS_DECOY)
+SEEDED_FILES = (FEED_A, FEED_B, FEED_PERMIT, FEED_MATCH, FEED_ET, FEED_GEO, ALIAS_S8_A, ALIAS_S8_Z)
 
-# --- ip_block.log scenarios (S1-S10) -- RFC 5737/3849 addresses. Chosen so no
-# value is a textual PREFIX of another (a short IP's exact-match grep pattern is
-# an unanchored-at-the-end BRE, so e.g. "192.0.2.1" would spuriously satisfy a
-# search for "192.0.2.10"). ---
+# --- ip_block.log scenarios (S1-S10) -- RFC 5737/3849 addresses. S3 and S8
+# deliberately pair an exact address with a longer textual prefix collision;
+# the remaining values avoid accidental prefix overlap. ---
 S1_IP = "192.0.2.10"  # still-listed (found in FEED_A)
 S2_IP = "192.0.2.20"  # de-listed (nowhere)
-S3_IP = "192.0.2.30"  # moved: logged RVFeedA, found only in FEED_B
+S3_IP = "192.0.2.3"  # moved: FEED_A has only .30, exact address is in FEED_B
 S4_IP = "203.0.113.77"  # CIDR: logged RVFeedA, FEED_A holds 203.0.113.0/24
 S5_IP = "198.51.100.60"  # GeoIP: alias pfB_Top_v4, found in FEED_GEO
 S6_IP = "2001:db8::5"  # IPv6, found in FEED_A
 S6_LOCAL = "2001:db8:1234::1"  # the local/dst side of the v6 row (unmatched, cosmetic)
-S8_IP = "198.51.100.40"  # alias-changed: found via FEED_A, aliased in ALIAS_OTHER
+S8_IP = "198.51.100.4"  # alias-changed: exact A alias precedes longer Z decoy
 S9_IP = "192.0.2.50"  # outbound copy of S1 (dst side), also in FEED_A
 S10_IP = "192.0.2.90"  # ET feed, found in FEED_ET
 
@@ -536,14 +531,26 @@ def _seed_feed_files(vm: helpers.SmokeVM) -> None:
         FEED_MATCH: f"{M1_IP}\n",
         FEED_ET: f"{S10_IP}\n",
         FEED_GEO: f"{S5_IP}\n",
-        ALIAS_OTHER: f"{S8_IP}\n",
-        ALIAS_DECOY: "203.0.113.250\n",
+        ALIAS_S8_A: f"{S8_IP}\n",
+        ALIAS_S8_Z: f"{S8_IP}0\n",
     }
     for path, content in files.items():
         result = subprocess.run(
             vm.ssh_argv("tee", path), input=content, capture_output=True, text=True, timeout=30, check=False
         )
         assert result.returncode == 0, f"failed to write {path!r}: rc={result.returncode} stderr={result.stderr!r}"
+
+    alias_order = vm.ssh(f'for file in {ALIASTABLES_DIR}/*.txt; do printf "%s\\n" "$file"; done', timeout=15)
+    assert alias_order.returncode == 0, (
+        f"failed to read aliastables production-glob order: rc={alias_order.returncode} stderr={alias_order.stderr!r}"
+    )
+    ordered_aliases = alias_order.stdout.splitlines()
+    assert ALIAS_S8_A in ordered_aliases and ALIAS_S8_Z in ordered_aliases, (
+        f"S8 fixtures missing from production-glob order: {ordered_aliases!r}"
+    )
+    assert ordered_aliases.index(ALIAS_S8_A) < ordered_aliases.index(ALIAS_S8_Z), (
+        f"S8 requires exact A before longer Z in production-glob order: {ordered_aliases!r}"
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -555,6 +562,7 @@ def _seed_feed_files(vm: helpers.SmokeVM) -> None:
 @pytest.fixture(scope="module")
 def render_diff_state(smoke_vm: helpers.SmokeVM, webui: WebUI) -> Iterator[dict[str, dict[str, Capture]]]:
     vm = smoke_vm
+    error_log_guard = PhpErrorLogGuard(vm)
 
     original_dnsbl_cfg = helpers.config_get(vm, CFG_DNSBL_ENABLE)
     orig_sizes = {
@@ -593,6 +601,8 @@ def render_diff_state(smoke_vm: helpers.SmokeVM, webui: WebUI) -> Iterator[dict[
         # stays the loud guard for that case.)
         rm = vm.ssh("rm -f " + " ".join(SEEDED_FILES), timeout=15)
         assert rm.returncode == 0, f"pre-baseline cleanup of seeded files failed: {rm.stderr!r}"
+
+        error_log_guard.snapshot()
 
         # (1) BASELINE -- pre-seed captures, same fixed order, so "no rv809 tokens
         # yet" is PROVEN, not assumed (CLAUDE.md transition-test rule).
@@ -656,6 +666,11 @@ def render_diff_state(smoke_vm: helpers.SmokeVM, webui: WebUI) -> Iterator[dict[
             errors.append(
                 f"restore pfb_dnsbl failed: rc={restore.returncode} stdout={restore.stdout!r} stderr={restore.stderr!r}"
             )
+
+        try:
+            error_log_guard.assert_no_growth()
+        except AssertionError as exc:
+            errors.append(str(exc))
 
         if errors:
             detail = "\n".join(errors)
@@ -721,12 +736,14 @@ def test_s2_delisted_renders_not_listed(render_diff_state: dict[str, dict[str, C
     assert "<s>" in row, f"S2 ({S2_IP}) expected a struck old feed/IP -- row: {row!r}"
 
 
+@pytest.mark.ui_render
 def test_s3_moved_feed_renders_strike(render_diff_state: dict[str, dict[str, Capture]]) -> None:
     """S3: an IP re-located to a DIFFERENT feed file renders the struck old feed + the new one.
 
-    Given: 192.0.2.30 is logged against RVFeedA but is present ONLY in FEED_B (RVFeedB.txt).
-    Then: find_reported_header() locates it under RVFeedB -> the feed cell struck-shows
-    the old feed name and displays the new one.
+    Given: 192.0.2.3 is logged against RVFeedA, which contains only the longer
+    192.0.2.30; the exact address is present in FEED_B (RVFeedB.txt).
+    Then: exact attribution ignores FEED_A's collision and the feed cell
+    struck-shows the old feed name before displaying the current one.
     """
     body = render_diff_state["captures"]["alert"].body
     row = row_containing(body, f"host={S3_IP}")
@@ -784,19 +801,21 @@ def test_s7_dup_badge_renders_on_s1_row(render_diff_state: dict[str, dict[str, C
     assert "[1]" in row, f"S1 row missing the dup-count badge '[1]' expected from S7's dup marker: {row!r}"
 
 
+@pytest.mark.ui_render
 def test_s8_alias_changed_cell_renders(render_diff_state: dict[str, dict[str, Capture]]) -> None:
     """S8: a host now living under a DIFFERENT pf alias table renders the struck old alias + the new one.
 
-    Given: 198.51.100.40 is logged under alias RVAliasSHOld (feed RVFeedC8, which
-    has no on-disk file -- forces the miss path), found via FEED_A, and is
-    present in ALIAS_OTHER (pfB_RVOther_v4.txt).
-    Then: the aliastables sweep resolves the CURRENT alias table name and the
-    Rule column struck-shows the old alias name, then the new one.
+    Given: 198.51.100.4 is logged under alias RVAliasSHOld (feed RVFeedC8, which
+    has no on-disk file -- forces the miss path), found via FEED_A, and is an
+    exact entry in the A alias while the later Z alias holds only 198.51.100.40.
+    Then: the aliastables sweep ignores the longer collision and the Rule
+    column struck-shows the old alias name before the exact A alias.
     """
     body = render_diff_state["captures"]["alert"].body
     row = row_containing(body, f"host={S8_IP}")
     assert f"<s>{S8_ALIAS_LOGGED}</s>" in row, f"S8 ({S8_IP}) expected the stale alias struck: {row!r}"
-    assert "pfB_RVOther_v4" in row, f"S8 ({S8_IP}) expected the new alias table name pfB_RVOther_v4: {row!r}"
+    assert "pfB_RVAliasA_v4" in row, f"S8 ({S8_IP}) expected the exact current alias pfB_RVAliasA_v4: {row!r}"
+    assert "pfB_RVAliasZ_v4" not in row, f"S8 ({S8_IP}) unexpectedly attributed the longer Z decoy: {row!r}"
 
 
 def test_s9_outbound_direction_still_listed(render_diff_state: dict[str, dict[str, Capture]]) -> None:


### PR DESCRIPTION
## Summary

- invalidate the IP attribution cache when feed content changes, even when the filter rules do not reload
- require complete IP/CIDR entry matches when attributing alerts, preventing prefix collisions such as `.5` matching `.52`
- preserve historical alert rendering while resolving current feed and alias ownership accurately

## Validation

- focused attribution regression suite: 44 tests, 246 assertions
- full PHPUnit suite: 3,492 tests, 21,668 assertions
- PHPStan: no branch-added findings
- PHPCS and PHP lint: pass
- live Tier-A Alerts render smoke: pass
- frozen RED/GREEN proofs independently replayed for both fix steps

Fixes #1367

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved IP/CIDR exact-match handling to prevent prefix/partial attribution, including stricter batched “last match” behavior and safer matching for grep-style inputs.
  - Tightened host/alias validation so only valid exact-match entries influence pattern generation; invalid inputs now safely yield unknown attribution.
  - Refined IP attribution cache invalidation rules so caches refresh correctly when configuration or feed ownership changes, keeping syslog/export results consistent.

- **Tests**
  - Expanded unit/parity/smoke/UI coverage for IPv4/IPv6 CIDR boundaries, longer-prefix collision prevention, invalid-host safety, historical feed drift, and cache invalidation after feed ownership changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->