### PR TITLE
DNSBL: keep staging row kinds enum-typed end to end

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -133,12 +133,13 @@ that consume them, are **unaffected** — they stay the old bare-domain/verbatim
 `.raw` per feed. The final manifest remains readable, self-describing JSON with its existing
 `raw`, `feed`, `group`, `provenance`, `log_flag`, and `mode` fields.
 
-**Emit/parse primitives** (`pfblockerng.inc`): `pfb_dnsbl_ndjson_emit_domain_row()` /
-`pfb_dnsbl_ndjson_emit_abp_row()` are the only writers — `json_encode()` with a **fixed element
-order** (tag, payload), `JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE`, no pretty-printing,
+**Emit/parse primitives** (`pfblockerng.inc`): `pfb_dnsbl_ndjson_emit_row()` is the only
+writer — its typed `PfbDnsblRowKind` argument serializes directly through `json_encode()`
+with a **fixed element order** (tag, payload),
+`JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE`, no pretty-printing,
 exactly one trailing `"\n"`. `pfb_dnsbl_ndjson_parse_row()` is the strict reader every PHP
 consumer shares: it normalizes current compact arrays and accepted legacy objects to the same
-internal `kind` plus `domain`/`raw` shape, and rejects (returns `NULL`) every other shape.
+enum-valued `kind` plus `domain`/`raw` shape, and rejects (returns `NULL`) every other shape.
 
 **Staging-generation guard + lazy rebuild.** The sync loop's verbatim-reuse fork
 (`pfb_dnsbl_verbatim_reuse_active()`) additionally requires the staged `.txt` to be

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -135,8 +135,8 @@ that consume them, are **unaffected** — they stay the old bare-domain/verbatim
 
 **Emit/parse primitives** (`pfblockerng.inc`): `pfb_dnsbl_ndjson_emit_row()` is the only
 writer — its typed `PfbDnsblRowKind` argument serializes directly through `json_encode()`
-with a **fixed element order** (tag, payload),
-`JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE`, no pretty-printing,
+with a **fixed element order** (tag, payload), `JSON_UNESCAPED_SLASHES |`
+`JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE`, no pretty-printing,
 exactly one trailing `"\n"`. `pfb_dnsbl_ndjson_parse_row()` is the strict reader every PHP
 consumer shares: it normalizes current compact arrays and accepted legacy objects to the same
 enum-valued `kind` plus `domain`/`raw` shape, and rejects (returns `NULL`) every other shape.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2159,16 +2159,9 @@ enum PfbDnsblRowKind: string
 	case Abp    = 'a';
 }
 
-function pfb_dnsbl_ndjson_emit_domain_row(string $domain, string $log, string $feed, string $group): string {
+function pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind $kind, string $payload): string {
 	return json_encode(
-		array(PfbDnsblRowKind::Domain->value, $domain),
-		JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
-	) . "\n";
-}
-
-function pfb_dnsbl_ndjson_emit_abp_row(string $raw): string {
-	return json_encode(
-		array(PfbDnsblRowKind::Abp->value, $raw),
+		array($kind, $payload),
 		JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
 	) . "\n";
 }
@@ -2184,27 +2177,34 @@ function pfb_dnsbl_ndjson_parse_row(string $line): ?array {
 			!is_string($row[1]) || $row[1] === '') {
 			return NULL;
 		}
-		return match (PfbDnsblRowKind::tryFrom($row[0])) {
-			PfbDnsblRowKind::Domain => ['kind' => 'domain', 'domain' => $row[1]],
-			PfbDnsblRowKind::Abp    => ['kind' => 'abp', 'raw' => $row[1]],
+		$kind = PfbDnsblRowKind::tryFrom($row[0]);
+		return match ($kind) {
+			PfbDnsblRowKind::Domain => ['kind' => $kind, 'domain' => $row[1]],
+			PfbDnsblRowKind::Abp    => ['kind' => $kind, 'raw' => $row[1]],
 			NULL                     => NULL,
 		};
 	}
 	if (!str_starts_with($trimmed, '{') || !array_key_exists('kind', $row)) {
 		return NULL;
 	}
