### PR TITLE
feeds: normalize alternate rows before rendering

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -384,7 +384,9 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 				$counter = 0;
 				$alt_feed_rows = array();
 				if (isset($alt_feeds[$ftype][$aliasname][$feed['header']])) {
-					$alt_feed_rows = array_values($alt_feeds[$ftype][$aliasname][$feed['header']]);
+					$alt_feed_rows = $alt_feeds[$ftype][$aliasname][$feed['header']];
+					ksort($alt_feed_rows, SORT_NUMERIC);
+					$alt_feed_rows = array_values($alt_feed_rows);
 					$counter = count($alt_feed_rows);
 				}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -382,8 +382,10 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 
 				// Print table/row of Feeds and consecutive rows for all 'Alternate' URLs available.
 				$counter = 0;
+				$alt_feed_rows = array();
 				if (isset($alt_feeds[$ftype][$aliasname][$feed['header']])) {
-					$counter = count($alt_feeds[$ftype][$aliasname][$feed['header']]);
+					$alt_feed_rows = array_values($alt_feeds[$ftype][$aliasname][$feed['header']]);
+					$counter = count($alt_feed_rows);
 				}
 
 				for ($i=0; $i <= $counter; $i++):
@@ -515,7 +517,7 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 						// Extract 'Alternate Feed' details from alt_feed array.
 						else {
 							$status = '';
-							$alt_feed	= $alt_feeds[$ftype][$aliasname][$feed['header']][$i -1];
+							$alt_feed	= $alt_feed_rows[$i -1];
 							$icon 		= $alt_feed['icon'];
 
 							if (in_array($alt_feed['header'], $feed_alt_selected)) {

--- a/tests/php/FeedsUrlCompareIconRenderTest.php
+++ b/tests/php/FeedsUrlCompareIconRenderTest.php
@@ -242,4 +242,64 @@ final class FeedsUrlCompareIconRenderTest extends TestCase
 			'the stored alternate entry must carry the checkmark match icon'
 		);
 	}
+
+	public function testNonContiguousAlternateBucketRendersEveryRowWithoutWarning(): void
+	{
+		$primaryUrl   = 'https://example.test/non-contiguous/primary.txt';
+		$matchedUrl   = 'https://example.test/non-contiguous/matched.txt';
+		$primaryHeader = 'NonContiguousPrimary';
+		$feed = $this->buildFeed($primaryHeader, $primaryUrl, 'https://example.test/non-contiguous/', [
+			'alternate' => [
+				['url' => 'https://example.test/non-contiguous/unmatched.txt', 'header' => 'UnmatchedAlternate'],
+				['url' => $matchedUrl, 'header' => 'FirstRenderedAlternate'],
+				['url' => 'https://example.test/non-contiguous/later.txt', 'header' => 'SecondRenderedAlternate'],
+			],
+		]);
+		$info = ['NonContiguousAlias' => [
+			'action' => 'permit',
+			'info'   => 'Non-contiguous alias info',
+			'feeds'  => [$feed],
+		]];
+		$exFeeds = [[
+			'aliasname' => 'NonContiguousAlias',
+			'action'    => 'permit',
+			'state'     => 'Enabled',
+			'url'       => $matchedUrl,
+			'header'    => 'FirstRenderedAlternate',
+			'rowid'     => 601,
+		]];
+		$diagnostics = [];
+		set_error_handler(
+			static function (int $errno, string $errstr) use (&$diagnostics): bool {
+				$diagnostics[] = [$errno, $errstr];
+				return TRUE;
+			},
+			E_ALL
+		);
+		try {
+			$html = $this->renderType('ipv4', $info, $exFeeds);
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame(
+			[1, 2],
+			array_keys($GLOBALS['alt_feeds']['ipv4']['NonContiguousAlias'][$primaryHeader]),
+			'test setup must exercise the non-contiguous alternate bucket'
+		);
+		$undefinedKeyDiagnostics = array_values(array_filter(
+			$diagnostics,
+			static fn(array $diagnostic): bool => str_contains($diagnostic[1], 'Undefined array key')
+		));
+		$this->assertSame([], $undefinedKeyDiagnostics, var_export($diagnostics, TRUE));
+
+		$firstRow  = strpos($html, 'value="alt_FirstRenderedAlternate"');
+		$secondRow = strpos($html, 'value="alt_SecondRenderedAlternate"');
+		$this->assertNotFalse($firstRow, 'first alternate row must render');
+		$this->assertNotFalse($secondRow, 'second alternate row must render');
+		$this->assertTrue(
+			$firstRow < $secondRow,
+			"alternate rows must preserve source order; positions: {$firstRow}, {$secondRow}"
+		);
+	}
 }

