### PR TITLE
agents: bound wait-script gh calls

### DIFF
--- a/scripts/agent/agent_env.sh
+++ b/scripts/agent/agent_env.sh
@@ -34,6 +34,39 @@ require_tool() {
 	fi
 }
 
+# Run one gh request within both its per-call cap and the wait's remaining deadline.
+gh_bounded() {
+	gh_now=$(date +%s)
+	gh_remaining=$((deadline - gh_now))
+	[ "$gh_remaining" -gt 0 ] || return 124
+	[ "$gh_remaining" -le 30 ] || gh_remaining=30
+	gh_stderr=$(mktemp "${TMPDIR:-/tmp}/pfb-gh-stderr.XXXXXX") || return 1
+	if [ "$gh_remaining" -gt 1 ]; then
+		gh_soft=$((gh_remaining - 1))
+		{ timeout -k 1 "$gh_soft" gh "$@"; } 2>"$gh_stderr"
+		gh_status=$?
+	else
+		{ timeout -s KILL "$gh_remaining" gh "$@"; } 2>"$gh_stderr"
+		gh_status=$?
+	fi
+	if [ "$gh_status" -ne 0 ]; then
+		cat "$gh_stderr"
+	fi
+	rm -f "$gh_stderr"
+	return "$gh_status"
+}
+
+# Pause no longer than the wait's remaining wall-clock budget.
+sleep_bounded() {
+	sleep_now=$(date +%s)
+	sleep_remaining=$((deadline - sleep_now))
+	[ "$sleep_remaining" -gt 0 ] || return 1
+	sleep_delay=$1
+	[ "$sleep_delay" -le "$sleep_remaining" ] || sleep_delay=$sleep_remaining
+	[ "$sleep_delay" -gt 0 ] || return 0
+	sleep "$sleep_delay"
+}
+
 # ADR-47: under a git hook, exported GIT_DIR/GIT_INDEX_FILE would aim every git op
 # at the hook's repo instead of the --worktree the caller named. Git-touching scripts
 # call this first. $1 = the calling script's $0 (to locate the shared lib).

