### PR TITLE
scripts: validate hook capsules end to end

### DIFF
--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -47,7 +48,6 @@ ADAPTER_BUDGET = 8_192
 POLICY_BUDGET = 12_288
 STUB_BUDGET = 400
 CAPSULE_BUDGET = 1_800
-CAPSULE_COMMAND_TIMEOUT = 5
 # The parity label (everything before the first ": ") is the one uncheckable part of
 # the UserPromptSubmit capsule; the bound keeps it a label, not a smuggling channel.
 PARITY_LABEL_MAX = 80
@@ -70,7 +70,7 @@ HEADER_WINDOW = 12
 _SCOPE_RE = re.compile(r"\*\*Scope:?\*\*|^Scope:|\bScope: ", re.MULTILINE)
 _LOADWHEN_RE = re.compile(r"Load[- ]when:", re.IGNORECASE)
 
-_MD_TOKEN_RE = re.compile(r"`([^`]*\.md)`")
+_MD_TOKEN_RE = re.compile(r"`([^`]*\.md[^`]*)`")
 _RESOLVE_DIRS = (".agents/policy", ".agents/context", "docs/misc")
 
 # A single well-formed `<a|b|c>` alternation group: prefix/suffix may not carry
@@ -220,18 +220,14 @@ def extract_capsules(settings_text: str) -> tuple[list[tuple[str, str]], list[st
                     if "additionalContext" not in command:
                         continue
                     try:
-                        stdout = subprocess.run(
-                            ["sh", "-c", command],
-                            capture_output=True,
-                            text=True,
-                            check=True,
-                            timeout=CAPSULE_COMMAND_TIMEOUT,
-                        ).stdout
-                        payload = json.loads(stdout)
+                        argv = shlex.split(command)
+                        if len(argv) != 2 or argv[0] != "echo" or shlex.join(argv) != command:
+                            raise ValueError("noncanonical capsule command")
+                        payload = json.loads(argv[1])
                         text = payload["hookSpecificOutput"]["additionalContext"]
                         if not isinstance(text, str):
                             raise TypeError("additionalContext is not text")
-                    except (subprocess.SubprocessError, OSError, UnicodeError, ValueError, KeyError, TypeError):
+                    except (OSError, UnicodeError, ValueError, KeyError, TypeError):
                         errors.append(f"{SETTINGS}: {event} capsule payload is not extractable JSON")
                         continue
                     capsules.append((event, text))

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -47,6 +47,7 @@ ADAPTER_BUDGET = 8_192
 POLICY_BUDGET = 12_288
 STUB_BUDGET = 400
 CAPSULE_BUDGET = 1_800
+CAPSULE_COMMAND_TIMEOUT = 5
 # The parity label (everything before the first ": ") is the one uncheckable part of
 # the UserPromptSubmit capsule; the bound keeps it a label, not a smuggling channel.
 PARITY_LABEL_MAX = 80
@@ -69,7 +70,7 @@ HEADER_WINDOW = 12
 _SCOPE_RE = re.compile(r"\*\*Scope:?\*\*|^Scope:|\bScope: ", re.MULTILINE)
 _LOADWHEN_RE = re.compile(r"Load[- ]when:", re.IGNORECASE)
 
-_MD_TOKEN_RE = re.compile(r"`([^`\s]+\.md)`")
+_MD_TOKEN_RE = re.compile(r"`([^`]*\.md)`")
 _RESOLVE_DIRS = (".agents/policy", ".agents/context", "docs/misc")
 
 # A single well-formed `<a|b|c>` alternation group: prefix/suffix may not carry
@@ -88,6 +89,8 @@ def _expand_template(tok: str) -> list[str] | None:
     """
     match = _TEMPLATE_RE.fullmatch(tok)
     if match is None:
+        return None
+    if any(char.isspace() for char in tok):
         return None
     alts = match["body"].replace("\\", "").split("|")
     if len(alts) < 2 or any(alt == "" for alt in alts):
@@ -180,12 +183,16 @@ def check_headers(root: Path) -> list[str]:
     bootstrap = root / "AGENTS.md"
     if not bootstrap.is_file():
         return ["AGENTS.md: bootstrap missing — nothing to route from"]
-    tokens, _ = routing_targets(bootstrap.read_text(encoding="utf-8"))
+    tokens, skipped = routing_targets(bootstrap.read_text(encoding="utf-8"))
+    violations = [
+        f"AGENTS.md: malformed routing target `{token}` skipped"
+        for token in skipped
+        if any(char.isspace() for char in token)
+    ]
     if not tokens:
         # A renamed/removed "## Routing table" heading would otherwise disarm
         # the whole header gate silently (zero targets = vacuous pass).
-        return ["AGENTS.md: no routing-table targets extracted — heading renamed or table removed?"]
-    violations = []
+        return violations or ["AGENTS.md: no routing-table targets extracted — heading renamed or table removed?"]
     for token in dict.fromkeys(tokens):
         rel = resolve_target(root, token)
         if rel is None:
@@ -212,11 +219,19 @@ def extract_capsules(settings_text: str) -> tuple[list[tuple[str, str]], list[st
                     command = hook.get("command", "")
                     if "additionalContext" not in command:
                         continue
-                    start, end = command.find("'"), command.rfind("'")
                     try:
-                        payload = json.loads(command[start + 1 : end])
+                        stdout = subprocess.run(
+                            ["sh", "-c", command],
+                            capture_output=True,
+                            text=True,
+                            check=True,
+                            timeout=CAPSULE_COMMAND_TIMEOUT,
+                        ).stdout
+                        payload = json.loads(stdout)
                         text = payload["hookSpecificOutput"]["additionalContext"]
-                    except (ValueError, KeyError, TypeError):
+                        if not isinstance(text, str):
+                            raise TypeError("additionalContext is not text")
+                    except (subprocess.SubprocessError, OSError, UnicodeError, ValueError, KeyError, TypeError):
                         errors.append(f"{SETTINGS}: {event} capsule payload is not extractable JSON")
                         continue
                     capsules.append((event, text))

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -249,6 +249,14 @@ def test_check_headers_reports_spaced_template_token(tmp_path: Path) -> None:
     assert violations == ["AGENTS.md: malformed routing target `lang-<php | python>.md` skipped"]
 
 
+def test_check_headers_reports_spaced_template_token_with_trailing_text(tmp_path: Path) -> None:
+    root = _scratch_repo(tmp_path)
+    bootstrap = _BOOTSTRAP.replace("lang-<php\\|python\\|shell>.md", "lang-<php | python>.md trailing")
+    _write(root, "AGENTS.md", bootstrap)
+    violations = ccb.check_headers(root)
+    assert violations == ["AGENTS.md: malformed routing target `lang-<php | python>.md trailing` skipped"]
+
+
 # --- both header shapes accepted; window enforced ------------------------------
 
 
@@ -297,6 +305,10 @@ def _settings_ups(capsule: str) -> str:
     )
 
 
+def _settings_command(command: str, event: str = "SessionStart") -> str:
+    return json.dumps({"hooks": {event: [{"hooks": [{"type": "command", "command": command}]}]}})
+
+
 def test_extract_capsules_returns_event_text_and_measures_bytes() -> None:
     # extract_capsules returns the capsule TEXT per event; byte length is
     # derived by the caller where it matters.
@@ -324,6 +336,40 @@ def test_extract_capsules_reports_unextractable_payload() -> None:
 
 def test_extract_capsules_rejects_shell_broken_apostrophe() -> None:
     capsules, errors = ccb.extract_capsules(_settings("repo's"))
+    assert capsules == []
+    assert errors == [".claude/settings.json: SessionStart capsule payload is not extractable JSON"]
+
+
+def test_extract_capsules_rejects_appended_command_without_execution(tmp_path: Path) -> None:
+    marker = tmp_path / "MARKER"
+    payload = json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "abc"}})
+    settings = _settings_command(f"echo '{payload}'; touch {marker}")
+    capsules, errors = ccb.extract_capsules(settings)
+    assert capsules == []
+    assert errors == [".claude/settings.json: SessionStart capsule payload is not extractable JSON"]
+    assert not marker.exists(), f"capsule validation executed side effect: {marker}"
+
+
+def test_extract_capsules_keeps_single_quoted_shell_metacharacters_literal(tmp_path: Path) -> None:
+    marker = tmp_path / "MARKER"
+    capsule = f"literal $(touch {marker})"
+    payload = json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": capsule}})
+    capsules, errors = ccb.extract_capsules(_settings_command(f"echo '{payload}'"))
+    assert capsules == [("SessionStart", capsule)]
+    assert errors == []
+    assert not marker.exists(), f"single-quoted capsule text expanded: {marker}"
+
+
+@pytest.mark.parametrize("shape", ["double-quoted", "printf", "extra-arg", "multiple-commands"])
+def test_extract_capsules_rejects_noncanonical_commands(shape: str) -> None:
+    payload = json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "abc"}})
+    command = {
+        "double-quoted": f'echo "{payload}"',
+        "printf": f"printf '%s' '{payload}'",
+        "extra-arg": f"echo '{payload}' ''",
+        "multiple-commands": f"echo '{payload}'; true",
+    }[shape]
+    capsules, errors = ccb.extract_capsules(_settings_command(command))
     assert capsules == []
     assert errors == [".claude/settings.json: SessionStart capsule payload is not extractable JSON"]
 

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -241,6 +241,14 @@ def test_check_headers_hostile_templates_skip_silently_no_crash(tmp_path: Path) 
     assert ccb.check_headers(root) == []
 
 
+def test_check_headers_reports_spaced_template_token(tmp_path: Path) -> None:
+    root = _scratch_repo(tmp_path)
+    bootstrap = _BOOTSTRAP.replace("lang-<php\\|python\\|shell>.md", "lang-<php | python>.md")
+    _write(root, "AGENTS.md", bootstrap)
+    violations = ccb.check_headers(root)
+    assert violations == ["AGENTS.md: malformed routing target `lang-<php | python>.md` skipped"]
+
+
 # --- both header shapes accepted; window enforced ------------------------------
 
 
@@ -310,6 +318,12 @@ def test_extract_capsules_reports_unextractable_payload() -> None:
         {"hooks": {"SessionStart": [{"hooks": [{"type": "command", "command": "emit-additionalContext.sh 'oops"}]}]}}
     )
     capsules, errors = ccb.extract_capsules(settings)
+    assert capsules == []
+    assert errors == [".claude/settings.json: SessionStart capsule payload is not extractable JSON"]
+
+
+def test_extract_capsules_rejects_shell_broken_apostrophe() -> None:
+    capsules, errors = ccb.extract_capsules(_settings("repo's"))
     assert capsules == []
     assert errors == [".claude/settings.json: SessionStart capsule payload is not extractable JSON"]
 


### PR DESCRIPTION
## Summary

Make the context-budget checker validate complete canonical capsule commands, not a quote-sliced payload.

- Parse each canonical `echo '<JSON>'` command with `shlex`, require an exact argv round-trip, then validate the JSON payload without executing repository-controlled shell.
- Fail closed on broken quoting, appended commands, noncanonical command forms, invalid JSON, and payload-shape errors.
- Capture malformed spaced Markdown routing tokens and report them instead of silently missing them.
- Preserve valid literal/template routing and the existing malformed-group skip contract.

Fixes #1462

## Verification

- Original frozen red hash: `d81e4f552e78e0ef61d58ce59b7924469ccaca56`
- RED: apostrophe capsule falsely extracted; spaced routing token produced no violation
- GREEN: same two tests passed unchanged
- Review-fix frozen red hash: `12134649e898d0ddb0b2dab8dae5439e64dd5fc6`
- Review-fix RED: 5 failed / 2 passed; GREEN: 7 passed unchanged
- `python3 -m pytest tests/test_context_budget.py` — 84 passed
- `python3 scripts/check_context_budget.py --all`
- Canonical Python/Markdown gates: PASS
- Independent red-proof replays and hostile-input matrices: PASS
- Outside-diff helper-produced capsule bypass tracked separately in #1501

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
