### PR TITLE
policy: let native issue types own classification

### DIFF
--- a/.agents/policy/issues.md
+++ b/.agents/policy/issues.md
@@ -45,9 +45,9 @@ native GitHub issue type, chosen from this table:
 Labels are optional. Add one only when it contributes orthogonal routing, subsystem, risk,
 or workflow metadata not already conveyed by the native type (`CI`, `dnsbl`, `security`,
 `wayfinder:*`, etc.). Never add `bug` or `enhancement` solely to duplicate `Bug`, `Feature`,
-or `Task`. When categories overlap, a defect is `Bug`; otherwise an improvement is `Task`,
-not `Feature`. Set the type at creation (`gh issue create --type Bug`); set any useful
-additive labels at creation too.
+or `Task`. A defect is `Bug`; a new user-facing capability is `Feature`; an improvement to
+existing behaviour or maintenance is `Task`. Set the type at creation
+(`gh issue create --type Bug`); set any useful additive labels at creation too.
 
 ## Issue state (lifecycle — native signals, #1388)
 

--- a/.agents/policy/issues.md
+++ b/.agents/policy/issues.md
@@ -33,11 +33,8 @@ issue. HARDENING-ONLY findings do not become tracker children.
 
 ## Classification at creation
 
-Every issue creation path — human, agent, issue form, or automation — sets both:
-
-1. at least one descriptive label appropriate to the work (`bug`, `enhancement`,
-   `documentation`, `CI`, `wayfinder:*`, etc.); and
-2. exactly one native GitHub issue type, chosen from this table:
+Every issue creation path — human, agent, issue form, or automation — sets exactly one
+native GitHub issue type, chosen from this table:
 
 | Issue type | Use for |
 | --- | --- |
@@ -45,16 +42,19 @@ Every issue creation path — human, agent, issue form, or automation — sets b
 | `Feature` | A new user-facing capability |
 | `Task` | Improvements to existing behaviour; implementation slices; maintenance, testing, CI, documentation, research, and process work |
 
