### PR TITLE
feeds: guard the nested alt_feeds header read in url_compare (#1694)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -281,7 +281,7 @@ function url_compare($ftype, $key, $rowid, $aliasname, $row_aliasname, $row_url,
 		}
 	}
 	else {
-		if ($alternate && isset($alt_feeds[$ftype]) && isset($alt_feeds[$ftype][$aliasname]) && !$alt_feeds[$ftype][$aliasname][$alt_header]) {
+		if ($alternate && isset($alt_feeds[$ftype]) && isset($alt_feeds[$ftype][$aliasname]) && empty($alt_feeds[$ftype][$aliasname][$alt_header])) {
 			$alt_feeds[$ftype][$aliasname][$feed_header][$a_key] = array(	'icon' => $x_icon, 'url' => $feed_url, 'header' => $alt_header,
 											'info' => $alt_info, 'register' => !empty($alt_register) ? TRUE : FALSE );
 		}

--- a/tests/php/FeedsUrlCompareAltHeaderUndefinedKeyTest.php
+++ b/tests/php/FeedsUrlCompareAltHeaderUndefinedKeyTest.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins url_compare()'s no-match branch (pfblockerng_feeds.php:284, issue #1694):
+ * once ANY alternate has matched for a given $ftype/$aliasname (so the
+ * `$alt_feeds[$ftype][$aliasname]` bucket exists), reaching that branch again for a
+ * SIBLING alternate whose own `$alt_header` sentinel was never written must not read
+ * `$alt_feeds[$ftype][$aliasname][$alt_header]` as if it were guaranteed to exist --
+ * doing so raised "Undefined array key" under E_ALL (the sentinel is only ever written
+ * together with the match record at :272-274, so an alt_header that has not yet
+ * matched anything has no sentinel at all) while STILL evaluating truthy-negated
+ * (missing key negates to TRUE), so the branch happened to run anyway. The fix must
+ * keep running that branch silently, not skip it.
+ *
+ * Calls url_compare() directly (loaded via FeedsPredefinedTypeLoader.php, same
+ * eval-extraction FeedsUrlCompareIconRenderTest.php uses -- pfblockerng_feeds.php
+ * carries top-level execution and cannot be require()d off-appliance).
+ */
+final class FeedsUrlCompareAltHeaderUndefinedKeyTest extends TestCase
+{
+	private mixed $savedAltFeeds = null;
+	private mixed $savedExFeeds  = null;
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/FeedsPredefinedTypeLoader.php';
+		pfb_test_load_feeds_predefined_type_functions();
+	}
+
+	protected function setUp(): void
+	{
+		$this->savedAltFeeds = $GLOBALS['alt_feeds'] ?? null;
+		$this->savedExFeeds  = $GLOBALS['ex_feeds'] ?? null;
+		$GLOBALS['alt_feeds'] = [];
+		$GLOBALS['ex_feeds']  = [];
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->savedAltFeeds === null) {
+			unset($GLOBALS['alt_feeds']);
+		} else {
+			$GLOBALS['alt_feeds'] = $this->savedAltFeeds;
+		}
+		if ($this->savedExFeeds === null) {
+			unset($GLOBALS['ex_feeds']);
+		} else {
+			$GLOBALS['ex_feeds'] = $this->savedExFeeds;
+		}
+	}
+
+	/**
+	 * Runs $fn with an error handler active for the full E_ALL mask and returns the
+	 * (errno, errstr) pairs it captured. Always restores whatever handler was
+	 * previously installed, even if $fn throws, so a failure here cannot leak into
+	 * sibling tests.
+	 *
+	 * @return list<array{0: int, 1: string}>
+	 */
+	private function captureDiagnostics(callable $fn): array
+	{
+		$diagnostics = [];
+		set_error_handler(
+			static function (int $errno, string $errstr) use (&$diagnostics): bool {
+				$diagnostics[] = [$errno, $errstr];
+				return true;
+			},
+			E_ALL
+		);
+		try {
+			$fn();
+		} finally {
+			restore_error_handler();
+		}
+		return $diagnostics;
+	}
+
+	/** @param list<array{0: int, 1: string}> $diagnostics */
+	private function assertNoUndefinedArrayKeyDiagnostic(array $diagnostics): void
+	{
+		$matches = array_values(array_filter(
+			$diagnostics,
+			static fn(array $d): bool => str_contains($d[1], 'Undefined array key')
+		));
+		$this->assertSame(
+			[],
+			$matches,
+			"expected no 'Undefined array key' diagnostic, got:\n" . var_export($diagnostics, true)
+		);
+	}
+
+	// Vacuity guard (coverage matrix row 6): proves captureDiagnostics()'s handler is
+	// genuinely active and genuinely observes this exact class of warning, so the
+	// "no diagnostics" assertions elsewhere in this file cannot pass merely because
+	// the handler never fired.
+	public function testHandlerCapturesADeliberateUndefinedArrayKeyWarning(): void
+	{
+		$probe = [];
+		$diagnostics = $this->captureDiagnostics(static function () use ($probe): void {
+			$unused = $probe['does_not_exist'];
+		});
+
+		$hasUndefinedKeyWarning = false;
+		foreach ($diagnostics as [$errno, $errstr]) {
+			if ($errno === E_WARNING && str_contains($errstr, 'Undefined array key')) {
+				$hasUndefinedKeyWarning = true;
+				break;
+			}
+		}
+		$this->assertTrue(
+			$hasUndefinedKeyWarning,
+			"vacuity guard failed -- the error handler did not observe a deliberately-triggered "
+				. "'Undefined array key' warning; captured:\n" . var_export($diagnostics, true)
+		);
+	}
+
+	// Coverage matrix rows 1+2 -- the red-before/green-after row. Two alternates
+	// under the same $ftype/$aliasname: the first (a_key=0, header 'FirstAlt')
+	// matches its row and writes both the match record and the 'FirstAlt' sentinel
+	// (:271-274). The second (a_key=1, header 'SecondAlt') is a SIBLING that has
+	// never matched anything -- its own sentinel key was never written -- yet the
+	// bucket `$alt_feeds['ipv4']['MyAlias']` now exists from the first call, so the
+	// no-match branch (:283-287) is reached with `[$alt_header]` absent.
+	public function testSecondAlternateReachedAfterFirstMatchTriggersNoUndefinedKeyWarning(): void
+	{
+		$ftype      = 'ipv4';
+		$aliasname  = 'MyAlias';
+		$feedHeader = 'PrimaryFeedHeader';
+
+		// First alternate: row_url == feed_url (alt url) -> real match, writes the
+		// record AND the 'FirstAlt' sentinel together.
+		url_compare(
+			$ftype, 0, 10, $aliasname, $aliasname,
+			'https://example.test/first-alt.txt', 'https://example.test/first-alt.txt',
+			'Enabled', $feedHeader, 0, TRUE, 'FirstAlt', '', ''
+		);
+		$this->assertTrue(
+			isset($GLOBALS['alt_feeds'][$ftype][$aliasname]['FirstAlt']),
+			'setup precondition failed: first alternate must have written its sentinel'
+		);
+
+		// Second alternate: row_url does NOT match this alt's feed_url -> no match,
+		// falls into the :283 else -- and 'SecondAlt' has no sentinel at all.
+		$diagnostics = $this->captureDiagnostics(function () use ($ftype, $aliasname, $feedHeader): void {
+			url_compare(
+				$ftype, 0, 10, $aliasname, $aliasname,
+				'https://example.test/unrelated-row.txt', 'https://example.test/second-alt.txt',
+				'Enabled', $feedHeader, 1, TRUE, 'SecondAlt', '', ''
+			);
+		});
+
+		$this->assertNoUndefinedArrayKeyDiagnostic($diagnostics);
+
+		// Functional outcome (row 2): the branch must still have run and written the
+		// alternate record for a_key=1 under $feed_header, not silently skipped it.
+		$slice = $GLOBALS['alt_feeds'][$ftype][$aliasname][$feedHeader] ?? null;
+		$this->assertIsArray(
+			$slice,
+			"expected \$alt_feeds[{$ftype}][{$aliasname}][{$feedHeader}] to be an array, got:\n"
+				. var_export($GLOBALS['alt_feeds'], true)
+		);
+		$this->assertArrayHasKey(
+			1,
+			$slice,
+			"expected the a_key=1 record to be written; \$alt_feeds slice was:\n" . var_export($slice, true)
+		);
+		$this->assertSame('SecondAlt', $slice[1]['header'] ?? null);
+		$this->assertSame('https://example.test/second-alt.txt', $slice[1]['url'] ?? null);
+		$this->assertSame('', $slice[1]['icon'] ?? 'not-empty', 'no-match branch must store an empty icon');
+	}
+
+	// Coverage matrix row 3: alt_header present and TRUE (already matched) -> the
+	// branch must NOT run again, so a later no-match call for the SAME alt_header
+	// must not clobber the record written when it first matched.
+	public function testAlreadyMatchedAlternateSentinelTrueDoesNotRewriteRecord(): void
+	{
+		$ftype      = 'ipv4';
+		$aliasname  = 'MyAlias';
+		$feedHeader = 'PrimaryFeedHeader';
+
+		url_compare(
+			$ftype, 0, 10, $aliasname, $aliasname,
+			'https://example.test/first-alt.txt', 'https://example.test/first-alt.txt',
+			'Enabled', $feedHeader, 0, TRUE, 'FirstAlt', '', ''
+		);
+		$recordAfterMatch = $GLOBALS['alt_feeds'][$ftype][$aliasname][$feedHeader][0] ?? null;
+		$this->assertNotNull($recordAfterMatch, 'setup precondition failed: first match must write a_key=0');
+		$this->assertNotSame('', $recordAfterMatch['icon'], 'setup precondition failed: match must carry a non-empty icon');
+
+		// A different existing row references the SAME alt_header ('FirstAlt') but
+		// this row's URL does not match it -- sentinel is already TRUE, so :284 must
+		// evaluate FALSE and skip the write entirely.
+		$diagnostics = $this->captureDiagnostics(function () use ($ftype, $aliasname, $feedHeader): void {
+			url_compare(
+				$ftype, 1, 11, $aliasname, $aliasname,
+				'https://example.test/another-unrelated-row.txt', 'https://example.test/first-alt.txt-does-not-match-this-row',
+				'Enabled', $feedHeader, 0, TRUE, 'FirstAlt', '', ''
+			);
+		});
+
+		$this->assertNoUndefinedArrayKeyDiagnostic($diagnostics);
+		$this->assertSame(
+			$recordAfterMatch,
+			$GLOBALS['alt_feeds'][$ftype][$aliasname][$feedHeader][0],
+			"record must be unchanged when the sentinel was already TRUE; before:\n"
+				. var_export($recordAfterMatch, true) . "\nafter:\n"
+				. var_export($GLOBALS['alt_feeds'][$ftype][$aliasname][$feedHeader][0], true)
+		);
+	}
+
+	// Coverage matrix row 4: alt_header present but falsy (not merely absent) ->
+	// the branch must still run, same as the absent-key case. This isolates :284's
+	// boolean-negation semantics from the presence/absence of the key itself.
+	public function testFalsySentinelValuePresentStillTriggersWrite(): void
+	{
+		$ftype      = 'ipv4';
+		$aliasname  = 'MyAlias';
+		$feedHeader = 'PrimaryFeedHeader';
+
+		// Seed the bucket so isset($alt_feeds[$ftype]) / isset($alt_feeds[$ftype][$aliasname])
+		// are both TRUE, with the 'ThirdAlt' sentinel explicitly present and FALSE
+		// (a state the production write path never produces on its own -- the
+		// sentinel is only ever set to TRUE -- but :284's own boolean logic must
+		// treat it the same as "absent" per the coverage matrix).
+		$GLOBALS['alt_feeds'][$ftype][$aliasname]['ThirdAlt'] = FALSE;
+
+		$diagnostics = $this->captureDiagnostics(function () use ($ftype, $aliasname, $feedHeader): void {
+			url_compare(
+				$ftype, 2, 12, $aliasname, $aliasname,
+				'https://example.test/unrelated-row-2.txt', 'https://example.test/third-alt.txt',
+				'Enabled', $feedHeader, 2, TRUE, 'ThirdAlt', '', ''
+			);
+		});
+
+		$this->assertNoUndefinedArrayKeyDiagnostic($diagnostics);
+		$slice = $GLOBALS['alt_feeds'][$ftype][$aliasname][$feedHeader] ?? null;
+		$this->assertIsArray($slice, 'expected the a_key=2 write to have created the feed_header slice');
+		$this->assertArrayHasKey(
+			2,
+			$slice,
+			"expected a_key=2 to be written for a present-but-falsy sentinel; slice:\n" . var_export($slice, true)
+		);
+	}
+
+	// Coverage matrix row 5: $alternate === FALSE short-circuits the whole guard --
+	// nothing written, no diagnostic, regardless of whether $alt_feeds[$ftype]
+	// already exists.
+	public function testAlternateFalseShortCircuitsGuardEntirely(): void
+	{
+		$ftype      = 'ipv4';
+		$aliasname  = 'MyAlias';
+		$feedHeader = 'PrimaryFeedHeader';
+
+		// Pre-seed the bucket so the isset() legs of :284 WOULD be TRUE, isolating
+		// that it is $alternate itself short-circuiting the expression.
+		$GLOBALS['alt_feeds'][$ftype][$aliasname]['SomeOtherAlt'] = TRUE;
+		$before = $GLOBALS['alt_feeds'];
+
+		$diagnostics = $this->captureDiagnostics(function () use ($ftype, $aliasname, $feedHeader): void {
+			url_compare(
+				$ftype, 3, 13, $aliasname, $aliasname,
+				'https://example.test/unrelated-row-3.txt', 'https://example.test/non-alt-url.txt',
+				'Enabled', $feedHeader, 5, FALSE, 'UnusedHeader', '', ''
+			);
+		});
+
+		$this->assertNoUndefinedArrayKeyDiagnostic($diagnostics);
+		$this->assertSame([], $diagnostics, "expected zero diagnostics of any kind, got:\n" . var_export($diagnostics, true));
+		$this->assertSame(
+			$before,
+			$GLOBALS['alt_feeds'],
+			"\$alternate=FALSE must write nothing; before:\n" . var_export($before, true)
+				. "\nafter:\n" . var_export($GLOBALS['alt_feeds'], true)
+		);
+	}
+}


