### PR TITLE
tests: fail instead of skipping when the alias-rename hook is missing

### DIFF
--- a/tests/smoke/test_smoke_alias_rename.py
+++ b/tests/smoke/test_smoke_alias_rename.py
@@ -9,8 +9,9 @@ across all three list sections (v4, v6, DNSBL).
 
 This test exercises the FULL path on a live pfSense VM:
 
-1. Assert the hook shim file exists (skip if the build does not ship it yet —
-   this decouples a ports pkg-plist update that may land separately).
+1. Assert the hook shim file exists. The build CI runs (``-devel``/``-nightly``)
+   always package it — its absence is a packaging regression, so this FAILS
+   rather than skips (issue #1658).
 2. Seed a test IPv4 list row with a known alias name in two fields.
 3. Trigger the rename via ``php_eval`` (simulate the shim invocation from
    ``saveAlias()``) and assert the rewrite landed in config.xml.
@@ -67,6 +68,25 @@ def deployed_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
+
+
+def _require_hook_shim(vm: SmokeVM) -> None:
+    """Fail (never skip) unless the pre_write_config hook shim is deployed.
+
+    ``test -f`` returns 1 for a clean "does not exist" and 0 for "exists". Any
+    other rc means the SSH probe itself did not complete (e.g. a transport
+    fault) — that must not be read as "present", nor conflated with the clean
+    "absent" case; it gets its own rc-bearing failure message (issue #1658).
+    """
+    result = vm.ssh("test", "-f", HOOK_SHIM, timeout=30)
+    if result.returncode == 0:
+        return
+    if result.returncode == 1:
+        pytest.fail(
+            f"pfBlockerNG is expected to ship {HOOK_SHIM} but this build does not have it "
+            "— packaging regression, not a skip"
+        )
+    pytest.fail(f"probe for {HOOK_SHIM} did not complete cleanly (rc={result.returncode}, stderr={result.stderr!r})")
 
 
 def _free_rowid(vm: SmokeVM, cfg_root: str) -> int:
@@ -134,18 +154,11 @@ def _invoke_rename_shim(vm: SmokeVM, old_name: str, new_name: str) -> None:
 def test_hook_shim_file_exists_on_deployed_build(deployed_vm: SmokeVM) -> None:
     """The pre_write_config hook shim is present on the deployed build.
 
-    This is the prerequisite for all alias-rename tests: if the shim is not
-    shipped in this build's pkg-plist, skip the remaining tests rather than
-    failing on a known-absent file.  The skip is recorded in the first test so
-    the module-level ``deployed_vm`` fixture only runs once.
+    This is the prerequisite for all alias-rename tests: pfBlockerNG is
+    expected to ship this file, so its absence is a packaging regression —
+    fail loudly rather than skip (issue #1658).
     """
-    vm = deployed_vm
-    result = vm.ssh("test", "-f", HOOK_SHIM, timeout=30)
-    if result.returncode != 0:
-        pytest.skip(
-            f"alias-rename hook shim not present on this build ({HOOK_SHIM}); "
-            "pkg-plist update pending — skipping alias-rename smoke"
-        )
+    _require_hook_shim(deployed_vm)
 
 
 def test_alias_rename_followup_rewrites_addr_and_port_keys(deployed_vm: SmokeVM) -> None:
@@ -172,10 +185,8 @@ def test_alias_rename_followup_rewrites_addr_and_port_keys(deployed_vm: SmokeVM)
         - aliasports_in is rewritten to 'PfbRenameDst'.
     """
     vm = deployed_vm
-    # Skip here too in case test ordering bypasses the shim-exists test.
-    shim_check = vm.ssh("test", "-f", HOOK_SHIM, timeout=30)
-    if shim_check.returncode != 0:
-        pytest.skip(f"alias-rename hook shim absent ({HOOK_SHIM}) — skip")
+    # Re-check here too in case test ordering bypasses the prerequisite test.
+    _require_hook_shim(vm)
 
     old_name = "PfbRenameSrc"
     new_name = "PfbRenameDst"
@@ -236,9 +247,8 @@ def test_alias_rename_followup_leaves_unrelated_alias_unchanged(deployed_vm: Smo
         - aliasaddr_out stays 'PfbUnrelated' (unrelated — no touch).
     """
     vm = deployed_vm
-    shim_check = vm.ssh("test", "-f", HOOK_SHIM, timeout=30)
-    if shim_check.returncode != 0:
-        pytest.skip(f"alias-rename hook shim absent ({HOOK_SHIM}) — skip")
+    # Re-check here too in case test ordering bypasses the prerequisite test.
+    _require_hook_shim(vm)
 
     old_name = "PfbRenameSrc2"
     new_name = "PfbRenameDst2"
@@ -293,9 +303,8 @@ def test_alias_rename_same_name_is_noop(deployed_vm: SmokeVM) -> None:
         aliasaddr_in remains 'PfbRenameNoop' (no write occurred).
     """
     vm = deployed_vm
-    shim_check = vm.ssh("test", "-f", HOOK_SHIM, timeout=30)
-    if shim_check.returncode != 0:
-        pytest.skip(f"alias-rename hook shim absent ({HOOK_SHIM}) — skip")
+    # Re-check here too in case test ordering bypasses the prerequisite test.
+    _require_hook_shim(vm)
 
     name = "PfbRenameNoop"
     rowid = _free_rowid(vm, CFG_IPV4)

--- a/tests/test_smoke_alias_rename_hook_guard.py
+++ b/tests/test_smoke_alias_rename_hook_guard.py
@@ -62,9 +62,14 @@ def test_probe_transport_failure_fails_distinctly() -> None:
         tsar._require_hook_shim(vm)  # type: ignore[arg-type]
 
 
-def test_no_skip_for_missing_hook_shim_condition() -> None:
-    """Row 4 regression guard: grep the module source -- no ``pytest.skip`` call mentions
-    the hook shim. All four call sites must route through ``_require_hook_shim`` instead."""
+def test_the_only_skip_left_is_the_missing_package_one() -> None:
+    """Row 4 regression guard: the module keeps exactly ONE ``pytest.skip``, the
+    no-package-to-deploy fixture guard.
+
+    Whitelisting the one legitimate skip beats blacklisting a keyword: a future skip for
+    a missing shipped file worded without "shim" would pass a keyword check, while any new
+    skip at all trips this one.
+    """
     src = inspect.getsource(tsar)
-    skip_lines = [ln for ln in src.splitlines() if "pytest.skip" in ln]
-    assert not any("shim" in ln.lower() for ln in skip_lines), skip_lines
+    skip_lines = [ln.strip() for ln in src.splitlines() if "pytest.skip" in ln]
+    assert skip_lines == ['pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")'], skip_lines

--- a/tests/test_smoke_alias_rename_hook_guard.py
+++ b/tests/test_smoke_alias_rename_hook_guard.py
@@ -10,6 +10,7 @@ quietly. Pinned off-VM with the ``_FakeVM`` pattern (precedent:
 
 from __future__ import annotations
 
+import ast
 import inspect
 import re
 from dataclasses import dataclass, field
@@ -63,15 +64,25 @@ def test_probe_transport_failure_fails_distinctly() -> None:
 
 
 def test_the_only_skip_left_is_the_missing_package_one() -> None:
-    """Row 4 regression guard: the module keeps exactly ONE ``pytest.skip``, the
-    no-package-to-deploy fixture guard.
+    """Row 4 regression guard: the module keeps exactly ONE ``pytest.skip`` call, the
+    no-package-to-deploy fixture guard, and its message is that guard's.
 
-    Whitelisting the one legitimate skip beats blacklisting a keyword: a future skip for
-    a missing shipped file worded without "shim" would pass a keyword check, while any new
-    skip at all trips this one.
+    Read the AST rather than the source text, so a comment that merely mentions
+    ``pytest.skip(`` cannot fail this and, more importantly, a deleted skip whose wording
+    survives as a comment cannot satisfy it: the message has to sit INSIDE the one
+    surviving call, not merely somewhere in the file.
     """
-    src = inspect.getsource(tsar)
-    # Count call sites rather than matching whole source lines: a harmless line-wrap of
-    # the legitimate skip must not fail this, while any ADDED skip still does.
-    assert len(re.findall(r"pytest\.skip\(", src)) == 1, "exactly one pytest.skip must remain"
-    assert "SMOKE_PKG not set" in src, "the surviving skip must be the no-package-to-deploy guard"
+    calls = [
+        node
+        for node in ast.walk(ast.parse(inspect.getsource(tsar)))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "skip"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "pytest"
+    ]
+    assert len(calls) == 1, f"exactly one pytest.skip call must remain, found {len(calls)}"
+    reason = calls[0].args[0] if calls[0].args else None
+    assert isinstance(reason, ast.Constant) and "SMOKE_PKG not set" in str(reason.value), (
+        "the surviving skip must be the no-package-to-deploy guard"
+    )

--- a/tests/test_smoke_alias_rename_hook_guard.py
+++ b/tests/test_smoke_alias_rename_hook_guard.py
@@ -71,5 +71,7 @@ def test_the_only_skip_left_is_the_missing_package_one() -> None:
     skip at all trips this one.
     """
     src = inspect.getsource(tsar)
-    skip_lines = [ln.strip() for ln in src.splitlines() if "pytest.skip" in ln]
-    assert skip_lines == ['pytest.skip("SMOKE_PKG not set — no built .pkg to deploy")'], skip_lines
+    # Count call sites rather than matching whole source lines: a harmless line-wrap of
+    # the legitimate skip must not fail this, while any ADDED skip still does.
+    assert len(re.findall(r"pytest\.skip\(", src)) == 1, "exactly one pytest.skip must remain"
+    assert "SMOKE_PKG not set" in src, "the surviving skip must be the no-package-to-deploy guard"

--- a/tests/test_smoke_alias_rename_hook_guard.py
+++ b/tests/test_smoke_alias_rename_hook_guard.py
@@ -1,0 +1,70 @@
+"""``_require_hook_shim`` must fail, never skip, when the alias-rename hook is missing (#1658).
+
+pfBlockerNG ships a required ``pre_write_config`` hook shim
+(``tests/smoke/test_smoke_alias_rename.py::HOOK_SHIM``). The build CI runs
+(``-devel``/``-nightly``) always package it -- its absence on a deployed build
+is a packaging regression, not a reason to skip the whole alias-rename module
+quietly. Pinned off-VM with the ``_FakeVM`` pattern (precedent:
+``tests/test_smoke_unbound_ready.py``, ``tests/test_guest_file_contains.py``).
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from dataclasses import dataclass, field
+
+import pytest
+
+from tests.smoke import test_smoke_alias_rename as tsar
+
+
+@dataclass
+class _FakeResult:
+    """Stand-in for ``subprocess.CompletedProcess[str]`` (the shape ``SmokeVM.ssh`` returns)."""
+
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class _FakeVM:
+    """Fake ``vm.ssh(*remote, timeout=...)`` -- records calls, replays one scripted result."""
+
+    result: _FakeResult
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+
+    def ssh(self, *remote: str, timeout: float = 60.0) -> _FakeResult:
+        self.calls.append(remote)
+        return self.result
+
+
+def test_absent_hook_fails_not_skips() -> None:
+    """rc 1 (clean ``test -f`` miss) -- the helper fails the run and names HOOK_SHIM."""
+    vm = _FakeVM(result=_FakeResult(returncode=1))
+    with pytest.raises(pytest.fail.Exception, match=re.escape(tsar.HOOK_SHIM)):
+        tsar._require_hook_shim(vm)  # type: ignore[arg-type]
+
+
+def test_present_hook_returns_normally() -> None:
+    """rc 0 -- the helper returns; no failure, no skip."""
+    vm = _FakeVM(result=_FakeResult(returncode=0))
+    tsar._require_hook_shim(vm)  # type: ignore[arg-type]  # must not raise
+
+
+def test_probe_transport_failure_fails_distinctly() -> None:
+    """rc 255 (ssh transport fault, e.g. connection refused) is neither "present" nor the
+    clean "absent" case -- it must still fail, with its own rc-bearing message, so a broken
+    probe is never misread as a packaging regression."""
+    vm = _FakeVM(result=_FakeResult(returncode=255, stderr="ssh: connect refused"))
+    with pytest.raises(pytest.fail.Exception, match="rc=255"):
+        tsar._require_hook_shim(vm)  # type: ignore[arg-type]
+
+
+def test_no_skip_for_missing_hook_shim_condition() -> None:
+    """Row 4 regression guard: grep the module source -- no ``pytest.skip`` call mentions
+    the hook shim. All four call sites must route through ``_require_hook_shim`` instead."""
+    src = inspect.getsource(tsar)
+    skip_lines = [ln for ln in src.splitlines() if "pytest.skip" in ln]
+    assert not any("shim" in ln.lower() for ln in skip_lines), skip_lines


### PR DESCRIPTION
## What

`tests/smoke/test_smoke_alias_rename.py` skipped whenever the shipped hook `/usr/local/pkg/firewall_aliases_edit/pre_write_config/pfblockerng.php` was absent from the deployed build. A required shipped file going missing is a packaging regression, not a reason to pass quietly — and because the module-scoped prerequisite guarded the rest, one absent file silently made the whole alias-rename suite vacuous.

The four former skip sites now route through a single `_require_hook_shim(vm)` helper that FAILS instead, naming the path and saying the package is expected to ship it.

## Why this does not turn CI red

The hook is present in the builds CI actually runs. `.github/workflows/ui-tests.yml` builds `channel: devel`, and both the `-devel` and `-nightly` ports create the directory and `INSTALL_DATA` the file; neither has a static `pkg-plist`, so they generate `TMPPLIST` from the staged tree and anything staged is packaged.

The stable port genuinely omits it, which is a real gap that would bite at promotion to `main` — filed separately as #1692 rather than folded in here.

## Probe semantics

The helper distinguishes three outcomes rather than two, matching the precedent set by `helpers.guest_file_contains` (issue #909):

| `test -f` result | Outcome |
| --- | --- |
| rc 0 | hook present, continue |
| rc 1 | clean miss — fail, naming the path as a packaging regression |
| any other rc | probe did not complete (transport failure) — fail with its own message carrying rc and stderr |

Folding the third case into either of the others is what makes a guard lie: an unreadable probe must not read as "present", and it must not masquerade as a clean absence either.

## Tests

`tests/test_smoke_alias_rename_hook_guard.py` pins the helper off-appliance with the repo's established `_FakeVM`/`_FakeResult` stub pattern, so no VM is needed to prove the behaviour:

- absent hook fails and names the path
- present hook returns normally
- a transport-level failure fails with its own distinct message
- the module keeps exactly one `pytest.skip`, the unrelated no-package-to-deploy fixture guard

That last one started as a check that no skip line mentioned "shim". An independent review pointed out that a skip worded `"required pfBlockerNG hook not deployed"` names no shim and would have passed, so it now whitelists the single legitimate skip instead — proven by mutation: adding exactly that reworded skip fails the test, where the keyword version stayed green.

Red→green was executed, not reasoned: with the production file reverted, all four guard tests fail (`AttributeError: module has no attribute '_require_hook_shim'` plus the skip-inventory assertion); restored, all four pass. The three alias-rename behaviour tests are byte-identical below their guard call — only the skip block changed.

Part of #1658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Smoke tests now clearly report missing deployment hook files instead of silently skipping affected checks.
  * Probe and connection failures are reported distinctly with useful diagnostic details.

* **Tests**
  * Added coverage for present, missing, and unreachable hook-file scenarios.
  * Added safeguards to prevent future skips from masking packaging regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->