### PR TITLE
pfblockerng: add text sanitization helpers; split textarea rows on any line ending

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3039,17 +3039,32 @@ function pfb_strtolower($line) {
 
 
 /**
+ * preg_replace() wrapper that fails open: pathological input can exhaust the
+ * regex engine (JIT stack, pcre.backtrack_limit) and preg_replace() returns
+ * NULL. Returning NULL up through a `: string` contract either wipes data
+ * (an earlier NULL coerces to '' through a later preg_replace) or throws a
+ * TypeError. This wrapper keeps $subject unchanged on NULL instead.
+ */
+function pfb_preg_replace_safe($pattern, $replacement, string $subject): string {
+	return preg_replace($pattern, $replacement, $subject) ?? $subject;
+}
+
+
+/**
  * Sanitize a single-line/scalar text field: converts legacy encodings to
  * UTF-8, strips every Unicode control character (Cc) -- including CR/LF/TAB,
- * since this contract is single-line -- and the BOM, then trims. Unicode
- * format characters (ZWJ/ZWNJ/bidi marks) are NOT Cc and survive.
+ * since this contract is single-line -- and the BOM, then trims (Unicode
+ * whitespace \p{Z}/tab, then the ASCII trim() backstop). Unicode format
+ * characters (ZWJ/ZWNJ/bidi marks) are NOT Cc and survive. A pathological
+ * preg_replace() failure degrades to the unstripped input, never to NULL.
  */
 function pfb_sanitize_text(string $text): string {
 	if (!mb_check_encoding($text, 'UTF-8')) {
 		$text = mb_convert_encoding($text, 'UTF-8',
 			mb_detect_encoding($text, 'UTF-8, ASCII, ISO-8859-1'));
 	}
-	$text = preg_replace('/[\p{Cc}\x{FEFF}]+/u', '', $text);
+	$text = pfb_preg_replace_safe('/[\p{Cc}\x{FEFF}]+/u', '', $text);
+	$text = pfb_preg_replace_safe('/^[\p{Z}\t]+|[\p{Z}\t]+$/u', '', $text);
 	return trim($text);
 }
 
@@ -3059,7 +3074,12 @@ function pfb_sanitize_text(string $text): string {
  * normalizes CRLF/CR/LF line endings to LF, strips every Unicode control
  * character except \n/\t (plus the BOM) -- so VT/FF/NEL/etc. never become row
  * separators or survive as data -- then right-strips trailing whitespace per
- * line. Does NOT drop blank lines; that is the caller's job (issue #1707).
+ * line. The right-strip is Unicode-aware (\p{Z} + tab), so NBSP/ideographic
+ * space/line-separator runs are stripped like ASCII space/tab, and a row of
+ * only Unicode whitespace right-strips to '' same as an ASCII-blank row. Does
+ * NOT drop blank lines; that is the caller's job (issue #1707). A
+ * pathological preg_replace() failure degrades to the unstripped input (or,
+ * per line, the ASCII-rtrim'd line) instead of wiping rows or fatal-ing.
  */
 function pfb_sanitize_text_area(string $text): string {
 	if (!mb_check_encoding($text, 'UTF-8')) {
@@ -3067,8 +3087,16 @@ function pfb_sanitize_text_area(string $text): string {
 			mb_detect_encoding($text, 'UTF-8, ASCII, ISO-8859-1'));
 	}
 	$text = str_replace(array("\r\n", "\r"), "\n", $text);
-	$text = preg_replace('/(?:[^\P{Cc}\n\t]|\x{FEFF})+/u', '', $text);
-	return preg_replace('/[ \t]+$/m', '', $text);
+	$text = pfb_preg_replace_safe(
+		'/[\x00-\x08\x0B-\x1F\x7F\x{80}-\x{9F}\x{FEFF}]+/u', '', $text);
+
+	$lines = explode("\n", $text);
+	foreach ($lines as &$line) {
+		$line = rtrim($line, " \t");
+		$line = pfb_preg_replace_safe('/[\p{Z}\t]+$/u', '', $line);
+	}
+	unset($line);
+	return implode("\n", $lines);
 }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3038,6 +3038,40 @@ function pfb_strtolower($line) {
 }
 
 
+/**
+ * Sanitize a single-line/scalar text field: converts legacy encodings to
+ * UTF-8, strips every Unicode control character (Cc) -- including CR/LF/TAB,
+ * since this contract is single-line -- and the BOM, then trims. Unicode
+ * format characters (ZWJ/ZWNJ/bidi marks) are NOT Cc and survive.
+ */
+function pfb_sanitize_text(string $text): string {
+	if (!mb_check_encoding($text, 'UTF-8')) {
+		$text = mb_convert_encoding($text, 'UTF-8',
+			mb_detect_encoding($text, 'UTF-8, ASCII, ISO-8859-1'));
+	}
+	$text = preg_replace('/[\p{Cc}\x{FEFF}]+/u', '', $text);
+	return trim($text);
+}
+
+
+/**
+ * Sanitize a multi-line textarea blob: converts legacy encodings to UTF-8,
+ * normalizes CRLF/CR/LF line endings to LF, strips every Unicode control
+ * character except \n/\t (plus the BOM) -- so VT/FF/NEL/etc. never become row
+ * separators or survive as data -- then right-strips trailing whitespace per
+ * line. Does NOT drop blank lines; that is the caller's job (issue #1707).
+ */
+function pfb_sanitize_text_area(string $text): string {
+	if (!mb_check_encoding($text, 'UTF-8')) {
+		$text = mb_convert_encoding($text, 'UTF-8',
+			mb_detect_encoding($text, 'UTF-8, ASCII, ISO-8859-1'));
+	}
+	$text = str_replace(array("\r\n", "\r"), "\n", $text);
+	$text = preg_replace('/(?:[^\P{Cc}\n\t]|\x{FEFF})+/u', '', $text);
+	return preg_replace('/[ \t]+$/m', '', $text);
+}
+
+
 // Function to decode alias custom entry box.
 // Default (False, True): Return as string with comments
 function pfb_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
@@ -3048,10 +3082,12 @@ function pfb_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
 		$custom = '';	// string accumulator; '' (not undef) when no lines match
 	}
 
-	$customlist = explode("\r\n", base64_decode($text));
+	// issue #1710/#1707: split on any line ending, drop whitespace-only rows, keep '0'.
+	$customlist = explode("\n", pfb_sanitize_text_area(base64_decode($text)));
 	if (!empty($customlist)) {
 		foreach ($customlist as $line) {
-			if (!str_starts_with(trim($line), '#') && !empty($line)) {
+			$trimmed_line = trim($line);
+			if (!str_starts_with($trimmed_line, '#') && ($trimmed_line !== '')) {
 				if ($idn && !ctype_print($line)) {
 					$line_old = $line;
 					// Convert encodings to UTF-8

--- a/tests/php/DnsblTldStatsFinalizeTest.php
+++ b/tests/php/DnsblTldStatsFinalizeTest.php
@@ -46,10 +46,17 @@ final class DnsblTldStatsFinalizeTest extends TestCase
 		$this->assertNoTldBookkeeping();
 	}
 
-	public function testWhitespaceHeaderBlankAndZeroRemainIgnored(): void
+	public function testWhitespaceHeaderAndBlankRemainIgnored(): void
 	{
-		$this->runFinalize("   \r\n# header\r\n\r\n0\r\n");
+		$this->runFinalize("   \r\n# header\r\n\r\n");
 		$this->assertNoTldBookkeeping();
+	}
+
+	public function testZeroRowCountsAsEntry(): void
+	{
+		// issue #1707: "0" is a valid row -- the old !empty() guard silently dropped it
+		$this->runFinalize("0\r\n");
+		$this->assertTldCount(1);
 	}
 
 	public function testLeadingDotsAndPlainValidTldsRemainRawDistinctBeforeTrim(): void

--- a/tests/php/PfbSanitizeTextTest.php
+++ b/tests/php/PfbSanitizeTextTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_sanitize_text() / pfb_sanitize_text_area() — shared text-field
+ * normalizers (issues #1710/#1707): scrub invalid encodings to UTF-8, strip
+ * Unicode control characters (and the BOM), and normalize whitespace. The
+ * single-line helper strips CR/LF/TAB too; the textarea helper normalizes
+ * line endings to LF and right-strips per-line trailing whitespace instead.
+ */
+#[CoversFunction('pfb_sanitize_text')]
+#[CoversFunction('pfb_sanitize_text_area')]
+final class PfbSanitizeTextTest extends TestCase
+{
+	// --- pfb_sanitize_text() ---
+
+	public function testSanitizeTextRemovesC0ControlChars(): void
+	{
+		$this->assertSame('hello', pfb_sanitize_text("h\x00e\x1Bl\x07lo"));
+	}
+
+	public function testSanitizeTextRemovesEscButKeepsPrintableRemainder(): void
+	{
+		// ESC alone is the Cc control byte; the printable ANSI-code remainder
+		// that follows it is ordinary text and survives.
+		$this->assertSame('red[31mtext', pfb_sanitize_text("red\x1b[31mtext"));
+	}
+
+	public function testSanitizeTextRemovesDel(): void
+	{
+		$this->assertSame('ab', pfb_sanitize_text("a\x7Fb"));
+	}
+
+	public function testSanitizeTextRemovesEmbeddedLineEndingsAndTabs(): void
+	{
+		$this->assertSame('abcd', pfb_sanitize_text("a\rb\nc\td"));
+	}
+
+	public function testSanitizeTextRemovesBom(): void
+	{
+		$this->assertSame('hello', pfb_sanitize_text("\xEF\xBB\xBFhello"));
+	}
+
+	public function testSanitizeTextTrimsLeadingAndTrailingWhitespace(): void
+	{
+		$this->assertSame('hello', pfb_sanitize_text('  hello  '));
+	}
+
+	public function testSanitizeTextPreservesLiteralZero(): void
+	{
+		$this->assertSame('0', pfb_sanitize_text('0'));
+	}
+
+	public function testSanitizeTextEmptyInputReturnsEmptyString(): void
+	{
+		$this->assertSame('', pfb_sanitize_text(''));
+	}
+
+	public function testSanitizeTextPreservesUnicodeText(): void
+	{
+		$this->assertSame('café', pfb_sanitize_text('café'));
+		$this->assertSame('日本語', pfb_sanitize_text('日本語'));
+		$this->assertSame('🎉', pfb_sanitize_text('🎉'));
+	}
+
+	public function testSanitizeTextPreservesNbspMidString(): void
+	{
+		$this->assertSame("a\xC2\xA0b", pfb_sanitize_text("a\xC2\xA0b"));
+	}
+
+	public function testSanitizeTextPreservesZeroWidthJoiner(): void
+	{
+		$this->assertSame("a\xE2\x80\x8Db", pfb_sanitize_text("a\xE2\x80\x8Db"));
+	}
+
+	public function testSanitizeTextConvertsInvalidUtf8FromIso88591(): void
+	{
+		$this->assertSame('bücher', pfb_sanitize_text("b\xFCcher"));
+	}
+
+	// --- pfb_sanitize_text_area() ---
+
+	public function testSanitizeTextAreaNormalizesCrlfToLf(): void
+	{
+		$this->assertSame("a\nb", pfb_sanitize_text_area("a\r\nb"));
+	}
+
+	public function testSanitizeTextAreaNormalizesCrToLf(): void
+	{
+		$this->assertSame("a\nb", pfb_sanitize_text_area("a\rb"));
+	}
+
+	public function testSanitizeTextAreaLeavesLfUnchanged(): void
+	{
+		$this->assertSame("a\nb", pfb_sanitize_text_area("a\nb"));
+	}
+
+	public function testSanitizeTextAreaNormalizesMixedLineEndings(): void
+	{
+		$this->assertSame("a\nb\nc\nd", pfb_sanitize_text_area("a\r\nb\nc\rd"));
+	}
+
+	public function testSanitizeTextAreaStripsTrailingSpacesAndTabsPerLine(): void
+	{
+		$this->assertSame("a\nb", pfb_sanitize_text_area("a  \t \nb\t\t"));
+	}
+
+	public function testSanitizeTextAreaPreservesLeadingIndentation(): void
+	{
+		$this->assertSame("  a\n\tb", pfb_sanitize_text_area("  a\n\tb"));
+	}
+
+	public function testSanitizeTextAreaPreservesInteriorTab(): void
+	{
+		$this->assertSame("a\tb", pfb_sanitize_text_area("a\tb"));
+	}
+
+	public function testSanitizeTextAreaRemovesVtFfNelEsc(): void
+	{
+		$in = "a\x0Bb\ncd\x0C\ne\x1Bf\ng\xC2\x85h";
+		$this->assertSame("ab\ncd\nef\ngh", pfb_sanitize_text_area($in));
+	}
+
+	public function testSanitizeTextAreaRemovesBom(): void
+	{
+		$this->assertSame('hello', pfb_sanitize_text_area("\xEF\xBB\xBFhello"));
+	}
+
+	public function testSanitizeTextAreaPreservesUnicodeLineContent(): void
+	{
+		$this->assertSame("café\n日本語\n🎉", pfb_sanitize_text_area("café\n日本語\n🎉"));
+	}
+
+	public function testSanitizeTextAreaConvertsInvalidUtf8FromIso88591(): void
+	{
+		$this->assertSame('bücher', pfb_sanitize_text_area("b\xFCcher"));
+	}
+
+	public function testSanitizeTextAreaEmptyInputReturnsEmptyString(): void
+	{
+		$this->assertSame('', pfb_sanitize_text_area(''));
+	}
+
+	public function testSanitizeTextAreaPreservesBlankLinesAsRows(): void
+	{
+		// The helper does not drop rows — that is the caller's job.
+		$this->assertSame("a\n\nb", pfb_sanitize_text_area("a\n\nb"));
+	}
+}

--- a/tests/php/PfbSanitizeTextTest.php
+++ b/tests/php/PfbSanitizeTextTest.php
@@ -82,6 +82,25 @@ final class PfbSanitizeTextTest extends TestCase
 		$this->assertSame('bücher', pfb_sanitize_text("b\xFCcher"));
 	}
 
+	public function testSanitizeTextRemovesC1ControlChars(): void
+	{
+		// NEL (U+0085, UTF-8 \xC2\x85) is a C1 control char, covered by \p{Cc}.
+		$this->assertSame('ab', pfb_sanitize_text("a\xC2\x85b"));
+	}
+
+	public function testSanitizeTextPreservesBidiMarks(): void
+	{
+		// RLO (U+202E) is a Unicode format char, not \p{Cc} -- must survive.
+		$this->assertSame("a\xE2\x80\xAEb", pfb_sanitize_text("a\xE2\x80\xAEb"));
+	}
+
+	public function testSanitizeTextTrimsUnicodeWhitespace(): void
+	{
+		// Leading U+3000 (ideographic space) and trailing NBSP must be trimmed,
+		// not just ASCII space/tab.
+		$this->assertSame('x', pfb_sanitize_text("\xE3\x80\x80x\xC2\xA0"));
+	}
+
 	// --- pfb_sanitize_text_area() ---
 
 	public function testSanitizeTextAreaNormalizesCrlfToLf(): void
@@ -149,5 +168,27 @@ final class PfbSanitizeTextTest extends TestCase
 	{
 		// The helper does not drop rows — that is the caller's job.
 		$this->assertSame("a\n\nb", pfb_sanitize_text_area("a\n\nb"));
+	}
+
+	public function testSanitizeTextAreaSurvivesHugeControlRun(): void
+	{
+		// A pathological run of control chars must not blow up the alternation
+		// pattern (JIT stack exhaustion -> NULL -> whole blob wiped to '').
+		$in = "keep\n" . str_repeat("\x00", 20000) . "\nalso";
+		$this->assertSame("keep\n\nalso", pfb_sanitize_text_area($in));
+	}
+
+	public function testSanitizeTextAreaSurvivesHugeSpaceRunMidLine(): void
+	{
+		// A >1,000,000-char space run mid-line (not at end-of-line) must not
+		// exhaust pcre.backtrack_limit and fatal via the : string return type.
+		$line = 'a' . str_repeat(' ', 1000001) . 'b';
+		$this->assertSame($line . "\n", pfb_sanitize_text_area($line . "\n"));
+	}
+
+	public function testSanitizeTextAreaStripsTrailingUnicodeWhitespace(): void
+	{
+		// Trailing NBSP / U+3000 must right-strip like ASCII space/tab.
+		$this->assertSame("a\nb\n", pfb_sanitize_text_area("a\xC2\xA0\nb\xE3\x80\x80\n"));
 	}
 }

--- a/tests/php/TextAreaDecodeTest.php
+++ b/tests/php/TextAreaDecodeTest.php
@@ -107,6 +107,10 @@ final class TextAreaDecodeTest extends TestCase
 	{
 		$in = self::rawEnc("alpha\r\nbeta\ngamma\rdelta");
 		$this->assertSame("alpha\nbeta\ngamma\ndelta\n", pfb_text_area_decode($in));
+		$this->assertSame(
+			[['alpha'], ['beta'], ['gamma'], ['delta']],
+			pfb_text_area_decode($in, true, true)
+		);
 	}
 
 	public function testTrailingSeparatorYieldsNoTrailingEmptyRow(): void
@@ -114,6 +118,7 @@ final class TextAreaDecodeTest extends TestCase
 		$in = self::rawEnc("a.com\n");
 		$this->assertSame("a.com\n", pfb_text_area_decode($in));
 		$this->assertSame(['a.com'], pfb_text_area_decode($in, true, false));
+		$this->assertSame([['a.com']], pfb_text_area_decode($in, true, true));
 	}
 
 	public function testControlCharsRemovedNotTreatedAsSeparators(): void
@@ -144,5 +149,25 @@ final class TextAreaDecodeTest extends TestCase
 		$this->assertSame("0\n", pfb_text_area_decode($in));
 		$this->assertSame(['0'], pfb_text_area_decode($in, true, false));
 		$this->assertSame([['0']], pfb_text_area_decode($in, true, true));
+	}
+
+	public function testUnicodeWhitespaceOnlyRowsDropped(): void
+	{
+		// A row that is only NBSP or only U+3000 (ideographic space) must
+		// right-strip to '' and be dropped, same as an ASCII-whitespace row.
+		$in = self::rawEnc("a.com\n\xC2\xA0\nb.com\n\xE3\x80\x80\nc.com");
+		$this->assertSame("a.com\nb.com\nc.com\n", pfb_text_area_decode($in));
+		$this->assertSame(['a.com', 'b.com', 'c.com'], pfb_text_area_decode($in, true, false));
+		$this->assertSame(
+			[['a.com'], ['b.com'], ['c.com']],
+			pfb_text_area_decode($in, true, true)
+		);
+	}
+
+	public function testDecoderSurvivesHugeControlRunRow(): void
+	{
+		// A pathological all-NUL row must not wipe the flanking good rows.
+		$in = self::rawEnc("a.com\n" . str_repeat("\x00", 20000) . "\nb.com");
+		$this->assertSame(['a.com', 'b.com'], pfb_text_area_decode($in, true, false));
 	}
 }

--- a/tests/php/TextAreaDecodeTest.php
+++ b/tests/php/TextAreaDecodeTest.php
@@ -22,6 +22,12 @@ final class TextAreaDecodeTest extends TestCase
 		return base64_encode(implode("\r\n", $lines));
 	}
 
+	/** Encode a raw payload verbatim (no CRLF-join) — for line-ending/control-char tests. */
+	private static function rawEnc(string $raw): string
+	{
+		return base64_encode($raw);
+	}
+
 	public function testStringModeLowercasesJoinsAndStripsComments(): void
 	{
 		$in = self::enc('EXAMPLE.COM', 'foo.com', '# whole-line comment', 'bar.com # inline');
@@ -77,5 +83,66 @@ final class TextAreaDecodeTest extends TestCase
 		// base64('') => '' => explode gives [''] => nothing appended. String mode
 		// initialises $custom to '' up front, so empty input yields '' (not null).
 		$this->assertSame('', pfb_text_area_decode(''));
+	}
+
+	// --- issue #1710: split on any line ending, not just CRLF ---
+
+	public function testLfOnlySplitsIntoRows(): void
+	{
+		$in = self::rawEnc("alpha\nbeta");
+		$this->assertSame("alpha\nbeta\n", pfb_text_area_decode($in));
+		$this->assertSame(['alpha', 'beta'], pfb_text_area_decode($in, true, false));
+		$this->assertSame([['alpha'], ['beta']], pfb_text_area_decode($in, true, true));
+	}
+
+	public function testCrOnlySplitsIntoRows(): void
+	{
+		$in = self::rawEnc("alpha\rbeta");
+		$this->assertSame("alpha\nbeta\n", pfb_text_area_decode($in));
+		$this->assertSame(['alpha', 'beta'], pfb_text_area_decode($in, true, false));
+		$this->assertSame([['alpha'], ['beta']], pfb_text_area_decode($in, true, true));
+	}
+
+	public function testMixedLineEndingsSplitInSourceOrder(): void
+	{
+		$in = self::rawEnc("alpha\r\nbeta\ngamma\rdelta");
+		$this->assertSame("alpha\nbeta\ngamma\ndelta\n", pfb_text_area_decode($in));
+	}
+
+	public function testTrailingSeparatorYieldsNoTrailingEmptyRow(): void
+	{
+		$in = self::rawEnc("a.com\n");
+		$this->assertSame("a.com\n", pfb_text_area_decode($in));
+		$this->assertSame(['a.com'], pfb_text_area_decode($in, true, false));
+	}
+
+	public function testControlCharsRemovedNotTreatedAsSeparators(): void
+	{
+		// VT (\x0B), FF (\x0C), NEL (U+0085, UTF-8 \xC2\x85) must be stripped from
+		// the row and must NOT act as row separators.
+		$in = self::rawEnc("al\x0Bpha\nbe\x0Cta\ngam\xC2\x85ma");
+		$this->assertSame("alpha\nbeta\ngamma\n", pfb_text_area_decode($in));
+	}
+
+	// --- issue #1707 (PHP half): drop whitespace-only rows, keep literal "0" ---
+
+	public function testWhitespaceOnlyRowsDropped(): void
+	{
+		$in = self::rawEnc("a.com\n   \nb.com\n\t\t\nc.com");
+		$this->assertSame("a.com\nb.com\nc.com\n", pfb_text_area_decode($in));
+		$this->assertSame(['a.com', 'b.com', 'c.com'], pfb_text_area_decode($in, true, false));
+		$this->assertSame(
+			[['a.com'], ['b.com'], ['c.com']],
+			pfb_text_area_decode($in, true, true)
+		);
+	}
+
+	public function testZeroRowPreserved(): void
+	{
+		// '0' is falsy in PHP; the old !empty($line) guard wrongly dropped it.
+		$in = self::rawEnc('0');
+		$this->assertSame("0\n", pfb_text_area_decode($in));
+		$this->assertSame(['0'], pfb_text_area_decode($in, true, false));
+		$this->assertSame([['0']], pfb_text_area_decode($in, true, true));
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -5931,6 +5931,33 @@
             }
         ]
     },
