### PR TITLE
pfblockerng: extract sync run plan

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
                  warning per test, and warnings fail the run). Coverage itself stays
                  informational for now (no enforced floor — see issue #39 / #38). -->
             <file>src/usr/local/pkg/pfblockerng/pfblockerng.inc</file>
+            <file>src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc</file>
             <file>src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc</file>
             <file>src/usr/local/www/pfblockerng/pfblockerng_alerts.php</file>
             <file>src/usr/local/www/pfblockerng/pfblockerng_log.php</file>

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -20,6 +20,41 @@
  * limitations under the License.
  */
 
+/** @return array{reuse:string,reuse_dnsbl:string,updatednsbl:bool,save:bool,clear_masterfiles:bool} */
+function pfb_sync_run_plan(array $request, bool $no_updates, bool $cron_tick, string $configured_reuse): array {
+	$plan = [
+		'reuse'             => $configured_reuse,
+		'reuse_dnsbl'       => '',
+		'updatednsbl'       => FALSE,
+		'save'              => $no_updates,
+		'clear_masterfiles' => FALSE,
+	];
+	if ($no_updates) {
+		return $plan;
+	}
+
+	$scope = $request['scope'] ?? '';
+	$force = !empty($request['force']);
+	if ($scope === 'both' && $force) {
+		$plan['reuse']             = 'on';
+		$plan['reuse_dnsbl']       = 'on';
+		$plan['updatednsbl']       = TRUE;
+		$plan['clear_masterfiles'] = TRUE;
+	} elseif ($scope === 'ip' && $force) {
+		$plan['reuse']             = 'on';
+		$plan['clear_masterfiles'] = TRUE;
+	} elseif ($scope === 'dnsbl' && $force) {
+		$plan['reuse']       = '';
+		$plan['reuse_dnsbl'] = 'on';
+		$plan['updatednsbl'] = TRUE;
+	} elseif ($cron_tick && $configured_reuse === 'on') {
+		$plan['reuse_dnsbl']       = 'on';
+		$plan['clear_masterfiles'] = TRUE;
+	}
+
+	return $plan;
+}
+
 // Main pfBlockerNG function
 function sync_package_pfblockerng($cron='') {
 	global $g, $pfb, $pfbarr;
@@ -145,43 +180,24 @@ function sync_package_pfblockerng($cron='') {
 	// 'pre' hook => pfb_run_hooks() returns immediately (byte-identical pass).
 	pfb_run_hooks('pre', array('TRIGGER' => $pfb_hook_val));
 
-	// Reloads existing lists without downloading new lists when defined 'on'
-	$pfb['reuse'] = $pfb['config']['pfb_reuse'];
-	$pfb['reuse_dnsbl'] = '';
-
-	// Define update process (update or reload)
-	if ($pfb_is_noups) {
-		// Cron pass with no feed changes: save the configuration; nothing to reload.
+	$pfb_run_plan = pfb_sync_run_plan(
+		$pfb_req,
+		$pfb_is_noups,
+		$pfb_cron_tick,
+		(string) $pfb['config']['pfb_reuse']
+	);
+	$pfb['reuse']       = $pfb_run_plan['reuse'];
+	$pfb['reuse_dnsbl'] = $pfb_run_plan['reuse_dnsbl'];
+	if ($pfb_run_plan['save']) {
 		$pfb['save'] = TRUE;
-	} elseif ($pfb_req['scope'] === 'both' && $pfb_req['force']) {
-		// Force Reload BOTH (Update page Run-now with force on, and the wizard reload):
-		// apply IP tables AND DNSBL from cached lists, no re-download — the union of the
-		// scope=ip and scope=dnsbl force branches. Without this, scope=both + force fell
-		// through with no adjustment (identical to force=false), so the most prominent
-		// "Force" control did nothing beyond a plain detector-respecting pass.
-		$pfb['reuse']        = 'on';
-		$pfb['reuse_dnsbl']  = 'on';
-		$pfb['updatednsbl']  = TRUE;
-		unlink_if_exists("{$pfb['dbdir']}/masterfile");
-		unlink_if_exists("{$pfb['dbdir']}/mastercat");
-	} elseif ($pfb_req['scope'] === 'ip' && $pfb_req['force']) {
-		// updateip: Force Reload IP — apply IP tables from cached lists, no re-download.
-		$pfb['reuse']       = 'on';
-		$pfb['reuse_dnsbl'] = '';
-		unlink_if_exists("{$pfb['dbdir']}/masterfile");
-		unlink_if_exists("{$pfb['dbdir']}/mastercat");
-	} elseif ($pfb_req['scope'] === 'dnsbl' && $pfb_req['force']) {
-		// updatednsbl: Force Reload DNSBL — apply from cached data, always reload Unbound.
-		$pfb['reuse']        = '';
-		$pfb['reuse_dnsbl']  = 'on';
-		$pfb['updatednsbl']  = TRUE;
-	} elseif ($pfb_cron_tick && $pfb['reuse'] == 'on') {
-		// Scheduled cron tick with global Reload toggle on: propagate reuse to DNSBL side.
-		$pfb['reuse_dnsbl'] = 'on';
+	}
+	if ($pfb_run_plan['updatednsbl']) {
+		$pfb['updatednsbl'] = TRUE;
+	}
+	if ($pfb_run_plan['clear_masterfiles']) {
 		unlink_if_exists("{$pfb['dbdir']}/masterfile");
 		unlink_if_exists("{$pfb['dbdir']}/mastercat");
 	}
-	// manual / '' (settings save / de-install) and any other non-cron path: no scope adjustment.
 
 	// Start of pfBlockerNG logging to 'pfblockerng.log'
 	if ($pfb['enable'] == 'on' && !$pfb['save']) {

--- a/tests/php/SyncRunPlanTest.php
+++ b/tests/php/SyncRunPlanTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversFunction('pfb_sync_run_plan')]
+final class SyncRunPlanTest extends TestCase
+{
+	public static function planProvider(): iterable
+	{
+		$off = [
+			'reuse' => '', 'reuse_dnsbl' => '', 'updatednsbl' => FALSE,
+			'save' => FALSE, 'clear_masterfiles' => FALSE,
+		];
+		$on = [
+			'reuse' => 'on', 'reuse_dnsbl' => '', 'updatednsbl' => FALSE,
+			'save' => FALSE, 'clear_masterfiles' => FALSE,
+		];
+
+		yield 'no updates outranks force' => [
+			['scope' => 'both', 'force' => TRUE], TRUE, FALSE, '',
+			array_replace($off, ['save' => TRUE]),
+		];
+		yield 'force both domains' => [
+			['scope' => 'both', 'force' => TRUE], FALSE, FALSE, '',
+			[
+				'reuse' => 'on', 'reuse_dnsbl' => 'on', 'updatednsbl' => TRUE,
+				'save' => FALSE, 'clear_masterfiles' => TRUE,
+			],
+		];
+		yield 'force IP only' => [
+			['scope' => 'ip', 'force' => TRUE], FALSE, FALSE, '',
+			array_replace($off, ['reuse' => 'on', 'clear_masterfiles' => TRUE]),
+		];
+		yield 'force DNSBL only' => [
+			['scope' => 'dnsbl', 'force' => TRUE], FALSE, FALSE, 'on',
+			array_replace($off, ['reuse_dnsbl' => 'on', 'updatednsbl' => TRUE]),
+		];
+		yield 'legacy update cron tick reuses DNSBL' => [
+			['scope' => 'both', 'force' => FALSE], FALSE, TRUE, 'on',
+			array_replace($on, ['reuse_dnsbl' => 'on', 'clear_masterfiles' => TRUE]),
+		];
+		yield 'manual array update keeps configured reuse local to IP' => [
+			['scope' => 'both', 'force' => FALSE], FALSE, FALSE, 'on', $on,
+		];
+		yield 'cron tick with reuse disabled' => [
+			['scope' => 'both', 'force' => FALSE], FALSE, TRUE, '', $off,
+		];
+		yield 'IP scope without force' => [
+			['scope' => 'ip', 'force' => FALSE], FALSE, FALSE, 'on', $on,
+		];
+		yield 'invalid scope is inert' => [
+			['scope' => 'invalid', 'force' => TRUE], FALSE, FALSE, 'on', $on,
+		];
+		yield 'empty request is inert' => [
+			[], FALSE, FALSE, '', $off,
+		];
+	}
+
+	#[DataProvider('planProvider')]
+	public function testPlanMatchesCurrentDecision(
+		array $request,
+		bool $no_updates,
+		bool $cron_tick,
+		string $configured_reuse,
+		array $expected
+	): void {
+		$this->assertSame(
+			$expected,
+			pfb_sync_run_plan($request, $no_updates, $cron_tick, $configured_reuse)
+		);
+	}
+
+	public function testRepeatedPlanningHasNoGlobalOrFilesystemEffects(): void
+	{
+		$previous_pfb = $GLOBALS['pfb'];
+		$dir = sys_get_temp_dir() . '/pfb_sync_plan_' . getmypid() . '_' . uniqid();
+		mkdir($dir, 0777, TRUE);
+		file_put_contents("{$dir}/masterfile", 'master');
+		file_put_contents("{$dir}/mastercat", 'category');
+		$GLOBALS['pfb'] = ['dbdir' => $dir, 'sentinel' => 'unchanged'];
+
+		try {
+			$request = ['scope' => 'both', 'force' => TRUE];
+			$first = pfb_sync_run_plan($request, FALSE, FALSE, '');
+			$this->assertSame($first, pfb_sync_run_plan($request, FALSE, FALSE, ''));
+			$this->assertSame(['dbdir' => $dir, 'sentinel' => 'unchanged'], $GLOBALS['pfb']);
+			$this->assertSame('master', file_get_contents("{$dir}/masterfile"));
+			$this->assertSame('category', file_get_contents("{$dir}/mastercat"));
+		} finally {
+			$GLOBALS['pfb'] = $previous_pfb;
+			@unlink("{$dir}/masterfile");
+			@unlink("{$dir}/mastercat");
+			@rmdir($dir);
+		}
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -6611,6 +6611,40 @@
             }
         ]
     },
+    "pfb_sync_run_plan": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "request",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "no_updates",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "cron_tick",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "configured_reuse",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_sync_status_close": {
         "returnsRef": false,
         "returnType": "void",


### PR DESCRIPTION
## Summary

- Extract the sync mode/reuse decision block into pure `pfb_sync_run_plan()`.
- Keep global mutation, masterfile deletion, hooks, logging, locks, and execution in `sync_package_pfblockerng()`.
- Cover cron/manual/force, IP/DNSBL/both, reuse, no-update, invalid, and empty inputs; pin purity and the function inventory.

## Verification

- Baseline oracle: `vendor/bin/phpunit --filter 'TriggerRequestTest|TriggerAdaptersTest|SyncFeedPassDeferralTest|FunctionInventoryParityTest'` — 24 tests, 96 assertions.
- Focused result: `vendor/bin/phpunit --filter 'SyncRunPlanTest|TriggerRequestTest|TriggerAdaptersTest|SyncFeedPassDeferralTest|FunctionInventoryParityTest'` — 35 tests, 110 assertions.
- Canonical gates: `scripts/agent/run-gates.sh --diff origin/devel` — PHP lint, full PHPUnit, PHPStan, and PHPCS passed.

Fixes #1403

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sync operations now use a centralized “run plan” to consistently decide whether to reuse existing downloads, reuse DNSBL feeds, update DNSBL content, save configuration, and clear cached masterfiles.
* **Tests**
  * Added PHPUnit coverage for planning logic across scope, force, and scheduled run scenarios.
  * Added a regression test ensuring repeated planning is side-effect free (no unintended global or filesystem changes).
  * Expanded coverage targets and updated function inventory fixtures accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->