### PR TITLE
dnsbl: align TOP1M whitelist wire

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4618,8 +4618,9 @@ def _dnsbl_normalise_whitelist(
 ) -> dict[str, dict[str, Any]]:
     """User-whitelist normalisation (mirrors PHP's pfb_unbound_python_whitelist()) into the
     query-time whiteDB shape: www-strip; leading-dot -> wildcard True else False.
-    TOP1M entries are loaded ONLY when enabled (bare domains -> exact). No build-time
-    list pruning -- this only populates whiteDB.
+    TOP1M entries are loaded ONLY when enabled as validated canonical bare domains;
+    retired comma-framed records and invalid domains are explicitly rejected by normalise().
+    No build-time list pruning -- this only populates whiteDB.
 
     ADR-07: the whiteDB value widens from a bare ``bool`` (wildcard?) to
     ``{"wildcard": bool, "important": bool}``. User whitelist + TOP1M load as
@@ -4642,8 +4643,8 @@ def _dnsbl_normalise_whitelist(
 
     if top1m_enabled:
         for raw in top1m_lines:
-            dom = raw.strip()
-            if dom:
+            dom = normalise(raw)
+            if dom is not None:
                 # TOP1M behaves as a user allow (sovereign, band 6) -- fact 7.
                 white_db.setdefault(dom, {"wildcard": False, "important": True, "band": PRIO_USER_ALLOW})
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9962,8 +9962,9 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 					}
 					$x++;
 
-					// Create three whitelist options per TOP1M whitelisted Domain
-					@fwrite($pfb_output, ".{$domain},,\n,{$domain},,\n,www.{$domain},,\n");
+					// Canonical TOP1M wire: one bare domain per line; exact lookup also allows only www.
+					// Deeper subdomains remain unallowed.
+					@fwrite($pfb_output, "{$domain}\n");
 				}
 
 				if ($x >= $pfb['dnsbl_top1m_cnt']) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7902,10 +7902,6 @@ function pfb_unbound_py_top1m_atomic_copy(string $source, string $path, array $s
 		@fclose($source_h);
 		return FALSE;
 	}
-	if ($first_byte !== '.') {
-		@fclose($source_h);
-		return pfb_unbound_py_atomic_copy($source, $path, $stream_ops);
-	}
 	if (!@rewind($source_h)) {
 		@fclose($source_h);
 		return FALSE;
@@ -7925,6 +7921,24 @@ function pfb_unbound_py_top1m_atomic_copy(string $source, string $path, array $s
 	$write_fn = $stream_ops['write'] ?? static fn($stream, $bytes) => @fwrite($stream, $bytes);
 	$flush_fn = $stream_ops['flush'] ?? static fn($stream) => @fflush($stream);
 	$fsync_fn = $stream_ops['fsync'] ?? static fn($stream) => @fsync($stream);
+	$ok = TRUE;
+	if ($first_byte !== '.') {
+		while (!feof($source_h)) {
+			$chunk = @fread($source_h, 1048576);
+			if ($chunk === FALSE) {
+				$ok = FALSE;
+				break;
+			}
+			if ($chunk !== '') {
+				$written = $write_fn($target_h, $chunk);
+				if ($written === FALSE || $written !== strlen($chunk)) {
+					$ok = FALSE;
+					break;
+				}
+			}
+		}
+	}
+
 	$patterns = array(
 		'comma' => array(
 			'/\A\.([A-Za-z0-9.-]+),,\n\z/D',
@@ -7951,8 +7965,7 @@ function pfb_unbound_py_top1m_atomic_copy(string $source, string $path, array $s
 		return TRUE;
 	};
 	$family = NULL;
-	$ok = TRUE;
-	while (TRUE) {
+	while ($first_byte === '.') {
 		$lines = array(@fgets($source_h, 1024));
 		if ($lines[0] === FALSE) {
 			$ok = feof($source_h);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7887,6 +7887,146 @@ function pfb_unbound_py_atomic_copy(string $source, string $path, array $stream_
 	return TRUE;
 }
 
+// Issue #1569: preserve canonical TOP1M bytes while projecting either retired
+// three-line wire family to the strict one-domain-per-line Python sidecar.
+function pfb_unbound_py_top1m_atomic_copy(string $source, string $path, array $stream_ops=array()): bool {
+	if (is_link($source) || !is_file($source) || !is_readable($source)) {
+		return FALSE;
+	}
+	$source_h = @fopen($source, 'rb');
+	if ($source_h === FALSE) {
+		return FALSE;
+	}
+	$first_byte = @fread($source_h, 1);
+	if ($first_byte === FALSE) {
+		@fclose($source_h);
+		return FALSE;
+	}
+	if ($first_byte !== '.') {
+		@fclose($source_h);
+		return pfb_unbound_py_atomic_copy($source, $path, $stream_ops);
+	}
+	if (!@rewind($source_h)) {
+		@fclose($source_h);
+		return FALSE;
+	}
+
+	$tmp = @tempnam(dirname($path), '.pfbtop1m_');
+	if ($tmp === FALSE) {
+		@fclose($source_h);
+		return FALSE;
+	}
+	$target_h = @fopen($tmp, 'wb');
+	if ($target_h === FALSE) {
+		@fclose($source_h);
+		@unlink($tmp);
+		return FALSE;
+	}
+	$write_fn = $stream_ops['write'] ?? static fn($stream, $bytes) => @fwrite($stream, $bytes);
+	$flush_fn = $stream_ops['flush'] ?? static fn($stream) => @fflush($stream);
+	$fsync_fn = $stream_ops['fsync'] ?? static fn($stream) => @fsync($stream);
+	$patterns = array(
+		'comma' => array(
+			'/\A\.([A-Za-z0-9.-]+),,\n\z/D',
+			'/\A,([A-Za-z0-9.-]+),,\n\z/D',
+			'/\A,www\.([A-Za-z0-9.-]+),,\n\z/D',
+		),
+		'native' => array(
+			'/\A\.([A-Za-z0-9.-]+) 60\n\z/D',
+			'/\A"([A-Za-z0-9.-]+) 60\n\z/D',
+			'/\A"www\.([A-Za-z0-9.-]+) 60\n\z/D',
+		),
+	);
+	$validate_domain = static function (string $domain): bool {
+		if (strlen($domain) > 253 || !str_contains($domain, '.')) {
+			return FALSE;
+		}
+		foreach (explode('.', $domain) as $label) {
+			$length = strlen($label);
+			if ($length < 1 || $length > 63 ||
+			    preg_match('/\A[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\z/D', $label) !== 1) {
+				return FALSE;
+			}
+		}
+		return TRUE;
+	};
+	$family = NULL;
+	$ok = TRUE;
+	while (TRUE) {
+		$lines = array(@fgets($source_h, 1024));
+		if ($lines[0] === FALSE) {
+			$ok = feof($source_h);
+			break;
+		}
+		$lines[] = @fgets($source_h, 1024);
+		$lines[] = @fgets($source_h, 1024);
+		if ($lines[1] === FALSE || $lines[2] === FALSE) {
+			$ok = FALSE;
+			break;
+		}
+
+		$record_family = NULL;
+		$domains = array();
+		foreach ($patterns as $candidate_family => $candidate_patterns) {
+			$matches = array();
+			if (preg_match($candidate_patterns[0], $lines[0], $matches) !== 1) {
+				continue;
+			}
+			$record_family = $candidate_family;
+			$domains[] = $matches[1];
+			for ($index = 1; $index < 3; $index++) {
+				$matches = array();
+				if (preg_match($candidate_patterns[$index], $lines[$index], $matches) !== 1) {
+					$ok = FALSE;
+					break 2;
+				}
+				$domains[] = $matches[1];
+			}
+			break;
+		}
+		if (!$ok || $record_family === NULL || ($family !== NULL && $family !== $record_family)) {
+			$ok = FALSE;
+			break;
+		}
+		$family = $record_family;
+		$domain = strtolower($domains[0]);
+		if (strtolower($domains[1]) !== $domain || strtolower($domains[2]) !== $domain ||
+		    !$validate_domain($domain)) {
+			$ok = FALSE;
+			break;
+		}
+		$output = "{$domain}\n";
+		$written = $write_fn($target_h, $output);
+		if ($written === FALSE || $written !== strlen($output)) {
+			$ok = FALSE;
+			break;
+		}
+	}
+	$ok = @fclose($source_h) && $ok;
+	$ok = $ok && $flush_fn($target_h) && $fsync_fn($target_h);
+	$ok = @fclose($target_h) && $ok;
+	if (!$ok) {
+		@unlink($tmp);
+		return FALSE;
+	}
+	$chown_fn = $stream_ops['chown'] ?? static fn($file, $owner) => @chown($file, $owner);
+	$chgrp_fn = $stream_ops['chgrp'] ?? static fn($file, $group) => @chgrp($file, $group);
+	$chmod_fn = $stream_ops['chmod'] ?? static fn($file, $mode) => @chmod($file, $mode);
+	$metadata_fn = $stream_ops['metadata'] ?? static function ($file) use ($chown_fn, $chgrp_fn, $chmod_fn): bool {
+		return $chown_fn($file, 'root') && $chgrp_fn($file, 'unbound') && $chmod_fn($file, 0640);
+	};
+	if (!$metadata_fn($tmp)) {
+		@unlink($tmp);
+		return FALSE;
+	}
+	$rename_fn = $stream_ops['rename'] ?? static fn($from, $to) => @rename($from, $to);
+	if (!$rename_fn($tmp, $path)) {
+		@unlink($tmp);
+		return FALSE;
+	}
+	return TRUE;
+}
+
 // #1357: one exclusive lock serializes full-set publication, scalar manifest patches,
 // convergence-gated generation GC, and teardown. Python readers never take this lock.
 function pfb_unbound_py_publication_lock(?float $timeout_s=NULL) {
@@ -8673,7 +8813,7 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 			pfb_logger("\nTOP1M fixed-file staging failed: {$top1m_target}", 2);
 			return FALSE;
 		}
-		if (!pfb_unbound_py_atomic_copy($top1m_source, $top1m_target, $top1m_atomic_ops)) {
+		if (!pfb_unbound_py_top1m_atomic_copy($top1m_source, $top1m_target, $top1m_atomic_ops)) {
 			if ($top1m_backup !== FALSE) {
 				@unlink($top1m_backup);
 				$top1m_backup = FALSE;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -80,15 +80,23 @@ function pfb_top1m_fetch_if_needed(string $dbdir, ?callable $fetch = NULL): bool
 
 /** Rebuild only from an active TOP1M source whose detector baseline is current. */
 function pfb_top1m_reprocess_needed(string $dbdir): bool {
-	$whitelist = "{$dbdir}/pfbalexawhitelist.txt";
-	$legacy = FALSE;
-	if (file_exists($whitelist)) {
-		$contents = @file_get_contents($whitelist);
-		$legacy = $contents !== FALSE && str_contains($contents, ',,');
+	if (pfb_top1m_refresh_needed($dbdir)) {
+		return FALSE;
 	}
 
-	return !pfb_top1m_refresh_needed($dbdir) &&
-		(!file_exists($whitelist) || $legacy || file_exists("{$dbdir}/top-1m.update"));
+	$whitelist = "{$dbdir}/pfbalexawhitelist.txt";
+	if (!file_exists($whitelist) || file_exists("{$dbdir}/top-1m.update")) {
+		return TRUE;
+	}
+
+	$handle = @fopen($whitelist, 'r');
+	if ($handle === FALSE) {
+		return FALSE;
+	}
+	$first_line = @fgets($handle);
+	@fclose($handle);
+
+	return $first_line !== FALSE && str_contains($first_line, ',,');
 }
 
 /** Record the manifest publication outcome without logging a false completion. */

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -85,18 +85,21 @@ function pfb_top1m_reprocess_needed(string $dbdir): bool {
 	}
 
 	$whitelist = "{$dbdir}/pfbalexawhitelist.txt";
-	if (!file_exists($whitelist) || file_exists("{$dbdir}/top-1m.update")) {
+	if ((!file_exists($whitelist) && !is_link($whitelist)) || file_exists("{$dbdir}/top-1m.update")) {
 		return TRUE;
+	}
+	if (is_link($whitelist) || !is_file($whitelist)) {
+		return FALSE;
 	}
 
 	$handle = @fopen($whitelist, 'r');
 	if ($handle === FALSE) {
 		return FALSE;
 	}
-	$first_line = @fgets($handle);
+	$first_byte = @fread($handle, 1);
 	@fclose($handle);
 
-	return $first_line !== FALSE && str_contains($first_line, ',,');
+	return $first_byte === '.';
 }
 
 /** Record the manifest publication outcome without logging a false completion. */

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -80,8 +80,15 @@ function pfb_top1m_fetch_if_needed(string $dbdir, ?callable $fetch = NULL): bool
 
 /** Rebuild only from an active TOP1M source whose detector baseline is current. */
 function pfb_top1m_reprocess_needed(string $dbdir): bool {
+	$whitelist = "{$dbdir}/pfbalexawhitelist.txt";
+	$legacy = FALSE;
+	if (file_exists($whitelist)) {
+		$contents = @file_get_contents($whitelist);
+		$legacy = $contents !== FALSE && str_contains($contents, ',,');
+	}
+
 	return !pfb_top1m_refresh_needed($dbdir) &&
-		(!file_exists("{$dbdir}/pfbalexawhitelist.txt") || file_exists("{$dbdir}/top-1m.update"));
+		(!file_exists($whitelist) || $legacy || file_exists("{$dbdir}/top-1m.update"));
 }
 
 /** Record the manifest publication outcome without logging a false completion. */

--- a/tests/php/Top1mFixedFileManifestTest.php
+++ b/tests/php/Top1mFixedFileManifestTest.php
@@ -5,6 +5,81 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+final class Top1mChangingSourceStream
+{
+	public $context;
+	public static int $opens = 0;
+	private string $bytes = '';
+	private int $offset = 0;
+
+	public static function reset(): void
+	{
+		self::$opens = 0;
+	}
+
+	public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
+	{
+		self::$opens++;
+		$this->bytes = self::$opens === 1
+			? "canonical.example\n"
+			: ".legacy.example,,\n,legacy.example,,\n,www.legacy.example,,\n";
+		$this->offset = 0;
+		return TRUE;
+	}
+
+	public function stream_read(int $count): string
+	{
+		$bytes = substr($this->bytes, $this->offset, $count);
+		$this->offset += strlen($bytes);
+		return $bytes;
+	}
+
+	public function stream_eof(): bool
+	{
+		return $this->offset >= strlen($this->bytes);
+	}
+
+	public function stream_seek(int $offset, int $whence=SEEK_SET): bool
+	{
+		$next = match ($whence) {
+			SEEK_SET => $offset,
+			SEEK_CUR => $this->offset + $offset,
+			SEEK_END => strlen($this->bytes) + $offset,
+			default => -1,
+		};
+		if ($next < 0 || $next > strlen($this->bytes)) {
+			return FALSE;
+		}
+		$this->offset = $next;
+		return TRUE;
+	}
+
+	public function stream_tell(): int
+	{
+		return $this->offset;
+	}
+
+	public function stream_stat(): array
+	{
+		return self::regularStat(strlen($this->bytes));
+	}
+
+	public function url_stat(string $path, int $flags): array
+	{
+		return self::regularStat(strlen("canonical.example\n"));
+	}
+
+	private static function regularStat(int $size): array
+	{
+		return [
+			2 => 0100644,
+			7 => $size,
+			'mode' => 0100644,
+			'size' => $size,
+		];
+	}
+}
+
 /** Issue #1542: TOP1M is a fixed sidecar file, not manifest-embedded data. */
 final class Top1mFixedFileManifestTest extends TestCase
 {
@@ -66,6 +141,27 @@ final class Top1mFixedFileManifestTest extends TestCase
 		$this->assertArrayNotHasKey('top1m_list', $manifest['config']);
 		$this->assertSame($source, file_get_contents($GLOBALS['pfb']['unbound_py_top1m']));
 		$this->assertFileExists($GLOBALS['pfb']['unbound_py_sources']);
+	}
+
+	public function testCanonicalPublicationUsesTheClassifiedSourceSnapshot(): void
+	{
+		$scheme = 'pfbtop1mrace';
+		$this->assertTrue(stream_wrapper_register($scheme, Top1mChangingSourceStream::class));
+		Top1mChangingSourceStream::reset();
+		$target = "{$this->tmp}/classified.txt";
+		try {
+			$result = pfb_unbound_py_top1m_atomic_copy(
+				"{$scheme}://source",
+				$target,
+				$this->successfulOwnershipOps()
+			);
+		} finally {
+			$this->assertTrue(stream_wrapper_unregister($scheme));
+		}
+
+		$this->assertTrue($result);
+		$this->assertSame(1, Top1mChangingSourceStream::$opens);
+		$this->assertSame("canonical.example\n", file_get_contents($target));
 	}
 
 	public static function legacyProjectionCases(): array

--- a/tests/php/Top1mFixedFileManifestTest.php
+++ b/tests/php/Top1mFixedFileManifestTest.php
@@ -68,6 +68,146 @@ final class Top1mFixedFileManifestTest extends TestCase
 		$this->assertFileExists($GLOBALS['pfb']['unbound_py_sources']);
 	}
 
+	public static function legacyProjectionCases(): array
+	{
+		return [
+			'python-mode' => [
+				".Example.COM,,\n,example.com,,\n,www.EXAMPLE.COM,,\n" .
+				".Duplicate.Example,,\n,DUPLICATE.example,,\n,www.duplicate.EXAMPLE,,\n" .
+				".duplicate.example,,\n,Duplicate.Example,,\n,www.DUPLICATE.EXAMPLE,,\n",
+			],
+			'native-mode' => [
+				".Example.COM 60\n\"example.com 60\n\"www.EXAMPLE.COM 60\n" .
+				".Duplicate.Example 60\n\"DUPLICATE.example 60\n\"www.duplicate.EXAMPLE 60\n" .
+				".duplicate.example 60\n\"Duplicate.Example 60\n\"www.DUPLICATE.EXAMPLE 60\n",
+			],
+		];
+	}
+
+	#[DataProvider('legacyProjectionCases')]
+	public function testEnabledProjectsCompleteLegacyRecordsAndPreservesCachedSource(string $source): void
+	{
+		$source_path = "{$this->tmp}/db/pfbalexawhitelist.txt";
+		file_put_contents($source_path, $source);
+
+		$result = $this->publishTop1m();
+
+		$this->assertIsArray($result);
+		$this->assertSame($source, file_get_contents($source_path));
+		$this->assertSame(
+			"example.com\nduplicate.example\nduplicate.example\n",
+			file_get_contents($GLOBALS['pfb']['unbound_py_top1m'])
+		);
+		$this->assertFileExists($GLOBALS['pfb']['unbound_py_sources']);
+	}
+
+	public static function malformedLegacySources(): array
+	{
+		$comma = static fn(string $domain): string =>
+			".{$domain},,\n,{$domain},,\n,www.{$domain},,\n";
+		$native = static fn(string $domain): string =>
+			".{$domain} 60\n\"{$domain} 60\n\"www.{$domain} 60\n";
+		$overlong_domain = 'aa.' . implode('.', array_fill(0, 126, 'a'));
+
+		return [
+			'mixed families'       => [$comma('one.example') . $native('two.example')],
+			'CRLF'                 => [str_replace("\n", "\r\n", $comma('bad.example'))],
+			'blank'                => [$comma('bad.example') . "\n"],
+			'header'               => [$comma('bad.example') . "header\n"],
+			'extra line'           => [$comma('bad.example') . ".extra.example,,\n"],
+			'incomplete triple'    => [".bad.example,,\n,bad.example,,\n"],
+			'missing final LF'     => [rtrim($comma('bad.example'), "\n")],
+			'mismatched domains'   => [".one.example,,\n,two.example,,\n,www.one.example,,\n"],
+			'mixed triple'         => [".bad.example,,\n\"bad.example 60\n\"www.bad.example 60\n"],
+			'underscore'           => [$comma('bad_name.example')],
+			'Unicode'              => [$comma('tést.example')],
+			'dotless'              => [$comma('dotless')],
+			'overlong label'       => [$comma(str_repeat('a', 64) . '.example')],
+			'overlong domain'      => [$comma($overlong_domain)],
+			'leading hyphen'       => [$comma('-bad.example')],
+			'trailing hyphen'      => [$comma('bad-.example')],
+			'overlong source line' => ['.' . str_repeat('a', 1100) . ",,\n"],
+		];
+	}
+
+	#[DataProvider('malformedLegacySources')]
+	public function testMalformedLegacySourceRollsBackTargetAndManifest(string $source): void
+	{
+		$this->seedPreviousPublication();
+		file_put_contents("{$this->tmp}/db/pfbalexawhitelist.txt", $source);
+
+		$result = $this->publishTop1m();
+
+		$this->assertFalse($result);
+		$this->assertPreviousPublication();
+		$this->assertSame([], glob("{$this->tmp}/.pfbtop1m_*") ?: []);
+	}
+
+	public static function publicationFailureOperations(): array
+	{
+		return [
+			'write'    => ['write'],
+			'flush'    => ['flush'],
+			'fsync'    => ['fsync'],
+			'metadata' => ['metadata'],
+			'rename'   => ['rename'],
+		];
+	}
+
+	#[DataProvider('publicationFailureOperations')]
+	public function testLegacyProjectionFailureRollsBackTargetAndManifest(string $operation): void
+	{
+		$this->seedPreviousPublication();
+		file_put_contents(
+			"{$this->tmp}/db/pfbalexawhitelist.txt",
+			".legacy.example,,\n,legacy.example,,\n,www.legacy.example,,\n"
+		);
+		$ops = match ($operation) {
+			'write' => ['write' => static fn($stream, string $bytes): int => max(0, strlen($bytes) - 1)],
+			'flush' => ['flush' => static fn($stream): bool => FALSE],
+			'fsync' => ['fsync' => static fn($stream): bool => FALSE],
+			'metadata' => ['metadata' => static fn(string $file): bool => FALSE],
+			'rename' => ['rename' => static fn(string $from, string $to): bool => FALSE],
+		};
+
+		$result = $this->publishTop1m($ops);
+
+		$this->assertFalse($result);
+		$this->assertPreviousPublication();
+		$this->assertSame([], glob("{$this->tmp}/.pfbtop1m_*") ?: []);
+	}
+
+	public static function nonregularSourceKinds(): array
+	{
+		return [
+			'directory' => ['directory'],
+			'FIFO'      => ['FIFO'],
+			'symlink'   => ['symlink'],
+		];
+	}
+
+	#[DataProvider('nonregularSourceKinds')]
+	public function testEnabledRejectsNonregularOrSymlinkedSource(string $kind): void
+	{
+		$this->seedPreviousPublication();
+		$source = "{$this->tmp}/db/pfbalexawhitelist.txt";
+		if ($kind === 'directory') {
+			mkdir($source);
+		} elseif ($kind === 'FIFO') {
+			$this->assertTrue(posix_mkfifo($source, 0600));
+		} else {
+			$linked = "{$this->tmp}/legacy-source.txt";
+			file_put_contents($linked, ".legacy.example,,\n,legacy.example,,\n,www.legacy.example,,\n");
+			symlink($linked, $source);
+		}
+
+		$result = $this->publishTop1m();
+
+		$this->assertFalse($result);
+		$this->assertPreviousPublication();
+		$this->assertSame([], glob("{$this->tmp}/.pfbtop1m_*") ?: []);
+	}
+
 	public function testEnabledPublicationFailureLeavesPreviousFileAndManifest(): void
 	{
 		$target = $GLOBALS['pfb']['unbound_py_top1m'];
@@ -194,6 +334,26 @@ final class Top1mFixedFileManifestTest extends TestCase
 			'chgrp' => static fn(string $file, string $group): bool => TRUE,
 			'chmod' => static fn(string $file, int $mode): bool => TRUE,
 		];
+	}
+
+	private function publishTop1m(array $ops=array())
+	{
+		$GLOBALS['pfb']['dnsbl_top1m'] = 'on';
+		return pfb_unbound_python_sources([], [
+			'top1m_atomic' => $ops + $this->successfulOwnershipOps(),
+		]);
+	}
+
+	private function seedPreviousPublication(): void
+	{
+		file_put_contents($GLOBALS['pfb']['unbound_py_top1m'], "old.example\n");
+		file_put_contents($GLOBALS['pfb']['unbound_py_sources'], '{"old":true}');
+	}
+
+	private function assertPreviousPublication(): void
+	{
+		$this->assertSame("old.example\n", file_get_contents($GLOBALS['pfb']['unbound_py_top1m']));
+		$this->assertSame('{"old":true}', file_get_contents($GLOBALS['pfb']['unbound_py_sources']));
 	}
 
 	private function removeTree(string $dir): void

--- a/tests/php/Top1mFixedFileManifestTest.php
+++ b/tests/php/Top1mFixedFileManifestTest.php
@@ -287,10 +287,18 @@ final class Top1mFixedFileManifestTest extends TestCase
 	{
 		$this->seedPreviousPublication();
 		$source = "{$this->tmp}/db/pfbalexawhitelist.txt";
+		$fifo_guard = NULL;
+		$fifo_payload = '';
 		if ($kind === 'directory') {
 			mkdir($source);
 		} elseif ($kind === 'FIFO') {
 			$this->assertTrue(posix_mkfifo($source, 0600));
+			$fifo_guard = fopen($source, 'r+');
+			$this->assertIsResource($fifo_guard);
+			$this->assertTrue(stream_set_blocking($fifo_guard, FALSE));
+			$fifo_payload = ".one.example,,\n,two.example,,\n,www.one.example,,\n";
+			$this->assertSame(strlen($fifo_payload), fwrite($fifo_guard, $fifo_payload));
+			$this->assertTrue(fflush($fifo_guard));
 		} else {
 			$linked = "{$this->tmp}/legacy-source.txt";
 			file_put_contents($linked, ".legacy.example,,\n,legacy.example,,\n,www.legacy.example,,\n");
@@ -300,6 +308,10 @@ final class Top1mFixedFileManifestTest extends TestCase
 		$result = $this->publishTop1m();
 
 		$this->assertFalse($result);
+		if (is_resource($fifo_guard)) {
+			$this->assertSame($fifo_payload, fread($fifo_guard, strlen($fifo_payload)));
+			fclose($fifo_guard);
+		}
 		$this->assertPreviousPublication();
 		$this->assertSame([], glob("{$this->tmp}/.pfbtop1m_*") ?: []);
 	}

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -319,7 +319,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$got = file_get_contents($this->whitelistPath());
 		$this->assertNotFalse($got);
 		$this->assertStringNotContainsString('stale.com', $got, 'the stale build must be replaced, not appended to');
-		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got);
+		$this->assertSame("example.com\n", $got);
 		$this->assertSame([], $this->tempFilesLeftBehind(), 'no temp build file left behind');
 		$this->assertStringContainsString('Parsed 3 lines | Found 1 of 1000', $this->readMainLog());
 	}
@@ -345,7 +345,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$got = file_get_contents($this->whitelistPath());
 		$this->assertNotFalse($got);
 		$this->assertStringNotContainsString('stale.com', $got, 'a valid small-count feed must replace the stale whitelist');
-		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got);
+		$this->assertSame("example.com\n", $got);
 		$this->assertStringNotContainsString('keeping the previous TOP1M whitelist', $this->readErrLog(),
 			'a valid feed must NOT emit the dead-feed warning');
 		$this->assertStringContainsString('Parsed 1 lines | Found 1 of 1', $this->readMainLog());
@@ -399,7 +399,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		// matched nothing).
 		$got = file_get_contents($this->whitelistPath());
 		$this->assertNotFalse($got);
-		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+		$this->assertSame("example.com\n", $got,
 			'the domain must come from domain_col (index 2), and the header row must not count as data');
 		$this->assertStringContainsString('Parsed 1 lines | Found 1 of 1000', $this->readMainLog());
 	}
@@ -454,7 +454,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 
 		// Then (GREEN): both real domains are correctly extracted from index 2.
 		$this->assertSame(
-			".google.com,,\n,google.com,,\n,www.google.com,,\n.facebook.com,,\n,facebook.com,,\n,www.facebook.com,,\n",
+			"google.com\nfacebook.com\n",
 			file_get_contents($this->whitelistPath()),
 			'the registered Majestic descriptor must extract Domain from index 2'
 		);
@@ -519,8 +519,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		// Then (GREEN): both real domains are correctly extracted from index 1
 		// ('www.' stripped per the existing whitelist-building convention).
 		$this->assertSame(
-			".facebook.com,,\n,facebook.com,,\n,www.facebook.com,,\n"
-			. ".fonts.googleapis.com,,\n,fonts.googleapis.com,,\n,www.fonts.googleapis.com,,\n",
+			"facebook.com\nfonts.googleapis.com\n",
 			file_get_contents($this->whitelistPath()),
 			'the registered OpenPageRank descriptor must extract Domain from index 1'
 		);
@@ -560,7 +559,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		// Then: both real domains are correctly extracted from the single column despite
 		// carrying no comma -- proves the comma-requirement relaxation for domain_col 0.
 		$this->assertSame(
-			".google.com,,\n,google.com,,\n,www.google.com,,\n.facebook.com,,\n,facebook.com,,\n,www.facebook.com,,\n",
+			"google.com\nfacebook.com\n",
 			file_get_contents($this->whitelistPath()),
 			'the registered Cloudflare descriptor must extract the single-column domain despite no comma in the data'
 		);
@@ -723,7 +722,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		// Then: the punycode-TLD row is counted as valid data and whitelisted
 		// -- not silently dropped by the final-label guard.
 		$this->assertSame(
-			".example.xn--p1ai,,\n,example.xn--p1ai,,\n,www.example.xn--p1ai,,\n",
+			"example.xn--p1ai\n",
 			file_get_contents($this->whitelistPath()),
 			'a punycode TLD (xn--p1ai) row must be accepted by the csv-mode hostname guard, not dropped'
 		);
@@ -925,7 +924,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		// Then: the punycode-TLD row is counted as valid data and whitelisted -- not
 		// wrongly dropped by the newly-applied hostname-shape guard.
 		$this->assertSame(
-			".example.xn--p1ai,,\n,example.xn--p1ai,,\n,www.example.xn--p1ai,,\n",
+			"example.xn--p1ai\n",
 			file_get_contents($this->whitelistPath()),
 			'a punycode TLD (xn--p1ai) rank_domain row must be accepted by the hostname-shape guard, not dropped'
 		);

--- a/tests/php/Top1mTldCaseFoldTest.php
+++ b/tests/php/Top1mTldCaseFoldTest.php
@@ -130,7 +130,7 @@ final class Top1mTldCaseFoldTest extends TestCase
 
 		$got = file_get_contents($this->whitelistPath());
 		$this->assertNotFalse($got);
-		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+		$this->assertSame("example.com\n", $got,
 			'an uppercase domain must fold to lowercase before the TLD compare and the write');
 	}
 
@@ -148,7 +148,7 @@ final class Top1mTldCaseFoldTest extends TestCase
 
 		$got = file_get_contents($this->whitelistPath());
 		$this->assertNotFalse($got);
-		$this->assertSame(".example.xn--p1ai,,\n,example.xn--p1ai,,\n,www.example.xn--p1ai,,\n", $got,
+		$this->assertSame("example.xn--p1ai\n", $got,
 			'a mixed-case punycode TLD must fold to lowercase before the TLD compare');
 	}
 
@@ -165,7 +165,7 @@ final class Top1mTldCaseFoldTest extends TestCase
 
 		$got = file_get_contents($this->whitelistPath());
 		$this->assertNotFalse($got);
-		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+		$this->assertSame("example.com\n", $got,
 			"the 'www.' strip must run against the FOLDED domain, not the raw uppercase value");
 	}
 
@@ -201,7 +201,7 @@ final class Top1mTldCaseFoldTest extends TestCase
 
 		$got = file_get_contents($this->whitelistPath());
 		$this->assertNotFalse($got);
-		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+		$this->assertSame("example.com\n", $got,
 			'an already-lowercase domain must match exactly as before -- no regression from the fold');
 	}
 
@@ -223,7 +223,7 @@ final class Top1mTldCaseFoldTest extends TestCase
 
 		$got = file_get_contents($this->whitelistPath());
 		$this->assertNotFalse($got);
-		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+		$this->assertSame("example.com\n", $got,
 			'domain_col 0 (real Cloudflare descriptor) must fold an uppercase single-column domain the same as every other column shape');
 	}
 
@@ -299,7 +299,7 @@ final class Top1mTldCaseFoldTest extends TestCase
 
 		$got = file_get_contents($this->whitelistPath());
 		$this->assertNotFalse($got);
-		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+		$this->assertSame("example.com\n", $got,
 			'an uppercase Domain field at domain_col 1 (real OpenPageRank descriptor) must still fold and match');
 	}
 
@@ -318,7 +318,7 @@ final class Top1mTldCaseFoldTest extends TestCase
 
 		$got = file_get_contents($this->whitelistPath());
 		$this->assertNotFalse($got);
-		$this->assertSame(".example.com,,\n,example.com,,\n,www.example.com,,\n", $got,
+		$this->assertSame("example.com\n", $got,
 			'a mixed-case Domain field at a non-default column (Majestic, index 2) must still fold and match');
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -7736,6 +7736,33 @@
         "returnType": "bool",
         "params": []
     },
+    "pfb_unbound_py_top1m_atomic_copy": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "source",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "stream_ops",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": "array (\n)"
+            }
+        ]
+    },
     "pfb_unbound_py_wait_applied": {
         "returnsRef": false,
         "returnType": null,

--- a/tests/smoke/test_top1m_fixed_file.py
+++ b/tests/smoke/test_top1m_fixed_file.py
@@ -417,30 +417,6 @@ def _complete_detector_sidecars(vm: SmokeVM) -> dict:
     )
 
 
-def _activate_domain_only_top1m(vm: SmokeVM, domain: str) -> dict:
-    """Publish one reader-valid domain and wait for the shipped watcher to apply it."""
-    body = f"{domain}\n"
-    return _json_eval(
-        vm,
-        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
-        "pfb_global();\n"
-        f"$fixture = {h._php_str(TEMP_PATHS[0])};\n"
-        f"$body = {h._php_str(body)};\n"
-        "$staged = @file_put_contents($fixture, $body, LOCK_EX) !== FALSE;\n"
-        f"$published = $staged && pfb_unbound_py_atomic_copy($fixture, '{TOP1M_FIXED}');\n"
-        "@unlink($fixture);\n"
-        "$generation = $published ? pfb_unbound_py_flip_sentinel() : FALSE;\n"
-        "$applied = is_int($generation) && pfb_unbound_py_wait_applied($generation, 60);\n"
-        "$out = array(\n"
-        "  'staged' => $staged, 'published' => $published, 'applied' => $applied,\n"
-        "  'generation' => $generation,\n"
-        f"  'fixed_regular' => is_file('{TOP1M_FIXED}') && !is_link('{TOP1M_FIXED}'),\n"
-        f"  'fixed_bytes' => @file_get_contents('{TOP1M_FIXED}'),\n"
-        ");",
-        "PFB1542READER",
-    )
-
-
 def _assert_vip(vm: SmokeVM, domain: str, stage: str) -> None:
     answer = h.dns_probe(vm, domain, "A")
     assert h.is_vip(answer), f"{stage}: {domain} should resolve to DNSBL VIP; got {answer}"
@@ -496,24 +472,14 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     first = _publication_state(vm)
     assert first["fixed_regular"], f"publisher did not create regular {TOP1M_FIXED}: {first!r}"
     assert first["fixed_bytes"] == first["whitelist_bytes"], "fixed file did not preserve publisher bytes"
+    assert first["fixed_bytes"] == f"{allowed}\n", f"TOP1M publisher did not emit canonical bytes: {first!r}"
     assert first["top1m_enabled"] is True
     assert first["top1m_keys"] == ["top1m_enabled"], f"manifest embeds retired TOP1M fields: {first!r}"
     assert allowed not in first["manifest_raw"], "manifest embeds TOP1M domain data instead of naming the fixed file"
     assert first["raw_identity"] is not None and first["raw_dir_identity"] is not None
 
-    # The legacy PHP generator currently comma-frames whitelist rows.  That is a
-    # separate pre-existing defect (#1569): preserve the publisher bytes above, then feed
-    # this change's stable-path reader the domain-only format it accepts.
-    reader_first = _activate_domain_only_top1m(vm, allowed)
-    reader_first_generation = reader_first.pop("generation")
+    reader_first_generation = first["reload_generation"]
     assert isinstance(reader_first_generation, int) and reader_first_generation > 0
-    assert reader_first == {
-        "staged": True,
-        "published": True,
-        "applied": True,
-        "fixed_regular": True,
-        "fixed_bytes": f"{allowed}\n",
-    }, reader_first
 
     h.flush_unbound_name(vm, allowed)
     _assert_stub_once(vm, allowed, "TOP1M allow")
@@ -540,16 +506,9 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     assert second["raw_dir_identity"] == first["raw_dir_identity"], "TOP1M-only update replaced unrelated generation"
     assert h.unbound_pid(vm) == pid_before, "TOP1M-only data change restarted Unbound instead of swapping"
 
-    reader_second = _activate_domain_only_top1m(vm, replacement)
-    reader_second_generation = reader_second.pop("generation")
+    assert second["fixed_bytes"] == f"{replacement}\n", f"replacement TOP1M bytes not canonical: {second!r}"
+    reader_second_generation = second["reload_generation"]
     assert isinstance(reader_second_generation, int)
-    assert reader_second == {
-        "staged": True,
-        "published": True,
-        "applied": True,
-        "fixed_regular": True,
-        "fixed_bytes": f"{replacement}\n",
-    }, reader_second
     assert reader_second_generation > reader_first_generation
 
     h.flush_unbound_name(vm, allowed)

--- a/tests/test_issue1542_top1m_fixed_file.py
+++ b/tests/test_issue1542_top1m_fixed_file.py
@@ -265,7 +265,7 @@ def test_enabled_rejects_invalid_top1m_domain_shape_and_wire_cap(tmp_path: Path,
 
 def test_enabled_top1m_is_exact_allow_with_www_fallback_not_deeper_wildcard(tmp_path: Path) -> None:
     manifest = _manifest(tmp_path)
-    (tmp_path / "feed.raw").write_text("blocked.example\nwww.blocked.example\n", encoding="utf-8")
+    (tmp_path / "feed.raw").write_text("blocked.example\nwww.blocked.example\n.blocked.example\n", encoding="utf-8")
     (tmp_path / "pfb_py_top1m.txt").write_text("blocked.example\nblocked.example\n", encoding="utf-8")
 
     result = P.dnsbl_build_from_manifest(str(manifest))

--- a/tests/test_issue1542_top1m_fixed_file.py
+++ b/tests/test_issue1542_top1m_fixed_file.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import json
 import os
+import subprocess
 import threading
 from collections.abc import Iterator
 from pathlib import Path
@@ -12,6 +13,8 @@ import pytest
 
 import pfb_unbound as P
 from tests.test_adr06_golden_oracle import _build_cfg, _decision_label
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _manifest(tmp_path: Path, *, enabled: bool = True) -> Path:
@@ -29,6 +32,64 @@ def _manifest(tmp_path: Path, *, enabled: bool = True) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def test_legacy_whitelist_reprocesses_to_python_exact_allow(tmp_path: Path) -> None:
+    (tmp_path / "top-1m.csv").write_text("1,LEGACY.COM\n", encoding="utf-8")
+    (tmp_path / "top-1m.csv.zip.orig").write_text("detector baseline\n", encoding="utf-8")
+    (tmp_path / "pfbalexawhitelist.txt").write_text(
+        ".legacy.com,,\n,legacy.com,,\n,www.legacy.com,,\n", encoding="utf-8"
+    )
+    php = r"""
+require 'tests/php/bootstrap.php';
+require_once 'src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+$dbdir = getenv('PFB_TOP1M_PROBE_DIR');
+mkdir($dbdir . '/dnsbl');
+$GLOBALS['pfb']['dbdir'] = $dbdir;
+$GLOBALS['pfb']['dnsdir'] = $dbdir . '/dnsbl';
+$GLOBALS['pfb']['dnsbl_top1m'] = 'on';
+$GLOBALS['pfb']['dnsbl_top1m_inc'] = 'com';
+$GLOBALS['pfb']['dnsbl_top1m_cnt'] = '1000';
+$GLOBALS['pfb']['dnsblconfig'] = ['tldblacklist' => '', 'tldexclusion' => '', 'suppression' => ''];
+$GLOBALS['pfb']['unbound_py_rawdir'] = $dbdir . '/raw';
+$GLOBALS['pfb']['unbound_py_sources'] = $dbdir . '/pfb_py_sources.json';
+$GLOBALS['pfb']['unbound_py_top1m'] = $dbdir . '/pfb_py_top1m.txt';
+$GLOBALS['pfb']['log'] = $dbdir . '/pfblockerng.log';
+$GLOBALS['pfb']['errlog'] = $dbdir . '/pfblockerng_error.log';
+$reprocess = pfb_top1m_reprocess_needed($dbdir);
+if ($reprocess) {
+    pfblockerng_top1m();
+    $published = pfb_unbound_python_sources([], ['top1m_atomic' => [
+        'chown' => static fn(string $file, string $owner): bool => TRUE,
+        'chgrp' => static fn(string $file, string $group): bool => TRUE,
+        'chmod' => static fn(string $file, int $mode): bool => TRUE,
+    ]]);
+    if ($published === FALSE) {
+        throw new RuntimeException('TOP1M fixed-file publication failed');
+    }
+}
+echo json_encode(['reprocess' => $reprocess], JSON_THROW_ON_ERROR);
+"""
+    env = os.environ.copy()
+    env["PFB_TOP1M_PROBE_DIR"] = str(tmp_path)
+    proc = subprocess.run(
+        ["php", "-r", php],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == {"reprocess": True}
+    assert (tmp_path / "pfbalexawhitelist.txt").read_bytes() == b"legacy.com\n"
+
+    result = P.dnsbl_build_from_manifest(str(_manifest(tmp_path)))
+    assert result is not None
+    assert result.white_db["legacy.com"]["wildcard"] is False
+    assert P.whitelist_check_domain("legacy.com", result.white_db, 1)
+    assert P.whitelist_check_domain("www.legacy.com", result.white_db, 1)
+    assert not P.whitelist_check_domain("deep.legacy.com", result.white_db, 1)
 
 
 def test_disabled_does_not_require_fixed_file(tmp_path: Path) -> None:

--- a/tests/test_issue1542_top1m_fixed_file.py
+++ b/tests/test_issue1542_top1m_fixed_file.py
@@ -265,7 +265,7 @@ def test_enabled_rejects_invalid_top1m_domain_shape_and_wire_cap(tmp_path: Path,
 
 def test_enabled_top1m_is_exact_allow_with_www_fallback_not_deeper_wildcard(tmp_path: Path) -> None:
     manifest = _manifest(tmp_path)
-    (tmp_path / "feed.raw").write_text("blocked.example\nwww.blocked.example\n.blocked.example\n", encoding="utf-8")
+    (tmp_path / "feed.raw").write_text("||blocked.example^\n", encoding="utf-8")
     (tmp_path / "pfb_py_top1m.txt").write_text("blocked.example\nblocked.example\n", encoding="utf-8")
 
     result = P.dnsbl_build_from_manifest(str(manifest))
@@ -296,7 +296,9 @@ def test_enabled_top1m_is_exact_allow_with_www_fallback_not_deeper_wildcard(tmp_
         == "whitelist"
     )
     deep_decision = P.evaluate_domain("deep.blocked.example", "deep.blocked.example", "example", False, cfg, containers)
+    assert deep_decision.is_found is True
     assert deep_decision.in_whitelist is False
+    assert _decision_label(deep_decision) == "block-null"
 
 
 @pytest.mark.parametrize("kind", ["missing", "directory", "unreadable"])

--- a/tests/test_issue1542_top1m_fixed_file.py
+++ b/tests/test_issue1542_top1m_fixed_file.py
@@ -28,6 +28,25 @@ echo json_encode([
 ], JSON_THROW_ON_ERROR);
 """
 
