### PR TITLE
tests: set PHPUnit host memory limit to 1G

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,9 @@
             <directory>tests/php</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <ini name="memory_limit" value="1G"/>
+    </php>
     <source>
         <include>
             <!-- Every file defining a #[CoversFunction]/#[CoversClass] target must be

--- a/tests/php/BootstrapSmokeTest.php
+++ b/tests/php/BootstrapSmokeTest.php
@@ -10,6 +10,11 @@ use PHPUnit\Framework\TestCase;
  */
 final class BootstrapSmokeTest extends TestCase
 {
+	public function testPhpUnitRunsWithOneGigabyteMemoryLimit(): void
+	{
+		$this->assertSame('1G', ini_get('memory_limit'));
+	}
+
 	public function testProductionFunctionsAreDefined(): void
 	{
 		foreach ([


### PR DESCRIPTION
## Summary

- Configure PHPUnit to set PHP `memory_limit=1G` from the suite-wide `phpunit.xml`.
- Add a regression assertion proving the runtime receives that value.
- Leave the CI workflow unchanged.

## Verification

- RED: focused test reported expected `1G`, actual `128M`; frozen test hash `73d8333d4215aadcea9b9a51d23d315e7867cb8a`.
- GREEN: the byte-identical focused test passed.
- `composer test -- --filter testPhpUnitRunsWithOneGigabyteMemoryLimit`: passed.
- `vendor/bin/phpunit`: passed, 3,859 tests and 22,831 assertions.
- `scripts/agent/run-gates.sh --diff origin/devel`: `GATES: PASS`.

Fixes #1571

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
