### PR TITLE
build: support staged package manifests

### DIFF
--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -7,9 +7,9 @@
 # port's textual substitutions, and (c) emitting a libpkg-format archive with the
 # right manifest. This tool replicates exactly that, portably (Linux + macOS),
 # by *executing the port's own do-extract/post-extract/do-install recipe* and
-# *reading its pkg-plist* — never a hardcoded, pfBlockerNG-specific file list. So
-# when the port gains files or changes dependencies, this tool keeps up: it reads
-# the same Makefile/plist the real `make package` reads.
+# consuming either its static pkg-plist or its staged dynamic plist — never a
+# hardcoded, pfBlockerNG-specific file list. So when the port gains files or
+# changes dependencies, this tool keeps up with the real `make package` inputs.
 #
 # It supports BOTH port layouts:
 #   * USE_GITHUB  (FreeBSD-ports branch pfblockerng/use-github): source fetched
@@ -43,6 +43,7 @@
 from __future__ import annotations
 
 import argparse
+import glob
 import hashlib
 import io
 import json
@@ -377,6 +378,20 @@ class Recipe:
             line = line[1:].lstrip()
         if not line:
             return
+        copytree = re.fullmatch(
+            r'\(cd\s+(.+?)\s+&&\s+\$\{COPYTREE_SHARE\}\s+\.\s+(\S+)(?:\s+"([^"]*)")?\)',
+            line,
+        )
+        if copytree:
+            args = [self.mk.expand(copytree.group(1)), self.mk.expand(copytree.group(2))]
+            if copytree.group(3) is not None:
+                args.append(self.mk.expand(copytree.group(3)))
+            self._cmd_copytree_share(args)
+            return
+        # A dynamic plist's FIND|SED pipeline only describes the staged files.
+        # The portable builder derives that same manifest directly from STAGEDIR.
+        if line.startswith("${FIND} ") and "${SED}" in line and "${TMPPLIST}" in line and ">>" in line:
+            return
         # A recipe command is either a ${MACRO} (e.g. ${INSTALL_DATA}) or a bare
         # command word (e.g. post-extract's literal `mv`). Both map to _cmd_<name>.
         m = re.match(r"^\$[{(]([A-Za-z_][A-Za-z0-9_]*)[})]\s*(.*)$", line)
@@ -426,7 +441,15 @@ class Recipe:
         if len(positional) < 2:
             raise BuildError(f"INSTALL with too few paths: {args!r}")
         dest = positional[-1]
-        srcs = positional[:-1]
+        srcs: list[str] = []
+        for source in positional[:-1]:
+            matches = glob.glob(source)
+            if glob.has_magic(source):
+                if not matches:
+                    raise BuildError(f"install source glob matched nothing: {source}")
+                srcs.extend(matches)
+            else:
+                srcs.append(source)
         dest_p = Path(dest)
         dest_is_dir = dest_p.is_dir() or dest.endswith("/") or len(srcs) > 1
         for s in srcs:
@@ -435,6 +458,8 @@ class Recipe:
                 raise BuildError(f"install source missing: {s}")
             target = dest_p / sp.name if dest_is_dir else dest_p
             target.parent.mkdir(parents=True, exist_ok=True)
+            if target.exists():
+                target.unlink()
             shutil.copyfile(sp, target)
             os.chmod(target, int(perm, 8))
             self.modes[self._install_path(target)] = perm
@@ -446,6 +471,33 @@ class Recipe:
         # INSTALL_SCRIPT installs with ${BINMODE}, which is 0555 on FreeBSD
         # (installed scripts/binaries are not writable) — NOT 0755.
         self._install(args, "0555")
