### PR TITLE
agent: default Codex worktrees to temp dir

### DIFF
--- a/scripts/agent/work-branch.sh
+++ b/scripts/agent/work-branch.sh
@@ -5,9 +5,9 @@
 # Usage: work-branch.sh <issue|adr> <NN> [TITLE ...] [--worktree] [--path PATH] [--base REF]
 #   Prints the branch name (`issue/NN-slug` / `adr/NN-slug`; empty slug -> bare `type/NN`).
 #   --worktree  also `git fetch origin` + `git worktree add -b BRANCH PATH BASE` at an
-#               ABSOLUTE path (default <primary checkout>/.claude/worktrees/<type>-<NN>;
-#               a relative --path anchors there too, even when invoked from a linked
-#               worktree); an existing branch or path gets a `-<epoch>` suffix
+#               ABSOLUTE path (default <primary checkout>/.claude/worktrees/<type>-<NN>,
+#               or <TMPDIR>/pfblockerng-<type>-<NN> under Codex; a relative --path anchors
+#               at the primary checkout); an existing branch or path gets a `-<epoch>` suffix
 #               (collision rule). Prints `BRANCH<TAB>PATH` instead.
 #   --base REF  worktree base (default origin/devel)
 #
@@ -80,7 +80,13 @@ main() {
 	   git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
 		branch="$branch-$(date +%s)"
 	fi
-	[ -n "$path" ] || path="$root/.claude/worktrees/$kind-$nn"
+	if [ -z "$path" ]; then
+		case "${CODEX_THREAD_ID:-}" in
+			'') path="$root/.claude/worktrees/$kind-$nn" ;;
+			*) tmp_root=$(CDPATH='' cd "${TMPDIR:-/tmp}" 2>/dev/null && pwd -P) || tmp_root=/tmp
+				path="$tmp_root/pfblockerng-$kind-$nn" ;;
+		esac
+	fi
 	case "$path" in /*) ;; *) path="$root/$path" ;; esac   # worktree add needs ABSOLUTE paths
 	[ -e "$path" ] && path="$path-$(date +%s)"
 	git worktree add -b "$branch" "$path" "$base" >/dev/null || exit 1

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -77,10 +77,17 @@ Describe 'work-branch.sh --worktree anchors at the primary checkout'
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
-  It 'defaults the path under the primary root when run from a linked worktree'
-    When run sh -c 'cd "$1" && exec sh "$2" issue 7 tld --worktree --base HEAD' _ "$fixture/session" "$script_abs"
+  It 'defaults the path under the primary root outside Codex'
+    When run sh -c 'cd "$1" && CODEX_THREAD_ID= exec sh "$2" issue 7 tld --worktree --base HEAD' _ "$fixture/session" "$script_abs"
     The status should equal 0
     The output should equal "$(printf 'issue/7-tld\t%s/.claude/worktrees/issue-7' "$primary")"
+    The stderr should include 'Preparing worktree'
+  End
+
+  It 'defaults the path under TMPDIR when run from Codex'
+    When run sh -c 'cd "$1" && CODEX_THREAD_ID=thread TMPDIR="$3" exec sh "$2" issue 7 tld --worktree --base HEAD' _ "$fixture/session" "$script_abs" "$fixture"
+    The status should equal 0
+    The output should equal "$(printf 'issue/7-tld\t%s/pfblockerng-issue-7' "$fixture")"
     The stderr should include 'Preparing worktree'
   End
 
@@ -92,7 +99,7 @@ Describe 'work-branch.sh --worktree anchors at the primary checkout'
   End
 
   It 'keeps the primary-checkout default placement unchanged'
-    When run sh -c 'cd "$1" && exec sh "$2" issue 9 tld --worktree --base HEAD' _ "$primary" "$script_abs"
+    When run sh -c 'cd "$1" && CODEX_THREAD_ID= exec sh "$2" issue 9 tld --worktree --base HEAD' _ "$primary" "$script_abs"
     The status should equal 0
     The output should equal "$(printf 'issue/9-tld\t%s/.claude/worktrees/issue-9' "$primary")"
     The stderr should include 'Preparing worktree'
@@ -101,7 +108,7 @@ Describe 'work-branch.sh --worktree anchors at the primary checkout'
   It 'is immune to an inherited CDPATH when resolving the primary root'
     # A CDPATH hit makes cd echo the destination AND resolve relative to the
     # CDPATH entry instead of $PWD — either corrupts the derived root.
-    When run sh -c 'mkdir -p "$3/.git" && cd "$1" && CDPATH=$3 exec sh "$2" issue 10 tld --worktree --base HEAD' _ "$primary" "$script_abs" "$fixture/decoy"
+    When run sh -c 'mkdir -p "$3/.git" && cd "$1" && CODEX_THREAD_ID= CDPATH=$3 exec sh "$2" issue 10 tld --worktree --base HEAD' _ "$primary" "$script_abs" "$fixture/decoy"
     The status should equal 0
     The output should equal "$(printf 'issue/10-tld\t%s/.claude/worktrees/issue-10' "$primary")"
     The stderr should include 'Preparing worktree'


### PR DESCRIPTION
## Summary

- Default canonical work-item worktrees under the normalized temporary directory when `CODEX_THREAD_ID` is set.
- Preserve the primary-checkout default for other clients.
- Preserve explicit relative and absolute `--path` behavior.

Fixes #1539

## Verification

- Frozen test hash: `8e4c857461d34e266c920aacaf0088a06de9f37b`
- Test-first RED: 19 examples, 1 expected failure; Codex default still resolved under the primary checkout.
- GREEN: 19 examples, 0 failures under dash.
- Full shellspec outside sandbox: 958 examples, 0 failures, 8 environmental skips.
- `sh -n` and ShellCheck pass.
- Independent gate re-executed RED→GREEN and verified Codex/non-Codex defaults, explicit paths, collision suffixing, and symlinked `TMPDIR` normalization.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.