### PR TITLE
Agent worktrees: trust checked-in RTK filters

### DIFF
--- a/.claude/hooks/rtk-install.sh
+++ b/.claude/hooks/rtk-install.sh
@@ -1,22 +1,34 @@
 #!/bin/sh
-# rtk-install.sh — SessionStart hook: install the rtk binary (pre-built, checksum-verified
-# by the upstream installer) when absent, e.g. in a cloud session. Installs to ~/.local/bin,
-# best-effort symlinks into /usr/local/bin and appends the PATH export to ~/.profile +
-# ~/.bashrc so the NEXT shell resolves it — the rtk Bash-rewrite hook stays a no-op until
-# the session PATH actually finds rtk. Never fails session start. RTK_VERSION pins a release.
+# rtk-install.sh — SessionStart hook: make RTK available, then trust the checked-in filters
+# from the current worktree. When absent, install the checksum-verified upstream binary to
+# ~/.local/bin, best-effort symlink it into /usr/local/bin, and update shell profiles for the
+# next shell. Never fails session start. RTK_VERSION pins a release.
 set -u
 
-command -v rtk >/dev/null 2>&1 && exit 0
-[ -x "$HOME/.local/bin/rtk" ] && exit 0
-
-{ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh; } >/dev/null 2>&1 || exit 0
-
-[ -x "$HOME/.local/bin/rtk" ] || exit 0
-if [ -w /usr/local/bin ] && [ ! -e /usr/local/bin/rtk ]; then
-	ln -s "$HOME/.local/bin/rtk" /usr/local/bin/rtk 2>/dev/null
+rtk_bin=$(command -v rtk 2>/dev/null) || rtk_bin=''
+if [ -z "$rtk_bin" ] && [ -x "$HOME/.local/bin/rtk" ]; then
+	rtk_bin="$HOME/.local/bin/rtk"
 fi
-for f in "$HOME/.profile" "$HOME/.bashrc"; do
-	# shellcheck disable=SC2016 # literal $HOME/$PATH wanted: the profile line must expand at ITS read time
-	grep -qs '\.local/bin' "$f" || printf 'export PATH="$HOME/.local/bin:$PATH"\n' >> "$f"
-done
+
+if [ -z "$rtk_bin" ]; then
+	{ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh; } >/dev/null 2>&1 || exit 0
+
+	[ -x "$HOME/.local/bin/rtk" ] || exit 0
+	rtk_bin="$HOME/.local/bin/rtk"
+	if [ -w /usr/local/bin ] && [ ! -e /usr/local/bin/rtk ]; then
+		ln -s "$rtk_bin" /usr/local/bin/rtk 2>/dev/null
+	fi
+	for f in "$HOME/.profile" "$HOME/.bashrc"; do
+		# shellcheck disable=SC2016 # literal $HOME/$PATH wanted: the profile line must expand at ITS read time
+		grep -qs '\.local/bin' "$f" || printf 'export PATH="$HOME/.local/bin:$PATH"\n' >> "$f"
+	done
+fi
+
+project_root=${CLAUDE_PROJECT_DIR:-}
+if [ -z "$project_root" ]; then
+	git_cdup=$(git rev-parse --show-cdup 2>/dev/null) || exit 0
+	project_root=$(CDPATH='' cd "${git_cdup:-.}" && pwd -L) || exit 0
+fi
+[ -n "$project_root" ] && [ -f "$project_root/.rtk/filters.toml" ] || exit 0
+(CDPATH='' cd "$project_root" && "$rtk_bin" trust >/dev/null 2>&1) || exit 0
 exit 0

--- a/.claude/hooks/rtk-install.sh
+++ b/.claude/hooks/rtk-install.sh
@@ -5,6 +5,11 @@
 # next shell. Never fails session start. RTK_VERSION pins a release.
 set -u
 
+hook_dir=$(CDPATH='' cd "$(dirname "$0")" && pwd -L) || exit 0
+# shellcheck source=../../scripts/lib/git-env-scrub.sh
+. "$hook_dir/../../scripts/lib/git-env-scrub.sh"
+pfb_scrub_git_env
+
 rtk_bin=$(command -v rtk 2>/dev/null) || rtk_bin=''
 if [ -z "$rtk_bin" ] && [ -x "$HOME/.local/bin/rtk" ]; then
 	rtk_bin="$HOME/.local/bin/rtk"
