### PR TITLE
agents: add shared role-family contract with cross-vendor parity check

### DIFF
--- a/.agents/policy/agent-roles.md
+++ b/.agents/policy/agent-roles.md
@@ -1,0 +1,304 @@
+# Agent role families — shared contract
+
+- **Scope:** vendor-neutral agent role families for Claude and Codex: what each role is
+  for, what it may read and mutate, what it must return, and which model tier serves it
+  (issue [#1387](https://github.com/pfBlockerNG/pfBlockerNG/issues/1387); companion to
+  the fresh-session ticket workflow in [`workflow.md`](workflow.md)).
+- **Load-when:** defining or routing an agent role; changing `.codex/agents/`,
+  `.claude/workflows/` model pins, `.agents/model-tiers.conf`, or this registry.
+- **Owner:** repo owner. **Last-verified:** 2026-07-16.
+
+## Goal
+
+One semantic contract per role family, mapped explicitly onto each vendor's native
+definitions, so both clients stay behaviorally aligned without identical files, models,
+tools, or wording. Context-window pollution is the enemy: a role loads its purpose-built
+context slice (its contract section plus the packet's Required reading), never the whole
+policy corpus.
+
+## Fixed constraints
+
+- Tier vocabulary is **top / mid / small** from
+  [`.agents/model-tiers.conf`](../model-tiers.conf). The contract names tiers, never
+  vendor model ids; a tier selects the model, and procedures set effort independently.
+- Expensive tiers require evidence (see Tier economics).
+- The delegation contract (CLAUDE.md: brief → handoff → gate) and the task-packet /
+  checkpoint schemas ([`workflow.md`](workflow.md)) bind every role unchanged; a role
+  contract may narrow them, never weaken them.
+- `scripts/check_agent_roles.py` validates the registry below against both vendors'
+  definitions if and only if either side changes (pre-commit + CI). It checks semantic
+  fields — tier vocabulary, mutation boundaries, binding targets, model-tier pins —
+  never textual identity, so vendor-native wording stays free.
+
+## Tier economics (Sol/Luna discipline, both vendors)
+
+- **small** is the default executor tier: implementation, verification, review, triage,
+  publishing, and coordination all start small.
+- **top** requires a named routing trigger: planning/gating substantial work; whole-PR
+  review of a large/complex PR (>300 lines, >6 files, or `src/`
+  parsing/guard/scheduling behaviour); verdict-quality triage of a complex issue.
+  Mid-task escalation additionally requires documented evidence **in the ticket** — a
+  failed executed attempt, a falsified packet premise, or cross-cutting design surfaced
+  mid-step; "feels hard" is not evidence ([`workflow.md`](workflow.md) "Model escalation
+  and risk triggers").
+- **mid** is a fallback tier only: it substitutes when top is unavailable (planning), or
+  runs as the second pass of the documented dual-review fallback — never a sole
+  reviewer, never a default route.
+
+## Role registry (machine-readable)
+
+`scripts/check_agent_roles.py` parses this table. Column vocabularies: **Tiers** —
+`top`/`mid`/`small`, primary (default) tier first, `+`-separated; **Mutation** —
+`read-only`/`workspace-write`; **Independent** — `yes`/`no`; **bindings** —
+comma-separated `kind:name` (Claude kinds: `workflow` = `.claude/workflows/<name>.js`,
+`skill` = `.agents/skills/<name>/`, `policy` = `.agents/policy/<name>`, `session` =
+the top-level session itself; Codex kinds: `agent` = `.codex/agents/<name>.toml`, plus
+`skill`/`policy`/`session` as for Claude).
+
+<!-- role-registry:begin -->
+
+| Role | Tiers | Mutation | Independent | Claude bindings | Codex bindings |
+| ---- | ----- | -------- | ----------- | --------------- | -------------- |
+| explorer | small+top | read-only | no | workflow:adr-investigate, workflow:issue-triage | agent:analyst, agent:analyst-top |
+| planner | top+mid | read-only | no | session | agent:planner |
+| implementer | small | workspace-write | no | workflow:phase-step | agent:implementer |
+| verifier | small | read-only | yes | workflow:phase-step, workflow:triage-findings | agent:adversarial-reviewer |
+| reviewer | small+top+mid | read-only | yes | workflow:review-single, workflow:review-fanout | agent:adversarial-reviewer, agent:adversarial-reviewer-top, agent:adversarial-reviewer-mid |
+| publisher | small | workspace-write | no | skill:pr-merge-flow | skill:pr-merge-flow |
+| coordinator | small | workspace-write | no | policy:workflow.md | policy:workflow.md |
+
+<!-- role-registry:end -->
+
+## Role contracts
+
+### explorer
+
+- **Purpose & routing:** read-only investigation with cited evidence — locate code,
+  gather facts, triage an issue, run an ADR investigation fan-out. Route here when the
+  outcome is a report, never an edit.
+- **Inputs & task packet:** a scoped question or issue, a worktree path, and the output
+  schema; Required reading as `file:line`/doc pointers, never pasted bodies.
+- **Outputs & evidence:** the requested schema, with every load-bearing fact tagged
+  verified (command + output) or ASSUMED; never a different planning artifact.
+- **Permissions & mutation:** read-only. May run read-only commands (grep, `git log`,
+  `gh` reads); never edits, commits, pushes, or changes labels.
+- **Context & skills:** the packet plus its named refs; code-search tooling. Not the
+  full policy corpus.
+- **Stop & escalation:** a packet premise contradicted by source ⇒ STOP and return a
+  structured blocker; an under-specified scope ⇒ route `needs-info`.
+- **Independence:** not required — it serves its caller.
+- **Tier intent:** small by default; top for verdict-quality triage of a complex issue
+  or an evidence-heavy cross-cutting investigation. Never mid.
+
+### planner
+
+- **Purpose & routing:** decompose substantial work into bounded steps, author the
+  brief/task packet (coverage matrix and hostile-input rows enumerated from source),
+  and gate every delegated step mechanically. Route: substantial multi-step
+  `src/`/`tests/`/CI work, ADR design, ambiguity forks.
+- **Inputs & task packet:** the work item (issue, ADR, map ticket), the live tree, and
+  the policy annexes the item touches.
+- **Outputs & evidence:** the brief (mandatory sections per the delegation contract),
+  the per-step gate record, and HALT/continue decisions — each check an executed
+  command with pasted output.
+- **Permissions & mutation:** read-only as the role: briefs and gates, not edits. The
+  session hosting it may switch roles in place — implementer for a small direct fix or
+  docs/config/skills work (CLAUDE.md carve-out), publisher/coordinator for landing and
+  bookkeeping — but the planner never grades its own implementation work.
+- **Context & skills:** CLAUDE.md and its annexes, the ADR directory, prior handoffs;
+  delegation skills (`/adr-phase`, `/gh-issue`, `/delegate`).
+- **Stop & escalation:** a genuine user fork ⇒ ask the user; a falsified premise ⇒ stop
+  and re-plan, loudly. Never silently patch the plan.
+- **Independence:** not independent of the work item, but producer≠gater: the per-step
+  verifier and PR reviewer are always different agents.
+- **Tier intent:** top — every downstream artifact leans on the brief, and brief bugs
+  demonstrably ship defects; mid only as the documented fallback when top is
+  unavailable.
+
+### implementer
+
+- **Purpose & routing:** execute exactly one approved brief/packet in the assigned
+  worktree. Two weights, one contract: **full** (default) and **light** — a
+  behaviour-preserving mechanical step pinned by an earlier gate-passed oracle, run
+  without a planning/reconcile wrapper (this is the issue's "quick implementer";
+  same permissions and evidence schema, smaller scope).
+- **Inputs & task packet:** THE BRIEF (mandatory sections) plus the prior step's
+  handoff. Trust the brief — no re-investigating its evidence.
+- **Outputs & evidence:** THE HANDOFF, fixed fields: verdict, what changed, gate
+  commands + output tails, red→green proof (executed, test-first, frozen), coverage
+  matrix ticks, deviations, carry-forward.
+- **Permissions & mutation:** workspace-write inside its worktree; commits as directed.
+  Never pushes protected branches, never merges, never edits the brief or policy.
+- **Context & skills:** the brief, its named refs, the code it edits, and the language
+  annex for the touched file types — nothing broader.
+- **Stop & escalation:** the ESCALATE contract — a contradicted premise or a mechanism
+  the brief never named ⇒ BLOCKED (or DONE-WITH-DEVIATION), never plain DONE; at most
+  2 executed attempts per step, then checkpoint and escalate citing both runs.
+- **Independence:** none; accountability stays with the spawner. May re-delegate a
+  genuine split, never the whole brief.
+- **Tier intent:** small, always. A higher tier mid-step requires documented evidence
+  in the ticket.
+
+### verifier
+
+- **Purpose & routing:** independently re-derive one completed step: re-run the gates,
+  re-execute the red→green proof, read the full diff against every plan item and
+  coverage row, audit test honesty and conventions. Route: after every delegated step,
+  before the next starts.
+- **Inputs & task packet:** the brief, the handoff, the diff, and the canonical gate
+  commands.
+- **Outputs & evidence:** the gate-record fields — commands + results, red/green
+  evidence, per-item diff verdicts, matrix confirmation, and an explicit SKIPPED list.
+- **Permissions & mutation:** read-only on sources; may execute gates and tests
+  ephemerally. Never patches a finding — defects route back to the planner.
+- **Context & skills:** the brief + handoff + diff and the canonical gate table;
+  deliberately not the implementer's transcript.
+- **Stop & escalation:** any defect or unnamed mechanism in the diff ⇒ reject the step;
+  a check it cannot run is recorded SKIPPED with the reason, never silently dropped.
+- **Independence:** required — never the agent (or model) that authored the brief or
+  the diff.
+- **Tier intent:** small, always (owner directive 2026-07-14): a different model reads
+  with different blind spots, and the step gate does not need the top tier.
+
+### reviewer
+
+- **Purpose & routing:** adversarial, execution-grounded review of a complete PR (or a
+  delta-scoped feedback fix). Route: every code PR; delta re-reviews after fix rounds.
+- **Inputs & task packet:** the PR number, base (a pre-fix SHA for delta re-reviews),
+  a worktree, and the intent/acceptance spec.
+- **Outputs & evidence:** schema-forced findings — severity, location, evidence,
+  reproduction — returned as review output; never an edited tree.
+- **Permissions & mutation:** read-only; may run discriminating probes and hostile
+  inputs. Never edits, commits, or downgrades a real pre-existing defect — those route
+  to a tracked follow-up.
+- **Context & skills:** the full diff plus surrounding code; the policy annexes the
+  diff touches.
+- **Stop & escalation:** the fix→re-review loop converges — it continues only while the
+  latest round has a blocking finding; hard cap 3 rounds, then a human decides.
+- **Independence:** required — a fresh context, never the author of the change.
+- **Tier intent:** small by default; top for a large/complex PR (whole-PR
+  cross-referencing is the point); mid only as the second pass of the documented
+  top-unavailable dual fallback, never a sole reviewer.
+
+### publisher
+
+- **Purpose & routing:** the commit-and-publish operator — mechanical landing:
+  rebase onto the live base, clean the diff, push, open the PR, keep labels in sync,
+  run bounded CI/review waits, merge only on instruction. Route: after gates and
+  review, when the remaining work is procedure, not judgment.
+- **Inputs & task packet:** the branch, the work item, and the landing instruction
+  (which flow, which labels, merge or stop-before-merge).
+- **Outputs & evidence:** the PR URL, label transitions, and merge/CI state — each
+  claim with its executed command + output tail.
+- **Permissions & mutation:** git/gh writes only — branch pushes, PR metadata, labels.
+  No new source changes beyond rebase conflict resolution; never force-push over
+  another session's PR; every wait is bounded and swept.
+- **Context & skills:** the `pr-merge-flow` / `pr-merge` / `pr-comments` skills and the
+  branch/release policy — not the implementation history.
+- **Stop & escalation:** the same CI failure cause twice after a fix attempt ⇒ stop and
+  checkpoint; a blocking review finding routes back to the planner, never a silent
+  self-fix.
+- **Independence:** not required.
+- **Tier intent:** small — procedure execution; never burn the top tier on waits.
+
+### coordinator
+
+- **Purpose & routing:** the low-cost ticket coordinator — shepherd the ticket
+  lifecycle: pick frontier tickets, claim before work, keep state labels honest, post
+  checkpoints, route `needs-info`/`ready-for-human`, dispatch workers with task
+  packets. Route: fresh-session ticket workflow sessions and label hygiene.
+- **Inputs & task packet:** the map/ticket state on GitHub — the durable execution
+  state; never a parent transcript.
+- **Outputs & evidence:** claims, structured checkpoints (all fields mandatory), label
+  transitions, and dispatched packets.
+- **Permissions & mutation:** GitHub metadata writes (labels, assignees, comments,
+  sub-issue/blocked-by relations). No source edits; never cancels a ticket without a
+  human; never overrides a human-set routing.
+- **Context & skills:** [`workflow.md`](workflow.md) plus the bootstrap routing rows —
+  deliberately minimal.
+- **Stop & escalation:** approaching compaction ⇒ checkpoint, unassign, terminate;
+  correctness-critical work never continues through compaction.
+- **Independence:** not required.
+- **Tier intent:** small — routing and bookkeeping. Escalation happens by dispatching a
+  planner, not by upgrading the coordinator.
+
+## Vendor mappings
+
+Behavioral equivalence, not surface parity: each client keeps its native orchestration
+as long as the role's semantic fields land as specified. Tier→model resolution always
+goes through [`model-tiers.conf`](../model-tiers.conf).
+
+### Claude
+
+| Role | Native definition |
+| ---- | ----------------- |
+| explorer | `.claude/workflows/adr-investigate.js` area readers and `.claude/workflows/issue-triage.js` (small default; top allowed for verdict quality); the harness `Explore` agent type for ad-hoc read-only fan-out |
+| planner | the top-level session itself (CLAUDE.md "Plan top-tier, implement small-tier"), including the `phase-step` Reconcile stage, which inherits the session model or an explicit `briefModel` |
+| implementer | `.claude/workflows/phase-step.js` Implement stage (pinned small); `/delegate` for ad-hoc briefs; `briefSpec.weight: 'light'` is the light variant |
+| verifier | `.claude/workflows/phase-step.js` Verify stage (pinned small, never the reconciler's model); `.claude/workflows/triage-findings.js` per-finding verifiers |
+| reviewer | `.claude/workflows/review-single.js` (small default; top for large/complex; mid only in the dual fallback); `.claude/workflows/review-fanout.js` on explicit user request |
+| publisher | `/pr-merge-flow` (with `/pr-merge`, `/pr-comments`) executed by the session or a small-tier delegate |
+| coordinator | the session following [`workflow.md`](workflow.md) |
+
+### Codex
+
+| Role | Native definition |
+| ---- | ----------------- |
+| explorer | `.codex/agents/analyst.toml` (small), `.codex/agents/analyst-top.toml` (top) |
+| planner | `.codex/agents/planner.toml` (top) |
+| implementer | `.codex/agents/implementer.toml` (small, workspace-write) |
+| verifier | `.codex/agents/adversarial-reviewer.toml` (small) |
+| reviewer | `.codex/agents/adversarial-reviewer.toml` (small), `.codex/agents/adversarial-reviewer-top.toml` (top), `.codex/agents/adversarial-reviewer-mid.toml` (mid, fallback second pass only) |
+| publisher | the `$pr-merge-flow` adapter (`.agents/skills/pr-merge-flow/`) |
+| coordinator | the session following [`workflow.md`](workflow.md) |
+
+## Decisions
+
+Deviations from issue #1387's starting six, with rationale:
+
+- **quick implementer merged into implementer** as the `light` weight: identical
+  permissions, evidence schema, and escalation contract; it differs only in scope cap
+  and skipped wrapping stages. The repo already models this as a routing parameter
+  (`WEIGHT: light` phases), and Codex defines one implementer role.
+- **planner added**: the de-facto top-tier role both vendors already define
+  (`.codex/agents/planner.toml`; the Claude session + Reconcile stage). The expensive
+  tier needs an explicit contract precisely because it is expensive.
+- **code reviewer split into verifier + reviewer**: different outputs (gate record vs
+  findings schema) and different tier routing (the verifier is pinned small by owner
+  directive; the reviewer escalates to top for large/complex PRs). Both stay
+  independent and read-only; Codex serves both from the `adversarial-reviewer` family.
+- **code explorer kept** (named `explorer`), covering evidence gathering, triage, and
+  investigation fan-outs — the Codex `analyst` family.
+- **publisher and coordinator kept**, bound to a skill and a policy document rather
+  than a dedicated vendor agent: both are procedure-driven small-tier roles a session
+  fills by loading one document, and neither vendor needs a separate agent definition
+  for them.
+- **The shell discovery guard stays.** `scripts/agent/check-agent-config-parity.sh`
+  keeps skill/workflow adapter parity, `model-tiers.conf` syntax, and its fast
+  pre-commit Codex role→tier pins; `scripts/check_agent_roles.py` owns the
+  registry-driven cross-vendor role semantics. The overlapping pins fail loudly on
+  divergence — folding them is deliberately deferred until the registry has bedded in.
+
+## Acceptance criteria
+
+- Every registry role has a contract section carrying all eight semantic fields, and
+  explicit Claude and Codex bindings that resolve to real files (or `session`).
+- `scripts/check_agent_roles.py --all` passes on the tree; it fails loudly when a
+  vendor definition drifts from the registry (retiered model pin, sandbox/mutation
+  mismatch, orphaned vendor role, missing contract field) while tolerating any
+  vendor-native wording difference.
+- The check runs if and only if a role surface changes: self-scoped `--staged` in
+  pre-commit and `--diff <base>` in CI.
+
+## Out of scope
+
+- Per-role context-slice documents (splitting CLAUDE.md into role-specific required
+  reading) — tracked by the wayfinder map
+  [#1383](https://github.com/pfBlockerNG/pfBlockerNG/issues/1383).
+- Effort-level policy: tiers select models; procedures own their effort settings.
+- Skill/workflow adapter parity and symlink integrity — already owned by
+  `scripts/agent/check-agent-config-parity.sh`.
+
+## Open forks
+
+- None.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -288,6 +288,18 @@ else
 	skip retired-tokens
 fi
 
+# --- Agent role-family parity (issue #1387): the shared role registry
+#     (.agents/policy/agent-roles.md) vs both vendors' role definitions. The
+#     checker self-scopes: it validates iff the staged diff touches a role
+#     surface (registry doc, model-tiers.conf, .codex/agents/,
+#     .claude/workflows/, .agents/skills/); otherwise it reports the skip. ---
+if [ -n "$py_bin" ]; then
+	step 'agent-roles (role registry vs vendor role definitions)'
+	"$py_bin" scripts/check_agent_roles.py --staged || failed 'agent-roles'
+else
+	skip agent-roles
+fi
+
 # --- ADR phase prompts: post-contract prompts (ADR >= 60) must carry the
 #     delegation-contract blocks (VERIFICATION, HANDOFF->RESULTS, test mode,
 #     reality-override). Older ADRs are grandfathered by the script itself. ---

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -291,7 +291,7 @@ fi
 # --- Agent role-family parity (issue #1387): the shared role registry
 #     (.agents/policy/agent-roles.md) vs both vendors' role definitions. The
 #     checker self-scopes: it validates iff the staged diff touches a role
-#     surface (registry doc, model-tiers.conf, .codex/agents/,
+#     surface (.agents/policy/, model-tiers.conf, .codex/agents/,
 #     .claude/workflows/, .agents/skills/); otherwise it reports the skip. ---
 if [ -n "$py_bin" ]; then
 	step 'agent-roles (role registry vs vendor role definitions)'

--- a/.github/workflows/agent-roles.yml
+++ b/.github/workflows/agent-roles.yml
@@ -1,0 +1,43 @@
+# Agent role-family parity (issue #1387) — a standalone workflow, NOT a test.yml
+# job: test.yml's global `paths-ignore` ('**/*.md') would skip that entire
+# workflow for an md-only change to the registry doc
+# (.agents/policy/agent-roles.md) — the exact file this gate guards. The `paths`
+# list mirrors scripts/check_agent_roles.py's trigger surfaces and is pinned by
+# tests/test_agent_roles_check.py::test_ci_workflow_paths_match_checker_triggers.
+# Semantic fields only — tier vocabulary, mutation boundaries, binding targets,
+# model pins — never textual identity.
+name: Agent roles
+
+on:
+  pull_request:
+    paths:
+      - '.agents/policy/agent-roles.md'
+      - '.agents/model-tiers.conf'
+      - 'scripts/check_agent_roles.py'
+      - '.codex/agents/**'
+      - '.claude/workflows/**'
+      - '.agents/skills/**'
+      - '.agents/policy/**'
+
+permissions:
+  contents: read
+
+jobs:
+  agent-roles:
+    name: Agent roles (role registry vs vendor role definitions)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need the merge-base with the PR base ref for the three-dot diff
+
+      - name: Validate the role registry against vendor role definitions
+        # ubuntu-latest ships python3 (3.11+ for tomllib). A deliberate model
+        # pin on an exempt line carries `roles-ok: <reason>`.
+        env:
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -eu
+          git fetch --no-tags origin "$BASE:refs/remotes/origin/$BASE"
+          python3 scripts/check_agent_roles.py --diff "origin/$BASE"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -514,6 +514,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
+        # Best-effort: the LTS-manifest fetch rides GitHub's API, which has served
+        # 503s for whole hours (2026-07-16). On failure the job proceeds on the
+        # runner image's preinstalled Node, which satisfies npx/node --test here.
+        continue-on-error: true
         uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
@@ -531,6 +535,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
+        # Best-effort: the LTS-manifest fetch rides GitHub's API, which has served
+        # 503s for whole hours (2026-07-16). On failure the job proceeds on the
+        # runner image's preinstalled Node, which satisfies npx/node --test here.
+        continue-on-error: true
         uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -757,35 +757,6 @@ jobs:
             exit "$rc"
           fi
 
-  # ── Agent role-family parity (issue #1387) ──
-  # PR-only, self-scoped: scripts/check_agent_roles.py validates the shared role
-  # registry (.agents/policy/agent-roles.md) against both vendors' role
-  # definitions IF AND ONLY IF the PR touches a role surface (registry doc,
-  # model-tiers.conf, .codex/agents/, .claude/workflows/, .agents/skills/);
-  # otherwise it reports the skip and passes. Semantic fields only — tier
-  # vocabulary, mutation boundaries, binding targets, model pins — never textual
-  # identity. On push it is skipped and folds into all-tests-passed as a pass,
-  # same shape as comment-narration above.
-  agent-roles:
-    name: Agent roles (role registry vs vendor role definitions)
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # need the merge-base with the PR base ref for the three-dot diff
-
-      - name: Validate the role registry against vendor role definitions
-        # ubuntu-latest ships python3 (3.11+ for tomllib). A deliberate model
-        # pin on an exempt line carries `roles-ok: <reason>`.
-        env:
-          BASE: ${{ github.event.pull_request.base.ref }}
-        run: |
-          set -eu
-          git fetch --no-tags origin "$BASE:refs/remotes/origin/$BASE"
-          python3 scripts/check_agent_roles.py --diff "origin/$BASE"
-
   # Single stable job name for branch-protection required-status-checks.
   # Must use if: always() so it runs (and fails) even when 'test' fails.
   all-tests-passed:
@@ -797,7 +768,7 @@ jobs:
     # The ADR-14 UI suite (`ui-suite`) IS folded in: it is skipped (== pass) on an
     # unlabeled PR / push, and only a `ui-tests`-labeled PR whose UI suite FAILS
     # blocks here — that is how the opt-in label gates a merge.
-    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, ui-suite, coverage-pairing, comment-narration, retired-tokens, agent-roles]
+    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, ui-suite, coverage-pairing, comment-narration, retired-tokens]
     runs-on: ubuntu-latest
     steps:
       - name: Check matrix results
@@ -879,11 +850,4 @@ jobs:
           case "${{ needs.retired-tokens.result }}" in
             success|skipped) ;;
             *) echo "Retired-token guard job errored or was cancelled."; exit 1 ;;
-          esac
-          # Agent role-family gate (issue #1387): 'skipped' (push, no PR base)
-          # is a PASS; a PR that drifts the role registry from either vendor's
-          # role definitions blocks here.
-          case "${{ needs.agent-roles.result }}" in
-            success|skipped) ;;
-            *) echo "Agent role-family gate (registry vs vendor role definitions) failed or was cancelled."; exit 1 ;;
           esac

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -514,7 +514,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
 
