### PR TITLE
pfblockerng: Alerts temporary IP unlock ADR-53 parity

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3681,6 +3681,51 @@ function pfb_ip_suppressed_match(string $ip, array $entries): ?string
 // ---------------------------------------------------------------------------
 
 /**
+ * pfb_live_table_snapshot -- read a live pf table's current membership: the
+ * ADR-40 mirror file when present (freshest applied set), else a live
+ * `pfctl -T show` fallback -- both streamed line-by-line (fgets), never
+ * slurped whole (a Deny table mirror can hold millions of entries, ADR-53
+ * §3). Extracted from the Alerts "+" (addsuppress) handler (issue #1412) so
+ * the temporary Unlock icon's live punch shares the exact same read instead
+ * of re-deriving it.
+ *
+ * NOT pure -- reads the mirror file / execs pfctl.
+ *
+ * @param  string $pfctl    Absolute path to the pfctl binary ($pfb['pfctl']).
+ * @param  string $aliasdir Alias mirror directory ($pfb['aliasdir']).
+ * @param  string $dbdir    Scratch-file directory for the pfctl-show fallback ($pfb['dbdir']).
+ * @param  string $table    The pf table name (caller-validated, e.g. via PFB_FILTER_WORD).
+ * @return string[] Raw membership lines (bare host or CIDR tokens; blank/'#'-comment lines tolerated).
+ */
+function pfb_live_table_snapshot(string $pfctl, string $aliasdir, string $dbdir, string $table): array
+{
+	$table_esc = escapeshellarg($table);
+	$mirror    = "{$aliasdir}/{$table}.txt";
+	$scan_file = is_readable($mirror) ? $mirror : NULL;
+	$scan_tmp  = NULL;
+	if ($scan_file === NULL) {
+		$scan_tmp = tempnam($dbdir, 'pfb_punch_');
+		// ADR-53 review finding H4: stderr -> /dev/null, NOT 2>&1 -- the
+		// capture file is parsed line-by-line as membership entries below;
+		// merging stderr into it would feed any pfctl diagnostic line into
+		// that parse as if it were a table member.
+		exec("{$pfctl} -t {$table_esc} -T show > " . escapeshellarg($scan_tmp) . ' 2>/dev/null');
+		$scan_file = $scan_tmp;
+	}
+	$table_entries = array();
+	if (($handle = @fopen($scan_file, 'r')) !== FALSE) {
+		while (($line = @fgets($handle)) !== FALSE) {
+			$table_entries[] = trim($line);
+		}
+		fclose($handle);
+	}
+	if ($scan_tmp !== NULL) {
+		@unlink($scan_tmp);
+	}
+	return $table_entries;
+}
+
+/**
  * pfb_v4_carve_single -- the covering-CIDR remainder of one IPv4 CIDR (or
  * bare host, normalised to '/32') with a single host removed. The IPv4
  * sibling of pfb_cidr_subtract_v6(), scoped to the one-entry/one-hole shape

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3705,7 +3705,7 @@ function pfb_live_table_snapshot(string $pfctl, string $aliasdir, string $dbdir,
 	$scan_tmp  = NULL;
 	if ($scan_file === NULL) {
 		$scan_tmp = tempnam($dbdir, 'pfb_punch_');
-		// ADR-53 review finding H4: stderr -> /dev/null, NOT 2>&1 -- the
+		// ADR-53: stderr -> /dev/null, NOT 2>&1 -- the
 		// capture file is parsed line-by-line as membership entries below;
 		// merging stderr into it would feed any pfctl diagnostic line into
 		// that parse as if it were a table member.

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -799,33 +799,10 @@ if (isset($_POST) && !empty($_POST)) {
 			$descr = pfb_filter($_POST['descr'], PFB_FILTER_HTML, 'alerts addsuppress');
 		}
 
-		// Read the table's current membership -- the ADR-40 mirror file when
-		// present (freshest applied set), else a live `pfctl -T show` fallback,
-		// both streamed line-by-line (fgets): a Deny table mirror can hold
-		// millions of entries (ADR-53 §3), so it is never slurped whole.
+		// Read the table's current membership (pfb_live_table_snapshot(),
+		// pfblockerng_extra.inc -- shared with the Unlock icon's live punch, #1412).
 		$table_esc	= escapeshellarg($table);
-		$mirror		= "{$pfb['aliasdir']}/{$table}.txt";
-		$scan_file	= is_readable($mirror) ? $mirror : NULL;
-		$scan_tmp	= NULL;
-		if ($scan_file === NULL) {
-			$scan_tmp = tempnam($pfb['dbdir'], 'pfb_punch_');
-			// ADR-53 review finding H4: stderr -> /dev/null, NOT 2>&1 -- the
-			// capture file is parsed line-by-line as membership entries below;
-			// merging stderr into it would feed any pfctl diagnostic line into
-			// that parse as if it were a table member.
-			exec("{$pfb['pfctl']} -t {$table_esc} -T show > " . escapeshellarg($scan_tmp) . ' 2>/dev/null');
-			$scan_file = $scan_tmp;
-		}
-		$table_entries = array();
-		if (($handle = @fopen($scan_file, 'r')) !== FALSE) {
-			while (($line = @fgets($handle)) !== FALSE) {
-				$table_entries[] = trim($line);
-			}
-			fclose($handle);
-		}
-		if ($scan_tmp !== NULL) {
-			@unlink($scan_tmp);
-		}
+		$table_entries	= pfb_live_table_snapshot($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table);
 
 		// Locate + carve every containing table entry (any mask, both
 		// families). Unlike the old /32 branch, an empty plan (nothing
@@ -1510,22 +1487,15 @@ if (isset($_POST) && !empty($_POST)) {
 		exit;
 	}
 
-	// Unlock/Lock IP events
+	// Unlock/Lock IP events -- ADR-53 parity (#1412): the icon now posts the
+	// EXACT alerted host (never a feed CIDR), same shape the Suppression "+"
+	// already posts, so a single PFB_FILTER_IP call replaces the old v4-only,
+	// /24-/32-only split-capture regex; any CIDR-shaped or otherwise invalid
+	// $_POST['ip'] (either family) is rejected by is_ipaddr() outright.
 	elseif (isset($_POST['ip_remove']) && !empty($_POST['ip_remove'])) {
 
-		$ip = '';
-		if (strpos($_POST['ip'], '/') !== FALSE) {
-			if (is_string($_POST['ip']) && preg_match('/^(?:([0-9.]{7,15})|([0-9a-f:]{2,39}|[0-9a-f:]{2,30}[0-9.]{7,15}))\/(\d{1,3})$/i', $_POST['ip'], $parts)) {
-				$ip = pfb_filter($parts[1], PFB_FILTER_IP, 'alerts ip_remove');
-				if (empty($ip) || (count($parts) != 4) || ($parts[3] < 24) || ($parts[3] > 32)) {
-					$ip = '';
-				}
-			}
-		}
-		else {
-			$ip = pfb_filter($_POST['ip'], PFB_FILTER_IP, 'alerts ip_remove');
-		}
-		$table = pfb_filter($_POST['table'], PFB_FILTER_WORD, 'alerts ip_remove');
+		$ip	= pfb_filter($_POST['ip'], PFB_FILTER_IP, 'alerts ip_remove');
+		$table	= pfb_filter($_POST['table'], PFB_FILTER_WORD, 'alerts ip_remove');
 
 		// If IP or table field is empty, exit.
 		if (empty($ip) || empty($table)) {
@@ -1534,19 +1504,34 @@ if (isset($_POST) && !empty($_POST)) {
 			exit;
 		}
 
-		$ip_esc		= escapeshellarg($ip);
-		$table_esc	= escapeshellarg($table);
+		$table_esc = escapeshellarg($table);
 
-		// Unlock IP
+		// Unlock IP -- ADR-53 covering-CIDR live punch (pfb_live_punch_plan(),
+		// pfblockerng_extra.inc), the same mechanism the Suppression "+" uses:
+		// carve exactly this host out of whichever table entr(y/ies) currently
+		// block it live, any mask, either family, instead of deleting the
+		// whole containing entry (the old direct single-token delete unblocked
+		// every sibling in that entry too).
 		if ($_POST['ip_remove'] == 'unlock') {
-			exec("{$pfb['pfctl']} -t {$table_esc} -T delete {$ip_esc} 2>&1");
+			$table_entries = pfb_live_table_snapshot($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table);
+			$plan = pfb_live_punch_plan($ip, $table_entries);
+
+			foreach ($plan['delete'] as $entry) {
+				exec("{$pfb['pfctl']} -t {$table_esc} -T delete " . escapeshellarg($entry) . ' 2>&1');
+			}
+			foreach ($plan['add'] as $cidr) {
+				exec("{$pfb['pfctl']} -t {$table_esc} -T add " . escapeshellarg($cidr) . ' 2>&1');
+			}
+
 			pfb_unlock('unlock', 'ip', $ip, $table, $ip_unlock);
 			$savemsg = "The IP [ {$ip} ] has been temporarily Unlocked from table [ {$table} ]!";
 		}
 
-		// Lock IP
+		// Lock IP -- restores exactly the alerted host (mirrors the
+		// un-suppress 'delete_ip' handler's direct re-add: no covering-CIDR
+		// remainder to compute, only the single host that was carved out).
 		elseif ($_POST['ip_remove'] == 'lock') {
-			exec("{$pfb['pfctl']} -t {$table_esc} -T add {$ip_esc} 2>&1");
+			exec("{$pfb['pfctl']} -t {$table_esc} -T add " . escapeshellarg($ip) . ' 2>&1');
 			pfb_unlock('lock', 'ip', $ip, $table, $ip_unlock);
 			$savemsg = "The IP [ {$ip} ] has been re-locked into table [ {$table} ]!";
 		}
@@ -3026,20 +3011,15 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		}
 	}
 
-	// v4-only, /32|/24 vs /25-/31 -- since ADR-53 (issue #422) this feeds ONLY
-	// the Unlock-icon gate below and the legacy whitelist-fallback quirk gate;
-	// the Suppression-icon gate itself is now family/mask-agnostic and no
-	// longer reads $mask_suppression. Left exactly as-is, deliberately out of
-	// scope for this change.
-	$mask_suppression	= FALSE;
-	$mask_unlock		= FALSE;
+	// v4-only, /32|/24 -- ADR-53 (issue #422) narrowed this to feed ONLY the
+	// legacy whitelist-fallback quirk gate below (issue #1412 moved the
+	// Unlock/Lock icon gate onto the family/mask-agnostic condition the
+	// Suppression icon already uses, so $mask_unlock -- its only other
+	// reader -- is retired).
+	$mask_suppression = FALSE;
 
-	if ($pfb_ipv4) {
-		if ($mask == '/32' || $mask == '/24') {
-			$mask_suppression = TRUE;
-		} elseif (substr($mask, strrpos($mask, '/') + 1) > 24) {
-			$mask_unlock = TRUE;
-		}
+	if ($pfb_ipv4 && ($mask == '/32' || $mask == '/24')) {
+		$mask_suppression = TRUE;
 	}
 
 	$table = $fields[13];
@@ -3126,19 +3106,25 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		}
 	}
 
-	// Unlock/Lock Icon
-	if ($rtype == 'Block' && ($mask_suppression || $mask_unlock)) {
+	// Unlock/Lock Icon -- ADR-53 parity (#1412): same eligibility as the
+	// Suppression icon above (any family, any mask -- $mask_suppression /
+	// the retired $mask_unlock were v4-only /24|/32 restrictions), and the
+	// SAME exact-host token the Suppression "+" posts ($host), never the
+	// possibly-CIDR $eval_ip a feed match can report; $ip_unlock is keyed by
+	// that same exact host (pfb_unlock() is called with $ip = the posted
+	// host in the ip_remove handler above).
+	if ($rtype == 'Block' && !$pfb_geoip) {
 		$tnote = "\n\nNote:\n&emsp;&emsp;&#8226; Unlocking IP(s) is temporary and may be automatically\n"
 			. "&emsp;&emsp;&emsp;re-locked on a Cron or Force command!\n"
 			. "&emsp;&emsp;&#8226; Review Threat Source ( i ) Icons for further IP details.";
 
-		if (!isset($ip_unlock[$eval_ip])) {
-			$unlock_ip = '<i class="fa-solid fa-lock text-danger" id="IPULCK|' . $h_eval_ip . '|'  . $h_table
-					. '" title="Unlock IP: [ ' . $h_eval_ip . ' ] from Aliastable [ ' . $h_table . ' ]?'
+		if (!isset($ip_unlock[$host])) {
+			$unlock_ip = '<i class="fa-solid fa-lock text-danger" id="IPULCK|' . $h_host . '|'  . $h_table
+					. '" title="Unlock IP: [ ' . $h_host . ' ] from Aliastable [ ' . $h_table . ' ]?'
 					. $tnote . '" ></i>';
 		} else {
-			$unlock_ip = '<i class="fa-solid fa-unlock text-primary" id="IPLCK|' . $h_eval_ip . '|' . $h_table
-					. '" title="Re-Lock IP: [ ' . $h_eval_ip . ' ] back into Aliastable [ ' . $h_table . ' ]?'
+			$unlock_ip = '<i class="fa-solid fa-unlock text-primary" id="IPLCK|' . $h_host . '|' . $h_table
+					. '" title="Re-Lock IP: [ ' . $h_host . ' ] back into Aliastable [ ' . $h_table . ' ]?'
 					. $tnote . '" ></i>';
 		}
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -3112,13 +3112,15 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	// SAME exact-host token the Suppression "+" posts ($host), never the
 	// possibly-CIDR $eval_ip a feed match can report; $ip_unlock is keyed by
 	// that same exact host (pfb_unlock() is called with $ip = the posted
-	// host in the ip_remove handler above).
+	// host in the ip_remove handler above). The stored table must match THIS
+	// row's table -- a host unlocked in another alias still shows the Unlock
+	// icon here.
 	if ($rtype == 'Block' && !$pfb_geoip) {
 		$tnote = "\n\nNote:\n&emsp;&emsp;&#8226; Unlocking IP(s) is temporary and may be automatically\n"
 			. "&emsp;&emsp;&emsp;re-locked on a Cron or Force command!\n"
 			. "&emsp;&emsp;&#8226; Review Threat Source ( i ) Icons for further IP details.";
 
-		if (!isset($ip_unlock[$host])) {
+		if (($ip_unlock[$host] ?? NULL) !== $table) {
 			$unlock_ip = '<i class="fa-solid fa-lock text-danger" id="IPULCK|' . $h_host . '|'  . $h_table
 					. '" title="Unlock IP: [ ' . $h_host . ' ] from Aliastable [ ' . $h_table . ' ]?'
 					. $tnote . '" ></i>';

--- a/tests/php/AlertsIpUnlockIconTest.php
+++ b/tests/php/AlertsIpUnlockIconTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
  * #1412 -- ADR-53 parity for the Alerts page's temporary IP Unlock/Re-Lock
  * action).
  *
- * BEHAVIOUR CHANGE, red->green: before this fix the gate was
+ * BEHAVIOUR CHANGE (#1412): before this change the gate was
  * ``$rtype == 'Block' && ($mask_suppression || $mask_unlock)`` -- both flags
  * were computed ONLY ``if ($pfb_ipv4)`` (an IPv6 Block row got neither, so
  * the icon NEVER rendered for v6) and, for v4, TRUE only for an exact /32 or
@@ -317,5 +317,27 @@ final class AlertsIpUnlockIconTest extends TestCase
 				. "host), got:\n{$html}"
 		);
 		$this->assertStringNotContainsString('IPULCK|192.0.2.11|', $html);
+	}
+
+	public function testHostUnlockedInAnotherTableStillRendersUnlockIconForThisRow(): void
+	{
+		file_put_contents("{$this->denydir}/ExactFeed.txt", "192.0.2.11\n");
+		// The host is unlocked in a DIFFERENT table -- this row's table is not.
+		$GLOBALS['ip_unlock'] = ['192.0.2.11' => 'pfB_Other_v4'];
+
+		$fields = $this->rawFields([
+			8 => '192.0.2.11', 15 => '192.0.2.11',
+			14 => 'pfB_Exact_v4', 16 => 'ExactFeed',
+		]);
+
+		$html = $this->render($fields, 'Block');
+
+		$this->assertStringContainsString(
+			'IPULCK|192.0.2.11|pfB_Exact_v4',
+			$html,
+			"expected the Unlock icon for this row's table when the host's \$ip_unlock entry "
+				. "belongs to a DIFFERENT table, got:\n{$html}"
+		);
+		$this->assertStringNotContainsString('IPLCK|192.0.2.11|', $html);
 	}
 }

--- a/tests/php/AlertsIpUnlockIconTest.php
+++ b/tests/php/AlertsIpUnlockIconTest.php
@@ -1,0 +1,321 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin convert_ip_log()'s Unlock/Lock icon render-eligibility gate (issue
+ * #1412 -- ADR-53 parity for the Alerts page's temporary IP Unlock/Re-Lock
+ * action).
+ *
+ * BEHAVIOUR CHANGE, red->green: before this fix the gate was
+ * ``$rtype == 'Block' && ($mask_suppression || $mask_unlock)`` -- both flags
+ * were computed ONLY ``if ($pfb_ipv4)`` (an IPv6 Block row got neither, so
+ * the icon NEVER rendered for v6) and, for v4, TRUE only for an exact /32 or
+ * /24 mask, or a mask strictly narrower than /24 (any BROADER mask, e.g.
+ * /16, got neither flag either). The icon's id/title also embedded
+ * $eval_ip -- the feed's (possibly CIDR) matched entry -- instead of the
+ * exact alerted host, and the "already unlocked" check
+ * (``isset($ip_unlock[$eval_ip])``) was keyed the same wrong way.
+ *
+ * The gate is now ``$rtype == 'Block' && !$pfb_geoip`` -- the exact
+ * eligibility the Suppression icon already uses (any family, any mask,
+ * GeoIP rows excluded) -- and the icon embeds $host (the exact alerted
+ * host), with $ip_unlock keyed by that same $host (matching how the
+ * ip_remove handler now stores it).
+ *
+ * Harness mirrors AlertsIpConvertPrefetchParityTest's off-appliance load +
+ * fixture-file technique (real find/grep exec() calls against a temp
+ * sandbox, no mocking of the lookup layer) but drives a single render per
+ * case instead of the prefetch/cold parity dance -- this file is about the
+ * RENDERED MARKUP, not the prefetch producer/consumer contract.
+ */
+#[CoversFunction('convert_ip_log')]
+final class AlertsIpUnlockIconTest extends TestCase
+{
+	private string $tmpDir;
+	private string $denydir;
+	private string $nativedir;
+	private string $ccdir;
+	private string $etdir;
+	private string $aliasdir;
+	private string $matchdir;
+	private string $matchgendir;
+
+	/** @var array<string, mixed> */
+	private array $savedGlobals = [];
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/AlertsPageLoader.php';
+		pfb_test_load_alerts_page_functions();
+	}
+
+	protected function setUp(): void
+	{
+		foreach ([
+			'pfb', 'continents', 'filterfieldsarray', 'clists', 'ip_unlock', 'counter',
+			'pfbentries', 'skipcount', 'dup', 'ipfilterlimit', 'ipfilterlimitentries',
+		] as $g) {
+			$this->savedGlobals[$g] = $GLOBALS[$g] ?? null;
+		}
+
+		$this->tmpDir    = sys_get_temp_dir() . '/pfb_ip_unlock_icon_' . bin2hex(random_bytes(6));
+		$this->denydir   = "{$this->tmpDir}/deny";
+		$this->nativedir = "{$this->tmpDir}/native";
+		$this->ccdir     = "{$this->tmpDir}/geoip";
+		$this->etdir     = "{$this->tmpDir}/et";
+		$this->aliasdir  = "{$this->tmpDir}/alias";
+		$this->matchdir  = "{$this->tmpDir}/match";
+		$this->matchgendir = "{$this->matchdir}/generated";
+		foreach ([
+			$this->denydir, $this->nativedir, $this->ccdir, $this->etdir, $this->aliasdir,
+			$this->matchdir, $this->matchgendir,
+		] as $d) {
+			mkdir($d, 0777, TRUE);
+		}
+		// A second, non-matching file in each multi-glob dir -- same "path:" grep-prefix
+		// requirement AlertsIpConvertPrefetchParityTest's setUp documents.
+		file_put_contents("{$this->nativedir}/NativePlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->matchdir}/MatchPlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->matchgendir}/MatchGenPlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->aliasdir}/AliasPlaceholder.txt", "10.0.0.3\n");
+
+		$GLOBALS['pfb'] = [
+			'grep'             => '/usr/bin/grep',
+			'denydir'          => $this->denydir,
+			'nativedir'        => $this->nativedir,
+			'permitdir'        => "{$this->tmpDir}/permit",
+			'matchdir'         => $this->matchdir,
+			'matchgendir'      => $this->matchgendir,
+			'etdir'            => $this->etdir,
+			'ccdir'            => $this->ccdir,
+			'aliasdir'         => $this->aliasdir,
+			'filterlogentries' => FALSE,
+			'asn_reporting'    => 'disabled',
+			'supp'             => '',	// PfbToggle::Off -- suppression-list lookup skipped
+		];
+		$GLOBALS['continents'] = array_flip(array(
+			'pfB_Africa', 'pfB_Antarctica', 'pfB_Asia', 'pfB_Europe',
+			'pfB_NAmerica', 'pfB_Oceania', 'pfB_SAmerica', 'pfB_Top',
+		));
+		$GLOBALS['filterfieldsarray'] = [];
+		$GLOBALS['clists']              = ['ipwhitelist4' => [], 'ipwhitelist6' => []];
+		$GLOBALS['ip_unlock']           = [];
+		$GLOBALS['counter']             = ['Block' => 0];
+		$GLOBALS['pfbentries']          = 1000;
+		$GLOBALS['skipcount']           = 0;
+		$GLOBALS['dup']                 = ['Block' => 0];
+		$GLOBALS['ipfilterlimit']       = FALSE;
+		$GLOBALS['ipfilterlimitentries'] = 0;
+
+		pfb_ip_render_memos_reset();
+	}
+
+	protected function tearDown(): void
+	{
+		pfb_ip_render_memos_reset();
+
+		foreach ($this->savedGlobals as $g => $v) {
+			if ($v === null) {
+				unset($GLOBALS[$g]);
+			} else {
+				$GLOBALS[$g] = $v;
+			}
+		}
+
+		rmdir_recursive($this->tmpDir);
+	}
+
+	/**
+	 * Build a raw, PRE-reorder $fields row -- same shape/reference as
+	 * AlertsIpConvertPrefetchParityTest::rawFields().
+	 */
+	private function rawFields(array $overrides): array
+	{
+		$base = [
+			0  => '2026-07-17 00:00:00',	// Date/Timestamp
+			1  => 'rule1',			// Rulenum
+			2  => 'em0',			// Real Interface
+			3  => 'WAN',			// Friendly Interface name
+			4  => 'block',			// Action
+			5  => 4,			// Version
+			6  => 'tcp',			// Protocol ID
+			7  => 'TCP',			// Protocol
+			8  => '192.0.2.11',		// SRC IP
+			9  => '198.51.100.1',		// DST IP
+			10 => '12345',			// SRC Port
+			11 => '443',			// DST Port
+			12 => 'in',			// Direction
+			13 => 'US',			// GeoIP code
+			14 => 'pfB_Default_v4',	// IP Alias Name
+			15 => '192.0.2.11',		// IP evaluated
+			16 => 'DefaultFeed',		// Feed Name
+			17 => '',			// gethostbyaddr resolved hostname
+			18 => '',			// Client Hostname
+			19 => 'Unknown',		// ASN
+		];
+		return array_replace($base, $overrides);
+	}
+
+	/** Render one row via the real page function, capturing its printed HTML. */
+	private function render(array $rawFields, string $rtype): string
+	{
+		$GLOBALS['dup'][$rtype]     = 0;
+		$GLOBALS['counter'][$rtype] = 0;
+		$GLOBALS['ipfilterlimit']   = FALSE;
+
+		ob_start();
+		convert_ip_log('non_unified', $rawFields, '', $rtype);
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Broad v4 mask (/16) -- the retired gate required an exact /32 or /24;
+	 * ANY other v4 mask (narrower OR broader) got neither $mask_suppression
+	 * nor $mask_unlock, so the icon never rendered. The evaluated entry
+	 * (198.51.0.0/16) also differs from the alerted host -- pins that the
+	 * icon embeds the EXACT host, never the feed's covering CIDR.
+	 */
+	public function testV4BroadMaskBlockRowRendersUnlockIconWithExactHost(): void
+	{
+		file_put_contents("{$this->denydir}/BroadFeed.txt", "198.51.0.0/16\n");
+
+		$fields = $this->rawFields([
+			8 => '198.51.5.9', 15 => '198.51.0.0/16',
+			14 => 'pfB_Deny_v4', 16 => 'BroadFeed',
+		]);
+
+		$html = $this->render($fields, 'Block');
+
+		$this->assertStringContainsString(
+			'IPULCK|198.51.5.9|pfB_Deny_v4',
+			$html,
+			"expected the Unlock icon for a v4 host evaluated against a /16 mask -- the retired "
+				. "mask_suppression/mask_unlock gate only accepted /32 or /24, got:\n{$html}"
+		);
+		$this->assertStringNotContainsString(
+			'IPULCK|198.51.0.0',
+			$html,
+			"the Unlock icon must embed the EXACT alerted host (198.51.5.9), never the feed's "
+				. "covering CIDR (198.51.0.0/16), got:\n{$html}"
+		);
+	}
+
+	/** Exact /32 -- the ONE shape the retired gate already accepted; must keep working. */
+	public function testV4Slash32BlockRowStillRendersUnlockIcon(): void
+	{
+		file_put_contents("{$this->denydir}/ExactFeed.txt", "192.0.2.11\n");
+
+		$fields = $this->rawFields([
+			8 => '192.0.2.11', 15 => '192.0.2.11',
+			14 => 'pfB_Exact_v4', 16 => 'ExactFeed',
+		]);
+
+		$html = $this->render($fields, 'Block');
+
+		$this->assertStringContainsString(
+			'IPULCK|192.0.2.11|pfB_Exact_v4',
+			$html,
+			"expected the Unlock icon to still render for an exact /32 v4 host (unchanged legacy "
+				. "shape), got:\n{$html}"
+		);
+	}
+
+	/**
+	 * IPv6 -- $mask_suppression/$mask_unlock were computed ONLY
+	 * ``if ($pfb_ipv4)``, so a v6 Block row got neither flag and the icon
+	 * NEVER rendered, regardless of mask. The evaluated entry is a /48 CIDR
+	 * (broad, mirroring the v4 broad-mask case) to also confirm the icon
+	 * embeds the exact host, not the CIDR.
+	 */
+	public function testV6BlockRowRendersUnlockIconWithExactHost(): void
+	{
+		file_put_contents("{$this->denydir}/V6Feed.txt", "2001:db8:dead::/48\n");
+
+		$fields = $this->rawFields([
+			5 => 6, 8 => '2001:db8:dead::5', 9 => '2001:db8:2::1',
+			15 => '2001:db8:dead::/48',
+			14 => 'pfB_Deny_v6', 16 => 'V6Feed',
+		]);
+
+		$html = $this->render($fields, 'Block');
+
+		$this->assertStringContainsString(
+			'IPULCK|2001:db8:dead::5|pfB_Deny_v6',
+			$html,
+			"expected the Unlock icon for a v6 host -- the retired gate was wired only for "
+				. "\$pfb_ipv4 and never rendered for ANY v6 row, got:\n{$html}"
+		);
+		$this->assertStringNotContainsString(
+			'IPULCK|2001:db8:dead::/48',
+			$html,
+			"the Unlock icon must embed the EXACT alerted v6 host, never the feed's covering "
+				. "/48, got:\n{$html}"
+		);
+	}
+
+	/**
+	 * GeoIP rows stay excluded -- same "maintainer constraint" the
+	 * Suppression icon already enforces (parity is the point of #1412).
+	 */
+	public function testGeoipBlockRowDoesNotRenderUnlockIcon(): void
+	{
+		file_put_contents("{$this->ccdir}/pfB_Top.txt", "198.51.100.90\n");
+
+		$fields = $this->rawFields([
+			8 => '198.51.100.90', 15 => '198.51.100.90',
+			14 => 'pfB_Top_v4', 16 => 'CountryFeedOld',
+		]);
+
+		$html = $this->render($fields, 'Block');
+
+		$this->assertStringNotContainsString('IPULCK|198.51.100.90', $html);
+		$this->assertStringNotContainsString('IPLCK|198.51.100.90', $html);
+	}
+
+	/** Non-Block rows (Match, Permit, ...) stay excluded -- $rtype gate, FALSE arm. */
+	public function testMatchRowDoesNotRenderUnlockIcon(): void
+	{
+		file_put_contents("{$this->matchdir}/Ads_v4.txt", "198.51.100.77\n");
+
+		$fields = $this->rawFields([
+			4 => 'match', 8 => '198.51.100.77', 15 => '198.51.100.77',
+			14 => 'pfB_Ads_v4', 16 => 'Ads_v4',
+		]);
+
+		$html = $this->render($fields, 'Match');
+
+		$this->assertStringNotContainsString('IPULCK|198.51.100.77', $html);
+		$this->assertStringNotContainsString('IPLCK|198.51.100.77', $html);
+	}
+
+	/**
+	 * Already-unlocked -- the "is this row's host currently unlocked" check
+	 * must key on the SAME token the ip_remove handler now stores ($host),
+	 * not $eval_ip. Re-locking a host must render the "IPLCK" (re-lock) icon,
+	 * not "IPULCK".
+	 */
+	public function testAlreadyUnlockedHostRendersRelockIconKeyedByHost(): void
+	{
+		file_put_contents("{$this->denydir}/ExactFeed.txt", "192.0.2.11\n");
+		$GLOBALS['ip_unlock'] = ['192.0.2.11' => 'pfB_Exact_v4'];
+
+		$fields = $this->rawFields([
+			8 => '192.0.2.11', 15 => '192.0.2.11',
+			14 => 'pfB_Exact_v4', 16 => 'ExactFeed',
+		]);
+
+		$html = $this->render($fields, 'Block');
+
+		$this->assertStringContainsString(
+			'IPLCK|192.0.2.11|pfB_Exact_v4',
+			$html,
+			"expected the Re-Lock icon for a host present in \$ip_unlock (keyed by the exact "
+				. "host), got:\n{$html}"
+		);
+		$this->assertStringNotContainsString('IPULCK|192.0.2.11|', $html);
+	}
+}

