### PR TITLE
pfblockerng: isolate control watcher failures

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -842,7 +842,12 @@ def pfb_control_watcher() -> None:
                     if msg:
                         log_info("[pfBlockerNG]: {}".format(msg))
                 except Exception as e:
-                    sys.stderr.write("[pfBlockerNG]: control command failed: {}\n".format(e))
+                    err = sys.__stderr__
+                    if err is not None:
+                        try:
+                            err.write("[pfBlockerNG]: control command failed: {}\n".format(e))
+                        except Exception:
+                            pass
             # Advance the applied marker on every consumed record (advance or rejection),
             # so the writer's wait never blocks on a record the reader already saw.
             _control_write_applied(seq)

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -837,9 +837,12 @@ def pfb_control_watcher() -> None:
             last_seq = seq
             command = _control_record_to_command(rec)
             if command is not None:
-                applied, msg = pfb_apply_control_command(command)
-                if msg:
-                    log_info("[pfBlockerNG]: {}".format(msg))
+                try:
+                    applied, msg = pfb_apply_control_command(command)
+                    if msg:
+                        log_info("[pfBlockerNG]: {}".format(msg))
+                except Exception as e:
+                    sys.stderr.write("[pfBlockerNG]: control command failed: {}\n".format(e))
             # Advance the applied marker on every consumed record (advance or rejection),
             # so the writer's wait never blocks on a record the reader already saw.
             _control_write_applied(seq)

--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -23,6 +23,7 @@ is gated on ``pfb["mod_threading"]`` and only a test that explicitly starts it r
 from __future__ import annotations
 
 import sqlite3
+import sys
 import threading
 import time
 from typing import Any
@@ -836,6 +837,21 @@ class TestControlWatcherLoop:
         first_call = threading.Event()
         later_call = threading.Event()
         handler_calls: list[str] = []
+        stderr_fallback: list[str] = []
+
+        class RecordingStderr:
+            def write(self, text: str) -> int:
+                stderr_fallback.append(text)
+                return len(text)
+
+        class SelectiveStderr:
+            def write(self, text: str) -> int:
+                if "control command failed" in text:
+                    raise OSError("closed stderr")
+                return len(text)
+
+        monkeypatch.setattr(sys, "__stderr__", RecordingStderr())
+        monkeypatch.setattr(sys, "stderr", SelectiveStderr())
 
         def apply_command(command: list[str]) -> tuple[bool, str]:
             handler_calls.append(command[1])
@@ -855,6 +871,7 @@ class TestControlWatcherLoop:
         h.publish({"seq": 1, "cmd": "disable"})
         assert first_call.wait(3.0), f"handler calls: {handler_calls!r}"
         assert h.wait_applied(1), f"applied marker: {h.read_applied()!r}"
+        assert "[pfBlockerNG]: control command failed: control handler failed\n" in stderr_fallback
         assert h.thread.is_alive(), "control watcher exited after handler exception"
 
         h.publish({"seq": 2, "cmd": "enable"})

--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -225,10 +225,8 @@ class TestControlEnableOpensDnsblStatsDb:
         ADR-10 swap, the control-channel enable, the timed re-enable). Two racing to
         recover the SAME corrupt stats DB can both fail ``_validate_db_with_recovery``'s
         first validate, so the loser's ``os.remove()`` hits an already-deleted file. That
