### PR TITLE
fix: retry cron after feed-pass lock race

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2647,8 +2647,8 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir): bool
 /**
  * pfblockerng_tick — ADR-43: apply-on-change due-ledger tick dispatcher.
  *
- * Reads the ledger, dispatches each job that is due (feeds, dcc, bl) via exec() as a
- * separate process, then marks each as ran. ss_refresh runs every tick; the scheduled
+ * Reads the ledger and handles both cadence advancement and separate-process dispatch via
+ * exec() for each due job (feeds, dcc, bl). ss_refresh runs every tick; the scheduled
  * log maintenance (pfb_log_mgmt) runs only on an idle tick (see below).
  *
  * Lives here (not in the www/ dispatcher script) rather than the reverse so the

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2730,8 +2730,8 @@ function pfblockerng_tick(): void
 			pfb_due_ledger_set_pending('cron', $dbdir);
 		} elseif ($in_win) {
 			logger(LOG_NOTICE, localize_text('Tick: dispatching feed cron.'), LOG_PREFIX_PKG_PFBLOCKERNG);
-			exec("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron >> {$pfb['runlog']} 2>&1 &");
 			pfb_due_ledger_mark_ran_anchored('cron', $cron_secs, $now, $seed, 0, $dbdir);
+			exec("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron >> {$pfb['runlog']} 2>&1 &");
 			$dispatched = TRUE;
 		} else {
 			logger(LOG_INFO, localize_text('Tick: feed cron deferred (outside apply window).'), LOG_PREFIX_PKG_PFBLOCKERNG);

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -716,6 +716,7 @@ function pfblockerng_sync_cron($force_all = FALSE, $scope = 'both') {
 	// sync_package_pfblockerng(); its tail call below reenters the SAME lock.
 	$pfb_feed_pass_owner = !isset($GLOBALS['pfb_feed_pass_lock']);
 	if (!pfb_feed_pass_begin('cron')) {
+		pfb_due_ledger_set_pending('cron', $pfb['dbdir']);
 		return;
 	}
 

--- a/tests/php/SyncCronFeedPassDeferralTest.php
+++ b/tests/php/SyncCronFeedPassDeferralTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1315 -- the cron/Force Check funnel must defer when its atomic
+ * feed-pass acquisition loses after the tick's advisory busy probe.
+ */
+final class SyncCronFeedPassDeferralTest extends TestCase
+{
+	private string $dbdir = '';
+	private array $originalPfb = [];
+	private $lockFp = NULL;
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php'
+		);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.php');
+		}
+		if (!preg_match('/function pfblockerng_sync_cron\b.*?(?=\nfunction )/s', $src, $match)) {
+			throw new RuntimeException('test bootstrap: pfblockerng_sync_cron() body not found');
+		}
+
+		$function = preg_replace(
+			'/^function pfblockerng_sync_cron\b/',
+			'function pfb_issue_1315_sync_cron',
+			$match[0],
+			1,
+			$count
+		);
+		if ($function === NULL || $count !== 1) {
+			throw new RuntimeException('test bootstrap: failed to load pfblockerng_sync_cron() body');
+		}
+		eval($function);
+	}
+
+	protected function setUp(): void
+	{
+		$this->originalPfb = $GLOBALS['pfb'];
+		$this->dbdir = sys_get_temp_dir() . '/pfb_sync_cron_feedpass_' . uniqid('', TRUE);
+		mkdir($this->dbdir, 0755, TRUE);
+		$GLOBALS['pfb']['dbdir'] = $this->dbdir;
+		$GLOBALS['pfb']['log'] = "{$this->dbdir}/pfblockerng.log";
+
+		$this->lockFp = fopen("{$this->dbdir}/pfb_feed_pass.lock", 'c');
+		$this->assertNotFalse($this->lockFp, 'test setup: failed to open feed-pass lock');
+		$this->assertTrue(flock($this->lockFp, LOCK_EX), 'test setup: failed to hold feed-pass lock');
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_resource($this->lockFp)) {
+			flock($this->lockFp, LOCK_UN);
+			fclose($this->lockFp);
+		}
+		pfb_feed_pass_release();
+		$GLOBALS['pfb'] = $this->originalPfb;
+		foreach (glob("{$this->dbdir}/*") ?: [] as $path) {
+			unlink($path);
+		}
+		rmdir($this->dbdir);
+	}
+
+	public function testLockLossSetsPendingApplyWithoutAdvancingNextDue(): void
+	{
+		$nextDue = time() + 3600;
+		pfb_due_ledger_write_entry('cron', [
+			'last_run' => time() - 3600,
+			'next_due' => $nextDue,
+			'jitter'   => 0,
+		], $this->dbdir);
+
+		$before = pfb_due_ledger_read_entry('cron', $this->dbdir);
+		$this->assertSame($nextDue, $before['next_due'], 'test setup: future next_due must be seeded');
+
+		pfb_issue_1315_sync_cron();
+
+		$after = pfb_due_ledger_read_entry('cron', $this->dbdir);
+		$this->assertSame($nextDue, $after['next_due'], 'lost lock must preserve next_due');
+		$this->assertTrue(!empty($after['pending_apply']), 'lost lock must schedule retry on next enabled tick');
+	}
+}

