### PR TITLE
agent: pin the wait-checks CI poll to the armed head SHA (#1690)

### DIFF
--- a/.agents/policy/landing.md
+++ b/.agents/policy/landing.md
@@ -6,9 +6,7 @@ merge gate, CI waits, post-merge. Load when: landing a PR or applying review fin
 - **Scope:** vendor-neutral mechanics for landing a pull request — review feedback
   first, then rebase-merge — extracted from the `pr-merge`, `pr-merge-flow`, and
   `pr-comments` skills and the `review-single` reviewer contract (all since retired,
-  [#1431](https://github.com/pfBlockerNG/pfBlockerNG/issues/1431); ticket
-  [#1428](https://github.com/pfBlockerNG/pfBlockerNG/issues/1428), map
-  [#1383](https://github.com/pfBlockerNG/pfBlockerNG/issues/1383)).
+  #1431; ticket #1428, map #1383).
 - **Load-when:** reviewing, resolving review feedback on, or merging a pull request.
 - **Owner:** repo owner. **Last-verified:** 2026-07-17.
 
@@ -354,8 +352,9 @@ The base advances out of band (parallel agents). In the dedicated worktree:
 Poll until every **required** check completes, excluding checks matching
 `coderabbit|snyk` (case-insensitive; both advisory) — via
 `scripts/agent/wait-checks.sh`, the single implementation (self-exiting background
-task, ~40-minute cap, result file's LAST line is the verdict). CLI transport
-unavailable → the client's GitHub MCP tools with wakeup-paced bounded checks.
+task, ~40-minute cap, result file's LAST line is the verdict; `--sha` pins the
+commit). CLI transport unavailable → the client's GitHub MCP tools with
+wakeup-paced bounded checks.
 
 - **Early-verdict reuse:** a CI wait armed at review start that already returned
   `PASS` may replace this wait IFF the SHA it watched still equals the PR head AND
@@ -367,6 +366,7 @@ unavailable → the client's GitHub MCP tools with wakeup-paced bounded checks.
 - **FAIL** → a real check failed: do not merge; report the failing checks and run
   URLs and stop.
 - **TIMEOUT** → report and ask whether to keep waiting; never merge on a timeout.
+- **STALE** → head moved after arming: re-arm and retry; never merge.
 
 ### Merge and clean up
 

--- a/.agents/policy/landing.md
+++ b/.agents/policy/landing.md
@@ -345,16 +345,16 @@ The base advances out of band (parallel agents). In the dedicated worktree:
 - Conflicts that are non-trivial or ambiguous → stop and hand back; never guess a
   resolution just to land the PR.
 - Push `--force-with-lease` (a no-op rebase pushes nothing — fine). The force-push
-  re-triggers CI; the wait below watches THAT run, never a stale one.
+  re-triggers CI; arm the wait below with `--sha "$(git rev-parse HEAD)"` (closes
+  a post-push lag).
 
 ### CI wait (excluding advisory bots)
 
 Poll until every **required** check completes, excluding checks matching
 `coderabbit|snyk` (case-insensitive; both advisory) — via
 `scripts/agent/wait-checks.sh`, the single implementation (self-exiting background
-task, ~40-minute cap, result file's LAST line is the verdict; `--sha` pins the
-commit). CLI transport unavailable → the client's GitHub MCP tools with
-wakeup-paced bounded checks.
+task, ~40-minute cap, result file's LAST line is the verdict). CLI transport
+unavailable → the client's GitHub MCP tools with wakeup-paced bounded checks.
 
 - **Early-verdict reuse:** a CI wait armed at review start that already returned
   `PASS` may replace this wait IFF the SHA it watched still equals the PR head AND
@@ -367,6 +367,7 @@ wakeup-paced bounded checks.
   URLs and stop.
 - **TIMEOUT** → report and ask whether to keep waiting; never merge on a timeout.
 - **STALE** → head moved after arming: re-arm and retry; never merge.
+- **GH-ERROR** → mechanism failure, not a verdict (exit 1): re-arm; never merge.
 
 ### Merge and clean up
 

--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -3,22 +3,26 @@
 # The single implementation of the CI wait the pr-merge skill used to inline.
 #
 # Usage: wait-checks.sh --repo OWNER/REPO --pr N [options]
+#   --sha SHA           pin polling to this commit (default: PR's head SHA at arm time)
 #   --exclude REGEX    case-insensitive check-name exclusion (default 'coderabbit|snyk' --
 #                      both are advisory and must never gate a merge)
 #   --interval SECONDS poll interval (default 30)
 #   --max-iter N       hard iteration cap (default 80, ~40 min at 30s)
 #
-# The LAST stdout line is the verdict: PASS | FAIL | TIMEOUT. On PASS/FAIL the relevant
-# checks JSON precedes it as detail. `bucket` semantics: skipping counts as done-not-
-# failed; PASS requires at least one relevant check registered (never green-by-absence).
+# The LAST stdout line is the verdict: PASS | FAIL | TIMEOUT | STALE. On PASS/FAIL the
+# relevant checks JSON precedes it as detail. `bucket` semantics: skipping counts as done-
+# not-failed; PASS requires at least one relevant check registered (never green-by-absence).
+# Checks are read SHA-addressed (commits/<sha>/check-runs + /status) rather than via the
+# PR's current head, and the head is re-verified against the pinned SHA immediately before
+# any PASS/FAIL, so a force-push can never be reported PASS for a commit it didn't run on.
 # Exit codes: see agent_env.sh. Self-terminating: iteration cap AND wall-clock deadline
 # (max-iter x interval + 300 s slack; PFB_WAIT_DEADLINE overrides) per CLAUDE.md
 # "No orphaned waits" #1.
 
-repo='' pr='' exclude='coderabbit|snyk' interval=30 max_iter=80
+repo='' pr='' sha='' sha_set=0 exclude='coderabbit|snyk' interval=30 max_iter=80
 
 usage() {
-	echo "usage: wait-checks.sh --repo O/R --pr N [--exclude REGEX] [--interval S] [--max-iter N]" >&2
+	echo "usage: wait-checks.sh --repo O/R --pr N [--sha SHA] [--exclude REGEX] [--interval S] [--max-iter N]" >&2
 	exit 2
 }
 
@@ -40,6 +44,31 @@ evaluate_checks() {
 	fi
 }
 
+# Map SHA-addressed check-runs + commit-status payloads (each possibly several
+# `--paginate` pages concatenated) to the {name, bucket} shape evaluate_checks() consumes.
+# Unrecognised status/conclusion values fall to "pending", never "pass" -- an unmapped
+# value must surface as a TIMEOUT a human looks at, not a silent green.
+checks_to_buckets() {
+	# $1 = check-runs payload, $2 = commit-status payload
+	{ printf '%s\n' "$1"; printf '%s\n' "$2"; } | jq -s -c '
+		[ .[] | (.check_runs // [])[] | {name: (.name // ""), bucket: (
+			if .status != "completed" then "pending"
+			elif (.conclusion == "success" or .conclusion == "neutral") then "pass"
+			elif .conclusion == "skipped" then "skipping"
+			elif .conclusion == "cancelled" then "cancel"
+			elif (.conclusion == "failure" or .conclusion == "timed_out"
+				or .conclusion == "action_required" or .conclusion == "stale"
+				or .conclusion == "startup_failure") then "fail"
+			else "pending" end) } ]
+		+
+		[ .[] | (.statuses // [])[] | {name: (.context // ""), bucket: (
+			if .state == "success" then "pass"
+			elif .state == "pending" then "pending"
+			elif (.state == "error" or .state == "failure") then "fail"
+			else "pending" end) } ]
+	'
+}
+
 main() {
 	# shellcheck source=scripts/agent/agent_env.sh
 	. "$(dirname "$0")/agent_env.sh"
@@ -47,6 +76,7 @@ main() {
 		case "$1" in
 			--repo) repo=$2; shift 2 ;;
 			--pr) pr=$2; shift 2 ;;
+			--sha) sha=$2; sha_set=1; shift 2 ;;
 			--exclude) exclude=$2; shift 2 ;;
 			--interval) interval=$2; shift 2 ;;
 			--max-iter) max_iter=$2; shift 2 ;;
