### PR TITLE
pfblockerng: ADR-53 live punch — live-only snapshot, streaming plan, fail-closed apply

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3941,6 +3941,69 @@ function pfb_live_punch_plan(string $ip, iterable $table_entries): array
 }
 
 /**
+ * pfb_live_punch_apply -- issue #1470: fail-closed executor for a
+ * pfb_live_punch_plan() plan. Order is INVERTED vs the naive shape: every
+ * $plan['add'] remainder execs FIRST, every $plan['delete'] containing entry
+ * LAST. Every remainder is a covering-CIDR SUBSET of a still-present
+ * containing entry (the plan's contract), so adding it first never changes
+ * live match behaviour; deleting the containing entr(y/ies) only once every
+ * remainder is already in place means no intermediate state ever unblocks
+ * the host or a sibling.
+ *
+ * On an add failure: stop (no further adds, no deletes), best-effort
+ * `-T delete` every remainder THIS call already added (its own rc is
+ * ignored -- those leftovers are subsets of the still-present containing
+ * entry, harmless), and return ok=FALSE. On a delete failure: stop at the
+ * first failure (no rollback -- entries already deleted had their remainder
+ * carved in the add phase; the failed entry still blocks the host, which is
+ * the fail-closed outcome).
+ *
+ * NEVER routes through pfb_pfctl_table_op(): that opens an ADR-61
+ * sync-status 'apply' ledger entry on failure, and the tick's retry sweep
+ * (pfb_ip_apply_retry() -> `-T replace` from the aliasdir mirror) would
+ * revert OTHER valid live punches whose stores still claim carved.
+ *
+ * NOT pure -- execs pfctl.
+ *
+ * @param  string $pfctl Absolute path to the pfctl binary ($pfb['pfctl']).
+ * @param  string $table The pf table name (caller-validated).
+ * @param  array{delete: string[], add: string[]} $plan pfb_live_punch_plan()'s output.
+ * @return array{ok: bool, fail: ?string} ok=TRUE iff every op succeeded (or the
+ *         plan was empty, zero execs); 'fail' names the first failing op as
+ *         "<op> <entry>", NULL when ok.
+ */
+function pfb_live_punch_apply(string $pfctl, string $table, array $plan): array {
+	$table_esc = escapeshellarg($table);
+	$applied   = [];
+
+	foreach ($plan['add'] as $entry) {
+		$out = [];
+		$rc  = 0;
+		exec("{$pfctl} -t {$table_esc} -T add " . escapeshellarg($entry) . ' 2>&1', $out, $rc);
+		if (pfb_pfctl_op_failed('add', $rc, implode(' ', $out))) {
+			foreach ($applied as $rollback_entry) {
+				exec("{$pfctl} -t {$table_esc} -T delete " . escapeshellarg($rollback_entry) . ' 2>&1');
+			}
+			pfb_logger('[pfb_live_punch_apply] ' . pfb_pfctl_error_message($table, 'add', $rc, implode(' ', $out)) . " entry={$entry}\n", 2);
+			return ['ok' => FALSE, 'fail' => "add {$entry}"];
+		}
+		$applied[] = $entry;
+	}
+
+	foreach ($plan['delete'] as $entry) {
+		$out = [];
+		$rc  = 0;
+		exec("{$pfctl} -t {$table_esc} -T delete " . escapeshellarg($entry) . ' 2>&1', $out, $rc);
+		if (pfb_pfctl_op_failed('delete', $rc, implode(' ', $out))) {
+			pfb_logger('[pfb_live_punch_apply] ' . pfb_pfctl_error_message($table, 'delete', $rc, implode(' ', $out)) . " entry={$entry}\n", 2);
+			return ['ok' => FALSE, 'fail' => "delete {$entry}"];
+		}
+	}
+
+	return ['ok' => TRUE, 'fail' => NULL];
+}
+
+/**
  * ADR-65 SS2.1: ask the live DNSBL matcher whether $domain is blocked, via the
  * read-only query channel (pfb_py_query / pfb_py_query.reply) -- no counter/
  * log/cache sink is touched, only the decision-cache LRU may warm.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3794,48 +3794,51 @@ function pfb_ip_suppressed_match(string $ip, array $entries): ?string
 // ---------------------------------------------------------------------------
 
 /**
- * pfb_live_table_snapshot -- read a live pf table's current membership: the
- * ADR-40 mirror file when present (freshest applied set), else a live
- * `pfctl -T show` fallback -- both streamed line-by-line (fgets), never
- * slurped whole (a Deny table mirror can hold millions of entries, ADR-53
- * §3). Extracted from the Alerts "+" (addsuppress) handler (issue #1412) so
- * the temporary Unlock icon's live punch shares the exact same read instead
- * of re-deriving it.
+ * pfb_live_table_snapshot -- stream a live pf table's current membership via
+ * `pfctl -T show`, the SOLE source (issue #1467: the ADR-40 mirror file is
+ * never read here -- a live punch never rewrites the mirror, so a second
+ * punch inside the same containing entry would read a stale set and
+ * silently revert the first punch). Extracted from the Alerts "+"
+ * (addsuppress) handler (issue #1412) so the temporary Unlock icon's live
+ * punch shares the exact same read instead of re-deriving it.
  *
- * NOT pure -- reads the mirror file / execs pfctl.
+ * Issue #1471: streamed as a \Generator (yielded line-by-line via fgets),
+ * never slurped whole -- a Deny table can hold millions of entries, and
+ * materialising them all as a PHP string array would exhaust the web-UI PHP
+ * process's memory.
+ *
+ * NOT pure -- execs pfctl.
  *
  * @param  string $pfctl    Absolute path to the pfctl binary ($pfb['pfctl']).
- * @param  string $aliasdir Alias mirror directory ($pfb['aliasdir']).
- * @param  string $dbdir    Scratch-file directory for the pfctl-show fallback ($pfb['dbdir']).
+ * @param  string $aliasdir Unused since #1467 -- the mirror is never read;
+ *                           kept for call-site signature compatibility.
+ * @param  string $dbdir    Scratch-file directory for the pfctl-show capture ($pfb['dbdir']).
  * @param  string $table    The pf table name (caller-validated, e.g. via PFB_FILTER_WORD).
- * @return string[] Raw membership lines (bare host or CIDR tokens; blank/'#'-comment lines tolerated).
+ * @return \Generator<string> Raw membership lines (bare host or CIDR tokens; blank/'#'-comment lines tolerated).
  */