--- a/tests/php/IpRemoveFilterHostileInputTest.php
+++ b/tests/php/IpRemoveFilterHostileInputTest.php
@@ -9,10 +9,10 @@ use PHPUnit\Framework\TestCase;
  * Pin the ip_remove handler's ip-validation shape (issue #1412): a single
  * ``pfb_filter($_POST['ip'], PFB_FILTER_IP, ...)`` call replaced the retired
  * v4-only, /24-/32-only split-capture regex. This exercises that EXACT call
- * (pfb_filter()/is_ipaddr() are untouched by #1412 -- no red/green dance
- * needed here, this is coverage of the validator the handler now relies on,
- * not a behaviour it changes) against the hostile-input shapes the brief
- * calls out: a v4-mapped IPv6 literal must be ACCEPTED as an ordinary v6
+ * (pfb_filter()/is_ipaddr() are untouched by #1412 -- this is coverage of
+ * the validator the handler now relies on, not a behaviour it changes)
+ * against hostile-input shapes: a v4-mapped IPv6 literal must be ACCEPTED
+ * as an ordinary v6
  * address (the retired regex's mixed hex/dotted branch handled this shape
  * too -- the replacement must not regress it), while the SAME literal with a
  * CIDR suffix must be REJECTED, exactly like any other masked input.

