### PR TITLE
agent: restore deleted red-proof paths

### DIFF
--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -40,7 +40,10 @@ restore_srcs() {
 			git -C "$worktree" checkout HEAD -- "$src" || return 1
 		else
 			git -C "$worktree" rm -q -r -f -- "$src" || return 1
-			git -C "$worktree" clean -q -d -f -x -- "$src" || return 1
+			git -C "$worktree" clean -q -d -f -f -x -- "$src" || return 1
+			if [ -e "$worktree/$src" ] || [ -L "$worktree/$src" ]; then
+				return 1
+			fi
 		fi
 	done
 }
@@ -89,6 +92,19 @@ main() {
 		echo "BAD-BASE-REF: '$base_ref' does not resolve to a single existing commit" >&2
 		exit 2
 	}
+	for src in $srcs; do
+		if ! git -C "$worktree" cat-file -e "HEAD:$src" 2>/dev/null; then
+			ignored=$(git -C "$worktree" status --porcelain=v1 --ignored --untracked-files=all -- "$src") || {
+				echo "DIRTY-TREE: the gate re-derives from committed state; commit or clean first." >&2
+				exit 2
+			}
+			case "$ignored" in
+				*'!! '* )
+					echo "DIRTY-TREE: the gate re-derives from committed state; commit or clean first." >&2
+					exit 2 ;;
+			esac
+		fi
+	done
 	# shellcheck disable=SC2086 # srcs is a space-separated path list by construction
 	git -C "$worktree" checkout "$base_sha" -- $srcs || fail "REVERT-FAIL: could not check out $base_ref src paths"
 	# INT/TERM trapped explicitly: under dash (Linux /bin/sh) an EXIT trap does NOT run