--- a/tests/php/TickChildDeferralOrderingTest.php
+++ b/tests/php/TickChildDeferralOrderingTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1315 review -- a child cron pass that loses the feed-pass lock may
+ * finish before the backgrounding tick resumes after exec(). The parent must
+ * advance its cadence before launch so it cannot erase the child's deferral.
+ */
+final class TickChildDeferralOrderingTest extends TestCase
+{
+	private string $dbdir = '';
+	private array $originalPfb = [];
+	private $lockFp = NULL;
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php'
+		);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.php');
+		}
+		if (!preg_match('/function pfblockerng_sync_cron\b.*?(?=\nfunction )/s', $src, $match)) {
+			throw new RuntimeException('test bootstrap: pfblockerng_sync_cron() body not found');
+		}
+
+		$function = preg_replace(
+			'/^function pfblockerng_sync_cron\b/',
+			'function pfb_issue_1315_ordering_sync_cron',
+			$match[0],
+			1,
+			$count
+		);
+		if ($function === NULL || $count !== 1) {
+			throw new RuntimeException('test bootstrap: failed to load pfblockerng_sync_cron() body');
+		}
+		eval($function);
+	}
+
+	protected function setUp(): void
+	{
+		$this->originalPfb = $GLOBALS['pfb'];
+		$this->dbdir = sys_get_temp_dir() . '/pfb_tick_child_order_' . uniqid('', TRUE);
+		mkdir($this->dbdir, 0755, TRUE);
+		$GLOBALS['pfb']['dbdir'] = $this->dbdir;
+		$GLOBALS['pfb']['log'] = "{$this->dbdir}/pfblockerng.log";
+
+		$this->lockFp = fopen("{$this->dbdir}/pfb_feed_pass.lock", 'c');
+		$this->assertNotFalse($this->lockFp, 'test setup: failed to open feed-pass lock');
+		$this->assertTrue(flock($this->lockFp, LOCK_EX), 'test setup: failed to hold feed-pass lock');
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_resource($this->lockFp)) {
+			flock($this->lockFp, LOCK_UN);
+			fclose($this->lockFp);
+		}
+		pfb_feed_pass_release();
+		$GLOBALS['pfb'] = $this->originalPfb;
+		foreach (glob("{$this->dbdir}/*") ?: [] as $path) {
+			unlink($path);
+		}
+		rmdir($this->dbdir);
+	}
+
+	public function testChildLockLossAfterLaunchKeepsPendingRetry(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc'
+		);
+		$this->assertNotFalse($src, 'test oracle: failed to read pfblockerng_extra.inc');
+
+		$branchStart = strpos($src, "logger(LOG_NOTICE, localize_text('Tick: dispatching feed cron.')");
+		$this->assertNotFalse($branchStart, 'test oracle: numeric feed-cron dispatch branch not found');
+		$branchEnd = strpos($src, '$dispatched = TRUE;', $branchStart);
+		$this->assertNotFalse($branchEnd, 'test oracle: feed-cron dispatch branch end not found');
+		$branch = substr($src, $branchStart, $branchEnd - $branchStart);
+
+		$launchPos = strpos($branch, 'exec("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron');
+		$markPos = strpos($branch, "pfb_due_ledger_mark_ran_anchored('cron'");
+		$this->assertNotFalse($launchPos, 'test oracle: exact cron background launch not found');
+		$this->assertNotFalse($markPos, 'test oracle: anchored cadence update not found');
+
+		$now = time();
+		$interval = 86400;
+		$oldNextDue = $now - 10;
+		pfb_due_ledger_write_entry('cron', [
+			'last_run' => $oldNextDue - $interval,
+			'next_due' => $oldNextDue,
+			'jitter'   => 0,
+		], $this->dbdir);
+
+		$operations = [
+			$launchPos => static function (): void {
+				pfb_issue_1315_ordering_sync_cron();
+			},
+			$markPos => function () use ($interval, $now): void {
+				pfb_due_ledger_mark_ran_anchored('cron', $interval, $now, 'test-seed', 0, $this->dbdir);
+			},
+		];
+		ksort($operations);
+		foreach ($operations as $operation) {
+			$operation();
+		}
+
+		$after = pfb_due_ledger_read_entry('cron', $this->dbdir);
+		$this->assertSame($oldNextDue + $interval, $after['next_due'],
+			'numeric cadence must still advance from the previous anchored due time');
+		$this->assertTrue(!empty($after['pending_apply']),
+			'child lock loss after launch must remain pending for the next enabled tick');
+	}
+}


### PR DESCRIPTION
Fixes #1315

Summary:
- mark the cron due-ledger pending when the child loses the atomic feed-pass lock
- preserve the existing next_due value so the next enabled tick retries
- add an exact-body regression test for the contested lock path

Verification:
- canonical PHP gates passed
- red-proof freeze/RED/GREEN passed
- Tier-A ui_render: 137 passed, 311 deselected (local-100038-1784182523-d2e005a6f467bff8)
- independent Sol/Medium gate passed

no-test-needed: non-rendering CLI path under www; exact PHP regression plus full Tier-A ui_render passed.

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cron feed processing when a lock is unavailable.
  - Deferred retries are now recorded correctly without advancing the next scheduled run.
  - Improved scheduling reliability when background processing encounters lock contention.
- **Tests**
  - Added coverage for deferred cron retries and scheduling order during lock contention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->