### PR TITLE
agents: avoid false paused-review verdict

### DIFF
--- a/scripts/agent/wait-reviewer.sh
+++ b/scripts/agent/wait-reviewer.sh
@@ -73,7 +73,7 @@ classify() {
 		printf 'DECLINE'
 		return 0
 	fi
-	if printf '%s' "$issuec" | grep -Eqi 'reviews? paused|paused .*review|review.*paused|⏸'; then
+	if printf '%s' "$issuec" | grep -Eqi '^[[:space:]>#*-]*reviews? (are )?paused([[:space:].!]|$)|⏸'; then
 		printf 'PAUSE'
 		return 0
 	fi

--- a/tests/shell/agent_wait_reviewer_spec.sh
+++ b/tests/shell/agent_wait_reviewer_spec.sh
@@ -83,6 +83,12 @@ Describe 'wait-reviewer.sh classify()'
   End
 
   It 'reports PAUSE when reviews are paused'
+    issuec='Reviews are paused because the branch is too active.'
+    When call classify
+    The output should equal 'PAUSE'
+  End
+
+  It 'reports PAUSE when reviews paused'
     issuec='Reviews paused because the branch is too active.'
     When call classify
     The output should equal 'PAUSE'
@@ -92,6 +98,15 @@ Describe 'wait-reviewer.sh classify()'
     issuec='⏸ CodeRabbit'
     When call classify
     The output should equal 'PAUSE'
+  End
+
+  It 'keeps polling after a triggered-review disclaimer mentions paused reviews'
+    issuec='Review triggered.
+
+> Note: CodeRabbit is an incremental review system and does not re-review already
+> reviewed commits. This command is applicable only when automatic reviews are paused.'
+    When call classify
+    The output should equal ''
   End
 
   It 'keeps polling (empty verdict) on unrelated chatter'


### PR DESCRIPTION
👀 ***#1335***: ***Awaiting review***

## Summary

- recognize only standalone CodeRabbit pause announcements (plus the pause emoji)
- ignore the standard “Review triggered” disclaimer that merely mentions paused reviews
- retain both `Reviews paused` and `Reviews are paused` behavior

## Verification

- frozen RED/GREEN replay against merged #1289: PASS
- focused ShellSpec: 81 examples, 0 failures
- canonical diff gate, `sh -n`, ShellCheck, and diff hygiene: PASS
- independent evidence gate: PASS

Fixes #1335

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
