### PR TITLE
scripts: bump token-savior fork pin onto upstream v4.9.0

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -9,6 +9,6 @@ max_depth = 2
 
 [mcp_servers.token-savior-recall]
 command = "sh"
-args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" 4d4d264b22c38bbbbfa46459d6d3799ee07739093411ad61a21a3bf0bd3ab18e && exec sh "$root/scripts/mcp-token-savior.sh"''']
+args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" d08ac01fdfa4a6c5a499038df61c1685acd953c082d8890dc74fede2003b1c8e && exec sh "$root/scripts/mcp-token-savior.sh"''']
 env = { TOKEN_SAVIOR_CLIENT = "codex" }
 startup_timeout_sec = 120

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -43,7 +43,7 @@ if [ "$venv_bad" = 1 ]; then
 fi
 bin="$venv/bin/token-savior"
 stamp="$venv/.pfb-ts-source"
-TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp,memory-vector] @ git+https://github.com/andrebrait/token-savior@162aa29947fc98da8dfc5319e9fd59b11bdfed34}"
+TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp,memory-vector] @ git+https://github.com/andrebrait/token-savior@0fd6ed140d5d3732349552e14d969b2ceb5b4da7}"
 
 # stdout is the MCP stdio channel — install chatter must stay on stderr
 if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then


### PR DESCRIPTION
Rebases the `andrebrait/token-savior` `integration` branch onto upstream Mibayy/token-savior v4.9.0 (`4a7c18e`, edit-impact block replaces the get_edit_context nudge) and bumps the pinned commit in `scripts/mcp-token-savior.sh` to the new tip `0fd6ed140d5d3732349552e14d969b2ceb5b4da7`.

- All 9 fork commits rebased cleanly, no conflicts; `git cherry` confirms none have merged upstream yet (PRs #47 #53 #54 #57 #58 #59 #60 #62 still open — header comment list unchanged).
- Fork suite on the rebased tip: **1901 passed, 9 skipped**. The 2 ruff findings are pre-existing on pristine `upstream/main` (bench scripts), verified via a throwaway worktree.
- `.codex/config.toml` integrity hash updated to the launcher's new SHA-256 (pinned by `tests/shell/mcp_token_savior_spec.sh`).

Gates: `sh -n` / `shellcheck` / `shellspec --shell dash` all PASS (890 examples, 0 failures after the hash fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the default token-savior MCP server version used during setup.
  - Adjusted startup hook integrity verification to match the updated expected hash.
  - Installation and environment rebuild behavior remain the same, with existing environments triggering a clean rebuild when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->