### PR TITLE
DNSBL manifest: enforce the executable v1 contract

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5258,18 +5258,61 @@ class _DnsblGenerationError(Exception):
 
 
 def _dnsbl_validate_manifest_raws(manifest: dict[str, Any], base_dir: str) -> None:
-    if "feeds" not in manifest or not isinstance(manifest["feeds"], list):
-        raise _DnsblGenerationError("DNSBL manifest feeds is not a list")
-    feeds = manifest["feeds"]
-    for feed in feeds:
-        if not isinstance(feed, dict) or not isinstance(feed.get("raw"), str) or not feed["raw"]:
-            raise _DnsblGenerationError("DNSBL manifest feed has no valid raw reference")
+    if not isinstance(manifest, dict):
+        raise _DnsblGenerationError("DNSBL manifest/v1 root must be an object")
+    if type(manifest.get("version")) is not int or manifest["version"] != 1:
+        raise _DnsblGenerationError("DNSBL manifest/v1 version must be integer 1")
+
+    config = manifest.get("config")
+    if not isinstance(config, dict):
+        raise _DnsblGenerationError("DNSBL manifest/v1 config must be an object")
+    list_fields = (
+        "tld_wildcard_blacklist",
+        "tld_wildcard_exclusion",
+        "user_whitelist",
+        "user_unlock",
+        "top1m_list",
+    )
+    for config_field in list_fields:
+        value = config.get(config_field)
+        if config_field in config and (not isinstance(value, list) or any(not isinstance(item, str) for item in value)):
+            raise _DnsblGenerationError("DNSBL manifest/v1 config.{} must be list[str]".format(config_field))
+    for flag_field in ("top1m_enabled", "regex_cap"):
+        if flag_field in config and not isinstance(config[flag_field], bool):
+            raise _DnsblGenerationError("DNSBL manifest/v1 config.{} must be bool".format(flag_field))
+
+    feeds = manifest.get("feeds")
+    if not isinstance(feeds, list):
+        raise _DnsblGenerationError("DNSBL manifest/v1 feeds must be a list")
+    required_fields = ("raw", "feed", "group", "log_flag")
+    for index, feed in enumerate(feeds):
+        prefix = "DNSBL manifest/v1 feeds[{}]".format(index)
+        if not isinstance(feed, dict):
+            raise _DnsblGenerationError("{} must be an object".format(prefix))
+        for row_field in required_fields:
+            if row_field not in feed or not isinstance(feed[row_field], str):
+                raise _DnsblGenerationError("{}.{} must be a string".format(prefix, row_field))
+        for row_field in ("raw", "feed"):
+            if not feed[row_field]:
+                raise _DnsblGenerationError("{}.{} must be a non-empty string".format(prefix, row_field))
+        if "provenance" in feed and (
+            not isinstance(feed["provenance"], str) or feed["provenance"] not in {"feed", "user"}
+        ):
+            raise _DnsblGenerationError("{}.provenance must be feed or user".format(prefix))
+        if "mode" in feed and (not isinstance(feed["mode"], str) or feed["mode"] not in {"deny", "permit"}):
+            raise _DnsblGenerationError("{}.mode must be deny or permit".format(prefix))
+
+    for index, feed in enumerate(feeds):
         raw = feed["raw"]
         path = raw if os.path.isabs(raw) else os.path.join(base_dir, raw)
         if not _dnsbl_path_within_base(path, base_dir):
-            raise _DnsblGenerationError("DNSBL feed escapes manifest base: '{}'".format(path))
+            raise _DnsblGenerationError(
+                "DNSBL manifest/v1 feeds[{}].raw resolves outside manifest base: '{}'".format(index, path)
+            )
         if not os.path.isfile(path):
-            raise _DnsblGenerationError("DNSBL feed is missing or not a regular file: '{}'".format(path))
+            raise _DnsblGenerationError(
+                "DNSBL manifest/v1 feeds[{}].raw is missing or not a regular file: '{}'".format(index, path)
+            )
 
 
 def _dnsbl_file_line_reader(base_dir: str, *, fail_closed: bool = False) -> Callable[[str], Iterable[str]]:
@@ -5388,12 +5431,10 @@ def dnsbl_build_from_manifest(manifest_path: str) -> BuildResult | None:
 
     try:
         if not isinstance(manifest, dict):
-            raise _DnsblGenerationError("DNSBL manifest root is not an object")
+            raise _DnsblGenerationError("DNSBL manifest/v1 root must be an object")
         base_dir = os.path.dirname(os.path.abspath(manifest_path))
-        if "config" not in manifest or not isinstance(manifest["config"], dict):
-            raise _DnsblGenerationError("DNSBL manifest config is not an object")
-        manifest_config = manifest["config"]
         _dnsbl_validate_manifest_raws(manifest, base_dir)
+        manifest_config = manifest["config"]
         config = _dnsbl_config_from_manifest(manifest, base_dir)
         top1m_enabled = bool(manifest_config.get("top1m_enabled", False))
         result = build(

--- a/tests/fixtures/dnsbl_corpus/manifest-v1.json
+++ b/tests/fixtures/dnsbl_corpus/manifest-v1.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "config": {
+    "tld_wildcard_blacklist": [
+      "zip"
+    ],
+    "tld_wildcard_exclusion": [
+      "excluded.com"
+    ],
+    "user_whitelist": [
+      "www.adblock.com",
+      ".wildwhite.org",
+      "phishing.net"
+    ],
+    "user_unlock": [],
+    "top1m_list": [
+      "popularcdn.com"
+    ],
+    "top1m_enabled": true
+  },
+  "feeds": [
+    {"raw": "raw/plain_hosts.raw", "feed": "plain_hosts", "group": "grp_plain", "provenance": "feed", "log_flag": "1"},
+    {"raw": "raw/csv_pt.raw", "feed": "csv_pt", "group": "grp_csv", "provenance": "feed", "log_flag": "1"},
+    {"raw": "raw/csv_bbc.raw", "feed": "csv_bbc", "group": "grp_csv", "provenance": "feed", "log_flag": "1"},
+    {"raw": "raw/csv_h3x.raw", "feed": "csv_h3x", "group": "grp_csv", "provenance": "feed", "log_flag": "1"},
+    {"raw": "raw/csv_otx.raw", "feed": "csv_otx", "group": "grp_csv", "provenance": "feed", "log_flag": "1"},
+    {"raw": "raw/csv_pon.raw", "feed": "csv_pon", "group": "grp_csv", "provenance": "feed", "log_flag": "1"},
+    {"raw": "raw/csv_et.raw", "feed": "csv_et", "group": "grp_csv", "provenance": "feed", "log_flag": "1"},
+    {"raw": "raw/custom_list.raw", "feed": "custom_list", "group": "grp_custom", "provenance": "user", "log_flag": "1"},
+    {"raw": "raw/abp_feed.raw", "feed": "abp_feed", "group": "�", "provenance": "feed", "log_flag": "1"},
+    {"raw": "raw/mixed_plain.raw", "feed": "mixed_plain", "group": "grp_mixed", "provenance": "feed", "log_flag": "1"},
+    {"raw": "raw/permit_feed.raw", "feed": "permit_feed", "group": "grp_permit", "provenance": "feed", "log_flag": "1", "mode": "permit"},
+    {"raw": "raw/oversized_feed.raw", "feed": "oversized_feed", "group": "grp_edge", "provenance": "feed", "log_flag": "1"},
+    {"raw": "raw/wirecap_feed.raw", "feed": "wirecap_feed", "group": "grp_edge", "provenance": "feed", "log_flag": "1"},
+    {"raw": "raw/reused_manifest_abp.raw", "feed": "reused_manifest_abp", "group": "grp_reuse", "provenance": "feed", "log_flag": "1"}
+  ]
+}

