### PR TITLE
pfblockerng: exact-block a 2-label domain that is itself a public suffix

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4284,7 +4284,13 @@ def tld_wildcard_classify(domain: str, tlds: dict[str, dict[str, str]], exclusio
 
     issue #1255: an empty ``tlds`` (TLD-Wildcard OFF, or no oracle staged) forces
     exact DATA for every domain -- defense-in-depth, since the dcnt==2 branch below
-    never consults ``tlds`` (a 2-label name is trivially its own registrable form).
+    never consults ``tlds`` for a NON-suffix 2-label name (trivially its own
+    registrable form).
+
+    issue #1256: a bare 2-label string that is ITSELF a known public suffix
+    (``co.uk``, ``com.br``, ``gov.br``, ...) is the apex of that suffix, not a
+    registrable domain under it -- wildcarding it would block the WHOLE suffix.
+    Decided semantics: exact-block the apex only (DATA), never silently skip it.
     """
     if not tlds:
         return DNSBL_CLASS_DATA, domain
@@ -4303,7 +4309,10 @@ def tld_wildcard_classify(domain: str, tlds: dict[str, dict[str, str]], exclusio
     elif dcnt == 3:
         dfound = _dnsbl_tld_wildcard_search(tlds, tld, dparts, 2, 3) or ""
     elif dcnt == 2:
-        dfound = ".".join(dparts[-2:])
+        candidate = ".".join(dparts[-2:])
+        # issue #1256: the candidate is itself a known public suffix -> its own
+        # apex, not a registrable domain -> exact DATA, not a wildcard ZONE.
+        dfound = "" if candidate in tlds.get(tld, {}) else candidate
 
     # TLD exclusion: whole domain in the exclusion set -> force exact DATA.
     if domain in exclusion:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4282,15 +4282,15 @@ def tld_wildcard_classify(domain: str, tlds: dict[str, dict[str, str]], exclusio
     whose parent is not a known public suffix -> exact DATA; a whole-domain TLD
     exclusion forces exact DATA (transparent, not wildcarded).
 
-    issue #1255: an empty ``tlds`` (TLD-Wildcard OFF, or no oracle staged) forces
-    exact DATA for every domain -- defense-in-depth, since the dcnt==2 branch below
-    never consults ``tlds`` for a NON-suffix 2-label name (trivially its own
-    registrable form).
+    An empty ``tlds`` (TLD-Wildcard OFF, or no oracle staged) returns exact DATA
+    for every domain BEFORE any classification runs (#1255) -- every branch below,
+    including the dcnt==2 suffix check, is oracle-present-only.
 
-    issue #1256: a bare 2-label string that is ITSELF a known public suffix
-    (``co.uk``, ``com.br``, ``gov.br``, ...) is the apex of that suffix, not a
-    registrable domain under it -- wildcarding it would block the WHOLE suffix.
-    Decided semantics: exact-block the apex only (DATA), never silently skip it.
+    A bare 2-label string that is ITSELF a known public suffix (``co.uk``,
+    ``com.br``, ``gov.br``, ...) is the apex of that suffix, not a registrable
+    domain under it -- wildcarding it would block the WHOLE suffix. It
+    exact-blocks the apex only (DATA); it is never wildcarded and never
+    silently skipped (#1256).
     """
     if not tlds:
         return DNSBL_CLASS_DATA, domain
@@ -4310,8 +4310,8 @@ def tld_wildcard_classify(domain: str, tlds: dict[str, dict[str, str]], exclusio
         dfound = _dnsbl_tld_wildcard_search(tlds, tld, dparts, 2, 3) or ""
     elif dcnt == 2:
         candidate = ".".join(dparts[-2:])
-        # issue #1256: the candidate is itself a known public suffix -> its own
-        # apex, not a registrable domain -> exact DATA, not a wildcard ZONE.
+        # A candidate that is itself a known public suffix is the suffix apex,
+        # not a registrable domain -> exact DATA, never a wildcard ZONE (#1256).
         dfound = "" if candidate in tlds.get(tld, {}) else candidate
 
     # TLD exclusion: whole domain in the exclusion set -> force exact DATA.

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -4172,14 +4172,10 @@ class TestAbpWildcardUnaffectedByTldWildcardToggle:
 
 
 class TestTldWildcardClassifyTwoLabelPublicSuffix:
-    """issue #1256: the dcnt==2 branch wildcarded ANY 2-label domain unconditionally,
-    including a domain that is ITSELF a known 2-label public suffix (com.br, co.uk,
-    gov.br, ...) -- wildcarding the suffix itself would block the WHOLE suffix
-    (every registrant under it), not just the one feed entry.
-
-    Decided semantics (the issue's own proposal, "edge to define" resolved): a bare
-    public-suffix feed entry exact-blocks the apex only (DATA) -- it is never
-    silently skipped, and it is never promoted to a wildcard ZONE.
+    """A 2-label domain that is ITSELF a known public suffix (com.br, co.uk,
+    gov.br, ...) exact-blocks the apex only (DATA) -- never silently skipped,
+    never promoted to a wildcard ZONE that would block the WHOLE suffix (every
+    registrant under it). Any other 2-label domain still wildcards (#1256).
     """
 
     # A realistic oracle shape: bare single-label TLDs coexist with 2-label
@@ -4188,7 +4184,7 @@ class TestTldWildcardClassifyTwoLabelPublicSuffix:
     # lines). "xn--p1ai.xn--80asehdb" is a synthetic-but-PSL-shaped (per-label
     # punycode, ADR-08/#914 "xn-- stays iTLD") 2-label suffix -- classify() treats
     # a suffix as an opaque string, so no real PSL entry is needed to pin this.
-    _SUFFIXES = ["com", "net", "org", "co.uk", "com.br", "gov.br", "xn--p1ai.xn--80asehdb"]
+    _SUFFIXES = ["com", "net", "org", "uk", "br", "co.uk", "com.br", "gov.br", "xn--p1ai.xn--80asehdb"]
 
     def _tlds(self) -> dict[str, dict[str, str]]:
         return _dnsbl_load_tld_wildcard_master(self._SUFFIXES, [], [])
@@ -4204,12 +4200,12 @@ class TestTldWildcardClassifyTwoLabelPublicSuffix:
 
     def test_evil_com_two_label_non_suffix_still_wildcards(self) -> None:
         # evil.com is a registrable domain UNDER the "com" suffix, not a suffix
-        # itself -- must still wildcard (the pre-existing, unchanged case).
+        # itself -- it must still wildcard.
         assert tld_wildcard_classify("evil.com", self._tlds(), set()) == (DNSBL_CLASS_ZONE, "evil.com")
 
     def test_three_label_under_two_label_suffix_still_wildcard_registrable(self) -> None:
         # example.co.uk is registrable UNDER co.uk (an actual public suffix) --
-        # the dcnt==3 oracle-search branch is untouched by this fix.
+        # the dcnt==3 oracle search classifies it registrable -> wildcard ZONE.
         assert tld_wildcard_classify("example.co.uk", self._tlds(), set()) == (DNSBL_CLASS_ZONE, "example.co.uk")
 
     def test_sub_domain_under_two_label_suffix_stays_exact(self) -> None:
@@ -4219,10 +4215,8 @@ class TestTldWildcardClassifyTwoLabelPublicSuffix:
         )
 
     def test_oracle_absent_two_label_public_suffix_stays_data(self) -> None:
-        # issue #1255's empty-oracle guard fires FIRST (top-of-function early
-        # return) -- this fix's new dcnt==2 suffix check is never reached, so the
-        # two features compose without conflict (whatever #1255 defined for an
-        # absent oracle is unchanged by this fix).
+        # The empty-oracle guard (#1255) returns exact DATA at the top of the
+        # function, before the dcnt==2 suffix check is ever reached.
         assert tld_wildcard_classify("com.br", {}, set()) == (DNSBL_CLASS_DATA, "com.br")
 
     def test_two_label_punycode_suffix_is_exact_data(self) -> None:
@@ -4235,30 +4229,27 @@ class TestTldWildcardClassifyTwoLabelPublicSuffix:
 
     def test_empty_label_two_label_shape_does_not_false_match(self) -> None:
         # Hostile input: a leading empty label (".uk") is never a real oracle key
-        # (the oracle stores "co.uk", not ".uk") -- must not spuriously match and
-        # suppress a wildcard. Unreachable through the production build() pipeline
-        # (_normalise_verdict rejects an empty label as domain-shape-invalid before
-        # tld_wildcard_classify() is ever called) -- this pins the classifier's own
-        # defensive behaviour when called directly, as the unit tests in this class
-        # do.
+        # (the oracle stores "uk"/"co.uk", not ".uk") -- it must not spuriously
+        # match and suppress a wildcard. Unreachable through the production
+        # build() pipeline (_normalise_verdict rejects an empty label as
+        # domain-shape-invalid first); the classifier stays defensive when
+        # called directly.
         assert tld_wildcard_classify(".uk", self._tlds(), set()) == (DNSBL_CLASS_ZONE, ".uk")
 
     def test_trailing_dot_form_is_not_a_two_label_shape(self) -> None:
-        # Probe: str.split(".") on a trailing-dot domain yields a trailing empty
-        # label, so "com.br." is dcnt==3, not dcnt==2 -- it never reaches this
-        # fix's branch at all (the dcnt==3 oracle search then misses on the empty
-        # tld and falls through to DATA anyway). Also moot in production:
-        # _normalise_verdict() strips the trailing dot (`.strip(".")`) before any
-        # domain reaches tld_wildcard_classify() -- probed here directly since the
-        # pipeline can never hand it a trailing-dot form.
+        # str.split(".") on a trailing-dot domain yields a trailing empty label,
+        # so "com.br." is dcnt==3, not dcnt==2 -- the dcnt==3 oracle search
+        # misses on the empty tld and falls through to DATA. Moot in production:
+        # _normalise_verdict() strips the trailing dot (`.strip(".")`) before
+        # any domain reaches tld_wildcard_classify().
         assert tld_wildcard_classify("com.br.", self._tlds(), set()) == (DNSBL_CLASS_DATA, "com.br.")
 
 
 class TestTldWildcardClassifyTwoLabelPublicSuffixViaBuild:
-    """issue #1256, full build() pipeline proof: a plain feed line reaching
+    """Full build() pipeline coverage (#1256): a plain feed line reaching
     tld_wildcard_classify() via build() is pre-normalised (lower-cased, dot-
     stripped) by _normalise_verdict() BEFORE classification -- so the bare
-    public-suffix exact-DATA fix is case-insensitive end to end without
+    public-suffix exact-DATA behaviour is case-insensitive end to end without
     tld_wildcard_classify() itself needing to normalise its input.
     """
 

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -4169,3 +4169,116 @@ class TestAbpWildcardUnaffectedByTldWildcardToggle:
         assert "evil.com" in result.zone_db, (
             f"||evil.com^ must stay ZONE with a populated oracle (TLD-Wildcard ON), got {sorted(result.zone_db)!r}"
         )
+
+
+class TestTldWildcardClassifyTwoLabelPublicSuffix:
+    """issue #1256: the dcnt==2 branch wildcarded ANY 2-label domain unconditionally,
+    including a domain that is ITSELF a known 2-label public suffix (com.br, co.uk,
+    gov.br, ...) -- wildcarding the suffix itself would block the WHOLE suffix
+    (every registrant under it), not just the one feed entry.
+
+    Decided semantics (the issue's own proposal, "edge to define" resolved): a bare
+    public-suffix feed entry exact-blocks the apex only (DATA) -- it is never
+    silently skipped, and it is never promoted to a wildcard ZONE.
+    """
+
+    # A realistic oracle shape: bare single-label TLDs coexist with 2-label
+    # suffixes, exactly as the real PSL-derived dnsbl_tld ships them (see
+    # tests/fixtures/adr06_golden/tld_master.txt: com/net/org/co.uk on adjacent
+    # lines). "xn--p1ai.xn--80asehdb" is a synthetic-but-PSL-shaped (per-label
+    # punycode, ADR-08/#914 "xn-- stays iTLD") 2-label suffix -- classify() treats
+    # a suffix as an opaque string, so no real PSL entry is needed to pin this.
+    _SUFFIXES = ["com", "net", "org", "co.uk", "com.br", "gov.br", "xn--p1ai.xn--80asehdb"]
+
+    def _tlds(self) -> dict[str, dict[str, str]]:
+        return _dnsbl_load_tld_wildcard_master(self._SUFFIXES, [], [])
+
+    def test_com_br_bare_suffix_is_exact_data(self) -> None:
+        assert tld_wildcard_classify("com.br", self._tlds(), set()) == (DNSBL_CLASS_DATA, "com.br")
+
+    def test_co_uk_bare_suffix_is_exact_data(self) -> None:
+        assert tld_wildcard_classify("co.uk", self._tlds(), set()) == (DNSBL_CLASS_DATA, "co.uk")
+
+    def test_gov_br_bare_suffix_is_exact_data(self) -> None:
+        assert tld_wildcard_classify("gov.br", self._tlds(), set()) == (DNSBL_CLASS_DATA, "gov.br")
+
+    def test_evil_com_two_label_non_suffix_still_wildcards(self) -> None:
+        # evil.com is a registrable domain UNDER the "com" suffix, not a suffix
+        # itself -- must still wildcard (the pre-existing, unchanged case).
+        assert tld_wildcard_classify("evil.com", self._tlds(), set()) == (DNSBL_CLASS_ZONE, "evil.com")
+
+    def test_three_label_under_two_label_suffix_still_wildcard_registrable(self) -> None:
+        # example.co.uk is registrable UNDER co.uk (an actual public suffix) --
+        # the dcnt==3 oracle-search branch is untouched by this fix.
+        assert tld_wildcard_classify("example.co.uk", self._tlds(), set()) == (DNSBL_CLASS_ZONE, "example.co.uk")
+
+    def test_sub_domain_under_two_label_suffix_stays_exact(self) -> None:
+        assert tld_wildcard_classify("sub.example.co.uk", self._tlds(), set()) == (
+            DNSBL_CLASS_DATA,
+            "sub.example.co.uk",
+        )
+
+    def test_oracle_absent_two_label_public_suffix_stays_data(self) -> None:
+        # issue #1255's empty-oracle guard fires FIRST (top-of-function early
+        # return) -- this fix's new dcnt==2 suffix check is never reached, so the
+        # two features compose without conflict (whatever #1255 defined for an
+        # absent oracle is unchanged by this fix).
+        assert tld_wildcard_classify("com.br", {}, set()) == (DNSBL_CLASS_DATA, "com.br")
+
+    def test_two_label_punycode_suffix_is_exact_data(self) -> None:
+        # Unicode/xn-- 2-label suffixes are opaque strings to the classifier --
+        # no ASCII-only special-casing exists or is needed.
+        assert tld_wildcard_classify("xn--p1ai.xn--80asehdb", self._tlds(), set()) == (
+            DNSBL_CLASS_DATA,
+            "xn--p1ai.xn--80asehdb",
+        )
+
+    def test_empty_label_two_label_shape_does_not_false_match(self) -> None:
+        # Hostile input: a leading empty label (".uk") is never a real oracle key
+        # (the oracle stores "co.uk", not ".uk") -- must not spuriously match and
+        # suppress a wildcard. Unreachable through the production build() pipeline
+        # (_normalise_verdict rejects an empty label as domain-shape-invalid before
+        # tld_wildcard_classify() is ever called) -- this pins the classifier's own
+        # defensive behaviour when called directly, as the unit tests in this class
+        # do.
+        assert tld_wildcard_classify(".uk", self._tlds(), set()) == (DNSBL_CLASS_ZONE, ".uk")
+
+    def test_trailing_dot_form_is_not_a_two_label_shape(self) -> None:
+        # Probe: str.split(".") on a trailing-dot domain yields a trailing empty
+        # label, so "com.br." is dcnt==3, not dcnt==2 -- it never reaches this
+        # fix's branch at all (the dcnt==3 oracle search then misses on the empty
+        # tld and falls through to DATA anyway). Also moot in production:
+        # _normalise_verdict() strips the trailing dot (`.strip(".")`) before any
+        # domain reaches tld_wildcard_classify() -- probed here directly since the
+        # pipeline can never hand it a trailing-dot form.
+        assert tld_wildcard_classify("com.br.", self._tlds(), set()) == (DNSBL_CLASS_DATA, "com.br.")
+
+
+class TestTldWildcardClassifyTwoLabelPublicSuffixViaBuild:
+    """issue #1256, full build() pipeline proof: a plain feed line reaching
+    tld_wildcard_classify() via build() is pre-normalised (lower-cased, dot-
+    stripped) by _normalise_verdict() BEFORE classification -- so the bare
+    public-suffix exact-DATA fix is case-insensitive end to end without
+    tld_wildcard_classify() itself needing to normalise its input.
+    """
+
+    def _build(self, raw_lines: list[str]) -> pfb_unbound.BuildResult:
+        manifest = {"feeds": [{"raw": "f.raw", "feed": "F", "group": "G", "log_flag": "1"}]}
+        config: dict[str, object] = {
+            "tld_wildcard_master": ["com", "net", "org", "co.uk", "com.br", "gov.br"],
+            "tld_wildcard_blacklist": [],
+            "tld_wildcard_exclusion": [],
+            "user_whitelist": [],
+            "top1m_list": [],
+        }
+        return pfb_unbound.build(manifest, config, line_reader=lambda raw: raw_lines)
+
+    def test_mixed_case_bare_suffix_feed_line_is_exact_not_wildcarded(self) -> None:
+        result = self._build(["COM.BR"])
+        assert "com.br" in result.data_db, "COM.BR must classify as exact DATA (case-insensitive)"
+        assert "com.br" not in result.zone_db
+
+    def test_mixed_case_registrable_feed_line_still_wildcards(self) -> None:
+        result = self._build(["EVIL.COM"])
+        assert "evil.com" in result.zone_db, "EVIL.COM must still wildcard (unchanged, case-insensitive)"
+        assert "evil.com" not in result.data_db


### PR DESCRIPTION
## Summary

- `tld_wildcard_classify()`'s `dcnt == 2` branch (`pfb_unbound.py`) wildcard-blocked
  **any** 2-label domain unconditionally, including one that is itself a known
  2-label public suffix (`com.br`, `co.uk`, `gov.br`, ...). Wildcarding the suffix
  itself would block the whole suffix (every registrant under it), not just the
  one feed entry.
- Fix: when the 2-label candidate is itself present in the public-suffix oracle
  (`tlds`, already loaded for the `dcnt == 3..5` branches), classify it as exact
  `DATA` instead of promoting it to a wildcard `ZONE`. A non-suffix 2-label name
  (`evil.com`) is unaffected and still wildcards.

## Semantics decision (the issue's "edge to define", resolved)

Per the issue's own proposal: a bare public-suffix feed entry **exact-blocks the
apex only** (`DATA`) — it is never silently skipped, and never promoted to a
wildcard `ZONE`. This composes with #1255's oracle-presence gate unmodified: an
absent/empty oracle still forces `DATA` for every domain via the existing
top-of-function early return, so this fix's new suffix check is only reached
when the oracle is present.

## PHP mirror — investigated, no change (site retired)

The packet named a PHP mirror at `pfblockerng.inc` `tld_analysis()` (~`:8583`).
That function **no longer exists** — ADR-65 ("DNSBL manifest single source")
fully retired PHP's TLD-classification pass; the Python manifest `build()` is
now the sole DNSBL classifier. This is enforced by an existing regression test
(`tests/php/DnsblPlaintextSummaryRetirementTest.php`) that fails if
`function tld_analysis(` ever reappears in `pfblockerng.inc` /
`pfblockerng_install.inc`. Grepping both languages for every
`dcnt`/label-count/`dnsbl_tld`-oracle consumer confirms `tld_wildcard_classify()`
(called once, from `build()`) is the **only** classification site in the whole
codebase — there is nothing left to mirror.

## Coverage matrix

| Row | Result | Test |
| --- | --- | --- |
| `com.br` NOT wildcarded | DATA | `test_com_br_bare_suffix_is_exact_data` |
| `co.uk` NOT wildcarded | DATA | `test_co_uk_bare_suffix_is_exact_data` |
| `gov.br` NOT wildcarded | DATA | `test_gov_br_bare_suffix_is_exact_data` |
| `evil.com` STILL wildcarded (2-label non-suffix) | ZONE | `test_evil_com_two_label_non_suffix_still_wildcards` |
| `example.co.uk` (3-label) still wildcard-registrable | ZONE | `test_three_label_under_two_label_suffix_still_wildcard_registrable` |
| `sub.example.co.uk` still exact | DATA | `test_sub_domain_under_two_label_suffix_stays_exact` |
| Oracle-ABSENT path unchanged (#1255) | DATA | `test_oracle_absent_two_label_public_suffix_stays_data` |
| Case-insensitivity (`COM.BR`) | DATA (via full `build()` pipeline — `_normalise_verdict()` lower-cases before `tld_wildcard_classify()` is ever called) | `test_mixed_case_bare_suffix_feed_line_is_exact_not_wildcarded` |
| Case-insensitivity control (`EVIL.COM` still wildcards) | ZONE | `test_mixed_case_registrable_feed_line_still_wildcards` |
| Unicode/punycode 2-label suffix (`xn--` form) | DATA | `test_two_label_punycode_suffix_is_exact_data` |
| Hostile: empty label (`.uk`) does not false-match | ZONE (unchanged, no spurious match) | `test_empty_label_two_label_shape_does_not_false_match` |
| Trailing-dot form (probed) | Never reaches the `dcnt==2` branch — `.split(".")` makes it `dcnt==3`; also unreachable in production since `_normalise_verdict()` strips the trailing dot first | `test_trailing_dot_form_is_not_a_two_label_shape` |
| PHP mirror | Retired by ADR-65; not off-appliance testable because the function no longer exists — justified deferral, see above | n/a (regression pinned by `tests/php/DnsblPlaintextSummaryRetirementTest.php`) |

## Red -> green proof

Test file frozen at RED (before any production edit):
```
$ git hash-object tests/test_pfb_unbound.py
0a17258bdb714beec89d237e95bb6916386e5261
```

RED run (before the fix) — 5 failed on the new-behaviour rows, 7 passed on the
unaffected-behaviour rows:
```
FAILED tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_com_br_bare_suffix_is_exact_data - AssertionError: assert ('zone', 'com.br') == ('data', 'com.br')
FAILED tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_co_uk_bare_suffix_is_exact_data - AssertionError: assert ('zone', 'co.uk') == ('data', 'co.uk')
FAILED tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_gov_br_bare_suffix_is_exact_data - AssertionError: assert ('zone', 'gov.br') == ('data', 'gov.br')
FAILED tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_two_label_punycode_suffix_is_exact_data - AssertionError: assert ('zone', 'xn--p1ai.xn--80asehdb') == ('data', 'xn--p1ai.xn--80asehdb')
FAILED tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffixViaBuild::test_mixed_case_bare_suffix_feed_line_is_exact_not_wildcarded - AssertionError: COM.BR must classify as exact DATA (case-insensitive)
================= 5 failed, 7 passed, 302 deselected in 0.42s ==================
```

Test file after fix, confirmed byte-identical to the RED freeze:
```
$ git hash-object tests/test_pfb_unbound.py
0a17258bdb714beec89d237e95bb6916386e5261
```

GREEN run (after the production fix, test file unchanged):
```
tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_com_br_bare_suffix_is_exact_data PASSED
tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_co_uk_bare_suffix_is_exact_data PASSED
tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_gov_br_bare_suffix_is_exact_data PASSED
tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_evil_com_two_label_non_suffix_still_wildcards PASSED
tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_three_label_under_two_label_suffix_still_wildcard_registrable PASSED
tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_sub_domain_under_two_label_suffix_stays_exact PASSED
tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_oracle_absent_two_label_public_suffix_stays_data PASSED
tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_two_label_punycode_suffix_is_exact_data PASSED
tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_empty_label_two_label_shape_does_not_false_match PASSED
tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffix::test_trailing_dot_form_is_not_a_two_label_shape PASSED
tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffixViaBuild::test_mixed_case_bare_suffix_feed_line_is_exact_not_wildcarded PASSED
tests/test_pfb_unbound.py::TestTldWildcardClassifyTwoLabelPublicSuffixViaBuild::test_mixed_case_registrable_feed_line_still_wildcards PASSED
====================== 12 passed, 302 deselected in 0.05s ======================
```

Full suites green after the fix (post-rebase onto latest `origin/devel`):
- `tests/test_pfb_unbound.py`: 314 passed
- Full Python suite (`tests/`, excluding php/smoke/js): 3208 passed, 4 skipped (unrelated)
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS (pytest, ruff check, ruff format --check, mypy)

## Config

No new/changed config fields — the fix consumes the existing `tld_wildcard_master`
oracle already loaded and threaded through `PfbConfig`.

Fixes #1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected DNS filtering for two-label public suffixes such as `co.uk`, `com.br`, and `gov.br`.
  * Bare public suffixes are now blocked exactly, without unintentionally wildcarding related domains.
  * Preserved wildcard behavior for registrable domains and subdomains.
  * Improved handling of mixed-case entries, punycode suffixes, trailing dots, and malformed inputs.

* **Tests**
  * Added coverage for suffix classification and complete feed-processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->