-function pfb_live_table_snapshot(string $pfctl, string $aliasdir, string $dbdir, string $table): array
+function pfb_live_table_snapshot(string $pfctl, string $aliasdir, string $dbdir, string $table): \Generator
 {
 	$table_esc = escapeshellarg($table);
-	$mirror    = "{$aliasdir}/{$table}.txt";
-	$scan_file = is_readable($mirror) ? $mirror : NULL;
-	$scan_tmp  = NULL;
-	if ($scan_file === NULL) {
-		$scan_tmp = tempnam($dbdir, 'pfb_punch_');
-		// ADR-53: stderr -> /dev/null, NOT 2>&1 -- the
-		// capture file is parsed line-by-line as membership entries below;
-		// merging stderr into it would feed any pfctl diagnostic line into
-		// that parse as if it were a table member.
-		exec("{$pfctl} -t {$table_esc} -T show > " . escapeshellarg($scan_tmp) . ' 2>/dev/null');
-		$scan_file = $scan_tmp;
-	}
-	$table_entries = array();
-	if (($handle = @fopen($scan_file, 'r')) !== FALSE) {
-		while (($line = @fgets($handle)) !== FALSE) {
-			$table_entries[] = trim($line);
+	$scan_tmp  = tempnam($dbdir, 'pfb_punch_');
+	// ADR-53: stderr -> /dev/null, NOT 2>&1 -- the
+	// capture file is parsed line-by-line as membership entries below;
+	// merging stderr into it would feed any pfctl diagnostic line into
+	// that parse as if it were a table member.
+	exec("{$pfctl} -t {$table_esc} -T show > " . escapeshellarg($scan_tmp) . ' 2>/dev/null');
+
+	$handle = @fopen($scan_tmp, 'r');
+	try {
+		if ($handle !== FALSE) {
+			while (($line = @fgets($handle)) !== FALSE) {
+				yield trim($line);
+			}
 		}
-		fclose($handle);
-	}
-	if ($scan_tmp !== NULL) {
+	} finally {
+		if ($handle !== FALSE) {
+			fclose($handle);
+		}
 		@unlink($scan_tmp);
 	}
-	return $table_entries;
 }
 
 /**
@@ -3884,24 +3887,26 @@ function pfb_v4_carve_single(string $cidr, string $host_ip): array
  * replace them (to `pfctl -T add`) -- a genuine set-subtraction, replacing
  * the retired /24-only 254-host re-add loop.
  *
- * $table_entries are raw lines from the table's membership snapshot (the
- * ADR-40 mirror file, or a `pfctl -T show` fallback) -- bare host tokens
- * ("1.2.3.4") or CIDR tokens ("1.2.3.0/24"), either family; blank/'#'-comment
- * lines are tolerated (skipped). A bare host token is treated as an exact
- * /32 or /128 -- containing ONLY itself, so punching it needs no
- * covering-CIDR add (delete only, same as the old exact-/32-match case).
+ * $table_entries are raw lines from the table's live membership snapshot
+ * (pfb_live_table_snapshot(), issue #1467: `pfctl -T show`, the sole
+ * source) -- bare host tokens ("1.2.3.4") or CIDR tokens ("1.2.3.0/24"),
+ * either family; blank/'#'-comment lines are tolerated (skipped). A bare
+ * host token is treated as an exact /32 or /128 -- containing ONLY itself,
+ * so punching it needs no covering-CIDR add (delete only, same as the old
+ * exact-/32-match case).
  *
  * PURE -- no pfctl/pf-table access; the caller supplies the already-read
- * membership snapshot (streamed, never slurped whole -- see the alerts page
- * call site) and applies the returned plan.
+ * membership snapshot (issue #1471: any iterable, including the streamed
+ * \Generator pfb_live_table_snapshot() returns -- see the alerts page call
+ * site) and applies the returned plan.
  *
- * @param  string   $ip             The host to carve out (v4 or v6).
- * @param  string[] $table_entries  Raw table membership lines.
+ * @param  string            $ip             The host to carve out (v4 or v6).
+ * @param  iterable<string>  $table_entries  Raw table membership lines.
  * @return array{delete: string[], add: string[]} 'delete' = every containing
  *         entry to remove; 'add' = the covering-CIDR remainder to re-add
  *         (empty when every containing entry was an exact host match).
  */
-function pfb_live_punch_plan(string $ip, array $table_entries): array
+function pfb_live_punch_plan(string $ip, iterable $table_entries): array
 {
 	$delete    = [];
 	$add       = [];

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3807,6 +3807,13 @@ function pfb_ip_suppressed_match(string $ip, array $entries): ?string
  * materialising them all as a PHP string array would exhaust the web-UI PHP
  * process's memory.
  *
+ * A capture failure (scratch file, pfctl exit, or reopen) throws
+ * \RuntimeException rather than yielding an empty result -- an empty result
+ * is otherwise indistinguishable from a genuinely empty table, and a caller
+ * (pfb_live_punch_run()) acting on that false "empty" would misreport a
+ * capture failure as "not currently blocked". The throw fires lazily, on the
+ * generator's first iteration.
+ *
  * NOT pure -- execs pfctl.
  *
  * @param  string $pfctl    Absolute path to the pfctl binary ($pfb['pfctl']).
@@ -3815,28 +3822,39 @@ function pfb_ip_suppressed_match(string $ip, array $entries): ?string
  * @param  string $dbdir    Scratch-file directory for the pfctl-show capture ($pfb['dbdir']).
  * @param  string $table    The pf table name (caller-validated, e.g. via PFB_FILTER_WORD).
  * @return \Generator<string> Raw membership lines (bare host or CIDR tokens; blank/'#'-comment lines tolerated).
+ * @throws \RuntimeException On a scratch-file, pfctl-exit, or reopen failure.
  */
 function pfb_live_table_snapshot(string $pfctl, string $aliasdir, string $dbdir, string $table): \Generator
 {
 	$table_esc = escapeshellarg($table);
 	$scan_tmp  = tempnam($dbdir, 'pfb_punch_');
+	if ($scan_tmp === FALSE) {
+		throw new \RuntimeException("table={$table}: tempnam() failed in dbdir={$dbdir}");
+	}
+
 	// ADR-53: stderr -> /dev/null, NOT 2>&1 -- the
 	// capture file is parsed line-by-line as membership entries below;
 	// merging stderr into it would feed any pfctl diagnostic line into
 	// that parse as if it were a table member.
-	exec("{$pfctl} -t {$table_esc} -T show > " . escapeshellarg($scan_tmp) . ' 2>/dev/null');
+	$exec_out = [];
+	$rc       = 0;
+	exec("{$pfctl} -t {$table_esc} -T show > " . escapeshellarg($scan_tmp) . ' 2>/dev/null', $exec_out, $rc);
+	if ($rc !== 0) {
+		@unlink($scan_tmp);
+		throw new \RuntimeException("table={$table}: pfctl -T show exited rc={$rc}");
+	}
 
 	$handle = @fopen($scan_tmp, 'r');
+	if ($handle === FALSE) {
+		@unlink($scan_tmp);
+		throw new \RuntimeException("table={$table}: fopen() failed on the pfctl-show capture");
+	}
 	try {
-		if ($handle !== FALSE) {
-			while (($line = @fgets($handle)) !== FALSE) {
-				yield trim($line);
-			}
+		while (($line = @fgets($handle)) !== FALSE) {
+			yield trim($line);
 		}
 	} finally {
-		if ($handle !== FALSE) {
-			fclose($handle);
-		}
+		fclose($handle);
 		@unlink($scan_tmp);
 	}
 }
@@ -3900,11 +3918,17 @@ function pfb_v4_carve_single(string $cidr, string $host_ip): array
  * \Generator pfb_live_table_snapshot() returns -- see the alerts page call
  * site) and applies the returned plan.
  *
+ * Two containing entries whose remainders overlap near the punched host
+ * (e.g. a /16 and a nested /24, both containing it) can each carve the same
+ * near-host covering CIDR -- the returned lists are deduplicated so a
+ * duplicate remainder never costs a wasted exec in pfb_live_punch_apply().
+ *
  * @param  string            $ip             The host to carve out (v4 or v6).
  * @param  iterable<string>  $table_entries  Raw table membership lines.
  * @return array{delete: string[], add: string[]} 'delete' = every containing
  *         entry to remove; 'add' = the covering-CIDR remainder to re-add
- *         (empty when every containing entry was an exact host match).
+ *         (empty when every containing entry was an exact host match);
+ *         both deduplicated.
  */
 function pfb_live_punch_plan(string $ip, iterable $table_entries): array
 {
@@ -3937,7 +3961,7 @@ function pfb_live_punch_plan(string $ip, iterable $table_entries): array
 		}
 	}
 
-	return ['delete' => $delete, 'add' => $add];
+	return ['delete' => array_values(array_unique($delete)), 'add' => array_values(array_unique($add))];
 }
 
 /**
@@ -3962,6 +3986,12 @@ function pfb_live_punch_plan(string $ip, iterable $table_entries): array
  * sync-status 'apply' ledger entry on failure, and the tick's retry sweep
  * (pfb_ip_apply_retry() -> `-T replace` from the aliasdir mirror) would
  * revert OTHER valid live punches whose stores still claim carved.
+ *
+ * Rollback neutrality: the best-effort rollback above may delete a remainder
+ * that happens to coincide with an independent, pre-existing table member --
+ * harmless, since rollback only ever runs before any delete, so a still-
+ * present containing entry still covers that member until the next reload
+ * restores the canonical set.
  *
  * NOT pure -- execs pfctl.
  *
@@ -4001,6 +4031,69 @@ function pfb_live_punch_apply(string $pfctl, string $table, array $plan): array 
 	}
 
 	return ['ok' => TRUE, 'fail' => NULL];
+}
+
+/**
+ * pfb_live_punch_run -- issue #1467 (CWE-362): orchestrates one Alerts "+" /
+ * Unlock live punch (snapshot -> plan -> apply) under the feed-pass lock
+ * (pfblockerng.inc's pfb_feed_pass_acquire()/_release()), so a concurrent
+ * ADR-40 replace can never interleave mid-punch -- a replace between our
+ * adds and our delete would wipe the adds (restoring the canonical set) and
+ * leave the delete alone to open the WHOLE containing entry until the next
+ * reload.
+ *
+ * $was_held is captured BEFORE acquiring: pfb_feed_pass_acquire() is
+ * reentrant (a nested call while this process already holds the lock is a
+ * no-op success), so an unconditional release here would drop an OUTER
+ * caller's hold. This call releases only when IT was the one that
+ * transitioned the lock from free to held.
+ *
+ * The snapshot and its consumption by pfb_live_punch_plan() both happen
+ * inside the lock scope (the plan call fully drains the generator before
+ * returning) -- a plan computed before a concurrent replace must never be
+ * applied after one.
+ *
+ * NOT pure -- execs pfctl, touches the feed-pass lock.
+ *
+ * @param  string $pfctl    Absolute path to the pfctl binary ($pfb['pfctl']).
+ * @param  string $aliasdir Passed through to pfb_live_table_snapshot() (unused there).
+ * @param  string $dbdir    Scratch-file directory ($pfb['dbdir']).
+ * @param  string $table    The pf table name (caller-validated).
+ * @param  string $ip       The host to carve out (v4 or v6).
+ * @return array{status: string, fail: ?string, del_cnt: int, add_cnt: int}
+ *         status is one of 'applied'|'not_blocked'|'busy'|'failed'; 'fail'
+ *         names the cause for 'failed' (NULL otherwise, prefixed
+ *         "snapshot: " for a capture failure); the counts are 0 outside
+ *         'applied'.
+ */
+function pfb_live_punch_run(string $pfctl, string $aliasdir, string $dbdir, string $table, string $ip): array {
+	$was_held = isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock']);
+
+	if (!pfb_feed_pass_acquire()) {
+		return ['status' => 'busy', 'fail' => NULL, 'del_cnt' => 0, 'add_cnt' => 0];
+	}
+
+	try {
+		$plan = pfb_live_punch_plan($ip, pfb_live_table_snapshot($pfctl, $aliasdir, $dbdir, $table));
+
+		if (empty($plan['delete'])) {
+			return ['status' => 'not_blocked', 'fail' => NULL, 'del_cnt' => 0, 'add_cnt' => 0];
+		}
+
+		$apply = pfb_live_punch_apply($pfctl, $table, $plan);
+		if (!$apply['ok']) {
+			return ['status' => 'failed', 'fail' => $apply['fail'], 'del_cnt' => 0, 'add_cnt' => 0];
+		}
+
+		return ['status' => 'applied', 'fail' => NULL, 'del_cnt' => count($plan['delete']), 'add_cnt' => count($plan['add'])];
+	} catch (\RuntimeException $e) {
+		pfb_logger("[pfb_live_punch_run] snapshot: {$e->getMessage()}\n", 2);
+		return ['status' => 'failed', 'fail' => 'snapshot: ' . $e->getMessage(), 'del_cnt' => 0, 'add_cnt' => 0];
+	} finally {
+		if (!$was_held) {
+			pfb_feed_pass_release();
+		}
+	}
 }
 
 /**

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -799,34 +799,30 @@ if (isset($_POST) && !empty($_POST)) {
 			$descr = pfb_filter($_POST['descr'], PFB_FILTER_HTML, 'alerts addsuppress');
 		}
 
-		// Read the table's current membership (pfb_live_table_snapshot(),
-		// pfblockerng_extra.inc -- shared with the Unlock icon's live punch, #1412).
-		$table_entries	= pfb_live_table_snapshot($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table);
+		// Snapshot + carve + apply, serialized against a concurrent feed pass
+		// (pfb_live_punch_run(), pfblockerng_extra.inc -- shared with the
+		// Unlock icon's live punch, #1412/#1467). An empty plan ('not_blocked')
+		// is NOT a refusal -- the customlist add below always proceeds, exactly
+		// as the old /24 branch already did unconditionally: suppression is a
+		// standing exemption for FUTURE loads, not contingent on today's live
+		// table snapshot.
+		$apply = pfb_live_punch_run($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table, $ip);
 
-		// Locate + carve every containing table entry (any mask, both
-		// families). Unlike the old /32 branch, an empty plan (nothing
-		// currently matches live) is NOT a refusal -- the customlist add below
-		// always proceeds, exactly as the old /24 branch already did
-		// unconditionally: suppression is a standing exemption for FUTURE
-		// loads, not contingent on today's live table snapshot.
-		$plan = pfb_live_punch_plan($ip, $table_entries);
-
-		// issue #1470: pfb_live_punch_apply() -- adds before deletes, rolled
-		// back on an add failure -- replaces the old delete-then-add loops
-		// that ignored exec() status and could unblock the whole containing
-		// entry on a failed re-add.
-		$apply = pfb_live_punch_apply($pfb['pfctl'], $table, $plan);
-
-		$del_cnt = count($plan['delete']);
 		$savemsg1 = "Host IP address {$ip}";
-		if (!$apply['ok']) {
-			$savemsg2 = " : Live punch failed [ {$apply['fail']} ], suppression will still apply at the next reload";
-		} elseif ($del_cnt > 0) {
-			$add_cnt = count($plan['add']);
-			$savemsg2 = ' : Removed ' . $del_cnt . ' entr' . ($del_cnt == 1 ? 'y' : 'ies')
-				. ', added ' . $add_cnt . ' covering CIDR' . ($add_cnt == 1 ? '' : 's');
-		} else {
-			$savemsg2 = " : Not currently blocked by Table [ {$table} ]";
+		switch ($apply['status']) {
+			case 'applied':
+				$savemsg2 = ' : Removed ' . $apply['del_cnt'] . ' entr' . ($apply['del_cnt'] == 1 ? 'y' : 'ies')
+					. ', added ' . $apply['add_cnt'] . ' covering CIDR' . ($apply['add_cnt'] == 1 ? '' : 's');
+				break;
+			case 'not_blocked':
+				$savemsg2 = " : Not currently blocked by Table [ {$table} ]";
+				break;
+			case 'busy':
+				$savemsg2 = ' : An update/reload pass is currently in progress, suppression will apply at the next reload';
+				break;
+			default: // 'failed'
+				$savemsg2 = " : Live punch failed [ {$apply['fail']} ], suppression will still apply at the next reload";
+				break;
 		}
 
 		$supp_key	= $is_v6 ? 'ipsuppression_v6' : 'ipsuppression';
@@ -1506,33 +1502,34 @@ if (isset($_POST) && !empty($_POST)) {
 
 		$table_esc = escapeshellarg($table);
 
-		// Unlock IP -- ADR-53 covering-CIDR live punch (pfb_live_punch_plan(),
+		// Unlock IP -- ADR-53 covering-CIDR live punch (pfb_live_punch_run(),
 		// pfblockerng_extra.inc), the same mechanism the Suppression "+" uses:
 		// carve exactly this host out of whichever table entr(y/ies) currently
 		// block it live, any mask, either family, instead of deleting the
 		// whole containing entry (the old direct single-token delete unblocked
-		// every sibling in that entry too).
+		// every sibling in that entry too). Serialized against a concurrent
+		// feed pass (issue #1467).
 		if ($_POST['ip_remove'] == 'unlock') {
-			$table_entries = pfb_live_table_snapshot($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table);
-			$plan = pfb_live_punch_plan($ip, $table_entries);
+			$apply = pfb_live_punch_run($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table, $ip);
 
-			if (empty($plan['delete'])) {
-				// Nothing live currently blocks this host -- no store write, no unlock recorded.
-				$savemsg = "The IP [ {$ip} ] is not currently blocked by table [ {$table} ] -- no unlock was recorded.";
-			} else {
-				// issue #1470: pfb_live_punch_apply() -- adds before deletes, rolled
-				// back on an add failure -- replaces the old delete-then-add loops
-				// that ignored exec() status and could unblock the whole containing
-				// entry on a failed re-add.
-				$apply = pfb_live_punch_apply($pfb['pfctl'], $table, $plan);
-				if ($apply['ok']) {
+			switch ($apply['status']) {
+				case 'applied':
 					pfb_unlock('unlock', 'ip', $ip, $table, $ip_unlock);
 					$savemsg = "The IP [ {$ip} ] has been temporarily Unlocked from table [ {$table} ]!";
-				} else {
+					break;
+				case 'not_blocked':
+					// Nothing live currently blocks this host -- no store write, no unlock recorded.
+					$savemsg = "The IP [ {$ip} ] is not currently blocked by table [ {$table} ] -- no unlock was recorded.";
+					break;
+				case 'busy':
+					// An update/reload pass is running -- no store write; ask the user to retry.
+					$savemsg = "Table [ {$table} ] is mid-update -- please retry the Unlock once the current run finishes.";
+					break;
+				default: // 'failed'
 					// No pfb_unlock() store write -- the table still blocks the IP, so the
 					// unlock store must not claim otherwise.
 					$savemsg = "The live unlock of IP [ {$ip} ] failed [ {$apply['fail']} ] -- table [ {$table} ] still blocks it; see the pfBlockerNG log.";
-				}
+					break;
 			}
 		}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -801,7 +801,6 @@ if (isset($_POST) && !empty($_POST)) {
 
 		// Read the table's current membership (pfb_live_table_snapshot(),
 		// pfblockerng_extra.inc -- shared with the Unlock icon's live punch, #1412).
-		$table_esc	= escapeshellarg($table);
 		$table_entries	= pfb_live_table_snapshot($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table);
 
 		// Locate + carve every containing table entry (any mask, both
@@ -812,16 +811,17 @@ if (isset($_POST) && !empty($_POST)) {
 		// loads, not contingent on today's live table snapshot.
 		$plan = pfb_live_punch_plan($ip, $table_entries);
 
-		foreach ($plan['delete'] as $entry) {
-			exec("{$pfb['pfctl']} -t {$table_esc} -T delete " . escapeshellarg($entry) . ' 2>&1');
-		}
-		foreach ($plan['add'] as $cidr) {
-			exec("{$pfb['pfctl']} -t {$table_esc} -T add " . escapeshellarg($cidr) . ' 2>&1');
-		}
+		// issue #1470: pfb_live_punch_apply() -- adds before deletes, rolled
+		// back on an add failure -- replaces the old delete-then-add loops
+		// that ignored exec() status and could unblock the whole containing
+		// entry on a failed re-add.
+		$apply = pfb_live_punch_apply($pfb['pfctl'], $table, $plan);
 
 		$del_cnt = count($plan['delete']);
 		$savemsg1 = "Host IP address {$ip}";
-		if ($del_cnt > 0) {
+		if (!$apply['ok']) {
+			$savemsg2 = " : Live punch failed [ {$apply['fail']} ], suppression will still apply at the next reload";
+		} elseif ($del_cnt > 0) {
 			$add_cnt = count($plan['add']);
 			$savemsg2 = ' : Removed ' . $del_cnt . ' entr' . ($del_cnt == 1 ? 'y' : 'ies')
 				. ', added ' . $add_cnt . ' covering CIDR' . ($add_cnt == 1 ? '' : 's');
@@ -1516,15 +1516,24 @@ if (isset($_POST) && !empty($_POST)) {
 			$table_entries = pfb_live_table_snapshot($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table);
 			$plan = pfb_live_punch_plan($ip, $table_entries);
 
-			foreach ($plan['delete'] as $entry) {
-				exec("{$pfb['pfctl']} -t {$table_esc} -T delete " . escapeshellarg($entry) . ' 2>&1');
+			if (empty($plan['delete'])) {
+				// Nothing live currently blocks this host -- no store write, no unlock recorded.
+				$savemsg = "The IP [ {$ip} ] is not currently blocked by table [ {$table} ] -- no unlock was recorded.";
+			} else {
+				// issue #1470: pfb_live_punch_apply() -- adds before deletes, rolled
+				// back on an add failure -- replaces the old delete-then-add loops
+				// that ignored exec() status and could unblock the whole containing
+				// entry on a failed re-add.
+				$apply = pfb_live_punch_apply($pfb['pfctl'], $table, $plan);
+				if ($apply['ok']) {
+					pfb_unlock('unlock', 'ip', $ip, $table, $ip_unlock);
+					$savemsg = "The IP [ {$ip} ] has been temporarily Unlocked from table [ {$table} ]!";
+				} else {
+					// No pfb_unlock() store write -- the table still blocks the IP, so the
+					// unlock store must not claim otherwise.
+					$savemsg = "The live unlock of IP [ {$ip} ] failed [ {$apply['fail']} ] -- table [ {$table} ] still blocks it; see the pfBlockerNG log.";
+				}
 			}
-			foreach ($plan['add'] as $cidr) {
-				exec("{$pfb['pfctl']} -t {$table_esc} -T add " . escapeshellarg($cidr) . ' 2>&1');
-			}
-
-			pfb_unlock('unlock', 'ip', $ip, $table, $ip_unlock);
-			$savemsg = "The IP [ {$ip} ] has been temporarily Unlocked from table [ {$table} ]!";
 		}
 
 		// Lock IP -- restores exactly the alerted host (mirrors the

--- a/tests/php/AlertsLivePunchApplyTest.php
+++ b/tests/php/AlertsLivePunchApplyTest.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_live_punch_apply() -- issue #1470: the fail-closed executor for a
+ * pfb_live_punch_plan() plan. The two ADR-53 live-punch callers
+ * (pfblockerng_alerts.php addsuppress / unlock) used to run `-T delete` then
+ * `-T add` with every exec() status ignored: a delete followed by a failed
+ * add unblocked the WHOLE containing entry silently.
+ *
+ * This helper inverts the order -- every add runs first, every delete runs
+ * last -- because every 'add' remainder is a covering-CIDR SUBSET of a still
+ * -present containing entry (pfb_live_punch_plan()'s contract): adding it
+ * first never changes live match behaviour, and no intermediate state after
+ * that ever unblocks the host or a sibling.
+ *
+ * Not unit-drivable via the two POST handlers themselves (they sit behind
+ * $_POST guards with header()+exit, verified this session -- AlertsPageLoader
+ * only extracts page FUNCTIONS). So these tests target the helper seam via an
+ * injectable pfctl shim (extends LiveTableSnapshotTest's writeShim() pattern
+ * to log every argv line and to fail on scripted op+entry pairs). The
+ * handler wiring itself (savemsg branches, store-write gating) is a JUSTIFIED
+ * DEFERRAL -- carried by review + this file's helper coverage, with success/
+ * empty-plan paths landing in the next step's Tier-B e2e.
+ */
+#[CoversFunction('pfb_live_punch_apply')]
+final class AlertsLivePunchApplyTest extends TestCase
+{
+	private string $tmp;
+	private string $shim;
+	private string $logPath;
+	private string $rulesPath;
+	private string $table = 'pfB_Test_v4';
+
+	protected function setUp(): void
+	{
+		global $pfb;
+
+		$this->tmp       = sys_get_temp_dir() . '/pfb_live_punch_apply_' . getmypid() . '_' . bin2hex(random_bytes(6));
+		mkdir($this->tmp, 0777, TRUE);
+		$this->logPath   = "{$this->tmp}/calls.log";
+		$this->rulesPath = "{$this->tmp}/rules.tsv";
+		putenv("PFB_TEST_LOG={$this->logPath}");
+		putenv("PFB_TEST_RULES={$this->rulesPath}");
+		$this->shim = $this->writeShim();
+
+		// pfb_live_punch_apply() calls pfb_logger() on failure (level 2, same as
+		// pfb_pfctl_table_op()) -- seed the log dir the same way
+		// AliasDeltaApplyTest/LiveLogStdoutTest do.
+		@mkdir($pfb['logdir'], 0777, TRUE);
+		@file_put_contents($pfb['log'], '');
+		@file_put_contents($pfb['errlog'], '');
+	}
+
+	protected function tearDown(): void
+	{
+		putenv('PFB_TEST_LOG');
+		putenv('PFB_TEST_RULES');
+		rmdir_recursive($this->tmp);
+	}
+
+	/**
+	 * Write an executable POSIX-sh pfctl shim: parses the fixed
+	 * `-t <table> -T <op> <entry>` argv shape pfb_live_punch_apply() execs,
+	 * appends one '|'-joined [op, table, entry] row per call to
+	 * $PFB_TEST_LOG (the ordering oracle), and consults $PFB_TEST_RULES for
+	 * a scripted [op, entry] -> [rc, stderr] failure (one '|'-joined rule
+	 * per line). An empty entry always fails (mirrors real pfctl refusing an
+	 * empty address) instead of the parser silently doing nothing.
+	 */
+	private function writeShim(): string
+	{
+		$shim = "{$this->tmp}/pfctl_shim.sh";
+		file_put_contents($shim, <<<'SH'
+#!/bin/sh
+table=""
+op=""
+entry=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-t) table="$2"; shift 2 ;;
+		-T) op="$2"; shift 2 ;;
+		*) entry="$1"; shift ;;
+	esac
+done
+printf '%s|%s|%s\n' "$op" "$table" "$entry" >> "$PFB_TEST_LOG"
+if [ -z "$entry" ]; then
+	printf 'pfctl: no address specified\n' >&2
+	exit 1
+fi
+if [ -f "$PFB_TEST_RULES" ]; then
+	while IFS='|' read -r r_op r_entry r_rc r_err; do
+		if [ "$r_op" = "$op" ] && [ "$r_entry" = "$entry" ]; then
+			if [ -n "$r_err" ]; then
+				printf '%s\n' "$r_err" >&2
+			fi
+			exit "$r_rc"
+		fi
+	done < "$PFB_TEST_RULES"
+fi
+if [ "$op" = "add" ]; then
+	printf '1/1 addresses added.\n'
+else
+	printf '1/1 addresses deleted.\n'
+fi
+exit 0
+SH
+		);
+		chmod($shim, 0755);
+		return $shim;
+	}
+
+	/** Script the shim to fail a specific op+entry call with $rc/$err. */
+	private function scriptFailure(string $op, string $entry, int $rc, string $err): void
+	{
+		file_put_contents($this->rulesPath, "{$op}|{$entry}|{$rc}|{$err}\n", FILE_APPEND);
+	}
+
+	/** @return array<int,array{0:string,1:string,2:string}> [op, table, entry] rows, call order. */
+	private function readLog(): array
+	{
+		$content = trim((string) @file_get_contents($this->logPath));
+		if ($content === '') {
+			return [];
+		}
+		$rows = [];
+		foreach (explode("\n", $content) as $line) {
+			$rows[] = explode('|', $line, 3);
+		}
+		return $rows;
+	}
+
+	/** @return string[] "<op> <entry>" per row -- compact assertion shape for ordering tests. */
+	private function opEntryRows(array $rows): array
+	{
+		return array_map(static fn(array $r): string => "{$r[0]} {$r[2]}", $rows);
+	}
+
+	// -------------------------------------------------------------------
+	// Coverage matrix row 1 -- ordering: all adds before any delete
+	// -------------------------------------------------------------------
+
+	public function testAllAddsExecuteBeforeAnyDelete(): void
+	{
+		$plan = [
+			'add'    => ['198.18.0.1/32', '198.18.0.2/32', '198.18.0.3/32'],
+			'delete' => ['198.18.0.0/30', '198.18.0.4/30'],
+		];
+
+		$result = pfb_live_punch_apply($this->shim, $this->table, $plan);
+
+		$this->assertTrue($result['ok'], 'an all-success plan must report ok=TRUE');
+		$this->assertNull($result['fail']);
+		$this->assertSame(
+			['add 198.18.0.1/32', 'add 198.18.0.2/32', 'add 198.18.0.3/32', 'delete 198.18.0.0/30', 'delete 198.18.0.4/30'],
+			$this->opEntryRows($this->readLog()),
+			'every add must execute before any delete -- fail-closed ordering'
+		);
+	}
+
+	// -------------------------------------------------------------------
+	// Coverage matrix row 2 -- argv fidelity (table + entry as single
+	// escaped args), including one v6 entry row
+	// -------------------------------------------------------------------
+
+	public function testArgvFieldsReachPfctlAsSingleEscapedArgsIncludingV6(): void
+	{
+		$plan = ['add' => ['2001:db8::/65'], 'delete' => ['2001:db8::/64']];
+
+		$result = pfb_live_punch_apply($this->shim, $this->table, $plan);
+
+		$this->assertTrue($result['ok']);
+		$this->assertSame(
+			[
+				['add', $this->table, '2001:db8::/65'],
+				['delete', $this->table, '2001:db8::/64'],
+			],
+			$this->readLog(),
+			'op, table, and entry must each reach pfctl as one literal field'
+		);
+	}
+
+	// -------------------------------------------------------------------
+	// Coverage matrix row 3 -- add fails mid-batch: rollback only what
+	// THIS call already added, no further adds, no plan deletes
+	// -------------------------------------------------------------------
+
+	public function testAddFailureRollsBackOnlyPreviouslyAddedEntries(): void
+	{
+		$this->scriptFailure('add', '198.18.0.2/32', 1, 'pfctl: forced failure for R2');
+		$plan = [
+			'add'    => ['198.18.0.1/32', '198.18.0.2/32', '198.18.0.3/32'],
+			'delete' => ['198.18.0.0/24'],
+		];
+
+		$result = pfb_live_punch_apply($this->shim, $this->table, $plan);
+
+		$this->assertFalse($result['ok']);
+		$this->assertSame('add 198.18.0.2/32', $result['fail']);
+		$this->assertSame(
+			['add 198.18.0.1/32', 'add 198.18.0.2/32', 'delete 198.18.0.1/32'],
+			$this->opEntryRows($this->readLog()),
+			'only the already-added R1 is rolled back -- R3 is never attempted, the plan deletes never run'
+		);
+	}
+
+	// -------------------------------------------------------------------
+	// Coverage matrix row 4 -- rollback delete itself fails: swallowed,
+	// no exception, no further ops after the rollback attempt
+	// -------------------------------------------------------------------
+
+	public function testRollbackDeleteFailureIsSwallowedWithNoFurtherOps(): void
+	{
+		$this->scriptFailure('add', '198.18.0.2/32', 1, 'pfctl: forced add failure');
+		$this->scriptFailure('delete', '198.18.0.1/32', 1, 'pfctl: forced rollback failure');
+		$plan = ['add' => ['198.18.0.1/32', '198.18.0.2/32'], 'delete' => ['198.18.0.0/24']];
+
+		$result = pfb_live_punch_apply($this->shim, $this->table, $plan);
+
+		$this->assertFalse($result['ok']);
+		$this->assertSame('add 198.18.0.2/32', $result['fail']);
+		$this->assertSame(
+			['add 198.18.0.1/32', 'add 198.18.0.2/32', 'delete 198.18.0.1/32'],
+			$this->opEntryRows($this->readLog()),
+			'the rollback delete is attempted exactly once; its own failure is ignored -- no crash, no further ops'
+		);
+	}
+
+	// -------------------------------------------------------------------
+	// Coverage matrix row 5 -- delete fails: stop at first failure, no
+	// further deletes, no rollback
+	// -------------------------------------------------------------------
+
+	public function testDeleteFailureStopsBeforeRemainingDeletes(): void
+	{
+		$this->scriptFailure('delete', '198.18.0.0/24', 1, 'pfctl: forced delete failure');
+		$plan = ['add' => ['198.18.0.1/32'], 'delete' => ['198.18.0.0/24', '198.19.0.0/24']];
+
+		$result = pfb_live_punch_apply($this->shim, $this->table, $plan);
+
+		$this->assertFalse($result['ok']);
+		$this->assertSame('delete 198.18.0.0/24', $result['fail']);
+		$this->assertSame(
+			['add 198.18.0.1/32', 'delete 198.18.0.0/24'],
+			$this->opEntryRows($this->readLog()),
+			'the second delete must never run once the first fails -- the failed entry stays fail-closed'
+		);
+	}
+
+	// -------------------------------------------------------------------
+	// Coverage matrix row 6 -- predicate integration: rc=0 output still
+	// classified as a failure via pfb_pfctl_op_failed()'s string checks
+	// -------------------------------------------------------------------
+
+	public function testRcZeroWithPfctlErrorTextIsClassifiedAsFailure(): void
+	{
+		$this->scriptFailure('add', '198.18.0.1/32', 0, 'pfctl: some odd diagnostic');
+		$plan = ['add' => ['198.18.0.1/32'], 'delete' => []];
+
+		$result = pfb_live_punch_apply($this->shim, $this->table, $plan);
+
+		$this->assertFalse($result['ok'], "rc=0 output containing 'pfctl:' must still classify as a failure");
+		$this->assertSame('add 198.18.0.1/32', $result['fail']);
+	}
+
+	public function testRcZeroWithTableDoesNotExistIsClassifiedAsFailure(): void
+	{
+		$this->scriptFailure('add', '198.18.0.1/32', 0, 'Table does not exist.');
+		$plan = ['add' => ['198.18.0.1/32'], 'delete' => []];
+
+		$result = pfb_live_punch_apply($this->shim, $this->table, $plan);
+
+		$this->assertFalse($result['ok'], "rc=0 output containing 'Table does not exist' must still classify as a failure");
+		$this->assertSame('add 198.18.0.1/32', $result['fail']);
+	}
+
+	// -------------------------------------------------------------------
+	// Coverage matrix row 7 -- duplicate-add tolerance: "0/1 addresses
+	// added." at rc=0 is NOT a failure
+	// -------------------------------------------------------------------
+
+	public function testDuplicateAddZeroOfOneIsNotAFailure(): void
+	{
+		$this->scriptFailure('add', '198.18.0.1/32', 0, '0/1 addresses added.');
+		$plan = ['add' => ['198.18.0.1/32'], 'delete' => []];
+
+		$result = pfb_live_punch_apply($this->shim, $this->table, $plan);
+
+		$this->assertTrue($result['ok'], "rc=0 '0/1 addresses added.' is the idempotent-duplicate case, not a failure");
+		$this->assertNull($result['fail']);
+	}
+
+	// -------------------------------------------------------------------
+	// Coverage matrix row 8 -- empty plan: ok=TRUE, zero execs
+	// -------------------------------------------------------------------
+
+	public function testEmptyPlanIsOkWithZeroExecs(): void
+	{
+		$result = pfb_live_punch_apply($this->shim, $this->table, ['add' => [], 'delete' => []]);
+
+		$this->assertTrue($result['ok']);
+		$this->assertNull($result['fail']);
+		$this->assertSame([], $this->readLog(), 'an empty plan must exec pfctl zero times');
+	}
+
+	// -------------------------------------------------------------------
+	// Coverage matrix row 9 -- hostile entries: shell metacharacters,
+	// embedded spaces, and an empty string all reach the shim as ONE
+	// literal argv (or, for the empty string, a caught pfctl failure) --
+	// never a crash, never a second shell word
+	// -------------------------------------------------------------------
+
+	public function testShellMetacharacterEntryReachesPfctlAsOneLiteralArgv(): void
+	{
+		$plan = ['add' => ['198.18.0.1;id'], 'delete' => []];
+
+		$result = pfb_live_punch_apply($this->shim, $this->table, $plan);
+
+		$this->assertTrue($result['ok']);
+		$this->assertSame(
+			[['add', $this->table, '198.18.0.1;id']],
+			$this->readLog(),
+			'the metacharacter must ride as one literal argv field, never a second shell command'
+		);
+	}
+
+	public function testEntryWithSpacesReachesPfctlAsOneLiteralArgv(): void
+	{
+		$plan = ['add' => ['not a real cidr'], 'delete' => []];
+
+		$result = pfb_live_punch_apply($this->shim, $this->table, $plan);
+
+		$this->assertTrue($result['ok']);
+		$this->assertSame(
+			[['add', $this->table, 'not a real cidr']],
+			$this->readLog(),
+			'embedded spaces must not split the entry into multiple argv fields'
+		);
+	}
+
+	public function testEmptyStringEntryFailsCleanlyInsteadOfCrashing(): void
+	{
+		$plan = ['add' => [''], 'delete' => []];
+
+		$result = pfb_live_punch_apply($this->shim, $this->table, $plan);
+
+		$this->assertFalse($result['ok'], 'an empty entry must be caught as a pfctl failure, never crash the helper');
+		$this->assertSame('add ', $result['fail']);
+		$this->assertSame([['add', $this->table, '']], $this->readLog());
+	}
+}

