### PR TITLE
widget: default-deny widget POST guard on absent Sec-Fetch-Site

### DIFF
--- a/src/usr/local/www/widgets/include/widget-pfblockerng.inc
+++ b/src/usr/local/www/widgets/include/widget-pfblockerng.inc
@@ -25,11 +25,13 @@ $pfblockerng_title = '<span title="Click to open Unified Log tab">pfBlockerNG</s
 $pfblockerng_title_link = 'pfblockerng/pfblockerng_alerts.php?view=unified';
 
 // issue #1050: the widget sets $nocsrf=TRUE (csrf-magic never runs here), so a
-// mutating POST handler gates on this instead. Fails OPEN on an absent header
-// (a legacy browser sending no Sec-Fetch-Site at all) -- session auth still applies.
+// mutating POST handler gates on this instead. DEFAULT-DENY on an absent header
+// (issue #1650): a header-less/legacy client would otherwise bypass the guard
+// entirely; every modern browser sends Sec-Fetch-Site, so the legitimate
+// same-origin widget POST still passes.
 function pfb_widget_post_allowed(array $server): bool {
 	if (!isset($server['HTTP_SEC_FETCH_SITE'])) {
-		return TRUE;
+		return FALSE;
 	}
 	return in_array($server['HTTP_SEC_FETCH_SITE'], array('same-origin', 'none'), TRUE);
 }

