### PR TITLE
tests: pin function-inventory parity oracle for the pfblockerng.inc split (#1122 phase 0)

### DIFF
--- a/tests/php/FunctionInventoryParityTest.php
+++ b/tests/php/FunctionInventoryParityTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Phase-0 parity oracle for the pfblockerng.inc domain split (#1122).
+ *
+ * Pins the full function surface the package defines when loaded through the
+ * umbrella include: every function name plus its Reflection signature
+ * (parameter names, by-ref flags, variadics, types, defaults, return type),
+ * against the committed golden snapshot in fixtures/function_inventory.json.
+ * Any extraction phase that drops, renames, duplicates (PHP fatals), or
+ * re-signatures a function fails here loudly; a pure byte-for-byte move
+ * between package files stays green, because the snapshot records no
+ * file-of-origin.
+ *
+ * The snapshot is captured at the end of tests/php/bootstrap.php (before any
+ * test runs), so this oracle is independent of test ordering.
+ *
+ * Legitimate signature changes regenerate the golden:
+ *   PFB_UPDATE_FUNCTION_INVENTORY=1 vendor/bin/phpunit --filter FunctionInventoryParityTest
+ */
+final class FunctionInventoryParityTest extends TestCase
+{
+	private const GOLDEN = __DIR__ . '/fixtures/function_inventory.json';
+
+	public function testPackageFunctionInventoryMatchesGolden(): void
+	{
+		$actual = $GLOBALS['pfb_function_inventory'] ?? null;
+		self::assertIsArray($actual, 'bootstrap did not capture the function inventory');
+		self::assertNotEmpty($actual, 'bootstrap captured zero package functions — the capture filter is broken');
+
+		if (getenv('PFB_UPDATE_FUNCTION_INVENTORY') === '1') {
+			$encoded = json_encode(
+				$actual,
+				JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR
+			);
+			self::assertNotFalse(file_put_contents(self::GOLDEN, $encoded . "\n"));
+		}
+
+		self::assertFileExists(self::GOLDEN);
+		$golden = json_decode((string) file_get_contents(self::GOLDEN), true, 512, JSON_THROW_ON_ERROR);
+		self::assertIsArray($golden);
+
+		self::assertSame(
+			array_keys($golden),
+			array_keys($actual),
+			'function inventory diverged from the golden snapshot: a change dropped, renamed, or added a package function'
+		);
+		self::assertSame(
+			$golden,
+			$actual,
+			'function signature(s) diverged from the golden snapshot (parameters / by-ref / defaults / types)'
+		);
+	}
+}

--- a/tests/php/FunctionInventoryParityTest.php
+++ b/tests/php/FunctionInventoryParityTest.php
@@ -38,6 +38,9 @@ final class FunctionInventoryParityTest extends TestCase
 				JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR
 			);
 			self::assertNotFalse(file_put_contents(self::GOLDEN, $encoded . "\n"));
+			// A regeneration run must never read as a plain PASS: if the env var
+			// ever leaked into CI, the oracle would be silently disabled.
+			self::markTestIncomplete('golden regenerated from the live capture — commit it and re-run without PFB_UPDATE_FUNCTION_INVENTORY');
 		}
 
 		self::assertFileExists(self::GOLDEN);

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -106,6 +106,10 @@ if (!function_exists('step3_submitphpaction')) {
 //    excludes the doubles, vendor code, and the wizard eval above — but the
 //    snapshot records no file-of-origin, so relocating a function between
 //    package files (the #1122 split) leaves it byte-identical.
+//    Coupling caveat: extra.inc's function_exists()-guarded CE-compat shims
+//    (localize_text, logger) are in the inventory only while
+//    pfsense_doubles.php defines no double for them — adding such a double
+//    later flips the parity test red with zero production change.
 $pfb_pkg_dir = realpath(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng') . DIRECTORY_SEPARATOR;
 $pfb_inventory = [];
 foreach (get_defined_functions()['user'] as $pfb_fn_name) {

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -98,3 +98,41 @@ if (!function_exists('step3_submitphpaction')) {
 	}
 	unset($pfb_wizard_src, $pfb_fn_pos);
 }
+
+// 7. Parity snapshot of the package's loaded function surface (#1122 phase 0),
+//    taken here so it reflects exactly what the umbrella + extra load defines,
+//    before any test can add or shadow symbols (order-independent by
+//    construction). The defining file selects package functions only — it
+//    excludes the doubles, vendor code, and the wizard eval above — but the
+//    snapshot records no file-of-origin, so relocating a function between
+//    package files (the #1122 split) leaves it byte-identical.
+$pfb_pkg_dir = realpath(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng') . DIRECTORY_SEPARATOR;
+$pfb_inventory = [];
+foreach (get_defined_functions()['user'] as $pfb_fn_name) {
+	$pfb_fn_ref = new ReflectionFunction($pfb_fn_name);
+	$pfb_fn_file = $pfb_fn_ref->getFileName();
+	if ($pfb_fn_file === false
+	    || strncmp((string) realpath($pfb_fn_file), $pfb_pkg_dir, strlen($pfb_pkg_dir)) !== 0) {
+		continue;
+	}
+	$pfb_fn_params = [];
+	foreach ($pfb_fn_ref->getParameters() as $pfb_fn_param) {
+		$pfb_fn_params[] = [
+			'name'     => $pfb_fn_param->getName(),
+			'byRef'    => $pfb_fn_param->isPassedByReference(),
+			'variadic' => $pfb_fn_param->isVariadic(),
+			'type'     => $pfb_fn_param->hasType() ? (string) $pfb_fn_param->getType() : null,
+			'default'  => $pfb_fn_param->isDefaultValueAvailable()
+				? var_export($pfb_fn_param->getDefaultValue(), true)
+				: null,
+		];
+	}
+	$pfb_inventory[$pfb_fn_ref->getName()] = [
+		'returnsRef'  => $pfb_fn_ref->returnsReference(),
+		'returnType'  => $pfb_fn_ref->hasReturnType() ? (string) $pfb_fn_ref->getReturnType() : null,
+		'params'      => $pfb_fn_params,
+	];
+}
+ksort($pfb_inventory, SORT_STRING);
+$GLOBALS['pfb_function_inventory'] = $pfb_inventory;
+unset($pfb_pkg_dir, $pfb_inventory, $pfb_fn_name, $pfb_fn_ref, $pfb_fn_file, $pfb_fn_params, $pfb_fn_param);

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -1,0 +1,8596 @@
+{
+    "FILTER_FLAG_NO_LOOPBACK_RANGE": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "convert_feeds_json": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "dnsbl_save_stats": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "dnsbl_stats_update": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "alias",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "alias_cnt",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "find_reported_header": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfbfolder",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "geoip",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            }
+        ]
+    },
+    "ip_explode": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "localize_text": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "args",
+                "byRef": false,
+                "variadic": true,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "logger": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "priority",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "message",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            },
+            {
+                "name": "prefix",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            },
+            {
+                "name": "facilities",
+                "byRef": false,
+                "variadic": false,
+                "type": "?int",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfBlockerNG_clearip": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfBlockerNG_clearsqlite": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "totalqueries",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "0"
+            }
+        ]
+    },
+    "pfb_adv_alias_field_errors": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "post",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_aggregate_member_list": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "type",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "family",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_alerts_default_page": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_alerts_ip_buffer_push": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "buf",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "kind",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_alerts_ip_replay_step": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "entry",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_alerts_unified_scan_done": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "filterlogentries",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "unified_count",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfbentries",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "ipfilterlimit",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "dnsblfilterlimit",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "dnsfilterlimit",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_alias_autocomplete_lists": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "aliases",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_alias_delta_batch_clamp": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "raw",
+                "byRef": false,
+                "variadic": false,
+                "type": "string|int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_alias_delta_batch_resolve": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "raw",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_alias_delta_mode_install_default": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "gconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_alias_entry_count": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "grep_lines",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_alias_field_type_ok": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "field",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "alias_type",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_alias_rename_followup": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "old_name",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "new_name",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_alias_set_different": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "new_set",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "mirror_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_alias_type": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "alias",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_aliastables": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_apply_alias_delta": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "pfctl_bin",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "table",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "table_file",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "desired_set",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "last_set",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "batch_size",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "force_replace",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": "false"
+            }
+        ]
+    },
+    "pfb_archive_member_names": {
+        "returnsRef": false,
+        "returnType": "?array",
+        "params": [
+            {
+                "name": "file",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_archive_missing_tool": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "canonical_type",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "checker",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_archive_probe": {
+        "returnsRef": false,
+        "returnType": "?array",
+        "params": [
+            {
+                "name": "canonical_type",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_archive_unsafe_member": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "names",
+                "byRef": false,
+                "variadic": false,
+                "type": "?array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_asn_blob_split": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "blob",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_asn_cache_window": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "asn_reporting",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_asn_csv_fields": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "blob",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_build_aggregate_aliases": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "new_aliases",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "new_aliases_list",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "pfb_alias_lists",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_build_autorule_list": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "existing_rules",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "pfb_generated",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "order",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "float",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "in_ifaces",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "out_ifaces",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_build_if_list": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "show_wan",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            },
+            {
+                "name": "show_groups",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            }
+        ]
+    },
+    "pfb_canonical_alias_set": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "member_content",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cfg_alias_delta_mode_read": {
+        "returnsRef": false,
+        "returnType": "PfbAliasDeltaMode",
+        "params": [
+            {
+                "name": "stored",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cfg_alias_delta_mode_write": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": "PfbAliasDeltaMode|string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cfg_field_adapter_type": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "entry",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cfg_field_vocab": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
+    "pfb_cfg_idn_mode_read": {
+        "returnsRef": false,
+        "returnType": "PfbIdnMode",
+        "params": [
+            {
+                "name": "stored",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cfg_idn_mode_write": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": "PfbIdnMode|string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cfg_lenient_read": {
+        "returnsRef": false,
+        "returnType": "PfbLenient",
+        "params": [
+            {
+                "name": "stored",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cfg_lenient_write": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "lenient",
+                "byRef": false,
+                "variadic": false,
+                "type": "PfbLenient|string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cfg_registry": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
+    "pfb_cfg_toggle_read": {
+        "returnsRef": false,
+        "returnType": "PfbToggle",
+        "params": [
+            {
+                "name": "stored",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cfg_toggle_write": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "toggle",
+                "byRef": false,
+                "variadic": false,
+                "type": "PfbToggle|string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cfg_top1m_source_read": {
+        "returnsRef": false,
+        "returnType": "PfbTop1mSource",
+        "params": [
+            {
+                "name": "stored",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cfg_top1m_source_write": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "source",
+                "byRef": false,
+                "variadic": false,
+                "type": "PfbTop1mSource|string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_channel_from_pkgname": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "name",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cidr_subtract_v6": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "cidrs",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "holes",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "errors",
+                "byRef": true,
+                "variadic": false,
+                "type": "?array",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_clear_contents": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_clear_pending_changes": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": []
+    },
+    "pfb_close_sqlite": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "db_handle",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_collect_autorule_suffix": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "rules",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_collect_foreign_trackers": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
+    "pfb_collect_localhosts": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_collect_localip": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_concat_member_files": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "member_paths",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_conditional_get_decision": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "http_status",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "body_hash",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "persisted_hash",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_conditional_get_validator_base": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "file_dwn",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_content_hash": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "path_or_data",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "is_file",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "true"
+            }
+        ]
+    },
+    "pfb_control_legacy_seed": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "dconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_count_lines": {
+        "returnsRef": false,
+        "returnType": "?int",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_create_dnsbl": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_create_dnsbl_cert": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_create_lighttpd": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_create_suppression_file": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_cron_base_hour": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "freq",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_cron_disable_path": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "dbdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_cron_disabled": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_cross_list_scope": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "dup_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "rep_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_daemon_dnsbl": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_daemon_dnsbl_index": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_daemon_filterlog": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_deinstall_clear_pending_changes": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": []
+    },
+    "pfb_determine_list_detail": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "list",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "confconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "key",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            }
+        ]
+    },
+    "pfb_diff_managed_rules": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "old_rules",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "new_rules",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_abp_extract_ip": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_apply_ledger_update": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": []
+    },
+    "pfb_dnsbl_apply_retry": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": []
+    },
+    "pfb_dnsbl_cache": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_collect_feed_ip": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "guard_value",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "candidate_value",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "custom",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "domain_data_ip",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "domain_data_ip6",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_concat_files": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "dest",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "sources",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_concat_write_ok": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "written",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_converged": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": []
+    },
+    "pfb_dnsbl_csv_extract": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "csvline",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "csv_type",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "csv_parser",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "run_once",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "alienvault_types",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "dnsbl_ip_enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "custom",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "domain_data_ip",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "domain_data_ip6",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "oline",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "dnsbl_lineno",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "parse_err",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_download_ledger_update": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "download_ok",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "message",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_extract_host": {
+        "returnsRef": false,
+        "returnType": "string|false",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "strict",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "oline",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "dnsbl_lineno",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "parse_err",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "scheme_skipped",
+                "byRef": true,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_feed_count": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_has_loaded_feeds": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "pfb",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_hash_line_classify": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_hold_stale_rebuild_skip": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "stale_generation_rebuild",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "is_hold",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "orig_exists",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_is_abp_rule_line": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_is_skippable_control_line": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_lastevent": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "p_group",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "p_entry",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "p_details",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_lenient_migrate": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "dconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_loaded_fingerprint": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "paths",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_loaded_input_paths": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "pfb",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_manifest_failure_notice": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": []
+    },
+    "pfb_dnsbl_manifest_missing": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "pfb",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_nat_enabled": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "iface",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "nonat",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_ndjson_emit_row": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "kind",
+                "byRef": false,
+                "variadic": false,
+                "type": "PfbDnsblRowKind",
+                "default": null
+            },
+            {
+                "name": "payload",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_ndjson_parse_row": {
+        "returnsRef": false,
+        "returnType": "?array",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_python_migrate": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "dconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_query": {
+        "returnsRef": false,
+        "returnType": "?array",
+        "params": [
+            {
+                "name": "domain",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "qtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'A'"
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "5.0"
+            }
+        ]
+    },
+    "pfb_dnsbl_reload_fingerprint": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "pfb",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_scheme_line": {
+        "returnsRef": false,
+        "returnType": "string|false",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "strict",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "oline",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "lineno",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "logfile",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "skipped",
+                "byRef": true,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_scheme_skip_warn": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "skipped",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_service": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_dnsbl_staging_first_line": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_staging_is_current_generation": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "first_line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_stale_rebuild_converge_txt": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "stale_generation_rebuild",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "txt_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_strip_bom": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_strip_scheme": {
+        "returnsRef": false,
+        "returnType": "string|false",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "strict",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": "false"
+            }
+        ]
+    },
+    "pfb_dnsbl_tld_stats_finalize": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "group_counts",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_unbracket_ip6": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_unlock_action": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "action",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_unlock_lines": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_dnsbl_update_marker_clear_active": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "orig_content_stale",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_v6_vip_required": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "listens_v6",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "auto",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_verbatim_reuse_active": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "txt_exists",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "update_exists",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "fail_exists",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "reuse_unset",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "staging_current_generation",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_vip_candidates": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "family",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_webpage": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_dnsbl_whitelist_lines": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_dnsblip_action_folder": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "action",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsblip_action_value": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "action",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsblip_finalize": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "dnsblip",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "fp",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "built",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "ip_cache",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "action",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "vtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsblip_mark_reprocess": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "action",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "vtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsblip_rebuild_check": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "output",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ip_files",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "fp_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dot_block_action": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "action",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dot_block_floating_rule": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "ifaces",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "exclude_alias",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "action",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dot_block_rule": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "iface",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "exclude_alias",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "action",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_download": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "list_url",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "file_dwn",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pflex",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "format",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "logtype",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "vtype",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "timeout",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "300"
+            },
+            {
+                "name": "type",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "username",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "password",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "srcint",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            },
+            {
+                "name": "response_meta",
+                "byRef": true,
+                "variadic": false,
+                "type": null,
+                "default": "NULL"
+            },
+            {
+                "name": "extra_headers",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": "array (\n)"
+            }
+        ]
+    },
+    "pfb_download_failure": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "alias",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfbfolder",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "list_url",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "format",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "vtype",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_download_http_headers": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "extra_headers",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "conditional_header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "''"
+            }
+        ]
+    },
+    "pfb_due_ledger_is_due": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "job_key",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "interval",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "now",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "seed",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "jitter_max",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_due_ledger_is_due_from_entry": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "entry",
+                "byRef": false,
+                "variadic": false,
+                "type": "?array",
+                "default": null
+            },
+            {
+                "name": "now",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_due_ledger_is_pending": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "job_key",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_due_ledger_mark_ran": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "job_key",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "interval",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "now",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "seed",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "jitter_max",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_due_ledger_mark_ran_anchored": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "job_key",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "interval",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "now",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "seed",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "jitter_max",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_due_ledger_read_entry": {
+        "returnsRef": false,
+        "returnType": "?array",
+        "params": [
+            {
+                "name": "job_key",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_due_ledger_seeded_jitter": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "job_key",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "seed",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "max",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_due_ledger_set_pending": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "job_key",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_due_ledger_write_entry": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "job_key",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "entry",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_emit_entry_reject_stats": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ensure_trailing_newline": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_exclude_alias_exists": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "alias",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_exclude_alias_types": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
+    "pfb_failures": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_feed_filter_enabled": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_feed_filter_install_default": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "gconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_feed_host_allowed": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "host",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "reason",
+                "byRef": true,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pinned",
+                "byRef": true,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_feed_internal_allowlist": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "ignored",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_feed_manifest_row": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "group",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "log_flag",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "provenance",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'deny'"
+            }
+        ]
+    },
+    "pfb_feed_pass_acquire": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": []
+    },
+    "pfb_feed_pass_begin": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "label",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_feed_pass_busy": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": []
+    },
+    "pfb_feed_pass_release": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": []
+    },
+    "pfb_feed_redirect_target": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "location",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "current_url",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "reason",
+                "byRef": true,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pinned",
+                "byRef": true,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_feed_task_running": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": []
+    },
+    "pfb_file_mtime": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_filter": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "input",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "type",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "reference",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "'Unknown'"
+            },
+            {
+                "name": "default",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "escape",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            },
+            {
+                "name": "reject_detail",
+                "byRef": true,
+                "variadic": false,
+                "type": null,
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_filter_service": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_filter_whitelist_atype": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "raw",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_filterlog_port": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "d",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "is_inbound",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_filterlog_refresh_config": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_filterlog_skip_count": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "count",
+                "byRef": false,
+                "variadic": false,
+                "type": "?int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_filterlog_timestamp": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "f",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "log_type",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "now",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_filterrules": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_find_managed_obj": {
+        "returnsRef": false,
+        "returnType": "array|false",
+        "params": [
+            {
+                "name": "section",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "marker",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "guard",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_find_marked_vip": {
+        "returnsRef": false,
+        "returnType": "?int",
+        "params": [
+            {
+                "name": "vips_config",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "marker",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "match_ip",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_find_reported_headers": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "hosts",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "pfbfolder",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "geoip",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            },
+            {
+                "name": "grep_failed",
+                "byRef": true,
+                "variadic": false,
+                "type": "?array",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_firewall_rule": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "action",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfb_alias",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "vtype",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfb_log",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "agateway_in",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "'default'"
+            },
+            {
+                "name": "agateway_out",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "'default'"
+            },
+            {
+                "name": "aaddrnot_in",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "adest_in",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "aports_in",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "aproto_in",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "anot_in",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "aaddrnot_out",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "asrc_out",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "aports_out",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "aproto_out",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "anot_out",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            }
+        ]
+    },
+    "pfb_force_clear_validators": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "dirs",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "clear_hashes",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_force_scope_dirs": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "scope",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ip_origdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "dnsbl_origdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_get_gateways": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_get_hooks": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "pfbconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "when",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_get_vip_options": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "family",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "pkg_xml_format",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": "false"
+            }
+        ]
+    },
+    "pfb_get_vips": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
+    "pfb_global": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_group_action_valid": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "action",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            },
+            {
+                "name": "gtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_hash_read": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "base",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_hash_write": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "base",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_header_reserved_error": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_hook_lifecycle_ctx": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "lifecycle",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_hook_script_valid": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "script",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "when",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "dir",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_hook_scripts": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "when",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "dir",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_hook_timeout": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "hook",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_hook_trigger": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "cron",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_apply_retry": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_closing_pass_active": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "dup_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "recompute_ran_v4",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_download_ledger_update": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "download_ok",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "message",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_exact_entry_pattern": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "entry",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_in_allowlist": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "allowlist",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_in_cidr": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "cidr",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_is_internal": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_is_opposite_family": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "vtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_is_self": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_log_row_schema_ok": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "fields",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_match_folders": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_ip_parse_fail_warn": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "parse_fail",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_prefetch": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "rows",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_prefetch_grep_lines": {
+        "returnsRef": false,
+        "returnType": "?array",
+        "params": [
+            {
+                "name": "cmd_prefix",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "cmd_suffix",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "patterns",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_prefetch_last_match": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "lines",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "raw_entry",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_preprocess_args": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "dup_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "agg_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "rep_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_recompute_family_headers": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "existing_deny",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "family",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_recompute_forget_header": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "snapdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "origdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_recompute_matrix": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "dedup_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "rep_trigger",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "drep_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "prep_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_recompute_memberlist_content": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "paths",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_recompute_memberlist_write": {
+        "returnsRef": false,
+        "returnType": "int|false",
+        "params": [
+            {
+                "name": "memberlist_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "paths",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_recompute_order_changed": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "family_headers",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "snapdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "memberlist_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_recompute_seed_snapshot": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "snapdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "denydir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_recompute_snapshot_path": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "snapdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_recompute_write_snapshot": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "src",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "snapdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "origdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_render_memos": {
+        "returnsRef": true,
+        "returnType": "array",
+        "params": []
+    },
+    "pfb_ip_render_memos_reset": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": []
+    },
+    "pfb_ip_render_query": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "fields",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_reuse_skip_active": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "reuse_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "orig_exists",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "is_dnsblip",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_suppress_body_active": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "supp_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "vtype_matches",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "supp_update",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "adv",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "feed_changed",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "recompute_ran",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_suppressed": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "entries",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_suppressed_match": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "entries",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_update_marker_clear_active": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "orig_content_stale",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_is_blank_or_comment_line": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_is_managed_obj": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "descr",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_iso_timestamp": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "raw",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_js_string": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "text",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_keep_migrate": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "gconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_list_section_for_vtype": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "vtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_live_punch_apply": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "pfctl",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "table",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "plan",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_live_punch_plan": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "table_entries",
+                "byRef": false,
+                "variadic": false,
+                "type": "iterable",
+                "default": null
+            }
+        ]
+    },
+    "pfb_live_punch_run": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "pfctl",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "aliasdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "dbdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "table",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_live_table_snapshot": {
+        "returnsRef": false,
+        "returnType": "Generator",
+        "params": [
+            {
+                "name": "pfctl",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "aliasdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "dbdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "table",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_local_feed_changed": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "source_path",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "orig_path",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_local_ip": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "subnet",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfb_localsub",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_log_age_cutoff": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "lines",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "cutoff_ts",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "field_mode",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_log_age_field_mode": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "logtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_log_age_trim_needed": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "agedays",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "logtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "margin_raw",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "0"
+            }
+        ]
+    },
+    "pfb_log_age_trim_temp": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "temp",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "days",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "logtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "unbounded_candidate",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": "false"
+            }
+        ]
+    },
+    "pfb_log_age_trim_temp_stream": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "temp",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "cutoff_ts",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "field_mode",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_log_age_trim_write_ok": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "written",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "content",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_log_event": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "type",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "domain",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "src_ip",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "req_agent",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_log_feed_host_reject": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "list_url",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "logtype",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_log_iso_timestamp": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_log_line_timestamp": {
+        "returnsRef": false,
+        "returnType": "?int",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "field_mode",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_log_max_days": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "raw",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_log_max_lines": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "raw",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_log_mgmt": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_log_tail_chunk": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "file",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "offset",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "flush",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": "false"
+            }
+        ]
+    },
+    "pfb_log_tail_payload": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "which",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "offset",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "has_offset",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_log_trim_margin_pct": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "raw",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_log_trim_needed": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "logmax",
+                "byRef": false,
+                "variadic": false,
+                "type": "string|int",
+                "default": null
+            },
+            {
+                "name": "agedays",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "logtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "margin_raw",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_logger": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "log",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "logtype",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_logger_format_for_target": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "raw",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "lead",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "now",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_logger_target_starts_at_bol": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_manage_dnsbl_vip": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_managed_rule_tracker": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "descr",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_mark_pending_changes": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": []
+    },
+    "pfb_match_reported_cidr": {
+        "returnsRef": false,
+        "returnType": "?array",
+        "params": [
+            {
+                "name": "result",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "v4_type",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_matchdir_apply_moves": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "moves",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "matchdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "matchgendir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_matchdir_config_headers": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "lists_by_vtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "dnsbl_config",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "continent_configs",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_matchdir_migrate_plan": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "matchdir_files",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "existing_deny",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "existing_match",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "ccwhite_match",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "matchgendir_files",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_matchdir_stale_localfile_refs": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "rows",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "matchdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "moved_basenames",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_matchgen_reap": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "existing_deny",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "ccwhite_match",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "matchgendir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_maxmind_credential_notice": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "maxmind_key",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "maxmind_account",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_member_file_is_placeholder_only": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "placeholder",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_migration_registry": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
+    "pfb_mime_in_allowlist": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "mime",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "allowlist",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_mime_normalise": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "raw",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_mirror_hook_output": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "logfile",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "offset",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_next_tick_boundary": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "tick_min",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "cur_hour",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "cur_min",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "cur_sec",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_normalize_row_header": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_octet_recover_type": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "file",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "supported_types",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "validator",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            }
+        ]
+    },
+    "pfb_open_sqlite": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "table",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "message",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_parse_fail_log": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "oline",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "logfile",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "lineno",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "keep_falsy_line",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": "false"
+            }
+        ]
+    },
+    "pfb_parse_pkg_operation": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "ps_lines",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "start_pid",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_parse_query": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_pending_changes": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": []
+    },
+    "pfb_pending_changes_marker": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_persist_hook_output": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "logfile",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "offset",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pfctl_checked_op": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "pfctl",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "table",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "op",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "entry",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pfctl_error_message": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "table",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "op",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "rc",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "stderr",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pfctl_op_failed": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "op",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "rc",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "stderr",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pfctl_table_count": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "table",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pfctl_table_op": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "table",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "op",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "args",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "''"
+            },
+            {
+                "name": "pfctl_bin",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "''"
+            }
+        ]
+    },
+    "pfb_pfctl_test_match_count": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "output",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pick_free_dnsbl_vip": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "family",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "interface",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pkg_argv_subcommand": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "argv",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pkg_installed_name": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_pkg_installed_repo": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "pkgname",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pkg_installed_version": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "pkgname",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pkg_latest": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "pkgname",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "reponame",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pkg_op_tears_down": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "op",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pkg_operation": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_pkg_repo_name_for_channel": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "channel",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pkg_ver": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_port_alias_types": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
+    "pfb_prefetch_pattern_file_write_ok": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "written",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "data",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_print_pending_changes_box": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "on_update_page",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": "false"
+            }
+        ]
+    },
+    "pfb_prune_failed_bl_lists": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "lists",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "pfb_return",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_purge_probe_bodies": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_py_sync_status_list_open": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "status_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_quiet_hours_in_window": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "now",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "window",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_rdns_seed_value": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "gconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "ipconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_redact_url": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "url",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_redirect_exclude_source": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "alias",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "context",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "''"
+            }
+        ]
+    },
+    "pfb_reject_detail_summary": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "reject_detail",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_reload_option_value": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_reload_unbound": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "cache",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            },
+            {
+                "name": "pfbpython",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            },
+            {
+                "name": "datapath",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            },
+            {
+                "name": "newly_blocked",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "array (\n)"
+            }
+        ]
+    },
+    "pfb_remove_config_settings": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_remove_managed_obj": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "section",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "marker",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "guard",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_remove_states": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_render_memo": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "store",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "key",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "resolver",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            }
+        ]
+    },
+    "pfb_req_to_hook_trigger": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "trigger",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_reserved_header_skip_active": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "is_reserved_owner",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_resolve_enabled": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "ipconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_resolve_list_script": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "name",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "dirs",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_resolve_relative_url": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "ref",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "base",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_resolve_tracker": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "rule_list",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "miss_cache",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "tracker",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "type",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "reparse",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            },
+            {
+                "name": "on_reparse",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_rsync_pin_url": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "list_url",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_rule_alias_needs_v4_suffix": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "address",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "ipprotocol",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_run_hooks": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "when",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "ctx",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "array (\n)"
+            }
+        ]
+    },
+    "pfb_run_log_target": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_run_migrations": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": []
+    },
+    "pfb_run_streams_to_stdout": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": []
+    },
+    "pfb_runlog_begin": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_sanitise_feed_header": {
+        "returnsRef": false,
+        "returnType": "string|false",
+        "params": [
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "reference",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'pfb_sanitise_feed_header'"
+            }
+        ]
+    },
+    "pfb_select_reload_aliases": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "rep_enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "alias_lists",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "alias_lists_all",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "active_aliases",
+                "byRef": false,
+                "variadic": false,
+                "type": "?array",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_should_notify": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "installed",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "latest",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "last_notified",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_software_add_tab": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "tab_array",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "active",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": "false"
+            },
+            {
+                "name": "provenance_ok",
+                "byRef": false,
+                "variadic": false,
+                "type": "?bool",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_software_cache_file": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_software_check_enabled": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "raw",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_software_is_our_build": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "installed_repo",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_software_panel_override": {
+        "returnsRef": false,
+        "returnType": "?bool",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_software_provenance_ok": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": []
+    },
+    "pfb_software_read_cache": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
+    "pfb_software_update_check": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "force",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": "false"
+            },
+            {
+                "name": "io",
+                "byRef": false,
+                "variadic": false,
+                "type": "?array",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_software_write_cache": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "cache",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_source_hash_target": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "file_download",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "orig_download",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_sqlite_table_spec": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "table",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ss_csv_rows": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "host",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "data",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "v4",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "v6",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            }
+        ]
+    },
+    "pfb_ss_doh_list_yandex_migrate": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "stored",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_ss_refresh_lines": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "lines",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "resolver",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ss_resolve_target": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "target",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_stdout_is_terminal": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": []
+    },
+    "pfb_stop_start_unbound": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "type",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_strip_trailing_port": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_strtolower": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_supp_update_active": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "pfbadv",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "supp_enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_suppress_file_v6": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "file",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "suppfile",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_sync_filter_password": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_sync_status_close": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "facility",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "stage",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_sync_status_close_removed_alias": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "gtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "aliasname",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_sync_status_dedup_check": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "log_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_sync_status_list_open": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "facility",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_sync_status_locked": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "fn",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            }
+        ]
+    },
+    "pfb_sync_status_open": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "facility",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "stage",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "message",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "clock_fn",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_sync_status_read_all": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_sync_status_write_all": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "data",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_syslog_escape": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "v",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_syslog_event": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "body",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_syslog_format_dnsbl": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "fields",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_syslog_format_ip": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "fields",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_syslog_logging_needs_update": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "current",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "want",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_syslog_logging_want": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_text_sanity": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "sample",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_tick_due_jobs": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "now",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "seed",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "dbdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "cron_interval",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "bl_interval",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_tick_interval_clamp": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "raw",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_tick_seed": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_top1m_auth_headers": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "provider",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "token",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_top1m_providers": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
+    "pfb_tracker": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "alias",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "int",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "text",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_trigger_request": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "verb",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_clear_work_files": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_unbound_dnsbl": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_listens_v6": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": []
+    },
+    "pfb_unbound_py_atomic_write": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "content",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "stream_ops",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": "array (\n)"
+            }
+        ]
+    },
+    "pfb_unbound_py_atomic_write_root": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "content",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_py_ccache_flush": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "names",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_py_ccache_flush_cmds": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "names",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "chroot_cmd",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_py_flip_sentinel": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_unbound_py_gc": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "converged",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_py_generation_matches": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "metadata",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_py_manifest_raw_paths": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "manifest_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "deduplicate",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": "true"
+            }
+        ]
+    },
+    "pfb_unbound_py_marker_generation": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_py_mode_active": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_unbound_py_normalize_absolute_path": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_py_publication_lock": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "?float",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_unbound_py_publication_unlock": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "lock",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_py_raw_artifacts": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "pfb",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_py_remove_raw_artifact": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_py_stream_sync": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "fh",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "content",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "write_fn",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "NULL"
+            },
+            {
+                "name": "flush_fn",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "NULL"
+            },
+            {
+                "name": "fsync_fn",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_unbound_py_swap_fits_ram": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_unbound_py_teardown_raw_set": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": []
+    },
+    "pfb_unbound_py_wait_applied": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "gen",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "30"
+            }
+        ]
+    },
+    "pfb_unbound_py_wait_control_applied": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "seq",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "5"
+            }
+        ]
+    },
+    "pfb_unbound_py_wait_marker": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "target",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_py_write_control": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "cmd",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "duration",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            },
+            {
+                "name": "wait_timeout",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "5"
+            }
+        ]
+    },
+    "pfb_unbound_python": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_python_sources": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "feeds",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "publication_ops",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": "array (\n)"
+            }
+        ]
+    },
+    "pfb_unbound_python_sources_locked": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "feeds",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "publication_ops",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": "array (\n)"
+            }
+        ]
+    },
+    "pfb_unbound_python_sources_patch": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "key",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "values",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "publication_ops",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": "array (\n)"
+            }
+        ]
+    },
+    "pfb_unbound_python_sources_patch_locked": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "key",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "values",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_unbound_python_sources_unlock": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_unbound_python_sources_whitelist": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_unbound_python_unmount": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfb_unbound_python_whitelist": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            }
+        ]
+    },
+    "pfb_unified_format_dnsbl": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "fields",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_unified_format_dnsreply": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "fields",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_unified_format_ip": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "fields",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_unlock": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "type",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "remove",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "r_type",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "filename_unlock",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_update_autotail": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "task_running",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "run_dispatch",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "logview_posted",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_update_available": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "installed",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "latest",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_update_pass_running": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "ps_lines",
+                "byRef": false,
+                "variadic": false,
+                "type": "?array",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_update_unbound": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfbupdate",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfbpython",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "dnsbl_tld_group_counts",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": "array (\n)"
+            }
+        ]
+    },
+    "pfb_utf16_bom_encoding": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "head",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_utf16_sample_to_utf8": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "sample",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_utf16_transcode_file": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_v4_carve_single": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "cidr",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "host_ip",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_v6_bin_dec": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "bin",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_v6_bin_inc": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "bin",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_v6_bin_to_addr": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "bin",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_v6_cidr_to_range": {
+        "returnsRef": false,
+        "returnType": "?array",
+        "params": [
+            {
+                "name": "token",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "is_blank",
+                "byRef": true,
+                "variadic": false,
+                "type": "?bool",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_v6_emit_covering_cidrs": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "start_bin",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "end_bin",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_valid_vtype": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "vtype",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_validate_archive": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "file",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "canonical_type",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "runner",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_validate_dns_redirect_post": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "posted_ifaces",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "valid_iface_list",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "posted_alias",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_validate_domain_labels": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "input",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_validate_dot_block_post": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "posted_ifaces",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "valid_iface_list",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "posted_alias",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "posted_action",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'reject'"
+            }
+        ]
+    },
+    "pfb_validate_log": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "feed",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "stage",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "reason",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "detail",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "''"
+            },
+            {
+                "name": "level",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": "2"
+            }
+        ]
+    },
+    "pfb_validate_log_line": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "feed",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "stage",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "reason",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "detail",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "''"
+            }
+        ]
+    },
+    "pfb_validate_redirect_exclude_alias": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "label",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "posted_ifaces",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "valid_iface_list",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "posted_alias",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_validate_suppression_line": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "family",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_validate_vips": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "interface",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "vip4",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "''"
+            },
+            {
+                "name": "vip6",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "''"
+            }
+        ]
+    },
+    "pfb_validator_read": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "base",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_validator_write": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "base",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "etag",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "lastmod",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_verb_deprecation_warning": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "verb",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_wizard_dnsvip_settings": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "auto",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "vip4",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "vip6",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_wizard_get_action": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "get",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_wizard_skip_action": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "post",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_wizard_suppress_autolaunch": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "get_action",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "wizard_skip_flag",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "config_zero",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_write_canonical_alias": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "canonical_set",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfblockerng_configure_tick_cron": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "tick_min",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "log",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfblockerng_cron_exists": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "pfb_cmd",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfb_min",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfb_hour",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfb_mday",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfb_wday",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfblockerng_do_xmlrpc_sync": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "sync_to_ip",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "port",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "protocol",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "username",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "password",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "synctimeout",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfblockerng_php_pre_deinstall_command": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfblockerng_plugin_xmlrpc_recv": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "new_sections",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfblockerng_plugin_xmlrpc_send": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfblockerng_ss_refresh": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfblockerng_sync_on_changes": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": []
+    },
+    "pfblockerng_sync_sections": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "include_interfaces",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfblockerng_tick": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": []
+    },
+    "pfblockerng_top1m": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "provider_override",
+                "byRef": false,
+                "variadic": false,
+                "type": "?array",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfbng_text_area_decode": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "text",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            },
+            {
+                "name": "type",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "true"
+            },
+            {
+                "name": "idn",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            }
+        ]
+    },
+    "sanitize_ipaddr": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "ipaddr",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "custom",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfbcidr",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "sanitize_ipaddr_v6": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "ipaddr",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "custom",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfbcidr",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "'Disabled'"
+            }
+        ]
+    },
+    "sync_package_pfblockerng": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "cron",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            }
+        ]
+    },
+    "validate_ipv4": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "ipaddr",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "validate_ipv6": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "ipaddr",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Part of #1122 (phase 0 — parity harness).

