### PR TITLE
pfblockerng: extract Alerts IP actions

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -4125,6 +4125,141 @@ function pfb_live_punch_run(string $pfctl, string $aliasdir, string $dbdir, stri
 }
 
 /**
+ * Apply an Alerts IP mutation after the page has filtered its inputs.
+ *
+ * @return array{redirect: bool, savemsg: string}
+ */
+function pfb_alerts_ip_action($action, string $ip, string $table, string $descr, array $clists, array $ip_unlock): array
+{
+	global $pfb;
+
+	$result = ['redirect' => TRUE, 'savemsg' => ''];
+
+	if ($action === 'addsuppress') {
+		$is_v6  = strpos($ip, ':') !== FALSE;
+		$family = $is_v6 ? 6 : 4;
+		$apply  = pfb_live_punch_run($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table, $ip);
+
+		switch ($apply['status']) {
+			case 'applied':
+				$savemsg2 = ' : Removed ' . $apply['del_cnt'] . ' entr' . ($apply['del_cnt'] == 1 ? 'y' : 'ies')
+					. ', added ' . $apply['add_cnt'] . ' covering CIDR' . ($apply['add_cnt'] == 1 ? '' : 's');
+				break;
+			case 'not_blocked':
+				$savemsg2 = " : Not currently blocked by Table [ {$table} ]";
+				break;
+			case 'busy':
+				$savemsg2 = ' : An update/reload pass is currently in progress, suppression will apply at the next reload';
+				break;
+			default:
+				$savemsg2 = " : Live punch failed [ {$apply['fail']} ], suppression will still apply at the next reload";
+				break;
+		}
+
+		$supp_key       = $is_v6 ? 'ipsuppression_v6' : 'ipsuppression';
+		$cfg_key        = $is_v6 ? 'v6suppression' : 'v4suppression';
+		$host_line      = $is_v6 ? "{$ip}/128" : "{$ip}/32";
+		$supp_data      = isset($clists[$supp_key]['data']) && is_array($clists[$supp_key]['data'])
+			? $clists[$supp_key]['data'] : [];
+		$refresh_suppfile = FALSE;
+		if (isset($supp_data[$host_line])) {
+			$result['savemsg'] = gettext("Host IP address {$ip} already exists in the IPv{$family} Suppression customlist.");
+		} elseif (pfb_ip_suppressed($ip, array_keys($supp_data))) {
+			$result['savemsg'] = gettext("Host IP address {$ip} is already covered by an existing IPv{$family} Suppression entry.");
+			$refresh_suppfile = TRUE;
+		} else {
+			$supp_dat = $host_line;
+			if (!empty($descr)) {
+				$supp_dat .= " # {$descr}";
+			}
+			$result['savemsg'] = gettext("Host IP address {$ip}") . gettext($savemsg2) . gettext(" and added to the IPv{$family} Suppression customlist.");
+			$data = '';
+			foreach ($supp_data as $line) {
+				$data .= "{$line}";
+			}
+			$data .= "{$supp_dat}\r\n";
+			$clists[$supp_key]['base64'] = base64_encode($data);
+			PfbConfig::write($cfg_key, $clists[$supp_key]['base64']);
+			write_config("pfBlockerNG: Added {$ip} to the IPv{$family} Suppression customlist", FALSE);
+			$refresh_suppfile = TRUE;
+		}
+
+		if ($refresh_suppfile) {
+			$pfb['ipconfig'][$cfg_key] = $clists[$supp_key]['base64'] ?? '';
+			pfb_create_suppression_file();
+		}
+		return $result;
+	}
+
+	if ($action === 'unlock') {
+		$apply = pfb_live_punch_run($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table, $ip);
+		switch ($apply['status']) {
+			case 'applied':
+				pfb_unlock('unlock', 'ip', $ip, $table, $ip_unlock);
+				$result['savemsg'] = "The IP [ {$ip} ] has been temporarily Unlocked from table [ {$table} ]!";
+				break;
+			case 'not_blocked':
+				$result['savemsg'] = "The IP [ {$ip} ] is not currently blocked by table [ {$table} ] -- no unlock was recorded.";
+				break;
+			case 'busy':
+				$result['savemsg'] = "Table [ {$table} ] is mid-update -- please retry the Unlock once the current run finishes.";
+				break;
+			default:
+				$result['savemsg'] = "The live unlock of IP [ {$ip} ] failed [ {$apply['fail']} ] -- table [ {$table} ] still blocks it; see the pfBlockerNG log.";
+				break;
+		}
+		return $result;
+	}
+
+	if ($action === 'lock') {
+		$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table, 'add', $ip);
+		if ($apply['ok']) {
+			pfb_unlock('lock', 'ip', $ip, $table, $ip_unlock);
+			$result['savemsg'] = "The IP [ {$ip} ] has been re-locked into table [ {$table} ]!";
+		} else {
+			$result['savemsg'] = "The live re-lock of IP [ {$ip} ] failed [ {$apply['fail']} ] -- table [ {$table} ] does not block it; see the pfBlockerNG log.";
+		}
+		return $result;
+	}
+
+	if ($action === 'ip_white') {
+		$vtype = strpos($table, '_v4') !== FALSE ? '4' : '6';
+		$list_key = 'ipwhitelist' . $vtype;
+		$data = isset($clists[$list_key][$table]['data']) && is_array($clists[$list_key][$table]['data'])
+			? $clists[$list_key][$table]['data'] : [];
+		if (isset($data[$ip])) {
+			$result['redirect'] = FALSE;
+			return $result;
+		}
+
+		$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table, 'add', $ip);
+		if (!$apply['ok']) {
+			$result['savemsg'] = "The add of [ {$ip} ] to aliastable [ {$table} ] failed [ {$apply['fail']} ] -- see the pfBlockerNG log.";
+			return $result;
+		}
+
+		@file_put_contents("{$pfb['aliasdir']}/{$table}.txt", "\n{$ip}", LOCK_EX);
+		$whitelist_string = !empty($descr) ? "{$ip} # {$descr}\r\n" : "{$ip}\r\n";
+		$custom = '';
+		foreach ($data as $line) {
+			$custom .= "{$line}";
+		}
+		$custom .= $whitelist_string;
+		$clists[$list_key][$table]['base64'] = base64_encode($custom);
+		$base64_idx = $clists[$list_key][$table]['base64_idx'] ?? 0;
+		config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$base64_idx}/custom", $clists[$list_key][$table]['base64']);
+		write_config("pfBlockerNG: Added [ {$ip} ] to [ {$table} ] Whitelist", FALSE);
+		$aname = substr(substr($table, 4), 0, -3);
+		touch("{$pfb['permitdir']}/{$aname}_custom_v{$vtype}.update");
+		$result['savemsg'] = "The IP [ {$ip} ] has been added to the [ {$table} ] Permit Alias customlist.";
+		return $result;
+	}
+
+	$result['savemsg'] = gettext('Cannot Lock/Unlock - Invalid action.');
+	return $result;
+}
+
+/**
  * ADR-65 SS2.1: ask the live DNSBL matcher whether $domain is blocked, via the
  * read-only query channel (pfb_py_query / pfb_py_query.reply) -- no counter/
  * log/cache sink is touched, only the decision-cache LRU may warm.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -4225,8 +4225,12 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 	if ($action === 'ip_white') {
 		$vtype = strpos($table, '_v4') !== FALSE ? '4' : '6';
 		$list_key = 'ipwhitelist' . $vtype;
-		$data = isset($clists[$list_key][$table]['data']) && is_array($clists[$list_key][$table]['data'])
-			? $clists[$list_key][$table]['data'] : [];
+		$metadata = $clists[$list_key][$table] ?? NULL;
+		if (!is_array($metadata) || !isset($metadata['base64_idx'])) {
+			$result['savemsg'] = "Cannot Whitelist - Permit alias [ {$table} ] metadata missing.";
+			return $result;
+		}
+		$data = isset($metadata['data']) && is_array($metadata['data']) ? $metadata['data'] : [];
 		if (isset($data[$ip])) {
 			$result['redirect'] = FALSE;
 			return $result;
@@ -4246,7 +4250,8 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 		}
 		$custom .= $whitelist_string;
 		$clists[$list_key][$table]['base64'] = base64_encode($custom);
-		$base64_idx = $clists[$list_key][$table]['base64_idx'] ?? 0;
+		$base64_idx = $metadata['base64_idx'];
+		// foreign structure: pfblockernglistsv4/v6/config/{row}/custom is a dynamic per-row key, not a registered config field
 		config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$base64_idx}/custom", $clists[$list_key][$table]['base64']);
 		write_config("pfBlockerNG: Added [ {$ip} ] to [ {$table} ] Whitelist", FALSE);
 		$aname = substr(substr($table, 4), 0, -3);

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1451,7 +1451,12 @@ if (isset($_POST) && !empty($_POST)) {
 			exit;
 		}
 
-		$result = pfb_alerts_ip_action($_POST['ip_remove'], $ip, $table, '', $clists, $ip_unlock);
+		$ip_remove_action = NULL;
+		if (is_string($_POST['ip_remove']) &&
+		    ($_POST['ip_remove'] === 'unlock' || $_POST['ip_remove'] === 'lock')) {
+			$ip_remove_action = $_POST['ip_remove'];
+		}
+		$result = pfb_alerts_ip_action($ip_remove_action, $ip, $table, '', $clists, $ip_unlock);
 		if ($result['redirect']) {
 			header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$result['savemsg']}");
 			exit;

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2937,8 +2937,8 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	// the retired $mask_unlock were v4-only /24|/32 restrictions), and the
 	// SAME exact-host token the Suppression "+" posts ($host), never the
 	// possibly-CIDR $eval_ip a feed match can report; $ip_unlock is keyed by
-	// that same exact host (pfb_unlock() is called with $ip = the posted
-	// host in the ip_remove handler above). The stored table must match THIS
+	// that same exact host (the package seam calls pfb_unlock() with $ip = the
+	// posted host). The stored table must match THIS
 	// row's table -- a host unlocked in another alias still shows the Unlock
 	// icon here.
 	if ($rtype == 'Block' && !$pfb_geoip) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -784,21 +784,8 @@ if (isset($_POST) && !empty($_POST)) {
 		$filterfieldsarray = array();
 	}
 
-	// Add a host (v4 or v6, ANY containing mask) to the suppression customlist,
-	// carving it out of whichever table entr(y/ies) currently block it live
-	// (ADR-53 §2.1 fork 3 -- full rework). The old /24-only 254-host re-add
-	// loop + "blocked by a CIDR other than /24" refusal are retired: any
-	// containing entry is now punched via pfb_live_punch_plan()'s
-	// covering-CIDR set-subtraction, mirroring the persisted v4/v6 engines
-	// (Phases 3/5).
+	// Add a host to the suppression customlist.
 	elseif (isset($_POST['addsuppress']) && !empty($_POST['addsuppress'])) {
-
-		// NOTE: no $escape flag — pfb_filter(..., TRUE) returns an escapeshellarg()'d
-		// token (quotes included), which the legacy flow interpolated into exec()
-		// directly. This flow escapes at each exec sink instead, and $ip feeds
-		// non-shell consumers (the punch plan, the stored customlist entry) that
-		// must see the raw address — the quoted form corrupted the stored config
-		// entry ('1.2.3.4'/32), caught live by the Tier B addsuppress e2e.
 		$ip	= pfb_filter($_POST['ip'], PFB_FILTER_IP, 'alerts addsuppress');
 		$table	= pfb_filter($_POST['table'], PFB_FILTER_WORD, 'alerts addsuppress');
 
@@ -809,94 +796,12 @@ if (isset($_POST) && !empty($_POST)) {
 			exit;
 		}
 
-		$is_v6 = strpos($ip, ':') !== FALSE;
-		$family = $is_v6 ? 6 : 4;
-
 		$descr = '';
 		if (isset($_POST['descr']) && !empty($_POST['descr'])) {
 			$descr = pfb_filter($_POST['descr'], PFB_FILTER_HTML, 'alerts addsuppress');
 		}
-
-		// Snapshot + carve + apply, serialized against a concurrent feed pass
-		// (pfb_live_punch_run(), pfblockerng_extra.inc -- shared with the
-		// Unlock icon's live punch, #1412/#1467). An empty plan ('not_blocked')
-		// is NOT a refusal -- the customlist add below always proceeds, exactly
-		// as the old /24 branch already did unconditionally: suppression is a
-		// standing exemption for FUTURE loads, not contingent on today's live
-		// table snapshot.
-		$apply = pfb_live_punch_run($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table, $ip);
-
-		$savemsg1 = "Host IP address {$ip}";
-		switch ($apply['status']) {
-			case 'applied':
-				$savemsg2 = ' : Removed ' . $apply['del_cnt'] . ' entr' . ($apply['del_cnt'] == 1 ? 'y' : 'ies')
-					. ', added ' . $apply['add_cnt'] . ' covering CIDR' . ($apply['add_cnt'] == 1 ? '' : 's');
-				break;
-			case 'not_blocked':
-				$savemsg2 = " : Not currently blocked by Table [ {$table} ]";
-				break;
-			case 'busy':
-				$savemsg2 = ' : An update/reload pass is currently in progress, suppression will apply at the next reload';
-				break;
-			default: // 'failed'
-				$savemsg2 = " : Live punch failed [ {$apply['fail']} ], suppression will still apply at the next reload";
-				break;
-		}
-
-		$supp_key	= $is_v6 ? 'ipsuppression_v6' : 'ipsuppression';
-		$cfg_key	= $is_v6 ? 'v6suppression' : 'v4suppression';
-		$host_line	= $is_v6 ? "{$ip}/128" : "{$ip}/32";
-
-		// Save the host to the correct-family Suppression List (bare-host dedup
-		// unchanged UX from the original v4-only code -- the "+" always
-		// suppresses the exact reported host, never the whole containing entry).
-		$pfbupdate        = FALSE;
-		$refresh_suppfile = FALSE;
-		if (isset($clists[$supp_key]['data'][$host_line])) {
-			$savemsg = gettext("Host IP address {$ip} already exists in the IPv{$family} Suppression customlist.");
-		} elseif (pfb_ip_suppressed($ip, array_keys($clists[$supp_key]['data']))) {
-			// ADR-53 review finding H6: the old flow also recognised a host
-			// already covered by a BROADER manual suppression entry (e.g. a
-			// /24 already covers this /32) -- appending the exact host on top
-			// would be a redundant customlist entry. Reuses the same
-			// prefix-aware predicate killstates uses (ADR-53) rather than
-			// re-deriving containment here. The live punch above already ran
-			// (unaffected by this dedup); the suppression file is still
-			// refreshed below so it reflects the covering entry.
-			$savemsg          = gettext("Host IP address {$ip} is already covered by an existing IPv{$family} Suppression entry.");
-			$refresh_suppfile = TRUE;
-		} else {
-			$supp_dat = $host_line;
-			if (!empty($descr)) {
-				$supp_dat .= " # {$descr}";
-			}
-
-			$savemsg          = gettext($savemsg1) . gettext($savemsg2) . gettext(" and added to the IPv{$family} Suppression customlist.");
-			$pfbupdate        = TRUE;
-			$refresh_suppfile = TRUE;
-		}
-
-		if ($pfbupdate) {
-			$data = '';
-			foreach ($clists[$supp_key]['data'] as $line) {
-				$data .= "{$line}";
-			}
-			$data .= "{$supp_dat}\r\n";
-			$clists[$supp_key]['base64'] = base64_encode($data);
-			PfbConfig::write($cfg_key, $clists[$supp_key]['base64']);
-			write_config("pfBlockerNG: Added {$ip} to the IPv{$family} Suppression customlist", FALSE);
-		}
-		if ($refresh_suppfile) {
-			// pfb_create_suppression_file() reads $pfb['ipconfig'][...], a
-			// snapshot taken at pfb_global() time -- refresh it in-memory so the
-			// suppression file this request writes reflects either the entry
-			// just appended, or (the "already covered" branch above) the
-			// pre-existing broader entry, keeping pfbsuppression(_v6).txt in
-			// step with the live punch that already ran.
-			$pfb['ipconfig'][$cfg_key] = $clists[$supp_key]['base64'];
-			pfb_create_suppression_file();	// Refresh pfbsuppression(_v6).txt
-		}
-		header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
+		$result = pfb_alerts_ip_action('addsuppress', $ip, $table, $descr, $clists, $ip_unlock);
+		header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$result['savemsg']}");
 		exit;
 	}
 
@@ -1546,58 +1451,11 @@ if (isset($_POST) && !empty($_POST)) {
 			exit;
 		}
 
-		// Unlock IP -- ADR-53 covering-CIDR live punch (pfb_live_punch_run(),
-		// pfblockerng_extra.inc), the same mechanism the Suppression "+" uses:
-		// carve exactly this host out of whichever table entr(y/ies) currently
-		// block it live, any mask, either family, instead of deleting the
-		// whole containing entry (the old direct single-token delete unblocked
-		// every sibling in that entry too). Serialized against a concurrent
-		// feed pass (issue #1467).
-		if ($_POST['ip_remove'] == 'unlock') {
-			$apply = pfb_live_punch_run($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table, $ip);
-
-			switch ($apply['status']) {
-				case 'applied':
-					pfb_unlock('unlock', 'ip', $ip, $table, $ip_unlock);
-					$savemsg = "The IP [ {$ip} ] has been temporarily Unlocked from table [ {$table} ]!";
-					break;
-				case 'not_blocked':
-					// Nothing live currently blocks this host -- no store write, no unlock recorded.
-					$savemsg = "The IP [ {$ip} ] is not currently blocked by table [ {$table} ] -- no unlock was recorded.";
-					break;
-				case 'busy':
-					// An update/reload pass is running -- no store write; ask the user to retry.
-					$savemsg = "Table [ {$table} ] is mid-update -- please retry the Unlock once the current run finishes.";
-					break;
-				default: // 'failed'
-					// No pfb_unlock() store write -- the table still blocks the IP, so the
-					// unlock store must not claim otherwise.
-					$savemsg = "The live unlock of IP [ {$ip} ] failed [ {$apply['fail']} ] -- table [ {$table} ] still blocks it; see the pfBlockerNG log.";
-					break;
-			}
+		$result = pfb_alerts_ip_action($_POST['ip_remove'], $ip, $table, '', $clists, $ip_unlock);
+		if ($result['redirect']) {
+			header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$result['savemsg']}");
+			exit;
 		}
-
-		// Lock IP -- restores exactly the alerted host (mirrors the
-		// un-suppress 'delete_ip' handler's direct re-add: no covering-CIDR
-		// remainder to compute, only the single host that was carved out).
-		elseif ($_POST['ip_remove'] == 'lock') {
-			// issue #1505: check the re-add before recording the re-lock -- a
-			// failed re-add must leave the IP genuinely unlocked in the store.
-			$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table, 'add', $ip);
-			if ($apply['ok']) {
-				pfb_unlock('lock', 'ip', $ip, $table, $ip_unlock);
-				$savemsg = "The IP [ {$ip} ] has been re-locked into table [ {$table} ]!";
-			} else {
-				$savemsg = "The live re-lock of IP [ {$ip} ] failed [ {$apply['fail']} ] -- table [ {$table} ] does not block it; see the pfBlockerNG log.";
-			}
-		}
-
-		else {
-			$savemsg = gettext('Cannot Lock/Unlock - Invalid action.');
-		}
-
-		header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
-		exit;
 	}
 
 	// Whitelist IP events
@@ -1630,40 +1488,9 @@ if (isset($_POST) && !empty($_POST)) {
 			exit;
 		}
 
-		if (!isset($clists['ipwhitelist' . $vtype][$table]['data'][$ip])) {
-			// issue #1505: check the add before touching the customlist/config --
-			// a failed add must leave every write undone.
-			$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table, 'add', $ip);
-			if ($apply['ok']) {
-				@file_put_contents("{$pfb['aliasdir']}/{$table}.txt", "\n{$ip}", LOCK_EX);
-
-				if (!empty($descr)) {
-					$whitelist_string = "{$ip} # {$descr}\r\n";
-				} else {
-					$whitelist_string = "{$ip}\r\n";
-				}
-
-				$data = '';
-				if (isset($clists['ipwhitelist' . $vtype][$table]['data']) && is_array($clists['ipwhitelist' . $vtype][$table]['data'])) {
-					foreach ($clists['ipwhitelist' . $vtype][$table]['data'] as $line) {
-						$data .= "{$line}";
-					}
-				}
-				$data .= "{$whitelist_string}";
-
-				$clists['ipwhitelist' . $vtype][$table]['base64'] = base64_encode($data);
-				// foreign structure: pfblockernglistsv4/v6/config/{row}/custom is a dynamic per-row key, not in registry
-				config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$clists['ipwhitelist' . $vtype][$table]['base64_idx']}/custom", $clists['ipwhitelist' . $vtype][$table]['base64']);
-				write_config("pfBlockerNG: Added [ {$ip} ] to [ {$table} ] Whitelist", FALSE);
-
-				$aname = substr(substr($table, 4),0, -3);					// Remove 'pfB_' and '_v4'
-				touch("{$pfb['permitdir']}/{$aname}_custom_v{$vtype}.update");			// Set Flag for Cron/Update process
-
-				$savemsg = "The IP [ {$ip} ] has been added to the [ {$table} ] Permit Alias customlist.";
-			} else {
-				$savemsg = "The add of [ {$ip} ] to aliastable [ {$table} ] failed [ {$apply['fail']} ] -- see the pfBlockerNG log.";
-			}
-			header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
+		$result = pfb_alerts_ip_action('ip_white', $ip, $table, $descr, $clists, $ip_unlock);
+		if ($result['redirect']) {
+			header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$result['savemsg']}");
 			exit;
 		}
 	}

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -327,15 +327,17 @@ SH
 	{
 		$this->scriptFailure('add', '198.51.100.20');
 		$ip_unlock = ['198.51.100.20' => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4'];
+		$before = "198.51.100.20,pfB_Deny_v4\nkeepme.example,pfB_Keep_v4\n";
+		file_put_contents($GLOBALS['pfb']['ip_unlock'], $before);
 
 		$clists = [];
-		$savemsg = pfb_alerts_ip_action('lock', '198.51.100.20', 'pfB_Deny_v4', '', $clists, $ip_unlock)['savemsg'];
+		$result = pfb_alerts_ip_action('lock', '198.51.100.20', 'pfB_Deny_v4', '', $clists, $ip_unlock);
+		$savemsg = $result['savemsg'];
 
 		$this->assertStringContainsString('failed', $savemsg);
-		$this->assertFileDoesNotExist(
-			$GLOBALS['pfb']['ip_unlock'],
-			'a failed re-lock must NOT write the unlock store -- the IP genuinely stays unlocked'
-		);
+		$this->assertTrue($result['redirect']);
+		$this->assertFileExists($GLOBALS['pfb']['ip_unlock']);
+		$this->assertSame($before, file_get_contents($GLOBALS['pfb']['ip_unlock']));
 	}
 
 	public function testIpRemoveLockSuccessAppliesUnlockStoreWrite(): void
@@ -343,9 +345,11 @@ SH
 		$ip_unlock = ['198.51.100.20' => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4'];
 
 		$clists = [];
-		$savemsg = pfb_alerts_ip_action('lock', '198.51.100.20', 'pfB_Deny_v4', '', $clists, $ip_unlock)['savemsg'];
+		$result = pfb_alerts_ip_action('lock', '198.51.100.20', 'pfB_Deny_v4', '', $clists, $ip_unlock);
+		$savemsg = $result['savemsg'];
 
 		$this->assertStringContainsString('re-locked', $savemsg);
+		$this->assertTrue($result['redirect']);
 		$this->assertFileExists($GLOBALS['pfb']['ip_unlock'], 'a successful re-lock must apply the unlock store write');
 		$content = file_get_contents($GLOBALS['pfb']['ip_unlock']);
 		$this->assertStringContainsString('keepme.example', $content, 'the untouched leftover entry must survive the rewrite');
@@ -360,6 +364,7 @@ SH
 		$result = pfb_alerts_ip_action('lock', '2001:db8::20', 'pfB_Deny_v6', '', $clists, $ip_unlock);
 
 		$this->assertStringContainsString('re-locked', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$content = file_get_contents($GLOBALS['pfb']['ip_unlock']);
 		$this->assertStringContainsString('keepme.example', $content);
 		$this->assertStringNotContainsString('2001:db8::20', $content);
@@ -373,9 +378,11 @@ SH
 		$ip_unlock = ['fe80::1%em0' => 'pfB_Deny_v6', 'keepme.example' => 'pfB_Keep_v4'];
 
 		$clists = [];
-		$savemsg = pfb_alerts_ip_action('lock', 'fe80::1%em0', 'pfB_Deny_v6', '', $clists, $ip_unlock)['savemsg'];
+		$result = pfb_alerts_ip_action('lock', 'fe80::1%em0', 'pfB_Deny_v6', '', $clists, $ip_unlock);
+		$savemsg = $result['savemsg'];
 
 		$this->assertStringContainsString('failed', $savemsg);
+		$this->assertTrue($result['redirect']);
 		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
 	}
 
@@ -404,6 +411,7 @@ SH
 		$result = pfb_alerts_ip_action('unlock', '198.51.100.22', 'pfB_Deny_v4', '', $clists, []);
 
 		$this->assertStringContainsString('temporarily Unlocked', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertFileExists($GLOBALS['pfb']['ip_unlock']);
 		$this->assertStringContainsString('198.51.100.22,pfB_Deny_v4', file_get_contents($GLOBALS['pfb']['ip_unlock']));
 	}
@@ -415,6 +423,7 @@ SH
 		$result = pfb_alerts_ip_action('unlock', '2001:db8::22', 'pfB_Deny_v6', '', $clists, []);
 
 		$this->assertStringContainsString('temporarily Unlocked', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertStringContainsString('2001:db8::22,pfB_Deny_v6', file_get_contents($GLOBALS['pfb']['ip_unlock']));
 	}
 
@@ -424,6 +433,7 @@ SH
 		$result = pfb_alerts_ip_action('unlock', '198.51.100.23', 'pfB_Deny_v4', '', $clists, []);
 
 		$this->assertStringContainsString('not currently blocked', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
 	}
 
@@ -434,6 +444,7 @@ SH
 		$result = pfb_alerts_ip_action('unlock', '198.51.100.24', 'pfB_Deny_v4', '', $clists, []);
 
 		$this->assertStringContainsString('live unlock', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
 	}
 
@@ -451,6 +462,7 @@ SH
 		}
 
 		$this->assertStringContainsString('mid-update', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
 	}
 
@@ -466,6 +478,7 @@ SH
 		$result = pfb_alerts_ip_action('ip_white', '198.51.100.30', 'pfB_Whitelist_v4', '', $clists, []);
 
 		$this->assertStringContainsString('failed', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertArrayNotHasKey(
 			'198.51.100.30',
 			$clists['ipwhitelist4']['pfB_Whitelist_v4']['data'],
@@ -497,6 +510,7 @@ SH
 		$result = pfb_alerts_ip_action('ip_white', '198.51.100.31', 'pfB_Whitelist_v4', '', $clists, []);
 
 		$this->assertStringContainsString('added', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertFileExists("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v4.txt");
 		$this->assertStringContainsString('198.51.100.31', file_get_contents("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v4.txt"));
 		// Non-vacuity anchor for the failure tests' assertArrayNotHasKey: prove
@@ -514,6 +528,7 @@ SH
 		$result = pfb_alerts_ip_action('ip_white', '2001:db8::30', 'pfB_Whitelist_v6', '', $clists, []);
 
 		$this->assertStringContainsString('failed', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertArrayNotHasKey('2001:db8::30', $clists['ipwhitelist6']['pfB_Whitelist_v6']['data']);
 		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v6.txt");
 		$this->assertEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
@@ -526,8 +541,27 @@ SH
 		$result = pfb_alerts_ip_action('ip_white', '2001:db8::31', 'pfB_Whitelist_v6', '', $clists, []);
 
 		$this->assertStringContainsString('added', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertFileExists("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v6.txt");
 		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
+		$this->assertSame(
+			base64_encode("2001:db8::31\r\n"),
+			$GLOBALS['config']['installedpackages']['pfblockernglistsv6']['config'][0]['custom']
+		);
+		$this->assertFileExists("{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v6.update");
+	}
+
+	public function testIpWhiteDescriptionAllowsMissingNestedDataShape(): void
+	{
+		$result = pfb_alerts_ip_action('ip_white', '198.51.100.33', 'pfB_Whitelist_v4', 'memo', [], []);
+
+		$this->assertStringContainsString('added', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
+		$this->assertSame(
+			base64_encode("198.51.100.33 # memo\r\n"),
+			$GLOBALS['config']['installedpackages']['pfblockernglistsv4']['config'][0]['custom']
+		);
+		$this->assertFileExists("{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v4.update");
 	}
 
 	public function testIpWhiteDuplicateSkipsPfctlAndRedirect(): void
@@ -550,6 +584,7 @@ SH
 		$result = pfb_alerts_ip_action('addsuppress', '198.51.100.40', 'pfB_Deny_v4', 'note', $clists, []);
 
 		$this->assertStringContainsString('Not currently blocked', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertSame("198.51.100.40/32 # note\r\n", base64_decode(PfbConfig::read('v4suppression')));
 		$this->assertFileExists($GLOBALS['pfb']['supptxt']);
 	}
@@ -561,6 +596,7 @@ SH
 		$result = pfb_alerts_ip_action('addsuppress', '2001:db8::40', 'pfB_Deny_v6', '', $clists, []);
 
 		$this->assertStringContainsString('Not currently blocked', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertSame("2001:db8::40/128\r\n", base64_decode(PfbConfig::read('v6suppression')));
 		$this->assertFileExists($GLOBALS['pfb']['supptxt_v6']);
 	}
@@ -573,6 +609,7 @@ SH
 		$result = pfb_alerts_ip_action('addsuppress', '198.51.100.42', 'pfB_Deny_v4', '', $clists, []);
 
 		$this->assertStringContainsString('Removed 1 entry, added 0 covering CIDRs', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertSame("198.51.100.42/32\r\n", base64_decode(PfbConfig::read('v4suppression')));
 	}
 
@@ -584,6 +621,7 @@ SH
 		$result = pfb_alerts_ip_action('addsuppress', '198.51.100.43', 'pfB_Deny_v4', '', $clists, []);
 
 		$this->assertStringContainsString('Live punch failed', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertSame("198.51.100.43/32\r\n", base64_decode(PfbConfig::read('v4suppression')));
 	}
 
@@ -601,6 +639,7 @@ SH
 		}
 
 		$this->assertStringContainsString('update/reload pass', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertSame("198.51.100.44/32\r\n", base64_decode(PfbConfig::read('v4suppression')));
 	}
 
@@ -611,8 +650,21 @@ SH
 		$result = pfb_alerts_ip_action('addsuppress', '198.51.100.41', 'pfB_Deny_v4', '', $clists, []);
 
 		$this->assertStringContainsString('already exists', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
 		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? []);
 		$this->assertSame('', (string) @file_get_contents($GLOBALS['pfb']['supptxt']));
+	}
+
+	public function testAddSuppressV6ExactDuplicateSkipsConfigRefresh(): void
+	{
+		$clists = ['ipsuppression_v6' => ['data' => ['2001:db8::41/128' => "2001:db8::41/128\r\n"], 'base64' => base64_encode("2001:db8::41/128\r\n")]];
+
+		$result = pfb_alerts_ip_action('addsuppress', '2001:db8::41', 'pfB_Deny_v6', '', $clists, []);
+
+		$this->assertSame('Host IP address 2001:db8::41 already exists in the IPv6 Suppression customlist.', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? []);
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['supptxt_v6']);
 	}
 
 	public function testAddSuppressBroaderEntryRefreshesSuppressionFileWithoutAppend(): void
@@ -625,6 +677,36 @@ SH
 		$this->assertStringContainsString('already covered', $result['savemsg']);
 		$this->assertSame("198.51.100.0/24\n", file_get_contents($GLOBALS['pfb']['supptxt']));
 		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? []);
+	}
+
+	public function testAlertsPageDispatchKeepsFiltersNavigationAndStrictIpActions(): void
+	{
+		$src = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php');
+		$this->assertNotFalse($src);
+
+		$this->assertStringContainsString("pfb_filter(\$_POST['ip'], PFB_FILTER_IP, 'alerts addsuppress')", $src);
+		$this->assertStringContainsString("pfb_filter(\$_POST['table'], PFB_FILTER_WORD, 'alerts addsuppress')", $src);
+		$this->assertStringContainsString("pfb_filter(\$_POST['descr'], PFB_FILTER_HTML, 'alerts ip_white')", $src);
+		$this->assertStringContainsString("str_starts_with(\$table, 'NEW_')", $src);
+		$this->assertStringContainsString("pfb_alerts_ip_action('ip_white'", $src);
+		$this->assertStringContainsString("pfb_filter(\$_POST['ip'], PFB_FILTER_IP, 'alerts ip_remove')", $src);
+		$this->assertStringContainsString("pfb_filter(\$_POST['table'], PFB_FILTER_WORD, 'alerts ip_remove')", $src);
+		$this->assertStringContainsString('header("Location: /pfblockerng/pfblockerng_category_edit.php?type=ipv{$vtype}&act=addgroup', $src);
+
+		$remove_start = strpos($src, "\telseif (isset(\$_POST['ip_remove'])");
+		$remove_end = strpos($src, "\n\t// Whitelist IP events", $remove_start);
+		$this->assertNotFalse($remove_start);
+		$this->assertNotFalse($remove_end);
+		$remove = substr($src, $remove_start, $remove_end - $remove_start);
+		$this->assertStringNotContainsString("pfb_alerts_ip_action(\$_POST['ip_remove']", $remove);
+		$this->assertStringContainsString("is_string(\$_POST['ip_remove'])", $remove);
+		$this->assertStringContainsString("=== 'unlock'", $remove);
+		$this->assertStringContainsString("=== 'lock'", $remove);
+		$this->assertStringNotContainsString('pfb_live_punch_run(', $remove);
+		$this->assertStringNotContainsString('pfb_pfctl_checked_op(', $remove);
+		$this->assertStringNotContainsString('pfb_unlock(', $remove);
+		$this->assertStringContainsString('header(', $remove);
+		$this->assertStringContainsString('exit;', $remove);
 	}
 
 	/** @return string[] the last [op, table, entry] row the shim logged. */

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * issue #1505: four `pfctl -T add/delete` exec() calls in
@@ -14,19 +15,10 @@ use PHPUnit\Framework\TestCase;
  * fail-closed pfb_live_punch_apply()) and gates every store write + the
  * success savemsg on the outcome.
  *
