### PR TITLE
pfblockerng: standardize text-field sanitization at the persist boundary; accept Unicode and IDN input

### DIFF
--- a/.agents/policy/coding.md
+++ b/.agents/policy/coding.md
@@ -68,25 +68,37 @@ most, but the rule is about clarity as much as cost — one binding names the in
 ("`line` is stripped from here on") instead of making the reader re-verify it per use.
 Applies to new code and to any touched block; fix the redundancy when you edit one.
 
-## Text-field sanitization — shared helpers at the persist boundary (issue #1723)
+## Text-field sanitization — sanitize once, at ingestion (issue #1723)
 
 Every user-entered text field is sanitized through the shared helpers in
-`pfblockerng.inc` before it is persisted or parsed — never an ad-hoc
-`trim`/`str_replace` chain:
+`pfblockerng.inc` exactly ONCE, at ingestion — the first operation a handler performs on
+the field, before any evaluation of its contents (validation, comparison, persist) —
+never an ad-hoc `trim`/`str_replace` chain and never re-sanitized downstream:
 
 - **Single-line fields:** `pfb_sanitize_text()` — legacy-encoding→UTF-8 scrub, strips
   control characters (Cc) + BOM, Unicode-aware trim. Unicode format characters
   (ZWJ/ZWNJ, bidi marks) survive: fields accept Unicode text, especially comments.
