### PR TITLE
dnsbl: detect TOP1M write failures

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10138,10 +10138,7 @@ function pfblockerng_top1m(?array $provider_override = NULL, array $stream_ops=a
 
 			if ($write_failed) {
 				unlink_if_exists($tmp_file);
-				$preservation = $had_previous
-					? 'keeping the previous TOP1M whitelist.'
-					: 'no TOP1M whitelist available.';
-				pfb_logger("\n  TOP1M: failed to write the new whitelist build -- {$preservation}\n", 2);
+				pfb_logger("\n  TOP1M: failed to write the new whitelist build -- publication aborted.\n", 2);
 			}
 			else if ($linecnt === 0) {
 				// Dead feed (empty/invalid top-1m.csv) -- discard the temp build and

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10012,7 +10012,8 @@ function pfb_top1m_candidate_valid(string $path, array $provider): bool
 // pfb_top1m_providers()[$pfb['dnsbl_top1m_type']->value] -- lets a unit test
 // exercise a synthetic descriptor's knobs without a live provider. Production
 // never passes it, so the resolved-provider path is exactly today's behaviour.
-function pfblockerng_top1m(?array $provider_override = NULL) {
+// $stream_ops is the filesystem-boundary test seam; production uses fwrite().
+function pfblockerng_top1m(?array $provider_override = NULL, array $stream_ops=array()) {
 	global $pfb;
 
 	if (empty($pfb['dnsbl_top1m_inc'])) {
@@ -10065,6 +10066,9 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 			pfb_logger("\n  TOP1M: could not create the temp whitelist file -- keeping the previous TOP1M whitelist.\n", 2);
 		}
 		else {
+			$write_fn = $stream_ops['write'] ?? static fn($stream, $bytes) => @fwrite($stream, $bytes);
+			$write_failed = FALSE;
+
 			// ADR-59: skip exactly the first physical line unconditionally when
 			// the provider ships a header row -- before the content filter below, so
 			// a header line's shape (which may not even contain a '.'/',') never
@@ -10117,7 +10121,12 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 
 					// Canonical TOP1M wire: one bare domain per line; exact lookup also allows only www.
 					// Deeper subdomains remain unallowed.
-					@fwrite($pfb_output, "{$domain}\n");
+					$record = "{$domain}\n";
+					$written = $write_fn($pfb_output, $record);
+					if ($written === FALSE || $written !== strlen($record)) {
+						$write_failed = TRUE;
+						break;
+					}
 				}
 
 				if ($x >= $pfb['dnsbl_top1m_cnt']) {
@@ -10127,7 +10136,14 @@ function pfblockerng_top1m(?array $provider_override = NULL) {
 			@fclose($pfb_output);
 			@fclose($handle);
 
-			if ($linecnt === 0) {
+			if ($write_failed) {
+				unlink_if_exists($tmp_file);
+				$preservation = $had_previous
+					? 'keeping the previous TOP1M whitelist.'
+					: 'no TOP1M whitelist available.';
+				pfb_logger("\n  TOP1M: failed to write the new whitelist build -- {$preservation}\n", 2);
+			}
+			else if ($linecnt === 0) {
 				// Dead feed (empty/invalid top-1m.csv) -- discard the temp build and
 				// keep whatever whitelist was already on disk instead of wiping it.
 				unlink_if_exists($tmp_file);

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -312,8 +312,8 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		];
 	}
 
-	/** Issue #1646: a write failure without a prior whitelist reports that none is available. */
-	public function testRecordWriteFailureWithoutPriorWhitelistWarnsNoListAvailable(): void
+	/** Issue #1646: a write failure without a prior whitelist aborts without publishing. */
+	public function testRecordWriteFailureWithoutPriorWhitelistAbortsPublication(): void
 	{
 		$this->assertFileDoesNotExist($this->whitelistPath(), 'before-state: no prior whitelist');
 		$this->assertNotFalse(file_put_contents($this->csvPath(), "1,example.com\n"), 'setup: valid top-1m.csv');

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -326,7 +326,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 			'a failed record write must not publish a new TOP1M whitelist');
 		$this->assertSame([], $this->tempFilesLeftBehind(), 'no staging file left after a failed first publication');
 		$this->assertStringContainsString('failed to write the new whitelist build', $this->readErrLog());
-		$this->assertStringContainsString('no TOP1M whitelist available', $this->readErrLog());
+		$this->assertStringContainsString('publication aborted', $this->readErrLog());
 		$this->assertStringNotContainsString('Parsed 1 lines', $this->readMainLog(),
 			'a failed first publication must not report success');
 	}

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -276,6 +276,56 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		$this->assertStringContainsString('failed to publish the new whitelist build', $this->readErrLog());
 	}
 
+	/**
+	 * Issue #1646: a failed or short record write must abort publication instead of
+	 * renaming a truncated staging file over the previous valid whitelist.
+	 */
+	#[DataProvider('recordWriteFailures')]
+	public function testRecordWriteFailurePreservesPriorWhitelistAndWarns(string $failure): void
+	{
+		$priorContent = "kept.example\n";
+		$this->assertNotFalse(file_put_contents($this->whitelistPath(), $priorContent), 'setup: seed prior whitelist');
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "1,example.com\n"), 'setup: valid top-1m.csv');
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()), 'before-state sanity');
+
+		$write = match ($failure) {
+			'false' => static fn($stream, string $bytes) => FALSE,
+			'short' => static fn($stream, string $bytes) => strlen($bytes) - 1,
+		};
+
+		pfblockerng_top1m(NULL, ['write' => $write]);
+
+		$this->assertSame($priorContent, file_get_contents($this->whitelistPath()),
+			"a {$failure} record write must preserve the previous TOP1M whitelist");
+		$this->assertSame([], $this->tempFilesLeftBehind(), "no staging file left after a {$failure} write");
+		$this->assertStringContainsString('failed to write the new whitelist build', $this->readErrLog());
+		$this->assertStringNotContainsString('Parsed 1 lines', $this->readMainLog(),
+			"a {$failure} write must not report successful publication");
+	}
+
+	/** @return array<string, array{string}> */
+	public static function recordWriteFailures(): array
+	{
+		return [
+			'fwrite false' => ['false'],
+			'fwrite short' => ['short'],
+		];
+	}
+
+	/** Issue #1646: the injected full-write boundary still publishes canonical bytes. */
+	public function testCompleteRecordWritePublishesCanonicalBytes(): void
+	{
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "1,example.com\n"), 'setup: valid top-1m.csv');
+
+		pfblockerng_top1m(NULL, [
+			'write' => static fn($stream, string $bytes) => fwrite($stream, $bytes),
+		]);
+
+		$this->assertSame("example.com\n", file_get_contents($this->whitelistPath()));
+		$this->assertSame([], $this->tempFilesLeftBehind(), 'no staging file left after a complete write');
+		$this->assertStringContainsString('Parsed 1 lines | Found 1 of 1000', $this->readMainLog());
+	}
+
 	/** Same dead-feed path, but with NO prior whitelist -- says so, and still no wipe/creation. */
 	public function testEmptyFeedWithNoPriorWhitelistWarnsNoListAvailable(): void
 	{

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -312,6 +312,25 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 		];
 	}
 
