### PR TITLE
pfblockerng: skip config write for missing Permit IP

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1431,6 +1431,7 @@ if (isset($_POST) && !empty($_POST)) {
 					}
 				}
 				else {
+					$pfb_found = FALSE;
 					$savemsg = "IP: [ {$entry} ] was not found in {$type} customlist!";
 				}
 				break;

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -84,6 +84,7 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 				. ' switch (1) { case 1:'
 				. $m[1]
 				. ' }'
+				. ' if ($pfb_found) { write_config("pfBlockerNG: Deleted [ {$entry} ] from {$type} customlist", FALSE); }'
 				. ' return [\'pfb_found\' => $pfb_found, \'savemsg\' => $savemsg]; }'
 			);
 		}
@@ -289,6 +290,20 @@ SH
 	// delete_ipwhitelist
 	// =====================================================================
 
+	public function testDeleteIpWhitelistV4NotFoundSkipsWrite(): void
+	{
+		$clists = ['ipwhitelist4' => ['pfB_Permit_v4' => ['base64_idx' => 0, 'data' => []]]];
+
+		$result = pfb_alerts_oracle_delete_ipwhitelist("'198.51.100.9'", "'pfB_Permit_v4'", $clists);
+
+		$this->assertEmpty(
+			$GLOBALS['pfb_test_write_config_calls'] ?? [],
+			'a missing Permit entry must NOT call write_config()'
+		);
+		$this->assertFalse($result['pfb_found']);
+		$this->assertStringContainsString('not found', $result['savemsg']);
+	}
+
 	public function testDeleteIpWhitelistV4FailureKeepsEntryAndSkipsWrite(): void
 	{
 		$this->scriptFailure('delete', '198.51.100.9');
@@ -319,6 +334,7 @@ SH
 			$this->lastLogRow(),
 			'the delete must reach pfctl as -t pfB_Permit_v4 -T delete 198.51.100.9'
 		);
+		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
 	}
 
 	public function testDeleteIpWhitelistV6FailureKeepsEntryAndSkipsWrite(): void

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -30,6 +30,7 @@ session-scoped VM for the sibling flows -- exercises the reverse branch too.
 from __future__ import annotations
 
 import base64
+import hashlib
 import subprocess
 import time
 from typing import TYPE_CHECKING, Any