--- a/tests/php/LivePunchPlanTest.php
+++ b/tests/php/LivePunchPlanTest.php
@@ -20,6 +20,13 @@ use PHPUnit\Framework\TestCase;
  * land. The counts below are cross-checked against ADR-53 §1.2's measured
  * covering-CIDR bounds ("/16 - /32 = 16", "/64 (v6) - /128 = 64",
  * "/24 - /32 = 8"), not guessed.
+ *
+ * Issue #1471: $table_entries widens from `array` to `iterable` -- the
+ * membership snapshot pfb_live_table_snapshot() hands in is now a streamed
+ * \Generator, not a fully materialised array. The tests below prove both
+ * shapes work: the existing tests above pass a plain array unchanged, and
+ * the generator-input tests below pass a \Generator through the same
+ * foreach-driven body.
  */
 #[CoversFunction('pfb_live_punch_plan')]
 #[CoversFunction('pfb_v4_carve_single')]
@@ -145,5 +152,47 @@ final class LivePunchPlanTest extends TestCase
 		$plan = pfb_live_punch_plan('10.0.0.1', ['', '# a comment', '10.0.0.0/24']);
 
 		$this->assertSame(['10.0.0.0/24'], $plan['delete']);
+	}
+
+	// --- generator input (issue #1471): the table membership snapshot is
+	// now a streamed \Generator, not just an array -- the plan must accept
+	// any iterable and consume it correctly in a single pass. ---
+
+	public function testV4GeneratorInputIsCarvedCorrectlyWithNonContainingSiblingConsumed(): void
+	{
+		$entries = (function (): \Generator {
+			yield '198.18.0.0/16';   // containing entry
+			yield '198.51.100.0/24'; // sibling, does not contain the host
+		})();
+
+		$plan = pfb_live_punch_plan('198.18.6.9', $entries);
+
+		$this->assertSame(['198.18.0.0/16'], $plan['delete']);
+		$this->assertCount(16, $plan['add']);
+		foreach ($plan['add'] as $cidr) {
+			$this->assertFalse(
+				ip_in_subnet('198.18.6.9', $cidr),
+				"the carved-out host must not fall inside any re-added covering CIDR [ {$cidr} ]"
+			);
+		}
+	}
+
+	public function testV6GeneratorInputIsCarvedCorrectlyWithNonContainingSiblingConsumed(): void
+	{
+		$entries = (function (): \Generator {
+			yield '2001:db8::/64'; // containing entry
+			yield '2001:db9::/64'; // sibling, does not contain the host
+		})();
+
+		$plan = pfb_live_punch_plan('2001:db8::9', $entries);
+
+		$this->assertSame(['2001:db8::/64'], $plan['delete']);
+		$this->assertCount(64, $plan['add']);
+		foreach ($plan['add'] as $cidr) {
+			$this->assertFalse(
+				ip_in_subnet('2001:db8::9', $cidr),
+				"the carved-out v6 host must not fall inside any re-added covering CIDR [ {$cidr} ]"
+			);
+		}
 	}
 }

