### PR TITLE
fix: isolate path derivation from CDPATH

### DIFF
--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -70,7 +70,7 @@ ON_BOX_HOOK="${ON_BOX_RCD_DIR}/pfblockerng_repo_generate.sh"
 
 # The hook source script lives next to this file. Resolve relative to this
 # script's directory so it works regardless of cwd.
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
 HOOK_SRC="${SCRIPT_DIR}/rc.d/pfblockerng_repo_generate.sh"
 
 # pfb_emit_embedded_hook — print the rc.d generator hook to stdout. In the repository

--- a/scripts/bench_ip_recompute.sh
+++ b/scripts/bench_ip_recompute.sh
@@ -25,7 +25,7 @@
 # for that side of the comparison; duplicate() is never resurrected here.
 set -u
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(CDPATH='' cd "$(dirname "$0")/.." && pwd)"
 PFBSH="${REPO_ROOT}/src/usr/local/pkg/pfblockerng/pfblockerng.sh"
 GREPCIDR="$(command -v grepcidr || true)"
 [ -n "$GREPCIDR" ] || { echo "bench: real grepcidr not found on PATH" >&2; exit 1; }

--- a/scripts/build-leg.sh
+++ b/scripts/build-leg.sh
@@ -46,7 +46,7 @@
 set -eu
 
 # ── Locate helpers relative to this script (CWD-independent) ────────────────
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
 
 # ── Scrub inherited git context (pre-commit hook exports GIT_DIR etc.) ──────
 # shellcheck source=scripts/lib/git-env-scrub.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,7 +14,7 @@
 
 set -e
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(CDPATH='' cd "$(dirname "$0")/.." && pwd)"
 CHANNEL="devel"
 SSH_TARGET=""
 

--- a/scripts/git-env-scrub-guard.sh
+++ b/scripts/git-env-scrub-guard.sh
@@ -30,7 +30,7 @@
 
 set -eu
 
-_SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+_SELF_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
 ROOT="${1:-${_SELF_DIR%/scripts}}"
 
 TMPF="$(mktemp)"

--- a/scripts/image-publish.sh
+++ b/scripts/image-publish.sh
@@ -94,7 +94,7 @@ die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 # Shared type/tag/push helpers — sourced so this script's published artifact is
 # byte-identical to image-upgrade.sh's for the same (type, version).
-SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 [ -f "$SCRIPT_DIR/image-lib.sh" ] || die "image-lib.sh not found next to this script: $SCRIPT_DIR/image-lib.sh"
 # shellcheck source=scripts/image-lib.sh
 . "$SCRIPT_DIR/image-lib.sh"

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -115,7 +115,7 @@ die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 # Shared type/tag/push helpers — sourced so the published artifact is byte-identical
 # to running image-publish.sh --type <type> with the derived tag.
-SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 [ -f "$SCRIPT_DIR/image-lib.sh" ] || die "image-lib.sh not found next to this script: $SCRIPT_DIR/image-lib.sh"
 # shellcheck source=scripts/image-lib.sh
 . "$SCRIPT_DIR/image-lib.sh"

