### PR TITLE
release: fail closed on dry_run instead of publishing on any non-true value

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -490,7 +490,6 @@ jobs:
         with:
           # dry_run=true: validate off the dispatch ref (HEAD); no tag exists yet.
           # dry_run=false: check out the just-created tag (contains the changelog).
-          # Only an exact 'false' checks out the tag.
           ref: ${{ github.event.inputs.dry_run == 'false' && github.event.inputs.tag || github.ref }}
           fetch-depth: 0   # need full history for changelog
 
@@ -823,7 +822,6 @@ jobs:
           # dry_run=true: build off the dispatch ref (HEAD); no tag exists yet.
           # dry_run=false: check out the just-created tag so .pkg is stamped from the
           #   tagged tree (which includes the committed changelog).
-          # Only an exact 'false' checks out the tag.
           ref: ${{ github.event.inputs.dry_run == 'false' && github.event.inputs.tag || github.ref }}
 
       - name: Set up Python 3.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -504,11 +504,9 @@ jobs:
           INPUT_TAG: ${{ github.event.inputs.tag }}
           INPUT_DRY: ${{ github.event.inputs.dry_run }}
         run: |
-          # Empty/omitted stays the safe default (dry-run, publish nothing) — the
-          # `type: boolean` input normally guarantees exactly "true"/"false" from the
-          # dispatch UI, but an API-triggered dispatch can still hand this an arbitrary
-          # string, so reject anything else loudly and early, before any
-          # $GITHUB_OUTPUT is written and before the tag/branch validation below runs.
+          # An API dispatch can hand this an arbitrary string despite the boolean input
+          # type, so reject anything but true/false before any $GITHUB_OUTPUT is written.
+          # Empty stays the safe default.
           DRY_RUN="${INPUT_DRY:-true}"
           case "$DRY_RUN" in
             true|false) ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,8 +453,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Only an exact 'false' checks out the tag; anything
-          # else (true, empty, a typo) falls back to HEAD, same as the mutation gates.
           ref: ${{ github.event.inputs.dry_run == 'false' && github.event.inputs.tag || github.ref }}
           fetch-depth: 0
       - name: Resolve stamp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ name: Release
 #      modes, gated on prepare-release succeeding (or being skipped in dry-run).
 #
 #   3. attach-pkgs / repo-publish / sync-ports-fork: real-publish only
-#      (dry_run == 'false', fail-closed — issue #1661), same ordering as before.
+#      (dry_run == 'false'), same ordering as before.
 #
 # dry_run=true (default): validate + build off HEAD; publish NOTHING (no commit, no
 # tag, no Release, no port bump, no pkg-repo poke).
@@ -59,9 +59,8 @@ jobs:
   prepare-release:
     name: Commit changelog + create the release tag
     runs-on: ubuntu-latest
-    # Fail-closed (issue #1661): only 'false' takes the real-publish path; true, empty
-    # and typo'd values skip. This expression is NOT the whole guard — GitHub compares
-    # strings case-INSENSITIVELY, so 'FALSE' satisfies it too; the first step below
+    # Only 'false' takes the real-publish path. NOT the whole guard: GitHub compares
+    # strings case-insensitively, so 'FALSE' satisfies this too and the first step below
     # re-checks case-sensitively before anything is pushed.
     if: ${{ github.event.inputs.dry_run == 'false' }}
     permissions:
@@ -77,10 +76,9 @@ jobs:
       sha:         ${{ steps.push-tag.outputs.sha }}
 
     steps:
-      # The job-level `if:` above admits any case-variant of 'false', so re-check here
-      # case-sensitively BEFORE the checkout that can push a commit and a tag. Without
-      # this, a 'FALSE' dispatch would push both and only then die at the `release`
-      # job's identical guard, stranding a half-cut release.
+      # The job-level `if:` admits any case-variant of 'false'; re-check case-sensitively
+      # BEFORE the checkout that pushes a commit and a tag, so a 'FALSE' dispatch cannot
+      # push both and then die at the `release` job's guard, stranding a half-cut release.
       - name: Reject a dry_run that is not exactly true or false
         env:
           INPUT_DRY: ${{ github.event.inputs.dry_run }}
