### PR TITLE
tests/smoke: drain tick tasks before dispatch (#1297)

### DIFF
--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -411,6 +411,7 @@ def test_tick_dispatches_due_feed(deployed_vm: SmokeVM) -> None:
 
     # Given: force cron past; snapshot the sync_cron marker count before the tick.
     _write_ledger_entry(vm, "cron", now_ts - 90000, now_ts - 1)
+    h.wait_no_active_pfb_task(vm)
     cron_marker_before = h.count_log_marker(vm, h.PFB_LOG, marker)
 
     before = _read_ledger(vm)
@@ -476,6 +477,7 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
 
     now_ts = int(vm.ssh("date +%s").stdout.strip())
     _write_ledger_entry(vm, "cron", now_ts - 86400, now_ts + 3600)
+    h.wait_no_active_pfb_task(vm)
     before = h.count_log_marker(vm, h.PFB_LOG, marker)
 
     # Positive control: a resolvable CNAME target the stub answers, baked stale in the CSV.

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -20,7 +20,9 @@ Tests:
 
 import json
 import os
+import subprocess
 from collections.abc import Iterator
+from typing import Literal
 
 import pytest
 
@@ -125,9 +127,10 @@ def _write_ledger_entry(vm: SmokeVM, job_key: str, last_run: int, next_due: int,
         raise RuntimeError(f"_write_ledger_entry failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
 
 
-def _run_tick(vm: SmokeVM) -> str:
-    """Fire one tick synchronously and return its combined stdout+stderr."""
-    return vm.ssh(f"{_PHP} {_PFB_PHP} tick 2>&1").stdout
+def _run_tick(vm: SmokeVM, verb: Literal["tick", "cron-tick"] = "tick") -> subprocess.CompletedProcess[str]:
+    """Drain active pfBlockerNG tasks, then fire one tick verb."""
+    h.wait_no_active_pfb_task(vm)
+    return vm.ssh(_PHP, _PFB_PHP, verb)
 
 
 _SS_EXTDNS_STUB = "192.168.89.2"  # WAN SLIRP host alias -> the stub_dns fixture
@@ -318,7 +321,7 @@ def test_cron_tick_respects_disable_flag(deployed_vm: SmokeVM) -> None:
         # --- flag present: cron-tick must NOT dispatch. ---
         _write_ledger_entry(vm, "cron", now_ts - 90000, now_ts - 1)
         before = _read_ledger(vm)
-        result = vm.ssh(_PHP, _PFB_PHP, "cron-tick")
+        result = _run_tick(vm, "cron-tick")
         assert result.returncode == 0, f"cron-tick (flag present) rc={result.returncode} stderr={result.stderr!r}"
         assert f"[ Disabled by {flag} ]" in result.stdout, (
             f"cron-tick (flag present) must print the disabled banner; got {result.stdout!r}"
@@ -332,7 +335,7 @@ def test_cron_tick_respects_disable_flag(deployed_vm: SmokeVM) -> None:
         # --- flag absent: cron-tick DOES dispatch (the non-vacuous other half). ---
         rm = vm.ssh("rm", "-f", flag)
         assert rm.returncode == 0, f"failed to remove {flag}: rc={rm.returncode} {rm.stderr!r}"
-        result2 = vm.ssh(_PHP, _PFB_PHP, "cron-tick")
+        result2 = _run_tick(vm, "cron-tick")
         assert result2.returncode == 0, f"cron-tick (flag absent) rc={result2.returncode} stderr={result2.stderr!r}"
         assert "[ Disabled by" not in result2.stdout, (
             f"cron-tick (flag absent) must not print the disabled banner; got {result2.stdout!r}"
@@ -368,7 +371,7 @@ def test_tick_verb_ignores_disable_flag(deployed_vm: SmokeVM) -> None:
     now_ts = int(vm.ssh("date +%s").stdout.strip())
     _write_ledger_entry(vm, "cron", now_ts - 90000, now_ts - 1)
 
-    result = vm.ssh(_PHP, _PFB_PHP, "tick")
+    result = _run_tick(vm)
     assert result.returncode == 0, f"tick rc={result.returncode} stderr={result.stderr!r}"
     assert "[ Disabled by" not in result.stdout, (
         f"the direct 'tick' verb must never print the cron-tick disabled banner; got {result.stdout!r}"
@@ -391,8 +394,8 @@ def test_tick_dispatches_due_feed(deployed_vm: SmokeVM) -> None:
       2. a ' CRON  PROCESS  START' marker appears in pfblockerng.log — that marker is logged
          ONLY by pfblockerng_sync_cron, so it proves the tick dispatches the `cron` verb
          (-> per-list Update Frequency + scheduled log reset) and NOT a bare
-         `pfb_trigger scope=both` (which logs no CRON PROCESS pass). This is the FIRST tick
-         test, so it runs on a clean box (no prior backgrounded cron holding the sync lock).
+         `pfb_trigger scope=both` (which logs no CRON PROCESS pass). The module-local runner
+         drains active pfBlockerNG tasks before dispatch, establishing a quiescent appliance.
 
     Scenario:
         Background: pfBlockerNG installed with at least one enabled feed.
@@ -448,8 +451,8 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
 
     The tick logs to syslog (not stdout), so observe the NON-dispatch via the
     ' CRON  PROCESS  START' marker (logged only by pfblockerng_sync_cron): a non-due cron
-    must produce NO new marker. Drain any in-flight cron from a prior tick test first so the
-    marker baseline is stable. This is marker-based (not ledger-value-based) so it is immune
+    must produce NO new marker. The module-local runner drains active pfBlockerNG tasks before
+    dispatch so the marker baseline is stable. This is marker-based (not ledger-value-based) so it is immune
     to a prior test's mark_ran overwriting the cron entry — both values stay 'future' anyway.
 
     On its own, "no CRON PROCESS marker" cannot distinguish "tick correctly skipped the
@@ -470,16 +473,6 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
     vm = deployed_vm
     marker = "CRON  PROCESS  START"
     ss_marker = "SafeSearch CNAME fallback IPs refreshed"
-
-    # Drain any in-flight backgrounded cron from a prior tick test so the marker baseline
-    # is stable (a still-running prior cron would log a marker unrelated to this tick).
-    assert h.wait_until(
-        lambda: (
-            vm.ssh("pgrep -f 'pfblockerng[.]php cron' >/dev/null && echo BUSY || echo CLEAR").stdout.strip() == "CLEAR"
-        ),
-        timeout=90,
-        interval=3,
-    ), "a prior backgrounded cron never finished; cannot isolate this tick"
 
     now_ts = int(vm.ssh("date +%s").stdout.strip())
     _write_ledger_entry(vm, "cron", now_ts - 86400, now_ts + 3600)

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -452,9 +452,10 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
 
     The tick logs to syslog (not stdout), so observe the NON-dispatch via the
     ' CRON  PROCESS  START' marker (logged only by pfblockerng_sync_cron): a non-due cron
-    must produce NO new marker. The module-local runner drains active pfBlockerNG tasks before
-    dispatch so the marker baseline is stable. This is marker-based (not ledger-value-based) so it is immune
-    to a prior test's mark_ran overwriting the cron entry — both values stay 'future' anyway.
+    must produce NO new marker. The explicit pre-baseline drain stabilizes marker attribution;
+    ``_run_tick`` drains again to close the pre-dispatch race. This is marker-based
+    (not ledger-value-based) so it is immune to a prior test's mark_ran overwriting
+    the cron entry — both values stay 'future' anyway.
 
     On its own, "no CRON PROCESS marker" cannot distinguish "tick correctly skipped the
     non-due cron" from "tick never ran at all" — both look identical. The positive control:

--- a/tests/test_smoke_tick_marker_baseline.py
+++ b/tests/test_smoke_tick_marker_baseline.py
@@ -13,8 +13,8 @@ from tests.smoke import test_smoke_tick as tick
 def test_due_marker_baseline_drains_before_capture(monkeypatch: pytest.MonkeyPatch) -> None:
     state = {"drains": 0, "marker": 0, "next_due": 0}
 
-    class VM:
-        def ssh(self, *args: str) -> Any:
+    class VM(tick.SmokeVM):
+        def ssh(self, *args: str, timeout: float = 60.0) -> Any:
             if args == ("date +%s",):
                 return SimpleNamespace(returncode=0, stdout="100\n", stderr="")
             if args == (tick._PHP, tick._PFB_PHP, "tick"):
@@ -40,4 +40,4 @@ def test_due_marker_baseline_drains_before_capture(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(tick.h, "wait_until", lambda predicate, **_kwargs: bool(predicate()))
 
     with pytest.raises(AssertionError, match="marker count did not increase"):
-        tick.test_tick_dispatches_due_feed(VM())
+        tick.test_tick_dispatches_due_feed(VM(""))

--- a/tests/test_smoke_tick_marker_baseline.py
+++ b/tests/test_smoke_tick_marker_baseline.py
@@ -1,0 +1,43 @@
+"""Off-appliance regression test for tick marker attribution."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tests.smoke import test_smoke_tick as tick
+
+
+def test_due_marker_baseline_drains_before_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {"drains": 0, "marker": 0, "next_due": 0}
+
+    class VM:
+        def ssh(self, *args: str) -> Any:
+            if args == ("date +%s",):
+                return SimpleNamespace(returncode=0, stdout="100\n", stderr="")
+            if args == (tick._PHP, tick._PFB_PHP, "tick"):
+                state["next_due"] = 101
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            raise AssertionError(args)
+
+    def write_ledger(_vm: Any, _key: str, _last: int, next_due: int) -> None:
+        state["next_due"] = next_due
+
+    def read_ledger(_vm: Any) -> dict[str, dict[str, int]]:
+        return {"cron": {"next_due": state["next_due"]}}
+
+    def drain(_vm: Any) -> None:
+        state["drains"] += 1
+        if state["drains"] == 1:
+            state["marker"] += 1
+
+    monkeypatch.setattr(tick, "_write_ledger_entry", write_ledger)
+    monkeypatch.setattr(tick, "_read_ledger", read_ledger)
+    monkeypatch.setattr(tick.h, "wait_no_active_pfb_task", drain)
+    monkeypatch.setattr(tick.h, "count_log_marker", lambda *_args: state["marker"])
+    monkeypatch.setattr(tick.h, "wait_until", lambda predicate, **_kwargs: bool(predicate()))
+
+    with pytest.raises(AssertionError, match="marker count did not increase"):
+        tick.test_tick_dispatches_due_feed(VM())

--- a/tests/test_smoke_tick_runner.py
+++ b/tests/test_smoke_tick_runner.py
@@ -1,0 +1,33 @@
+"""Off-appliance contract tests for the tick smoke runner."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tests.smoke import test_smoke_tick as tick
+
+
+def test_run_tick_drains_before_dispatch_and_returns_ssh_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[tuple[str, Any]] = []
+    vm: Any = SimpleNamespace()
+    ssh_result: Any = SimpleNamespace(returncode=0, stdout="tick output", stderr="")
+
+    def wait_no_active_pfb_task(received_vm: Any) -> None:
+        events.append(("drain", received_vm))
+
+    def ssh(*args: Any) -> Any:
+        events.append(("ssh", args))
+        return ssh_result
+
+    vm.ssh = ssh
+    monkeypatch.setattr(tick.h, "wait_no_active_pfb_task", wait_no_active_pfb_task)
+
+    result = tick._run_tick(vm)
+
+    assert events == [("drain", vm), ("ssh", (tick._PHP, tick._PFB_PHP, "tick"))], (
+        f"expected drain before tick dispatch, got events={events!r}"
+    )
+    assert result is ssh_result, f"runner must preserve SSH result object, got {result!r}"


### PR DESCRIPTION
## Summary

- drain active pfBlockerNG tasks before every tick-family smoke dispatch
- route direct `tick` and `cron-tick` calls through one bounded helper
- remove the stale first-test premise and redundant process poll
- add a frozen off-appliance ordering contract test

## Evidence

- red proof: frozen test fails on `12993943856179e8d99bbacc2e86c5cd9c58cca6`, passes on signed head
- `python3 -m pytest`: 3055 passed, 4 skipped
- ruff, format, and mypy: pass
- leased appliance `-m tick`: 7 passed, 789 deselected

Fixes #1297

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