--- a/tests/php/IpRemoveFilterHostileInputTest.php
+++ b/tests/php/IpRemoveFilterHostileInputTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin the ip_remove handler's ip-validation shape (issue #1412): a single
+ * ``pfb_filter($_POST['ip'], PFB_FILTER_IP, ...)`` call replaced the retired
+ * v4-only, /24-/32-only split-capture regex. This exercises that EXACT call
+ * (pfb_filter()/is_ipaddr() are untouched by #1412 -- no red/green dance
+ * needed here, this is coverage of the validator the handler now relies on,
+ * not a behaviour it changes) against the hostile-input shapes the brief
+ * calls out: a v4-mapped IPv6 literal must be ACCEPTED as an ordinary v6
+ * address (the retired regex's mixed hex/dotted branch handled this shape
+ * too -- the replacement must not regress it), while the SAME literal with a
+ * CIDR suffix must be REJECTED, exactly like any other masked input.
+ */
+#[CoversFunction('pfb_filter')]
+final class IpRemoveFilterHostileInputTest extends TestCase
+{
+	/** A v4-mapped v6 bare address is a valid IP -- the handler must accept it. */
+	public function testV4MappedV6BareAddressIsAccepted(): void
+	{
+		$result = pfb_filter('::ffff:192.168.1.1', PFB_FILTER_IP, 'ip_remove test');
+
+		$this->assertNotFalse($result, 'a v4-mapped v6 bare address must be accepted by PFB_FILTER_IP');
+		$this->assertSame('::ffff:192.168.1.1', $result);
+	}
+
+	/** The SAME v4-mapped address with a CIDR suffix is rejected -- no mask is ever accepted. */
+	public function testV4MappedV6CidrShapeIsRejected(): void
+	{
+		$result = pfb_filter('::ffff:192.168.1.1/64', PFB_FILTER_IP, 'ip_remove test');
+
+		$this->assertSame('', $result, 'a CIDR-shaped input (any family, any mask) must be rejected by PFB_FILTER_IP');
+	}
+
+	/** A plain v6 CIDR is rejected -- the retired regex's unread v6 capture group is moot now. */
+	public function testPlainV6CidrShapeIsRejected(): void
+	{
+		$result = pfb_filter('2001:db8::5/64', PFB_FILTER_IP, 'ip_remove test');
+
+		$this->assertSame('', $result);
+	}
+
+	/** A plain v4 CIDR is rejected -- the retired regex's ONE admitted shape, now uniformly refused. */
+	public function testPlainV4CidrShapeIsRejected(): void
+	{
+		$result = pfb_filter('198.18.5.9/16', PFB_FILTER_IP, 'ip_remove test');
+
+		$this->assertSame('', $result);
+	}
+}