@@ -455,7 +453,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Fail-closed (issue #1661): only an exact 'false' checks out the tag; anything
+          # Only an exact 'false' checks out the tag; anything
           # else (true, empty, a typo) falls back to HEAD, same as the mutation gates.
           ref: ${{ github.event.inputs.dry_run == 'false' && github.event.inputs.tag || github.ref }}
           fetch-depth: 0
@@ -492,7 +490,7 @@ jobs:
         with:
           # dry_run=true: validate off the dispatch ref (HEAD); no tag exists yet.
           # dry_run=false: check out the just-created tag (contains the changelog).
-          # Fail-closed (issue #1661): only an exact 'false' checks out the tag.
+          # Only an exact 'false' checks out the tag.
           ref: ${{ github.event.inputs.dry_run == 'false' && github.event.inputs.tag || github.ref }}
           fetch-depth: 0   # need full history for changelog
 
@@ -509,7 +507,7 @@ jobs:
           # Empty/omitted stays the safe default (dry-run, publish nothing) — the
           # `type: boolean` input normally guarantees exactly "true"/"false" from the
           # dispatch UI, but an API-triggered dispatch can still hand this an arbitrary
-          # string, so reject anything else LOUDLY and EARLY (issue #1661), before any
+          # string, so reject anything else loudly and early, before any
           # $GITHUB_OUTPUT is written and before the tag/branch validation below runs.
           DRY_RUN="${INPUT_DRY:-true}"
           case "$DRY_RUN" in
@@ -827,7 +825,7 @@ jobs:
           # dry_run=true: build off the dispatch ref (HEAD); no tag exists yet.
           # dry_run=false: check out the just-created tag so .pkg is stamped from the
           #   tagged tree (which includes the committed changelog).
-          # Fail-closed (issue #1661): only an exact 'false' checks out the tag.
+          # Only an exact 'false' checks out the tag.
           ref: ${{ github.event.inputs.dry_run == 'false' && github.event.inputs.tag || github.ref }}
 
       - name: Set up Python 3.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,10 @@ jobs:
   prepare-release:
     name: Commit changelog + create the release tag
     runs-on: ubuntu-latest
-    # Fail-closed (issue #1661): only an EXACT 'false' takes the real-publish path;
-    # anything else (true, empty, or a typo'd value) skips — see the `release` job's
-    # metadata step for the loud, explicit rejection of anything that isn't true/false.
+    # Fail-closed (issue #1661): only 'false' takes the real-publish path; true, empty
+    # and typo'd values skip. This expression is NOT the whole guard — GitHub compares
+    # strings case-INSENSITIVELY, so 'FALSE' satisfies it too; the first step below
+    # re-checks case-sensitively before anything is pushed.
     if: ${{ github.event.inputs.dry_run == 'false' }}
     permissions:
       contents: write
@@ -76,6 +77,19 @@ jobs:
       sha:         ${{ steps.push-tag.outputs.sha }}
 
     steps:
+      # The job-level `if:` above admits any case-variant of 'false', so re-check here
+      # case-sensitively BEFORE the checkout that can push a commit and a tag. Without
+      # this, a 'FALSE' dispatch would push both and only then die at the `release`
+      # job's identical guard, stranding a half-cut release.
+      - name: Reject a dry_run that is not exactly true or false
+        env:
+          INPUT_DRY: ${{ github.event.inputs.dry_run }}
+        run: |
+          case "$INPUT_DRY" in
+            true|false) ;;
+            *) echo "::error::dry_run input must be exactly 'true' or 'false' (got: '${INPUT_DRY}')"; exit 1 ;;
+          esac
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0          # full history: tag ancestry + log range

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ name: Release
 #      modes, gated on prepare-release succeeding (or being skipped in dry-run).
 #
 #   3. attach-pkgs / repo-publish / sync-ports-fork: real-publish only
-#      (dry_run != 'true'), same ordering as before.
+#      (dry_run == 'false', fail-closed — issue #1661), same ordering as before.
 #
 # dry_run=true (default): validate + build off HEAD; publish NOTHING (no commit, no
 # tag, no Release, no port bump, no pkg-repo poke).
@@ -37,7 +37,8 @@ on:
       dry_run:
         description: "true (default) = validate + build, publish NOTHING. false = cut the real release."
         required: false
-        default: "true"
+        default: true
+        type: boolean
 
 # Least-privilege default; jobs that need more elevate explicitly below
 # (release: contents:write to publish; prepare-release: contents:write to commit +
@@ -58,7 +59,10 @@ jobs:
   prepare-release:
     name: Commit changelog + create the release tag
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.dry_run != 'true' }}
+    # Fail-closed (issue #1661): only an EXACT 'false' takes the real-publish path;
+    # anything else (true, empty, or a typo'd value) skips — see the `release` job's
+    # metadata step for the loud, explicit rejection of anything that isn't true/false.
+    if: ${{ github.event.inputs.dry_run == 'false' }}
     permissions:
       contents: write
       models: read    # actions/ai-inference for the changelog draft
@@ -437,7 +441,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.dry_run != 'true' && github.event.inputs.tag || github.ref }}
+          # Fail-closed (issue #1661): only an exact 'false' checks out the tag; anything
+          # else (true, empty, a typo) falls back to HEAD, same as the mutation gates.
+          ref: ${{ github.event.inputs.dry_run == 'false' && github.event.inputs.tag || github.ref }}
           fetch-depth: 0
       - name: Resolve stamp
         id: stamp
@@ -472,7 +478,8 @@ jobs:
         with:
           # dry_run=true: validate off the dispatch ref (HEAD); no tag exists yet.
           # dry_run=false: check out the just-created tag (contains the changelog).
-          ref: ${{ github.event.inputs.dry_run != 'true' && github.event.inputs.tag || github.ref }}
+          # Fail-closed (issue #1661): only an exact 'false' checks out the tag.
+          ref: ${{ github.event.inputs.dry_run == 'false' && github.event.inputs.tag || github.ref }}
           fetch-depth: 0   # need full history for changelog
 
       - name: Gather release metadata
@@ -485,7 +492,16 @@ jobs:
           INPUT_TAG: ${{ github.event.inputs.tag }}
           INPUT_DRY: ${{ github.event.inputs.dry_run }}
         run: |
+          # Empty/omitted stays the safe default (dry-run, publish nothing) — the
+          # `type: boolean` input normally guarantees exactly "true"/"false" from the
+          # dispatch UI, but an API-triggered dispatch can still hand this an arbitrary
+          # string, so reject anything else LOUDLY and EARLY (issue #1661), before any
+          # $GITHUB_OUTPUT is written and before the tag/branch validation below runs.
           DRY_RUN="${INPUT_DRY:-true}"
+          case "$DRY_RUN" in
+            true|false) ;;
+            *) echo "::error::dry_run input must be exactly 'true' or 'false' (got: '${INPUT_DRY}')"; exit 1 ;;
+          esac
           TAG="$INPUT_TAG"
           [ -n "$TAG" ] || { echo "::error::tag input is required"; exit 1; }
 