@@ -54,6 +84,7 @@ main() {
 		esac
 	done
 	{ [ -n "$repo" ] && [ -n "$pr" ]; } || usage
+	[ "$sha_set" -eq 0 ] || [ -n "$sha" ] || usage
 	require_gh
 	require_tool timeout
 	require_tool jq
@@ -61,18 +92,35 @@ main() {
 	# Wall-clock deadline alongside the cap (CLAUDE.md "No orphaned waits" #1);
 	# PFB_WAIT_DEADLINE (epoch seconds) overrides for tests/ops.
 	deadline=${PFB_WAIT_DEADLINE:-$(( $(date +%s) + max_iter * interval + 300 ))}
+
+	if [ "$sha_set" -eq 0 ]; then
+		# A wait that cannot pin a SHA must fail loudly, never poll blind.
+		if ! sha=$(gh_bounded pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid) || [ -z "$sha" ]; then
+			printf 'GH-ERROR\n%s\n' "$sha"
+			exit 1
+		fi
+	fi
+
 	i=0
 	ghfail=0
 	while [ "$i" -lt "$max_iter" ]; do
 		if [ "$(date +%s)" -ge "$deadline" ]; then
 			break
 		fi
-		if ! json=$(gh_bounded pr checks "$pr" --repo "$repo" --json name,bucket); then
+		ok=1 failed_output=''
+		if ! cr_json=$(gh_bounded api --paginate "repos/$repo/commits/$sha/check-runs"); then
+			ok=0
+			failed_output=$cr_json
+		elif ! status_json=$(gh_bounded api --paginate "repos/$repo/commits/$sha/status"); then
+			ok=0
+			failed_output=$status_json
+		fi
+		if [ "$ok" -eq 0 ]; then
 			# 3 consecutive gh failures = a real problem (bad repo/pr, auth, outage),
 			# not "no checks yet" -- fail loudly instead of polling to a blind TIMEOUT.
 			ghfail=$((ghfail + 1))
 			if [ "$ghfail" -ge 3 ]; then
-				printf 'GH-ERROR\n%s\n' "$json"
+				printf 'GH-ERROR\n%s\n' "$failed_output"
 				exit 1
 			fi
 			i=$((i + 1))
@@ -80,10 +128,20 @@ main() {
 			continue
 		fi
 		ghfail=0
-		[ -n "$json" ] || json='[]'
+		json=$(checks_to_buckets "$cr_json" "$status_json")
 		v=$(evaluate_checks "$json")
 		case "$v" in
 			PASS|FAIL)
+				# The pinned SHA may no longer be the PR head (fix push, force-push
+				# mid-wait) -- confirm before handing out a terminal verdict.
+				if ! live=$(gh_bounded pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid); then
+					printf 'GH-ERROR\n%s\n' "$live"
+					exit 1
+				fi
+				if [ "$live" != "$sha" ]; then
+					printf 'pinned=%s observed=%s\nSTALE\n' "$sha" "$live"
+					exit 0
+				fi
 				printf '%s' "$json" | jq -c "[.[] | select((.name|ascii_downcase|test(\"$exclude\"))|not)]"
 				printf '%s\n' "$v"
 				exit 0

--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -93,16 +93,29 @@ main() {
 	# PFB_WAIT_DEADLINE (epoch seconds) overrides for tests/ops.
 	deadline=${PFB_WAIT_DEADLINE:-$(( $(date +%s) + max_iter * interval + 300 ))}
 
+	ghfail=0
 	if [ "$sha_set" -eq 0 ]; then
-		# A wait that cannot pin a SHA must fail loudly, never poll blind.
-		if ! sha=$(gh_bounded pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid) || [ -z "$sha" ]; then
-			printf 'GH-ERROR\n%s\n' "$sha"
-			exit 1
-		fi
+		# Bounded retry (same 3-strike tolerance as the poll loop below) before
+		# failing loud: a single transient blip on the very first call -- right
+		# after a force-push, exactly when this wait is armed and the API is
+		# least settled -- must not kill the whole wait. Still capped by the
+		# wall-clock deadline via gh_bounded; a wait that still cannot pin a SHA
+		# after that tolerance is exhausted must fail loudly, never poll blind.
+		while :; do
+			if sha=$(gh_bounded pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid) && [ -n "$sha" ]; then
+				break
+			fi
+			ghfail=$((ghfail + 1))
+			if [ "$ghfail" -ge 3 ]; then
+				printf 'GH-ERROR\n%s\n' "$sha"
+				exit 1
+			fi
+			sleep_bounded "$interval" || { printf 'GH-ERROR\n%s\n' "$sha"; exit 1; }
+		done
+		ghfail=0
 	fi
 
 	i=0
-	ghfail=0
 	while [ "$i" -lt "$max_iter" ]; do
 		if [ "$(date +%s)" -ge "$deadline" ]; then
 			break

--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -9,12 +9,16 @@
 #   --interval SECONDS poll interval (default 30)
 #   --max-iter N       hard iteration cap (default 80, ~40 min at 30s)
 #
-# The LAST stdout line is the verdict: PASS | FAIL | TIMEOUT | STALE. On PASS/FAIL the
-# relevant checks JSON precedes it as detail. `bucket` semantics: skipping counts as done-
-# not-failed; PASS requires at least one relevant check registered (never green-by-absence).
-# Checks are read SHA-addressed (commits/<sha>/check-runs + /status) rather than via the
-# PR's current head, and the head is re-verified against the pinned SHA immediately before
-# any PASS/FAIL, so a force-push can never be reported PASS for a commit it didn't run on.
+# The LAST stdout line is the verdict: PASS | FAIL | TIMEOUT | STALE. On PASS/FAIL a
+# `pinned=<sha>` line and the relevant checks JSON precede it as detail. `bucket`
+# semantics: skipping counts as done-not-failed; PASS requires at least one relevant
+# check registered (never green-by-absence). Checks are read SHA-addressed
+# (commits/<sha>/check-runs + /status) rather than via the PR's current head, and the
+# head is re-verified against the pinned SHA (same bounded retry as arm-time; an empty
+# re-read is GH-ERROR, never STALE) immediately before any PASS/FAIL, so a force-push
+# can never be reported PASS for a commit it didn't run on.
+# GH-ERROR (exit 1) is a mechanism failure, not a checks verdict: its FIRST line is
+# GH-ERROR, diagnostic follows -- it does not participate in the last-line contract.
 # Exit codes: see agent_env.sh. Self-terminating: iteration cap AND wall-clock deadline
 # (max-iter x interval + 300 s slack; PFB_WAIT_DEADLINE overrides) per CLAUDE.md
 # "No orphaned waits" #1.
@@ -146,15 +150,27 @@ main() {
 		case "$v" in
 			PASS|FAIL)
 				# The pinned SHA may no longer be the PR head (fix push, force-push
-				# mid-wait) -- confirm before handing out a terminal verdict.
-				if ! live=$(gh_bounded pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid); then
-					printf 'GH-ERROR\n%s\n' "$live"
-					exit 1
-				fi
+				# mid-wait) -- confirm before handing out a terminal verdict. Same
+				# bounded retry as arm-time resolution: a blip here must not discard
+				# an otherwise-completed wait. An empty read is a hard failure, same
+				# as arm-time -- it is never proof the head moved, only that this
+				# read didn't land, so it is GH-ERROR, not STALE.
+				while :; do
+					if live=$(gh_bounded pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid) && [ -n "$live" ]; then
+						break
+					fi
+					ghfail=$((ghfail + 1))
+					if [ "$ghfail" -ge 3 ]; then
+						printf 'GH-ERROR\n%s\n' "$live"
+						exit 1
+					fi
+					sleep_bounded "$interval" || { printf 'GH-ERROR\n%s\n' "$live"; exit 1; }
+				done
 				if [ "$live" != "$sha" ]; then
 					printf 'pinned=%s observed=%s\nSTALE\n' "$sha" "$live"
 					exit 0
 				fi
+				printf 'pinned=%s\n' "$sha"
 				printf '%s' "$json" | jq -c "[.[] | select((.name|ascii_downcase|test(\"$exclude\"))|not)]"
 				printf '%s\n' "$v"
 				exit 0

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -50,6 +50,178 @@ Describe 'wait-checks.sh evaluate_checks()'
   End
 End
 
+# checks_to_buckets(): maps the two SHA-addressed REST reads (check-runs + commit status,
+# each possibly several `--paginate` pages concatenated) to the {name, bucket} shape
+# evaluate_checks() consumes. Unrecognised conclusion/state values fall to "pending", never
+# "pass" (#1690: an unmapped value must surface as a TIMEOUT a human looks at).
+Describe 'wait-checks.sh checks_to_buckets()'
+  AGENT_SOURCE_ONLY=1
+  Include scripts/agent/wait-checks.sh
+
+  It 'maps a queued check run to pending'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"queued","conclusion":null}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"pending"}]'
+  End
+
+  It 'maps an in_progress check run to pending'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"in_progress","conclusion":null}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"pending"}]'
+  End
+
+  It 'maps a completed/success check run to pass'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"pass"}]'
+  End
+
+  It 'maps a completed/neutral check run to pass'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"completed","conclusion":"neutral"}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"pass"}]'
+  End
+
+  It 'maps a completed/skipped check run to skipping'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"completed","conclusion":"skipped"}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"skipping"}]'
+  End
+
+  It 'maps a completed/cancelled check run to cancel'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"completed","conclusion":"cancelled"}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"cancel"}]'
+  End
+
+  It 'maps a completed/failure check run to fail'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"completed","conclusion":"failure"}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"fail"}]'
+  End
+
+  It 'maps a completed/timed_out check run to fail'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"completed","conclusion":"timed_out"}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"fail"}]'
+  End
+
+  It 'maps a completed/action_required check run to fail'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"completed","conclusion":"action_required"}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"fail"}]'
+  End
+
+  It 'maps a completed/stale check run to fail'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"completed","conclusion":"stale"}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"fail"}]'
+  End
+
+  It 'maps a completed/startup_failure check run to fail'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"completed","conclusion":"startup_failure"}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"fail"}]'
+  End
+
+  It 'maps a completed check run with a null conclusion to pending, never pass'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"completed","conclusion":null}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"pending"}]'
+  End
+
+  It 'maps a completed check run with an unrecognised conclusion to pending, never pass'
+    When call checks_to_buckets '{"check_runs":[{"name":"pytest","status":"completed","conclusion":"weird_future_value"}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"pytest","bucket":"pending"}]'
+  End
+
+  It 'maps a success commit status to pass'
+    When call checks_to_buckets '{"check_runs":[]}' '{"statuses":[{"context":"legacy-ci","state":"success"}]}'
+    The output should equal '[{"name":"legacy-ci","bucket":"pass"}]'
+  End
+
+  It 'maps a pending commit status to pending'
+    When call checks_to_buckets '{"check_runs":[]}' '{"statuses":[{"context":"legacy-ci","state":"pending"}]}'
+    The output should equal '[{"name":"legacy-ci","bucket":"pending"}]'
+  End
+
+  It 'maps an error commit status to fail'
+    When call checks_to_buckets '{"check_runs":[]}' '{"statuses":[{"context":"legacy-ci","state":"error"}]}'
+    The output should equal '[{"name":"legacy-ci","bucket":"fail"}]'
+  End
+
+  It 'maps a failure commit status to fail'
+    When call checks_to_buckets '{"check_runs":[]}' '{"statuses":[{"context":"legacy-ci","state":"failure"}]}'
+    The output should equal '[{"name":"legacy-ci","bucket":"fail"}]'
+  End
+
+  It 'maps an unrecognised commit-status state to pending, never pass'
+    When call checks_to_buckets '{"check_runs":[]}' '{"statuses":[{"context":"legacy-ci","state":"weird"}]}'
+    The output should equal '[{"name":"legacy-ci","bucket":"pending"}]'
+  End
+
+  It 'takes the status name from .context, ignoring any .name field on the status object'
+    When call checks_to_buckets '{"check_runs":[]}' '{"statuses":[{"name":"WRONG","context":"right-name","state":"success"}]}'
+    The output should equal '[{"name":"right-name","bucket":"pass"}]'
+  End
+
+  It 'concatenates check-run and status entries from both payloads, dropping nothing'
+    cr='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    st='{"statuses":[{"context":"legacy-ci","state":"success"}]}'
+    When call checks_to_buckets "$cr" "$st"
+    The output should equal '[{"name":"pytest","bucket":"pass"},{"name":"legacy-ci","bucket":"pass"}]'
+  End
+
+  It 'reads every page when --paginate concatenates multiple JSON documents in one payload'
+    cr=$(printf '%s\n%s\n' \
+      '{"check_runs":[{"name":"page1","status":"completed","conclusion":"success"}]}' \
+      '{"check_runs":[{"name":"page2","status":"completed","conclusion":"success"}]}')
+    When call checks_to_buckets "$cr" '{"statuses":[]}'
+    The output should equal '[{"name":"page1","bucket":"pass"},{"name":"page2","bucket":"pass"}]'
+  End
+
+  It 'contributes zero entries from a page missing its check_runs/statuses key, without a jq error'
+    cr=$(printf '%s\n%s\n' '{"total_count":0}' '{"check_runs":[{"name":"only-one","status":"completed","conclusion":"success"}]}')
+    When call checks_to_buckets "$cr" '{"total_count":0}'
+    The output should equal '[{"name":"only-one","bucket":"pass"}]'
+  End
+
+  It 'maps a null check-run name to an empty string instead of crashing downstream'
+    When call checks_to_buckets '{"check_runs":[{"name":null,"status":"completed","conclusion":"success"}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"","bucket":"pass"}]'
+  End
+
+  It 'maps a missing check-run name field to an empty string'
+    When call checks_to_buckets '{"check_runs":[{"status":"completed","conclusion":"success"}]}' '{"statuses":[]}'
+    The output should equal '[{"name":"","bucket":"pass"}]'
+  End
+
+  It 'evaluate_checks does not crash on a checks_to_buckets result carrying an empty name'
+    exclude='coderabbit|snyk'
+    buckets=$(checks_to_buckets '{"check_runs":[{"name":null,"status":"completed","conclusion":"success"}]}' '{"statuses":[]}')
+    When call evaluate_checks "$buckets"
+    The output should equal 'PASS'
+  End
+
+  It 'preserves a check-run name containing quotes and backslashes through the jq round-trip'
+    cr='{"check_runs":[{"name":"weird \"quoted\" \\ name","status":"completed","conclusion":"success"}]}'
+    When call checks_to_buckets "$cr" '{"statuses":[]}'
+    The output should equal '[{"name":"weird \"quoted\" \\ name","bucket":"pass"}]'
+  End
+
+  It 'treats an empty check-runs payload as zero entries, not a jq error'
+    When call checks_to_buckets '' '{"statuses":[{"context":"x","state":"success"}]}'
+    The output should equal '[{"name":"x","bucket":"pass"}]'
+  End
+
+  It 'treats both payloads empty as zero entries, not a jq error'
+    When call checks_to_buckets '' ''
+    The output should equal '[]'
+  End
+
+  It 'treats an unexpected-shape payload (e.g. a Not-Found error body) as zero entries, not a crash'
+    When call checks_to_buckets '{"message":"Not Found"}' '{"message":"Not Found"}'
+    The output should equal '[]'
+  End
+
+  It 'excludes a failing CodeRabbit commit status beside a passing check run, across both payload classes'
+    exclude='coderabbit|snyk'
+    cr='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    st='{"statuses":[{"context":"CodeRabbit","state":"failure"}]}'
+    buckets=$(checks_to_buckets "$cr" "$st")
+    When call evaluate_checks "$buckets"
+    The output should equal 'PASS'
+  End
+End
+
 Describe 'agent_env.sh bounded gh execution'
   AGENT_SOURCE_ONLY=1
   Include scripts/agent/agent_env.sh
