### PR TITLE
pfblockerng: extract IP line parser

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9849,6 +9849,21 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 	global $pfb;
 
+	$result = pfb_sanitize_ipaddr($ipaddr, $custom, $pfbcidr, $pfb['supp']);
+	foreach ($result['messages'] as $message) {
+		pfb_logger($message, 1);
+	}
+	return $result['address'];
+}
+
+/**
+ * Normalize one IPv4 entry without reading global state or emitting logs.
+ *
+ * @return array{address: ?string, messages: list<string>}
+ */
+function pfb_sanitize_ipaddr($ipaddr, $custom, $pfbcidr, $supp): array {
+	$messages = [];
+
 	$parts	= explode('/', $ipaddr);
 	$subnet	= $parts[0];
 	$mask	= $parts[1] ?? '';	// '' (not undef) when no CIDR
@@ -9857,7 +9872,7 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 	// strip here (str_replace('32', '')) used to rewrite an invalid mask into a
 	// valid, far broader one (/132 -> /1 = half of IPv4) (issue #719).
 	if ($mask !== '' && (!ctype_digit($mask) || (int)$mask > 32)) {
-		return;
+		return ['address' => NULL, 'messages' => $messages];
 	}
 
 	// An explicit /0 covers the entire IPv4 space and is never honored from a
@@ -9867,7 +9882,7 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 	if ($mask !== '' && (int)$mask === 0 && !$custom) {
 		// Unlike the v6 sibling, callers reach this before validate_ipv4(), so
 		// $ipaddr is raw feed text — strip control chars to keep the log clean.
-		pfb_logger("\n  Feed /0 CIDR clamped to single host: " . preg_replace('/[[:cntrl:]]/', '', $ipaddr), 1);
+		$messages[] = "\n  Feed /0 CIDR clamped to single host: " . preg_replace('/[[:cntrl:]]/', '', $ipaddr);
 		$mask = '';
 	}
 	$iparr = explode('.', $subnet);
@@ -9898,21 +9913,21 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 	$ip_final = implode('.', $ip);
 
 	// Exclude private/reserved IPs (bypass exclusion for custom lists)
-	if ($pfb['supp'] == 'on' && !$custom) {
+	if ($supp == 'on' && !$custom) {
 
 		// Remove 'loopback' and '0.0.0.0' IPs
 		if ($ip[0] == 127 || $ip[0] == 0 || empty($ip[0])) {
-			return;
+			return ['address' => NULL, 'messages' => $messages];
 		}
 
 		// Advanced IPv4 Tunable (Set CIDR Block size limit)
 		if ($pfbcidr != 'Disabled' && !empty($mask) && $mask < $pfbcidr) {
-			pfb_logger("\n  Suppression CIDR Limit: {$ip_final}/{$mask}", 1);
+			$messages[] = "\n  Suppression CIDR Limit: {$ip_final}/{$mask}";
 			$mask = '32';
 		}
 
 		if (!filter_var($ip_final, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== FALSE) {
-			return;
+			return ['address' => NULL, 'messages' => $messages];
 		}
 
 		// FILTER_FLAG_NO_PRIV_RANGE|NO_RES_RANGE keep documentation (RFC 5737),
@@ -9930,16 +9945,16 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 			($long & 0xfffe0000) === 0xc6120000 ||	// 198.18.0.0/15 benchmarking
 			($long & 0xffffff00) === 0xc0586300	// 192.88.99.0/24 6to4 relay anycast
 		)) {
-			return;
+			return ['address' => NULL, 'messages' => $messages];
 		}
 	}
 
 	// '!== '' (not !empty()): empty('0') is TRUE, which silently collapsed a
 	// custom list's honored /0 to a bare host (issue #744).
 	if ($mask !== '') {
-		return "{$ip_final}/{$mask}";
+		return ['address' => "{$ip_final}/{$mask}", 'messages' => $messages];
 	}
-	return "{$ip_final}";
+	return ['address' => "{$ip_final}", 'messages' => $messages];
 }
 
 
@@ -9955,6 +9970,21 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 function sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr = 'Disabled') {
 	global $pfb;
 
+	$result = pfb_sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr, $pfb['supp']);
+	foreach ($result['messages'] as $message) {
+		pfb_logger($message, 1);
+	}
+	return $result['address'];
+}
+
+/**
+ * Normalize one IPv6 entry without reading global state or emitting logs.
+ *
+ * @return array{address: ?string, messages: list<string>}
+ */
+function pfb_sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr, $supp): array {
+	$messages = [];
+
 	// Extract the address part (before '/' for a CIDR like 'fc00::/7')
 	$parts	= explode('/', $ipaddr);
 	$s_ip	= $parts[0];
@@ -9965,11 +9995,11 @@ function sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr = 'Disabled') {
 	// form is dropped explicitly first -- inet_pton()'s handling of it is
 	// platform-dependent (FreeBSD/glibc reject it, macOS strips the zone).
 	if (strpos($s_ip, '%') !== FALSE) {
-		return;
+		return ['address' => NULL, 'messages' => $messages];
 	}
 	$bin = inet_pton($s_ip);
 	if ($bin === FALSE) {
-		return;
+		return ['address' => NULL, 'messages' => $messages];
 	}
 
 	// An explicit /0 covers the entire IPv6 space and is never honored from a
@@ -9978,12 +10008,12 @@ function sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr = 'Disabled') {
 	// kept as written.
 	$mask_clamped = FALSE;
 	if ($mask !== '' && ctype_digit($mask) && (int)$mask === 0 && !$custom) {
-		pfb_logger("\n  Feed /0 CIDR clamped to single host: {$ipaddr}", 1);
+		$messages[] = "\n  Feed /0 CIDR clamped to single host: {$ipaddr}";
 		$mask_clamped = TRUE;
 	}
 
 	// Exclude private/reserved IPs (bypass exclusion for custom lists)
-	if ($pfb['supp'] == 'on' && !$custom) {
+	if ($supp == 'on' && !$custom) {
 
 		// Advanced IPv6 Tunable (Set CIDR Block size limit) (issue #760 §3).
 		// A /0 was already clamped above (mask stays '0', never > 0, so this
@@ -9992,7 +10022,7 @@ function sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr = 'Disabled') {
 		// 0-128 here; the ctype_digit()/range checks are defensive redundancy
 		// for any direct caller that skips that guard.
 		if ($pfbcidr != 'Disabled' && $mask !== '' && ctype_digit($mask) && (int)$mask > 0 && (int)$mask < (int)$pfbcidr) {
-			pfb_logger("\n  Suppression CIDR Limit: {$s_ip}/{$mask}", 1);
+			$messages[] = "\n  Suppression CIDR Limit: {$s_ip}/{$mask}";
 			$mask_clamped = TRUE;
 		}
 
@@ -10000,7 +10030,7 @@ function sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr = 'Disabled') {
 		// IPv4-mapped and the reserved set (mirrors inc:7118-7119).
 		if (!filter_var($s_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) ||
 		    !filter_var($s_ip, FILTER_CALLBACK, array('options' => 'FILTER_FLAG_NO_LOOPBACK_RANGE'))) {
-			return;
+			return ['address' => NULL, 'messages' => $messages];
 		}
 
 		// The filter flags above keep documentation (2001:db8::/32), multicast
@@ -10012,16 +10042,16 @@ function sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr = 'Disabled') {
 			substr($bin, 0, 1) === "\xff" ||								// ff00::/8 multicast
 			substr($bin, 0, 12) === "\x00\x64\xff\x9b" . str_repeat("\x00", 8)	// 64:ff9b::/96 NAT64
 		) {
-			return;
+			return ['address' => NULL, 'messages' => $messages];
 		}
 	}
 
 	// issue #1084: canonical inet_ntop() form; mask re-appended only when
 	// neither clamp above dropped it.
 	if ($mask !== '' && !$mask_clamped) {
-		return inet_ntop($bin) . '/' . $mask;
+		return ['address' => inet_ntop($bin) . '/' . $mask, 'messages' => $messages];
 	}
-	return inet_ntop($bin);
+	return ['address' => inet_ntop($bin), 'messages' => $messages];
 }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -55,6 +55,193 @@ function pfb_sync_run_plan(array $request, bool $no_updates, bool $cron_tick, st
 	return $plan;
 }
 