-Labels remain orthogonal metadata and are never replaced by the type. When categories
-overlap, a defect is `Bug`; otherwise an improvement is `Task`, not `Feature`. Set both
-at creation (`gh issue create --label bug --type Bug`), not as a later cleanup pass.
+Labels are optional. Add one only when it contributes orthogonal routing, subsystem, risk,
+or workflow metadata not already conveyed by the native type (`CI`, `dnsbl`, `security`,
+`wayfinder:*`, etc.). Never add `bug` or `enhancement` solely to duplicate `Bug`, `Feature`,
+or `Task`. When categories overlap, a defect is `Bug`; otherwise an improvement is `Task`,
+not `Feature`. Set the type at creation (`gh issue create --type Bug`); set any useful
+additive labels at creation too.
 
 ## Issue state (lifecycle — native signals, #1388)
 
 Native GitHub signals replace the retired `WIP`/`Waiting PR` labels (adopted 2026-07-17 from
 the probe evidence in issue #1388). Applies to all work going forward; old issues keep their
 legacy labels — no bulk migration, but clear a legacy label whenever a transition you perform
-would have cleared it. Descriptive labels (`bug`, `enhancement`, …) stay.
+would have cleared it. Additive labels (`CI`, `dnsbl`, `security`, …) stay.
 
 - **Pick up (claimed)** → `gh issue edit <N> --add-assignee @me`.
 - **PR open (waiting-PR)** → `Fixes #N` in the PR body; the state is **derived** from the

--- a/.agents/policy/workflow.md
+++ b/.agents/policy/workflow.md
@@ -39,9 +39,9 @@ implementable — the forks are tickets.
 
 ### Task packet
 
-The issue body IS the packet, and the issue carries both its descriptive label(s) and
-the native type defined by `issues.md`. A fresh session must be able to execute from it
-plus its linked references alone. Required fields:
+The issue body IS the packet, and the issue carries the native type defined by `issues.md`
+plus optional additive labels when they contribute information beyond that type. A fresh
+session must be able to execute from it plus its linked references alone. Required fields:
 
 - **Objective** — the one outcome.
 - **Required reading** — `file:line` and doc pointers (bootstrap routing rows), never

--- a/.agents/skills/qa/SKILL.md
+++ b/.agents/skills/qa/SKILL.md
@@ -46,7 +46,7 @@ Keep as a single issue when:
 
 ### 4. File the GitHub issue(s)
 
-Create bugs with `gh issue create --label bug --type Bug`. Do NOT ask the user to
+Create bugs with `gh issue create --type Bug`. Do NOT ask the user to
 review first — just file and share URLs.
 
 Issues must be **durable** — they should still make sense after major refactors. Write from the user's perspective.

--- a/.agents/skills/setup-matt-pocock-skills/issue-tracker-github.md
+++ b/.agents/skills/setup-matt-pocock-skills/issue-tracker-github.md
@@ -4,7 +4,7 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --title "..." --body "..." --label "<label>" --type "<type>"`. Use a heredoc for multi-line bodies. Both `--label` and `--type` are mandatory.
+- **Create an issue**: `gh issue create --title "..." --body "..." --type "<type>"`. Use a heredoc for multi-line bodies. `--type` is mandatory; `--label` is optional and used only for metadata the type does not already convey.
 - **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
@@ -15,8 +15,9 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 
 Issue types are single-valued: `Bug` for defects, `Feature` for new user-facing
 capabilities, and `Task` for improvements, implementation work, maintenance, tests,
-CI, documentation, research, and process work. Keep descriptive labels alongside the
-type; a defect wins when categories overlap.
+CI, documentation, research, and process work. Add labels only for orthogonal metadata
+such as subsystem, risk, workstream, or lifecycle; never duplicate the type. A defect
+wins when categories overlap.
 
 ## Pull requests as a triage surface
 

--- a/.agents/skills/setup-matt-pocock-skills/triage-labels.md
+++ b/.agents/skills/setup-matt-pocock-skills/triage-labels.md
@@ -18,10 +18,10 @@ Edit the right-hand column to match whatever vocabulary you actually use.
 
 The two **category** roles map to the issue's native **type**, not a label:
 
-| Category role | Our tracker      | How to set                        |
-| ------------- | ---------------- | --------------------------------- |
-| `bug`         | type **Bug**     | `gh issue edit <n> --type Bug`    |
-| `enhancement` | `enhancement` label | `gh issue edit <n> --add-label enhancement` |
+| Category role | Our tracker             | How to set                                      |
+| ------------- | ----------------------- | ----------------------------------------------- |
+| `bug`         | type **Bug**            | `gh issue edit <n> --type Bug`                  |
+| `enhancement` | type **Feature**/**Task** | `gh issue edit <n> --type Feature` or `--type Task` |
 
-The `bug` label has been retired — categorise bugs with the type only. Migrate
-`enhancement` to a type the same way if/when you retire that label.
+Category labels have been retired for issues. Use `Feature` for a new user-facing
+capability and `Task` for an improvement to existing behaviour or maintenance work.

--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -28,10 +28,11 @@ Two **category** roles:
 - `bug` — something is broken
 - `enhancement` — new feature or improvement
 
-Category is expressed with the issue's native **type**, not a label: `bug` maps to
-type **Bug** (`gh issue edit <n> --type Bug`, or `gh issue create --type Bug`). The `bug`
-label has been retired — do not add it. `enhancement` still maps to the `enhancement`
-label until it is likewise migrated to a type.
+For issues, category is expressed with the native **type**, not a label: `bug` maps
+to **Bug**; `enhancement` maps to **Feature** for a new user-facing capability or
+**Task** for an improvement to existing behaviour or maintenance work. Do not add a
+category label that merely duplicates the type. For PRs, use the linked issue's type
+when one exists; PR-only labels remain additive metadata.
 
 Five **state** roles:
 

--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -32,7 +32,8 @@ For issues, category is expressed with the native **type**, not a label: `bug` m
 to **Bug**; `enhancement` maps to **Feature** for a new user-facing capability or
 **Task** for an improvement to existing behaviour or maintenance work. Do not add a
 category label that merely duplicates the type. For PRs, use the linked issue's type
-when one exists; PR-only labels remain additive metadata.
+when one exists; an unlinked PR still uses `bug` or `enhancement` because PRs have no
+native type. Other PR-only labels remain additive metadata.
 
 Five **state** roles:
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: Feature request
 description: Propose a new user-facing pfBlockerNG capability.
-labels: ["enhancement"]
 type: feature
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/task_request.yml
+++ b/.github/ISSUE_TEMPLATE/task_request.yml
@@ -1,6 +1,5 @@
 name: Improvement or maintenance task
 description: Propose an improvement to existing behavior or project maintenance.
-labels: ["enhancement"]
 type: task
 body:
   - type: textarea

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -117,6 +117,6 @@ jobs:
               --repo "$REPO" \
               --title "$TITLE" \
               --body-file "$BODY_FILE" \
-              --label "nightly-red,bug" \
+              --label "nightly-red" \
               --type Bug
           fi

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -208,6 +208,6 @@ jobs:
               --repo "$REPO" \
               --title "$TITLE" \
               --body-file "${{ steps.report.outputs.body_file }}" \
-              --label "top1m-provider,bug" \
+              --label "top1m-provider" \
               --type Bug
           fi

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -403,7 +403,7 @@ jobs:
               --repo "$REPO" \
               --title "$TITLE" \
               --body-file "$BODY_FILE" \
-              --label "version-tracker,enhancement" \
+              --label "version-tracker" \
               --type Task \
               || echo "  ::warning::Could not open nudge issue for ${CHANNEL} ${VERSION}"
             rm -f "$BODY_FILE"
@@ -484,7 +484,7 @@ jobs:
                 --repo "$REPO" \
                 --title "$TITLE" \
                 --body-file "$BODY_FILE" \
-                --label "version-tracker,enhancement" \
+                --label "version-tracker" \
                 --type Task \
                 || echo "  ::warning::Could not create tracking issue for ${CHANNEL} ${VERSION}"
             fi

--- a/tests/test_issue_creation_metadata.py
+++ b/tests/test_issue_creation_metadata.py
@@ -1,4 +1,4 @@
-"""Ticket creators must set a native issue type plus each path's required labels."""
+"""Ticket creators use native issue types; labels add only orthogonal metadata."""
 
 import shlex
 from pathlib import Path
@@ -22,13 +22,13 @@ def _option_values(command: str, option: str) -> list[str]:
     return [tokens[index + 1] for index, token in enumerate(tokens[:-1]) if token == option]
 
 
-def test_automated_issue_creators_set_label_and_type() -> None:
+def test_automated_issue_creators_set_type_and_only_additive_labels() -> None:
     expected = {
-        "nightly-failure-alert.yml": [("nightly-red,bug", "Bug")],
-        "top1m-healthcheck.yml": [("top1m-provider,bug", "Bug")],
+        "nightly-failure-alert.yml": [("nightly-red", "Bug")],
+        "top1m-healthcheck.yml": [("top1m-provider", "Bug")],
         "version-tracker.yml": [
-            ("version-tracker,enhancement", "Task"),
-            ("version-tracker,enhancement", "Task"),
+            ("version-tracker", "Task"),
+            ("version-tracker", "Task"),
         ],
     }
     commands: dict[str, list[str]] = {}
@@ -56,8 +56,8 @@ def test_issue_forms_declare_native_type_and_disable_blank_issues() -> None:
     # issue type (a81fc030 dropped the redundant `bug` label).
     forms = {
         "bug_report.yml": ("type: bug",),
-        "feature_request.yml": ('labels: ["enhancement"]', "type: feature"),
-        "task_request.yml": ('labels: ["enhancement"]', "type: task"),
+        "feature_request.yml": ("type: feature",),
+        "task_request.yml": ("type: task",),
     }
     template_dir = ROOT / ".github/ISSUE_TEMPLATE"
     form_files = {
@@ -73,17 +73,19 @@ def test_issue_forms_declare_native_type_and_disable_blank_issues() -> None:
     assert "blank_issues_enabled: false" in config
 
 
-def test_human_ticket_procedures_require_both_metadata_axes() -> None:
+def test_human_ticket_procedures_make_labels_optional() -> None:
     policy = _read(".agents/policy/issues.md")
     for issue_type in ("Bug", "Feature", "Task"):
         assert f"| `{issue_type}` |" in policy
-    assert "`gh issue create --label bug --type Bug`" in policy
+    assert "Labels are optional" in policy
+    assert "`gh issue create --type Bug`" in policy
 
     qa = _read(".agents/skills/qa/SKILL.md")
-    assert "`gh issue create --label bug --type Bug`" in qa
+    assert "`gh issue create --type Bug`" in qa
 
     tracker = _read(".agents/skills/setup-matt-pocock-skills/issue-tracker-github.md")
-    assert '--label "<label>" --type "<type>"' in tracker
+    assert '--type "<type>"' in tracker
+    assert "`--label` is optional" in tracker
     assert "gh issue create --label wayfinder:map --type Task" in tracker
 
     wayfinder = _read(".agents/skills/wayfinder/SKILL.md")
@@ -92,7 +94,7 @@ def test_human_ticket_procedures_require_both_metadata_axes() -> None:
 
     workflow = _read(".agents/policy/workflow.md")
     assert "`wayfinder:map` and typed `Task`" in workflow
-    assert "descriptive label(s)" in workflow
+    assert "optional additive labels" in workflow
     assert "native type defined by `issues.md`" in workflow
 
     refactor = _read(".agents/skills/request-refactor-plan/SKILL.md")

--- a/tests/test_issue_creation_metadata.py
+++ b/tests/test_issue_creation_metadata.py
@@ -69,7 +69,7 @@ def test_issue_forms_declare_native_type_and_disable_blank_issues() -> None:
         form = _read(f".github/ISSUE_TEMPLATE/{filename}")
         for expected in expected_lines:
             assert f"\n{expected}\n" in form
-        assert not re.search(r"(?mi)^labels:.*\b(?:bug|enhancement)\b", form)
+        assert not re.search(r"""(?m)^\s*["']?labels["']?\s*:""", form)
 
     config = _read(".github/ISSUE_TEMPLATE/config.yml")
     assert "blank_issues_enabled: false" in config

--- a/tests/test_issue_creation_metadata.py
+++ b/tests/test_issue_creation_metadata.py
@@ -1,5 +1,6 @@
 """Ticket creators use native issue types; labels add only orthogonal metadata."""
 
+import re
 import shlex
 from pathlib import Path
 
@@ -68,6 +69,7 @@ def test_issue_forms_declare_native_type_and_disable_blank_issues() -> None:
         form = _read(f".github/ISSUE_TEMPLATE/{filename}")
         for expected in expected_lines:
             assert f"\n{expected}\n" in form
+        assert not re.search(r"(?mi)^labels:.*\b(?:bug|enhancement)\b", form)
 
     config = _read(".github/ISSUE_TEMPLATE/config.yml")
     assert "blank_issues_enabled: false" in config


### PR DESCRIPTION
## Summary

- Make the native `Bug` / `Feature` / `Task` type the only required issue classification.
- Make labels optional and additive: subsystem, risk, workstream, lifecycle, and similar metadata only.
- Remove redundant `bug` / `enhancement` labels from issue forms and automated issue creators while preserving `nightly-red`, `top1m-provider`, and `version-tracker`.
- Align QA, triage, tracker, and workflow policy surfaces with the same rule.

This policy contradiction surfaced while triaging #1702. This PR does not fix #1702's feed-rendering defect.

## Test-first proof

RED on untouched creation paths:

```text
python3 -m pytest -q tests/test_issue_creation_metadata.py
2 failed, 1 passed
```

Frozen test hash:

```text
0ef359af08500ed5f4a946674742081f481a4978
```

GREEN after the policy and creator changes, same hash:

```text
python3 -m pytest -q tests/test_issue_creation_metadata.py
3 passed
```

Canonical diff gates:

```text
GATE PASS: python3 -m pytest
GATE PASS: ruff check .
GATE PASS: ruff format --check .
GATE PASS: mypy tests/
GATE PASS: npx markdownlint-cli2
GATES: PASS
```

The full pytest gate used `commit.gpgsign=false` only for scratch-repository fixture commits; the host's global signing setting otherwise makes those temporary commits exit 128.

## Scope

PR-only `enhancement` labels remain unchanged because pull requests have no native issue type. Orthogonal issue labels such as `security`, `CI`, `dnsbl`, `wayfinder:*`, and lifecycle labels remain unchanged.

## Audit

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated issue creation and triage guidance to require native issue types (Bug/Feature/Task) and make labels optional as purely additive, orthogonal metadata.
  * Clarified task packet and issue lifecycle behavior for legacy vs additive labels.
* **Bug Fixes**
  * Removed automatic label assignment in feature/task templates and adjusted workflow-created tracking issues to use only the relevant single label.
* **Tests**
  * Updated issue-creation metadata expectations to enforce `--type` and allow only optional additive `--label` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->