### PR TITLE
tests: pin leading-zero IPv4 verdict in is_ipaddrv4 double (#1468)

### DIFF
--- a/tests/php/IpAddrDoublesTest.php
+++ b/tests/php/IpAddrDoublesTest.php
@@ -16,12 +16,14 @@ use PHPUnit\Framework\TestCase;
  * Regression for two doubles that modeled util.inc wrongly (issue #721):
  *   - is_ipaddrv4() did an ip2long()/long2ip() ROUND-TRIP that real pfSense
  *     never does; real pfSense is a bare `ip2long($ipaddr) === FALSE` check.
- *     PHP's ip2long() delegates to libc inet_pton(AF_INET), which accepts only
- *     the canonical dotted-quad — leading-zero octets ('192.000.002.005') are
- *     rejected on BOTH FreeBSD (the pfSense/CE target; inet_pton4's
- *     leading-zero guard) and glibc — so the old round-trip was behaviourally
- *     equivalent for v4 and this is a control-flow-fidelity fix (mirror
- *     upstream verbatim, prevent future drift), not a verdict flip.
+ *     PHP's ip2long() delegates to libc inet_pton(AF_INET), whose treatment of
+ *     leading-zero octets ('192.000.002.005') is PLATFORM-DEPENDENT: FreeBSD
+ *     (the pfSense/CE target; inet_pton4's leading-zero guard) and glibc
+ *     reject them, but macOS ACCEPTS them (probed 2026-07-18, PHP 8.5.8 on
+ *     Darwin: ip2long('192.000.002.005') === 3221225989 — issue #1468). The
+ *     double therefore pins the APPLIANCE verdict with an explicit
+ *     leading-zero reject after the bare ip2long() check, so its answers are
+ *     identical on every dev platform (see the pinned v4Provider rows).
  *   - is_ipaddrv6() stripped ANY '%zone' suffix before validating. Real
  *     pfSense strips it ONLY when the address is link-local (is_linklocal()),
  *     so a non-link-local zoned address ('2001:db8::1%em0') was wrongly
@@ -41,12 +43,14 @@ final class IpAddrDoublesTest extends TestCase
 		return [
 			// Leading-zero octets are LIBC-DEPENDENT (#723): FreeBSD (the
 			// pfSense target) and glibc (CI) reject them at inet_pton(), but
-			// macOS accepts them — so the verdict cannot be pinned as a
-			// constant without failing on a Mac dev box. The invariant that
-			// matters is MECHANISM parity: the double must agree with this
-			// platform's ip2long(), whatever it says (asserted in
-			// testIsIpaddrv4MatchesLocalIp2long below).
+			// macOS accepts them (probed — see the header, #1468). The double
+			// pins the FreeBSD/appliance verdict with an explicit leading-zero
+			// reject, so these rows are CONSTANT on every dev platform —
+			// including a Mac dev box, where a bare ip2long() double would
+			// wrongly accept them.
 			'plain dotted-quad accepted'   => ['192.0.2.5', true],
+			'leading-zero octets rejected (pinned)'      => ['192.000.002.005', false],
+			'leading-zero first octet rejected (pinned)' => ['010.0.0.1', false],
 			'three-octet form rejected'    => ['1.2.3', false],
 			'out-of-range octet rejected'  => ['256.1.1.1', false],
 			'empty string rejected'        => ['', false],
@@ -62,13 +66,15 @@ final class IpAddrDoublesTest extends TestCase
 		$this->assertSame($expected, is_ipaddrv4($input));
 	}
 
-	public function testIsIpaddrv4MatchesLocalIp2long(): void
+	public function testIsIpaddrv4LeadingZeroVerdictIsPlatformIndependent(): void
 	{
-		// Mechanism parity with real pfSense (bare ip2long check): whatever this
-		// platform's libc says about a leading-zero octet, the double says the same.
-		$expected = (ip2long('192.000.002.005') !== false);
-		$this->assertSame($expected, is_ipaddrv4('192.000.002.005'),
-			'expected: double verdict identical to local ip2long() for a leading-zero octet');
+		// The #1468 pin: even where the LOCAL libc accepts a leading-zero octet
+		// (macOS), the double must still return the appliance verdict (reject).
+		// Replaces the old mechanism-parity assertion, which followed the local
+		// ip2long() and so gave a different verdict on a Mac dev box.
+		$this->assertFalse(is_ipaddrv4('192.000.002.005'),
+			'expected: leading-zero octet rejected regardless of local ip2long() verdict '
+			. '(local ip2long acceptance: ' . var_export(ip2long('192.000.002.005') !== false, true) . ')');
 	}
 
 	// --- is_ipaddrv6() --------------------------------------------------------

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -15,13 +15,18 @@
  *     strip + double-"::" reject, via filter_var() standing in for
  *     Net_IPv6::checkIPv6 (no PEAR off-appliance). pfb_filter (IP/IPV4) and
  *     pfb_dnsbl_abp_extract_ip depend on their precise accept/reject behaviour.
- *     NOTE on v4: PHP's ip2long() delegates to libc inet_pton(AF_INET), which
- *     accepts only the canonical dotted-quad — leading-zero octets like
- *     '192.000.002.005' are rejected on BOTH FreeBSD (the pfSense/CE target;
- *     inet_pton4's leading-zero guard) and glibc. Consequently the old
- *     round-trip was behaviourally equivalent for v4; dropping it is a
- *     control-flow-fidelity fix (mirror upstream verbatim), not a verdict
- *     flip. The v6 %zone fix IS a real verdict flip — see IpAddrDoublesTest.
+ *     NOTE on v4: PHP's ip2long() delegates to libc inet_pton(AF_INET), whose
+ *     handling of leading-zero octets like '192.000.002.005' is
+ *     PLATFORM-DEPENDENT: FreeBSD (the pfSense/CE target; inet_pton4's
+ *     leading-zero guard) and glibc reject them, but macOS ACCEPTS them
+ *     (probed 2026-07-18, PHP 8.5.8 on Darwin: ip2long('192.000.002.005')
+ *     === 3221225989 — issue #1468). A bare ip2long() double is therefore
+ *     platform-dependent on a Mac dev box, so is_ipaddrv4 adds an explicit
+ *     leading-zero reject after the ip2long() check: a no-op where libc
+ *     already rejects, and a pin to the appliance verdict where it doesn't.
+ *     Verdict fidelity to the appliance beats verbatim control-flow
+ *     mirroring for a double. The v6 %zone fix IS a real verdict flip — see
+ *     IpAddrDoublesTest.
  *
  * Everything else is a minimal no-op/throwaway double: it exists only so the
  * symbol resolves. Functions reached only by code paths the seed suite does NOT
@@ -32,13 +37,16 @@
  */
 
 if (!function_exists('is_ipaddrv4')) {
-	// pfSense util.inc verbatim: a bare ip2long() check, NO long2ip() round-trip.
-	// Rejects '1.2.3' / out-of-range / leading-zero octets / non-strings —
-	// ip2long() (libc inet_pton) accepts only the canonical dotted-quad, on
-	// FreeBSD and glibc alike (see the file-header NOTE), so this double now
-	// runs the exact same control flow as the real function.
+	// pfSense util.inc: a bare ip2long() check, NO long2ip() round-trip —
+	// rejects '1.2.3' / out-of-range / non-strings. Leading-zero octets are
+	// libc-dependent (macOS accepts, FreeBSD/glibc reject — file-header NOTE,
+	// #1468), so the trailing preg pins the FreeBSD/appliance verdict: it
+	// only ever fires on a platform whose inet_pton accepted the shape.
 	function is_ipaddrv4($ipaddr) {
 		if (!is_string($ipaddr) || empty($ipaddr) || ip2long($ipaddr) === FALSE) {
+			return false;
+		}
+		if (preg_match('/(?:^|\.)0\d/', $ipaddr) === 1) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
## Summary

`tests/php/pfsense_doubles.php` carried a fidelity note claiming leading-zero IPv4 octets (e.g. `192.000.002.005`) are rejected by libc `inet_pton(AF_INET)` "on BOTH FreeBSD and glibc", implying the bare-`ip2long()` double was platform-independent. An executed probe on the macOS dev host (PHP 8.5.8 on Darwin) shows macOS **accepts** that shape: `ip2long('192.000.002.005') === 3221225989`. The double's verdict was therefore platform-dependent on a Mac dev box, and the old mechanism-parity test (`testIsIpaddrv4MatchesLocalIp2long`) followed the local libc rather than the appliance.

This takes the "pin the double's behavior explicitly so it is platform-independent" option from the issue:

- `is_ipaddrv4` double: explicit leading-zero reject after the `ip2long()` check — a no-op on FreeBSD/glibc (where `inet_pton` already rejects the shape), a pin to the appliance verdict on macOS.
- Both stale notes (file header + function body in `pfsense_doubles.php`, header + provider comment in `IpAddrDoublesTest.php`) corrected to state the probed platform matrix.
- The mechanism-parity test is replaced by constant pinned rows (`192.000.002.005`, `010.0.0.1` rejected) plus `testIsIpaddrv4LeadingZeroVerdictIsPlatformIndependent`, which prints the local `ip2long()` verdict on failure.

## Test-first proof (executed on macOS, the affected platform)

- RED on the untouched double: 3 failures, all "double accepts a leading-zero octet" (frozen at `git hash-object` `606c997e5154f7854cb98454b9a52c1e66b2b2c3`).
- GREEN after the pin, test file byte-identical (same hash): full PHP suite 3761 tests / 22421 assertions pass.

Dev-only change (tests infra), no shipped-code impact.

Fixes #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv4 address validation consistency across platforms.
  * IPv4 addresses containing leading-zero octets are now consistently rejected.
  * Standard dotted-quad IPv4 addresses without leading zeros remain accepted.

* **Tests**
  * Updated validation coverage to verify platform-independent results for leading-zero IPv4 addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->