@@ -156,6 +328,9 @@ Describe 'wait-checks.sh tool contracts'
 End
 
 Describe 'wait-checks.sh loop verdicts (stub gh)'
+  # gh now serves 3 call shapes: `pr view` (SHA arm/re-verify), `.../check-runs`,
+  # `.../status` -- GH_STUB_CHECK_RUNS / GH_STUB_STATUS_PAYLOAD replace the old
+  # single-shape GH_STUB_CHECKS fixture (#1690: checks moved SHA-addressed).
   setup_stub() {
     stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/ghstub.XXXXXX")"
     cat > "$stubdir/gh" <<'STUB'
@@ -167,7 +342,11 @@ count=$((count + 1))
 case " ${GH_STUB_FAIL_CALLS:-} " in
 	*" $count "*) printf '%s\n' "${GH_STUB_FAIL_OUTPUT:-HTTP 404}"; exit 1 ;;
 esac
-printf '%s\n' "$GH_STUB_CHECKS"
+case "$*" in
+	*"pr view "*) printf '%s\n' "${GH_STUB_SHA:-deadbeef}" ;;
+	*"/check-runs"*) printf '%s\n' "$GH_STUB_CHECK_RUNS" ;;
+	*"/status"*) printf '%s\n' "$GH_STUB_STATUS_PAYLOAD" ;;
+esac
 STUB
     chmod +x "$stubdir/gh"
     PATH="$stubdir:$PATH"