--- a/scripts/install-from-repo.sh
+++ b/scripts/install-from-repo.sh
@@ -28,7 +28,7 @@
 
 set -e
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(CDPATH='' cd "$(dirname "$0")/.." && pwd)"
 CHANNEL="devel"
 PORT=22
 SSH_KEY=""

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -58,7 +58,7 @@ case "${1:-}" in
     -h|--help) usage 0 ;;
 esac
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(CDPATH='' cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 # ── Required env ──────────────────────────────────────────────────────────── #

--- a/scripts/publish-smoke-image.sh
+++ b/scripts/publish-smoke-image.sh
@@ -23,7 +23,7 @@ set -e
 
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
-SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 PUBLISH="$SCRIPT_DIR/image-publish.sh"
 [ -x "$PUBLISH" ] || die "image-publish.sh not found next to this script: $PUBLISH"
 

--- a/scripts/resolve-legs.sh
+++ b/scripts/resolve-legs.sh
@@ -55,7 +55,7 @@
 set -eu
 
 # ── Self-dir (for lib + sibling scripts) ─────────────────────────────────── #
-_RL_DIR="$(cd "$(dirname "$0")" && pwd)"
+_RL_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
 
 # ── GIT_* scrub (ADR-47 chokepoint) ───────────────────────────────────── #
 # shellcheck source=scripts/lib/git-env-scrub.sh

--- a/scripts/run-smoke.sh
+++ b/scripts/run-smoke.sh
@@ -55,7 +55,7 @@
 
 set -eu
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(CDPATH='' cd "$(dirname "$0")/.." && pwd)"
 
 # ── Defaults ───────────────────────────────────────────────────────────────── #
 _PATHS="tests/smoke"

--- a/scripts/select-box.sh
+++ b/scripts/select-box.sh
@@ -41,7 +41,7 @@
 #   is a single shared object visible to the whole pool.
 
 # ── Locate sibling lib/ (same directory as this script) ──────────────────────
-_SB_SELF="$(cd "$(dirname "$0")" && pwd)"
+_SB_SELF="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
 
 # ── Scrub inherited GIT_* context (via shared lib — ADR-47 chokepoint) ────
 # The pre-commit hook exports GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE / ...

--- a/scripts/sparse-clone-ports.sh
+++ b/scripts/sparse-clone-ports.sh
@@ -48,7 +48,7 @@ PYFLAVOR="$6"
 
 # Resolve the repo root relative to this script so the builder can always be found
 # regardless of where the caller's CWD is.
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
 BUILDER="${SCRIPT_DIR}/build-pkg-portable.py"
 
 # Derive the pfBlockerNG port dir for the channel — single source of truth in the

--- a/tests/shell/boot_vm_spec.sh
+++ b/tests/shell/boot_vm_spec.sh
@@ -15,6 +15,7 @@ Describe 'boot_vm.sh slirp netdev argv'
     scrub_git_env
     WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/bootvmspec.XXXXXX")"
     ARGV_FILE="${WORK}/argv"
+    IMG_ARGV_FILE="${WORK}/img-argv"
     BASE="${WORK}/base.qcow2"; : > "$BASE"
     OVERLAY="${WORK}/ovl.qcow2"
     BIN="${WORK}/bin"; mkdir -p "$BIN"
@@ -28,6 +29,7 @@ QEOF
     # Stub qemu-img: create the overlay (its LAST arg) so the -drive path is valid.
     cat > "${BIN}/qemu-img" << 'QIEOF'
 #!/bin/sh
+printf '%s\n' "$@" > "$IMG_ARGV_FILE"
 while [ "$#" -gt 1 ]; do shift; done
 : > "$1"
 QIEOF
@@ -35,7 +37,7 @@ QIEOF
 
     SMOKE_QEMU_BIN="${BIN}/qemu"
     SMOKE_QEMU_IMG_BIN="${BIN}/qemu-img"
-    export WORK ARGV_FILE BASE OVERLAY SMOKE_QEMU_BIN SMOKE_QEMU_IMG_BIN
+    export WORK ARGV_FILE IMG_ARGV_FILE BASE OVERLAY SMOKE_QEMU_BIN SMOKE_QEMU_IMG_BIN
   }
   teardown() { rm -rf "$WORK"; }
   BeforeEach 'setup'
@@ -44,6 +46,24 @@ QIEOF
   # ---- slirp (default) — role pfsense ----------------------------------------
 
   Describe 'role pfsense'
