### PR TITLE
dnsbl: make bulk cache flush optional

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -279,8 +279,11 @@ manifest and excludes stages; legacy fixed `pfb_py_raw/` manifests remain readab
   `benchmarks/spike_adr10_swap.py`'s kill-gate), the feature/python mode off, Unbound down, a
   staged config change, or a prior swap/sentinel error.
 - **Cache on swap:** `decisionDB` cleared (no stale decision); **block→allow
-  immediate** (blocks not C-cached since #43). After the applied-generation handshake, bulk
-  feed/cron data updates clear Unbound's full message and RRset caches with `flush_zone +c .`.
+  immediate** (blocks not C-cached since #43). The default-off `pfb_cache_flush` option lets
+  operators clear Unbound's full message and RRset caches with `flush_zone +c .` after the
+  applied-generation handshake for bulk feed/cron data updates. Disabled retains cached PASS
+  answers until TTL expiry; enabled gives immediate allow→block enforcement at the cost of
+  discarding unrelated cached answers.
   Alerts Custom_List add, exact whitelist deletion, and Lock instead flush the validated domain
   plus `www.`; wildcard whitelist deletion clears the full cache; whitelist add and Unlock need
   no flush. Normal settings-page whitelist changes remain config-class updates and restart

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -60,6 +60,8 @@ exclusions.
   `pfb_cfg_*_read/write` delegations) in `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc`:
   - `dnsbl_lenient` / `pfb_keep` → `PfbLenient` (`'on'`/`'off'`); `dnsbl_vip_auto` and ~76 other
     `'on'`/`''` checkbox fields → `PfbToggle` (off-value `''`).
+  - **`pfb_cache_flush` → `PfbToggle`**: default Off; enables the post-handshake full Unbound
+    cache flush for bulk zero-downtime DNSBL data swaps.
   - **`pfb_alias_delta_mode` → `PfbAliasDeltaMode`** (ADR-40, registry adapters
     `pfb_cfg_alias_delta_mode_read/write`): tokens `'auto'` (new-install default) / `'delta'` /
     `'replace'`. Unknown or absent token reads as `Auto`. **Grandfather seed:** an already-configured

--- a/docs/research/unbound-reload-strategies.md
+++ b/docs/research/unbound-reload-strategies.md
@@ -40,8 +40,9 @@ For a data-only update, the running Python module remains loaded:
 4. Python atomically replaces the live snapshot and clears its `decisionDB` memo.
 5. Python publishes an applied-generation marker.
 6. PHP waits for that marker before returning.
-7. A bulk update clears Unbound's full message and RRset caches; exact Alerts allow→block edits
-   instead flush only their validated domain and `www.` sibling.
+7. When the default-off **Clear Resolver Cache** option is enabled, a bulk update clears
+   Unbound's full message and RRset caches. Exact Alerts allow→block edits instead flush only
+   their validated domain and `www.` sibling regardless of that option.
 
 The implementation and fallback gates are in
 [`pfb_reload_unbound()`](../../src/usr/local/pkg/pfblockerng/pfblockerng.inc#L9465-L9554).
@@ -134,11 +135,13 @@ one-directional:
 - Allow to block may keep serving the previously resolved real answer until its TTL expires.
 
 Bulk feed updates do not have a cheap exact effective delta because wildcard rules, regular
-expressions, ABP priority, TLD/IDN policy, and allow rules can all change the result. After the
-Python applied-generation handshake succeeds, the bulk caller therefore runs
-`unbound-control flush_zone +c .`, which clears the full message and RRset caches without pausing
-or restarting Unbound. A data-path restart fallback does not restore the pre-update cache; normal
-settings-page whitelist changes remain config-class updates and restart Unbound.
+expressions, ABP priority, TLD/IDN policy, and allow rules can all change the result. The
+default-off **Clear Resolver Cache** option therefore lets the operator choose between retaining
+cached PASS answers until TTL expiry and immediate allow→block enforcement. When enabled, the
+bulk caller runs `unbound-control flush_zone +c .` after the Python applied-generation handshake
+succeeds, clearing the full message and RRset caches without pausing or restarting Unbound. A
+data-path restart fallback does not restore the pre-update cache; normal settings-page whitelist
+changes remain config-class updates and restart Unbound.
 
 Alerts cache treatment follows transition direction after `pfb_reload_unbound()` returns.
 Custom_List add, exact whitelist deletion, and Lock flush the validated domain and its `www.`
@@ -170,7 +173,7 @@ Cache choice depends on semantics:
 | Logging, telemetry, or other answer-neutral setting | Keep cache |
 | Exact Alerts allow→block edit | Keep cache and flush the validated single-domain set after the snapshot is confirmed applied |
 | Alerts wildcard-whitelist removal | Clear the full message and RRset caches after the snapshot is confirmed applied |
-| Bulk generation load | Clear the full message and RRset caches after the snapshot is confirmed applied |
+| Bulk generation load | User-selected: retain caches by default, or clear the full message and RRset caches after the snapshot is confirmed applied |
 | Regex, TLD, IDN, SafeSearch, response-shape, or other broad DNS-policy change | Clear the native cache |
 | Python module inclusion/removal | Clear the native cache unless live testing proves retained entries cannot violate the new policy |
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8110,6 +8110,10 @@ function pfb_unbound_py_flip_sentinel() {
 	if (!pfb_unbound_py_atomic_write($sentinel, "{$next}\n")) {
 		return FALSE;
 	}
+	$published_hook = $GLOBALS['pfb_test_unbound_py_sentinel_published'] ?? NULL;
+	if (is_callable($published_hook)) {
+		$published_hook($sentinel, $next);
+	}
 
 	// Return the generation just published (>= 1) so the caller can wait for the
 	// watcher's applied-generation marker to reach it -- the readiness handshake that

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2780,6 +2780,7 @@ function pfb_global() {
 	$pfb['dnsbl_top1m']	= $pfb['dnsblconfig']['alexa_enable'];							// TOP1M whitelist
 	$pfb['dnsbl_top1m_type']	= PfbConfig::read('alexa_type');						// TOP1M type (PfbTop1mSource enum; legacy 'alexa' coalesces to Tranco, #877) (default Tranco)
 	$pfb['dnsbl_res_cache']	= $pfb['dnsblconfig']['pfb_cache'];							// DNSBL Option to backup/restore Resolver cache
+	$pfb['dnsbl_cache_flush']	= PfbConfig::read('pfb_cache_flush');						// Opt-in full cache flush after DNSBL data swaps
 	$pfb['dnsbl_global_log']= PfbConfig::read('global_log');							// Global Logging/Blocking mode (default '')
 	// ADR-22: lenient feed parsing. 'on' = permissive scheme strip (today); anything else =
 	// strict RFC 3986 scheme validation + URL-path rejection. New installs default OFF
@@ -9734,11 +9735,12 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython, array $dnsbl_tld_grou
 		// unchanged). The manifest + per-feed raw were already published atomically by
 		// pfb_unbound_python_sources() above; flip the sentinel, no restart. A config
 		// change ($pfbpython TRUE) -> $datapath FALSE -> the restart path. The bulk
-		// fast path flushes the full resolver cache after the applied-generation handshake;
-		// config restarts preserve cache, data fallback clears it by passing FALSE.
+		// fast path optionally flushes the full resolver cache after the applied-generation
+		// handshake; config restarts preserve cache, data fallback clears it by passing FALSE.
 		$datapath = !$pfbpython;
 		$swapped = pfb_reload_unbound($mode, !$datapath, $pfbpython, $datapath);
-		if ($datapath && $swapped) {
+		if ($datapath && $swapped &&
+		    pfb_cfg_toggle_read($pfb['dnsbl_cache_flush'] ?? '') === PfbToggle::On) {
 			exec("{$pfb['chroot_cmd']} flush_zone +c . 2>&1");
 		}
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -873,6 +873,14 @@ function pfb_cfg_registry(): array
 			'write_adapter' => NULL,
 		],
 
+		// Full resolver-cache flush after a successful DNSBL data swap. Default off.
+		'pfb_cache_flush' => [
+			'section'       => $dnsbl,
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+		],
+
 		// Global logging/blocking mode. Default ''.
 		'global_log' => [
 			'section'       => $dnsbl,

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -55,6 +55,7 @@ $pconfig['dnsbl_allow_int']	= explode(',', $pfb['dconfig']['dnsbl_allow_int'])	?
 $pconfig['global_log']		= $pfb['dconfig']['global_log']				?: '';
 $pconfig['dnsbl_webpage']	= $pfb['dconfig']['dnsbl_webpage']			?: 'dnsbl_default.php';
 $pconfig['pfb_cache']		= isset($pfb['dconfig']['pfb_cache'])			? $pfb['dconfig']['pfb_cache'] : 'on';
+$pconfig['pfb_cache_flush']	= PfbConfig::read('pfb_cache_flush');
 
 $pconfig['pfb_py_reply']	= isset($pfb['dconfig']['pfb_py_reply'])		? $pfb['dconfig']['pfb_py_reply'] : 'on';
 $pconfig['pfb_hsts']		= isset($pfb['dconfig']['pfb_hsts'])			? $pfb['dconfig']['pfb_hsts'] : 'on';
@@ -800,6 +801,7 @@ if ($_POST) {
 			$pfb['dconfig']['dnsbl_allow_int']	= implode(',', (array)$_POST['dnsbl_allow_int'])			?: '';
 			$pfb['dconfig']['global_log']		= $_POST['global_log']							?: '';
 			$pfb['dconfig']['pfb_cache']		= pfb_filter($_POST['pfb_cache'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
+			$pfb['dconfig']['pfb_cache_flush']	= pfb_filter($_POST['pfb_cache_flush'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 
 			$pfb['dconfig']['pfb_py_reply']		= pfb_filter($_POST['pfb_py_reply'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['pfb_hsts']		= pfb_filter($_POST['pfb_hsts'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
@@ -3210,6 +3212,16 @@ $section->addInput(new Form_Checkbox(
 	pfb_cfg_toggle_read($pconfig['pfb_cache']) === PfbToggle::On,
 	'on'
 ))->setHelp('Default: <strong>Enabled</strong><br />Enable the backup and restore of the DNS Resolver Cache on DNSBL Update|Reload|Cron events');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_cache_flush',
+	gettext('Clear Resolver Cache'),
+	'Enable',
+	pfb_cfg_toggle_read($pconfig['pfb_cache_flush']) === PfbToggle::On,
+	'on'
+))->setHelp('Default: <strong>Disabled</strong><br />When enabled, clear Unbound\'s full resolver cache after a DNSBL data update is applied without restarting Unbound. '
+	. 'This makes newly blocked domains take effect immediately when an allowed answer was already cached, but also discards unrelated answers and can temporarily increase DNS latency and upstream queries. '
+	. 'When disabled, cached allowed answers remain until their DNS TTL expires. Resolver restarts already clear the cache; exact Alerts actions use targeted flushing.');
 
 $section->addInput(new Form_Input(
 	'pfb_py_cache_max',

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -77,6 +77,7 @@ final class CfgGatewayTest extends TestCase
 			'pfb_dnsbl_nonat'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat',
 			'pfb_reuse'        => 'installedpackages/pfblockerng/config/0/pfb_reuse',
 			'pfb_hsts'         => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
+			'pfb_cache_flush'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache_flush',
 			'pfb_feed_sanity'  => 'installedpackages/pfblockerng/config/0/pfb_feed_sanity',
 		];
 
@@ -107,6 +108,7 @@ final class CfgGatewayTest extends TestCase
 			'pfb_dnsbl_nonat'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat',
 			'pfb_reuse'        => 'installedpackages/pfblockerng/config/0/pfb_reuse',
 			'pfb_hsts'         => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
+			'pfb_cache_flush'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache_flush',
 			'pfb_feed_sanity'  => 'installedpackages/pfblockerng/config/0/pfb_feed_sanity',
 		];
 
@@ -297,6 +299,14 @@ final class CfgGatewayTest extends TestCase
 		// When/Then: returns Off (default '').
 		$result = PfbConfig::read('pfb_feed_sanity');
 		$this->assertSame(PfbToggle::Off, $result, 'pfb_feed_sanity absent -> Off (default)');
+	}
+
+	public function testReadReturnsOffDefaultForDnsblCacheFlushAbsentKey(): void
+	{
+		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache_flush';
+		$this->assertNull(config_get_path($path));
+		$this->assertSame(PfbToggle::Off, PfbConfig::read('pfb_cache_flush'),
+			'pfb_cache_flush absent -> Off (default)');
 	}
 
 	public function testReadReturnsRegisteredDefaultForPfbKeepAbsentKey(): void
@@ -1070,6 +1080,7 @@ final class CfgGatewayTest extends TestCase
 			'alexa_inclusion',
 			'top1m_token', // ADR-59 P5
 			'pfb_cache',
+			'pfb_cache_flush',
 			'global_log',
 			'pfb_dnsbl_lenient',
 			'pfb_py_reply',

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -568,9 +568,14 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 			'bulk caller must disable restart cache preservation for datapath updates'
 		);
 		$this->assertStringContainsString(
-			"if (\$datapath && \$swapped) {\n\t\t\texec(\"{\$pfb['chroot_cmd']} flush_zone +c . 2>&1\");\n\t\t}",
+			"pfb_cfg_toggle_read(\$pfb['dnsbl_cache_flush'] ?? '') === PfbToggle::On",
 			$update_region,
-			'bulk caller must full-flush only after a successful applied-generation swap'
+			'bulk caller must gate the full flush on the default-off DNSBL option'
+		);
+		$this->assertStringContainsString(
+			'exec("{$pfb[\'chroot_cmd\']} flush_zone +c . 2>&1");',
+			$update_region,
+			'bulk caller must retain the post-handshake full-flush command'
 		);
 	}
 

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -567,15 +567,12 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 			$update_region,
 			'bulk caller must disable restart cache preservation for datapath updates'
 		);
-		$this->assertStringContainsString(
-			"pfb_cfg_toggle_read(\$pfb['dnsbl_cache_flush'] ?? '') === PfbToggle::On",
+		$this->assertMatchesRegularExpression(
+			'/if \(\$datapath && \$swapped &&\s*'
+			. 'pfb_cfg_toggle_read\(\$pfb\[\x27dnsbl_cache_flush\x27\] \?\? \x27\x27\) === PfbToggle::On\) \{\s*'
+			. 'exec\("\{\$pfb\[\x27chroot_cmd\x27\]\} flush_zone \+c \. 2>&1"\);\s*\}/s',
 			$update_region,
-			'bulk caller must gate the full flush on the default-off DNSBL option'
-		);
-		$this->assertStringContainsString(
-			'exec("{$pfb[\'chroot_cmd\']} flush_zone +c . 2>&1");',
-			$update_region,
-			'bulk caller must retain the post-handshake full-flush command'
+			'bulk caller must keep the full flush inside the successful data-swap and default-off option guard'
 		);
 	}
 

--- a/tests/php/PfbUpdateUnboundCachePolicyTest.php
+++ b/tests/php/PfbUpdateUnboundCachePolicyTest.php
@@ -99,7 +99,11 @@ final class PfbUpdateUnboundCachePolicyTest extends TestCase
 		} else {
 			unset($GLOBALS['config']['unbound']);
 		}
-		unset($GLOBALS['pfb_test_process_running'], $GLOBALS['pfb_test_sysctl']);
+		unset(
+			$GLOBALS['pfb_test_process_running'],
+			$GLOBALS['pfb_test_sysctl'],
+			$GLOBALS['pfb_test_unbound_py_sentinel_published']
+		);
 		foreach (glob("{$this->dir}/*") ?: [] as $file) {
 			@unlink($file);
 		}
@@ -110,11 +114,28 @@ final class PfbUpdateUnboundCachePolicyTest extends TestCase
 	private function installRecorder(string $log): void
 	{
 		$marker = escapeshellarg("{$this->dir}/pfb_py_reload.applied");
+		$runtime_log = escapeshellarg($GLOBALS['pfb']['log']);
 		file_put_contents(
 			$GLOBALS['pfb']['chroot_cmd'],
-			"#!/bin/sh\nprintf '%s|applied=%s\\n' \"\$*\" \"\$(cat {$marker})\" >> " . escapeshellarg($log) . "\n"
+			"#!/bin/sh\n"
+			. "if grep -q 'zero-downtime swap.*completed' {$runtime_log}; then completed=1; else completed=0; fi\n"
+			. "printf '%s|applied=%s|completed=%s\\n' \"\$*\" \"\$(cat {$marker})\" \"\$completed\" >> "
+			. escapeshellarg($log) . "\n"
 		);
 		chmod($GLOBALS['pfb']['chroot_cmd'], 0755);
+	}
+
+	private function installAppliedMarkerWatcher(): void
+	{
+		$sentinel = "{$this->dir}/pfb_py_reload";
+		$applied = "{$this->dir}/pfb_py_reload.applied";
+		file_put_contents($sentinel, "1\n");
+		file_put_contents($applied, "1\n");
+		$GLOBALS['pfb_test_unbound_py_sentinel_published'] = static function (string $path, int $generation) use ($sentinel, $applied): void {
+			if ($path === $sentinel) {
+				file_put_contents($applied, "{$generation}\n");
+			}
+		};
 	}
 
 	private function runUpdateIgnoringMacOsTempnamNotice(): void
@@ -133,9 +154,16 @@ final class PfbUpdateUnboundCachePolicyTest extends TestCase
 	{
 		$log = "{$this->dir}/control.log";
 		$this->installRecorder($log);
+		$this->installAppliedMarkerWatcher();
 
 		$this->runUpdateIgnoringMacOsTempnamNotice();
 
+		$this->assertSame("2\n", file_get_contents("{$this->dir}/pfb_py_reload.applied"),
+			'default-disabled assertion must follow a fresh generation application');
+		$runtime_log = file_get_contents($GLOBALS['pfb']['log']);
+		$this->assertNotFalse($runtime_log, 'bulk update must write its successful reload path');
+		$this->assertStringContainsString('[ zero-downtime swap ] completed', $runtime_log,
+			'default-disabled assertion must follow a completed data swap');
 		$lines = file_exists($log) ? (file($log, FILE_IGNORE_NEW_LINES) ?: []) : [];
 		$this->assertSame([], $lines,
 			'default-disabled bulk cache clearing must retain Unbound cache after a successful swap');
@@ -145,6 +173,7 @@ final class PfbUpdateUnboundCachePolicyTest extends TestCase
 	{
 		$log = "{$this->dir}/control.log";
 		$this->installRecorder($log);
+		$this->installAppliedMarkerWatcher();
 		$GLOBALS['pfb']['dnsbl_cache_flush'] = 'on';
 		$this->assertTrue(pfb_unbound_py_mode_active(), 'test setup must enable live Python mode');
 		$this->assertTrue(pfb_unbound_py_swap_fits_ram(), 'test setup must allow the data swap');
@@ -152,9 +181,11 @@ final class PfbUpdateUnboundCachePolicyTest extends TestCase
 
 		$this->runUpdateIgnoringMacOsTempnamNotice();
 
+		$this->assertSame("2\n", file_get_contents("{$this->dir}/pfb_py_reload.applied"),
+			'cache flush must follow a fresh generation application');
 		$lines = file($log, FILE_IGNORE_NEW_LINES);
 		$this->assertNotFalse($lines, 'bulk update must invoke the configured control command');
-		$this->assertSame(['flush_zone +c .|applied=1'], $lines,
+		$this->assertSame(['flush_zone +c .|applied=2|completed=1'], $lines,
 			'full cache flush must be issued by the bulk caller after the applied marker is live');
 	}
 

--- a/tests/php/PfbUpdateUnboundCachePolicyTest.php
+++ b/tests/php/PfbUpdateUnboundCachePolicyTest.php
@@ -6,9 +6,9 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_update_unbound() owns the bulk DNSBL cache policy. A successful data swap
- * flushes the full cache only after the applied-generation handshake; a restart
- * fallback does not restore a stale dump and does not issue a post-swap flush.
+ * pfb_update_unbound() owns the opt-in bulk DNSBL cache policy. A successful data
+ * swap retains the cache by default; when enabled, the full flush happens only after
+ * the applied-generation handshake. Restart fallback never issues a post-swap flush.
  */
 #[CoversFunction('pfb_update_unbound')]
 final class PfbUpdateUnboundCachePolicyTest extends TestCase
@@ -27,6 +27,7 @@ final class PfbUpdateUnboundCachePolicyTest extends TestCase
 			'dnsbldir', 'dbdir', 'dnsbl_file', 'dnsdir', 'dnsbl_cache', 'unbound_py_count',
 			'unbound_py_sources', 'unbound_py_rawdir', 'unbound_py_data', 'unbound_py_zone',
 			'unbound_py_reject_stats', 'chroot_cmd', 'dnsbl_python_unmount', 'dnsbl_res_cache',
+			'dnsbl_cache_flush',
 			'enable', 'dnsbl', 'save', 'dnsbl_tld_wildcard', 'domain_update', 'reuse_dnsbl',
 			'dnsbl_unlock', 'keep', 'install', 'errlog', 'log',
 		] as $key) {
@@ -54,6 +55,7 @@ final class PfbUpdateUnboundCachePolicyTest extends TestCase
 			'chroot_cmd' => "{$this->dir}/unbound-control-recorder",
 			'dnsbl_python_unmount' => FALSE,
 			'dnsbl_res_cache' => 'on',
+			'dnsbl_cache_flush' => '',
 			'enable' => 'on',
 			'dnsbl' => 'on',
 			'save' => TRUE,
@@ -127,10 +129,23 @@ final class PfbUpdateUnboundCachePolicyTest extends TestCase
 		}
 	}
 
-	public function testSuccessfulBulkSwapFlushesOnlyAfterAppliedGeneration(): void
+	public function testDefaultDisabledBulkSwapRetainsResolverCache(): void
 	{
 		$log = "{$this->dir}/control.log";
 		$this->installRecorder($log);
+
+		$this->runUpdateIgnoringMacOsTempnamNotice();
+
+		$lines = file_exists($log) ? (file($log, FILE_IGNORE_NEW_LINES) ?: []) : [];
+		$this->assertSame([], $lines,
+			'default-disabled bulk cache clearing must retain Unbound cache after a successful swap');
+	}
+
+	public function testEnabledBulkSwapFlushesOnlyAfterAppliedGeneration(): void
+	{
+		$log = "{$this->dir}/control.log";
+		$this->installRecorder($log);
+		$GLOBALS['pfb']['dnsbl_cache_flush'] = 'on';
 		$this->assertTrue(pfb_unbound_py_mode_active(), 'test setup must enable live Python mode');
 		$this->assertTrue(pfb_unbound_py_swap_fits_ram(), 'test setup must allow the data swap');
 		$this->assertTrue(is_process_running('unbound'), 'test setup must keep Unbound running');
@@ -147,6 +162,7 @@ final class PfbUpdateUnboundCachePolicyTest extends TestCase
 	{
 		$log = "{$this->dir}/control.log";
 		$this->installRecorder($log);
+		$GLOBALS['pfb']['dnsbl_cache_flush'] = 'on';
 		$checks = 0;
 		$GLOBALS['pfb_test_sysctl']['hw.usermem'] = '1';
 		$GLOBALS['pfb_test_process_running']['unbound'] = static function () use (&$checks): bool {

--- a/tests/php/WwwGroupAGatewayTest.php
+++ b/tests/php/WwwGroupAGatewayTest.php
@@ -359,6 +359,7 @@ final class WwwGroupAGatewayTest extends TestCase
 			'global_log'                 => '',
 			'dnsbl_webpage'              => 'dnsbl_default.php',
 			'pfb_cache'                  => 'on',
+			'pfb_cache_flush'            => 'on',
 			'pfb_py_reply'               => 'on',
 			'pfb_hsts'                   => 'on',
 			'pfb_idn'                    => 'off',

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -121,6 +121,7 @@ class RequireConfigGatewaySniff implements Sniff
 		// ADR-59 P5: masked Cloudflare Radar Bearer token
 		'installedpackages/pfblockerngdnsblsettings/config/0/top1m_token',
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache',
+		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache_flush',
 		'installedpackages/pfblockerngdnsblsettings/config/0/global_log',
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_lenient',
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_py_reply',

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1557,6 +1557,37 @@ def set_dnsbl_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
         )
 
 
+def set_dnsbl_cache_flush(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
+    """Toggle the opt-in full resolver-cache flush after DNSBL data swaps."""
+    val = "on" if on else ""
+    snippet = (
+        f"$d = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
+        f"$d['pfb_cache_flush'] = {_php_str(val)};\n"
+        f"config_set_path({_php_str(CFG_DNSBL_SETTINGS)}, $d);\n"
+        "write_config('pfBlockerNG smoke: toggle pfb_cache_flush');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"set_dnsbl_cache_flush({on}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
+class DnsblCacheFlushEnabled:
+    """Enable bulk cache flushing for one smoke case, then restore its default."""
+
+    def __init__(self, vm: SmokeVM) -> None:
+        self.vm = vm
+
+    def __enter__(self) -> DnsblCacheFlushEnabled:
+        set_dnsbl_cache_flush(self.vm, True)
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        set_dnsbl_cache_flush(self.vm, False)
+
+
 def set_package_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
     """Toggle the pfBlockerNG MASTER switch (``enable_cb``) at ``CFG_GLOBAL``.
 
@@ -4076,8 +4107,9 @@ def flush_unbound_name(vm: SmokeVM, name: str, *, timeout: float = 30.0) -> None
     """Flush a SINGLE name from Unbound's C message cache (``unbound-control flush <name>``).
 
     Generic smoke-test utility for cases that need independent probes. Production bulk
-    swaps clear the full cache after the applied-generation handshake; exact Alerts
-    allow-to-block edits use the targeted equivalent for their validated domain.
+    swaps can clear the full cache after the applied-generation handshake when the user
+    enables that option; exact Alerts allow-to-block edits use the targeted equivalent
+    for their validated domain.
     """
     result = vm.ssh("/usr/local/sbin/unbound-control", "-c", UNBOUND_CONF, "flush", name, timeout=timeout)
     if result.returncode != 0:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1584,8 +1584,17 @@ class DnsblCacheFlushEnabled:
         set_dnsbl_cache_flush(self.vm, True)
         return self
 
-    def __exit__(self, *_exc: object) -> None:
-        set_dnsbl_cache_flush(self.vm, False)
+    def __exit__(self, *exc: object) -> None:
+        try:
+            set_dnsbl_cache_flush(self.vm, False)
+        except Exception as reset_exc:  # noqa: BLE001
+            if exc and exc[0] is not None:
+                print(
+                    "[smoke] cache-flush option restore failed during teardown "
+                    f"(suppressed; original error stands): {reset_exc!r}"
+                )
+            else:
+                raise
 
 
 def set_package_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -789,10 +789,9 @@ def test_dnsbl_feed_update_no_restart(deployed_vm: SmokeVM, client_vm: SmokeVM, 
     * AFTER: the name is BLOCKED (VIP), Unbound's pid is UNCHANGED (no restart), and the
       pfBlockerNG log gained a ``zero-downtime swap`` fast-path line.
 
-    NO-FALLBACK NOTE: a config-clean feed-content re-fetch IS reliably the no-restart path
-    (the brief's primary route), so this exercises a genuine feed update — not the #51 lock
-    substitute. The enabled post-handshake full cache flush removes the name's prior resolved
-    answer before the first post-reload probe observes the swapped block.
+    NO-FALLBACK NOTE: a config-clean feed-content re-fetch reliably takes the no-restart
+    path. The enabled post-handshake full cache flush removes the name's prior resolved answer
+    before the first post-reload probe observes the swapped block.
     """
     domain = h.unique_domain("feedupd")
     other = h.unique_domain("feedupd-filler")

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -490,12 +490,12 @@ def test_dnsbl_resolve_block_unlock_relock_lifecycle(
     # (b) Now put it on a DNSBL feed -> the SAME domain is now BLOCKED (VIP).
     feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_unlock.txt", f"{domain}\n")
     spec = h.DnsblCase(aliasname="smokeunlock", feed_url=feed_url, header="smokeunlock", mode=h.DnsblMode.VIP)
-    with h.CaseContext(deployed_vm, spec):
+    with h.DnsblCacheFlushEnabled(deployed_vm), h.CaseContext(deployed_vm, spec):
         h.unblock_egress()  # the allowed probes (a-shape) must reach the controlled stub
         # Listing the name is the feed/swap allow->block direction: the module already
-        # mounted (a prior case), so first-enable applies via the no-restart swap, which
-        # Bulk data applies flush Unbound's full message + RRset caches after the
-        # applied-generation handshake, so the pre-resolved answer cannot survive.
+        # mounted (a prior case), so first-enable applies via the no-restart swap. The
+        # opt-in bulk policy flushes Unbound's full message + RRset caches after
+        # the applied-generation handshake, so the pre-resolved answer cannot survive.
         blocked = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_vip(blocked), f"{domain} still resolving after block: {blocked}"
 
@@ -724,7 +724,7 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(
     # No host override on the name — it would shadow the DNSBL block (served as
     # local-data before the python module); an allowed name resolves via the stub.
     spec = h.DnsblCase(aliasname="smokeunlocktmp", feed_url=feed_url, header="smokeunlocktmp", mode=h.DnsblMode.VIP)
-    with h.CaseContext(deployed_vm, spec):
+    with h.DnsblCacheFlushEnabled(deployed_vm), h.CaseContext(deployed_vm, spec):
         # Egress OPEN: the update path deadlocks under a dark egress, and the allowed
         # (unlock) probe must reach the controlled stub. The block probes return the VIP
         # locally, so there is no false-green from leaving egress open.
@@ -746,8 +746,8 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(
         # forces the reload + clears the manifest's user_unlock. It is a config-clean
         # DNSBL-data update -> the no-restart fast path (data_path=True waits on the swap).
         h.reload(deployed_vm, "update", data_path=True)
-        # The Force-update re-lock is a bulk data apply; its post-handshake full cache
-        # flush clears the prior resolved answer before the swapped re-block is observed.
+        # The enabled post-handshake full-cache flush clears the prior resolved answer
+        # before the swapped re-block is observed.
         relocked = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_vip(relocked), f"re-locked {domain} still resolving: {relocked}"
 
@@ -784,14 +784,15 @@ def test_dnsbl_feed_update_no_restart(deployed_vm: SmokeVM, client_vm: SmokeVM, 
       update in python mode routes through the no-restart data fast path
       (``pfb_update_unbound`` -> ``pfb_reload_unbound($mode, !$datapath, $pfbpython, $datapath)``,
       inc:4151), so PHP flips the sentinel and the watcher swaps the snapshot. The bulk
-      caller then clears the full resolver cache after the applied-generation handshake.
+      caller then clears the full resolver cache after the applied-generation handshake
+      because this test explicitly enables the default-off cache-flush option.
     * AFTER: the name is BLOCKED (VIP), Unbound's pid is UNCHANGED (no restart), and the
       pfBlockerNG log gained a ``zero-downtime swap`` fast-path line.
 
     NO-FALLBACK NOTE: a config-clean feed-content re-fetch IS reliably the no-restart path
     (the brief's primary route), so this exercises a genuine feed update — not the #51 lock
-    substitute. The post-handshake full cache flush removes the name's prior resolved answer
-    before the first post-reload probe observes the swapped block.
+    substitute. The enabled post-handshake full cache flush removes the name's prior resolved
+    answer before the first post-reload probe observes the swapped block.
     """
     domain = h.unique_domain("feedupd")
     other = h.unique_domain("feedupd-filler")
@@ -800,7 +801,7 @@ def test_dnsbl_feed_update_no_restart(deployed_vm: SmokeVM, client_vm: SmokeVM, 
     feed_name = "smoke_dnsbl_feedupd.txt"
     feed_url = h.write_local_feed(deployed_vm, feed_name, f"{other}\n")
     spec = h.DnsblCase(aliasname="smokefeedupd", feed_url=feed_url, header="smokefeedupd", mode=h.DnsblMode.VIP)
-    with h.CaseContext(deployed_vm, spec):
+    with h.DnsblCacheFlushEnabled(deployed_vm), h.CaseContext(deployed_vm, spec):
         h.unblock_egress()  # the allowed (before-state) probe must reach the controlled stub
 
         # BEFORE: the target is not on the feed yet -> it RESOLVES via the stub sentinel.

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -225,6 +225,12 @@ FLOWS: tuple[ToggleFlow, ...] = (
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache",
     ),
     ToggleFlow(
+        name="dnsbl_cache_flush",
+        page="/pfblockerng/pfblockerng_dnsbl.php",
+        field="pfb_cache_flush",
+        config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache_flush",
+    ),
+    ToggleFlow(
         name="dnsbl_py_nolog",
         page="/pfblockerng/pfblockerng_dnsbl.php",
         field="pfb_py_nolog",

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1580,6 +1580,18 @@ def test_feeds_custom_panel_heading_renders(webui: WebUI, php_error_log_guard: P
     )
 
 
+def test_dnsbl_cache_flush_option_renders(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """DNSBL page exposes the default-off full-cache trade-off without PHP diagnostics."""
+    path = "/pfblockerng/pfblockerng_dnsbl.php"
+    resp = webui.get(path)
+    result = evaluate_render(path, resp.status_code, resp.text, ("DNSBL Configuration",))
+    assert result.ok, f"DNSBL cache-flush render oracle failed: {result.detail}"
+    assert 'name="pfb_cache_flush"' in resp.text, "DNSBL page is missing the cache-flush checkbox"
+    assert "When disabled, cached allowed answers remain until their DNS TTL expires" in resp.text, (
+        "DNSBL cache-flush help must explain the default-disabled TTL trade-off"
+    )
+
+
 def test_states_removal_help_references_ip_tab(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """The category-edit 'States Removal' help points at the IP tab, where 'Kill States' lives.
 


### PR DESCRIPTION
## Summary

- add a default-disabled **Clear Resolver Cache** DNSBL option
- when enabled, run `flush_zone +c .` only after a successful applied-generation bulk data swap
- keep restart and Alerts cache policies unchanged
- document the TTL versus immediate-enforcement trade-off, including the research note introduced by d4319a6b
- cover config gateway, default/enabled/fallback branches, Tier-A rendering, functional persistence, and live-smoke state cleanup

## Verification

- test-first RED: default-off test failed against unconditional flushing
- mutation RED: removing the successful-swap gate failed the restart-fallback test
- focused PHPUnit: 151 tests, 1,436 assertions
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS
- independent top-tier review: CLEAN after one blocking test-honesty fix
- smoke/UI collection: 176 tests collected; appliance execution delegated to CI

Fixes #1615

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Resolver cache flush / Clear Resolver Cache** DNSBL setting (default **Off**).
  * When enabled, DNSBL bulk updates perform a full resolver cache flush **only after** the applied-generation handshake; when disabled, cached allowed results are retained until DNS TTL expiry.
  * Includes UI, configuration gateway, and persistence support for the new toggle.
* **Documentation**
  * Updated lifecycle and ADR guidance to reflect the configurable, opt-in cache-flush behavior.
* **Tests**
  * Expanded unit, UI, and smoke coverage for default-off vs enabled timing and command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->