--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -39,7 +39,7 @@ restore_srcs() {
 		if git -C "$worktree" cat-file -e "HEAD:$src" 2>/dev/null; then
 			git -C "$worktree" checkout HEAD -- "$src" || return 1
 		else
-			git -C "$worktree" rm -q -r -f -- "$src" || return 1
+			git -C "$worktree" rm -q -r -f --ignore-unmatch -- "$src" || return 1
 			git -C "$worktree" clean -q -d -f -f -x -- "$src" || return 1
 			if [ -e "$worktree/$src" ] || [ -L "$worktree/$src" ]; then
 				return 1

--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -105,12 +105,12 @@ main() {
 			esac
 		fi
 	done
-	# shellcheck disable=SC2086 # srcs is a space-separated path list by construction
-	git -C "$worktree" checkout "$base_sha" -- $srcs || fail "REVERT-FAIL: could not check out $base_ref src paths"
 	# INT/TERM trapped explicitly: under dash (Linux /bin/sh) an EXIT trap does NOT run
 	# on an untrapped signal, which would strand the src paths at the base ref.
 	trap 'restore_srcs' EXIT
 	trap 'restore_srcs; trap - EXIT; exit 130' INT TERM
+	# shellcheck disable=SC2086 # srcs is a space-separated path list by construction
+	git -C "$worktree" checkout "$base_sha" -- $srcs || fail "REVERT-FAIL: could not check out $base_ref src paths"
 
 	if (cd "$worktree" && sh -c "$test_cmd" >/dev/null 2>&1); then
 		fail "RED-FAIL: test passed against $base_ref src -- it does not pin the defect"

--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -13,7 +13,8 @@
 #   --base-ref  the pre-fix baseline (default HEAD~1). Pass the true pre-fix commit
 #               explicitly whenever the step landed more than one commit (a follow-up
 #               doc/ADR reconciliation, a review fix) -- HEAD~1 then names the wrong
-#               commit. Omitting it keeps today's behaviour byte-identical.
+#               commit. Omitting it keeps today's behaviour byte-identical. Every --src
+#               must exist at --base-ref; added-only paths fail with REVERT-FAIL.
 #
 # Prints FREEZE-OK / RED-OK / GREEN-OK step lines, then final `VERDICT: PASS`.
 # Any step failing prints the failing step + `VERDICT: FAIL` and exits 1. Requires a
@@ -31,6 +32,16 @@ usage() {
 fail() {
 	printf '%s\nVERDICT: FAIL\n' "$1"
 	exit 1
+}
+
+restore_srcs() {
+	for src in $srcs; do
+		if git -C "$worktree" cat-file -e "HEAD:$src" 2>/dev/null; then
+			git -C "$worktree" checkout HEAD -- "$src" || return 1
+		else
+			git -C "$worktree" rm -q -f -- "$src" || return 1
+		fi
+	done
 }
 
 main() {
@@ -79,20 +90,17 @@ main() {
 	}
 	# shellcheck disable=SC2086 # srcs is a space-separated path list by construction
 	git -C "$worktree" checkout "$base_sha" -- $srcs || fail "REVERT-FAIL: could not check out $base_ref src paths"
-	# shellcheck disable=SC2064,SC2086 # expand now: restore exactly these paths on any exit.
 	# INT/TERM trapped explicitly: under dash (Linux /bin/sh) an EXIT trap does NOT run
 	# on an untrapped signal, which would strand the src paths at the base ref.
-	trap "git -C '$worktree' checkout HEAD -- $srcs" EXIT
-	# shellcheck disable=SC2064,SC2086 # expand now, deliberately (same paths as above)
-	trap "git -C '$worktree' checkout HEAD -- $srcs; trap - EXIT; exit 130" INT TERM
+	trap 'restore_srcs' EXIT
+	trap 'restore_srcs; trap - EXIT; exit 130' INT TERM
 
 	if (cd "$worktree" && sh -c "$test_cmd" >/dev/null 2>&1); then
 		fail "RED-FAIL: test passed against $base_ref src -- it does not pin the defect"
 	fi
 	printf 'RED-OK: test fails against %s src\n' "$base_ref"
 
-	# shellcheck disable=SC2086
-	git -C "$worktree" checkout HEAD -- $srcs || fail "RESTORE-FAIL"
+	restore_srcs || fail "RESTORE-FAIL"
 	trap - EXIT INT TERM
 
 	if ! (cd "$worktree" && sh -c "$test_cmd" >/dev/null 2>&1); then

--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -39,7 +39,7 @@ restore_srcs() {
 		if git -C "$worktree" cat-file -e "HEAD:$src" 2>/dev/null; then
 			git -C "$worktree" checkout HEAD -- "$src" || return 1
 		else
-			git -C "$worktree" rm -q -f -- "$src" || return 1
+			git -C "$worktree" rm -q -r -f -- "$src" || return 1
 		fi
 	done
 }

--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -40,6 +40,7 @@ restore_srcs() {
 			git -C "$worktree" checkout HEAD -- "$src" || return 1
 		else
 			git -C "$worktree" rm -q -r -f -- "$src" || return 1
+			git -C "$worktree" clean -q -d -f -x -- "$src" || return 1
 		fi
 	done
 }

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -73,6 +73,21 @@ Describe 'verify-red-proof.sh'
     gitc add -A
     gitc commit -qm v2
   }
+  make_deleted_directory_with_red_descendants_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-del-dir-desc.XXXXXX")"
+    git -C "$repo" init -q
+    mkdir "$repo/gone"
+    echo OLD > "$repo/gone/a.txt"
+    printf 'gone/ignored.txt\n' > "$repo/.gitignore"
+    printf 'if test -e gone/a.txt; then\n  printf UNTRACKED > gone/new.txt\n  printf IGNORED > gone/ignored.txt\n  false\nfi\ntest ! -e gone\n' > "$repo/test_pin.sh"
+    gitc add -A
+    gitc commit -qm v1
+    rm -rf "$repo/gone"
+    echo other > "$repo/other.txt"
+    gitc add -A
+    gitc commit -qm v2
+  }
   make_mixed_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-mixed.XXXXXX")"
@@ -133,6 +148,17 @@ Describe 'verify-red-proof.sh'
     The output should include 'VERDICT: PASS'
     Assert [ ! -e "$repo/gone" ]
     Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'removes untracked and ignored descendants from a red-run deleted directory'
+    make_deleted_directory_with_red_descendants_repo
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src gone
+    The status should equal 0
+    The output should include 'RED-OK'
+    The output should include 'GREEN-OK'
+    The output should include 'VERDICT: PASS'
+    Assert [ ! -e "$repo/gone" ]
+    Assert [ -z "$(git -C "$repo" status --porcelain --untracked-files=all)" ]
   End
 
   It 'restores modified and deleted src paths to their distinct HEAD states'

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -45,6 +45,45 @@ Describe 'verify-red-proof.sh'
     gitc commit -qm v3-followup
     pin_hash=$(gitc hash-object test_pin.sh)
   }
+  make_deleted_repo() {
+    # HEAD~1 tracks old.txt; HEAD deletes it. $1 is the test command.
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-del.XXXXXX")"
+    git -C "$repo" init -q
+    echo OLD > "$repo/old.txt"
+    printf '%s\n' "$1" > "$repo/test_pin.sh"
+    gitc add -A
+    gitc commit -qm v1
+    rm "$repo/old.txt"
+    echo other > "$repo/other.txt"
+    gitc add -A
+    gitc commit -qm v2
+  }
+  make_mixed_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-mixed.XXXXXX")"
+    git -C "$repo" init -q
+    echo BAD > "$repo/src.txt"
+    echo OLD > "$repo/old.txt"
+    printf 'grep -q GOOD src.txt && test ! -e old.txt\n' > "$repo/test_pin.sh"
+    gitc add -A
+    gitc commit -qm v1
+    echo GOOD > "$repo/src.txt"
+    rm "$repo/old.txt"
+    gitc add -A
+    gitc commit -qm v2
+  }
+  make_added_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-add.XXXXXX")"
+    git -C "$repo" init -q
+    printf 'test -e added.txt\n' > "$repo/test_pin.sh"
+    gitc add -A
+    gitc commit -qm v1
+    echo ADDED > "$repo/added.txt"
+    gitc add -A
+    gitc commit -qm v2
+  }
   cleanup() { rm -rf "$repo"; }
   After 'cleanup'
 