+    It 'resolves absolute, basename, and nested-relative base images independently of CDPATH'
+      mkdir -p "${WORK}/base-dir/nested" "${WORK}/decoy/nested"
+      : > "${WORK}/base-dir/base.qcow2"
+      : > "${WORK}/base-dir/nested/base.qcow2"
+      When run sh -c '
+        unset CDPATH
+        IMG_ARGV_FILE="$5/absolute" sh "$1" "$2" "$5/absolute-overlay"
+        cd "$3" || exit 1
+        CDPATH="" IMG_ARGV_FILE="$5/basename" sh "$1" base.qcow2 "$5/basename-overlay"
+        CDPATH="$4" IMG_ARGV_FILE="$5/nested" sh "$1" nested/base.qcow2 "$5/nested-overlay"
+      ' _ "$SCRIPT" "$BASE" "${WORK}/base-dir" "${WORK}/decoy" "$WORK"
+      The status should be success
+      The stderr should include 'boot_vm:'
+      The contents of file "${WORK}/absolute" should include "$BASE"
+      The contents of file "${WORK}/basename" should include "${WORK}/base-dir/base.qcow2"
+      The contents of file "${WORK}/nested" should include "${WORK}/base-dir/nested/base.qcow2"
+    End
+
     It 'WAN net0 is user-net with the 192.168.89.2 host alias'
       When run sh "$SCRIPT" --role pfsense "$BASE" "$OVERLAY"
       The status should be success

--- a/tests/shell/cdpath_spec.sh
+++ b/tests/shell/cdpath_spec.sh
@@ -1,0 +1,78 @@
+#shellcheck shell=sh
+# cdpath_spec.sh — path derivation must ignore inherited CDPATH.
+
+Describe 'script path derivation'
+  assert_cdpath_guards() {
+    _cdp_failed=0
+    while IFS='|' read -r _cdp_file _cdp_line; do
+      [ -n "$_cdp_file" ] || continue
+      if ! grep -Fqx "$_cdp_line" "${PFB_ROOT}/${_cdp_file}"; then
+        printf '%s: expected exact path guard: %s\n' "$_cdp_file" "$_cdp_line" >&2
+        _cdp_failed=1
+      fi
+    done <<'EOF'
+scripts/add-repo.sh|SCRIPT_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
+scripts/bench_ip_recompute.sh|REPO_ROOT="$(CDPATH='' cd "$(dirname "$0")/.." && pwd)"
+scripts/build-leg.sh|SCRIPT_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
+scripts/deploy.sh|REPO_ROOT="$(CDPATH='' cd "$(dirname "$0")/.." && pwd)"
+scripts/git-env-scrub-guard.sh|_SELF_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
+scripts/image-publish.sh|SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+scripts/image-upgrade.sh|SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+scripts/install-from-repo.sh|REPO_ROOT="$(CDPATH='' cd "$(dirname "$0")/.." && pwd)"
+scripts/local-smoke.sh|REPO_ROOT="$(CDPATH='' cd "$(dirname "$0")/.." && pwd)"
+scripts/publish-smoke-image.sh|SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+scripts/resolve-legs.sh|_RL_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
+scripts/run-smoke.sh|REPO_ROOT="$(CDPATH='' cd "$(dirname "$0")/.." && pwd)"
+scripts/select-box.sh|_SB_SELF="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
+scripts/sparse-clone-ports.sh|SCRIPT_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
+tests/smoke/boot_vm.sh|    *) BASE_IMG="$(CDPATH='' cd "$(dirname "$BASE_IMG")" && pwd)/$(basename "$BASE_IMG")" ;;
+EOF
+    return "$_cdp_failed"
+  }
+
+  image_publish_help_matrix() (
+    _cdp_work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/cdpathspec.XXXXXX")" || exit 1
+    trap 'rm -rf "$_cdp_work"' EXIT INT TERM
+    _cdp_decoy="${_cdp_work}/decoy"
+    _cdp_space_decoy="${_cdp_work}/space decoy"
+    mkdir -p "${_cdp_decoy}/scripts" "${_cdp_space_decoy}/scripts" || exit 1
+    cd "$PFB_ROOT" || exit 1
+
+    _cdp_help() {
+      _cdp_label="$1"
+      _cdp_value="$2"
+      _cdp_argv0="$3"
+      if [ "$_cdp_value" = __UNSET__ ]; then
+        (unset CDPATH; sh "$_cdp_argv0" --help)
+      else
+        (CDPATH="$_cdp_value"; export CDPATH; sh "$_cdp_argv0" --help)
+      fi > "${_cdp_work}/out" 2> "${_cdp_work}/err"
+      _cdp_rc=$?
+      if [ "$_cdp_rc" -ne 0 ] || ! grep -q 'Usage:' "${_cdp_work}/out"; then
+        printf 'image-publish --help failed: %s rc=%s\nstdout:\n' "$_cdp_label" "$_cdp_rc" >&2
+        sed 's/^/  /' "${_cdp_work}/out" >&2
+        printf 'stderr:\n' >&2
+        sed 's/^/  /' "${_cdp_work}/err" >&2
+        return 1
+      fi
+    }
+
+    _cdp_help 'CDPATH unset, absolute $0' __UNSET__ "${PFB_ROOT}/scripts/image-publish.sh" || exit 1
+    _cdp_help 'CDPATH empty, ./scripts $0' '' './scripts/image-publish.sh' || exit 1
+    _cdp_help 'CDPATH=., scripts $0' '.' 'scripts/image-publish.sh' || exit 1
+    _cdp_help 'CDPATH=repo, scripts $0' "$PFB_ROOT" 'scripts/image-publish.sh' || exit 1
+    _cdp_help 'CDPATH=decoy, scripts $0' "$_cdp_decoy" 'scripts/image-publish.sh' || exit 1
+    _cdp_help 'CDPATH=decoy:repo, scripts $0' "${_cdp_decoy}:${PFB_ROOT}" 'scripts/image-publish.sh' || exit 1
+    _cdp_help 'CDPATH=space-decoy, scripts $0' "$_cdp_space_decoy" 'scripts/image-publish.sh' || exit 1
+  )
+
+  It 'guards all path-producing cd substitutions'
+    When call assert_cdpath_guards
+    The status should be success
+  End
+
+  It 'keeps image-publish --help working across hostile CDPATH and invocation forms'
+    When call image_publish_help_matrix
+    The status should be success
+  End
+End

