### PR TITLE
scripts: context byte-budget and routing-header checker (Stage 2, #1437)

### DIFF
--- a/.agents/policy/sessions.md
+++ b/.agents/policy/sessions.md
@@ -1,7 +1,7 @@
 # Session layouts and managed-remote sessions
 
-Scope: where a session runs, where work-item worktrees go, and cross-session resume. Load
-when: starting work in an unfamiliar environment or resuming another session's item.
+Scope: where a session runs, where work-item worktrees go, and cross-session resume.
+Load when: starting work in an unfamiliar environment or resuming another session's item.
 
 ## Session layouts (three environments, one rule)
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -299,6 +299,18 @@ else
 	skip agent-roles
 fi
 
+# --- Context byte budgets + routing headers (map #1383): the bootstrap, the
+#     .agents/policy|context files, dir stubs, and hook capsules stay within
+#     their byte budgets, and every AGENTS.md routing-table target keeps its
+#     Scope/Load-when header. Self-scopes: validates iff the staged diff
+#     touches a context surface; otherwise reports the skip. ---
+if [ -n "$py_bin" ]; then
+	step 'context-budget (bootstrap/policy byte budgets + routing headers)'
+	"$py_bin" scripts/check_context_budget.py --staged || failed 'context-budget'
+else
+	skip context-budget
+fi
+
 # =============================== PHP (*.php, *.inc) ========================== #
 if [ "$staged_php" = 1 ]; then
 	# php -l syntax check (output shown only for files that fail).

--- a/.github/workflows/context-budget.yml
+++ b/.github/workflows/context-budget.yml
@@ -1,0 +1,50 @@
+# Context byte budgets + routing headers (map #1383, #1437) — a standalone
+# workflow, NOT a test.yml job: test.yml's global `paths-ignore` ('**/*.md')
+# would skip that entire workflow for an md-only change — the exact change
+# class this gate polices (the budgets gate re-accretion of the hot context,
+# and policy/docs edits land md-only, often pushed straight to devel). The
+# `paths` lists mirror scripts/check_context_budget.py's trigger surfaces and
+# are pinned by
+# tests/test_context_budget.py::test_ci_workflow_paths_match_checker_triggers.
+name: Context budget
+
+on:
+  push:
+    branches: [main, devel]
+    paths:
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - '.claude/settings.json'
+      - 'scripts/check_context_budget.py'
+      - '.agents/policy/**'
+      - '.agents/context/**'
+      - 'docs/misc/**'
+      - '**/AGENTS.md'
+      - '**/CLAUDE.md'
+  pull_request:
+    paths:
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - '.claude/settings.json'
+      - 'scripts/check_context_budget.py'
+      - '.agents/policy/**'
+      - '.agents/context/**'
+      - 'docs/misc/**'
+      - '**/AGENTS.md'
+      - '**/CLAUDE.md'
+
+permissions:
+  contents: read
+
+jobs:
+  context-budget:
+    name: Context byte budgets + routing headers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Enforce context byte budgets + routing headers
+        # ubuntu-latest ships python3. --all: the workflow's own path filter
+        # already scopes when this runs; the check itself is sub-second.
+        run: python3 scripts/check_context_budget.py --all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,13 +262,6 @@ jobs:
           git fetch --no-tags --depth=1 origin ci-metadata:refs/remotes/origin/ci-metadata
           python3 scripts/check_version_literals.py --verify-matrix
 
-      - name: Context byte budgets + routing headers
-        # The AGENTS.md bootstrap, .agents/policy|context files, dir stubs, and
-        # hook capsules each carry a byte budget (map #1383 anti-monolith rules),
-        # and every bootstrap routing-table target must keep its Scope/Load-when
-        # header. Full check — the budgets gate re-accretion of the hot context.
-        run: python3 scripts/check_context_budget.py --all
-
   shell-tests:
     name: shellspec (POSIX sh)
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,6 +262,13 @@ jobs:
           git fetch --no-tags --depth=1 origin ci-metadata:refs/remotes/origin/ci-metadata
           python3 scripts/check_version_literals.py --verify-matrix
 
+      - name: Context byte budgets + routing headers
+        # The AGENTS.md bootstrap, .agents/policy|context files, dir stubs, and
+        # hook capsules each carry a byte budget (map #1383 anti-monolith rules),
+        # and every bootstrap routing-table target must keep its Scope/Load-when
+        # header. Full check — the budgets gate re-accretion of the hot context.
+        run: python3 scripts/check_context_budget.py --all
+
   shell-tests:
     name: shellspec (POSIX sh)
     runs-on: ubuntu-latest

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -6,14 +6,13 @@ hold the routed policy/context files; hook capsules ride `.claude/settings.json`
 Every surface has a byte budget so the hot context cannot silently re-accrete
 (taxonomy #1386 anti-monolith rules), and every file the bootstrap's routing
 table references must carry a `Scope:` + `Load-when:` header so it stays
-routable. Budgets (calibrated on the measured Stage 1/2 tree, not the matrix
-estimates):
+routable. Budgets (calibrated on the measured tree, not the matrix estimates):
 
 - `AGENTS.md` (bootstrap)                          10,240 B
 - `CLAUDE.md` (thin adapter + tool-managed blocks)  8,192 B
 - `.agents/policy/*.md` / `.agents/context/*.md`   12,288 B default; grandfathered
   ratchet caps for the pre-taxonomy files (landing 26,000, agent-roles 19,000,
-  delegation 18,000 — may shrink, never grow)
+  delegation 18,000 — frozen constants: lower them as the files shrink)
 - nested `CLAUDE.md`/`AGENTS.md` dir stubs            400 B
 - each hook-capsule `additionalContext` payload     1,800 B
 
@@ -23,9 +22,9 @@ touches a context surface (AGENTS.md, CLAUDE.md, .agents/policy/,
 checker); otherwise it reports the skip and exits 0. --all checks unconditionally.
 
 Usage:
-    check_context_budget.py --staged        # pre-commit: staged diff decides
-    check_context_budget.py --diff <base>   # CI PR gate: base...HEAD decides
-    check_context_budget.py --all           # unconditional full check
+    check_context_budget.py --staged        # pre-commit: staged diff decides, index content checked
+    check_context_budget.py --diff <base>   # local/ad-hoc: base...HEAD decides
+    check_context_budget.py --all           # CI gate (context-budget.yml) + unconditional full check
     [--root PATH]                           # repo root (default: script's repo)
 
 Exit status: 0 = clean or skipped, 1 = violations (printed), 2 = usage/git error.
@@ -38,6 +37,7 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 BOOTSTRAP_BUDGET = 10_240
@@ -72,12 +72,14 @@ def budget_for(rel: str) -> int | None:
     """Byte budget for a tracked file, or None when unbudgeted."""
     if rel in FILE_BUDGETS:
         return FILE_BUDGETS[rel]
-    if rel.startswith((".agents/policy/", ".agents/context/")) and rel.endswith(".md"):
-        return POLICY_BUDGET
     base = rel.rsplit("/", 1)[-1]
     if "/" in rel and base in ("CLAUDE.md", "AGENTS.md") and not rel.startswith("plugins/"):
         # plugins/ is vendored — its instruction files are not our dir stubs.
+        # Checked before the policy/context prefix: a nested AGENTS.md/CLAUDE.md
+        # under .agents/ is a dir stub, not a routed policy file.
         return STUB_BUDGET
+    if rel.startswith((".agents/policy/", ".agents/context/")) and rel.endswith(".md"):
+        return POLICY_BUDGET
     return None
 
 
@@ -87,7 +89,13 @@ def check_sizes(root: Path, tracked: list[str]) -> list[str]:
         budget = budget_for(rel)
         if budget is None:
             continue
-        size = (root / rel).stat().st_size
+        try:
+            size = (root / rel).stat().st_size
+        except OSError as exc:
+            # Tracked but unreadable (e.g. deleted from the worktree with the
+            # deletion unstaged) — fail closed with a violation, not a traceback.
+            violations.append(f"{rel}: unreadable ({exc.strerror or exc})")
+            continue
         if size > budget:
             violations.append(f"{rel}: {size} bytes > budget {budget}")
     return violations
@@ -137,6 +145,10 @@ def check_headers(root: Path) -> list[str]:
     if not bootstrap.is_file():
         return ["AGENTS.md: bootstrap missing — nothing to route from"]
     tokens, _ = routing_targets(bootstrap.read_text(encoding="utf-8"))
+    if not tokens:
+        # A renamed/removed "## Routing table" heading would otherwise disarm
+        # the whole header gate silently (zero targets = vacuous pass).
+        return ["AGENTS.md: no routing-table targets extracted — heading renamed or table removed?"]
     violations = []
     for token in dict.fromkeys(tokens):
         rel = resolve_target(root, token)
@@ -152,7 +164,12 @@ def extract_capsules(settings_text: str) -> tuple[list[tuple[str, int]], list[st
     """(event, payload-bytes) per hook capsule; second element = extraction errors."""
     capsules: list[tuple[str, int]] = []
     errors: list[str] = []
-    settings = json.loads(settings_text)
+    try:
+        settings = json.loads(settings_text)
+    except ValueError:
+        # Fail closed as a violation, not a traceback: a malformed settings file
+        # means the capsule budgets cannot be verified.
+        return [], [f"{SETTINGS}: not parseable JSON — capsule budgets unverifiable"]
     for event, entries in settings.get("hooks", {}).items():
         for entry in entries:
             for hook in entry.get("hooks", []):
@@ -190,14 +207,16 @@ def _git(root: Path, *args: str) -> str:
     return proc.stdout
 
 
+# The CI workflow (.github/workflows/context-budget.yml) path-filters on these same
+# surfaces; pinned by tests/test_context_budget.py::test_ci_workflow_paths_match_checker_triggers.
+_TRIGGER_FILES = ("AGENTS.md", "CLAUDE.md", SETTINGS, "scripts/check_context_budget.py")
+_TRIGGER_DIRS = (".agents/policy/", ".agents/context/", "docs/misc/")
+
+
 def touches_context_surface(changed: list[str]) -> bool:
     for rel in changed:
         base = rel.rsplit("/", 1)[-1]
-        if (
-            rel in ("AGENTS.md", "CLAUDE.md", SETTINGS, "scripts/check_context_budget.py")
-            or rel.startswith((".agents/policy/", ".agents/context/"))
-            or base in ("CLAUDE.md", "AGENTS.md")
-        ):
+        if rel in _TRIGGER_FILES or rel.startswith(_TRIGGER_DIRS) or base in ("CLAUDE.md", "AGENTS.md"):
             return True
     return False
 
@@ -216,16 +235,25 @@ def main(argv: list[str] | None = None) -> int:
             diff_args = (
                 ["diff", "--cached", "--name-only"] if args.staged else ["diff", "--name-only", f"{args.diff}...HEAD"]
             )
-            changed = _git(root, *diff_args).split()
-            if not touches_context_surface(changed):
+            changed = _git(root, "-c", "core.quotePath=off", *diff_args).split("\n")
+            if not touches_context_surface([c for c in changed if c]):
                 print("context-budget: no context surface in the diff — skipped")
                 return 0
-        tracked = _git(root, "ls-files").split("\n")
+        # quotePath=off: a non-ASCII filename would otherwise come back
+        # C-quoted ("…") and silently match no budget.
+        tracked = _git(root, "-c", "core.quotePath=off", "ls-files").split("\n")
         tracked = [t for t in tracked if t]
+        if args.staged:
+            # Validate the INDEX snapshot, not the working tree: staged and
+            # worktree content can diverge, and the commit ships the index.
+            with tempfile.TemporaryDirectory() as staged_root:
+                _git(root, "checkout-index", "--all", f"--prefix={staged_root}/")
+                violations = run_checks(Path(staged_root), tracked)
+        else:
+            violations = run_checks(root, tracked)
     except (subprocess.CalledProcessError, OSError) as exc:
         print(f"context-budget: git failed: {exc}", file=sys.stderr)
         return 2
-    violations = run_checks(root, tracked)
     for violation in violations:
         print(violation)
     return 1 if violations else 0

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -166,24 +166,26 @@ def extract_capsules(settings_text: str) -> tuple[list[tuple[str, int]], list[st
     errors: list[str] = []
     try:
         settings = json.loads(settings_text)
-    except ValueError:
-        # Fail closed as a violation, not a traceback: a malformed settings file
-        # means the capsule budgets cannot be verified.
-        return [], [f"{SETTINGS}: not parseable JSON — capsule budgets unverifiable"]
-    for event, entries in settings.get("hooks", {}).items():
-        for entry in entries:
-            for hook in entry.get("hooks", []):
-                command = hook.get("command", "")
-                if "additionalContext" not in command:
-                    continue
-                start, end = command.find("'"), command.rfind("'")
-                try:
-                    payload = json.loads(command[start + 1 : end])
-                    text = payload["hookSpecificOutput"]["additionalContext"]
-                except (ValueError, KeyError, TypeError):
-                    errors.append(f"{SETTINGS}: {event} capsule payload is not extractable JSON")
-                    continue
-                capsules.append((event, len(text.encode("utf-8"))))
+        # The whole traversal sits in the try: a parse error OR a valid-JSON
+        # wrong-shape file (hooks as a list, entries as strings, …) fails closed
+        # as a violation, never a traceback that would also swallow the other
+        # checks' already-found violations.
+        for event, entries in settings.get("hooks", {}).items():
+            for entry in entries:
+                for hook in entry.get("hooks", []):
+                    command = hook.get("command", "")
+                    if "additionalContext" not in command:
+                        continue
+                    start, end = command.find("'"), command.rfind("'")
+                    try:
+                        payload = json.loads(command[start + 1 : end])
+                        text = payload["hookSpecificOutput"]["additionalContext"]
+                    except (ValueError, KeyError, TypeError):
+                        errors.append(f"{SETTINGS}: {event} capsule payload is not extractable JSON")
+                        continue
+                    capsules.append((event, len(text.encode("utf-8"))))
+    except (ValueError, AttributeError, TypeError):
+        return [], [f"{SETTINGS}: not a parseable hooks structure — capsule budgets unverifiable"]
     return capsules, errors
 
 

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Enforce the context-taxonomy byte budgets and routing headers (map #1383, #1437).
+
+AGENTS.md is the canonical agent bootstrap; `.agents/policy/` + `.agents/context/`
+hold the routed policy/context files; hook capsules ride `.claude/settings.json`.
+Every surface has a byte budget so the hot context cannot silently re-accrete
+(taxonomy #1386 anti-monolith rules), and every file the bootstrap's routing
+table references must carry a `Scope:` + `Load-when:` header so it stays
+routable. Budgets (calibrated on the measured Stage 1/2 tree, not the matrix
+estimates):
+
+- `AGENTS.md` (bootstrap)                          10,240 B
+- `CLAUDE.md` (thin adapter + tool-managed blocks)  8,192 B
+- `.agents/policy/*.md` / `.agents/context/*.md`   12,288 B default; grandfathered
+  ratchet caps for the pre-taxonomy files (landing 26,000, agent-roles 19,000,
+  delegation 18,000 — may shrink, never grow)
+- nested `CLAUDE.md`/`AGENTS.md` dir stubs            400 B
+- each hook-capsule `additionalContext` payload     1,800 B
+
+CONDITIONAL: in --staged / --diff mode the checks run IF AND ONLY IF the change
+touches a context surface (AGENTS.md, CLAUDE.md, .agents/policy/,
+.agents/context/, .claude/settings.json, any nested CLAUDE.md/AGENTS.md, or this
+checker); otherwise it reports the skip and exits 0. --all checks unconditionally.
+
+Usage:
+    check_context_budget.py --staged        # pre-commit: staged diff decides
+    check_context_budget.py --diff <base>   # CI PR gate: base...HEAD decides
+    check_context_budget.py --all           # unconditional full check
+    [--root PATH]                           # repo root (default: script's repo)
+
+Exit status: 0 = clean or skipped, 1 = violations (printed), 2 = usage/git error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+BOOTSTRAP_BUDGET = 10_240
+ADAPTER_BUDGET = 8_192
+POLICY_BUDGET = 12_288
+STUB_BUDGET = 400
+CAPSULE_BUDGET = 1_800
+
+# Grandfathered ratchet caps for files predating the taxonomy budgets: they may
+# shrink toward POLICY_BUDGET, never grow past their cap.
+FILE_BUDGETS = {
+    "AGENTS.md": BOOTSTRAP_BUDGET,
+    "CLAUDE.md": ADAPTER_BUDGET,
+    ".agents/policy/landing.md": 26_000,
+    ".agents/policy/agent-roles.md": 19_000,
+    ".agents/policy/delegation.md": 18_000,
+}
+
+SETTINGS = ".claude/settings.json"
+
+# Accepts both header shapes in the first HEADER_WINDOW lines: the plain
+# "Scope: ... Load when: ..." prose and the bulleted "- **Scope:** / - **Load-when:**".
+HEADER_WINDOW = 12
+_SCOPE_RE = re.compile(r"\*\*Scope:?\*\*|^Scope:|\bScope: ", re.MULTILINE)
+_LOADWHEN_RE = re.compile(r"Load[- ]when:", re.IGNORECASE)
+
+_MD_TOKEN_RE = re.compile(r"`([^`\s]+\.md)`")
+_RESOLVE_DIRS = (".agents/policy", ".agents/context", "docs/misc")
+
+
+def budget_for(rel: str) -> int | None:
+    """Byte budget for a tracked file, or None when unbudgeted."""
+    if rel in FILE_BUDGETS:
+        return FILE_BUDGETS[rel]
+    if rel.startswith((".agents/policy/", ".agents/context/")) and rel.endswith(".md"):
+        return POLICY_BUDGET
+    base = rel.rsplit("/", 1)[-1]
+    if "/" in rel and base in ("CLAUDE.md", "AGENTS.md") and not rel.startswith("plugins/"):
+        # plugins/ is vendored — its instruction files are not our dir stubs.
+        return STUB_BUDGET
+    return None
+
+
+def check_sizes(root: Path, tracked: list[str]) -> list[str]:
+    violations = []
+    for rel in tracked:
+        budget = budget_for(rel)
+        if budget is None:
+            continue
+        size = (root / rel).stat().st_size
+        if size > budget:
+            violations.append(f"{rel}: {size} bytes > budget {budget}")
+    return violations
+
+
+def routing_targets(bootstrap_text: str) -> tuple[list[str], list[str]]:
+    """Backticked *.md targets of the bootstrap routing table.
+
+    Returns (raw_tokens, non_literal_tokens_skipped). Tokens containing template
+    characters (<, |) are skipped — they name a file family, not a file.
+    """
+    lines = bootstrap_text.split("\n")
+    in_table = False
+    tokens: list[str] = []
+    skipped: list[str] = []
+    for line in lines:
+        if line.startswith("## "):
+            in_table = "Routing table" in line
+            continue
+        if in_table and line.startswith("|"):
+            for tok in _MD_TOKEN_RE.findall(line):
+                if "<" in tok or "|" in tok:
+                    skipped.append(tok)
+                else:
+                    tokens.append(tok)
+    return tokens, skipped
+
+
+def resolve_target(root: Path, token: str) -> str | None:
+    """Resolve a routing token to a repo-relative path, or None."""
+    if "/" in token:
+        return token if (root / token).is_file() else None
+    for d in _RESOLVE_DIRS:
+        rel = f"{d}/{token}"
+        if (root / rel).is_file():
+            return rel
+    return None
+
+
+def has_context_header(text: str) -> bool:
+    head = "\n".join(text.split("\n")[:HEADER_WINDOW])
+    return bool(_SCOPE_RE.search(head)) and bool(_LOADWHEN_RE.search(head))
+
+
+def check_headers(root: Path) -> list[str]:
+    bootstrap = root / "AGENTS.md"
+    if not bootstrap.is_file():
+        return ["AGENTS.md: bootstrap missing — nothing to route from"]
+    tokens, _ = routing_targets(bootstrap.read_text(encoding="utf-8"))
+    violations = []
+    for token in dict.fromkeys(tokens):
+        rel = resolve_target(root, token)
+        if rel is None:
+            violations.append(f"AGENTS.md: routing target `{token}` does not resolve to a file")
+            continue
+        if not has_context_header((root / rel).read_text(encoding="utf-8")):
+            violations.append(f"{rel}: routed file lacks a Scope: + Load-when: header (first {HEADER_WINDOW} lines)")
+    return violations
+
+
+def extract_capsules(settings_text: str) -> tuple[list[tuple[str, int]], list[str]]:
+    """(event, payload-bytes) per hook capsule; second element = extraction errors."""
+    capsules: list[tuple[str, int]] = []
+    errors: list[str] = []
+    settings = json.loads(settings_text)
+    for event, entries in settings.get("hooks", {}).items():
+        for entry in entries:
+            for hook in entry.get("hooks", []):
+                command = hook.get("command", "")
+                if "additionalContext" not in command:
+                    continue
+                start, end = command.find("'"), command.rfind("'")
+                try:
+                    payload = json.loads(command[start + 1 : end])
+                    text = payload["hookSpecificOutput"]["additionalContext"]
+                except (ValueError, KeyError, TypeError):
+                    errors.append(f"{SETTINGS}: {event} capsule payload is not extractable JSON")
+                    continue
+                capsules.append((event, len(text.encode("utf-8"))))
+    return capsules, errors
+
+
+def check_capsules(root: Path) -> list[str]:
+    settings = root / SETTINGS
+    if not settings.is_file():
+        return []
+    capsules, violations = extract_capsules(settings.read_text(encoding="utf-8"))
+    for event, size in capsules:
+        if size > CAPSULE_BUDGET:
+            violations.append(f"{SETTINGS}: {event} capsule {size} bytes > budget {CAPSULE_BUDGET}")
+    return violations
+
+
+def run_checks(root: Path, tracked: list[str]) -> list[str]:
+    return check_sizes(root, tracked) + check_headers(root) + check_capsules(root)
+
+
+def _git(root: Path, *args: str) -> str:
+    proc = subprocess.run(["git", "-C", str(root), *args], capture_output=True, text=True, check=True)
+    return proc.stdout
+
+
+def touches_context_surface(changed: list[str]) -> bool:
+    for rel in changed:
+        base = rel.rsplit("/", 1)[-1]
+        if (
+            rel in ("AGENTS.md", "CLAUDE.md", SETTINGS, "scripts/check_context_budget.py")
+            or rel.startswith((".agents/policy/", ".agents/context/"))
+            or base in ("CLAUDE.md", "AGENTS.md")
+        ):
+            return True
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--staged", action="store_true", help="scope by the staged diff")
+    mode.add_argument("--diff", metavar="BASE", help="scope by BASE...HEAD")
+    mode.add_argument("--all", action="store_true", help="check unconditionally")
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parent.parent)
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+    try:
+        if not args.all:
+            diff_args = (
+                ["diff", "--cached", "--name-only"] if args.staged else ["diff", "--name-only", f"{args.diff}...HEAD"]
+            )
+            changed = _git(root, *diff_args).split()
+            if not touches_context_surface(changed):
+                print("context-budget: no context surface in the diff — skipped")
+                return 0
+        tracked = _git(root, "ls-files").split("\n")
+        tracked = [t for t in tracked if t]
+    except (subprocess.CalledProcessError, OSError) as exc:
+        print(f"context-budget: git failed: {exc}", file=sys.stderr)
+        return 2
+    violations = run_checks(root, tracked)
+    for violation in violations:
+        print(violation)
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -241,7 +241,10 @@ def _run_cli(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
 
 def test_cli_staged_skips_when_no_context_surface_staged(tmp_path: Path) -> None:
     root = _scratch_repo(tmp_path)
-    subprocess.run(["git", "-C", root, "commit", "-qm", "base"], check=True)
+    subprocess.run(
+        ["git", "-C", root, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "base"],
+        check=True,
+    )
     _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
     _write(root, "src/thing.inc", "<?php\n")
     subprocess.run(["git", "-C", root, "add", "src/thing.inc"], check=True)
@@ -252,7 +255,10 @@ def test_cli_staged_skips_when_no_context_surface_staged(tmp_path: Path) -> None
 
 def test_cli_staged_runs_and_fails_on_staged_over_budget_policy(tmp_path: Path) -> None:
     root = _scratch_repo(tmp_path)
-    subprocess.run(["git", "-C", root, "commit", "-qm", "base"], check=True)
+    subprocess.run(
+        ["git", "-C", root, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "base"],
+        check=True,
+    )
     _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
     subprocess.run(["git", "-C", root, "add", "-A"], check=True)
     proc = _run_cli(root, "--staged")

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -1,8 +1,8 @@
 """Tests for scripts/check_context_budget.py.
 
-Every violation class is paired with its nearest clean sibling so a green run
-proves the checker discriminates (fires on the violating shape, stays quiet on
-the compliant one): budgets per surface class, boundary at the exact budget,
+Every violation class is paired with its nearest clean sibling (the checker
+must fire on the violating shape and stay quiet on the compliant one):
+budgets per surface class, boundary at the exact budget,
 routing-table extraction/resolution, both header shapes, capsule extraction,
 and the conditional --staged/--diff trigger through the CLI against scratch
 git repos. One test pins the live repository tree itself within budget.
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -82,6 +83,10 @@ def _tracked(root: Path) -> list[str]:
         (".agents/policy/delegation.md", 18_000),
         ("tests/smoke/CLAUDE.md", 400),
         ("src/usr/local/AGENTS.md", 400),
+        # Nested stubs under .agents/ are dir stubs, not routed policy files —
+        # the stub branch must win over the policy/context prefix.
+        (".agents/context/sub/AGENTS.md", 400),
+        (".agents/policy/sub/CLAUDE.md", 400),
         ("plugins/ponytail/AGENTS.md", None),
         ("src/usr/local/pkg/pfblockerng/pfblockerng.inc", None),
         ("docs/misc/architecture-notes.md", None),
@@ -105,6 +110,12 @@ def test_nested_stub_over_budget_fires_root_files_use_own_budget(tmp_path: Path)
     _write(root, "AGENTS.md", "x" * 401)  # root bootstrap: 401 B is far under 10,240
     violations = ccb.check_sizes(root, ["www/CLAUDE.md", "AGENTS.md"])
     assert violations == ["www/CLAUDE.md: 401 bytes > budget 400"]
+
+
+def test_size_of_missing_tracked_file_fails_closed(tmp_path: Path) -> None:
+    # Tracked-but-deleted (deletion unstaged) must yield a violation, not a traceback.
+    violations = ccb.check_sizes(tmp_path, [".agents/policy/gone.md"])
+    assert len(violations) == 1 and violations[0].startswith(".agents/policy/gone.md: unreadable")
 
 
 # --- routing-table extraction and resolution -----------------------------------
@@ -139,6 +150,16 @@ def test_check_headers_flags_missing_header(tmp_path: Path) -> None:
     _write(root, ".agents/context/beta.md", "# Beta\n\nNo routing header here.\n")
     violations = ccb.check_headers(root)
     assert violations == [".agents/context/beta.md: routed file lacks a Scope: + Load-when: header (first 12 lines)"]
+
+
+def test_check_headers_flags_renamed_routing_table_heading(tmp_path: Path) -> None:
+    # Zero extracted targets must be a violation, not a vacuous pass — otherwise
+    # renaming the "## Routing table" heading disarms the whole header gate.
+    root = _scratch_repo(tmp_path)
+    _write(root, "AGENTS.md", _BOOTSTRAP.replace("## Routing table", "## Where to read"))
+    _write(root, ".agents/context/beta.md", "# Beta\n\nNo routing header here.\n")
+    violations = ccb.check_headers(root)
+    assert violations == ["AGENTS.md: no routing-table targets extracted — heading renamed or table removed?"]
 
 
 # --- both header shapes accepted; window enforced ------------------------------
@@ -204,6 +225,12 @@ def test_extract_capsules_reports_unextractable_payload() -> None:
     assert errors == [".claude/settings.json: SessionStart capsule payload is not extractable JSON"]
 
 
+def test_extract_capsules_malformed_settings_fails_closed() -> None:
+    capsules, errors = ccb.extract_capsules("{not json")
+    assert capsules == []
+    assert errors == [".claude/settings.json: not parseable JSON — capsule budgets unverifiable"]
+
+
 # --- conditional trigger -------------------------------------------------------
 
 
@@ -216,6 +243,7 @@ def test_extract_capsules_reports_unextractable_payload() -> None:
         "scripts/check_context_budget.py",
         ".agents/policy/alpha.md",
         ".agents/context/beta.md",
+        "docs/misc/architecture-notes.md",
         "tests/smoke/CLAUDE.md",
     ],
 )
@@ -224,7 +252,7 @@ def test_touches_context_surface_true(rel: str) -> None:
 
 
 def test_touches_context_surface_false_on_unrelated() -> None:
-    assert not ccb.touches_context_surface(["src/usr/local/www/x.php", "docs/misc/notes.md"])
+    assert not ccb.touches_context_surface(["src/usr/local/www/x.php", "docs/history/incidents.md"])
 
 
 # --- CLI against scratch repos -------------------------------------------------
@@ -266,6 +294,61 @@ def test_cli_staged_runs_and_fails_on_staged_over_budget_policy(tmp_path: Path) 
     assert ".agents/policy/alpha.md" in proc.stdout and "> budget 12288" in proc.stdout
 
 
+def test_cli_staged_checks_index_content_not_working_tree(tmp_path: Path) -> None:
+    # Staged over-budget + worktree fixed back under budget: the commit would
+    # still ship the violation, so --staged must fail (index is the snapshot).
+    root = _scratch_repo(tmp_path)
+    subprocess.run(
+        ["git", "-C", root, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "base"],
+        check=True,
+    )
+    _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+    _write(root, ".agents/policy/alpha.md", f"# Alpha\n\n{_HEADER}")
+    proc = _run_cli(root, "--staged")
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert ".agents/policy/alpha.md" in proc.stdout and "> budget 12288" in proc.stdout
+
+
+def test_cli_staged_ignores_unstaged_working_tree_violation(tmp_path: Path) -> None:
+    # Staged content clean + worktree bloated: the commit ships the clean index,
+    # so --staged must pass instead of false-failing on the dirty worktree.
+    root = _scratch_repo(tmp_path)
+    subprocess.run(
+        ["git", "-C", root, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "base"],
+        check=True,
+    )
+    _write(root, ".agents/policy/alpha.md", f"# Alpha (tweaked)\n\n{_HEADER}")
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+    _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
+    proc = _run_cli(root, "--staged")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_cli_diff_fires_on_over_budget_commit_vs_base(tmp_path: Path) -> None:
+    root = _scratch_repo(tmp_path)
+    git = ["git", "-C", str(root), "-c", "user.name=t", "-c", "user.email=t@example.com"]
+    subprocess.run([*git, "commit", "-qm", "base"], check=True)
+    _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+    subprocess.run([*git, "commit", "-qm", "bloat"], check=True)
+    proc = _run_cli(root, "--diff", "HEAD~1")
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert ".agents/policy/alpha.md" in proc.stdout and "> budget 12288" in proc.stdout
+
+
+def test_cli_all_flags_non_ascii_named_policy_file(tmp_path: Path) -> None:
+    # Under default core.quotePath, ls-files C-quotes non-ASCII names and the
+    # quoted string would match no budget — the checker must still see the file.
+    root = _scratch_repo(tmp_path)
+    _write(root, ".agents/policy/pölicy.md", "# P\n\n" + _HEADER + "x" * 20_000)
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+    proc = _run_cli(root, "--all")
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    # NFC/NFD filename normalization differs per OS — match the ASCII tail only.
+    assert "licy.md" in proc.stdout and "> budget 12288" in proc.stdout
+
+
 def test_cli_all_clean_scratch_repo_exits_zero(tmp_path: Path) -> None:
     root = _scratch_repo(tmp_path)
     proc = _run_cli(root, "--all")
@@ -275,6 +358,26 @@ def test_cli_all_clean_scratch_repo_exits_zero(tmp_path: Path) -> None:
 def test_cli_all_missing_git_exits_two(tmp_path: Path) -> None:
     proc = _run_cli(tmp_path / "not-a-repo", "--all")
     assert proc.returncode == 2
+
+
+# --- CI wiring ------------------------------------------------------------------
+
+
+def test_ci_workflow_paths_match_checker_triggers() -> None:
+    # The gate rides its own path-filtered workflow (test.yml's global
+    # `paths-ignore: '**/*.md'` would skip an md-only change — the exact class
+    # this gate polices). Both trigger blocks must mirror the checker's surfaces.
+    text = (_REPO_ROOT / ".github/workflows/context-budget.yml").read_text(encoding="utf-8")
+    listed = re.findall(r"^\s+- '([^']+)'\s*$", text, re.MULTILINE)
+    expected = (
+        set(ccb._TRIGGER_FILES)
+        | {f"{d}**" for d in ccb._TRIGGER_DIRS}
+        # the basename trigger (nested dir stubs anywhere) as workflow globs:
+        | {"**/AGENTS.md", "**/CLAUDE.md"}
+    )
+    assert set(listed) == expected, f"workflow paths {sorted(set(listed))} != checker triggers {sorted(expected)}"
+    assert listed.count("AGENTS.md") == 2, "push AND pull_request must each carry the full paths list"
+    assert "push:" in text, "md-only pushes straight to devel are the dominant re-accretion vector"
 
 
 # --- the live tree stays within its own budgets --------------------------------

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -225,10 +225,29 @@ def test_extract_capsules_reports_unextractable_payload() -> None:
     assert errors == [".claude/settings.json: SessionStart capsule payload is not extractable JSON"]
 
 
-def test_extract_capsules_malformed_settings_fails_closed() -> None:
-    capsules, errors = ccb.extract_capsules("{not json")
+@pytest.mark.parametrize(
+    "settings_text",
+    [
+        "{not json",  # parse error
+        '{"hooks": ["not", "a", "dict"]}',  # valid JSON, hooks is a list
+        '["top-level list"]',  # valid JSON, wrong top-level shape
+        '{"hooks": {"SessionStart": "not-entries"}}',  # entries not a list of dicts
+    ],
+)
+def test_extract_capsules_malformed_settings_fails_closed(settings_text: str) -> None:
+    capsules, errors = ccb.extract_capsules(settings_text)
     assert capsules == []
-    assert errors == [".claude/settings.json: not parseable JSON — capsule budgets unverifiable"]
+    assert errors == [".claude/settings.json: not a parseable hooks structure — capsule budgets unverifiable"]
+
+
+def test_run_checks_reports_size_violations_despite_malformed_settings(tmp_path: Path) -> None:
+    # A capsule-check failure must not swallow violations the other checks found.
+    root = _scratch_repo(tmp_path)
+    _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
+    _write(root, ".claude/settings.json", '{"hooks": ["not", "a", "dict"]}')
+    violations = ccb.run_checks(root, [".agents/policy/alpha.md", ".claude/settings.json"])
+    assert any("> budget 12288" in v for v in violations)
+    assert any("not a parseable hooks structure" in v for v in violations)
 
 
 # --- conditional trigger -------------------------------------------------------
@@ -368,16 +387,22 @@ def test_ci_workflow_paths_match_checker_triggers() -> None:
     # `paths-ignore: '**/*.md'` would skip an md-only change — the exact class
     # this gate polices). Both trigger blocks must mirror the checker's surfaces.
     text = (_REPO_ROOT / ".github/workflows/context-budget.yml").read_text(encoding="utf-8")
-    listed = re.findall(r"^\s+- '([^']+)'\s*$", text, re.MULTILINE)
     expected = (
         set(ccb._TRIGGER_FILES)
         | {f"{d}**" for d in ccb._TRIGGER_DIRS}
         # the basename trigger (nested dir stubs anywhere) as workflow globs:
         | {"**/AGENTS.md", "**/CLAUDE.md"}
     )
-    assert set(listed) == expected, f"workflow paths {sorted(set(listed))} != checker triggers {sorted(expected)}"
-    assert listed.count("AGENTS.md") == 2, "push AND pull_request must each carry the full paths list"
+    # Compare each trigger block INDEPENDENTLY: the two hand-duplicated paths
+    # lists drift exactly one-block-at-a-time, and a whole-file set comparison
+    # cannot see an entry dropped from only one of them.
     assert "push:" in text, "md-only pushes straight to devel are the dominant re-accretion vector"
+    push_block, _, tail = text.partition("pull_request:")
+    pr_block = tail.partition("permissions:")[0]
+    for name, block in (("push", push_block), ("pull_request", pr_block)):
+        listed = re.findall(r"^\s+- '([^']+)'\s*$", block, re.MULTILINE)
+        assert len(listed) == len(expected), f"{name} paths list has duplicates or gaps: {sorted(listed)}"
+        assert set(listed) == expected, f"{name} paths {sorted(listed)} != checker triggers {sorted(expected)}"
 
 
 # --- the live tree stays within its own budgets --------------------------------

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -1,0 +1,279 @@
+"""Tests for scripts/check_context_budget.py.
+
+Every violation class is paired with its nearest clean sibling so a green run
+proves the checker discriminates (fires on the violating shape, stays quiet on
+the compliant one): budgets per surface class, boundary at the exact budget,
+routing-table extraction/resolution, both header shapes, capsule extraction,
+and the conditional --staged/--diff trigger through the CLI against scratch
+git repos. One test pins the live repository tree itself within budget.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_context_budget.py"
+_spec = importlib.util.spec_from_file_location("check_context_budget", _TOOL)
+assert _spec is not None and _spec.loader is not None
+ccb = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = ccb
+_spec.loader.exec_module(ccb)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_HEADER = "Scope: test file. Load when: testing.\n"
+
+_BOOTSTRAP = """# Bootstrap
+
+## Routing table — read on trigger, not up front
+
+| Task touches | Read first |
+| ------------ | ---------- |
+| policy work | `.agents/policy/alpha.md` |
+| context work | `beta.md` |
+| languages | `lang-<php\\|python\\|shell>.md` per touched language |
+
+## After
+
+Prose mentioning `outside.md` that is not a routing row.
+"""
+
+
+def _write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _scratch_repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    _write(root, "AGENTS.md", _BOOTSTRAP)
+    _write(root, ".agents/policy/alpha.md", f"# Alpha\n\n{_HEADER}")
+    _write(root, ".agents/context/beta.md", f"# Beta\n\n{_HEADER}")
+    subprocess.run(["git", "init", "-q", root], check=True)
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+    return root
+
+
+def _tracked(root: Path) -> list[str]:
+    out = subprocess.run(["git", "-C", root, "ls-files"], capture_output=True, text=True, check=True).stdout
+    return [line for line in out.split("\n") if line]
+
+
+# --- budget_for: one assertion per surface class -------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rel", "budget"),
+    [
+        ("AGENTS.md", 10_240),
+        ("CLAUDE.md", 8_192),
+        (".agents/policy/new-policy.md", 12_288),
+        (".agents/context/new-context.md", 12_288),
+        (".agents/policy/landing.md", 26_000),
+        (".agents/policy/agent-roles.md", 19_000),
+        (".agents/policy/delegation.md", 18_000),
+        ("tests/smoke/CLAUDE.md", 400),
+        ("src/usr/local/AGENTS.md", 400),
+        ("plugins/ponytail/AGENTS.md", None),
+        ("src/usr/local/pkg/pfblockerng/pfblockerng.inc", None),
+        ("docs/misc/architecture-notes.md", None),
+    ],
+)
+def test_budget_for_surface_classes(rel: str, budget: int | None) -> None:
+    assert ccb.budget_for(rel) == budget
+
+
+def test_size_over_budget_fires_and_at_budget_passes(tmp_path: Path) -> None:
+    root = tmp_path
+    _write(root, ".agents/policy/fat.md", "x" * 12_289)
+    _write(root, ".agents/policy/exact.md", "x" * 12_288)
+    violations = ccb.check_sizes(root, [".agents/policy/fat.md", ".agents/policy/exact.md"])
+    assert violations == [".agents/policy/fat.md: 12289 bytes > budget 12288"]
+
+
+def test_nested_stub_over_budget_fires_root_files_use_own_budget(tmp_path: Path) -> None:
+    root = tmp_path
+    _write(root, "www/CLAUDE.md", "x" * 401)
+    _write(root, "AGENTS.md", "x" * 401)  # root bootstrap: 401 B is far under 10,240
+    violations = ccb.check_sizes(root, ["www/CLAUDE.md", "AGENTS.md"])
+    assert violations == ["www/CLAUDE.md: 401 bytes > budget 400"]
+
+
+# --- routing-table extraction and resolution -----------------------------------
+
+
+def test_routing_targets_extracts_table_rows_only() -> None:
+    tokens, skipped = ccb.routing_targets(_BOOTSTRAP)
+    assert tokens == [".agents/policy/alpha.md", "beta.md"]
+    assert skipped == ["lang-<php\\|python\\|shell>.md"]
+
+
+def test_resolve_target_bare_token_searches_policy_context_docs(tmp_path: Path) -> None:
+    root = _scratch_repo(tmp_path)
+    assert ccb.resolve_target(root, "beta.md") == ".agents/context/beta.md"
+    assert ccb.resolve_target(root, ".agents/policy/alpha.md") == ".agents/policy/alpha.md"
+    assert ccb.resolve_target(root, "missing.md") is None
+
+
+def test_check_headers_clean_tree_passes(tmp_path: Path) -> None:
+    root = _scratch_repo(tmp_path)
+    assert ccb.check_headers(root) == []
+
+
+def test_check_headers_flags_unresolvable_target(tmp_path: Path) -> None:
+    root = _scratch_repo(tmp_path)
+    (root / ".agents/context/beta.md").unlink()
+    assert ccb.check_headers(root) == ["AGENTS.md: routing target `beta.md` does not resolve to a file"]
+
+
+def test_check_headers_flags_missing_header(tmp_path: Path) -> None:
+    root = _scratch_repo(tmp_path)
+    _write(root, ".agents/context/beta.md", "# Beta\n\nNo routing header here.\n")
+    violations = ccb.check_headers(root)
+    assert violations == [".agents/context/beta.md: routed file lacks a Scope: + Load-when: header (first 12 lines)"]
+
+
+# --- both header shapes accepted; window enforced ------------------------------
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Scope: things. Load when: touching things.",
+        "- **Scope:** things over multiple words.\n- **Load-when:** touching things.",
+    ],
+)
+def test_has_context_header_accepts_both_house_shapes(header: str) -> None:
+    assert ccb.has_context_header(f"# Title\n\n{header}\n")
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "# Title\n\nLoad when: no scope line.\n",
+        "# Title\n\nScope: no load-when line.\n",
+        "# Title\n" + "\n" * 12 + "Scope: too late. Load when: beyond the window.\n",
+    ],
+)
+def test_has_context_header_rejects_missing_or_late_fields(text: str) -> None:
+    assert not ccb.has_context_header(text)
+
+
+# --- capsule extraction and budget ---------------------------------------------
+
+
+def _settings(capsule: str) -> str:
+    payload = json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": capsule}})
+    return json.dumps(
+        {
+            "hooks": {
+                "SessionStart": [{"hooks": [{"type": "command", "command": f"echo '{payload}'"}]}],
+                "PreToolUse": [{"hooks": [{"type": "command", "command": "true"}]}],
+            }
+        }
+    )
+
+
+def test_extract_capsules_measures_payload_bytes() -> None:
+    capsules, errors = ccb.extract_capsules(_settings("abc"))
+    assert capsules == [("SessionStart", 3)] and errors == []
+
+
+def test_check_capsules_flags_over_budget_only(tmp_path: Path) -> None:
+    root = tmp_path
+    _write(root, ".claude/settings.json", _settings("x" * 1_801))
+    assert ccb.check_capsules(root) == [".claude/settings.json: SessionStart capsule 1801 bytes > budget 1800"]
+    _write(root, ".claude/settings.json", _settings("x" * 1_800))
+    assert ccb.check_capsules(root) == []
+
+
+def test_extract_capsules_reports_unextractable_payload() -> None:
+    settings = json.dumps(
+        {"hooks": {"SessionStart": [{"hooks": [{"type": "command", "command": "emit-additionalContext.sh 'oops"}]}]}}
+    )
+    capsules, errors = ccb.extract_capsules(settings)
+    assert capsules == []
+    assert errors == [".claude/settings.json: SessionStart capsule payload is not extractable JSON"]
+
+
+# --- conditional trigger -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "AGENTS.md",
+        "CLAUDE.md",
+        ".claude/settings.json",
+        "scripts/check_context_budget.py",
+        ".agents/policy/alpha.md",
+        ".agents/context/beta.md",
+        "tests/smoke/CLAUDE.md",
+    ],
+)
+def test_touches_context_surface_true(rel: str) -> None:
+    assert ccb.touches_context_surface(["src/other.inc", rel])
+
+
+def test_touches_context_surface_false_on_unrelated() -> None:
+    assert not ccb.touches_context_surface(["src/usr/local/www/x.php", "docs/misc/notes.md"])
+
+
+# --- CLI against scratch repos -------------------------------------------------
+
+
+def _run_cli(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_TOOL), *args, "--root", str(root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_cli_staged_skips_when_no_context_surface_staged(tmp_path: Path) -> None:
+    root = _scratch_repo(tmp_path)
+    subprocess.run(["git", "-C", root, "commit", "-qm", "base"], check=True)
+    _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
+    _write(root, "src/thing.inc", "<?php\n")
+    subprocess.run(["git", "-C", root, "add", "src/thing.inc"], check=True)
+    proc = _run_cli(root, "--staged")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "skipped" in proc.stdout
+
+
+def test_cli_staged_runs_and_fails_on_staged_over_budget_policy(tmp_path: Path) -> None:
+    root = _scratch_repo(tmp_path)
+    subprocess.run(["git", "-C", root, "commit", "-qm", "base"], check=True)
+    _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+    proc = _run_cli(root, "--staged")
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert ".agents/policy/alpha.md" in proc.stdout and "> budget 12288" in proc.stdout
+
+
+def test_cli_all_clean_scratch_repo_exits_zero(tmp_path: Path) -> None:
+    root = _scratch_repo(tmp_path)
+    proc = _run_cli(root, "--all")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_cli_all_missing_git_exits_two(tmp_path: Path) -> None:
+    proc = _run_cli(tmp_path / "not-a-repo", "--all")
+    assert proc.returncode == 2
+
+
+# --- the live tree stays within its own budgets --------------------------------
+
+
+def test_live_repository_tree_is_clean() -> None:
+    tracked = _tracked(_REPO_ROOT)
+    assert ccb.run_checks(_REPO_ROOT, tracked) == []

--- a/tests/test_scanner_finding_policy.py
+++ b/tests/test_scanner_finding_policy.py
@@ -1,7 +1,9 @@
 """Vocabulary-consistency tripwires for scanner-finding policy artifacts.
 
-Keeps CLAUDE.md and the landing policy (.agents/policy/landing.md) on one
-vocabulary for the scanner/audit finding gate and HARDENING-ONLY handling.
+Keeps the issue policy (.agents/policy/issues.md — the scanner/audit finding
+gate's home since the #1436/#1437 context extraction) and the landing policy
+(.agents/policy/landing.md) on one vocabulary for the scanner/audit finding
+gate and HARDENING-ONLY handling.
 """
 
 from __future__ import annotations
@@ -23,11 +25,11 @@ def _assert_vocabulary(source: str, text: str, expected: str) -> None:
 
 
 def test_scanner_finding_actionability_vocabulary_is_consistent() -> None:
-    policy = _read("CLAUDE.md")
+    issues = _read(".agents/policy/issues.md")
     landing = _read(".agents/policy/landing.md")
 
-    _assert_vocabulary("CLAUDE.md", policy, "### Scanner/audit finding gate")
-    _assert_vocabulary("CLAUDE.md", policy, "Every newly found **actionable** TypeError-class defect")
+    _assert_vocabulary("issues.md", issues, "## Scanner/audit finding gate")
+    _assert_vocabulary("issues.md", issues, "Every newly found **actionable** TypeError-class defect")
 
     _assert_vocabulary(
         "landing.md",
@@ -38,13 +40,13 @@ def test_scanner_finding_actionability_vocabulary_is_consistent() -> None:
 
 
 def test_hardening_only_vocabulary_is_consistent_across_policy() -> None:
-    policy = _read("CLAUDE.md")
+    issues = _read(".agents/policy/issues.md")
     landing = _read(".agents/policy/landing.md")
 
-    _assert_vocabulary("CLAUDE.md", policy, "**HARDENING-ONLY**")
-    _assert_vocabulary("CLAUDE.md", policy, "HARDENING-ONLY findings do not become tracker children")
+    _assert_vocabulary("issues.md", issues, "**HARDENING-ONLY**")
+    _assert_vocabulary("issues.md", issues, "HARDENING-ONLY findings do not become tracker children")
     _assert_vocabulary(
         "landing.md",
         landing,
-        "HARDENING-ONLY finding (per the CLAUDE.md scanner gate) is SKIP",
+        "HARDENING-ONLY finding (per the issues.md scanner gate) is SKIP",
     )


### PR DESCRIPTION
Part of #1383, second half of #1437 (the AGENTS.md bootstrap inversion landed docs-class as c19b03d5).

Fixes #1437

## What

- **`scripts/check_context_budget.py`** — enforces the context-taxonomy anti-monolith budgets (research #1386 §4.3, calibrated on the measured tree rather than the matrix estimates):
  - `AGENTS.md` bootstrap ≤ 10,240 B (measured 10,041 — the 8 KB estimate predated the vendor-adapter tables living in the bootstrap)
  - `CLAUDE.md` adapter ≤ 8,192 B (5,942 incl. the rtk-managed block)
  - `.agents/policy/*.md` / `.agents/context/*.md` ≤ 12,288 B, with grandfathered **ratchet caps** for the three pre-taxonomy files (landing 26,000 / agent-roles 19,000 / delegation 18,000 — may shrink, never grow)
  - nested `CLAUDE.md`/`AGENTS.md` dir stubs ≤ 400 B (vendored `plugins/` excluded)
  - each hook-capsule `additionalContext` payload ≤ 1,800 B
  - every AGENTS.md routing-table target must resolve to a file carrying a `Scope:` + `Load-when:` header (both house shapes accepted)
- Self-scoping `--staged` / `--diff <base>` / `--all` modes mirroring the sibling checkers; wired into `.githooks/pre-commit` and the CI checker job (`--all`).
- `tests/test_context_budget.py` — 40 tests, one axis per checker branch (budget per surface class, boundary at exact budget, table extraction incl. template-token skip, target resolution, both header shapes + window, capsule extraction/budget/unextractable, conditional trigger per surface, CLI against scratch git repos) plus a live-tree pin.
- `tests/test_scanner_finding_policy.py` — vocabulary pins relocated to `.agents/policy/issues.md` (the gate's home since the #1436 extraction; the docs-class commits skip CI so the stale pins surfaced on this code-bearing run: 2 failed → relocated → green).
- `.agents/policy/sessions.md` — header line unwrapped so `Load when:` is machine-detectable (found by the checker's first live run).

## Red-path proof (new wired gate)

Checker CLI on the pre-fix live tree (real findings, exit 1):

```text
plugins/ponytail/AGENTS.md: 2593 bytes > budget 400
.agents/policy/sessions.md: routed file lacks a Scope: + Load-when: header (first 12 lines)
exit=1
```

Through the wired pre-commit hook with a staged over-budget file:

```text
[pre-commit] context-budget (bootstrap/policy byte budgets + routing headers)
.agents/policy/zz-red-canary.md: 13041 bytes > budget 12288
[pre-commit] FAILED: context-budget
```

## Gates

```text
GATE PASS: python3 -m pytest        (3160 passed, 4 skipped)
GATE PASS: ruff check .
GATE PASS: ruff format --check .
GATE PASS: mypy tests/
GATE PASS: npx markdownlint-cli2
GATES: PASS
```

Deferred to Stage 3 (#1439): capsule/bootstrap parity check and capsule reduction (taxonomy §4.3.6); dir stubs themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Also fixes #1450 — commit e7ddc902 relocates the scanner-policy vocabulary pins (broken on devel by the Stage-1 extraction 651932d0) to their new home in `.agents/policy/issues.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks for context file size limits, routing references, required headers, and hook payload limits.
  * Checks run during pre-commit validation and continuous integration.

* **Documentation**
  * Reformatted session layout metadata for improved readability.

* **Tests**
  * Added comprehensive coverage for context-budget validation and updated policy vocabulary checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->