@@ -60,12 +99,46 @@ Describe 'verify-red-proof.sh'
     Assert [ -z "$(git -C "$repo" status --porcelain)" ]
   End
 
+  It 'passes a deleted-only red->green proof and restores the HEAD deletion'
+    make_deleted_repo 'test ! -e old.txt'
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src old.txt
+    The status should equal 0
+    The output should include 'RED-OK'
+    The output should include 'GREEN-OK'
+    The output should include 'VERDICT: PASS'
+    Assert [ ! -e "$repo/old.txt" ]
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'restores modified and deleted src paths to their distinct HEAD states'
+    make_mixed_repo
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' \
+      --src src.txt --src old.txt
+    The status should equal 0
+    The output should include 'RED-OK'
+    The output should include 'GREEN-OK'
+    The output should include 'VERDICT: PASS'
+    The contents of file "$repo/src.txt" should equal 'GOOD'
+    Assert [ ! -e "$repo/old.txt" ]
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
   It 'rejects a test that already passes against HEAD~1 (pins nothing)'
     make_repo GOOD GOOD
     When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt
     The status should equal 1
     The output should include 'RED-FAIL'
     The output should include 'VERDICT: FAIL'
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'restores a deleted src path through the EXIT trap after RED-FAIL'
+    make_deleted_repo 'test -e old.txt'
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src old.txt
+    The status should equal 1
+    The output should include 'RED-FAIL'
+    The output should include 'VERDICT: FAIL'
+    Assert [ ! -e "$repo/old.txt" ]
     Assert [ -z "$(git -C "$repo" status --porcelain)" ]
   End
 
@@ -92,12 +165,40 @@ Describe 'verify-red-proof.sh'
     The output should equal ''
   End
 