@@ -531,7 +531,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -757,6 +757,35 @@ jobs:
             exit "$rc"
           fi
 
+  # ── Agent role-family parity (issue #1387) ──
+  # PR-only, self-scoped: scripts/check_agent_roles.py validates the shared role
+  # registry (.agents/policy/agent-roles.md) against both vendors' role
+  # definitions IF AND ONLY IF the PR touches a role surface (registry doc,
+  # model-tiers.conf, .codex/agents/, .claude/workflows/, .agents/skills/);
+  # otherwise it reports the skip and passes. Semantic fields only — tier
+  # vocabulary, mutation boundaries, binding targets, model pins — never textual
+  # identity. On push it is skipped and folds into all-tests-passed as a pass,
+  # same shape as comment-narration above.
+  agent-roles:
+    name: Agent roles (role registry vs vendor role definitions)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need the merge-base with the PR base ref for the three-dot diff
+
+      - name: Validate the role registry against vendor role definitions
+        # ubuntu-latest ships python3 (3.11+ for tomllib). A deliberate model
+        # pin on an exempt line carries `roles-ok: <reason>`.
+        env:
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -eu
+          git fetch --no-tags origin "$BASE:refs/remotes/origin/$BASE"
+          python3 scripts/check_agent_roles.py --diff "origin/$BASE"
+
   # Single stable job name for branch-protection required-status-checks.
   # Must use if: always() so it runs (and fails) even when 'test' fails.
   all-tests-passed:
@@ -768,7 +797,7 @@ jobs:
     # The ADR-14 UI suite (`ui-suite`) IS folded in: it is skipped (== pass) on an
     # unlabeled PR / push, and only a `ui-tests`-labeled PR whose UI suite FAILS
     # blocks here — that is how the opt-in label gates a merge.
-    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, ui-suite, coverage-pairing, comment-narration, retired-tokens]
+    needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, ui-suite, coverage-pairing, comment-narration, retired-tokens, agent-roles]
     runs-on: ubuntu-latest
     steps:
       - name: Check matrix results
@@ -850,4 +879,11 @@ jobs:
           case "${{ needs.retired-tokens.result }}" in
             success|skipped) ;;
             *) echo "Retired-token guard job errored or was cancelled."; exit 1 ;;
+          esac
+          # Agent role-family gate (issue #1387): 'skipped' (push, no PR base)
+          # is a PASS; a PR that drifts the role registry from either vendor's
+          # role definitions blocks here.
+          case "${{ needs.agent-roles.result }}" in
+            success|skipped) ;;
+            *) echo "Agent role-family gate (registry vs vendor role definitions) failed or was cancelled."; exit 1 ;;
           esac

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,10 @@ prompts.
   large/complex whole-PR review uses `adversarial-reviewer-top`; its documented
   fallback pairs the small role with `adversarial-reviewer-mid`. The
   `$review-single` and `$review-fanout` adapters apply those roles to the shared
-  canonical review workflows.
+  canonical review workflows. The role-family semantics (purpose, permissions,
+  tier intent, bindings) live in
+  [`.agents/policy/agent-roles.md`](.agents/policy/agent-roles.md), validated by
+  `scripts/check_agent_roles.py` whenever a role surface changes.
 - For the shared worktree policy, `scripts/agent/work-branch.sh --worktree`
   resolves the primary checkout even from a Codex session worktree.
 - The Codex `SessionStart` hook runs the shared branch-freshness and visible

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,11 @@ effort value). The machine-readable mapping is `.agents/model-tiers.conf`: the
 **mid tier** means `claude-opus-4-8` and `gpt-5.6-terra`; the **small tier**
 means `claude-sonnet-5` and `gpt-5.6-luna`. A tier selects the model, not
 the effort knob: workflows still set their required effort independently.
+The role families built on these tiers (explorer, planner, implementer,
+verifier, reviewer, publisher, coordinator) are specified with their vendor
+bindings in [`.agents/policy/agent-roles.md`](.agents/policy/agent-roles.md);
+`scripts/check_agent_roles.py` keeps both vendors' definitions aligned
+whenever either side changes.
 
 Substantial coding work is **planned and gated by the top tier** (falling back
 to mid when top is unavailable) and **implemented by small-tier** sub-agents:

--- a/scripts/check_agent_roles.py
+++ b/scripts/check_agent_roles.py
@@ -12,7 +12,7 @@ retiered model pin, a sandbox/mutation mismatch, an orphaned vendor role, a
 missing contract field) fails loudly.
 
 CONDITIONAL: in --staged / --diff mode the full validation runs IF AND ONLY IF