-        FileNotFoundError must NOT escape the helper -- from the un-wrapped enable call
-        site it would propagate out of ``pfb_apply_control_command``, kill
-        ``pfb_control_watcher``'s thread, and silently disable the control channel until
-        Unbound restarts (issue #870).
+        FileNotFoundError must NOT escape the helper: the shared handler also runs on the
+        legacy DNS-TXT query path, where no watcher boundary contains it (issue #870).
 
         Issue #900: ``pfb_db_validate`` -> ``_db_run`` swallows every fault internally and
         never raises in production, so (unlike the test this replaces) it is NOT
@@ -543,10 +541,8 @@ class TestSharedHandlerBypass:
         assert P.gpListDB.get("192.0.2.10") == 0
 
     def test_malformed_bypass_rejected_without_raising(self) -> None:
-        # PFBL-03: a malformed bypass command must be REJECTED (returned), never RAISED --
-        # a missing IP (IndexError) or a non-IP (ValueError) would otherwise crash the
-        # control watcher thread. Both classes return (False, <message>) and leave the
-        # bypass DB untouched.
+        # PFBL-03: malformed bypass commands return stable rejections and never raise into
+        # the shared handler's unwrapped legacy DNS-TXT caller. Both classes leave the bypass DB untouched.
         # Given: the would-be IP is NOT in the bypass DB (BEFORE).
         assert P.gpListDB.get("not-an-ip") is None
 
@@ -832,6 +828,41 @@ def control_harness(tmp_path: Any, monkeypatch: Any) -> Any:
 
 
 class TestControlWatcherLoop:
+    def test_handler_exception_is_consumed_and_later_record_applies(
+        self, control_harness: _ControlHarness, monkeypatch: Any
+    ) -> None:
+        h = control_harness
+        original_handler = P.pfb_apply_control_command
+        first_call = threading.Event()
+        later_call = threading.Event()
+        handler_calls: list[str] = []
+
+        def apply_command(command: list[str]) -> tuple[bool, str]:
+            handler_calls.append(command[1])
+            if len(handler_calls) == 1:
+                first_call.set()
+                raise RuntimeError("control handler failed")
+            result = original_handler(command)
+            later_call.set()
+            return result
+
+        monkeypatch.setattr(P, "pfb_apply_control_command", apply_command)
+        P.pfb["python_blacklist"] = False
+        h.start()
+        assert h.wait_started()
+        assert P.pfb["python_blacklist"] is False
+
+        h.publish({"seq": 1, "cmd": "disable"})
+        assert first_call.wait(3.0), f"handler calls: {handler_calls!r}"
+        assert h.wait_applied(1), f"applied marker: {h.read_applied()!r}"
+        assert h.thread.is_alive(), "control watcher exited after handler exception"
+
+        h.publish({"seq": 2, "cmd": "enable"})
+        assert later_call.wait(3.0), f"handler calls: {handler_calls!r}"
+        assert h.wait_applied(2), f"applied marker: {h.read_applied()!r}"
+        assert handler_calls == ["disable", "enable"]
+        assert P.pfb["python_blacklist"] is True
+
     def test_fresh_command_is_applied(self, control_harness: _ControlHarness) -> None:
         # Scenario: a root-issued command arriving on the channel performs the action.
         h = control_harness

--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -828,7 +828,56 @@ def control_harness(tmp_path: Any, monkeypatch: Any) -> Any:
         assert not teardown_errors, "\n".join(teardown_errors)
 
 
+class _RaisingStderr:
+    def write(self, text: str) -> int:
+        raise OSError(f"closed stderr: {text}")
+
+
 class TestControlWatcherLoop:
+    @pytest.mark.parametrize(
+        "hostile_stderr",
+        [
+            pytest.param(None, id="stderr-none"),
+            pytest.param(_RaisingStderr(), id="stderr-write-raises"),
+        ],
+    )
+    def test_hostile_stderr_fallback_preserves_progress(
+        self, control_harness: _ControlHarness, monkeypatch: Any, hostile_stderr: Any
+    ) -> None:
+        h = control_harness
+        original_handler = P.pfb_apply_control_command
+        first_call = threading.Event()
+        later_call = threading.Event()
+        handler_calls: list[str] = []
+
+        monkeypatch.setattr(sys, "__stderr__", hostile_stderr)
+
+        def apply_command(command: list[str]) -> tuple[bool, str]:
+            handler_calls.append(command[1])
+            if len(handler_calls) == 1:
+                first_call.set()
+                raise RuntimeError("control handler failed")
+            result = original_handler(command)
+            later_call.set()
+            return result
+
+        monkeypatch.setattr(P, "pfb_apply_control_command", apply_command)
+        P.pfb["python_blacklist"] = False
+        h.start()
+        assert h.wait_started()
+        assert P.pfb["python_blacklist"] is False
+
+        h.publish({"seq": 1, "cmd": "disable"})
+        assert first_call.wait(3.0), f"handler calls: {handler_calls!r}"
+        assert h.wait_applied(1), f"applied marker: {h.read_applied()!r}"
+        assert h.thread.is_alive(), "control watcher exited after hostile stderr fallback"
+
+        h.publish({"seq": 2, "cmd": "enable"})
+        assert later_call.wait(3.0), f"handler calls: {handler_calls!r}"
+        assert h.wait_applied(2), f"applied marker: {h.read_applied()!r}"
+        assert handler_calls == ["disable", "enable"]
+        assert P.pfb["python_blacklist"] is True
+
     def test_handler_exception_is_consumed_and_later_record_applies(
         self, control_harness: _ControlHarness, monkeypatch: Any
     ) -> None:


### PR DESCRIPTION
## Summary

- Isolate each control-channel record from exceptions raised by the shared command handler.
- Consume failed records, advance the applied marker, and keep the watcher available for later sequences.
- Preserve reload-watcher behavior, the shared command grammar, and legacy DNS-TXT behavior.

## Validation

- Signed rebased head `74e3b269e5f4ff04e45502e6ddb57cf12918b4ee` on `7435ab7829b87a3ac2f7d404ed510325274765a1`.
- `scripts/agent/run-gates.sh --diff origin/devel` — full pytest, Ruff lint/format, and mypy passed.
- Frozen red proof against `origin/devel` — RED/GREEN PASS with identical test bytes.
- Frozen diagnostic-boundary proof against `ad5840e4` — RED/GREEN PASS.
- Exact unguarded-stderr mutation — both hostile stderr cases fail with applied marker 0; signed head passes.
- Focused control, legacy DNS-TXT, reload-watcher, and #1296 preservation suites — 89 passed.
- Independent Sol/Medium adversarial review — PASS, zero findings.

Fixes #1353

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
