### PR TITLE
scripts: skip category-Cc control characters in sync-script name guard

### DIFF
--- a/scripts/misc/update_hsts_preload_list.py
+++ b/scripts/misc/update_hsts_preload_list.py
@@ -28,9 +28,10 @@ Conversion
 Mirrors update_public_suffix_list.py: every non-ASCII label is punycode-encoded
 via the stdlib 'idna' codec (per-label); an already-ASCII label passes through
 verbatim (idempotent). Names are lowercased. A malformed name is skipped rather
-than emitted: whitespace or an RFC 3454 Table B.1 "commonly mapped to nothing"
-character (zero-width space, BOM, variation selectors, ...) anywhere, or a
-label past the 63-octet DNS cap, ASCII or not.
+than emitted: whitespace, an RFC 3454 Table B.1 "commonly mapped to nothing"
+character (zero-width space, BOM, variation selectors, ...) anywhere, a
+category-Cc control character (NUL, DEL, ...), or a label past the 63-octet
+DNS cap, ASCII or not.
 
 Output format
 -------------
@@ -60,6 +61,7 @@ import binascii
 import json
 import stringprep
 import sys
+import unicodedata
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
@@ -131,14 +133,17 @@ def extract_names(entries: list[dict[str, object]]) -> list[str]:
 
 
 def _has_blank_or_ignorable_char(text: str) -> bool:
-    """True if text carries a blank (str.isspace()) or an RFC 3454 Table B.1
+    """True if text carries a blank (str.isspace()), an RFC 3454 Table B.1
     "commonly mapped to nothing" character (zero-width space, BOM, word joiner,
     variation selectors, ...) -- the exact predicate the stdlib idna codec's
     nameprep step uses internally (stringprep.in_table_b1) to silently strip these
