### PR TITLE
test: pin native issue type instead of bug label on the bug form

### DIFF
--- a/tests/test_issue_creation_metadata.py
+++ b/tests/test_issue_creation_metadata.py
@@ -1,4 +1,4 @@
-"""Ticket creators must set descriptive labels and native issue types together."""
+"""Ticket creators must set a native issue type plus each path's required labels."""
 
 import shlex
 from pathlib import Path
@@ -51,9 +51,11 @@ def test_automated_issue_creators_set_label_and_type() -> None:
             assert _option_values(command, "--type") == [issue_type]
 
 
-def test_issue_forms_set_label_and_type_and_disable_blank_issues() -> None:
+def test_issue_forms_declare_native_type_and_disable_blank_issues() -> None:
+    # The bug form carries no label: its category rides solely on the native
+    # issue type (a81fc030 dropped the redundant `bug` label).
     forms = {
-        "bug_report.yml": ('labels: ["bug"]', "type: bug"),
+        "bug_report.yml": ("type: bug",),
         "feature_request.yml": ('labels: ["enhancement"]', "type: feature"),
         "task_request.yml": ('labels: ["enhancement"]', "type: task"),
     }
@@ -62,10 +64,10 @@ def test_issue_forms_set_label_and_type_and_disable_blank_issues() -> None:
         path.name for path in template_dir.iterdir() if path.suffix in {".yml", ".yaml"} and path.name != "config.yml"
     }
     assert form_files == forms.keys()
-    for filename, (label, issue_type) in forms.items():
+    for filename, expected_lines in forms.items():
         form = _read(f".github/ISSUE_TEMPLATE/{filename}")
-        assert f"\n{label}\n" in form
-        assert f"\n{issue_type}\n" in form
+        for expected in expected_lines:
+            assert f"\n{expected}\n" in form
 
     config = _read(".github/ISSUE_TEMPLATE/config.yml")
     assert "blank_issues_enabled: false" in config


### PR DESCRIPTION
## Summary

`devel` has been red on the default pytest suite since a81fc030 removed the redundant `labels: ["bug"]` line from `.github/ISSUE_TEMPLATE/bug_report.yml`: the metadata guard `tests/test_issue_creation_metadata.py::test_issue_forms_set_label_and_type_and_disable_blank_issues` still required that label line. The template change was intentional — the bug form's category now rides on the native GitHub issue type (`type: bug`) — so this PR fixes the guard side.

## Changes

- `tests/test_issue_creation_metadata.py` only:
  - The bug form entry no longer expects a `labels:` line; it still requires the top-level `type: bug` declaration.
  - The feature and task form entries keep both their `labels: ["enhancement"]` and `type:` pins (those lines are still present in the templates).
  - Renamed the form guard to `test_issue_forms_declare_native_type_and_disable_blank_issues` and reworded the module docstring to match the new invariant. No other file references the old test name (tree-wide grep, only pytest caches hit).
- No template changes were needed: all three issue forms on `origin/devel` already declare their native `type:` (`bug` / `feature` / `task`).

## Evidence

- **Red (untouched devel tip a81fc030):** `python3 -m pytest tests/test_issue_creation_metadata.py` → `1 failed, 2 passed` with `assert '\nlabels: ["bug"]\n' in 'name: Bug report\n...'`.
- **Green after the guard fix (guard frozen at `git hash-object` `f75133ce5243812aaf258a345a851f089e78ee39`):** `3 passed`.
- **Perturbation proof (the type expectation bites):** deleting the top-level `type: bug` line from `bug_report.yml` turns the guard red — `AssertionError: assert '\ntype: bug\n' in 'name: Bug report\n...'` — even though indented `- type:` body entries remain (the `\n`-anchored match only accepts the top-level declaration). Restoring the template returns the suite to `3 passed`.
- **Gates:** `scripts/agent/run-gates.sh --diff origin/devel` → `GATE PASS: python3 -m pytest`, `ruff check`, `ruff format --check`, `mypy tests/` — `GATES: PASS`.

Fixes #1672

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