- * The four handlers live in top-level script code (a switch/if chain inside
- * pfblockerng_alerts.php's `if (isset($_POST))` block), not functions, so
- * each region is eval-extracted verbatim from the REAL source -- same
- * technique as CategoryEditPostGuardTest -- anchored on text stable across
- * both the pre-fix and post-fix code, so this one file proves red on the old
- * code and green on the new. delete_ip/delete_ipwhitelist keep their case's
- * own trailing `break;`, so those two are wrapped in a `switch (1) { case 1:
- * ... }` shell; the lock/ip_white regions are plain statement lists and are
- * eval'd directly. ip_white's extraction stops BEFORE the header() call
- * (calling header()/exit() inside a test would kill the process) -- this
- * only works because the fix hoists header()+exit() to run once after the
- * if/else (never duplicated per-branch), which is also why the SAME
- * extraction anchor resolves in both the pre-fix and post-fix source.
+ * delete_ip/delete_ipwhitelist remain top-level page code and keep their
+ * source-evaluated oracle coverage. Alerts IP mutations use the package seam
+ * directly so store/config ordering and explicit redirect results are tested
+ * without executing page headers or exits.
  *
  * Uses the same injectable pfctl shim pattern as AlertsLivePunchApplyTest
  * (writeShim() + PFB_TEST_LOG argv log + PFB_TEST_RULES scripted per-op
@@ -89,50 +81,6 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 			);
 		}
 
