### PR TITLE
tests/smoke: fix inject() cross-family IP-list leak in _ip_inject_snippet

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3032,6 +3032,7 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
 
 def _ip_inject_snippet(spec: IpCase) -> str:
     root = CFG_IP_V6_LISTS if spec.family == "v6" else CFG_IP_V4_LISTS
+    other_root = CFG_IP_V4_LISTS if spec.family == "v6" else CFG_IP_V6_LISTS
     row = {
         "header": spec.header,
         "url": spec.feed_url,
@@ -3060,6 +3061,9 @@ def _ip_inject_snippet(spec: IpCase) -> str:
         f"$list = {_php_kv_array(listcfg)};\n"
         f"$list['row'] = array({_php_kv_array(row)});\n"
         f"config_set_path({_php_str(root)}, array($list));\n"
+        # issue #1456 (inject_ip_lists' #1214 sibling): reset the OTHER family's
+        # root too, else it keeps holding a PRIOR call's list group.
+        f"config_set_path({_php_str(other_root)}, array());\n"
         "write_config('pfBlockerNG smoke: IP case');\n"
         "echo 'OK';"
     )

--- a/tests/smoke/test_smoke_isolation.py
+++ b/tests/smoke/test_smoke_isolation.py
@@ -27,6 +27,11 @@ Two more (issue #1214), same keystone family:
 * ``test_reset_pfb_baseline_clears_geoip_dataset`` — ``reset_pfb_baseline`` removes every
   ``seed_geoip_dataset`` artifact (CSVs, mmdb, generated GUI pages), so a later module never
   reads a fake GeoIP corpus a prior module seeded.
+
+One more (issue #1456), the single-case sibling of the #1214 fix:
+
+* ``test_inject_resets_untouched_family`` — a family absent from a single-case ``inject()``
+  call is reset to empty too, not left holding a PRIOR call's list group.
 """
 
 from __future__ import annotations
@@ -201,6 +206,49 @@ def test_inject_ip_lists_resets_untouched_family(deployed_vm: SmokeVM) -> None:
     assert leaked_v4 == 0, f"v4 list root leaked forward from a prior inject_ip_lists call ({leaked_v4} rows)"
     # ... and the v6 root holds exactly the newest spec.
     assert _section_count(vm, h.CFG_IP_V6_LISTS) == 1, "inject_ip_lists did not write the v6 list section (3rd call)"
+
+
+def test_inject_resets_untouched_family(deployed_vm: SmokeVM) -> None:
+    """A family absent from a single-case inject() call is reset to empty, not left holding a
+    PRIOR call's list group (issue #1456, the ``inject_ip_lists``/#1214 fix's single-case
+    sibling: ``_ip_inject_snippet`` only wrote its OWN family's root) -- proved in BOTH
+    directions.
+
+    Scenario:
+      Given a v6 IP list injected via inject(),
+      When a LATER inject() call in the same module injects only a v4 spec,
+      Then the v6 list-config root is EMPTY (not the leaked-forward v6 list) and the v4
+        root holds exactly the new spec (the issue's reported shape);
+      When a THIRD call injects only a v6 spec (the mirror direction),
+      Then the now-untouched v4 root is EMPTY too, and the v6 root holds the newest spec.
+    """
+    vm = deployed_vm
+    feed_url = "http://192.168.89.2/ip_plain_cidr.txt"
+    v6spec = h.IpCase(aliasname="smokeisoinjv6", feed_url=feed_url, header="smokeisoinjv6", family="v6")
+    v4spec = h.IpCase(aliasname="smokeisoinjv4", feed_url=feed_url, header="smokeisoinjv4")
+    v6spec2 = h.IpCase(aliasname="smokeisoinjv6b", feed_url=feed_url, header="smokeisoinjv6b", family="v6")
+
+    # GIVEN a v6-only inject() call.
+    h.inject(vm, v6spec)
+    assert _section_count(vm, h.CFG_IP_V6_LISTS) == 1, "inject did not write the v6 list section"
+
+    # WHEN a LATER call injects only a v4 spec.
+    h.inject(vm, v4spec)
+
+    # THEN the untouched v6 root is reset to empty (not left holding the prior v6 list) ...
+    leaked = _section_count(vm, h.CFG_IP_V6_LISTS)
+    assert leaked == 0, f"v6 list root leaked forward from a prior inject() call ({leaked} rows)"
+    # ... and the v4 root holds exactly the new spec.
+    assert _section_count(vm, h.CFG_IP_V4_LISTS) == 1, "inject did not write the v4 list section"
+
+    # WHEN a THIRD call injects only a v6 spec (the mirror direction).
+    h.inject(vm, v6spec2)
+
+    # THEN the now-untouched v4 root is reset to empty too ...
+    leaked_v4 = _section_count(vm, h.CFG_IP_V4_LISTS)
+    assert leaked_v4 == 0, f"v4 list root leaked forward from a prior inject() call ({leaked_v4} rows)"
+    # ... and the v6 root holds exactly the newest spec.
+    assert _section_count(vm, h.CFG_IP_V6_LISTS) == 1, "inject did not write the v6 list section (3rd call)"
 
 
 def test_reset_pfb_baseline_clears_geoip_dataset(deployed_vm: SmokeVM) -> None:


### PR DESCRIPTION
## Summary

- `_ip_inject_snippet()` (the single-case path used by `helpers.inject()`) wrote only its own family's IP list-config root (`config_set_path(root, array($list))`), leaving the OTHER family's root holding whatever a prior call in the same VM session had written there. This is the single-case sibling of the leak fixed for `inject_ip_lists()` in issue #1214.
- Mirrors the #1214 fix: both family roots are now always written on every `inject()` call for an `IpCase` — the target family gets the new single-element list, the other family is explicitly reset to `array()`.
- Adds `test_inject_resets_untouched_family` to `tests/smoke/test_smoke_isolation.py`, mirroring `test_inject_ip_lists_resets_untouched_family`, proving the fix in both directions (v6→v4, then v4→v6).

Fixes #1456

## Caller audit (coverage matrix)

Enumerated every `inject()` call site with an `IpCase` across `tests/smoke/` (grep `IpCase(` + `h.inject(`/`helpers.inject(`). No caller relies on the leak: every test/module either (a) injects a single family per test with reset()/module-fixture boundaries in between, or (b) already uses `inject_ip_lists()` (the #1214-fixed multi-family path) when two families need to coexist in one config write. No test sequences two separate `inject()` calls of different IP families within one test expecting cross-call survival.

## Test plan

- [x] Red proof: `test_inject_resets_untouched_family` authored and run FIRST against the unfixed `_ip_inject_snippet` — failed with `AssertionError: v6 list root leaked forward from a prior inject() call (1 rows)`.
- [x] Fix applied to `_ip_inject_snippet`; same test re-run byte-identical (`git hash-object` unchanged) — passed, along with the existing `inject_ip_lists` sibling test.
- [x] Caller regression sample: 12 tests across `test_smoke_714_asn_geoip.py`, `test_smoke_adr40.py`, `test_smoke_aggregate.py`, `test_smoke_hooks.py`, `test_smoke_suppression.py` (all 6) — all pass on the fixed branch. 3 tests requiring the two-VM path were skipped (`--no-two-vm`), unrelated to this change.
- [x] `scripts/agent/run-gates.sh --diff origin/devel` — all Python gates pass (pytest, ruff check, ruff format, mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)