+
+    def _cmd_copytree_share(self, args: list[str]) -> None:
+        if len(args) not in (2, 3):
+            raise BuildError(f"COPYTREE_SHARE expects source, destination, and optional filter: {args!r}")
+        source, destination = (Path(arg) for arg in args[:2])
+        artifact_filter = ["!", "-name", ".DS_Store", "!", "-name", "*.pyc", "!", "-path", "*/__pycache__/*"]
+        if len(args) == 3 and shlex.split(args[2]) != artifact_filter:
+            raise BuildError(f"unsupported COPYTREE_SHARE filter: {args[2]!r}")
+        if not source.is_dir():
+            raise BuildError(f"COPYTREE_SHARE source is not a directory: {source}")
+        for item in source.rglob("*"):
+            if item.is_symlink():
+                raise BuildError(f"COPYTREE_SHARE symlinks are not supported: {item}")
+            relative = item.relative_to(source)
+            if len(args) == 3 and (
+                item.name == ".DS_Store" or item.suffix == ".pyc" or "__pycache__" in relative.parts
+            ):
+                continue
+            target = destination / relative
+            if item.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                os.chmod(target, 0o755)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(item, target)
+            os.chmod(target, 0o644)
+            self.modes[self._install_path(target)] = "0644"
 
     def _cmd_mv(self, args: list[str]) -> None:
         # Drop flags (e.g. -f), then split into (sources, dest).
@@ -1481,18 +1533,25 @@ def run_build(args: argparse.Namespace) -> Build:
     stagedir = Path(seed["STAGEDIR"])
     staged_paths = {"/" + os.path.relpath(p, stagedir): p for p in stagedir.rglob("*") if p.is_file()}
 
-    plist_path = portdir / "pkg-plist"
-    plist_sub = {"DATADIR": "share/" + portname, "PORTNAME": portname, "PORTVERSION": mk.get("PORTVERSION")}
-    plist_files, plist_dirs = parse_plist(plist_path.read_text(), plist_sub, prefix)
-
-    plist_set = set(plist_files)
     staged_set = set(staged_paths)
-    missing = plist_set - staged_set
-    extra = staged_set - plist_set
-    if missing:
-        raise BuildError("plist lists files the recipe did not stage:\n  " + "\n  ".join(sorted(missing)))
-    if extra:
-        raise BuildError("recipe staged files not in the plist:\n  " + "\n  ".join(sorted(extra)))
+    plist_path = portdir / "pkg-plist"
+    if plist_path.is_file():
+        plist_sub = {
+            "DATADIR": "share/" + portname,
+            "PORTNAME": portname,
+            "PORTVERSION": mk.get("PORTVERSION"),
+        }
+        plist_files, plist_dirs = parse_plist(plist_path.read_text(), plist_sub, prefix)
+        plist_set = set(plist_files)
+        missing = plist_set - staged_set
+        extra = staged_set - plist_set
+        if missing:
+            raise BuildError("plist lists files the recipe did not stage:\n  " + "\n  ".join(sorted(missing)))
+        if extra:
+            raise BuildError("recipe staged files not in the plist:\n  " + "\n  ".join(sorted(extra)))
+    else:
+        plist_set = staged_set
+        plist_dirs = [_abspath(path, prefix) for path in shlex.split(mk.get("PLIST_DIRS"))]
 
     for ip in sorted(plist_set):
         perm = recipe.modes.get(ip, "0644")

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -379,13 +379,11 @@ class Recipe:
         if not line:
             return
         copytree = re.fullmatch(
-            r'\(cd\s+(.+?)\s+&&\s+\$\{COPYTREE_SHARE\}\s+\.\s+(\S+)(?:\s+"([^"]*)")?\)',
+            r"\(cd\s+(.+?)\s+&&\s+\$\{COPYTREE_SHARE\}\s+\.\s+(\S+)\)",
             line,
         )
         if copytree:
             args = [self.mk.expand(copytree.group(1)), self.mk.expand(copytree.group(2))]
-            if copytree.group(3) is not None:
-                args.append(self.mk.expand(copytree.group(3)))
             self._cmd_copytree_share(args)
             return
         # A dynamic plist's FIND|SED pipeline only describes the staged files.
@@ -473,22 +471,15 @@ class Recipe:
         self._install(args, "0555")
 
     def _cmd_copytree_share(self, args: list[str]) -> None:
-        if len(args) not in (2, 3):
-            raise BuildError(f"COPYTREE_SHARE expects source, destination, and optional filter: {args!r}")
-        source, destination = (Path(arg) for arg in args[:2])
-        artifact_filter = ["!", "-name", ".DS_Store", "!", "-name", "*.pyc", "!", "-path", "*/__pycache__/*"]
-        if len(args) == 3 and shlex.split(args[2]) != artifact_filter:
-            raise BuildError(f"unsupported COPYTREE_SHARE filter: {args[2]!r}")
+        if len(args) != 2:
+            raise BuildError(f"COPYTREE_SHARE expects source and destination: {args!r}")
+        source, destination = (Path(arg) for arg in args)
         if not source.is_dir():
             raise BuildError(f"COPYTREE_SHARE source is not a directory: {source}")
         for item in source.rglob("*"):
             if item.is_symlink():
                 raise BuildError(f"COPYTREE_SHARE symlinks are not supported: {item}")
             relative = item.relative_to(source)
