### PR TITLE
dnsbl: keep regex INI transport base64

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 
+import base64
 import csv
 import errno
 import hashlib
@@ -502,36 +503,35 @@ def _build_swap_snapshot() -> Snapshot | None:
         config = ConfigParser()
         try:
             config.read(pfb["pfb_unbound.ini"])
-            if config.has_section("REGEX"):
-                r_count = 1
-                for name, pattern in config.items("REGEX"):
-                    if _regex_is_catastrophic_shape(pattern):
-                        sys.stderr.write(
-                            "[pfBlockerNG]: dropping pathological user regex [ {} ] pattern [ {} ] "
-                            "on line #{} (catastrophic shape)".format(name, pattern, r_count)
-                        )
-                        r_count += 1
-                        continue
-                    if pfb["regex_cap"] and len(pattern) > REGEX_STATIC_LEN_CAP:
-                        sys.stderr.write(
-                            "[pfBlockerNG]: dropping over-length user regex [ {} ] pattern [ {} ] "
-                            "on line #{} (static length cap)".format(name, pattern, r_count)
-                        )
-                        r_count += 1
-                        continue
-                    try:
-                        regex_db[name] = {
-                            "re": re.compile(pattern),
-                            "important": False,
-                            "band": PRIO_USER_BLOCK,
-                        }
-                    except Exception as e:
-                        sys.stderr.write(
-                            "[pfBlockerNG]: Regex [ {} ] compile error pattern [  {}  ] on line #{}: {}".format(
-                                name, pattern, r_count, e
-                            )
-                        )
+            r_count = 1
+            for name, pattern in _load_user_regex_entries(config):
+                if _regex_is_catastrophic_shape(pattern):
+                    sys.stderr.write(
+                        "[pfBlockerNG]: dropping pathological user regex [ {} ] pattern [ {} ] "
+                        "on line #{} (catastrophic shape)".format(name, pattern, r_count)
+                    )
                     r_count += 1
+                    continue
+                if pfb["regex_cap"] and len(pattern) > REGEX_STATIC_LEN_CAP:
+                    sys.stderr.write(
+                        "[pfBlockerNG]: dropping over-length user regex [ {} ] pattern [ {} ] "
+                        "on line #{} (static length cap)".format(name, pattern, r_count)
+                    )
+                    r_count += 1
+                    continue
+                try:
+                    regex_db[name] = {
+                        "re": re.compile(pattern),
+                        "important": False,
+                        "band": PRIO_USER_BLOCK,
+                    }
+                except Exception as e:
+                    sys.stderr.write(
+                        "[pfBlockerNG]: Regex [ {} ] compile error pattern [  {}  ] on line #{}: {}".format(
+                            name, pattern, r_count, e
+                        )
+                    )
+                r_count += 1
         except Exception as e:
             sys.stderr.write("[pfBlockerNG]: reload: failed to load user REGEX ini: {}".format(e))
 
@@ -1110,6 +1110,43 @@ def _load_ini_config() -> ConfigParser | None:
     return config
 
 
+def _load_user_regex_entries(config: ConfigParser) -> list[tuple[str, str]]:
+    """Load normalized user regex rows from MAIN.regex_list or legacy REGEX."""
+    if config.has_option("MAIN", "regex_list"):
+        encoded = config.get("MAIN", "regex_list", raw=True)
+        try:
+            text = base64.b64decode(encoded.encode("ascii"), validate=True).decode("utf-8")
+        except (UnicodeError, ValueError) as e:
+            sys.stderr.write("[pfBlockerNG]: Failed to decode MAIN.regex_list: {}".format(e))
+            return []
+
+        entries: list[tuple[str, str]] = []
+        names: set[str] = set()
+        row_number = 0
+        for line in re.split(r"[\r\n]+", text):
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            row_number += 1
+            pattern, separator, description = line.partition("#")
+            pattern = pattern.strip().lower()
+            if not pattern:
+                continue
+            if separator:
+                name = re.sub(r"\W", "", description.strip().replace(" ", "_"), flags=re.ASCII)
+            else:
+                name = "Regex_{}".format(row_number)
+            name = name.lower()
+            if name in names:
+                name = "{}_{}".format(name, row_number)
+            names.add(name)
+            entries.append((name, pattern))
+        return entries
+
+    if config.has_section("REGEX"):
+        return list(config.items("REGEX"))
+    return []
+
+
 def init_standard(id: int, env: module_env) -> bool:
     global \
         pfb, \