+OFFLINE_PUBLICATION_PROBE = r"""
+require 'tests/php/bootstrap.php';
+$root = getenv('PFB_TOP1M_PROBE_DIR');
+$GLOBALS['pfb']['dbdir'] = $root . '/db';
+$GLOBALS['pfb']['dnsdir'] = $root . '/dnsbl';
+$GLOBALS['pfb']['dnsbl_top1m'] = 'on';
+$GLOBALS['pfb']['dnsbl_tld_wildcard'] = '';
+$GLOBALS['pfb']['dnsblconfig'] = ['tldblacklist' => '', 'tldexclusion' => '', 'suppression' => ''];
+$GLOBALS['pfb']['unbound_py_rawdir'] = $root . '/pfb_py_raw';
+$GLOBALS['pfb']['unbound_py_sources'] = $root . '/pfb_py_sources.json';
+$GLOBALS['pfb']['unbound_py_top1m'] = $root . '/pfb_py_top1m.txt';
+$result = pfb_unbound_python_sources([], ['top1m_atomic' => [
+    'chown' => static fn(string $file, string $owner): bool => TRUE,
+    'chgrp' => static fn(string $file, string $group): bool => TRUE,
+    'chmod' => static fn(string $file, int $mode): bool => TRUE,
+]]);
+echo json_encode(['published' => is_array($result)], JSON_THROW_ON_ERROR);
+"""
+
 
 def _run_reprocess_probe(tmp_path: Path, *, timeout: int = 30) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