--- a/tests/php/FeedsUrlCompareIconRenderTest.php
+++ b/tests/php/FeedsUrlCompareIconRenderTest.php
@@ -250,9 +250,8 @@ final class FeedsUrlCompareIconRenderTest extends TestCase
 		$primaryHeader = 'NonContiguousPrimary';
 		$feed = $this->buildFeed($primaryHeader, $primaryUrl, 'https://example.test/non-contiguous/', [
 			'alternate' => [
-				['url' => 'https://example.test/non-contiguous/unmatched.txt', 'header' => 'UnmatchedAlternate'],
-				['url' => $matchedUrl, 'header' => 'FirstRenderedAlternate'],
-				['url' => 'https://example.test/non-contiguous/later.txt', 'header' => 'SecondRenderedAlternate'],
+				1 => ['url' => $matchedUrl, 'header' => 'FirstRenderedAlternate'],
+				2 => ['url' => 'https://example.test/non-contiguous/later.txt', 'header' => 'SecondRenderedAlternate'],
 			],
 		]);
 		$info = ['NonContiguousAlias' => [
@@ -260,14 +259,24 @@ final class FeedsUrlCompareIconRenderTest extends TestCase
 			'info'   => 'Non-contiguous alias info',
 			'feeds'  => [$feed],
 		]];
