### PR TITLE
ci: exempt vendored agent skill scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,9 @@ jobs:
           }
           bad=$(git ls-files | grep -v -e '^\.claude/skills/ponytail/' -e '^\.claude/skills/caveman/' \
             -e '^\.claude/skills/diagnosing-bugs/' -e '^\.claude/skills/git-guardrails-claude-code/' \
-            -e '^\.claude/skills/wizard/' | find_bash_shebangs)
+            -e '^\.claude/skills/wizard/' \
+            -e '^\.agents/skills/diagnosing-bugs/' -e '^\.agents/skills/git-guardrails-claude-code/' \
+            -e '^\.agents/skills/wizard/' | find_bash_shebangs)
           if [ -n "$bad" ]; then
             echo "bash shebang not allowed (use #!/bin/sh):"; echo "$bad"; exit 1
           fi


### PR DESCRIPTION
## Summary

- mirror the pre-commit Bash-shebang exclusions for the migrated `.agents` copies of three vendored skill trees
- keep the exemption limited to `diagnosing-bugs`, `git-guardrails-claude-code`, and `wizard`
- unblock the base-wide ShellCheck gate for #1395 and #1413 without changing their code

## Evidence

- RED on `64cf3769`: the workflow-equivalent scan reported the Bash assets under `.agents/skills/diagnosing-bugs/` and `.agents/skills/git-guardrails-claude-code/`
- GREEN: the same scan passes after matching `.githooks/pre-commit`
- `actionlint .github/workflows/test.yml`
- `sh scripts/agent/check-agent-config-parity.sh` — 58 skills and 6 workflows mapped
- `sh scripts/agent/run-gates.sh --diff origin/devel` — PASS

No broader import, refactor, or runtime change is included.

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