-		// Region 3: the ip_remove=='lock' elseif branch (its own open+close braces).
-		// The anchor is `elseif (...) {` since it sits alongside an `if ($_POST[
-		// 'ip_remove'] == 'unlock')` sibling -- rewritten to `if` so it evals as a
-		// standalone statement. The end anchor skips over the trailing catch-all
-		// `else { ... }` (invalid ip_remove action) to the shared header() call
-		// after the whole if/elseif/else chain (2-tab indent, blank line before it).
-		if (!function_exists('pfb_alerts_oracle_ip_lock')) {
-			if (!preg_match(
-				'/(elseif \(\$_POST\[\'ip_remove\'\] == \'lock\'\) \{\n.*?\n\t\t\})\n\n\t\telse \{\n.*?\n\t\t\}\n\n\t\theader\(/s',
-				$src,
-				$m
-			)) {
-				throw new RuntimeException('test bootstrap: ip_remove lock region not found');
-			}
-			$body = preg_replace('/^elseif\b/', 'if', $m[1], 1);
-			eval(
-				'function pfb_alerts_oracle_ip_lock(string $ip, string $table, array $ip_unlock = []): string {'
-				. ' global $pfb; $_POST[\'ip_remove\'] = \'lock\';'
-				. ' $table_esc = escapeshellarg($table); $savemsg = \'\';'
-				. $body
-				. ' unset($_POST[\'ip_remove\']); return $savemsg; }'
-			);
-		}
-
-		// Region 4: the ip_white if(!isset(...)) body -- captured WITHOUT its
-		// enclosing braces (the wrapper always wants this branch to run) and
-		// stopping BEFORE the header() call (3-tab indent, no blank line before
-		// it): calling header()/exit() inside PHPUnit would abort the process.
-		if (!function_exists('pfb_alerts_oracle_ip_white')) {
-			if (!preg_match(
-				'/if \(!isset\(\$clists\[\'ipwhitelist\' \. \$vtype\]\[\$table\]\[\'data\'\]\[\$ip\]\)\) \{\n(.*?)\n\t\t\theader\(/s',
-				$src,
-				$m
-			)) {
-				throw new RuntimeException('test bootstrap: ip_white region not found');
-			}
-			eval(
-				'function pfb_alerts_oracle_ip_white(string $ip, string $table, string $vtype, string $descr, array &$clists): array {'
-				. ' global $pfb; $ip_esc = escapeshellarg($ip); $table_esc = escapeshellarg($table);'
-				. ' $savemsg = \'\';'
-				. $m[1]
-				. ' return [\'savemsg\' => $savemsg, \'clists\' => $clists]; }'
-			);
-		}
 	}
 
 	protected function setUp(): void