+  It 'restores a deleted src path when SIGTERM interrupts the red run (dash semantics)'
+    make_deleted_repo 'test ! -e old.txt'
+    interrupt_deleted_case() {
+      dash "$script" --worktree "$repo" --test-cmd 'sleep 30' --src old.txt >/dev/null 2>&1 &
+      pid=$!
+      sleep 1
+      kill -TERM "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      printf '%s\n' "$?"
+      git -C "$repo" status --porcelain
+    }
+    When call interrupt_deleted_case
+    The output should equal '130'
+    Assert [ ! -e "$repo/old.txt" ]
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
   It 'rejects a fix that does not satisfy its own pin (GREEN-FAIL)'
     make_repo BAD BAD
     When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt
     The status should equal 1
     The output should include 'RED-OK'
     The output should include 'GREEN-FAIL'
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'keeps added-only src paths unsupported and leaves HEAD clean after REVERT-FAIL'
+    make_added_repo
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src added.txt
+    The status should equal 1
+    The output should include 'REVERT-FAIL'
+    The output should include 'VERDICT: FAIL'
+    The stderr should include "pathspec 'added.txt'"
+    The contents of file "$repo/added.txt" should equal 'ADDED'
     Assert [ -z "$(git -C "$repo" status --porcelain)" ]
   End
 

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -156,6 +156,11 @@ Describe 'verify-red-proof.sh'
     gitc add -A
     gitc commit -qm v2
   }
+  arm_checkout_term_hook() {
+    hook="$repo/.git/hooks/post-checkout"
+    printf '%s\n' '#!/bin/sh' 'rm -f "$0"' 'parent=$(ps -o ppid= -p "$PPID" | tr -d " ")' 'kill -TERM "$parent"' > "$hook"
+    chmod +x "$hook"
+  }
   cleanup() { rm -rf "$repo"; }
   After 'cleanup'
 
@@ -363,6 +368,21 @@ Describe 'verify-red-proof.sh'
     }
     When call interrupt_case
     The output should equal ''
