### PR TITLE
pfblockerng: reset continent names per page

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1505,10 +1505,10 @@ function pfblockerng_get_countries() {
 	$log = " Creating pfBlockerNG Continent PHP files\n";
 	pfb_logger("{$log}", 4);
 
-	$continent = $continent_en = '';
 	$roptions4 = array();
 
 	foreach ($geoip_files as $cont => $file) {
+		$continent = $continent_en = '';
 
 		// issue #1507: $ftotal4/$ftotal6 are assigned only when a continent has
 		// data -- reset per continent so a data-less one renders 0, not the

--- a/tests/smoke/ui/test_render_dataless_continent_count.py
+++ b/tests/smoke/ui/test_render_dataless_continent_count.py
@@ -13,13 +13,10 @@ entries inherited the PREVIOUS continent's count. The seeded MaxMind test corpus
 gives every one of the 9 continents at least one entry, so the ``PAGE_TABLE``
 sweep never drives the stays-empty path -- this module manufactures it live.
 
-The data-less continent is manufactured as a header-ONLY continent file
+The #1507 data-less continent is manufactured as a header-ONLY continent file
 (``# Continent IPv{4,6}:`` + ``# Continent en:`` lines kept, all country blocks
-stripped), NOT a missing file: with a missing file ``$continent_en`` carries over
-from the previous continent (a distinct pre-existing defect, out of #1507's
-scope) and the regenerated page would be written to the WRONG path. Header-only
-keeps the page's own name/title correct and isolates exactly the ``$ftotal``
-carry.
+stripped). Issue #1515 covers the distinct missing-file case: the continent
+names must not carry from the previous iteration and redirect that page write.
 
 The authenticated requests still verify that the regenerated pages render
 cleanly. Direct generated-file assertions carry the count regression contract.
@@ -45,6 +42,7 @@ _CC_DIR = "/usr/local/share/GeoIP/cc"
 _ANTARCTICA_V4 = f"{_CC_DIR}/Antarctica_v4.txt"
 _ANTARCTICA_V6 = f"{_CC_DIR}/Antarctica_v6.txt"
 _BAK_SUFFIX = ".pfb1507bak"
+_MISSING_BAK_SUFFIX = ".pfb1515bak"
 
 _AFRICA_PAGE = "/pfblockerng/pfblockerng_Africa.php"
 _ANTARCTICA_PAGE = "/pfblockerng/pfblockerng_Antarctica.php"
@@ -52,15 +50,108 @@ _AFRICA_GENERATED_PAGE = "/usr/local/www/pfblockerng/pfblockerng_Africa.php"
 _ANTARCTICA_GENERATED_PAGE = "/usr/local/www/pfblockerng/pfblockerng_Antarctica.php"
 
 
-def _generated_count(smoke_vm: SmokeVM, page: str, variable: str) -> str:
-    """Return one raw generated count assignment from ``page``."""
+def _generated_page(smoke_vm: SmokeVM, page: str) -> str:
+    """Return one generated continent page."""
     generated = smoke_vm.ssh("/bin/cat", page, timeout=15)
     assert generated.returncode == 0, (
         f"failed to read generated page {page}: rc={generated.returncode} {generated.stderr!r}"
     )
-    assignment = re.search(rf'^\${re.escape(variable)}\s*=\s*"(\d+)";$', generated.stdout, re.MULTILINE)
+    return generated.stdout
+
+
+def _generated_count(smoke_vm: SmokeVM, page: str, variable: str) -> str:
+    """Return one raw generated count assignment from ``page``."""
+    assignment = re.search(rf'^\${re.escape(variable)}\s*=\s*"(\d+)";$', _generated_page(smoke_vm, page), re.MULTILINE)
     assert assignment is not None, f"{page}: no numeric ${variable} assignment in generated page"
     return assignment.group(1)
+
+
+def test_missing_continent_files_do_not_clobber_previous_page(smoke_vm: SmokeVM, webui: WebUI) -> None:
+    """issue #1515: missing continent files cannot redirect a write to the previous page.
+
+    Scenario:
+      Given Africa and Antarctica have valid generated pages,
+        and both Antarctica continent files become unavailable,
+      When  ``gc`` regenerates the continent pages,
+      Then  Africa's page remains byte-identical instead of receiving
+            Antarctica's empty render, and Antarctica's existing page remains
+            available until its source files return.
+    """
+    africa_before = _generated_page(smoke_vm, _AFRICA_GENERATED_PAGE)
+    antarctica_before = _generated_page(smoke_vm, _ANTARCTICA_GENERATED_PAGE)
+    assert _generated_count(smoke_vm, _AFRICA_GENERATED_PAGE, "options_countries4_cnt") != "0", (
+        "before-state anchor: seeded Africa must have IPv4 options, else an empty-render clobber is invisible"
+    )
+
+    mutated = False
+    try:
+        backup = smoke_vm.ssh(
+            f"cp -p {_ANTARCTICA_V4} {_ANTARCTICA_V4}{_MISSING_BAK_SUFFIX}"
+            f" && cp -p {_ANTARCTICA_V6} {_ANTARCTICA_V6}{_MISSING_BAK_SUFFIX}"
+        )
+        assert backup.returncode == 0, (
+            f"failed to back up Antarctica cc files: rc={backup.returncode} {backup.stderr!r}"
+        )
+        mutated = True
+
+        remove = smoke_vm.ssh(f"rm -f {_ANTARCTICA_V4} {_ANTARCTICA_V6}")
+        assert remove.returncode == 0, f"failed to remove Antarctica cc files: rc={remove.returncode} {remove.stderr!r}"
+
+        gc = smoke_vm.ssh(helpers.PHP_BIN, helpers.PFB_CLI, "gc", timeout=600)
+        assert gc.returncode == 0, f"gc with missing Antarctica failed: rc={gc.returncode} {gc.stderr!r} {gc.stdout!r}"
+
+        guard = PhpErrorLogGuard(smoke_vm)
+        guard.snapshot()
+
+        africa = webui.get(_AFRICA_PAGE)
+        africa_result = evaluate_render(_AFRICA_PAGE, africa.status_code, africa.text, ("Continent - Africa",))
+        assert africa_result.ok, f"Africa render oracle failed after missing-file gc: {africa_result.detail}"
+        africa_after = _generated_page(smoke_vm, _AFRICA_GENERATED_PAGE)
+        assert africa_after == africa_before, (
+            "issue #1515: missing Antarctica files clobbered Africa's generated page; "
+            f"expected {len(africa_before)} bytes, got {len(africa_after)} bytes"
+        )
+
+        antarctica = webui.get(_ANTARCTICA_PAGE)
+        antarctica_result = evaluate_render(
+            _ANTARCTICA_PAGE, antarctica.status_code, antarctica.text, ("Continent - Antarctica",)
+        )
+        assert antarctica_result.ok, (
+            f"Antarctica render oracle failed after missing-file gc: {antarctica_result.detail}"
+        )
+        antarctica_after = _generated_page(smoke_vm, _ANTARCTICA_GENERATED_PAGE)
+        assert antarctica_after == antarctica_before, (
+            "issue #1515: missing Antarctica files must leave its existing page untouched; "
+            f"expected {len(antarctica_before)} bytes, got {len(antarctica_after)} bytes"
+        )
+
+        guard.assert_no_growth()
+    finally:
+        if mutated:
+            restore = smoke_vm.ssh(
+                f"mv {_ANTARCTICA_V4}{_MISSING_BAK_SUFFIX} {_ANTARCTICA_V4}"
+                f" && mv {_ANTARCTICA_V6}{_MISSING_BAK_SUFFIX} {_ANTARCTICA_V6}"
+            )
+            if restore.returncode != 0:
+                raise AssertionError(
+                    f"failed to restore Antarctica cc files: rc={restore.returncode} {restore.stderr!r}"
+                )
+            regen = smoke_vm.ssh(helpers.PHP_BIN, helpers.PFB_CLI, "gc", timeout=600)
+            if regen.returncode != 0:
+                raise AssertionError(
+                    f"gc after restore failed: rc={regen.returncode} {regen.stderr!r} {regen.stdout!r}"
+                )
+
+    africa_restored = _generated_page(smoke_vm, _AFRICA_GENERATED_PAGE)
+    antarctica_restored = _generated_page(smoke_vm, _ANTARCTICA_GENERATED_PAGE)
+    assert africa_restored == africa_before, (
+        "post-restore Africa page did not return to baseline; "
+        f"expected {len(africa_before)} bytes, got {len(africa_restored)} bytes"
+    )
+    assert antarctica_restored == antarctica_before, (
+        "post-restore Antarctica page did not return to baseline; "
+        f"expected {len(antarctica_before)} bytes, got {len(antarctica_restored)} bytes"
+    )
 
 
 def test_dataless_continent_renders_zero_counts(smoke_vm: SmokeVM, webui: WebUI) -> None:


### PR DESCRIPTION
## Summary

- Reset `$continent` and `$continent_en` at the start of each continent iteration.
- Preserve an existing continent page when that continent's source files are missing, instead of overwriting the previous continent's page.
- Add Tier-A live-VM coverage for the missing-file producer and byte-identity of both generated pages.

## Root cause

`pfblockerng_get_countries()` initialized both page-identity variables once before the outer continent loop. A missing or unreadable continent file therefore retained the previous iteration's names, and the existing validated write used that stale `$continent_en` as its output path.

## Validation

- Frozen regression-test hash: `79103e45767eb5d0f45b5be6f60856fa5907c46f`
- RED: `scripts/local-smoke.sh --marker ui_render --filter test_missing_continent_files_do_not_clobber_previous_page` — `1 failed, 461 deselected`; Africa changed from 31,252 to 23,955 bytes.
- GREEN, unchanged test: same command — `1 passed, 461 deselected`.
- `scripts/agent/run-gates.sh --diff origin/devel` — `GATES: PASS` (pytest, Ruff, format, mypy, PHPUnit, PHPStan, PHPCS, PHP syntax).
- The live package used the coordinated FreeBSD-ports registration commit `ad074be09` prepared for PR #1523; the temporary local harness override was removed from this branch before review.

Fixes #1515

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