@@ -143,6 +91,7 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 		mkdir($this->tmp, 0777, TRUE);
 		mkdir("{$this->tmp}/alias", 0777, TRUE);
 		mkdir("{$this->tmp}/permit", 0777, TRUE);
+		mkdir("{$this->tmp}/db", 0777, TRUE);
 
 		$this->logPath   = "{$this->tmp}/calls.log";
 		$this->rulesPath = "{$this->tmp}/rules.tsv";
@@ -152,6 +101,7 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 
 		$pfb['pfctl']     = $this->shim;
 		$pfb['aliasdir']  = "{$this->tmp}/alias";
+		$pfb['dbdir']     = "{$this->tmp}/db";
 		$pfb['permitdir'] = "{$this->tmp}/permit";
 		$pfb['ip_unlock'] = "{$this->tmp}/ip_unlock.txt";
 		$pfb['supptxt']    = "{$this->tmp}/pfbsuppression.txt";
@@ -175,6 +125,7 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 	{
 		putenv('PFB_TEST_LOG');
 		putenv('PFB_TEST_RULES');
+		putenv('PFB_TEST_SHOW_ENTRY');
 		rmdir_recursive($this->tmp);
 		unset($GLOBALS['pfb_test_write_config_calls'], $GLOBALS['config']);
 	}
