### PR TITLE
list_scripts: resolve jq and iprange by absolute path in the AWS pre-script

### DIFF
--- a/src/usr/local/pkg/pfblockerng/list_scripts/aws_region_prefixes.sh
+++ b/src/usr/local/pkg/pfblockerng/list_scripts/aws_region_prefixes.sh
@@ -25,8 +25,18 @@ alias="${1}"
 prefix="${2}"
 region="${3}"
 
+# issue #714: resolve privileged binaries to absolute paths (override-with-default,
+# matching pfblockerng.sh's pathaggregate naming) instead of bare-name PATH lookup.
+pathjq="${pathjq:-/usr/local/bin/jq}"
+pathaggregate="${pathaggregate:-/usr/local/bin/iprange}"
+
 if [ -z "${alias}" ] || [ ! -f "${alias}" ]; then
 	echo "AWS pre-script: input file not found: ${alias}"
+	exit 1
+fi
+
+if [ ! -x "${pathjq}" ]; then
+	echo "AWS pre-script: jq not found or not executable: ${pathjq}"
 	exit 1
 fi
 
@@ -52,15 +62,20 @@ fi
 # pipeline hid a jq failure (POSIX sh has no pipefail): a malformed/truncated
 # download could emit a partial set that iprange happily passed through, silently
 # overwriting the alias with bad data. Parse to a temp, verify, THEN publish.
-if ! jq -r "${jqfilter}" "${alias}" > "${rawfile}"; then
+if ! "${pathjq}" -r "${jqfilter}" "${alias}" > "${rawfile}"; then
 	echo "AWS pre-script: jq failed to parse ${alias}"
 	rm -f "${rawfile}" "${tempfile}"
 	exit 1
 fi
 
 if [ "${prefix}" = '_v4' ]; then
+	if [ ! -x "${pathaggregate}" ]; then
+		echo "AWS pre-script: iprange not found or not executable: ${pathaggregate}"
+		rm -f "${rawfile}" "${tempfile}"
+		exit 1
+	fi
 	# iprange aggregates the IPv4 CIDRs (reads stdin, as the original pipeline did).
-	if ! iprange < "${rawfile}" > "${tempfile}"; then
+	if ! "${pathaggregate}" < "${rawfile}" > "${tempfile}"; then
 		echo "AWS pre-script: iprange aggregation failed"
 		rm -f "${rawfile}" "${tempfile}"
 		exit 1

--- a/tests/shell/ip_pre_aws_spec.sh
+++ b/tests/shell/ip_pre_aws_spec.sh
@@ -112,3 +112,70 @@ Describe 'aws_region_prefixes.sh v6 dedup (issue #1079)'
     The lines of contents of file "$awswork" should equal 2
   End
 End
+
+# issue #714: aws_region_prefixes.sh used to invoke jq/iprange by bare name, so
+# whatever came first on PATH decided which binary ran. It now resolves both
+# through pathjq/pathaggregate (spec_helper points these at the real jq and the
+# iprange shim); a hostile same-named binary placed earlier on PATH must never run.
+Describe 'aws_region_prefixes.sh ignores hostile PATH entries (issue #714)'
+  hostiledir=""
+  awswork=""
+  setup() {
+    hostiledir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/awshostile.XXXXXX")"
+    awswork="$(mktemp "${SHELLSPEC_TMPBASE:-/tmp}/awshostilein.XXXXXX")"
+    cp "${PFB_FIXTURES}/aws-ip-ranges.json" "${awswork}"
+  }
+  cleanup() { rm -rf "${hostiledir}"; rm -f "${awswork}"; }
+  Before 'setup'
+  After 'cleanup'
+
+  write_hostile_shim() {
+    cat > "$1" <<'EOF'
+#!/bin/sh
+echo "HOSTILE $(basename "$0") INVOKED" >&2
+exit 1
+EOF
+    chmod +x "$1"
+  }
+
+  It 'never invokes a hostile jq placed earlier in PATH'
+    write_hostile_shim "${hostiledir}/jq"
+    When run env PATH="${hostiledir}:${PATH}" sh "${PFB_PKGDIR}/list_scripts/ip_pre_AWS_AF.sh" "${awswork}" _v4
+    The status should be success
+    The stderr should not include "HOSTILE"
+    The contents of file "${awswork}" should equal "10.10.0.0/24"
+  End
+
+  It 'never invokes a hostile iprange placed earlier in PATH'
+    write_hostile_shim "${hostiledir}/iprange"
+    When run env PATH="${hostiledir}:${PATH}" sh "${PFB_PKGDIR}/list_scripts/ip_pre_AWS_AF.sh" "${awswork}" _v4
+    The status should be success
+    The stderr should not include "HOSTILE"
+    The contents of file "${awswork}" should equal "10.10.0.0/24"
+  End
+End
+
+# A resolved pathjq/pathaggregate that doesn't exist/isn't executable must fail
+# loudly naming the path, never silently run an empty command.
+Describe 'aws_region_prefixes.sh fails loudly on a missing resolved binary (issue #714)'
+  awswork=""
+  setup() {
+    awswork="$(mktemp "${SHELLSPEC_TMPBASE:-/tmp}/awsmissing.XXXXXX")"
+    cp "${PFB_FIXTURES}/aws-ip-ranges.json" "${awswork}"
+  }
+  cleanup() { rm -f "${awswork}"; }
+  Before 'setup'
+  After 'cleanup'
+
+  It 'fails naming the path when pathjq does not resolve to an executable'
+    When run env pathjq="/nonexistent/pfb-test-jq" sh "${PFB_PKGDIR}/list_scripts/ip_pre_AWS_AF.sh" "${awswork}" _v4
+    The status should be failure
+    The output should include "/nonexistent/pfb-test-jq"
+  End
+
+  It 'fails naming the path when pathaggregate does not resolve to an executable'
+    When run env pathaggregate="/nonexistent/pfb-test-iprange" sh "${PFB_PKGDIR}/list_scripts/ip_pre_AWS_AF.sh" "${awswork}" _v4
+    The status should be failure
+    The output should include "/nonexistent/pfb-test-iprange"
+  End
+End

