### PR TITLE
pfblockerng: gate the four Alerts pfctl mutations on exec status

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5695,9 +5695,9 @@ function pfb_ip_recompute_forget_header(string $header, string $snapdir, string 
 
 // Format a single log line for a failed pfctl table operation.  Pure function:
 // no side-effects, fully unit-testable without a live pfctl binary.
-// Callers: pfb_pfctl_table_op() (below), plus pfb_live_punch_apply() and
-// pfb_pfctl_checked_op() (pfblockerng_extra.inc) — the exec() routes for
-// pfctl -T mutation ops.  The message names every field so "Table does not exist"
+// Callers: pfb_pfctl_table_op() (below) and pfb_live_punch_apply()
+// (pfblockerng_extra.inc; also reached via pfb_pfctl_checked_op()) — the exec()
+// routes for pfctl -T mutation ops.  The message names every field so "Table does not exist"
 // floods carry table/op attribution in the log.
 function pfb_pfctl_error_message(string $table, string $op, int $rc, string $stderr): string {
 	$msg = trim(str_replace(["\r\n", "\r", "\n"], ' ', $stderr));

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5695,7 +5695,8 @@ function pfb_ip_recompute_forget_header(string $header, string $snapdir, string 
 
 // Format a single log line for a failed pfctl table operation.  Pure function:
 // no side-effects, fully unit-testable without a live pfctl binary.
-// Callers: pfb_pfctl_table_op() (below) — which is the only exec() wrapper for
+// Callers: pfb_pfctl_table_op() (below), plus pfb_live_punch_apply() and
+// pfb_pfctl_checked_op() (pfblockerng_extra.inc) — the exec() routes for
 // pfctl -T mutation ops.  The message names every field so "Table does not exist"
 // floods carry table/op attribution in the log.
 function pfb_pfctl_error_message(string $table, string $op, int $rc, string $stderr): string {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -4049,8 +4049,13 @@ function pfb_live_punch_apply(string $pfctl, string $table, array $plan): array 
  * @param  string $op    'add' or 'delete' -- a fixed caller literal.
  * @param  string $entry The single table entry to add/delete.
  * @return array{ok: bool, fail: ?string} see pfb_live_punch_apply().
+ * @throws InvalidArgumentException on an $op outside add|delete -- a plan keyed
+ *         by any other verb would silently succeed with zero execs.
  */
 function pfb_pfctl_checked_op(string $pfctl, string $table, string $op, string $entry): array {
+	if (!in_array($op, ['add', 'delete'], TRUE)) {
+		throw new InvalidArgumentException("pfb_pfctl_checked_op: op must be 'add' or 'delete', got [ {$op} ]");
+	}
 	$plan = ['delete' => [], 'add' => []];
 	$plan[$op][] = $entry;
 	return pfb_live_punch_apply($pfctl, $table, $plan);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -4034,6 +4034,29 @@ function pfb_live_punch_apply(string $pfctl, string $table, array $plan): array 
 }
 
 /**
+ * pfb_pfctl_checked_op -- issue #1505: fail-closed single-entry `pfctl -T
+ * add|delete` for the four Alerts page mutation sites (delete_ip,
+ * delete_ipwhitelist, ip_remove=lock, ip_white) that used to ignore exec()'s
+ * status outright. Builds a one-entry plan and runs it through the SAME
+ * fail-closed executor pfb_live_punch_apply() -- never pfb_pfctl_table_op():
+ * see that function's docblock (ADR-61 ledger).
+ *
+ * $op is a fixed caller literal 'add'|'delete', never request-supplied
+ * (mirrors pfb_pfctl_table_op()'s $op contract).
+ *
+ * @param  string $pfctl Absolute path to the pfctl binary ($pfb['pfctl']).
+ * @param  string $table The pf table name (caller-validated, unescaped).
+ * @param  string $op    'add' or 'delete' -- a fixed caller literal.
+ * @param  string $entry The single table entry to add/delete.
+ * @return array{ok: bool, fail: ?string} see pfb_live_punch_apply().
+ */
+function pfb_pfctl_checked_op(string $pfctl, string $table, string $op, string $entry): array {
+	$plan = ['delete' => [], 'add' => []];
+	$plan[$op][] = $entry;
+	return pfb_live_punch_apply($pfctl, $table, $plan);
+}
+
+/**
  * pfb_live_punch_run -- issue #1467 (CWE-362): orchestrates one Alerts "+" /
  * Unlock live punch (snapshot -> plan -> apply) under the feed-pass lock
  * (pfblockerng.inc's pfb_feed_pass_acquire()/_release()), so a concurrent

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1368,23 +1368,29 @@ if (isset($_POST) && !empty($_POST)) {
 				// the old /32-before-/24 precedence.
 				$match = pfb_ip_suppressed_match($ip, array_keys($clists[$supp_key]['data']));
 				if ($match !== NULL) {
-					unset($clists[$supp_key]['data'][$match]);
+					// issue #1505: check the re-add before touching the customlist --
+					// a failed re-add must leave the suppression entry in place.
+					$apply = pfb_pfctl_checked_op($pfb['pfctl'], trim($table, "'"), 'add', $match);
+					if ($apply['ok']) {
+						unset($clists[$supp_key]['data'][$match]);
 
-					exec("{$pfb['pfctl']} -t {$table} -T add " . escapeshellarg($match) . ' 2>&1');
+						$data = '';
+						foreach ($clists[$supp_key]['data'] as $line) {
+							$data .= "{$line}";
+						}
+						$clists[$supp_key]['base64'] = base64_encode($data);
+						PfbConfig::write($cfg_key, $clists[$supp_key]['base64']);
 
-					$data = '';
-					foreach ($clists[$supp_key]['data'] as $line) {
-						$data .= "{$line}";
+						// Keep pfbsuppression(_v6).txt in step with the config edit --
+						// same in-memory refresh the addsuppress handler applies.
+						$pfb['ipconfig'][$cfg_key] = $clists[$supp_key]['base64'];
+						pfb_create_suppression_file();
+
+						$savemsg = "Removed [ {$match} ] from {$type} customlist and re-added it back into the aliastable [ {$table} ]";
+					} else {
+						$pfb_found = FALSE;
+						$savemsg = "The re-add of [ {$match} ] into aliastable [ {$table} ] failed [ {$apply['fail']} ] -- the {$type} customlist entry was kept; see the pfBlockerNG log.";
 					}
-					$clists[$supp_key]['base64'] = base64_encode($data);
-					PfbConfig::write($cfg_key, $clists[$supp_key]['base64']);
-
-					// Keep pfbsuppression(_v6).txt in step with the config edit --
-					// same in-memory refresh the addsuppress handler applies.
-					$pfb['ipconfig'][$cfg_key] = $clists[$supp_key]['base64'];
-					pfb_create_suppression_file();
-
-					$savemsg = "Removed [ {$match} ] from {$type} customlist and re-added it back into the aliastable [ {$table} ]";
 				}
 				else {
 					$pfb_found = FALSE;
@@ -1402,20 +1408,27 @@ if (isset($_POST) && !empty($_POST)) {
 				$ix	= ip_explode(trim($entry, "'"));	// Explode IP into evaluation strings
 
 				if (isset($clists['ipwhitelist' . $vtype][$table_2]['data'][$ix[0]])) {
-					unset($clists['ipwhitelist' . $vtype][$table_2]['data'][$ix[0]]);
-					exec("{$pfb['pfctl']} -t {$table} -T delete {$entry} 2>&1");
+					// issue #1505: check the delete before touching the customlist --
+					// a failed delete must leave the Permit entry in place.
+					$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table_2, 'delete', trim($entry, "'"));
+					if ($apply['ok']) {
+						unset($clists['ipwhitelist' . $vtype][$table_2]['data'][$ix[0]]);
 
-					$data = '';
-					foreach ($clists['ipwhitelist' . $vtype][$table_2]['data'] as $line) {
-						$data .= "{$line}";
+						$data = '';
+						foreach ($clists['ipwhitelist' . $vtype][$table_2]['data'] as $line) {
+							$data .= "{$line}";
+						}
+
+						$clists['ipwhitelist' . $vtype][$table_2]['base64'] = base64_encode($data);
+						// foreign structure: pfblockernglistsv4/v6/config/{row}/custom is a dynamic per-row key, not in registry
+						config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$clists['ipwhitelist' . $vtype][$table_2]['base64_idx']}/custom", $clists['ipwhitelist' . $vtype][$table_2]['base64']);
+						$aname = substr(substr($table_2, 4),0, -3);					// Remove 'pfB_' and '_v4'
+						touch("{$pfb['permitdir']}/{$aname}_custom_v{$vtype}.update");			// Set Flag for Cron/Update process
+						$savemsg = "The IP [ {$entry} ] has been deleted from the [ {$table} ] Permit Alias customlist.";
+					} else {
+						$pfb_found = FALSE;
+						$savemsg = "The delete of [ {$entry} ] from aliastable [ {$table} ] failed [ {$apply['fail']} ] -- the {$type} customlist entry was kept; see the pfBlockerNG log.";
 					}
-
-					$clists['ipwhitelist' . $vtype][$table_2]['base64'] = base64_encode($data);
-					// foreign structure: pfblockernglistsv4/v6/config/{row}/custom is a dynamic per-row key, not in registry
-					config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$clists['ipwhitelist' . $vtype][$table_2]['base64_idx']}/custom", $clists['ipwhitelist' . $vtype][$table_2]['base64']);
-					$aname = substr(substr($table_2, 4),0, -3);					// Remove 'pfB_' and '_v4'
-					touch("{$pfb['permitdir']}/{$aname}_custom_v{$vtype}.update");			// Set Flag for Cron/Update process
-					$savemsg = "The IP [ {$entry} ] has been deleted from the [ {$table} ] Permit Alias customlist.";
 				}
 				else {
 					$savemsg = "IP: [ {$entry} ] was not found in {$type} customlist!";
@@ -1532,8 +1545,6 @@ if (isset($_POST) && !empty($_POST)) {
 			exit;
 		}
 
-		$table_esc = escapeshellarg($table);
-
 		// Unlock IP -- ADR-53 covering-CIDR live punch (pfb_live_punch_run(),
 		// pfblockerng_extra.inc), the same mechanism the Suppression "+" uses:
 		// carve exactly this host out of whichever table entr(y/ies) currently
@@ -1569,9 +1580,15 @@ if (isset($_POST) && !empty($_POST)) {
 		// un-suppress 'delete_ip' handler's direct re-add: no covering-CIDR
 		// remainder to compute, only the single host that was carved out).
 		elseif ($_POST['ip_remove'] == 'lock') {
-			exec("{$pfb['pfctl']} -t {$table_esc} -T add " . escapeshellarg($ip) . ' 2>&1');
-			pfb_unlock('lock', 'ip', $ip, $table, $ip_unlock);
-			$savemsg = "The IP [ {$ip} ] has been re-locked into table [ {$table} ]!";
+			// issue #1505: check the re-add before recording the re-lock -- a
+			// failed re-add must leave the IP genuinely unlocked in the store.
+			$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table, 'add', $ip);
+			if ($apply['ok']) {
+				pfb_unlock('lock', 'ip', $ip, $table, $ip_unlock);
+				$savemsg = "The IP [ {$ip} ] has been re-locked into table [ {$table} ]!";
+			} else {
+				$savemsg = "The live re-lock of IP [ {$ip} ] failed [ {$apply['fail']} ] -- table [ {$table} ] does not block it; see the pfBlockerNG log.";
+			}
 		}
 
 		else {
@@ -1612,36 +1629,39 @@ if (isset($_POST) && !empty($_POST)) {
 			exit;
 		}
 
-		$ip_esc		= escapeshellarg($ip);
-		$table_esc	= escapeshellarg($table);
-
 		if (!isset($clists['ipwhitelist' . $vtype][$table]['data'][$ip])) {
-			exec("{$pfb['pfctl']} -t {$table_esc} -T add {$ip_esc} 2>&1");
-			@file_put_contents("{$pfb['aliasdir']}/{$table}.txt", "\n{$ip}", LOCK_EX);
+			// issue #1505: check the add before touching the customlist/config --
+			// a failed add must leave every write undone.
+			$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table, 'add', $ip);
+			if ($apply['ok']) {
+				@file_put_contents("{$pfb['aliasdir']}/{$table}.txt", "\n{$ip}", LOCK_EX);
 
-			if (!empty($descr)) {
-				$whitelist_string = "{$ip} # {$descr}\r\n";
-			} else {
-				$whitelist_string = "{$ip}\r\n";
-			}
-
-			$data = '';
-			if (isset($clists['ipwhitelist' . $vtype][$table]['data']) && is_array($clists['ipwhitelist' . $vtype][$table]['data'])) {
-				foreach ($clists['ipwhitelist' . $vtype][$table]['data'] as $line) {
-					$data .= "{$line}";
+				if (!empty($descr)) {
+					$whitelist_string = "{$ip} # {$descr}\r\n";
+				} else {
+					$whitelist_string = "{$ip}\r\n";
 				}
+
+				$data = '';
+				if (isset($clists['ipwhitelist' . $vtype][$table]['data']) && is_array($clists['ipwhitelist' . $vtype][$table]['data'])) {
+					foreach ($clists['ipwhitelist' . $vtype][$table]['data'] as $line) {
+						$data .= "{$line}";
+					}
+				}
+				$data .= "{$whitelist_string}";
+
+				$clists['ipwhitelist' . $vtype][$table]['base64'] = base64_encode($data);
+				// foreign structure: pfblockernglistsv4/v6/config/{row}/custom is a dynamic per-row key, not in registry
+				config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$clists['ipwhitelist' . $vtype][$table]['base64_idx']}/custom", $clists['ipwhitelist' . $vtype][$table]['base64']);
+				write_config("pfBlockerNG: Added [ {$ip} ] to [ {$table} ] Whitelist", FALSE);
+
+				$aname = substr(substr($table, 4),0, -3);					// Remove 'pfB_' and '_v4'
+				touch("{$pfb['permitdir']}/{$aname}_custom_v{$vtype}.update");			// Set Flag for Cron/Update process
+
+				$savemsg = "The IP [ {$ip} ] has been added to the [ {$table} ] Permit Alias customlist.";
+			} else {
+				$savemsg = "The add of [ {$ip} ] to aliastable [ {$table} ] failed [ {$apply['fail']} ] -- see the pfBlockerNG log.";
 			}
-			$data .= "{$whitelist_string}";
-
-			$clists['ipwhitelist' . $vtype][$table]['base64'] = base64_encode($data);
-			// foreign structure: pfblockernglistsv4/v6/config/{row}/custom is a dynamic per-row key, not in registry
-			config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$clists['ipwhitelist' . $vtype][$table]['base64_idx']}/custom", $clists['ipwhitelist' . $vtype][$table]['base64']);
-			write_config("pfBlockerNG: Added [ {$ip} ] to [ {$table} ] Whitelist", FALSE);
-
-			$aname = substr(substr($table, 4),0, -3);					// Remove 'pfB_' and '_v4'
-			touch("{$pfb['permitdir']}/{$aname}_custom_v{$vtype}.update");			// Set Flag for Cron/Update process
-
-			$savemsg = "The IP [ {$ip} ] has been added to the [ {$table} ] Permit Alias customlist.";
 			header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
 			exit;
 		}

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -108,7 +108,7 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 				. ' global $pfb; $_POST[\'ip_remove\'] = \'lock\';'
 				. ' $table_esc = escapeshellarg($table); $savemsg = \'\';'
 				. $body
-				. ' return $savemsg; }'
+				. ' unset($_POST[\'ip_remove\']); return $savemsg; }'
 			);
 		}
 
@@ -438,6 +438,9 @@ SH
 		$this->assertStringContainsString('added', $result['savemsg']);
 		$this->assertFileExists("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v4.txt");
 		$this->assertStringContainsString('198.51.100.31', file_get_contents("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v4.txt"));
+		// Non-vacuity anchor for the failure tests' assertArrayNotHasKey: prove
+		// config_set_path() IS observable through this seam on success.
+		$this->assertArrayHasKey('installedpackages', $GLOBALS['config'] ?? [], 'the success path must persist via config_set_path()');
 		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
 		$this->assertFileExists("{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v4.update");
 	}

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -1,0 +1,477 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1505: four `pfctl -T add/delete` exec() calls in
+ * pfblockerng_alerts.php ignored the exec status outright -- a failed
+ * mutation still got the config/store write and a success savemsg (fail-open
+ * unblocking, or store/table drift): delete_ip's re-add, delete_ipwhitelist's
+ * delete, ip_remove=lock's re-add, and ip_white's add. The fix routes each
+ * through pfb_pfctl_checked_op() (pfblockerng_extra.inc, built on the
+ * fail-closed pfb_live_punch_apply()) and gates every store write + the
+ * success savemsg on the outcome.
+ *
+ * The four handlers live in top-level script code (a switch/if chain inside
+ * pfblockerng_alerts.php's `if (isset($_POST))` block), not functions, so
+ * each region is eval-extracted verbatim from the REAL source -- same
+ * technique as CategoryEditPostGuardTest -- anchored on text stable across
+ * both the pre-fix and post-fix code, so this one file proves red on the old
+ * code and green on the new. delete_ip/delete_ipwhitelist keep their case's
+ * own trailing `break;`, so those two are wrapped in a `switch (1) { case 1:
+ * ... }` shell; the lock/ip_white regions are plain statement lists and are
+ * eval'd directly. ip_white's extraction stops BEFORE the header() call
+ * (calling header()/exit() inside a test would kill the process) -- this
+ * only works because the fix hoists header()+exit() to run once after the
+ * if/else (never duplicated per-branch), which is also why the SAME
+ * extraction anchor resolves in both the pre-fix and post-fix source.
+ *
+ * Uses the same injectable pfctl shim pattern as AlertsLivePunchApplyTest
+ * (writeShim() + PFB_TEST_LOG argv log + PFB_TEST_RULES scripted per-op
+ * failures) since pfb_pfctl_checked_op() ultimately execs through the same
+ * `pfctl -t <table> -T <op> <entry>` shape.
+ */
+final class AlertsPfctlCheckedSitesTest extends TestCase
+{
+	private string $tmp;
+	private string $shim;
+	private string $logPath;
+	private string $rulesPath;
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_alerts.php');
+		}
+
+		// Region 1: the delete_ip case body (own trailing break;) -- wrapped in a
+		// throwaway switch so `break;` has a valid target.
+		if (!function_exists('pfb_alerts_oracle_delete_ip')) {
+			if (!preg_match(
+				'/case \'delete_ip\':\n(.*?)\n\t\t\tcase \'delete_ipwhitelist\':/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: delete_ip region not found');
+			}
+			eval(
+				'function pfb_alerts_oracle_delete_ip(string $entry, string $table, array &$clists): array {'
+				. ' global $pfb; $pfb_found = TRUE; $savemsg = \'\'; $type = \'\';'
+				. ' switch (1) { case 1:'
+				. $m[1]
+				. ' }'
+				. ' return [\'pfb_found\' => $pfb_found, \'savemsg\' => $savemsg]; }'
+			);
+		}
+
+		// Region 2: the delete_ipwhitelist case body (own trailing break;).
+		if (!function_exists('pfb_alerts_oracle_delete_ipwhitelist')) {
+			if (!preg_match(
+				'/case \'delete_ipwhitelist\':\n(.*?)\n\t\t\tdefault:/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: delete_ipwhitelist region not found');
+			}
+			eval(
+				'function pfb_alerts_oracle_delete_ipwhitelist(string $entry, string $table, array &$clists): array {'
+				. ' global $pfb; $pfb_found = TRUE; $savemsg = \'\'; $type = \'\';'
+				. ' switch (1) { case 1:'
+				. $m[1]
+				. ' }'
+				. ' return [\'pfb_found\' => $pfb_found, \'savemsg\' => $savemsg]; }'
+			);
+		}
+
+		// Region 3: the ip_remove=='lock' elseif branch (its own open+close braces).
+		// The anchor is `elseif (...) {` since it sits alongside an `if ($_POST[
+		// 'ip_remove'] == 'unlock')` sibling -- rewritten to `if` so it evals as a
+		// standalone statement. The end anchor skips over the trailing catch-all
+		// `else { ... }` (invalid ip_remove action) to the shared header() call
+		// after the whole if/elseif/else chain (2-tab indent, blank line before it).
+		if (!function_exists('pfb_alerts_oracle_ip_lock')) {
+			if (!preg_match(
+				'/(elseif \(\$_POST\[\'ip_remove\'\] == \'lock\'\) \{\n.*?\n\t\t\})\n\n\t\telse \{\n.*?\n\t\t\}\n\n\t\theader\(/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: ip_remove lock region not found');
+			}
+			$body = preg_replace('/^elseif\b/', 'if', $m[1], 1);
+			eval(
+				'function pfb_alerts_oracle_ip_lock(string $ip, string $table, array $ip_unlock = []): string {'
+				. ' global $pfb; $_POST[\'ip_remove\'] = \'lock\';'
+				. ' $table_esc = escapeshellarg($table); $savemsg = \'\';'
+				. $body
+				. ' return $savemsg; }'
+			);
+		}
+
+		// Region 4: the ip_white if(!isset(...)) body -- captured WITHOUT its
+		// enclosing braces (the wrapper always wants this branch to run) and
+		// stopping BEFORE the header() call (3-tab indent, no blank line before
+		// it): calling header()/exit() inside PHPUnit would abort the process.
+		if (!function_exists('pfb_alerts_oracle_ip_white')) {
+			if (!preg_match(
+				'/if \(!isset\(\$clists\[\'ipwhitelist\' \. \$vtype\]\[\$table\]\[\'data\'\]\[\$ip\]\)\) \{\n(.*?)\n\t\t\theader\(/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: ip_white region not found');
+			}
+			eval(
+				'function pfb_alerts_oracle_ip_white(string $ip, string $table, string $vtype, string $descr, array &$clists): array {'
+				. ' global $pfb; $ip_esc = escapeshellarg($ip); $table_esc = escapeshellarg($table);'
+				. ' $savemsg = \'\';'
+				. $m[1]
+				. ' return [\'savemsg\' => $savemsg, \'clists\' => $clists]; }'
+			);
+		}
+	}
+
+	protected function setUp(): void
+	{
+		global $pfb;
+
+		$this->tmp       = sys_get_temp_dir() . '/pfb_alerts_checked_sites_' . getmypid() . '_' . bin2hex(random_bytes(6));
+		mkdir($this->tmp, 0777, TRUE);
+		mkdir("{$this->tmp}/alias", 0777, TRUE);
+		mkdir("{$this->tmp}/permit", 0777, TRUE);
+
+		$this->logPath   = "{$this->tmp}/calls.log";
+		$this->rulesPath = "{$this->tmp}/rules.tsv";
+		putenv("PFB_TEST_LOG={$this->logPath}");
+		putenv("PFB_TEST_RULES={$this->rulesPath}");
+		$this->shim = $this->writeShim();
+
+		$pfb['pfctl']     = $this->shim;
+		$pfb['aliasdir']  = "{$this->tmp}/alias";
+		$pfb['permitdir'] = "{$this->tmp}/permit";
+		$pfb['ip_unlock'] = "{$this->tmp}/ip_unlock.txt";
+		$pfb['supptxt']    = "{$this->tmp}/pfbsuppression.txt";
+		$pfb['supptxt_v6'] = "{$this->tmp}/pfbsuppression_v6.txt";
+		$pfb['ipconfig']   = ['v4suppression' => '', 'v6suppression' => ''];
+
+		// pfb_logger() (called on a scripted pfctl failure) needs a writable log dir --
+		// same seeding as AlertsLivePunchApplyTest/AliasDeltaApplyTest.
+		$pfb['logdir'] = "{$this->tmp}/log";
+		$pfb['log']    = "{$pfb['logdir']}/pfblockerng.log";
+		$pfb['errlog'] = "{$pfb['logdir']}/pfblockerng_error.log";
+		@mkdir($pfb['logdir'], 0777, TRUE);
+		@file_put_contents($pfb['log'], '');
+		@file_put_contents($pfb['errlog'], '');
+
+		$GLOBALS['pfb_test_write_config_calls'] = [];
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		putenv('PFB_TEST_LOG');
+		putenv('PFB_TEST_RULES');
+		rmdir_recursive($this->tmp);
+		unset($GLOBALS['pfb_test_write_config_calls'], $GLOBALS['config']);
+	}
+
+	/** Same shim shape as AlertsLivePunchApplyTest::writeShim(). */
+	private function writeShim(): string
+	{
+		$shim = "{$this->tmp}/pfctl_shim.sh";
+		file_put_contents($shim, <<<'SH'
+#!/bin/sh
+table=""
+op=""
+entry=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-t) table="$2"; shift 2 ;;
+		-T) op="$2"; shift 2 ;;
+		*) entry="$1"; shift ;;
+	esac
+done
+printf '%s|%s|%s\n' "$op" "$table" "$entry" >> "$PFB_TEST_LOG"
+if [ -z "$entry" ]; then
+	printf 'pfctl: no address specified\n' >&2
+	exit 1
+fi
+if [ -f "$PFB_TEST_RULES" ]; then
+	while IFS='|' read -r r_op r_entry r_rc r_err; do
+		if [ "$r_op" = "$op" ] && [ "$r_entry" = "$entry" ]; then
+			if [ -n "$r_err" ]; then
+				printf '%s\n' "$r_err" >&2
+			fi
+			exit "$r_rc"
+		fi
+	done < "$PFB_TEST_RULES"
+fi
+if [ "$op" = "add" ]; then
+	printf '1/1 addresses added.\n'
+else
+	printf '1/1 addresses deleted.\n'
+fi
+exit 0
+SH
+		);
+		chmod($shim, 0755);
+		return $shim;
+	}
+
+	/** Script the shim to fail a specific op+entry call. */
+	private function scriptFailure(string $op, string $entry, int $rc = 1, string $err = 'pfctl: forced failure'): void
+	{
+		file_put_contents($this->rulesPath, "{$op}|{$entry}|{$rc}|{$err}\n", FILE_APPEND);
+	}
+
+	// =====================================================================
+	// delete_ip
+	// =====================================================================
+
+	public function testDeleteIpV4FailureKeepsSuppressionEntryAndSkipsWrite(): void
+	{
+		$this->scriptFailure('add', '198.51.100.5');
+		$clists = ['ipsuppression' => ['data' => ['198.51.100.5' => "198.51.100.5\r\n"]]];
+
+		$result = pfb_alerts_oracle_delete_ip("'198.51.100.5'", "'pfB_Deny_v4'", $clists);
+
+		$this->assertFalse($result['pfb_found'], 'a failed re-add must not report success ($pfb_found)');
+		$this->assertStringContainsString('failed', $result['savemsg'], 'savemsg must name the failure');
+		$this->assertArrayHasKey(
+			'198.51.100.5',
+			$clists['ipsuppression']['data'],
+			'a failed re-add must KEEP the suppression customlist entry'
+		);
+	}
+
+	public function testDeleteIpV4SuccessRemovesEntryAndWrites(): void
+	{
+		$clists = ['ipsuppression' => ['data' => ['198.51.100.5' => "198.51.100.5\r\n"]]];
+
+		$result = pfb_alerts_oracle_delete_ip("'198.51.100.5'", "'pfB_Deny_v4'", $clists);
+
+		$this->assertTrue($result['pfb_found']);
+		$this->assertStringContainsString('Removed', $result['savemsg']);
+		$this->assertArrayNotHasKey('198.51.100.5', $clists['ipsuppression']['data']);
+		$this->assertSame(
+			['add', 'pfB_Deny_v4', '198.51.100.5'],
+			$this->lastLogRow(),
+			'the re-add must reach pfctl as -t pfB_Deny_v4 -T add 198.51.100.5'
+		);
+	}
+
+	public function testDeleteIpV6FailureKeepsSuppressionEntryAndSkipsWrite(): void
+	{
+		$this->scriptFailure('add', '2001:db8::5');
+		$clists = ['ipsuppression_v6' => ['data' => ['2001:db8::5' => "2001:db8::5\r\n"]]];
+
+		$result = pfb_alerts_oracle_delete_ip("'2001:db8::5'", "'pfB_Deny_v6'", $clists);
+
+		$this->assertFalse($result['pfb_found']);
+		$this->assertStringContainsString('failed', $result['savemsg']);
+		$this->assertArrayHasKey('2001:db8::5', $clists['ipsuppression_v6']['data']);
+	}
+
+	public function testDeleteIpV6SuccessRemovesEntryAndWrites(): void
+	{
+		$clists = ['ipsuppression_v6' => ['data' => ['2001:db8::5' => "2001:db8::5\r\n"]]];
+
+		$result = pfb_alerts_oracle_delete_ip("'2001:db8::5'", "'pfB_Deny_v6'", $clists);
+
+		$this->assertTrue($result['pfb_found']);
+		$this->assertArrayNotHasKey('2001:db8::5', $clists['ipsuppression_v6']['data']);
+	}
+
+	// =====================================================================
+	// delete_ipwhitelist
+	// =====================================================================
+
+	public function testDeleteIpWhitelistV4FailureKeepsEntryAndSkipsWrite(): void
+	{
+		$this->scriptFailure('delete', '198.51.100.9');
+		$clists = ['ipwhitelist4' => ['pfB_Permit_v4' => ['base64_idx' => 0, 'data' => ['198.51.100.9' => "198.51.100.9\r\n"]]]];
+
+		$result = pfb_alerts_oracle_delete_ipwhitelist("'198.51.100.9'", "'pfB_Permit_v4'", $clists);
+
+		$this->assertFalse($result['pfb_found'], 'a failed delete must not report success ($pfb_found)');
+		$this->assertStringContainsString('failed', $result['savemsg']);
+		$this->assertArrayHasKey(
+			'198.51.100.9',
+			$clists['ipwhitelist4']['pfB_Permit_v4']['data'],
+			'a failed delete must KEEP the Permit customlist entry'
+		);
+	}
+
+	public function testDeleteIpWhitelistV4SuccessRemovesEntryAndWrites(): void
+	{
+		$clists = ['ipwhitelist4' => ['pfB_Permit_v4' => ['base64_idx' => 0, 'data' => ['198.51.100.9' => "198.51.100.9\r\n"]]]];
+
+		$result = pfb_alerts_oracle_delete_ipwhitelist("'198.51.100.9'", "'pfB_Permit_v4'", $clists);
+
+		$this->assertTrue($result['pfb_found']);
+		$this->assertStringContainsString('deleted', $result['savemsg']);
+		$this->assertArrayNotHasKey('198.51.100.9', $clists['ipwhitelist4']['pfB_Permit_v4']['data']);
+		$this->assertSame(
+			['delete', 'pfB_Permit_v4', '198.51.100.9'],
+			$this->lastLogRow(),
+			'the delete must reach pfctl as -t pfB_Permit_v4 -T delete 198.51.100.9'
+		);
+	}
+
+	public function testDeleteIpWhitelistV6FailureKeepsEntryAndSkipsWrite(): void
+	{
+		$this->scriptFailure('delete', '2001:db8::9');
+		$clists = ['ipwhitelist6' => ['pfB_Permit_v6' => ['base64_idx' => 0, 'data' => ['2001:db8::9' => "2001:db8::9\r\n"]]]];
+
+		$result = pfb_alerts_oracle_delete_ipwhitelist("'2001:db8::9'", "'pfB_Permit_v6'", $clists);
+
+		$this->assertFalse($result['pfb_found']);
+		$this->assertStringContainsString('failed', $result['savemsg']);
+		$this->assertArrayHasKey('2001:db8::9', $clists['ipwhitelist6']['pfB_Permit_v6']['data']);
+	}
+
+	public function testDeleteIpWhitelistV6SuccessRemovesEntryAndWrites(): void
+	{
+		$clists = ['ipwhitelist6' => ['pfB_Permit_v6' => ['base64_idx' => 0, 'data' => ['2001:db8::9' => "2001:db8::9\r\n"]]]];
+
+		$result = pfb_alerts_oracle_delete_ipwhitelist("'2001:db8::9'", "'pfB_Permit_v6'", $clists);
+
+		$this->assertTrue($result['pfb_found']);
+		$this->assertArrayNotHasKey('2001:db8::9', $clists['ipwhitelist6']['pfB_Permit_v6']['data']);
+	}
+
+	// =====================================================================
+	// ip_remove == 'lock'
+	// =====================================================================
+
+	// Seeding a non-empty $ip_unlock (with a leftover 'keepme' entry) matters:
+	// pfb_unlock('lock', ...) always fopen()s the store file and, when the
+	// resulting set is empty, unlinks it right back -- an empty seed would make
+	// "no write happened" and "wrote then self-deleted" indistinguishable. With
+	// a leftover entry, a genuine write leaves an observable file.
+
+	public function testIpRemoveLockFailureSkipsUnlockStoreWrite(): void
+	{
+		$this->scriptFailure('add', '198.51.100.20');
+		$ip_unlock = ['198.51.100.20' => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4'];
+
+		$savemsg = pfb_alerts_oracle_ip_lock('198.51.100.20', 'pfB_Deny_v4', $ip_unlock);
+
+		$this->assertStringContainsString('failed', $savemsg);
+		$this->assertFileDoesNotExist(
+			$GLOBALS['pfb']['ip_unlock'],
+			'a failed re-lock must NOT write the unlock store -- the IP genuinely stays unlocked'
+		);
+	}
+
+	public function testIpRemoveLockSuccessAppliesUnlockStoreWrite(): void
+	{
+		$ip_unlock = ['198.51.100.20' => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4'];
+
+		$savemsg = pfb_alerts_oracle_ip_lock('198.51.100.20', 'pfB_Deny_v4', $ip_unlock);
+
+		$this->assertStringContainsString('re-locked', $savemsg);
+		$this->assertFileExists($GLOBALS['pfb']['ip_unlock'], 'a successful re-lock must apply the unlock store write');
+		$content = file_get_contents($GLOBALS['pfb']['ip_unlock']);
+		$this->assertStringContainsString('keepme.example', $content, 'the untouched leftover entry must survive the rewrite');
+		$this->assertStringNotContainsString('198.51.100.20', $content, 'the re-locked IP must be removed from the unlock store');
+	}
+
+	public function testIpRemoveLockZoneIdHostileEntryFailureSkipsStoreWrite(): void
+	{
+		// PFB_FILTER_IP passes zone-id IPv6 shapes (fe80::1%em0) -- a zone-id host
+		// recorded in the unlock store, then fed back into the lock re-add.
+		$this->scriptFailure('add', 'fe80::1%em0');
+		$ip_unlock = ['fe80::1%em0' => 'pfB_Deny_v6', 'keepme.example' => 'pfB_Keep_v4'];
+
+		$savemsg = pfb_alerts_oracle_ip_lock('fe80::1%em0', 'pfB_Deny_v6', $ip_unlock);
+
+		$this->assertStringContainsString('failed', $savemsg);
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
+	}
+
+	// =====================================================================
+	// ip_white
+	// =====================================================================
+
+	public function testIpWhiteV4FailureSkipsAllWrites(): void
+	{
+		$this->scriptFailure('add', '198.51.100.30');
+		$clists = ['ipwhitelist4' => ['pfB_Whitelist_v4' => ['base64_idx' => 0, 'data' => []]]];
+
+		$result = pfb_alerts_oracle_ip_white('198.51.100.30', 'pfB_Whitelist_v4', '4', '', $clists);
+
+		$this->assertStringContainsString('failed', $result['savemsg']);
+		$this->assertArrayNotHasKey(
+			'198.51.100.30',
+			$result['clists']['ipwhitelist4']['pfB_Whitelist_v4']['data'],
+			'a failed add must not update the in-memory customlist'
+		);
+		$this->assertFileDoesNotExist(
+			"{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v4.txt",
+			'a failed add must NOT append to the aliasdir .txt file'
+		);
+		$this->assertArrayNotHasKey(
+			'installedpackages',
+			$GLOBALS['config'] ?? [],
+			'a failed add must NOT call config_set_path()'
+		);
+		$this->assertEmpty(
+			$GLOBALS['pfb_test_write_config_calls'] ?? [],
+			'a failed add must NOT call write_config()'
+		);
+		$this->assertFileDoesNotExist(
+			"{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v4.update",
+			'a failed add must NOT touch the cron/update flag file'
+		);
+	}
+
+	public function testIpWhiteV4SuccessAppendsAndWrites(): void
+	{
+		$clists = ['ipwhitelist4' => ['pfB_Whitelist_v4' => ['base64_idx' => 0, 'data' => []]]];
+
+		$result = pfb_alerts_oracle_ip_white('198.51.100.31', 'pfB_Whitelist_v4', '4', '', $clists);
+
+		$this->assertStringContainsString('added', $result['savemsg']);
+		$this->assertFileExists("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v4.txt");
+		$this->assertStringContainsString('198.51.100.31', file_get_contents("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v4.txt"));
+		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
+		$this->assertFileExists("{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v4.update");
+	}
+
+	public function testIpWhiteV6FailureSkipsAllWrites(): void
+	{
+		$this->scriptFailure('add', '2001:db8::30');
+		$clists = ['ipwhitelist6' => ['pfB_Whitelist_v6' => ['base64_idx' => 0, 'data' => []]]];
+
+		$result = pfb_alerts_oracle_ip_white('2001:db8::30', 'pfB_Whitelist_v6', '6', '', $clists);
+
+		$this->assertStringContainsString('failed', $result['savemsg']);
+		$this->assertArrayNotHasKey('2001:db8::30', $result['clists']['ipwhitelist6']['pfB_Whitelist_v6']['data']);
+		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v6.txt");
+		$this->assertEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
+	}
+
+	public function testIpWhiteV6SuccessAppendsAndWrites(): void
+	{
+		$clists = ['ipwhitelist6' => ['pfB_Whitelist_v6' => ['base64_idx' => 0, 'data' => []]]];
+
+		$result = pfb_alerts_oracle_ip_white('2001:db8::31', 'pfB_Whitelist_v6', '6', '', $clists);
+
+		$this->assertStringContainsString('added', $result['savemsg']);
+		$this->assertFileExists("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v6.txt");
+		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
+	}
+
+	/** @return string[] the last [op, table, entry] row the shim logged. */
+	private function lastLogRow(): array
+	{
+		$content = trim((string) @file_get_contents($this->logPath));
+		$this->assertNotSame('', $content, 'the shim must have logged at least one call');
+		$lines = explode("\n", $content);
+		return explode('|', end($lines), 3);
+	}
+}

--- a/tests/php/PfctlCheckedOpTest.php
+++ b/tests/php/PfctlCheckedOpTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_pfctl_checked_op() -- issue #1505: the one-op checked wrapper the four
+ * Alerts page mutation sites (delete_ip, delete_ipwhitelist, ip_remove=lock,
+ * ip_white) route through instead of a raw, status-ignored exec(). Builds a
+ * single-entry pfb_live_punch_apply() plan and delegates to it -- these tests
+ * pin the wrapper's own contract (op->plan mapping, return shape, escaping),
+ * not pfb_live_punch_apply()'s internals (already covered by
+ * AlertsLivePunchApplyTest).
+ *
+ * Same injectable pfctl shim pattern as AlertsLivePunchApplyTest.
+ */
+#[CoversFunction('pfb_pfctl_checked_op')]
+final class PfctlCheckedOpTest extends TestCase
+{
+	private string $tmp;
+	private string $shim;
+	private string $logPath;
+	private string $rulesPath;
+	private string $table = 'pfB_Test_v4';
+
+	protected function setUp(): void
+	{
+		global $pfb;
+
+		$this->tmp = sys_get_temp_dir() . '/pfb_pfctl_checked_op_' . getmypid() . '_' . bin2hex(random_bytes(6));
+		mkdir($this->tmp, 0777, TRUE);
+		$this->logPath   = "{$this->tmp}/calls.log";
+		$this->rulesPath = "{$this->tmp}/rules.tsv";
+		putenv("PFB_TEST_LOG={$this->logPath}");
+		putenv("PFB_TEST_RULES={$this->rulesPath}");
+		$this->shim = $this->writeShim();
+
+		// pfb_live_punch_apply() logs via pfb_logger() on failure -- same seeding
+		// as AlertsLivePunchApplyTest.
+		$pfb['logdir'] = "{$this->tmp}/log";
+		$pfb['log']    = "{$pfb['logdir']}/pfblockerng.log";
+		$pfb['errlog'] = "{$pfb['logdir']}/pfblockerng_error.log";
+		@mkdir($pfb['logdir'], 0777, TRUE);
+		@file_put_contents($pfb['log'], '');
+		@file_put_contents($pfb['errlog'], '');
+	}
+
+	protected function tearDown(): void
+	{
+		putenv('PFB_TEST_LOG');
+		putenv('PFB_TEST_RULES');
+		rmdir_recursive($this->tmp);
+	}
+
+	/** Same shim shape as AlertsLivePunchApplyTest::writeShim(). */
+	private function writeShim(): string
+	{
+		$shim = "{$this->tmp}/pfctl_shim.sh";
+		file_put_contents($shim, <<<'SH'
+#!/bin/sh
+table=""
+op=""
+entry=""
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		-t) table="$2"; shift 2 ;;
+		-T) op="$2"; shift 2 ;;
+		*) entry="$1"; shift ;;
+	esac
+done
+printf '%s|%s|%s\n' "$op" "$table" "$entry" >> "$PFB_TEST_LOG"
+if [ -z "$entry" ]; then
+	printf 'pfctl: no address specified\n' >&2
+	exit 1
+fi
+if [ -f "$PFB_TEST_RULES" ]; then
+	while IFS='|' read -r r_op r_entry r_rc r_err; do
+		if [ "$r_op" = "$op" ] && [ "$r_entry" = "$entry" ]; then
+			if [ -n "$r_err" ]; then
+				printf '%s\n' "$r_err" >&2
+			fi
+			exit "$r_rc"
+		fi
+	done < "$PFB_TEST_RULES"
+fi
+if [ "$op" = "add" ]; then
+	printf '1/1 addresses added.\n'
+else
+	printf '1/1 addresses deleted.\n'
+fi
+exit 0
+SH
+		);
+		chmod($shim, 0755);
+		return $shim;
+	}
+
+	/** Script the shim to fail a specific op+entry call with $rc/$err. */
+	private function scriptFailure(string $op, string $entry, int $rc, string $err): void
+	{
+		file_put_contents($this->rulesPath, "{$op}|{$entry}|{$rc}|{$err}\n", FILE_APPEND);
+	}
+
+	/** @return array<int,array{0:string,1:string,2:string}> [op, table, entry] rows. */
+	private function readLog(): array
+	{
+		$content = trim((string) @file_get_contents($this->logPath));
+		if ($content === '') {
+			return [];
+		}
+		$rows = [];
+		foreach (explode("\n", $content) as $line) {
+			$rows[] = explode('|', $line, 3);
+		}
+		return $rows;
+	}
+
+	public function testOpAddEmitsDashTAddArgv(): void
+	{
+		$result = pfb_pfctl_checked_op($this->shim, $this->table, 'add', '198.18.0.1/32');
+
+		$this->assertTrue($result['ok']);
+		$this->assertNull($result['fail']);
+		$this->assertSame([['add', $this->table, '198.18.0.1/32']], $this->readLog());
+	}
+
+	public function testOpDeleteEmitsDashTDeleteArgv(): void
+	{
+		$result = pfb_pfctl_checked_op($this->shim, $this->table, 'delete', '198.18.0.1/32');
+
+		$this->assertTrue($result['ok']);
+		$this->assertNull($result['fail']);
+		$this->assertSame([['delete', $this->table, '198.18.0.1/32']], $this->readLog());
+	}
+
+	public function testScriptedFailureReturnsOkFalseWithFailString(): void
+	{
+		$this->scriptFailure('add', '198.18.0.1/32', 1, 'pfctl: forced failure');
+
+		$result = pfb_pfctl_checked_op($this->shim, $this->table, 'add', '198.18.0.1/32');
+
+		$this->assertFalse($result['ok']);
+		$this->assertSame('add 198.18.0.1/32', $result['fail']);
+	}
+
+	public function testScriptedDeleteFailureReturnsOkFalseWithFailString(): void
+	{
+		$this->scriptFailure('delete', '198.18.0.1/32', 1, 'pfctl: forced failure');
+
+		$result = pfb_pfctl_checked_op($this->shim, $this->table, 'delete', '198.18.0.1/32');
+
+		$this->assertFalse($result['ok']);
+		$this->assertSame('delete 198.18.0.1/32', $result['fail']);
+	}
+
+	public function testHostileEntryReachesShimAsOneArgvTokenNoShellInjection(): void
+	{
+		$canary = "{$this->tmp}/pwned";
+		$hostileEntry = "1.2.3.4;touch {$canary}";
+
+		$result = pfb_pfctl_checked_op($this->shim, $this->table, 'add', $hostileEntry);
+
+		$this->assertTrue($result['ok'], 'a metacharacter-laden entry must still reach pfctl as ONE literal argv, not fail the op');
+		$this->assertSame(
+			[['add', $this->table, $hostileEntry]],
+			$this->readLog(),
+			'the entry must ride as one literal argv field, never split into a second shell command'
+		);
+		$this->assertFileDoesNotExist($canary, 'the embedded `;touch` must never execute as a second shell command');
+	}
+}