--- a/tests/php/LiveTableSnapshotTest.php
+++ b/tests/php/LiveTableSnapshotTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_live_table_snapshot() -- issue #1412: the ADR-40 mirror-or-pfctl-fallback
+ * table-membership read, extracted from the Alerts "+" (addsuppress) handler
+ * so the temporary Unlock icon's live punch shares the exact same read
+ * instead of re-deriving it (pfblockerng_extra.inc).
+ *
+ * Brand-new symbol, no pre-existing behaviour to be wrong -- CLAUDE.md's
+ * existence-only-red exemption applies (Test coverage #1): its only possible
+ * "red" against the pre-#1412 tree is "undefined function", itself coverage
+ * theater. These tests instead pin its two real branches directly: the
+ * ADR-40 mirror file wins when readable (no pfctl needed at all -- proven by
+ * pointing $pfctl at a binary that does not exist), and a missing/unreadable
+ * mirror falls back to the pfctl path, failing SOFT (empty array, no
+ * warning/fatal) when that pfctl invocation itself cannot run.
+ */
+#[CoversFunction('pfb_live_table_snapshot')]
+final class LiveTableSnapshotTest extends TestCase
+{
+	private string $tmpDir;
+	private string $aliasdir;
+	private string $dbdir;
+
+	protected function setUp(): void
+	{
+		$this->tmpDir   = sys_get_temp_dir() . '/pfb_live_table_snapshot_' . bin2hex(random_bytes(6));
+		$this->aliasdir = "{$this->tmpDir}/alias";
+		$this->dbdir    = "{$this->tmpDir}/db";
+		mkdir($this->aliasdir, 0777, TRUE);
+		mkdir($this->dbdir, 0777, TRUE);
+	}
+
+	protected function tearDown(): void
+	{
+		rmdir_recursive($this->tmpDir);
+	}
+
+	/**
+	 * The mirror file wins when readable -- and pfctl is never even invoked:
+	 * $pfctl here is a nonexistent binary, so if the function fell through to
+	 * the pfctl branch it would return an EMPTY array (a failed exec()
+	 * produces no output), never the mirror's real content.
+	 */
+	public function testMirrorFileWinsAndPfctlIsNeverInvoked(): void
+	{
+		file_put_contents("{$this->aliasdir}/pfB_Test_v4.txt", "10.0.0.0/24\n198.51.100.7\n");
+
+		$entries = pfb_live_table_snapshot('/nonexistent/pfctl-binary-xyz', $this->aliasdir, $this->dbdir, 'pfB_Test_v4');
+
+		$this->assertSame(['10.0.0.0/24', '198.51.100.7'], $entries);
+	}
+
+	/** Blank and '#'-comment lines in the mirror are returned raw -- untouched, un-filtered. */
+	public function testMirrorBlankAndCommentLinesReturnedRaw(): void
+	{
+		file_put_contents("{$this->aliasdir}/pfB_Raw_v4.txt", "10.0.0.1\n\n# a comment\n10.0.0.2\n");
+
+		$entries = pfb_live_table_snapshot('/nonexistent/pfctl-binary-xyz', $this->aliasdir, $this->dbdir, 'pfB_Raw_v4');
+
+		$this->assertSame(['10.0.0.1', '', '# a comment', '10.0.0.2'], $entries);
+	}
+
+	/**
+	 * No mirror file -> falls back to the pfctl path; a pfctl invocation that
+	 * cannot run at all (nonexistent binary) fails SOFT -- an empty array,
+	 * never a warning or fatal.
+	 */
+	public function testMissingMirrorFallsBackToPfctlAndFailsSoftOnBrokenPfctl(): void
+	{
+		$entries = pfb_live_table_snapshot('/nonexistent/pfctl-binary-xyz', $this->aliasdir, $this->dbdir, 'pfB_NoMirror_v4');
+
+		$this->assertSame([], $entries);
+	}
+
+	/**
+	 * No mirror file, but a WORKING pfctl-shaped command -- proves the
+	 * fallback path genuinely execs and parses $pfctl's own '-T show' output,
+	 * not just "returns empty no matter what". A tiny shell shim stands in
+	 * for pfctl (off-appliance has no real pf).
+	 */
+	public function testMissingMirrorFallsBackToPfctlAndParsesItsOutput(): void
+	{
+		$shim = "{$this->tmpDir}/pfctl-shim.sh";
+		file_put_contents($shim, "#!/bin/sh\nprintf '203.0.113.0/28\\n203.0.113.99\\n'\n");
+		chmod($shim, 0755);
+
+		$entries = pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_NoMirror_v4');
+
+		$this->assertSame(['203.0.113.0/28', '203.0.113.99'], $entries);
+	}
+}

--- a/tests/php/LiveTableSnapshotTest.php
+++ b/tests/php/LiveTableSnapshotTest.php
@@ -11,10 +11,7 @@ use PHPUnit\Framework\TestCase;
  * so the temporary Unlock icon's live punch shares the exact same read
  * instead of re-deriving it (pfblockerng_extra.inc).
  *
- * Brand-new symbol, no pre-existing behaviour to be wrong -- CLAUDE.md's
- * existence-only-red exemption applies (Test coverage #1): its only possible
- * "red" against the pre-#1412 tree is "undefined function", itself coverage
- * theater. These tests instead pin its two real branches directly: the
+ * These tests pin the extraction's two real branches directly: the
  * ADR-40 mirror file wins when readable (no pfctl needed at all -- proven by
  * pointing $pfctl at a binary that does not exist), and a missing/unreadable
  * mirror falls back to the pfctl path, failing SOFT (empty array, no

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -889,7 +889,7 @@ def test_ip_unlock_v4_carves_containing_range_relock_restores_and_spares_sibling
 ) -> None:
     """ip_remove=unlock carves a host out of a containing /16; relock restores it.
 
-    True multi-step transition (CLAUDE.md before/after rule): a local IPv4
+    True multi-step transition test: a local IPv4
     feed lists an RFC 2544 benchmarking /16 (unblockable via a single-token
     pfctl delete -- no such exact entry exists in the table) plus a separate
     sibling entry outside it.

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -64,6 +64,11 @@ CFG_IPV4_LISTS = "installedpackages/pfblockernglistsv4/config"
 # NOT touch the unlock state" (no swap-timing race to poll around).
 DNSBL_UNLOCK_STORE = "/tmp/dnsbl_unlock"
 
+# The IP sibling of DNSBL_UNLOCK_STORE ($pfb['ip_unlock'], pfblockerng.inc:149).
+# Same synchronous-write contract (pfb_unlock()), keyed by the EXACT alerted
+# host since issue #1412 (never a feed CIDR) -- see _ip_unlock_hosts() below.
+IP_UNLOCK_STORE = "/tmp/ip_unlock"
+
 
 def _csrf(webui: WebUI) -> str:
     """GET the alerts page and return its freshly-injected ``__csrf_magic`` token.
@@ -116,6 +121,26 @@ def _suppression_entries(vm: helpers.SmokeVM, cfg_path: str) -> set[str]:
     except (ValueError, UnicodeError):
         return set()
     return {line.split()[0] for line in text.splitlines() if line.strip()}
+
+
+def _ip_unlock_hosts(vm: helpers.SmokeVM) -> dict[str, str]:
+    """Return IP_UNLOCK_STORE's content as {exact host: table}.
+
+    pfb_unlock() (pfblockerng.inc) writes one ``host,table`` CSV line per
+    unlocked entry -- since issue #1412 ``host`` is the EXACT alerted host the
+    ip_remove handler validated (never a feed CIDR), so this is the faithful
+    oracle for "did the handler unlock/re-lock the RIGHT token". An
+    absent/empty store is an empty dict.
+    """
+    raw = helpers.read_log_file(vm, IP_UNLOCK_STORE)
+    entries: dict[str, str] = {}
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split(",", 1)
+        if len(parts) == 2:
+            entries[parts[0]] = parts[1]
+    return entries
 
 
 # --------------------------------------------------------------------------- #
@@ -841,6 +866,230 @@ def test_delete_ip_v6_unsuppresses_entry_and_restores_block(
             "write_config('pfBlockerNG smoke: restore v6suppression');\n"
             "echo 'OK';",
         )
+        helpers.reset(vm)
+
+
+# --------------------------------------------------------------------------- #
+# ip_remove (alerts.php:1490 -- ADR-53 parity, issue #1412): the temporary IP
+# Unlock/Re-Lock action. The retired handler deleted/added a SINGLE token
+# directly via pfctl -- for a bare-host table entry that matched (the ONE
+# shape it fully supported), but a containing entry BROADER than the token
+# posted (e.g. a manual-mask /16, or -- the ONLY shape its split-capture regex
+# admitted -- a /24-/32 CIDR the client posted itself) either unblocked the
+# WHOLE entry (every sibling with it) or silently missed (no exact-token match
+# in the table at all). This flow now shares pfb_live_punch_plan() with the
+# Suppression "+" (addsuppress) -- same covering-CIDR carve, any mask, either
+# family -- so only the alerted host is affected, siblings are spared.
+# --------------------------------------------------------------------------- #
+
+
+def test_ip_unlock_v4_carves_containing_range_relock_restores_and_spares_sibling(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """ip_remove=unlock carves a host out of a containing /16; relock restores it.
+
+    True multi-step transition (CLAUDE.md before/after rule): a local IPv4
+    feed lists an RFC 2544 benchmarking /16 (unblockable via a single-token
+    pfctl delete -- no such exact entry exists in the table) plus a separate
+    sibling entry outside it.
+
+    Given: the target AND the sibling both match the live pf table; the
+        target is absent from IP_UNLOCK_STORE.
+    When: ip_remove=unlock is posted for the target host only.
+    Then: the target no longer matches the table (carved out of the /16,
+        never the whole entry deleted); the sibling -- a distinct feed entry
+        entirely outside the hole -- still matches; IP_UNLOCK_STORE records
+        the EXACT host (never the /16).
+    When: ip_remove=lock (re-lock) is posted for the same host.
+    Then: the target matches the table again; IP_UNLOCK_STORE no longer lists it.
+    """
+    vm = smoke_vm
+    target = "198.18.6.9"  # inside 198.18.0.0/16
+    sibling = "198.19.51.6"  # a SEPARATE feed entry, RFC 2544 space, outside the /16 hole
+
+    feed_url = helpers.write_local_feed(vm, "ui_ipunlock4.txt", f"198.18.0.0/16\n{sibling}\n")
+    spec = helpers.IpCase(aliasname="uiipunlock4", feed_url=feed_url, header="uiipunlock4")
+    table = spec.alias
+
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "updateip")
+    try:
+        # BEFORE: the table is populated and both addresses match it live.
+        members = helpers.wait_pfctl_table(vm, table)
+        assert members, f"pf table {table} never populated after the settling update"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, f"{target} expected to match pf table {table} before unlock; pfctl said: {raw!r}"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, sibling)
+        assert matched, f"{sibling} expected to match pf table {table} before unlock; pfctl said: {raw!r}"
+        assert target not in _ip_unlock_hosts(vm), f"{target} already in {IP_UNLOCK_STORE} before the test"
+
+        # WHEN: unlock the target -- the ADR-53 live punch carves it out of the /16.
+        resp = _post_action(webui, {"ip_remove": "unlock", "ip": target, "table": table})
+        assert not looks_like_login_page(resp.text), "ip_remove=unlock POST returned the login form (session lost)"
+
+        # THEN: the target no longer matches (carved out); the sibling -- a
+        # separate feed entry entirely outside the hole -- is untouched.
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert not matched, (
+            f"{target} still matches pf table {table} after ip_remove=unlock -- the live punch did not "
+            f"take effect (or the whole /16 was deleted+never re-carved); pfctl said: {raw!r}"
+        )
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, sibling)
+        assert matched, (
+            f"{sibling} no longer matches pf table {table} after ip_remove=unlock -- an unrelated sibling "
+            f"was punched (the whole containing entry was deleted, not just the target); pfctl said: {raw!r}"
+        )
+
+        # THEN: IP_UNLOCK_STORE records the EXACT host -- never the /16.
+        unlocked = _ip_unlock_hosts(vm)
+        assert unlocked.get(target) == table, (
+            f"expected {IP_UNLOCK_STORE} to record the exact host {target!r} -> {table!r}, got {unlocked!r}"
+        )
+
+        # WHEN: re-lock the same host.
+        resp = _post_action(webui, {"ip_remove": "lock", "ip": target, "table": table})
+        assert not looks_like_login_page(resp.text), "ip_remove=lock POST returned the login form (session lost)"
+
+        # THEN: the target is blocked again; the store no longer lists it.
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, (
+            f"{target} does not match pf table {table} after ip_remove=lock -- the re-lock did not "
+            f"restore the block; pfctl said: {raw!r}"
+        )
+        assert target not in _ip_unlock_hosts(vm), f"{target} still present in {IP_UNLOCK_STORE} after ip_remove=lock"
+    finally:
+        helpers.reset(vm)
+
+
+def test_ip_unlock_v6_carves_containing_range_relock_restores_and_spares_sibling(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """ip_remove=unlock/lock over IPv6 -- same carve+restore shape as the v4 case above.
+
+    The retired handler's split-capture regex silently mishandled a v6 shape
+    (a defined-but-unread capture group, issue #1412's fourth defect) --
+    this drives the SAME server round-trip a bare v6 host now takes, over an
+    RFC 3849 documentation /64 plus a separate sibling /64.
+    """
+    vm = smoke_vm
+    target = "2001:db8:19:1::42"  # inside 2001:db8:19:1::/64
+    sibling = "2001:db8:19:2::9"  # a SEPARATE feed entry, a different /64, outside the hole
+
+    feed_url = helpers.write_local_feed(vm, "ui_ipunlock6.txt", f"2001:db8:19:1::/64\n{sibling}\n")
+    spec = helpers.IpCase(aliasname="uiipunlock6", feed_url=feed_url, header="uiipunlock6", family="v6")
+    table = spec.alias
+
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "updateip")
+    try:
+        members = helpers.wait_pfctl_table(vm, table)
+        assert members, f"pf table {table} never populated after the settling update"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, f"{target} expected to match pf table {table} before unlock; pfctl said: {raw!r}"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, sibling)
+        assert matched, f"{sibling} expected to match pf table {table} before unlock; pfctl said: {raw!r}"
+        assert target not in _ip_unlock_hosts(vm), f"{target} already in {IP_UNLOCK_STORE} before the test"
+
+        resp = _post_action(webui, {"ip_remove": "unlock", "ip": target, "table": table})
+        assert not looks_like_login_page(resp.text), "ip_remove=unlock POST returned the login form (session lost)"
+
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert not matched, (
+            f"{target} still matches pf table {table} after ip_remove=unlock -- the live punch did not "
+            f"take effect; pfctl said: {raw!r}"
+        )
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, sibling)
+        assert matched, (
+            f"{sibling} no longer matches pf table {table} after ip_remove=unlock -- an unrelated sibling "
+            f"was punched; pfctl said: {raw!r}"
+        )
+        unlocked = _ip_unlock_hosts(vm)
+        assert unlocked.get(target) == table, (
+            f"expected {IP_UNLOCK_STORE} to record the exact host {target!r} -> {table!r}, got {unlocked!r}"
+        )
+
+        resp = _post_action(webui, {"ip_remove": "lock", "ip": target, "table": table})
+        assert not looks_like_login_page(resp.text), "ip_remove=lock POST returned the login form (session lost)"
+
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, (
+            f"{target} does not match pf table {table} after ip_remove=lock -- the re-lock did not "
+            f"restore the block; pfctl said: {raw!r}"
+        )
+        assert target not in _ip_unlock_hosts(vm), f"{target} still present in {IP_UNLOCK_STORE} after ip_remove=lock"
+    finally:
+        helpers.reset(vm)
+
+
+def test_ip_unlock_rejects_invalid_ip_no_mutation(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """ip_remove=unlock rejects a malformed/CIDR-shaped ip -- no pf or store mutation.
+
+    Branch/hostile-input coverage for the retired split-capture regex's
+    replacement (a single PFB_FILTER_IP call, #1412): a CIDR-shaped POST --
+    the ONE shape the old regex partially parsed -- is now rejected exactly
+    like any other malformed address, for both families (is_ipaddr() rejects
+    a '/' outright); an empty ip/table is unchanged. Oracle = the pf table
+    (must stay untouched -- no delete/add exec may run) and IP_UNLOCK_STORE
+    (must stay unchanged).
+    """
+    vm = smoke_vm
+    target = "198.18.7.10"
+    sibling = "198.19.52.7"
+
+    feed_url = helpers.write_local_feed(vm, "ui_ipunlock_reject.txt", f"198.18.0.0/16\n{sibling}\n")
+    spec = helpers.IpCase(aliasname="uiipunlockrej", feed_url=feed_url, header="uiipunlockrej")
+    table = spec.alias
+
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "updateip")
+    try:
+        members = helpers.wait_pfctl_table(vm, table)
+        assert members, f"pf table {table} never populated after the settling update"
+
+        store_before = _ip_unlock_hosts(vm)
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, f"{target} expected to match pf table {table} before the rejected POSTs; pfctl said: {raw!r}"
+
+        for bad_ip in (
+            "999.999.999.999",  # malformed v4
+            f"{target}/16",  # v4 CIDR shape -- the ONE shape the old split-capture regex admitted
+            "2001:db8::dead:beef:9/64",  # v6 CIDR shape -- the old regex's unread v6 capture group
+        ):
+            resp = _post_action(webui, {"ip_remove": "unlock", "ip": bad_ip, "table": table})
+            assert not looks_like_login_page(resp.text), f"rejected ip={bad_ip!r} POST returned the login form"
+
+        # THEN: the table is untouched (the target still blocked) and the
+        # unlock store gained no entries -- every rejected POST is a true no-op.
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, (
+            f"{target} no longer matches pf table {table} after REJECTED ip_remove POSTs -- a rejected "
+            f"input must never mutate the live table; pfctl said: {raw!r}"
+        )
+        assert _ip_unlock_hosts(vm) == store_before, (
+            f"{IP_UNLOCK_STORE} changed after REJECTED ip_remove POSTs: before={store_before!r} "
+            f"after={_ip_unlock_hosts(vm)!r}"
+        )
+
+        # Empty ip AND empty table are also rejected (separate guard, same invariants).
+        resp = _post_action(webui, {"ip_remove": "unlock", "ip": "", "table": table})
+        assert not looks_like_login_page(resp.text), "empty-ip POST returned the login form"
+        resp = _post_action(webui, {"ip_remove": "unlock", "ip": target, "table": ""})
+        assert not looks_like_login_page(resp.text), "empty-table POST returned the login form"
+
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, (
+            f"{target} no longer matches pf table {table} after empty-field REJECTED POSTs; pfctl said: {raw!r}"
+        )
+        assert _ip_unlock_hosts(vm) == store_before, (
+            f"{IP_UNLOCK_STORE} changed after empty-field REJECTED POSTs: before={store_before!r} "
+            f"after={_ip_unlock_hosts(vm)!r}"
+        )
+    finally:
         helpers.reset(vm)
 
 

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -907,6 +907,7 @@ def test_ip_unlock_v4_carves_containing_range_relock_restores_and_spares_sibling
     vm = smoke_vm
     target = "198.18.6.9"  # inside 198.18.0.0/16
     sibling = "198.19.51.6"  # a SEPARATE feed entry, RFC 2544 space, outside the /16 hole