--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -55,6 +55,7 @@ main() {
 	done
 	{ [ -n "$repo" ] && [ -n "$pr" ]; } || usage
 	require_gh
+	require_tool timeout
 	require_tool jq
 
 	# Wall-clock deadline alongside the cap (CLAUDE.md "No orphaned waits" #1);
@@ -66,7 +67,7 @@ main() {
 		if [ "$(date +%s)" -ge "$deadline" ]; then
 			break
 		fi
-		if ! json=$(gh pr checks "$pr" --repo "$repo" --json name,bucket 2>&1); then
+		if ! json=$(gh_bounded pr checks "$pr" --repo "$repo" --json name,bucket); then
 			# 3 consecutive gh failures = a real problem (bad repo/pr, auth, outage),
 			# not "no checks yet" -- fail loudly instead of polling to a blind TIMEOUT.
 			ghfail=$((ghfail + 1))
@@ -75,7 +76,7 @@ main() {
 				exit 1
 			fi
 			i=$((i + 1))
-			sleep "$interval"
+			sleep_bounded "$interval" || break
 			continue
 		fi
 		ghfail=0
@@ -89,7 +90,7 @@ main() {
 				;;
 		esac
 		i=$((i + 1))
-		sleep "$interval"
+		sleep_bounded "$interval" || break
 	done
 	printf 'TIMEOUT\n'
 }

--- a/scripts/agent/wait-reviewer.sh
+++ b/scripts/agent/wait-reviewer.sh
@@ -23,7 +23,8 @@
 # Login match is ANCHORED: == handle, == handle[bot], or startswith(handle-).
 # A wall-clock deadline (max-iter x interval + 300 s slack; PFB_WAIT_DEADLINE overrides)
 # bounds the wait even when individual gh calls stall.
-# Exit codes: see agent_env.sh (0 verdict, 2 usage, 3 gh unavailable -> MCP fallback).
+# Exit codes: see agent_env.sh (0 verdict, 1 GH-ERROR after 3 failed polls, 2 usage,
+# 3 gh unavailable -> MCP fallback, 4 TOOL-MISSING).
 # Self-terminating by construction (CLAUDE.md "No orphaned waits" #1): iteration cap AND
 # wall-clock deadline; run it in the background and read the verdict.
 
@@ -96,28 +97,73 @@ jq_filter() {
 }
 
 fetch_state() {
-	inline=$(gh api "repos/$repo/pulls/$pr/comments" --paginate -q "$(jq_filter created_at) | .id" 2>/dev/null)
-	review=$(gh api "repos/$repo/pulls/$pr/reviews" --paginate -q "$(jq_filter submitted_at) | (.body // \"x\")" 2>/dev/null)
-	issuec=$(gh api "repos/$repo/issues/$pr/comments" --paginate -q "$(jq_filter updated_at) | (.body // \"\")" 2>/dev/null)
+	fetch_error=''
+	if [ "$default_since" -eq 1 ]; then
+		if ! since=$(gh_bounded pr view "$pr" --repo "$repo" --json commits -q '.commits[-1].committedDate'); then
+			fetch_error=$since
+			since=''
+			return 1
+		fi
+		default_since=0
+	fi
+	if ! fetch_inline=$(gh_bounded api "repos/$repo/pulls/$pr/comments" --paginate -q "$(jq_filter created_at) | .id"); then
+		fetch_error=$fetch_inline
+		return 1
+	fi
+	if ! fetch_review=$(gh_bounded api "repos/$repo/pulls/$pr/reviews" --paginate -q "$(jq_filter submitted_at) | (.body // \"x\")"); then
+		fetch_error=$fetch_review
+		return 1
+	fi
+	if ! fetch_issuec=$(gh_bounded api "repos/$repo/issues/$pr/comments" --paginate -q "$(jq_filter updated_at) | (.body // \"\")"); then
+		fetch_error=$fetch_issuec
+		return 1
+	fi
 	# Presence (any commit) vs content (since $since) split (issue #1325): only fetched
 	# when $since narrows the content query, else presence == content already.
 	if [ -n "$since" ]; then
-		inline_any=$(gh api "repos/$repo/pulls/$pr/comments" --paginate -q "$(jq_filter created_at notime) | .id" 2>/dev/null)
-		review_any=$(gh api "repos/$repo/pulls/$pr/reviews" --paginate -q "$(jq_filter submitted_at notime) | .id" 2>/dev/null)
-		issuec_any=$(gh api "repos/$repo/issues/$pr/comments" --paginate -q "$(jq_filter updated_at notime) | .id" 2>/dev/null)
+		if ! fetch_inline_any=$(gh_bounded api "repos/$repo/pulls/$pr/comments" --paginate -q "$(jq_filter created_at notime) | .id"); then
+			fetch_error=$fetch_inline_any
+			return 1
+		fi
+		if ! fetch_review_any=$(gh_bounded api "repos/$repo/pulls/$pr/reviews" --paginate -q "$(jq_filter submitted_at notime) | .id"); then
+			fetch_error=$fetch_review_any
+			return 1
+		fi
+		if ! fetch_issuec_any=$(gh_bounded api "repos/$repo/issues/$pr/comments" --paginate -q "$(jq_filter updated_at notime) | .id"); then
+			fetch_error=$fetch_issuec_any
+			return 1
+		fi
 	else
-		inline_any=$inline
-		review_any=$review
-		issuec_any=$issuec
+		fetch_inline_any=$fetch_inline
+		fetch_review_any=$fetch_review
+		fetch_issuec_any=$fetch_issuec
 	fi
+	fetch_sinfo=''
 	if [ "$handle" = "snyk" ]; then
-		sha=$(gh pr view "$pr" --repo "$repo" --json headRefOid -q .headRefOid 2>/dev/null)
-		sinfo=$(gh api "repos/$repo/commits/$sha/status" \
-			-q '.statuses[] | select((.context|ascii_downcase)|test("snyk")) | "\(.state) \(.description)"' 2>/dev/null)
-		sinfo="$sinfo
-$(gh api "repos/$repo/commits/$sha/check-runs" --paginate \
-			-q '.check_runs[] | select((.name|ascii_downcase)|test("snyk")) | "\(.conclusion // .status) \(.output.title // "")"' 2>/dev/null)"
+		if ! fetch_sha=$(gh_bounded pr view "$pr" --repo "$repo" --json headRefOid -q .headRefOid); then
+			fetch_error=$fetch_sha
+			return 1
+		fi
+		if ! fetch_status=$(gh_bounded api "repos/$repo/commits/$fetch_sha/status" \
+			-q '.statuses[] | select((.context|ascii_downcase)|test("snyk")) | "\(.state) \(.description)"'); then
+			fetch_error=$fetch_status
+			return 1
+		fi
+		if ! fetch_checks=$(gh_bounded api "repos/$repo/commits/$fetch_sha/check-runs" --paginate \
+			-q '.check_runs[] | select((.name|ascii_downcase)|test("snyk")) | "\(.conclusion // .status) \(.output.title // "")"'); then
+			fetch_error=$fetch_checks
+			return 1
+		fi
+		fetch_sinfo="$fetch_status
+$fetch_checks"
 	fi
+	inline=$fetch_inline
+	review=$fetch_review
+	issuec=$fetch_issuec
+	inline_any=$fetch_inline_any
+	review_any=$fetch_review_any
+	issuec_any=$fetch_issuec_any
+	sinfo=$fetch_sinfo
 }
 
 main() {
@@ -139,12 +185,14 @@ main() {
 	{ [ -n "$repo" ] && [ -n "$pr" ] && [ -n "$handle" ]; } || usage
 	case "$mode" in ack|finished) ;; *) usage ;; esac
 	require_gh
+	require_tool timeout
 
 	if [ -z "$max_iter" ]; then
 		if [ "$mode" = "ack" ]; then max_iter=20; else max_iter=60; fi
 	fi
+	default_since=0
 	if [ -z "$since" ] && [ "$mode" = "finished" ] && [ "$handle" != "snyk" ]; then
-		since=$(gh pr view "$pr" --repo "$repo" --json commits -q '.commits[-1].committedDate' 2>/dev/null)
+		default_since=1
 	fi
 
 	# Wall-clock deadline alongside the iteration cap (CLAUDE.md "No orphaned waits" #1):
@@ -153,11 +201,22 @@ main() {
 	deadline=${PFB_WAIT_DEADLINE:-$(( $(date +%s) + max_iter * interval + 300 ))}
 	i=0
 	seen=0
+	ghfail=0
 	while [ "$i" -lt "$max_iter" ]; do
 		if [ "$(date +%s)" -ge "$deadline" ]; then
 			break
 		fi
-		fetch_state
+		if ! fetch_state; then
+			ghfail=$((ghfail + 1))
+			if [ "$ghfail" -ge 3 ]; then
+				printf 'GH-ERROR\n%s\n' "$fetch_error"
+				exit 1
+			fi
+			i=$((i + 1))
+			sleep_bounded "$interval" || break
+			continue
+		fi
+		ghfail=0
 		[ -n "${inline_any}${review_any}${issuec_any}$(printf '%s' "$sinfo" | tr -dc '[:lower:]')" ] && seen=1
 		v=$(classify)
 		if [ -n "$v" ]; then
@@ -170,7 +229,7 @@ main() {
 			exit 0
 		fi
 		i=$((i + 1))
-		sleep "$interval"
+		sleep_bounded "$interval" || break
 	done
 	if [ "$mode" = "ack" ]; then printf 'NOACK\n'; else printf 'TIMEOUT\n'; fi
 }

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -50,10 +50,125 @@ Describe 'wait-checks.sh evaluate_checks()'
   End
 End
 
+Describe 'agent_env.sh bounded gh execution'
+  AGENT_SOURCE_ONLY=1
+  Include scripts/agent/agent_env.sh
+
+  setup_stub() {
+    stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/ghstub.XXXXXX")"
+    cat > "$stubdir/gh" <<'STUB'
+#!/bin/sh
+printf '%s' "${GH_STUB_STDOUT-partial stdout}"
+printf '%s' "${GH_STUB_STDERR- + stderr}" >&2
+if [ -n "${GH_STUB_HANG:-}" ]; then
+	[ -z "${GH_STUB_IGNORE_TERM:-}" ] || trap '' TERM
+	sleep "${GH_STUB_HANG_SECONDS:-4}"
+	[ -z "${GH_STUB_HANG_MARKER:-}" ] || printf done > "$GH_STUB_HANG_MARKER"
+fi
+exit "${GH_STUB_STATUS:-0}"
+STUB
+    chmod +x "$stubdir/gh"
+    PATH="$stubdir:$PATH"
+  }
+  cleanup_stub() { rm -rf "$stubdir"; }
+  Before 'setup_stub'
+  After 'cleanup_stub'
+
+  It 'captures combined diagnostics and preserves the gh child status'
+    deadline=$(( $(date +%s) + 60 ))
+    export GH_STUB_STATUS=7
+    When call gh_bounded api endpoint
+    The status should equal 7
+    The output should equal 'partial stdout + stderr'
+  End
+
+  It 'suppresses stderr from a successful stderr-only request'
+    deadline=$(( $(date +%s) + 60 ))
+    export GH_STUB_STDOUT=''
+    When call gh_bounded api endpoint
+    The status should equal 0
+    The output should equal ''
+  End
+
+  It 'keeps successful JSON stdout valid when gh also writes stderr'
+    deadline=$(( $(date +%s) + 60 ))
+    export GH_STUB_STDOUT='[{"name":"pytest","bucket":"pass"}]'
+    export GH_STUB_STDERR='warning from gh'
+    When call gh_bounded pr checks 1
+    The status should equal 0
+    The output should equal '[{"name":"pytest","bucket":"pass"}]'
+  End
+
+  It 'caps one call at 30 seconds even when the deadline is farther away'
+    cat > "$stubdir/timeout" <<'STUB'
+#!/bin/sh
+printf '%s' "$*"
+exit 124
+STUB
+    chmod +x "$stubdir/timeout"
+    deadline=$(( $(date +%s) + 300 ))
+    When call gh_bounded api endpoint
+    The status should equal 124
+    The output should equal '-k 1 29 gh api endpoint'
+  End
+
+  It 'returns timeout status with partial output when the remaining deadline expires'
+    deadline=$(( $(date +%s) + 2 ))
+    export GH_STUB_HANG=1
+    When call gh_bounded api endpoint
+    The status should equal 124
+    The output should equal 'partial stdout + stderr'
+  End
+
+  It 'kills a TERM-ignoring gh child before it can outlive the deadline'
+    deadline=$(( $(date +%s) + 2 ))
+    export GH_STUB_HANG=1 GH_STUB_IGNORE_TERM=1 GH_STUB_HANG_SECONDS=3
+    export GH_STUB_HANG_MARKER="$stubdir/outlived"
+    When call gh_bounded api endpoint
+    The status should not equal 0
+    The output should include 'partial stdout + stderr'
+    The file "$GH_STUB_HANG_MARKER" should not be exist
+  End
+End
+
+Describe 'wait-checks.sh tool contracts'
+  setup_tool_path() {
+    toolpath="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/toolpath.XXXXXX")"
+    ln -s "$(command -v dirname)" "$toolpath/dirname"
+  }
+  cleanup_tool_path() { rm -rf "$toolpath"; }
+  Before 'setup_tool_path'
+  After 'cleanup_tool_path'
+
+  It 'exits 3 when gh is absent'
+    When run env PATH="$toolpath" /bin/sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The status should equal 3
+    The stderr should include 'GH-UNAVAILABLE'
+  End
+
+  It 'exits 4 when timeout is absent'
+    printf '#!/bin/sh\nexit 0\n' > "$toolpath/gh"
+    chmod +x "$toolpath/gh"
+    When run env PATH="$toolpath" /bin/sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The status should equal 4
+    The stderr should include 'TOOL-MISSING: timeout'
+  End
+End
+
 Describe 'wait-checks.sh loop verdicts (stub gh)'
   setup_stub() {
     stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/ghstub.XXXXXX")"
-    printf '#!/bin/sh\n[ -n "${GH_STUB_FAIL:-}" ] && exit 1\necho "$GH_STUB_CHECKS"\n' > "$stubdir/gh"
+    cat > "$stubdir/gh" <<'STUB'
+#!/bin/sh
+count=0
+[ ! -f "${GH_STUB_COUNT_FILE:-}" ] || count=$(cat "$GH_STUB_COUNT_FILE")
+count=$((count + 1))
+[ -z "${GH_STUB_COUNT_FILE:-}" ] || printf '%s\n' "$count" > "$GH_STUB_COUNT_FILE"
+case " ${GH_STUB_FAIL_CALLS:-} " in
+	*" $count "*) printf '%s\n' "${GH_STUB_FAIL_OUTPUT:-HTTP 404}"; exit 1 ;;
+esac
+printf '%s\n' "$GH_STUB_CHECKS"
+STUB
     chmod +x "$stubdir/gh"
     PATH="$stubdir:$PATH"
   }
@@ -61,6 +176,19 @@ Describe 'wait-checks.sh loop verdicts (stub gh)'
   Before 'setup_stub'
   After 'cleanup_stub'
   script="scripts/agent/wait-checks.sh"
+
+  setup_near_deadline() {
+    cat > "$stubdir/date" <<'STUB'
+#!/bin/sh
+printf '100\n'
+STUB
+    cat > "$stubdir/sleep" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$1" >> "$WAIT_SLEEP_FILE"
+STUB
+    chmod +x "$stubdir/date" "$stubdir/sleep"
+    export PFB_WAIT_DEADLINE=103 WAIT_SLEEP_FILE="$stubdir/sleeps"
+  }
 
   It 'reports TIMEOUT when checks stay pending through the cap'
     export GH_STUB_CHECKS='[{"name":"pytest","bucket":"pending"}]'
@@ -74,12 +202,38 @@ Describe 'wait-checks.sh loop verdicts (stub gh)'
     When run sh "$script" --repo o/r --pr 1 --interval 0 --max-iter 3
     The line 1 of output should equal 'TIMEOUT'
   End
+
+  It 'resets the failure streak after a successful pending snapshot'
+    export GH_STUB_COUNT_FILE="$stubdir/count"
+    export GH_STUB_FAIL_CALLS='1 2 4 5'
+    export GH_STUB_CHECKS='[{"name":"pytest","bucket":"pending"}]'
+    When run sh "$script" --repo o/r --pr 1 --interval 0 --max-iter 5
+    The status should equal 0
+    The line 1 of output should equal 'TIMEOUT'
+  End
+
+  It 'caps sleep after a successful pending poll at the remaining deadline'
+    setup_near_deadline
+    export GH_STUB_CHECKS='[{"name":"pytest","bucket":"pending"}]'
+    When run sh "$script" --repo o/r --pr 1 --interval 99 --max-iter 1
+    The line 1 of output should equal 'TIMEOUT'
+    The contents of file "$WAIT_SLEEP_FILE" should equal '3'
+  End
+
+  It 'caps sleep after a failed poll at the remaining deadline'
+    setup_near_deadline
+    export GH_STUB_COUNT_FILE="$stubdir/count"
+    export GH_STUB_FAIL_CALLS='1'
+    When run sh "$script" --repo o/r --pr 1 --interval 99 --max-iter 1
+    The line 1 of output should equal 'TIMEOUT'
+    The contents of file "$WAIT_SLEEP_FILE" should equal '3'
+  End
 End
 
 Describe 'wait-checks.sh gh-failure detection'
   setup_stub() {
     stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/ghstub.XXXXXX")"
-    printf '#!/bin/sh\nexit 1\n' > "$stubdir/gh"
+    printf '#!/bin/sh\nprintf '\''[{"name":"pytest","bucket":"fail"}] HTTP 404\\n'\''\nexit 1\n' > "$stubdir/gh"
     chmod +x "$stubdir/gh"
     PATH="$stubdir:$PATH"
   }
@@ -87,9 +241,10 @@ Describe 'wait-checks.sh gh-failure detection'
   Before 'setup_stub'
   After 'cleanup_stub'
 
-  It 'reports GH-ERROR after repeated gh failures instead of polling to a blind TIMEOUT'
+  It 'reports GH-ERROR after repeated failures without classifying their actionable stdout'
     When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 10
     The status should equal 1
     The line 1 of output should equal 'GH-ERROR'
+    The output should include 'HTTP 404'
   End
 End

--- a/tests/shell/agent_wait_reviewer_spec.sh
+++ b/tests/shell/agent_wait_reviewer_spec.sh
@@ -129,11 +129,28 @@ Describe 'wait-reviewer.sh classify()'
 End
 
 Describe 'wait-reviewer.sh gh-unavailable contract'
+  setup_tool_path() {
+    toolpath="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/toolpath.XXXXXX")"
+    ln -s "$(command -v dirname)" "$toolpath/dirname"
+    ln -s "$(command -v tr)" "$toolpath/tr"
+  }
+  cleanup_tool_path() { rm -rf "$toolpath"; }
+  Before 'setup_tool_path'
+  After 'cleanup_tool_path'
+
   It 'exits 3 with the MCP fallback pointer when gh is absent'
     When run sh -c 'PATH=/dev/null; . scripts/agent/agent_env.sh; require_gh'
     The status should equal 3
     The stderr should include 'GH-UNAVAILABLE'
     The stderr should include 'mcp__github__'
+  End
+
+  It 'exits 4 when timeout is absent'
+    printf '#!/bin/sh\nexit 0\n' > "$toolpath/gh"
+    chmod +x "$toolpath/gh"
+    When run env PATH="$toolpath" /bin/sh scripts/agent/wait-reviewer.sh --repo o/r --pr 1 --handle bot --until ack --interval 0 --max-iter 1
+    The status should equal 4
+    The stderr should include 'TOOL-MISSING: timeout'
   End
 End
 
@@ -176,16 +193,53 @@ Describe 'wait-reviewer.sh loop verdicts (stub gh)'
     stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/ghstub.XXXXXX")"
     cat > "$stubdir/gh" <<'STUB'
 #!/bin/sh
+count=0
+if [ -n "${GH_STUB_COUNT_FILE:-}" ]; then
+	[ ! -f "$GH_STUB_COUNT_FILE" ] || count=$(cat "$GH_STUB_COUNT_FILE")
+	count=$((count + 1))
+	printf '%s\n' "$count" > "$GH_STUB_COUNT_FILE"
+	case " ${GH_STUB_FAIL_CALLS:-} " in
+		*" $count "*) printf '%s\n' "${GH_STUB_FAIL_OUTPUT:-HTTP 404}"; exit 1 ;;
+	esac
+fi
+
+site='' file=''
 case "$*" in