-            if len(args) == 3 and (
-                item.name == ".DS_Store" or item.suffix == ".pyc" or "__pycache__" in relative.parts
-            ):
-                continue
             target = destination / relative
             if item.is_dir():
                 target.mkdir(parents=True, exist_ok=True)
@@ -998,7 +989,12 @@ def acquire_source(mk: Makefile, workdir: Path, args: argparse.Namespace) -> Pat
                 f"--local-src {local} does not look like a pfBlockerNG checkout (expected a src/ tree containing usr/)"
             )
         # Copy into WRKSRC so post-extract's sed/mv never mutate the working tree.
-        shutil.copytree(src_root, wrksrc, dirs_exist_ok=True)
+        shutil.copytree(
+            src_root,
+            wrksrc,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns(".DS_Store", "*.pyc", "__pycache__"),
+        )
         sys.stderr.write(f"==> source: local working tree {src_root}\n")
         return wrksrc
 

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -329,32 +329,6 @@ def test_recipe_copytree_share_then_script_glob_preserves_payload_and_modes(tmp_
     assert recipe.modes["/usr/local/pkg/app/helper.sh"] == "0555"
 
 
-def test_recipe_copytree_share_excludes_local_artifacts(tmp_path: Path) -> None:
-    src = tmp_path / "src"
-    (src / "usr/local/pkg/app/__pycache__").mkdir(parents=True)
-    (src / "usr/local/pkg/app/app.inc").write_text("<?php\n")
-    (src / "usr/local/pkg/app/.DS_Store").write_text("finder")
-    (src / "usr/local/pkg/app/__pycache__/app.pyc").write_bytes(b"cache")
-    stage = tmp_path / "stage"
-    stage.mkdir()
-
-    mk = make_mk(
-        tmp_path,
-        (
-            f"WRKSRC=\t{src}\nSTAGEDIR=\t{stage}\n"
-            "do-install:\n"
-            "\t(cd ${WRKSRC} && ${COPYTREE_SHARE} . ${STAGEDIR} "
-            "\"! -name .DS_Store ! -name '*.pyc' ! -path '*/__pycache__/*'\")\n"
-        ),
-    )
-
-    bpp.Recipe(mk).run("do-install")
-
-    assert (stage / "usr/local/pkg/app/app.inc").is_file()
-    assert not (stage / "usr/local/pkg/app/.DS_Store").exists()
-    assert not (stage / "usr/local/pkg/app/__pycache__/app.pyc").exists()
-
-
 def test_recipe_install_can_overwrite_a_readonly_staged_file(tmp_path: Path) -> None:
     src = tmp_path / "src"
     src.mkdir()
@@ -417,6 +391,29 @@ def test_safe_extract_rejects_traversal(tmp_path: Path) -> None:
     buf.seek(0)
     with tarfile.open(fileobj=buf) as tf2, pytest.raises(bpp.BuildError):
         bpp._safe_extract(tf2, tmp_path / "dest")
+
+
+def test_local_source_acquisition_excludes_untracked_artifacts(tmp_path: Path) -> None:
+    checkout = tmp_path / "checkout"
+    source = checkout / "src/usr/local/pkg/app"
+    (source / "__pycache__").mkdir(parents=True)
+    (source / "app.inc").write_text("<?php\n")
+    (source / ".DS_Store").write_text("finder")
+    (source / "__pycache__/app.pyc").write_bytes(b"cache")
+    workdir = tmp_path / "work"
+    wrksrc = workdir / "source/src"
+    mk = make_mk(tmp_path, f"USE_GITHUB=\tyes\nWRKSRC=\t{wrksrc}\n")
+
+    result = bpp.acquire_source(
+        mk,
+        workdir,
+        bpp.argparse.Namespace(local_src=str(checkout), gh_tagname=None),
+    )
+
+    assert result == wrksrc
+    assert (wrksrc / "usr/local/pkg/app/app.inc").is_file()
+    assert not (wrksrc / "usr/local/pkg/app/.DS_Store").exists()
+    assert not (wrksrc / "usr/local/pkg/app/__pycache__").exists()
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -303,6 +303,82 @@ def test_recipe_install_modes_mv_sed(tmp_path: Path) -> None:
     assert (stage / "usr/local/etc/tpl.xml").read_text() == "v=9.9\n"  # reinplace applied to staged file
 
 
+def test_recipe_copytree_share_then_script_glob_preserves_payload_and_modes(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    (src / "usr/local/pkg/app").mkdir(parents=True)
+    (src / "usr/local/pkg/app/app.inc").write_text("<?php\n")
+    (src / "usr/local/pkg/app/helper.sh").write_text("#!/bin/sh\n")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+
+    mk = make_mk(
+        tmp_path,
+        (
+            f"WRKSRC=\t{src}\nSTAGEDIR=\t{stage}\nPREFIX=\t/usr/local\n"
+            "do-install:\n"
+            "\t(cd ${WRKSRC} && ${COPYTREE_SHARE} . ${STAGEDIR})\n"
+            "\t${INSTALL_SCRIPT} ${WRKSRC}${PREFIX}/pkg/app/*.sh ${STAGEDIR}${PREFIX}/pkg/app\n"
+        ),
+    )
+    recipe = bpp.Recipe(mk)
+    recipe.run("do-install")
+
+    assert (stage / "usr/local/pkg/app/app.inc").read_text() == "<?php\n"
+    assert (stage / "usr/local/pkg/app/helper.sh").read_text() == "#!/bin/sh\n"
+    assert recipe.modes["/usr/local/pkg/app/app.inc"] == "0644"
+    assert recipe.modes["/usr/local/pkg/app/helper.sh"] == "0555"
+
+
+def test_recipe_copytree_share_excludes_local_artifacts(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    (src / "usr/local/pkg/app/__pycache__").mkdir(parents=True)
+    (src / "usr/local/pkg/app/app.inc").write_text("<?php\n")
+    (src / "usr/local/pkg/app/.DS_Store").write_text("finder")
+    (src / "usr/local/pkg/app/__pycache__/app.pyc").write_bytes(b"cache")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+
+    mk = make_mk(
+        tmp_path,
+        (
+            f"WRKSRC=\t{src}\nSTAGEDIR=\t{stage}\n"
+            "do-install:\n"
+            "\t(cd ${WRKSRC} && ${COPYTREE_SHARE} . ${STAGEDIR} "
+            "\"! -name .DS_Store ! -name '*.pyc' ! -path '*/__pycache__/*'\")\n"
+        ),
+    )
+
+    bpp.Recipe(mk).run("do-install")
+
+    assert (stage / "usr/local/pkg/app/app.inc").is_file()
+    assert not (stage / "usr/local/pkg/app/.DS_Store").exists()
+    assert not (stage / "usr/local/pkg/app/__pycache__/app.pyc").exists()
+
+
+def test_recipe_install_can_overwrite_a_readonly_staged_file(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "helper.sh").write_text("#!/bin/sh\necho first\n")
+    stage = tmp_path / "stage"
+    (stage / "usr/local/bin").mkdir(parents=True)
+
+    mk = make_mk(
+        tmp_path,
+        (
+            f"SRC=\t{src}\nSTAGEDIR=\t{stage}\nPREFIX=\t/usr/local\n"
+            "do-install:\n"
+            "\t${INSTALL_SCRIPT} ${SRC}/helper.sh ${STAGEDIR}${PREFIX}/bin\n"
+            "\t${INSTALL_SCRIPT} ${SRC}/helper.sh ${STAGEDIR}${PREFIX}/bin\n"
+        ),
+    )
+
+    recipe = bpp.Recipe(mk)
+    recipe.run("do-install")
+
+    assert (stage / "usr/local/bin/helper.sh").read_text() == "#!/bin/sh\necho first\n"
+    assert recipe.modes["/usr/local/bin/helper.sh"] == "0555"
+
+
 def test_recipe_bare_mv_and_unknown_command(tmp_path: Path) -> None:
     src = tmp_path / "w"
     (src / "a").mkdir(parents=True)
@@ -626,6 +702,51 @@ def test_end_to_end_classic_build(tmp_path: Path) -> None:
     # info.xml %%PKGVERSION%% substituted in the staged payload
     info = _extract(tf, "/usr/local/share/testpkg/info.xml").decode()
     assert info == "<version>1.0_2</version>\n"
+
+
+def test_end_to_end_dynamic_plist_uses_the_staged_payload(tmp_path: Path) -> None:
+    ports, portdir = _make_classic_port(tmp_path)
+    portdir.joinpath("pkg-plist").unlink()
+    makefile = portdir / "Makefile"
+    makefile.write_text(
+        makefile.read_text().replace(
+            "NO_BUILD=\tyes\n",
+            "NO_BUILD=\tyes\nPLIST_DIRS=\t/etc/inc/priv /etc/inc\n",
+        )
+        + "post-install:\n"
+        + "\t@${FIND} -s ${STAGEDIR}${PREFIX} -type f -print | "
+        + '${SED} -e "s#${STAGEDIR}${PREFIX}/##g" >> ${TMPPLIST}\n'
+    )
+    out = tmp_path / "out"
+
+    rc = bpp.main(
+        [
+            "--ports",
+            str(ports),
+            "--port-dir",
+            str(portdir),
+            "--abi",
+            "FreeBSD:15:amd64",
+            "--py-flavor",
+            "py311",
+            "--compression",
+            "xz",
+            "--freebsd-version",
+            "1500068",
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert rc == 0
+    full, _, _ = _read_pkg(out / "testpkg-1.0_2.pkg")
+    assert set(full["files"]) == {
+        "/etc/inc/priv/test.priv.inc",
+        "/usr/local/bin/hello.sh",
+        "/usr/local/etc/testpkg.conf",
+        "/usr/local/share/testpkg/info.xml",
+    }
+    assert set(full["directories"]) == {"/etc/inc/priv", "/etc/inc"}
 
 
 def test_end_to_end_plist_drift_aborts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- teach the portable package builder the FreeBSD `COPYTREE_SHARE` recipe used by pfBlockerNG ports
- support script-install globs and real `install(1)` overwrite semantics
- derive the package manifest from `STAGEDIR` when a port intentionally uses a dynamic plist
- preserve strict static `pkg-plist` drift checks for ports that still provide one
- exclude local `.DS_Store`, `*.pyc`, and `__pycache__` artifacts while acquiring `--local-src`

This is the pfBlockerNG-side prerequisite for replacing the brittle devel/nightly port file inventories with recursive staging plus a generated `TMPPLIST`.

Related: #1545

## Test-first proof

Frozen test file: `tests/test_build_pkg_portable.py`

- formatted RED hash: `7223d62e5f4d78c5c91e6c26636b62e78838d734`
- RED: the builder rejected `COPYTREE_SHARE` and the `FIND | SED >> TMPPLIST` recipe
- GREEN: the same two tests passed unchanged
- overwrite reproduction RED/GREEN hash: `3c51218dcfd70c14318cc835b0a299cfb49cd031`
- local-source artifact reproduction RED/GREEN hash:
  `54f66f667ae1f67bd3599fe4a66814a38acd5f99`
- RED: local source acquisition copied `.DS_Store` and Python cache artifacts into `WRKSRC`
- GREEN: the same test passed unchanged after ignoring those untracked artifacts at acquisition

Final validation:

- `python3 -m pytest -q tests/test_build_pkg_portable.py` — 102 passed
- `ruff check scripts/build-pkg-portable.py tests/test_build_pkg_portable.py`
- `ruff format --check scripts/build-pkg-portable.py tests/test_build_pkg_portable.py`
- `mypy scripts/build-pkg-portable.py tests/test_build_pkg_portable.py`
- devel and nightly packages built successfully from the companion ports worktree
- an unlisted `future_helper.inc` fixture increased the package from 74 to 75 files and appeared in the archive without any Makefile or plist edit
- `.DS_Store`, `*.pyc`, and `__pycache__` artifacts stayed out of the archive
- review removed emulation of `COPYTREE_SHARE`'s optional filter because the real FreeBSD
  macro expands its third argument unquoted; the companion ports use the safe unfiltered
  whole-tree form, while local artifact exclusion occurs before staging

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