@@ -754,7 +770,7 @@ jobs:
         # .pkg assets to the same draft, then the publish-release job flips it to
         # published — at which point immutability locks it with ALL assets present.
         # (draft: true defers the release.published event to the publish-release step.)
-        if: ${{ steps.meta.outputs.dry_run != 'true' }}
+        if: ${{ steps.meta.outputs.dry_run == 'false' }}
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
@@ -797,7 +813,8 @@ jobs:
           # dry_run=true: build off the dispatch ref (HEAD); no tag exists yet.
           # dry_run=false: check out the just-created tag so .pkg is stamped from the
           #   tagged tree (which includes the committed changelog).
-          ref: ${{ github.event.inputs.dry_run != 'true' && github.event.inputs.tag || github.ref }}
+          # Fail-closed (issue #1661): only an exact 'false' checks out the tag.
+          ref: ${{ github.event.inputs.dry_run == 'false' && github.event.inputs.tag || github.ref }}
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v6
@@ -908,7 +925,7 @@ jobs:
     # Run whenever release succeeded AND it was a real publish (not a dry-run);
     # regardless of the build outcome. A build-pkgs-portable failure surfaces as a
     # red leg but does not prevent attach-pkgs from completing with a warning.
-    if: always() && needs.release.result == 'success' && needs.release.outputs.dry_run != 'true'
+    if: always() && needs.release.result == 'success' && needs.release.outputs.dry_run == 'false'
     permissions:
       contents: write
 
@@ -966,7 +983,7 @@ jobs:
     name: Health-check + publish the draft Release
     runs-on: ubuntu-latest
     needs: [prepare-release, release, attach-pkgs, read-matrix]
-    if: always() && needs.release.result == 'success' && needs.attach-pkgs.result == 'success' && needs.read-matrix.result == 'success' && needs.release.outputs.dry_run != 'true'
+    if: always() && needs.release.result == 'success' && needs.attach-pkgs.result == 'success' && needs.read-matrix.result == 'success' && needs.release.outputs.dry_run == 'false'
     permissions:
       contents: write
     steps:
@@ -1061,7 +1078,7 @@ jobs:
     name: Trigger pkg repository publish
     runs-on: ubuntu-latest
     needs: [prepare-release, release, attach-pkgs, publish-release, sync-ports-fork]
-    if: always() && needs.release.result == 'success' && needs.publish-release.result == 'success' && needs.release.outputs.dry_run != 'true'
+    if: always() && needs.release.result == 'success' && needs.publish-release.result == 'success' && needs.release.outputs.dry_run == 'false'
     permissions:
       contents: read
     steps:
@@ -1096,7 +1113,7 @@ jobs:
     name: Sync port on FreeBSD-ports fork
     runs-on: ubuntu-latest
     needs: [prepare-release, release, publish-release]
-    if: always() && needs.publish-release.result == 'success' && needs.release.outputs.dry_run != 'true'
+    if: always() && needs.publish-release.result == 'success' && needs.release.outputs.dry_run == 'false'
     permissions:
       contents: read
 

--- a/tests/test_release_dry_run_gate.py
+++ b/tests/test_release_dry_run_gate.py
@@ -162,6 +162,20 @@ def test_dry_run_input_is_declared_boolean() -> None:
     )
 
 
+def test_dry_run_input_defaults_to_the_safe_value() -> None:
+    """An omitted input must default to a dry run.
+
+    The default carries as much of the fail-closed contract as the type does: flip it to
+    false and a dispatch that simply omits the input publishes for real.
+    """
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    dispatch = workflow_text.split("\non:\n", 1)[1].split("\npermissions:\n", 1)[0]
+    dry_run_block = dispatch.split("      dry_run:\n", 1)[1].split("\n\n", 1)[0]
+    assert re.search(r"^        default:\s*(true|'true'|\"true\")\s*$", dry_run_block, re.MULTILINE), (
+        f"dry_run input must default to true (a dry run); block was:\n{dry_run_block}"
+    )
+
+
 def test_metadata_step_rejects_non_boolean_dry_run() -> None:
     """The `release` job's metadata step must hard-reject anything but true/false.
 

--- a/tests/test_release_dry_run_gate.py
+++ b/tests/test_release_dry_run_gate.py
@@ -11,16 +11,22 @@ that the input itself is declared as a two-value boolean and that the
 `release` job's metadata step rejects anything else loudly before emitting
 any output.
 
-The job/step enumeration is built from the parsed YAML *structure* (job
-headers), never from hardcoded line numbers, so it keeps working as the file
+The job/step enumeration scans for job and step headers by indentation rather
+than parsing YAML, but it keys off that structure instead of hardcoded line
+numbers, so it keeps working as the file
 is edited and a mutation job that quietly loses its dry_run gate — or a new
 one added without picking it up — is caught rather than silently unguarded.
 """
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
+import textwrap
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github/workflows/release.yml"
@@ -203,10 +209,72 @@ def test_metadata_step_rejects_non_boolean_dry_run() -> None:
         f"metadata step must validate $DRY_RUN with a case/esac guard; step was:\n{meta_step}"
     )
     guard = guard_match.group(1)
-    assert re.search(r"true\|false\)\s*;;", guard), f"guard must accept only true/false, got:\n{guard}"
     assert "::error::" in guard, f"guard must emit ::error:: on rejection, got:\n{guard}"
     assert "exit 1" in guard, f"guard must exit non-zero on rejection, got:\n{guard}"