@@ -1570,55 +1607,41 @@ def init_standard(id: int, env: module_env) -> bool:
                 pfb["python_blacklist"] = True
 
             # Collect user-defined Regex patterns
-            if config.has_section("REGEX"):
-                regex_config = config.items("REGEX")
-                if regex_config:
-                    r_count = 1
-                    for name, pattern in regex_config:
-                        # ADR-07: a catastrophic SHAPE in the un-vetted USER regex
-                        # list is dropped at load UNCONDITIONALLY (logged, not compiled)
-                        # -- the always-on safety gate. The opt-in length ceiling (the
-                        # "Limit long/complex regex" setting) is the separate tunable
-                        # half: it drops over-length-but-safe user patterns only when on.
-                        if _regex_is_catastrophic_shape(pattern):
-                            sys.stderr.write(
-                                "[pfBlockerNG]: dropping pathological user regex [ {} ] pattern [ {} ] "
-                                "on line #{} (catastrophic shape)".format(name, pattern, r_count)
-                            )
-                            r_count += 1
-                            continue
-                        if pfb["regex_cap"] and len(pattern) > REGEX_STATIC_LEN_CAP:
-                            sys.stderr.write(
-                                "[pfBlockerNG]: dropping over-length user regex [ {} ] pattern [ {} ] "
-                                "on line #{} (static length cap)".format(name, pattern, r_count)
-                            )
-                            r_count += 1
-                            continue
-                        try:
-                            # ADR-07: a USER regex is SOVEREIGN -- band 5 (user block),
-                            # so it beats ANY feed allow (@@ band 2 / @@$important band 4),
-                            # matching the decision oracle's Provenance.USER block. Stored
-                            # as the {"re","important","band"} payload the matcher scores
-                            # via _block_entry_band; a bare compiled pattern would score the
-                            # feed-block band 1 and be overridden by a feed @@. ($badfilter-
-                            # immunity is inherent: user regex never enter the feed reconcile
-                            # rule list.) A user regex never loses to a feed allow, only to
-                            # the user whitelist (band 6) -- preserved by the fast path.
-                            regexDB[name] = {
-                                "re": re.compile(pattern),
-                                "important": False,
-                                "band": PRIO_USER_BLOCK,
-                            }
-                            pfb["regexDB"] = True
-                            pfb["python_blacklist"] = True
-                        except Exception as e:
-                            sys.stderr.write(
-                                "[pfBlockerNG]: Regex [ {} ] compile error pattern [  {}  ] on line #{}: {}".format(
-                                    name, pattern, r_count, e
-                                )
-                            )
-                            pass
-                        r_count += 1
+            r_count = 1
+            for name, pattern in _load_user_regex_entries(config):
+                # ADR-07: a catastrophic SHAPE in the un-vetted USER regex
+                # list is dropped at load UNCONDITIONALLY (logged, not compiled).
+                if _regex_is_catastrophic_shape(pattern):
+                    sys.stderr.write(
+                        "[pfBlockerNG]: dropping pathological user regex [ {} ] pattern [ {} ] "
+                        "on line #{} (catastrophic shape)".format(name, pattern, r_count)
+                    )
+                    r_count += 1
+                    continue
+                if pfb["regex_cap"] and len(pattern) > REGEX_STATIC_LEN_CAP:
+                    sys.stderr.write(
+                        "[pfBlockerNG]: dropping over-length user regex [ {} ] pattern [ {} ] "
+                        "on line #{} (static length cap)".format(name, pattern, r_count)
+                    )
+                    r_count += 1
+                    continue
+                try:
+                    # ADR-07: a USER regex is SOVEREIGN -- band 5 (user block),
+                    # so it beats feed allows and remains user-owned.
+                    regexDB[name] = {
+                        "re": re.compile(pattern),
+                        "important": False,
+                        "band": PRIO_USER_BLOCK,
+                    }
+                    pfb["regexDB"] = True
+                    pfb["python_blacklist"] = True
+                except Exception as e:
+                    sys.stderr.write(
+                        "[pfBlockerNG]: Regex [ {} ] compile error pattern [  {}  ] on line #{}: {}".format(
+                            name, pattern, r_count, e
+                        )
+                    )
+                r_count += 1
 
             # Collect user-defined no AAAA domains
             if config.has_section("noAAAA"):

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -497,8 +497,8 @@ def _build_swap_snapshot() -> Snapshot | None:
     regex_db: dict[str, Any] = dict(build_result.regex_db)
     allow_regex_db: dict[str, Any] = dict(build_result.allow_regex_db)
 
