### PR TITLE
pfblockerng: restore CCT IP feed

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11701,6 +11701,7 @@ final class PfbDownloadRequest
 		public readonly string $password = '',
 		public readonly string|false $sourceInterface = FALSE,
 		public readonly array $extraHeaders = array(),
+		public readonly bool $cookies = FALSE,
 	) {
 	}
 }
@@ -11739,6 +11740,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 	$password = $request->password;
 	$srcint = $request->sourceInterface;
 	$extra_headers = $request->extraHeaders;
+	$cookies = $request->cookies;
 	$top1m_provider = ($type === 'top1m') ? pfb_top1m_active_provider() : array();
 	global $pfb;
 	$http_status = '';
@@ -11911,6 +11913,9 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				// Load curl default settings — incl. the CURLOPT_PROTOCOLS scheme allow-list
 				// (an independent libcurl-layer backstop to PFB_FILTER_URL) and gzip encoding.
 				curl_setopt_array($ch, $pfb['curl_defaults']);
+				if ($cookies) {
+					curl_setopt($ch, CURLOPT_COOKIEFILE, '');
+				}
 
 				curl_setopt($ch, CURLOPT_FILE, $fhandle);	// Add $fhandle setting to cURL
 				curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);	// Set cURL download timeout

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -121,6 +121,45 @@ function pfb_dnsbl_reload_needed(bool $publish_failed, bool $data_changed, bool 
 	return !$publish_failed && ($data_changed || $update || $python || $safesearch_update || $unlock_forced);
 }
 