-
     output_marker = meta_step.index('>> "$GITHUB_OUTPUT"')
     guard_pos = meta_step.index(guard_match.group(0))
     assert guard_pos < output_marker, "the dry_run guard must run BEFORE any $GITHUB_OUTPUT write"
+
+
+# Both case/esac guards, keyed by the variable each one validates. There are two on
+# purpose -- prepare-release re-checks before the tag push because the job-level
+# expression compares case-insensitively -- so both must be executed, not just the one
+# a reviewer happened to name.
+GUARD_VARS = ("INPUT_DRY", "DRY_RUN")
+
+
+def _guard_scripts() -> list[str]:
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    scripts = [
+        textwrap.dedent(match.group(1))
+        for var in GUARD_VARS
+        for match in [re.search(rf'(case "\${var}" in\n.*?\n[ \t]*esac)', workflow_text, re.DOTALL)]
+        if match is not None
+    ]
+    assert len(scripts) == len(GUARD_VARS), f"expected a case/esac guard per {GUARD_VARS}, found {len(scripts)}"
+    return scripts
+
+
+def _run_guard(value: str) -> list[int]:
+    """Execute EVERY dry_run case/esac guard under sh with the value, returning each rc."""
+    results = []
+    for script in _guard_scripts():
+        body = f'INPUT_DRY="$1"\nDRY_RUN="${{INPUT_DRY:-true}}"\n{script}\n'
+        results.append(
+            subprocess.run(  # noqa: S603
+                ["sh", "-c", body, "sh", value],
+                env={"PATH": os.environ.get("PATH", "")},
+                capture_output=True,
+                text=True,
+            ).returncode
+        )
+    return results
+
+
+@pytest.mark.parametrize("value", ["true", "false"])
+def test_the_guard_accepts_exactly_the_safe_values(value: str) -> None:
+    """Executed, not pattern-matched: these must survive the real guard."""
+    assert all(rc == 0 for rc in _run_guard(value)), f"a guard rejected the legitimate value {value!r}"
+
+
+def test_an_omitted_value_is_safe_under_both_guards() -> None:
+    """The two guards treat an omitted value differently, and both outcomes are safe.
+
+    The metadata guard defaults it to a dry run; the pre-tag guard checks the raw input
+    and rejects it outright. Neither can publish, which is what matters -- an omitted
+    value cannot reach prepare-release anyway, since its job-level expression requires
+    'false'. Pinned so that a future edit which makes either one ACCEPT-and-publish is
+    caught rather than reasoned about.
+    """
+    assert _run_guard("") != [0, 0], "an omitted dry_run must not sail through every guard as a publish"
+
+
+@pytest.mark.parametrize("value", ["TRUE", "True", "FALSE", "False", "tru", "yes", "1", "0", " false"])
+def test_the_guard_rejects_case_variants_and_malformed_values(value: str) -> None:
+    """Issue #1661 asks that case variants and malformed values be PINNED, not merely
+    handled. Running the guard is the only way to catch a regression that widens it --
+    an assertion on the guard's source text passes happily against `TRUE|true|false)`.
+    """
+    assert all(rc != 0 for rc in _run_guard(value)), (
+        f"a guard accepted {value!r}, which must never reach a publish gate"
+    )

--- a/tests/test_release_dry_run_gate.py
+++ b/tests/test_release_dry_run_gate.py
@@ -42,6 +42,8 @@ _JOB_HEADER_RE = re.compile(r"^  ([A-Za-z][A-Za-z0-9_-]*):[ \t]*$")
 # Any string-compared fail-open shape: dry_run != 'true' / != "true", regardless
 # of which context reads it (github.event.inputs / steps.*.outputs / needs.*.outputs).
 _FAIL_OPEN_RE = re.compile(r"dry_run\s*!=\s*['\"]true['\"]")
+# A step starts at a `- ` list item at step indent (6 spaces inside a job body).
+_STEP_HEADER_RE = re.compile(r"^      - ")
 
 
 def _jobs_section_lines(workflow_text: str) -> list[str]:
@@ -81,6 +83,18 @@ def _dry_run_expressions(job_lines: list[str]) -> list[str]:
     exists to check.
     """
     return [line.strip() for line in job_lines if "dry_run" in line and not line.strip().startswith("#")]
+
+
+def _split_into_steps(job_lines: list[str]) -> list[list[str]]:
+    """Group a job body into its steps, so a per-step assertion is bounded by the step
+    itself rather than by a line count that rots as comments are added around it."""
+    steps: list[list[str]] = []
+    for line in job_lines:
+        if _STEP_HEADER_RE.match(line):
+            steps.append([])
+        if steps:
+            steps[-1].append(line)
+    return steps
 
 
 def _parsed_jobs() -> dict[str, list[str]]:
@@ -143,11 +157,10 @@ def test_every_mutation_job_gates_on_an_explicit_false() -> None:
 def test_the_release_draft_step_is_gated_on_an_explicit_false() -> None:
     """The draft-creation step sits inside the `release` job, which carries other
     dry_run references, so a per-job check cannot tell that THIS step lost its gate."""
-    lines = _parsed_jobs()["release"]
-    draft = [i for i, line in enumerate(lines) if "softprops/action-gh-release" in line]
+    steps = _split_into_steps(_parsed_jobs()["release"])
+    draft = [step for step in steps if any("softprops/action-gh-release" in line for line in step)]
     assert draft, "the release job no longer creates a draft via softprops/action-gh-release"
-    window = "\n".join(lines[max(0, draft[0] - 12) : draft[0]])
-    assert re.search(r"dry_run\s*==\s*'false'", window), (
+    assert re.search(r"dry_run\s*==\s*'false'", "\n".join(draft[0])), (
         "the draft-creation step must be gated on an explicit dry_run == 'false'"
     )
 

--- a/tests/test_release_dry_run_gate.py
+++ b/tests/test_release_dry_run_gate.py
@@ -224,49 +224,68 @@ GUARD_VARS = ("INPUT_DRY", "DRY_RUN")
 
 
 def _guard_scripts() -> list[str]:
+    """Every guard, lifted from the workflow verbatim.
+
+    For the metadata guard the slice starts at its `DRY_RUN=` assignment, so the
+    default-fallback ships INTO the test. Reconstructing that line here instead would
+    shadow the one piece of logic that decides what an omitted input means.
+    """
     workflow_text = WORKFLOW.read_text(encoding="utf-8")
     scripts = [
         textwrap.dedent(match.group(1))
         for var in GUARD_VARS
-        for match in [re.search(rf'(case "\${var}" in\n.*?\n[ \t]*esac)', workflow_text, re.DOTALL)]
+        for match in [
+            re.search(
+                rf'((?:^[ \t]*{var}="[^"\n]*"\n)?[ \t]*case "\${var}" in\n.*?\n[ \t]*esac)',
+                workflow_text,
+                re.DOTALL | re.MULTILINE,
+            )
+        ]
         if match is not None
     ]
     assert len(scripts) == len(GUARD_VARS), f"expected a case/esac guard per {GUARD_VARS}, found {len(scripts)}"
     return scripts
 
 
-def _run_guard(value: str) -> list[int]:
-    """Execute EVERY dry_run case/esac guard under sh with the value, returning each rc."""
+def _run_guard(value: str) -> list[tuple[int, str]]:
+    """Execute EVERY dry_run guard under sh, returning each (exit status, resolved value).
+
+    Only `INPUT_DRY` is supplied -- whatever a guard derives from it comes from the
+    workflow's own text.
+    """
     results = []
     for script in _guard_scripts():
-        body = f'INPUT_DRY="$1"\nDRY_RUN="${{INPUT_DRY:-true}}"\n{script}\n'
-        results.append(
-            subprocess.run(  # noqa: S603
-                ["sh", "-c", body, "sh", value],
-                env={"PATH": os.environ.get("PATH", "")},
-                capture_output=True,
-                text=True,
-            ).returncode
+        body = f'INPUT_DRY="$1"\n{script}\nprintf %s "${{DRY_RUN-$INPUT_DRY}}"\n'
+        completed = subprocess.run(  # noqa: S603
+            ["sh", "-c", body, "sh", value],
+            env={"PATH": os.environ.get("PATH", "")},
+            capture_output=True,
+            text=True,
         )
+        results.append((completed.returncode, completed.stdout))
     return results
 
 
 @pytest.mark.parametrize("value", ["true", "false"])
 def test_the_guard_accepts_exactly_the_safe_values(value: str) -> None:
     """Executed, not pattern-matched: these must survive the real guard."""
-    assert all(rc == 0 for rc in _run_guard(value)), f"a guard rejected the legitimate value {value!r}"
+    assert all(rc == 0 for rc, _ in _run_guard(value)), f"a guard rejected the legitimate value {value!r}"
 
 
-def test_an_omitted_value_is_safe_under_both_guards() -> None:
-    """The two guards treat an omitted value differently, and both outcomes are safe.
+def test_an_omitted_value_resolves_to_a_dry_run() -> None:
+    """An omitted value must RESOLVE to "true", not merely survive a guard.
 
-    The metadata guard defaults it to a dry run; the pre-tag guard checks the raw input
-    and rejects it outright. Neither can publish, which is what matters -- an omitted
-    value cannot reach prepare-release anyway, since its job-level expression requires
-    'false'. Pinned so that a future edit which makes either one ACCEPT-and-publish is
-    caught rather than reasoned about.
+    Checking exit status alone cannot see this: the guards accept both "true" and
+    "false", so a default flipped to false would pass every acceptance check while
+    turning an omitted input into a real publish. Assert the value each guard actually
+    produces. The pre-tag guard has no default and rejects a raw empty string, which is
+    equally safe -- it simply never runs for an omitted value, since its job-level
+    expression requires 'false'.
     """
-    assert _run_guard("") != [0, 0], "an omitted dry_run must not sail through every guard as a publish"
+    outcomes = _run_guard("")
+    resolved = [value for rc, value in outcomes if rc == 0]
+    assert resolved, "no guard accepted an omitted value; at least the metadata guard must"
+    assert all(value == "true" for value in resolved), f"an omitted dry_run must resolve to a dry run, got {outcomes!r}"
 
 
 @pytest.mark.parametrize("value", ["TRUE", "True", "FALSE", "False", "tru", "yes", "1", "0", " false"])