+    inside_sibling = "198.18.200.7"  # inside the SAME /16, covered only by the re-added remainder
 
     feed_url = helpers.write_local_feed(vm, "ui_ipunlock4.txt", f"198.18.0.0/16\n{sibling}\n")
     spec = helpers.IpCase(aliasname="uiipunlock4", feed_url=feed_url, header="uiipunlock4")
@@ -939,6 +940,14 @@ def test_ip_unlock_v4_carves_containing_range_relock_restores_and_spares_sibling
         assert matched, (
             f"{sibling} no longer matches pf table {table} after ip_remove=unlock -- an unrelated sibling "
             f"was punched (the whole containing entry was deleted, not just the target); pfctl said: {raw!r}"
+        )
+        # THEN: an address INSIDE the carved /16 (not the target) still matches --
+        # only the re-added remainder CIDRs can cover it, so this discriminates a
+        # delete-only regression the outside-hole sibling above cannot see.
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, inside_sibling)
+        assert matched, (
+            f"{inside_sibling} no longer matches pf table {table} after ip_remove=unlock -- the "
+            f"covering-CIDR remainder was not re-added (delete-only punch); pfctl said: {raw!r}"
         )
 
         # THEN: IP_UNLOCK_STORE records the EXACT host -- never the /16.
@@ -976,6 +985,7 @@ def test_ip_unlock_v6_carves_containing_range_relock_restores_and_spares_sibling
     vm = smoke_vm
     target = "2001:db8:19:1::42"  # inside 2001:db8:19:1::/64
     sibling = "2001:db8:19:2::9"  # a SEPARATE feed entry, a different /64, outside the hole
