### PR TITLE
dnsbl: strip and bind strings once in hot parse paths

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1005,7 +1005,7 @@ def parse_tld_allow(raw: str) -> list[str]:
     against the lowercased qname label (RFC 4343) -- so normalise the config side
     at the same read boundary.
     """
-    return [t.strip().lower() for t in raw.split(",") if t.strip()]
+    return [t.lower() for t in (part.strip() for part in raw.split(",")) if t]
 
 
 def _parse_ini_int(config: ConfigParser, section: str, option: str) -> int | None:
@@ -1124,11 +1124,12 @@ def _load_user_regex_entries(config: ConfigParser) -> list[tuple[str, str]]:
         names: set[str] = set()
         row_number = 0
         for line in re.split(r"[\r\n]+", text):
-            if not line.strip() or line.lstrip().startswith("#"):
+            line = line.strip()
+            if not line or line.startswith("#"):
                 continue
             row_number += 1
             pattern, separator, description = line.partition("#")
-            pattern = pattern.strip().encode("utf-8").lower().decode("utf-8")
+            pattern = pattern.rstrip().encode("utf-8").lower().decode("utf-8")
             if not pattern:
                 continue
             if separator:
@@ -2247,10 +2248,11 @@ def idn_confusable_action(
 def get_q_name_qstate(qstate: module_qstate | None) -> str:
     q_name = ""
     try:
-        if qstate and qstate.qinfo and qstate.qinfo.qname_str and qstate.qinfo.qname_str.strip():
-            q_name = qstate.qinfo.qname_str.rstrip(".")
-        elif qstate and qstate.return_msg and qstate.return_msg.qinfo and qstate.return_msg.qinfo.qname_str.strip():
-            q_name = qstate.return_msg.qinfo.qname_str.rstrip(".")
+        name = qstate.qinfo.qname_str if qstate and qstate.qinfo else None
+        if not (name and name.strip()) and qstate and qstate.return_msg and qstate.return_msg.qinfo:
+            name = qstate.return_msg.qinfo.qname_str
+        if name and name.strip():
+            q_name = name.rstrip(".")
     except Exception as e:
         sys.stderr.write("[pfBlockerNG]: Failed get_q_name_qstate: {}".format(e))
         pass
@@ -2260,8 +2262,9 @@ def get_q_name_qstate(qstate: module_qstate | None) -> str:
 def get_q_name_qinfo(qinfo: query_info | None) -> str:
     q_name = ""
     try:
-        if qinfo and qinfo.qname_str and qinfo.qname_str.strip():
-            q_name = qinfo.qname_str.rstrip(".")
+        name = qinfo.qname_str if qinfo else None
+        if name and name.strip():
+            q_name = name.rstrip(".")
     except Exception as e:
         sys.stderr.write("[pfBlockerNG]: Failed get_q_name_qinfo: {}".format(e))
         pass
@@ -5197,7 +5200,7 @@ def build(
                 if rule is not None:
                     abp_rules.append(rule)
                 continue
-            entry = parse(raw_line)
+            entry = parse(stripped)
             if entry is None:
                 continue
             domain, bucket = _normalise_verdict(entry.value)

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -1968,8 +1968,9 @@ function sync_package_pfblockerng($cron='') {
 												}
 											}
 
-											// Remove leading/trailing dots
-											$line = trim(trim($line), '.');
+											// Remove leading/trailing dots ($line is already
+											// whitespace-trimmed above)
+											$line = trim($line, '.');
 
 											// Domain Validation
 											if (empty(pfb_filter($line, PFB_FILTER_DOMAIN, 'DNSBL_Download'))) {

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -862,6 +862,17 @@ class TestGetQNameQstate:
             f"expected 'Unknown', got {pfb_unbound.get_q_name_qstate(qstate)!r}"
         )
 
+    def test_none_qname_on_fallback_returns_unknown(self) -> None:
+        # qname_str=None on both the primary and the return_msg fallback: the bound
+        # read returns "Unknown" without raising (no caught-AttributeError path).
+        qstate = types.SimpleNamespace(
+            qinfo=types.SimpleNamespace(qname_str=None),
+            return_msg=types.SimpleNamespace(qinfo=types.SimpleNamespace(qname_str=None)),
+        )
+        assert pfb_unbound.get_q_name_qstate(qstate) == "Unknown", (
+            f"expected 'Unknown', got {pfb_unbound.get_q_name_qstate(qstate)!r}"
+        )
+
 
 class TestGetQNameQinfo:
     def test_present_stripped(self) -> None:


### PR DESCRIPTION
Applies the new normalize-once coding standard ([`coding.md` "Normalize once"](../blob/devel/.agents/policy/coding.md)) to the DNSBL hot parse paths, per the owner's direct request (no tracking issue; branch-name deviation from `issue/NN-slug` explicitly authorized for this one PR).

## Changes (all behavior-preserving)

- `_load_user_regex_entries()` — the named example: the line was stripped/lstripped in the guard and re-stripped for the pattern; now stripped once at loop entry. The pattern keeps an `rstrip()` for the whitespace ahead of an inline `#` (leading whitespace is already gone).
- `parse_tld_allow()` — each comma token was stripped twice (filter + map); now stripped once via a generator binding.
- `get_q_name_qstate()` / `get_q_name_qinfo()` — bound `qname_str` once instead of re-walking the SWIG attribute chain up to 3× per condition; this runs per query. Return values are identical in every case; the only observable delta is that a pathological `qname_str = None` on the return_msg fallback no longer produces a caught-`AttributeError` stderr line (it returns the same `"Unknown"`).
- `build()` — the plain-feed loop already computes `stripped` for the ABP-router guard, then handed the raw line to `parse()` (which re-strips first thing); it now hands the stripped line. The sibling permit-feed loop already did exactly this.
- `pfblockerng_apply.inc` dot-trim — `trim(trim($line), '.')` → `trim($line, '.')`. Every path reaching this site passes the unconditional `$line = trim($line)` after the extract-host step, and the intervening steps (IP checks are read-only; `idn_to_ascii()` output is bare punycode) cannot reintroduce edge whitespace.

## Deliberately skipped

- `pfb_text_area_decode()` and the widget loop over it: their discarded `trim()` guard is entangled with open bugs #1707 (whitespace-only lines leaking through as empty entries) and #1710 (CRLF-only split) — any normalize-once restructuring there changes behavior, so it belongs to those fixes.
- `dnsbl_query_answer()` guard (`domain.rstrip(".").strip()` recomputed by the callee): cross-function contract change for a cold path.

## Verification

- pytest: 3443 passed, 5 skipped (full suite)
- PHPUnit: 4113 tests, 23380 assertions, OK
- PHPStan clean, PHPCS clean, `php -l` clean, ruff check/format clean
- Touched functions are pinned by existing suites: `get_q_name_*` (tests/test_pfb_unbound.py), `parse_tld_allow` (#713/#720 pins), `_load_user_regex_entries` (test_issue1718_*), `parse()`/`build()` (ADR-48/62 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved normalization of domain and TLD entries by consistently trimming whitespace and ignoring empty values.
  - Enhanced handling of user-defined regular expressions, including blank lines, comments, and surrounding whitespace.
  - Improved DNS query-name cleanup and fallback handling.
  - Fixed permit-feed parsing so entries are trimmed before normalization.
  - Simplified domain-feed processing for more consistent dot and whitespace removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->