### PR TITLE
pfblockerng: replace positional download interface

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11430,14 +11430,60 @@ function pfb_download_http_headers(array $extra_headers, string $conditional_hea
 }
 
 
-// Function to download feeds. Optional $response_meta — when a non-NULL reference is passed
-// (detector probe mode), filled with ['status' => <http_status_string>, 'etag' => <ETag or
-// ''>, 'lastmod' => <epoch or 0>]; the two sync callers in this file do NOT pass it, so their
-// behaviour is unchanged. Optional $extra_headers (ADR-59) — caller-supplied HTTP header
-// strings (e.g. a Cloudflare Radar 'Authorization: Bearer <token>'), merged with the
-// conditional-GET header via pfb_download_http_headers(). The TOP1M provider is the first
-// caller; every other feed still passes none, so its CURLOPT_HTTPHEADER behaviour is unchanged.
-function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $logtype, $vtype='', $timeout=300, $type='', $username='', $password='', $srcint=FALSE, &$response_meta=NULL, array $extra_headers=array()) {
+final class PfbDownloadRequest
+{
+	public function __construct(
+		public readonly string $listUrl,
+		public readonly string $downloadPath,
+		public readonly bool $flex,
+		public readonly string $header,
+		public readonly string $format,
+		public readonly int $logType,
+		public readonly string $versionType = '',
+		public readonly int $timeout = 300,
+		public readonly string $type = '',
+		public readonly string $username = '',
+		public readonly string $password = '',
+		public readonly string|false $sourceInterface = FALSE,
+		public readonly array $extraHeaders = array(),
+	) {
+	}
+}
+
+final class PfbDownloadResult
+{
+	private function __construct(
+		public readonly bool $success,
+		public readonly ?array $responseMeta,
+	) {
+	}
+
+	public static function success(?array $responseMeta = NULL): self
+	{
+		return new self(TRUE, $responseMeta);
+	}
+
+	public static function failure(?array $responseMeta = NULL): self
+	{
+		return new self(FALSE, $responseMeta);
+	}
+}
+
+// Function to download feeds.
+function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
+	$list_url = $request->listUrl;
+	$file_dwn = $request->downloadPath;
+	$pflex = $request->flex;
+	$header = $request->header;
+	$format = $request->format;
+	$logtype = $request->logType;
+	$vtype = $request->versionType;
+	$timeout = $request->timeout;
+	$type = $request->type;
+	$username = $request->username;
+	$password = $request->password;
+	$srcint = $request->sourceInterface;
+	$extra_headers = $request->extraHeaders;
 	global $pfb;
 	$http_status = '';
 	$elog = ">> {$pfb['log']} 2>&1";
@@ -11449,13 +11495,13 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 	if ($format == 'whois') {
 		if (empty(pfb_filter($list_url, PFB_FILTER_DOMAIN, 'pfb_download'))) {
 			pfb_logger("\n Failed", 2);
-			return FALSE;
+			return PfbDownloadResult::failure();
 		}
 	}
 	elseif ($format == 'asn') {
 		if (empty(pfb_filter($list_url, PFB_FILTER_ALNUM, 'pfb_download'))) {
 			pfb_logger("\n Failed", 2);
-			return FALSE;
+			return PfbDownloadResult::failure();
 		}
 	}
 	elseif (!pfb_filter($list_url, PFB_FILTER_URL, 'pfb_download_failure')) {
@@ -11464,7 +11510,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		// line goes to error.log only). See pfb_log_feed_host_reject().
 		pfb_log_feed_host_reject($list_url, $header, $logtype);
 		pfb_logger("\n Failed", 2);
-		return FALSE;
+		return PfbDownloadResult::failure();
 	}
 
 	// Cron change-detection probe (conditional GET + content hash; legacy name was 'md5')
@@ -11515,7 +11561,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			if (!pfb_feed_host_allowed($rsync_host, $rsync_reason, $rsync_pinned)) {
 				$log = "\n[ {$header} ] {$rsync_reason} \xe2\x80\x94 skipped\n";
 				pfb_logger("{$log}", "{$logtype}");
-				return FALSE;
+				return PfbDownloadResult::failure();
 			}
 
 			// Pin the connection to the vetted IP (substitute it for the host in the
@@ -11524,7 +11570,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			if ($rsync_src === '') {
 				$log = "\n[ {$header} ] feed host could not be pinned \xe2\x80\x94 skipped\n";
 				pfb_logger("{$log}", "{$logtype}");
-				return FALSE;
+				return PfbDownloadResult::failure();
 			}
 		}
 		$rsync_src_esc = escapeshellarg("{$rsync_src}");
@@ -11539,13 +11585,13 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			$rsync_msg = trim(implode(' ', $rsync_output));
 			$log = "\n  RSYNC Failed (exit {$rsync_rc})" . ($rsync_msg !== '' ? ": {$rsync_msg}" : '') . "...\n";
 			pfb_logger("{$log}", "{$logtype}");
-			return FALSE;
+			return PfbDownloadResult::failure();
 		}
 	}
 	elseif ($format == 'whois' || $format == 'asn') {
 		// Convert a Domain name/AS into its respective IP addresses
 		exec("{$pfb['script']} whoisconvert {$header_esc} {$vtype} {$list_url_esc} {$elog}");
-		return TRUE;
+		return PfbDownloadResult::success();
 	}
 	else {
 		// Determine if URL is a pfSense localfile
@@ -11561,7 +11607,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				$error = error_get_last();
 				$log = "\n[ {$header} ] {$error['message']}\n";
 				pfb_logger("{$log}", "{$logtype}");
-				return FALSE;
+				return PfbDownloadResult::failure();
 			} else {
 				// Save original downloaded file
 				@file_put_contents("{$file_download}", $file_data, LOCK_EX);
@@ -11596,14 +11642,14 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			    !pfb_feed_host_allowed($feed_host, $feed_reason, $feed_pinned)) {
 				$log = "\n[ {$header} ] {$feed_reason} \xe2\x80\x94 skipped\n";
 				pfb_logger("{$log}", "{$logtype}");
-				return FALSE;
+				return PfbDownloadResult::failure();
 			}
 
 			if (($fhandle = @fopen("{$file_download}", 'w')) !== FALSE) {
 				if (!($ch = curl_init("{$list_download}"))) {
 					$log = "\nFailed to create cURL resource... Exiting...\n";
 					pfb_logger("{$log}", "{$logtype}");
-					return FALSE;
+					return PfbDownloadResult::failure();
 				}
 
 				// Load curl default settings — incl. the CURLOPT_PROTOCOLS scheme allow-list
@@ -11776,7 +11822,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 						if ($fhandle) {
 							@fclose($fhandle);
 						}
-						return FALSE;
+						return PfbDownloadResult::failure();
 					}
 
 					$rdr_reason	= '';
@@ -11791,7 +11837,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 						if ($fhandle) {
 							@fclose($fhandle);
 						}
-						return FALSE;
+						return PfbDownloadResult::failure();
 					}
 
 					// Discard the redirect-page body so only the final hop's body
@@ -11832,28 +11878,23 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		}
 	}
 
-	// Probe mode for the cron detector (type='change_detect'): fill $response_meta when
-	// the caller requested it (ADR-42 conditional-GET path), then return.
+	// Probe mode for the cron detector (type='change_detect'): return response metadata
+	// (ADR-42 conditional-GET path), then return.
 	// A 304 means "not modified" — the server confirmed the feed unchanged; the
 	// caller (pfb_update_check detector) handles the 304 via pfb_conditional_get_decision.
 	// Any 200 means the body was downloaded to {file_dwn}.raw; the caller hashes it.
 	// Any other status means the probe failed; the caller fails-safe to re-ingest.
 	//
-	// CONTRACT: the caller MUST pass $response_meta = array() (not NULL) to activate
-	// the fill block.  NULL is the sentinel for the two sync callers that do NOT want
-	// the block filled; NULL !== NULL is always FALSE, so NULL silently skips the fill.
 	if ($type == 'change_detect') {
-		if ($response_meta !== NULL) {
-			$response_meta = array(
-				'status'  => (string) $http_status,
-				'etag'    => isset($response_etag) ? $response_etag : '',
-				'lastmod' => isset($remote_stamp) && $remote_stamp > 0 ? (int) $remote_stamp : 0,
-			);
-		}
+		$probe_meta = array(
+			'status'  => (string) $http_status,
+			'etag'    => isset($response_etag) ? $response_etag : '',
+			'lastmod' => isset($remote_stamp) && $remote_stamp > 0 ? (int) $remote_stamp : 0,
+		);
 		if ($http_status == '304' || $http_status == '200') {
-			return TRUE;
+			return PfbDownloadResult::success($probe_meta);
 		}
-		return FALSE;
+		return PfbDownloadResult::failure($probe_meta);
 	}
 
 	// Remove any downloaded files with md5 extension
