### PR TITLE
agent: fail closed on Composer vendor drift

### DIFF
--- a/.agents/policy/git.md
+++ b/.agents/policy/git.md
@@ -44,6 +44,8 @@ git worktree remove <path>            # run from any directory OUTSIDE <path>
   outside the tree being removed (the primary checkout works; so does a session worktree).
   `gh pr merge --delete-branch` can't check out a base another worktree holds — verify the
   merge landed, then `git push origin --delete <branch>`.
+- Each worktree owns its Composer `vendor/` tree; never share or symlink `vendor/` between
+  worktrees. Run `composer install --no-interaction` in the current worktree.
 
 ## Git hooks
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,7 +11,8 @@
 #      (a PHP-only commit doesn't pay for the markdown/python/shell linters, etc.).
 #
 # Each check also runs only when its tool is available: a contributor missing a
-# tool is warned and that check is skipped, never blocked (CI is the hard gate).
+# tool is warned and that check is skipped, never blocked (CI is the hard gate),
+# except the mandatory Composer vendor guard for staged PHP.
 # All applicable checks run even after one fails, so every problem is reported in
 # a single pass. Bypass in an emergency with `git commit --no-verify`.
 #
@@ -313,6 +314,23 @@ fi
 
 # =============================== PHP (*.php, *.inc) ========================== #
 if [ "$staged_php" = 1 ]; then
+	composer_vendor_ok=1
+	if [ -n "$py_bin" ]; then
+		step 'composer vendor'
+		"$py_bin" scripts/check_composer_vendor.py || {
+			failed 'composer vendor'
+			composer_vendor_ok=0
+		}
+	else
+		failed 'composer vendor (python interpreter unavailable)'
+		composer_vendor_ok=0
+	fi
+
+	# Composer PHP tools are unsafe against a missing, shared, or stale vendor tree.
+	# The guard is fail-closed and runs before every PHP analysis gate.
+	if [ "$composer_vendor_ok" != 1 ]; then
+		printf '[pre-commit] Composer vendor check failed; skipping PHP analysis gates.\n' >&2
+	else
 	# php -l syntax check (output shown only for files that fail).
 	if have php; then
 		step 'php -l'
@@ -340,6 +358,7 @@ if [ "$staged_php" = 1 ]; then
 		vendor/bin/phpcs -d memory_limit=1G || failed 'phpcs'
 	else
 		skip phpcs
