### PR TITLE
fix: address devel adversarial review findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ test-results/
 
 # ── AI-agent worktrees (per-task, never committed) ───────────────────────────
 .claude/worktrees/
+.codex/local-notes.md
 
 # token-savior MCP server index cache (one per project root / worktree)
 .token-savior-cache.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,12 +56,6 @@ prompts.
   through the approved elevated execution path before concluding that GitHub
   authentication is invalid; a sandboxed `gh auth status` failure is not
   conclusive.
-- The owner's usual local-smoke pool is `root@10.0.0.31` through
-  `root@10.0.0.38` (space-separated in `PFB_BOXES`). Treat it as the current
-  default inventory, while still letting the lease script skip unavailable
-  boxes. `SMOKE_ADMIN_PASSWORD` is provisioned on the boxes through their SSH
-  environment; do not ask for, copy, or print a local password before trying
-  the normal leased-box flow.
 - Project `.codex/config.toml`, `.codex/hooks.json`, and custom agents load only
   after the repository is trusted. Review changed hooks with `/hooks`.
 - Codex's shared-Git-hook marker is `CODEX_THREAD_ID`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,8 @@ DNSBL blocklist preprocessing lives in the Python plugin
   path, TLD blacklist/exclusion, user whitelist, TOP1M list + enabled flag) plus
   one `feeds` row per raw file
   (`{raw, feed, group, provenance, log_flag[, mode]}`; absent `mode` means deny).
-- `/var/unbound/pfb_py_raw/<feed>.raw` — per-feed IP-stripped bare-domain raw.
+- `/var/unbound/pfb_py_raw.<xxh128>/<feed>.raw` — per-feed IP-stripped
+  bare-domain raw in the immutable generation named by each manifest `raw` row.
 
 `pfb_unbound.dnsbl_build_from_manifest()` then does **parse → normalise → classify
 (data/zone via the public-suffix master) → build** `dataDB`/`zoneDB` +

