### PR TITLE
pfblockerng: ASN log CSV columns, drop legacy log read support (#1369)

### DIFF
--- a/.ADRs/ADR_38_System_Log_Integration/ADR.md
+++ b/.ADRs/ADR_38_System_Log_Integration/ADR.md
@@ -579,7 +579,11 @@ coarser, field-count-only gate (not full CSV-aware parsing): a valid new-schema 
 happens to contain a literal comma inflates the raw `awk` field count and is (silently) excluded from
 this one statistic — a known, accepted limitation of the pre-existing `cut`/`awk` pipeline, which was
 never CSV-quote-aware for *any* column. The Alerts table/tooltip/filter (which read via real
-`fgetcsv()`) are unaffected by this limitation.
+`fgetcsv()`) are unaffected by this limitation. The limitation is currently unreachable from the real
+writer: `pfblockerng.sh`'s `iptoasn()` strips `"`/`{`/`}`/`,` from every mmdblookup value (`tr -d`)
+before the blob is cached or written, so no comma can reach `asn_name` today — if a future ASN
+provider path (ADR-32) ever bypasses that shell sanitization, this stat starts silently dropping
+those rows and the pipeline must become CSV-aware (e.g. PHP-side `fgetcsv()` aggregation).
 
 ### A3.6 Test coverage
 

--- a/.ADRs/ADR_38_System_Log_Integration/ADR.md
+++ b/.ADRs/ADR_38_System_Log_Integration/ADR.md
@@ -497,3 +497,117 @@ smoke. Findings (live, on the local two-VM box) that shaped the working recipe:
 Net recipe: WAN-subnet victim + `enable_float` + `enable_log`, with the civm trigger pinning a host route
 for the victim via pfSense so the SYN takes the LAN→WAN path. This leg now runs in the CI smoke fan-out;
 the §7 manual-SIEM checklist remains the only out-of-CI item.
