### PR TITLE
agents: capture token-savior-recall MCP tool outputs too

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,7 +62,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|WebFetch|Read|Grep|mcp__playwright__.*",
+        "matcher": "Bash|WebFetch|Read|Grep|mcp__playwright__.*|mcp__token-savior-recall__.*",
         "hooks": [
           {
             "type": "command",

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -34,7 +34,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "^(Bash|mcp__playwright__.*)$",
+        "matcher": "^(Bash|mcp__playwright__.*|mcp__token-savior-recall__.*)$",
         "hooks": [
           {
             "type": "command",

--- a/docs/misc/codex-migration.md
+++ b/docs/misc/codex-migration.md
@@ -60,7 +60,7 @@ This is the only synchronization boundary:
 | `PreToolUse` Git policy | `.codex/hooks.json` | Reuses the raw-payload-compatible shared guard for Codex `Bash` hook events; coverage remains subject to the client emitting that event for unified shell execution. |
 | `PreToolUse` retired-token notice | `.codex/hooks.json` | Reuses `check_retired_tokens.py --claude-hook` for the same supported `Bash` event surface. |
 | `SessionStart` branch synchronization | `.codex/hooks.json` | Runs on startup/resume/clear and shares the same branch script. |
-| Token Savior MCP and capture hook | `.codex/config.toml` plus `.codex/hooks.json` | Uses the same pinned `andrebrait/token-savior` launcher and capture wrapper as Claude, with the client label set to `codex`. Current Codex hooks expose `Bash`, `apply_patch`, and MCP tool-name matching, not Claude-style Read/Grep/WebFetch events, so this config requests best-effort capture for `Bash` and Playwright MCP output only; it never captures Token Savior itself or unrelated MCP servers. |
+| Token Savior MCP and capture hook | `.codex/config.toml` plus `.codex/hooks.json` | Uses the same pinned `andrebrait/token-savior` launcher and capture wrapper as Claude, with the client label set to `codex`. Current Codex hooks expose `Bash`, `apply_patch`, and MCP tool-name matching, not Claude-style Read/Grep/WebFetch events, so this config requests best-effort capture for `Bash`, Playwright, and `token-savior-recall` MCP output only; it never captures unrelated MCP servers. |
 | Ponytail and Caveman | Real Codex plugins | Installed directly (`codex plugin marketplace add …` / `npx skills add … -a codex`), not vendored into the repo. |
 
 The shared Git hooks recognize both `CLAUDECODE=1` and Codex's

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -98,8 +98,13 @@ Describe 'Token Savior vendor wiring'
     The status should be success
   End
 
-  It 'requests only supported Bash and Playwright MCP capture events in Codex'
-    When run python3 -c 'import json, re, sys; groups=json.load(open(sys.argv[1]))["hooks"]["PostToolUse"]; pattern=next(g["matcher"] for g in groups if any("tool_capture_hook" in h["command"] for h in g["hooks"])); approved=("Bash", "mcp__playwright__browser_snapshot"); rejected=("Read", "Grep", "WebFetch", "apply_patch", "PrefixBash", "BashSuffix", "mcp__token-savior-recall__capture_get", "mcp__github__get_file_contents", "mcp__other__read"); assert all(re.search(pattern, name) for name in approved); assert not any(re.search(pattern, name) for name in rejected)' "${PFB_ROOT}/.codex/hooks.json"
+  It 'captures Claude tool and token-savior-recall output without blanket MCP matching'
+    When run python3 -c 'import json, re, sys; groups=json.load(open(sys.argv[1]))["hooks"]["PostToolUse"]; pattern=next(g["matcher"] for g in groups if any("tool_capture_hook" in h["command"] for h in g["hooks"])); approved=("Bash", "Read", "Grep", "WebFetch", "mcp__playwright__browser_snapshot", "mcp__token-savior-recall__search_codebase", "mcp__token-savior-recall__get_full_context"); rejected=("mcp__github__get_file_contents", "mcp__other__read"); assert all(re.search(pattern, name) for name in approved); assert not any(re.search(pattern, name) for name in rejected)' "${PFB_ROOT}/.claude/settings.json"
+    The status should be success
+  End
+
+  It 'requests only supported Bash, Playwright, and token-savior-recall capture events in Codex'
+    When run python3 -c 'import json, re, sys; groups=json.load(open(sys.argv[1]))["hooks"]["PostToolUse"]; pattern=next(g["matcher"] for g in groups if any("tool_capture_hook" in h["command"] for h in g["hooks"])); approved=("Bash", "mcp__playwright__browser_snapshot", "mcp__token-savior-recall__search_codebase", "mcp__token-savior-recall__get_full_context"); rejected=("Read", "Grep", "WebFetch", "apply_patch", "PrefixBash", "BashSuffix", "mcp__github__get_file_contents", "mcp__other__read"); assert all(re.search(pattern, name) for name in approved); assert not any(re.search(pattern, name) for name in rejected)' "${PFB_ROOT}/.codex/hooks.json"
     The status should be success
   End
 End


### PR DESCRIPTION
## What

Widen the token-savior `tool_capture` PostToolUse matchers — in `.claude/settings.json` and `.codex/hooks.json` — to also cover the `token-savior-recall` MCP tools (`mcp__token-savior-recall__.*`).

## Why

The capture hook sandboxes large tool outputs to `ts://capture/{id}` so they survive context compaction. The matchers covered Bash/WebFetch/Read/Grep and playwright tools, but not the token-savior-recall MCP tools themselves (`search_codebase`, `get_function_source`, `get_full_context`, ...), whose outputs are routinely large — exactly the class the sandbox exists for.

Upstream's `ts init` templates had the same defect with a different spelling (`mcp__token-savior__*`, matching no live tool name); fixed upstream in Mibayy/token-savior#64. This repo wires the hooks through its own committed configs, so it needs the equivalent one-line widening in each.

## Verification

Config-only diff (two matcher lines). Both files parse (`python3 -c "import json; json.load(...)"` on each). The widened Claude matcher is live in the session that authored this PR — token-savior-recall tool outputs get `[token-savior:capture] ... sandboxed to ts://capture/{id}` PostToolUse context; Codex matcher is the same regex applied by the same `scripts/ts-hook.sh` entrypoint. Codex hook schema (event name, `tool_name: "Bash"` normalization, matcher semantics) verified live against codex-cli 0.144.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guidance to reflect capture support for Token Savior recall output alongside Bash and Playwright.

* **Bug Fixes**
  * Improved post-tool capture matching for Token Savior recall operations while excluding unrelated tool events.

* **Tests**
  * Added coverage validating Claude and Codex capture behavior and filtering unsupported event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->