--- a/tests/php/LivePunchPlanTest.php
+++ b/tests/php/LivePunchPlanTest.php
@@ -195,4 +195,27 @@ final class LivePunchPlanTest extends TestCase
 			);
 		}
 	}
+
+	// --- Nested containing entries must not emit duplicate remainders --
+	// wasted execs downstream in pfb_live_punch_apply(). Two containing
+	// entries whose remainders overlap near the punched host (a /16 AND a
+	// /24 both containing it) carve the SAME near-host covering CIDRs twice,
+	// once per containing entry. ---
+
+	public function testNestedV4ContainingEntriesProduceNoDuplicatePlanEntries(): void
+	{
+		$plan = pfb_live_punch_plan('198.18.0.5', ['198.18.0.0/16', '198.18.0.0/24']);
+
+		$this->assertSame(['198.18.0.0/16', '198.18.0.0/24'], $plan['delete']);
+		$this->assertSame(
+			count($plan['add']),
+			count(array_unique($plan['add'])),
+			'the /16 and /24 remainders overlap near the punched host -- the add list must not repeat a covering CIDR'
+		);
+		$this->assertSame(
+			count($plan['delete']),
+			count(array_unique($plan['delete'])),
+			'the delete list must not repeat a containing entry either'
+		);
+	}
 }