-the change touches a role surface (the registry doc, .agents/model-tiers.conf,
+the change touches a role surface (.agents/policy/, .agents/model-tiers.conf,
 .codex/agents/, .claude/workflows/, .agents/skills/, or this checker); otherwise
 it reports the skip and exits 0. --all validates unconditionally.
 
@@ -48,15 +48,15 @@ _POLICY = ".agents/policy"
 # Role surfaces: full validation triggers iff a changed path is one of these
 # files or sits under one of these directories.
 _TRIGGER_FILES = (_ROLES_DOC, _TIERS_CONF, "scripts/check_agent_roles.py")
-_TRIGGER_DIRS = (f"{_CODEX_AGENTS}/", f"{_CLAUDE_WORKFLOWS}/", f"{_SKILLS}/")
+_TRIGGER_DIRS = (f"{_CODEX_AGENTS}/", f"{_CLAUDE_WORKFLOWS}/", f"{_SKILLS}/", f"{_POLICY}/")
 
 _BEGIN = "<!-- role-registry:begin -->"
 _END = "<!-- role-registry:end -->"
 _HEADER = ("Role", "Tiers", "Mutation", "Independent", "Claude bindings", "Codex bindings")
 _TIERS = ("top", "mid", "small")
 _MUTATIONS = ("read-only", "workspace-write")
-_CLAUDE_KINDS = ("workflow", "skill", "policy", "session")
-_CODEX_KINDS = ("agent", "skill", "policy", "session")
+_CLAUDE_KINDS = ("workflow", "skill", "policy")
+_CODEX_KINDS = ("agent", "skill", "policy")
 _TIER_KEYS = tuple(f"{tier.upper()}_{vendor}" for tier in _TIERS for vendor in ("CLAUDE", "CODEX"))
 _ROLE_ID = re.compile(r"[a-z][a-z0-9-]*")
 # A DIRECTLY QUOTED model id is a pin; a mid-prose mention inside a longer
@@ -126,7 +126,7 @@ def _parse_bindings(
         if not sep or not target or kind not in kinds:
             problems.append(
                 f"{_ROLES_DOC}: role '{role}': {column} binding '{part}' is not 'session' or "
-                f"kind:name with kind in {'/'.join(k for k in kinds if k != 'session')}"
+                f"kind:name with kind in {'/'.join(kinds)}"
             )
             continue
         bindings.append((kind, target))
@@ -150,8 +150,8 @@ def _parse_registry(doc: str, problems: list[str]) -> list[Role]:
     seen: set[str] = set()
     for line in rows[1:]:
         cells = _split_row(line)
-        if all(set(cell) <= set("-: ") for cell in cells):
-            continue  # the |----| separator row
+        if all(cell and set(cell) <= set("-: ") for cell in cells):
+            continue  # the |----| separator row (all-empty cells are NOT a separator)
         if len(cells) != len(_HEADER):
             problems.append(f"{_ROLES_DOC}: registry row needs {len(_HEADER)} columns: {line.strip()}")
             continue
@@ -309,10 +309,10 @@ def validate(root: Path) -> tuple[int, list[str]]:
     if not doc_path.is_file():
         return 0, [f"missing role contract: {_ROLES_DOC}"]
     problems: list[str] = []
-    doc = doc_path.read_text(encoding="utf-8")
+    doc = doc_path.read_text(encoding="utf-8", errors="replace")
     tiers_path = root / _TIERS_CONF
     if tiers_path.is_file():
-        tiers_conf = _parse_tiers_conf(tiers_path.read_text(encoding="utf-8"), problems)
+        tiers_conf = _parse_tiers_conf(tiers_path.read_text(encoding="utf-8", errors="replace"), problems)
     else:
         tiers_conf = {}
         problems.append(f"missing tier vocabulary: {_TIERS_CONF}")

--- a/scripts/check_agent_roles.py
+++ b/scripts/check_agent_roles.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Validate the shared agent role registry against both vendors' role definitions.
+
+`.agents/policy/agent-roles.md` is the shared, vendor-neutral role-family
+contract (issue #1387). Its machine-readable registry table binds every role to
+Claude surfaces (`.claude/workflows/*.js`, skills, policy docs, the session) and
+Codex surfaces (`.codex/agents/*.toml`, skills, policy docs, the session). This
+checker validates the SEMANTIC fields — tier vocabulary, mutation boundaries,
+binding targets, model-tier pins, contract-section completeness — never textual
+identity, so vendor-native wording may differ freely while capability drift (a
+retiered model pin, a sandbox/mutation mismatch, an orphaned vendor role, a
+missing contract field) fails loudly.
+
+CONDITIONAL: in --staged / --diff mode the full validation runs IF AND ONLY IF
+the change touches a role surface (the registry doc, .agents/model-tiers.conf,
+.codex/agents/, .claude/workflows/, .agents/skills/, or this checker); otherwise
+it reports the skip and exits 0. --all validates unconditionally.
+
+Usage:
+    check_agent_roles.py --staged            # pre-commit: staged diff decides
+    check_agent_roles.py --diff <base>       # CI PR gate: base...HEAD decides
+    check_agent_roles.py --all               # unconditional full validation
+    [--root PATH]                            # repo root (default: script's repo)
+
+A model pin on a line containing `roles-ok` is exempt (with a reason, like the
+other checkers' escape hatches).
+
+Exit status: 0 = clean or skipped, 1 = violations (printed), 2 = usage/git error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import NamedTuple
+
+_ROLES_DOC = ".agents/policy/agent-roles.md"
+_TIERS_CONF = ".agents/model-tiers.conf"
+_CODEX_AGENTS = ".codex/agents"
+_CLAUDE_WORKFLOWS = ".claude/workflows"
+_SKILLS = ".agents/skills"
+_POLICY = ".agents/policy"
+
+# Role surfaces: full validation triggers iff a changed path is one of these
+# files or sits under one of these directories.
+_TRIGGER_FILES = (_ROLES_DOC, _TIERS_CONF, "scripts/check_agent_roles.py")
+_TRIGGER_DIRS = (f"{_CODEX_AGENTS}/", f"{_CLAUDE_WORKFLOWS}/", f"{_SKILLS}/")
+
+_BEGIN = "<!-- role-registry:begin -->"
+_END = "<!-- role-registry:end -->"
+_HEADER = ("Role", "Tiers", "Mutation", "Independent", "Claude bindings", "Codex bindings")
+_TIERS = ("top", "mid", "small")
+_MUTATIONS = ("read-only", "workspace-write")
+_CLAUDE_KINDS = ("workflow", "skill", "policy", "session")
+_CODEX_KINDS = ("agent", "skill", "policy", "session")
+_TIER_KEYS = tuple(f"{tier.upper()}_{vendor}" for tier in _TIERS for vendor in ("CLAUDE", "CODEX"))
+_ROLE_ID = re.compile(r"[a-z][a-z0-9-]*")
+# A DIRECTLY QUOTED model id is a pin; a mid-prose mention inside a longer
+# string is not — that tolerance is what "no textual identity" means here.
+_CLAUDE_MODEL_PIN = re.compile(r"""['"](claude-[a-z0-9.-]+)['"]""")
+_ESCAPE = "roles-ok"
+# The eight semantic fields every role's contract section must carry.
+_SECTION_FIELDS = (
+    "Purpose & routing",
+    "Inputs & task packet",
+    "Outputs & evidence",
+    "Permissions & mutation",
+    "Context & skills",
+    "Stop & escalation",
+    "Independence",
+    "Tier intent",
+)
+
+
+class Role(NamedTuple):
+    name: str
+    tiers: tuple[str, ...]  # primary first
+    mutation: str
+    independent: str
+    claude: tuple[tuple[str, str], ...]  # (kind, target); ("session", "")
+    codex: tuple[tuple[str, str], ...]
+
+
+def _parse_tiers_conf(text: str, problems: list[str]) -> dict[str, str]:
+    """Parse KEY=VALUE tier lines; require exactly the six known keys, once each."""
+    values: dict[str, str] = {}
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, sep, value = (part.strip() for part in line.partition("="))
+        if not sep or not key or not value:
+            problems.append(f"{_TIERS_CONF}:{lineno}: invalid tier assignment: {line}")
+        elif key not in _TIER_KEYS:
+            problems.append(f"{_TIERS_CONF}:{lineno}: unknown tier key: {key}")
+        elif key in values:
+            problems.append(f"{_TIERS_CONF}:{lineno}: duplicate tier key: {key}")
+        else:
+            values[key] = value
+    for key in _TIER_KEYS:
+        if key not in values:
+            problems.append(f"{_TIERS_CONF}: missing tier key: {key}")
+    return values
+
+
+def _split_row(line: str) -> list[str]:
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def _parse_bindings(
+    cell: str, kinds: tuple[str, ...], column: str, role: str, problems: list[str]
+) -> tuple[tuple[str, str], ...]:
+    bindings: list[tuple[str, str]] = []
+    for part in (p.strip() for p in cell.split(",")):
+        if not part:
+            problems.append(f"{_ROLES_DOC}: role '{role}': empty {column} binding")
+            continue
+        if part == "session":
+            bindings.append(("session", ""))
+            continue
+        kind, sep, target = part.partition(":")
+        if not sep or not target or kind not in kinds:
+            problems.append(
+                f"{_ROLES_DOC}: role '{role}': {column} binding '{part}' is not 'session' or "
+                f"kind:name with kind in {'/'.join(k for k in kinds if k != 'session')}"
+            )
+            continue
+        bindings.append((kind, target))
+    return tuple(bindings)
+
+
+def _parse_registry(doc: str, problems: list[str]) -> list[Role]:
+    begin, end = doc.find(_BEGIN), doc.find(_END)
+    if begin < 0 or end < begin:
+        problems.append(f"{_ROLES_DOC}: registry markers missing ({_BEGIN} ... {_END})")
+        return []
+    rows = [line for line in doc[begin + len(_BEGIN) : end].splitlines() if line.strip().startswith("|")]
+    if not rows:
+        problems.append(f"{_ROLES_DOC}: registry table is empty")
+        return []
+    header = _split_row(rows[0])
+    if header != list(_HEADER):
+        problems.append(f"{_ROLES_DOC}: registry header must be {list(_HEADER)}, got {header}")
+        return []
+    roles: list[Role] = []
+    seen: set[str] = set()
+    for line in rows[1:]:
+        cells = _split_row(line)
+        if all(set(cell) <= set("-: ") for cell in cells):
+            continue  # the |----| separator row
+        if len(cells) != len(_HEADER):
+            problems.append(f"{_ROLES_DOC}: registry row needs {len(_HEADER)} columns: {line.strip()}")
+            continue
+        name, tiers_cell, mutation, independent, claude_cell, codex_cell = cells
+        ok = True
+        if not _ROLE_ID.fullmatch(name):
+            problems.append(f"{_ROLES_DOC}: invalid role id: {name!r}")
+            ok = False
+        if name in seen:
+            problems.append(f"{_ROLES_DOC}: duplicate role: {name}")
+            ok = False
+        seen.add(name)
+        tiers = tuple(tier.strip() for tier in tiers_cell.split("+"))
+        if any(tier not in _TIERS for tier in tiers) or len(set(tiers)) != len(tiers):
+            problems.append(
+                f"{_ROLES_DOC}: role '{name}': Tiers must be distinct {'/'.join(_TIERS)} tokens "
+                f"joined by '+', primary first; got {tiers_cell!r}"
+            )
+            ok = False
+        if mutation not in _MUTATIONS:
+            problems.append(f"{_ROLES_DOC}: role '{name}': Mutation must be one of {_MUTATIONS}, got {mutation!r}")
+            ok = False
+        if independent not in ("yes", "no"):
+            problems.append(f"{_ROLES_DOC}: role '{name}': Independent must be yes/no, got {independent!r}")
+            ok = False
+        claude = _parse_bindings(claude_cell, _CLAUDE_KINDS, "Claude", name, problems)
+        codex = _parse_bindings(codex_cell, _CODEX_KINDS, "Codex", name, problems)
+        if ok:
+            roles.append(Role(name, tiers, mutation, independent, claude, codex))
+    return roles
+
+
+def _check_sections(doc: str, roles: list[Role], problems: list[str]) -> None:
+    for role in roles:
+        match = re.search(rf"^### {re.escape(role.name)}$", doc, re.MULTILINE)
+        if not match:
+            problems.append(f"{_ROLES_DOC}: missing contract section '### {role.name}'")
+            continue
+        rest = doc[match.end() :]
+        next_heading = re.search(r"^#{2,3} ", rest, re.MULTILINE)
+        section = rest[: next_heading.start()] if next_heading else rest
+        for field in _SECTION_FIELDS:
+            if f"**{field}:**" not in section:
+                problems.append(f"{_ROLES_DOC}: section '### {role.name}' missing field '**{field}:**'")
+
+
+def _scan_model_pins(path: Path) -> list[str]:
+    pins: list[str] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if _ESCAPE in line:
+            continue
+        pins.extend(_CLAUDE_MODEL_PIN.findall(line))
+    return pins
+
+
+def _check_claude_workflows(
+    root: Path, workflow_roles: dict[str, list[Role]], tiers_conf: dict[str, str], problems: list[str]
+) -> None:
+    model_tier = {model: key.split("_")[0].lower() for key, model in tiers_conf.items() if key.endswith("_CLAUDE")}
+    for target, bound in sorted(workflow_roles.items()):
+        path = root / _CLAUDE_WORKFLOWS / f"{target}.js"
+        names = "/".join(sorted(role.name for role in bound))
+        if not path.is_file():
+            problems.append(f"role(s) {names}: missing Claude workflow {_CLAUDE_WORKFLOWS}/{target}.js")
+            continue
+        pins = _scan_model_pins(path)
+        allowed = {tier for role in bound for tier in role.tiers}
+        for pin in sorted(set(pins)):
+            tier = model_tier.get(pin)
+            if tier is None:
+                problems.append(f"{_CLAUDE_WORKFLOWS}/{target}.js pins '{pin}', which is not in {_TIERS_CONF}")
+            elif tier not in allowed:
+                problems.append(
+                    f"{_CLAUDE_WORKFLOWS}/{target}.js pins '{pin}' ({tier} tier), outside "
+                    f"tier(s) {'+'.join(sorted(allowed))} of role(s) {names}"
+                )
+        for role in bound:
+            primary = tiers_conf.get(f"{role.tiers[0].upper()}_CLAUDE")
+            if primary is not None and primary not in pins:
+                problems.append(
+                    f"{_CLAUDE_WORKFLOWS}/{target}.js never pins role '{role.name}' "
+                    f"primary tier '{role.tiers[0]}' ({primary})"
+                )
+
+
+def _check_codex_agents(
+    root: Path, agent_roles: dict[str, list[Role]], tiers_conf: dict[str, str], problems: list[str]
+) -> None:
+    agent_model: dict[str, str | None] = {}
+    for target, bound in sorted(agent_roles.items()):
+        path = root / _CODEX_AGENTS / f"{target}.toml"
+        names = "/".join(sorted(role.name for role in bound))
+        agent_model[target] = None
+        if not path.is_file():
+            problems.append(f"role(s) {names}: missing Codex agent {_CODEX_AGENTS}/{target}.toml")
+            continue
+        try:
+            data = tomllib.loads(path.read_text(encoding="utf-8"))
+        except (tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
+            problems.append(f"{_CODEX_AGENTS}/{target}.toml: unparsable TOML: {exc}")
+            continue
+        model, sandbox = data.get("model"), data.get("sandbox_mode")
+        allowed = {tiers_conf.get(f"{tier.upper()}_CODEX") for role in bound for tier in role.tiers} - {None}
+        if isinstance(model, str):
+            agent_model[target] = model
+        if not isinstance(model, str) or model not in allowed:
+            problems.append(
+                f"{_CODEX_AGENTS}/{target}.toml model {model!r} is not a Codex model of "
+                f"the tier(s) declared for role(s) {names}"
+            )
+        mutations = {role.mutation for role in bound}
+        if len(mutations) > 1:
+            problems.append(f"{_CODEX_AGENTS}/{target}.toml is bound by roles with conflicting Mutation: {names}")
+        elif sandbox != next(iter(mutations)):
+            problems.append(
+                f"{_CODEX_AGENTS}/{target}.toml sandbox_mode {sandbox!r} != role Mutation "
+                f"'{next(iter(mutations))}' ({names})"
+            )
+    for role in {role.name: role for bound in agent_roles.values() for role in bound}.values():
+        bound_agents = [target for kind, target in role.codex if kind == "agent"]
+        primary = tiers_conf.get(f"{role.tiers[0].upper()}_CODEX")
+        if primary is not None and not any(agent_model.get(target) == primary for target in bound_agents):
+            problems.append(
+                f"role '{role.name}': no Codex agent binding runs its primary tier '{role.tiers[0]}' ({primary})"
+            )
+
+
+def _check_file_bindings(root: Path, roles: list[Role], problems: list[str]) -> None:
+    for role in roles:
+        for kind, target in role.claude + role.codex:
+            if kind == "skill" and not (root / _SKILLS / target / "SKILL.md").is_file():
+                problems.append(f"role '{role.name}': skill binding '{target}' has no {_SKILLS}/{target}/SKILL.md")
+            elif kind == "policy" and not (root / _POLICY / target).is_file():
+                problems.append(f"role '{role.name}': policy binding '{target}' has no {_POLICY}/{target}")
+
+
+def _check_orphans(root: Path, roles: list[Role], problems: list[str]) -> None:
+    claimed_agents = {target for role in roles for kind, target in role.codex if kind == "agent"}
+    claimed_workflows = {target for role in roles for kind, target in role.claude if kind == "workflow"}
+    for directory, suffix, claimed, side in (
+        (root / _CODEX_AGENTS, ".toml", claimed_agents, "Codex role"),
+        (root / _CLAUDE_WORKFLOWS, ".js", claimed_workflows, "Claude workflow"),
+    ):
+        if not directory.is_dir():
+            problems.append(f"missing directory: {directory.relative_to(root)}")
+            continue
+        for path in sorted(directory.glob(f"*{suffix}")):
+            if path.stem not in claimed:
+                problems.append(f"{path.relative_to(root)}: {side} not claimed by any registry row")
+
+
+def validate(root: Path) -> tuple[int, list[str]]:
+    """Full semantic validation; returns (role count, problems)."""
+    doc_path = root / _ROLES_DOC
+    if not doc_path.is_file():
+        return 0, [f"missing role contract: {_ROLES_DOC}"]
+    problems: list[str] = []
+    doc = doc_path.read_text(encoding="utf-8")
+    tiers_path = root / _TIERS_CONF
+    if tiers_path.is_file():
+        tiers_conf = _parse_tiers_conf(tiers_path.read_text(encoding="utf-8"), problems)
+    else:
+        tiers_conf = {}
+        problems.append(f"missing tier vocabulary: {_TIERS_CONF}")
+    roles = _parse_registry(doc, problems)
+    if not roles and not problems:
+        problems.append(f"{_ROLES_DOC}: registry has no roles")
+    _check_sections(doc, roles, problems)
+    _check_file_bindings(root, roles, problems)
+    workflow_roles: dict[str, list[Role]] = {}
+    agent_roles: dict[str, list[Role]] = {}
+    for role in roles:
+        for kind, target in role.claude:
+            if kind == "workflow":
+                workflow_roles.setdefault(target, []).append(role)
+        for kind, target in role.codex:
+            if kind == "agent":
+                agent_roles.setdefault(target, []).append(role)
+    _check_claude_workflows(root, workflow_roles, tiers_conf, problems)
+    _check_codex_agents(root, agent_roles, tiers_conf, problems)
+    _check_orphans(root, roles, problems)
+    return len(roles), problems
+
+
+def _changed_paths(root: Path, git_args: list[str]) -> list[str]:
+    out = subprocess.run(
+        ["git", "-C", str(root), "diff", "--name-only", "--no-color", *git_args],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def touches_role_surface(paths: list[str]) -> bool:
+    return any(path in _TRIGGER_FILES or any(path.startswith(prefix) for prefix in _TRIGGER_DIRS) for path in paths)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0], prog="check_agent_roles.py")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--staged", action="store_true", help="validate iff the staged diff touches a role surface")
+    mode.add_argument("--diff", metavar="BASE", help="validate iff BASE...HEAD touches a role surface")
+    mode.add_argument("--all", action="store_true", help="unconditional full validation")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="repository root (default: this script's repository)",
+    )
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+    if not args.all:
+        try:
+            changed = _changed_paths(root, ["--cached"] if args.staged else [f"{args.diff}...HEAD"])
+        except (subprocess.CalledProcessError, OSError) as exc:
+            stderr = getattr(exc, "stderr", "") or str(exc)
+            print(f"agent-roles: git diff failed: {stderr.strip()}", file=sys.stderr)
+            return 2
+        if not touches_role_surface(changed):
+            print("agent-roles: no role surface changed; skipped")
+            return 0
+    count, problems = validate(root)
+    if problems:
+        print("Agent role-family drift detected:\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        print(
+            f"\nThe shared role contract ({_ROLES_DOC}) and the vendor role definitions"
+            "\nmust stay semantically aligned: fix the drifted side, or update the"
+            "\nregistry row and its contract section together. A deliberate model pin"
+            "\non an exempt line carries `roles-ok: <reason>`.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"agent-roles: registry and vendor role definitions consistent ({count} roles)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_agent_roles.py
+++ b/scripts/check_agent_roles.py
@@ -352,7 +352,7 @@ def touches_role_surface(paths: list[str]) -> bool:
 
 
 def main(argv: list[str]) -> int:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0], prog="check_agent_roles.py")
+    parser = argparse.ArgumentParser(description=(__doc__ or "").partition("\n")[0], prog="check_agent_roles.py")
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--staged", action="store_true", help="validate iff the staged diff touches a role surface")
     mode.add_argument("--diff", metavar="BASE", help="validate iff BASE...HEAD touches a role surface")

--- a/tests/test_agent_roles_check.py
+++ b/tests/test_agent_roles_check.py
@@ -242,6 +242,15 @@ def test_doc_not_utf8_clean_error(tmp_path: Path) -> None:
     assert "registry markers missing" in result.stderr
 
 
+def test_tiers_not_utf8_clean_error(tmp_path: Path) -> None:
+    make_tree(tmp_path)
+    (tmp_path / ".agents/model-tiers.conf").write_text(_TIERS_TEXT, encoding="utf-16")
+    result = _cli(tmp_path, "--all")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+    assert "tier key" in result.stderr
+
+
 def test_tiers_missing_key(tmp_path: Path) -> None:
     make_tree(tmp_path, tiers=_TIERS_TEXT.replace("MID_CODEX=codex-mid\n", ""))
     _assert_flags(_problems(tmp_path), "missing tier key: MID_CODEX")

--- a/tests/test_agent_roles_check.py
+++ b/tests/test_agent_roles_check.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -46,8 +47,9 @@ _ROWS = (
     "| checker | small+top | read-only | yes | workflow:check | agent:checker, agent:checker-top |",
     "| lander | small | workspace-write | no | skill:land | skill:land |",
     "| steward | top | read-only | no | session | session |",
+    "| keeper | small | workspace-write | no | policy:flow.md | policy:flow.md |",
 )
-_ROLE_NAMES = ("builder", "checker", "lander", "steward")
+_ROLE_NAMES = ("builder", "checker", "lander", "steward", "keeper")
 
 
 def _section(name: str) -> str:
@@ -84,6 +86,7 @@ def make_tree(
     _write(root / ".agents/model-tiers.conf", tiers)
     _write(root / ".agents/policy/agent-roles.md", doc if doc is not None else _doc())
     _write(root / ".agents/skills/land/SKILL.md", "# land\n")
+    _write(root / ".agents/policy/flow.md", "# flow\n")
     _write(root / ".claude/workflows/build.js", build_js)
     _write(root / ".claude/workflows/check.js", check_js)
     _write(root / ".codex/agents/builder.toml", builder_toml or _toml("codex-small", "workspace-write"))
@@ -115,6 +118,16 @@ def test_live_repository_registry_is_consistent() -> None:
     count, problems = car.validate(_REPO_ROOT)
     assert problems == []
     assert count >= 7  # explorer/planner/implementer/verifier/reviewer/publisher/coordinator
+
+
+def test_ci_workflow_paths_match_checker_triggers() -> None:
+    # The CI trigger must mirror the checker's role surfaces: test.yml's global
+    # `paths-ignore: '**/*.md'` skips that whole workflow for md-only changes,
+    # so the agent-roles gate rides its own path-filtered workflow instead.
+    text = (_REPO_ROOT / ".github/workflows/agent-roles.yml").read_text(encoding="utf-8")
+    listed = re.findall(r"^\s+- '([^']+)'\s*$", text, re.MULTILINE)
+    expected = set(car._TRIGGER_FILES) | {f"{d}**" for d in car._TRIGGER_DIRS}
+    assert set(listed) == expected, f"workflow paths {sorted(listed)} != checker triggers {sorted(expected)}"
 
 
 # --------------------------------------------------------------------------- #
@@ -207,6 +220,26 @@ def test_empty_binding_cell(tmp_path: Path) -> None:
 # --------------------------------------------------------------------------- #
 # Tier vocabulary (.agents/model-tiers.conf)
 # --------------------------------------------------------------------------- #
+
+
+def test_session_binding_with_target_rejected(tmp_path: Path) -> None:
+    rows = _ROWS[:3] + ("| steward | top | read-only | no | session:evil | session |",) + _ROWS[4:]
+    make_tree(tmp_path, doc=_doc(rows=rows))
+    _assert_flags(_problems(tmp_path), "Claude binding 'session:evil'")
+
+
+def test_registry_blank_row_rejected(tmp_path: Path) -> None:
+    make_tree(tmp_path, doc=_doc(rows=(*_ROWS, "|  |  |  |  |  |  |")))
+    _assert_flags(_problems(tmp_path), "invalid role id")
+
+
+def test_doc_not_utf8_clean_error(tmp_path: Path) -> None:
+    make_tree(tmp_path)
+    (tmp_path / ".agents/policy/agent-roles.md").write_text(_doc(), encoding="utf-16")
+    result = _cli(tmp_path, "--all")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+    assert "registry markers missing" in result.stderr
 
 
 def test_tiers_missing_key(tmp_path: Path) -> None:
@@ -370,6 +403,7 @@ def test_touches_role_surface_unit() -> None:
     assert car.touches_role_surface([".claude/workflows/phase-step.js"])
     assert car.touches_role_surface([".agents/model-tiers.conf"])
     assert car.touches_role_surface([".agents/policy/agent-roles.md"])
+    assert car.touches_role_surface([".agents/policy/flow.md"])
     assert car.touches_role_surface(["scripts/check_agent_roles.py"])
     assert not car.touches_role_surface(["src/usr/local/pkg/pfblockerng/pfblockerng.inc", "README.md"])
     assert not car.touches_role_surface([])
@@ -423,7 +457,6 @@ def test_cli_staged_validates_clean_role_surface_change(tmp_path: Path) -> None:
 
 
 def test_cli_staged_red_on_drift(tmp_path: Path) -> None:
-    # The wired gate's red path: a retiered Codex implementer must FAIL --staged.
     root = _git_tree(tmp_path)
     _write(root / ".codex/agents/builder.toml", _toml("codex-top", "workspace-write"))
     _git(root, "add", ".codex/agents/builder.toml")
@@ -431,6 +464,14 @@ def test_cli_staged_red_on_drift(tmp_path: Path) -> None:
     assert result.returncode == 1, result.stdout + result.stderr
     assert "Agent role-family drift detected" in result.stderr
     assert "builder.toml model 'codex-top'" in result.stderr
+
+
+def test_cli_staged_red_on_deleted_policy_binding(tmp_path: Path) -> None:
+    root = _git_tree(tmp_path)
+    _git(root, "rm", "-q", ".agents/policy/flow.md")
+    result = _cli(root, "--staged")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "policy binding 'flow.md' has no .agents/policy/flow.md" in result.stderr
 
 
 def test_cli_diff_skips_unrelated_change(tmp_path: Path) -> None:
@@ -456,7 +497,7 @@ def test_cli_diff_red_on_drift(tmp_path: Path) -> None:
 def test_cli_all_green_and_exit_codes(tmp_path: Path) -> None:
     result = _cli(make_tree(tmp_path), "--all")
     assert result.returncode == 0, result.stderr
-    assert "consistent (4 roles)" in result.stdout
+    assert "consistent (5 roles)" in result.stdout
 
 
 def test_cli_usage_error_exit_2(tmp_path: Path) -> None:

--- a/tests/test_agent_roles_check.py
+++ b/tests/test_agent_roles_check.py
@@ -1,0 +1,464 @@
+"""Tests for scripts/check_agent_roles.py.
+
+Every violation class is paired with the nearest clean sibling (the valid
+fixture tree), so a green run proves the checker discriminates rather than
+always firing (or never firing). The checker validates SEMANTIC fields —
+tier vocabulary, mutation boundaries, binding targets, model pins — so the
+fixtures vary exactly one semantic aspect per test while wording stays free.
+
+The conditional trigger (--staged / --diff run the full validation iff a role
+surface changed) is exercised through the CLI against real scratch git repos.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_agent_roles.py"
+_spec = importlib.util.spec_from_file_location("check_agent_roles", _TOOL)
+assert _spec is not None and _spec.loader is not None
+car = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = car
+_spec.loader.exec_module(car)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_TIERS_TEXT = (
+    "TOP_CLAUDE=claude-top-x\n"
+    "TOP_CODEX=codex-top\n"
+    "MID_CLAUDE=claude-mid-x\n"
+    "MID_CODEX=codex-mid\n"
+    "SMALL_CLAUDE=claude-small-x\n"
+    "SMALL_CODEX=codex-small\n"
+)
+
+_HEADER_ROWS = (
+    "| Role | Tiers | Mutation | Independent | Claude bindings | Codex bindings |",
+    "| ---- | ----- | -------- | ----------- | --------------- | -------------- |",
+)
+
+_ROWS = (
+    "| builder | small | workspace-write | no | workflow:build | agent:builder |",
+    "| checker | small+top | read-only | yes | workflow:check | agent:checker, agent:checker-top |",
+    "| lander | small | workspace-write | no | skill:land | skill:land |",
+    "| steward | top | read-only | no | session | session |",
+)
+_ROLE_NAMES = ("builder", "checker", "lander", "steward")
+
+
+def _section(name: str) -> str:
+    fields = "\n".join(f"- **{field}:** x" for field in car._SECTION_FIELDS)
+    return f"### {name}\n\n{fields}\n"
+
+
+def _doc(rows: tuple[str, ...] = _ROWS, sections: tuple[str, ...] = _ROLE_NAMES) -> str:
+    table = "\n".join((*_HEADER_ROWS, *rows))
+    body = "\n".join(_section(name) for name in sections)
+    return f"# roles\n\n<!-- role-registry:begin -->\n{table}\n<!-- role-registry:end -->\n\n{body}"
+
+
+def _toml(model: str, sandbox: str) -> str:
+    return f'name = "x"\nmodel = "{model}"\nsandbox_mode = "{sandbox}"\n'
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def make_tree(
+    root: Path,
+    *,
+    doc: str | None = None,
+    tiers: str = _TIERS_TEXT,
+    build_js: str = "agent(p, { model: 'claude-small-x' })\n",
+    check_js: str = "a 'claude-small-x' b \"claude-top-x\"\n",
+    builder_toml: str | None = None,
+    checker_toml: str | None = None,
+    checker_top_toml: str | None = None,
+) -> Path:
+    _write(root / ".agents/model-tiers.conf", tiers)
+    _write(root / ".agents/policy/agent-roles.md", doc if doc is not None else _doc())
+    _write(root / ".agents/skills/land/SKILL.md", "# land\n")
+    _write(root / ".claude/workflows/build.js", build_js)
+    _write(root / ".claude/workflows/check.js", check_js)
+    _write(root / ".codex/agents/builder.toml", builder_toml or _toml("codex-small", "workspace-write"))
+    _write(root / ".codex/agents/checker.toml", checker_toml or _toml("codex-small", "read-only"))
+    _write(root / ".codex/agents/checker-top.toml", checker_top_toml or _toml("codex-top", "read-only"))
+    return root
+
+
+def _problems(root: Path) -> list[str]:
+    return car.validate(root)[1]
+
+
+def _assert_flags(problems: list[str], needle: str) -> None:
+    assert any(needle in problem for problem in problems), f"expected {needle!r} in {problems}"
+
+
+# --------------------------------------------------------------------------- #
+# Clean baselines (the paired positives for every violation test below)
+# --------------------------------------------------------------------------- #
+
+
+def test_valid_fixture_is_clean(tmp_path: Path) -> None:
+    count, problems = car.validate(make_tree(tmp_path))
+    assert problems == []
+    assert count == len(_ROWS)
+
+
+def test_live_repository_registry_is_consistent() -> None:
+    count, problems = car.validate(_REPO_ROOT)
+    assert problems == []
+    assert count >= 7  # explorer/planner/implementer/verifier/reviewer/publisher/coordinator
+
+
+# --------------------------------------------------------------------------- #
+# Registry document and table parsing
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_doc_reported(tmp_path: Path) -> None:
+    make_tree(tmp_path)
+    (tmp_path / ".agents/policy/agent-roles.md").unlink()
+    _assert_flags(_problems(tmp_path), "missing role contract")
+
+
+def test_registry_markers_missing(tmp_path: Path) -> None:
+    make_tree(tmp_path, doc="# roles, but no table markers\n")
+    _assert_flags(_problems(tmp_path), "registry markers missing")
+
+
+def test_registry_empty_table(tmp_path: Path) -> None:
+    make_tree(tmp_path, doc="<!-- role-registry:begin -->\n<!-- role-registry:end -->\n")
+    _assert_flags(_problems(tmp_path), "registry table is empty")
+
+
+def test_registry_header_drift(tmp_path: Path) -> None:
+    doc = _doc().replace("| Role |", "| Family |")
+    make_tree(tmp_path, doc=doc)
+    _assert_flags(_problems(tmp_path), "registry header must be")
+
+
+def test_registry_row_column_count(tmp_path: Path) -> None:
+    rows = (*_ROWS, "| stub | small | read-only |")
+    make_tree(tmp_path, doc=_doc(rows=rows))
+    _assert_flags(_problems(tmp_path), "columns")
+
+
+def test_unknown_tier_token(tmp_path: Path) -> None:
+    rows = (*_ROWS, "| giant | huge | read-only | no | session | session |")
+    make_tree(tmp_path, doc=_doc(rows=rows, sections=(*_ROLE_NAMES, "giant")))
+    _assert_flags(_problems(tmp_path), "Tiers must be distinct")
+
+
+def test_duplicate_tier_token(tmp_path: Path) -> None:
+    rows = (*_ROWS, "| twice | small+small | read-only | no | session | session |")
+    make_tree(tmp_path, doc=_doc(rows=rows, sections=(*_ROLE_NAMES, "twice")))
+    _assert_flags(_problems(tmp_path), "Tiers must be distinct")
+
+
+def test_duplicate_role(tmp_path: Path) -> None:
+    rows = (*_ROWS, _ROWS[0])
+    make_tree(tmp_path, doc=_doc(rows=rows))
+    _assert_flags(_problems(tmp_path), "duplicate role")
+
+
+def test_invalid_role_id(tmp_path: Path) -> None:
+    rows = (*_ROWS, "| Builder2! | small | read-only | no | session | session |")
+    make_tree(tmp_path, doc=_doc(rows=rows))
+    _assert_flags(_problems(tmp_path), "invalid role id")
+
+
+def test_bad_mutation_value(tmp_path: Path) -> None:
+    rows = (*_ROWS, "| muta | small | writable | no | session | session |")
+    make_tree(tmp_path, doc=_doc(rows=rows, sections=(*_ROLE_NAMES, "muta")))
+    _assert_flags(_problems(tmp_path), "Mutation must be one of")
+
+
+def test_bad_independent_value(tmp_path: Path) -> None:
+    rows = (*_ROWS, "| indy | small | read-only | maybe | session | session |")
+    make_tree(tmp_path, doc=_doc(rows=rows, sections=(*_ROLE_NAMES, "indy")))
+    _assert_flags(_problems(tmp_path), "Independent must be yes/no")
+
+
+def test_claude_agent_kind_rejected(tmp_path: Path) -> None:
+    rows = (*_ROWS, "| xrole | small | read-only | no | agent:builder | session |")
+    make_tree(tmp_path, doc=_doc(rows=rows, sections=(*_ROLE_NAMES, "xrole")))
+    _assert_flags(_problems(tmp_path), "Claude binding 'agent:builder'")
+
+
+def test_codex_workflow_kind_rejected(tmp_path: Path) -> None:
+    rows = (*_ROWS, "| yrole | small | read-only | no | session | workflow:build |")
+    make_tree(tmp_path, doc=_doc(rows=rows, sections=(*_ROLE_NAMES, "yrole")))
+    _assert_flags(_problems(tmp_path), "Codex binding 'workflow:build'")
+
+
+def test_empty_binding_cell(tmp_path: Path) -> None:
+    rows = (*_ROWS, "| zrole | small | read-only | no |  | session |")
+    make_tree(tmp_path, doc=_doc(rows=rows, sections=(*_ROLE_NAMES, "zrole")))
+    _assert_flags(_problems(tmp_path), "empty Claude binding")
+
+
+# --------------------------------------------------------------------------- #
+# Tier vocabulary (.agents/model-tiers.conf)
+# --------------------------------------------------------------------------- #
+
+
+def test_tiers_missing_key(tmp_path: Path) -> None:
+    make_tree(tmp_path, tiers=_TIERS_TEXT.replace("MID_CODEX=codex-mid\n", ""))
+    _assert_flags(_problems(tmp_path), "missing tier key: MID_CODEX")
+
+
+def test_tiers_missing_file(tmp_path: Path) -> None:
+    make_tree(tmp_path)
+    (tmp_path / ".agents/model-tiers.conf").unlink()
+    _assert_flags(_problems(tmp_path), "missing tier vocabulary")
+
+
+def test_tiers_duplicate_key(tmp_path: Path) -> None:
+    make_tree(tmp_path, tiers=_TIERS_TEXT + "TOP_CLAUDE=claude-other\n")
+    _assert_flags(_problems(tmp_path), "duplicate tier key: TOP_CLAUDE")
+
+
+def test_tiers_unknown_key(tmp_path: Path) -> None:
+    make_tree(tmp_path, tiers=_TIERS_TEXT + "HUGE_CLAUDE=claude-huge\n")
+    _assert_flags(_problems(tmp_path), "unknown tier key: HUGE_CLAUDE")
+
+
+def test_tiers_invalid_line(tmp_path: Path) -> None:
+    make_tree(tmp_path, tiers=_TIERS_TEXT + "SMALL_CODEX\n")
+    _assert_flags(_problems(tmp_path), "invalid tier assignment")
+
+
+# --------------------------------------------------------------------------- #
+# Contract sections (the eight semantic fields per role)
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_role_section(tmp_path: Path) -> None:
+    make_tree(tmp_path, doc=_doc(sections=("builder", "checker", "lander")))
+    _assert_flags(_problems(tmp_path), "missing contract section '### steward'")
+
+
+def test_section_missing_field(tmp_path: Path) -> None:
+    doc = _doc().replace("- **Tier intent:** x\n\n### checker", "\n### checker", 1)
+    make_tree(tmp_path, doc=doc)
+    _assert_flags(_problems(tmp_path), "section '### builder' missing field '**Tier intent:**'")
+
+
+# --------------------------------------------------------------------------- #
+# Claude workflow bindings (model pins vs declared tiers)
+# --------------------------------------------------------------------------- #
+
+
+def test_workflow_file_missing(tmp_path: Path) -> None:
+    make_tree(tmp_path)
+    (tmp_path / ".claude/workflows/build.js").unlink()
+    _assert_flags(_problems(tmp_path), "missing Claude workflow .claude/workflows/build.js")
+
+
+def test_workflow_pin_outside_role_tiers(tmp_path: Path) -> None:
+    make_tree(tmp_path, build_js="m 'claude-small-x'\nx 'claude-top-x'\n")
+    _assert_flags(_problems(tmp_path), "pins 'claude-top-x' (top tier), outside tier(s) small")
+
+
+def test_workflow_pin_unknown_model(tmp_path: Path) -> None:
+    make_tree(tmp_path, build_js="m 'claude-small-x'\nx 'claude-weird-9'\n")
+    _assert_flags(_problems(tmp_path), "pins 'claude-weird-9', which is not in")
+
+
+def test_workflow_missing_primary_pin(tmp_path: Path) -> None:
+    make_tree(tmp_path, build_js="no pins here\n")
+    _assert_flags(_problems(tmp_path), "never pins role 'builder' primary tier 'small'")
+
+
+def test_workflow_escape_line_exempt(tmp_path: Path) -> None:
+    make_tree(tmp_path, build_js="m 'claude-small-x'\n// roles-ok: fallback note 'claude-top-x'\n")
+    assert _problems(tmp_path) == []
+
+
+def test_workflow_mid_string_mention_not_a_pin(tmp_path: Path) -> None:
+    make_tree(tmp_path, build_js="m 'claude-small-x'\nconst t = 'pass claude-top-x when told'\n")
+    assert _problems(tmp_path) == []
+
+
+# --------------------------------------------------------------------------- #
+# Codex agent bindings (model tier + sandbox/mutation)
+# --------------------------------------------------------------------------- #
+
+
+def test_codex_agent_file_missing(tmp_path: Path) -> None:
+    make_tree(tmp_path)
+    (tmp_path / ".codex/agents/builder.toml").unlink()
+    _assert_flags(_problems(tmp_path), "missing Codex agent .codex/agents/builder.toml")
+
+
+def test_codex_model_wrong_tier(tmp_path: Path) -> None:
+    make_tree(tmp_path, builder_toml=_toml("codex-top", "workspace-write"))
+    _assert_flags(_problems(tmp_path), "builder.toml model 'codex-top' is not a Codex model")
+
+
+def test_codex_model_missing_key(tmp_path: Path) -> None:
+    make_tree(tmp_path, builder_toml='name = "x"\nsandbox_mode = "workspace-write"\n')
+    _assert_flags(_problems(tmp_path), "builder.toml model None is not a Codex model")
+
+
+def test_codex_sandbox_mismatch(tmp_path: Path) -> None:
+    make_tree(tmp_path, builder_toml=_toml("codex-small", "read-only"))
+    _assert_flags(_problems(tmp_path), "sandbox_mode 'read-only' != role Mutation 'workspace-write'")
+
+
+def test_codex_toml_unparsable(tmp_path: Path) -> None:
+    make_tree(tmp_path, builder_toml="model = codex-small oops\n")
+    _assert_flags(_problems(tmp_path), "unparsable TOML")
+
+
+def test_codex_primary_tier_uncovered(tmp_path: Path) -> None:
+    # Both checker agents on the top model: legal tiers, but nobody runs the
+    # small primary — the drift the coverage rule exists to catch.
+    make_tree(tmp_path, checker_toml=_toml("codex-top", "read-only"))
+    _assert_flags(_problems(tmp_path), "role 'checker': no Codex agent binding runs its primary tier 'small'")
+
+
+def test_codex_conflicting_mutation_roles(tmp_path: Path) -> None:
+    rows = (*_ROWS, "| auditor | small | read-only | yes | workflow:check | agent:builder |")
+    make_tree(tmp_path, doc=_doc(rows=rows, sections=(*_ROLE_NAMES, "auditor")))
+    _assert_flags(_problems(tmp_path), "bound by roles with conflicting Mutation")
+
+
+# --------------------------------------------------------------------------- #
+# Skill / policy bindings and orphaned vendor definitions
+# --------------------------------------------------------------------------- #
+
+
+def test_skill_binding_missing(tmp_path: Path) -> None:
+    make_tree(tmp_path)
+    (tmp_path / ".agents/skills/land/SKILL.md").unlink()
+    _assert_flags(_problems(tmp_path), "skill binding 'land' has no")
+
+
+def test_policy_binding_missing(tmp_path: Path) -> None:
+    rows = (*_ROWS, "| scribe | small | read-only | no | policy:missing.md | session |")
+    make_tree(tmp_path, doc=_doc(rows=rows, sections=(*_ROLE_NAMES, "scribe")))
+    _assert_flags(_problems(tmp_path), "policy binding 'missing.md' has no")
+
+
+def test_orphan_codex_agent(tmp_path: Path) -> None:
+    make_tree(tmp_path)
+    _write(tmp_path / ".codex/agents/stray.toml", _toml("codex-small", "read-only"))
+    _assert_flags(_problems(tmp_path), "stray.toml: Codex role not claimed by any registry row")
+
+
+def test_unclaimed_claude_workflow(tmp_path: Path) -> None:
+    make_tree(tmp_path)
+    _write(tmp_path / ".claude/workflows/stray.js", "x\n")
+    _assert_flags(_problems(tmp_path), "stray.js: Claude workflow not claimed by any registry row")
+
+
+# --------------------------------------------------------------------------- #
+# Conditional trigger + CLI (--staged / --diff / --all, exit codes)
+# --------------------------------------------------------------------------- #
+
+
+def test_touches_role_surface_unit() -> None:
+    assert car.touches_role_surface([".codex/agents/planner.toml"])
+    assert car.touches_role_surface([".claude/workflows/phase-step.js"])
+    assert car.touches_role_surface([".agents/model-tiers.conf"])
+    assert car.touches_role_surface([".agents/policy/agent-roles.md"])
+    assert car.touches_role_surface(["scripts/check_agent_roles.py"])
+    assert not car.touches_role_surface(["src/usr/local/pkg/pfblockerng/pfblockerng.inc", "README.md"])
+    assert not car.touches_role_surface([])
+    # Exact-file trigger, not a lookalike sibling file.
+    assert not car.touches_role_surface([".agents/model-tiers.conf.bak"])
+
+
+def _git(root: Path, *args: str) -> None:
+    env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull}
+    subprocess.run(
+        ["git", "-C", str(root), "-c", "user.name=t", "-c", "user.email=t@example.com", *args],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def _cli(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_TOOL), *args, "--root", str(root)],
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+
+def _git_tree(root: Path) -> Path:
+    make_tree(root)
+    _write(root / "README.md", "unrelated\n")
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "base", "--no-verify")
+    return root
+
+
+def test_cli_staged_skips_unrelated_change(tmp_path: Path) -> None:
+    root = _git_tree(tmp_path)
+    _write(root / "README.md", "changed\n")
+    _git(root, "add", "README.md")
+    result = _cli(root, "--staged")
+    assert result.returncode == 0, result.stderr
+    assert "skipped" in result.stdout
+
+
+def test_cli_staged_validates_clean_role_surface_change(tmp_path: Path) -> None:
+    root = _git_tree(tmp_path)
+    _write(root / ".agents/model-tiers.conf", _TIERS_TEXT + "# comment\n")
+    _git(root, "add", ".agents/model-tiers.conf")
+    result = _cli(root, "--staged")
+    assert result.returncode == 0, result.stderr
+    assert "consistent" in result.stdout
+
+
+def test_cli_staged_red_on_drift(tmp_path: Path) -> None:
+    # The wired gate's red path: a retiered Codex implementer must FAIL --staged.
+    root = _git_tree(tmp_path)
+    _write(root / ".codex/agents/builder.toml", _toml("codex-top", "workspace-write"))
+    _git(root, "add", ".codex/agents/builder.toml")
+    result = _cli(root, "--staged")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Agent role-family drift detected" in result.stderr
+    assert "builder.toml model 'codex-top'" in result.stderr
+
+
+def test_cli_diff_skips_unrelated_change(tmp_path: Path) -> None:
+    root = _git_tree(tmp_path)
+    _write(root / "README.md", "changed\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "unrelated", "--no-verify")
+    result = _cli(root, "--diff", "HEAD~1")
+    assert result.returncode == 0, result.stderr
+    assert "skipped" in result.stdout
+
+
+def test_cli_diff_red_on_drift(tmp_path: Path) -> None:
+    root = _git_tree(tmp_path)
+    _write(root / ".codex/agents/checker.toml", _toml("codex-mid", "read-only"))
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "retier", "--no-verify")
+    result = _cli(root, "--diff", "HEAD~1")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "checker.toml model 'codex-mid'" in result.stderr
+
+
+def test_cli_all_green_and_exit_codes(tmp_path: Path) -> None:
+    result = _cli(make_tree(tmp_path), "--all")
+    assert result.returncode == 0, result.stderr
+    assert "consistent (4 roles)" in result.stdout
+
+
+def test_cli_usage_error_exit_2(tmp_path: Path) -> None:
+    result = _cli(tmp_path)  # no mode flag
+    assert result.returncode == 2


### PR DESCRIPTION
Resolves #1387.

## What this adds

**1. Shared, vendor-neutral role-family contract** — [`.agents/policy/agent-roles.md`](../blob/issue/1387-specify-aligned-claude-and/.agents/policy/agent-roles.md)

Seven role families, each specified with the eight semantic fields the issue requires (purpose/routing, inputs/task packet, outputs/evidence, permissions/mutation, context/skills, stop/escalation/handoff, independence, tier intent), plus a machine-readable registry table and tier-economics rules. Deviations from the issue's starting six, with rationale (full detail in the doc's Decisions section):

- **quick implementer merged into implementer** as the `light` weight — identical permissions/evidence/escalation contract; the repo already models the difference as a routing parameter (`WEIGHT: light` phases), and Codex defines a single implementer role.
- **planner added** — the de-facto top-tier role both vendors already define; the expensive tier needs an explicit contract precisely because it is expensive.
- **code reviewer split into verifier + reviewer** — different outputs (gate record vs findings schema) and different tier routing (verifier pinned small by owner directive; reviewer escalates to top for large/complex PRs).
- **explorer, publisher, coordinator kept** — publisher and coordinator bind to a skill (`pr-merge-flow`) and a policy document (`workflow.md`) rather than dedicated vendor agents: procedure-driven small-tier roles a session fills by loading one document.

**2. Explicit vendor mappings** — the registry binds every role to concrete Claude surfaces (`.claude/workflows/*.js` stages, skills, policy docs, the session) and Codex surfaces (`.codex/agents/*.toml`, skills, policy docs, the session), with per-vendor mapping tables in the doc. Sol/Luna economics get their Claude equivalents: small (Sonnet/Luna) is the default executor everywhere; top (Fable/Sol) requires a named routing trigger and documented in-ticket evidence for mid-task escalation; mid (Opus/Terra) is fallback-only, never a sole reviewer or default route. Tier→model resolution always goes through `.agents/model-tiers.conf` — the contract never names vendor models.

**3. Conditional validation** — `scripts/check_agent_roles.py`

Runs the full semantic validation **if and only if** a role surface changes (the registry doc, `model-tiers.conf`, `.codex/agents/`, `.claude/workflows/`, `.agents/skills/`, or the checker itself): self-scoped `--staged` in `.githooks/pre-commit` and `--diff <base>` in a new PR-only CI job folded into `all-tests-passed` (skipped == pass on push, same shape as `comment-narration`). It detects capability drift without enforcing textual identity:

- registry semantics: tier vocabulary, mutation boundary, independence, binding kinds, contract-section completeness (all eight fields per role);
- Claude side: bound workflow files must exist; directly *quoted* model pins must map into the binding roles' declared tiers, and each role's primary tier must be pinned — mid-prose model mentions are deliberately not pins, so wording stays free;
- Codex side: bound `.toml` files must exist and parse; `model` must belong to a declared tier with the primary tier covered; `sandbox_mode` must match the role's mutation boundary;
- both directions: every `.codex/agents/*.toml` and every `.claude/workflows/*.js` must be claimed by a registry row (orphan detection);
- escape hatch: `roles-ok: <reason>` on a deliberate exempt line, like the sibling checkers.

`tests/test_agent_roles_check.py` (48 tests) pairs every violation class with its nearest clean sibling, pins the live repository state (`test_live_repository_registry_is_consistent`), and exercises the conditional trigger through the CLI against scratch git repos, including the red paths (`--staged` and `--diff` failing on a retiered Codex model).

The existing `scripts/agent/check-agent-config-parity.sh` keeps discovery/adapter parity and its fast pre-commit role→tier pins; the overlap fails loudly on divergence, and folding it into the registry checker is deliberately deferred (documented in the doc's Decisions section).

## Executed red path (new blocking gate)

Retiered `implementer.toml` to the mid model + stray top-tier pin appended to `phase-step.js` in a fixture copy:

```text
Agent role-family drift detected:

  .claude/workflows/phase-step.js pins 'claude-fable-5' (top tier), outside tier(s) small of role(s) implementer/verifier
  .codex/agents/implementer.toml model 'gpt-5.6-terra' is not a Codex model of the tier(s) declared for role(s) implementer
  role 'implementer': no Codex agent binding runs its primary tier 'small' (gpt-5.6-luna)
exit=1
```

## Gates

- `scripts/agent/run-gates.sh --diff origin/devel`: pytest, ruff check, ruff format, mypy tests/, markdownlint — all PASS
- `check_agent_roles.py --all` and `--diff origin/devel` green on the tree (7 roles); `sh -n .githooks/pre-commit`, `parity-guard.sh`, `check-agent-config-parity.sh`, `check_comment_narration.py`, `check_version_literals.py` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a shared contract defining agent roles, model tiers, vendor mappings, delegation rules, and acceptance criteria.
  * Updated project guidance to reference the centralized role definitions and validation process.

* **Quality & Validation**
  * Added automated checks to detect inconsistencies between role definitions, model tiers, workflows, and agent configurations.
  * Added pre-commit and pull-request validation gates, with unrelated changes skipped automatically.

* **Tests**
  * Added comprehensive coverage for valid configurations, malformed definitions, missing bindings, configuration drift, and command-line behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->