### PR DESCRIPTION
Fixes #1694.

## What

`url_compare()` guarded the outer levels of the `$alt_feeds` lookup but then dereferenced the nested
alternate-header key inside a `!` negation without confirming it exists:

```php
if ($alternate && isset($alt_feeds[$ftype]) && isset($alt_feeds[$ftype][$aliasname])
    && !$alt_feeds[$ftype][$aliasname][$alt_header]) {
```

Under `E_ALL` that raises `Warning: Undefined array key` whenever a feed carries two or more
alternates and one has already matched for the alias while a sibling has not yet been recorded. The
sibling branch four lines up already guards the same key with `isset()`; this one did not.

The fix is one line: `!$alt_feeds[...][$alt_header]` becomes `empty($alt_feeds[...][$alt_header])`.

## Why `empty()` and not an `isset()` conjunction

`empty($x)` is defined as "`$x` does not exist **or** `$x` is falsy", which is exactly what the bare
negation already meant — `!$x` on an undefined offset evaluates `NULL` to `TRUE` — minus the warning.
An `isset(...) && !...` conjunction would have *changed* the branch: the absent-key case would stop
taking it.

That is not reasoning, it was executed. The verifier ran both forms under
`php -d error_reporting=E_ALL` across every reachable value:

| state | `!$x` | `empty($x)` | agree |
|---|---|---|---|
| absent | true (+ `Undefined array key`) | true | ✅ |
| `TRUE` | false | false | ✅ |
| `FALSE` / `NULL` / `0` / `'0'` / `''` / `[]` | true | true | ✅ |
| `[1,2]` / `'hello'` | false | false | ✅ |