-    before punycode-encoding a label. A category-'Cf'-only check misses several
+    before punycode-encoding a label -- or a category-Cc control character (NUL,
+    DEL, ...): an ASCII-range Cc char takes the isascii() passthrough branch in
+    _punycode_label untouched, so it would otherwise be emitted verbatim instead
+    of being skipped (issue #1455). A category-'Cf'-only check misses several
     Table B.1 members that are category Mn/Pd (issue #1306 follow-up), letting
     idna's encoder silently coalesce them away instead of the name being skipped."""
-    return any(c.isspace() or stringprep.in_table_b1(c) for c in text)
+    return any(c.isspace() or stringprep.in_table_b1(c) or unicodedata.category(c) == "Cc" for c in text)
 
 
 def _punycode_label(label: str) -> str:

--- a/scripts/misc/update_public_suffix_list.py
+++ b/scripts/misc/update_public_suffix_list.py
@@ -23,9 +23,10 @@ so a mixed ascii+unicode suffix only converts its unicode label(s)); an
 already-ASCII label (including 'xn--' punycode) passes through verbatim -- the
 conversion is therefore idempotent. Labels are lowercased defensively (DNS is
 case-insensitive). A malformed line is skipped rather than emitted: internal
-whitespace or an RFC 3454 Table B.1 "commonly mapped to nothing" character
-(zero-width space, BOM, variation selectors, ...) after stripping, or any
-label past the 63-octet DNS cap, ASCII or not -- PSL never ships any of these.
+whitespace, an RFC 3454 Table B.1 "commonly mapped to nothing" character
+(zero-width space, BOM, variation selectors, ...) after stripping, a category-Cc
+control character (NUL, DEL, ...), or any label past the 63-octet DNS cap,
+ASCII or not -- PSL never ships any of these.
 
 Output format
 -------------
@@ -54,6 +55,7 @@ from __future__ import annotations
 import argparse
 import stringprep
 import sys
+import unicodedata
 import urllib.request
 from pathlib import Path
 
@@ -116,14 +118,17 @@ def extract_icann_lines(lines: list[str]) -> list[str]:
 
 
 def _has_blank_or_ignorable_char(text: str) -> bool:
-    """True if text carries a blank (str.isspace()) or an RFC 3454 Table B.1
+    """True if text carries a blank (str.isspace()), an RFC 3454 Table B.1
     "commonly mapped to nothing" character (zero-width space, BOM, word joiner,
     variation selectors, ...) -- the exact predicate the stdlib idna codec's
     nameprep step uses internally (stringprep.in_table_b1) to silently strip these
-    before punycode-encoding a label. A category-'Cf'-only check misses several
+    before punycode-encoding a label -- or a category-Cc control character (NUL,
+    DEL, ...): an ASCII-range Cc char takes the isascii() passthrough branch in
+    _punycode_label untouched, so it would otherwise be emitted verbatim instead
+    of being skipped (issue #1455). A category-'Cf'-only check misses several
     Table B.1 members that are category Mn/Pd (issue #1306 follow-up), letting
     idna's encoder silently coalesce them away instead of the line being skipped."""
-    return any(c.isspace() or stringprep.in_table_b1(c) for c in text)
+    return any(c.isspace() or stringprep.in_table_b1(c) or unicodedata.category(c) == "Cc" for c in text)
 
 
 def _punycode_label(label: str) -> str:

--- a/tests/test_update_hsts_preload_list.py
+++ b/tests/test_update_hsts_preload_list.py
@@ -260,6 +260,29 @@ def test_normalise_name_skips_empty_name() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Coverage matrix row 8c (issue #1455): category-Cc control characters skipped,
+# not emitted verbatim -- an ASCII-range Cc char (e.g. NUL, DEL) is neither
+# str.isspace() nor stringprep.in_table_b1(), so it takes the isascii()
+# passthrough branch in _punycode_label untouched instead of being rejected.
+# --------------------------------------------------------------------------- #
+
+
+def test_normalise_name_skips_name_with_nul() -> None:
+    # issue #1455 repro: raw NUL was previously emitted verbatim into pfb_py_hsts.txt.
+    assert uhpl.normalise_name("a\x00b.example") is None
+
+
+def test_normalise_name_skips_name_with_del() -> None:
+    assert uhpl.normalise_name("a\x7fb.example") is None
+
+
+def test_normalise_name_skips_name_with_bell() -> None:
+    # U+0007 (BEL) -- not one of the two codepoints named in the issue, proves
+    # the fix catches the whole category-Cc class, not a hardcoded pair.
+    assert uhpl.normalise_name("a\x07b.example") is None
+
+
+# --------------------------------------------------------------------------- #
 # Coverage matrix row 9: header exact 4-line shape incl. License + SYNCED date
 # --------------------------------------------------------------------------- #
 

--- a/tests/test_update_public_suffix_list.py
+++ b/tests/test_update_public_suffix_list.py
@@ -459,3 +459,26 @@ def test_convert_suffix_skips_line_with_ideographic_space() -> None:
 
 def test_convert_suffix_skips_empty_line() -> None:
     assert upsl.convert_suffix("") is None
+
+
+# --------------------------------------------------------------------------- #
+# Hostile-input row H9 (issue #1455): category-Cc control characters skipped,
+# not emitted verbatim -- an ASCII-range Cc char (e.g. NUL, DEL) is neither
+# str.isspace() nor stringprep.in_table_b1(), so it takes the isascii()
+# passthrough branch in _punycode_label untouched instead of being rejected.
+# --------------------------------------------------------------------------- #
+
+
+def test_convert_suffix_skips_line_with_nul() -> None:
+    # issue #1455 repro: raw NUL was previously emitted verbatim into dnsbl_tld.
+    assert upsl.convert_suffix("a\x00b.com") is None
+
+
+def test_convert_suffix_skips_line_with_del() -> None:
+    assert upsl.convert_suffix("a\x7fb.com") is None
+
+
+def test_convert_suffix_skips_line_with_bell() -> None:
+    # U+0007 (BEL) -- not one of the two codepoints named in the issue, proves
+    # the fix catches the whole category-Cc class, not a hardcoded pair.
+    assert upsl.convert_suffix("a\x07b.com") is None


### PR DESCRIPTION
## Summary

`_has_blank_or_ignorable_char()` in both data-sync scripts caught blank and RFC 3454 Table B.1 ignorable characters, but a category-`Cc` control character (e.g. `U+0000` NUL, `U+007F` DEL) was neither `str.isspace()` nor `stringprep.in_table_b1()`. An ASCII-range `Cc` character takes the `isascii()` passthrough branch in `_punycode_label` untouched, so it was emitted verbatim into the generated data file instead of the line/name being skipped.

Extends the guard with a third clause, `unicodedata.category(c) == "Cc"`, in both `scripts/misc/update_public_suffix_list.py` and `scripts/misc/update_hsts_preload_list.py` (kept byte-mirrored).

## Predicate choice

Considered the issue's suggested `unicodedata.category(c).startswith("C")` against the narrower `category(c) == "Cc"`. Probed both in-session:

- Every ASCII-range `Cc` codepoint not already caught by `isspace()`/`in_table_b1()` (NUL, BEL, ESC, DEL, ...) reaches the `isascii()` passthrough branch and is emitted raw today — confirmed with `convert_suffix()`/`normalise_name()` calls on the unmodified scripts.
- `Cs` (surrogates) cannot survive a real UTF-8-sourced fetch or JSON name field in practice.
- `Co` (private-use) and non-ASCII `Cc` (the C1 range, `U+0080`-`U+009F`) are already rejected independently: any label containing one is non-ASCII, so it takes the `label.encode("idna")` path, which raises `UnicodeEncodeError` (a `UnicodeError` subclass) already caught by the existing `except UnicodeError` in `convert_suffix`/`normalise_name`. Confirmed by probe.
- `Cn` (unassigned) codepoints mixed into a non-ASCII label are silently accepted by the idna codec and would need `startswith("C")` to catch — but that's a distinct failure mode (silent encode of a reserved codepoint, not raw byte pass-through) outside this issue's title/scope ("Cc control characters"). Noted as a possible follow-up, not filed as a separate issue.

`category(c) == "Cc"` is therefore the minimal change that closes the reported gap without touching unrelated, already-handled, or out-of-scope classes.

## Testing

Six new tests (NUL / DEL / BEL — one representative not named in the issue, per script) authored and run RED against the untouched scripts, frozen byte-identical (`git hash-object` recorded at red time, matches post-fix), then GREEN with zero test edits after the fix. Full suite (3170 passed, 4 pre-existing root-guard skips) and `scripts/agent/run-gates.sh --diff origin/devel` (pytest, ruff check, ruff format --check, mypy) all pass.

Fixes #1455

🤖 Generated with [Claude Code](https://claude.com/claude-code)