+/** Extract one built-in Cybercrime Tracker CSV record into a bare IP candidate. */
+function pfb_cct_ip_parse_record(string $raw_record, bool $lenient): ?string {
+	if (strlen($raw_record) > 16384) {
+		return NULL;
+	}
+
+	$record = trim($raw_record);
+	if ($record === '' || $record === 'TYPE,URL,IP') {
+		return NULL;
+	}
+
+	$fields = str_getcsv($record, ',', '"', '"');
+	if (count($fields) !== 3) {
+		return NULL;
+	}
+
+	$ip = trim($fields[2]);
+	if (($ip !== '') && (is_ipaddrv4($ip) || is_ipaddrv6($ip))) {
+		return $ip;
+	}
+	if (!$lenient) {
+		return NULL;
+	}
+
+	$url = trim($fields[1]);
+	$url = preg_replace('#^[a-z][a-z0-9+.-]*://#i', '', $url) ?? '';
+	$slash = strpos($url, '/');
+	if ($slash !== FALSE) {
+		$url = substr($url, 0, $slash);
+	}
+	$colon = strpos($url, ':');
+	if ($colon !== FALSE) {
+		$url = substr($url, 0, $colon);
+	}
+	$url = trim($url);
+
+	return is_ipaddrv4($url) ? $url : NULL;
+}
+
 /**
  * Parse one generic IP-feed line without touching run state or emitting output.
  * @param array{vtype:string,pftype:string,custom:bool,cidr_floor_v4:int|string,cidr_floor_v6:int|string,suppression:string,range:string,ipv4:string,ipv6:string} $config
@@ -1724,6 +1763,7 @@ function sync_package_pfblockerng($cron='') {
 											password: '',
 											sourceInterface: $srcint,
 											extraHeaders: array(),
+											cookies: $header === 'CCT_IP',
 										))->success)) {
 
 											// Determine reason for download failure
@@ -3203,6 +3243,7 @@ function sync_package_pfblockerng($cron='') {
 										password: '',
 										sourceInterface: $srcint,
 										extraHeaders: array(),
+										cookies: $header === 'CCT_IP',
 									))->success)) {
 
 										// Determine reason for download failure
@@ -3306,9 +3347,14 @@ function sync_package_pfblockerng($cron='') {
 									$ip_lineno++;
 
 									$raw_line = $line;
-									$parsed_line = pfb_ip_parse_line($raw_line, [
+									$parse_line = $raw_line;
+									if ($header === 'CCT_IP') {
+										$parse_line = pfb_cct_ip_parse_record($raw_line,
+											$pfb['dnsbl_lenient'] === PfbLenient::On) ?? '';
+									}
+									$parsed_line = pfb_ip_parse_line($parse_line, [
 										'vtype'         => $list['vtype'],
-										'pftype'        => $pftype,
+										'pftype'        => $header === 'CCT_IP' ? 'auto' : $pftype,
 										'custom'        => $custom,
 										'cidr_floor_v4' => $pfbcidr,
 										'cidr_floor_v6' => $pfbcidr_v6,

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc
@@ -160,6 +160,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 				password: '',
 				sourceInterface: $srcint,
 				extraHeaders: array(),
+				cookies: $header === 'CCT_IP',
 			));
 
 			if (!$probe_result->success || $probe_result->responseMeta === NULL) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -371,7 +371,7 @@
 				{
 					"feed":		"Cyber Crime WHQ",
 					"website":	"https://cybercrime-tracker.net/about.php",
-					"url":		"https://cybercrime-tracker.net/fuckerz.php",
+					"url":		"https://cybercrime-tracker.net/csv.php",
 					"header":	"CCT_IP"
 				},
 				{

--- a/tests/php/CctIpFeedTest.php
+++ b/tests/php/CctIpFeedTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** CCT_IP CSV extraction and the opt-in cookie-backed download path. */
+#[CoversFunction('pfb_cct_ip_parse_record')]
+final class CctIpFeedTest extends TestCase
+{
+	/** @var resource|null */
+	private $server = null;
+	private string $workdir = '';
+	private int $port = 0;
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_resource($this->server)) {
+			proc_terminate($this->server);
+			proc_close($this->server);
+		}
+		unset($GLOBALS['pfb_test_resolve_map']);
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			foreach ((array) glob("{$this->workdir}/*") as $file) {
+				@unlink((string) $file);
+			}
+			@rmdir($this->workdir);
+		}
+	}
+
+	#[DataProvider('records')]
+	public function testCctRecordExtraction(string $record, bool $lenient, ?string $expected): void
+	{
+		$this->assertSame($expected, pfb_cct_ip_parse_record($record, $lenient));
+	}
+
+	/** @return iterable<string,array{string,bool,?string}> */
+	public static function records(): iterable
+	{
+		yield 'header' => ['TYPE,URL,IP', FALSE, NULL];
+		yield 'empty' => ['', TRUE, NULL];
+		yield 'short' => ['bot,http://1.2.3.4', TRUE, NULL];
+		yield 'extra' => ['bot,http://1.2.3.4,1.2.3.4,extra', TRUE, NULL];
+		yield 'quoted comma' => ['bot,"https://example.test/a,b",198.51.100.1', FALSE, '198.51.100.1'];
+		yield 'third column v4 wins' => ['bot,https://203.0.113.8/1,198.51.100.1', TRUE, '198.51.100.1'];
+		yield 'third column v6 wins' => ['bot,https://198.51.100.1/1,2001:db8::1', TRUE, '2001:db8::1'];
+		yield 'invalid third strict' => ['bot,https://103.147.185.68:8443/j/p29oa/login.php,invalid', FALSE, NULL];
+		yield 'invalid third lenient' => ['bot,https://103.147.185.68:8443/j/p29oa/login.php,invalid', TRUE, '103.147.185.68'];
+		yield 'blank third path' => ['bot,103.147.185.68/1/b/,', TRUE, '103.147.185.68'];
+		yield 'domain fallback rejected' => ['bot,static.82.150.216.95.clients.example/login,', TRUE, NULL];
+		yield 'numeric label rejected' => ['bot,1.2.3.4.example/path,', TRUE, NULL];
+		yield 'leading zero rejected' => ['bot,001.2.3.4/path,', TRUE, NULL];
+		yield 'bracketed v6 rejected' => ['bot,[2001:db8::1]:8443/path,', TRUE, NULL];
+		yield 'fallback never cidr' => ['bot,103.147.185.68/1/b/,', TRUE, '103.147.185.68'];
+	}
+
+	public function testCatalogPinsCctCsvEndpoint(): void
+	{
+		$catalog = json_decode(
+			(string) file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_feeds.json'),
+			TRUE,
+			512,
+			JSON_THROW_ON_ERROR
+		);
+		$findCct = static function (array $node) use (&$findCct): array {
+			if (($node['header'] ?? '') === 'CCT_IP') {
+				return [$node];
+			}
+			$found = [];
+			foreach ($node as $child) {
+				if (is_array($child)) {
+					$found = array_merge($found, $findCct($child));
+				}
+			}
+			return $found;
+		};
+		$cct = $findCct($catalog);
+		$this->assertCount(1, $cct);
+		$this->assertSame('https://cybercrime-tracker.net/csv.php', $cct[0]['url']);
+	}
+
+	public function testCctWiringUsesAutoParserOnlyForCctRows(): void
+	{
+		$source = (string) file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertStringContainsString('pfb_cct_ip_parse_record', $source);
+		$this->assertStringContainsString("\$header === 'CCT_IP'", $source);
+		$config = [
+			'vtype'         => '_v4',
+			'pftype'        => 'auto',
+			'custom'        => TRUE,
+			'cidr_floor_v4' => 'Disabled',
+			'cidr_floor_v6' => 'Disabled',
+			'suppression'   => 'off',
+			'range'         => '/((?:\d{1,3}\.){3}\d{1,3})-((?:\d{1,3}\.){3}\d{1,3})/',
+			'ipv4'          => '/(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\/\d{1,2})?/',
+			'ipv6'          => '/[0-9A-Fa-f:]+(?:\/\d{1,3})?/',
+		];
+		$candidate = pfb_cct_ip_parse_record('bot,https://103.147.185.68/1,', TRUE);
+		$this->assertSame('103.147.185.68', $candidate);
+		$this->assertSame(['103.147.185.68'], pfb_ip_parse_line($candidate, $config)['entries']);
+	}
+
+	public function testCctCookiesAreDisabledByDefaultAndOptInPerRequest(): void
+	{
+		$defaults = new PfbDownloadRequest(
+			listUrl: 'https://example.test/feed',
+			downloadPath: '/tmp/feed',
+			flex: FALSE,
+			header: 'CCT_IP',
+			format: '',
+			logType: 1,
+		);
+		$this->assertFalse($defaults->cookies);
+		$enabled = new PfbDownloadRequest(
+			listUrl: 'https://example.test/feed',
+			downloadPath: '/tmp/feed',
+			flex: FALSE,
+			header: 'CCT_IP',
+			format: '',
+			logType: 1,
+			cookies: TRUE,
+		);
+		$this->assertTrue($enabled->cookies);
+	}
+
+	public function testCookieChallengeNeedsOptInAndReplaysAcrossManualRedirects(): void
+	{
+		if (!extension_loaded('curl')) {
+			$this->markTestSkipped('curl extension not available');
+		}
+		$this->startCookieServer();
+		$GLOBALS['pfb_test_resolve_map'] = [
+			'cct-feed.example.' => [
+				['type' => 'A', 'data' => '127.0.0.1'],
+				['type' => 'A', 'data' => '203.0.113.20'],
+			],
+		];
+		$url = "http://cct-feed.example:{$this->port}/start?hop=1";
+		$without = pfb_download(new PfbDownloadRequest(
+			listUrl: $url,
+			downloadPath: "{$this->workdir}/without",
+			flex: FALSE,
+			header: 'CCT_IP',
+			format: '',
+			logType: 1,
+			type: 'change_detect',
+		));
+		$this->assertFalse($without->success);
+
+		$with = pfb_download(new PfbDownloadRequest(
+			listUrl: $url,
+			downloadPath: "{$this->workdir}/with",
+			flex: FALSE,
+			header: 'CCT_IP',
+			format: '',
+			logType: 1,
+			type: 'change_detect',
+			cookies: TRUE,
+		));
+		$this->assertTrue($with->success);
+		$this->assertSame('200', $with->responseMeta['status'] ?? '');
+	}
+
+	private function startCookieServer(): void
+	{
+		$this->workdir = tempnam(sys_get_temp_dir(), 'cct');
+		$this->assertNotFalse($this->workdir);
+		$this->assertTrue(unlink($this->workdir) && mkdir($this->workdir, 0700));
+		$router = "{$this->workdir}/router.php";
+		$routerSrc = <<<'PHP'
+<?php
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+if ($path === '/start') {
+	header('Location: /hop?next=2', TRUE, 302);
+	return;
+}
+if ($path === '/hop') {
+	setcookie('cct_gate', 'ok');
+	header('Location: /final', TRUE, 302);
+	return;
+}
+if ($path === '/final' && ($_COOKIE['cct_gate'] ?? '') === 'ok') {
+	header('Content-Type: text/plain');
+	echo "TYPE,URL,IP\nsource,https://example.test,198.51.100.1\n";
+	return;
+}
+http_response_code(403);
+echo "cookie required\n";
+PHP;
+		$this->assertNotFalse(file_put_contents($router, $routerSrc));
+		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', "{$this->workdir}/server.err", 'w']];
+		for ($try = 0; $try < 10; $try++) {
+			$port = random_int(20000, 60000);
+			$process = proc_open(
+				['php', '-S', "127.0.0.1:{$port}", $router],
+				$descriptors,
+				$pipes,
+				$this->workdir,
+				['PATH' => (string) getenv('PATH')]
+			);
+			if (!is_resource($process)) {
+				continue;
+			}
+			for ($i = 0; $i < 40; $i++) {
+				$sock = @fsockopen('127.0.0.1', $port, $errno, $error, 0.05);
+				if ($sock !== FALSE) {
+					fclose($sock);
+					$this->server = $process;
+					$this->port = $port;
+					return;
+				}
+				usleep(50000);
+			}
+			proc_terminate($process);
+			proc_close($process);
+		}
+		$error = (string) @file_get_contents("{$this->workdir}/server.err");
+		$this->fail('could not start cookie php -S fixture server: ' . $error);
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -767,6 +767,26 @@
             }
         ]
     },