+    inside_sibling = "2001:db8:19:1::43"  # inside the SAME /64, covered only by the re-added remainder
 
     feed_url = helpers.write_local_feed(vm, "ui_ipunlock6.txt", f"2001:db8:19:1::/64\n{sibling}\n")
     spec = helpers.IpCase(aliasname="uiipunlock6", feed_url=feed_url, header="uiipunlock6", family="v6")
@@ -1004,6 +1014,14 @@ def test_ip_unlock_v6_carves_containing_range_relock_restores_and_spares_sibling
         assert matched, (
             f"{sibling} no longer matches pf table {table} after ip_remove=unlock -- an unrelated sibling "
             f"was punched; pfctl said: {raw!r}"
+        )
+        # THEN: an address INSIDE the carved /64 (not the target) still matches --
+        # only the re-added remainder CIDRs can cover it, so this discriminates a
+        # delete-only regression the outside-hole sibling above cannot see.
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, inside_sibling)
+        assert matched, (
+            f"{inside_sibling} no longer matches pf table {table} after ip_remove=unlock -- the "
+            f"covering-CIDR remainder was not re-added (delete-only punch); pfctl said: {raw!r}"
         )
         unlocked = _ip_unlock_hosts(vm)
         assert unlocked.get(target) == table, (


### PR DESCRIPTION
## Summary

The Alerts page's temporary IP Unlock/Re-Lock action (`ip_remove`) predated ADR-53 and had fallen out of parity with the persistent Suppression action:

- the Unlock/Lock icon rendered only for a v4 host evaluated against an exact `/32` or `/24` mask (`$mask_suppression`/`$mask_unlock`, computed `if ($pfb_ipv4)` only) — an IPv6 Block row, or a v4 row against any other mask (narrower OR broader), got the icon at all;
- the icon's id/title embedded `$eval_ip` — the feed's matched entry, which can be a covering CIDR — instead of the exact alerted host;
- the `ip_remove` handler's split-capture regex accepted a CIDR only in `/24`-`/32`, had an unread IPv6 capture group, and otherwise deleted/added the posted token **directly** with `pfctl` — against a table entry broader than the token (e.g. a manually configured `/16`), that either unblocked every sibling in the whole containing entry or silently missed (no exact-token match).

This brings the temporary Unlock/Re-Lock action to parity with Suppression (ADR-53):

- the icon now renders for any family/mask Block row (`$rtype == 'Block' && !$pfb_geoip`, mirroring the Suppression icon's own eligibility exactly);
- it posts and keys `$ip_unlock` on the **exact alerted host** (`$host`), matching how the Suppression `"+"` already posts;
- `ip_remove=unlock` now reads the table's live membership and routes through `pfb_live_punch_plan()` — the same ADR-53 covering-CIDR carve the Suppression `"+"` uses — instead of a direct single-token `pfctl` delete, so only the alerted host is affected and sibling addresses in the same containing entry are spared. `pfb_live_table_snapshot()` (the ADR-40-mirror-or-`pfctl -T show` read) is extracted from the `addsuppress` handler so both call sites share it instead of duplicating it.
- `ip_remove=lock` (re-lock) still restores exactly the alerted host with a direct single-token add — mirroring the existing un-suppress (`delete_ip`) handler's own re-add, which needs no covering-CIDR remainder either.

Fixes #1412

## Test plan

- [x] PHPUnit, red-first: `tests/php/AlertsIpUnlockIconTest.php` pins the icon render-eligibility gate (v4 broad mask, v6, GeoIP exclusion, non-Block exclusion, exact-host embedding, `$ip_unlock` keyed by host) against the real `convert_ip_log()`. `tests/php/LiveTableSnapshotTest.php` covers the new `pfb_live_table_snapshot()` extraction (mirror-file precedence, pfctl fallback, soft-fail on a broken pfctl).
- [x] Full `vendor/bin/phpunit` suite green (3693 tests / 22234 assertions).
- [x] `composer phpstan` / `composer phpcs` clean.
- [x] Live-VM smoke (`tests/smoke/ui/test_alerts.py`, `ui_e2e`), red-then-green on a leased box: `test_ip_unlock_v4_carves_containing_range_relock_restores_and_spares_sibling`, `test_ip_unlock_v6_carves_containing_range_relock_restores_and_spares_sibling` (covering-CIDR carve + relock + sibling preserved, both families), `test_ip_unlock_rejects_invalid_ip_no_mutation` (malformed/CIDR-shaped/empty POST fields leave the live table and the unlock store untouched).
- [x] Tier-A `ui_render` coverage for the touched page already exists (`tests/smoke/ui/test_render_smoke.py`'s generic Alerts page-load check) and is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Alerts suppression and IP unlock/re-lock handling for IPv4 and IPv6 addresses.
  * Unlocking now targets the exact alerted host while preserving neighboring blocked addresses.
  * Re-locking restores the selected host to protection.

* **Bug Fixes**
  * Invalid or malformed address inputs are rejected without changing firewall state.
  * Unlock and re-lock actions now consistently target the correct host.

* **Tests**
  * Added coverage for live table lookups, address validation, and Alerts unlock/re-lock behavior across IPv4, IPv6, GeoIP, and invalid-input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->