### PR TITLE
Agent bootstrap: pin and verify the RTK installer

### DIFF
--- a/.claude/hooks/rtk-install.sh
+++ b/.claude/hooks/rtk-install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # rtk-install.sh — SessionStart hook: make RTK available, then trust the checked-in filters
-# from the current worktree. When absent, install the checksum-verified upstream binary to
-# ~/.local/bin, best-effort symlink it into /usr/local/bin, and update shell profiles for the
-# next shell. Never fails session start. RTK_VERSION pins a release.
+# from the current worktree. When absent, verify the immutable upstream installer pinned below,
+# use it to install the pinned release to ~/.local/bin, best-effort symlink it into
+# /usr/local/bin, and update shell profiles for the next shell. Never fails session start.
 set -u
 
 hook_dir=$(CDPATH='' cd "$(dirname "$0")" && pwd -L) || exit 0
@@ -16,7 +16,24 @@ if [ -z "$rtk_bin" ] && [ -x "$HOME/.local/bin/rtk" ]; then
 fi
 
 if [ -z "$rtk_bin" ]; then
-	{ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh; } >/dev/null 2>&1 || exit 0
+	rtk_version='v0.43.0'
+	rtk_installer_commit='5a7880d404db8364d602f2ecdc41dd790f64013f'
+	rtk_installer_sha256='d6eb73a772903e13ff34ee1be8a8b24e896ba9a978f20d2279a08b4083ea6f77'
+	rtk_installer=$(mktemp "${TMPDIR:-/tmp}/rtk-install.XXXXXX") || exit 0
+	trap 'rm -f "$rtk_installer"' 0
+	trap 'exit 0' HUP INT TERM
+	curl -fsSL "https://raw.githubusercontent.com/rtk-ai/rtk/${rtk_installer_commit}/install.sh" \
+		-o "$rtk_installer" >/dev/null 2>&1 || exit 0
+	if command -v sha256sum >/dev/null 2>&1; then
+		rtk_installer_actual=$(sha256sum "$rtk_installer" 2>/dev/null) || exit 0
+	elif command -v shasum >/dev/null 2>&1; then
+		rtk_installer_actual=$(shasum -a 256 "$rtk_installer" 2>/dev/null) || exit 0
+	else
+		exit 0
+	fi
+	rtk_installer_actual=${rtk_installer_actual%% *}
+	[ "$rtk_installer_actual" = "$rtk_installer_sha256" ] || exit 0
+	{ RTK_VERSION="$rtk_version" RTK_SKIP_CHECKSUM=0 sh "$rtk_installer"; } >/dev/null 2>&1 || exit 0
 
 	[ -x "$HOME/.local/bin/rtk" ] || exit 0
 	rtk_bin="$HOME/.local/bin/rtk"

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/rtk-install.sh\" 8130c85ad7256b35a3c49e787cae897ffb20bb7166e64770d866f6ad10ac4228 && exec sh \"$root/.claude/hooks/rtk-install.sh\"",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/rtk-install.sh\" 4acd43aa6ac6b3f17a446de1d74bd54a552081d9c8ed6dcc0d0f839c1029e0e3 && exec sh \"$root/.claude/hooks/rtk-install.sh\"",
             "timeout": 120,
             "statusMessage": "Preparing RTK filters"
           },