-	if ($row['kind'] === 'domain') {
-		$required = array('domain', 'log', 'feed', 'group');
-	} elseif ($row['kind'] === 'abp') {
-		$required = array('raw');
-	} else {
+	$kind = match ($row['kind']) {
+		'domain' => PfbDnsblRowKind::Domain,
+		'abp'    => PfbDnsblRowKind::Abp,
+		default  => NULL,
+	};
+	if ($kind === NULL) {
 		return NULL;
 	}
+	$required = match ($kind) {
+		PfbDnsblRowKind::Domain => array('domain', 'log', 'feed', 'group'),
+		PfbDnsblRowKind::Abp    => array('raw'),
+	};
 	foreach ($required as $key) {
 		if (!isset($row[$key]) || !is_string($row[$key]) || $row[$key] === '') {
 			return NULL;
 		}
 	}
+	$row['kind'] = $kind;
 	return $row;
 }
 
@@ -8446,7 +8446,10 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 			if ($row === NULL) {
 				continue;
 			}
-			$raw_line = $row['kind'] === 'abp' ? "{$row['raw']}\n" : "{$row['domain']}\n";
+			$raw_line = match ($row['kind']) {
+				PfbDnsblRowKind::Domain => "{$row['domain']}\n",
+				PfbDnsblRowKind::Abp    => "{$row['raw']}\n",
+			};
 			$written = @fwrite($raw_h, $raw_line);
 			if ($written === FALSE || $written !== strlen($raw_line)) {
 				$raw_ok = FALSE;
@@ -17439,7 +17442,7 @@ function sync_package_pfblockerng($cron='') {
 											// parse_abp() (never a domain/IP/path anchor -> silently
 											// skipped).
 											if (pfb_dnsbl_is_abp_rule_line($line)) {
-												$domain_data = pfb_dnsbl_ndjson_emit_abp_row($line);
+												$domain_data = pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Abp, $line);
 												@fwrite($dhandle, $domain_data);
 												continue;
 											}
@@ -17610,8 +17613,7 @@ function sync_package_pfblockerng($cron='') {
 											}
 
 											// For DNSBL python, save domain and Logging type
-											$domain_data = pfb_dnsbl_ndjson_emit_domain_row(
-												strtolower($line), (string) $logging_type, $header, $alias);
+											$domain_data = pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, strtolower($line));
 											@fwrite($dhandle, $domain_data);
 										}
 									}

--- a/tests/php/DnsblInterchangeRetirementTest.php
+++ b/tests/php/DnsblInterchangeRetirementTest.php
@@ -72,7 +72,7 @@ final class DnsblInterchangeRetirementTest extends TestCase
 
 		file_put_contents(
 			"{$GLOBALS['pfb']['dnsbl_file']}.raw",
-			pfb_dnsbl_ndjson_emit_domain_row('sub.deep.example', '1', 'PlainFeed', 'GroupA')
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, 'sub.deep.example')
 		);
 
 		pfb_dnsbl_tld_stats_finalize([]);

--- a/tests/php/DnsblLineParsingBenchmarkTest.php
+++ b/tests/php/DnsblLineParsingBenchmarkTest.php
@@ -32,8 +32,8 @@ final class DnsblLineParsingBenchmarkTest extends TestCase
 	{
 		$root = dirname(__DIR__, 2);
 		file_put_contents("{$this->tmp}/dnsbl/benchfeed.txt",
-			pfb_dnsbl_ndjson_emit_domain_row('one.example', '1', 'benchfeed', 'grp') .
-			pfb_dnsbl_ndjson_emit_domain_row('two.example', '1', 'benchfeed', 'grp'));
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, 'one.example') .
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, 'two.example'));
 
 		$command = implode(' ', array_map('escapeshellarg', [
 			PHP_BINARY,

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -54,7 +54,7 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 	private function writeFeed(string $domain): void
 	{
 		file_put_contents("{$this->tmp}/dnsbl/feed1.txt",
-			pfb_dnsbl_ndjson_emit_domain_row($domain, '1', 'Feed', 'Group'));
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, $domain));
 	}
 
 	private function publish(array $publicationOps = []): array|false

--- a/tests/php/PfbNdjsonInterchangeTest.php
+++ b/tests/php/PfbNdjsonInterchangeTest.php
@@ -75,11 +75,10 @@ final class PfbNdjsonInterchangeTest extends TestCase
 		$this->assertNull(pfb_dnsbl_ndjson_parse_row($line), 'this line must be rejected as NULL');
 	}
 