+    "pfb_cct_ip_parse_record": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "raw_record",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "lenient",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
     "pfb_cfg_alias_delta_mode_read": {
         "returnsRef": false,
         "returnType": "PfbAliasDeltaMode",

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -127,7 +127,11 @@ PAGE_TABLE: tuple[Page, ...] = (
     Page(
         "feeds_ipv4",
         "/pfblockerng/pfblockerng_feeds.php?type=ipv4",
-        ("Pre-defined Alias/Group/Feeds", "IPv4 Alias name(s):"),
+        (
+            "Pre-defined Alias/Group/Feeds",
+            "IPv4 Alias name(s):",
+            "https://cybercrime-tracker.net/csv.php",
+        ),
     ),
     Page(
         "feeds_ipv6",


### PR DESCRIPTION
## Summary

- move the built-in `CCT_IP` catalog entry to `https://cybercrime-tracker.net/csv.php`
- parse its `TYPE,URL,IP` rows without applying the generic whole-row regex parser
- prefer the IP column; use the normalized URL host only when lenient parsing is enabled
- enable a per-request in-memory libcurl cookie engine for CCT full fetches and change-detection probes
- keep the generic parser/UI work split into #1679, natively blocked by #1605

## Parser contract

URL fallback runs only after an absent/invalid IP column and only in lenient mode. It strips scheme, then path, then port, and validates a bare IP. URL-derived CIDRs are impossible.

## Test-first evidence

Frozen test blob: `f8fb2e594736d49e22d7f0bd22016deaaa468fc5`.

- RED on untouched production/catalog: 19 tests, 16 errors, 3 failures from the absent CCT parser/cookie request option/wiring and old endpoint
- GREEN unchanged: 19 tests, 29 assertions
- focused CCT + generic IP parser + retry regression: 36 tests, 70 assertions
- full PHPUnit12: 3926 tests, 22795 assertions
- post-rebase canonical gates: `GATES: PASS`
- independent implementation gate: ACCEPT, no blocking findings

The live Tier-A `ui_render` PR gate remains required because the shipped feed catalog lives under `www/`; no rendered PHP/JS behavior changed.

Fixes #1678

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.