--- a/tests/smoke/boot_vm.sh
+++ b/tests/smoke/boot_vm.sh
@@ -157,7 +157,7 @@ fi
 # and fail. An absolute backing path is location-independent.
 case "$BASE_IMG" in
     /*) ;;
-    *) BASE_IMG="$(cd "$(dirname "$BASE_IMG")" && pwd)/$(basename "$BASE_IMG")" ;;
+    *) BASE_IMG="$(CDPATH='' cd "$(dirname "$BASE_IMG")" && pwd)/$(basename "$BASE_IMG")" ;;
 esac
 
 # Resolve the qemu binaries by name if the absolute path is not present


### PR DESCRIPTION
## Summary

- isolate all 15 script-relative path derivations from inherited CDPATH
- preserve each site's existing quoting, pwd, and cd semantics
- add dynamic hostile-CDPATH and relative BASE_IMG coverage

## Root cause

POSIX cd consults CDPATH for relative operands and may print the selected directory. Inside command substitution, that output corrupted captured paths or selected a decoy tree.

## Validation

- frozen RED/GREEN proof: 9 examples, 3 failures before; 9 examples, 0 failures after
- all 15 sites covered, full ShellSpec suite, canonical shell gates
- independent phase-step gate PASS

Fixes #1342

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script path resolution so command-line tools work consistently when `CDPATH` is set, including with relative paths, nested directories, and paths containing spaces.
  * Ensured image and repository operations resolve their locations reliably without changing deployment or boot behavior.

* **Tests**
  * Added coverage for `CDPATH`-independent path handling across shell scripts.
  * Expanded boot and image publishing checks to verify resolved paths and command arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->