### PR TITLE
fix: retry deferred apply when schedule is disabled

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -68,6 +68,7 @@ $pfb['cut']	= '/usr/bin/cut';
 $pfb['sed']	= '/usr/bin/sed';
 $pfb['cat']	= '/bin/cat';
 $pfb['ls']	= '/bin/ls';
+$pfb['php']	= '/usr/local/bin/php';
 $pfb['pfctl']	= '/sbin/pfctl';
 $pfb['wc']	= '/usr/bin/wc';
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2667,7 +2667,7 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir): bool
  * inside the window applies it. Default '' = apply immediately on every due tick.
  *
  * Cadence seeding from legacy knobs (§2.G — no config.xml migration):
- *   feed cron : PfbConfig::read('pfb_interval') hours; skip when 'Disabled'.
+ *   feed cron : PfbConfig::read('pfb_interval') hours; skip scheduled runs when 'Disabled'.
  *   dcc       : 86400 s daily, jitter = seeded_jitter (stable per install).
  *   bl        : 86400 or 604800 s, jitter = seeded_jitter (stable per install).
  *
@@ -2712,8 +2712,8 @@ function pfblockerng_tick(): void
 
 	// --- Dispatch due (or pending) jobs; defer when outside the apply window ---
 
-	// Feed cron: dispatch the `cron` verb (-> pfblockerng_sync_cron), NOT pfb_trigger
-	// directly.  pfblockerng_sync_cron applies each feed's per-list Update Frequency
+	// Scheduled feed cron: dispatch the `cron` verb (-> pfblockerng_sync_cron), NOT pfb_trigger
+	// directly. pfblockerng_sync_cron applies each feed's per-list Update Frequency
 	// ($list['cron']: EveryDay/Weekly/NNhour) before its final sync_package_pfblockerng('cron'),
 	// and runs the ADR-19 software-update check at the end -- both of which a bare
 	// `pfb_trigger scope=both` skips (it would poll every feed every tick and never
@@ -2721,7 +2721,9 @@ function pfblockerng_tick(): void
 	// (IP) + ADR-10 (DNSBL) inside that final sync. Backgrounded so the tick stays
 	// fast. The scheduled log trim no longer rides this dispatch (issue #573) --
 	// see pfb_log_mgmt() at the end of this function.