@@ -275,6 +294,6 @@ def test_the_guard_rejects_case_variants_and_malformed_values(value: str) -> Non
     handled. Running the guard is the only way to catch a regression that widens it --
     an assertion on the guard's source text passes happily against `TRUE|true|false)`.
     """
-    assert all(rc != 0 for rc in _run_guard(value)), (
+    assert all(rc != 0 for rc, _ in _run_guard(value)), (
         f"a guard accepted {value!r}, which must never reach a publish gate"
     )

--- a/tests/test_release_dry_run_gate.py
+++ b/tests/test_release_dry_run_gate.py
@@ -125,6 +125,33 @@ def test_every_mutation_job_gates_on_dry_run() -> None:
     assert not missing, f"mutation job(s) with no dry_run reference at all: {missing}"
 
 
+def test_every_mutation_job_gates_on_an_explicit_false() -> None:
+    """Each mutation job must carry a positive `dry_run == 'false'` comparison.
+
+    Merely mentioning dry_run is not enough: a polarity flip to `== 'true'` would make
+    every DRY RUN publish -- the mirror of the bug this file exists for -- while still
+    referencing dry_run, so the previous test cannot see it.
+    """
+    positive = re.compile(r"dry_run\s*==\s*'false'")
+    jobs = _parsed_jobs()
+    unpinned = {
+        job for job in MUTATION_JOBS if not any(positive.search(line) for line in _dry_run_expressions(jobs[job]))
+    }
+    assert not unpinned, f"mutation job(s) not gated on an explicit == 'false': {unpinned}"
+
+
+def test_the_release_draft_step_is_gated_on_an_explicit_false() -> None:
+    """The draft-creation step sits inside the `release` job, which carries other
+    dry_run references, so a per-job check cannot tell that THIS step lost its gate."""
+    lines = _parsed_jobs()["release"]
+    draft = [i for i, line in enumerate(lines) if "softprops/action-gh-release" in line]
+    assert draft, "the release job no longer creates a draft via softprops/action-gh-release"
+    window = "\n".join(lines[max(0, draft[0] - 12) : draft[0]])
+    assert re.search(r"dry_run\s*==\s*'false'", window), (
+        "the draft-creation step must be gated on an explicit dry_run == 'false'"
+    )
+
+
 def test_dry_run_input_is_declared_boolean() -> None:
     """The dispatch form itself must only offer two values, not free-form text."""
     workflow_text = WORKFLOW.read_text(encoding="utf-8")

--- a/tests/test_release_dry_run_gate.py
+++ b/tests/test_release_dry_run_gate.py
@@ -1,0 +1,158 @@
+"""release.yml's `dry_run` must fail CLOSED (issue #1661).
+
+`dry_run` gates every mutating step of the release pipeline (tag creation, the
+GitHub Release, .pkg attachment, publish, the pkg-repo dispatch, and the
+FreeBSD-ports bump). The workflow used to gate every one of those with the
+fail-OPEN shape `dry_run != 'true'`: anything that is not the exact string
+"true" -- "TRUE", "True", "tru", "yes", "1", an empty string via a bad
+dispatch -- published for real. This module parses the live workflow (never a
+copy) and enforces the fail-CLOSED shape everywhere `dry_run` is read, plus
+that the input itself is declared as a two-value boolean and that the
+`release` job's metadata step rejects anything else loudly before emitting
+any output.
+
+The job/step enumeration is built from the parsed YAML *structure* (job
+headers), never from hardcoded line numbers, so it keeps working as the file
+is edited and a mutation job that quietly loses its dry_run gate — or a new
+one added without picking it up — is caught rather than silently unguarded.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/release.yml"
+
+# Jobs that perform a real-world mutation gated by dry_run (issue #1661 evidence
+# table): prepare-release creates+pushes the tag; release creates the GitHub
+# Release; attach-pkgs/publish-release/repo-publish/sync-ports-fork publish,
+# flip the release live, poke the pkg repo, and push the ports-fork bump.
+MUTATION_JOBS = {
+    "prepare-release",
+    "release",
+    "attach-pkgs",
+    "publish-release",
+    "repo-publish",
+    "sync-ports-fork",
+}
+
+_JOB_HEADER_RE = re.compile(r"^  ([A-Za-z][A-Za-z0-9_-]*):[ \t]*$")
+# Any string-compared fail-open shape: dry_run != 'true' / != "true", regardless
+# of which context reads it (github.event.inputs / steps.*.outputs / needs.*.outputs).
+_FAIL_OPEN_RE = re.compile(r"dry_run\s*!=\s*['\"]true['\"]")
+
+
+def _jobs_section_lines(workflow_text: str) -> list[str]:
+    lines = workflow_text.splitlines()
+    start = lines.index("jobs:") + 1
+    return lines[start:]
+
+
+def _split_into_jobs(lines: list[str]) -> dict[str, list[str]]:
+    """Group the (already `jobs:`-relative) lines under each top-level job name."""
+    jobs: dict[str, list[str]] = {}
+    current: str | None = None
+    buffer: list[str] = []
+    for line in lines:
+        match = _JOB_HEADER_RE.match(line)
+        if match is not None:
+            if current is not None:
+                jobs[current] = buffer
+            current = match.group(1)
+            buffer = []
+        elif current is not None:
+            buffer.append(line)
+    if current is not None:
+        jobs[current] = buffer
+    return jobs
+
+
+def _dry_run_expressions(job_lines: list[str]) -> list[str]:
+    """Every live (non-comment) line in a job body that reads `dry_run`.
+
+    Covers every consumption form named in issue #1661: `github.event.inputs.dry_run`,
+    `inputs.dry_run`, `steps.*.outputs.dry_run`, and `needs.release.outputs.dry_run`
+    -- whichever forms the line actually uses, not a fixed list of contexts. Deliberately
+    does NOT require the `${{ }}` wrapper: a job/step-level `if:` value is itself an
+    expression and is commonly written bare (e.g. `if: needs.release.outputs.dry_run
+    != 'true'`), so requiring `${{` would silently miss exactly the gates this test
+    exists to check.
+    """
+    return [line.strip() for line in job_lines if "dry_run" in line and not line.strip().startswith("#")]
+
+
+def _parsed_jobs() -> dict[str, list[str]]:
+    return _split_into_jobs(_jobs_section_lines(WORKFLOW.read_text(encoding="utf-8")))
+
+
+def test_mutation_jobs_exist_in_the_workflow() -> None:
+    # Sanity check on the fixture itself: if a job in MUTATION_JOBS gets renamed
+    # or removed, fail here with a clear message rather than a confusing
+    # false-negative in the gate assertions below.
+    jobs = _parsed_jobs()
+    missing = MUTATION_JOBS - jobs.keys()
+    assert not missing, f"expected job(s) not found in release.yml: {missing}"
+
+
+def test_no_fail_open_dry_run_gate_anywhere() -> None:
+    """No job or step condition may use the fail-open `dry_run != 'true'` shape.
+
+    This is a whole-file scan, not limited to MUTATION_JOBS, so a brand-new
+    job/step added later that reintroduces the fail-open shape is caught too.
+    """
+    jobs = _parsed_jobs()
+    offenders = [
+        f"{job}: {expr}"
+        for job, lines in jobs.items()
+        for expr in _dry_run_expressions(lines)
+        if _FAIL_OPEN_RE.search(expr)
+    ]
+    assert not offenders, f"fail-open 'dry_run != true' shape found (must be 'dry_run == false'): {offenders}"
+
+
+def test_every_mutation_job_gates_on_dry_run() -> None:
+    """Every publish-mutating job must reference `dry_run` somewhere in its body.
+
+    Built from the parsed job bodies (never a hardcoded line number), so a
+    mutation job whose gate is deleted outright -- or a newly added mutation
+    job that forgets to reference dry_run at all -- fails here.
+    """
+    jobs = _parsed_jobs()
+    gated_jobs = {job for job, lines in jobs.items() if _dry_run_expressions(lines)}
+    missing = MUTATION_JOBS - gated_jobs
+    assert not missing, f"mutation job(s) with no dry_run reference at all: {missing}"
+
+
+def test_dry_run_input_is_declared_boolean() -> None:
+    """The dispatch form itself must only offer two values, not free-form text."""
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    dispatch = workflow_text.split("\non:\n", 1)[1].split("\npermissions:\n", 1)[0]
+    dry_run_block = dispatch.split("      dry_run:\n", 1)[1].split("\n\n", 1)[0]
+    assert re.search(r"^        type:\s*boolean\s*$", dry_run_block, re.MULTILINE), (
+        f"dry_run input must declare `type: boolean`; block was:\n{dry_run_block}"
+    )
+
+
+def test_metadata_step_rejects_non_boolean_dry_run() -> None:
+    """The `release` job's metadata step must hard-reject anything but true/false.
+
+    Must run BEFORE the step writes to $GITHUB_OUTPUT, so a bad dispatch value
+    never reaches a downstream job/output at all.
+    """
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    meta_step = workflow_text.split("id: meta\n", 1)[1].split("\n      - name:", 1)[0]
+
+    guard_match = re.search(r'case "\$DRY_RUN" in\n(.*?)\n[ \t]*esac', meta_step, re.DOTALL)
+    assert guard_match is not None, (
+        f"metadata step must validate $DRY_RUN with a case/esac guard; step was:\n{meta_step}"
+    )
+    guard = guard_match.group(1)
+    assert re.search(r"true\|false\)\s*;;", guard), f"guard must accept only true/false, got:\n{guard}"
+    assert "::error::" in guard, f"guard must emit ::error:: on rejection, got:\n{guard}"
+    assert "exit 1" in guard, f"guard must exit non-zero on rejection, got:\n{guard}"
+
+    output_marker = meta_step.index('>> "$GITHUB_OUTPUT"')
+    guard_pos = meta_step.index(guard_match.group(0))
+    assert guard_pos < output_marker, "the dry_run guard must run BEFORE any $GITHUB_OUTPUT write"