-	public function testExtraUnknownKeyAlongsideValidDomainRowIsIgnoredIncidentally(): void
+	public function testLegacyDomainRowRetainsExtraFields(): void
 	{
-		// Incidental behaviour of json_decode()'s associative mode -- NOT a forward-
-		// compatibility promise (schema v1 has none); pinned so a future change to the
-		// parser's key handling shows up here first.
+		// Legacy schema-v1 metadata remains available while only kind is normalized
+		// to the internal enum.
 		$row = pfb_dnsbl_ndjson_parse_row('{"kind":"domain","domain":"a.com","log":"1","feed":"f","group":"g","extra":"ignored-me"}');
 
 		$this->assertSame([

--- a/tests/php/PfbNdjsonInterchangeTest.php
+++ b/tests/php/PfbNdjsonInterchangeTest.php
@@ -11,8 +11,7 @@ use PHPUnit\Framework\TestCase;
  * NDJSON interchange -- compact tagged-array writers plus schema-v1 object fallback.
  */
 #[CoversClass(PfbDnsblRowKind::class)]
-#[CoversFunction('pfb_dnsbl_ndjson_emit_domain_row')]
-#[CoversFunction('pfb_dnsbl_ndjson_emit_abp_row')]
+#[CoversFunction('pfb_dnsbl_ndjson_emit_row')]
 #[CoversFunction('pfb_dnsbl_ndjson_parse_row')]
 final class PfbNdjsonInterchangeTest extends TestCase
 {
@@ -83,8 +82,14 @@ final class PfbNdjsonInterchangeTest extends TestCase
 		// parser's key handling shows up here first.
 		$row = pfb_dnsbl_ndjson_parse_row('{"kind":"domain","domain":"a.com","log":"1","feed":"f","group":"g","extra":"ignored-me"}');
 
-		$this->assertIsArray($row);
-		$this->assertSame('a.com', $row['domain']);
+		$this->assertSame([
+			'kind'   => PfbDnsblRowKind::Domain,
+			'domain' => 'a.com',
+			'log'    => '1',
+			'feed'   => 'f',
+			'group'  => 'g',
+			'extra'  => 'ignored-me',
+		], $row);
 	}
 
 	public function testDuplicateKeyLastValueWinsIncidentally(): void
@@ -111,7 +116,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 	public function testCompactDomainRowNormalizesToSchemaFields(): void
 	{
 		$this->assertSame(
-			['kind' => 'domain', 'domain' => 'example.com'],
+			['kind' => PfbDnsblRowKind::Domain, 'domain' => 'example.com'],
 			pfb_dnsbl_ndjson_parse_row('["d","example.com"]')
 		);
 	}
@@ -119,7 +124,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 	public function testCompactAbpRowNormalizesToSchemaFields(): void
 	{
 		$this->assertSame(
-			['kind' => 'abp', 'raw' => '@@||allow.example^'],
+			['kind' => PfbDnsblRowKind::Abp, 'raw' => '@@||allow.example^'],
 			pfb_dnsbl_ndjson_parse_row('["a","@@||allow.example^"]')
 		);
 	}
@@ -128,7 +133,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 	{
 		$huge = str_repeat('a', 100000) . '.com';
 		$this->assertSame(
-			['kind' => 'domain', 'domain' => $huge],
+			['kind' => PfbDnsblRowKind::Domain, 'domain' => $huge],
 			pfb_dnsbl_ndjson_parse_row('["d","' . $huge . '"]')
 		);
 	}
@@ -137,7 +142,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 	{
 		$this->assertSame(
 			[
-				'kind' => 'domain',
+				'kind' => PfbDnsblRowKind::Domain,
 				'domain' => 'legacy.example',
 				'log' => '1',
 				'feed' => 'feedA',
@@ -146,7 +151,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 			pfb_dnsbl_ndjson_parse_row('{"kind":"domain","domain":"legacy.example","log":"1","feed":"feedA","group":"groupA"}')
 		);
 		$this->assertSame(
-			['kind' => 'abp', 'raw' => '@@||legacy.example^'],
+			['kind' => PfbDnsblRowKind::Abp, 'raw' => '@@||legacy.example^'],
 			pfb_dnsbl_ndjson_parse_row('{"kind":"abp","raw":"@@||legacy.example^"}')
 		);
 	}
@@ -168,7 +173,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 	#[DataProvider('domainRoundTripProvider')]
 	public function testEmitDomainRowRoundTripsAndStaysSingleLine(string $domain): void
 	{
-		$line = pfb_dnsbl_ndjson_emit_domain_row($domain, '1', 'feedA', 'groupA');
+		$line = pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, $domain);
 
 		$this->assertStringStartsWith('["d","', $line, 'compact domain tag first');
 		$this->assertSame(1, substr_count($line, "\n"), 'exactly one raw newline byte -- the trailing one');
@@ -177,7 +182,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 		$parsed = pfb_dnsbl_ndjson_parse_row(rtrim($line, "\n"));
 		$this->assertIsArray($parsed, 'the emitted line must parse back');
 		$this->assertSame($domain, $parsed['domain'], 'round-trip must recover the exact original domain, escaping notwithstanding');
-		$this->assertSame(['kind' => 'domain', 'domain' => $domain], $parsed);
+		$this->assertSame(['kind' => PfbDnsblRowKind::Domain, 'domain' => $domain], $parsed);
 	}
 
 	public static function abpRoundTripProvider(): array
@@ -195,7 +200,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 	#[DataProvider('abpRoundTripProvider')]
 	public function testEmitAbpRowRoundTrips(string $raw): void
 	{
-		$line = pfb_dnsbl_ndjson_emit_abp_row($raw);
+		$line = pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Abp, $raw);
 
 		$this->assertStringStartsWith('["a","', $line, 'compact ABP tag first');
 		$this->assertSame(1, substr_count($line, "\n"));
@@ -207,11 +212,11 @@ final class PfbNdjsonInterchangeTest extends TestCase
 
 	public function testEmitAbpRowUsesExpectedTagAndUnescapedSlashes(): void
 	{
-		$line = pfb_dnsbl_ndjson_emit_abp_row('||example.com^');
+		$line = pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Abp, '||example.com^');
 		$this->assertSame("[\"a\",\"||example.com^\"]\n", $line);
 
 		// JSON_UNESCAPED_SLASHES proof: a raw containing '/' must not gain '\/'.
-		$regexLine = pfb_dnsbl_ndjson_emit_abp_row('/^ad[0-9]+\\./');
+		$regexLine = pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Abp, '/^ad[0-9]+\\./');
 		$this->assertStringNotContainsString('\\/', $regexLine, 'JSON_UNESCAPED_SLASHES must leave "/" unescaped');
 	}
 
@@ -225,7 +230,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 	{
 		$this->assertSame(
 			"[\"d\",\"example.com\"]\n",
-			pfb_dnsbl_ndjson_emit_domain_row('example.com', '1', 'feedA', 'groupA')
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, 'example.com')
 		);
 	}
 
