### PR TITLE
ci: keep closed tracking issues closed

### DIFF
--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -92,25 +92,17 @@ jobs:
             printf '_Opened automatically by the nightly-failure-alert workflow. Updated in place on every red nightly; closes manually with the fix._\n'
           } > "$BODY_FILE"
 
-          # Dedup by label + exact title (top1m-healthcheck pattern, incl. the
-          # >30-item page-cap lift) — but across ALL states: a recurrence after a
-          # fix REOPENS the closed tracker instead of filing a duplicate (PR #958
-          # review). Prefer an open match, then the lowest issue number.
-          MATCH=$(gh issue list --repo "$REPO" --state all \
+          # Dedup open issues by label + exact title (top1m-healthcheck pattern,
+          # including the >30-item page-cap lift). Closed issues stay closed.
+          MATCH=$(gh issue list --repo "$REPO" --state open \
             --label "nightly-red" --limit 500 --json number,title,state \
             | jq -r --arg t "$TITLE" \
-                '[.[] | select(.title == $t)] | sort_by(.state != "OPEN", .number)
-                 | .[0] | if . then "\(.number) \(.state)" else empty end')
+                '[.[] | select(.title == $t)] | sort_by(.number)
+                 | .[0].number // empty')
 
           if [ -n "$MATCH" ]; then
-            EXISTING_NUM=${MATCH% *}
-            EXISTING_STATE=${MATCH#* }
-            if [ "$EXISTING_STATE" = "CLOSED" ]; then
-              echo "[reopen] Reopening tracking issue #${EXISTING_NUM}"
-              gh issue reopen "$EXISTING_NUM" --repo "$REPO"
-            fi
-            echo "[update] Updating tracking issue #${EXISTING_NUM}"
-            gh issue edit "$EXISTING_NUM" --repo "$REPO" --body-file "$BODY_FILE"
+            echo "[update] Updating tracking issue #${MATCH}"
+            gh issue edit "$MATCH" --repo "$REPO" --body-file "$BODY_FILE"
           else
             echo "[create] Opening tracking issue"
             gh issue create \

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -181,27 +181,17 @@ jobs:
           set -euo pipefail
           TITLE="[top1m-healthcheck] provider URL unhealthy"
 
-          # Scope to the tracking label and lift the default 30-item cap (see
-          # version-tracker.yml's dedup note) so an older issue past the
-          # first page is still found and updated in place, not re-created --
-          # but across ALL states: a recurrence after a closed tracker
-          # REOPENS it instead of filing a duplicate (issue #960). Prefer an
-          # open match, then the lowest issue number.
-          MATCH=$(gh issue list --repo "$REPO" --state all \
+          # Scope to open issues with the tracking label and lift the default
+          # 30-item cap so an older open issue is updated, not duplicated.
+          MATCH=$(gh issue list --repo "$REPO" --state open \
             --label "top1m-provider" --limit 500 --json number,title,state \
             | jq -r --arg t "$TITLE" \
-                '[.[] | select(.title == $t)] | sort_by(.state != "OPEN", .number)
-                 | .[0] | if . then "\(.number) \(.state)" else empty end')
+                '[.[] | select(.title == $t)] | sort_by(.number)
+                 | .[0].number // empty')
 
           if [ -n "$MATCH" ]; then
-            EXISTING_NUM=${MATCH% *}
-            EXISTING_STATE=${MATCH#* }
-            if [ "$EXISTING_STATE" = "CLOSED" ]; then
-              echo "[reopen] Reopening tracking issue #${EXISTING_NUM}"
-              gh issue reopen "$EXISTING_NUM" --repo "$REPO"
-            fi
-            echo "[update] Updating tracking issue #${EXISTING_NUM}"
-            gh issue edit "$EXISTING_NUM" --repo "$REPO" --body-file "${{ steps.report.outputs.body_file }}"
+            echo "[update] Updating tracking issue #${MATCH}"
+            gh issue edit "$MATCH" --repo "$REPO" --body-file "${{ steps.report.outputs.body_file }}"
           else
             echo "[create] Opening tracking issue"
             gh issue create \

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -347,39 +347,25 @@ jobs:
 
             TITLE="[version-tracker] pfSense ${CHANNEL} ${VERSION} still-supported — evaluate for matrix"
 
-            # Scope to the version-tracker label and lift the default 30-item cap:
-            # without an explicit --limit, gh issue list returns only the 30 newest
-            # open issues, so an older tracker issue beyond that window is invisible
-            # to the dedup and a duplicate is opened every run. Match across ALL
-            # states (issue #960): a recurrence after a closed tracker REOPENS it
-            # instead of filing a duplicate. Prefer an open match, then the lowest
-            # issue number.
-            MATCH=$(gh issue list --repo "$REPO" --state all \
+            # Scope to open version-tracker issues and lift the default 30-item
+            # cap so an older open tracker remains visible to deduplication.
+            MATCH=$(gh issue list --repo "$REPO" --state open \
               --label "version-tracker" --limit 500 --json number,title,state \
               | jq -r --arg t "$TITLE" \
-                  '[.[] | select(.title == $t)] | sort_by(.state != "OPEN", .number)
-                   | .[0] | if . then "\(.number) \(.state)" else empty end')
-            if [ -n "$MATCH" ] && [ "${MATCH#* }" = "OPEN" ]; then
+                  '[.[] | select(.title == $t)] | sort_by(.number)
+                   | .[0].number // empty')
+            if [ -n "$MATCH" ]; then
               echo "  [skip] open issue already exists for ${CHANNEL} ${VERSION}"
               continue
             fi
 
             # Skip if a closed issue with tracker-wontfix mentions this version.
-            # Checked BEFORE reopening: a wontfix'd version must never be
-            # reopened. --limit 500 lifts the default 30-item cap (see above).
+            # --limit 500 lifts the default 30-item cap (see above).
             WONTFIX=$(gh issue list --repo "$REPO" --state closed --label "tracker-wontfix" \
               --limit 500 --json title \
               | jq --arg v "$VERSION" '[.[] | select(.title | contains($v))] | length')
             if [ "${WONTFIX:-0}" -gt 0 ]; then
               echo "  [wontfix] suppressed for ${CHANNEL} ${VERSION}"
-              continue
-            fi
-
-            if [ -n "$MATCH" ] && [ "${MATCH#* }" = "CLOSED" ]; then
-              EXISTING_NUM=${MATCH% *}
-              echo "  [reopen] Reopening tracking issue #${EXISTING_NUM} for ${CHANNEL} ${VERSION}"
-              gh issue reopen "$EXISTING_NUM" --repo "$REPO" \
-                || echo "  ::warning::Could not reopen tracking issue #${EXISTING_NUM}"
               continue
             fi
 
@@ -454,30 +440,18 @@ jobs:
               printf '_the page signal changes (TBD → released date → GA)._\n'
             } > "$BODY_FILE"
 
-            # Update an existing tracking issue; create one if none exists.
-            # Scope to the version-tracker label and lift the default 30-item cap so
-            # an older tracking issue past the first page is still found and updated
-            # in place rather than re-created (the duplicate-issue bug). Match across
-            # ALL states (issue #960): a recurrence after a closed tracker REOPENS it
-            # instead of filing a duplicate. Prefer an open match, then the lowest
-            # issue number.
-            MATCH=$(gh issue list --repo "$REPO" --state all \
+            # Update an open tracking issue; create one if none exists. The
+            # explicit limit keeps older open trackers visible to deduplication.
+            MATCH=$(gh issue list --repo "$REPO" --state open \
               --label "version-tracker" --limit 500 --json number,title,state \
               | jq -r --arg t "$TITLE" \
-                  '[.[] | select(.title == $t)] | sort_by(.state != "OPEN", .number)
-                   | .[0] | if . then "\(.number) \(.state)" else empty end')
+                  '[.[] | select(.title == $t)] | sort_by(.number)
+                   | .[0].number // empty')
 
             if [ -n "$MATCH" ]; then
-              EXISTING_NUM=${MATCH% *}
-              EXISTING_STATE=${MATCH#* }
-              if [ "$EXISTING_STATE" = "CLOSED" ]; then
-                echo "  [reopen] Reopening tracking issue #${EXISTING_NUM} for ${CHANNEL} ${VERSION}"
-                gh issue reopen "$EXISTING_NUM" --repo "$REPO" \
-                  || echo "  ::warning::Could not reopen tracking issue #${EXISTING_NUM}"
-              fi
-              echo "  [update] Updating tracking issue #${EXISTING_NUM} for ${CHANNEL} ${VERSION}"
-              gh issue edit "$EXISTING_NUM" --repo "$REPO" --body-file "$BODY_FILE" \
-                || echo "  ::warning::Could not update tracking issue #${EXISTING_NUM}"
+              echo "  [update] Updating tracking issue #${MATCH} for ${CHANNEL} ${VERSION}"
+              gh issue edit "$MATCH" --repo "$REPO" --body-file "$BODY_FILE" \
+                || echo "  ::warning::Could not update tracking issue #${MATCH}"
             else
               echo "  [create] Opening tracking issue for ${CHANNEL} ${VERSION}"
               gh issue create \

--- a/tests/test_workflow_issue_dedup_contract.py
+++ b/tests/test_workflow_issue_dedup_contract.py
@@ -1,5 +1,7 @@
 """Preserve safe deduplication around issue creation (issue #1735)."""
 
+from __future__ import annotations
+
 import os
 import re
 import subprocess

--- a/tests/test_workflow_issue_dedup_contract.py
+++ b/tests/test_workflow_issue_dedup_contract.py
@@ -30,6 +30,10 @@ def _issue_creation_steps(path: Path) -> list[str]:
     return [step for step in path.read_text(encoding="utf-8").split("\n      - name:") if "gh issue create " in step]
 
 
+def _script(step: str) -> str:
+    return "\n".join(line[10:] for line in step.split("        run: |\n", 1)[1].splitlines())
+
+
 def _run_script(
     path: Path,
     step_name: str,
@@ -41,7 +45,7 @@ def _run_script(
 ) -> list[str]:
     source = path.read_text(encoding="utf-8")
     step = source.split(f"      - name: {step_name}\n", 1)[1].split("\n      - name:", 1)[0]
-    script = "\n".join(line[10:] for line in step.split("        run: |\n", 1)[1].splitlines())
+    script = _script(step).replace("${{ steps.report.outputs.body_file }}", str(tmp_path / "body.md"))
     log = tmp_path / "gh.log"
     fake_gh = tmp_path / "gh"
     fake_gh.write_text(
@@ -79,13 +83,14 @@ def test_issue_creation_steps_keep_exact_open_deduplication() -> None:
 
     for step in steps:
         commands = _commands(step)
+        code = "\n".join(line for line in _script(step).splitlines() if not line.lstrip().startswith("#"))
         creates = [command for command in commands if command.startswith("gh issue create ")]
         dedups = [
             command for command in commands if "gh issue list " in command and "--json number,title,state" in command
         ]
         assert len(dedups) == len(creates), f"expected one dedup lookup per issue create: {step}"
-        assert "set -euo pipefail" in step, f"issue dedup must fail closed on lookup errors: {step}"
-        assert step.count("select(.title == $t)") == len(creates), f"issue dedup must use exact titles: {step}"
+        assert "set -euo pipefail" in code, f"issue dedup must fail closed on lookup errors: {step}"
+        assert code.count("select(.title == $t)") == len(creates), f"issue dedup must use exact titles: {step}"
 
         for create, dedup in zip(creates, dedups, strict=True):
             assert "--state open" in dedup, f"issue dedup must query open issues only: {dedup}"
@@ -100,6 +105,7 @@ def test_issue_creation_steps_keep_exact_open_deduplication() -> None:
     [
         ('[{"number":42,"title":"[nightly-red] Smoke failing on devel","state":"OPEN"}]', ["edit 42"]),
         ("[]", ["create"]),
+        ('[{"number":42,"title":"different","state":"OPEN"}]', ["create"]),
     ],
 )
 def test_nightly_open_match_updates_and_closed_only_creates(tmp_path: Path, opened: str, expected: list[str]) -> None:
@@ -122,6 +128,26 @@ def test_nightly_open_match_updates_and_closed_only_creates(tmp_path: Path, open
 
 
 @pytest.mark.parametrize(
+    ("opened", "expected"),
+    [
+        ('[{"number":42,"title":"[top1m-healthcheck] provider URL unhealthy","state":"OPEN"}]', ["edit 42"]),
+        ("[]", ["create"]),
+        ('[{"number":42,"title":"different","state":"OPEN"}]', ["create"]),
+    ],
+)
+def test_top1m_open_match_updates_and_closed_only_creates(tmp_path: Path, opened: str, expected: list[str]) -> None:
+    assert (
+        _run_script(
+            WORKFLOWS / "top1m-healthcheck.yml",
+            "Open or update the tracking issue",
+            tmp_path,
+            opened=opened,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
     ("opened", "closed", "expected"),
     [
         (
@@ -131,6 +157,7 @@ def test_nightly_open_match_updates_and_closed_only_creates(tmp_path: Path, open
             [],
         ),
         ("[]", "[]", ["create"]),
+        ('[{"number":42,"title":"different","state":"OPEN"}]', "[]", ["create"]),
         ("[]", '[{"title":"wontfix pfSense 2.8"}]', []),
     ],
 )
@@ -148,6 +175,33 @@ def test_supported_missing_open_skips_closed_only_creates_and_wontfix_suppresses
             tmp_path,
             opened=opened,
             closed=closed,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("opened", "expected"),
+    [
+        (
+            '[{"number":42,"title":"[version-tracker] pfSense CE 2.8 — upcoming version tracking","state":"OPEN"}]',
+            ["edit 42"],
+        ),
+        ("[]", ["create"]),
+        ('[{"number":42,"title":"different","state":"OPEN"}]', ["create"]),
+    ],
+)
+def test_upcoming_open_match_updates_and_closed_only_creates(tmp_path: Path, opened: str, expected: list[str]) -> None:
+    (tmp_path / "probe_result.json").write_text(
+        '{"future":[{"version":"2.8","channel":"CE","released":"TBD","freebsd_major":"15"}]}',
+        encoding="utf-8",
+    )
+    assert (
+        _run_script(
+            WORKFLOWS / "version-tracker.yml",
+            "Open or update tracking issues for upcoming/TBD versions",
+            tmp_path,
+            opened=opened,
         )
         == expected
     )

--- a/tests/test_workflow_issue_dedup_contract.py
+++ b/tests/test_workflow_issue_dedup_contract.py
@@ -1,0 +1,153 @@
+"""Preserve safe deduplication around issue creation (issue #1735)."""
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+_LABEL = re.compile(r'--label "([^"]+)"')
+
+
+def _commands(source: str) -> list[str]:
+    commands: list[str] = []
+    command = ""
+    for line in source.splitlines():
+        stripped = line.strip()
+        command = f"{command} {stripped}".strip()
+        if stripped.endswith("\\"):
+            command = command[:-1].rstrip()
+        else:
+            commands.append(command)
+            command = ""
+    return commands
+
+
+def _issue_creation_steps(path: Path) -> list[str]:
+    return [step for step in path.read_text(encoding="utf-8").split("\n      - name:") if "gh issue create " in step]
+
+
+def _run_script(
+    path: Path,
+    step_name: str,
+    tmp_path: Path,
+    *,
+    opened: str,
+    closed: str = "[]",
+    extra_env: dict[str, str] | None = None,
+) -> list[str]:
+    source = path.read_text(encoding="utf-8")
+    step = source.split(f"      - name: {step_name}\n", 1)[1].split("\n      - name:", 1)[0]
+    script = "\n".join(line[10:] for line in step.split("        run: |\n", 1)[1].splitlines())
+    log = tmp_path / "gh.log"
+    fake_gh = tmp_path / "gh"
+    fake_gh.write_text(
+        """#!/bin/sh
+case "$*" in
+  "issue list "*"--state closed"*) printf '%s\\n' "$GH_CLOSED" ;;
+  "issue list "*) printf '%s\\n' "$GH_OPEN" ;;
+  "issue edit "*) printf 'edit %s\\n' "$3" >> "$GH_LOG" ;;
+  "issue create "*) printf 'create\\n' >> "$GH_LOG" ;;
+  "issue reopen "*) printf 'reopen %s\\n' "$3" >> "$GH_LOG" ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    env = os.environ | {
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "GH_CLOSED": closed,
+        "GH_LOG": str(log),
+        "GH_OPEN": opened,
+        "REPO": "owner/repo",
+    }
+    env.update(extra_env or {})
+    subprocess.run(["bash", "-c", script], cwd=tmp_path, env=env, check=True, capture_output=True, text=True)
+    return log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+
+
+def test_issue_creation_steps_keep_exact_open_deduplication() -> None:
+    steps = [
+        step
+        for path in sorted((*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml")))
+        for step in _issue_creation_steps(path)
+    ]
+    assert steps, "found no issue-creation steps"
+
+    for step in steps:
+        commands = _commands(step)
+        creates = [command for command in commands if command.startswith("gh issue create ")]
+        dedups = [
+            command for command in commands if "gh issue list " in command and "--json number,title,state" in command
+        ]
+        assert len(dedups) == len(creates), f"expected one dedup lookup per issue create: {step}"
+        assert "set -euo pipefail" in step, f"issue dedup must fail closed on lookup errors: {step}"
+        assert step.count("select(.title == $t)") == len(creates), f"issue dedup must use exact titles: {step}"
+
+        for create, dedup in zip(creates, dedups, strict=True):
+            assert "--state open" in dedup, f"issue dedup must query open issues only: {dedup}"
+            assert "--limit 500" in dedup, f"issue dedup must lift the default page limit: {dedup}"
+            assert _LABEL.findall(dedup) == _LABEL.findall(create), (
+                f"dedup and create labels differ: dedup={dedup!r}, create={create!r}"
+            )
+
+
+@pytest.mark.parametrize(
+    ("opened", "expected"),
+    [
+        ('[{"number":42,"title":"[nightly-red] Smoke failing on devel","state":"OPEN"}]', ["edit 42"]),
+        ("[]", ["create"]),
+    ],
+)
+def test_nightly_open_match_updates_and_closed_only_creates(tmp_path: Path, opened: str, expected: list[str]) -> None:
+    assert (
+        _run_script(
+            WORKFLOWS / "nightly-failure-alert.yml",
+            "Open or update the tracking issue",
+            tmp_path,
+            opened=opened,
+            extra_env={
+                "WF_NAME": "Smoke",
+                "RUN_URL": "https://example.invalid/run",
+                "HEAD_SHA": "deadbeef",
+                "BRANCH": "devel",
+                "DRILL": "",
+            },
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("opened", "closed", "expected"),
+    [
+        (
+            '[{"number":42,"title":"[version-tracker] pfSense CE 2.8 still-supported — evaluate for matrix",'
+            '"state":"OPEN"}]',
+            "[]",
+            [],
+        ),
+        ("[]", "[]", ["create"]),
+        ("[]", '[{"title":"wontfix pfSense 2.8"}]', []),
+    ],
+)
+def test_supported_missing_open_skips_closed_only_creates_and_wontfix_suppresses(
+    tmp_path: Path, opened: str, closed: str, expected: list[str]
+) -> None:
+    (tmp_path / "probe_result.json").write_text(
+        '{"supported_missing":[{"version":"2.8","channel":"CE","freebsd_major":"15"}]}',
+        encoding="utf-8",
+    )
+    assert (
+        _run_script(
+            WORKFLOWS / "version-tracker.yml",
+            "Open nudge issues for supported-but-missing versions",
+            tmp_path,
+            opened=opened,
+            closed=closed,
+        )
+        == expected
+    )

--- a/tests/test_workflow_issue_lifecycle.py
+++ b/tests/test_workflow_issue_lifecycle.py
@@ -1,5 +1,7 @@
 """Issue-opening workflows deduplicate against open issues only (issue #1735)."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_workflow_issue_lifecycle.py
+++ b/tests/test_workflow_issue_lifecycle.py
@@ -1,0 +1,45 @@
+"""Issue-opening workflows deduplicate against open issues only (issue #1735)."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _commands(source: str) -> list[str]:
+    commands: list[str] = []
+    command = ""
+    for line in source.splitlines():
+        stripped = line.strip()
+        command = f"{command} {stripped}".strip()
+        if stripped.endswith("\\"):
+            command = command[:-1].rstrip()
+        else:
+            commands.append(command)
+            command = ""
+    return commands
+
+
+def test_issue_openers_never_reopen_closed_issues() -> None:
+    creators: list[str] = []
+    offenders: list[str] = []
+    for path in sorted((*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml"))):
+        commands = _commands(path.read_text(encoding="utf-8"))
+        create_count = sum(command.startswith("gh issue create ") for command in commands)
+        if not create_count:
+            continue
+        creators.append(path.name)
+        offenders.extend(f"{path.name}: {command}" for command in commands if command.startswith("gh issue reopen "))
+        dedup_commands = [
+            command for command in commands if "gh issue list " in command and "--json number,title,state" in command
+        ]
+        assert len(dedup_commands) == create_count, (
+            f"{path.name}: expected one exact-state dedup lookup per issue create; "
+            f"found {len(dedup_commands)} for {create_count} create command(s)"
+        )
+        assert all("--state open" in command for command in dedup_commands), (
+            f"{path.name}: issue dedup must query open issues only: {dedup_commands}"
+        )
+
+    assert creators, "found no issue-opening workflows"
+    assert not offenders, "issue-opening workflows must never reopen closed issues:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary

- deduplicate all issue-opening workflows against open exact-title matches only
- leave closed tracking issues untouched; create a new tracker when no open match exists
- preserve the version-tracker closed wontfix suppression
- add a repository-wide regression guard for current and future issue-opening workflows

## Verification

- Test-first RED: focused test failed on nightly-failure-alert using --state all
- Frozen test hash: cf344259d504066eb769f5ab2f29273673dd5170
- Mechanical proof: FREEZE-OK, RED-OK against pre-fix base 8ec752b53b1f923522872ebcc7df8d35c1d41b98, GREEN-OK against HEAD
- Canonical gates: pytest PASS; Ruff check PASS; Ruff format PASS; mypy PASS
- Actionlint syntax validation: PASS
- Repository workflow scan: zero gh issue reopen commands

Fixes #1735

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