--- a/tests/test_release_dry_run_gate.py
+++ b/tests/test_release_dry_run_gate.py
@@ -1,22 +1,4 @@
-"""release.yml's `dry_run` must fail CLOSED (issue #1661).
-
-`dry_run` gates every mutating step of the release pipeline (tag creation, the
-GitHub Release, .pkg attachment, publish, the pkg-repo dispatch, and the
-FreeBSD-ports bump). The workflow used to gate every one of those with the
-fail-OPEN shape `dry_run != 'true'`: anything that is not the exact string
-"true" -- "TRUE", "True", "tru", "yes", "1", an empty string via a bad
-dispatch -- published for real. This module parses the live workflow (never a
-copy) and enforces the fail-CLOSED shape everywhere `dry_run` is read, plus
-that the input itself is declared as a two-value boolean and that the
-`release` job's metadata step rejects anything else loudly before emitting
-any output.
-
-The job/step enumeration scans for job and step headers by indentation rather
-than parsing YAML, but it keys off that structure instead of hardcoded line
-numbers, so it keeps working as the file
-is edited and a mutation job that quietly loses its dry_run gate — or a new
-one added without picking it up — is caught rather than silently unguarded.
-"""
+"""Pin fail-closed `dry_run` handling for the current release mutation jobs."""
 
 from __future__ import annotations
 
@@ -31,10 +13,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github/workflows/release.yml"
 