@@ -176,6 +355,11 @@ STUB
   Before 'setup_stub'
   After 'cleanup_stub'
   script="scripts/agent/wait-checks.sh"
+
+  pending_fixture() {
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"in_progress","conclusion":null}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+  }
 
   setup_near_deadline() {
     cat > "$stubdir/date" <<'STUB'
@@ -191,22 +375,44 @@ STUB
   }
 
   It 'reports TIMEOUT when checks stay pending through the cap'
-    export GH_STUB_CHECKS='[{"name":"pytest","bucket":"pending"}]'
+    pending_fixture
     When run sh "$script" --repo o/r --pr 1 --interval 0 --max-iter 2
     The line 1 of output should equal 'TIMEOUT'
   End
 
   It 'honours the wall-clock deadline even when a verdict would be reached'
-    export GH_STUB_CHECKS='[{"name":"pytest","bucket":"pass"}]'
-    export PFB_WAIT_DEADLINE=1
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    # date returns "100" for the arm-time gh_bounded call (deadline 101 still ahead of
+    # it) then "200" for the loop's own check -- the loop must break on ITS deadline
+    # check even though the (unfetched) checks would otherwise pass.
+    cat > "$stubdir/date" <<'STUB'
+#!/bin/sh
+n=0
+[ ! -f "${DATE_COUNT_FILE:-}" ] || n=$(cat "$DATE_COUNT_FILE")
+n=$((n + 1))
+[ -z "${DATE_COUNT_FILE:-}" ] || printf '%s\n' "$n" > "$DATE_COUNT_FILE"
+if [ "$n" -le 1 ]; then
+	printf '100\n'
+else
+	printf '200\n'
+fi
+STUB
+    chmod +x "$stubdir/date"
+    export DATE_COUNT_FILE="$stubdir/date-count"
+    export PFB_WAIT_DEADLINE=101
     When run sh "$script" --repo o/r --pr 1 --interval 0 --max-iter 3
     The line 1 of output should equal 'TIMEOUT'
   End
 
   It 'resets the failure streak after a successful pending snapshot'
