### PR TITLE
tests/smoke: make syslog export tests order-independent

### DIFF
--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -953,6 +953,9 @@ def test_syslog_off_no_new_records(deployed_vm: SmokeVM, client_vm: SmokeVM) -> 
     assert seed_line, (
         f"Seeding failed: no export record for {domain} with export ON.\n{syslog_export_state_snapshot(vm)}"
     )
+    # Let any trailing export from the seed probe land before baselining — a duplicate
+    # in-flight event would otherwise read as a spurious "OFF gate" failure below.
+    time.sleep(FILTERLOG_SETTLE_SECS)
 
     count_while_on = len(_pfb_event_lines(vm))
 

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -178,6 +178,20 @@ def deployed_vm(
     yield smoke_vm
 
 
+@pytest.fixture(autouse=True)
+def _syslog_export_off(deployed_vm: SmokeVM) -> None:
+    """Per-test isolation (#1396): every test starts with syslog export OFF.
+
+    A test that needs export ON seeds it itself — no test may inherit the toggle
+    (or prior export records) from a sibling, so each node passes alone through
+    the filtered smoke path and in any order. Fails loudly if the reset does not
+    take (a module-scoped baseline is NOT per-test isolation).
+    """
+    _set_syslog_enabled(deployed_vm, on=False)
+    val = h.config_get(deployed_vm, CFG_GENERAL + "/log_syslog")
+    assert val == "", f"syslog-export OFF reset did not take: log_syslog={val!r}"
+
+
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
@@ -501,8 +515,9 @@ def test_syslog_routing_and_rotation_registered(deployed_vm: SmokeVM) -> None:
 def test_syslog_on_dnsbl_event_exported(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
     """OFF ⇒ no export record; ON ⇒ a pfblockerng record per DNSBL block, host-side, no restart.
 
-    Given: DNSBL blocking TWO distinct domains (VIP); syslog export OFF (fixture default),
-           so NO event line exists in pfblockerng_syslog.log yet.
+    Given: DNSBL blocking TWO distinct domains (VIP); syslog export OFF (per-test
+           reset, #1396). The OFF/ON proof is baseline-relative, so records left by
+           sibling tests (any order) don't matter.
     When:  domain_off is probed WHILE export is STILL OFF (no restart) — the DNSBL block
            itself still fires (proven via the CSV dnsbl.log marker), but must export
            nothing. THEN log_syslog is enabled (write_config ONLY — no restart) and the
@@ -520,7 +535,7 @@ def test_syslog_on_dnsbl_event_exported(deployed_vm: SmokeVM, client_vm: SmokeVM
     domain_on: str = vm._pfb_dnsbl_domain_on  # type: ignore[attr-defined]
     civm_ip: str = vm._pfb_civm_ip  # type: ignore[attr-defined]
 
-    # Given: syslog export OFF (fixture default) — no event lines recorded yet.
+    # Given: syslog export OFF (per-test reset) — baseline whatever is already there.
     before = _pfb_event_lines(vm)
     sys_leak_before = len(_system_log_export_leaks(vm))
 
@@ -601,7 +616,8 @@ def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: Smok
     """ON ⇒ a pfblockerng record per IP Block event in the dedicated file.
 
     Given: a floating Deny_Outbound rule covering TEST_IP_BLOCK_RANGE; syslog export
-           ON (from the DNSBL test); the filterlog daemon running; the civm client
+           ON (seeded by THIS test — LIVE toggle, no restart, never inherited from a
+           sibling, #1396); the filterlog daemon running; the civm client
            behind the firewall.
     When:  the civm client curls the blocked WAN IP (pass-through traffic pf blocks
            + logs on WAN-out — NOT pfSense's own traffic, which the rule misses).
@@ -613,8 +629,10 @@ def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: Smok
     """
     vm = deployed_vm
 
+    # Seed our own ON state LIVE (no restart) — never inherited from a sibling (#1396).
+    _set_syslog_enabled(vm, on=True)
     val = h.config_get(vm, CFG_GENERAL + "/log_syslog")
-    assert val == "on", f"Precondition: expected log_syslog='on' from prior test, got {val!r}"
+    assert val == "on", f"seeded log_syslog did not take: expected 'on', got {val!r}"
 
     before = _pfb_event_lines(vm)
     ip_block_before = h.read_log_file(vm, IP_BLOCK_LOG)
@@ -909,11 +927,13 @@ def test_ip_attribution_cache_invalidated_after_feed_ownership_change(deployed_v
 def test_syslog_off_no_new_records(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
     """OFF ⇒ zero export; CSV logging unchanged — LIVE toggle, no restart.
 
-    Before/after proof: first assert ON produced records (true from prior tests),
-    then disable LIVE and assert the count does NOT increase. Exercised via the
-    DNSBL leg (a re-probe of the blocked domain from civm).
+    Before/after proof: first seed export ON and prove ONE exported record in-test
+    (never inherited from a sibling, #1396), then disable LIVE and assert the count
+    does NOT increase. Exercised via the DNSBL leg (probes of the blocked domain
+    from civm).
 
-    Given: syslog export ON (from prior tests), records already in the dedicated file.
+    Given: syslog export ON (seeded by THIS test) with a verified export record of
+           its own in the dedicated file.
     When:  log_syslog set OFF (write_config ONLY — no restart); the blocked domain is
            probed again from civm.
     Then:  the export-record count does NOT increase — the daemon honored the LIVE off.
@@ -921,12 +941,20 @@ def test_syslog_off_no_new_records(deployed_vm: SmokeVM, client_vm: SmokeVM) -> 
     """
     vm = deployed_vm
     domain: str = vm._pfb_dnsbl_domain  # type: ignore[attr-defined]
+    civm_ip: str = vm._pfb_civm_ip  # type: ignore[attr-defined]
+
+    # Seed our own ON record (#1396): enable LIVE, probe, and prove ONE exported event —
+    # the before-state for the OFF flip is created here, never inherited from a sibling.
+    seed_baseline = len(_pfb_event_lines(vm))
+    _set_syslog_enabled(vm, on=True)
+    ans = h.dns_probe_client(client_vm, domain, "A")
+    assert h.is_vip(ans), f"DNSBL block should fire while seeding the ON record, got {ans}"
+    seed_line = _wait_for_event(vm, baseline_len=seed_baseline, want=("act=dnsbl", f"qname={domain}", f"qip={civm_ip}"))
+    assert seed_line, (
+        f"Seeding failed: no export record for {domain} with export ON.\n{syslog_export_state_snapshot(vm)}"
+    )
 
     count_while_on = len(_pfb_event_lines(vm))
-    assert count_while_on > 0, (
-        f"Precondition: expected export records from prior ON tests, but {PFB_SYSLOG_LOG} has "
-        f"{count_while_on}.\n{syslog_export_state_snapshot(vm)}"
-    )
 
     dnsbl_csv_before = h.count_log_marker(vm, DNSBL_LOG, domain)
 


### PR DESCRIPTION
## Problem

Two live-smoke tests in `tests/smoke/test_syslog_export.py` depended on state or records created by an earlier sibling (#1396):

- `test_syslog_on_ip_block_event_exported` required `log_syslog` to be ON from `test_syslog_on_dnsbl_event_exported`, although the shared fixture initializes it OFF.
- `test_syslog_off_no_new_records` required prior ON records without creating and verifying its own ON event first.

Source-order collection masked the dependency; the supported `pytest_filter` smoke path selects either node independently and failed its precondition.

## Fix

- New autouse fixture `_syslog_export_off` resets `log_syslog` OFF before every test in the module and fails loudly if the reset does not take (per-test isolation, not a module-scoped baseline).
- `test_syslog_on_ip_block_event_exported` seeds its own ON state (LIVE toggle, no restart) and verifies the readback; the IP-block export event it then generates and asserts is its own.
- `test_syslog_off_no_new_records` seeds ON, probes the blocked domain from civm, and proves ONE exported DNSBL record of its own before flipping OFF — the before-state for the OFF proof is created in-test.
- `test_syslog_on_dnsbl_event_exported` keeps its OFF→ON transition proof; its baselines were already relative, and the per-test reset now guarantees its OFF starting state in any order.

## Red→green evidence (leased smoke VM, `scripts/local-smoke.sh`)

**RED** — `--ref devel` (pre-fix), `--filter "test_syslog_on_ip_block_event_exported or test_syslog_off_no_new_records"`, box `root@10.0.0.32`:

```
FAILED tests/smoke/test_syslog_export.py::test_syslog_on_ip_block_event_exported
E       AssertionError: Precondition: expected log_syslog='on' from prior test, got ''
FAILED tests/smoke/test_syslog_export.py::test_syslog_off_no_new_records
E       AssertionError: Precondition: expected export records from prior ON tests, but /var/log/pfblockerng_syslog.log has 0.
================= 2 failed, 808 deselected in 77.53s (0:01:17) =================
```

**GREEN** — `--ref issue/1396-tests-smoke-make-syslog-export` (this branch), three runs on separate leased boxes:

| Run | Filter | Result |
| --- | ------ | ------ |
| A (alone, filtered path) | `test_syslog_on_ip_block_event_exported` | `1 passed, 809 deselected in 77.51s` |
| B (alone, filtered path) | `test_syslog_off_no_new_records` | `1 passed, 809 deselected in 78.47s` |
| C (whole module, source order) | `test_syslog_export` | `5 passed, 805 deselected in 123.87s` |

Runs A and B exercise the reordered/independent collection the issue names (each node without its siblings); run C proves normal source order still passes.

Fixes #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
