### PR TITLE
tests/smoke: fix inject_ip_lists/seed_geoip_dataset cross-module state leakage

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -769,6 +769,9 @@ _GEOIP_MMDB_FIXTURE = "GeoLite2-Country.mmdb"
 # pfblockerng.sh's dMax classify loop runs (~:1148).
 _GEOIP_MMDB_PROBE_IP = "67.43.156.1"
 _GEOIP_MMDB_PROBE_CC = "BT"
+# $pfb['ccdir'] (pfblockerng.inc) -- per-continent/per-ISO-code txt files `ugc`'s
+# uc_countries()/get_countries() derive from the CSVs; teardown_geoip_dataset's cleanup.
+_GEOIP_CCDIR = "/usr/local/share/GeoIP/cc"
 
 
 def seed_geoip_dataset(vm: SmokeVM, *, timeout: float = 120.0) -> None:
@@ -865,6 +868,28 @@ def seed_geoip_dataset(vm: SmokeVM, *, timeout: float = 120.0) -> None:
         raise RuntimeError(
             f"seed_geoip_dataset: mmdblookup sanity check failed: rc={lookup.returncode} "
             f"stdout={lookup.stdout!r} stderr={lookup.stderr!r}"
+        )
+
+
+def teardown_geoip_dataset(vm: SmokeVM, *, timeout: float = 60.0) -> None:
+    """Undo :func:`seed_geoip_dataset`'s on-box footprint (issue #1214).
+
+    Removes the seeded CSV/mmdb fixtures, the derived per-continent/per-ISO-code
+    txt files (:data:`_GEOIP_CCDIR`), and the generated GUI pages
+    (:data:`GEOIP_CONTINENT_PAGES`) -- restoring the box's natural "no GeoIP
+    database" state (none of this is package-shipped; `ugc` is what creates it
+    all). Plain ``rm``, so a path never seeded/generated this run is not an error;
+    wired into :func:`reset_pfb_baseline` so a later module never inherits it.
+    """
+    fixture_paths = [f"{GEOIP_SHARE_DIR}/{name}" for name in (*_GEOIP_CSV_FIXTURES, _GEOIP_MMDB_FIXTURE)]
+    page_paths = [f"{PFB_WWW_DIR}/{page}" for page in GEOIP_CONTINENT_PAGES]
+    result = vm.ssh("rm", "-f", *fixture_paths, *page_paths, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(f"teardown_geoip_dataset: rm -f failed: rc={result.returncode} stderr={result.stderr!r}")
+    result = vm.ssh("rm", "-rf", _GEOIP_CCDIR, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"teardown_geoip_dataset: rm -rf {_GEOIP_CCDIR} failed: rc={result.returncode} stderr={result.stderr!r}"
         )
 
 
@@ -2716,13 +2741,17 @@ def inject_ip_lists(vm: SmokeVM, specs: list[IpCase], *, timeout: float = 90.0) 
     aggregate test -- use this: it groups the specs by family root and writes each root with
     ALL its list groups at once (and still sets enable_cb + the inbound/outbound interface,
     like ``inject``). Control records are applied first, per IpCase, mirroring ``inject``.
+
+    issue #1214: BOTH family roots are always written -- a family absent from ``specs``
+    gets reset to ``array()`` -- so a family untouched by this call never inherits a
+    stale list group a PRIOR call (same module, no reset in between) left behind.
     """
     for spec in specs:
         set_control_records(vm, spec.control_local_data, spec.control_local_zone, timeout=timeout)
-    by_root: dict[str, list[str]] = {}
+    by_root: dict[str, list[str]] = {CFG_IP_V4_LISTS: [], CFG_IP_V6_LISTS: []}
     for spec in specs:
         root = CFG_IP_V6_LISTS if spec.family == "v6" else CFG_IP_V4_LISTS
-        by_root.setdefault(root, []).append(_ip_list_php(spec))
+        by_root[root].append(_ip_list_php(spec))
     ipset = {"inbound_interface": SMOKE_IP_IFACE, "outbound_interface": SMOKE_IP_IFACE}
     set_roots = "".join(
         f"config_set_path({_php_str(root)}, array({', '.join(groups)}));\n" for root, groups in by_root.items()
@@ -3245,7 +3274,9 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
         row cannot answer a later module's probe before the DNSBL module) and regenerates
         the resolver config so the live daemon matches;
       * drops the derived state — ``clearip``/``cleardnsbl`` (tables/sqlite) then a blocking
-        ``apply_filter_sync`` (pf rules).
+        ``apply_filter_sync`` (pf rules);
+      * removes any :func:`seed_geoip_dataset` footprint (issue #1214) so a later module never
+        reads a fake GeoIP corpus a prior module seeded.
 
     NO forced ``update``: the config is now empty, so there is nothing to rebuild — the next
     module's ``deployed_vm`` re-establishes the VIP/DNS/feed config it needs. (Like :func:`reset`,
@@ -3278,6 +3309,9 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
     result = php_eval(vm, snippet, timeout=timeout)
     if result.returncode != 0 or "OK" not in result.stdout:
         raise RuntimeError(f"reset_pfb_baseline failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+    # Plain filesystem cleanup, independent of package install state (unlike the CLI-driven
+    # clears below) — always undo any GeoIP corpus a prior module seeded.
+    teardown_geoip_dataset(vm)
     # Drop the derived state: tables/sqlite (clearip/cleardnsbl) + pf rules (blocking sync).
     # Skip the CLI-driven clears when the package is uninstalled — a prior test's `pkg delete`
     # (e.g. test_dot_doq_block's uninstall case) removes PFB_CLI, so shelling it here fails with

--- a/tests/smoke/test_smoke_isolation.py
+++ b/tests/smoke/test_smoke_isolation.py
@@ -19,6 +19,14 @@ These two tests pin the keystone's behaviour (red→green vs the old ``reset()``
   it declares: a prior case's ``pfb_hsts`` does not survive (replace-not-merge), while the
   VIP/port infrastructure ``ensure_dnsbl_vip`` set IS preserved (so DNSBL is not force-disabled).
   A plain ``array_merge`` leaves ``pfb_hsts=on`` leaked → the first ``Then`` fails on the old path.
+
+Two more (issue #1214), same keystone family:
+
+* ``test_inject_ip_lists_resets_untouched_family`` — a family absent from an
+  ``inject_ip_lists`` call is reset to empty, not left holding a PRIOR call's list group.
+* ``test_reset_pfb_baseline_clears_geoip_dataset`` — ``reset_pfb_baseline`` removes every
+  ``seed_geoip_dataset`` artifact (CSVs, mmdb, generated GUI pages), so a later module never
+  reads a fake GeoIP corpus a prior module seeded.
 """
 
 from __future__ import annotations
@@ -152,3 +160,70 @@ def test_dnsbl_inject_replaces_leaked_toggle(deployed_vm: SmokeVM) -> None:
     assert leaked == "", f"pfb_hsts leaked across DNSBL cases: {leaked!r} (array_merge would keep 'on')"
     # ... and the VIP infrastructure key is PRESERVED (a naive config_del would force-disable DNSBL).
     assert h.config_get(vm, vip_key) != "", "replace dropped pfb_dnsvip4 — would force-disable DNSBL"
+
+
+def test_inject_ip_lists_resets_untouched_family(deployed_vm: SmokeVM) -> None:
+    """A family absent from an inject_ip_lists() call is reset to empty, not left holding a
+    PRIOR call's list group (issue #1214) -- proved in BOTH directions.
+
+    Scenario:
+      Given a v6 IP list injected via inject_ip_lists,
+      When a LATER inject_ip_lists call in the same module injects only a v4 spec,
+      Then the v6 list-config root is EMPTY (not the leaked-forward v6 list) and the v4
+        root holds exactly the new spec (the issue's reported shape);
+      When a THIRD call injects only a v6 spec (the mirror direction),
+      Then the now-untouched v4 root is EMPTY too, and the v6 root holds the newest spec.
+    """
+    vm = deployed_vm
+    feed_url = "http://192.168.89.2/ip_plain_cidr.txt"
+    v6spec = h.IpCase(aliasname="smokeisoipv6", feed_url=feed_url, header="smokeisoipv6", family="v6")
+    v4spec = h.IpCase(aliasname="smokeisoipv4", feed_url=feed_url, header="smokeisoipv4")
+    v6spec2 = h.IpCase(aliasname="smokeisoipv6b", feed_url=feed_url, header="smokeisoipv6b", family="v6")
+
+    # GIVEN a v6-only inject_ip_lists call.
+    h.inject_ip_lists(vm, [v6spec])
+    assert _section_count(vm, h.CFG_IP_V6_LISTS) == 1, "inject_ip_lists did not write the v6 list section"
+
+    # WHEN a LATER call injects only a v4 spec.
+    h.inject_ip_lists(vm, [v4spec])
+
+    # THEN the untouched v6 root is reset to empty (not left holding the prior v6 list) ...
+    leaked = _section_count(vm, h.CFG_IP_V6_LISTS)
+    assert leaked == 0, f"v6 list root leaked forward from a prior inject_ip_lists call ({leaked} rows)"
+    # ... and the v4 root holds exactly the new spec.
+    assert _section_count(vm, h.CFG_IP_V4_LISTS) == 1, "inject_ip_lists did not write the v4 list section"
+
+    # WHEN a THIRD call injects only a v6 spec (the mirror direction).
+    h.inject_ip_lists(vm, [v6spec2])
+
+    # THEN the now-untouched v4 root is reset to empty too ...
+    leaked_v4 = _section_count(vm, h.CFG_IP_V4_LISTS)
+    assert leaked_v4 == 0, f"v4 list root leaked forward from a prior inject_ip_lists call ({leaked_v4} rows)"
+    # ... and the v6 root holds exactly the newest spec.
+    assert _section_count(vm, h.CFG_IP_V6_LISTS) == 1, "inject_ip_lists did not write the v6 list section (3rd call)"
+
+
+def test_reset_pfb_baseline_clears_geoip_dataset(deployed_vm: SmokeVM) -> None:
+    """reset_pfb_baseline undoes seed_geoip_dataset's on-box footprint: a later module must
+    not inherit a fake GeoIP corpus a prior module seeded (issue #1214).
+
+    Scenario:
+      Given the MaxMind-DB test corpus is seeded (CSVs, mmdb, generated GUI pages),
+      When reset_pfb_baseline runs,
+      Then every seeded/generated GeoIP artifact is gone.
+    """
+    vm = deployed_vm
+    mmdb_path = f"{h.GEOIP_SHARE_DIR}/GeoLite2-Country.mmdb"
+    a_page = f"{h.PFB_WWW_DIR}/{h.GEOIP_CONTINENT_PAGES[0]}"
+
+    # GIVEN the GeoIP corpus is seeded.
+    h.seed_geoip_dataset(vm)
+    assert vm.ssh("test", "-f", mmdb_path).returncode == 0, "seed_geoip_dataset did not write the mmdb fixture"
+    assert vm.ssh("test", "-f", a_page).returncode == 0, "seed_geoip_dataset did not generate the Africa page"
+
+    # WHEN the clean-baseline reset runs.
+    h.reset_pfb_baseline(vm)
+
+    # THEN every seeded/generated GeoIP artifact is gone.
+    assert vm.ssh("test", "-f", mmdb_path).returncode != 0, "mmdb fixture survived reset_pfb_baseline"
+    assert vm.ssh("test", "-f", a_page).returncode != 0, "generated Africa page survived reset_pfb_baseline"


### PR DESCRIPTION
## Summary

- `inject_ip_lists()` only wrote the family root(s) present in the given specs, so a family absent from a call (e.g. a v4-only call after a prior v6-only call in the same module) kept whatever list group an earlier call had left there. It now always writes both `CFG_IP_V4_LISTS` and `CFG_IP_V6_LISTS`, resetting the absent family to an empty array.
- `seed_geoip_dataset()` wrote the MaxMind-DB test corpus (CSVs, mmdb, generated GUI pages) with no teardown anywhere, per the 2026-07-13 audit comment on #1214. Added `teardown_geoip_dataset()` and wired it into `reset_pfb_baseline()` (the module-scoped SMOKE-tier isolation keystone), so a later module never inherits a fake GeoIP corpus a prior module seeded. The UI tier's own deliberate GeoIP seeding (`ui/conftest.py`) is untouched — `reset_pfb_baseline`/`_pfb_module_baseline` already excludes the UI tier.

## Evidence

Red-first reproduction tests added to `tests/smoke/test_smoke_isolation.py` (the existing home for `reset_pfb_baseline` keystone coverage):

- `test_inject_ip_lists_resets_untouched_family` — proves BOTH directions (a v4-only call resetting a leaked v6 root, and the mirror: a v6-only call resetting a leaked v4 root). RED: `AssertionError: v6 list root leaked forward from a prior inject_ip_lists call (1 rows)`; GREEN after the fix.
- `test_reset_pfb_baseline_clears_geoip_dataset` — RED: `AssertionError: mmdb fixture survived reset_pfb_baseline`; GREEN after the fix.

Both run live on a leased CE box via `scripts/local-smoke.sh`, along with the two pre-existing sibling isolation tests in the same module (no regression), plus the full `test_smoke_ip_recompute.py` (12 tests), `test_smoke_suppression.py` (6 tests), `test_smoke_aggregate.py` (8 tests), and `test_smoke_autorule_immutable.py` (6 base + 5 parametrized) — every module in the coverage matrix that calls `inject_ip_lists`/`seed_geoip_dataset` — all green post-fix.

A pre-existing, already-tracked baseline failure (`tests/test_scanner_finding_policy.py`, issue #1450 — a CLAUDE.md Stage-1 policy-extraction vocabulary drift) is unrelated to this change; this diff touches only `tests/smoke/helpers.py` and `tests/smoke/test_smoke_isolation.py`.

## Test plan

- [x] `ruff check .` / `ruff format --check .` / `mypy tests/` — pass
- [x] `python3 -m pytest` — pass except the pre-existing #1450 failure (unrelated files)
- [x] Live-VM red→green: `scripts/local-smoke.sh --filter 'test_inject_ip_lists_resets_untouched_family or test_reset_pfb_baseline_clears_geoip_dataset'`
- [x] Live-VM regression sweep: `scripts/local-smoke.sh --filter 'recompute or continent_only_geoip or find_reported_header or suppression'` — 18 passed
- [x] Live-VM regression sweep: `scripts/local-smoke.sh --filter 'aggregate or test_user_rules_preserved_after_force_update or test_force_update_is_idempotent or test_order0_pfb_block_before_user_pass or test_order1_user_pass_before_pfb_block or test_pfb_permit_precedes_user_block_every_order or test_order4_reorders_user_block_before_user_pass'` — 18 passed

Fixes #1214

🤖 Generated with [Claude Code](https://claude.com/claude-code)