-    # USER REGEX-ini patterns (sovereign band) merged on top of the feed block-regex,
-    # mirroring init's REGEX-section load (incl. the opt-in static cap).
+    # USER regex patterns from MAIN.regex_list (legacy REGEX fallback) merged on top of
+    # the feed block-regex, mirroring init's load (incl. the opt-in static cap).
     if os.path.isfile(pfb["pfb_unbound.ini"]):
         config = ConfigParser()
         try:
@@ -1132,6 +1132,7 @@ def _load_user_regex_entries(config: ConfigParser) -> list[tuple[str, str]]:
             if not pattern:
                 continue
             if separator:
+                description = description.partition("#")[0]
                 name = re.sub(r"\W", "", description.strip().replace(" ", "_"), flags=re.ASCII)
             else:
                 name = "Regex_{}".format(row_number)

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1128,7 +1128,7 @@ def _load_user_regex_entries(config: ConfigParser) -> list[tuple[str, str]]:
                 continue
             row_number += 1
             pattern, separator, description = line.partition("#")
-            pattern = pattern.strip().lower()
+            pattern = pattern.strip().encode("utf-8").lower().decode("utf-8")
             if not pattern:
                 continue
             if separator:
@@ -1696,8 +1696,8 @@ def init_standard(id: int, env: module_env) -> bool:
                 feedGroupIndexDB = build_result.feed_group_index_db
                 whiteDB = build_result.white_db
 
-                # ADR-07: MERGE the ABP feed block-regex into regexDB (preserving the
-                # user-regex patterns compiled from the REGEX ini section above) and load
+                # ADR-07: MERGE the ABP feed block-regex into regexDB, preserving user-regex
+                # patterns compiled from MAIN.regex_list (legacy [REGEX] fallback) above, and load
                 # the @@/re/ allow-regex into allowRegexDB. Feed regex carry an explicit
                 # band + $important; user regex are the {re, band: PRIO_USER_BLOCK (5)}
                 # payload (sovereign over feed allows -- loaded above).
