### PR TITLE
tests: execution-backed probe matrix + boundary rows for the v4 pin (#1468)

### DIFF
--- a/tests/php/IpAddrDoublesTest.php
+++ b/tests/php/IpAddrDoublesTest.php
@@ -19,11 +19,12 @@ use PHPUnit\Framework\TestCase;
  *     PHP's ip2long() delegates to libc inet_pton(AF_INET), whose treatment of
  *     leading-zero octets ('192.000.002.005') is PLATFORM-DEPENDENT: FreeBSD
  *     (the pfSense/CE target; inet_pton4's leading-zero guard) and glibc
- *     reject them, but macOS ACCEPTS them (probed 2026-07-18, PHP 8.5.8 on
- *     Darwin: ip2long('192.000.002.005') === 3221225989 — issue #1468). The
- *     double therefore pins the APPLIANCE verdict with an explicit
- *     leading-zero reject after the bare ip2long() check, so its answers are
- *     identical on every dev platform (see the pinned v4Provider rows).
+ *     reject them, but macOS ACCEPTS them (all three verdicts executed
+ *     2026-07-18 — full probe matrix in pfsense_doubles.php's header NOTE;
+ *     issue #1468). The double therefore pins the APPLIANCE verdict with an
+ *     explicit leading-zero reject after the bare ip2long() check, so its
+ *     answers are identical on every dev platform (see the pinned
+ *     v4Provider rows).
  *   - is_ipaddrv6() stripped ANY '%zone' suffix before validating. Real
  *     pfSense strips it ONLY when the address is link-local (is_linklocal()),
  *     so a non-link-local zoned address ('2001:db8::1%em0') was wrongly
@@ -43,20 +44,26 @@ final class IpAddrDoublesTest extends TestCase
 		return [
 			// Leading-zero octets are LIBC-DEPENDENT (#723): FreeBSD (the
 			// pfSense target) and glibc (CI) reject them at inet_pton(), but
-			// macOS accepts them (probed — see the header, #1468). The double
-			// pins the FreeBSD/appliance verdict with an explicit leading-zero
-			// reject, so these rows are CONSTANT on every dev platform —
-			// including a Mac dev box, where a bare ip2long() double would
-			// wrongly accept them.
-			'plain dotted-quad accepted'   => ['192.0.2.5', true],
-			'leading-zero octets rejected (pinned)'      => ['192.000.002.005', false],
-			'leading-zero first octet rejected (pinned)' => ['010.0.0.1', false],
-			'three-octet form rejected'    => ['1.2.3', false],
-			'out-of-range octet rejected'  => ['256.1.1.1', false],
-			'empty string rejected'        => ['', false],
-			'non-string int rejected'      => [42, false],
-			'non-string null rejected'     => [null, false],
-			'non-string array rejected'    => [['192.0.2.5'], false],
+			// macOS accepts them (all three probed — see the header NOTE in
+			// pfsense_doubles.php, #1468). The double pins the FreeBSD/appliance
+			// verdict with an explicit leading-zero reject, so these rows are
+			// CONSTANT on every dev platform — including a Mac dev box, where a
+			// bare ip2long() double would wrongly accept them. The single-zero
+			// rows pin the guard's boundary: a '0' octet with no second digit is
+			// canonical and must stay accepted (probed accepted on all three
+			// platforms); they fail if the reject is ever widened past
+			// leading-zero shapes.
+			'plain dotted-quad accepted'                  => ['192.0.2.5', true],
+			'single-zero octets accepted (boundary)'      => ['0.0.0.0', true],
+			'single-zero first octet accepted (boundary)' => ['0.1.2.3', true],
+			'leading-zero octets rejected (pinned)'       => ['192.000.002.005', false],
+			'leading-zero first octet rejected (pinned)'  => ['010.0.0.1', false],
+			'three-octet form rejected'                   => ['1.2.3', false],
+			'out-of-range octet rejected'                 => ['256.1.1.1', false],
+			'empty string rejected'                       => ['', false],
+			'non-string int rejected'                     => [42, false],
+			'non-string null rejected'                    => [null, false],
+			'non-string array rejected'                   => [['192.0.2.5'], false],
 		];
 	}
 

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -17,13 +17,17 @@
  *     pfb_dnsbl_abp_extract_ip depend on their precise accept/reject behaviour.
  *     NOTE on v4: PHP's ip2long() delegates to libc inet_pton(AF_INET), whose
  *     handling of leading-zero octets like '192.000.002.005' is
- *     PLATFORM-DEPENDENT: FreeBSD (the pfSense/CE target; inet_pton4's
- *     leading-zero guard) and glibc reject them, but macOS ACCEPTS them
- *     (probed 2026-07-18, PHP 8.5.8 on Darwin: ip2long('192.000.002.005')
- *     === 3221225989 — issue #1468). A bare ip2long() double is therefore
- *     platform-dependent on a Mac dev box, so is_ipaddrv4 adds an explicit
- *     leading-zero reject after the ip2long() check: a no-op where libc
- *     already rejects, and a pin to the appliance verdict where it doesn't.
+ *     PLATFORM-DEPENDENT. All three verdicts executed 2026-07-18 via
+ *     php -r 'var_dump(ip2long("192.000.002.005"));' (issue #1468):
+ *       - macOS (Darwin, PHP 8.5.8): int(3221225989) — ACCEPTED;
+ *       - glibc (Debian bookworm container, PHP 8.3): bool(false) — rejected;
+ *       - FreeBSD (live pfSense CE guest, PHP 8.4.23): bool(false) —
+ *         rejected (inet_pton4's leading-zero guard).
+ *     A bare ip2long() double is therefore platform-dependent on a Mac dev
+ *     box, so is_ipaddrv4 adds an explicit leading-zero reject after the
+ *     ip2long() check: a no-op where libc already rejects, and a pin to the
+ *     appliance verdict where it doesn't. Single-zero octets ('0.0.0.0',
+ *     '0.1.2.3') stay accepted on all three platforms (probed same day).
  *     Verdict fidelity to the appliance beats verbatim control-flow
  *     mirroring for a double. The v6 %zone fix IS a real verdict flip — see
  *     IpAddrDoublesTest.


### PR DESCRIPTION
## Summary

Follow-up to #1491 (the `is_ipaddrv4` leading-zero pin for issue #1468), prompted by comparing it against the superseded parallel PR #1492. Two improvements, no behavior change to the double:

1. **Execution-backed probe matrix.** The landed note cited only the macOS probe; the FreeBSD/glibc reject claims rested on source-reading (#1492 rightly flagged FreeBSD as "assumed — verify on a pfSense guest"). Both have since been executed: glibc via a `php:8.3-cli-bookworm` container, FreeBSD via a live pfSense CE guest (PHP 8.4.23) — `ip2long('192.000.002.005')` returns `bool(false)` on both. The file-header NOTE now carries the full three-platform matrix with the probe command, per-platform verdicts, and provenance.

2. **Boundary rows.** Neither #1491 nor #1492 pinned the accept side of the guard: single-zero octets (`0.0.0.0`, `0.1.2.3`) must stay accepted (probed accepted on all three platforms). Two new provider rows cover it; provider `=>` arrows realigned (the review nitpick from #1491) while touching those lines.

## Proof

Behavior-preserving change — new rows pin existing verdicts (green oracle), plus an executed mutation check that the rows are failable: widening the guard regex to `/(?:^|\.)0/` fails 4 rows including both new boundary rows; reverting restores green. Full suite: 3763 tests / 22423 assertions pass.

Part of #1468 (already closed by #1491).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
