### PR TITLE
pfblockerng_feeds: return icon from url_compare() instead of global $icon

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -709,12 +709,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
 
 		-
-			message: '#^Variable \$icon in empty\(\) always exists and is always falsy\.$#'
-			identifier: empty.variable
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
-
-		-
 			message: '#^Variable \$p_tr_style might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -202,10 +202,14 @@ function pfb_feeds_render_aliasname_inputs($section, $type, $feeds_list, $pconfi
 	}
 }
 
+// Returns the matched-feed icon markup for the ($alternate = FALSE) primary-URL
+// comparison (issue #1330); the caller assigns it to $icon only when non-empty, same
+// as this function's former direct `global $icon` mutation. Empty string means "no
+// match, leave $icon as the caller already has it" -- never a request to clear it.
 function url_compare($ftype, $key, $rowid, $aliasname, $row_aliasname, $row_url, $feed_url, $row_state,
 	    $feed_header, $alternate=FALSE, $alt_header='', $alt_info='', $alt_register='', $a_key) {
 
-	global $ex_feeds, $alt_feeds, $icon;
+	global $ex_feeds, $alt_feeds;
 	$x_icon = '';
 
 	// Convert user defined URLs with '_API_KEY' to baseline URL format
@@ -263,10 +267,7 @@ function url_compare($ftype, $key, $rowid, $aliasname, $row_aliasname, $row_url,
 	}
 
 	if (!empty($x_icon)) {
-		if (!$alternate) {
-			$icon	= $x_icon;
-		}
-		else {
+		if ($alternate) {
 			if (!isset($alt_feeds[$ftype][$aliasname][$alt_header])) {
 				$alt_feeds[$ftype][$aliasname][$feed_header][$a_key] = array(	'icon' => $x_icon, 'url' => $feed_url, 'header' => $alt_header,
 												'info' => $alt_info, 'register' => !empty($alt_register) ? TRUE : FALSE);
@@ -285,6 +286,8 @@ function url_compare($ftype, $key, $rowid, $aliasname, $row_aliasname, $row_url,
 											'info' => $alt_info, 'register' => !empty($alt_register) ? TRUE : FALSE );
 		}
 	}
+
+	return $x_icon;
 }
 
 // Render the predefined-feeds table rows for a single $type ('ipv4'|'ipv6'|'dnsbl'),
@@ -292,9 +295,10 @@ function url_compare($ftype, $key, $rowid, $aliasname, $row_aliasname, $row_url,
 // group + the hidden alt_<header> input + the per-row icons), identical to the inline
 // per-type block it replaces. The cross-type accumulators ($alt_selected CSV,
 // $feed_info_row separator counter, $aliasname_found) and the state shared with
-// url_compare ($ex_feeds, $alt_feeds, $icon) live at page (global) scope and are bound
-// via `global`. The page calls it once, for the active (?type=) tab only
-// (ADR-16 type-scoped UI).
+// url_compare() ($ex_feeds, $alt_feeds) live at page (global) scope and are bound via
+// `global`; $icon is assigned here from url_compare()'s return value (issue #1330 --
+// no longer a cross-function global mutation). The page calls it once, for the active
+// (?type=) tab only (ADR-16 type-scoped UI).
 function pfb_feeds_render_predefined_type($ftype, $info) {
 
 	global $ex_feeds, $alt_feeds, $icon, $fconfig, $feed_alt_selected;
@@ -343,8 +347,11 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 					}
 
 					// Determine all Aliases that reference the Feed URL
-					url_compare($ftype, $key, $row['rowid'], $aliasname, $row['aliasname'], $row['url'], $feed['url'],
+					$row_icon = url_compare($ftype, $key, $row['rowid'], $aliasname, $row['aliasname'], $row['url'], $feed['url'],
 							$row['state'], $feed['header'], FALSE, '', '', '', 0);
+					if (!empty($row_icon)) {
+						$icon = $row_icon;
+					}
 
 					// Determine all Aliases that reference the 'Alternate' Feed URLs
 					if (isset($feed['alternate'])) {

--- a/tests/php/FeedsPredefinedTypeLoader.php
+++ b/tests/php/FeedsPredefinedTypeLoader.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Shared off-appliance loader for the pfblockerng_feeds.php predefined-feeds render
+ * block: url_compare() and pfb_feeds_render_predefined_type() (issue #1330).
+ *
+ * pfblockerng_feeds.php carries top-level execution (require_once + POST handling +
+ * head.inc) and cannot be require()d off-appliance. Both target functions are
+ * self-contained top-level `function` declarations with no pfSense-runtime calls in
+ * their bodies, so — same pattern as AlertsPageLoader.php — the source is read, its
+ * top-of-file require_once() lines are stripped, and everything from the first
+ * `function` keyword up to the first top-level statement that follows the block
+ * (`$type_label = array(...)`, which precedes the page's head.inc include) is eval'd
+ * verbatim. No production file is modified to make it testable.
+ */
+function pfb_test_load_feeds_predefined_type_functions(): void
+{
+	if (function_exists('url_compare')) {
+		return;
+	}
+	$src = file_get_contents(
+		dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_feeds.php'
+	);
+	if ($src === false) {
+		throw new RuntimeException('failed to read pfblockerng_feeds.php');
+	}
+	$src = preg_replace('/^\s*require_once\(.*\);\s*$/m', '', $src);
+	$start = strpos($src, "\nfunction ");
+	$end   = strpos($src, "\n\$type_label = array(");
+	if ($start === false || $end === false || $end <= $start) {
+		throw new RuntimeException('could not locate the function block in pfblockerng_feeds.php');
+	}
+	eval("\n" . substr($src, $start + 1, $end - $start - 1));
+}

--- a/tests/php/FeedsUrlCompareIconRenderTest.php
+++ b/tests/php/FeedsUrlCompareIconRenderTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Render pins for pfb_feeds_render_predefined_type()'s per-row "feed status" icon
+ * (issue #1330). url_compare() used to mutate `global $icon` directly from inside a
+ * sibling function call -- a PHPStan blind spot the ESCALATE evidence comment on the
+ * issue proved is NOT dead code: three `empty($icon)` guards downstream (:452, :460,
+ * :489) rely on that mutation to skip re-assigning the icon once url_compare() has
+ * already set the "feed exists" checkmark, so a feed already added to an alias keeps
+ * its checkmark instead of getting clobbered by the "add feed" icon. This file pins
+ * that behaviour byte-for-byte across the return-based refactor:
+ *
+ *   - existing feed, no alternates (guard :489)             -- checkmark, not add-icon
+ *   - existing feed, with alternates, header pre-selected
+ *     (guard :452, the in_array()+empty($icon) precedence)  -- checkmark, not add-icon
+ *   - brand-new feed, no existing alias match (guard :489,
+ *     empty-icon side)                                      -- add-icon, not checkmark
+ *
+ * pfblockerng_feeds.php carries top-level execution and cannot be require()d
+ * off-appliance; see FeedsPredefinedTypeLoader.php for the eval-extraction mechanics
+ * (same pattern as AlertsPageLoader.php).
+ */
+final class FeedsUrlCompareIconRenderTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/FeedsPredefinedTypeLoader.php';
+		pfb_test_load_feeds_predefined_type_functions();
+	}
+
+	/** @param array<string, mixed> $extra */
+	private function buildFeed(string $header, string $url, string $website, array $extra = []): array
+	{
+		return array_merge([
+			'feed'     => $header,
+			'website'  => $website,
+			'url'      => $url,
+			'header'   => $header,
+			'register' => '',
+		], $extra);
+	}
+
+	/**
+	 * Seeds every global pfb_feeds_render_predefined_type()/url_compare() read
+	 * (page-scope state normally set up by pfblockerng_feeds.php itself) and
+	 * captures the rendered HTML for one $ftype/$info pair.
+	 *
+	 * @param array<string, mixed>   $info
+	 * @param list<array<string, mixed>> $exFeedsForType
+	 * @param list<string>           $feedAltSelected
+	 */
+	private function renderType(string $ftype, array $info, array $exFeedsForType, array $feedAltSelected = []): string
+	{
+		$GLOBALS['ex_feeds']          = [$ftype => $exFeedsForType];
+		$GLOBALS['alt_feeds']         = [];
+		$GLOBALS['fconfig']           = [];
+		$GLOBALS['feed_alt_selected'] = $feedAltSelected;
+		$GLOBALS['alt_selected']      = '';
+		$GLOBALS['feed_info_row']     = 0;
+		$GLOBALS['aliasname_found']   = [];
+
+		ob_start();
+		pfb_feeds_render_predefined_type($ftype, $info);
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Isolates the rendered <tr> row whose HTML contains $needle, then returns the
+	 * content of that row's LAST <td> -- the `<td><?=$icon;?></td>` cell (:593).
+	 * The row's OTHER cells can also carry a "fa-solid fa-check" (the separate
+	 * $status "Alias/Group exists" icon at :340), so scoping strictly to the last
+	 * <td> is what makes the assertion sensitive to $icon specifically.
+	 */
+	private function iconCellForRow(string $html, string $needle): string
+	{
+		$this->assertNotFalse(
+			preg_match_all('/<tr[^>]*>.*?<\/tr>/s', $html, $matches),
+			'no <tr> rows found in rendered HTML'
+		);
+		foreach ($matches[0] as $row) {
+			if (str_contains($row, $needle)) {
+				$tdPos = strrpos($row, '<td>');
+				$this->assertNotFalse($tdPos, 'icon <td> not found in matched row');
+				$cell = substr($row, $tdPos + strlen('<td>'));
+				return (string) preg_replace('/<\/td>\s*\z/', '', $cell);
+			}
+		}
+		$this->fail("no rendered <tr> contains marker: {$needle}");
+	}
+
+	// Scenario 1 (ESCALATE evidence comment): a feed whose URL already matches an
+	// existing alias row, no 'alternate' URLs configured -- guard :489.
+	public function testExistingFeedNoAlternatesRendersCheckmarkNotAddIcon(): void
+	{
+		$url  = 'https://example.test/pin-no-alt/list.txt';
+		$feed = $this->buildFeed('PinFeedNoAlt', $url, 'https://example.test/pin-no-alt/');
+		$info = ['PinAlias1' => ['action' => 'permit', 'info' => 'Pin alias info', 'feeds' => [$feed]]];
+		$exFeeds = [[
+			'aliasname' => 'PinAlias1',
+			'action'    => 'permit',
+			'state'     => 'Enabled',
+			'url'       => $url,
+			'header'    => 'PinFeedNoAlt',
+			'rowid'     => 101,
+		]];
+
+		$cell = $this->iconCellForRow($this->renderType('ipv4', $info, $exFeeds), $url);
+
+		$this->assertStringContainsString('fa-solid fa-check', $cell, 'existing feed must render the checkmark icon');
+		$this->assertStringNotContainsString('fa-solid fa-plus-circle', $cell, 'existing feed must NOT render the add icon');
+	}
+
+	// Scenario 2 (ESCALATE evidence comment): same as above, PLUS an 'alternate' URL
+	// that also matches an existing row, with the primary header pre-selected in
+	// $feed_alt_selected -- this forces in_array($feed['header'], $feed_alt_selected)
+	// TRUE at :452, so only the `&& empty($icon)` term stops re-assignment. This is
+	// the acceptance-criteria #3 precedence pin: drop that guard term and this
+	// assertion fails (see the handoff's throwaway-mutation proof).
+	public function testExistingFeedWithAlternatesSelectedRendersCheckmarkNotAddIcon(): void
+	{
+		$primaryUrl = 'https://example.test/pin-with-alt/list.txt';
+		$altUrl     = 'https://alt.example.test/pin-with-alt-secondary.txt';
+		$feed = $this->buildFeed('PinFeedWithAlt', $primaryUrl, 'https://example.test/pin-with-alt/', [
+			'alternate' => [
+				['url' => $altUrl, 'header' => 'PinFeedWithAltAlt'],
+			],
+		]);
+		$info = ['PinAlias2' => ['action' => 'permit', 'info' => 'Pin alias info', 'feeds' => [$feed]]];
+		$exFeeds = [
+			[
+				'aliasname' => 'PinAlias2',
+				'action'    => 'permit',
+				'state'     => 'Enabled',
+				'url'       => $primaryUrl,
+				'header'    => 'PinFeedWithAlt',
+				'rowid'     => 201,
+			],
+			[
+				'aliasname' => 'PinAlias2',
+				'action'    => 'permit',
+				'state'     => 'Enabled',
+				'url'       => $altUrl,
+				'header'    => 'PinFeedWithAltAlt',
+				'rowid'     => 202,
+			],
+		];
+
+		$html = $this->renderType('ipv4', $info, $exFeeds, ['PinFeedWithAlt']);
+		$cell = $this->iconCellForRow($html, $primaryUrl);
+
+		$this->assertStringContainsString('fa-solid fa-check', $cell, 'existing feed must render the checkmark icon');
+		$this->assertStringNotContainsString(
+			'fa-solid fa-plus-circle',
+			$cell,
+			'existing feed must NOT render the add icon even when its header is in feed_alt_selected'
+		);
+	}
+
+	// Contrast case: a feed with no existing alias/row match at all renders the
+	// "add feed" icon -- pins the OTHER side of the :489 guard (empty($icon) TRUE),
+	// and that the refactored url_compare() call site does not clobber $icon with an
+	// empty return value on a non-match.
+	public function testNewFeedNoAlternatesRendersAddIcon(): void
+	{
+		$url  = 'https://example.test/pin-new/list.txt';
+		$feed = $this->buildFeed('PinFeedNew', $url, 'https://example.test/pin-new/');
+		$info = ['PinAlias3' => ['action' => 'permit', 'info' => 'Pin alias info', 'feeds' => [$feed]]];
+		$exFeeds = [[
+			'aliasname' => 'OtherAlias',
+			'action'    => 'permit',
+			'state'     => 'Enabled',
+			'url'       => 'https://example.test/unrelated/other.txt',
+			'header'    => 'OtherHeader',
+			'rowid'     => 301,
+		]];
+
+		$cell = $this->iconCellForRow($this->renderType('ipv4', $info, $exFeeds), $url);
+
+		$this->assertStringContainsString('fa-solid fa-plus-circle', $cell, 'a feed with no existing alias match must render the add icon');
+		$this->assertStringNotContainsString('fa-solid fa-check', $cell, 'a feed with no existing alias match must NOT render the checkmark icon');
+	}
+}


### PR DESCRIPTION
## Summary

- `url_compare()` (`src/usr/local/www/pfblockerng/pfblockerng_feeds.php`) now **returns**
  the matched-feed icon markup for its `$alternate = FALSE` call instead of mutating
  `global $icon` from inside a sibling-function call. `pfb_feeds_render_predefined_type()`
  assigns the return value to `$icon` exactly where the function used to assign it
  directly (`if (!empty($row_icon)) { $icon = $row_icon; }`).
- Removed the three now-resolved `empty.variable` entries in `phpstan-baseline.neon` for
  this file — the dataflow is now visible inside a single function's control flow, so
  PHPStan no longer reports the three `empty($icon)` guards (`:452`, `:460`, `:489`) as
  always-true dead code.
- This is a **behaviour-preserving** refactor. Per the issue's ESCALATE evidence comment,
  the three guards are load-bearing: they stop an already-existing "feed added to an
  alias" checkmark from being clobbered by the "add feed" icon. No rendering change, no
  guard removed — only the `$icon` dataflow's visibility to static analysis changed.

## Coverage matrix

Every `url_compare()` call site and every `$icon` read/write in the file (from grep),
ticked:

| Line (pre-refactor) | What | Disposition |
| --- | --- | --- |
| `:208` `global $ex_feeds, $alt_feeds, $icon;` | declaration | `$icon` dropped from the `global` statement; `$ex_feeds`/`$alt_feeds` untouched |
| `:267` `$icon = $x_icon;` | write | replaced by `return $x_icon;` at the function's end; the `if (!$alternate)` branch that gated it is now `if ($alternate)` guarding only the `$alt_feeds` mutation |
| `:295-296` comment ("the state shared with url_compare ($ex_feeds, $alt_feeds, $icon)...") | doc | updated: `$icon` is now assigned from the return value, not a shared global mutation |
| `:300` `global $ex_feeds, $alt_feeds, $icon, $fconfig, $feed_alt_selected;` | declaration | unchanged — `pfb_feeds_render_predefined_type()` still owns `$icon` at page scope |
| `:316` `$status = $icon = '';` | write (reset) | unchanged — local per-feed reset, unrelated to the cross-function mutation |
| `:346-347` `url_compare(..., FALSE, ...)` (non-alternate call) | call site | now captures the return value into `$row_icon` and assigns `$icon = $row_icon` only when non-empty — byte-identical net effect to the old `if (!empty($x_icon)) { if (!$alternate) { $icon = $x_icon; } }` |
| `:352-354` `url_compare(..., TRUE, ...)` (alternate call) | call site | unchanged — return value is unused, exactly as `$icon` was never touched by this call before (gated by `!$alternate`, always false here) |
| `:452` `if (in_array(...) && empty($icon))` | read (guard) | unchanged code; now genuinely evaluated against a value PHPStan can trace within one function — pinned GREEN/FAIL by `testExistingFeedWithAlternatesSelectedRendersCheckmarkNotAddIcon` |
| `:460` `elseif (empty($icon))` | read (guard) | unchanged code; reachable/exercised in the has-alternates render path (not independently pinned by a dedicated unit test — covered by the Tier-A `ui_render` real-catalogue page load) |
| `:471` `$icon = ...` (add icon) | write | unchanged |
| `:489` `if (empty($icon))` | read (guard) | unchanged code; both directions pinned — `testExistingFeedNoAlternatesRendersCheckmarkNotAddIcon` (icon pre-set, guard skips) and `testNewFeedNoAlternatesRendersAddIcon` (icon empty, guard assigns) |
| `:490` `$icon = ...` (add icon) | write | unchanged |
| `:508` `$icon = $alt_feed['icon'];` | write | unchanged — reads from `$alt_feeds`, itself populated by `url_compare()`'s untouched `$alternate = TRUE` branch |
| `:512` `if (empty($icon))` | read (guard) | unchanged — was never PHPStan-flagged (the assignment at `:508` is visible to PHPStan within the same function) |
| `:513` `$icon = ...` (add icon) | write | unchanged |
| `:593` `<td><?=$icon;?></td>` | read (render) | unchanged |

Tier-A `ui_render` coverage for the Feeds page already exists (test mandate #4 — verified,
not added): `tests/smoke/ui/test_render_smoke.py` probes
`/pfblockerng/pfblockerng_feeds.php?type=ipv4|ipv6|dnsbl` (the `feeds_ipv4`/`feeds_ipv6`/
`feeds_dnsbl` `Page(...)` entries).

## Test plan

Off-appliance PHPUnit render pins (`tests/php/FeedsUrlCompareIconRenderTest.php`, loaded
via the eval-extraction helper `tests/php/FeedsPredefinedTypeLoader.php` — same pattern as
`AlertsPageLoader.php`), authored and frozen GREEN against the pre-refactor code, then
re-run GREEN unchanged against the refactor:

- `testExistingFeedNoAlternatesRendersCheckmarkNotAddIcon` — ESCALATE-comment Scenario 1
  (existing alias match, no alternates, guard `:489`): checkmark renders, add-icon does not.
- `testExistingFeedWithAlternatesSelectedRendersCheckmarkNotAddIcon` — ESCALATE-comment
  Scenario 2 (existing alias match + a matching alternate URL, primary header pre-selected
  in `$feed_alt_selected`, guard `:452`): checkmark still renders despite
  `in_array($feed['header'], $feed_alt_selected)` being true — this is the acceptance
  criteria #3 precedence pin.
- `testNewFeedNoAlternatesRendersAddIcon` — contrast case, no existing match: add-icon
  renders, checkmark does not (pins the other side of the `:489` guard and that the
  refactored call site does not clobber `$icon` with an empty return).

**Pre-refactor GREEN** (`vendor/bin/phpunit --filter FeedsUrlCompareIconRenderTest tests/php`):

```text
...                                                                 3 / 3 (100%)

Time: 00:00.034, Memory: 48.00 MB

OK (3 tests, 12 assertions)
```

**Post-refactor GREEN** (identical, byte-frozen test files —
`git hash-object tests/php/FeedsUrlCompareIconRenderTest.php` =
`76ef0a4eb62c42e82cec4b251e9deaaf5bf29aed`,
`tests/php/FeedsPredefinedTypeLoader.php` = `38977874c9ab63c6b5f70a1ba089793c07dd6806`,
unchanged before/after the refactor commit):

```text
...                                                                 3 / 3 (100%)

Time: 00:00.031, Memory: 48.00 MB

OK (3 tests, 12 assertions)
```

**Guard-precedence FAILS on regression** (acceptance criteria #3 demonstration): a
throwaway, never-committed edit dropping the `empty($icon)` guard terms exactly as the
issue's originally-proposed (and refuted) fix would have — `in_array(...) && empty($icon)`
→ `in_array(...)`, `elseif (empty($icon))` → `else`, `if (empty($icon))` → `if (TRUE)` —
reverted immediately after capturing this output:

```text
F F.                                                                 3 / 3 (100%)

There were 2 failures:

1) FeedsUrlCompareIconRenderTest::testExistingFeedNoAlternatesRendersCheckmarkNotAddIcon
existing feed must render the checkmark icon
Failed asserting that '&emsp;<a href="/pfblockerng/pfblockerng_category_edit.php?type=ipv4&act=add&atype=PinFeedNoAlt"title="Add feed: [ PinFeedNoAlt ]"><i class="fa-solid fa-plus-circle"></i></a></td>
		</tr>' [ASCII](length: 186) contains "fa-solid fa-check" [ASCII](length: 17).

2) FeedsUrlCompareIconRenderTest::testExistingFeedWithAlternatesSelectedRendersCheckmarkNotAddIcon
existing feed must render the checkmark icon
Failed asserting that '&emsp;<a href="/pfblockerng/pfblockerng_category_edit.php?type=ipv4&act=add&atype=PinFeedWithAlt"title="Add feed: [ PinFeedWithAlt ]"><i class="fa-solid fa-plus-circle"></i></a></td>
		</tr>' [ASCII](length: 190) contains "fa-solid fa-check" [ASCII](length: 17).

FAILURES!
Tests: 3, Assertions: 10, Failures: 2.
```

Other gates:

- `composer phpstan` → `[OK] No errors` — zero findings for `pfblockerng_feeds.php` with
  the three `empty.variable` baseline entries removed (confirmed scoped to just this file
  too: `vendor/bin/phpstan analyse ... src/usr/local/www/pfblockerng/pfblockerng_feeds.php`
  → `[OK] No errors`). The file's other three pre-existing baseline entries
  (`parameter.requiredAfterOptional`, two `variable.undefined` for `$p_tr_style`/`$p_type`)
  are untouched — out of this issue's scope.
- `vendor/bin/phpunit tests/php` (full suite) → `Tests: 3686, Assertions: 22231,
  Deprecations: 1, Notices: 1, Skipped: 4` — no failures; the one pre-existing
  deprecation/notice pair (PHP 8.5 `curl_setopt_array()`/`curl_close()`) is unrelated,
  from `DownloadRetryBodyResetTest`.
- `composer phpcs -- --standard=phpcs.xml.dist src/` → clean.
- `scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (php -l × 3, phpunit,
  phpstan, phpcs).
- `.githooks/pre-commit` passed on both commits without `--no-verify`.

Fixes #1330

🤖 Generated with [Claude Code](https://claude.com/claude-code)


no-test-needed: behaviour-preserving refactor of url_compare() dataflow; rendered output is pinned byte-level by the new PHPUnit render tests (FeedsUrlCompareIconRenderTest, clobber-proven failable), and Tier-A ui_render coverage for all three feeds tabs already exists in tests/smoke/ui/test_render_smoke.py — a new ui test would duplicate existing coverage.