-	*pulls/*/comments*) cat "$GH_STUB_INLINE" 2>/dev/null ;;
-	*pulls/*/reviews*)
+	*'--json commits'*) site='default-since' ;;
+	*pulls/*/comments*)
 		case "$*" in
-			*'select(.submitted_at >'*) cat "$GH_STUB_REVIEW_SINCE" 2>/dev/null ;;
-			*) cat "$GH_STUB_REVIEW_ANY" 2>/dev/null ;;
+			*'created_at >'*) site='inline-content'; file=${GH_STUB_INLINE:-} ;;
+			*) site='inline-presence'; file=${GH_STUB_INLINE_ANY:-${GH_STUB_INLINE:-}} ;;
 		esac
 		;;
-	*) exit 0 ;;
+	*pulls/*/reviews*)
+		case "$*" in
+			*'submitted_at >'*) site='review-content'; file=${GH_STUB_REVIEW_SINCE:-} ;;
+			*) site='review-presence'; file=${GH_STUB_REVIEW_ANY:-${GH_STUB_REVIEW_SINCE:-}} ;;
+		esac
+		;;
+	*issues/*/comments*)
+		case "$*" in
+			*'updated_at >'*) site='issue-content'; file=${GH_STUB_ISSUE_SINCE:-} ;;
+			*) site='issue-presence'; file=${GH_STUB_ISSUE_ANY:-${GH_STUB_ISSUE_SINCE:-}} ;;
+		esac
+		;;
+	*'--json headRefOid'*) site='snyk-head' ;;
+	*/status*) site='snyk-status'; file=${GH_STUB_SNYK_STATUS:-} ;;
+	*/check-runs*) site='snyk-check-runs'; file=${GH_STUB_SNYK_CHECKS:-} ;;
 esac