@@ -11861,7 +11902,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 
 	// '304 not modified' - Utilize previously downloaded file if available
 	if ($http_status == '304' && file_exists("{$orig_download}")) {
-		return TRUE;
+		return PfbDownloadResult::success();
 	}
 
 	if (file_exists($file_download) && ($http_status == '200' || $http_status == '221' || $http_status == '226')) {
@@ -11875,7 +11916,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 		$file_type = pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download', '', FALSE, $reject_detail);
 		if (!$file_type) {
 			pfb_validate_log($header, 'mime', 'mime_not_allowed', pfb_reject_detail_summary($reject_detail));
-			return FALSE;
+			return PfbDownloadResult::failure();
 		}
 
 		// ADR-49: opt-in plain-text sanity scan on accepted text feeds. The flag is
@@ -11901,7 +11942,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				if ($pfb_sanity !== NULL) {
 					pfb_validate_log($header, 'plaintext', $pfb_sanity, basename($file_download));
 					unlink_if_exists($file_download);
-					return FALSE;
+					return PfbDownloadResult::failure();
 				}
 			}
 		}
@@ -11931,7 +11972,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			if (!pfb_validate_archive($file_download, $file_type)) {
 				pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
 				unlink_if_exists($file_download);
-				return FALSE;
+				return PfbDownloadResult::failure();
 			}
 			if ($type == 'geoip') {
 				// Extras - MaxMind downloads
@@ -11941,29 +11982,29 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				if ($unsafe_member !== NULL) {
 					pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
 					unlink_if_exists($file_download);
-					return FALSE;
+					return PfbDownloadResult::failure();
 				}
 				exec("/usr/bin/tar -xzf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1", $output, $retval);
 				unlink_if_exists($file_download);
 				if ($retval != 0) {
 					pfb_logger("\n[pfb_download] geoip extraction failed (tar exit {$retval})", 2);
-					return FALSE;
+					return PfbDownloadResult::failure();
 				}
-				return TRUE;
+				return PfbDownloadResult::success();
 			}
 			elseif ($type == 'asn') {
 				exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);
 				if ($retval != 0) {
 					pfb_logger("\n[pfb_download] asn extraction failed (gunzip exit {$retval})", 2);
 					unlink_if_exists($file_download);
-					return FALSE;
+					return PfbDownloadResult::failure();
 				}
 
 				// Update ASN Lookup table definitions
 				exec("{$pfb['script']} asn_table {$elog}");
 
 				unlink_if_exists($file_download);
-				return TRUE;
+				return PfbDownloadResult::success();
 			}
 			elseif ($type == 'top1m') {
 				// ADR-59: a gz-container TOP1M provider decompresses straight to
@@ -11972,9 +12013,9 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				unlink_if_exists($file_download);
 				if ($retval != 0) {
 					pfb_logger("\n[pfb_download] top1m extraction failed (gunzip exit {$retval})", 2);
-					return FALSE;
+					return PfbDownloadResult::failure();
 				}
-				return TRUE;
+				return PfbDownloadResult::success();
 			}
 			elseif ($type == 'blacklist') {
 				// Extras - Blacklist downloads
@@ -11993,7 +12034,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					if ($unsafe_member !== NULL) {
 						pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
 						unlink_if_exists($file_dwn);
-						return FALSE;
+						return PfbDownloadResult::failure();
 					}
 
 					// Extract Blacklist categories from sub-folders into a single folder structure
@@ -12021,14 +12062,14 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				}
 				else {
 					pfb_logger("\n Invalid filename [{$filename}]", 1);
-					return FALSE;
+					return PfbDownloadResult::failure();
 				}
 			}
 			else {
 				$reject_detail = array();
 				if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail)) {
 					pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
-					return FALSE;
+					return PfbDownloadResult::failure();
 				}
 				pfb_logger('.', 1);
 				exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$file_org_esc}", $output, $retval);
@@ -12038,12 +12079,12 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			if (!pfb_validate_archive($file_download, $file_type)) {
 				pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
 				unlink_if_exists($file_download);
-				return FALSE;
+				return PfbDownloadResult::failure();
 			}
 			$reject_detail = array();
 			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail)) {
 				pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
-				return FALSE;
+				return PfbDownloadResult::failure();
 			}
 			pfb_logger('.', 1);
 			exec("/usr/bin/bzip2 -dkc {$file_dwn_esc} > {$file_org_esc}", $output, $retval);
@@ -12052,7 +12093,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			if (!pfb_validate_archive($file_download, $file_type)) {
 				pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
 				unlink_if_exists($file_download);
-				return FALSE;
+				return PfbDownloadResult::failure();
 			}
 
 			// Extras - MaxMind/TOP1M downloads
@@ -12067,7 +12108,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 					if ($unsafe_member !== NULL) {
 						pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
 						unlink_if_exists($file_download);
-						return FALSE;
+						return PfbDownloadResult::failure();
 					}
 					exec("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1", $output, $retval);
 				} else {
@@ -12078,9 +12119,9 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				if ($retval != 0) {
 					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})", 2);
 					unlink_if_exists($file_download);
-					return FALSE;
+					return PfbDownloadResult::failure();
 				}
-				return TRUE;
+				return PfbDownloadResult::success();
 			}
 
 			pfb_logger('.', 1);
@@ -12094,7 +12135,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			   the post-extraction PFB_FILTER_FILE_MIME re-check below is the ZIP
 			   inner-content gate (issue #808).
 			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download')) {
-				return FALSE;
+				return PfbDownloadResult::failure();
 			}
 			*/
 	
@@ -12124,7 +12165,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			if (!pfb_filter(array("{$file_org_esc}", "{$orig_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download', '', FALSE, $reject_detail)) {
 				pfb_validate_log($header, 'inner', 'inner_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
 				unlink_if_exists($file_download);
-				return FALSE;
+				return PfbDownloadResult::failure();
 			}
 		}
 		elseif ($file_type == 'application/x-7z-compressed') {
@@ -12135,17 +12176,17 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			if ($missing_7z !== NULL) {
 				pfb_logger("\n[pfb_download] Cannot process {$file_type} feed: '{$missing_7z}' is not installed. Install the 7-Zip package (pkg install 7-zip) to use 7z-compressed feeds. Skipping [" . htmlspecialchars(pfb_redact_url($list_url)) . "]", 2);
 				unlink_if_exists($file_download);
-				return FALSE;
+				return PfbDownloadResult::failure();
 			}
 			if (!pfb_validate_archive($file_download, $file_type)) {
 				pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
 				unlink_if_exists($file_download);
-				return FALSE;
+				return PfbDownloadResult::failure();
 			}
 			$reject_detail = array();
 			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail)) {
 				pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
-				return FALSE;
+				return PfbDownloadResult::failure();
 			}
 			pfb_logger('.', 1);
 			exec("/usr/local/bin/7z e -so {$file_dwn_esc} > {$file_org_esc}", $output, $retval);
@@ -12159,9 +12200,9 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				$renamed = @rename("{$file_download}", "{$head_download}");
 				if (!$renamed) {
 					pfb_logger("\n[pfb_download] {$type} rename to destination failed", 2);
-					return FALSE;
+					return PfbDownloadResult::failure();
 				}
-				return TRUE;
+				return PfbDownloadResult::success();
 			}
 			elseif ($type == 'blacklist') {
 				$retval = 0;
@@ -12171,7 +12212,7 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				$renamed = @rename("{$file_download}", "{$orig_download}");
 				if (!$renamed) {
 					pfb_logger("\n[pfb_download] {$header} rename to .orig failed", 2);
-					return FALSE;
+					return PfbDownloadResult::failure();
 				}
 				$retval = 0;
 			}
@@ -12216,19 +12257,19 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 			if (strpos($list_url, 'iprepdata.txt') !== FALSE) {
 				exec("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}");
 			}
-			return TRUE;
+				return PfbDownloadResult::success();
 		}
 		else {
 			$log = "   Decompression Failed\n";
 			pfb_logger("{$log}", 2);
-			return FALSE;
+				return PfbDownloadResult::failure();
 		}
 	}
 	else {
 		// Download failed
 		unlink_if_exists("{$file_download}");
 	}
-	return FALSE;
+	return PfbDownloadResult::failure();
 }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12227,7 +12227,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			// ADR-42 / issue #713 bug 5: refresh the content-hash sidecar at every
 			// successful ingest so pfb_local_feed_changed() / the probe's conditional-GET
 			// compare always land on the SAME domain of bytes the probe hashed.  The probe