+  End
+
+  It 'restores src paths when SIGTERM arrives during baseline checkout'
+    make_repo BAD GOOD
+    arm_checkout_term_hook
+    interrupt_checkout_case() {
+      dash "$script" --worktree "$repo" --test-cmd 'true' --src src.txt >/dev/null 2>&1 &
+      pid=$!
+      wait "$pid" 2>/dev/null
+      printf '%s\n' "$?"
+    }
+    When call interrupt_checkout_case
+    The output should equal '130'
+    The contents of file "$repo/src.txt" should equal 'GOOD'
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
   End
 
   It 'restores a deleted src path when SIGTERM interrupts the red run (dash semantics)'

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -8,6 +8,19 @@ Describe 'verify-red-proof.sh'
 
   gitc() { git -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
 
+  assert_repo_clean() {
+    status_output=$(git -C "$repo" status --porcelain "$@")
+    status_code=$?
+    if [ "$status_code" -ne 0 ]; then
+      return "$status_code"
+    fi
+    if [ -n "$status_output" ]; then
+      printf '%s\n' "$status_output" >&2
+      return 1
+    fi
+    return 0
+  }
+
   make_repo() {
     # $1 = HEAD~1 src content, $2 = HEAD src content
     # ADR-47: under the pre-commit hook, exported GIT_DIR/GIT_INDEX_FILE would
@@ -173,7 +186,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'RED-OK'
     The output should include 'GREEN-OK'
     The line 4 of output should equal 'VERDICT: PASS'
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'passes a deleted-only red->green proof and restores the HEAD deletion'
@@ -184,7 +197,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'GREEN-OK'
     The output should include 'VERDICT: PASS'
     Assert [ ! -e "$repo/old.txt" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'passes a deleted-directory red->green proof and restores the HEAD deletion'
@@ -195,7 +208,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'GREEN-OK'
     The output should include 'VERDICT: PASS'
     Assert [ ! -e "$repo/gone" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'removes untracked and ignored descendants from a red-run deleted directory'
@@ -206,7 +219,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'GREEN-OK'
     The output should include 'VERDICT: PASS'
     Assert [ ! -e "$repo/gone" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain --untracked-files=all)" ]
+    Assert assert_repo_clean --untracked-files=all
   End
 
   It 'rejects preexisting ignored data only beneath a HEAD-absent src and preserves it'
@@ -221,7 +234,7 @@ Describe 'verify-red-proof.sh'
     The contents of file "$repo/gone/ignored.txt" should equal 'KEEP'
     The contents of file "$repo/unrelated/ignored.txt" should equal 'OTHER'
     Assert [ ! -e "$repo/gone/a.txt" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'allows unrelated ignored data while proving the requested src path is clean'
@@ -247,7 +260,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'VERDICT: PASS'
     Assert [ ! -e "$repo/gone" ]
     Assert [ ! -L "$repo/gone" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain --untracked-files=all)" ]
+    Assert assert_repo_clean --untracked-files=all
   End
 
   It 'removes a red-created nested repository through EXIT after RED-FAIL'
@@ -258,7 +271,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'VERDICT: FAIL'
     Assert [ ! -e "$repo/gone" ]
     Assert [ ! -L "$repo/gone" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain --untracked-files=all)" ]
+    Assert assert_repo_clean --untracked-files=all
   End
 
   It 'removes a red-created nested repository through SIGTERM restoration'
@@ -270,13 +283,13 @@ Describe 'verify-red-proof.sh'
       kill -TERM "$pid" 2>/dev/null
       wait "$pid" 2>/dev/null
       printf '%s\n' "$?"
-      git -C "$repo" status --porcelain
+      assert_repo_clean
     }
     When call interrupt_nested_case
     The output should equal '130'
     Assert [ ! -e "$repo/gone" ]
     Assert [ ! -L "$repo/gone" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain --untracked-files=all)" ]
+    Assert assert_repo_clean --untracked-files=all
   End
 
   It 'restores modified and deleted src paths to their distinct HEAD states'
@@ -289,7 +302,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'VERDICT: PASS'
     The contents of file "$repo/src.txt" should equal 'GOOD'
     Assert [ ! -e "$repo/old.txt" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'restores duplicate HEAD-absent src paths idempotently'
@@ -301,7 +314,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'GREEN-OK'
     The output should include 'VERDICT: PASS'
     Assert [ ! -e "$repo/gone" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'restores overlapping HEAD-absent src paths in ancestor-first order'
@@ -313,7 +326,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'GREEN-OK'
     The output should include 'VERDICT: PASS'
     Assert [ ! -e "$repo/gone" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'restores overlapping HEAD-absent src paths in descendant-first order'
@@ -325,7 +338,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'GREEN-OK'
     The output should include 'VERDICT: PASS'
     Assert [ ! -e "$repo/gone" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'rejects a test that already passes against HEAD~1 (pins nothing)'
@@ -334,7 +347,7 @@ Describe 'verify-red-proof.sh'
     The status should equal 1
     The output should include 'RED-FAIL'
     The output should include 'VERDICT: FAIL'
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'restores a deleted src path through the EXIT trap after RED-FAIL'
@@ -344,7 +357,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'RED-FAIL'
     The output should include 'VERDICT: FAIL'
     Assert [ ! -e "$repo/old.txt" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'rejects an edited reproduction test via the freeze hash'
@@ -364,7 +377,7 @@ Describe 'verify-red-proof.sh'
       sleep 1
       kill -TERM "$pid" 2>/dev/null
       wait "$pid" 2>/dev/null
-      git -C "$repo" status --porcelain
+      assert_repo_clean
     }
     When call interrupt_case
     The output should equal ''
@@ -382,7 +395,7 @@ Describe 'verify-red-proof.sh'
     When call interrupt_checkout_case
     The output should equal '130'
     The contents of file "$repo/src.txt" should equal 'GOOD'
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'restores a deleted src path when SIGTERM interrupts the red run (dash semantics)'
@@ -394,12 +407,12 @@ Describe 'verify-red-proof.sh'
       kill -TERM "$pid" 2>/dev/null
       wait "$pid" 2>/dev/null
       printf '%s\n' "$?"
-      git -C "$repo" status --porcelain
+      assert_repo_clean
     }
     When call interrupt_deleted_case
     The output should equal '130'
     Assert [ ! -e "$repo/old.txt" ]
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'rejects a fix that does not satisfy its own pin (GREEN-FAIL)'
@@ -408,7 +421,7 @@ Describe 'verify-red-proof.sh'
     The status should equal 1
     The output should include 'RED-OK'
     The output should include 'GREEN-FAIL'
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'keeps added-only src paths unsupported and leaves HEAD clean after REVERT-FAIL'
@@ -419,7 +432,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'VERDICT: FAIL'
     The stderr should include "pathspec 'added.txt'"
     The contents of file "$repo/added.txt" should equal 'ADDED'
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'rejects a --src path with shell metacharacters at parse time'
@@ -438,6 +451,22 @@ Describe 'verify-red-proof.sh'
     The stderr should include 'DIRTY-TREE'
   End
 
+  It 'does not pass when git status cannot inspect the path'
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-not-repo.XXXXXX")"
+    When call assert_repo_clean
+    The status should equal 128
+    The stderr should include 'not a git repository'
+  End
+
+  It 'prints porcelain diagnostics for a dirty untracked repository'
+    make_repo BAD GOOD
+    echo scratch > "$repo/untracked.txt"
+    When call assert_repo_clean
+    The status should equal 1
+    The stderr should include '?? untracked.txt'
+  End
+
   It 'verifies a genuine red->green proof against an explicit --base-ref (3-commit fixture, mirrors PR #1247)'
     make_repo3 BAD GOOD FOLLOWUP
     When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' \
@@ -446,7 +475,7 @@ Describe 'verify-red-proof.sh'
     The output should include 'RED-OK'
     The output should include 'GREEN-OK'
     The line 4 of output should equal 'VERDICT: PASS'
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'without --base-ref, the same 3-commit fixture still falsely reports RED-FAIL (documents the default HEAD~1 bug)'
@@ -472,7 +501,7 @@ Describe 'verify-red-proof.sh'
     When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref '-q'
     The status should equal 2
     The stderr should include 'BAD-BASE-REF'
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'rejects a --base-ref that looks like a git option ("--force")'
@@ -480,7 +509,7 @@ Describe 'verify-red-proof.sh'
     When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref '--force'
     The status should equal 2
     The stderr should include 'BAD-BASE-REF'
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   # An empty value is caught by the parse-time guard, NOT by the later rev-parse check:
@@ -499,7 +528,7 @@ Describe 'verify-red-proof.sh'
     When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref 'no-such-ref'
     The status should equal 2
     The stderr should include 'BAD-BASE-REF'
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   # The 3-commit fixture is what makes these pin RANGE rejection rather than merely
@@ -509,7 +538,7 @@ Describe 'verify-red-proof.sh'
     When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref 'HEAD~2..HEAD'
     The status should equal 2
     The stderr should include 'BAD-BASE-REF'
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 
   It 'rejects a --base-ref that is a symmetric revision range whose endpoints both exist ("HEAD~2...HEAD")'
@@ -517,6 +546,6 @@ Describe 'verify-red-proof.sh'
     When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt --base-ref 'HEAD~2...HEAD'
     The status should equal 2
     The stderr should include 'BAD-BASE-REF'
-    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+    Assert assert_repo_clean
   End
 End

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -103,6 +103,20 @@ Describe 'verify-red-proof.sh'
     gitc add -A
     gitc commit -qm v2
   }
+  make_deleted_overlap_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-overlap.XXXXXX")"
+    git -C "$repo" init -q
+    mkdir "$repo/gone"
+    echo OLD > "$repo/gone/a.txt"
+    printf 'test ! -e gone/a.txt\n' > "$repo/test_pin.sh"
+    gitc add -A
+    gitc commit -qm v1
+    rm -rf "$repo/gone"
+    echo other > "$repo/other.txt"
+    gitc add -A
+    gitc commit -qm v2
+  }
   make_deleted_directory_with_nested_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-nested.XXXXXX")"
@@ -270,6 +284,42 @@ Describe 'verify-red-proof.sh'
     The output should include 'VERDICT: PASS'
     The contents of file "$repo/src.txt" should equal 'GOOD'
     Assert [ ! -e "$repo/old.txt" ]
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'restores duplicate HEAD-absent src paths idempotently'
+    make_deleted_overlap_repo
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' \
+      --src gone --src gone
+    The status should equal 0
+    The output should include 'RED-OK'
+    The output should include 'GREEN-OK'
+    The output should include 'VERDICT: PASS'
+    Assert [ ! -e "$repo/gone" ]
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'restores overlapping HEAD-absent src paths in ancestor-first order'
+    make_deleted_overlap_repo
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' \
+      --src gone --src gone/a.txt
+    The status should equal 0
+    The output should include 'RED-OK'
+    The output should include 'GREEN-OK'
+    The output should include 'VERDICT: PASS'
+    Assert [ ! -e "$repo/gone" ]
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'restores overlapping HEAD-absent src paths in descendant-first order'
+    make_deleted_overlap_repo
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' \
+      --src gone/a.txt --src gone
+    The status should equal 0
+    The output should include 'RED-OK'
+    The output should include 'GREEN-OK'
+    The output should include 'VERDICT: PASS'
+    Assert [ ! -e "$repo/gone" ]
     Assert [ -z "$(git -C "$repo" status --porcelain)" ]
   End
 

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -59,6 +59,20 @@ Describe 'verify-red-proof.sh'
     gitc add -A
     gitc commit -qm v2
   }
+  make_deleted_directory_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-del-dir.XXXXXX")"
+    git -C "$repo" init -q
+    mkdir "$repo/gone"
+    echo OLD > "$repo/gone/a.txt"
+    printf 'test ! -e gone\n' > "$repo/test_pin.sh"
+    gitc add -A
+    gitc commit -qm v1
+    rm -rf "$repo/gone"
+    echo other > "$repo/other.txt"
+    gitc add -A
+    gitc commit -qm v2
+  }
   make_mixed_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-mixed.XXXXXX")"
@@ -107,6 +121,17 @@ Describe 'verify-red-proof.sh'
     The output should include 'GREEN-OK'
     The output should include 'VERDICT: PASS'
     Assert [ ! -e "$repo/old.txt" ]
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'passes a deleted-directory red->green proof and restores the HEAD deletion'
+    make_deleted_directory_repo
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src gone
+    The status should equal 0
+    The output should include 'RED-OK'
+    The output should include 'GREEN-OK'
+    The output should include 'VERDICT: PASS'
+    Assert [ ! -e "$repo/gone" ]
     Assert [ -z "$(git -C "$repo" status --porcelain)" ]
   End
 

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -88,6 +88,35 @@ Describe 'verify-red-proof.sh'
     gitc add -A
     gitc commit -qm v2
   }
+  make_ignored_deleted_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-ignored.XXXXXX")"
+    git -C "$repo" init -q
+    mkdir "$repo/gone"
+    echo OLD > "$repo/gone/a.txt"
+    printf 'gone/ignored.txt\nunrelated/\n' > "$repo/.gitignore"
+    printf 'test ! -e gone\n' > "$repo/test_pin.sh"
+    gitc add -A
+    gitc commit -qm v1
+    rm -rf "$repo/gone"
+    echo other > "$repo/other.txt"
+    gitc add -A
+    gitc commit -qm v2
+  }
+  make_deleted_directory_with_nested_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-nested.XXXXXX")"
+    git -C "$repo" init -q
+    mkdir "$repo/gone"
+    echo OLD > "$repo/gone/a.txt"
+    printf 'if test -e gone/a.txt; then\n  mkdir -p gone/nested\n  git -C gone/nested init -q\n  %s\nelse\n  test ! -e gone\nfi\n' "$1" > "$repo/test_pin.sh"
+    gitc add -A
+    gitc commit -qm v1
+    rm -rf "$repo/gone"
+    echo other > "$repo/other.txt"
+    gitc add -A
+    gitc commit -qm v2
+  }
   make_mixed_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-mixed.XXXXXX")"
