### PR TITLE
dnsbl: remove legacy regex INI fallback

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -497,8 +497,8 @@ def _build_swap_snapshot() -> Snapshot | None:
     regex_db: dict[str, Any] = dict(build_result.regex_db)
     allow_regex_db: dict[str, Any] = dict(build_result.allow_regex_db)
 
-    # USER regex patterns from MAIN.regex_list (legacy REGEX fallback) merged on top of
-    # the feed block-regex, mirroring init's load (incl. the opt-in static cap).
+    # USER regex patterns from MAIN.regex_list merged on top of the feed block-regex,
+    # mirroring init's load (incl. the opt-in static cap).
     if os.path.isfile(pfb["pfb_unbound.ini"]):
         config = ConfigParser()
         try:
@@ -1111,7 +1111,7 @@ def _load_ini_config() -> ConfigParser | None:
 
 
 def _load_user_regex_entries(config: ConfigParser) -> list[tuple[str, str]]:
-    """Load normalized user regex rows from MAIN.regex_list or legacy REGEX."""
+    """Load normalized user regex rows from MAIN.regex_list."""
     if config.has_option("MAIN", "regex_list"):
         encoded = config.get("MAIN", "regex_list", raw=True)
         try:
@@ -1144,8 +1144,6 @@ def _load_user_regex_entries(config: ConfigParser) -> list[tuple[str, str]]:
             entries.append((name, pattern))
         return entries
 
-    if config.has_section("REGEX"):
-        return list(config.items("REGEX"))
     return []
 
 
@@ -1698,7 +1696,7 @@ def init_standard(id: int, env: module_env) -> bool:
                 whiteDB = build_result.white_db
 
                 # ADR-07: MERGE the ABP feed block-regex into regexDB, preserving user-regex
-                # patterns compiled from MAIN.regex_list (legacy [REGEX] fallback) above, and load
+                # patterns compiled from MAIN.regex_list above, and load
                 # the @@/re/ allow-regex into allowRegexDB. Feed regex carry an explicit
                 # band + $important; user regex are the {re, band: PRIO_USER_BLOCK (5)}
                 # payload (sovereign over feed allows -- loaded above).
@@ -5262,8 +5260,8 @@ def build(
                 }
 
         # Irreducible regex -> regexDB (block) / allowRegexDB (allow). Compile here;
-        # a broken pattern is logged + skipped, mirroring the init regex load
-        # (MAIN.regex_list, with legacy [REGEX] fallback). The runtime warn/evict guard (ADR-07)
+        # a broken pattern is logged + skipped, mirroring the MAIN.regex_list init load.
+        # The runtime warn/evict guard (ADR-07)
         # applies later, at query time in evaluate_domain, not during this compile.
         # Iterate over a stable list so the emit order is deterministic.
         regex_db, block_admitted = _dnsbl_compile_regex_rules(result.block_regex_irreducible, static_cap=static_cap)

--- a/tests/test_issue1718_empty_regex_transport.py
+++ b/tests/test_issue1718_empty_regex_transport.py
@@ -14,10 +14,10 @@ def _write_manifest(path: Path) -> None:
     path.write_text('{"version": 1, "config": {}, "feeds": []}\n', encoding="utf-8")
 
 
-def test_empty_main_regex_marker_does_not_fall_back_to_legacy(tmp_path: Path, monkeypatch: Any) -> None:
-    """An explicitly empty MAIN blob disables stale legacy regex entries everywhere."""
+def test_empty_main_regex_marker_loads_no_user_regexes(tmp_path: Path, monkeypatch: Any) -> None:
+    """An explicitly empty MAIN blob produces no user regex entries."""
     (tmp_path / "pfb_unbound.ini").write_text(
-        "[MAIN]\npython_enable = true\nregex_list = \n[REGEX]\nlegacy = stale\n",
+        "[MAIN]\npython_enable = true\nregex_list = \n",
         encoding="utf-8",
     )
     _write_manifest(tmp_path / "pfb_py_sources.json")

--- a/tests/test_issue1718_regex_transport.py
+++ b/tests/test_issue1718_regex_transport.py
@@ -6,6 +6,7 @@ import base64
 from pathlib import Path
 from typing import Any
 
+import pytest
 import unboundmodule
 
 import pfb_unbound as P
@@ -71,11 +72,15 @@ def test_swap_load_matches_initial(tmp_path: Path, monkeypatch: Any) -> None:
         P.deinit(0)
 
 
-def test_present_malformed_or_non_utf8_marker_fails_closed(tmp_path: Path, monkeypatch: Any) -> None:
+def test_present_malformed_or_non_utf8_marker_fails_closed(
+    tmp_path: Path, monkeypatch: Any, caplog: pytest.LogCaptureFixture
+) -> None:
     for payload in ("%%%", base64.b64encode(b"\xff").decode("ascii")):