@@ -233,7 +238,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 	{
 		$this->assertSame(
 			"[\"a\",\"/^ad[0-9]+\\\\./\"]\n",
-			pfb_dnsbl_ndjson_emit_abp_row('/^ad[0-9]+\\./')
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Abp, '/^ad[0-9]+\\./')
 		);
 	}
 
@@ -254,7 +259,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 	#[DataProvider('invalidUtf8ByteProvider')]
 	public function testEmitDomainRowWithInvalidUtf8DomainStaysAValidRow(string $badBytes): void
 	{
-		$line = pfb_dnsbl_ndjson_emit_domain_row("bad{$badBytes}domain.com", '1', 'feedA', 'groupA');
+		$line = pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, "bad{$badBytes}domain.com");
 
 		$this->assertSame(1, substr_count($line, "\n"), 'exactly one line, never a phantom blank');
 		$this->assertNotSame("\n", $line, 'must never degrade to a bare newline');
@@ -262,7 +267,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 
 		$row = pfb_dnsbl_ndjson_parse_row(rtrim($line, "\n"));
 		$this->assertIsArray($row, 'the emitted line must parse back as valid interchange');
-		$this->assertSame('domain', $row['kind']);
+		$this->assertSame(PfbDnsblRowKind::Domain, $row['kind']);
 		$expected = $badBytes === "\xFF" ? 'bad�domain.com' : 'bad�(domain.com';
 		$this->assertSame($expected, $row['domain']);
 	}
