### PR TITLE
Burn the level-2 variable.undefined PHPStan cohort (87 entries -> 0)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -337,27 +337,27 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
 
 		-
-			message: '#^Undefined variable\: \$ftotal4$#'
+			message: '#^Variable \$ftotal4 might not be defined\.$#'
 			identifier: variable.undefined
-			count: 2
+			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
 
 		-
-			message: '#^Undefined variable\: \$ftotal6$#'
+			message: '#^Variable \$ftotal6 might not be defined\.$#'
 			identifier: variable.undefined
-			count: 2
+			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
 
 		-
-			message: '#^Undefined variable\: \$options4$#'
+			message: '#^Variable \$options4 might not be defined\.$#'
 			identifier: variable.undefined
-			count: 4
+			count: 3
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
 
 		-
-			message: '#^Undefined variable\: \$options6$#'
+			message: '#^Variable \$options6 might not be defined\.$#'
 			identifier: variable.undefined
-			count: 4
+			count: 3
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,12 +181,6 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$domain in empty\(\) is never defined\.$#'
-			identifier: empty.variable
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Variable \$folder might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,6 +181,12 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
+			message: '#^Variable \$domain in empty\(\) is never defined\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
 			message: '#^Variable \$folder might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -301,7 +307,7 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$src_ip in empty\(\) is never defined\.$#'
+			message: '#^Variable \$src_ip in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,12 +31,6 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Deprecated in PHP 8\.0\: Required parameter \$domain follows optional parameter \$mode\.$#'
-			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Deprecated in PHP 8\.0\: Required parameter \$filename_unlock follows optional parameter \$r_type\.$#'
 			identifier: parameter.requiredAfterOptional
 			count: 1
@@ -55,31 +49,7 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Deprecated in PHP 8\.0\: Required parameter \$logfile follows optional parameter \$line\.$#'
-			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Deprecated in PHP 8\.0\: Required parameter \$logtype follows optional parameter \$pflex\.$#'
-			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Deprecated in PHP 8\.0\: Required parameter \$oline follows optional parameter \$line\.$#'
-			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Deprecated in PHP 8\.0\: Required parameter \$req_agent follows optional parameter \$mode\.$#'
-			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Deprecated in PHP 8\.0\: Required parameter \$src_ip follows optional parameter \$mode\.$#'
 			identifier: parameter.requiredAfterOptional
 			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -127,30 +97,6 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Undefined variable\: \$logtype$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Undefined variable\: \$src_ip$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$alias might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$asn might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Variable \$asn_ex in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
@@ -163,68 +109,8 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$db_handle might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$details might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$dir might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$folder might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$geoip might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$int might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$iplog might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$l_type might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Variable \$labels in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$lastdnsblclear might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$lastipclear might not be defined\.$#'
-			identifier: variable.undefined
 			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
@@ -235,62 +121,14 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$log might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$logtab might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$new_rules_nocreated might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$orig_rules_nocreated might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$pfb_alias might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Variable \$pfb_include in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$pfb_query might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
 			message: '#^Variable \$pfb_tables in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$pfbfolder might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Variable \$resolved_host might not be defined\.$#'
-			identifier: variable.undefined
 			count: 2
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
@@ -307,69 +145,9 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$u_msg might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
-
-		-
 			message: '#^Parameter \#1 \$string of function str_pad expects string, int given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Undefined variable\: \$coptions4$#'
-			identifier: variable.undefined
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Undefined variable\: \$coptions6$#'
-			identifier: variable.undefined
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Undefined variable\: \$et_options$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Variable \$ftotal4 might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Variable \$ftotal6 might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Variable \$options4 might not be defined\.$#'
-			identifier: variable.undefined
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Variable \$options6 might not be defined\.$#'
-			identifier: variable.undefined
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Variable \$argv might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-
-		-
-			message: '#^Variable \$et_options might not be defined\.$#'
-			identifier: variable.undefined
-			count: 3
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
 
 		-
@@ -391,51 +169,9 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
 
 		-
-			message: '#^Variable \$alert_stats might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
 			message: '#^Variable \$alert_view in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$bg might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$colspan might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$column_title might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$dnsblfilterlimitentries might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$dnsfilterlimitentries might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$dstport might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
 			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
 
 		-
@@ -445,75 +181,9 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
 
 		-
-			message: '#^Variable \$extra_txt might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$fcounter might not be defined\.$#'
-			identifier: variable.undefined
-			count: 4
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
 			message: '#^Variable \$filter_unified in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$ipfilterlimitentries might not be defined\.$#'
-			identifier: variable.undefined
-			count: 4
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$max_table_entries might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$p_query_port might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$pfbdenycnt might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$pfbdnscnt might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$pfbdnsreplycnt might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$pfbfilterlimit might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$pfbmatchcnt might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$pfbpermitcnt might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
 			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
 
 		-
@@ -529,51 +199,9 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
 
 		-
-			message: '#^Variable \$pfbunicnt might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$rtype might not be defined\.$#'
-			identifier: variable.undefined
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$savemsg might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
-			message: '#^Variable \$table might not be defined\.$#'
-			identifier: variable.undefined
-			count: 6
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-
-		-
 			message: '#^Variable \$blacklist_types in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-
-		-
-			message: '#^Variable \$cat might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-
-		-
-			message: '#^Variable \$input_errors might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-
-		-
-			message: '#^Variable \$savemsg might not be defined\.$#'
-			identifier: variable.undefined
-			count: 3
 			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
 
 		-
@@ -589,33 +217,9 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
 
 		-
-			message: '#^Variable \$input_errors might not be defined\.$#'
-			identifier: variable.undefined
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
-
-		-
-			message: '#^Variable \$maxmind_verify might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
-
-		-
-			message: '#^Variable \$r_id might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
-
-		-
 			message: '#^Variable \$rowid in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
-
-		-
-			message: '#^Variable \$variable might not be defined\.$#'
-			identifier: variable.undefined
-			count: 6
 			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
 
 		-
@@ -637,57 +241,9 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
 
 		-
-			message: '#^Variable \$a_aliasname might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Variable \$a_cron might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Variable \$a_description might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Variable \$a_header might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Variable \$a_url might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
 			message: '#^Variable \$customlist in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Variable \$final might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Variable \$geoip_isos might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-
-		-
-			message: '#^Variable \$input_errors might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
 			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
 
 		-
@@ -707,84 +263,6 @@ parameters:
 			identifier: parameter.requiredAfterOptional
 			count: 1
 			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
-
-		-
-			message: '#^Variable \$p_tr_style might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
-
-		-
-			message: '#^Variable \$p_type might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
-
-		-
-			message: '#^Variable \$options_log_max_dnsbl_parse_err might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Variable \$options_log_max_dnslog might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Variable \$options_log_max_dnsreplylog might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Variable \$options_log_max_errlog might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Variable \$options_log_max_extraslog might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Variable \$options_log_max_ip_blocklog might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Variable \$options_log_max_ip_matchlog might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Variable \$options_log_max_ip_parse_err might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Variable \$options_log_max_ip_permitlog might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Variable \$options_log_max_log might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
-
-		-
-			message: '#^Variable \$options_log_max_unilog might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_general.php
 
 		-
 			message: '#^Variable \$v4suppression in empty\(\) always exists and is not falsy\.$#'
@@ -829,18 +307,6 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_update.php
 
 		-
-			message: '#^Variable \$ptype might not be defined\.$#'
-			identifier: variable.undefined
-			count: 8
-			path: src/usr/local/www/pfblockerng/www/dnsbl_default.php
-
-		-
-			message: '#^Variable \$ts might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/pfblockerng/www/dnsbl_default.php
-
-		-
 			message: '#^Parameter \#2 \$timestamp of function date expects int\|null, string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -867,23 +333,5 @@ parameters:
 		-
 			message: '#^Parameter \#2 \.\.\.\$arg1 of function min expects non\-empty\-array, 100 given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
