### PR TITLE
www: order url_compare()'s required $a_key before its optional parameters

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -207,7 +207,7 @@ function pfb_feeds_render_aliasname_inputs($section, $type, $feeds_list, $pconfi
 // as this function's former direct `global $icon` mutation. Empty string means "no
 // match, leave $icon as the caller already has it" -- never a request to clear it.
 function url_compare($ftype, $key, $rowid, $aliasname, $row_aliasname, $row_url, $feed_url, $row_state,
-	    $feed_header, $alternate=FALSE, $alt_header='', $alt_info='', $alt_register='', $a_key) {
+	    $feed_header, $a_key, $alternate=FALSE, $alt_header='', $alt_info='', $alt_register='') {
 
 	global $ex_feeds, $alt_feeds;
 	$x_icon = '';
@@ -352,7 +352,7 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 
 					// Determine all Aliases that reference the Feed URL
 					$row_icon = url_compare($ftype, $key, $row['rowid'], $aliasname, $row['aliasname'], $row['url'], $feed['url'],
-							$row['state'], $feed['header'], FALSE, '', '', '', 0);
+							$row['state'], $feed['header'], 0, FALSE, '', '', '');
 					if (!empty($row_icon)) {
 						$icon = $row_icon;
 					}
@@ -361,8 +361,8 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 					if (isset($feed['alternate'])) {
 						foreach ($feed['alternate'] as $a_key => $alt) {
 							url_compare($ftype, $key, $row['rowid'], $aliasname, $row['aliasname'], $row['url'],
-								$alt['url'], $row['state'], $feed['header'], TRUE, $alt['header'],
-								isset($alt['info']) ? $alt['info'] : '', isset($alt['register']) ? 'register' : '', $a_key);
+								$alt['url'], $row['state'], $feed['header'], $a_key, TRUE, $alt['header'],
+								isset($alt['info']) ? $alt['info'] : '', isset($alt['register']) ? 'register' : '');
 						}
 					}
 				}

--- a/tests/php/FeedsUrlCompareDeprecationTest.php
+++ b/tests/php/FeedsUrlCompareDeprecationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1657 — url_compare() in pfblockerng_feeds.php declared its four
+ * optional parameters ($alternate, $alt_header, $alt_info, $alt_register)
+ * BEFORE the required $a_key, which PHP 8 deprecates (one Deprecated notice
+ * per optional parameter ahead of the required one). Loading the Feeds page
+ * emitted four deprecations while `php -l` and PHPUnit stayed green -- this
+ * pins the E_ALL lint of the file itself so that class of regression cannot
+ * come back silently.
+ *
+ * Scope: this file only, NOT tree-wide. A tree-wide `php -d error_reporting=
+ * E_ALL -l` sweep of every tracked src/ PHP file (issue #1657 brief, section
+ * 5) found a SECOND, pre-existing offender outside this file's blast radius:
+ * pfBlockerNG_get_table() in src/usr/local/www/widgets/widgets/
+ * pfblockerng.widget.php ("Optional parameter $mode declared before required
+ * parameter $pfb_table"). That one is out of scope for #1657 and is left for
+ * a follow-up issue -- fixing it here would be an undisclosed scope creep.
+ */
+final class FeedsUrlCompareDeprecationTest extends TestCase
+{
+	private const TARGET = 'src/usr/local/www/pfblockerng/pfblockerng_feeds.php';
+
+	public function testFeedsFileLintsCleanUnderErrorReportingEAll(): void
+	{
+		$root = dirname(__DIR__, 2);
+		$path = $root . '/' . self::TARGET;
+		$this->assertFileExists($path);
+
+		$cmd = escapeshellarg(PHP_BINARY)
+			. ' -d error_reporting=E_ALL -l '
+			. escapeshellarg($path)
+			. ' 2>&1';
+
+		$output = shell_exec($cmd);
+		$this->assertIsString($output, 'php -l must produce output');
+
+		$this->assertStringContainsString(
+			'No syntax errors detected',
+			(string) $output,
+			'php -l must confirm the file still parses'
+		);
+		$this->assertDoesNotMatchRegularExpression(
+			'/\b(Deprecated|Warning|Notice)\b/',
+			(string) $output,
+			"php -l -d error_reporting=E_ALL must emit no Deprecated/Warning/Notice diagnostics; got:\n{$output}"
+		);
+	}
+}

--- a/tests/php/FeedsUrlCompareIconRenderTest.php
+++ b/tests/php/FeedsUrlCompareIconRenderTest.php
@@ -183,4 +183,63 @@ final class FeedsUrlCompareIconRenderTest extends TestCase
 		$this->assertStringContainsString('fa-solid fa-plus-circle', $cell, 'a feed with no existing alias match must render the add icon');
 		$this->assertStringNotContainsString('fa-solid fa-check', $cell, 'a feed with no existing alias match must NOT render the checkmark icon');
 	}