--- a/tests/php/Adr62DnsblCorpusManifestTest.php
+++ b/tests/php/Adr62DnsblCorpusManifestTest.php
@@ -57,15 +57,17 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 			'dnsdir'             => "{$this->tmp}/dnsbl",
 			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
 			'dbdir'              => "{$this->tmp}/db",
-			'dnsbl_top1m'        => 'off',
+			'dnsbl_top1m'        => 'on',
+			'dnsbl_tld_wildcard' => 'on',
 			'dnsbl_tld_data'     => "{$this->tmp}/does_not_exist",
 			'dnsbl_unlock'       => "{$this->tmp}/dnsbl_unlock",
 			'dnsblconfig'        => [
-				'tldblacklist' => '',
-				'tldexclusion' => '',
-				'suppression'  => '',
+				'tldblacklist' => base64_encode("zip"),
+				'tldexclusion' => base64_encode("excluded.com"),
+				'suppression'  => base64_encode("www.adblock.com\r\n.wildwhite.org\r\nphishing.net"),
 			],
 		]);
+		file_put_contents("{$this->tmp}/db/pfbalexawhitelist.txt", "popularcdn.com\n");
 
 		$json = file_get_contents(self::CORPUS_DIR . '/feeds.json');
 		$this->assertNotFalse($json, 'corpus feeds.json must be readable');
@@ -97,6 +99,9 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 			];
 			if (isset($f['mode'])) {
 				$row['mode'] = $f['mode'];
+			}
+			if ($f['header'] === 'abp_feed') {
+				$row['group'] = "\xFF";
 			}
 			$rows[] = $row;
 		}
@@ -151,6 +156,47 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 				$this->assertArrayNotHasKey('mode', $row, "unexpected mode key for [ {$f['header']} ]");
 			}
 		}
+	}
+
+	/** The real PHP writer publishes the checked-in v1 fixture shape and raw bytes. */
+	public function testPublishedManifestMatchesV1Fixture(): void
+	{
+		$fixturePath = self::CORPUS_DIR . '/manifest-v1.json';
+		$fixtureJson = file_get_contents($fixturePath);
+		$this->assertNotFalse($fixtureJson, 'manifest-v1 fixture must be readable');
+		$fixture = json_decode($fixtureJson, TRUE);
+		$this->assertIsArray($fixture, 'manifest-v1 fixture must decode');
+
+		$published = pfb_unbound_python_sources($this->feedRows());
+		$this->assertIsArray($published);
+		$publishedJson = file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
+		$this->assertNotFalse($publishedJson, 'published manifest must be readable');
+		$publishedDecoded = json_decode($publishedJson, TRUE);
+		$this->assertIsArray($publishedDecoded, 'published manifest must decode');
+		$normalized = $publishedDecoded;
+		foreach ($normalized['feeds'] as &$row) {
+			$row['raw'] = 'raw/' . basename($row['raw']);
+		}
+		unset($row);
+		$this->assertSame($fixture, $normalized);
+
+		foreach ($fixture['feeds'] as $expected) {
+			$actual = null;
+			foreach ($publishedDecoded['feeds'] as $row) {
+				if ($row['feed'] === $expected['feed']) {
+					$actual = $row;
+					break;
+				}
+			}
+			$this->assertIsArray($actual, "fixture feed [ {$expected['feed']} ] must be published");
+			$rawPath = dirname($GLOBALS['pfb']['unbound_py_sources']) . '/' . $actual['raw'];
+			$this->assertSame(
+				file_get_contents(self::CORPUS_DIR . '/' . $expected['raw']),
+				file_get_contents($rawPath),
+				"published raw bytes drifted for [ {$expected['feed']} ]"
+			);
+		}
+		$this->assertSame("\u{FFFD}", $normalized['feeds'][8]['group']);
 	}
 
 	// --- #752/#753 divergence: the PHP-side half (pfb_filter is a pure, --

