### PR TITLE
test(smoke): preserve cache flush through case injection

### DIFF
--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -490,7 +490,7 @@ def test_dnsbl_resolve_block_unlock_relock_lifecycle(
     # (b) Now put it on a DNSBL feed -> the SAME domain is now BLOCKED (VIP).
     feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_unlock.txt", f"{domain}\n")
     spec = h.DnsblCase(aliasname="smokeunlock", feed_url=feed_url, header="smokeunlock", mode=h.DnsblMode.VIP)
-    with h.DnsblCacheFlushEnabled(deployed_vm), h.CaseContext(deployed_vm, spec):
+    with h.CaseContext(deployed_vm, spec), h.DnsblCacheFlushEnabled(deployed_vm):
         h.unblock_egress()  # the allowed probes (a-shape) must reach the controlled stub
         # Listing the name is the feed/swap allow->block direction: the module already
         # mounted (a prior case), so first-enable applies via the no-restart swap. The
@@ -724,7 +724,7 @@ def test_dnsbl_temp_unlock_cleared_by_force_update(
     # No host override on the name — it would shadow the DNSBL block (served as
     # local-data before the python module); an allowed name resolves via the stub.
     spec = h.DnsblCase(aliasname="smokeunlocktmp", feed_url=feed_url, header="smokeunlocktmp", mode=h.DnsblMode.VIP)
-    with h.DnsblCacheFlushEnabled(deployed_vm), h.CaseContext(deployed_vm, spec):
+    with h.CaseContext(deployed_vm, spec), h.DnsblCacheFlushEnabled(deployed_vm):
         # Egress OPEN: the update path deadlocks under a dark egress, and the allowed
         # (unlock) probe must reach the controlled stub. The block probes return the VIP
         # locally, so there is no false-green from leaving egress open.
@@ -800,7 +800,7 @@ def test_dnsbl_feed_update_no_restart(deployed_vm: SmokeVM, client_vm: SmokeVM, 
     feed_name = "smoke_dnsbl_feedupd.txt"
     feed_url = h.write_local_feed(deployed_vm, feed_name, f"{other}\n")
     spec = h.DnsblCase(aliasname="smokefeedupd", feed_url=feed_url, header="smokefeedupd", mode=h.DnsblMode.VIP)
-    with h.DnsblCacheFlushEnabled(deployed_vm), h.CaseContext(deployed_vm, spec):
+    with h.CaseContext(deployed_vm, spec), h.DnsblCacheFlushEnabled(deployed_vm):
         h.unblock_egress()  # the allowed (before-state) probe must reach the controlled stub
 
         # BEFORE: the target is not on the feed yet -> it RESOLVES via the stub sentinel.

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -490,12 +490,12 @@ def test_dnsbl_resolve_block_unlock_relock_lifecycle(
     # (b) Now put it on a DNSBL feed -> the SAME domain is now BLOCKED (VIP).
     feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_unlock.txt", f"{domain}\n")
     spec = h.DnsblCase(aliasname="smokeunlock", feed_url=feed_url, header="smokeunlock", mode=h.DnsblMode.VIP)
-    with h.CaseContext(deployed_vm, spec), h.DnsblCacheFlushEnabled(deployed_vm):
+    with h.CaseContext(deployed_vm, spec):
         h.unblock_egress()  # the allowed probes (a-shape) must reach the controlled stub
         # Listing the name is the feed/swap allow->block direction: the module already
-        # mounted (a prior case), so first-enable applies via the no-restart swap. The
-        # opt-in bulk policy flushes Unbound's full message + RRset caches after
-        # the applied-generation handshake, so the pre-resolved answer cannot survive.
+        # mounted (a prior case), so first-enable applies via the no-restart swap. Flush
+        # the pre-resolved answer before observing the new block.
+        h.flush_unbound_name(deployed_vm, domain)
         blocked = h.dns_probe_client(client_vm, domain, "A")
         assert h.is_vip(blocked), f"{domain} still resolving after block: {blocked}"
 


### PR DESCRIPTION
## Summary

- Flush the lifecycle test pre-resolution explicitly after its setup reload.
- Enter `CaseContext` before `DnsblCacheFlushEnabled` in the two tests whose in-body zero-downtime updates require full cache flushing.
- Leave production behavior unchanged.

## Root cause

`DnsblCacheFlushEnabled` was entered first. `CaseContext` then injected its DNSBL fixture configuration and removed `pfb_cache_flush`, so later swaps loaded the correct entries but the client still received its cached pre-swap answer. The exact-head diagnostics showed `loaded entries: 1` and a completed zero-downtime swap while the configuration diff showed `pfb_cache_flush` disappearing before the assertion.

The lifecycle test has a different transition: its cached answer exists before `CaseContext` performs the setup reload. It now performs a targeted flush immediately before asserting the new block instead of relying on an unused bulk-flush wrapper.

## Verification

- Frozen RED test blob: `3431565d247f432f716cc997dade2f389df0ee91`.
- RED on both CE and Plus: https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/30017384834
- Final test blob: `5c7ad6a0ccec8ca20b2003c474a7cc5df0286379`.
- Final-head CE proof: https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/30020172913
- Final-head Plus proof: https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/30020172581
- Local gates: Ruff lint/format and strict mypy passed through the canonical pre-commit hook.

Refs #961

---

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an explicit targeted cache flush for the lifecycle setup transition.
  * Preserved cache-flush configuration through the two in-body DNSBL update transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->