+    pending_fixture
     export GH_STUB_COUNT_FILE="$stubdir/count"
-    export GH_STUB_FAIL_CALLS='1 2 4 5'
-    export GH_STUB_CHECKS='[{"name":"pytest","bucket":"pending"}]'
+    # call 1 = arm `pr view` (must succeed); each iteration is 1 call when check-runs
+    # fails (short-circuits the status read) or 2 when it succeeds: iters 1-2 fail
+    # (calls 2,3), iter 3 succeeds (calls 4,5) and resets the streak, iters 4-5 fail
+    # (calls 6,7) -- never 3 consecutive, so TIMEOUT not GH-ERROR.
+    export GH_STUB_FAIL_CALLS='2 3 6 7'
     When run sh "$script" --repo o/r --pr 1 --interval 0 --max-iter 5
     The status should equal 0
     The line 1 of output should equal 'TIMEOUT'
@@ -214,7 +420,7 @@ STUB
 
   It 'caps sleep after a successful pending poll at the remaining deadline'
     setup_near_deadline
-    export GH_STUB_CHECKS='[{"name":"pytest","bucket":"pending"}]'
+    pending_fixture
     When run sh "$script" --repo o/r --pr 1 --interval 99 --max-iter 1
     The line 1 of output should equal 'TIMEOUT'
     The contents of file "$WAIT_SLEEP_FILE" should equal '3'
@@ -223,7 +429,9 @@ STUB
   It 'caps sleep after a failed poll at the remaining deadline'
     setup_near_deadline
     export GH_STUB_COUNT_FILE="$stubdir/count"
-    export GH_STUB_FAIL_CALLS='1'
+    # call 1 = arm `pr view` (must succeed so the loop is reached at all); call 2 =
+    # the single iteration's check-runs read, which fails.
+    export GH_STUB_FAIL_CALLS='2'
     When run sh "$script" --repo o/r --pr 1 --interval 99 --max-iter 1
     The line 1 of output should equal 'TIMEOUT'
     The contents of file "$WAIT_SLEEP_FILE" should equal '3'
@@ -246,5 +454,164 @@ Describe 'wait-checks.sh gh-failure detection'
     The status should equal 1
     The line 1 of output should equal 'GH-ERROR'
     The output should include 'HTTP 404'