-# Jobs that perform a real-world mutation gated by dry_run (issue #1661 evidence
-# table): prepare-release creates+pushes the tag; release creates the GitHub
-# Release; attach-pkgs/publish-release/repo-publish/sync-ports-fork publish,
-# flip the release live, poke the pkg repo, and push the ports-fork bump.
+# Current jobs that create or publish release artifacts.
 MUTATION_JOBS = {
     "prepare-release",
     "release",
@@ -133,12 +112,7 @@ def test_no_fail_open_dry_run_gate_anywhere() -> None:
 
 
 def test_every_mutation_job_gates_on_dry_run() -> None:
-    """Every publish-mutating job must reference `dry_run` somewhere in its body.
-
-    Built from the parsed job bodies (never a hardcoded line number), so a
-    mutation job whose gate is deleted outright -- or a newly added mutation
-    job that forgets to reference dry_run at all -- fails here.
-    """
+    """Every listed mutation job must reference `dry_run` somewhere in its body."""
     jobs = _parsed_jobs()
     gated_jobs = {job for job, lines in jobs.items() if _dry_run_expressions(lines)}
     missing = MUTATION_JOBS - gated_jobs
@@ -216,10 +190,8 @@ def test_metadata_step_rejects_non_boolean_dry_run() -> None:
     assert guard_pos < output_marker, "the dry_run guard must run BEFORE any $GITHUB_OUTPUT write"
 
 
-# Both case/esac guards, keyed by the variable each one validates. There are two on
-# purpose -- prepare-release re-checks before the tag push because the job-level
-# expression compares case-insensitively -- so both must be executed, not just the one
-# a reviewer happened to name.
+# The pre-tag guard blocks case variants before mutation; the metadata guard
+# protects downstream outputs. Both shipped guards must execute.
 GUARD_VARS = ("INPUT_DRY", "DRY_RUN")
 
 
@@ -266,10 +238,21 @@ def _run_guard(value: str) -> list[tuple[int, str]]:
     return results
 
 
+def test_pre_tag_guard_is_the_first_prepare_release_step() -> None:
+    """Case-variant false must be rejected before any release mutation."""
+    steps = _split_into_steps(_parsed_jobs()["prepare-release"])
+    assert steps, "prepare-release must contain the pre-tag dry_run guard"
+    first_step = "\n".join(steps[0])
+    assert 'case "$INPUT_DRY" in' in first_step, (
+        f"prepare-release must validate $INPUT_DRY in its first step; first step was:\n{first_step}"
+    )
+
+
 @pytest.mark.parametrize("value", ["true", "false"])
 def test_the_guard_accepts_exactly_the_safe_values(value: str) -> None:
     """Executed, not pattern-matched: these must survive the real guard."""
-    assert all(rc == 0 for rc, _ in _run_guard(value)), f"a guard rejected the legitimate value {value!r}"
+    outcomes = _run_guard(value)
+    assert all(rc == 0 for rc, _ in outcomes), f"all guards must accept {value!r}; actual outcomes were {outcomes!r}"
 
 
 def test_an_omitted_value_resolves_to_a_dry_run() -> None:
@@ -294,6 +277,5 @@ def test_the_guard_rejects_case_variants_and_malformed_values(value: str) -> Non
     handled. Running the guard is the only way to catch a regression that widens it --
     an assertion on the guard's source text passes happily against `TRUE|true|false)`.
     """
-    assert all(rc != 0 for rc, _ in _run_guard(value)), (
-        f"a guard accepted {value!r}, which must never reach a publish gate"
-    )
+    outcomes = _run_guard(value)
+    assert all(rc != 0 for rc, _ in outcomes), f"all guards must reject {value!r}; actual outcomes were {outcomes!r}"


### PR DESCRIPTION
## What

`dry_run` was a free-form `workflow_dispatch` input, and every mutating job used the fail-open predicate `dry_run != 'true'`. Values such as `tru`, `yes`, `1`, and `0` therefore selected the real-release path and could push a tag, create a GitHub Release, publish the package repository, and update the ports fork.

This change makes publication fail closed:

1. The dispatch input is `type: boolean` and defaults to `true`.
2. Every mutation gate positively requires `dry_run == 'false'`.
3. `prepare-release` validates the raw value case-sensitively in its first step, before checkout, changelog, commit, or tag work.
4. The release metadata step independently rejects anything other than exact `true` or `false` before writing `$GITHUB_OUTPUT`.

## Case sensitivity

GitHub expression string comparisons are case-insensitive. A value such as `FALSE` can therefore satisfy the job-level `== 'false'` expression, but the first `prepare-release` shell step rejects it before any mutation. Read-only checkout ternaries can likewise select the requested tag for a case variant; downstream publication remains unreachable because `prepare-release` fails.

Other malformed values do not satisfy the positive mutation gates. The metadata guard still rejects them before any release output or draft creation.

The exact `false` path remains intact:

`prepare-release` → `release` → `build-pkgs-portable` → `attach-pkgs` → `publish-release` → `repo-publish` / `sync-ports-fork`.

## Tests

`tests/test_release_dry_run_gate.py` parses the shipped workflow by job and step structure and executes both shell guards under `sh`. Its 21 tests pin:

- the boolean input and safe default;
- removal of every fail-open `!= 'true'` expression;
- explicit-false gates for all current mutation jobs and the draft-creation step;
- the pre-tag guard as the first `prepare-release` step;
- exact `true` / `false`, missing/default, case variants, and malformed values;
- guard placement before output writes; and
- per-guard diagnostics on failure.

Mutation proof moved the pre-tag guard after tag creation: the new order test failed while the other 20 tests passed. Widening a guard, flipping or deleting the default, deleting a guard, and reversing gate polarity are likewise pinned.

The current mutation-job and guard sets are curated. #1662 is the natural follow-up for making that membership self-maintaining as the release workflow grows.

The live dry-run dispatch/no-write acceptance criterion remains open on #1661 and overlaps #1662; this PR does not claim that live proof.

Part of #1661.

🤖 Updated by OpenAI Codex and posted on behalf of @andrebrait.