@@ -60,14 +79,20 @@ def _manifest(tmp_path: Path, *, enabled: bool = True) -> Path:
     return path
 
 
-def test_refresh_needed_short_circuits_without_opening_whitelist(tmp_path: Path) -> None:
+@pytest.mark.parametrize("current_baseline", [False, True], ids=["missing-baseline", "current-baseline"])
+def test_nonregular_whitelist_never_triggers_reprocessing(tmp_path: Path, current_baseline: bool) -> None:
     (tmp_path / "top-1m.csv").write_text("1,current.example\n", encoding="utf-8")
-    os.mkfifo(tmp_path / "pfbalexawhitelist.txt")
+    if current_baseline:
+        (tmp_path / "top-1m.csv.zip.orig").write_text("detector baseline\n", encoding="utf-8")
+    whitelist = tmp_path / "pfbalexawhitelist.txt"
+    os.mkfifo(whitelist)
+    fifo = os.open(whitelist, os.O_RDWR | os.O_NONBLOCK)
 
     try:
-        proc = _run_reprocess_probe(tmp_path, timeout=1)
-    except subprocess.TimeoutExpired:
-        pytest.fail("refresh-needed predicate opened the whitelist FIFO")
+        os.write(fifo, b".legacy.example,,\n")
+        proc = _run_reprocess_probe(tmp_path)
+    finally:
+        os.close(fifo)
 
     assert proc.returncode == 0, proc.stderr
     assert json.loads(proc.stdout)["reprocess"] is False
