### PR TITLE
ci: pin Ruff formatter version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Ruff
-        run: pip install ruff
+        run: pip install ruff==0.15.22
 
       - name: Ruff lint
         # Config in pyproject.toml.

--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ruff_ci_install_is_pinned() -> None:
+    workflow = (ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
+    ruff_job = workflow.split("\n  ruff:\n", 1)[1].split("\n  shellcheck:\n", 1)[0]
+    install_step = ruff_job.split("      - name: Install Ruff\n", 1)[1].split("\n      - name:", 1)[0].strip()
+    ruff_installs = [line.strip() for line in ruff_job.splitlines() if "pip install" in line and "ruff" in line]
+
+    assert install_step == "run: pip install ruff==0.15.22"
+    assert ruff_installs == ["run: pip install ruff==0.15.22"]


### PR DESCRIPTION
## Summary

- Pin the GitHub Actions Ruff installation to 0.15.22.
- Preserve the existing Ruff lint and format commands.
- Add a regression test that rejects an unpinned CI install.

Fixes #1644

## Why

PR #1643 exposed formatter dependency drift: the workflow's unpinned install selected Ruff 0.16.0, which began checking Python code blocks in three unchanged Markdown files. The branch itself did not touch those files or Ruff configuration. Pinning the repository's currently passing version restores deterministic CI without rewriting immutable ADR bodies or unrelated research documents.

## Verification

- Frozen final test hash: `320c16b44ee5b724a07ec3d4d26d076d117c54b7`.
- Test-only commit `1d66c073`: expected RED against the unpinned workflow.
- Final commit `bb47bae3`: GREEN, 1 test passed.
- `verify-red-proof.sh`: `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`.
- `GIT_CONFIG_GLOBAL=/dev/null rtk scripts/agent/run-gates.sh --diff origin/devel`: pytest, Ruff lint, Ruff format, and mypy passed.
- Independent review found the original whole-workflow assertion could false-pass with a decoy pin. The corrected test isolates `jobs.ruff`, verifies the exact `Install Ruff` step, rejects additional Ruff installs, and passed direct-unpin, upgrade-plus-decoy, and duplicate-install probes.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