+	/** Issue #1646: a write failure without a prior whitelist reports that none is available. */
+	public function testRecordWriteFailureWithoutPriorWhitelistWarnsNoListAvailable(): void
+	{
+		$this->assertFileDoesNotExist($this->whitelistPath(), 'before-state: no prior whitelist');
+		$this->assertNotFalse(file_put_contents($this->csvPath(), "1,example.com\n"), 'setup: valid top-1m.csv');
+
+		pfblockerng_top1m(NULL, [
+			'write' => static fn($stream, string $bytes) => FALSE,
+		]);
+
+		$this->assertFileDoesNotExist($this->whitelistPath(),
+			'a failed record write must not publish a new TOP1M whitelist');
+		$this->assertSame([], $this->tempFilesLeftBehind(), 'no staging file left after a failed first publication');
+		$this->assertStringContainsString('failed to write the new whitelist build', $this->readErrLog());
+		$this->assertStringContainsString('no TOP1M whitelist available', $this->readErrLog());
+		$this->assertStringNotContainsString('Parsed 1 lines', $this->readMainLog(),
+			'a failed first publication must not report success');
+	}
+
 	/** Issue #1646: the injected full-write boundary still publishes canonical bytes. */
 	public function testCompleteRecordWritePublishesCanonicalBytes(): void
 	{

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -8999,6 +8999,13 @@
                 "variadic": false,
                 "type": "?array",
                 "default": "NULL"
+            },
+            {
+                "name": "stream_ops",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": "array (\n)"
             }
         ]
     },


### PR DESCRIPTION
## Summary

- Check every TOP1M whitelist record write for `false` and short-write results.
- Abort the build, remove its staging file, preserve the previous whitelist, and log a failure instead of renaming truncated output.
- Keep complete-write publication, empty/invalid-feed preservation, and atomic rename behavior unchanged.
- Add a filesystem-boundary injection seam solely for deterministic write-failure tests.

Fixes #1646.

## Test-first proof

- Frozen test commit: `fdcbae01`
- Frozen test SHA-256: `fd20f062c193d8470d0450bb134e7f1744e8edbe0284f086af22a5482223b64e`
- RED before production edit: 3 selected tests, 2 failures. Both false and short writes replaced `kept.example` with `example.com`.
- GREEN with unchanged test bytes: 3 tests, 32 assertions.
- Review correction removed an unnecessary prior/no-prior warning branch:
  - Frozen correction test SHA-256: `5783290b561dfec3075f7ae764b0530cb5249cb5c8820f06a89c416f782baf6f`
  - RED: 1 selected test failed because no generic publication-aborted warning existed.
  - GREEN with unchanged correction-test bytes: 4 selected tests, 45 assertions.
- Focused TOP1M writer plus function-inventory coverage: 35 tests, 345 assertions.
- All TOP1M tests outside the known #1594 sandbox fixture limitation passed; the elevated canonical gate reran the repository PHPUnit suite with fixture binding available.

## Verification

- `scripts/agent/run-gates.sh`: PASS
- PHP syntax, PHPUnit, PHPStan, and PHPCS: PASS
- Independent Standards and Spec reviews: PASS on exact final head `e382cce7`.
- Hosted CI: every required job passed, including aggregate tests and Aikido security scan.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