+
+	// Issue #1657 coverage-matrix row 5: url_compare()'s $a_key moved from
+	// trailing (after $alternate/$alt_header/$alt_info/$alt_register) to just
+	// before $alternate, so the required parameter no longer sits after four
+	// optional ones. $a_key is the literal array key url_compare() stores an
+	// alternate's match state under, at
+	// $alt_feeds[$ftype][$aliasname][$feed_header][$a_key] (:272, :285) -- so
+	// this pins the STORED KEY ITSELF, not just the rendered icon, which is
+	// what makes it sensitive to a one-slot shift at the alternates call site
+	// (:363-365) that the three render-pin tests above are not (proven by
+	// mutation: swapping the $a_key/$alternate argument order there leaves all
+	// three green, because $alternate silently receives $a_key's value (0,
+	// int-falsy) instead of TRUE, which skips the alt_feeds store entirely
+	// without touching the primary-URL row those tests inspect).
+	//
+	// A single alternate ($a_key === 0 from `foreach ($feed['alternate'] as
+	// $a_key => $alt)` on a one-element array) that matches an existing row
+	// must be stored under array key 0 specifically: if the reorder shifts
+	// $a_key into $alternate's slot, $alternate becomes falsy and the whole
+	// store is skipped -- array_key_exists(0, ...) then fails against a
+	// missing parent array, not merely a wrong key.
+	public function testAlternateMatchIsStoredUnderItsForeachKey(): void
+	{
+		$primaryUrl = 'https://example.test/pin-a-key/list.txt';
+		$altUrl     = 'https://alt.example.test/pin-a-key-secondary.txt';
+		$primaryHeader = 'PinFeedAKey';
+		$feed = $this->buildFeed($primaryHeader, $primaryUrl, 'https://example.test/pin-a-key/', [
+			'alternate' => [
+				['url' => $altUrl, 'header' => 'PinFeedAKeyAlt'],
+			],
+		]);
+		$info = ['PinAlias5' => ['action' => 'permit', 'info' => 'Pin alias info', 'feeds' => [$feed]]];
+		$exFeeds = [[
+			'aliasname' => 'PinAlias5',
+			'action'    => 'permit',
+			'state'     => 'Enabled',
+			'url'       => $altUrl,
+			'header'    => 'PinFeedAKeyAlt',
+			'rowid'     => 501,
+		]];
+
+		$this->renderType('ipv4', $info, $exFeeds);
+
+		$this->assertArrayHasKey('ipv4', $GLOBALS['alt_feeds']);
+		$this->assertArrayHasKey('PinAlias5', $GLOBALS['alt_feeds']['ipv4']);
+		$this->assertArrayHasKey($primaryHeader, $GLOBALS['alt_feeds']['ipv4']['PinAlias5']);
+		$this->assertArrayHasKey(
+			0,
+			$GLOBALS['alt_feeds']['ipv4']['PinAlias5'][$primaryHeader],
+			'the single alternate must be stored under its foreach key (0), the $a_key argument -- '
+				. 'if $a_key landed in $alternate\'s call-site slot instead, $alternate would be falsy '
+				. 'and this store would be skipped entirely'
+		);
+		$this->assertStringContainsString(
+			'fa-solid fa-check',
+			$GLOBALS['alt_feeds']['ipv4']['PinAlias5'][$primaryHeader][0]['icon'],
+			'the stored alternate entry must carry the checkmark match icon'
+		);
+	}
 }