All ten rows agree; the only difference is the diagnostic. The branch that runs is unchanged in every
state, reachable or not.

## The test

`tests/php/FeedsUrlCompareAltHeaderUndefinedKeyTest.php` **executes** `url_compare()` through the
existing `tests/php/FeedsPredefinedTypeLoader.php` (`pfblockerng_feeds.php` carries top-level
execution and cannot be `require`d off-appliance). It builds the exact shape the issue names — two
alternates, the first already matched, the second reached with its header key absent — and captures
diagnostics with `set_error_handler`, restoring in `finally`.

The static `E_ALL` lint from #1657 structurally cannot see this: it is a runtime notice, not a
declaration-time one. So the test had to run the function, not lint the file.

It asserts two things, deliberately:

1. no `Undefined array key` diagnostic, and
2. the alternate record is **still written** to `$alt_feeds[$ftype][$aliasname][$feed_header][$a_key]`.

The second assertion is what stops a "fix" that silences the warning by skipping the branch. That was
proven, not assumed: the verifier built exactly that mutant (`isset(...) && !...`) and the suite went
red with `Failed asserting that an array has the key 1`. The vacuity guard —
`testHandlerCapturesADeliberateUndefinedArrayKeyWarning` — calls the same private capture helper the
real assertions use, so it proves the handler is live in the configuration that matters, not in a
separate one.