-			// (pfb_update_check -> pfb_download($type='change_detect')) hashes the RAW
+			// (pfb_update_check -> pfb_download(PfbDownloadRequest(type: 'change_detect'))) hashes the RAW
 			// fetched body (it returns before any decompression), so the persisted digest
 			// here must cover those same raw bytes too -- not the decompressed '.orig' --
 			// or a compressed feed (gz/bz2/zip/7z) never matches and re-ingests every cron.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -1644,8 +1644,21 @@ function sync_package_pfblockerng($cron='') {
 										pfb_logger(' completed .', 1);
 									} else {
 										// Download file
-										if (!pfb_download($row['url'], $file_dwn, $pflex, $header,
-											$row['format'], 1, '', 300, '', '', '', $srcint)) {
+										if (!(pfb_download(new PfbDownloadRequest(
+											listUrl: $row['url'],
+											downloadPath: $file_dwn,
+											flex: $pflex,
+											header: $header,
+											format: $row['format'],
+											logType: 1,
+											versionType: '',
+											timeout: 300,
+											type: '',
+											username: '',
+											password: '',
+											sourceInterface: $srcint,
+											extraHeaders: array(),
+										))->success)) {
 
 											// Determine reason for download failure
 											pfb_download_failure($alias, $header, $pfbfolder, $row['url'], $row['format'], '');
@@ -3109,8 +3122,21 @@ function sync_package_pfblockerng($cron='') {
 								}
 								else {
 									// Download list
-									if (!pfb_download($row['url'], $file_dwn, $pflex, $header, $row['format'],
-										1, $list['vtype'], 300, '', '', '', $srcint)) {
+									if (!(pfb_download(new PfbDownloadRequest(
+										listUrl: $row['url'],
+										downloadPath: $file_dwn,
+										flex: $pflex,
+										header: $header,
+										format: $row['format'],
+										logType: 1,
+										versionType: $list['vtype'],
+										timeout: 300,
+										type: '',
+										username: '',
+										password: '',
+										sourceInterface: $srcint,
+										extraHeaders: array(),
+									))->success)) {
 
 										// Determine reason for download failure
 										pfb_download_failure($alias, $header, $pfbfolder, $row['url'], $row['format'], $list['vtype']);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc
@@ -146,10 +146,23 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 			// decided by pfb_conditional_get_decision() (decision matrix documented
 			// there). The SSRF guard + redirect revalidation loop stay intact because the
 			// probe goes through pfb_download(), not a bare curl_init().
-			$probe_meta = array();
-			$probe_ok = pfb_download("{$list_download}", "{$pfborig}/{$header}.md5", $pflex, $header, '', 1, '', 300, 'change_detect', '', '', $srcint, $probe_meta);
+			$probe_result = pfb_download(new PfbDownloadRequest(
+				listUrl: "{$list_download}",
+				downloadPath: "{$pfborig}/{$header}.md5",
+				flex: $pflex,
+				header: $header,
+				format: '',
+				logType: 1,
+				versionType: '',
+				timeout: 300,
+				type: 'change_detect',
+				username: '',
+				password: '',
+				sourceInterface: $srcint,
+				extraHeaders: array(),
+			));
 
-			if (!$probe_ok || $probe_meta === NULL) {
+			if (!$probe_result->success || $probe_result->responseMeta === NULL) {
 				// Probe failed entirely (connection error, bad URL, etc.) → fail-safe.
 				$log = "\n\tFailed to probe feed for change detection!\tUpdate skipped\n";
 				unlink_if_exists("{$pfborig}/{$header}.md5.raw");
@@ -158,6 +171,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 				return;
 			}
 
+			$probe_meta = $probe_result->responseMeta;
 			$probe_status = $probe_meta['status'];
 
 			if ($probe_status === '304') {

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -467,8 +467,21 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 		// (Cloudflare Radar's Bearer token; array() for every keyless provider) --
 		// every other feed leaves it unset, so ?? array() keeps their downloads
 		// unaffected.
-		if (!pfb_download($feed['url'], $file_dwn, FALSE, "{$feed['folder']}/{$feed['file']}", '', $logtype, '', $timeout, $feed['type'],
-		    $feed['username'], $feed['password'], extra_headers: $feed['headers'] ?? array())) {
+		if (!(pfb_download(new PfbDownloadRequest(
+			listUrl: $feed['url'],
+			downloadPath: $file_dwn,
+			flex: FALSE,
+			header: "{$feed['folder']}/{$feed['file']}",
+			format: '',
+			logType: $logtype,
+			versionType: '',
+			timeout: $timeout,
+			type: $feed['type'],
+			username: $feed['username'],
+			password: $feed['password'],
+			sourceInterface: FALSE,
+			extraHeaders: $feed['headers'] ?? array(),
+		))->success)) {
 
 			$log = "\nFailed to Download {$feed['file']}\n";
 			pfb_logger("{$log}", $logtype);

--- a/tests/php/ConditionalGetHelpersTest.php
+++ b/tests/php/ConditionalGetHelpersTest.php
@@ -403,65 +403,6 @@ final class ConditionalGetHelpersTest extends TestCase
 		);
 	}
 
-	// -------------------------------------------------------------------------
-	// pfb_download() fill-guard contract — NULL vs array()
-	// -------------------------------------------------------------------------
-
-	/**
-	 * The fill guard inside pfb_download uses `$response_meta !== NULL`.
-	 * Callers MUST pass array() (not NULL) to activate the fill.
-	 * This test pins the PHP identity contract that makes that guard work:
-	 *   - NULL !== NULL  is FALSE  → the sync callers (passing no 13th arg → default NULL)
-	 *                                 silently skip the fill block (correct).
-	 *   - array() !== NULL is TRUE → the probe caller (pfb_update_check) gets the block
-	 *                                 filled (required for change detection to function).
-	 *
-	 * Context: pfb_download itself cannot be exercised off-appliance (its localfile
-	 * branch requires paths under the hardcoded allowed dirs — /var/db/pfblockerng/* —
-	 * which are not writable in CI; the curl branch needs a network peer).  This test
-	 * pins the guard contract at the PHP-identity level so the blocker (NULL init in
-	 * pfblockerng.php that silently disabled all remote change detection) cannot regress
-	 * without a RED test.
-	 *
-	 * RED on a pre-fix codebase where pfblockerng.php initialised $probe_meta = NULL
-	 * instead of $probe_meta = array(): see FIX 1 in the ADR-42 review findings.
-	 */
-	public function test_probe_meta_fill_guard_requires_array_not_null(): void
-	{
-		// NULL !== NULL → FALSE: the fill block is SKIPPED (sync-caller sentinel).
-		$this->assertFalse(
-			NULL !== NULL,
-			'NULL !== NULL must be FALSE — the fill-guard skip-sentinel contract'
-		);
-
-		// array() !== NULL → TRUE: the fill block FIRES (probe-caller contract).
-		$this->assertTrue(
-			array() !== NULL,
-			'array() !== NULL must be TRUE — the probe caller must pass array(), not NULL, '
-			. 'to activate the pfb_download fill block; passing NULL silently disables change detection'
-		);
-
-		// Simulate the pre-fix bug: $probe_meta = NULL stays NULL after a hypothetical
-		// fill attempt (the guard would have been skipped).  The post-fix $probe_meta = array()
-		// would be replaced with the filled array.  We assert the guard distinction here
-		// rather than calling pfb_download (not exercisable off-appliance — see above).
-		$probe_meta_broken = NULL;
-		$probe_meta_fixed  = array();
-		$fills_on_broken   = ($probe_meta_broken !== NULL);	// FALSE — fill skipped
-		$fills_on_fixed    = ($probe_meta_fixed  !== NULL);	// TRUE  — fill fires
-
-		$this->assertFalse(
-			$fills_on_broken,
-			'Pre-fix NULL init: the fill guard evaluates to FALSE → fill is skipped → '
-			. '$probe_meta stays NULL → caller sees NULL and treats every probe as failed'
-		);
-		$this->assertTrue(
-			$fills_on_fixed,
-			'Post-fix array() init: the fill guard evaluates to TRUE → fill fires → '
-			. '$probe_meta is populated → change detection works correctly'
-		);
-	}
-
 	/**
 	 * ADR-42 §3 — the probe must read validators from the detector's {header}.orig
 	 * baseline, NOT the infixed {header}.md5.orig.  The detector hands pfb_download

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -22,12 +22,12 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$source = file_get_contents(
 			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
 		);
-		if ($source === false) {
+		if ($source === FALSE) {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
 		}
 
 		$start = strpos($source, 'function pfb_download(');
-		if ($start === false) {
+		if ($start === FALSE) {
 			throw new RuntimeException('test bootstrap: function pfb_download( not found');
 		}
 
@@ -73,7 +73,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 				&& $tokens[$i + 4] === array('id' => T_LNUMBER, 'text' => '0')
 				&& $tokens[$i + 5]['text'] === ')') {
 				return $tokens[$i + 6]['text'] === '{'
-					&& self::hasDirectFalseReturn($tokens, $i + 6);
+					&& self::hasDirectFailureResult($tokens, $i + 6);
 			}
 		}
 
@@ -81,7 +81,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	}
 
 	/**
-	 * @return array{bound: bool, directReturn: bool}
+	 * @return array{bound: bool, directFailureResult: bool}
 	 */
 	private static function analyzeRenameGuard(string $segment, string $destination, int $outerDepth = 0): array
 	{
@@ -114,7 +114,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 				|| ($depths[$assignment] ?? NULL) !== $outerDepth
 				|| ($depths[$lhs] ?? NULL) !== $outerDepth
 				|| ($boundary !== NULL && !in_array($boundary, [';', '{', '}'], TRUE))) {
-				return array('bound' => FALSE, 'directReturn' => FALSE);
+				return array('bound' => FALSE, 'directFailureResult' => FALSE);
 			}
 
 			$args = array(array());
@@ -144,7 +144,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 				$args
 			);
 			if ($close === NULL || $argumentText !== ['"{$file_download}"', '"{' . $destination . '}"']) {
-				return array('bound' => FALSE, 'directReturn' => FALSE);
+				return array('bound' => FALSE, 'directFailureResult' => FALSE);
 			}
 
 			$guard = $close + 2;
@@ -158,16 +158,16 @@ final class DownloadExtractionExitCodeTest extends TestCase
 				&& ($tokens[$guard + 4]['text'] ?? '') === ')'
 				&& ($tokens[$guard + 5]['text'] ?? '') === '{';
 			if (!$bound) {
-				return array('bound' => FALSE, 'directReturn' => FALSE);
+				return array('bound' => FALSE, 'directFailureResult' => FALSE);
 			}
 
 			return array(
 				'bound' => TRUE,
-				'directReturn' => self::hasDirectFalseReturn($tokens, $guard + 5)
+				'directFailureResult' => self::hasDirectFailureResult($tokens, $guard + 5)
 			);
 		}
 
-		return array('bound' => FALSE, 'directReturn' => FALSE);
+		return array('bound' => FALSE, 'directFailureResult' => FALSE);
 	}
 
 	/**
@@ -206,7 +206,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	/**
 	 * @param list<array{id: int|null, text: string}> $tokens
 	 */
-	private static function hasDirectFalseReturn(array $tokens, int $openingBrace): bool
+	private static function hasDirectFailureResult(array $tokens, int $openingBrace): bool
 	{
 		$depth = 1;
 		$interpolationDepth = 0;
@@ -237,29 +237,79 @@ final class DownloadExtractionExitCodeTest extends TestCase
 					&& ($tokens[$i + 3] ?? NULL) === array('id' => T_STRING, 'text' => 'failure')
 					&& ($tokens[$i + 4]['text'] ?? '') === '('
 					&& ($tokens[$i + 5]['text'] ?? '') === ')'
-					&& ($tokens[$i + 6]['text'] ?? '') === ';')
-					|| (($tokens[$i + 1] ?? NULL) === array('id' => T_STRING, 'text' => 'FALSE')
-						&& ($tokens[$i + 2]['text'] ?? '') === ';');
+					&& ($tokens[$i + 6]['text'] ?? '') === ';');
 			}
 		}
 
 		return FALSE;
 	}
 
+	public function testEveryPfbDownloadReturnUsesTypedResultExceptHeaderCallback(): void
+	{
+		$tokens = self::significantTokens(self::$body);
+		$typedResultCount = 0;
+		$headerCallbackCount = 0;
+		$unexpectedReturns = array();
+
+		for ($i = 0, $count = count($tokens); $i < $count; $i++) {
+			if ($tokens[$i]['id'] !== T_RETURN) {
+				continue;
+			}
+
+			$isTypedResult = ($tokens[$i + 1] ?? NULL) === array('id' => T_STRING, 'text' => 'PfbDownloadResult')
+				&& ($tokens[$i + 2]['id'] ?? NULL) === T_DOUBLE_COLON
+				&& in_array($tokens[$i + 3] ?? NULL, [
+					array('id' => T_STRING, 'text' => 'success'),
+					array('id' => T_STRING, 'text' => 'failure'),
+				], TRUE)
+				&& ($tokens[$i + 4]['text'] ?? '') === '(';
+			if ($isTypedResult) {
+				$typedResultCount++;
+				continue;
+			}
+
+			$isHeaderCallback = ($tokens[$i + 1] ?? NULL) === array('id' => T_STRING, 'text' => 'strlen')
+				&& ($tokens[$i + 2]['text'] ?? '') === '('
+				&& ($tokens[$i + 3] ?? NULL) === array('id' => T_VARIABLE, 'text' => '$hdr_line')
+				&& ($tokens[$i + 4]['text'] ?? '') === ')'
+				&& ($tokens[$i + 5]['text'] ?? '') === ';';
+			if ($isHeaderCallback) {
+				$headerCallbackCount++;
+				continue;
+			}
+
+			$expression = '';
+			for ($j = $i; $j < min($i + 8, $count); $j++) {
+				$expression .= $tokens[$j]['text'];
+			}
+			$unexpectedReturns[] = $expression;
+		}
+
+		$this->assertStringContainsString('function ($curl_handle, $hdr_line)', self::$body,
+			'vacuity: the sole non-result return must remain the cURL header callback');
+		$this->assertSame(44, $typedResultCount,
+			'pfb_download() must expose exactly 44 PfbDownloadResult success/failure returns');
+		$this->assertSame(1, $headerCallbackCount,
+			'pfb_download() may have only the header callback strlen return outside PfbDownloadResult');
+		$this->assertSame(array(), $unexpectedReturns,
+			'pfb_download() has an untyped return; every return must be PfbDownloadResult success/failure '
+			. 'except the header callback strlen: ' . json_encode($unexpectedReturns));
+	}
+
 	// -----------------------------------------------------------------------
 	// Row 1 -- gzip geoip: /usr/bin/tar -xzf site.
 	// -----------------------------------------------------------------------
 
-	public function testGzipGeoipTarCapturesRetvalAndIsCheckedBeforeReturnTrue(): void
+	public function testGzipGeoipTarCapturesRetvalAndIsCheckedBeforeSuccessResult(): void
 	{
 		$tarPos = strpos(self::$body, "/usr/bin/tar -xzf {\$file_dwn_esc} --strip=1 -C {\$pfb['geoipshare']}");
 		$this->assertNotFalse($tarPos, 'vacuity: the gzip-geoip tar -xzf site must exist for this test to mean anything');
 
-		$returnTrue = strpos(self::$body, 'return PfbDownloadResult::success();', $tarPos);
-		$this->assertNotFalse($returnTrue, 'vacuity: gzip-geoip site must reach a success result;');
+		$successResult = strpos(self::$body, 'return PfbDownloadResult::success();', $tarPos);
+		$this->assertNotFalse($successResult, 'vacuity: gzip-geoip site must reach a success result;');
 		$segmentStart = strrpos(substr(self::$body, 0, $tarPos), "\n");
 		$segmentStart = $segmentStart === FALSE ? 0 : $segmentStart + 1;
-		$segment = substr(self::$body, $segmentStart, $returnTrue + strlen('return PfbDownloadResult::success();') - $segmentStart);
+		$segment = substr(self::$body, $segmentStart, $successResult + strlen('return PfbDownloadResult::success();') - $segmentStart);
 
 		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segment,
 			'gzip-geoip tar -xzf must capture $output, $retval -- a corrupt archive currently reports success unconditionally');
@@ -297,7 +347,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	// Row 3 -- gzip top1m: same gunzip-capture-but-ignored shape as asn.
 	// -----------------------------------------------------------------------
 
-	public function testGzipTop1mChecksRetvalBeforeReturnTrue(): void
+	public function testGzipTop1mChecksRetvalBeforeSuccessResult(): void
 	{
 		$top1mAnchor = strpos(self::$body, "\$type == 'top1m'");
 		$this->assertNotFalse($top1mAnchor, 'vacuity: the gzip-top1m branch must exist');
@@ -305,9 +355,9 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$gunzip = strpos(self::$body, 'exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}"', $top1mAnchor);
 		$this->assertNotFalse($gunzip, 'vacuity: gzip-top1m gunzip exec must exist');
 
-		$returnTrue = strpos(self::$body, 'return PfbDownloadResult::success();', $gunzip);
-		$this->assertNotFalse($returnTrue, 'vacuity: gzip-top1m site must reach a success result;');
-		$segment = substr(self::$body, $gunzip, $returnTrue + strlen('return PfbDownloadResult::success();') - $gunzip);
+		$successResult = strpos(self::$body, 'return PfbDownloadResult::success();', $gunzip);
+		$this->assertNotFalse($successResult, 'vacuity: gzip-top1m site must reach a success result;');
+		$segment = substr(self::$body, $gunzip, $successResult + strlen('return PfbDownloadResult::success();') - $gunzip);
 
 		$this->assertTrue(self::hasNonzeroRetvalGuard($segment),
 			'gzip-top1m must check nonzero $retval before its success result -- a nonzero gunzip exit must not report success; '
@@ -350,10 +400,10 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	// -----------------------------------------------------------------------
 	// Row 5 & 6 -- zip extras: both the multi-member (-xf) and single-member
 	// (-xOf) tar sites must capture $retval; a check must gate their shared
-	// return TRUE.
+	// success result.
 	// -----------------------------------------------------------------------
 
-	public function testZipExtrasBothTarSitesCaptureRetvalAndAreCheckedBeforeReturnTrue(): void
+	public function testZipExtrasBothTarSitesCaptureRetvalAndAreCheckedBeforeSuccessResult(): void
 	{
 		$multi = strpos(self::$body, 'exec("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc}');
 		$this->assertNotFalse($multi, 'vacuity: the zip multi-member tar -xf site must exist');
@@ -361,18 +411,18 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$single = strpos(self::$body, 'exec("/usr/bin/tar -xOf {$file_dwn_esc} > {$header_esc}"', $multi);
 		$this->assertNotFalse($single, 'vacuity: the zip single-member tar -xOf site must exist');
 
-		$returnTrue = strpos(self::$body, 'return PfbDownloadResult::success();', $single);
-		$this->assertNotFalse($returnTrue, 'vacuity: zip extras must reach a shared success result;');
+		$successResult = strpos(self::$body, 'return PfbDownloadResult::success();', $single);
+		$this->assertNotFalse($successResult, 'vacuity: zip extras must reach a shared success result;');
 
 		$segMulti = substr(self::$body, $multi, $single - $multi);
 		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segMulti,
 			'zip multi-member tar -xf must capture $output, $retval; segment: ' . json_encode($segMulti));
 
-		$segSingleToReturn = substr(self::$body, $single, $returnTrue + strlen('return PfbDownloadResult::success();') - $single);
+		$segSingleToReturn = substr(self::$body, $single, $successResult + strlen('return PfbDownloadResult::success();') - $single);
 		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segSingleToReturn,
 			'zip single-member tar -xOf must capture $output, $retval; segment: ' . json_encode($segSingleToReturn));
 		$this->assertTrue(self::hasNonzeroRetvalGuard($segSingleToReturn),
-			'zip extras must check nonzero $retval before their shared return TRUE; segment: '
+			'zip extras must check nonzero $retval before their shared success result; segment: '
 			. json_encode($segSingleToReturn));
 	}
 
@@ -392,7 +442,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$analysis = self::analyzeRenameGuard($segment, '$head_download', 1);
 		$this->assertTrue($analysis['bound'],
 			'uncompressed extras must check !$renamed before success result; segment: ' . json_encode($segment));
-		$this->assertTrue($analysis['directReturn'],
+		$this->assertTrue($analysis['directFailureResult'],
 			'a failed rename() must have a failure result path; segment: ' . json_encode($segment));
 	}
 
@@ -418,7 +468,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertTrue($analysis['bound'],
 			'generic uncompressed feeds must check !$renamed before the $retval == 0 success gate; segment: '
 			. json_encode($segment));
-		$this->assertTrue($analysis['directReturn'],
+		$this->assertTrue($analysis['directFailureResult'],
 			'a failed rename() must have a failure result path before the success gate; segment: ' . json_encode($segment));
 	}
 }

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -232,8 +232,14 @@ final class DownloadExtractionExitCodeTest extends TestCase
 					break;
 				}
 			} elseif ($depth === 1 && $tokens[$i]['id'] === T_RETURN) {
-				return ($tokens[$i + 1] ?? NULL) === array('id' => T_STRING, 'text' => 'FALSE')
-					&& ($tokens[$i + 2]['text'] ?? '') === ';';
+				return (($tokens[$i + 1] ?? NULL) === array('id' => T_STRING, 'text' => 'PfbDownloadResult')
+					&& ($tokens[$i + 2]['id'] ?? NULL) === T_DOUBLE_COLON
+					&& ($tokens[$i + 3] ?? NULL) === array('id' => T_STRING, 'text' => 'failure')
+					&& ($tokens[$i + 4]['text'] ?? '') === '('
+					&& ($tokens[$i + 5]['text'] ?? '') === ')'
+					&& ($tokens[$i + 6]['text'] ?? '') === ';')
+					|| (($tokens[$i + 1] ?? NULL) === array('id' => T_STRING, 'text' => 'FALSE')
+						&& ($tokens[$i + 2]['text'] ?? '') === ';');
 			}
 		}
 
