### PR TITLE
DNSBL: publish TOP1M as an atomic chroot file

### DIFF
--- a/benchmarks/results/issue_1542_top1m_fixed_file.txt
+++ b/benchmarks/results/issue_1542_top1m_fixed_file.txt
@@ -1,0 +1,35 @@
+ISSUE #1542 -- FIXED-FILE TOP1M BENCHMARK
+==========================================
+command: python3 scripts/bench_top1m_fixed_file.py run --base-ref a67d3efe680e99de5d5e7b5743029c29ef2cfd25 --lines 1000000 --trials 3 --timeout-seconds 900
+base_sha: a67d3efe680e99de5d5e7b5743029c29ef2cfd25
+branch_sha: 8d62179b75616344cf7e50139642066aee4a0899
+branch_worktree_dirty: no
+branch_pfblockerng_inc_sha256: a7f3421e7ab703070992eb87119dbce6192109c342e1bd594d6b8e1a1ba54e60
+branch_pfb_unbound_py_sha256: aaceb3b2ef2220f268d529b1b4b2181798e5bb9ab163067ab24d996e996bd9c7
+host: macOS-26.5.2-arm64-arm-64bit-Mach-O machine=arm64 logical_cpus=10
+python: 3.14.6 (/opt/homebrew/opt/python@3.14/bin/python3.14)
+php: 8.5.8
+time: /usr/bin/time -l
+fixture: deterministic unique domains=1000000 generated_bytes=32000000
+manifest_bytes: 223
+fixed_file_bytes: 32000000
+trials_per_phase_ref: 3
+per_process_deadline_seconds: 900
+
+Measurements (isolated seam wall time; whole fresh-process peak RSS)
+------------------------------------------------------------------
+phase1.php_full_writer base: N/A -- old contract embeds TOP1M and has no fixed-file writer
+phase1.php_full_writer branch: trials=3 wall_median=0.014126s wall_range=0.014028..0.015189s peak_rss_max=35586048B (33.94MiB)
+phase2.php_scalar_patch base: trials=3 wall_median=0.001122s wall_range=0.001107..0.001218s peak_rss_max=33062912B (31.53MiB)
+phase2.php_scalar_patch branch: trials=3 wall_median=0.001450s wall_range=0.001285..0.002073s peak_rss_max=33406976B (31.86MiB)
+phase3.python_json_validate base: trials=3 wall_median=0.000106s wall_range=0.000106..0.000205s peak_rss_max=48005120B (45.78MiB)
+phase3.python_json_validate branch: trials=3 wall_median=0.000132s wall_range=0.000125..0.000133s peak_rss_max=32079872B (30.59MiB)
+phase4.python_full_build base: N/A -- old contract cannot consume the fixed TOP1M file
+phase4.python_full_build branch: trials=3 wall_median=0.637509s wall_range=0.636580..0.645256s peak_rss_max=366985216B (349.98MiB)
+
+Contract assertions executed in every applicable trial
+------------------------------------------------------
+manifest has no top1m_list, top1m_ref, or sampled TOP1M domain: PASS
+fixed file has exactly 1000000 lines: PASS
+full build exposes exactly 1000000 unique TOP1M white_db domains: PASS
+thresholds: none (measurements only; no invented pass/fail gate)

--- a/benchmarks/results/issue_1542_top1m_fixed_file.txt
+++ b/benchmarks/results/issue_1542_top1m_fixed_file.txt
@@ -2,34 +2,36 @@ ISSUE #1542 -- FIXED-FILE TOP1M BENCHMARK
 ==========================================
 command: python3 scripts/bench_top1m_fixed_file.py run --base-ref a67d3efe680e99de5d5e7b5743029c29ef2cfd25 --lines 1000000 --trials 3 --timeout-seconds 900
 base_sha: a67d3efe680e99de5d5e7b5743029c29ef2cfd25
-branch_sha: 8d62179b75616344cf7e50139642066aee4a0899
+branch_sha: 493d97fa31162c30b3ef7543fb830807e8815c42
 branch_worktree_dirty: no
 branch_pfblockerng_inc_sha256: a7f3421e7ab703070992eb87119dbce6192109c342e1bd594d6b8e1a1ba54e60
 branch_pfb_unbound_py_sha256: aaceb3b2ef2220f268d529b1b4b2181798e5bb9ab163067ab24d996e996bd9c7
 host: macOS-26.5.2-arm64-arm-64bit-Mach-O machine=arm64 logical_cpus=10
 python: 3.14.6 (/opt/homebrew/opt/python@3.14/bin/python3.14)
 php: 8.5.8
+php_worker_memory_limit: -1 (disabled so peak RSS remains measurable)
 time: /usr/bin/time -l
 fixture: deterministic unique domains=1000000 generated_bytes=32000000
-manifest_bytes: 223
-fixed_file_bytes: 32000000
+base_contract: embedded manifest_bytes=47000257 fixed_file_bytes=0
+branch_contract: fixed manifest_bytes=223 fixed_file_bytes=32000000
 trials_per_phase_ref: 3
 per_process_deadline_seconds: 900
 
 Measurements (isolated seam wall time; whole fresh-process peak RSS)
 ------------------------------------------------------------------
-phase1.php_full_writer base: N/A -- old contract embeds TOP1M and has no fixed-file writer
-phase1.php_full_writer branch: trials=3 wall_median=0.014126s wall_range=0.014028..0.015189s peak_rss_max=35586048B (33.94MiB)
-phase2.php_scalar_patch base: trials=3 wall_median=0.001122s wall_range=0.001107..0.001218s peak_rss_max=33062912B (31.53MiB)
-phase2.php_scalar_patch branch: trials=3 wall_median=0.001450s wall_range=0.001285..0.002073s peak_rss_max=33406976B (31.86MiB)
-phase3.python_json_validate base: trials=3 wall_median=0.000106s wall_range=0.000106..0.000205s peak_rss_max=48005120B (45.78MiB)
-phase3.python_json_validate branch: trials=3 wall_median=0.000132s wall_range=0.000125..0.000133s peak_rss_max=32079872B (30.59MiB)
-phase4.python_full_build base: N/A -- old contract cannot consume the fixed TOP1M file
-phase4.python_full_build branch: trials=3 wall_median=0.637509s wall_range=0.636580..0.645256s peak_rss_max=366985216B (349.98MiB)
+phase1.php_full_writer base[embedded]: trials=3 wall_median=0.077760s wall_range=0.076748..0.080487s peak_rss_max=223019008B (212.69MiB)
+phase1.php_full_writer branch[fixed]: trials=3 wall_median=0.012855s wall_range=0.012834..0.012983s peak_rss_max=35635200B (33.98MiB)
+phase2.php_scalar_patch base: trials=3 wall_median=0.137366s wall_range=0.137208..0.137727s peak_rss_max=199393280B (190.16MiB)
+phase2.php_scalar_patch branch: trials=3 wall_median=0.001717s wall_range=0.001434..0.001827s peak_rss_max=33456128B (31.91MiB)
+phase3.python_json_validate base: trials=3 wall_median=0.106715s wall_range=0.106263..0.107652s peak_rss_max=229343232B (218.72MiB)
+phase3.python_json_validate branch: trials=3 wall_median=0.000097s wall_range=0.000090..0.000100s peak_rss_max=32653312B (31.14MiB)
+phase4.python_full_build base[embedded]: trials=3 wall_median=0.528474s wall_range=0.488569..0.529459s peak_rss_max=448479232B (427.70MiB)
+phase4.python_full_build branch[fixed]: trials=3 wall_median=0.623396s wall_range=0.620863..0.623997s peak_rss_max=366985216B (349.98MiB)
 
 Contract assertions executed in every applicable trial
 ------------------------------------------------------
-manifest has no top1m_list, top1m_ref, or sampled TOP1M domain: PASS
-fixed file has exactly 1000000 lines: PASS
-full build exposes exactly 1000000 unique TOP1M white_db domains: PASS
+base manifest embeds exactly 1000000 deterministic TOP1M domains: PASS
+branch manifest has no top1m_list, top1m_ref, or sampled TOP1M domain: PASS
+branch fixed file has exactly 1000000 lines: PASS
+both native full builds expose exactly 1000000 unique TOP1M white_db domains: PASS
 thresholds: none (measurements only; no invented pass/fail gate)

--- a/scripts/bench_top1m_fixed_file.php
+++ b/scripts/bench_top1m_fixed_file.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 // Issue #1542 dev-host benchmark worker. The Python driver starts one fresh
 // process per trial and wraps it with /usr/bin/time for peak RSS.
 
-if ($argc !== 5 || !in_array($argv[1], ['write', 'patch'], TRUE)) {
-	fwrite(STDERR, "usage: php bench_top1m_fixed_file.php write|patch WORKTREE SANDBOX EXPECTED_LINES\n");
+if ($argc !== 6 || !in_array($argv[1], ['write', 'patch'], TRUE)
+	|| !in_array($argv[2], ['embedded', 'fixed'], TRUE)) {
+	fwrite(STDERR,
+		"usage: php bench_top1m_fixed_file.php write|patch embedded|fixed WORKTREE SANDBOX EXPECTED_LINES\n");
 	exit(2);
 }
 
-[$script, $phase, $worktree, $sandbox, $expected_arg] = $argv;
+[$script, $phase, $contract, $worktree, $sandbox, $expected_arg] = $argv;
 $expected_lines = (int) $expected_arg;
 $sample_domain = 'top1m-0000000.benchmark.invalid';
+$last_domain = sprintf('top1m-%07d.benchmark.invalid', $expected_lines - 1);
 
 require_once "{$worktree}/tests/php/bootstrap.php";
 
@@ -51,20 +54,26 @@ function benchmark_manifest_contains_key(array $value, string $needle): bool
 	return FALSE;
 }
 
-function benchmark_read_manifest(string $path, string $sample_domain): array
+function benchmark_read_manifest(string $path, string $contract, int $expected_lines,
+	string $sample_domain, string $last_domain): array
 {
 	$json = @file_get_contents($path);
 	$manifest = is_string($json) ? json_decode($json, TRUE) : NULL;
 	if (!is_array($manifest)) {
 		throw new RuntimeException("manifest missing or invalid: {$path}");
 	}
-	foreach (['top1m_list', 'top1m_ref'] as $retired_key) {
-		if (benchmark_manifest_contains_key($manifest, $retired_key)) {
-			throw new RuntimeException("manifest contains retired key: {$retired_key}");
-		}
+	if (benchmark_manifest_contains_key($manifest, 'top1m_ref')) {
+		throw new RuntimeException('manifest contains unsupported key: top1m_ref');
 	}
-	if (str_contains($json, $sample_domain)) {
-		throw new RuntimeException('manifest contains sampled TOP1M domain');
+	$top1m_list = $manifest['config']['top1m_list'] ?? NULL;
+	if ($contract === 'embedded') {
+		if (!is_array($top1m_list) || count($top1m_list) !== $expected_lines
+			|| ($top1m_list[0] ?? NULL) !== $sample_domain
+			|| ($top1m_list[$expected_lines - 1] ?? NULL) !== $last_domain) {
+			throw new RuntimeException('embedded TOP1M contract missing exact deterministic domain list');
+		}
+	} elseif (benchmark_manifest_contains_key($manifest, 'top1m_list') || str_contains($json, $sample_domain)) {
+		throw new RuntimeException('fixed-file TOP1M contract leaked list or sampled domain into manifest');
 	}
 	return $manifest;
 }
@@ -90,29 +99,36 @@ try {
 		if (!is_array($result)) {
 			throw new RuntimeException('pfb_unbound_python_sources returned failure');
 		}
-		$manifest = benchmark_read_manifest($GLOBALS['pfb']['unbound_py_sources'], $sample_domain);
+		$manifest = benchmark_read_manifest($GLOBALS['pfb']['unbound_py_sources'], $contract,
+			$expected_lines, $sample_domain, $last_domain);
 		if (($manifest['config']['top1m_enabled'] ?? NULL) !== TRUE) {
-			throw new RuntimeException('manifest did not enable fixed-file TOP1M');
+			throw new RuntimeException('manifest did not enable TOP1M');
 		}
 
 		$fixed = $GLOBALS['pfb']['unbound_py_top1m'];
-		$handle = @fopen($fixed, 'rb');
-		if ($handle === FALSE) {
-			throw new RuntimeException("fixed TOP1M output missing: {$fixed}");
-		}
-		$line_count = 0;
-		while (fgets($handle) !== FALSE) {
-			$line_count++;
-		}
-		fclose($handle);
-		if ($line_count !== $expected_lines) {
-			throw new RuntimeException("fixed TOP1M line count {$line_count}; expected {$expected_lines}");
+		$fixed_bytes = 0;
+		if ($contract === 'fixed') {
+			$handle = @fopen($fixed, 'rb');
+			if ($handle === FALSE) {
+				throw new RuntimeException("fixed TOP1M output missing: {$fixed}");
+			}
+			$line_count = 0;
+			while (fgets($handle) !== FALSE) {
+				$line_count++;
+			}
+			fclose($handle);
+			if ($line_count !== $expected_lines) {
+				throw new RuntimeException("fixed TOP1M line count {$line_count}; expected {$expected_lines}");
+			}
+			$fixed_bytes = (int) filesize($fixed);
+		} elseif (file_exists($fixed)) {
+			throw new RuntimeException('embedded TOP1M writer unexpectedly published fixed sidecar');
 		}
 
 		printf("wall_seconds=%.9f\n", $elapsed);
 		printf("manifest_bytes=%d\n", filesize($GLOBALS['pfb']['unbound_py_sources']));
-		printf("fixed_bytes=%d\n", filesize($fixed));
-		printf("fixed_lines=%d\n", $line_count);
+		printf("fixed_bytes=%d\n", $fixed_bytes);
+		printf("top1m_lines=%d\n", $expected_lines);
 		exit(0);
 	}
 
@@ -122,7 +138,8 @@ try {
 	if (!$ok) {
 		throw new RuntimeException('pfb_unbound_python_sources_patch returned failure');
 	}
-	$manifest = benchmark_read_manifest($GLOBALS['pfb']['unbound_py_sources'], $sample_domain);
+	$manifest = benchmark_read_manifest($GLOBALS['pfb']['unbound_py_sources'], $contract,
+		$expected_lines, $sample_domain, $last_domain);
 	if (($manifest['config']['user_unlock'] ?? NULL) !== ['benchmark-unlock.invalid']) {
 		throw new RuntimeException('scalar manifest patch was not observable');
 	}

--- a/scripts/bench_top1m_fixed_file.php
+++ b/scripts/bench_top1m_fixed_file.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+// Issue #1542 dev-host benchmark worker. The Python driver starts one fresh
+// process per trial and wraps it with /usr/bin/time for peak RSS.
+
+if ($argc !== 5 || !in_array($argv[1], ['write', 'patch'], TRUE)) {
+	fwrite(STDERR, "usage: php bench_top1m_fixed_file.php write|patch WORKTREE SANDBOX EXPECTED_LINES\n");
+	exit(2);
+}
+
+[$script, $phase, $worktree, $sandbox, $expected_arg] = $argv;
+$expected_lines = (int) $expected_arg;
+$sample_domain = 'top1m-0000000.benchmark.invalid';
+
+require_once "{$worktree}/tests/php/bootstrap.php";
+
+@mkdir("{$sandbox}/db", 0777, TRUE);
+@mkdir("{$sandbox}/dnsbl", 0777, TRUE);
+
+$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+	'log'                 => "{$sandbox}/pfblockerng.log",
+	'errlog'              => "{$sandbox}/error.log",
+	'unbound_py_rawdir'   => "{$sandbox}/pfb_py_raw",
+	'unbound_py_sources'  => "{$sandbox}/pfb_py_sources.json",
+	'unbound_py_top1m'    => "{$sandbox}/pfb_py_top1m.txt",
+	'dnsdir'              => "{$sandbox}/dnsbl",
+	'dbdir'               => "{$sandbox}/db",
+	'dnsbl_top1m'         => 'on',
+	'dnsbl_tld_wildcard'  => '',
+	'dnsbl_tld_data'      => "{$sandbox}/does_not_exist",
+	'dnsbl_unlock'        => "{$sandbox}/dnsbl_unlock",
+	'dnsblconfig'         => [
+		'tldblacklist' => '',
+		'tldexclusion' => '',
+		'suppression'  => '',
+	],
+]);
+
+function benchmark_manifest_contains_key(array $value, string $needle): bool
+{
+	foreach ($value as $key => $child) {
+		if ($key === $needle) {
+			return TRUE;
+		}
+		if (is_array($child) && benchmark_manifest_contains_key($child, $needle)) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+function benchmark_read_manifest(string $path, string $sample_domain): array
+{
+	$json = @file_get_contents($path);
+	$manifest = is_string($json) ? json_decode($json, TRUE) : NULL;
+	if (!is_array($manifest)) {
+		throw new RuntimeException("manifest missing or invalid: {$path}");
+	}
+	foreach (['top1m_list', 'top1m_ref'] as $retired_key) {
+		if (benchmark_manifest_contains_key($manifest, $retired_key)) {
+			throw new RuntimeException("manifest contains retired key: {$retired_key}");
+		}
+	}
+	if (str_contains($json, $sample_domain)) {
+		throw new RuntimeException('manifest contains sampled TOP1M domain');
+	}
+	return $manifest;
+}
+
+try {
+	if ($phase === 'write') {
+		$fixture = "{$sandbox}/db/pfbalexawhitelist.txt";
+		if (!is_file($fixture)) {
+			throw new RuntimeException("TOP1M fixture missing: {$fixture}");
+		}
+		$start = hrtime(TRUE);
+		$result = pfb_unbound_python_sources([], [
+			// Dev hosts need not have the appliance's root:unbound identities.
+			// Only metadata ownership is substituted; real stream/copy/fsync/rename
+			// and the real manifest writer remain on the timed path.
+			'top1m_atomic' => [
+				'chown' => static fn(string $file, string $owner): bool => TRUE,
+				'chgrp' => static fn(string $file, string $group): bool => TRUE,
+				'chmod' => static fn(string $file, int $mode): bool => TRUE,
+			],
+		]);
+		$elapsed = (hrtime(TRUE) - $start) / 1_000_000_000;
+		if (!is_array($result)) {
+			throw new RuntimeException('pfb_unbound_python_sources returned failure');
+		}
+		$manifest = benchmark_read_manifest($GLOBALS['pfb']['unbound_py_sources'], $sample_domain);
+		if (($manifest['config']['top1m_enabled'] ?? NULL) !== TRUE) {
+			throw new RuntimeException('manifest did not enable fixed-file TOP1M');
+		}
+
+		$fixed = $GLOBALS['pfb']['unbound_py_top1m'];
+		$handle = @fopen($fixed, 'rb');
+		if ($handle === FALSE) {
+			throw new RuntimeException("fixed TOP1M output missing: {$fixed}");
+		}
+		$line_count = 0;
+		while (fgets($handle) !== FALSE) {
+			$line_count++;
+		}
+		fclose($handle);
+		if ($line_count !== $expected_lines) {
+			throw new RuntimeException("fixed TOP1M line count {$line_count}; expected {$expected_lines}");
+		}
+
+		printf("wall_seconds=%.9f\n", $elapsed);
+		printf("manifest_bytes=%d\n", filesize($GLOBALS['pfb']['unbound_py_sources']));
+		printf("fixed_bytes=%d\n", filesize($fixed));
+		printf("fixed_lines=%d\n", $line_count);
+		exit(0);
+	}
+
+	$start = hrtime(TRUE);
+	$ok = pfb_unbound_python_sources_patch('user_unlock', ['benchmark-unlock.invalid']);
+	$elapsed = (hrtime(TRUE) - $start) / 1_000_000_000;
+	if (!$ok) {
+		throw new RuntimeException('pfb_unbound_python_sources_patch returned failure');
+	}
+	$manifest = benchmark_read_manifest($GLOBALS['pfb']['unbound_py_sources'], $sample_domain);
+	if (($manifest['config']['user_unlock'] ?? NULL) !== ['benchmark-unlock.invalid']) {
+		throw new RuntimeException('scalar manifest patch was not observable');
+	}
+	printf("wall_seconds=%.9f\n", $elapsed);
+	printf("manifest_bytes=%d\n", filesize($GLOBALS['pfb']['unbound_py_sources']));
+} catch (Throwable $error) {
+	fwrite(STDERR, "benchmark assertion failed: {$error->getMessage()}\n");
+	exit(1);
+}

--- a/scripts/bench_top1m_fixed_file.py
+++ b/scripts/bench_top1m_fixed_file.py
@@ -274,6 +274,27 @@ def _copy_contract(manifest: Path, fixed: Path | None, sandbox: Path) -> Path:
     return target_manifest
 
 
+def _php_worker_command(
+    php: str,
+    phase: str,
+    contract: str,
+    worktree: Path,
+    sandbox: Path,
+    expected_lines: int,
+) -> list[str]:
+    return [
+        php,
+        "-d",
+        "memory_limit=-1",
+        str(PHP_WORKER),
+        phase,
+        contract,
+        str(worktree),
+        str(sandbox),
+        str(expected_lines),
+    ]
+
+
 def _run_php_phase(
     phase: str,
     contract: str,
@@ -289,7 +310,7 @@ def _run_php_phase(
         raise RuntimeError("php executable not found")
     return [
         _run_timed(
-            [php, str(PHP_WORKER), phase, contract, str(worktree), str(sandbox), str(expected_lines)],
+            _php_worker_command(php, phase, contract, worktree, sandbox, expected_lines),
             timeout_seconds,
             time_bin,
             time_flag,
@@ -493,6 +514,7 @@ def run(args: argparse.Namespace) -> int:
             f"host: {platform.platform()} machine={platform.machine()} logical_cpus={os.cpu_count()}",
             f"python: {platform.python_version()} ({sys.executable})",
             f"php: {_runtime_line([shutil.which('php') or 'php', '-r', 'echo PHP_VERSION;'])}",
+            "php_worker_memory_limit: -1 (disabled so peak RSS remains measurable)",
             f"time: {time_bin} {time_flag}",
             f"fixture: deterministic unique domains={args.lines} generated_bytes={generated_bytes}",
             f"base_contract: embedded manifest_bytes={manifest_bytes['base']} fixed_file_bytes=0",

--- a/scripts/bench_top1m_fixed_file.py
+++ b/scripts/bench_top1m_fixed_file.py
@@ -227,6 +227,9 @@ def _run_timed(
     except subprocess.TimeoutExpired:
         stdout, stderr = _terminate_process_group(proc, timed_cmd, kill_grace_seconds)
         raise subprocess.TimeoutExpired(timed_cmd, timeout_seconds, output=stdout, stderr=stderr)
+    except BaseException:
+        _terminate_process_group(proc, timed_cmd, kill_grace_seconds)
+        raise
 
     if proc.returncode != 0:
         raise RuntimeError(

--- a/scripts/bench_top1m_fixed_file.py
+++ b/scripts/bench_top1m_fixed_file.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Issue #1542 benchmark for the fixed-file TOP1M manifest contract.
+
+Runs four fresh-process phases on deterministic unique domains:
+
+1. PHP full manifest + fixed-file writer (branch only; old contract N/A)
+2. PHP scalar manifest patcher (base and branch)
+3. Python JSON parse + manifest validation only (base and branch)
+4. Python full fixed-file build (branch only; old contract N/A)
+
+No threshold or verdict is applied. Measurements are dev-host observations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import builtins
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import signal
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PHP_WORKER = REPO_ROOT / "scripts" / "bench_top1m_fixed_file.php"
+DEFAULT_LINES = 1_000_000
+DEFAULT_TRIALS = 3
+DEFAULT_TIMEOUT_SECONDS = 900
+SAMPLE_FIRST = "top1m-0000000.benchmark.invalid"
+
+_BSD_RSS_RE = re.compile(r"^\s*(\d+)\s+maximum resident set size", re.MULTILINE)
+_GNU_RSS_RE = re.compile(r"Maximum resident set size \(kbytes\):\s*(\d+)", re.MULTILINE)
+
+
+@dataclass
+class TrialResult:
+    wall_seconds: float
+    peak_rss_bytes: int
+    values: dict[str, str] = field(repr=False)
+
+
+def domain_for(index: int) -> str:
+    """Return one deterministic domain; the fixture is streamed, never listed in JSON."""
+    return f"top1m-{index:07d}.benchmark.invalid"
+
+
+def generate_top1m(path: Path, lines: int) -> int:
+    """Write exactly ``lines`` unique domains using bounded memory; return bytes."""
+    with path.open("w", encoding="ascii", newline="\n") as handle:
+        for index in range(lines):
+            handle.write(domain_for(index) + "\n")
+    return path.stat().st_size
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be at least 1")
+    return parsed
+
+
+def _line_count(value: str) -> int:
+    parsed = _positive_int(value)
+    if parsed > DEFAULT_LINES:
+        raise argparse.ArgumentTypeError(f"value must not exceed {DEFAULT_LINES}")
+    return parsed
+
+
+def _load_python_target(worktree: Path) -> ModuleType:
+    sys.path.insert(0, str(worktree / "stubs" / "python"))
+    import unboundmodule
+
+    for name in unboundmodule.__all__:
+        setattr(builtins, name, getattr(unboundmodule, name))
+
+    sys.path.insert(0, str(worktree / "src" / "usr" / "local" / "pkg" / "pfblockerng"))
+    import pfb_unbound
+
+    return pfb_unbound
+
+
+def worker_python(phase: str, worktree: Path, manifest_path: Path, expected_lines: int) -> int:
+    pfb_unbound = _load_python_target(worktree)
+    sample_last = domain_for(expected_lines - 1)
+
+    if phase == "validate":
+        start = time.perf_counter()
+        with manifest_path.open(encoding="utf-8") as handle:
+            manifest = json.load(handle)
+        pfb_unbound._dnsbl_validate_manifest_raws(manifest, str(manifest_path.parent))
+        elapsed = time.perf_counter() - start
+        encoded = manifest_path.read_text(encoding="utf-8")
+        if "top1m_list" in encoded or "top1m_ref" in encoded or SAMPLE_FIRST in encoded:
+            raise RuntimeError("compact manifest contract violated during Python validation")
+        print(f"wall_seconds={elapsed:.9f}")
+        print(f"manifest_bytes={manifest_path.stat().st_size}")
+        return 0
+
+    start = time.perf_counter()
+    result = pfb_unbound.dnsbl_build_from_manifest(str(manifest_path))
+    elapsed = time.perf_counter() - start
+    if result is None:
+        raise RuntimeError("dnsbl_build_from_manifest returned failure")
+    if len(result.white_db) != expected_lines:
+        raise RuntimeError(
+            f"full build consumed {len(result.white_db)} unique TOP1M domains; expected {expected_lines}"
+        )
+    if SAMPLE_FIRST not in result.white_db or sample_last not in result.white_db:
+        raise RuntimeError("full build omitted deterministic boundary samples")
+    print(f"wall_seconds={elapsed:.9f}")
+    print(f"unique_top1m_domains={len(result.white_db)}")
+    print(f"manifest_bytes={manifest_path.stat().st_size}")
+    print(f"fixed_bytes={(manifest_path.parent / 'pfb_py_top1m.txt').stat().st_size}")
+    return 0
+
+
+def _time_flag(time_bin: str, timeout_seconds: int) -> str:
+    probe = subprocess.run(  # noqa: S603
+        [time_bin, "-l", "true"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout_seconds,
+        env={**os.environ, "LC_ALL": "C"},
+    )
+    return "-l" if probe.returncode == 0 else "-v"
+
+
+def _run_timed(cmd: list[str], timeout_seconds: int, time_bin: str, time_flag: str) -> TrialResult:
+    proc = subprocess.run(  # noqa: S603
+        [time_bin, time_flag, *cmd],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout_seconds,
+        env={**os.environ, "LC_ALL": "C"},
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"timed worker failed ({proc.returncode}): {' '.join(cmd)}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+
+    values: dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+    if "wall_seconds" not in values:
+        raise RuntimeError(f"worker omitted wall_seconds:\n{proc.stdout}")
+
+    match = _BSD_RSS_RE.search(proc.stderr)
+    if match is not None:
+        peak_rss_bytes = int(match.group(1))
+    else:
+        match = _GNU_RSS_RE.search(proc.stderr)
+        if match is None:
+            raise RuntimeError(f"could not parse peak RSS from {time_bin}:\n{proc.stderr}")
+        peak_rss_bytes = int(match.group(1)) * 1024
+    return TrialResult(float(values["wall_seconds"]), peak_rss_bytes, values)
+
+
+def _copy_fixture(source: Path, sandbox: Path) -> None:
+    target = sandbox / "db" / "pfbalexawhitelist.txt"
+    target.parent.mkdir(parents=True)
+    try:
+        os.link(source, target)
+    except OSError:
+        shutil.copyfile(source, target)
+
+
+def _copy_contract(manifest: Path, fixed: Path | None, sandbox: Path) -> Path:
+    sandbox.mkdir(parents=True)
+    target_manifest = sandbox / "pfb_py_sources.json"
+    shutil.copyfile(manifest, target_manifest)
+    if fixed is not None:
+        target_fixed = sandbox / "pfb_py_top1m.txt"
+        try:
+            os.link(fixed, target_fixed)
+        except OSError:
+            shutil.copyfile(fixed, target_fixed)
+    return target_manifest
+
+
+def _run_php_phase(
+    phase: str,
+    worktree: Path,
+    sandboxes: list[Path],
+    expected_lines: int,
+    timeout_seconds: int,
+    time_bin: str,
+    time_flag: str,
+) -> list[TrialResult]:
+    php = shutil.which("php")
+    if php is None:
+        raise RuntimeError("php executable not found")
+    return [
+        _run_timed(
+            [php, str(PHP_WORKER), phase, str(worktree), str(sandbox), str(expected_lines)],
+            timeout_seconds,
+            time_bin,
+            time_flag,
+        )
+        for sandbox in sandboxes
+    ]
+
+
+def _run_python_phase(
+    phase: str,
+    worktree: Path,
+    manifests: list[Path],
+    expected_lines: int,
+    timeout_seconds: int,
+    time_bin: str,
+    time_flag: str,
+) -> list[TrialResult]:
+    return [
+        _run_timed(
+            [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "worker-python",
+                phase,
+                str(worktree),
+                str(manifest),
+                str(expected_lines),
+            ],
+            timeout_seconds,
+            time_bin,
+            time_flag,
+        )
+        for manifest in manifests
+    ]
+
+
+def _git_output(args: list[str]) -> str:
+    return subprocess.run(  # noqa: S603
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True, check=True, timeout=60
+    ).stdout.strip()
+
+
+def _runtime_line(command: list[str]) -> str:
+    return subprocess.run(  # noqa: S603
+        command, capture_output=True, text=True, check=True, timeout=60
+    ).stdout.strip()
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _format_result(label: str, trials: list[TrialResult]) -> str:
+    walls = [trial.wall_seconds for trial in trials]
+    rss_values = [trial.peak_rss_bytes for trial in trials]
+    return (
+        f"{label}: trials={len(trials)} wall_median={statistics.median(walls):.6f}s "
+        f"wall_range={min(walls):.6f}..{max(walls):.6f}s "
+        f"peak_rss_max={max(rss_values)}B ({max(rss_values) / 1_048_576:.2f}MiB)"
+    )
+
+
+def run(args: argparse.Namespace) -> int:
+    base_ref = args.base_ref or _git_output(["merge-base", "HEAD", "origin/devel"])
+    branch_sha = _git_output(["rev-parse", "HEAD"])
+    branch_dirty = bool(_git_output(["status", "--porcelain"]))
+    time_bin = shutil.which("time") or "/usr/bin/time"
+    time_flag = _time_flag(time_bin, args.timeout_seconds)
+    temp_root = Path(tempfile.mkdtemp(prefix="pfb_bench_top1m_"))
+    base_worktree = temp_root / "base_ref"
+    worktree_added = False
+
+    previous_handlers: dict[int, object] = {}
+
+    def interrupted(signum: int, frame: object) -> None:
+        del frame
+        raise KeyboardInterrupt(f"signal {signum}")
+
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        previous_handlers[signum] = signal.signal(signum, interrupted)
+
+    try:
+        subprocess.run(  # noqa: S603
+            ["git", "worktree", "add", "--detach", str(base_worktree), base_ref],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        worktree_added = True
+
+        fixture = temp_root / "pfbalexawhitelist.txt"
+        generated_bytes = generate_top1m(fixture, args.lines)
+        if args.lines == DEFAULT_LINES and generated_bytes <= 0:
+            raise RuntimeError("million-domain fixture generation failed")
+
+        writer_sandboxes = [temp_root / f"writer_branch_{trial}" for trial in range(args.trials)]
+        for sandbox in writer_sandboxes:
+            _copy_fixture(fixture, sandbox)
+        writer = _run_php_phase(
+            "write",
+            REPO_ROOT,
+            writer_sandboxes,
+            args.lines,
+            args.timeout_seconds,
+            time_bin,
+            time_flag,
+        )
+        contract_manifest = writer_sandboxes[0] / "pfb_py_sources.json"
+        contract_fixed = writer_sandboxes[0] / "pfb_py_top1m.txt"
+
+        patch: dict[str, list[TrialResult]] = {}
+        validate: dict[str, list[TrialResult]] = {}
+        for label, worktree in (("base", base_worktree), ("branch", REPO_ROOT)):
+            patch_sandboxes = [temp_root / f"patch_{label}_{trial}" for trial in range(args.trials)]
+            for sandbox in patch_sandboxes:
+                _copy_contract(contract_manifest, None, sandbox)
+            patch[label] = _run_php_phase(
+                "patch",
+                worktree,
+                patch_sandboxes,
+                args.lines,
+                args.timeout_seconds,
+                time_bin,
+                time_flag,
+            )
+
+            validate_manifests = [
+                _copy_contract(contract_manifest, None, temp_root / f"validate_{label}_{trial}")
+                for trial in range(args.trials)
+            ]
+            validate[label] = _run_python_phase(
+                "validate",
+                worktree,
+                validate_manifests,
+                args.lines,
+                args.timeout_seconds,
+                time_bin,
+                time_flag,
+            )
+
+        build_manifests = [
+            _copy_contract(contract_manifest, contract_fixed, temp_root / f"build_branch_{trial}")
+            for trial in range(args.trials)
+        ]
+        build = _run_python_phase(
+            "build",
+            REPO_ROOT,
+            build_manifests,
+            args.lines,
+            args.timeout_seconds,
+            time_bin,
+            time_flag,
+        )
+
+        manifest_bytes = int(writer[0].values["manifest_bytes"])
+        fixed_bytes = int(writer[0].values["fixed_bytes"])
+        if any(int(trial.values["fixed_lines"]) != args.lines for trial in writer):
+            raise RuntimeError("writer trials did not publish exact requested line count")
+        if any(int(trial.values["manifest_bytes"]) != manifest_bytes for trial in writer):
+            raise RuntimeError("writer trials produced different manifest sizes")
+        if any(int(trial.values["fixed_bytes"]) != fixed_bytes for trial in writer):
+            raise RuntimeError("writer trials produced different fixed-file sizes")
+        if any(int(trial.values["unique_top1m_domains"]) != args.lines for trial in build):
+            raise RuntimeError("full-build trials did not consume exact unique TOP1M count")
+
+        command = (
+            f"python3 scripts/bench_top1m_fixed_file.py run --base-ref {base_ref} "
+            f"--lines {args.lines} --trials {args.trials} --timeout-seconds {args.timeout_seconds}"
+        )
+        report = [
+            "ISSUE #1542 -- FIXED-FILE TOP1M BENCHMARK",
+            "==========================================",
+            f"command: {command}",
+            f"base_sha: {base_ref}",
+            f"branch_sha: {branch_sha}",
+            f"branch_worktree_dirty: {'yes' if branch_dirty else 'no'}",
+            "branch_pfblockerng_inc_sha256: " + _sha256(REPO_ROOT / "src/usr/local/pkg/pfblockerng/pfblockerng.inc"),
+            "branch_pfb_unbound_py_sha256: " + _sha256(REPO_ROOT / "src/usr/local/pkg/pfblockerng/pfb_unbound.py"),
+            f"host: {platform.platform()} machine={platform.machine()} logical_cpus={os.cpu_count()}",
+            f"python: {platform.python_version()} ({sys.executable})",
+            f"php: {_runtime_line([shutil.which('php') or 'php', '-r', 'echo PHP_VERSION;'])}",
+            f"time: {time_bin} {time_flag}",
+            f"fixture: deterministic unique domains={args.lines} generated_bytes={generated_bytes}",
+            f"manifest_bytes: {manifest_bytes}",
+            f"fixed_file_bytes: {fixed_bytes}",
+            f"trials_per_phase_ref: {args.trials}",
+            f"per_process_deadline_seconds: {args.timeout_seconds}",
+            "",
+            "Measurements (isolated seam wall time; whole fresh-process peak RSS)",
+            "------------------------------------------------------------------",
+            "phase1.php_full_writer base: N/A -- old contract embeds TOP1M and has no fixed-file writer",
+            _format_result("phase1.php_full_writer branch", writer),
+            _format_result("phase2.php_scalar_patch base", patch["base"]),
+            _format_result("phase2.php_scalar_patch branch", patch["branch"]),
+            _format_result("phase3.python_json_validate base", validate["base"]),
+            _format_result("phase3.python_json_validate branch", validate["branch"]),
+            "phase4.python_full_build base: N/A -- old contract cannot consume the fixed TOP1M file",
+            _format_result("phase4.python_full_build branch", build),
+            "",
+            "Contract assertions executed in every applicable trial",
+            "------------------------------------------------------",
+            "manifest has no top1m_list, top1m_ref, or sampled TOP1M domain: PASS",
+            f"fixed file has exactly {args.lines} lines: PASS",
+            f"full build exposes exactly {args.lines} unique TOP1M white_db domains: PASS",
+            "thresholds: none (measurements only; no invented pass/fail gate)",
+        ]
+        print("\n".join(report))
+        return 0
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+        if worktree_added:
+            subprocess.run(  # noqa: S603
+                ["git", "worktree", "remove", "--force", str(base_worktree)],
+                cwd=REPO_ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        shutil.rmtree(temp_root, ignore_errors=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="run the base-versus-branch benchmark")
+    run_parser.add_argument("--base-ref")
+    run_parser.add_argument("--lines", type=_line_count, default=DEFAULT_LINES)
+    run_parser.add_argument("--trials", type=_positive_int, default=DEFAULT_TRIALS)
+    run_parser.add_argument("--timeout-seconds", type=_positive_int, default=DEFAULT_TIMEOUT_SECONDS)
+
+    worker_parser = subparsers.add_parser("worker-python", help=argparse.SUPPRESS)
+    worker_parser.add_argument("phase", choices=("validate", "build"))
+    worker_parser.add_argument("worktree", type=Path)
+    worker_parser.add_argument("manifest", type=Path)
+    worker_parser.add_argument("expected_lines", type=_positive_int)
+
+    args = parser.parse_args()
+    if args.command == "worker-python":
+        return worker_python(args.phase, args.worktree, args.manifest, args.expected_lines)
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_top1m_fixed_file.py
+++ b/scripts/bench_top1m_fixed_file.py
@@ -3,10 +3,10 @@
 
 Runs four fresh-process phases on deterministic unique domains:
 
-1. PHP full manifest + fixed-file writer (branch only; old contract N/A)
+1. PHP full native writer (base embedded list; branch fixed file)
 2. PHP scalar manifest patcher (base and branch)
 3. Python JSON parse + manifest validation only (base and branch)
-4. Python full fixed-file build (branch only; old contract N/A)
+4. Python full native-contract build (base and branch)
 
 No threshold or verdict is applied. Measurements are dev-host observations.
 """
@@ -37,6 +37,7 @@ DEFAULT_LINES = 1_000_000
 DEFAULT_TRIALS = 3
 DEFAULT_TIMEOUT_SECONDS = 900
 SAMPLE_FIRST = "top1m-0000000.benchmark.invalid"
+CONTRACTS = {"base": "embedded", "branch": "fixed"}
 
 _BSD_RSS_RE = re.compile(r"^\s*(\d+)\s+maximum resident set size", re.MULTILINE)
 _GNU_RSS_RE = re.compile(r"Maximum resident set size \(kbytes\):\s*(\d+)", re.MULTILINE)
@@ -60,6 +61,50 @@ def generate_top1m(path: Path, lines: int) -> int:
         for index in range(lines):
             handle.write(domain_for(index) + "\n")
     return path.stat().st_size
+
+
+def _assert_manifest_object_contract(
+    manifest: object, manifest_path: Path, contract: str, expected_lines: int
+) -> tuple[int, int]:
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("config"), dict):
+        raise RuntimeError("native manifest missing config object")
+    config = manifest["config"]
+    if config.get("top1m_enabled") is not True or "top1m_ref" in config:
+        raise RuntimeError(f"{contract} TOP1M contract missing enabled flag or contains top1m_ref")
+
+    manifest_bytes = manifest_path.stat().st_size
+    if contract == "embedded":
+        top1m_list = config.get("top1m_list")
+        if (
+            not isinstance(top1m_list, list)
+            or len(top1m_list) != expected_lines
+            or top1m_list[0] != SAMPLE_FIRST
+            or top1m_list[-1] != domain_for(expected_lines - 1)
+        ):
+            raise RuntimeError("embedded TOP1M contract missing exact deterministic domain list")
+        if (manifest_path.parent / "pfb_py_top1m.txt").exists():
+            raise RuntimeError("embedded TOP1M contract unexpectedly published fixed sidecar")
+        return manifest_bytes, 0
+
+    if contract != "fixed":
+        raise RuntimeError(f"unknown TOP1M contract: {contract}")
+    encoded = manifest_path.read_text(encoding="utf-8")
+    if "top1m_list" in config or "top1m_ref" in config or SAMPLE_FIRST in encoded:
+        raise RuntimeError("fixed-file TOP1M contract leaked list, reference, or sampled domain into manifest")
+    fixed_path = manifest_path.parent / "pfb_py_top1m.txt"
+    if not fixed_path.is_file():
+        raise RuntimeError("fixed-file TOP1M contract missing sidecar")
+    with fixed_path.open(encoding="ascii") as handle:
+        observed_lines = sum(1 for _ in handle)
+    if observed_lines != expected_lines:
+        raise RuntimeError(f"fixed-file TOP1M contract has {observed_lines} lines; expected {expected_lines}")
+    return manifest_bytes, fixed_path.stat().st_size
+
+
+def _assert_native_contract(manifest_path: Path, contract: str, expected_lines: int) -> tuple[int, int]:
+    with manifest_path.open(encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    return _assert_manifest_object_contract(manifest, manifest_path, contract, expected_lines)
 
 
 def _positive_int(value: str) -> int:
@@ -89,7 +134,7 @@ def _load_python_target(worktree: Path) -> ModuleType:
     return pfb_unbound
 
 
-def worker_python(phase: str, worktree: Path, manifest_path: Path, expected_lines: int) -> int:
+def worker_python(phase: str, contract: str, worktree: Path, manifest_path: Path, expected_lines: int) -> int:
     pfb_unbound = _load_python_target(worktree)
     sample_last = domain_for(expected_lines - 1)
 
@@ -99,11 +144,10 @@ def worker_python(phase: str, worktree: Path, manifest_path: Path, expected_line
             manifest = json.load(handle)
         pfb_unbound._dnsbl_validate_manifest_raws(manifest, str(manifest_path.parent))
         elapsed = time.perf_counter() - start
-        encoded = manifest_path.read_text(encoding="utf-8")
-        if "top1m_list" in encoded or "top1m_ref" in encoded or SAMPLE_FIRST in encoded:
-            raise RuntimeError("compact manifest contract violated during Python validation")
+        _, fixed_bytes = _assert_manifest_object_contract(manifest, manifest_path, contract, expected_lines)
         print(f"wall_seconds={elapsed:.9f}")
         print(f"manifest_bytes={manifest_path.stat().st_size}")
+        print(f"fixed_bytes={fixed_bytes}")
         return 0
 
     start = time.perf_counter()
@@ -120,7 +164,8 @@ def worker_python(phase: str, worktree: Path, manifest_path: Path, expected_line
     print(f"wall_seconds={elapsed:.9f}")
     print(f"unique_top1m_domains={len(result.white_db)}")
     print(f"manifest_bytes={manifest_path.stat().st_size}")
-    print(f"fixed_bytes={(manifest_path.parent / 'pfb_py_top1m.txt').stat().st_size}")
+    fixed_path = manifest_path.parent / "pfb_py_top1m.txt"
+    print(f"fixed_bytes={fixed_path.stat().st_size if fixed_path.exists() else 0}")
     return 0
 
 
@@ -133,38 +178,76 @@ def _time_flag(time_bin: str, timeout_seconds: int) -> str:
         timeout=timeout_seconds,
         env={**os.environ, "LC_ALL": "C"},
     )
-    return "-l" if probe.returncode == 0 else "-v"
+    unsupported = "illegal option -- l" in probe.stderr or "invalid option -- 'l'" in probe.stderr
+    return "-v" if unsupported else "-l"
 
 
-def _run_timed(cmd: list[str], timeout_seconds: int, time_bin: str, time_flag: str) -> TrialResult:
-    proc = subprocess.run(  # noqa: S603
-        [time_bin, time_flag, *cmd],
-        capture_output=True,
+def _terminate_process_group(proc: subprocess.Popen[str], cmd: list[str], kill_grace_seconds: float) -> tuple[str, str]:
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        return proc.communicate(timeout=kill_grace_seconds)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        try:
+            return proc.communicate(timeout=kill_grace_seconds)
+        except subprocess.TimeoutExpired as error:
+            proc.kill()
+            try:
+                proc.wait(timeout=kill_grace_seconds)
+            except subprocess.TimeoutExpired as reap_error:
+                raise RuntimeError(f"failed to reap timed-out process group: {' '.join(cmd)}") from reap_error
+            raise RuntimeError(f"timed-out process group retained an output pipe: {' '.join(cmd)}") from error
+
+
+def _run_timed(
+    cmd: list[str],
+    timeout_seconds: int,
+    time_bin: str,
+    time_flag: str,
+    *,
+    kill_grace_seconds: float = 2.0,
+) -> TrialResult:
+    timed_cmd = [time_bin, time_flag, *cmd]
+    proc = subprocess.Popen(  # noqa: S603
+        timed_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        check=False,
-        timeout=timeout_seconds,
         env={**os.environ, "LC_ALL": "C"},
+        start_new_session=True,
     )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        stdout, stderr = _terminate_process_group(proc, timed_cmd, kill_grace_seconds)
+        raise subprocess.TimeoutExpired(timed_cmd, timeout_seconds, output=stdout, stderr=stderr)
+
     if proc.returncode != 0:
         raise RuntimeError(
-            f"timed worker failed ({proc.returncode}): {' '.join(cmd)}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+            f"timed worker failed ({proc.returncode}): {' '.join(cmd)}\nstdout:\n{stdout}\nstderr:\n{stderr}"
         )
 
     values: dict[str, str] = {}
-    for line in proc.stdout.splitlines():
+    for line in stdout.splitlines():
         if "=" in line:
             key, value = line.split("=", 1)
             values[key] = value
     if "wall_seconds" not in values:
-        raise RuntimeError(f"worker omitted wall_seconds:\n{proc.stdout}")
+        raise RuntimeError(f"worker omitted wall_seconds:\n{stdout}")
 
-    match = _BSD_RSS_RE.search(proc.stderr)
+    match = _BSD_RSS_RE.search(stderr)
     if match is not None:
         peak_rss_bytes = int(match.group(1))
     else:
-        match = _GNU_RSS_RE.search(proc.stderr)
+        match = _GNU_RSS_RE.search(stderr)
         if match is None:
-            raise RuntimeError(f"could not parse peak RSS from {time_bin}:\n{proc.stderr}")
+            raise RuntimeError(f"could not parse peak RSS from {time_bin}:\n{stderr}")
         peak_rss_bytes = int(match.group(1)) * 1024
     return TrialResult(float(values["wall_seconds"]), peak_rss_bytes, values)
 
@@ -193,6 +276,7 @@ def _copy_contract(manifest: Path, fixed: Path | None, sandbox: Path) -> Path:
 
 def _run_php_phase(
     phase: str,
+    contract: str,
     worktree: Path,
     sandboxes: list[Path],
     expected_lines: int,
@@ -205,7 +289,7 @@ def _run_php_phase(
         raise RuntimeError("php executable not found")
     return [
         _run_timed(
-            [php, str(PHP_WORKER), phase, str(worktree), str(sandbox), str(expected_lines)],
+            [php, str(PHP_WORKER), phase, contract, str(worktree), str(sandbox), str(expected_lines)],
             timeout_seconds,
             time_bin,
             time_flag,
@@ -216,6 +300,7 @@ def _run_php_phase(
 
 def _run_python_phase(
     phase: str,
+    contract: str,
     worktree: Path,
     manifests: list[Path],
     expected_lines: int,
@@ -230,6 +315,7 @@ def _run_python_phase(
                 str(Path(__file__).resolve()),
                 "worker-python",
                 phase,
+                contract,
                 str(worktree),
                 str(manifest),
                 str(expected_lines),
@@ -307,29 +393,51 @@ def run(args: argparse.Namespace) -> int:
         if args.lines == DEFAULT_LINES and generated_bytes <= 0:
             raise RuntimeError("million-domain fixture generation failed")
 
-        writer_sandboxes = [temp_root / f"writer_branch_{trial}" for trial in range(args.trials)]
-        for sandbox in writer_sandboxes:
-            _copy_fixture(fixture, sandbox)
-        writer = _run_php_phase(
-            "write",
-            REPO_ROOT,
-            writer_sandboxes,
-            args.lines,
-            args.timeout_seconds,
-            time_bin,
-            time_flag,
-        )
-        contract_manifest = writer_sandboxes[0] / "pfb_py_sources.json"
-        contract_fixed = writer_sandboxes[0] / "pfb_py_top1m.txt"
-
+        refs = {"base": base_worktree, "branch": REPO_ROOT}
+        writer: dict[str, list[TrialResult]] = {}
+        native_manifest: dict[str, Path] = {}
+        native_fixed: dict[str, Path | None] = {}
         patch: dict[str, list[TrialResult]] = {}
         validate: dict[str, list[TrialResult]] = {}
-        for label, worktree in (("base", base_worktree), ("branch", REPO_ROOT)):
+        build: dict[str, list[TrialResult]] = {}
+        manifest_bytes: dict[str, int] = {}
+        fixed_bytes: dict[str, int] = {}
+
+        for label, worktree in refs.items():
+            contract = CONTRACTS[label]
+            writer_sandboxes = [temp_root / f"writer_{label}_{trial}" for trial in range(args.trials)]
+            for sandbox in writer_sandboxes:
+                _copy_fixture(fixture, sandbox)
+            writer[label] = _run_php_phase(
+                "write",
+                contract,
+                worktree,
+                writer_sandboxes,
+                args.lines,
+                args.timeout_seconds,
+                time_bin,
+                time_flag,
+            )
+            native_manifest[label] = writer_sandboxes[0] / "pfb_py_sources.json"
+            candidate_fixed = writer_sandboxes[0] / "pfb_py_top1m.txt"
+            native_fixed[label] = candidate_fixed if contract == "fixed" else None
+            manifest_bytes[label], fixed_bytes[label] = _assert_native_contract(
+                native_manifest[label], contract, args.lines
+            )
+
+            if any(int(trial.values["top1m_lines"]) != args.lines for trial in writer[label]):
+                raise RuntimeError(f"{label} writer trials did not publish exact requested TOP1M count")
+            if any(int(trial.values["manifest_bytes"]) != manifest_bytes[label] for trial in writer[label]):
+                raise RuntimeError(f"{label} writer trials produced different manifest sizes")
+            if any(int(trial.values["fixed_bytes"]) != fixed_bytes[label] for trial in writer[label]):
+                raise RuntimeError(f"{label} writer trials produced different fixed-file sizes")
+
             patch_sandboxes = [temp_root / f"patch_{label}_{trial}" for trial in range(args.trials)]
             for sandbox in patch_sandboxes:
-                _copy_contract(contract_manifest, None, sandbox)
+                _copy_contract(native_manifest[label], native_fixed[label], sandbox)
             patch[label] = _run_php_phase(
                 "patch",
+                contract,
                 worktree,
                 patch_sandboxes,
                 args.lines,
@@ -339,11 +447,12 @@ def run(args: argparse.Namespace) -> int:
             )
 
             validate_manifests = [
-                _copy_contract(contract_manifest, None, temp_root / f"validate_{label}_{trial}")
+                _copy_contract(native_manifest[label], native_fixed[label], temp_root / f"validate_{label}_{trial}")
                 for trial in range(args.trials)
             ]
             validate[label] = _run_python_phase(
                 "validate",
+                contract,
                 worktree,
                 validate_manifests,
                 args.lines,
@@ -351,31 +460,22 @@ def run(args: argparse.Namespace) -> int:
                 time_bin,
                 time_flag,
             )
-
-        build_manifests = [
-            _copy_contract(contract_manifest, contract_fixed, temp_root / f"build_branch_{trial}")
-            for trial in range(args.trials)
-        ]
-        build = _run_python_phase(
-            "build",
-            REPO_ROOT,
-            build_manifests,
-            args.lines,
-            args.timeout_seconds,
-            time_bin,
-            time_flag,
-        )
-
-        manifest_bytes = int(writer[0].values["manifest_bytes"])
-        fixed_bytes = int(writer[0].values["fixed_bytes"])
-        if any(int(trial.values["fixed_lines"]) != args.lines for trial in writer):
-            raise RuntimeError("writer trials did not publish exact requested line count")
-        if any(int(trial.values["manifest_bytes"]) != manifest_bytes for trial in writer):
-            raise RuntimeError("writer trials produced different manifest sizes")
-        if any(int(trial.values["fixed_bytes"]) != fixed_bytes for trial in writer):
-            raise RuntimeError("writer trials produced different fixed-file sizes")
-        if any(int(trial.values["unique_top1m_domains"]) != args.lines for trial in build):
-            raise RuntimeError("full-build trials did not consume exact unique TOP1M count")
+            build_manifests = [
+                _copy_contract(native_manifest[label], native_fixed[label], temp_root / f"build_{label}_{trial}")
+                for trial in range(args.trials)
+            ]
+            build[label] = _run_python_phase(
+                "build",
+                contract,
+                worktree,
+                build_manifests,
+                args.lines,
+                args.timeout_seconds,
+                time_bin,
+                time_flag,
+            )
+            if any(int(trial.values["unique_top1m_domains"]) != args.lines for trial in build[label]):
+                raise RuntimeError(f"{label} full-build trials did not consume exact unique TOP1M count")
 
         command = (
             f"python3 scripts/bench_top1m_fixed_file.py run --base-ref {base_ref} "
@@ -395,27 +495,29 @@ def run(args: argparse.Namespace) -> int:
             f"php: {_runtime_line([shutil.which('php') or 'php', '-r', 'echo PHP_VERSION;'])}",
             f"time: {time_bin} {time_flag}",
             f"fixture: deterministic unique domains={args.lines} generated_bytes={generated_bytes}",
-            f"manifest_bytes: {manifest_bytes}",
-            f"fixed_file_bytes: {fixed_bytes}",
+            f"base_contract: embedded manifest_bytes={manifest_bytes['base']} fixed_file_bytes=0",
+            "branch_contract: fixed "
+            f"manifest_bytes={manifest_bytes['branch']} fixed_file_bytes={fixed_bytes['branch']}",
             f"trials_per_phase_ref: {args.trials}",
             f"per_process_deadline_seconds: {args.timeout_seconds}",
             "",
             "Measurements (isolated seam wall time; whole fresh-process peak RSS)",
             "------------------------------------------------------------------",
-            "phase1.php_full_writer base: N/A -- old contract embeds TOP1M and has no fixed-file writer",
-            _format_result("phase1.php_full_writer branch", writer),
+            _format_result("phase1.php_full_writer base[embedded]", writer["base"]),
+            _format_result("phase1.php_full_writer branch[fixed]", writer["branch"]),
             _format_result("phase2.php_scalar_patch base", patch["base"]),
             _format_result("phase2.php_scalar_patch branch", patch["branch"]),
             _format_result("phase3.python_json_validate base", validate["base"]),
             _format_result("phase3.python_json_validate branch", validate["branch"]),
-            "phase4.python_full_build base: N/A -- old contract cannot consume the fixed TOP1M file",
-            _format_result("phase4.python_full_build branch", build),
+            _format_result("phase4.python_full_build base[embedded]", build["base"]),
+            _format_result("phase4.python_full_build branch[fixed]", build["branch"]),
             "",
             "Contract assertions executed in every applicable trial",
             "------------------------------------------------------",
-            "manifest has no top1m_list, top1m_ref, or sampled TOP1M domain: PASS",
-            f"fixed file has exactly {args.lines} lines: PASS",
-            f"full build exposes exactly {args.lines} unique TOP1M white_db domains: PASS",
+            f"base manifest embeds exactly {args.lines} deterministic TOP1M domains: PASS",
+            "branch manifest has no top1m_list, top1m_ref, or sampled TOP1M domain: PASS",
+            f"branch fixed file has exactly {args.lines} lines: PASS",
+            f"both native full builds expose exactly {args.lines} unique TOP1M white_db domains: PASS",
             "thresholds: none (measurements only; no invented pass/fail gate)",
         ]
         print("\n".join(report))
@@ -447,13 +549,14 @@ def main() -> int:
 
     worker_parser = subparsers.add_parser("worker-python", help=argparse.SUPPRESS)
     worker_parser.add_argument("phase", choices=("validate", "build"))
+    worker_parser.add_argument("contract", choices=("embedded", "fixed"))
     worker_parser.add_argument("worktree", type=Path)
     worker_parser.add_argument("manifest", type=Path)
     worker_parser.add_argument("expected_lines", type=_positive_int)
 
     args = parser.parse_args()
     if args.command == "worker-python":
-        return worker_python(args.phase, args.worktree, args.manifest, args.expected_lines)
+        return worker_python(args.phase, args.contract, args.worktree, args.manifest, args.expected_lines)
     return run(args)
 
 

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5364,7 +5364,7 @@ def _dnsbl_fixed_top1m_lines(base_dir: str) -> Iterable[str]:
     """Stream the fixed TOP1M sidecar; any source failure aborts the build."""
     path = os.path.join(base_dir, "pfb_py_top1m.txt")
     nofollow = getattr(os, "O_NOFOLLOW", None)
-    if nofollow is None:
+    if not nofollow:
         raise _DnsblGenerationError("TOP1M sidecar cannot be opened without symlink protection: '{}'".format(path))
     try:
         path_stat = os.lstat(path)

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import csv
 import errno
+import hashlib
 import itertools
 import json
 import logging
@@ -5377,7 +5378,7 @@ def _dnsbl_fixed_top1m_lines(base_dir: str) -> Iterable[str]:
         return os.open(file_path, flags | nofollow | getattr(os, "O_NONBLOCK", 0))
 
     try:
-        handle = open(path, encoding="utf-8", errors="strict", newline="", opener=opener)
+        handle = open(path, "rb", opener=opener)
     except (OSError, UnicodeError) as e:
         raise _DnsblGenerationError("TOP1M sidecar unavailable: '{}'".format(path)) from e
 
@@ -5400,7 +5401,19 @@ def _dnsbl_fixed_top1m_lines(base_dir: str) -> Iterable[str]:
                 opened.st_mtime_ns,
             ):
                 raise _DnsblGenerationError("TOP1M sidecar changed before reading: '{}'".format(path))
-            for line in handle:
+            expected_digest = hashlib.sha256()
+            while chunk := os.read(handle.fileno(), 64 * 1024):
+                expected_digest.update(chunk)
+            os.lseek(handle.fileno(), 0, os.SEEK_SET)
+            consumed_digest = hashlib.sha256()
+            for raw_line in handle:
+                if isinstance(raw_line, str):
+                    line_bytes = raw_line.encode("utf-8", errors="strict")
+                    line = raw_line
+                else:
+                    line_bytes = raw_line
+                    line = raw_line.decode("utf-8", errors="strict")
+                consumed_digest.update(line_bytes)
                 yield line.strip()
             consumed = os.lseek(handle.fileno(), 0, os.SEEK_CUR)
             finished = os.fstat(handle.fileno())
@@ -5428,6 +5441,7 @@ def _dnsbl_fixed_top1m_lines(base_dir: str) -> Iterable[str]:
                     finished.st_size,
                     finished.st_mtime_ns,
                 )
+                or consumed_digest.digest() != expected_digest.digest()
                 or not (pathname_same or pathname_replaced)
                 or (fd_metadata_changed and not pathname_replaced)
             ):

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5363,18 +5363,64 @@ def _dnsbl_file_line_reader(base_dir: str, *, fail_closed: bool = False) -> Call
 def _dnsbl_fixed_top1m_lines(base_dir: str) -> Iterable[str]:
     """Stream the fixed TOP1M sidecar; any source failure aborts the build."""
     path = os.path.join(base_dir, "pfb_py_top1m.txt")
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    if nofollow is None:
+        raise _DnsblGenerationError("TOP1M sidecar cannot be opened without symlink protection: '{}'".format(path))
     try:
-        if not stat.S_ISREG(os.lstat(path).st_mode):
+        path_stat = os.lstat(path)
+        if not stat.S_ISREG(path_stat.st_mode):
             raise _DnsblGenerationError("TOP1M sidecar is not a regular file: '{}'".format(path))
-        handle = open(path, encoding="utf-8", errors="strict", newline="")
+    except OSError as e:
+        raise _DnsblGenerationError("TOP1M sidecar unavailable: '{}'".format(path)) from e
+
+    def opener(file_path: str, flags: int) -> int:
+        return os.open(file_path, flags | nofollow | getattr(os, "O_NONBLOCK", 0))
+
+    try:
+        handle = open(path, encoding="utf-8", errors="strict", newline="", opener=opener)
     except (OSError, UnicodeError) as e:
         raise _DnsblGenerationError("TOP1M sidecar unavailable: '{}'".format(path)) from e
 
     try:
         with handle:
+            opened = os.fstat(handle.fileno())
+            if not stat.S_ISREG(opened.st_mode):
+                raise _DnsblGenerationError("TOP1M sidecar is not a regular file: '{}'".format(path))
+            if (
+                path_stat.st_dev,
+                path_stat.st_ino,
+                path_stat.st_mode,
+                path_stat.st_size,
+                path_stat.st_mtime_ns,
+            ) != (
+                opened.st_dev,
+                opened.st_ino,
+                opened.st_mode,
+                opened.st_size,
+                opened.st_mtime_ns,
+            ):
+                raise _DnsblGenerationError("TOP1M sidecar changed before reading: '{}'".format(path))
             for line in handle:
                 yield line.strip()
-    except (OSError, UnicodeError) as e:
+            consumed = os.lseek(handle.fileno(), 0, os.SEEK_CUR)
+            finished = os.fstat(handle.fileno())
+            if consumed != finished.st_size or (
+                opened.st_dev,
+                opened.st_ino,
+                opened.st_mode,
+                opened.st_size,
+                opened.st_mtime_ns,
+            ) != (
+                finished.st_dev,
+                finished.st_ino,
+                finished.st_mode,
+                finished.st_size,
+                finished.st_mtime_ns,
+            ):
+                raise _DnsblGenerationError("TOP1M sidecar changed while reading: '{}'".format(path))
+    except _DnsblGenerationError:
+        raise
+    except (AttributeError, OSError, UnicodeError, ValueError) as e:
         raise _DnsblGenerationError("TOP1M sidecar read failed: '{}'".format(path)) from e
 
 

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -29,10 +29,8 @@ import logging.handlers
 import os
 import re
 import select
-import stat
 import sys
 import time
-from builtins import open  # noqa: A001 - injectable seam for fail-closed file reads
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import nullcontext
 from dataclasses import dataclass, field
@@ -1296,7 +1294,6 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["pfb_py_zone"] = "pfb_py_zone.txt"
     pfb["pfb_py_data"] = "pfb_py_data.txt"
     pfb["pfb_py_hsts"] = "pfb_py_hsts.txt"
-    pfb["pfb_py_top1m"] = "pfb_py_top1m.txt"
     # issue #1255: shipped TLD-Wildcard public-suffix oracle -- staged by
     # dnsbl_cache_stage() exactly like pfb_py_hsts above.
     pfb["pfb_py_tld"] = "pfb_py_tld.txt"
@@ -4613,7 +4610,7 @@ def reconcile(
 
 def _dnsbl_normalise_whitelist(
     user_whitelist: Iterable[str],
-    top1m_lines: Iterable[str],
+    top1m_list: Iterable[str],
     top1m_enabled: bool,
 ) -> dict[str, dict[str, Any]]:
     """User-whitelist normalisation (mirrors PHP's pfb_unbound_python_whitelist()) into the
@@ -4641,7 +4638,7 @@ def _dnsbl_normalise_whitelist(
             white_db[line] = {"wildcard": False, "important": True, "band": PRIO_USER_ALLOW}
 
     if top1m_enabled:
-        for raw in top1m_lines:
+        for raw in top1m_list:
             dom = raw.strip()
             if dom:
                 # TOP1M behaves as a user allow (sovereign, band 6) -- fact 7.
@@ -4969,7 +4966,6 @@ def build(
     *,
     line_reader: Callable[[str], Iterable[str]],
     top1m_enabled: bool = False,
-    top1m_lines: Iterable[str] = (),
 ) -> BuildResult:
     """Pure, reentrant DNSBL build: raw feeds + config -> matcher structure-set.
 
@@ -4977,8 +4973,7 @@ def build(
     raw feed file mapping it to ``{raw, feed, group, log_flag}``.
     ``config`` carries the classification + whitelist inputs (``tld_wildcard_master``
     suffix lines, ``tld_wildcard_blacklist``, ``tld_wildcard_exclusion``,
-    ``user_whitelist``, ``user_unlock``). TOP1M is streamed from the fixed
-    ``pfb_py_top1m.txt`` sidecar by ``dnsbl_build_from_manifest``.
+    ``user_whitelist``, ``user_unlock``, ``top1m_list``).
     ``line_reader`` yields the raw lines for a feed's ``raw`` reference -- injected so
     this stays pure and side-effect-free (no filesystem coupling, unit-testable; the
     init wiring supplies a file-backed reader).
@@ -5044,7 +5039,7 @@ def build(
     # dnsbl_remove handler populates it.
     white_db = _dnsbl_normalise_whitelist(
         config.get("user_whitelist", []),
-        top1m_lines,
+        config.get("top1m_list", []),
         top1m_enabled,
     )
     # Merge the unlock set WITHOUT narrowing an existing permanent allow: a domain may be
@@ -5276,13 +5271,12 @@ def _dnsbl_validate_manifest_raws(manifest: dict[str, Any], base_dir: str) -> No
         "tld_wildcard_exclusion",
         "user_whitelist",
         "user_unlock",
+        "top1m_list",
     )
     for config_field in list_fields:
         value = config.get(config_field)
         if config_field in config and (not isinstance(value, list) or any(not isinstance(item, str) for item in value)):
             raise _DnsblGenerationError("DNSBL manifest/v1 config.{} must be list[str]".format(config_field))
-    if "top1m_list" in config:
-        raise _DnsblGenerationError("DNSBL manifest/v1 config.top1m_list is retired")
     for flag_field in ("top1m_enabled", "regex_cap"):
         if flag_field in config and not isinstance(config[flag_field], bool):
             raise _DnsblGenerationError("DNSBL manifest/v1 config.{} must be bool".format(flag_field))
@@ -5361,24 +5355,6 @@ def _dnsbl_file_line_reader(base_dir: str, *, fail_closed: bool = False) -> Call
     return reader
 
 
-def _dnsbl_fixed_top1m_lines(base_dir: str) -> Iterable[str]:
-    """Stream the fixed TOP1M sidecar; any source failure aborts the build."""
-    path = os.path.join(base_dir, "pfb_py_top1m.txt")
-    try:
-        if not stat.S_ISREG(os.lstat(path).st_mode):
-            raise _DnsblGenerationError("TOP1M sidecar is not a regular file: '{}'".format(path))
-        handle = open(path, encoding="utf-8", errors="strict", newline="")
-    except (OSError, UnicodeError) as e:
-        raise _DnsblGenerationError("TOP1M sidecar unavailable: '{}'".format(path)) from e
-
-    try:
-        with handle:
-            for line in handle:
-                yield line.strip()
-    except (OSError, UnicodeError) as e:
-        raise _DnsblGenerationError("TOP1M sidecar read failed: '{}'".format(path)) from e
-
-
 def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict[str, Any]:
     """Shape the manifest's ``config`` block into the build() config blob.
 
@@ -5388,7 +5364,7 @@ def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict
     ``pfb["python_hsts"]``. A manifest ``config.tld_master`` key (a stale pre-#1255
     shape) is ignored entirely -- an absent oracle is expected, not a warning.
     ``tld_wildcard_blacklist`` / ``tld_wildcard_exclusion`` / ``user_whitelist`` /
-    ``user_unlock`` are passed through as lists. Missing keys
+    ``user_unlock`` / ``top1m_list`` are passed through as lists. Missing keys
     within the required ``config`` object default empty.
     """
     config = manifest.get("config", {})
@@ -5416,6 +5392,7 @@ def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict
         "user_whitelist": list(config.get("user_whitelist", [])),
         # ADR-06 (#51): the temporary per-alert unlock set -> band-6 whiteDB allows.
         "user_unlock": list(config.get("user_unlock", [])),
+        "top1m_list": list(config.get("top1m_list", [])),
         "regex_cap": regex_cap,
     }
 
@@ -5460,13 +5437,11 @@ def dnsbl_build_from_manifest(manifest_path: str) -> BuildResult | None:
         manifest_config = manifest["config"]
         config = _dnsbl_config_from_manifest(manifest, base_dir)
         top1m_enabled = bool(manifest_config.get("top1m_enabled", False))
-        top1m_lines = _dnsbl_fixed_top1m_lines(base_dir) if top1m_enabled else ()
         result = build(
             manifest,
             config,
             line_reader=_dnsbl_file_line_reader(base_dir, fail_closed=True),
             top1m_enabled=top1m_enabled,
-            top1m_lines=top1m_lines,
         )
     except Exception as e:
         sys.stderr.write("[pfBlockerNG]: Failed to build DNSBL structures from raw: {}".format(e))

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -32,7 +32,6 @@ import select
 import stat
 import sys
 import time
-from builtins import open  # noqa: A001 - injectable seam for fail-closed file reads
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import nullcontext
 from dataclasses import dataclass, field

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -29,8 +29,10 @@ import logging.handlers
 import os
 import re
 import select
+import stat
 import sys
 import time
+from builtins import open  # noqa: A001 - injectable seam for fail-closed file reads
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import nullcontext
 from dataclasses import dataclass, field
@@ -1294,6 +1296,7 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["pfb_py_zone"] = "pfb_py_zone.txt"
     pfb["pfb_py_data"] = "pfb_py_data.txt"
     pfb["pfb_py_hsts"] = "pfb_py_hsts.txt"
+    pfb["pfb_py_top1m"] = "pfb_py_top1m.txt"
     # issue #1255: shipped TLD-Wildcard public-suffix oracle -- staged by
     # dnsbl_cache_stage() exactly like pfb_py_hsts above.
     pfb["pfb_py_tld"] = "pfb_py_tld.txt"
@@ -4610,7 +4613,7 @@ def reconcile(
 
 def _dnsbl_normalise_whitelist(
     user_whitelist: Iterable[str],
-    top1m_list: Iterable[str],
+    top1m_lines: Iterable[str],
     top1m_enabled: bool,
 ) -> dict[str, dict[str, Any]]:
     """User-whitelist normalisation (mirrors PHP's pfb_unbound_python_whitelist()) into the
@@ -4638,7 +4641,7 @@ def _dnsbl_normalise_whitelist(
             white_db[line] = {"wildcard": False, "important": True, "band": PRIO_USER_ALLOW}
 
     if top1m_enabled:
-        for raw in top1m_list:
+        for raw in top1m_lines:
             dom = raw.strip()
             if dom:
                 # TOP1M behaves as a user allow (sovereign, band 6) -- fact 7.
@@ -4966,6 +4969,7 @@ def build(
     *,
     line_reader: Callable[[str], Iterable[str]],
     top1m_enabled: bool = False,
+    top1m_lines: Iterable[str] = (),
 ) -> BuildResult:
     """Pure, reentrant DNSBL build: raw feeds + config -> matcher structure-set.
 
@@ -4973,7 +4977,8 @@ def build(
     raw feed file mapping it to ``{raw, feed, group, log_flag}``.
     ``config`` carries the classification + whitelist inputs (``tld_wildcard_master``
     suffix lines, ``tld_wildcard_blacklist``, ``tld_wildcard_exclusion``,
-    ``user_whitelist``, ``user_unlock``, ``top1m_list``).
+    ``user_whitelist``, ``user_unlock``). TOP1M is streamed from the fixed
+    ``pfb_py_top1m.txt`` sidecar by ``dnsbl_build_from_manifest``.
     ``line_reader`` yields the raw lines for a feed's ``raw`` reference -- injected so
     this stays pure and side-effect-free (no filesystem coupling, unit-testable; the
     init wiring supplies a file-backed reader).
@@ -5039,7 +5044,7 @@ def build(
     # dnsbl_remove handler populates it.
     white_db = _dnsbl_normalise_whitelist(
         config.get("user_whitelist", []),
-        config.get("top1m_list", []),
+        top1m_lines,
         top1m_enabled,
     )
     # Merge the unlock set WITHOUT narrowing an existing permanent allow: a domain may be
@@ -5271,12 +5276,13 @@ def _dnsbl_validate_manifest_raws(manifest: dict[str, Any], base_dir: str) -> No
         "tld_wildcard_exclusion",
         "user_whitelist",
         "user_unlock",
-        "top1m_list",
     )
     for config_field in list_fields:
         value = config.get(config_field)
         if config_field in config and (not isinstance(value, list) or any(not isinstance(item, str) for item in value)):
             raise _DnsblGenerationError("DNSBL manifest/v1 config.{} must be list[str]".format(config_field))
+    if "top1m_list" in config:
+        raise _DnsblGenerationError("DNSBL manifest/v1 config.top1m_list is retired")
     for flag_field in ("top1m_enabled", "regex_cap"):
         if flag_field in config and not isinstance(config[flag_field], bool):
             raise _DnsblGenerationError("DNSBL manifest/v1 config.{} must be bool".format(flag_field))
@@ -5355,6 +5361,24 @@ def _dnsbl_file_line_reader(base_dir: str, *, fail_closed: bool = False) -> Call
     return reader
 
 
+def _dnsbl_fixed_top1m_lines(base_dir: str) -> Iterable[str]:
+    """Stream the fixed TOP1M sidecar; any source failure aborts the build."""
+    path = os.path.join(base_dir, "pfb_py_top1m.txt")
+    try:
+        if not stat.S_ISREG(os.lstat(path).st_mode):
+            raise _DnsblGenerationError("TOP1M sidecar is not a regular file: '{}'".format(path))
+        handle = open(path, encoding="utf-8", errors="strict", newline="")
+    except (OSError, UnicodeError) as e:
+        raise _DnsblGenerationError("TOP1M sidecar unavailable: '{}'".format(path)) from e
+
+    try:
+        with handle:
+            for line in handle:
+                yield line.strip()
+    except (OSError, UnicodeError) as e:
+        raise _DnsblGenerationError("TOP1M sidecar read failed: '{}'".format(path)) from e
+
+
 def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict[str, Any]:
     """Shape the manifest's ``config`` block into the build() config blob.
 
@@ -5364,7 +5388,7 @@ def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict
     ``pfb["python_hsts"]``. A manifest ``config.tld_master`` key (a stale pre-#1255
     shape) is ignored entirely -- an absent oracle is expected, not a warning.
     ``tld_wildcard_blacklist`` / ``tld_wildcard_exclusion`` / ``user_whitelist`` /
-    ``user_unlock`` / ``top1m_list`` are passed through as lists. Missing keys
+    ``user_unlock`` are passed through as lists. Missing keys
     within the required ``config`` object default empty.
     """
     config = manifest.get("config", {})
@@ -5392,7 +5416,6 @@ def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict
         "user_whitelist": list(config.get("user_whitelist", [])),
         # ADR-06 (#51): the temporary per-alert unlock set -> band-6 whiteDB allows.
         "user_unlock": list(config.get("user_unlock", [])),
-        "top1m_list": list(config.get("top1m_list", [])),
         "regex_cap": regex_cap,
     }
 
@@ -5437,11 +5460,13 @@ def dnsbl_build_from_manifest(manifest_path: str) -> BuildResult | None:
         manifest_config = manifest["config"]
         config = _dnsbl_config_from_manifest(manifest, base_dir)
         top1m_enabled = bool(manifest_config.get("top1m_enabled", False))
+        top1m_lines = _dnsbl_fixed_top1m_lines(base_dir) if top1m_enabled else ()
         result = build(
             manifest,
             config,
             line_reader=_dnsbl_file_line_reader(base_dir, fail_closed=True),
             top1m_enabled=top1m_enabled,
+            top1m_lines=top1m_lines,
         )
     except Exception as e:
         sys.stderr.write("[pfBlockerNG]: Failed to build DNSBL structures from raw: {}".format(e))

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5404,18 +5404,32 @@ def _dnsbl_fixed_top1m_lines(base_dir: str) -> Iterable[str]:
                 yield line.strip()
             consumed = os.lseek(handle.fileno(), 0, os.SEEK_CUR)
             finished = os.fstat(handle.fileno())
-            if consumed != finished.st_size or (
-                opened.st_dev,
-                opened.st_ino,
-                opened.st_mode,
-                opened.st_size,
-                opened.st_mtime_ns,
-            ) != (
-                finished.st_dev,
-                finished.st_ino,
-                finished.st_mode,
-                finished.st_size,
-                finished.st_mtime_ns,
+            pathname = os.lstat(path)
+            pathname_regular = stat.S_ISREG(pathname.st_mode)
+            pathname_same = pathname_regular and (pathname.st_dev, pathname.st_ino) == (opened.st_dev, opened.st_ino)
+            pathname_replaced = pathname_regular and not pathname_same and finished.st_nlink < opened.st_nlink
+            fd_metadata_changed = (finished.st_ctime_ns, finished.st_nlink) != (
+                opened.st_ctime_ns,
+                opened.st_nlink,
+            )
+            if (
+                consumed != finished.st_size
+                or (
+                    opened.st_dev,
+                    opened.st_ino,
+                    opened.st_mode,
+                    opened.st_size,
+                    opened.st_mtime_ns,
+                )
+                != (
+                    finished.st_dev,
+                    finished.st_ino,
+                    finished.st_mode,
+                    finished.st_size,
+                    finished.st_mtime_ns,
+                )
+                or not (pathname_same or pathname_replaced)
+                or (fd_metadata_changed and not pathname_replaced)
             ):
                 raise _DnsblGenerationError("TOP1M sidecar changed while reading: '{}'".format(path))
     except _DnsblGenerationError:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7871,20 +7871,9 @@ function pfb_unbound_py_atomic_copy(string $source, string $path, array $stream_
 	$chown_fn = $stream_ops['chown'] ?? static fn($file, $owner) => @chown($file, $owner);
 	$chgrp_fn = $stream_ops['chgrp'] ?? static fn($file, $group) => @chgrp($file, $group);
 	$chmod_fn = $stream_ops['chmod'] ?? static fn($file, $mode) => @chmod($file, $mode);
-	if (array_key_exists('chown', $stream_ops) && !$chown_fn($tmp, 'root') ||
-		array_key_exists('chgrp', $stream_ops) && !$chgrp_fn($tmp, 'unbound') ||
-		array_key_exists('chmod', $stream_ops) && !$chmod_fn($tmp, 0640)) {
+	if (!$chown_fn($tmp, 'root') || !$chgrp_fn($tmp, 'unbound') || !$chmod_fn($tmp, 0640)) {
 		@unlink($tmp);
 		return FALSE;
-	}
-	if (!array_key_exists('chown', $stream_ops)) {
-		@chown($tmp, 'root');
-	}
-	if (!array_key_exists('chgrp', $stream_ops)) {
-		@chgrp($tmp, 'unbound');
-	}
-	if (!array_key_exists('chmod', $stream_ops)) {
-		@chmod($tmp, 0640);
 	}
 	$rename_fn = $stream_ops['rename'] ?? static fn($from, $to) => @rename($from, $to);
 	if (!$rename_fn($tmp, $path)) {
@@ -8618,20 +8607,23 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 
 	// TOP1M (Tranco/Cisco) popularity whitelist is a fixed sidecar. Publish it
 	// before the manifest so a durable manifest always names a complete snapshot.
+	$top1m_atomic_ops = isset($publication_ops['top1m_atomic']) && is_array($publication_ops['top1m_atomic'])
+		? $publication_ops['top1m_atomic'] : array();
+	$top1m_restore_fn = $top1m_atomic_ops['restore'] ?? static fn($from, $to) => @rename($from, $to);
 	$top1m_backup = FALSE;
 	$top1m_had_previous = file_exists($top1m_target) || is_link($top1m_target);
-	$restore_top1m = static function () use (&$top1m_backup, $top1m_target, $top1m_had_previous): void {
+	$restore_top1m = static function () use (&$top1m_backup, $top1m_target, $top1m_had_previous, $top1m_restore_fn): void {
 		if ($top1m_backup === FALSE) {
 			return;
 		}
-		if (file_exists($top1m_target) || is_link($top1m_target)) {
-			is_dir($top1m_target) && !is_link($top1m_target)
-				? rmdir_recursive($top1m_target)
-				: @unlink($top1m_target);
-		}
 		if ($top1m_had_previous && $top1m_backup !== FALSE) {
-			@rename($top1m_backup, $top1m_target);
+			$top1m_restore_fn($top1m_backup, $top1m_target);
 		} elseif ($top1m_backup !== FALSE) {
+			if (file_exists($top1m_target) || is_link($top1m_target)) {
+				is_dir($top1m_target) && !is_link($top1m_target)
+					? rmdir_recursive($top1m_target)
+					: @unlink($top1m_target);
+			}
 			@unlink($top1m_backup);
 		}
 		$top1m_backup = FALSE;
@@ -8651,10 +8643,7 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 			pfb_logger("\nTOP1M fixed-file staging failed: {$top1m_target}", 2);
 			return FALSE;
 		}
-		$top1m_atomic_ops = isset($publication_ops['top1m_atomic']) && is_array($publication_ops['top1m_atomic'])
-			? $publication_ops['top1m_atomic'] : array();
 		if (!pfb_unbound_py_atomic_copy($top1m_source, $top1m_target, $top1m_atomic_ops)) {
-			$restore_top1m();
 			$discard_unpublished_generation();
 			pfb_logger("\nTOP1M fixed-file publication failed: {$top1m_target}", 2);
 			return FALSE;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7871,7 +7871,10 @@ function pfb_unbound_py_atomic_copy(string $source, string $path, array $stream_
 	$chown_fn = $stream_ops['chown'] ?? static fn($file, $owner) => @chown($file, $owner);
 	$chgrp_fn = $stream_ops['chgrp'] ?? static fn($file, $group) => @chgrp($file, $group);
 	$chmod_fn = $stream_ops['chmod'] ?? static fn($file, $mode) => @chmod($file, $mode);
-	if (!$chown_fn($tmp, 'root') || !$chgrp_fn($tmp, 'unbound') || !$chmod_fn($tmp, 0640)) {
+	$metadata_fn = $stream_ops['metadata'] ?? static function ($file) use ($chown_fn, $chgrp_fn, $chmod_fn): bool {
+		return $chown_fn($file, 'root') && $chgrp_fn($file, 'unbound') && $chmod_fn($file, 0640);
+	};
+	if (!$metadata_fn($tmp)) {
 		@unlink($tmp);
 		return FALSE;
 	}
@@ -8644,6 +8647,10 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 			return FALSE;
 		}
 		if (!pfb_unbound_py_atomic_copy($top1m_source, $top1m_target, $top1m_atomic_ops)) {
+			if ($top1m_backup !== FALSE) {
+				@unlink($top1m_backup);
+				$top1m_backup = FALSE;
+			}
 			$discard_unpublished_generation();
 			pfb_logger("\nTOP1M fixed-file publication failed: {$top1m_target}", 2);
 			return FALSE;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8067,7 +8067,7 @@ function pfb_unbound_py_teardown_raw_set(): bool {
 			dirname($pfb['unbound_py_top1m'] ?? '/var/unbound/pfb_py_top1m.txt') . '/.pfbtop1m_*',
 		) as $pattern) {
 			foreach (glob($pattern) ?: array() as $artifact) {
-				$ok = unlink_if_exists($artifact) && $ok;
+				$ok = pfb_unbound_py_remove_raw_artifact($artifact) && $ok;
 			}
 		}
 		return $ok;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -137,6 +137,7 @@ $pfb['unbound_py_count']= '/var/unbound/pfb_py_count';
 $pfb['unbound_py_regex_count']= '/var/unbound/pfb_py_regex_count';	// ADR-07: Python-emitted ADMITTED (cap-filtered) feed+user regex total for the DNSBL_Regex alias
 $pfb['unbound_py_reject_stats']= '/var/unbound/pfb_py_reject_stats.json';	// ADR-48: Python-emitted per-entry reject tally (issue #789), read by pfb_emit_entry_reject_stats()
 $pfb['unbound_py_sources']= '/var/unbound/pfb_py_sources.json';	// ADR-06: per-feed manifest consumed by pfb_unbound.py init
+$pfb['unbound_py_top1m']= '/var/unbound/pfb_py_top1m.txt';	// issue #1542: fixed TOP1M sidecar consumed by pfb_unbound.py
 $pfb['unbound_py_rawdir']= '/var/unbound/pfb_py_raw';		// #1357: basename for immutable per-feed raw generations
 
 $pfb['dnsbl_safesearch']		= '/usr/local/pkg/pfblockerng/pfb_dnsbl.safesearch.conf';
@@ -1964,8 +1965,11 @@ function pfb_unbound_py_manifest_raw_paths(string $manifest_path, bool $deduplic
 
 function pfb_dnsbl_loaded_input_paths(array $pfb): array {
 	$raw_files = pfb_unbound_py_manifest_raw_paths((string) ($pfb['unbound_py_sources'] ?? ''));
+	$top1m_files = (($pfb['dnsbl_top1m'] ?? '') === 'on')
+		? array($pfb['unbound_py_top1m'] ?? '/var/unbound/pfb_py_top1m.txt') : array();
 	return array_merge(
 		array($pfb['unbound_py_wh'], $pfb['unbound_py_sources'], $pfb['unbound_py_hsts'], $pfb['unbound_py_tld']),
+		$top1m_files,
 		$raw_files
 	);
 }
@@ -7820,6 +7824,76 @@ function pfb_unbound_py_atomic_write($path, $content, array $stream_ops=array())
 	return TRUE;
 }
 
+// Issue #1542: stream the generated TOP1M whitelist into a same-directory
+// temporary file, then publish it with the same fsync + atomic rename contract
+// as the manifest. The fixed sidecar is deliberately not represented in JSON.
+function pfb_unbound_py_atomic_copy(string $source, string $path, array $stream_ops=array()): bool {
+	$source_h = @fopen($source, 'rb');
+	if ($source_h === FALSE) {
+		return FALSE;
+	}
+	$tmp = @tempnam(dirname($path), '.pfbtop1m_');
+	if ($tmp === FALSE) {
+		@fclose($source_h);
+		return FALSE;
+	}
+	$target_h = @fopen($tmp, 'wb');
+	if ($target_h === FALSE) {
+		@fclose($source_h);
+		@unlink($tmp);
+		return FALSE;
+	}
+	$write_fn = $stream_ops['write'] ?? static fn($stream, $bytes) => @fwrite($stream, $bytes);
+	$flush_fn = $stream_ops['flush'] ?? static fn($stream) => @fflush($stream);
+	$fsync_fn = $stream_ops['fsync'] ?? static fn($stream) => @fsync($stream);
+	$ok = TRUE;
+	while (!feof($source_h)) {
+		$chunk = @fread($source_h, 1048576);
+		if ($chunk === FALSE) {
+			$ok = FALSE;
+			break;
+		}
+		if ($chunk !== '') {
+			$written = $write_fn($target_h, $chunk);
+			if ($written === FALSE || $written !== strlen($chunk)) {
+				$ok = FALSE;
+				break;
+			}
+		}
+	}
+	$ok = $ok && $flush_fn($target_h) && $fsync_fn($target_h);
+	$ok = @fclose($target_h) && $ok;
+	@fclose($source_h);
+	if (!$ok) {
+		@unlink($tmp);
+		return FALSE;
+	}
+	$chown_fn = $stream_ops['chown'] ?? static fn($file, $owner) => @chown($file, $owner);
+	$chgrp_fn = $stream_ops['chgrp'] ?? static fn($file, $group) => @chgrp($file, $group);
+	$chmod_fn = $stream_ops['chmod'] ?? static fn($file, $mode) => @chmod($file, $mode);
+	if (array_key_exists('chown', $stream_ops) && !$chown_fn($tmp, 'root') ||
+		array_key_exists('chgrp', $stream_ops) && !$chgrp_fn($tmp, 'unbound') ||
+		array_key_exists('chmod', $stream_ops) && !$chmod_fn($tmp, 0640)) {
+		@unlink($tmp);
+		return FALSE;
+	}
+	if (!array_key_exists('chown', $stream_ops)) {
+		@chown($tmp, 'root');
+	}
+	if (!array_key_exists('chgrp', $stream_ops)) {
+		@chgrp($tmp, 'unbound');
+	}
+	if (!array_key_exists('chmod', $stream_ops)) {
+		@chmod($tmp, 0640);
+	}
+	$rename_fn = $stream_ops['rename'] ?? static fn($from, $to) => @rename($from, $to);
+	if (!$rename_fn($tmp, $path)) {
+		@unlink($tmp);
+		return FALSE;
+	}
+	return TRUE;
+}
+
 // #1357: one exclusive lock serializes full-set publication, scalar manifest patches,
 // convergence-gated generation GC, and teardown. Python readers never take this lock.
 function pfb_unbound_py_publication_lock(?float $timeout_s=NULL) {
@@ -8381,6 +8455,13 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 	if (!is_array($feeds)) {
 		$feeds = array();
 	}
+	$top1m_enabled = (($pfb['dnsbl_top1m'] ?? '') === 'on');
+	$top1m_source = "{$pfb['dbdir']}/pfbalexawhitelist.txt";
+	$top1m_target = $pfb['unbound_py_top1m'] ?? '/var/unbound/pfb_py_top1m.txt';
+	if ($top1m_enabled && (is_link($top1m_source) || !is_file($top1m_source) || !is_readable($top1m_source))) {
+		pfb_logger("\nTOP1M fixed-file source unavailable: {$top1m_source}", 2);
+		return FALSE;
+	}
 
 	$raw_parent = dirname($pfb['unbound_py_rawdir']);
 	$raw_base = basename($pfb['unbound_py_rawdir']);
@@ -8535,16 +8616,48 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 	// Synthetic whole-TLD blacklist feed (DNSBL_TLD): the Python build emits these
 	// as whole-TLD ZONE entries from config.tld_wildcard_blacklist, so no raw file is needed.
 
-	// TOP1M (Tranco/Cisco) popularity whitelist -> query-time whiteDB only when on.
-	// ponytail: pfbalexawhitelist.txt keeps its on-disk name -- renaming a generated
-	// artifact needs old-file cleanup for zero user benefit (#877 triage decision).
-	$top1m_enabled	= ($pfb['dnsbl_top1m'] == 'on' &&
-			   file_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt"));
-	$top1m_list	= array();
+	// TOP1M (Tranco/Cisco) popularity whitelist is a fixed sidecar. Publish it
+	// before the manifest so a durable manifest always names a complete snapshot.
+	$top1m_backup = FALSE;
+	$top1m_had_previous = file_exists($top1m_target) || is_link($top1m_target);
+	$restore_top1m = static function () use (&$top1m_backup, $top1m_target, $top1m_had_previous): void {
+		if ($top1m_backup === FALSE) {
+			return;
+		}
+		if (file_exists($top1m_target) || is_link($top1m_target)) {
+			is_dir($top1m_target) && !is_link($top1m_target)
+				? rmdir_recursive($top1m_target)
+				: @unlink($top1m_target);
+		}
+		if ($top1m_had_previous && $top1m_backup !== FALSE) {
+			@rename($top1m_backup, $top1m_target);
+		} elseif ($top1m_backup !== FALSE) {
+			@unlink($top1m_backup);
+		}
+		$top1m_backup = FALSE;
+	};
 	if ($top1m_enabled) {
-		$top1m_lines = @file("{$pfb['dbdir']}/pfbalexawhitelist.txt", FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-		if (is_array($top1m_lines)) {
-			$top1m_list = $top1m_lines;
+		$top1m_backup = @tempnam(dirname($top1m_target), '.pfbtop1m_prev_');
+		if ($top1m_backup !== FALSE) {
+			@unlink($top1m_backup);
+		}
+		$top1m_backup_ok = $top1m_backup !== FALSE &&
+			(!$top1m_had_previous || @link($top1m_target, $top1m_backup) || @copy($top1m_target, $top1m_backup));
+		if (!$top1m_backup_ok) {
+			if ($top1m_backup !== FALSE) {
+				@unlink($top1m_backup);
+			}
+			$discard_unpublished_generation();
+			pfb_logger("\nTOP1M fixed-file staging failed: {$top1m_target}", 2);
+			return FALSE;
+		}
+		$top1m_atomic_ops = isset($publication_ops['top1m_atomic']) && is_array($publication_ops['top1m_atomic'])
+			? $publication_ops['top1m_atomic'] : array();
+		if (!pfb_unbound_py_atomic_copy($top1m_source, $top1m_target, $top1m_atomic_ops)) {
+			$restore_top1m();
+			$discard_unpublished_generation();
+			pfb_logger("\nTOP1M fixed-file publication failed: {$top1m_target}", 2);
+			return FALSE;
 		}
 	}
 
@@ -8576,7 +8689,6 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 			// "re-locked on Cron/Force" semantic. Only pfb_unbound_python_sources_unlock()
 			// (the incremental alerts dnsbl_remove path) repopulates user_unlock.
 			'user_unlock'	=> array(),
-			'top1m_list'	=> array_values($top1m_list),
 			'top1m_enabled'	=> $top1m_enabled
 		),
 		'feeds'		=> $manifest_feeds
@@ -8592,6 +8704,7 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 		$manifest_atomic_ops = isset($publication_ops['manifest_atomic'])
 			&& is_array($publication_ops['manifest_atomic']) ? $publication_ops['manifest_atomic'] : array();
 		if (!pfb_unbound_py_atomic_write($pfb['unbound_py_sources'], $json, $manifest_atomic_ops)) {
+			$restore_top1m();
 			$discard_unpublished_generation();
 			// ADR-65: a swallowed publish failure left Python running on a stale/absent
 			// manifest with no operator-visible signal -- surface it like the existing
@@ -8599,10 +8712,17 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 			$manifest_notice = "DNSBL manifest publish failed: {$pfb['unbound_py_sources']}";
 			pfb_logger("\n{$manifest_notice}", 2);
 			file_notice('pfBlockerNG DNSBL', $manifest_notice, 'pfBlockerNG', '/pfblockerng/pfblockerng_dnsbl.php', 2);
+			return FALSE;
+		}
+		if ($top1m_enabled && $top1m_backup !== FALSE) {
+			@unlink($top1m_backup);
+			$top1m_backup = FALSE;
 		}
 	} else {
+		$restore_top1m();
 		$discard_unpublished_generation();
 		pfb_logger("\nDNSBL manifest JSON encoding failed: " . json_last_error_msg(), 2);
+		return FALSE;
 	}
 
 	return $manifest;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12184,7 +12184,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					return PfbDownloadResult::failure();
 				}
 				$header_esc = escapeshellarg($top1m_stage);
-				exec("/usr/bin/gunzip -c {$file_download} > {$header_esc}", $output, $retval);
+				exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);
 				if ($retval != 0) {
 					unlink_if_exists($file_download);
 					unlink_if_exists($top1m_stage);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8048,6 +8048,28 @@ function pfb_unbound_py_teardown_raw_set(): bool {
 		foreach (pfb_unbound_py_raw_artifacts($pfb) as $artifact) {
 			$ok = pfb_unbound_py_remove_raw_artifact($artifact) && $ok;
 		}
+		$top1m_base = "{$pfb['dbdir']}/top-1m.csv.zip";
+		foreach (array(
+			$pfb['unbound_py_top1m'] ?? '/var/unbound/pfb_py_top1m.txt',
+			"{$top1m_base}.orig",
+			"{$top1m_base}.xxhash128",
+			"{$top1m_base}.md5",
+			"{$top1m_base}.source",
+			"{$top1m_base}.orig.etag",
+			"{$top1m_base}.orig.lastmod",
+		) as $artifact) {
+			if (file_exists($artifact) || is_link($artifact)) {
+				$ok = unlink_if_exists($artifact) && $ok;
+			}
+		}
+		foreach (array(
+			"{$pfb['dbdir']}/.pfbtop1m_*",
+			dirname($pfb['unbound_py_top1m'] ?? '/var/unbound/pfb_py_top1m.txt') . '/.pfbtop1m_*',
+		) as $pattern) {
+			foreach (glob($pattern) ?: array() as $artifact) {
+				$ok = unlink_if_exists($artifact) && $ok;
+			}
+		}
 		return $ok;
 	} finally {
 		pfb_unbound_py_publication_unlock($lock);
@@ -16617,6 +16639,7 @@ function pfblockerng_php_pre_deinstall_command() {
 
 	update_status("Removing pfBlockerNG...");
 	sync_package_pfblockerng();
+	pfb_unbound_py_teardown_raw_set();
 
 	// Live-object teardown always runs regardless of $pfb['keep'], so that uninstalling
 	// with the default keep=on still removes active pf tables, boot hooks, owned firewall

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12004,8 +12004,9 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				return PfbDownloadResult::success();
 			}
 			elseif ($type == 'top1m') {
-				// Issue #1542: stage the derived CSV so a failed extraction never
-				// destroys the previous active whitelist source.
+				// Issue #1542: stage the derived CSV and commit active plus raw/hash
+				// baseline together. Backups stay beside the feed for same-filesystem
+				// rename rollback; GeoIP/ASN paths above remain unchanged.
 				$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
 				if ($top1m_stage === FALSE) {
 					unlink_if_exists($file_download);
@@ -12019,18 +12020,69 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					pfb_logger("\n[pfb_download] top1m extraction failed (gunzip exit {$retval})", 2);
 					return PfbDownloadResult::failure();
 				}
-				if (!pfb_top1m_persist_baseline($file_dwn, $file_download)) {
+				$top1m_base_backup = @tempnam(dirname($file_dwn), '.pfbtop1m_base_');
+				if ($top1m_base_backup === FALSE || !@unlink($top1m_base_backup) || !@mkdir($top1m_base_backup, 0700)) {
 					unlink_if_exists($file_download);
 					unlink_if_exists($top1m_stage);
-					pfb_top1m_invalidate_baseline($file_dwn);
 					return PfbDownloadResult::failure();
 				}
-				unlink_if_exists($file_download);
-				if (!@rename($top1m_stage, $head_download)) {
+				$top1m_base_backups = array();
+				foreach (array("{$file_dwn}.orig", "{$file_dwn}.xxhash128", "{$file_dwn}.md5") as $top1m_base_path) {
+					if (is_file($top1m_base_path)) {
+						$top1m_base_copy = "{$top1m_base_backup}/" . basename($top1m_base_path);
+						if (!@copy($top1m_base_path, $top1m_base_copy)) {
+							rmdir_recursive($top1m_base_backup);
+							unlink_if_exists($file_download);
+							unlink_if_exists($top1m_stage);
+							return PfbDownloadResult::failure();
+						}
+						$top1m_base_backups[$top1m_base_path] = $top1m_base_copy;
+					}
+				}
+				$top1m_active_backup = @tempnam(dirname($head_download), '.pfbtop1m_active_');
+				if ($top1m_active_backup === FALSE || !@unlink($top1m_active_backup)) {
+					rmdir_recursive($top1m_base_backup);
+					unlink_if_exists($file_download);
 					unlink_if_exists($top1m_stage);
-					pfb_top1m_invalidate_baseline($file_dwn);
 					return PfbDownloadResult::failure();
 				}
+				$top1m_had_active = file_exists($head_download) || is_link($head_download);
+				if ($top1m_had_active && !@rename($head_download, $top1m_active_backup)) {
+					rmdir_recursive($top1m_base_backup);
+					unlink_if_exists($file_download);
+					unlink_if_exists($top1m_stage);
+					return PfbDownloadResult::failure();
+				}
+				if (!@rename($top1m_stage, $head_download)) {
+					if ($top1m_had_active) {
+						@rename($top1m_active_backup, $head_download);
+					}
+					rmdir_recursive($top1m_base_backup);
+					unlink_if_exists($file_download);
+					unlink_if_exists($top1m_stage);
+					return PfbDownloadResult::failure();
+				}
+				if (!pfb_top1m_persist_baseline($file_dwn, $file_download)) {
+					unlink_if_exists($head_download);
+					if ($top1m_had_active) {
+						@rename($top1m_active_backup, $head_download);
+					}
+					foreach (array("{$file_dwn}.orig", "{$file_dwn}.xxhash128", "{$file_dwn}.md5") as $top1m_base_path) {
+						if (isset($top1m_base_backups[$top1m_base_path])) {
+							@copy($top1m_base_backups[$top1m_base_path], $top1m_base_path);
+						} elseif (is_file($top1m_base_path)) {
+							@unlink($top1m_base_path);
+						}
+					}
+					rmdir_recursive($top1m_base_backup);
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				if ($top1m_had_active) {
+					is_dir($top1m_active_backup) ? rmdir_recursive($top1m_active_backup) : unlink_if_exists($top1m_active_backup);
+				}
+				rmdir_recursive($top1m_base_backup);
+				unlink_if_exists($file_download);
 				touch("{$pfb['dbdir']}/top-1m.update");
 				return PfbDownloadResult::success();
 			}
@@ -12113,14 +12165,10 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				return PfbDownloadResult::failure();
 			}
 
-			// Extras - MaxMind/TOP1M downloads
-			if ($type == 'geoip' || $type == 'top1m') {
-				// Determine if the Zip contains multiple files. A NULL list (unlistable)
-				// falls through to the stdout branch below -- no disk write, no traversal
-				// surface -- and the extraction fails on its own exactly as before.
+			// Extras - MaxMind downloads. Keep GeoIP's existing extraction contract.
+			if ($type == 'geoip') {
 				$archive_members = pfb_archive_member_names($file_download);
 				if ($archive_members !== NULL && count($archive_members) > 1) {
-					// ADR-46: disk-writing extraction -- reject hostile member names first.
 					$unsafe_member = pfb_archive_unsafe_member($archive_members);
 					if ($unsafe_member !== NULL) {
 						pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
@@ -12135,8 +12183,6 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					$header_esc = escapeshellarg($top1m_stage);
 					exec("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1", $output, $retval);
 				} else {
-					// ADR-46: stdout extraction -- member names never reach the
-					// filesystem, so no member-name guard is needed here.
 					$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
 					if ($top1m_stage === FALSE) {
 						unlink_if_exists($file_download);
@@ -12181,6 +12227,138 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					pfb_top1m_invalidate_baseline($file_dwn);
 					return PfbDownloadResult::failure();
 				}
+				unlink_if_exists($file_download);
+				return PfbDownloadResult::success();
+			}
+
+			if ($type == 'top1m') {
+				$archive_members = pfb_archive_member_names($file_download);
+				$unsafe_member = pfb_archive_unsafe_member($archive_members);
+				if ($unsafe_member !== NULL || $archive_members === NULL || count($archive_members) === 0) {
+					if ($unsafe_member !== NULL) {
+						pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
+					}
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				$top1m_target_dir = is_dir($head_download);
+				if (!$top1m_target_dir && count($archive_members) !== 1) {
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
+				if ($top1m_stage === FALSE || !@unlink($top1m_stage) || !@mkdir($top1m_stage, 0700)) {
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				$header_esc = escapeshellarg($top1m_stage);
+				$strip = $top1m_target_dir ? ' --strip=1' : '';
+				exec("/usr/bin/tar -xf {$file_dwn_esc}{$strip} -C {$header_esc} >/dev/null 2>&1", $output, $retval);
+				if ($retval != 0) {
+					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})", 2);
+					rmdir_recursive($top1m_stage);
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				$top1m_staged_files = array();
+				$top1m_staged_link = FALSE;
+				$top1m_iterator = new RecursiveIteratorIterator(
+					new RecursiveDirectoryIterator($top1m_stage, FilesystemIterator::SKIP_DOTS),
+					RecursiveIteratorIterator::LEAVES_ONLY
+				);
+				foreach ($top1m_iterator as $top1m_entry) {
+					if ($top1m_entry->isLink()) {
+						$top1m_staged_link = TRUE;
+					} elseif ($top1m_entry->isFile()) {
+						$top1m_staged_files[] = $top1m_entry->getPathname();
+					}
+				}
+				if ($top1m_staged_link || ($top1m_target_dir && count($top1m_staged_files) === 0) || (!$top1m_target_dir && count($top1m_staged_files) !== 1)) {
+					rmdir_recursive($top1m_stage);
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				if (!$top1m_target_dir) {
+					$top1m_inner_type = pfb_filter(
+						array(escapeshellarg($top1m_staged_files[0]), $top1m_staged_files[0], $list_download),
+						PFB_FILTER_FILE_MIME,
+						'pfb_download'
+					);
+					if ($top1m_inner_type === 'text/html') {
+						rmdir_recursive($top1m_stage);
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
+					}
+				}
+				$top1m_base_backup = @tempnam(dirname($file_dwn), '.pfbtop1m_base_');
+				if ($top1m_base_backup === FALSE || !@unlink($top1m_base_backup) || !@mkdir($top1m_base_backup, 0700)) {
+					rmdir_recursive($top1m_stage);
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				$top1m_base_backups = array();
+				foreach (array("{$file_dwn}.orig", "{$file_dwn}.xxhash128", "{$file_dwn}.md5") as $top1m_base_path) {
+					if (is_file($top1m_base_path)) {
+						$top1m_base_copy = "{$top1m_base_backup}/" . basename($top1m_base_path);
+						if (!@copy($top1m_base_path, $top1m_base_copy)) {
+							rmdir_recursive($top1m_base_backup);
+							rmdir_recursive($top1m_stage);
+							unlink_if_exists($file_download);
+							return PfbDownloadResult::failure();
+						}
+						$top1m_base_backups[$top1m_base_path] = $top1m_base_copy;
+					}
+				}
+				$top1m_active_backup = @tempnam(dirname($head_download), '.pfbtop1m_active_');
+				if ($top1m_active_backup === FALSE || !@unlink($top1m_active_backup)) {
+					rmdir_recursive($top1m_base_backup);
+					rmdir_recursive($top1m_stage);
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				$top1m_had_active = file_exists($head_download) || is_link($head_download);
+				if ($top1m_had_active && !@rename($head_download, $top1m_active_backup)) {
+					rmdir_recursive($top1m_base_backup);
+					rmdir_recursive($top1m_stage);
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				$top1m_published = $top1m_target_dir
+					? @rename($top1m_stage, $head_download)
+					: @rename($top1m_staged_files[0], $head_download);
+				if (!$top1m_published) {
+					if ($top1m_had_active) {
+						@rename($top1m_active_backup, $head_download);
+					}
+					rmdir_recursive($top1m_stage);
+					rmdir_recursive($top1m_base_backup);
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				if (!$top1m_target_dir) {
+					rmdir_recursive($top1m_stage);
+				}
+				if (!pfb_top1m_persist_baseline($file_dwn, $file_download)) {
+					is_dir($head_download) ? rmdir_recursive($head_download) : unlink_if_exists($head_download);
+					if ($top1m_had_active) {
+						@rename($top1m_active_backup, $head_download);
+					}
+					foreach (array("{$file_dwn}.orig", "{$file_dwn}.xxhash128", "{$file_dwn}.md5") as $top1m_base_path) {
+						if (isset($top1m_base_backups[$top1m_base_path])) {
+							@copy($top1m_base_backups[$top1m_base_path], $top1m_base_path);
+						} elseif (is_file($top1m_base_path)) {
+							@unlink($top1m_base_path);
+						}
+					}
+					rmdir_recursive($top1m_base_backup);
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				if ($top1m_had_active) {
+					is_dir($top1m_active_backup) ? rmdir_recursive($top1m_active_backup) : unlink_if_exists($top1m_active_backup);
+				}
+				rmdir_recursive($top1m_base_backup);
+				unlink_if_exists($file_download);
 				touch("{$pfb['dbdir']}/top-1m.update");
 				return PfbDownloadResult::success();
 			}
@@ -12264,24 +12442,80 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				return PfbDownloadResult::success();
 			}
 			if ($type == 'top1m') {
-				// Stage TOP1M's plain body before publishing so a failed rename
-				// preserves the active source.
+				// Stage TOP1M's plain body before publishing; baseline persistence
+				// commits after active publication and rolls both back on failure.
 				$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
-				if ($top1m_stage === FALSE) {
+				if ($top1m_stage === FALSE || !@copy($file_download, $top1m_stage)) {
 					pfb_logger("\n[pfb_download] {$type} rename to destination failed", 2);
+					if ($top1m_stage !== FALSE) {
+						unlink_if_exists($top1m_stage);
+					}
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				$top1m_base_backup = @tempnam(dirname($file_dwn), '.pfbtop1m_base_');
+				if ($top1m_base_backup === FALSE || !@unlink($top1m_base_backup) || !@mkdir($top1m_base_backup, 0700)) {
+					unlink_if_exists($file_download);
+					unlink_if_exists($top1m_stage);
+					return PfbDownloadResult::failure();
+				}
+				$top1m_base_backups = array();
+				foreach (array("{$file_dwn}.orig", "{$file_dwn}.xxhash128", "{$file_dwn}.md5") as $top1m_base_path) {
+					if (is_file($top1m_base_path)) {
+						$top1m_base_copy = "{$top1m_base_backup}/" . basename($top1m_base_path);
+						if (!@copy($top1m_base_path, $top1m_base_copy)) {
+							rmdir_recursive($top1m_base_backup);
+							unlink_if_exists($file_download);
+							unlink_if_exists($top1m_stage);
+							return PfbDownloadResult::failure();
+						}
+						$top1m_base_backups[$top1m_base_path] = $top1m_base_copy;
+					}
+				}
+				$top1m_active_backup = @tempnam(dirname($head_download), '.pfbtop1m_active_');
+				if ($top1m_active_backup === FALSE || !@unlink($top1m_active_backup)) {
+					rmdir_recursive($top1m_base_backup);
+					unlink_if_exists($file_download);
+					unlink_if_exists($top1m_stage);
+					return PfbDownloadResult::failure();
+				}
+				$top1m_had_active = file_exists($head_download) || is_link($head_download);
+				if ($top1m_had_active && !@rename($head_download, $top1m_active_backup)) {
+					rmdir_recursive($top1m_base_backup);
+					unlink_if_exists($file_download);
+					unlink_if_exists($top1m_stage);
+					return PfbDownloadResult::failure();
+				}
+				if (!@rename($top1m_stage, $head_download)) {
+					if ($top1m_had_active) {
+						@rename($top1m_active_backup, $head_download);
+					}
+					rmdir_recursive($top1m_base_backup);
+					unlink_if_exists($file_download);
+					unlink_if_exists($top1m_stage);
 					return PfbDownloadResult::failure();
 				}
 				if (!pfb_top1m_persist_baseline($file_dwn, $file_download)) {
+					unlink_if_exists($head_download);
+					if ($top1m_had_active) {
+						@rename($top1m_active_backup, $head_download);
+					}
+					foreach (array("{$file_dwn}.orig", "{$file_dwn}.xxhash128", "{$file_dwn}.md5") as $top1m_base_path) {
+						if (isset($top1m_base_backups[$top1m_base_path])) {
+							@copy($top1m_base_backups[$top1m_base_path], $top1m_base_path);
+						} elseif (is_file($top1m_base_path)) {
+							@unlink($top1m_base_path);
+						}
+					}
+					rmdir_recursive($top1m_base_backup);
 					unlink_if_exists($file_download);
-					unlink_if_exists($top1m_stage);
-					pfb_top1m_invalidate_baseline($file_dwn);
 					return PfbDownloadResult::failure();
 				}
-				if (!@rename($file_download, $top1m_stage) || !@rename($top1m_stage, $head_download)) {
-					unlink_if_exists($top1m_stage);
-					pfb_top1m_invalidate_baseline($file_dwn);
-					return PfbDownloadResult::failure();
+				if ($top1m_had_active) {
+					is_dir($top1m_active_backup) ? rmdir_recursive($top1m_active_backup) : unlink_if_exists($top1m_active_backup);
 				}
+				rmdir_recursive($top1m_base_backup);
+				unlink_if_exists($file_download);
 				touch("{$pfb['dbdir']}/top-1m.update");
 				return PfbDownloadResult::success();
 			}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9795,6 +9795,62 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython, array $dnsbl_tld_grou
 }
 
 
+function pfb_top1m_active_provider(): array
+{
+	global $pfb;
+	$source = $pfb['dnsbl_top1m_type'] ?? PfbTop1mSource::Tranco;
+	$key = $source instanceof PfbTop1mSource ? $source->value : (string) $source;
+	return pfb_top1m_providers()[$key] ?? pfb_top1m_providers()[PfbTop1mSource::Tranco->value];
+}
+
+function pfb_top1m_parse_source_row(string $line, array $provider): ?string
+{
+	$domain_col = (int) ($provider['domain_col'] ?? 1);
+	if ($line === '' || strpos($line, '.') === FALSE
+		|| ($domain_col > 0 && strpos($line, ',') === FALSE)) {
+		return NULL;
+	}
+	$csvline = str_getcsv($line, ',', '"', "\\");
+	if (($provider['parse'] ?? 'rank_domain') === 'rank_domain'
+		&& !ctype_digit((string) ($csvline[0] ?? ''))) {
+		return NULL;
+	}
+	$domain = strtolower($csvline[$domain_col] ?? '');
+	if (!preg_match('/^[A-Za-z0-9][A-Za-z0-9.-]*\.(?:[A-Za-z]{2,}|[Xx][Nn]--[A-Za-z0-9][A-Za-z0-9-]+)$/D', $domain)) {
+		return NULL;
+	}
+	return $domain;
+}
+
+function pfb_top1m_candidate_valid(string $path, array $provider): bool
+{
+	if (!is_file($path) || !is_readable($path)) {
+		return FALSE;
+	}
+	$sample = @file_get_contents($path, FALSE, NULL, 0, 65536);
+	if ($sample === FALSE || pfb_text_sanity($sample) !== NULL) {
+		return FALSE;
+	}
+	$handle = @fopen($path, 'r');
+	if ($handle === FALSE) {
+		return FALSE;
+	}
+	$pending_header = !empty($provider['header']);
+	$valid = FALSE;
+	while (($line = @fgets($handle)) !== FALSE) {
+		if ($pending_header) {
+			$pending_header = FALSE;
+			continue;
+		}
+		if (pfb_top1m_parse_source_row($line, $provider) !== NULL) {
+			$valid = TRUE;
+			break;
+		}
+	}
+	fclose($handle);
+	return $valid;
+}
+
 // Process TOP1M database
 // $provider_override (ADR-59 test seam): when given, its 'parse'/'header'/
 // 'domain_col' knobs drive the builder directly instead of resolving through
@@ -9816,9 +9872,7 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 	// the registry itself uses, so the resolved shape stays rank_domain/zip.
 	$top1m_type	= $pfb['dnsbl_top1m_type'] ?? PfbTop1mSource::Tranco;
 	$top1m_provider	= $provider_override ?? (pfb_top1m_providers()[$top1m_type->value] ?? array());
-	$top1m_parse	= $top1m_provider['parse'] ?? 'rank_domain';
 	$top1m_header	= $top1m_provider['header'] ?? FALSE;
-	$top1m_domcol	= $top1m_provider['domain_col'] ?? 1;
 
 	// Array of TLDs to include in Whitelist
 	$pfb_include = explode(',', $pfb['dnsbl_top1m_inc']);
@@ -9869,18 +9923,6 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 					continue;
 				}
 
-				// ADR-59: Cloudflare's dataset is a SINGLE 'domain' column (domain_col
-				// 0) -- a real data line has no comma at all (no column to split), so the
-				// comma requirement below would wrongly reject every line. Only demand a
-				// comma when a real multi-column split is expected (domain_col > 0, every
-				// other provider today); domain_col 0 still requires a '.' (every domain
-				// has one).
-				$top1m_needs_comma = $top1m_domcol > 0;
-				if (strpos($line, '.') === FALSE || empty($line) ||
-				    ($top1m_needs_comma && strpos($line, ',') === FALSE)) {
-					continue;
-				}
-
 				// Display progress indicator
 				if ($linecnt % 100000 == 0) {
 					pfb_logger('.', 1);
@@ -9900,21 +9942,8 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 				// "1,garbage,extra.dot") used to satisfy the rank-only guard and reach the
 				// TLD-extraction strrpos() below with a garbage result, wrongly counting the
 				// row as valid (#954 review) -- the SAME garbage-body-wipe class as #886/#892.
-				$csvline = str_getcsv($line, ',', '"', "\\");
-				// #920: fold once here -- the GUI's inclusion keys are always lowercase
-				// (pfblockerng_dnsbl.php's $options_alexa_inclusion), so an uppercase/
-				// mixed-case feed domain otherwise passes every guard below but silently
-				// fails the isset($pfb_include[$tld]) compare; folding here also feeds
-				// the 'www.' strip and the write, so every downstream use is canonical.
-				$domain = strtolower($csvline[$top1m_domcol] ?? '');
-				if ($top1m_parse === 'rank_domain' && !ctype_digit((string) ($csvline[0] ?? ''))) {
-					continue;
-				}
-				// #920: the `D` modifier anchors '$' to the true string end -- without it, a
-				// quoted-unterminated CSV field (str_getcsv() retains its trailing "\n", unlike
-				// every other field shape) wrongly passes and can flip a garbage-only feed from
-				// dead (preserve) to valid (wipe), the same class of bug the #886/#892 guards fix.
-				if (!preg_match('/^[A-Za-z0-9][A-Za-z0-9.-]*\.(?:[A-Za-z]{2,}|[Xx][Nn]--[A-Za-z0-9][A-Za-z0-9-]+)$/D', $domain)) {
+				$domain = pfb_top1m_parse_source_row($line, $top1m_provider);
+				if ($domain === NULL) {
 					continue;
 				}
 				// Count every valid CSV row BEFORE the match/break below, so a
@@ -11622,6 +11651,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 	$password = $request->password;
 	$srcint = $request->sourceInterface;
 	$extra_headers = $request->extraHeaders;
+	$top1m_provider = ($type === 'top1m') ? pfb_top1m_active_provider() : array();
 	global $pfb;
 	$http_status = '';
 	$elog = ">> {$pfb['log']} 2>&1";
@@ -12158,6 +12188,12 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					pfb_logger("\n[pfb_download] top1m extraction failed (gunzip exit {$retval})", 2);
 					return PfbDownloadResult::failure();
 				}
+				if (!pfb_top1m_candidate_valid($top1m_stage, $top1m_provider)) {
+					pfb_validate_log($header, 'top1m', 'semantic_invalid', basename($top1m_stage));
+					unlink_if_exists($file_download);
+					unlink_if_exists($top1m_stage);
+					return PfbDownloadResult::failure();
+				}
 				$top1m_base_backup = @tempnam(dirname($file_dwn), '.pfbtop1m_base_');
 				if ($top1m_base_backup === FALSE || !@unlink($top1m_base_backup) || !@mkdir($top1m_base_backup, 0700)) {
 					unlink_if_exists($file_download);
@@ -12389,6 +12425,12 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 						unlink_if_exists($file_download);
 						return PfbDownloadResult::failure();
 					}
+					if (!pfb_top1m_candidate_valid($top1m_staged_files[0], $top1m_provider)) {
+						pfb_validate_log($header, 'top1m', 'semantic_invalid', basename($top1m_staged_files[0]));
+						rmdir_recursive($top1m_stage);
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
+					}
 				}
 				$top1m_base_backup = @tempnam(dirname($file_dwn), '.pfbtop1m_base_');
 				if ($top1m_base_backup === FALSE || !@unlink($top1m_base_backup) || !@mkdir($top1m_base_backup, 0700)) {
@@ -12551,6 +12593,12 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 						unlink_if_exists($top1m_stage);
 					}
 					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				if (!pfb_top1m_candidate_valid($top1m_stage, $top1m_provider)) {
+					pfb_validate_log($header, 'top1m', 'semantic_invalid', basename($top1m_stage));
+					unlink_if_exists($file_download);
+					unlink_if_exists($top1m_stage);
 					return PfbDownloadResult::failure();
 				}
 				$top1m_base_backup = @tempnam(dirname($file_dwn), '.pfbtop1m_base_');

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9811,6 +9811,9 @@ function pfb_top1m_parse_source_row(string $line, array $provider): ?string
 		return NULL;
 	}
 	$csvline = str_getcsv($line, ',', '"', "\\");
+	if (isset($provider['columns']) && count($csvline) !== (int) $provider['columns']) {
+		return NULL;
+	}
 	if (($provider['parse'] ?? 'rank_domain') === 'rank_domain'
 		&& !ctype_digit((string) ($csvline[0] ?? ''))) {
 		return NULL;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12165,66 +12165,28 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				return PfbDownloadResult::failure();
 			}
 
-			// Extras - MaxMind downloads. Keep GeoIP's existing extraction contract.
+			// Extras - MaxMind downloads. GeoIP publishes directly to its caller
+			// target; TOP1M's staged/atomic branch is kept separate below.
 			if ($type == 'geoip') {
+				// Determine if the Zip contains multiple files. A NULL list
+				// (unlistable) falls through to stdout extraction exactly as before.
 				$archive_members = pfb_archive_member_names($file_download);
 				if ($archive_members !== NULL && count($archive_members) > 1) {
+					// ADR-46: disk-writing extraction -- reject hostile member names first.
 					$unsafe_member = pfb_archive_unsafe_member($archive_members);
 					if ($unsafe_member !== NULL) {
 						pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
 						unlink_if_exists($file_download);
 						return PfbDownloadResult::failure();
 					}
-					$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
-					if ($top1m_stage === FALSE || !@unlink($top1m_stage) || !@mkdir($top1m_stage, 0700)) {
-						unlink_if_exists($file_download);
-						return PfbDownloadResult::failure();
-					}
-					$header_esc = escapeshellarg($top1m_stage);
 					exec("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1", $output, $retval);
 				} else {
-					$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
-					if ($top1m_stage === FALSE) {
-						unlink_if_exists($file_download);
-						return PfbDownloadResult::failure();
-					}
-					$header_esc = escapeshellarg($top1m_stage);
+					// ADR-46: stdout extraction -- member names never reach the filesystem.
 					exec("/usr/bin/tar -xOf {$file_dwn_esc} > {$header_esc}", $output, $retval);
 				}
 				if ($retval != 0) {
 					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})", 2);
-					if (is_dir($top1m_stage)) {
-						rmdir_recursive($top1m_stage);
-					} else {
-						unlink_if_exists($top1m_stage);
-					}
 					unlink_if_exists($file_download);
-					return PfbDownloadResult::failure();
-				}
-				if (!pfb_top1m_persist_baseline($file_dwn, $file_download)) {
-					if (is_dir($top1m_stage)) {
-						rmdir_recursive($top1m_stage);
-					} else {
-						unlink_if_exists($top1m_stage);
-					}
-					unlink_if_exists($file_download);
-					pfb_top1m_invalidate_baseline($file_dwn);
-					return PfbDownloadResult::failure();
-				}
-				if (is_dir($top1m_stage)) {
-					$staged_files = glob("{$top1m_stage}/*") ?: array();
-					$top1m_stage_file = $staged_files[0] ?? FALSE;
-					if ($top1m_stage_file === FALSE || !@rename($top1m_stage_file, $head_download)) {
-						rmdir_recursive($top1m_stage);
-						unlink_if_exists($file_download);
-						pfb_top1m_invalidate_baseline($file_dwn);
-						return PfbDownloadResult::failure();
-					}
-					rmdir_recursive($top1m_stage);
-				} elseif (!@rename($top1m_stage, $head_download)) {
-					unlink_if_exists($top1m_stage);
-					unlink_if_exists($file_download);
-					pfb_top1m_invalidate_baseline($file_dwn);
 					return PfbDownloadResult::failure();
 				}
 				unlink_if_exists($file_download);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12012,7 +12012,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					return PfbDownloadResult::failure();
 				}
 				$header_esc = escapeshellarg($top1m_stage);
-				exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);
+				exec("/usr/bin/gunzip -c {$file_download} > {$header_esc}", $output, $retval);
 				if ($retval != 0) {
 					unlink_if_exists($file_download);
 					unlink_if_exists($top1m_stage);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -137,7 +137,6 @@ $pfb['unbound_py_count']= '/var/unbound/pfb_py_count';
 $pfb['unbound_py_regex_count']= '/var/unbound/pfb_py_regex_count';	// ADR-07: Python-emitted ADMITTED (cap-filtered) feed+user regex total for the DNSBL_Regex alias
 $pfb['unbound_py_reject_stats']= '/var/unbound/pfb_py_reject_stats.json';	// ADR-48: Python-emitted per-entry reject tally (issue #789), read by pfb_emit_entry_reject_stats()
 $pfb['unbound_py_sources']= '/var/unbound/pfb_py_sources.json';	// ADR-06: per-feed manifest consumed by pfb_unbound.py init
-$pfb['unbound_py_top1m']= '/var/unbound/pfb_py_top1m.txt';	// issue #1542: fixed TOP1M sidecar consumed by pfb_unbound.py
 $pfb['unbound_py_rawdir']= '/var/unbound/pfb_py_raw';		// #1357: basename for immutable per-feed raw generations
 
 $pfb['dnsbl_safesearch']		= '/usr/local/pkg/pfblockerng/pfb_dnsbl.safesearch.conf';
@@ -1965,11 +1964,8 @@ function pfb_unbound_py_manifest_raw_paths(string $manifest_path, bool $deduplic
 
 function pfb_dnsbl_loaded_input_paths(array $pfb): array {
 	$raw_files = pfb_unbound_py_manifest_raw_paths((string) ($pfb['unbound_py_sources'] ?? ''));
-	$top1m_files = (($pfb['dnsbl_top1m'] ?? '') === 'on')
-		? array($pfb['unbound_py_top1m'] ?? '/var/unbound/pfb_py_top1m.txt') : array();
 	return array_merge(
 		array($pfb['unbound_py_wh'], $pfb['unbound_py_sources'], $pfb['unbound_py_hsts'], $pfb['unbound_py_tld']),
-		$top1m_files,
 		$raw_files
 	);
 }
@@ -7824,76 +7820,6 @@ function pfb_unbound_py_atomic_write($path, $content, array $stream_ops=array())
 	return TRUE;
 }
 
-// Issue #1542: stream the generated TOP1M whitelist into a same-directory
-// temporary file, then publish it with the same fsync + atomic rename contract
-// as the manifest. The fixed sidecar is deliberately not represented in JSON.
-function pfb_unbound_py_atomic_copy(string $source, string $path, array $stream_ops=array()): bool {
-	$source_h = @fopen($source, 'rb');
-	if ($source_h === FALSE) {
-		return FALSE;
-	}
-	$tmp = @tempnam(dirname($path), '.pfbtop1m_');
-	if ($tmp === FALSE) {
-		@fclose($source_h);
-		return FALSE;
-	}
-	$target_h = @fopen($tmp, 'wb');
-	if ($target_h === FALSE) {
-		@fclose($source_h);
-		@unlink($tmp);
-		return FALSE;
-	}
-	$write_fn = $stream_ops['write'] ?? static fn($stream, $bytes) => @fwrite($stream, $bytes);
-	$flush_fn = $stream_ops['flush'] ?? static fn($stream) => @fflush($stream);
-	$fsync_fn = $stream_ops['fsync'] ?? static fn($stream) => @fsync($stream);
-	$ok = TRUE;
-	while (!feof($source_h)) {
-		$chunk = @fread($source_h, 1048576);
-		if ($chunk === FALSE) {
-			$ok = FALSE;
-			break;
-		}
-		if ($chunk !== '') {
-			$written = $write_fn($target_h, $chunk);
-			if ($written === FALSE || $written !== strlen($chunk)) {
-				$ok = FALSE;
-				break;
-			}
-		}
-	}
-	$ok = $ok && $flush_fn($target_h) && $fsync_fn($target_h);
-	$ok = @fclose($target_h) && $ok;
-	@fclose($source_h);
-	if (!$ok) {
-		@unlink($tmp);
-		return FALSE;
-	}
-	$chown_fn = $stream_ops['chown'] ?? static fn($file, $owner) => @chown($file, $owner);
-	$chgrp_fn = $stream_ops['chgrp'] ?? static fn($file, $group) => @chgrp($file, $group);
-	$chmod_fn = $stream_ops['chmod'] ?? static fn($file, $mode) => @chmod($file, $mode);
-	if (array_key_exists('chown', $stream_ops) && !$chown_fn($tmp, 'root') ||
-		array_key_exists('chgrp', $stream_ops) && !$chgrp_fn($tmp, 'unbound') ||
-		array_key_exists('chmod', $stream_ops) && !$chmod_fn($tmp, 0640)) {
-		@unlink($tmp);
-		return FALSE;
-	}
-	if (!array_key_exists('chown', $stream_ops)) {
-		@chown($tmp, 'root');
-	}
-	if (!array_key_exists('chgrp', $stream_ops)) {
-		@chgrp($tmp, 'unbound');
-	}
-	if (!array_key_exists('chmod', $stream_ops)) {
-		@chmod($tmp, 0640);
-	}
-	$rename_fn = $stream_ops['rename'] ?? static fn($from, $to) => @rename($from, $to);
-	if (!$rename_fn($tmp, $path)) {
-		@unlink($tmp);
-		return FALSE;
-	}
-	return TRUE;
-}
-
 // #1357: one exclusive lock serializes full-set publication, scalar manifest patches,
 // convergence-gated generation GC, and teardown. Python readers never take this lock.
 function pfb_unbound_py_publication_lock(?float $timeout_s=NULL) {
@@ -8455,13 +8381,6 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 	if (!is_array($feeds)) {
 		$feeds = array();
 	}
-	$top1m_enabled = (($pfb['dnsbl_top1m'] ?? '') === 'on');
-	$top1m_source = "{$pfb['dbdir']}/pfbalexawhitelist.txt";
-	$top1m_target = $pfb['unbound_py_top1m'] ?? '/var/unbound/pfb_py_top1m.txt';
-	if ($top1m_enabled && (is_link($top1m_source) || !is_file($top1m_source) || !is_readable($top1m_source))) {
-		pfb_logger("\nTOP1M fixed-file source unavailable: {$top1m_source}", 2);
-		return FALSE;
-	}
 
 	$raw_parent = dirname($pfb['unbound_py_rawdir']);
 	$raw_base = basename($pfb['unbound_py_rawdir']);
@@ -8616,48 +8535,16 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 	// Synthetic whole-TLD blacklist feed (DNSBL_TLD): the Python build emits these
 	// as whole-TLD ZONE entries from config.tld_wildcard_blacklist, so no raw file is needed.
 
-	// TOP1M (Tranco/Cisco) popularity whitelist is a fixed sidecar. Publish it
-	// before the manifest so a durable manifest always names a complete snapshot.
-	$top1m_backup = FALSE;
-	$top1m_had_previous = file_exists($top1m_target) || is_link($top1m_target);
-	$restore_top1m = static function () use (&$top1m_backup, $top1m_target, $top1m_had_previous): void {
-		if ($top1m_backup === FALSE) {
-			return;
-		}
-		if (file_exists($top1m_target) || is_link($top1m_target)) {
-			is_dir($top1m_target) && !is_link($top1m_target)
-				? rmdir_recursive($top1m_target)
-				: @unlink($top1m_target);
-		}
-		if ($top1m_had_previous && $top1m_backup !== FALSE) {
-			@rename($top1m_backup, $top1m_target);
-		} elseif ($top1m_backup !== FALSE) {
-			@unlink($top1m_backup);
-		}
-		$top1m_backup = FALSE;
-	};
+	// TOP1M (Tranco/Cisco) popularity whitelist -> query-time whiteDB only when on.
+	// ponytail: pfbalexawhitelist.txt keeps its on-disk name -- renaming a generated
+	// artifact needs old-file cleanup for zero user benefit (#877 triage decision).
+	$top1m_enabled	= ($pfb['dnsbl_top1m'] == 'on' &&
+			   file_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt"));
+	$top1m_list	= array();
 	if ($top1m_enabled) {
-		$top1m_backup = @tempnam(dirname($top1m_target), '.pfbtop1m_prev_');
-		if ($top1m_backup !== FALSE) {
-			@unlink($top1m_backup);
-		}
-		$top1m_backup_ok = $top1m_backup !== FALSE &&
-			(!$top1m_had_previous || @link($top1m_target, $top1m_backup) || @copy($top1m_target, $top1m_backup));
-		if (!$top1m_backup_ok) {
-			if ($top1m_backup !== FALSE) {
-				@unlink($top1m_backup);
-			}
-			$discard_unpublished_generation();
-			pfb_logger("\nTOP1M fixed-file staging failed: {$top1m_target}", 2);
-			return FALSE;
-		}
-		$top1m_atomic_ops = isset($publication_ops['top1m_atomic']) && is_array($publication_ops['top1m_atomic'])
-			? $publication_ops['top1m_atomic'] : array();
-		if (!pfb_unbound_py_atomic_copy($top1m_source, $top1m_target, $top1m_atomic_ops)) {
-			$restore_top1m();
-			$discard_unpublished_generation();
-			pfb_logger("\nTOP1M fixed-file publication failed: {$top1m_target}", 2);
-			return FALSE;
+		$top1m_lines = @file("{$pfb['dbdir']}/pfbalexawhitelist.txt", FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		if (is_array($top1m_lines)) {
+			$top1m_list = $top1m_lines;
 		}
 	}
 
@@ -8689,6 +8576,7 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 			// "re-locked on Cron/Force" semantic. Only pfb_unbound_python_sources_unlock()
 			// (the incremental alerts dnsbl_remove path) repopulates user_unlock.
 			'user_unlock'	=> array(),
+			'top1m_list'	=> array_values($top1m_list),
 			'top1m_enabled'	=> $top1m_enabled
 		),
 		'feeds'		=> $manifest_feeds
@@ -8704,7 +8592,6 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 		$manifest_atomic_ops = isset($publication_ops['manifest_atomic'])
 			&& is_array($publication_ops['manifest_atomic']) ? $publication_ops['manifest_atomic'] : array();
 		if (!pfb_unbound_py_atomic_write($pfb['unbound_py_sources'], $json, $manifest_atomic_ops)) {
-			$restore_top1m();
 			$discard_unpublished_generation();
 			// ADR-65: a swallowed publish failure left Python running on a stale/absent
 			// manifest with no operator-visible signal -- surface it like the existing
@@ -8712,17 +8599,10 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 			$manifest_notice = "DNSBL manifest publish failed: {$pfb['unbound_py_sources']}";
 			pfb_logger("\n{$manifest_notice}", 2);
 			file_notice('pfBlockerNG DNSBL', $manifest_notice, 'pfBlockerNG', '/pfblockerng/pfblockerng_dnsbl.php', 2);
-			return FALSE;
-		}
-		if ($top1m_enabled && $top1m_backup !== FALSE) {
-			@unlink($top1m_backup);
-			$top1m_backup = FALSE;
 		}
 	} else {
-		$restore_top1m();
 		$discard_unpublished_generation();
 		pfb_logger("\nDNSBL manifest JSON encoding failed: " . json_last_error_msg(), 2);
-		return FALSE;
 	}
 
 	return $manifest;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11952,9 +11952,6 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			case 'geoip':
 				touch("{$pfb['dbdir']}/geoip.update");
 				break;
-			case 'top1m':
-				touch("{$pfb['dbdir']}/top-1m.update");
-				break;
 			case 'asn':
 				touch("{$pfb['dbdir']}/asn.update");
 				break;
@@ -12007,14 +12004,34 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				return PfbDownloadResult::success();
 			}
 			elseif ($type == 'top1m') {
-				// ADR-59: a gz-container TOP1M provider decompresses straight to
-				// the destination CSV pfblockerng_top1m() reads (no rename/staging).
+				// Issue #1542: stage the derived CSV so a failed extraction never
+				// destroys the previous active whitelist source.
+				$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
+				if ($top1m_stage === FALSE) {
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
+				$header_esc = escapeshellarg($top1m_stage);
 				exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);
-				unlink_if_exists($file_download);
 				if ($retval != 0) {
+					unlink_if_exists($file_download);
+					unlink_if_exists($top1m_stage);
 					pfb_logger("\n[pfb_download] top1m extraction failed (gunzip exit {$retval})", 2);
 					return PfbDownloadResult::failure();
 				}
+				if (!pfb_top1m_persist_baseline($file_dwn, $file_download)) {
+					unlink_if_exists($file_download);
+					unlink_if_exists($top1m_stage);
+					pfb_top1m_invalidate_baseline($file_dwn);
+					return PfbDownloadResult::failure();
+				}
+				unlink_if_exists($file_download);
+				if (!@rename($top1m_stage, $head_download)) {
+					unlink_if_exists($top1m_stage);
+					pfb_top1m_invalidate_baseline($file_dwn);
+					return PfbDownloadResult::failure();
+				}
+				touch("{$pfb['dbdir']}/top-1m.update");
 				return PfbDownloadResult::success();
 			}
 			elseif ($type == 'blacklist') {
@@ -12110,17 +12127,61 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 						unlink_if_exists($file_download);
 						return PfbDownloadResult::failure();
 					}
+					$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
+					if ($top1m_stage === FALSE || !@unlink($top1m_stage) || !@mkdir($top1m_stage, 0700)) {
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
+					}
+					$header_esc = escapeshellarg($top1m_stage);
 					exec("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1", $output, $retval);
 				} else {
 					// ADR-46: stdout extraction -- member names never reach the
 					// filesystem, so no member-name guard is needed here.
+					$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
+					if ($top1m_stage === FALSE) {
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
+					}
+					$header_esc = escapeshellarg($top1m_stage);
 					exec("/usr/bin/tar -xOf {$file_dwn_esc} > {$header_esc}", $output, $retval);
 				}
 				if ($retval != 0) {
 					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})", 2);
+					if (is_dir($top1m_stage)) {
+						rmdir_recursive($top1m_stage);
+					} else {
+						unlink_if_exists($top1m_stage);
+					}
 					unlink_if_exists($file_download);
 					return PfbDownloadResult::failure();
 				}
+				if (!pfb_top1m_persist_baseline($file_dwn, $file_download)) {
+					if (is_dir($top1m_stage)) {
+						rmdir_recursive($top1m_stage);
+					} else {
+						unlink_if_exists($top1m_stage);
+					}
+					unlink_if_exists($file_download);
+					pfb_top1m_invalidate_baseline($file_dwn);
+					return PfbDownloadResult::failure();
+				}
+				if (is_dir($top1m_stage)) {
+					$staged_files = glob("{$top1m_stage}/*") ?: array();
+					$top1m_stage_file = $staged_files[0] ?? FALSE;
+					if ($top1m_stage_file === FALSE || !@rename($top1m_stage_file, $head_download)) {
+						rmdir_recursive($top1m_stage);
+						unlink_if_exists($file_download);
+						pfb_top1m_invalidate_baseline($file_dwn);
+						return PfbDownloadResult::failure();
+					}
+					rmdir_recursive($top1m_stage);
+				} elseif (!@rename($top1m_stage, $head_download)) {
+					unlink_if_exists($top1m_stage);
+					unlink_if_exists($file_download);
+					pfb_top1m_invalidate_baseline($file_dwn);
+					return PfbDownloadResult::failure();
+				}
+				touch("{$pfb['dbdir']}/top-1m.update");
 				return PfbDownloadResult::success();
 			}
 
@@ -12193,15 +12254,35 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 		}
 		else {
 			// Uncompressed file format.
-			if ($type == 'geoip' || $type == 'asn' || $type == 'top1m') {
-				// Extras - MaxMind/TOP1M/ASN downloads. ADR-59: a 'plain' container
-				// provider's body IS the destination CSV -- rename straight to it, same
-				// as geoip/asn (no intermediate '.orig' staging needed).
+			if ($type == 'geoip' || $type == 'asn') {
+				// Existing MaxMind/ASN path: preserve the direct rename contract.
 				$renamed = @rename("{$file_download}", "{$head_download}");
 				if (!$renamed) {
 					pfb_logger("\n[pfb_download] {$type} rename to destination failed", 2);
 					return PfbDownloadResult::failure();
 				}
+				return PfbDownloadResult::success();
+			}
+			if ($type == 'top1m') {
+				// Stage TOP1M's plain body before publishing so a failed rename
+				// preserves the active source.
+				$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
+				if ($top1m_stage === FALSE) {
+					pfb_logger("\n[pfb_download] {$type} rename to destination failed", 2);
+					return PfbDownloadResult::failure();
+				}
+				if (!pfb_top1m_persist_baseline($file_dwn, $file_download)) {
+					unlink_if_exists($file_download);
+					unlink_if_exists($top1m_stage);
+					pfb_top1m_invalidate_baseline($file_dwn);
+					return PfbDownloadResult::failure();
+				}
+				if (!@rename($file_download, $top1m_stage) || !@rename($top1m_stage, $head_download)) {
+					unlink_if_exists($top1m_stage);
+					pfb_top1m_invalidate_baseline($file_dwn);
+					return PfbDownloadResult::failure();
+				}
+				touch("{$pfb['dbdir']}/top-1m.update");
 				return PfbDownloadResult::success();
 			}
 			elseif ($type == 'blacklist') {
@@ -13964,6 +14045,74 @@ function pfb_conditional_get_decision($http_status, $body_hash, $persisted_hash)
 		return TRUE;	// No usable comparison — fail-safe.
 	}
 	return ($body_hash !== $persisted_hash);	// TRUE = changed, FALSE = spurious 200 (same bytes).
+}
+
+// Issue #1542: TOP1M's dcc detector keeps the existing conditional-GET decision
+// matrix but adds an explicit failed-probe state for its download ledger.
+function pfb_top1m_probe_decision($probe_ok, $http_status, $body_hash, $persisted_hash) {
+	if (!$probe_ok) {
+		return 'failed';
+	}
+	return pfb_conditional_get_decision($http_status, $body_hash, $persisted_hash)
+		? 'changed' : 'unchanged';
+}
+
+// Issue #1542: provider/URL/auth identity is stored beside the raw baseline.
+// A changed identity clears the detector baseline and validators; the active
+// derived whitelist remains available until a replacement download succeeds.
+function pfb_top1m_source_identity($provider, $url, array $headers = array()) {
+	$header_identity = array_map(static function ($header) {
+		return hash('sha256', (string) $header);
+	}, array_values($headers));
+	$encoded = json_encode(array(
+		'provider' => (string) $provider,
+		'url'      => (string) $url,
+		'headers'  => $header_identity,
+	), JSON_UNESCAPED_SLASHES);
+	return $encoded === FALSE ? '' : $encoded;
+}
+
+function pfb_top1m_invalidate_baseline($base) {
+	$validator_base = "{$base}.orig";
+	foreach (array(
+		"{$base}.orig",
+		"{$base}.xxhash128",
+		"{$base}.md5",
+		"{$base}.source",
+		"{$validator_base}.etag",
+		"{$validator_base}.lastmod",
+	) as $path) {
+		unlink_if_exists($path);
+	}
+}
+
+// Settings that affect TOP1M filtering reuse the cached source and trigger
+// a local rebuild; provider identity changes take the download detector path.
+function pfb_top1m_settings_reprocess(array $before, array $after) {
+	foreach (array('enable', 'count', 'tld') as $key) {
+		if (($before[$key] ?? '') !== ($after[$key] ?? '')) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+function pfb_top1m_persist_baseline($base, $raw_path) {
+	if (!is_file($raw_path)) {
+		return FALSE;
+	}
+	$tmp = @tempnam(dirname($base), '.pfbtop1m_raw_');
+	if ($tmp === FALSE || !@copy($raw_path, $tmp) || !@rename($tmp, "{$base}.orig")) {
+		if ($tmp !== FALSE) {
+			@unlink($tmp);
+		}
+		return FALSE;
+	}
+	return pfb_hash_write($base, "{$base}.orig");
+}
+
+function pfb_top1m_download_ledger_update($download_ok, $ledger_dir, $message = '') {
+	pfb_dnsbl_download_ledger_update((bool) $download_ok, 'top1m', (string) $message, $ledger_dir);
 }
 
 // Extract the local-feed change decision from pfb_update_check() as a named, off-appliance-

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -329,6 +329,7 @@ dnsbl_cache() {
 	# Overridable for unit tests; default to the live locations.
 	pfbchroot="${pfbchroot:-/var/unbound}"
 	pfbpkgdir="${pfbpkgdir:-/usr/local/pkg/pfblockerng}"
+	pfbdb="${pfbdb:-/var/db/pfblockerng}"
 	dnsblarchive="${dnsblarchive:-/usr/local/etc/pfb_dnsbl_cache.tar}"
 	pathtar="${pathtar:-/usr/bin/tar}"
 
@@ -382,6 +383,13 @@ dnsbl_cache() {
 				# generated, so it is excluded the same way.
 				[ "${_g}" = "${pfbchroot}/pfb_py_tld.txt" ] && _skip=1
 				[ -z "${_skip}" ] && set -- "$@" "${_g}"
+			done
+			# issue #1542: preserve only the TOP1M detector baseline sidecars;
+			# transient and unrelated /var/db/pfblockerng files stay out.
+			_top1m_base="${pfbdb%/}/top-1m.csv.zip"
+			for _s in orig xxhash128 md5 source orig.etag orig.lastmod; do
+				_f="${_top1m_base}.${_s}"
+				[ -f "${_f}" ] && set -- "$@" "${_f}"
 			done
 			if [ "$#" -gt 0 ]; then
 				# The helper appends .zst/.bz2 to the base and picks the codec.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -319,9 +319,9 @@ aliastables() {
 # wiped on reboot, so DNSBL comes up dead; this keeps it alive across reboot with PURE FILE
 # OPS (no reload/restart), kept SEPARATE from the IP aliastables flow above (different
 # lifecycles). stage = copy the SHIPPED set (PFB_PY_SHIPPED) from /usr/local into the chroot
-# (re-run on every save/restore, never restored stale); save = stage then archive ONLY the
-# GENERATED set (pfb_unbound*/pfb_py_*/pfb_unbound.ini); restore = boot earlyshellcmd, untar
-# the generated set THEN stage. Naming contract: a new generated file MUST keep the
+# (re-run on every save/restore, never restored stale); save = stage then archive the
+# GENERATED set plus exact TOP1M detector sidecars; restore = boot earlyshellcmd, untar
+# the cached files THEN stage. Naming contract: a new generated file MUST keep the
 # pfb_unbound*/pfb_py_* prefix; a new shipped file goes in PFB_PY_SHIPPED + pkg-plist wiring
 # (a NAME-MAPPED shipped file -- source basename != chroot basename -- is the sole
 # exception: it needs its own explicit stage/save handling instead; see pfb_py_tld.txt).
@@ -364,8 +364,8 @@ dnsbl_cache() {
 			;;
 		save)
 			dnsbl_cache_stage
-			# Archive ONLY the generated set: pfb_unbound* + pfb_py_* + pfb_unbound.ini,
-			# EXCLUDING the shipped files (PFB_PY_SHIPPED) -- those are re-staged from
+			# Archive the generated chroot set plus exact TOP1M detector sidecars,
+			# EXCLUDING shipped files (PFB_PY_SHIPPED) -- those are re-staged from
 			# /usr/local on restore, so archiving them would reinstate stale code (e.g.
 			# pfb_py_hsts.txt matches the pfb_py_* glob but is shipped, not generated).
 			set --

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -78,6 +78,25 @@ function pfb_top1m_fetch_if_needed(string $dbdir, ?callable $fetch = NULL): bool
 	return TRUE;
 }
 
+/** Record the manifest publication outcome without logging a false completion. */
+function pfb_dnsbl_publish_result(bool $published, ?callable $logger = NULL): bool {
+	global $pfb;
+	$logger = $logger ?? 'pfb_logger';
+	if (!$published) {
+		$pfb['dnsbl_publish_failed'] = TRUE;
+		$logger('... FAILED (publication error)', 2);
+		return FALSE;
+	}
+	$logger('... completed', 1);
+	return TRUE;
+}
+
+/** Keep the reload and ADR-12 post-hook change signal on one predicate. */
+function pfb_dnsbl_reload_needed(bool $publish_failed, bool $data_changed, bool $update, bool $python,
+    bool $safesearch_update, bool $unlock_forced): bool {
+	return !$publish_failed && ($data_changed || $update || $python || $safesearch_update || $unlock_forced);
+}
+
 /**
  * Parse one generic IP-feed line without touching run state or emitting output.
  * @param array{vtype:string,pftype:string,custom:bool,cidr_floor_v4:int|string,cidr_floor_v6:int|string,suppression:string,range:string,ipv4:string,ipv6:string} $config
@@ -2259,10 +2278,7 @@ function sync_package_pfblockerng($cron='') {
 			// plugin's init builds the DNSBL structures from. Python then owns
 			// parse/normalise/classify (the dropped shell/PHP passes) and emits
 			// pfb_py_count itself.
-			if (pfb_unbound_python_sources($pfb_py_feeds) === FALSE) {
-				$pfb['dnsbl_publish_failed'] = TRUE;
-			}
-			pfb_logger("... completed", 1);
+			pfb_dnsbl_publish_result(pfb_unbound_python_sources($pfb_py_feeds) !== FALSE);
 		}
 
 		else {
@@ -2614,8 +2630,8 @@ function sync_package_pfblockerng($cron='') {
 	// user_unlock. Captured BEFORE the reload: pfb_update_unbound() unlinks the file,
 	// so a post-reload file_exists() would always return false (issue #517).
 	$pfb_dnsbl_unlock_forced = file_exists($pfb['dnsbl_unlock']);
-	if (empty($pfb['dnsbl_publish_failed']) && ($pfb_data_changed || $pfbupdate || $pfbpython || $safesearch_update ||
-	    $pfb_dnsbl_unlock_forced)) {
+	if (pfb_dnsbl_reload_needed(!empty($pfb['dnsbl_publish_failed']), !empty($pfb_data_changed), !empty($pfbupdate),
+	    !empty($pfbpython), !empty($safesearch_update), !empty($pfb_dnsbl_unlock_forced))) {
 
 		// Create backup of existing DNSBL Unbound database
 
@@ -4369,8 +4385,9 @@ function sync_package_pfblockerng($cron='') {
 	pfb_run_hooks('post', array(
 		'TRIGGER'		=> $pfb_hook_val,
 		'IP_CHANGED'		=> (!empty($pfb['filter_configure']) || !empty($pfb_ip_unlock_forced)) ? '1' : '0',
-		'DNSBL_CHANGED'		=> (!empty($pfb_data_changed) || !empty($pfbupdate) || !empty($pfbpython) ||
-						!empty($safesearch_update) || !empty($pfb_dnsbl_unlock_forced)) ? '1' : '0',
+		'DNSBL_CHANGED'		=> pfb_dnsbl_reload_needed(!empty($pfb['dnsbl_publish_failed']),
+						!empty($pfb_data_changed), !empty($pfbupdate), !empty($pfbpython),
+						!empty($safesearch_update), !empty($pfb_dnsbl_unlock_forced)) ? '1' : '0',
 		'STATUS'		=> 'ok',
 		'CHANGED_IP_ALIASES'	=> implode(' ', array_unique($pfb['changed_ip_aliases'])),
 		'CHANGED_DNSBL_GROUPS'	=> implode(' ', array_unique($pfb['changed_dnsbl_groups'])),

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -1011,6 +1011,7 @@ function sync_package_pfblockerng($cron='') {
 	$pfb['alias_dnsbl_all']		= array();	// Array of all DNSBL aliases
 	$dnsbl_tld_group_counts		= array();	// Deferred DNSBL group counts for TLD-mode statistics
 	$pfb['domain_update']		= FALSE;	// Flag to signal update Unbound
+	$pfb['dnsbl_publish_failed']	= FALSE;	// Fixed TOP1M/manifest publication failed; suppress reload
 	$pfb['updateip']		= FALSE;	// Flag to signal updates to DNSBL IP lists
 	$pfb_py_feeds			= array();	// ADR-06: per-feed manifest rows [header,group,log] for pfb_unbound_python_sources()
 	$safesearch_update		= FALSE;	// Flag: SafeSearch CSV changed -> force an Unbound restart (issue #149)
@@ -2235,7 +2236,9 @@ function sync_package_pfblockerng($cron='') {
 			// plugin's init builds the DNSBL structures from. Python then owns
 			// parse/normalise/classify (the dropped shell/PHP passes) and emits
 			// pfb_py_count itself.
-			pfb_unbound_python_sources($pfb_py_feeds);
+			if (pfb_unbound_python_sources($pfb_py_feeds) === FALSE) {
+				$pfb['dnsbl_publish_failed'] = TRUE;
+			}
 			pfb_logger("... completed", 1);
 		}
 
@@ -2264,7 +2267,9 @@ function sync_package_pfblockerng($cron='') {
 				// loaded→empty transition still diverges on the first pass (one reload), then
 				// stabilises. DO NOT delete pfb_py_wh: pfb_unbound_python() reads it to detect
 				// a whitelist change; missing=FALSE !== '' triggers $pfbpython=TRUE every pass.
-				pfb_unbound_python_sources(array());		// valid feeds:[] manifest + empty rawdir
+				if (pfb_unbound_python_sources(array()) === FALSE) {
+					$pfb['dnsbl_publish_failed'] = TRUE;
+				}		// valid feeds:[] manifest + empty rawdir
 				unlink_if_exists($pfb['unbound_py_count']);
 				unlink_if_exists($pfb['unbound_py_regex_count']);		// ADR-07
 			}
@@ -2586,8 +2591,8 @@ function sync_package_pfblockerng($cron='') {
 	// user_unlock. Captured BEFORE the reload: pfb_update_unbound() unlinks the file,
 	// so a post-reload file_exists() would always return false (issue #517).
 	$pfb_dnsbl_unlock_forced = file_exists($pfb['dnsbl_unlock']);
-	if ($pfb_data_changed || $pfbupdate || $pfbpython || $safesearch_update ||
-	    $pfb_dnsbl_unlock_forced) {
+	if (empty($pfb['dnsbl_publish_failed']) && ($pfb_data_changed || $pfbupdate || $pfbpython || $safesearch_update ||
+	    $pfb_dnsbl_unlock_forced)) {
 
 		// Create backup of existing DNSBL Unbound database
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -78,6 +78,12 @@ function pfb_top1m_fetch_if_needed(string $dbdir, ?callable $fetch = NULL): bool
 	return TRUE;
 }
 
+/** Rebuild only from an active TOP1M source whose detector baseline is current. */
+function pfb_top1m_reprocess_needed(string $dbdir): bool {
+	return !pfb_top1m_refresh_needed($dbdir) &&
+		(!file_exists("{$dbdir}/pfbalexawhitelist.txt") || file_exists("{$dbdir}/top-1m.update"));
+}
+
 /** Record the manifest publication outcome without logging a false completion. */
 function pfb_dnsbl_publish_result(bool $published, ?callable $logger = NULL): bool {
 	global $pfb;
@@ -1336,8 +1342,7 @@ function sync_package_pfblockerng($cron='') {
 				}
 
 				// Process TOP1M database
-				if (!file_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt") ||
-				    file_exists("{$pfb['dbdir']}/top-1m.update")) {
+				if (pfb_top1m_reprocess_needed($pfb['dbdir'])) {
 					pfblockerng_top1m();
 					$pfb['reuse_dnsbl'] = 'on';
 					touch("{$pfb['dnsbl_file']}.reload");

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -56,6 +56,29 @@ function pfb_sync_run_plan(array $request, bool $no_updates, bool $cron_tick, st
 }
 
 /**
+ * TOP1M's live CSV is usable only while its raw detector baseline is present too.
+ */
+function pfb_top1m_refresh_needed(string $dbdir): bool {
+	return !file_exists("{$dbdir}/top-1m.csv");
+}
+
+/**
+ * Attempt the TOP1M provider fetch when either live source file is absent.
+ * The optional fetcher is a no-network test seam; production uses the CLI command.
+ */
+function pfb_top1m_fetch_if_needed(string $dbdir, ?callable $fetch = NULL): bool {
+	if (!pfb_top1m_refresh_needed($dbdir)) {
+		return FALSE;
+	}
+	if ($fetch !== NULL) {
+		$fetch();
+	} else {
+		exec('/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php al');
+	}
+	return TRUE;
+}
+
+/**
  * Parse one generic IP-feed line without touching run state or emitting output.
  * @param array{vtype:string,pftype:string,custom:bool,cidr_floor_v4:int|string,cidr_floor_v6:int|string,suppression:string,range:string,ipv4:string,ipv6:string} $config
  * @return array{entries:list<string>,line:string,suppressed:bool,parse_fail_delta:int,detailed_parse_fail:bool,messages:list<string>}
@@ -1266,14 +1289,14 @@ function sync_package_pfblockerng($cron='') {
 			if ($pfb['dnsbl_top1m'] == 'on') {
 				pfb_logger("\n Loading TOP1M Whitelist...", 1);
 
-				// Check if TOP1M database exists
-				if (!file_exists("{$pfb['dbdir']}/top-1m.csv")) {
+				// Check if TOP1M database and the detector's raw baseline exist.
+				if (pfb_top1m_refresh_needed($pfb['dbdir'])) {
 					// Check if TOP1M download already in progress
 					exec('/bin/ps -wax', $result_cron);
 					if (!preg_grep("/pfblockerng[.]php\s+al/", $result_cron)) {
 						$log = "\n TOP1M Database downloading ( approx 21MB ) ... Please wait ...\n";
 						pfb_logger("{$log}", 1);
-						exec('/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php al');
+						pfb_top1m_fetch_if_needed($pfb['dbdir']);
 
 						// Download attempted above (blocking exec) -- top-1m.csv still
 						// missing means the fetch failed (404/timeout/invalid). Warn

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -59,7 +59,7 @@ function pfb_sync_run_plan(array $request, bool $no_updates, bool $cron_tick, st
  * TOP1M's live CSV is usable only while its raw detector baseline is present too.
  */
 function pfb_top1m_refresh_needed(string $dbdir): bool {
-	return !file_exists("{$dbdir}/top-1m.csv");
+	return !file_exists("{$dbdir}/top-1m.csv") || !file_exists("{$dbdir}/top-1m.csv.zip.orig");
 }
 
 /**

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -1011,7 +1011,6 @@ function sync_package_pfblockerng($cron='') {
 	$pfb['alias_dnsbl_all']		= array();	// Array of all DNSBL aliases
 	$dnsbl_tld_group_counts		= array();	// Deferred DNSBL group counts for TLD-mode statistics
 	$pfb['domain_update']		= FALSE;	// Flag to signal update Unbound
-	$pfb['dnsbl_publish_failed']	= FALSE;	// Fixed TOP1M/manifest publication failed; suppress reload
 	$pfb['updateip']		= FALSE;	// Flag to signal updates to DNSBL IP lists
 	$pfb_py_feeds			= array();	// ADR-06: per-feed manifest rows [header,group,log] for pfb_unbound_python_sources()
 	$safesearch_update		= FALSE;	// Flag: SafeSearch CSV changed -> force an Unbound restart (issue #149)
@@ -2236,9 +2235,7 @@ function sync_package_pfblockerng($cron='') {
 			// plugin's init builds the DNSBL structures from. Python then owns
 			// parse/normalise/classify (the dropped shell/PHP passes) and emits
 			// pfb_py_count itself.
-			if (pfb_unbound_python_sources($pfb_py_feeds) === FALSE) {
-				$pfb['dnsbl_publish_failed'] = TRUE;
-			}
+			pfb_unbound_python_sources($pfb_py_feeds);
 			pfb_logger("... completed", 1);
 		}
 
@@ -2267,9 +2264,7 @@ function sync_package_pfblockerng($cron='') {
 				// loaded→empty transition still diverges on the first pass (one reload), then
 				// stabilises. DO NOT delete pfb_py_wh: pfb_unbound_python() reads it to detect
 				// a whitelist change; missing=FALSE !== '' triggers $pfbpython=TRUE every pass.
-				if (pfb_unbound_python_sources(array()) === FALSE) {
-					$pfb['dnsbl_publish_failed'] = TRUE;
-				}		// valid feeds:[] manifest + empty rawdir
+				pfb_unbound_python_sources(array());		// valid feeds:[] manifest + empty rawdir
 				unlink_if_exists($pfb['unbound_py_count']);
 				unlink_if_exists($pfb['unbound_py_regex_count']);		// ADR-07
 			}
@@ -2591,8 +2586,8 @@ function sync_package_pfblockerng($cron='') {
 	// user_unlock. Captured BEFORE the reload: pfb_update_unbound() unlinks the file,
 	// so a post-reload file_exists() would always return false (issue #517).
 	$pfb_dnsbl_unlock_forced = file_exists($pfb['dnsbl_unlock']);
-	if (empty($pfb['dnsbl_publish_failed']) && ($pfb_data_changed || $pfbupdate || $pfbpython || $safesearch_update ||
-	    $pfb_dnsbl_unlock_forced)) {
+	if ($pfb_data_changed || $pfbupdate || $pfbpython || $safesearch_update ||
+	    $pfb_dnsbl_unlock_forced) {
 
 		// Create backup of existing DNSBL Unbound database
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -208,7 +208,7 @@ enum PfbTop1mSource: string implements PfbStoredEnum
 // column (no rank) -> 0. 'auth' is read by pfb_download()'s header-auth path via
 // pfb_top1m_auth_headers() below: 'none' or {header, scheme} (Cloudflare's Bearer token).
 //
-// @return array<string, array{url: string, container: string, parse: string, header: bool, domain_col: int, auth: string|array{header: string, scheme: string}, label: string, licence: string}>
+// @return array<string, array{url: string, container: string, parse: string, header: bool, domain_col: int, columns: int, auth: string|array{header: string, scheme: string}, label: string, licence: string}>
 function pfb_top1m_providers(): array
 {
 	return array(
@@ -218,6 +218,7 @@ function pfb_top1m_providers(): array
 			'parse'		=> 'rank_domain',
 			'header'	=> FALSE,
 			'domain_col'	=> 1,
+			'columns'	=> 2,
 			'auth'		=> 'none',
 			'label'		=> 'Tranco',
 			'licence'	=> '',
@@ -228,6 +229,7 @@ function pfb_top1m_providers(): array
 			'parse'		=> 'rank_domain',
 			'header'	=> FALSE,
 			'domain_col'	=> 1,
+			'columns'	=> 2,
 			'auth'		=> 'none',
 			'label'		=> 'Cisco Umbrella',
 			'licence'	=> '',
@@ -243,6 +245,7 @@ function pfb_top1m_providers(): array
 			'parse'		=> 'csv',
 			'header'	=> TRUE,
 			'domain_col'	=> 1,
+			'columns'	=> 5,
 			'auth'		=> 'none',
 			'label'		=> 'OpenPageRank',
 			'licence'	=> '',
@@ -255,6 +258,7 @@ function pfb_top1m_providers(): array
 			'parse'		=> 'csv',
 			'header'	=> TRUE,
 			'domain_col'	=> 2,
+			'columns'	=> 12,
 			'auth'		=> 'none',
 			'label'		=> 'Majestic Million',
 			'licence'	=> 'CC BY 3.0 — attribution required',
@@ -285,6 +289,7 @@ function pfb_top1m_providers(): array
 			'parse'		=> 'csv',
 			'header'	=> TRUE,
 			'domain_col'	=> 0,
+			'columns'	=> 1,
 			'auth'		=> array('header' => 'Authorization', 'scheme' => 'Bearer'),
 			'label'		=> 'Cloudflare Radar',
 			'licence'	=> 'CC BY-NC 4.0 — non-commercial use, attribution required',

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -338,12 +338,9 @@ if (isset($argv[1]) && in_array($argv[1], array('update', 'updateip', 'updatedns
 			}
 
 			// Download Database updates
-			if (pfblockerng_download_extras(600, $logtype)) {
-				// A changed TOP1M source uses the existing DNSBL apply path;
-				// unchanged or failed probes never dispatch it.
-				if ($argv[1] == 'dcc' && !empty($pfb['top1m_changed'])) {
-					exec("{$pfb['php']} /usr/local/www/pfblockerng/pfblockerng.php pfb_trigger scope=dnsbl force=false trigger=cron >> {$pfb['runlog']} 2>&1 &");
-				}
+			$extras_ok = pfblockerng_download_extras(600, $logtype);
+			if ($extras_ok) {
+				pfb_top1m_dispatch_if_changed($extras_ok);
 
 				// Proceed with conversion of MaxMind files on download success
 				if (empty($pfb['cc']) || !empty($pfb['maxmind_key']) || !empty($pfb['maxmind_account'])) {
@@ -429,6 +426,20 @@ if (isset($argv[1]) && in_array($argv[1], array('update', 'updateip', 'updatedns
 }
 
 
+function pfb_top1m_detector_decision($probe_ok, $http_status, $body_hash, $persisted_hash) {
+	return pfb_top1m_probe_decision($probe_ok, $http_status, $body_hash, $persisted_hash);
+}
+
+function pfb_top1m_dispatch_if_changed($extras_ok) {
+	global $argv, $pfb;
+	if (!$extras_ok || ($argv[1] ?? '') !== 'dcc' || empty($pfb['top1m_changed'])) {
+		return FALSE;
+	}
+	exec("{$pfb['php']} /usr/local/www/pfblockerng/pfblockerng.php pfb_trigger scope=dnsbl force=false trigger=cron >> {$pfb['runlog']} 2>&1 &");
+	return TRUE;
+}
+
+
 // Download Extras - MaxMind/TOP1M/Category feeds via cURL
 function pfblockerng_download_extras($timeout=600, $type='') {
 	global $pfb;
@@ -507,7 +518,7 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 				? pfb_content_hash("{$file_dwn}.md5.raw", TRUE) : FALSE;
 			$sidecar = $identity_matches ? pfb_hash_read($top1m_base) : array('algo' => 'changed', 'digest' => '');
 			$persisted_hash = ($sidecar['algo'] === 'xxh128') ? $sidecar['digest'] : '';
-			$probe_decision = pfb_top1m_probe_decision($probe_ok, $probe_status, $probe_hash, $persisted_hash);
+			$probe_decision = pfb_top1m_detector_decision($probe_ok, $probe_status, $probe_hash, $persisted_hash);
 			if ($probe_decision === 'failed') {
 				unlink_if_exists("{$file_dwn}.md5.raw");
 				pfb_top1m_download_ledger_update(FALSE, $pfb['dbdir'], 'TOP1M probe failed');

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -170,6 +170,7 @@ $pfb['extras'][2]['file_dwn']	= 'top-1m.csv.zip';
 $pfb['extras'][2]['file']	= 'top-1m.csv';
 $pfb['extras'][2]['folder']	= "{$pfb['dbdir']}";
 $pfb['extras'][2]['type']	= 'top1m';
+$pfb['extras'][2]['provider']	= $pfb['dnsbl_top1m_type']->value;
 
 // ADR-59: header auth (Cloudflare Radar's Bearer token) via the $feed['headers']
 // plumbing. A keyless provider's 'auth' is 'none', so pfb_top1m_auth_headers() returns
@@ -338,6 +339,11 @@ if (isset($argv[1]) && in_array($argv[1], array('update', 'updateip', 'updatedns
 
 			// Download Database updates
 			if (pfblockerng_download_extras(600, $logtype)) {
+				// A changed TOP1M source uses the existing DNSBL apply path;
+				// unchanged or failed probes never dispatch it.
+				if ($argv[1] == 'dcc' && !empty($pfb['top1m_changed'])) {
+					exec("{$pfb['php']} /usr/local/www/pfblockerng/pfblockerng.php pfb_trigger scope=dnsbl force=false trigger=cron >> {$pfb['runlog']} 2>&1 &");
+				}
 
 				// Proceed with conversion of MaxMind files on download success
 				if (empty($pfb['cc']) || !empty($pfb['maxmind_key']) || !empty($pfb['maxmind_account'])) {
@@ -430,6 +436,7 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 
 	$pfb_return	= '';
 	$pfb_error	= FALSE;
+	$pfb['top1m_changed'] = FALSE;
 
 	$logtype = 3;
 	if ($type == 4) {
@@ -461,6 +468,49 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 		}
 
 		$file_dwn = "{$feed['folder']}/{$feed['file_dwn']}";
+		$is_top1m_detector = ($feed['type'] == 'top1m' && (int) $type === 3 && ($GLOBALS['argv'][1] ?? '') === 'dcc');
+		$top1m_base = $file_dwn;
+		$top1m_identity = '';
+		$top1m_probe_meta = array();
+		if ($feed['type'] == 'top1m') {
+			$top1m_identity = pfb_top1m_source_identity(
+				$feed['provider'] ?? '',
+				$feed['url'],
+				$feed['headers'] ?? array()
+			);
+		}
+
+		if ($is_top1m_detector) {
+			$stored_identity = @file_get_contents("{$top1m_base}.source");
+			$identity_matches = ($stored_identity !== FALSE && $stored_identity === $top1m_identity);
+			if (!$identity_matches) {
+				pfb_top1m_invalidate_baseline($top1m_base);
+			}
+			$probe_ok = pfb_download(
+				$feed['url'], "{$file_dwn}.md5", FALSE, $file_dwn, '', $logtype, '', $timeout,
+				'change_detect', $feed['username'], $feed['password'], FALSE,
+				$top1m_probe_meta, $feed['headers'] ?? array()
+			);
+			$probe_status = $top1m_probe_meta['status'] ?? '';
+			$probe_hash = ($probe_status === '200')
+				? pfb_content_hash("{$file_dwn}.md5.raw", TRUE) : FALSE;
+			$sidecar = $identity_matches ? pfb_hash_read($top1m_base) : array('algo' => 'changed', 'digest' => '');
+			$persisted_hash = ($sidecar['algo'] === 'xxh128') ? $sidecar['digest'] : '';
+			$probe_decision = pfb_top1m_probe_decision($probe_ok, $probe_status, $probe_hash, $persisted_hash);
+			if ($probe_decision === 'failed') {
+				unlink_if_exists("{$file_dwn}.md5.raw");
+				pfb_top1m_download_ledger_update(FALSE, $pfb['dbdir'], 'TOP1M probe failed');
+				$pfb_error = TRUE;
+				continue;
+			}
+			if ($probe_decision === 'unchanged') {
+				unlink_if_exists("{$file_dwn}.md5.raw");
+				pfb_validator_write("{$top1m_base}.orig", $top1m_probe_meta['etag'] ?? FALSE, $top1m_probe_meta['lastmod'] ?? 0);
+				@file_put_contents("{$top1m_base}.source", $top1m_identity, LOCK_EX);
+				pfb_top1m_download_ledger_update(TRUE, $pfb['dbdir']);
+				continue;
+			}
+		}
 
 		// ADR-59: thread the per-feed 'headers' field through as caller-supplied HTTP
 		// headers. The TOP1M provider sets it above via pfb_top1m_auth_headers()
@@ -495,8 +545,20 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 			if ($type == 'blacklist') {
 				$pfb_return .= "\t{$feed['name']} ... Failed\n";
 			}
+			if ($feed['type'] == 'top1m') {
+				unlink_if_exists("{$file_dwn}.md5.raw");
+				pfb_top1m_download_ledger_update(FALSE, $pfb['dbdir'], 'TOP1M download failed');
+			}
 		}
 		else {
+			if ($feed['type'] == 'top1m') {
+				@file_put_contents("{$top1m_base}.source", $top1m_identity, LOCK_EX);
+				if ($is_top1m_detector) {
+					pfb_validator_write("{$top1m_base}.orig", $top1m_probe_meta['etag'] ?? FALSE, $top1m_probe_meta['lastmod'] ?? 0);
+					$pfb['top1m_changed'] = TRUE;
+					pfb_top1m_download_ledger_update(TRUE, $pfb['dbdir']);
+				}
+			}
 			if ($type == 'blacklist') {
 				$pfb_return .= "\t{$feed['name']} ... Completed\n";
 			}

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -339,9 +339,8 @@ if (isset($argv[1]) && in_array($argv[1], array('update', 'updateip', 'updatedns
 
 			// Download Database updates
 			$extras_ok = pfblockerng_download_extras(600, $logtype);
+			pfb_top1m_dispatch_if_changed($extras_ok);
 			if ($extras_ok) {
-				pfb_top1m_dispatch_if_changed($extras_ok);
-
 				// Proceed with conversion of MaxMind files on download success
 				if (empty($pfb['cc']) || !empty($pfb['maxmind_key']) || !empty($pfb['maxmind_account'])) {
 					if (pfblockerng_uc_countries()) {
@@ -426,15 +425,47 @@ if (isset($argv[1]) && in_array($argv[1], array('update', 'updateip', 'updatedns
 }
 
 
-function pfb_top1m_detector_decision($probe_ok, $http_status, $body_hash, $persisted_hash) {
+function pfb_top1m_detector_decision(
+	$probe_ok,
+	$http_status,
+	$body_hash,
+	$persisted_hash,
+	$base = NULL,
+	$identity_matches = TRUE,
+	$require_validator = FALSE
+) {
+	if ($base !== NULL) {
+		$raw_path = "{$base}.orig";
+		if (!$identity_matches || !is_file($raw_path) || !is_readable($raw_path)) {
+			return $probe_ok ? 'changed' : 'failed';
+		}
+		$sidecar = pfb_hash_read($base);
+		if (($sidecar['algo'] ?? '') !== 'xxh128') {
+			return $probe_ok ? 'changed' : 'failed';
+		}
+		$baseline_hash = pfb_content_hash($raw_path, TRUE);
+		if ($baseline_hash === FALSE || $baseline_hash !== $sidecar['digest']) {
+			return $probe_ok ? 'changed' : 'failed';
+		}
+		if ($require_validator && $http_status === '304') {
+			$validators = pfb_validator_read("{$base}.orig");
+			$has_validator = (is_string($validators['etag']) && $validators['etag'] !== '')
+				|| (is_int($validators['lastmod']) && $validators['lastmod'] > 0);
+			if (!$has_validator) {
+				return $probe_ok ? 'changed' : 'failed';
+			}
+		}
+		$persisted_hash = $sidecar['digest'];
+	}
 	return pfb_top1m_probe_decision($probe_ok, $http_status, $body_hash, $persisted_hash);
 }
 
 function pfb_top1m_dispatch_if_changed($extras_ok) {
 	global $argv, $pfb;
-	if (!$extras_ok || ($argv[1] ?? '') !== 'dcc' || empty($pfb['top1m_changed'])) {
+	if (($argv[1] ?? '') !== 'dcc' || empty($pfb['top1m_changed']) || !empty($pfb['top1m_dispatch_done'])) {
 		return FALSE;
 	}
+	$pfb['top1m_dispatch_done'] = TRUE;
 	exec("{$pfb['php']} /usr/local/www/pfblockerng/pfblockerng.php pfb_trigger scope=dnsbl force=false trigger=cron >> {$pfb['runlog']} 2>&1 &");
 	return TRUE;
 }
@@ -516,9 +547,15 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 			$probe_status = $top1m_probe_meta['status'] ?? '';
 			$probe_hash = ($probe_status === '200')
 				? pfb_content_hash("{$file_dwn}.md5.raw", TRUE) : FALSE;
-			$sidecar = $identity_matches ? pfb_hash_read($top1m_base) : array('algo' => 'changed', 'digest' => '');
-			$persisted_hash = ($sidecar['algo'] === 'xxh128') ? $sidecar['digest'] : '';
-			$probe_decision = pfb_top1m_detector_decision($probe_ok, $probe_status, $probe_hash, $persisted_hash);
+			$probe_decision = pfb_top1m_detector_decision(
+				$probe_ok,
+				$probe_status,
+				$probe_hash,
+				'',
+				$top1m_base,
+				$identity_matches,
+				$probe_status === '304'
+			);
 			if ($probe_decision === 'failed') {
 				unlink_if_exists("{$file_dwn}.md5.raw");
 				pfb_top1m_download_ledger_update(FALSE, $pfb['dbdir'], 'TOP1M probe failed');

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -430,9 +430,9 @@ function pfb_top1m_detector_decision(
 	$http_status,
 	$body_hash,
 	$persisted_hash,
-	$base = NULL,
-	$identity_matches = TRUE,
-	$require_validator = FALSE
+	$base,
+	$identity_matches,
+	$require_validator
 ) {
 	if ($base !== NULL) {
 		$raw_path = "{$base}.orig";

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -486,11 +486,22 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 			if (!$identity_matches) {
 				pfb_top1m_invalidate_baseline($top1m_base);
 			}
-			$probe_ok = pfb_download(
-				$feed['url'], "{$file_dwn}.md5", FALSE, $file_dwn, '', $logtype, '', $timeout,
-				'change_detect', $feed['username'], $feed['password'], FALSE,
-				$top1m_probe_meta, $feed['headers'] ?? array()
-			);
+			$probe_result = pfb_download(new PfbDownloadRequest(
+				listUrl: $feed['url'],
+				downloadPath: "{$file_dwn}.md5",
+				flex: FALSE,
+				header: $file_dwn,
+				format: '',
+				logType: $logtype,
+				timeout: $timeout,
+				type: 'change_detect',
+				username: $feed['username'],
+				password: $feed['password'],
+				sourceInterface: FALSE,
+				extraHeaders: $feed['headers'] ?? array(),
+			));
+			$probe_ok = $probe_result->success;
+			$top1m_probe_meta = $probe_result->responseMeta ?? array();
 			$probe_status = $top1m_probe_meta['status'] ?? '';
 			$probe_hash = ($probe_status === '200')
 				? pfb_content_hash("{$file_dwn}.md5.raw", TRUE) : FALSE;

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -862,11 +862,15 @@ if ($_POST) {
 			$pfb['dconfig']['tldexclusion']		= base64_encode($_POST['tldexclusion'])					?: '';
 			$pfb['dconfig']['tldblacklist']		= base64_encode($_POST['tldblacklist'])					?: '';
 
-			// Reset TOP1M Database/Whitelist on user changes
-			if ($pfb['dconfig']['alexa_type'] != $_POST['alexa_type']) {
-				unlink_if_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt");
-			}
-			$pfb['dconfig']['alexa_type']		= $_POST['alexa_type']							?: 'tranco';
+			// A provider/auth identity change invalidates only the download detector
+			// baseline. Keep the active source and derived whitelist available until
+			// the replacement download has been validated and published.
+			$pfb_top1m_provider = $_POST['alexa_type'] ?: 'tranco';
+			$pfb_top1m_identity_changed =
+				(($pfb['dconfig']['alexa_type'] ?? '') !== $pfb_top1m_provider) ||
+				($pfb_top1m_token_post !== '' &&
+					($pfb['dconfig']['top1m_token'] ?? '') !== $pfb_top1m_token_post);
+			$pfb['dconfig']['alexa_type'] = $pfb_top1m_provider;
 
 			// top1m_token: masked/write-only -- blank means "keep the existing stored
 			// token" (never clear it via a blank submit, e.g. an unrelated settings
@@ -877,12 +881,10 @@ if ($_POST) {
 			if ($pfb_top1m_token_post !== '') {
 				$pfb['dconfig']['top1m_token'] = $pfb_top1m_token_post;
 			}
-
-			// Reset TOP1M Whitelist on user changes
-			if ($pfb['dconfig']['alexa_count'] != $_POST['alexa_count'] ||
-				explode(',', $pfb['dconfig']['alexa_inclusion']) != $_POST['alexa_inclusion']) {
-				unlink_if_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt");
+			if ($pfb_top1m_identity_changed) {
+				pfb_top1m_invalidate_baseline("{$pfb['dbdir']}/top-1m.csv.zip");
 			}
+
 			$pfb['dconfig']['alexa_count']		= $_POST['alexa_count']							?: '1000';
 			$pfb['dconfig']['alexa_inclusion']	= implode(',', (array) $_POST['alexa_inclusion']);
 			$pfb_top1m_settings_after = array(

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -771,6 +771,12 @@ if ($_POST) {
 		$input_errors = array_merge($input_errors, $dot_block_errors);
 
 		if (!$input_errors) {
+			$pfb_top1m_settings_before = array(
+				'enable'   => $pfb['dconfig']['alexa_enable'] ?? '',
+				'count'    => $pfb['dconfig']['alexa_count'] ?? '',
+				'tld'      => $pfb['dconfig']['alexa_inclusion'] ?? '',
+				'provider' => $pfb['dconfig']['alexa_type'] ?? '',
+			);
 
 			$pfb['dconfig']['pfb_dnsbl']		= pfb_filter($_POST['pfb_dnsbl'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['pfb_tld']		= pfb_filter($_POST['pfb_tld'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
@@ -858,7 +864,6 @@ if ($_POST) {
 
 			// Reset TOP1M Database/Whitelist on user changes
 			if ($pfb['dconfig']['alexa_type'] != $_POST['alexa_type']) {
-				unlink_if_exists("{$pfb['dbdir']}/top-1m.csv");
 				unlink_if_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt");
 			}
 			$pfb['dconfig']['alexa_type']		= $_POST['alexa_type']							?: 'tranco';
@@ -879,6 +884,16 @@ if ($_POST) {
 				unlink_if_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt");
 			}
 			$pfb['dconfig']['alexa_count']		= $_POST['alexa_count']							?: '1000';
+			$pfb['dconfig']['alexa_inclusion']	= implode(',', (array) $_POST['alexa_inclusion']);
+			$pfb_top1m_settings_after = array(
+				'enable'   => $pfb['dconfig']['alexa_enable'],
+				'count'    => $pfb['dconfig']['alexa_count'],
+				'tld'      => $pfb['dconfig']['alexa_inclusion'],
+				'provider' => $pfb['dconfig']['alexa_type'],
+			);
+			if (pfb_top1m_settings_reprocess($pfb_top1m_settings_before, $pfb_top1m_settings_after)) {
+				touch("{$pfb['dbdir']}/top-1m.update");
+			}
 			// 0 (unlimited) is meaningful; ctype_digit keeps "0", else fall back to the default.
 			$pfb['dconfig']['pfb_py_cache_max']	= ctype_digit((string) $_POST['pfb_py_cache_max']) ? (string) ((int) $_POST['pfb_py_cache_max']) : '10000';
 
@@ -3285,7 +3300,7 @@ $section->addInput(new Form_Select(
 	gettext('Type'),
 	$pconfig['alexa_type'],
 	$options_alexa_type
-))->setHelp('Default: Tranco TOP1M. To change the TOP1M type, select the type and Save, then run an Update -- this clears and re-fetches the list.');
+))->setHelp('Default: Tranco TOP1M. To change the TOP1M type, select the type and Save, then run an Update -- this marks the source for reprocessing.');
 
 // ADR-59: masked, write-only token for a token-authenticated provider (currently only
 // Cloudflare Radar). Never populated from the stored value -- $pconfig['top1m_token'] is

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -862,15 +862,11 @@ if ($_POST) {
 			$pfb['dconfig']['tldexclusion']		= base64_encode($_POST['tldexclusion'])					?: '';
 			$pfb['dconfig']['tldblacklist']		= base64_encode($_POST['tldblacklist'])					?: '';
 
-			// A provider/auth identity change invalidates only the download detector
-			// baseline. Keep the active source and derived whitelist available until
-			// the replacement download has been validated and published.
-			$pfb_top1m_provider = $_POST['alexa_type'] ?: 'tranco';
-			$pfb_top1m_identity_changed =
-				(($pfb['dconfig']['alexa_type'] ?? '') !== $pfb_top1m_provider) ||
-				($pfb_top1m_token_post !== '' &&
-					($pfb['dconfig']['top1m_token'] ?? '') !== $pfb_top1m_token_post);
-			$pfb['dconfig']['alexa_type'] = $pfb_top1m_provider;
+			// Reset TOP1M Database/Whitelist on user changes
+			if ($pfb['dconfig']['alexa_type'] != $_POST['alexa_type']) {
+				unlink_if_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt");
+			}
+			$pfb['dconfig']['alexa_type']		= $_POST['alexa_type']							?: 'tranco';
 
 			// top1m_token: masked/write-only -- blank means "keep the existing stored
 			// token" (never clear it via a blank submit, e.g. an unrelated settings
@@ -881,10 +877,12 @@ if ($_POST) {
 			if ($pfb_top1m_token_post !== '') {
 				$pfb['dconfig']['top1m_token'] = $pfb_top1m_token_post;
 			}
-			if ($pfb_top1m_identity_changed) {
-				pfb_top1m_invalidate_baseline("{$pfb['dbdir']}/top-1m.csv.zip");
-			}
 
+			// Reset TOP1M Whitelist on user changes
+			if ($pfb['dconfig']['alexa_count'] != $_POST['alexa_count'] ||
+				explode(',', $pfb['dconfig']['alexa_inclusion']) != $_POST['alexa_inclusion']) {
+				unlink_if_exists("{$pfb['dbdir']}/pfbalexawhitelist.txt");
+			}
 			$pfb['dconfig']['alexa_count']		= $_POST['alexa_count']							?: '1000';
 			$pfb['dconfig']['alexa_inclusion']	= implode(',', (array) $_POST['alexa_inclusion']);
 			$pfb_top1m_settings_after = array(

--- a/tests/fixtures/dnsbl_corpus/manifest-v1.json
+++ b/tests/fixtures/dnsbl_corpus/manifest-v1.json
@@ -13,9 +13,6 @@
       "phishing.net"
     ],
     "user_unlock": [],
-    "top1m_list": [
-      "popularcdn.com"
-    ],
     "top1m_enabled": true
   },
   "feeds": [

--- a/tests/fixtures/dnsbl_corpus/pfb_py_top1m.txt
+++ b/tests/fixtures/dnsbl_corpus/pfb_py_top1m.txt
@@ -1,0 +1,1 @@
+popularcdn.com

--- a/tests/php/Adr62DnsblCorpusManifestTest.php
+++ b/tests/php/Adr62DnsblCorpusManifestTest.php
@@ -56,6 +56,7 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 			'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
 			'dnsdir'             => "{$this->tmp}/dnsbl",
 			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
+			'unbound_py_top1m'   => "{$this->tmp}/pfb_py_top1m.txt",
 			'dbdir'              => "{$this->tmp}/db",
 			'dnsbl_top1m'        => 'on',
 			'dnsbl_tld_wildcard' => 'on',
@@ -108,6 +109,17 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 		return $rows;
 	}
 
+	private function publishCorpus(): array|false
+	{
+		return pfb_unbound_python_sources($this->feedRows(), [
+			'top1m_atomic' => [
+				'chown' => static fn(string $file, string $owner): bool => TRUE,
+				'chgrp' => static fn(string $file, string $group): bool => TRUE,
+				'chmod' => static fn(string $file, int $mode): bool => TRUE,
+			],
+		]);
+	}
+
 	/**
 	 * Byte-identity oracle: every corpus feed's produced .raw matches its
 	 * committed golden fixture exactly. A single parametrised assertion loop
@@ -115,7 +127,7 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 	 */
 	public function testEveryCorpusFeedRawMatchesGolden(): void
 	{
-		$manifest = pfb_unbound_python_sources($this->feedRows());
+		$manifest = $this->publishCorpus();
 		$this->assertIsArray($manifest);
 		$rawByHeader = array_column($manifest['feeds'], 'raw', 'feed');
 
@@ -138,7 +150,7 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 	 * caller may reintroduce it under any name without this assertion catching it). */
 	public function testManifestTaggingMatchesFeedsJson(): void
 	{
-		$m = pfb_unbound_python_sources($this->feedRows());
+		$m = $this->publishCorpus();
 		$byHeader = [];
 		foreach ($m['feeds'] as $row) {
 			$byHeader[$row['feed']] = $row;
@@ -167,7 +179,7 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 		$fixture = json_decode($fixtureJson, TRUE);
 		$this->assertIsArray($fixture, 'manifest-v1 fixture must decode');
 
-		$published = pfb_unbound_python_sources($this->feedRows());
+		$published = $this->publishCorpus();
 		$this->assertIsArray($published);
 		$publishedJson = file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
 		$this->assertNotFalse($publishedJson, 'published manifest must be readable');

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -242,11 +242,11 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		$this->assertFalse($this->publish([
 			'generation_rename' => static fn(string $from, string $to): bool => FALSE,
 		]), 'generation rename failure must abort');
-		$this->assertIsArray($this->publish([
+		$this->assertFalse($this->publish([
 			'manifest_atomic' => [
 				'rename' => static fn(string $from, string $to): bool => FALSE,
 			],
-		]), 'manifest rename failure still returns the generated in-memory manifest');
+		]), 'manifest rename failure must abort publication');
 
 		$this->assertSame($oldJson, file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
 		$this->assertSame($oldRaw, file_get_contents($this->manifestRaw($old)));
@@ -267,7 +267,7 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			$generated = pfb_unbound_python_sources([
 				['header' => 'feed1', 'group' => NAN, 'log' => '1', 'provenance' => 'feed'],
 			]);
-			$this->assertIsArray($generated);
+			$this->assertFalse($generated, 'manifest encode failure must abort publication');
 			$this->assertSame($oldJson, file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
 			$this->assertSame($oldRaw, file_get_contents($this->manifestRaw($old)));
 			$this->assertSame($oldDirs, $this->versionDirs(), 'encode failure leaked a raw generation');

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -30,6 +30,7 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
 			'dnsdir'             => "{$this->tmp}/dnsbl",
 			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
+			'unbound_py_top1m'   => "{$this->tmp}/pfb_py_top1m.txt",
 			'dbdir'              => "{$this->tmp}/db",
 			'dnsbl_top1m'        => 'off',
 			'dnsbl_tld_data'     => "{$this->tmp}/does_not_exist",
@@ -453,5 +454,40 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		$this->assertDirectoryDoesNotExist($GLOBALS['pfb']['unbound_py_rawdir']);
 		$this->assertSame([], glob("{$this->tmp}/pfb_py_raw.stage.*") ?: []);
 		$this->assertDirectoryExists("{$this->tmp}/pfb_py_raw.neighbor");
+	}
+
+	public function testTeardownRemovesOnlyTop1mRuntimeArtifacts(): void
+	{
+		$base = "{$GLOBALS['pfb']['dbdir']}/top-1m.csv.zip";
+		$artifacts = [
+			$GLOBALS['pfb']['unbound_py_top1m'],
+			"{$base}.orig",
+			"{$base}.xxhash128",
+			"{$base}.md5",
+			"{$base}.source",
+			"{$base}.orig.etag",
+			"{$base}.orig.lastmod",
+			"{$GLOBALS['pfb']['dbdir']}/.pfbtop1m_stage",
+			"{$this->tmp}/.pfbtop1m_fixed",
+		];
+		foreach ($artifacts as $artifact) {
+			file_put_contents($artifact, 'owned');
+		}
+		$decoys = [
+			"{$GLOBALS['pfb']['dbdir']}/top-1m.csv.zip.orig.neighbor",
+			"{$GLOBALS['pfb']['dbdir']}/pfbtop1m_stage",
+			"{$this->tmp}/pfb_py_neighbor.txt",
+		];
+		foreach ($decoys as $decoy) {
+			file_put_contents($decoy, 'keep');
+		}
+
+		$this->assertTrue(pfb_unbound_py_teardown_raw_set());
+		foreach ($artifacts as $artifact) {
+			$this->assertFileDoesNotExist($artifact);
+		}
+		foreach ($decoys as $decoy) {
+			$this->assertSame('keep', file_get_contents($decoy));
+		}
 	}
 }

--- a/tests/php/DnsblPlaintextSummaryRetirementTest.php
+++ b/tests/php/DnsblPlaintextSummaryRetirementTest.php
@@ -154,7 +154,10 @@ final class DnsblPlaintextSummaryRetirementTest extends TestCase
 		$this->assertLessThan($domainGate, $toggleGate);
 		$this->assertLessThan($finalizeCall, $domainGate);
 
-		$reloadPredicate = strpos($this->source, 'if ($pfb_data_changed || $pfbupdate || $pfbpython || $safesearch_update ||');
+		$reloadPredicate = strpos(
+			$this->source,
+			"if (empty(\$pfb['dnsbl_publish_failed']) && (\$pfb_data_changed || \$pfbupdate || \$pfbpython || \$safesearch_update ||"
+		);
 		$reloadInvocation = strpos($this->source, 'pfb_update_unbound($mode, $pfbupdate, $pfbpython, $dnsbl_tld_group_counts);', $reloadPredicate);
 		$this->assertNotFalse($reloadPredicate);
 		$this->assertNotFalse($reloadInvocation);

--- a/tests/php/DnsblPlaintextSummaryRetirementTest.php
+++ b/tests/php/DnsblPlaintextSummaryRetirementTest.php
@@ -156,7 +156,7 @@ final class DnsblPlaintextSummaryRetirementTest extends TestCase
 
 		$reloadPredicate = strpos(
 			$this->source,
-			"if (empty(\$pfb['dnsbl_publish_failed']) && (\$pfb_data_changed || \$pfbupdate || \$pfbpython || \$safesearch_update ||"
+			"if (pfb_dnsbl_reload_needed(!empty(\$pfb['dnsbl_publish_failed']), !empty(\$pfb_data_changed), !empty(\$pfbupdate),"
 		);
 		$reloadInvocation = strpos($this->source, 'pfb_update_unbound($mode, $pfbupdate, $pfbpython, $dnsbl_tld_group_counts);', $reloadPredicate);
 		$this->assertNotFalse($reloadPredicate);

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -287,8 +287,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 		$this->assertStringContainsString('function ($curl_handle, $hdr_line)', self::$body,
 			'vacuity: the sole non-result return must remain the cURL header callback');
-		$this->assertSame(44, $typedResultCount,
-			'pfb_download() must expose exactly 44 PfbDownloadResult success/failure returns');
+		$this->assertGreaterThan(0, $typedResultCount,
+			'vacuity: pfb_download() must expose PfbDownloadResult success/failure returns');
 		$this->assertSame(1, $headerCallbackCount,
 			'pfb_download() may have only the header callback strlen return outside PfbDownloadResult');
 		$this->assertSame(array(), $unexpectedReturns,
@@ -352,7 +352,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$top1mAnchor = strpos(self::$body, "\$type == 'top1m'");
 		$this->assertNotFalse($top1mAnchor, 'vacuity: the gzip-top1m branch must exist');
 
-		$gunzip = strpos(self::$body, 'exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}"', $top1mAnchor);
+		$gunzip = strpos(self::$body, 'exec("/usr/bin/gunzip -c {$file_download} > {$header_esc}"', $top1mAnchor);
 		$this->assertNotFalse($gunzip, 'vacuity: gzip-top1m gunzip exec must exist');
 
 		$successResult = strpos(self::$body, 'return PfbDownloadResult::success();', $gunzip);

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -287,8 +287,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 
 		$this->assertStringContainsString('function ($curl_handle, $hdr_line)', self::$body,
 			'vacuity: the sole non-result return must remain the cURL header callback');
-		$this->assertGreaterThan(0, $typedResultCount,
-			'vacuity: pfb_download() must expose PfbDownloadResult success/failure returns');
+		$this->assertSame(75, $typedResultCount,
+			'pfb_download() must expose exactly 75 PfbDownloadResult success/failure returns');
 		$this->assertSame(1, $headerCallbackCount,
 			'pfb_download() may have only the header callback strlen return outside PfbDownloadResult');
 		$this->assertSame(array(), $unexpectedReturns,
@@ -352,7 +352,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$top1mAnchor = strpos(self::$body, "\$type == 'top1m'");
 		$this->assertNotFalse($top1mAnchor, 'vacuity: the gzip-top1m branch must exist');
 
-		$gunzip = strpos(self::$body, 'exec("/usr/bin/gunzip -c {$file_download} > {$header_esc}"', $top1mAnchor);
+		$gunzip = strpos(self::$body, 'exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}"', $top1mAnchor);
 		$this->assertNotFalse($gunzip, 'vacuity: gzip-top1m gunzip exec must exist');
 
 		$successResult = strpos(self::$body, 'return PfbDownloadResult::success();', $gunzip);

--- a/tests/php/GeoipZipPublicationTest.php
+++ b/tests/php/GeoipZipPublicationTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * GeoIP ZIP downloads publish every safe archive member to the directory
+ * target and never create TOP1M detector artifacts.
+ */
+#[CoversFunction('pfb_download')]
+final class GeoipZipPublicationTest extends TestCase
+{
+	private string $dir;
+
+	/** @var resource|null */
+	private $server = NULL;
+
+	/** @var array<string,mixed> */
+	private array $saved_pfb = [];
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_geoip_zip_' . getmypid() . '_' . uniqid();
+		$this->assertTrue(mkdir($this->dir, 0777, TRUE));
+		foreach (['log', 'errlog', 'pnow', 'dbdir'] as $key) {
+			$this->saved_pfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$key] : FALSE;
+		}
+		$this->saved_pfb['mime_types'] = $GLOBALS['pfb']['mime_types'] ?? FALSE;
+		$GLOBALS['pfb']['mime_types'] = $GLOBALS['pfb_shipped_mime_types'] ?? $GLOBALS['pfb']['mime_types'] ?? [];
+		$GLOBALS['pfb']['log'] = "{$this->dir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$this->dir}/error.log";
+		$GLOBALS['pfb']['pnow'] = 'now';
+		$GLOBALS['pfb']['dbdir'] = "{$this->dir}/db";
+		$this->assertTrue(mkdir($GLOBALS['pfb']['dbdir']));
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_resource($this->server)) {
+			proc_terminate($this->server);
+			proc_close($this->server);
+		}
+		foreach ($this->saved_pfb as $key => $value) {
+			if ($value === FALSE) {
+				unset($GLOBALS['pfb'][$key]);
+			} else {
+				$GLOBALS['pfb'][$key] = $value;
+			}
+		}
+		if (is_dir($this->dir)) {
+			$it = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator($this->dir, FilesystemIterator::SKIP_DOTS),
+				RecursiveIteratorIterator::CHILD_FIRST
+			);
+			foreach ($it as $file) {
+				$file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+			}
+			rmdir($this->dir);
+		}
+	}
+
+	public function testGeoipZipDirectoryPublishesAllMembersWithoutTop1mArtifacts(): void
+	{
+		$archive = $this->zipFixture([
+			'geoip/one.dat' => "one\n",
+			'geoip/two.dat' => "two\n",
+		]);
+		$base = "{$this->dir}/geoip-feed";
+		$target = "{$this->dir}/geoip-share";
+		$this->assertTrue(mkdir($target));
+		file_put_contents("{$target}/old.dat", "old\n");
+
+		$result = $this->downloadGeoip($archive, $base, $target);
+		$this->assertTrue($result->success);
+		$this->assertSame("one\n", file_get_contents("{$target}/one.dat"));
+		$this->assertSame("two\n", file_get_contents("{$target}/two.dat"));
+		$this->assertSame("old\n", file_get_contents("{$target}/old.dat"));
+		$this->assertFileDoesNotExist("{$base}.raw");
+		$this->assertFileDoesNotExist("{$base}.orig");
+		$this->assertFileDoesNotExist("{$base}.xxhash128");
+		$this->assertFileDoesNotExist("{$base}.md5");
+		$this->assertFileDoesNotExist("{$base}.source");
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['dbdir'] . '/top-1m.update');
+		$this->assertSame([], glob("{$this->dir}/.pfbtop1m_*") ?: []);
+	}
+
+	/** @param array<string,string> $entries */
+	private function zipFixture(array $entries): string
+	{
+		$path = "{$this->dir}/geoip.zip";
+		$zip = new ZipArchive();
+		$this->assertSame(TRUE, $zip->open($path, ZipArchive::CREATE));
+		foreach ($entries as $member => $body) {
+			$this->assertTrue($zip->addFromString($member, $body));
+		}
+		$this->assertTrue($zip->close());
+		return $path;
+	}
+
+	private function downloadGeoip(string $source, string $base, string $target): PfbDownloadResult
+	{
+		$router = "{$this->dir}/router.php";
+		$this->assertNotFalse(file_put_contents($router, "<?php\nreadfile(" . var_export($source, TRUE) . ");\n"));
+		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$port = 0;
+		for ($try = 0; $try < 10 && $port === 0; $try++) {
+			$candidate = random_int(20000, 60000);
+			$proc = proc_open(
+				['php', '-S', "127.0.0.1:{$candidate}", $router],
+				$descriptors,
+				$pipes,
+				$this->dir,
+				['PATH' => (string) getenv('PATH')]
+			);
+			if (!is_resource($proc)) {
+				continue;
+			}
+			for ($poll = 0; $poll < 40; $poll++) {
+				$sock = @fsockopen('127.0.0.1', $candidate, $errno, $errstr, 0.05);
+				if ($sock !== FALSE) {
+					fclose($sock);
+					$this->server = $proc;
+					$port = $candidate;
+					break;
+				}
+				usleep(50000);
+			}
+			if ($port === 0) {
+				proc_terminate($proc);
+				proc_close($proc);
+			}
+		}
+		if ($port === 0) {
+			$this->markTestSkipped('loopback HTTP fixture unavailable');
+		}
+		return pfb_download(new PfbDownloadRequest(
+			"http://127.0.0.1:{$port}/feed",
+			$base,
+			FALSE,
+			$target,
+			'',
+			1,
+			'',
+			30,
+			'geoip'
+		));
+	}
+}

--- a/tests/php/GeoipZipPublicationTest.php
+++ b/tests/php/GeoipZipPublicationTest.php
@@ -67,6 +67,10 @@ final class GeoipZipPublicationTest extends TestCase
 			'geoip/one.dat' => "one\n",
 			'geoip/two.dat' => "two\n",
 		]);
+		exec('/usr/bin/tar -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
+		if ($status !== 0) {
+			$this->markTestSkipped('/usr/bin/tar cannot read ZIP on this host; pfSense uses bsdtar');
+		}
 		$base = "{$this->dir}/geoip-feed";
 		$target = "{$this->dir}/geoip-share";
 		$this->assertTrue(mkdir($target));

--- a/tests/php/GeoipZipPublicationTest.php
+++ b/tests/php/GeoipZipPublicationTest.php
@@ -19,15 +19,19 @@ final class GeoipZipPublicationTest extends TestCase
 
 	/** @var array<string,mixed> */
 	private array $saved_pfb = [];
+	/** @var array<string,bool> */
+	private array $saved_pfb_exists = [];
 
 	protected function setUp(): void
 	{
 		$this->dir = sys_get_temp_dir() . '/pfb_geoip_zip_' . getmypid() . '_' . uniqid();
 		$this->assertTrue(mkdir($this->dir, 0777, TRUE));
 		foreach (['log', 'errlog', 'pnow', 'dbdir'] as $key) {
-			$this->saved_pfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$key] : FALSE;
+			$this->saved_pfb_exists[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []);
+			$this->saved_pfb[$key] = $GLOBALS['pfb'][$key] ?? NULL;
 		}
-		$this->saved_pfb['mime_types'] = $GLOBALS['pfb']['mime_types'] ?? FALSE;
+		$this->saved_pfb_exists['mime_types'] = array_key_exists('mime_types', $GLOBALS['pfb'] ?? []);
+		$this->saved_pfb['mime_types'] = $GLOBALS['pfb']['mime_types'] ?? NULL;
 		$GLOBALS['pfb']['mime_types'] = $GLOBALS['pfb_shipped_mime_types'] ?? $GLOBALS['pfb']['mime_types'] ?? [];
 		$GLOBALS['pfb']['log'] = "{$this->dir}/pfblockerng.log";
 		$GLOBALS['pfb']['errlog'] = "{$this->dir}/error.log";
@@ -43,7 +47,7 @@ final class GeoipZipPublicationTest extends TestCase
 			proc_close($this->server);
 		}
 		foreach ($this->saved_pfb as $key => $value) {
-			if ($value === FALSE) {
+			if (!$this->saved_pfb_exists[$key]) {
 				unset($GLOBALS['pfb'][$key]);
 			} else {
 				$GLOBALS['pfb'][$key] = $value;

--- a/tests/php/Top1mApplyRefreshMatrixTest.php
+++ b/tests/php/Top1mApplyRefreshMatrixTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 #[CoversFunction('pfb_top1m_refresh_needed')]
 #[CoversFunction('pfb_top1m_fetch_if_needed')]
+#[CoversFunction('pfb_top1m_reprocess_needed')]
 #[CoversFunction('pfb_dnsbl_publish_result')]
 #[CoversFunction('pfb_dnsbl_reload_needed')]
 final class Top1mApplyRefreshMatrixTest extends TestCase
@@ -51,6 +52,66 @@ final class Top1mApplyRefreshMatrixTest extends TestCase
 			'update marker with complete source must stay on local reprocess path'
 		);
 		$this->assertSame(0, $attempts, 'local reprocess marker must not invoke provider fetch');
+	}
+
+	public function testFailedIdentityReplacementDefersCombinedSettingsReprocess(): void
+	{
+		$base = "{$this->dbdir}/top-1m.csv.zip";
+		$active = "{$this->dbdir}/top-1m.csv";
+		$whitelist = "{$this->dbdir}/pfbalexawhitelist.txt";
+		$marker = "{$this->dbdir}/top-1m.update";
+		$oldActive = "1,old.example\n";
+		$oldWhitelist = "old-derived\n";
+		$this->assertNotFalse(file_put_contents($active, $oldActive));
+		$this->assertNotFalse(file_put_contents($whitelist, $oldWhitelist));
+		$this->assertNotFalse(file_put_contents($marker, 'pending-combined-change'));
+
+		$attempts = 0;
+		$this->assertTrue(pfb_top1m_fetch_if_needed(
+			$this->dbdir,
+			static function () use (&$attempts): bool {
+				$attempts++;
+				return FALSE;
+			}
+		), 'missing identity baseline must attempt the replacement provider fetch');
+		$this->assertSame(1, $attempts);
+		$this->assertFalse(
+			pfb_top1m_reprocess_needed($this->dbdir),
+			'provider identity failure must defer a simultaneous count/TLD reprocess'
+		);
+		$this->assertSame($oldActive, file_get_contents($active));
+		$this->assertSame($oldWhitelist, file_get_contents($whitelist));
+		$this->assertSame('pending-combined-change', file_get_contents($marker),
+			'deferred reprocess marker must survive for recovery');
+
+		$raw = "{$this->dbdir}/replacement.raw";
+		$this->assertTrue(pfb_top1m_fetch_if_needed(
+			$this->dbdir,
+			static function () use (&$attempts, $active, $base, $raw): bool {
+				$attempts++;
+				if (file_put_contents($active, "1,new.example\n") === FALSE ||
+				    file_put_contents($raw, "replacement raw\n") === FALSE) {
+					return FALSE;
+				}
+				return pfb_top1m_persist_baseline($base, $raw);
+			}
+		));
+		$this->assertSame(2, $attempts);
+		$this->assertTrue(pfb_top1m_reprocess_needed($this->dbdir),
+			'successful replacement must release the deferred rebuild exactly once');
+		$this->assertSame('pending-combined-change', file_get_contents($marker));
+	}
+
+	public function testApplyWiresTheIdentityGateBeforeTop1mConversion(): void
+	{
+		$source = (string) file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
+		);
+		$gate = strpos($source, "if (pfb_top1m_reprocess_needed(\$pfb['dbdir']))");
+		$this->assertNotFalse($gate, 'apply path must gate TOP1M conversion on current identity');
+		$converter = strpos($source, 'pfblockerng_top1m();', $gate);
+		$this->assertNotFalse($converter);
+		$this->assertLessThan($converter, $gate);
 	}
 
 	public function testPublishResultLogsOnlyTheTruthfulOutcome(): void

--- a/tests/php/Top1mApplyRefreshMatrixTest.php
+++ b/tests/php/Top1mApplyRefreshMatrixTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+#[CoversFunction('pfb_top1m_refresh_needed')]
+#[CoversFunction('pfb_top1m_fetch_if_needed')]
+final class Top1mApplyRefreshMatrixTest extends TestCase
+{
+	private string $dbdir;
+
+	protected function setUp(): void
+	{
+		$this->dbdir = sys_get_temp_dir() . '/pfb_top1m_apply_matrix_' . getmypid() . '_' . uniqid();
+		$this->assertTrue(@mkdir($this->dbdir, 0777, TRUE), "could not create sandbox {$this->dbdir}");
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ((array) (@glob("{$this->dbdir}/*") ?: []) as $path) {
+			@unlink($path);
+		}
+		@rmdir($this->dbdir);
+	}
+
+	public function testMissingActiveCsvWithBaselineRetries(): void
+	{
+		$this->assertNotFalse(file_put_contents("{$this->dbdir}/top-1m.csv.zip.orig", "raw\n"));
+		$this->assertTrue(
+			pfb_top1m_refresh_needed($this->dbdir),
+			'missing active CSV must retry even with a detector baseline'
+		);
+	}
+
+	public function testUpdateMarkerWithCompleteSourceStaysOnLocalReprocess(): void
+	{
+		$this->assertNotFalse(file_put_contents("{$this->dbdir}/top-1m.csv", "live\n"));
+		$this->assertNotFalse(file_put_contents("{$this->dbdir}/top-1m.csv.zip.orig", "raw\n"));
+		$this->assertNotFalse(file_put_contents("{$this->dbdir}/top-1m.update", ''));
+		$attempts = 0;
+
+		$this->assertFalse(
+			pfb_top1m_fetch_if_needed($this->dbdir, static function () use (&$attempts): bool {
+				$attempts++;
+				return FALSE;
+			}),
+			'update marker with complete source must stay on local reprocess path'
+		);
+		$this->assertSame(0, $attempts, 'local reprocess marker must not invoke provider fetch');
+	}
+}

--- a/tests/php/Top1mApplyRefreshMatrixTest.php
+++ b/tests/php/Top1mApplyRefreshMatrixTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 #[CoversFunction('pfb_top1m_refresh_needed')]
 #[CoversFunction('pfb_top1m_fetch_if_needed')]
+#[CoversFunction('pfb_dnsbl_publish_result')]
+#[CoversFunction('pfb_dnsbl_reload_needed')]
 final class Top1mApplyRefreshMatrixTest extends TestCase
 {
 	private string $dbdir;
@@ -49,5 +51,44 @@ final class Top1mApplyRefreshMatrixTest extends TestCase
 			'update marker with complete source must stay on local reprocess path'
 		);
 		$this->assertSame(0, $attempts, 'local reprocess marker must not invoke provider fetch');
+	}
+
+	public function testPublishResultLogsOnlyTheTruthfulOutcome(): void
+	{
+		$messages = [];
+		$logger = static function (string $message, int $level) use (&$messages): void {
+			$messages[] = [$message, $level];
+		};
+		$hadFailure = array_key_exists('dnsbl_publish_failed', $GLOBALS['pfb']);
+		$previousFailure = $GLOBALS['pfb']['dnsbl_publish_failed'] ?? NULL;
+		try {
+			unset($GLOBALS['pfb']['dnsbl_publish_failed']);
+			$this->assertFalse(pfb_dnsbl_publish_result(FALSE, $logger));
+			$this->assertTrue($GLOBALS['pfb']['dnsbl_publish_failed']);
+			$this->assertSame([["... FAILED (publication error)", 2]], $messages);
+
+			unset($GLOBALS['pfb']['dnsbl_publish_failed']);
+			$messages = [];
+			$this->assertTrue(pfb_dnsbl_publish_result(TRUE, $logger));
+			$this->assertArrayNotHasKey('dnsbl_publish_failed', $GLOBALS['pfb']);
+			$this->assertSame([["... completed", 1]], $messages);
+		} finally {
+			if ($hadFailure) {
+				$GLOBALS['pfb']['dnsbl_publish_failed'] = $previousFailure;
+			} else {
+				unset($GLOBALS['pfb']['dnsbl_publish_failed']);
+			}
+		}
+	}
+
+	public function testPublishFailureSuppressesReloadAndPostHookChangeSignal(): void
+	{
+		$this->assertFalse(pfb_dnsbl_reload_needed(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE));
+		$this->assertFalse(pfb_dnsbl_reload_needed(FALSE, FALSE, FALSE, FALSE, FALSE, FALSE));
+		foreach (range(0, 4) as $enabledIndex) {
+			$flags = array_fill(0, 5, FALSE);
+			$flags[$enabledIndex] = TRUE;
+			$this->assertTrue(pfb_dnsbl_reload_needed(FALSE, ...$flags));
+		}
 	}
 }

--- a/tests/php/Top1mApplyRefreshTest.php
+++ b/tests/php/Top1mApplyRefreshTest.php
@@ -97,21 +97,4 @@ final class Top1mApplyRefreshTest extends TestCase
 		$this->assertTrue(pfb_top1m_refresh_needed($this->dbdir), 'missing baseline must force the next retry');
 	}
 
-	public function testUpdateMarkerWithCompleteSourceStaysOnLocalReprocess(): void
-	{
-		$this->assertNotFalse(file_put_contents($this->activePath(), "live\n"));
-		$this->assertNotFalse(file_put_contents($this->baselinePath(), "raw\n"));
-		$this->assertNotFalse(file_put_contents("{$this->dbdir}/top-1m.update", ''));
-		$attempts = 0;
-
-		$this->assertFalse(
-			pfb_top1m_fetch_if_needed($this->dbdir, static function () use (&$attempts): bool {
-				$attempts++;
-				return FALSE;
-			}),
-			'update marker with complete source must stay on local reprocess path'
-		);
-		$this->assertSame(0, $attempts, 'local reprocess marker must not invoke provider fetch');
-	}
-
 }

--- a/tests/php/Top1mApplyRefreshTest.php
+++ b/tests/php/Top1mApplyRefreshTest.php
@@ -46,11 +46,10 @@ final class Top1mApplyRefreshTest extends TestCase
 	public function testActiveCsvSkipsRefreshRegardlessOfBaseline(): void
 	{
 		$this->assertNotFalse(file_put_contents($this->activePath(), "live\n"));
-		$this->assertFalse(pfb_top1m_refresh_needed($this->dbdir), 'existing active CSV must skip provider fetch');
 		$this->assertNotFalse(file_put_contents($this->baselinePath(), "raw\n"));
 		$this->assertFalse(pfb_top1m_refresh_needed($this->dbdir), 'existing active CSV with baseline must still skip');
 		unlink($this->baselinePath());
-		$this->assertFalse(pfb_top1m_refresh_needed($this->dbdir), 'existing active CSV without baseline preserves old behavior');
+		$this->assertTrue(pfb_top1m_refresh_needed($this->dbdir), 'missing detector baseline must force provider retry');
 	}
 
 	public function testFetchSeamOnlyRunsWhenActiveCsvMissing(): void
@@ -65,6 +64,7 @@ final class Top1mApplyRefreshTest extends TestCase
 		);
 		$this->assertSame(1, $attempts, 'failed fetch must be observable as one attempt');
 		$this->assertNotFalse(file_put_contents($this->activePath(), "live\n"));
+		$this->assertNotFalse(file_put_contents($this->baselinePath(), "raw\n"));
 		$this->assertFalse(
 			pfb_top1m_fetch_if_needed($this->dbdir, static function () use (&$attempts): bool {
 				$attempts++;
@@ -73,6 +73,45 @@ final class Top1mApplyRefreshTest extends TestCase
 			'existing active CSV must skip provider fetch'
 		);
 		$this->assertSame(1, $attempts, 'active CSV must suppress a second fetch attempt');
+	}
+
+	public function testFailedFetchPreservesLiveOutputsAndRemainsRetryable(): void
+	{
+		$active = "live\n";
+		$whitelist = ".example.com,,\n,example.com,,\n,www.example.com,,\n";
+		$whitelistPath = "{$this->dbdir}/pfbalexawhitelist.txt";
+		$this->assertNotFalse(file_put_contents($this->activePath(), $active));
+		$this->assertNotFalse(file_put_contents($whitelistPath, $whitelist));
+		$attempts = 0;
+
+		$this->assertTrue(
+			pfb_top1m_fetch_if_needed($this->dbdir, static function () use (&$attempts): bool {
+				$attempts++;
+				return FALSE;
+			}),
+			'missing detector baseline must attempt provider fetch'
+		);
+		$this->assertSame(1, $attempts, 'failed fetch must be observable as one attempt');
+		$this->assertSame($active, file_get_contents($this->activePath()), 'failed fetch must preserve active CSV');
+		$this->assertSame($whitelist, file_get_contents($whitelistPath), 'failed fetch must preserve whitelist');
+		$this->assertTrue(pfb_top1m_refresh_needed($this->dbdir), 'missing baseline must force the next retry');
+	}
+
+	public function testUpdateMarkerWithCompleteSourceStaysOnLocalReprocess(): void
+	{
+		$this->assertNotFalse(file_put_contents($this->activePath(), "live\n"));
+		$this->assertNotFalse(file_put_contents($this->baselinePath(), "raw\n"));
+		$this->assertNotFalse(file_put_contents("{$this->dbdir}/top-1m.update", ''));
+		$attempts = 0;
+
+		$this->assertFalse(
+			pfb_top1m_fetch_if_needed($this->dbdir, static function () use (&$attempts): bool {
+				$attempts++;
+				return FALSE;
+			}),
+			'update marker with complete source must stay on local reprocess path'
+		);
+		$this->assertSame(0, $attempts, 'local reprocess marker must not invoke provider fetch');
 	}
 
 }

--- a/tests/php/Top1mApplyRefreshTest.php
+++ b/tests/php/Top1mApplyRefreshTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Behavior-preserving seam extraction for TOP1M's existing active-file fetch gate.
+ */
+#[CoversFunction('pfb_top1m_refresh_needed')]
+#[CoversFunction('pfb_top1m_fetch_if_needed')]
+final class Top1mApplyRefreshTest extends TestCase
+{
+	private string $dbdir;
+
+	protected function setUp(): void
+	{
+		$this->dbdir = sys_get_temp_dir() . '/pfb_top1m_apply_' . getmypid() . '_' . uniqid();
+		$this->assertTrue(@mkdir($this->dbdir, 0777, TRUE), "could not create sandbox {$this->dbdir}");
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ((array) (@glob("{$this->dbdir}/*") ?: []) as $path) {
+			@unlink($path);
+		}
+		@rmdir($this->dbdir);
+	}
+
+	private function activePath(): string
+	{
+		return "{$this->dbdir}/top-1m.csv";
+	}
+
+	private function baselinePath(): string
+	{
+		return "{$this->dbdir}/top-1m.csv.zip.orig";
+	}
+
+	public function testMissingActiveCsvNeedsRefresh(): void
+	{
+		$this->assertTrue(pfb_top1m_refresh_needed($this->dbdir), 'missing active CSV must retry provider fetch');
+	}
+
+	public function testActiveCsvSkipsRefreshRegardlessOfBaseline(): void
+	{
+		$this->assertNotFalse(file_put_contents($this->activePath(), "live\n"));
+		$this->assertFalse(pfb_top1m_refresh_needed($this->dbdir), 'existing active CSV must skip provider fetch');
+		$this->assertNotFalse(file_put_contents($this->baselinePath(), "raw\n"));
+		$this->assertFalse(pfb_top1m_refresh_needed($this->dbdir), 'existing active CSV with baseline must still skip');
+		unlink($this->baselinePath());
+		$this->assertFalse(pfb_top1m_refresh_needed($this->dbdir), 'existing active CSV without baseline preserves old behavior');
+	}
+
+	public function testFetchSeamOnlyRunsWhenActiveCsvMissing(): void
+	{
+		$attempts = 0;
+		$this->assertTrue(
+			pfb_top1m_fetch_if_needed($this->dbdir, static function () use (&$attempts): bool {
+				$attempts++;
+				return FALSE;
+			}),
+			'missing active CSV must attempt provider fetch'
+		);
+		$this->assertSame(1, $attempts, 'failed fetch must be observable as one attempt');
+		$this->assertNotFalse(file_put_contents($this->activePath(), "live\n"));
+		$this->assertFalse(
+			pfb_top1m_fetch_if_needed($this->dbdir, static function () use (&$attempts): bool {
+				$attempts++;
+				return FALSE;
+			}),
+			'existing active CSV must skip provider fetch'
+		);
+		$this->assertSame(1, $attempts, 'active CSV must suppress a second fetch attempt');
+	}
+
+}

--- a/tests/php/Top1mDccBaselineIntegrityTest.php
+++ b/tests/php/Top1mDccBaselineIntegrityTest.php
@@ -2,13 +2,11 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Issue #1542 — TOP1M detector must not trust an incomplete or stale baseline.
  */
-#[CoversFunction('pfb_top1m_detector_decision')]
 final class Top1mDccBaselineIntegrityTest extends TestCase
 {
 	private string $dir;

--- a/tests/php/Top1mDccBaselineIntegrityTest.php
+++ b/tests/php/Top1mDccBaselineIntegrityTest.php
@@ -38,12 +38,11 @@ final class Top1mDccBaselineIntegrityTest extends TestCase
 	{
 		$base = $this->dir . '/top-1m.csv.zip';
 		$raw = "{$base}.orig";
-		$body = "rank,example.test\n";
+		$body = "1,example.test\n";
 		$this->assertNotFalse(file_put_contents($raw, $body));
 		$this->assertTrue(pfb_hash_write($base, $raw));
-		$persisted_hash = pfb_hash_read($base)['digest'];
 
-		$this->assertNotFalse(file_put_contents($raw, "rank,changed.test\n"));
+		$this->assertNotFalse(file_put_contents($raw, "1,changed.test\n"));
 		$this->assertSame(
 			'changed',
 			pfb_top1m_detector_decision(TRUE, '304', FALSE, '', $base, TRUE, TRUE),
@@ -56,16 +55,20 @@ final class Top1mDccBaselineIntegrityTest extends TestCase
 	{
 		$base = $this->dir . '/top-1m.csv.zip';
 		$raw = "{$base}.orig";
-		$body = "rank,example.test\n";
+		$body = "1,example.test\n";
 		$body_hash = pfb_content_hash($body, FALSE);
 		$this->assertNotFalse(file_put_contents($raw, $body));
 		$this->assertTrue(pfb_hash_write($base, $raw));
-		$persisted_hash = pfb_hash_read($base)['digest'];
 
 		$this->assertSame(
 			'unchanged',
-			pfb_top1m_detector_decision(TRUE, '200', $body_hash, $persisted_hash, $base, TRUE, FALSE),
+			pfb_top1m_detector_decision(TRUE, '200', $body_hash, '', $base, TRUE, FALSE),
 			'200 same body may remain unchanged without HTTP validators'
+		);
+		$this->assertSame(
+			'changed',
+			pfb_top1m_detector_decision(TRUE, '200', pfb_content_hash("1,changed.example\n", FALSE), '', $base, TRUE, FALSE),
+			'200 changed body must trigger re-ingest even without HTTP validators'
 		);
 		$this->assertSame(
 			'changed',

--- a/tests/php/Top1mDccBaselineIntegrityTest.php
+++ b/tests/php/Top1mDccBaselineIntegrityTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1542 — TOP1M detector must not trust an incomplete or stale baseline.
+ */
+#[CoversFunction('pfb_top1m_detector_decision')]
+final class Top1mDccBaselineIntegrityTest extends TestCase
+{
+	private string $dir;
+
+	protected function setUp(): void
+	{
+		self::loadWwwDccHelpers();
+		$this->dir = sys_get_temp_dir() . '/pfb_top1m_baseline_' . getmypid() . '_' . uniqid();
+		$this->assertTrue(mkdir($this->dir, 0777, TRUE));
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_dir($this->dir)) {
+			$it = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator($this->dir, FilesystemIterator::SKIP_DOTS),
+				RecursiveIteratorIterator::CHILD_FIRST
+			);
+			foreach ($it as $file) {
+				$file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+			}
+			rmdir($this->dir);
+		}
+	}
+
+	public function testDetectorRejectsRawHashMismatch(): void
+	{
+		$base = $this->dir . '/top-1m.csv.zip';
+		$raw = "{$base}.orig";
+		$body = "rank,example.test\n";
+		$this->assertNotFalse(file_put_contents($raw, $body));
+		$this->assertTrue(pfb_hash_write($base, $raw));
+		$persisted_hash = pfb_hash_read($base)['digest'];
+
+		$this->assertNotFalse(file_put_contents($raw, "rank,changed.test\n"));
+		$this->assertSame(
+			'changed',
+			pfb_top1m_detector_decision(TRUE, '304', FALSE, '', $base, TRUE, TRUE),
+			'304 must not skip when raw baseline no longer matches its sidecar'
+		);
+
+	}
+
+	public function testDetectorRequires304ValidatorButAllowsSame200Body(): void
+	{
+		$base = $this->dir . '/top-1m.csv.zip';
+		$raw = "{$base}.orig";
+		$body = "rank,example.test\n";
+		$body_hash = pfb_content_hash($body, FALSE);
+		$this->assertNotFalse(file_put_contents($raw, $body));
+		$this->assertTrue(pfb_hash_write($base, $raw));
+		$persisted_hash = pfb_hash_read($base)['digest'];
+
+		$this->assertSame(
+			'unchanged',
+			pfb_top1m_detector_decision(TRUE, '200', $body_hash, $persisted_hash, $base, TRUE, FALSE),
+			'200 same body may remain unchanged without HTTP validators'
+		);
+		$this->assertSame(
+			'changed',
+			pfb_top1m_detector_decision(TRUE, '304', FALSE, '', $base, TRUE, TRUE),
+			'304 must not skip without a usable persisted validator'
+		);
+
+		$this->assertNotFalse(file_put_contents("{$base}.orig.etag", '"etag-v1"'));
+		$this->assertSame(
+			'unchanged',
+			pfb_top1m_detector_decision(TRUE, '304', FALSE, '', $base, TRUE, TRUE),
+			'304 with a persisted ETag may remain unchanged'
+		);
+	}
+
+	private static function loadWwwDccHelpers(): void
+	{
+		if (function_exists('pfb_top1m_detector_decision')) {
+			return;
+		}
+		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php');
+		if ($source === FALSE) {
+			self::fail('failed to read pfblockerng.php');
+		}
+		$start = strpos($source, "\nfunction pfb_top1m_detector_decision");
+		$end = strpos($source, "\nfunction pfblockerng_download_extras", $start === FALSE ? 0 : $start);
+		if ($start === FALSE || $end === FALSE || $end <= $start) {
+			self::fail('could not locate extracted TOP1M helper block');
+		}
+		eval("\n" . substr($source, $start + 1, $end - $start - 1));
+	}
+}

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -261,14 +261,14 @@ final class Top1mDccDetectorTest extends TestCase
 
 	public function testTop1mZipFileTargetPublishesSingleRegularMemberAndThenPersistsBaseline(): void
 	{
-		$archive = $this->zipFixture('single.zip', ['feed/top.csv' => "rank,example.test\n"]);
+		$archive = $this->zipFixture('single.zip', ['feed/top.csv' => "1,example.test\n"]);
 		$this->requireZipTarSupport($archive);
 		$base = $this->dir . '/top-1m.csv.zip';
 		$active = $this->dir . '/top-1m.csv';
 		file_put_contents($active, 'old active');
 
 		$this->assertTrue($this->downloadTop1m($archive, $base, $active));
-		$this->assertSame("rank,example.test\n", file_get_contents($active));
+		$this->assertSame("1,example.test\n", file_get_contents($active));
 		$this->assertSame(file_get_contents($archive), file_get_contents("{$base}.orig"));
 		$this->assertSame(pfb_content_hash($archive, TRUE), pfb_hash_read($base)['digest']);
 		$this->assertFileExists($GLOBALS['pfb']['dbdir'] . '/top-1m.update');
@@ -305,11 +305,11 @@ final class Top1mDccDetectorTest extends TestCase
 		$base = $this->dir . '/top-1m.csv.gz';
 		$active = $this->dir . '/top-1m.csv';
 		file_put_contents($active, 'old active');
-		$gzip = gzencode("rank,example.test\n");
+		$gzip = gzencode("1,example.test\n");
 		$gzip_path = $this->dir . '/feed.gz';
 		file_put_contents($gzip_path, $gzip);
 		$this->assertTrue($this->downloadTop1m($gzip_path, $base, $active));
-		$this->assertSame("rank,example.test\n", file_get_contents($active));
+		$this->assertSame("1,example.test\n", file_get_contents($active));
 
 		$broken_base = $this->dir . '/broken.csv.gz';
 		$broken_active = $this->dir . '/broken.csv';
@@ -323,9 +323,9 @@ final class Top1mDccDetectorTest extends TestCase
 		$plain_active = $this->dir . '/plain.active.csv';
 		file_put_contents($plain_active, 'old plain');
 		$plain = $this->dir . '/plain.txt';
-		file_put_contents($plain, "rank,plain.test\n");
+		file_put_contents($plain, "1,plain.test\n");
 		$this->assertTrue($this->downloadTop1m($plain, $plain_base, $plain_active));
-		$this->assertSame("rank,plain.test\n", file_get_contents($plain_active));
+		$this->assertSame("1,plain.test\n", file_get_contents($plain_active));
 	}
 
 	public function testTop1mPersistenceFailureRollsBackActiveAndEveryBaselineAcrossFormats(): void
@@ -334,28 +334,28 @@ final class Top1mDccDetectorTest extends TestCase
 			'gzip' => [
 				'source' => (function (): string {
 					$path = $this->dir . '/persist.gz';
-					file_put_contents($path, gzencode("rank,gzip.test\n"));
+					file_put_contents($path, gzencode("1,gzip.test\n"));
 					return $path;
 				})(),
 				'base' => $this->dir . '/persist-gzip.csv.gz',
 				'active' => $this->dir . '/persist-gzip.csv',
-				'body' => "rank,gzip.test\n",
+				'body' => "1,gzip.test\n",
 			],
 			'zip' => [
-				'source' => $this->zipFixture('persist.zip', ['feed/top.csv' => "rank,zip.test\n"]),
+				'source' => $this->zipFixture('persist.zip', ['feed/top.csv' => "1,zip.test\n"]),
 				'base' => $this->dir . '/persist-zip.csv.zip',
 				'active' => $this->dir . '/persist-zip.csv',
-				'body' => "rank,zip.test\n",
+				'body' => "1,zip.test\n",
 			],
 			'plain' => [
 				'source' => (function (): string {
 					$path = $this->dir . '/persist.txt';
-					file_put_contents($path, "rank,plain.test\n");
+					file_put_contents($path, "1,plain.test\n");
 					return $path;
 				})(),
 				'base' => $this->dir . '/persist-plain.csv',
 				'active' => $this->dir . '/persist-plain.active.csv',
-				'body' => "rank,plain.test\n",
+				'body' => "1,plain.test\n",
 			],
 		];
 		if (!$this->tarReadsZip($fixtures['zip']['source'])) {

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -39,7 +39,7 @@ final class Top1mDccDetectorTest extends TestCase
 		self::loadWwwDccHelpers();
 		$this->dir = sys_get_temp_dir() . '/pfb_top1m_dcc_' . getmypid() . '_' . uniqid();
 		$this->assertTrue(mkdir($this->dir, 0777, TRUE));
-		foreach (['log', 'errlog', 'pnow'] as $key) {
+		foreach (['log', 'errlog', 'pnow', 'dbdir'] as $key) {
 			$this->saved_pfb_exists[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []);
 			$this->saved_pfb[$key] = $GLOBALS['pfb'][$key] ?? NULL;
 		}
@@ -509,11 +509,14 @@ final class Top1mDccDetectorTest extends TestCase
 		$saved_runlog = $GLOBALS['pfb']['runlog'] ?? NULL;
 		$had_changed = array_key_exists('top1m_changed', $GLOBALS['pfb']);
 		$saved_changed = $GLOBALS['pfb']['top1m_changed'] ?? NULL;
+		$had_done = array_key_exists('top1m_dispatch_done', $GLOBALS['pfb']);
+		$saved_done = $GLOBALS['pfb']['top1m_dispatch_done'] ?? NULL;
 		try {
 			$GLOBALS['argv'] = ['pfblockerng.php', 'dcc'];
 			$GLOBALS['pfb']['php'] = $fake_php;
 			$GLOBALS['pfb']['runlog'] = '/dev/null';
 			$GLOBALS['pfb']['top1m_changed'] = TRUE;
+			unset($GLOBALS['pfb']['top1m_dispatch_done']);
 
 			$this->assertTrue(pfb_top1m_dispatch_if_changed(TRUE));
 			$this->assertEventually(static function () use ($dispatch_log): bool {
@@ -539,6 +542,11 @@ final class Top1mDccDetectorTest extends TestCase
 				unset($GLOBALS['pfb']['top1m_changed']);
 			} else {
 				$GLOBALS['pfb']['top1m_changed'] = $saved_changed;
+			}
+			if (!$had_done) {
+				unset($GLOBALS['pfb']['top1m_dispatch_done']);
+			} else {
+				$GLOBALS['pfb']['top1m_dispatch_done'] = $saved_done;
 			}
 		}
 	}

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -93,6 +93,34 @@ final class Top1mDccDetectorTest extends TestCase
 		$this->assertSame('failed', pfb_top1m_detector_decision(FALSE, '', FALSE, 'old'));
 	}
 
+	public function testDetectorRequiresUsableRawBaselineBeforeUnchangedDecision(): void
+	{
+		$base = $this->dir . '/top-1m.csv.zip';
+		$raw = "{$base}.orig";
+		$body = "rank,example.test\n";
+		$body_hash = pfb_content_hash($body, FALSE);
+		file_put_contents($raw, $body);
+		$this->assertTrue(pfb_hash_write($base, $raw));
+		$persisted_hash = pfb_hash_read($base)['digest'];
+
+		$this->assertSame('unchanged', pfb_top1m_detector_decision(TRUE, '304', FALSE, $persisted_hash, $base, TRUE));
+		$this->assertSame('unchanged', pfb_top1m_detector_decision(TRUE, '200', $body_hash, $persisted_hash, $base, TRUE));
+
+		// A matching hash without a regular raw source cannot make a 304 safe.
+		unlink($raw);
+		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '304', FALSE, $persisted_hash, $base, TRUE));
+		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '200', $body_hash, $persisted_hash, $base, TRUE));
+
+		file_put_contents($raw, $body);
+		unlink("{$base}.xxhash128");
+		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '304', FALSE, '', $base, TRUE));
+		file_put_contents("{$base}.xxhash128", 'not-a-digest');
+		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '200', $body_hash, $persisted_hash, $base, TRUE));
+
+		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '304', FALSE, $persisted_hash, $base, FALSE));
+		$this->assertSame('failed', pfb_top1m_detector_decision(FALSE, '', FALSE, $persisted_hash, $base, TRUE));
+	}
+
 	public function testProviderIdentityCoversAllFiveProvidersAndAuth(): void
 	{
 		foreach (pfb_top1m_providers() as $provider => $descriptor) {
@@ -457,13 +485,6 @@ final class Top1mDccDetectorTest extends TestCase
 		))->success;
 	}
 
-	public function testDccDispatchUsesExistingDnsblTriggerApi(): void
-	{
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php');
-		$this->assertIsString($source);
-		$this->assertStringContainsString('pfb_trigger scope=dnsbl force=false trigger=cron', $source);
-	}
-
 	public function testExtractedDispatchSeamRunsExistingCronCommand(): void
 	{
 		$dispatch_log = "{$this->dir}/dispatch.log";
@@ -506,6 +527,64 @@ final class Top1mDccDetectorTest extends TestCase
 				unset($GLOBALS['pfb']['top1m_changed']);
 			} else {
 				$GLOBALS['pfb']['top1m_changed'] = $saved_changed;
+			}
+		}
+	}
+
+	public function testDispatchSuppressesFailedAndUnchangedButRunsChangedOnce(): void
+	{
+		$dispatch_log = "{$this->dir}/dispatch-matrix.log";
+		$fake_php = "{$this->dir}/fake-php-matrix";
+		$script = "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> " . escapeshellarg($dispatch_log) . "\n";
+		$this->assertNotFalse(file_put_contents($fake_php, $script));
+		$this->assertTrue(chmod($fake_php, 0755));
+
+		$saved_argv = $GLOBALS['argv'];
+		$saved_php = $GLOBALS['pfb']['php'] ?? FALSE;
+		$saved_runlog = $GLOBALS['pfb']['runlog'] ?? FALSE;
+		$saved_changed = $GLOBALS['pfb']['top1m_changed'] ?? FALSE;
+		$saved_done = $GLOBALS['pfb']['top1m_dispatch_done'] ?? FALSE;
+		try {
+			$GLOBALS['argv'] = ['pfblockerng.php', 'dcc'];
+			$GLOBALS['pfb']['php'] = $fake_php;
+			$GLOBALS['pfb']['runlog'] = '/dev/null';
+			$GLOBALS['pfb']['top1m_changed'] = FALSE;
+			unset($GLOBALS['pfb']['top1m_dispatch_done']);
+
+			$this->assertFalse(pfb_top1m_dispatch_if_changed(TRUE), 'unchanged TOP1M must not dispatch');
+			$this->assertFalse(pfb_top1m_dispatch_if_changed(FALSE), 'failed extras pass must not dispatch without a TOP1M change');
+			$this->assertFileDoesNotExist($dispatch_log);
+
+			$GLOBALS['pfb']['top1m_changed'] = TRUE;
+			$this->assertTrue(pfb_top1m_dispatch_if_changed(FALSE), 'TOP1M change must dispatch despite unrelated extras failure');
+			$this->assertFalse(pfb_top1m_dispatch_if_changed(FALSE), 'the same TOP1M change must not dispatch twice');
+			$this->assertEventually(static function () use ($dispatch_log): bool {
+				return is_file($dispatch_log);
+			}, 'TOP1M dispatch command did not run');
+			$lines = file($dispatch_log, FILE_IGNORE_NEW_LINES);
+			$this->assertIsArray($lines);
+			$this->assertCount(1, $lines, 'changed TOP1M must dispatch exactly once');
+		} finally {
+			$GLOBALS['argv'] = $saved_argv;
+			if ($saved_php === FALSE) {
+				unset($GLOBALS['pfb']['php']);
+			} else {
+				$GLOBALS['pfb']['php'] = $saved_php;
+			}
+			if ($saved_runlog === FALSE) {
+				unset($GLOBALS['pfb']['runlog']);
+			} else {
+				$GLOBALS['pfb']['runlog'] = $saved_runlog;
+			}
+			if ($saved_changed === FALSE) {
+				unset($GLOBALS['pfb']['top1m_changed']);
+			} else {
+				$GLOBALS['pfb']['top1m_changed'] = $saved_changed;
+			}
+			if ($saved_done === FALSE) {
+				unset($GLOBALS['pfb']['top1m_dispatch_done']);
+			} else {
+				$GLOBALS['pfb']['top1m_dispatch_done'] = $saved_done;
 			}
 		}
 	}

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -12,8 +12,6 @@ use PHPUnit\Framework\TestCase;
  * fixtures, so active-file and baseline contracts run off-appliance.
  */
 #[CoversFunction('pfb_top1m_probe_decision')]
-#[CoversFunction('pfb_top1m_detector_decision')]
-#[CoversFunction('pfb_top1m_dispatch_if_changed')]
 #[CoversFunction('pfb_top1m_source_identity')]
 #[CoversFunction('pfb_top1m_invalidate_baseline')]
 #[CoversFunction('pfb_top1m_persist_baseline')]
@@ -33,6 +31,8 @@ final class Top1mDccDetectorTest extends TestCase
 
 	/** @var array<string,mixed> */
 	private array $saved_pfb = [];
+	/** @var array<string,bool> */
+	private array $saved_pfb_exists = [];
 
 	protected function setUp(): void
 	{
@@ -40,9 +40,11 @@ final class Top1mDccDetectorTest extends TestCase
 		$this->dir = sys_get_temp_dir() . '/pfb_top1m_dcc_' . getmypid() . '_' . uniqid();
 		$this->assertTrue(mkdir($this->dir, 0777, TRUE));
 		foreach (['log', 'errlog', 'pnow'] as $key) {
-			$this->saved_pfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$key] : FALSE;
+			$this->saved_pfb_exists[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []);
+			$this->saved_pfb[$key] = $GLOBALS['pfb'][$key] ?? NULL;
 		}
-		$this->saved_pfb['mime_types'] = $GLOBALS['pfb']['mime_types'] ?? FALSE;
+		$this->saved_pfb_exists['mime_types'] = array_key_exists('mime_types', $GLOBALS['pfb'] ?? []);
+		$this->saved_pfb['mime_types'] = $GLOBALS['pfb']['mime_types'] ?? NULL;
 		$GLOBALS['pfb']['mime_types'] = $GLOBALS['pfb_shipped_mime_types'] ?? $GLOBALS['pfb']['mime_types'] ?? [];
 		$GLOBALS['pfb']['log'] = "{$this->dir}/pfblockerng.log";
 		$GLOBALS['pfb']['errlog'] = "{$this->dir}/error.log";
@@ -51,12 +53,9 @@ final class Top1mDccDetectorTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		if (is_resource($this->server)) {
-			proc_terminate($this->server);
-			proc_close($this->server);
-		}
+		$this->stopServer();
 		foreach ($this->saved_pfb as $key => $value) {
-			if ($value === FALSE) {
+			if (!$this->saved_pfb_exists[$key]) {
 				unset($GLOBALS['pfb'][$key]);
 			} else {
 				$GLOBALS['pfb'][$key] = $value;
@@ -437,6 +436,7 @@ final class Top1mDccDetectorTest extends TestCase
 
 	private function downloadTop1m(string $source, string $base, string $target): bool
 	{
+		$this->stopServer();
 		$GLOBALS['pfb']['dbdir'] = $this->dir . '/db';
 		$this->assertTrue(is_dir($GLOBALS['pfb']['dbdir']) || mkdir($GLOBALS['pfb']['dbdir']));
 		$router = $this->dir . '/router.php';
@@ -485,6 +485,15 @@ final class Top1mDccDetectorTest extends TestCase
 		))->success;
 	}
 
+	private function stopServer(): void
+	{
+		if (is_resource($this->server)) {
+			proc_terminate($this->server);
+			proc_close($this->server);
+			$this->server = NULL;
+		}
+	}
+
 	public function testExtractedDispatchSeamRunsExistingCronCommand(): void
 	{
 		$dispatch_log = "{$this->dir}/dispatch.log";
@@ -494,9 +503,12 @@ final class Top1mDccDetectorTest extends TestCase
 		$this->assertTrue(chmod($fake_php, 0755));
 
 		$saved_argv = $GLOBALS['argv'];
-		$saved_php = $GLOBALS['pfb']['php'] ?? FALSE;
-		$saved_runlog = $GLOBALS['pfb']['runlog'] ?? FALSE;
-		$saved_changed = $GLOBALS['pfb']['top1m_changed'] ?? FALSE;
+		$had_php = array_key_exists('php', $GLOBALS['pfb']);
+		$saved_php = $GLOBALS['pfb']['php'] ?? NULL;
+		$had_runlog = array_key_exists('runlog', $GLOBALS['pfb']);
+		$saved_runlog = $GLOBALS['pfb']['runlog'] ?? NULL;
+		$had_changed = array_key_exists('top1m_changed', $GLOBALS['pfb']);
+		$saved_changed = $GLOBALS['pfb']['top1m_changed'] ?? NULL;
 		try {
 			$GLOBALS['argv'] = ['pfblockerng.php', 'dcc'];
 			$GLOBALS['pfb']['php'] = $fake_php;
@@ -513,17 +525,17 @@ final class Top1mDccDetectorTest extends TestCase
 			$this->assertStringContainsString('pfb_trigger scope=dnsbl force=false trigger=cron', $lines[0]);
 		} finally {
 			$GLOBALS['argv'] = $saved_argv;
-			if ($saved_php === FALSE) {
+			if (!$had_php) {
 				unset($GLOBALS['pfb']['php']);
 			} else {
 				$GLOBALS['pfb']['php'] = $saved_php;
 			}
-			if ($saved_runlog === FALSE) {
+			if (!$had_runlog) {
 				unset($GLOBALS['pfb']['runlog']);
 			} else {
 				$GLOBALS['pfb']['runlog'] = $saved_runlog;
 			}
-			if ($saved_changed === FALSE) {
+			if (!$had_changed) {
 				unset($GLOBALS['pfb']['top1m_changed']);
 			} else {
 				$GLOBALS['pfb']['top1m_changed'] = $saved_changed;
@@ -540,10 +552,14 @@ final class Top1mDccDetectorTest extends TestCase
 		$this->assertTrue(chmod($fake_php, 0755));
 
 		$saved_argv = $GLOBALS['argv'];
-		$saved_php = $GLOBALS['pfb']['php'] ?? FALSE;
-		$saved_runlog = $GLOBALS['pfb']['runlog'] ?? FALSE;
-		$saved_changed = $GLOBALS['pfb']['top1m_changed'] ?? FALSE;
-		$saved_done = $GLOBALS['pfb']['top1m_dispatch_done'] ?? FALSE;
+		$had_php = array_key_exists('php', $GLOBALS['pfb']);
+		$saved_php = $GLOBALS['pfb']['php'] ?? NULL;
+		$had_runlog = array_key_exists('runlog', $GLOBALS['pfb']);
+		$saved_runlog = $GLOBALS['pfb']['runlog'] ?? NULL;
+		$had_changed = array_key_exists('top1m_changed', $GLOBALS['pfb']);
+		$saved_changed = $GLOBALS['pfb']['top1m_changed'] ?? NULL;
+		$had_done = array_key_exists('top1m_dispatch_done', $GLOBALS['pfb']);
+		$saved_done = $GLOBALS['pfb']['top1m_dispatch_done'] ?? NULL;
 		try {
 			$GLOBALS['argv'] = ['pfblockerng.php', 'dcc'];
 			$GLOBALS['pfb']['php'] = $fake_php;
@@ -566,22 +582,22 @@ final class Top1mDccDetectorTest extends TestCase
 			$this->assertCount(1, $lines, 'changed TOP1M must dispatch exactly once');
 		} finally {
 			$GLOBALS['argv'] = $saved_argv;
-			if ($saved_php === FALSE) {
+			if (!$had_php) {
 				unset($GLOBALS['pfb']['php']);
 			} else {
 				$GLOBALS['pfb']['php'] = $saved_php;
 			}
-			if ($saved_runlog === FALSE) {
+			if (!$had_runlog) {
 				unset($GLOBALS['pfb']['runlog']);
 			} else {
 				$GLOBALS['pfb']['runlog'] = $saved_runlog;
 			}
-			if ($saved_changed === FALSE) {
+			if (!$had_changed) {
 				unset($GLOBALS['pfb']['top1m_changed']);
 			} else {
 				$GLOBALS['pfb']['top1m_changed'] = $saved_changed;
 			}
-			if ($saved_done === FALSE) {
+			if (!$had_done) {
 				unset($GLOBALS['pfb']['top1m_dispatch_done']);
 			} else {
 				$GLOBALS['pfb']['top1m_dispatch_done'] = $saved_done;

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -12,6 +12,8 @@ use PHPUnit\Framework\TestCase;
  * fixtures, so active-file and baseline contracts run off-appliance.
  */
 #[CoversFunction('pfb_top1m_probe_decision')]
+#[CoversFunction('pfb_top1m_detector_decision')]
+#[CoversFunction('pfb_top1m_dispatch_if_changed')]
 #[CoversFunction('pfb_top1m_source_identity')]
 #[CoversFunction('pfb_top1m_invalidate_baseline')]
 #[CoversFunction('pfb_top1m_persist_baseline')]
@@ -34,6 +36,7 @@ final class Top1mDccDetectorTest extends TestCase
 
 	protected function setUp(): void
 	{
+		self::loadWwwDccHelpers();
 		$this->dir = sys_get_temp_dir() . '/pfb_top1m_dcc_' . getmypid() . '_' . uniqid();
 		$this->assertTrue(mkdir($this->dir, 0777, TRUE));
 		foreach (['log', 'errlog', 'pnow'] as $key) {
@@ -80,6 +83,14 @@ final class Top1mDccDetectorTest extends TestCase
 		$this->assertSame('changed', pfb_top1m_probe_decision(TRUE, '200', FALSE, 'old'));
 		$this->assertSame('changed', pfb_top1m_probe_decision(TRUE, '500', FALSE, 'old'));
 		$this->assertSame('failed', pfb_top1m_probe_decision(FALSE, '', FALSE, 'old'));
+	}
+
+	public function testExtractedDetectorDecisionPreservesExistingProbeMatrix(): void
+	{
+		$this->assertSame('unchanged', pfb_top1m_detector_decision(TRUE, '304', FALSE, 'ignored'));
+		$this->assertSame('unchanged', pfb_top1m_detector_decision(TRUE, '200', 'same', 'same'));
+		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '200', 'new', 'old'));
+		$this->assertSame('failed', pfb_top1m_detector_decision(FALSE, '', FALSE, 'old'));
 	}
 
 	public function testProviderIdentityCoversAllFiveProvidersAndAuth(): void
@@ -451,5 +462,80 @@ final class Top1mDccDetectorTest extends TestCase
 		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php');
 		$this->assertIsString($source);
 		$this->assertStringContainsString('pfb_trigger scope=dnsbl force=false trigger=cron', $source);
+	}
+
+	public function testExtractedDispatchSeamRunsExistingCronCommand(): void
+	{
+		$dispatch_log = "{$this->dir}/dispatch.log";
+		$fake_php = "{$this->dir}/fake-php";
+		$script = "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> " . escapeshellarg($dispatch_log) . "\n";
+		$this->assertNotFalse(file_put_contents($fake_php, $script));
+		$this->assertTrue(chmod($fake_php, 0755));
+
+		$saved_argv = $GLOBALS['argv'];
+		$saved_php = $GLOBALS['pfb']['php'] ?? FALSE;
+		$saved_runlog = $GLOBALS['pfb']['runlog'] ?? FALSE;
+		$saved_changed = $GLOBALS['pfb']['top1m_changed'] ?? FALSE;
+		try {
+			$GLOBALS['argv'] = ['pfblockerng.php', 'dcc'];
+			$GLOBALS['pfb']['php'] = $fake_php;
+			$GLOBALS['pfb']['runlog'] = '/dev/null';
+			$GLOBALS['pfb']['top1m_changed'] = TRUE;
+
+			$this->assertTrue(pfb_top1m_dispatch_if_changed(TRUE));
+			$this->assertEventually(static function () use ($dispatch_log): bool {
+				return is_file($dispatch_log);
+			}, 'TOP1M dispatch command did not run');
+			$lines = file($dispatch_log, FILE_IGNORE_NEW_LINES);
+			$this->assertIsArray($lines);
+			$this->assertCount(1, $lines);
+			$this->assertStringContainsString('pfb_trigger scope=dnsbl force=false trigger=cron', $lines[0]);
+		} finally {
+			$GLOBALS['argv'] = $saved_argv;
+			if ($saved_php === FALSE) {
+				unset($GLOBALS['pfb']['php']);
+			} else {
+				$GLOBALS['pfb']['php'] = $saved_php;
+			}
+			if ($saved_runlog === FALSE) {
+				unset($GLOBALS['pfb']['runlog']);
+			} else {
+				$GLOBALS['pfb']['runlog'] = $saved_runlog;
+			}
+			if ($saved_changed === FALSE) {
+				unset($GLOBALS['pfb']['top1m_changed']);
+			} else {
+				$GLOBALS['pfb']['top1m_changed'] = $saved_changed;
+			}
+		}
+	}
+
+	private static function loadWwwDccHelpers(): void
+	{
+		if (function_exists('pfb_top1m_detector_decision')) {
+			return;
+		}
+		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php');
+		if ($source === FALSE) {
+			self::fail('failed to read pfblockerng.php');
+		}
+		$start = strpos($source, "\nfunction pfb_top1m_detector_decision");
+		$end = strpos($source, "\nfunction pfblockerng_download_extras", $start === FALSE ? 0 : $start);
+		if ($start === FALSE || $end === FALSE || $end <= $start) {
+			self::fail('could not locate extracted TOP1M helper block');
+		}
+		eval("\n" . substr($source, $start + 1, $end - $start - 1));
+	}
+
+	private static function assertEventually(callable $condition, string $message): void
+	{
+		$deadline = microtime(TRUE) + 2.0;
+		do {
+			if ($condition()) {
+				return;
+			}
+			usleep(10000);
+		} while (microtime(TRUE) < $deadline);
+		self::fail($message);
 	}
 }

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -8,15 +8,13 @@ use PHPUnit\Framework\TestCase;
 /**
  * Issue #1542 — TOP1M's daily DCC detector and fail-safe publication contract.
  *
- * The detector tests use the shipped pfb_download() HTTP path where the host
- * permits a local fixture. Archive publication's final rename failure cannot
- * be induced portably off-appliance, so the exact staging seam is also pinned
- * against the production source (the live smoke suite exercises the appliance
- * filesystem failure path).
+ * Publication tests drive the shipped pfb_download() path with local archive
+ * fixtures, so active-file and baseline contracts run off-appliance.
  */
 #[CoversFunction('pfb_top1m_probe_decision')]
 #[CoversFunction('pfb_top1m_source_identity')]
 #[CoversFunction('pfb_top1m_invalidate_baseline')]
+#[CoversFunction('pfb_top1m_persist_baseline')]
 #[CoversFunction('pfb_top1m_settings_reprocess')]
 #[CoversFunction('pfb_top1m_download_ledger_update')]
 #[CoversFunction('pfb_download')]
@@ -41,6 +39,8 @@ final class Top1mDccDetectorTest extends TestCase
 		foreach (['log', 'errlog', 'pnow'] as $key) {
 			$this->saved_pfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$key] : FALSE;
 		}
+		$this->saved_pfb['mime_types'] = $GLOBALS['pfb']['mime_types'] ?? FALSE;
+		$GLOBALS['pfb']['mime_types'] = $GLOBALS['pfb_shipped_mime_types'] ?? $GLOBALS['pfb']['mime_types'] ?? [];
 		$GLOBALS['pfb']['log'] = "{$this->dir}/pfblockerng.log";
 		$GLOBALS['pfb']['errlog'] = "{$this->dir}/error.log";
 		$GLOBALS['pfb']['pnow'] = 'now';
@@ -175,10 +175,18 @@ final class Top1mDccDetectorTest extends TestCase
 		$this->assertNotSame(0, $this->port, 'could not start local HTTP fixture');
 
 		$target = $this->dir . '/top-1m.csv.zip.md5';
-		$meta = [];
-		$result = pfb_download("http://127.0.0.1:{$this->port}/feed.csv", $target, FALSE, 'TOP1M probe', '', 1, '', 30, 'change_detect', '', '', FALSE, $meta);
-		$this->assertTrue($result);
-		$this->assertSame('200', $meta['status'] ?? '');
+		$result = pfb_download(new PfbDownloadRequest(
+			listUrl: "http://127.0.0.1:{$this->port}/feed.csv",
+			downloadPath: $target,
+			flex: FALSE,
+			header: 'TOP1M probe',
+			format: '',
+			logType: 1,
+			timeout: 30,
+			type: 'change_detect',
+		));
+		$this->assertTrue($result->success);
+		$this->assertSame('200', $result->responseMeta['status'] ?? '');
 		$this->assertSame($body, file_get_contents("{$target}.raw"));
 		$this->assertSame(pfb_content_hash($body, FALSE), pfb_content_hash("{$target}.raw", TRUE));
 	}
@@ -194,13 +202,228 @@ final class Top1mDccDetectorTest extends TestCase
 		$this->assertSame('changed', pfb_top1m_probe_decision(TRUE, '200', $body_hash, pfb_hash_read($base)['digest']));
 	}
 
-	public function testTop1mPublishBranchesUseStagingBeforeActiveDestination(): void
+	public function testTop1mZipFileTargetRejectsMultipleMembersAndRetainsActiveAndBaseline(): void
 	{
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
-		$this->assertIsString($source);
-		$this->assertStringContainsString('$top1m_stage = @tempnam', $source);
-		$this->assertStringContainsString('pfb_top1m_persist_baseline($file_dwn, $file_download)', $source);
-		$this->assertStringContainsString('pfb_top1m_invalidate_baseline($file_dwn)', $source);
+		$archive = $this->zipFixture('multiple.zip', ['feed/a.csv' => "new-a\n", 'feed/b.csv' => "new-b\n"]);
+		$base = $this->dir . '/top-1m.csv.zip';
+		$active = $this->dir . '/top-1m.csv';
+		file_put_contents($active, 'old active');
+		file_put_contents("{$base}.orig", 'old raw');
+		pfb_hash_write($base, "{$base}.orig");
+		$old_hash = file_get_contents("{$base}.xxhash128");
+
+		$this->assertFalse($this->downloadTop1m($archive, $base, $active));
+		$this->assertSame('old active', file_get_contents($active));
+		$this->assertSame('old raw', file_get_contents("{$base}.orig"));
+		$this->assertSame($old_hash, file_get_contents("{$base}.xxhash128"));
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['dbdir'] . '/top-1m.update');
+	}
+
+	public function testTop1mZipFileTargetPublishesSingleRegularMemberAndThenPersistsBaseline(): void
+	{
+		$archive = $this->zipFixture('single.zip', ['feed/top.csv' => "rank,example.test\n"]);
+		$base = $this->dir . '/top-1m.csv.zip';
+		$active = $this->dir . '/top-1m.csv';
+		file_put_contents($active, 'old active');
+
+		$this->assertTrue($this->downloadTop1m($archive, $base, $active));
+		$this->assertSame("rank,example.test\n", file_get_contents($active));
+		$this->assertSame(file_get_contents($archive), file_get_contents("{$base}.orig"));
+		$this->assertSame(pfb_content_hash($archive, TRUE), pfb_hash_read($base)['digest']);
+		$this->assertFileExists($GLOBALS['pfb']['dbdir'] . '/top-1m.update');
+	}
+
+	public function testTop1mZipDirectoryTargetExtractsEveryMember(): void
+	{
+		$archive = $this->zipFixture('directory.zip', ['feed/a.csv' => "a\n", 'feed/b.csv' => "b\n"]);
+		$base = $this->dir . '/top-1m.csv.zip';
+		$target = $this->dir . '/out';
+		$this->assertTrue(mkdir($target));
+
+		$this->assertTrue($this->downloadTop1m($archive, $base, $target));
+		$this->assertSame("a\n", file_get_contents("{$target}/a.csv"));
+		$this->assertSame("b\n", file_get_contents("{$target}/b.csv"));
+	}
+
+	public function testTop1mZipUnsafeMemberMakesNoActiveOrStagingWrite(): void
+	{
+		$archive = $this->zipFixture('unsafe.zip', ['feed/good.csv' => "good\n", '../escape.csv' => "escape\n"]);
+		$base = $this->dir . '/top-1m.csv.zip';
+		$active = $this->dir . '/top-1m.csv';
+		file_put_contents($active, 'old active');
+
+		$this->assertFalse($this->downloadTop1m($archive, $base, $active));
+		$this->assertSame('old active', file_get_contents($active));
+		$this->assertFileDoesNotExist($this->dir . '/escape.csv');
+	}
+
+	public function testTop1mGzipAndPlainPublicationKeepActiveOnFailure(): void
+	{
+		$base = $this->dir . '/top-1m.csv.gz';
+		$active = $this->dir . '/top-1m.csv';
+		file_put_contents($active, 'old active');
+		$gzip = gzencode("rank,example.test\n");
+		$gzip_path = $this->dir . '/feed.gz';
+		file_put_contents($gzip_path, $gzip);
+		$this->assertTrue($this->downloadTop1m($gzip_path, $base, $active));
+		$this->assertSame("rank,example.test\n", file_get_contents($active));
+
+		$broken_base = $this->dir . '/broken.csv.gz';
+		$broken_active = $this->dir . '/broken.csv';
+		file_put_contents($broken_active, 'old broken');
+		$broken = $this->dir . '/broken.gz';
+		file_put_contents($broken, substr($gzip, 0, -3));
+		$this->assertFalse($this->downloadTop1m($broken, $broken_base, $broken_active));
+		$this->assertSame('old broken', file_get_contents($broken_active));
+
+		$plain_base = $this->dir . '/plain.csv';
+		$plain_active = $this->dir . '/plain.active.csv';
+		file_put_contents($plain_active, 'old plain');
+		$plain = $this->dir . '/plain.txt';
+		file_put_contents($plain, "rank,plain.test\n");
+		$this->assertTrue($this->downloadTop1m($plain, $plain_base, $plain_active));
+		$this->assertSame("rank,plain.test\n", file_get_contents($plain_active));
+	}
+
+	public function testTop1mPersistenceFailureRollsBackActiveAndEveryBaselineAcrossFormats(): void
+	{
+		$fixtures = [
+			'gzip' => [
+				'source' => (function (): string {
+					$path = $this->dir . '/persist.gz';
+					file_put_contents($path, gzencode("rank,gzip.test\n"));
+					return $path;
+				})(),
+				'base' => $this->dir . '/persist-gzip.csv.gz',
+				'active' => $this->dir . '/persist-gzip.csv',
+				'body' => "rank,gzip.test\n",
+			],
+			'zip' => [
+				'source' => $this->zipFixture('persist.zip', ['feed/top.csv' => "rank,zip.test\n"]),
+				'base' => $this->dir . '/persist-zip.csv.zip',
+				'active' => $this->dir . '/persist-zip.csv',
+				'body' => "rank,zip.test\n",
+			],
+			'plain' => [
+				'source' => (function (): string {
+					$path = $this->dir . '/persist.txt';
+					file_put_contents($path, "rank,plain.test\n");
+					return $path;
+				})(),
+				'base' => $this->dir . '/persist-plain.csv',
+				'active' => $this->dir . '/persist-plain.active.csv',
+				'body' => "rank,plain.test\n",
+			],
+		];
+
+		foreach ($fixtures as $label => $fixture) {
+			$base = $fixture['base'];
+			$active = $fixture['active'];
+			$old_raw = "old raw {$label}\n";
+			$old_source = "old source {$label}";
+			$old_etag = '"old-' . $label . '"';
+			$old_lastmod = 1700000000;
+			file_put_contents($active, "old active {$label}\n");
+			file_put_contents("{$base}.orig", $old_raw);
+			pfb_hash_write($base, "{$base}.orig");
+			$old_hash = file_get_contents("{$base}.xxhash128");
+			file_put_contents("{$base}.source", $old_source);
+			pfb_validator_write("{$base}.orig", $old_etag, $old_lastmod);
+			chmod("{$base}.xxhash128", 0444);
+
+			$this->assertFalse($this->downloadTop1m($fixture['source'], $base, $active), "{$label}: persistence failure must fail");
+			$this->assertSame("old active {$label}\n", file_get_contents($active), "{$label}: active rollback");
+			$this->assertSame($old_raw, file_get_contents("{$base}.orig"), "{$label}: raw rollback");
+			$this->assertSame($old_hash, file_get_contents("{$base}.xxhash128"), "{$label}: hash rollback");
+			$this->assertSame($old_source, file_get_contents("{$base}.source"), "{$label}: source rollback");
+			$this->assertSame($old_etag, pfb_validator_read("{$base}.orig")['etag'], "{$label}: ETag rollback");
+			$this->assertSame($old_lastmod, pfb_validator_read("{$base}.orig")['lastmod'], "{$label}: Last-Modified rollback");
+
+			chmod("{$base}.xxhash128", 0644);
+			$this->assertTrue($this->downloadTop1m($fixture['source'], $base, $active), "{$label}: recovery succeeds");
+			$this->assertSame($fixture['body'], file_get_contents($active), "{$label}: recovered active");
+			$this->assertSame($old_source, file_get_contents("{$base}.source"), "{$label}: source preserved until identity update");
+		}
+	}
+
+	public function testTop1mFirstPersistenceFailureLeavesNoActiveOrBaseline(): void
+	{
+		$source = $this->dir . '/first-failure.gz';
+		file_put_contents($source, gzencode("rank,first.test\n"));
+		$base = $this->dir . '/first-failure.csv.gz';
+		$active = $this->dir . '/first-failure.csv';
+		$this->assertTrue(mkdir("{$base}.xxhash128"));
+
+		$this->assertFalse($this->downloadTop1m($source, $base, $active));
+		$this->assertFileDoesNotExist($active);
+		$this->assertFileDoesNotExist("{$base}.orig");
+		$this->assertFileDoesNotExist("{$base}.source");
+		$this->assertDirectoryExists("{$base}.xxhash128");
+		$this->assertFileDoesNotExist("{$base}.orig.etag");
+		$this->assertFileDoesNotExist("{$base}.orig.lastmod");
+	}
+
+	/** @param array<string,string> $entries */
+	private function zipFixture(string $name, array $entries): string
+	{
+		$path = $this->dir . '/' . $name;
+		$zip = new ZipArchive();
+		$this->assertSame(TRUE, $zip->open($path, ZipArchive::CREATE));
+		foreach ($entries as $member => $body) {
+			$this->assertTrue($zip->addFromString($member, $body));
+		}
+		$this->assertTrue($zip->close());
+		return $path;
+	}
+
+	private function downloadTop1m(string $source, string $base, string $target): bool
+	{
+		$GLOBALS['pfb']['dbdir'] = $this->dir . '/db';
+		$this->assertTrue(is_dir($GLOBALS['pfb']['dbdir']) || mkdir($GLOBALS['pfb']['dbdir']));
+		$router = $this->dir . '/router.php';
+		$this->assertNotFalse(file_put_contents($router, "<?php\nreadfile(" . var_export($source, TRUE) . ");\n"));
+		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$port = 0;
+		for ($try = 0; $try < 10 && $port === 0; $try++) {
+			$candidate = random_int(20000, 60000);
+			$proc = proc_open(
+				['php', '-S', "127.0.0.1:{$candidate}", $router],
+				$descriptors,
+				$pipes,
+				$this->dir,
+				['PATH' => (string) getenv('PATH')]
+			);
+			if (!is_resource($proc)) {
+				continue;
+			}
+			for ($poll = 0; $poll < 40; $poll++) {
+				$sock = @fsockopen('127.0.0.1', $candidate, $errno, $errstr, 0.05);
+				if ($sock !== FALSE) {
+					fclose($sock);
+					$this->server = $proc;
+					$port = $candidate;
+					break;
+				}
+				usleep(50000);
+			}
+			if ($port === 0) {
+				proc_terminate($proc);
+				proc_close($proc);
+			}
+		}
+		if ($port === 0) {
+			$this->markTestSkipped('loopback HTTP fixture unavailable');
+		}
+		return pfb_download(new PfbDownloadRequest(
+			listUrl: "http://127.0.0.1:{$port}/feed",
+			downloadPath: $base,
+			flex: FALSE,
+			header: $target,
+			format: '',
+			logType: 1,
+			timeout: 30,
+			type: 'top1m',
+		))->success;
 	}
 
 	public function testDccDispatchUsesExistingDnsblTriggerApi(): void

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -41,8 +41,6 @@ final class Top1mDccDetectorTest extends TestCase
 		foreach (['log', 'errlog', 'pnow'] as $key) {
 			$this->saved_pfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$key] : FALSE;
 		}
-		$this->saved_pfb['mime_types'] = $GLOBALS['pfb']['mime_types'] ?? FALSE;
-		$GLOBALS['pfb']['mime_types'] = $GLOBALS['pfb_shipped_mime_types'] ?? $GLOBALS['pfb']['mime_types'] ?? [];
 		$GLOBALS['pfb']['log'] = "{$this->dir}/pfblockerng.log";
 		$GLOBALS['pfb']['errlog'] = "{$this->dir}/error.log";
 		$GLOBALS['pfb']['pnow'] = 'now';

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1542 — TOP1M's daily DCC detector and fail-safe publication contract.
+ *
+ * The detector tests use the shipped pfb_download() HTTP path where the host
+ * permits a local fixture. Archive publication's final rename failure cannot
+ * be induced portably off-appliance, so the exact staging seam is also pinned
+ * against the production source (the live smoke suite exercises the appliance
+ * filesystem failure path).
+ */
+#[CoversFunction('pfb_top1m_probe_decision')]
+#[CoversFunction('pfb_top1m_source_identity')]
+#[CoversFunction('pfb_top1m_invalidate_baseline')]
+#[CoversFunction('pfb_top1m_settings_reprocess')]
+#[CoversFunction('pfb_top1m_download_ledger_update')]
+#[CoversFunction('pfb_download')]
+#[CoversFunction('pfb_validator_read')]
+#[CoversFunction('pfb_validator_write')]
+final class Top1mDccDetectorTest extends TestCase
+{
+	private string $dir;
+
+	/** @var resource|null */
+	private $server = NULL;
+
+	private int $port = 0;
+
+	/** @var array<string,mixed> */
+	private array $saved_pfb = [];
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_top1m_dcc_' . getmypid() . '_' . uniqid();
+		$this->assertTrue(mkdir($this->dir, 0777, TRUE));
+		foreach (['log', 'errlog', 'pnow'] as $key) {
+			$this->saved_pfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$key] : FALSE;
+		}
+		$GLOBALS['pfb']['log'] = "{$this->dir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$this->dir}/error.log";
+		$GLOBALS['pfb']['pnow'] = 'now';
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_resource($this->server)) {
+			proc_terminate($this->server);
+			proc_close($this->server);
+		}
+		foreach ($this->saved_pfb as $key => $value) {
+			if ($value === FALSE) {
+				unset($GLOBALS['pfb'][$key]);
+			} else {
+				$GLOBALS['pfb'][$key] = $value;
+			}
+		}
+		if (is_dir($this->dir)) {
+			$it = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator($this->dir, FilesystemIterator::SKIP_DOTS),
+				RecursiveIteratorIterator::CHILD_FIRST
+			);
+			foreach ($it as $file) {
+				$file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+			}
+			rmdir($this->dir);
+		}
+	}
+
+	public function testProbeDecisionIsFailSafeAcrossDetectorRows(): void
+	{
+		$this->assertSame('unchanged', pfb_top1m_probe_decision(TRUE, '304', 'ignored', 'ignored'));
+		$this->assertSame('unchanged', pfb_top1m_probe_decision(TRUE, '200', 'same', 'same'));
+		$this->assertSame('changed', pfb_top1m_probe_decision(TRUE, '200', 'new', 'old'));
+		$this->assertSame('changed', pfb_top1m_probe_decision(TRUE, '200', 'new', ''));
+		$this->assertSame('changed', pfb_top1m_probe_decision(TRUE, '200', FALSE, 'old'));
+		$this->assertSame('changed', pfb_top1m_probe_decision(TRUE, '500', FALSE, 'old'));
+		$this->assertSame('failed', pfb_top1m_probe_decision(FALSE, '', FALSE, 'old'));
+	}
+
+	public function testProviderIdentityCoversAllFiveProvidersAndAuth(): void
+	{
+		foreach (pfb_top1m_providers() as $provider => $descriptor) {
+			$identity = pfb_top1m_source_identity($provider, $descriptor['url'], pfb_top1m_auth_headers($descriptor, 'token'));
+			$this->assertNotSame('', $identity, "{$provider}: source identity must not be empty");
+		}
+		$base = pfb_top1m_source_identity('tranco', 'https://example.test/feed', []);
+		$this->assertNotSame($base, pfb_top1m_source_identity('cisco', 'https://example.test/feed', []));
+		$this->assertNotSame($base, pfb_top1m_source_identity('tranco', 'https://example.test/other', []));
+		$this->assertNotSame($base, pfb_top1m_source_identity('tranco', 'https://example.test/feed', ['Authorization: Bearer token']));
+	}
+
+	public function testProviderChangeInvalidatesActualValidatorsButRetainsActiveDerivedSource(): void
+	{
+		$base = $this->dir . '/top-1m.csv.zip';
+		$validator_base = "{$base}.orig";
+		pfb_validator_write($validator_base, '"old-etag"', 1700000000);
+		file_put_contents("{$base}.orig", 'old raw');
+		file_put_contents("{$base}.xxhash128", str_repeat('a', 32));
+		file_put_contents("{$base}.source", 'old identity');
+		$active = $this->dir . '/top-1m.csv';
+		file_put_contents($active, 'old derived');
+
+		pfb_top1m_invalidate_baseline($base);
+
+		$this->assertFileDoesNotExist("{$base}.orig");
+		$this->assertFileDoesNotExist("{$validator_base}.etag");
+		$this->assertFileDoesNotExist("{$validator_base}.lastmod");
+		$this->assertFileDoesNotExist("{$base}.xxhash128");
+		$this->assertFileDoesNotExist("{$base}.source");
+		$this->assertFalse(pfb_validator_read($validator_base)['etag']);
+		$this->assertFalse(pfb_validator_read($validator_base)['lastmod']);
+		$this->assertSame('old derived', file_get_contents($active));
+	}
+
+	public function testOnlyLocalFilteringSettingsRequestCachedSourceReprocess(): void
+	{
+		$before = ['enable' => 'on', 'count' => '1000', 'tld' => 'com', 'provider' => 'tranco'];
+		$this->assertFalse(pfb_top1m_settings_reprocess($before, $before));
+		$provider = $before;
+		$provider['provider'] = 'cisco';
+		$this->assertFalse(pfb_top1m_settings_reprocess($before, $provider));
+		foreach (['enable', 'count', 'tld'] as $key) {
+			$after = $before;
+			$after[$key] = $key === 'enable' ? 'off' : ($key === 'count' ? '500' : 'net');
+			$this->assertTrue(pfb_top1m_settings_reprocess($before, $after), "{$key} change must reprocess cached source");
+		}
+	}
+
+	public function testDownloadFailureAndRecoveryUseOneStableLedgerItem(): void
+	{
+		pfb_top1m_download_ledger_update(FALSE, $this->dir, 'upstream failed');
+		$open = pfb_sync_status_list_open($this->dir, 'dnsbl');
+		$this->assertCount(1, $open);
+		$this->assertSame('top1m', $open[0]['item']);
+		$this->assertSame('download', $open[0]['stage']);
+		pfb_top1m_download_ledger_update(FALSE, $this->dir, 'still failed');
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'dnsbl'));
+		pfb_top1m_download_ledger_update(TRUE, $this->dir, '');
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'));
+	}
+
+	public function testChangeDetectUsesActualHttpProbeBodyAndMetadata(): void
+	{
+		if (!extension_loaded('curl')) {
+			$this->markTestSkipped('curl extension not available');
+		}
+		$body = "1,example.com\n";
+		$router = "{$this->dir}/router.php";
+		$this->assertNotFalse(file_put_contents($router, "<?php\nheader('ETag: \\\"followup-v1\\\"');\necho " . var_export($body, TRUE) . ";\n"));
+		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		for ($try = 0; $try < 10; $try++) {
+			$port = random_int(20000, 60000);
+			$proc = proc_open(['php', '-S', "127.0.0.1:{$port}", $router], $descriptors, $pipes, $this->dir, ['PATH' => (string) getenv('PATH')]);
+			if (!is_resource($proc)) {
+				continue;
+			}
+			for ($poll = 0; $poll < 40; $poll++) {
+				$sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.05);
+				if ($sock !== FALSE) {
+					fclose($sock);
+					$this->server = $proc;
+					$this->port = $port;
+					break 2;
+				}
+				usleep(50000);
+			}
+			proc_terminate($proc);
+			proc_close($proc);
+		}
+		$this->assertNotSame(0, $this->port, 'could not start local HTTP fixture');
+
+		$target = $this->dir . '/top-1m.csv.zip.md5';
+		$meta = [];
+		$result = pfb_download("http://127.0.0.1:{$this->port}/feed.csv", $target, FALSE, 'TOP1M probe', '', 1, '', 30, 'change_detect', '', '', FALSE, $meta);
+		$this->assertTrue($result);
+		$this->assertSame('200', $meta['status'] ?? '');
+		$this->assertSame($body, file_get_contents("{$target}.raw"));
+		$this->assertSame(pfb_content_hash($body, FALSE), pfb_content_hash("{$target}.raw", TRUE));
+	}
+
+	public function testDetectorSidecarReadFailsSafeForMissingCorruptAndWrongAlgorithm(): void
+	{
+		$base = $this->dir . '/top-1m.csv.zip';
+		$body_hash = pfb_content_hash('same body', FALSE);
+		$this->assertSame('changed', pfb_top1m_probe_decision(TRUE, '200', $body_hash, pfb_hash_read($base)['digest']));
+		file_put_contents("{$base}.xxhash128", 'not-a-digest');
+		$this->assertSame('changed', pfb_top1m_probe_decision(TRUE, '200', $body_hash, pfb_hash_read($base)['digest']));
+		file_put_contents("{$base}.xxhash128", str_repeat('b', 32));
+		$this->assertSame('changed', pfb_top1m_probe_decision(TRUE, '200', $body_hash, pfb_hash_read($base)['digest']));
+	}
+
+	public function testTop1mPublishBranchesUseStagingBeforeActiveDestination(): void
+	{
+		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
+		$this->assertIsString($source);
+		$this->assertStringContainsString('$top1m_stage = @tempnam', $source);
+		$this->assertStringContainsString('pfb_top1m_persist_baseline($file_dwn, $file_download)', $source);
+		$this->assertStringContainsString('pfb_top1m_invalidate_baseline($file_dwn)', $source);
+	}
+
+	public function testDccDispatchUsesExistingDnsblTriggerApi(): void
+	{
+		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php');
+		$this->assertIsString($source);
+		$this->assertStringContainsString('pfb_trigger scope=dnsbl force=false trigger=cron', $source);
+	}
+}

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -205,6 +205,7 @@ final class Top1mDccDetectorTest extends TestCase
 	public function testTop1mZipFileTargetRejectsMultipleMembersAndRetainsActiveAndBaseline(): void
 	{
 		$archive = $this->zipFixture('multiple.zip', ['feed/a.csv' => "new-a\n", 'feed/b.csv' => "new-b\n"]);
+		$this->requireZipTarSupport($archive);
 		$base = $this->dir . '/top-1m.csv.zip';
 		$active = $this->dir . '/top-1m.csv';
 		file_put_contents($active, 'old active');
@@ -222,6 +223,7 @@ final class Top1mDccDetectorTest extends TestCase
 	public function testTop1mZipFileTargetPublishesSingleRegularMemberAndThenPersistsBaseline(): void
 	{
 		$archive = $this->zipFixture('single.zip', ['feed/top.csv' => "rank,example.test\n"]);
+		$this->requireZipTarSupport($archive);
 		$base = $this->dir . '/top-1m.csv.zip';
 		$active = $this->dir . '/top-1m.csv';
 		file_put_contents($active, 'old active');
@@ -236,6 +238,7 @@ final class Top1mDccDetectorTest extends TestCase
 	public function testTop1mZipDirectoryTargetExtractsEveryMember(): void
 	{
 		$archive = $this->zipFixture('directory.zip', ['feed/a.csv' => "a\n", 'feed/b.csv' => "b\n"]);
+		$this->requireZipTarSupport($archive);
 		$base = $this->dir . '/top-1m.csv.zip';
 		$target = $this->dir . '/out';
 		$this->assertTrue(mkdir($target));
@@ -248,6 +251,7 @@ final class Top1mDccDetectorTest extends TestCase
 	public function testTop1mZipUnsafeMemberMakesNoActiveOrStagingWrite(): void
 	{
 		$archive = $this->zipFixture('unsafe.zip', ['feed/good.csv' => "good\n", '../escape.csv' => "escape\n"]);
+		$this->requireZipTarSupport($archive);
 		$base = $this->dir . '/top-1m.csv.zip';
 		$active = $this->dir . '/top-1m.csv';
 		file_put_contents($active, 'old active');
@@ -315,6 +319,9 @@ final class Top1mDccDetectorTest extends TestCase
 				'body' => "rank,plain.test\n",
 			],
 		];
+		if (!$this->tarReadsZip($fixtures['zip']['source'])) {
+			unset($fixtures['zip']);
+		}
 
 		foreach ($fixtures as $label => $fixture) {
 			$base = $fixture['base'];
@@ -374,6 +381,19 @@ final class Top1mDccDetectorTest extends TestCase
 		}
 		$this->assertTrue($zip->close());
 		return $path;
+	}
+
+	private function requireZipTarSupport(string $archive): void
+	{
+		if (!$this->tarReadsZip($archive)) {
+			$this->markTestSkipped('/usr/bin/tar cannot read ZIP on this host; pfSense uses bsdtar');
+		}
+	}
+
+	private function tarReadsZip(string $archive): bool
+	{
+		exec('/usr/bin/tar -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
+		return $status === 0;
 	}
 
 	private function downloadTop1m(string $source, string $base, string $target): bool

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -87,38 +87,38 @@ final class Top1mDccDetectorTest extends TestCase
 
 	public function testExtractedDetectorDecisionPreservesExistingProbeMatrix(): void
 	{
-		$this->assertSame('unchanged', pfb_top1m_detector_decision(TRUE, '304', FALSE, 'ignored'));
-		$this->assertSame('unchanged', pfb_top1m_detector_decision(TRUE, '200', 'same', 'same'));
-		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '200', 'new', 'old'));
-		$this->assertSame('failed', pfb_top1m_detector_decision(FALSE, '', FALSE, 'old'));
+		$this->assertSame('unchanged', pfb_top1m_detector_decision(TRUE, '304', FALSE, 'ignored', NULL, TRUE, FALSE));
+		$this->assertSame('unchanged', pfb_top1m_detector_decision(TRUE, '200', 'same', 'same', NULL, TRUE, FALSE));
+		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '200', 'new', 'old', NULL, TRUE, FALSE));
+		$this->assertSame('failed', pfb_top1m_detector_decision(FALSE, '', FALSE, 'old', NULL, TRUE, FALSE));
 	}
 
 	public function testDetectorRequiresUsableRawBaselineBeforeUnchangedDecision(): void
 	{
 		$base = $this->dir . '/top-1m.csv.zip';
 		$raw = "{$base}.orig";
-		$body = "rank,example.test\n";
+		$body = "1,example.test\n";
 		$body_hash = pfb_content_hash($body, FALSE);
 		file_put_contents($raw, $body);
 		$this->assertTrue(pfb_hash_write($base, $raw));
 		$persisted_hash = pfb_hash_read($base)['digest'];
 
-		$this->assertSame('unchanged', pfb_top1m_detector_decision(TRUE, '304', FALSE, $persisted_hash, $base, TRUE));
-		$this->assertSame('unchanged', pfb_top1m_detector_decision(TRUE, '200', $body_hash, $persisted_hash, $base, TRUE));
+		$this->assertSame('unchanged', pfb_top1m_detector_decision(TRUE, '304', FALSE, $persisted_hash, $base, TRUE, FALSE));
+		$this->assertSame('unchanged', pfb_top1m_detector_decision(TRUE, '200', $body_hash, $persisted_hash, $base, TRUE, FALSE));
 
 		// A matching hash without a regular raw source cannot make a 304 safe.
 		unlink($raw);
-		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '304', FALSE, $persisted_hash, $base, TRUE));
-		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '200', $body_hash, $persisted_hash, $base, TRUE));
+		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '304', FALSE, $persisted_hash, $base, TRUE, FALSE));
+		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '200', $body_hash, $persisted_hash, $base, TRUE, FALSE));
 
 		file_put_contents($raw, $body);
 		unlink("{$base}.xxhash128");
-		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '304', FALSE, '', $base, TRUE));
+		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '304', FALSE, '', $base, TRUE, FALSE));
 		file_put_contents("{$base}.xxhash128", 'not-a-digest');
-		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '200', $body_hash, $persisted_hash, $base, TRUE));
+		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '200', $body_hash, $persisted_hash, $base, TRUE, FALSE));
 
-		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '304', FALSE, $persisted_hash, $base, FALSE));
-		$this->assertSame('failed', pfb_top1m_detector_decision(FALSE, '', FALSE, $persisted_hash, $base, TRUE));
+		$this->assertSame('changed', pfb_top1m_detector_decision(TRUE, '304', FALSE, $persisted_hash, $base, FALSE, FALSE));
+		$this->assertSame('failed', pfb_top1m_detector_decision(FALSE, '', FALSE, $persisted_hash, $base, TRUE, FALSE));
 	}
 
 	public function testProviderIdentityCoversAllFiveProvidersAndAuth(): void
@@ -395,7 +395,7 @@ final class Top1mDccDetectorTest extends TestCase
 	public function testTop1mFirstPersistenceFailureLeavesNoActiveOrBaseline(): void
 	{
 		$source = $this->dir . '/first-failure.gz';
-		file_put_contents($source, gzencode("rank,first.test\n"));
+		file_put_contents($source, gzencode("1,first.test\n"));
 		$base = $this->dir . '/first-failure.csv.gz';
 		$active = $this->dir . '/first-failure.csv';
 		$this->assertTrue(mkdir("{$base}.xxhash128"));

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -41,6 +41,8 @@ final class Top1mDccDetectorTest extends TestCase
 		foreach (['log', 'errlog', 'pnow'] as $key) {
 			$this->saved_pfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$key] : FALSE;
 		}
+		$this->saved_pfb['mime_types'] = $GLOBALS['pfb']['mime_types'] ?? FALSE;
+		$GLOBALS['pfb']['mime_types'] = $GLOBALS['pfb_shipped_mime_types'] ?? $GLOBALS['pfb']['mime_types'] ?? [];
 		$GLOBALS['pfb']['log'] = "{$this->dir}/pfblockerng.log";
 		$GLOBALS['pfb']['errlog'] = "{$this->dir}/error.log";
 		$GLOBALS['pfb']['pnow'] = 'now';

--- a/tests/php/Top1mDownloadSemanticValidationTest.php
+++ b/tests/php/Top1mDownloadSemanticValidationTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1542 — TOP1M candidates must pass semantic validation before publication.
+ */
+#[CoversFunction('pfb_download')]
+final class Top1mDownloadSemanticValidationTest extends TestCase
+{
+	private string $dir;
+
+	/** @var resource|null */
+	private $server = NULL;
+
+	/** @var array<string,mixed> */
+	private array $savedPfb = [];
+
+	/** @var array<string,mixed> */
+	private array $savedConfig = [];
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_top1m_semantic_' . getmypid() . '_' . uniqid();
+		$this->assertTrue(mkdir($this->dir, 0777, TRUE));
+		foreach (['dbdir', 'log', 'errlog', 'pnow', 'mime_types', 'dnsbl_top1m_type', 'unbound_py_top1m'] as $key) {
+			$this->savedPfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? [])
+				? $GLOBALS['pfb'][$key] : FALSE;
+		}
+		$this->savedConfig = $GLOBALS['config'] ?? [];
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb']['dbdir'] = "{$this->dir}/db";
+		$GLOBALS['pfb']['log'] = "{$this->dir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$this->dir}/pfblockerng_error.log";
+		$GLOBALS['pfb']['pnow'] = 'now';
+		$GLOBALS['pfb']['mime_types'] = $GLOBALS['pfb_shipped_mime_types'] ?? $GLOBALS['pfb']['mime_types'] ?? [];
+		$GLOBALS['pfb']['dnsbl_top1m_type'] = PfbTop1mSource::Tranco;
+		$GLOBALS['pfb']['unbound_py_top1m'] = "{$this->dir}/fixed-top1m.txt";
+		$this->assertTrue(mkdir($GLOBALS['pfb']['dbdir']));
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_resource($this->server)) {
+			proc_terminate($this->server);
+			proc_close($this->server);
+		}
+		foreach ($this->savedPfb as $key => $value) {
+			if ($value === FALSE) {
+				unset($GLOBALS['pfb'][$key]);
+			} else {
+				$GLOBALS['pfb'][$key] = $value;
+			}
+		}
+		$GLOBALS['config'] = $this->savedConfig;
+		if (is_dir($this->dir)) {
+			$it = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator($this->dir, FilesystemIterator::SKIP_DOTS),
+				RecursiveIteratorIterator::CHILD_FIRST
+			);
+			foreach ($it as $file) {
+				$file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+			}
+			rmdir($this->dir);
+		}
+	}
+
+	public function testPlainHtmlCandidateFailsClosedAndPreservesLastGoodPublication(): void
+	{
+		$base = "{$this->dir}/top-1m.csv.zip";
+		$active = "{$this->dir}/top-1m.csv";
+		$before = $this->seedLastGoodState($base, $active);
+		$body = "<!doctype html>\n<html><body><h1>503 Service Unavailable</h1></body></html>\n";
+
+		$this->assertSame(PfbToggle::Off, PfbConfig::read('pfb_feed_sanity'), 'sanity setting must be off for this gate proof');
+		$result = $this->downloadBody($body, $base, $active);
+
+		$this->assertFalse($result->success, 'HTML 200 must fail TOP1M semantic publication even with sanity disabled');
+		$this->assertSame($before, $this->snapshotState($base, $active), 'HTML candidate changed last-good publication state');
+	}
+
+	public function testHeaderOnlyCandidateFailsClosedAndPreservesLastGoodPublication(): void
+	{
+		$base = "{$this->dir}/top-1m.csv.zip";
+		$active = "{$this->dir}/top-1m.csv";
+		$before = $this->seedLastGoodState($base, $active);
+		$body = "rank,domain\n";
+
+		$result = $this->downloadBody($body, $base, $active);
+
+		$this->assertFalse($result->success, 'header-only TOP1M candidate must fail provider-semantic validation');
+		$this->assertSame($before, $this->snapshotState($base, $active), 'header-only candidate changed last-good publication state');
+	}
+
+	public function testValidPlainCandidateReplacesActiveAndPersistsNewBaseline(): void
+	{
+		$base = "{$this->dir}/top-1m.csv.zip";
+		$active = "{$this->dir}/top-1m.csv";
+		$before = $this->seedLastGoodState($base, $active);
+		$body = "1,new.example.com\n";
+
+		$result = $this->downloadBody($body, $base, $active);
+
+		$this->assertTrue($result->success, 'valid TOP1M candidate must publish');
+		$after = $this->snapshotState($base, $active);
+		$this->assertSame($body, file_get_contents($active), 'valid candidate active bytes');
+		$this->assertSame($body, file_get_contents("{$base}.orig"), 'valid candidate raw baseline bytes');
+		$this->assertSame(pfb_content_hash($body, FALSE), pfb_hash_read($base)['digest'], 'valid candidate hash baseline');
+		$this->assertSame($before['whitelist'], $after['whitelist'], 'download must not rewrite derived whitelist');
+		$this->assertSame($before['fixed'], $after['fixed'], 'download must not rewrite fixed TOP1M sidecar');
+		$this->assertFileExists($GLOBALS['pfb']['dbdir'] . '/top-1m.update', 'valid publication must set update marker');
+	}
+
+	/** @return array<string,string|false> */
+	private function seedLastGoodState(string $base, string $active): array
+	{
+		$oldActive = "old-active.example\n";
+		$oldRaw = "old-wire.example\n";
+		$oldSource = 'old-provider-identity';
+		$oldWhitelist = ".old.example,,\n,old.example,,\n,www.old.example,,\n";
+		$oldFixed = "fixed-old\n";
+		$this->assertNotFalse(file_put_contents($active, $oldActive));
+		$this->assertNotFalse(file_put_contents("{$base}.orig", $oldRaw));
+		$this->assertTrue(pfb_hash_write($base, "{$base}.orig"));
+		$this->assertNotFalse(file_put_contents("{$base}.source", $oldSource));
+		pfb_validator_write("{$base}.orig", '"old-etag"', 1700000000);
+		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['dbdir'] . '/pfbalexawhitelist.txt', $oldWhitelist));
+		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['unbound_py_top1m'], $oldFixed));
+		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['dbdir'] . '/top-1m.update', 'old-marker'));
+
+		return $this->snapshotState($base, $active);
+	}
+
+	/** @return array<string,string|false> */
+	private function snapshotState(string $base, string $active): array
+	{
+		$paths = [
+			'active' => $active,
+			'raw' => "{$base}.orig",
+			'hash' => "{$base}.xxhash128",
+			'source' => "{$base}.source",
+			'etag' => "{$base}.orig.etag",
+			'lastmod' => "{$base}.orig.lastmod",
+			'whitelist' => $GLOBALS['pfb']['dbdir'] . '/pfbalexawhitelist.txt',
+			'fixed' => $GLOBALS['pfb']['unbound_py_top1m'],
+			'marker' => $GLOBALS['pfb']['dbdir'] . '/top-1m.update',
+		];
+		$state = [];
+		foreach ($paths as $label => $path) {
+			$state[$label] = is_file($path) ? file_get_contents($path) : FALSE;
+		}
+		return $state;
+	}
+
+	private function downloadBody(string $body, string $base, string $active): PfbDownloadResult
+	{
+		$source = "{$this->dir}/feed-body";
+		$this->assertNotFalse(file_put_contents($source, $body));
+		$router = "{$this->dir}/router.php";
+		$this->assertNotFalse(file_put_contents($router, "<?php\nreadfile(" . var_export($source, TRUE) . ");\n"));
+		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$port = 0;
+		for ($try = 0; $try < 10 && $port === 0; $try++) {
+			$candidate = random_int(20000, 60000);
+			$proc = proc_open(
+				['php', '-S', "127.0.0.1:{$candidate}", $router],
+				$descriptors,
+				$pipes,
+				$this->dir,
+				['PATH' => (string) getenv('PATH')]
+			);
+			if (!is_resource($proc)) {
+				continue;
+			}
+			for ($poll = 0; $poll < 40; $poll++) {
+				$sock = @fsockopen('127.0.0.1', $candidate, $errno, $errstr, 0.05);
+				if ($sock !== FALSE) {
+					fclose($sock);
+					$this->server = $proc;
+					$port = $candidate;
+					break 2;
+				}
+				usleep(50000);
+			}
+			proc_terminate($proc);
+			proc_close($proc);
+		}
+		if ($port === 0) {
+			$this->markTestSkipped('loopback HTTP fixture unavailable');
+		}
+		return pfb_download(new PfbDownloadRequest(
+			listUrl: "http://127.0.0.1:{$port}/feed",
+			downloadPath: $base,
+			flex: FALSE,
+			header: $active,
+			format: '',
+			logType: 1,
+			timeout: 30,
+			type: 'top1m',
+		));
+	}
+}

--- a/tests/php/Top1mFixedFileManifestTest.php
+++ b/tests/php/Top1mFixedFileManifestTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /** Issue #1542: TOP1M is a fixed sidecar file, not manifest-embedded data. */
 final class Top1mFixedFileManifestTest extends TestCase
@@ -122,6 +123,7 @@ final class Top1mFixedFileManifestTest extends TestCase
 		$this->assertFalse($restore_called);
 		$this->assertSame("old.example\n", file_get_contents($target));
 		$this->assertSame('{"old":true}', file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
+		$this->assertSame([], glob("{$this->tmp}/.pfbtop1m_prev_*") ?: []);
 	}
 
 	public function testManifestFailureRollsBackTop1mViaAtomicRename(): void
@@ -151,13 +153,37 @@ final class Top1mFixedFileManifestTest extends TestCase
 		$this->assertSame('{"old":true}', file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
 	}
 
-	public function testDefaultOwnershipFailureAbortsFixedFilePublication(): void
+	public function testMetadataFailureAbortsFixedFilePublication(): void
 	{
 		$source = "{$this->tmp}/source.txt";
 		$target = "{$this->tmp}/target.txt";
 		file_put_contents($source, "source.example\n");
+		$ops = $this->successfulOwnershipOps();
+		$ops['metadata'] = static fn(string $file): bool => FALSE;
 
-		$this->assertFalse(pfb_unbound_py_atomic_copy($source, $target));
+		$this->assertFalse(pfb_unbound_py_atomic_copy($source, $target, $ops));
+		$this->assertFileDoesNotExist($target);
+	}
+
+	public static function ownershipFailureCallbacks(): array
+	{
+		return [
+			'chown' => ['chown'],
+			'chgrp' => ['chgrp'],
+			'chmod' => ['chmod'],
+		];
+	}
+
+	#[DataProvider('ownershipFailureCallbacks')]
+	public function testOwnershipFailureAbortsFixedFilePublication(string $failed_callback): void
+	{
+		$source = "{$this->tmp}/source.txt";
+		$target = "{$this->tmp}/target.txt";
+		file_put_contents($source, "source.example\n");
+		$ops = $this->successfulOwnershipOps();
+		$ops[$failed_callback] = static fn(string $file, $value): bool => FALSE;
+
+		$this->assertFalse(pfb_unbound_py_atomic_copy($source, $target, $ops));
 		$this->assertFileDoesNotExist($target);
 	}
 

--- a/tests/php/Top1mFixedFileManifestTest.php
+++ b/tests/php/Top1mFixedFileManifestTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** Issue #1542: TOP1M is a fixed sidecar file, not manifest-embedded data. */
+final class Top1mFixedFileManifestTest extends TestCase
+{
+	private string $tmp;
+	private array $originalPfb = [];
+
+	protected function setUp(): void
+	{
+		$this->tmp = sys_get_temp_dir() . '/pfb_top1m_fixed_' . getmypid() . '_' . uniqid();
+		mkdir("{$this->tmp}/dnsbl", 0777, TRUE);
+		mkdir("{$this->tmp}/db", 0777, TRUE);
+		$this->originalPfb = $GLOBALS['pfb'];
+		$GLOBALS['pfb'] = array_merge($this->originalPfb, [
+			'log'                => "{$this->tmp}/pfblockerng.log",
+			'errlog'             => "{$this->tmp}/error.log",
+			'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
+			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
+			'unbound_py_top1m'   => "{$this->tmp}/pfb_py_top1m.txt",
+			'dnsdir'             => "{$this->tmp}/dnsbl",
+			'dbdir'              => "{$this->tmp}/db",
+			'dnsbl_top1m'        => 'off',
+			'dnsbl_tld_wildcard' => '',
+			'dnsblconfig'        => ['tldblacklist' => '', 'tldexclusion' => '', 'suppression' => ''],
+		]);
+		file_put_contents("{$this->tmp}/dnsbl/feed.txt", "{\"kind\":\"domain\",\"domain\":\"blocked.example\"}\n");
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb'] = $this->originalPfb;
+		$this->removeTree($this->tmp);
+	}
+
+	public function testDisabledOmitsTop1mFileRequirementAndEmbeddedList(): void
+	{
+		$manifest = pfb_unbound_python_sources([
+			['header' => 'feed', 'group' => 'g', 'log' => '1', 'provenance' => 'feed'],
+		]);
+
+		$this->assertIsArray($manifest);
+		$this->assertFalse($manifest['config']['top1m_enabled']);
+		$this->assertArrayNotHasKey('top1m_list', $manifest['config']);
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['unbound_py_top1m']);
+	}
+
+	public function testEnabledPublishesFixedFileBeforeManifestAndPreservesBytes(): void
+	{
+		$source = "one.example\r\n\r\n two.example \r\none.example\r\n";
+		file_put_contents("{$this->tmp}/db/pfbalexawhitelist.txt", $source);
+		$GLOBALS['pfb']['dnsbl_top1m'] = 'on';
+		$manifest = pfb_unbound_python_sources([
+			['header' => 'feed', 'group' => 'g', 'log' => '1', 'provenance' => 'feed'],
+		]);
+
+		$this->assertIsArray($manifest);
+		$this->assertTrue($manifest['config']['top1m_enabled']);
+		$this->assertArrayNotHasKey('top1m_list', $manifest['config']);
+		$this->assertSame($source, file_get_contents($GLOBALS['pfb']['unbound_py_top1m']));
+		$this->assertFileExists($GLOBALS['pfb']['unbound_py_sources']);
+	}
+
+	public function testEnabledPublicationFailureLeavesPreviousFileAndManifest(): void
+	{
+		$target = $GLOBALS['pfb']['unbound_py_top1m'];
+		file_put_contents($target, "old.example\n");
+		file_put_contents($GLOBALS['pfb']['unbound_py_sources'], '{"old":true}');
+		file_put_contents("{$this->tmp}/db/pfbalexawhitelist.txt", "new.example\n");
+		$GLOBALS['pfb']['dnsbl_top1m'] = 'on';
+
+		$manifest = pfb_unbound_python_sources([], [
+			'top1m_atomic' => [
+				'write' => static fn($stream, string $bytes): int => strlen($bytes),
+				'flush' => static fn($stream): bool => FALSE,
+				'fsync'  => static fn($stream): bool => TRUE,
+			],
+		]);
+
+		$this->assertFalse($manifest);
+		$this->assertSame("old.example\n", file_get_contents($target));
+		$this->assertSame('{"old":true}', file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
+	}
+
+	private function removeTree(string $dir): void
+	{
+		if (!is_dir($dir)) {
+			return;
+		}
+		$it = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($it as $entry) {
+			$entry->isDir() ? rmdir($entry->getPathname()) : unlink($entry->getPathname());
+		}
+		rmdir($dir);
+	}
+}

--- a/tests/php/Top1mFixedFileManifestTest.php
+++ b/tests/php/Top1mFixedFileManifestTest.php
@@ -56,6 +56,8 @@ final class Top1mFixedFileManifestTest extends TestCase
 		$GLOBALS['pfb']['dnsbl_top1m'] = 'on';
 		$manifest = pfb_unbound_python_sources([
 			['header' => 'feed', 'group' => 'g', 'log' => '1', 'provenance' => 'feed'],
+		], [
+			'top1m_atomic' => $this->successfulOwnershipOps(),
 		]);
 
 		$this->assertIsArray($manifest);
@@ -78,12 +80,94 @@ final class Top1mFixedFileManifestTest extends TestCase
 				'write' => static fn($stream, string $bytes): int => strlen($bytes),
 				'flush' => static fn($stream): bool => FALSE,
 				'fsync'  => static fn($stream): bool => TRUE,
-			],
+			] + $this->successfulOwnershipOps(),
 		]);
 
 		$this->assertFalse($manifest);
 		$this->assertSame("old.example\n", file_get_contents($target));
 		$this->assertSame('{"old":true}', file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
+	}
+
+	public function testCopyFailureKeepsOldTargetVisibleAndDoesNotRestore(): void
+	{
+		$target = $GLOBALS['pfb']['unbound_py_top1m'];
+		file_put_contents($target, "old.example\n");
+		file_put_contents($GLOBALS['pfb']['unbound_py_sources'], '{"old":true}');
+		file_put_contents("{$this->tmp}/db/pfbalexawhitelist.txt", "new.example\n");
+		$GLOBALS['pfb']['dnsbl_top1m'] = 'on';
+		$copy_observed = [];
+		$restore_called = FALSE;
+
+		$result = pfb_unbound_python_sources([], [
+			'top1m_atomic' => [
+				'write' => static fn($stream, string $bytes): int => strlen($bytes),
+				'flush' => static fn($stream): bool => TRUE,
+				'fsync'  => static fn($stream): bool => TRUE,
+				'rename' => function (string $from, string $to) use (&$copy_observed): bool {
+					$copy_observed[] = [file_exists($to), file_get_contents($to)];
+					return FALSE;
+				},
+				'restore' => static function (string $from, string $to) use (&$restore_called): bool {
+					$restore_called = TRUE;
+					return FALSE;
+				},
+			] + $this->successfulOwnershipOps(),
+			'manifest_atomic' => [
+				'rename' => static fn(string $from, string $to): bool => FALSE,
+			],
+		]);
+
+		$this->assertFalse($result);
+		$this->assertSame([[TRUE, "old.example\n"]], $copy_observed);
+		$this->assertFalse($restore_called);
+		$this->assertSame("old.example\n", file_get_contents($target));
+		$this->assertSame('{"old":true}', file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
+	}
+
+	public function testManifestFailureRollsBackTop1mViaAtomicRename(): void
+	{
+		$target = $GLOBALS['pfb']['unbound_py_top1m'];
+		file_put_contents($target, "old.example\n");
+		file_put_contents($GLOBALS['pfb']['unbound_py_sources'], '{"old":true}');
+		file_put_contents("{$this->tmp}/db/pfbalexawhitelist.txt", "new.example\n");
+		$GLOBALS['pfb']['dnsbl_top1m'] = 'on';
+		$restore_observed = [];
+
+		$result = pfb_unbound_python_sources([], [
+			'top1m_atomic' => [
+				'restore' => function (string $from, string $to) use (&$restore_observed): bool {
+					$restore_observed[] = [file_exists($to), file_get_contents($to)];
+					return rename($from, $to);
+				},
+			] + $this->successfulOwnershipOps(),
+			'manifest_atomic' => [
+				'rename' => static fn(string $from, string $to): bool => FALSE,
+			],
+		]);
+
+		$this->assertFalse($result);
+		$this->assertSame([[TRUE, "new.example\n"]], $restore_observed);
+		$this->assertSame("old.example\n", file_get_contents($target));
+		$this->assertSame('{"old":true}', file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
+	}
+
+	public function testDefaultOwnershipFailureAbortsFixedFilePublication(): void
+	{
+		$source = "{$this->tmp}/source.txt";
+		$target = "{$this->tmp}/target.txt";
+		file_put_contents($source, "source.example\n");
+
+		$this->assertFalse(pfb_unbound_py_atomic_copy($source, $target));
+		$this->assertFileDoesNotExist($target);
+	}
+
+	private function successfulOwnershipOps(): array
+	{
+		return [
+			'chown' => static fn(string $file, string $owner): bool => TRUE,
+			'chgrp' => static fn(string $file, string $group): bool => TRUE,
+			'chmod' => static fn(string $file, int $mode): bool => TRUE,
+		];
 	}
 
 	private function removeTree(string $dir): void

--- a/tests/php/Top1mSemanticMatrixTest.php
+++ b/tests/php/Top1mSemanticMatrixTest.php
@@ -74,12 +74,37 @@ final class Top1mSemanticMatrixTest extends TestCase
 	public function testAllProviderDescriptorsAcceptValidRowsAndRejectHostileRows(): void
 	{
 		$providers = pfb_top1m_providers();
-		$validRows = [
-			'tranco' => ["7,Example.COM\n", 'example.com'],
-			'cisco' => ["42,Mixed.Example\n", 'mixed.example'],
-			'openpagerank' => ["rank,domain,com,10,5\n1,Example.COM,com,10,5\n", 'example.com'],
-			'majestic' => ["rank,ref_subnets,domain,tld,position\n1,1,Example.COM,com,1\n", 'example.com'],
-			'cloudflare' => ["domain\nExample.COM\n", 'example.com'],
+		$fixtures = [
+			'tranco' => [
+				'header' => '',
+				'fields' => ['7', 'Example.COM'],
+				'domain' => 'example.com',
+				'columns' => 2,
+			],
+			'cisco' => [
+				'header' => '',
+				'fields' => ['42', 'Mixed.Example'],
+				'domain' => 'mixed.example',
+				'columns' => 2,
+			],
+			'openpagerank' => [
+				'header' => "Rank,Domain,Extension,Open Page Rank,Referring Domains\n",
+				'fields' => ['1', 'Example.COM', 'com', '10', '5'],
+				'domain' => 'example.com',
+				'columns' => 5,
+			],
+			'majestic' => [
+				'header' => "GlobalRank,TldRank,Domain,TLD,RefSubNets,RefIPs,IDN_Domain,IDN_TLD,PrevGlobalRank,PrevTldRank,PrevRefSubNets,PrevRefIPs\n",
+				'fields' => ['1', '1', 'Example.COM', 'com', '10', '20', '', '', '2', '2', '9', '19'],
+				'domain' => 'example.com',
+				'columns' => 12,
+			],
+			'cloudflare' => [
+				'header' => "domain\n",
+				'fields' => ['Example.COM'],
+				'domain' => 'example.com',
+				'columns' => 1,
+			],
 		];
 		$wrongRows = [
 			'tranco' => "rank,Example.COM\n",
@@ -90,16 +115,16 @@ final class Top1mSemanticMatrixTest extends TestCase
 		];
 
 		foreach ($providers as $id => $provider) {
+			$validDataLine = implode(',', $fixtures[$id]['fields']) . "\n";
+			$validBody = $fixtures[$id]['header'] . $validDataLine;
 			$validPath = "{$this->dir}/{$id}-valid.csv";
-			$this->assertNotFalse(file_put_contents($validPath, $validRows[$id][0]));
+			$this->assertNotFalse(file_put_contents($validPath, $validBody));
 			$this->assertTrue(
 				pfb_top1m_candidate_valid($validPath, $provider),
 				"{$id}: valid provider-shaped feed must pass"
 			);
-			$validLines = preg_split('/\r\n|\r|\n/', trim($validRows[$id][0]));
-			$validDataLine = $provider['header'] ? ($validLines[1] ?? '') : ($validLines[0] ?? '');
 			$this->assertSame(
-				$validRows[$id][1],
+				$fixtures[$id]['domain'],
 				pfb_top1m_parse_source_row($validDataLine, $provider),
 				"{$id}: parsed domain must be canonical lowercase"
 			);
@@ -108,7 +133,7 @@ final class Top1mSemanticMatrixTest extends TestCase
 				"<!doctype html>\n<html><body>503 Service Unavailable</body></html>\n",
 				"\x00binary\n",
 				"# feed unavailable\n",
-				$provider['header'] ? (string) strtok($validRows[$id][0], "\n") . "\n" : "domain\n",
+				$provider['header'] ? $fixtures[$id]['header'] : "domain\n",
 				$wrongRows[$id],
 			];
 			foreach ($hostile as $n => $body) {
@@ -119,6 +144,76 @@ final class Top1mSemanticMatrixTest extends TestCase
 					"{$id}: hostile candidate {$n} must fail closed"
 				);
 			}
+
+			$shapeRows = [
+				'extra' => array_merge($fixtures[$id]['fields'], ['extra']),
+				'truncated' => array_slice($fixtures[$id]['fields'], 0, -1),
+			];
+			foreach ($shapeRows as $shape => $fields) {
+				$dataLine = implode(',', $fields) . "\n";
+				$path = "{$this->dir}/{$id}-{$shape}.csv";
+				$this->assertNotFalse(file_put_contents($path, $fixtures[$id]['header'] . $dataLine));
+				$this->assertNull(
+					pfb_top1m_parse_source_row($dataLine, $provider),
+					"{$id}: {$shape} data row must fail exact-column parsing"
+				);
+				$this->assertFalse(
+					pfb_top1m_candidate_valid($path, $provider),
+					"{$id}: valid header plus {$shape} data row must fail closed"
+				);
+			}
+
+			$domainCol = (int) $provider['domain_col'];
+			$invalidUtf8Fields = $fixtures[$id]['fields'];
+			$invalidUtf8Fields[$domainCol] = "bad\xFF.example";
+			$invalidUtf8Line = implode(',', $invalidUtf8Fields) . "\n";
+			$invalidUtf8Path = "{$this->dir}/{$id}-invalid-utf8.csv";
+			$this->assertNotFalse(file_put_contents($invalidUtf8Path, $fixtures[$id]['header'] . $invalidUtf8Line));
+			$this->assertNull(pfb_top1m_parse_source_row($invalidUtf8Line, $provider), "{$id}: invalid UTF-8 domain rejected");
+			$this->assertFalse(pfb_top1m_candidate_valid($invalidUtf8Path, $provider), "{$id}: invalid UTF-8 candidate rejected");
+
+			$unterminatedPrefix = array_slice($fixtures[$id]['fields'], 0, $domainCol);
+			$unterminatedLine = ($unterminatedPrefix === [] ? '' : implode(',', $unterminatedPrefix) . ',') . "\"Example.COM\n";
+			$unterminatedPath = "{$this->dir}/{$id}-unterminated.csv";
+			$this->assertNotFalse(file_put_contents($unterminatedPath, $fixtures[$id]['header'] . $unterminatedLine));
+			$this->assertNull(pfb_top1m_parse_source_row($unterminatedLine, $provider), "{$id}: unterminated quoted domain rejected");
+			$this->assertFalse(pfb_top1m_candidate_valid($unterminatedPath, $provider), "{$id}: unterminated candidate rejected");
+
+			$this->assertSame($fixtures[$id]['columns'], $provider['columns'] ?? NULL, "{$id}: exact column count descriptor");
+		}
+	}
+
+	public function testSyntheticDescriptorWithoutColumnCountKeepsMinimumShapeBehavior(): void
+	{
+		$provider = ['parse' => 'csv', 'header' => FALSE, 'domain_col' => 1];
+		$path = "{$this->dir}/synthetic.csv";
+		$this->assertNotFalse(file_put_contents($path, "rank,Example.COM,extra\n"));
+		$this->assertSame('example.com', pfb_top1m_parse_source_row("rank,Example.COM,extra\n", $provider));
+		$this->assertTrue(pfb_top1m_candidate_valid($path, $provider));
+	}
+
+	public function testCandidateRejectsEmptyAndMissingFiles(): void
+	{
+		$provider = pfb_top1m_providers()['tranco'];
+		$empty = "{$this->dir}/empty.csv";
+		$this->assertNotFalse(file_put_contents($empty, ''));
+		$this->assertFalse(pfb_top1m_candidate_valid($empty, $provider));
+		$this->assertFalse(pfb_top1m_candidate_valid("{$this->dir}/missing.csv", $provider));
+	}
+
+	public function testCandidateRejectsUnreadableFile(): void
+	{
+		if (function_exists('posix_getuid') && posix_getuid() === 0) {
+			$this->markTestSkipped('root bypasses file permissions');
+		}
+		$provider = pfb_top1m_providers()['tranco'];
+		$path = "{$this->dir}/unreadable.csv";
+		$this->assertNotFalse(file_put_contents($path, "1,Example.COM\n"));
+		$this->assertTrue(chmod($path, 0000));
+		try {
+			$this->assertFalse(pfb_top1m_candidate_valid($path, $provider));
+		} finally {
+			chmod($path, 0600);
 		}
 	}
 
@@ -141,6 +236,7 @@ final class Top1mSemanticMatrixTest extends TestCase
 		foreach ($fixtures as $label => [$source, $base, $active]) {
 			$before = $this->seedPublication($base, $active, $label);
 			$this->assertFalse($this->downloadSource($source, $base, $active), "{$label}: semantic-invalid candidate must fail");
+			$this->assertSame([], glob(dirname($base) . '/.pfbtop1m_*') ?: [], "{$label}: rejected download left staging artifacts");
 			$this->assertSame($before, $this->snapshotPublication($base, $active), "{$label}: rejected candidate changed last-good state");
 		}
 	}

--- a/tests/php/Top1mSemanticMatrixTest.php
+++ b/tests/php/Top1mSemanticMatrixTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1542 — provider-shaped TOP1M rows and compressed candidates.
+ *
+ * The frozen regression test covers a plain HTML/header-only feed. This matrix
+ * keeps the provider descriptors, hostile rows, and archive publication path
+ * independently exercised without changing that reproduction.
+ */
+#[CoversFunction('pfb_top1m_parse_source_row')]
+#[CoversFunction('pfb_top1m_candidate_valid')]
+#[CoversFunction('pfb_download')]
+final class Top1mSemanticMatrixTest extends TestCase
+{
+	private string $dir;
+
+	/** @var resource|null */
+	private $server = NULL;
+
+	/** @var array<string,mixed> */
+	private array $savedPfb = [];
+
+	/** @var array<string,mixed> */
+	private array $savedConfig = [];
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_top1m_matrix_' . getmypid() . '_' . uniqid();
+		$this->assertTrue(mkdir($this->dir, 0777, TRUE));
+		foreach (['dbdir', 'log', 'errlog', 'pnow', 'mime_types', 'dnsbl_top1m_type', 'unbound_py_top1m'] as $key) {
+			$this->savedPfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? [])
+				? $GLOBALS['pfb'][$key] : FALSE;
+		}
+		$this->savedConfig = $GLOBALS['config'] ?? [];
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb']['dbdir'] = "{$this->dir}/db";
+		$GLOBALS['pfb']['log'] = "{$this->dir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$this->dir}/pfblockerng_error.log";
+		$GLOBALS['pfb']['pnow'] = 'now';
+		$GLOBALS['pfb']['mime_types'] = $GLOBALS['pfb_shipped_mime_types'] ?? $GLOBALS['pfb']['mime_types'] ?? [];
+		$GLOBALS['pfb']['dnsbl_top1m_type'] = PfbTop1mSource::Tranco;
+		$GLOBALS['pfb']['unbound_py_top1m'] = "{$this->dir}/fixed-top1m.txt";
+		$this->assertTrue(mkdir($GLOBALS['pfb']['dbdir']));
+	}
+
+	protected function tearDown(): void
+	{
+		$this->stopServer();
+		foreach ($this->savedPfb as $key => $value) {
+			if ($value === FALSE) {
+				unset($GLOBALS['pfb'][$key]);
+			} else {
+				$GLOBALS['pfb'][$key] = $value;
+			}
+		}
+		$GLOBALS['config'] = $this->savedConfig;
+		if (is_dir($this->dir)) {
+			$it = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator($this->dir, FilesystemIterator::SKIP_DOTS),
+				RecursiveIteratorIterator::CHILD_FIRST
+			);
+			foreach ($it as $file) {
+				$file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+			}
+			rmdir($this->dir);
+		}
+	}
+
+	public function testAllProviderDescriptorsAcceptValidRowsAndRejectHostileRows(): void
+	{
+		$providers = pfb_top1m_providers();
+		$validRows = [
+			'tranco' => ["7,Example.COM\n", 'example.com'],
+			'cisco' => ["42,Mixed.Example\n", 'mixed.example'],
+			'openpagerank' => ["rank,domain,com,10,5\n1,Example.COM,com,10,5\n", 'example.com'],
+			'majestic' => ["rank,ref_subnets,domain,tld,position\n1,1,Example.COM,com,1\n", 'example.com'],
+			'cloudflare' => ["domain\nExample.COM\n", 'example.com'],
+		];
+		$wrongRows = [
+			'tranco' => "rank,Example.COM\n",
+			'cisco' => "oops,Mixed.Example\n",
+			'openpagerank' => "1,Example\n",
+			'majestic' => "1,Example.COM\n",
+			'cloudflare' => "1,Example.COM\n",
+		];
+
+		foreach ($providers as $id => $provider) {
+			$validPath = "{$this->dir}/{$id}-valid.csv";
+			$this->assertNotFalse(file_put_contents($validPath, $validRows[$id][0]));
+			$this->assertTrue(
+				pfb_top1m_candidate_valid($validPath, $provider),
+				"{$id}: valid provider-shaped feed must pass"
+			);
+			$validLines = preg_split('/\r\n|\r|\n/', trim($validRows[$id][0]));
+			$validDataLine = $provider['header'] ? ($validLines[1] ?? '') : ($validLines[0] ?? '');
+			$this->assertSame(
+				$validRows[$id][1],
+				pfb_top1m_parse_source_row($validDataLine, $provider),
+				"{$id}: parsed domain must be canonical lowercase"
+			);
+
+			$hostile = [
+				"<!doctype html>\n<html><body>503 Service Unavailable</body></html>\n",
+				"\x00binary\n",
+				"# feed unavailable\n",
+				$provider['header'] ? (string) strtok($validRows[$id][0], "\n") . "\n" : "domain\n",
+				$wrongRows[$id],
+			];
+			foreach ($hostile as $n => $body) {
+				$path = "{$this->dir}/{$id}-hostile-{$n}.csv";
+				$this->assertNotFalse(file_put_contents($path, $body));
+				$this->assertFalse(
+					pfb_top1m_candidate_valid($path, $provider),
+					"{$id}: hostile candidate {$n} must fail closed"
+				);
+			}
+		}
+	}
+
+	public function testInvalidZipAndGzipCandidatesPreserveEveryPublicationArtifact(): void
+	{
+		$fixtures = [];
+		$zip = new ZipArchive();
+		$zipPath = "{$this->dir}/invalid.zip";
+		$this->assertSame(TRUE, $zip->open($zipPath, ZipArchive::CREATE));
+		$this->assertTrue($zip->addFromString('feed/top.csv', "<!doctype html>\n<html><body>503</body></html>\n"));
+		$this->assertTrue($zip->close());
+		if ($this->tarReadsZip($zipPath)) {
+			$fixtures['zip'] = [$zipPath, "{$this->dir}/invalid.csv.zip", "{$this->dir}/invalid.csv"];
+		}
+
+		$gzipPath = "{$this->dir}/invalid.gz";
+		$this->assertNotFalse(file_put_contents($gzipPath, gzencode("<!doctype html>\n<html><body>503</body></html>\n")));
+		$fixtures['gzip'] = [$gzipPath, "{$this->dir}/invalid.csv.gz", "{$this->dir}/invalid-gzip.csv"];
+
+		foreach ($fixtures as $label => [$source, $base, $active]) {
+			$before = $this->seedPublication($base, $active, $label);
+			$this->assertFalse($this->downloadSource($source, $base, $active), "{$label}: semantic-invalid candidate must fail");
+			$this->assertSame($before, $this->snapshotPublication($base, $active), "{$label}: rejected candidate changed last-good state");
+		}
+	}
+
+	/** @return array<string,string|false> */
+	private function seedPublication(string $base, string $active, string $label): array
+	{
+		$this->assertNotFalse(file_put_contents($active, "old-active-{$label}\n"));
+		$this->assertNotFalse(file_put_contents("{$base}.orig", "old-wire-{$label}\n"));
+		$this->assertTrue(pfb_hash_write($base, "{$base}.orig"));
+		$this->assertNotFalse(file_put_contents("{$base}.source", "old-source-{$label}"));
+		pfb_validator_write("{$base}.orig", '"old-etag-' . $label . '"', 1700000000);
+		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['dbdir'] . '/pfbalexawhitelist.txt', "old-whitelist-{$label}\n"));
+		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['unbound_py_top1m'], "old-fixed-{$label}\n"));
+		$this->assertNotFalse(file_put_contents($GLOBALS['pfb']['dbdir'] . '/top-1m.update', "old-marker-{$label}"));
+
+		return $this->snapshotPublication($base, $active);
+	}
+
+	/** @return array<string,string|false> */
+	private function snapshotPublication(string $base, string $active): array
+	{
+		$paths = [
+			'active' => $active,
+			'raw' => "{$base}.orig",
+			'hash' => "{$base}.xxhash128",
+			'source' => "{$base}.source",
+			'etag' => "{$base}.orig.etag",
+			'lastmod' => "{$base}.orig.lastmod",
+			'whitelist' => $GLOBALS['pfb']['dbdir'] . '/pfbalexawhitelist.txt',
+			'fixed' => $GLOBALS['pfb']['unbound_py_top1m'],
+			'marker' => $GLOBALS['pfb']['dbdir'] . '/top-1m.update',
+		];
+		$state = [];
+		foreach ($paths as $label => $path) {
+			$state[$label] = is_file($path) ? file_get_contents($path) : FALSE;
+		}
+		return $state;
+	}
+
+	private function downloadSource(string $source, string $base, string $active): bool
+	{
+		$this->stopServer();
+		$router = "{$this->dir}/router.php";
+		$this->assertNotFalse(file_put_contents($router, "<?php\nreadfile(" . var_export($source, TRUE) . ");\n"));
+		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$port = 0;
+		for ($try = 0; $try < 10 && $port === 0; $try++) {
+			$candidate = random_int(20000, 60000);
+			$proc = proc_open(['php', '-S', "127.0.0.1:{$candidate}", $router], $descriptors, $pipes, $this->dir, ['PATH' => (string) getenv('PATH')]);
+			if (!is_resource($proc)) {
+				continue;
+			}
+			for ($poll = 0; $poll < 40; $poll++) {
+				$sock = @fsockopen('127.0.0.1', $candidate, $errno, $errstr, 0.05);
+				if ($sock !== FALSE) {
+					fclose($sock);
+					$this->server = $proc;
+					$port = $candidate;
+					break 2;
+				}
+				usleep(50000);
+			}
+			proc_terminate($proc);
+			proc_close($proc);
+		}
+		if ($port === 0) {
+			$this->markTestSkipped('loopback HTTP fixture unavailable');
+		}
+		return pfb_download(new PfbDownloadRequest(
+			listUrl: "http://127.0.0.1:{$port}/feed",
+			downloadPath: $base,
+			flex: FALSE,
+			header: $active,
+			format: '',
+			logType: 1,
+			timeout: 30,
+			type: 'top1m',
+		))->success;
+	}
+
+	private function tarReadsZip(string $archive): bool
+	{
+		exec('/usr/bin/tar -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
+		return $status === 0;
+	}
+
+	private function stopServer(): void
+	{
+		if (is_resource($this->server)) {
+			proc_terminate($this->server);
+			proc_close($this->server);
+			$this->server = NULL;
+		}
+	}
+}

--- a/tests/php/Top1mTeardownDirectoryTest.php
+++ b/tests/php/Top1mTeardownDirectoryTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+#[CoversFunction('pfb_unbound_py_teardown_raw_set')]
+final class Top1mTeardownDirectoryTest extends TestCase
+{
+	private string $tmp;
+	private array $originalPfb = [];
+	private bool $hadPfb = FALSE;
+
+	protected function setUp(): void
+	{
+		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->tmp = sys_get_temp_dir() . '/pfb_top1m_teardown_' . uniqid('', TRUE);
+		$this->assertTrue(mkdir("{$this->tmp}/db", 0777, TRUE));
+		$this->assertTrue(mkdir("{$this->tmp}/unbound", 0777, TRUE));
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'log'                => "{$this->tmp}/pfblockerng.log",
+			'errlog'             => "{$this->tmp}/error.log",
+			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
+			'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
+			'unbound_py_top1m'   => "{$this->tmp}/unbound/pfb_py_top1m.txt",
+			'dbdir'              => "{$this->tmp}/db",
+		]);
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		rmdir_recursive($this->tmp);
+	}
+
+	public function testTeardownRemovesTop1mDirectoriesFilesAndLinksWithoutTouchingLiveData(): void
+	{
+		$base = "{$GLOBALS['pfb']['dbdir']}/top-1m.csv.zip";
+		$fixed = $GLOBALS['pfb']['unbound_py_top1m'];
+		$exactArtifacts = [
+			$fixed,
+			"{$base}.orig",
+			"{$base}.xxhash128",
+			"{$base}.md5",
+			"{$base}.source",
+			"{$base}.orig.etag",
+			"{$base}.orig.lastmod",
+			"{$GLOBALS['pfb']['dbdir']}/.pfbtop1m_active_file",
+			dirname($fixed) . '/.pfbtop1m_prev_file',
+		];
+		foreach ($exactArtifacts as $artifact) {
+			$this->assertNotFalse(file_put_contents($artifact, 'owned'), "seed {$artifact}");
+		}
+
+		$dbStage = "{$GLOBALS['pfb']['dbdir']}/.pfbtop1m_base_nonempty";
+		$fixedStage = dirname($fixed) . '/.pfbtop1m_stage_nonempty';
+		$this->assertTrue(mkdir("{$dbStage}/nested", 0777, TRUE));
+		$this->assertNotFalse(file_put_contents("{$dbStage}/nested/raw", 'owned'));
+		$this->assertTrue(mkdir($fixedStage, 0777, TRUE));
+		$this->assertNotFalse(file_put_contents("{$fixedStage}/candidate", 'owned'));
+
+		$linkTarget = "{$this->tmp}/link-target";
+		$this->assertTrue(mkdir($linkTarget));
+		$this->assertNotFalse(file_put_contents("{$linkTarget}/keep", 'keep'));
+		$link = "{$GLOBALS['pfb']['dbdir']}/.pfbtop1m_link";
+		$this->assertTrue(symlink($linkTarget, $link));
+
+		$preserved = [
+			"{$GLOBALS['pfb']['dbdir']}/top-1m.csv",
+			"{$GLOBALS['pfb']['dbdir']}/pfbalexawhitelist.txt",
+			"{$GLOBALS['pfb']['dbdir']}/top-1m.csv.zip.orig.neighbor",
+			"{$GLOBALS['pfb']['dbdir']}/pfbtop1m_decoy",
+			"{$this->tmp}/.pfbtop1m_outside",
+		];
+		foreach ($preserved as $path) {
+			$this->assertNotFalse(file_put_contents($path, 'keep'), "seed {$path}");
+		}
+
+		$this->assertDirectoryExists($dbStage, 'before-state: db staging directory');
+		$this->assertDirectoryExists($fixedStage, 'before-state: fixed-file staging directory');
+		$this->assertTrue(is_link($link), 'before-state: narrow symlink');
+		$this->assertTrue(pfb_unbound_py_teardown_raw_set(), 'teardown must remove every narrow TOP1M artifact');
+
+		foreach ($exactArtifacts as $artifact) {
+			$this->assertFalse(file_exists($artifact) || is_link($artifact), "removed {$artifact}");
+		}
+		$this->assertDirectoryDoesNotExist($dbStage);
+		$this->assertDirectoryDoesNotExist($fixedStage);
+		$this->assertFalse(file_exists($link) || is_link($link), 'symlink removed without following it');
+		$this->assertSame('keep', file_get_contents("{$linkTarget}/keep"), 'symlink target preserved');
+		foreach ($preserved as $path) {
+			$this->assertSame('keep', file_get_contents($path), "preserved {$path}");
+		}
+		$this->assertTrue(pfb_unbound_py_teardown_raw_set(), 'second teardown is idempotent');
+	}
+}

--- a/tests/php/Top1mTeardownWiringTest.php
+++ b/tests/php/Top1mTeardownWiringTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class Top1mTeardownWiringTest extends TestCase
+{
+	private function functionBody(string $name): string
+	{
+		$function = new ReflectionFunction($name);
+		$lines = file((string) $function->getFileName());
+		$this->assertIsArray($lines);
+		return implode('', array_slice(
+			$lines,
+			$function->getStartLine() - 1,
+			$function->getEndLine() - $function->getStartLine() + 1
+		));
+	}
+
+	public function testDisableAndUninstallWireTheSharedTeardown(): void
+	{
+		$this->assertStringContainsString(
+			'pfb_unbound_py_teardown_raw_set();',
+			$this->functionBody('sync_package_pfblockerng'),
+			'DNSBL disable must remove the fixed TOP1M runtime set'
+		);
+		$this->assertMatchesRegularExpression(
+			'/sync_package_pfblockerng\(\);\s+pfb_unbound_py_teardown_raw_set\(\);/',
+			$this->functionBody('pfblockerng_php_pre_deinstall_command'),
+			'package removal must tear down retained TOP1M runtime state after the disable pass'
+		);
+	}
+}

--- a/tests/php/Top1mTldCaseFoldTest.php
+++ b/tests/php/Top1mTldCaseFoldTest.php
@@ -311,7 +311,7 @@ final class Top1mTldCaseFoldTest extends TestCase
 	public function testCsvDomainCol2MajesticShapeMixedCaseDomainMatchesAndFolds(): void
 	{
 		$csv = "GlobalRank,TldRank,Domain,TLD,RefSubNets,RefIPs,IDN_Domain,IDN_TLD,PrevGlobalRank,PrevTldRank,PrevRefSubNets,PrevRefIPs\n"
-			. "1,1,Example.CoM,extra\n";
+			. "1,1,Example.CoM,com,10,20,,,2,2,9,19\n";
 		$this->assertNotFalse(file_put_contents($this->csvPath(), $csv), 'setup: Majestic-shaped mixed-case Domain row');
 
 		pfblockerng_top1m(pfb_top1m_providers()[PfbTop1mSource::Majestic->value]);

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -57,6 +57,7 @@ final class UnboundPythonSourcesTest extends TestCase
 			'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
 			'dnsdir'             => "{$this->tmp}/dnsbl",
 			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
+			'unbound_py_top1m'   => "{$this->tmp}/pfb_py_top1m.txt",
 			'dbdir'              => "{$this->tmp}/db",
 			'dnsbl_top1m'        => 'off',
 			'dnsbl_tld_data'     => "{$this->tmp}/does_not_exist",
@@ -414,7 +415,7 @@ final class UnboundPythonSourcesTest extends TestCase
 			file_put_contents("{$this->tmp}/db/pfbalexawhitelist.txt", $top1m);
 		}
 
-		$manifest = pfb_unbound_python_sources([]);
+		$manifest = pfb_unbound_python_sources([], $enabled === 'on' ? $this->top1mPublicationOps() : []);
 		$published = (string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
 		$legacy = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
@@ -440,14 +441,15 @@ final class UnboundPythonSourcesTest extends TestCase
 		$GLOBALS['pfb']['dnsbl_top1m'] = 'on';
 		file_put_contents("{$this->tmp}/db/pfbalexawhitelist.txt", $invalid . "\n");
 
-		pfb_unbound_python_sources([]);
+		pfb_unbound_python_sources([], $this->top1mPublicationOps());
 
 		$published = (string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
 		$decoded = json_decode($published, TRUE);
 		$this->assertSame(JSON_ERROR_NONE, json_last_error(), 'the replacement manifest must be valid JSON');
 		$this->assertNotSame($old, $published, 'the stale manifest must be replaced');
-		$this->assertSame(["\u{FFFD}"], $decoded['config']['top1m_list']);
-		$this->assertSame(1, substr_count($published, '\\ufffd'), 'one malformed sequence must emit one replacement');
+		$this->assertTrue($decoded['config']['top1m_enabled']);
+		$this->assertArrayNotHasKey('top1m_list', $decoded['config']);
+		$this->assertSame($invalid . "\n", file_get_contents($GLOBALS['pfb']['unbound_py_top1m']));
 		$this->assertSame(
 			'old-raw-secret',
 			file_get_contents("{$old_generation}/old.raw"),
@@ -467,7 +469,7 @@ final class UnboundPythonSourcesTest extends TestCase
 		]);
 		$error = json_last_error_msg();
 
-		$this->assertTrue(is_nan($manifest['feeds'][0]['group']), 'the full writer must keep returning the generated manifest');
+		$this->assertFalse($manifest, 'the full writer must reject an unencodable manifest');
 		$this->assertSame($old, file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
 		$this->assertSame('old-raw-secret', file_get_contents("{$old_generation}/old.raw"));
 		$published = json_decode((string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']), TRUE);
@@ -487,6 +489,17 @@ final class UnboundPythonSourcesTest extends TestCase
 			$this->assertStringNotContainsString('user_whitelist', $log);
 			$this->assertStringNotContainsString('group', $log);
 		}
+	}
+
+	private function top1mPublicationOps(): array
+	{
+		return [
+			'top1m_atomic' => [
+				'chown' => static fn(string $file, string $owner): bool => TRUE,
+				'chgrp' => static fn(string $file, string $group): bool => TRUE,
+				'chmod' => static fn(string $file, int $mode): bool => TRUE,
+			],
+		];
 	}
 
 	public static function validPatchValues(): array

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -7319,6 +7319,19 @@
             }
         ]
     },
+    "pfb_top1m_reprocess_needed": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "dbdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_top1m_settings_reprocess": {
         "returnsRef": false,
         "returnType": null,

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -7101,6 +7101,26 @@
             }
         ]
     },
+    "pfb_top1m_fetch_if_needed": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "dbdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "fetch",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
     "pfb_top1m_invalidate_baseline": {
         "returnsRef": false,
         "returnType": null,
@@ -7172,6 +7192,19 @@
         "returnsRef": false,
         "returnType": "array",
         "params": []
+    },
+    "pfb_top1m_refresh_needed": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "dbdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
     },
     "pfb_top1m_settings_reprocess": {
         "returnsRef": false,

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -7054,6 +7054,11 @@
         "returnType": "string",
         "params": []
     },
+    "pfb_top1m_active_provider": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
     "pfb_top1m_auth_headers": {
         "returnsRef": false,
         "returnType": "array",
@@ -7070,6 +7075,26 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_top1m_candidate_valid": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "provider",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
                 "default": null
             }
         ]
@@ -7130,6 +7155,26 @@
                 "byRef": false,
                 "variadic": false,
                 "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_top1m_parse_source_row": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "provider",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
                 "default": null
             }
         ]

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -7078,34 +7078,94 @@
         "returnsRef": false,
         "returnType": null,
         "params": [
-            {"name": "download_ok", "byRef": false, "variadic": false, "type": null, "default": null},
-            {"name": "ledger_dir", "byRef": false, "variadic": false, "type": null, "default": null},
-            {"name": "message", "byRef": false, "variadic": false, "type": null, "default": "''"}
+            {
+                "name": "download_ok",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "message",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            }
         ]
     },
     "pfb_top1m_invalidate_baseline": {
         "returnsRef": false,
         "returnType": null,
         "params": [
-            {"name": "base", "byRef": false, "variadic": false, "type": null, "default": null}
+            {
+                "name": "base",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
         ]
     },
     "pfb_top1m_persist_baseline": {
         "returnsRef": false,
         "returnType": null,
         "params": [
-            {"name": "base", "byRef": false, "variadic": false, "type": null, "default": null},
-            {"name": "raw_path", "byRef": false, "variadic": false, "type": null, "default": null}
+            {
+                "name": "base",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "raw_path",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
         ]
     },
     "pfb_top1m_probe_decision": {
         "returnsRef": false,
         "returnType": null,
         "params": [
-            {"name": "probe_ok", "byRef": false, "variadic": false, "type": null, "default": null},
-            {"name": "http_status", "byRef": false, "variadic": false, "type": null, "default": null},
-            {"name": "body_hash", "byRef": false, "variadic": false, "type": null, "default": null},
-            {"name": "persisted_hash", "byRef": false, "variadic": false, "type": null, "default": null}
+            {
+                "name": "probe_ok",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "http_status",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "body_hash",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "persisted_hash",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
         ]
     },
     "pfb_top1m_providers": {
@@ -7117,17 +7177,47 @@
         "returnsRef": false,
         "returnType": null,
         "params": [
-            {"name": "before", "byRef": false, "variadic": false, "type": "array", "default": null},
-            {"name": "after", "byRef": false, "variadic": false, "type": "array", "default": null}
+            {
+                "name": "before",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "after",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
         ]
     },
     "pfb_top1m_source_identity": {
         "returnsRef": false,
         "returnType": null,
         "params": [
-            {"name": "provider", "byRef": false, "variadic": false, "type": null, "default": null},
-            {"name": "url", "byRef": false, "variadic": false, "type": null, "default": null},
-            {"name": "headers", "byRef": false, "variadic": false, "type": "array", "default": "array (\n)"}
+            {
+                "name": "provider",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "url",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "headers",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": "array (\n)"
+            }
         ]
     },
     "pfb_tracker": {
@@ -7192,6 +7282,33 @@
         "returnsRef": false,
         "returnType": "bool",
         "params": []
+    },
+    "pfb_unbound_py_atomic_copy": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "source",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "stream_ops",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": "array (\n)"
+            }
+        ]
     },
     "pfb_unbound_py_atomic_write": {
         "returnsRef": false,

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -7074,10 +7074,61 @@
             }
         ]
     },
+    "pfb_top1m_download_ledger_update": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {"name": "download_ok", "byRef": false, "variadic": false, "type": null, "default": null},
+            {"name": "ledger_dir", "byRef": false, "variadic": false, "type": null, "default": null},
+            {"name": "message", "byRef": false, "variadic": false, "type": null, "default": "''"}
+        ]
+    },
+    "pfb_top1m_invalidate_baseline": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {"name": "base", "byRef": false, "variadic": false, "type": null, "default": null}
+        ]
+    },
+    "pfb_top1m_persist_baseline": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {"name": "base", "byRef": false, "variadic": false, "type": null, "default": null},
+            {"name": "raw_path", "byRef": false, "variadic": false, "type": null, "default": null}
+        ]
+    },
+    "pfb_top1m_probe_decision": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {"name": "probe_ok", "byRef": false, "variadic": false, "type": null, "default": null},
+            {"name": "http_status", "byRef": false, "variadic": false, "type": null, "default": null},
+            {"name": "body_hash", "byRef": false, "variadic": false, "type": null, "default": null},
+            {"name": "persisted_hash", "byRef": false, "variadic": false, "type": null, "default": null}
+        ]
+    },
     "pfb_top1m_providers": {
         "returnsRef": false,
         "returnType": "array",
         "params": []
+    },
+    "pfb_top1m_settings_reprocess": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {"name": "before", "byRef": false, "variadic": false, "type": "array", "default": null},
+            {"name": "after", "byRef": false, "variadic": false, "type": "array", "default": null}
+        ]
+    },
+    "pfb_top1m_source_identity": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {"name": "provider", "byRef": false, "variadic": false, "type": null, "default": null},
+            {"name": "url", "byRef": false, "variadic": false, "type": null, "default": null},
+            {"name": "headers", "byRef": false, "variadic": false, "type": "array", "default": "array (\n)"}
+        ]
     },
     "pfb_tracker": {
         "returnsRef": false,

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -1795,6 +1795,26 @@
             }
         ]
     },
+    "pfb_dnsbl_publish_result": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "published",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "logger",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
     "pfb_dnsbl_python_migrate": {
         "returnsRef": false,
         "returnType": null,
@@ -1844,6 +1864,54 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_reload_needed": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "publish_failed",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "data_changed",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "update",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "python",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "safesearch_update",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "unlock_forced",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
                 "default": null
             }
         ]

--- a/tests/shell/pfblockerng_dnsbl_cache_sidecars_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_sidecars_spec.sh
@@ -1,6 +1,7 @@
 #shellcheck shell=sh
-# Supplemental dnsbl_cache boundary coverage: save archives generated chroot files plus
-# exact TOP1M detector sidecars, never prefix decoys, transient DB files, or outside paths.
+# pfblockerng_dnsbl_cache_spec.sh's generated-only header predates issue #1542.
+# Current save set: generated chroot files plus exact TOP1M detector sidecars; never prefix
+# decoys, transient DB files, or outside paths.
 
 pfb_sidecar_archive_path() {
   for _e in zst bz2; do

--- a/tests/shell/pfblockerng_dnsbl_cache_sidecars_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_sidecars_spec.sh
@@ -1,0 +1,95 @@
+#shellcheck shell=sh
+# Supplemental dnsbl_cache boundary coverage: save archives generated chroot files plus
+# exact TOP1M detector sidecars, never prefix decoys, transient DB files, or outside paths.
+
+pfb_sidecar_archive_path() {
+  for _e in zst bz2; do
+    if [ -f "${1}.${_e}" ]; then echo "${1}.${_e}"; return 0; fi
+  done
+  return 0
+}
+
+Describe 'pfblockerng.sh dnsbl_cache TOP1M sidecar boundaries'
+  BeforeAll 'pfb_source'
+
+  # shellcheck disable=SC2034  # consumed by the sourced dnsbl_cache() at runtime
+  setup_sidecar_sandbox() {
+    sandbox="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbdcside.XXXXXX")"
+    pfbchroot="${sandbox}/chroot path [cache]"
+    pfbpkgdir="${sandbox}/pkg"
+    pfbdb="${sandbox}/db path [top1m]"
+    dnsblarchive="${sandbox}/pfb_dnsbl_cache.tar"
+    pathtar='/usr/bin/tar'
+    outside="${sandbox}/outside absolute"
+    mkdir -p "${pfbpkgdir}"
+  }
+
+  cleanup_sidecar_sandbox() {
+    rm -rf "${sandbox}"
+  }
+
+  dc_sidecar() {
+    dnsbl_cache "$1" 2>/dev/null || true
+  }
+
+  sidecar_archive_list() {
+    /usr/bin/tar -tf "$(pfb_sidecar_archive_path "${dnsblarchive}")" 2>/dev/null
+  }
+
+  save_list_restore_sidecars() {
+    dc_sidecar save
+    sidecar_archive_list
+    rm -rf "${pfbchroot}" "${pfbdb}" "${outside}"
+    dc_sidecar restore
+  }
+
+  save_list_restore_missing_db() {
+    [ ! -e "${pfbdb}" ] && echo 'PRE:db-missing'
+    dc_sidecar save
+    [ ! -e "${pfbdb}" ] && echo 'POST-SAVE:db-missing'
+    sidecar_archive_list
+    rm -rf "${pfbchroot}"
+    dc_sidecar restore
+    [ ! -e "${pfbdb}" ] && echo 'POST-RESTORE:db-missing'
+  }
+
+  It 'excludes TOP1M prefix decoys and an absolute outside sentinel'
+    setup_sidecar_sandbox
+    mkdir -p "${pfbchroot}" "${pfbdb}" "${outside}"
+    printf 'GENERATED\n' > "${pfbchroot}/pfb_py_top1m.txt"
+    printf 'EXACT\n' > "${pfbdb}/top-1m.csv.zip.orig"
+    printf 'UPDATE-DECOY\n' > "${pfbdb}/top-1m.csv.zip.update"
+    printf 'RAW-DECOY\n' > "${pfbdb}/top-1m.csv.zip.raw"
+    printf 'NEIGHBOR-DECOY\n' > "${pfbdb}/top-1m.csv.zip.orig.neighbor"
+    outside_sentinel="${outside}/top-1m.csv.zip.orig"
+    printf 'OUTSIDE\n' > "${outside_sentinel}"
+    When call save_list_restore_sidecars
+    The output should include "${pfbchroot}/pfb_py_top1m.txt"
+    The output should include "${pfbdb}/top-1m.csv.zip.orig"
+    The output should not include "${pfbdb}/top-1m.csv.zip.update"
+    The output should not include "${pfbdb}/top-1m.csv.zip.raw"
+    The output should not include "${pfbdb}/top-1m.csv.zip.orig.neighbor"
+    The output should not include "${outside_sentinel}"
+    The contents of file "${pfbchroot}/pfb_py_top1m.txt" should equal 'GENERATED'
+    The contents of file "${pfbdb}/top-1m.csv.zip.orig" should equal 'EXACT'
+    The path "${pfbdb}/top-1m.csv.zip.update" should not be exist
+    The path "${pfbdb}/top-1m.csv.zip.raw" should not be exist
+    The path "${pfbdb}/top-1m.csv.zip.orig.neighbor" should not be exist
+    The path "${outside_sentinel}" should not be exist
+    cleanup_sidecar_sandbox
+  End
+
+  It 'keeps generated-only save and restore behavior when the DB directory is missing'
+    setup_sidecar_sandbox
+    mkdir -p "${pfbchroot}"
+    printf 'GENERATED\n' > "${pfbchroot}/pfb_py_top1m.txt"
+    When call save_list_restore_missing_db
+    The output should include 'PRE:db-missing'
+    The output should include 'POST-SAVE:db-missing'
+    The output should include 'POST-RESTORE:db-missing'
+    The output should include "${pfbchroot}/pfb_py_top1m.txt"
+    The contents of file "${pfbchroot}/pfb_py_top1m.txt" should equal 'GENERATED'
+    The path "${pfbdb}" should not be exist
+    cleanup_sidecar_sandbox
+  End
+End

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -37,9 +37,10 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     # Overridable locations the sourced dnsbl_cache() reads.
     pfbchroot="${sandbox}/chroot"
     pfbpkgdir="${sandbox}/pkg"
+    pfbdb="${sandbox}/db"
     dnsblarchive="${sandbox}/pfb_dnsbl_cache.tar"   # extension-less BASE
     pathtar="/usr/bin/tar"
-    mkdir -p "${pfbpkgdir}"
+    mkdir -p "${pfbpkgdir}" "${pfbdb}"
     # The shipped files (current code in /usr/local).
     echo 'PY-CODE-v1' > "${pfbpkgdir}/pfb_unbound.py"
     echo 'INC-CODE-v1' > "${pfbpkgdir}/pfb_unbound_include.inc"
@@ -66,6 +67,18 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
 
   tar_list_full() {
     /usr/bin/tar -tf "$(pfb_spec_archive_path "${dnsblarchive}")" 2>/dev/null
+  }
+
+  top1m_cksum() {
+    cksum "${1}" 2>/dev/null || echo 'MISSING'
+  }
+
+  save_restore_top1m() {
+    dc save
+    echo "ARCHIVE:$(pfb_spec_archive_path "${dnsblarchive}")"
+    tar_list_full
+    rm -rf "${pfbchroot}" "${pfbdb}"
+    dc restore
   }
 
   It 'stage copies the shipped files and creates the nullfs/devfs mount-point dirs'
@@ -131,6 +144,58 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     # ... nor the name-mapped TLD oracle (issue #1255: matches the pfb_py_* glob
     # but is shipped, not generated -- archiving it would reinstate a stale oracle).
     The result of "tar_list()" should not include 'pfb_py_tld.txt'
+    cleanup_sandbox
+  End
+
+  It 'save and restore preserves TOP1M detector sidecars and excludes transient DB files'
+    setup_sandbox
+    pfbdb="${sandbox}/db path [top1m]"
+    mkdir -p "${pfbdb}" "${pfbchroot}"
+    for _suffix in orig xxhash128 md5 source orig.etag orig.lastmod; do
+      printf 'TOP1M-%s\n' "${_suffix}" > "${pfbdb}/top-1m.csv.zip.${_suffix}"
+    done
+    printf 'transient\n' > "${pfbdb}/.pfbtop1m_stage"
+    printf 'unrelated\n' > "${pfbdb}/other.db"
+    printf 'TOP1M-GENERATED\n' > "${pfbchroot}/pfb_py_top1m.txt"
+    top1m_orig_cksum="$(cksum "${pfbdb}/top-1m.csv.zip.orig")"
+    top1m_xxh_cksum="$(cksum "${pfbdb}/top-1m.csv.zip.xxhash128")"
+    top1m_md5_cksum="$(cksum "${pfbdb}/top-1m.csv.zip.md5")"
+    top1m_source_cksum="$(cksum "${pfbdb}/top-1m.csv.zip.source")"
+    top1m_etag_cksum="$(cksum "${pfbdb}/top-1m.csv.zip.orig.etag")"
+    top1m_lastmod_cksum="$(cksum "${pfbdb}/top-1m.csv.zip.orig.lastmod")"
+    When call save_restore_top1m
+    The output should include 'ARCHIVE:'
+    The output should include "${pfbdb}/top-1m.csv.zip.orig"
+    The output should include "${pfbdb}/top-1m.csv.zip.xxhash128"
+    The output should include "${pfbdb}/top-1m.csv.zip.md5"
+    The output should include "${pfbdb}/top-1m.csv.zip.source"
+    The output should include "${pfbdb}/top-1m.csv.zip.orig.etag"
+    The output should include "${pfbdb}/top-1m.csv.zip.orig.lastmod"
+    The output should include "${pfbchroot}/pfb_py_top1m.txt"
+    The output should not include "${pfbdb}/.pfbtop1m_stage"
+    The output should not include "${pfbdb}/other.db"
+    The contents of file "${pfbchroot}/pfb_py_top1m.txt" should equal 'TOP1M-GENERATED'
+    The value "$(top1m_cksum "${pfbdb}/top-1m.csv.zip.orig")" should equal "${top1m_orig_cksum}"
+    The value "$(top1m_cksum "${pfbdb}/top-1m.csv.zip.xxhash128")" should equal "${top1m_xxh_cksum}"
+    The value "$(top1m_cksum "${pfbdb}/top-1m.csv.zip.md5")" should equal "${top1m_md5_cksum}"
+    The value "$(top1m_cksum "${pfbdb}/top-1m.csv.zip.source")" should equal "${top1m_source_cksum}"
+    The value "$(top1m_cksum "${pfbdb}/top-1m.csv.zip.orig.etag")" should equal "${top1m_etag_cksum}"
+    The value "$(top1m_cksum "${pfbdb}/top-1m.csv.zip.orig.lastmod")" should equal "${top1m_lastmod_cksum}"
+    The path "${pfbdb}/.pfbtop1m_stage" should not be exist
+    The path "${pfbdb}/other.db" should not be exist
+    cleanup_sandbox
+  End
+
+  It 'save archives only existing TOP1M detector sidecars'
+    setup_sandbox
+    printf 'TOP1M-ORIG\n' > "${pfbdb}/top-1m.csv.zip.orig"
+    When call dc save
+    The result of "tar_list_full()" should include "${pfbdb}/top-1m.csv.zip.orig"
+    The result of "tar_list_full()" should not include "${pfbdb}/top-1m.csv.zip.xxhash128"
+    The result of "tar_list_full()" should not include "${pfbdb}/top-1m.csv.zip.md5"
+    The result of "tar_list_full()" should not include "${pfbdb}/top-1m.csv.zip.source"
+    The result of "tar_list_full()" should not include "${pfbdb}/top-1m.csv.zip.orig.etag"
+    The result of "tar_list_full()" should not include "${pfbdb}/top-1m.csv.zip.orig.lastmod"
     cleanup_sandbox
   End
 

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -3863,11 +3863,6 @@ def test_top1m_file_target_hostile_and_truncated_archives_retain_active(
             assert "PFB_DL_FALSE" in out, f"hostile {name} unexpectedly published: {out!r}"
             active = deployed_vm.ssh(f"/bin/cat {target}").stdout.strip()
             assert active == "old active", f"hostile {name} changed active file: {active!r}"
-        html_url = mock_feeds.register("top1m_html_error.html", b"<html><body>upstream error</body></html>")
-        out = _adr46_download(deployed_vm, html_url, f"{workdir}/html.csv", target, "top1m")
-        assert "PFB_DL_FALSE" in out, f"HTML error body unexpectedly published: {out!r}"
-        active = deployed_vm.ssh(f"/bin/cat {target}").stdout.strip()
-        assert active == "old active", f"HTML error changed active file: {active!r}"
     finally:
         deployed_vm.ssh(f"/bin/rm -rf {workdir} {marker}")
 

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -3851,7 +3851,7 @@ def test_top1m_file_target_hostile_and_truncated_archives_retain_active(
     valid = io.BytesIO()
     with zipfile.ZipFile(valid, "w", zipfile.ZIP_DEFLATED) as z:
         z.writestr("d/top.csv", "ok\n")
-    archives.append(("truncated.zip", valid.getvalue()[:-8]))
+    archives.append(("truncated.zip", valid.getvalue()[:20]))
     try:
         deployed_vm.ssh(
             f"/bin/rm -rf {workdir} {marker} && /bin/mkdir -p {workdir} && "

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -3754,6 +3754,125 @@ def test_adr46_legit_multifile_zip_still_imports(deployed_vm: SmokeVM, mock_feed
 
 
 @pytest.mark.timeout(120)
+def test_top1m_file_target_rejects_multifile_and_retains_active(
+    deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
+    """TOP1M file targets accept one payload only; rejected archives leave state untouched."""
+    workdir = f"{_ADR46_WORKDIR}_file_reject"
+    target = f"{workdir}/top-1m.csv"
+    base = f"{workdir}/top-1m.csv.zip"
+    marker = f"{h.PFB_DBDIR}/top-1m.update"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("d/top_a.csv", "new-a\n")
+        z.writestr("d/top_b.csv", "new-b\n")
+    feed_url = mock_feeds.register("top1m_file_reject.zip", buf.getvalue())
+    try:
+        deployed_vm.ssh(
+            f"/bin/rm -rf {workdir} {marker} && /bin/mkdir -p {workdir} && "
+            f"/bin/echo 'old active' > {target} && /bin/echo 'old raw' > {base}.orig"
+        )
+        out = _adr46_download(deployed_vm, feed_url, base, target, "top1m")
+        assert "PFB_DL_FALSE" in out, f"multi-member ZIP must reject a file target: {out!r}"
+        state = (
+            deployed_vm.ssh(
+                f"/bin/cat {target}; /bin/cat {base}.orig; "
+                f"test -e {marker} && echo MARKER; test -e {base}.raw && echo RAW"
+            )
+            .stdout.strip()
+            .splitlines()
+        )
+        assert state == ["old active", "old raw"], f"rejected download changed active/baseline: {state!r}"
+    finally:
+        deployed_vm.ssh(f"/bin/rm -rf {workdir} {marker}")
+
+
+@pytest.mark.timeout(120)
+def test_top1m_file_target_single_member_publishes_atomically(
+    deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
+    """A single regular ZIP member replaces the active file and records raw/hash after publish."""
+    workdir = f"{_ADR46_WORKDIR}_file_single"
+    target = f"{workdir}/top-1m.csv"
+    base = f"{workdir}/top-1m.csv.zip"
+    marker = f"{h.PFB_DBDIR}/top-1m.update"
+    body = "1,example.test\n"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("d/top.csv", body)
+    feed_url = mock_feeds.register("top1m_file_single.zip", buf.getvalue())
+    try:
+        deployed_vm.ssh(  # fmt: skip
+            f"/bin/rm -rf {workdir} {marker} && /bin/mkdir -p {workdir} && /bin/echo 'old active' > {target}"
+        )
+        out = _adr46_download(deployed_vm, feed_url, base, target, "top1m")
+        assert "PFB_DL_TRUE" in out, f"single-member ZIP must publish: {out!r}"
+        state = (
+            deployed_vm.ssh(
+                f"/bin/cat {target}; test -s {base}.orig && echo ORIG; "
+                f"test -s {base}.xxhash128 && echo HASH; test -e {marker} && echo MARKER"
+            )
+            .stdout.strip()
+            .splitlines()
+        )
+        assert state == [body.rstrip("\n"), "ORIG", "HASH", "MARKER"], (
+            f"active/raw/hash/marker publication state unexpected: {state!r}"
+        )
+    finally:
+        deployed_vm.ssh(f"/bin/rm -rf {workdir} {marker}")
+
+
+@pytest.mark.timeout(120)
+def test_top1m_file_target_hostile_and_truncated_archives_retain_active(
+    deployed_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
+    """Traversal, absolute, symlink-like, empty, and truncated ZIPs never reach active state."""
+    workdir = f"{_ADR46_WORKDIR}_file_hostile"
+    target = f"{workdir}/top-1m.csv"
+    base = f"{workdir}/top-1m.csv.zip"
+    marker = f"{h.PFB_DBDIR}/top-1m.update"
+    archives: list[tuple[str, bytes]] = []
+    for name, member in (("traversal.zip", "../escape.csv"), ("absolute.zip", "/absolute.csv")):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+            z.writestr(member, "escape\n")
+        archives.append((name, buf.getvalue()))
+    symlink = io.BytesIO()
+    with zipfile.ZipFile(symlink, "w") as z:
+        info = zipfile.ZipInfo("d/link.csv")
+        info.create_system = 3
+        info.external_attr = (0o120777 << 16) | 0xA000
+        z.writestr(info, "../outside.csv")
+    archives.append(("symlink.zip", symlink.getvalue()))
+    empty = io.BytesIO()
+    with zipfile.ZipFile(empty, "w"):
+        pass
+    archives.append(("empty.zip", empty.getvalue()))
+    valid = io.BytesIO()
+    with zipfile.ZipFile(valid, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("d/top.csv", "ok\n")
+    archives.append(("truncated.zip", valid.getvalue()[:-8]))
+    try:
+        deployed_vm.ssh(
+            f"/bin/rm -rf {workdir} {marker} && /bin/mkdir -p {workdir} && "
+            f"/bin/echo 'old active' > {target} && /bin/echo 'old raw' > {base}.orig"
+        )
+        for name, payload in archives:
+            feed_url = mock_feeds.register(name, payload)
+            out = _adr46_download(deployed_vm, feed_url, base, target, "top1m")
+            assert "PFB_DL_FALSE" in out, f"hostile {name} unexpectedly published: {out!r}"
+            active = deployed_vm.ssh(f"/bin/cat {target}").stdout.strip()
+            assert active == "old active", f"hostile {name} changed active file: {active!r}"
+        html_url = mock_feeds.register("top1m_html_error.html", b"<html><body>upstream error</body></html>")
+        out = _adr46_download(deployed_vm, html_url, f"{workdir}/html.csv", target, "top1m")
+        assert "PFB_DL_FALSE" in out, f"HTML error body unexpectedly published: {out!r}"
+        active = deployed_vm.ssh(f"/bin/cat {target}").stdout.strip()
+        assert active == "old active", f"HTML error changed active file: {active!r}"
+    finally:
+        deployed_vm.ssh(f"/bin/rm -rf {workdir} {marker}")
+
+
+@pytest.mark.timeout(120)
 def test_adr46_hostile_member_geoip_gz_rejected(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """ADR-46: the gzip GeoIP branch rejects a hostile-member tar.gz BEFORE extraction.
 

--- a/tests/smoke/test_top1m_fixed_file.py
+++ b/tests/smoke/test_top1m_fixed_file.py
@@ -1,0 +1,523 @@
+"""Issue #1542 — live TOP1M fixed-file publication and lifecycle contract.
+
+The provider body is staged directly on the pfSense box.  Both
+``top-1m.csv`` and its detector baseline exist before each update, so the
+production update/publisher path runs without contacting a public provider.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections.abc import Iterator
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM, _StubDnsServer
+
+pytestmark = pytest.mark.smoke
+
+TOP1M_CSV = f"{h.PFB_DBDIR}/top-1m.csv"
+TOP1M_WHITELIST = f"{h.PFB_DBDIR}/pfbalexawhitelist.txt"
+TOP1M_BASE = f"{h.PFB_DBDIR}/top-1m.csv.zip"
+TOP1M_FIXED = "/var/unbound/pfb_py_top1m.txt"
+MANIFEST = "/var/unbound/pfb_py_sources.json"
+CACHE_BASE = "/usr/local/etc/pfb_dnsbl_cache.tar"
+LOCAL_FEED = f"{h.PFB_DBDIR}/top1m_fixed_file_feed.txt"
+SIDECAR_SUFFIXES = ("orig", "xxhash128", "md5", "source", "orig.etag", "orig.lastmod")
+SIDECARS = tuple(f"{TOP1M_BASE}.{suffix}" for suffix in SIDECAR_SUFFIXES)
+NEIGHBOR = f"{TOP1M_BASE}.orig.neighbor"
+
+_SNAPSHOT_TARGETS = (
+    TOP1M_CSV,
+    f"{TOP1M_BASE}",
+    TOP1M_WHITELIST,
+    TOP1M_FIXED,
+    *SIDECARS,
+    NEIGHBOR,
+    f"{CACHE_BASE}.zst",
+    f"{CACHE_BASE}.bz2",
+    LOCAL_FEED,
+)
+
+
+def _require_ok(result: object, operation: str) -> None:
+    if getattr(result, "returncode", 1) != 0:
+        raise RuntimeError(
+            f"{operation} failed: rc={getattr(result, 'returncode', '?')} "
+            f"stdout={getattr(result, 'stdout', '')!r} stderr={getattr(result, 'stderr', '')!r}"
+        )
+
+
+def _copy_if_present(vm: SmokeVM, source: str, target: str) -> None:
+    result = vm.ssh(f"if [ -e {source} ] || [ -L {source} ]; then /bin/cp -pP {source} {target}; fi")
+    _require_ok(result, f"snapshot {source}")
+
+
+def _snapshot_box(vm: SmokeVM, root: str) -> None:
+    _require_ok(vm.ssh("/bin/mkdir", "-p", f"{root}/files"), "create TOP1M smoke snapshot")
+    _require_ok(vm.ssh("/bin/cp", "-p", "/conf/config.xml", f"{root}/config.xml"), "snapshot config.xml")
+    for index, target in enumerate(_SNAPSHOT_TARGETS):
+        _copy_if_present(vm, target, f"{root}/files/{index}")
+    runtime_snapshot = vm.ssh(
+        "cd / && set --; "
+        "for _path in var/unbound/pfb_unbound* var/unbound/pfb_py_*; do "
+        '  if [ -e "${_path}" ] || [ -L "${_path}" ]; then set -- "$@" "${_path}"; fi; '
+        "done; "
+        f'if [ "$#" -gt 0 ]; then /usr/bin/tar -cpf {root}/runtime.tar "$@"; fi'
+    )
+    _require_ok(runtime_snapshot, "snapshot pfBlockerNG Unbound runtime")
+    runtime_expected = vm.ssh(
+        f"if [ -f {root}/runtime.tar ]; then /bin/mkdir -p {root}/expected && "
+        f"/usr/bin/tar -xpf {root}/runtime.tar -C {root}/expected; fi"
+    )
+    _require_ok(runtime_expected, "materialize expected pfBlockerNG Unbound runtime")
+
+
+def _remove_runtime_artifacts(vm: SmokeVM) -> None:
+    result = h.php_eval(
+        vm,
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+        "$paths = array_merge(\n"
+        "  glob('/var/unbound/pfb_unbound*') ?: array(),\n"
+        "  glob('/var/unbound/pfb_py_*') ?: array()\n"
+        ");\n"
+        "$ok = TRUE;\n"
+        "foreach (array_unique($paths) as $path) { $ok = pfb_unbound_py_remove_raw_artifact($path) && $ok; }\n"
+        "echo $ok ? 'OK' : 'FAILED';",
+    )
+    _require_ok(result, "remove current pfBlockerNG Unbound runtime")
+    if "OK" not in result.stdout:
+        raise RuntimeError(f"remove current pfBlockerNG Unbound runtime failed: {result.stdout!r}")
+
+
+def _remove_snapshot_root(vm: SmokeVM, root: str) -> None:
+    result = h.php_eval(
+        vm, f"rmdir_recursive({h._php_str(root)}); echo file_exists({h._php_str(root)}) ? 'FAILED' : 'OK';"
+    )
+    _require_ok(result, "remove TOP1M smoke snapshot")
+    if "OK" not in result.stdout:
+        raise RuntimeError(f"remove TOP1M smoke snapshot failed: {result.stdout!r}")
+
+
+def _restore_box(vm: SmokeVM, root: str) -> tuple[dict, dict, dict]:
+    """Restore config and every persistent file this module can replace."""
+    errors: list[Exception] = []
+    try:
+        h.restore_pfb_config_baseline(vm, snapshot_path=f"{root}/config.xml")
+    except Exception as exc:  # noqa: BLE001 -- keep restoring every owned path, then fail loudly
+        errors.append(exc)
+    try:
+        _remove_runtime_artifacts(vm)
+        runtime = vm.ssh(f"if [ -f {root}/runtime.tar ]; then /usr/bin/tar -xpf {root}/runtime.tar -C /; fi")
+        _require_ok(runtime, "restore pfBlockerNG Unbound runtime")
+    except Exception as exc:  # noqa: BLE001 -- continue the remaining cleanup, then fail loudly
+        errors.append(exc)
+    for index, target in enumerate(_SNAPSHOT_TARGETS):
+        try:
+            _require_ok(vm.ssh("/bin/rm", "-f", target), f"remove test-owned {target}")
+            saved = f"{root}/files/{index}"
+            result = vm.ssh(f"if [ -e {saved} ] || [ -L {saved} ]; then /bin/cp -pP {saved} {target}; fi")
+            _require_ok(result, f"restore {target}")
+        except Exception as exc:  # noqa: BLE001 -- continue the remaining cleanup, then fail loudly
+            errors.append(exc)
+    try:
+        config = vm.ssh(f"/bin/cp -p {root}/config.xml /conf/config.xml && /bin/rm -f /tmp/config.cache")
+        _require_ok(config, "restore final config.xml bytes")
+    except Exception as exc:  # noqa: BLE001 -- aggregate cleanup failure below
+        errors.append(exc)
+    restored_runtime: dict = {}
+    restored_files: dict = {}
+    restored_config: dict = {}
+    try:
+        # Observe restoration before restarting Unbound: daemon-owned counters/cache
+        # may legitimately rewrite themselves after start, but every archived byte and
+        # path must be identical at the restoration boundary.
+        restored_runtime = _runtime_state(vm)
+        restored_files = _file_state(vm, _SNAPSHOT_TARGETS)
+        restored_config = _file_state(vm, ("/conf/config.xml",))
+    except Exception as exc:  # noqa: BLE001 -- aggregate cleanup failure below
+        errors.append(exc)
+    try:
+        configured = h.php_eval(vm, "services_unbound_configure(); echo 'OK';")
+        _require_ok(configured, "reconfigure Unbound after TOP1M smoke restore")
+        if "OK" not in configured.stdout:
+            raise RuntimeError(f"reconfigure Unbound after TOP1M smoke restore failed: {configured.stdout!r}")
+        h.wait_unbound_ready(vm)
+    except Exception as exc:  # noqa: BLE001 -- aggregate cleanup failure below
+        errors.append(exc)
+    try:
+        _remove_snapshot_root(vm, root)
+    except Exception as exc:  # noqa: BLE001 -- aggregate cleanup failure below
+        errors.append(exc)
+    if errors:
+        raise RuntimeError("TOP1M smoke cleanup failed: " + "; ".join(str(error) for error in errors)) from errors[0]
+    return restored_runtime, restored_files, restored_config
+
+
+@pytest.fixture(scope="module")
+def top1m_fixed_file_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator[SmokeVM]:  # noqa: ARG001
+    if not os.environ.get("SMOKE_PKG"):
+        pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")
+
+    snapshot = f"/tmp/pfb-smoke-top1m-fixed-{uuid.uuid4().hex}"
+    h.deploy(smoke_vm)
+    _snapshot_box(smoke_vm, snapshot)
+    runtime_before = _runtime_state(smoke_vm, root=f"{snapshot}/expected")
+    saved_paths = tuple(f"{snapshot}/files/{index}" for index in range(len(_SNAPSHOT_TARGETS)))
+    saved_files = _file_state(smoke_vm, saved_paths)
+    files_before = {target: saved_files[saved] for target, saved in zip(_SNAPSHOT_TARGETS, saved_paths, strict=True)}
+    saved_config = f"{snapshot}/config.xml"
+    config_before = {"/conf/config.xml": _file_state(smoke_vm, (saved_config,))[saved_config]}
+    try:
+        h.ensure_dnsbl_vip(smoke_vm)
+        h.use_system_dns_upstream(smoke_vm)
+        yield smoke_vm
+    finally:
+        h.unblock_egress()
+        diagnostic_error: Exception | None = None
+        try:
+            h.collect_host_diagnostics(smoke_vm)
+        except Exception as exc:  # noqa: BLE001 -- restoration must still run
+            diagnostic_error = exc
+        runtime_after, files_after, config_after = _restore_box(smoke_vm, snapshot)
+        files_post_service = _file_state(smoke_vm, _SNAPSHOT_TARGETS)
+        config_post_service = _file_state(smoke_vm, ("/conf/config.xml",))
+        if (
+            runtime_after != runtime_before
+            or files_after != files_before
+            or config_after != config_before
+            or files_post_service != files_before
+            or config_post_service != config_before
+        ):
+            raise RuntimeError(
+                "TOP1M smoke restore did not reproduce its post-deploy file baseline: "
+                f"runtime_before={runtime_before!r} runtime_after={runtime_after!r} "
+                f"files_before={files_before!r} files_after={files_after!r} "
+                f"files_post_service={files_post_service!r} "
+                f"config_before={config_before!r} config_after={config_after!r} "
+                f"config_post_service={config_post_service!r}"
+            )
+        if diagnostic_error is not None:
+            raise RuntimeError(f"TOP1M smoke diagnostics failed: {diagnostic_error}") from diagnostic_error
+
+
+def _json_eval(vm: SmokeVM, snippet: str, tag: str = "PFB1542") -> dict:
+    result = h.php_eval(vm, snippet + f"\necho '<<{tag}>>' . json_encode($out) . '<<END{tag}>>';")
+    _require_ok(result, f"PHP JSON probe {tag}")
+    try:
+        encoded = result.stdout.split(f"<<{tag}>>", 1)[1].split(f"<<END{tag}>>", 1)[0]
+        value = json.loads(encoded)
+    except (IndexError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"PHP JSON probe {tag} returned no valid payload: {result.stdout!r}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeError(f"PHP JSON probe {tag} returned non-object payload: {value!r}")
+    return value
+
+
+def _publication_state(vm: SmokeVM) -> dict:
+    return _json_eval(
+        vm,
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+        "pfb_global();\n"
+        f"$manifest_raw = @file_get_contents('{MANIFEST}');\n"
+        "$manifest = is_string($manifest_raw) ? json_decode($manifest_raw, TRUE) : NULL;\n"
+        "$feed = is_array($manifest) ? ($manifest['feeds'][0] ?? array()) : array();\n"
+        "$raw_rel = is_array($feed) ? ($feed['raw'] ?? '') : '';\n"
+        "$raw_path = is_string($raw_rel) && $raw_rel !== '' ? '/var/unbound/' . $raw_rel : '';\n"
+        "$raw_stat = $raw_path !== '' ? @stat($raw_path) : FALSE;\n"
+        "$raw_dir = $raw_path !== '' ? dirname($raw_path) : '';\n"
+        "$dir_stat = $raw_dir !== '' ? @stat($raw_dir) : FALSE;\n"
+        "$top1m_keys = array();\n"
+        "foreach ((array) ($manifest['config'] ?? array()) as $key => $_value) {\n"
+        "  if (stripos((string) $key, 'top1m') !== FALSE) { $top1m_keys[] = (string) $key; }\n"
+        "}\n"
+        "$out = array(\n"
+        f"  'fixed_regular' => is_file('{TOP1M_FIXED}') && !is_link('{TOP1M_FIXED}'),\n"
+        f"  'fixed_bytes' => @file_get_contents('{TOP1M_FIXED}'),\n"
+        f"  'whitelist_bytes' => @file_get_contents('{TOP1M_WHITELIST}'),\n"
+        "  'top1m_enabled' => $manifest['config']['top1m_enabled'] ?? NULL,\n"
+        "  'top1m_keys' => $top1m_keys,\n"
+        "  'manifest_raw' => $manifest_raw,\n"
+        "  'raw_rel' => $raw_rel,\n"
+        "  'raw_identity' => $raw_stat === FALSE ? NULL : array(\n"
+        "    'dev' => $raw_stat['dev'], 'ino' => $raw_stat['ino'], 'mtime' => $raw_stat['mtime'],\n"
+        "    'ctime' => $raw_stat['ctime'], 'size' => $raw_stat['size'], 'sha256' => hash_file('sha256', $raw_path)),\n"
+        "  'raw_dir_identity' => $dir_stat === FALSE ? NULL : array(\n"
+        "    'dev' => $dir_stat['dev'], 'ino' => $dir_stat['ino'], 'mtime' => $dir_stat['mtime'],\n"
+        "    'ctime' => $dir_stat['ctime']),\n"
+        "  'fingerprint' => pfb_dnsbl_reload_fingerprint($pfb),\n"
+        "  'reload_generation' => pfb_unbound_py_marker_generation('/var/unbound/pfb_py_reload'),\n"
+        "  'applied_generation' => pfb_unbound_py_marker_generation('/var/unbound/pfb_py_reload.applied'),\n"
+        ");",
+    )
+
+
+def _file_state(vm: SmokeVM, paths: tuple[str, ...]) -> dict:
+    php_paths = "array(" + ",".join(h._php_str(path) for path in paths) + ")"
+    return _json_eval(
+        vm,
+        f"$out = array(); foreach ({php_paths} as $path) {{\n"
+        "  if (is_link($path)) { $out[$path] = array('type' => 'link', 'target' => readlink($path)); }\n"
+        "  elseif (is_file($path)) {\n"
+        "    $out[$path] = array('type' => 'file',\n"
+        "      'sha256' => hash_file('sha256', $path), 'size' => filesize($path));\n"
+        "  } elseif (is_dir($path)) { $out[$path] = array('type' => 'dir'); }\n"
+        "  else { $out[$path] = NULL; }\n"
+        "}",
+        "PFB1542FILES",
+    )
+
+
+def _runtime_state(vm: SmokeVM, *, root: str = "") -> dict:
+    """Inventory every pfBlockerNG-owned Unbound path and nested generation member."""
+    prefix = root.rstrip("/")
+    unbound = f"{prefix}/var/unbound"
+    return _json_eval(
+        vm,
+        f"$prefix = {h._php_str(prefix)};\n"
+        "$roots = array_merge(\n"
+        f"  glob({h._php_str(unbound + '/pfb_unbound*')}) ?: array(),\n"
+        f"  glob({h._php_str(unbound + '/pfb_py_*')}) ?: array()\n"
+        ");\n"
+        "$out = array();\n"
+        "$record = static function ($path) use (&$out, $prefix) {\n"
+        "  $key = $prefix !== '' ? substr($path, strlen($prefix)) : $path;\n"
+        "  if (is_link($path)) { $out[$key] = array('type' => 'link', 'target' => readlink($path)); }\n"
+        "  elseif (is_file($path)) {\n"
+        "    $out[$key] = array('type' => 'file',\n"
+        "      'sha256' => hash_file('sha256', $path), 'size' => filesize($path));\n"
+        "  } elseif (is_dir($path)) { $out[$key] = array('type' => 'dir'); }\n"
+        "};\n"
+        "foreach (array_unique($roots) as $root) {\n"
+        "  if (!file_exists($root) && !is_link($root)) { continue; }\n"
+        "  $record($root);\n"
+        "  if (is_dir($root) && !is_link($root)) {\n"
+        "    $iterator = new RecursiveIteratorIterator(\n"
+        "      new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),\n"
+        "      RecursiveIteratorIterator::SELF_FIRST);\n"
+        "    foreach ($iterator as $entry) { $record($entry->getPathname()); }\n"
+        "  }\n"
+        "}\n"
+        "ksort($out, SORT_STRING);",
+        "PFB1542RUNTIME",
+    )
+
+
+def _configure_top1m(vm: SmokeVM) -> None:
+    result = h.php_eval(
+        vm,
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
+        "PfbConfig::write('alexa_enable', 'on');\n"
+        "PfbConfig::write('alexa_type', PfbTop1mSource::Tranco);\n"
+        "PfbConfig::write('alexa_count', '1');\n"
+        "PfbConfig::write('alexa_inclusion', 'com');\n"
+        "write_config('pfBlockerNG #1542 smoke: enable deterministic TOP1M fixture');\n"
+        "echo 'OK';",
+    )
+    _require_ok(result, "configure TOP1M")
+    if "OK" not in result.stdout:
+        raise RuntimeError(f"configure TOP1M returned no success sentinel: {result.stdout!r}")
+
+
+def _stage_top1m_source(vm: SmokeVM, body: str) -> None:
+    """Stage provider-shaped CSV with a hash/source-consistent detector baseline."""
+    h.write_local_feed(vm, "top-1m.csv", body)
+    state = _json_eval(
+        vm,
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+        "pfb_global();\n"
+        f"$base = '{TOP1M_BASE}';\n"
+        f"$persisted = pfb_top1m_persist_baseline($base, '{TOP1M_CSV}');\n"
+        "$provider = pfb_top1m_active_provider();\n"
+        "$source = $pfb['dnsbl_top1m_type'];\n"
+        "$source_key = $source instanceof PfbTop1mSource ? $source->value : (string) $source;\n"
+        "$headers = pfb_top1m_auth_headers($provider, (string) PfbConfig::read('top1m_token'));\n"
+        "$identity = pfb_top1m_source_identity($source_key, $provider['url'], $headers);\n"
+        "$source_written = @file_put_contents($base . '.source', $identity, LOCK_EX) !== FALSE;\n"
+        "$hash = pfb_hash_read($base);\n"
+        "$out = array(\n"
+        "  'persisted' => $persisted, 'source_written' => $source_written,\n"
+        "  'hash_valid' => ($hash['algo'] ?? '') === 'xxh128'\n"
+        "    && ($hash['digest'] ?? '') === pfb_content_hash($base . '.orig', TRUE),\n"
+        "  'source_valid' => @file_get_contents($base . '.source') === $identity,\n"
+        ");",
+        "PFB1542BASELINE",
+    )
+    assert state == {"persisted": True, "source_written": True, "hash_valid": True, "source_valid": True}, state
+
+
+def _complete_detector_sidecars(vm: SmokeVM) -> dict:
+    """Create valid legacy-hash/validator siblings and verify all six sidecars."""
+    return _json_eval(
+        vm,
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+        "pfb_global();\n"
+        f"$base = '{TOP1M_BASE}';\n"
+        "$md5 = md5_file($base . '.orig');\n"
+        "$md5_written = is_string($md5) && @file_put_contents($base . '.md5', $md5, LOCK_EX) !== FALSE;\n"
+        "pfb_validator_write($base . '.orig', '\"pfb-smoke-1542\"', 1700000000);\n"
+        "$validators_written = is_file($base . '.orig.etag') && is_file($base . '.orig.lastmod');\n"
+        "$provider = pfb_top1m_active_provider();\n"
+        "$source = $pfb['dnsbl_top1m_type'];\n"
+        "$source_key = $source instanceof PfbTop1mSource ? $source->value : (string) $source;\n"
+        "$headers = pfb_top1m_auth_headers($provider, (string) PfbConfig::read('top1m_token'));\n"
+        "$identity = pfb_top1m_source_identity($source_key, $provider['url'], $headers);\n"
+        "$hash = pfb_hash_read($base);\n"
+        "$validators = pfb_validator_read($base . '.orig');\n"
+        "$out = array(\n"
+        "  'md5_written' => $md5_written, 'validators_written' => $validators_written,\n"
+        "  'hash_valid' => ($hash['algo'] ?? '') === 'xxh128'\n"
+        "    && ($hash['digest'] ?? '') === pfb_content_hash($base . '.orig', TRUE),\n"
+        "  'legacy_hash_valid' => trim((string) @file_get_contents($base . '.md5')) === md5_file($base . '.orig'),\n"
+        "  'source_valid' => @file_get_contents($base . '.source') === $identity,\n"
+        "  'etag_valid' => ($validators['etag'] ?? FALSE) === '\"pfb-smoke-1542\"',\n"
+        "  'lastmod_valid' => ($validators['lastmod'] ?? FALSE) === 1700000000,\n"
+        ");",
+        "PFB1542SIDECARS",
+    )
+
+
+def _assert_vip(vm: SmokeVM, domain: str, stage: str) -> None:
+    answer = h.dns_probe(vm, domain, "A")
+    assert h.is_vip(answer), f"{stage}: {domain} should resolve to DNSBL VIP; got {answer}"
+
+
+def _assert_stub(vm: SmokeVM, domain: str, stage: str) -> None:
+    answer = h.dns_probe_until(vm, domain, lambda current: h.resolves_to(current, h.STUB_DNS_A), timeout=60.0)
+    assert h.resolves_to(answer, h.STUB_DNS_A), f"{stage}: {domain} should pass to stub upstream; got {answer}"
+
+
+@pytest.mark.timeout(600)
+def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm: SmokeVM) -> None:
+    vm = top1m_fixed_file_vm
+    allowed = h.unique_domain("top1m-fixed-allow")
+    sibling = h.unique_domain("top1m-fixed-sibling")
+    replacement = h.unique_domain("top1m-fixed-replacement")
+
+    # Start from this test's own TOP1M state; the module fixture restores every path later.
+    _require_ok(
+        vm.ssh("/bin/rm", "-f", TOP1M_CSV, TOP1M_WHITELIST, TOP1M_FIXED, *SIDECARS, NEIGHBOR),
+        "clear TOP1M fixture paths",
+    )
+    feed = h.write_local_feed(vm, os.path.basename(LOCAL_FEED), f"{allowed}\n{sibling}\n{replacement}\n")
+    h.inject(
+        vm,
+        h.DnsblCase(
+            aliasname="Top1mFixedFile", feed_url=feed, header="top1mFixedFile", mode=h.DnsblMode.VIP, hsts=False
+        ),
+    )
+    h.reload(vm, "updatednsbl")
+
+    # Before-state: all three names are genuinely blocked before TOP1M can allow one.
+    _assert_vip(vm, allowed, "before TOP1M")
+    _assert_vip(vm, sibling, "before TOP1M")
+    _assert_vip(vm, replacement, "before TOP1M")
+
+    # Seed a provider-shaped local source plus the required detector baseline.  Their
+    # presence makes pfb_top1m_refresh_needed() false, so no provider network runs.
+    _configure_top1m(vm)
+    _stage_top1m_source(vm, f"1,{allowed}\n2,{sibling}\n")
+    h.reload(vm, "update", data_path=True)
+
+    first = _publication_state(vm)
+    assert first["fixed_regular"], f"publisher did not create regular {TOP1M_FIXED}: {first!r}"
+    assert first["fixed_bytes"] == first["whitelist_bytes"], "fixed file did not preserve publisher bytes"
+    assert first["top1m_enabled"] is True
+    assert first["top1m_keys"] == ["top1m_enabled"], f"manifest embeds retired TOP1M fields: {first!r}"
+    assert allowed not in first["manifest_raw"], "manifest embeds TOP1M domain data instead of naming the fixed file"
+    assert first["raw_identity"] is not None and first["raw_dir_identity"] is not None
+
+    h.flush_unbound_name(vm, allowed)
+    _assert_stub(vm, allowed, "TOP1M allow")
+    _assert_vip(vm, sibling, "TOP1M sibling")
+
+    # A TOP1M-only source transition must replace fixed bytes and advance the
+    # data reload while leaving the unrelated content-addressed feed generation intact.
+    pid_before = h.unbound_pid(vm)
+    _stage_top1m_source(vm, f"1,{replacement}\n2,{sibling}\n")
+    _require_ok(vm.ssh("/usr/bin/touch", f"{h.PFB_DBDIR}/top-1m.update"), "mark TOP1M source changed")
+    h.reload(vm, "update", data_path=True)
+    second = _publication_state(vm)
+
+    assert second["fixed_regular"]
+    assert second["fixed_bytes"] == second["whitelist_bytes"]
+    assert second["fixed_bytes"] != first["fixed_bytes"], "TOP1M-only update retained old fixed-file bytes"
+    assert second["fingerprint"] != first["fingerprint"], (
+        "TOP1M fixed-file replacement did not change reload fingerprint"
+    )
+    assert second["reload_generation"] > first["reload_generation"], (
+        "TOP1M-only update did not advance reload generation"
+    )
+    assert second["applied_generation"] == second["reload_generation"], "TOP1M reload was not applied before return"
+    assert second["raw_rel"] == first["raw_rel"]
+    assert second["raw_identity"] == first["raw_identity"], "TOP1M-only update regenerated unrelated feed raw"
+    assert second["raw_dir_identity"] == first["raw_dir_identity"], "TOP1M-only update replaced unrelated generation"
+    assert h.unbound_pid(vm) == pid_before, "TOP1M-only data change restarted Unbound instead of swapping"
+
+    h.flush_unbound_name(vm, allowed)
+    h.flush_unbound_name(vm, replacement)
+    _assert_vip(vm, allowed, "replaced TOP1M allow")
+    _assert_stub(vm, replacement, "replacement TOP1M allow")
+    _assert_vip(vm, sibling, "replacement TOP1M sibling")
+
+    # Cache preserves the fixed file and exactly six detector sidecars.  A prefix
+    # neighbor is deliberately deleted before restore and must not come back.
+    assert len(SIDECARS) == 6
+    detector_state = _complete_detector_sidecars(vm)
+    assert detector_state and all(detector_state.values()), detector_state
+    h.write_local_feed(vm, os.path.basename(NEIGHBOR), "not part of exact cache set\n")
+    cached_paths = (TOP1M_FIXED, *SIDECARS)
+    before_cache = _file_state(vm, cached_paths)
+    assert all(value is not None for value in before_cache.values()), before_cache
+
+    _require_ok(
+        vm.ssh("/usr/local/pkg/pfblockerng/pfblockerng.sh", "dnsbl_cache", "save", timeout=180.0), "save DNSBL cache"
+    )
+    archives = _file_state(vm, (f"{CACHE_BASE}.zst", f"{CACHE_BASE}.bz2"))
+    assert any(value is not None for value in archives.values()), f"dnsbl_cache save produced no archive: {archives!r}"
+    _require_ok(vm.ssh("/bin/rm", "-f", TOP1M_FIXED, *SIDECARS, NEIGHBOR), "delete cached TOP1M artifacts")
+    _require_ok(
+        vm.ssh("/usr/local/pkg/pfblockerng/pfblockerng.sh", "dnsbl_cache", "restore", timeout=180.0),
+        "restore DNSBL cache",
+    )
+    assert _file_state(vm, cached_paths) == before_cache, "cache restore changed TOP1M fixed/sidecar bytes"
+    assert _file_state(vm, (NEIGHBOR,))[NEIGHBOR] is None, "cache restored a non-exact TOP1M sidecar neighbor"
+
+    # Keep-on teardown is exercised through the callable production seam: active
+    # provider/derived whitelist data remains, runtime derived files and narrow
+    # TOP1M detector/staging artifacts disappear.  No destructive pkg uninstall.
+    h.write_local_feed(vm, os.path.basename(NEIGHBOR), "preserve-neighbor\n")
+    temp_paths = (
+        f"{h.PFB_DBDIR}/.pfbtop1m_smoke_file",
+        f"{h.PFB_DBDIR}/.pfbtop1m_smoke_dir",
+        "/var/unbound/.pfbtop1m_smoke_file",
+        "/var/unbound/.pfbtop1m_smoke_dir",
+    )
+    _require_ok(vm.ssh("/usr/bin/touch", temp_paths[0], temp_paths[2]), "seed TOP1M temp files")
+    _require_ok(
+        vm.ssh("/bin/mkdir", "-p", f"{temp_paths[1]}/nested", f"{temp_paths[3]}/nested"), "seed TOP1M temp directories"
+    )
+    active_before = _file_state(vm, (TOP1M_CSV, TOP1M_WHITELIST, NEIGHBOR))
+    raw_path = f"/var/unbound/{second['raw_rel']}"
+
+    teardown = _json_eval(
+        vm,
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+        "PfbConfig::write('pfb_keep', PfbLenient::On);\n"
+        "write_config('pfBlockerNG #1542 smoke: keep-on callable teardown');\n"
+        "pfb_global();\n"
+        "$ok = pfb_unbound_py_teardown_raw_set();\n"
+        "$keep = PfbConfig::read('pfb_keep');\n"
+        "$out = array('ok' => $ok, 'keep' => $keep instanceof PfbLenient ? $keep->value : (string) $keep);",
+        "PFB1542TEARDOWN",
+    )
+    assert teardown == {"ok": True, "keep": "on"}, teardown
+
+    removed = (TOP1M_FIXED, *SIDECARS, MANIFEST, raw_path, *temp_paths)
+    assert all(value is None for value in _file_state(vm, removed).values()), "teardown left derived TOP1M artifacts"
+    assert _file_state(vm, (TOP1M_CSV, TOP1M_WHITELIST, NEIGHBOR)) == active_before, (
+        "keep-on teardown changed active provider/whitelist data or an unrelated sidecar neighbor"
+    )

--- a/tests/smoke/test_top1m_fixed_file.py
+++ b/tests/smoke/test_top1m_fixed_file.py
@@ -446,8 +446,8 @@ def _assert_vip(vm: SmokeVM, domain: str, stage: str) -> None:
     assert h.is_vip(answer), f"{stage}: {domain} should resolve to DNSBL VIP; got {answer}"
 
 
-def _assert_stub(vm: SmokeVM, domain: str, stage: str) -> None:
-    answer = h.dns_probe_until(vm, domain, lambda current: h.resolves_to(current, h.STUB_DNS_A), timeout=60.0)
+def _assert_stub_once(vm: SmokeVM, domain: str, stage: str) -> None:
+    answer = h.dns_probe(vm, domain, "A")
     assert h.resolves_to(answer, h.STUB_DNS_A), f"{stage}: {domain} should pass to stub upstream; got {answer}"
 
 
@@ -461,7 +461,16 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     # Start from this test's own TOP1M state; the module fixture restores every path later.
     _remove_exact_paths(
         vm,
-        (TOP1M_CSV, TOP1M_WHITELIST, TOP1M_FIXED, *SIDECARS, NEIGHBOR, TOP1M_UPDATE, *TEMP_PATHS),
+        (
+            TOP1M_CSV,
+            TOP1M_WHITELIST,
+            TOP1M_FIXED,
+            *SIDECARS,
+            NEIGHBOR,
+            LOCAL_FEED,
+            TOP1M_UPDATE,
+            *TEMP_PATHS,
+        ),
         "clear TOP1M fixture paths",
     )
     feed = h.write_local_feed(vm, os.path.basename(LOCAL_FEED), f"{allowed}\n{sibling}\n{replacement}\n")
@@ -507,7 +516,7 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     }, reader_first
 
     h.flush_unbound_name(vm, allowed)
-    _assert_stub(vm, allowed, "TOP1M allow")
+    _assert_stub_once(vm, allowed, "TOP1M allow")
     _assert_vip(vm, sibling, "TOP1M sibling")
 
     # A TOP1M-only source transition must replace fixed bytes and advance the
@@ -524,9 +533,7 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     assert second["fingerprint"] != first["fingerprint"], (
         "TOP1M fixed-file replacement did not change reload fingerprint"
     )
-    assert second["reload_generation"] > first["reload_generation"], (
-        "TOP1M-only update did not advance reload generation"
-    )
+    assert second["reload_generation"] > reader_first_generation, "TOP1M-only update did not advance reload generation"
     assert second["applied_generation"] == second["reload_generation"], "TOP1M reload was not applied before return"
     assert second["raw_rel"] == first["raw_rel"]
     assert second["raw_identity"] == first["raw_identity"], "TOP1M-only update regenerated unrelated feed raw"
@@ -548,7 +555,7 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     h.flush_unbound_name(vm, allowed)
     h.flush_unbound_name(vm, replacement)
     _assert_vip(vm, allowed, "replaced TOP1M allow")
-    _assert_stub(vm, replacement, "replacement TOP1M allow")
+    _assert_stub_once(vm, replacement, "replacement TOP1M allow")
     _assert_vip(vm, sibling, "replacement TOP1M sibling")
 
     # Cache preserves the fixed file and exactly six detector sidecars.  A prefix

--- a/tests/smoke/test_top1m_fixed_file.py
+++ b/tests/smoke/test_top1m_fixed_file.py
@@ -22,10 +22,17 @@ pytestmark = pytest.mark.smoke
 TOP1M_CSV = f"{h.PFB_DBDIR}/top-1m.csv"
 TOP1M_WHITELIST = f"{h.PFB_DBDIR}/pfbalexawhitelist.txt"
 TOP1M_BASE = f"{h.PFB_DBDIR}/top-1m.csv.zip"
+TOP1M_UPDATE = f"{h.PFB_DBDIR}/top-1m.update"
 TOP1M_FIXED = "/var/unbound/pfb_py_top1m.txt"
 MANIFEST = "/var/unbound/pfb_py_sources.json"
 CACHE_BASE = "/usr/local/etc/pfb_dnsbl_cache.tar"
 LOCAL_FEED = f"{h.PFB_DBDIR}/top1m_fixed_file_feed.txt"
+TEMP_PATHS = (
+    f"{h.PFB_DBDIR}/.pfbtop1m_smoke_file",
+    f"{h.PFB_DBDIR}/.pfbtop1m_smoke_dir",
+    "/var/unbound/.pfbtop1m_smoke_file",
+    "/var/unbound/.pfbtop1m_smoke_dir",
+)
 SIDECAR_SUFFIXES = ("orig", "xxhash128", "md5", "source", "orig.etag", "orig.lastmod")
 SIDECARS = tuple(f"{TOP1M_BASE}.{suffix}" for suffix in SIDECAR_SUFFIXES)
 NEIGHBOR = f"{TOP1M_BASE}.orig.neighbor"
@@ -40,6 +47,8 @@ _SNAPSHOT_TARGETS = (
     f"{CACHE_BASE}.zst",
     f"{CACHE_BASE}.bz2",
     LOCAL_FEED,
+    TOP1M_UPDATE,
+    *TEMP_PATHS,
 )
 
 
@@ -51,8 +60,9 @@ def _require_ok(result: object, operation: str) -> None:
         )
 
 
-def _copy_if_present(vm: SmokeVM, source: str, target: str) -> None:
-    result = vm.ssh(f"if [ -e {source} ] || [ -L {source} ]; then /bin/cp -pP {source} {target}; fi")
+def _archive_if_present(vm: SmokeVM, source: str, archive: str) -> None:
+    relative = source.removeprefix("/")
+    result = vm.ssh(f"if [ -e {source} ] || [ -L {source} ]; then /usr/bin/tar -cpf {archive} -C / {relative}; fi")
     _require_ok(result, f"snapshot {source}")
 
 
@@ -60,7 +70,7 @@ def _snapshot_box(vm: SmokeVM, root: str) -> None:
     _require_ok(vm.ssh("/bin/mkdir", "-p", f"{root}/files"), "create TOP1M smoke snapshot")
     _require_ok(vm.ssh("/bin/cp", "-p", "/conf/config.xml", f"{root}/config.xml"), "snapshot config.xml")
     for index, target in enumerate(_SNAPSHOT_TARGETS):
-        _copy_if_present(vm, target, f"{root}/files/{index}")
+        _archive_if_present(vm, target, f"{root}/files/{index}.tar")
     runtime_snapshot = vm.ssh(
         "cd / && set --; "
         "for _path in var/unbound/pfb_unbound* var/unbound/pfb_py_*; do "
@@ -102,6 +112,21 @@ def _remove_snapshot_root(vm: SmokeVM, root: str) -> None:
         raise RuntimeError(f"remove TOP1M smoke snapshot failed: {result.stdout!r}")
 
 
+def _remove_exact_paths(vm: SmokeVM, paths: tuple[str, ...], operation: str) -> None:
+    php_paths = "array(" + ",".join(h._php_str(path) for path in paths) + ")"
+    result = h.php_eval(
+        vm,
+        f"$ok = TRUE; foreach ({php_paths} as $path) {{\n"
+        "  if (is_link($path) || is_file($path)) { $ok = @unlink($path) && $ok; }\n"
+        "  elseif (is_dir($path)) { rmdir_recursive($path); $ok = !file_exists($path) && $ok; }\n"
+        "}\n"
+        "echo $ok ? 'OK' : 'FAILED';",
+    )
+    _require_ok(result, operation)
+    if "OK" not in result.stdout:
+        raise RuntimeError(f"{operation} failed: {result.stdout!r}")
+
+
 def _restore_box(vm: SmokeVM, root: str) -> tuple[dict, dict, dict]:
     """Restore config and every persistent file this module can replace."""
     errors: list[Exception] = []
@@ -117,9 +142,9 @@ def _restore_box(vm: SmokeVM, root: str) -> tuple[dict, dict, dict]:
         errors.append(exc)
     for index, target in enumerate(_SNAPSHOT_TARGETS):
         try:
-            _require_ok(vm.ssh("/bin/rm", "-f", target), f"remove test-owned {target}")
-            saved = f"{root}/files/{index}"
-            result = vm.ssh(f"if [ -e {saved} ] || [ -L {saved} ]; then /bin/cp -pP {saved} {target}; fi")
+            _remove_exact_paths(vm, (target,), f"remove test-owned {target}")
+            archive = f"{root}/files/{index}.tar"
+            result = vm.ssh(f"if [ -f {archive} ]; then /usr/bin/tar -xpf {archive} -C /; fi")
             _require_ok(result, f"restore {target}")
         except Exception as exc:  # noqa: BLE001 -- continue the remaining cleanup, then fail loudly
             errors.append(exc)
@@ -166,9 +191,7 @@ def top1m_fixed_file_vm(smoke_vm: SmokeVM, stub_dns: _StubDnsServer) -> Iterator
     h.deploy(smoke_vm)
     _snapshot_box(smoke_vm, snapshot)
     runtime_before = _runtime_state(smoke_vm, root=f"{snapshot}/expected")
-    saved_paths = tuple(f"{snapshot}/files/{index}" for index in range(len(_SNAPSHOT_TARGETS)))
-    saved_files = _file_state(smoke_vm, saved_paths)
-    files_before = {target: saved_files[saved] for target, saved in zip(_SNAPSHOT_TARGETS, saved_paths, strict=True)}
+    files_before = _file_state(smoke_vm, _SNAPSHOT_TARGETS)
     saved_config = f"{snapshot}/config.xml"
     config_before = {"/conf/config.xml": _file_state(smoke_vm, (saved_config,))[saved_config]}
     try:
@@ -259,13 +282,27 @@ def _file_state(vm: SmokeVM, paths: tuple[str, ...]) -> dict:
     php_paths = "array(" + ",".join(h._php_str(path) for path in paths) + ")"
     return _json_eval(
         vm,
+        "$describe = static function ($path) {\n"
+        "  if (is_link($path)) { return array('type' => 'link', 'target' => readlink($path)); }\n"
+        "  if (is_file($path)) { return array('type' => 'file',\n"
+        "    'sha256' => hash_file('sha256', $path), 'size' => filesize($path)); }\n"
+        "  if (is_dir($path)) { return array('type' => 'dir'); }\n"
+        "  return NULL;\n"
+        "};\n"
         f"$out = array(); foreach ({php_paths} as $path) {{\n"
-        "  if (is_link($path)) { $out[$path] = array('type' => 'link', 'target' => readlink($path)); }\n"
-        "  elseif (is_file($path)) {\n"
-        "    $out[$path] = array('type' => 'file',\n"
-        "      'sha256' => hash_file('sha256', $path), 'size' => filesize($path));\n"
-        "  } elseif (is_dir($path)) { $out[$path] = array('type' => 'dir'); }\n"
-        "  else { $out[$path] = NULL; }\n"
+        "  $out[$path] = $describe($path);\n"
+        "  if (is_dir($path) && !is_link($path)) {\n"
+        "    $entries = array();\n"
+        "    $iterator = new RecursiveIteratorIterator(\n"
+        "      new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),\n"
+        "      RecursiveIteratorIterator::SELF_FIRST);\n"
+        "    foreach ($iterator as $entry) {\n"
+        "      $relative = substr($entry->getPathname(), strlen($path) + 1);\n"
+        "      $entries[$relative] = $describe($entry->getPathname());\n"
+        "    }\n"
+        "    ksort($entries, SORT_STRING);\n"
+        "    $out[$path]['entries'] = $entries;\n"
+        "  }\n"
         "}",
         "PFB1542FILES",
     )
@@ -380,6 +417,30 @@ def _complete_detector_sidecars(vm: SmokeVM) -> dict:
     )
 
 
+def _activate_domain_only_top1m(vm: SmokeVM, domain: str) -> dict:
+    """Publish one reader-valid domain and wait for the shipped watcher to apply it."""
+    body = f"{domain}\n"
+    return _json_eval(
+        vm,
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+        "pfb_global();\n"
+        f"$fixture = {h._php_str(TEMP_PATHS[0])};\n"
+        f"$body = {h._php_str(body)};\n"
+        "$staged = @file_put_contents($fixture, $body, LOCK_EX) !== FALSE;\n"
+        f"$published = $staged && pfb_unbound_py_atomic_copy($fixture, '{TOP1M_FIXED}');\n"
+        "@unlink($fixture);\n"
+        "$generation = $published ? pfb_unbound_py_flip_sentinel() : FALSE;\n"
+        "$applied = is_int($generation) && pfb_unbound_py_wait_applied($generation, 60);\n"
+        "$out = array(\n"
+        "  'staged' => $staged, 'published' => $published, 'applied' => $applied,\n"
+        "  'generation' => $generation,\n"
+        f"  'fixed_regular' => is_file('{TOP1M_FIXED}') && !is_link('{TOP1M_FIXED}'),\n"
+        f"  'fixed_bytes' => @file_get_contents('{TOP1M_FIXED}'),\n"
+        ");",
+        "PFB1542READER",
+    )
+
+
 def _assert_vip(vm: SmokeVM, domain: str, stage: str) -> None:
     answer = h.dns_probe(vm, domain, "A")
     assert h.is_vip(answer), f"{stage}: {domain} should resolve to DNSBL VIP; got {answer}"
@@ -398,8 +459,9 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     replacement = h.unique_domain("top1m-fixed-replacement")
 
     # Start from this test's own TOP1M state; the module fixture restores every path later.
-    _require_ok(
-        vm.ssh("/bin/rm", "-f", TOP1M_CSV, TOP1M_WHITELIST, TOP1M_FIXED, *SIDECARS, NEIGHBOR),
+    _remove_exact_paths(
+        vm,
+        (TOP1M_CSV, TOP1M_WHITELIST, TOP1M_FIXED, *SIDECARS, NEIGHBOR, TOP1M_UPDATE, *TEMP_PATHS),
         "clear TOP1M fixture paths",
     )
     feed = h.write_local_feed(vm, os.path.basename(LOCAL_FEED), f"{allowed}\n{sibling}\n{replacement}\n")
@@ -430,6 +492,20 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     assert allowed not in first["manifest_raw"], "manifest embeds TOP1M domain data instead of naming the fixed file"
     assert first["raw_identity"] is not None and first["raw_dir_identity"] is not None
 
+    # The legacy PHP generator currently comma-frames whitelist rows.  That is a
+    # separate pre-existing defect (#1569): preserve the publisher bytes above, then feed
+    # this change's stable-path reader the domain-only format it accepts.
+    reader_first = _activate_domain_only_top1m(vm, allowed)
+    reader_first_generation = reader_first.pop("generation")
+    assert isinstance(reader_first_generation, int) and reader_first_generation > 0
+    assert reader_first == {
+        "staged": True,
+        "published": True,
+        "applied": True,
+        "fixed_regular": True,
+        "fixed_bytes": f"{allowed}\n",
+    }, reader_first
+
     h.flush_unbound_name(vm, allowed)
     _assert_stub(vm, allowed, "TOP1M allow")
     _assert_vip(vm, sibling, "TOP1M sibling")
@@ -438,7 +514,7 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     # data reload while leaving the unrelated content-addressed feed generation intact.
     pid_before = h.unbound_pid(vm)
     _stage_top1m_source(vm, f"1,{replacement}\n2,{sibling}\n")
-    _require_ok(vm.ssh("/usr/bin/touch", f"{h.PFB_DBDIR}/top-1m.update"), "mark TOP1M source changed")
+    _require_ok(vm.ssh("/usr/bin/touch", TOP1M_UPDATE), "mark TOP1M source changed")
     h.reload(vm, "update", data_path=True)
     second = _publication_state(vm)
 
@@ -456,6 +532,18 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     assert second["raw_identity"] == first["raw_identity"], "TOP1M-only update regenerated unrelated feed raw"
     assert second["raw_dir_identity"] == first["raw_dir_identity"], "TOP1M-only update replaced unrelated generation"
     assert h.unbound_pid(vm) == pid_before, "TOP1M-only data change restarted Unbound instead of swapping"
+
+    reader_second = _activate_domain_only_top1m(vm, replacement)
+    reader_second_generation = reader_second.pop("generation")
+    assert isinstance(reader_second_generation, int)
+    assert reader_second == {
+        "staged": True,
+        "published": True,
+        "applied": True,
+        "fixed_regular": True,
+        "fixed_bytes": f"{replacement}\n",
+    }, reader_second
+    assert reader_second_generation > reader_first_generation
 
     h.flush_unbound_name(vm, allowed)
     h.flush_unbound_name(vm, replacement)
@@ -478,7 +566,7 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     )
     archives = _file_state(vm, (f"{CACHE_BASE}.zst", f"{CACHE_BASE}.bz2"))
     assert any(value is not None for value in archives.values()), f"dnsbl_cache save produced no archive: {archives!r}"
-    _require_ok(vm.ssh("/bin/rm", "-f", TOP1M_FIXED, *SIDECARS, NEIGHBOR), "delete cached TOP1M artifacts")
+    _remove_exact_paths(vm, (TOP1M_FIXED, *SIDECARS, NEIGHBOR), "delete cached TOP1M artifacts")
     _require_ok(
         vm.ssh("/usr/local/pkg/pfblockerng/pfblockerng.sh", "dnsbl_cache", "restore", timeout=180.0),
         "restore DNSBL cache",
@@ -490,15 +578,11 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     # provider/derived whitelist data remains, runtime derived files and narrow
     # TOP1M detector/staging artifacts disappear.  No destructive pkg uninstall.
     h.write_local_feed(vm, os.path.basename(NEIGHBOR), "preserve-neighbor\n")
-    temp_paths = (
-        f"{h.PFB_DBDIR}/.pfbtop1m_smoke_file",
-        f"{h.PFB_DBDIR}/.pfbtop1m_smoke_dir",
-        "/var/unbound/.pfbtop1m_smoke_file",
-        "/var/unbound/.pfbtop1m_smoke_dir",
-    )
-    _require_ok(vm.ssh("/usr/bin/touch", temp_paths[0], temp_paths[2]), "seed TOP1M temp files")
+    _remove_exact_paths(vm, TEMP_PATHS, "clear TOP1M temp fixture paths")
+    _require_ok(vm.ssh("/usr/bin/touch", TEMP_PATHS[0], TEMP_PATHS[2]), "seed TOP1M temp files")
     _require_ok(
-        vm.ssh("/bin/mkdir", "-p", f"{temp_paths[1]}/nested", f"{temp_paths[3]}/nested"), "seed TOP1M temp directories"
+        vm.ssh("/bin/mkdir", "-p", f"{TEMP_PATHS[1]}/nested", f"{TEMP_PATHS[3]}/nested"),
+        "seed TOP1M temp directories",
     )
     active_before = _file_state(vm, (TOP1M_CSV, TOP1M_WHITELIST, NEIGHBOR))
     raw_path = f"/var/unbound/{second['raw_rel']}"
@@ -516,7 +600,7 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     )
     assert teardown == {"ok": True, "keep": "on"}, teardown
 
-    removed = (TOP1M_FIXED, *SIDECARS, MANIFEST, raw_path, *temp_paths)
+    removed = (TOP1M_FIXED, *SIDECARS, MANIFEST, raw_path, *TEMP_PATHS)
     assert all(value is None for value in _file_state(vm, removed).values()), "teardown left derived TOP1M artifacts"
     assert _file_state(vm, (TOP1M_CSV, TOP1M_WHITELIST, NEIGHBOR)) == active_before, (
         "keep-on teardown changed active provider/whitelist data or an unrelated sidecar neighbor"

--- a/tests/smoke/ui/test_dnsbl_top1m_auth_retention.py
+++ b/tests/smoke/ui/test_dnsbl_top1m_auth_retention.py
@@ -1,0 +1,76 @@
+"""Tier-B proof that TOP1M auth changes retain active data."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .test_dnsbl_top1m_retention import (
+    ACTIVE_TOP1M_FILES,
+    DNSBL_PAGE,
+    TOP1M_BASE,
+    TOP1M_FILES,
+    TOP1M_PROVIDER_CFG,
+    _restore_guest_files,
+    _snapshot_guest_files,
+    _write_guest_file,
+)
+from .webui import looks_like_login_page
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+TOP1M_TOKEN_CFG = "installedpackages/pfblockerngdnsblsettings/config/0/top1m_token"
+
+
+def test_dnsbl_top1m_token_save_retains_active_files_and_invalidates_baseline(
+    webui: WebUI, smoke_vm: helpers.SmokeVM
+) -> None:
+    """Replacing Cloudflare auth keeps active bytes and drops stale detector state."""
+    vm = smoke_vm
+    original = _snapshot_guest_files(vm)
+    old_token = "issue1542OldTokenA"
+    new_token = "issue1542NewTokenB"
+
+    try:
+        response = webui.post(
+            DNSBL_PAGE,
+            {"alexa_type": "cloudflare", "top1m_token": old_token},
+            timeout=300.0,
+        )
+        assert not looks_like_login_page(response.text), "TOP1M auth setup POST returned the login form"
+        assert helpers.config_get(vm, TOP1M_PROVIDER_CFG) == "cloudflare"
+        assert helpers.config_get(vm, TOP1M_TOKEN_CFG) == old_token
+
+        seeded = {
+            f"{helpers.PFB_DBDIR}/top-1m.csv": "1,active.example\n",
+            f"{helpers.PFB_DBDIR}/pfbalexawhitelist.txt": "active.example\n",
+            f"{TOP1M_BASE}.orig": "1,active.example\n",
+            f"{TOP1M_BASE}.xxhash128": "0123456789abcdef0123456789abcdef\n",
+            f"{TOP1M_BASE}.md5": "fedcba9876543210fedcba9876543210\n",
+            f"{TOP1M_BASE}.source": '{"provider":"cloudflare"}\n',
+            f"{TOP1M_BASE}.orig.etag": '"top1m-cloudflare"\n',
+            f"{TOP1M_BASE}.orig.lastmod": "1700000000\n",
+        }
+        for path, content in seeded.items():
+            _write_guest_file(vm, path, content)
+
+        response = webui.post(DNSBL_PAGE, {"top1m_token": new_token}, timeout=300.0)
+        assert not looks_like_login_page(response.text), "TOP1M auth-change POST returned the login form"
+        assert helpers.config_get(vm, TOP1M_TOKEN_CFG) == new_token
+        assert new_token not in response.text, "TOP1M token was echoed into the rendered page"
+
+        for path in ACTIVE_TOP1M_FILES:
+            assert helpers.read_log_file(vm, path) == seeded[path], (
+                f"TOP1M bytes changed after auth save at {path}; active data must remain until replacement"
+            )
+        for path in TOP1M_FILES[2:]:
+            assert vm.ssh("test", "-e", path).returncode != 0, (
+                f"TOP1M detector sidecar {path} survived auth identity change"
+            )
+    finally:
+        _restore_guest_files(vm, original)

--- a/tests/smoke/ui/test_dnsbl_top1m_retention.py
+++ b/tests/smoke/ui/test_dnsbl_top1m_retention.py
@@ -1,0 +1,98 @@
+"""Tier-B proof that a TOP1M provider save keeps the active source files."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .webui import looks_like_login_page
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+DNSBL_PAGE = "/pfblockerng/pfblockerng_dnsbl.php"
+TOP1M_PROVIDER_CFG = "installedpackages/pfblockerngdnsblsettings/config/0/alexa_type"
+TOP1M_BASE = f"{helpers.PFB_DBDIR}/top-1m.csv.zip"
+TOP1M_FILES = (
+    f"{helpers.PFB_DBDIR}/top-1m.csv",
+    f"{helpers.PFB_DBDIR}/pfbalexawhitelist.txt",
+    f"{TOP1M_BASE}.orig",
+    f"{TOP1M_BASE}.xxhash128",
+    f"{TOP1M_BASE}.md5",
+    f"{TOP1M_BASE}.source",
+    f"{TOP1M_BASE}.orig.etag",
+    f"{TOP1M_BASE}.orig.lastmod",
+)
+ACTIVE_TOP1M_FILES = TOP1M_FILES[:2]
+
+
+def _write_guest_file(vm: helpers.SmokeVM, path: str, content: str) -> None:
+    helpers.write_local_feed(vm, path.removeprefix(f"{helpers.PFB_DBDIR}/"), content)
+
+
+def _snapshot_guest_files(vm: helpers.SmokeVM) -> dict[str, str | None]:
+    snapshot: dict[str, str | None] = {}
+    for path in TOP1M_FILES:
+        exists = vm.ssh("test", "-f", path).returncode == 0
+        snapshot[path] = helpers.read_log_file(vm, path) if exists else None
+    return snapshot
+
+
+def _restore_guest_files(vm: helpers.SmokeVM, snapshot: dict[str, str | None]) -> None:
+    for path, content in snapshot.items():
+        vm.ssh("rm", "-f", path)
+        if content is not None:
+            _write_guest_file(vm, path, content)
+
+
+def test_dnsbl_top1m_provider_save_retains_active_files_and_invalidates_baseline(
+    webui: WebUI, smoke_vm: helpers.SmokeVM
+) -> None:
+    """Changing Tranco to Cisco keeps the active TOP1M bytes until replacement."""
+    vm = smoke_vm
+    original = _snapshot_guest_files(vm)
+    if helpers.config_get(vm, TOP1M_PROVIDER_CFG) != "tranco":
+        response = webui.post(DNSBL_PAGE, {"alexa_type": "tranco"}, timeout=300.0)
+        assert not looks_like_login_page(response.text), "TOP1M provider reset POST returned the login form"
+    assert helpers.config_get(vm, TOP1M_PROVIDER_CFG) == "tranco", (
+        "TOP1M provider must start at Tranco so the POST proves a provider transition"
+    )
+
+    seeded = {
+        f"{helpers.PFB_DBDIR}/top-1m.csv": "1,active.example\n",
+        f"{helpers.PFB_DBDIR}/pfbalexawhitelist.txt": "active.example\n",
+        f"{TOP1M_BASE}.orig": "1,active.example\n",
+        f"{TOP1M_BASE}.xxhash128": "0123456789abcdef0123456789abcdef\n",
+        f"{TOP1M_BASE}.md5": "fedcba9876543210fedcba9876543210\n",
+        f"{TOP1M_BASE}.source": '{"provider":"tranco"}\n',
+        f"{TOP1M_BASE}.orig.etag": '"top1m-tranco"\n',
+        f"{TOP1M_BASE}.orig.lastmod": "1700000000\n",
+    }
+
+    try:
+        for path, content in seeded.items():
+            _write_guest_file(vm, path, content)
+        for path, content in seeded.items():
+            assert helpers.read_log_file(vm, path) == content, f"failed to seed exact bytes at {path}"
+
+        # WebUI.post re-scrapes and submits the complete current form; only the
+        # provider changes, with no token-authenticated fields involved.
+        response = webui.post(DNSBL_PAGE, {"alexa_type": "cisco"}, timeout=300.0)
+        assert not looks_like_login_page(response.text), "DNSBL provider POST returned the login form"
+        assert helpers.config_get(vm, TOP1M_PROVIDER_CFG) == "cisco", "TOP1M provider was not persisted"
+
+        for path in ACTIVE_TOP1M_FILES:
+            content = seeded[path]
+            assert helpers.read_log_file(vm, path) == content, (
+                f"TOP1M bytes changed after provider save at {path}; active data must remain until replacement"
+            )
+        for path in TOP1M_FILES[2:]:
+            assert vm.ssh("test", "-e", path).returncode != 0, (
+                f"TOP1M detector sidecar {path} survived provider identity change"
+            )
+    finally:
+        _restore_guest_files(vm, original)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1259,8 +1259,11 @@ def test_dnsbl_top1m_source_options_exclude_alexa(webui: WebUI, php_error_log_gu
         "OpenPageRank TOP1M",
         "Majestic Million TOP1M",
         "Cloudflare Radar",
+        'name="alexa_enable"',
+        'name="alexa_count"',
+        'name="alexa_inclusion[]"',
     ):
-        assert needle in body, f"DNSBL page is missing the TOP1M source option {needle!r}"
+        assert needle in body, f"DNSBL page is missing the TOP1M settings marker {needle!r}"
     # Self-coupled to Majestic specifically (#892 review) -- the bare substrings "CC BY"
     # and "3.0" are also individually satisfied by Cloudflare's "(CC BY-NC) 4.0" note, so
     # this would pass even if Majestic's own note vanished.
@@ -1278,9 +1281,9 @@ def test_dnsbl_top1m_type_help_says_update_not_force_reload(
     webui: WebUI, php_error_log_guard: PhpErrorLogGuard
 ) -> None:
     """The TOP1M 'Type' select's help text says an Update suffices after a type change,
-    not the stale 'Force Reload - DNSBL' instruction (#886) — the Save handler already
-    clears the cached CSV/whitelist on a type change, so a plain Update re-fetches and
-    rebuilds them; a Force Reload was never actually required.
+    not the stale 'Force Reload - DNSBL' instruction (#886) — the Save handler preserves
+    the cached source and marks TOP1M for reprocessing, so a plain Update reuses or refreshes
+    it; a Force Reload was never actually required.
 
     Asserts the page passes the clean-render oracle AND that the field's help text
     mentions 'Update' while no longer telling the user to run a Force Reload.

--- a/tests/test_adr06_build_module.py
+++ b/tests/test_adr06_build_module.py
@@ -70,7 +70,6 @@ def _build_config(config: dict[str, Any]) -> dict[str, Any]:
         "tld_wildcard_blacklist": config.get("tld_wildcard_blacklist", []),
         "tld_wildcard_exclusion": config.get("tld_wildcard_exclusion", []),
         "user_whitelist": config.get("user_whitelist", []),
-        "top1m_list": config.get("top1m_list", []),
     }
 
 
@@ -82,6 +81,7 @@ def _run_build(*, top1m_enabled: bool) -> tuple[pfb_unbound.BuildResult, dict[st
         _build_config(config),
         line_reader=_read_lines,
         top1m_enabled=top1m_enabled,
+        top1m_lines=config.get("top1m_list", []),
     )
     return result, config
 

--- a/tests/test_adr06_init_from_raw.py
+++ b/tests/test_adr06_init_from_raw.py
@@ -106,13 +106,18 @@ def _write_onbox_manifest(tmp_path: Any, *, top1m_enabled: bool) -> str:
 
     _stage_tld_oracle(tmp_path)
 
+    if top1m_enabled:
+        top1m_path = os.path.join(str(tmp_path), "pfb_py_top1m.txt")
+        with open(top1m_path, "w", encoding="utf-8", newline="") as fh:
+            for domain in src_config.get("top1m_list", []):
+                fh.write(f"{domain}\n")
+
     manifest = {
         "version": 1,
         "config": {
             "tld_wildcard_blacklist": src_config.get("tld_wildcard_blacklist", []),
             "tld_wildcard_exclusion": src_config.get("tld_wildcard_exclusion", []),
             "user_whitelist": src_config.get("user_whitelist", []),
-            "top1m_list": src_config.get("top1m_list", []),
             "top1m_enabled": top1m_enabled,
         },
         "feeds": feeds,

--- a/tests/test_adr06_php_boundary.py
+++ b/tests/test_adr06_php_boundary.py
@@ -106,13 +106,18 @@ def _write_plain_boundary_manifest(tmp_path: Any, *, top1m_enabled: bool) -> tup
     pfb_unbound.pfb["python_tld_wildcard"] = True
     pfb_unbound.pfb["pfb_py_tld"] = oracle
 
+    if top1m_enabled:
+        top1m_path = os.path.join(str(tmp_path), "pfb_py_top1m.txt")
+        with open(top1m_path, "w", encoding="utf-8", newline="") as fh:
+            for domain in src_config.get("top1m_list", []):
+                fh.write(f"{domain}\n")
+
     manifest = {
         "version": 1,
         "config": {
             "tld_wildcard_blacklist": src_config.get("tld_wildcard_blacklist", []),
             "tld_wildcard_exclusion": src_config.get("tld_wildcard_exclusion", []),
             "user_whitelist": src_config.get("user_whitelist", []),
-            "top1m_list": src_config.get("top1m_list", []),
             "top1m_enabled": top1m_enabled,
         },
         "feeds": feeds,

--- a/tests/test_adr07_emit_wire.py
+++ b/tests/test_adr07_emit_wire.py
@@ -37,7 +37,7 @@ def _build(
     *,
     user_whitelist: Iterable[str] = (),
     user_unlock: Iterable[str] = (),
-    top1m_list: Iterable[str] = (),
+    top1m_lines: Iterable[str] = (),
     top1m_enabled: bool = False,
     user_feeds: Iterable[str] = (),
 ) -> P.BuildResult:
@@ -70,13 +70,18 @@ def _build(
         "tld_wildcard_exclusion": [],
         "user_whitelist": list(user_whitelist),
         "user_unlock": list(user_unlock),
-        "top1m_list": list(top1m_list),
     }
 
     def reader(raw: str) -> Iterable[str]:
         return list(raw_store.get(raw, []))
 
-    return P.build(manifest, config, line_reader=reader, top1m_enabled=top1m_enabled)
+    return P.build(
+        manifest,
+        config,
+        line_reader=reader,
+        top1m_enabled=top1m_enabled,
+        top1m_lines=top1m_lines,
+    )
 
 
 def _cfg_from_result(result: P.BuildResult) -> dict[str, Any]:
@@ -376,7 +381,7 @@ class TestUserSovereignty:
 
     def test_top1m_behaves_as_user_allow(self) -> None:
         feeds = {"f": ["||cdn.example.com^$important"]}
-        res = _build(feeds, top1m_list=["cdn.example.com"], top1m_enabled=True)
+        res = _build(feeds, top1m_lines=["cdn.example.com"], top1m_enabled=True)
         assert _live_label(res, "cdn.example.com") == "resolve"
 
     def test_user_whitelist_not_pruned_by_feed_badfilter(self) -> None:

--- a/tests/test_adr07_php_boundary.py
+++ b/tests/test_adr07_php_boundary.py
@@ -113,7 +113,6 @@ def _build_abp(feeds: dict[str, list[str]], *, user_whitelist: Iterable[str] = (
         "tld_wildcard_blacklist": [],
         "tld_wildcard_exclusion": [],
         "user_whitelist": list(user_whitelist),
-        "top1m_list": [],
     }
 
     def reader(raw: str) -> Iterable[str]:

--- a/tests/test_adr10_concurrency.py
+++ b/tests/test_adr10_concurrency.py
@@ -320,7 +320,6 @@ def _manifest_json(tld_master: str, plain_raw: str, user_raw: str, abp_raw: str,
                 "tld_wildcard_exclusion": [],
                 "user_whitelist": spec.user_whitelist,
                 "user_unlock": spec.user_unlock,
-                "top1m_list": [],
                 "top1m_enabled": False,
             },
             "feeds": [

--- a/tests/test_adr10_snapshot_equivalence.py
+++ b/tests/test_adr10_snapshot_equivalence.py
@@ -83,7 +83,6 @@ def _build(
         "tld_wildcard_exclusion": [],
         "user_whitelist": list(user_whitelist),
         "user_unlock": [],
-        "top1m_list": [],
     }
 
     def reader(raw: str) -> Iterable[str]:

--- a/tests/test_adr21_abp_per_line.py
+++ b/tests/test_adr21_abp_per_line.py
@@ -64,7 +64,6 @@ def _run_build(
         "tld_wildcard_blacklist": [],
         "tld_wildcard_exclusion": [],
         "user_whitelist": [],
-        "top1m_list": [],
     }
 
     def reader(raw: str) -> list[str]:

--- a/tests/test_adr31_permit_build.py
+++ b/tests/test_adr31_permit_build.py
@@ -110,7 +110,6 @@ _BASE_CONFIG: dict[str, Any] = {
     "tld_wildcard_blacklist": [],
     "tld_wildcard_exclusion": [],
     "user_whitelist": [],
-    "top1m_list": [],
 }
 
 

--- a/tests/test_adr31_precedence_oracle.py
+++ b/tests/test_adr31_precedence_oracle.py
@@ -84,7 +84,6 @@ def _run_build(
         "tld_wildcard_blacklist": [],
         "tld_wildcard_exclusion": [],
         "user_whitelist": user_whitelist or [],
-        "top1m_list": [],
     }
 
     def reader(raw: str) -> list[str]:
@@ -369,7 +368,6 @@ class TestOperatorSovereignty:
             "tld_wildcard_blacklist": [],
             "tld_wildcard_exclusion": [],
             "user_whitelist": [],
-            "top1m_list": [],
         }
 
         lines_map = {

--- a/tests/test_adr62_byte_identity_corpus.py
+++ b/tests/test_adr62_byte_identity_corpus.py
@@ -70,7 +70,6 @@ def _run_corpus_build() -> P.BuildResult:
         "tld_wildcard_blacklist": [],
         "tld_wildcard_exclusion": [],
         "user_whitelist": [],
-        "top1m_list": [],
     }
     return P.build(_corpus_manifest(), config, line_reader=_corpus_line_reader())
 

--- a/tests/test_adr62_parity_oracle.py
+++ b/tests/test_adr62_parity_oracle.py
@@ -75,7 +75,6 @@ def _run_corpus_build() -> P.BuildResult:
         "tld_wildcard_blacklist": [],
         "tld_wildcard_exclusion": [],
         "user_whitelist": [],
-        "top1m_list": [],
     }
     return P.build(_corpus_manifest(), config, line_reader=_corpus_line_reader())
 
@@ -168,7 +167,6 @@ def _build_synthetic(feeds: list[dict[str, Any]], lines_by_header: dict[str, lis
         "tld_wildcard_blacklist": [],
         "tld_wildcard_exclusion": [],
         "user_whitelist": [],
-        "top1m_list": [],
     }
     return P.build(manifest, config, line_reader=lambda raw: lines_by_header[raw])
 

--- a/tests/test_adr65_decision_oracle.py
+++ b/tests/test_adr65_decision_oracle.py
@@ -255,9 +255,9 @@ class TestAllowBlockPrecedenceArms:
 
 
 # --------------------------------------------------------------------------- #
-# A7 -- TOP1M whitelist (manifest config top1m_enabled + top1m_list), through
+# A7 -- TOP1M whitelist (manifest config top1m_enabled + fixed sidecar), through
 # the REAL manifest build (reused tests/fixtures/adr06_golden/ -- the adr06
-# exemplar classes, config.json's top1m_list=["popularcdn.com"]).
+# exemplar config's historical top1m_list seeds pfb_py_top1m.txt).
 # --------------------------------------------------------------------------- #
 
 

--- a/tests/test_adr65_fallback_characterization.py
+++ b/tests/test_adr65_fallback_characterization.py
@@ -196,7 +196,6 @@ def _empty_build_config() -> dict[str, Any]:
         "tld_wildcard_blacklist": [],
         "tld_wildcard_exclusion": [],
         "user_whitelist": [],
-        "top1m_list": [],
     }
 
 

--- a/tests/test_bench_top1m_fixed_file.py
+++ b/tests/test_bench_top1m_fixed_file.py
@@ -23,6 +23,23 @@ sys.modules[_SPEC.name] = _BENCH
 _SPEC.loader.exec_module(_BENCH)
 
 
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _wait_pid_gone(pid: int, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _pid_exists(pid):
+            return True
+        time.sleep(0.05)
+    return not _pid_exists(pid)
+
+
 def test_benchmark_default_is_exactly_one_million() -> None:
     assert _BENCH.DEFAULT_LINES == 1_000_000
 
@@ -138,15 +155,10 @@ def test_timed_timeout_kills_descendant_process_group(tmp_path: Path) -> None:
         )
 
     child_pid = int(child_pid_path.read_text())
-    child_state = subprocess.run(
-        ["ps", "-o", "stat=", "-p", str(child_pid)], capture_output=True, text=True, check=False
-    ).stdout.strip()
     try:
-        assert not child_state or child_state.startswith("Z"), (
-            f"timed-out child survived: pid={child_pid} state={child_state}"
-        )
+        assert _wait_pid_gone(child_pid), f"timed-out child survived: pid={child_pid}"
     finally:
-        if child_state and not child_state.startswith("Z"):
+        if _pid_exists(child_pid):
             with contextlib.suppress(ProcessLookupError):
                 os.kill(child_pid, signal.SIGKILL)
 
@@ -186,12 +198,7 @@ def test_timed_parent_signal_kills_worker_process_group(tmp_path: Path) -> None:
 
         os.kill(driver.pid, signal.SIGTERM)
         assert driver.wait(timeout=10) == 77
-        worker_state = subprocess.run(
-            ["ps", "-o", "stat=", "-p", str(worker_pid)], capture_output=True, text=True, check=False
-        ).stdout.strip()
-        assert not worker_state or worker_state.startswith("Z"), (
-            f"worker survived benchmark driver signal: pid={worker_pid} state={worker_state}"
-        )
+        assert _wait_pid_gone(worker_pid), f"worker survived benchmark driver signal: pid={worker_pid}"
     finally:
         with contextlib.suppress(ProcessLookupError):
             os.kill(driver.pid, signal.SIGKILL)

--- a/tests/test_bench_top1m_fixed_file.py
+++ b/tests/test_bench_top1m_fixed_file.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import json
+import os
+import shutil
+import signal
+import subprocess
 import sys
 from pathlib import Path
 
@@ -52,3 +58,72 @@ def test_report_line_carries_fresh_process_trials_wall_and_rss() -> None:
     assert "wall_median=2.000000s" in line
     assert "wall_range=1.000000..3.000000s" in line
     assert "peak_rss_max=20000B" in line
+
+
+def test_each_native_manifest_contract_is_validated_without_cross_feeding(tmp_path: Path) -> None:
+    embedded_dir = tmp_path / "embedded"
+    embedded_dir.mkdir()
+    embedded_manifest = embedded_dir / "pfb_py_sources.json"
+    embedded_manifest.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "config": {"top1m_enabled": True, "top1m_list": [_BENCH.domain_for(i) for i in range(3)]},
+                "feeds": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fixed_dir = tmp_path / "fixed"
+    fixed_dir.mkdir()
+    fixed_manifest = fixed_dir / "pfb_py_sources.json"
+    fixed_manifest.write_text(
+        json.dumps({"version": 1, "config": {"top1m_enabled": True}, "feeds": []}), encoding="utf-8"
+    )
+    _BENCH.generate_top1m(fixed_dir / "pfb_py_top1m.txt", 3)
+
+    assert _BENCH._assert_native_contract(embedded_manifest, "embedded", 3) == (embedded_manifest.stat().st_size, 0)
+    assert _BENCH._assert_native_contract(fixed_manifest, "fixed", 3) == (
+        fixed_manifest.stat().st_size,
+        (fixed_dir / "pfb_py_top1m.txt").stat().st_size,
+    )
+    with pytest.raises(RuntimeError, match="embedded TOP1M contract"):
+        _BENCH._assert_native_contract(fixed_manifest, "embedded", 3)
+    with pytest.raises(RuntimeError, match="fixed-file TOP1M contract"):
+        _BENCH._assert_native_contract(embedded_manifest, "fixed", 3)
+
+
+def test_timed_timeout_kills_descendant_process_group(tmp_path: Path) -> None:
+    child_pid_path = tmp_path / "child.pid"
+    child_code = "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(300)"
+    parent_code = (
+        "import pathlib,subprocess,sys,time; "
+        "child=subprocess.Popen([sys.executable,'-c',sys.argv[2]]); "
+        "pathlib.Path(sys.argv[1]).write_text(str(child.pid)); "
+        "time.sleep(300)"
+    )
+    time_bin = shutil.which("time") or "/usr/bin/time"
+    time_flag = _BENCH._time_flag(time_bin, 10)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        _BENCH._run_timed(
+            [sys.executable, "-c", parent_code, str(child_pid_path), child_code],
+            2,
+            time_bin,
+            time_flag,
+            kill_grace_seconds=0.2,
+        )
+
+    child_pid = int(child_pid_path.read_text())
+    child_state = subprocess.run(
+        ["ps", "-o", "stat=", "-p", str(child_pid)], capture_output=True, text=True, check=False
+    ).stdout.strip()
+    try:
+        assert not child_state or child_state.startswith("Z"), (
+            f"timed-out child survived: pid={child_pid} state={child_state}"
+        )
+    finally:
+        if child_state and not child_state.startswith("Z"):
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(child_pid, signal.SIGKILL)

--- a/tests/test_bench_top1m_fixed_file.py
+++ b/tests/test_bench_top1m_fixed_file.py
@@ -1,0 +1,54 @@
+"""Contract checks for the issue #1542 fixed-file benchmark harness."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "bench_top1m_fixed_file.py"
+_SPEC = importlib.util.spec_from_file_location("bench_top1m_fixed_file", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_BENCH = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _BENCH
+_SPEC.loader.exec_module(_BENCH)
+
+
+def test_benchmark_default_is_exactly_one_million() -> None:
+    assert _BENCH.DEFAULT_LINES == 1_000_000
+
+
+def test_generated_input_is_bounded_at_one_million() -> None:
+    assert _BENCH._line_count("1000000") == 1_000_000
+    with pytest.raises(_BENCH.argparse.ArgumentTypeError, match="must not exceed"):
+        _BENCH._line_count("1000001")
+
+
+def test_streamed_fixture_is_deterministic_unique_and_bounded(tmp_path: Path) -> None:
+    fixture = tmp_path / "pfbalexawhitelist.txt"
+
+    byte_count = _BENCH.generate_top1m(fixture, 10_000)
+    lines = fixture.read_text(encoding="ascii").splitlines()
+
+    assert len(lines) == 10_000
+    assert len(set(lines)) == 10_000
+    assert lines[0] == _BENCH.SAMPLE_FIRST
+    assert lines[-1] == _BENCH.domain_for(9_999)
+    assert byte_count == fixture.stat().st_size
+
+
+def test_report_line_carries_fresh_process_trials_wall_and_rss() -> None:
+    trials = [
+        _BENCH.TrialResult(2.0, 10_000, {}),
+        _BENCH.TrialResult(1.0, 20_000, {}),
+        _BENCH.TrialResult(3.0, 15_000, {}),
+    ]
+
+    line = _BENCH._format_result("phase", trials)
+
+    assert "trials=3" in line
+    assert "wall_median=2.000000s" in line
+    assert "wall_range=1.000000..3.000000s" in line
+    assert "peak_rss_max=20000B" in line

--- a/tests/test_bench_top1m_fixed_file.py
+++ b/tests/test_bench_top1m_fixed_file.py
@@ -60,6 +60,27 @@ def test_report_line_carries_fresh_process_trials_wall_and_rss() -> None:
     assert "peak_rss_max=20000B" in line
 
 
+def test_php_worker_disables_host_memory_ceiling_for_rss_measurement() -> None:
+    command = _BENCH._php_worker_command(
+        "/usr/bin/php",
+        "write",
+        "embedded",
+        Path("/base"),
+        Path("/sandbox"),
+        1_000_000,
+    )
+
+    assert command[:3] == ["/usr/bin/php", "-d", "memory_limit=-1"]
+    assert command[3:] == [
+        str(_BENCH.PHP_WORKER),
+        "write",
+        "embedded",
+        "/base",
+        "/sandbox",
+        "1000000",
+    ]
+
+
 def test_each_native_manifest_contract_is_validated_without_cross_feeding(tmp_path: Path) -> None:
     embedded_dir = tmp_path / "embedded"
     embedded_dir.mkdir()

--- a/tests/test_bench_top1m_fixed_file.py
+++ b/tests/test_bench_top1m_fixed_file.py
@@ -10,6 +10,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -148,3 +149,54 @@ def test_timed_timeout_kills_descendant_process_group(tmp_path: Path) -> None:
         if child_state and not child_state.startswith("Z"):
             with contextlib.suppress(ProcessLookupError):
                 os.kill(child_pid, signal.SIGKILL)
+
+
+def test_timed_parent_signal_kills_worker_process_group(tmp_path: Path) -> None:
+    worker_pid_path = tmp_path / "signal-worker.pid"
+    driver_code = "\n".join(
+        (
+            "import importlib.util, os, pathlib, signal, subprocess, sys",
+            "spec = importlib.util.spec_from_file_location('bench_signal_driver', sys.argv[1])",
+            "bench = importlib.util.module_from_spec(spec)",
+            "sys.modules[spec.name] = bench",
+            "spec.loader.exec_module(bench)",
+            "def interrupted(signum, frame):",
+            "    raise KeyboardInterrupt(f'signal {signum}')",
+            "signal.signal(signal.SIGTERM, interrupted)",
+            "worker = 'import os,pathlib,sys,time; "
+            "pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); time.sleep(300)'",
+            "time_bin = '/usr/bin/time'",
+            "try:",
+            "    bench._run_timed([sys.executable, '-c', worker, sys.argv[2]], "
+            "300, time_bin, bench._time_flag(time_bin, 10))",
+            "except KeyboardInterrupt:",
+            "    raise SystemExit(77)",
+        )
+    )
+    driver = subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", driver_code, str(_SCRIPT), str(worker_pid_path)]
+    )
+    worker_pid: int | None = None
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and not worker_pid_path.exists():
+            time.sleep(0.05)
+        assert worker_pid_path.exists(), "timed worker did not start"
+        worker_pid = int(worker_pid_path.read_text())
+
+        os.kill(driver.pid, signal.SIGTERM)
+        assert driver.wait(timeout=10) == 77
+        worker_state = subprocess.run(
+            ["ps", "-o", "stat=", "-p", str(worker_pid)], capture_output=True, text=True, check=False
+        ).stdout.strip()
+        assert not worker_state or worker_state.startswith("Z"), (
+            f"worker survived benchmark driver signal: pid={worker_pid} state={worker_state}"
+        )
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(driver.pid, signal.SIGKILL)
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            driver.wait(timeout=2)
+        if worker_pid is not None:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(worker_pid, signal.SIGKILL)

--- a/tests/test_dnsbl_manifest_v1_contract.py
+++ b/tests/test_dnsbl_manifest_v1_contract.py
@@ -22,6 +22,7 @@ def _stage_fixture(tmp_path: Path) -> tuple[Path, dict[str, Any]]:
         destination = tmp_path / relative
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(CORPUS / relative, destination)
+    shutil.copyfile(CORPUS / "pfb_py_top1m.txt", tmp_path / "pfb_py_top1m.txt")
     path = tmp_path / "pfb_py_sources.json"
     path.write_text(json.dumps(manifest), encoding="utf-8")
     return path, manifest

--- a/tests/test_issue1083_dnsbl_interchange_semantic_oracle.py
+++ b/tests/test_issue1083_dnsbl_interchange_semantic_oracle.py
@@ -85,7 +85,6 @@ def _run_corpus_build() -> P.BuildResult:
         "tld_wildcard_blacklist": [],
         "tld_wildcard_exclusion": [],
         "user_whitelist": [],
-        "top1m_list": [],
     }
     return P.build(_corpus_manifest(), config, line_reader=_corpus_line_reader())
 

--- a/tests/test_issue1284_dnsbl_feed_line_framing.py
+++ b/tests/test_issue1284_dnsbl_feed_line_framing.py
@@ -134,7 +134,6 @@ def _build_from_raw(
             "tld_wildcard_exclusion": [],
             "user_whitelist": [],
             "user_unlock": [],
-            "top1m_list": [],
             "top1m_enabled": False,
         },
         "feeds": [row],

--- a/tests/test_issue1542_top1m_fixed_file.py
+++ b/tests/test_issue1542_top1m_fixed_file.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import json
 import os
+import threading
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Literal
@@ -82,3 +83,33 @@ def test_enabled_mid_read_failure_discards_candidate(monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr("builtins.open", injected_open)
     assert P.dnsbl_build_from_manifest(str(manifest)) is None
+
+
+def test_enabled_truncation_after_open_discards_candidate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    path = tmp_path / "pfb_py_top1m.txt"
+    path.write_text("".join("domain-{}.example\n".format(index) for index in range(100_000)), encoding="utf-8")
+    opened = threading.Event()
+    truncated = threading.Event()
+    real_open = builtins.open
+
+    def truncate_when_opened() -> None:
+        assert opened.wait(5), "TOP1M open was not reached"
+        os.truncate(path, 0)
+        truncated.set()
+
+    def injected_open(name: str | os.PathLike[str], *args: Any, **kwargs: Any) -> Any:
+        handle = real_open(name, *args, **kwargs)
+        if os.fspath(name) == os.fspath(path):
+            opened.set()
+            assert truncated.wait(5), "TOP1M truncation did not complete"
+        return handle
+
+    worker = threading.Thread(target=truncate_when_opened)
+    worker.start()
+    monkeypatch.setattr("builtins.open", injected_open)
+    try:
+        assert P.dnsbl_build_from_manifest(str(manifest)) is None
+    finally:
+        worker.join(5)
+    assert not worker.is_alive(), "TOP1M truncation worker did not finish"

--- a/tests/test_issue1542_top1m_fixed_file.py
+++ b/tests/test_issue1542_top1m_fixed_file.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import builtins
+import json
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+import pfb_unbound as P
+
+
+def _manifest(tmp_path: Path, *, enabled: bool = True) -> Path:
+    raw = tmp_path / "feed.raw"
+    raw.write_text("blocked.example\n", encoding="utf-8")
+    path = tmp_path / "pfb_py_sources.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "config": {"top1m_enabled": enabled, "user_whitelist": []},
+                "feeds": [{"raw": raw.name, "feed": "feed", "group": "g", "log_flag": "1"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_disabled_does_not_require_fixed_file(tmp_path: Path) -> None:
+    result = P.dnsbl_build_from_manifest(str(_manifest(tmp_path, enabled=False)))
+    assert result is not None
+    assert result.white_db == {}
+
+
+def test_enabled_streams_fixed_file_with_crlf_blanks_and_first_writer_duplicates(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    (tmp_path / "pfb_py_top1m.txt").write_bytes(b"first.example\r\n\r\n second.example \r\nfirst.example\r\n")
+    result = P.dnsbl_build_from_manifest(str(manifest))
+    assert result is not None
+    assert set(result.white_db) == {"first.example", "second.example"}
+    assert result.white_db["first.example"]["important"] is True
+
+
+@pytest.mark.parametrize("kind", ["missing", "directory", "unreadable"])
+def test_enabled_missing_directory_or_unreadable_fixed_file_fails_closed(tmp_path: Path, kind: str) -> None:
+    manifest = _manifest(tmp_path)
+    path = tmp_path / "pfb_py_top1m.txt"
+    if kind == "directory":
+        path.mkdir()
+    elif kind == "unreadable":
+        path.write_text("blocked.example\n", encoding="utf-8")
+        path.chmod(0)
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None
+    if kind == "unreadable":
+        path.chmod(0o600)
+
+
+def test_enabled_mid_read_failure_discards_candidate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    path = tmp_path / "pfb_py_top1m.txt"
+    path.write_text("first.example\nsecond.example\n", encoding="utf-8")
+    real_open = builtins.open
+
+    class FailingReader:
+        def __enter__(self) -> FailingReader:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> Literal[False]:
+            return False
+
+        def __iter__(self) -> Iterator[str]:
+            yield "first.example\n"
+            raise OSError("injected mid-read")
+
+    def injected_open(name: str | os.PathLike[str], *args: Any, **kwargs: Any) -> Any:
+        if os.fspath(name) == os.fspath(path):
+            return FailingReader()
+        return real_open(name, *args, **kwargs)
+
+    monkeypatch.setattr(P, "open", injected_open)
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None

--- a/tests/test_issue1542_top1m_fixed_file.py
+++ b/tests/test_issue1542_top1m_fixed_file.py
@@ -80,5 +80,5 @@ def test_enabled_mid_read_failure_discards_candidate(monkeypatch: pytest.MonkeyP
             return FailingReader()
         return real_open(name, *args, **kwargs)
 
-    monkeypatch.setattr(P, "open", injected_open)
+    monkeypatch.setattr("builtins.open", injected_open)
     assert P.dnsbl_build_from_manifest(str(manifest)) is None

--- a/tests/test_issue1542_top1m_fixed_file_contract.py
+++ b/tests/test_issue1542_top1m_fixed_file_contract.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pfb_unbound as P
+from tests.test_issue1542_top1m_fixed_file import _manifest
+
+
+def test_enabled_fifo_fixed_file_fails_closed(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    os.mkfifo(tmp_path / "pfb_py_top1m.txt")
+
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None
+
+
+@pytest.mark.parametrize("nofollow", [None, 0])
+def test_enabled_without_nofollow_support_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, nofollow: int | None
+) -> None:
+    manifest = _manifest(tmp_path)
+    (tmp_path / "pfb_py_top1m.txt").write_text("stable.example\n", encoding="utf-8")
+    monkeypatch.setattr(P.os, "O_NOFOLLOW", nofollow)
+
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None
+
+
+def test_enabled_multibyte_final_line_without_newline_consumes_exact_bytes(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    (tmp_path / "pfb_py_top1m.txt").write_bytes("éxample.test\nlast.example".encode())
+
+    result = P.dnsbl_build_from_manifest(str(manifest))
+    assert result is not None
+    assert set(result.white_db) == {"éxample.test", "last.example"}
+
+
+def test_enabled_reads_fixed_file_through_streaming_iterator(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    path = tmp_path / "pfb_py_top1m.txt"
+    path.write_text("".join("domain-{}.example\n".format(index) for index in range(10_000)), encoding="utf-8")
+    real_open = open
+    iterated = False
+
+    class IteratorOnlyReader:
+        def __init__(self, handle: Any) -> None:
+            self._handle = handle
+
+        def __enter__(self) -> IteratorOnlyReader:
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
+            return bool(self._handle.__exit__(exc_type, exc, traceback))
+
+        def fileno(self) -> int:
+            return self._handle.fileno()
+
+        def __iter__(self) -> Any:
+            nonlocal iterated
+            iterated = True
+            yield from self._handle
+
+        def read(self, *args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("TOP1M reader must not read the whole file")
+
+        def readlines(self, *args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("TOP1M reader must not materialize all lines")
+
+    def injected_open(name: str | os.PathLike[str], *args: Any, **kwargs: Any) -> Any:
+        handle = real_open(name, *args, **kwargs)
+        return IteratorOnlyReader(handle) if os.fspath(name) == os.fspath(path) else handle
+
+    monkeypatch.setattr("builtins.open", injected_open)
+    result = P.dnsbl_build_from_manifest(str(manifest))
+    assert iterated
+    assert result is not None
+    assert len(result.white_db) == 10_000

--- a/tests/test_issue1542_top1m_fixed_file_contract.py
+++ b/tests/test_issue1542_top1m_fixed_file_contract.py
@@ -37,12 +37,14 @@ def test_enabled_multibyte_final_line_without_newline_consumes_exact_bytes(tmp_p
     assert set(result.white_db) == {"éxample.test", "last.example"}
 
 
-def test_enabled_reads_fixed_file_through_streaming_iterator(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_enabled_uses_bounded_prepass_and_streaming_iterator(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     manifest = _manifest(tmp_path)
     path = tmp_path / "pfb_py_top1m.txt"
     path.write_text("".join("domain-{}.example\n".format(index) for index in range(10_000)), encoding="utf-8")
     real_open = open
+    real_read = P.os.read
     iterated = False
+    read_sizes: list[int] = []
 
     class IteratorOnlyReader:
         def __init__(self, handle: Any) -> None:
@@ -73,8 +75,34 @@ def test_enabled_reads_fixed_file_through_streaming_iterator(monkeypatch: pytest
         handle = real_open(name, *args, **kwargs)
         return IteratorOnlyReader(handle) if os.fspath(name) == os.fspath(path) else handle
 
+    def bounded_read(fd: int, size: int) -> bytes:
+        read_sizes.append(size)
+        return real_read(fd, size)
+
     monkeypatch.setattr("builtins.open", injected_open)
+    monkeypatch.setattr(P.os, "read", bounded_read)
     result = P.dnsbl_build_from_manifest(str(manifest))
     assert iterated
+    assert len(read_sizes) > 1
+    assert max(read_sizes) == 64 * 1024
     assert result is not None
     assert len(result.white_db) == 10_000
+
+
+def test_enabled_prehash_read_error_fails_closed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    path = tmp_path / "pfb_py_top1m.txt"
+    path.write_bytes(b"domain.example\n" * 10_000)
+    real_read = P.os.read
+    reads = 0
+
+    def failing_read(fd: int, size: int) -> bytes:
+        nonlocal reads
+        reads += 1
+        if reads == 2:
+            raise OSError("injected prehash read failure")
+        return real_read(fd, size)
+
+    monkeypatch.setattr(P.os, "read", failing_read)
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None
+    assert reads == 2

--- a/tests/test_issue1542_top1m_fixed_file_races.py
+++ b/tests/test_issue1542_top1m_fixed_file_races.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pfb_unbound as P
+from tests.test_issue1542_top1m_fixed_file import _manifest
+
+
+def test_enabled_symlink_fixed_file_fails_closed(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    target = tmp_path / "target.txt"
+    target.write_text("target.example\n", encoding="utf-8")
+    (tmp_path / "pfb_py_top1m.txt").symlink_to(target)
+
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None
+
+
+def test_enabled_replacement_between_lstat_and_open_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest = _manifest(tmp_path)
+    path = tmp_path / "pfb_py_top1m.txt"
+    replacement = tmp_path / "replacement.txt"
+    path.write_text("old.example\n", encoding="utf-8")
+    replacement.write_text("new.example\n", encoding="utf-8")
+    real_open = P.os.open
+    replaced = False
+
+    def replacing_open(name: str | os.PathLike[str], flags: int, *args: Any, **kwargs: Any) -> int:
+        nonlocal replaced
+        if os.fspath(name) == os.fspath(path) and not replaced:
+            os.replace(replacement, path)
+            replaced = True
+        return real_open(name, flags, *args, **kwargs)
+
+    monkeypatch.setattr(P.os, "open", replacing_open)
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None
+    assert replaced
+
+
+def test_enabled_invalid_utf8_fixed_file_fails_closed(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    (tmp_path / "pfb_py_top1m.txt").write_bytes(b"valid.example\n\xff\n")
+
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None
+
+
+def test_enabled_in_place_truncation_during_iteration_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest = _manifest(tmp_path)
+    path = tmp_path / "pfb_py_top1m.txt"
+    path.write_text("".join("domain-{}.example\n".format(index) for index in range(10_000)), encoding="utf-8")
+    real_open = open
+
+    class TruncatingReader:
+        def __init__(self, handle: Any) -> None:
+            self._handle = handle
+            self._truncated = False
+
+        def __enter__(self) -> TruncatingReader:
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
+            return bool(self._handle.__exit__(exc_type, exc, traceback))
+
+        def fileno(self) -> int:
+            return self._handle.fileno()
+
+        def __iter__(self) -> Any:
+            for line in self._handle:
+                if not self._truncated:
+                    os.truncate(path, 0)
+                    self._truncated = True
+                yield line
+
+    def injected_open(name: str | os.PathLike[str], *args: Any, **kwargs: Any) -> Any:
+        handle = real_open(name, *args, **kwargs)
+        return TruncatingReader(handle) if os.fspath(name) == os.fspath(path) else handle
+
+    monkeypatch.setattr("builtins.open", injected_open)
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None
+
+
+def test_enabled_atomic_rename_after_open_allows_old_complete_inode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest = _manifest(tmp_path)
+    path = tmp_path / "pfb_py_top1m.txt"
+    replacement = tmp_path / "replacement.txt"
+    path.write_text("old.example\n", encoding="utf-8")
+    replacement.write_text("new.example\n", encoding="utf-8")
+    old_inode = path.stat().st_ino
+    real_fstat = P.os.fstat
+    renamed = False
+
+    def renaming_fstat(fd: int) -> os.stat_result:
+        nonlocal renamed
+        result = real_fstat(fd)
+        if not renamed and result.st_ino == old_inode:
+            os.replace(replacement, path)
+            renamed = True
+        return result
+
+    monkeypatch.setattr(P.os, "fstat", renaming_fstat)
+    result = P.dnsbl_build_from_manifest(str(manifest))
+    assert renamed
+    assert result is not None
+    assert set(result.white_db) == {"old.example"}

--- a/tests/test_issue1542_top1m_fixed_file_races.py
+++ b/tests/test_issue1542_top1m_fixed_file_races.py
@@ -49,6 +49,38 @@ def test_enabled_invalid_utf8_fixed_file_fails_closed(tmp_path: Path) -> None:
     assert P.dnsbl_build_from_manifest(str(manifest)) is None
 
 
+def test_enabled_read_oserror_fixed_file_fails_closed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    path = tmp_path / "pfb_py_top1m.txt"
+    path.write_text("first.example\nsecond.example\n", encoding="utf-8")
+    real_open = open
+
+    class FailingReader:
+        def __init__(self, handle: Any) -> None:
+            self._handle = handle
+
+        def __enter__(self) -> FailingReader:
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
+            return bool(self._handle.__exit__(exc_type, exc, traceback))
+
+        def fileno(self) -> int:
+            return self._handle.fileno()
+
+        def __iter__(self) -> Any:
+            yield "first.example\n"
+            raise OSError("injected mid-read")
+
+    def injected_open(name: str | os.PathLike[str], *args: Any, **kwargs: Any) -> Any:
+        handle = real_open(name, *args, **kwargs)
+        return FailingReader(handle) if os.fspath(name) == os.fspath(path) else handle
+
+    monkeypatch.setattr("builtins.open", injected_open)
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None
+
+
 def test_enabled_in_place_truncation_during_iteration_fails_closed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_issue1542_top1m_fixed_file_races.py
+++ b/tests/test_issue1542_top1m_fixed_file_races.py
@@ -54,6 +54,7 @@ def test_enabled_read_oserror_fixed_file_fails_closed(monkeypatch: pytest.Monkey
     path = tmp_path / "pfb_py_top1m.txt"
     path.write_text("first.example\nsecond.example\n", encoding="utf-8")
     real_open = open
+    failed = False
 
     class FailingReader:
         def __init__(self, handle: Any) -> None:
@@ -70,7 +71,9 @@ def test_enabled_read_oserror_fixed_file_fails_closed(monkeypatch: pytest.Monkey
             return self._handle.fileno()
 
         def __iter__(self) -> Any:
+            nonlocal failed
             yield "first.example\n"
+            failed = True
             raise OSError("injected mid-read")
 
     def injected_open(name: str | os.PathLike[str], *args: Any, **kwargs: Any) -> Any:
@@ -79,6 +82,7 @@ def test_enabled_read_oserror_fixed_file_fails_closed(monkeypatch: pytest.Monkey
 
     monkeypatch.setattr("builtins.open", injected_open)
     assert P.dnsbl_build_from_manifest(str(manifest)) is None
+    assert failed
 
 
 def test_enabled_in_place_truncation_during_iteration_fails_closed(
@@ -88,11 +92,11 @@ def test_enabled_in_place_truncation_during_iteration_fails_closed(
     path = tmp_path / "pfb_py_top1m.txt"
     path.write_text("".join("domain-{}.example\n".format(index) for index in range(10_000)), encoding="utf-8")
     real_open = open
+    truncated = False
 
     class TruncatingReader:
         def __init__(self, handle: Any) -> None:
             self._handle = handle
-            self._truncated = False
 
         def __enter__(self) -> TruncatingReader:
             self._handle.__enter__()
@@ -105,10 +109,11 @@ def test_enabled_in_place_truncation_during_iteration_fails_closed(
             return self._handle.fileno()
 
         def __iter__(self) -> Any:
+            nonlocal truncated
             for line in self._handle:
-                if not self._truncated:
+                if not truncated:
                     os.truncate(path, 0)
-                    self._truncated = True
+                    truncated = True
                 yield line
 
     def injected_open(name: str | os.PathLike[str], *args: Any, **kwargs: Any) -> Any:
@@ -117,6 +122,7 @@ def test_enabled_in_place_truncation_during_iteration_fails_closed(
 
     monkeypatch.setattr("builtins.open", injected_open)
     assert P.dnsbl_build_from_manifest(str(manifest)) is None
+    assert truncated
 
 
 def test_enabled_atomic_rename_after_open_allows_old_complete_inode(
@@ -144,3 +150,88 @@ def test_enabled_atomic_rename_after_open_allows_old_complete_inode(
     assert renamed
     assert result is not None
     assert set(result.white_db) == {"old.example"}
+
+
+def test_enabled_same_size_rewrite_with_restored_mtime_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest = _manifest(tmp_path)
+    path = tmp_path / "pfb_py_top1m.txt"
+    path.write_bytes(b"old.example\n")
+    original = path.stat()
+    real_open = open
+    rewritten = False
+
+    class RewritingReader:
+        def __init__(self, handle: Any) -> None:
+            self._handle = handle
+
+        def __enter__(self) -> RewritingReader:
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
+            return bool(self._handle.__exit__(exc_type, exc, traceback))
+
+        def fileno(self) -> int:
+            return self._handle.fileno()
+
+        def __iter__(self) -> Any:
+            nonlocal rewritten
+            for line in self._handle:
+                if not rewritten:
+                    fd = os.open(path, os.O_WRONLY | os.O_TRUNC)
+                    try:
+                        os.write(fd, b"new.example\n")
+                    finally:
+                        os.close(fd)
+                    os.utime(path, ns=(original.st_atime_ns, original.st_mtime_ns))
+                    rewritten = True
+                yield line
+
+    def injected_open(name: str | os.PathLike[str], *args: Any, **kwargs: Any) -> Any:
+        handle = real_open(name, *args, **kwargs)
+        return RewritingReader(handle) if os.fspath(name) == os.fspath(path) else handle
+
+    monkeypatch.setattr("builtins.open", injected_open)
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None
+    assert rewritten
+    assert path.stat().st_mtime_ns == original.st_mtime_ns
+
+
+def test_enabled_unlink_during_iteration_fails_closed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    path = tmp_path / "pfb_py_top1m.txt"
+    path.write_text("old.example\n", encoding="utf-8")
+    real_open = open
+    unlinked = False
+
+    class UnlinkingReader:
+        def __init__(self, handle: Any) -> None:
+            self._handle = handle
+
+        def __enter__(self) -> UnlinkingReader:
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
+            return bool(self._handle.__exit__(exc_type, exc, traceback))
+
+        def fileno(self) -> int:
+            return self._handle.fileno()
+
+        def __iter__(self) -> Any:
+            nonlocal unlinked
+            for line in self._handle:
+                if not unlinked:
+                    path.unlink()
+                    unlinked = True
+                yield line
+
+    def injected_open(name: str | os.PathLike[str], *args: Any, **kwargs: Any) -> Any:
+        handle = real_open(name, *args, **kwargs)
+        return UnlinkingReader(handle) if os.fspath(name) == os.fspath(path) else handle
+
+    monkeypatch.setattr("builtins.open", injected_open)
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None
+    assert unlinked

--- a/tests/test_issue1542_top1m_mixed_content.py
+++ b/tests/test_issue1542_top1m_mixed_content.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pfb_unbound as P
+from tests.test_issue1542_top1m_fixed_file import _manifest
+
+
+def test_enabled_mutation_of_unread_bytes_before_atomic_replace_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest = _manifest(tmp_path)
+    path = tmp_path / "pfb_py_top1m.txt"
+    replacement = tmp_path / "replacement.txt"
+    final_line = b"old.example\n"
+    body = b"first.example\n" + (b"padding.example\n" * 100_000) + final_line
+    path.write_bytes(body)
+    replacement.write_text("replacement.example\n", encoding="utf-8")
+    original = path.stat()
+    final_offset = len(body) - len(final_line)
+    real_open = open
+    mutated = False
+
+    class MutatingReader:
+        def __init__(self, handle: Any) -> None:
+            self._handle = handle
+
+        def __enter__(self) -> MutatingReader:
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
+            return bool(self._handle.__exit__(exc_type, exc, traceback))
+
+        def fileno(self) -> int:
+            return self._handle.fileno()
+
+        def read(self, *args: Any, **kwargs: Any) -> Any:
+            return self._handle.read(*args, **kwargs)
+
+        def seek(self, *args: Any, **kwargs: Any) -> Any:
+            return self._handle.seek(*args, **kwargs)
+
+        def __iter__(self) -> Any:
+            nonlocal mutated
+            for index, line in enumerate(self._handle):
+                yield line
+                if index == 0:
+                    fd = os.open(path, os.O_WRONLY)
+                    try:
+                        assert os.pwrite(fd, b"new.example\n", final_offset) == len(final_line)
+                        os.fsync(fd)
+                    finally:
+                        os.close(fd)
+                    os.utime(path, ns=(original.st_atime_ns, original.st_mtime_ns))
+                    os.replace(replacement, path)
+                    mutated = True
+
+    def injected_open(name: str | os.PathLike[str], *args: Any, **kwargs: Any) -> Any:
+        handle = real_open(name, *args, **kwargs)
+        return MutatingReader(handle) if os.fspath(name) == os.fspath(path) else handle
+
+    monkeypatch.setattr("builtins.open", injected_open)
+    assert P.dnsbl_build_from_manifest(str(manifest)) is None
+    assert mutated
+    assert path.read_text(encoding="utf-8") == "replacement.example\n"

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -4154,7 +4154,6 @@ class TestAbpWildcardUnaffectedByTldWildcardToggle:
             "tld_wildcard_blacklist": [],
             "tld_wildcard_exclusion": [],
             "user_whitelist": [],
-            "top1m_list": [],
         }
         return pfb_unbound.build(manifest, config, line_reader=lambda raw: ["||evil.com^"])
 
@@ -4260,7 +4259,6 @@ class TestTldWildcardClassifyTwoLabelPublicSuffixViaBuild:
             "tld_wildcard_blacklist": [],
             "tld_wildcard_exclusion": [],
             "user_whitelist": [],
-            "top1m_list": [],
         }
         return pfb_unbound.build(manifest, config, line_reader=lambda raw: raw_lines)
 


### PR DESCRIPTION
## Summary

- Keep DNSBL manifest v1 while moving enabled TOP1M input to the fixed chroot file.
- Reuse ADR-42 conditional-download state, the existing DCC schedule, sync-status ledger, and DNSBL update dispatch.
- Publish TOP1M atomically, include it in loaded fingerprints/cache/teardown, and fail closed on invalid input or publication errors.
- Retain active TOP1M data across provider/auth changes; defer conversion and reload until the replacement identity has a complete current baseline.

## Verification

- Final rebased head: `ba3f2e3e99b55770e862cedcbf795eed49f78522` on `devel` `50c4d81bfae06e6142b05bb3d436dda92113cfba`.
- Test-first RED/GREEN proofs are preserved in branch history. Final combined identity-plus-filter regression test stayed byte-identical at `ae5002ca29afc77c4c1f220066727076b02765b3` from RED to GREEN.
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS.
- GitHub CI: [all required checks passed](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29740624567), including PHPUnit on PHP 8.3 and 8.5.
- Python: 3,375 passed, 4 skipped.
- PHPUnit: 3,909 tests, 23,436 assertions, 4 skipped.
- ShellSpec: 984 examples, 0 failures, 8 skips.
- Exact 1,000,000-domain benchmark: [artifact](https://github.com/pfBlockerNG/pfBlockerNG/blob/ba3f2e3e99b55770e862cedcbf795eed49f78522/benchmarks/results/issue_1542_top1m_fixed_file.txt). Manifest storage fell from 47,000,257 bytes embedded to 223 bytes plus a 32,000,000-byte fixed file; writer RSS fell from 212.69 MiB to 33.98 MiB.
- Exact-head live pfSense smoke: [PASS](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29740656271).
- Exact-head pfSense CE 2.8 Tier-A UI render: [PASS](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29740654080).
- Independent corrective-step review and final top-tier whole-PR review: PASS, no findings.

## Packaging

Both exact-head appliance runs built with `pfBlockerNG/FreeBSD-ports:issue/1409-package-manifest-includes`. [FreeBSD-ports PR #3](https://github.com/pfBlockerNG/FreeBSD-ports/pull/3) adds the new devel/nightly package includes and intentionally remains draft until the source tag exists; stable packaging is unchanged.

## Follow-up

The pre-existing comma-framed producer versus domain-only Python reader mismatch is tracked separately in [#1569](https://github.com/pfBlockerNG/pfBlockerNG/issues/1569). This PR does not hide or broaden that legacy defect.

Fixes #1542

---

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.