## What

Adds the behaviour-preserving parity oracle every later extraction phase of the `pfblockerng.inc` domain split must keep green:

- `tests/php/bootstrap.php` now captures, at the end of bootstrap (before any test runs, so it is order-independent by construction), the full function surface defined by files under `src/usr/local/pkg/pfblockerng/`: sorted names plus per-function Reflection signature data (parameter names, by-ref flags, variadics, types, evaluated defaults, return type). Selection is by defining file so test doubles, vendor code, and the wizard eval are excluded — but the snapshot records no file-of-origin, so a byte-for-byte move between package files stays green.
- `tests/php/FunctionInventoryParityTest.php` asserts the captured inventory against the committed golden snapshot (`tests/php/fixtures/function_inventory.json`, 461 functions: umbrella + `pfblockerng_extra.inc`). Names are compared first so a drop/rename/addition reads as a clean name diff; the second assertion catches signature drift. Legitimate changes regenerate the golden with `PFB_UPDATE_FUNCTION_INVENTORY=1 vendor/bin/phpunit --filter FunctionInventoryParityTest` — a regeneration run reports Incomplete, never a plain PASS, so a leaked env var cannot silently disable the oracle.

No production code changes.

## Evidence

Failability proofs (behaviour-preserving oracle, so the proof is that it fails on the regression classes it guards):

- **Real red, both CI legs:** the first pushed head carried a golden generated before the rebase onto `8e86748b` (which added `pfb_pfctl_checked_op` to `pfblockerng_extra.inc`); CI PHPUnit on PHP 8.3 AND 8.5 went red with "function inventory diverged from the golden snapshot" naming the drift — a live demonstration that the oracle catches a one-function surface change. Golden regenerated on the rebased tree; both legs green since.
- Temp function appended to `pfblockerng.inc` → RED naming `pfb_parity_probe_temp`; source reverted.
- One `byRef` flag flipped in the golden → RED on the signature assertion; golden restored.
- Plain run → GREEN.

Gates on the current head (`scripts/agent/run-gates.sh`): `php -l` (both touched files), `vendor/bin/phpunit` (full suite OK), `composer phpstan`, `composer phpcs -- --standard=phpcs.xml.dist src/` — all PASS. The suite's 1 notice / 1 deprecation / skips pre-exist (production curl paths on PHP 8.5; missing `7z` and `/var/db` perms locally) and are unrelated.

Cross-version stability: the adversarial review probed the capture on PHP 8.3.32 — byte-identical to the 8.5.8-generated golden (570 typed params, 305 return types; defaults serialized via `var_export` strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