+  End
+End
+
+Describe 'wait-checks.sh SHA pinning (#1690 regression)'
+  setup_stub() {
+    stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/ghstub.XXXXXX")"
+    cat > "$stubdir/gh" <<'STUB'
+#!/bin/sh
+argv="$*"
+[ -z "${ARGV_LOG:-}" ] || printf '%s\n' "$argv" >> "$ARGV_LOG"
+case "$argv" in
+	*"pr checks"*)
+		printf '%s\n' "$GH_STUB_PR_CHECKS_LEGACY"
+		;;
+	*"pr view "*)
+		count=0
+		[ ! -f "${GH_STUB_PRVIEW_COUNT_FILE:-/nonexistent}" ] || count=$(cat "$GH_STUB_PRVIEW_COUNT_FILE")
+		count=$((count + 1))
+		[ -z "${GH_STUB_PRVIEW_COUNT_FILE:-}" ] || printf '%s\n' "$count" > "$GH_STUB_PRVIEW_COUNT_FILE"
+		case " ${GH_STUB_PRVIEW_FAIL_CALLS:-} " in
+			*" $count "*) printf '%s\n' "${GH_STUB_PRVIEW_FAIL_OUTPUT:-pr view failed}" >&2; exit 1 ;;
+		esac
+		if [ "$count" -eq 1 ]; then
+			printf '%s\n' "$GH_STUB_HEAD_SHA_1"
+		else
+			printf '%s\n' "${GH_STUB_HEAD_SHA_2:-$GH_STUB_HEAD_SHA_1}"
+		fi
+		;;
+	*"/check-runs"*)
+		if [ -z "${GH_STUB_EXPECT_SHA:-}" ]; then
+			printf '%s\n' "$GH_STUB_CHECK_RUNS"
+		else
+			case "$argv" in
+				*"/commits/$GH_STUB_EXPECT_SHA/check-runs"*) printf '%s\n' "$GH_STUB_CHECK_RUNS" ;;
+				*) exit 1 ;;
+			esac
+		fi
+		;;
+	*"/status"*)
+		if [ -z "${GH_STUB_EXPECT_SHA:-}" ]; then
+			printf '%s\n' "$GH_STUB_STATUS_PAYLOAD"
+		else
+			case "$argv" in
+				*"/commits/$GH_STUB_EXPECT_SHA/status"*) printf '%s\n' "$GH_STUB_STATUS_PAYLOAD" ;;
+				*) exit 1 ;;
+			esac
+		fi
+		;;
+	*)
+		exit 1
+		;;
+esac
+STUB
+    chmod +x "$stubdir/gh"
+    PATH="$stubdir:$PATH"
+  }
+  cleanup_stub() { rm -rf "$stubdir"; }
+  Before 'setup_stub'
+  After 'cleanup_stub'
+
+  It 'never reports PASS for a force-pushed head with zero registered checks, even though the previous commit was green (#1690)'
+    export GH_STUB_PR_CHECKS_LEGACY='[{"name":"pytest","bucket":"pass"}]'
+    export GH_STUB_HEAD_SHA_1='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    export GH_STUB_CHECK_RUNS='{"check_runs":[]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 2
+    The output should include 'TIMEOUT'
+    The output should not include 'PASS'
+  End
+
+  It 'reports STALE, never PASS, when the head moves after the pinned checks went green'
+    export GH_STUB_PR_CHECKS_LEGACY='[{"name":"pytest","bucket":"pass"}]'
+    export GH_STUB_PRVIEW_COUNT_FILE="$stubdir/prview-count"
+    export GH_STUB_HEAD_SHA_1='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    export GH_STUB_HEAD_SHA_2='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The output should include 'STALE'
+    The output should not include 'PASS'
+    The output should include 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    The output should include 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    The status should equal 0
+  End
+
+  It 'reports PASS when the pinned SHA is all-green and the head has not moved'
+    export GH_STUB_HEAD_SHA_1='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The status should equal 0
+    The line 1 of output should equal '[{"name":"pytest","bucket":"pass"}]'
+    The line 2 of output should equal 'PASS'
+  End
+
+  It 'reports FAIL when the pinned SHA has a failing check and the head has not moved'
+    export GH_STUB_HEAD_SHA_1='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"failure"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The status should equal 0
+    The line 1 of output should equal '[{"name":"pytest","bucket":"fail"}]'
+    The line 2 of output should equal 'FAIL'
+  End
+
+  It '--sha skips arm-time resolution (never calls pr view to resolve) but still re-verifies before the verdict'
+    explicit_sha='cccccccccccccccccccccccccccccccccccccccc'
+    export GH_STUB_PRVIEW_COUNT_FILE="$stubdir/prview-count"
+    export GH_STUB_HEAD_SHA_1="$explicit_sha"
+    export GH_STUB_EXPECT_SHA="$explicit_sha"
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --sha "$explicit_sha" --interval 0 --max-iter 1
+    The status should equal 0
+    The line 2 of output should equal 'PASS'
+    The contents of file "$GH_STUB_PRVIEW_COUNT_FILE" should equal '1'
+  End
+
+  It 'fails loudly with GH-ERROR when arm-time SHA resolution itself errors (gh exits nonzero)'
+    export GH_STUB_PRVIEW_FAIL_CALLS='1'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The status should equal 1
+    The line 1 of output should equal 'GH-ERROR'
+  End
+
+  It 'fails loudly with GH-ERROR when arm-time SHA resolution yields an empty value'
+    export GH_STUB_HEAD_SHA_1=''
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The status should equal 1
+    The line 1 of output should equal 'GH-ERROR'
+  End
+
+  It 'fails loudly with GH-ERROR when the pre-verdict head re-read fails, never emitting a verdict'
+    export GH_STUB_PRVIEW_COUNT_FILE="$stubdir/prview-count"
+    export GH_STUB_HEAD_SHA_1='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    export GH_STUB_PRVIEW_FAIL_CALLS='2'
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The status should equal 1
+    The line 1 of output should equal 'GH-ERROR'
+  End
+
+  It 'rejects an explicit empty --sha as a usage error, never falling through to an unpinned poll'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --sha '' --interval 0 --max-iter 1
+    The status should equal 2
+    The stderr should include 'usage:'
+  End
+
+  It 'passes a metacharacter-laden --sha through to gh as inert opaque data, never evaluated'
+    canary="$stubdir/injected"
+    weird='sha; touch '"$canary"'; $(touch '"$canary"')'
+    export GH_STUB_HEAD_SHA_1="$weird"
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --sha "$weird" --interval 0 --max-iter 1
+    The status should equal 0
+    The line 2 of output should equal 'PASS'
+    The file "$canary" should not be exist
   End
 End

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -586,6 +586,33 @@ STUB
     The line 1 of output should equal 'GH-ERROR'
   End
 
+  It 'recovers from transient arm-time pr-view failures within the retry budget, reaching a normal verdict'
+    # A blip on the very first call (right after a force-push, when the API is
+    # least settled) must not kill the whole wait: 2 failures then a success is
+    # inside the same 3-strike tolerance the poll loop already has.
+    export GH_STUB_PRVIEW_COUNT_FILE="$stubdir/prview-count"
+    export GH_STUB_PRVIEW_FAIL_CALLS='1 2'
+    export GH_STUB_HEAD_SHA_1='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The status should equal 0
+    The line 2 of output should equal 'PASS'
+    The output should not include 'GH-ERROR'
+    The contents of file "$GH_STUB_PRVIEW_COUNT_FILE" should equal '4'
+  End
+
+  It 'still fails loudly with GH-ERROR once the arm-time retry budget (3 attempts) is exhausted'
+    export GH_STUB_PRVIEW_COUNT_FILE="$stubdir/prview-count"
+    export GH_STUB_PRVIEW_FAIL_CALLS='1 2 3'
+    export GH_STUB_PRVIEW_FAIL_OUTPUT='HTTP 503'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The status should equal 1
+    The line 1 of output should equal 'GH-ERROR'
+    The output should include 'HTTP 503'
+    The contents of file "$GH_STUB_PRVIEW_COUNT_FILE" should equal '3'
+  End
+
   It 'fails loudly with GH-ERROR when the pre-verdict head re-read fails, never emitting a verdict'
     export GH_STUB_PRVIEW_COUNT_FILE="$stubdir/prview-count"
     export GH_STUB_HEAD_SHA_1='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -476,6 +476,9 @@ case "$argv" in
 		case " ${GH_STUB_PRVIEW_FAIL_CALLS:-} " in
 			*" $count "*) printf '%s\n' "${GH_STUB_PRVIEW_FAIL_OUTPUT:-pr view failed}" >&2; exit 1 ;;
 		esac
