### PR TITLE
tests: assert raw #1507 generated continent counts

### DIFF
--- a/tests/smoke/ui/test_render_dataless_continent_count.py
+++ b/tests/smoke/ui/test_render_dataless_continent_count.py
@@ -1,14 +1,17 @@
-"""Tier-A ``ui_render`` coverage for issue #1507: a data-less continent renders count 0.
+"""Tier-A coverage for issue #1507: a data-less continent gets generated count 0.
 
-``pfblockerng_get_countries()`` (the ``gc`` verb) writes each continent page with
-``$options_countries4_cnt``/``$options_countries6_cnt`` rendered as the ``size``
-attribute of the ``countries4``/``countries6`` selects (pfblockerng.php:2002/2011).
+``pfblockerng_get_countries()`` (the ``gc`` verb) writes
+``$options_countries4_cnt``/``$options_countries6_cnt`` into each generated
+continent page. pfSense's ``Form_Select`` clamps an empty select's rendered
+``size`` to its minimum row count, so the HTML attribute is not an oracle for
+those raw generated values. This module reads the assignments from the generated
+pages on the live box instead.
+
 ``$ftotal4``/``$ftotal6`` are assigned only inside the per-type coptions-guarded
 build block, so before the #1507 fix a continent whose file yields NO country
-entries rendered the PREVIOUS continent's count beside an empty list. The seeded
-MaxMind test corpus gives every one of the 9 continents at least one entry (e.g.
-``Antarctica [6697173] AQ (0)``), so the ``PAGE_TABLE`` sweep never drives the
-stays-empty path -- this module manufactures it on the live box.
+entries inherited the PREVIOUS continent's count. The seeded MaxMind test corpus
+gives every one of the 9 continents at least one entry, so the ``PAGE_TABLE``
+sweep never drives the stays-empty path -- this module manufactures it live.
 
 The data-less continent is manufactured as a header-ONLY continent file
 (``# Continent IPv{4,6}:`` + ``# Continent en:`` lines kept, all country blocks
@@ -18,14 +21,8 @@ scope) and the regenerated page would be written to the WRONG path. Header-only
 keeps the page's own name/title correct and isolates exactly the ``$ftotal``
 carry.
 
-Fail-before / pass-after: pre-fix, the mutated ``gc`` run regenerates the
-Antarctica page with Africa's (the previous continent's) nonzero counts as the
-select sizes, so the ``size="0"`` assertions fail; they pass only with the
-per-continent reset. The off-appliance red run is executed and pinned by
-``tests/php/PfbOptionsHeredocMultiContinentTest.php``.
-
-AUTHORED, NOT EXECUTED this session (no live VM) -- run via
-``pytest tests/smoke/ui -m ui_render --override-ini="addopts="`` on the fan-out VM.
+The authenticated requests still verify that the regenerated pages render
+cleanly. Direct generated-file assertions carry the count regression contract.
 """
 
 from __future__ import annotations
@@ -51,37 +48,42 @@ _BAK_SUFFIX = ".pfb1507bak"
 
 _AFRICA_PAGE = "/pfblockerng/pfblockerng_Africa.php"
 _ANTARCTICA_PAGE = "/pfblockerng/pfblockerng_Antarctica.php"
+_AFRICA_GENERATED_PAGE = "/usr/local/www/pfblockerng/pfblockerng_Africa.php"
+_ANTARCTICA_GENERATED_PAGE = "/usr/local/www/pfblockerng/pfblockerng_Antarctica.php"
 
 
-def _select_size(body: str, name: str, page: str) -> str:
-    """The ``size`` attribute of the ``<select name="{name}[]">`` on ``page``'s body."""
-    tag = re.search(rf'<select\b[^>]*name="{re.escape(name)}(?:\[\])?"[^>]*>', body)
-    assert tag is not None, f"{page}: no <select> named {name!r} in the rendered body"
-    size = re.search(r'size="(\d+)"', tag.group(0))
-    assert size is not None, f"{page}: the {name!r} select carries no numeric size attribute: {tag.group(0)!r}"
-    return size.group(1)
+def _generated_count(smoke_vm: SmokeVM, page: str, variable: str) -> str:
+    """Return one raw generated count assignment from ``page``."""
+    generated = smoke_vm.ssh("/bin/cat", page, timeout=15)
+    assert generated.returncode == 0, (
+        f"failed to read generated page {page}: rc={generated.returncode} {generated.stderr!r}"
+    )
+    assignment = re.search(rf'^\${re.escape(variable)}\s*=\s*"(\d+)";$', generated.stdout, re.MULTILINE)
+    assert assignment is not None, f"{page}: no numeric ${variable} assignment in generated page"
+    return assignment.group(1)
 
 
 def test_dataless_continent_renders_zero_counts(smoke_vm: SmokeVM, webui: WebUI) -> None:
     """issue #1507: a continent with no country entries renders count 0, not a stale carry.
 
     Scenario:
-      Given the seeded corpus (baseline Antarctica renders a nonzero select size),
+      Given the seeded corpus (baseline Antarctica generates nonzero counts),
         and Antarctica's continent files stripped to their headers (no country
         blocks -- the "MaxMind data gap" producer from the issue),
       When  ``gc`` regenerates the continent pages,
       Then  the Antarctica page still passes the Tier-A oracle and BOTH its
-            country selects render ``size="0"`` -- while Africa (the continent
-            whose counts a stale ``$ftotal4``/``$ftotal6`` carry would have
-            leaked here) renders nonzero sizes in the same run.
+            raw generated country counts equal ``0`` -- while Africa (the
+            continent whose counts a stale ``$ftotal4``/``$ftotal6`` carry would
+            have leaked here) generates nonzero counts in the same run.
     """
     resp = webui.get(_ANTARCTICA_PAGE)
     result = evaluate_render(_ANTARCTICA_PAGE, resp.status_code, resp.text, ("Continent - Antarctica",))
     assert result.ok, f"baseline Antarctica render oracle failed: {result.detail}"
