### PR TITLE
www: fixed-string match the block-page dnsbl.log correlation grep

### DIFF
--- a/src/usr/local/www/pfblockerng/www/index.php
+++ b/src/usr/local/www/pfblockerng/www/index.php
@@ -65,7 +65,10 @@ if (file_exists('/var/log/pfblockerng/dnsbl.log')) {
 			$now = escapeshellarg($ts);
 			$domain = escapeshellarg(',' . $ptype['HTTP_HOST'] . ',');
 
-			exec("/usr/bin/tail -n50 /var/log/pfblockerng/dnsbl.log | /usr/bin/grep {$domain} | /usr/bin/grep {$now} | /usr/bin/tail -1", $data, $retval);
+			// issue #1652: -F -- the host is data, not a pattern; as a BRE its
+			// '.' wildcard-matched any char and could select a DIFFERENT
+			// entry's row (ads.example.com matching ads-example.com).
+			exec("/usr/bin/tail -n50 /var/log/pfblockerng/dnsbl.log | /usr/bin/grep -F -- {$domain} | /usr/bin/grep {$now} | /usr/bin/tail -1", $data, $retval);
 			if (isset($data[0]) && !empty($data[0])) {
 				$data = explode(',', $data[0]);
 				if (is_array($data) && !empty($data)) {

--- a/tests/php/LogFormatConsumersTest.php
+++ b/tests/php/LogFormatConsumersTest.php
@@ -139,7 +139,8 @@ final class LogFormatConsumersTest extends TestCase
 		$domain = escapeshellarg(',' . $host . ',');
 
 		$data = [];
-		exec("/usr/bin/tail -n50 {$log} | /usr/bin/grep -F -- {$domain} | /usr/bin/grep {$now} | /usr/bin/tail -1", $data, $retval);
+		$logArg = escapeshellarg($log);
+		exec("/usr/bin/tail -n50 {$logArg} | /usr/bin/grep -F -- {$domain} | /usr/bin/grep {$now} | /usr/bin/tail -1", $data, $retval);
 		$this->assertSame(0, $retval, 'the reproduced pipeline must exit 0');
 		$this->assertNotEmpty($data, 'the ISO-format log line must be found by the rebuilt grep key (green)');
 
@@ -214,7 +215,7 @@ final class LogFormatConsumersTest extends TestCase
 		// index.php's exact key construction, per host queried.
 		$pipelineFor = static fn (string $host): string => str_replace(
 			['/var/log/pfblockerng/dnsbl.log', '{$domain}', '{$now}'],
-			[$log, escapeshellarg(',' . $host . ','), $now],
+			[escapeshellarg($log), escapeshellarg(',' . $host . ','), $now],
 			$m[1]
 		);
 

--- a/tests/php/LogFormatConsumersTest.php
+++ b/tests/php/LogFormatConsumersTest.php
@@ -114,7 +114,7 @@ final class LogFormatConsumersTest extends TestCase
 			"www/index.php's outer timestamp build changed -- update this oracle"
 		);
 		$this->assertStringContainsString(
-			'/usr/bin/tail -n50 /var/log/pfblockerng/dnsbl.log | /usr/bin/grep {$domain} | /usr/bin/grep {$now} | /usr/bin/tail -1',
+			'/usr/bin/tail -n50 /var/log/pfblockerng/dnsbl.log | /usr/bin/grep -F -- {$domain} | /usr/bin/grep {$now} | /usr/bin/tail -1',
 			$source,
 			"www/index.php's correlation exec() pipeline changed -- update this oracle"
 		);
@@ -139,7 +139,7 @@ final class LogFormatConsumersTest extends TestCase
 		$domain = escapeshellarg(',' . $host . ',');
 
 		$data = [];
-		exec("/usr/bin/tail -n50 {$log} | /usr/bin/grep {$domain} | /usr/bin/grep {$now} | /usr/bin/tail -1", $data, $retval);
+		exec("/usr/bin/tail -n50 {$log} | /usr/bin/grep -F -- {$domain} | /usr/bin/grep {$now} | /usr/bin/tail -1", $data, $retval);
 		$this->assertSame(0, $retval, 'the reproduced pipeline must exit 0');
 		$this->assertNotEmpty($data, 'the ISO-format log line must be found by the rebuilt grep key (green)');
 
@@ -178,6 +178,60 @@ final class LogFormatConsumersTest extends TestCase
 		$this->assertEmpty(
 			$data,
 			'the OLD 3-space-token key must NOT match a NEW ISO-format log line -- this is the live breakage Phase 5 fixes'
+		);
+	}
+
+	/**
+	 * issue #1652: the correlation grep embedded the host as an unanchored
+	 * Basic Regular Expression, so '.' wildcard-matched any character and a
+	 * blocked host could correlate to a DIFFERENT entry's row --
+	 * `ads.example.com` matching `ads-example.com`'s line -- rendering the
+	 * wrong Group/Feed/Evaluated-Domain on the block page. Runs the CURRENT
+	 * source's exec() pipeline (extracted from www/index.php, not
+	 * hand-copied, so this test goes red on the unfixed BRE grep and pins
+	 * the fixed-string `-F` match against regression) with index.php's exact
+	 * key construction, against a log holding ONLY the lookalike host's row.
+	 */
+	public function testBlockPageCorrelationNeverMatchesLookalikeHostRow(): void
+	{
+		$source = (string) file_get_contents(self::INDEX_PHP);
+		$matched = preg_match(
+			'#exec\("(/usr/bin/tail -n50 /var/log/pfblockerng/dnsbl\.log[^"]+)", \$data, \$retval\);#',
+			$source,
+			$m
+		);
+		$this->assertSame(1, $matched, 'could not extract the correlation exec() pipeline from www/index.php');
+
+		$log = $this->tempFile('pfb_dnsbl_lookalike_');
+		// ONLY the lookalike's row: '-' exactly where the victim host has '.'.
+		file_put_contents(
+			$log,
+			"DNSBL-python,2026-07-08 14:30:15,ads-example.com,203.0.113.9,Python,DNSBL-Full,LookalikeGroup,ads-example.com,LookalikeFeed,+,A\n"
+		);
+
+		$ts = '2026-07-08 14:30';
+		$now = escapeshellarg($ts);
+		// index.php's exact key construction, per host queried.
+		$pipelineFor = static fn (string $host): string => str_replace(
+			['/var/log/pfblockerng/dnsbl.log', '{$domain}', '{$now}'],
+			[$log, escapeshellarg(',' . $host . ','), $now],
+			$m[1]
+		);
+
+		// Control (before-state discipline): the lookalike host itself DOES
+		// correlate to its own row, proving the fixture, key construction, and
+		// extracted pipeline find a genuine match.
+		$ownData = [];
+		exec($pipelineFor('ads-example.com'), $ownData);
+		$this->assertNotEmpty($ownData, "control: the lookalike host must correlate to its OWN row");
+
+		$data = [];
+		exec($pipelineFor('ads.example.com'), $data);
+		$this->assertSame(
+			[],
+			$data,
+			"a blocked host must never correlate to a DIFFERENT entry's row ('.' must not wildcard-match '-'); matched: "
+			. implode(' | ', $data)
 		);
 	}
 

--- a/tests/php/LogFormatConsumersTest.php
+++ b/tests/php/LogFormatConsumersTest.php
@@ -187,11 +187,8 @@ final class LogFormatConsumersTest extends TestCase
 	 * Basic Regular Expression, so '.' wildcard-matched any character and a
 	 * blocked host could correlate to a DIFFERENT entry's row --
 	 * `ads.example.com` matching `ads-example.com`'s line -- rendering the
-	 * wrong Group/Feed/Evaluated-Domain on the block page. Runs the CURRENT
-	 * source's exec() pipeline (extracted from www/index.php, not
-	 * hand-copied, so this test goes red on the unfixed BRE grep and pins
-	 * the fixed-string `-F` match against regression) with index.php's exact
-	 * key construction, against a log holding ONLY the lookalike host's row.
+	 * wrong Group/Feed/Evaluated-Domain on the block page. A log containing
+	 * only the lookalike host's row must not correlate to the blocked host.
 	 */
 	public function testBlockPageCorrelationNeverMatchesLookalikeHostRow(): void
 	{

--- a/tests/smoke/ui/test_dnsbl_block_page.py
+++ b/tests/smoke/ui/test_dnsbl_block_page.py
@@ -27,8 +27,13 @@ from .. import helpers
 
 pytestmark = pytest.mark.ui_e2e
 
+DNSBL_LOG = "/var/log/pfblockerng/dnsbl.log"
 
-def test_dnsbl_block_page_shows_real_correlation_detail(deployed_vm: helpers.SmokeVM) -> None:
+
+def test_dnsbl_block_page_shows_real_correlation_detail(
+    deployed_vm: helpers.SmokeVM,
+    request: pytest.FixtureRequest,
+) -> None:
     """Scenario: a real DNSBL block correlates into the sinkhole page's detail row.
 
     Given a DNSBL feed listing one unique test domain (VIP mode).
@@ -58,6 +63,43 @@ def test_dnsbl_block_page_shows_real_correlation_detail(deployed_vm: helpers.Smo
         # HTTP probe below only makes sense once this is asserted true.
         answer = helpers.dns_probe(deployed_vm, domain)
         assert helpers.is_vip(answer), f"expected VIP block for {domain!r}, got answer: {answer!r}"
+
+        # issue #1652: append a later lookalike row that the old BRE grep also
+        # matched (a domain '.' acted as a wildcard for '-'). The page must keep
+        # correlating the genuine row, not tail-select this forged attribution.
+        lookalike = domain.replace(".", "-", 1)
+        before_size = deployed_vm.ssh("stat", "-f", "%z", DNSBL_LOG)
+        assert before_size.returncode == 0 and before_size.stdout.strip().isdigit(), (
+            f"could not size {DNSBL_LOG} before lookalike append: "
+            f"rc={before_size.returncode} out={before_size.stdout!r} err={before_size.stderr!r}"
+        )
+
+        def restore_log() -> None:
+            restored = deployed_vm.ssh("truncate", "-s", before_size.stdout.strip(), DNSBL_LOG)
+            assert restored.returncode == 0, (
+                f"could not truncate {DNSBL_LOG} after lookalike test: rc={restored.returncode} err={restored.stderr!r}"
+            )
+
+        request.addfinalizer(restore_log)
+        guest_now = deployed_vm.ssh("date", "+%Y-%m-%d %H:%M:%S")
+        assert guest_now.returncode == 0 and guest_now.stdout.strip(), (
+            f"could not read guest timestamp: rc={guest_now.returncode} err={guest_now.stderr!r}"
+        )
+        lookalike_row = (
+            f"DNSBL-python,{guest_now.stdout.strip()},{lookalike},203.0.113.9,Python,"
+            f"DNSBL-Full,LookalikeGroup,{lookalike},LookalikeFeed,+,A\n"
+        )
+        appended = subprocess.run(
+            deployed_vm.ssh_argv("tee", "-a", DNSBL_LOG),
+            input=lookalike_row,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        assert appended.returncode == 0, (
+            f"could not append lookalike row to {DNSBL_LOG}: rc={appended.returncode} err={appended.stderr!r}"
+        )
 
         # THEN: an on-box curl to the sinkhole (the DNSBL VIP is a loopback-scoped
         # lo0 IP-alias, unreachable from the runner) with Host set to the

--- a/tests/smoke/ui/test_dnsbl_block_page.py
+++ b/tests/smoke/ui/test_dnsbl_block_page.py
@@ -69,12 +69,25 @@ def test_dnsbl_block_page_shows_real_correlation_detail(
         answer = helpers.dns_probe(deployed_vm, domain)
         assert helpers.is_vip(answer), f"expected VIP block for {domain!r}, got answer: {answer!r}"
 
+        # The ssh default (60s) outruns wait_until's 12s deadline, so a post-connect stall
+        # burns the whole poll without ever reporting why. Cap each probe just under that
+        # deadline and poll THROUGH a stall (ConnectTimeout is 10s, so a shorter hard
+        # failure would trade one flake for another), keeping the rc/stderr that grep rc=2
+        # (unreadable log) and ssh rc=255 (transport) would otherwise hide behind a bare
+        # "row not found".
+        last_probe: dict[str, object] = {}
+
         def log_contains(blocked_domain: str) -> bool:
-            result = deployed_vm.ssh("grep", "-Fq", "--", f",{blocked_domain},", DNSBL_LOG)
+            try:
+                result = deployed_vm.ssh("grep", "-Fq", "--", f",{blocked_domain},", DNSBL_LOG, timeout=11.0)
+            except subprocess.TimeoutExpired:
+                last_probe.update(rc="ssh timed out after 11.0s", stderr="")
+                return False
+            last_probe.update(rc=result.returncode, stderr=result.stderr)
             return result.returncode == 0
 
         assert helpers.wait_until(lambda: log_contains(domain), timeout=12.0, interval=0.5), (
-            f"genuine DNSBL log row for {domain!r} did not arrive"
+            f"genuine DNSBL log row for {domain!r} did not arrive ({last_probe})"
         )
 
         # issue #1652: create a genuine, later lookalike event that the old BRE
@@ -86,7 +99,7 @@ def test_dnsbl_block_page_shows_real_correlation_detail(
             f"expected VIP block for lookalike {lookalike!r}, got answer: {lookalike_answer!r}"
         )
         assert helpers.wait_until(lambda: log_contains(lookalike), timeout=12.0, interval=0.5), (
-            f"genuine DNSBL log row for lookalike {lookalike!r} did not arrive"
+            f"genuine DNSBL log row for lookalike {lookalike!r} did not arrive ({last_probe})"
         )
 
         # THEN: an on-box curl to the sinkhole (the DNSBL VIP is a loopback-scoped

--- a/tests/smoke/ui/test_dnsbl_block_page.py
+++ b/tests/smoke/ui/test_dnsbl_block_page.py
@@ -32,7 +32,6 @@ DNSBL_LOG = "/var/log/pfblockerng/dnsbl.log"
 
 def test_dnsbl_block_page_shows_real_correlation_detail(
     deployed_vm: helpers.SmokeVM,
-    request: pytest.FixtureRequest,
 ) -> None:
     """Scenario: a real DNSBL block correlates into the sinkhole page's detail row.
 
@@ -46,8 +45,14 @@ def test_dnsbl_block_page_shows_real_correlation_detail(
     ``dnsbl.log`` match -- never the ``-`` fallback -- with the Evaluated Domain
     cell equal to the queried name.
     """
-    domain = helpers.unique_domain("dnsblpage")
-    feed_path = helpers.write_local_feed(deployed_vm, "ui_dnsbl_block_page.txt", f"{domain}\n")
+    base_domain = helpers.unique_domain("dnsblpage")
+    domain = f"target.{base_domain}"
+    lookalike = f"target-{base_domain}"
+    feed_path = helpers.write_local_feed(
+        deployed_vm,
+        "ui_dnsbl_block_page.txt",
+        f"{domain}\n{lookalike}\n",
+    )
     spec = helpers.DnsblCase(
         aliasname="uidnsblpage", feed_url=feed_path, header="uidnsblpage", mode=helpers.DnsblMode.VIP
     )
@@ -64,41 +69,24 @@ def test_dnsbl_block_page_shows_real_correlation_detail(
         answer = helpers.dns_probe(deployed_vm, domain)
         assert helpers.is_vip(answer), f"expected VIP block for {domain!r}, got answer: {answer!r}"
 
-        # issue #1652: append a later lookalike row that the old BRE grep also
-        # matched (a domain '.' acted as a wildcard for '-'). The page must keep
-        # correlating the genuine row, not tail-select this forged attribution.
-        lookalike = domain.replace(".", "-", 1)
-        before_size = deployed_vm.ssh("stat", "-f", "%z", DNSBL_LOG)
-        assert before_size.returncode == 0 and before_size.stdout.strip().isdigit(), (
-            f"could not size {DNSBL_LOG} before lookalike append: "
-            f"rc={before_size.returncode} out={before_size.stdout!r} err={before_size.stderr!r}"
+        def log_contains(blocked_domain: str) -> bool:
+            result = deployed_vm.ssh("grep", "-Fq", "--", f",{blocked_domain},", DNSBL_LOG)
+            return result.returncode == 0
+
+        assert helpers.wait_until(lambda: log_contains(domain), timeout=12.0, interval=0.5), (
+            f"genuine DNSBL log row for {domain!r} did not arrive"
         )
 
-        def restore_log() -> None:
-            restored = deployed_vm.ssh("truncate", "-s", before_size.stdout.strip(), DNSBL_LOG)
-            assert restored.returncode == 0, (
-                f"could not truncate {DNSBL_LOG} after lookalike test: rc={restored.returncode} err={restored.stderr!r}"
-            )
-
-        request.addfinalizer(restore_log)
-        guest_now = deployed_vm.ssh("date", "+%Y-%m-%d %H:%M:%S")
-        assert guest_now.returncode == 0 and guest_now.stdout.strip(), (
-            f"could not read guest timestamp: rc={guest_now.returncode} err={guest_now.stderr!r}"
+        # issue #1652: create a genuine, later lookalike event that the old BRE
+        # grep also matched (the target's '.' acted as a wildcard for '-').
+        # Synchronizing on both asynchronous logger writes makes their ordering
+        # authoritative without modifying or truncating the active log.
+        lookalike_answer = helpers.dns_probe(deployed_vm, lookalike)
+        assert helpers.is_vip(lookalike_answer), (
+            f"expected VIP block for lookalike {lookalike!r}, got answer: {lookalike_answer!r}"
         )
-        lookalike_row = (
-            f"DNSBL-python,{guest_now.stdout.strip()},{lookalike},203.0.113.9,Python,"
-            f"DNSBL-Full,LookalikeGroup,{lookalike},LookalikeFeed,+,A\n"
-        )
-        appended = subprocess.run(
-            deployed_vm.ssh_argv("tee", "-a", DNSBL_LOG),
-            input=lookalike_row,
-            capture_output=True,
-            text=True,
-            timeout=15,
-            check=False,
-        )
-        assert appended.returncode == 0, (
-            f"could not append lookalike row to {DNSBL_LOG}: rc={appended.returncode} err={appended.stderr!r}"
+        assert helpers.wait_until(lambda: log_contains(lookalike), timeout=12.0, interval=0.5), (
+            f"genuine DNSBL log row for lookalike {lookalike!r} did not arrive"
         )
 
         # THEN: an on-box curl to the sinkhole (the DNSBL VIP is a loopback-scoped


### PR DESCRIPTION
## Summary

The DNSBL block landing page (`src/usr/local/www/pfblockerng/www/index.php:68`) embedded the requested host into `grep` as an unanchored Basic Regular Expression. `.` matched any character, so a blocked host could correlate to a **different** entry's `dnsbl.log` row (`ads.example.com` matching `ads-example.com`) and the block page rendered the wrong entry's Group / Feed / Evaluated-Domain.

`grep -F --` now matches the `,host,` key as a fixed whole-field string. `escapeshellarg` + `htmlspecialchars` handling is unchanged (display-only integrity fix, injection was already prevented).

Fixes #1652

## Test-first proof (red → green, executed)

- New `LogFormatConsumersTest::testBlockPageCorrelationNeverMatchesLookalikeHostRow` extracts the **live** exec() pipeline from `www/index.php` (not hand-copied) and runs it against a synthetic log holding only `ads-example.com`'s row, with `ads.example.com` as the requested host; a control assertion first proves the lookalike correlates to its own row.
- **Red** (pre-fix, test file frozen at `git hash-object` `470fbc61177785abe80d4814c67f612672ceebed`): the victim host matched the lookalike row — `matched: DNSBL-python,2026-07-08 14:30:15,ads-example.com,...,LookalikeGroup,...,LookalikeFeed,+,A` — plus the updated pipeline tripwire red.
- **Green** (post-fix, zero test edits, hash identical): 21/21 in the class; full PHPUnit suite 3916 tests OK.
- The in-file pipeline tripwire and the ADR-60 P5 reproduction were updated in the same frozen pre-red edit to the `-F --` shape, keeping them in sync with the source.

## UI-tier coverage

This page is served by the DNSBL sinkhole lighttpd, not the webConfigurator — it is the documented `EXCLUDED_FROM_TIER_A["dnsbl_vip_sinkhole_pages"]` entry in `tests/smoke/ui/test_render_smoke.py` (Tier A's authenticated session cannot reach it). Its established coverage is hermetic PHPUnit reproduce-and-exec (this PR's test, per ADR-60 P5 convention) plus the live Tier-B `ui_e2e` correlation test `tests/smoke/ui/test_dnsbl_block_page.py`, which still exercises the true-match path end-to-end.

## Gates

`scripts/agent/run-gates.sh --diff origin/devel`: PASS (php -l, PHPUnit, PHPStan, PHPCS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNSBL sinkhole block-page correlation by using exact host matching when locating the relevant `dnsbl.log` entry, avoiding accidental correlations from pattern-like or lookalike hostnames.
  * Ensures the block-page details consistently reflect the correct evaluated domain.

* **Tests**
  * Updated correlation tests to reflect the corrected matching behavior.
  * Added a regression test to prevent lookalike-host miscorrelation.
  * Strengthened DNSBL block-page E2E smoke tests by waiting for the expected log lines before asserting rendered page values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->