### PR TITLE
tests: strengthen TLD oracle/manifest test coverage from PR #1321 review

### DIFF
--- a/scripts/bench_dnsbl_line_parsing.py
+++ b/scripts/bench_dnsbl_line_parsing.py
@@ -107,7 +107,9 @@ def worker_python(worktree: str, raw_path: str, iterations: int) -> int:
     manifest = {
         "version": 1,
         "config": {
-            "tld_wildcard_master": [],
+            # issue #1328: 'tld_wildcard_master' is NOT a real manifest wire key --
+            # the oracle rides a shipped file (_dnsbl_config_from_manifest() never
+            # reads it from config), so this fixture must not carry it.
             "tld_wildcard_blacklist": [],
             "tld_wildcard_exclusion": [],
             "user_whitelist": [],

--- a/tests/php/TldBridgeEmitTest.php
+++ b/tests/php/TldBridgeEmitTest.php
@@ -157,6 +157,9 @@ final class TldBridgeEmitTest extends TestCase
 
 		$m = pfb_unbound_python_sources([]);
 
+		// issue #1328: the oracle must never ride the manifest under its post-rename
+		// (ADR-66) blob name either.
+		$this->assertArrayNotHasKey('tld_wildcard_master', $m['config'], 'tld_wildcard_master must never appear in the manifest');
 		$this->assertSame([], $m['config']['tld_wildcard_blacklist'], 'OFF must empty tld_wildcard_blacklist even though it was configured');
 		$this->assertSame([], $m['config']['tld_wildcard_exclusion'], 'OFF must empty tld_wildcard_exclusion even though it was configured');
 	}
@@ -169,6 +172,7 @@ final class TldBridgeEmitTest extends TestCase
 
 		$m = pfb_unbound_python_sources([]);
 
+		$this->assertArrayNotHasKey('tld_wildcard_master', $m['config'], 'tld_wildcard_master must never appear in the manifest, even ON');
 		$this->assertSame(['evil-tld'], $m['config']['tld_wildcard_blacklist'], 'ON must populate tld_wildcard_blacklist from config');
 		$this->assertSame(['good.example'], $m['config']['tld_wildcard_exclusion'], 'ON must populate tld_wildcard_exclusion from config');
 	}

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -232,6 +232,10 @@ final class UnboundPythonSourcesTest extends TestCase
 		// issue #1255: the public-suffix oracle is no longer carried in the manifest
 		// (HSTS parity -- a shipped static file + ini flag instead); the key is absent.
 		$this->assertArrayNotHasKey('tld_master', $m['config']);
+		// issue #1328: pin the POST-RENAME (ADR-66) blob name too -- a writer
+		// regression emitting the oracle under the new name would slip past the
+		// old-name-only pin above.
+		$this->assertArrayNotHasKey('tld_wildcard_master', $m['config']);
 		$this->assertSame([], $m['config']['tld_wildcard_blacklist']);
 		$this->assertSame([], $m['config']['user_whitelist']);
 		$this->assertSame([], $m['config']['user_unlock']);
@@ -252,6 +256,7 @@ final class UnboundPythonSourcesTest extends TestCase
 		$m = pfb_unbound_python_sources($this->feeds());
 
 		$this->assertArrayNotHasKey('tld_master', $m['config'], 'tld_master must never appear in the manifest');
+		$this->assertArrayNotHasKey('tld_wildcard_master', $m['config'], 'tld_wildcard_master (post-rename blob name) must never appear in the manifest');
 		$this->assertSame([], $m['config']['tld_wildcard_blacklist'], 'OFF must empty tld_wildcard_blacklist even though it was configured');
 		$this->assertSame([], $m['config']['tld_wildcard_exclusion'], 'OFF must empty tld_wildcard_exclusion even though it was configured');
 	}
@@ -265,6 +270,7 @@ final class UnboundPythonSourcesTest extends TestCase
 		$m = pfb_unbound_python_sources($this->feeds());
 
 		$this->assertArrayNotHasKey('tld_master', $m['config'], 'tld_master must never appear in the manifest, even ON');
+		$this->assertArrayNotHasKey('tld_wildcard_master', $m['config'], 'tld_wildcard_master (post-rename blob name) must never appear in the manifest, even ON');
 		$this->assertSame(['evil-tld'], $m['config']['tld_wildcard_blacklist'], 'ON must populate tld_wildcard_blacklist from config');
 		$this->assertSame(['good.example'], $m['config']['tld_wildcard_exclusion'], 'ON must populate tld_wildcard_exclusion from config');
 	}

--- a/tests/test_manifest_path_confinement.py
+++ b/tests/test_manifest_path_confinement.py
@@ -182,12 +182,25 @@ class TestTldWildcardOracleGating:
 
         assert config["tld_wildcard_master"] == []
 