-    baseline_size4 = _select_size(resp.text, "countries4", _ANTARCTICA_PAGE)
-    assert baseline_size4 != "0", (
-        "before-state anchor: seeded Antarctica must render a nonzero IPv4 select size "
-        "(every corpus continent carries at least one entry), else the final size=0 proves nothing"
+    baseline_count4 = _generated_count(smoke_vm, _ANTARCTICA_GENERATED_PAGE, "options_countries4_cnt")
+    baseline_count6 = _generated_count(smoke_vm, _ANTARCTICA_GENERATED_PAGE, "options_countries6_cnt")
+    assert baseline_count4 != "0" and baseline_count6 != "0", (
+        "before-state anchor: seeded Antarctica must generate nonzero IPv4 and IPv6 counts "
+        "(every corpus continent carries entries), else the final zeros prove nothing"
     )
 
     mutated = False
@@ -114,24 +116,24 @@ def test_dataless_continent_renders_zero_counts(smoke_vm: SmokeVM, webui: WebUI)
         africa = webui.get(_AFRICA_PAGE)
         africa_result = evaluate_render(_AFRICA_PAGE, africa.status_code, africa.text, ("Continent - Africa",))
         assert africa_result.ok, f"Africa render oracle failed after the mutated gc: {africa_result.detail}"
-        assert _select_size(africa.text, "countries4", _AFRICA_PAGE) != "0", (
+        assert _generated_count(smoke_vm, _AFRICA_GENERATED_PAGE, "options_countries4_cnt") != "0", (
             "non-vacuity anchor: Africa (the previous continent in $geoip_files order) must render a "
-            "nonzero IPv4 size in this very gc run -- the value a stale $ftotal4 carry would leak into Antarctica"
+            "nonzero IPv4 count in this very gc run -- the value a stale $ftotal4 carry would leak into Antarctica"
         )
-        assert _select_size(africa.text, "countries6", _AFRICA_PAGE) != "0", (
-            "non-vacuity anchor: Africa must render a nonzero IPv6 size in this very gc run -- the value a "
+        assert _generated_count(smoke_vm, _AFRICA_GENERATED_PAGE, "options_countries6_cnt") != "0", (
+            "non-vacuity anchor: Africa must render a nonzero IPv6 count in this very gc run -- the value a "
             "stale $ftotal6 carry would leak into Antarctica"
         )
 
         resp = webui.get(_ANTARCTICA_PAGE)
         result = evaluate_render(_ANTARCTICA_PAGE, resp.status_code, resp.text, ("Continent - Antarctica",))
         assert result.ok, f"data-less Antarctica render oracle failed: {result.detail}"
-        assert _select_size(resp.text, "countries4", _ANTARCTICA_PAGE) == "0", (
-            "issue #1507: a data-less continent's IPv4 select must render size=0, "
+        assert _generated_count(smoke_vm, _ANTARCTICA_GENERATED_PAGE, "options_countries4_cnt") == "0", (
+            "issue #1507: a data-less continent's raw generated IPv4 count must be 0, "
             "not the previous continent's stale $ftotal4"
         )
-        assert _select_size(resp.text, "countries6", _ANTARCTICA_PAGE) == "0", (
-            "issue #1507: a data-less continent's IPv6 select must render size=0, "
+        assert _generated_count(smoke_vm, _ANTARCTICA_GENERATED_PAGE, "options_countries6_cnt") == "0", (
+            "issue #1507: a data-less continent's raw generated IPv6 count must be 0, "
             "not the previous continent's stale $ftotal6"
         )
 
@@ -156,6 +158,11 @@ def test_dataless_continent_renders_zero_counts(smoke_vm: SmokeVM, webui: WebUI)
     # later tests (the PAGE_TABLE sweep, the seeded-csv needles) see the
     # original pages regardless of ordering.
     resp = webui.get(_ANTARCTICA_PAGE)
-    assert _select_size(resp.text, "countries4", _ANTARCTICA_PAGE) == baseline_size4, (
-        "post-restore Antarctica IPv4 select size did not return to its baseline -- the restore/regen did not take"
+    result = evaluate_render(_ANTARCTICA_PAGE, resp.status_code, resp.text, ("Continent - Antarctica",))
+    assert result.ok, f"restored Antarctica render oracle failed: {result.detail}"
+    assert _generated_count(smoke_vm, _ANTARCTICA_GENERATED_PAGE, "options_countries4_cnt") == baseline_count4, (
+        "post-restore Antarctica IPv4 count did not return to its baseline -- the restore/regen did not take"
+    )
+    assert _generated_count(smoke_vm, _ANTARCTICA_GENERATED_PAGE, "options_countries6_cnt") == baseline_count6, (
+        "post-restore Antarctica IPv6 count did not return to its baseline -- the restore/regen did not take"
     )


### PR DESCRIPTION
Fixes #1528.

## Problem

PR #1511 added mandatory Tier-A coverage for the #1507 per-continent count reset, but the live test asserted rendered HTML select size equals 0. pfSense Form_Select normalizes an empty select to its minimum 10 rows, so the assertion observes framework layout rather than the raw generated options_countries4_cnt/options_countries6_cnt values.

This surfaced while refreshing full Tier-A for PR #1523. Exact devel control at 381d3de4 reproduced the same failure on CE 2.8 and Plus 26.03: https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29648803359

## Fix

The one-file test repair:

- reads raw count assignments from the generated Africa and Antarctica PHP pages on the live VM;
- retains authenticated baseline, mutated, and restored page-render checks;
- anchors both IPv4 and IPv6 baseline and previous-continent counts as nonzero;
- asserts both raw Antarctica counts become 0 after header-only data files and gc;
- verifies both restored raw counts return to baseline.

No production code changes.

## Executed proof

Frozen shipping test blob: 0b81e8008c123a75fb751a42c55a0e4b1d892a1a.

Scratch mutation RED, with the #1507 reset removed after baseline capture: https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29649334886

- CE 2.8: exact repaired assertion failed, raw generated IPv4 count 115 instead of 0.
- Plus 26.03: same exact assertion and value.

Unchanged production GREEN: https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29649334085

- CE 2.8: 1 passed, 460 deselected.
- Plus 26.03: 1 passed, 460 deselected.

Canonical local gates:

- python3 -m pytest: PASS
- ruff check .: PASS
- ruff format --check .: PASS
- mypy tests/: PASS

After review, run full CE and Plus Tier-A before merge, then resume PR #1523 on the new devel base.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.