--- a/tests/php/LivePunchRunTest.php
+++ b/tests/php/LivePunchRunTest.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_live_punch_run() -- issue #1467/#1470 (CWE-362): the Alerts "+" /
+ * Unlock live punch's add-first/delete-last sequence
+ * (pfb_live_punch_apply()) could interleave with a concurrent ADR-40
+ * replace -- the replace wipes our adds mid-punch (restoring the canonical
+ * set), then our delete opens the WHOLE containing CIDR until the next
+ * reload. This orchestrator serializes the snapshot-plan-apply sequence
+ * inside the existing feed-pass lock (pfblockerng.inc's
+ * pfb_feed_pass_acquire()/_release()) so a concurrent feed pass can never
+ * observe a half-punched table.
+ *
+ * Brand-new code (CLAUDE.md Test coverage #1 exception): pfb_live_punch_run()
+ * did not exist before this change -- no red run against the void; every
+ * test below asserts real behaviour against the finished implementation.
+ */
+#[CoversFunction('pfb_live_punch_run')]
+final class LivePunchRunTest extends TestCase
+{
+	private string $tmp;
+	private string $dbdir;
+	private string $aliasdir;
+	private string $shim;
+	private string $logPath;
+	private string $rulesPath;
+	private string $showRulePath;
+	private string $table = 'pfB_Test_v4';
+	private bool $hadPfb = FALSE;
+	private array $originalPfb = [];
+
+	/** Raw fds opened directly by a test (bypassing pfb_feed_pass_acquire()) -- closed in tearDown. */
+	private array $rawFps = [];
+
+	protected function setUp(): void
+	{
+		$this->hadPfb      = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+
+		$this->tmp      = sys_get_temp_dir() . '/pfb_live_punch_run_' . getmypid() . '_' . bin2hex(random_bytes(6));
+		$this->dbdir    = "{$this->tmp}/db";
+		$this->aliasdir = "{$this->tmp}/alias";
+		mkdir($this->dbdir, 0777, TRUE);
+		mkdir($this->aliasdir, 0777, TRUE);
+
+		$this->logPath      = "{$this->tmp}/calls.log";
+		$this->rulesPath    = "{$this->tmp}/rules.tsv";
+		$this->showRulePath = "{$this->tmp}/show_rule.txt";
+		putenv("PFB_TEST_LOG={$this->logPath}");
+		putenv("PFB_TEST_RULES={$this->rulesPath}");
+		putenv("PFB_TEST_SHOW_RULE={$this->showRulePath}");
+		$this->shim = $this->writeShim();
+
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'dbdir'  => $this->dbdir,
+			'log'    => "{$this->tmp}/pfblockerng.log",
+			'errlog' => "{$this->tmp}/error.log",
+		]);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->rawFps as $fp) {
+			if (is_resource($fp)) {
+				@flock($fp, LOCK_UN);
+				@fclose($fp);
+			}
+		}
+		$this->rawFps = [];
+
+		// Never leave this process holding the lock across tests.
+		unset($GLOBALS['pfb_feed_pass_lock']);
+
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+
+		putenv('PFB_TEST_LOG');
+		putenv('PFB_TEST_RULES');
+		putenv('PFB_TEST_SHOW_RULE');
+		rmdir_recursive($this->tmp);
+	}
+
+	private function lockPath(): string
+	{
+		return "{$this->dbdir}/pfb_feed_pass.lock";
+	}
+
+	/** Script the '-T show' call: $rc plus the raw stdout lines it prints (the table's membership). */
+	private function scriptShow(int $rc, array $lines = []): void
+	{
+		file_put_contents($this->showRulePath, $rc . "\n" . implode("\n", $lines) . ($lines === [] ? '' : "\n"));
+	}
+
+	/** Script a specific '-T add|delete' op+entry pair to fail, extending AlertsLivePunchApplyTest's shim pattern. */
+	private function scriptFailure(string $op, string $entry, int $rc, string $err): void
+	{
+		file_put_contents($this->rulesPath, "{$op}|{$entry}|{$rc}|{$err}\n", FILE_APPEND);
+	}
+
+	private function readLog(): array
+	{
+		$content = trim((string) @file_get_contents($this->logPath));
+		return $content === '' ? [] : explode("\n", $content);
+	}
+
+	/**
+	 * pfctl shim: logs every call as "<op>|<table>|<entry>", answers '-T show'
+	 * from $PFB_TEST_SHOW_RULE (rc on line 1, membership lines after -- an
+	 * empty table when the file is absent), and answers '-T add'/'-T delete'
+	 * successfully unless $PFB_TEST_RULES scripts that exact op+entry to fail
+	 * (same shape as AlertsLivePunchApplyTest's shim).
+	 */
+	private function writeShim(): string
+	{
+		$shim = "{$this->tmp}/pfctl_shim.sh";
+		file_put_contents($shim, <<<'SH'
+#!/bin/sh
+table=""
+op=""
+entry=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-t) table="$2"; shift 2 ;;
+		-T) op="$2"; shift 2 ;;
+		*) entry="$1"; shift ;;
+	esac
+done
+printf '%s|%s|%s\n' "$op" "$table" "$entry" >> "$PFB_TEST_LOG"
+
+if [ "$op" = "show" ]; then
+	if [ -f "$PFB_TEST_SHOW_RULE" ]; then
+		rc=$(head -n1 "$PFB_TEST_SHOW_RULE")
+		tail -n +2 "$PFB_TEST_SHOW_RULE"
+		exit "$rc"
+	fi
+	exit 0
+fi
+
+if [ -z "$entry" ]; then
+	printf 'pfctl: no address specified\n' >&2
+	exit 1
+fi
+if [ -f "$PFB_TEST_RULES" ]; then
+	while IFS='|' read -r r_op r_entry r_rc r_err; do
+		if [ "$r_op" = "$op" ] && [ "$r_entry" = "$entry" ]; then
+			if [ -n "$r_err" ]; then
+				printf '%s\n' "$r_err" >&2
+			fi
+			exit "$r_rc"
+		fi
+	done < "$PFB_TEST_RULES"
+fi
+if [ "$op" = "add" ]; then
+	printf '1/1 addresses added.\n'
+else
+	printf '1/1 addresses deleted.\n'
+fi
+exit 0
+SH
+		);
+		chmod($shim, 0755);
+		return $shim;
+	}
+
+	// -------------------------------------------------------------------
+	// 'not_blocked' -- an empty live table: no delete/add execs, no lock
+	// left held.
+	// -------------------------------------------------------------------
+
+	public function testEmptyTableReturnsNotBlocked(): void
+	{
+		$result = pfb_live_punch_run($this->shim, $this->aliasdir, $this->dbdir, $this->table, '198.18.0.5');
+
+		$this->assertSame(
+			['status' => 'not_blocked', 'fail' => NULL, 'del_cnt' => 0, 'add_cnt' => 0],
+			$result
+		);
+		$this->assertSame(['show|pfB_Test_v4|'], $this->readLog(), 'only the snapshot -T show must run -- no add/delete');
+	}
+
+	// -------------------------------------------------------------------
+	// 'applied' -- a containing entry is punched, adds-before-deletes,
+	// counts reflect the plan.
+	// -------------------------------------------------------------------
+
+	public function testContainingEntryReturnsAppliedWithCounts(): void
+	{
+		$this->scriptShow(0, ['203.0.113.0/24']);
+
+		$result = pfb_live_punch_run($this->shim, $this->aliasdir, $this->dbdir, $this->table, '203.0.113.5');
+
+		$this->assertSame('applied', $result['status']);
+		$this->assertNull($result['fail']);
+		$this->assertSame(1, $result['del_cnt'], 'one containing entry (the /24) is deleted');
+		$this->assertSame(8, $result['add_cnt'], 'a /24 minus one host carves into 8 covering CIDRs (ADR-53 measured bound)');
+	}
+
+	// -------------------------------------------------------------------
+	// 'failed' -- a scripted pfctl failure surfaces pfb_live_punch_apply()'s
+	// fail string unchanged.
+	// -------------------------------------------------------------------
+
+	public function testApplyFailureReturnsFailedWithApplyFailString(): void
+	{
+		$this->scriptShow(0, ['203.0.113.0/24']);
+		$this->scriptFailure('delete', '203.0.113.0/24', 1, 'pfctl: forced delete failure');
+
+		$result = pfb_live_punch_run($this->shim, $this->aliasdir, $this->dbdir, $this->table, '203.0.113.5');
+
+		$this->assertSame('failed', $result['status']);
+		$this->assertSame('delete 203.0.113.0/24', $result['fail']);
+		$this->assertSame(0, $result['del_cnt']);
+		$this->assertSame(0, $result['add_cnt']);
+	}
+
+	// -------------------------------------------------------------------
+	// F2 integration -- a snapshot capture failure (pfb_live_table_snapshot()
+	// throwing \RuntimeException) is caught and reported as 'failed', never
+	// an uncaught fatal, never misread as an empty/not-blocked table.
+	// -------------------------------------------------------------------
+
+	public function testSnapshotThrowIsCaughtAsFailedWithSnapshotPrefix(): void
+	{
+		$this->scriptShow(1, []); // -T show itself fails -> pfb_live_table_snapshot() throws
+
+		$result = pfb_live_punch_run($this->shim, $this->aliasdir, $this->dbdir, $this->table, '203.0.113.5');
+
+		$this->assertSame('failed', $result['status']);
+		$this->assertNotNull($result['fail']);
+		$this->assertStringStartsWith('snapshot: ', $result['fail'], "a snapshot-capture failure must be distinguishable from a plan/apply failure");
+		$this->assertSame(0, $result['del_cnt']);
+		$this->assertSame(0, $result['add_cnt']);
+	}
+
+	// -------------------------------------------------------------------
+	// 'busy' -- another handle holds the feed-pass lock: no snapshot, no
+	// execs at all.
+	// -------------------------------------------------------------------
+
+	public function testConcurrentFeedPassReturnsBusyWithZeroExecs(): void
+	{
+		$holder = fopen($this->lockPath(), 'c');
+		$this->rawFps[] = $holder;
+		$this->assertTrue(flock($holder, LOCK_EX), 'test setup: failed to flock the holder fd');
+
+		$result = pfb_live_punch_run($this->shim, $this->aliasdir, $this->dbdir, $this->table, '203.0.113.5');
+
+		$this->assertSame(
+			['status' => 'busy', 'fail' => NULL, 'del_cnt' => 0, 'add_cnt' => 0],
+			$result
+		);
+		$this->assertSame([], $this->readLog(), 'busy must short-circuit before any pfctl exec -- not even the snapshot');
+
+		// Holder undisturbed.
+		$this->assertTrue(flock($holder, LOCK_EX | LOCK_NB),
+			'the original holder must remain able to operate on its own lock afterwards');
+	}
+
+	// -------------------------------------------------------------------
+	// $was_held reentrancy guard -- a nested call inside an already-held
+	// lock must NOT release the outer caller's hold.
+	// -------------------------------------------------------------------
+
+	public function testReentrantCallDoesNotReleaseAnOuterHold(): void
+	{
+		$outerHandle = fopen($this->lockPath(), 'c');
+		$this->rawFps[] = $outerHandle;
+		$this->assertTrue(flock($outerHandle, LOCK_EX), 'test setup: failed to flock the outer handle');
+		$GLOBALS['pfb_feed_pass_lock'] = $outerHandle;
+
+		$result = pfb_live_punch_run($this->shim, $this->aliasdir, $this->dbdir, $this->table, '198.18.0.5');
+
+		$this->assertSame('not_blocked', $result['status'], 'test setup: an empty table is the simplest path through the lock scope');
+
+		// A fresh probe fd must still find the lock held -- pfb_live_punch_run()
+		// must not have released an outer caller's pre-existing hold.
+		$probe = fopen($this->lockPath(), 'c');
+		$this->rawFps[] = $probe;
+		$this->assertFalse(flock($probe, LOCK_EX | LOCK_NB),
+			'the outer hold must still be locked after a reentrant pfb_live_punch_run() call');
+	}
+}