@@ -196,9 +147,12 @@ while [ "$#" -gt 0 ]; do
 	esac
 done
 printf '%s|%s|%s\n' "$op" "$table" "$entry" >> "$PFB_TEST_LOG"
-if [ -z "$entry" ]; then
+if [ "$op" != "show" ] && [ -z "$entry" ]; then
 	printf 'pfctl: no address specified\n' >&2
 	exit 1
+fi
+if [ "$op" = "show" ] && [ -n "$PFB_TEST_SHOW_ENTRY" ]; then
+	printf '%s\n' "$PFB_TEST_SHOW_ENTRY"
 fi
 if [ -f "$PFB_TEST_RULES" ]; then
 	while IFS='|' read -r r_op r_entry r_rc r_err; do
@@ -374,7 +328,8 @@ SH
 		$this->scriptFailure('add', '198.51.100.20');
 		$ip_unlock = ['198.51.100.20' => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4'];
 
-		$savemsg = pfb_alerts_oracle_ip_lock('198.51.100.20', 'pfB_Deny_v4', $ip_unlock);
+		$clists = [];
+		$savemsg = pfb_alerts_ip_action('lock', '198.51.100.20', 'pfB_Deny_v4', '', $clists, $ip_unlock)['savemsg'];
 
 		$this->assertStringContainsString('failed', $savemsg);
 		$this->assertFileDoesNotExist(
@@ -387,13 +342,27 @@ SH
 	{
 		$ip_unlock = ['198.51.100.20' => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4'];
 
-		$savemsg = pfb_alerts_oracle_ip_lock('198.51.100.20', 'pfB_Deny_v4', $ip_unlock);
+		$clists = [];
+		$savemsg = pfb_alerts_ip_action('lock', '198.51.100.20', 'pfB_Deny_v4', '', $clists, $ip_unlock)['savemsg'];
 
 		$this->assertStringContainsString('re-locked', $savemsg);
 		$this->assertFileExists($GLOBALS['pfb']['ip_unlock'], 'a successful re-lock must apply the unlock store write');
 		$content = file_get_contents($GLOBALS['pfb']['ip_unlock']);
 		$this->assertStringContainsString('keepme.example', $content, 'the untouched leftover entry must survive the rewrite');
 		$this->assertStringNotContainsString('198.51.100.20', $content, 'the re-locked IP must be removed from the unlock store');
+	}
+
+	public function testIpRemoveLockV6SuccessRemovesExactHostOnly(): void
+	{
+		$ip_unlock = ['2001:db8::20' => 'pfB_Deny_v6', 'keepme.example' => 'pfB_Keep_v4'];
+		$clists = [];
+
+		$result = pfb_alerts_ip_action('lock', '2001:db8::20', 'pfB_Deny_v6', '', $clists, $ip_unlock);
+
+		$this->assertStringContainsString('re-locked', $result['savemsg']);
+		$content = file_get_contents($GLOBALS['pfb']['ip_unlock']);
+		$this->assertStringContainsString('keepme.example', $content);
+		$this->assertStringNotContainsString('2001:db8::20', $content);
 	}
 
 	public function testIpRemoveLockZoneIdHostileEntryFailureSkipsStoreWrite(): void
@@ -403,9 +372,85 @@ SH
 		$this->scriptFailure('add', 'fe80::1%em0');
 		$ip_unlock = ['fe80::1%em0' => 'pfB_Deny_v6', 'keepme.example' => 'pfB_Keep_v4'];
 
-		$savemsg = pfb_alerts_oracle_ip_lock('fe80::1%em0', 'pfB_Deny_v6', $ip_unlock);
+		$clists = [];
+		$savemsg = pfb_alerts_ip_action('lock', 'fe80::1%em0', 'pfB_Deny_v6', '', $clists, $ip_unlock)['savemsg'];
 
 		$this->assertStringContainsString('failed', $savemsg);
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
+	}
+
+	#[DataProvider('invalidActionProvider')]
+	public function testUnexpectedAlertActionIsInert(mixed $action): void
+	{
+		$clists = [];
+		$result = pfb_alerts_ip_action($action, '198.51.100.21', 'pfB_Deny_v4', '', $clists, []);
+
+		$this->assertTrue($result['redirect']);
+		$this->assertSame('Cannot Lock/Unlock - Invalid action.', $result['savemsg']);
+		$this->assertSame([], $clists);
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
+		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['aliasdir']}/pfB_Deny_v4.txt");
+	}
+
+	public static function invalidActionProvider(): array
+	{
+		return [['bogus'], [''], [[]]];
+	}
+
+	public function testIpRemoveUnlockAppliedRecordsV4Host(): void
+	{
+		putenv('PFB_TEST_SHOW_ENTRY=198.51.100.22');
+		$clists = [];
+		$result = pfb_alerts_ip_action('unlock', '198.51.100.22', 'pfB_Deny_v4', '', $clists, []);
+
+		$this->assertStringContainsString('temporarily Unlocked', $result['savemsg']);
+		$this->assertFileExists($GLOBALS['pfb']['ip_unlock']);
+		$this->assertStringContainsString('198.51.100.22,pfB_Deny_v4', file_get_contents($GLOBALS['pfb']['ip_unlock']));
+	}
+
+	public function testIpRemoveUnlockAppliedRecordsV6Host(): void
+	{
+		putenv('PFB_TEST_SHOW_ENTRY=2001:db8::22');
+		$clists = [];
+		$result = pfb_alerts_ip_action('unlock', '2001:db8::22', 'pfB_Deny_v6', '', $clists, []);
+
+		$this->assertStringContainsString('temporarily Unlocked', $result['savemsg']);
+		$this->assertStringContainsString('2001:db8::22,pfB_Deny_v6', file_get_contents($GLOBALS['pfb']['ip_unlock']));
+	}
+
+	public function testIpRemoveUnlockNotBlockedRecordsNothing(): void
+	{
+		$clists = [];
+		$result = pfb_alerts_ip_action('unlock', '198.51.100.23', 'pfB_Deny_v4', '', $clists, []);
+
+		$this->assertStringContainsString('not currently blocked', $result['savemsg']);
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
+	}
+
+	public function testIpRemoveUnlockFailedRecordsNothing(): void
+	{
+		$this->scriptFailure('show', '');
+		$clists = [];
+		$result = pfb_alerts_ip_action('unlock', '198.51.100.24', 'pfB_Deny_v4', '', $clists, []);
+
+		$this->assertStringContainsString('live unlock', $result['savemsg']);
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
+	}
+
+	public function testIpRemoveUnlockBusyRecordsNothing(): void
+	{
+		$lock = fopen("{$GLOBALS['pfb']['dbdir']}/pfb_feed_pass.lock", 'c');
+		$this->assertNotFalse($lock);
+		$this->assertTrue(flock($lock, LOCK_EX | LOCK_NB));
+		try {
+			$clists = [];
+			$result = pfb_alerts_ip_action('unlock', '198.51.100.25', 'pfB_Deny_v4', '', $clists, []);
+		} finally {
+			flock($lock, LOCK_UN);
+			fclose($lock);
+		}
+
+		$this->assertStringContainsString('mid-update', $result['savemsg']);
 		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
 	}
 
@@ -418,12 +463,12 @@ SH
 		$this->scriptFailure('add', '198.51.100.30');
 		$clists = ['ipwhitelist4' => ['pfB_Whitelist_v4' => ['base64_idx' => 0, 'data' => []]]];
 
-		$result = pfb_alerts_oracle_ip_white('198.51.100.30', 'pfB_Whitelist_v4', '4', '', $clists);
+		$result = pfb_alerts_ip_action('ip_white', '198.51.100.30', 'pfB_Whitelist_v4', '', $clists, []);
 
 		$this->assertStringContainsString('failed', $result['savemsg']);
 		$this->assertArrayNotHasKey(
 			'198.51.100.30',
-			$result['clists']['ipwhitelist4']['pfB_Whitelist_v4']['data'],
+			$clists['ipwhitelist4']['pfB_Whitelist_v4']['data'],
 			'a failed add must not update the in-memory customlist'
 		);
 		$this->assertFileDoesNotExist(
@@ -449,7 +494,7 @@ SH
 	{
 		$clists = ['ipwhitelist4' => ['pfB_Whitelist_v4' => ['base64_idx' => 0, 'data' => []]]];
 
-		$result = pfb_alerts_oracle_ip_white('198.51.100.31', 'pfB_Whitelist_v4', '4', '', $clists);
+		$result = pfb_alerts_ip_action('ip_white', '198.51.100.31', 'pfB_Whitelist_v4', '', $clists, []);
 
 		$this->assertStringContainsString('added', $result['savemsg']);
 		$this->assertFileExists("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v4.txt");
@@ -466,10 +511,10 @@ SH
 		$this->scriptFailure('add', '2001:db8::30');
 		$clists = ['ipwhitelist6' => ['pfB_Whitelist_v6' => ['base64_idx' => 0, 'data' => []]]];
 
-		$result = pfb_alerts_oracle_ip_white('2001:db8::30', 'pfB_Whitelist_v6', '6', '', $clists);
+		$result = pfb_alerts_ip_action('ip_white', '2001:db8::30', 'pfB_Whitelist_v6', '', $clists, []);
 
 		$this->assertStringContainsString('failed', $result['savemsg']);
-		$this->assertArrayNotHasKey('2001:db8::30', $result['clists']['ipwhitelist6']['pfB_Whitelist_v6']['data']);
+		$this->assertArrayNotHasKey('2001:db8::30', $clists['ipwhitelist6']['pfB_Whitelist_v6']['data']);
 		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v6.txt");
 		$this->assertEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
 	}
@@ -478,11 +523,108 @@ SH
 	{
 		$clists = ['ipwhitelist6' => ['pfB_Whitelist_v6' => ['base64_idx' => 0, 'data' => []]]];
 
-		$result = pfb_alerts_oracle_ip_white('2001:db8::31', 'pfB_Whitelist_v6', '6', '', $clists);
+		$result = pfb_alerts_ip_action('ip_white', '2001:db8::31', 'pfB_Whitelist_v6', '', $clists, []);
 
 		$this->assertStringContainsString('added', $result['savemsg']);
 		$this->assertFileExists("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v6.txt");
 		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
+	}
+
+	public function testIpWhiteDuplicateSkipsPfctlAndRedirect(): void
+	{
+		$clists = ['ipwhitelist4' => ['pfB_Whitelist_v4' => ['base64_idx' => 0, 'data' => ['198.51.100.32' => "198.51.100.32\r\n"]]]];
+
+		$result = pfb_alerts_ip_action('ip_white', '198.51.100.32', 'pfB_Whitelist_v4', '', $clists, []);
+
+		$this->assertFalse($result['redirect']);
+		$this->assertSame('', $result['savemsg']);
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? []);
+		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v4.txt");
+		$this->assertSame('', (string) @file_get_contents($this->logPath));
+	}
+
+	public function testAddSuppressNotBlockedPersistsExactV4Host(): void
+	{
+		$clists = ['ipsuppression' => ['data' => []]];
+
+		$result = pfb_alerts_ip_action('addsuppress', '198.51.100.40', 'pfB_Deny_v4', 'note', $clists, []);
+
+		$this->assertStringContainsString('Not currently blocked', $result['savemsg']);
+		$this->assertSame("198.51.100.40/32 # note\r\n", base64_decode(PfbConfig::read('v4suppression')));
+		$this->assertFileExists($GLOBALS['pfb']['supptxt']);
+	}
+
+	public function testAddSuppressNotBlockedPersistsExactV6Host(): void
+	{
+		$clists = ['ipsuppression_v6' => ['data' => []]];
+
+		$result = pfb_alerts_ip_action('addsuppress', '2001:db8::40', 'pfB_Deny_v6', '', $clists, []);
+
+		$this->assertStringContainsString('Not currently blocked', $result['savemsg']);
+		$this->assertSame("2001:db8::40/128\r\n", base64_decode(PfbConfig::read('v6suppression')));
+		$this->assertFileExists($GLOBALS['pfb']['supptxt_v6']);
+	}
+
+	public function testAddSuppressAppliedPersistsAfterLivePunch(): void
+	{
+		putenv('PFB_TEST_SHOW_ENTRY=198.51.100.42');
+		$clists = ['ipsuppression' => ['data' => []]];
+
+		$result = pfb_alerts_ip_action('addsuppress', '198.51.100.42', 'pfB_Deny_v4', '', $clists, []);
+
+		$this->assertStringContainsString('Removed 1 entry, added 0 covering CIDRs', $result['savemsg']);
+		$this->assertSame("198.51.100.42/32\r\n", base64_decode(PfbConfig::read('v4suppression')));
+	}
+
+	public function testAddSuppressFailedStillPersistsStandingSuppression(): void
+	{
+		$this->scriptFailure('show', '');
+		$clists = ['ipsuppression' => ['data' => []]];
+
+		$result = pfb_alerts_ip_action('addsuppress', '198.51.100.43', 'pfB_Deny_v4', '', $clists, []);
+
+		$this->assertStringContainsString('Live punch failed', $result['savemsg']);
+		$this->assertSame("198.51.100.43/32\r\n", base64_decode(PfbConfig::read('v4suppression')));
+	}
+
+	public function testAddSuppressBusyStillPersistsStandingSuppression(): void
+	{
+		$lock = fopen("{$GLOBALS['pfb']['dbdir']}/pfb_feed_pass.lock", 'c');
+		$this->assertNotFalse($lock);
+		$this->assertTrue(flock($lock, LOCK_EX | LOCK_NB));
+		try {
+			$clists = ['ipsuppression' => ['data' => []]];
+			$result = pfb_alerts_ip_action('addsuppress', '198.51.100.44', 'pfB_Deny_v4', '', $clists, []);
+		} finally {
+			flock($lock, LOCK_UN);
+			fclose($lock);
+		}
+
+		$this->assertStringContainsString('update/reload pass', $result['savemsg']);
+		$this->assertSame("198.51.100.44/32\r\n", base64_decode(PfbConfig::read('v4suppression')));
+	}
+
+	public function testAddSuppressExactDuplicateSkipsConfigRefresh(): void
+	{
+		$clists = ['ipsuppression' => ['data' => ['198.51.100.41/32' => "198.51.100.41/32\r\n"], 'base64' => base64_encode("198.51.100.41/32\r\n")]];
+
+		$result = pfb_alerts_ip_action('addsuppress', '198.51.100.41', 'pfB_Deny_v4', '', $clists, []);
+
+		$this->assertStringContainsString('already exists', $result['savemsg']);
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? []);
+		$this->assertSame('', (string) @file_get_contents($GLOBALS['pfb']['supptxt']));
+	}
+
+	public function testAddSuppressBroaderEntryRefreshesSuppressionFileWithoutAppend(): void
+	{
+		$line = "198.51.100.0/24\r\n";
+		$clists = ['ipsuppression' => ['data' => ['198.51.100.0/24' => $line], 'base64' => base64_encode($line)]];
+
+		$result = pfb_alerts_ip_action('addsuppress', '198.51.100.41', 'pfB_Deny_v4', '', $clists, []);
+
+		$this->assertStringContainsString('already covered', $result['savemsg']);
+		$this->assertSame("198.51.100.0/24\n", file_get_contents($GLOBALS['pfb']['supptxt']));
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? []);
 	}
 
 	/** @return string[] the last [op, table, entry] row the shim logged. */

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -479,11 +479,6 @@ SH
 
 		$this->assertStringContainsString('failed', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
-		$this->assertArrayNotHasKey(
-			'198.51.100.30',
-			$clists['ipwhitelist4']['pfB_Whitelist_v4']['data'],
-			'a failed add must not update the in-memory customlist'
-		);
 		$this->assertFileDoesNotExist(
 			"{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v4.txt",
 			'a failed add must NOT append to the aliasdir .txt file'
@@ -529,7 +524,6 @@ SH
 
 		$this->assertStringContainsString('failed', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
-		$this->assertArrayNotHasKey('2001:db8::30', $clists['ipwhitelist6']['pfB_Whitelist_v6']['data']);
 		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v6.txt");
 		$this->assertEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
 	}
@@ -551,17 +545,21 @@ SH
 		$this->assertFileExists("{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v6.update");
 	}
 
-	public function testIpWhiteDescriptionAllowsMissingNestedDataShape(): void
+	public function testIpWhiteDescriptionRejectsMissingNestedDataShape(): void
 	{
-		$result = pfb_alerts_ip_action('ip_white', '198.51.100.33', 'pfB_Whitelist_v4', 'memo', [], []);
+		$table = 'pfB_Hostile_v4';
+		$alias_path = "{$GLOBALS['pfb']['aliasdir']}/{$table}.txt";
+		$update_path = "{$GLOBALS['pfb']['permitdir']}/Hostile_custom_v4.update";
 
-		$this->assertStringContainsString('added', $result['savemsg']);
+		$result = pfb_alerts_ip_action('ip_white', '198.51.100.33', $table, 'memo', [], []);
+
+		$this->assertStringContainsString('metadata missing', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
-		$this->assertSame(
-			base64_encode("198.51.100.33 # memo\r\n"),
-			$GLOBALS['config']['installedpackages']['pfblockernglistsv4']['config'][0]['custom']
-		);
-		$this->assertFileExists("{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v4.update");
+		$this->assertFileDoesNotExist($this->logPath, 'missing alias metadata must not call pfctl');
+		$this->assertFileDoesNotExist($alias_path, 'missing alias metadata must not write the alias file');
+		$this->assertArrayNotHasKey('installedpackages', $GLOBALS['config'] ?? [], 'missing alias metadata must not call config_set_path()');
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? [], 'missing alias metadata must not call write_config()');
+		$this->assertFileDoesNotExist($update_path, 'missing alias metadata must not touch the update flag');
 	}
 
 	public function testIpWhiteDuplicateSkipsPfctlAndRedirect(): void

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -574,13 +574,11 @@ SH
 		$this->assertFileDoesNotExist($update_path, 'missing alias metadata must not touch the update flag');
 	}
 