Branch coverage: sentinel present-and-`TRUE` (branch not taken), present-and-falsy (taken),
`$alternate === FALSE` (whole guard short-circuits). Each was mutation-checked to kill exactly its own
test.

## Evidence

Red→green, executed test-first and then re-executed independently by a read-only verifier against the
committed bytes via `scripts/agent/verify-red-proof.sh`:

```
FREEZE-OK: tests/php/FeedsUrlCompareAltHeaderUndefinedKeyTest.php
RED-OK: test fails against origin/devel src
GREEN-OK: test passes against HEAD
VERDICT: PASS
```

The red fails for the right reason — `errno 2` (`E_WARNING`), naming the alternate header:

```
expected no 'Undefined array key' diagnostic, got:
array ( 0 => array ( 0 => 2, 1 => 'Undefined array key "SecondAlt"', ), )
```

Full suite against a throwaway `origin/devel` worktree, side by side:

| | Tests | Assertions | Deprecations | Notices | Skipped | Failures |
|---|---|---|---|---|---|---|
| `origin/devel` | 4054 | 23163 | 1 | 1 | 3 | 0 |
| this branch | 4059 | 23181 | 1 | 1 | 3 | 0 |

The pre-existing deprecation/notice/skips are identical in content, not just in count.

## Deferred — a second instance of the same class

