### PR TITLE
scripts: tighten inline escape tokens

### DIFF
--- a/scripts/check_agent_roles.py
+++ b/scripts/check_agent_roles.py
@@ -62,7 +62,7 @@ _ROLE_ID = re.compile(r"[a-z][a-z0-9-]*")
 # A DIRECTLY QUOTED model id is a pin; a mid-prose mention inside a longer
 # string is not — that tolerance is what "no textual identity" means here.
 _CLAUDE_MODEL_PIN = re.compile(r"""['"](claude-[a-z0-9.-]+)['"]""")
-_ESCAPE = "roles-ok"
+_ESCAPE = re.compile(r"(?<![\w-])roles-ok:[^\S\r\n]*\S")
 # The eight semantic fields every role's contract section must carry.
 _SECTION_FIELDS = (
     "Purpose & routing",
@@ -201,7 +201,7 @@ def _check_sections(doc: str, roles: list[Role], problems: list[str]) -> None:
 def _scan_model_pins(path: Path) -> list[str]:
     pins: list[str] = []
     for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-        if _ESCAPE in line:
+        if _ESCAPE.search(line):
             continue
         pins.extend(_CLAUDE_MODEL_PIN.findall(line))
     return pins

--- a/scripts/check_agent_roles.py
+++ b/scripts/check_agent_roles.py
@@ -22,8 +22,8 @@ Usage:
     check_agent_roles.py --all               # unconditional full validation
     [--root PATH]                            # repo root (default: script's repo)
 
-A model pin on a line containing `roles-ok` is exempt (with a reason, like the
-other checkers' escape hatches).
+A model pin is exempt only when its line carries standalone, case-sensitive
+`roles-ok:` followed by a same-line non-whitespace reason.
 
 Exit status: 0 = clean or skipped, 1 = violations (printed), 2 = usage/git error.
 """

--- a/scripts/check_comment_narration.py
+++ b/scripts/check_comment_narration.py
@@ -46,7 +46,7 @@ _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
 )
 
 # Matched case-insensitively so a differently-cased escape still exempts.
-_ESCAPE = "narration-ok"
+_ESCAPE = re.compile(r"(?<![\w-])narration-ok:[^\S\r\n]*\S", re.IGNORECASE)
 
 _SCAN_ROOTS = ("src", "scripts")
 
@@ -98,7 +98,7 @@ def find_violations(diff_text: str) -> list[Violation]:
             continue
         if in_hunk and raw.startswith("+"):
             line = raw[1:]
-            if path is not None and _in_scope(path) and _ESCAPE not in line.lower():
+            if path is not None and _in_scope(path) and not _ESCAPE.search(line):
                 for pattern, reason in _PATTERNS:
                     if pattern.search(line):
                         violations.append(Violation(path, lineno, line.strip(), reason))

--- a/scripts/check_comment_narration.py
+++ b/scripts/check_comment_narration.py
@@ -46,7 +46,7 @@ _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
 )
 
 # Matched case-insensitively so a differently-cased escape still exempts.
-_ESCAPE = re.compile(r"(?<![\w-])narration-ok:[^\S\r\n]*\S", re.IGNORECASE)
+_ESCAPE = re.compile(r"(?<![\w-])narration-ok:[^\S\r\n]*\S")
 
 _SCAN_ROOTS = ("src", "scripts")
 
@@ -98,7 +98,7 @@ def find_violations(diff_text: str) -> list[Violation]:
             continue
         if in_hunk and raw.startswith("+"):
             line = raw[1:]
-            if path is not None and _in_scope(path) and not _ESCAPE.search(line):
+            if path is not None and _in_scope(path) and not _ESCAPE.search(line.lower()):
                 for pattern, reason in _PATTERNS:
                     if pattern.search(line):
                         violations.append(Violation(path, lineno, line.strip(), reason))

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -33,8 +33,8 @@ SCOPE (deliberately low false-positive: VALUES only, never prose)
   (they define/contain the patterns being matched, so scanning them is
   meaningless self-reference). ``docs/misc/pfSense_versions.md`` is outside
   the scan roots anyway; it is named here only to document that intent.
-* A line containing the substring ``version-literal-ok`` is exempt (inline
-  escape: ``# version-literal-ok: <reason>``).
+* A line is exempt only when it carries standalone, case-sensitive
+  ``version-literal-ok:`` followed by a same-line non-whitespace reason.
 * Comments are prose in every scanned language, per that language's syntax
   (enumerated from the scan roots' actual file types — issue #941): ``#``
   line/trailing comments everywhere; ``//`` and ``/* ... */`` in PHP/JS

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -127,7 +127,7 @@ _QUOTED_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|\'([^\']*)\'|`(?:[^`\\]|\\.)*`')
 _QUOTED_C_RE = re.compile(r'"((?:[^"\\]|\\.)*)"|\'((?:[^\'\\]|\\.)*)\'|`((?:[^`\\]|\\.)*)`')
 
 # Inline per-line escape (`# version-literal-ok: <reason>`), spec'd in issue #922.
-_ESCAPE = "version-literal-ok"
+_ESCAPE = re.compile(r"(?<![\w-])version-literal-ok:[^\S\r\n]*\S")
 
 # Tracked-tree roots where a version literal could plausibly be pasted.
 _SCAN_ROOTS = ("src", "scripts", ".github/workflows")
@@ -437,7 +437,7 @@ def scan_text(path: Path, text: str) -> list[tuple[Path, int, str]]:
     c_style = path.suffix in _C_COMMENT_EXTS
     code_lines = _code_lines(lines, path.suffix)
     for lineno, (line, code) in enumerate(zip(lines, code_lines, strict=True), start=1):
-        if code is None or _ESCAPE in line:
+        if code is None or _ESCAPE.search(line):
             continue
         if _line_has_value_literal(code, c_style):
             violations.append((path, lineno, line.strip()))

--- a/tests/test_agent_roles_check.py
+++ b/tests/test_agent_roles_check.py
@@ -509,6 +509,35 @@ def test_cli_all_green_and_exit_codes(tmp_path: Path) -> None:
     assert "consistent (5 roles)" in result.stdout
 
 
+def test_cli_escape_requires_colon_and_reason(tmp_path: Path) -> None:
+    valid = (
+        "roles-ok: reason",
+        "roles-ok:\t  reason",
+        "roles-ok: []{}()$.*+?",
+        f"roles-ok: {'x' * 4096}",
+        "roles-ok: \ufffd",
+    )
+    malformed = (
+        "roles-ok",
+        "roles-ok:",
+        "roles-ok:   ",
+        "roles-ok reason",
+        "roles-ok - reason",
+        "xroles-ok: reason",
+        "roles-ok-extra: reason",
+        "Roles-OK: reason",
+        "roles-ok:\n// reason",
+    )
+    for marker in valid:
+        make_tree(tmp_path, build_js=f"m 'claude-small-x'\nm 'claude-top-x' // {marker}\n")
+        result = _cli(tmp_path, "--all")
+        assert result.returncode == 0, f"valid marker {marker!r}: {result.stdout}{result.stderr}"
+    for marker in malformed:
+        make_tree(tmp_path, build_js=f"m 'claude-small-x'\nm 'claude-top-x' // {marker}\n")
+        result = _cli(tmp_path, "--all")
+        assert result.returncode == 1, f"malformed marker {marker!r}: {result.stdout}{result.stderr}"
+
+
 def test_cli_usage_error_exit_2(tmp_path: Path) -> None:
     result = _cli(tmp_path)  # no mode flag
     assert result.returncode == 2

--- a/tests/test_comment_narration_check.py
+++ b/tests/test_comment_narration_check.py
@@ -292,6 +292,39 @@ def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run([sys.executable, str(_TOOL), *args], cwd=repo, capture_output=True, text=True)
 
 
+def test_cli_escape_requires_colon_and_reason(tmp_path: Path) -> None:
+    valid = (
+        "narration-ok: reason",
+        "narration-ok:\t  reason",
+        "Narration-OK: reason",
+        "narration-ok: []{}()$.*+?",
+        f"narration-ok: {'x' * 4096}",
+        "narration-ok: \ufffd",
+    )
+    malformed = (
+        "narration-ok",
+        "narration-ok:",
+        "narration-ok:   ",
+        "narration-ok reason",
+        "narration-ok - reason",
+        "xnarration-ok: reason",
+        "narration-ok-extra: reason",
+        "narration-ok:\n// reason",
+    )
+    for index, (marker, expected) in enumerate((*((m, 0) for m in valid), *((m, 1) for m in malformed))):
+        repo = tmp_path / str(index)
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "devel")
+        (repo / "src").mkdir()
+        (repo / "src/a.inc").write_text("// clean\n")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "base")
+        (repo / "src/a.inc").write_text(f"// clean\n// Phase 2 // {marker}\n")
+        _git(repo, "add", ".")
+        result = _run(repo, "--staged")
+        assert result.returncode == expected, f"marker {marker!r}: {result.stdout}{result.stderr}"
+
+
 def test_cli_staged_and_diff_modes(tmp_path: Path) -> None:
     _git(tmp_path, "init", "-q", "-b", "devel")
     (tmp_path / "src").mkdir()

--- a/tests/test_comment_narration_check.py
+++ b/tests/test_comment_narration_check.py
@@ -309,6 +309,8 @@ def test_cli_escape_requires_colon_and_reason(tmp_path: Path) -> None:
         "narration-ok - reason",
         "xnarration-ok: reason",
         "narration-ok-extra: reason",
+        "narratİon-ok: reason",
+        "narratıon-ok: reason",
         "narration-ok:\n// reason",
     )
     for index, (marker, expected) in enumerate((*((m, 0) for m in valid), *((m, 1) for m in malformed))):

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -608,6 +608,36 @@ def _rev(repo: Path) -> str:
     return out.stdout.strip()
 
 
+def test_cli_escape_requires_colon_and_reason(tmp_path: Path) -> None:
+    valid = (
+        "version-literal-ok: reason",
+        "version-literal-ok:\t  reason",
+        "version-literal-ok: []{}()$.*+?",
+        f"version-literal-ok: {'x' * 4096}",
+        "version-literal-ok: \ufffd",
+    )
+    malformed = (
+        "version-literal-ok",
+        "version-literal-ok:",
+        "version-literal-ok:   ",
+        "version-literal-ok reason",
+        "version-literal-ok - reason",
+        "xversion-literal-ok: reason",
+        "version-literal-ok-extra: reason",
+        "Version-Literal-OK: reason",
+        "version-literal-ok:\n# reason",
+    )
+    for index, (marker, expected) in enumerate((*((m, 0) for m in valid), *((m, 1) for m in malformed))):
+        repo = tmp_path / str(index)
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "devel")
+        (repo / "scripts").mkdir()
+        (repo / "scripts/tool.sh").write_text(f'_ABI="{_FREEBSD15}" # {marker}\n')
+        _git(repo, "add", ".")
+        result = _run(repo)
+        assert result.returncode == expected, f"marker {marker!r}: {result.stdout}{result.stderr}"
+
+
 def test_cli_staged_mode_flags_then_clears(tmp_path: Path) -> None:
     _git(tmp_path, "init", "-q", "-b", "devel")
     (tmp_path / "scripts").mkdir()


### PR DESCRIPTION
## Summary

- require standalone `roles-ok:`, `narration-ok:`, and `version-literal-ok:` markers with a same-line reason
- preserve each checker's existing case rules, modes, scope, and exit codes
- reconcile executable headers with the tightened contract

## Evidence

- test-first reproduction: three CLI tests failed on the untouched source, then passed unchanged after the fix
- frozen test hashes verified independently by `verify-red-proof.sh`
- targeted checker suites: `175 passed`
- canonical Python gates: pytest, Ruff lint, Ruff format, and mypy all passed
- independent hostile-input matrix: all three real CLI/file surfaces passed
- post-rebase range-diff: both patches byte-equivalent; full gates passed on current `devel`

Fixes #1421

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