+/**
+ * Parse one generic IP-feed line without touching run state or emitting output.
+ * @param array{vtype:string,pftype:string,custom:bool,cidr_floor_v4:int|string,cidr_floor_v6:int|string,suppression:string,range:string,ipv4:string,ipv6:string} $config
+ * @return array{entries:list<string>,line:string,suppressed:bool,parse_fail_delta:int,detailed_parse_fail:bool,messages:list<string>}
+ */
+function pfb_ip_parse_line(string $raw_line, array $config): array {
+	$line = trim($raw_line);
+	$result = [
+		'entries'             => [],
+		'line'                => $line,
+		'suppressed'          => FALSE,
+		'parse_fail_delta'    => 0,
+		'detailed_parse_fail' => FALSE,
+		'messages'            => [],
+	];
+	if (pfb_is_blank_or_comment_line($line)) {
+		return $result;
+	}
+
+	$vtype       = $config['vtype'];
+	$pftype      = $config['pftype'];
+	$custom      = $config['custom'];
+	$pfbcidr     = $config['cidr_floor_v4'];
+	$pfbcidr_v6  = $config['cidr_floor_v6'];
+	$suppression = $config['suppression'];
+	$parse_error = FALSE;
+
+	if ($vtype == '_v4' && $pftype == 'auto') {
+		if (strpos($line, '-') !== FALSE && strpos($line, ':') !== FALSE) {
+			$line = str_replace(':', '', strstr($line, ':', FALSE));
+		}
+		if (strpos($line, ' ') !== FALSE) {
+			$line = strstr($line, ' ', TRUE);
+		}
+		if (strpos($line, '#') !== FALSE) {
+			$line = str_replace('#', '', strstr($line, '#', TRUE));
+		}
+		$line = trim($line);
+
+		if (strpos($line, '-') !== FALSE) {
+			$matches = explode('-', $line);
+			if (count($matches) == 2) {
+				$a_cidr = ip_range_to_subnet_array($matches[0], $matches[1]);
+				if (!empty($a_cidr)) {
+					foreach ($a_cidr as $cidr) {
+						$sanitized = pfb_sanitize_ipaddr($cidr, $custom, $pfbcidr, $suppression);
+						$result['messages'] = array_merge($result['messages'], $sanitized['messages']);
+						if (!empty($sanitized['address'])) {
+							if (validate_ipv4($sanitized['address'])) {
+								$result['entries'][] = $sanitized['address'];
+							} else {
+								$parse_error = TRUE;
+							}
+						}
+					}
+					if (!$parse_error) {
+						$result['line'] = $line;
+						return $result;
+					}
+				}
+			} else {
+				$parse_error = TRUE;
+			}
+		}
+
+		if (!$parse_error) {
+			$sanitized = pfb_sanitize_ipaddr($line, $custom, $pfbcidr, $suppression);
+			$result['messages'] = array_merge($result['messages'], $sanitized['messages']);
+			if (!empty($sanitized['address']) && validate_ipv4($sanitized['address'])) {
+				$result['entries'][] = $sanitized['address'];
+				$result['line'] = $line;
+				return $result;
+			}
+			$parse_error = TRUE;
+		}
+	}
+
+	if ($vtype == '_v4' && ($pftype == 'regex' || $parse_error)) {
+		if (strpos($raw_line, '-') !== FALSE && strpos($raw_line, '.') !== FALSE &&
+			preg_match($config['range'], $raw_line, $matches)) {
+			$a_cidr = ip_range_to_subnet_array($matches[1], $matches[2]);
+			if (!empty($a_cidr)) {
+				foreach ($a_cidr as $cidr) {
+					$sanitized = pfb_sanitize_ipaddr($cidr, $custom, $pfbcidr, $suppression);
+					$result['messages'] = array_merge($result['messages'], $sanitized['messages']);
+					if (!empty($sanitized['address']) && validate_ipv4($sanitized['address'])) {
+						$result['entries'][] = $sanitized['address'];
+					} else {
+						$result['parse_fail_delta']++;
+					}
+				}
+			}
+			$result['line'] = $line;
+			return $result;
+		}
+
+		if (substr_count($raw_line, '.') >= 3 && preg_match_all($config['ipv4'], $raw_line, $matches)) {
+			foreach (array_unique($matches[0]) as $match) {
+				if (strpos($raw_line, 'cf-footer-item') === FALSE) {
+					$sanitized = pfb_sanitize_ipaddr($match, $custom, $pfbcidr, $suppression);
+					$result['messages'] = array_merge($result['messages'], $sanitized['messages']);
+					if (!empty($sanitized['address']) && validate_ipv4($sanitized['address'])) {
+						$result['entries'][] = $sanitized['address'];
+					}
+				}
+			}
+			$result['line'] = $line;
+			return $result;
+		}
+	}
+
+	if ($vtype == '_v6') {
+		if ($pftype == 'auto' && strpos($line, ':') !== FALSE) {
+			if (strpos($line, '#') !== FALSE) {
+				$line = str_replace('#', '', strstr($line, '#', TRUE));
+			}
+			if (validate_ipv6($line)) {
+				$sanitized = pfb_sanitize_ipaddr_v6($line, $custom, $pfbcidr_v6, $suppression);
+				$result['messages'] = array_merge($result['messages'], $sanitized['messages']);
+				if (!empty($sanitized['address'])) {
+					$result['entries'][] = $sanitized['address'];
+				} else {
+					$result['suppressed'] = TRUE;
+				}
+				$result['line'] = $line;
+				return $result;
+			}
+		}
+
+		if (strpos($line, '-') !== FALSE && strpos($line, ':') !== FALSE) {
+			$matches = explode('-', $line);
+			if (count($matches) == 2) {
+				$a_cidr = ip_range_to_subnet_array($matches[0], $matches[1]);
+				if (!empty($a_cidr)) {
+					foreach ($a_cidr as $cidr) {
+						if (!empty($cidr)) {
+							if (validate_ipv6($cidr)) {
+								$sanitized = pfb_sanitize_ipaddr_v6($cidr, $custom, $pfbcidr_v6, $suppression);
+								$result['messages'] = array_merge($result['messages'], $sanitized['messages']);
+								if (!empty($sanitized['address'])) {
+									$result['entries'][] = $sanitized['address'];
+								} else {
+									$result['suppressed'] = TRUE;
+								}
+							} else {
+								$parse_error = TRUE;
+							}
+						}
+					}
+				}
+				if (!$parse_error) {
+					$result['line'] = $line;
+					return $result;
+				}
+			} else {
+				$parse_error = TRUE;
+			}
+		}
+
+		if (strpos($raw_line, ':') !== FALSE && preg_match_all($config['ipv6'], $raw_line, $matches)) {
+			foreach (array_unique($matches[0]) as $match) {
+				if (strpos($match, '#') !== FALSE) {
+					$match = str_replace('#', '', strstr($match, '#', TRUE));
+				}
+				if (strpos($raw_line, 'cf-footer-item') === FALSE && validate_ipv6($match)) {
+					$sanitized = pfb_sanitize_ipaddr_v6($match, $custom, $pfbcidr_v6, $suppression);
+					$result['messages'] = array_merge($result['messages'], $sanitized['messages']);
+					if (!empty($sanitized['address'])) {
+						$result['entries'][] = $sanitized['address'];
+					} else {
+						$result['suppressed'] = TRUE;
+					}
+				}
+			}
+			$result['line'] = $line;
+			return $result;
+		}
+	}
+
+	if (!empty($line) && !preg_match('/[a-zA-Z,;|\"\'?]/', $line) && !pfb_ip_is_opposite_family($line, $vtype)) {
+		$result['parse_fail_delta']++;
+		$result['detailed_parse_fail'] = TRUE;
+	}
+	$result['line'] = $line;
+	return $result;
+}
+
 // Main pfBlockerNG function
 function sync_package_pfblockerng($cron='') {
 	global $g, $pfb, $pfbarr;
@@ -3025,225 +3212,29 @@ function sync_package_pfblockerng($cron='') {
 									// issue #1004: incremented every iteration, regardless of outcome
 									$ip_lineno++;
 
-									// Record original line for regex matching, if required.
-									$oline = $line;
-
-									// Remove any leading/trailing whitespaces
-									$line = trim($line);
-
-									// Remove commentlines and blank lines (mirrors the DNSBL hosts-
-									// format skip -- feeds mix '#'/'!'/'//' comment conventions
-									// regardless of the list's own declared format).
-									if (pfb_is_blank_or_comment_line($line)) {
-										continue;
+									$raw_line = $line;
+									$parsed_line = pfb_ip_parse_line($raw_line, [
+										'vtype'         => $list['vtype'],
+										'pftype'        => $pftype,
+										'custom'        => $custom,
+										'cidr_floor_v4' => $pfbcidr,
+										'cidr_floor_v6' => $pfbcidr_v6,
+										'suppression'   => $pfb['supp'],
+										'range'         => $pfb['range'],
+										'ipv4'          => $pfb['ipv4'],
+										'ipv6'          => $pfb['ipv6'],
+									]);
+									$line = $parsed_line['line'];
+									foreach ($parsed_line['messages'] as $message) {
+										pfb_logger($message, 1);
 									}
-
-									$parse_error = FALSE;
-									if ($list['vtype'] == '_v4' && $pftype == 'auto') {
-
-										// IBlock - parser sample ( JKS Media, LLC:4.53.2.12-4.53.2.15 )
-										// Remove leading domain name details
-										if (strpos($line, '-') !== FALSE && strpos($line, ':') !== FALSE) {
-											$line = str_replace(':', '', strstr($line, ':', FALSE));
-										}
-
-										// If 'space' character found, remove characters after space
-										if (strpos($line, ' ') !== FALSE) {
-											$line = strstr($line, ' ', TRUE);
-										}
-
-										// If '#' character found, remove characters after '#'
-										if (strpos($line, '#') !== FALSE) {
-											$line = str_replace('#', '', strstr($line, '#', TRUE));
-										}
-
-										// Remove any leading/trailing whitespaces
-										$line = trim($line);
-
-										// Range parser
-										if (strpos($line, '-') !== FALSE) {
-											$matches = explode('-', $line);
-											if (count($matches) == 2) {
-												$a_cidr = ip_range_to_subnet_array($matches[0],$matches[1]);
-												if (!empty($a_cidr)) {
-													foreach ($a_cidr as $cidr) {
-														$cidr = sanitize_ipaddr($cidr, $custom, $pfbcidr);
-														if (!empty($cidr)) {
-															if (validate_ipv4($cidr)) {
-																$ip_data .= $cidr . "\n";
-															}
-															else {
-																$parse_error = TRUE;
-															}
-														}
-													}
-													if (!$parse_error) {
-														continue;
-													}
-												}
-											}
-											else {
-												$parse_error = TRUE;
-											}
-										}
-
-										if (!$parse_error) {
-											// Single address parser
-											$parsed = sanitize_ipaddr($line, $custom, $pfbcidr);
-											if (validate_ipv4($parsed)) {
-												$ip_data .= $parsed . "\n";
-												continue;
-											}
-											else {
-												$parse_error = TRUE;
-											}
-										}
+									foreach ($parsed_line['entries'] as $entry) {
+										$ip_data .= $entry . "\n";
 									}
-
-									if ($list['vtype'] == '_v4' && ($pftype == 'regex' || $parse_error)) {
-
-										// Use regex as last alternative.
-
-										if (strpos($oline, '-') !== FALSE && strpos($oline, '.') !== FALSE) {
-											// Network range 192.168.0.0-192.168.0.254
-											if (preg_match($pfb['range'], $oline, $matches)) {
-												$a_cidr = ip_range_to_subnet_array($matches[1], $matches[2]);
-												if (!empty($a_cidr)) {
-													foreach ($a_cidr as $cidr) {
-														$cidr = sanitize_ipaddr($cidr, $custom, $pfbcidr);
-														if (validate_ipv4($cidr)) {
-															$ip_data .= $cidr . "\n";
-														}
-														else {
-															// issue #1004: detail sink deliberately Site-B-only (per-line);
-															// this per-CIDR path can fire many times per source line.
-															$parse_fail++;
-														}
-													}
-												}
-												continue;
-											}
-										}
-
-										// IPv4/CIDR format 192.168.0.0 | 192.168.0.0/16
-										// A match requires 3 literal dots; skip the regex engine on lines that cannot contain one.
-										if (substr_count($oline, '.') >= 3 && preg_match_all($pfb['ipv4'], $oline, $matches)) {
-											$matches = array_unique($matches[0]);
-											foreach ($matches as $match) {
-
-												// Workaround to skip cloudflare error pages
-												if (strpos($oline, 'cf-footer-item') === FALSE) {
-													$parsed = sanitize_ipaddr($match, $custom, $pfbcidr);
-													if (validate_ipv4($parsed)) {
-														$ip_data .= $parsed . "\n";
-													}
-												}
-											}
-											continue;
-										}
-									}
-
-									if ($list['vtype'] == '_v6') {
-										// Auto IPv6 parser
-										if ($pftype == 'auto') {
-											if (strpos($line, ':') !== FALSE) {
-
-												// Remove any comments
-												if (strpos($line, '#') !== FALSE) {
-													$line = str_replace('#', '', strstr($line, '#', TRUE));
-												}
-
-												if (validate_ipv6($line)) {
-													$parsed = sanitize_ipaddr_v6($line, $custom, $pfbcidr_v6);
-													if (!empty($parsed)) {
-														$ip_data .= $parsed . "\n";
-													}
-													else {
-														$ip_suppressed = TRUE;
-													}
-													continue;
-												}
-											}
-										}
-
-										// Range parser
-										if (strpos($line, '-') !== FALSE && strpos($line, ':') !== FALSE) {
-											$matches = explode('-', $line);
-											if (count($matches) == 2) {
-												$a_cidr = ip_range_to_subnet_array($matches[0],$matches[1]);
-												if (!empty($a_cidr)) {
-													foreach ($a_cidr as $cidr) {
-														if (!empty($cidr)) {
-															if (validate_ipv6($cidr)) {
-																$parsed = sanitize_ipaddr_v6($cidr, $custom, $pfbcidr_v6);
-																if (!empty($parsed)) {
-																	$ip_data .= $parsed . "\n";
-																}
-																else {
-																	$ip_suppressed = TRUE;
-																}
-															}
-															else {
-																$parse_error = TRUE;
-															}
-														}
-													}
-												}
-												if (!$parse_error) {
-													continue;
-												}
-											}
-											else {
-												$parse_error = TRUE;
-											}
-										}
-
-										// IPv6 Regex parser
-										// A match requires a literal colon; skip the regex engine on colon-less lines.
-										if (strpos($oline, ':') !== FALSE && preg_match_all($pfb['ipv6'], $oline, $matches)) {
-											$matches = array_unique($matches[0]);
-											foreach ($matches as $match) {
-
-												// Remove any comments
-												if (strpos($match, '#') !== FALSE) {
-													$match = str_replace('#', '', strstr($match, '#', TRUE));
-												}
-
-												// Workaround to skip cloudflare error pages
-												if (strpos($oline, 'cf-footer-item') === FALSE) {
-													if (validate_ipv6($match)) {
-														$parsed = sanitize_ipaddr_v6($match, $custom, $pfbcidr_v6);
-														if (!empty($parsed)) {
-															$ip_data .= $parsed . "\n";
-														}
-														else {
-															$ip_suppressed = TRUE;
-														}
-													}
-												}
-											}
-											// Mirrors the IPv4 regex-parser sibling block above: without this,
-											// a line the regex already matched and collected still falls
-											// through to the parse-fail heuristic below and is double-counted.
-											continue;
-										}
-									}
-
-									// Check for parse failures
-									if (!empty($line) && !preg_match('/[a-zA-Z,;|\"\'?]/', $line)) {
-
-										// A syntactically valid address of the list's OTHER family (a
-										// hex-letter-free IPv6 line in a '_v4' list, or an IPv4 line in
-										// a '_v6' list) is not a parse failure -- mixed-family feeds are
-										// common, and the family this list doesn't collect is silently
-										// skipped either way (same as any hex-lettered opposite-family
-										// address already is, uncounted). Only flag genuine garbage.
-										$other_family_addr = pfb_ip_is_opposite_family($line, $list['vtype']);
-
-										if (!$other_family_addr) {
-											$parse_fail++;
-											pfb_parse_fail_log($header, $line, $oline, $pfb['ip_parse_err'], $ip_lineno, TRUE);
-										}
+									$ip_suppressed = $ip_suppressed || $parsed_line['suppressed'];
+									$parse_fail += $parsed_line['parse_fail_delta'];
+									if ($parsed_line['detailed_parse_fail']) {
+										pfb_parse_fail_log($header, $line, $raw_line, $pfb['ip_parse_err'], $ip_lineno, TRUE);
 									}
 								}
 							}

--- a/tests/php/IpParseLineTest.php
+++ b/tests/php/IpParseLineTest.php
@@ -38,6 +38,22 @@ final class IpParseLineTest extends TestCase
 		$this->assertSame($expected, pfb_ip_parse_line($raw, $config), "unexpected result for {$raw}");
 	}
 
+	/**
+	 * @param array{entries?:list<string>,suppressed?:bool,parse_fail_delta?:int,detailed_parse_fail?:bool,messages?:list<string>} $overrides
+	 * @return array{entries:list<string>,line:string,suppressed:bool,parse_fail_delta:int,detailed_parse_fail:bool,messages:list<string>}
+	 */
+	private function expectedResult(string $line, array $overrides = []): array
+	{
+		return array_replace([
+			'entries'             => [],
+			'line'                => $line,
+			'suppressed'          => FALSE,
+			'parse_fail_delta'    => 0,
+			'detailed_parse_fail' => FALSE,
+			'messages'            => [],
+		], $overrides);
+	}
+
 	public function testBlankAndCommentPrefixesAreSkippedAfterTrim(): void
 	{
 		$config = $this->config('_v4');
@@ -65,106 +81,107 @@ final class IpParseLineTest extends TestCase
 	public function testIpv4AutoIblockAndRangeExpand(): void
 	{
 		$config = $this->config('_v4');
-		$result = pfb_ip_parse_line('JKS Media, LLC:4.53.2.12-4.53.2.15', $config);
-		$this->assertSame(['4.53.2.12/30'], $result['entries']);
-		$this->assertSame(0, $result['parse_fail_delta']);
-		$this->assertFalse($result['detailed_parse_fail']);
-
-		$result = pfb_ip_parse_line('192.0.2.1-192.0.2.2', $config);
-		$this->assertSame(['192.0.2.1', '192.0.2.2'], $result['entries']);
+		$this->assertLine('JKS Media, LLC:4.53.2.12-4.53.2.15', $config, $this->expectedResult(
+			'4.53.2.12-4.53.2.15',
+			['entries' => ['4.53.2.12/30']]
+		));
+		$this->assertLine('192.0.2.1-192.0.2.2', $config, $this->expectedResult(
+			'192.0.2.1-192.0.2.2',
+			['entries' => ['192.0.2.1', '192.0.2.2']]
+		));
 	}
 
 	public function testIpv4RegexDeduplicatesAndSkipsCloudflare(): void
 	{
 		$config = $this->config('_v4', 'regex');
-		$result = pfb_ip_parse_line('from 1.2.3.4 to 1.2.3.4 and 5.6.7.8', $config);
-		$this->assertSame(['1.2.3.4', '5.6.7.8'], $result['entries']);
-		$this->assertSame(0, $result['parse_fail_delta']);
-		$this->assertSame([], pfb_ip_parse_line('cf-footer-item 1.2.3.4', $config)['entries']);
-		$this->assertSame([], pfb_ip_parse_line('version 1.2.3', $config)['entries']);
+		$this->assertLine('from 1.2.3.4 to 1.2.3.4 and 5.6.7.8', $config, $this->expectedResult(
+			'from 1.2.3.4 to 1.2.3.4 and 5.6.7.8',
+			['entries' => ['1.2.3.4', '5.6.7.8']]
+		));
+		$this->assertLine('cf-footer-item 1.2.3.4', $config, $this->expectedResult('cf-footer-item 1.2.3.4'));
+		$this->assertLine('version 1.2.3', $config, $this->expectedResult('version 1.2.3'));
 	}
 
 	public function testIpv4SuppressionFloorReplaysCoreMessage(): void
 	{
 		$config = $this->config('_v4', 'auto', FALSE, 'on', 24);
-		$result = pfb_ip_parse_line('8.8.8.0/16', $config);
-		$this->assertSame(['8.8.8.0/32'], $result['entries']);
-		$this->assertSame(["\n  Suppression CIDR Limit: 8.8.8.0/16"], $result['messages']);
+		$this->assertLine('8.8.8.0/16', $config, $this->expectedResult('8.8.8.0/16', [
+			'entries'  => ['8.8.8.0/32'],
+			'messages' => ["\n  Suppression CIDR Limit: 8.8.8.0/16"],
+		]));
 	}
 
 	public function testIpv4RegexRangeCountsEachSuppressedExpandedCidr(): void
 	{
-		$result = pfb_ip_parse_line(
+		$this->assertLine(
 			'192.0.2.1-192.0.2.10',
-			$this->config('_v4', 'regex', FALSE, 'on')
+			$this->config('_v4', 'regex', FALSE, 'on'),
+			$this->expectedResult('192.0.2.1-192.0.2.10', ['parse_fail_delta' => 5])
 		);
-		$this->assertSame([], $result['entries']);
-		$this->assertSame(5, $result['parse_fail_delta']);
-		$this->assertFalse($result['detailed_parse_fail']);
 	}
 
 	public function testMalformedNumericLineRequestsDetailedParseFailureButAlphabeticIsSilent(): void
 	{
 		$config = $this->config('_v4');
-		$result = pfb_ip_parse_line('999.999.999.999', $config);
-		$this->assertSame([], $result['entries']);
-		$this->assertSame(1, $result['parse_fail_delta']);
-		$this->assertTrue($result['detailed_parse_fail']);
-		$this->assertSame(0, pfb_ip_parse_line('not-an-address', $config)['parse_fail_delta']);
-		$this->assertSame(0, pfb_ip_parse_line('0', $config)['parse_fail_delta']);
+		$this->assertLine('999.999.999.999', $config, $this->expectedResult('999.999.999.999', [
+			'parse_fail_delta'    => 1,
+			'detailed_parse_fail' => TRUE,
+		]));
+		$this->assertLine('not-an-address', $config, $this->expectedResult('not-an-address'));
+		$this->assertLine('0', $config, $this->expectedResult('0'));
 	}
 
 	public function testOppositeFamilyIsSilentlySkipped(): void
 	{
-		$v4 = pfb_ip_parse_line('2001:db8::1', $this->config('_v4'));
-		$this->assertSame([], $v4['entries']);
-		$this->assertSame(0, $v4['parse_fail_delta']);
-		$v6 = pfb_ip_parse_line('192.0.2.1', $this->config('_v6'));
-		$this->assertSame([], $v6['entries']);
-		$this->assertSame(0, $v6['parse_fail_delta']);
+		$this->assertLine('2001:db8::1', $this->config('_v4'), $this->expectedResult('2001:db8::1'));
+		$this->assertLine('192.0.2.1', $this->config('_v6'), $this->expectedResult('192.0.2.1'));
 	}
 
 	public function testIpv6AutoCanonicalisesCommentsAndMarksSuppression(): void
 	{
 		$config = $this->config('_v6');
-		$result = pfb_ip_parse_line('2001:0db8::1 # note', $config);
-		$this->assertSame(['2001:db8::1'], $result['entries']);
-		$this->assertSame('2001:0db8::1 ', $result['line']);
-		$suppressed = pfb_ip_parse_line('fc00::1', $this->config('_v6', 'auto', FALSE, 'on'));
-		$this->assertSame([], $suppressed['entries']);
-		$this->assertTrue($suppressed['suppressed']);
+		$this->assertLine('2001:0db8::1 # note', $config, $this->expectedResult(
+			'2001:0db8::1 ',
+			['entries' => ['2001:db8::1']]
+		));
+		$this->assertLine('fc00::1', $this->config('_v6', 'auto', FALSE, 'on'), $this->expectedResult(
+			'fc00::1',
+			['suppressed' => TRUE]
+		));
 	}
 
 	public function testIpv6RangeAndMalformedRangeFallThroughToRegexOrFailure(): void
 	{
 		$config = $this->config('_v6');
-		$result = pfb_ip_parse_line('2001:db8::1-2001:db8::2', $config);
-		$this->assertSame(['2001:db8::1/128', '2001:db8::2/128'], $result['entries']);
+		$this->assertLine('2001:db8::1-2001:db8::2', $config, $this->expectedResult(
+			'2001:db8::1-2001:db8::2',
+			['entries' => ['2001:db8::1/128', '2001:db8::2/128']]
+		));
 		$badConfig = $config;
 		$badConfig['ipv6'] = '/(?:(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4})/';
-		$malformed = pfb_ip_parse_line('1234:5678', $badConfig);
-		$this->assertSame(1, $malformed['parse_fail_delta']);
-		$this->assertTrue($malformed['detailed_parse_fail']);
+		$this->assertLine('1234:5678', $badConfig, $this->expectedResult('1234:5678', [
+			'parse_fail_delta'    => 1,
+			'detailed_parse_fail' => TRUE,
+		]));
 	}
 
 	public function testIpv6RegexDeduplicatesCloudflareAndComments(): void
 	{
 		$config = $this->config('_v6', 'regex');
-		$result = pfb_ip_parse_line('from 2001:db8::1#note to 2001:db8::1', $config);
-		$this->assertSame(['2001:db8::1'], $result['entries']);
-		$this->assertSame([], pfb_ip_parse_line('cf-footer-item 2001:db8::1', $config)['entries']);
-		$this->assertSame([], pfb_ip_parse_line('plain-hostname', $config)['entries']);
+		$this->assertLine('from 2001:db8::1#note to 2001:db8::1', $config, $this->expectedResult(
+			'from 2001:db8::1#note to 2001:db8::1',
+			['entries' => ['2001:db8::1']]
+		));
+		$this->assertLine('cf-footer-item 2001:db8::1', $config, $this->expectedResult('cf-footer-item 2001:db8::1'));
+		$this->assertLine('plain-hostname', $config, $this->expectedResult('plain-hostname'));
 	}
 
 	public function testHostileWhitespaceQuotesAndInvalidUtf8StayPure(): void
 	{
 		$config = $this->config('_v4', 'regex');
-		$this->assertSame(['1.2.3.4'], pfb_ip_parse_line("\t 1.2.3.4  \t", $config)['entries']);
-		$quoted = pfb_ip_parse_line('"1.2.3.4"', $config);
-		$this->assertSame(['1.2.3.4'], $quoted['entries']);
-		$this->assertSame(0, $quoted['parse_fail_delta']);
-		$invalid = pfb_ip_parse_line("\xFF1.2.3.4", $config);
-		$this->assertIsArray($invalid);
+		$this->assertLine("\t 1.2.3.4  \t", $config, $this->expectedResult('1.2.3.4', ['entries' => ['1.2.3.4']]));
+		$this->assertLine('"1.2.3.4"', $config, $this->expectedResult('"1.2.3.4"', ['entries' => ['1.2.3.4']]));
+		$this->assertLine("\xFF1.2.3.4", $config, $this->expectedResult("\xFF1.2.3.4", ['entries' => ['1.2.3.4']]));
 	}
 
 	public function testNonStringInputRaisesTypeErrorAtTrustBoundary(): void
@@ -177,17 +194,18 @@ final class IpParseLineTest extends TestCase
 	public function testOversizedNumericLineReturnsBoundedResultWithoutWriting(): void
 	{
 		$line = str_repeat('9', 100000);
-		$result = pfb_ip_parse_line($line, $this->config('_v4'));
-		$this->assertSame([], $result['entries']);
-		$this->assertSame(1, $result['parse_fail_delta']);
-		$this->assertSame(100000, strlen($result['line']));
+		$this->assertLine($line, $this->config('_v4'), $this->expectedResult($line, [
+			'parse_fail_delta'    => 1,
+			'detailed_parse_fail' => TRUE,
+		]));
 	}
 
 	public function testIpv4AutoMalformedRangeFallsThroughToRegex(): void
 	{
-		$result = pfb_ip_parse_line('1.2.3.4-1.2.3.5-extra', $this->config('_v4'));
-		$this->assertSame(['1.2.3.4/31'], $result['entries']);
-		$this->assertSame(0, $result['parse_fail_delta']);
+		$this->assertLine('1.2.3.4-1.2.3.5-extra', $this->config('_v4'), $this->expectedResult(
+			'1.2.3.4-1.2.3.5-extra',
+			['entries' => ['1.2.3.4/31']]
+		));
 	}
 
 	public function testIpv6EmptyAndInvalidRangesDoNotEmitEntries(): void
@@ -195,9 +213,7 @@ final class IpParseLineTest extends TestCase
 		$config = $this->config('_v6');
 		$config['ipv6'] = '/(?:(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4})/';
 		foreach (['2001:db8::1-', '1234:5678-1234:5678'] as $line) {
-			$result = pfb_ip_parse_line($line, $config);
-			$this->assertSame([], $result['entries'], $line);
-			$this->assertSame(0, $result['parse_fail_delta'], $line);
+			$this->assertLine($line, $config, $this->expectedResult($line));
 		}
 	}
 }

--- a/tests/php/IpParseLineTest.php
+++ b/tests/php/IpParseLineTest.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Direct matrix for the pure generic IP-feed line parser extracted from the
  * sync loop.  The result array is the complete handoff contract to that loop.
  */
+#[CoversFunction('pfb_ip_parse_line')]
 final class IpParseLineTest extends TestCase
 {
 	private const RANGE = '/((?:\d{1,3}\.){3}\d{1,3})-((?:\d{1,3}\.){3}\d{1,3})/';

--- a/tests/php/IpParseLineTest.php
+++ b/tests/php/IpParseLineTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Direct matrix for the pure generic IP-feed line parser extracted from the
+ * sync loop.  The result array is the complete handoff contract to that loop.
+ */
+final class IpParseLineTest extends TestCase
+{
+	private const RANGE = '/((?:\d{1,3}\.){3}\d{1,3})-((?:\d{1,3}\.){3}\d{1,3})/';
+	private const IPV4 = '/(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\/\d{1,2})?/';
+	private const IPV6 = '/[0-9A-Fa-f:]+(?:\/\d{1,3})?/';
+
+	/** @return array{vtype:string,pftype:string,custom:bool,cidr_floor_v4:int|string,cidr_floor_v6:int|string,suppression:string,range:string,ipv4:string,ipv6:string} */
+	private function config(string $vtype, string $pftype = 'auto', bool $custom = TRUE, string $suppression = 'off', int|string $v4Floor = 'Disabled', int|string $v6Floor = 'Disabled'): array
+	{
+		return [
+			'vtype'         => $vtype,
+			'pftype'        => $pftype,
+			'custom'        => $custom,
+			'cidr_floor_v4' => $v4Floor,
+			'cidr_floor_v6' => $v6Floor,
+			'suppression'   => $suppression,
+			'range'         => self::RANGE,
+			'ipv4'          => self::IPV4,
+			'ipv6'          => self::IPV6,
+		];
+	}
+
+	/** @param array<string,mixed> $expected */
+	private function assertLine(string $raw, array $config, array $expected): void
+	{
+		$this->assertSame($expected, pfb_ip_parse_line($raw, $config), "unexpected result for {$raw}");
+	}
+
+	public function testBlankAndCommentPrefixesAreSkippedAfterTrim(): void
+	{
+		$config = $this->config('_v4');
+		foreach (["  \n", ' # comment', ' ! generated', ' // generated'] as $line) {
+			$this->assertLine($line, $config, [
+				'entries' => [], 'line' => trim($line), 'suppressed' => FALSE,
+				'parse_fail_delta' => 0, 'detailed_parse_fail' => FALSE, 'messages' => [],
+			]);
+		}
+	}
+
+	public function testIpv4AutoHostCidrAndCommentsPreserveOrder(): void
+	{
+		$config = $this->config('_v4');
+		$this->assertLine("  1.2.3.4/32 # trailing\n", $config, [
+			'entries' => ['1.2.3.4'], 'line' => '1.2.3.4/32', 'suppressed' => FALSE,
+			'parse_fail_delta' => 0, 'detailed_parse_fail' => FALSE, 'messages' => [],
+		]);
+		$this->assertLine('1.2.3.0/24', $config, [
+			'entries' => ['1.2.3.0/24'], 'line' => '1.2.3.0/24', 'suppressed' => FALSE,
+			'parse_fail_delta' => 0, 'detailed_parse_fail' => FALSE, 'messages' => [],
+		]);
+	}
+
+	public function testIpv4AutoIblockAndRangeExpand(): void
+	{
+		$config = $this->config('_v4');
+		$result = pfb_ip_parse_line('JKS Media, LLC:4.53.2.12-4.53.2.15', $config);
+		$this->assertSame(['4.53.2.12/30'], $result['entries']);
+		$this->assertSame(0, $result['parse_fail_delta']);
+		$this->assertFalse($result['detailed_parse_fail']);
+
+		$result = pfb_ip_parse_line('192.0.2.1-192.0.2.2', $config);
+		$this->assertSame(['192.0.2.1', '192.0.2.2'], $result['entries']);
+	}
+
+	public function testIpv4RegexDeduplicatesAndSkipsCloudflare(): void
+	{
+		$config = $this->config('_v4', 'regex');
+		$result = pfb_ip_parse_line('from 1.2.3.4 to 1.2.3.4 and 5.6.7.8', $config);
+		$this->assertSame(['1.2.3.4', '5.6.7.8'], $result['entries']);
+		$this->assertSame(0, $result['parse_fail_delta']);
+		$this->assertSame([], pfb_ip_parse_line('cf-footer-item 1.2.3.4', $config)['entries']);
+		$this->assertSame([], pfb_ip_parse_line('version 1.2.3', $config)['entries']);
+	}
+
+	public function testIpv4SuppressionFloorReplaysCoreMessage(): void
+	{
+		$config = $this->config('_v4', 'auto', FALSE, 'on', 24);
+		$result = pfb_ip_parse_line('8.8.8.0/16', $config);
+		$this->assertSame(['8.8.8.0/32'], $result['entries']);
+		$this->assertSame(["\n  Suppression CIDR Limit: 8.8.8.0/16"], $result['messages']);
+	}
+
+	public function testIpv4RegexRangeCountsEachSuppressedExpandedCidr(): void
+	{
+		$result = pfb_ip_parse_line(
+			'192.0.2.1-192.0.2.10',
+			$this->config('_v4', 'regex', FALSE, 'on')
+		);
+		$this->assertSame([], $result['entries']);
+		$this->assertSame(5, $result['parse_fail_delta']);
+		$this->assertFalse($result['detailed_parse_fail']);
+	}
+
+	public function testMalformedNumericLineRequestsDetailedParseFailureButAlphabeticIsSilent(): void
+	{
+		$config = $this->config('_v4');
+		$result = pfb_ip_parse_line('999.999.999.999', $config);
+		$this->assertSame([], $result['entries']);
+		$this->assertSame(1, $result['parse_fail_delta']);
+		$this->assertTrue($result['detailed_parse_fail']);
+		$this->assertSame(0, pfb_ip_parse_line('not-an-address', $config)['parse_fail_delta']);
+		$this->assertSame(0, pfb_ip_parse_line('0', $config)['parse_fail_delta']);
+	}
+
+	public function testOppositeFamilyIsSilentlySkipped(): void
+	{
+		$v4 = pfb_ip_parse_line('2001:db8::1', $this->config('_v4'));
+		$this->assertSame([], $v4['entries']);
+		$this->assertSame(0, $v4['parse_fail_delta']);
+		$v6 = pfb_ip_parse_line('192.0.2.1', $this->config('_v6'));
+		$this->assertSame([], $v6['entries']);
+		$this->assertSame(0, $v6['parse_fail_delta']);
+	}
+
+	public function testIpv6AutoCanonicalisesCommentsAndMarksSuppression(): void
+	{
+		$config = $this->config('_v6');
+		$result = pfb_ip_parse_line('2001:0db8::1 # note', $config);
+		$this->assertSame(['2001:db8::1'], $result['entries']);
+		$this->assertSame('2001:0db8::1 ', $result['line']);
+		$suppressed = pfb_ip_parse_line('fc00::1', $this->config('_v6', 'auto', FALSE, 'on'));
+		$this->assertSame([], $suppressed['entries']);
+		$this->assertTrue($suppressed['suppressed']);
+	}
+
+	public function testIpv6RangeAndMalformedRangeFallThroughToRegexOrFailure(): void
+	{
+		$config = $this->config('_v6');
+		$result = pfb_ip_parse_line('2001:db8::1-2001:db8::2', $config);
+		$this->assertSame(['2001:db8::1/128', '2001:db8::2/128'], $result['entries']);
+		$badConfig = $config;
+		$badConfig['ipv6'] = '/(?:(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4})/';
+		$malformed = pfb_ip_parse_line('1234:5678', $badConfig);
+		$this->assertSame(1, $malformed['parse_fail_delta']);
+		$this->assertTrue($malformed['detailed_parse_fail']);
+	}
+
+	public function testIpv6RegexDeduplicatesCloudflareAndComments(): void
+	{
+		$config = $this->config('_v6', 'regex');
+		$result = pfb_ip_parse_line('from 2001:db8::1#note to 2001:db8::1', $config);
+		$this->assertSame(['2001:db8::1'], $result['entries']);
+		$this->assertSame([], pfb_ip_parse_line('cf-footer-item 2001:db8::1', $config)['entries']);
+		$this->assertSame([], pfb_ip_parse_line('plain-hostname', $config)['entries']);
+	}
+
+	public function testHostileWhitespaceQuotesAndInvalidUtf8StayPure(): void
+	{
+		$config = $this->config('_v4', 'regex');
+		$this->assertSame(['1.2.3.4'], pfb_ip_parse_line("\t 1.2.3.4  \t", $config)['entries']);
+		$quoted = pfb_ip_parse_line('"1.2.3.4"', $config);
+		$this->assertSame(['1.2.3.4'], $quoted['entries']);
+		$this->assertSame(0, $quoted['parse_fail_delta']);
+		$invalid = pfb_ip_parse_line("\xFF1.2.3.4", $config);
+		$this->assertIsArray($invalid);
+	}
+
+	public function testNonStringInputRaisesTypeErrorAtTrustBoundary(): void
+	{
+		$this->expectException(TypeError::class);
+		/** @phpstan-ignore-next-line intentionally hostile non-string input */
+		pfb_ip_parse_line([], $this->config('_v4'));
+	}
+
+	public function testOversizedNumericLineReturnsBoundedResultWithoutWriting(): void
+	{
+		$line = str_repeat('9', 100000);
+		$result = pfb_ip_parse_line($line, $this->config('_v4'));
+		$this->assertSame([], $result['entries']);
+		$this->assertSame(1, $result['parse_fail_delta']);
+		$this->assertSame(100000, strlen($result['line']));
+	}
+
+	public function testIpv4AutoMalformedRangeFallsThroughToRegex(): void
+	{
+		$result = pfb_ip_parse_line('1.2.3.4-1.2.3.5-extra', $this->config('_v4'));
+		$this->assertSame(['1.2.3.4/31'], $result['entries']);
+		$this->assertSame(0, $result['parse_fail_delta']);
+	}
+
+	public function testIpv6EmptyAndInvalidRangesDoNotEmitEntries(): void
+	{
+		$config = $this->config('_v6');
+		$config['ipv6'] = '/(?:(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4})/';
+		foreach (['2001:db8::1-', '1234:5678-1234:5678'] as $line) {
+			$result = pfb_ip_parse_line($line, $config);
+			$this->assertSame([], $result['entries'], $line);
+			$this->assertSame(0, $result['parse_fail_delta'], $line);
+		}
+	}
+}

--- a/tests/php/IpParseLineWiringTest.php
+++ b/tests/php/IpParseLineWiringTest.php
@@ -50,11 +50,21 @@ final class IpParseLineWiringTest extends TestCase
 		foreach ($replayContract as $effect => $needle) {
 			$this->assertStringContainsString($needle, $loop, "missing parser replay effect: {$effect}");
 		}
-		$this->assertStringContainsString('$ip_lineno++;', $loop);
+		$lineNumber = strpos($loop, '$ip_lineno++;');
+		$parseCall = strpos($loop, '$parsed_line = pfb_ip_parse_line(');
+		$this->assertNotFalse($lineNumber, 'line-number increment missing');
+		$this->assertNotFalse($parseCall, 'parser invocation missing');
+		$this->assertLessThan($parseCall, $lineNumber, 'line number must increment before parsing and diagnostics');
 		$this->assertStringContainsString('pfb_ip_parse_fail_warn($parse_fail, $header);', self::$source);
-		$this->assertStringContainsString(
-			"if (empty(\$ip_data) && \$ip_suppressed && \$list['vtype'] == '_v6')",
-			self::$source
-		);
+
+		$placeholderStart = strpos(self::$source, "if (empty(\$ip_data) && \$ip_suppressed && \$list['vtype'] == '_v6')");
+		$this->assertNotFalse($placeholderStart, 'suppressed-IPv6 placeholder gate missing');
+		$placeholderEnd = strpos(self::$source, 'if (!empty($ip_data))', (int) $placeholderStart);
+		$this->assertNotFalse($placeholderEnd, 'suppressed-IPv6 placeholder block end missing');
+		$placeholder = substr(self::$source, (int) $placeholderStart, (int) $placeholderEnd - (int) $placeholderStart);
+		$this->assertStringContainsString('$p_ip     = "::{$pfb[\'ip_ph\']}";', $placeholder);
+		$this->assertStringContainsString('$ip_data  = "{$p_ip}\\n";', $placeholder);
+		$this->assertStringContainsString('All IPv6 entries suppressed', $placeholder);
+		$this->assertStringContainsString('pfb_logger(', $placeholder);
 	}
 }

--- a/tests/php/IpParseLineWiringTest.php
+++ b/tests/php/IpParseLineWiringTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The feed loop must delegate each raw line to the pure parser seam.  This
+ * source pin keeps the extraction honest: the old family/parser branches must
+ * not remain inline where they can silently diverge from the helper.
+ */
+final class IpParseLineWiringTest extends TestCase
+{
+	private static string $source;
+
+	public static function setUpBeforeClass(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+		self::$source = (string) file_get_contents($path);
+	}
+
+	public function testSyncLoopDelegatesRawLineToPureParser(): void
+	{
+		$ipPass = strpos(self::$source, '$ip_lineno = 0');
+		$this->assertNotFalse($ipPass, 'IP feed parser setup not found');
+		$loopStart = strpos(self::$source, 'while (($line = @fgets($fhandle)) !== FALSE)', (int) $ipPass);
+		$this->assertNotFalse($loopStart, 'sync feed loop not found');
+		$loopEnd = strpos(self::$source, 'if ($fhandle)', (int) $loopStart);
+		$this->assertNotFalse($loopEnd, 'sync feed loop end not found');
+		$loop = substr(self::$source, (int) $loopStart, (int) $loopEnd - (int) $loopStart);
+
+		$this->assertStringContainsString('pfb_ip_parse_line(', $loop);
+		$this->assertStringContainsString('$raw_line', $loop);
+		$this->assertStringNotContainsString("if (\$list['vtype'] == '_v4'", $loop);
+		$this->assertStringNotContainsString("if (\$list['vtype'] == '_v6'", $loop);
+		$this->assertStringNotContainsString('preg_match_all($pfb[\'ipv4\']', $loop);
+		$this->assertStringNotContainsString('preg_match_all($pfb[\'ipv6\']', $loop);
+	}
+}

--- a/tests/php/IpParseLineWiringTest.php
+++ b/tests/php/IpParseLineWiringTest.php
@@ -35,5 +35,26 @@ final class IpParseLineWiringTest extends TestCase
 		$this->assertStringNotContainsString("if (\$list['vtype'] == '_v6'", $loop);
 		$this->assertStringNotContainsString('preg_match_all($pfb[\'ipv4\']', $loop);
 		$this->assertStringNotContainsString('preg_match_all($pfb[\'ipv6\']', $loop);
+
+		$replayContract = [
+			'normalized line'       => '$line = $parsed_line[\'line\'];',
+			'ordered messages'      => 'foreach ($parsed_line[\'messages\'] as $message)',
+			'message logging'       => 'pfb_logger($message, 1);',
+			'ordered entries'       => 'foreach ($parsed_line[\'entries\'] as $entry)',
+			'newline-delimited data' => '$ip_data .= $entry . "\\n";',
+			'suppression state'     => '$ip_suppressed = $ip_suppressed || $parsed_line[\'suppressed\'];',
+			'parse-failure count'   => '$parse_fail += $parsed_line[\'parse_fail_delta\'];',
+			'detailed-failure gate' => 'if ($parsed_line[\'detailed_parse_fail\'])',
+			'detailed-failure data' => 'pfb_parse_fail_log($header, $line, $raw_line, $pfb[\'ip_parse_err\'], $ip_lineno, TRUE);',
+		];
+		foreach ($replayContract as $effect => $needle) {
+			$this->assertStringContainsString($needle, $loop, "missing parser replay effect: {$effect}");
+		}
+		$this->assertStringContainsString('$ip_lineno++;', $loop);
+		$this->assertStringContainsString('pfb_ip_parse_fail_warn($parse_fail, $header);', self::$source);
+		$this->assertStringContainsString(
+			"if (empty(\$ip_data) && \$ip_suppressed && \$list['vtype'] == '_v6')",
+			self::$source
+		);
 	}
 }