+    "pfb_preg_replace_safe": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "pattern",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "replacement",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "subject",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_print_pending_changes_box": {
         "returnsRef": false,
         "returnType": "void",

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -6481,6 +6481,32 @@
             }
         ]
     },
+    "pfb_sanitize_text": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "text",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_sanitize_text_area": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "text",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_select_reload_aliases": {
         "returnsRef": false,
         "returnType": "array",


### PR DESCRIPTION
## Summary

Adds two shared, unit-tested text-sanitization helpers and rewires the shared textarea decoder onto them:

- **`pfb_sanitize_text()`** — single-line fields: converts legacy encodings to UTF-8, strips every Unicode control character (Cc, including CR/LF/TAB) plus the BOM, then trims. Unicode format characters (ZWJ/ZWNJ/bidi marks) survive, so Unicode text — especially comments — is preserved.
- **`pfb_sanitize_text_area()`** — multi-line fields: same UTF-8 conversion, normalizes CRLF/CR/LF line endings to LF, strips every control character except `\n`/`\t` (plus BOM), and right-strips each line (indentation survives, trailing whitespace does not).
- **`pfb_text_area_decode()`** now splits rows on the sanitized blob (`explode("\n", pfb_sanitize_text_area(...))`) and admits rows via a single-bound `trim($line) !== ''` guard.

Fixes #1710.
Part of #1707 (the shared-decoder half: whitespace-only rows are dropped and the valid row `"0"` is preserved; the Python `[REGEX]` loader defense-in-depth guards remain open on that issue).
Groundwork for #1723 (persist-boundary wiring of the helpers plus IDN/Unicode domain validation).

## Behaviour changes

| Input | Before | After |
| --- | --- | --- |
| LF-only / CR-only / mixed line endings | Rows glued into one value (regex INI corruption, silent pattern loss) | Identical logical rows for CRLF/LF/CR/mixed |
| Whitespace-only row | Admitted, later collapses to an empty sovereign regex matching every query | Dropped |
| Row `"0"` | Silently dropped by `!empty()` | Preserved |
| VT / FF / NEL / other control chars | Preserved as data | Removed — never row separators, never data |
| Legacy ISO-8859-1 bytes | Passed through raw outside the IDN branch | Converted to UTF-8 |

One deliberate deviation from #1710's letter: the issue proposed keeping VT/FF/NEL as row data. Per the owner's directive that every control character is removed from text fields, the helpers strip them instead (pinned by `testControlCharsRemovedNotTreatedAsSeparators`).

`DnsblTldStatsFinalizeTest::testWhitespaceHeaderBlankAndZeroRemainIgnored` pinned the old `!empty()` quirk; it is split into `testWhitespaceHeaderAndBlankRemainIgnored` (unchanged pin) and `testZeroRowCountsAsEntry` (the #1707-mandated behaviour).

## Evidence

- Test-first red→green executed: 6 reproduction tests failed on untouched code (LF/CR/mixed glue, whitespace-row admission, `"0"` drop, control-char passthrough), frozen byte-identical (red-time hashes `8ba5e260` / `e2b5ada8` re-verified against the committed blobs), then passed unchanged after the fix. Independently re-executed via `scripts/agent/verify-red-proof.sh` (`RED-OK`/`GREEN-OK`/`FREEZE-OK`, verdict PASS).
- `scripts/agent/run-gates.sh --diff origin/devel`: all gates pass (`php -l`, full PHPUnit suite 4146 tests / 0 failures, PHPStan clean, PHPCS clean).
- Coverage: all three decoder modes (string / flat array / structured) exercised for every separator shape, plus empty input, trailing separators, blank/whitespace rows, comment rows, inline comments, `"0"`, VT/FF/NEL, BOM, Unicode passthrough (café/日本語/emoji/NBSP/ZWJ), and invalid-UTF-8 conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of text and multi-line input by removing unsupported control characters and normalizing line endings.
  * Preserved valid Unicode content, indentation, blank lines, and literal `0` values.
  * Improved decoding of pasted or imported text with legacy character encoding.
  * Prevented whitespace-only rows from creating unintended entries or statistics.

* **Tests**
  * Added comprehensive coverage for text sanitization and multi-line input processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->