### PR TITLE
scripts: close helper-capsule bypass and cap oversized capsule commands

### DIFF
--- a/.github/workflows/context-budget.yml
+++ b/.github/workflows/context-budget.yml
@@ -20,6 +20,8 @@ on:
       - '.agents/context/**'
       - 'docs/misc/**'
       - '.claude/rules/**'
+      - '.claude/hooks/**'
+      - 'scripts/**'
       - '**/AGENTS.md'
       - '**/CLAUDE.md'
   pull_request:
@@ -32,6 +34,8 @@ on:
       - '.agents/context/**'
       - 'docs/misc/**'
       - '.claude/rules/**'
+      - '.claude/hooks/**'
+      - 'scripts/**'
       - '**/AGENTS.md'
       - '**/CLAUDE.md'
 

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -111,7 +111,13 @@ _DELEGATES_RE = re.compile(r"(?m)^\s*exec\b|\bsubprocess\.\w+\(|\bos\.exec\w*\(|
 # (a non-.sh/.py extension) or stripped by a shell metacharacter glued to the path
 # (`x.sh$()`, backtick) — both still run the file. This finds the path regardless;
 # derived from _HELPER_DIRS so the two never drift.
-_HELPER_PATH_RE = re.compile(r"(?:" + "|".join(re.escape(d.rstrip("/")) for d in _HELPER_DIRS) + r")/[\w./-]+")
+# The path token runs to the next shell metacharacter/quote/whitespace, so it
+# captures the whole unquoted filename — including valid path chars the shell
+# keeps but a `\w` class drops (`+`, `@`, `~`, `=`, `,`) — while still stopping at
+# a glued `$()`/backtick. Over-matching is harmless: the result is existence-gated.
+_HELPER_PATH_RE = re.compile(
+    r"(?:" + "|".join(re.escape(d.rstrip("/")) for d in _HELPER_DIRS) + r")/[^\s'\"()|&;<>$`]+"
+)
 
 # Accepts both header shapes in the first HEADER_WINDOW lines: the plain
 # "Scope: ... Load when: ..." prose and the bulleted "- **Scope:** / - **Load-when:**".

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -317,12 +317,16 @@ def check_parity(root: Path) -> list[str]:
 def _script_refs(command: str) -> list[str] | None:
     """Repo-script tokens (*.sh / *.py) of a hook command, or None when untokenizable."""
     try:
-        argv = shlex.split(command)
+        # punctuation_chars: split glued shell operators (`x.sh;sh`, `x.sh>log`) into
+        # their own tokens so an operator can never hide a script reference.
+        lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lex.whitespace_split = True
+        argv = list(lex)
     except ValueError:
         return None
     refs = []
     for tok in argv:
-        if not tok.endswith((".sh", ".py")):
+        if not tok.lower().endswith((".sh", ".py")):
             continue
         for prefix in _PROJECT_DIR_PREFIXES:
             tok = tok.removeprefix(prefix)

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -16,6 +16,7 @@ routable. Budgets (calibrated on the measured tree, not the matrix estimates):
 - nested `CLAUDE.md`/`AGENTS.md` dir stubs            400 B
 - `.claude/rules/*.md` (Claude soft routing backstops) 400 B
 - each hook-capsule `additionalContext` payload     1,800 B
+- any single hook command (pre-tokenization cap)   11,000 B
 
 A hook command may also invoke a repo helper script (under scripts/ or
 .claude/hooks/, both trigger surfaces). A helper whose content could emit
@@ -57,6 +58,10 @@ CAPSULE_BUDGET = 1_800
 # The parity label (everything before the first ": ") is the one uncheckable part of
 # the UserPromptSubmit capsule; the bound keeps it a label, not a smuggling channel.
 PARITY_LABEL_MAX = 80
+# Ceiling for any hook command: decoded 1,800 B capsule budget × 6 (worst-case \uXXXX
+# JSON escaping) + envelope/quoting slack. shlex is nonlinear on huge quoted strings
+# (~25 s at 1 MB — issue #1504), so longer commands are rejected before tokenization.
+COMMAND_BYTES_MAX = CAPSULE_BUDGET * 6 + 200
 
 # Grandfathered ratchet caps for files predating the taxonomy budgets: they may
 # shrink toward POLICY_BUDGET, never grow past their cap.
@@ -238,6 +243,10 @@ def extract_capsules(settings_text: str) -> tuple[list[tuple[str, str]], list[st
                     command = hook.get("command", "")
                     if "additionalContext" not in command:
                         continue
+                    size = len(command.encode("utf-8"))
+                    if size > COMMAND_BYTES_MAX:
+                        errors.append(f"{SETTINGS}: {event} capsule command {size} bytes > cap {COMMAND_BYTES_MAX}")
+                        continue
                     try:
                         argv = shlex.split(command)
                         if len(argv) != 2 or argv[0] != "echo" or shlex.join(argv) != command:
@@ -356,6 +365,13 @@ def check_indirect_producers(root: Path) -> list[str]:
                     command = hook.get("command", "")
                     if "additionalContext" in command:
                         continue  # the canonical inline-capsule path (extract_capsules) owns it
+                    size = len(command.encode("utf-8"))
+                    if size > COMMAND_BYTES_MAX:
+                        violations.append(
+                            f"{SETTINGS}: {event} hook command {size} bytes > cap {COMMAND_BYTES_MAX}"
+                            " — cannot rule out a capsule"
+                        )
+                        continue
                     refs = _script_refs(command)
                     if refs is None:
                         violations.append(

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -19,10 +19,11 @@ routable. Budgets (calibrated on the measured tree, not the matrix estimates):
 - any single hook command (pre-tokenization cap)   11,000 B
 
 A hook command may also invoke a repo helper script (under scripts/ or
-.claude/hooks/, both trigger surfaces). A helper whose content could emit
+.claude/hooks/, both trigger surfaces). Detection recognizes `*.sh`/`*.py`
+command tokens; a recognized helper whose content could emit
 `hookSpecificOutput.additionalContext` must be a registered
-DYNAMIC_CAPSULE_PRODUCERS entry; any other indirect producer — or a helper
-reference the checker cannot statically resolve and read — fails closed (#1501).
+DYNAMIC_CAPSULE_PRODUCERS entry, and a recognized reference the checker cannot
+statically resolve and read fails closed (#1501).
 
 CONDITIONAL: in --staged / --diff mode the checks run IF AND ONLY IF the change
 touches a context surface (AGENTS.md, CLAUDE.md, .agents/policy/,

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -20,8 +20,11 @@ routable. Budgets (calibrated on the measured tree, not the matrix estimates):
 
 A hook command may also invoke a repo helper script (under scripts/ or
 .claude/hooks/, both trigger surfaces). Detection recognizes `*.sh`/`*.py`
-command tokens, including one nested inside a quoted compound shell fragment
-(`sh -c '...'`); a recognized helper whose content could emit
+command tokens (including one nested inside a quoted compound fragment,
+`sh -c '...'`) plus any helper-dir-rooted path that resolves to a committed
+file regardless of extension, even when a glued shell metacharacter
+(`x.sh$()`, backtick) would strip the recognizable suffix off the token; a
+recognized helper whose content could emit
 `hookSpecificOutput.additionalContext` — directly (the literal string) or by
 delegating execution to another program/module the checker cannot read (a
 shell `exec`, a `subprocess`/`os.exec*`/`os.system` call) — must be a
@@ -102,6 +105,13 @@ _PROJECT_DIR_PREFIXES = ("${CLAUDE_PROJECT_DIR:-.}/", "${CLAUDE_PROJECT_DIR}/")
 # `additionalContext` literal directly — the delegation-mediated bypass #1501's
 # own fix would otherwise still miss (e.g. `exec "$py" -m "token_savior.hooks.$1"`).
 _DELEGATES_RE = re.compile(r"(?m)^\s*exec\b|\bsubprocess\.\w+\(|\bos\.exec\w*\(|\bos\.system\(")
+
+# Helper-dir-rooted path candidates in a raw hook command. Suffix-gated
+# tokenization misses a helper whose recognizable .sh/.py suffix is either absent
+# (a non-.sh/.py extension) or stripped by a shell metacharacter glued to the path
+# (`x.sh$()`, backtick) — both still run the file. This finds the path regardless;
+# derived from _HELPER_DIRS so the two never drift.
+_HELPER_PATH_RE = re.compile(r"(?:" + "|".join(re.escape(d.rstrip("/")) for d in _HELPER_DIRS) + r")/[\w./-]+")
 
 # Accepts both header shapes in the first HEADER_WINDOW lines: the plain
 # "Scope: ... Load when: ..." prose and the bulleted "- **Scope:** / - **Load-when:**".
@@ -336,8 +346,8 @@ def check_parity(root: Path) -> list[str]:
     return violations
 
 
-def _script_refs(command: str, _depth: int = 0) -> list[str] | None:
-    """Repo-script tokens (*.sh / *.py) of a hook command, or None when untokenizable.
+def _script_refs(root: Path, command: str, _depth: int = 0) -> list[str] | None:
+    """Repo-script references of a hook command, or None when untokenizable.
 
     A token that itself contains embedded whitespace after tokenization is a quoted
     compound shell fragment (`sh -c 'python3 scripts/emit.py --flag'` collapses to
@@ -358,7 +368,7 @@ def _script_refs(command: str, _depth: int = 0) -> list[str] | None:
     for tok in argv:
         if not tok.lower().endswith((".sh", ".py")):
             if _depth < 4 and any(char.isspace() for char in tok):
-                nested = _script_refs(tok, _depth + 1)
+                nested = _script_refs(root, tok, _depth + 1)
                 if nested is None:
                     return None
                 refs.extend(nested)
@@ -366,6 +376,17 @@ def _script_refs(command: str, _depth: int = 0) -> list[str] | None:
         for prefix in _PROJECT_DIR_PREFIXES:
             tok = tok.removeprefix(prefix)
         refs.append(tok.removeprefix("./"))
+    # Suffix-gated tokenization misses two real references (#1501): a helper with a
+    # non-.sh/.py extension is never matched, and a metacharacter glued to a helper
+    # path (`x.sh$()`, backtick) strips the recognizable suffix off every surviving
+    # token though the shell still runs the file. Union in any helper-dir-rooted
+    # path in the raw command that resolves to a committed file, regardless of
+    # extension. Existence-gated, so a spurious fragment never adds a false
+    # fail-closed violation (the live tree stays clean).
+    for match in _HELPER_PATH_RE.finditer(command):
+        cand = match.group(0)
+        if cand not in refs and (root / cand).is_file():
+            refs.append(cand)
     return refs
 
 
@@ -422,7 +443,7 @@ def check_indirect_producers(root: Path) -> list[str]:
                             " — cannot rule out a capsule"
                         )
                         continue
-                    refs = _script_refs(command)
+                    refs = _script_refs(root, command)
                     if refs is None:
                         violations.append(
                             f"{SETTINGS}: {event} hook command has unparseable quoting — cannot rule out a capsule"

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -20,10 +20,13 @@ routable. Budgets (calibrated on the measured tree, not the matrix estimates):
 
 A hook command may also invoke a repo helper script (under scripts/ or
 .claude/hooks/, both trigger surfaces). Detection recognizes `*.sh`/`*.py`
-command tokens; a recognized helper whose content could emit
-`hookSpecificOutput.additionalContext` must be a registered
-DYNAMIC_CAPSULE_PRODUCERS entry, and a recognized reference the checker cannot
-statically resolve and read fails closed (#1501).
+command tokens, including one nested inside a quoted compound shell fragment
+(`sh -c '...'`); a recognized helper whose content could emit
+`hookSpecificOutput.additionalContext` — directly (the literal string) or by
+delegating execution to another program/module the checker cannot read (a
+shell `exec`, a `subprocess`/`os.exec*`/`os.system` call) — must be a
+registered DYNAMIC_CAPSULE_PRODUCERS entry, and a recognized reference the
+checker cannot statically resolve and read fails closed (#1501).
 
 CONDITIONAL: in --staged / --diff mode the checks run IF AND ONLY IF the change
 touches a context surface (AGENTS.md, CLAUDE.md, .agents/policy/,
@@ -59,9 +62,10 @@ CAPSULE_BUDGET = 1_800
 # The parity label (everything before the first ": ") is the one uncheckable part of
 # the UserPromptSubmit capsule; the bound keeps it a label, not a smuggling channel.
 PARITY_LABEL_MAX = 80
-# Ceiling for any hook command: decoded 1,800 B capsule budget × 6 (worst-case \uXXXX
-# JSON escaping) + envelope/quoting slack. shlex is nonlinear on huge quoted strings
-# (~25 s at 1 MB — issue #1504), so longer commands are rejected before tokenization.
+# Ceiling for any hook command: decoded 1,800 B capsule budget × 6 (generous safety
+# margin over the ×3 worst-case \uXXXX JSON-escaping ratio) + envelope/quoting slack.
+# shlex is nonlinear on huge quoted strings (~25 s at 1 MB — issue #1504), so longer
+# commands are rejected before tokenization.
 COMMAND_BYTES_MAX = CAPSULE_BUDGET * 6 + 200
 
 # Grandfathered ratchet caps for files predating the taxonomy budgets: they may
@@ -79,15 +83,25 @@ SETTINGS = ".claude/settings.json"
 # Registered (event, script) hook helpers whose additionalContext is a RUNTIME-computed
 # diagnostic — no static payload exists to budget/parity-check. Any unregistered helper
 # that could emit a capsule fails closed (inline as canonical `echo '<JSON>'` or register).
+# ts-hook.sh delegates to a token-savior module (`exec "$py" -m "token_savior.hooks.$1"`)
+# that emits a runtime additionalContext diagnostic — a known, first-party delegatee.
 DYNAMIC_CAPSULE_PRODUCERS = {
     ("SessionStart", ".claude/hooks/session-branch-sync.sh"),
     ("PreToolUse", "scripts/check_retired_tokens.py"),
+    ("PostToolUse", "scripts/ts-hook.sh"),
 }
 
 # Helper scripts must live under these roots: both are trigger surfaces
 # (_TRIGGER_DIRS), so editing a helper re-runs this gate.
 _HELPER_DIRS = ("scripts/", ".claude/hooks/")
 _PROJECT_DIR_PREFIXES = ("${CLAUDE_PROJECT_DIR:-.}/", "${CLAUDE_PROJECT_DIR}/")
+
+# A helper that hands execution off to another program/module the checker cannot
+# read (a POSIX shell `exec` re-invocation, a `subprocess` call, an `os.exec*`/
+# `os.system` call) is exactly as unverifiable as one that contains the
+# `additionalContext` literal directly — the delegation-mediated bypass #1501's
+# own fix would otherwise still miss (e.g. `exec "$py" -m "token_savior.hooks.$1"`).
+_DELEGATES_RE = re.compile(r"(?m)^\s*exec\b|\bsubprocess\.\w+\(|\bos\.exec\w*\(|\bos\.system\(")
 
 # Accepts both header shapes in the first HEADER_WINDOW lines: the plain
 # "Scope: ... Load when: ..." prose and the bulleted "- **Scope:** / - **Load-when:**".
@@ -244,7 +258,14 @@ def extract_capsules(settings_text: str) -> tuple[list[tuple[str, str]], list[st
                     command = hook.get("command", "")
                     if "additionalContext" not in command:
                         continue
-                    size = len(command.encode("utf-8"))
+                    try:
+                        size = len(command.encode("utf-8"))
+                    except UnicodeEncodeError:
+                        # A lone/unpaired surrogate (valid in a JSON \uXXXX escape,
+                        # invalid UTF-8) must not crash out to the file-level catch
+                        # and discard every other hook's already-found violations.
+                        errors.append(f"{SETTINGS}: {event} capsule command has an unencodable character")
+                        continue
                     if size > COMMAND_BYTES_MAX:
                         errors.append(f"{SETTINGS}: {event} capsule command {size} bytes > cap {COMMAND_BYTES_MAX}")
                         continue
@@ -315,8 +336,16 @@ def check_parity(root: Path) -> list[str]:
     return violations
 
 
-def _script_refs(command: str) -> list[str] | None:
-    """Repo-script tokens (*.sh / *.py) of a hook command, or None when untokenizable."""
+def _script_refs(command: str, _depth: int = 0) -> list[str] | None:
+    """Repo-script tokens (*.sh / *.py) of a hook command, or None when untokenizable.
+
+    A token that itself contains embedded whitespace after tokenization is a quoted
+    compound shell fragment (`sh -c 'python3 scripts/emit.py --flag'` collapses to
+    one opaque token) — its script reference would otherwise hide inside that one
+    token, so it is recursively re-tokenized. Depth is bounded (nested quoting is
+    finite, and the caller already caps the command's raw byte length before this
+    ever runs) purely as a defensive limit, not because it is reachable in practice.
+    """
     try:
         # punctuation_chars: split glued shell operators (`x.sh;sh`, `x.sh>log`) into
         # their own tokens so an operator can never hide a script reference.
@@ -328,6 +357,11 @@ def _script_refs(command: str) -> list[str] | None:
     refs = []
     for tok in argv:
         if not tok.lower().endswith((".sh", ".py")):
+            if _depth < 4 and any(char.isspace() for char in tok):
+                nested = _script_refs(tok, _depth + 1)
+                if nested is None:
+                    return None
+                refs.extend(nested)
             continue
         for prefix in _PROJECT_DIR_PREFIXES:
             tok = tok.removeprefix(prefix)
@@ -340,7 +374,7 @@ def _check_helper(root: Path, event: str, ref: str) -> list[str]:
     if "$" in ref or ref.startswith("/") or ".." in ref.split("/"):
         return [f"{SETTINGS}: {event} hook references unresolvable script `{ref}` — cannot verify capsule emission"]
     if not ref.startswith(_HELPER_DIRS):
-        return [f"{SETTINGS}: {event} hook helper `{ref}` outside the checked roots {'/'.join(_HELPER_DIRS)}"]
+        return [f"{SETTINGS}: {event} hook helper `{ref}` outside the checked roots {', '.join(_HELPER_DIRS)}"]
     path = root / ref
     if not path.is_file():
         return [f"{SETTINGS}: {event} hook helper `{ref}` not found — cannot verify capsule emission"]
@@ -348,7 +382,9 @@ def _check_helper(root: Path, event: str, ref: str) -> list[str]:
         text = path.read_text(encoding="utf-8", errors="replace")
     except OSError as exc:
         return [f"{SETTINGS}: {event} hook helper `{ref}` unreadable ({exc.strerror or exc})"]
-    if "additionalContext" not in text or (event, ref) in DYNAMIC_CAPSULE_PRODUCERS:
+    if (event, ref) in DYNAMIC_CAPSULE_PRODUCERS:
+        return []
+    if "additionalContext" not in text and not _DELEGATES_RE.search(text):
         return []
     return [
         f"{SETTINGS}: {event} hook helper `{ref}` may emit additionalContext the checker cannot validate — "
@@ -370,7 +406,16 @@ def check_indirect_producers(root: Path) -> list[str]:
                     command = hook.get("command", "")
                     if "additionalContext" in command:
                         continue  # the canonical inline-capsule path (extract_capsules) owns it
-                    size = len(command.encode("utf-8"))
+                    try:
+                        size = len(command.encode("utf-8"))
+                    except UnicodeEncodeError:
+                        # Same fail-closed-per-command discipline as extract_capsules:
+                        # one hostile command must not crash out and silently drop
+                        # every other hook's already-found indirect-producer violations.
+                        violations.append(
+                            f"{SETTINGS}: {event} hook command has an unencodable character — cannot rule out a capsule"
+                        )
+                        continue
                     if size > COMMAND_BYTES_MAX:
                         violations.append(
                             f"{SETTINGS}: {event} hook command {size} bytes > cap {COMMAND_BYTES_MAX}"

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -17,11 +17,17 @@ routable. Budgets (calibrated on the measured tree, not the matrix estimates):
 - `.claude/rules/*.md` (Claude soft routing backstops) 400 B
 - each hook-capsule `additionalContext` payload     1,800 B
 
+A hook command may also invoke a repo helper script (under scripts/ or
+.claude/hooks/, both trigger surfaces). A helper whose content could emit
+`hookSpecificOutput.additionalContext` must be a registered
+DYNAMIC_CAPSULE_PRODUCERS entry; any other indirect producer — or a helper
+reference the checker cannot statically resolve and read — fails closed (#1501).
+
 CONDITIONAL: in --staged / --diff mode the checks run IF AND ONLY IF the change
 touches a context surface (AGENTS.md, CLAUDE.md, .agents/policy/,
-.agents/context/, docs/misc/, .claude/rules/, .claude/settings.json, any nested
-CLAUDE.md/AGENTS.md, or this checker); otherwise it reports the skip and exits 0.
---all checks unconditionally.
+.agents/context/, docs/misc/, .claude/rules/, .claude/hooks/, scripts/,
+.claude/settings.json, any nested CLAUDE.md/AGENTS.md, or this checker);
+otherwise it reports the skip and exits 0. --all checks unconditionally.
 
 Usage:
     check_context_budget.py --staged        # pre-commit: staged diff decides, index content checked
@@ -63,6 +69,19 @@ FILE_BUDGETS = {
 }
 
 SETTINGS = ".claude/settings.json"
+
+# Registered (event, script) hook helpers whose additionalContext is a RUNTIME-computed
+# diagnostic — no static payload exists to budget/parity-check. Any unregistered helper
+# that could emit a capsule fails closed (inline as canonical `echo '<JSON>'` or register).
+DYNAMIC_CAPSULE_PRODUCERS = {
+    ("SessionStart", ".claude/hooks/session-branch-sync.sh"),
+    ("PreToolUse", "scripts/check_retired_tokens.py"),
+}
+
+# Helper scripts must live under these roots: both are trigger surfaces
+# (_TRIGGER_DIRS), so editing a helper re-runs this gate.
+_HELPER_DIRS = ("scripts/", ".claude/hooks/")
+_PROJECT_DIR_PREFIXES = ("${CLAUDE_PROJECT_DIR:-.}/", "${CLAUDE_PROJECT_DIR}/")
 
 # Accepts both header shapes in the first HEADER_WINDOW lines: the plain
 # "Scope: ... Load when: ..." prose and the bulleted "- **Scope:** / - **Load-when:**".
@@ -286,8 +305,79 @@ def check_parity(root: Path) -> list[str]:
     return violations
 
 
+def _script_refs(command: str) -> list[str] | None:
+    """Repo-script tokens (*.sh / *.py) of a hook command, or None when untokenizable."""
+    try:
+        argv = shlex.split(command)
+    except ValueError:
+        return None
+    refs = []
+    for tok in argv:
+        if not tok.endswith((".sh", ".py")):
+            continue
+        for prefix in _PROJECT_DIR_PREFIXES:
+            tok = tok.removeprefix(prefix)
+        refs.append(tok.removeprefix("./"))
+    return refs
+
+
+def _check_helper(root: Path, event: str, ref: str) -> list[str]:
+    """Fail-closed verdicts for one helper-script reference of a hook command."""
+    if "$" in ref or ref.startswith("/") or ".." in ref.split("/"):
+        return [f"{SETTINGS}: {event} hook references unresolvable script `{ref}` — cannot verify capsule emission"]
+    if not ref.startswith(_HELPER_DIRS):
+        return [f"{SETTINGS}: {event} hook helper `{ref}` outside the checked roots {'/'.join(_HELPER_DIRS)}"]
+    path = root / ref
+    if not path.is_file():
+        return [f"{SETTINGS}: {event} hook helper `{ref}` not found — cannot verify capsule emission"]
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return [f"{SETTINGS}: {event} hook helper `{ref}` unreadable ({exc.strerror or exc})"]
+    if "additionalContext" not in text or (event, ref) in DYNAMIC_CAPSULE_PRODUCERS:
+        return []
+    return [
+        f"{SETTINGS}: {event} hook helper `{ref}` may emit additionalContext the checker cannot validate — "
+        "inline it as a canonical echo '<JSON>' capsule or register it in DYNAMIC_CAPSULE_PRODUCERS"
+    ]
+
+
+def check_indirect_producers(root: Path) -> list[str]:
+    """Flag hook helper scripts that could emit a capsule the budget/parity gate never sees (#1501)."""
+    settings = root / SETTINGS
+    if not settings.is_file():
+        return []
+    violations: list[str] = []
+    try:
+        parsed = json.loads(settings.read_text(encoding="utf-8"))
+        for event, entries in parsed.get("hooks", {}).items():
+            for entry in entries:
+                for hook in entry.get("hooks", []):
+                    command = hook.get("command", "")
+                    if "additionalContext" in command:
+                        continue  # the canonical inline-capsule path (extract_capsules) owns it
+                    refs = _script_refs(command)
+                    if refs is None:
+                        violations.append(
+                            f"{SETTINGS}: {event} hook command has unparseable quoting — cannot rule out a capsule"
+                        )
+                        continue
+                    for ref in refs:
+                        violations.extend(_check_helper(root, event, ref))
+    except (ValueError, AttributeError, TypeError):
+        # Unparseable/wrong-shape settings: check_capsules already fails closed on the file.
+        return []
+    return violations
+
+
 def run_checks(root: Path, tracked: list[str]) -> list[str]:
-    return check_sizes(root, tracked) + check_headers(root) + check_capsules(root) + check_parity(root)
+    return (
+        check_sizes(root, tracked)
+        + check_headers(root)
+        + check_capsules(root)
+        + check_parity(root)
+        + check_indirect_producers(root)
+    )
 
 
 def _git(root: Path, *args: str) -> str:
@@ -298,7 +388,7 @@ def _git(root: Path, *args: str) -> str:
 # The CI workflow (.github/workflows/context-budget.yml) path-filters on these same
 # surfaces; pinned by tests/test_context_budget.py::test_ci_workflow_paths_match_checker_triggers.
 _TRIGGER_FILES = ("AGENTS.md", "CLAUDE.md", SETTINGS, "scripts/check_context_budget.py")
-_TRIGGER_DIRS = (".agents/policy/", ".agents/context/", "docs/misc/", ".claude/rules/")
+_TRIGGER_DIRS = (".agents/policy/", ".agents/context/", "docs/misc/", ".claude/rules/", ".claude/hooks/", "scripts/")
 
 
 def touches_context_surface(changed: list[str]) -> bool:

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -577,6 +577,28 @@ def test_indirect_delegating_helper_without_literal_still_detected(tmp_path: Pat
     assert any("scripts/delegate.sh" in v for v in violations), violations
 
 
+def test_indirect_extensionless_helper_still_detected(tmp_path: Path) -> None:
+    # issue found in review (B1): a committed helper with no .sh/.py extension is
+    # never collected by the suffix-gated tokenizer, so an emitting helper named
+    # e.g. `scripts/emit-context` slips the fail-closed gate entirely (#1501).
+    root = _indirect_root(tmp_path, "sh scripts/emit-context")
+    _write(root, "scripts/emit-context", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
+    violations = ccb.check_indirect_producers(root)
+    assert any("scripts/emit-context" in v for v in violations), violations
+
+
+@pytest.mark.parametrize("glue", ["$()", "``"])
+def test_indirect_glued_substitution_helper_still_detected(tmp_path: Path, glue: str) -> None:
+    # issue found in review (B1): an empty command substitution glued with no
+    # whitespace right after a .sh/.py helper (`x.sh$()`, `x.sh` + backticks) is a
+    # shell no-op that still runs the file, yet it strips the recognizable suffix
+    # off every surviving shlex token, so the reference goes invisible (#1501).
+    root = _indirect_root(tmp_path, f"sh scripts/emit.sh{glue}")
+    _write(root, "scripts/emit.sh", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
+    violations = ccb.check_indirect_producers(root)
+    assert any("scripts/emit.sh" in v for v in violations), violations
+
+
 def test_indirect_registered_dynamic_producer_clean(tmp_path: Path) -> None:
     root = _indirect_root(tmp_path, 'sh "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/session-branch-sync.sh"')
     _write(root, ".claude/hooks/session-branch-sync.sh", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -560,10 +560,14 @@ def test_indirect_quoted_compound_script_ref_still_detected(tmp_path: Path) -> N
     # issue found in review: `sh -c '...'` (an ordinary shell idiom) collapses its
     # whole quoted body to ONE shlex token after quote removal — a script ref
     # embedded inside that merged token must not go invisible to _script_refs.
-    root = _indirect_root(tmp_path, "sh -c 'python3 scripts/emit.py --flag'")
-    _write(root, "scripts/emit.py", "print('additionalContext')\n")
+    # The ref sits OUTSIDE the helper dirs on purpose: _HELPER_PATH_RE is helper-dir
+    # scoped and structurally cannot reach it, so only the compound-fragment
+    # recursion surfaces it — keeping this a live mutant for the recursion rather
+    # than a shadow of the extension-agnostic path scan.
+    root = _indirect_root(tmp_path, "sh -c 'python3 tools/emit.py --flag'")
+    _write(root, "tools/emit.py", "print('additionalContext')\n")
     violations = ccb.check_indirect_producers(root)
-    assert any("scripts/emit.py" in v for v in violations), violations
+    assert any("tools/emit.py" in v and "outside the checked roots" in v for v in violations), violations
 
 
 def test_indirect_delegating_helper_without_literal_still_detected(tmp_path: Path) -> None:

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -453,8 +453,8 @@ def test_indirect_over_cap_command_fails_closed(tmp_path: Path) -> None:
 
 
 def test_indirect_unencodable_command_fails_closed_without_masking_others(tmp_path: Path) -> None:
-    # issue found in review: a lone/unpaired surrogate in ONE hook command must not
-    # crash check_indirect_producers's per-file try and silently drop every OTHER
+    # A lone/unpaired surrogate in ONE hook command must not crash
+    # check_indirect_producers's per-file try and silently drop every OTHER
     # hook's already-found violation in the same settings file.
     root = tmp_path
     _write(root, "scripts/real_emit.sh", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
@@ -557,9 +557,9 @@ def test_indirect_uppercase_extension_helper_still_detected(tmp_path: Path) -> N
 
 
 def test_indirect_quoted_compound_script_ref_still_detected(tmp_path: Path) -> None:
-    # issue found in review: `sh -c '...'` (an ordinary shell idiom) collapses its
-    # whole quoted body to ONE shlex token after quote removal — a script ref
-    # embedded inside that merged token must not go invisible to _script_refs.
+    # `sh -c '...'` (an ordinary shell idiom) collapses its whole quoted body to
+    # ONE shlex token after quote removal — a script ref embedded inside that
+    # merged token must not go invisible to _script_refs.
     # The ref sits OUTSIDE the helper dirs on purpose: _HELPER_PATH_RE is helper-dir
     # scoped and structurally cannot reach it, so only the compound-fragment
     # recursion surfaces it — keeping this a live mutant for the recursion rather
@@ -571,7 +571,7 @@ def test_indirect_quoted_compound_script_ref_still_detected(tmp_path: Path) -> N
 
 
 def test_indirect_delegating_helper_without_literal_still_detected(tmp_path: Path) -> None:
-    # issue found in review: a helper that delegates emission to another module
+    # A helper that delegates emission to another module
     # (`exec "$PY" -m "pkg.hooks.$1"`, the live ts-hook.sh shape) carries no
     # "additionalContext" literal itself — the substring-only check would
     # otherwise miss it entirely and never require registration (#1501).
@@ -595,10 +595,10 @@ def test_indirect_extensionless_helper_still_detected(tmp_path: Path, name: str)
 
 @pytest.mark.parametrize("glue", ["$()", "``"])
 def test_indirect_glued_substitution_helper_still_detected(tmp_path: Path, glue: str) -> None:
-    # issue found in review (B1): an empty command substitution glued with no
-    # whitespace right after a .sh/.py helper (`x.sh$()`, `x.sh` + backticks) is a
-    # shell no-op that still runs the file, yet it strips the recognizable suffix
-    # off every surviving shlex token, so the reference goes invisible (#1501).
+    # An empty command substitution glued with no whitespace right after a
+    # .sh/.py helper (`x.sh$()`, `x.sh` + backticks) is a shell no-op that still
+    # runs the file, yet it strips the recognizable suffix off every surviving
+    # shlex token, so the reference goes invisible (#1501).
     root = _indirect_root(tmp_path, f"sh scripts/emit.sh{glue}")
     _write(root, "scripts/emit.sh", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
     violations = ccb.check_indirect_producers(root)

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -399,6 +399,107 @@ def test_run_checks_reports_size_violations_despite_malformed_settings(tmp_path:
     assert any("not a parseable hooks structure" in v for v in violations)
 
 
+# --- indirect capsule producers (#1501) ------------------------------------------
+
+
+def _indirect_root(tmp_path: Path, command: str, event: str = "SessionStart") -> Path:
+    _write(tmp_path, ".claude/settings.json", _settings_command(command, event))
+    return tmp_path
+
+
+def test_indirect_helper_without_capsule_output_clean(tmp_path: Path) -> None:
+    # Nearest clean sibling of the bypass: same hook shape, helper emits no capsule.
+    root = _indirect_root(tmp_path, 'sh "${CLAUDE_PROJECT_DIR:-.}/scripts/quiet.sh"')
+    _write(root, "scripts/quiet.sh", "#!/bin/sh\nexit 0\n")
+    assert ccb.check_indirect_producers(root) == []
+
+
+def test_indirect_empty_helper_clean(tmp_path: Path) -> None:
+    root = _indirect_root(tmp_path, "sh scripts/empty.sh")
+    _write(root, "scripts/empty.sh", "")
+    assert ccb.check_indirect_producers(root) == []
+
+
+def test_indirect_missing_helper_fails_closed(tmp_path: Path) -> None:
+    root = _indirect_root(tmp_path, "sh scripts/ghost.sh")
+    violations = ccb.check_indirect_producers(root)
+    assert len(violations) == 1 and "`scripts/ghost.sh` not found" in violations[0], violations
+
+
+@pytest.mark.parametrize(
+    ("command", "marker"),
+    [
+        ('sh "scripts/broken.sh', "unparseable quoting"),
+        ('sh "$HOME/x.sh"', "unresolvable script"),
+        ("sh /tmp/x.sh", "unresolvable script"),
+        ("sh scripts/../x.sh", "unresolvable script"),
+    ],
+)
+def test_indirect_unresolvable_command_shapes_fail_closed(tmp_path: Path, command: str, marker: str) -> None:
+    root = _indirect_root(tmp_path, command)
+    violations = ccb.check_indirect_producers(root)
+    assert len(violations) == 1 and marker in violations[0], violations
+
+
+def test_indirect_helper_outside_checked_roots_fails_closed(tmp_path: Path) -> None:
+    # A helper outside scripts//.claude/hooks/ dodges the trigger surfaces: editing
+    # it would never re-run this gate, so its location alone is a violation.
+    root = _indirect_root(tmp_path, "sh tests/helper.sh")
+    _write(root, "tests/helper.sh", "#!/bin/sh\nexit 0\n")
+    violations = ccb.check_indirect_producers(root)
+    assert len(violations) == 1 and "outside the checked roots" in violations[0], violations
+
+
+def test_indirect_registered_dynamic_producer_clean(tmp_path: Path) -> None:
+    root = _indirect_root(tmp_path, 'sh "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/session-branch-sync.sh"')
+    _write(root, ".claude/hooks/session-branch-sync.sh", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
+    assert ccb.check_indirect_producers(root) == []
+
+
+def test_indirect_registered_script_at_other_event_fails_closed(tmp_path: Path) -> None:
+    # Registration is per (event, script) pair: rewiring a registered producer to a
+    # different event is a new, unreviewed capsule surface.
+    command = 'sh "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/session-branch-sync.sh"'
+    root = _indirect_root(tmp_path, command, event="UserPromptSubmit")
+    _write(root, ".claude/hooks/session-branch-sync.sh", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
+    violations = ccb.check_indirect_producers(root)
+    assert len(violations) == 1 and "cannot validate" in violations[0], violations
+
+
+def test_indirect_registered_retired_tokens_compound_command_clean(tmp_path: Path) -> None:
+    command = 'cd "${CLAUDE_PROJECT_DIR:-.}" && python3 scripts/check_retired_tokens.py --claude-hook || true'
+    root = _indirect_root(tmp_path, command, event="PreToolUse")
+    _write(root, "scripts/check_retired_tokens.py", "REPORT_KEY = 'additionalContext'\n")
+    assert ccb.check_indirect_producers(root) == []
+
+
+def test_indirect_no_script_reference_command_clean(tmp_path: Path) -> None:
+    command = (
+        "command -v zstd >/dev/null 2>&1 || python3 -c 'import zstandard' 2>/dev/null"
+        " || pip3 install -q zstandard >/dev/null 2>&1 || true"
+    )
+    root = _indirect_root(tmp_path, command)
+    assert ccb.check_indirect_producers(root) == []
+
+
+def test_indirect_wrong_shape_settings_defers_to_capsule_check(tmp_path: Path) -> None:
+    # check_capsules already fails closed on the whole file; no duplicate violation here.
+    _write(tmp_path, ".claude/settings.json", '{"hooks": ["not", "a", "dict"]}')
+    assert ccb.check_indirect_producers(tmp_path) == []
+
+
+def test_run_checks_flags_helper_script_capsule_bypass(tmp_path: Path) -> None:
+    # issue #1501: the hook command carries no `additionalContext` literal, but the
+    # repo helper script it invokes emits a valid oversized capsule Claude consumes —
+    # the checker must flag the indirect producer, never skip the hook silently.
+    root = _scratch_repo(tmp_path)
+    payload = json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "X" * 5_000}})
+    _write(root, "scripts/emit-context.sh", f"#!/bin/sh\nprintf '%s\\n' '{payload}'\n")
+    _write(root, ".claude/settings.json", _settings_command('sh "${CLAUDE_PROJECT_DIR:-.}/scripts/emit-context.sh"'))
+    violations = ccb.run_checks(root, _tracked(root))
+    assert any("scripts/emit-context.sh" in v for v in violations), violations
+
+
 # --- UserPromptSubmit capsule <-> AGENTS.md parity ------------------------------
 
 
@@ -509,6 +610,8 @@ def test_check_parity_live_repository_user_prompt_submit_clean() -> None:
         "docs/misc/architecture-notes.md",
         "tests/smoke/CLAUDE.md",
         ".claude/rules/smoke.md",
+        ".claude/hooks/rtk-hook.sh",
+        "scripts/ts-hook.sh",
     ],
 )
 def test_touches_context_surface_true(rel: str) -> None:

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import re
 import subprocess
 import sys
@@ -467,6 +468,15 @@ def test_indirect_missing_helper_fails_closed(tmp_path: Path) -> None:
     root = _indirect_root(tmp_path, "sh scripts/ghost.sh")
     violations = ccb.check_indirect_producers(root)
     assert len(violations) == 1 and "`scripts/ghost.sh` not found" in violations[0], violations
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses file permissions — denial cannot be simulated")
+def test_indirect_unreadable_helper_fails_closed(tmp_path: Path) -> None:
+    root = _indirect_root(tmp_path, "sh scripts/locked.sh")
+    helper = _write(root, "scripts/locked.sh", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
+    helper.chmod(0)
+    violations = ccb.check_indirect_producers(root)
+    assert len(violations) == 1 and "unreadable" in violations[0], violations
 
 
 @pytest.mark.parametrize(

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -399,6 +399,49 @@ def test_run_checks_reports_size_violations_despite_malformed_settings(tmp_path:
     assert any("not a parseable hooks structure" in v for v in violations)
 
 
+def test_extract_capsules_rejects_over_cap_command_before_tokenization() -> None:
+    # issue #1504: shlex is nonlinear on huge quoted strings (~25 s at 1 MB), so a
+    # command beyond the derived ceiling (decoded 1,800 B budget × worst-case JSON
+    # escaping + envelope) must be rejected on byte length alone, never tokenized.
+    payload = json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "X" * 11_000}})
+    capsules, errors = ccb.extract_capsules(_settings_command(f"echo '{payload}'"))
+    assert capsules == []
+    assert len(errors) == 1 and "SessionStart" in errors[0] and "cap" in errors[0], errors
+
+
+def _canonical_command_padded_to(nbytes: int) -> str:
+    """A canonical `echo '<JSON>'` capsule command of exactly nbytes UTF-8 bytes."""
+    empty = json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": ""}})
+    pad = nbytes - len(f"echo '{empty}'".encode())
+    payload = json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "X" * pad}})
+    command = f"echo '{payload}'"
+    assert len(command.encode("utf-8")) == nbytes
+    return command
+
+
+def test_extract_capsules_command_at_cap_is_tokenized() -> None:
+    # The boundary itself passes the cap: an at-ceiling command still reaches
+    # tokenization and extraction (its payload then answers to the 1,800 B budget).
+    capsules, errors = ccb.extract_capsules(_settings_command(_canonical_command_padded_to(ccb.COMMAND_BYTES_MAX)))
+    assert errors == []
+    assert len(capsules) == 1 and capsules[0][0] == "SessionStart"
+    assert len(capsules[0][1].encode("utf-8")) > 1_800  # the cap never replaces the budget
+
+
+def test_extract_capsules_command_one_byte_over_cap_rejected() -> None:
+    over = ccb.COMMAND_BYTES_MAX + 1
+    capsules, errors = ccb.extract_capsules(_settings_command(_canonical_command_padded_to(over)))
+    assert capsules == []
+    assert errors == [f".claude/settings.json: SessionStart capsule command {over} bytes > cap {ccb.COMMAND_BYTES_MAX}"]
+
+
+def test_indirect_over_cap_command_fails_closed(tmp_path: Path) -> None:
+    # A non-capsule command over the cap is never tokenized for script refs either.
+    root = _indirect_root(tmp_path, "true " + "x" * 11_000)
+    violations = ccb.check_indirect_producers(root)
+    assert len(violations) == 1 and "cannot rule out a capsule" in violations[0], violations
+
+
 # --- indirect capsule producers (#1501) ------------------------------------------
 
 

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -436,11 +436,38 @@ def test_extract_capsules_command_one_byte_over_cap_rejected() -> None:
     assert errors == [f".claude/settings.json: SessionStart capsule command {over} bytes > cap {ccb.COMMAND_BYTES_MAX}"]
 
 
+def test_extract_capsules_unencodable_command_fails_closed() -> None:
+    # A lone/unpaired UTF-16 surrogate is valid inside a JSON \uXXXX escape but
+    # cannot be UTF-8 encoded; the byte-cap check's .encode("utf-8") must not
+    # crash out to the file-level catch and discard every other capsule's result.
+    capsules, errors = ccb.extract_capsules(_settings_command("echo additionalContext \ud800"))
+    assert capsules == []
+    assert len(errors) == 1 and "SessionStart" in errors[0] and "unencodable" in errors[0], errors
+
+
 def test_indirect_over_cap_command_fails_closed(tmp_path: Path) -> None:
     # A non-capsule command over the cap is never tokenized for script refs either.
     root = _indirect_root(tmp_path, "true " + "x" * 11_000)
     violations = ccb.check_indirect_producers(root)
     assert len(violations) == 1 and "cannot rule out a capsule" in violations[0], violations
+
+
+def test_indirect_unencodable_command_fails_closed_without_masking_others(tmp_path: Path) -> None:
+    # issue found in review: a lone/unpaired surrogate in ONE hook command must not
+    # crash check_indirect_producers's per-file try and silently drop every OTHER
+    # hook's already-found violation in the same settings file.
+    root = tmp_path
+    _write(root, "scripts/real_emit.sh", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
+    settings_text = (
+        '{"hooks": {'
+        '"SessionStart": [{"hooks": [{"type": "command", "command": "sh scripts/real_emit.sh \\ud800"}]}],'
+        '"PreToolUse": [{"hooks": [{"type": "command", "command": "sh scripts/real_emit.sh"}]}]'
+        "}}"
+    )
+    _write(root, ".claude/settings.json", settings_text)
+    violations = ccb.check_indirect_producers(root)
+    assert any("unencodable" in v for v in violations), violations
+    assert any("PreToolUse" in v and "scripts/real_emit.sh" in v for v in violations), violations
 
 
 # --- indirect capsule producers (#1501) ------------------------------------------
@@ -527,6 +554,27 @@ def test_indirect_uppercase_extension_helper_still_detected(tmp_path: Path) -> N
     _write(root, "scripts/LOUD.SH", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
     violations = ccb.check_indirect_producers(root)
     assert any("scripts/LOUD.SH" in v for v in violations), violations
+
+
+def test_indirect_quoted_compound_script_ref_still_detected(tmp_path: Path) -> None:
+    # issue found in review: `sh -c '...'` (an ordinary shell idiom) collapses its
+    # whole quoted body to ONE shlex token after quote removal — a script ref
+    # embedded inside that merged token must not go invisible to _script_refs.
+    root = _indirect_root(tmp_path, "sh -c 'python3 scripts/emit.py --flag'")
+    _write(root, "scripts/emit.py", "print('additionalContext')\n")
+    violations = ccb.check_indirect_producers(root)
+    assert any("scripts/emit.py" in v for v in violations), violations
+
+
+def test_indirect_delegating_helper_without_literal_still_detected(tmp_path: Path) -> None:
+    # issue found in review: a helper that delegates emission to another module
+    # (`exec "$PY" -m "pkg.hooks.$1"`, the live ts-hook.sh shape) carries no
+    # "additionalContext" literal itself — the substring-only check would
+    # otherwise miss it entirely and never require registration (#1501).
+    root = _indirect_root(tmp_path, "sh scripts/delegate.sh")
+    _write(root, "scripts/delegate.sh", '#!/bin/sh\nexec "$PY" -m "pkg.hooks.$1"\n')
+    violations = ccb.check_indirect_producers(root)
+    assert any("scripts/delegate.sh" in v for v in violations), violations
 
 
 def test_indirect_registered_dynamic_producer_clean(tmp_path: Path) -> None:

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -493,6 +493,32 @@ def test_indirect_helper_outside_checked_roots_fails_closed(tmp_path: Path) -> N
     assert len(violations) == 1 and "outside the checked roots" in violations[0], violations
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sh scripts/x.sh;sh scripts/quiet.sh",
+        "sh scripts/x.sh>/tmp/out.log",
+        "sh scripts/x.sh|cat",
+        "sh scripts/x.sh&&true",
+    ],
+)
+def test_indirect_metachar_glued_helper_still_detected(tmp_path: Path, command: str) -> None:
+    # Shell operators glued to the path (no whitespace) must not make an emitting
+    # helper invisible: `scripts/x.sh;sh` is a ref plus an operator, not a non-ref token.
+    root = _indirect_root(tmp_path, command)
+    _write(root, "scripts/x.sh", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
+    _write(root, "scripts/quiet.sh", "#!/bin/sh\nexit 0\n")
+    violations = ccb.check_indirect_producers(root)
+    assert any("scripts/x.sh" in v for v in violations), violations
+
+
+def test_indirect_uppercase_extension_helper_still_detected(tmp_path: Path) -> None:
+    root = _indirect_root(tmp_path, "sh scripts/LOUD.SH")
+    _write(root, "scripts/LOUD.SH", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
+    violations = ccb.check_indirect_producers(root)
+    assert any("scripts/LOUD.SH" in v for v in violations), violations
+
+
 def test_indirect_registered_dynamic_producer_clean(tmp_path: Path) -> None:
     root = _indirect_root(tmp_path, 'sh "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/session-branch-sync.sh"')
     _write(root, ".claude/hooks/session-branch-sync.sh", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -581,14 +581,16 @@ def test_indirect_delegating_helper_without_literal_still_detected(tmp_path: Pat
     assert any("scripts/delegate.sh" in v for v in violations), violations
 
 
-def test_indirect_extensionless_helper_still_detected(tmp_path: Path) -> None:
-    # issue found in review (B1): a committed helper with no .sh/.py extension is
-    # never collected by the suffix-gated tokenizer, so an emitting helper named
-    # e.g. `scripts/emit-context` slips the fail-closed gate entirely (#1501).
-    root = _indirect_root(tmp_path, "sh scripts/emit-context")
-    _write(root, "scripts/emit-context", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
+@pytest.mark.parametrize("name", ["emit-context", "emit+context", "emit@context"])
+def test_indirect_extensionless_helper_still_detected(tmp_path: Path, name: str) -> None:
+    # A committed helper with no .sh/.py extension — including a name with valid
+    # unquoted path characters such as + or @ — must still be resolved and checked;
+    # the suffix-gated tokenizer drops it entirely, so the path scan must cover the
+    # full unquoted filename, not a truncated prefix (#1501).
+    root = _indirect_root(tmp_path, f"sh scripts/{name}")
+    _write(root, f"scripts/{name}", "#!/bin/sh\nprintf '%s' 'additionalContext payload'\n")
     violations = ccb.check_indirect_producers(root)
-    assert any("scripts/emit-context" in v for v in violations), violations
+    assert any(f"scripts/{name}" in v for v in violations), violations
 
 
 @pytest.mark.parametrize("glue", ["$()", "``"])


### PR DESCRIPTION
Fixes #1501 and #1504.

## #1504 — cap oversized capsule commands before shlex

Any hook command over `COMMAND_BYTES_MAX` (11,000 B) is rejected **before** `shlex` tokenization on both the capsule and indirect-producer paths, so a huge quoted string can't drive shlex's nonlinear parse (~25 s at 1 MB). Boundary-pinned tests.

## #1501 — fail closed on helper-produced capsules

The checker flags any hook helper that could emit `hookSpecificOutput.additionalContext` the budget/parity gate never sees, unless registered in `DYNAMIC_CAPSULE_PRODUCERS`:

- **helper references resolved regardless of extension or a glued shell metacharacter** (`x.sh$()`, backtick) — a helper-dir-rooted path that resolves to a committed file is checked even when the `.sh`/`.py` suffix is absent or stripped off the token;
- a script reference nested in a quoted compound fragment (`sh -c '...'`) is recursively re-tokenized;
- a helper that **delegates** emission (`exec` / `subprocess` / `os.exec*` / `os.system`) is flagged even without an `additionalContext` literal;
- an unencodable (lone-surrogate) command fails closed per-command instead of crashing the file scan and dropping every other hook's findings.

## Scope of "fail closed"

This closes the reference- and delegation-based bypasses a static checker can see. Inherent residual limits a no-execution checker cannot follow — a `python3 -c` that runtime-constructs its payload, delegation via `eval`/source, plain-stdout context injection — are documented and tracked in #1530.

## Review

Two-pass adversarial review (Sonnet + Opus) found two helper-detection bypasses (non-`.sh`/`.py` extension; `$()`/backtick glued after the suffix); both fixed here **test-first** (red→green, frozen byte-identical) with an extensionless-helper case and a parametrized glued case. The delegation/compound/unencodable hardening carries its own tests. Full `test_context_budget.py` suite green (117).

Files: `scripts/check_context_budget.py`, `tests/test_context_budget.py`, `.github/workflows/context-budget.yml`.