### PR TITLE
pfblockerng: rename pfbng_text_area_decode() to pfb_text_area_decode()

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3040,7 +3040,7 @@ function pfb_strtolower($line) {
 
 // Function to decode alias custom entry box.
 // Default (False, True): Return as string with comments
-function pfbng_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
+function pfb_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
 
 	if ($mode) {
 		$custom = array();
@@ -6470,7 +6470,7 @@ function pfb_create_suppression_file() {
 	// install migration only seeds v4suppression when a legacy
 	// pfBlockerNGSuppress alias existed; v6suppression is never migrated), so
 	// a direct array read here throws a PHP8 "undefined array key" warning.
-	$v4suppression = pfbng_text_area_decode($pfb['ipconfig']['v4suppression'] ?? '', FALSE, TRUE);
+	$v4suppression = pfb_text_area_decode($pfb['ipconfig']['v4suppression'] ?? '', FALSE, TRUE);
 	if (!empty($v4suppression)) {
 		@file_put_contents("{$pfb['supptxt']}", $v4suppression, LOCK_EX);
 	} else {
@@ -6478,7 +6478,7 @@ function pfb_create_suppression_file() {
 	}
 
 	// ADR-53: v6 sibling -- same decode/write/unlink-when-empty shape as v4 above.
-	$v6suppression = pfbng_text_area_decode($pfb['ipconfig']['v6suppression'] ?? '', FALSE, TRUE);
+	$v6suppression = pfb_text_area_decode($pfb['ipconfig']['v6suppression'] ?? '', FALSE, TRUE);
 	if (!empty($v6suppression)) {
 		@file_put_contents("{$pfb['supptxt_v6']}", $v6suppression, LOCK_EX);
 	} else {
@@ -7287,7 +7287,7 @@ function pfb_unbound_python_whitelist($mode='') {
 	pfb_global();
 
 	$dnsbl_whitelist = '';
-	$dnsbl_white = pfbng_text_area_decode($pfb['dnsblconfig']['suppression'], TRUE, FALSE, TRUE);
+	$dnsbl_white = pfb_text_area_decode($pfb['dnsblconfig']['suppression'], TRUE, FALSE, TRUE);
 	if (!empty($dnsbl_white)) {
 		foreach ($dnsbl_white as $key => $line) {
 			if (!empty($line)) {
@@ -7322,7 +7322,7 @@ function pfb_unbound_python_whitelist($mode='') {
 function pfb_dnsbl_whitelist_lines() {
 	global $pfb;
 
-	$lines = pfbng_text_area_decode($pfb['dnsblconfig']['suppression'], TRUE, FALSE, TRUE);
+	$lines = pfb_text_area_decode($pfb['dnsblconfig']['suppression'], TRUE, FALSE, TRUE);
 	$out = array();
 	if (!empty($lines)) {
 		foreach ($lines as $line) {
@@ -8822,8 +8822,8 @@ function pfb_unbound_python_sources_locked($feeds, array $publication_ops=array(
 	$tld_wildcard_blacklist = array();
 	$tld_wildcard_exclusion = array();
 	if (!empty($pfb['dnsbl_tld_wildcard'])) {
-		$tld_wildcard_blacklist = pfbng_text_area_decode($pfb['dnsblconfig']['tldblacklist'], TRUE, FALSE, TRUE) ?: array();
-		$tld_wildcard_exclusion = pfbng_text_area_decode($pfb['dnsblconfig']['tldexclusion'], TRUE, FALSE, TRUE) ?: array();
+		$tld_wildcard_blacklist = pfb_text_area_decode($pfb['dnsblconfig']['tldblacklist'], TRUE, FALSE, TRUE) ?: array();
+		$tld_wildcard_exclusion = pfb_text_area_decode($pfb['dnsblconfig']['tldexclusion'], TRUE, FALSE, TRUE) ?: array();
 	}
 
 	$manifest = array(
@@ -9159,7 +9159,7 @@ forwarding	= {$forwarding}
 EOF;
 		if ($pfb['dnsbl_regex'] == 'on' && isset($pfb['dnsbl_regex_list']) && !empty($pfb['dnsbl_regex_list'])) {
 			$regex = '';
-			$regex_list = pfbng_text_area_decode($pfb['dnsbl_regex_list'], TRUE, TRUE, FALSE);
+			$regex_list = pfb_text_area_decode($pfb['dnsbl_regex_list'], TRUE, TRUE, FALSE);
 			if (!empty($regex_list)) {
 				$counter = 1;
 				$key_index = array();
@@ -9191,7 +9191,7 @@ EOF;
 
 		if ($pfb['dnsbl_noaaaa'] == 'on' && isset($pfb['dnsbl_noaaaa_list']) && !empty($pfb['dnsbl_noaaaa_list'])) {
 			$noaaaa = '';
-			$noaaaa_list = pfbng_text_area_decode($pfb['dnsbl_noaaaa_list'], TRUE, TRUE, TRUE);
+			$noaaaa_list = pfb_text_area_decode($pfb['dnsbl_noaaaa_list'], TRUE, TRUE, TRUE);
 			if (!empty($noaaaa_list)) {
 				foreach ($noaaaa_list as $key => $list) {
 					if (str_starts_with($list[0], '.')) {
@@ -9211,7 +9211,7 @@ EOF;
 
 		if ($pfb['dnsbl_gp'] == 'on' && isset($pfb['dnsbl_gp_bypass_list']) && !empty($pfb['dnsbl_gp_bypass_list'])) {
 			$gp_bypass = '';
-			$gp_bypass_list = pfbng_text_area_decode($pfb['dnsbl_gp_bypass_list'], TRUE, TRUE, FALSE);
+			$gp_bypass_list = pfb_text_area_decode($pfb['dnsbl_gp_bypass_list'], TRUE, TRUE, FALSE);
 			if (!empty($gp_bypass_list)) {
 				foreach ($gp_bypass_list as $key => $list) {
 					$gp_bypass .= "{$key} = {$list[0]}\n";
@@ -9329,7 +9329,7 @@ function pfb_dnsbl_tld_stats_finalize(array $group_counts): void {
 	}
 
 	// Collect TLD Blacklist(s). If configured the whole TLD will be blocked
-	$tld_blacklist = pfbng_text_area_decode($pfb['dnsblconfig']['tldblacklist'], TRUE, FALSE, TRUE);
+	$tld_blacklist = pfb_text_area_decode($pfb['dnsblconfig']['tldblacklist'], TRUE, FALSE, TRUE);
 	if (!empty($tld_blacklist)) {
 		$tld_blacklist = array_flip($tld_blacklist);
 	}
@@ -11203,7 +11203,7 @@ function pfb_feed_internal_allowlist($ignored = NULL) {
 	}
 
 	// The allowlist is stored base64-encoded, like every other pfBlockerNG textarea
-	// (suppression / whitelist / custom; see pfbng_text_area_decode). Decode before
+	// (suppression / whitelist / custom; see pfb_text_area_decode). Decode before
 	// parsing; an undecodable value yields no entries, so the filter stays fail-closed.
 	$raw = (string) base64_decode($raw);
 
@@ -13692,8 +13692,8 @@ function pfb_remove_states() {
 	// ADR-53 review finding B: '?? ""' -- same absent-key guard as
 	// pfb_create_suppression_file() (both keys are absent from config.xml
 	// until their first save on an upgraded or fresh install).
-	$v4suppression = pfbng_text_area_decode($pfb['ipconfig']['v4suppression'] ?? '', TRUE, FALSE);
-	$v6suppression = pfbng_text_area_decode($pfb['ipconfig']['v6suppression'] ?? '', TRUE, FALSE);
+	$v4suppression = pfb_text_area_decode($pfb['ipconfig']['v4suppression'] ?? '', TRUE, FALSE);
+	$v6suppression = pfb_text_area_decode($pfb['ipconfig']['v6suppression'] ?? '', TRUE, FALSE);
 
 	// Collect Interface list that have pfB Rules assigned
 	$data		= pfb_filterrules();
@@ -13724,7 +13724,7 @@ function pfb_remove_states() {
 				continue;
 			}
 			if (!empty($list['custom']) && strpos($list['action'], 'Permit_') !== FALSE) {
-				$custom		= pfbng_text_area_decode($list['custom'], TRUE, FALSE);
+				$custom		= pfb_text_area_decode($list['custom'], TRUE, FALSE);
 				$custom_supp	= array_merge($custom_supp, $custom);
 			}
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -867,7 +867,7 @@ function sync_package_pfblockerng($cron='') {
 
 		// If 'TLD' enabled and TLD Blacklists are defined, add to enabled DNSBL lists
 		if ($pfb['dnsbl_tld_wildcard']) {
-			$tld_wildcard_blacklist = pfbng_text_area_decode($pfb['dnsblconfig']['tldblacklist'], TRUE, FALSE, TRUE);
+			$tld_wildcard_blacklist = pfb_text_area_decode($pfb['dnsblconfig']['tldblacklist'], TRUE, FALSE, TRUE);
 			if (!empty($tld_wildcard_blacklist)) {
 				$pfb['existing']['dnsbl'][] = 'DNSBL_TLD';
 			}
@@ -1296,7 +1296,7 @@ function sync_package_pfblockerng($cron='') {
 
 			// Collect Whitelist, create string, and save to file (for grep -vF -f cmd)
 			pfb_logger("\n Loading DNSBL Whitelist...", 1);
-			$pfb_white = pfbng_text_area_decode($pfb['dnsblconfig']['suppression'], TRUE, FALSE, TRUE);
+			$pfb_white = pfb_text_area_decode($pfb['dnsblconfig']['suppression'], TRUE, FALSE, TRUE);
 			if (!empty($pfb_white)) {
 				foreach ($pfb_white as $line) {
 					if (!empty($line)) {
@@ -1752,7 +1752,7 @@ function sync_package_pfblockerng($cron='') {
 								}
 								else {
 									// Collect custom list data.
-									$custom_list = pfbng_text_area_decode($row['custom'], FALSE, TRUE, TRUE);
+									$custom_list = pfb_text_area_decode($row['custom'], FALSE, TRUE, TRUE);
 									@file_put_contents("{$file_dwn}.orig", $custom_list, LOCK_EX);
 									unset($custom_list);
 								}
@@ -2209,7 +2209,7 @@ function sync_package_pfblockerng($cron='') {
 			} else {
 				$regex_cnt = 0;
 				if (isset($pfb['dnsbl_regex_list'])) {
-					$regex_cnt = count(pfbng_text_area_decode($pfb['dnsbl_regex_list'], TRUE, FALSE, FALSE)) ?: 0;
+					$regex_cnt = count(pfb_text_area_decode($pfb['dnsbl_regex_list'], TRUE, FALSE, FALSE)) ?: 0;
 				}
 			}
 			$pfb['alias_dnsbl_all'][] = 'DNSBL_Regex';
@@ -3245,7 +3245,7 @@ function sync_package_pfblockerng($cron='') {
 							else {
 								if ($list['whois_convert'] == 'on') {
 									// Process Domain/AS based custom list
-									$custom_list = str_replace("\n", ',', pfbng_text_area_decode($list['custom'], FALSE, TRUE, TRUE));
+									$custom_list = str_replace("\n", ',', pfb_text_area_decode($list['custom'], FALSE, TRUE, TRUE));
 									if (!empty(pfb_filter($custom_list, PFB_FILTER_CSV_WHOIS, 'Process Domain/AS based custom list'))) {
 										exec("{$pfb['script']} whoisconvert {$header_esc} {$list['vtype']} {$custom_list} {$elog}");
 									} else {
@@ -3254,7 +3254,7 @@ function sync_package_pfblockerng($cron='') {
 								}
 								else {
 									// Process IP based custom list
-									$custom_list = pfbng_text_area_decode($list['custom'], FALSE, TRUE, FALSE);
+									$custom_list = pfb_text_area_decode($list['custom'], FALSE, TRUE, FALSE);
 									@file_put_contents("{$file_dwn}.orig", $custom_list, LOCK_EX);
 								}
 								pfb_logger(' . completed .', 1);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3702,7 +3702,7 @@ function pfb_ip_suppressed_match(string $ip, array $entries): ?string
 		if ($entry === '' || str_starts_with($entry, '#')) {
 			continue;
 		}
-		// Strip a trailing inline '#' comment, same as pfbng_text_area_decode().
+		// Strip a trailing inline '#' comment, same as pfb_text_area_decode().
 		$stripped = trim(strstr($entry, '#', TRUE) ?: $entry);
 
 		// Bare host -> exact single-host CIDR BEFORE the containment test:

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -253,7 +253,7 @@ if (!$alert_summary) {
 
 					$clists[$type]['options'][] = $lname;	// List of all Permit Aliases/DNSBL Customlists
 
-					$decoded = pfbng_text_area_decode($data['custom'], TRUE, TRUE);
+					$decoded = pfb_text_area_decode($data['custom'], TRUE, TRUE);
 					if (!empty($decoded)) {
 						foreach ($decoded as $line) {
 
@@ -311,7 +311,7 @@ if (!$alert_summary) {
 
 		$clists[$type]['data']		= array();
 		if (isset($clists[$type]['base64']) && !empty($clists[$type]['base64'])) {
-			$decoded = pfbng_text_area_decode($clists[$type]['base64'], TRUE, TRUE);
+			$decoded = pfb_text_area_decode($clists[$type]['base64'], TRUE, TRUE);
 			if (!empty($decoded)) {
 				foreach ($decoded as $line) {
 

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -699,7 +699,7 @@ function pfBlockerNG_get_header($mode='') {
 			elseif ($type == 'Suppression' || $type == 'Whitelist') {
 
 				$gcount = 0;
-				foreach (pfbng_text_area_decode($config_path, TRUE, FALSE, TRUE) as $cline) {
+				foreach (pfb_text_area_decode($config_path, TRUE, FALSE, TRUE) as $cline) {
 					if (!str_starts_with(trim($cline), '#') && !empty($cline)) {
 						$gcount++;
 					}
@@ -712,7 +712,7 @@ function pfBlockerNG_get_header($mode='') {
 				if ($type == 'Suppression') {
 					// ADR-53 review finding B: '?? ""' -- same absent-key guard
 					// as the v4 read above.
-					foreach (pfbng_text_area_decode($pfb['ipconfig']['v6suppression'] ?? '', TRUE, FALSE, TRUE) as $cline) {
+					foreach (pfb_text_area_decode($pfb['ipconfig']['v6suppression'] ?? '', TRUE, FALSE, TRUE) as $cline) {
 						if (!str_starts_with(trim($cline), '#') && !empty($cline)) {
 							$gcount++;
 						}

--- a/tests/php/BootstrapSmokeTest.php
+++ b/tests/php/BootstrapSmokeTest.php
@@ -19,7 +19,7 @@ final class BootstrapSmokeTest extends TestCase
 	{
 		foreach ([
 			'pfb_filter',
-			'pfbng_text_area_decode',
+			'pfb_text_area_decode',
 			'pfb_dnsbl_abp_extract_ip',
 			'sanitize_ipaddr',
 			'pfb_validate_domain_labels',

--- a/tests/php/CreateSuppressionFileTest.php
+++ b/tests/php/CreateSuppressionFileTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  * red->green proof: both FAIL (undefined array key / missing file) against the pre-Phase-6
  * function and PASS once the v6 branch lands.
  *
- * pfbng_text_area_decode(text, FALSE, TRUE) (the mode pfb_create_suppression_file() uses)
+ * pfb_text_area_decode(text, FALSE, TRUE) (the mode pfb_create_suppression_file() uses)
  * lowercases + trims each non-comment, non-blank line and joins with a single "\n" --
  * NOT the original "\r\n" -- so the expected file content below reflects that shape.
  */

--- a/tests/php/PfbStrtolowerTest.php
+++ b/tests/php/PfbStrtolowerTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * pfb_strtolower() — lower-case + trim a line UNLESS it contains a '#', in which
  * case only trim (comment text is preserved verbatim). Used by the array-map in
- * pfbng_text_area_decode()'s comment-split path.
+ * pfb_text_area_decode()'s comment-split path.
  */
 #[CoversFunction('pfb_strtolower')]
 final class PfbStrtolowerTest extends TestCase

--- a/tests/php/README.md
+++ b/tests/php/README.md
@@ -54,7 +54,7 @@ for test execution.
 | Test file | Function under test |
 | --------- | ------------------- |
 | `PfbFilterTest` | `pfb_filter` (DOMAIN/IP/IPV4/WORD/HEX_COLOR/ON_OFF/NUM) |
-| `TextAreaDecodeTest` | `pfbng_text_area_decode` (base64/CRLF/comment/IDN) |
+| `TextAreaDecodeTest` | `pfb_text_area_decode` (base64/CRLF/comment/IDN) |
 | `AbpExtractIpTest` | `pfb_dnsbl_abp_extract_ip` (ADR-07 DNSBL-IP extraction) |
 | `SanitizeIpaddrTest` | `sanitize_ipaddr` (IPv4 normalise + suppression) |
 | `ValidateDomainLabelsTest` | `pfb_validate_domain_labels` (63-char labels) |

--- a/tests/php/TextAreaDecodeTest.php
+++ b/tests/php/TextAreaDecodeTest.php
@@ -6,14 +6,14 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfbng_text_area_decode() — the Custom_List/whitelist textarea decoder: base64
+ * pfb_text_area_decode() — the Custom_List/whitelist textarea decoder: base64
  * in, CRLF-split, '#'-comment handling, lower-casing, optional IDN->punycode.
  *
  * $mode: FALSE => newline-joined string; TRUE => array.
  * $type (mode only): TRUE => per-line [value(, '#comment')]; FALSE => bare value.
  * $idn:  TRUE  => convert non-ASCII hostnames to punycode (idn_to_ascii).
  */
-#[CoversFunction('pfbng_text_area_decode')]
+#[CoversFunction('pfb_text_area_decode')]
 final class TextAreaDecodeTest extends TestCase
 {
 	/** Encode like a browser textarea: lines joined by CRLF, then base64. */
@@ -26,27 +26,27 @@ final class TextAreaDecodeTest extends TestCase
 	{
 		$in = self::enc('EXAMPLE.COM', 'foo.com', '# whole-line comment', 'bar.com # inline');
 		// Whole-line comment dropped; inline comment trimmed off; all lower-cased.
-		$this->assertSame("example.com\nfoo.com\nbar.com\n", pfbng_text_area_decode($in));
+		$this->assertSame("example.com\nfoo.com\nbar.com\n", pfb_text_area_decode($in));
 	}
 
 	public function testStringModeSkipsEmptyLines(): void
 	{
 		$in = self::enc('a.com', '', 'b.com');
-		$this->assertSame("a.com\nb.com\n", pfbng_text_area_decode($in));
+		$this->assertSame("a.com\nb.com\n", pfb_text_area_decode($in));
 	}
 
 	public function testArrayModeBareValues(): void
 	{
 		$in = self::enc('Foo.com', '# c', 'bar.com # x');
 		// mode=TRUE, type=FALSE => array of bare, comment-stripped, lower values.
-		$this->assertSame(['foo.com', 'bar.com'], pfbng_text_area_decode($in, true, false));
+		$this->assertSame(['foo.com', 'bar.com'], pfb_text_area_decode($in, true, false));
 	}
 
 	public function testArrayModeTypedNonCommentWrapsInArray(): void
 	{
 		$in = self::enc('Foo.com');
 		// mode=TRUE, type=TRUE => each non-comment line becomes [value].
-		$this->assertSame([['foo.com']], pfbng_text_area_decode($in, true, true));
+		$this->assertSame([['foo.com']], pfb_text_area_decode($in, true, true));
 	}
 
 	public function testArrayModeTypedCommentSplit(): void
@@ -54,7 +54,7 @@ final class TextAreaDecodeTest extends TestCase
 		$in = self::enc('bar.com # note');
 		// Comment line splits into [value, '#comment'] via pfb_strtolower: the
 		// value is trimmed+lowered, the '#'-bearing token kept (trimmed) verbatim.
-		$this->assertSame([['bar.com', '# note']], pfbng_text_area_decode($in, true, true));
+		$this->assertSame([['bar.com', '# note']], pfb_text_area_decode($in, true, true));
 	}
 
 	public function testIdnConversionToPunycode(): void
@@ -66,7 +66,7 @@ final class TextAreaDecodeTest extends TestCase
 		setlocale(LC_CTYPE, 'C');
 		try {
 			$in = self::enc('bücher.de');
-			$this->assertSame("xn--bcher-kva.de\n", pfbng_text_area_decode($in, false, true, true));
+			$this->assertSame("xn--bcher-kva.de\n", pfb_text_area_decode($in, false, true, true));
 		} finally {
 			setlocale(LC_CTYPE, $prev);
 		}
@@ -76,6 +76,6 @@ final class TextAreaDecodeTest extends TestCase
 	{
 		// base64('') => '' => explode gives [''] => nothing appended. String mode
 		// initialises $custom to '' up front, so empty input yields '' (not null).
-		$this->assertSame('', pfbng_text_area_decode(''));
+		$this->assertSame('', pfb_text_area_decode(''));
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -7186,6 +7186,40 @@
         "returnType": null,
         "params": []
     },
+    "pfb_text_area_decode": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "text",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            },
+            {
+                "name": "type",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "true"
+            },
+            {
+                "name": "idn",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "false"
+            }
+        ]
+    },
     "pfb_text_sanity": {
         "returnsRef": false,
         "returnType": "?string",
@@ -9120,40 +9154,6 @@
                 "variadic": false,
                 "type": "array",
                 "default": "array (\n)"
-            }
-        ]
-    },
-    "pfbng_text_area_decode": {
-        "returnsRef": false,
-        "returnType": null,
-        "params": [
-            {
-                "name": "text",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": null
-            },
-            {
-                "name": "mode",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": "false"
-            },
-            {
-                "name": "type",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": "true"
-            },
-            {
-                "name": "idn",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": "false"
             }
         ]
     },

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1321,7 +1321,7 @@ def _b64_textarea(lines: list[str]) -> str:
 
     pfBlockerNG TEXTAREA settings (``suppression``, ``pfb_regex_list``, ``custom``, …)
     are kept base64-encoded in config (the GUI base64_encodes on save) and decoded by
-    ``pfbng_text_area_decode()`` (``base64_decode`` then ``explode("\\r\\n", …)``). A
+    ``pfb_text_area_decode()`` (``base64_decode`` then ``explode("\\r\\n", …)``). A
     PLAIN value injected here would be base64_decoded into GARBAGE — invalid bytes that
     crash the python module's INI load (``Failed to load ini configuration: 'utf-8'
     codec can't decode byte``) and silently disable DNSBL. Encode with CRLF separators
@@ -2227,7 +2227,7 @@ def use_stub_for_safesearch(vm: SmokeVM, forwarding_on: bool, *, timeout: float 
 
     # Recursive mode: no unbound/forwarding, but route every query to the stub
     # via a catch-all forward-zone in custom_options.  pfSense stores
-    # custom_options base64-encoded (pfbng_text_area_decode / base64_encode on
+    # custom_options base64-encoded (pfb_text_area_decode / base64_encode on
     # save), so encode before writing.
     forward_zone = f'forward-zone:\n    name: "."\n    forward-addr: {GUEST_TO_HOST_ALIAS}\n'
     encoded = base64.b64encode(forward_zone.encode()).decode()
@@ -2972,7 +2972,7 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
     settings["pfb_dnsbl"] = "on"
     if spec.whitelist:
         # suppression is a pfBlockerNG TEXTAREA field: config stores it base64-encoded
-        # (GUI pfblockerng_dnsbl.php:555) and pfbng_text_area_decode() base64_decodes +
+        # (GUI pfblockerng_dnsbl.php:555) and pfb_text_area_decode() base64_decodes +
         # splits on CRLF. A PLAIN value here decodes to GARBAGE — so encode it.
         settings["suppression"] = _b64_textarea(spec.whitelist)
     if spec.dnsbl_ip_action:
@@ -3040,7 +3040,7 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
         "order": "primary",
     }
     # The DNSBL Group Custom_List: a base64 'custom' field (CRLF-joined domains, the
-    # exact shape pfbng_text_area_decode expects, inc:1120). A non-empty 'custom'
+    # exact shape pfb_text_area_decode expects, inc:1120). A non-empty 'custom'
     # makes pfBlockerNG auto-generate the sovereign '{aliasname}_custom' row.
     custom_line = ""
     if spec.custom_domains:

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -517,7 +517,7 @@ def test_stub_set_records_families_multi_and_nodata() -> None:
 
 
 def test_b64_textarea_matches_pfblockerng_decode() -> None:
-    """``_b64_textarea`` produces what ``pfbng_text_area_decode`` expects: base64 of a
+    """``_b64_textarea`` produces what ``pfb_text_area_decode`` expects: base64 of a
     CRLF-joined list (so base64_decode + explode("\\r\\n") returns the lines back)."""
     import base64
 

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -104,7 +104,7 @@ def _suppression_entries(vm: helpers.SmokeVM, cfg_path: str) -> set[str]:
     """Return the ENTRY TOKENS of a pfBlockerNG textarea config node.
 
     The alerts handlers store the whitelist / TLD-exclusion / IP-suppression lists
-    base64-encoded (``base64_encode`` in the handler; ``pfbng_text_area_decode``
+    base64-encoded (``base64_encode`` in the handler; ``pfb_text_area_decode``
     base64-decodes on read), one entry per CRLF line as ``<token> [# comment]``. The
     handler keys its in-memory store by the FIRST whitespace-delimited token of each
     line (``$clists[...]['data'][$line[0]]``), so an exact-token set is the faithful

--- a/tools/webassets/cm-regex.js
+++ b/tools/webassets/cm-regex.js
@@ -10,7 +10,7 @@ import { syntaxHighlighting, defaultHighlightStyle } from "@codemirror/language"
 import { pfbRegexList } from "./lezer-pfb-regex-list/src/index.js";
 import { pfbHighlightStyle } from "./pfb-highlight-style.js";
 
-// Server-side validation (pfbng_text_area_decode(), preg_match/re.compile) stays
+// Server-side validation (pfb_text_area_decode(), preg_match/re.compile) stays
 // authoritative -- this is a highlighter, not a validator.
 
 // Derives an accessible name for the replacement editor from the textarea it's replacing --

--- a/tools/webassets/lezer-pfb-regex-list/README.md
+++ b/tools/webassets/lezer-pfb-regex-list/README.md
@@ -14,10 +14,10 @@ so a pattern gets full regex highlighting and its trailing description gets styl
 comment.
 
 **This is a highlighter, not a validator.** The server-side decoder
-(`pfbng_text_area_decode()` in `src/usr/local/pkg/pfblockerng/pfblockerng.inc`) stays
+(`pfb_text_area_decode()` in `src/usr/local/pkg/pfblockerng/pfblockerng.inc`) stays
 authoritative for what actually gets stored.
 
-## Line format (mirrors `pfbng_text_area_decode()` exactly)
+## Line format (mirrors `pfb_text_area_decode()` exactly)
 
 - A line whose **trimmed** start is `#` is a whole-line `Comment` -- the decoder drops
   these lines entirely, never storing them.

--- a/tools/webassets/lezer-pfb-regex-list/src/pfb-regex-list.grammar
+++ b/tools/webassets/lezer-pfb-regex-list/src/pfb-regex-list.grammar
@@ -1,5 +1,5 @@
 // Lezer grammar for the pfBlockerNG regex-list textarea format (issue #1669 slice B).
-// Mirrors pfblockerng.inc's pfbng_text_area_decode() (the custom-entry textarea decoder)
+// Mirrors pfblockerng.inc's pfb_text_area_decode() (the custom-entry textarea decoder)
 // EXACTLY: per line, a line whose TRIMMED start is "#" is a whole-line Comment (dropped
 // by the decoder, never stored); otherwise the FIRST "#" anywhere in the line splits it
 // into Pattern (mounts the Python-re grammar from @pfblockerng/lezer-regexp via
@@ -8,7 +8,7 @@
 // Comment in the editor -- that is intended, it surfaces the decoder's real split.
 //
 // This is a HIGHLIGHTER grammar, not a validator: server-side validation
-// (pfbng_text_area_decode() itself, plus preg_match/re.compile on the split pattern half)
+// (pfb_text_area_decode() itself, plus preg_match/re.compile on the split pattern half)
 // stays authoritative.
 //
 // A trailing @precedence { Comment, Pattern } (below) is still required: lezer-generator


### PR DESCRIPTION
## What

Renames `pfbng_text_area_decode()` to `pfb_text_area_decode()`. It was the only symbol in the
repository carrying a `pfbng_` prefix — every other package function uses `pfb_` — so the
outlier cost a moment of doubt on every read and every grep.

Pure rename, no behaviour change: the definition, all call sites, the tests, and the
editor-tooling comments that name it all move together.

## Scope

- **Production** — `pfblockerng.inc` (definition + call sites), `pfblockerng_apply.inc`,
  `pfblockerng_extra.inc`, `pfblockerng_alerts.php`, `pfblockerng.widget.php`.
- **Tests** — the four PHPUnit tests that name it, `tests/php/README.md`, and the three smoke
  files that reference it in comments/docstrings.
- **Editor tooling comments** — `tools/webassets/cm-regex.js` and the Lezer grammar/README
  (comment lines only; no generated parser artifact changes).
- **Golden fixture** — `tests/php/fixtures/function_inventory.json`.

The function is package-internal — no package XML references it and there is no consumer
outside this repository — so no backwards-compatible alias is shipped.

The eight references in the historical `.ADRs/` corpus are deliberately left as written: ADR
bodies and artifacts are immutable and record the name the code carried at the time.

## Test evidence

`FunctionInventoryParityTest` is the oracle for exactly this class of change, and it caught
the rename before the golden was touched:

```
$ vendor/bin/phpunit --filter FunctionInventoryParityTest
FAILURES!
Tests: 1, Assertions: 5, Failures: 1.
```

Regenerating the golden the documented way (`PFB_UPDATE_FUNCTION_INVENTORY=1`) and re-running
the full suite:

```
$ vendor/bin/phpunit
OK, but there were issues!
Tests: 4089, Assertions: 23241, Deprecations: 1, Notices: 1, Skipped: 3.
```

The one deprecation and one notice are pre-existing and unrelated to this change.

Full canonical gates, run via `scripts/agent/run-gates.sh`:

```
GATE PASS: python3 -m pytest
GATE PASS: ruff check . / ruff format --check . / mypy tests/
GATE PASS: php -l (9 touched files)
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATE PASS: npx markdownlint-cli2
GATES: PASS
```

`www/` is touched, so the runner prints its Tier-A `ui_render` reminder. No new UI coverage is
added here on purpose: the change renames an internal helper and alters no reachable UI
behaviour, markup, or page output, and the existing `ui_render` coverage for the alerts page
and the widget already exercises the call sites.

Part of #1714

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected text-area decoding across DNSBL, IP, suppression, whitelist, alert, and widget data.
  * Preserved existing decoding behavior while ensuring configured lists and counts continue to load correctly.

* **Tests**
  * Updated automated coverage and validation to use the corrected text-area decoder naming.

* **Documentation**
  * Updated related comments and reference documentation to reflect the corrected decoder name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->