-    def test_manifest_tld_master_key_is_ignored_regardless_of_flag(self, tmp_path: Any) -> None:
+    @pytest.mark.parametrize("flag_on", [False, True])
+    def test_manifest_tld_master_key_is_ignored_regardless_of_flag(self, tmp_path: Any, flag_on: bool) -> None:
         # A manifest embedding tld_master (stale pre-#1255 shape, or crafted) must
-        # never feed the oracle -- the flag + shipped file are the sole source.
-        pfb_unbound.pfb["python_tld_wildcard"] = False
+        # never feed the oracle -- the flag + shipped file are the sole source, for
+        # BOTH flag states. ON ships a REAL oracle file alongside the poisoned
+        # manifest key, so a regression that merged/fell back to the manifest value
+        # would surface as extra/wrong entries, not just an empty-vs-empty match.
+        pfb_unbound.pfb["python_tld_wildcard"] = flag_on
+        expected: list[str] = []
+        if flag_on:
+            oracle = tmp_path / "pfb_py_tld.txt"
+            oracle.write_text("com\nnet\n", encoding="utf-8")
+            pfb_unbound.pfb["pfb_py_tld"] = str(oracle)
+            expected = ["com", "net"]
         manifest = {"config": {"tld_master": "/etc/passwd"}}
 
         config = pfb_unbound._dnsbl_config_from_manifest(manifest, str(tmp_path))
 
-        assert config["tld_wildcard_master"] == []
+        assert config["tld_wildcard_master"] == expected, (
+            f"expected {expected!r} (only the shipped oracle, never the poisoned "
+            f"manifest 'tld_master' key), got {config['tld_wildcard_master']!r}"
+        )


### PR DESCRIPTION
## Summary

Closes three of the four test-strength gaps deferred from PR #1321's review (#1328); the fourth is deferred further as its own tracking issue (see below).

- **Item 1 (missing not-has-key pin):** `tests/php/UnboundPythonSourcesTest.php` pinned only `assertArrayNotHasKey('tld_master', ...)` (the pre-ADR-66 blob name). Added a sibling `assertArrayNotHasKey('tld_wildcard_master', ...)` beside each of the three existing pins, plus the two optional C3 tests in `tests/php/TldBridgeEmitTest.php`, so a writer regression that emits the oracle under the post-rename name is caught too.
- **Item 2 (single-sided flag test):** `tests/test_manifest_path_confinement.py::TestTldWildcardOracleGating::test_manifest_tld_master_key_is_ignored_regardless_of_flag` covered only `python_tld_wildcard=False`. Parameterized over both flag states; ON now ships a real oracle file alongside the poisoned `config.tld_master` manifest value and asserts only the shipped file's content is consumed.
- **Item 3 (bench fixture drift):** `scripts/bench_dnsbl_line_parsing.py`'s fixture carried a `tld_wildcard_master` manifest key that doesn't exist in the real wire shape (the writer never emits it; `_dnsbl_config_from_manifest()` never reads it from the manifest). Removed.
- **Item 4 (bare asserts, ~599 sites in `tests/test_pfb_unbound.py`):** the issue's own text frames this as "its own cleanup" -- too large to fold into this scoped fix. Filed as #1452.

## Test plan

- [x] `vendor/bin/phpunit` -- 45/45 green (`UnboundPythonSourcesTest` + `TldBridgeEmitTest`), full suite green.
- [x] `python3 -m pytest tests/test_manifest_path_confinement.py` -- 17/17 green, including both new parameter cases.
- [x] Full `python3 -m pytest` -- 3081 passed, 4 skipped, 2 pre-existing failures unrelated to this diff (`test_scanner_finding_policy.py`, already tracked as #1450 -- broken by an unrelated CLAUDE.md restructuring commit, zero overlap with this diff).
- [x] `ruff check .` / `ruff format --check .` / `mypy tests/` -- all clean.
- [x] `composer phpstan` / `composer phpcs -- --standard=phpcs.xml.dist src/` -- clean.
- [x] Red->green proof for item 1: temporarily emitted `'tld_wildcard_master' => array()` into the PHP manifest writer -- 5 new assertions failed as expected; reverted, reran green.
- [x] Red->green proof for item 2: temporarily merged the poisoned `config.tld_master` value into the oracle read path -- only the new `[True]` (ON) parameter case failed (proving the OFF-only test would have missed this regression entirely); reverted, reran green.
- [x] Behaviour-preservation proof for item 3: ran the bench worker directly before/after the fixture fix -- `data_db_size`/`zone_db_size`/`white_db_size` identical (1/1/1) in both cases.

Fixes #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)