@@ -158,6 +187,76 @@ Describe 'verify-red-proof.sh'
     The output should include 'GREEN-OK'
     The output should include 'VERDICT: PASS'
     Assert [ ! -e "$repo/gone" ]
+    Assert [ -z "$(git -C "$repo" status --porcelain --untracked-files=all)" ]
+  End
+
+  It 'rejects preexisting ignored data only beneath a HEAD-absent src and preserves it'
+    make_ignored_deleted_repo
+    mkdir -p "$repo/gone" "$repo/unrelated"
+    printf KEEP > "$repo/gone/ignored.txt"
+    printf OTHER > "$repo/unrelated/ignored.txt"
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src gone
+    The status should equal 2
+    The output should not include 'REVERT-FAIL'
+    The stderr should include 'DIRTY-TREE'
+    The contents of file "$repo/gone/ignored.txt" should equal 'KEEP'
+    The contents of file "$repo/unrelated/ignored.txt" should equal 'OTHER'
+    Assert [ ! -e "$repo/gone/a.txt" ]
+    Assert [ -z "$(git -C "$repo" status --porcelain)" ]
+  End
+
+  It 'allows unrelated ignored data while proving the requested src path is clean'
+    make_ignored_deleted_repo
+    mkdir -p "$repo/unrelated"
+    printf OTHER > "$repo/unrelated/ignored.txt"
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src gone
+    The status should equal 0
+    The output should include 'RED-OK'
+    The output should include 'GREEN-OK'
+    The output should include 'VERDICT: PASS'
+    The contents of file "$repo/unrelated/ignored.txt" should equal 'OTHER'
+    Assert [ ! -e "$repo/gone" ]
+    Assert [ ! -L "$repo/gone" ]
+  End
+
+  It 'removes a red-created nested repository on normal restoration'
+    make_deleted_directory_with_nested_repo 'test ! -e gone'
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src gone
+    The status should equal 0
+    The output should include 'RED-OK'
+    The output should include 'GREEN-OK'
+    The output should include 'VERDICT: PASS'
+    Assert [ ! -e "$repo/gone" ]
+    Assert [ ! -L "$repo/gone" ]
+    Assert [ -z "$(git -C "$repo" status --porcelain --untracked-files=all)" ]
+  End
+
+  It 'removes a red-created nested repository through EXIT after RED-FAIL'
+    make_deleted_directory_with_nested_repo ':'
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src gone
+    The status should equal 1
+    The output should include 'RED-FAIL'
+    The output should include 'VERDICT: FAIL'
+    Assert [ ! -e "$repo/gone" ]
+    Assert [ ! -L "$repo/gone" ]
+    Assert [ -z "$(git -C "$repo" status --porcelain --untracked-files=all)" ]
+  End
+
+  It 'removes a red-created nested repository through SIGTERM restoration'
+    make_deleted_directory_with_nested_repo 'sleep 30'
+    interrupt_nested_case() {
+      dash "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src gone >/dev/null 2>&1 &
+      pid=$!
+      sleep 1
+      kill -TERM "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      printf '%s\n' "$?"
+      git -C "$repo" status --porcelain
+    }
+    When call interrupt_nested_case
+    The output should equal '130'
+    Assert [ ! -e "$repo/gone" ]
+    Assert [ ! -L "$repo/gone" ]
     Assert [ -z "$(git -C "$repo" status --porcelain --untracked-files=all)" ]
   End
 