@@ -5260,7 +5260,7 @@ def build(
 
         # Irreducible regex -> regexDB (block) / allowRegexDB (allow). Compile here;
         # a broken pattern is logged + skipped, mirroring the init regex load
-        # (pfb_unbound.py REGEX section). The runtime warn/evict guard (ADR-07)
+        # (MAIN.regex_list, with legacy [REGEX] fallback). The runtime warn/evict guard (ADR-07)
         # applies later, at query time in evaluate_domain, not during this compile.
         # Iterate over a stable list so the emit order is deterministic.
         regex_db, block_admitted = _dnsbl_compile_regex_rules(result.block_regex_irreducible, static_cap=static_cap)

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9158,35 +9158,7 @@ forwarding	= {$forwarding}
 
 EOF;
 		if ($pfb['dnsbl_regex'] == 'on' && isset($pfb['dnsbl_regex_list']) && !empty($pfb['dnsbl_regex_list'])) {
-			$regex = '';
-			$regex_list = pfb_text_area_decode($pfb['dnsbl_regex_list'], TRUE, TRUE, FALSE);
-			if (!empty($regex_list)) {
-				$counter = 1;
-				$key_index = array();
-				foreach ($regex_list as $key => $list) {
-					if (!isset($list[1])) {
-						$list[1] = "Regex_{$counter}";
-					} else {
-						$list[1] = trim(ltrim($list[1], '#'));
-						$list[1] = preg_replace("/\W/", '', str_replace(' ', '_', $list[1]));
-					}
-
-					// Check if key exists
-					if (!isset($key_index[$list[1]])) {
-						$regex .= "{$list[1]} = {$list[0]}\n";
-						$key_index[$list[1]] = '';
-					} else {
-						$regex .= "{$list[1]}_{$counter} = {$list[0]}\n";
-						$key_index["{$list[1]}_{$counter}"] = '';
-					}
-					$counter++;
-				}
-				$pfb_py_conf .= <<<EOF
-
-[REGEX]
-{$regex}
-EOF;
-			}
+			$pfb_py_conf .= "regex_list = {$pfb['dnsbl_regex_list']}\n";
 		}
 
 		if ($pfb['dnsbl_noaaaa'] == 'on' && isset($pfb['dnsbl_noaaaa_list']) && !empty($pfb['dnsbl_noaaaa_list'])) {

--- a/tests/php/RegexIniTransportTest.php
+++ b/tests/php/RegexIniTransportTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** Issue #1718: regex textarea stays opaque base64 through the PHP INI writer. */
+final class RegexIniTransportTest extends TestCase
+{
+	private const SRC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+
+	private function functionBody(string $name): string
+	{
+		$source = file_get_contents(self::SRC);
+		$this->assertNotFalse($source, 'failed to read pfblockerng.inc');
+		$start = strpos($source, "\nfunction {$name}(");
+		$this->assertNotFalse($start, "function {$name}() not found");
+		$start++;
+		$open = strpos($source, '{', $start);
+		$this->assertNotFalse($open, "opening brace missing for {$name}()");
+		$depth = 0;
+		for ($i = $open, $len = strlen($source); $i < $len; $i++) {
+			if ($source[$i] === '{') {
+				$depth++;
+			} elseif ($source[$i] === '}') {
+				$depth--;
+				if ($depth === 0) {
+					return substr($source, $start, $i - $start + 1);
+				}
+			}
+		}
+		$this->fail("closing brace missing for {$name}()");
+	}
+
+	public function testWriterEmitsStoredRegexBlobUnderMainWithoutDecode(): void
+	{
+		$body = $this->functionBody('pfb_unbound_python');
+		$this->assertMatchesRegularExpression(
+			'/regex_list\s*=\s*\{\$pfb\[\'dnsbl_regex_list\'\]\}/',
+			$body,
+			'PHP must emit the stored base64 blob as MAIN.regex_list'
+		);
+		$this->assertDoesNotMatchRegularExpression(
+			'/pfb_text_area_decode\(\$pfb\[\'dnsbl_regex_list\'\]/',
+			$body,
+			'PHP must not decode or re-encode the regex blob'
+		);
+	}
+
+	public function testWriterDoesNotGenerateLegacyRegexSection(): void
+	{
+		$body = $this->functionBody('pfb_unbound_python');
+		$this->assertDoesNotMatchRegularExpression(
+			'/\[REGEX\]/',
+			$body,
+			'new writer must not emit plaintext legacy REGEX entries'
+		);
+	}
+}

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1356,12 +1356,10 @@ def _b64_textarea(lines: list[str]) -> str:
     """Base64-encode a CRLF-joined textarea value — the shape pfBlockerNG stores.
 
     pfBlockerNG TEXTAREA settings (``suppression``, ``pfb_regex_list``, ``custom``, …)
-    are kept base64-encoded in config (the GUI base64_encodes on save) and decoded by
-    ``pfb_text_area_decode()`` (``base64_decode`` then ``explode("\\r\\n", …)``). A
-    PLAIN value injected here would be base64_decoded into GARBAGE — invalid bytes that
-    crash the python module's INI load (``Failed to load ini configuration: 'utf-8'
-    codec can't decode byte``) and silently disable DNSBL. Encode with CRLF separators
-    so the decode splits into the right lines. Empty list -> '' (no entries)."""
+    are kept base64-encoded in config (the GUI base64_encodes on save). Python regex
+    transport decodes ``pfb_regex_list`` from MAIN.regex_list; other textareas use
+    ``pfb_text_area_decode()``. Encode with CRLF separators so every consumer sees
+    the intended rows. Empty list -> '' (no entries)."""
     return base64.b64encode("\r\n".join(lines).encode()).decode()
 
 
@@ -3018,9 +3016,9 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
         settings["action"] = spec.dnsbl_ip_action
     if spec.user_regex:
         # The user "Python Regex List" (inc:849-850,2711). pfb_regex must be 'on' AND
-        # pfb_regex_list non-empty for the [REGEX] ini section to be written. Like
-        # suppression it is a base64 TEXTAREA field — a PLAIN value decodes to garbage
-        # and crashes the ini load. User regex are sovereign block patterns (band 5).
+        # pfb_regex_list non-empty for MAIN.regex_list to be written. The value remains
+        # a base64 TEXTAREA payload; Python decodes it at the shared INI boundary.
+        # User regex are sovereign block patterns (band 5).
         settings["pfb_regex"] = "on"
         settings["pfb_regex_list"] = _b64_textarea(spec.user_regex)
     if spec.regex_cap:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3015,10 +3015,9 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
         # from CFG_DNSBL_SETTINGS/action; != 'Disabled' enables it).
         settings["action"] = spec.dnsbl_ip_action
     if spec.user_regex:
-        # The user "Python Regex List" (inc:849-850,2711). pfb_regex must be 'on' AND
-        # pfb_regex_list non-empty for MAIN.regex_list to be written. The value remains
-        # a base64 TEXTAREA payload; Python decodes it at the shared INI boundary.
-        # User regex are sovereign block patterns (band 5).
+        # User "Python Regex List" is emitted only when pfb_regex=on and
+        # pfb_regex_list is non-empty; value remains a base64 MAIN.regex_list payload
+        # decoded by Python at the shared INI boundary (sovereign block, band 5).
         settings["pfb_regex"] = "on"
         settings["pfb_regex_list"] = _b64_textarea(spec.user_regex)
     if spec.regex_cap:

--- a/tests/test_adr10_concurrency.py
+++ b/tests/test_adr10_concurrency.py
@@ -43,6 +43,7 @@ repo's branch + before/after coverage rules.
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import subprocess
@@ -340,9 +341,8 @@ def _manifest_json(tld_master: str, plain_raw: str, user_raw: str, abp_raw: str,
 def _ini_text(spec: GenSpec) -> str:
     lines = ["[MAIN]", ""]
     if spec.ini_regex:
-        lines.append("[REGEX]")
-        for i, pat in enumerate(spec.ini_regex):
-            lines.append("r{} = {}".format(i, pat))
+        payload = base64.b64encode("\r\n".join(spec.ini_regex).encode("utf-8")).decode("ascii")
+        lines.append("regex_list = {}".format(payload))
     return "\n".join(lines) + "\n"
 
 

--- a/tests/test_adr10_concurrency.py
+++ b/tests/test_adr10_concurrency.py
@@ -25,7 +25,7 @@ BLOCK (gen1 blocked, gen2 allowed -- except the per-mechanism CONTROL, still blo
   m3 abp anchored    -> dataDB  band 1  (||sub.d.com^, 3-part -> DATA)
   m4 abp regex       -> regexDB band 1  (irreducible /re/)
   m5 abp $important  -> dataDB  band 3  (||sub.d.com^$important)
-  m6 user regex      -> regexDB band 5  (ini [REGEX] pattern -- lives in the ini)
+  m6 user regex      -> regexDB band 5  (base64 MAIN.regex_list row -- lives in the ini)
   m7 user block      -> dataDB  band 5  (feed provenance=user, plain exact line)
 ALLOW (gen1 allowed via an allow out-ranking a co-listed block; gen2 blocked -- except
 the per-mechanism CONTROL, still allowed):
@@ -113,7 +113,7 @@ LANES_BLOCK: dict[str, Lane] = {
     "m4_abpre": Lane("m4_abpre", _stems("m4abpre", _N_FLIP), "m4abprectl"),
     # m5 abp $important (DATA band 3): ||sub.d.com^$important, 3-part -> DATA.
     "m5_imp": Lane("m5_imp", _d3("m5imp", _N_FLIP), _d3_ctl("m5imp")),
-    # m6 user regex (regexDB band 5): ini [REGEX] (probe = <stem>7.com).
+    # m6 user regex (regexDB band 5): base64 MAIN.regex_list row (probe = <stem>7.com).
     "m6_userre": Lane("m6_userre", _stems("m6userre", _N_FLIP), "m6userrectl"),
     # m7 user block (DATA band 5): feed provenance=user, plain exact 3-part line -> DATA.
     "m7_userblk": Lane("m7_userblk", _d3("m7ublk", _N_FLIP), _d3_ctl("m7ublk")),
@@ -152,7 +152,7 @@ def _abp_regex_line(stem: str, *, allow: bool, important: bool) -> str:
 
 
 def _ini_regex_pattern(stem: str) -> str:
-    # User-regex (ini [REGEX]) -- irreducible, matches ``<stem><digit>.com``.
+    # User-regex row encoded in MAIN.regex_list -- irreducible, matches ``<stem><digit>.com``.
     return "{}[0-9]\\.com".format(stem)
 
 
@@ -165,7 +165,7 @@ class GenSpec:
     abp_feed: list[str]  # ABP feed lines (m3/m4/m5 + allow lanes a11/a12/a13)
     user_whitelist: list[str]  # config.user_whitelist (a9)
     user_unlock: list[str]  # config.user_unlock (a10)
-    ini_regex: list[str]  # ini [REGEX] patterns (m6)
+    ini_regex: list[str]  # MAIN.regex_list patterns before base64 encoding (m6)
 
 
 def _gen1_spec() -> GenSpec:

--- a/tests/test_issue1718_empty_regex_transport.py
+++ b/tests/test_issue1718_empty_regex_transport.py
@@ -1,0 +1,39 @@
+"""Issue #1718: an empty MAIN regex marker is authoritative."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import unboundmodule
+
+import pfb_unbound as P
+
+
+def _write_manifest(path: Path) -> None:
+    path.write_text('{"version": 1, "config": {}, "feeds": []}\n', encoding="utf-8")
+
+
+def test_empty_main_regex_marker_does_not_fall_back_to_legacy(tmp_path: Path, monkeypatch: Any) -> None:
+    """An explicitly empty MAIN blob disables stale legacy regex entries everywhere."""
+    (tmp_path / "pfb_unbound.ini").write_text(
+        "[MAIN]\npython_enable = true\nregex_list = \n[REGEX]\nlegacy = stale\n",
+        encoding="utf-8",
+    )
+    _write_manifest(tmp_path / "pfb_py_sources.json")
+    monkeypatch.chdir(tmp_path)
+    P.pfb["mod_maxminddb_e"] = "stub"
+    P.pfb["mod_threading_e"] = "stub"
+    P.pfb["mod_sqlite3_e"] = "stub"
+    P.pfb["mod_sqlite3"] = False
+    P.pfb["mod_threading"] = False
+
+    try:
+        assert P.init_standard(0, unboundmodule.module_env()) is True
+        assert dict(P.regexDB) == {}
+
+        swapped = P._build_swap_snapshot()
+        assert swapped is not None
+        assert swapped.regex_db == {}
+    finally:
+        P.deinit(0)

--- a/tests/test_issue1718_regex_ascii_lower_compat.py
+++ b/tests/test_issue1718_regex_ascii_lower_compat.py
@@ -1,0 +1,24 @@
+"""Issue #1718: preserve PHP ASCII-only regex lowercasing."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any
+
+import pfb_unbound as P
+from tests.test_issue1718_regex_transport import _ini, _initial_load
+
+
+def test_user_regex_lowercase_matches_php_ascii_semantics(tmp_path: Path, monkeypatch: Any) -> None:
+    encoded = base64.b64encode("ÄBC#Name\n".encode("utf-8")).decode("ascii")
+
+    try:
+        _initial_load(tmp_path, monkeypatch, _ini(encoded))
+        assert P.regexDB["name"]["re"].pattern == "Äbc"
+
+        swapped = P._build_swap_snapshot()
+        assert swapped is not None
+        assert swapped.regex_db["name"]["re"].pattern == "Äbc"
+    finally:
+        P.deinit(0)

--- a/tests/test_issue1718_regex_description_compat.py
+++ b/tests/test_issue1718_regex_description_compat.py
@@ -1,0 +1,26 @@
+"""Issue #1718: preserve legacy regex description name semantics."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any
+
+import pfb_unbound as P
+from tests.test_issue1718_regex_transport import _ini, _initial_load
+
+
+def test_extra_hash_in_description_is_not_part_of_regex_name(tmp_path: Path, monkeypatch: Any) -> None:
+    encoded = base64.b64encode(b"alpha#Foo#Bar\n").decode("ascii")
+
+    try:
+        _initial_load(tmp_path, monkeypatch, _ini(encoded))
+        assert set(P.regexDB) == {"foo"}
+        assert P.regexDB["foo"]["re"].pattern == "alpha"
+
+        swapped = P._build_swap_snapshot()
+        assert swapped is not None
+        assert set(swapped.regex_db) == {"foo"}
+        assert swapped.regex_db["foo"]["re"].pattern == "alpha"
+    finally:
+        P.deinit(0)

--- a/tests/test_issue1718_regex_transport.py
+++ b/tests/test_issue1718_regex_transport.py
@@ -1,0 +1,93 @@
+"""Issue #1718: opaque base64 regex transport reaches both Python load sites."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any
+
+import unboundmodule
+
+import pfb_unbound as P
+
+
+def _manifest(path: Path) -> None:
+    path.write_text(
+        '{"version": 1, "config": {}, "feeds": []}\n',
+        encoding="utf-8",
+    )
+
+
+def _ini(payload: str, *, legacy: str = "") -> str:
+    body = "[MAIN]\npython_enable = true\nregex_list = {}\n".format(payload)
+    if payload == "__ABSENT__":
+        body = "[MAIN]\npython_enable = true\n"
+    if legacy:
+        body += "[REGEX]\nlegacy = {}\n".format(legacy)
+    return body
+
+
+def _initial_load(tmp_path: Path, monkeypatch: Any, ini_body: str) -> None:
+    (tmp_path / "pfb_unbound.ini").write_text(ini_body, encoding="utf-8")
+    _manifest(tmp_path / "pfb_py_sources.json")
+    monkeypatch.chdir(tmp_path)
+    P.pfb["mod_maxminddb_e"] = "stub"
+    P.pfb["mod_threading_e"] = "stub"
+    P.pfb["mod_sqlite3_e"] = "stub"
+    P.pfb["mod_sqlite3"] = False
+    P.pfb["mod_threading"] = False
+    assert P.init_standard(0, unboundmodule.module_env()) is True
+
+
+def test_initial_load_decodes_base64_rows_and_preserves_names(tmp_path: Path, monkeypatch: Any) -> None:
+    text = '# full comment\r\n A%=:;"\\D#Foo desc \nB%=:;"\\D#Foo desc\n unnamed#Inline description\rblank\r\n'
+    encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    try:
+        _initial_load(tmp_path, monkeypatch, _ini(encoded))
+        assert set(P.regexDB) == {"foo_desc", "foo_desc_2", "inline_description", "regex_4"}
+        assert P.regexDB["foo_desc"]["re"].pattern == 'a%=:;"\\d'
+        assert P.regexDB["foo_desc_2"]["re"].pattern == 'b%=:;"\\d'
+        assert P.regexDB["inline_description"]["re"].pattern == "unnamed"
+        assert P.regexDB["regex_4"]["re"].pattern == "blank"
+    finally:
+        P.deinit(0)
+
+
+def test_swap_load_matches_initial_and_ignores_legacy_when_marker_present(tmp_path: Path, monkeypatch: Any) -> None:
+    text = "alpha#Description\r\nbeta\n"
+    encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    ini = tmp_path / "pfb_unbound.ini"
+    manifest = tmp_path / "pfb_py_sources.json"
+    _manifest(manifest)
+    ini.write_text(_ini(encoded, legacy="stale"), encoding="utf-8")
+    monkeypatch.setitem(P.pfb, "pfb_unbound.ini", str(ini))
+    monkeypatch.setitem(P.pfb, "pfb_py_sources", str(manifest))
+    initial = None
+    try:
+        _initial_load(tmp_path, monkeypatch, _ini(encoded, legacy="stale"))
+        initial = {name: entry["re"].pattern for name, entry in P.regexDB.items()}
+        swapped = P._build_swap_snapshot()
+        assert swapped is not None
+        assert {name: entry["re"].pattern for name, entry in swapped.regex_db.items()} == initial
+        assert "stale" not in swapped.regex_db
+    finally:
+        P.deinit(0)
+
+
+def test_present_malformed_or_non_utf8_marker_fails_closed_without_legacy_fallback(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    for payload in ("%%%", base64.b64encode(b"\xff").decode("ascii")):
+        try:
+            _initial_load(tmp_path, monkeypatch, _ini(payload, legacy="old"))
+            assert P.regexDB == {}, "marker failure must not load stale legacy entries"
+        finally:
+            P.deinit(0)
+
+
+def test_absent_marker_keeps_legacy_read_compatibility(tmp_path: Path, monkeypatch: Any) -> None:
+    try:
+        _initial_load(tmp_path, monkeypatch, _ini("__ABSENT__", legacy="old"))
+        assert P.regexDB["legacy"]["re"].pattern == "old"
+    finally:
+        P.deinit(0)


### PR DESCRIPTION
## Summary

- keep the DNSBL regex textarea base64-encoded through PHP INI transport
- strictly decode and validate the payload in Python
- preserve legacy regex parsing, naming, fallback, startup, and swap semantics
- update test INI producers to use `MAIN.regex_list`

## Testing

- red-proof verifier: four frozen tests RED against `5d48b336`, GREEN at HEAD
- focused Python: 7 passed
- focused PHPUnit: 2 tests, 9 assertions
- canonical gates: pytest, ruff, format, mypy, PHP lint, PHPUnit, PHPStan, PHPCS
- live VM user-regex smoke: skipped because no VM was available

Fixes #1718

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for transporting custom DNSBL regex patterns through the main configuration.
  * Regex names and patterns are normalized, deduplicated, and safely compiled.
  * Blank, comment, malformed, and unsafe patterns are handled without interrupting initialization.

* **Bug Fixes**
  * Prevented stale or legacy regex entries from being used when an explicit regex list is provided.
  * Preserved compatibility with configurations that do not provide the new regex list format.

* **Tests**
  * Added coverage for encoding, empty lists, malformed data, naming compatibility, and swap loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->