### PR TITLE
scripts: index every Token Savior worktree

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,6 +7,6 @@ max_depth = 2
 
 [mcp_servers.token-savior-recall]
 command = "sh"
-args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" f2a5b41ad8465b4d60afb4f7814e85c510e0ff0608be4cdd1c37c9eacdb7664c && exec sh "$root/scripts/mcp-token-savior.sh"''']
+args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" 81ab5456446f80702821e01227a19ebf1666a4ddb480599e89e98aaa4b941423 && exec sh "$root/scripts/mcp-token-savior.sh"''']
 env = { TOKEN_SAVIOR_CLIENT = "codex" }
 startup_timeout_sec = 120

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -9,8 +9,10 @@
 # a mkdir lock serializes concurrent sessions racing that rebuild (the venv is one shared
 # per-user cache). Requires python3 >= 3.11 and git (pip installs from a git URL).
 # Env (all optional):
-#   WORKSPACE_ROOTS        comma-separated project roots (default: Git worktree root
-#                          when resolvable, otherwise current directory)
+#   WORKSPACE_ROOTS        comma-separated project roots (default: every usable worktree
+#                          of the current Git repository, otherwise current directory)
+#   CLAUDE_PROJECT_ROOT    active root hint understood by Token Savior (default: current
+#                          Git worktree; applies to Claude and Codex clients)
 #   TOKEN_SAVIOR_CLIENT    telemetry client label (default: claude-code; Codex config
 #                          passes codex explicitly)
 #   TOKEN_SAVIOR_PROFILE   server tool profile (default: optimized)
@@ -82,10 +84,33 @@ if command -v git >/dev/null 2>&1; then
 	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
 	[ -z "$repo_root" ] || workspace_root=$repo_root
 fi
-WORKSPACE_ROOTS="${WORKSPACE_ROOTS:-$workspace_root}"
+if [ -z "${WORKSPACE_ROOTS:-}" ]; then
+	WORKSPACE_ROOTS=$workspace_root
+	if command -v git >/dev/null 2>&1 && [ -x "$venv/bin/python3" ]; then
+		worktree_roots=$(git worktree list --porcelain -z 2>/dev/null | "$venv/bin/python3" -c '
+import os
+import sys
+
+roots = []
+for record in sys.stdin.buffer.read().split(b"\0\0"):
+    fields = record.split(b"\0")
+    if any(field.startswith(b"prunable") for field in fields):
+        continue
+    path = next((field[9:] for field in fields if field.startswith(b"worktree ")), None)
+    if path is None:
+        continue
+    root = os.path.abspath(os.fsdecode(path))
+    if os.path.isdir(root):
+        roots.append(root)
+sys.stdout.write(",".join(roots))
+' || true)
+		[ -z "$worktree_roots" ] || WORKSPACE_ROOTS=$worktree_roots
+	fi
+fi
+CLAUDE_PROJECT_ROOT="${CLAUDE_PROJECT_ROOT:-$workspace_root}"
 TOKEN_SAVIOR_CLIENT="${TOKEN_SAVIOR_CLIENT:-claude-code}"
 TOKEN_SAVIOR_PROFILE="${TOKEN_SAVIOR_PROFILE:-optimized}"
 INCLUDE_PATTERNS="${INCLUDE_PATTERNS:-**/*.py:**/*.php:**/*.inc:**/*.sh:**/*.js:**/*.md:**/*.txt:**/*.json:**/*.jsonc:**/*.yml:**/*.yaml:**/*.xml:**/*.conf:**/*.toml:**/*.neon}"
 TOKEN_SAVIOR_MAX_FILE_SIZE="${TOKEN_SAVIOR_MAX_FILE_SIZE:-2000000}"
-export WORKSPACE_ROOTS TOKEN_SAVIOR_CLIENT TOKEN_SAVIOR_PROFILE INCLUDE_PATTERNS TOKEN_SAVIOR_MAX_FILE_SIZE
+export WORKSPACE_ROOTS CLAUDE_PROJECT_ROOT TOKEN_SAVIOR_CLIENT TOKEN_SAVIOR_PROFILE INCLUDE_PATTERNS TOKEN_SAVIOR_MAX_FILE_SIZE
 exec "$bin"

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -20,6 +20,7 @@ printf '%s\n' "${INCLUDE_PATTERNS:-UNSET}"
 printf '%s\n' "${TOKEN_SAVIOR_MAX_FILE_SIZE:-UNSET}"
 printf '%s\n' "${TOKEN_SAVIOR_CLIENT:-UNSET}"
 printf '%s\n' "${WORKSPACE_ROOTS:-UNSET}"
+printf '%s\n' "${CLAUDE_PROJECT_ROOT:-UNSET}"
 EOF
     chmod +x "${WORK}/venv/bin/token-savior"
     default_source="$(sed -n 's/^TS_SOURCE="\${TS_SOURCE:-\(.*\)}"$/\1/p' "${SCRIPT}")"
@@ -27,6 +28,7 @@ EOF
     # silently send every example down the slow venv-rebuild path.
     [ -n "${default_source}" ] || { echo "TS_SOURCE extraction failed — launcher line reformatted?" >&2; return 1; }
     printf '%s\n' "${default_source}" > "${WORK}/venv/.pfb-ts-source"
+    ln -s "$(command -v python3)" "${WORK}/venv/bin/python3"
   }
 
   cleanup() { [ -n "${WORK}" ] && rm -rf "${WORK}"; [ ! -d "${WORK}" ] || return 1; }