The `$alt_feeds` sweep this PR is scoped by turned up a genuine sibling defect at `:518`, filed as
**#1702**: the alternate bucket is iterated by position (`[$i - 1]`) but keyed by `$a_key`, so a match
that creates the bucket on a non-first alternate leaves key `0` unwritten while `count()` still reports
N. Reproduced with an executed probe (`slice keys present: 1,2`, `count=2`,
`diagnostics: '2:Undefined array key 0'`). It is a different mechanism in code this diff does not
touch, so it is tracked rather than folded in.

Also recorded and deliberately **not** filed: `:276`–`:278` guards the outer key while reading two
levels deeper, which would break on a duplicate `alternate[].header` within one feed. A full scan of
the shipped `pfblockerng_feeds.json` found no duplicate headers, so there is no producer for it today —
a data-authoring hazard, not an actionable defect. Details are in #1702's Related section.

## no-test-needed

no-test-needed: this fix is observable only as a PHP `E_WARNING`, and no smoke tier can see one.
`tests/smoke/helpers.py` sets `STRICT_PHP_ERROR_REPORTING = "E_ALL ^ (E_WARNING | E_NOTICE |
E_DEPRECATED)"` — Netgate's beta mask, which `tests/smoke/ui/test_strict_php_errors.py` pins as the
level the render-sweep VM runs at — so `E_WARNING` is masked and `PhpErrorLogGuard` observes nothing to
guard. Separately, the trigger needs an alias already subscribed to a multi-alternate feed with exactly
one alternate matched; a fresh box has an empty `$ex_feeds[$ftype]`, which short-circuits the whole
`alt_feeds` path, so a bare Tier-A page visit cannot reach the state at all. A new marker here would
assert nothing. The failable coverage is the hermetic test above, red before and green after.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alternate feed URL matching to prevent undefined-array-key warnings.
  * Preserved existing alternate feed records when a prior match has already been detected.
  * Correctly handles empty, false, and previously set alternate feed states.

* **Tests**
  * Added coverage for alternate feed matching, warning prevention, record preservation, and short-circuit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->