### PR TITLE
Preserve settings across upgrades and GUI downgrades

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -16775,6 +16775,9 @@ function pfblockerng_php_pre_deinstall_command() {
 	require_once('config.inc');
 	global $g, $pfb;
 
+	// Keep Settings remains governed by the existing pfb_keep boundary.
+	pfb_settings_family_pre_uninstall();
+
 	// #697: tear down ONLY on a genuine removal; keep pfBlockerNG live across a package upgrade.
 	// pfSense reaches the pre-deinstall for both, but with a different pkg operation (read from the
 	// pkg ancestor's argv): a real uninstall -- and a MAJOR OS upgrade's mass-removal -- is

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -450,6 +450,14 @@ function pfb_cfg_registry(): array
 		// General section (pfblockerng/config/0)
 		// -------------------------------------------------------------------
 
+		// Settings snapshot schema marker. Missing installs are the legacy 3.2 family.
+		'settings_family' => [
+			'section'       => $gen,
+			'default'       => '3.2',
+			'read_adapter'  => NULL,
+			'write_adapter' => NULL,
+		],
+
 		// Master enable/disable: 'on' | '' (checkbox).
 		'enable_cb' => [
 			'section'       => $gen,
@@ -1418,6 +1426,320 @@ final class PfbConfig
 		}
 		return $registry[$key];
 	}