--- a/tests/php/LiveTableSnapshotTest.php
+++ b/tests/php/LiveTableSnapshotTest.php
@@ -76,14 +76,21 @@ final class LiveTableSnapshotTest extends TestCase
 	}
 
 	/**
-	 * A pfctl invocation that cannot run at all (nonexistent binary/missing
-	 * table) fails SOFT -- an empty result, never a warning or fatal.
+	 * A pfctl invocation that cannot run at all (nonexistent binary) is no
+	 * longer indistinguishable from an empty table -- it throws
+	 * \RuntimeException instead of failing soft, so an orchestrator can tell
+	 * "genuinely empty" from "snapshot capture failed" (a fail-soft empty
+	 * result here used to read as -- and be acted on as -- "not currently
+	 * blocked"). Supersedes the prior fail-soft spec. The throw fires
+	 * lazily, on the generator's first iteration.
 	 */
-	public function testBrokenPfctlFailsSoftAndYieldsNothing(): void
+	public function testBrokenPfctlThrowsRuntimeException(): void
 	{
-		$entries = self::collect(pfb_live_table_snapshot('/nonexistent/pfctl-binary-xyz', $this->aliasdir, $this->dbdir, 'pfB_NoTable_v4'));
+		$this->expectException(\RuntimeException::class);
 
-		$this->assertSame([], $entries);
+		foreach (pfb_live_table_snapshot('/nonexistent/pfctl-binary-xyz', $this->aliasdir, $this->dbdir, 'pfB_NoTable_v4') as $entry) {
+			// the throw fires lazily -- iterating is what triggers the generator body
+		}
 	}
 
 	/**
@@ -140,6 +147,10 @@ final class LiveTableSnapshotTest extends TestCase
 			"awk 'BEGIN { for (i = 0; i < 200000; i++) printf \"10.%d.%d.%d/32\\n\", int(i / 65536) % 256, int(i / 256) % 256, i % 256 }'"
 		);
 
+		// Reset the process-wide peak immediately before the measured consumption
+		// (CountLinesTest precedent) -- otherwise an earlier test's higher peak in
+		// this same process can mask a regression here.
+		memory_reset_peak_usage();
 		$before = memory_get_peak_usage();
 		$count  = 0;
 		foreach (pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_Big_v4') as $entry) {

--- a/tests/php/LiveTableSnapshotTest.php
+++ b/tests/php/LiveTableSnapshotTest.php
@@ -6,16 +6,18 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_live_table_snapshot() -- issue #1412: the ADR-40 mirror-or-pfctl-fallback
- * table-membership read, extracted from the Alerts "+" (addsuppress) handler
- * so the temporary Unlock icon's live punch shares the exact same read
- * instead of re-deriving it (pfblockerng_extra.inc).
+ * pfb_live_table_snapshot() -- issue #1467: the live `pfctl -T show` capture
+ * is the SOLE source of a pf table's membership. The ADR-40 mirror file
+ * (issue #1412's original mirror-or-pfctl-fallback design) is never read --
+ * a live punch never rewrites the mirror, so a second punch inside the same
+ * containing entry would otherwise read a stale set and silently revert the
+ * first punch. $aliasdir stays in the signature (unused) for call-site and
+ * red-proof stability.
  *
- * These tests pin the extraction's two real branches directly: the
- * ADR-40 mirror file wins when readable (no pfctl needed at all -- proven by
- * pointing $pfctl at a binary that does not exist), and a missing/unreadable
- * mirror falls back to the pfctl path, failing SOFT (empty array, no
- * warning/fatal) when that pfctl invocation itself cannot run.
+ * Issue #1471: the snapshot streams as a \Generator instead of slurping
+ * every line into an array -- a Deny table can hold millions of entries, and
+ * materialising the whole set as a PHP string array would exhaust the web-UI
+ * PHP process's memory.
  */
 #[CoversFunction('pfb_live_table_snapshot')]
 final class LiveTableSnapshotTest extends TestCase
@@ -39,56 +41,147 @@ final class LiveTableSnapshotTest extends TestCase
 	}
 
 	/**
-	 * The mirror file wins when readable -- and pfctl is never even invoked:
-	 * $pfctl here is a nonexistent binary, so if the function fell through to
-	 * the pfctl branch it would return an EMPTY array (a failed exec()
-	 * produces no output), never the mirror's real content.
+	 * Collect a snapshot result into a plain array -- iteration-agnostic, so
+	 * the same frozen assertion works whether pfb_live_table_snapshot()
+	 * returns an array (red, pre-#1471) or a \Generator (green, post-#1471).
 	 */
-	public function testMirrorFileWinsAndPfctlIsNeverInvoked(): void
+	private static function collect(iterable $entries): array
 	{
-		file_put_contents("{$this->aliasdir}/pfB_Test_v4.txt", "10.0.0.0/24\n198.51.100.7\n");
-
-		$entries = pfb_live_table_snapshot('/nonexistent/pfctl-binary-xyz', $this->aliasdir, $this->dbdir, 'pfB_Test_v4');
-
-		$this->assertSame(['10.0.0.0/24', '198.51.100.7'], $entries);
+		$out = [];
+		foreach ($entries as $entry) {
+			$out[] = $entry;
+		}
+		return $out;
 	}
 
-	/** Blank and '#'-comment lines in the mirror are returned raw -- untouched, un-filtered. */
-	public function testMirrorBlankAndCommentLinesReturnedRaw(): void
+	private function writeShim(string $body): string
 	{
-		file_put_contents("{$this->aliasdir}/pfB_Raw_v4.txt", "10.0.0.1\n\n# a comment\n10.0.0.2\n");
-
-		$entries = pfb_live_table_snapshot('/nonexistent/pfctl-binary-xyz', $this->aliasdir, $this->dbdir, 'pfB_Raw_v4');
-
-		$this->assertSame(['10.0.0.1', '', '# a comment', '10.0.0.2'], $entries);
+		$shim = "{$this->tmpDir}/pfctl-shim-" . bin2hex(random_bytes(4)) . '.sh';
+		file_put_contents($shim, "#!/bin/sh\n{$body}\n");
+		chmod($shim, 0755);
+		return $shim;
 	}
 
 	/**
-	 * No mirror file -> falls back to the pfctl path; a pfctl invocation that
-	 * cannot run at all (nonexistent binary) fails SOFT -- an empty array,
-	 * never a warning or fatal.
+	 * pfctl's own '-T show' output is parsed -- a tiny shell shim stands in
+	 * for pfctl (off-appliance has no real pf).
 	 */