@@ -34,12 +39,10 @@ filter_dir="$project_root/.rtk"
 filter_path="$filter_dir/filters.toml"
 [ -n "$project_root" ] && [ -d "$filter_dir" ] && [ ! -L "$filter_dir" ] || exit 0
 [ -f "$filter_path" ] && [ ! -L "$filter_path" ] || exit 0
-filter_stage=$(git -C "$project_root" ls-files --stage -- "$filter_rel" 2>/dev/null) || exit 0
-case "$filter_stage" in
-	'100644 '*) ;;
-	*) exit 0 ;;
-esac
 filter_head=$(git -C "$project_root" rev-parse "HEAD:$filter_rel" 2>/dev/null) || exit 0
+filter_stage=$(git -C "$project_root" ls-files --stage -- "$filter_rel" 2>/dev/null) || exit 0
+filter_expected=$(printf '100644 %s 0\t%s' "$filter_head" "$filter_rel")
+[ "$filter_stage" = "$filter_expected" ] || exit 0
 filter_work=$(git -C "$project_root" hash-object -- "$filter_rel" 2>/dev/null) || exit 0
 [ "$filter_work" = "$filter_head" ] || exit 0
 (CDPATH='' cd "$project_root" && "$rtk_bin" trust >/dev/null 2>&1) || exit 0

--- a/.claude/hooks/rtk-install.sh
+++ b/.claude/hooks/rtk-install.sh
@@ -30,13 +30,17 @@ if [ -z "$project_root" ]; then
 	project_root=$(CDPATH='' cd "${git_cdup:-.}" && pwd -L) || exit 0
 fi
 filter_rel='.rtk/filters.toml'
-filter_path="$project_root/$filter_rel"
-[ -n "$project_root" ] && [ -f "$filter_path" ] && [ ! -L "$filter_path" ] || exit 0
+filter_dir="$project_root/.rtk"
+filter_path="$filter_dir/filters.toml"
+[ -n "$project_root" ] && [ -d "$filter_dir" ] && [ ! -L "$filter_dir" ] || exit 0
+[ -f "$filter_path" ] && [ ! -L "$filter_path" ] || exit 0
 filter_stage=$(git -C "$project_root" ls-files --stage -- "$filter_rel" 2>/dev/null) || exit 0
 case "$filter_stage" in
 	'100644 '*) ;;
 	*) exit 0 ;;
 esac
-git -C "$project_root" diff --quiet HEAD -- "$filter_rel" 2>/dev/null || exit 0
+filter_head=$(git -C "$project_root" rev-parse "HEAD:$filter_rel" 2>/dev/null) || exit 0
+filter_work=$(git -C "$project_root" hash-object -- "$filter_rel" 2>/dev/null) || exit 0
+[ "$filter_work" = "$filter_head" ] || exit 0
 (CDPATH='' cd "$project_root" && "$rtk_bin" trust >/dev/null 2>&1) || exit 0
 exit 0

--- a/.claude/hooks/rtk-install.sh
+++ b/.claude/hooks/rtk-install.sh
@@ -43,7 +43,7 @@ filter_head=$(git -C "$project_root" rev-parse "HEAD:$filter_rel" 2>/dev/null) |
 filter_stage=$(git -C "$project_root" ls-files --stage -- "$filter_rel" 2>/dev/null) || exit 0
 filter_expected=$(printf '100644 %s 0\t%s' "$filter_head" "$filter_rel")
 [ "$filter_stage" = "$filter_expected" ] || exit 0
-filter_work=$(git -C "$project_root" hash-object -- "$filter_rel" 2>/dev/null) || exit 0
+filter_work=$(git -C "$project_root" hash-object --no-filters -- "$filter_rel" 2>/dev/null) || exit 0
 [ "$filter_work" = "$filter_head" ] || exit 0
 (CDPATH='' cd "$project_root" && "$rtk_bin" trust >/dev/null 2>&1) || exit 0
 exit 0

--- a/.claude/hooks/rtk-install.sh
+++ b/.claude/hooks/rtk-install.sh
@@ -29,6 +29,14 @@ if [ -z "$project_root" ]; then
 	git_cdup=$(git rev-parse --show-cdup 2>/dev/null) || exit 0
 	project_root=$(CDPATH='' cd "${git_cdup:-.}" && pwd -L) || exit 0
 fi