@@ -249,16 +255,16 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$tarPos = strpos(self::$body, "/usr/bin/tar -xzf {\$file_dwn_esc} --strip=1 -C {\$pfb['geoipshare']}");
 		$this->assertNotFalse($tarPos, 'vacuity: the gzip-geoip tar -xzf site must exist for this test to mean anything');
 
-		$returnTrue = strpos(self::$body, 'return TRUE;', $tarPos);
-		$this->assertNotFalse($returnTrue, 'vacuity: gzip-geoip site must reach a return TRUE;');
+		$returnTrue = strpos(self::$body, 'return PfbDownloadResult::success();', $tarPos);
+		$this->assertNotFalse($returnTrue, 'vacuity: gzip-geoip site must reach a success result;');
 		$segmentStart = strrpos(substr(self::$body, 0, $tarPos), "\n");
 		$segmentStart = $segmentStart === FALSE ? 0 : $segmentStart + 1;
-		$segment = substr(self::$body, $segmentStart, $returnTrue + strlen('return TRUE;') - $segmentStart);
+		$segment = substr(self::$body, $segmentStart, $returnTrue + strlen('return PfbDownloadResult::success();') - $segmentStart);
 
 		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segment,
 			'gzip-geoip tar -xzf must capture $output, $retval -- a corrupt archive currently reports success unconditionally');
 		$this->assertTrue(self::hasNonzeroRetvalGuard($segment),
-			'gzip-geoip must check nonzero $retval before its return TRUE -- a nonzero exit must not report success');
+			'gzip-geoip must check nonzero $retval before its success result -- a nonzero exit must not report success');
 	}
 
 	// -----------------------------------------------------------------------