@@ -870,17 +871,17 @@ def test_delete_ip_v6_unsuppresses_entry_and_restores_block(
 
 
 # --------------------------------------------------------------------------- #
-# entry_delete=delete_ipwhitelist (alerts.php:1400 -- issue #1505): fail-closed
+# entry_delete=delete_ipwhitelist (alerts.php:1400 -- issues #1505, #1514): fail-closed
 # invariant -- every customlist/config write and the cron `.update` flag gate on
-# the checked pfctl delete outcome; a failed delete must change nothing.
+# a real customlist deletion; a failed or missing delete must change nothing.
 # --------------------------------------------------------------------------- #
 
 
-def test_delete_ipwhitelist_pfctl_failure_keeps_customlist_entry(
+def test_delete_ipwhitelist_noop_paths_skip_config_write(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
 ) -> None:
-    """A failed pfctl delete must not drop the Permit customlist entry (#1505).
+    """Failed and missing Permit deletes must not persist a config change (#1505, #1514).
 
     Scenario: fail-closed store/table consistency for entry_delete=delete_ipwhitelist.
 
@@ -893,7 +894,8 @@ def test_delete_ipwhitelist_pfctl_failure_keeps_customlist_entry(
     Then: (1) the failure savemsg is surfaced, (2) the alias's customlist
     STILL holds the host -- the config write never ran, (3) no
     ``Wl1505_custom_v4.update`` cron flag was touched -- the write-gate never
-    fired.
+    fired, and (4) deleting a different host absent from the customlist leaves
+    the raw config.xml unchanged.
     """
     vm = smoke_vm
     host = "192.0.2.150"  # RFC 5737 TEST-NET-1 -- unused elsewhere in this module
@@ -956,6 +958,15 @@ def test_delete_ipwhitelist_pfctl_failure_keeps_customlist_entry(
             == "YES"
         )
         assert not flag_present, f"{update_flag} unexpectedly exists after a failed delete_ipwhitelist POST"
+
+        # THEN (4): a missing entry is also a no-op -- no write_config revision.
+        missing_host = "192.0.2.151"
+        config_before = hashlib.sha256(helpers.read_log_file(vm, "/conf/config.xml").encode("utf-8")).hexdigest()
+        resp = _post_action(webui, {"entry_delete": "delete_ipwhitelist", "domain": missing_host, "table": table})
+        assert not looks_like_login_page(resp.text), "missing delete_ipwhitelist POST returned the login form"
+        assert "was not found" in resp.text, f"missing-entry savemsg absent from response: {resp.text!r}"
+        config_after = hashlib.sha256(helpers.read_log_file(vm, "/conf/config.xml").encode("utf-8")).hexdigest()
+        assert config_after == config_before, "missing Permit entry unexpectedly created a config.xml revision"
     finally:
         _del_list_row(vm, CFG_IPV4_LISTS, rowid)
         helpers.php_eval(vm, f"@unlink({helpers._php_str(update_flag)}); echo 'OK';")

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -30,7 +30,6 @@ session-scoped VM for the sibling flows -- exercises the reverse branch too.
 from __future__ import annotations
 
 import base64
-import hashlib
 import subprocess
 import time
 from typing import TYPE_CHECKING, Any
@@ -142,6 +141,16 @@ def _ip_unlock_hosts(vm: helpers.SmokeVM) -> dict[str, str]:
         if len(parts) == 2:
             entries[parts[0]] = parts[1]
     return entries
+
+
+def _config_sha256(vm: helpers.SmokeVM) -> str:
+    """Return the guest config.xml byte digest, failing loudly on a bad read."""
+    result = vm.ssh("/sbin/sha256", "-q", "/conf/config.xml")
+    digest = result.stdout.strip()
+    assert result.returncode == 0 and digest, (
+        f"sha256 /conf/config.xml failed: rc={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    return digest
 
 
 # --------------------------------------------------------------------------- #
@@ -961,11 +970,11 @@ def test_delete_ipwhitelist_noop_paths_skip_config_write(
 
         # THEN (4): a missing entry is also a no-op -- no write_config revision.
         missing_host = "192.0.2.151"
-        config_before = hashlib.sha256(helpers.read_log_file(vm, "/conf/config.xml").encode("utf-8")).hexdigest()
+        config_before = _config_sha256(vm)
         resp = _post_action(webui, {"entry_delete": "delete_ipwhitelist", "domain": missing_host, "table": table})
         assert not looks_like_login_page(resp.text), "missing delete_ipwhitelist POST returned the login form"
         assert "was not found" in resp.text, f"missing-entry savemsg absent from response: {resp.text!r}"
-        config_after = hashlib.sha256(helpers.read_log_file(vm, "/conf/config.xml").encode("utf-8")).hexdigest()
+        config_after = _config_sha256(vm)
         assert config_after == config_before, "missing Permit entry unexpectedly created a config.xml revision"
     finally:
         _del_list_row(vm, CFG_IPV4_LISTS, rowid)

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -880,9 +880,8 @@ def test_delete_ip_v6_unsuppresses_entry_and_restores_block(
 
 
 # --------------------------------------------------------------------------- #
-# entry_delete=delete_ipwhitelist (alerts.php:1400 -- issues #1505, #1514): fail-closed
-# invariant -- every customlist/config write and the cron `.update` flag gate on
-# a real customlist deletion; a failed or missing delete must change nothing.
+# entry_delete=delete_ipwhitelist: failed or missing Permit deletes must not
+# mutate persisted state.
 # --------------------------------------------------------------------------- #
 
 
@@ -890,7 +889,7 @@ def test_delete_ipwhitelist_noop_paths_skip_config_write(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
 ) -> None:
-    """Failed and missing Permit deletes must not persist a config change (#1505, #1514).
+    """Failed and missing Permit deletes must not persist a config change.
 
     Scenario: fail-closed store/table consistency for entry_delete=delete_ipwhitelist.
 


### PR DESCRIPTION
## Summary

- Mark a missing Permit custom-list entry as not found before the Alerts page reaches its shared persistence gate.
- Prevent a no-op `delete_ipwhitelist` request from calling `write_config()` and creating a misleading configuration revision.
- Add PHPUnit red/green coverage and a live CE/Plus UI regression that verifies the raw `config.xml` digest remains unchanged.

## Root cause

The Alerts handler initializes `$pfb_found` to `TRUE`. The `delete_ipwhitelist` not-found branch reported the missing entry but did not reset that flag, so the shared post-switch success gate still persisted the unchanged configuration. The sibling `delete_ip` branch already resets the flag.

## Verification

- Frozen PHPUnit regression executed RED before the production edit and GREEN unchanged afterward.
- `scripts/agent/verify-red-proof.sh`: PASS (`FREEZE-OK`, `RED-OK`, `GREEN-OK`).
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS.
- [Final-head required checks](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29658432567): PASS.
- [Final-head CE/Plus Tier-A render](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29658440708): PASS.
- [Final-head CE/Plus Alerts functional regression](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29658440076): PASS.

The live runs use the coordinated FreeBSD-ports registration prepared by #1523 because `pfblockerng_apply.inc` is intentionally staged there until the next source tag and port-version bump.

Fixes #1514

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