@@ -270,7 +275,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 	#[DataProvider('invalidUtf8ByteProvider')]
 	public function testEmitAbpRowWithInvalidUtf8RawStaysAValidRow(string $badBytes): void
 	{
-		$line = pfb_dnsbl_ndjson_emit_abp_row("||bad{$badBytes}domain.example^");
+		$line = pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Abp, "||bad{$badBytes}domain.example^");
 
 		$this->assertSame(1, substr_count($line, "\n"), 'exactly one line, never a phantom blank');
 		$this->assertNotSame("\n", $line, 'must never degrade to a bare newline');
@@ -278,7 +283,7 @@ final class PfbNdjsonInterchangeTest extends TestCase
 
 		$row = pfb_dnsbl_ndjson_parse_row(rtrim($line, "\n"));
 		$this->assertIsArray($row, 'the emitted line must parse back as valid interchange');
-		$this->assertSame('abp', $row['kind']);
+		$this->assertSame(PfbDnsblRowKind::Abp, $row['kind']);
 		$expected = $badBytes === "\xFF" ? '||bad�domain.example^' : '||bad�(domain.example^';
 		$this->assertSame($expected, $row['raw']);
 	}

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -72,14 +72,14 @@ final class UnboundPythonSourcesTest extends TestCase
 
 		// Plain feed: NDJSON domain rows (#1083).
 		file_put_contents("{$this->tmp}/dnsbl/feed1.txt",
-			pfb_dnsbl_ndjson_emit_domain_row('example.com', '1', 'f', 'g') .
-			pfb_dnsbl_ndjson_emit_domain_row('foo.com', '1', 'f', 'g') .
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, 'example.com') .
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, 'foo.com') .
 			'{"kind":"domain","domain":"","log":"1","feed":"f","group":"g"}' . "\n");  // empty domain => skipped
 
 		// ABP feed: NDJSON abp rows, raw payload passed through verbatim.
 		file_put_contents("{$this->tmp}/dnsbl/abpfeed.txt",
-			pfb_dnsbl_ndjson_emit_abp_row('||ads.example^') .
-			pfb_dnsbl_ndjson_emit_abp_row('@@||good.example^'));
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Abp, '||ads.example^') .
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Abp, '@@||good.example^'));
 	}
 
 	protected function tearDown(): void
@@ -157,7 +157,7 @@ final class UnboundPythonSourcesTest extends TestCase
 	public function testPermitFeedCarriesModeIntoManifest(): void
 	{
 		file_put_contents("{$this->tmp}/dnsbl/permitfeed.txt",
-			pfb_dnsbl_ndjson_emit_domain_row('allow.example.com', '1', 'f', 'g'));
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, 'allow.example.com'));
 		$m = pfb_unbound_python_sources([
 			['header' => 'permitfeed', 'group' => 'g', 'log' => '1', 'provenance' => 'feed', 'mode' => 'permit'],
 		]);