+
+if [ "${GH_STUB_FAIL_SITE:-}" = "$site" ]; then
+	[ "$site" = 'default-since' ] || printf '%s\n' "${GH_STUB_FAIL_OUTPUT:-HTTP 404}"
+	exit 1
+fi
+
+case "$site" in
+	default-since) printf '%s\n' '2026-01-01T00:00:00Z' ;;
+	snyk-head) printf '%s\n' 'deadbeef' ;;
+	*) [ -z "$file" ] || cat "$file" ;;
+esac
+exit 0
 STUB
     chmod +x "$stubdir/gh"
     PATH="$stubdir:$PATH"
@@ -194,6 +248,19 @@ STUB
   Before 'setup_stub'
   After 'cleanup_stub'
   script="scripts/agent/wait-reviewer.sh"
+
+  setup_near_deadline() {
+    cat > "$stubdir/date" <<'STUB'
+#!/bin/sh
+printf '100\n'
+STUB
+    cat > "$stubdir/sleep" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$1" >> "$WAIT_SLEEP_FILE"
+STUB
+    chmod +x "$stubdir/date" "$stubdir/sleep"
+    export PFB_WAIT_DEADLINE=103 WAIT_SLEEP_FILE="$stubdir/sleeps"
+  }
 
   It 'reports NOACK when the cap expires in ack mode with zero engagement'
     unset GH_STUB_INLINE