-	public function testIpWhitePersistenceFailuresKeepConfigWriteAndSuccessMessage(): void
+	public function testIpWhiteAliasPersistenceFailureKeepsConfigWriteAndSuccessMessage(): void
 	{
 		$table = 'pfB_Whitelist_v4';
 		$alias_path = "{$GLOBALS['pfb']['aliasdir']}/{$table}.txt";
-		$update_path = "{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v4.update";
 		$this->assertTrue(mkdir($alias_path), 'setup: alias-file failure target must be a directory');
-		$this->assertTrue(mkdir($update_path), 'setup: update-flag failure target must be a directory');
 
 		$result = pfb_alerts_ip_action(
 			'ip_white',
@@ -600,7 +598,6 @@ SH
 		);
 		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
 		$this->assertDirectoryExists($alias_path, 'alias-file persistence failure must leave the target directory untouched');
-		$this->assertDirectoryExists($update_path, 'update-flag persistence failure must leave the target directory untouched');
 	}
 
 	public function testIpWhiteDuplicateSkipsPfctlAndRedirect(): void

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -394,7 +394,6 @@ SH
 
 		$this->assertTrue($result['redirect']);
 		$this->assertSame('Cannot Lock/Unlock - Invalid action.', $result['savemsg']);
-		$this->assertSame([], $clists);
 		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
 		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['aliasdir']}/pfB_Deny_v4.txt");
 	}
