### PR TITLE
tests: pin is_ipaddrv4 leading-zero verdict platform-independent

### DIFF
--- a/tests/php/IpAddrDoublesTest.php
+++ b/tests/php/IpAddrDoublesTest.php
@@ -16,12 +16,15 @@ use PHPUnit\Framework\TestCase;
  * Regression for two doubles that modeled util.inc wrongly (issue #721):
  *   - is_ipaddrv4() did an ip2long()/long2ip() ROUND-TRIP that real pfSense
  *     never does; real pfSense is a bare `ip2long($ipaddr) === FALSE` check.
- *     PHP's ip2long() delegates to libc inet_pton(AF_INET), which accepts only
- *     the canonical dotted-quad — leading-zero octets ('192.000.002.005') are
- *     rejected on BOTH FreeBSD (the pfSense/CE target; inet_pton4's
- *     leading-zero guard) and glibc — so the old round-trip was behaviourally
- *     equivalent for v4 and this is a control-flow-fidelity fix (mirror
- *     upstream verbatim, prevent future drift), not a verdict flip.
+ *     A later pass (#1468) found the "leading-zero octets reject on BOTH
+ *     FreeBSD and glibc" claim in this area was an overclaim never actually
+ *     probed off-appliance: PHP's ip2long() delegates to the HOST libc's
+ *     inet_pton(AF_INET), and macOS ACCEPTS '192.000.002.005' (glibc and,
+ *     per FreeBSD source, FreeBSD both reject it) -- see the file-header NOTE
+ *     in pfsense_doubles.php for the full probe matrix. is_ipaddrv4() now
+ *     carries an explicit leading-zero-octet guard so its verdict is pinned
+ *     to the FreeBSD/glibc reject on every host, not just the ones whose
+ *     libc happens to agree.
  *   - is_ipaddrv6() stripped ANY '%zone' suffix before validating. Real
  *     pfSense strips it ONLY when the address is link-local (is_linklocal()),
  *     so a non-link-local zoned address ('2001:db8::1%em0') was wrongly
@@ -39,13 +42,6 @@ final class IpAddrDoublesTest extends TestCase
 	public static function v4Provider(): array
 	{
 		return [
-			// Leading-zero octets are LIBC-DEPENDENT (#723): FreeBSD (the
-			// pfSense target) and glibc (CI) reject them at inet_pton(), but
-			// macOS accepts them — so the verdict cannot be pinned as a
-			// constant without failing on a Mac dev box. The invariant that
-			// matters is MECHANISM parity: the double must agree with this
-			// platform's ip2long(), whatever it says (asserted in
-			// testIsIpaddrv4MatchesLocalIp2long below).
 			'plain dotted-quad accepted'   => ['192.0.2.5', true],
 			'three-octet form rejected'    => ['1.2.3', false],
 			'out-of-range octet rejected'  => ['256.1.1.1', false],
@@ -53,6 +49,12 @@ final class IpAddrDoublesTest extends TestCase
 			'non-string int rejected'      => [42, false],
 			'non-string null rejected'     => [null, false],
 			'non-string array rejected'    => [['192.0.2.5'], false],
+			// Pinned platform-independent verdict (issue #1468, corrects an
+			// overclaim from #721): leading-zero octets are rejected on every
+			// host this double runs on, not just the ones whose libc happens
+			// to reject them -- see the is_ipaddrv4() guard and the file-header
+			// NOTE in pfsense_doubles.php for the probe matrix.
+			'leading-zero octet rejected (platform-independent pin)' => ['192.000.002.005', false],
 		];
 	}
 
@@ -60,15 +62,6 @@ final class IpAddrDoublesTest extends TestCase
 	public function testIsIpaddrv4(mixed $input, bool $expected): void
 	{
 		$this->assertSame($expected, is_ipaddrv4($input));
-	}
-
-	public function testIsIpaddrv4MatchesLocalIp2long(): void
-	{
-		// Mechanism parity with real pfSense (bare ip2long check): whatever this
-		// platform's libc says about a leading-zero octet, the double says the same.
-		$expected = (ip2long('192.000.002.005') !== false);
-		$this->assertSame($expected, is_ipaddrv4('192.000.002.005'),
-			'expected: double verdict identical to local ip2long() for a leading-zero octet');
 	}
 
 	// --- is_ipaddrv6() --------------------------------------------------------

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -15,13 +15,25 @@
  *     strip + double-"::" reject, via filter_var() standing in for
  *     Net_IPv6::checkIPv6 (no PEAR off-appliance). pfb_filter (IP/IPV4) and
  *     pfb_dnsbl_abp_extract_ip depend on their precise accept/reject behaviour.
- *     NOTE on v4: PHP's ip2long() delegates to libc inet_pton(AF_INET), which
- *     accepts only the canonical dotted-quad — leading-zero octets like
- *     '192.000.002.005' are rejected on BOTH FreeBSD (the pfSense/CE target;
- *     inet_pton4's leading-zero guard) and glibc. Consequently the old
- *     round-trip was behaviourally equivalent for v4; dropping it is a
- *     control-flow-fidelity fix (mirror upstream verbatim), not a verdict
- *     flip. The v6 %zone fix IS a real verdict flip — see IpAddrDoublesTest.
+ *     NOTE on v4 leading-zero octets (issue #1468, corrects an overclaim from
+ *     #721): PHP's ip2long() delegates to the HOST libc's inet_pton(AF_INET),
+ *     and that verdict is NOT platform-independent. Probed 2026-07-18:
+ *       - macOS 15, PHP 8.5.8 (Homebrew): ip2long('192.000.002.005') ===
+ *         3221225989 — ACCEPTED (leading zeros silently read as decimal).
+ *       - Debian 12, PHP 8.4.23 (glibc): ip2long('192.000.002.005') ===
+ *         false — REJECTED.
+ *       - FreeBSD (the pfSense/CE target): NOT probed this session (no box
+ *         reachable) — ASSUMED to reject, per inet_pton4's leading-zero guard
+ *         in FreeBSD libc source. Verify on a pfSense guest before this fix
+ *         ships: `php -r 'var_dump(ip2long("192.000.002.005"));'` should
+ *         print `bool(false)`.
+ *     Because the double stands in for the FreeBSD target, is_ipaddrv4()
+ *     below adds an explicit leading-zero-octet guard ahead of ip2long() so
+ *     its verdict is pinned to the FreeBSD/glibc reject regardless of which
+ *     platform runs the test suite (was: an unguarded bare ip2long() check,
+ *     which is only "control-flow-fidelity" on the platforms that reject —
+ *     macOS silently diverges). The v6 %zone fix IS a real verdict flip —
+ *     see IpAddrDoublesTest.
  *
  * Everything else is a minimal no-op/throwaway double: it exists only so the
  * symbol resolves. Functions reached only by code paths the seed suite does NOT
@@ -33,12 +45,22 @@
 
 if (!function_exists('is_ipaddrv4')) {
 	// pfSense util.inc verbatim: a bare ip2long() check, NO long2ip() round-trip.
-	// Rejects '1.2.3' / out-of-range / leading-zero octets / non-strings —
-	// ip2long() (libc inet_pton) accepts only the canonical dotted-quad, on
-	// FreeBSD and glibc alike (see the file-header NOTE), so this double now
-	// runs the exact same control flow as the real function.
+	// Rejects '1.2.3' / out-of-range / non-strings via ip2long() (libc
+	// inet_pton) alone. Leading-zero octets ('192.000.002.005') get an
+	// EXPLICIT guard ahead of ip2long() — that call alone is platform-
+	// dependent here (see the file-header NOTE, issue #1468): the guard pins
+	// the verdict to the FreeBSD/glibc reject on every host this double runs
+	// on, instead of silently accepting on macOS.
 	function is_ipaddrv4($ipaddr) {
-		if (!is_string($ipaddr) || empty($ipaddr) || ip2long($ipaddr) === FALSE) {
+		if (!is_string($ipaddr) || empty($ipaddr)) {
+			return false;
+		}
+		// Any octet with a leading zero followed by another digit ('00',
+		// '01', ... '099') — matches inet_pton4's leading-zero guard.
+		if (preg_match('/(?:^|\.)0\d/', $ipaddr) === 1) {
+			return false;
+		}
+		if (ip2long($ipaddr) === FALSE) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
## Summary

`tests/php/pfsense_doubles.php` claimed leading-zero IPv4 octets (e.g. `192.000.002.005`) are rejected "on BOTH FreeBSD (the pfSense/CE target; inet_pton4's leading-zero guard) and glibc," via `is_ipaddrv4()`'s bare `ip2long()` check. An executed probe during PR #1465's review showed the macOS dev host **accepts** that shape instead — the comment overclaimed, and the double's leading-zero verdict silently depended on the host platform running the test suite.

This PR pins the verdict:

- `is_ipaddrv4()` now carries an explicit leading-zero-octet guard (`preg_match('/(?:^|\.)0\d/', ...)`) ahead of the `ip2long()` call, so the double rejects `192.000.002.005` on every host, not just the ones whose libc happens to agree.
- The file-header NOTE and the inline comment on `is_ipaddrv4()` now state the actual probed matrix instead of the overclaim.
- `IpAddrDoublesTest.php` gains a pinned data-provider case (`192.000.002.005` -> `false`) and drops the now-obsolete "mechanism parity" test, which asserted the double must agree with whatever the *host's* `ip2long()` said — a premise the pin explicitly contradicts.

## Probe evidence

**macOS (this dev host, PHP 8.5.8, Homebrew):**
```
$ php -r '
$tests = ["192.000.002.005", "192.0.2.5", "192.168.001.1", "010.0.0.1"];
foreach ($tests as $t) { echo $t . " => " . var_export(ip2long($t), true) . "\n"; }
'
192.000.002.005 => 3221225989
192.0.2.5 => 3221225989
192.168.001.1 => 3232235777
010.0.0.1 => 167772161
```
All four **accepted** — leading zeros silently treated as decimal digits.

**glibc (Debian 12 smoke box, root@10.0.0.31, PHP 8.4.23):**
```
$ php -r '$tests = ["192.000.002.005", "192.0.2.5", "192.168.001.1", "010.0.0.1"]; foreach ($tests as $t) { $r = ip2long($t); echo $t . " => " . var_export($r, true) . "\n"; }'
192.000.002.005 => false
192.0.2.5 => 3221225989
192.168.001.1 => false
010.0.0.1 => false
```
Leading-zero shapes **rejected**; canonical dotted-quad accepted.

**FreeBSD (pfSense/CE target):** not reachable this session — no box available. The reject verdict is **ASSUMED**, based on FreeBSD libc's `inet_pton4()` leading-zero guard in source (cited in the comment, not executed). Before this fix ships, please run the following on a pfSense guest and confirm it prints `bool(false)`:
```
php -r 'var_dump(ip2long("192.000.002.005"));'
```

## Test-first proof

Added the pinned data-provider case first and ran it RED against the un-pinned double (macOS accepts the shape, test expects reject):
```
1) IpAddrDoublesTest::testIsIpaddrv4@leading-zero octet rejected (platform-independent pin) with data ('192.000.002.005', false)
Failed asserting that true is identical to false.
Tests: 33, Assertions: 34, Failures: 1.
```
Applied the `is_ipaddrv4()` guard (test frozen byte-identical) and reran — GREEN:
```
OK (33 tests, 34 assertions)
```
Full suite: `OK, but there were issues!` — `Tests: 3759, Assertions: 22419, Deprecations: 1, Notices: 1, Skipped: 4` (the 1 deprecation/notice are pre-existing, unrelated to this change — `url_compare()` parameter-order deprecation in `FeedsPredefinedTypeLoader.php`).

## Test plan

- [x] `vendor/bin/phpunit tests/php/IpAddrDoublesTest.php` — 33/33 green
- [x] `vendor/bin/phpunit` (full suite) — 3759/3759 green, no new deprecations/notices
- [x] `sh scripts/agent/run-gates.sh --diff origin/devel` — GATES: PASS (php -l, phpunit, phpstan, phpcs)
- [ ] Verify `ip2long("192.000.002.005")` on an actual pfSense/FreeBSD guest before merge (command above)

Fixes #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