+		case " ${GH_STUB_PRVIEW_EMPTY_CALLS:-} " in
+			*" $count "*) exit 0 ;;
+		esac
 		if [ "$count" -eq 1 ]; then
 			printf '%s\n' "$GH_STUB_HEAD_SHA_1"
 		else
@@ -545,8 +548,9 @@ STUB
     export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
     When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
     The status should equal 0
-    The line 1 of output should equal '[{"name":"pytest","bucket":"pass"}]'
-    The line 2 of output should equal 'PASS'
+    The line 1 of output should equal 'pinned=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    The line 2 of output should equal '[{"name":"pytest","bucket":"pass"}]'
+    The line 3 of output should equal 'PASS'
   End
 
   It 'reports FAIL when the pinned SHA has a failing check and the head has not moved'
@@ -555,8 +559,9 @@ STUB
     export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
     When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
     The status should equal 0
-    The line 1 of output should equal '[{"name":"pytest","bucket":"fail"}]'
-    The line 2 of output should equal 'FAIL'
+    The line 1 of output should equal 'pinned=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    The line 2 of output should equal '[{"name":"pytest","bucket":"fail"}]'
+    The line 3 of output should equal 'FAIL'
   End
 
   It '--sha skips arm-time resolution (never calls pr view to resolve) but still re-verifies before the verdict'
@@ -568,7 +573,7 @@ STUB
     export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
     When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --sha "$explicit_sha" --interval 0 --max-iter 1
     The status should equal 0
-    The line 2 of output should equal 'PASS'
+    The line 3 of output should equal 'PASS'
     The contents of file "$GH_STUB_PRVIEW_COUNT_FILE" should equal '1'
   End
 
@@ -597,7 +602,7 @@ STUB
     export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
     When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
     The status should equal 0
-    The line 2 of output should equal 'PASS'
+    The line 3 of output should equal 'PASS'
     The output should not include 'GH-ERROR'
     The contents of file "$GH_STUB_PRVIEW_COUNT_FILE" should equal '4'
   End
@@ -613,15 +618,61 @@ STUB
     The contents of file "$GH_STUB_PRVIEW_COUNT_FILE" should equal '3'
   End
 
-  It 'fails loudly with GH-ERROR when the pre-verdict head re-read fails, never emitting a verdict'
+  It 'recovers from a transient pre-verdict re-read blip, reaching a normal verdict'
+    # Same 3-strike tolerance as arm-time: a single blip on the re-read -- e.g. at
+    # minute 39 of a 40-minute wait -- must not discard an otherwise-completed wait.
     export GH_STUB_PRVIEW_COUNT_FILE="$stubdir/prview-count"
     export GH_STUB_HEAD_SHA_1='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
     export GH_STUB_PRVIEW_FAIL_CALLS='2'
     export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
     export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
     When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The status should equal 0
+    The line 3 of output should equal 'PASS'
+    The output should not include 'GH-ERROR'
+    The contents of file "$GH_STUB_PRVIEW_COUNT_FILE" should equal '3'
+  End
+
+  It 'still fails loudly with GH-ERROR once the pre-verdict re-read retry budget (3 attempts) is exhausted, never emitting a verdict'
+    export GH_STUB_PRVIEW_COUNT_FILE="$stubdir/prview-count"
+    export GH_STUB_HEAD_SHA_1='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    export GH_STUB_PRVIEW_FAIL_CALLS='2 3 4'
+    export GH_STUB_PRVIEW_FAIL_OUTPUT='HTTP 503'
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
     The status should equal 1
     The line 1 of output should equal 'GH-ERROR'
+    The output should include 'HTTP 503'
+    The output should not include 'PASS'
+    The contents of file "$GH_STUB_PRVIEW_COUNT_FILE" should equal '4'
+  End
+
+  It 'recovers from a single transient EMPTY pre-verdict re-read (not just a hard gh failure), reaching a normal verdict'
+    export GH_STUB_PRVIEW_COUNT_FILE="$stubdir/prview-count"
+    export GH_STUB_HEAD_SHA_1='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    export GH_STUB_PRVIEW_EMPTY_CALLS='2'
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The status should equal 0
+    The line 3 of output should equal 'PASS'
+    The output should not include 'GH-ERROR'
+    The contents of file "$GH_STUB_PRVIEW_COUNT_FILE" should equal '3'
+  End
+
+  It 'treats a sustained empty pre-verdict re-read as GH-ERROR, never STALE (an empty read is not proof the head moved)'
+    export GH_STUB_PRVIEW_COUNT_FILE="$stubdir/prview-count"
+    export GH_STUB_HEAD_SHA_1='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    export GH_STUB_PRVIEW_EMPTY_CALLS='2 3 4'
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 1
+    The status should equal 1
+    The line 1 of output should equal 'GH-ERROR'
+    The output should not include 'STALE'
+    The output should not include 'PASS'
+    The contents of file "$GH_STUB_PRVIEW_COUNT_FILE" should equal '4'
   End
 
   It 'rejects an explicit empty --sha as a usage error, never falling through to an unpinned poll'
@@ -638,7 +689,7 @@ STUB
     export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
     When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --sha "$weird" --interval 0 --max-iter 1
     The status should equal 0
-    The line 2 of output should equal 'PASS'
+    The line 3 of output should equal 'PASS'
     The file "$canary" should not be exist
   End
 End


### PR DESCRIPTION
Fixes #1690.