--- a/tests/test_dnsbl_manifest_v1_contract.py
+++ b/tests/test_dnsbl_manifest_v1_contract.py
@@ -63,7 +63,9 @@ def test_fixture_manifest_v1_builds_and_config_affects_result(tmp_path: Path) ->
     assert result.white_db["adblock.com"]["wildcard"] is False
     assert result.white_db["wildwhite.org"]["wildcard"] is True
     assert result.white_db["allowme.example"]["band"] == pfb_unbound.PRIO_FEED_ALLOW
-    assert {entry["group"] for entry in result.feed_group_index_db.values()} >= {
+    observed_groups = {entry["group"] for entry in result.feed_group_index_db.values()}
+    assert "\ufffd" in observed_groups
+    assert observed_groups >= {
         "grp_custom",
         "grp_permit",
     }
@@ -94,6 +96,20 @@ def test_empty_feeds_are_valid(tmp_path: Path) -> None:
     assert result.zone_db == {}
 
 
+def test_empty_group_and_log_flag_are_valid(tmp_path: Path) -> None:
+    path, manifest = _stage_fixture(tmp_path)
+    manifest["feeds"] = [dict(manifest["feeds"][0])]
+    manifest["feeds"][0]["group"] = ""
+    manifest["feeds"][0]["log_flag"] = ""
+    _write_manifest(path, manifest)
+
+    result = pfb_unbound.dnsbl_build_from_manifest(str(path))
+
+    assert result is not None
+    assert {entry["group"] for entry in result.feed_group_index_db.values()} >= {""}
+    assert result.data_db["plainhost1.example"]["log"] == ""
+
+
 @pytest.mark.parametrize(
     ("mutate", "field"),
     [
@@ -116,9 +132,11 @@ def test_empty_feeds_are_valid(tmp_path: Path) -> None:
         (lambda m: m["feeds"].__setitem__(0, "row"), "feeds[0]"),
         (lambda m: m["feeds"][0].pop("raw"), "feeds[0].raw"),
         (lambda m: m["feeds"][0].__setitem__("raw", ""), "feeds[0].raw"),
+        (lambda m: m["feeds"][0].pop("feed"), "feeds[0].feed"),
         (lambda m: m["feeds"][0].__setitem__("feed", 1), "feeds[0].feed"),
         (lambda m: m["feeds"][0].__setitem__("feed", ""), "feeds[0].feed"),
         (lambda m: m["feeds"][0].pop("group"), "feeds[0].group"),
+        (lambda m: m["feeds"][0].pop("log_flag"), "feeds[0].log_flag"),
         (lambda m: m["feeds"][0].__setitem__("log_flag", False), "feeds[0].log_flag"),
         (lambda m: m["feeds"][0].__setitem__("provenance", "other"), "feeds[0].provenance"),
         (lambda m: m["feeds"][0].__setitem__("provenance", []), "feeds[0].provenance"),

--- a/tests/test_dnsbl_manifest_v1_contract.py
+++ b/tests/test_dnsbl_manifest_v1_contract.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pfb_unbound
+
+CORPUS = Path(__file__).parent / "fixtures" / "dnsbl_corpus"
+FIXTURE = CORPUS / "manifest-v1.json"
+
+
+def _stage_fixture(tmp_path: Path) -> tuple[Path, dict[str, Any]]:
+    with FIXTURE.open(encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    for row in manifest["feeds"]:
+        relative = Path(row["raw"])
+        destination = tmp_path / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(CORPUS / relative, destination)
+    path = tmp_path / "pfb_py_sources.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    return path, manifest
+
+
+def _write_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def _ledger_path(path: Path) -> Path:
+    ledger = path.parent / "status.json"
+    pfb_unbound.pfb["pfb_py_status"] = str(ledger)
+    return ledger
+
+
+def _assert_rejected_before_build(
+    path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    expected_field: str,
+    ledger: Path,
+) -> None:
+    def fail_build(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("manifest contract reached build()")
+
+    monkeypatch.setattr(pfb_unbound, "build", fail_build)
+    assert pfb_unbound.dnsbl_build_from_manifest(str(path)) is None
+    entries = json.loads(ledger.read_text(encoding="utf-8"))
+    assert entries and expected_field in entries[-1]["message"]
+
+
+def test_fixture_manifest_v1_builds_and_config_affects_result(tmp_path: Path) -> None:
+    path, _ = _stage_fixture(tmp_path)
+
+    result = pfb_unbound.dnsbl_build_from_manifest(str(path))
+
+    assert result is not None
+    assert result.zone_db["zip"]["index"] >= 0
+    assert result.white_db["popularcdn.com"]["important"] is True
+    assert result.white_db["adblock.com"]["wildcard"] is False
+    assert result.white_db["wildwhite.org"]["wildcard"] is True
+    assert result.white_db["allowme.example"]["band"] == pfb_unbound.PRIO_FEED_ALLOW
+    assert {entry["group"] for entry in result.feed_group_index_db.values()} >= {
+        "grp_custom",
+        "grp_permit",
+    }
+
+
+def test_in_base_absolute_raw_path_is_preserved(tmp_path: Path) -> None:
+    path, manifest = _stage_fixture(tmp_path)
+    manifest["feeds"] = [dict(manifest["feeds"][0])]
+    manifest["feeds"][0]["raw"] = str(tmp_path / "raw" / "plain_hosts.raw")
+    _write_manifest(path, manifest)
+
+    result = pfb_unbound.dnsbl_build_from_manifest(str(path))
+
+    assert result is not None
+    assert result.counts > 0
+
+
+def test_empty_feeds_are_valid(tmp_path: Path) -> None:
+    path, manifest = _stage_fixture(tmp_path)
+    manifest["feeds"] = []
+    manifest["config"] = {}
+    _write_manifest(path, manifest)
+
+    result = pfb_unbound.dnsbl_build_from_manifest(str(path))
+
+    assert result is not None
+    assert result.data_db == {}
+    assert result.zone_db == {}
+
+
+@pytest.mark.parametrize(
+    ("mutate", "field"),
+    [
+        (lambda m: m.pop("version"), "version"),
+        (lambda m: m.__setitem__("version", 2), "version"),
+        (lambda m: m.__setitem__("version", "1"), "version"),
+        (lambda m: m.__setitem__("version", True), "version"),
+        (lambda m: m.__setitem__("version", None), "version"),
+        (lambda m: m.pop("config"), "config"),
+        (lambda m: m.__setitem__("config", []), "config"),
+        (lambda m: m["config"].__setitem__("tld_wildcard_blacklist", "zip"), "config.tld_wildcard_blacklist"),
+        (
+            lambda m: m["config"].__setitem__("user_whitelist", ["ok.example", 1]),
+            "config.user_whitelist",
+        ),
+        (lambda m: m["config"].__setitem__("top1m_enabled", 1), "config.top1m_enabled"),
+        (lambda m: m["config"].__setitem__("regex_cap", "on"), "config.regex_cap"),
+        (lambda m: m.pop("feeds"), "feeds"),
+        (lambda m: m.__setitem__("feeds", {}), "feeds"),
+        (lambda m: m["feeds"].__setitem__(0, "row"), "feeds[0]"),
+        (lambda m: m["feeds"][0].pop("raw"), "feeds[0].raw"),
+        (lambda m: m["feeds"][0].__setitem__("raw", ""), "feeds[0].raw"),
+        (lambda m: m["feeds"][0].__setitem__("feed", 1), "feeds[0].feed"),
+        (lambda m: m["feeds"][0].__setitem__("feed", ""), "feeds[0].feed"),
+        (lambda m: m["feeds"][0].pop("group"), "feeds[0].group"),
+        (lambda m: m["feeds"][0].__setitem__("log_flag", False), "feeds[0].log_flag"),
+        (lambda m: m["feeds"][0].__setitem__("provenance", "other"), "feeds[0].provenance"),
+        (lambda m: m["feeds"][0].__setitem__("provenance", []), "feeds[0].provenance"),
+        (lambda m: m["feeds"][0].__setitem__("mode", "other"), "feeds[0].mode"),
+        (lambda m: m["feeds"][0].__setitem__("mode", {}), "feeds[0].mode"),
+    ],
+)
+def test_invalid_v1_shape_is_rejected_before_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutate: Callable[[dict[str, Any]], Any],
+    field: str,
+) -> None:
+    path, manifest = _stage_fixture(tmp_path)
+    mutate(manifest)
+    _write_manifest(path, manifest)
+    ledger = _ledger_path(path)
+
+    _assert_rejected_before_build(path, monkeypatch, field, ledger)
+
+
+def test_known_shapes_are_checked_before_raw_io(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path, manifest = _stage_fixture(tmp_path)
+    manifest["feeds"][0]["raw"] = "missing.raw"
+    manifest["feeds"][0]["log_flag"] = 1
+    _write_manifest(path, manifest)
+    ledger = _ledger_path(path)
+
+    def fail_path_check(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("raw I/O started before contract validation")
+
+    monkeypatch.setattr(pfb_unbound, "_dnsbl_path_within_base", fail_path_check)
+    _assert_rejected_before_build(path, monkeypatch, "feeds[0].log_flag", ledger)
+
+
+def test_unknown_additive_root_config_and_feed_keys_are_accepted(tmp_path: Path) -> None:
+    path, manifest = _stage_fixture(tmp_path)
+    manifest["future_root"] = {"enabled": True}
+    manifest["config"]["future_config"] = {"value": 7}
+    manifest["feeds"][0]["future_feed"] = ["kept additive"]
+    _write_manifest(path, manifest)
+
+    result = pfb_unbound.dnsbl_build_from_manifest(str(path))
+
+    assert result is not None
+
+
+def test_non_object_root_is_rejected_before_build(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "pfb_py_sources.json"
+    path.write_text("[]", encoding="utf-8")
+    ledger = _ledger_path(path)
+    _assert_rejected_before_build(path, monkeypatch, "root", ledger)


### PR DESCRIPTION
## Summary

- Enforce the executable DNSBL manifest v1 contract at the existing Python loader seam before raw-file I/O or build work.
- Check the real PHP writer against one committed manifest fixture, then consume that same fixture through the real Python loader.
- Preserve version-1 additive compatibility, optional-field defaults, provenance, permit mode, raw-path confinement, and INI-owned `regex_cap` behavior.

## Verification

- Test-first proof: final frozen contract suite failed on the pre-fix source (`21 failed, 9 passed`) and passed unchanged after the fix (`30 passed`).
- Freeze hashes: `ba2ea6151bad1d14af7ff472285d67607112f636` (test) and `36922da591f2f677fa8b2afa732f2b9ba3af31ba` (fixture).
- `scripts/agent/verify-red-proof.sh ... --base-ref 708af7fd...` → `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`.
- `env GIT_CONFIG_GLOBAL=/dev/null scripts/agent/run-gates.sh --diff origin/devel` → all Python and PHP gates passed, including full pytest and PHPUnit.
- Independent per-step gate: PASS; all four changed files, hostile-input rows, test honesty, and both production callers verified.

## Risk

Valid v1 manifests retain existing behavior. Malformed or unsupported manifests fail closed at the contract seam and retain the existing parse-ledger signal. No production PHP code or dependency changed.

Fixes #1402

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict validation for DNSBL manifest version 1 files.
  * Validates configuration values, feed definitions, flags, supported modes, and referenced files before processing.
  * Supports valid empty manifests and preserves valid absolute feed paths.
  * Reports invalid manifest data early with clear generation errors.

* **Tests**
  * Added coverage for valid manifests, configuration effects, feed handling, and invalid input rejection.
  * Added a published manifest fixture for output and feed-content verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->