--- a/tests/php/WidgetPostAllowedTest.php
+++ b/tests/php/WidgetPostAllowedTest.php
@@ -11,10 +11,11 @@ use PHPUnit\Framework\TestCase;
  *
  * pfblockerng.widget.php sets $nocsrf=TRUE for the whole endpoint (its read-only
  * AJAX GETs need no token), so its mutating POST handlers (pfb_submit,
- * pfblockerngack, and the three packet-count clears) gate on this instead: reject a cross-site-shaped POST via the
- * Sec-Fetch-Site fetch metadata header, allow everything else -- including an
- * ABSENT header (a legacy browser sending none at all), a deliberate fail-open
- * documented at the call site.
+ * pfblockerngack, and the three packet-count clears) gate on this instead: allow
+ * a POST only when the Sec-Fetch-Site fetch metadata header proves it is
+ * same-origin (or a direct navigation, 'none'). An ABSENT header is DENIED
+ * (issue #1650): the earlier fail-open let any header-less/legacy client bypass
+ * the guard entirely, so the gate is default-deny.
  *
  * widget-pfblockerng.inc carries no top-level pfSense-dependent execution (just
  * two title-string assignments plus this function), so it is require_once()d
@@ -41,7 +42,7 @@ final class WidgetPostAllowedTest extends TestCase
 	public static function truthTableProvider(): array
 	{
 		return [
-			'absent header -- fail-open (legacy browser)' => [[], true],
+			'absent header -- denied (default-deny, issue #1650)' => [[], false],
 			"'same-origin' -- allowed"                     => [['HTTP_SEC_FETCH_SITE' => 'same-origin'], true],
 			"'none' -- allowed (direct navigation/bookmark)" => [['HTTP_SEC_FETCH_SITE' => 'none'], true],
 			"'cross-site' -- blocked"                       => [['HTTP_SEC_FETCH_SITE' => 'cross-site'], false],

--- a/tests/smoke/ui/test_widget_clear_failed.py
+++ b/tests/smoke/ui/test_widget_clear_failed.py
@@ -84,13 +84,19 @@ def _dismiss(webui: WebUI, headers: dict[str, str] | None = None) -> None:
     ``Sec-Fetch-Site`` to drive ``pfb_widget_post_allowed()``'s gate -- the response
     is still a normal 200 either way (blocked = the mutation is skipped and the
     page falls through to its normal render, never a login bounce or a 4xx).
+
+    Default ``Sec-Fetch-Site: same-origin`` (issue #1650): the guard is now
+    default-deny on an absent header, and ``requests`` (unlike a browser) sends
+    no fetch metadata at all -- so the legitimate-path tests must emulate the
+    modern browser's same-origin form POST; ``headers`` overrides it.
     """
     page = webui.get(WIDGET_PAGE)
     assert page.status_code == 200, f"GET {WIDGET_PAGE} -> HTTP {page.status_code} (expected 200)"
     assert not looks_like_login_page(page.text), "pre-dismiss GET bounced to the login page -- not authenticated"
     payload = scrape_form_fields(page.text)
     payload["pfblockerngack"] = "1"
-    resp = webui.session.post(webui.url(WIDGET_PAGE), data=payload, headers=headers, timeout=30)
+    send_headers = {"Sec-Fetch-Site": "same-origin", **(headers or {})}
+    resp = webui.session.post(webui.url(WIDGET_PAGE), data=payload, headers=send_headers, timeout=30)
     assert resp.status_code == 200, f"POST {WIDGET_PAGE} pfblockerngack=1 -> HTTP {resp.status_code} (expected 200)"
     assert not looks_like_login_page(resp.text), "dismiss POST bounced to the login page -- session not authenticated"
 

--- a/tests/smoke/ui/test_widget_submit_missing_fields.py
+++ b/tests/smoke/ui/test_widget_submit_missing_fields.py
@@ -68,7 +68,14 @@ def test_widget_save_missing_per_field_keys_does_not_warn(
         del payload[key]
     payload["pfb_submit"] = "save"
 
-    resp = webui.session.post(webui.url(WIDGET_PAGE), data=payload, timeout=30)
+    # issue #1650: pfb_widget_post_allowed() is default-deny on an absent
+    # Sec-Fetch-Site; emulate the modern browser's same-origin form POST.
+    resp = webui.session.post(
+        webui.url(WIDGET_PAGE),
+        data=payload,
+        headers={"Sec-Fetch-Site": "same-origin"},
+        timeout=30,
+    )
 
     assert resp.status_code == 200, (
         f"POST {WIDGET_PAGE} pfb_submit (fields omitted) -> HTTP {resp.status_code} "


### PR DESCRIPTION
## Summary

`pfb_widget_post_allowed()` — the dashboard widget's CSRF stand-in (the widget sets `$nocsrf = TRUE`, so csrf-magic never runs on this endpoint) — **failed open** when the `Sec-Fetch-Site` request header was absent. A header-less or legacy client (e.g. Firefox < 90) bypassed the guard entirely and could reach the widget's privileged POST handlers: root cron install, `restart_service('pfb_dnsbl')`, packet-counter clears, and `write_config`.

The guard is now **default-deny**: an absent `Sec-Fetch-Site` is rejected. The allowed set (`same-origin`, `none`) is unchanged, so the legitimate widget POST from a modern browser — which always sends the header — still passes, as does direct navigation.

Fixes #1650

## Changes

- `src/usr/local/www/widgets/include/widget-pfblockerng.inc`: absent-header branch returns `FALSE`; call-site comment updated (fail-open → default-deny).
- `tests/php/WidgetPostAllowedTest.php`: truth-table row for the absent header flipped to *denied* (the red→green reproduction); docblock updated. The `same-origin`/`none` rows pin the preserved legitimate paths.
- `tests/smoke/ui/test_widget_clear_failed.py`, `tests/smoke/ui/test_widget_submit_missing_fields.py`: the Tier-B legitimate-path POSTs now send `Sec-Fetch-Site: same-origin` (python-requests sends no fetch metadata, so they implicitly relied on the removed fail-open); the cross-site denial test still overrides the header.

## Test evidence (test-first red→green)

Reproduction test frozen at red (`git hash-object tests/php/WidgetPostAllowedTest.php` = `9d103488a6ab0abf370f1c9b50d3c126205a4a0b`), executed RED on the untouched guard:

```
1) WidgetPostAllowedTest::testTruthTable@absent header -- denied (default-deny, issue #1650) with data ([], false)
pfb_widget_post_allowed(array (
)) expected false
Failed asserting that true is identical to false.
```

After the one-line guard change, the byte-identical file (same hash) ran GREEN: `OK (7 tests, 14 assertions)` — including the `same-origin`-allowed row, proving the legitimate path is preserved.

`scripts/agent/run-gates.sh --diff origin/devel`: **GATES: PASS** (pytest, ruff, mypy, php -l, full PHPUnit 3915 tests, PHPStan, PHPCS).

Tier-A `ui_render` coverage of the widget page exists (`tests/smoke/ui/test_render_smoke.py` GETs `/widgets/widgets/pfblockerng.widget.php` with the `id="pfblockerngack"` marker); the GET path is untouched by this change. Tier-B widget POST modules were updated as above and should be exercised via `ui-tests.yml` (they are schedule/dispatch-only).

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Widget POST requests are now denied when browser fetch metadata is missing.
  * Requests remain allowed only with recognized same-origin fetch metadata.

* **Bug Fixes**
  * Prevented header-less or legacy requests from bypassing widget request protection.

* **Tests**
  * Updated coverage for missing and supported fetch metadata scenarios.
  * UI checks now include same-origin metadata for simulated browser POST requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->