### PR TITLE
fix: keep reload watcher alive after logging failure

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5494,7 +5494,12 @@ def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_coun
         new_snapshot = build_snapshot()
     except Exception as e:
         # Fail-closed: a raising build leaves the live snapshot + decision memo intact.
-        sys.stderr.write("[pfBlockerNG]: DNSBL rebuild failed, keeping current snapshot: {}".format(e))
+        err = sys.stderr
+        if err is not None:
+            try:
+                err.write("[pfBlockerNG]: DNSBL rebuild failed, keeping current snapshot: {}".format(e))
+            except Exception:
+                pass
         return False
 
     if new_snapshot is None:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5498,7 +5498,7 @@ def rebuild_and_swap(build_snapshot: Callable[[], Snapshot | None], *, emit_coun
         if err is not None:
             try:
                 err.write("[pfBlockerNG]: DNSBL rebuild failed, keeping current snapshot: {}".format(e))
-            except Exception:
+            except OSError:
                 pass
         return False
 

--- a/tests/test_adr10_swap.py
+++ b/tests/test_adr10_swap.py
@@ -232,7 +232,7 @@ class TestRebuildAndSwapFailClosed:
         assert P.decisionDB.get("stale.example.com") is not None
         assert emitted == {}  # no recount on failure.
 
-    def test_builder_raises_keeps_everything(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_builder_raises_keeps_everything(self, tmp_path: Any, monkeypatch: Any, capsys: Any) -> None:
         old = _snapshot(data={"old.example.com": {"log": "1", "index": 0, "important": False}}, counts=1)
         P._snapshot = old
         _seed_decision("stale.example.com")
@@ -255,6 +255,9 @@ class TestRebuildAndSwapFailClosed:
         assert P._snapshot is old
         assert "stale.example.com" in P.decisionDB  # STALE memo SURVIVES a raising build.
         assert emitted == {}
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == "[pfBlockerNG]: DNSBL rebuild failed, keeping current snapshot: build blew up"
 
     @pytest.mark.parametrize("emit_counts", [True, False])
     @pytest.mark.parametrize(

--- a/tests/test_adr10_swap.py
+++ b/tests/test_adr10_swap.py
@@ -89,6 +89,11 @@ class _RaisingStderr:
         raise OSError(text)
 
 
+class _ValueErrorStderr:
+    def write(self, text: str) -> int:
+        raise ValueError(text)
+
+
 def test_each_snapshot_gets_a_fresh_generation() -> None:
     # issue #1074: the decisionDB memo stamp needs every built Snapshot to carry a
     # unique, advancing generation -- two builds must never share one (id() reuse is
@@ -283,6 +288,15 @@ class TestRebuildAndSwapFailClosed:
         assert P.rebuild_and_swap(_boom, emit_counts=emit_counts) is False
         assert P._snapshot is old
         assert "stale.example.com" in P.decisionDB
+
+    def test_builder_error_diagnostic_propagates_non_oserror(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(sys, "stderr", _ValueErrorStderr())
+
+        def _boom() -> P.Snapshot:
+            raise RuntimeError("build blew up")
+
+        with pytest.raises(ValueError, match="DNSBL rebuild failed.*build blew up"):
+            P.rebuild_and_swap(_boom)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_adr10_swap.py
+++ b/tests/test_adr10_swap.py
@@ -21,7 +21,10 @@ shape -- None and raising builder).
 from __future__ import annotations
 
 import re
+import sys
 from typing import Any
+
+import pytest
 
 import pfb_unbound as P
 from pfb_unbound import _db_flush_dnsbl, _dnsbl_stats_wanted
@@ -79,6 +82,11 @@ def _set_count_paths(tmp_path: Any) -> None:
     so a test exercising the count re-emit must set them itself."""
     P.pfb["pfb_py_count"] = str(tmp_path / "pfb_py_count")
     P.pfb["pfb_py_regex_count"] = str(tmp_path / "pfb_py_regex_count")
+
+
+class _RaisingStderr:
+    def write(self, text: str) -> int:
+        raise OSError(text)
 
 
 def test_each_snapshot_gets_a_fresh_generation() -> None:
@@ -247,6 +255,31 @@ class TestRebuildAndSwapFailClosed:
         assert P._snapshot is old
         assert "stale.example.com" in P.decisionDB  # STALE memo SURVIVES a raising build.
         assert emitted == {}
+
+    @pytest.mark.parametrize("emit_counts", [True, False])
+    @pytest.mark.parametrize(
+        "hostile_stderr",
+        [
+            pytest.param(None, id="stderr-none"),
+            pytest.param(_RaisingStderr(), id="stderr-write-raises"),
+        ],
+    )
+    def test_builder_raises_with_hostile_stderr_keeps_everything(
+        self, monkeypatch: Any, hostile_stderr: Any, emit_counts: bool
+    ) -> None:
+        old = _snapshot(data={"old.example.com": {"log": "1", "index": 0, "important": False}}, counts=1)
+        P._snapshot = old
+        _seed_decision("stale.example.com")
+        monkeypatch.setattr(sys, "stderr", hostile_stderr)
+
+        def _boom() -> P.Snapshot:
+            raise RuntimeError("build blew up")
+
+        assert P._snapshot is old
+        assert "stale.example.com" in P.decisionDB
+        assert P.rebuild_and_swap(_boom, emit_counts=emit_counts) is False
+        assert P._snapshot is old
+        assert "stale.example.com" in P.decisionDB
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_adr10_watcher.py
+++ b/tests/test_adr10_watcher.py
@@ -21,6 +21,7 @@ join. The watcher does NOT auto-run during the normal suite -- it is gated on
 
 from __future__ import annotations
 
+import sys
 import threading
 import time
 from typing import Any
@@ -69,6 +70,11 @@ def _no_emit(monkeypatch: Any) -> None:
     P.pfb["pfb_py_count"] = "pfb_py_count"
     P.pfb["pfb_py_regex_count"] = "pfb_py_regex_count"
     monkeypatch.setattr(P, "dnsbl_emit_count", lambda *a, **k: True)
+
+
+class _RaisingStderr:
+    def write(self, text: str) -> int:
+        raise OSError(text)
 
 
 # --------------------------------------------------------------------------- #
@@ -449,6 +455,58 @@ class TestHarnessWaiterDiagnostics:
 
 
 class TestWatcherLoop:
+    @pytest.mark.parametrize(
+        "hostile_stderr",
+        [
+            pytest.param(None, id="stderr-none"),
+            pytest.param(_RaisingStderr(), id="stderr-write-raises"),
+        ],
+    )
+    def test_builder_exception_with_hostile_stderr_keeps_watcher_alive_for_next_generation(
+        self, tmp_path: Any, monkeypatch: Any, hostile_stderr: Any
+    ) -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        old = _snapshot(tag="old.example.com", counts=0)
+        P._snapshot = old
+        original_builder = h.builder
+        first_failure = threading.Event()
+        calls = 0
+
+        def fail_once() -> P.Snapshot:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                first_failure.set()
+                raise RuntimeError("build blew up")
+            result = original_builder()
+            assert result is not None
+            return result
+
+        h.builder = fail_once  # type: ignore[method-assign]
+        monkeypatch.setattr(P, "_open_dnsbl_stats_db_if_wanted", lambda: None)
+        monkeypatch.setattr(sys, "stderr", hostile_stderr)
+        h.start()
+        try:
+            with h._builds_cond:
+                baseline_reads = h.sentinel_reads
+            h.publish(1)
+            assert first_failure.wait(3.0)
+            h.wait_sentinel_reads(baseline_reads + 2, timeout=3.0)
+            assert P._snapshot is old
+            assert h.read_applied() is None
+            assert h.thread.is_alive()
+
+            h.publish(2)
+            h.wait_builds(1, timeout=3.0)
+            h.wait_snapshot_contains("gen2.example.com", timeout=3.0)
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline and h.read_applied() != 2:
+                time.sleep(0.01)
+            assert h.read_applied() == 2
+            assert h.thread.is_alive()
+        finally:
+            h.stop_join()
+
     def test_generation_advance_triggers_swap(self, tmp_path: Any, monkeypatch: Any) -> None:
         h = _Harness(tmp_path, monkeypatch)
         old = _snapshot(tag="old.example.com", counts=0)


### PR DESCRIPTION
Fixes #1390

Summary:
- make rebuild-failure stderr reporting best-effort for unavailable or failing streams
- preserve fail-closed snapshot and applied-marker behavior
- keep the watcher alive so a later generation can rebuild and swap

Verification:
- frozen RED/GREEN proof passed for direct and threaded watcher failures
- focused watcher/swap suite: 58 passed
- canonical Python gates passed
- two independent Sol/Medium gates passed after review fixes
- appliance smoke not applicable to injected embedded-loader stderr failures

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.