+
+## Amendment 3 (2026-07-18, issue #1369) — IP feature/Unified log ASN CSV columns; no back-compat
+
+**Scope.** Corrects A1.6's fidelity claim "own Reports/Alerts UI is unaffected — it reads the CSVs,
+whose content is unchanged" for the **ASN column only**: that content changes, on the IP feature logs
+(`ip_block.log`/`ip_permit.log`/`ip_match.log`) and `unified.log`, as of this amendment. Every other
+A1/A2 claim stands untouched — the syslog `key=value` body, the `pfb_syslog_format_ip`/`_dnsbl`
+formatters, the `<logging>` block, the live toggle, the dedicated file, and the IP/DNSBL syslog legs are
+all **unaffected** by this change; ASN is not a syslog-emitted field's *shape*, only a value it carries
+(§A3.4).
+
+### A3.1 What changed
+
+The single pipe-delimited ASN blob field (`|ASN:  AS50360 | domain:  4vendeta.com | name:  Tamatiya
+EOOD |` — `mmdblookup` output flattened by `pfblockerng.sh`'s `iptoasn()`) is **replaced, in the IP
+feature logs and `unified.log` only**, by three plain CSV columns: `asn`, `asn_domain`, `asn_name`.
+Feature-log rows go from **21 to 23 fields**; `unified.log` IP rows (which carry a leading event-type
+field) go from **22 to 24 fields**. The new columns are written via native PHP `fputcsv()` with an
+**explicit empty escape argument** (`fputcsv($fh, $row, ',', '"', '')` — RFC4180 double-quote doubling,
+never PHP's default backslash-escape quirk), and CR/LF inside a value is normalized to a space **first**
+so a written row always stays exactly one physical line (the reverse-tail readers' load-bearing
+assumption). No header row, no schema-version column, no config/dependency change.
+
+### A3.2 No back-compat for log entries (owner decision, 2026-07-18)
+
+The owner's authorizing decision on issue #1369, quoted verbatim: *"For 1369, we won't care about
+back-compat for the log entries."* Concretely:
+
+- Readers — `convert_ip_log()` (Alerts table + tooltip + ASN filter), the Top ASN statistics pipeline,
+  and the Unified view — parse **only** the current 23-field feature-row / 24-field Unified-row schema.
+- **Any other post-timestamp-shift field count — including every pre-upgrade legacy row still on disk —
+  is skipped silently**, with **zero** PHP warnings/notices. A skipped row does not consume a
+  render-limit slot and is never partially rendered.
+- Old entries simply disappear from the Alerts/Reports UI until log rotation removes them; this is
+  **accepted**, not a defect. There is no row-normalization, no mixed-schema rendering, and no
+  mixed-legacy/new Top ASN aggregation — all dropped from the original issue packet by this decision.
+
+### A3.3 Unchanged: the internal pipe blob
+
+`iptoasn()` (`pfblockerng.sh`), the `asncache.asn` SQLite column, and the syslog `asn=` value emitted by
+`pfb_syslog_format_ip()` (§2.1/A1 — unaffected by this amendment) **all keep the existing internal
+pipe-blob format** — none of those three are log *entries* in the CSV-schema sense this amendment
+covers. `pfb_asn_blob_split(string $blob): array{asn,domain,name}` (`pfblockerng_extra.inc`) is the one
+new pure helper that decodes that blob — splitting on `|` into segments, each split at its **first**
+`:` into label/value — so the writer's three new CSV columns and the untouched internal consumers derive
+from the exact same source value without a second, drifting parser.
+
+### A3.4 New pure helpers (PHPUnit-pinned, `tests/php/UnifiedFormatTest.php`)
+
+- `pfb_asn_blob_split(string $blob): array{asn: string, domain: string, name: string}` — §A3.3.
+- `pfb_asn_csv_fields(string $blob): string` — the three CSV-escaped columns for one row (§A3.1);
+  CR/LF-normalizes each value first, then `fputcsv()`s to an in-memory stream. Spliced into the
+  existing `$log`/`$details` string-concatenation the filterlog daemon already builds — RFC4180 field
+  quoting is local per field, so pre-escaping this one fragment and string-joining it with the
+  unchanged surrounding fields is equivalent to escaping the whole row at once (round-trip-proven,
+  `UnifiedFormatTest.php`'s `testAsnCsvFieldsSurviveThroughPfbUnifiedFormatIpAndFgetcsv`).
+- `pfb_ip_log_row_schema_ok(array $fields, string $mode): bool` (`pfblockerng_extra.inc`) — the exact
+  field-count gate behind §A3.2, checked **before** `convert_ip_log()`'s timestamp-shift reorder and
+  before any indexed field access, in all three places a raw row reaches that function (the single-pass
+  Block/Permit/Match loop, the two-pass prefetch buffer's Pass 1, and the Unified loop) — the two-pass
+  buffer path folds a schema-invalid row into the same gap-marker path a filtered-out row takes, so it
+  never reaches `pfb_ip_render_query()`'s fixed-index reads in Pass 1.5 either.
+
+**Reader escape-parameter correction.** `fgetcsv()`'s default `$escape` is a backslash — PHP's own
+non-standard extension to RFC4180, which has no escape character at all. A value written with
+`fputcsv(..., '')` and read back with a *mismatched* default-escape `fgetcsv()` can corrupt a field
+containing a literal backslash (the closing quote gets escape-consumed). All five `fgetcsv()` call sites
+in `pfblockerng_alerts.php` (DNSBL, DNS-reply, Unified, and both Block/Permit/Match read loops) now pass
+the same explicit empty escape argument as the writer, for symmetry — a no-op for the three log types
+this amendment does not touch (none of their fields are ever quoted), and the fix that makes the new
+ASN columns round-trip correctly for every character class in the coverage matrix, including backslash.
+
+### A3.5 Top ASN statistics
+
+The `ipasn` stat's shell pipeline (`pfblockerng_alerts.php`, `cut -d ',' -f20` — the ASN column's
+1-based position, **unchanged** by this amendment since the two new columns were appended *after* it)
+gains an `awk -F',' 'NF == 23'` gate before the cut, so a pre-upgrade legacy row — whose column 20 is
+still the old pipe-blob text — is excluded rather than counted as a bogus "ASN" bucket. This is a
+coarser, field-count-only gate (not full CSV-aware parsing): a valid new-schema row whose `asn_name`
+happens to contain a literal comma inflates the raw `awk` field count and is (silently) excluded from
+this one statistic — a known, accepted limitation of the pre-existing `cut`/`awk` pipeline, which was
+never CSV-quote-aware for *any* column. The Alerts table/tooltip/filter (which read via real
+`fgetcsv()`) are unaffected by this limitation.
+
+### A3.6 Test coverage
+
+- `tests/php/UnifiedFormatTest.php` — `pfb_asn_blob_split`/`pfb_asn_csv_fields` pure-function pins:
+  the real blob shape from issue #1369's own pasted example; bare `Unknown`/`null`/`''` states;
+  comma/quote/colon/Unicode/CR/LF in domain or name; round-trip through `fgetcsv()`, including spliced
+  through `pfb_unified_format_ip()`.
+- `tests/php/AlertsAsnCsvTest.php` (new) — `convert_ip_log()` end-to-end: new-schema rows render;
+  legacy/malformed rows are skipped silently with zero warnings, in both `non_unified` and `Unified`
+  mode; ASN state axis (found/`Unknown`/`null`/reporting-disabled); IPv4 and IPv6; the ASN filter still
+  matches the new plain field and never evaluates against a legacy row; the full write→CSV-parse→render
+  pipeline for every text-handling case, not hand-typed array literals.
+- `tests/php/LogFormatConsumersTest.php` — the Top ASN `awk`/`cut` pipeline (§A3.5): a source tripwire
+  on the exact gated command, plus green/red pipeline-reproduction pairs proving the gate excludes a
+  legacy row's blob text and the pre-amendment ungated pipeline would have counted it.
+- `tests/php/AlertsIpConvertPrefetchParityTest.php` / `AlertsIpUnlockIconTest.php` — pre-existing
+  fixtures widened from the old 20-element `non_unified` row shape to the new 22-element shape (the 2
+  new trailing columns); behaviour-neutral for the OLD code (extra elements were already ignored), and
+  required for these tests to keep passing once the schema gate (§A3.2/A3.4) lands.
+- `tests/smoke/ui/test_alerts_asn_csv.py` (new, `ui_render`) — live-VM Tier-A: a new-schema row (with a
+  comma in both `asn_domain` and `asn_name`) renders its visible ASN and a tooltip built from the domain
+  and name; a legacy-schema row renders nothing at all; the Tier-A render oracle (200, no PHP diagnostic
+  in the body, page marker present) passes, and the server's own `php_error.log` gains no bytes.
+
+### A3.7 Reconciling ADR-32 (Proposed, IPinfo GeoIP/ASN provider)
+
+Checked: ADR-32 operates entirely at the **provider/lookup** seam (`GeoipProvider`/`AsnProvider`
+returning a normalized `asn`/`as_org` record) and makes no claim about the IP-log **CSV serialization**
+this amendment changes — its one relevant bullet ("Phase 4 ... Keep block shapes/log formats stable")
+is a forward-looking instruction that will simply apply to *this* (post-#1369) log format once that
+Proposed phase is eventually implemented. **No edit needed**; ADR-32 is not stale.

--- a/docs/misc/alerts-reports-pipeline.md
+++ b/docs/misc/alerts-reports-pipeline.md
@@ -38,7 +38,7 @@ behind.
 | --- | ------ | -------------------------------- |
 | `dnsbl.log` | `pfb_unbound.py` (`_log_dnsbl` path) | full verdict: block type, group, evaluated domain/zone, feed, query type |
 | `dns_reply.log` | `pfb_unbound.py` | reply type/record, TTL, resolved address, GeoIP iso code |
-| `ip_block/permit/match.log` | filterlog daemon (`pfb_daemon_filterlog`, `pfblockerng.inc`) | pf tracker → pfB rule/alias, matching feed + IP/CIDR entry (`find_reported_header()`), GeoIP (`mmdblookup`), rDNS, ASN |
+| `ip_block/permit/match.log` | filterlog daemon (`pfb_daemon_filterlog`, `pfblockerng.inc`) | pf tracker → pfB rule/alias, matching feed + IP/CIDR entry (`find_reported_header()`), GeoIP (`mmdblookup`), rDNS, ASN (3 CSV columns, issue #1369 — see below) |
 | `unified.log` | filterlog daemon (sole writer, ADR-38 Amendment 1) | reformatted copies of the three streams above |
 
 The daemon reconstructs the bare pf event into a fully attributed record **once**, at
@@ -52,6 +52,29 @@ group/feed to build the `dnsbl.log` line it appends, and increments the per-grou
 counter (`UPDATE dnsbl SET counter = counter + 1`). A miss (`NULL` or `blocked=false`)
 renders every field `Unknown` rather than guessing. Issue #1349 retired the unconsumed
 reports-cache SQLite writer/table; the event log is the sole durable per-block record.
+
+### ASN CSV columns, no back-compat for log entries (issue #1369, ADR-38 Amendment 3)
+
+The IP feature logs and `unified.log` used to embed ASN metadata as a single pipe-delimited
+blob field (`|ASN:  AS50360 | domain:  4vendeta.com | name:  Tamatiya EOOD |` — flattened
+`mmdblookup` output, `pfblockerng.sh`'s `iptoasn()`). That field is now **three plain CSV
+columns** — `asn`, `asn_domain`, `asn_name` — written via `fputcsv()` with an explicit empty
+escape argument (RFC4180 quoting, never PHP's default backslash-escape quirk) and CR/LF
+normalized to a space first, so a row always stays one physical line. Feature-log rows go
+from 21 to 23 fields; `unified.log` IP rows (leading event-type field included) go from 22
+to 24. The internal pipe blob itself is **unchanged** — `iptoasn()`, the `asncache.asn`
+SQLite column, and the syslog `asn=` value (ADR-38 §2.1) all keep it; only the *log-line*
+representation changed. `pfb_asn_blob_split()`/`pfb_asn_csv_fields()`
+(`pfblockerng_extra.inc`) are the pure helpers bridging the two.
+
+**No back-compat for log entries** (owner decision, 2026-07-18): `convert_ip_log()`, the Top
+ASN statistics pipeline, and the Unified view parse **only** the current field-count schema.
+Any other count — including every pre-upgrade legacy row still on disk — is skipped
+silently, zero PHP warnings, until log rotation removes it (`pfb_ip_log_row_schema_ok()`,
+checked before the timestamp-shift reorder in every one of `convert_ip_log()`'s three call
+sites, plus the two-pass buffer's Pass 1). See ADR-38 Amendment 3 for the full contract,
+the reader `fgetcsv()` escape-parameter correction it required, and the Top ASN `awk`
+field-count gate's known comma-in-name limitation.
 
 ## Read path — the Alerts page
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14437,8 +14437,14 @@ function pfb_daemon_filterlog() {
 					$ts_formatted = pfb_filterlog_timestamp($f, $log_type, time());
 					$log = "{$ts_formatted},{$d[3]},{$d[4]},{$int},{$d[6]},{$d[8]},";
 
-					// Details:	"Direction/GeoIP/Aliasname/IP evaluated/Feed Name/Resolved Hostname/Client Hostname/ASN/Duplicate status"
-					$details	= "{$dir},{$geoip},{$pfb_alias},{$pfb_query[1]},{$pfb_query[0]},{$resolved_host},{$hostname},{$asn}";
+					// Details:	"Direction/GeoIP/Aliasname/IP evaluated/Feed Name/Resolved Hostname/Client Hostname/ASN,ASN Domain,ASN Name/Duplicate status"
+					// issue #1369: the single pipe-blob ASN field is replaced by 3 plain
+					// CSV columns (asn, asn_domain, asn_name), CSV-escaped by
+					// pfb_asn_csv_fields() (native fputcsv(), explicit empty escape arg,
+					// CR/LF normalized to spaces first) -- see ADR-38 Amendment 3. The raw
+					// $asn blob itself is untouched and still feeds the syslog asn= value
+					// below + the asncache.asn row.
+					$details	= "{$dir},{$geoip},{$pfb_alias},{$pfb_query[1]},{$pfb_query[0]},{$resolved_host},{$hostname}," . pfb_asn_csv_fields($asn);
 
 					// Reverse Match text
 					if ($d[6] == 'match') {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2154,6 +2154,119 @@ function pfb_unified_format_dnsreply(array $fields): string
 }
 
 // ---------------------------------------------------------------------------
+// issue #1369 (ADR-38 Amendment 3) -- ASN CSV-column helpers. The internal
+// pipe-delimited ASN blob (mmdblookup output flattened by pfblockerng.sh's
+// iptoasn(), e.g. "|ASN:  AS50360 | domain:  4vendeta.com | name:  Tamatiya
+// EOOD |") stays the wire/cache format for iptoasn()/asncache.asn/the syslog
+// asn= value -- these two helpers are the ONLY place that blob is decoded
+// into the three plain CSV columns (asn, asn_domain, asn_name) the IP log
+// writer now emits, replacing the single blob field in ip_block/permit/
+// match.log + unified.log. PURE -- no globals; pfb_asn_csv_fields()'s only
+// I/O is an in-memory stream.
+// ---------------------------------------------------------------------------
+
+/**
+ * pfb_asn_blob_split — split the internal ASN blob into its three labelled
+ * parts. The blob is either a bare state literal ('null' when ASN reporting
+ * was off at write time, 'Unknown' when the lookup found nothing, or empty)
+ * or the pipe-delimited "label:  value" shape above: split on '|' into
+ * segments, each segment split at its FIRST ':' into label/value. A blob
+ * with no '|' or no ':' (unrecognised shape) is treated as a bare ASN state
+ * literal, verbatim.
+ *
+ * @param string $blob Raw internal ASN value ($asn as pfb_daemon_filterlog builds it).
+ * @return array{asn: string, domain: string, name: string}
+ */
+function pfb_asn_blob_split(string $blob): array
+{
+	$blob = trim($blob);
+
+	if ($blob === '' || strpos($blob, '|') === FALSE || strpos($blob, ':') === FALSE) {
+		return ['asn' => ($blob === '' ? 'Unknown' : $blob), 'domain' => '', 'name' => ''];
+	}
+
+	$parts = ['asn' => '', 'domain' => '', 'name' => ''];
+	foreach (explode('|', $blob) as $segment) {
+		$segment = trim($segment);
+		if ($segment === '') {
+			continue;
+		}
+		$colon = strpos($segment, ':');
+		if ($colon === FALSE) {
+			continue;
+		}
+		$label = strtolower(trim(substr($segment, 0, $colon)));
+		$value = trim(substr($segment, $colon + 1));
+		if (array_key_exists($label, $parts) && $value !== '') {
+			$parts[$label] = $value;
+		}
+	}
+
+	if ($parts['asn'] === '') {
+		$parts['asn'] = 'Unknown';
+	}
+
+	return $parts;
+}
+
+/**
+ * pfb_asn_csv_fields — render the 3 new ASN CSV columns (asn, asn_domain,
+ * asn_name) from the internal blob (pfb_asn_blob_split()), CSV-escaped via
+ * native fputcsv() with an explicit empty escape argument -- RFC4180
+ * double-quote doubling, never PHP's default backslash-escape quirk -- so a
+ * comma/quote/colon/Unicode value in the domain or organisation name
+ * round-trips through fgetcsv() with no bespoke escaping. CR/LF is
+ * normalized to a single space FIRST so the written row always stays one
+ * physical line (reverse-tail readers rely on this).
+ *
+ * @param string $blob Raw internal ASN blob/state.
+ * @return string Three comma-joined, CSV-escaped fields (no trailing newline).
+ */
+function pfb_asn_csv_fields(string $blob): string
+{
+	$split = pfb_asn_blob_split($blob);
+
+	$row = array_map(
+		static function (string $v): string {
+			return str_replace(["\r\n", "\r", "\n"], ' ', $v);
+		},
+		[$split['asn'], $split['domain'], $split['name']]
+	);
+
+	$fh = fopen('php://temp', 'r+');
+	fputcsv($fh, $row, ',', '"', '');
+	rewind($fh);
+	$line = (string) stream_get_contents($fh);
+	fclose($fh);
+
+	return rtrim($line, "\r\n");
+}
+
+/**
+ * pfb_ip_log_row_schema_ok — exact field-count schema gate for a raw
+ * (pre-timestamp-shift) IP feature-log row as delivered to convert_ip_log().
+ * Only the current 23-field feature-row / 24-field Unified-row schema (see
+ * .ADRs/ADR_38_System_Log_Integration/ Amendment 3) is supported; ANY other
+ * count -- including every pre-upgrade legacy (21-field feature / 22-field
+ * Unified) row still on disk -- must be rejected BEFORE a single indexed
+ * field access, so a short/garbage row never trips an "undefined array key"
+ * notice downstream.
+ *
+ * $mode distinguishes 'Unified' (leading event-type field already stripped
+ * by the caller, trailing duplicate marker still attached -- 23 raw fields)
+ * from every other caller (duplicate marker already popped -- 22 raw fields).
+ *
+ * @param array<int,mixed> $fields Raw fgetcsv() row, before convert_ip_log()'s
+ *                                 own timestamp-shift reorder.
+ * @param string            $mode  'Unified' or 'non_unified'.
+ * @return bool
+ */
+function pfb_ip_log_row_schema_ok(array $fields, string $mode): bool
+{
+	return count($fields) === ($mode === 'Unified' ? 23 : 22);
+}
+
+// ---------------------------------------------------------------------------
 // ADR-38 — PHP syslog event emitter. pfb_syslog_event(string $body) emits ONE record with
 // ident 'pfblockerng' at a FIXED facility (LOG_LOCAL6) and severity (LOG_INFO) — not
 // user-configurable: the package <logging> PROGRAM-name filter routes events regardless of

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1886,6 +1886,17 @@ if ($alert_summary) {
 				case 'replysrcipd':
 					exec("{$cut_cmd},8 {$alert_log} | {$su_cmd} | sort -nr 2>&1", $stats);
 					break;
+				case 'ipasn':
+					// issue #1369 (ADR-38 Amendment 3): no back-compat for log entries --
+					// only the new 23-field schema carries a plain ASN token at column 20
+					// (unchanged position: the 2 new columns were appended AFTER it). A
+					// pre-upgrade 21-field legacy row's column 20 is still the old
+					// pipe-blob text, and any other field count is malformed either way --
+					// gate on the exact new field count before extracting, so a legacy/
+					// malformed row is skipped silently instead of polluting the Top ASN
+					// count with blob noise.
+					exec("{$pfb['awk']} -F',' 'NF == 23' {$alert_log} | {$cut_cmd} | {$agent_cmd} {$su_cmd} | sort -nr 2>&1", $stats);
+					break;
 				default:
 					exec("{$cut_cmd} {$alert_log} | {$agent_cmd} {$su_cmd} | sort -nr 2>&1", $stats);
 					break;
@@ -2818,6 +2829,16 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		return array(TRUE, '');
 	}
 
+	// issue #1369 (ADR-38 Amendment 3): only the current 23-field feature-row /
+	// 24-field Unified-row schema is supported on the read path -- no back-compat
+	// for log entries (owner decision). ANY other field count, including every
+	// pre-upgrade legacy row still on disk, is skipped here silently (no PHP
+	// warnings/notices) BEFORE the timestamp shift below or any indexed field
+	// access -- see pfb_ip_log_row_schema_ok() (pfblockerng_extra.inc).
+	if (!pfb_ip_log_row_schema_ok($fields, $mode)) {
+		return array(FALSE, '');
+	}
+
 	// issue #809: page-scope memos (pfb_render_memo(), pfblockerng.inc) live for one
 	// render. $memos['validate'] caches the "still in its logged feed file" validate
 	// exec, keyed by the exact command; $memos['miss'] caches the "where does this
@@ -2857,7 +2878,9 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		[15]	= Feed Name
 		[16]	= gethostbyaddr resolved hostname
 		[17]	= Client Hostname
-		[18]	= ASN					*/
+		[18]	= ASN
+		[19]	= ASN Domain	(issue #1369)
+		[20]	= ASN Name	(issue #1369)		*/
 
 	// If alerts filtering is selected, process filters as required.
 	if ($pfb['filterlogentries']) {
@@ -2937,16 +2960,15 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		});
 	}
 
-	// ASN - Add to GeoIP column
-	if ($pfb['asn_reporting'] != 'disabled' && !empty($fields[18]) && $fields[18] != 'Unknown') {
-
-		if (strpos($fields[18], '|') !== FALSE) {
-			$fields[18]	= str_replace('ASN:', '', $fields[18]);
-			$asn		= explode('|', $fields[18], 3);
-			$fields[18] = "<span title=\"|" . pfb_hsc($asn[2]) . "\">" . pfb_hsc($asn[1]) . "</span>";
-		} else {
-			$fields[18] = '';
-		}
+	// ASN - Add to GeoIP column. issue #1369 (ADR-38 Amendment 3): the ASN
+	// number renders directly from its own plain CSV column ([18]); the
+	// tooltip is built from the separate ASN Domain/Name columns ([19]/[20])
+	// -- no more pipe-blob explode()/label-stripping.
+	if ($pfb['asn_reporting'] != 'disabled' && !empty($fields[18]) && $fields[18] != 'Unknown' && $fields[18] != 'null') {
+		$asn_domain = $fields[19] ?? '';
+		$asn_name   = $fields[20] ?? '';
+		$asn_title  = "domain:  {$asn_domain} | name:  {$asn_name}";
+		$fields[18] = "<span title=\"" . pfb_hsc($asn_title) . "\">" . pfb_hsc($fields[18]) . "</span>";
 	}
 	else {
 		$fields[18] = '';
@@ -4255,8 +4277,14 @@ if (!$alert_summary):
 			// convert_ip_log()) can render another row -- see that helper for the exact
 			// non-filter/filter mode conditions. If any per-type filter-limit knob is 0
 			// (unlimited) its flag never sets and this still scans to EOF, exactly as before.
+			// issue #1369: every fgetcsv() call reading these logs (all 5 sites in this
+			// file) passes an explicit empty escape argument, matching the writer's
+			// pfb_asn_csv_fields()/fputcsv() -- a bare fgetcsv() defaults to a backslash
+			// escape char, which would mis-parse a literal backslash inside a quoted ASN
+			// domain/name field (RFC4180 has no escape char at all; PHP's default is a
+			// non-standard extension the two sides must agree on to round-trip).
 			if (($handle = @popen('/usr/bin/tail -r ' . escapeshellarg($pfb_log), 'r')) !== FALSE) {
-				while (($fields = @fgetcsv($handle)) !== FALSE) {
+				while (($fields = @fgetcsv($handle, 0, ',', '"', '')) !== FALSE) {
 
 					if (pfb_alerts_unified_scan_done($pfb['filterlogentries'], $counter['Unified'], $pfbentries, $ipfilterlimit, $dnsblfilterlimit, $dnsfilterlimit)) {
 						break;
@@ -4325,7 +4353,7 @@ if (!$alert_summary):
 			// ADR-65: a single streaming pass -- rows render straight from their own
 			// logged fields now, so there is nothing left to batch-prefetch between passes.
 			if (($handle = @popen('/usr/bin/tail -r ' . escapeshellarg($pfb_log), 'r')) !== FALSE) {
-				while (($fields = @fgetcsv($handle)) !== FALSE) {
+				while (($fields = @fgetcsv($handle, 0, ',', '"', '')) !== FALSE) {
 
 					// Remove and record duplicate entries
 					if ($fields[9] == '-') {
@@ -4363,7 +4391,7 @@ if (!$alert_summary):
 			<tbody>
 	<?php
 			if (($handle = @popen('/usr/bin/tail -r ' . escapeshellarg($pfb_log), 'r')) !== FALSE) {
-				while (($fields = @fgetcsv($handle)) !== FALSE) {
+				while (($fields = @fgetcsv($handle, 0, ',', '"', '')) !== FALSE) {
 
 					// Suppress user-defined reply types
 					if (isset($pfbreplytypes) && isset($pfbreplytypes[$fields[2]])) {
@@ -4421,7 +4449,7 @@ if (!$alert_summary):
 
 			if (!$ip_two_pass) {
 				if (($handle = @popen('/usr/bin/tail -r ' . escapeshellarg($pfb_log), 'r')) !== FALSE) {
-					while (($fields = @fgetcsv($handle)) !== FALSE) {
+					while (($fields = @fgetcsv($handle, 0, ',', '"', '')) !== FALSE) {
 						$last_fld = array_pop($fields);
 
 						// Remove and record duplicate entries
@@ -4452,12 +4480,23 @@ if (!$alert_summary):
 				$ip_buffered	  = array();
 				$ip_accepted_seen = 0;
 				if (($handle = @popen('/usr/bin/tail -r ' . escapeshellarg($pfb_log), 'r')) !== FALSE) {
-					while (($fields = @fgetcsv($handle)) !== FALSE) {
+					while (($fields = @fgetcsv($handle, 0, ',', '"', '')) !== FALSE) {
 						$last_fld = array_pop($fields);
 
 						// Duplicate-marker line: extend the current run.
 						if ($last_fld == '-') {
 							pfb_alerts_ip_buffer_push($ip_buffered, 'dup');
+							continue;
+						}
+
+						// issue #1369: a legacy/malformed row's field count never matches
+						// the current schema -- fold it into the SAME gap-marker path as a
+						// filtered row, so it is never buffered and never reaches Pass 1.5's
+						// pfb_ip_render_query() (which assumes the current schema's fixed
+						// indices) or pfb_match_filter_field() below. convert_ip_log()'s own
+						// guard is a backstop for the OTHER two callers, not the only one here.
+						if (!pfb_ip_log_row_schema_ok($fields, 'non_unified')) {
+							pfb_alerts_ip_buffer_push($ip_buffered, 'reject');
 							continue;
 						}
 

--- a/tests/php/AlertsAsnCsvTest.php
+++ b/tests/php/AlertsAsnCsvTest.php
@@ -282,6 +282,12 @@ final class AlertsAsnCsvTest extends TestCase
 		$this->assertTrue(pfb_ip_log_row_schema_ok(array_fill(0, 23, ''), 'Unified'), '23 elements = new Unified schema');
 		$this->assertFalse(pfb_ip_log_row_schema_ok(array_fill(0, 21, ''), 'Unified'), '21 elements = old legacy Unified count, must reject');
 		$this->assertFalse(pfb_ip_log_row_schema_ok(array_fill(0, 0, ''), 'non_unified'), 'empty row must reject');
+		// The gate is an EXACT count, not a minimum -- an over-long row (extra
+		// commas from any source) is just as unsupported as a short one.
+		$this->assertFalse(pfb_ip_log_row_schema_ok(array_fill(0, 23, ''), 'non_unified'), '23 elements = one field too many for non_unified, must reject');
+		$this->assertFalse(pfb_ip_log_row_schema_ok(array_fill(0, 24, ''), 'non_unified'), '24 elements = over-long non_unified row, must reject');
+		$this->assertFalse(pfb_ip_log_row_schema_ok(array_fill(0, 24, ''), 'Unified'), '24 elements = one field too many for Unified, must reject');
+		$this->assertFalse(pfb_ip_log_row_schema_ok(array_fill(0, 25, ''), 'Unified'), '25 elements = over-long Unified row, must reject');
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/AlertsAsnCsvTest.php
+++ b/tests/php/AlertsAsnCsvTest.php
@@ -1,0 +1,579 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1369 (ADR-38 Amendment 3) -- ASN CSV-column coverage for the Alerts
+ * page's IP-row converter.
+ *
+ * The internal pipe-delimited ASN blob (mmdblookup output flattened by
+ * pfblockerng.sh's iptoasn()) is replaced, on the IP feature-log write path,
+ * by 3 plain CSV columns -- asn, asn_domain, asn_name -- CSV-escaped via
+ * native fputcsv() (pfb_asn_csv_fields(), pfblockerng_extra.inc). The
+ * owner's 2026-07-18 amendment to issue #1369 drops ALL back-compat for log
+ * entries: convert_ip_log() parses ONLY the current 23-field feature-row /
+ * 24-field Unified-row schema; any other field count -- including every
+ * pre-upgrade legacy row still on disk -- is skipped silently, with zero PHP
+ * warnings/notices, until log rotation removes it.
+ *
+ * Coverage matrix (issue #1369 packet, amended):
+ *   Schema:    new schema OK; legacy (old field count) SKIPPED silently;
+ *              malformed (any other count) SKIPPED silently
+ *   View:      Block (non_unified) + Unified (24-field, leading event type)
+ *   Family:    IPv4, IPv6
+ *   ASN state: found, 'Unknown', null/missing metadata
+ *   Text:      comma, quote, colon, Unicode, empty, CR/LF in asn_name/domain
+ *              -- round-trips through real fgetcsv() parsing, no bespoke
+ *              escaping needed by the reader
+ *   Consumers: Alerts table + tooltip (built from domain+name), ASN filter
+ *
+ * Harness mirrors AlertsIpConvertPrefetchParityTest's off-appliance load +
+ * real-tmpdir technique (AlertsPageLoader.php; no mocking of the lookup
+ * layer convert_ip_log() itself drives for the non-ASN parts of the row).
+ */
+#[CoversFunction('convert_ip_log')]
+#[CoversFunction('pfb_ip_log_row_schema_ok')]
+final class AlertsAsnCsvTest extends TestCase
+{
+	private string $tmpDir;
+	private string $denydir;
+	private string $nativedir;
+	private string $ccdir;
+	private string $etdir;
+	private string $aliasdir;
+	private string $matchdir;
+	private string $matchgendir;
+
+	/** @var array<string, mixed> */
+	private array $savedGlobals = [];
+
+	public static function setUpBeforeClass(): void
+	{
+		// See AlertsPageLoader.php for the off-appliance load mechanics.
+		require_once __DIR__ . '/AlertsPageLoader.php';
+		pfb_test_load_alerts_page_functions();
+	}
+
+	protected function setUp(): void
+	{
+		foreach ([
+			'pfb', 'continents', 'filterfieldsarray', 'clists', 'ip_unlock', 'counter',
+			'pfbentries', 'skipcount', 'dup', 'ipfilterlimit', 'ipfilterlimitentries', 'config',
+		] as $g) {
+			$this->savedGlobals[$g] = $GLOBALS[$g] ?? null;
+		}
+
+		$this->tmpDir    = sys_get_temp_dir() . '/pfb_asn_csv_' . bin2hex(random_bytes(6));
+		$this->denydir   = "{$this->tmpDir}/deny";
+		$this->nativedir = "{$this->tmpDir}/native";
+		$this->ccdir     = "{$this->tmpDir}/geoip";
+		$this->etdir     = "{$this->tmpDir}/et";
+		$this->aliasdir  = "{$this->tmpDir}/alias";
+		$this->matchdir  = "{$this->tmpDir}/match";
+		$this->matchgendir = "{$this->matchdir}/generated";
+		foreach ([
+			$this->denydir, $this->nativedir, $this->ccdir, $this->etdir, $this->aliasdir,
+			$this->matchdir, $this->matchgendir,
+		] as $d) {
+			mkdir($d, 0777, TRUE);
+		}
+		// Keeps nativedir/matchdir/matchgendir non-empty (avoids the shell literal-glob
+		// edge case on an otherwise-empty dir) -- same rationale as
+		// AlertsIpConvertPrefetchParityTest's setUp().
+		file_put_contents("{$this->nativedir}/NativePlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->matchdir}/MatchPlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->matchgendir}/MatchGenPlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->aliasdir}/AliasPlaceholder.txt", "10.0.0.3\n");
+		// The reported host is present in its logged feed, so the render never
+		// falls into find_reported_header()'s miss path -- irrelevant to the
+		// ASN column under test, kept simple/deterministic.
+		file_put_contents("{$this->denydir}/DefaultFeed.txt", "192.0.2.11\n2001:db8:dead::5\n");
+
+		$GLOBALS['pfb'] = [
+			'grep'             => '/usr/bin/grep',
+			'denydir'          => $this->denydir,
+			'nativedir'        => $this->nativedir,
+			'permitdir'        => "{$this->tmpDir}/permit",
+			'matchdir'         => $this->matchdir,
+			'matchgendir'      => $this->matchgendir,
+			'etdir'            => $this->etdir,
+			'ccdir'            => $this->ccdir,
+			'aliasdir'         => $this->aliasdir,
+			'filterlogentries' => FALSE,
+			'asn_reporting'    => 'week',	// enabled (any non-'disabled' vocabulary value)
+			'supp'             => '',	// PfbToggle::Off -- suppression-list lookup skipped
+			// Unified-mode row background CSS class (light/dark theme) -- pre-existing
+			// keys with no seeded default anywhere in production (used only by the
+			// Unified row's <tr> background pick); needed here only so a Unified-mode
+			// render doesn't trip on an unrelated, pre-existing undefined-key gap.
+			'uniblock'         => 'pfb-row-light',
+			'uniblock2'        => 'pfb-row-dark',
+		];
+		// Unified mode reads this to pick the light/dark row background class
+		// (see 'uniblock'/'uniblock2' above); seeded so strpos() never receives null.
+		$GLOBALS['config']['system']['webgui']['webguicss'] = '';
+		$GLOBALS['continents'] = array_flip(array(
+			'pfB_Africa', 'pfB_Antarctica', 'pfB_Asia', 'pfB_Europe',
+			'pfB_NAmerica', 'pfB_Oceania', 'pfB_SAmerica', 'pfB_Top',
+		));
+		$GLOBALS['filterfieldsarray'] = [];
+		$GLOBALS['clists']              = ['ipwhitelist4' => [], 'ipwhitelist6' => []];
+		$GLOBALS['ip_unlock']           = [];
+		$GLOBALS['counter']             = ['Block' => 0, 'Unified' => 0];
+		$GLOBALS['pfbentries']          = 1000;
+		$GLOBALS['skipcount']           = 0;
+		$GLOBALS['dup']                 = ['Block' => 0, 'Unified' => 0];
+		$GLOBALS['ipfilterlimit']       = FALSE;
+		$GLOBALS['ipfilterlimitentries'] = 0;
+
+		pfb_ip_render_memos_reset();
+	}
+
+	protected function tearDown(): void
+	{
+		pfb_ip_render_memos_reset();
+
+		foreach ($this->savedGlobals as $g => $v) {
+			if ($v === null) {
+				unset($GLOBALS[$g]);
+			} else {
+				$GLOBALS[$g] = $v;
+			}
+		}
+
+		rmdir_recursive($this->tmpDir);
+	}
+
+	/**
+	 * Build a raw, PRE-reorder, NEW-SCHEMA (22-element) $fields row -- the
+	 * exact non_unified shape the page's log reader delivers to
+	 * convert_ip_log() (dup marker already popped, timestamp still at [0]).
+	 * Same base as AlertsIpConvertPrefetchParityTest::rawFields(), extended
+	 * with the 2 new ASN columns at [20]/[21].
+	 */
+	private function rawFields(array $overrides): array
+	{
+		$base = [
+			0  => '2026-07-18 00:00:00',	// Date/Timestamp
+			1  => 'rule1',			// Rulenum
+			2  => 'em0',			// Real Interface
+			3  => 'WAN',			// Friendly Interface name
+			4  => 'block',			// Action
+			5  => 4,			// Version
+			6  => 'tcp',			// Protocol ID
+			7  => 'TCP',			// Protocol
+			8  => '192.0.2.11',		// SRC IP
+			9  => '198.51.100.1',		// DST IP
+			10 => '12345',			// SRC Port
+			11 => '443',			// DST Port
+			12 => 'in',			// Direction
+			13 => 'US',			// GeoIP code
+			14 => 'pfB_Default_v4',	// IP Alias Name
+			15 => '192.0.2.11',		// IP evaluated
+			16 => 'DefaultFeed',		// Feed Name
+			17 => '',			// gethostbyaddr resolved hostname
+			18 => '',			// Client Hostname
+			19 => 'Unknown',		// ASN
+			20 => '',			// ASN Domain
+			21 => '',			// ASN Name
+		];
+		return array_replace($base, $overrides);
+	}
+
+	/** Render one row via the real page function, capturing its printed HTML + warnings. */
+	private function render(array $fields, string $mode, string $rtype): array
+	{
+		$GLOBALS['dup'][$rtype]     = 0;
+		$GLOBALS['counter'][$rtype] = 0;
+		$GLOBALS['ipfilterlimit']   = FALSE;
+		$counterBefore = $GLOBALS['counter'][$rtype];
+
+		$warnings = [];
+		set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
+			$warnings[] = $errstr;
+			return true;
+		});
+		ob_start();
+		try {
+			$ret = convert_ip_log($mode, $fields, '', $rtype);
+		} finally {
+			$html = (string) ob_get_clean();
+			restore_error_handler();
+		}
+
+		return [$ret, $html, $warnings, $counterBefore];
+	}
+
+	// -----------------------------------------------------------------------
+	// Schema axis: new OK; legacy SKIPPED; malformed SKIPPED
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A well-formed new-schema (22-element) non_unified row renders normally
+	 * -- baseline for the skip tests below (proves the harness itself works
+	 * before proving what gets rejected).
+	 */
+	public function testNewSchemaRowRenders(): void
+	{
+		$fields = $this->rawFields([]);
+
+		[$ret, $html, $warnings] = $this->render($fields, 'non_unified', 'Block');
+
+		$this->assertFalse($ret[0], 'a rendered row must not signal "stop the render loop"');
+		$this->assertNotSame('', $html, 'a well-formed new-schema row must render SOME output');
+		$this->assertSame([], $warnings, 'a well-formed row must render with zero PHP warnings');
+	}
+
+	/**
+	 * A pre-upgrade LEGACY row (old 20-element non_unified shape -- the
+	 * single pipe-blob ASN field, no asn_domain/asn_name columns) is skipped
+	 * silently: no output, no warnings, and the row does not consume a
+	 * render-limit slot ($counter untouched).
+	 */
+	public function testLegacyTwentyFieldRowIsSkippedSilently(): void
+	{
+		$legacy = [
+			0  => '2026-07-18 00:00:00', 1 => 'rule1', 2 => 'em0', 3 => 'WAN', 4 => 'block',
+			5  => 4, 6 => 'tcp', 7 => 'TCP', 8 => '192.0.2.11', 9 => '198.51.100.1',
+			10 => '12345', 11 => '443', 12 => 'in', 13 => 'US', 14 => 'pfB_Default_v4',
+			15 => '192.0.2.11', 16 => 'DefaultFeed', 17 => '', 18 => '',
+			19 => '|ASN:  AS50360 | domain:  4vendeta.com | name:  Tamatiya EOOD |',	// old blob shape
+		];
+		$this->assertCount(20, $legacy, 'fixture sanity: this must be the OLD 20-element shape');
+
+		[$ret, $html, $warnings, $counterBefore] = $this->render($legacy, 'non_unified', 'Block');
+
+		$this->assertSame([FALSE, ''], $ret);
+		$this->assertSame('', $html, 'a legacy-schema row must render NOTHING, not a partial/garbled row');
+		$this->assertSame([], $warnings, 'skipping a legacy row must never raise a PHP warning/notice');
+		$this->assertSame($counterBefore, $GLOBALS['counter']['Block'], 'a skipped row must not consume a render-limit slot');
+	}
+
+	/**
+	 * A genuinely malformed row (arbitrary short field count, matching
+	 * neither the legacy nor the current schema) is skipped exactly the same
+	 * way -- zero warnings despite having far fewer elements than every
+	 * index the render path would otherwise touch.
+	 */
+	public function testMalformedShortRowIsSkippedSilently(): void
+	{
+		$malformed = [0 => '2026-07-18 00:00:00', 1 => 'rule1', 2 => 'em0', 3 => 'WAN', 4 => 'block'];
+
+		[$ret, $html, $warnings, $counterBefore] = $this->render($malformed, 'non_unified', 'Block');
+
+		$this->assertSame([FALSE, ''], $ret);
+		$this->assertSame('', $html);
+		$this->assertSame([], $warnings, 'a malformed row must never raise a PHP warning/notice');
+		$this->assertSame($counterBefore, $GLOBALS['counter']['Block']);
+	}
+
+	/**
+	 * pfb_ip_log_row_schema_ok() directly, both modes -- the exact boundary
+	 * convert_ip_log() relies on.
+	 */
+	public function testSchemaGateExactCounts(): void
+	{
+		$this->assertTrue(pfb_ip_log_row_schema_ok(array_fill(0, 22, ''), 'non_unified'), '22 elements = new non_unified schema');
+		$this->assertFalse(pfb_ip_log_row_schema_ok(array_fill(0, 20, ''), 'non_unified'), '20 elements = old legacy schema, must reject');
+		$this->assertFalse(pfb_ip_log_row_schema_ok(array_fill(0, 21, ''), 'non_unified'), '21 elements = old Unified count under the wrong mode, must reject');
+		$this->assertTrue(pfb_ip_log_row_schema_ok(array_fill(0, 23, ''), 'Unified'), '23 elements = new Unified schema');
+		$this->assertFalse(pfb_ip_log_row_schema_ok(array_fill(0, 21, ''), 'Unified'), '21 elements = old legacy Unified count, must reject');
+		$this->assertFalse(pfb_ip_log_row_schema_ok(array_fill(0, 0, ''), 'non_unified'), 'empty row must reject');
+	}
+
+	// -----------------------------------------------------------------------
+	// View axis: Unified (24-field, leading event type already stripped by
+	// the caller, trailing dup marker still attached)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A well-formed new-schema Unified-mode row (23 raw elements: timestamp
+	 * + 21 body fields + trailing dup marker, matching what
+	 * pfblockerng_alerts.php's Unified loop hands convert_ip_log() after
+	 * stripping the leading event-type field) renders the ASN + tooltip
+	 * exactly like the non_unified view.
+	 */
+	public function testUnifiedModeNewSchemaRowRendersAsnAndTooltip(): void
+	{
+		$fields = $this->rawFields([
+			19 => 'AS50360', 20 => '4vendeta.com', 21 => 'Tamatiya EOOD',
+		]);
+		$fields[22] = '+';	// trailing duplicate marker -- Unified mode does NOT pop it
+		$this->assertCount(23, $fields, 'fixture sanity: Unified non_unified+1 shape');
+
+		[$ret, $html, $warnings] = $this->render($fields, 'Unified', 'Block');
+
+		$this->assertSame([], $warnings);
+		$this->assertStringContainsString('AS50360', $html, 'the visible ASN must render in Unified mode too');
+		$this->assertStringContainsString('title="domain:', $html, 'the tooltip must render in Unified mode too');
+	}
+
+	/**
+	 * A legacy-shape Unified row (22 raw elements -- the old count) is
+	 * skipped silently, mirroring the non_unified legacy case.
+	 */
+	public function testUnifiedModeLegacyRowIsSkippedSilently(): void
+	{
+		$legacy = [
+			0 => '2026-07-18 00:00:00', 1 => 'rule1', 2 => 'em0', 3 => 'WAN', 4 => 'block',
+			5 => 4, 6 => 'tcp', 7 => 'TCP', 8 => '192.0.2.11', 9 => '198.51.100.1',
+			10 => '12345', 11 => '443', 12 => 'in', 13 => 'US', 14 => 'pfB_Default_v4',
+			15 => '192.0.2.11', 16 => 'DefaultFeed', 17 => '', 18 => '',
+			19 => 'Unknown', 20 => '+',	// old 20-body-field shape + trailing dup marker = 21
+		];
+		$this->assertCount(21, $legacy, 'fixture sanity: OLD Unified shape (20 body fields + dup)');
+
+		[$ret, $html, $warnings, $counterBefore] = $this->render($legacy, 'Unified', 'Block');
+
+		$this->assertSame([FALSE, ''], $ret);
+		$this->assertSame('', $html);
+		$this->assertSame([], $warnings);
+		$this->assertSame($counterBefore, $GLOBALS['counter']['Block']);
+	}
+
+	// -----------------------------------------------------------------------
+	// ASN state axis: found / Unknown / null
+	// -----------------------------------------------------------------------
+
+	public function testFoundAsnRendersVisibleAsnAndTooltipFromDomainAndName(): void
+	{
+		$fields = $this->rawFields([
+			19 => 'AS50360', 20 => '4vendeta.com', 21 => 'Tamatiya EOOD',
+		]);
+
+		[, $html, $warnings] = $this->render($fields, 'non_unified', 'Block');
+
+		$this->assertSame([], $warnings);
+		$this->assertStringContainsString('>AS50360<', $html, 'the visible ASN text must render');
+		$this->assertStringContainsString('title="domain:  4vendeta.com | name:  Tamatiya EOOD"', $html, 'the tooltip must be built from the domain + name columns');
+	}
+
+	public function testUnknownAsnRendersNoAsnMarkup(): void
+	{
+		$fields = $this->rawFields([19 => 'Unknown', 20 => '', 21 => '']);
+
+		[, $html, $warnings] = $this->render($fields, 'non_unified', 'Block');
+
+		$this->assertSame([], $warnings);
+		$this->assertStringNotContainsString('<span title="domain:', $html, "an 'Unknown' ASN state must render no ASN span");
+	}
+
+	/**
+	 * 'null' -- the write-time literal when ASN reporting was OFF when the
+	 * event was logged but is enabled now at render time (the "missing
+	 * metadata" state distinct from a completed-but-empty lookup).
+	 */
+	public function testNullAsnRendersNoAsnMarkup(): void
+	{
+		$fields = $this->rawFields([19 => 'null', 20 => '', 21 => '']);
+
+		[, $html, $warnings] = $this->render($fields, 'non_unified', 'Block');
+
+		$this->assertSame([], $warnings);
+		$this->assertStringNotContainsString('<span title="domain:', $html, "a 'null' ASN state must render no ASN span");
+	}
+
+	public function testAsnReportingDisabledRendersNoAsnMarkupEvenWhenFound(): void
+	{
+		$GLOBALS['pfb']['asn_reporting'] = 'disabled';
+		$fields = $this->rawFields([
+			19 => 'AS50360', 20 => '4vendeta.com', 21 => 'Tamatiya EOOD',
+		]);
+
+		[, $html, $warnings] = $this->render($fields, 'non_unified', 'Block');
+
+		$this->assertSame([], $warnings);
+		$this->assertStringNotContainsString('AS50360', $html, 'ASN reporting disabled must suppress the column regardless of a found value');
+	}
+
+	// -----------------------------------------------------------------------
+	// Family axis: IPv4, IPv6
+	// -----------------------------------------------------------------------
+
+	public function testFoundAsnRendersForIpv6Row(): void
+	{
+		$fields = $this->rawFields([
+			5 => 6, 8 => '2001:db8:dead::5', 9 => '2001:db8:2::1',
+			15 => '2001:db8:dead::5', 16 => 'DefaultFeed',
+			19 => 'AS64500', 20 => 'v6.example', 21 => 'V6 Org',
+		]);
+
+		[, $html, $warnings] = $this->render($fields, 'non_unified', 'Block');
+
+		$this->assertSame([], $warnings);
+		$this->assertStringContainsString('>AS64500<', $html);
+		$this->assertStringContainsString('title="domain:  v6.example | name:  V6 Org"', $html);
+	}
+
+	// -----------------------------------------------------------------------
+	// Text handling axis: comma, quote, colon, Unicode, empty, CR/LF --
+	// driven through a REAL fgetcsv() parse (not hand-typed array literals),
+	// proving the writer+reader round trip end to end.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Build a raw CSV line the way pfb_daemon_filterlog() does (log fields,
+	 * then $details ending in pfb_asn_csv_fields()'s encoded tail), parse it
+	 * back with the SAME escape argument the page's read loop now uses, pop
+	 * the trailing dup marker (mirroring the non_unified read-loop caller),
+	 * and hand the result straight to convert_ip_log() -- exercising the
+	 * real write -> real CSV parse -> render pipeline for one row.
+	 */
+	private function renderFromRealAsnBlob(string $blob, array $overrides = []): array
+	{
+		$asnCsv = pfb_asn_csv_fields($blob);
+		$o = array_replace([
+			'ts' => '2026-07-18 00:00:00', 'rule' => 'rule1', 'int' => 'em0', 'fint' => 'WAN',
+			'action' => 'block', 'ver' => 4, 'protoid' => 'tcp', 'proto' => 'TCP',
+			'src' => '192.0.2.11', 'dst' => '198.51.100.1', 'sport' => '12345', 'dport' => '443',
+			'dir' => 'in', 'geoip' => 'US', 'alias' => 'pfB_Default_v4', 'eval' => '192.0.2.11',
+			'feed' => 'DefaultFeed', 'resolved' => '', 'client' => '',
+		], $overrides);
+
+		$line = implode(',', [
+			$o['ts'], $o['rule'], $o['int'], $o['fint'], $o['action'], $o['ver'], $o['protoid'], $o['proto'],
+			$o['src'], $o['dst'], $o['sport'], $o['dport'], $o['dir'], $o['geoip'], $o['alias'], $o['eval'],
+			$o['feed'], $o['resolved'], $o['client'],
+		]) . ',' . $asnCsv . ',+';
+
+		$fh = fopen('php://temp', 'r+');
+		$this->assertNotFalse($fh);
+		fwrite($fh, $line . "\n");
+		rewind($fh);
+		$fields = fgetcsv($fh, 0, ',', '"', '');
+		fclose($fh);
+		$this->assertNotFalse($fields, 'the synthetic line must parse as valid CSV');
+
+		$dup = array_pop($fields);	// mirrors the page's non_unified read loop
+		$this->assertSame('+', $dup);
+		$this->assertCount(22, $fields, 'fixture sanity: 22-element new non_unified schema after popping dup');
+
+		return $this->render($fields, 'non_unified', 'Block');
+	}
+
+	public function testTextHandlingCommaInDomainRoundTripsAndRenders(): void
+	{
+		[, $html, $warnings] = $this->renderFromRealAsnBlob(
+			'|ASN:  AS64510 | domain:  ex,ample.com | name:  CommaOrg |'
+		);
+
+		$this->assertSame([], $warnings);
+		$this->assertStringContainsString('>AS64510<', $html);
+		$this->assertStringContainsString('ex,ample.com', $html, 'the comma-bearing domain must reach the tooltip intact');
+	}
+
+	public function testTextHandlingQuoteInNameRoundTripsAndRenders(): void
+	{
+		[, $html, $warnings] = $this->renderFromRealAsnBlob(
+			'|ASN:  AS64511 | domain:  example.net | name:  "Quoted" Org |'
+		);
+
+		$this->assertSame([], $warnings);
+		$this->assertStringContainsString('>AS64511<', $html);
+		// pfb_hsc() HTML-encodes the literal double quote for safe attribute embedding.
+		$this->assertStringContainsString('&quot;Quoted&quot; Org', $html, 'the quote-bearing name must reach the tooltip, HTML-encoded');
+	}
+
+	public function testTextHandlingColonInNameRoundTripsAndRenders(): void
+	{
+		[, $html, $warnings] = $this->renderFromRealAsnBlob(
+			'|ASN:  AS64512 | domain:  example.org | name:  Org: EMEA Division |'
+		);
+
+		$this->assertSame([], $warnings);
+		$this->assertStringContainsString('>AS64512<', $html);
+		$this->assertStringContainsString('Org: EMEA Division', $html, 'the colon-bearing name must reach the tooltip intact');
+	}
+
+	public function testTextHandlingUnicodeInNameRoundTripsAndRenders(): void
+	{
+		[, $html, $warnings] = $this->renderFromRealAsnBlob(
+			'|ASN:  AS64513 | domain:  xn--ls8h.example | name:  Ünïcödé Örg 日本 |'
+		);
+
+		$this->assertSame([], $warnings);
+		$this->assertStringContainsString('>AS64513<', $html);
+		$this->assertStringContainsString('Ünïcödé Örg 日本', $html, 'the Unicode name must reach the tooltip byte-identical');
+	}
+
+	public function testTextHandlingEmptyDomainAndNameRenderBlankTooltipSegments(): void
+	{
+		[, $html, $warnings] = $this->renderFromRealAsnBlob(
+			'|ASN:  AS64514 | domain:   | name:   |'
+		);
+
+		$this->assertSame([], $warnings);
+		$this->assertStringContainsString('>AS64514<', $html);
+		$this->assertStringContainsString('title="domain:   | name:  "', $html, 'empty domain/name must render as blank tooltip segments, not warnings/placeholders');
+	}
+
+	public function testTextHandlingCrLfInNameRoundTripsAsNormalizedSpace(): void
+	{
+		[, $html, $warnings] = $this->renderFromRealAsnBlob(
+			"|ASN:  AS64515 | domain:  example.io | name:  Line One\r\nLine Two |"
+		);
+
+		$this->assertSame([], $warnings);
+		$this->assertStringContainsString('>AS64515<', $html);
+		$this->assertStringContainsString('Line One Line Two', $html, 'CR/LF in the name must have been normalized to a space before it ever reached the log');
+		$this->assertStringNotContainsString("Line One\r\nLine Two", $html);
+	}
+
+	// -----------------------------------------------------------------------
+	// Consumer axis: ASN filter (pfb_match_filter_field key==18 special-case)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * The ASN filter (Alerts page "Filter" fields, keyed on the ASN column
+	 * position) continues to match against the new plain ASN token -- no
+	 * change needed to pfb_match_filter_field(), which already strips a
+	 * leading 'AS' from the query and regex-matches the raw field value.
+	 */
+	public function testAsnFilterMatchesNewPlainAsnField(): void
+	{
+		$GLOBALS['pfb']['filterlogentries'] = TRUE;
+		$GLOBALS['filterfieldsarray'] = [[18 => 'AS50360']];
+
+		$matching = $this->rawFields([19 => 'AS50360', 20 => '4vendeta.com', 21 => 'Tamatiya EOOD']);
+		[, $htmlMatch, $warnings1] = $this->render($matching, 'non_unified', 'Block');
+
+		$GLOBALS['dup']['Block'] = 0;
+		$GLOBALS['counter']['Block'] = 0;
+		$nonMatching = $this->rawFields([19 => 'AS99999', 20 => 'other.example', 21 => 'Other Org']);
+		[$retNoMatch, $htmlNoMatch, $warnings2] = $this->render($nonMatching, 'non_unified', 'Block');
+
+		$this->assertSame([], $warnings1);
+		$this->assertSame([], $warnings2);
+		$this->assertStringContainsString('>AS50360<', $htmlMatch, 'a row whose ASN matches the filter must render');
+		$this->assertSame('', $htmlNoMatch, 'a row whose ASN does NOT match the filter must render nothing');
+		$this->assertSame([FALSE, ''], $retNoMatch);
+	}
+
+	/**
+	 * A schema-invalid (legacy) row is skipped BEFORE the filter match ever
+	 * runs against it -- proves the schema gate is unconditional, not
+	 * dependent on whether filtering is active.
+	 */
+	public function testAsnFilterNeverEvaluatesAgainstALegacyRow(): void
+	{
+		$GLOBALS['pfb']['filterlogentries'] = TRUE;
+		$GLOBALS['filterfieldsarray'] = [[18 => 'AS50360']];
+
+		$legacy = [
+			0 => '2026-07-18 00:00:00', 1 => 'rule1', 2 => 'em0', 3 => 'WAN', 4 => 'block',
+			5 => 4, 6 => 'tcp', 7 => 'TCP', 8 => '192.0.2.11', 9 => '198.51.100.1',
+			10 => '12345', 11 => '443', 12 => 'in', 13 => 'US', 14 => 'pfB_Default_v4',
+			15 => '192.0.2.11', 16 => 'DefaultFeed', 17 => '', 18 => '',
+			19 => '|ASN:  AS50360 | domain:  4vendeta.com | name:  Tamatiya EOOD |',
+		];
+
+		[$ret, $html, $warnings] = $this->render($legacy, 'non_unified', 'Block');
+
+		$this->assertSame([FALSE, ''], $ret);
+		$this->assertSame('', $html);
+		$this->assertSame([], $warnings, 'a legacy row must never reach pfb_match_filter_field() at all');
+	}
+}

--- a/tests/php/AlertsIpConvertPrefetchParityTest.php
+++ b/tests/php/AlertsIpConvertPrefetchParityTest.php
@@ -161,6 +161,12 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 	 * per convert_ip_log()'s own "(Removed and re-ordered)" + "(Final $fields array
 	 * reference)" doc comment: index 0 is the timestamp that gets shifted out, and
 	 * every field from convert_ip_log()'s reference list follows shifted up by one.
+	 *
+	 * issue #1369: 22 elements (0-21), the current post-timestamp-shift-plus-one
+	 * schema -- indices 20/21 (ASN Domain/ASN Name) are new; convert_ip_log() now
+	 * silently skips any OTHER field count (pfb_ip_log_row_schema_ok()), so every
+	 * fixture in this file must carry the full 22-element shape or every case here
+	 * would render nothing at all.
 	 */
 	private function rawFields(array $overrides): array
 	{
@@ -185,6 +191,8 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 			17 => '',			// gethostbyaddr resolved hostname
 			18 => '',			// Client Hostname
 			19 => 'Unknown',		// ASN
+			20 => '',			// ASN Domain (issue #1369)
+			21 => '',			// ASN Name (issue #1369)
 		];
 		return array_replace($base, $overrides);
 	}

--- a/tests/php/AlertsIpUnlockIconTest.php
+++ b/tests/php/AlertsIpUnlockIconTest.php
@@ -132,6 +132,9 @@ final class AlertsIpUnlockIconTest extends TestCase
 	/**
 	 * Build a raw, PRE-reorder $fields row -- same shape/reference as
 	 * AlertsIpConvertPrefetchParityTest::rawFields().
+	 *
+	 * issue #1369: 22 elements (0-21) -- see that file's rawFields() docblock;
+	 * convert_ip_log() silently skips any other field count.
 	 */
 	private function rawFields(array $overrides): array
 	{
@@ -156,6 +159,8 @@ final class AlertsIpUnlockIconTest extends TestCase
 			17 => '',			// gethostbyaddr resolved hostname
 			18 => '',			// Client Hostname
 			19 => 'Unknown',		// ASN
+			20 => '',			// ASN Domain (issue #1369)
+			21 => '',			// ASN Name (issue #1369)
 		];
 		return array_replace($base, $overrides);
 	}

--- a/tests/php/LogFormatConsumersTest.php
+++ b/tests/php/LogFormatConsumersTest.php
@@ -528,4 +528,81 @@ EOT;
 			$this->assertSame($expected, $data, "{$label}: unexpected rendered bucket label");
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// issue #1369 (ADR-38 Amendment 3) -- Top ASN stats: the shell (cut/awk)
+	// pipeline behind pfblockerng_alerts.php's 'ipasn' stat is inline
+	// top-level page code (the $stat_info/switch block), not a callable
+	// function -- same reproduce-and-exec convention this file already uses
+	// for the day-bucket/chart pipelines above.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Source tripwire: the 'ipasn' case must gate on the exact new-schema
+	 * field count (NF == 23) BEFORE cutting column 20, so this oracle goes
+	 * red the moment the gate or the column position drifts.
+	 */
+	public function testTopAsnStatPipelineSourceHasSchemaGate(): void
+	{
+		$source = (string) file_get_contents(self::ALERTS_PHP);
+		$needle = "{\$pfb['awk']} -F',' 'NF == 23' {\$alert_log} | {\$cut_cmd} | {\$agent_cmd} {\$su_cmd} | sort -nr 2>&1";
+		$this->assertStringContainsString($needle, $source, "pfblockerng_alerts.php's Top ASN ('ipasn') pipeline changed -- update this oracle");
+		$this->assertStringContainsString("'ipasn'\t\t=> 20", $source, "the 'ipasn' cut-column position changed -- update this oracle (must stay 20: the 2 new columns were appended AFTER it)");
+	}
+
+	/**
+	 * A synthetic ip_block.log with 2 new-schema (23-field) rows sharing one
+	 * ASN plus 1 pre-upgrade legacy (21-field, single pipe-blob ASN column)
+	 * row. Green: the NEW (NF==23-gated) pipeline counts only the 2 new-
+	 * schema rows under their plain ASN token; the legacy row's blob-shaped
+	 * column 20 never appears at all.
+	 */
+	private function mixedAsnFixture(): string
+	{
+		$fixture = $this->tempFile('pfb_alerts_asn_mixed_');
+		$new1 = '2026-07-18 09:00:00,rule1,em0,WAN,block,4,tcp,TCP,192.0.2.1,198.51.100.1,1,2,in,US,Alias,192.0.2.1,Feed,,,AS50360,4vendeta.com,Tamatiya EOOD,+';
+		$new2 = '2026-07-18 09:05:00,rule1,em0,WAN,block,4,tcp,TCP,192.0.2.2,198.51.100.1,1,2,in,US,Alias,192.0.2.2,Feed,,,AS50360,4vendeta.com,Tamatiya EOOD,+';
+		$legacy = '2026-07-18 09:10:00,rule1,em0,WAN,block,4,tcp,TCP,192.0.2.9,198.51.100.1,1,2,in,US,Alias,192.0.2.9,Feed,,,|ASN:  AS99999 | domain:  legacy.example | name:  Legacy Org |,+';
+		$this->assertCount(23, explode(',', $new1), 'fixture sanity: new1 must be the 23-field schema');
+		$this->assertCount(23, explode(',', $new2), 'fixture sanity: new2 must be the 23-field schema');
+		$this->assertCount(21, explode(',', $legacy), 'fixture sanity: legacy must be the OLD 21-field schema');
+		file_put_contents($fixture, "{$new1}\n{$new2}\n{$legacy}\n");
+		return $fixture;
+	}
+
+	public function testTopAsnNewPipelineSkipsLegacyRowAndCountsNewSchemaRows(): void
+	{
+		$fixture = $this->mixedAsnFixture();
+
+		// Reproduces the 'ipasn' case body verbatim (tripwired above) against
+		// the synthetic fixture instead of a real alert_log.
+		exec("/usr/bin/awk -F',' 'NF == 23' {$fixture} | /usr/bin/cut -d ',' -f20 | sort | uniq -c | sort -nr 2>&1", $stats);
+
+		$joined = implode(', ', $stats);
+		$this->assertStringNotContainsString('ASN:', $joined, "the legacy row's pipe-blob text must never appear in the Top ASN stat; got: {$joined}");
+		$this->assertStringNotContainsString('AS99999', $joined, "the legacy row's ASN must never be counted; got: {$joined}");
+		$this->assertCount(1, $stats, 'the 2 new-schema rows sharing one ASN must collapse into exactly one bucket');
+		$this->assertStringContainsString('AS50360', $stats[0], "expected the new-schema ASN bucket; got: {$stats[0]}");
+		$this->assertMatchesRegularExpression('/^\s*2\s+AS50360$/', $stats[0], "expected a count of 2 for AS50360; got: {$stats[0]}");
+	}
+
+	/**
+	 * Red proof: the PRE-#1369 (ungated) pipeline -- a bare `cut -d ',' -f20`
+	 * with no NF filter -- pollutes the Top ASN count with the legacy row's
+	 * raw pipe-blob text as if it were a real ASN bucket (the live breakage
+	 * the owner's no-back-compat amendment requires this gate to prevent).
+	 */
+	public function testTopAsnOldUngatedPipelinePollutesWithLegacyBlobText(): void
+	{
+		$fixture = $this->mixedAsnFixture();
+
+		exec("/usr/bin/cut -d ',' -f20 {$fixture} | sort | uniq -c | sort -nr 2>&1", $stats);
+
+		$joined = implode(', ', $stats);
+		$this->assertStringContainsString(
+			'ASN:',
+			$joined,
+			"the OLD ungated pipeline must surface the legacy row's raw blob text as a bucket (the live breakage); got: {$joined}"
+		);
+	}
 }

--- a/tests/php/UnifiedFormatTest.php
+++ b/tests/php/UnifiedFormatTest.php
@@ -6,20 +6,32 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * ADR-38 Amendment 1 — DNSBL syslog + unified.log formatter tests.
+ * ADR-38 Amendment 3 (issue #1369) — ASN CSV-column helper tests.
  *
  * Pins the behaviour of:
  *   pfb_syslog_format_dnsbl(array $fields): string
  *   pfb_unified_format_ip(array $fields): string
  *   pfb_unified_format_dnsbl(array $fields): string
  *   pfb_unified_format_dnsreply(array $fields): string
+ *   pfb_asn_blob_split(string $blob): array
+ *   pfb_asn_csv_fields(string $blob): string
  *
- * All four functions are PURE (no I/O, no globals).  These tests are the only
+ * All six functions are PURE (no I/O, no globals -- pfb_asn_csv_fields()'s
+ * only I/O is an in-memory php://temp stream). These tests are the only
  * callers during this phase.
  *
  * Coverage mandate (CLAUDE.md):
  *   - pfb_syslog_format_dnsbl: all fields; group absent; feed absent; both
  *     absent; a value with a space is double-quoted; NULL b_type + CNAME q_type.
  *   - pfb_unified_format_ip/dnsbl/dnsreply: exact golden-string fidelity.
+ *   - pfb_asn_blob_split/pfb_asn_csv_fields (issue #1369): the real pipe-blob
+ *     shape from the issue's own pasted example; bare 'Unknown'/'null'/''
+ *     states; comma/quote/colon/Unicode/CR/LF in domain or name (fputcsv()
+ *     also quotes any value containing a space -- stricter than bare
+ *     RFC4180, still valid); the encoded 3-field tail round-trips through
+ *     fgetcsv() with no bespoke escaping, including when spliced into a full
+ *     unified.log row via pfb_unified_format_ip() (field-local CSV quoting
+ *     composes).
  *
  * All assertions are against EXACT golden strings.
  */
@@ -473,5 +485,279 @@ final class UnifiedFormatTest extends TestCase
 			$result,
 			'the new ISO-8601 datetime must pass through unmodified -- zero further change needed'
 		);
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_asn_blob_split (issue #1369 / ADR-38 Amendment 3)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * The real blob shape from issue #1369's own pasted example line, verbatim
+	 * (not re-derived): "|ASN:  AS50360 | domain:  4vendeta.com | name:
+	 * Tamatiya EOOD |". Confirms the label/value split at the FIRST ':' per
+	 * segment, trimming the padding whitespace mmdblookup's flattening leaves.
+	 */
+	public function testAsnBlobSplitRealExampleFromIssue(): void
+	{
+		$blob = '|ASN:  AS50360 | domain:  4vendeta.com | name:  Tamatiya EOOD |';
+
+		$result = pfb_asn_blob_split($blob);
+
+		$this->assertSame(
+			['asn' => 'AS50360', 'domain' => '4vendeta.com', 'name' => 'Tamatiya EOOD'],
+			$result,
+			'the real issue #1369 example blob must split into these exact 3 parts'
+		);
+	}
+
+	/**
+	 * A bare 'Unknown' state literal (the lookup found nothing) has no '|' or
+	 * ':' -- passed through verbatim as 'asn', domain/name empty.
+	 */
+	public function testAsnBlobSplitUnknownStateLiteral(): void
+	{
+		$result = pfb_asn_blob_split('Unknown');
+
+		$this->assertSame(['asn' => 'Unknown', 'domain' => '', 'name' => ''], $result);
+	}
+
+	/**
+	 * A bare 'null' state literal (ASN reporting was off at write time) --
+	 * same bare-literal handling as 'Unknown'.
+	 */
+	public function testAsnBlobSplitNullStateLiteral(): void
+	{
+		$result = pfb_asn_blob_split('null');
+
+		$this->assertSame(['asn' => 'null', 'domain' => '', 'name' => ''], $result);
+	}
+
+	/**
+	 * An empty blob coerces to the 'Unknown' state (never a blank asn value).
+	 */
+	public function testAsnBlobSplitEmptyStringCoercesToUnknown(): void
+	{
+		$result = pfb_asn_blob_split('');
+
+		$this->assertSame(['asn' => 'Unknown', 'domain' => '', 'name' => ''], $result);
+	}
+
+	/**
+	 * A domain/name carrying a comma, a double quote, a colon, and a
+	 * Unicode codepoint all split correctly -- the label split only ever
+	 * consumes the segment's FIRST ':', so a colon inside the VALUE (not
+	 * just the label) is preserved verbatim.
+	 */
+	public function testAsnBlobSplitPreservesCommaQuoteColonAndUnicodeInValues(): void
+	{
+		$blob = '|ASN:  AS64500 | domain:  ex,ample.com | name:  Ünïcödé "Org", Ltd: EMEA |';
+
+		$result = pfb_asn_blob_split($blob);
+
+		$this->assertSame('AS64500', $result['asn']);
+		$this->assertSame('ex,ample.com', $result['domain']);
+		$this->assertSame('Ünïcödé "Org", Ltd: EMEA', $result['name']);
+	}
+
+	// -----------------------------------------------------------------------
+	// pfb_asn_csv_fields (issue #1369 / ADR-38 Amendment 3)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Single-token domain/name (no comma/quote/space anywhere) renders as 3
+	 * fully unquoted CSV fields -- nothing forces fputcsv() to quote.
+	 */
+	public function testAsnCsvFieldsSingleTokenValuesRenderFullyUnquoted(): void
+	{
+		$blob = '|ASN:  AS64599 | domain:  example.com | name:  ExampleOrg |';
+
+		$result = pfb_asn_csv_fields($blob);
+
+		$this->assertSame('AS64599,example.com,ExampleOrg', $result);
+	}
+
+	/**
+	 * The real blob shape from issue #1369's own pasted example. PHP's
+	 * fputcsv() quotes ANY field containing a space -- a stricter guarantee
+	 * than the bare RFC4180 minimum (delimiter/enclosure/newline only), still
+	 * valid CSV that round-trips identically (proved by the fgetcsv
+	 * round-trip tests below), so the multi-word org name comes back quoted.
+	 */
+	public function testAsnCsvFieldsRealExampleFromIssueQuotesTheSpaceContainingName(): void
+	{
+		$blob = '|ASN:  AS50360 | domain:  4vendeta.com | name:  Tamatiya EOOD |';
+
+		$result = pfb_asn_csv_fields($blob);
+
+		$this->assertSame('AS50360,4vendeta.com,"Tamatiya EOOD"', $result);
+	}
+
+	/**
+	 * A comma inside the org name forces RFC4180 double-quoting of THAT field
+	 * only -- native fputcsv() behaviour with an explicit empty escape arg
+	 * (never PHP's default backslash-escape quirk).
+	 */
+	public function testAsnCsvFieldsCommaInNameIsDoubleQuoted(): void
+	{
+		$blob = '|ASN:  AS64500 | domain:  example.com | name:  Example, Inc |';
+
+		$result = pfb_asn_csv_fields($blob);
+
+		$this->assertSame('AS64500,example.com,"Example, Inc"', $result);
+	}
+
+	/**
+	 * A double quote inside the org name is doubled per RFC4180 (never
+	 * backslash-escaped) -- exercises fputcsv()'s explicit empty escape arg.
+	 */
+	public function testAsnCsvFieldsQuoteInNameIsRfc4180Doubled(): void
+	{
+		$blob = '|ASN:  AS64501 | domain:  example.net | name:  "Quoted" Org |';
+
+		$result = pfb_asn_csv_fields($blob);
+
+		$this->assertSame('AS64501,example.net,"""Quoted"" Org"', $result);
+	}
+
+	/**
+	 * A colon inside the org name (not just the label) survives -- the
+	 * blob-split only consumes the segment's FIRST ':', and CSV has no
+	 * quoting rule for ':' at all (the surrounding quotes here are the same
+	 * space-triggered quoting as the real-example test above, not a colon
+	 * escaping rule).
+	 */
+	public function testAsnCsvFieldsColonInNamePassesThroughUnescaped(): void
+	{
+		$blob = '|ASN:  AS64502 | domain:  example.org | name:  Org: EMEA Division |';
+
+		$result = pfb_asn_csv_fields($blob);
+
+		$this->assertSame('AS64502,example.org,"Org: EMEA Division"', $result);
+	}
+
+	/**
+	 * A Unicode codepoint in the org name passes through byte-identical --
+	 * fputcsv() is byte-oriented, not charset-aware, so UTF-8 needs no
+	 * special handling (quoted here because the value also contains spaces).
+	 */
+	public function testAsnCsvFieldsUnicodeInNamePassesThroughUnmodified(): void
+	{
+		$blob = '|ASN:  AS64503 | domain:  xn--ls8h.example | name:  Ünïcödé Örg 日本 |';
+
+		$result = pfb_asn_csv_fields($blob);
+
+		$this->assertSame('AS64503,xn--ls8h.example,"Ünïcödé Örg 日本"', $result);
+	}
+
+	/**
+	 * An empty domain/name (label present, value empty) renders as an empty
+	 * CSV segment, never a stray placeholder.
+	 */
+	public function testAsnCsvFieldsEmptyDomainAndNameRenderAsEmptySegments(): void
+	{
+		$blob = '|ASN:  AS64504 | domain:   | name:   |';
+
+		$result = pfb_asn_csv_fields($blob);
+
+		$this->assertSame('AS64504,,', $result);
+	}
+
+	/**
+	 * CR/LF embedded in the org name is normalized to a single space BEFORE
+	 * CSV-encoding -- so a written row always stays exactly one physical
+	 * line (reverse-tail readers rely on this), per the issue #1369
+	 * amendment's explicit contract.
+	 */
+	public function testAsnCsvFieldsCrLfInNameNormalizedToSpace(): void
+	{
+		$blob = "|ASN:  AS64505 | domain:  example.io | name:  Line One\r\nLine Two |";
+
+		$result = pfb_asn_csv_fields($blob);
+
+		$this->assertSame('AS64505,example.io,"Line One Line Two"', $result);
+		$this->assertStringNotContainsString("\n", $result, 'the encoded fragment must never contain a raw newline');
+		$this->assertStringNotContainsString("\r", $result, 'the encoded fragment must never contain a raw carriage return');
+	}
+
+	/**
+	 * A bare 'Unknown'/'null' state blob renders as a single unquoted token
+	 * plus two empty segments -- exactly the writer's "no metadata" shape.
+	 */
+	public function testAsnCsvFieldsUnknownAndNullStatesRenderBareToken(): void
+	{
+		$this->assertSame('Unknown,,', pfb_asn_csv_fields('Unknown'));
+		$this->assertSame('null,,', pfb_asn_csv_fields('null'));
+		$this->assertSame('Unknown,,', pfb_asn_csv_fields(''));
+	}
+
+	/**
+	 * End-to-end round trip: the encoded 3-field tail, spliced into a full
+	 * comma-joined row exactly as pfb_daemon_filterlog() builds $details,
+	 * parses back via fgetcsv() (matching escape argument) into the SAME 3
+	 * values -- "round-trips through CSV without bespoke escaping" for a
+	 * value carrying every awkward character in the coverage matrix at once.
+	 */
+	public function testAsnCsvFieldsRoundTripsThroughFgetcsv(): void
+	{
+		$blob = '|ASN:  AS64506 | domain:  ex,am"ple.com | name:  Ünïcödé "Org", Ltd: EMEA |';
+		$asnCsv = pfb_asn_csv_fields($blob);
+
+		// Mirrors pfb_daemon_filterlog()'s $details construction: the 3-field
+		// tail is spliced onto the end of an otherwise plain comma-joined row.
+		$line = "2026-07-18 00:00:00,rule1,em0,WAN,block,4,tcp,TCP,192.0.2.1,198.51.100.1,1,2,in,US,Alias,192.0.2.1,Feed,,," . $asnCsv;
+
+		$fh = fopen('php://temp', 'r+');
+		$this->assertNotFalse($fh);
+		fwrite($fh, $line . "\n");
+		rewind($fh);
+		$parsed = fgetcsv($fh, 0, ',', '"', '');
+		fclose($fh);
+
+		$this->assertNotFalse($parsed, 'the spliced row must parse as valid CSV');
+		// Indices 0-18 are the 19 plain fields (timestamp through Client
+		// Hostname) before the ASN triplet at 19/20/21.
+		$this->assertSame('AS64506', $parsed[19] ?? null, 'asn column');
+		$this->assertSame('ex,am"ple.com', $parsed[20] ?? null, 'asn_domain column, comma+quote intact');
+		$this->assertSame('Ünïcödé "Org", Ltd: EMEA', $parsed[21] ?? null, 'asn_name column, comma+quote+colon+unicode intact');
+		$this->assertCount(22, $parsed, 'exactly 22 fields: 19 plain (incl. timestamp) + asn + asn_domain + asn_name');
+	}
+
+	/**
+	 * Same round trip, but the encoded tail is spliced through
+	 * pfb_unified_format_ip() itself (the 'details' key) -- proving
+	 * field-local CSV quoting composes: pre-escaping the 3-field tail with
+	 * fputcsv() and then string-joining it into the simple l_type/log/
+	 * details/dup concat is equivalent to escaping the whole row at once,
+	 * because RFC4180 quoting never depends on neighbouring fields.
+	 */
+	public function testAsnCsvFieldsSurviveThroughPfbUnifiedFormatIpAndFgetcsv(): void
+	{
+		$blob = '|ASN:  AS64507 | domain:  4vendeta.com | name:  Tamatiya, EOOD |';
+		$asnCsv = pfb_asn_csv_fields($blob);
+
+		$log = '2026-07-18 00:00:00,rule1,em0,WAN,block,4,tcp,TCP,192.0.2.1,198.51.100.1,1,2';
+		$details = 'in,US,Alias,192.0.2.1,Feed,ResolvedHost,ClientHost,' . $asnCsv;
+
+		$unified = pfb_unified_format_ip([
+			'l_type'  => 'Block',
+			'log'     => $log,
+			'details' => $details,
+			'dup'     => '+',
+		]);
+
+		$fh = fopen('php://temp', 'r+');
+		$this->assertNotFalse($fh);
+		fwrite($fh, $unified . "\n");
+		rewind($fh);
+		$parsed = fgetcsv($fh, 0, ',', '"', '');
+		fclose($fh);
+
+		$this->assertNotFalse($parsed);
+		$this->assertSame('Block', $parsed[0] ?? null, 'unified row keeps its leading event-type prefix');
+		$this->assertCount(24, $parsed, 'l_type + 19 plain fields (incl. timestamp) + asn + asn_domain + asn_name + dup = 24');
+		$this->assertSame('AS64507', $parsed[20] ?? null, 'asn column');
+		$this->assertSame('4vendeta.com', $parsed[21] ?? null, 'asn_domain column');
+		$this->assertSame('Tamatiya, EOOD', $parsed[22] ?? null, 'asn_name column, comma intact');
+		$this->assertSame('+', $parsed[23] ?? null, 'trailing duplicate-marker column unaffected');
 	}
 }

--- a/tests/smoke/ui/test_alerts_asn_csv.py
+++ b/tests/smoke/ui/test_alerts_asn_csv.py
@@ -20,6 +20,7 @@ the sweep-level oracle condition ``(d)`` a body-only check would miss).
 
 from __future__ import annotations
 
+import re
 import subprocess
 import time
 from typing import TYPE_CHECKING
@@ -62,19 +63,29 @@ def _asn_reporting_enabled(smoke_vm: SmokeVM) -> Iterator[None]:
     """
     vm = smoke_vm
     original = helpers.config_get(vm, ASN_REPORTING_CFG)
-    helpers.php_eval(
+    enable = helpers.php_eval(
         vm,
         f"config_set_path('{ASN_REPORTING_CFG}', 'week');\n"
         "write_config('pfBlockerNG smoke: enable asn_reporting for issue #1369 ASN CSV test');\n"
         "echo 'OK';",
     )
-    yield
-    helpers.php_eval(
-        vm,
-        f"config_set_path('{ASN_REPORTING_CFG}', '{original}');\n"
-        "write_config('pfBlockerNG smoke: restore asn_reporting after issue #1369 ASN CSV test');\n"
-        "echo 'OK';",
+    assert enable.returncode == 0 and "OK" in enable.stdout, (
+        f"failed to enable asn_reporting (rc={enable.returncode}, stdout={enable.stdout!r}) -- "
+        "config may be partially mutated"
     )
+    try:
+        yield
+    finally:
+        restore = helpers.php_eval(
+            vm,
+            f"config_set_path('{ASN_REPORTING_CFG}', '{original}');\n"
+            "write_config('pfBlockerNG smoke: restore asn_reporting after issue #1369 ASN CSV test');\n"
+            "echo 'OK';",
+        )
+        assert restore.returncode == 0 and "OK" in restore.stdout, (
+            f"failed to restore asn_reporting={original!r} (rc={restore.returncode}, "
+            f"stdout={restore.stdout!r}) -- config state leaked to sibling smoke modules"
+        )
 
 
 @pytest.fixture
@@ -87,13 +98,12 @@ def _seeded_ip_block_log(smoke_vm: SmokeVM) -> Iterator[None]:
     a clean, focused assertion).
     """
     vm = smoke_vm
-    ts = time.strftime("%b %d %H:%M:%S")
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
 
     # NEW schema (23 raw fields incl. timestamp): ...,feed,rhost,chost,
     # asn,asn_domain,asn_name,dup -- the comma-bearing domain/name are
-    # RFC4180-quoted exactly as pfb_asn_csv_fields()/fputcsv() would encode
-    # them (UnifiedFormatTest.php pins the encoder itself off-box; this
-    # proves the SAME shape renders correctly through the real page).
+    # RFC4180-quoted (double-quote wrapping, no escape character), the
+    # exact bytes pfb_asn_csv_fields()/fputcsv() emit for these values.
     new_row = (
         f"{ts},100,em0,WAN,block,4,6,TCP,"
         f"{NEW_SCHEMA_HOST},10.0.0.5,12345,443,"
@@ -111,41 +121,55 @@ def _seeded_ip_block_log(smoke_vm: SmokeVM) -> Iterator[None]:
     )
 
     log_dir = IP_BLOCK_LOG.rsplit("/", 1)[0]
-    ensure = vm.ssh(f"mkdir -p {log_dir} && touch {IP_BLOCK_LOG}", timeout=15)
-    assert ensure.returncode == 0, f"failed to ensure {IP_BLOCK_LOG} exists: {ensure.stderr!r}"
-
     deny_feed_new = "/var/db/pfblockerng/deny/pfB_AsnFeedNew.txt"
     deny_feed_legacy = "/var/db/pfblockerng/deny/pfB_AsnFeedLegacy.txt"
-    seed = vm.ssh(
-        f"printf '{NEW_SCHEMA_HOST}\\n' > {deny_feed_new} && printf '{LEGACY_SCHEMA_HOST}\\n' > {deny_feed_legacy}",
-        timeout=15,
-    )
-    assert seed.returncode == 0, f"failed to seed deny-folder feed files: stderr={seed.stderr!r}"
 
-    size_before = vm.ssh("stat", "-f", "%z", IP_BLOCK_LOG, timeout=15)
-    assert size_before.returncode == 0, f"failed to stat {IP_BLOCK_LOG}: stderr={size_before.stderr!r}"
-    original_size = size_before.stdout.strip()
+    # Every mutation registers its undo BEFORE the next fallible step runs, so
+    # a failure anywhere mid-setup still tears down what already landed
+    # instead of leaking feed files / log rows into sibling smoke modules.
+    feeds_seeded = False
+    original_size: str | None = None
+    try:
+        ensure = vm.ssh(f"mkdir -p {log_dir} && touch {IP_BLOCK_LOG}", timeout=15)
+        assert ensure.returncode == 0, f"failed to ensure {IP_BLOCK_LOG} exists: {ensure.stderr!r}"
 
-    append = subprocess.run(
-        vm.ssh_argv("tee", "-a", IP_BLOCK_LOG),
-        input=new_row + legacy_row,
-        capture_output=True,
-        text=True,
-        timeout=15,
-        check=False,
-    )
-    assert append.returncode == 0, f"failed to append fixture rows to {IP_BLOCK_LOG}: stderr={append.stderr!r}"
+        seed = vm.ssh(
+            f"printf '{NEW_SCHEMA_HOST}\\n' > {deny_feed_new} && printf '{LEGACY_SCHEMA_HOST}\\n' > {deny_feed_legacy}",
+            timeout=15,
+        )
+        feeds_seeded = True
+        assert seed.returncode == 0, f"failed to seed deny-folder feed files: stderr={seed.stderr!r}"
 
-    yield
+        size_before = vm.ssh("stat", "-f", "%z", IP_BLOCK_LOG, timeout=15)
+        assert size_before.returncode == 0, f"failed to stat {IP_BLOCK_LOG}: stderr={size_before.stderr!r}"
 
-    restore = vm.ssh(f"truncate -s {original_size} {IP_BLOCK_LOG}", timeout=15)
-    assert restore.returncode == 0, f"failed to restore {IP_BLOCK_LOG} size: stderr={restore.stderr!r}"
-    size_after = vm.ssh("stat", "-f", "%z", IP_BLOCK_LOG, timeout=15)
-    assert size_after.returncode == 0 and size_after.stdout.strip() == original_size, (
-        f"{IP_BLOCK_LOG} restore did not take (before={original_size!r}, after={size_after.stdout.strip()!r}) "
-        "-- synthetic rows leaked to sibling tests"
-    )
-    vm.ssh(f"rm -f {deny_feed_new} {deny_feed_legacy}", timeout=15)
+        append = subprocess.run(
+            vm.ssh_argv("tee", "-a", IP_BLOCK_LOG),
+            input=new_row + legacy_row,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        original_size = size_before.stdout.strip()
+        assert append.returncode == 0, f"failed to append fixture rows to {IP_BLOCK_LOG}: stderr={append.stderr!r}"
+
+        yield
+    finally:
+        if original_size is not None:
+            restore = vm.ssh(f"truncate -s {original_size} {IP_BLOCK_LOG}", timeout=15)
+            assert restore.returncode == 0, f"failed to restore {IP_BLOCK_LOG} size: stderr={restore.stderr!r}"
+            size_after = vm.ssh("stat", "-f", "%z", IP_BLOCK_LOG, timeout=15)
+            assert size_after.returncode == 0 and size_after.stdout.strip() == original_size, (
+                f"{IP_BLOCK_LOG} restore did not take (before={original_size!r}, after={size_after.stdout.strip()!r}) "
+                "-- synthetic rows leaked to sibling tests"
+            )
+        if feeds_seeded:
+            removed = vm.ssh(f"rm -f {deny_feed_new} {deny_feed_legacy}", timeout=15)
+            assert removed.returncode == 0, (
+                f"failed to remove seeded deny-folder feed files: stderr={removed.stderr!r} "
+                "-- feed state leaked to sibling smoke modules"
+            )
 
 
 def test_alerts_asn_csv_new_schema_renders_legacy_schema_silently_absent(
@@ -182,13 +206,21 @@ def test_alerts_asn_csv_new_schema_renders_legacy_schema_silently_absent(
 
     body = resp.text
 
-    # THEN: the new-schema row's ASN renders visibly...
-    assert NEW_SCHEMA_ASN in body, f"visible ASN {NEW_SCHEMA_ASN!r} did not render for the new-schema row"
-    # ...with a tooltip built from domain + name (HTML-encoded; the comma
-    # itself is not an HTML metacharacter, so it appears verbatim in the
-    # title attribute even though it required CSV quoting on the wire).
-    assert NEW_SCHEMA_DOMAIN in body, f"ASN tooltip domain {NEW_SCHEMA_DOMAIN!r} missing from the rendered page"
-    assert "Example, Org" in body, "ASN tooltip name (with its comma intact) missing from the rendered page"
+    # THEN: the new-schema row's ASN renders visibly, inside ITS OWN span --
+    # scoped to the ASN cell so a stray occurrence of the same strings
+    # elsewhere on the page cannot satisfy these assertions.
+    asn_span = re.search(r'<span title="([^"]*)">' + re.escape(NEW_SCHEMA_ASN) + r"</span>", body)
+    assert asn_span, f"no ASN span rendering {NEW_SCHEMA_ASN!r} found in the page"
+    # The tooltip is built from the domain + name columns (the comma itself is
+    # not an HTML metacharacter, so it appears verbatim in the title attribute
+    # even though it required CSV quoting on the wire).
+    asn_title = asn_span.group(1)
+    assert NEW_SCHEMA_DOMAIN in asn_title, (
+        f"ASN tooltip domain {NEW_SCHEMA_DOMAIN!r} missing from the ASN span title {asn_title!r}"
+    )
+    assert "Example, Org" in asn_title, (
+        f"ASN tooltip name (with its comma intact) missing from the ASN span title {asn_title!r}"
+    )
     assert NEW_SCHEMA_HOST in body, "the new-schema row's host itself did not render at all"
 
     # THEN: the legacy row is COMPLETELY absent -- not a garbled/partial

--- a/tests/smoke/ui/test_alerts_asn_csv.py
+++ b/tests/smoke/ui/test_alerts_asn_csv.py
@@ -1,0 +1,205 @@
+"""Tier-A ``ui_render`` coverage for the ASN CSV-column schema (issue #1369,
+ADR-38 Amendment 3).
+
+The single pipe-delimited ASN blob field in ``ip_block.log`` (etc.) is
+replaced by 3 plain CSV columns (``asn``, ``asn_domain``, ``asn_name``),
+CSV-escaped via native ``fputcsv()``. The owner's 2026-07-18 amendment drops
+ALL back-compat for log entries: ``convert_ip_log()`` parses ONLY the current
+23-field feature-row schema; a pre-upgrade legacy (21-field, single-blob) row
+is skipped silently -- no PHP warning/notice, the row simply never renders,
+until log rotation removes it.
+
+This module seeds real log content directly into ``ip_block.log`` (the same
+CSV-injection technique ``test_alerts.py``'s suppression-icon test uses) and
+asserts what a generic 200-status sweep never would: a NEW-schema row's ASN
++ tooltip actually render, a LEGACY-schema row renders NOTHING (not a
+garbled/partial row), and the page carries no PHP diagnostic either in the
+response body OR the server's own ``php_error.log`` (``PhpErrorLogGuard``,
+the sweep-level oracle condition ``(d)`` a body-only check would miss).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+from .webui import looks_like_login_page
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+ALERTS_PAGE = "/pfblockerng/pfblockerng_alerts.php"
+IP_BLOCK_LOG = "/var/log/pfblockerng/ip_block.log"
+ASN_REPORTING_CFG = "installedpackages/pfblockerngipsettings/config/0/asn_reporting"
+
+# RFC 5737 TEST-NET-3 -- clearly synthetic, never a real routable host.
+NEW_SCHEMA_HOST = "203.0.113.50"
+LEGACY_SCHEMA_HOST = "203.0.113.51"
+
+NEW_SCHEMA_ASN = "AS64500"
+NEW_SCHEMA_DOMAIN = "example,test"  # comma -- must round-trip through real CSV quoting
+NEW_SCHEMA_NAME = "Example, Org"  # comma -- same
+
+
+@pytest.fixture
+def _asn_reporting_enabled(smoke_vm: SmokeVM) -> Iterator[None]:
+    """Force ``asn_reporting`` on (any non-'disabled' value) for the test, restore after.
+
+    The Alerts page's ASN column renders nothing at all when ASN reporting is
+    disabled (``$pfb['asn_reporting'] != 'disabled'`` gate), independent of
+    what the log rows themselves carry -- this fixture is the precondition
+    every assertion below depends on.
+    """
+    vm = smoke_vm
+    original = helpers.config_get(vm, ASN_REPORTING_CFG)
+    helpers.php_eval(
+        vm,
+        f"config_set_path('{ASN_REPORTING_CFG}', 'week');\n"
+        "write_config('pfBlockerNG smoke: enable asn_reporting for issue #1369 ASN CSV test');\n"
+        "echo 'OK';",
+    )
+    yield
+    helpers.php_eval(
+        vm,
+        f"config_set_path('{ASN_REPORTING_CFG}', '{original}');\n"
+        "write_config('pfBlockerNG smoke: restore asn_reporting after issue #1369 ASN CSV test');\n"
+        "echo 'OK';",
+    )
+
+
+@pytest.fixture
+def _seeded_ip_block_log(smoke_vm: SmokeVM) -> Iterator[None]:
+    """Append one new-schema + one legacy-schema row to ``ip_block.log``; restore size after.
+
+    Feed files are seeded in the deny folder so both rows are "still listed"
+    (avoids the unrelated find_reported_header() miss-path noise; the NB in
+    ``test_alerts.py``'s suppression-icon test explains why this matters for
+    a clean, focused assertion).
+    """
+    vm = smoke_vm
+    ts = time.strftime("%b %d %H:%M:%S")
+
+    # NEW schema (23 raw fields incl. timestamp): ...,feed,rhost,chost,
+    # asn,asn_domain,asn_name,dup -- the comma-bearing domain/name are
+    # RFC4180-quoted exactly as pfb_asn_csv_fields()/fputcsv() would encode
+    # them (UnifiedFormatTest.php pins the encoder itself off-box; this
+    # proves the SAME shape renders correctly through the real page).
+    new_row = (
+        f"{ts},100,em0,WAN,block,4,6,TCP,"
+        f"{NEW_SCHEMA_HOST},10.0.0.5,12345,443,"
+        f"in,US,pfB_Deny_v4,{NEW_SCHEMA_HOST},pfB_AsnFeedNew,Unknown,Unknown,"
+        f'{NEW_SCHEMA_ASN},"{NEW_SCHEMA_DOMAIN}","{NEW_SCHEMA_NAME}",+\n'
+    )
+    # LEGACY schema (21 raw fields): the single pipe-blob ASN column, no
+    # asn_domain/asn_name -- must render NOTHING per the owner's no-back-compat
+    # amendment, not a garbled row.
+    legacy_row = (
+        f"{ts},100,em0,WAN,block,4,6,TCP,"
+        f"{LEGACY_SCHEMA_HOST},10.0.0.6,12345,443,"
+        f"in,US,pfB_Deny_v4,{LEGACY_SCHEMA_HOST},pfB_AsnFeedLegacy,Unknown,Unknown,"
+        "|ASN:  AS99999 | domain:  legacy.example | name:  Legacy Org |,+\n"
+    )
+
+    log_dir = IP_BLOCK_LOG.rsplit("/", 1)[0]
+    ensure = vm.ssh(f"mkdir -p {log_dir} && touch {IP_BLOCK_LOG}", timeout=15)
+    assert ensure.returncode == 0, f"failed to ensure {IP_BLOCK_LOG} exists: {ensure.stderr!r}"
+
+    deny_feed_new = "/var/db/pfblockerng/deny/pfB_AsnFeedNew.txt"
+    deny_feed_legacy = "/var/db/pfblockerng/deny/pfB_AsnFeedLegacy.txt"
+    seed = vm.ssh(
+        f"printf '{NEW_SCHEMA_HOST}\\n' > {deny_feed_new} && printf '{LEGACY_SCHEMA_HOST}\\n' > {deny_feed_legacy}",
+        timeout=15,
+    )
+    assert seed.returncode == 0, f"failed to seed deny-folder feed files: stderr={seed.stderr!r}"
+
+    size_before = vm.ssh("stat", "-f", "%z", IP_BLOCK_LOG, timeout=15)
+    assert size_before.returncode == 0, f"failed to stat {IP_BLOCK_LOG}: stderr={size_before.stderr!r}"
+    original_size = size_before.stdout.strip()
+
+    append = subprocess.run(
+        vm.ssh_argv("tee", "-a", IP_BLOCK_LOG),
+        input=new_row + legacy_row,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    assert append.returncode == 0, f"failed to append fixture rows to {IP_BLOCK_LOG}: stderr={append.stderr!r}"
+
+    yield
+
+    restore = vm.ssh(f"truncate -s {original_size} {IP_BLOCK_LOG}", timeout=15)
+    assert restore.returncode == 0, f"failed to restore {IP_BLOCK_LOG} size: stderr={restore.stderr!r}"
+    size_after = vm.ssh("stat", "-f", "%z", IP_BLOCK_LOG, timeout=15)
+    assert size_after.returncode == 0 and size_after.stdout.strip() == original_size, (
+        f"{IP_BLOCK_LOG} restore did not take (before={original_size!r}, after={size_after.stdout.strip()!r}) "
+        "-- synthetic rows leaked to sibling tests"
+    )
+    vm.ssh(f"rm -f {deny_feed_new} {deny_feed_legacy}", timeout=15)
+
+
+def test_alerts_asn_csv_new_schema_renders_legacy_schema_silently_absent(
+    smoke_vm: SmokeVM,
+    webui: WebUI,
+    _asn_reporting_enabled: None,
+    _seeded_ip_block_log: None,
+) -> None:
+    """New-schema ASN row renders visible ASN + tooltip; legacy row renders nothing.
+
+    Scenario:
+      Given ip_block.log carries one new (23-field) row with a found ASN whose
+            domain/name each carry a comma (real CSV round-trip, not a bespoke
+            escape), and one pre-upgrade legacy (21-field, single pipe-blob
+            ASN column) row.
+      When  the Alerts page (default view, which renders ip_block.log's Block
+            table) is GET-ted.
+      Then  the Tier-A render oracle passes (200, no PHP diagnostic in the
+            body, page marker present) AND the server's own php_error.log
+            gained no bytes (oracle condition (d) -- a logged-but-not-echoed
+            warning would still fail this)
+        AND the new-schema row's ASN renders visibly, with a tooltip built
+            from its domain + name
+        AND the legacy row renders NOTHING AT ALL -- its host never appears
+            anywhere in the page body.
+    """
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = webui.get(ALERTS_PAGE)
+    result = evaluate_render(ALERTS_PAGE, resp.status_code, resp.text, ("Alert Settings",))
+    assert result.ok, f"Tier-A render oracle failed for the Alerts page: {result.detail}"
+    assert not looks_like_login_page(resp.text), "alerts page GET returned the login form (session lost)"
+
+    body = resp.text
+
+    # THEN: the new-schema row's ASN renders visibly...
+    assert NEW_SCHEMA_ASN in body, f"visible ASN {NEW_SCHEMA_ASN!r} did not render for the new-schema row"
+    # ...with a tooltip built from domain + name (HTML-encoded; the comma
+    # itself is not an HTML metacharacter, so it appears verbatim in the
+    # title attribute even though it required CSV quoting on the wire).
+    assert NEW_SCHEMA_DOMAIN in body, f"ASN tooltip domain {NEW_SCHEMA_DOMAIN!r} missing from the rendered page"
+    assert "Example, Org" in body, "ASN tooltip name (with its comma intact) missing from the rendered page"
+    assert NEW_SCHEMA_HOST in body, "the new-schema row's host itself did not render at all"
+
+    # THEN: the legacy row is COMPLETELY absent -- not a garbled/partial
+    # render, no trace of its host anywhere in the page.
+    assert LEGACY_SCHEMA_HOST not in body, (
+        f"the legacy-schema row's host {LEGACY_SCHEMA_HOST!r} rendered -- pre-upgrade rows must be "
+        "skipped silently per the owner's no-back-compat amendment (issue #1369)"
+    )
+    assert "AS99999" not in body, "the legacy row's raw ASN number must never render"
+    assert "legacy.example" not in body, "the legacy row's raw domain must never render"
+
+    # THEN (oracle condition (d)): no PHP diagnostic was logged either, even
+    # if display_errors would have kept it out of the body.
+    guard.assert_no_growth()


### PR DESCRIPTION
## Summary

Replaces the single pipe-delimited ASN metadata blob in IP feature logs
(`ip_block.log`/`ip_permit.log`/`ip_match.log`) and `unified.log` with three
plain CSV columns — `asn`, `asn_domain`, `asn_name` — serialized via native
`fputcsv()` with an explicit empty escape argument. Per the owner's decision
below, the read path drops legacy-row support entirely.

## Owner decision (binding amendment, quoted verbatim)

> For 1369, we won't care about back-compat for the log entries.

Posted 2026-07-18 on issue #1369, amending the original packet's
"Compatibility and non-goals" section. What it dropped:

- Reading legacy 21-field feature rows / 22-field Unified rows.
- Mixed old/new row support in the same file until rotation.
- Legacy row-normalization on the read path.
- "Legacy rows render identically" acceptance criterion.
- Mixed-row Top ASN aggregation.

What stayed (unchanged from the original packet): the writer schema (3 new
CSV columns replacing the pipe blob), `fputcsv()` serialization with an
explicit empty escape argument, CR/LF-to-space normalization before writing,
no header/schema-version column, the internal pipe blob unchanged for
`iptoasn()`/`asncache.asn`/the syslog `asn=` value, no config/dependency/
HTML-structure changes, no log rewriting or SQLite migration.

**Amended contract:** readers (`convert_ip_log()` — Alerts table/tooltip/ASN
filter, Top ASN statistics, Unified view) parse **only** the current
23-field feature-row / 24-field Unified-row schema. Any other
post-timestamp-shift field count — including every pre-upgrade legacy row
still on disk — is skipped silently, zero PHP warnings/notices. Old entries
disappear from the UI until log rotation removes them; accepted.

## What changed

- `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc` — new pure helpers:
  `pfb_asn_blob_split()` (decodes the internal pipe blob into
  asn/domain/name), `pfb_asn_csv_fields()` (CSV-escapes the 3 new columns via
  `fputcsv()`, CR/LF normalized to spaces first), `pfb_ip_log_row_schema_ok()`
  (the exact field-count schema gate).
- `src/usr/local/pkg/pfblockerng/pfblockerng.inc` — the filterlog daemon's
  `$details` construction now splices in `pfb_asn_csv_fields($asn)` in place
  of the old bare blob field. The raw `$asn` blob itself is untouched (still
  feeds the syslog `asn=` value and the `asncache` row).
- `src/usr/local/www/pfblockerng/pfblockerng_alerts.php` — `convert_ip_log()`
  gates every raw row on `pfb_ip_log_row_schema_ok()` before its timestamp
  shift or any indexed access; the ASN cell renders the plain ASN token
  directly and builds its tooltip from the separate domain/name columns; the
  two-pass IP-table buffer's Pass 1 folds a schema-invalid row into the same
  gap-marker path a filtered row takes (so it never reaches
  `pfb_ip_render_query()`'s fixed-index reads); the Top ASN stats pipeline
  gains an `awk -F',' 'NF == 23'` gate before its `cut`; all 5 `fgetcsv()`
  call sites in this file now pass the writer's matching empty escape
  argument (see "Findings" below).
- Tests: `tests/php/AlertsAsnCsvTest.php` (new), `tests/php/UnifiedFormatTest.php`
  (extended), `tests/php/LogFormatConsumersTest.php` (extended),
  `tests/php/AlertsIpConvertPrefetchParityTest.php` /
  `tests/php/AlertsIpUnlockIconTest.php` (fixtures widened to the new row
  shape), `tests/smoke/ui/test_alerts_asn_csv.py` (new, Tier-A `ui_render`).
- Docs: `.ADRs/ADR_38_System_Log_Integration/ADR.md` (Amendment 3, appended —
  ADR bodies are immutable, corrections append-only),
  `docs/misc/alerts-reports-pipeline.md` (new schema + no-back-compat
  behaviour). Proposed ADR-32 checked and found not stale (see "Docs delta").

## Finding beyond the packet: reader/writer `fgetcsv()` escape-parameter mismatch

The packet mandates `fputcsv()` with an explicit empty escape argument on
write. A bare `fgetcsv($handle)` (the existing read-site shape) defaults to
a **backslash** escape character — PHP's own non-standard extension; RFC4180
has no escape character at all. Probed directly (PHP 8.5.8, this repo's
`.venv`): a value written with `fputcsv(..., '')` containing a literal
backslash is corrupted when read back with the *default*-escape `fgetcsv()`
(the closing quote gets escape-consumed, merging fields). Fixed by passing
the same explicit empty escape argument at all 5 `fgetcsv()` call sites in
`pfblockerng_alerts.php` — a no-op for the DNSBL/DNS-reply/Unified-non-IP
rows (none of their fields are ever quoted) and the fix that makes the new
ASN columns round-trip correctly for every character class in the coverage
matrix, including backslash.

## Coverage matrix

| Axis | Cases | Test(s) |
| --- | --- | --- |
| Schema | new 23-field OK | `AlertsAsnCsvTest::testNewSchemaRowRenders`, `testUnifiedModeNewSchemaRowRendersAsnAndTooltip` |
| Schema | legacy 21-field SKIPPED silently | `testLegacyTwentyFieldRowIsSkippedSilently`, `testUnifiedModeLegacyRowIsSkippedSilently`, `testAsnFilterNeverEvaluatesAgainstALegacyRow` |
| Schema | malformed/other counts SKIPPED silently | `testMalformedShortRowIsSkippedSilently`, `testSchemaGateExactCounts` |
| View | Block/Permit/Match (`non_unified`) | all `AlertsAsnCsvTest` non-Unified cases |
| View | Unified (24-field, leading event type) | `testUnifiedModeNewSchemaRowRendersAsnAndTooltip`, `testUnifiedModeLegacyRowIsSkippedSilently` |
| Family | IPv4 | default fixture across `AlertsAsnCsvTest` |
| Family | IPv6 | `testFoundAsnRendersForIpv6Row` |
| ASN state | found | `testFoundAsnRendersVisibleAsnAndTooltipFromDomainAndName` |
| ASN state | Unknown | `testUnknownAsnRendersNoAsnMarkup` |
| ASN state | null/missing metadata | `testNullAsnRendersNoAsnMarkup`, `testAsnReportingDisabledRendersNoAsnMarkupEvenWhenFound` |
| Text | comma | `testTextHandlingCommaInDomainRoundTripsAndRenders`, `UnifiedFormatTest::testAsnCsvFieldsCommaInNameIsDoubleQuoted` |
| Text | quote | `testTextHandlingQuoteInNameRoundTripsAndRenders`, `testAsnCsvFieldsQuoteInNameIsRfc4180Doubled` |
| Text | colon | `testTextHandlingColonInNameRoundTripsAndRenders`, `testAsnCsvFieldsColonInNamePassesThroughUnescaped` |
| Text | Unicode | `testTextHandlingUnicodeInNameRoundTripsAndRenders`, `testAsnCsvFieldsUnicodeInNamePassesThroughUnmodified` |
| Text | empty | `testTextHandlingEmptyDomainAndNameRenderBlankTooltipSegments`, `testAsnCsvFieldsEmptyDomainAndNameRenderAsEmptySegments` |
| Text | CR/LF | `testTextHandlingCrLfInNameRoundTripsAsNormalizedSpace`, `testAsnCsvFieldsCrLfInNameNormalizedToSpace` |
| Consumers | Alerts table + tooltip | `testFoundAsnRendersVisibleAsnAndTooltipFromDomainAndName` + smoke test |
| Consumers | ASN filter | `testAsnFilterMatchesNewPlainAsnField` |
| Consumers | Top ASN stats | `LogFormatConsumersTest::testTopAsnStatPipelineSourceHasSchemaGate`, `testTopAsnNewPipelineSkipsLegacyRowAndCountsNewSchemaRows`, `testTopAsnOldUngatedPipelinePollutesWithLegacyBlobText` |
| Consumers | Unified log | `testUnifiedModeNewSchemaRowRendersAsnAndTooltip` + smoke test |
| Unchanged | syslog `asn=` value / `asncache.asn` blob | ADR-38 §2.1/A1 unaffected (not re-tested here); `pfb_asn_blob_split()`/`pfb_asn_csv_fields()` are the only new consumers of the blob |

## Red -> green proofs

**PHPUnit** (`vendor/bin/phpunit --filter 'UnifiedFormatTest|AlertsAsnCsv|LogFormatConsumers'`):
production reverted to unmodified `origin/devel` HEAD (via file swap, not a
destructive git op — tests-only commit content kept in place), red run:
90 tests, 24 errors, 8 failures. Test file hashes frozen via `git
hash-object` at that exact state, production restored, hashes re-verified
byte-identical, green run: 90 tests, 324 assertions, 0 failures.

**Smoke** (`scripts/local-smoke.sh --ref issue/1369-asn-csv-columns -m
ui_render --filter test_alerts_asn_csv_new_schema_renders_legacy_schema_silently_absent`):
green leg against the pushed feature branch; red leg against a `tmp/`
ref pinned at the tests-only commit (production untouched), `tmp/` ref
deleted after. See PR comment below for the pasted summary lines and freeze
hashes (verbatim evidence).

## Docs delta

- ADR-38 Amendment 3 appended (`.ADRs/ADR_38_System_Log_Integration/ADR.md`)
  — corrects Amendment 1's "CSV content is unchanged" fidelity claim for the
  ASN column specifically; everything else in ADR-38/Amendments 1-2 stands.
- `docs/misc/alerts-reports-pipeline.md` — new "ASN CSV columns, no
  back-compat for log entries" subsection.
- Proposed ADR-32 (IPinfo GeoIP/ASN provider) checked: it operates at the
  provider/lookup seam (`GeoipProvider`/`AsnProvider` normalized `asn`/
  `as_org` record), not the log CSV serialization this PR changes. Its one
  relevant bullet ("keep log formats stable" during a future provider swap)
  is forward-looking and will apply to this (post-#1369) format when that
  Proposed phase eventually lands. **No edit made** — not stale.

Fixes #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ASN information in IP logs and unified logs is now recorded as separate ASN, domain, and name fields.
  * Alerts, Reports, filtering, and Top ASN statistics now display and process the updated ASN format.
  * Special characters, commas, quotes, Unicode, and line breaks in ASN details are handled correctly.

* **Bug Fixes**
  * Legacy or malformed log entries are safely skipped to prevent incorrect displays and statistics.

* **Documentation**
  * Updated log format and Alerts/Reports pipeline documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->