## What

`scripts/agent/wait-checks.sh` polled `gh pr checks`, which is PR-scoped. Armed immediately after a
force-push — exactly what the landing flow prescribes — it could read the **previous** commit's checks,
find them complete and green, and return `PASS` for a commit it never observed. The verdict looks
authoritative and is wrong, and it lands precisely where the risk is highest: the post-rebase wait whose
whole job is to validate the code that will actually merge.

The decisive fact is that the old data source *cannot* be fixed by filtering. `gh pr checks --json`
exposes exactly `bucket, completedAt, description, event, link, name, startedAt, state, workflow` — there
is no commit or SHA field at all (gh 2.96.0). So the source had to be replaced, not filtered.

## The change

- **Pin the SHA at arm time** — `--sha` if given (which also lets a caller assert the SHA it intends to
  merge), otherwise resolved once via `gh pr view --json headRefOid`.
- **Read SHA-addressed** — `gh api --paginate repos/O/R/commits/<sha>/check-runs` plus `…/status`. Both
  are needed: a commit's rollup carries check runs *and* legacy commit statuses (probed on a real head:
  23 `CheckRun` nodes plus a `StatusContext`), so dropping either class would be green-by-absence.
- **A new `checks_to_buckets()`** maps both payloads into the `{name, bucket}` shape, leaving
  `evaluate_checks()` byte-identical — so every existing verdict rule, including "PASS requires at least
  one relevant check", is untouched.
- **Re-verify the head before any terminal verdict**, emitting a new `STALE` verdict if it moved, so a
  concurrent push cannot be silently absorbed either.
- **`GH-ERROR`** when the SHA cannot be resolved or re-verified — a wait that cannot pin a SHA fails
  loudly rather than polling blind.

Unknown or malformed values map to `pending`, never `pass`: an unrecognised future conclusion surfaces
as a TIMEOUT a human looks at, rather than a false green.

## Why the stub tests were not enough

Every end-to-end test drives a stub `gh`, and a stub faithfully encodes whatever the author *believed*
the API does. So the fix was also verified against the live GitHub API, on a real green PR:

| Probe | Result |
|---|---|
| Green PR, SHA resolved automatically | `PASS` |
| Same PR, explicit `--sha` | `PASS`, no double-resolve |
| `--sha` pinned to a *different* real commit | `STALE` |
| A real commit with zero registered checks | `TIMEOUT` — never `PASS` |
| Bogus all-zero SHA | `GH-ERROR` (HTTP 422), exit 1 |
| The **old** script against the same green PR | `PASS` — control, proving the harness sound |

The third row is #1690's exact bug shape, reproduced against live data rather than a fixture. Field
names and cases were checked against the real payloads too (`completed`, `success`, `skipped` — all
lowercase), because a case mismatch would have mapped every check to `pending` and hung the wait forever
while every stub test still passed.

## Evidence

Red→green, executed test-first and independently re-executed by a read-only verifier against the
committed bytes:

```
FREEZE-OK: tests/shell/agent_wait_checks_spec.sh
RED-OK: test fails against origin/devel src
GREEN-OK: test passes against HEAD
VERDICT: PASS
```

The red fails for the right reason — the old script emits `PASS` off the previous commit's payload:

```
1) ...never reports PASS for a force-pushed head with zero registered checks...(#1690)
   1.1) The output should include TIMEOUT
        expected "[{"name":"pytest","bucket":"pass"}]\nPASS" to include "TIMEOUT"
2) ...reports STALE, never PASS, when the head moves after the pinned checks went green
   2.1) The output should include STALE
        expected "[{"name":"pytest","bucket":"pass"}]\nPASS" to include "STALE"
```

The mapper was attacked exhaustively — every documented `status`, `conclusion` and `state` value, two
invented unknowns, `null`, empty payloads, `{"message":"Not Found"}`, truncated JSON, a bare array,
names containing quotes/backslashes/newlines/regex metacharacters, and multi-document `--paginate`
output including interleaved payload types. **Nothing unknown or malformed ever produced `pass`.**

The decisive failure-tolerance case was also executed: when `check-runs` succeeds but `status` fails,
the script does **not** compute a verdict from half the data — a failing required commit status can
never be silently bypassed into a `PASS`.

Gates: `sh -n`, `shellcheck`, and the full `shellspec` suite under `dash` (1001 examples, 0 failures,
8 pre-existing environment-gated skips confirmed identical against a clean `origin/devel` worktree).

## Second commit — arm-time retry tolerance

The first gate raised that arm-time resolution had **zero** retry tolerance while the poll loop
tolerates two consecutive failures. Since this wait is armed immediately after every force-push —
precisely when the API is least settled — one blip would have killed the whole wait, working against
the issue's own purpose. `f570868e` gives it the same bounded 3-attempt budget, reusing the existing
idiom and `sleep_bounded` (not a raw sleep, which would be an orphaned wait), still fail-loud once
exhausted.

Verified rather than assumed: 3 total attempts before `GH-ERROR`; a 2-second deadline terminates the
script in 2.27s even mid-retry-budget; an empty SHA is retried and can never leak into the poll loop as
a pin (zero downstream calls made); and a recovered resolution pins the SHA the *successful* call
returned, not a stale value from a failed attempt.

## Also noted, tracked separately

`evaluate_checks()` excludes advisory bots by **unanchored substring**, so a required check merely
*containing* `snyk` or `coderabbit` would be silently dropped from the verdict — the same wrong-verdict
class as this issue, by a different route. That function is byte-identical to `origin/devel` here, so it
is filed as **#1706** rather than folded in.

## Note on `landing.md`

The policy note documenting `--sha` and `STALE` had to fit under that file's frozen 26,000-byte budget
ratchet, which had 9 bytes of slack. Three markdown issue-links in an unrelated bullet were shortened to
bare `#NNNN` refs to make room — no information lost, the issue numbers remain identifiable, and bare
refs already appear elsewhere in that same file.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CI check monitoring by pinning results to a specific commit.
  - Detects when a pull request changes during validation and reports a stale result instead of incorrectly passing or failing.
  - Unknown or unmapped check states now remain pending rather than being treated as successful.
  - Added clearer handling for API failures, timeouts, retries, and unavailable check data.

- **Documentation**
  - Updated CI wait behavior and source references in the contribution guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->