### PR TITLE
scripts: reject unassigned (Cn) codepoints in sync-script name guard

### DIFF
--- a/scripts/misc/update_hsts_preload_list.py
+++ b/scripts/misc/update_hsts_preload_list.py
@@ -30,8 +30,8 @@ via the stdlib 'idna' codec (per-label); an already-ASCII label passes through
 verbatim (idempotent). Names are lowercased. A malformed name is skipped rather
 than emitted: whitespace, an RFC 3454 Table B.1 "commonly mapped to nothing"
 character (zero-width space, BOM, variation selectors, ...) anywhere, a
-category-Cc control character (NUL, DEL, ...), or a label past the 63-octet
-DNS cap, ASCII or not.
+category-Cc control character (NUL, DEL, ...), a category-Cn (unassigned)
+codepoint, or a label past the 63-octet DNS cap, ASCII or not.
 
 Output format
 -------------
@@ -137,13 +137,20 @@ def _has_blank_or_ignorable_char(text: str) -> bool:
     "commonly mapped to nothing" character (zero-width space, BOM, word joiner,
     variation selectors, ...) -- the exact predicate the stdlib idna codec's
     nameprep step uses internally (stringprep.in_table_b1) to silently strip these
-    before punycode-encoding a label -- or a category-Cc control character (NUL,
+    before punycode-encoding a label -- a category-Cc control character (NUL,
     DEL, ...): an ASCII-range Cc char takes the isascii() passthrough branch in
     _punycode_label untouched, so it would otherwise be emitted verbatim instead
-    of being skipped (issue #1455). A category-'Cf'-only check misses several
-    Table B.1 members that are category Mn/Pd (issue #1306 follow-up), letting
-    idna's encoder silently coalesce them away instead of the name being skipped."""
-    return any(c.isspace() or stringprep.in_table_b1(c) or unicodedata.category(c) == "Cc" for c in text)
+    of being skipped (issue #1455) -- or a category-Cn (unassigned) codepoint: the
+    idna codec accepts one without error and silently punycode-encodes it (issue
+    #1463; probed: U+0378 encodes cleanly). category(c) == "Cn" tracks the
+    interpreter's own (live) Unicode data, so it rejects only codepoints
+    unassigned as of THIS run; the alternative, stringprep.in_table_a1, is frozen
+    to the Unicode 3.2 baseline and would reject every codepoint assigned since
+    (e.g. U+0526, U+08A0) -- a massive false-positive class, so it was rejected
+    for this guard. A category-'Cf'-only check misses several Table B.1 members
+    that are category Mn/Pd (issue #1306 follow-up), letting idna's encoder
+    silently coalesce them away instead of the name being skipped."""
+    return any(c.isspace() or stringprep.in_table_b1(c) or unicodedata.category(c) in ("Cc", "Cn") for c in text)
 
 
 def _punycode_label(label: str) -> str:

--- a/scripts/misc/update_public_suffix_list.py
+++ b/scripts/misc/update_public_suffix_list.py
@@ -25,8 +25,8 @@ conversion is therefore idempotent. Labels are lowercased defensively (DNS is
 case-insensitive). A malformed line is skipped rather than emitted: internal
 whitespace, an RFC 3454 Table B.1 "commonly mapped to nothing" character
 (zero-width space, BOM, variation selectors, ...) after stripping, a category-Cc
-control character (NUL, DEL, ...), or any label past the 63-octet DNS cap,
-ASCII or not -- PSL never ships any of these.
+control character (NUL, DEL, ...), a category-Cn (unassigned) codepoint, or any
+label past the 63-octet DNS cap, ASCII or not -- PSL never ships any of these.
 
 Output format
 -------------
@@ -122,13 +122,20 @@ def _has_blank_or_ignorable_char(text: str) -> bool:
     "commonly mapped to nothing" character (zero-width space, BOM, word joiner,
     variation selectors, ...) -- the exact predicate the stdlib idna codec's
     nameprep step uses internally (stringprep.in_table_b1) to silently strip these
-    before punycode-encoding a label -- or a category-Cc control character (NUL,
+    before punycode-encoding a label -- a category-Cc control character (NUL,
     DEL, ...): an ASCII-range Cc char takes the isascii() passthrough branch in
     _punycode_label untouched, so it would otherwise be emitted verbatim instead
-    of being skipped (issue #1455). A category-'Cf'-only check misses several
-    Table B.1 members that are category Mn/Pd (issue #1306 follow-up), letting
-    idna's encoder silently coalesce them away instead of the line being skipped."""
-    return any(c.isspace() or stringprep.in_table_b1(c) or unicodedata.category(c) == "Cc" for c in text)
+    of being skipped (issue #1455) -- or a category-Cn (unassigned) codepoint: the
+    idna codec accepts one without error and silently punycode-encodes it (issue
+    #1463; probed: U+0378 encodes cleanly). category(c) == "Cn" tracks the
+    interpreter's own (live) Unicode data, so it rejects only codepoints
+    unassigned as of THIS run; the alternative, stringprep.in_table_a1, is frozen
+    to the Unicode 3.2 baseline and would reject every codepoint assigned since
+    (e.g. U+0526, U+08A0) -- a massive false-positive class, so it was rejected
+    for this guard. A category-'Cf'-only check misses several Table B.1 members
+    that are category Mn/Pd (issue #1306 follow-up), letting idna's encoder
+    silently coalesce them away instead of the line being skipped."""
+    return any(c.isspace() or stringprep.in_table_b1(c) or unicodedata.category(c) in ("Cc", "Cn") for c in text)
 
 
 def _punycode_label(label: str) -> str:

--- a/tests/test_update_hsts_preload_list.py
+++ b/tests/test_update_hsts_preload_list.py
@@ -283,6 +283,40 @@ def test_normalise_name_skips_name_with_bell() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Coverage matrix row 8d (issue #1463): category-Cn (unassigned) codepoints
+# skipped, not silently punycode-encoded -- the stdlib idna codec accepts an
+# unassigned codepoint without error (probed: U+0378 encodes cleanly), so it
+# rides into pfb_py_hsts.txt untouched unless _has_blank_or_ignorable_char()
+# also rejects category-Cn.
+# --------------------------------------------------------------------------- #
+
+
+def test_normalise_name_skips_name_with_unassigned_codepoint_mixed_nonascii() -> None:
+    # issue #1463 reported shape: Cn (U+0378) mixed with another non-ASCII
+    # label char (U+00E9, e-acute) in the same label.
+    assert uhpl.normalise_name("a͸é.example") is None
+
+
+def test_normalise_name_skips_name_with_unassigned_codepoint_otherwise_ascii_label() -> None:
+    # Cn is the ONLY non-ASCII char in an otherwise-ASCII label -- probed: no
+    # ASCII-range (0x00-0x7F) codepoint is Cn, so this label is non-ASCII
+    # overall and takes the idna path, never the isascii() passthrough branch
+    # (unlike the Cc case in issue #1455, which DID pass through raw).
+    assert uhpl.normalise_name("a͸b.example") is None
+
+
+def test_normalise_name_still_encodes_recently_assigned_codepoint_not_cn() -> None:
+    # U+0526 (CYRILLIC CAPITAL LETTER PE WITH DESCENDER, assigned Unicode 5.1)
+    # is "unassigned" under RFC 3454 Table A.1's frozen Unicode-3.2 baseline
+    # (stringprep.in_table_a1 -> True) but is NOT category-Cn on this
+    # interpreter's live Unicode data -- pins the tolerance decision: reject
+    # unassigned-NOW (unicodedata.category(c) == "Cn"), not
+    # unassigned-as-of-3.2 (stringprep.in_table_a1), which would false-positive
+    # reject this valid, currently-assigned codepoint.
+    assert uhpl.normalise_name("aԦb.example") == "xn--ab-e6c.example"
+
+
+# --------------------------------------------------------------------------- #
 # Coverage matrix row 9: header exact 4-line shape incl. License + SYNCED date
 # --------------------------------------------------------------------------- #
 

--- a/tests/test_update_public_suffix_list.py
+++ b/tests/test_update_public_suffix_list.py
@@ -482,3 +482,37 @@ def test_convert_suffix_skips_line_with_bell() -> None:
     # U+0007 (BEL) -- not one of the two codepoints named in the issue, proves
     # the fix catches the whole category-Cc class, not a hardcoded pair.
     assert upsl.convert_suffix("a\x07b.com") is None
+
+
+# --------------------------------------------------------------------------- #
+# Hostile-input row H10 (issue #1463): category-Cn (unassigned) codepoints
+# skipped, not silently punycode-encoded -- the stdlib idna codec accepts an
+# unassigned codepoint without error (probed: U+0378 encodes cleanly), so it
+# rides into dnsbl_tld untouched unless _has_blank_or_ignorable_char() also
+# rejects category-Cn.
+# --------------------------------------------------------------------------- #
+
+
+def test_convert_suffix_skips_line_with_unassigned_codepoint_mixed_nonascii() -> None:
+    # issue #1463 reported shape: Cn (U+0378) mixed with another non-ASCII
+    # label char (U+00E9, e-acute) in the same label.
+    assert upsl.convert_suffix("a͸é.com") is None
+
+
+def test_convert_suffix_skips_line_with_unassigned_codepoint_otherwise_ascii_label() -> None:
+    # Cn is the ONLY non-ASCII char in an otherwise-ASCII label -- probed: no
+    # ASCII-range (0x00-0x7F) codepoint is Cn, so this label is non-ASCII
+    # overall and takes the idna path, never the isascii() passthrough branch
+    # (unlike the Cc case in issue #1455, which DID pass through raw).
+    assert upsl.convert_suffix("a͸b.com") is None
+
+
+def test_convert_suffix_still_encodes_recently_assigned_codepoint_not_cn() -> None:
+    # U+0526 (CYRILLIC CAPITAL LETTER PE WITH DESCENDER, assigned Unicode 5.1)
+    # is "unassigned" under RFC 3454 Table A.1's frozen Unicode-3.2 baseline
+    # (stringprep.in_table_a1 -> True) but is NOT category-Cn on this
+    # interpreter's live Unicode data -- pins the tolerance decision: reject
+    # unassigned-NOW (unicodedata.category(c) == "Cn"), not
+    # unassigned-as-of-3.2 (stringprep.in_table_a1), which would false-positive
+    # reject this valid, currently-assigned codepoint.
+    assert upsl.convert_suffix("aԦb.com") == "xn--ab-e6c.com"


### PR DESCRIPTION
## Summary

`_has_blank_or_ignorable_char()` in both data-sync scripts caught blank, RFC 3454 Table B.1 ignorable, and category-`Cc` control characters (issue #1455 / PR #1460), but a category-`Cn` (unassigned) codepoint mixed into a non-ASCII label was silently accepted by the stdlib `idna` codec and punycode-encoded into the generated data file instead of the line/name being skipped.

Extends the guard with a fourth `unicodedata.category(c) == "Cn"` clause, in both `scripts/misc/update_public_suffix_list.py` and `scripts/misc/update_hsts_preload_list.py` (kept byte-mirrored), and updates both module docstrings + the guard docstring coherently.

## Predicate choice

Probed both candidates on the repo's Python (3.14.6, `unicodedata.unidata_version` = **16.0.0**) with U+0378 (never assigned) and two codepoints assigned well after Unicode 3.2 (U+0526, Cyrillic, assigned 5.1; U+08A0, Arabic, assigned 6.1):

```
>>> unicodedata.unidata_version
'16.0.0'
>>> for cp in (0x0378, 0x0526, 0x08A0):
...     c = chr(cp)
...     print(f"U+{cp:04X}: category={unicodedata.category(c)!r} in_table_a1={stringprep.in_table_a1(c)}")
U+0378: category='Cn' in_table_a1=True
U+0526: category='Lu' in_table_a1=True
U+08A0: category='Lo' in_table_a1=True
```

- `unicodedata.category(c) == "Cn"` tracks the interpreter's own (live) Unicode 16.0 data: it flags only U+0378 (genuinely unassigned), not U+0526/U+08A0 (assigned letters).
- `stringprep.in_table_a1(c)` is frozen to the Unicode 3.2 baseline (RFC 3454): it flags **all three**, including the two currently-assigned, valid IDN letters — a massive false-positive class that would reject legitimate PSL/HSTS entries using any codepoint assigned to Unicode after 3.2 (i.e. most of Unicode's growth since 2002).
- Confirmed the idna codec does NOT raise on a `Cn` codepoint (no escalation triggered):

```
>>> "a͸é".encode("idna")
b'xn--a-bga87q'
```

- Also probed: no ASCII-range (`0x00`-`0x7F`) codepoint is category-`Cn` (all 128 are already assigned to some category), so a label carrying a `Cn` codepoint is always non-ASCII overall and always takes the `idna` encode path — never the `isascii()` passthrough branch that let raw `Cc` bytes (issue #1455) through untouched. Confirmed with `convert_suffix()`/`normalise_name()` calls on the unmodified (pre-fix) scripts.

**Decision:** `category(c) == "Cn"` -- the minimal change that closes the reported gap without rejecting codepoints assigned since RFC 3454 Table A.1's Unicode 3.2 freeze.

## Coverage matrix

| Row | Shape | Expected | Test |
| --- | --- | --- | --- |
| Reported shape | `Cn` (U+0378) mixed with another non-ASCII char (é) in one label | REJECTED | `test_convert_suffix_skips_line_with_unassigned_codepoint_mixed_nonascii` / `test_normalise_name_skips_name_with_unassigned_codepoint_mixed_nonascii` |
| `Cn` in an otherwise-ASCII label | `Cn` is the only non-ASCII char in the label (probed: still takes the `idna` path, not `isascii()` passthrough — no ASCII-range `Cn` exists) | REJECTED | `test_convert_suffix_skips_line_with_unassigned_codepoint_otherwise_ascii_label` / `test_normalise_name_skips_name_with_unassigned_codepoint_otherwise_ascii_label` |
| Tolerance pin | recently-assigned non-`Cn` codepoint (U+0526, assigned Unicode 5.1) in a valid IDN label | ACCEPTED (still encoded) | `test_convert_suffix_still_encodes_recently_assigned_codepoint_not_cn` / `test_normalise_name_still_encodes_recently_assigned_codepoint_not_cn` |
| Regression | existing Cc/B.1/blank/space suites | unchanged, still green | full existing suite (100 tests across both files) |

## Testing

Test-first, executed:

1. Authored the 6 new tests above (3 per script) against the **untouched** scripts (i.e. with the #1455 `Cc` fix already in place, but no `Cn` fix). RED run:

```
$ python3 -m pytest tests/test_update_public_suffix_list.py tests/test_update_hsts_preload_list.py -q
...
FAILED tests/test_update_public_suffix_list.py::test_convert_suffix_skips_line_with_unassigned_codepoint_mixed_nonascii
FAILED tests/test_update_public_suffix_list.py::test_convert_suffix_skips_line_with_unassigned_codepoint_otherwise_ascii_label
FAILED tests/test_update_hsts_preload_list.py::test_normalise_name_skips_name_with_unassigned_codepoint_mixed_nonascii
FAILED tests/test_update_hsts_preload_list.py::test_normalise_name_skips_name_with_unassigned_codepoint_otherwise_ascii_label
4 failed, 96 passed in 0.93s
```

(The two tolerance-pin tests passed even RED — they were never broken; they pin behaviour the fix must preserve.)

2. Froze test files at RED time:

```
$ git hash-object tests/test_update_public_suffix_list.py tests/test_update_hsts_preload_list.py
1f8207a09c037c245bf4bcf26bf016e46736a067
d960248a5ce86c5daf86d5e3e6aad0ca2691fb1b
```

3. Applied the fix (guard + docstrings, no test edits). Re-ran GREEN, byte-identical test files:

```
$ python3 -m pytest tests/test_update_public_suffix_list.py tests/test_update_hsts_preload_list.py -q
100 passed in 0.88s

$ git hash-object tests/test_update_public_suffix_list.py tests/test_update_hsts_preload_list.py
1f8207a09c037c245bf4bcf26bf016e46736a067   # unchanged
d960248a5ce86c5daf86d5e3e6aad0ca2691fb1b   # unchanged
```

4. Full suite + gates:

```
$ python3 -m pytest -q
3176 passed, 4 skipped in 88.74s (0:01:28)

$ scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: python3 -m pytest
GATE PASS: ruff check .
GATE PASS: ruff format --check .
GATE PASS: mypy tests/
GATES: PASS
```

Fixes #1463

🤖 Generated with [Claude Code](https://claude.com/claude-code)
