### PR TITLE
feeds: discontinue CCT IP source

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -369,9 +369,11 @@
 					"header":	"CoinBlocker"
 				},
 				{
+					"status":	"discontinued",
 					"feed":		"Cyber Crime WHQ",
 					"website":	"https://cybercrime-tracker.net/about.php",
-					"url":		"https://cybercrime-tracker.net/fuckerz.php",
+					"url":		"https://cybercrime-tracker.net/csv.php",
+					"info":		"Discontinued in pfBlockerNG: the upstream feed now requires cookies and returns TYPE,URL,IP CSV. Configurable request/parser support is tracked in #1679.",
 					"header":	"CCT_IP"
 				},
 				{

--- a/tests/php/FeedCorpusSurveyTest.php
+++ b/tests/php/FeedCorpusSurveyTest.php
@@ -131,7 +131,7 @@ final class FeedCorpusSurveyTest extends TestCase
 	/**
 	 * Corpus samples that are NOT real feed bodies, so a non-null verdict on them is
 	 * the scanner working correctly, NOT a false positive. Keyed by feed header ->
-	 * the documented reason. The one-time PR #827 capture caught these five: two are
+	 * the documented reason. The one-time PR #827 capture caught these six: three are
 	 * catalogue-marked `discontinued`, and three are dead/gated feeds whose captured
 	 * body is a header-only stub or an auth wall. Each is asserted below to STILL be
 	 * flagged, so a stale entry (a feed that came back to life) fails loudly rather
@@ -141,20 +141,9 @@ final class FeedCorpusSurveyTest extends TestCase
 		'MaxMind_BD_Proxy' => 'catalogue status=discontinued — the url is MaxMind\'s HTML sample-list webpage, not a raw feed (html_error_page)',
 		'Abuse_SSLBL'      => 'catalogue status=discontinued — abuse.ch retired the SSLBL IP blacklist; the body is header-only, zero data rows (below_min_content)',
 		'Abuse_SSLBL_Agr'  => 'the retired SSLBL aggressive list — sibling of the discontinued Abuse_SSLBL (catalogue status unset); header-only, zero data rows (below_min_content)',
+		'CCT_IP'           => 'catalogue status=discontinued — the provider replaced the captured HTML endpoint with a cookie-backed CSV feed',
 		'Darklist'         => 'header-only at capture — darklist.de/raw.php returned its 2-line header with zero IP rows (below_min_content)',
 		'MPatrol'          => 'API-key gated — the catalogue url is an _API_KEY_ template; the capture hit the "access denied" auth wall, not the feed (below_min_content)',
-	];
-
-	/**
-	 * Corpus samples whose feed is REAL but whose 8 KiB capture is all leading HTML
-	 * boilerplate — the data starts past the capture cap, so a non-null verdict on
-	 * the TRUNCATED sample is expected and NOT representative of production, where
-	 * pfb_download() samples up to 64 KiB and sees the data. Same stay-flagged +
-	 * completeness guards as KNOWN_NON_FEED: an entry that starts passing means the
-	 * capture (or the scanner) changed and the entry must be re-checked/removed.
-	 */
-	private const KNOWN_TRUNCATED_FEED = [
-		'CCT_IP' => 'HTML-wrapped IP feed; first IP ~12 KiB into a 650+ KiB page (verified live 2026-07-04), past the 8 KiB corpus capture',
 	];
 
 	public function testCatalogueSurveyHasZeroFalsePositives(): void
@@ -172,14 +161,7 @@ final class FeedCorpusSurveyTest extends TestCase
 		$flagged = [];
 		$stale = [];
 		$matched = [];
-		// '+' keeps the LEFT value on a key collision with no error -- assert the
-		// classes stay disjoint so a duplicated header fails loudly instead.
-		$this->assertSame(
-			[],
-			array_intersect_key(self::KNOWN_NON_FEED, self::KNOWN_TRUNCATED_FEED),
-			'a feed header must appear in only ONE exclusion class'
-		);
-		$exclusions = self::KNOWN_NON_FEED + self::KNOWN_TRUNCATED_FEED;
+		$exclusions = self::KNOWN_NON_FEED;
 		foreach (self::textSamples() as $feed) {
 			$sample = (string) file_get_contents(self::CORPUS_DIR . '/' . $feed['sample_file']);
 			$verdict = pfb_text_sanity($sample);
@@ -205,7 +187,7 @@ final class FeedCorpusSurveyTest extends TestCase
 		$this->assertSame(
 			[],
 			$stale,
-			"exclusions (KNOWN_NON_FEED / KNOWN_TRUNCATED_FEED) that are no longer flagged (stale — re-check the feed and remove the entry):\n"
+			"KNOWN_NON_FEED exclusions that are no longer flagged (stale — re-check the feed and remove the entry):\n"
 			. implode("\n", $stale)
 		);
 		// Completeness: every exclusion key must have been encountered in the corpus.

--- a/tests/php/FeedsDiscontinuedTest.php
+++ b/tests/php/FeedsDiscontinuedTest.php
@@ -49,4 +49,31 @@ final class FeedsDiscontinuedTest extends TestCase
 		$this->assertNotNull($alienvault, 'Alienvault feed must still be present in ipv4/PRI2 (flagged, not deleted)');
 		$this->assertSame('discontinued', $alienvault['status'] ?? NULL, 'Alienvault feed must be marked discontinued (#319)');
 	}
+
+	public function testCctIpFeedIsDiscontinuedWithReason(): void
+	{
+		$feeds = $this->loadFeeds();
+		$cctHeaders = [];
+		array_walk_recursive($feeds, static function (mixed $value, string|int $key) use (&$cctHeaders): void {
+			if ($key === 'header' && $value === 'CCT_IP') {
+				$cctHeaders[] = $value;
+			}
+		});
+		$this->assertCount(1, $cctHeaders, 'CCT_IP must have exactly one catalogue identity');
+
+		$cct = NULL;
+		foreach ($feeds['ipv4']['PRI4']['feeds'] as $feed) {
+			if (($feed['header'] ?? '') === 'CCT_IP') {
+				$cct = $feed;
+				break;
+			}
+		}
+
+		$this->assertNotNull($cct, 'CCT_IP must remain in the catalogue as a discontinued feed');
+		$this->assertSame('discontinued', $cct['status'] ?? NULL);
+		$this->assertSame('https://cybercrime-tracker.net/csv.php', $cct['url'] ?? NULL);
+		$this->assertStringContainsString('requires cookies', $cct['info'] ?? '');
+		$this->assertStringContainsString('TYPE,URL,IP CSV', $cct['info'] ?? '');
+		$this->assertStringContainsString('#1679', $cct['info'] ?? '');
+	}
 }

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1578,6 +1578,7 @@ def test_feeds_custom_panel_heading_renders(webui: WebUI, php_error_log_guard: P
     result = evaluate_render(path, resp.status_code, resp.text, ("Pre-defined Alias/Group/Feeds",))
     assert result.ok, f"Feeds render oracle failed: {result.detail}"
     body = resp.text
+    assert "CCT_IP" not in body, "Feeds page still offers the discontinued CCT_IP feed"
     assert "Custom Feeds" in body, "Feeds page is missing the 'Custom Feeds' panel heading"
     assert "Unknown user defined Feeds" not in body, (
         "Feeds page still shows the old 'Unknown user defined Feeds' heading"


### PR DESCRIPTION
## Summary

- retain the built-in `CCT_IP` catalog identity but mark it `discontinued`, removing it from the current picker
- record the provider’s current `https://cybercrime-tracker.net/csv.php` endpoint and why pfBlockerNG cannot safely consume it today: cookies plus `TYPE,URL,IP` CSV
- defer configurable request/parser behavior to #1679, natively blocked by normalized Feed foundation #1605
- reclassify the old one-time HTML corpus sample and pin the discontinued state plus Feeds-page absence

This is the owner-directed minimal fallback after closing parser PR #1682. No parser, downloader, or runtime behavior from #1682 is included.

## Test-first evidence

Original frozen `FeedsDiscontinuedTest.php` blob: `8c6878c3390c48e8582756f6868cf9d0f1315d30`.

- RED on untouched `devel`: 3 tests, 1 failure at missing CCT `discontinued` status
- GREEN unchanged with corpus survey: 5 tests, 1460 assertions
- review then added a global exact-one `CCT_IP` identity assertion and removed the now-empty truncated-feed exclusion class; current blobs are `425c1a1e0e7dcd721a2ea5c143e67cbe5ca41ce946ac78b4b75ab856133c8467` and `ab42f59646e6e7804fd596d3fb71d02d2a3d6af1e2be45a62766bfb3e0675073`
- post-review GREEN: 5 tests, 1460 assertions; PHPCS and diff-check pass
- full pre-commit gate passes; CI uses the repository-pinned Ruff 0.15.22 and this PR changes no Ruff-related files
- independent implementation gate: ACCEPT, no blockers

The changed catalog lives under `www/`; the existing Tier-A IPv4 Feeds render test now directly asserts `CCT_IP` is absent. The `ui-tests` label makes the live-VM Tier-A run a blocking PR gate.

Fixes #1678

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Cyber Crime WHQ” IPv4 feed to reflect its discontinued status and switched it to the current CSV source.
  * Added user-visible context about the source requiring cookies and providing a `TYPE,URL,IP` CSV.
  * Removed the discontinued “CCT_IP” feed marker/option from the custom feeds UI.
* **Tests**
  * Added checks to confirm the feed remains present in the catalogue with the expected URL and reason.
  * Updated feed corpus survey exclusions and related false-positive validation.
  * Enhanced UI smoke coverage to ensure discontinued entries are not rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