--- a/scripts/agent/verify-red-proof.sh
+++ b/scripts/agent/verify-red-proof.sh
@@ -35,17 +35,24 @@ fail() {
 }
 
 restore_srcs() {
+	restore_failed=0
 	for src in $srcs; do
+		path_failed=0
 		if git -C "$worktree" cat-file -e "HEAD:$src" 2>/dev/null; then
-			git -C "$worktree" checkout HEAD -- "$src" || return 1
+			git -C "$worktree" checkout HEAD -- "$src" || path_failed=1
 		else
-			git -C "$worktree" rm -q -r -f --ignore-unmatch -- "$src" || return 1
-			git -C "$worktree" clean -q -d -f -f -x -- "$src" || return 1
+			git -C "$worktree" rm -q -r -f --ignore-unmatch -- "$src" || path_failed=1
+			git -C "$worktree" clean -q -d -f -f -x -- "$src" || path_failed=1
 			if [ -e "$worktree/$src" ] || [ -L "$worktree/$src" ]; then
-				return 1
+				path_failed=1
 			fi
 		fi
+		if [ "$path_failed" -ne 0 ]; then
+			echo "restore failed for --src path: $src" >&2
+			restore_failed=1
+		fi
 	done
+	return "$restore_failed"
 }
 
 main() {
@@ -72,7 +79,11 @@ main() {
 	{ [ -n "$worktree" ] && [ -n "$test_cmd" ] && [ -n "$srcs" ]; } || usage
 	require_tool git
 
-	if [ -n "$(git -C "$worktree" status --porcelain)" ]; then
+	status_output=$(git -C "$worktree" status --porcelain) || {
+		echo "DIRTY-TREE: cannot inspect the worktree; refusing to continue." >&2
+		exit 2
+	}
+	if [ -n "$status_output" ]; then
 		echo "DIRTY-TREE: the gate re-derives from committed state; commit or clean first." >&2
 		exit 2
 	fi

--- a/scripts/check_noopener.py
+++ b/scripts/check_noopener.py
@@ -16,6 +16,9 @@ A `target … = … _blank…` occurrence (HTML ASCII case; double/single/no quo
 spaces/tabs around `=`; a `(?<![\\w-])` guard excludes `data-target="_blank"`)
 is a VIOLATION unless it is
 IMMEDIATELY followed — only whitespace between — by `rel=["']?noopener`.
+An unquoted `_blank/` prefix is deliberately treated as a flaggable near-miss:
+WHATWG includes the slash in the attribute value, but the likely typo must fail
+review rather than silently escape this checker.
 That is the house convention this codebase now follows: `rel` sits directly
 after `target`, so it survives even the multi-line PHP string-concatenation
 tag shape (`'target="_blank"' . ' rel="noopener noreferrer"'` would NOT be
@@ -52,10 +55,10 @@ import sys
 from typing import NamedTuple
 
 # HTML ASCII case/whitespace only. The unquoted branch requires a value delimiter
-# and leaves it untouched for the adjacent-rel matcher; quoted trailing spaces/tabs
-# are included.
+# or the deliberate slash near-miss and leaves it untouched for the adjacent-rel
+# matcher; quoted trailing spaces/tabs are included.
 _TARGET_BLANK_RE = re.compile(
-    r'(?<![\w-])(?ai:target)[ \t]*=[ \t]*(?:(?P<q>["\'])(?ai:_blank)[ \t]*(?P=q)|(?ai:_blank)(?=[ \t>]|$))'
+    r'(?<![\w-])(?ai:target)[ \t]*=[ \t]*(?:(?P<q>["\'])(?ai:_blank)[ \t]*(?P=q)|(?ai:_blank)(?=[ \t>/]|$))'
 )
 
 # `rel="noopener…"` (or single-quoted / unquoted), immediately after `target=…`

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -6790,7 +6790,8 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                 # surfaced once, here on the fresh evaluation, in the same dnsbl.log shape as
                 # a block (dual-form b_eval so it is actionable). A repeat query reuses the
                 # cached decision and is not re-logged (the name resolves normally).
-                if dnsbl.idn_alert is not None:
+                # issue #1349: preserve block/alert exclusivity after cache retirement.
+                if dnsbl.idn_alert is not None and not (dnsbl.is_found and not dnsbl.in_whitelist):
                     _log_idn_alert(q_name, q_ip, dnsbl.idn_alert, get_q_type(qstate, None))
 
             # Block iff found and not whitelisted; an allow decision falls through to

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7824,6 +7824,7 @@ function pfb_unbound_py_publication_lock(?float $timeout_s=NULL) {
 
 	$wait_s = max($timeout_s, 0.0);
 	$deadline = microtime(TRUE) + $wait_s;
+	// Independent poll cap bounds the wait if the wall clock stalls or moves backward.
 	$max_polls = (int) ceil($wait_s / 0.02) + 2;
 	$polls = 0;
 	$first_attempt = TRUE;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7799,7 +7799,7 @@ function pfb_unbound_py_atomic_write($path, $content, array $stream_ops=array())
 
 // #1357: one exclusive lock serializes full-set publication, scalar manifest patches,
 // convergence-gated generation GC, and teardown. Python readers never take this lock.
-function pfb_unbound_py_publication_lock() {
+function pfb_unbound_py_publication_lock(?float $timeout_s=NULL) {
 	global $pfb;
 
 	$manifest_path = $pfb['unbound_py_sources'] ?? '';
@@ -7808,14 +7808,55 @@ function pfb_unbound_py_publication_lock() {
 		return FALSE;
 	}
 	$lock = @fopen(dirname($manifest_path) . '/pfb_py_sources.lock', 'c');
-	if ($lock === FALSE || !@flock($lock, LOCK_EX)) {
-		if (is_resource($lock)) {
-			@fclose($lock);
-		}
+	if ($lock === FALSE) {
 		pfb_logger("\nDNSBL publication lock unavailable", 2);
 		return FALSE;
 	}
-	return $lock;
+
+	if ($timeout_s === NULL) {
+		if (!@flock($lock, LOCK_EX)) {
+			@fclose($lock);
+			pfb_logger("\nDNSBL publication lock unavailable", 2);
+			return FALSE;
+		}
+		return $lock;
+	}
+
+	$wait_s = max($timeout_s, 0.0);
+	$deadline = microtime(TRUE) + $wait_s;
+	$max_polls = (int) ceil($wait_s / 0.02) + 2;
+	$polls = 0;
+	$first_attempt = TRUE;
+	do {
+		$allow_expired_attempt = $first_attempt && $wait_s <= 0.0;
+		$first_attempt = FALSE;
+		if (!$allow_expired_attempt && microtime(TRUE) >= $deadline) {
+			break;
+		}
+		$would_block = 0;
+		if (@flock($lock, LOCK_EX | LOCK_NB, $would_block)) {
+			if (!$allow_expired_attempt && microtime(TRUE) >= $deadline) {
+				@flock($lock, LOCK_UN);
+				break;
+			}
+			return $lock;
+		}
+		if ($would_block !== 1) {
+			@fclose($lock);
+			pfb_logger("\nDNSBL publication lock unavailable", 2);
+			return FALSE;
+		}
+		$polls++;
+		$remaining_s = $deadline - microtime(TRUE);
+		if ($polls >= $max_polls || $remaining_s <= 0.0) {
+			break;
+		}
+		usleep((int) min(20000, ceil($remaining_s * 1000000)));
+	} while (TRUE);
+
+	@fclose($lock);
+	pfb_logger("\nDNSBL publication lock timed out", 2);
+	return FALSE;
 }
 
 function pfb_unbound_py_publication_unlock($lock): void {
@@ -7862,7 +7903,7 @@ function pfb_unbound_py_remove_raw_artifact(string $path): bool {
 function pfb_unbound_py_gc(bool $converged): bool {
 	global $pfb;
 
-	$lock = pfb_unbound_py_publication_lock();
+	$lock = pfb_unbound_py_publication_lock(0.25);
 	if ($lock === FALSE) {
 		return FALSE;
 	}
@@ -8545,9 +8586,10 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 // (shared by the whitelist/unlock in-place patchers below), without a full
 // feed re-enumeration. The query-time whiteDB is rebuilt from this on reload.
 function pfb_unbound_python_sources_patch($key, $values, array $publication_ops=array()) {
-	$lock_fn = $publication_ops['lock'] ?? static fn() => pfb_unbound_py_publication_lock();
+	$lock_fn = $publication_ops['lock'] ?? static fn() => pfb_unbound_py_publication_lock(0.25);
 	$lock = $lock_fn();
 	if ($lock === FALSE) {
+		pfb_logger("\nDNSBL scalar manifest patch skipped while publication was busy; retry the action or run a DNSBL update", 2);
 		return FALSE;
 	}
 	try {

--- a/tests/fixtures/dnsbl_corpus/README.md
+++ b/tests/fixtures/dnsbl_corpus/README.md
@@ -30,7 +30,8 @@ Never hand-edit `raw/*.raw`. Change `txt/*.txt` or `feeds.json`, then regenerate
 `pfb_unbound_python_sources()` over the corpus (see
 `tests/php/Adr62DnsblCorpusManifestTest.php`::`GENERATE.md` note, or simply run the PHPUnit
 suite — a byte mismatch fails loudly with a diff) and copy the freshly written
-`<rawdir>/pfb_py_raw/*.raw` back over `raw/*.raw`. Commit the diff.
+files named by the manifest's `feeds[].raw` rows from
+`<rawdir>/pfb_py_raw.<xxh128>/` back over `raw/*.raw`. Commit the diff.
 
 ## What the corpus is NOT
 

--- a/tests/js/triage_findings_guard.test.js
+++ b/tests/js/triage_findings_guard.test.js
@@ -36,3 +36,10 @@ test('hardening-only findings require SKIP', () => {
 	);
 	assert.doesNotThrow(() => runGuard([verdict('hardening-skip', 'SKIP', 'hardening-only')]));
 });
+
+test('every verdict is checked', () => {
+	const valid = verdict('valid', 'SKIP', 'not-applicable');
+	const invalid = verdict('invalid', 'DEFER', 'hardening-only');
+	assert.throws(() => runGuard([valid, invalid]), /invalid: DEFER requires an actionable issue_gate/);
+	assert.throws(() => runGuard([invalid, valid]), /invalid: DEFER requires an actionable issue_gate/);
+});

--- a/tests/js/triage_findings_guard.test.js
+++ b/tests/js/triage_findings_guard.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const workflowPath = path.resolve(__dirname, '../../.claude/workflows/triage-findings.js');
+const workflow = fs.readFileSync(workflowPath, 'utf8');
+const guardStart = 'for (const verdict of verdicts) {';
+const guardEnd = '\nlog(';
+const start = workflow.indexOf(guardStart);
+const end = workflow.indexOf(guardEnd, start);
+
+assert.notEqual(start, -1, `expected guard start ${JSON.stringify(guardStart)} in ${workflowPath}`);
+assert.notEqual(end, -1, `expected guard end ${JSON.stringify(guardEnd)} in ${workflowPath}`);
+
+const runGuard = new Function('verdicts', workflow.slice(start, end));
+
+function verdict(id, decision, disposition) {
+	return { id, verdict: decision, issue_gate: { disposition } };
+}
+
+test('DEFER requires an actionable issue gate', () => {
+	assert.throws(
+		() => runGuard([verdict('defer-hardening', 'DEFER', 'hardening-only')]),
+		/defer-hardening: DEFER requires an actionable issue_gate/
+	);
+	assert.doesNotThrow(() => runGuard([verdict('defer-actionable', 'DEFER', 'actionable')]));
+});
+
+test('hardening-only findings require SKIP', () => {
+	assert.throws(
+		() => runGuard([verdict('hardening-apply', 'APPLY', 'hardening-only')]),
+		/hardening-apply: hardening-only findings must be SKIP/
+	);
+	assert.doesNotThrow(() => runGuard([verdict('hardening-skip', 'SKIP', 'hardening-only')]));
+});

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 #[CoversFunction('pfb_unbound_python_sources')]
 #[CoversFunction('pfb_unbound_python_sources_patch')]
+#[CoversFunction('pfb_unbound_py_publication_lock')]
 #[CoversFunction('pfb_unbound_py_gc')]
 #[CoversFunction('pfb_unbound_py_teardown_raw_set')]
 final class DnsblManifestAtomicGenerationTest extends TestCase
@@ -73,6 +74,79 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		$dirs = glob("{$this->tmp}/pfb_py_raw.*") ?: [];
 		return array_values(array_filter($dirs,
 			static fn(string $path): bool => preg_match('/pfb_py_raw\.[0-9a-f]{32}$/D', $path) === 1));
+	}
+
+	private function assertContendedOperationTimesOut(callable $operation): void
+	{
+		$manifestBefore = (string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
+		$holderPid = NULL;
+		$operationPid = NULL;
+		$holderParent = NULL;
+		$operationParent = NULL;
+		try {
+			[$holderParent, $holderChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+			stream_set_timeout($holderParent, 5);
+			stream_set_timeout($holderChild, 5);
+			$holderPid = pcntl_fork();
+			if ($holderPid === 0) {
+				fclose($holderParent);
+				$lock = pfb_unbound_py_publication_lock();
+				fwrite($holderChild, "LOCKED\n");
+				fgets($holderChild);
+				pfb_unbound_py_publication_unlock($lock);
+				fclose($holderChild);
+				exit(0);
+			}
+			$this->assertGreaterThan(0, $holderPid);
+			fclose($holderChild);
+			$this->assertSame("LOCKED\n", fgets($holderParent));
+
+			[$operationParent, $operationChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+			stream_set_timeout($operationParent, 5);
+			stream_set_timeout($operationChild, 5);
+			$operationPid = pcntl_fork();
+			if ($operationPid === 0) {
+				fclose($operationParent);
+				$started = microtime(TRUE);
+				$ok = $operation();
+				fwrite($operationChild, json_encode([
+					'ok' => $ok,
+					'elapsed' => microtime(TRUE) - $started,
+				]) . "\n");
+				fclose($operationChild);
+				exit(0);
+			}
+			$this->assertGreaterThan(0, $operationPid);
+			fclose($operationChild);
+
+			$read = [$operationParent];
+			$write = NULL;
+			$except = NULL;
+			$this->assertSame(1, stream_select($read, $write, $except, 1),
+				'contended interactive operation exceeded its bounded lock wait');
+			$result = json_decode((string) fgets($operationParent), TRUE);
+			$this->assertIsArray($result);
+			$this->assertFalse($result['ok'], 'contended interactive operation must skip mutation');
+			$this->assertLessThan(1.0, $result['elapsed'], 'contended lock wait exceeded its deadline margin');
+			$this->assertSame($manifestBefore, file_get_contents($GLOBALS['pfb']['unbound_py_sources']),
+				'lock timeout must not mutate the published manifest');
+		} finally {
+			if (is_resource($holderParent)) {
+				@fwrite($holderParent, "RELEASE\n");
+				fclose($holderParent);
+			}
+			if (is_resource($operationParent)) {
+				fclose($operationParent);
+			}
+			foreach ([$holderPid, $operationPid] as $pid) {
+				if (is_int($pid) && $pid > 0) {
+					if (pcntl_waitpid($pid, $childStatus, WNOHANG) === 0 && function_exists('posix_kill')) {
+						posix_kill($pid, SIGKILL);
+					}
+					pcntl_waitpid($pid, $childStatus);
+				}
+			}
+		}
 	}
 
 	public function testSuccessfulPublicationKeepsOldSetAndCommitsOneCompleteGeneration(): void
@@ -279,6 +353,38 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		$patched = json_decode((string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']), TRUE);
 		$this->assertSame($rawRefs, array_column($patched['feeds'], 'raw'));
 		$this->assertSame(['allow.example'], $patched['config']['user_unlock']);
+	}
+
+	public function testScalarPatchTimesOutWithoutMutatingManifest(): void
+	{
+		$manifest = $this->publish();
+		$this->assertIsArray($manifest);
+
+		$this->assertContendedOperationTimesOut(
+			static fn(): bool => pfb_unbound_python_sources_patch('user_unlock', ['allow.example'])
+		);
+
+		$patched = json_decode((string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']), TRUE);
+		$this->assertSame([], $patched['config']['user_unlock']);
+		$log = (string) file_get_contents($GLOBALS['pfb']['log']);
+		$this->assertStringContainsString('retry the action or run a DNSBL update', $log);
+	}
+
+	public function testGarbageCollectionTimesOutWithoutRemovingRawGenerations(): void
+	{
+		$first = $this->publish();
+		$this->assertIsArray($first);
+		$this->writeFeed('two.example');
+		$second = $this->publish();
+		$this->assertIsArray($second);
+		$stage = "{$this->tmp}/pfb_py_raw.stage.abcdef0123456789abcdef0123456789";
+		mkdir($stage);
+
+		$this->assertContendedOperationTimesOut(static fn(): bool => pfb_unbound_py_gc(TRUE));
+
+		$this->assertDirectoryExists(dirname($this->manifestRaw($first)));
+		$this->assertDirectoryExists(dirname($this->manifestRaw($second)));
+		$this->assertDirectoryExists($stage);
 	}
 
 	public function testGarbageCollectionRequiresConvergenceAndProtectsCurrentGeneration(): void

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -274,7 +274,18 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		}
 	}
 
-	public function testScalarPatchPreservesRawReferencesAndSerializesOnPublicationLock(): void
+	public function testDefaultScalarPatchSucceedsWhenPublicationLockIsUncontended(): void
+	{
+		$manifest = $this->publish();
+		$this->assertIsArray($manifest);
+
+		$this->assertTrue(pfb_unbound_python_sources_patch('user_unlock', ['allow.example']));
+
+		$patched = json_decode((string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']), TRUE);
+		$this->assertSame(['allow.example'], $patched['config']['user_unlock']);
+	}
+
+	public function testDefaultScalarPatchRetriesUntilPublicationLockIsReleased(): void
 	{
 		$manifest = $this->publish();
 		$this->assertIsArray($manifest);
@@ -307,12 +318,8 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			$patchPid = pcntl_fork();
 			if ($patchPid === 0) {
 				fclose($patchParent);
-				$ok = pfb_unbound_python_sources_patch('user_unlock', ['allow.example'], [
-					'lock' => static function () use ($patchChild) {
-						fwrite($patchChild, "ATTEMPT\n");
-						return pfb_unbound_py_publication_lock();
-					},
-				]);
+				fwrite($patchChild, "ATTEMPT\n");
+				$ok = pfb_unbound_python_sources_patch('user_unlock', ['allow.example']);
 				fwrite($patchChild, $ok ? "DONE\n" : "FAILED\n");
 				fclose($patchChild);
 				exit($ok ? 0 : 1);

--- a/tests/php/DnsblQueryClientTest.php
+++ b/tests/php/DnsblQueryClientTest.php
@@ -24,7 +24,8 @@ use PHPUnit\Framework\TestCase;
  *     field, mistyped field, truncated/non-JSON/oversized bytes, foreign id)
  *     is ignored, never a fatal, and the call times out to NULL;
  *   - blocked=false with empty attribution is a VALID verdict, not NULL;
- *   - the bounded wait obeys both the deadline and the hard poll cap;
+ *   - the bounded wait behaviorally obeys its deadline, while a source pin
+ *     records the independent hard poll cap that protects a stalled clock;
  *   - cleanup: reply+request unlinked on a matched verdict or timeout, no
  *     ".pfbctl_" staging residue.
  *
@@ -496,7 +497,8 @@ final class DnsblQueryClientTest extends TestCase
 		$this->assertFalse($requestPublished, 'lock timeout must not publish a query request');
 	}
 
-	public function testLockWaitHasHardPollCapIndependentOfClockDeadline(): void
+	/** Source pin: stalled-clock behavior has no deterministic production seam. */
+	public function testSourcePinLockWaitContainsIndependentHardPollCap(): void
 	{
 		$function = new ReflectionFunction('pfb_dnsbl_query');
 		$lines = file($function->getFileName());

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -171,8 +171,65 @@ Describe 'verify-red-proof.sh'
   }
   arm_checkout_term_hook() {
     hook="$repo/.git/hooks/post-checkout"
-    printf '%s\n' '#!/bin/sh' 'rm -f "$0"' 'parent=$(ps -o ppid= -p "$PPID" | tr -d " ")' 'kill -TERM "$parent"' > "$hook"
+    printf '%s\n' \
+      '#!/bin/sh' \
+      'rm -f "$0"' \
+      'gitdir=${0%/hooks/post-checkout}' \
+      'mkfifo "$gitdir/checkout-release"' \
+      'touch "$gitdir/checkout-ready"' \
+      'read ready < "$gitdir/checkout-release"' > "$hook"
     chmod +x "$hook"
+  }
+  interrupt_after_marker() {
+    marker=$1
+    shift
+    interrupt_status=$(dash -c '
+      marker=$1
+      shift
+      "$@" >/dev/null 2>&1 &
+      child=$!
+      polls=0
+      while [ ! -e "$marker" ]; do
+        if ! kill -0 "$child" 2>/dev/null; then
+          echo "child exited before readiness marker: $marker" >&2
+          exit 1
+        fi
+        polls=$((polls + 1))
+        if [ "$polls" -ge 500 ]; then
+          echo "timed out waiting for readiness marker: $marker" >&2
+          kill -TERM "$child" 2>/dev/null
+          wait "$child" 2>/dev/null
+          exit 1
+        fi
+        sleep 0.01
+      done
+      kill -TERM "$child" 2>/dev/null
+      printf 'release\n' > "${marker%ready}release"
+      wait "$child" 2>/dev/null
+      printf "%s\n" "$?"
+    ' sh "$marker" "$@") || return 1
+  }
+  make_restore_failure_shim() {
+    real_git=$(command -v git)
+    shim_dir="$repo/.git/restore-shim"
+    mkdir "$shim_dir"
+    printf '%s\n' \
+      '#!/bin/sh' \
+      'last=' \
+      'for arg in "$@"; do last=$arg; done' \
+      'case "${PFB_FAIL_RESTORE:-}:$3:$4:$last" in' \
+      '  checkout:checkout:HEAD:src.txt|rm:rm:*:old.txt|clean:clean:*:old.txt) exit 9 ;;' \
+      '  residual:rm:*:old.txt|residual:clean:*:old.txt) exit 0 ;;' \
+      'esac' \
+      "exec '$real_git' \"\$@\"" > "$shim_dir/git"
+    chmod +x "$shim_dir/git"
+  }
+  assert_later_restore() {
+    case "$1" in
+      old-absent) [ ! -e "$repo/old.txt" ] ;;
+      src-good) [ "$(cat "$repo/src.txt")" = GOOD ] ;;
+      *) return 2 ;;
+    esac
   }
   cleanup() { rm -rf "$repo"; }
   After 'cleanup'
@@ -275,14 +332,11 @@ Describe 'verify-red-proof.sh'
   End
 
   It 'removes a red-created nested repository through SIGTERM restoration'
-    make_deleted_directory_with_nested_repo 'sleep 30'
+    make_deleted_directory_with_nested_repo 'mkfifo .git/redproof-release; touch .git/redproof-ready; read ready < .git/redproof-release; false'
     interrupt_nested_case() {
-      dash "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src gone >/dev/null 2>&1 &
-      pid=$!
-      sleep 1
-      kill -TERM "$pid" 2>/dev/null
-      wait "$pid" 2>/dev/null
-      printf '%s\n' "$?"
+      interrupt_after_marker "$repo/.git/redproof-ready" \
+        dash "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src gone || return 1
+      printf '%s\n' "$interrupt_status"
       assert_repo_clean
     }
     When call interrupt_nested_case
@@ -372,11 +426,8 @@ Describe 'verify-red-proof.sh'
   It 'restores the src paths when SIGTERM interrupts the red run (dash semantics)'
     make_repo BAD GOOD
     interrupt_case() {
-      dash "$script" --worktree "$repo" --test-cmd 'sleep 30' --src src.txt >/dev/null 2>&1 &
-      pid=$!
-      sleep 1
-      kill -TERM "$pid" 2>/dev/null
-      wait "$pid" 2>/dev/null
+      interrupt_after_marker "$repo/.git/redproof-ready" \
+        dash "$script" --worktree "$repo" --test-cmd 'mkfifo .git/redproof-release; touch .git/redproof-ready; read ready < .git/redproof-release; false' --src src.txt || return 1
       assert_repo_clean
     }
     When call interrupt_case
@@ -387,26 +438,22 @@ Describe 'verify-red-proof.sh'
     make_repo BAD GOOD
     arm_checkout_term_hook
     interrupt_checkout_case() {
-      dash "$script" --worktree "$repo" --test-cmd 'true' --src src.txt >/dev/null 2>&1 &
-      pid=$!
-      wait "$pid" 2>/dev/null
-      printf '%s\n' "$?"
+      interrupt_after_marker "$repo/.git/checkout-ready" \
+        dash "$script" --worktree "$repo" --test-cmd 'true' --src src.txt || return 1
+      printf '%s\n' "$interrupt_status"
+      assert_repo_clean
     }
     When call interrupt_checkout_case
     The output should equal '130'
     The contents of file "$repo/src.txt" should equal 'GOOD'
-    Assert assert_repo_clean
   End
 
   It 'restores a deleted src path when SIGTERM interrupts the red run (dash semantics)'
     make_deleted_repo 'test ! -e old.txt'
     interrupt_deleted_case() {
-      dash "$script" --worktree "$repo" --test-cmd 'sleep 30' --src old.txt >/dev/null 2>&1 &
-      pid=$!
-      sleep 1
-      kill -TERM "$pid" 2>/dev/null
-      wait "$pid" 2>/dev/null
-      printf '%s\n' "$?"
+      interrupt_after_marker "$repo/.git/redproof-ready" \
+        dash "$script" --worktree "$repo" --test-cmd 'mkfifo .git/redproof-release; touch .git/redproof-ready; read ready < .git/redproof-release; false' --src old.txt || return 1
+      printf '%s\n' "$interrupt_status"
       assert_repo_clean
     }
     When call interrupt_deleted_case
@@ -449,6 +496,37 @@ Describe 'verify-red-proof.sh'
     When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt
     The status should equal 2
     The stderr should include 'DIRTY-TREE'
+  End
+
+  It 'fails closed when initial git status fails with empty stdout'
+    make_repo BAD GOOD
+    gitc config status.showUntrackedFiles bogus
+    When run sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src src.txt
+    The status should equal 2
+    The stderr should include 'DIRTY-TREE'
+    The output should not include 'RED-OK'
+    The output should not include 'VERDICT: PASS'
+    The contents of file "$repo/src.txt" should equal 'GOOD'
+  End
+
+  Context 'best-effort restoration after one path fails'
+    Parameters
+      'checkout' 'src.txt' 'old.txt' 'old-absent'
+      'rm'       'old.txt' 'src.txt' 'src-good'
+      'clean'    'old.txt' 'src.txt' 'src-good'
+      'residual' 'old.txt' 'src.txt' 'src-good'
+    End
+
+    It "continues after a $1 failure and restores the later path"
+      make_mixed_repo
+      make_restore_failure_shim
+      When run env PFB_FAIL_RESTORE="$1" PATH="$shim_dir:$PATH" \
+        sh "$script" --worktree "$repo" --test-cmd 'sh test_pin.sh' --src "$2" --src "$3"
+      The status should equal 1
+      The output should include 'RESTORE-FAIL'
+      The stderr should include 'restore failed for'
+      Assert assert_later_restore "$4"
+    End
   End
 
   It 'does not pass when git status cannot inspect the path'

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -226,9 +226,21 @@ Describe 'verify-red-proof.sh'
   }
   assert_later_restore() {
     case "$1" in
-      old-absent) [ ! -e "$repo/old.txt" ] ;;
-      src-good) [ "$(cat "$repo/src.txt")" = GOOD ] ;;
-      *) return 2 ;;
+      old-absent)
+        [ ! -e "$repo/old.txt" ] && return 0
+        echo 'expected old.txt state: absent; actual: present' >&2
+        return 1
+        ;;
+      src-good)
+        actual=$(cat "$repo/src.txt" 2>/dev/null || echo '<missing>')
+        [ "$actual" = GOOD ] && return 0
+        echo "expected src.txt content: GOOD; actual: $actual" >&2
+        return 1
+        ;;
+      *)
+        echo "expected restore selector: old-absent or src-good; actual: $1" >&2
+        return 2
+        ;;
     esac
   }
   cleanup() { rm -rf "$repo"; }
@@ -527,6 +539,22 @@ Describe 'verify-red-proof.sh'
       The stderr should include 'restore failed for'
       Assert assert_later_restore "$4"
     End
+  End
+
+  It 'reports expected and actual state for failed restoration checks'
+    make_mixed_repo
+    touch "$repo/old.txt"
+    When call assert_later_restore old-absent
+    The status should equal 1
+    The stderr should include 'expected old.txt state: absent; actual: present'
+  End
+
+  It 'reports expected and actual content for failed restoration checks'
+    make_mixed_repo
+    printf '%s\n' BAD > "$repo/src.txt"
+    When call assert_later_restore src-good
+    The status should equal 1
+    The stderr should include 'expected src.txt content: GOOD; actual: BAD'
   End
 
   It 'does not pass when git status cannot inspect the path'

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -72,8 +72,7 @@ from .webui import looks_like_login_page, row_containing
 if TYPE_CHECKING:
     from .webui import WebUI
 
-# S3 and S8 intentionally also gate Tier A. Selecting either runs this shared
-# fixture's full baseline-plus-seeded GET matrix to verify exact Alerts attribution.
+# Selecting S3 or S8 runs the full baseline-plus-seeded GET matrix.
 pytestmark = pytest.mark.ui_e2e
 
 ALERTS_PAGE = "/pfblockerng/pfblockerng_alerts.php"

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -72,6 +72,8 @@ from .webui import looks_like_login_page, row_containing
 if TYPE_CHECKING:
     from .webui import WebUI
 
+# S3 and S8 intentionally also gate Tier A. Selecting either runs this shared
+# fixture's full baseline-plus-seeded GET matrix to verify exact Alerts attribution.
 pytestmark = pytest.mark.ui_e2e
 
 ALERTS_PAGE = "/pfblockerng/pfblockerng_alerts.php"

--- a/tests/test_noopener_check.py
+++ b/tests/test_noopener_check.py
@@ -218,6 +218,9 @@ _HOSTILE_VIOLATION_ROWS = (
     ("wrong_rel", '<a target="_blank" rel="opener">'),
     ("hyphen_rel_suffix", '<a target="_blank" rel="noopener-evil">'),
     ("word_rel_suffix", '<a target="_blank" rel="noopener_evil">'),
+    ("unquoted_slash", "<a target=_blank/>"),
+    ("unquoted_slash_with_rel", '<a target=_blank/ rel="noopener noreferrer">'),
+    ("quoted_slash", '<a target="_blank"/>'),
 )
 
 

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1502,6 +1502,42 @@ class TestOperateDnsbl:
         entry = pfb_unbound.decisionDB.get("evil-domain.com")
         assert entry.dnsbl.group == "DNSBL_Regex"
 
+    def test_idn_alert_overlapping_regex_emits_only_block_log(self, monkeypatch: Any) -> None:
+        self._enable(monkeypatch)
+        pfb_unbound.pfb["idn_mode"] = pfb_unbound.IDN_MODE_CONFUSABLE
+        pfb_unbound.pfb["python_idn_block_malicious"] = False
+        pfb_unbound.pfb["python_idn_escalate_suspicious"] = False
+        pfb_unbound.regexDB["user-overlap"] = re.compile(r"xn--bnk-1ce")
+        logs: list[tuple[str, str]] = []
+        monkeypatch.setattr(pfb_unbound, "pfb_log", lambda path, line: logs.append((path, line)))
+
+        qstate = make_qstate("xn--bnk-1ce.com.", qtype=RR_A)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+
+        assert qstate.ext_state[0] == MODULE_FINISHED
+        assert len(logs) == 1, f"expected one block log, got {logs!r}"
+        fields = logs[0][1].split(",")
+        assert fields[5] == "Python", f"expected regex block type, got {fields!r}"
+        assert fields[6] == "DNSBL_Regex", f"expected regex group, got {fields!r}"
+        assert fields[8] == "user-overlap", f"expected user regex feed, got {fields!r}"
+
+    def test_idn_alert_without_block_emits_one_alert_log(self, monkeypatch: Any) -> None:
+        self._enable(monkeypatch)
+        pfb_unbound.pfb["idn_mode"] = pfb_unbound.IDN_MODE_CONFUSABLE
+        pfb_unbound.pfb["python_idn_block_malicious"] = False
+        pfb_unbound.pfb["python_idn_escalate_suspicious"] = False
+        logs: list[tuple[str, str]] = []
+        monkeypatch.setattr(pfb_unbound, "pfb_log", lambda path, line: logs.append((path, line)))
+
+        qstate = make_qstate("xn--bnk-1ce.com.", qtype=RR_A)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+
+        assert qstate.ext_state[0] == MODULE_WAIT_MODULE
+        assert len(logs) == 1, f"expected one IDN alert log, got {logs!r}"
+        fields = logs[0][1].split(",")
+        assert fields[5] == "Homoglyph_Alert", f"expected IDN alert type, got {fields!r}"
+        assert fields[6] == pfb_unbound.IDN_GROUP_SUSPECT, f"expected suspect group, got {fields!r}"
+
     def test_allow_decision_short_circuit(self, monkeypatch: Any) -> None:
         # A cached allow verdict ("let it resolve") short-circuits the matcher -- the
         # unified-cache equivalent of the old excludeDB membership skip.

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1538,6 +1538,28 @@ class TestOperateDnsbl:
         assert fields[5] == "Homoglyph_Alert", f"expected IDN alert type, got {fields!r}"
         assert fields[6] == pfb_unbound.IDN_GROUP_SUSPECT, f"expected suspect group, got {fields!r}"
 
+    def test_idn_alert_overlapping_whitelisted_regex_emits_alert_log(self, monkeypatch: Any) -> None:
+        self._enable(monkeypatch)
+        pfb_unbound.pfb["idn_mode"] = pfb_unbound.IDN_MODE_CONFUSABLE
+        pfb_unbound.pfb["python_idn_block_malicious"] = False
+        pfb_unbound.pfb["python_idn_escalate_suspicious"] = False
+        pfb_unbound.regexDB["user-overlap"] = re.compile(r"xn--bnk-1ce")
+        add_white("xn--bnk-1ce.com", wildcard=False)
+        logs: list[tuple[str, str]] = []
+        monkeypatch.setattr(pfb_unbound, "pfb_log", lambda path, line: logs.append((path, line)))
+
+        qstate = make_qstate("xn--bnk-1ce.com.", qtype=RR_A)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+
+        assert qstate.ext_state[0] == MODULE_WAIT_MODULE
+        decision = pfb_unbound.decisionDB["xn--bnk-1ce.com"].dnsbl
+        assert decision.is_found is True
+        assert decision.in_whitelist is True
+        assert len(logs) == 1, f"expected one whitelisted IDN alert log, got {logs!r}"
+        fields = logs[0][1].split(",")
+        assert fields[5] == "Homoglyph_Alert", f"expected IDN alert type, got {fields!r}"
+        assert fields[6] == pfb_unbound.IDN_GROUP_SUSPECT, f"expected suspect group, got {fields!r}"
+
     def test_allow_decision_short_circuit(self, monkeypatch: Any) -> None:
         # A cached allow verdict ("let it resolve") short-circuits the matcher -- the
         # unified-cache equivalent of the old excludeDB membership skip.

--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -893,14 +893,7 @@ class TestControlWatcherLoop:
                 stderr_fallback.append(text)
                 return len(text)
 
-        class SelectiveStderr:
-            def write(self, text: str) -> int:
-                if "control command failed" in text:
-                    raise OSError("closed stderr")
-                return len(text)
-
         monkeypatch.setattr(sys, "__stderr__", RecordingStderr())
-        monkeypatch.setattr(sys, "stderr", SelectiveStderr())
 
         def apply_command(command: list[str]) -> tuple[bool, str]:
             handler_calls.append(command[1])

--- a/tests/test_release_ci_path_consistency.py
+++ b/tests/test_release_ci_path_consistency.py
@@ -1,0 +1,35 @@
+"""Keep release CI fallback exclusions aligned with workflow path filters."""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _workflow_paths(trigger: str) -> list[str]:
+    lines = (ROOT / ".github/workflows/test.yml").read_text().splitlines()
+    trigger_line = f"  {trigger}:"
+    start = lines.index(trigger_line)
+    paths_start = next(index for index in range(start + 1, len(lines)) if lines[index] == "    paths-ignore:")
+    paths: list[str] = []
+    for line in lines[paths_start + 1 :]:
+        if line and not line.startswith("      "):
+            break
+        match = re.match(r"      - '(.+)'$", line)
+        if match:
+            paths.append(match.group(1))
+    return paths
+
+
+def _release_gate_paths() -> list[str]:
+    source = (ROOT / "scripts/release-ci-gate.sh").read_text()
+    return re.findall(r"':\(top,exclude,(?:glob|literal)\)([^']+)'", source)
+
+
+def test_release_fallback_exclusions_match_both_workflow_triggers() -> None:
+    push = _workflow_paths("push")
+    pull_request = _workflow_paths("pull_request")
+    release_gate = _release_gate_paths()
+
+    assert pull_request == push, f"pull_request paths-ignore differs from push: {pull_request!r} != {push!r}"
+    assert release_gate == push, f"release fallback exclusions differ from workflow: {release_gate!r} != {push!r}"

--- a/tests/test_release_ci_path_consistency.py
+++ b/tests/test_release_ci_path_consistency.py
@@ -1,5 +1,7 @@
 """Keep release CI fallback exclusions aligned with workflow path filters."""
 
+from __future__ import annotations
+
 import re
 from pathlib import Path
 
@@ -27,9 +29,12 @@ def _workflow_paths_from_source(source: str, trigger: str) -> list[str]:
     for line in lines[paths_start + 1 : end]:
         if line and not line.startswith("      "):
             break
-        match = re.match(r"      - '(.+)'$", line)
-        if match:
-            paths.append(match.group(1))
+        if not line:
+            continue
+        match = re.fullmatch(r"      - '(.+)'", line)
+        if match is None:
+            raise AssertionError(f"unparsed paths-ignore entry: {line!r}")
+        paths.append(match.group(1))
     return paths
 
 
@@ -48,6 +53,9 @@ def test_release_fallback_exclusions_match_both_workflow_triggers() -> None:
     pull_request = _workflow_paths("pull_request")
     release_gate = _release_gate_paths()
 
+    assert push, "push paths-ignore must not be empty"
+    assert pull_request, "pull_request paths-ignore must not be empty"
+    assert release_gate, "release fallback exclusions must not be empty"
     assert pull_request == push, f"pull_request paths-ignore differs from push: {pull_request!r} != {push!r}"
     assert release_gate == push, f"release fallback exclusions differ from workflow: {release_gate!r} != {push!r}"
 
@@ -64,4 +72,16 @@ on:
 """
 
     with pytest.raises(AssertionError, match="push: missing paths-ignore"):
+        _workflow_paths_from_source(source, "push")
+
+
+def test_workflow_parser_rejects_unparsed_path_entries() -> None:
+    source = """\
+on:
+  push:
+    paths-ignore:
+      - "**/*.md"
+"""
+
+    with pytest.raises(AssertionError, match="unparsed paths-ignore entry"):
         _workflow_paths_from_source(source, "push")

--- a/tests/test_release_ci_path_consistency.py
+++ b/tests/test_release_ci_path_consistency.py
@@ -3,22 +3,39 @@
 import re
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def _workflow_paths(trigger: str) -> list[str]:
-    lines = (ROOT / ".github/workflows/test.yml").read_text().splitlines()
+def _workflow_paths_from_source(source: str, trigger: str) -> list[str]:
+    lines = source.splitlines()
     trigger_line = f"  {trigger}:"
-    start = lines.index(trigger_line)
-    paths_start = next(index for index in range(start + 1, len(lines)) if lines[index] == "    paths-ignore:")
+    try:
+        start = lines.index(trigger_line)
+    except ValueError as exc:
+        raise AssertionError(f"workflow trigger {trigger!r} is missing") from exc
+    end = next(
+        (index for index in range(start + 1, len(lines)) if re.fullmatch(r"  [A-Za-z_][A-Za-z0-9_-]*:", lines[index])),
+        len(lines),
+    )
+    try:
+        paths_start = next(index for index in range(start + 1, end) if lines[index] == "    paths-ignore:")
+    except StopIteration as exc:
+        raise AssertionError(f"{trigger}: missing paths-ignore") from exc
     paths: list[str] = []
-    for line in lines[paths_start + 1 :]:
+    for line in lines[paths_start + 1 : end]:
         if line and not line.startswith("      "):
             break
         match = re.match(r"      - '(.+)'$", line)
         if match:
             paths.append(match.group(1))
     return paths
+
+
+def _workflow_paths(trigger: str) -> list[str]:
+    source = (ROOT / ".github/workflows/test.yml").read_text()
+    return _workflow_paths_from_source(source, trigger)
 
 
 def _release_gate_paths() -> list[str]:
@@ -33,3 +50,18 @@ def test_release_fallback_exclusions_match_both_workflow_triggers() -> None:
 
     assert pull_request == push, f"pull_request paths-ignore differs from push: {pull_request!r} != {push!r}"
     assert release_gate == push, f"release fallback exclusions differ from workflow: {release_gate!r} != {push!r}"
+
+
+def test_workflow_parser_does_not_cross_trigger_boundaries() -> None:
+    source = """\
+on:
+  push:
+    branches:
+      - devel
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+"""
+
+    with pytest.raises(AssertionError, match="push: missing paths-ignore"):
+        _workflow_paths_from_source(source, "push")

--- a/tests/test_scanner_finding_policy.py
+++ b/tests/test_scanner_finding_policy.py
@@ -1,3 +1,9 @@
+"""Vocabulary-consistency tripwires for scanner-finding policy artifacts.
+
+Behavioral enforcement coverage lives in ``tests/js/triage_findings_guard.test.js``;
+these checks only keep policy, workflow schemas, and skill text on one vocabulary.
+"""
+
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -7,16 +13,21 @@ def _read(relative_path: str) -> str:
     return (ROOT / relative_path).read_text(encoding="utf-8")
 
 
-def test_scanner_findings_require_actionability_before_issue_creation() -> None:
+def _assert_vocabulary(source: str, text: str, expected: str) -> None:
+    actual = expected if expected in text else None
+    assert actual == expected, f"{source}: expected vocabulary {expected!r}, got {actual!r}"
+
+
+def test_scanner_finding_actionability_vocabulary_is_consistent() -> None:
     policy = _read("CLAUDE.md")
     batch_triage = _read(".claude/workflows/triage-findings.js")
     issue_triage = _read(".claude/workflows/issue-triage.js")
     pr_comments = _read(".claude/skills/pr-comments/SKILL.md")
 
-    assert "### Scanner/audit finding gate" in policy
-    assert "Every newly found **actionable** TypeError-class defect" in policy
+    _assert_vocabulary("CLAUDE.md", policy, "### Scanner/audit finding gate")
+    _assert_vocabulary("CLAUDE.md", policy, "Every newly found **actionable** TypeError-class defect")
 
-    assert "'issue_gate'" in batch_triage
+    _assert_vocabulary("triage-findings.js", batch_triage, "'issue_gate'")
     for field in (
         "producer",
         "supported_path",
@@ -25,25 +36,25 @@ def test_scanner_findings_require_actionability_before_issue_creation() -> None:
         "impact_scope",
         "black_box_repro",
     ):
-        assert f"'{field}'" in batch_triage
-    assert "DEFER requires an actionable issue_gate" in batch_triage
+        _assert_vocabulary("triage-findings.js", batch_triage, f"'{field}'")
+    _assert_vocabulary("triage-findings.js", batch_triage, "DEFER requires an actionable issue_gate")
 
-    assert "'reachability'" in issue_triage
-    assert "supported producer" in issue_triage
-    assert "validated issue-gate block" in pr_comments
+    _assert_vocabulary("issue-triage.js", issue_triage, "'reachability'")
+    _assert_vocabulary("issue-triage.js", issue_triage, "supported producer")
+    _assert_vocabulary("pr-comments/SKILL.md", pr_comments, "validated issue-gate block")
 
 
-def test_hardening_only_is_terminal_across_issue_workflows() -> None:
+def test_hardening_only_vocabulary_is_consistent_across_issue_workflows() -> None:
     policy = _read("CLAUDE.md")
     batch_triage = _read(".claude/workflows/triage-findings.js")
     issue_triage = _read(".claude/workflows/issue-triage.js")
     gh_issue = _read(".claude/skills/gh-issue/SKILL.md")
     pr_comments = _read(".claude/skills/pr-comments/SKILL.md")
 
-    assert "**HARDENING-ONLY**" in policy
-    assert "HARDENING-ONLY findings do not become tracker children" in policy
-    assert "hardening-only findings must be SKIP" in batch_triage
-    assert "'HARDENING-ONLY'" in issue_triage
-    assert "DUPLICATE / HARDENING-ONLY" in gh_issue
-    assert "HARDENING-ONLY closes as not planned" in gh_issue
-    assert "HARDENING-ONLY finding is `SKIP`" in pr_comments
+    _assert_vocabulary("CLAUDE.md", policy, "**HARDENING-ONLY**")
+    _assert_vocabulary("CLAUDE.md", policy, "HARDENING-ONLY findings do not become tracker children")
+    _assert_vocabulary("triage-findings.js", batch_triage, "hardening-only findings must be SKIP")
+    _assert_vocabulary("issue-triage.js", issue_triage, "'HARDENING-ONLY'")
+    _assert_vocabulary("gh-issue/SKILL.md", gh_issue, "DUPLICATE / HARDENING-ONLY")
+    _assert_vocabulary("gh-issue/SKILL.md", gh_issue, "HARDENING-ONLY closes as not planned")
+    _assert_vocabulary("pr-comments/SKILL.md", pr_comments, "HARDENING-ONLY finding is `SKIP`")

--- a/tests/test_scanner_finding_policy.py
+++ b/tests/test_scanner_finding_policy.py
@@ -4,6 +4,8 @@ Behavioral enforcement coverage lives in ``tests/js/triage_findings_guard.test.j
 these checks only keep policy, workflow schemas, and skill text on one vocabulary.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -29,6 +31,7 @@ def test_scanner_finding_actionability_vocabulary_is_consistent() -> None:
 
     _assert_vocabulary("triage-findings.js", batch_triage, "'issue_gate'")
     for field in (
+        "disposition",
         "producer",
         "supported_path",
         "required_privilege",

--- a/tests/test_smoke_tick_marker_baseline.py
+++ b/tests/test_smoke_tick_marker_baseline.py
@@ -10,7 +10,7 @@ import pytest
 from tests.smoke import test_smoke_tick as tick
 
 
-def test_due_marker_baseline_drains_before_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+def _tick_fixture(monkeypatch: pytest.MonkeyPatch, *, emit_tick_marker: bool) -> tuple[dict[str, int], tick.SmokeVM]:
     state = {"drains": 0, "marker": 0, "next_due": 0}
 
     class VM(tick.SmokeVM):
@@ -19,6 +19,8 @@ def test_due_marker_baseline_drains_before_capture(monkeypatch: pytest.MonkeyPat
                 return SimpleNamespace(returncode=0, stdout="100\n", stderr="")
             if args == (tick._PHP, tick._PFB_PHP, "tick"):
                 state["next_due"] = 101
+                if emit_tick_marker:
+                    state["marker"] += 1
                 return SimpleNamespace(returncode=0, stdout="", stderr="")
             raise AssertionError(args)
 
@@ -39,5 +41,19 @@ def test_due_marker_baseline_drains_before_capture(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(tick.h, "count_log_marker", lambda *_args: state["marker"])
     monkeypatch.setattr(tick.h, "wait_until", lambda predicate, **_kwargs: bool(predicate()))
 
+    return state, VM("")
+
+
+def test_due_marker_baseline_drains_before_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    _state, vm = _tick_fixture(monkeypatch, emit_tick_marker=False)
+
     with pytest.raises(AssertionError, match="marker count did not increase"):
-        tick.test_tick_dispatches_due_feed(VM(""))
+        tick.test_tick_dispatches_due_feed(vm)
+
+
+def test_due_marker_after_baseline_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    state, vm = _tick_fixture(monkeypatch, emit_tick_marker=True)
+
+    tick.test_tick_dispatches_due_feed(vm)
+
+    assert state == {"drains": 2, "marker": 2, "next_due": 101}


### PR DESCRIPTION
## Summary

- flag the unquoted `target=_blank/` near-miss and restore exclusive block-versus-IDN-alert logging
- bound publication-lock waits on interactive scalar-patch and opportunistic-GC paths while leaving the full writer blocking
- replace scanner-policy coverage theater with executable JavaScript guards and harden the red-proof verifier's status/restoration paths
- reconcile test honesty, immutable-generation docs, Tier-A marker intent, and public-versus-local agent configuration

## Root cause

The reviewed commit window accumulated several small semantic gaps: a regex
delimiter accidentally excluded a typo shape, cache retirement flattened an
historical `elif`, and one publication lock API served both long-running writers
and web-request callers without a deadline. Several tests also asserted source
text or vocabulary while presenting themselves as behavioral coverage.

## Validation

- four frozen red-to-green proofs pass against `origin/devel` for noopener, IDN overlap, publication-lock contention, and red-proof restoration
- canonical diff gates pass: pytest, Ruff, Mypy, PHPUnit, PHPStan, PHPCS, ShellCheck, ShellSpec, PHP lint, and Markdown lint
- mutation probes prove the triage-workflow guard and release-path consistency tests fail on inverted/drifted logic
- latest-develop full PHPUnit reached 3,573 tests; its sandboxed loopback-server row was rerun outside the sandbox and passed (1 test, 8 assertions)

Follow-ups: #1396 tracks the pre-existing syslog smoke-test order dependency;
#1397 tracks a permanent fail-closed guard against stale or symlinked Composer
`vendor/` trees. The exact `$rsync` false report was already documented in #1347.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Refined DNSBL decision logging to keep IDN alerts and DNSBL blocks mutually exclusive.
  - Hardened hostile-link detection for unquoted `target=_blank/...` near-misses.
  - Improved red-proof verifier “fail-closed” behavior when repository state can’t be inspected, and made restoration proceed best-effort with clearer failure handling.
- **Documentation**
  - Updated DNSBL raw-file generation/restore instructions to use manifest-driven hashed immutable output paths.
- **Tests**
  - Added/expanded coverage for lock timeouts/contended operations, scalar patch + GC timeout behavior, and workflow/policy guardrails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->