-	public function testMissingMirrorFallsBackToPfctlAndFailsSoftOnBrokenPfctl(): void
+	public function testPfctlOutputIsParsed(): void
 	{
-		$entries = pfb_live_table_snapshot('/nonexistent/pfctl-binary-xyz', $this->aliasdir, $this->dbdir, 'pfB_NoMirror_v4');
+		$shim = $this->writeShim("printf '203.0.113.0/28\\n203.0.113.99\\n'");
+
+		$entries = self::collect(pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_Test_v4'));
+
+		$this->assertSame(['203.0.113.0/28', '203.0.113.99'], $entries);
+	}
+
+	/**
+	 * A pfctl invocation that cannot run at all (nonexistent binary/missing
+	 * table) fails SOFT -- an empty result, never a warning or fatal.
+	 */
+	public function testBrokenPfctlFailsSoftAndYieldsNothing(): void
+	{
+		$entries = self::collect(pfb_live_table_snapshot('/nonexistent/pfctl-binary-xyz', $this->aliasdir, $this->dbdir, 'pfB_NoTable_v4'));
 
 		$this->assertSame([], $entries);
 	}
 
 	/**
-	 * No mirror file, but a WORKING pfctl-shaped command -- proves the
-	 * fallback path genuinely execs and parses $pfctl's own '-T show' output,
-	 * not just "returns empty no matter what". A tiny shell shim stands in
-	 * for pfctl (off-appliance has no real pf).
+	 * Issue #1467: a mirror file present does NOT win -- it is never read at
+	 * all. The mirror holds a stale set A; live pfctl reports a different
+	 * set B, exactly as it would after a first live punch that never
+	 * rewrote the mirror. The snapshot must reflect B, the live truth, not
+	 * the stale mirror.
 	 */
-	public function testMissingMirrorFallsBackToPfctlAndParsesItsOutput(): void
+	public function testMirrorPresentIsIgnoredLivePfctlIsTheSoleSource(): void
 	{
-		$shim = "{$this->tmpDir}/pfctl-shim.sh";
-		file_put_contents($shim, "#!/bin/sh\nprintf '203.0.113.0/28\\n203.0.113.99\\n'\n");
-		chmod($shim, 0755);
+		file_put_contents("{$this->aliasdir}/pfB_Test_v4.txt", "198.18.0.0/16\n");
 
-		$entries = pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_NoMirror_v4');
+		$shim = $this->writeShim("printf '198.18.0.0/17\\n198.18.128.0/18\\n198.18.192.0/19\\n'");
 
-		$this->assertSame(['203.0.113.0/28', '203.0.113.99'], $entries);
+		$entries = self::collect(pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_Test_v4'));
+
+		$this->assertSame(
+			['198.18.0.0/17', '198.18.128.0/18', '198.18.192.0/19'],
+			$entries,
+			'the live pfctl set (post-punch remainder) must win -- the stale mirror is never consulted'
+		);
+	}
+
+	/** Blank and '#'-comment lines in pfctl's output are returned raw -- untouched, un-filtered. */
+	public function testPfctlBlankAndCommentLinesReturnedRaw(): void
+	{
+		$shim = $this->writeShim("printf '10.0.0.1\\n\\n# a comment\\n10.0.0.2\\n'");
+
+		$entries = self::collect(pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_Raw_v4'));
+
+		$this->assertSame(['10.0.0.1', '', '# a comment', '10.0.0.2'], $entries);
+	}
+
+	/** Issue #1471: the snapshot is a \Generator -- never a fully materialised array. */
+	public function testSnapshotIsAGenerator(): void
+	{
+		$shim = $this->writeShim("printf '10.0.0.1\\n'");
+
+		$result = pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_Gen_v4');
+
+		$this->assertInstanceOf(\Generator::class, $result);
+	}
+
+	/**
+	 * A large table (~200k entries) must stream through with a bounded
+	 * memory footprint. A 200k-string PHP array costs roughly 15-20 MiB;
+	 * the generator must cost well under that. The threshold is set safely
+	 * above the PHP 8.5 memory_get_peak_usage() ~2 MiB quantization step.
+	 */
+	public function testLargeTableStreamsWithBoundedMemory(): void
+	{
+		$shim = $this->writeShim(
+			"awk 'BEGIN { for (i = 0; i < 200000; i++) printf \"10.%d.%d.%d/32\\n\", int(i / 65536) % 256, int(i / 256) % 256, i % 256 }'"
+		);
+
+		$before = memory_get_peak_usage();
+		$count  = 0;
+		foreach (pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_Big_v4') as $entry) {
+			$count++;
+		}
+		$after = memory_get_peak_usage();
+
+		$this->assertSame(200000, $count);
+		$this->assertLessThan(
+			8 * 1024 * 1024,
+			$after - $before,
+			"peak memory delta must stay well under a 200k-element array's cost"
+		);
+	}
+
+	/** After a full iteration, the pfctl-show scratch temp file is cleaned up. */
+	public function testTempFileCleanedUpAfterFullIteration(): void
+	{
+		$shim = $this->writeShim("printf '10.0.0.1\\n10.0.0.2\\n'");
+
+		foreach (pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_Clean_v4') as $entry) {
+			// drain fully
+		}
+
+		$this->assertSame([], glob("{$this->dbdir}/pfb_punch_*"), 'the scratch temp file must not survive a full iteration');
+	}
+
+	/** An abandoned (partially-iterated, then destroyed) generator still cleans up its temp file. */
+	public function testTempFileCleanedUpAfterAbandonedIteration(): void
+	{
+		$shim = $this->writeShim("printf '10.0.0.1\\n10.0.0.2\\n10.0.0.3\\n'");
+
+		$gen = pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_Abandon_v4');
+		foreach ($gen as $entry) {
+			break; // take exactly one entry, then abandon
+		}
+		unset($gen);
+
+		$this->assertSame(
+			[],
+			glob("{$this->dbdir}/pfb_punch_*"),
+			'the scratch temp file must be cleaned up even when the generator is abandoned mid-iteration'
+		);
 	}
 }

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -1112,6 +1112,291 @@ def test_ip_unlock_rejects_invalid_ip_no_mutation(
 
 
 # --------------------------------------------------------------------------- #
+# Live-punch redesign (issues #1467/#1470/#1471): pfb_live_table_snapshot() now
+# reads live ``pfctl -T show`` as its SOLE source (the stale ADR-40 mirror file
+# is never consulted), so a SECOND punch inside the same containing entry sees
+# the FIRST punch's already-applied result instead of silently reverting it;
+# and pfb_live_punch_apply() (#1470) computes the punch PLAN before writing the
+# unlock store, so an unlock of a host nothing live blocks records NOTHING and
+# says so, instead of claiming success it never performed.
+# --------------------------------------------------------------------------- #
+
+
+def test_ip_unlock_double_punch_v4_second_punch_keeps_first_carved(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A second unlock in the same containing /16 must not silently re-lock the first (issue #1467).
+
+    Before this fix, ``pfb_live_table_snapshot()`` preferred the stale ADR-40
+    mirror file over a live ``pfctl -T show`` capture. A live punch never
+    rewrites that mirror, so a SECOND unlock inside the same containing entry
+    read the mirror's PRE-first-punch membership, recomputed the covering-CIDR
+    remainder from scratch, and re-added CIDRs that re-covered the FIRST
+    unlocked host -- silently re-locking it without ever touching
+    ``ip_remove=lock``. The fix makes live ``pfctl -T show`` the sole snapshot
+    source, so the second punch's plan is always computed against the table as
+    it stands AFTER the first punch.
+
+    Given: a local IPv4 feed lists an RFC 2544 /16 (``198.18.0.0/16``) plus a
+        separate sibling entry outside it; both punch targets, a third inside
+        host, and the sibling all match the live pf table.
+    When: the FIRST host is unlocked -- asserted carved before continuing (the
+        before-state gate for the second punch). Then, WITHOUT any reload in
+        between, the SECOND host (same /16) is unlocked too.
+    Then: the second host no longer matches (its own punch worked); the FIRST
+        host STILL does not match -- pre-fix this is exactly where the second
+        punch's stale-mirror remainder re-covers it (the regression trap); a
+        third, untouched host inside the /16 still matches (remainder
+        integrity -- discriminates a delete-only regression the outside
+        sibling below cannot see); the outside sibling is untouched; the
+        unlock store records BOTH exact hosts mapped to the table.
+    """
+    vm = smoke_vm
+    first = "198.18.6.9"  # inside 198.18.0.0/16 -- unlocked FIRST
+    second = "198.18.200.7"  # inside the SAME /16 -- unlocked SECOND, no reload between
+    third_inside = "198.18.90.1"  # inside the SAME /16, never unlocked -- remainder integrity
+    sibling = "198.19.51.6"  # a SEPARATE feed entry, RFC 2544 space, outside the /16 hole
+
+    feed_url = helpers.write_local_feed(vm, "ui_ipunlock4dp.txt", f"198.18.0.0/16\n{sibling}\n")
+    spec = helpers.IpCase(aliasname="uiipunlock4dp", feed_url=feed_url, header="uiipunlock4dp")
+    table = spec.alias
+
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "updateip")
+    try:
+        # BEFORE: the table is populated and every address matches it live.
+        members = helpers.wait_pfctl_table(vm, table)
+        assert members, f"pf table {table} never populated after the settling update"
+        for host in (first, second, third_inside, sibling):
+            matched, raw = helpers.pfctl_table_test_raw(vm, table, host)
+            assert matched, f"{host} expected to match pf table {table} before any unlock; pfctl said: {raw!r}"
+        assert first not in _ip_unlock_hosts(vm), f"{first} already in {IP_UNLOCK_STORE} before the test"
+        assert second not in _ip_unlock_hosts(vm), f"{second} already in {IP_UNLOCK_STORE} before the test"
+
+        # WHEN: unlock the FIRST host -- carved out of the /16.
+        resp = _post_action(webui, {"ip_remove": "unlock", "ip": first, "table": table})
+        assert not looks_like_login_page(resp.text), (
+            "first ip_remove=unlock POST returned the login form (session lost)"
+        )
+        # THEN (before-state gate for the second punch): the first host is carved.
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, first)
+        assert not matched, (
+            f"{first} still matches pf table {table} after the FIRST unlock -- the live punch did not "
+            f"take effect; pfctl said: {raw!r}"
+        )
+
+        # WHEN: WITHOUT any reload, unlock the SECOND host -- same containing /16.
+        resp = _post_action(webui, {"ip_remove": "unlock", "ip": second, "table": table})
+        assert not looks_like_login_page(resp.text), (
+            "second ip_remove=unlock POST returned the login form (session lost)"
+        )
+
+        # THEN (issue #1467's oracle set):
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, second)
+        assert not matched, (
+            f"{second} still matches pf table {table} after the SECOND unlock -- the live punch did not "
+            f"take effect; pfctl said: {raw!r}"
+        )
+        # The FIRST host must STILL be carved -- pre-fix, the second punch's
+        # stale-mirror snapshot re-added covering CIDRs that silently re-locked it.
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, first)
+        assert not matched, (
+            f"{first} matches pf table {table} again after the SECOND unlock -- the second punch's plan "
+            f"was computed against a stale snapshot and re-covered the first carve (issue #1467 regression); "
+            f"pfctl said: {raw!r}"
+        )
+        # A third, untouched host inside the /16 still matches -- only the
+        # re-added remainder CIDRs can cover it, discriminating a delete-only punch.
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, third_inside)
+        assert matched, (
+            f"{third_inside} no longer matches pf table {table} after the double unlock -- the "
+            f"covering-CIDR remainder was not re-added (delete-only punch); pfctl said: {raw!r}"
+        )
+        # The outside sibling -- a distinct feed entry entirely outside the hole -- is untouched.
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, sibling)
+        assert matched, (
+            f"{sibling} no longer matches pf table {table} after the double unlock -- an unrelated "
+            f"sibling was punched; pfctl said: {raw!r}"
+        )
+        # The unlock store records BOTH exact hosts mapped to the table.
+        unlocked = _ip_unlock_hosts(vm)
+        assert unlocked.get(first) == table, (
+            f"expected {IP_UNLOCK_STORE} to record the exact host {first!r} -> {table!r}, got {unlocked!r}"
+        )
+        assert unlocked.get(second) == table, (
+            f"expected {IP_UNLOCK_STORE} to record the exact host {second!r} -> {table!r}, got {unlocked!r}"
+        )
+    finally:
+        helpers.reset(vm)
+
+
+def test_ip_unlock_double_punch_v6_second_punch_keeps_first_carved(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A second v6 unlock in the same containing /64 must not silently re-lock the first (issue #1467).
+
+    Same regression shape as the v4 case above, over the same RFC 3849 v6
+    geometry the sibling carve/relock test (``test_ip_unlock_v6_carves_...``)
+    uses: ``2001:db8:19:1::/64`` as the containing entry, with the earlier
+    test's ``target`` (``::42``) and ``inside_sibling`` (``::43``) reused here
+    as the first and second punch targets respectively, plus a third,
+    never-unlocked host in the same /64 and the earlier test's outside
+    sibling /64 (``2001:db8:19:2::/64``, host ``::9``).
+
+    Given/When/Then mirror the v4 double-punch exactly, over v6 addresses.
+    """
+    vm = smoke_vm
+    first = "2001:db8:19:1::42"  # inside 2001:db8:19:1::/64 -- unlocked FIRST
+    second = "2001:db8:19:1::43"  # inside the SAME /64 -- unlocked SECOND, no reload between
+    third_inside = "2001:db8:19:1::90"  # inside the SAME /64, never unlocked -- remainder integrity
+    sibling = "2001:db8:19:2::9"  # a SEPARATE feed entry, a different /64, outside the hole
+
+    feed_url = helpers.write_local_feed(vm, "ui_ipunlock6dp.txt", f"2001:db8:19:1::/64\n{sibling}\n")
+    spec = helpers.IpCase(aliasname="uiipunlock6dp", feed_url=feed_url, header="uiipunlock6dp", family="v6")
+    table = spec.alias
+
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "updateip")
+    try:
+        members = helpers.wait_pfctl_table(vm, table)
+        assert members, f"pf table {table} never populated after the settling update"
+        for host in (first, second, third_inside, sibling):
+            matched, raw = helpers.pfctl_table_test_raw(vm, table, host)
+            assert matched, f"{host} expected to match pf table {table} before any unlock; pfctl said: {raw!r}"
+        assert first not in _ip_unlock_hosts(vm), f"{first} already in {IP_UNLOCK_STORE} before the test"
+        assert second not in _ip_unlock_hosts(vm), f"{second} already in {IP_UNLOCK_STORE} before the test"
+
+        resp = _post_action(webui, {"ip_remove": "unlock", "ip": first, "table": table})
+        assert not looks_like_login_page(resp.text), (
+            "first ip_remove=unlock POST returned the login form (session lost)"
+        )
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, first)
+        assert not matched, (
+            f"{first} still matches pf table {table} after the FIRST unlock -- the live punch did not "
+            f"take effect; pfctl said: {raw!r}"
+        )
+
+        resp = _post_action(webui, {"ip_remove": "unlock", "ip": second, "table": table})
+        assert not looks_like_login_page(resp.text), (
+            "second ip_remove=unlock POST returned the login form (session lost)"
+        )
+
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, second)
+        assert not matched, (
+            f"{second} still matches pf table {table} after the SECOND unlock -- the live punch did not "
+            f"take effect; pfctl said: {raw!r}"
+        )
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, first)
+        assert not matched, (
+            f"{first} matches pf table {table} again after the SECOND unlock -- the second punch's plan "
+            f"was computed against a stale snapshot and re-covered the first carve (issue #1467 regression); "
+            f"pfctl said: {raw!r}"
+        )
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, third_inside)
+        assert matched, (
+            f"{third_inside} no longer matches pf table {table} after the double unlock -- the "
+            f"covering-CIDR remainder was not re-added (delete-only punch); pfctl said: {raw!r}"
+        )
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, sibling)
+        assert matched, (
+            f"{sibling} no longer matches pf table {table} after the double unlock -- an unrelated "
+            f"sibling was punched; pfctl said: {raw!r}"
+        )
+        unlocked = _ip_unlock_hosts(vm)
+        assert unlocked.get(first) == table, (
+            f"expected {IP_UNLOCK_STORE} to record the exact host {first!r} -> {table!r}, got {unlocked!r}"
+        )
+        assert unlocked.get(second) == table, (
+            f"expected {IP_UNLOCK_STORE} to record the exact host {second!r} -> {table!r}, got {unlocked!r}"
+        )
+    finally:
+        helpers.reset(vm)
+
+
+def test_ip_unlock_not_currently_blocked_records_nothing(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """ip_remove=unlock on a host nothing live blocks records NO unlock (issue #1470).
+
+    Before this fix, an unlock POST for a host the table does not cover still
+    called ``pfb_unlock()`` and claimed success. The handler now computes the
+    live punch PLAN first (``pfb_live_punch_plan()``); an empty ``delete`` set
+    means nothing live blocks the host, so NO store write happens and the
+    savemsg says so instead of claiming an unlock that never occurred.
+
+    Given: a local IPv4 feed populates a live pf table (``198.18.0.0/16``,
+        represented by an in-range host, ``member``); the target host
+        (RFC 5737 TEST-NET-3 -- in NO feed entry, never RFC 1918) does not
+        match the table.
+    When: ip_remove=unlock is posted for that host.
+    Then: the unlock store gains no entry for it and is otherwise BYTE-FOR-BYTE
+        unchanged (the primary oracle -- pre-fix it gains an entry); the
+        table's actual member is unchanged (still matches); the response is
+        not the login page and its savemsg names the "not currently blocked"
+        case (the same resp.text savemsg idiom the covered-host addsuppress
+        test above uses).
+    """
+    vm = smoke_vm
+    member = "198.18.1.1"  # inside 198.18.0.0/16 -- proves the table itself is untouched
+    target = "203.0.113.5"  # RFC 5737 TEST-NET-3 -- in NO feed entry, never currently blocked
+
+    feed_url = helpers.write_local_feed(vm, "ui_ipunlock_notblocked.txt", "198.18.0.0/16\n")
+    spec = helpers.IpCase(aliasname="uiipunlocknb", feed_url=feed_url, header="uiipunlocknb")
+    table = spec.alias
+
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "updateip")
+    try:
+        # BEFORE: the table is populated; the member matches, the target does not
+        # (the before-state gate -- "not currently blocked" must be genuinely true).
+        members = helpers.wait_pfctl_table(vm, table)
+        assert members, f"pf table {table} never populated after the settling update"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, member)
+        assert matched, f"{member} expected to match pf table {table} before the test; pfctl said: {raw!r}"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert not matched, (
+            f"{target} unexpectedly matches pf table {table} before the test -- it must be genuinely "
+            f"unblocked for this to be a true not-currently-blocked case; pfctl said: {raw!r}"
+        )
+        store_before = _ip_unlock_hosts(vm)
+        assert target not in store_before, f"{target} already in {IP_UNLOCK_STORE} before the test"
+
+        # WHEN: unlock is posted for a host nothing live blocks.
+        resp = _post_action(webui, {"ip_remove": "unlock", "ip": target, "table": table})
+        assert not looks_like_login_page(resp.text), "ip_remove=unlock POST returned the login form (session lost)"
+
+        # THEN: no unlock was recorded -- the store is BYTE-FOR-BYTE unchanged,
+        # not merely missing the target (pre-fix it gains a "target,table" line).
+        after = _ip_unlock_hosts(vm)
+        assert target not in after, f"{target} recorded in {IP_UNLOCK_STORE} after an unlock of an unblocked host"
+        assert after == store_before, (
+            f"{IP_UNLOCK_STORE} changed after an unlock POST for a not-currently-blocked host: "
+            f"before={store_before!r} after={after!r}"
+        )
+        # THEN: the table is unchanged (the member still matches; the target still doesn't).
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, member)
+        assert matched, (
+            f"{member} no longer matches pf table {table} after the not-currently-blocked unlock POST -- "
+            f"the live table was unexpectedly mutated; pfctl said: {raw!r}"
+        )
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert not matched, (
+            f"{target} unexpectedly matches pf table {table} after the not-currently-blocked unlock POST; "
+            f"pfctl said: {raw!r}"
+        )
+        # THEN: the savemsg names the "not currently blocked" case, not a claimed unlock.
+        assert "is not currently blocked" in resp.text, (
+            "expected the 'is not currently blocked' savemsg after an unlock POST for a host nothing live "
+            "blocks; response body did not contain it"
+        )
+    finally:
+        helpers.reset(vm)
+
+
+# --------------------------------------------------------------------------- #
 # Suppression-icon render eligibility (convert_ip_log, alerts.php:3057 -- issue
 # #422, ADR-53 follow-up). Before this fix the gate was
 # ``$pfb_ipv4 && !$pfb_geoip && $mask_suppression`` -- TRUE only for a v4 host

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -1162,9 +1162,11 @@ def test_ip_unlock_double_punch_v4_second_punch_keeps_first_carved(
     spec = helpers.IpCase(aliasname="uiipunlock4dp", feed_url=feed_url, header="uiipunlock4dp")
     table = spec.alias
 
-    helpers.inject(vm, spec)
-    helpers.reload(vm, "updateip")
     try:
+        # Inject/reload live INSIDE the try -- a failed setup
+        # must still hit `finally: helpers.reset(vm)`.
+        helpers.inject(vm, spec)
+        helpers.reload(vm, "updateip")
         # BEFORE: the table is populated and every address matches it live.
         members = helpers.wait_pfctl_table(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
@@ -1257,9 +1259,11 @@ def test_ip_unlock_double_punch_v6_second_punch_keeps_first_carved(
     spec = helpers.IpCase(aliasname="uiipunlock6dp", feed_url=feed_url, header="uiipunlock6dp", family="v6")
     table = spec.alias
 
-    helpers.inject(vm, spec)
-    helpers.reload(vm, "updateip")
     try:
+        # Inject/reload live INSIDE the try -- a failed setup
+        # must still hit `finally: helpers.reset(vm)`.
+        helpers.inject(vm, spec)
+        helpers.reload(vm, "updateip")
         members = helpers.wait_pfctl_table(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
         for host in (first, second, third_inside, sibling):
@@ -1347,9 +1351,11 @@ def test_ip_unlock_not_currently_blocked_records_nothing(
     spec = helpers.IpCase(aliasname="uiipunlocknb", feed_url=feed_url, header="uiipunlocknb")
     table = spec.alias
 
-    helpers.inject(vm, spec)
-    helpers.reload(vm, "updateip")
     try:
+        # Inject/reload live INSIDE the try -- a failed setup
+        # must still hit `finally: helpers.reset(vm)`.
+        helpers.inject(vm, spec)
+        helpers.reload(vm, "updateip")
         # BEFORE: the table is populated; the member matches, the target does not
         # (the before-state gate -- "not currently blocked" must be genuinely true).
         members = helpers.wait_pfctl_table(vm, table)


### PR DESCRIPTION
Redesigns the ADR-53 live punch mechanism shared by the Alerts Suppression "+" and temporary IP Unlock actions, fixing the three deferred findings from PR #1465's review as one combined change.

Fixes #1467
Fixes #1470
Fixes #1471

## What changed

**#1467 — stale-mirror double punch.** `pfb_live_table_snapshot()` no longer prefers the ADR-40 mirror file: live `pfctl -T show` is the sole snapshot source. Live punches never rewrite the mirror, so a second punch inside the same containing entry planned against pre-first-punch state and silently reverted the first carve. Planning against the live table makes every subsequent punch correct by construction — no mirror rewrites, no re-punch bookkeeping. The `$aliasdir` parameter is retained (unused) for call-site stability.

**#1471 — whole-table materialization.** The snapshot is now a streaming `\Generator` (temp-file cleanup in `try`/`finally`, including abandoned iteration), and `pfb_live_punch_plan()` accepts `iterable`. Peak memory across a 200,000-line table dropped from ~11.7 MiB (full array) to under the 8 MiB test bound; only containing entries are ever retained.

**#1470 — non-atomic apply.** New `pfb_live_punch_apply()` replaces both callers' unchecked exec loops:

- **Adds before deletes.** Every remainder CIDR is added while its containing entry still stands (adds are behavior-neutral subsets), and containing entries are deleted last — no intermediate state can unblock the host or its siblings.
- Every `pfctl` exec's rc + output is checked via the landed `pfb_pfctl_op_failed()` predicate. An add failure stops the punch and best-effort rolls back the remainders already added; a delete failure stops fail-closed. Failures are logged and reported.
- The helper deliberately does NOT route through `pfb_pfctl_table_op()`: its ADR-61 sync-status ledger entry would let the retry sweep mirror-replace the table and revert other valid live punches.
- Caller honesty: unlocking an IP that is not currently blocked now records nothing in the unlock store and says so; a failed live unlock writes no store entry. The Suppression "+" keeps its standing-exemption semantics (the customlist write proceeds; a live-punch failure is surfaced in the message and heals at the next reload).

## Evidence

- Test-first red→green per step, executed and hash-frozen (reproduction test files byte-identical between red and green; re-executed independently via `verify-red-proof.sh` by a separate verifier agent per step — both verdicts PASS).
  - Step 1 red: mirror preferred over live pfctl; array not Generator; 12.2 MiB peak on 200k lines.
  - Step 2 red: 12 helper-contract tests error against the pre-fix tree.
- Independent small-tier verifier gates on every step, including executed adversarial mutations: deletes-first swap and predicate-bypass each flipped exactly the guarding tests; a missing-`finally` variant flipped only the abandoned-iteration cleanup test.
- Live Tier-B legs on the local pool (3 new `ui_e2e` tests: v4 + v6 double punch, not-blocked unlock honesty):
  - GREEN (branch tip `3bc11b9a`): `3 passed, 453 deselected in 82.76s`.
  - RED (tests cherry-picked onto unfixed devel, ref `tmp/red-verify-1467` = `760e00e2`): `3 failed`, failing on the discriminating assertions — `198.18.200.7 still matches pf table pfB_uiipunlock4dp_v4 after the SECOND unlock` (v6 analog identical) and `203.0.113.5 recorded in /tmp/ip_unlock after an unlock of an unblocked host`.
- Full gates green at every step (`php -l`, PHPUnit, PHPStan, PHPCS, pytest/ruff/mypy for the smoke commit).

## Follow-up

A dated ADR-53 amendment (snapshot source, apply ordering, streaming — superseding the §2.1 mirror-first decision) plus the architecture-notes update lands as a docs-class commit on devel after this merges, per the ADR-38 Amendment 3 precedent.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IP suppression updates to apply live table changes safely and report failures accurately.
  * Prevented unlock records from being saved when an IP is not currently blocked or when the live update fails.
  * Fixed repeated IPv4 and IPv6 unlocks so earlier carve-outs remain effective without requiring a reload.
  * Improved handling of large live tables by streaming table data, reducing memory usage.
* **Reliability**
  * Added safer rollback and execution handling for live table updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->