### PR TITLE
fix: discard partial GeoIP output after cat failure

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -341,8 +341,9 @@ if (in_array($argv[1], array('update', 'updateip', 'updatednsbl', 'dc', 'dcc', '
 
 				// Proceed with conversion of MaxMind files on download success
 				if (empty($pfb['cc']) || !empty($pfb['maxmind_key']) || !empty($pfb['maxmind_account'])) {
-					pfblockerng_uc_countries();
-					pfblockerng_get_countries();
+					if (pfblockerng_uc_countries()) {
+						pfblockerng_get_countries();
+					}
 				}
 			}
 			break;
@@ -400,8 +401,9 @@ if (in_array($argv[1], array('update', 'updateip', 'updatednsbl', 'dc', 'dcc', '
 			pfblockerng_get_countries();
 			break;
 		case 'ugc':
-			pfblockerng_uc_countries();
-			pfblockerng_get_countries();
+			if (pfblockerng_uc_countries()) {
+				pfblockerng_get_countries();
+			}
 
 			if (!empty($argv[2]) && !empty($argv[3])) {
 				$argv2 = htmlspecialchars($argv[2]);
@@ -1421,7 +1423,16 @@ function pfblockerng_uc_countries() {
 											// Concat ISO Networks to Continent file
 											// issue #1299: no 2>&1 -- merging cat's stderr into this
 											// data file lets a cat failure corrupt it on reparse.
-											exec("{$pfb['cat']} {$iso_file_esc} >> {$pfb_file_esc}");
+											$cat_output = array();
+											$cat_status = 0;
+											exec("{$pfb['cat']} {$iso_file_esc} >> {$pfb_file_esc}", $cat_output, $cat_status);
+											if ($cat_status !== 0) {
+												$log = "\n Failed to append ISO data [ {$iso} IPv{$type} ] (cat status {$cat_status})\n";
+												pfb_logger("{$log}", 4);
+												@unlink($pfb_file);
+												rmdir_recursive("{$pfb['ccdir_tmp']}");
+												return FALSE;
+											}
 										}
 										else {
 											// Create placeholder file for undefined 'ISO Represented' or undefined Countries
@@ -1464,6 +1475,7 @@ function pfblockerng_uc_countries() {
 	}
 	unset($pfb_geoip);
 	rmdir_recursive("{$pfb['ccdir_tmp']}");
+	return TRUE;
 }
 
 

--- a/tests/php/GeoipContinentCatStderrGuardTest.php
+++ b/tests/php/GeoipContinentCatStderrGuardTest.php
@@ -49,23 +49,33 @@ final class GeoipContinentCatStderrGuardTest extends TestCase
 			throw new RuntimeException('test bootstrap: failed to create tmp dir ' . self::$tmpDir);
 		}
 
-		// Oracle: the ISO-append exec() call itself, extracted verbatim so it
-		// tracks whichever form is actually in source -- with or without the
-		// trailing " 2>&1" -- proving red pre-fix, green post-fix.
+		// Oracle: the ISO-append status-handling block, extracted verbatim so
+		// the real command and its failure cleanup execute in this test.
 		if (!function_exists('pfb_cat_append_oracle')) {
 			if (!preg_match(
-				'/exec\("\{\$pfb\[\'cat\'\]\} \{\$iso_file_esc\} >> \{\$pfb_file_esc\}( 2>&1)?"\);/',
+				'/(?:\$cat_output\s*=\s*array\(\);\s*\$cat_status\s*=\s*0;\s*)?'
+				. 'exec\("\{\$pfb\[\'cat\'\]\} \{\$iso_file_esc\} >> \{\$pfb_file_esc\}( 2>&1)?"'
+				. '(?:,\s*\$cat_output,\s*\$cat_status)?\);'
+				. '(?:\s*if \(\$cat_status !== 0\) \{.*?return FALSE;\s*\})?/s',
 				$src,
 				$m
 			)) {
-				throw new RuntimeException('oracle extraction failed: the cat-append exec() call was not found in pfblockerng.php');
+				throw new RuntimeException('oracle extraction failed: the cat-append status block was not found in pfblockerng.php');
 			}
+			$block = str_replace(
+				['pfb_logger(', 'rmdir_recursive('],
+				['pfb_geoip_test_logger(', 'pfb_geoip_test_rmdir_recursive('],
+				$m[0]
+			);
 			eval(
-				'function pfb_cat_append_oracle(string $iso_file, string $pfb_file): void {'
-				. ' $pfb = ["cat" => "/bin/cat"];'
+				'function pfb_cat_append_oracle('
+				. 'string $iso_file, string $pfb_file, string $cat = "/bin/cat", string $iso = "US", string $type = "4"'
+				. '): bool {'
+				. ' $pfb = ["cat" => $cat, "ccdir_tmp" => dirname($pfb_file) . "/build_tmp"];'
 				. ' $iso_file_esc = escapeshellarg($iso_file);'
 				. ' $pfb_file_esc = escapeshellarg($pfb_file);'
-				. ' ' . $m[0]
+				. ' ' . $block
+				. ' return TRUE;'
 				. ' }'
 			);
 		}
@@ -77,6 +87,55 @@ final class GeoipContinentCatStderrGuardTest extends TestCase
 			is_dir($f) ? @rmdir($f) : @unlink($f);
 		}
 		@rmdir(self::$tmpDir);
+	}
+
+	private function makeCatFixture(string $name, string $body): string
+	{
+		$path = self::$tmpDir . '/' . $name;
+		file_put_contents($path, "#!/bin/sh\n{$body}");
+		chmod($path, 0755);
+		return $path;
+	}
+
+	public function testPartialStdoutFailureIsDiscardedAndReported(): void
+	{
+		$cat = $this->makeCatFixture('partial-cat', "printf 'partial-network\\n'\nexit 7\n");
+		$isoFile = self::$tmpDir . '/US_v4.txt';
+		$pfbFile = self::$tmpDir . '/continent_partial_v4.txt';
+		$buildTmp = self::$tmpDir . '/build_tmp';
+		pfb_geoip_test_rmdir_recursive($buildTmp);
+		mkdir($buildTmp);
+		file_put_contents($buildTmp . '/working', 'temporary');
+		file_put_contents($isoFile, "ignored\n");
+		file_put_contents($pfbFile, "# header\n");
+		$GLOBALS['pfb_geoip_test_logs'] = [];
+
+		$result = pfb_cat_append_oracle($isoFile, $pfbFile, $cat, 'US', '4');
+
+		$this->assertFalse($result);
+		$this->assertFileDoesNotExist($pfbFile, 'failed append must discard header plus partial stdout');
+		$this->assertDirectoryDoesNotExist($buildTmp, 'failed build must clean temporary state');
+		$this->assertSame([["\n Failed to append ISO data [ US IPv4 ] (cat status 7)\n", 4]], $GLOBALS['pfb_geoip_test_logs']);
+	}
+
+	public function testFailureWithoutStdoutIsDiscardedAndReported(): void
+	{
+		$cat = $this->makeCatFixture('silent-cat', "exit 9\n");
+		$isoFile = self::$tmpDir . '/CA_v6.txt';
+		$pfbFile = self::$tmpDir . '/continent_silent_v6.txt';
+		$buildTmp = self::$tmpDir . '/build_tmp';
+		pfb_geoip_test_rmdir_recursive($buildTmp);
+		mkdir($buildTmp);
+		file_put_contents($isoFile, "ignored\n");
+		file_put_contents($pfbFile, "# header\n");
+		$GLOBALS['pfb_geoip_test_logs'] = [];
+
+		$result = pfb_cat_append_oracle($isoFile, $pfbFile, $cat, 'CA', '6');
+
+		$this->assertFalse($result);
+		$this->assertFileDoesNotExist($pfbFile);
+		$this->assertDirectoryDoesNotExist($buildTmp);
+		$this->assertSame([["\n Failed to append ISO data [ CA IPv6 ] (cat status 9)\n", 4]], $GLOBALS['pfb_geoip_test_logs']);
 	}
 
 	public function testCatFailureOnUnreadableIsoDoesNotCorruptContinentFile(): void
@@ -91,18 +150,12 @@ final class GeoipContinentCatStderrGuardTest extends TestCase
 		$this->assertTrue(file_exists($isoDir), 'fixture must pass the file_exists() guard at line 1412 unchanged');
 
 		$pfbFile = self::$tmpDir . '/continent_v4.txt';
-		touch($pfbFile);
-		$this->assertSame('', file_get_contents($pfbFile), 'fixture must start empty');
+		file_put_contents($pfbFile, "# partial continent output\n");
 
-		pfb_cat_append_oracle($isoDir, $pfbFile);
+		$result = pfb_cat_append_oracle($isoDir, $pfbFile);
 
-		$content = file_get_contents($pfbFile);
-		$this->assertNotFalse($content, 'destination file must remain readable after the exec() call');
-		$this->assertSame(
-			'',
-			$content,
-			"issue #1299: cat's stderr leaked into the continent data file -- expected '' but got " . var_export($content, TRUE)
-		);
+		$this->assertFalse($result, 'cat failure must be reported to the conversion caller');
+		$this->assertFileDoesNotExist($pfbFile, 'failed conversion must discard partial continent output');
 	}
 
 	public function testCatAppendExecDoesNotMergeStderrIntoDataFile(): void
@@ -111,7 +164,8 @@ final class GeoipContinentCatStderrGuardTest extends TestCase
 		// source string -- keeps the failure diff readable (the whole-source
 		// form dumps ~2700 lines on failure).
 		if (!preg_match(
-			'/exec\("\{\$pfb\[\'cat\'\]\} \{\$iso_file_esc\} >> \{\$pfb_file_esc\}( 2>&1)?"\);/',
+			'/exec\("\{\$pfb\[\'cat\'\]\} \{\$iso_file_esc\} >> \{\$pfb_file_esc\}( 2>&1)?"'
+			. '(?:,\s*\$cat_output,\s*\$cat_status)?\);/',
 			self::$src,
 			$m
 		)) {
@@ -123,4 +177,79 @@ final class GeoipContinentCatStderrGuardTest extends TestCase
 			"issue #1299: the continent-file cat append must not redirect cat's stderr (2>&1) into the data file -- got: {$m[0]}"
 		);
 	}
+
+	/** @return array<string, array{string}> */
+	public static function ipVersionProvider(): array
+	{
+		return [
+			'IPv4' => ['v4'],
+			'IPv6' => ['v6'],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('ipVersionProvider')]
+	public function testCatSuccessAppendsNetworksAndReportsTrue(string $type): void
+	{
+		$isoFile = self::$tmpDir . "/US_{$type}.txt";
+		$pfbFile = self::$tmpDir . "/continent_{$type}_success.txt";
+		file_put_contents($isoFile, "network-{$type}\n");
+		file_put_contents($pfbFile, "# header {$type}\n");
+
+		$this->assertTrue(pfb_cat_append_oracle($isoFile, $pfbFile));
+		$this->assertSame("# header {$type}\nnetwork-{$type}\n", file_get_contents($pfbFile));
+	}
+
+	public function testBuilderReportsSuccessAfterAllContinentRows(): void
+	{
+		$this->assertMatchesRegularExpression(
+			'/rmdir_recursive\("\{\$pfb\[\'ccdir_tmp\'\]\}"\);\s*return TRUE;\s*}/',
+			self::$src,
+			'pfblockerng_uc_countries() must report successful completion to paired callers'
+		);
+	}
+
+	public function testDcAndDccGateCountryGenerationOnConversionSuccess(): void
+	{
+		$this->assertMatchesRegularExpression(
+			'/case \'dc\':.*?case \'dcc\':.*?if \(pfblockerng_uc_countries\(\)\) \{\s*pfblockerng_get_countries\(\);\s*}/s',
+			self::$src
+		);
+	}
+
+	public function testUgcGatesCountryGenerationOnConversionSuccess(): void
+	{
+		$this->assertMatchesRegularExpression(
+			'/case \'ugc\':\s*if \(pfblockerng_uc_countries\(\)\) \{\s*pfblockerng_get_countries\(\);\s*}/s',
+			self::$src
+		);
+	}
+
+	public function testStandaloneUcAndGcDispatchRemainIndependent(): void
+	{
+		$this->assertMatchesRegularExpression(
+			'/case \'uc\':.*?pfblockerng_uc_countries\(\);\s*break;\s*case \'gc\':.*?pfblockerng_get_countries\(\);\s*break;/s',
+			self::$src
+		);
+	}
+
+	public function testCountryBuildUsesSameAppendGuardForIpv4AndIpv6(): void
+	{
+		$this->assertMatchesRegularExpression(
+			'/foreach \(array\(\'4\', \'6\'\) as \$type\).*?' . preg_quote('exec("{$pfb[\'cat\']} {$iso_file_esc} >> {$pfb_file_esc}"', '/') . '/s',
+			self::$src
+		);
+	}
+}
+
+function pfb_geoip_test_logger(string $message, int $level): void
+{
+	$GLOBALS['pfb_geoip_test_logs'][] = [$message, $level];
+}
+
+function pfb_geoip_test_rmdir_recursive(string $path): void
+{
+	foreach (glob($path . '/*') ?: [] as $entry) {
+		is_dir($entry) ? pfb_geoip_test_rmdir_recursive($entry) : unlink($entry);
+	}
+	@rmdir($path);
 }

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -649,10 +649,11 @@ def test_geoip_pages_render_the_seeded_csv_rows(
     """Scenario: the GeoIP pages carry the SEEDED data, not just their chrome (issue #1219/#1228).
 
     Given the UI session seeded MaxMind's official test corpus and ran `ugc`,
-    When the GeoIP pages that carry seeded rows are fetched (the seven below; the other GeoIP
-         pages are covered for RENDER by PAGE_TABLE),
-    Then every needle below renders — and each one is produced by specific corpus rows, so
-         deleting them (or gutting a whole CSV) fails this test.
+    When `ugc` is rerun locally and the GeoIP pages that carry seeded rows are fetched (the
+         seven below; the other GeoIP pages are covered for RENDER by PAGE_TABLE),
+    Then the rerun adds no ISO-append failure marker and every needle below renders — and each
+         one is produced by specific corpus rows, so deleting them (or gutting a whole CSV)
+         fails this test.
 
     These assertions cannot live in ``PAGE_TABLE``: the render oracle matches markers with
     ``any()`` (``render_oracle.py``), and every GeoIP page already carries a data-INDEPENDENT
@@ -685,6 +686,24 @@ def test_geoip_pages_render_the_seeded_csv_rows(
       * Reputation's ``BT (1)`` — the same seeded data through a SEPARATE serialization path
                          (``pfb_build_reputation_tab()``), which the continent pages never touch
     """
+    marker = "Failed to append ISO data"
+    extras_log = "/var/log/pfblockerng/extras.log"
+
+    def append_failure_count() -> int:
+        result = smoke_vm.ssh("grep", "-Fc", marker, extras_log)
+        assert result.returncode in (0, 1), (
+            f"failed to count {marker!r} in {extras_log}: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+        return int(result.stdout.strip())
+
+    failures_before = append_failure_count()
+    ugc = smoke_vm.ssh(helpers.PHP_BIN, helpers.PFB_CLI, "ugc", timeout=600)
+    assert ugc.returncode == 0, f"fresh local ugc failed: rc={ugc.returncode} {ugc.stderr!r} {ugc.stdout!r}"
+    failures_after = append_failure_count()
+    assert failures_after == failures_before, (
+        f"fresh local ugc logged an ISO append failure: before={failures_before} after={failures_after}"
+    )
+
     expected: dict[str, tuple[str, ...]] = {
         "/pfblockerng/pfblockerng_Africa.php": ("Libya [2215636] LY (1)",),
         "/pfblockerng/pfblockerng_Asia.php": ("Bhutan [1252634] BT (1)",),
@@ -710,12 +729,6 @@ def test_geoip_pages_render_the_seeded_csv_rows(
                 f"{path} is missing the seeded-data needle {needle!r} — the GeoIP fixture row it "
                 f"pins never reached the render (page rendered, but on empty/incomplete data)"
             )
-
-    append_failure = smoke_vm.ssh("grep", "-F", "Failed to append ISO data", "/var/log/pfblockerng/extras.log")
-    assert append_failure.returncode == 1, (
-        "seeded ugc rendered complete GeoIP rows but logged an ISO append failure: "
-        f"rc={append_failure.returncode} {append_failure.stderr!r} {append_failure.stdout!r}"
-    )
 
 
 def test_general_page_keep_help_upgrade_warning(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:  # noqa: ARG001

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -643,7 +643,9 @@ def test_update_page_cron_status_without_flag_never_misreports_missing_cron(
             raise AssertionError(f"failed to restore {flag}: rc={touch.returncode} {touch.stderr!r}")
 
 
-def test_geoip_pages_render_the_seeded_csv_rows(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:  # noqa: ARG001
+def test_geoip_pages_render_the_seeded_csv_rows(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:  # noqa: ARG001
     """Scenario: the GeoIP pages carry the SEEDED data, not just their chrome (issue #1219/#1228).
 
     Given the UI session seeded MaxMind's official test corpus and ran `ugc`,
@@ -708,6 +710,12 @@ def test_geoip_pages_render_the_seeded_csv_rows(webui: WebUI, php_error_log_guar
                 f"{path} is missing the seeded-data needle {needle!r} — the GeoIP fixture row it "
                 f"pins never reached the render (page rendered, but on empty/incomplete data)"
             )
+
+    append_failure = smoke_vm.ssh("grep", "-F", "Failed to append ISO data", "/var/log/pfblockerng/extras.log")
+    assert append_failure.returncode == 1, (
+        "seeded ugc rendered complete GeoIP rows but logged an ISO append failure: "
+        f"rc={append_failure.returncode} {append_failure.stderr!r} {append_failure.stdout!r}"
+    )
 
 
 def test_general_page_keep_help_upgrade_warning(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:  # noqa: ARG001


### PR DESCRIPTION
Fixes #1324

Summary:
- capture the continent ISO append process status without merging stderr into feed data
- discard partial continent output and temporary build state after a failed append
- gate only paired dc/dcc and ugc country regeneration on successful conversion
- pair successful ugc output with exact Tier-A GeoIP render/log coverage

Verification:
- frozen RED/GREEN proof passed against 64cf3769332a6340e2356b956a3f9ec2b7e6d1db
- focused GeoIP guard: 11 tests, 22 assertions
- full PHPUnit: 3,580 tests, 21,794 assertions, 4 skipped
- full pytest, Ruff, mypy, PHPStan, PHPCS, syntax, and canonical gates passed
- exact-head Tier-A ui_render: 137 passed, 287 deselected; leased run local-100033-1784199570-2bcd4ac0a5d51c57 on root@10.0.0.33

Audit:
- signed head: 3ca33137b733fc15ea3c7e1b956cec19bb9c4d52
- signed production commit: db0af3df159f3e36523047c5511c206913af12cc
- test freeze: eb3eb4779e61040dc8dc2607c9d463c82824a637
- successful v4/v6 append bytes and standalone uc/gc dispatch remain unchanged

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.