### PR TITLE
gc: reset $ftotal4/$ftotal6 per continent so data-less continents render 0

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1511,6 +1511,11 @@ function pfblockerng_get_countries() {
 
 	foreach ($geoip_files as $cont => $file) {
 
+		// issue #1507: $ftotal4/$ftotal6 are assigned only when a continent has
+		// data -- reset per continent so a data-less one renders 0, not the
+		// previous continent's count.
+		$ftotal4 = $ftotal6 = 0;
+
 		// Process the following for IPv4 and IPv6
 		foreach (array('4', '6') as $type) {
 

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1489,7 +1489,6 @@ function pfblockerng_get_countries() {
 
 	$coptions4 = $coptions6 = array();
 	$options4 = $options6 = '';
-	$ftotal4 = $ftotal6 = 0;
 
 	$geoip_files = array (	'Africa'		=> "{$pfb['ccdir']}/Africa_v4.txt",
 				'Antarctica'		=> "{$pfb['ccdir']}/Antarctica_v4.txt",

--- a/tests/php/PfbOptionsHeredocMultiContinentTest.php
+++ b/tests/php/PfbOptionsHeredocMultiContinentTest.php
@@ -46,9 +46,11 @@ require_once __DIR__ . '/PfbNoPhpWarningTrait.php';
  *          block, so without a per-continent reset a data-less continent
  *          renders the PREVIOUS continent's count beside an empty list
  *
- *   Scenario: continent 1 has one IPv4 entry (count 1), continent 2 has
+ *   Scenario: continent 1 has one IPv4 entry AND one IPv6 entry (count 1
+ *             each -- both types populated, so a reset dropped for either
+ *             type alone is independently falsifiable), continent 2 has
  *             none -> continent 2's heredoc-equivalent count must render
- *             "0", not continent 1's stale "1"
+ *             "0" for BOTH types, not continent 1's stale "1"
  */
 final class PfbOptionsHeredocMultiContinentTest extends TestCase
 {
@@ -110,10 +112,10 @@ final class PfbOptionsHeredocMultiContinentTest extends TestCase
 			. ' $ftotal4 = $ftotal6 = 0;'
 			. ' $cont = "TestCont";'
 			. ' $rendered = [];'
-			. ' foreach ([TRUE, FALSE] as $continentHasV4Data) {'
+			. ' foreach ([TRUE, FALSE] as $continentHasData) {'
 			. '   ' . $loopTop
 			. '   foreach (array("4", "6") as $type) {'
-			. '     if ($type === "4" && $continentHasV4Data) {'
+			. '     if ($continentHasData) {'
 			. '       ${"coptions" . $type}[] = \'x|"US" => "Test US (1)"\';'
 			. '     }'
 			. '     ' . $typeBlock
@@ -148,7 +150,7 @@ final class PfbOptionsHeredocMultiContinentTest extends TestCase
 		});
 
 		$this->assertSame('1', $rendered[0]['cnt4'], 'before-state anchor: continent 1 (one IPv4 entry) must render count 1 -- the very value a stale carry would leak into continent 2');
-		$this->assertSame('0', $rendered[0]['cnt6'], 'sanity: continent 1 has no IPv6 data, so its IPv6 count must render 0');
+		$this->assertSame('1', $rendered[0]['cnt6'], 'before-state anchor: continent 1 (one IPv6 entry) must render count 1 -- the very value a stale carry would leak into continent 2 (non-vacuity: without this, cnt6 is 0 on every continent regardless of the reset, and the continent-2 assertion below can never fail)');
 		$this->assertSame(
 			'0',
 			$rendered[1]['cnt4'],

--- a/tests/php/PfbOptionsHeredocMultiContinentTest.php
+++ b/tests/php/PfbOptionsHeredocMultiContinentTest.php
@@ -22,12 +22,14 @@ require_once __DIR__ . '/PfbNoPhpWarningTrait.php';
  * 1b9ab1fa was an artifact of that blindness, not proof -- this test
  * drives the REAL multi-continent control flow instead.
  *
- * Extracts three verbatim anchors from pfblockerng.php: the per-type
+ * Extracts four verbatim anchors from pfblockerng.php: whatever sits at
+ * the top of the continent loop (the per-continent $ftotal4/$ftotal6
+ * reset -- extracted POSITIONALLY, not hand-copied, so this test proves
+ * the issue #1507 fix lands in the right place), the per-type
  * coptions-guarded options-build block (+ its trailing $coptions* unset),
  * whatever guard sits between the type-loop's close and the heredoc start
- * (empty pre-fix; the reinstated `??=` pair post-fix -- extracted
- * POSITIONALLY, not hand-copied, so this test proves the actual fix
- * lands in the right place), and the final $options4/$options6 unset.
+ * (the `??=` pair, same positional-extraction contract), and the final
+ * $options4/$options6 unset.
  * Drives two simulated continent iterations -- the file itself cannot be
  * require()d off-appliance (house precedent: CountryNetworksCountGuardTest.php,
  * GeoipContinentCatStderrGuardTest.php, PfbEtOptionsUndefinedTest.php).
@@ -38,6 +40,15 @@ require_once __DIR__ . '/PfbNoPhpWarningTrait.php';
  *   Scenario: continent 1 has IPv4 data, continent 2 has none -> continent
  *             2's heredoc-equivalent read must not warn, and must render
  *             as the empty string
+ *
+ * Feature: issue #1507 -- $ftotal4/$ftotal6 must render each continent's
+ *          OWN count; $ftotal* is assigned only inside the coptions-guarded
+ *          block, so without a per-continent reset a data-less continent
+ *          renders the PREVIOUS continent's count beside an empty list
+ *
+ *   Scenario: continent 1 has one IPv4 entry (count 1), continent 2 has
+ *             none -> continent 2's heredoc-equivalent count must render
+ *             "0", not continent 1's stale "1"
  */
 final class PfbOptionsHeredocMultiContinentTest extends TestCase
 {
@@ -53,6 +64,14 @@ final class PfbOptionsHeredocMultiContinentTest extends TestCase
 		$src = file_get_contents($path);
 		if ($src === FALSE) {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng.php');
+		}
+
+		if (!preg_match(
+			'/foreach \(\$geoip_files as \$cont => \$file\) \{\n(.*?)\/\/ Process the following for IPv4 and IPv6/s',
+			$src,
+			$mLoopTop
+		)) {
+			throw new RuntimeException('oracle extraction failed: the continent-loop-top region (between the outer foreach open and the per-type loop comment) was not found in pfblockerng.php');
 		}
 
 		if (!preg_match(
@@ -79,6 +98,7 @@ final class PfbOptionsHeredocMultiContinentTest extends TestCase
 			throw new RuntimeException('oracle extraction failed: the final $options4/$options6 unset was not found in pfblockerng.php');
 		}
 
+		$loopTop    = $mLoopTop[1];
 		$typeBlock  = $mBlock[0];
 		$postGuard  = $mGuard[1];
 		$finalUnset = $mUnset[0];
@@ -91,6 +111,7 @@ final class PfbOptionsHeredocMultiContinentTest extends TestCase
 			. ' $cont = "TestCont";'
 			. ' $rendered = [];'
 			. ' foreach ([TRUE, FALSE] as $continentHasV4Data) {'
+			. '   ' . $loopTop
 			. '   foreach (array("4", "6") as $type) {'
 			. '     if ($type === "4" && $continentHasV4Data) {'
 			. '       ${"coptions" . $type}[] = \'x|"US" => "Test US (1)"\';'
@@ -98,7 +119,7 @@ final class PfbOptionsHeredocMultiContinentTest extends TestCase
 			. '     ' . $typeBlock
 			. '   }'
 			. '   ' . $postGuard . ';'
-			. '   $rendered[] = "{$options4}{$options6}";'
+			. '   $rendered[] = ["options" => "{$options4}{$options6}", "cnt4" => "{$ftotal4}", "cnt6" => "{$ftotal6}"];'
 			. '   ' . $finalUnset
 			. ' }'
 			. ' return $rendered;'
@@ -112,11 +133,31 @@ final class PfbOptionsHeredocMultiContinentTest extends TestCase
 			return pfb_options_heredoc_oracle();
 		});
 
-		$this->assertNotSame('', $rendered[0], 'sanity: continent 1 (has IPv4 data) must render something non-empty');
+		$this->assertNotSame('', $rendered[0]['options'], 'sanity: continent 1 (has IPv4 data) must render something non-empty');
 		$this->assertSame(
 			'',
-			$rendered[1],
+			$rendered[1]['options'],
 			'$options4/$options6 must render as the empty string on a data-less continent (unset by the previous continent\'s tail, never reassigned since its coptions4/6 are empty), not an undefined-variable NULL'
+		);
+	}
+
+	public function testSecondContinentWithNoDataRendersZeroCounts(): void
+	{
+		$rendered = $this->assertNoPhpWarning(static function (): array {
+			return pfb_options_heredoc_oracle();
+		});
+
+		$this->assertSame('1', $rendered[0]['cnt4'], 'before-state anchor: continent 1 (one IPv4 entry) must render count 1 -- the very value a stale carry would leak into continent 2');
+		$this->assertSame('0', $rendered[0]['cnt6'], 'sanity: continent 1 has no IPv6 data, so its IPv6 count must render 0');
+		$this->assertSame(
+			'0',
+			$rendered[1]['cnt4'],
+			'issue #1507: $options_countries4_cnt must render 0 on a data-less continent, not the previous continent\'s stale $ftotal4'
+		);
+		$this->assertSame(
+			'0',
+			$rendered[1]['cnt6'],
+			'issue #1507: $options_countries6_cnt must render 0 on a data-less continent, not a stale $ftotal6'
 		);
 	}
 }

--- a/tests/smoke/ui/test_render_dataless_continent_count.py
+++ b/tests/smoke/ui/test_render_dataless_continent_count.py
@@ -1,0 +1,161 @@
+"""Tier-A ``ui_render`` coverage for issue #1507: a data-less continent renders count 0.
+
+``pfblockerng_get_countries()`` (the ``gc`` verb) writes each continent page with
+``$options_countries4_cnt``/``$options_countries6_cnt`` rendered as the ``size``
+attribute of the ``countries4``/``countries6`` selects (pfblockerng.php:2002/2011).
+``$ftotal4``/``$ftotal6`` are assigned only inside the per-type coptions-guarded
+build block, so before the #1507 fix a continent whose file yields NO country
+entries rendered the PREVIOUS continent's count beside an empty list. The seeded
+MaxMind test corpus gives every one of the 9 continents at least one entry (e.g.
+``Antarctica [6697173] AQ (0)``), so the ``PAGE_TABLE`` sweep never drives the
+stays-empty path -- this module manufactures it on the live box.
+
+The data-less continent is manufactured as a header-ONLY continent file
+(``# Continent IPv{4,6}:`` + ``# Continent en:`` lines kept, all country blocks
+stripped), NOT a missing file: with a missing file ``$continent_en`` carries over
+from the previous continent (a distinct pre-existing defect, out of #1507's
+scope) and the regenerated page would be written to the WRONG path. Header-only
+keeps the page's own name/title correct and isolates exactly the ``$ftotal``
+carry.
+
+Fail-before / pass-after: pre-fix, the mutated ``gc`` run regenerates the
+Antarctica page with Africa's (the previous continent's) nonzero counts as the
+select sizes, so the ``size="0"`` assertions fail; they pass only with the
+per-continent reset. The off-appliance red run is executed and pinned by
+``tests/php/PfbOptionsHeredocMultiContinentTest.php``.
+
+AUTHORED, NOT EXECUTED this session (no live VM) -- run via
+``pytest tests/smoke/ui -m ui_render --override-ini="addopts="`` on the fan-out VM.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+
+if TYPE_CHECKING:
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+_CC_DIR = "/usr/local/share/GeoIP/cc"
+_ANTARCTICA_V4 = f"{_CC_DIR}/Antarctica_v4.txt"
+_ANTARCTICA_V6 = f"{_CC_DIR}/Antarctica_v6.txt"
+_BAK_SUFFIX = ".pfb1507bak"
+
+_AFRICA_PAGE = "/pfblockerng/pfblockerng_Africa.php"
+_ANTARCTICA_PAGE = "/pfblockerng/pfblockerng_Antarctica.php"
+
+
+def _select_size(body: str, name: str, page: str) -> str:
+    """The ``size`` attribute of the ``<select name="{name}[]">`` on ``page``'s body."""
+    tag = re.search(rf'<select\b[^>]*name="{re.escape(name)}(?:\[\])?"[^>]*>', body)
+    assert tag is not None, f"{page}: no <select> named {name!r} in the rendered body"
+    size = re.search(r'size="(\d+)"', tag.group(0))
+    assert size is not None, f"{page}: the {name!r} select carries no numeric size attribute: {tag.group(0)!r}"
+    return size.group(1)
+
+
+def test_dataless_continent_renders_zero_counts(smoke_vm: SmokeVM, webui: WebUI) -> None:
+    """issue #1507: a continent with no country entries renders count 0, not a stale carry.
+
+    Scenario:
+      Given the seeded corpus (baseline Antarctica renders a nonzero select size),
+        and Antarctica's continent files stripped to their headers (no country
+        blocks -- the "MaxMind data gap" producer from the issue),
+      When  ``gc`` regenerates the continent pages,
+      Then  the Antarctica page still passes the Tier-A oracle and BOTH its
+            country selects render ``size="0"`` -- while Africa (the continent
+            whose counts a stale ``$ftotal4``/``$ftotal6`` carry would have
+            leaked here) renders nonzero sizes in the same run.
+    """
+    resp = webui.get(_ANTARCTICA_PAGE)
+    result = evaluate_render(_ANTARCTICA_PAGE, resp.status_code, resp.text, ("Continent - Antarctica",))
+    assert result.ok, f"baseline Antarctica render oracle failed: {result.detail}"
+    baseline_size4 = _select_size(resp.text, "countries4", _ANTARCTICA_PAGE)
+    assert baseline_size4 != "0", (
+        "before-state anchor: seeded Antarctica must render a nonzero IPv4 select size "
+        "(every corpus continent carries at least one entry), else the final size=0 proves nothing"
+    )
+
+    mutated = False
+    try:
+        backup = smoke_vm.ssh(
+            f"cp -p {_ANTARCTICA_V4} {_ANTARCTICA_V4}{_BAK_SUFFIX}"
+            f" && cp -p {_ANTARCTICA_V6} {_ANTARCTICA_V6}{_BAK_SUFFIX}"
+        )
+        assert backup.returncode == 0, (
+            f"failed to back up Antarctica cc files: rc={backup.returncode} {backup.stderr!r}"
+        )
+        mutated = True
+
+        strip = smoke_vm.ssh(
+            f"grep '^# Continent' {_ANTARCTICA_V4}{_BAK_SUFFIX} > {_ANTARCTICA_V4}"
+            f" && grep '^# Continent' {_ANTARCTICA_V6}{_BAK_SUFFIX} > {_ANTARCTICA_V6}"
+        )
+        assert strip.returncode == 0, (
+            f"failed to strip Antarctica cc files to headers: rc={strip.returncode} {strip.stderr!r}"
+        )
+
+        gc = smoke_vm.ssh(helpers.PHP_BIN, helpers.PFB_CLI, "gc", timeout=600)
+        assert gc.returncode == 0, (
+            f"gc on header-only Antarctica failed: rc={gc.returncode} {gc.stderr!r} {gc.stdout!r}"
+        )
+
+        guard = PhpErrorLogGuard(smoke_vm)
+        guard.snapshot()
+
+        africa = webui.get(_AFRICA_PAGE)
+        africa_result = evaluate_render(_AFRICA_PAGE, africa.status_code, africa.text, ("Continent - Africa",))
+        assert africa_result.ok, f"Africa render oracle failed after the mutated gc: {africa_result.detail}"
+        assert _select_size(africa.text, "countries4", _AFRICA_PAGE) != "0", (
+            "non-vacuity anchor: Africa (the previous continent in $geoip_files order) must render a "
+            "nonzero IPv4 size in this very gc run -- the value a stale $ftotal4 carry would leak into Antarctica"
+        )
+        assert _select_size(africa.text, "countries6", _AFRICA_PAGE) != "0", (
+            "non-vacuity anchor: Africa must render a nonzero IPv6 size in this very gc run -- the value a "
+            "stale $ftotal6 carry would leak into Antarctica"
+        )
+
+        resp = webui.get(_ANTARCTICA_PAGE)
+        result = evaluate_render(_ANTARCTICA_PAGE, resp.status_code, resp.text, ("Continent - Antarctica",))
+        assert result.ok, f"data-less Antarctica render oracle failed: {result.detail}"
+        assert _select_size(resp.text, "countries4", _ANTARCTICA_PAGE) == "0", (
+            "issue #1507: a data-less continent's IPv4 select must render size=0, "
+            "not the previous continent's stale $ftotal4"
+        )
+        assert _select_size(resp.text, "countries6", _ANTARCTICA_PAGE) == "0", (
+            "issue #1507: a data-less continent's IPv6 select must render size=0, "
+            "not the previous continent's stale $ftotal6"
+        )
+
+        guard.assert_no_growth()
+    finally:
+        if mutated:
+            restore = smoke_vm.ssh(
+                f"mv {_ANTARCTICA_V4}{_BAK_SUFFIX} {_ANTARCTICA_V4}"
+                f" && mv {_ANTARCTICA_V6}{_BAK_SUFFIX} {_ANTARCTICA_V6}"
+            )
+            if restore.returncode != 0:
+                raise AssertionError(
+                    f"failed to restore Antarctica cc files: rc={restore.returncode} {restore.stderr!r}"
+                )
+            regen = smoke_vm.ssh(helpers.PHP_BIN, helpers.PFB_CLI, "gc", timeout=600)
+            if regen.returncode != 0:
+                raise AssertionError(
+                    f"gc after restore failed: rc={regen.returncode} {regen.stderr!r} {regen.stdout!r}"
+                )
+
+    # Loud self-encapsulation check: the restore + regen must actually take, so
+    # later tests (the PAGE_TABLE sweep, the seeded-csv needles) see the
+    # original pages regardless of ordering.
+    resp = webui.get(_ANTARCTICA_PAGE)
+    assert _select_size(resp.text, "countries4", _ANTARCTICA_PAGE) == baseline_size4, (
+        "post-restore Antarctica IPv4 select size did not return to its baseline -- the restore/regen did not take"
+    )


### PR DESCRIPTION
Fixes #1507.

## What

In `pfblockerng_get_countries()` (the `gc` verb), `$ftotal4`/`$ftotal6` are assigned only inside the per-type `coptions`-guarded build block and were never reset between continent iterations. A continent with no data for a type (missing/empty continent file) therefore rendered the **previous** continent's count (`$options_countries4_cnt`/`$options_countries6_cnt`, the country selects' `size` attribute) next to its — correctly empty — options list. This pre-existing behaviour was traced and deliberately preserved byte-for-byte by PR #1506 (warning-removal contract), then deferred here as a user-visible fix.

The fix resets `$ftotal4 = $ftotal6 = 0;` at the top of each continent iteration, so a data-less continent renders `0`. The per-continent reset makes the #1506 function-top `$ftotal4 = $ftotal6 = 0;` init dead code (the fixed 9-entry `$geoip_files` loop always runs), so that line is removed — a single init site remains (review round 1 finding).

## Red -> green proof (executed)

`tests/php/PfbOptionsHeredocMultiContinentTest.php` gains a fourth positionally-extracted anchor (the continent-loop-top region, so the test proves the reset lands in the right place, not a hand-copy) and a new test capturing the heredoc-equivalent count renders per continent.

RED on untouched production code (test file `git hash-object` = `1ed5098589bf68a1025b68ee56600ea68de702ba`):

```text
1) PfbOptionsHeredocMultiContinentTest::testSecondContinentWithNoDataRendersZeroCounts
issue #1507: $options_countries4_cnt must render 0 on a data-less continent, not the previous continent's stale $ftotal4
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'0'
+'1'
Tests: 2, Assertions: 7, Failures: 1.
```

GREEN after the one-line reset, test file byte-identical (`git hash-object` still `1ed5098589bf68a1025b68ee56600ea68de702ba`):

```text
OK (2 tests, 8 assertions)
```

## Tier-A coverage (test mandate #4)

New module `tests/smoke/ui/test_render_dataless_continent_count.py` (`ui_render`): the seeded MaxMind corpus gives every one of the 9 continents at least one entry, so the stays-empty `$ftotal` path was never driven in-tier. The test manufactures a data-less continent on the live box — Antarctica's cc files stripped to their `# Continent` headers (header-only, not missing, to stay independent of the separate `$continent_en` carry defect tracked in #1515) — reruns `gc`, and asserts the Antarctica page passes the Tier-A oracle with both country selects rendering `size="0"`, while Africa (the continent whose counts a stale carry would have leaked) renders nonzero sizes in the same run. Baseline and post-restore assertions pin before-state and self-encapsulation (restore + regen in `finally`). Authored, not executed in this session (no live VM); the Tier-A CI leg runs it. Tier B is not required: no new page, no multi-step flow, no structural change.

## Gates

`scripts/agent/run-gates.sh --diff origin/devel` on the rebased head:

```text
GATE PASS: python3 -m pytest
GATE PASS: ruff check .
GATE PASS: ruff format --check .
GATE PASS: mypy tests/
GATE PASS: python3 scripts/check_composer_vendor.py
GATE PASS: php -l src/usr/local/www/pfblockerng/pfblockerng.php
GATE PASS: php -l tests/php/PfbOptionsHeredocMultiContinentTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

`git diff origin/devel --name-only | python3 scripts/check_coverage_pairing.py` → `Coverage pairing OK: no src<->tests or www<->ui-tests violation.`

Full PHPUnit suite: 3794 tests / 22583 assertions OK (the 1 deprecation + 1 notice are pre-existing `pfblockerng.inc` curl items on PHP 8.5, untouched by this diff).

## Deferred

- #1515 — `$continent`/`$continent_en` stale carry writes a data-less continent's page to the previous continent's path (outside-diff review finding, pre-existing, out of #1507's scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed continent pages with no country data incorrectly displaying counts carried over from another continent.
  - Empty IPv4 and IPv6 country lists now correctly display counts of `0`.
  - Prevented warnings when rendering continents without available country data.
  - Preserved correct counts for continents that contain data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->