--- a/tests/php/IpRegexPrefilterGuardTest.php
+++ b/tests/php/IpRegexPrefilterGuardTest.php
@@ -195,10 +195,10 @@ final class IpRegexPrefilterGuardTest extends TestCase
 	public function testProductionGuardsArePresenceChecks(): void
 	{
 		$this->assertStringContainsString(
-			"substr_count(\$oline, '.') >= 3 && preg_match_all(\$pfb['ipv4'], \$oline, \$matches)",
+			"substr_count(\$raw_line, '.') >= 3 && preg_match_all(\$config['ipv4'], \$raw_line, \$matches)",
 			self::$src, 'IPv4 dot-count prefilter guard missing or altered');
 		$this->assertStringContainsString(
-			"strpos(\$oline, ':') !== FALSE && preg_match_all(\$pfb['ipv6'], \$oline, \$matches)",
+			"strpos(\$raw_line, ':') !== FALSE && preg_match_all(\$config['ipv6'], \$raw_line, \$matches)",
 			self::$src, 'IPv6 colon prefilter guard missing or altered');
 	}
 }

--- a/tests/php/IpRegexPrefilterGuardTest.php
+++ b/tests/php/IpRegexPrefilterGuardTest.php
@@ -6,17 +6,16 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * IP regex prefilter guards (pfblockerng_apply.inc, inside sync_package_pfblockerng,
- * not unit-reachable directly — pinned here against the real regex literals
- * extracted from the production file).
+ * IP regex prefilter guards in pfb_ip_parse_line() (pfblockerng_apply.inc),
+ * pinned here against the real regex literals extracted from the production file.
  *