### PR DESCRIPTION
## What

`url_compare()` on the Feeds page declared four optional parameters (`$alternate`, `$alt_header`, `$alt_info`, `$alt_register`) before the required `$a_key`, which PHP 8 deprecates. Every Feeds page load emitted four deprecations while `php -l` and PHPUnit stayed green, so nothing caught them:

```
Deprecated: url_compare(): Optional parameter $alternate declared before required parameter $a_key is implicitly treated as a required parameter
Deprecated: url_compare(): Optional parameter $alt_header ...
Deprecated: url_compare(): Optional parameter $alt_info ...
Deprecated: url_compare(): Optional parameter $alt_register ...
```

`$a_key` now precedes the optional tail and stays **required**. Defaulting it would also have silenced the deprecation, but it is semantically required — both call sites always pass it — so a default would have hidden the contract rather than fixed the ordering.

Both call sites pass arguments positionally and were reordered to match. Every value still reaches the same parameter it reached before; an independent review walked both call sites position by position to confirm no off-by-one.

## Why the existing tests were not enough

The three existing render tests do not discriminate argument order. Swapping `$a_key` and `TRUE` at the alternate call site leaves all three green: the mutation gives `$alternate` a falsy `0`, which silently skips the alternate store without touching the primary row those tests inspect.

So this ships `testAlternateMatchIsStoredUnderItsForeachKey`, which reads the `$alt_feeds` structure directly and fails under exactly that mutation (`Failed asserting that an array has the key 'ipv4'`). Both halves — old tests stay green, new test goes red — were reproduced by the reviewer, not just asserted.

## The guard

`tests/php/FeedsUrlCompareDeprecationTest.php` lints the file under `error_reporting=E_ALL` and asserts zero `Deprecated`/`Warning`/`Notice` output. Proven non-vacuous by reintroducing a deprecation through a *different* mechanism than the original bug (defaulting `$feed_header` while leaving `$a_key` required after it) — the guard fails on that too.

It is scoped to this one file on purpose. A sweep of all 21 tracked PHP files under `src/` found exactly one other offender, `pfBlockerNG_get_table()` in the dashboard widget, filed as #1693. Once that lands, this guard should be widened to cover every tracked `src/` PHP file so the class cannot return anywhere.

Being a static lint, it catches declaration-time diagnostics only. A runtime `Undefined array key` in the same function's `$alt_feeds` lookup surfaced while designing the new test and is filed separately as #1694 — it needs an executing test, not a lint, and is out of scope here.

Part of #1657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


no-test-needed: the Feeds page already carries reachable Tier-A `ui_render` coverage for all three `?type=` sub-tabs in `tests/smoke/ui/test_render_smoke.py`, and this change is a behaviour-preserving signature reorder. A second reviewer rendered the predefined-feed type on both `origin/devel` and this head, with a fixture carrying a primary match and two alternates, and diffed the results: the HTML, the `$alt_feeds` structure and the `$ex_feeds` found-state are byte-identical, the only difference being the four deprecation banners `devel` emits before rendering. Every argument also still reaches the parameter it reached before, walked position by position. The coverage that was genuinely missing was hermetic and ships here: an E_ALL lint guard proven red against the original bug, plus a render test that discriminates argument order where the three pre-existing ones do not. Adding a new live-VM marker would mean inventing an assertion about fresh-box render state that cannot be verified off-appliance, which is worse than the coverage already in place.