-
-		-
-			message: '#^Variable \$key might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
-
-		-
-			message: '#^Variable \$type might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
-
-		-
-			message: '#^Variable \$widgetname might not be defined\.$#'
-			identifier: variable.undefined
 			count: 1
 			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14675,6 +14675,7 @@ function pfb_daemon_dnsbl() {
 		$checkpos	= 3; 	// Pre Lighttpd v1.4.47
 		// INIT-GAP (#1497): assigned per-line further down, read again (via
 		// pfb_filter()) on a LATER line under a checkpos-gated branch.
+		$domain		= '';
 		$src_ip		= '';
 
 		while (!feof($h_handle)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14899,6 +14899,11 @@ function pfb_open_sqlite($table, $message) {
 	// ADR-60: these writes bypass pfb_logger() entirely, so they stamp themselves.
 	$now = pfb_log_iso_timestamp();
 
+	// issue #1494: both connection attempts below can throw, leaving $db_handle
+	// unset at the `if ($db_handle)` check -- init here so that path returns
+	// FALSE cleanly instead of reading an undefined variable.
+	$db_handle = NULL;
+
 	try {
 		$db_handle = new SQLite3($database);
 		$db_handle->busyTimeout("{$pfb['sqlite_timeout']}");
@@ -17185,6 +17190,10 @@ function sync_package_pfblockerng($cron='') {
 				}
 			}
 
+			// issue #1494: the empty-header skip message below reads $logtab before
+			// its per-row assignment when the very first row hits that branch.
+			$logtab = '';
+
 			foreach ($lists as $list) {
 
 				// Reset variables once per alias
@@ -18679,7 +18688,9 @@ function sync_package_pfblockerng($cron='') {
 						if ($asn_run_once && $row['format'] == 'asn') {
 							$mmsg = 'To utilize the ASN functionality, you must register for a free IPinfo Account. Review IP Tab for more information.';
 							if (empty($pfb['asn_token'])) {
-								pfb_logger($mmsg, $logtype);
+								// issue #1494: $logtype had zero assignments in this function;
+								// sibling credential-notice call (MaxMind, above) uses level 1.
+								pfb_logger($mmsg, 1);
 								file_notice('pfBlockerNG ASN', $mmsg, 'pfBlockerNG', '/pfblockerng/pfblockerng_ip.php', 2);
 							}
 							$asn_run_once = FALSE;
@@ -19848,7 +19859,7 @@ function sync_package_pfblockerng($cron='') {
 	// If 'Rule Changes' are found, utilize the 'filter_configure()' function, if not, utilize 'pfctl replace' command
 	// Captured here (before the if/else) so it is always defined at the post-hook emit.
 	$pfb_ip_unlock_forced = FALSE;
-	if ($pfb['autorules'] && $orig_rules_nocreated != $new_rules_nocreated || $pfb['enable'] == '' || $pfb['remove']) {
+	if ($pfb['autorules'] && ($orig_rules_nocreated ?? []) != ($new_rules_nocreated ?? []) || $pfb['enable'] == '' || $pfb['remove']) {
 
 		if (!$pfb['save']) {
 			$log = "\n===[  Aliastables / Rules  ]================================\n\n";

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1339,6 +1339,10 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			// permit — the validation-time and fetch-time verdicts agree (pinned by
 			// FeedFilterParityTest).
 			$is_RSYNC = FALSE;
+			// INIT-GAP (#1497): $is_RSYNC is only ever TRUE via the branch below
+			// that assigns $rsync, but that correlation isn't visible to static
+			// analysis at the $rsync[0]/[1] read further down.
+			$rsync = array();
 			if (strpos($input, '::') !== FALSE && !$escape) {
 				$rsync = explode('::', $input);
 				if (count($rsync) == 2 && !empty($rsync[0]) && filter_var($rsync[0], FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)) {
@@ -13982,6 +13986,21 @@ function pfb_daemon_filterlog() {
 	$line_cnt	= 0;
 	$rule_list	= $rule_list['other'] = array();
 
+	// INIT-GAP (#1497): each of these is assigned per-line inside the
+	// `if ($dup_entry == '+')` branch below, but read again OUTSIDE that
+	// branch (unconditional write/syslog emit) -- init here so a duplicate
+	// (or the very first) stdin line never reads an undefined variable.
+	$details	= '';
+	$iplog		= '';
+	$log		= '';
+	$dir		= '';
+	$int		= '';
+	$geoip		= '';
+	$pfb_alias	= '';
+	$pfb_query	= array();
+	$resolved_host	= '';
+	$asn		= '';
+
 	if (file_exists('/usr/local/sbin/clog_pfb')) {
 
 		// Parse full filter.log on first run, otherwise only parse new filter.log events
@@ -14197,6 +14216,14 @@ function pfb_daemon_filterlog() {
 						$folder = pfb_ip_match_folders() . " {$pfb['nativedir']}/*";
 						$iplog	= "{$pfb['ip_matchlog']}";
 						$l_type = 'Match';
+					}
+					// INIT-GAP (#1497): $d[6] is always one of block/pass/unkn(%u) in
+					// practice, but the chain above has no else -- default these so
+					// they are defined for any other value. Behaviour-preserving.
+					else {
+						$folder = '';
+						$iplog	= '';
+						$l_type = 'Unknown';
 					}
 
 					if ($d[8] == 4) {
@@ -14646,6 +14673,9 @@ function pfb_daemon_dnsbl() {
 		$lighty_58	= FALSE;
 		$lighty_59	= FALSE;
 		$checkpos	= 3; 	// Pre Lighttpd v1.4.47
+		// INIT-GAP (#1497): assigned per-line further down, read again (via
+		// pfb_filter()) on a LATER line under a checkpos-gated branch.
+		$src_ip		= '';
 
 		while (!feof($h_handle)) {
 			$pfb_buffer = @fgets($h_handle);
@@ -15501,6 +15531,11 @@ function pfBlockerNG_clearsqlite($mode, $totalqueries = 0) {
 
 	// Format of todo array: database, error message, SQLite command
 	$todo = array();
+
+	// INIT-GAP (#1497): each is assigned only in its own $mode branch below,
+	// but read again in the $todo processing loop's matching $mode branch.
+	$lastipclear = '';
+	$lastdnsblclear = '';
 
 	// Clear SQLite database 'queries' entry and update totalqueries (+queries), if Unbound Resolver PID changed (Reload)
 	if ($mode == 'update_totalqueries') {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1339,10 +1339,6 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			// permit — the validation-time and fetch-time verdicts agree (pinned by
 			// FeedFilterParityTest).
 			$is_RSYNC = FALSE;
-			// INIT-GAP (#1497): $is_RSYNC is only ever TRUE via the branch below
-			// that assigns $rsync, but that correlation isn't visible to static
-			// analysis at the $rsync[0]/[1] read further down.
-			$rsync = array();
 			if (strpos($input, '::') !== FALSE && !$escape) {
 				$rsync = explode('::', $input);
 				if (count($rsync) == 2 && !empty($rsync[0]) && filter_var($rsync[0], FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14213,9 +14213,9 @@ function pfb_daemon_filterlog() {
 						$iplog	= "{$pfb['ip_matchlog']}";
 						$l_type = 'Match';
 					}
-					// INIT-GAP (#1497): $d[6] is always one of block/pass/unkn(%u) in
-					// practice, but the chain above has no else -- default these so
-					// they are defined for any other value. Behaviour-preserving.
+					// INIT-GAP (#1497): defined defaults for an out-of-format action
+					// (unreachable per the kernel filterlog format: $d[6] is always
+					// block/pass/unkn(%u)).
 					else {
 						$folder = '';
 						$iplog	= '';

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -412,6 +412,9 @@ if ($ufound) {
 // Upgrade OpenVPN and IPSec 'checkbox options' to pfBlockerNG In/Out interface selections
 update_status(" OpenVPN/IPSec interface selections...");
 $ufound = FALSE;
+// INIT-GAP (#1497): only assigned inside the nested !empty($pfb['config'])
+// block below, but read again (unconditionally, once $ufound) further down.
+$u_msg = '';
 
 $pfb_interfaces = PfbConfig::readSection('installedpackages/pfblockerng/config/0');
 if (!empty($pfb_interfaces)) {

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1665,6 +1665,14 @@ function pfblockerng_get_countries() {
 			unset(${'coptions' . $type});
 		}
 
+		// #1493 defect 2: the heredoc below reads $options4/$options6 once per
+		// continent, but the per-continent tail unconditionally unsets them
+		// (~2216) -- a continent whose coptions4/6 stayed empty (fopen failure,
+		// or genuinely no data) never re-enters the guarded block above to
+		// reassign them, so anything after the first continent needs this fill.
+		$options4 ??= ''; // @phpstan-ignore nullCoalesce.variable (dynamic ${'options4'} unset at the previous continent's tail is invisible to PHPStan)
+		$options6 ??= ''; // @phpstan-ignore nullCoalesce.variable (dynamic ${'options6'} unset at the previous continent's tail is invisible to PHPStan)
+
 $php_data = <<<EOF
 <?php
 /*

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -197,7 +197,7 @@ $pfb['extras'][4]['type']       = 'asn';
 // Next Available Extras Key value for Blacklist Category Downloads
 $next_key = $next_key_start = 5;
 
-if ($argv[1] == 'bl' || $argv[1] == 'bls') {
+if (isset($argv[1]) && ($argv[1] == 'bl' || $argv[1] == 'bls')) {
 
 	if (empty(pfb_filter($argv[2], PFB_FILTER_CSV, 'php'))) {
 		$argv[2] = '';
@@ -241,7 +241,7 @@ if ($argv[1] == 'bl' || $argv[1] == 'bls') {
 }
 
 // Call include file and collect updated Global settings
-if (in_array($argv[1], array('update', 'updateip', 'updatednsbl', 'dc', 'dcc', 'bu', 'uc', 'gc', 'al', 'asn', 'asn_shell', 'bl', 'bls', 'cron', 'ugc', 'pfb_trigger', 'tick', 'forcecheck'))) {
+if (isset($argv[1]) && in_array($argv[1], array('update', 'updateip', 'updatednsbl', 'dc', 'dcc', 'bu', 'uc', 'gc', 'al', 'asn', 'asn_shell', 'bl', 'bls', 'cron', 'ugc', 'pfb_trigger', 'tick', 'forcecheck'))) {
 	pfb_global();
 
 	$pfb['extras_update'] = FALSE;  // Flag when Extras (MaxMind/TOP1M) are updateded via cron job
@@ -1661,6 +1661,11 @@ function pfblockerng_get_countries() {
 			unset(${'coptions' . $type});
 		}
 
+		$options4 ??= '';
+		$options6 ??= '';
+		$ftotal4 ??= 0;
+		$ftotal6 ??= 0;
+
 $php_data = <<<EOF
 <?php
 /*
@@ -2217,7 +2222,7 @@ EOF;
 
 	sort($roptions4, SORT_STRING);
 	$eoa = count($roptions4);
-	$etoptions = '';
+	$et_options = '';
 	$count = 1;
 
 	foreach ($roptions4 as $option4) {

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1487,6 +1487,10 @@ function pfblockerng_uc_countries() {
 function pfblockerng_get_countries() {
 	global $g, $pfb;
 
+	$coptions4 = $coptions6 = array();
+	$options4 = $options6 = '';
+	$ftotal4 = $ftotal6 = 0;
+
 	$geoip_files = array (	'Africa'		=> "{$pfb['ccdir']}/Africa_v4.txt",
 				'Antarctica'		=> "{$pfb['ccdir']}/Antarctica_v4.txt",
 				'Asia'			=> "{$pfb['ccdir']}/Asia_v4.txt",
@@ -1660,11 +1664,6 @@ function pfblockerng_get_countries() {
 			}
 			unset(${'coptions' . $type});
 		}
-
-		$options4 ??= '';
-		$options6 ??= '';
-		$ftotal4 ??= 0;
-		$ftotal6 ??= 0;
 
 $php_data = <<<EOF
 <?php

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -79,9 +79,20 @@ $pfbmatchstat	= explode(',', $pfb['aglobal']['pfbmatchstat'])	?: array();
 $pfbdnsblstat	= explode(',', $pfb['aglobal']['pfbdnsblstat'])	?: array();
 $pfbdnsblreplystat = explode(',', $pfb['aglobal']['pfbdnsblreplystat']) ?: array();
 
-foreach ($aglobal_array as $type => $value) {
-	${"$type"} = $pfb['aglobal'][$type] != '' ? $pfb['aglobal'][$type] : $value;
-}
+// issue #1497: explicit assignments (was a ${"$type"} variable-variable loop
+// over $aglobal_array) -- PHPStan can't trace a variable-variable target, so
+// every read of these 9 names was flagged as undefined despite always being
+// set here. $aglobal_array itself stays (the save-handler loop below at
+// ~line 592 is a separate consumer that still iterates it).
+$pfbunicnt               = $pfb['aglobal']['pfbunicnt']               != '' ? $pfb['aglobal']['pfbunicnt']               : $aglobal_array['pfbunicnt'];
+$pfbdenycnt              = $pfb['aglobal']['pfbdenycnt']              != '' ? $pfb['aglobal']['pfbdenycnt']              : $aglobal_array['pfbdenycnt'];
+$pfbpermitcnt            = $pfb['aglobal']['pfbpermitcnt']            != '' ? $pfb['aglobal']['pfbpermitcnt']            : $aglobal_array['pfbpermitcnt'];
+$pfbmatchcnt             = $pfb['aglobal']['pfbmatchcnt']             != '' ? $pfb['aglobal']['pfbmatchcnt']             : $aglobal_array['pfbmatchcnt'];
+$pfbdnscnt               = $pfb['aglobal']['pfbdnscnt']               != '' ? $pfb['aglobal']['pfbdnscnt']              : $aglobal_array['pfbdnscnt'];
+$pfbdnsreplycnt          = $pfb['aglobal']['pfbdnsreplycnt']          != '' ? $pfb['aglobal']['pfbdnsreplycnt']          : $aglobal_array['pfbdnsreplycnt'];
+$ipfilterlimitentries    = $pfb['aglobal']['ipfilterlimitentries']    != '' ? $pfb['aglobal']['ipfilterlimitentries']    : $aglobal_array['ipfilterlimitentries'];
+$dnsblfilterlimitentries = $pfb['aglobal']['dnsblfilterlimitentries'] != '' ? $pfb['aglobal']['dnsblfilterlimitentries'] : $aglobal_array['dnsblfilterlimitentries'];
+$dnsfilterlimitentries   = $pfb['aglobal']['dnsfilterlimitentries']   != '' ? $pfb['aglobal']['dnsfilterlimitentries']   : $aglobal_array['dnsfilterlimitentries'];
 
 $alert_view	= 'alert';
 $alert_title	= '';
@@ -1232,6 +1243,12 @@ if (isset($_POST) && !empty($_POST)) {
 
 		$entry = '';
 		$table = '';
+		// issue #1497: every case that reaches the $pfb_found gate below sets $type
+		// unconditionally before any read of it; this file-scope name used to be
+		// masked by the top-of-file ${"$type"} counter loop's leftover PHP
+		// foreach-variable-persists value, which the #1497 explicit-assignment
+		// rewrite removed. Same hand-crafted-only class as $table above.
+		$type = '';
 
 		// IPv4/IPv6 validation
 		if ($entry = pfb_filter($_POST['domain'], PFB_FILTER_IP, 'alerts entry_delete', '', TRUE)) {
@@ -4476,10 +4493,9 @@ if (!$alert_summary):
 			// per-row limit ($ipfilterlimitentries != 0) AND real filter fields set.
 			// Otherwise the log genuinely scans to EOF (unbounded buffer unsafe), so both
 			// cases keep the single-pass streaming loop. See docs/misc/alerts-reports-pipeline.md.
-			// $ipfilterlimitentries is always genuinely set by this point (the dynamic
-			// ${"$type"} assignment near the top of this file, which PHPStan can't trace);
-			// this coalesce is a runtime no-op that keeps every read below provably defined.
-			$ipfilterlimitentries = $ipfilterlimitentries ?? 0;
+			// issue #1497: $ipfilterlimitentries is now an explicit top-of-page
+			// assignment (was a ${"$type"} variable-variable loop PHPStan couldn't
+			// trace), so it is provably defined here -- no coalesce needed.
 			$ip_two_pass = !$pfb['filterlogentries'] || ($ipfilterlimitentries != 0 && !empty($filterfieldsarray[0]));
 
 			if (!$ip_two_pass) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -86,6 +86,13 @@ foreach ($aglobal_array as $type => $value) {
 $alert_view	= 'alert';
 $alert_title	= '';
 $alert_summary	= FALSE;
+// The 'Collect Alert Statistics' block below (reached only when $alert_summary
+// is TRUE) always assigns this fresh; the stats-render section far below reads
+// it only under the identical $alert_summary condition. PHPStan can't trace
+// that two separate `if ($alert_summary)` blocks thousands of lines apart
+// agree, so this default keeps both reads provably defined without changing
+// which branch runs.
+$alert_stats	= array();
 $active		= array('alerts' => TRUE, 'unified' => FALSE, 'ip_block' => FALSE, 'ip_permit' => FALSE, 'ip_match' => FALSE,
 			'dnsbl' => FALSE, 'reply' => FALSE, 'dnsbl_reply_stat' => FALSE);
 
@@ -3326,6 +3333,9 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 			case 'Match':
 				$bg = strpos(config_get_path('system/webgui/webguicss'), 'dark') ? $pfb['unimatch2'] : $pfb['unimatch'];
 				break;
+			default:
+				$bg = '';
+				break;
 		}
 
 		if ($bg == 'none') {
@@ -4454,6 +4464,12 @@ if (!$alert_summary):
 	<?php
 
 			$p_query_port = '';
+			// $rtype is set above (case 'alert' of the switch($alert_view) block, same
+			// $logtype iteration) whenever this Block/Permit/Match section is reached;
+			// PHPStan can't trace that correlation, so this coalesce is a runtime no-op
+			// that keeps every read below provably defined -- same idiom the two-pass
+			// branch below already uses.
+			$rtype = $rtype ?? '';
 
 			// issue #809 scope guard: batching below only runs when a finite row bound
 			// exists -- non-filter mode (bound $pfbentries), or filter mode with a real
@@ -4580,9 +4596,8 @@ if (!$alert_summary):
 				// pfb_alerts_ip_replay_step() (pfblockerng.inc; decode contract documented
 				// there), unit-pinned by AlertsBufferReplayTest -- 'render' rows replay through
 				// the unchanged convert_ip_log() loop body, consulting the batched prefetch via
-				// pfb_ip_render_memos() first. $rtype is always set here (see the
-				// $ipfilterlimitentries coalesce note above; PHPStan can't trace it).
-				$rtype = $rtype ?? '';
+				// pfb_ip_render_memos() first. $rtype was already coalesced above (the
+				// $ipfilterlimitentries coalesce note), so it is provably defined here.
 				foreach ($ip_buffered as $ip_entry) {
 					$ip_step = pfb_alerts_ip_replay_step($ip_entry);
 					if (isset($ip_step['dup_add'])) {
@@ -4609,6 +4624,20 @@ if (!$alert_summary):
 		</tbody>
 		<tfoot>
 	<?php
+		// $logtype only ever takes the seven literal keys of the foreach array above
+		// (issue #809's same reasoning as $pfbentries's default), so every case below
+		// is exhaustive in practice -- but PHPStan can't narrow the switch subject to
+		// that literal union, so it treats the (unreachable) default as leaving these
+		// unset. Behaviour-neutral defaults keep the post-switch reads provably defined.
+		$colspan = '';
+		$fcounter = 0;
+		$pfbfilterlimit = FALSE;
+		// $rtype is set above (case 'alert' of the switch($alert_view) block) whenever
+		// $logtype is 'Block'/'Permit'/'Match' -- the only way the case below is
+		// reached -- but the tbody's own coalesce above only runs when file_exists()
+		// gates it TRUE (a fresh-install log-not-yet-created iteration skips it), so
+		// this file-scope read needs its own no-op coalesce.
+		$rtype = $rtype ?? '';
 		switch ($logtype) {
 			case 'Block':
 			case 'Permit':
@@ -4867,7 +4896,7 @@ foreach ($stats as $stat_type => $stype):
 
 						<?php if ($stype[3]): ?>
 						<th style="width: 2%; text-align: center;">
-							<?
+							<?php
 							$column_title = 'GeoIP';
 							if ($stat_type == 'dnsbldomain' || $stat_type == 'dnsblevald') {
 								$column_title = 'Type';

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1224,6 +1224,7 @@ if (isset($_POST) && !empty($_POST)) {
 	elseif (isset($_POST['entry_delete']) && !empty($_POST['entry_delete'])) {
 
 		$entry = '';
+		$table = '';
 
 		// IPv4/IPv6 validation
 		if ($entry = pfb_filter($_POST['domain'], PFB_FILTER_IP, 'alerts entry_delete', '', TRUE)) {
@@ -1269,6 +1270,12 @@ if (isset($_POST) && !empty($_POST)) {
 				}
 			case 'delete_domainwildcard':
 				$type = 'DNSBL Whitelist';
+				// $savemsg is always set below when this case is reached directly (the
+				// condition is a tautology on that path) or already set by the
+				// 'delete_domain' fallthrough above; PHPStan can't trace either
+				// correlation, so this coalesce is a runtime no-op that keeps the
+				// post-switch read provably defined.
+				$savemsg = $savemsg ?? '';
 				if ($_POST['entry_delete'] == 'delete_domainwildcard') {
 					$savemsg = "The Wildcard Domain [ .{$entry} ] has been deleted from the {$type} customlist!";
 					if (isset($clists['dnsblwhitelist']['data']['.' . $entry]) ||
@@ -1392,6 +1399,7 @@ if (isset($_POST) && !empty($_POST)) {
 				break;
 			default:
 				$pfb_found = FALSE;
+				$savemsg = gettext('Cannot Delete this entry, invalid delete action.');
 				break;
 		}
 
@@ -1540,6 +1548,10 @@ if (isset($_POST) && !empty($_POST)) {
 			exec("{$pfb['pfctl']} -t {$table_esc} -T add " . escapeshellarg($ip) . ' 2>&1');
 			pfb_unlock('lock', 'ip', $ip, $table, $ip_unlock);
 			$savemsg = "The IP [ {$ip} ] has been re-locked into table [ {$table} ]!";
+		}
+
+		else {
+			$savemsg = gettext('Cannot Lock/Unlock - Invalid action.');
 		}
 
 		header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
@@ -2913,6 +2925,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	// Cleanup port output
 	if ($fields[6] == 'ICMP' || $fields[6] == 'ICMPV6') {
 		$srcport = '';
+		$dstport = '';
 	} else {
 		$srcport = ":" . pfb_hsc($fields[9]);
 		$dstport = ":" . pfb_hsc($fields[10]);
@@ -3449,7 +3462,6 @@ if ($alert_summary && strpos($alert_view, 'ip_') !== FALSE) {
 		. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Alias</a>&emsp;'
 		. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
 		. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
-		. "{$extra_txt}"
 	));
 	$form->add($section);
 }
@@ -4260,6 +4272,7 @@ if (!$alert_summary):
 	<?php
 		// Create Unified Report
 		$handle = FALSE;
+		$p_query_port = '';
 		if ($logtype == 'Unified' && file_exists("{$pfb_log}")) {
 	?>
 			<thead>
@@ -4623,11 +4636,13 @@ if (!$alert_summary):
 					if ($ipfilterlimit && $dnsblfilterlimit && $dnsfilterlimit) {
 						$pfbfilterlimit = TRUE;
 					}
+					$fcounter = 0;
 					foreach ($counter as $c) {
 						$fcounter += $c;
 					}
 				}
 				else {
+					$pfbfilterlimit = FALSE;
 					$fcounter = $counter['Unified'];
 				}
 				break;
@@ -4868,10 +4883,13 @@ foreach ($stats as $stat_type => $stype):
 				</thead>
 				<tbody>
 					<?php
+					// issue #1495: default FALSE -- when the first non-chart stat category
+					// has no data (routine on a fresh install), the block below never runs,
+					// and $max_table_entries must still be defined for the tfoot check.
+					$max_table_entries = FALSE;
 					if (!empty($alert_stats[$alert_view][$stat_type])) {
 
 						$table_entries = 0;
-						$max_table_entries = FALSE;
 						foreach ($alert_stats[$alert_view][$stat_type] as $data => $data_count) {
 
 							if ($pfbmaxtable != 'max') {

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -145,17 +145,16 @@ $options_blacklist_lang		= ['EN' => 'English', 'DE' => 'German', 'FR' => 'French
 $options_blacklist_freq		= ['Never' => 'Never', 'EveryDay' => 'Once a day (Random hour)', 'Weekly' => 'Weekly (Sunday)'];
 $options_blacklist_logging	= ['enabled' => 'Enabled', 'disabled' => 'Disabled'];
 
+// Unconditional (not just inside the $_POST branch below): $input_errors is read
+// at print_input_errors() on every GET page load too (issue #1496).
+$savemsg = '';
+$input_errors = array();
+
 if ($_POST && !$_POST['enableall'] && !$_POST['disableall']) {
 
 	$rowid		= 0;
 	$a_list		= array();
 	$config_mod	= FALSE;
-	if (isset($input_errors)) {
-		unset($input_errors);
-	}
-	if (isset($savemsg)) {
-		unset($savemsg);
-	}
 
 	if (isset($_POST['blacklist_enable'])) {
 		if (!array_key_exists($_POST['blacklist_enable'], $options_blacklist_enable)) {
@@ -289,7 +288,10 @@ if ($_POST && !$_POST['enableall'] && !$_POST['disableall']) {
 		}
 	}
 
-	if ($config_mod && !isset($input_errors)) {
+	// issue #1496: $input_errors is now unconditionally an array (see top-of-file
+	// init) -- isset() would always be TRUE and permanently block save; empty()
+	// preserves the original "no errors were recorded" semantics.
+	if ($config_mod && empty($input_errors)) {
 
 		write_config('[ pfBlockerNG ] save DNSBL Category settings');
 		pfb_mark_pending_changes();	// applies on the next Update, not on save

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -454,6 +454,9 @@ foreach ($blacklist_types as $type => $setting) {
 
 	// Build array of Blacklist categories and descriptions by language
 	$data = array();
+	// issue #1497: read at 469/474 if a malformed feed ever orders a DESC/NAME
+	// line before its NAME: line; every real feed has NAME: first per line.
+	$cat = '';
 	if (isset($blacklist_types[$type]['CONTENTS']) && !empty($blacklist_types[$type]['CONTENTS'])) {
 		foreach ($blacklist_types[$type]['CONTENTS'] as $line) {
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -456,7 +456,7 @@ foreach ($blacklist_types as $type => $setting) {
 	$data = array();
 	// issue #1497: read at 469/474 if a malformed feed ever orders a DESC/NAME
 	// line before its NAME: line; every real feed has NAME: first per line.
-	$cat = '';
+	$cat = array();
 	if (isset($blacklist_types[$type]['CONTENTS']) && !empty($blacklist_types[$type]['CONTENTS'])) {
 		foreach ($blacklist_types[$type]['CONTENTS'] as $line) {
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -385,6 +385,10 @@ if (isset($savemsg)) {
 	<div id="<?=$pageid;?>" class="panel-body">
 
 		<?php
+			// issue #1497: read at 565, reachable only when $gtype == 'geoip' (same
+			// guard as below) -- but that guard is far enough away, across a table
+			// render loop, that PHPStan can't correlate the two.
+			$maxmind_verify = FALSE;
 			// Maxmind credential verification
 			if ($gtype == 'geoip') {
 				$maxmind_verify = TRUE;
@@ -419,7 +423,12 @@ if (isset($savemsg)) {
 			</thead>
 			<tbody>
 
-				<?php if (!empty($rowdata) && !empty($rowdata[0])):
+				<?php
+				// issue #1497: read at 594 ($r_id +1, the "Add" link). Both branches
+				// below provably assign it (foreach over a proven non-empty $rowdata,
+				// or the else's explicit -1); this default changes nothing at runtime.
+				$r_id = -1;
+				if (!empty($rowdata) && !empty($rowdata[0])):
 					foreach ($rowdata as $r_id => $row): ?>
 
 				<tr style="vertical-align: top"<?php if ($gtype != 'geoip'): ?> class="sortable"<?php endif; ?> id="pfb_r<?=$r_id;?>">

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -175,9 +175,10 @@ if (!empty($action) && isset($gtype) && isset($rowid)) {
 			exit;
 
 		case 'update':
-			if (isset($input_errors)) {
-				unset($input_errors);
-			}
+			// issue #1496: reads at 251/286/300 hit undefined on normal AJAX
+			// act=update/reorder flows with no init (the old idiom was a no-op).
+			// No isset($input_errors) consumer downstream -- safe unconditional init.
+			$input_errors = array();
 			if (is_array($rowdata)) {
 				$cron_values = array(	'Never',
 							'01hour',
@@ -213,6 +214,10 @@ if (!empty($action) && isset($gtype) && isset($rowid)) {
 								$variable = $k_field[0];
 							} else {
 								$input_errors[] = "Failed Variable: " . htmlspecialchars($k_field[0]);
+								// issue #1496: mirrors the sibling continue below (!is_string($value))
+								// -- without it, switch ($variable) runs with $variable undefined on
+								// an invalid prefix, producing a warning plus a second garbled error.
+								continue;
 							}
 
 							// Validate Rowid

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -1071,6 +1071,10 @@ if (empty($input_errors) && (empty($rowdata[$rowid]['sort']) || $rowdata[$rowid]
 	ksort($new_enabled, SORT_NATURAL | SORT_FLAG_CASE);
 
 	$new = $new_enabled + $new_disabled;
+	// issue #1497: read at 1077; $new is never empty here ($rowdata[$rowid]['row']
+	// always has at least the placeholder row added above), but PHPStan can't
+	// prove that -- array() (not '': $final[] appends, which fatals on a string).
+	$final = array();
 	foreach ($new as $key => $data) {
 		$final[] = $data;
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -77,6 +77,10 @@ $rowdata	= array();
 $rowid		= 0;
 $id		= 0;
 $action		= $gtype = $atype = $chg_state = '';
+// issue #1496: unconditional -- read on save (752) and every GET render (940).
+$input_errors	= array();
+// issue #1496: default for the unconditional JS interpolation near the page bottom.
+$geoip_isos	= '';
 
 if (isset($_GET)) {
 	if (isset($_GET['rowid']) && !empty($_GET['rowid'])) {
@@ -191,6 +195,9 @@ if (($action == 'add' || $action == 'addgroup') && !empty($atype) && !isset($_PO
 
 	$pfb_found	= FALSE;
 	$all_group	= $new_group = array();
+	// issue #1496: reads at 275-284/319-321 when a stale-atype add/addgroup
+	// (bookmarked link after a catalog change) finds no matching feed/alias below.
+	$a_aliasname	= $a_description = $a_cron = $a_url = $a_header = '';
 
 	$rowdata	= PfbConfig::readSection("installedpackages/{$conf_type}/config");
 
@@ -446,9 +453,9 @@ if ($_POST && isset($_POST['save'])) {
 
 	$pconfig = $_POST;
 	$line = 1;
-	if (isset($input_errors)) {
-		unset($input_errors);
-	}
+	// issue #1496: $input_errors is now unconditionally initialised top-of-file
+	// (array()); the old unset() here would have undone that. Nothing appends to
+	// it before this point, so no reset is needed.
 	if (isset($savemsg)) {
 		unset($savemsg);
 	}
@@ -624,8 +631,8 @@ if ($_POST && isset($_POST['save'])) {
 	// Existence + type are resolved from the configuration (pfb_alias_type), NOT is_alias()
 	// (empty $aliastable cache here) nor alias_get_type() (reserved system tables would
 	// wrongly pass) — see pfb_adv_alias_field_errors().
-	// Append (not array_merge): $input_errors is left unset until the first error so the
-	// later isset($input_errors) checks hold — appending auto-vivifies only on a real error.
+	// Append (not array_merge): keeps $input_errors as a flat, growing list --
+	// this loop's errors must not clobber ones already recorded above.
 	foreach (pfb_adv_alias_field_errors($_POST) as $pfb_alias_error) {
 		$input_errors[] = $pfb_alias_error;
 	}
@@ -1047,8 +1054,11 @@ if (empty($rowdata[$rowid]['row'])) {
 							'header'	=> '' ) );
 }
 
+// issue #1496: $input_errors is now unconditionally an array -- isset() would
+// always be TRUE and permanently disable the sort/rebuild below; empty()
+// preserves the original "no errors were recorded" semantics.
 // Sort row by Header/Label field followed by Enabled/Disabled State settings
-if (!isset($input_errors) && (empty($rowdata[$rowid]['sort']) || $rowdata[$rowid]['sort'] == 'sort')) {
+if (empty($input_errors) && (empty($rowdata[$rowid]['sort']) || $rowdata[$rowid]['sort'] == 'sort')) {
 	$new_disabled = $new_enabled = array();
 	foreach ($rowdata[$rowid]['row'] as $key => $data) {
 		if ($data['state'] == 'Disabled') {

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -824,6 +824,9 @@ print ($section);
 			<tbody>
 
 				<?php
+				// issue #1496: read at 848 on the first row of every render; only ever
+				// assigned at the tail of the loop below (previous-row tracking).
+				$p_type = '';
 				$p_aliasname = '';
 				// Only the active type's custom (unmatched user-defined) feeds (type-scoped body).
 				if (!empty($ex_feeds)):

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -312,6 +312,10 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 	$p_type = '';
 	foreach ($info as $aliasname => $data):
 		$p_aliasname = '';
+		// issue #1497: read at 396 on the first alt-URL row; only ever assigned at
+		// the loop tail (606, previous-row tracking) -- a malformed-data edge on
+		// the very first iteration otherwise leaves it undefined.
+		$p_tr_style = '';
 		if (!isset($data['feeds'])) {
 			continue;
 		}

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -149,6 +149,7 @@ if ($_POST) {
 			if (strpos($s_option, 'log_max_') !== FALSE) {
 				$query = $options_log_types;
 			} else {
+				// @phpstan-ignore variable.undefined, variable.undefined, variable.undefined, variable.undefined, variable.undefined, variable.undefined, variable.undefined, variable.undefined, variable.undefined, variable.undefined, variable.undefined (11x: the strpos guard above consumes all log_max_* keys before this line runs; PHPStan doesn't narrow the literal union, so it still considers all 11 log_max_* completions reachable here)
 				$query = ${"options_$s_option"};
 			}
 

--- a/src/usr/local/www/pfblockerng/www/dnsbl_default.php
+++ b/src/usr/local/www/pfblockerng/www/dnsbl_default.php
@@ -25,6 +25,13 @@
 	<meta http-equiv="content-Type" content="text/html; charset=UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
+	<?php
+	// issue #1497: includer-provided (www/index.php always defines both before
+	// include()ing this template -- $ptype at $ptype['type'] = ...; $ts inside
+	// its dnsbl.log search loop, defaulted for the no-log-yet case).
+	/** @var array<string,string> $ptype */
+	/** @var string $ts */
+	?>
 	<?php if ($ptype['type'] == '-'): ?>
 	<meta http-equiv="refresh" content="1">
 	<?php endif; ?>

--- a/src/usr/local/www/pfblockerng/www/index.php
+++ b/src/usr/local/www/pfblockerng/www/index.php
@@ -38,6 +38,10 @@ foreach (array('HTTP_HOST', 'HTTP_REFERER', 'HTTP_USER_AGENT', 'REMOTE_ADDR') as
 }
 
 $ptype['type'] = $ptype['group'] = $ptype['evald'] = $ptype['feed'] = '-';
+// issue #1496: the included dnsbl_default.php template interpolates $ts
+// unconditionally; the file_exists() block below is the only assigner, so a
+// fresh install (no log yet) hit this undefined on every DNSBL block-page.
+$ts = '';
 if (file_exists('/var/log/pfblockerng/dnsbl.log')) {
 	for ($i=0; $i <= 5; $i++) {
 

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -478,6 +478,11 @@ function pfBlockerNG_get_failed() {
 		$tab6 = "\t\t\t\t\t";
 		$tab7 = "\t\t\t\t\t\t";
 		$counter = 1;
+		// issue #1497: read at the link build below only when $pfb_found is TRUE,
+		// which is set in the same loop iteration that assigns both -- provably
+		// paired, but PHPStan can't correlate that across the nested foreach/break 2.
+		$key = '';
+		$type = '';
 
 		foreach ($entries as $entry) {
 			$text = htmlspecialchars($entry['message']);

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -1085,6 +1085,10 @@ function pfBlockerNG_get_table($mode='', $pfb_table) {
 
 <!-- Widget customization settings wrench -->
 </div>
+<?php
+// issue #1497: pfSense dashboard widget-include convention provides $widgetname.
+/** @var string $widgetname */
+?>
 <div id="widget-<?=$widgetname?>_panel-footer" class="panel-footer collapse">
 
 <form action="/widgets/widgets/pfblockerng.widget.php" method="post" class="form-horizontal">

--- a/tests/php/AlertsIpConvertPrefetchParityTest.php
+++ b/tests/php/AlertsIpConvertPrefetchParityTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/PfbNoPhpWarningTrait.php';
+
 /**
  * End-to-end producer<->consumer parity for the issue #809 Phase 3b Alerts IP-table
  * prefetch (PR #825 review nitpick T3): IpPrefetchTest.php pins pfb_ip_prefetch() and
@@ -37,6 +39,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_render_memo')]
 final class AlertsIpConvertPrefetchParityTest extends TestCase
 {
+	use PfbNoPhpWarningTrait;
+
 	private string $tmpDir;
 	private string $denydir;
 	private string $nativedir;
@@ -594,6 +598,31 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 			$html,
 			"expected the rendered row to still attribute this match event to the matchdir feed "
 				. "'Ads_v4', got:\n{$html}"
+		);
+	}
+
+	/**
+	 * Issue #1495 defect 1: an ICMP/ICMPv6 row never assigns $dstport (only
+	 * $srcport is cleared in that branch, ~line 2915), so the non-Unified row
+	 * template's "{$fields[98]}{$dstport}" interpolation (~line 3299) reads an
+	 * undefined variable -- a PHP E_WARNING on every rendered ICMP block/permit/
+	 * match event. Routine on any firewall logging ICMP blocks (#1495 evidence).
+	 */
+	public function test_icmp_row_renders_without_undefined_dstport_warning(): void
+	{
+		file_put_contents("{$this->denydir}/DenyFeedIcmp.txt", "192.0.2.99\n");
+
+		$fields = $this->rawFields([
+			7 => 'ICMP', 8 => '192.0.2.99', 15 => '192.0.2.99',
+			14 => 'pfB_Icmp_v4', 16 => 'DenyFeedIcmp',
+		]);
+
+		[, $html] = $this->assertNoPhpWarning(fn () => $this->render($fields, 'Block'));
+
+		$this->assertStringContainsString(
+			'192.0.2.99',
+			$html,
+			"expected the ICMP row to still render the evaluated IP, got:\n{$html}"
 		);
 	}
 }

--- a/tests/php/CategoryEditAutoSortTest.php
+++ b/tests/php/CategoryEditAutoSortTest.php
@@ -33,7 +33,7 @@ final class CategoryEditAutoSortTest extends TestCase
 		if (!function_exists('pfb_category_oracle_auto_sort')) {
 			if (!preg_match(
 				'/\/\/ Sort row by Header\/Label field followed by Enabled\/Disabled State settings\n'
-				. '(if \(!isset\(\$input_errors\).*?\$rowdata\[\$rowid\]\[\'row\'\] = \$final;\n)/s',
+				. '(if \(empty\(\$input_errors\).*?\$rowdata\[\$rowid\]\[\'row\'\] = \$final;\n)/s',
 				$src,
 				$m
 			)) {

--- a/tests/php/CategoryPostdataInvalidPrefixGuardTest.php
+++ b/tests/php/CategoryPostdataInvalidPrefixGuardTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/PfbNoPhpWarningTrait.php';
+
+/**
+ * pfblockerng_category.php's `act=update` postdata foreach (issue #1496 defect 2):
+ * an invalid variable-name prefix (a key like "bogus-0", e.g. a stale/hand-edited
+ * AJAX payload) hits the `else` at the "Validate Variable names" check without the
+ * `continue;` its sibling guard (the "Failed Value" `!is_string($value)` check,
+ * a few lines below) already has. Execution falls through to `switch ($variable)`
+ * with $variable never assigned on this iteration -- an undefined-variable warning,
+ * PLUS a second, garbled "Failed variable name:" error appended on top of the
+ * correct "Failed Variable:" one.
+ *
+ * The file carries top-level execution and cannot be require()d off-appliance
+ * (house precedent: CountryNetworksCountGuardTest.php, PfbOptionsHeredocMultiContinentTest.php).
+ * This test eval-extracts the postdata foreach fragment VERBATIM and POSITIONALLY
+ * (anchored on the foreach's own open/close braces plus the next statement's
+ * comment as an end-anchor) from the real shipped source, so it drives the actual
+ * fix landing in the right place rather than a hand-copied guess.
+ *
+ * Feature: an invalid variable-name-prefix key must short-circuit its iteration
+ *          with exactly one recorded error, never fall through to an undefined
+ *          $variable switch
+ *
+ *   Scenario: postdata key "bogus-0" (unrecognized prefix) -> no PHP warning,
+ *             $input_errors has exactly the one "Failed Variable" entry
+ */
+final class CategoryPostdataInvalidPrefixGuardTest extends TestCase
+{
+	use PfbNoPhpWarningTrait;
+
+	public static function setUpBeforeClass(): void
+	{
+		if (function_exists('pfb_category_postdata_oracle')) {
+			return;
+		}
+
+		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category.php';
+		$src = file_get_contents($path);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category.php');
+		}
+
+		// Anchored on the foreach's own braces (5 tabs) plus the next statement's
+		// comment as an end-anchor, so only the foreach block itself is captured --
+		// not the enclosing `if (!empty($post_data)...)`'s own closing brace.
+		if (!preg_match(
+			'/(foreach \(\$post_data as \$key => \$value\) \{.*?\n\t{5}\})\n\t{4}\}\n\n\t{4}\/\/ Save new Table order format/s',
+			$src,
+			$m
+		)) {
+			throw new RuntimeException('oracle extraction failed: the postdata foreach block was not found in pfblockerng_category.php');
+		}
+
+		eval(
+			'function pfb_category_postdata_oracle(array $post_data, string $gtype, array $cron_values, array $aliaslog_values): array {'
+			. ' $rowid = 0; $rowdata = array(); $input_errors = array();'
+			. $m[1]
+			. ' return $input_errors;'
+			. ' }'
+		);
+	}
+
+	public function testInvalidPrefixKeyDoesNotWarnAndRecordsExactlyOneError(): void
+	{
+		$cron_values = array('Never', '01hour', '02hours', '03hours', '04hours', '06hours', '08hours', '12hours', 'EveryDay', 'Weekly');
+		$aliaslog_values = array('enabled', 'disabled', 'disabled_log', 'nxdomain_log', 'nxdomain');
+
+		$input_errors = $this->assertNoPhpWarning(static function () use ($cron_values, $aliaslog_values): array {
+			return pfb_category_postdata_oracle(array('bogus-0' => 'somevalue'), 'ipv4', $cron_values, $aliaslog_values);
+		});
+
+		$this->assertSame(
+			array('Failed Variable: bogus'),
+			$input_errors,
+			'an invalid variable-name prefix must short-circuit with exactly its own error, never fall through to an undefined $variable switch'
+		);
+	}
+}

--- a/tests/php/PfbEtOptionsUndefinedTest.php
+++ b/tests/php/PfbEtOptionsUndefinedTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/PfbNoPhpWarningTrait.php';
+
+/**
+ * pfblockerng.php's pfblockerng_get_countries() (issue #1493 defect 1): line
+ * ~2220 assigns the dead-store typo `$etoptions = '';` -- every subsequent
+ * read in the reputation-tab options loop (2229/2234/2236) and the call to
+ * pfb_build_reputation_tab($et_options) at 2242 reads the never-assigned
+ * `$et_options` instead. With $roptions4 empty (no GeoIP continent data --
+ * the fresh-install/bare-`gc` path) the loop body never runs, so the ONLY
+ * read is the unconditional call at 2242: PHP 8 emits "Undefined variable
+ * $et_options" and passes NULL to the builder.
+ *
+ * The file carries top-level execution and cannot be require()d
+ * off-appliance (house precedent: CountryNetworksCountGuardTest.php,
+ * GeoipContinentCatStderrGuardTest.php). Calling the real
+ * pfblockerng_get_countries() is additionally unsafe here: it flows on to
+ * pfb_build_reputation_tab(), which unconditionally file_put_contents()s the
+ * hardcoded absolute path /usr/local/www/pfblockerng/pfblockerng_reputation.php
+ * with no sandboxing hook. So this test eval-extracts only the
+ * $roptions4 -> $et_options options-build block (sort()..the
+ * pfb_build_reputation_tab() call) verbatim, swapping the builder call for a
+ * recording test double -- the real defect line runs unmocked, with zero
+ * file I/O.
+ *
+ * Feature: the reputation-tab options string reaching the builder must
+ *          always be a defined string, never an undefined-variable read
+ *
+ *   Scenario: no GeoIP country data collected (empty $roptions4) -> the
+ *             options-build loop body never executes, so $et_options must
+ *             still be a defined '' at the builder call, with no warning
+ */
+final class PfbEtOptionsUndefinedTest extends TestCase
+{
+	use PfbNoPhpWarningTrait;
+
+	private static string $src;
+
+	public static function setUpBeforeClass(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php';
+		$src = file_get_contents($path);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.php');
+		}
+		self::$src = $src;
+
+		if (!function_exists('pfb_et_options_oracle')) {
+			if (!preg_match(
+				'/sort\(\$roptions4, SORT_STRING\);.*?pfb_build_reputation_tab\(\$et_options\);/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('oracle extraction failed: the reputation-tab options-build block was not found in pfblockerng.php');
+			}
+			$block = str_replace('pfb_build_reputation_tab(', 'pfb_et_options_test_sink(', $m[0]);
+			eval(
+				'function pfb_et_options_oracle(array $roptions4): void {'
+				. ' ' . $block
+				. ' }'
+			);
+		}
+	}
+
+	protected function setUp(): void
+	{
+		$GLOBALS['pfb_et_options_test_sink_arg'] = 'sink-not-called';
+	}
+
+	public function testEtOptionsReachesReputationTabBuilderDefinedAndEmpty(): void
+	{
+		$this->assertNoPhpWarning(static function (): void {
+			pfb_et_options_oracle([]);
+		});
+
+		$this->assertSame(
+			'',
+			$GLOBALS['pfb_et_options_test_sink_arg'],
+			'$et_options must reach pfb_build_reputation_tab() as the empty string produced by the (empty) options loop, not an undefined-variable NULL'
+		);
+	}
+}
+
+function pfb_et_options_test_sink($et_options): void
+{
+	$GLOBALS['pfb_et_options_test_sink_arg'] = $et_options;
+}

--- a/tests/php/PfbOpenSqliteFailureTest.php
+++ b/tests/php/PfbOpenSqliteFailureTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_open_sqlite() -- both connection attempts throwing (issue #1494 defect 3;
+ * #1497 red-proof). A database path nested under a directory that never exists
+ * makes BOTH `new SQLite3($database)` attempts (primary ~14903, retry ~14910)
+ * throw -- SQLite's default open flags (SQLITE3_OPEN_READWRITE |
+ * SQLITE3_OPEN_CREATE) cannot create the file when its parent directory is
+ * absent. Pre-fix, $db_handle was never assigned on this path, so
+ * `if ($db_handle)` (~14918) read an undefined variable (PHP E_WARNING) before
+ * falling through to `return FALSE;`. Fix: `$db_handle = NULL;` before the
+ * first try -- same FALSE return, no warning.
+ */
+#[CoversFunction('pfb_open_sqlite')]
+final class PfbOpenSqliteFailureTest extends TestCase
+{
+	use PfbNoPhpWarningTrait;
+
+	private string $tmp;
+	private array $savedPfb = [];
+
+	protected function setUp(): void
+	{
+		$this->savedPfb = $GLOBALS['pfb'] ?? [];
+
+		$this->tmp = sys_get_temp_dir() . '/pfb_open_sqlite_qa_' . uniqid('', true);
+		mkdir($this->tmp, 0777, true);
+
+		$GLOBALS['pfb'] = [
+			// Nested under a directory that is never created -- both the primary
+			// and retry `new SQLite3()` attempts fail with SQLITE_CANTOPEN.
+			'dnsbl_info'     => "{$this->tmp}/missing/nested/dnsbl.sqlite3",
+			'sqlite_timeout' => 2000,
+			'errlog'         => "{$this->tmp}/error.log",
+		];
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb'] = $this->savedPfb;
+		@unlink("{$this->tmp}/error.log");
+		@rmdir($this->tmp);
+	}
+
+	public function testBothConnectionAttemptsThrowingReturnsFalseWithoutWarning(): void
+	{
+		$result = $this->assertNoPhpWarning(function () {
+			return pfb_open_sqlite(1, 'Test double connection failure');
+		});
+
+		$this->assertFalse($result, 'expected pfb_open_sqlite() to return FALSE when both connection attempts throw');
+	}
+}

--- a/tests/php/PfbOpenSqliteFailureTest.php
+++ b/tests/php/PfbOpenSqliteFailureTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/PfbNoPhpWarningTrait.php';
+
 /**
  * pfb_open_sqlite() -- both connection attempts throwing (issue #1494 defect 3;
  * #1497 red-proof). A database path nested under a directory that never exists

--- a/tests/php/PfbOptionsHeredocMultiContinentTest.php
+++ b/tests/php/PfbOptionsHeredocMultiContinentTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/PfbNoPhpWarningTrait.php';
+
+/**
+ * pfblockerng.php's pfblockerng_get_countries() (issue #1493 defect 2,
+ * corrected -- verifier finding on commit 1b9ab1fa): unlike $ftotal4/
+ * $ftotal6, $options4/$options6 ARE unset every continent iteration by the
+ * unconditional `unset(${'options4'}, ${'options6'}, $php_data);` at the
+ * end of the per-continent tail (~2216). The #1497 function-top init
+ * (`$options4 = $options6 = '';`) runs ONCE per function call, so any
+ * continent AFTER the first whose per-type data is empty (fopen failure or
+ * an empty $coptions* -- 8 of $geoip_files's 9 continents in the bare
+ * `gc`-before-any-GeoIP-download scenario #1493 exists to fix) reaches the
+ * generated-page heredoc with $options4/$options6 undefined again.
+ * PHPStan cannot see the dynamic ${'options4'}/${'options6'} unset (the
+ * same blindness that hid the original defect), so its clean report after
+ * 1b9ab1fa was an artifact of that blindness, not proof -- this test
+ * drives the REAL multi-continent control flow instead.
+ *
+ * Extracts three verbatim anchors from pfblockerng.php: the per-type
+ * coptions-guarded options-build block (+ its trailing $coptions* unset),
+ * whatever guard sits between the type-loop's close and the heredoc start
+ * (empty pre-fix; the reinstated `??=` pair post-fix -- extracted
+ * POSITIONALLY, not hand-copied, so this test proves the actual fix
+ * lands in the right place), and the final $options4/$options6 unset.
+ * Drives two simulated continent iterations -- the file itself cannot be
+ * require()d off-appliance (house precedent: CountryNetworksCountGuardTest.php,
+ * GeoipContinentCatStderrGuardTest.php, PfbEtOptionsUndefinedTest.php).
+ *
+ * Feature: $options4/$options6 must reach the per-continent heredoc as a
+ *          defined string on EVERY continent, not just the first
+ *
+ *   Scenario: continent 1 has IPv4 data, continent 2 has none -> continent
+ *             2's heredoc-equivalent read must not warn, and must render
+ *             as the empty string
+ */
+final class PfbOptionsHeredocMultiContinentTest extends TestCase
+{
+	use PfbNoPhpWarningTrait;
+
+	public static function setUpBeforeClass(): void
+	{
+		if (function_exists('pfb_options_heredoc_oracle')) {
+			return;
+		}
+
+		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php';
+		$src = file_get_contents($path);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.php');
+		}
+
+		if (!preg_match(
+			'/if \(!empty\(\$\{\'coptions\' \. \$type\}\)\) \{.*?unset\(\$\{\'coptions\' \. \$type\}\);/s',
+			$src,
+			$mBlock
+		)) {
+			throw new RuntimeException('oracle extraction failed: the per-type coptions-guarded options-build block was not found in pfblockerng.php');
+		}
+
+		if (!preg_match(
+			'/unset\(\$\{\'coptions\' \. \$type\}\);\n\t\t\}\n\n(.*?)\$php_data = <<<EOF/s',
+			$src,
+			$mGuard
+		)) {
+			throw new RuntimeException('oracle extraction failed: the post-type-loop guard region (between the type-loop close and the heredoc start) was not found in pfblockerng.php');
+		}
+
+		if (!preg_match(
+			'/unset\(\$\{\'options4\'\}, \$\{\'options6\'\}, \$php_data\);/',
+			$src,
+			$mUnset
+		)) {
+			throw new RuntimeException('oracle extraction failed: the final $options4/$options6 unset was not found in pfblockerng.php');
+		}
+
+		$typeBlock  = $mBlock[0];
+		$postGuard  = $mGuard[1];
+		$finalUnset = $mUnset[0];
+
+		eval(
+			'function pfb_options_heredoc_oracle(): array {'
+			. ' $coptions4 = $coptions6 = array();'
+			. ' $options4 = $options6 = "";'
+			. ' $ftotal4 = $ftotal6 = 0;'
+			. ' $cont = "TestCont";'
+			. ' $rendered = [];'
+			. ' foreach ([TRUE, FALSE] as $continentHasV4Data) {'
+			. '   foreach (array("4", "6") as $type) {'
+			. '     if ($type === "4" && $continentHasV4Data) {'
+			. '       ${"coptions" . $type}[] = \'x|"US" => "Test US (1)"\';'
+			. '     }'
+			. '     ' . $typeBlock
+			. '   }'
+			. '   ' . $postGuard . ';'
+			. '   $rendered[] = "{$options4}{$options6}";'
+			. '   ' . $finalUnset
+			. ' }'
+			. ' return $rendered;'
+			. ' }'
+		);
+	}
+
+	public function testSecondContinentWithNoDataDoesNotWarnReadingOptions(): void
+	{
+		$rendered = $this->assertNoPhpWarning(static function (): array {
+			return pfb_options_heredoc_oracle();
+		});
+
+		$this->assertNotSame('', $rendered[0], 'sanity: continent 1 (has IPv4 data) must render something non-empty');
+		$this->assertSame(
+			'',
+			$rendered[1],
+			'$options4/$options6 must render as the empty string on a data-less continent (unset by the previous continent\'s tail, never reassigned since its coptions4/6 are empty), not an undefined-variable NULL'
+		);
+	}
+}

--- a/tests/smoke/ui/test_render_variable_undefined_regressions.py
+++ b/tests/smoke/ui/test_render_variable_undefined_regressions.py
@@ -1,0 +1,133 @@
+"""Tier-A ``ui_render`` coverage for issue #1497 (PR #1506)'s page-level fixes.
+
+PR #1506 burns the level-2 PHPStan ``variable.undefined`` cohort (#1493-#1497)
+to zero across the pfBlockerNG www pages. Most of the touched render paths are
+ALREADY GET-swept by ``test_render_smoke.py``'s ``PAGE_TABLE`` (the generic
+Tier-A oracle: HTTP 200, no rendered PHP diagnostic SHAPE, a page marker, and no
+``php_error.log`` growth -- see ``render_oracle.py``), so duplicating a plain
+GET here would be coverage theater (CLAUDE.md "no coverage theater"):
+
+* ``pfblockerng_blacklist.php`` plain GET -- the ``blacklist`` PAGE_TABLE entry
+  already exercises the top-of-file ``$savemsg``/``$input_errors`` init (#1496),
+  which runs unconditionally before the ``$_POST`` branch.
+* ``pfblockerng_category.php`` plain GET -- ``$gtype`` with no ``?type`` param
+  falls through the SAME switch case as ``category_dnsbl``
+  (``case 'dnsbl': default:`` share one block, category.php:111-117), so the
+  ``continue;`` invalid-prefix fix (#1496) is already exercised.
+* ``pfblockerng_feeds.php`` plain GET -- ``$gtype`` defaults to ``'ipv4'`` with
+  no ``?type`` param (feeds.php:42), identical to the ``feeds_ipv4`` entry; the
+  ``$p_type``/``$p_tr_style`` defaults (#1497/#1496) run unconditionally on
+  every type's Custom Feeds render, regardless of whether custom feeds exist.
+* ``pfblockerng_general.php`` plain GET -- the fix there is an
+  ``@phpstan-ignore`` annotation only (zero runtime change); the ``general``
+  PAGE_TABLE entry already proves the page renders warning-free.
+
+Two render paths genuinely have NO existing Tier-A coverage and are pinned here:
+
+1. ``pfblockerng_alerts.php?view=unified`` -- the Unified-view first-pass
+   cluster (``$p_query_port``/``$colspan``/``$fcounter``/``$pfbfilterlimit``/the
+   ``$rtype`` coalesce, #1495) only runs when ``$logtype == 'Unified'`` reaches
+   the render loop past the "skip empty table" gate, which only happens for
+   ``$alert_view == 'unified'`` (alerts.php:4267-4272) -- the default
+   ``alerts`` PAGE_TABLE entry (no ``?view``) uses ``$alert_view == 'alert'``,
+   under which the ``Unified`` iteration ``continue 2``s at alerts.php:4257
+   before ever reaching that cluster.
+2. ``pfblockerng_category_edit.php?type=dnsbl&act=add&atype=<stale>`` -- the
+   ``$a_aliasname``/``$a_description``/``$a_cron``/``$a_url``/``$a_header``
+   defaults (#1496, category_edit.php:200) only run on the ``act=add``
+   "no matching feed found" path (a stale/bookmarked ``atype`` the current DNSBL
+   feed catalog no longer contains); the existing
+   ``category_edit_fresh_addgroup_whitelist`` PAGE_TABLE entry uses
+   ``act=addgroup`` with a ``Whitelist|...`` atype, which takes the Whitelist
+   branch (category_edit.php:297-322) and never reads any of these 5 variables.
+
+Both GETs are hermetic (no config write -- no ``$_POST['save']``, no feed
+download) and reuse the exact oracle (``evaluate_render`` + ``PhpErrorLogGuard``)
+every other Tier-A ``ui_render`` module uses.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+
+if TYPE_CHECKING:
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+ALERTS_UNIFIED_PAGE = "/pfblockerng/pfblockerng_alerts.php?view=unified"
+
+# PFB_FILTER_ATYPE (pfblockerng.inc ~1728) accepts only [a-zA-Z0-9.|_]+ -- no
+# hyphen. Deliberately does not match any real feed header/aliasname in the
+# DNSBL catalog (a stale/bookmarked link after a catalog change), so
+# $pfb_found stays FALSE and the page falls through to the fresh-row defaults
+# this module pins.
+_STALE_ATYPE = "Smoke1497StaleFeedNotInCatalog"
+CATEGORY_EDIT_ADD_DNSBL_STALE_PAGE = (
+    f"/pfblockerng/pfblockerng_category_edit.php?type=dnsbl&act=add&atype={_STALE_ATYPE}"
+)
+
+
+def test_alerts_unified_view_renders_clean(smoke_vm: SmokeVM, webui: WebUI) -> None:
+    """``?view=unified`` renders the Unified panel without a PHP diagnostic (#1495).
+
+    Scenario:
+      Given the default install (the ``pfbunicnt`` aglobal counter defaults to
+        200 -- alerts.php:35 -- so the Unified panel's "skip empty table" guard
+        does not skip it; no log content needs seeding).
+      When  GET ``pfblockerng_alerts.php?view=unified``.
+      Then  the Tier-A oracle passes (200, no PHP diagnostic shape, the Unified
+            panel marker present) AND ``php_error.log`` gains no new bytes --
+            the two ways a suppressed ``variable.undefined`` regression would
+            surface (#1495: ``$p_query_port``/``$colspan``/``$fcounter``/
+            ``$pfbfilterlimit``/the ``$rtype`` coalesce all execute on this
+            exact path, regardless of whether the unified log FILE exists).
+    """
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = webui.get(ALERTS_UNIFIED_PAGE)
+    # "Unified<small>" is the panel h2 title's gettext($logtype) output butted
+    # directly against the literal <small> tag (alerts.php:4292, byte-verified
+    # -- zero whitespace between the PHP short-echo and the tag), so it proves
+    # the Unified panel itself rendered, not just the always-present "Unified"
+    # sub-tab nav label.
+    result = evaluate_render(ALERTS_UNIFIED_PAGE, resp.status_code, resp.text, ("Unified<small>",))
+    assert result.ok, f"Tier-A render oracle failed for the Unified alerts view: {result.detail}"
+
+    guard.assert_no_growth()
+
+
+def test_category_edit_add_dnsbl_stale_atype_renders_clean(smoke_vm: SmokeVM, webui: WebUI) -> None:
+    """``act=add`` with a stale/unmatched DNSBL ``atype`` renders clean (#1496).
+
+    Scenario:
+      Given a bookmarked/stale add link: ``type=dnsbl&act=add`` with an
+        ``atype`` that matches no feed header/aliasname in the current DNSBL
+        catalog (the exact "catalog changed since the link was bookmarked"
+        scenario the fix's comment names).
+      When  GET the category-edit page with that link.
+      Then  the Tier-A oracle passes (200, no PHP diagnostic shape, the page's
+            marker present) AND ``php_error.log`` gains no new bytes -- the
+            page falls through to the ``!$pfb_found`` branch
+            (category_edit.php:277-291), reading ``$a_aliasname``/
+            ``$a_description``/``$a_cron``/``$a_url``/``$a_header`` before any
+            assignment inside the (never-matched) feed loop. No config write
+            happens (no ``$_POST['save']`` in the request), so no cleanup is
+            needed.
+    """
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = webui.get(CATEGORY_EDIT_ADD_DNSBL_STALE_PAGE)
+    # "Advanced Tuneables" is the same generic page-wide marker the sibling
+    # category_edit_fresh_addgroup_whitelist PAGE_TABLE entry uses.
+    result = evaluate_render(CATEGORY_EDIT_ADD_DNSBL_STALE_PAGE, resp.status_code, resp.text, ("Advanced Tuneables",))
+    assert result.ok, f"Tier-A render oracle failed for the stale-atype add path: {result.detail}"
+
+    guard.assert_no_growth()


### PR DESCRIPTION
Burns the level-2 PHPStan `variable.undefined` cohort out of the baseline: **87 unique / 154 raw sites → 0**, with the four underlying defect groups fixed and everything else silenced only where a static-analysis limitation (not a code defect) was proven.

Fixes #1493
Fixes #1494
Fixes #1495
Fixes #1496
Fixes #1497

## What's here (14 commits, per-issue grouping)

- **#1494 — `pfblockerng.inc`**: `$db_handle` NULL init in `pfb_open_sqlite()` (double connection failure), `$logtab` init before the lists loop, `pfb_logger($mmsg, 1)` for the never-assigned `$logtype`, `?? []` on the auto-rules compare (mirrors the existing defense ten lines below). Plus behaviour-neutral INIT-GAP inits across the daemon reader functions.
- **#1493 — `pfblockerng.php` (gc path)**: `$etoptions`→`$et_options` dead-store typo (warning on every country-code run), function-top init for the `${'coptions'.$type}` family, per-iteration `$options4/6 ??= ''` before the heredoc (the per-continent `unset(${'options4'}, ...)` at the loop tail is invisible to PHPStan — inline-ignored with a why), `isset($argv[1])` guards at both unguarded read sites.
- **#1495 — `pfblockerng_alerts.php`**: ICMP rows' `$dstport`, the Unified-view first-pass cluster (`$p_query_port`/`$fcounter`/`$pfbfilterlimit`/`$max_table_entries`), `entry_delete` `$table`/`$savemsg` hardening, dead `$extra_txt` concat removed, and the `${"$type"}` counter loop replaced with explicit assignments (identical fallback semantics, verified against the pre-image).
- **#1496 — form pages + DNSBL front controller**: the vestigial `if (isset($x)) unset($x);` idiom replaced with real inits for `$savemsg`/`$input_errors` (two `!isset()`→`empty()` consumer flips truth-tabled for equivalence), the missing `continue;` in category.php's invalid-prefix branch, stale-`atype` `$a_*` inits, `$geoip_isos`, `$p_type`, and `$ts` in `www/index.php`.
- **CONTEXT silencing**: `pfblockerng_general.php:152` phantom-union inline ignore (the `strpos` guard consumes all 11 `log_max_*` keys before the `else`), `/** @var */` docblocks for the includer-provided `$ptype`/`$ts` (dnsbl template) and `$widgetname` (pfSense widget loop).
- **Baseline regen**: `variable.undefined` 87→0; additionally sweeps 5 stale `parameter.requiredAfterOptional` entries whose signatures devel already retired (9c48c4dc, #1408).

## Evidence

- Every step was implemented by a small-tier agent and gated by an independent verifier that re-ran the gates, re-executed the red proofs via `scripts/agent/verify-red-proof.sh`, and read the full diff. Two verifier rounds produced fix commits (a non-self-contained red test; a `??=` removal that was actually load-bearing behind PHPStan's dynamic-variable blindness — reinstated with a regression test).
- Four executed red→green PHPUnit proofs, frozen byte-identical: `PfbOpenSqliteFailureTest`, `PfbEtOptionsUndefinedTest`, `PfbOptionsHeredocMultiContinentTest`, `AlertsIpConvertPrefetchParityTest` (ICMP case), `CategoryPostdataInvalidPrefixGuardTest`.
- Baseline identifier histograms — before: 87 variable.undefined / 17 isset.variable / 15 argument.type / 14 empty.variable / 11 parameter.requiredAfterOptional / 3 unset.variable / 1 binaryOp.invalid; after: 0 / 17 / 15 / 14 / 6 / 3 / 1. Nothing grew.
- Whole-tree no-baseline PHPStan run: zero `variable.undefined` remaining.
- `scripts/agent/run-gates.sh --diff origin/devel`: GATES: PASS (php -l, phpunit 3793 tests, phpstan, phpcs).
- Tier-A `ui_render` coverage: all touched webConfigurator pages are covered by the existing render suite (`tests/smoke/ui/test_render_smoke.py` asserts warning-free bodies + `php_error.log`) or policy-excluded (`www/index.php`/`www/dnsbl_default.php` sit in `EXCLUDED_FROM_TIER_A`, the sanctioned sinkhole-page mechanism); `tests/smoke/ui/test_render_variable_undefined_regressions.py` adds two hermetic cases driving the Unified alerts view and the stale-`atype` category-edit path this PR fixes. The hermetic PHPUnit page-fragment tests above pin the specific regressions.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