- * The two preg_match_all fallback parsers run on $oline (the original feed line,
+ * The two preg_match_all fallback parsers run on $raw_line (the original feed line,
  * which may carry IPs embedded in mid-line noise) and are gated by a cheap
  * necessary-condition prefilter that skips the regex engine when the line cannot
  * possibly contain a match:
  *
- *   IPv4:  substr_count($oline, '.') >= 3 && preg_match_all($pfb['ipv4'], ...)
- *   IPv6:  strpos($oline, ':') !== FALSE && preg_match_all($pfb['ipv6'], ...)
+ *   IPv4:  substr_count($raw_line, '.') >= 3 && preg_match_all($config['ipv4'], ...)
+ *   IPv6:  strpos($raw_line, ':') !== FALSE && preg_match_all($config['ipv6'], ...)
  *
  * The guards must be necessary conditions of a match — a line the guard rejects
  * can NEVER match the regex — so the guarded path returns the byte-identical set

--- a/tests/php/SanitizeIpaddrCoreTest.php
+++ b/tests/php/SanitizeIpaddrCoreTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+#[CoversFunction('pfb_sanitize_ipaddr')]
+#[CoversFunction('pfb_sanitize_ipaddr_v6')]
+final class SanitizeIpaddrCoreTest extends TestCase
+{
+	public function testIpv4CoreReturnsAddressAndClampMessage(): void
+	{
+		$this->assertSame(
+			[
+				'address' => '1.2.3.4',
+				'messages' => ["\n  Feed /0 CIDR clamped to single host: 1.2.3.4/0"],
+			],
+			pfb_sanitize_ipaddr('1.2.3.4/0', false, 'Disabled', 'off')
+		);
+	}
+
+	public function testIpv4CoreCarriesFloorMessageBeforeDrop(): void
+	{
+		$this->assertSame(
+			[
+				'address' => NULL,
+				'messages' => ["\n  Suppression CIDR Limit: 10.0.0.5/8"],
+			],
+			pfb_sanitize_ipaddr('10.0.0.5/8', false, 24, 'on')
+		);
+	}
+
+	public function testIpv4CoreHonorsCustomSlashZero(): void
+	{
+		$this->assertSame(
+			['address' => '0.0.0.0/0', 'messages' => []],
+			pfb_sanitize_ipaddr('0.0.0.0/0', true, 'Disabled', 'on')
+		);
+	}
+
+	public function testIpv6CoreReturnsCanonicalAddressAndClampMessage(): void
+	{
+		$this->assertSame(
+			[
+				'address' => '2001:db8::1',
+				'messages' => ["\n  Feed /0 CIDR clamped to single host: 2001:DB8::1/0"],
+			],
+			pfb_sanitize_ipaddr_v6('2001:DB8::1/0', false, 'Disabled', 'off')
+		);
+	}
+
+	public function testIpv6CoreCarriesFloorMessageBeforeDrop(): void
+	{
+		$this->assertSame(
+			[
+				'address' => NULL,
+				'messages' => ["\n  Suppression CIDR Limit: fc00::1/32"],
+			],
+			pfb_sanitize_ipaddr_v6('fc00::1/32', false, 48, 'on')
+		);
+	}
+
+	public function testIpv6CoreDropsZoneWithoutMessages(): void
+	{
+		$this->assertSame(
+			['address' => NULL, 'messages' => []],
+			pfb_sanitize_ipaddr_v6('fe80::1%igb0', false, 'Disabled', 'off')
+		);
+	}
+}

--- a/tests/php/SanitizeIpaddrCoreTest.php
+++ b/tests/php/SanitizeIpaddrCoreTest.php
@@ -16,7 +16,7 @@ final class SanitizeIpaddrCoreTest extends TestCase
 				'address' => '1.2.3.4',
 				'messages' => ["\n  Feed /0 CIDR clamped to single host: 1.2.3.4/0"],
 			],
