### PR TITLE
pfblockerng: generalize suffix-apex protection past the 2-label case

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4284,13 +4284,17 @@ def tld_wildcard_classify(domain: str, tlds: dict[str, dict[str, str]], exclusio
 
     An empty ``tlds`` (TLD-Wildcard OFF, or no oracle staged) returns exact DATA
     for every domain BEFORE any classification runs (#1255) -- every branch below,
-    including the dcnt==2 suffix check, is oracle-present-only.
+    including the suffix-apex check, is oracle-present-only.
 
-    A bare 2-label string that is ITSELF a known public suffix (``co.uk``,
-    ``com.br``, ``gov.br``, ...) is the apex of that suffix, not a registrable
-    domain under it -- wildcarding it would block the WHOLE suffix. It
-    exact-blocks the apex only (DATA); it is never wildcarded and never
-    silently skipped (#1256).
+    A domain that is ITSELF a known public suffix, at ANY label count
+    (``co.uk``, ``com.br``, ``act.edu.au``, ``pvt.k12.ma.us``, ...) is the apex
+    of that suffix, not a registrable domain under it -- wildcarding it would
+    block the WHOLE suffix (every registrant under it). It exact-blocks the
+    apex only (DATA); it is never wildcarded and never silently skipped.
+    Checked once, ahead of the dcnt dispatch below, so this subsumes what was
+    originally a dcnt==2-only special case (#1256) -- the identical bug class
+    recurred one level deeper at dcnt==3..5 (#1476: e.g. ``act.edu.au``
+    blanket-wildcarding ``*.act.edu.au``).
     """
     if not tlds:
         return DNSBL_CLASS_DATA, domain
@@ -4300,7 +4304,12 @@ def tld_wildcard_classify(domain: str, tlds: dict[str, dict[str, str]], exclusio
     tld = dparts[-1]
     dfound = ""
 
-    if dcnt > 5:
+    if domain in tlds.get(tld, {}):
+        # The domain is itself a known public suffix -- its own apex, not a
+        # registrable name under it -> exact DATA, never a wildcard ZONE
+        # (#1256, generalized to every label count by #1476).
+        dfound = ""
+    elif dcnt > 5:
         dfound = ""
     elif dcnt == 5:
         dfound = _dnsbl_tld_wildcard_search(tlds, tld, dparts, 4, 5) or ""
@@ -4309,10 +4318,7 @@ def tld_wildcard_classify(domain: str, tlds: dict[str, dict[str, str]], exclusio
     elif dcnt == 3:
         dfound = _dnsbl_tld_wildcard_search(tlds, tld, dparts, 2, 3) or ""
     elif dcnt == 2:
-        candidate = ".".join(dparts[-2:])
-        # A candidate that is itself a known public suffix is the suffix apex,
-        # not a registrable domain -> exact DATA, never a wildcard ZONE (#1256).
-        dfound = "" if candidate in tlds.get(tld, {}) else candidate
+        dfound = domain
 
     # TLD exclusion: whole domain in the exclusion set -> force exact DATA.
     if domain in exclusion:

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -4273,3 +4273,180 @@ class TestTldWildcardClassifyTwoLabelPublicSuffixViaBuild:
         result = self._build(["EVIL.COM"])
         assert "evil.com" in result.zone_db, "EVIL.COM must still wildcard (unchanged, case-insensitive)"
         assert "evil.com" not in result.data_db
+
+
+class TestTldWildcardClassifyMultiLabelPublicSuffix:
+    """issue #1476: the dcnt==2-only bare-suffix protection added by #1256/#1475
+    wildcarded a bare N-label feed entry (N=3..5) that is ITSELF a public suffix
+    whenever its (N-1)-label parent is ALSO a known suffix -- the identical bug
+    class recurred one level deeper (e.g. ``act.edu.au`` blanket-wildcarding
+    ``*.act.edu.au``). The apex-protection check is generalized to fire at ANY
+    label count, ahead of the dcnt dispatch -- subsuming the old dcnt==2 special
+    case rather than living alongside it.
+
+    All suffix chains below are REAL entries from the shipped oracle
+    (src/usr/local/pkg/pfblockerng/dnsbl_tld) except the 5-label chain -- the
+    real oracle ships zero 4-dot (5-label) suffix lines as of #1476, so that one
+    is synthetic but PSL-shaped: one level deeper than the real
+    edu.au/act.edu.au and k12.ma.us/pvt.k12.ma.us nesting used below.
+    """
+
+    _SUFFIXES = [
+        "com",
+        "net",
+        "org",
+        # Real oracle: au -> edu.au -> act.edu.au / nsw.edu.au (3-label suffixes,
+        # each with its 2-label parent ALSO a suffix -- the dcnt==3 bug shape).
+        "au",
+        "edu.au",
+        "act.edu.au",
+        "nsw.edu.au",
+        # Real oracle: us -> ma.us -> k12.ma.us -> pvt.k12.ma.us (4-label
+        # suffix, whose 3-label parent k12.ma.us is ALSO a suffix -- the
+        # dcnt==4 bug shape; issue #1476's own evidence).
+        "us",
+        "ma.us",
+        "k12.ma.us",
+        "pvt.k12.ma.us",
+        # Synthetic PSL-shaped 5-label suffix ("e.d.c.b.psltest") whose
+        # 4-label parent ("d.c.b.psltest") is ALSO a suffix -- the dcnt==5 bug
+        # shape, no real 5-label suffix ships to pin this with real data.
+        "d.c.b.psltest",
+        "e.d.c.b.psltest",
+        # Synthetic PSL-shaped 3-label punycode suffix ("xn--a1.xn--b2.xn--c3")
+        # whose 2-label parent ("xn--b2.xn--c3") is ALSO a suffix -- same
+        # dcnt==3 bug shape as act.edu.au, opaque-punycode hostile row.
+        "xn--b2.xn--c3",
+        "xn--a1.xn--b2.xn--c3",
+    ]
+
+    def _tlds(self) -> dict[str, dict[str, str]]:
+        return _dnsbl_load_tld_wildcard_master(self._SUFFIXES, [], [])
+
+    # ---- bare N-label suffix apex -> exact DATA, one row per dcnt branch ---- #
+
+    def test_three_label_real_suffix_apex_is_exact_data(self) -> None:
+        # act.edu.au is itself a public suffix (real oracle); its parent
+        # edu.au is ALSO a suffix -- the pre-#1476 dcnt==3 branch wildcarded it.
+        assert tld_wildcard_classify("act.edu.au", self._tlds(), set()) == (DNSBL_CLASS_DATA, "act.edu.au"), (
+            f"expected {(DNSBL_CLASS_DATA, 'act.edu.au')!r}, got "
+            f"{tld_wildcard_classify('act.edu.au', self._tlds(), set())!r}"
+        )
+
+    def test_three_label_real_suffix_apex_is_exact_data_second_entry(self) -> None:
+        assert tld_wildcard_classify("nsw.edu.au", self._tlds(), set()) == (DNSBL_CLASS_DATA, "nsw.edu.au"), (
+            f"expected {(DNSBL_CLASS_DATA, 'nsw.edu.au')!r}, got "
+            f"{tld_wildcard_classify('nsw.edu.au', self._tlds(), set())!r}"
+        )
+
+    def test_four_label_real_suffix_apex_is_exact_data(self) -> None:
+        # pvt.k12.ma.us is itself a public suffix (real oracle); its parent
+        # k12.ma.us is ALSO a suffix -- the pre-#1476 dcnt==4 branch wildcarded
+        # it (issue #1476's own pasted evidence: -> ('zone', 'pvt.k12.ma.us')).
+        assert tld_wildcard_classify("pvt.k12.ma.us", self._tlds(), set()) == (
+            DNSBL_CLASS_DATA,
+            "pvt.k12.ma.us",
+        ), (
+            f"expected {(DNSBL_CLASS_DATA, 'pvt.k12.ma.us')!r}, got "
+            f"{tld_wildcard_classify('pvt.k12.ma.us', self._tlds(), set())!r}"
+        )
+
+    def test_five_label_synthetic_suffix_apex_is_exact_data(self) -> None:
+        # Synthetic PSL-shaped 5-label suffix whose 4-label parent is ALSO a
+        # suffix -- the pre-#1476 dcnt==5 branch would wildcard it, same bug
+        # class one level deeper still (no real 5-label suffix to pin instead).
+        assert tld_wildcard_classify("e.d.c.b.psltest", self._tlds(), set()) == (
+            DNSBL_CLASS_DATA,
+            "e.d.c.b.psltest",
+        ), (
+            f"expected {(DNSBL_CLASS_DATA, 'e.d.c.b.psltest')!r}, got "
+            f"{tld_wildcard_classify('e.d.c.b.psltest', self._tlds(), set())!r}"
+        )
+
+    def test_three_label_punycode_suffix_apex_is_exact_data(self) -> None:
+        # Punycode/xn-- multi-label suffix, same dcnt==3 bug shape as
+        # act.edu.au (2-label parent also a suffix) -- opaque-string hostile
+        # row: no ASCII-only special-casing exists or is needed.
+        assert tld_wildcard_classify("xn--a1.xn--b2.xn--c3", self._tlds(), set()) == (
+            DNSBL_CLASS_DATA,
+            "xn--a1.xn--b2.xn--c3",
+        ), (
+            f"expected {(DNSBL_CLASS_DATA, 'xn--a1.xn--b2.xn--c3')!r}, got "
+            f"{tld_wildcard_classify('xn--a1.xn--b2.xn--c3', self._tlds(), set())!r}"
+        )
+
+    # ---- registrable name UNDER a known suffix -> still wildcard ZONE ------- #
+
+    def test_four_label_registrable_under_three_label_suffix_still_wildcards(self) -> None:
+        # example.act.edu.au is registrable UNDER the real 3-label suffix
+        # act.edu.au -- the dcnt==4 oracle search classifies it registrable ->
+        # wildcard ZONE, untouched by the generalized apex check.
+        assert tld_wildcard_classify("example.act.edu.au", self._tlds(), set()) == (
+            DNSBL_CLASS_ZONE,
+            "example.act.edu.au",
+        )
+
+    def test_five_label_registrable_under_four_label_suffix_still_wildcards(self) -> None:
+        # sub.pvt.k12.ma.us is registrable UNDER the real 4-label suffix
+        # pvt.k12.ma.us -- exercises the dcnt==5 oracle-search ZONE side with
+        # real data (complements the synthetic apex-DATA row above).
+        assert tld_wildcard_classify("sub.pvt.k12.ma.us", self._tlds(), set()) == (
+            DNSBL_CLASS_ZONE,
+            "sub.pvt.k12.ma.us",
+        )
+
+    def test_sub_domain_under_registrable_name_stays_exact(self) -> None:
+        # sub.example.act.edu.au is two levels below the suffix apex -- its
+        # 4-label truncation (example.act.edu.au) is not itself a known
+        # suffix, so it stays exact DATA (unchanged).
+        assert tld_wildcard_classify("sub.example.act.edu.au", self._tlds(), set()) == (
+            DNSBL_CLASS_DATA,
+            "sub.example.act.edu.au",
+        )
+
+    # ---- unchanged controls -------------------------------------------------- #
+
+    def test_dcnt_greater_than_five_stays_unclassified_data(self) -> None:
+        # 6-label name under the real au suffix chain -- dcnt>5 is never
+        # classified (unconditional dfound="" branch), unchanged by #1476.
+        domain = "another.sub.example.act.edu.au"
+        assert tld_wildcard_classify(domain, self._tlds(), set()) == (DNSBL_CLASS_DATA, domain)
+
+    def test_oracle_absent_multi_label_suffix_apex_stays_data(self) -> None:
+        # The empty-oracle guard (#1255) returns exact DATA at the top of the
+        # function, before the generalized apex check is ever reached.
+        assert tld_wildcard_classify("act.edu.au", {}, set()) == (DNSBL_CLASS_DATA, "act.edu.au")
+
+    def test_exclusion_and_oracle_apex_agree_on_data(self) -> None:
+        # act.edu.au is in BOTH the oracle (as a suffix apex) AND the
+        # exclusion set -- the two mechanisms must agree, never conflict:
+        # still DATA either way.
+        assert tld_wildcard_classify("act.edu.au", self._tlds(), {"act.edu.au"}) == (
+            DNSBL_CLASS_DATA,
+            "act.edu.au",
+        )
+
+    # ---- hostile shapes ------------------------------------------------------- #
+
+    def test_leading_empty_label_three_label_suffix_shape_does_not_false_match(self) -> None:
+        # Hostile input: a leading empty label on the 3-label suffix
+        # act.edu.au (".act.edu.au") is dcnt==4, not dcnt==3, and its own
+        # domain string is never a literal oracle key (the oracle stores
+        # "act.edu.au", not ".act.edu.au") -- the generalized apex check must
+        # not spuriously match. It falls through to the dcnt==4 oracle search,
+        # whose 3-label truncation ("act.edu.au") IS the real suffix -> still
+        # classifies as a wildcard ZONE (same pattern as the pre-existing
+        # 2-label ".uk" pin) -- unreachable in production (_normalise_verdict
+        # rejects an empty label first).
+        assert tld_wildcard_classify(".act.edu.au", self._tlds(), set()) == (
+            DNSBL_CLASS_ZONE,
+            ".act.edu.au",
+        )
+
+    def test_trailing_dot_three_label_suffix_form_is_not_a_three_label_shape(self) -> None:
+        # str.split(".") on a trailing-dot domain yields a trailing empty
+        # label, so "act.edu.au." is dcnt==4, not dcnt==3 -- the dcnt==4
+        # oracle search misses on the empty tld and falls through to DATA.
+        # Moot in production: _normalise_verdict() strips the trailing dot
+        # before any domain reaches tld_wildcard_classify().
+        assert tld_wildcard_classify("act.edu.au.", self._tlds(), set()) == (DNSBL_CLASS_DATA, "act.edu.au.")


### PR DESCRIPTION
## Summary

PR #1475 (issue #1256) stopped `tld_wildcard_classify()` from wildcarding a bare 2-label
domain that is itself a public suffix, but the check was hardcoded to `dcnt == 2`. The
identical bug survives one level deeper: a bare N-label feed entry (N=3..5) that is ITSELF a
public suffix still wildcards whenever its (N-1)-label parent is also a known suffix,
blanket-blocking every registrant under it. Confirmed against the real shipped oracle
(`src/usr/local/pkg/pfblockerng/dnsbl_tld`):

```
act.edu.au               in-oracle=True  -> ('zone', 'act.edu.au')   # was wrong, now DATA
pvt.k12.ma.us             in-oracle=True  -> ('zone', 'pvt.k12.ma.us')  # was wrong, now DATA
```

## What changed

`src/usr/local/pkg/pfblockerng/pfb_unbound.py` — `tld_wildcard_classify()`: replaced the
`dcnt == 2`-only suffix-apex check with one generalized check ahead of the `dcnt` dispatch —
`if domain in tlds.get(tld, {})` — that fires at ANY label count. Docstring updated to
describe the generalized behaviour and cross-reference both #1256 and #1476.

### `dcnt == 2` special case: REPLACE, not keep alongside

The old `dcnt == 2` branch computed `candidate = ".".join(dparts[-2:])`, which for a 2-label
domain is always the domain itself, then checked `candidate in tlds.get(tld, {})`. The new
generalized check does that exact same lookup (`domain in tlds.get(tld, {})`) once, before the
dispatch — so the `dcnt == 2` branch collapses to `dfound = domain` (the suffix-apex work it
used to do inline is now handled upstream). Keeping both checks would have been two
overlapping mechanisms testing the same condition twice; replacing keeps the docstring and the
control flow coherent, per the issue's fix sketch.

## Coverage matrix

| Row | Test | Oracle |
|---|---|---|
| 3-label real suffix apex (`act.edu.au`) → DATA | `test_three_label_real_suffix_apex_is_exact_data` | real |
| 3-label real suffix apex, 2nd entry (`nsw.edu.au`) → DATA | `test_three_label_real_suffix_apex_is_exact_data_second_entry` | real |
| 4-label real suffix apex (`pvt.k12.ma.us`) → DATA | `test_four_label_real_suffix_apex_is_exact_data` | real |
| 5-label suffix apex → DATA (no real 5-label suffix ships; synthetic PSL-shaped `e.d.c.b.psltest`) | `test_five_label_synthetic_suffix_apex_is_exact_data` | synthetic |
| 3-label punycode suffix apex → DATA (hostile: opaque multi-label punycode, same bug shape) | `test_three_label_punycode_suffix_apex_is_exact_data` | synthetic |
| `example.act.edu.au` (registrable under 3-label suffix) → still ZONE | `test_four_label_registrable_under_three_label_suffix_still_wildcards` | real |
| `sub.pvt.k12.ma.us` (registrable under 4-label suffix) → still ZONE | `test_five_label_registrable_under_four_label_suffix_still_wildcards` | real |
| `sub.example.act.edu.au` (2 levels below apex) → still DATA | `test_sub_domain_under_registrable_name_stays_exact` | real |
| dcnt>5 name → unchanged (never classified) | `test_dcnt_greater_than_five_stays_unclassified_data` | real |
| oracle-absent → unchanged (empty-`tlds` short circuit, #1255) | `test_oracle_absent_multi_label_suffix_apex_stays_data` | n/a |
| exclusion interaction (domain in both oracle and exclusion set) → DATA either way | `test_exclusion_and_oracle_apex_agree_on_data` | real |
| hostile: leading-empty-label form of a 3-label suffix (`.act.edu.au`) → ZONE (unreachable in production, mirrors pre-existing `.uk` pin) | `test_leading_empty_label_three_label_suffix_shape_does_not_false_match` | real |
| hostile: trailing-dot form (`act.edu.au.`) → DATA (unreachable in production) | `test_trailing_dot_three_label_suffix_form_is_not_a_three_label_shape` | real |
| `evil.com` + the #1256 dozen → unchanged | existing `TestTldWildcardClassifyTwoLabelPublicSuffix` (10) + `...ViaBuild` (2) | real |

13 new tests in `TestTldWildcardClassifyMultiLabelPublicSuffix`
(`tests/test_pfb_unbound.py`); all twelve pre-existing #1256/#1475 tests pass unmodified.

## Red → green proof

RED (untouched code, new tests only):

```
tests/test_pfb_unbound.py FFFFF........                                  [100%]
5 failed, 8 passed, 314 deselected in 0.60s

FAILED ...::test_three_label_real_suffix_apex_is_exact_data
  AssertionError: expected ('data', 'act.edu.au'), got ('zone', 'act.edu.au')
FAILED ...::test_three_label_real_suffix_apex_is_exact_data_second_entry
  AssertionError: expected ('data', 'nsw.edu.au'), got ('zone', 'nsw.edu.au')
FAILED ...::test_four_label_real_suffix_apex_is_exact_data
  AssertionError: expected ('data', 'pvt.k12.ma.us'), got ('zone', 'pvt.k12.ma.us')
FAILED ...::test_five_label_synthetic_suffix_apex_is_exact_data
  AssertionError: expected ('data', 'e.d.c.b.psltest'), got ('zone', 'e.d.c.b.psltest')
FAILED ...::test_three_label_punycode_suffix_apex_is_exact_data
  AssertionError: expected ('data', 'xn--a1.xn--b2.xn--c3'), got ('zone', 'xn--a1.xn--b2.xn--c3')
```

Freeze hash (`git hash-object tests/test_pfb_unbound.py`) at RED time:
`e12fcebdb0f5eeb640d4e4da820283cf11757c82`

GREEN (same test file, byte-identical, hash re-verified `e12fcebdb0f5eeb640d4e4da820283cf11757c82`
before the run — production fix applied):

```
tests/test_pfb_unbound.py ..............................                 [100%]
30 passed, 297 deselected in 0.06s
```

Full suite: `3221 passed, 4 skipped` (pre-existing skips, unrelated).
`scripts/agent/run-gates.sh --diff origin/devel`:

```
GATE PASS: python3 -m pytest
GATE PASS: ruff check .
GATE PASS: ruff format --check .
GATE PASS: mypy tests/
GATES: PASS
```

## Related note (not addressed here)

The issue also flagged that a TLD-level `tld_wildcard_exclusion` entry (e.g. `uk`) prunes the
whole TLD subtree from the oracle, silently re-exposing the 2-label wildcard for suffixes
under it — pre-existing behavior, unaffected by this fix, called out as a separate decision
in the issue and left open.

Fixes #1476

🤖 Generated with [Claude Code](https://claude.com/claude-code)