+	fi
 	fi
 fi
 

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -45,6 +45,7 @@ gates_for() {
 		out="${out}python3 -m pytest${nl}ruff check .${nl}ruff format --check .${nl}mypy tests/${nl}"
 	fi
 	if printf '%s\n' "$files" | grep -Eq '\.(php|inc)$'; then
+		out="${out}python3 scripts/check_composer_vendor.py${nl}"
 		for f in $(printf '%s\n' "$files" | grep -E '\.(php|inc)$'); do
 			out="${out}php -l $f${nl}"
 		done
@@ -71,6 +72,11 @@ run_gate() {
 	# $1 = command line
 	tool=${1%% *}
 	if ! (cd "$worktree" && { command -v "$tool" >/dev/null 2>&1 || [ -x "$tool" ]; }); then
+		if [ "$1" = 'python3 scripts/check_composer_vendor.py' ]; then
+			printf 'GATE FAIL: %s (TOOL-MISSING: %s)\n' "$1" "$tool"
+			overall=1
+			return 1
+		fi
 		printf 'GATE SKIP: %s (TOOL-MISSING: %s)\n' "$1" "$tool"
 		[ "$allow_missing" -eq 1 ] || overall=1
 		return 0
@@ -82,6 +88,7 @@ run_gate() {
 	else
 		printf 'GATE FAIL: %s\n' "$1"
 		overall=1
+		[ "$1" = 'python3 scripts/check_composer_vendor.py' ] && return 1
 	fi
 }
 
@@ -126,7 +133,8 @@ main() {
 	report=$(printf '%s\n' "$cmds" | {
 		overall=0
 		while IFS= read -r c; do
-			[ -n "$c" ] && run_gate "$c"
+			[ -n "$c" ] || continue
+			run_gate "$c" || break
 		done
 		echo "OVERALL=$overall"
 	})

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -100,8 +100,8 @@ run_gate() {
 	else
 		printf 'GATE FAIL: %s\n' "$1"
 		overall=1
-		[ "$1" = 'python3 scripts/check_composer_vendor.py' ] && return 1
 	fi
+	return 0
 }
 
 main() {
@@ -146,15 +146,18 @@ main() {
 		overall=0
 		while IFS= read -r c; do
 			[ -n "$c" ] || continue
-			run_gate "$c" || break
+			if ! run_gate "$c"; then
+				[ "$c" = 'python3 scripts/check_composer_vendor.py' ] && break
+			fi
 		done
 		echo "OVERALL=$overall"
 	})
+	overall_status=${report##*OVERALL=}
 	printf '%s\n' "$report" | grep -v '^OVERALL='
 	if printf '%s\n' "$files" | grep -q '^src/usr/local/www/'; then
 		printf 'REMINDER: www/ touched -- Tier-A ui_render coverage is required and cannot be script-checked (test mandate #4)\n'
 	fi
-	if printf '%s\n' "$report" | grep -q 'OVERALL=0'; then
+	if [ "$overall_status" = 0 ]; then
 		printf 'GATES: PASS\n'
 		exit 0
 	fi

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -81,6 +81,18 @@ run_gate() {
 		[ "$allow_missing" -eq 1 ] || overall=1
 		return 0
 	fi
+	if [ "$1" = 'python3 scripts/check_composer_vendor.py' ]; then
+		checker_output=$(cd "$worktree" && sh -c "$1" </dev/null 2>&1)
+		checker_status=$?
+		if [ "$checker_status" -eq 0 ]; then
+			printf 'GATE PASS: %s\n' "$1"
+			return 0
+		fi
+		printf '%s\n' "$checker_output"
+		printf 'GATE FAIL: %s\n' "$1"
+		overall=1
+		return 1
+	fi
 	# issue #1194: </dev/null -- a stdin-reading gate (full PHPUnit) otherwise eats
 	# the command loop's remaining gate lines, silently skipping those gates.
 	if (cd "$worktree" && sh -c "$1" </dev/null >/dev/null 2>&1); then

--- a/scripts/check_composer_vendor.py
+++ b/scripts/check_composer_vendor.py
@@ -20,7 +20,7 @@ def _load_json(path: Path, label: str) -> tuple[Any | None, list[str]]:
         return json.loads(path.read_text(encoding="utf-8"), parse_constant=_reject_json_constant), []
     except FileNotFoundError:
         return None, [f"missing {label}: {path}"]
-    except (OSError, UnicodeDecodeError, ValueError) as exc:
+    except (OSError, UnicodeDecodeError, ValueError, RecursionError) as exc:
         return None, [f"malformed {label}: {exc}"]
 
 

--- a/scripts/check_composer_vendor.py
+++ b/scripts/check_composer_vendor.py
@@ -29,14 +29,14 @@ def _package_tuple(package: Any) -> tuple[str, tuple[str, str | None, str | None
         return None
     refs: list[str | None] = []
     for field in ("source", "dist"):
-        value = package.get(field)
-        if value is None:
+        if field not in package:
             refs.append(None)
             continue
+        value = package[field]
         if not isinstance(value, dict):
             return None
         reference = value.get("reference")
-        if reference is not None and not isinstance(reference, str):
+        if not isinstance(reference, str) or not reference:
             return None
         refs.append(reference)
     return name, (version, refs[0], refs[1])

--- a/scripts/check_composer_vendor.py
+++ b/scripts/check_composer_vendor.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Verify a worktree's Composer metadata matches its lock file."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REMEDIATION = "remediation: composer install --no-interaction"
+
+
+def _load_json(path: Path, label: str) -> tuple[Any | None, list[str]]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), []
+    except FileNotFoundError:
+        return None, [f"missing {label}: {path}"]
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, [f"malformed {label}: {exc}"]
+
+
+def _package_tuple(package: Any) -> tuple[str, tuple[str, str | None, str | None]] | None:
+    if not isinstance(package, dict):
+        return None
+    name = package.get("name")
+    version = package.get("version")
+    if not isinstance(name, str) or not name or not isinstance(version, str) or not version:
+        return None
+    refs: list[str | None] = []
+    for field in ("source", "dist"):
+        value = package.get(field)
+        if value is None:
+            refs.append(None)
+            continue
+        if not isinstance(value, dict):
+            return None
+        reference = value.get("reference")
+        if reference is not None and not isinstance(reference, str):
+            return None
+        refs.append(reference)
+    return name, (version, refs[0], refs[1])
+
+
+def _packages(value: Any, label: str) -> tuple[dict[str, tuple[str, str | None, str | None]], list[str]]:
+    if not isinstance(value, list):
+        return {}, [f"malformed {label}: packages must be a list"]
+    packages: dict[str, tuple[str, str | None, str | None]] = {}
+    errors: list[str] = []
+    for index, package in enumerate(value):
+        parsed = _package_tuple(package)
+        if parsed is None:
+            errors.append(f"malformed {label} package {index}: name, version, source, and dist metadata")
+            continue
+        name, details = parsed
+        if name in packages:
+            errors.append(f"malformed {label}: duplicate package {name}")
+            continue
+        packages[name] = details
+    return packages, errors
+
+
+def _read_lock(path: Path) -> tuple[dict[str, tuple[str, str | None, str | None]], list[str]]:
+    value, errors = _load_json(path, "composer.lock")
+    if errors:
+        return {}, errors
+    if not isinstance(value, dict):
+        return {}, ["malformed composer.lock: top level must be an object"]
+    packages: dict[str, tuple[str, str | None, str | None]] = {}
+    for key in ("packages", "packages-dev"):
+        current, current_errors = _packages(value.get(key), f"composer.lock {key}")
+        errors.extend(current_errors)
+        for name, details in current.items():
+            if name in packages:
+                errors.append(f"malformed composer.lock: duplicate package {name}")
+            else:
+                packages[name] = details
+    return packages, errors
+
+
+def _read_installed(path: Path) -> tuple[dict[str, tuple[str, str | None, str | None]], list[str]]:
+    value, errors = _load_json(path, "vendor/composer/installed.json")
+    if errors:
+        return {}, errors
+    if not isinstance(value, dict):
+        return {}, ["malformed vendor/composer/installed.json: top level must be an object"]
+    if "packages" not in value:
+        return {}, ["malformed vendor/composer/installed.json: missing packages metadata"]
+    return _packages(value["packages"], "vendor/composer/installed.json")
+
+
+def _compare(
+    locked: dict[str, tuple[str, str | None, str | None]],
+    installed: dict[str, tuple[str, str | None, str | None]],
+) -> list[str]:
+    def display(reference: str | None) -> str:
+        return reference if reference is not None else "null"
+
+    diagnostics: list[str] = []
+    for name in sorted(locked.keys() - installed.keys()):
+        diagnostics.append(f"missing package: {name} (locked {locked[name][0]})")
+    for name in sorted(installed.keys() - locked.keys()):
+        diagnostics.append(f"extra package: {name} (installed {installed[name][0]})")
+    for name in sorted(locked.keys() & installed.keys()):
+        locked_version, locked_source, locked_dist = locked[name]
+        installed_version, installed_source, installed_dist = installed[name]
+        if locked_version != installed_version:
+            diagnostics.append(f"version mismatch: {name} (locked {locked_version}; installed {installed_version})")
+        if locked_source != installed_source:
+            diagnostics.append(
+                f"source reference mismatch: {name} "
+                f"(locked {display(locked_source)}; installed {display(installed_source)})"
+            )
+        if locked_dist != installed_dist:
+            diagnostics.append(
+                f"dist reference mismatch: {name} (locked {display(locked_dist)}; installed {display(installed_dist)})"
+            )
+    return diagnostics
+
+
+def check(root: Path) -> list[str]:
+    vendor = root / "vendor"
+    if vendor.is_symlink():
+        return [f"vendor is symlinked: {vendor}"]
+    if not vendor.is_dir():
+        return [f"missing vendor directory: {vendor}"]
+    installed = vendor / "composer" / "installed.json"
+    locked, lock_errors = _read_lock(root / "composer.lock")
+    installed_packages, installed_errors = _read_installed(installed)
+    errors = lock_errors + installed_errors
+    return errors if errors else _compare(locked, installed_packages)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 2:
+        print("usage: check_composer_vendor.py [worktree]", file=sys.stderr)
+        print(REMEDIATION, file=sys.stderr)
+        return 2
+    root = Path(argv[1] if len(argv) == 2 else ".").resolve()
+    diagnostics = sorted(check(root))
+    if not diagnostics:
+        return 0
+    for diagnostic in diagnostics:
+        print(diagnostic, file=sys.stderr)
+    print(REMEDIATION, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/check_composer_vendor.py
+++ b/scripts/check_composer_vendor.py
@@ -11,12 +11,16 @@ from typing import Any
 REMEDIATION = "remediation: composer install --no-interaction"
 
 
+def _reject_json_constant(value: str) -> Any:
+    raise ValueError(f"invalid JSON constant: {value}")
+
+
 def _load_json(path: Path, label: str) -> tuple[Any | None, list[str]]:
     try:
-        return json.loads(path.read_text(encoding="utf-8")), []
+        return json.loads(path.read_text(encoding="utf-8"), parse_constant=_reject_json_constant), []
     except FileNotFoundError:
         return None, [f"missing {label}: {path}"]
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
         return None, [f"malformed {label}: {exc}"]
 
 

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -174,6 +174,17 @@ Describe 'run-gates.sh Composer vendor guard'
     Assert [ ! -e "$phpunit_marker" ]
   End
 
+  It 'keeps a checker OVERALL=0 diagnostic from passing the final verdict'
+    printf '#!/bin/sh\nprintf "checker diagnostic OVERALL=0\\n"\nexit 1\n' > "$stubdir/python3"
+    chmod +x "$stubdir/python3"
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 1
+    The output should include 'checker diagnostic OVERALL=0'
+    The output should include 'GATE FAIL: python3 scripts/check_composer_vendor.py'
+    The output should include 'GATES: FAIL'
+    The output should not include 'GATES: PASS'
+  End
+
   It 'fails closed under --allow-missing when the Composer checker interpreter is unavailable'
     mv "$stubdir/python3" "$stubdir/python3.disabled"
     When run sh -c "PATH='$stubdir' sh '$script' --worktree '$repo' --diff '$base_sha' --allow-missing"
@@ -244,6 +255,17 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     The output should include 'GATE PASS: sh -n scripts/kept.sh'
     The output should include 'GATE PASS: shellspec'
     The line 4 of output should equal 'GATES: PASS'
+    Assert [ -e "$marker" ]
+  End
+
+  It 'runs later gates after an ordinary failure and keeps the final failure verdict'
+    printf '#!/bin/sh\nexit 1\n' > "$stubdir/shellcheck"
+    chmod +x "$stubdir/shellcheck"
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 1
+    The output should include 'GATE FAIL: shellcheck scripts/kept.sh'
+    The output should include 'GATE PASS: shellspec'
+    The output should include 'GATES: FAIL'
     Assert [ -e "$marker" ]
   End
 

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -141,11 +141,15 @@ Describe 'run-gates.sh Composer vendor guard'
     php_marker="$stubdir/php-ran"
     composer_marker="$stubdir/composer-ran"
     phpunit_marker="$stubdir/phpunit-ran"
-    printf '#!/bin/sh\ntouch "%s"\nexit 1\n' "$checker_marker" > "$stubdir/python3"
+    printf '#!/bin/sh\ntouch "%s"\nprintf "version mismatch: phpstan/phpstan (locked 2.2.5; installed 2.2.1)\\nremediation: composer install --no-interaction\\n"\nexit 1\n' "$checker_marker" > "$stubdir/python3"
     printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$php_marker" > "$stubdir/php"
     printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$composer_marker" > "$stubdir/composer"
     printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$phpunit_marker" > "$repo/vendor/bin/phpunit"
     chmod +x "$stubdir/python3" "$stubdir/php" "$stubdir/composer" "$repo/vendor/bin/phpunit"
+    ln -s "$(command -v git)" "$stubdir/git"
+    for tool in cat dirname grep sh sort; do
+      ln -s "$(command -v "$tool")" "$stubdir/$tool"
+    done
     PATH="$stubdir:$PATH"
   }
   cleanup() { rm -rf "$repo" "$stubdir"; }
@@ -156,12 +160,30 @@ Describe 'run-gates.sh Composer vendor guard'
   It 'stops before PHP analysis when the Composer vendor checker fails'
     When run sh "$script" --worktree "$repo" --diff "$base_sha"
     The status should equal 1
+    The line 1 of output should equal 'version mismatch: phpstan/phpstan (locked 2.2.5; installed 2.2.1)'
+    The line 2 of output should equal 'remediation: composer install --no-interaction'
     The output should include 'GATE FAIL: python3 scripts/check_composer_vendor.py'
     The output should not include 'GATE PASS: php -l src/a.php'
     The output should not include 'GATE PASS: vendor/bin/phpunit'
     The output should not include 'GATE PASS: composer phpstan'
     The output should not include 'GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/'
+    The lines of output should equal 4
     Assert [ -e "$checker_marker" ]
+    Assert [ ! -e "$php_marker" ]
+    Assert [ ! -e "$composer_marker" ]
+    Assert [ ! -e "$phpunit_marker" ]
+  End
+
+  It 'fails closed under --allow-missing when the Composer checker interpreter is unavailable'
+    mv "$stubdir/python3" "$stubdir/python3.disabled"
+    When run sh -c "PATH='$stubdir' sh '$script' --worktree '$repo' --diff '$base_sha' --allow-missing"
+    The status should equal 1
+    The output should include 'GATE FAIL: python3 scripts/check_composer_vendor.py (TOOL-MISSING: python3)'
+    The output should not include 'GATE SKIP: python3 scripts/check_composer_vendor.py'
+    The output should not include 'GATE PASS: php -l src/a.php'
+    The output should not include 'GATE PASS: vendor/bin/phpunit'
+    The output should not include 'GATE PASS: composer phpstan'
+    The output should not include 'GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/'
     Assert [ ! -e "$php_marker" ]
     Assert [ ! -e "$composer_marker" ]
     Assert [ ! -e "$phpunit_marker" ]

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -24,12 +24,13 @@ Describe 'run-gates.sh gates_for()'
       #|src/b.php
     End
     When call gates_for
-    The line 1 of output should equal 'php -l src/a.inc'
-    The line 2 of output should equal 'php -l src/b.php'
-    The line 3 of output should equal 'vendor/bin/phpunit'
-    The line 4 of output should equal 'composer phpstan'
-    The line 5 of output should equal 'composer phpcs -- --standard=phpcs.xml.dist src/'
-    The lines of output should equal 5
+    The line 1 of output should equal 'python3 scripts/check_composer_vendor.py'
+    The line 2 of output should equal 'php -l src/a.inc'
+    The line 3 of output should equal 'php -l src/b.php'
+    The line 4 of output should equal 'vendor/bin/phpunit'
+    The line 5 of output should equal 'composer phpstan'
+    The line 6 of output should equal 'composer phpcs -- --standard=phpcs.xml.dist src/'
+    The lines of output should equal 6
   End
 
   It 'maps shell files to per-file sh -n + shellcheck plus the dash-pinned shellspec'
@@ -118,6 +119,52 @@ Describe 'run-gates.sh gates_for()'
     Data "src/usr/local/pkg/pfblockerng/info.xml"
     When call gates_for
     The output should equal ''
+  End
+End
+
+Describe 'run-gates.sh Composer vendor guard'
+  gitc() { git -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+  make_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rungatesphp.XXXXXX")"
+    git -C "$repo" init -q
+    gitc config commit.gpgsign false
+    mkdir -p "$repo/src" "$repo/vendor/bin" "$repo/scripts"
+    printf 'base\n' > "$repo/README"
+    gitc add -A; gitc commit -qm base
+    base_sha=$(gitc rev-parse HEAD)
+    printf '<?php echo 1;\n' > "$repo/src/a.php"
+    gitc add -A; gitc commit -qm php
+
+    stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rungatesphpstub.XXXXXX")"
+    checker_marker="$stubdir/checker-ran"
+    php_marker="$stubdir/php-ran"
+    composer_marker="$stubdir/composer-ran"
+    phpunit_marker="$stubdir/phpunit-ran"
+    printf '#!/bin/sh\ntouch "%s"\nexit 1\n' "$checker_marker" > "$stubdir/python3"
+    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$php_marker" > "$stubdir/php"
+    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$composer_marker" > "$stubdir/composer"
+    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$phpunit_marker" > "$repo/vendor/bin/phpunit"
+    chmod +x "$stubdir/python3" "$stubdir/php" "$stubdir/composer" "$repo/vendor/bin/phpunit"
+    PATH="$stubdir:$PATH"
+  }
+  cleanup() { rm -rf "$repo" "$stubdir"; }
+  Before 'make_repo'
+  After 'cleanup'
+  script="scripts/agent/run-gates.sh"
+
+  It 'stops before PHP analysis when the Composer vendor checker fails'
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 1
+    The output should include 'GATE FAIL: python3 scripts/check_composer_vendor.py'
+    The output should not include 'GATE PASS: php -l src/a.php'
+    The output should not include 'GATE PASS: vendor/bin/phpunit'
+    The output should not include 'GATE PASS: composer phpstan'
+    The output should not include 'GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/'
+    Assert [ -e "$checker_marker" ]
+    Assert [ ! -e "$php_marker" ]
+    Assert [ ! -e "$composer_marker" ]
+    Assert [ ! -e "$phpunit_marker" ]
   End
 End
 

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -188,6 +188,25 @@ Describe 'run-gates.sh Composer vendor guard'
     Assert [ ! -e "$composer_marker" ]
     Assert [ ! -e "$phpunit_marker" ]
   End
+
+  It 'suppresses successful Composer checker diagnostics while running PHP gates'
+    printf '#!/bin/sh\ntouch "%s"\nprintf "checker stdout\\n"\nprintf "checker stderr\\n" >&2\nexit 0\n' "$checker_marker" > "$stubdir/python3"
+    chmod +x "$stubdir/python3"
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 0
+    The output should not include 'checker stdout'
+    The output should not include 'checker stderr'
+    The output should include 'GATE PASS: python3 scripts/check_composer_vendor.py'
+    The output should include 'GATE PASS: php -l src/a.php'
+    The output should include 'GATE PASS: vendor/bin/phpunit'
+    The output should include 'GATE PASS: composer phpstan'
+    The output should include 'GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/'
+    The output should include 'GATES: PASS'
+    Assert [ -e "$checker_marker" ]
+    Assert [ -e "$php_marker" ]
+    Assert [ -e "$composer_marker" ]
+    Assert [ -e "$phpunit_marker" ]
+  End
 End
 
 Describe 'run-gates.sh main (fixture repo, stubbed tools)'

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -196,6 +196,7 @@ Describe 'run-gates.sh Composer vendor guard'
     The status should equal 0
     The output should not include 'checker stdout'
     The output should not include 'checker stderr'
+    The stderr should equal ''
     The output should include 'GATE PASS: python3 scripts/check_composer_vendor.py'
     The output should include 'GATE PASS: php -l src/a.php'
     The output should include 'GATE PASS: vendor/bin/phpunit'

--- a/tests/shell/precommit_composer_vendor_spec.sh
+++ b/tests/shell/precommit_composer_vendor_spec.sh
@@ -40,8 +40,10 @@ Describe '.githooks/pre-commit Composer vendor guard'
   End
 
   It 'runs every PHP analysis gate when the Composer vendor checker succeeds'
-    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$checker_marker" > "$stubdir/python3"
-    chmod +x "$stubdir/python3"
+    for interpreter in python python3; do
+      printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$checker_marker" > "$stubdir/$interpreter"
+    done
+    chmod +x "$stubdir/python" "$stubdir/python3"
     When run sh -c "cd '$repo' && sh .githooks/pre-commit"
     The status should equal 0
     The output should include '[pre-commit] php -l'

--- a/tests/shell/precommit_composer_vendor_spec.sh
+++ b/tests/shell/precommit_composer_vendor_spec.sh
@@ -1,0 +1,39 @@
+#shellcheck shell=sh
+# .githooks/pre-commit Composer vendor guard: a failed guard blocks Composer tools.
+
+Describe '.githooks/pre-commit Composer vendor guard'
+  gitc() { git -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+  make_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitphp.XXXXXX")"
+    git -C "$repo" init -q
+    gitc config commit.gpgsign false
+    mkdir -p "$repo/.githooks" "$repo/src" "$repo/vendor/bin"
+    cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
+    printf '<?php echo 1;\n' > "$repo/src/a.php"
+    gitc add src/a.php
+
+    stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitphpstub.XXXXXX")"
+    php_marker="$stubdir/php-ran"
+    phpstan_marker="$stubdir/phpstan-ran"
+    phpcs_marker="$stubdir/phpcs-ran"
+    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$php_marker" > "$stubdir/php"
+    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$phpstan_marker" > "$repo/vendor/bin/phpstan"
+    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$phpcs_marker" > "$repo/vendor/bin/phpcs"
+    chmod +x "$stubdir/php" "$repo/vendor/bin/phpstan" "$repo/vendor/bin/phpcs"
+    PATH="$stubdir:$PATH"
+  }
+  cleanup() { rm -rf "$repo" "$stubdir"; }
+  Before 'make_repo'
+  After 'cleanup'
+
+  It 'fails closed before PHPStan and PHPCS when the checker is unavailable'
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The output should not include '[pre-commit] phpstan'
+    The output should not include '[pre-commit] phpcs'
+    The stderr should include '[pre-commit] FAILED: composer vendor'
+    Assert [ ! -e "$phpstan_marker" ]
+    Assert [ ! -e "$phpcs_marker" ]
+  End
+End

--- a/tests/shell/precommit_composer_vendor_spec.sh
+++ b/tests/shell/precommit_composer_vendor_spec.sh
@@ -14,6 +14,7 @@ Describe '.githooks/pre-commit Composer vendor guard'
     gitc add src/a.php
 
     stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitphpstub.XXXXXX")"
+    checker_marker="$stubdir/checker-ran"
     php_marker="$stubdir/php-ran"
     phpstan_marker="$stubdir/phpstan-ran"
     phpcs_marker="$stubdir/phpcs-ran"
@@ -33,7 +34,22 @@ Describe '.githooks/pre-commit Composer vendor guard'
     The output should not include '[pre-commit] phpstan'
     The output should not include '[pre-commit] phpcs'
     The stderr should include '[pre-commit] FAILED: composer vendor'
+    Assert [ ! -e "$php_marker" ]
     Assert [ ! -e "$phpstan_marker" ]
     Assert [ ! -e "$phpcs_marker" ]
+  End
+
+  It 'runs every PHP analysis gate when the Composer vendor checker succeeds'
+    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$checker_marker" > "$stubdir/python3"
+    chmod +x "$stubdir/python3"
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 0
+    The output should include '[pre-commit] php -l'
+    The output should include '[pre-commit] phpstan'
+    The output should include '[pre-commit] phpcs'
+    Assert [ -e "$checker_marker" ]
+    Assert [ -e "$php_marker" ]
+    Assert [ -e "$phpstan_marker" ]
+    Assert [ -e "$phpcs_marker" ]
   End
 End

--- a/tests/test_check_composer_vendor.py
+++ b/tests/test_check_composer_vendor.py
@@ -70,6 +70,32 @@ def test_absent_source_references_are_normalized_to_null(tmp_path: Path) -> None
     assert result.returncode == 0, result.stderr
 
 
+@pytest.mark.parametrize(
+    ("field", "metadata"),
+    [
+        ("source", {}),
+        ("source", {"reference": None}),
+        ("source", {"reference": ""}),
+        ("dist", {}),
+        ("dist", {"reference": None}),
+        ("dist", {"reference": ""}),
+    ],
+)
+def test_present_reference_metadata_must_be_non_empty_string(
+    tmp_path: Path, field: str, metadata: dict[str, Any]
+) -> None:
+    locked = package()
+    locked[field] = metadata
+    installed = package()
+    installed[field] = metadata
+    result = run_checker(fixture(tmp_path, [locked], [installed]))
+    assert_failure(
+        result,
+        "malformed composer.lock packages package 0",
+        "malformed vendor/composer/installed.json package 0",
+    )
+
+
 def test_symlinked_vendor_fails_before_metadata(tmp_path: Path) -> None:
     (tmp_path / "composer.lock").write_text("not json", encoding="utf-8")
     target = tmp_path / "shared-vendor"

--- a/tests/test_check_composer_vendor.py
+++ b/tests/test_check_composer_vendor.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts/check_composer_vendor.py"
+
+
+def package(
+    name: str = "acme/pkg",
+    version: str = "1.0.0",
+    *,
+    source: str | None = "source-ref",
+    dist: str | None = "dist-ref",
+) -> dict[str, Any]:
+    result: dict[str, Any] = {"name": name, "version": version}
+    if source is not None:
+        result["source"] = {"reference": source}
+    if dist is not None:
+        result["dist"] = {"reference": dist}
+    return result
+
+
+def fixture(
+    tmp_path: Path,
+    locked: list[dict[str, Any]],
+    installed: list[dict[str, Any]] | None = None,
+    *,
+    installed_value: Any = None,
+) -> Path:
+    (tmp_path / "vendor" / "composer").mkdir(parents=True)
+    (tmp_path / "composer.lock").write_text(
+        json.dumps({"packages": locked[:1], "packages-dev": locked[1:]}), encoding="utf-8"
+    )
+    if installed_value is None:
+        installed_value = {"packages": installed if installed is not None else locked}
+    (tmp_path / "vendor" / "composer" / "installed.json").write_text(json.dumps(installed_value), encoding="utf-8")
+    return tmp_path
+
+
+def run_checker(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(SCRIPT), str(root)], capture_output=True, text=True, check=False)
+
+
+def assert_failure(result: subprocess.CompletedProcess[str], *needles: str) -> None:
+    assert result.returncode == 1, result
+    assert result.stderr.count("composer install --no-interaction") == 1, result.stderr
+    for needle in needles:
+        assert needle in result.stderr, result.stderr
+
+
+def test_matching_packages_and_dev_packages_pass(tmp_path: Path) -> None:
+    root = fixture(tmp_path, [package(), package("acme/dev", "2.0.0")])
+    result = run_checker(root)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_absent_source_references_are_normalized_to_null(tmp_path: Path) -> None:
+    locked = package(source=None, dist="same")
+    installed = package(source=None, dist="same")
+    result = run_checker(fixture(tmp_path, [locked], [installed]))
+    assert result.returncode == 0, result.stderr
+
+
+def test_symlinked_vendor_fails_before_metadata(tmp_path: Path) -> None:
+    (tmp_path / "composer.lock").write_text("not json", encoding="utf-8")
+    target = tmp_path / "shared-vendor"
+    target.mkdir()
+    (tmp_path / "vendor").symlink_to(target, target_is_directory=True)
+    assert_failure(run_checker(tmp_path), "vendor is symlinked")
+
+
+def test_missing_installed_json_fails(tmp_path: Path) -> None:
+    (tmp_path / "vendor").mkdir()
+    (tmp_path / "composer.lock").write_text(json.dumps({"packages": [], "packages-dev": []}), encoding="utf-8")
+    assert_failure(run_checker(tmp_path), "missing vendor/composer/installed.json")
+
+
+def test_missing_and_extra_packages_are_named(tmp_path: Path) -> None:
+    locked = [package("acme/missing"), package("acme/kept")]
+    installed = [package("acme/kept"), package("acme/extra")]
+    result = run_checker(fixture(tmp_path, locked, installed))
+    assert_failure(result, "missing package: acme/missing", "extra package: acme/extra")
+
+
+def test_stale_version_source_and_dist_references_are_named(tmp_path: Path) -> None:
+    locked = package(version="2.2.5", source="locked-source", dist="locked-dist")
+    installed = package(version="2.2.1", source="installed-source", dist="installed-dist")
+    result = run_checker(fixture(tmp_path, [locked], [installed]))
+    assert_failure(
+        result,
+        "version mismatch: acme/pkg (locked 2.2.5; installed 2.2.1)",
+        "source reference mismatch: acme/pkg (locked locked-source; installed installed-source)",
+        "dist reference mismatch: acme/pkg (locked locked-dist; installed installed-dist)",
+    )
+
+
+def test_failed_check_does_not_mutate_fixture(tmp_path: Path) -> None:
+    root = fixture(tmp_path, [package(version="2.2.5")], [package(version="2.2.1")])
+    paths = [root / "composer.lock", root / "vendor" / "composer" / "installed.json"]
+    before = {path: path.read_bytes() for path in paths}
+    assert_failure(run_checker(root), "version mismatch")
+    assert {path: path.read_bytes() for path in paths} == before
+
+
+@pytest.mark.parametrize(
+    ("value", "needle"),
+    [
+        ("", "malformed vendor/composer/installed.json"),
+        ("null", "top level must be an object"),
+        ("{}", "missing packages metadata"),
+        ('{"packages": {}}', "packages must be a list"),
+        ('{"packages": [1]}', "package 0"),
+        ('{"packages": [{"name": 1, "version": "1"}]}', "package 0"),
+        ('{"packages": [{"name": "a/b", "version": 1}]}', "package 0"),
+        ('{"packages": [{"name": "a/b", "version": "1", "source": []}]}', "package 0"),
+        (
+            '{"packages": [{"name": "a/b", "version": "1", "source": {"reference": 1}}]}',
+            "package 0",
+        ),
+        ('{"packages": [{"name": "a/b", "version": "1", "dist": []}]}', "package 0"),
+        (
+            '{"packages": [{"name": "a/b", "version": "1", "dist": {"reference": 1}}]}',
+            "package 0",
+        ),
+        (
+            '{"packages": [{"name": "a/b", "version": "1"}, {"name": "a/b", "version": "1"}]}',
+            "duplicate package a/b",
+        ),
+    ],
+)
+def test_installed_metadata_hostile_inputs_fail_closed(tmp_path: Path, value: str, needle: str) -> None:
+    fixture(tmp_path, [package()])
+    installed_path = tmp_path / "vendor" / "composer" / "installed.json"
+    if value == "":
+        installed_path.write_bytes(b"")
+    else:
+        installed_path.write_text(value, encoding="utf-8")
+    assert_failure(run_checker(tmp_path), needle)
+
+
+def test_invalid_utf8_fails_closed(tmp_path: Path) -> None:
+    fixture(tmp_path, [package()])
+    (tmp_path / "vendor" / "composer" / "installed.json").write_bytes(b"\xff")
+    assert_failure(run_checker(tmp_path), "malformed vendor/composer/installed.json")
+
+
+def test_malformed_lock_fails_closed(tmp_path: Path) -> None:
+    fixture(tmp_path, [package()])
+    (tmp_path / "composer.lock").write_text(json.dumps({"packages": "wrong", "packages-dev": []}), encoding="utf-8")
+    assert_failure(run_checker(tmp_path), "malformed composer.lock packages: packages must be a list")

--- a/tests/test_check_composer_vendor.py
+++ b/tests/test_check_composer_vendor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -44,8 +45,8 @@ def fixture(
     return tmp_path
 
 
-def run_checker(root: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run([sys.executable, str(SCRIPT), str(root)], capture_output=True, text=True, check=False)
+def run_checker(root: Path, executable: str = sys.executable) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([executable, str(SCRIPT), str(root)], capture_output=True, text=True, check=False)
 
 
 def assert_failure(result: subprocess.CompletedProcess[str], *needles: str) -> None:
@@ -271,3 +272,23 @@ def test_valid_json_numbers_remain_accepted(tmp_path: Path, relative_path: str) 
     assert result.returncode == 0, result.stderr
     assert result.stdout == ""
     assert result.stderr == ""
+
+
+@pytest.mark.parametrize("relative_path", ["composer.lock", "vendor/composer/installed.json"])
+def test_deeply_nested_json_fails_closed(tmp_path: Path, relative_path: str) -> None:
+    python311 = shutil.which("python3.11")
+    if python311 is None:
+        pytest.skip("python3.11 unavailable")
+    assert python311 is not None
+    root = fixture(tmp_path, [package()])
+    nested = "[" * 2000 + "]" * 2000
+    if relative_path == "composer.lock":
+        payload = '{"packages": ' + nested + ', "packages-dev": []}'
+        needle = "malformed composer.lock"
+    else:
+        payload = '{"packages": ' + nested + "}"
+        needle = "malformed vendor/composer/installed.json"
+    (root / relative_path).write_text(payload, encoding="utf-8")
+    result = run_checker(root, python311)
+    assert_failure(result, needle)
+    assert "Traceback" not in result.stderr, result.stderr

--- a/tests/test_check_composer_vendor.py
+++ b/tests/test_check_composer_vendor.py
@@ -129,6 +129,13 @@ def test_stale_version_source_and_dist_references_are_named(tmp_path: Path) -> N
     )
 
 
+def test_stale_phpstan_fixture_reports_versions_and_remediation(tmp_path: Path) -> None:
+    locked = package("phpstan/phpstan", "2.2.5")
+    installed = package("phpstan/phpstan", "2.2.1")
+    result = run_checker(fixture(tmp_path, [locked], [installed]))
+    assert_failure(result, "version mismatch: phpstan/phpstan (locked 2.2.5; installed 2.2.1)")
+
+
 def test_failed_check_does_not_mutate_fixture(tmp_path: Path) -> None:
     root = fixture(tmp_path, [package(version="2.2.5")], [package(version="2.2.1")])
     paths = [root / "composer.lock", root / "vendor" / "composer" / "installed.json"]
@@ -183,3 +190,84 @@ def test_malformed_lock_fails_closed(tmp_path: Path) -> None:
     fixture(tmp_path, [package()])
     (tmp_path / "composer.lock").write_text(json.dumps({"packages": "wrong", "packages-dev": []}), encoding="utf-8")
     assert_failure(run_checker(tmp_path), "malformed composer.lock packages: packages must be a list")
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "payload", "needle"),
+    [
+        (
+            "composer.lock",
+            '{"packages": [], "packages-dev": [], "ignored": NaN}',
+            "malformed composer.lock",
+        ),
+        (
+            "vendor/composer/installed.json",
+            '{"packages": [], "ignored": NaN}',
+            "malformed vendor/composer/installed.json",
+        ),
+        (
+            "composer.lock",
+            '{"packages": [], "packages-dev": [], "ignored": Infinity}',
+            "malformed composer.lock",
+        ),
+        (
+            "vendor/composer/installed.json",
+            '{"packages": [], "ignored": Infinity}',
+            "malformed vendor/composer/installed.json",
+        ),
+        (
+            "composer.lock",
+            '{"packages": [], "packages-dev": [], "ignored": -Infinity}',
+            "malformed composer.lock",
+        ),
+        (
+            "vendor/composer/installed.json",
+            '{"packages": [], "ignored": -Infinity}',
+            "malformed vendor/composer/installed.json",
+        ),
+    ],
+)
+def test_nonstandard_json_constants_fail_closed(tmp_path: Path, relative_path: str, payload: str, needle: str) -> None:
+    root = fixture(tmp_path, [package()])
+    (root / relative_path).write_text(payload, encoding="utf-8")
+    result = run_checker(root)
+    assert_failure(result, needle)
+    assert "Traceback" not in result.stderr, result.stderr
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "payload", "needle"),
+    [
+        (
+            "composer.lock",
+            '{"packages": [], "packages-dev": [], "ignored": ' + ("9" * 5000) + "}",
+            "malformed composer.lock",
+        ),
+        (
+            "vendor/composer/installed.json",
+            '{"packages": [], "ignored": ' + ("9" * 5000) + "}",
+            "malformed vendor/composer/installed.json",
+        ),
+    ],
+)
+def test_oversized_json_integer_fails_closed(tmp_path: Path, relative_path: str, payload: str, needle: str) -> None:
+    root = fixture(tmp_path, [package()])
+    (root / relative_path).write_text(payload, encoding="utf-8")
+    result = run_checker(root)
+    assert_failure(result, needle)
+    assert "Traceback" not in result.stderr, result.stderr
+
+
+@pytest.mark.parametrize("relative_path", ["composer.lock", "vendor/composer/installed.json"])
+def test_valid_json_numbers_remain_accepted(tmp_path: Path, relative_path: str) -> None:
+    root = fixture(tmp_path, [package()])
+    path = root / relative_path
+    if relative_path == "composer.lock":
+        payload = {"packages": [package()], "packages-dev": [], "ignored": 123}
+    else:
+        payload = {"packages": [package()], "ignored": 123}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    result = run_checker(root)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""


### PR DESCRIPTION
## Summary

- add an offline, read-only checker for `composer.lock` versus `vendor/composer/installed.json`
- reject symlinked, missing, malformed, extra, missing, version-drifted, or reference-drifted Composer packages
- run the guard before local PHP tooling in pre-commit and canonical gate paths
- document that each worktree owns its own `vendor/` tree

## Root cause

A linked worktree could run PHP tooling against a stale or shared `vendor/` tree. The reproduced incident used PHPStan 2.2.1 while the worktree lock required 2.2.5, producing two false `$rsync` undefined-variable errors.

Failures now stop before PHP analysis and print one remediation:

```text
composer install --no-interaction
```

## Verification

- reproduced the stale symlinked-vendor failure: two PHPStan `variable.undefined` errors
- frozen RED: gate and pre-commit fixtures proved PHP tools still ran before the guard existed
- unchanged GREEN: 22 ShellSpec examples passed
- checker matrix: 27 pytest cases passed, including malformed source/dist reference rows
- canonical post-rebase gates: pytest, Ruff, format, mypy, ShellCheck, ShellSpec under dash, and Markdown lint all passed
- independent verification re-executed the frozen RED/GREEN proof and hostile inputs; an initial missing-reference finding was fixed and independently re-verified

Fixes #1397

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Composer vendor validation to verify `composer.lock` matches installed Composer metadata, with remediation guidance (`composer install --no-interaction`).
  * Updated worktrees policy to require a dedicated `vendor/` per worktree and run Composer installs in the current worktree.

* **Bug Fixes**
  * Pre-commit and gate checks now fail closed for Composer validation issues and stop before running PHP analysis when validation can’t run or reports mismatches.

* **Tests**
  * Added/expanded ShellSpec and unit tests for Composer validation, gate execution order, fail-closed behavior, and hostile/large JSON inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->