-			pfb_sanitize_ipaddr('1.2.3.4/0', false, 'Disabled', 'off')
+			pfb_sanitize_ipaddr('1.2.3.4/0', FALSE, 'Disabled', 'off')
 		);
 	}
 
@@ -27,7 +27,7 @@ final class SanitizeIpaddrCoreTest extends TestCase
 				'address' => NULL,
 				'messages' => ["\n  Suppression CIDR Limit: 10.0.0.5/8"],
 			],
-			pfb_sanitize_ipaddr('10.0.0.5/8', false, 24, 'on')
+			pfb_sanitize_ipaddr('10.0.0.5/8', FALSE, 24, 'on')
 		);
 	}
 
@@ -35,8 +35,28 @@ final class SanitizeIpaddrCoreTest extends TestCase
 	{
 		$this->assertSame(
 			['address' => '0.0.0.0/0', 'messages' => []],
-			pfb_sanitize_ipaddr('0.0.0.0/0', true, 'Disabled', 'on')
+			pfb_sanitize_ipaddr('0.0.0.0/0', TRUE, 'Disabled', 'on')
 		);
+	}
+
+	public function testIpv4CoreSuppressesReservedClassesWithoutMessages(): void
+	{
+		$addresses = [
+			'zero'             => '0.0.0.0',
+			'loopback'         => '127.0.0.1',
+			'documentation'     => '192.0.2.1',
+			'multicast'        => '224.0.0.1',
+			'carrier-grade NAT' => '100.64.0.1',
+			'benchmarking'      => '198.18.0.1',
+			'6to4 relay'        => '192.88.99.1',
+		];
+		foreach ($addresses as $class => $address) {
+			$this->assertSame(
+				['address' => NULL, 'messages' => []],
+				pfb_sanitize_ipaddr($address, FALSE, 'Disabled', 'on'),
+				"{$class} address must be suppressed without a message"
+			);
+		}
 	}
 
 	public function testIpv6CoreReturnsCanonicalAddressAndClampMessage(): void