--- a/tests/shell/spec_helper.sh
+++ b/tests/shell/spec_helper.sh
@@ -17,11 +17,18 @@ PFB_SHIMS="${PFB_ROOT}/tests/shell/bin"
 . "${PFB_ROOT}/scripts/lib/git-env-scrub.sh"
 scrub_git_env() { pfb_scrub_git_env; }
 
-# Put the iprange shim ahead of the real PATH so the AWS pre-scripts (which call
-# `iprange` by bare name) pick up the deterministic stand-in. jq stays the real
-# system binary.
+# Put the iprange shim ahead of the real PATH -- pfb_real_iprange() (see
+# pfblockerng_suppress_spec.sh) strips PFB_SHIMS back off to find a genuine
+# system iprange when one is present.
 PATH="${PFB_SHIMS}:${PATH}"
-export PATH PFB_ROOT PFB_PKGDIR PFB_FIXTURES PFB_SHIMS
+
+# issue #714: aws_region_prefixes.sh resolves jq/iprange via pathjq/pathaggregate
+# (absolute path, no bare-name PATH lookup) instead of calling them by bare name.
+# Point those at the real system jq and at the deterministic iprange shim.
+pathjq="$(command -v jq)"
+pathaggregate="${PFB_SHIMS}/iprange"
+
+export PATH PFB_ROOT PFB_PKGDIR PFB_FIXTURES PFB_SHIMS pathjq pathaggregate
 
 # Run one ip_pre_AWS_*.sh over a private copy of the fixture (the script
 # overwrites its input file in place) and echo the resulting prefixes, sorted and


### PR DESCRIPTION
## What

`aws_region_prefixes.sh` — the shared implementation behind all 25 `ip_pre_AWS_*.sh` wrappers — called `jq` and `iprange` as bare command names, so whatever `PATH` the calling process happened to carry decided which binary ran. `.agents/context/lang-shell.md` requires add-on binaries (it names `iprange`, `grepcidr`, `mmdblookup`, `jq`, `pfctl`) to be reached through absolute-path `path*` variables. This is the last open item of the #714 audit backlog.

Both binaries now resolve inside the script:

```sh
pathjq="${pathjq:-/usr/local/bin/jq}"
pathaggregate="${pathaggregate:-/usr/local/bin/iprange}"
```

each guarded by `[ ! -x ]` with a loud failure naming the path, so a missing binary can never degrade into an empty command.

## Why the paths live in this script rather than coming from `pfblockerng.sh`

`pfblockerng.sh` is the naming precedent (`pathaggregate="/usr/local/bin/iprange"` and siblings) but cannot be the runtime source here: `pfblockerng_apply.inc` executes the pre-script straight from PHP —

```php
exec("{$tmo}" . escapeshellarg($pfb_script_pre) . " {$file_dwn_esc} ...")
```

— so the script is never a child of `pfblockerng.sh` and would inherit nothing from it. Exporting those variables there would have expanded to empty here and broken all 25 AWS feeds. The override-with-default form keeps production PATH-independent while letting the spec suite point the variables at its shims.

## Proof on a real appliance

Run on a live pfSense box with a deliberately clean environment — `env -i PATH=/usr/bin:/bin`, so no `path*` overrides and `/usr/local/bin` not even on `PATH`:

```
$ env -i PATH=/usr/bin:/bin sh aws_region_prefixes.sh aws-sample.json _v4 us- ; echo EXIT=$? ; cat aws-sample.json
EXIT=0
13.34.37.64/27
52.94.76.0/22
```

The script rewrites its input file in place and prints nothing on success, so the CIDR lines above come from the trailing `cat`, not from the script's stdout. Correct `us-` filtering, `ap-northeast-2` excluded. It could only have resolved through the absolute defaults, since `/usr/local/bin` is not on that `PATH`.

The same script from `devel`, same box, same clean environment:

```
aws_region_prefixes.sh: jq: not found
AWS pre-script: jq failed to parse aws-sample.json
```

— leaving the downloaded JSON unfiltered. So this is not only a hardening change: the bare lookup genuinely fails whenever `/usr/local/bin` is absent from the caller's `PATH`.

## Tests

Four new shellspec examples, all run under the dash pin (`shellspec --shell dash`, 959 examples green across the suite):

- a hostile `jq` earlier in `PATH` is not invoked
- a hostile `iprange` earlier in `PATH` is not invoked
- a missing/non-executable resolved `jq` fails loudly, naming the path
- likewise for `iprange`

Red→green was executed: against the pre-fix script the hostile shims print `HOSTILE jq INVOKED` / `HOSTILE iprange INVOKED` on stderr — the vulnerability firing — and the two guard examples fail because no guard exists yet. The 34 pre-existing region-filter examples stay green throughout; `spec_helper.sh` now supplies the overrides explicitly, since a `PATH` shim is deliberately no longer reachable.

## Scope

`pfblockerng.sh` and the 25 wrappers are untouched. A tree-wide grep found no other bare `jq`/`iprange` invocation in `src/` — the remaining textual hits are prose in comments.

Part of #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