@@ -283,8 +289,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			'gzip-asn must check $retval and bail BEFORE the asn_table exec -- else a failed decompress '
 			. 'rebuilds the ASN table from a stale/partial file; found between gunzip and asn_table: '
 			. json_encode($segment));
-		$this->assertStringContainsString('return FALSE', $segment,
-			'gzip-asn nonzero-retval path must return FALSE before asn_table runs');
+		$this->assertStringContainsString('PfbDownloadResult::failure()', $segment,
+			'gzip-asn nonzero-retval path must return failure before asn_table runs');
 	}
 
 	// -----------------------------------------------------------------------
@@ -299,12 +305,12 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$gunzip = strpos(self::$body, 'exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}"', $top1mAnchor);
 		$this->assertNotFalse($gunzip, 'vacuity: gzip-top1m gunzip exec must exist');
 
-		$returnTrue = strpos(self::$body, 'return TRUE;', $gunzip);
-		$this->assertNotFalse($returnTrue, 'vacuity: gzip-top1m site must reach a return TRUE;');
-		$segment = substr(self::$body, $gunzip, $returnTrue + strlen('return TRUE;') - $gunzip);
+		$returnTrue = strpos(self::$body, 'return PfbDownloadResult::success();', $gunzip);
+		$this->assertNotFalse($returnTrue, 'vacuity: gzip-top1m site must reach a success result;');
+		$segment = substr(self::$body, $gunzip, $returnTrue + strlen('return PfbDownloadResult::success();') - $gunzip);
 
 		$this->assertTrue(self::hasNonzeroRetvalGuard($segment),
-			'gzip-top1m must check nonzero $retval before its return TRUE -- a nonzero gunzip exit must not report success; '
+			'gzip-top1m must check nonzero $retval before its success result -- a nonzero gunzip exit must not report success; '
 			. 'segment: ' . json_encode($segment));
 	}
 
@@ -355,14 +361,14 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$single = strpos(self::$body, 'exec("/usr/bin/tar -xOf {$file_dwn_esc} > {$header_esc}"', $multi);
 		$this->assertNotFalse($single, 'vacuity: the zip single-member tar -xOf site must exist');
 
-		$returnTrue = strpos(self::$body, 'return TRUE;', $single);
-		$this->assertNotFalse($returnTrue, 'vacuity: zip extras must reach a shared return TRUE;');
+		$returnTrue = strpos(self::$body, 'return PfbDownloadResult::success();', $single);
+		$this->assertNotFalse($returnTrue, 'vacuity: zip extras must reach a shared success result;');
 
 		$segMulti = substr(self::$body, $multi, $single - $multi);
 		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segMulti,
 			'zip multi-member tar -xf must capture $output, $retval; segment: ' . json_encode($segMulti));
 
-		$segSingleToReturn = substr(self::$body, $single, $returnTrue + strlen('return TRUE;') - $single);
+		$segSingleToReturn = substr(self::$body, $single, $returnTrue + strlen('return PfbDownloadResult::success();') - $single);
 		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segSingleToReturn,
 			'zip single-member tar -xOf must capture $output, $retval; segment: ' . json_encode($segSingleToReturn));
 		$this->assertTrue(self::hasNonzeroRetvalGuard($segSingleToReturn),
@@ -385,9 +391,9 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 		$analysis = self::analyzeRenameGuard($segment, '$head_download', 1);
 		$this->assertTrue($analysis['bound'],
-			'uncompressed extras must check !$renamed before return TRUE; segment: ' . json_encode($segment));
+			'uncompressed extras must check !$renamed before success result; segment: ' . json_encode($segment));
 		$this->assertTrue($analysis['directReturn'],
-			'a failed rename() must have a return FALSE path; segment: ' . json_encode($segment));
+			'a failed rename() must have a failure result path; segment: ' . json_encode($segment));
 	}
 
 	// -----------------------------------------------------------------------
