### PR TITLE
tests: align alert fixtures with ASN schema

### DIFF
--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -1552,25 +1552,25 @@ def test_alerts_rows_render_suppress_icons_for_v6_and_broad_v4(
     supp_entry = "203.0.113.0/28"
 
     ts = time.strftime("%b %d %H:%M:%S")  # e.g. "Jun 18 12:00:00"
-    # ip_block.log CSV format (21 fields, see the issue #361 test above):
+    # ip_block.log CSV format (23 fields, see the issue #361 test above):
     # ts,rule,real_iface,friendly_iface,action,ipv,proto_id,proto,
-    # src_ip,dst_ip,src_port,dst_port,dir,geoip,alias,ip_eval,feed,rhost,chost,asn,dup
+    # src_ip,dst_ip,src_port,dst_port,dir,geoip,alias,ip_eval,feed,rhost,chost,asn,asn_domain,asn_name,dup
     csv_lines = (
         # (a) v6, inbound -> $host = SRC = the foreign v6 address; ip_eval /48.
         f"{ts},100,em0,WAN,block,6,58,ICMPV6,"
         f"{v6_host},{v6_local},,"
         f",in,US,pfB_Deny_v6,"
-        "2001:db8:dead::/48,pfB_TestFeed_v6,Unknown,Unknown,Unknown,+\n"
+        "2001:db8:dead::/48,pfB_TestFeed_v6,Unknown,Unknown,Unknown,,,+\n"
         # (b) v4, inbound -> $host = SRC = the broad-mask host; ip_eval mask /16.
         f"{ts},100,em0,WAN,block,4,6,TCP,"
         f"{v4_broad_host},10.0.0.5,12345,443,"
         "in,US,pfB_Deny_v4,"
-        "198.51.0.0/16,pfB_TestFeed_v4,Unknown,Unknown,Unknown,+\n"
+        "198.51.0.0/16,pfB_TestFeed_v4,Unknown,Unknown,Unknown,,,+\n"
         # (c) v4, inbound -> $host covered by the seeded v4suppression /28.
         f"{ts},100,em0,WAN,block,4,6,TCP,"
         f"{v4_supp_host},10.0.0.6,12345,443,"
         "in,US,pfB_Deny_v4,"
-        "203.0.113.0/28,pfB_TestFeed_v4,Unknown,Unknown,Unknown,+\n"
+        "203.0.113.0/28,pfB_TestFeed_v4,Unknown,Unknown,Unknown,,,+\n"
     )
 
     ip_block_log = helpers.IP_BLOCK_LOG
@@ -1786,20 +1786,20 @@ def test_alerts_rows_render_whitelist_icons_oracle(
     plus_host = "203.0.113.88"  # same block, NOT in the seeded Permit alias
 
     ts = time.strftime("%b %d %H:%M:%S")  # e.g. "Jun 18 12:00:00"
-    # ip_block.log CSV format (21 fields, see the suppress-icon
+    # ip_block.log CSV format (23 fields, see the suppress-icon
     # test above): ts,rule,real_iface,friendly_iface,action,ipv,proto_id,proto,
-    # src_ip,dst_ip,src_port,dst_port,dir,geoip,alias,ip_eval,feed,rhost,chost,asn,dup
+    # src_ip,dst_ip,src_port,dst_port,dir,geoip,alias,ip_eval,feed,rhost,chost,asn,asn_domain,asn_name,dup
     block_csv = (
         f"{ts},100,em0,WAN,block,4,6,TCP,"
         f"{trash_host},10.0.0.10,12345,443,"
         "in,US,pfB_798AliasDeny_v4,"
-        f"{trash_host}/32,pfB_798BlockFeed_v4,Unknown,Unknown,Unknown,+\n"
+        f"{trash_host}/32,pfB_798BlockFeed_v4,Unknown,Unknown,Unknown,,,+\n"
     )
     geo_csv = (
         f"{ts},100,em0,WAN,block,4,6,TCP,"
         f"{plus_host},10.0.0.11,12345,443,"
         "in,US,pfB_Europe_v4,"
-        "203.0.113.0/23,798GeoFeed,Unknown,Unknown,Unknown,+\n"
+        "203.0.113.0/23,798GeoFeed,Unknown,Unknown,Unknown,,,+\n"
     )
 
     ip_block_log = helpers.IP_BLOCK_LOG
@@ -2147,16 +2147,16 @@ def test_ipv6_alert_external_host_attribution(
     foreign = helpers.IPV6_FOREIGN  # 2001:db8:dead:beef::1 — outside the /64
     local = helpers.IPV6_LOCAL_HOST  # 2001:db8:51:1::1234   — inside the /64
 
-    # ip_block.log IPv6 CSV format (21 fields):
+    # ip_block.log IPv6 CSV format (23 fields):
     # ts,rule,real_iface,friendly_iface,action,ipv,proto_id,proto,
     # src_ip,dst_ip,src_port,dst_port,
-    # dir,geoip,alias,ip_eval,feed,rhost,chost,asn,dup
+    # dir,geoip,alias,ip_eval,feed,rhost,chost,asn,asn_domain,asn_name,dup
     # ip_eval is the evaluated (blocked) host = the foreign address in both cases.
     csv_line = (
         f"{ts},100,em0,WAN,block,6,58,ICMPV6,"
         f"{src_ip},{dst_ip},,"
         f",{direction},US,pfB_Deny_v6,"
-        f"{foreign},pfB_TestFeed_v6,Unknown,Unknown,Unknown,+\n"
+        f"{foreign},pfB_TestFeed_v6,Unknown,Unknown,Unknown,,,+\n"
     )
 
     ip_block_log = helpers.IP_BLOCK_LOG

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -377,16 +377,16 @@ def _ip_line(
     proto: str = "TCP",
     dup: str = "+",
 ) -> str:
-    """One ip_block.log/ip_permit.log/ip_match.log CSV line (21 fields).
+    """One ip_block.log/ip_permit.log/ip_match.log CSV line (23 fields).
 
     ts,rule,real_iface,friendly_iface,action,ipv,proto_id,proto,src_ip,dst_ip,
-    src_port,dst_port,dir,geoip,alias,ip_eval,feed,rhost,chost,asn,dup
+    src_port,dst_port,dir,geoip,alias,ip_eval,feed,rhost,chost,asn,asn_domain,asn_name,dup
     """
     ports = ",," if proto in ("ICMP", "ICMPV6") else ",12345,443"
     return (
         f"{FIXED_TS},100,em0,WAN,{action},{ipv},{proto_id},{proto},"
         f"{src_ip},{dst_ip}{ports},"
-        f"{direction},US,{alias},{ip_eval},{feed},Unknown,Unknown,Unknown,{dup}\n"
+        f"{direction},US,{alias},{ip_eval},{feed},Unknown,Unknown,Unknown,,,{dup}\n"
     )
 
 

--- a/tests/smoke/ui/test_alerts_seed_restore.py
+++ b/tests/smoke/ui/test_alerts_seed_restore.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import inspect
 import os
 import shlex
@@ -15,6 +16,19 @@ from typing import Any, Callable, cast
 import pytest
 
 from . import test_alerts_render_verify as alerts
+
+
+def test_alert_fixture_ip_rows_match_current_csv_schema() -> None:
+    direct_lines = alerts._ip_scenarios() + alerts._permit_lines() + alerts._match_lines()
+    direct_rows = list(csv.reader(direct_lines))
+    unified_rows = [
+        row for row in csv.reader(alerts._unified_lines()) if row and row[0] in {"Block", "Permit", "Match"}
+    ]
+
+    direct_counts = {len(row) for row in direct_rows}
+    unified_counts = {len(row) for row in unified_rows}
+    assert direct_counts == {23}, f"raw direct IP field counts: expected {{23}}, got {direct_counts}"
+    assert unified_counts == {24}, f"raw Unified IP field counts: expected {{24}}, got {unified_counts}"
 
 
 class _LocalVM:

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1792,7 +1792,7 @@ def test_corrupt_group_actions_render_repairably(
     unified_rows = (
         f"Block,{fixed_ts},100,em0,WAN,block,4,6,TCP,"
         f"{ip_host},10.0.0.134,12345,443,in,US,{ip_logged_alias},{ip_eval},"
-        f"{ip_feed_name},Unknown,Unknown,Unknown,+\n"
+        f"{ip_feed_name},Unknown,Unknown,Unknown,,,+\n"
         f"DNS-reply,{fixed_ts},cache,,A,30,{dns_domain},127.0.0.1,203.0.113.134,US\n"
     )
 


### PR DESCRIPTION
## Summary

- update direct IP alert fixtures to the current 23-field ASN CSV schema
- update Unified IP alert fixtures to the current 24-field schema
- add an off-appliance regression test that pins both field counts
- repair the remaining Tier-B fixture writers sharing the stale format

## Root cause

PR #1369 added `asn_domain` and `asn_name` columns and intentionally stopped accepting legacy IP log rows. Several older smoke fixtures still emitted 21-field direct rows or 22-field Unified rows, so `convert_ip_log()` rejected them before rendering. That made the seeded hosts disappear and caused the three Tier-A failures tracked in #1524.

## Impact

This changes test fixtures only. Production behavior is unchanged. Tier-A and Tier-B alert-render coverage now exercises rows accepted by the current production schema.

## Validation

- frozen test hash: `5c49590a902253862f856544b9746d8b32fa27e7`
- mechanical proof: `FREEZE-OK`, `RED-OK` against `0dd973e6`, `GREEN-OK` at `4568dc9`
- off-appliance fixture tests: 22 passed, 1 skipped
- focused touched-file tests: 23 passed, 151 skipped
- Ruff, format, mypy, compileall, and diff checks: passed
- independent implementation gate: passed with no findings
- leased-box control at `0dd973e6`: the three focused Tier-A tests failed
- leased-box validation at `4568dc9`: the same three tests passed

Fixes #1524

## Agent audit

Implemented by OpenAI Codex under the repository delegation policy. Independently reviewed by a separate Codex verifier.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert rendering and repair validation for records using the current CSV format.
  * Corrected synthetic alert data used to verify suppression, whitelist, GeoIP, and IPv6 attribution indicators.

* **Tests**
  * Added regression coverage to detect mismatches between generated alert records and the expected CSV schema.
  * Updated rendering checks to reflect the latest alert record structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->