-[ -n "$project_root" ] && [ -f "$project_root/.rtk/filters.toml" ] || exit 0
+filter_rel='.rtk/filters.toml'
+filter_path="$project_root/$filter_rel"
+[ -n "$project_root" ] && [ -f "$filter_path" ] && [ ! -L "$filter_path" ] || exit 0
+filter_stage=$(git -C "$project_root" ls-files --stage -- "$filter_rel" 2>/dev/null) || exit 0
+case "$filter_stage" in
+	'100644 '*) ;;
+	*) exit 0 ;;
+esac
+git -C "$project_root" diff --quiet HEAD -- "$filter_rel" 2>/dev/null || exit 0
 (CDPATH='' cd "$project_root" && "$rtk_bin" trust >/dev/null 2>&1) || exit 0
 exit 0

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/rtk-install.sh\" 3b5a889b7e8479a387fff35aafa539f8ad96587f01f5e6fcf61e3442f447684b && exec sh \"$root/.claude/hooks/rtk-install.sh\"",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/rtk-install.sh\" 465db3f57ceed49fc61e9e4058fdc46bde4cd776e0139059300e0614c6685925 && exec sh \"$root/.claude/hooks/rtk-install.sh\"",
             "timeout": 120,
             "statusMessage": "Preparing RTK filters"
           },

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/rtk-install.sh\" 465db3f57ceed49fc61e9e4058fdc46bde4cd776e0139059300e0614c6685925 && exec sh \"$root/.claude/hooks/rtk-install.sh\"",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/rtk-install.sh\" 8130c85ad7256b35a3c49e787cae897ffb20bb7166e64770d866f6ad10ac4228 && exec sh \"$root/.claude/hooks/rtk-install.sh\"",
             "timeout": 120,
             "statusMessage": "Preparing RTK filters"
           },

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/rtk-install.sh\" 13ea127116e5201b5689e77cf91260fa5845e869f559988b4d5c089f30bcf990 && exec sh \"$root/.claude/hooks/rtk-install.sh\"",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/rtk-install.sh\" aec3bdb067de21bc012d8c6a47352277bd096166818c11bf94e68b50bb783c2d && exec sh \"$root/.claude/hooks/rtk-install.sh\"",
             "timeout": 120,
             "statusMessage": "Preparing RTK filters"
           },

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/rtk-install.sh\" aec3bdb067de21bc012d8c6a47352277bd096166818c11bf94e68b50bb783c2d && exec sh \"$root/.claude/hooks/rtk-install.sh\"",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/rtk-install.sh\" 3b5a889b7e8479a387fff35aafa539f8ad96587f01f5e6fcf61e3442f447684b && exec sh \"$root/.claude/hooks/rtk-install.sh\"",
             "timeout": 120,
             "statusMessage": "Preparing RTK filters"
           },

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,6 +6,12 @@
         "hooks": [
           {
             "type": "command",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/rtk-install.sh\" 13ea127116e5201b5689e77cf91260fa5845e869f559988b4d5c089f30bcf990 && exec sh \"$root/.claude/hooks/rtk-install.sh\"",
+            "timeout": 120,
+            "statusMessage": "Preparing RTK filters"
+          },
+          {
+            "type": "command",
             "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/session-branch-sync.sh\" 0b76ca04b33cf66cdaca56bdf77c26002129b3b5248195b0fc9ef1ce97230ed4 && exec sh \"$root/.claude/hooks/session-branch-sync.sh\"",
             "timeout": 120,
             "statusMessage": "Checking branch freshness"

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -126,6 +126,7 @@ hook_commands = [
     for hook in group["hooks"]
 ]
 for relative in (
+    ".claude/hooks/rtk-install.sh",
     ".claude/hooks/session-branch-sync.sh",
     "scripts/claude-bash-guard.sh",
     "scripts/check_retired_tokens.py",

--- a/tests/shell/rtk_blob_identity_spec.sh
+++ b/tests/shell/rtk_blob_identity_spec.sh
@@ -60,4 +60,36 @@ EOF
     The status should be success
     The file "${log}" should not be exist
   End
+
+  It 'does not trust metadata redirected through an inherited Git directory'
+    evil="${work}/evil"
+    mkdir -p "${evil}/.rtk"
+    git init -q "${evil}"
+    git -C "${evil}" config user.email test@example.com
+    git -C "${evil}" config user.name Test
+    git -C "${evil}" config commit.gpgsign false
+    printf '[local]\n' > "${evil}/.rtk/filters.toml"
+    git -C "${evil}" add .rtk/filters.toml
+    git -C "${evil}" commit -q -m filters
+    printf '[local]\n' > "${project}/.rtk/filters.toml"
+    When run env PATH="${shim}:${PATH}" RTK_LOG="${log}" CLAUDE_PROJECT_DIR="${project}" \
+      GIT_DIR="${evil}/.git" sh "${hook}"
+    The status should be success
+    The file "${log}" should not be exist
+  End
+
+  It 'does not trust a filter while its index entry is unmerged'
+    base_oid=$(printf 'base\n' | git -C "${project}" hash-object -w --stdin)
+    ours_oid=$(printf 'ours\n' | git -C "${project}" hash-object -w --stdin)
+    theirs_oid=$(printf 'theirs\n' | git -C "${project}" hash-object -w --stdin)
+    git -C "${project}" update-index --index-info <<EOF
+0 0000000000000000000000000000000000000000	.rtk/filters.toml
+100644 ${base_oid} 1	.rtk/filters.toml
+100644 ${ours_oid} 2	.rtk/filters.toml
+100644 ${theirs_oid} 3	.rtk/filters.toml
+EOF
+    When run run_hook
+    The status should be success
+    The file "${log}" should not be exist
+  End
 End

--- a/tests/shell/rtk_blob_identity_spec.sh
+++ b/tests/shell/rtk_blob_identity_spec.sh
@@ -1,0 +1,63 @@
+#shellcheck shell=sh
+# Git index optimization flags can hide worktree edits from `git diff`. Trust
+# compares actual filter bytes with HEAD and still requires regular-file mode.
+
+Describe 'rtk committed filter identity'
+  hook="${PFB_ROOT}/.claude/hooks/rtk-install.sh"
+
+  setup() {
+    scrub_git_env
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rtk-identity.XXXXXX")"
+    project="${work}/project"
+    shim="${work}/shim"
+    log="${work}/rtk.log"
+    mkdir -p "${project}/.rtk" "${shim}"
+    git init -q "${project}"
+    git -C "${project}" config user.email test@example.com
+    git -C "${project}" config user.name Test
+    git -C "${project}" config commit.gpgsign false
+    printf '[filters]\n' > "${project}/.rtk/filters.toml"
+    git -C "${project}" add .rtk/filters.toml
+    git -C "${project}" commit -q -m filters
+    cat > "${shim}/rtk" <<'EOF'
+#!/bin/sh
+printf '%s|%s\n' "$PWD" "$*" >> "$RTK_LOG"
+EOF
+    chmod +x "${shim}/rtk"
+  }
+
+  cleanup() {
+    rm -rf "${work}"
+  }
+
+  run_hook() {
+    env PATH="${shim}:${PATH}" RTK_LOG="${log}" CLAUDE_PROJECT_DIR="${project}" sh "${hook}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'does not trust changed bytes hidden by assume-unchanged'
+    git -C "${project}" update-index --assume-unchanged .rtk/filters.toml
+    printf '[local]\n' > "${project}/.rtk/filters.toml"
+    When run run_hook
+    The status should be success
+    The file "${log}" should not be exist
+  End
+
+  It 'does not trust changed bytes hidden by skip-worktree'
+    git -C "${project}" update-index --skip-worktree .rtk/filters.toml
+    printf '[local]\n' > "${project}/.rtk/filters.toml"
+    When run run_hook
+    The status should be success
+    The file "${log}" should not be exist
+  End
+
+  It 'does not trust a filter committed with executable mode'
+    git -C "${project}" update-index --chmod=+x .rtk/filters.toml
+    git -C "${project}" commit -q -m executable-filter
+    When run run_hook
+    The status should be success
+    The file "${log}" should not be exist
+  End
+End

--- a/tests/shell/rtk_blob_identity_spec.sh
+++ b/tests/shell/rtk_blob_identity_spec.sh
@@ -92,4 +92,15 @@ EOF
     The status should be success
     The file "${log}" should not be exist
   End
+
+  It 'does not trust changed bytes normalized by a Git clean filter'
+    git -C "${project}" config filter.upper.clean "tr '[:lower:]' '[:upper:]'"
+    git -C "${project}" config filter.upper.smudge cat
+    printf '*.toml filter=upper\n' > "${project}/.gitattributes"
+    git -C "${project}" add .gitattributes .rtk/filters.toml
+    git -C "${project}" commit -q -m clean-filter
+    When run run_hook
+    The status should be success
+    The file "${log}" should not be exist
+  End
 End

--- a/tests/shell/rtk_filter_path_spec.sh
+++ b/tests/shell/rtk_filter_path_spec.sh
@@ -1,0 +1,43 @@
+#shellcheck shell=sh
+# A regular filter reached through a symlinked .rtk directory is not owned by
+# the worktree, even when its bytes equal the committed blob.
+
+Describe 'rtk filter path ownership'
+  hook="${PFB_ROOT}/.claude/hooks/rtk-install.sh"
+
+  setup() {
+    scrub_git_env
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rtk-path.XXXXXX")"
+    project="${work}/project"
+    shim="${work}/shim"
+    log="${work}/rtk.log"
+    mkdir -p "${project}/.rtk" "${shim}"
+    git init -q "${project}"
+    git -C "${project}" config user.email test@example.com
+    git -C "${project}" config user.name Test
+    git -C "${project}" config commit.gpgsign false
+    printf '[filters]\n' > "${project}/.rtk/filters.toml"
+    git -C "${project}" add .rtk/filters.toml
+    git -C "${project}" commit -q -m filters
+    mv "${project}/.rtk" "${work}/outside-rtk"
+    ln -s "${work}/outside-rtk" "${project}/.rtk"
+    cat > "${shim}/rtk" <<'EOF'
+#!/bin/sh
+printf '%s|%s\n' "$PWD" "$*" >> "$RTK_LOG"
+EOF
+    chmod +x "${shim}/rtk"
+  }
+
+  cleanup() {
+    rm -rf "${work}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'does not trust a committed blob reached through a symlinked filter directory'
+    When run env PATH="${shim}:${PATH}" RTK_LOG="${log}" CLAUDE_PROJECT_DIR="${project}" sh "${hook}"
+    The status should be success
+    The file "${log}" should not be exist
+  End
+End

--- a/tests/shell/rtk_install_spec.sh
+++ b/tests/shell/rtk_install_spec.sh
@@ -1,0 +1,83 @@
+#shellcheck shell=sh
+# Agent sessions must trust the repository-owned RTK filters from the current
+# worktree root. Claude and Codex share the same best-effort bootstrap hook.
+
+Describe 'rtk SessionStart bootstrap'
+  hook="${PFB_ROOT}/.claude/hooks/rtk-install.sh"
+
+  setup() {
+    scrub_git_env
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rtk-install.XXXXXX")"
+    project="${work}/project"
+    shim="${work}/shim"
+    log="${work}/rtk.log"
+    mkdir -p "${project}/.rtk" "${project}/subdir" "${shim}"
+    git init -q "${project}"
+    printf '[filters]\n' > "${project}/.rtk/filters.toml"
+    cat > "${shim}/rtk" <<'EOF'
+#!/bin/sh
+printf '%s|%s\n' "$PWD" "$*" >> "$RTK_LOG"
+EOF
+    chmod +x "${shim}/rtk"
+  }
+
+  cleanup() {
+    rm -rf "${work}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'trusts filters against the Git worktree root when RTK already exists'
+    When run env PATH="${shim}:${PATH}" RTK_LOG="${log}" CLAUDE_PROJECT_DIR= \
+      sh -c 'cd "$1" && exec sh "$2"' _ "${project}/subdir" "${hook}"
+    The status should be success
+    The contents of file "${log}" should equal "${project}|trust"
+  End
+
+  It 'does not trust a worktree without a project filter file'
+    rm "${project}/.rtk/filters.toml"
+    When run env PATH="${shim}:${PATH}" RTK_LOG="${log}" CLAUDE_PROJECT_DIR="${project}" sh "${hook}"
+    The status should be success
+    The file "${log}" should not be exist
+  End
+End
+
+verify_vendor_rtk_bootstrap() {
+  python3 - "$PFB_ROOT" <<'PY'
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+relative = ".claude/hooks/rtk-install.sh"
+digest = hashlib.sha256((root / relative).read_bytes()).hexdigest()
+
+claude = json.loads((root / ".claude/settings.json").read_text())
+claude_commands = [
+    hook["command"]
+    for group in claude["hooks"]["SessionStart"]
+    for hook in group["hooks"]
+    if relative in hook["command"]
+]
+assert len(claude_commands) == 1, "Claude must run the shared RTK bootstrap once"
+
+codex = json.loads((root / ".codex/hooks.json").read_text())
+codex_commands = [
+    hook["command"]
+    for group in codex["hooks"]["SessionStart"]
+    for hook in group["hooks"]
+    if relative in hook["command"]
+]
+assert len(codex_commands) == 1, "Codex must run the shared RTK bootstrap once"
+assert digest in codex_commands[0], "Codex RTK bootstrap integrity hash is stale"
+PY
+}
+
+Describe 'RTK bootstrap vendor wiring'
+  It 'uses the integrity-pinned shared hook for Claude and Codex'
+    When call verify_vendor_rtk_bootstrap
+    The status should be success
+  End
+End

--- a/tests/shell/rtk_install_spec.sh
+++ b/tests/shell/rtk_install_spec.sh
@@ -14,6 +14,11 @@ Describe 'rtk SessionStart bootstrap'
     mkdir -p "${project}/.rtk" "${project}/subdir" "${shim}"
     git init -q "${project}"
     printf '[filters]\n' > "${project}/.rtk/filters.toml"
+    git -C "${project}" config user.email test@example.com
+    git -C "${project}" config user.name Test
+    git -C "${project}" config commit.gpgsign false
+    git -C "${project}" add .rtk/filters.toml
+    git -C "${project}" commit -q -m filters
     cat > "${shim}/rtk" <<'EOF'
 #!/bin/sh
 printf '%s|%s\n' "$PWD" "$*" >> "$RTK_LOG"

--- a/tests/shell/rtk_local_install_spec.sh
+++ b/tests/shell/rtk_local_install_spec.sh
@@ -1,0 +1,45 @@
+#shellcheck shell=sh
+# A cloud install may place RTK in ~/.local/bin before the current shell has
+# refreshed PATH. Session bootstrap must still trust this worktree's filters.
+
+Describe 'rtk local-install bootstrap'
+  hook="${PFB_ROOT}/.claude/hooks/rtk-install.sh"
+
+  setup() {
+    scrub_git_env
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rtk-local.XXXXXX")"
+    project="${work}/project"
+    home="${work}/home"
+    log="${work}/rtk.log"
+    mkdir -p "${project}/.rtk" "${home}/.local/bin"
+    git init -q "${project}"
+    printf '[filters]\n' > "${project}/.rtk/filters.toml"
+    cat > "${home}/.local/bin/rtk" <<'EOF'
+#!/bin/sh
+printf '%s|%s\n' "$PWD" "$*" >> "$RTK_LOG"
+exit "${RTK_EXIT:-0}"
+EOF
+    chmod +x "${home}/.local/bin/rtk"
+  }
+
+  cleanup() {
+    rm -rf "${work}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'uses the installed binary even before local bin is on PATH'
+    When run env HOME="${home}" PATH="/usr/bin:/bin" RTK_LOG="${log}" \
+      CLAUDE_PROJECT_DIR="${project}" sh "${hook}"
+    The status should be success
+    The contents of file "${log}" should equal "${project}|trust"
+  End
+
+  It 'keeps session startup non-blocking when trust fails'
+    When run env HOME="${home}" PATH="/usr/bin:/bin" RTK_LOG="${log}" RTK_EXIT=9 \
+      CLAUDE_PROJECT_DIR="${project}" sh "${hook}"
+    The status should be success
+    The contents of file "${log}" should equal "${project}|trust"
+  End
+End

--- a/tests/shell/rtk_local_install_spec.sh
+++ b/tests/shell/rtk_local_install_spec.sh
@@ -14,6 +14,11 @@ Describe 'rtk local-install bootstrap'
     mkdir -p "${project}/.rtk" "${home}/.local/bin"
     git init -q "${project}"
     printf '[filters]\n' > "${project}/.rtk/filters.toml"
+    git -C "${project}" config user.email test@example.com
+    git -C "${project}" config user.name Test
+    git -C "${project}" config commit.gpgsign false
+    git -C "${project}" add .rtk/filters.toml
+    git -C "${project}" commit -q -m filters
     cat > "${home}/.local/bin/rtk" <<'EOF'
 #!/bin/sh
 printf '%s|%s\n' "$PWD" "$*" >> "$RTK_LOG"

--- a/tests/shell/rtk_tracked_filter_spec.sh
+++ b/tests/shell/rtk_tracked_filter_spec.sh
@@ -1,0 +1,68 @@
+#shellcheck shell=sh
+# Automatic trust is limited to the committed regular filter file. Local files,
+# worktree edits, and symlinks must still require explicit human review.
+
+Describe 'rtk checked-in filter trust boundary'
+  hook="${PFB_ROOT}/.claude/hooks/rtk-install.sh"
+
+  setup() {
+    scrub_git_env
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rtk-tracked.XXXXXX")"
+    project="${work}/project"
+    shim="${work}/shim"
+    log="${work}/rtk.log"
+    mkdir -p "${project}/.rtk" "${shim}"
+    git init -q "${project}"
+    git -C "${project}" config user.email test@example.com
+    git -C "${project}" config user.name Test
+    git -C "${project}" config commit.gpgsign false
+    printf '[filters]\n' > "${project}/.rtk/filters.toml"
+    git -C "${project}" add .rtk/filters.toml
+    git -C "${project}" commit -q -m filters
+    cat > "${shim}/rtk" <<'EOF'
+#!/bin/sh
+printf '%s|%s\n' "$PWD" "$*" >> "$RTK_LOG"
+EOF
+    chmod +x "${shim}/rtk"
+  }
+
+  cleanup() {
+    rm -rf "${work}"
+  }
+
+  run_hook() {
+    env PATH="${shim}:${PATH}" RTK_LOG="${log}" CLAUDE_PROJECT_DIR="${project}" sh "${hook}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'trusts the unchanged committed regular filter'
+    When run run_hook
+    The status should be success
+    The contents of file "${log}" should equal "${project}|trust"
+  End
+
+  It 'does not trust an untracked filter'
+    git -C "${project}" rm -q --cached .rtk/filters.toml
+    When run run_hook
+    The status should be success
+    The file "${log}" should not be exist
+  End
+
+  It 'does not trust local edits to the committed filter'
+    printf '# local edit\n' >> "${project}/.rtk/filters.toml"
+    When run run_hook
+    The status should be success
+    The file "${log}" should not be exist
+  End
+
+  It 'does not trust a symlink replacing the committed filter'
+    rm "${project}/.rtk/filters.toml"
+    printf '[outside]\n' > "${work}/outside.toml"
+    ln -s "${work}/outside.toml" "${project}/.rtk/filters.toml"
+    When run run_hook
+    The status should be success
+    The file "${log}" should not be exist
+  End
+End


### PR DESCRIPTION
## Summary

- share one RTK SessionStart bootstrap between Claude Code and Codex
- trust `.rtk/filters.toml` only when its regular-file path, Git stage/mode, committed blob, and raw working bytes all match `HEAD`
- scrub inherited Git environment variables before repository inspection
- keep trust/install failures best-effort and preserve Codex's pinned hook-integrity check
- add ShellSpec coverage for bootstrap, worktree trust, symlink/tamper rejection, unmerged-index rejection, and Git clean-filter bypass

## Validation

- test-first proof for the original change: RED `5 examples, 4 failures`; GREEN after implementation
- clean-filter regression: frozen test RED `6 examples, 1 failure`; GREEN `6 examples, 0 failures`
- targeted RTK ShellSpec suite: `38 examples, 0 failures`
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS after final rebase
- GitHub CI: all required checks green at `32e17188`
- independent full review plus four authorized review-fix delta rounds; final delta review CLEAN

## Review audit

- **APPLY:** CodeRabbit's clean-filter finding fixed at `32e17188` with `git hash-object --no-filters`; regression coverage proves raw working bytes cannot be hidden by `.gitattributes`
- **DEFER:** two duplicate mutable-installer/pinning findings are valid pre-existing risk, tracked in #1548
- **SKIP:** generic docstring-coverage warning does not apply to this shell/config-only change; no Python functions changed and repository gates pass

Fixes #1544

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