@@ -46,7 +66,7 @@ final class SanitizeIpaddrCoreTest extends TestCase
 				'address' => '2001:db8::1',
 				'messages' => ["\n  Feed /0 CIDR clamped to single host: 2001:DB8::1/0"],
 			],
-			pfb_sanitize_ipaddr_v6('2001:DB8::1/0', false, 'Disabled', 'off')
+			pfb_sanitize_ipaddr_v6('2001:DB8::1/0', FALSE, 'Disabled', 'off')
 		);
 	}
 
@@ -57,7 +77,7 @@ final class SanitizeIpaddrCoreTest extends TestCase
 				'address' => NULL,
 				'messages' => ["\n  Suppression CIDR Limit: fc00::1/32"],
 			],
-			pfb_sanitize_ipaddr_v6('fc00::1/32', false, 48, 'on')
+			pfb_sanitize_ipaddr_v6('fc00::1/32', FALSE, 48, 'on')
 		);
 	}
 
@@ -65,7 +85,26 @@ final class SanitizeIpaddrCoreTest extends TestCase
 	{
 		$this->assertSame(
 			['address' => NULL, 'messages' => []],
-			pfb_sanitize_ipaddr_v6('fe80::1%igb0', false, 'Disabled', 'off')
+			pfb_sanitize_ipaddr_v6('fe80::1%igb0', FALSE, 'Disabled', 'off')
 		);
+	}
+
+	public function testIpv6CoreSuppressesReservedClassesWithoutMessages(): void
+	{
+		$addresses = [
+			'unique-local'  => 'fc00::1',
+			'link-local'    => 'fe80::1',
+			'loopback'      => '::1',
+			'documentation' => '2001:db8::1',
+			'multicast'     => 'ff02::1',
+			'NAT64'         => '64:ff9b::1',
+		];
+		foreach ($addresses as $class => $address) {
+			$this->assertSame(
+				['address' => NULL, 'messages' => []],
+				pfb_sanitize_ipaddr_v6($address, FALSE, 'Disabled', 'on'),
+				"{$class} address must be suppressed without a message"
+			);
+		}
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -3773,6 +3773,26 @@
             }
         ]
     },
