### PR TITLE
pfblockerng: apply the runtime regex length cap at save time (#1688)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1694,8 +1694,8 @@ function pfb_adv_alias_field_errors(array $post): array
  * pfb_dnsbl_regex_validation_errors — validate the DNSBL regex form in one
  * bounded Python pass, preserving source line numbers and resolver semantics.
  *
- * @param bool $regex_cap Mirrors the "Limit long/complex regex" toggle; threaded
- *     through to the probe for a save-time length-cap check landing separately.
+ * @param bool $regex_cap Mirrors the "Limit long/complex regex" toggle: gates the
+ *     save-time length-cap diagnostic so it agrees with the resolver's load-time drop.
  * @return array<int, string> Non-empty validation or infrastructure diagnostics.
  */
 function pfb_dnsbl_regex_validation_errors(string $contents, string $python, bool $regex_cap, string $timeout_bin = '/usr/bin/timeout'): array
@@ -1750,6 +1750,10 @@ for line_number, line in enumerate(sys.stdin, start=1):
     budget = len(re.findall(r"(?<!\\)[+*]", pattern)) + len(re.findall(r"(?<!\\)\|", pattern))
     if budget > 12:
         report(line_number, pattern, "too many quantifiers/alternations")
+        failed = True
+        continue
+    if regex_cap and len(pattern) > 200:  # REGEX_STATIC_LEN_CAP mirror (pfb_unbound.py)
+        report(line_number, pattern, 'over the 200-character length cap ("Limit long/complex regex")')
         failed = True
         continue
     try:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1694,9 +1694,11 @@ function pfb_adv_alias_field_errors(array $post): array
  * pfb_dnsbl_regex_validation_errors — validate the DNSBL regex form in one
  * bounded Python pass, preserving source line numbers and resolver semantics.
  *
+ * @param bool $regex_cap Mirrors the "Limit long/complex regex" toggle; threaded
+ *     through to the probe for a save-time length-cap check landing separately.
  * @return array<int, string> Non-empty validation or infrastructure diagnostics.
  */
-function pfb_dnsbl_regex_validation_errors(string $contents, string $python, string $timeout_bin = '/usr/bin/timeout'): array
+function pfb_dnsbl_regex_validation_errors(string $contents, string $python, bool $regex_cap, string $timeout_bin = '/usr/bin/timeout'): array
 {
 	if ($contents === '') {
 		return [];
@@ -1728,6 +1730,8 @@ failed = False
 def report(line_number, pattern, message):
     print(f"line {line_number}: {pattern!r}: {message}", file=sys.stderr)
 
+regex_cap = len(sys.argv) > 1 and sys.argv[1] == "1"
+
 for line_number, line in enumerate(sys.stdin, start=1):
     line = line.rstrip("\r\n")
     if not line.strip() or line.lstrip().startswith("#"):
@@ -1756,7 +1760,7 @@ for line_number, line in enumerate(sys.stdin, start=1):
 
 raise SystemExit(1 if failed else 0)
 PYTHON;
-	$command = array($timeout_bin, '-s', 'TERM', '-k', '1', '5', $python, '-c', $probe);
+	$command = array($timeout_bin, '-s', 'TERM', '-k', '1', '5', $python, '-c', $probe, $regex_cap ? '1' : '0');
 	$descriptors = array(
 		0 => array('pipe', 'r'),
 		1 => array('file', '/dev/null', 'w'),

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -704,7 +704,7 @@ if ($_POST) {
 		$pfb_regex_python = pfb_python_interpreter();
 		if (($pfb_regex_python !== '' && is_executable($pfb_regex_python)) ||
 		    (($_POST['pfb_regex'] ?? '') === 'on')) {
-			foreach (pfb_dnsbl_regex_validation_errors((string) ($_POST['pfb_regex_list'] ?? ''), $pfb_regex_python) as $regex_error) {
+			foreach (pfb_dnsbl_regex_validation_errors((string) ($_POST['pfb_regex_list'] ?? ''), $pfb_regex_python, ($_POST['pfb_regex_cap'] ?? '') === 'on') as $regex_error) {
 				$input_errors[] = 'Customlist pfb_regex_list: ' . htmlspecialchars($regex_error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 			}
 		}

--- a/tests/php/DnsblRegexEntryErrorTest.php
+++ b/tests/php/DnsblRegexEntryErrorTest.php
@@ -54,6 +54,31 @@ final class DnsblRegexEntryErrorTest extends TestCase
 		return $errors[0] ?? 'missing validator diagnostic';
 	}
 
+	private static function anchoredPattern(int $length): string
+	{
+		if ($length < 2) {
+			throw new InvalidArgumentException('length must be >= 2 to hold both anchors');
+		}
+		return '^' . str_repeat('a', $length - 2) . '$';
+	}
+
+	// issue #1688 red-before proof: the save-time validator has no length-cap concept
+	// yet, so an over-length-but-otherwise-safe pattern is silently accepted here even
+	// though pfb_unbound.py drops it at load once "Limit long/complex regex" is on.
+	public function testOverLengthPatternIsRejectedOnceTheSaveTimeCapExists(): void
+	{
+		$pattern = self::anchoredPattern(201);
+		$error = self::oneError($pattern . "\n", TRUE);
+		$this->assertStringContainsString('line 1:', $error);
+		$this->assertStringContainsString('200-character length cap', $error);
+	}
+
+	public function testOverLengthPatternAloneIsAcceptedWithoutACapConcept(): void
+	{
+		$pattern = self::anchoredPattern(201);
+		$this->assertSame([], self::errors($pattern . "\n"), 'over-length alone is not a rejection reason yet');
+	}
+
 	/** @return array<string, array{string}> */
 	public static function catastrophicShapeProvider(): array
 	{
@@ -253,5 +278,151 @@ final class DnsblRegexEntryErrorTest extends TestCase
 	public function testBenignPatternIsAccepted(string $pattern): void
 	{
 		$this->assertSame([], self::errors($pattern . "\n"), "{$pattern} must be accepted");
+	}
+
+	// --- issue #1688: save-time length cap matches the resolver's REGEX_STATIC_LEN_CAP ---
+
+	public function testExactlyTwoHundredCharactersIsAcceptedWhenTheCapIsOn(): void
+	{
+		$pattern = self::anchoredPattern(200);
+		$this->assertSame([], self::errors($pattern . "\n", TRUE), 'the cap compares with >, so exactly 200 is still admissible');
+	}
+
+	public function testExactlyTwoHundredOneCharactersIsRejectedWhenTheCapIsOn(): void
+	{
+		$pattern = self::anchoredPattern(201);
+		$error = self::oneError($pattern . "\n", TRUE);
+		$this->assertStringContainsString('line 1:', $error);
+		$this->assertStringContainsString('200-character length cap', $error);
+	}
+
+	/** @return array<string, array{string}> */
+	public static function preStrippingLengthProvider(): array
+	{
+		return [
+			'long trailing comment, short pattern' => ['^ads$ # ' . str_repeat('x', 250)],
+			'leading whitespace padding' => [str_repeat(' ', 250) . '^ads$'],
+		];
+	}
+
+	#[DataProvider('preStrippingLengthProvider')]
+	public function testLengthIsMeasuredAfterCommentStripAndTrim(string $line): void
+	{
+		$this->assertGreaterThan(200, strlen($line), 'fixture must be over-length before stripping, to prove parity');
+		$this->assertSame(
+			[],
+			self::errors($line . "\n", TRUE),
+			'the resolver measures the stripped/trimmed/lowercased pattern, not the raw line'
+		);
+	}
+
+	public function testOverLengthAndCatastrophicShapeReportsTheShapeFirst(): void
+	{
+		$pattern = '(' . str_repeat('a', 250) . '+)+';
+		$this->assertGreaterThan(200, strlen($pattern));
+		$error = self::oneError($pattern . "\n", TRUE);
+		$this->assertStringContainsString('catastrophic-backtracking shape', $error);
+		$this->assertStringNotContainsString('length cap', $error);
+	}
+
+	public function testOverLengthAndOverBudgetReportsTheBudgetFirst(): void
+	{
+		$labels = array_map(static fn (int $i): string => str_repeat(chr(97 + $i), 15), range(0, 13));
+		$pattern = implode('|', $labels);
+		$this->assertGreaterThan(200, strlen($pattern));
+		$error = self::oneError($pattern . "\n", TRUE);
+		$this->assertStringContainsString('too many quantifiers/alternations', $error);
+		$this->assertStringNotContainsString('length cap', $error);
+	}
+
+	public function testOverLengthAndMalformedReportsTheLengthCapFirst(): void
+	{
+		$pattern = '(unclosed' . str_repeat('a', 200);
+		$this->assertGreaterThan(200, strlen($pattern));
+		$error = self::oneError($pattern . "\n", TRUE);
+		$this->assertStringContainsString('200-character length cap', $error);
+		$this->assertStringNotContainsString('compile error', $error);
+	}
+
+	public function testOnlyTheOverLengthLineIsReportedAmongMultipleLines(): void
+	{
+		$contents = "^short1$\n" . self::anchoredPattern(201) . "\n^short2$\n";
+		$errors = self::errors($contents, TRUE);
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('line 2:', $errors[0]);
+		$this->assertStringContainsString('200-character length cap', $errors[0]);
+	}
+
+	#[DataProvider('catastrophicShapeProvider')]
+	public function testCatastrophicShapeIsRejectedRegardlessOfTheCapSetting(string $pattern): void
+	{
+		$error = self::oneError($pattern . "\n", TRUE);
+		$this->assertStringContainsString('line 1:', $error);
+		$this->assertStringContainsString('catastrophic-backtracking shape', $error);
+	}
+
+	#[DataProvider('benignProvider')]
+	public function testBenignPatternIsAcceptedRegardlessOfTheCapSetting(string $pattern): void
+	{
+		$this->assertSame([], self::errors($pattern . "\n", TRUE), "{$pattern} must be accepted even with the cap on");
+	}
+
+	public function testEmptyContentsShortCircuitsWithoutSpawningAPythonProcess(): void
+	{
+		$errors = pfb_dnsbl_regex_validation_errors('', '/path/that/does/not/exist/python', TRUE);
+		$this->assertSame([], $errors, 'an unusable python path would surface as an error if the short-circuit did not fire first');
+	}
+
+	public function testOverLengthPatternWithShellMetacharactersIsRejectedSafely(): void
+	{
+		$hostile = 'ads$(rm -rf /)`id`\'"\\' . str_repeat('a', 200);
+		$this->assertGreaterThan(200, strlen($hostile));
+		$error = self::oneError($hostile . "\n", TRUE);
+		$this->assertStringContainsString('line 1:', $error);
+		$this->assertStringContainsString('200-character length cap', $error);
+	}
+
+	public function testControlCharacterWinsOverLengthWhenBothPresent(): void
+	{
+		$pattern = "^ads\x00" . str_repeat('a', 210) . '$';
+		$this->assertGreaterThan(200, strlen($pattern));
+		$error = self::oneError($pattern . "\n", TRUE);
+		$this->assertStringContainsString('control', strtolower($error));
+		$this->assertStringNotContainsString('length cap', $error);
+	}
+
+	public function testHundredThousandCharacterLineIsRejectedWithoutHanging(): void
+	{
+		$pattern = self::anchoredPattern(100000);
+		$start = microtime(TRUE);
+		$error = self::oneError($pattern . "\n", TRUE);
+		$elapsed = microtime(TRUE) - $start;
+		$this->assertLessThan(5.0, $elapsed, 'must resolve well within the 5s timeout wrapper');
+		$this->assertStringContainsString('200-character length cap', $error);
+	}
+
+	public function testProbeDefaultsCapOffWhenTheArgvFlagIsAbsent(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
+		$source = file_get_contents($path);
+		$this->assertNotFalse($source);
+		$this->assertMatchesRegularExpression("/\\\$probe = <<<'PYTHON'\\n(.*?)\\nPYTHON;/s", $source);
+		preg_match("/\\\$probe = <<<'PYTHON'\\n(.*?)\\nPYTHON;/s", $source, $matches);
+		$probe = $matches[1];
+
+		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$process = proc_open([self::$python, '-c', $probe], $descriptors, $pipes);
+		$this->assertIsResource($process);
+		fwrite($pipes[0], self::anchoredPattern(300) . "\n");
+		fclose($pipes[0]);
+		$stdout = stream_get_contents($pipes[1]);
+		$stderr = stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$exitCode = proc_close($process);
+
+		$this->assertSame(0, $exitCode, "probe must not crash on a missing argv flag; stderr: {$stderr}");
+		$this->assertSame('', trim($stderr));
+		$this->assertSame('', trim($stdout));
 	}
 }

--- a/tests/php/DnsblRegexEntryErrorTest.php
+++ b/tests/php/DnsblRegexEntryErrorTest.php
@@ -38,18 +38,19 @@ final class DnsblRegexEntryErrorTest extends TestCase
 	}
 
 	/** @return array<int, string> */
-	private static function errors(string $contents, ?string $python = null, ?string $timeout = null): array
+	private static function errors(string $contents, bool $regexCap = FALSE, ?string $python = null, ?string $timeout = null): array
 	{
 		return pfb_dnsbl_regex_validation_errors(
 			$contents,
 			$python ?? self::$python,
+			$regexCap,
 			$timeout ?? self::$timeout
 		);
 	}
 
-	private static function oneError(string $contents): string
+	private static function oneError(string $contents, bool $regexCap = FALSE): string
 	{
-		$errors = self::errors($contents);
+		$errors = self::errors($contents, $regexCap);
 		return $errors[0] ?? 'missing validator diagnostic';
 	}
 
@@ -202,8 +203,8 @@ final class DnsblRegexEntryErrorTest extends TestCase
 	public function testMissingPythonAndTimeoutFailClosed(): void
 	{
 		$contents = "^ads\\.\n(?u)\\w+\n";
-		$missingPython = self::errors($contents, '', self::$timeout);
-		$missingTimeout = self::errors($contents, self::$python, '/path/that/does/not/exist/timeout');
+		$missingPython = self::errors($contents, FALSE, '', self::$timeout);
+		$missingTimeout = self::errors($contents, FALSE, self::$python, '/path/that/does/not/exist/timeout');
 
 		$this->assertNotSame([], $missingPython);
 		$this->assertNotSame([], $missingTimeout);
@@ -221,7 +222,7 @@ final class DnsblRegexEntryErrorTest extends TestCase
 			"\nexec " . escapeshellarg(self::$python) . ' "$@"' . "\n");
 		chmod($wrapper, 0700);
 		try {
-			$this->assertSame([], self::errors("^one$\n^two$\n(?u)\\w+\n", $wrapper));
+			$this->assertSame([], self::errors("^one$\n^two$\n(?u)\\w+\n", FALSE, $wrapper));
 			$this->assertSame("launch\n", file_get_contents($marker));
 		} finally {
 			@unlink($wrapper);

--- a/tests/php/DnsblRegexToggleGateWiringTest.php
+++ b/tests/php/DnsblRegexToggleGateWiringTest.php
@@ -68,12 +68,12 @@ final class DnsblRegexToggleGateWiringTest extends TestCase
 		$this->assertMatchesRegularExpression(
 			"#\\|\\|\\s*\\(\\s*\\(\\s*\\\$_POST\\['pfb_regex'\\]\\s*\\?\\?\\s*''\\s*\\)\\s*===\\s*'on'\\s*\\)\\s*\\)\\s*\\{\\s*"
 			. "foreach\\s*\\(pfb_dnsbl_regex_validation_errors\\(\\(string\\)\\s*\\(\\s*\\\$_POST\\['pfb_regex_list'\\]\\s*\\?\\?\\s*''\\s*\\),\\s*"
-			. "\\\$pfb_regex_python\\)\\s*as\\s*\\\$regex_error\\)\\s*\\{\\s*"
+			. "\\\$pfb_regex_python,\\s*\\(\\s*\\\$_POST\\['pfb_regex_cap'\\]\\s*\\?\\?\\s*''\\s*\\)\\s*===\\s*'on'\\)\\s*as\\s*\\\$regex_error\\)\\s*\\{\\s*"
 			. "\\\$input_errors\\[\\]\\s*=\\s*'Customlist pfb_regex_list:\\s*'\\s*\\.\\s*"
 			. "htmlspecialchars\\(\\\$regex_error,\\s*ENT_QUOTES\\s*\\|\\s*ENT_SUBSTITUTE,\\s*'UTF-8'\\);\\s*\\}\\s*\\}#",
 			self::$src,
 			"expected the toggle disjunct to gate only the fail-closed leg, with the "
-			. 'validation call and its error-append inside that guard'
+			. 'validation call (including the pfb_regex_cap third argument, issue #1688) and its error-append inside that guard'
 		);
 	}
 

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -1856,6 +1856,13 @@
                 "default": null
             },
             {
+                "name": "regex_cap",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
                 "name": "timeout_bin",
                 "byRef": false,
                 "variadic": false,

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
+from pathlib import Path
 from typing import Any
 
 import pfb_unbound
@@ -262,6 +263,21 @@ class TestStaticCapAtLoad:
         cap_off = pfb_unbound.build(manifest, {"regex_cap": False}, line_reader=reader)
         # The long-but-benign irreducible regex is dropped only when the length cap is on.
         assert cap_on.regex_count < cap_off.regex_count
+
+
+def test_save_time_probe_length_cap_matches_runtime_constant() -> None:
+    """Issue #1688 parity: pfblockerng_extra.inc's embedded save-time probe rejects a
+    pattern the SAME length that this module's REGEX_STATIC_LEN_CAP drops at load, so
+    the save-time verdict cannot silently drift from the resolver's."""
+    inc_path = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
+    source = inc_path.read_text()
+    match = re.search(r"len\(pattern\)\s*>\s*(\d+):\s*#\s*REGEX_STATIC_LEN_CAP", source)
+    assert match is not None, (
+        "expected the PHP probe's length-cap comparison, tagged '# REGEX_STATIC_LEN_CAP', in pfblockerng_extra.inc"
+    )
+    php_cap = int(match.group(1))
+    runtime_cap = pfb_unbound.REGEX_STATIC_LEN_CAP
+    assert php_cap == runtime_cap, f"probe cap={php_cap} != pfb_unbound.REGEX_STATIC_LEN_CAP={runtime_cap}"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Fixes #1688.

## What

With **Limit long/complex regex** (`pfb_regex_cap`) enabled, the resolver drops any Regex List pattern
over 200 characters at load. The save-time validator added in #1667 never modelled that rule — it copies
the runtime's catastrophic-shape regexes and quantifier/alternation budget and runs a real `re.compile`,
but has no length check and was never told the toggle's value. So a long-but-valid pattern was accepted
at save and then silently dropped at load: the administrator is told the save succeeded and reasonably
believes the pattern is live, while the resolver never loads it.

The toggle is submitted in the same POST as the pattern list, so the value needed to model this was
already in scope.

## The change, in two commits

**`26d08273` — plumbing, behaviour-preserving.** `pfb_dnsbl_regex_validation_errors()` gains a
**required** `bool $regex_cap` in position 3, ahead of the only defaulted parameter. Required rather than
optional deliberately: a caller forgetting to model this toggle is precisely the defect, and a default
would let it recur silently. The flag reaches Python as an **argv element**, never interpolated into the
probe — that heredoc stays a nowdoc, because interpolating a value into the script body would be a
code-injection shape. No length check in this commit; every pre-existing test passes unchanged, which is
the behaviour-preserving oracle.

**`18b8233b` — the fix.** The probe's length check, placed after the shape and budget checks and before
`re.compile`, mirroring the runtime's own order so the *first* diagnostic reported is the one the
resolver would produce.

Splitting it this way is what makes the red proof mechanically reproducible: with commit 1 in place the
reproduction test fails because the over-length pattern is **accepted**, not because of an arity or type
error against a changed signature.

## The parity claim, proved rather than asserted

The whole point is that save-time and runtime must agree, and each derives its measured string
independently — the probe does `line.split("#", 1)[0].strip().lower()`, while the runtime measures what
`pfbng_text_area_decode()` writes into the ini. Asserting those are equivalent would be worthless, so
both sides were **executed** against inputs designed to diverge:

| Input | Probe | Runtime | Agree |
|---|---|---|---|
| plain pattern | 19 | 19 | ✅ |
| pattern + long trailing comment pushing the raw line past 200 | 5 | 5 | ✅ |
| leading/trailing whitespace padding | 19 | 19 | ✅ |
| two `#` characters | 4 | 4 | ✅ |
| mixed case | 19 (lowered) | 19 (lowered) | ✅ |
| tabs around `#` | 19 | 19 | ✅ |
| comment-only / empty line | no entry | no entry | ✅ |
| 200 chars after strip/lower, 250 raw | 200 | 200 | ✅ |
| 201 chars | 201 | 201 | ✅ |

Non-ASCII was checked and is **unreachable**: `pfblockerng_dnsbl.php` rejects any non-ASCII submission
via `mb_detect_encoding(…, 'ASCII', TRUE)` before save, unconditionally — so the codepoint-vs-byte
divergence `İ` would cause cannot occur.

The constants were byte-diffed rather than eyeballed: `REGEX_STATIC_LEN_CAP = 200`, all three runtime
drop sites use `>` (not `>=`), the probe uses `>` on `200`, and the four shape regexes plus the budget
regexes and threshold are byte-identical between the probe and `pfb_unbound.py`.

## Evidence

Red→green, executed test-first and re-executed independently by a read-only verifier:

```
FREEZE-OK: tests/php/DnsblRegexEntryErrorTest.php
RED-OK: test fails against 3dccdf33 src
GREEN-OK: test passes against HEAD
VERDICT: PASS
```

The red is 6 failures, all of the "silently accepted" shape (`Failed asserting that 'missing validator
diagnostic' contains "line 1:"`), with **zero** `ArgumentCountError`/`TypeError` — which is what the
two-commit split exists to guarantee.

Both commits are individually green, so bisect stays usable across the rebase-merge: commit 1 gives
PHPUnit 4054 / pytest 3436, commit 2 gives PHPUnit 4081 / pytest 3437, each re-run twice with identical
tallies.

Precedence and gating were mutation-proven rather than assumed — each mutation flipped exactly its own
test red:

- cap made unconditional → the "cap OFF accepts an over-length pattern" row goes red, proving the toggle
  genuinely gates;
- cap moved ahead of the shape check → "shape wins" goes red;
- cap moved ahead of the budget check → "budget wins" goes red;
- cap moved after `re.compile` → "cap beats compile" goes red;
- the runtime constant changed to 199 → the parity test goes red naming **both** values.

Hostile inputs covered: a 201-char pattern laced with shell metacharacters, quotes and backticks
(rejected safely; it reaches Python over stdin, never a shell); a control character plus over-length
(control-char rejection still wins); a 100 000-character line; and the probe run with **no** argv flag at
all, plus `'2'`, `''`, `'true'` and a 10 000-character flag — all fail safe with the cap off, never
crashing on `sys.argv[1]`. The array-POST shape `pfb_regex_cap[]=on` returns `false` with no warning,
matching the sibling toggle's idiom exactly.

## no-test-needed

no-test-needed: this change touches `src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php` (the call site
passing the toggle), and no honest UI test is available for it. The named candidate carrier,
`tests/smoke/ui/test_browser_dnsbl.py::test_gateway_dnsbl_lenient_save_roundtrip`, was read in full and
rejected: its assertions depend on the save **succeeding**, so injecting an over-length `pfb_regex_list`
with the cap on would populate `$input_errors` and block the save of every field in that POST, breaking
the existing test. A correct UI test would need its own decoupled save/restore pair for
`pfb_regex_list`/`pfb_regex_cap` — a new scenario, not one more assertion. Compounding it, a fresh smoke
VM has an empty `pfb_regex_list`, and the validator short-circuits on empty contents, so the toggle has
no observable effect without dedicated setup that cannot be asserted off-appliance. The failable
coverage is the hermetic suite above, red before and green after.

## Found while doing this — tracked separately

The probe/runtime parity comparison surfaced one genuine divergence outside this issue's scope: a
**whitespace-only** line is skipped by the probe but produces an *empty* pattern at runtime, which
`re.compile("")` admits and which then matches every query name. Filed as **#1707**, with the executed
evidence; it never approaches the 200-character boundary this issue is about (length 0 either way) and
predates these commits.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