--- a/tests/shell/fixtures/rtk-install-v0.43.0.sh
+++ b/tests/shell/fixtures/rtk-install-v0.43.0.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env sh
+# rtk installer - https://github.com/rtk-ai/rtk
+# Usage: curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+
+set -e
+
+REPO="rtk-ai/rtk"
+BINARY_NAME="rtk"
+INSTALL_DIR="${RTK_INSTALL_DIR:-$HOME/.local/bin}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() {
+    printf "${GREEN}[INFO]${NC} %s\n" "$1"
+}
+
+warn() {
+    printf "${YELLOW}[WARN]${NC} %s\n" "$1"
+}
+
+error() {
+    printf "${RED}[ERROR]${NC} %s\n" "$1"
+    exit 1
+}
+
+# Detect OS
+detect_os() {
+    case "$(uname -s)" in
+        Linux*)  OS="linux";;
+        Darwin*) OS="darwin";;
+        *)       error "Unsupported operating system: $(uname -s)";;
+    esac
+}
+
+# Detect architecture
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)  ARCH="x86_64";;
+        arm64|aarch64) ARCH="aarch64";;
+        *)             error "Unsupported architecture: $(uname -m)";;
+    esac
+}
+
+# Get latest release version
+# Primary: parse the 302 redirect on /releases/latest (no API call, no rate limit).
+# Fallback: the GitHub REST API (subject to 60 req/hour anonymous limit).
+get_latest_version() {
+    # Try the web redirect first — does not count against the API rate limit.
+    VERSION=$(curl -sI "https://github.com/${REPO}/releases/latest" \
+        | grep -i '^location:' \
+        | sed -E 's|.*/tag/([^[:space:]]+).*|\1|' \
+        | tr -d '\r')
+
+    # Fallback to the REST API if the redirect didn't yield a tag.
+    if [ -z "$VERSION" ]; then
+        warn "Redirect lookup failed, falling back to GitHub API..."
+        VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+            | grep '"tag_name":' \
+            | sed -E 's/.*"([^"]+)".*/\1/')
+    fi
+
+    if [ -z "$VERSION" ]; then
+        error "Failed to get latest version (GitHub API may be rate-limited; set RTK_VERSION=vX.Y.Z to pin)"
+    fi
+}
+
+# Build target triple
+get_target() {
+    case "$OS" in
+        linux)
+            case "$ARCH" in
+                x86_64)  TARGET="x86_64-unknown-linux-musl";;
+                aarch64) TARGET="aarch64-unknown-linux-gnu";;
+            esac
+            ;;
+        darwin)
+            TARGET="${ARCH}-apple-darwin"
+            ;;
+    esac
+}
+
+# Download and install
+install() {
+    info "Detected: $OS $ARCH"
+    info "Target: $TARGET"
+    info "Version: $VERSION"
+
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY_NAME}-${TARGET}.tar.gz"
+    CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt"
+    TEMP_DIR=$(mktemp -d)
+    ARCHIVE="${TEMP_DIR}/${BINARY_NAME}.tar.gz"
+    CHECKSUMS="${TEMP_DIR}/checksums.txt"
+    ASSET_NAME="${BINARY_NAME}-${TARGET}.tar.gz"
+
+    info "Downloading from: $DOWNLOAD_URL"
+    if ! curl -fsSL "$DOWNLOAD_URL" -o "$ARCHIVE"; then
+        error "Failed to download binary"
+    fi
+
+    info "Downloading checksums..."
+    if ! curl -fsSL "$CHECKSUMS_URL" -o "$CHECKSUMS"; then
+        error "Failed to download checksums.txt — refusing to install unverified binary (set RTK_SKIP_CHECKSUM=1 to bypass at your own risk)"
+    fi
+
+    if [ "${RTK_SKIP_CHECKSUM:-0}" = "1" ]; then
+        warn "RTK_SKIP_CHECKSUM=1 set — SKIPPING checksum verification (NOT RECOMMENDED)"
+    else
+        info "Verifying SHA-256 checksum..."
+        EXPECTED=$(grep "[[:space:]]${ASSET_NAME}\$" "$CHECKSUMS" | awk '{print $1}')
+        if [ -z "$EXPECTED" ]; then
+            error "checksum for ${ASSET_NAME} not found in checksums.txt — refusing to install"
+        fi
+        # sha256sum (Linux GNU) vs shasum -a 256 (macOS) — prefer whichever is available.
+        if command -v sha256sum >/dev/null 2>&1; then
+            ACTUAL=$(sha256sum "$ARCHIVE" | awk '{print $1}')
+        elif command -v shasum >/dev/null 2>&1; then
+            ACTUAL=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
+        else
+            error "Neither sha256sum nor shasum available — cannot verify checksum"
+        fi
+        if [ "$EXPECTED" != "$ACTUAL" ]; then
+            error "checksum mismatch! expected=${EXPECTED} actual=${ACTUAL} — refusing to install"
+        fi
+        info "Checksum verified."
+    fi
+
+    # Verify archive contents before extraction (CWE-22 path traversal).
+    # Reject any entry with an absolute path or a ".." component.
+    info "Verifying archive contents..."
+    if tar -tzf "$ARCHIVE" | grep -qE '^/|(^|/)\.\.(/|$)'; then
+        error "Archive contains unsafe paths (absolute or directory traversal) — refusing to extract"
+    fi
+
+    info "Extracting..."
+    tar -xzf "$ARCHIVE" -C "$TEMP_DIR"
+
+    mkdir -p "$INSTALL_DIR"
+    mv "${TEMP_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/"
+
+    chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+
+    # Cleanup
+    rm -rf "$TEMP_DIR"
+
+    info "Successfully installed ${BINARY_NAME} to ${INSTALL_DIR}/${BINARY_NAME}"
+}
+
+# Verify installation
+verify() {
+    INSTALLED_BIN="${INSTALL_DIR}/${BINARY_NAME}"
+    if [ -x "$INSTALLED_BIN" ]; then
+        info "Verification: $("$INSTALLED_BIN" --version)"
+    else
+        error "Binary not found at expected location: $INSTALLED_BIN"
+    fi
+    if ! command -v "$BINARY_NAME" >/dev/null 2>&1; then
+        warn "Binary installed but not in PATH. Add to your shell profile:"
+        warn "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+    fi
+}
+
+main() {
+    info "Installing $BINARY_NAME..."
+
+    detect_os
+    detect_arch
+    get_target
+    if [ -n "$RTK_VERSION" ]; then
+        VERSION="$RTK_VERSION"
+        info "Using pinned version from RTK_VERSION: $VERSION"
+    else
+        get_latest_version
+    fi
+    install
+    verify
+
+    echo ""
+    info "Installation complete! Run '$BINARY_NAME --help' to get started."
+}
+
+main