@@ -413,6 +419,6 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			'generic uncompressed feeds must check !$renamed before the $retval == 0 success gate; segment: '
 			. json_encode($segment));
 		$this->assertTrue($analysis['directReturn'],
-			'a failed rename() must have a return FALSE path before the success gate; segment: ' . json_encode($segment));
+			'a failed rename() must have a failure result path before the success gate; segment: ' . json_encode($segment));
 	}
 }

--- a/tests/php/DownloadRetryBodyResetTest.php
+++ b/tests/php/DownloadRetryBodyResetTest.php
@@ -153,17 +153,29 @@ PHP;
 	{
 		$file_dwn = "{$this->workdir}/feed.txt";
 		$url      = "http://flaky-feed.example:{$this->port}/feed.txt";
-		$meta     = [];
-
 		// When: the first attempt is cut mid-body (curl error 18) and the retry
 		// succeeds. (The production retry path sleeps 5s once here.)
-		$result = pfb_download($url, $file_dwn, false, 'RetryFeed', '', 1, '', 30, 'change_detect', '', '', false, $meta);
+		$result = pfb_download(new PfbDownloadRequest(
+			listUrl: $url,
+			downloadPath: $file_dwn,
+			flex: FALSE,
+			header: 'RetryFeed',
+			format: '',
+			logType: 1,
+			versionType: '',
+			timeout: 30,
+			type: 'change_detect',
+			username: '',
+			password: '',
+			sourceInterface: FALSE,
+			extraHeaders: array(),
+		));
 
 		// Then: the download succeeds and the file holds EXACTLY the final
 		// response body -- before the fix it held the 16 partial bytes with the
 		// full body appended after them (80 bytes of corrupted concatenation).
-		$this->assertTrue($result, 'retry download must succeed');
-		$this->assertSame('200', $meta['status'] ?? '', 'probe metadata must carry the final 200');
+		$this->assertTrue($result->success, 'retry download must succeed');
+		$this->assertSame('200', $result->responseMeta['status'] ?? '', 'probe metadata must carry the final 200');
 		// pfb_download() writes the body to {file_dwn}.raw.
 		$got = file_get_contents("{$file_dwn}.raw");
 		$this->assertNotFalse($got);

--- a/tests/php/FeedChangeHashHelpersTest.php
+++ b/tests/php/FeedChangeHashHelpersTest.php
@@ -691,7 +691,7 @@ final class FeedChangeHashHelpersTest extends TestCase
 
 	/**
 	 * The bug (issue #713 bug 5): the change-detection probe (pfb_update_check ->
-	 * pfb_download($type='change_detect')) hashes the RAW fetched body — it returns
+	 * pfb_download(PfbDownloadRequest(type: 'change_detect'))) hashes the RAW fetched body — it returns
 	 * before any decompression. For a compressed feed, ingest used to persist the
 	 * sidecar from the DECOMPRESSED .orig instead, so the two hashes covered different
 	 * bytes and could never match — every cron re-ingested a compressed feed even when
@@ -739,7 +739,7 @@ final class FeedChangeHashHelpersTest extends TestCase
 		);
 
 		// WHEN: a later cron probe re-fetches the SAME compressed bytes (server unchanged
-		// — pfb_download($type='change_detect') writes the raw body to {header}.md5.raw
+		// — pfb_download(PfbDownloadRequest(type: 'change_detect')) writes the raw body to {header}.md5.raw
 		// and returns before decompressing).
 		$probe_raw = $this->dir . '/feed.md5.raw';
 		file_put_contents($probe_raw, $raw_bytes);

--- a/tests/php/FeedChangeHashHelpersTest.php
+++ b/tests/php/FeedChangeHashHelpersTest.php
@@ -587,7 +587,7 @@ final class FeedChangeHashHelpersTest extends TestCase
 	 *   THEN both return FALSE (the sidecar is correct, no re-ingest triggered).
 	 *
 	 * RED on pre-Phase-2 code: if pfb_local_feed_changed writes the sidecar (instead of
-	 * pfb_download), the second call would see a stale sidecar and return TRUE.
+	 * the download ingest path), the second call would see a stale sidecar and return TRUE.
 	 */
 	public function test_local_feed_changed_idempotent_after_ingest_with_sidecar(): void
 	{

--- a/tests/php/PfbDownloadEntryVettingSkipLogTest.php
+++ b/tests/php/PfbDownloadEntryVettingSkipLogTest.php
@@ -102,25 +102,24 @@ final class PfbDownloadEntryVettingSkipLogTest extends TestCase
 
 		// When pfb_download() is called on that URL (a plain remote format, so
 		// entry vetting takes the PFB_FILTER_URL elseif branch).
-		$response_meta = null;
-		$result = pfb_download(
-			'https://internal.entry.vet/list.txt',
-			'/tmp/pfb_entry_vet_test',
-			FALSE,
-			'entryvettest',
-			'',
-			2,
-			'',
-			300,
-			'',
-			'',
-			'',
-			FALSE,
-			$response_meta
-		);
+		$result = pfb_download(new PfbDownloadRequest(
+			listUrl: 'https://internal.entry.vet/list.txt',
+			downloadPath: '/tmp/pfb_entry_vet_test',
+			flex: FALSE,
+			header: 'entryvettest',
+			format: '',
+			logType: 2,
+			versionType: '',
+			timeout: 300,
+			type: '',
+			username: '',
+			password: '',
+			sourceInterface: FALSE,
+			extraHeaders: array(),
+		));
 
 		// Then the download is refused ...
-		$this->assertFalse($result, 'pfb_download must refuse a URL rejected at entry vetting');
+		$this->assertFalse($result->success, 'pfb_download must refuse a URL rejected at entry vetting');
 
 		// ... and the MAIN log carries the header-scoped, reason-bearing skip
 		// line (issue #811), alongside the pre-existing bare failure line.
@@ -157,25 +156,24 @@ final class PfbDownloadEntryVettingSkipLogTest extends TestCase
 		// When pfb_download() is called with a disallowed scheme (gopher) --
 		// pfb_filter() rejects on the scheme check, before ever consulting the
 		// feed-host guard for its own verdict.
-		$response_meta = null;
-		$result = pfb_download(
-			'gopher://public.entry.vet/list.txt',
-			'/tmp/pfb_entry_vet_test2',
-			FALSE,
-			'entryvettest2',
-			'',
-			2,
-			'',
-			300,
-			'',
-			'',
-			'',
-			FALSE,
-			$response_meta
-		);
+		$result = pfb_download(new PfbDownloadRequest(
+			listUrl: 'gopher://public.entry.vet/list.txt',
+			downloadPath: '/tmp/pfb_entry_vet_test2',
+			flex: FALSE,
+			header: 'entryvettest2',
+			format: '',
+			logType: 2,
+			versionType: '',
+			timeout: 300,
+			type: '',
+			username: '',
+			password: '',
+			sourceInterface: FALSE,
+			extraHeaders: array(),
+		));
 
 		// Then the download is refused ...
-		$this->assertFalse($result, 'pfb_download must refuse an invalid-scheme URL');
+		$this->assertFalse($result->success, 'pfb_download must refuse an invalid-scheme URL');
 
 		// ... but the main log carries NO guard skip line -- the guard itself
 		// would have allowed this host, so #811's re-check must not fire.
@@ -213,25 +211,24 @@ final class PfbDownloadEntryVettingSkipLogTest extends TestCase
 
 		// When pfb_download() is called with a disallowed scheme on that host --
 		// pfb_filter() rejects on the scheme check, never reaching the guard.
-		$response_meta = null;
-		$result = pfb_download(
-			'gopher://internal.scheme.vet/list.txt',
-			'/tmp/pfb_entry_vet_test3',
-			FALSE,
-			'entryvettest3',
-			'',
-			2,
-			'',
-			300,
-			'',
-			'',
-			'',
-			FALSE,
-			$response_meta
-		);
+		$result = pfb_download(new PfbDownloadRequest(
+			listUrl: 'gopher://internal.scheme.vet/list.txt',
+			downloadPath: '/tmp/pfb_entry_vet_test3',
+			flex: FALSE,
+			header: 'entryvettest3',
+			format: '',
+			logType: 2,
+			versionType: '',
+			timeout: 300,
+			type: '',
+			username: '',
+			password: '',
+			sourceInterface: FALSE,
+			extraHeaders: array(),
+		));
 
 		// Then the download is refused ...
-		$this->assertFalse($result, 'pfb_download must refuse an invalid-scheme URL');
+		$this->assertFalse($result->success, 'pfb_download must refuse an invalid-scheme URL');
 
 		// ... and the main log carries NO guard skip line even though the host
 		// is internal -- the guard was not why vetting failed.

--- a/tests/php/PfbDownloadInterfaceTest.php
+++ b/tests/php/PfbDownloadInterfaceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class PfbDownloadInterfaceTest extends TestCase
+{
+	public function testRequestDefaultsAndFullMapping(): void
+	{
+		$defaults = new PfbDownloadRequest(
+			listUrl: 'https://example.test/list',
+			downloadPath: '/tmp/list',
+			flex: FALSE,
+			header: 'feed',
+			format: 'plain',
+			logType: 1,
+		);
+
+		$this->assertSame('', $defaults->versionType);
+		$this->assertSame(300, $defaults->timeout);
+		$this->assertSame('', $defaults->type);
+		$this->assertSame('', $defaults->username);
+		$this->assertSame('', $defaults->password);
+		$this->assertFalse($defaults->sourceInterface);
+		$this->assertSame(array(), $defaults->extraHeaders);
+
+		$mapped = new PfbDownloadRequest(
+			listUrl: 'rsync://host/module',
+			downloadPath: '/var/db/feed',
+			flex: TRUE,
+			header: 'mapped',
+			format: 'rsync',
+			logType: 3,
+			versionType: 'v4',
+			timeout: 42,
+			type: 'change_detect',
+			username: 'user',
+			password: 'pass',
+			sourceInterface: 'wan',
+			extraHeaders: array('Authorization: Bearer token'),
+		);
+
+		$this->assertSame('rsync://host/module', $mapped->listUrl);
+		$this->assertSame('/var/db/feed', $mapped->downloadPath);
+		$this->assertTrue($mapped->flex);
+		$this->assertSame('mapped', $mapped->header);
+		$this->assertSame('rsync', $mapped->format);
+		$this->assertSame(3, $mapped->logType);
+		$this->assertSame('v4', $mapped->versionType);
+		$this->assertSame(42, $mapped->timeout);
+		$this->assertSame('change_detect', $mapped->type);
+		$this->assertSame('user', $mapped->username);
+		$this->assertSame('pass', $mapped->password);
+		$this->assertSame('wan', $mapped->sourceInterface);
+		$this->assertSame(array('Authorization: Bearer token'), $mapped->extraHeaders);
+	}
+
+	public function testResultSuccessAndFailureExposeMetadata(): void
+	{
+		$success = PfbDownloadResult::success();
+		$this->assertTrue($success->success);
+		$this->assertNull($success->responseMeta);
+
+		$metadata = array('status' => '304', 'etag' => '"tag"', 'lastmod' => 123);
+		$failure = PfbDownloadResult::failure($metadata);
+		$this->assertFalse($failure->success);
+		$this->assertSame($metadata, $failure->responseMeta);
+	}
+
+	public function testDownloadFunctionHasRequestAndResultSignature(): void
+	{
+		$reflection = new ReflectionFunction('pfb_download');
+		$this->assertCount(1, $reflection->getParameters());
+		$this->assertSame(PfbDownloadRequest::class, $reflection->getParameters()[0]->getType()?->getName());
+		$this->assertSame(PfbDownloadResult::class, $reflection->getReturnType()?->getName());
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -2290,105 +2290,14 @@
     },
     "pfb_download": {
         "returnsRef": false,
-        "returnType": null,
+        "returnType": "PfbDownloadResult",
         "params": [
             {
-                "name": "list_url",
+                "name": "request",
                 "byRef": false,
                 "variadic": false,
-                "type": null,
+                "type": "PfbDownloadRequest",
                 "default": null
-            },
-            {
-                "name": "file_dwn",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": null
-            },
-            {
-                "name": "pflex",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": null
-            },
-            {
-                "name": "header",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": null
-            },
-            {
-                "name": "format",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": null
-            },
-            {
-                "name": "logtype",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": null
-            },
-            {
-                "name": "vtype",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": "''"
-            },
-            {
-                "name": "timeout",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": "300"
-            },
-            {
-                "name": "type",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": "''"
-            },
-            {
-                "name": "username",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": "''"
-            },
-            {
-                "name": "password",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": "''"
-            },
-            {
-                "name": "srcint",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": "false"
-            },
-            {
-                "name": "response_meta",
-                "byRef": true,
-                "variadic": false,
-                "type": null,
-                "default": "NULL"
-            },
-            {
-                "name": "extra_headers",
-                "byRef": false,
-                "variadic": false,
-                "type": "array",
-                "default": "array (\n)"
             }
         ]
     },

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -3623,7 +3623,7 @@ _ADR46_WORKDIR = f"{h.PFB_DBDIR}/adr46_guard"
 
 
 def _adr46_download(vm: SmokeVM, feed_url: str, file_dwn: str, header: str, dl_type: str) -> str:
-    """Run pfb_download(<feed_url>, <file_dwn>, ..., type=<dl_type>) on the box; return stdout.
+    """Run pfb_download(PfbDownloadRequest(..., type=<dl_type>)) on the box; return stdout.
 
     ``header`` is the request's extraction/log field: the ``tar -C`` target for the
     ZIP geoip/top1m branch, and the ``feed=`` token of the canonical reject line at

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -2472,7 +2472,7 @@ def test_corrupt_zip_rejected(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer)
     file(1) still reports ``application/zip`` (it reads the EOCD), so the feed
     enters the ZIP branch; ``bsdtar -tf`` then fails to parse the broken local
     header and exits non-zero. pfb_validate_archive() catches that; pfb_download()
-    returns FALSE; the alias is never created.
+    result success flag is FALSE; the alias is never created.
 
     NB: a *tail-truncated* ZIP is NOT a reliable corruption — libarchive streams
     local headers without needing the EOCD, so ``tar -tf`` on the first half still
@@ -2486,7 +2486,7 @@ def test_corrupt_zip_rejected(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer)
     Given the alias does not exist (the feed has never been successfully loaded).
     When the case injects + Force-Updates over the corrupt ZIP bytes,
     Then the alias remains absent — the structural probe rejected the corrupt archive
-      before extraction and pfb_download() returned FALSE.
+      before extraction and pfb_download() result success flag was FALSE.
     """
     # FreeBSD-verified corpus fixture (fixtures/archive_corrupt.zip; see
     # fixtures/README.md "Archive corpus"): leading PK\x03\x04 signature clobbered,
@@ -2501,7 +2501,7 @@ def test_corrupt_zip_rejected(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer)
 
     with h.CaseContext(deployed_vm, spec):
         # When — Force Update fetches corrupt ZIP; structural probe (bsdtar) fails.
-        # Then — alias still absent; pfb_download returned FALSE; table never created.
+        # Then — alias still absent; pfb_download result success flag was FALSE; table never created.
         tables_after = h.pfctl_tables(deployed_vm)
         assert spec.alias not in tables_after, (
             f"expected {spec.alias!r} absent after corrupt ZIP (structural probe must reject), "
@@ -2515,7 +2515,7 @@ def test_corrupt_gzip_rejected(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
 
     Scenario: the corpus fixture is a valid gzip stream truncated past its header —
     the deflate payload and CRC/ISIZE trailer are gone, so ``gunzip -t`` exits
-    non-zero. pfb_validate_archive() catches the failure; pfb_download() returns
+    non-zero. pfb_validate_archive() catches the failure; pfb_download() result success flag is
     FALSE; the alias is never created. (Unlike ZIP, a truncated gzip IS reliably
     corrupt to the codec — gzip is a single stream with no streamable directory.)
 
@@ -2552,7 +2552,7 @@ def test_corrupt_bzip2_rejected(deployed_vm: SmokeVM, mock_feeds: _MockFeedServe
 
     Scenario: the corpus fixture is a valid bzip2 stream truncated mid-block, so
     ``bzip2 -t`` exits non-zero. pfb_validate_archive() rejects it; pfb_download()
-    returns FALSE; the alias is never created.
+    result success flag is FALSE; the alias is never created.
 
     Paired with ``test_bzip2_feed_imports`` (healthy bzip2 imports) to prove the probe
     is a real branch.
@@ -3625,15 +3625,20 @@ _ADR46_WORKDIR = f"{h.PFB_DBDIR}/adr46_guard"
 def _adr46_download(vm: SmokeVM, feed_url: str, file_dwn: str, header: str, dl_type: str) -> str:
     """Run pfb_download(<feed_url>, <file_dwn>, ..., type=<dl_type>) on the box; return stdout.
 
-    ``header`` is pfb_download()'s 4th arg: the ``tar -C`` extraction target for the
+    ``header`` is the request's extraction/log field: the ``tar -C`` target for the
     ZIP geoip/top1m branch, and the ``feed=`` token of the canonical reject line at
     every wired site.
     """
     snippet = (
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
         "pfb_global();\n"
-        f"$ok = pfb_download({h._php_str(feed_url)}, {h._php_str(file_dwn)}, FALSE, "  # noqa: SLF001
-        f"{h._php_str(header)}, '', 1, '', 60, {h._php_str(dl_type)});\n"  # noqa: SLF001
+        "$ok = pfb_download(new PfbDownloadRequest("
+        f"listUrl: {h._php_str(feed_url)}, "  # noqa: SLF001
+        f"downloadPath: {h._php_str(file_dwn)}, flex: FALSE, "  # noqa: SLF001
+        f"header: {h._php_str(header)}, format: '', logType: 1, versionType: '', "  # noqa: SLF001
+        f"timeout: 60, type: {h._php_str(dl_type)}, username: '', password: '', "  # noqa: SLF001
+        "sourceInterface: FALSE, extraHeaders: array()));"
+        "$ok = $ok->success;\n"
         "echo $ok ? 'PFB_DL_TRUE' : 'PFB_DL_FALSE';"
     )
     res = h.php_eval(vm, snippet, timeout=120.0)
@@ -3650,13 +3655,13 @@ def test_adr46_hostile_member_zip_rejected(deployed_vm: SmokeVM, mock_feeds: _Mo
     `../pfb_adr46_escape.txt`.
 
     Pre-ADR-46 behaviour is SILENT PARTIAL SUCCESS -- bsdtar's default refusal just
-    skips the `..` member (extraction stderr is discarded) and the branch returns
-    TRUE -- so this test FAILS on pre-guard code (pfb_download returns TRUE, no
+    skips the `..` member (extraction stderr is discarded) and the result success flag is
+    TRUE -- so this test FAILS on pre-guard code (pfb_download reported success, no
     canonical line) and PASSES with the guard (explicit stage=member reject).
 
     Given a clean work dir and the delta baseline for the stage=member line,
     When  pfb_download() fetches the traversal ZIP as a top-1M extra,
-    Then  it returns FALSE, a canonical "stage=member reason=unsafe_member_name
+    Then  its result success flag is FALSE, a canonical "stage=member reason=unsafe_member_name
       detected=../pfb_adr46_escape.txt" line is logged, the downloaded archive is
       unlinked, and NOTHING was extracted (no benign member, no escape file).
     """
@@ -3676,8 +3681,8 @@ def test_adr46_hostile_member_zip_rejected(deployed_vm: SmokeVM, mock_feeds: _Mo
 
         # Then -- explicit reject, not silent partial success.
         assert "PFB_DL_FALSE" in out, (
-            f"expected pfb_download to return FALSE on a '..'-member archive "
-            f"(pre-ADR-46 it silently returned TRUE); got stdout: {out!r}"
+            f"expected pfb_download success flag FALSE on a '..'-member archive "
+            f"(pre-ADR-46 it silently reported success); got stdout: {out!r}"
         )
         after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
         if not (after > before):
@@ -3708,7 +3713,7 @@ def test_adr46_legit_multifile_zip_still_imports(deployed_vm: SmokeVM, mock_feed
 
     Given a clean pre-created target dir (asserted empty) and the stage=member baseline,
     When  pfb_download() fetches a benign two-member ZIP as a top-1M extra,
-    Then  it returns TRUE, both members land in the target dir (--strip=1 applied),
+    Then  its result success flag is TRUE, both members land in the target dir (--strip=1 applied),
       and NO stage=member line was added.
     """
     workdir = f"{_ADR46_WORKDIR}_legit"
@@ -3731,7 +3736,7 @@ def test_adr46_legit_multifile_zip_still_imports(deployed_vm: SmokeVM, mock_feed
 
         # Then -- import succeeds and the guard stayed silent.
         assert "PFB_DL_TRUE" in out, (
-            f"expected pfb_download to return TRUE for a benign multi-member zip "
+            f"expected pfb_download success flag TRUE for a benign multi-member zip "
             f"(the guard must be a pass-through); got stdout: {out!r}"
         )
         extracted = deployed_vm.ssh(f"/bin/ls -A {target}").stdout.split()
@@ -3763,7 +3768,7 @@ def test_adr46_hostile_member_geoip_gz_rejected(deployed_vm: SmokeVM, mock_feeds
     Given a clean work dir, no escape file beside the geoipshare dir, and the
       stage=member delta baseline,
     When  pfb_download() fetches the traversal tar.gz as type='geoip',
-    Then  it returns FALSE, the canonical stage=member line names the hostile
+    Then  its result success flag is FALSE, the canonical stage=member line names the hostile
       member, the archive is unlinked, and no escape file appeared.
     """
     marker = "stage=member reason=unsafe_member_name detected=../pfb_adr46_escape.txt"
@@ -3786,8 +3791,8 @@ def test_adr46_hostile_member_geoip_gz_rejected(deployed_vm: SmokeVM, mock_feeds
 
         # Then -- explicit reject before any disk write.
         assert "PFB_DL_FALSE" in out, (
-            f"expected pfb_download to return FALSE on a '..'-member tar.gz via the gzip GeoIP "
-            f"branch (pre-guard it silently returned TRUE); got stdout: {out!r}"
+            f"expected pfb_download success flag FALSE on a '..'-member tar.gz via the gzip GeoIP "
+            f"branch (pre-guard it silently reported success); got stdout: {out!r}"
         )
         after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
         if not (after > before):
@@ -3821,7 +3826,7 @@ def test_adr46_hostile_member_blacklist_rejected(deployed_vm: SmokeVM, mock_feed
     Given a clean work dir and category dir, and the stage=member delta baseline,
     When  pfb_download() fetches the traversal tar.gz as type='blacklist' with a
       file_dwn ending .tar.gz (the branch's naming contract),
-    Then  it returns FALSE, the canonical stage=member line is logged, the renamed
+    Then  its result success flag is FALSE, the canonical stage=member line is logged, the renamed
       archive is unlinked, and the category dir contains no extracted files.
     """
     marker = "stage=member reason=unsafe_member_name detected=../pfb_adr46_escape.txt"
@@ -3844,8 +3849,8 @@ def test_adr46_hostile_member_blacklist_rejected(deployed_vm: SmokeVM, mock_feed
 
         # Then -- explicit reject; the renamed archive is gone; nothing extracted.
         assert "PFB_DL_FALSE" in out, (
-            f"expected pfb_download to return FALSE on a '..'-member tar.gz via the blacklist "
-            f"branch (pre-guard it silently returned TRUE); got stdout: {out!r}"
+            f"expected pfb_download success flag FALSE on a '..'-member tar.gz via the blacklist "
+            f"branch (pre-guard it silently reported success); got stdout: {out!r}"
         )
         after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
         if not (after > before):

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2646,6 +2646,35 @@ def test_page_table_covers_every_pfblockerng_page() -> None:
     assert "dnsbl_vip_sinkhole_pages" in excluded_names
 
 
+def test_pfblockerng_download_extras_uses_typed_download_result() -> None:
+    """Pin the CLI-only download contract that Tier-A HTTP rendering cannot execute.
+
+    ``pfblockerng.php`` is never served directly: it is the CLI dispatcher and
+    template for the generated GeoIP pages.  Keep this source assertion in the
+    ``ui_render`` module so the changed PHP call shape still has a front-end
+    coverage pairing without pretending an HTTP render reaches this function.
+    """
+    source_path = helpers.SMOKE_DIR.parent.parent / "src/usr/local/www/pfblockerng/pfblockerng.php"
+    source = source_path.read_text(encoding="utf-8")
+
+    declaration = "function pfblockerng_download_extras("
+    start = source.index(declaration)
+    remainder = source[start + len(declaration) :]
+    next_function = re.search(r"^function\s+\w+\s*\(", remainder, flags=re.MULTILINE)
+    assert next_function is not None, "pfblockerng_download_extras() must be followed by another function"
+    function_source = source[start : start + len(declaration) + next_function.start()]
+
+    assert re.search(r"pfb_download\(\s*new\s+PfbDownloadRequest\(", function_source, flags=re.DOTALL), (
+        "pfblockerng_download_extras() must construct PfbDownloadRequest"
+    )
+    assert re.search(r"\)\s*\)\s*->\s*success\b", function_source, flags=re.DOTALL), (
+        "pfblockerng_download_extras() must consume PfbDownloadResult->success"
+    )
+    assert not re.search(r"pfb_download\(\s*(?!new\s+PfbDownloadRequest\b)", function_source, flags=re.DOTALL), (
+        "retired positional pfb_download() call shape must not return"
+    )
+
+
 def test_reputation_page_help_text_names_relocated_matchgen_paths(
     webui: WebUI, php_error_log_guard: PhpErrorLogGuard
 ) -> None:  # noqa: ARG001


### PR DESCRIPTION
## Summary

- replace `pfb_download()`'s 14 positional parameters with `PfbDownloadRequest`
- return `PfbDownloadResult`, including conditional-probe metadata without a by-reference out parameter
- migrate every live production caller and direct PHP/smoke caller without a compatibility wrapper

## Verification

- behavior-preserving before oracle: 52 tests, 162 assertions
- independent `scripts/agent/run-gates.sh --diff origin/devel`: PASS (pytest, ruff, mypy, PHP lint, full PHPUnit, PHPStan, PHPCS)
- focused interface/source suite: 19 tests, 105 assertions
- exact caller inventory: four production and five direct test/smoke calls; all use one request object
- local appliance smoke and Tier-A reached package deployment but were blocked before changed code by the known missing `pfblockerng_apply.inc` package entry tracked in #1545
- companion-manifest CE/Plus workflow runs use pfBlockerNG/FreeBSD-ports#3

Fixes #1404

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
