### PR TITLE
policy: require issue labels and types

### DIFF
--- a/.agents/policy/issues.md
+++ b/.agents/policy/issues.md
@@ -31,6 +31,24 @@ string-typed sink — the array-`$_POST` family: #1070/#1106/#1128/#1139) gets i
 is linked as a sub-issue of tracker #1143 (GraphQL `addSubIssue`); never fold it into an older
 issue. HARDENING-ONLY findings do not become tracker children.
 
+## Classification at creation
+
+Every issue creation path — human, agent, issue form, or automation — sets both:
+
+1. at least one descriptive label appropriate to the work (`bug`, `enhancement`,
+   `documentation`, `CI`, `wayfinder:*`, etc.); and
+2. exactly one native GitHub issue type, chosen from this table:
+
+| Issue type | Use for |
+| --- | --- |
+| `Bug` | Unexpected or regressed existing behaviour, including defects in CI tooling |
+| `Feature` | A new user-facing capability |
+| `Task` | Improvements to existing behaviour; implementation slices; maintenance, testing, CI, documentation, research, and process work |
+
+Labels remain orthogonal metadata and are never replaced by the type. When categories
+overlap, a defect is `Bug`; otherwise an improvement is `Task`, not `Feature`. Set both
+at creation (`gh issue create --label bug --type Bug`), not as a later cleanup pass.
+
 ## Issue state (lifecycle — native signals, #1388)
 
 Native GitHub signals replace the retired `WIP`/`Waiting PR` labels (adopted 2026-07-17 from

--- a/.agents/policy/workflow.md
+++ b/.agents/policy/workflow.md
@@ -24,7 +24,7 @@
 
 ### Map
 
-An issue labelled `wayfinder:map` with sections **Destination**, **Notes**,
+An issue labelled `wayfinder:map` and typed `Task`, with sections **Destination**, **Notes**,
 **Decisions so far**, **Not yet specified** (the fog), **Out of scope**. Tickets are
 native sub-issues. The body is edited in place as current truth; each resolved ticket
 appends one pointer line to Decisions so far.
@@ -39,8 +39,9 @@ implementable — the forks are tickets.
 
 ### Task packet
 
-The issue body IS the packet: a fresh session must be able to execute from it plus its
-linked references alone. Required fields:
+The issue body IS the packet, and the issue carries both its descriptive label(s) and
+the native type defined by `issues.md`. A fresh session must be able to execute from it
+plus its linked references alone. Required fields:
 
 - **Objective** — the one outcome.
 - **Required reading** — `file:line` and doc pointers (bootstrap routing rows), never

--- a/.agents/skills/caveman-compress/SECURITY.md
+++ b/.agents/skills/caveman-compress/SECURITY.md
@@ -28,4 +28,5 @@ Files larger than 500KB are rejected before any API call is made.
 
 ### Reporting a vulnerability
 
-If you believe you've found a genuine security issue, please open a GitHub issue with the label `security`.
+If you believe you've found a genuine security issue, please open a GitHub issue with the
+label `security` and native type `Bug`.

--- a/.agents/skills/qa/SKILL.md
+++ b/.agents/skills/qa/SKILL.md
@@ -46,7 +46,8 @@ Keep as a single issue when:
 
 ### 4. File the GitHub issue(s)
 
-Create issues with `gh issue create`. Do NOT ask the user to review first — just file and share URLs.
+Create bugs with `gh issue create --label bug --type Bug`. Do NOT ask the user to
+review first — just file and share URLs.
 
 Issues must be **durable** — they should still make sense after major refactors. Write from the user's perspective.
 

--- a/.agents/skills/request-refactor-plan/SKILL.md
+++ b/.agents/skills/request-refactor-plan/SKILL.md
@@ -19,7 +19,10 @@ This skill will be invoked when the user wants to create a refactor request. You
 
 7. Break the implementation into a plan of tiny commits. Remember Martin Fowler's advice to "make each refactoring step as small as possible, so that you can always see the program working."
 
-8. Create a GitHub issue with the refactor plan. Use the following template for the issue description:
+8. Create a GitHub issue with the refactor plan, the descriptive `architecture`
+   label, and native `Task` type
+   (`gh issue create --label architecture --type Task`). Use the following template
+   for the issue description:
 
 <refactor-plan-template>
 

--- a/.agents/skills/setup-matt-pocock-skills/issue-tracker-github.md
+++ b/.agents/skills/setup-matt-pocock-skills/issue-tracker-github.md
@@ -4,7 +4,7 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Create an issue**: `gh issue create --title "..." --body "..." --label "<label>" --type "<type>"`. Use a heredoc for multi-line bodies. Both `--label` and `--type` are mandatory.
 - **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
@@ -12,6 +12,11 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 - **Close**: `gh issue close <number> --comment "..."`
 
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+Issue types are single-valued: `Bug` for defects, `Feature` for new user-facing
+capabilities, and `Task` for improvements, implementation work, maintenance, tests,
+CI, documentation, research, and process work. Keep descriptive labels alongside the
+type; a defect wins when categories overlap.
 
 ## Pull requests as a triage surface
 
@@ -37,8 +42,8 @@ Run `gh issue view <number> --comments`.
 
 Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
 
-- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
-- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Map**: a single issue labelled `wayfinder:map` and typed `Task`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map --type Task`.
+- **Child ticket**: an issue typed `Task` and linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
 - **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
 - **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
 - **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.

--- a/.agents/skills/wayfinder/SKILL.md
+++ b/.agents/skills/wayfinder/SKILL.md
@@ -18,7 +18,9 @@ Every map and ticket is an issue, so it has a **name** — its title. In everyth
 
 ## The Map
 
-The map is a single issue on this repo's issue tracker, labelled `wayfinder:map` — the canonical artifact. Its tickets are child issues of the map.
+The map is a single issue on this repo's issue tracker, labelled `wayfinder:map` and
+given native issue type `Task` — the canonical artifact. Its tickets are child issues
+of the map.
 
 The map is an **index**, not a store. It lists the decisions made and points at the tickets that hold their detail; a decision lives in exactly one place — its ticket — so the map never restates it, only gists it and links.
 
@@ -62,7 +64,9 @@ Each ticket is a **child issue** of the map; the tracker's issue id is its ident
 <the decision or investigation this ticket resolves>
 ```
 
-Each ticket carries a `wayfinder:<type>` label — one of `research`, `prototype`, `grilling`, `task` (see [Ticket Types](#ticket-types)).
+Each ticket carries a `wayfinder:<type>` label — one of `research`, `prototype`,
+`grilling`, `task` (see [Ticket Types](#ticket-types)) — plus native issue type
+`Task`.
 
 A session **claims** a ticket by assigning it to the dev driving the map, **first**, before any work, so concurrent sessions skip it. That assignee _is_ the claim: an open, unassigned ticket is unclaimed.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Report a problem with pfBlockerNG so we can reproduce and fix it.
 labels: ["bug"]
+type: bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Propose a new user-facing pfBlockerNG capability.
+labels: ["enhancement"]
+type: feature
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the user need or limitation, not an implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: What new capability do you want?
+      description: Describe the observable outcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add examples, alternatives, or constraints if useful.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task_request.yml
+++ b/.github/ISSUE_TEMPLATE/task_request.yml
@@ -1,0 +1,28 @@
+name: Improvement or maintenance task
+description: Propose an improvement to existing behavior or project maintenance.
+labels: ["enhancement"]
+type: task
+body:
+  - type: textarea
+    id: current
+    attributes:
+      label: What should be improved?
+      description: Describe the existing behavior, workflow, documentation, or maintenance need.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: What outcome do you want?
+      description: Describe the observable completion condition.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add examples, alternatives, or constraints if useful.
+    validations:
+      required: false

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -117,5 +117,6 @@ jobs:
               --repo "$REPO" \
               --title "$TITLE" \
               --body-file "$BODY_FILE" \
-              --label "nightly-red,bug"
+              --label "nightly-red,bug" \
+              --type Bug
           fi

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -202,5 +202,6 @@ jobs:
               --repo "$REPO" \
               --title "$TITLE" \
               --body-file "${{ steps.report.outputs.body_file }}" \
-              --label "top1m-provider,bug"
+              --label "top1m-provider,bug" \
+              --type Bug
           fi

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -401,6 +401,7 @@ jobs:
               --title "$TITLE" \
               --body-file "$BODY_FILE" \
               --label "version-tracker,enhancement" \
+              --type Task \
               || echo "  ::warning::Could not open nudge issue for ${CHANNEL} ${VERSION}"
             rm -f "$BODY_FILE"
           done
@@ -481,6 +482,7 @@ jobs:
                 --title "$TITLE" \
                 --body-file "$BODY_FILE" \
                 --label "version-tracker,enhancement" \
+                --type Task \
                 || echo "  ::warning::Could not create tracking issue for ${CHANNEL} ${VERSION}"
             fi
             rm -f "$BODY_FILE"

--- a/tests/test_issue_creation_metadata.py
+++ b/tests/test_issue_creation_metadata.py
@@ -1,5 +1,6 @@
 """Ticket creators must set descriptive labels and native issue types together."""
 
+import shlex
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -16,13 +17,18 @@ def _continued_command(lines: list[str], start: int) -> str:
     return "\n".join(command)
 
 
+def _option_values(command: str, option: str) -> list[str]:
+    tokens = shlex.split(command.replace("\\\n", " "))
+    return [tokens[index + 1] for index, token in enumerate(tokens[:-1]) if token == option]
+
+
 def test_automated_issue_creators_set_label_and_type() -> None:
     expected = {
-        "nightly-failure-alert.yml": [('--label "nightly-red,bug"', "--type Bug")],
-        "top1m-healthcheck.yml": [('--label "top1m-provider,bug"', "--type Bug")],
+        "nightly-failure-alert.yml": [("nightly-red,bug", "Bug")],
+        "top1m-healthcheck.yml": [("top1m-provider,bug", "Bug")],
         "version-tracker.yml": [
-            ('--label "version-tracker,enhancement"', "--type Task"),
-            ('--label "version-tracker,enhancement"', "--type Task"),
+            ("version-tracker,enhancement", "Task"),
+            ("version-tracker,enhancement", "Task"),
         ],
     }
     commands: dict[str, list[str]] = {}
@@ -41,8 +47,8 @@ def test_automated_issue_creators_set_label_and_type() -> None:
     for filename, expected_commands in expected.items():
         assert len(commands[filename]) == len(expected_commands)
         for command, (label, issue_type) in zip(commands[filename], expected_commands, strict=True):
-            assert label in command
-            assert issue_type in command
+            assert _option_values(command, "--label") == [label]
+            assert _option_values(command, "--type") == [issue_type]
 
 
 def test_issue_forms_set_label_and_type_and_disable_blank_issues() -> None:
@@ -51,6 +57,11 @@ def test_issue_forms_set_label_and_type_and_disable_blank_issues() -> None:
         "feature_request.yml": ('labels: ["enhancement"]', "type: feature"),
         "task_request.yml": ('labels: ["enhancement"]', "type: task"),
     }
+    template_dir = ROOT / ".github/ISSUE_TEMPLATE"
+    form_files = {
+        path.name for path in template_dir.iterdir() if path.suffix in {".yml", ".yaml"} and path.name != "config.yml"
+    }
+    assert form_files == forms.keys()
     for filename, (label, issue_type) in forms.items():
         form = _read(f".github/ISSUE_TEMPLATE/{filename}")
         assert f"\n{label}\n" in form
@@ -84,3 +95,6 @@ def test_human_ticket_procedures_require_both_metadata_axes() -> None:
 
     refactor = _read(".agents/skills/request-refactor-plan/SKILL.md")
     assert "`gh issue create --label architecture --type Task`" in refactor
+
+    security = _read(".agents/skills/caveman-compress/SECURITY.md")
+    assert "label `security` and native type `Bug`" in security

--- a/tests/test_issue_creation_metadata.py
+++ b/tests/test_issue_creation_metadata.py
@@ -9,37 +9,78 @@ def _read(relative: str) -> str:
     return (ROOT / relative).read_text(encoding="utf-8")
 
 
+def _continued_command(lines: list[str], start: int) -> str:
+    command = [lines[start]]
+    while command[-1].rstrip().endswith("\\"):
+        command.append(lines[start + len(command)])
+    return "\n".join(command)
+
+
 def test_automated_issue_creators_set_label_and_type() -> None:
-    commands = []
-    for path in (ROOT / ".github/workflows").glob("*.yml"):
+    expected = {
+        "nightly-failure-alert.yml": [('--label "nightly-red,bug"', "--type Bug")],
+        "top1m-healthcheck.yml": [('--label "top1m-provider,bug"', "--type Bug")],
+        "version-tracker.yml": [
+            ('--label "version-tracker,enhancement"', "--type Task"),
+            ('--label "version-tracker,enhancement"', "--type Task"),
+        ],
+    }
+    commands: dict[str, list[str]] = {}
+    workflows = ROOT / ".github/workflows"
+    for path in workflows.iterdir():
+        if path.suffix not in {".yml", ".yaml"}:
+            continue
         lines = path.read_text(encoding="utf-8").splitlines()
         for index, line in enumerate(lines):
             if "gh issue create" not in line:
                 continue
-            command = "\n".join(lines[index : index + 10])
-            commands.append(f"{path.name}:{index + 1}")
-            assert "--label" in command, f"{commands[-1]} creates an unlabelled issue"
-            assert "--type" in command, f"{commands[-1]} creates an untyped issue"
+            command = _continued_command(lines, index)
+            commands.setdefault(path.name, []).append(command)
 
-    assert commands, "no automated issue creators were inspected"
+    assert commands.keys() == expected.keys()
+    for filename, expected_commands in expected.items():
+        assert len(commands[filename]) == len(expected_commands)
+        for command, (label, issue_type) in zip(commands[filename], expected_commands, strict=True):
+            assert label in command
+            assert issue_type in command
 
 
-def test_bug_form_sets_label_and_type() -> None:
-    form = _read(".github/ISSUE_TEMPLATE/bug_report.yml")
-    assert '\nlabels: ["bug"]\n' in form
-    assert "\ntype: bug\n" in form
+def test_issue_forms_set_label_and_type_and_disable_blank_issues() -> None:
+    forms = {
+        "bug_report.yml": ('labels: ["bug"]', "type: bug"),
+        "feature_request.yml": ('labels: ["enhancement"]', "type: feature"),
+        "task_request.yml": ('labels: ["enhancement"]', "type: task"),
+    }
+    for filename, (label, issue_type) in forms.items():
+        form = _read(f".github/ISSUE_TEMPLATE/{filename}")
+        assert f"\n{label}\n" in form
+        assert f"\n{issue_type}\n" in form
+
+    config = _read(".github/ISSUE_TEMPLATE/config.yml")
+    assert "blank_issues_enabled: false" in config
 
 
 def test_human_ticket_procedures_require_both_metadata_axes() -> None:
     policy = _read(".agents/policy/issues.md")
     for issue_type in ("Bug", "Feature", "Task"):
         assert f"| `{issue_type}` |" in policy
+    assert "`gh issue create --label bug --type Bug`" in policy
 
-    assert "`gh issue create --label bug --type Bug`" in _read(".agents/skills/qa/SKILL.md")
+    qa = _read(".agents/skills/qa/SKILL.md")
+    assert "`gh issue create --label bug --type Bug`" in qa
 
     tracker = _read(".agents/skills/setup-matt-pocock-skills/issue-tracker-github.md")
-    assert "--label" in tracker
-    assert "--type" in tracker
+    assert '--label "<label>" --type "<type>"' in tracker
+    assert "gh issue create --label wayfinder:map --type Task" in tracker
 
     wayfinder = _read(".agents/skills/wayfinder/SKILL.md")
+    assert "`wayfinder:<type>` label" in wayfinder
     assert "native issue type `Task`" in wayfinder
+
+    workflow = _read(".agents/policy/workflow.md")
+    assert "`wayfinder:map` and typed `Task`" in workflow
+    assert "descriptive label(s)" in workflow
+    assert "native type defined by `issues.md`" in workflow
+
+    refactor = _read(".agents/skills/request-refactor-plan/SKILL.md")
+    assert "`gh issue create --label architecture --type Task`" in refactor

--- a/tests/test_issue_creation_metadata.py
+++ b/tests/test_issue_creation_metadata.py
@@ -1,0 +1,45 @@
+"""Ticket creators must set descriptive labels and native issue types together."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def test_automated_issue_creators_set_label_and_type() -> None:
+    commands = []
+    for path in (ROOT / ".github/workflows").glob("*.yml"):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if "gh issue create" not in line:
+                continue
+            command = "\n".join(lines[index : index + 10])
+            commands.append(f"{path.name}:{index + 1}")
+            assert "--label" in command, f"{commands[-1]} creates an unlabelled issue"
+            assert "--type" in command, f"{commands[-1]} creates an untyped issue"
+
+    assert commands, "no automated issue creators were inspected"
+
+
+def test_bug_form_sets_label_and_type() -> None:
+    form = _read(".github/ISSUE_TEMPLATE/bug_report.yml")
+    assert '\nlabels: ["bug"]\n' in form
+    assert "\ntype: bug\n" in form
+
+
+def test_human_ticket_procedures_require_both_metadata_axes() -> None:
+    policy = _read(".agents/policy/issues.md")
+    for issue_type in ("Bug", "Feature", "Task"):
+        assert f"| `{issue_type}` |" in policy
+
+    assert "`gh issue create --label bug --type Bug`" in _read(".agents/skills/qa/SKILL.md")
+
+    tracker = _read(".agents/skills/setup-matt-pocock-skills/issue-tracker-github.md")
+    assert "--label" in tracker
+    assert "--type" in tracker
+
+    wayfinder = _read(".agents/skills/wayfinder/SKILL.md")
+    assert "native issue type `Task`" in wayfinder


### PR DESCRIPTION
## Summary

- require every issue creator to set both descriptive labels and exactly one native GitHub issue type
- classify defects and security reports as `Bug`, new user-facing capabilities as `Feature`, and improvements/CI/docs/maintenance as `Task`
- cover QA, Wayfinder, refactor planning, security reporting, issue forms, and all automated issue-opening workflows
- add typed Feature and Task forms and disable unclassified blank issues
- preserve labels as orthogonal metadata

## Verification

- initial RED: `python3 -m pytest -q tests/test_issue_creation_metadata.py` — 3 failed against the previous procedure
- frozen test hash: `528f41d413fcd0ad1740a94b42eaf427195ac8c7`
- mutation RED: changing workflow type `Bug` to `Buggy` — 1 failed
- GREEN: same test command and frozen hash — 3 passed
- `scripts/agent/run-gates.sh --diff origin/devel` — all selected gates passed
- `actionlint` — only pre-existing SC2016 informational warnings

Fixes #1641

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new GitHub issue templates for feature requests and improvement/maintenance tasks.
* **Documentation**
  * Updated issue-creation guidance and workflow/skill procedures to require both a descriptive label and a single native issue type at creation time, including label/type overlap rules.
  * Updated existing security and bug-report instructions/templates to include explicit issue metadata.
* **Tests**
  * Added/strengthened end-to-end checks ensuring workflows, issue forms, and documented procedures consistently set label + type metadata (and that blank issue creation is disabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->