### PR DESCRIPTION
Fixes #1290

Restore each red-proof source to its distinct committed HEAD state: checkout paths present at HEAD and remove paths absent at HEAD. HEAD-absent restoration is idempotent for duplicate and ancestor/descendant `--src` inputs. Added-only source paths remain unsupported and fail cleanly at initial REVERT-FAIL.

Arm cleanup before the baseline checkout so a checkout-time signal or partial checkout failure cannot strand already-mutated sources.

Validation:
- original issue RED→GREEN proof against f7ae6e6e: PASS
- checkout-signal frozen test blob: 03af2e75e80083e35c3148738f7f4d357e52e068
- checkout-signal RED: 1 example, 1 failure; exit 143, baseline content left dirty
- checkout-signal GREEN: 1 example, 0 failures; exit 130, HEAD restored cleanly
- focused ShellSpec after review fixes: 34 examples, 0 failures
- full ShellSpec before the test-only final review fix: 887 examples, 0 failures, 8 skipped
- canonical shell gates after the final review fix: PASS
- all 27 repository-cleanliness probes now preserve `git status` failures; non-repository and dirty/untracked regression cases pass

Signed PR head: f09ada807e01efea0b633be0ae2a6751983eea56

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Red-proof verification now supports deleted files and directories, including nested and overlapping paths.
  * Cleanup preserves valid pre-existing ignored content while removing artifacts created during verification.
  * Interrupted or failed verification runs now restore the worktree more reliably.

* **Bug Fixes**
  * Improved diagnostics for dirty or non-Git worktrees.
  * Added explicit handling for unsupported added-only paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->