-		$exFeeds = [[
-			'aliasname' => 'NonContiguousAlias',
-			'action'    => 'permit',
-			'state'     => 'Enabled',
-			'url'       => $matchedUrl,
-			'header'    => 'FirstRenderedAlternate',
-			'rowid'     => 601,
-		]];
+		$exFeeds = [
+			[
+				'aliasname' => 'NonContiguousAlias',
+				'action'    => 'permit',
+				'state'     => 'Enabled',
+				'url'       => 'https://example.test/non-contiguous/later.txt',
+				'header'    => 'SecondRenderedAlternate',
+				'rowid'     => 602,
+			],
+			[
+				'aliasname' => 'NonContiguousAlias',
+				'action'    => 'permit',
+				'state'     => 'Enabled',
+				'url'       => $matchedUrl,
+				'header'    => 'FirstRenderedAlternate',
+				'rowid'     => 601,
+			],
+		];
 		$diagnostics = [];
 		set_error_handler(
 			static function (int $errno, string $errstr) use (&$diagnostics): bool {
@@ -283,9 +292,9 @@ final class FeedsUrlCompareIconRenderTest extends TestCase
 		}
 
 		$this->assertSame(
-			[1, 2],
+			[2, 1],
 			array_keys($GLOBALS['alt_feeds']['ipv4']['NonContiguousAlias'][$primaryHeader]),
-			'test setup must exercise the non-contiguous alternate bucket'
+			'test setup must exercise a non-contiguous bucket inserted out of source order'
 		);
 		$undefinedKeyDiagnostics = array_values(array_filter(
 			$diagnostics,

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1629,6 +1629,52 @@ def test_feeds_custom_panel_heading_renders(webui: WebUI, php_error_log_guard: P
     )
 
 
+# Dual-marked ui_e2e because setup writes one config row; the module-level
+# ui_render marker keeps this live render regression in the Tier-A gate.
+@pytest.mark.ui_e2e
+def test_feeds_non_contiguous_alternate_bucket_renders_every_row(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:  # noqa: ARG001
+    """A configured non-first SFS alternate renders it and every later alternate (#1702)."""
+    path = "/pfblockerng/pfblockerng_feeds.php?type=ipv4"
+    rowid = _free_rowid(smoke_vm, CFG_IPV4)
+    base = f"{CFG_IPV4}/{rowid}"
+    matched_url = "https://www.stopforumspam.com/downloads/listed_ip_7.zip"
+    headers = ("SFS_7d", "SFS_30d", "SFS_90d", "SFS_180d", "SFS_365d")
+    try:
+        seed = helpers.php_eval(
+            smoke_vm,
+            f"config_set_path({helpers._php_str(f'{base}/aliasname')}, 'SFS');\n"
+            f"config_set_path({helpers._php_str(f'{base}/action')}, 'Deny_Both');\n"
+            f"config_set_path({helpers._php_str(f'{base}/row/0/state')}, 'Enabled');\n"
+            f"config_set_path({helpers._php_str(f'{base}/row/0/url')}, {helpers._php_str(matched_url)});\n"
+            f"config_set_path({helpers._php_str(f'{base}/row/0/header')}, 'SFS_7d');\n"
+            "write_config('pfBlockerNG smoke #1702: seed non-first alternate');\n"
+            "echo 'OK';",
+        )
+        assert seed.returncode == 0 and "OK" in seed.stdout, (
+            f"failed to seed SFS alternate row: rc={seed.returncode}, stdout={seed.stdout!r}, stderr={seed.stderr!r}"
+        )
+        assert helpers.config_get(smoke_vm, f"{base}/row/0/url") == matched_url, (
+            "non-first alternate setup did not persist"
+        )
+
+        resp = webui.get(path)
+        result = evaluate_render(path, resp.status_code, resp.text, ("Pre-defined Alias/Group/Feeds",))
+        assert result.ok, f"Feeds render oracle failed: {result.detail}"
+
+        markers = [f'value="alt_{header}"' for header in headers]
+        positions = [resp.text.find(marker) for marker in markers]
+        assert all(position >= 0 for position in positions), (
+            f"configured alternate and later rows did not all render: {dict(zip(headers, positions, strict=True))}"
+        )
+        assert positions == sorted(positions), (
+            f"alternate rows did not preserve source order: {dict(zip(headers, positions, strict=True))}"
+        )
+    finally:
+        _del_rowid(smoke_vm, CFG_IPV4, rowid)
+
+
 def test_dnsbl_cache_flush_option_renders(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """DNSBL page exposes the default-off full-cache trade-off without PHP diagnostics."""
     path = "/pfblockerng/pfblockerng_dnsbl.php"


### PR DESCRIPTION
## Summary

- Normalize alternate-feed buckets before positional rendering.
- Sort sparse buckets by numeric source key so configured alternates retain catalog order even when matches are discovered in reverse config-row order.
- Add hermetic PHPUnit coverage and a Tier-A live pfSense UI render regression.

## Verification

- Initial RED on unchanged production: `Undefined array key 0` plus null-offset diagnostics; targeted PHPUnit failed.
- Review-fix RED at frozen test hash `1750869e96407154e50def6278534a5bc121bf78`: reverse insertion `[2,1]` rendered alternate 2 before alternate 1.
- GREEN at the same hash: targeted PHPUnit 1 test, 5 assertions; related suite 10 tests, 40 assertions.
- Full canonical gates after final rebase: PASS.
- Tier-A live UI: 1 passed, 504 deselected on final head `979fc7badf7f7e1b2a67eb5168f52b73b77af1fa`.

Fixes #1702

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.