--- a/tests/shell/rtk_install_spec.sh
+++ b/tests/shell/rtk_install_spec.sh
@@ -58,6 +58,7 @@ Describe 'rtk fallback installer integrity'
     home="${work}/home"
     shim="${work}/shim"
     curl_log="${work}/curl.log"
+    sh_log="${work}/sh.log"
     executed="${work}/executed"
     mkdir -p "${home}" "${shim}"
     cat > "${shim}/curl" <<'EOF'
@@ -95,7 +96,13 @@ case "$url" in
   *) exit 22 ;;
 esac
 EOF
+    cat > "${shim}/sh" <<'EOF'
+#!/bin/sh
+printf '%s|%s\n' "${RTK_VERSION:-}" "${RTK_SKIP_CHECKSUM:-}" >> "$RTK_SH_LOG"
+exec /bin/sh "$@"
+EOF
     chmod +x "${shim}/curl"
+    chmod +x "${shim}/sh"
   }
 
   cleanup() {
@@ -107,17 +114,18 @@ EOF
 
   It 'executes the verified immutable installer with a pinned release'
     When run env HOME="${home}" PATH="${shim}:/usr/bin:/bin" RTK_CURL_LOG="${curl_log}" \
-      RTK_INSTALLER_FIXTURE="${fixture}" RTK_EXECUTED_MARKER="${executed}" \
-      CLAUDE_PROJECT_DIR="${work}" sh "${hook}"
+      RTK_INSTALLER_FIXTURE="${fixture}" RTK_EXECUTED_MARKER="${executed}" RTK_SH_LOG="${sh_log}" \
+      RTK_VERSION=v999.0.0 RTK_SKIP_CHECKSUM=1 CLAUDE_PROJECT_DIR="${work}" /bin/sh "${hook}"
     The status should be success
     The contents of file "${curl_log}" should include 'rtk/5a7880d404db8364d602f2ecdc41dd790f64013f/install.sh'
     The contents of file "${curl_log}" should include '/releases/download/v0.43.0/rtk-'
+    The contents of file "${sh_log}" should equal 'v0.43.0|0'
   End
 
   It 'rejects changed installer bytes without executing them'
     When run env HOME="${home}" PATH="${shim}:/usr/bin:/bin" RTK_CURL_LOG="${curl_log}" \
-      RTK_INSTALLER_FIXTURE="${fixture}" RTK_EXECUTED_MARKER="${executed}" RTK_HOSTILE=1 \
-      CLAUDE_PROJECT_DIR="${work}" sh "${hook}"
+      RTK_INSTALLER_FIXTURE="${fixture}" RTK_EXECUTED_MARKER="${executed}" RTK_SH_LOG="${sh_log}" \
+      RTK_HOSTILE=1 CLAUDE_PROJECT_DIR="${work}" /bin/sh "${hook}"
     The status should be success
     The file "${executed}" should not be exist
   End

--- a/tests/shell/rtk_install_spec.sh
+++ b/tests/shell/rtk_install_spec.sh
@@ -48,6 +48,81 @@ EOF
   End
 End
 
+Describe 'rtk fallback installer integrity'
+  hook="${PFB_ROOT}/.claude/hooks/rtk-install.sh"
+  fixture="${PFB_ROOT}/tests/shell/fixtures/rtk-install-v0.43.0.sh"
+
+  setup() {
+    scrub_git_env
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rtk-fallback.XXXXXX")"
+    home="${work}/home"
+    shim="${work}/shim"
+    curl_log="${work}/curl.log"
+    executed="${work}/executed"
+    mkdir -p "${home}" "${shim}"
+    cat > "${shim}/curl" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$RTK_CURL_LOG"
+out=''
+url=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      shift
+      out="$1"
+      ;;
+    http*) url="$1" ;;
+  esac
+  shift
+done
+
+case "$url" in
+  *raw.githubusercontent.com/rtk-ai/rtk/*/install.sh)
+    if [ "${RTK_HOSTILE:-0}" = 1 ]; then
+      payload='touch "$RTK_EXECUTED_MARKER"'
+      if [ -n "$out" ]; then
+        printf '%s\n' "$payload" > "$out"
+      else
+        printf '%s\n' "$payload"
+      fi
+    elif [ -n "$out" ]; then
+      cp "$RTK_INSTALLER_FIXTURE" "$out"
+    else
+      cat "$RTK_INSTALLER_FIXTURE"
+    fi
+    exit 0
+    ;;
+  *) exit 22 ;;
+esac
+EOF
+    chmod +x "${shim}/curl"
+  }
+
+  cleanup() {
+    rm -rf "${work}"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'executes the verified immutable installer with a pinned release'
+    When run env HOME="${home}" PATH="${shim}:/usr/bin:/bin" RTK_CURL_LOG="${curl_log}" \
+      RTK_INSTALLER_FIXTURE="${fixture}" RTK_EXECUTED_MARKER="${executed}" \
+      CLAUDE_PROJECT_DIR="${work}" sh "${hook}"
+    The status should be success
+    The contents of file "${curl_log}" should include 'rtk/5a7880d404db8364d602f2ecdc41dd790f64013f/install.sh'
+    The contents of file "${curl_log}" should include '/releases/download/v0.43.0/rtk-'
+  End
+
+  It 'rejects changed installer bytes without executing them'
+    When run env HOME="${home}" PATH="${shim}:/usr/bin:/bin" RTK_CURL_LOG="${curl_log}" \
+      RTK_INSTALLER_FIXTURE="${fixture}" RTK_EXECUTED_MARKER="${executed}" RTK_HOSTILE=1 \
+      CLAUDE_PROJECT_DIR="${work}" sh "${hook}"
+    The status should be success
+    The file "${executed}" should not be exist
+  End
+End
+
 verify_vendor_rtk_bootstrap() {
   python3 - "$PFB_ROOT" <<'PY'
 import hashlib


### PR DESCRIPTION
## Summary

- pin the RTK fallback installer to commit `5a7880d404db8364d602f2ecdc41dd790f64013f`
- verify the installer against its recorded SHA-256 before execution
- force stable release `v0.43.0` and upstream payload checksum verification
- preserve best-effort SessionStart, local-install detection, PATH updates, and worktree filter trust

## Verification

- RED: `shellspec --shell "$(command -v dash)" tests/shell/rtk_install_spec.sh` — 5 examples, 2 failures; mutable installer executed the hostile payload
- frozen proof: `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`
- targeted RTK matrix: 18 examples, 0 failures
- `scripts/agent/run-gates.sh --diff origin/devel` — `GATES: PASS`

Fixes #1548

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