@@ -425,6 +424,20 @@ SH
 		$this->assertStringContainsString('temporarily Unlocked', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
 		$this->assertStringContainsString('2001:db8::22,pfB_Deny_v6', file_get_contents($GLOBALS['pfb']['ip_unlock']));
+	}
+
+	public function testIpRemoveUnlockStorePersistenceFailureKeepsLivePunchAndSuccessMessage(): void
+	{
+		putenv('PFB_TEST_SHOW_ENTRY=198.51.100.26');
+		$store = $GLOBALS['pfb']['ip_unlock'];
+		$this->assertTrue(mkdir($store), 'setup: unlock-store failure target must be a directory');
+
+		$result = pfb_alerts_ip_action('unlock', '198.51.100.26', 'pfB_Deny_v4', '', [], []);
+
+		$this->assertStringContainsString('temporarily Unlocked', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
+		$this->assertSame(['delete', 'pfB_Deny_v4', '198.51.100.26'], $this->lastLogRow());
+		$this->assertDirectoryExists($store, 'unlock-store persistence failure must leave the target directory untouched');
 	}
 
 	public function testIpRemoveUnlockNotBlockedRecordsNothing(): void
@@ -508,8 +521,7 @@ SH
 		$this->assertTrue($result['redirect']);
 		$this->assertFileExists("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v4.txt");
 		$this->assertStringContainsString('198.51.100.31', file_get_contents("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v4.txt"));
-		// Non-vacuity anchor for the failure tests' assertArrayNotHasKey: prove
-		// config_set_path() IS observable through this seam on success.
+		// config_set_path() persistence is observable through the global config on success.
 		$this->assertArrayHasKey('installedpackages', $GLOBALS['config'] ?? [], 'the success path must persist via config_set_path()');
 		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
 		$this->assertFileExists("{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v4.update");
@@ -562,6 +574,35 @@ SH
 		$this->assertFileDoesNotExist($update_path, 'missing alias metadata must not touch the update flag');
 	}
 