@@ -72,10 +74,40 @@ EOF
     The line 3 of output should equal 'codex'
   End
 
-  It 'uses the Git worktree root when launched from a subdirectory'
+  It 'registers every usable worktree and makes the current worktree active'
+    mkdir -p "${WORK}/repo root" "${WORK}/detached tree" "${WORK}/prunable tree" "${WORK}/shim"
+    cat > "${WORK}/shim/git" << 'EOF'
+#!/bin/sh
+case "$*" in
+  'rev-parse --show-toplevel') printf '%s\n' "${FAKE_DETACHED}" ;;
+  'worktree list --porcelain -z')
+    printf 'worktree %s\0HEAD 1111111\0branch refs/heads/main\0\0' "${FAKE_PRIMARY}"
+    printf 'worktree %s\0HEAD 2222222\0detached\0\0' "${FAKE_DETACHED}"
+    printf 'worktree %s\0HEAD 3333333\0detached\0\0' "${FAKE_MISSING}"
+    printf 'worktree %s\0HEAD 4444444\0detached\0prunable gitdir file points to non-existent location\0\0' "${FAKE_PRUNABLE}"
+    ;;
+  *) exit 1 ;;
+esac
+EOF
+    chmod +x "${WORK}/shim/git"
+    When run env PATH="${WORK}/shim:${PATH}" FAKE_PRIMARY="${WORK}/repo root" FAKE_DETACHED="${WORK}/detached tree" FAKE_MISSING="${WORK}/missing tree" FAKE_PRUNABLE="${WORK}/prunable tree" TS_VENV="${WORK}/venv" sh "${SCRIPT}"
+    The status should be success
+    The line 4 of output should equal "${WORK}/repo root,${WORK}/detached tree"
+    The line 5 of output should equal "${WORK}/detached tree"
+  End
+
+  It 'preserves explicit workspace roots and active-root hints'
+    When run env WORKSPACE_ROOTS='/custom/one,/custom/two' CLAUDE_PROJECT_ROOT='/custom/two' TS_VENV="${WORK}/venv" sh "${SCRIPT}"
+    The status should be success
+    The line 4 of output should equal '/custom/one,/custom/two'
+    The line 5 of output should equal '/custom/two'
+  End
+
+  It 'uses the Git worktree root as the active root when launched from a subdirectory'
     When run sh -c 'unset WORKSPACE_ROOTS GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX; cd "$1" && TS_VENV="$2" exec sh "$3"' _ "${PFB_ROOT}/tests" "${WORK}/venv" "${SCRIPT}"
     The status should be success
-    The line 4 of output should equal "${PFB_ROOT}"
+    The line 4 of output should include "${PFB_ROOT}"
+    The line 5 of output should equal "${PFB_ROOT}"
   End
 End
 


### PR DESCRIPTION
## Summary

- register every usable linked worktree with Token Savior by default
- keep the launching worktree active through `CLAUDE_PROJECT_ROOT`
- preserve explicit workspace and active-root overrides
- keep Codex launcher integrity verification synchronized

## Why

The launcher previously registered only the worktree that started the MCP server. Multiple Codex or Claude sessions therefore could not reliably recall code from their own linked worktrees.

The launcher now parses `git worktree list --porcelain -z`, keeps valid primary and detached worktrees, excludes missing and prunable paths, and preserves paths containing spaces.

## Validation

- RED: `shellspec tests/shell/mcp_token_savior_spec.sh` — 24 examples, 2 expected failures
- GREEN: same command, unchanged test SHA `650b28b77a536165023eb04742d7ed3e787147e401d305c55588d9c8799143ef` — 24 examples, 0 failures
- `scripts/agent/run-gates.sh --diff origin/devel` — `GATES: PASS`
- full ShellSpec under `dash` — 976 examples, 0 failures, 8 environment skips

Fixes #1551

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically detects usable Git worktrees for workspace processing when no workspace roots are specified.
  * Exports the active project root for improved Token Savior context.
  * Ignores missing or prunable worktrees during detection.

* **Bug Fixes**
  * Added integrity validation for the Token Savior launcher before execution.

* **Tests**
  * Expanded coverage for multiple worktrees, detached worktrees, missing paths, and project-root handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->