--- a/tests/php/PfctlCheckedOpTest.php
+++ b/tests/php/PfctlCheckedOpTest.php
@@ -135,6 +135,15 @@ SH
 		$this->assertSame([['delete', $this->table, '198.18.0.1/32']], $this->readLog());
 	}
 
+	public function testInvalidOpThrowsInsteadOfSilentSuccess(): void
+	{
+		// A plan keyed by any verb pfb_live_punch_apply() does not iterate would
+		// return ok=TRUE with zero execs -- the guard must refuse it loudly.
+		$this->expectException(InvalidArgumentException::class);
+
+		pfb_pfctl_checked_op($this->shim, $this->table, 'kill', '198.18.0.1/32');
+	}
+
 	public function testScriptedFailureReturnsOkFalseWithFailString(): void
 	{
 		$this->scriptFailure('add', '198.18.0.1/32', 1, 'pfctl: forced failure');

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -870,6 +870,102 @@ def test_delete_ip_v6_unsuppresses_entry_and_restores_block(
 
 
 # --------------------------------------------------------------------------- #
+# entry_delete=delete_ipwhitelist (alerts.php:1400 -- issue #1505): before this
+# fix the handler ran `pfctl -T delete` and ignored exec()'s exit status, so a
+# FAILED live delete still unset the customlist entry, wrote it to config, and
+# touched the cron `.update` flag -- a fail-OPEN divergence between the config
+# store and the live pf table. pfb_pfctl_checked_op() now gates every one of
+# those writes on the pfctl outcome: a failed delete must leave the Permit
+# alias customlist entry (and the pf table) exactly as they were.
+# --------------------------------------------------------------------------- #
+
+
+def test_delete_ipwhitelist_pfctl_failure_keeps_customlist_entry(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A failed pfctl delete must not drop the Permit customlist entry (#1505).
+
+    Scenario: fail-closed store/table consistency for entry_delete=delete_ipwhitelist.
+
+    Given: a Permit v4 alias (``Wl1505``) whose only customlist host is
+    ``192.0.2.150``, and NO update/reload has ever run for it -- so its pf
+    table ``pfB_Wl1505_v4`` genuinely does not exist on the box, and
+    ``pfctl -t pfB_Wl1505_v4 -T delete`` fails with "Table does not exist"
+    (the non-kill-op failure class ``pfb_pfctl_op_failed()`` documents).
+    When: ``entry_delete=delete_ipwhitelist`` is posted for that host.
+    Then: (1) the failure savemsg is surfaced, (2) the alias's customlist
+    STILL holds the host -- the config write never ran, (3) no
+    ``Wl1505_custom_v4.update`` cron flag was touched -- the write-gate never
+    fired.
+    """
+    vm = smoke_vm
+    host = "192.0.2.150"  # RFC 5737 TEST-NET-1 -- unused elsewhere in this module
+    aliasname = "Wl1505"
+    table = f"pfB_{aliasname}_v4"
+
+    rowid = _free_list_rowid(vm, CFG_IPV4_LISTS)
+    base = f"{CFG_IPV4_LISTS}/{rowid}"
+    custom_path = f"{base}/custom"
+    permit_row = {
+        "aliasname": aliasname,
+        "action": "Permit_Inbound",
+        "custom": helpers._b64_textarea([host]),
+    }
+    update_flag = f"{helpers.PFB_DBDIR}/permit/{aliasname}_custom_v4.update"
+
+    try:
+        setup_result = helpers.php_eval(
+            vm,
+            f"config_set_path({helpers._php_str(base)}, {helpers._php_kv_array(permit_row)});\n"
+            "write_config('pfBlockerNG smoke: seed #1505 delete_ipwhitelist pfctl-failure Permit alias');\n"
+            "echo 'OK';",
+        )
+        assert setup_result.returncode == 0 and "OK" in setup_result.stdout, (
+            f"Failed to seed the Permit alias row: rc={setup_result.returncode}, stdout={setup_result.stdout!r}"
+        )
+
+        # GIVEN: the seeded customlist already holds the host ...
+        entries = _suppression_entries(vm, custom_path)
+        assert host in entries, f"{host} not present in the seeded {table} customlist before the delete POST: {entries}"
+        # ... and the pf table genuinely does not exist (no update/reload ever ran for it).
+        tables = helpers.pfctl_tables(vm)
+        assert table not in tables, f"{table} unexpectedly already exists on the box before the delete POST: {tables}"
+
+        # WHEN: entry_delete=delete_ipwhitelist for the host -- the checked
+        # pfctl delete must fail against the never-built table.
+        resp = _post_action(webui, {"entry_delete": "delete_ipwhitelist", "domain": host, "table": table})
+        assert not looks_like_login_page(resp.text), "delete_ipwhitelist POST returned the login form (session lost)"
+
+        # THEN (1): the failure savemsg is surfaced (pfblockerng_alerts.php:1430).
+        for marker in ("failed [", "customlist entry was kept"):
+            assert marker in resp.text, (
+                f"expected the pfctl-failure savemsg fragment {marker!r} after a failed delete_ipwhitelist POST; "
+                f"response body did not contain it"
+            )
+
+        # THEN (2): the customlist entry was KEPT -- no config_set_path ran.
+        entries_after = _suppression_entries(vm, custom_path)
+        assert host in entries_after, (
+            f"{host} was dropped from the {table} customlist despite the pfctl delete failing; entries={entries_after}"
+        )
+
+        # THEN (3): no cron '.update' flag was touched -- the write-gate never fired.
+        flag_present = (
+            helpers._php_read_scalar(
+                vm,
+                f"$e = file_exists({helpers._php_str(update_flag)}) ? 'YES' : 'NO';",
+                "$e",
+            )
+            == "YES"
+        )
+        assert not flag_present, f"{update_flag} unexpectedly exists after a failed delete_ipwhitelist POST"
+    finally:
+        _del_list_row(vm, CFG_IPV4_LISTS, rowid)
+        helpers.php_eval(vm, f"@unlink({helpers._php_str(update_flag)}); echo 'OK';")
+
+
+# --------------------------------------------------------------------------- #
 # ip_remove (alerts.php:1490 -- ADR-53 parity, issue #1412): the temporary IP
 # Unlock/Re-Lock action. The retired handler deleted/added a SINGLE token
 # directly via pfctl -- for a bare-host table entry that matched (the ONE

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -870,13 +870,9 @@ def test_delete_ip_v6_unsuppresses_entry_and_restores_block(
 
 
 # --------------------------------------------------------------------------- #
-# entry_delete=delete_ipwhitelist (alerts.php:1400 -- issue #1505): before this
-# fix the handler ran `pfctl -T delete` and ignored exec()'s exit status, so a
-# FAILED live delete still unset the customlist entry, wrote it to config, and
-# touched the cron `.update` flag -- a fail-OPEN divergence between the config
-# store and the live pf table. pfb_pfctl_checked_op() now gates every one of
-# those writes on the pfctl outcome: a failed delete must leave the Permit
-# alias customlist entry (and the pf table) exactly as they were.
+# entry_delete=delete_ipwhitelist (alerts.php:1400 -- issue #1505): fail-closed
+# invariant -- every customlist/config write and the cron `.update` flag gate on
+# the checked pfctl delete outcome; a failed delete must change nothing.
 # --------------------------------------------------------------------------- #
 
 


### PR DESCRIPTION
Fixes #1505

## What

The four remaining `pfctl -T add/delete` exec sites in `pfblockerng_alerts.php` ignored the exec status — a failed table mutation still got its config/store write and a success savemsg (fail-open unblocking or persistent store/table drift until the next rebuild):

- `delete_ip` (un-suppress re-add)
- `delete_ipwhitelist` (Permit customlist delete)
- `ip_remove=lock` (re-lock re-add)
- `ip_white` (Permit customlist add)

New helper `pfb_pfctl_checked_op()` (`pfblockerng_extra.inc`) builds a one-entry plan and routes it through the landed fail-closed executor `pfb_live_punch_apply()` — status checked via `pfb_pfctl_op_failed()`, one attributed log line on failure, and **never** `pfb_pfctl_table_op()` (its ADR-61 sync-status ledger entry would let the tick retry sweep mirror-replace the table and revert valid live punches — see `pfb_live_punch_apply()`'s docblock). Each site now runs the checked op first and gates every store/config write and the success savemsg on the outcome; on failure nothing is written, `$pfb_found = FALSE` skips `write_config()` where applicable, and the savemsg names the failure (style of the existing unlock `failed` branch). Success paths are behaviour-identical.

## Tests

- **Red→green (test-first, executed):** `tests/php/AlertsPfctlCheckedSitesTest.php` — region-extraction reproductions of all four handler blocks (verbatim source, anchors stable across pre/post-fix) driven through a scripted POSIX-sh pfctl shim. Red on pre-fix base `fc7de565`: 8 failure-path tests failed for the exact defect (store write + success savemsg despite failed pfctl); green post-fix: 20/20, test file frozen byte-identical (red-time `git hash-object` `7fd6b81f…` equals the committed file). Independently re-executed by a separate verifier via `scripts/agent/verify-red-proof.sh` (`FREEZE-OK` / `RED-OK` / `GREEN-OK` / `VERDICT: PASS`), including a per-test discrimination check (each failure-path test individually red on the pre-fix source).
- **Coverage matrix:** per site {v4, v6} × {pfctl failure, success} store-state + savemsg assertions; lock zone-id hostile row (`fe80::1%em0`); helper unit tests (`tests/php/PfctlCheckedOpTest.php`) for op routing, ok/fail shape, and one-argv-token escaping (shell-metacharacter entry, canary file never created).
- **Tier-B live e2e (coverage pairing for the `www/` change):** `test_delete_ipwhitelist_pfctl_failure_keeps_customlist_entry` in `tests/smoke/ui/test_alerts.py` — seeds a Permit alias whose pf table was never built, so the handler's checked delete hits a genuine `pfctl: Table does not exist`; asserts failure savemsg, customlist entry retained, and no `.update` cron flag. Executed green on a leased smoke box against this branch: `1 passed, 458 deselected in 55.47s`. A live RED execution was deferred as redundant with the PHPUnit red proof (it pins the same invariant and would require pushing a scratch pre-fix+test ref).

## Gates

`run-gates.sh --diff origin/devel` all green (php -l, full PHPUnit 3813 tests, phpstan `[OK]`, phpcs clean, pytest/ruff/ruff-format/mypy for the touched Python test module, comment-narration clean). Verified by independent small-tier verifiers on both steps (diff-vs-claims cross-checks, test-honesty and anchor-uniqueness probes included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Alerts page IP suppression, Permit Alias, locking, and whitelist actions.
  - Changes are now applied only when the underlying firewall operation succeeds.
  - Failed operations display an error and preserve existing entries and configuration.
  - Prevented partial updates that could leave firewall state and saved settings out of sync.
  - Added safer handling for unusual or potentially unsafe address values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->