### PR TITLE
pfblockerng: centralize IP render attribution

### DIFF
--- a/docs/misc/alerts-reports-pipeline.md
+++ b/docs/misc/alerts-reports-pipeline.md
@@ -150,13 +150,13 @@ streamed-loop effect is constant and field-independent (the `$dup = 0` reset plu
 rendered row's badge. That bounds the buffer at ≤ (limit + 1) field arrays plus
 ≤ (limit + 2) scalar/marker entries regardless of log size or filter selectivity —
 O(rows rendered), never O(rows scanned). Pass 1.5 derives every accepted row's query
-(`pfb_ip_render_query()` — the SAME derivation `convert_ip_log()` itself uses) and hands
+(`pfb_ip_render_query()` — the SAME derivation `pfb_ip_render_attribution()` uses) and hands
 them to `pfb_ip_prefetch()`, which runs, in a bounded number of `grep -f <patternfile>`
 passes: the validate round (grouped by the shared file-listing pipeline), the miss round
 (`pfb_find_reported_headers()`, a batched exact + prefix/CIDR sibling of
 `find_reported_header()` sharing `pfb_match_reported_cidr()` with it), and the aliastables
 round (one pass across every still-missing row). Pass 2 replays the buffer through the
-unchanged per-row loop body, which transparently consults the seeded results
+unchanged per-row loop body; its attribution seam transparently consults the seeded results
 (`pfb_ip_render_memos()`) instead of re-`exec`'ing. Filter mode with
 `$ipfilterlimitentries == 0` (genuinely unbounded — the log is scanned to EOF regardless)
 and the degenerate `empty($filterfieldsarray[0])` case both keep the single-pass streaming

--- a/docs/misc/alerts-reports-pipeline.md
+++ b/docs/misc/alerts-reports-pipeline.md
@@ -100,13 +100,12 @@ rows, and the IP filter-match ordering constraint (below) still applies.
 
 ### IP filter/lookup ordering
 
-The IP-side expensive lookups run **before** the filter/limit gates, and that order is
-load-bearing: the Alert-filter match runs against the **corrected** fields (post
-re-check), so a user filtering on a feed name matches the IP's *current* feed, not the
-stale logged one. The filter gate therefore cannot be hoisted above the lookup without
-changing filter semantics. The **counter/limit** gate is independent of the lookup and can
-move (issue #809 Phase 1). Consequence of today's order: with filtering enabled, every
-line of the whole log pays the full lookup, matching or not.
+`convert_ip_log()` filters and applies its counter/limit gates to the raw, timestamp-
+reordered fields before attribution. Accepted rows then call the package seam
+`pfb_ip_render_attribution()`, which owns the per-row validate/miss/alias fallback and
+returns the values needed for rendering. The bounded Block/Permit/Match path derives the
+same queries in Pass 1.5 for `pfb_ip_prefetch()`; the page remains the consumer and keeps
+the filter, counter, icon, and HTML decisions.
 
 ## The IP report cache
 
@@ -127,7 +126,7 @@ the external `drill` CNAME chase that used to run per DNSBL row are all gone (th
 is likewise no DNSBL-side batched prefetch pass anymore: the `pfb_dnsbl_prefetch()` family
 was removed in issue #1349 too.
 
-IP row (`convert_ip_log`):
+IP row (`convert_ip_log` via `pfb_ip_render_attribution`):
 
 - validate: `find <feed dirs> | xargs grep '^<ip>'` (narrowed to the logged feed's file
   in the common case; the whole dir for GeoIP/ET rows) — **unless** the row was already

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10342,6 +10342,79 @@ function pfb_ip_render_query(array $fields): array {
 }
 
 
+// Render-time attribution for one POST-timestamp-reorder IP row. The page keeps
+// filtering, counters, icons, and HTML; this seam owns the per-row lookup fallback.
+function pfb_ip_render_attribution(array $fields): array {
+	global $pfb;
+
+	$rq = pfb_ip_render_query($fields);
+	$memos = &pfb_ip_render_memos();
+	$mask = '';
+	if ($fields[4] == 4) {
+		$mask = strstr($fields[14], '/', FALSE) ?: '/32';
+	}
+
+	$feed_new = $eval_new = $alias_new = $pfb_matchtitle = '';
+	$validate = '';
+	if ($rq['validate_cmd'] !== NULL) {
+		$validate_cmd = $rq['validate_cmd'];
+		$validate = pfb_render_memo($memos['validate'], $validate_cmd, function () use ($validate_cmd) {
+			return exec($validate_cmd);
+		});
+	}
+
+	if (empty($validate)) {
+		$miss_key = "{$rq['host']}|{$rq['folder']}";
+		list($pfb_query, $validate) = pfb_render_memo($memos['miss'], $miss_key, function () use ($rq, $pfb) {
+			$pfb_query = find_reported_header($rq['host'], $rq['folder']);
+			$eval_new = ($pfb_query[1] == 'Unknown') ? 'Not listed!' : $pfb_query[1];
+			$raw_validate = '';
+			$q_ip = pfb_ip_exact_entry_pattern($eval_new);
+			if ($q_ip !== NULL) {
+				$q_ip_esc = escapeshellarg($q_ip);
+				$raw_validate = exec("/usr/bin/find {$pfb['aliasdir']}/*.txt -type f | xargs {$pfb['grep']} {$q_ip_esc} /dev/null 2>&1");
+			}
+			return array($pfb_query, $raw_validate);
+		});
+
+		if ($pfb_query[0] == 'Unknown') {
+			$feed_new = 'Not listed!';
+			$pfb_matchtitle = 'This IP is not currently listed!';
+		} else {
+			$feed_new = $pfb_query[0];
+		}
+
+		if ($pfb_query[1] == 'Unknown') {
+			$mask = '';
+			$eval_new = 'Not listed!';
+		} else {
+			if ($fields[4] == 4) {
+				$mx = explode('/', $pfb_query[1]);
+				$mask = empty($mx[1]) ? '/32' : "/{$mx[1]}";
+			}
+			$eval_new = $pfb_query[1];
+		}
+
+		$validate = ltrim(strrchr(strstr(strstr($validate, ':', TRUE), '.txt', TRUE), '/'), '/');
+		if ($validate != $fields[13]) {
+			$alias_new = $validate;
+		}
+	}
+
+	return array(
+		'host' => $rq['host'],
+		'hostname' => $rq['hostname'],
+		'pfb_geoip' => $rq['pfb_geoip'],
+		'field15' => $rq['field15'],
+		'mask' => $mask,
+		'feed_new' => $feed_new,
+		'eval_new' => $eval_new,
+		'alias_new' => $alias_new,
+		'pfb_matchtitle' => $pfb_matchtitle,
+	);
+}
+
+
 // issue #809: promotes convert_ip_log()'s two function-static memo stores ($validate_memo /
 // $ip_miss_memo, pfblockerng_alerts.php) to a reference-returning accessor so the batched
 // prefetch pass below (pfb_ip_prefetch()) can seed them from OUTSIDE convert_ip_log(). Same

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10241,8 +10241,8 @@ function pfb_ip_match_folders(): string {
 }
 
 
-// issue #809: the exact per-row query derivation convert_ip_log() (pfblockerng_alerts.php)
-// needs before validating/re-locating a reported IP — extracted VERBATIM so the batched
+// issue #809: the exact per-row query derivation pfb_ip_render_attribution() needs before
+// validating/re-locating a reported IP — extracted VERBATIM so the batched
 // prefetch pass (pfb_ip_prefetch()) derives IDENTICAL lookup groups from the same $fields.
 // $fields must already be in convert_ip_log()'s POST-REORDER shape (called AFTER
 // `$fields[99] = array_shift($fields);`).

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10301,7 +10301,7 @@ function pfb_ip_render_query(array $fields): array {
 	}
 
 	// Determine if event IP still exists in Feed Aliastable -- builds the exact validate
-	// command convert_ip_log() execs (via its page-scope memo); NULL reproduces today's
+	// command pfb_ip_render_attribution() execs (via its page-scope memo); NULL reproduces today's
 	// `$validate = '';` no-exec guard (an 'Unknown' evaluated IP or feed name never ran a
 	// validate exec at all).
 	$validate_file_cmd = NULL;
@@ -10415,9 +10415,9 @@ function pfb_ip_render_attribution(array $fields): array {
 }
 
 
-// issue #809: promotes convert_ip_log()'s two function-static memo stores ($validate_memo /
-// $ip_miss_memo, pfblockerng_alerts.php) to a reference-returning accessor so the batched
-// prefetch pass below (pfb_ip_prefetch()) can seed them from OUTSIDE convert_ip_log(). Same
+// issue #809: exposes the render-attribution memo stores ($validate_memo / $ip_miss_memo)
+// through a reference-returning accessor so the batched prefetch pass below
+// (pfb_ip_prefetch()) can seed them before pfb_ip_render_attribution() consumes them. Same
 // one-page-load lifetime as before (a static local, just declared here). No reset is needed
 // between the three per-type IP tables rendered on one page load: every key is content-derived
 // (the exact validate command string, or "$host|$folder") and therefore stable regardless of
@@ -10640,8 +10640,9 @@ function pfb_find_reported_headers(array $hosts, $pfbfolder, $geoip = FALSE, ?ar
 // table's replay pass: the validate round (is the logged IP/CIDR still in its feed file), the
 // miss round (find_reported_header()'s exact + prefix/CIDR search), and the aliastables round
 // (which alias table now holds the resolved IP), each collapsed from one exec() per row to at
-// most one grep pass per distinct group. Seeds pfb_ip_render_memos() — convert_ip_log()
-// consults the same memo stores, falling back to its own per-row exec for anything unseeded.
+// most one grep pass per distinct group. Seeds pfb_ip_render_memos() —
+// pfb_ip_render_attribution() consults the same stores, falling back to a per-row exec for
+// anything unseeded.
 // $rows: one entry per buffered, filter-accepted row — 'host', 'folder', 'eval_ip_raw',
 // 'validate_file_cmd'/'validate_cmd' from pfb_ip_render_query() (both NULL when unused).
 function pfb_ip_prefetch(array $rows): void {
@@ -10657,7 +10658,7 @@ function pfb_ip_prefetch(array $rows): void {
 	$validate_groups = array();
 	foreach ($rows as $row) {
 		if ($row['validate_cmd'] === NULL) {
-			continue;	// mirrors convert_ip_log()'s own no-exec guard -- never validated
+			continue;	// mirrors pfb_ip_render_attribution()'s no-exec guard -- never validated
 		}
 		if (array_key_exists($row['validate_cmd'], $memos['validate'])) {
 			continue;	// already resolved (this row, or an identical earlier one)
@@ -10683,7 +10684,7 @@ function pfb_ip_prefetch(array $rows): void {
 		if ($lines === NULL) {
 			// B3 (issue #809 review): this group's pattern file could not be created/
 			// written -- leave every row in it UNSEEDED (never cache a false ''/no-hit)
-			// so convert_ip_log()'s own per-row exec fallback runs for them instead.
+			// so pfb_ip_render_attribution()'s per-row exec fallback runs for them instead.
 			continue;
 		}
 
@@ -10711,7 +10712,7 @@ function pfb_ip_prefetch(array $rows): void {
 	}
 
 	// Round A/B (batched find_reported_header()), grouped by folder. NOTE -- quirk
-	// PRESERVED, not introduced by this phase: convert_ip_log()'s own miss-round call is
+	// PRESERVED, not introduced by this phase: pfb_ip_render_attribution()'s miss-round call is
 	// `find_reported_header($host, $folder)`, no third argument, so it ALWAYS runs with
 	// $geoip=FALSE even for a GeoIP row (whose $folder already points at ccdir on its own,
 	// so the exact-match round is unaffected either way -- only the prefix round's
@@ -10763,8 +10764,8 @@ function pfb_ip_prefetch(array $rows): void {
 
 	// issue #833: '/dev/null' rides ahead of xargs's own appended file list, so
 	// grep always has >=2 files and always emits the "path:" prefix, matching
-	// convert_ip_log()'s own per-row aliastables exec (pfblockerng_alerts.php)
-	// which needs that same forced-prefix fix for its downstream alias-name parse.
+	// pfb_ip_render_attribution()'s per-row aliastables exec, which needs that same
+	// forced-prefix fix for its downstream alias-name parse.
 	$alias_lines = pfb_ip_prefetch_grep_lines(
 		"/usr/bin/find {$pfb['aliasdir']}/*.txt -type f | xargs {$pfb['grep']} -f",
 		'/dev/null 2>&1',

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -4513,7 +4513,7 @@ if (!$alert_summary):
 				}
 
 				// Pass 1.5 (derive + batch): every ACCEPTED buffered row's lookups, via the
-				// SAME helper (pfb_ip_render_query()) convert_ip_log() itself calls in Pass 2
+				// SAME helper (pfb_ip_render_query()) the Pass 2 attribution seam calls
 				// -- so the two passes can never derive a different answer for the same row.
 				// int runs and gap markers carry no fields and are never looked up.
 				$ip_prefetch_rows = array();
@@ -4540,8 +4540,8 @@ if (!$alert_summary):
 				// Pass 2 (render): replay the buffer in the same (reversed) order via
 				// pfb_alerts_ip_replay_step() (pfblockerng.inc; decode contract documented
 				// there), unit-pinned by AlertsBufferReplayTest -- 'render' rows replay through
-				// the unchanged convert_ip_log() loop body, consulting the batched prefetch via
-				// pfb_ip_render_memos() first. $rtype was already coalesced above (the
+				// the unchanged convert_ip_log() loop body, whose attribution seam consults the
+				// batched pfb_ip_render_memos() first. $rtype was already coalesced above (the
 				// $ipfilterlimitentries coalesce note), so it is provably defined here.
 				foreach ($ip_buffered as $ip_entry) {
 					$ip_step = pfb_alerts_ip_replay_step($ip_entry);

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2902,15 +2902,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		return array(FALSE, '');
 	}
 
-	// issue #809: page-scope memos (pfb_render_memo(), pfblockerng.inc) live for one
-	// render. $memos['validate'] caches the "still in its logged feed file" validate
-	// exec, keyed by the exact command; $memos['miss'] caches the "where does this
-	// host live NOW" path (find_reported_header() + raw aliastables grep), keyed by
-	// host+folder. pfb_ip_render_memos() is a shared accessor so pfb_ip_prefetch()
-	// can seed both from outside this function.
-	$memos = &pfb_ip_render_memos();
-
-	$alert_ip = $pfb_query = $pfb_matchtitle = '';
+	$alert_ip = '';
 	$src_icons = $dst_icons = $feed_new = $eval_new = $alias_new = '';
 
 	// Reorder timestamp field for Filter fields functionality
@@ -2984,45 +2976,20 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		$vtype = 4;
 	}
 
-	// IPv4 IP address mask -- relocated up from its original position (issue #809):
-	// it depends only on $pfb_ipv4/$fields[14], neither of which the derivation below
-	// touches, and nothing between here and its original site reads $mask, so this is
-	// behaviour-identical.
-	$mask = '';
-	if ($pfb_ipv4) {
-		$mask = strstr($fields[14], '/', FALSE) ?: '/32';
-	}
-
-	// issue #809: the GeoIP/host-selection/ET-header/folder/validate-command derivation
-	// is extracted to pfb_ip_render_query() (pfblockerng.inc) -- a verbatim-motion
-	// refactor so the batched prefetch pass (pfb_ip_prefetch(), called from this page's
-	// two-pass IP table render below) derives the IDENTICAL lookup groups from a copy
-	// of the same $fields, with no separate re-derivation to drift from this one.
-	$rq = pfb_ip_render_query($fields);
-
-	$host		= $rq['host'];
-	$hostname	= $rq['hostname'];
-	$pfb_geoip	= $rq['pfb_geoip'];
-	$fields[15]	= $rq['field15'];	// ET-header 'Category:Feed' prefix strip -- render-visible
-	$folder		= $rq['folder'];
+	$attribution = pfb_ip_render_attribution($fields);
+	$host = $attribution['host'];
+	$hostname = $attribution['hostname'];
+	$pfb_geoip = $attribution['pfb_geoip'];
+	$fields[15] = $attribution['field15'];
+	$mask = $attribution['mask'];
+	$feed_new = $attribution['feed_new'];
+	$eval_new = $attribution['eval_new'];
+	$alias_new = $attribution['alias_new'];
+	$pfb_matchtitle = $attribution['pfb_matchtitle'];
 
 	// HTML-encode the resolved/DHCP hostnames before they are printed as cell text.
 	$hostname['src'] = pfb_hsc($hostname['src']);
 	$hostname['dst'] = pfb_hsc($hostname['dst']);
-
-	// Determine if event IP still exists in Feed Aliastable. Per-row pipeline with no
-	// render-time cache (the daemon's ipcache is event-time only); a miss falls into
-	// find_reported_header() -- full grep sweeps of the feed dirs -- plus a whole-
-	// aliastables grep below (alerts-reports-pipeline.md, issue #809). Memoized by the
-	// exact command about to run; in non-filter/bounded-filter mode this key is usually
-	// pre-seeded by pfb_ip_prefetch(), so the closure below is the per-row fallback.
-	$validate = '';
-	if ($rq['validate_cmd'] !== NULL) {
-		$validate_cmd = $rq['validate_cmd'];
-		$validate = pfb_render_memo($memos['validate'], $validate_cmd, function () use ($validate_cmd) {
-			return exec($validate_cmd);
-		});
-	}
 
 	// ASN - Add to GeoIP column. issue #1369 (ADR-38 Amendment 3): the ASN
 	// number renders directly from its own plain CSV column ([18]); the
@@ -3036,65 +3003,6 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	}
 	else {
 		$fields[18] = '';
-	}
-
-	// Determine if a different IP/CIDR is now alerting on this host
-	// issue #809: find_reported_header($host, $folder) and the raw aliastables grep
-	// below are both pure functions of ($host, $folder) -- find_reported_header()'s
-	// result decides $eval_new, which is the only input to the aliastables grep -- so
-	// they are memoized together as one unit, keyed on "$host|$folder". Everything
-	// that depends on THIS row ($mask needs $pfb_ipv4, the post-processed $validate
-	// needs the ltrim/strrchr/strstr chain, and the $validate != $fields[13] compare)
-	// stays outside the memo and is recomputed every row from the cached raw values.
-	if (empty($validate)) {
-		$miss_key = "{$host}|{$folder}";
-		list($pfb_query, $validate) = pfb_render_memo($memos['miss'], $miss_key, function () use ($host, $folder, $pfb) {
-			$pfb_query = find_reported_header($host, $folder);
-
-			// $eval_new here mirrors the outer derivation below exactly (including the
-			// 'Not listed!' substitution on an 'Unknown' match) because it is what
-			// builds the aliastables grep command -- the exec must stay byte-identical
-			// to today's regardless of which branch produced it.
-			$eval_new = ($pfb_query[1] == 'Unknown') ? 'Not listed!' : $pfb_query[1];
-
-			// Determine if IP is in a new Aliastable
-			$raw_validate = '';
-			$q_ip = pfb_ip_exact_entry_pattern($eval_new);
-			if ($q_ip !== NULL) {
-				$q_ip_esc = escapeshellarg($q_ip);
-				// issue #833: '/dev/null' gives xargs a permanent extra file arg, so
-				// grep always emits a "path:" prefix even when aliasdir holds exactly
-				// one .txt file -- the ltrim(strrchr(strstr(strstr(...)))) alias-name
-				// parse below requires that shape.
-				$raw_validate = exec("/usr/bin/find {$pfb['aliasdir']}/*.txt -type f | xargs {$pfb['grep']} {$q_ip_esc} /dev/null 2>&1");
-			}
-
-			return array($pfb_query, $raw_validate);
-		});
-
-		if ($pfb_query[0] == 'Unknown') {
-			$feed_new	= 'Not listed!';
-			$pfb_matchtitle = 'This IP is not currently listed!';
-		} else {
-			$feed_new	= $pfb_query[0];
-		}
-
-		if ($pfb_query[1] == 'Unknown') {
-			$mask		= '';
-			$eval_new	= 'Not listed!';
-		}
-		else {
-			if ($pfb_ipv4) {
-				$mx	= explode('/', $pfb_query[1]);
-				$mask	= empty($mx[1]) ? '/32' : "/{$mx[1]}";
-			}
-			$eval_new	= $pfb_query[1];
-		}
-
-		$validate = ltrim(strrchr(strstr(strstr($validate, ':', TRUE), '.txt', TRUE), '/'), '/');
-		if ($validate != $fields[13]) {
-			$alias_new = $validate;
-		}
 	}
 
 	// v4-only, /32|/24 -- ADR-53 (issue #422) narrowed this to feed ONLY the
@@ -3119,7 +3027,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	}
 
 	// HTML-encoded copies of the IP/alias tokens that get folded into the icon
-	// id/title/href markup below (the raw values stay for lookups + exec paths).
+	// id/title/href markup below (the raw values stay for lookup paths).
 	$h_host		= pfb_hsc($host);
 	$h_eval_ip	= pfb_hsc($eval_ip);
 	$h_table	= pfb_hsc($table);

--- a/tests/php/AlertsIpConvertPrefetchParityTest.php
+++ b/tests/php/AlertsIpConvertPrefetchParityTest.php
@@ -98,7 +98,7 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 		// ccdir/etdir/aliasdir each need a SECOND, non-matching file: grep only
 		// prefixes a matched line with "path:" when >1 file is searched, and
 		// find_reported_header()'s pfb_parse_query() (feed/alias name split) and
-		// convert_ip_log()'s own alias-name ltrim/strrchr/strstr chain both depend on
+		// pfb_ip_render_attribution()'s alias-name ltrim/strrchr/strstr chain both depend on
 		// that "path:content" shape. A lone-file dir would silently break the parse
 		// for cases E/G/H regardless of prefetch -- not what this test is about.
 		file_put_contents("{$this->ccdir}/OtherRegionPlaceholder.txt", "10.0.0.1\n");
@@ -206,7 +206,7 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 	 * Build the SAME prefetch-row shape pfblockerng_alerts.php's Pass 1.5 builds
 	 * (pfblockerng_alerts.php, the $ip_prefetch_rows loop) from a RAW pre-reorder
 	 * $fields row: a page-copy reorder, then pfb_ip_render_query() -- the identical
-	 * derivation convert_ip_log() itself runs on its own copy.
+	 * derivation pfb_ip_render_attribution() runs.
 	 */
 	private function prefetchRowFor(array $rawFields): array
 	{
@@ -521,8 +521,8 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 	 * #833 reports as broken.
 	 *
 	 * Given: pre-fix, `find aliasdir/*.txt | xargs grep` hands grep a single file,
-	 * so its match comes back UNPREFIXED; convert_ip_log()'s alias-name parse chain
-	 * (pfblockerng_alerts.php ltrim(strrchr(strstr(strstr(...))))) requires the
+	 * so its match comes back UNPREFIXED; pfb_ip_render_attribution()'s alias-name parse
+	 * chain requires the
 	 * "path:content" shape and silently collapses to '' without it -- the rendered
 	 * row would show NO "moved to a new alias" cell at all, even though the IP
 	 * genuinely moved.

--- a/tests/php/AlertsIpConvertPrefetchParityTest.php
+++ b/tests/php/AlertsIpConvertPrefetchParityTest.php
@@ -11,19 +11,19 @@ require_once __DIR__ . '/PfbNoPhpWarningTrait.php';
  * End-to-end producer<->consumer parity for the issue #809 Phase 3b Alerts IP-table
  * prefetch (PR #825 review nitpick T3): IpPrefetchTest.php pins pfb_ip_prefetch() and
  * its helpers in isolation, but nothing drives convert_ip_log() itself (the page
- * consumer) to prove the batched producer and the per-row consumer actually agree on
+ * caller) to prove the batched producer and the attribution seam actually agree on
  * the memo keys -- a wrong validate/miss key would either silently discard the
  * prefetch (falling back to per-row exec, still correct but unbatched) or, worse,
- * hand convert_ip_log() the WRONG cached value for a different row.
+ * hand pfb_ip_render_attribution() the WRONG cached value for a different row.
  *
- * Feature: pfb_ip_prefetch()'s seeded memos are consumed by convert_ip_log() through
- *          the exact same keys, so a render is byte-identical whether or not the
+ * Feature: pfb_ip_prefetch()'s seeded memos are consumed by pfb_ip_render_attribution()
+ *          through the exact same keys, so a render is byte-identical whether or not the
  *          batched prefetch ran first
  *
  *   Scenario: for every reported-IP shape convert_ip_log() renders, seeding
  *             pfb_ip_render_memos() via pfb_ip_prefetch() (as the page's Pass 1.5
  *             does) and then rendering must produce IDENTICAL output to resetting the
- *             memos (forcing convert_ip_log()'s own per-row exec fallback) and
+ *             memos (forcing pfb_ip_render_attribution()'s per-row exec fallback) and
  *             rendering again -- that parity IS the contract PR #825 claims.
  *
  * Every case drives REAL fixture files on disk through REAL find/grep exec() calls
@@ -263,14 +263,14 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 
 		$seededMemos = &pfb_ip_render_memos();
 
-		// Guard against a vacuous pass: prove the EXACT key convert_ip_log() will
+		// Guard against a vacuous pass: prove the EXACT key pfb_ip_render_attribution() will
 		// consult was actually seeded by this prefetch call -- the producer<->consumer
 		// memo-key wiring itself -- not merely that the store is non-empty.
 		$this->assertArrayHasKey(
 			$row['validate_cmd'],
 			$seededMemos['validate'],
 			"[{$scenario}] expected pfb_ip_prefetch() to seed the exact validate_cmd key "
-				. "convert_ip_log() will look up: " . var_export($row['validate_cmd'], TRUE)
+				. "pfb_ip_render_attribution() will look up: " . var_export($row['validate_cmd'], TRUE)
 		);
 		if (empty($seededMemos['validate'][$row['validate_cmd']])) {
 			$missKey = $row['host'] . '|' . $row['folder'];
@@ -285,8 +285,8 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 		// When: convert_ip_log() renders while the prefetch memos are seeded.
 		[$retSeeded, $htmlSeeded] = $this->render($fields, $rtype);
 
-		// Given: a COLD render -- the memo store reset, so convert_ip_log() must take
-		// its own per-row exec fallback for every lookup this row needs.
+		// Given: a COLD render -- the memo store reset, so pfb_ip_render_attribution()
+		// must take its per-row exec fallback for every lookup this row needs.
 		pfb_ip_render_memos_reset();
 		$coldMemos = &pfb_ip_render_memos();
 		$this->assertSame(

--- a/tests/php/AlertsIpConvertPrefetchParityTest.php
+++ b/tests/php/AlertsIpConvertPrefetchParityTest.php
@@ -34,6 +34,7 @@ require_once __DIR__ . '/PfbNoPhpWarningTrait.php';
 #[CoversFunction('convert_ip_log')]
 #[CoversFunction('pfb_ip_prefetch')]
 #[CoversFunction('pfb_ip_render_query')]
+#[CoversFunction('pfb_ip_render_attribution')]
 #[CoversFunction('pfb_ip_render_memos')]
 #[CoversFunction('pfb_ip_render_memos_reset')]
 #[CoversFunction('pfb_render_memo')]
@@ -433,6 +434,20 @@ final class AlertsIpConvertPrefetchParityTest extends TestCase
 			8 => '192.0.2.77', 15 => '192.0.2.77',
 			14 => 'pfB_OldAlias_v4', 16 => 'DenyFeedOldG',
 		]);
+		$reordered = $fields;
+		$reordered[99] = array_shift($reordered);
+		$attribution = pfb_ip_render_attribution($reordered);
+		$this->assertSame([
+			'host' => '192.0.2.77',
+			'field15' => 'DenyFeedOldG',
+			'mask' => '/32',
+			'feed_new' => 'DenyFeedNewG',
+			'eval_new' => '192.0.2.77',
+			'alias_new' => 'pfB_NewAlias_v4',
+			'pfb_matchtitle' => '',
+		], array_intersect_key($attribution, array_flip([
+			'host', 'field15', 'mask', 'feed_new', 'eval_new', 'alias_new', 'pfb_matchtitle',
+		])), 'expected the attribution seam to preserve moved-feed and alias relocation values');
 
 		$this->assertParity($fields, 'Block', 'aliastable-changed v4');
 	}

--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -634,7 +634,7 @@ final class IpPrefetchTest extends TestCase
 	 * pfb_parse_query() returns a 1-element array (no [1]) -- find_reported_
 	 * header()'s exact-match branch returns that 1-element array VERBATIM (it has
 	 * no Unknown/Unknown fallback of its own), corrupting every caller that reads
-	 * result[1] (e.g. convert_ip_log() builds a degenerate '^' aliastables
+	 * result[1] (e.g. pfb_ip_render_attribution() builds a degenerate '^' aliastables
 	 * pattern from the resulting NULL).
 	 * When: the per-row AND batched lookups both run against the single-file
 	 * folder.
@@ -755,7 +755,7 @@ final class IpPrefetchTest extends TestCase
 		$rq     = pfb_ip_render_query($fields);
 
 		// Given: pfb_ip_render_query() derives the folder/validate command this row's
-		// convert_ip_log() call would use -- the deny+native glob, block-branch folder.
+		// pfb_ip_render_attribution() call would use -- the deny+native glob, block-branch folder.
 		$this->assertSame("{$GLOBALS['pfb']['denydir']}/*.txt {$GLOBALS['pfb']['nativedir']}/*.txt", $rq['folder']);
 		$this->assertNotNull($rq['validate_cmd'], 'expected a validate command to be built (fields[14]/[15] are not Unknown)');
 
@@ -947,7 +947,7 @@ final class IpPrefetchTest extends TestCase
 	 * EXACT match unreachable via Round A silently resolved to Unknown/Unknown and was
 	 * then CACHED as a definitive miss, a true false negative for a host that DOES have
 	 * a real match. GREEN after: the miss round leaves the row entirely unseeded so
-	 * convert_ip_log()'s per-row fallback (unaffected by the sandbox -- it never uses a
+	 * pfb_ip_render_attribution()'s per-row fallback (unaffected by the sandbox -- it never uses a
 	 * pattern file) resolves it live instead.
 	 */
 	public function test_prefetch_leaves_the_miss_round_unseeded_when_round_a_pattern_file_cannot_be_created(): void
@@ -1066,7 +1066,7 @@ final class IpPrefetchTest extends TestCase
 			);
 
 			// Then: pfb_render_memo(), consulting the ALREADY-seeded store (exactly as
-			// convert_ip_log() does on every render), still returns the correct cached
+			// pfb_ip_render_attribution() does on every render), still returns the correct cached
 			// result -- it never re-execs against the now-missing directories.
 			list($cachedQuery, $cachedValidate) = pfb_render_memo(
 				$memos['miss'],
@@ -1118,7 +1118,7 @@ final class IpPrefetchTest extends TestCase
 	 * When: pfb_ip_prefetch() runs its miss + aliastables rounds for that row.
 	 * Then: the prefetch completes WITHOUT the issue #831 TypeError, AND the row
 	 * is now correctly SEEDED with the real (feed, value) pair -- no longer left
-	 * to convert_ip_log()'s per-row fallback.
+	 * to pfb_ip_render_attribution()'s per-row fallback.
 	 */
 	public function test_single_file_folder_miss_row_is_correctly_seeded_after_the_833_fix(): void
 	{

--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -39,7 +39,7 @@ use PHPUnit\Framework\TestCase;
  *     fixture dir/geoip=TRUE case proves the ccdir-redirect branch too.
  *
  *   Scenario: pfb_ip_prefetch() end-to-end -- seeding pfb_ip_render_memos() for real rows
- *     Rows built via pfb_ip_render_query() (the SAME helper convert_ip_log() itself calls)
+ *     Rows built via pfb_ip_render_query() (the SAME helper pfb_ip_render_attribution() calls)
  *     over real fixture dirs. Asserts the validate round, the miss round (find_reported_
  *     header() result), and the aliastables round (including the genuine "no match ->
  *     empty string" case) all seed the exact values a per-row exec would have produced.
@@ -784,8 +784,8 @@ final class IpPrefetchTest extends TestCase
 		// string in the alias fixture -- exactly what a per-row exec would have produced.
 		// issue #833: the alias fixture dir (fixtures/ip_prefetch/alias) holds exactly
 		// ONE .txt file, so the aliastables grep is now forced (via /dev/null) to emit
-		// its "path:" prefix -- the shape convert_ip_log()'s own alias-name parse chain
-		// (pfblockerng_alerts.php ltrim/strrchr/strstr) requires.
+		// its "path:" prefix -- the shape pfb_ip_render_attribution()'s alias-name parse
+		// chain requires.
 		$missKey = "{$rq['host']}|{$rq['folder']}";
 		$this->assertArrayHasKey($missKey, $memos['miss'], "expected the miss round to seed key '{$missKey}'");
 		$expectedRawValidate = "{$GLOBALS['pfb']['aliasdir']}/pfB_SomeAlias_v4.txt:192.0.2.0/24";
@@ -1221,7 +1221,7 @@ final class IpPrefetchTest extends TestCase
 	 *
 	 * Given: a real etdir fixture file containing the reported IP.
 	 * When: the row's validate_cmd (built by pfb_ip_render_query()) is actually
-	 * exec()'d, exactly as convert_ip_log() does.
+	 * exec()'d, exactly as pfb_ip_render_attribution() does.
 	 * Then: the still-listed line comes back. Pre-fix, `find`'s primary-operator
 	 * error left the pipe with nothing for `xargs grep` to search, so this always
 	 * came back empty (a false "no longer listed") regardless of the real feed

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -4102,6 +4102,19 @@
             }
         ]
     },
+    "pfb_ip_render_attribution": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "fields",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
     "pfb_ip_render_memos": {
         "returnsRef": true,
         "returnType": "array",

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -991,7 +991,9 @@ def test_s8_alias_changed_cell_renders(render_diff_state: dict[str, dict[str, Ca
     feed_change = (
         f"<s>{FEED_C8_NAME}</s><br /><small><s>{S8_IP}</s></small><br />{FEED_A_NAME}<br /><small>{S8_IP}</small>"
     )
-    assert feed_change in row, f"S8 ({S8_IP}) expected the stale-to-current feed transition {feed_change!r}: {row!r}"
+    cells = re.findall(r"<td(?:\s[^>]*)?>(.*?)</td>", row, re.DOTALL)
+    assert cells, f"S8 ({S8_IP}) row has no table cells: {row!r}"
+    assert cells[-1] == feed_change, f"S8 ({S8_IP}) expected Feed cell {feed_change!r}, got {cells[-1]!r}"
 
 
 def test_s9_outbound_direction_still_listed(render_diff_state: dict[str, dict[str, Capture]]) -> None:

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -988,7 +988,9 @@ def test_s8_alias_changed_cell_renders(render_diff_state: dict[str, dict[str, Ca
     assert f"<s>{S8_ALIAS_LOGGED}</s>" in row, f"S8 ({S8_IP}) expected the stale alias struck: {row!r}"
     assert "pfB_RVAliasA_v4" in row, f"S8 ({S8_IP}) expected the exact current alias pfB_RVAliasA_v4: {row!r}"
     assert "pfB_RVAliasZ_v4" not in row, f"S8 ({S8_IP}) unexpectedly attributed the longer Z decoy: {row!r}"
-    feed_change = f"<s>{FEED_C8_NAME}</s><br />{FEED_A_NAME}<br /><small>{S8_IP}</small>"
+    feed_change = (
+        f"<s>{FEED_C8_NAME}</s><br /><small><s>{S8_IP}</s></small><br />{FEED_A_NAME}<br /><small>{S8_IP}</small>"
+    )
     assert feed_change in row, f"S8 ({S8_IP}) expected the stale-to-current feed transition {feed_change!r}: {row!r}"
 
 

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -988,8 +988,8 @@ def test_s8_alias_changed_cell_renders(render_diff_state: dict[str, dict[str, Ca
     assert f"<s>{S8_ALIAS_LOGGED}</s>" in row, f"S8 ({S8_IP}) expected the stale alias struck: {row!r}"
     assert "pfB_RVAliasA_v4" in row, f"S8 ({S8_IP}) expected the exact current alias pfB_RVAliasA_v4: {row!r}"
     assert "pfB_RVAliasZ_v4" not in row, f"S8 ({S8_IP}) unexpectedly attributed the longer Z decoy: {row!r}"
-    assert f"<s>{FEED_C8_NAME}</s>" in row, f"S8 ({S8_IP}) expected the stale feed {FEED_C8_NAME!r} struck: {row!r}"
-    assert FEED_A_NAME in row, f"S8 ({S8_IP}) expected the current feed {FEED_A_NAME!r}: {row!r}"
+    feed_change = f"<s>{FEED_C8_NAME}</s><br />{FEED_A_NAME}<br /><small>{S8_IP}</small>"
+    assert feed_change in row, f"S8 ({S8_IP}) expected the stale-to-current feed transition {feed_change!r}: {row!r}"
 
 
 def test_s9_outbound_direction_still_listed(render_diff_state: dict[str, dict[str, Capture]]) -> None:

--- a/tests/smoke/ui/test_alerts_render_verify.py
+++ b/tests/smoke/ui/test_alerts_render_verify.py
@@ -988,6 +988,8 @@ def test_s8_alias_changed_cell_renders(render_diff_state: dict[str, dict[str, Ca
     assert f"<s>{S8_ALIAS_LOGGED}</s>" in row, f"S8 ({S8_IP}) expected the stale alias struck: {row!r}"
     assert "pfB_RVAliasA_v4" in row, f"S8 ({S8_IP}) expected the exact current alias pfB_RVAliasA_v4: {row!r}"
     assert "pfB_RVAliasZ_v4" not in row, f"S8 ({S8_IP}) unexpectedly attributed the longer Z decoy: {row!r}"
+    assert f"<s>{FEED_C8_NAME}</s>" in row, f"S8 ({S8_IP}) expected the stale feed {FEED_C8_NAME!r} struck: {row!r}"
+    assert FEED_A_NAME in row, f"S8 ({S8_IP}) expected the current feed {FEED_A_NAME!r}: {row!r}"
 
 
 def test_s9_outbound_direction_still_listed(render_diff_state: dict[str, dict[str, Capture]]) -> None:


### PR DESCRIPTION
## Summary

- centralize render-time IP attribution in `pfb_ip_render_attribution()`
- leave the Alerts page responsible only for filtering, counters, icons, and HTML
- preserve prefetch/cold fallback parity and document the live filter-before-attribution order

## Verification

- untouched-base oracle: 45 tests, 270 assertions
- targeted attribution/schema/replay suite: 76 tests, 445 assertions
- full PHPUnit: 3,855 tests, 22,803 assertions, 4 skipped
- PHP lint, PHPStan, PHPCS, Markdownlint, and `scripts/agent/run-gates.sh --diff origin/devel`: PASS
- independent step verifier: PASS

This is a behavior-preserving extraction, so the repository's refactor exception applies instead of a manufactured missing-symbol red run. Tier-A CE/Plus UI rendering remains the PR/live gate.

Fixes #1401

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IP event attribution and rendering for alerts and reports.
  * Applied filtering and counter limits before row attribution for more accurate results.
  * Improved handling of aliases, feeds, CIDR masks, host details, and unmatched entries.
  * Ensured prefetch and render-time attribution produce consistent results.

* **Documentation**
  * Updated attribution pipeline documentation and render-time cost descriptions.

* **Tests**
  * Added coverage for attribution scenarios involving moved feeds and alias changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->