### PR TITLE
dnsbl: restore chroot ownership during staging

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -338,6 +338,7 @@ dnsbl_cache() {
 
 	dnsbl_cache_stage() {
 		mkdir -p "${pfbchroot}"
+		chown -f unbound:unbound "${pfbchroot}"
 		# The nullfs/devfs mount-point dirs pfb_python_mount expects (fresh-MFS safety).
 		for _d in lib dev var/log/pfblockerng usr/local/share/GeoIP; do
 			mkdir -p "${pfbchroot}/${_d}"

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -97,6 +97,23 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     cleanup_sandbox
   End
 
+  stage_root_chown() (
+    setup_sandbox
+    # shellcheck disable=SC2329  # invoked indirectly by dnsbl_cache
+    chown() {
+      if [ "$3" = "${pfbchroot}" ]; then
+        printf '%s %s CHROOT\n' "$1" "$2"
+      fi
+    }
+    dnsbl_cache stage
+    cleanup_sandbox
+  )
+
+  It 'stage gives unbound the chroot directory without recursive ownership changes'
+    When call stage_root_chown
+    The output should equal '-f unbound:unbound CHROOT'
+  End
+
   It 'stage copies the TLD oracle from dnsbl_tld to pfb_py_tld.txt (name-mapped, issue #1255)'
     setup_sandbox
     When call dc stage


### PR DESCRIPTION
## Summary

- Restore `unbound:unbound` ownership on the existing DNSBL chroot during every stage operation.
- Keep ownership repair at the parent directory only; do not recursively alter mount points or unrelated chroot contents.
- Add a ShellSpec assertion that pins the exact non-recursive `chown -f unbound:unbound CHROOT` call.

## Root cause

An existing `/var/unbound` directory could remain owned by root. Staging corrected individual shipped files but not the directory itself, so the Unbound worker could not create DNSBL count files, SQLite journals/WAL files, or control applied markers.

## Verification

- Frozen live test blob: `d902633bea23b1dd2e5e331762ed5517e5d1a1be`.
- RED on current `devel`: https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/30013296200
- GREEN focused, pfSense CE 2.8: https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/30016299331
- GREEN focused, pfSense Plus 26.03: https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/30016299236
- ShellSpec ownership test blob: `70fc2912bf87a7aa7ec14ddd6cb6d7de2ba67420`; RED with the production call removed, GREEN unchanged after restoration.
- Canonical local gates: PASS (`sh -n`, ShellCheck, 954 ShellSpec examples with 8 environment skips).
- Exact-head full fan-out: https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/30017384834. The original ownership cascade is gone and both shard-1 legs pass. Remaining failures are isolated test defects: cache-flush fixture ordering in shard 2 and tracked Hold expectation drift in #1478. They remain under #961 and are intentionally not mixed into this production patch.

Refs #961

---

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNSBL cache staging by ensuring the DNSBL chroot root directory has the correct `unbound:unbound` ownership, improving permission consistency during the `stage` process.
* **Tests**
  * Added a new assertion for the `dnsbl_cache stage` subcommand to verify ownership behavior, including that it applies the expected non-recursive chown to the chroot directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->