-- **Multi-line textarea fields:** persist through `pfb_text_area_encode()`
-  (`base64_encode(pfb_sanitize_text_area(...))`) — CRLF/CR normalized to LF, control
-  characters stripped except `\n`/`\t`, each line right-stripped (indentation
-  survives). Parse through `pfb_text_area_decode()`, which drops blank and
-  whitespace-only rows and preserves the valid row `"0"`.
+- **Multi-line textarea fields:** `pfb_sanitize_text_area()` at ingestion — CRLF/CR
+  normalized to LF, control characters stripped except `\n`/`\t`, each line
+  right-stripped (indentation survives) — then persisted with a plain `base64_encode()`.
+  `pfb_text_area_encode()` (`base64_encode(pfb_sanitize_text_area(...))`) remains only
+  for programmatic writers whose encode call itself IS the ingestion point (the
+  alerts.php/pfblockerng_extra.inc/pfblockerng_install.inc re-encoders, the Unbound
+  `custom_options` re-encode) — never a second pass after a `$_POST` field already went
+  through the ingestion prologue. Parse through `pfb_text_area_decode()`, which
+  sanitizes once on read, drops blank/whitespace-only rows, and preserves the valid row
+  `"0"`.
+- **Downstream is structural, not sanitizing:** once ingested, a consumer may still do
+  its own per-format hygiene on the one sanitized binding — split into lines, skip
+  blank/comment rows, lowercase — that is shape-parsing for its own use, not a second
+  sanitize pass. Exemplar: `pfb_unbound.py`'s `_load_user_regex_entries()` base64-decodes
+  the persisted blob, then `re.split()`s and strips per line and skips `#`/blank rows —
+  structural parsing of already-sanitized data, never re-stripping control chars.
 - **Validation stays fail-closed:** `pfb_filter()` remains the backstop gate (rejects
-  Cc/BOM and invalid UTF-8; type-specific checks after). `PFB_FILTER_DOMAIN` /
-  `PFB_FILTER_TLD` accept IDN input by validating its `idn_to_ascii()` punycode form
-  and returning the original text; mixed-script domains are accepted by design
-  (admins block typosquats in their own lists).
+  Cc/BOM and invalid UTF-8; type-specific checks after), run on the one sanitized
+  binding. `PFB_FILTER_DOMAIN` / `PFB_FILTER_TLD` accept IDN input by validating its
+  `idn_to_ascii()` punycode form and returning the original text; mixed-script domains
+  are accepted by design (admins block typosquats in their own lists).
 
 A new field MUST route through these helpers; a persist path that deliberately stays
 narrower documents why (exemplar fork: the hook-script editor, issue #1728). Contracts

--- a/.agents/policy/coding.md
+++ b/.agents/policy/coding.md
@@ -68,6 +68,31 @@ most, but the rule is about clarity as much as cost — one binding names the in
 ("`line` is stripped from here on") instead of making the reader re-verify it per use.
 Applies to new code and to any touched block; fix the redundancy when you edit one.
 
+## Text-field sanitization — shared helpers at the persist boundary (issue #1723)
+
+Every user-entered text field is sanitized through the shared helpers in
+`pfblockerng.inc` before it is persisted or parsed — never an ad-hoc
+`trim`/`str_replace` chain:
+
+- **Single-line fields:** `pfb_sanitize_text()` — legacy-encoding→UTF-8 scrub, strips
+  control characters (Cc) + BOM, Unicode-aware trim. Unicode format characters
+  (ZWJ/ZWNJ, bidi marks) survive: fields accept Unicode text, especially comments.
+- **Multi-line textarea fields:** persist through `pfb_text_area_encode()`
+  (`base64_encode(pfb_sanitize_text_area(...))`) — CRLF/CR normalized to LF, control
+  characters stripped except `\n`/`\t`, each line right-stripped (indentation
+  survives). Parse through `pfb_text_area_decode()`, which drops blank and
+  whitespace-only rows and preserves the valid row `"0"`.
+- **Validation stays fail-closed:** `pfb_filter()` remains the backstop gate (rejects
+  Cc/BOM and invalid UTF-8; type-specific checks after). `PFB_FILTER_DOMAIN` /
+  `PFB_FILTER_TLD` accept IDN input by validating its `idn_to_ascii()` punycode form
+  and returning the original text; mixed-script domains are accepted by design
+  (admins block typosquats in their own lists).
+
+A new field MUST route through these helpers; a persist path that deliberately stays
+narrower documents why (exemplar fork: the hook-script editor, issue #1728). Contracts
+pinned by `PfbSanitizeTextTest`, `TextAreaDecodeTest`, `PfbFilterContractTest`, and
+`tests/smoke/ui/test_sanitize_persist.py`.
+
 ## Linting
 
 Run linters while working; the `.githooks/pre-commit` hook blocks failing commits

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1527,9 +1527,11 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			if (preg_match('/[^\x00-\x7F]/', $input)) {
 				if (str_starts_with($input, '.')) {
 					// idn_to_ascii() returns an empty string on a leading dot;
-					// strip it, convert, then re-prefix on success (mirrors
+					// strip exactly ONE -- ltrim() would strip every leading dot,
+					// collapsing a double leading dot to a single legal label --
+					// convert, then re-prefix on success (mirrors
 					// pfb_text_area_decode()'s IDN branch).
-					$candidate = idn_to_ascii(ltrim($input, '.'));
+					$candidate = idn_to_ascii(substr($input, 1));
 					$candidate = empty($candidate) ? FALSE : ('.' . $candidate);
 				} else {
 					$candidate = idn_to_ascii($input);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7287,7 +7287,7 @@ function pfb_unbound_dnsbl($mode) {
 	// Update config.xml, if changes required
 	if ($pfbupdate) {
 		pfb_logger("{$log}", 1);
-		$unbound_custom = base64_encode(str_replace("\r\n", "\n", $unbound_custom));
+		$unbound_custom = pfb_text_area_encode($unbound_custom);
 		$pfb['unboundconfig'] = "{$unbound_custom}";
 		config_set_path('unbound/custom_options', $pfb['unboundconfig']);
 		write_config('pfBlockerNG: saving Unbound custom options');

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1232,7 +1232,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 		return $return_type;
 	}
 
-	// Check for control characters. The /u modifier is required: without it, \p{C}
+	// Check for control characters. The /u modifier is required: without it, \p{Cc}
 	// classifies each raw BYTE as a Latin-1 codepoint, so a valid multibyte UTF-8
 	// character (e.g. "€", "日") whose continuation byte falls in 0x80-0x9F is
 	// falsely rejected while other non-ASCII bytes pass through unexamined -- and a
@@ -1241,9 +1241,15 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 	// to fail closed (this is a PFBL-01 input-sanitisation gate) rather than open.
 	// The reject above already returned for every non-FILE_MIME type, so this array
 	// branch only ever sees FILE_MIME's flat literal-string arrays (ADR-48).
+	// issue #1723: narrowed from \p{C} (Cc+Cf+Co+Cs+Cn) to \p{Cc}+BOM (\x{FEFF}).
+	// Unicode format characters (Cf: ZWJ/ZWNJ, bidi marks, zero-width) are no
+	// longer grounds to reject a whole field -- free-text fields must accept
+	// Unicode; domain-shaped fields still exclude them via their type-specific
+	// validation below (ASCII regex or IDNA). Cc and the BOM stay rejected;
+	// invalid UTF-8 stays fail-closed.
 	if (is_array($input)) {
 		foreach ($input as $vline) {
-			if (preg_match("/[\p{C}]+/u", $vline) !== 0) {
+			if (preg_match("/[\p{Cc}\x{FEFF}]+/u", $vline) !== 0) {
 				pfb_logger("{$header} Control characters found [ " . htmlspecialchars($vline) . " ]", 6);
 				// ADR-48: this early return precedes the switch, so it also rejects
 				// the FILE_MIME types -- fill the out-param for an opted-in caller
@@ -1257,7 +1263,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 		}
 	}
 	else {
-		if (preg_match("/[\p{C}]+/u", $input) !== 0) {
+		if (preg_match("/[\p{Cc}\x{FEFF}]+/u", $input) !== 0) {
 			pfb_logger("{$header} Control characters found [ " . htmlspecialchars($input) . " ]", 6);
 			if (is_array($reject_detail)) {
 				$reject_detail = array('mime_raw' => 'control-characters', 'mime' => '', 'retval' => -1);
@@ -1497,18 +1503,45 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			}
 			break;
 		case PFB_FILTER_TLD:
-			// Validate TLD
-			if (preg_match("/^[a-zA-Z0-9_\.\-]+$/", $input)) {
+			// Validate TLD. issue #1723: a non-ASCII (IDN) TLD is converted to its
+			// punycode candidate before the charset check; on success the ORIGINAL
+			// input is returned (the read path IDN-converts separately).
+			$candidate = $input;
+			if (preg_match('/[^\x00-\x7F]/', $input)) {
+				$candidate = idn_to_ascii($input);
+				$candidate = empty($candidate) ? FALSE : $candidate;
+			}
+			if (($candidate !== FALSE) && preg_match("/^[a-zA-Z0-9_\.\-]+$/", $candidate)) {
 				$result = htmlspecialchars($input);
 			}
 			break;
 		case PFB_FILTER_DOMAIN:
-			// Validate domain
-			if ((strpos($input, '.') !== FALSE) &&			// Exclude no dots
-			    (strpos($input, '..') === FALSE) &&			// Exclude double dot
-			    (strlen($input) < 255) &&				// Validate length of domain (Max 255 chars)
-			    (pfb_validate_domain_labels($input) !== FALSE) &&	// Validate length of labels (Max of 63 chars)
-			    (preg_match("/^[a-zA-Z0-9_\.\-]+$/", $input))) {  	// Exclude any other characters
+			// Validate domain. issue #1723: a non-ASCII (Unicode/IDN) domain is
+			// converted to its punycode candidate before the existing dots/length/
+			// labels/charset checks run below; on success the ORIGINAL (Unicode)
+			// input is returned (htmlspecialchars'd) -- callers use the return as
+			// a pass/fail gate and persist the raw text, the read path
+			// (pfb_text_area_decode()'s IDN branch) IDN-converts separately at
+			// read time, so what is returned on success must not change.
+			$candidate = $input;
+			if (preg_match('/[^\x00-\x7F]/', $input)) {
+				if (str_starts_with($input, '.')) {
+					// idn_to_ascii() returns an empty string on a leading dot;
+					// strip it, convert, then re-prefix on success (mirrors
+					// pfb_text_area_decode()'s IDN branch).
+					$candidate = idn_to_ascii(ltrim($input, '.'));
+					$candidate = empty($candidate) ? FALSE : ('.' . $candidate);
+				} else {
+					$candidate = idn_to_ascii($input);
+					$candidate = empty($candidate) ? FALSE : $candidate;
+				}
+			}
+			if (($candidate !== FALSE) &&
+			    (strpos($candidate, '.') !== FALSE) &&			// Exclude no dots
+			    (strpos($candidate, '..') === FALSE) &&			// Exclude double dot
+			    (strlen($candidate) < 255) &&				// Validate length of domain (Max 255 chars)
+			    (pfb_validate_domain_labels($candidate) !== FALSE) &&	// Validate length of labels (Max of 63 chars)
+			    (preg_match("/^[a-zA-Z0-9_\.\-]+$/", $candidate))) {  	// Exclude any other characters
 				$result = TRUE;
 			}
 			if ($result) {
@@ -3057,6 +3090,9 @@ function pfb_preg_replace_safe($pattern, $replacement, string $subject): string 
  * whitespace \p{Z}/tab, then the ASCII trim() backstop). Unicode format
  * characters (ZWJ/ZWNJ/bidi marks) are NOT Cc and survive. A pathological
  * preg_replace() failure degrades to the unstripped input, never to NULL.
+ * Under a pathological (~1M-char) whitespace run the guarded preg pass
+ * degrades fail-open the same way, so Unicode-whitespace stripping may not
+ * apply for that call.
  */
 function pfb_sanitize_text(string $text): string {
 	if (!mb_check_encoding($text, 'UTF-8')) {
@@ -3080,6 +3116,9 @@ function pfb_sanitize_text(string $text): string {
  * NOT drop blank lines; that is the caller's job (issue #1707). A
  * pathological preg_replace() failure degrades to the unstripped input (or,
  * per line, the ASCII-rtrim'd line) instead of wiping rows or fatal-ing.
+ * Under a pathological (~1M-char) whitespace run the guarded preg pass
+ * degrades fail-open the same way, so Unicode-whitespace stripping may not
+ * apply for that call.
  */
 function pfb_sanitize_text_area(string $text): string {
 	if (!mb_check_encoding($text, 'UTF-8')) {
@@ -3188,6 +3227,16 @@ function pfb_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
 		}
 		return $custom;
 	}
+}
+
+
+/**
+ * Persist-boundary counterpart to pfb_text_area_decode(): sanitizes a raw
+ * textarea blob (pfb_sanitize_text_area()) and base64-encodes it for config
+ * storage. Every textarea save routes through it (issue #1723).
+ */
+function pfb_text_area_encode(string $raw): string {
+	return base64_encode(pfb_sanitize_text_area($raw));
 }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3595,7 +3595,7 @@ function pfb_py_sync_status_list_open(string $status_dir): array
  * PURE — no config access, no I/O; only the pfSense is_subnetv4()/is_subnetv6()
  * predicates.
  *
- * @param  string $line   One raw textarea line (as split on "\r\n"), untrimmed.
+ * @param  string $line   One raw textarea line (as split on "\n" post-ingestion-sanitize, issue #1723), untrimmed.
  * @param  string $family 'ipv4' or 'ipv6'.
  * @return string|null    NULL when the line is valid (or a comment/blank no-op);
  *                         otherwise the input_errors message for this line.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -4444,7 +4444,7 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 				$data .= "{$line}";
 			}
 			$data .= "{$supp_dat}\r\n";
-			$clists[$supp_key]['base64'] = base64_encode($data);
+			$clists[$supp_key]['base64'] = pfb_text_area_encode($data);
 			PfbConfig::write($cfg_key, $clists[$supp_key]['base64']);
 			write_config("pfBlockerNG: Added {$ip} to the IPv{$family} Suppression customlist", FALSE);
 			$refresh_suppfile = TRUE;
@@ -4515,7 +4515,7 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 			$custom .= "{$line}";
 		}
 		$custom .= $whitelist_string;
-		$clists[$list_key][$table]['base64'] = base64_encode($custom);
+		$clists[$list_key][$table]['base64'] = pfb_text_area_encode($custom);
 		$base64_idx = $metadata['base64_idx'];
 		// foreign structure: pfblockernglistsv4/v6/config/{row}/custom is a dynamic per-row key, not a registered config field
 		config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$base64_idx}/custom", $clists[$list_key][$table]['base64']);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -630,7 +630,7 @@ if (!isset($pfb_ip_cfg['v4suppression'])) {
 			}
 			// ADR-53: write via the same section array read above (a bulk migration
 			// write alongside the rest of $pfb_ip_cfg, not a lone per-field save).
-			$pfb_ip_cfg['v4suppression'] = base64_encode($customlist) ?: '';
+			$pfb_ip_cfg['v4suppression'] = pfb_text_area_encode($customlist) ?: '';
 			PfbConfig::writeSection('installedpackages/pfblockerngipsettings/config/0', $pfb_ip_cfg);
 			// unset($config['aliases']['alias'][$key]);
 			$ufound = TRUE;

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -853,7 +853,7 @@ if (isset($_POST) && !empty($_POST)) {
 					$data .= "{$line}";
 				}
 			}
-			$clists['dnsblwhitelist']['base64'] = base64_encode($data);
+			$clists['dnsblwhitelist']['base64'] = pfb_text_area_encode($data);
 			PfbConfig::write('suppression', $clists['dnsblwhitelist']['base64']);
 			write_config("pfBlockerNG: Removed [ {$wl_base} ] from DNSBL Whitelist (added to Custom_List)", FALSE);
 
@@ -879,7 +879,7 @@ if (isset($_POST) && !empty($_POST)) {
 			} else {
 				$data .= "{$domain}\r\n";
 			}
-			$clists['dnsbl'][$list]['base64'] = base64_encode($data);
+			$clists['dnsbl'][$list]['base64'] = pfb_text_area_encode($data);
 			// foreign structure: pfblockerngdnsbl/config/{row}/custom is a dynamic per-row key, not in registry
 			config_set_path("installedpackages/pfblockerngdnsbl/config/{$clists['dnsbl'][$list]['base64_idx']}/custom", $clists['dnsbl'][$list]['base64']);
 			write_config("pfBlockerNG: Added [ {$domain} ] to DNSBL Group [ {$list} ] customlist", FALSE);
@@ -1020,7 +1020,7 @@ if (isset($_POST) && !empty($_POST)) {
 					}
 				}
 				$data .= "{$whitelist}\r\n";
-				$clists['dnsblwhitelist']['base64'] = base64_encode($data);
+				$clists['dnsblwhitelist']['base64'] = pfb_text_area_encode($data);
 				PfbConfig::write('suppression', $clists['dnsblwhitelist']['base64']);
 				write_config("pfBlockerNG: Added [ {$domain} ] to DNSBL Whitelist", FALSE);
 			}
@@ -1057,7 +1057,7 @@ if (isset($_POST) && !empty($_POST)) {
 				foreach ($clists['dnsbl'][$lname]['data'] as $line) {
 					$data .= "{$line}";
 				}
-				$clists['dnsbl'][$lname]['base64'] = base64_encode($data);
+				$clists['dnsbl'][$lname]['base64'] = pfb_text_area_encode($data);
 				// foreign structure: pfblockerngdnsbl/config/{row}/custom is a dynamic per-row key, not in registry
 				config_set_path("installedpackages/pfblockerngdnsbl/config/{$clists['dnsbl'][$lname]['base64_idx']}/custom", $clists['dnsbl'][$lname]['base64']);
 				write_config("pfBlockerNG: Removed [ {$domain} ] from DNSBL Group [ {$lname} ] customlist (whitelisted)", FALSE);
@@ -1120,7 +1120,7 @@ if (isset($_POST) && !empty($_POST)) {
 					$data .= "{$line}";
 				}
 				$data .= "{$exclude_string}\r\n";
-				$clists['tldexclusion']['base64'] = base64_encode($data);
+				$clists['tldexclusion']['base64'] = pfb_text_area_encode($data);
 				PfbConfig::write('tldexclusion', $clists['tldexclusion']['base64']);
 				write_config("pfBlockerNG: Added [ {$domain} ] to DNSBL TLD Exclusion customlist.", FALSE);
 			}
@@ -1221,7 +1221,7 @@ if (isset($_POST) && !empty($_POST)) {
 						$data .= "{$line}";
 					}
 				}
-				$clists['dnsblwhitelist']['base64'] = base64_encode($data);
+				$clists['dnsblwhitelist']['base64'] = pfb_text_area_encode($data);
 				PfbConfig::write('suppression', $clists['dnsblwhitelist']['base64']);
 				break;
 			case 'delete_exclusion':
@@ -1234,7 +1234,7 @@ if (isset($_POST) && !empty($_POST)) {
 				foreach ($clists['tldexclusion']['data'] as $line) {
 					$data .= "{$line}";
 				}
-				$clists['tldexclusion']['base64'] = base64_encode($data);
+				$clists['tldexclusion']['base64'] = pfb_text_area_encode($data);
 				PfbConfig::write('tldexclusion', $clists['tldexclusion']['base64']);
 				break;
 			case 'delete_ip':
@@ -1269,7 +1269,7 @@ if (isset($_POST) && !empty($_POST)) {
 						foreach ($clists[$supp_key]['data'] as $line) {
 							$data .= "{$line}";
 						}
-						$clists[$supp_key]['base64'] = base64_encode($data);
+						$clists[$supp_key]['base64'] = pfb_text_area_encode($data);
 						PfbConfig::write($cfg_key, $clists[$supp_key]['base64']);
 
 						// Keep pfbsuppression(_v6).txt in step with the config edit --
@@ -1310,7 +1310,7 @@ if (isset($_POST) && !empty($_POST)) {
 							$data .= "{$line}";
 						}
 
-						$clists['ipwhitelist' . $vtype][$table_2]['base64'] = base64_encode($data);
+						$clists['ipwhitelist' . $vtype][$table_2]['base64'] = pfb_text_area_encode($data);
 						// foreign structure: pfblockernglistsv4/v6/config/{row}/custom is a dynamic per-row key, not in registry
 						config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$clists['ipwhitelist' . $vtype][$table_2]['base64_idx']}/custom", $clists['ipwhitelist' . $vtype][$table_2]['base64']);
 						$aname = substr(substr($table_2, 4),0, -3);					// Remove 'pfB_' and '_v4'

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -463,6 +463,29 @@ if ($_POST && isset($_POST['save'])) {
 		unset($_REQUEST['savemsg']);
 	}
 
+	// issue #1106: reject an array-valued field ('aliasname[]=x') before any string
+	// sink below TypeErrors on it. Every field is scalar in normal use; no field is exempt.
+	// Runs before the #1723 sanitize prologue below (which itself string-casts every
+	// target field) and before the select-options coercion below (several of the
+	// #1723 target fields -- aliasports_in/out, aliasaddr_in/out, srcint, script_pre/
+	// post -- are ALSO select_options entries, so the sanitize prologue must run
+	// before that coercion too, not just before the free-text-specific checks).
+	foreach ($_POST as $pfb_post_key => $pfb_post_value) {
+		if (!is_scalar($pfb_post_value)) {
+			$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars((string) $pfb_post_key);
+			$_POST[$pfb_post_key] = '';
+		}
+	}
+
+	// issue #1723: sanitize at ingestion -- first step, before any evaluation
+	// (trims stray whitespace that would otherwise false-trip the \W reject
+	// below; strips control chars).
+	foreach (array('aliasname', 'description', 'srcint', 'script_pre', 'script_post',
+			'aliasports_in', 'aliasports_out', 'aliasaddr_in', 'aliasaddr_out') as $pfb_text_field) {
+		$_POST[$pfb_text_field] = pfb_sanitize_text((string) ($_POST[$pfb_text_field] ?? ''));
+	}
+	$_POST['custom'] = pfb_sanitize_text_area((string) ($_POST['custom'] ?? ''));
+
 	// Validate Select field options
 	$select_options = array(	'action'		=> 'Disabled',
 					'cron'			=> 'Never',
@@ -498,20 +521,6 @@ if ($_POST && isset($_POST['save'])) {
 			$_POST[$s_option] = $s_default;
 		}
 	}
-
-	// issue #1106: reject an array-valued field ('aliasname[]=x') before any string
-	// sink below TypeErrors on it. Every field is scalar in normal use; no field is exempt.
-	foreach ($_POST as $pfb_post_key => $pfb_post_value) {
-		if (!is_scalar($pfb_post_value)) {
-			$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars((string) $pfb_post_key);
-			$_POST[$pfb_post_key] = '';
-		}
-	}
-
-	// issue #1723: sanitize the single-line free-text field BEFORE the \W /
-	// length validation below reads it (trims stray whitespace that would
-	// otherwise false-trip the \W reject; strips control chars).
-	$_POST['aliasname'] = pfb_sanitize_text($_POST['aliasname'] ?? '');
 
 	if (empty($_POST['aliasname'])) {
 		$input_errors[] = 'Info: Name field must be defined.';
@@ -690,7 +699,10 @@ if ($_POST && isset($_POST['save'])) {
 
 	// Validate Custom List
 	if (!empty($_POST['custom'])) {
-		$customlist = explode("\r\n", $_POST['custom']);
+		// issue #1723: the ingestion prologue already normalized CRLF/CR to LF, so
+		// per-line validation now splits on "\n" (the pre-#1723 "\r\n" split matched
+		// a browser's raw CRLF submission; that separator no longer survives ingestion).
+		$customlist = explode("\n", $_POST['custom']);
 		if (!empty($customlist)) {
 			foreach ($customlist as $line) {
 
@@ -773,10 +785,10 @@ if ($_POST && isset($_POST['save'])) {
 		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/aliasname", $_POST['aliasname'] ?: '');
 
 		if (isset($_POST['description']) && !empty($_POST['description'])) {
-			// issue #1723: sanitize BEFORE pfb_filter() -- its own universal
-			// control-char gate would otherwise reject the whole value (not just
-			// the control char) and silently store '' instead.
-			config_set_path("installedpackages/{$conf_type}/config/{$rowid}/description", pfb_filter(pfb_sanitize_text($_POST['description']), PFB_FILTER_HTML, 'Category_edit') ?: '');
+			// issue #1723: already sanitized by the ingestion prologue above -- pfb_filter()'s
+			// own universal control-char gate would otherwise reject the whole (unsanitized)
+			// value instead of just the control char, and silently store '' instead.
+			config_set_path("installedpackages/{$conf_type}/config/{$rowid}/description", pfb_filter($_POST['description'], PFB_FILTER_HTML, 'Category_edit') ?: '');
 		} else {
 			config_set_path("installedpackages/{$conf_type}/config/{$rowid}/description", '');
 		}
@@ -786,9 +798,10 @@ if ($_POST && isset($_POST['save'])) {
 		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/dow", $_POST['dow'] ?: '');
 		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/sort", $_POST['sort'] ?: 'sort');
 
-		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/srcint", pfb_sanitize_text($_POST['srcint'] ?? '') ?: '');
-		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/script_pre", pfb_sanitize_text($_POST['script_pre'] ?? '') ?: '');
-		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/script_post", pfb_sanitize_text($_POST['script_post'] ?? '') ?: '');
+		// issue #1723: already sanitized by the ingestion prologue above -- plain read.
+		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/srcint", $_POST['srcint'] ?: '');
+		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/script_pre", $_POST['script_pre'] ?: '');
+		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/script_post", $_POST['script_post'] ?: '');
 
 		if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 			config_set_path("installedpackages/{$conf_type}/config/{$rowid}/aliaslog", $_POST['aliaslog'] ?: 'enabled');
@@ -838,7 +851,7 @@ if ($_POST && isset($_POST['save'])) {
 			}
 		}
 
-		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/custom", pfb_text_area_encode($_POST['custom'] ?? '') ?: '');
+		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/custom", base64_encode($_POST['custom'] ?? '') ?: '');
 
 		$rowhelper_exist = array();
 		foreach ($_POST as $key => $value) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -318,7 +318,7 @@ if (($action == 'add' || $action == 'addgroup') && !empty($atype) && !isset($_PO
 			} else {
 				$custom_line = "{$data[1]}";
 			}
-			$rowdata[$rowid]['custom'] = base64_encode("{$custom_line}");
+			$rowdata[$rowid]['custom'] = pfb_text_area_encode("{$custom_line}");
 		}
 
 		// Create new Alias via Feeds Tab
@@ -507,6 +507,11 @@ if ($_POST && isset($_POST['save'])) {
 			$_POST[$pfb_post_key] = '';
 		}
 	}
+
+	// issue #1723: sanitize the single-line free-text field BEFORE the \W /
+	// length validation below reads it (trims stray whitespace that would
+	// otherwise false-trip the \W reject; strips control chars).
+	$_POST['aliasname'] = pfb_sanitize_text($_POST['aliasname'] ?? '');
 
 	if (empty($_POST['aliasname'])) {
 		$input_errors[] = 'Info: Name field must be defined.';
@@ -768,7 +773,10 @@ if ($_POST && isset($_POST['save'])) {
 		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/aliasname", $_POST['aliasname'] ?: '');
 
 		if (isset($_POST['description']) && !empty($_POST['description'])) {
-			config_set_path("installedpackages/{$conf_type}/config/{$rowid}/description", pfb_filter($_POST['description'], PFB_FILTER_HTML, 'Category_edit') ?: '');
+			// issue #1723: sanitize BEFORE pfb_filter() -- its own universal
+			// control-char gate would otherwise reject the whole value (not just
+			// the control char) and silently store '' instead.
+			config_set_path("installedpackages/{$conf_type}/config/{$rowid}/description", pfb_filter(pfb_sanitize_text($_POST['description']), PFB_FILTER_HTML, 'Category_edit') ?: '');
 		} else {
 			config_set_path("installedpackages/{$conf_type}/config/{$rowid}/description", '');
 		}
@@ -778,9 +786,9 @@ if ($_POST && isset($_POST['save'])) {
 		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/dow", $_POST['dow'] ?: '');
 		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/sort", $_POST['sort'] ?: 'sort');
 
-		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/srcint", $_POST['srcint'] ?: '');
-		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/script_pre", $_POST['script_pre'] ?: '');
-		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/script_post", $_POST['script_post'] ?: '');
+		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/srcint", pfb_sanitize_text($_POST['srcint'] ?? '') ?: '');
+		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/script_pre", pfb_sanitize_text($_POST['script_pre'] ?? '') ?: '');
+		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/script_post", pfb_sanitize_text($_POST['script_post'] ?? '') ?: '');
 
 		if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 			config_set_path("installedpackages/{$conf_type}/config/{$rowid}/aliaslog", $_POST['aliaslog'] ?: 'enabled');
@@ -830,7 +838,7 @@ if ($_POST && isset($_POST['save'])) {
 			}
 		}
 
-		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/custom", base64_encode($_POST['custom']) ?: '');
+		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/custom", pfb_text_area_encode($_POST['custom'] ?? '') ?: '');
 
 		$rowhelper_exist = array();
 		foreach ($_POST as $key => $value) {
@@ -841,6 +849,14 @@ if ($_POST && isset($_POST['save'])) {
 
 				// Collect all rowhelper keys
 				$rowhelper_exist[$k_field[1]] = '';
+
+				// issue #1723: sanitize the header/url single-line text columns
+				// before their existing PFB_FILTER_HTML/htmlentities handling below
+				// (state-N/format-N stay untouched -- they are select values, not
+				// free text).
+				if (in_array($k_field[0], array('header', 'url'), TRUE)) {
+					$value = pfb_sanitize_text((string) $value);
+				}
 
 				if (!empty($value) && $k_field[0] != 'url') {
 					$value = pfb_filter($value, PFB_FILTER_HTML, 'Category_edit save');

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -644,7 +644,7 @@ if ($_POST) {
 		// reject a real base64url/JWT token -- PFB_FILTER_TOKEN accepts that charset.
 		// Reference 'top1m_token' suppresses pfb_filter()'s failed-validation log line
 		// -- the token itself must never reach a log, even a rejected one.
-		$pfb_top1m_token_post = trim((string) ($_POST['top1m_token'] ?? ''));
+		$pfb_top1m_token_post = pfb_sanitize_text((string) ($_POST['top1m_token'] ?? ''));
 		if ($pfb_top1m_token_post !== '' && empty(pfb_filter($pfb_top1m_token_post, PFB_FILTER_TOKEN, 'top1m_token'))) {
 			$input_errors[] = 'DNSBL TOP1M Token is invalid!';
 		}
@@ -858,19 +858,22 @@ if ($_POST) {
 
 			$pfb['dconfig']['autoaddrnot_in']	= pfb_filter($_POST['autoaddrnot_in'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['autoports_in']		= pfb_filter($_POST['autoports_in'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
-			$pfb['dconfig']['aliasports_in']	= $_POST['aliasports_in']						?: '';
+			// issue #1723 review: aliasaddr_in/out, aliasports_in/out are free-text
+			// fields with no pfb_filter() gate -- sanitize at the persist boundary
+			// like the other single-line fields in this file.
+			$pfb['dconfig']['aliasports_in']	= pfb_sanitize_text((string) ($_POST['aliasports_in'] ?? ''))		?: '';
 			$pfb['dconfig']['autoaddr_in']		= pfb_filter($_POST['autoaddr_in'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['autonot_in']		= pfb_filter($_POST['autonot_in'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
-			$pfb['dconfig']['aliasaddr_in']		= $_POST['aliasaddr_in']						?: '';
+			$pfb['dconfig']['aliasaddr_in']		= pfb_sanitize_text((string) ($_POST['aliasaddr_in'] ?? ''))		?: '';
 			$pfb['dconfig']['autoproto_in']		= $_POST['autoproto_in']						?: 'any';
 			$pfb['dconfig']['agateway_in']		= $_POST['agateway_in']							?: 'default';
 
 			$pfb['dconfig']['autoaddrnot_out']	= pfb_filter($_POST['autoaddrnot_out'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['autoports_out']	= pfb_filter($_POST['autoports_out'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
-			$pfb['dconfig']['aliasports_out']	= $_POST['aliasports_out']						?: '';
+			$pfb['dconfig']['aliasports_out']	= pfb_sanitize_text((string) ($_POST['aliasports_out'] ?? ''))	?: '';
 			$pfb['dconfig']['autoaddr_out']		= pfb_filter($_POST['autoaddr_out'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['autonot_out']		= pfb_filter($_POST['autonot_out'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
-			$pfb['dconfig']['aliasaddr_out']	= $_POST['aliasaddr_out']						?: '';
+			$pfb['dconfig']['aliasaddr_out']	= pfb_sanitize_text((string) ($_POST['aliasaddr_out'] ?? ''))		?: '';
 			$pfb['dconfig']['autoproto_out']	= $_POST['autoproto_out']						?: 'any';
 			$pfb['dconfig']['agateway_out']		= $_POST['agateway_out']						?: 'default';
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -542,6 +542,15 @@ $savemsg = '';
 if ($_POST) {
 	if (isset($_POST['save'])) {
 
+		// issue #1723: sanitize at ingestion -- first step, before any evaluation.
+		foreach (array('pfb_dnsvip4', 'pfb_dnsvip6', 'dnsbl_webpage', 'dnsbl_redir_exclude', 'dnsbl_dot_block_exclude',
+				'top1m_token', 'aliasaddr_in', 'aliasaddr_out', 'aliasports_in', 'aliasports_out') as $pfb_text_field) {
+			$_POST[$pfb_text_field] = pfb_sanitize_text((string) ($_POST[$pfb_text_field] ?? ''));
+		}
+		foreach (array('pfb_regex_list', 'pfb_noaaaa_list', 'pfb_gp_bypass_list', 'suppression', 'tldexclusion', 'tldblacklist') as $pfb_text_area_field) {
+			$_POST[$pfb_text_area_field] = pfb_sanitize_text_area((string) ($_POST[$pfb_text_area_field] ?? ''));
+		}
+
 		// Validate Select field options
 		$select_options = array(						'dnsbl_interface'	=> 'lo0',
 						'global_log'		=> '',
@@ -591,7 +600,8 @@ if ($_POST) {
 
 		// Validate DNSBL webserver block page
 		$dnsbl_webpage		= FALSE;
-		$dnsbl_webpage_file	= pfb_filter(basename(pfb_sanitize_text($_POST['dnsbl_webpage'] ?? '')), PFB_FILTER_WORD_DOT, 'dnsbl', 'dnsbl_default.php');
+		// issue #1723: already sanitized by the ingestion prologue above -- plain read.
+		$dnsbl_webpage_file	= pfb_filter(basename($_POST['dnsbl_webpage'] ?? ''), PFB_FILTER_WORD_DOT, 'dnsbl', 'dnsbl_default.php');
 		if (file_exists("/usr/local/www/pfblockerng/www/{$dnsbl_webpage_file}") &&
 		    @filesize("/usr/local/www/pfblockerng/www/{$dnsbl_webpage_file}") > 0 &&
 		    pfb_filter(array("/usr/local/www/pfblockerng/www/{$dnsbl_webpage_file}", 'text/html'), PFB_FILTER_FILE_MIME_COMPARE, 'dnsbl')) {
@@ -644,7 +654,8 @@ if ($_POST) {
 		// reject a real base64url/JWT token -- PFB_FILTER_TOKEN accepts that charset.
 		// Reference 'top1m_token' suppresses pfb_filter()'s failed-validation log line
 		// -- the token itself must never reach a log, even a rejected one.
-		$pfb_top1m_token_post = pfb_sanitize_text((string) ($_POST['top1m_token'] ?? ''));
+		// issue #1723: already sanitized by the ingestion prologue above -- plain read.
+		$pfb_top1m_token_post = (string) ($_POST['top1m_token'] ?? '');
 		if ($pfb_top1m_token_post !== '' && empty(pfb_filter($pfb_top1m_token_post, PFB_FILTER_TOKEN, 'top1m_token'))) {
 			$input_errors[] = 'DNSBL TOP1M Token is invalid!';
 		}
@@ -658,7 +669,11 @@ if ($_POST) {
 				'tldblacklist'		=> 'tld' ) as $custom_type => $custom_format) {
 
 				if (!empty($_POST[$custom_type])) {
-					$customlist = explode("\r\n", $_POST[$custom_type]);
+					// issue #1723: the ingestion prologue already normalized CRLF/CR to LF,
+					// so per-line validation now splits on "\n" (the pre-#1723 "\r\n" split
+					// matched a browser's raw CRLF submission; that separator no longer
+					// survives ingestion).
+					$customlist = explode("\n", $_POST[$custom_type]);
 					if (!empty($customlist)) {
 						foreach ($customlist as $line) {
 
@@ -720,9 +735,7 @@ if ($_POST) {
 		// error (ADR-13 §7 pivot — it is a non-blocking runtime warning from pfb_global).
 		$pfb_auto = (isset($_POST['pfb_dnsvip_auto']) && $_POST['pfb_dnsvip_auto'] == 'on');
 		if (!$pfb_auto) {
-			// issue #1723: sanitize before the 'none' compare / VIP validation below.
-			$_POST['pfb_dnsvip4'] = pfb_sanitize_text($_POST['pfb_dnsvip4'] ?? '');
-			$_POST['pfb_dnsvip6'] = pfb_sanitize_text($_POST['pfb_dnsvip6'] ?? '');
+			// issue #1723: already sanitized by the ingestion prologue above.
 			if (($_POST['pfb_dnsvip4'] ?? '') == 'none') {
 				$_POST['pfb_dnsvip4'] = '';
 			}
@@ -770,7 +783,8 @@ if ($_POST) {
 
 		// Validate DNS Redirect fields.
 		$redir_ifaces_raw = (array)($_POST['dnsbl_redir_int'] ?? []);
-		$redir_alias_raw  = pfb_sanitize_text((string)($_POST['dnsbl_redir_exclude'] ?? ''));
+		// issue #1723: already sanitized by the ingestion prologue above -- plain read.
+		$redir_alias_raw  = (string)($_POST['dnsbl_redir_exclude'] ?? '');
 		$redir_errors     = pfb_validate_dns_redirect_post(
 			$redir_ifaces_raw,
 			array_keys($options_dnsbl_redir_int),
@@ -780,7 +794,8 @@ if ($_POST) {
 
 		// Validate DoT/DoQ Block fields.
 		$dot_block_ifaces_raw = (array)($_POST['dnsbl_dot_block_int'] ?? []);
-		$dot_block_alias_raw  = pfb_sanitize_text((string)($_POST['dnsbl_dot_block_exclude'] ?? ''));
+		// issue #1723: already sanitized by the ingestion prologue above -- plain read.
+		$dot_block_alias_raw  = (string)($_POST['dnsbl_dot_block_exclude'] ?? '');
 		$dot_block_action_raw = (string)($_POST['dnsbl_dot_block_action'] ?? 'reject');
 		$dot_block_errors     = pfb_validate_dot_block_post(
 			$dot_block_ifaces_raw,
@@ -858,33 +873,33 @@ if ($_POST) {
 
 			$pfb['dconfig']['autoaddrnot_in']	= pfb_filter($_POST['autoaddrnot_in'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['autoports_in']		= pfb_filter($_POST['autoports_in'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
-			// issue #1723 review: aliasaddr_in/out, aliasports_in/out are free-text
-			// fields with no pfb_filter() gate -- sanitize at the persist boundary
-			// like the other single-line fields in this file.
-			$pfb['dconfig']['aliasports_in']	= pfb_sanitize_text((string) ($_POST['aliasports_in'] ?? ''))		?: '';
+			// issue #1723: aliasaddr_in/out, aliasports_in/out already sanitized by the
+			// ingestion prologue above -- plain read.
+			$pfb['dconfig']['aliasports_in']	= $_POST['aliasports_in']						?: '';
 			$pfb['dconfig']['autoaddr_in']		= pfb_filter($_POST['autoaddr_in'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['autonot_in']		= pfb_filter($_POST['autonot_in'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
-			$pfb['dconfig']['aliasaddr_in']		= pfb_sanitize_text((string) ($_POST['aliasaddr_in'] ?? ''))		?: '';
+			$pfb['dconfig']['aliasaddr_in']		= $_POST['aliasaddr_in']						?: '';
 			$pfb['dconfig']['autoproto_in']		= $_POST['autoproto_in']						?: 'any';
 			$pfb['dconfig']['agateway_in']		= $_POST['agateway_in']							?: 'default';
 
 			$pfb['dconfig']['autoaddrnot_out']	= pfb_filter($_POST['autoaddrnot_out'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['autoports_out']	= pfb_filter($_POST['autoports_out'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
-			$pfb['dconfig']['aliasports_out']	= pfb_sanitize_text((string) ($_POST['aliasports_out'] ?? ''))	?: '';
+			$pfb['dconfig']['aliasports_out']	= $_POST['aliasports_out']						?: '';
 			$pfb['dconfig']['autoaddr_out']		= pfb_filter($_POST['autoaddr_out'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['autonot_out']		= pfb_filter($_POST['autonot_out'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
-			$pfb['dconfig']['aliasaddr_out']	= pfb_sanitize_text((string) ($_POST['aliasaddr_out'] ?? ''))		?: '';
+			$pfb['dconfig']['aliasaddr_out']	= $_POST['aliasaddr_out']						?: '';
 			$pfb['dconfig']['autoproto_out']	= $_POST['autoproto_out']						?: 'any';
 			$pfb['dconfig']['agateway_out']		= $_POST['agateway_out']						?: 'default';
 
 			$pfb['dconfig']['alexa_enable']		= pfb_filter($_POST['alexa_enable'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 
-			$pfb['dconfig']['pfb_regex_list']	= pfb_text_area_encode($_POST['pfb_regex_list'] ?? '')			?: '';
-			$pfb['dconfig']['pfb_noaaaa_list']	= pfb_text_area_encode($_POST['pfb_noaaaa_list'] ?? '')			?: '';
-			$pfb['dconfig']['pfb_gp_bypass_list']	= pfb_text_area_encode($_POST['pfb_gp_bypass_list'] ?? '')			?: '';
-			$pfb['dconfig']['suppression']		= pfb_text_area_encode($_POST['suppression'] ?? '')				?: '';
-			$pfb['dconfig']['tldexclusion']		= pfb_text_area_encode($_POST['tldexclusion'] ?? '')				?: '';
-			$pfb['dconfig']['tldblacklist']		= pfb_text_area_encode($_POST['tldblacklist'] ?? '')				?: '';
+			// issue #1723: already sanitized by the ingestion prologue above -- plain encode.
+			$pfb['dconfig']['pfb_regex_list']	= base64_encode($_POST['pfb_regex_list'] ?? '')				?: '';
+			$pfb['dconfig']['pfb_noaaaa_list']	= base64_encode($_POST['pfb_noaaaa_list'] ?? '')				?: '';
+			$pfb['dconfig']['pfb_gp_bypass_list']	= base64_encode($_POST['pfb_gp_bypass_list'] ?? '')				?: '';
+			$pfb['dconfig']['suppression']		= base64_encode($_POST['suppression'] ?? '')					?: '';
+			$pfb['dconfig']['tldexclusion']		= base64_encode($_POST['tldexclusion'] ?? '')					?: '';
+			$pfb['dconfig']['tldblacklist']		= base64_encode($_POST['tldblacklist'] ?? '')					?: '';
 
 			// A provider/auth identity change invalidates only the download detector
 			// baseline. Keep the active source and derived whitelist available until

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -591,7 +591,7 @@ if ($_POST) {
 
 		// Validate DNSBL webserver block page
 		$dnsbl_webpage		= FALSE;
-		$dnsbl_webpage_file	= pfb_filter(basename($_POST['dnsbl_webpage']), PFB_FILTER_WORD_DOT, 'dnsbl', 'dnsbl_default.php');
+		$dnsbl_webpage_file	= pfb_filter(basename(pfb_sanitize_text($_POST['dnsbl_webpage'] ?? '')), PFB_FILTER_WORD_DOT, 'dnsbl', 'dnsbl_default.php');
 		if (file_exists("/usr/local/www/pfblockerng/www/{$dnsbl_webpage_file}") &&
 		    @filesize("/usr/local/www/pfblockerng/www/{$dnsbl_webpage_file}") > 0 &&
 		    pfb_filter(array("/usr/local/www/pfblockerng/www/{$dnsbl_webpage_file}", 'text/html'), PFB_FILTER_FILE_MIME_COMPARE, 'dnsbl')) {
@@ -720,6 +720,9 @@ if ($_POST) {
 		// error (ADR-13 §7 pivot — it is a non-blocking runtime warning from pfb_global).
 		$pfb_auto = (isset($_POST['pfb_dnsvip_auto']) && $_POST['pfb_dnsvip_auto'] == 'on');
 		if (!$pfb_auto) {
+			// issue #1723: sanitize before the 'none' compare / VIP validation below.
+			$_POST['pfb_dnsvip4'] = pfb_sanitize_text($_POST['pfb_dnsvip4'] ?? '');
+			$_POST['pfb_dnsvip6'] = pfb_sanitize_text($_POST['pfb_dnsvip6'] ?? '');
 			if (($_POST['pfb_dnsvip4'] ?? '') == 'none') {
 				$_POST['pfb_dnsvip4'] = '';
 			}
@@ -767,7 +770,7 @@ if ($_POST) {
 
 		// Validate DNS Redirect fields.
 		$redir_ifaces_raw = (array)($_POST['dnsbl_redir_int'] ?? []);
-		$redir_alias_raw  = trim((string)($_POST['dnsbl_redir_exclude'] ?? ''));
+		$redir_alias_raw  = pfb_sanitize_text((string)($_POST['dnsbl_redir_exclude'] ?? ''));
 		$redir_errors     = pfb_validate_dns_redirect_post(
 			$redir_ifaces_raw,
 			array_keys($options_dnsbl_redir_int),
@@ -777,7 +780,7 @@ if ($_POST) {
 
 		// Validate DoT/DoQ Block fields.
 		$dot_block_ifaces_raw = (array)($_POST['dnsbl_dot_block_int'] ?? []);
-		$dot_block_alias_raw  = trim((string)($_POST['dnsbl_dot_block_exclude'] ?? ''));
+		$dot_block_alias_raw  = pfb_sanitize_text((string)($_POST['dnsbl_dot_block_exclude'] ?? ''));
 		$dot_block_action_raw = (string)($_POST['dnsbl_dot_block_action'] ?? 'reject');
 		$dot_block_errors     = pfb_validate_dot_block_post(
 			$dot_block_ifaces_raw,
@@ -873,12 +876,12 @@ if ($_POST) {
 
 			$pfb['dconfig']['alexa_enable']		= pfb_filter($_POST['alexa_enable'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 
-			$pfb['dconfig']['pfb_regex_list']	= base64_encode($_POST['pfb_regex_list'])				?: '';
-			$pfb['dconfig']['pfb_noaaaa_list']	= base64_encode($_POST['pfb_noaaaa_list'])				?: '';
-			$pfb['dconfig']['pfb_gp_bypass_list']	= base64_encode($_POST['pfb_gp_bypass_list'])				?: '';
-			$pfb['dconfig']['suppression']		= base64_encode($_POST['suppression'])					?: '';
-			$pfb['dconfig']['tldexclusion']		= base64_encode($_POST['tldexclusion'])					?: '';
-			$pfb['dconfig']['tldblacklist']		= base64_encode($_POST['tldblacklist'])					?: '';
+			$pfb['dconfig']['pfb_regex_list']	= pfb_text_area_encode($_POST['pfb_regex_list'] ?? '')			?: '';
+			$pfb['dconfig']['pfb_noaaaa_list']	= pfb_text_area_encode($_POST['pfb_noaaaa_list'] ?? '')			?: '';
+			$pfb['dconfig']['pfb_gp_bypass_list']	= pfb_text_area_encode($_POST['pfb_gp_bypass_list'] ?? '')			?: '';
+			$pfb['dconfig']['suppression']		= pfb_text_area_encode($_POST['suppression'] ?? '')				?: '';
+			$pfb['dconfig']['tldexclusion']		= pfb_text_area_encode($_POST['tldexclusion'] ?? '')				?: '';
+			$pfb['dconfig']['tldblacklist']		= pfb_text_area_encode($_POST['tldblacklist'] ?? '')				?: '';
 
 			// A provider/auth identity change invalidates only the download detector
 			// baseline. Keep the active source and derived whitelist available until

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -126,6 +126,11 @@ $input_errors = array();
 if ($_POST) {
 	if (isset($_POST['save'])) {
 
+		// issue #1723: sanitize at ingestion -- first step, before any evaluation.
+		// The whole-blob trim() folds in here too (persist-site base64_encode() is
+		// now plain -- sanitize once, never re-sanitize downstream).
+		$_POST['pfb_feed_internal_allowlist'] = trim(pfb_sanitize_text_area((string) ($_POST['pfb_feed_internal_allowlist'] ?? '')));
+
 		// Validate Select field options
 		$select_options = array(	'pfb_interval'			=> 1,
 						'pfb_min'			=> 0,
@@ -195,7 +200,7 @@ if ($_POST) {
 			// browser does not submit it. Preserve the previously stored value in that
 			// case rather than overwriting it with the absent POST field.
 			if ($pfb['gconfig']['pfb_feed_internal_filter'] === 'on') {
-				$pfb['gconfig']['pfb_feed_internal_allowlist']	= pfb_text_area_encode(trim($_POST['pfb_feed_internal_allowlist'] ?? ''));
+				$pfb['gconfig']['pfb_feed_internal_allowlist']	= base64_encode($_POST['pfb_feed_internal_allowlist'] ?? '');
 			}
 			$pfb['gconfig']['pfb_interval']			= $_POST['pfb_interval']			?: 1;
 			$pfb['gconfig']['pfb_min']			= $_POST['pfb_min']				?: 0;

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -195,7 +195,7 @@ if ($_POST) {
 			// browser does not submit it. Preserve the previously stored value in that
 			// case rather than overwriting it with the absent POST field.
 			if ($pfb['gconfig']['pfb_feed_internal_filter'] === 'on') {
-				$pfb['gconfig']['pfb_feed_internal_allowlist']	= base64_encode(str_replace("\r\n", "\n", trim($_POST['pfb_feed_internal_allowlist'] ?? '')));
+				$pfb['gconfig']['pfb_feed_internal_allowlist']	= pfb_text_area_encode(trim($_POST['pfb_feed_internal_allowlist'] ?? ''));
 			}
 			$pfb['gconfig']['pfb_interval']			= $_POST['pfb_interval']			?: 1;
 			$pfb['gconfig']['pfb_min']			= $_POST['pfb_min']				?: 0;

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -108,6 +108,14 @@ if ($_POST) {
 
 		unset($savemsg);
 
+		// issue #1723: sanitize single-line free-text fields before any existing
+		// filter/validation below reads them (autorule_suffix is select-coerced
+		// right after this -- sanitizing first is a no-op for its 3 valid keys).
+		$_POST['ip_placeholder']	= pfb_sanitize_text($_POST['ip_placeholder'] ?? '');
+		$_POST['asn_token']		= pfb_sanitize_text($_POST['asn_token'] ?? '');
+		$_POST['autorule_suffix']	= pfb_sanitize_text($_POST['autorule_suffix'] ?? '');
+		$_POST['maxmind_account']	= pfb_sanitize_text($_POST['maxmind_account'] ?? '');
+
 		// Validate Select field options
 		$select_options = array(	'asn_reporting'		=> 'disabled',
 						'maxmind_locale'	=> 'en',
@@ -144,7 +152,7 @@ if ($_POST) {
 		// issue #924: maxmind_key is masked/write-only -- a blank POST keeps the stored key, so
 		// validate only a non-empty submission. Reference 'maxmind_key' suppresses pfb_filter()'s
 		// failed-validation log line so the secret never reaches a log, even when rejected.
-		$pfb_maxmind_key_post = trim((string) ($_POST['maxmind_key'] ?? ''));
+		$pfb_maxmind_key_post = pfb_sanitize_text((string) ($_POST['maxmind_key'] ?? ''));
 		if ($pfb_maxmind_key_post !== '' && empty(pfb_filter($pfb_maxmind_key_post, PFB_FILTER_WORD, 'maxmind_key'))) {
 			$input_errors[] = 'MaxMind License key Invalid';
 		}
@@ -230,8 +238,8 @@ if ($_POST) {
 			$pfb['iconfig']['pass_order']		= $_POST['pass_order']						?: 'order_0';
 			$pfb['iconfig']['autorule_suffix']	= $_POST['autorule_suffix']					?: 'autorule';
 			$pfb['iconfig']['killstates']		= pfb_filter($_POST['killstates'], PFB_FILTER_ON_OFF, 'ip')	?: '';
-			$pfb['iconfig']['v4suppression']	= base64_encode($_POST['v4suppression'])			?: '';
-			$pfb['iconfig']['v6suppression']	= base64_encode($_POST['v6suppression'])			?: '';
+			$pfb['iconfig']['v4suppression']	= pfb_text_area_encode($_POST['v4suppression'] ?? '')		?: '';
+			$pfb['iconfig']['v6suppression']	= pfb_text_area_encode($_POST['v6suppression'] ?? '')		?: '';
 
 			// ADR-11: per-type aggregate aliases multi-select -> CSV scalar (sanitised to the
 			// known option keys; default none). Gateway-registered in the general section, so

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -108,13 +108,13 @@ if ($_POST) {
 
 		unset($savemsg);
 
-		// issue #1723: sanitize single-line free-text fields before any existing
-		// filter/validation below reads them (autorule_suffix is select-coerced
-		// right after this -- sanitizing first is a no-op for its 3 valid keys).
-		$_POST['ip_placeholder']	= pfb_sanitize_text($_POST['ip_placeholder'] ?? '');
-		$_POST['asn_token']		= pfb_sanitize_text($_POST['asn_token'] ?? '');
-		$_POST['autorule_suffix']	= pfb_sanitize_text($_POST['autorule_suffix'] ?? '');
-		$_POST['maxmind_account']	= pfb_sanitize_text($_POST['maxmind_account'] ?? '');
+		// issue #1723: sanitize at ingestion -- first step, before any evaluation.
+		foreach (array('ip_placeholder', 'asn_token', 'autorule_suffix', 'maxmind_account', 'maxmind_key') as $pfb_text_field) {
+			$_POST[$pfb_text_field] = pfb_sanitize_text((string) ($_POST[$pfb_text_field] ?? ''));
+		}
+		foreach (array('v4suppression', 'v6suppression') as $pfb_text_area_field) {
+			$_POST[$pfb_text_area_field] = pfb_sanitize_text_area((string) ($_POST[$pfb_text_area_field] ?? ''));
+		}
 
 		// Validate Select field options
 		$select_options = array(	'asn_reporting'		=> 'disabled',
@@ -152,7 +152,8 @@ if ($_POST) {
 		// issue #924: maxmind_key is masked/write-only -- a blank POST keeps the stored key, so
 		// validate only a non-empty submission. Reference 'maxmind_key' suppresses pfb_filter()'s
 		// failed-validation log line so the secret never reaches a log, even when rejected.
-		$pfb_maxmind_key_post = pfb_sanitize_text((string) ($_POST['maxmind_key'] ?? ''));
+		// issue #1723: already sanitized by the ingestion prologue above -- plain read.
+		$pfb_maxmind_key_post = (string) ($_POST['maxmind_key'] ?? '');
 		if ($pfb_maxmind_key_post !== '' && empty(pfb_filter($pfb_maxmind_key_post, PFB_FILTER_WORD, 'maxmind_key'))) {
 			$input_errors[] = 'MaxMind License key Invalid';
 		}
@@ -161,7 +162,10 @@ if ($_POST) {
 			$input_errors[] = 'IPinfo Token Invalid';
 		}
 
-		$v4suppression = explode("\r\n", $_POST['v4suppression']);
+		// issue #1723: the ingestion prologue already normalized CRLF/CR to LF, so
+		// per-line validation now splits on "\n" (the pre-#1723 "\r\n" split matched
+		// a browser's raw CRLF submission; that separator no longer survives ingestion).
+		$v4suppression = explode("\n", $_POST['v4suppression']);
 		if (!empty($v4suppression)) {
 			foreach ($v4suppression as $line) {
 				$suppression_error = pfb_validate_suppression_line($line, 'ipv4');
@@ -175,7 +179,7 @@ if ($_POST) {
 		// non-empty array, so (unlike the v4 block above) this skips the vestigial
 		// !empty() wrapper -- avoids replicating the pre-existing PHPStan
 		// empty.variable finding baselined for v4suppression at the same call shape.
-		foreach (explode("\r\n", $_POST['v6suppression']) as $line) {
+		foreach (explode("\n", $_POST['v6suppression']) as $line) {
 			$suppression_error = pfb_validate_suppression_line($line, 'ipv6');
 			if ($suppression_error !== NULL) {
 				$input_errors[] = $suppression_error;
@@ -238,8 +242,9 @@ if ($_POST) {
 			$pfb['iconfig']['pass_order']		= $_POST['pass_order']						?: 'order_0';
 			$pfb['iconfig']['autorule_suffix']	= $_POST['autorule_suffix']					?: 'autorule';
 			$pfb['iconfig']['killstates']		= pfb_filter($_POST['killstates'], PFB_FILTER_ON_OFF, 'ip')	?: '';
-			$pfb['iconfig']['v4suppression']	= pfb_text_area_encode($_POST['v4suppression'] ?? '')		?: '';
-			$pfb['iconfig']['v6suppression']	= pfb_text_area_encode($_POST['v6suppression'] ?? '')		?: '';
+			// issue #1723: already sanitized by the ingestion prologue -- plain encode.
+			$pfb['iconfig']['v4suppression']	= base64_encode($_POST['v4suppression'] ?? '')			?: '';
+			$pfb['iconfig']['v6suppression']	= base64_encode($_POST['v6suppression'] ?? '')			?: '';
 
 			// ADR-11: per-type aggregate aliases multi-select -> CSV scalar (sanitised to the
 			// known option keys; default none). Gateway-registered in the general section, so

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -550,8 +550,9 @@ SH
 		$this->assertTrue($result['redirect']);
 		$this->assertFileExists("{$GLOBALS['pfb']['aliasdir']}/pfB_Whitelist_v6.txt");
 		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
+		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
 		$this->assertSame(
-			base64_encode("2001:db8::31\r\n"),
+			base64_encode("2001:db8::31\n"),
 			$GLOBALS['config']['installedpackages']['pfblockernglistsv6']['config'][0]['custom']
 		);
 		$this->assertFileExists("{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v6.update");
@@ -592,8 +593,9 @@ SH
 		$this->assertStringContainsString('added', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
 		$this->assertSame(['add', $table, '198.51.100.34'], $this->lastLogRow());
+		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
 		$this->assertSame(
-			base64_encode("198.51.100.34\r\n"),
+			base64_encode("198.51.100.34\n"),
 			$GLOBALS['config']['installedpackages']['pfblockernglistsv4']['config'][0]['custom']
 		);
 		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
@@ -621,7 +623,8 @@ SH
 
 		$this->assertStringContainsString('Not currently blocked', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
-		$this->assertSame("198.51.100.40/32 # note\r\n", base64_decode(PfbConfig::read('v4suppression')));
+		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
+		$this->assertSame("198.51.100.40/32 # note\n", base64_decode(PfbConfig::read('v4suppression')));
 		$this->assertFileExists($GLOBALS['pfb']['supptxt']);
 	}
 
@@ -634,7 +637,8 @@ SH
 
 		$this->assertStringContainsString('Not currently blocked', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
-		$this->assertSame("198.51.100.45/32\r\n", base64_decode(PfbConfig::read('v4suppression')));
+		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
+		$this->assertSame("198.51.100.45/32\n", base64_decode(PfbConfig::read('v4suppression')));
 		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
 		$this->assertDirectoryExists($suppression_file, 'suppression-file persistence failure must leave the target directory untouched');
 	}
@@ -647,7 +651,8 @@ SH
 
 		$this->assertStringContainsString('Not currently blocked', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
-		$this->assertSame("2001:db8::40/128\r\n", base64_decode(PfbConfig::read('v6suppression')));
+		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
+		$this->assertSame("2001:db8::40/128\n", base64_decode(PfbConfig::read('v6suppression')));
 		$this->assertFileExists($GLOBALS['pfb']['supptxt_v6']);
 	}
 
@@ -660,7 +665,8 @@ SH
 
 		$this->assertStringContainsString('Removed 1 entry, added 0 covering CIDRs', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
-		$this->assertSame("198.51.100.42/32\r\n", base64_decode(PfbConfig::read('v4suppression')));
+		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
+		$this->assertSame("198.51.100.42/32\n", base64_decode(PfbConfig::read('v4suppression')));
 	}
 
 	public function testAddSuppressFailedStillPersistsStandingSuppression(): void
@@ -672,7 +678,8 @@ SH
 
 		$this->assertStringContainsString('Live punch failed', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
-		$this->assertSame("198.51.100.43/32\r\n", base64_decode(PfbConfig::read('v4suppression')));
+		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
+		$this->assertSame("198.51.100.43/32\n", base64_decode(PfbConfig::read('v4suppression')));
 	}
 
 	public function testAddSuppressBusyStillPersistsStandingSuppression(): void
@@ -690,7 +697,8 @@ SH
 
 		$this->assertStringContainsString('update/reload pass', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
-		$this->assertSame("198.51.100.44/32\r\n", base64_decode(PfbConfig::read('v4suppression')));
+		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
+		$this->assertSame("198.51.100.44/32\n", base64_decode(PfbConfig::read('v4suppression')));
 	}
 
 	public function testAddSuppressExactDuplicateSkipsConfigRefresh(): void

--- a/tests/php/CategoryEditPostGuardTest.php
+++ b/tests/php/CategoryEditPostGuardTest.php
@@ -51,9 +51,21 @@ final class CategoryEditPostGuardTest extends TestCase
 			}
 		}
 
-		// Region 1: select_options-normalisation close through the ingress guard,
-		// the aliasname checks and the CIDR checks -- up to the state-loop foreach.
+		// Region 1: the #1106 ingress guard + #1723 sanitize prologue (issue #1723
+		// moved these ahead of the select_options-normalisation loop so sanitize
+		// runs before ANY evaluation, including that loop's coercion of
+		// aliasports_in/srcint/etc -- two non-adjacent stretches of source,
+		// concatenated here), THEN (unchanged position) the select_options loop's
+		// close through the aliasname checks and the CIDR checks -- up to the
+		// state-loop foreach.
 		if (!function_exists('pfb_category_oracle_aliasname_region')) {
+			if (!preg_match(
+				'/(\t\/\/ issue #1106: reject an array-valued field.*?)\n\n\t\/\/ Validate Select field options/s',
+				$src,
+				$guard
+			)) {
+				throw new RuntimeException('test bootstrap: #1106/#1723 guard region not found');
+			}
 			if (!preg_match(
 				'/\$_POST\[\$s_option\] = \$s_default;\n\t\t\}\n\t\}\n(.*?)(?=\n\tforeach \(\$_POST as \$key => \$value\) \{)/s',
 				$src,
@@ -64,6 +76,7 @@ final class CategoryEditPostGuardTest extends TestCase
 			eval(
 				'function pfb_category_oracle_aliasname_region(string $gtype): array {'
 				. ' $input_errors = array();'
+				. $guard[1]
 				. $m[1]
 				. ' return $input_errors; }'
 			);

--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -319,9 +319,10 @@ final class PfbFilterContractTest extends TestCase
 	{
 		// issue #1723: the control-character gate narrowed from \p{C} (Cc+Cf+Co+
 		// Cs+Cn) to \p{Cc}+BOM only. U+200B (ZERO WIDTH SPACE) is Cf, not Cc, so
-		// it no longer makes a whole free-text field a reject; homoglyph/
-		// zero-width defense for domain-shaped fields now lives in the
-		// type-specific validators below (ASCII regex / IDNA), not this gate.
+		// it no longer makes a whole free-text field a reject. Mixed-script/
+		// homoglyph domains are ACCEPTED by design (admins block typosquat
+		// domains in their own lists); zero-width chars in domain-shaped input
+		// are rejected by UTS46, free-text keeps them.
 		$this->assertSame("\xE2\x80\x8B", pfb_filter("\xE2\x80\x8B", PFB_FILTER_HTML, 'ref', 'DEF'));
 	}
 

--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -117,6 +117,14 @@ final class PfbFilterContractTest extends TestCase
 			'IDN domain (latin)'        => ['bücher.de'],
 			'IDN domain (CJK)'          => ['日本語.example'],
 			'IDN leading-dot wildcard'  => ['.bücher.de'],
+			// PR #1729 review: ZWNJ/ZWJ (U+200C/U+200D) are UTS46 CONTEXTJ/
+			// deviation characters, contextually legal in real IDNA labels
+			// (e.g. Persian); PHP's idn_to_ascii(IDNA_DEFAULT) has no
+			// CHECK_CONTEXTJ, so the punycode candidate validates and the
+			// original Unicode is returned -- same stance as mixed-script
+			// acceptance above.
+			'ZWNJ inside a label'       => ["exam\xE2\x80\x8Cple.com"],
+			'ZWJ inside a label'        => ["exam\xE2\x80\x8Dple.com"],
 		];
 	}
 
@@ -129,6 +137,13 @@ final class PfbFilterContractTest extends TestCase
 	public function testTldFilterAcceptsUnicodeIdnUnchanged(): void
 	{
 		$this->assertSame('рф', pfb_filter('рф', PFB_FILTER_TLD, 'PFBL-01 contract'));
+	}
+
+	public function testTldFilterAcceptsZeroWidthJoiner(): void
+	{
+		// PR #1729 review: same ZWJ-accepted-by-design stance as the domain
+		// pins above, pinned for PFB_FILTER_TLD too.
+		$this->assertSame("\xD1\x80\xE2\x80\x8D\xD1\x84", pfb_filter("\xD1\x80\xE2\x80\x8D\xD1\x84", PFB_FILTER_TLD, 'PFBL-01 contract'));
 	}
 
 	/** @return array<string, array{0: string}> label => hostile/boundary value the DOMAIN filter must still reject */
@@ -153,6 +168,12 @@ final class PfbFilterContractTest extends TestCase
 			// returns FALSE (UTS46 rejects it), so the candidate stays FALSE and
 			// the domain is rejected before the charset/label checks run.
 			'zero-width leading label'    => ["\xE2\x80\x8B.com"],
+			// U+202E (RIGHT-TO-LEFT OVERRIDE) inside a label -- probed:
+			// idn_to_ascii() returns FALSE (UTS46 disallows bidi control
+			// characters), so the candidate stays FALSE and the domain is
+			// rejected before the charset/label checks run. Contrast with the
+			// free-text PFB_FILTER_HTML gate above, which accepts it.
+			'bidi override inside a label' => ["exam\xE2\x80\xAEple.com"],
 		];
 	}
 
@@ -168,6 +189,19 @@ final class PfbFilterContractTest extends TestCase
 		// IDN-acceptance change (no regression on the plain-ASCII path).
 		$this->assertSame('example.com', pfb_filter('example.com', PFB_FILTER_DOMAIN, 'PFBL-01 contract'));
 		$this->assertSame('', pfb_filter('exam!ple.com', PFB_FILTER_DOMAIN, 'PFBL-01 contract'));
+	}
+
+	public function testDomainFilterRejectsIdnDoubleLeadingDot(): void
+	{
+		// PR #1729 review: the IDN leading-dot branch used ltrim($input, '.'),
+		// which strips ALL leading dots -- "..bücher.de" was wrongly ACCEPTED
+		// (ltrim leaves "bücher.de", a legal single label) while its ASCII
+		// sibling "..example.com" is correctly rejected (double-dot survives
+		// unmodified on the ASCII path). Strip exactly ONE leading dot so both
+		// paths reject a double leading dot identically.
+		$this->assertSame('DEF', pfb_filter("..b\xC3\xBCcher.de", PFB_FILTER_DOMAIN, 'ref', 'DEF'));
+		// Single leading dot must still be accepted unchanged (regression guard).
+		$this->assertSame(".b\xC3\xBCcher.de", pfb_filter(".b\xC3\xBCcher.de", PFB_FILTER_DOMAIN, 'PFBL-01 contract'));
 	}
 
 	// --- PFB_FILTER_WORD (feed headers + friendly interface names) ---------------
@@ -321,8 +355,17 @@ final class PfbFilterContractTest extends TestCase
 		// Cs+Cn) to \p{Cc}+BOM only. U+200B (ZERO WIDTH SPACE) is Cf, not Cc, so
 		// it no longer makes a whole free-text field a reject. Mixed-script/
 		// homoglyph domains are ACCEPTED by design (admins block typosquat
-		// domains in their own lists); zero-width chars in domain-shaped input
-		// are rejected by UTS46, free-text keeps them.
+		// domains in their own lists).
+		//
+		// PR #1729 review: in domain-shaped input, ZWSP as an entire label
+		// ("​.com") IS rejected -- idn_to_ascii() itself refuses it, UTS46
+		// disallows it (see 'zero-width leading label' below). ZWNJ/ZWJ
+		// (U+200C/U+200D) are ACCEPTED by design in domain-shaped input --
+		// both are UTS46 CONTEXTJ/deviation characters, contextually legal in
+		// real IDNA labels (e.g. Persian), and PHP's idn_to_ascii(IDNA_DEFAULT)
+		// has no CHECK_CONTEXTJ, so the punycode candidate is exactly what the
+		// resolver queries (same stance as mixed-script acceptance, see
+		// domainUnicodeAcceptedProvider). Free-text keeps all of them.
 		$this->assertSame("\xE2\x80\x8B", pfb_filter("\xE2\x80\x8B", PFB_FILTER_HTML, 'ref', 'DEF'));
 	}
 

--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -125,6 +125,12 @@ final class PfbFilterContractTest extends TestCase
 			// acceptance above.
 			'ZWNJ inside a label'       => ["exam\xE2\x80\x8Cple.com"],
 			'ZWJ inside a label'        => ["exam\xE2\x80\x8Dple.com"],
+			// Mid-label U+200B (ZWSP) is silently MAPPED AWAY by UTS46 --
+			// probed: idn_to_ascii("exam\u{200B}ple.com") === 'example.com' --
+			// so the row is accepted and blocks the mapped target; an invisible
+			// copy-paste artifact cannot make a row silently miss. Only a ZWSP
+			// standing as an entire label is rejected (hostile provider below).
+			'ZWSP inside a label (mapped away)' => ["exam\xE2\x80\x8Bple.com"],
 		];
 	}
 

--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -102,6 +102,74 @@ final class PfbFilterContractTest extends TestCase
 		$this->assertSame('', pfb_filter($input, PFB_FILTER_DOMAIN, 'PFBL-01 contract'));
 	}
 
+	// --- PFB_FILTER_DOMAIN / PFB_FILTER_TLD: Unicode/IDN acceptance (issue #1723) --
+	//
+	// Non-ASCII input is converted to its punycode candidate for validation
+	// (dots/length/labels/charset), but on success the ORIGINAL Unicode input is
+	// returned (htmlspecialchars'd) -- matching the read path
+	// (pfb_text_area_decode()'s IDN branch), which also IDNA-converts at read
+	// time, and preserving the pass/fail-gate contract callers rely on.
+
+	/** @return array<string, array{0: string}> label => Unicode domain returned unchanged */
+	public static function domainUnicodeAcceptedProvider(): array
+	{
+		return [
+			'IDN domain (latin)'        => ['bücher.de'],
+			'IDN domain (CJK)'          => ['日本語.example'],
+			'IDN leading-dot wildcard'  => ['.bücher.de'],
+		];
+	}
+
+	#[DataProvider('domainUnicodeAcceptedProvider')]
+	public function testDomainFilterAcceptsUnicodeIdnUnchanged(string $domain): void
+	{
+		$this->assertSame($domain, pfb_filter($domain, PFB_FILTER_DOMAIN, 'PFBL-01 contract'));
+	}
+
+	public function testTldFilterAcceptsUnicodeIdnUnchanged(): void
+	{
+		$this->assertSame('рф', pfb_filter('рф', PFB_FILTER_TLD, 'PFBL-01 contract'));
+	}
+
+	/** @return array<string, array{0: string}> label => hostile/boundary value the DOMAIN filter must still reject */
+	public static function domainUnicodeHostileProvider(): array
+	{
+		return [
+			// No dot -- same rule as the ASCII case (pin: rejected before and
+			// after via the "Exclude no dots" check on the converted candidate).
+			'IDN no dot'                  => ['bücher'],
+			// Embedded space, pure ASCII -- unaffected by the IDN branch (pin).
+			'space (ascii, unaffected)'   => ['exa mple.com'],
+			// Double dot inside an IDN label -- idn_to_ascii() itself refuses
+			// the malformed input (probed: returns FALSE), so it never reaches
+			// the label check; still rejected either way.
+			'IDN double dot'              => ["b\xC3\xBCcher..de"],
+			// Punycode form of a 60-char single label exceeds the 63-char
+			// label cap once 'xn--...-' is added -- probed: idn_to_ascii()
+			// itself returns FALSE for the whole domain (UTS46 refuses an
+			// over-length label before we ever run pfb_validate_domain_labels()).
+			'IDN label overlong in punycode' => [str_repeat('ü', 60) . '.de'],
+			// U+200B (ZERO WIDTH SPACE) leading a label -- probed: idn_to_ascii()
+			// returns FALSE (UTS46 rejects it), so the candidate stays FALSE and
+			// the domain is rejected before the charset/label checks run.
+			'zero-width leading label'    => ["\xE2\x80\x8B.com"],
+		];
+	}
+
+	#[DataProvider('domainUnicodeHostileProvider')]
+	public function testDomainFilterRejectsUnicodeHostileInput(string $input): void
+	{
+		$this->assertSame('', pfb_filter($input, PFB_FILTER_DOMAIN, 'PFBL-01 contract'));
+	}
+
+	public function testDomainFilterAsciiPathUnaffectedByIdnBranch(): void
+	{
+		// Unchanged ASCII accept/reject pins -- must stay green throughout the
+		// IDN-acceptance change (no regression on the plain-ASCII path).
+		$this->assertSame('example.com', pfb_filter('example.com', PFB_FILTER_DOMAIN, 'PFBL-01 contract'));
+		$this->assertSame('', pfb_filter('exam!ple.com', PFB_FILTER_DOMAIN, 'PFBL-01 contract'));
+	}
+
 	// --- PFB_FILTER_WORD (feed headers + friendly interface names) ---------------
 
 	/** @return array<string, array{0: string}> label => valid \w-only value returned unchanged */
@@ -247,11 +315,34 @@ final class PfbFilterContractTest extends TestCase
 		$this->assertSame('DEF', pfb_filter("abc\x07def", PFB_FILTER_HTML, 'ref', 'DEF'));
 	}
 
-	public function testScalarFilterRejectsZeroWidthSpaceAsFormatControl(): void
+	public function testScalarFilterAcceptsZeroWidthFormatCharacter(): void
 	{
-		// U+200B (ZERO WIDTH SPACE, Unicode category Cf) is a genuine \p{C} member --
-		// a homoglyph/zero-width hardening pin, distinct from the false-positive fix.
-		$this->assertSame('DEF', pfb_filter("\xE2\x80\x8B", PFB_FILTER_HTML, 'ref', 'DEF'));
+		// issue #1723: the control-character gate narrowed from \p{C} (Cc+Cf+Co+
+		// Cs+Cn) to \p{Cc}+BOM only. U+200B (ZERO WIDTH SPACE) is Cf, not Cc, so
+		// it no longer makes a whole free-text field a reject; homoglyph/
+		// zero-width defense for domain-shaped fields now lives in the
+		// type-specific validators below (ASCII regex / IDNA), not this gate.
+		$this->assertSame("\xE2\x80\x8B", pfb_filter("\xE2\x80\x8B", PFB_FILTER_HTML, 'ref', 'DEF'));
+	}
+
+	public function testScalarFilterAcceptsZeroWidthJoinerInsideText(): void
+	{
+		// U+200D (ZERO WIDTH JOINER) is Cf -- must survive embedded in text too.
+		$this->assertSame("a\xE2\x80\x8Db", pfb_filter("a\xE2\x80\x8Db", PFB_FILTER_HTML, 'ref', 'DEF'));
+	}
+
+	public function testScalarFilterAcceptsBidiOverrideMark(): void
+	{
+		// U+202E (RIGHT-TO-LEFT OVERRIDE) is Cf -- free-text fields must accept
+		// Unicode; bidi-spoofing defense is out of scope for this gate.
+		$this->assertSame("a\xE2\x80\xAEb", pfb_filter("a\xE2\x80\xAEb", PFB_FILTER_HTML, 'ref', 'DEF'));
+	}
+
+	public function testScalarFilterStillRejectsByteOrderMark(): void
+	{
+		// U+FEFF (BOM) is not \p{Cc} but is explicitly named in the narrowed
+		// class (\x{FEFF}) -- must keep being rejected.
+		$this->assertSame('DEF', pfb_filter("a\xEF\xBB\xBFb", PFB_FILTER_HTML, 'ref', 'DEF'));
 	}
 
 	public function testScalarFilterRejectsInvalidUtf8FailClosed(): void

--- a/tests/php/PfbSanitizeTextTest.php
+++ b/tests/php/PfbSanitizeTextTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversFunction('pfb_sanitize_text')]
 #[CoversFunction('pfb_sanitize_text_area')]
+#[CoversFunction('pfb_text_area_encode')]
 final class PfbSanitizeTextTest extends TestCase
 {
 	// --- pfb_sanitize_text() ---
@@ -190,5 +191,42 @@ final class PfbSanitizeTextTest extends TestCase
 	{
 		// Trailing NBSP / U+3000 must right-strip like ASCII space/tab.
 		$this->assertSame("a\nb\n", pfb_sanitize_text_area("a\xC2\xA0\nb\xE3\x80\x80\n"));
+	}
+
+	public function testSanitizeTextSurvivesHugeWhitespaceRun(): void
+	{
+		// A >1,000,000-char space run defeats the trim regex's backtrack limit
+		// the same way testSanitizeTextAreaSurvivesHugeSpaceRunMidLine() pins for
+		// the textarea helper. Probed (issue #1723): pfb_preg_replace_safe()
+		// degrades to the UNSTRIPPED input byte-for-byte (leading/trailing NBSP
+		// included) rather than fatal-ing or wiping data -- a fail-open pin, not
+		// a design goal: under this load the Unicode-whitespace trim may not
+		// apply for the call.
+		$in = "\xC2\xA0x" . str_repeat(' ', 1100000) . "y\xC2\xA0";
+		$out = pfb_sanitize_text($in);
+		$this->assertIsString($out);
+		$this->assertStringContainsString('x', $out);
+		$this->assertStringContainsString('y', $out);
+		$this->assertSame($in, $out);
+	}
+
+	// --- pfb_text_area_encode() ---
+
+	public function testTextAreaEncodeEmptyInputReturnsEmptyString(): void
+	{
+		$this->assertSame('', pfb_text_area_encode(''));
+	}
+
+	public function testTextAreaEncodeDecodeRoundTrip(): void
+	{
+		// Persist-boundary (encode) feeding the read-boundary (decode): the
+		// decoder lowercases, strips \x07 (Cc, stripped by
+		// pfb_sanitize_text_area()), and right-strips the trailing NBSP+space
+		// off the 'B' row. Probed exact result (issue #1723): three rows,
+		// 'a'/'b'/'c' -- not two, the \x07 does not merge 'B' and 'C' into one
+		// row since it sits immediately after the '\n' it does not remove.
+		$raw = "A\r\nB\xC2\xA0 \n\x07C";
+		$encoded = pfb_text_area_encode($raw);
+		$this->assertSame(['a', 'b', 'c'], pfb_text_area_decode($encoded, TRUE, FALSE));
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -7353,6 +7353,19 @@
             }
         ]
     },
+    "pfb_text_area_encode": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "raw",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_text_sanity": {
         "returnsRef": false,
         "returnType": "?string",

--- a/tests/smoke/ui/test_sanitize_persist.py
+++ b/tests/smoke/ui/test_sanitize_persist.py
@@ -13,15 +13,16 @@ Tests 1-5 pin the persist-boundary sanitizers wired in commit 2 of #1723
 ``pfb_sanitize_text()`` for single-line fields) -- RED before that commit
 (raw bytes/control chars persist, or the field is dropped entirely by an
 unrelated pre-existing control-char gate), GREEN after. Test 6 is a LIVE PIN
-of step 1 (commit 57aa96e1, same branch): the DNSBL custom-list IDN
-acceptance is already GREEN at red time -- it never touches the encode
-wiring, it is here so the whole #1723 story has one CI-visible regression
-guard for the IDN half too.
+of step 1 (the pfb_filter IDN/Unicode commit, same branch): the DNSBL
+custom-list IDN acceptance is already GREEN at red time -- it never touches
+the encode wiring, it is here so the whole #1723 story has one CI-visible
+regression guard for the IDN half too.
 """
 
 from __future__ import annotations
 
 import base64
+import uuid
 from typing import TYPE_CHECKING
 
 import pytest
@@ -187,19 +188,29 @@ def test_ip_suppression_cr_only_rows_persist_as_lf(
     the bare ``\\r`` separators verbatim.
 
     GREEN (after): ``pfb_text_area_encode()`` normalizes them to ``\\n``.
+
+    The header comment carries a per-run UUID token (not just the fixed
+    RFC 5737 addresses) so the computed ``expected`` value is unique across
+    re-runs on an unreset box -- the persisted value is asserted EQUAL to
+    that computed expectation (not merely "changed from before"), and a
+    before-state read still guards against a stale box already holding this
+    run's exact expected value.
     """
     vm = smoke_vm
+    token = uuid.uuid4().hex[:12]
     addr1, addr2, addr3 = "198.51.100.1/32", "198.51.100.2/32", "198.51.100.3/32"
-    raw = f"# smoke cr-only header\r{addr1}\r{addr2}\r{addr3}"
-    expected = f"# smoke cr-only header\n{addr1}\n{addr2}\n{addr3}"
+    raw = f"# smoke cr-only header {token}\r{addr1}\r{addr2}\r{addr3}"
+    expected = f"# smoke cr-only header {token}\n{addr1}\n{addr2}\n{addr3}"
     cfg = "installedpackages/pfblockerngipsettings/config/0/v4suppression"
 
     before = helpers.config_get(vm, cfg)
+    assert _decoded(before) != expected, (
+        f"v4suppression already holds this run's expected value (stale/colliding state): {expected!r}"
+    )
     resp = webui.post(IP_PAGE, {"v4suppression": raw}, timeout=SETTINGS_SAVE_TIMEOUT)
     assert not looks_like_login_page(resp.text), "IP POST returned the login form (session lost)"
 
     after = helpers.config_get(vm, cfg)
-    assert after != before, "v4suppression did not change -- the save did not take (POST must CAUSE the change)"
     assert _decoded(after) == expected, f"v4suppression CR rows not normalized to LF: got {_decoded(after)!r}"
 
 
@@ -285,8 +296,9 @@ def test_category_edit_custom_list_accepts_idn_row(
 ) -> None:
     """A Unicode-label custom-list row saves cleanly (live pin of step 1's IDN change).
 
-    NOT a persist-boundary sanitization test -- step 1 (commit 57aa96e1, same
-    branch) already widened ``pfb_filter()``/the category-edit custom-list
+    NOT a persist-boundary sanitization test -- step 1 (the pfb_filter
+    IDN/Unicode commit, same branch) already widened ``pfb_filter()``/the
+    category-edit custom-list
     validator to accept IDN/Unicode domains; this is already GREEN at red
     time and stays green through commit 2 (the encode wiring never touches
     this validator). It exists so #1723 pins BOTH halves of the "standardize
@@ -316,8 +328,13 @@ def test_category_edit_custom_list_accepts_idn_row(
             "IDN custom-list row aborted the whole save (aliasname did not persist) -- "
             "the custom-list validator rejected the Unicode label"
         )
-        assert base64.b64decode(helpers.config_get(vm, f"{base}/custom")) != b"", (
-            "IDN custom-list row: 'custom' field is empty after a supposedly successful save"
+        # The single-line row carries no CR/LF/control chars/trailing whitespace, so
+        # pfb_text_area_encode()'s pfb_sanitize_text_area() pass is a no-op -- the
+        # decoded persisted value must equal the typed row exactly, not merely be
+        # non-empty.
+        assert _decoded(helpers.config_get(vm, f"{base}/custom")) == custom_row, (
+            f"IDN custom-list row: 'custom' field does not match the typed row, "
+            f"got {_decoded(helpers.config_get(vm, f'{base}/custom'))!r}"
         )
     finally:
         tce._del_rowid(vm, tce.CFG_DNSBL, rowid)

--- a/tests/smoke/ui/test_sanitize_persist.py
+++ b/tests/smoke/ui/test_sanitize_persist.py
@@ -1,0 +1,323 @@
+"""Tier-B live pins for the persist-boundary text sanitizers (issue #1723).
+
+Marker ``ui_e2e`` -- see :mod:`tests.smoke.ui.test_functional` for the tier's
+general shape. Every test here drives a real CSRF POST (``requests``, never a
+browser) and asserts the box's EFFECTIVE ``config.xml`` state (via
+:func:`tests.smoke.helpers.config_get`), never the HTTP response body --
+``requests``' ``session.post(data=...)`` sends the Python string's bytes
+UNCHANGED (no browser-side CRLF canonicalization of textarea content), so a
+raw payload mixing LF/CR-only/control chars reaches the server byte-for-byte.
+
+Tests 1-5 pin the persist-boundary sanitizers wired in commit 2 of #1723
+(``pfb_text_area_encode()`` for multi-line textarea fields,
+``pfb_sanitize_text()`` for single-line fields) -- RED before that commit
+(raw bytes/control chars persist, or the field is dropped entirely by an
+unrelated pre-existing control-char gate), GREEN after. Test 6 is a LIVE PIN
+of step 1 (commit 57aa96e1, same branch): the DNSBL custom-list IDN
+acceptance is already GREEN at red time -- it never touches the encode
+wiring, it is here so the whole #1723 story has one CI-visible regression
+guard for the IDN half too.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from . import test_category_edit as tce
+from .webui import looks_like_login_page
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+DNSBL_PAGE = "/pfblockerng/pfblockerng_dnsbl.php"
+IP_PAGE = "/pfblockerng/pfblockerng_ip.php"
+GENERAL_PAGE = "/pfblockerng/pfblockerng_general.php"
+
+# Generous POST timeouts: DNSBL/IP saves only write_config() (fast); General's
+# save additionally runs sync_package_pfblockerng() (a full config-rebuild
+# pass) AFTER write_config, mirroring test_functional.ToggleFlow's default.
+SETTINGS_SAVE_TIMEOUT = 120.0
+GENERAL_SAVE_TIMEOUT = 300.0
+
+
+@pytest.fixture(scope="module")
+def dnsbl_vip_ready(smoke_vm: helpers.SmokeVM) -> None:
+    """Ensure the DNSBL sinkhole VIP exists so a DNSBL settings save validates.
+
+    Mirrors :func:`tests.smoke.ui.test_functional.dnsbl_vip_ready` -- the DNSBL
+    save runs ``pfb_validate_vips`` (manual mode) on every save; without a
+    valid VIP the save always aborts with an input error before any of the
+    fields under test here are even reached. Idempotent on the fixed uniqid.
+    """
+    helpers.ensure_dnsbl_vip(smoke_vm)
+
+
+def _decoded(b64_value: str) -> str:
+    """UTF-8-decode a base64 config blob (empty string decodes to '')."""
+    return base64.b64decode(b64_value).decode("utf-8") if b64_value else ""
+
+
+def test_dnsbl_textarea_save_normalizes_line_endings_and_controls(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    dnsbl_vip_ready: None,  # noqa: ARG001
+) -> None:
+    """``pfb_regex_list`` save normalizes line endings and strips control chars.
+
+    Raw payload mixes: a LF-terminated row with trailing space+tab, and a row
+    separated from the next by a BARE CR (old-Mac line ending, no LF) with an
+    embedded ``\\x0B`` (vertical tab).
+
+    Design notes (two independent, pre-existing gates this field carries that
+    the other multi-line fields do not -- neither is touched by this fix, and
+    the payload is shaped to survive both so the ENCODE-time sanitizer stays
+    the sole variable under test):
+
+    * pfBlockerNG's separate Python regex-syntax validator
+      (``pfb_dnsbl_regex_validation_errors``, gated on a usable interpreter)
+      reads its stdin line-by-line splitting ONLY on ``\\n`` -- unlike PHP's
+      sanitizer, it does NOT treat a bare ``\\r`` as a line break, so a raw
+      ``\\r`` stays embedded INSIDE whatever Python "line" it falls in; a
+      non-comment line containing an embedded control byte then trips its
+      "contains ASCII control character" rejection and aborts the WHOLE
+      DNSBL settings save (confirmed empirically: an early draft without the
+      leading ``#`` failed with both before/after reading '', i.e. no save
+      at all). Prefixing the CR/VT-bearing row with ``#`` sidesteps it: the
+      validator skips a line outright once it starts with ``#``, without
+      ever inspecting its characters.
+    * ``pfblockerng_dnsbl.php`` ALSO gates the whole field on
+      ``mb_detect_encoding($_POST['pfb_regex_list'], 'ASCII', TRUE)``
+      ("DNSBL Regex list contains non-ascii characters") -- so, unlike every
+      other field this issue touches, this one cannot carry an NBSP-only-row
+      (or any non-ASCII byte) at all; that Unicode-aware-strip property is
+      pinned on ``suppression`` instead (next test below), which has no such
+      gate and already needs Unicode content for its own assertion.
+
+    RED (before commit 2): ``base64_encode($_POST['pfb_regex_list'])`` stores
+    the raw bytes verbatim -- the CR-only row boundary, the trailing
+    whitespace, and the VT all survive undecoded.
+
+    GREEN (after): ``pfb_text_area_encode()`` runs ``pfb_sanitize_text_area()``
+    first -- CR/CRLF normalize to LF, every control char (incl. ``\\x0B``) is
+    stripped, and each line is right-stripped.
+    """
+    vm = smoke_vm
+    domain = helpers.unique_domain("pfbregex")
+    raw = f"{domain}  \t\n#plainrow2\rvtrow3\x0b\nfinalrow4"
+    expected = f"{domain}\n#plainrow2\nvtrow3\nfinalrow4"
+    cfg = "installedpackages/pfblockerngdnsblsettings/config/0/pfb_regex_list"
+
+    before = helpers.config_get(vm, cfg)
+    resp = webui.post(DNSBL_PAGE, {"pfb_regex_list": raw}, timeout=SETTINGS_SAVE_TIMEOUT)
+    assert not looks_like_login_page(resp.text), "DNSBL POST returned the login form (session lost)"
+
+    after = helpers.config_get(vm, cfg)
+    assert after != before, "pfb_regex_list did not change -- the save did not take (POST must CAUSE the change)"
+    assert _decoded(after) == expected, f"pfb_regex_list not normalized: expected {expected!r}, got {_decoded(after)!r}"
+
+
+def test_dnsbl_suppression_comment_control_char_stripped(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    dnsbl_vip_ready: None,  # noqa: ARG001
+) -> None:
+    """DNSBL ``suppression`` save strips a control char from a comment, keeps Unicode.
+
+    Also carries the NBSP-only-row property originally planned for the
+    ``pfb_regex_list`` test (test 1): that field has its OWN, unrelated
+    ``mb_detect_encoding($_POST['pfb_regex_list'], 'ASCII', TRUE)`` save-time
+    gate ("DNSBL Regex list contains non-ascii characters") that rejects ANY
+    non-ASCII byte outright -- NBSP included -- so it structurally cannot
+    carry this property; ``suppression`` has no such gate and already needs
+    Unicode content for the control-char/comment assertion above, so it is
+    the natural home for it. The two-line raw body stays validation-inert:
+    pfBlockerNG's customlist validator here also splits on the LITERAL
+    ``"\\r\\n"`` substring (absent from a bare ``\\n``-joined body), so the
+    whole two-line payload is handled as ONE "line" containing a ``#`` --
+    only the text BEFORE the first ``#`` (our clean ASCII domain) is
+    validated; everything after, including the second line, is comment tail.
+
+    RED (before commit 2): the raw ``\\x07`` (BEL) survives in the persisted
+    base64 blob, and the NBSP-only second row survives as literal NBSP
+    (not an empty line).
+
+    GREEN (after): ``pfb_text_area_encode()`` strips the ``\\x07`` while
+    leaving the Unicode comment text (``é``, ``☕``) byte-identical, and
+    right-strips the NBSP-only row to an EMPTY line (Unicode-aware, not
+    ASCII-only whitespace).
+    """
+    vm = smoke_vm
+    domain = helpers.unique_domain("pfbsupp")
+    raw = f"{domain} # caf\x07é ☕\n\xa0"
+    expected = f"{domain} # café ☕\n"
+    cfg = "installedpackages/pfblockerngdnsblsettings/config/0/suppression"
+
+    before = helpers.config_get(vm, cfg)
+    resp = webui.post(DNSBL_PAGE, {"suppression": raw}, timeout=SETTINGS_SAVE_TIMEOUT)
+    assert not looks_like_login_page(resp.text), "DNSBL POST returned the login form (session lost)"
+
+    after = helpers.config_get(vm, cfg)
+    assert after != before, "suppression did not change -- the save did not take (POST must CAUSE the change)"
+    assert _decoded(after) == expected, f"suppression control-char not stripped: got {_decoded(after)!r}"
+
+
+def test_ip_suppression_cr_only_rows_persist_as_lf(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """``v4suppression`` save normalizes bare-CR row separators to LF.
+
+    Design note: the save-time validator (``pfblockerng_ip.php``) still splits
+    on the LITERAL substring ``"\\r\\n"`` (a separate, pre-existing quirk this
+    issue does not touch), so a genuinely CR-only multi-row body would be
+    handed to ``pfb_validate_suppression_line`` as ONE dirty multi-address
+    string and rejected outright -- confounding this test with an unrelated
+    abort. A leading ``#`` comment sidesteps it: ``pfb_validate_suppression_line``
+    returns early (no validation at all) whenever the line it is given starts
+    with ``#`` -- exactly the shape of a real suppression list with a header
+    comment -- so the encode-time sanitizer is the sole variable under test.
+
+    RED (before commit 2): ``base64_encode($_POST['v4suppression'])`` stores
+    the bare ``\\r`` separators verbatim.
+
+    GREEN (after): ``pfb_text_area_encode()`` normalizes them to ``\\n``.
+    """
+    vm = smoke_vm
+    addr1, addr2, addr3 = "198.51.100.1/32", "198.51.100.2/32", "198.51.100.3/32"
+    raw = f"# smoke cr-only header\r{addr1}\r{addr2}\r{addr3}"
+    expected = f"# smoke cr-only header\n{addr1}\n{addr2}\n{addr3}"
+    cfg = "installedpackages/pfblockerngipsettings/config/0/v4suppression"
+
+    before = helpers.config_get(vm, cfg)
+    resp = webui.post(IP_PAGE, {"v4suppression": raw}, timeout=SETTINGS_SAVE_TIMEOUT)
+    assert not looks_like_login_page(resp.text), "IP POST returned the login form (session lost)"
+
+    after = helpers.config_get(vm, cfg)
+    assert after != before, "v4suppression did not change -- the save did not take (POST must CAUSE the change)"
+    assert _decoded(after) == expected, f"v4suppression CR rows not normalized to LF: got {_decoded(after)!r}"
+
+
+def test_general_allowlist_control_chars_stripped(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """``pfb_feed_internal_allowlist`` save strips an embedded control char.
+
+    The field is already CRLF-normalized and trimmed by the EXISTING save code
+    (``base64_encode(str_replace("\\r\\n", "\\n", trim(...)))``) -- the
+    control-strip is the RED differentiator this test pins, not the
+    normalization (already covered elsewhere). The allowlist textarea is
+    rendered ``disabled`` while ``pfb_feed_internal_filter`` is off (a
+    disabled control submits nothing), so the override explicitly turns the
+    filter on -- otherwise the save silently preserves the old stored value
+    and the field under test is never reached.
+
+    RED (before commit 2): the raw ``\\x07`` survives.
+    GREEN (after): ``pfb_text_area_encode()`` strips it, Unicode intact.
+    """
+    vm = smoke_vm
+    domain = helpers.unique_domain("pfballow")
+    raw = f"caf\x07é-{domain}"
+    expected = f"café-{domain}"
+    cfg = "installedpackages/pfblockerng/config/0/pfb_feed_internal_allowlist"
+
+    before = helpers.config_get(vm, cfg)
+    resp = webui.post(
+        GENERAL_PAGE,
+        {"pfb_feed_internal_filter": "on", "pfb_feed_internal_allowlist": raw},
+        timeout=GENERAL_SAVE_TIMEOUT,
+    )
+    assert not looks_like_login_page(resp.text), "General POST returned the login form (session lost)"
+
+    after = helpers.config_get(vm, cfg)
+    assert after != before, "pfb_feed_internal_allowlist did not change -- the save did not take"
+    assert _decoded(after) == expected, f"allowlist control-char not stripped: got {_decoded(after)!r}"
+
+
+def test_category_edit_description_sanitized(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """DNSBL alias ``description`` save trims, strips controls, keeps Unicode.
+
+    RED (before commit 2): ``pfb_filter($_POST['description'], PFB_FILTER_HTML,
+    ...)`` has its OWN, unrelated universal control-character gate (every
+    ``pfb_filter()`` call rejects input containing ``\\p{Cc}``) -- so a
+    raw ``\\x07`` in the posted description does not survive mangled, it makes
+    ``pfb_filter()`` reject the WHOLE value and fall back to its default
+    (``''``): the persisted description is EMPTY, not ``'café'``. Either way
+    the assertion below (`== 'café'`) fails for the reason this change
+    addresses -- the field was never sanitized before reaching that gate.
+
+    GREEN (after): ``pfb_sanitize_text()`` runs BEFORE ``pfb_filter()`` --
+    the control char is gone before the gate ever sees the value, so
+    ``pfb_filter()`` passes it through (``htmlspecialchars(trim('café'))``
+    is a no-op here) and the persisted description is ``'café'``.
+    """
+    vm = smoke_vm
+    rowid = tce._free_rowid(vm, tce.CFG_DNSBL)
+    base = f"{tce.CFG_DNSBL}/{rowid}"
+    aliasname = "smokedescsan"
+    try:
+        assert helpers.config_get(vm, f"{base}/description") == "", f"rowid {rowid} not free (description already set)"
+
+        tce._post_form(
+            webui,
+            tce._dnsbl_payload(rowid, aliasname, description="  caf\x07é  "),
+        )
+
+        assert helpers.config_get(vm, f"{base}/description") == "café", (
+            "description not sanitized (trim + control-strip + Unicode-intact)"
+        )
+    finally:
+        tce._del_rowid(vm, tce.CFG_DNSBL, rowid)
+
+
+def test_category_edit_custom_list_accepts_idn_row(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A Unicode-label custom-list row saves cleanly (live pin of step 1's IDN change).
+
+    NOT a persist-boundary sanitization test -- step 1 (commit 57aa96e1, same
+    branch) already widened ``pfb_filter()``/the category-edit custom-list
+    validator to accept IDN/Unicode domains; this is already GREEN at red
+    time and stays green through commit 2 (the encode wiring never touches
+    this validator). It exists so #1723 pins BOTH halves of the "standardize
+    text fields" story with one live CI guard each.
+
+    Given a free DNSBL rowid, saving a custom-list row whose label is a
+    Unicode string (``"bü" + unique_domain()`` -- never an RFC 6761 TLD) must
+    NOT abort the whole save (the DNSBL custom-list validator idn_to_ascii()s
+    a non-ctype_print row before validating it as a domain) -- proven by the
+    aliasname (written in the SAME ``if (!$input_errors)`` block as the custom
+    row) landing, and the custom field itself being non-empty afterward.
+    """
+    vm = smoke_vm
+    rowid = tce._free_rowid(vm, tce.CFG_DNSBL)
+    base = f"{tce.CFG_DNSBL}/{rowid}"
+    aliasname = "smokeidnrow"
+    custom_row = "bü" + helpers.unique_domain("pfbidn")
+    try:
+        assert helpers.config_get(vm, f"{base}/aliasname") == "", f"rowid {rowid} not free (aliasname already set)"
+
+        tce._post_form(
+            webui,
+            tce._dnsbl_payload(rowid, aliasname, custom=custom_row),
+        )
+
+        assert helpers.config_get(vm, f"{base}/aliasname") == aliasname, (
+            "IDN custom-list row aborted the whole save (aliasname did not persist) -- "
+            "the custom-list validator rejected the Unicode label"
+        )
+        assert base64.b64decode(helpers.config_get(vm, f"{base}/custom")) != b"", (
+            "IDN custom-list row: 'custom' field is empty after a supposedly successful save"
+        )
+    finally:
+        tce._del_rowid(vm, tce.CFG_DNSBL, rowid)

--- a/tests/smoke/ui/test_sanitize_persist.py
+++ b/tests/smoke/ui/test_sanitize_persist.py
@@ -39,6 +39,7 @@ pytestmark = pytest.mark.ui_e2e
 DNSBL_PAGE = "/pfblockerng/pfblockerng_dnsbl.php"
 IP_PAGE = "/pfblockerng/pfblockerng_ip.php"
 GENERAL_PAGE = "/pfblockerng/pfblockerng_general.php"
+PFB_INC_PATH = "/usr/local/pkg/pfblockerng/pfblockerng.inc"
 
 # Generous POST timeouts: DNSBL/IP saves only write_config() (fast); General's
 # save additionally runs sync_package_pfblockerng() (a full config-rebuild
@@ -62,6 +63,22 @@ def dnsbl_vip_ready(smoke_vm: helpers.SmokeVM) -> None:
 def _decoded(b64_value: str) -> str:
     """UTF-8-decode a base64 config blob (empty string decodes to '')."""
     return base64.b64decode(b64_value).decode("utf-8") if b64_value else ""
+
+
+def _dnsbl_folder(vm: helpers.SmokeVM) -> str:
+    """The DNSBL feed folder (``$pfb['dnsdir']``) the box resolves at runtime.
+
+    Mirrors ``pfb_determine_list_detail('unbound', ...)``'s folder mapping
+    (pfblockerng.inc ~5257) -- read live rather than hardcoded so this test
+    stays correct across ``$g['vardb_path']`` layouts.
+    """
+    pre = f"require_once({helpers._php_str(PFB_INC_PATH)});\nglobal $pfb; pfb_global();\n$e = $pfb['dnsdir'];"
+    return helpers._php_read_scalar(vm, pre, "$e", timeout=120.0)
+
+
+def _flag_exists(vm: helpers.SmokeVM, path: str) -> bool:
+    pre = f"$e = file_exists({helpers._php_str(path)}) ? 'YES' : 'NO';"
+    return helpers._php_read_scalar(vm, pre, "$e", timeout=120.0) == "YES"
 
 
 def test_dnsbl_textarea_save_normalizes_line_endings_and_controls(
@@ -337,4 +354,63 @@ def test_category_edit_custom_list_accepts_idn_row(
             f"got {_decoded(helpers.config_get(vm, f'{base}/custom'))!r}"
         )
     finally:
+        tce._del_rowid(vm, tce.CFG_DNSBL, rowid)
+
+
+def test_category_edit_noop_resave_does_not_touch_update_flag(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A no-op custom-list resave must not touch the list's ``.update`` flag (#1729 review).
+
+    The change detector at ``pfblockerng_category_edit.php`` ~829 compared the
+    RAW ``$_POST['custom']`` (CRLF, exactly as a browser submits a textarea)
+    against the STORED blob -- which ``pfb_text_area_encode()`` persists
+    LF-only. An unchanged custom list therefore always compared unequal, so
+    every no-op save touched
+    ``{$pfbarr['folder']}/{$aname}_custom{$suffix}.update``, forcing a
+    spurious custom-list reprocess/WHOIS re-query on the next cron pass.
+
+    Given a DNSBL alias (``action='unbound'`` -> ``pfb_determine_list_detail``
+    resolves a real folder, mirroring a normal DNSBL group) saved once with a
+    CRLF-joined custom list, its ``.update`` flag then removed,
+    When the IDENTICAL (CRLF) form is re-POSTed unchanged,
+    Then the persisted ``custom`` value must be unchanged AND the flag file
+    must NOT reappear.
+
+    RED (before the fix): the second save's raw-vs-sanitized compare is
+    always unequal -> the flag is touched every time.
+    GREEN (after): compare sanitized-vs-sanitized -> a no-op resave never
+    touches the flag.
+    """
+    vm = smoke_vm
+    rowid = tce._free_rowid(vm, tce.CFG_DNSBL)
+    base = f"{tce.CFG_DNSBL}/{rowid}"
+    aliasname = "smokenoopresave"
+    folder = _dnsbl_folder(vm)
+    flag = f"{folder}/{aliasname}_custom.update"
+    raw_custom = "\r\n".join([helpers.unique_domain("pfbnoopa"), helpers.unique_domain("pfbnoopb")])
+    try:
+        assert helpers.config_get(vm, f"{base}/aliasname") == "", f"rowid {rowid} not free (aliasname already set)"
+
+        tce._post_form(webui, tce._dnsbl_payload(rowid, aliasname, custom=raw_custom))
+        assert helpers.config_get(vm, f"{base}/aliasname") == aliasname, "first save did not persist the alias"
+        first_custom = helpers.config_get(vm, f"{base}/custom")
+        assert first_custom, "first save did not persist a custom list"
+
+        # Sweep the flag the first (necessarily change-detected) save touched, and
+        # confirm its absence before the no-op resave under test.
+        helpers.php_eval(vm, f"@unlink({helpers._php_str(flag)}); echo 'OK';", timeout=120.0)
+        assert not _flag_exists(vm, flag), f"precondition: {flag} must be absent before the no-op resave"
+
+        tce._post_form(webui, tce._dnsbl_payload(rowid, aliasname, custom=raw_custom))
+
+        assert helpers.config_get(vm, f"{base}/custom") == first_custom, (
+            "an identical (CRLF) resave must not change the persisted custom list"
+        )
+        assert not _flag_exists(vm, flag), (
+            f"a no-op custom-list resave must not touch {flag} (raw-vs-sanitized compare bug)"
+        )
+    finally:
+        helpers.php_eval(vm, f"@unlink({helpers._php_str(flag)}); echo 'OK';", timeout=120.0)
         tce._del_rowid(vm, tce.CFG_DNSBL, rowid)


### PR DESCRIPTION
## Summary

Makes text-field sanitization a repository standard enforced at the persist boundary, building on #1724's shared helpers. Four commits:

1. **`pfblockerng: accept Unicode text and IDN domains in pfb_filter; add pfb_text_area_encode()`** — `pfb_filter()`'s control-character reject gate narrows from `\p{C}` to `\p{Cc}` + BOM: Unicode format characters (ZWJ/ZWNJ, bidi marks, zero-width) no longer reject a whole field, while Cc, BOM, and invalid UTF-8 stay rejected fail-closed. `PFB_FILTER_DOMAIN`/`PFB_FILTER_TLD` accept Unicode domains by validating the `idn_to_ascii()` punycode form (leading-dot rows handled like the decoder) and returning the original input — callers keep their pass/fail contract, the read path already converts to punycode. New `pfb_text_area_encode()` = `base64_encode(pfb_sanitize_text_area(...))`. Also lands the two deferred notes from PR #1724's re-review (scalar pathological-input pin, fail-open doc caveats).
2. **`tests: pin persist-boundary sanitization save flows`** — six Tier B `ui_e2e` tests (`tests/smoke/ui/test_sanitize_persist.py`) driving real CSRF POST saves and asserting the persisted `config.xml` state.
3. **`www: sanitize text fields at the persist boundary`** — all 14 remaining textarea persist sites route through `pfb_text_area_encode()` (dnsbl ×6, ip ×2, category_edit ×2, general ×1 replacing its hand-rolled normalization, alerts ×9-site re-encoders, extra/install/inc re-encoders); single-line free-text POST fields wrap in `pfb_sanitize_text()` before validation (ip: `ip_placeholder`, `asn_token`, `autorule_suffix`, `maxmind_account`, `maxmind_key` inside its write-only branch; dnsbl: `pfb_dnsvip4/6`, `dnsbl_webpage`, `dnsbl_redir_exclude`, `dnsbl_dot_block_exclude`; category_edit: `aliasname`, `description`, `srcint`, `script_pre/post`, rowhelper header/url per element).
4. **`docs: make persist-boundary text sanitization a coding standard`** — the standard in `.agents/policy/coding.md`.

Fixes #1723.

## Evidence

- **Hermetic red→green** (commit 1): 7 reproduction tests + 2 undefined-helper errors executed RED on untouched code, frozen by hash, GREEN unchanged; independently re-executed via `verify-red-proof.sh` (FREEZE-OK ×2, RED-OK, GREEN-OK, PASS).
- **Live red→green** (commits 2-3): the six e2e tests ran against a red-baseline ref on a leased pfSense VM — `5 failed, 1 passed` (raw CR/control bytes persisted verbatim; the IDN save already green from commit 1) — then `6 passed` on the wired branch. Independently RE-EXECUTED by the verification pass on a fresh box lease: same `5 failed, 1 passed` → `6 passed`, test file byte-identical throughout (`b7477875`).
- `run-gates.sh --diff origin/devel` green across Python + PHP suites, PHPStan, PHPCS.
- Completeness swept from source: every `base64_encode` site in `src/` is converted or excluded with reason (Pulsedive URL builder, log download, serialized ledger payload — not textarea content). One adjacent path deliberately stays narrower: the hook-script editor's raw script writes — decision tracked in #1728.

## Deliberate calls

- **Persisted form stays what the admin typed**; IDN conversion remains read-side (`pfb_text_area_decode($idn)`), so validation accepts Unicode without changing storage format. Deviates from the issue's "store the punycode form" wording — storage-side conversion already exists on the read path and changing the stored form would churn every consumer for no behaviour gain.
- **Mixed-script/homoglyph domains are accepted by design**: admins enter typosquat domains into their own block lists; rejecting confusables here would break the core use case. Zero-width handling in domain-shaped input follows UTS46 as probed: a ZWSP standing as an entire label is rejected (idn_to_ascii FALSE); a mid-label ZWSP is silently mapped away (idn_to_ascii('exam\u200Bple.com') = 'example.com') and the row is accepted, blocking the mapped target — an invisible copy-paste artifact cannot make a row silently miss; ZWNJ/ZWJ (contextually legal in IDNA labels, e.g. Persian) are accepted by design. All pinned by executed tests.
- **`PFB_FILTER_WORD_DOT` untouched** — it validates a webroot filename, not a hostname.
- `AlertsPfctlCheckedSitesTest` oracles updated CRLF→LF (they pinned raw-CRLF persistence, now normalized); the old ZWSP hardening pin in `PfbFilterContractTest` is replaced by an accept pin per this issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved text-field sanitization when saving single-line and multi-line values.
  * Added support for Unicode and internationalized domain names in domain and TLD validation.
  * Standardized textarea line-ending normalization and control-character removal.
* **Bug Fixes**
  * Prevented malformed input and unexpected array values from affecting saved settings.
  * Preserved valid Unicode text while rejecting invalid control characters and BOM markers.
  * Improved reliability when saving suppression, allowlist, and custom-list data.
* **Tests**
  * Added coverage for Unicode domains, sanitization edge cases, and persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->