+    "pfb_ip_parse_line": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "raw_line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "config",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
     "pfb_ip_prefetch": {
         "returnsRef": false,
         "returnType": "void",

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -6219,6 +6219,74 @@
             }
         ]
     },
+    "pfb_sanitize_ipaddr": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "ipaddr",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "custom",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfbcidr",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "supp",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_sanitize_ipaddr_v6": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "ipaddr",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "custom",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "pfbcidr",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "supp",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
     "pfb_select_reload_aliases": {
         "returnsRef": false,
         "returnType": "array",


### PR DESCRIPTION
## Summary

- extract pure IPv4/IPv6 sanitizer cores while retaining the existing logging adapters
- extract generic IP feed line parsing into `pfb_ip_parse_line()` with explicit inputs and result fields
- keep file I/O, line numbers, output writes, counters, suppression aggregation, and parse logging in `sync_package_pfblockerng()`
- add direct parser matrix, frozen delegation wiring proof, regex-prefilter coverage, and function inventory metadata

## Verification

- frozen structural proof: RED on `d4029712`, GREEN unchanged on this branch (`330fa7f50261c0b982b5797e4b83f6ce347636bb`)
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS
- PHPUnit: 3,852 tests, 22,780 assertions, 4 skips
- independent sanitizer-core gate: PASS
- independent parser semantic gate: PASS
- live pfSense CE: 7 selected parser/feed/suppression cases passed
- live pfSense Plus 26.03: 7 selected cases passed in [run 29682882591](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29682882591)

The live runs used FreeBSD-ports commit `ad074be09709` as the package-manifest input because the pre-existing apply-module split was not registered in current branch packages. Release sequencing is tracked separately in #1545; that sidecar is intentionally not merged as an alpha.21 standalone rebuild.

Fixes #1410

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved IP feed parsing for IPv4 and IPv6 addresses, including normalization, range expansion, deduplication, comment handling, and suppression rules.
  * Enhanced handling of malformed, oversized, incompatible, and invalid feed entries.
  * Improved suppression reporting and CIDR limit handling, including address clamping.

* **Tests**
  * Added comprehensive coverage for parsing, sanitization, suppression, malformed input, IPv6 handling, and parser integration.
  * Updated validation checks to reflect current feed-processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->