-	if (!$cron_disabled && ($due['cron'] || pfb_due_ledger_is_pending('cron', $dbdir))) {
+	$cron_entry   = pfb_due_ledger_read_entry('cron', $dbdir);
+	$cron_pending = $cron_entry !== NULL && !empty($cron_entry['pending_apply']);
+	if ((!$cron_disabled && $due['cron']) || $cron_pending) {
 		if ($in_win && pfb_feed_pass_busy()) {
 			// issue #1175: a running feed pass would race the shared recompute staging --
 			// defer via pending so the NEXT tick retries. busy() is advisory only: the
@@ -2729,9 +2731,16 @@ function pfblockerng_tick(): void
 			logger(LOG_INFO, localize_text('Tick: feed cron deferred (another feed pass is running).'), LOG_PREFIX_PKG_PFBLOCKERNG);
 			pfb_due_ledger_set_pending('cron', $dbdir);
 		} elseif ($in_win) {
-			logger(LOG_NOTICE, localize_text('Tick: dispatching feed cron.'), LOG_PREFIX_PKG_PFBLOCKERNG);
-			pfb_due_ledger_mark_ran_anchored('cron', $cron_secs, $now, $seed, 0, $dbdir);
-			exec("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron >> {$pfb['runlog']} 2>&1 &");
+			if ($cron_disabled) {
+				logger(LOG_NOTICE, localize_text('Tick: dispatching pending manual apply.'), LOG_PREFIX_PKG_PFBLOCKERNG);
+				unset($cron_entry['pending_apply']);
+				pfb_due_ledger_write_entry('cron', $cron_entry, $dbdir);
+				exec("{$pfb['php']} /usr/local/www/pfblockerng/pfblockerng.php pfb_trigger scope=both force=false trigger=manual >> {$pfb['runlog']} 2>&1 &");
+			} else {
+				logger(LOG_NOTICE, localize_text('Tick: dispatching feed cron.'), LOG_PREFIX_PKG_PFBLOCKERNG);
+				pfb_due_ledger_mark_ran_anchored('cron', $cron_secs, $now, $seed, 0, $dbdir);
+				exec("{$pfb['php']} /usr/local/www/pfblockerng/pfblockerng.php cron >> {$pfb['runlog']} 2>&1 &");
+			}
 			$dispatched = TRUE;
 		} else {
 			logger(LOG_INFO, localize_text('Tick: feed cron deferred (outside apply window).'), LOG_PREFIX_PKG_PFBLOCKERNG);
@@ -2743,7 +2752,7 @@ function pfblockerng_tick(): void
 	if ($due['dcc'] || pfb_due_ledger_is_pending('dcc', $dbdir)) {
 		if ($in_win) {
 			logger(LOG_NOTICE, localize_text('Tick: dispatching dcc.'), LOG_PREFIX_PKG_PFBLOCKERNG);
-			exec("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php dcc >> {$pfb['extraslog']} 2>&1 &");
+			exec("{$pfb['php']} /usr/local/www/pfblockerng/pfblockerng.php dcc >> {$pfb['extraslog']} 2>&1 &");
 			pfb_due_ledger_mark_ran('dcc', 86400, $now, $seed, 23 * 3600, $dbdir);
 			$dispatched = TRUE;
 		} else {
@@ -2770,7 +2779,7 @@ function pfblockerng_tick(): void
 
 			if (!empty($bl_str)) {
 				logger(LOG_NOTICE, localize_text('Tick: dispatching bl.'), LOG_PREFIX_PKG_PFBLOCKERNG);
-				exec("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php bl " . escapeshellarg($bl_str) . " >> {$pfb['extraslog']} 2>&1 &");
+				exec("{$pfb['php']} /usr/local/www/pfblockerng/pfblockerng.php bl " . escapeshellarg($bl_str) . " >> {$pfb['extraslog']} 2>&1 &");
 				pfb_due_ledger_mark_ran('bl', $bl_secs, $now, $seed, 23 * 3600, $dbdir);
 				$dispatched = TRUE;
 			}

--- a/tests/php/TickChildDeferralOrderingTest.php
+++ b/tests/php/TickChildDeferralOrderingTest.php
@@ -80,7 +80,7 @@ final class TickChildDeferralOrderingTest extends TestCase
 		$this->assertNotFalse($branchEnd, 'test oracle: feed-cron dispatch branch end not found');
 		$branch = substr($src, $branchStart, $branchEnd - $branchStart);
 
-		$launchPos = strpos($branch, 'exec("/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron');
+		$launchPos = strpos($branch, 'exec("{$pfb[\'php\']} /usr/local/www/pfblockerng/pfblockerng.php cron');
 		$markPos = strpos($branch, "pfb_due_ledger_mark_ran_anchored('cron'");
 		$this->assertNotFalse($launchPos, 'test oracle: exact cron background launch not found');
 		$this->assertNotFalse($markPos, 'test oracle: anchored cadence update not found');

--- a/tests/php/TickFeedPassDeferralTest.php
+++ b/tests/php/TickFeedPassDeferralTest.php
@@ -43,6 +43,8 @@ final class TickFeedPassDeferralTest extends TestCase
 	private mixed $originalRunlog = NULL;
 	private bool $hadExtraslog = FALSE;
 	private mixed $originalExtraslog = NULL;
+	private bool $hadPhp = FALSE;
+	private mixed $originalPhp = NULL;
 
 	/** Raw fd simulating another process holding the feed-pass lock. */
 	private $lockFp = NULL;
@@ -57,6 +59,9 @@ final class TickFeedPassDeferralTest extends TestCase
 
 		$this->hadExtraslog      = array_key_exists('extraslog', $GLOBALS['pfb'] ?? []);
 		$this->originalExtraslog = $GLOBALS['pfb']['extraslog'] ?? NULL;
+
+		$this->hadPhp      = array_key_exists('php', $GLOBALS['pfb'] ?? []);
+		$this->originalPhp = $GLOBALS['pfb']['php'] ?? NULL;
 
 		$this->dbdir = sys_get_temp_dir() . '/pfb_tick_feedpass_' . uniqid('', TRUE);
 		mkdir($this->dbdir, 0755, TRUE);
@@ -94,6 +99,11 @@ final class TickFeedPassDeferralTest extends TestCase
 			$GLOBALS['pfb']['extraslog'] = $this->originalExtraslog;
 		} else {
 			unset($GLOBALS['pfb']['extraslog']);
+		}
+		if ($this->hadPhp) {
+			$GLOBALS['pfb']['php'] = $this->originalPhp;
+		} else {
+			unset($GLOBALS['pfb']['php']);
 		}
 		$this->rrmdir($this->dbdir);
 	}
@@ -169,6 +179,84 @@ final class TickFeedPassDeferralTest extends TestCase
 			'next_due' => $now + 3600,
 			'jitter'   => 0,
 		], $GLOBALS['pfb']['dbdir']);
+	}
+
+	private function seedDueLedgerEntry(string $jobKey, int $now): void
+	{
+		pfb_due_ledger_write_entry($jobKey, [
+			'last_run' => $now - 86410,
+			'next_due' => $now - 10,
+			'jitter'   => 0,
+		], $GLOBALS['pfb']['dbdir']);
+	}
+
+	private function installPhpArgvRecorder(): string
+	{
+		$phpPath = "{$this->dbdir}/php-recorder";
+		$script   = <<<'SH'
+#!/bin/sh
+active="${0}.active.$$"
+done="${0}.done.$$"
+tmp="${done}.tmp"
+: > "$active"
+trap 'rm -f "$active" "$tmp"' EXIT HUP INT TERM
+printf '%s\0' "$@" > "$tmp"
+mv "$tmp" "$done"
+SH;
+		file_put_contents($phpPath, $script . "\n");
+		chmod($phpPath, 0755);
+		return $phpPath;
+	}
+
+	/** @return list<list<string>> */
+	private function awaitRecordedInvocations(string $phpPath): array
+	{
+		$deadline    = hrtime(TRUE) + 2_000_000_000;
+		$stableSince = NULL;
+		$donePaths   = [];
+		while (hrtime(TRUE) < $deadline) {
+			$now         = hrtime(TRUE);
+			$currentDone = glob("{$phpPath}.done.*") ?: [];
+			$activePaths = glob("{$phpPath}.active.*") ?: [];
+			sort($currentDone);
+			if ($currentDone !== [] && $activePaths === []) {
+				if ($currentDone !== $donePaths) {
+					$donePaths   = $currentDone;
+					$stableSince = $now;
+				} elseif ($stableSince !== NULL && $now - $stableSince >= 200_000_000) {
+					break;
+				}
+			} else {
+				$stableSince = NULL;
+			}
+			usleep(1000);
+		}
+		$this->assertNotEmpty($donePaths,
+			'tick dispatch must complete at the configured PHP executable within 2 seconds');
+		$this->assertSame([], glob("{$phpPath}.active.*") ?: [],
+			'all configured PHP invocations must finish before argv is asserted');
+
+		$recorded = [];
+		foreach ($donePaths as $donePath) {
+			$raw = file_get_contents($donePath);
+			$this->assertNotFalse($raw, 'PHP argv recorder output must be readable');
+			$args = explode("\0", $raw);
+			array_pop($args);
+			$recorded[] = $args;
+		}
+		return $recorded;
+	}
+
+	private function installLedgerRequeueCommand(): string
+	{
+		$ledgerPath = "{$this->dbdir}/pfb_due_ledger.json";
+		$sourcePath = "{$ledgerPath}.requeued";
+		$scriptPath = "{$this->dbdir}/requeue-ledger";
+		copy($ledgerPath, $sourcePath);
+		file_put_contents($scriptPath, "#!/bin/sh\n/bin/cp "
+			. escapeshellarg($sourcePath) . ' ' . escapeshellarg($ledgerPath) . "\n");
+		chmod($scriptPath, 0755);
+		return $scriptPath;
 	}
 
 	/** Hold the feed-pass lock as ANOTHER process would -- a second, independent fd. */