@@ -213,7 +213,7 @@ final class UnboundPythonSourcesTest extends TestCase
 	public function testMalformedNonJsonLineIsSkippedNotExtracted(): void
 	{
 		file_put_contents("{$this->tmp}/dnsbl/stalefeed.txt",
-			pfb_dnsbl_ndjson_emit_domain_row('legit.example', '1', 'f', 'g') .
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, 'legit.example') .
 			"not valid ndjson,stale-block.example,stale2.example##.ad\n");
 		$manifest = pfb_unbound_python_sources([
 			['header' => 'stalefeed', 'group' => 'g', 'log' => '1', 'provenance' => 'feed'],
@@ -572,7 +572,7 @@ final class UnboundPythonSourcesTest extends TestCase
 		// Given a build whose feed list carries one non-\w header among valid rows
 		// (its source file even exists, so only the validation can be the skip cause)
 		file_put_contents("{$this->tmp}/dnsbl/bad.header.txt",
-			pfb_dnsbl_ndjson_emit_domain_row('example.com', '1', 'f', 'g'));
+			pfb_dnsbl_ndjson_emit_row(PfbDnsblRowKind::Domain, 'example.com'));
 		$feeds = $this->feeds();
 		$feeds[] = ['header' => 'bad.header', 'group' => 'g', 'log' => '1'];
 		$this->assertSame('', $this->logContents(), 'log must start empty');

--- a/tests/smoke/test_smoke_adr62.py
+++ b/tests/smoke/test_smoke_adr62.py
@@ -405,7 +405,7 @@ def test_adr62_reused_feed_current_generation_ndjson_resolves_without_redownload
       pass downloaded both: the main row blocked domain A, the sibling row
       blocked X1), whose main-row staging file (``{dnsdir}/{header}.txt``) is
       then OVERWRITTEN with a hand-written compact NDJSON domain row (the exact
-      ``pfb_dnsbl_ndjson_emit_domain_row`` byte shape) for a DIFFERENT domain B —
+      ``pfb_dnsbl_ndjson_emit_row`` domain byte shape) for a DIFFERENT domain B —
       simulating a feed whose staging genuinely already is in the current NDJSON
       generation — while the SIBLING row's served feed changes content (X1 → X2)
       and the main row's served feed stays byte-identical.
@@ -457,7 +457,7 @@ def test_adr62_reused_feed_current_generation_ndjson_resolves_without_redownload
 
         # Overwrite the MAIN row's staging with a hand-written, CURRENT-generation
         # NDJSON domain row for a DIFFERENT domain — the exact byte shape
-        # pfb_dnsbl_ndjson_emit_domain_row() produces.
+        # pfb_dnsbl_ndjson_emit_row() produces for a domain.
         # Its served feed stays byte-identical (no re-download trigger); the
         # SIBLING feed changes so the cron pass rebuilds the database at all.
         ndjson_line = f'["d","{reused_domain}"]\n'


### PR DESCRIPTION
## Summary

- Replace the duplicate domain and ABP staging writers with one enum-typed emitter.
- Serialize `PfbDnsblRowKind` directly while preserving the exact compact NDJSON bytes.
- Normalize compact and legacy rows to an enum-valued internal `kind`.
- Dispatch the sole raw-file translator with an exhaustive enum `match`.
- Retain all legacy object metadata and keep the final manifest unchanged.

## Why

The previous implementation introduced an enum at the wire boundary, then immediately
converted it to and from strings. That left duplicate helpers and discarded the enum's
expressiveness and type safety inside the parser/consumer path.

## Impact

No staging-wire, raw-file, final-manifest, streaming, or compatibility behavior changes.
The internal PHP representation now stays typed after parsing.

Closes #1482

## Validation

- Frozen RED: `PfbNdjsonInterchangeTest` hash
  `1b80232779f37a0b13dfe040454ed070e5a5abc5`; 4 enum-contract failures and
  17 missing-emitter errors.
- GREEN unchanged: 57 tests, 122 assertions.
- Focused PHP regressions: 117 tests, 405 assertions.
- Full pytest: 3,226 passed, 4 skipped.
- Full PHPUnit: 3,721 tests, 22,273 assertions, 4 skipped.
- PHPStan, PHPCS, Ruff, mypy, Markdownlint, PHP syntax, and repository hooks passed.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Standardized DNSBL interchange output across domain and ABP entries.
  - Ensured consistent NDJSON formatting, including stable field ordering and line endings.
  - Improved parsing compatibility for compact and supported legacy row formats.
  - Invalid or unsupported row shapes are rejected consistently.

- **Documentation**
  - Updated architecture notes to reflect the unified interchange format behavior.

- **Tests**
  - Expanded coverage for round-trip parsing, exact output, malformed input, and UTF-8 handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->