@@ -214,6 +281,20 @@ STUB
     The output should include 'FINISHED'
   End
 
+  It 'reports FINISHED when a submitted review appears'
+    export GH_STUB_REVIEW_SINCE="$stubdir/review.txt"
+    echo review > "$GH_STUB_REVIEW_SINCE"
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 3
+    The output should include 'FINISHED'
+  End
+
+  It 'reports FINISHED when an actionable issue comment appears'
+    export GH_STUB_ISSUE_SINCE="$stubdir/issue.txt"
+    echo 'Actionable comments posted: 1' > "$GH_STUB_ISSUE_SINCE"
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 3
+    The output should include 'FINISHED'
+  End
+
   It 'honours the wall-clock deadline even when content would be found (No-orphaned-waits #1)'
     export GH_STUB_INLINE="$stubdir/inline.txt"
     echo 42 > "$GH_STUB_INLINE"
@@ -227,5 +308,107 @@ STUB
     echo 99 > "$GH_STUB_REVIEW_ANY"
     When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 3 --presence 1
     The line 1 of output should equal 'TIMEOUT'
+  End
+
+  It 'uses the default time floor while treating an older review only as presence'
+    export GH_STUB_REVIEW_ANY="$stubdir/review_any.txt"
+    echo 99 > "$GH_STUB_REVIEW_ANY"
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --interval 0 --max-iter 3 --presence 1
+    The line 1 of output should equal 'TIMEOUT'
+  End
+
+
+  It 'treats an inline comment before --since as presence: TIMEOUT, not NOTPRESENT'
+    export GH_STUB_INLINE_ANY="$stubdir/inline_any.txt"
+    echo 98 > "$GH_STUB_INLINE_ANY"
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 3 --presence 1
+    The line 1 of output should equal 'TIMEOUT'
+  End
+
+  It 'treats an issue comment before --since as presence: TIMEOUT, not NOTPRESENT'
+    export GH_STUB_ISSUE_ANY="$stubdir/issue_any.txt"
+    echo 97 > "$GH_STUB_ISSUE_ANY"
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 3 --presence 1
+    The line 1 of output should equal 'TIMEOUT'
+  End
+
+  It 'reads a terminal Snyk commit status'
+    export GH_STUB_SNYK_STATUS="$stubdir/status.txt"
+    echo 'success Scan completed' > "$GH_STUB_SNYK_STATUS"
+    When run sh "$script" --repo o/r --pr 1 --handle snyk --until finished --since x --interval 0 --max-iter 3
+    The output should include 'FINISHED'
+  End
+
+  It 'reads a terminal Snyk check-run'
+    export GH_STUB_SNYK_CHECKS="$stubdir/checks.txt"
+    echo 'completed Scan completed' > "$GH_STUB_SNYK_CHECKS"
+    When run sh "$script" --repo o/r --pr 1 --handle snyk --until finished --since x --interval 0 --max-iter 3
+    The output should include 'FINISHED'
+  End
+
+  It 'discards earlier terminal data when a later snapshot call fails'
+    export GH_STUB_INLINE="$stubdir/inline.txt"
+    echo 42 > "$GH_STUB_INLINE"
+    export GH_STUB_FAIL_SITE='issue-content'
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 1
+    The line 1 of output should equal 'TIMEOUT'
+  End
+
+  It 'never classifies actionable stdout from a failed gh call'
+    export GH_STUB_FAIL_SITE='inline-content'
+    export GH_STUB_FAIL_OUTPUT='Actionable comments posted: 3 (HTTP 404)'
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 3
+    The status should equal 1
+    The line 1 of output should equal 'GH-ERROR'
+  End
+
+  It 'keeps the default time floor when its lookup fails, rejecting a stale review'
+    export GH_STUB_FAIL_SITE='default-since'
+    export GH_STUB_REVIEW_ANY="$stubdir/stale_review.txt"
+    echo stale-review > "$GH_STUB_REVIEW_ANY"
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --interval 0 --max-iter 3
+    The status should equal 1
+    The line 1 of output should equal 'GH-ERROR'
+  End
+
+  It 'resets the failure streak after a complete successful poll'
+    export GH_STUB_COUNT_FILE="$stubdir/count"
+    export GH_STUB_FAIL_CALLS='1 2 6 7'
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until ack --interval 0 --max-iter 5 --presence 0
+    The status should equal 0
+    The line 1 of output should equal 'NOACK'
+  End
+
+  It 'caps sleep after a successful pending poll at the remaining deadline'
+    setup_near_deadline
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until ack --interval 99 --max-iter 1 --presence 0
+    The line 1 of output should equal 'NOACK'
+    The contents of file "$WAIT_SLEEP_FILE" should equal '3'
+  End
+
+  It 'caps sleep after a failed poll at the remaining deadline'
+    setup_near_deadline
+    export GH_STUB_FAIL_SITE='inline-content'
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 99 --max-iter 1 --presence 0
+    The line 1 of output should equal 'TIMEOUT'
+    The contents of file "$WAIT_SLEEP_FILE" should equal '3'
+  End
+
+  Parameters
+    inline-content coderabbitai
+    review-content coderabbitai
+    issue-content coderabbitai
+    inline-presence coderabbitai
+    review-presence coderabbitai
+    issue-presence coderabbitai
+    snyk-head snyk
+    snyk-status snyk
+    snyk-check-runs snyk
+  End
+  It "reports GH-ERROR when reviewer endpoint $1 fails for three polls"
+    export GH_STUB_FAIL_SITE="$1"
+    When run sh "$script" --repo o/r --pr 1 --handle "$2" --until finished --since x --interval 0 --max-iter 3 --presence 0
+    The status should equal 1
+    The line 1 of output should equal 'GH-ERROR'
   End
 End


### PR DESCRIPTION
## Summary

- bound every reviewer/check GitHub CLI call to the remaining wait deadline
- discard failed and partial snapshots before classification
- preserve consecutive-failure recovery and existing verdict contracts
- add hermetic ShellSpec coverage for every GitHub call site and missing-tool path

## Root cause

GitHub CLI failures wrote response bodies to stdout while callers ignored exit status, allowing error payloads to look like reviewer activity. Loop deadlines also did not bound an in-flight command.

## Validation

- frozen RED/GREEN proof: 91 examples, 18 failures before; 91 examples, 0 failures after
- full ShellSpec suite and canonical shell gates
- independent phase-step gate PASS

Fixes #1289

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