@@ -386,5 +474,213 @@ final class TickFeedPassDeferralTest extends TestCase
 		$this->assertTrue(!empty($after['pending_apply']),
 			'outside the quiet-hours window the tick must defer via pending_apply, whether or not '
 			. 'a feed pass is running');
+	}
+
+	/**
+	 * Scenario:
+	 *   Given pfb_interval='Disabled' and a future cron ledger entry whose manual
+	 *         GUI apply was deferred with pending_apply=TRUE.
+	 *   And   the apply window is open and the feed-pass lock is free.
+	 *   When  pfblockerng_tick() runs.
+	 *   Then  the pending manual apply dispatches once, clears only pending_apply,
+	 *         preserves cadence fields, and suppresses same-tick log maintenance.
+	 */
+	public function testDisabledIntervalDispatchesPendingManualApplyWithoutMovingCadence(): void
+	{
+		$this->seedTickPrereqs('Disabled');
+		pfb_global();
+		$fakePhp = $this->installPhpArgvRecorder();
+		$GLOBALS['pfb']['php'] = $fakePhp;
+		if (!is_dir($GLOBALS['pfb']['logdir'])) {
+			@mkdir($GLOBALS['pfb']['logdir'], 0755, TRUE);
+		}
+
+		$now = time();
+		$expected = [
+			'last_run'      => $now - 7200,
+			'next_due'      => $now + 7200,
+			'jitter'        => 37,
+			'pending_apply' => TRUE,
+		];
+		pfb_due_ledger_write_entry('cron', $expected, $GLOBALS['pfb']['dbdir']);
+		$this->seedFutureLedgerEntry('dcc', $now);
+		$this->seedFutureLedgerEntry('bl',  $now);
+
+		$logPath = $GLOBALS['pfb']['log'];
+		file_put_contents($logPath, implode("\n", ['l1', 'l2', 'l3', 'l4', 'l5']) . "\n");
+		$this->assertSame($expected,
+			pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']),
+			'test setup: disabled cron must start future, pending, and byte-for-byte known');
+
+		pfblockerng_tick();
+
+		$this->assertSame([
+			['/usr/local/www/pfblockerng/pfblockerng.php', 'pfb_trigger', 'scope=both', 'force=false', 'trigger=manual'],
+		], $this->awaitRecordedInvocations($fakePhp),
+			'disabled pending apply must dispatch exactly once with the manual trigger argv');
+		$after = pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']);
+		$this->assertSame([
+			'last_run' => $expected['last_run'],
+			'next_due' => $expected['next_due'],
+			'jitter'   => $expected['jitter'],
+		], $after,
+			'disabled pending apply must clear only pending_apply; cadence fields must remain unchanged');
+		$lines = array_values(array_filter(explode("\n", (string) file_get_contents($logPath)), 'strlen'));
+		$this->assertSame(['l1', 'l2', 'l3', 'l4', 'l5'], $lines,
+			'dispatching the pending manual apply must suppress same-tick log maintenance');
+	}
+
+	/**
+	 * Scenario:
+	 *   Given pfb_interval='Disabled' with pending_apply=TRUE inside the window.
+	 *   And   another feed pass holds the lock.
+	 *   When  pfblockerng_tick() runs.
+	 *   Then  the whole ledger entry remains pending and unchanged for retry.
+	 */
+	public function testDisabledIntervalRetainsPendingManualApplyWhileFeedPassIsBusy(): void
+	{
+		$this->seedTickPrereqs('Disabled');
+		pfb_global();
+		$now = time();
+		$expected = [
+			'last_run'      => $now - 3600,
+			'next_due'      => $now + 3600,
+			'jitter'        => 19,
+			'pending_apply' => TRUE,
+		];
+		pfb_due_ledger_write_entry('cron', $expected, $GLOBALS['pfb']['dbdir']);
+		$this->seedFutureLedgerEntry('dcc', $now);
+		$this->seedFutureLedgerEntry('bl',  $now);
+		$this->holdLockAsAnotherProcess();
+
+		pfblockerng_tick();
+
+		$this->assertSame($expected,
+			pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']),
+			'busy feed pass must retain disabled pending apply and every cadence field unchanged');
+	}
+
+	/**
+	 * Scenario:
+	 *   Given pfb_interval='Disabled' with pending_apply=TRUE outside the window.
+	 *   When  pfblockerng_tick() runs.
+	 *   Then  the whole ledger entry remains pending and unchanged for retry.
+	 */
+	public function testDisabledIntervalRetainsPendingManualApplyOutsideQuietHours(): void
+	{
+		$this->seedTickPrereqs('Disabled', $this->outsideWindowNow());
+		pfb_global();
+		$now = time();
+		$expected = [
+			'last_run'      => $now - 1800,
+			'next_due'      => $now + 1800,
+			'jitter'        => 11,
+			'pending_apply' => TRUE,
+		];
+		pfb_due_ledger_write_entry('cron', $expected, $GLOBALS['pfb']['dbdir']);
+		$this->seedFutureLedgerEntry('dcc', $now);
+		$this->seedFutureLedgerEntry('bl',  $now);
+
+		pfblockerng_tick();
+
+		$this->assertSame($expected,
+			pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']),
+			'closed quiet-hours window must retain disabled pending apply and every cadence field unchanged');
+	}
+
+	public function testScheduledCronUsesConfiguredPhpExactlyOnce(): void
+	{
+		$this->seedTickPrereqs('24');
+		pfb_global();
+		$fakePhp = $this->installPhpArgvRecorder();
+		$GLOBALS['pfb']['php'] = $fakePhp;
+		$now = time();
+		$this->seedDueLedgerEntry('cron', $now);
+		$this->seedFutureLedgerEntry('dcc', $now);
+		$this->seedFutureLedgerEntry('bl', $now);
+
+		pfblockerng_tick();
+
+		$this->assertSame([
+			['/usr/local/www/pfblockerng/pfblockerng.php', 'cron'],
+		], $this->awaitRecordedInvocations($fakePhp));
+	}
+
+	public function testDccUsesConfiguredPhpExactlyOnce(): void
+	{
+		$this->seedTickPrereqs('24');
+		pfb_global();
+		$fakePhp = $this->installPhpArgvRecorder();
+		$GLOBALS['pfb']['php'] = $fakePhp;
+		$now = time();
+		$this->seedFutureLedgerEntry('cron', $now);
+		$this->seedDueLedgerEntry('dcc', $now);
+		$this->seedFutureLedgerEntry('bl', $now);
+
+		pfblockerng_tick();
+
+		$this->assertSame([
+			['/usr/local/www/pfblockerng/pfblockerng.php', 'dcc'],
+		], $this->awaitRecordedInvocations($fakePhp));
+	}
+
+	public function testBlUsesConfiguredPhpExactlyOnce(): void
+	{
+		$this->seedTickPrereqs('24');
+		pfb_global();
+		$fakePhp = $this->installPhpArgvRecorder();
+		$GLOBALS['pfb']['php'] = $fakePhp;
+		$GLOBALS['pfb']['enable'] = 'on';
+		$GLOBALS['pfb']['blconfig'] = [
+			'blacklist_enable'   => 'Enable',
+			'blacklist_selected' => 'test-list',
+			'item'               => [[
+				'xml'      => 'test-list',
+				'selected' => 'on',
+			]],
+		];
+		$now = time();
+		$this->seedFutureLedgerEntry('cron', $now);
+		$this->seedFutureLedgerEntry('dcc', $now);
+		$this->seedDueLedgerEntry('bl', $now);
+
+		pfblockerng_tick();
+
+		$this->assertSame([
+			['/usr/local/www/pfblockerng/pfblockerng.php', 'bl', 'test-list'],
+		], $this->awaitRecordedInvocations($fakePhp));
+	}
+
+	public function testDisabledManualChildRequeueSurvivesDispatch(): void
+	{
+		$this->seedTickPrereqs('Disabled');
+		pfb_global();
+		$now = time();
+		$expected = [
+			'last_run'      => $now - 7200,
+			'next_due'      => $now + 7200,
+			'jitter'        => 37,
+			'pending_apply' => TRUE,
+		];
+		pfb_due_ledger_write_entry('cron', $expected, $GLOBALS['pfb']['dbdir']);
+		$this->seedFutureLedgerEntry('dcc', $now);
+		$this->seedFutureLedgerEntry('bl', $now);
+		$fakePhp = $this->installPhpArgvRecorder();
+		$requeue = $this->installLedgerRequeueCommand();
+		$GLOBALS['pfb']['php'] = escapeshellarg($requeue) . '; ' . escapeshellarg($fakePhp);
+
+		pfblockerng_tick();
+
+		$this->assertSame([
+			['/usr/local/www/pfblockerng/pfblockerng.php', 'pfb_trigger', 'scope=both', 'force=false', 'trigger=manual'],
+		], $this->awaitRecordedInvocations($fakePhp));
+		$this->assertSame($expected,
+			pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']),
+			'a child lock-loss requeue must survive the parent dispatch path');
+	}
+
+	public function testDefaultPhpExecutableIsProductionPhp(): void
+	{
+		$this->assertSame('/usr/local/bin/php', $GLOBALS['pfb']['php']);
 	}
 }


### PR DESCRIPTION
Fixes #1322

Summary:
- consume a pending GUI apply with the existing manual trigger while periodic cron is disabled
- preserve cadence fields and retain pending state across busy-lock or quiet-hours deferral
- expose the trusted PHP executable path so all four tick dispatches are exact-argv testable

Verification:
- frozen RED/GREEN proof passed for manual, cron, DCC, and blacklist dispatches
- focused file: 10 tests, 36 assertions
- full PHPUnit: 3,655 tests, 21,931 assertions, 4 skipped
- canonical PHP gates passed
- repeated independent Sol/Medium gates passed after review fixes

Deviation: review-stage command-observability required a trusted PHP executable seam not named in the initial brief; every source-enumerated dispatch is now exact-argv and exactly-once covered.

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the PHP executable used by background feed, DNSBL, and update tasks.
  - Added handling for pending manual updates when automatic feed scheduling is disabled.
- **Bug Fixes**
  - Improved deferred update processing during quiet hours and busy feed operations.
  - Preserved scheduling information while retrying pending manual applies.
  - Improved reliability when child update tasks requeue pending work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->