+}
+
+// Settings-family snapshots capture only pfBlockerNG-owned installedpackages sections. Foreign
+// config remains live while the registered marker records the exact schema family.
+const PFB_SETTINGS_FAMILY_RANK = ['3.2' => 0, '4.0' => 1, '4.1' => 2];
+
+function pfb_settings_family_from_version(string $version): ?string
+{
+	$version = ltrim(trim($version), 'vV');
+	if (preg_match('/^(\d+\.\d+)(?:\.\d+)?(?:[.-].*)?$/', $version, $match) !== 1
+		|| !isset(PFB_SETTINGS_FAMILY_RANK[$match[1]])) {
+		return NULL;
+	}
+	return $match[1];
+}
+
+function pfb_settings_family_current(): ?string
+{
+	$value = PfbConfig::read('settings_family');
+	return is_string($value) && isset(PFB_SETTINGS_FAMILY_RANK[$value]) ? $value : NULL;
+}
+
+function pfb_settings_family_save(string $family): bool
+{
+	if (!isset(PFB_SETTINGS_FAMILY_RANK[$family])) {
+		return FALSE;
+	}
+	$installed = config_get_path('installedpackages', []);
+	if (!is_array($installed)) {
+		return TRUE;
+	}
+	$owned = [];
+	foreach ($installed as $section => $value) {
+		if (str_starts_with((string) $section, 'pfblockerng')) {
+			$owned[(string) $section] = $value;
+		}
+	}
+	if ($owned === []) {
+		return TRUE;
+	}
+
+	global $pfb;
+	$root = (string) ($pfb['dbdir'] ?? '/var/db/pfblockerng');
+	$effective_owner = function_exists('posix_geteuid') ? posix_geteuid() : 0;
+	$expected_owner = ($root === '/var/db/pfblockerng') ? 0 : $effective_owner;
+	$root_stat = @lstat($root);
+	if ($root_stat !== FALSE && (($root_stat['mode'] & 0170000) !== 0040000 || is_link($root)
+		|| (($root_stat['mode'] & 0022) !== 0) || $root_stat['uid'] !== $expected_owner)) {
+		return FALSE;
+	}
+	if ($root_stat === FALSE && !@mkdir($root, 0755, TRUE)) {
+		return FALSE;
+	}
+	$root_stat = @lstat($root);
+	if ($root_stat === FALSE || (($root_stat['mode'] & 0170000) !== 0040000) || is_link($root)
+		|| (($root_stat['mode'] & 0022) !== 0) || $root_stat['uid'] !== $expected_owner) {
+		return FALSE;
+	}
+
+	$slot = $root . '/settings-' . $family . '.xml';
+	$slot_stat = @lstat($slot);
+	if ($slot_stat !== FALSE && (($slot_stat['mode'] & 0170000) !== 0100000 || is_link($slot)
+		|| ($slot_stat['mode'] & 07777) !== 0600 || $slot_stat['uid'] !== $expected_owner)) {
+		return FALSE;
+	}
+	$payload = base64_encode(serialize($owned));
+	if (function_exists('dump_xml_config')) {
+		$xml = dump_xml_config(['family' => $family, 'payload' => $payload], 'pfblockerng-settings');
+	} else {
+		$doc = new SimpleXMLElement('<pfblockerng-settings/>');
+		$doc->addChild('family', $family);
+		$doc->addChild('payload', $payload);
+		$xml = $doc->asXML();
+	}
+	if (!is_string($xml) || $xml === '') {
+		return FALSE;
+	}
+
+	$tmp = @tempnam($root, '.settings-');
+	if (!is_string($tmp)) {
+		return FALSE;
+	}
+	$written = @file_put_contents($tmp, $xml, LOCK_EX);
+	$exact = ($written === strlen($xml) && @file_get_contents($tmp) === $xml);
+	if (!$exact || !@chmod($tmp, 0600)) {
+		@unlink($tmp);
+		return FALSE;
+	}
+	$tmp_stat = @lstat($tmp);
+	if ($tmp_stat === FALSE
+		|| (($tmp_stat['mode'] & 0170000) !== 0100000)
+		|| (($tmp_stat['mode'] & 07777) !== 0600)
+		|| $tmp_stat['uid'] !== $expected_owner || !@rename($tmp, $slot)) {
+		@unlink($tmp);
+		return FALSE;
+	}
+	clearstatcache(TRUE, $slot);
+	$slot_stat = @lstat($slot);
+	return $slot_stat !== FALSE
+		&& (($slot_stat['mode'] & 0170000) === 0100000)
+		&& (($slot_stat['mode'] & 07777) === 0600)
+		&& $slot_stat['uid'] === $expected_owner
+		&& @file_get_contents($slot) === $xml;
+}
+
+function pfb_settings_family_replace(string $family): bool
+{
+	if (!isset(PFB_SETTINGS_FAMILY_RANK[$family])) {
+		return FALSE;
+	}
+	global $pfb;
+	$root = (string) ($pfb['dbdir'] ?? '/var/db/pfblockerng');
+	$effective_owner = function_exists('posix_geteuid') ? posix_geteuid() : 0;
+	$expected_owner = ($root === '/var/db/pfblockerng') ? 0 : $effective_owner;
+	$slot = $root . '/settings-' . $family . '.xml';
+	$slot_stat = @lstat($slot);
+	if ($slot_stat === FALSE) {
+		return TRUE;
+	}
+	$root_stat = @lstat($root);
+	if ($root_stat === FALSE || is_link($root) || (($root_stat['mode'] & 0170000) !== 0040000)
+		|| (($root_stat['mode'] & 0022) !== 0) || $root_stat['uid'] !== $expected_owner
+		|| (($slot_stat['mode'] & 0170000) !== 0100000)
+		|| is_link($slot) || (($slot_stat['mode'] & 07777) !== 0600)
+		|| $slot_stat['uid'] !== $expected_owner) {
+		return FALSE;
+	}
+	$parsed = NULL;
+	if (function_exists('parse_xml_config')) {
+		$parsed = parse_xml_config($slot, 'pfblockerng-settings');
+	} else {
+		$doc = @simplexml_load_file($slot, 'SimpleXMLElement', LIBXML_NONET | LIBXML_NOBLANKS);
+		if ($doc !== FALSE && $doc->getName() === 'pfblockerng-settings') {
+			$parsed = [
+				'family'  => (string) ($doc->family ?? ''),
+				'payload' => (string) ($doc->payload ?? ''),
+			];
+		}
+	}
+	if (!is_array($parsed)
+		|| !isset($parsed['family'], $parsed['payload'])
+		|| !is_string($parsed['family'])
+		|| $parsed['family'] !== $family
+		|| !is_string($parsed['payload'])) {
+		return FALSE;
+	}
+	$encoded = base64_decode($parsed['payload'], TRUE);
+	if ($encoded === FALSE) {
+		return FALSE;
+	}
+	try {
+		$owned = @unserialize($encoded, ['allowed_classes' => FALSE]);
+	} catch (Throwable) {
+		return FALSE;
+	}
+	if (!is_array($owned) || $owned === []) {
+		return FALSE;
+	}
+	foreach ($owned as $section => $_value) {
+		if (!is_string($section) || !str_starts_with($section, 'pfblockerng')) {
+			return FALSE;
+		}
+	}
+	$validate_value = static function (mixed $value, array &$active_references) use (&$validate_value): bool {
+		if (!is_array($value)) {
+			return is_scalar($value) || $value === NULL;
+		}
+		foreach ($value as $key => $nested) {
+			$reference = ReflectionReference::fromArrayElement($value, $key);
+			if ($reference !== NULL) {
+				$reference_id = $reference->getId();
+				if (isset($active_references[$reference_id])) {
+					return FALSE;
+				}
+				$active_references[$reference_id] = TRUE;
+				$valid = $validate_value($nested, $active_references);
+				unset($active_references[$reference_id]);
+				if (!$valid) {
+					return FALSE;
+				}
+			} elseif (!$validate_value($nested, $active_references)) {
+				return FALSE;
+			}
+		}
+		return TRUE;
+	};
+	$active_references = [];
+	if (!$validate_value($owned, $active_references)) {
+		return FALSE;
+	}
+	$installed = config_get_path('installedpackages', []);
+	if (!is_array($installed)) {
+		$installed = [];
+	}
+	$rebuilt = [];
+	$owned_sections = array_keys($owned);
+	$owned_index = 0;
+	foreach ($installed as $section => $value) {
+		if (str_starts_with((string) $section, 'pfblockerng')) {
+			if (isset($owned_sections[$owned_index])) {
+				$owned_section = $owned_sections[$owned_index++];
+				$rebuilt[$owned_section] = $owned[$owned_section];
+				unset($owned[$owned_section]);
+			}
+			continue;
+		}
+		$rebuilt[$section] = $value;
+	}
+	foreach ($owned as $section => $value) {
+		$rebuilt[$section] = $value;
+	}
+	// Whole-tree write deliberately bypasses field adapters so unknown and empty snapshot values,
+	// along with owned-section ordering, are restored exactly.
+	config_set_path('installedpackages', $rebuilt);
+	write_config('pfBlockerNG: restore settings family');
+	return TRUE;
+}
+
+function pfb_settings_family_record(string $family): bool
+{
+	if (!isset(PFB_SETTINGS_FAMILY_RANK[$family])) {
+		return FALSE;
+	}
+	try {
+		PfbConfig::write('settings_family', $family);
+		write_config('pfBlockerNG: record settings family');
+		return TRUE;
+	} catch (Throwable) {
+		return FALSE;
+	}
+}
+
+function pfb_settings_downgrade_context_target(string $current_family): ?string
+{
+	if (!isset(PFB_SETTINGS_FAMILY_RANK[$current_family])) {
+		return NULL;
+	}
+	global $pfb;
+	$override = isset($pfb['downgrade_context_path']);
+	$path = $override ? (string) $pfb['downgrade_context_path'] : '/var/run/pfblockerng-downgrade-context.json';
+	$stat = $path === '' ? FALSE : @lstat($path);
+	if ($stat === FALSE || (($stat['mode'] & 0170000) !== 0100000)
+		|| (($stat['mode'] & 07777) !== 0600)) {
+		return NULL;
+	}
+	$owner = @fileowner($path);
+	if ((!$override && $owner !== 0) || ($override && function_exists('posix_geteuid') && $owner !== posix_geteuid())) {
+		return NULL;
+	}
+	$size = @filesize($path);
+	if ($size === FALSE || $size > 512) {
+		return NULL;
+	}
+	$raw = @file_get_contents($path);
+	if (!is_string($raw)) {
+		return NULL;
+	}
+	try {
+		$context = json_decode($raw, TRUE, 512, JSON_THROW_ON_ERROR);
+	} catch (Throwable) {
+		return NULL;
+	}
+	$keys = is_array($context) ? array_keys($context) : [];
+	sort($keys);
+	if (!is_array($context)
+		|| $keys !== ['created_at', 'source_family', 'target_family', 'version']
+		|| !isset($context['version'], $context['source_family'], $context['target_family'], $context['created_at'])
+		|| $context['version'] !== 1
+		|| !is_string($context['source_family'])
+		|| !is_string($context['target_family'])
+		|| !is_int($context['created_at'])
+		|| $context['source_family'] !== $current_family
+		|| !isset(PFB_SETTINGS_FAMILY_RANK[$context['source_family']])
+		|| !isset(PFB_SETTINGS_FAMILY_RANK[$context['target_family']])) {
+		return NULL;
+	}
+	$now = time();
+	if ($context['created_at'] > $now || $now - $context['created_at'] > 300
+		|| PFB_SETTINGS_FAMILY_RANK[$context['target_family']]
+			>= PFB_SETTINGS_FAMILY_RANK[$context['source_family']]) {
+		return NULL;
+	}
+	return $context['target_family'];
+}
+
+function pfb_settings_downgrade_context_consume(): void
+{
+	global $pfb;
+	$path = isset($pfb['downgrade_context_path'])
+		? (string) $pfb['downgrade_context_path']
+		: '/var/run/pfblockerng-downgrade-context.json';
+	$stat = $path === '' ? FALSE : @lstat($path);
+	if ($stat !== FALSE && (($stat['mode'] & 0170000) === 0100000)) {
+		@unlink($path);
+	}
+}
+
+function pfb_settings_family_pre_uninstall(): void
+{
+	$current_family = pfb_settings_family_current();
+	if ($current_family === NULL) {
+		pfb_settings_downgrade_context_consume();
+		throw new RuntimeException('pfBlockerNG: settings-family marker invalid');
+	}
+	if (!pfb_settings_family_save($current_family)) {
+		pfb_settings_downgrade_context_consume();
+		throw new RuntimeException('pfBlockerNG: settings-family snapshot failed');
+	}
+	$restore_family = pfb_settings_downgrade_context_target($current_family);
+	if ($restore_family !== NULL && !pfb_settings_family_replace($restore_family)) {
+		pfb_settings_downgrade_context_consume();
+		throw new RuntimeException('pfBlockerNG: settings-family restore failed');
+	}
+	pfb_settings_downgrade_context_consume();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -26,6 +26,21 @@ require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 global $g, $pfb;
 pfb_global();
 
+// Capture the surviving live source family before restoring the package target family. Missing
+// markers resolve to the legacy 3.2 family through PfbConfig's registered default.
+$pfb_source_family = pfb_settings_family_current();
+if ($pfb_source_family === NULL || !pfb_settings_family_save($pfb_source_family)) {
+	throw new RuntimeException('pfBlockerNG: unable to save source settings family');
+}
+
+// Restore exact-family settings before legacy migrations read their sections. Missing slot is a
+// valid fresh install; unsupported package versions or corrupt slots fail closed.
+$pfb_installed_family = pfb_settings_family_from_version((string) pfb_pkg_ver());
+if ($pfb_installed_family === NULL || !pfb_settings_family_replace($pfb_installed_family)) {
+	throw new RuntimeException('pfBlockerNG: unable to restore settings family');
+}
+pfb_global();
+
 // Set 'Install flag' to skip sync process during installations.
 $g['pfblockerng_install'] = TRUE;
 
@@ -117,6 +132,10 @@ if (
 // writes back and calls write_config() only when a change is needed. Replaces the four
 // hand-wired blocks (ADR-02, PFBL-03, ADR-22, issue #281) with a single ordered registry.
 pfb_run_migrations();
+
+if (!pfb_settings_family_record($pfb_installed_family)) {
+	throw new RuntimeException('pfBlockerNG: unable to record settings family');
+}
 
 // MaxMind Database is no longer pre-installed during package installation
 if (empty($pfb['maxmind_key'])) {

--- a/tests/php/PfbSettingsFamilyIntegrityTest.php
+++ b/tests/php/PfbSettingsFamilyIntegrityTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class PfbSettingsFamilyIntegrityTest extends TestCase
+{
+	private string $root;
+
+	protected function setUp(): void
+	{
+		$this->root = sys_get_temp_dir() . '/pfb_family_integrity_' . bin2hex(random_bytes(5));
+		mkdir($this->root, 0700, TRUE);
+		$GLOBALS['pfb']['dbdir'] = $this->root;
+		$GLOBALS['config'] = [
+			'installedpackages' => [
+				'pfblockerng' => ['config' => ['0' => ['credential' => 'snapshot']]],
+				'pfblockerngglobal' => ['config' => ['0' => ['marker' => 'snapshot']]],
+				'otherpackage' => ['config' => ['0' => ['marker' => 'keep']]],
+			],
+		];
+	}
+
+	protected function tearDown(): void
+	{
+		$this->removeTree($this->root);
+	}
+
+	public function testSaveRejectsGroupOrWorldWritableDbdir(): void
+	{
+		chmod($this->root, 0777);
+
+		$this->assertFalse(pfb_settings_family_save('3.2'));
+		$this->assertFileDoesNotExist($this->root . '/settings-3.2.xml');
+	}
+
+	public function testReplaceRejectsGroupOrWorldWritableDbdir(): void
+	{
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		chmod($this->root, 0777);
+		$GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential'] = 'live';
+
+		$this->assertFalse(pfb_settings_family_replace('3.2'));
+		$this->assertSame('live', $GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential']);
+	}
+
+	public function testReplaceRestoresSnapshotOwnedOrderAroundUnrelatedEntries(): void
+	{
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		$GLOBALS['config']['installedpackages'] = [
+			'pfblockerngglobal' => ['config' => ['0' => ['marker' => 'live-global']]],
+			'otherpackage' => ['config' => ['0' => ['marker' => 'keep']]],
+			'pfblockerng' => ['config' => ['0' => ['credential' => 'live']]],
+		];
+
+		$this->assertTrue(pfb_settings_family_replace('3.2'));
+		$this->assertSame(
+			['pfblockerng', 'otherpackage', 'pfblockerngglobal'],
+			array_keys($GLOBALS['config']['installedpackages'])
+		);
+		$this->assertSame('keep', $GLOBALS['config']['installedpackages']['otherpackage']['config']['0']['marker']);
+	}
+
+	private function removeTree(string $path): void
+	{
+		if (!is_dir($path)) {
+			return;
+		}
+		foreach (scandir($path) ?: [] as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+			$child = $path . '/' . $entry;
+			is_dir($child) && !is_link($child) ? $this->removeTree($child) : @unlink($child);
+		}
+		@rmdir($path);
+	}
+}

--- a/tests/php/PfbSettingsFamilyObjectSlotTest.php
+++ b/tests/php/PfbSettingsFamilyObjectSlotTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class PfbSettingsFamilyObjectSlotTest extends TestCase
+{
+	private string $root;
+
+	protected function setUp(): void
+	{
+		$this->root = sys_get_temp_dir() . '/pfb_family_object_' . bin2hex(random_bytes(5));
+		mkdir($this->root, 0700, TRUE);
+		$GLOBALS['pfb']['dbdir'] = $this->root;
+		$GLOBALS['config'] = [
+			'installedpackages' => [
+				'pfblockerng' => ['config' => ['0' => ['credential' => 'live']]],
+				'otherpackage' => ['config' => ['0' => ['marker' => 'keep']]],
+			],
+		];
+	}
+
+	protected function tearDown(): void
+	{
+		$this->removeTree($this->root);
+	}
+
+	public function testNestedObjectPayloadIsRejectedBeforeConfigMutation(): void
+	{
+		$payload = [
+			'pfblockerng' => ['config' => ['0' => ['credential' => 'snapshot', 'nested' => new stdClass()]]],
+		];
+		$encoded = base64_encode(serialize($payload));
+		$xml = '<pfblockerng-settings><family>3.2</family><payload>' . $encoded
+			. '</payload></pfblockerng-settings>';
+		$slot = $this->root . '/settings-3.2.xml';
+		file_put_contents($slot, $xml);
+		chmod($slot, 0600);
+		$before = $GLOBALS['config'];
+
+		$this->assertFalse(pfb_settings_family_replace('3.2'));
+		$this->assertSame($before, $GLOBALS['config']);
+	}
+
+	private function removeTree(string $path): void
+	{
+		if (!is_dir($path)) {
+			return;
+		}
+		foreach (scandir($path) ?: [] as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+			$child = $path . '/' . $entry;
+			is_dir($child) && !is_link($child) ? $this->removeTree($child) : @unlink($child);
+		}
+		@rmdir($path);
+	}
+}

--- a/tests/php/PfbSettingsFamilyPostInstallCaptureTest.php
+++ b/tests/php/PfbSettingsFamilyPostInstallCaptureTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class PfbSettingsFamilyPostInstallCaptureTest extends TestCase
+{
+	public function testPostInstallCapturesSourceBeforeTargetRestoreAndMigrations(): void
+	{
+		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc');
+		$this->assertIsString($source);
+		$start = strpos($source, 'global $g, $pfb;');
+		$source_current = strpos($source, '$pfb_source_family = pfb_settings_family_current();', $start);
+		$source_save = strpos($source, 'pfb_settings_family_save($pfb_source_family)', $start);
+		$target_current = strpos($source, '$pfb_installed_family = pfb_settings_family_from_version((string) pfb_pkg_ver());', $start);
+		$target_replace = strpos($source, 'pfb_settings_family_replace($pfb_installed_family)', $start);
+		$migrations = strpos($source, 'pfb_run_migrations();', $start);
+
+		$this->assertNotFalse($source_current);
+		$this->assertNotFalse($source_save);
+		$this->assertNotFalse($target_current);
+		$this->assertNotFalse($target_replace);
+		$this->assertNotFalse($migrations);
+		$this->assertStringContainsString('$pfb_source_family === NULL || !pfb_settings_family_save($pfb_source_family)', $source);
+		$this->assertLessThan($target_current, $source_current);
+		$this->assertLessThan($target_replace, $source_save);
+		$this->assertLessThan($migrations, $target_replace);
+	}
+}

--- a/tests/php/PfbSettingsFamilyTest.php
+++ b/tests/php/PfbSettingsFamilyTest.php
@@ -1,0 +1,304 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class PfbSettingsFamilyTest extends TestCase
+{
+	private string $root;
+
+	protected function setUp(): void
+	{
+		$this->root = sys_get_temp_dir() . '/pfb_family_' . bin2hex(random_bytes(5));
+		mkdir($this->root, 0700, TRUE);
+		$GLOBALS['pfb']['dbdir'] = $this->root;
+		$GLOBALS['pfb']['downgrade_context_path'] = $this->root . '/context.json';
+		$GLOBALS['config'] = [
+			'system' => ['hostname' => 'unchanged'],
+			'installedpackages' => [
+				'pfblockerng' => ['config' => ['0' => [
+					'pfb_keep' => 'off',
+					'credential' => 'secret-canary',
+					'empty' => [],
+				]]],
+				'pfblockerngglobal' => ['unknown_future' => ['nested' => ['value' => 'keep-me']]],
+				'otherpackage' => ['config' => ['untouched' => 'yes']],
+			],
+		];
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['pfb']['downgrade_context_path']);
+		$this->removeTree($this->root);
+	}
+
+	public function testMissingMarkerDefaultsToThreeTwoAndRecordUsesGateway(): void
+	{
+		$this->assertSame('3.2', pfb_settings_family_current());
+		$this->assertSame('3.2', PfbConfig::read('settings_family'));
+		$this->assertTrue(pfb_settings_family_record('4.0'));
+		$this->assertSame('4.0', pfb_settings_family_current());
+		$this->assertSame('4.0', PfbConfig::read('settings_family'));
+	}
+
+	public function testInvalidMarkerAndUnknownVersionFailClosed(): void
+	{
+		PfbConfig::write('settings_family', '9.0');
+		$this->assertNull(pfb_settings_family_current());
+		$this->assertSame('3.2', pfb_settings_family_from_version('3.2.0'));
+		$this->assertSame('4.0', pfb_settings_family_from_version('4.0.0'));
+		$this->assertSame('4.1', pfb_settings_family_from_version('4.1.0'));
+		$this->assertNull(pfb_settings_family_from_version('5.0.1'));
+	}
+
+	public function testSaveAndReplacePreserveOwnedSubtreeAndUnrelatedConfig(): void
+	{
+		$owned = [
+			'pfblockerng' => $GLOBALS['config']['installedpackages']['pfblockerng'],
+			'pfblockerngglobal' => $GLOBALS['config']['installedpackages']['pfblockerngglobal'],
+		];
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		$GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential'] = 'changed';
+		$GLOBALS['config']['installedpackages']['otherpackage']['config']['untouched'] = 'changed';
+		$this->assertTrue(pfb_settings_family_replace('3.2'));
+		$this->assertSame($owned['pfblockerng'], $GLOBALS['config']['installedpackages']['pfblockerng']);
+		$this->assertSame($owned['pfblockerngglobal'], $GLOBALS['config']['installedpackages']['pfblockerngglobal']);
+		$this->assertSame('changed', $GLOBALS['config']['installedpackages']['otherpackage']['config']['untouched']);
+		$this->assertSame('unchanged', $GLOBALS['config']['system']['hostname']);
+	}
+
+	public function testMissingSlotLeavesLiveConfigUntouched(): void
+	{
+		$before = $GLOBALS['config'];
+		$this->assertTrue(pfb_settings_family_replace('4.0'));
+		$this->assertSame($before, $GLOBALS['config']);
+	}
+
+	public function testRawDowngradeWithoutContextDoesNotReplaceV3(): void
+	{
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		$GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential'] = 'current-v4';
+		$this->assertNull(pfb_settings_downgrade_context_target('4.0'));
+		$this->assertSame('current-v4', $GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential']);
+	}
+
+	public function testValidGuiContextRestoresExactLowerSlotAndConsumes(): void
+	{
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		$GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential'] = 'current-v4';
+		$this->writeContext(['version' => 1, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time()]);
+		$this->assertSame('3.2', pfb_settings_downgrade_context_target('4.0'));
+		$this->assertTrue(pfb_settings_family_replace('3.2'));
+		pfb_settings_downgrade_context_consume();
+		$this->assertFileDoesNotExist($this->contextPath());
+		$this->assertSame('secret-canary', $GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential']);
+	}
+
+	public function testInvalidContextsRejectAndRegularFilesAreConsumed(): void
+	{
+		$contexts = [
+			['version' => 2, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time()],
+			['version' => 1, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time() - 301],
+			['version' => 1, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time() + 1],
+			['version' => 1, 'source_family' => '3.2', 'target_family' => '3.2', 'created_at' => time()],
+			['version' => 1, 'source_family' => '4.0', 'target_family' => '4.0', 'created_at' => time()],
+			['version' => '1', 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time()],
+			['version' => 1, 'source_family' => ['4.0'], 'target_family' => '3.2', 'created_at' => time()],
+		];
+		foreach ($contexts as $context) {
+			$this->writeContext($context);
+			$this->assertNull(pfb_settings_downgrade_context_target('4.0'));
+			pfb_settings_downgrade_context_consume();
+			$this->assertFileDoesNotExist($this->contextPath());
+		}
+
+		file_put_contents($this->contextPath(), '{malformed');
+		chmod($this->contextPath(), 0600);
+		$this->assertNull(pfb_settings_downgrade_context_target('4.0'));
+		pfb_settings_downgrade_context_consume();
+		$this->assertFileDoesNotExist($this->contextPath());
+
+		$this->writeContext(['version' => 1, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time(), 'future' => TRUE]);
+		$this->assertNull(pfb_settings_downgrade_context_target('4.0'));
+		pfb_settings_downgrade_context_consume();
+		$this->assertFileDoesNotExist($this->contextPath());
+
+		file_put_contents($this->contextPath(), str_repeat('x', 513));
+		chmod($this->contextPath(), 0600);
+		$this->assertNull(pfb_settings_downgrade_context_target('4.0'));
+		pfb_settings_downgrade_context_consume();
+		$this->assertFileDoesNotExist($this->contextPath());
+
+		$this->writeContext(['version' => 1, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time()]);
+		chmod($this->contextPath(), 0644);
+		$this->assertNull(pfb_settings_downgrade_context_target('4.0'));
+		pfb_settings_downgrade_context_consume();
+		$this->assertFileDoesNotExist($this->contextPath());
+
+		$target = $this->root . '/context-target.json';
+		file_put_contents($target, '{}');
+		symlink($target, $this->contextPath());
+		$this->assertNull(pfb_settings_downgrade_context_target('4.0'));
+		pfb_settings_downgrade_context_consume();
+		$this->assertFileExists($this->contextPath());
+	}
+
+	public function testValidContextWithMissingTargetIsConsumedWithoutMutation(): void
+	{
+		$before = $GLOBALS['config'];
+		$this->writeContext(['version' => 1, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time()]);
+		$this->assertSame('3.2', pfb_settings_downgrade_context_target('4.0'));
+		$this->assertTrue(pfb_settings_family_replace('3.2'));
+		pfb_settings_downgrade_context_consume();
+		$this->assertSame($before, $GLOBALS['config']);
+		$this->assertFileDoesNotExist($this->contextPath());
+	}
+
+	public function testKeepOffIsPreservedAtLegacyBoundary(): void
+	{
+		$this->assertSame(PfbLenient::Off, PfbConfig::read('pfb_keep'));
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		$this->assertSame(PfbLenient::Off, PfbConfig::read('pfb_keep'));
+	}
+
+	public function testSaveWithNoOwnedConfigIsNoOpWithoutCreatingSlot(): void
+	{
+		foreach (array_keys($GLOBALS['config']['installedpackages']) as $section) {
+			if (str_starts_with((string) $section, 'pfblockerng')) {
+				unset($GLOBALS['config']['installedpackages'][$section]);
+			}
+		}
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		$this->assertFileDoesNotExist($this->root . '/settings-3.2.xml');
+	}
+
+	public function testSaveCreatesSecureSlotAndOverwritesExisting(): void
+	{
+		$rootMode = fileperms($this->root) & 0777;
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		$slot = $this->root . '/settings-3.2.xml';
+		$this->assertSame($rootMode, fileperms($this->root) & 0777);
+		$this->assertSame(0600, fileperms($slot) & 0777);
+		$first = file_get_contents($slot);
+		$GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential'] = 'overwrite-proof';
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		$second = file_get_contents($slot);
+		$this->assertNotSame($first, $second);
+	}
+
+	public function testCorruptSlotFailsWithoutMutatingLiveConfig(): void
+	{
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		$slot = $this->root . '/settings-3.2.xml';
+		file_put_contents($slot, 'corrupt');
+		chmod($slot, 0600);
+		$before = $GLOBALS['config'];
+		$this->assertFalse(pfb_settings_family_replace('3.2'));
+		$this->assertSame($before, $GLOBALS['config']);
+	}
+
+	public function testPreUninstallRawPathSavesCurrentFamilyWithoutRestoringLowerSlot(): void
+	{
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		$this->assertTrue(pfb_settings_family_record('4.0'));
+		$GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential'] = 'current-v4';
+		pfb_settings_family_pre_uninstall();
+		$this->assertFileExists($this->root . '/settings-4.0.xml');
+		$this->assertSame('current-v4', $GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential']);
+	}
+
+	public function testPreUninstallValidContextSavesCurrentRestoresLowerAndConsumes(): void
+	{
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		$this->assertTrue(pfb_settings_family_record('4.0'));
+		$GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential'] = 'current-v4';
+		$this->writeContext(['version' => 1, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time()]);
+		pfb_settings_family_pre_uninstall();
+		$this->assertFileExists($this->root . '/settings-4.0.xml');
+		$this->assertSame('secret-canary', $GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential']);
+		$this->assertFileDoesNotExist($this->contextPath());
+	}
+
+	public function testPreUninstallInvalidContextSavesOnlyAndConsumes(): void
+	{
+		$this->assertTrue(pfb_settings_family_save('3.2'));
+		$this->assertTrue(pfb_settings_family_record('4.0'));
+		$GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential'] = 'current-v4';
+		$this->writeContext(['version' => 2, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time()]);
+		pfb_settings_family_pre_uninstall();
+		$this->assertFileExists($this->root . '/settings-4.0.xml');
+		$this->assertSame('current-v4', $GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential']);
+		$this->assertFileDoesNotExist($this->contextPath());
+	}
+
+	public function testLifecycleOrdersReplaceAndContextConsumptionBeforeMigrations(): void
+	{
+		$install = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc');
+		$this->assertIsString($install);
+		$replace = strpos($install, 'pfb_settings_family_replace');
+		$migrations = strpos($install, 'pfb_run_migrations();');
+		$this->assertNotFalse($replace);
+		$this->assertNotFalse($migrations);
+		$this->assertLessThan($migrations, $replace);
+
+		$extra = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');
+		$this->assertIsString($extra);
+		$this->assertStringContainsString('/var/run/pfblockerng-downgrade-context.json', $extra);
+		$this->assertStringContainsString('pfb_settings_downgrade_context_consume', $extra);
+
+		$installed = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc');
+		$this->assertIsString($installed);
+		$installMigrations = strpos($installed, 'pfb_run_migrations();');
+		$installRecord = strpos($installed, 'pfb_settings_family_record');
+		$installReplace = strpos($installed, 'pfb_settings_family_replace');
+		$installFamily = strpos($installed, '$pfb_installed_family = pfb_settings_family_from_version((string) pfb_pkg_ver());');
+		$this->assertNotFalse($installFamily);
+		$this->assertNotFalse(strpos($installed, 'pfb_settings_family_replace($pfb_installed_family)'));
+		$this->assertNotFalse(strpos($installed, 'pfb_settings_family_record($pfb_installed_family)'));
+		$this->assertLessThan($installReplace, $installFamily);
+		$this->assertLessThan($installMigrations, $installReplace);
+		$this->assertLessThan($installRecord, $installMigrations);
+		$this->assertStringContainsString('installedpackages/pfblockerng', $installed);
+	}
+
+	public function testLifecycleSavePrecedesOperationAndConditionalRestore(): void
+	{
+		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
+		$this->assertIsString($source);
+		$start = strpos($source, 'function pfblockerng_php_pre_deinstall_command');
+		$pre = strpos($source, 'pfb_settings_family_pre_uninstall()', $start);
+		$operation = strpos($source, 'pfb_pkg_operation()', $start);
+		$this->assertNotFalse($start);
+		$this->assertNotFalse($pre);
+		$this->assertLessThan($operation, $pre);
+		$this->assertStringContainsString('Keep Settings', $source);
+	}
+
+	private function contextPath(): string
+	{
+		return $GLOBALS['pfb']['downgrade_context_path'];
+	}
+
+	private function writeContext(array $context): void
+	{
+		file_put_contents($this->contextPath(), json_encode($context, JSON_THROW_ON_ERROR));
+		chmod($this->contextPath(), 0600);
+	}
+
+	private function removeTree(string $path): void
+	{
+		if (!is_dir($path)) {
+			return;
+		}
+		foreach (scandir($path) ?: [] as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+			$child = $path . '/' . $entry;
+			is_dir($child) && !is_link($child) ? $this->removeTree($child) : @unlink($child);
+		}
+		@rmdir($path);
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -6515,6 +6515,86 @@
             }
         ]
     },
+    "pfb_settings_downgrade_context_consume": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": []
+    },
+    "pfb_settings_downgrade_context_target": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "current_family",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_settings_family_current": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": []
+    },
+    "pfb_settings_family_from_version": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "version",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_settings_family_pre_uninstall": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": []
+    },
+    "pfb_settings_family_record": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "family",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_settings_family_replace": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "family",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_settings_family_save": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "family",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_should_notify": {
         "returnsRef": false,
         "returnType": "bool",


### PR DESCRIPTION
## Summary

- save the surviving live configuration to its source-family slot at the start of POST-INSTALL
- restore only the installed target-family slot before migrations, leaving live configuration untouched when no target slot exists
- save current settings on PRE-UNINSTALL and restore a lower family only from a validated GUI downgrade context
- preserve existing Keep Settings behavior and fail closed on unsafe or corrupt snapshots
- require no FreeBSD-ports or frozen-v3 change

## Test plan

- test-first lifecycle, post-install ordering, permissions, symlink, malformed payload, and downgrade-context regressions
- `scripts/agent/run-gates.sh --diff origin/devel`
- independent standards and specification reviews

Closes #1675