@@ -88,12 +113,59 @@ def test_current_canonical_whitelist_check_has_bounded_peak_memory(tmp_path: Pat
     assert result["peak_delta"] < 1024 * 1024
 
 
-def test_legacy_whitelist_reprocesses_to_python_exact_allow(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "legacy_wire",
+    [
+        b".offline.example,,\n,offline.example,,\n,www.offline.example,,\n",
+        b'.offline.example 60\n"offline.example 60\n"www.offline.example 60\n',
+    ],
+    ids=["python-mode", "native-mode"],
+)
+def test_offline_legacy_publication_projects_strict_exact_allow(tmp_path: Path, legacy_wire: bytes) -> None:
+    dbdir = tmp_path / "db"
+    dbdir.mkdir()
+    (tmp_path / "dnsbl").mkdir()
+    source = dbdir / "pfbalexawhitelist.txt"
+    source.write_bytes(legacy_wire)
+    env = os.environ.copy()
+    env["PFB_TOP1M_PROBE_DIR"] = str(tmp_path)
+
+    proc = subprocess.run(
+        ["php", "-r", OFFLINE_PUBLICATION_PROBE],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == {"published": True}
+    assert not (dbdir / "top-1m.csv.zip.orig").exists()
+    assert source.read_bytes() == legacy_wire
+    assert (tmp_path / "pfb_py_top1m.txt").read_bytes() == b"offline.example\n"
+
+    result = P.dnsbl_build_from_manifest(str(tmp_path / "pfb_py_sources.json"))
+    assert result is not None
+    assert result.white_db["offline.example"]["wildcard"] is False
+    assert P.whitelist_check_domain("offline.example", result.white_db, 1)
+    assert P.whitelist_check_domain("www.offline.example", result.white_db, 1)
+    assert not P.whitelist_check_domain("deep.offline.example", result.white_db, 1)
+
+
+@pytest.mark.parametrize(
+    "legacy_wire",
+    [
+        b".legacy.com,,\n,legacy.com,,\n,www.legacy.com,,\n",
+        b'.legacy.com 60\n"legacy.com 60\n"www.legacy.com 60\n',
+    ],
+    ids=["python-mode", "native-mode"],
+)
+def test_legacy_whitelist_reprocesses_to_python_exact_allow(tmp_path: Path, legacy_wire: bytes) -> None:
     (tmp_path / "top-1m.csv").write_text("1,LEGACY.COM\n", encoding="utf-8")
     (tmp_path / "top-1m.csv.zip.orig").write_text("detector baseline\n", encoding="utf-8")
-    (tmp_path / "pfbalexawhitelist.txt").write_text(
-        ".legacy.com,,\n,legacy.com,,\n,www.legacy.com,,\n", encoding="utf-8"
-    )
+    (tmp_path / "pfbalexawhitelist.txt").write_bytes(legacy_wire)
     php = r"""
 require 'tests/php/bootstrap.php';
 require_once 'src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';

--- a/tests/test_issue1542_top1m_fixed_file.py
+++ b/tests/test_issue1542_top1m_fixed_file.py
@@ -11,6 +11,7 @@ from typing import Any, Literal
 import pytest
 
 import pfb_unbound as P
+from tests.test_adr06_golden_oracle import _build_cfg, _decision_label
 
 
 def _manifest(tmp_path: Path, *, enabled: bool = True) -> Path:
@@ -38,11 +39,76 @@ def test_disabled_does_not_require_fixed_file(tmp_path: Path) -> None:
 
 def test_enabled_streams_fixed_file_with_crlf_blanks_and_first_writer_duplicates(tmp_path: Path) -> None:
     manifest = _manifest(tmp_path)
-    (tmp_path / "pfb_py_top1m.txt").write_bytes(b"first.example\r\n\r\n second.example \r\nfirst.example\r\n")
+    (tmp_path / "pfb_py_top1m.txt").write_bytes(b"first.example\r\n\r\n SECOND.EXAMPLE \r\nfirst.example\r\n")
     result = P.dnsbl_build_from_manifest(str(manifest))
     assert result is not None
     assert set(result.white_db) == {"first.example", "second.example"}
     assert result.white_db["first.example"]["important"] is True
+
+
+@pytest.mark.parametrize("legacy", [".legacy.example,,\n", ",legacy.example,,\n", ",www.legacy.example,,\n"])
+def test_enabled_rejects_retired_comma_framed_top1m_lines(tmp_path: Path, legacy: str) -> None:
+    manifest = _manifest(tmp_path)
+    (tmp_path / "pfb_py_top1m.txt").write_text(legacy, encoding="utf-8")
+
+    result = P.dnsbl_build_from_manifest(str(manifest))
+
+    assert result is not None
+    assert result.white_db == {}, f"retired TOP1M record became a whitelist key: {result.white_db!r}"
+    assert all("," not in key for key in result.white_db)
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        "dotless\n",
+        "a" * 63 + "." + "b" * 63 + "." + "c" * 63 + "." + "d" * 63 + ".com\n",
+    ],
+)
+def test_enabled_rejects_invalid_top1m_domain_shape_and_wire_cap(tmp_path: Path, invalid: str) -> None:
+    manifest = _manifest(tmp_path)
+    (tmp_path / "pfb_py_top1m.txt").write_text(invalid, encoding="utf-8")
+
+    result = P.dnsbl_build_from_manifest(str(manifest))
+
+    assert result is not None
+    assert result.white_db == {}
+
+
+def test_enabled_top1m_is_exact_allow_with_www_fallback_not_deeper_wildcard(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path)
+    (tmp_path / "feed.raw").write_text("blocked.example\nwww.blocked.example\n", encoding="utf-8")
+    (tmp_path / "pfb_py_top1m.txt").write_text("blocked.example\nblocked.example\n", encoding="utf-8")
+
+    result = P.dnsbl_build_from_manifest(str(manifest))
+
+    assert result is not None
+    assert result.white_db["blocked.example"]["wildcard"] is False
+    assert P.whitelist_check_domain("blocked.example", result.white_db, 1)
+    assert P.whitelist_check_domain("www.blocked.example", result.white_db, 1)
+    assert not P.whitelist_check_domain("deep.blocked.example", result.white_db, 1)
+
+    containers = {
+        "dataDB": result.data_db,
+        "zoneDB": result.zone_db,
+        "whiteDB": result.white_db,
+        "regexDB": {},
+        "feedGroupIndexDB": result.feed_group_index_db,
+        "hstsDB": {},
+    }
+    cfg = _build_cfg({}, has_white=True)
+    assert (
+        _decision_label(P.evaluate_domain("blocked.example", "blocked.example", "example", False, cfg, containers))
+        == "whitelist"
+    )
+    assert (
+        _decision_label(
+            P.evaluate_domain("www.blocked.example", "www.blocked.example", "example", False, cfg, containers)
+        )
+        == "whitelist"
+    )
+    deep_decision = P.evaluate_domain("deep.blocked.example", "deep.blocked.example", "example", False, cfg, containers)
+    assert deep_decision.in_whitelist is False
 
 
 @pytest.mark.parametrize("kind", ["missing", "directory", "unreadable"])

--- a/tests/test_issue1542_top1m_fixed_file.py
+++ b/tests/test_issue1542_top1m_fixed_file.py
@@ -16,6 +16,32 @@ from tests.test_adr06_golden_oracle import _build_cfg, _decision_label
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
+REPROCESS_PROBE = r"""
+require 'tests/php/bootstrap.php';
+require_once 'src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+memory_reset_peak_usage();
+$before = memory_get_usage();
+$reprocess = pfb_top1m_reprocess_needed(getenv('PFB_TOP1M_PROBE_DIR'));
+echo json_encode([
+    'reprocess' => $reprocess,
+    'peak_delta' => memory_get_peak_usage() - $before,
+], JSON_THROW_ON_ERROR);
+"""
+
+
+def _run_reprocess_probe(tmp_path: Path, *, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PFB_TOP1M_PROBE_DIR"] = str(tmp_path)
+    return subprocess.run(
+        ["php", "-r", REPROCESS_PROBE],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+
 
 def _manifest(tmp_path: Path, *, enabled: bool = True) -> Path:
     raw = tmp_path / "feed.raw"
@@ -32,6 +58,34 @@ def _manifest(tmp_path: Path, *, enabled: bool = True) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def test_refresh_needed_short_circuits_without_opening_whitelist(tmp_path: Path) -> None:
+    (tmp_path / "top-1m.csv").write_text("1,current.example\n", encoding="utf-8")
+    os.mkfifo(tmp_path / "pfbalexawhitelist.txt")
+
+    try:
+        proc = _run_reprocess_probe(tmp_path, timeout=1)
+    except subprocess.TimeoutExpired:
+        pytest.fail("refresh-needed predicate opened the whitelist FIFO")
+
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["reprocess"] is False
+
+
+def test_current_canonical_whitelist_check_has_bounded_peak_memory(tmp_path: Path) -> None:
+    (tmp_path / "top-1m.csv").write_text("1,current.example\n", encoding="utf-8")
+    (tmp_path / "top-1m.csv.zip.orig").write_text("detector baseline\n", encoding="utf-8")
+    with (tmp_path / "pfbalexawhitelist.txt").open("w", encoding="utf-8") as handle:
+        for index in range(200_000):
+            handle.write(f"domain-{index:06d}.example\n")
+
+    proc = _run_reprocess_probe(tmp_path)
+
+    assert proc.returncode == 0, proc.stderr
+    result = json.loads(proc.stdout)
+    assert result["reprocess"] is False
+    assert result["peak_delta"] < 1024 * 1024
 
 
 def test_legacy_whitelist_reprocesses_to_python_exact_allow(tmp_path: Path) -> None:
@@ -79,6 +133,7 @@ echo json_encode(['reprocess' => $reprocess], JSON_THROW_ON_ERROR);
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
     assert proc.returncode == 0, proc.stderr
     assert json.loads(proc.stdout) == {"reprocess": True}

--- a/tests/test_issue1542_top1m_fixed_file_contract.py
+++ b/tests/test_issue1542_top1m_fixed_file_contract.py
@@ -34,7 +34,7 @@ def test_enabled_multibyte_final_line_without_newline_consumes_exact_bytes(tmp_p
 
     result = P.dnsbl_build_from_manifest(str(manifest))
     assert result is not None
-    assert set(result.white_db) == {"éxample.test", "last.example"}
+    assert set(result.white_db) == {"last.example"}
 
 
 def test_enabled_uses_bounded_prepass_and_streaming_iterator(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Emit one lowercase bare domain per line from the TOP1M whitelist producer and keep the Python consumer strict.
- Atomically project both shipped legacy TOP1M fixed-file families to the canonical wire, including offline upgrades whose cached ZIP lacks the original source member.
- Validate complete legacy triples, preserve the previous fixed file and manifest on failure, and keep conversion memory bounded.
- Classify and publish from one source handle so a pathname replacement cannot race classification against copying.
- Keep canonical reprocessing bounded to a regular-file first-byte probe; reject symlinks, FIFOs, malformed records, and invalid DNS names.

Fixes #1569.

## Test-first proof

- Canonical producer/consumer contract: frozen tests executed red before production edits, then green unchanged.
- Legacy rebuild and resource-path behavior: frozen transition tests executed red before each production edit, then green unchanged.
- Atomic upgrade projector:
  - Python test hash: `02dffcef3df9d2d9dbc95488d24881d5d4b36bef`
  - PHP test hash: `2d6076831ccc7e4f2b658c2efffe8b4ab4622847`
  - RED: PHP 36 tests with 19 expected failures; selected Python 7 tests with 4 failures.
  - GREEN: PHP 36 tests / 139 assertions; selected Python 7 tests passed unchanged.
- Source-snapshot race:
  - Frozen test commit: `55e37aab`
  - Test hash: `cdada978813439f68a0006d560ffd9ea17e7cb04`
  - RED: old implementation opened the classified path twice.
  - GREEN: final implementation publishes through the single classified handle.

## Verification

- Canonical local gates: pytest, Ruff check/format, mypy, PHP lint, PHPUnit, PHPStan, and PHPCS passed.
- Final focused coverage: Python 34 tests passed; PHP 87 tests / 575 assertions passed before the final test-only review correction.
- Final test-only review correction: focused Python test passed; PHP 3 tests / 18 assertions passed; complete canonical gates passed.
- Appliance smoke `top1m_fixed_file_publish_reload_cache_and_teardown`: 1 passed, 819 deselected in 87.87s.
- Independent top-tier production review plus separate Standards and Spec reviews: PASS.
- The separate pre-existing unchecked-write defect found during review is tracked as #1646.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