+        caplog.clear()
         try:
             _initial_load(tmp_path, monkeypatch, _ini(payload))
             assert P.regexDB == {}
+            assert "Failed to decode MAIN.regex_list" in caplog.text
         finally:
             P.deinit(0)
 

--- a/tests/test_issue1718_regex_transport.py
+++ b/tests/test_issue1718_regex_transport.py
@@ -18,12 +18,10 @@ def _manifest(path: Path) -> None:
     )
 
 
-def _ini(payload: str, *, legacy: str = "") -> str:
+def _ini(payload: str) -> str:
     body = "[MAIN]\npython_enable = true\nregex_list = {}\n".format(payload)
     if payload == "__ABSENT__":
         body = "[MAIN]\npython_enable = true\n"
-    if legacy:
-        body += "[REGEX]\nlegacy = {}\n".format(legacy)
     return body
 
 
@@ -53,41 +51,43 @@ def test_initial_load_decodes_base64_rows_and_preserves_names(tmp_path: Path, mo
         P.deinit(0)
 
 
-def test_swap_load_matches_initial_and_ignores_legacy_when_marker_present(tmp_path: Path, monkeypatch: Any) -> None:
+def test_swap_load_matches_initial(tmp_path: Path, monkeypatch: Any) -> None:
     text = "alpha#Description\r\nbeta\n"
     encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
     ini = tmp_path / "pfb_unbound.ini"
     manifest = tmp_path / "pfb_py_sources.json"
     _manifest(manifest)
-    ini.write_text(_ini(encoded, legacy="stale"), encoding="utf-8")
+    ini.write_text(_ini(encoded), encoding="utf-8")
     monkeypatch.setitem(P.pfb, "pfb_unbound.ini", str(ini))
     monkeypatch.setitem(P.pfb, "pfb_py_sources", str(manifest))
     initial = None
     try:
-        _initial_load(tmp_path, monkeypatch, _ini(encoded, legacy="stale"))
+        _initial_load(tmp_path, monkeypatch, _ini(encoded))
         initial = {name: entry["re"].pattern for name, entry in P.regexDB.items()}
         swapped = P._build_swap_snapshot()
         assert swapped is not None
         assert {name: entry["re"].pattern for name, entry in swapped.regex_db.items()} == initial
-        assert "stale" not in swapped.regex_db
     finally:
         P.deinit(0)
 
 
-def test_present_malformed_or_non_utf8_marker_fails_closed_without_legacy_fallback(
-    tmp_path: Path, monkeypatch: Any
-) -> None:
+def test_present_malformed_or_non_utf8_marker_fails_closed(tmp_path: Path, monkeypatch: Any) -> None:
     for payload in ("%%%", base64.b64encode(b"\xff").decode("ascii")):
         try:
-            _initial_load(tmp_path, monkeypatch, _ini(payload, legacy="old"))
-            assert P.regexDB == {}, "marker failure must not load stale legacy entries"
+            _initial_load(tmp_path, monkeypatch, _ini(payload))
+            assert P.regexDB == {}
         finally:
             P.deinit(0)
 
 
-def test_absent_marker_keeps_legacy_read_compatibility(tmp_path: Path, monkeypatch: Any) -> None:
+def test_absent_marker_ignores_obsolete_regex_section(tmp_path: Path, monkeypatch: Any) -> None:
+    ini_body = _ini("__ABSENT__") + "[REGEX]\nlegacy = old\n"
     try:
-        _initial_load(tmp_path, monkeypatch, _ini("__ABSENT__", legacy="old"))
-        assert P.regexDB["legacy"]["re"].pattern == "old"
+        _initial_load(tmp_path, monkeypatch, ini_body)
+        assert P.regexDB == {}
+
+        swapped = P._build_swap_snapshot()
+        assert swapped is not None
+        assert swapped.regex_db == {}
     finally:
         P.deinit(0)


### PR DESCRIPTION
## Summary

- remove the obsolete plaintext `[REGEX]` fallback from the Python loader
- make regenerated `MAIN.regex_list` the sole user-regex INI transport
- remove fallback assumptions from normal transport fixtures and comments
- retain one negative runtime check proving obsolete `[REGEX]` data is ignored

## Testing

- red-proof verifier: frozen tests RED against `d141f14d`, GREEN at HEAD
- focused Python: 404 passed, including PR #1720 parser coverage
- canonical gates: pytest, Ruff check/format, mypy
- hostile probes: absent, empty, malformed, non-UTF-8, and valid payloads

Fixes #1718

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