+	public function testIpWhitePersistenceFailuresKeepConfigWriteAndSuccessMessage(): void
+	{
+		$table = 'pfB_Whitelist_v4';
+		$alias_path = "{$GLOBALS['pfb']['aliasdir']}/{$table}.txt";
+		$update_path = "{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v4.update";
+		$this->assertTrue(mkdir($alias_path), 'setup: alias-file failure target must be a directory');
+		$this->assertTrue(mkdir($update_path), 'setup: update-flag failure target must be a directory');
+
+		$result = pfb_alerts_ip_action(
+			'ip_white',
+			'198.51.100.34',
+			$table,
+			'',
+			['ipwhitelist4' => [$table => ['base64_idx' => 0, 'data' => []]]],
+			[]
+		);
+
+		$this->assertStringContainsString('added', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
+		$this->assertSame(['add', $table, '198.51.100.34'], $this->lastLogRow());
+		$this->assertSame(
+			base64_encode("198.51.100.34\r\n"),
+			$GLOBALS['config']['installedpackages']['pfblockernglistsv4']['config'][0]['custom']
+		);
+		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
+		$this->assertDirectoryExists($alias_path, 'alias-file persistence failure must leave the target directory untouched');
+		$this->assertDirectoryExists($update_path, 'update-flag persistence failure must leave the target directory untouched');
+	}
+
 	public function testIpWhiteDuplicateSkipsPfctlAndRedirect(): void
 	{
 		$clists = ['ipwhitelist4' => ['pfB_Whitelist_v4' => ['base64_idx' => 0, 'data' => ['198.51.100.32' => "198.51.100.32\r\n"]]]];
@@ -585,6 +626,20 @@ SH
 		$this->assertTrue($result['redirect']);
 		$this->assertSame("198.51.100.40/32 # note\r\n", base64_decode(PfbConfig::read('v4suppression')));
 		$this->assertFileExists($GLOBALS['pfb']['supptxt']);
+	}
+
+	public function testAddSuppressSuppressionFilePersistenceFailureKeepsConfigAndSuccessMessage(): void
+	{
+		$suppression_file = $GLOBALS['pfb']['supptxt'];
+		$this->assertTrue(mkdir($suppression_file), 'setup: suppression-file failure target must be a directory');
+
+		$result = pfb_alerts_ip_action('addsuppress', '198.51.100.45', 'pfB_Deny_v4', '', ['ipsuppression' => ['data' => []]], []);
+
+		$this->assertStringContainsString('Not currently blocked', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
+		$this->assertSame("198.51.100.45/32\r\n", base64_decode(PfbConfig::read('v4suppression')));
+		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
+		$this->assertDirectoryExists($suppression_file, 'suppression-file persistence failure must leave the target directory untouched');
 	}
 
 	public function testAddSuppressNotBlockedPersistsExactV6Host(): void

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -199,6 +199,54 @@
         "returnType": null,
         "params": []
     },
+    "pfb_alerts_ip_action": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "action",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "ip",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "table",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "descr",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "clists",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "ip_unlock",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
     "pfb_alerts_ip_buffer_push": {
         "returnsRef": false,
         "returnType": "void",

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -483,12 +483,16 @@ def test_alerts_invalid_actions_leave_state_unchanged_and_addsuppress_writes_exa
         custom_path = f"{CFG_IPV4_LISTS}/0/custom"
         helpers.inject(vm, spec)
         helpers.reload(vm, "updateip")
+        table_before = sorted(helpers.wait_pfctl_table(vm, hostile_table))
+        assert table_before, f"{hostile_table} did not populate before hostile action"
         # Build the live table under Deny_Both first, then change only the
         # persisted row classification. Permit_Inbound with the harness's
         # default protocol does not declare a live table, while Alerts derives
-        # whitelist metadata from the current config row. Avoiding a second
-        # reload leaves one real table plus matching Permit metadata: exactly
-        # the two preconditions raw ip_white forwarding needs to mutate state.
+        # whitelist metadata from the current config row. The bounded table
+        # wait must finish before this write because filter_configure can land
+        # asynchronously after updateip returns. Avoiding a second reload then
+        # leaves one real table plus matching Permit metadata: exactly the two
+        # preconditions raw ip_white forwarding needs to mutate state.
         classify_result = helpers.php_eval(
             vm,
             f"config_set_path({helpers._php_str(f'{CFG_IPV4_LISTS}/0/action')}, 'Permit_Inbound');\n"
@@ -499,8 +503,9 @@ def test_alerts_invalid_actions_leave_state_unchanged_and_addsuppress_writes_exa
             "failed to classify hostile-dispatch alias as Permit: "
             f"rc={classify_result.returncode} stdout={classify_result.stdout!r}"
         )
-        table_before = sorted(helpers.pfctl_table_members(vm, hostile_table))
-        assert table_before, f"{hostile_table} did not populate before hostile action"
+        assert sorted(helpers.pfctl_table_members(vm, hostile_table)) == table_before, (
+            "config-only Permit classification unexpectedly changed live table state"
+        )
         assert not helpers.pfctl_table_test(vm, hostile_table, hostile_ip), (
             f"{hostile_ip} unexpectedly matched {hostile_table} before hostile action"
         )

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -469,17 +469,40 @@ def test_alerts_invalid_actions_leave_state_unchanged_and_addsuppress_writes_exa
 
         # REJECT: a valid IP/table paired with another action word must stay
         # inert; page-owned strict dispatch must never pass ``ip_white`` to the
-        # package seam used by ip_remove.
+        # package seam used by ip_remove. The Permit row and live table make a
+        # raw-forward regression observable through both config and pf state.
+        feed_host = "198.51.100.47"
+        hostile_ip = "198.51.100.46"
+        feed_path = helpers.write_local_feed(vm, "ui_hostile_ip.txt", f"{feed_host}\n")
+        spec = helpers.IpCase(
+            aliasname="uihostile",
+            feed_url=feed_path,
+            header="uihostile",
+            action="Permit_Inbound",
+        )
+        hostile_table = spec.alias
+        custom_path = f"{CFG_IPV4_LISTS}/0/custom"
+        helpers.inject(vm, spec)
+        helpers.reload(vm, "updateip")
+        table_before = sorted(helpers.pfctl_table_members(vm, hostile_table))
+        assert table_before, f"{hostile_table} did not populate before hostile action"
+        assert not helpers.pfctl_table_test(vm, hostile_table, hostile_ip), (
+            f"{hostile_ip} unexpectedly matched {hostile_table} before hostile action"
+        )
         config_before = _config_sha256(vm)
-        pf_before = helpers.pfctl_table_test_raw(vm, table, valid_ip)
+        custom_before = helpers.config_get(vm, custom_path)
         unlock_before = _ip_unlock_hosts(vm)
-        resp = _post_action(webui, {"ip_remove": "ip_white", "ip": valid_ip, "table": table})
+        resp = _post_action(webui, {"ip_remove": "ip_white", "ip": hostile_ip, "table": hostile_table})
         assert not looks_like_login_page(resp.text), "hostile ip_remove POST returned the login form"
         assert _config_sha256(vm) == config_before, "hostile ip_remove action changed config.xml"
-        assert helpers.pfctl_table_test_raw(vm, table, valid_ip) == pf_before, (
+        assert helpers.config_get(vm, custom_path) == custom_before, (
+            "hostile ip_remove action changed the Permit customlist"
+        )
+        assert sorted(helpers.pfctl_table_members(vm, hostile_table)) == table_before, (
             "hostile ip_remove action changed pf state"
         )
         assert _ip_unlock_hosts(vm) == unlock_before, "hostile ip_remove action changed IP unlock state"
+        helpers.reset(vm)
 
         # ACCEPT: a valid IPv4 against a table with no live match -> still writes
         # the exact host (no mask choice exists any more; no refusal either).

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -478,12 +478,27 @@ def test_alerts_invalid_actions_leave_state_unchanged_and_addsuppress_writes_exa
             aliasname="uihostile",
             feed_url=feed_path,
             header="uihostile",
-            action="Permit_Inbound",
         )
         hostile_table = spec.alias
         custom_path = f"{CFG_IPV4_LISTS}/0/custom"
         helpers.inject(vm, spec)
         helpers.reload(vm, "updateip")
+        # Build the live table under Deny_Both first, then change only the
+        # persisted row classification. Permit_Inbound with the harness's
+        # default protocol does not declare a live table, while Alerts derives
+        # whitelist metadata from the current config row. Avoiding a second
+        # reload leaves one real table plus matching Permit metadata: exactly
+        # the two preconditions raw ip_white forwarding needs to mutate state.
+        classify_result = helpers.php_eval(
+            vm,
+            f"config_set_path({helpers._php_str(f'{CFG_IPV4_LISTS}/0/action')}, 'Permit_Inbound');\n"
+            "write_config('pfBlockerNG smoke: classify hostile-dispatch alias as Permit');\n"
+            "echo 'OK';",
+        )
+        assert classify_result.returncode == 0 and "OK" in classify_result.stdout, (
+            "failed to classify hostile-dispatch alias as Permit: "
+            f"rc={classify_result.returncode} stdout={classify_result.stdout!r}"
+        )
         table_before = sorted(helpers.pfctl_table_members(vm, hostile_table))
         assert table_before, f"{hostile_table} did not populate before hostile action"
         assert not helpers.pfctl_table_test(vm, hostile_table, hostile_ip), (

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -426,17 +426,20 @@ def test_addwhitelistdom_exclude_writes_tld_exclusion_and_entry_delete_removes_i
 # --------------------------------------------------------------------------- #
 
 
-def test_addsuppress_writes_exact_host_and_invalid_ip_rejected(
+@pytest.mark.ui_render
+def test_alerts_invalid_actions_leave_state_unchanged_and_addsuppress_writes_exact_host(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
 ) -> None:
-    """addsuppress writes the EXACT host (never a network line) and rejects a bad IP.
+    """Reject hostile action values, then add the EXACT host (never a network line).
 
-    Branch coverage for the any-mask/v4+v6 suppression validator, with
-    ``v4suppression`` as oracle:
+    Branch coverage for strict Alerts action dispatch and the any-mask/v4+v6
+    suppression validator, with config, pf, and IP unlock state as oracles:
 
     * REJECT first (proves the node's before-value): an invalid IPv4 makes the
       handler exit before any write -- the node is UNCHANGED.
+    * REJECT a hostile valid-word action: ``ip_remove=ip_white`` with a valid
+      IP/table must not reach another action seam or change any effective state.
     * ACCEPT with no live table match: a valid IPv4 against a table with no
       matching entry still writes the ``ip/32`` line -- the retired mechanism's
       "blocked by a CIDR other than /24" refusal is gone, and the ADR-53
@@ -463,6 +466,20 @@ def test_addsuppress_writes_exact_host_and_invalid_ip_rejected(
         assert helpers.config_get(vm, CFG_V4SUPPRESSION) == original, (
             "v4suppression config node changed after a REJECTED (invalid IP) addsuppress POST"
         )
+
+        # REJECT: a valid IP/table paired with another action word must stay
+        # inert; page-owned strict dispatch must never pass ``ip_white`` to the
+        # package seam used by ip_remove.
+        config_before = _config_sha256(vm)
+        pf_before = helpers.pfctl_table_test_raw(vm, table, valid_ip)
+        unlock_before = _ip_unlock_hosts(vm)
+        resp = _post_action(webui, {"ip_remove": "ip_white", "ip": valid_ip, "table": table})
+        assert not looks_like_login_page(resp.text), "hostile ip_remove POST returned the login form"
+        assert _config_sha256(vm) == config_before, "hostile ip_remove action changed config.xml"
+        assert helpers.pfctl_table_test_raw(vm, table, valid_ip) == pf_before, (
+            "hostile ip_remove action changed pf state"
+        )
+        assert _ip_unlock_hosts(vm) == unlock_before, "hostile ip_remove action changed IP unlock state"
 
         # ACCEPT: a valid IPv4 against a table with no live match -> still writes
         # the exact host (no mask choice exists any more; no refusal either).


### PR DESCRIPTION
## Summary

- move Alerts IP suppression, temporary lock/unlock, and whitelist orchestration behind `pfb_alerts_ip_action()`
- keep POST filtering, navigation, redirects, and rendering in the Alerts page
- cover IPv4/IPv6, duplicate/absent/invalid inputs, `pfctl` failures, and persistence-failure partial states through the real package seam
- reject cross-action `ip_remove` values and unknown whitelist metadata before any side effect
- add a Tier-A live oracle that proves hostile action values cannot cross-dispatch into a configured Permit alias

## Verification

- `scripts/agent/run-gates.sh --diff origin/devel` — PASS on rebased head `4cd612e4`
- PHPUnit — 3,882 tests / 22,951 assertions in the final canonical gate
- PHPStan, PHPCS, PHP syntax, Ruff, formatting, mypy, pytest, shellspec, and coverage pairing — PASS
- focused Alerts matrix — 39 tests / 181 assertions
- frozen regression proof — `FREEZE-OK`, RED on `7157091e`, GREEN on `4cd612e4`; SHA-256 `483b17d70f1fb629bf1e0293255ec3b5e93d6bcb6bddbf1f95ec0cc10cafe556`
- independent full-diff and repair-delta reviews — PASS, no open findings
- [full Tier-A CE 2.8 + Plus 26.03 run](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/29739659599) — PASS using staged `pfBlockerNG/FreeBSD-ports#3` package manifests; 146 tests passed on each leg

Fixes #1405

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
