### PR TITLE
scripts: bump token-savior pin to 49c5c2d (CLAUDE_CONFIG_DIR fix)

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -9,6 +9,6 @@ max_depth = 2
 
 [mcp_servers.token-savior-recall]
 command = "sh"
-args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" d08ac01fdfa4a6c5a499038df61c1685acd953c082d8890dc74fede2003b1c8e && exec sh "$root/scripts/mcp-token-savior.sh"''']
+args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" f2a5b41ad8465b4d60afb4f7814e85c510e0ff0608be4cdd1c37c9eacdb7664c && exec sh "$root/scripts/mcp-token-savior.sh"''']
 env = { TOKEN_SAVIOR_CLIENT = "codex" }
 startup_timeout_sec = 120

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -4,7 +4,7 @@
 # Installs TS_SOURCE into a per-user cached venv, then execs it. The default TS_SOURCE is the
 # andrebrait/token-savior fork's `integration` branch pinned by commit — it carries fixes and
 # language support not yet merged upstream (Mibayy/token-savior PRs #47 #53 #54 #57 #58 #59
-# #60 #62); repoint to PyPI's token-savior-recall[mcp,memory-vector] once those merge. A TS_SOURCE change (e.g. a
+# #60 #62 #64 #66); repoint to PyPI's token-savior-recall[mcp,memory-vector] once those merge. A TS_SOURCE change (e.g. a
 # new pinned commit) is detected via the .pfb-ts-source stamp and triggers a clean venv rebuild;
 # a mkdir lock serializes concurrent sessions racing that rebuild (the venv is one shared
 # per-user cache). Requires python3 >= 3.11 and git (pip installs from a git URL).
@@ -43,7 +43,7 @@ if [ "$venv_bad" = 1 ]; then
 fi
 bin="$venv/bin/token-savior"
 stamp="$venv/.pfb-ts-source"
-TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp,memory-vector] @ git+https://github.com/andrebrait/token-savior@0fd6ed140d5d3732349552e14d969b2ceb5b4da7}"
+TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp,memory-vector] @ git+https://github.com/andrebrait/token-savior@49c5c2d6b57df77343112a5d00219bdbcb9e2a0a}"
 
 # stdout is the MCP stdio channel — install chatter must stay on stderr
 if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then


### PR DESCRIPTION
Advances the `andrebrait/token-savior` `integration` pin from `0fd6ed1` to `49c5c2d`, picking up two fork commits:

- portable `ts init` hook commands + real Codex `hooks.json` schema (upstream [Mibayy/token-savior#64](https://github.com/Mibayy/token-savior/pull/64))
- `CLAUDE_CONFIG_DIR` support in `ts init` global scope and transcript discovery (upstream [Mibayy/token-savior#66](https://github.com/Mibayy/token-savior/pull/66), fixes [Mibayy/token-savior#65](https://github.com/Mibayy/token-savior/issues/65))

The launcher's SHA-256 integrity pin in `.codex/config.toml` is updated to match the edited script.

## Verification (all executed)

- Full token-savior suite on the pinned commit: 1919 passed, 2 skipped.
- `shellspec tests/shell/mcp_token_savior_spec.sh` under dash: 21 examples, 0 failures.
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS (sh -n, shellcheck, shellspec).
- Launcher exercised against a throwaway `TS_VENV`: installs the new pin, stamp matches, `token_savior` imports, server binary present; `settings_path('claude','global')` and `transcript_root()` honor `CLAUDE_CONFIG_DIR` in the installed package.
- Codex integrity command re-run against the edited launcher with the new hash: pass.
- Tree-wide grep for the retired pin `0fd6ed1` and old launcher hash `d08ac01f`: zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)