### PR TITLE
pfblockerng: reorder pfb_unlock parameters

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -16421,7 +16421,7 @@ function pfBlockerNG_clearsqlite($mode, $totalqueries = 0) {
 
 
 // Function to read/lock/unlock IP/Domains from Aliastables/DNSBL (Called via Alerts Page)
-function pfb_unlock($mode, $type, $remove='', $r_type='', $filename_unlock) {
+function pfb_unlock($mode, $type, $filename_unlock, $remove='', $r_type='') {
 	global $pfb;
 
 	if ($type == 'ip') {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -4461,7 +4461,7 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 		$apply = pfb_live_punch_run($pfb['pfctl'], $pfb['aliasdir'], $pfb['dbdir'], $table, $ip);
 		switch ($apply['status']) {
 			case 'applied':
-				pfb_unlock('unlock', 'ip', $ip, $table, $ip_unlock);
+				pfb_unlock('unlock', 'ip', $ip_unlock, $ip, $table);
 				$result['savemsg'] = "The IP [ {$ip} ] has been temporarily Unlocked from table [ {$table} ]!";
 				break;
 			case 'not_blocked':
@@ -4480,7 +4480,7 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 	if ($action === 'lock') {
 		$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table, 'add', $ip);
 		if ($apply['ok']) {
-			pfb_unlock('lock', 'ip', $ip, $table, $ip_unlock);
+			pfb_unlock('lock', 'ip', $ip_unlock, $ip, $table);
 			$result['savemsg'] = "The IP [ {$ip} ] has been re-locked into table [ {$table} ]!";
 		} else {
 			$result['savemsg'] = "The live re-lock of IP [ {$ip} ] failed [ {$apply['fail']} ] -- table [ {$table} ] does not block it; see the pfBlockerNG log.";

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1212,7 +1212,7 @@ if (isset($_POST) && !empty($_POST)) {
 				}
 
 				// Remove Domain from unlock file
-				pfb_unlock('lock', 'dnsbl', $entry, '', $dnsbl_unlock);
+				pfb_unlock('lock', 'dnsbl', $dnsbl_unlock, $entry, '');
 
 				$data = '';
 				foreach ($clists['dnsblwhitelist']['data'] as $line) {
@@ -1378,7 +1378,7 @@ if (isset($_POST) && !empty($_POST)) {
 		// Unbound. Dispatch: pfb_dnsbl_unlock_action() (unit-tested); unknown action = no-op.
 		$ua = pfb_dnsbl_unlock_action($action);
 		if ($ua['mode'] !== '') {
-			pfb_unlock($ua['mode'], 'dnsbl', $domain, $dnsbl_type, $dnsbl_unlock);
+			pfb_unlock($ua['mode'], 'dnsbl', $dnsbl_unlock, $domain, $dnsbl_type);
 
 			// Patch the manifest's config.user_unlock from the updated store, then
 			// reload Unbound so the query-time whiteDB picks up the change.

--- a/tests/php/SrcPhpDeprecationLintTest.php
+++ b/tests/php/SrcPhpDeprecationLintTest.php
@@ -14,29 +14,28 @@ use PHPUnit\Framework\TestCase;
  * pfBlockerNG_get_table() in src/usr/local/www/widgets/widgets/
  * pfblockerng.widget.php ("Optional parameter $mode declared before required
  * parameter $pfb_table"). Issue #1693 fixed that widget and widens the guard
- * here to every tracked src/*.php file, so this whole defect class -- not
+ * here to every tracked src/*.php file; issue #1699 adds src/*.inc, so this
+ * whole defect class -- not
  * just one file at a time -- stays pinned tree-wide.
  *
- * Enumeration is the CANONICAL TRACKED SET (`git ls-files 'src/*.php'`), not
+ * Enumeration is the CANONICAL TRACKED SET (`git ls-files 'src/*.php'
+ * 'src/*.inc'`), not
  * a directory walk: a walk would also lint an ignored or generated file if
  * one happened to exist on disk in some checkout, and a hardcoded minimum
  * file count is a maintenance trap in the deletion direction (legitimately
- * removing a src/*.php file would turn the guard red for no reason). The
+ * removing a src/*.php or src/*.inc file would turn the guard red for no reason). The
  * non-vacuity guard is instead `assertNotEmpty()` -- an empty list is the
  * only vacuous case, and it can no longer be reached by a legitimate
  * deletion. `git ls-files` itself is asserted to succeed so a missing git
  * binary or a checkout outside a repo cannot silently produce that empty
  * list -- the exact fail-open shape this guard exists to prevent.
  *
- * Scope: src/*.php only. src/*.inc is NOT yet covered by this sweep: the same
- * E_ALL lint extended to src/*.inc finds a separate, pre-existing offender --
- * pfb_unlock() in src/usr/local/pkg/pfblockerng/pfblockerng.inc, declaring an
- * optional parameter ahead of a required one -- tracked in its own issue,
- * #1699, and deliberately out of scope for this test.
+ * Issue #1699 extends the sweep to tracked src/*.inc files after fixing the
+ * remaining pfb_unlock() declaration-time deprecation.
  */
 final class SrcPhpDeprecationLintTest extends TestCase
 {
-	public function testEverySrcPhpFileLintsCleanUnderErrorReportingEAll(): void
+	public function testEverySrcPhpAndIncFileLintsCleanUnderErrorReportingEAll(): void
 	{
 		$root = dirname(__DIR__, 2);
 		$srcDir = $root . '/src';
@@ -46,7 +45,7 @@ final class SrcPhpDeprecationLintTest extends TestCase
 
 		$this->assertNotEmpty(
 			$files,
-			'git ls-files must discover at least one tracked src/*.php file --'
+			'git ls-files must discover at least one tracked src/*.php or src/*.inc file --'
 				. ' a broken enumeration must never pass by finding zero.'
 		);
 
@@ -73,23 +72,23 @@ final class SrcPhpDeprecationLintTest extends TestCase
 			[],
 			$failures,
 			'php -l -d error_reporting=E_ALL must confirm parse and emit no'
-				. ' Deprecated/Warning/Notice diagnostics for every tracked src/*.php file;'
+				. ' Deprecated/Warning/Notice diagnostics for every tracked src/*.php and src/*.inc file;'
 				. ' offending file(s):' . "\n" . implode("\n---\n", $failures)
 		);
 	}
 
 	/**
-	 * Enumerate the tracked src/*.php set via `git ls-files -z`, NUL-split so a
+	 * Enumerate tracked src/*.php and src/*.inc via `git ls-files -z`, NUL-split so a
 	 * tracked path containing a space or a newline can never corrupt the list.
 	 * A non-zero exit (git missing, $root not a repo, etc.) throws rather than
 	 * silently returning an empty/partial list -- a silent empty list here is
 	 * exactly the fail-open shape this guard exists to prevent.
 	 *
-	 * @return string[] absolute paths of every tracked src/*.php file
+	 * @return string[] absolute paths of every tracked src/*.php and src/*.inc file
 	 */
 	private static function trackedPhpFiles(string $root): array
 	{
-		$cmd = ['git', '-C', $root, 'ls-files', '-z', '--', 'src/*.php'];
+		$cmd = ['git', '-C', $root, 'ls-files', '-z', '--', 'src/*.php', 'src/*.inc'];
 		$descriptors = [
 			0 => ['pipe', 'r'],
 			1 => ['pipe', 'w'],

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -8331,25 +8331,25 @@
                 "default": null
             },
             {
-                "name": "remove",
+                "name": "filename_unlock",
                 "byRef": false,
                 "variadic": false,
                 "type": null,
                 "default": null
+            },
+            {
+                "name": "remove",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
             },
             {
                 "name": "r_type",
                 "byRef": false,
                 "variadic": false,
                 "type": null,
-                "default": null
-            },
-            {
-                "name": "filename_unlock",
-                "byRef": false,
-                "variadic": false,
-                "type": null,
-                "default": null
+                "default": "''"
             }
         ]
     },

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -4243,7 +4243,7 @@ def dnsbl_alert_lock_toggle(vm: SmokeVM, domain: str, action: str, *, timeout: f
         f"$action = {_php_str(action)};\n"
         "$ua = pfb_dnsbl_unlock_action($action);\n"
         "$u = pfb_unlock('read', 'dnsbl', '', '', '');\n"
-        f"pfb_unlock($ua['mode'], 'dnsbl', {_php_str(domain)}, 'python', $u);\n"
+        f"pfb_unlock($ua['mode'], 'dnsbl', $u, {_php_str(domain)}, 'python');\n"
         "pfb_unbound_python_sources_unlock();\n"
         "$swapped = pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);\n"
         "if ($swapped) {\n"

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -630,7 +630,7 @@ def test_dnsbl_sentinel_flip_failure_clears_sync_marker(deployed_vm: SmokeVM, mo
                 "pfb_global();\n"
                 "$ua = pfb_dnsbl_unlock_action('unlock');\n"
                 "$u = pfb_unlock('read', 'dnsbl', '', '', '');\n"
-                f"pfb_unlock($ua['mode'], 'dnsbl', {h._php_str(domain)}, 'python', $u);\n"
+                f"pfb_unlock($ua['mode'], 'dnsbl', $u, {h._php_str(domain)}, 'python');\n"
                 "pfb_unbound_python_sources_unlock();\n"
                 "pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);\n"
                 "echo 'OK';"

--- a/tests/smoke/ui/php_diagnostic_baseline.txt
+++ b/tests/smoke/ui/php_diagnostic_baseline.txt
@@ -10,8 +10,6 @@
 #
 # THIS LIST MAY ONLY SHRINK. A new diagnostic is a regression: fix the site, never append
 # to this file. Burning the backlog below down to empty is tracked in #1712.
-/usr/local/pkg/pfblockerng/pfblockerng.inc|Deprecated|Optional parameter $r_type declared before required parameter $filename_unlock is implicitly treated as a required parameter
-/usr/local/pkg/pfblockerng/pfblockerng.inc|Deprecated|Optional parameter $remove declared before required parameter $filename_unlock is implicitly treated as a required parameter
 /usr/local/pkg/pfblockerng/pfblockerng.inc|Deprecated|base64_decode(): Passing null to parameter #1 ($string) of type string is deprecated
 /usr/local/pkg/pfblockerng/pfblockerng.inc|Deprecated|explode(): Passing null to parameter #2 ($string) of type string is deprecated
 /usr/local/www/pfblockerng/pfblockerng_Africa.php|Deprecated|explode(): Passing null to parameter #2 ($string) of type string is deprecated

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -223,6 +223,10 @@ def test_dnsbl_lock_unlock_lifecycle_via_alerts(
         # the value the production helper sends.
         resp = _post_action(webui, {"dnsbl_remove": "unlock", "domain": domain, "dnsbl_type": "python"})
         assert not looks_like_login_page(resp.text), "unlock POST returned the login form (session lost)"
+        unlock_lines = set(helpers.read_log_file(vm, DNSBL_UNLOCK_STORE).splitlines())
+        assert f"{domain},python" in unlock_lines, (
+            f"unlock store must record {domain!r} with type 'python', got {sorted(unlock_lines)!r}"
+        )
         # The handler returns only after the applied-generation handshake. Blocked
         # answers are not cached, so Unlock needs no native-cache flush.
         unlocked = helpers.dns_probe(vm, domain, "A")
@@ -232,6 +236,10 @@ def test_dnsbl_lock_unlock_lifecycle_via_alerts(
         # targeted delta-flush clears the prior resolved answer).
         resp = _post_action(webui, {"dnsbl_remove": "lock", "domain": domain, "dnsbl_type": "python"})
         assert not looks_like_login_page(resp.text), "re-lock POST returned the login form (session lost)"
+        relock_lines = set(helpers.read_log_file(vm, DNSBL_UNLOCK_STORE).splitlines())
+        assert not any(line.startswith(f"{domain},") for line in relock_lines), (
+            f"re-lock must remove {domain!r} from the unlock store, got {sorted(relock_lines)!r}"
+        )
         # Lock likewise returns after the applied-generation handshake and targeted
         # domain/www cache flush.
         relocked = helpers.dns_probe(vm, domain, "A")


### PR DESCRIPTION
## Summary

- Move required `$filename_unlock` before optional `$remove` and `$r_type` in `pfb_unlock()`.
- Reorder every affected production and generated-smoke positional call without changing argument meaning.
- Extend the tracked-source `E_ALL` lint sweep from `src/*.php` to `src/*.php` plus `src/*.inc`, and refresh the intentional function-signature inventory.
- Retire the two fixed optional-before-required fingerprints from the PHP diagnostic baseline.

## Root cause

`pfb_unlock()` declared optional parameters before the required unlock-state parameter. PHP 8 therefore treated the optional parameters as required and emitted declaration-time deprecations. Giving the state parameter a default would hide caller errors, so the required parameter and each positional caller move together.

## Verification

- RED: `vendor/bin/phpunit tests/php/SrcPhpDeprecationLintTest.php` failed under PHP 8.5.8 and named only `src/usr/local/pkg/pfblockerng/pfblockerng.inc`, with both optional-before-required diagnostics.
- Freeze: `git hash-object tests/php/SrcPhpDeprecationLintTest.php` = `06adb5aefa13c3de56714ca9c9fdbb3dd2a1c0f2` before and after the production fix.
- GREEN: focused lint oracle passed: 1 test, 3 assertions.
- Focused PHP lock/unlock paths passed: 93 tests, 362 assertions.
- Final canonical gates: `scripts/agent/run-gates.sh` -> `GATES: PASS` (pytest, Ruff, mypy, PHP lint, PHPUnit, PHPStan, PHPCS).
- Live caller smoke: 2 passed (`test_dnsbl_resolve_block_unlock_relock_lifecycle`, `test_dnsbl_sentinel_flip_failure_clears_sync_marker`).
- Live Alerts UI lifecycle: 1 passed (`test_dnsbl_lock_unlock_lifecycle_via_alerts`), including exact unlock-store write/removal assertions.
- Independent delta and final whole-diff reviews found no remaining blockers at `76dd3baf`.

Fixes #1699

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.