### PR TITLE
tests: restore pre-existing Alerts fixture files

### DIFF
--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -754,21 +754,15 @@ def render_diff_state(smoke_vm: helpers.SmokeVM, webui: WebUI) -> Iterator[dict[
         ):
             orig_sizes[path] = _ensure_log(vm, path)
 
-        # DNSBL must be EFFECTIVELY enabled for the alert view's DNSBL Python panel to
-        # render at all: the panel gate reads the runtime $pfb['dnsbl'], which pfb_global
-        # force-disables ("DNSBL disabled: no VIP configured") when no sinkhole VIP
-        # exists -- the config toggle alone is not enough (first live run proved it:
-        # every D-scenario row was absent). Seed the VIP first (idempotent, the standard
-        # harness fixture), then flip the toggle. The Block/Permit/Match panels are NOT
-        # gated by this toggle.
+        # DNSBL panel requires a configured sinkhole VIP and enabled toggle.
+        # Configure VIP before enabling DNSBL.
         helpers.ensure_dnsbl_vip(vm)
         helpers.set_dnsbl_enabled(vm, True)
 
         error_log_guard.snapshot()
         error_log_snapshotted = True
 
-        # (1) BASELINE -- pre-seed captures, same fixed order, so "no rv809 tokens
-        # yet" is PROVEN, not assumed (CLAUDE.md transition-test rule).
+        # (1) Capture fixed-order baseline responses before seeding.
         for key, path in GET_MATRIX:
             t0 = time.perf_counter()
             resp = webui.get(path)

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -130,6 +130,7 @@ SEEDED_FILES = (FEED_A, FEED_B, FEED_PERMIT, FEED_MATCH, FEED_ET, FEED_GEO, ALIA
 class SeededFileBackup:
     path: str
     backup_path: str | None
+    kind: str
 
 
 def _seeded_file_kind(vm: Any, path: str) -> str:
@@ -147,6 +148,34 @@ def _seeded_file_kind(vm: Any, path: str) -> str:
     kind = result.stdout.strip()
     assert kind in {"absent", "file", "symlink", "unsupported"}, f"unexpected seeded path type for {path!r}: {kind!r}"
     return kind
+
+
+def _reconcile_seeded_restore(
+    vm: Any,
+    backup: SeededFileBackup,
+    exc: Exception,
+    action: str,
+) -> str | None:
+    assert backup.backup_path is not None
+    try:
+        path_kind = _seeded_file_kind(vm, backup.path)
+        backup_kind = _seeded_file_kind(vm, backup.backup_path)
+    except Exception as inspect_exc:
+        return (
+            f"{action} {backup.path!r} from {backup.backup_path!r} could not be reconciled after {exc}: "
+            f"inspection raised unexpectedly: {inspect_exc}; recorded backup retained if present"
+        )
+    if path_kind == backup.kind and backup_kind == "absent":
+        return None
+    recovery = (
+        f"recorded backup retained for recovery at {backup.backup_path!r}"
+        if backup_kind == backup.kind
+        else f"recorded backup unavailable for recovery at {backup.backup_path!r}"
+    )
+    return (
+        f"{action} {backup.path!r} from {backup.backup_path!r} unresolved after {exc}: "
+        f"path={path_kind} backup={backup_kind} expected={backup.kind}; {recovery}"
+    )
 
 
 def _restore_seeded_files(vm: Any, backups: list[SeededFileBackup]) -> list[str]:
@@ -167,7 +196,9 @@ def _restore_seeded_files(vm: Any, backups: list[SeededFileBackup]) -> list[str]
         try:
             restore = vm.ssh("mv", backup.backup_path, backup.path, timeout=15)
         except Exception as exc:
-            errors.append(f"restore seeded path {backup.path!r} from {backup.backup_path!r} raised unexpectedly: {exc}")
+            error = _reconcile_seeded_restore(vm, backup, exc, "restore seeded path")
+            if error is not None:
+                errors.append(error)
             continue
         if restore.returncode != 0:
             errors.append(
@@ -186,13 +217,13 @@ def _backup_seeded_files(vm: Any, paths: tuple[str, ...]) -> list[SeededFileBack
     planned: list[SeededFileBackup] = []
     for path, kind in kinds:
         if kind == "absent":
-            planned.append(SeededFileBackup(path, None))
+            planned.append(SeededFileBackup(path, None, kind))
             continue
         while True:
             backup_path = f"{path}.pfb-alerts-backup-{uuid.uuid4().hex}"
             if _seeded_file_kind(vm, backup_path) == "absent":
                 break
-        planned.append(SeededFileBackup(path, backup_path))
+        planned.append(SeededFileBackup(path, backup_path, kind))
 
     current: SeededFileBackup | None = None
     try:
@@ -216,10 +247,14 @@ def _backup_seeded_files(vm: Any, paths: tuple[str, ...]) -> list[SeededFileBack
                     try:
                         restore = vm.ssh("mv", current.backup_path, current.path, timeout=15)
                     except Exception as restore_exc:
-                        rollback_errors.append(
-                            f"restore ambiguous seeded path {current.path!r} from {current.backup_path!r} "
-                            f"raised unexpectedly: {restore_exc}"
+                        error = _reconcile_seeded_restore(
+                            vm,
+                            current,
+                            restore_exc,
+                            "restore ambiguous seeded path",
                         )
+                        if error is not None:
+                            rollback_errors.append(error)
                     else:
                         if restore.returncode != 0:
                             rollback_errors.append(

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -152,7 +152,11 @@ def _seeded_file_kind(vm: Any, path: str) -> str:
 def _restore_seeded_files(vm: Any, backups: list[SeededFileBackup]) -> list[str]:
     errors: list[str] = []
     for backup in reversed(backups):
-        remove = vm.ssh("rm", "-f", backup.path, timeout=15)
+        try:
+            remove = vm.ssh("rm", "-f", backup.path, timeout=15)
+        except Exception as exc:
+            errors.append(f"remove seeded replacement {backup.path!r} raised unexpectedly: {exc}")
+            continue
         if remove.returncode != 0:
             errors.append(
                 f"remove seeded replacement {backup.path!r} failed: rc={remove.returncode} stderr={remove.stderr!r}"
@@ -160,7 +164,11 @@ def _restore_seeded_files(vm: Any, backups: list[SeededFileBackup]) -> list[str]
             continue
         if backup.backup_path is None:
             continue
-        restore = vm.ssh("mv", backup.backup_path, backup.path, timeout=15)
+        try:
+            restore = vm.ssh("mv", backup.backup_path, backup.path, timeout=15)
+        except Exception as exc:
+            errors.append(f"restore seeded path {backup.path!r} from {backup.backup_path!r} raised unexpectedly: {exc}")
+            continue
         if restore.returncode != 0:
             errors.append(
                 f"restore seeded path {backup.path!r} from {backup.backup_path!r} failed: "
@@ -186,8 +194,10 @@ def _backup_seeded_files(vm: Any, paths: tuple[str, ...]) -> list[SeededFileBack
                 break
         planned.append(SeededFileBackup(path, backup_path))
 
+    current: SeededFileBackup | None = None
     try:
         for backup in planned:
+            current = backup
             if backup.backup_path is not None:
                 move = vm.ssh("mv", backup.path, backup.backup_path, timeout=15)
                 assert move.returncode == 0, (
@@ -195,10 +205,41 @@ def _backup_seeded_files(vm: Any, paths: tuple[str, ...]) -> list[SeededFileBack
                     f"rc={move.returncode} stderr={move.stderr!r}"
                 )
             backups.append(backup)
-    except AssertionError as exc:
-        rollback_errors = _restore_seeded_files(vm, backups)
-        detail = "\n".join([str(exc), *rollback_errors])
-        raise AssertionError(f"seeded path backup failed; rollback attempted:\n{detail}") from exc
+            current = None
+    except Exception as exc:
+        rollback_errors: list[str] = []
+        if current is not None and current.backup_path is not None:
+            try:
+                path_kind = _seeded_file_kind(vm, current.path)
+                backup_kind = _seeded_file_kind(vm, current.backup_path)
+                if path_kind == "absent" and backup_kind in {"file", "symlink"}:
+                    try:
+                        restore = vm.ssh("mv", current.backup_path, current.path, timeout=15)
+                    except Exception as restore_exc:
+                        rollback_errors.append(
+                            f"restore ambiguous seeded path {current.path!r} from {current.backup_path!r} "
+                            f"raised unexpectedly: {restore_exc}"
+                        )
+                    else:
+                        if restore.returncode != 0:
+                            rollback_errors.append(
+                                f"restore ambiguous seeded path {current.path!r} from {current.backup_path!r} "
+                                f"failed: rc={restore.returncode} stderr={restore.stderr!r}"
+                            )
+                elif path_kind == "absent" or backup_kind != "absent":
+                    rollback_errors.append(
+                        f"ambiguous seeded path {current.path!r} retained for recovery: "
+                        f"path={path_kind} backup={backup_kind} at {current.backup_path!r}"
+                    )
+            except Exception as inspect_exc:
+                rollback_errors.append(
+                    f"inspect ambiguous seeded path {current.path!r} and {current.backup_path!r} "
+                    f"raised unexpectedly: {inspect_exc}"
+                )
+        rollback_errors.extend(_restore_seeded_files(vm, backups))
+        if rollback_errors:
+            exc.add_note("seeded path backup rollback errors:\n" + "\n".join(rollback_errors))
+        raise
 
     return backups
 

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -56,8 +56,11 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import shlex
 import subprocess
+import sys
 import time
+import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -121,6 +124,84 @@ ALIAS_S8_A = f"{ALIASTABLES_DIR}/pfB_RVAliasA_v4.txt"
 ALIAS_S8_Z = f"{ALIASTABLES_DIR}/pfB_RVAliasZ_v4.txt"
 
 SEEDED_FILES = (FEED_A, FEED_B, FEED_PERMIT, FEED_MATCH, FEED_ET, FEED_GEO, ALIAS_S8_A, ALIAS_S8_Z)
+
+
+@dataclass(frozen=True)
+class SeededFileBackup:
+    path: str
+    backup_path: str | None
+
+
+def _seeded_file_kind(vm: Any, path: str) -> str:
+    quoted = shlex.quote(path)
+    result = vm.ssh(
+        f"if [ -L {quoted} ]; then printf symlink; "
+        f"elif [ -f {quoted} ]; then printf file; "
+        f"elif [ -e {quoted} ]; then printf unsupported; "
+        "else printf absent; fi",
+        timeout=15,
+    )
+    assert result.returncode == 0, (
+        f"failed to inspect seeded path {path!r}: rc={result.returncode} stderr={result.stderr!r}"
+    )
+    kind = result.stdout.strip()
+    assert kind in {"absent", "file", "symlink", "unsupported"}, f"unexpected seeded path type for {path!r}: {kind!r}"
+    return kind
+
+
+def _restore_seeded_files(vm: Any, backups: list[SeededFileBackup]) -> list[str]:
+    errors: list[str] = []
+    for backup in reversed(backups):
+        remove = vm.ssh("rm", "-f", backup.path, timeout=15)
+        if remove.returncode != 0:
+            errors.append(
+                f"remove seeded replacement {backup.path!r} failed: rc={remove.returncode} stderr={remove.stderr!r}"
+            )
+            continue
+        if backup.backup_path is None:
+            continue
+        restore = vm.ssh("mv", backup.backup_path, backup.path, timeout=15)
+        if restore.returncode != 0:
+            errors.append(
+                f"restore seeded path {backup.path!r} from {backup.backup_path!r} failed: "
+                f"rc={restore.returncode} stderr={restore.stderr!r}"
+            )
+    return errors
+
+
+def _backup_seeded_files(vm: Any, paths: tuple[str, ...]) -> list[SeededFileBackup]:
+    kinds = [(path, _seeded_file_kind(vm, path)) for path in paths]
+    unsupported = [path for path, kind in kinds if kind == "unsupported"]
+    assert not unsupported, f"unsupported seeded path type; refusing mutation: {unsupported!r}"
+
+    backups: list[SeededFileBackup] = []
+    planned: list[SeededFileBackup] = []
+    for path, kind in kinds:
+        if kind == "absent":
+            planned.append(SeededFileBackup(path, None))
+            continue
+        while True:
+            backup_path = f"{path}.pfb-alerts-backup-{uuid.uuid4().hex}"
+            if _seeded_file_kind(vm, backup_path) == "absent":
+                break
+        planned.append(SeededFileBackup(path, backup_path))
+
+    try:
+        for backup in planned:
+            if backup.backup_path is not None:
+                move = vm.ssh("mv", backup.path, backup.backup_path, timeout=15)
+                assert move.returncode == 0, (
+                    f"backup seeded path {backup.path!r} to {backup.backup_path!r} failed: "
+                    f"rc={move.returncode} stderr={move.stderr!r}"
+                )
+            backups.append(backup)
+    except AssertionError as exc:
+        rollback_errors = _restore_seeded_files(vm, backups)
+        detail = "\n".join([str(exc), *rollback_errors])
+        raise AssertionError(f"seeded path backup failed; rollback attempted:\n{detail}") from exc
+
+    return backups
+
 
 # --- ip_block.log scenarios (S1-S10) -- RFC 5737/3849 addresses. S3 and S8
 # deliberately pair an exact address with a longer textual prefix collision;
@@ -572,11 +653,19 @@ def _seed_feed_files(vm: helpers.SmokeVM) -> None:
 @pytest.fixture(scope="module")
 def render_diff_state(smoke_vm: helpers.SmokeVM, webui: WebUI) -> Iterator[dict[str, dict[str, Capture]]]:
     vm = smoke_vm
-    error_log_guard = PhpErrorLogGuard(vm)
+    baseline: dict[str, Capture] = {}
+    captures: dict[str, Capture] = {}
+    seeded_backups: list[SeededFileBackup] = []
+    orig_sizes: dict[str, str] = {}
+    original_dnsbl_cfg: str | None = None
+    error_log_guard: PhpErrorLogGuard | None = None
+    error_log_snapshotted = False
 
-    original_dnsbl_cfg = helpers.config_get(vm, CFG_DNSBL_ENABLE)
-    orig_sizes = {
-        path: _ensure_log(vm, path)
+    try:
+        seeded_backups = _backup_seeded_files(vm, SEEDED_FILES)
+
+        error_log_guard = PhpErrorLogGuard(vm)
+        original_dnsbl_cfg = helpers.config_get(vm, CFG_DNSBL_ENABLE)
         for path in (
             IP_BLOCK_LOG,
             IP_PERMIT_LOG,
@@ -586,33 +675,21 @@ def render_diff_state(smoke_vm: helpers.SmokeVM, webui: WebUI) -> Iterator[dict[
             UNIFIED_LOG,
             PY_DATA_FILE,
             PY_ZONE_FILE,
-        )
-    }
+        ):
+            orig_sizes[path] = _ensure_log(vm, path)
 
-    # DNSBL must be EFFECTIVELY enabled for the alert view's DNSBL Python panel to
-    # render at all: the panel gate reads the runtime $pfb['dnsbl'], which pfb_global
-    # force-disables ("DNSBL disabled: no VIP configured") when no sinkhole VIP
-    # exists -- the config toggle alone is not enough (first live run proved it:
-    # every D-scenario row was absent). Seed the VIP first (idempotent, the standard
-    # harness fixture), then flip the toggle. The Block/Permit/Match panels are NOT
-    # gated by this toggle.
-    helpers.ensure_dnsbl_vip(vm)
-    helpers.set_dnsbl_enabled(vm, True)
-
-    baseline: dict[str, Capture] = {}
-    captures: dict[str, Capture] = {}
-
-    try:
-        # A prior hard-killed run (VM SIGKILL mid-module) can leave seeded
-        # feed/aliastable files on disk because teardown never ran. Clear them FIRST
-        # so the baseline before-state is provably clean and symmetric with teardown.
-        # (Appended log lines from such a crash cannot be
-        # excised without the lost original sizes; the baseline token assertion below
-        # stays the loud guard for that case.)
-        rm = vm.ssh("rm -f " + " ".join(SEEDED_FILES), timeout=15)
-        assert rm.returncode == 0, f"pre-baseline cleanup of seeded files failed: {rm.stderr!r}"
+        # DNSBL must be EFFECTIVELY enabled for the alert view's DNSBL Python panel to
+        # render at all: the panel gate reads the runtime $pfb['dnsbl'], which pfb_global
+        # force-disables ("DNSBL disabled: no VIP configured") when no sinkhole VIP
+        # exists -- the config toggle alone is not enough (first live run proved it:
+        # every D-scenario row was absent). Seed the VIP first (idempotent, the standard
+        # harness fixture), then flip the toggle. The Block/Permit/Match panels are NOT
+        # gated by this toggle.
+        helpers.ensure_dnsbl_vip(vm)
+        helpers.set_dnsbl_enabled(vm, True)
 
         error_log_guard.snapshot()
+        error_log_snapshotted = True
 
         # (1) BASELINE -- pre-seed captures, same fixed order, so "no rv809 tokens
         # yet" is PROVEN, not assumed (CLAUDE.md transition-test rule).
@@ -649,43 +726,58 @@ def render_diff_state(smoke_vm: helpers.SmokeVM, webui: WebUI) -> Iterator[dict[
         yield {"baseline": baseline, "captures": captures}
 
     finally:
+        original_error = sys.exception()
         errors: list[str] = []
 
-        rm = vm.ssh("rm -f " + " ".join(SEEDED_FILES), timeout=15)
-        if rm.returncode != 0:
-            errors.append(f"rm -f seeded feed files failed: rc={rm.returncode} stderr={rm.stderr!r}")
+        try:
+            errors.extend(_restore_seeded_files(vm, seeded_backups))
+        except Exception as exc:
+            errors.append(f"restore seeded files raised unexpectedly: {exc}")
 
         for path, size in orig_sizes.items():
-            result = subprocess.run(
-                vm.ssh_argv("/usr/bin/truncate", "-s", size, path),
-                capture_output=True,
-                text=True,
-                timeout=15,
-                check=False,
-            )
-            if result.returncode != 0:
-                errors.append(f"truncate {path!r} to size={size!r} failed: {result.stderr!r}")
+            try:
+                result = subprocess.run(
+                    vm.ssh_argv("/usr/bin/truncate", "-s", size, path),
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    errors.append(f"truncate {path!r} to size={size!r} failed: {result.stderr!r}")
+            except Exception as exc:
+                errors.append(f"truncate {path!r} to size={size!r} raised unexpectedly: {exc}")
 
-        restore = helpers.php_eval(
-            vm,
-            f"config_set_path({helpers._php_str(CFG_DNSBL_ENABLE)}, {helpers._php_str(original_dnsbl_cfg)});\n"
-            "write_config('pfBlockerNG smoke: restore pfb_dnsbl after render-diff harness');\n"
-            "echo 'OK';",
-        )
-        if restore.returncode != 0 or "OK" not in restore.stdout:
-            errors.append(
-                f"restore pfb_dnsbl failed: rc={restore.returncode} stdout={restore.stdout!r} stderr={restore.stderr!r}"
-            )
+        if original_dnsbl_cfg is not None:
+            try:
+                restore = helpers.php_eval(
+                    vm,
+                    f"config_set_path({helpers._php_str(CFG_DNSBL_ENABLE)}, {helpers._php_str(original_dnsbl_cfg)});\n"
+                    "write_config('pfBlockerNG smoke: restore pfb_dnsbl after render-diff harness');\n"
+                    "echo 'OK';",
+                )
+                if restore.returncode != 0 or "OK" not in restore.stdout:
+                    errors.append(
+                        f"restore pfb_dnsbl failed: rc={restore.returncode} "
+                        f"stdout={restore.stdout!r} stderr={restore.stderr!r}"
+                    )
+            except Exception as exc:
+                errors.append(f"restore pfb_dnsbl raised unexpectedly: {exc}")
 
-        try:
-            error_log_guard.assert_no_growth()
-        except AssertionError as exc:
-            errors.append(str(exc))
+        if error_log_guard is not None and error_log_snapshotted:
+            try:
+                error_log_guard.assert_no_growth()
+            except Exception as exc:
+                errors.append(str(exc))
 
         if errors:
             detail = "\n".join(errors)
+            message = f"render_diff_state teardown left the VM polluted:\n{detail}"
             print(f"render_diff_state teardown FAILED to fully restore VM state:\n{detail}")
-            raise AssertionError(f"render_diff_state teardown left the VM polluted:\n{detail}")
+            if original_error is not None and not isinstance(original_error, GeneratorExit):
+                original_error.add_note(message)
+            else:
+                raise AssertionError(message)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_alerts_seed_restore.py
+++ b/tests/smoke/ui/test_alerts_seed_restore.py
@@ -7,6 +7,7 @@ import os
 import shlex
 import stat
 import subprocess
+import traceback
 import uuid
 from pathlib import Path
 from typing import Any, Callable, cast
@@ -249,9 +250,19 @@ def test_fixture_preserves_body_error_when_cleanup_also_fails(tmp_path: Path, mo
     fixture, _events = _fixture_harness(monkeypatch, paths, "post_yield_cleanup")
     next(fixture)
 
-    with pytest.raises(RuntimeError, match="post_yield") as caught:
-        fixture.throw(RuntimeError("post_yield"))
+    original: RuntimeError | None = None
+    try:
+        raise RuntimeError("post_yield")
+    except RuntimeError as exc:
+        original = exc
+    assert original is not None
+    original_tail = traceback.extract_tb(original.__traceback__)[-1]
 
+    with pytest.raises(RuntimeError, match="post_yield") as caught:
+        fixture.throw(original)
+
+    assert caught.value is original
+    assert traceback.extract_tb(caught.value.__traceback__)[-1] == original_tail
     assert any("teardown" in note for note in getattr(caught.value, "__notes__", []))
     assert _snapshots(paths) == before
 
@@ -334,6 +345,26 @@ def test_fixture_backup_timeout_after_ambiguous_move_restores_all_files(tmp_path
     assert set(tmp_path.iterdir()) == {first, second}
 
 
+def test_ambiguous_backup_rollback_timeout_after_success_is_confirmed(tmp_path: Path) -> None:
+    first = tmp_path / "a.txt"
+    second = tmp_path / "b.txt"
+    first.write_bytes(b"first original\n")
+    second.write_bytes(b"second original\n")
+    before = _snapshots([first, second])
+
+    def raise_after(remote: tuple[str, ...]) -> bool:
+        return len(remote) >= 3 and remote[0] == "mv" and (remote[1] == str(second) or remote[2] == str(second))
+
+    vm = _WrappedVM(_LocalVM(), raise_after=raise_after)
+
+    with pytest.raises(subprocess.TimeoutExpired) as caught:
+        alerts._backup_seeded_files(vm, (str(first), str(second)))
+
+    assert getattr(caught.value, "__notes__", []) == []
+    assert _snapshots([first, second]) == before
+    assert set(tmp_path.iterdir()) == {first, second}
+
+
 def test_restore_remove_failure_keeps_backup_at_recorded_path(tmp_path: Path) -> None:
     target = tmp_path / "seed.txt"
     target.write_bytes(b"original\n")
@@ -404,6 +435,63 @@ def test_restore_timeout_keeps_affected_backup_and_continues_full_matrix(tmp_pat
         for backup in backups
         if backup.backup_path is not None
     )
+
+
+def test_restore_timeout_after_success_confirms_exact_original(tmp_path: Path) -> None:
+    paths, live_target, dangling_target = _matrix_paths(tmp_path)
+    _create_matrix(paths, live_target, dangling_target)
+    before = _snapshots(paths)
+    backups = alerts._backup_seeded_files(_LocalVM(), tuple(map(str, paths)))
+    affected = backups[-1]
+    _seed_replacements(paths)
+    vm = _WrappedVM(
+        _LocalVM(),
+        raise_after=lambda remote: (
+            len(remote) >= 3 and remote[0] == "mv" and remote[1] == affected.backup_path and remote[2] == affected.path
+        ),
+    )
+
+    errors = alerts._restore_seeded_files(vm, backups)
+
+    assert errors == []
+    assert _snapshots(paths) == before
+    assert all(not os.path.lexists(backup.backup_path) for backup in backups if backup.backup_path is not None)
+
+
+@pytest.mark.parametrize("destination_kind", ["absent", "unsupported"])
+def test_restore_timeout_with_unresolved_state_retains_exact_backup(
+    tmp_path: Path,
+    destination_kind: str,
+) -> None:
+    paths, live_target, dangling_target = _matrix_paths(tmp_path)
+    _create_matrix(paths, live_target, dangling_target)
+    before = _snapshots(paths)
+    backups = alerts._backup_seeded_files(_LocalVM(), tuple(map(str, paths)))
+    affected = backups[-1]
+    affected_backup = Path(affected.backup_path or "")
+    _seed_replacements(paths)
+
+    def raise_after(remote: tuple[str, ...]) -> bool:
+        if not (
+            len(remote) >= 3 and remote[0] == "mv" and remote[1] == affected.backup_path and remote[2] == affected.path
+        ):
+            return False
+        Path(affected.path).rename(affected_backup)
+        if destination_kind == "unsupported":
+            Path(affected.path).mkdir()
+        return True
+
+    errors = alerts._restore_seeded_files(_WrappedVM(_LocalVM(), raise_after=raise_after), backups)
+
+    assert len(errors) == 1
+    assert affected.path in errors[0]
+    assert "unresolved" in errors[0]
+    assert f"path={destination_kind}" in errors[0]
+    assert "backup=symlink" in errors[0]
+    assert "retained for recovery" in errors[0]
+    assert "timed out" in errors[0]
+    assert _snapshot(affected_backup) == before[affected.path]
+    assert _snapshots(paths[:-1]) == {path: state for path, state in before.items() if path != affected.path}
 
 
 @pytest.mark.parametrize("unsupported", ["directory", "fifo", "device"])

--- a/tests/smoke/ui/test_alerts_seed_restore.py
+++ b/tests/smoke/ui/test_alerts_seed_restore.py
@@ -1,0 +1,521 @@
+"""Regression coverage for preserving Alerts render-verification seed files."""
+
+from __future__ import annotations
+
+import inspect
+import os
+import shlex
+import stat
+import subprocess
+import uuid
+from pathlib import Path
+from typing import Any, Callable, cast
+
+import pytest
+
+from . import test_alerts_render_verify as alerts
+
+
+class _LocalVM:
+    """Small SmokeVM-compatible shell adapter for hermetic filesystem tests."""
+
+    def ssh_argv(self, *remote: str) -> list[str]:
+        if remote and remote[0] == "/usr/bin/truncate":
+            return ["/usr/bin/true"]
+        return list(remote)
+
+    def ssh(self, *remote: str, timeout: float = 15.0) -> subprocess.CompletedProcess[str]:
+        if len(remote) == 1:
+            return subprocess.run(
+                remote[0],
+                shell=True,
+                executable="/bin/sh",
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        return subprocess.run(
+            remote,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+
+
+class _WrappedVM:
+    def __init__(
+        self,
+        inner: _LocalVM,
+        fail: Callable[[tuple[str, ...]], bool] | None = None,
+    ) -> None:
+        self.inner = inner
+        self.fail = fail
+        self.calls: list[tuple[str, ...]] = []
+
+    def ssh_argv(self, *remote: str) -> list[str]:
+        return self.inner.ssh_argv(*remote)
+
+    def ssh(self, *remote: str, timeout: float = 15.0) -> subprocess.CompletedProcess[str]:
+        self.calls.append(remote)
+        if self.fail is not None and self.fail(remote):
+            return subprocess.CompletedProcess(remote, 1, "", f"injected failure: {remote!r}")
+        return self.inner.ssh(*remote, timeout=timeout)
+
+
+def _matrix_paths(tmp_path: Path) -> tuple[list[Path], Path, Path]:
+    paths = [tmp_path / f"seed-{index}.txt" for index in range(8)]
+    live_target = tmp_path / "live-target"
+    dangling_target = tmp_path / "missing-target"
+    return paths, live_target, dangling_target
+
+
+def _create_matrix(paths: list[Path], live_target: Path, dangling_target: Path) -> None:
+    paths[0].write_bytes(b"regular nonempty\n")
+    paths[1].write_bytes(b"")
+    paths[2].write_bytes(b"no-final-newline")
+    paths[3].write_bytes(b"first line\nsecond line\n")
+    # paths[4] and paths[5] deliberately absent.
+    live_target.write_bytes(b"live target\n")
+    paths[6].symlink_to(live_target)
+    paths[7].symlink_to(dangling_target)
+
+    for index, path in enumerate(paths[:4]):
+        path.chmod(0o600 + index * 0o10)
+        timestamp = 1_700_000_000_000_000_000 + index * 1_000_000_000
+        os.utime(path, ns=(timestamp, timestamp))
+    for index, path in enumerate(paths[6:]):
+        timestamp = 1_700_000_010_000_000_000 + index * 1_000_000_000
+        os.utime(path, ns=(timestamp, timestamp), follow_symlinks=False)
+
+
+def _snapshot(path: Path) -> dict[str, Any]:
+    if not os.path.lexists(path):
+        return {"kind": "absent"}
+    info = os.lstat(path)
+    snapshot: dict[str, Any] = {
+        "uid": info.st_uid,
+        "gid": info.st_gid,
+        "mode": stat.S_IMODE(info.st_mode),
+        "mtime_ns": info.st_mtime_ns,
+    }
+    if hasattr(info, "st_birthtime"):
+        snapshot["birthtime"] = info.st_birthtime
+    if path.is_symlink():
+        return {"kind": "symlink", "target": os.readlink(path), **snapshot}
+    if path.is_file():
+        return {"kind": "file", "bytes": path.read_bytes(), **snapshot}
+    return {"kind": "unsupported", **snapshot}
+
+
+def _snapshots(paths: list[Path]) -> dict[str, dict[str, Any]]:
+    return {str(path): _snapshot(path) for path in paths}
+
+
+def _seed_replacements(paths: list[Path]) -> None:
+    for index, path in enumerate(paths):
+        path.write_bytes(f"replacement {index}\n".encode())
+
+
+def test_fixture_preserves_files_around_baseline_seed_and_yield() -> None:
+    source = inspect.getsource(cast(Any, alerts.render_diff_state).__wrapped__)
+
+    backup_at = source.index("_backup_seeded_files(vm, SEEDED_FILES)")
+    try_at = source.index("    try:\n")
+    ensure_log_at = source.index("_ensure_log(vm, path)")
+    dnsbl_at = source.index("helpers.ensure_dnsbl_vip(vm)")
+    baseline_get_at = source.index("for key, path in GET_MATRIX")
+    yield_at = source.index('yield {"baseline": baseline, "captures": captures}')
+    finally_at = source.index("    finally:\n", yield_at)
+    restore_at = source.index("_restore_seeded_files(vm, seeded_backups)")
+
+    assert try_at < backup_at < ensure_log_at < dnsbl_at < baseline_get_at < yield_at < finally_at < restore_at
+
+
+class _WebUI:
+    def __init__(self, fail_get: bool = False) -> None:
+        self.fail_get = fail_get
+
+    def get(self, _path: str) -> Any:
+        if self.fail_get:
+            raise RuntimeError("get")
+        return type("Response", (), {"text": "Alert Settings", "status_code": 200})()
+
+
+def _fixture_harness(
+    monkeypatch: Any,
+    paths: list[Path],
+    failure_point: str,
+) -> tuple[Any, list[str]]:
+    events: list[str] = []
+
+    class _LogGuard:
+        def __init__(self, _vm: Any) -> None:
+            pass
+
+        def snapshot(self) -> None:
+            events.append("log_snapshot")
+
+        def assert_no_growth(self) -> None:
+            events.append("log_teardown")
+            if failure_point in {"teardown", "post_yield_cleanup"}:
+                raise AssertionError("teardown")
+
+    def assert_backed_up(event: str) -> None:
+        events.append(event)
+        assert all(not os.path.lexists(path) for path in paths)
+
+    def ensure_log(_vm: Any, _path: str) -> str:
+        assert_backed_up("ensure_log")
+        if failure_point == "ensure_log":
+            raise RuntimeError("ensure_log")
+        return "0"
+
+    def ensure_dnsbl(_vm: Any) -> None:
+        assert_backed_up("dnsbl")
+        if failure_point == "dnsbl":
+            raise RuntimeError("dnsbl")
+
+    monkeypatch.setattr(alerts, "SEEDED_FILES", tuple(map(str, paths)))
+    monkeypatch.setattr(alerts, "GET_MATRIX", (("alert", "/alerts"),))
+    monkeypatch.setattr(alerts, "PhpErrorLogGuard", _LogGuard)
+    monkeypatch.setattr(alerts, "_ensure_log", ensure_log)
+    monkeypatch.setattr(alerts.helpers, "config_get", lambda _vm, _path: "")
+    monkeypatch.setattr(alerts.helpers, "ensure_dnsbl_vip", ensure_dnsbl)
+    monkeypatch.setattr(alerts.helpers, "set_dnsbl_enabled", lambda _vm, _enabled: events.append("dnsbl_set"))
+    monkeypatch.setattr(alerts.helpers, "php_eval", lambda _vm, _code: subprocess.CompletedProcess([], 0, "OK", ""))
+    monkeypatch.setattr(alerts, "_seed_feed_files", lambda _vm: _seed_replacements(paths))
+    monkeypatch.setattr(alerts, "_append", lambda _vm, _path, _content: None)
+    monkeypatch.setattr(alerts, "_write_diagnostics", lambda _baseline, _captures: None)
+
+    fixture = cast(Any, alerts.render_diff_state).__wrapped__(_LocalVM(), _WebUI(failure_point == "get"))
+    return fixture, events
+
+
+def _seeded_fixture_matrix(tmp_path: Path) -> tuple[list[Path], dict[str, dict[str, Any]]]:
+    paths, live_target, dangling_target = _matrix_paths(tmp_path)
+    _create_matrix(paths, live_target, dangling_target)
+    return paths, _snapshots(paths)
+
+
+def test_fixture_restores_exact_matrix_after_normal_completion(tmp_path: Path, monkeypatch: Any) -> None:
+    paths, before = _seeded_fixture_matrix(tmp_path)
+    fixture, _events = _fixture_harness(monkeypatch, paths, "normal")
+
+    next(fixture)
+    with pytest.raises(StopIteration):
+        next(fixture)
+
+    assert _snapshots(paths) == before
+
+
+@pytest.mark.parametrize("failure_point", ["ensure_log", "dnsbl", "get", "post_yield", "teardown"])
+def test_fixture_restores_exact_matrix_after_any_lifecycle_failure(
+    tmp_path: Path,
+    monkeypatch: Any,
+    failure_point: str,
+) -> None:
+    paths, before = _seeded_fixture_matrix(tmp_path)
+    fixture, events = _fixture_harness(monkeypatch, paths, failure_point)
+
+    if failure_point in {"ensure_log", "dnsbl", "get"}:
+        with pytest.raises(RuntimeError, match=failure_point):
+            next(fixture)
+    else:
+        next(fixture)
+        if failure_point == "post_yield":
+            with pytest.raises(RuntimeError, match="post_yield"):
+                fixture.throw(RuntimeError("post_yield"))
+        else:
+            with pytest.raises(AssertionError, match="teardown"):
+                next(fixture)
+
+    assert events
+    assert _snapshots(paths) == before
+
+
+def test_fixture_preserves_body_error_when_cleanup_also_fails(tmp_path: Path, monkeypatch: Any) -> None:
+    paths, before = _seeded_fixture_matrix(tmp_path)
+    fixture, _events = _fixture_harness(monkeypatch, paths, "post_yield_cleanup")
+    next(fixture)
+
+    with pytest.raises(RuntimeError, match="post_yield") as caught:
+        fixture.throw(RuntimeError("post_yield"))
+
+    assert any("teardown" in note for note in getattr(caught.value, "__notes__", []))
+    assert _snapshots(paths) == before
+
+
+def test_backup_failure_rolls_back_prior_moves(tmp_path: Path) -> None:
+    paths, live_target, dangling_target = _matrix_paths(tmp_path)
+    _create_matrix(paths, live_target, dangling_target)
+    before = _snapshots(paths)
+    failed_path = str(paths[2])
+    vm = _WrappedVM(
+        _LocalVM(),
+        fail=lambda remote: len(remote) >= 2 and remote[0] == "mv" and remote[1] == failed_path,
+    )
+
+    with pytest.raises(AssertionError, match="injected failure"):
+        alerts._backup_seeded_files(vm, tuple(map(str, paths)))
+
+    assert _snapshots(paths) == before
+
+
+def test_fixture_backup_failure_does_not_delete_rolled_back_files(tmp_path: Path, monkeypatch: Any) -> None:
+    first = tmp_path / "a.txt"
+    second = tmp_path / "b.txt"
+    first.write_bytes(b"first original\n")
+    second.write_bytes(b"second original\n")
+    vm = _WrappedVM(
+        _LocalVM(),
+        fail=lambda remote: len(remote) >= 2 and remote[0] == "mv" and remote[1] == str(second),
+    )
+
+    class _NoopLogGuard:
+        def __init__(self, _vm: Any) -> None:
+            pass
+
+        def snapshot(self) -> None:
+            pass
+
+        def assert_no_growth(self) -> None:
+            pass
+
+    monkeypatch.setattr(alerts, "SEEDED_FILES", (str(first), str(second)))
+    monkeypatch.setattr(alerts, "PhpErrorLogGuard", _NoopLogGuard)
+    monkeypatch.setattr(alerts, "_ensure_log", lambda _vm, _path: "0")
+    monkeypatch.setattr(alerts.helpers, "config_get", lambda _vm, _path: "")
+    monkeypatch.setattr(alerts.helpers, "ensure_dnsbl_vip", lambda _vm: None)
+    monkeypatch.setattr(alerts.helpers, "set_dnsbl_enabled", lambda _vm, _enabled: None)
+    monkeypatch.setattr(
+        alerts.helpers,
+        "php_eval",
+        lambda _vm, _code: subprocess.CompletedProcess([], 0, "OK", ""),
+    )
+
+    fixture = cast(Any, alerts.render_diff_state).__wrapped__(vm, object())
+    with pytest.raises(AssertionError, match="injected failure"):
+        next(fixture)
+
+    assert first.read_bytes() == b"first original\n"
+    assert second.read_bytes() == b"second original\n"
+    assert set(tmp_path.iterdir()) == {first, second}
+
+
+def test_restore_remove_failure_keeps_backup_at_recorded_path(tmp_path: Path) -> None:
+    target = tmp_path / "seed.txt"
+    target.write_bytes(b"original\n")
+    backups = alerts._backup_seeded_files(_LocalVM(), (str(target),))
+    backup_path = Path(backups[0].backup_path or "")
+    target.mkdir()
+
+    errors = alerts._restore_seeded_files(_LocalVM(), backups)
+
+    assert len(errors) == 1
+    assert str(target) in errors[0]
+    assert backup_path.read_bytes() == b"original\n"
+    assert list(target.iterdir()) == []
+
+
+def test_restore_runs_in_reverse_and_aggregates_failures(tmp_path: Path) -> None:
+    paths, live_target, dangling_target = _matrix_paths(tmp_path)
+    _create_matrix(paths, live_target, dangling_target)
+    backups = alerts._backup_seeded_files(_LocalVM(), tuple(map(str, paths)))
+    _seed_replacements(paths)
+
+    failed_rm = str(paths[4])
+    failed_mv = str(paths[1])
+
+    def fail(remote: tuple[str, ...]) -> bool:
+        return (len(remote) >= 3 and remote[:2] == ("rm", "-f") and remote[2] == failed_rm) or (
+            len(remote) >= 3 and remote[0] == "mv" and remote[2] == failed_mv and ".pfb-alerts-backup-" in remote[1]
+        )
+
+    vm = _WrappedVM(_LocalVM(), fail=fail)
+    errors = alerts._restore_seeded_files(vm, backups)
+
+    assert len(errors) == 2
+    assert any(failed_rm in error for error in errors)
+    assert any(failed_mv in error for error in errors)
+    restored_targets = [
+        remote[2]
+        for remote in vm.calls
+        if len(remote) >= 3 and remote[0] == "mv" and ".pfb-alerts-backup-" in remote[1]
+    ]
+    existing_targets = [backup.path for backup in backups if backup.backup_path is not None]
+    assert restored_targets == list(reversed(existing_targets))
+
+
+@pytest.mark.parametrize("unsupported", ["directory", "fifo", "device"])
+def test_unsupported_type_rejected_before_any_mutation(tmp_path: Path, unsupported: str) -> None:
+    regular = tmp_path / "first.txt"
+    regular.write_bytes(b"must stay put\n")
+    if unsupported == "directory":
+        invalid = tmp_path / "directory.txt"
+        invalid.mkdir()
+    elif unsupported == "fifo":
+        invalid = tmp_path / "fifo.txt"
+        os.mkfifo(invalid)
+    else:
+        invalid = Path("/dev/null")
+
+    with pytest.raises(AssertionError, match="unsupported"):
+        alerts._backup_seeded_files(_LocalVM(), (str(regular), str(invalid)))
+
+    assert regular.read_bytes() == b"must stay put\n"
+
+
+def _remote_write(vm: Any, path: str, content: str) -> None:
+    result = subprocess.run(
+        vm.ssh_argv("tee", path),
+        input=content,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert result.returncode == 0, f"write {path!r} failed: {result.stderr!r}"
+
+
+def _remote_kind(vm: Any, path: str) -> str:
+    quoted = shlex.quote(path)
+    result = vm.ssh(
+        f"if [ -L {quoted} ]; then printf symlink; "
+        f"elif [ -f {quoted} ]; then printf file; "
+        f"elif [ -e {quoted} ]; then printf unsupported; "
+        "else printf absent; fi",
+        timeout=15,
+    )
+    assert result.returncode == 0, f"inspect {path!r} failed: {result.stderr!r}"
+    assert result.stdout in {"absent", "file", "symlink", "unsupported"}
+    return result.stdout
+
+
+def _remote_snapshot(vm: Any, path: str) -> dict[str, Any]:
+    kind = _remote_kind(vm, path)
+    if kind == "absent":
+        return {"kind": kind}
+
+    metadata = vm.ssh("stat", "-f", "%u\t%g\t%Lp\t%m\t%B", path, timeout=15)
+    birthtime = True
+    if metadata.returncode != 0:
+        metadata = vm.ssh("stat", "-f", "%u\t%g\t%Lp\t%m", path, timeout=15)
+        birthtime = False
+    assert metadata.returncode == 0, f"stat {path!r} failed: {metadata.stderr!r}"
+    fields = metadata.stdout.strip().split("\t")
+    snapshot: dict[str, Any] = {
+        "kind": kind,
+        "uid": int(fields[0]),
+        "gid": int(fields[1]),
+        "mode": int(fields[2], 8),
+        "mtime": int(fields[3]),
+    }
+    if birthtime:
+        snapshot["birthtime"] = int(fields[4])
+
+    command = "readlink" if kind == "symlink" else "cat"
+    payload = vm.ssh(command, path, timeout=15)
+    assert payload.returncode == 0, f"snapshot {path!r} failed: {payload.stderr!r}"
+    snapshot["target" if kind == "symlink" else "bytes"] = (
+        payload.stdout if kind == "symlink" else payload.stdout.encode()
+    )
+    return snapshot
+
+
+def _remote_snapshots(vm: Any, paths: list[str]) -> dict[str, dict[str, Any]]:
+    return {path: _remote_snapshot(vm, path) for path in paths}
+
+
+def _remote_move_aside(vm: Any, paths: list[str], token: str) -> list[tuple[str, str | None]]:
+    backups: list[tuple[str, str | None]] = []
+    try:
+        for path in paths:
+            kind = _remote_kind(vm, path)
+            assert kind != "unsupported", f"unsupported live seeded path: {path!r}"
+            backup = None if kind == "absent" else f"{path}.seed-restore-outer-{token}"
+            if backup is not None:
+                assert _remote_kind(vm, backup) == "absent", f"outer backup collision: {backup!r}"
+                move = vm.ssh("mv", path, backup, timeout=15)
+                assert move.returncode == 0, f"outer backup {path!r} failed: {move.stderr!r}"
+            backups.append((path, backup))
+    except BaseException:
+        rollback = _remote_restore_aside(vm, backups)
+        assert rollback == [], "outer backup rollback failed: " + "\n".join(rollback)
+        raise
+    return backups
+
+
+def _remote_restore_aside(vm: Any, backups: list[tuple[str, str | None]]) -> list[str]:
+    errors: list[str] = []
+    for path, backup in reversed(backups):
+        remove = vm.ssh("rm", "-f", path, timeout=15)
+        if remove.returncode != 0:
+            errors.append(f"remove controlled path {path!r} failed: {remove.stderr!r}")
+            continue
+        if backup is not None:
+            restore = vm.ssh("mv", backup, path, timeout=15)
+            if restore.returncode != 0:
+                errors.append(f"restore outer backup {backup!r} failed: {restore.stderr!r}")
+    return errors
+
+
+def _remote_create_matrix(vm: Any, paths: list[str], live_target: str, dangling_target: str) -> None:
+    parents = sorted({str(Path(path).parent) for path in paths})
+    mkdir = vm.ssh("mkdir", "-p", *parents, timeout=15)
+    assert mkdir.returncode == 0, f"mkdir failed: {mkdir.stderr!r}"
+    for path, content in zip(
+        paths[:4],
+        ("regular nonempty\n", "", "no-final-newline", "first line\nsecond line\n"),
+        strict=True,
+    ):
+        _remote_write(vm, path, content)
+    for path, mode, timestamp in zip(
+        paths[:4],
+        ("0600", "0640", "0644", "0660"),
+        ("202401010101.01", "202401010102.02", "202401010103.03", "202401010104.04"),
+        strict=True,
+    ):
+        metadata = vm.ssh(f"chmod {mode} {shlex.quote(path)} && touch -t {timestamp} {shlex.quote(path)}", timeout=15)
+        assert metadata.returncode == 0, f"metadata seed {path!r} failed: {metadata.stderr!r}"
+    _remote_write(vm, live_target, "live target\n")
+    for path, target, timestamp in (
+        (paths[6], live_target, "202401010105.05"),
+        (paths[7], dangling_target, "202401010106.06"),
+    ):
+        link = vm.ssh("ln", "-s", target, path, timeout=15)
+        assert link.returncode == 0, f"symlink {path!r} failed: {link.stderr!r}"
+        metadata = vm.ssh("touch", "-h", "-t", timestamp, path, timeout=15)
+        assert metadata.returncode == 0, f"symlink metadata seed {path!r} failed: {metadata.stderr!r}"
+
+
+@pytest.mark.ui_e2e
+def test_seeded_files_restore_live(smoke_vm: Any, webui: Any) -> None:
+    """Leased-box fixture proof over all eight production seed paths."""
+    vm = smoke_vm
+    paths = list(alerts.SEEDED_FILES)
+    token = uuid.uuid4().hex
+    live_target = f"{paths[6]}.seed-restore-live-{token}"
+    dangling_target = f"{paths[7]}.seed-restore-missing-{token}"
+    auxiliary = (live_target, dangling_target)
+    outer_backups = _remote_move_aside(vm, paths, token)
+    cleanup_errors: list[str] = []
+
+    try:
+        _remote_create_matrix(vm, paths, live_target, dangling_target)
+        before = _remote_snapshots(vm, paths)
+
+        fixture = cast(Any, alerts.render_diff_state).__wrapped__(vm, webui)
+        next(fixture)
+        with pytest.raises(StopIteration):
+            next(fixture)
+
+        assert _remote_snapshots(vm, paths) == before
+    finally:
+        cleanup = vm.ssh("rm", "-f", *auxiliary, timeout=15)
+        if cleanup.returncode != 0:
+            cleanup_errors.append(f"live matrix cleanup failed: {cleanup.stderr!r}")
+        cleanup_errors.extend(_remote_restore_aside(vm, outer_backups))
+
+    assert cleanup_errors == []

--- a/tests/smoke/ui/test_alerts_seed_restore.py
+++ b/tests/smoke/ui/test_alerts_seed_restore.py
@@ -49,9 +49,13 @@ class _WrappedVM:
         self,
         inner: _LocalVM,
         fail: Callable[[tuple[str, ...]], bool] | None = None,
+        raise_before: Callable[[tuple[str, ...]], bool] | None = None,
+        raise_after: Callable[[tuple[str, ...]], bool] | None = None,
     ) -> None:
         self.inner = inner
         self.fail = fail
+        self.raise_before = raise_before
+        self.raise_after = raise_after
         self.calls: list[tuple[str, ...]] = []
 
     def ssh_argv(self, *remote: str) -> list[str]:
@@ -59,9 +63,14 @@ class _WrappedVM:
 
     def ssh(self, *remote: str, timeout: float = 15.0) -> subprocess.CompletedProcess[str]:
         self.calls.append(remote)
+        if self.raise_before is not None and self.raise_before(remote):
+            raise subprocess.TimeoutExpired(remote, timeout)
         if self.fail is not None and self.fail(remote):
             return subprocess.CompletedProcess(remote, 1, "", f"injected failure: {remote!r}")
-        return self.inner.ssh(*remote, timeout=timeout)
+        result = self.inner.ssh(*remote, timeout=timeout)
+        if self.raise_after is not None and self.raise_after(remote):
+            raise subprocess.TimeoutExpired(remote, timeout)
+        return result
 
 
 def _matrix_paths(tmp_path: Path) -> tuple[list[Path], Path, Path]:
@@ -304,6 +313,27 @@ def test_fixture_backup_failure_does_not_delete_rolled_back_files(tmp_path: Path
     assert set(tmp_path.iterdir()) == {first, second}
 
 
+def test_fixture_backup_timeout_after_ambiguous_move_restores_all_files(tmp_path: Path, monkeypatch: Any) -> None:
+    first = tmp_path / "a.txt"
+    second = tmp_path / "b.txt"
+    first.write_bytes(b"first original\n")
+    second.write_bytes(b"second original\n")
+    before = _snapshots([first, second])
+    vm = _WrappedVM(
+        _LocalVM(),
+        raise_after=lambda remote: len(remote) >= 2 and remote[0] == "mv" and remote[1] == str(second),
+    )
+
+    monkeypatch.setattr(alerts, "SEEDED_FILES", (str(first), str(second)))
+    fixture = cast(Any, alerts.render_diff_state).__wrapped__(vm, object())
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        next(fixture)
+
+    assert _snapshots([first, second]) == before
+    assert set(tmp_path.iterdir()) == {first, second}
+
+
 def test_restore_remove_failure_keeps_backup_at_recorded_path(tmp_path: Path) -> None:
     target = tmp_path / "seed.txt"
     target.write_bytes(b"original\n")
@@ -346,6 +376,34 @@ def test_restore_runs_in_reverse_and_aggregates_failures(tmp_path: Path) -> None
     ]
     existing_targets = [backup.path for backup in backups if backup.backup_path is not None]
     assert restored_targets == list(reversed(existing_targets))
+
+
+def test_restore_timeout_keeps_affected_backup_and_continues_full_matrix(tmp_path: Path) -> None:
+    paths, live_target, dangling_target = _matrix_paths(tmp_path)
+    _create_matrix(paths, live_target, dangling_target)
+    before = _snapshots(paths)
+    backups = alerts._backup_seeded_files(_LocalVM(), tuple(map(str, paths)))
+    affected = backups[-1]
+    affected_backup = Path(affected.backup_path or "")
+    _seed_replacements(paths)
+    vm = _WrappedVM(
+        _LocalVM(),
+        raise_before=lambda remote: len(remote) >= 3 and remote[:2] == ("rm", "-f") and remote[2] == affected.path,
+    )
+
+    errors = alerts._restore_seeded_files(vm, backups)
+
+    assert len(errors) == 1
+    assert affected.path in errors[0]
+    assert "timed out" in errors[0]
+    assert paths[-1].read_bytes() == b"replacement 7\n"
+    assert affected_backup.is_symlink()
+    assert _snapshots(paths[:-1]) == {path: state for path, state in before.items() if path != str(paths[-1])}
+    assert all(
+        backup.backup_path == affected.backup_path or not os.path.lexists(backup.backup_path)
+        for backup in backups
+        if backup.backup_path is not None
+    )
 
 
 @pytest.mark.parametrize("unsupported", ["directory", "fifo", "device"])

--- a/tests/smoke/ui/test_alerts_seed_restore.py
+++ b/tests/smoke/ui/test_alerts_seed_restore.py
@@ -101,7 +101,7 @@ def _snapshot(path: Path) -> dict[str, Any]:
         "mtime_ns": info.st_mtime_ns,
     }
     if hasattr(info, "st_birthtime"):
-        snapshot["birthtime"] = info.st_birthtime
+        snapshot["birthtime"] = getattr(info, "st_birthtime")
     if path.is_symlink():
         return {"kind": "symlink", "target": os.readlink(path), **snapshot}
     if path.is_file():


### PR DESCRIPTION
👀 ***#1382***(***#1427***): ***Restore Alerts state***

Closes #1382.

## Summary

- preserve every fixed Alerts seed path before any fixture mutation;
- restore absent files, regular files, live symlinks, and dangling symlinks exactly through same-directory atomic renames;
- retain recoverable backups and aggregate cleanup errors on hostile, partial, or timed-out operations;
- add independent fixture-level coverage for setup, render, post-yield, teardown, and combined-error paths, including ownership, mode, and timestamps.

## Verification

- frozen RED/GREEN proof: 17 failures on `a28c0645`, 10 failures on the prior implementation, 17 passes on the final commit;
- Python gates: 3,109 passed, 4 skipped; Ruff check/format and mypy passed;
- targeted live restore: 1 passed;
- full changed Alerts suite: 35 passed.

---
🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
