### PR TITLE
agent: pass the wait-checks exclusion to jq as data (#1756)

### DIFF
--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -10,8 +10,9 @@
 #                      exact advisory contexts -- CodeRabbit, snyk, code/snyk,
 #                      code/snyk (pfBlockerNG) -- which are advisory and must never gate a
 #                      merge (#1706: an unanchored default silently dropped required checks
-#                      such as `security/snyk-policy-check`). A caller-supplied REGEX is
-#                      passed to jq verbatim and stays unanchored on purpose.
+#                      such as `security/snyk-policy-check`). A caller-supplied REGEX
+#                      stays unanchored on purpose; it reaches jq as DATA, and one
+#                      Oniguruma cannot compile exits 2 rather than polling blind (#1756).
 #   --interval SECONDS poll interval (default 30)
 #   --max-iter N       hard iteration cap (default 80, ~40 min at 30s)
 #
@@ -40,7 +41,7 @@ usage() {
 # Reduce one checks-JSON snapshot to PASS / FAIL / PENDING / EMPTY (prints verdict).
 evaluate_checks() {
 	# $1 = checks JSON array of {name, bucket}
-	rel=$(printf '%s' "$1" | jq -c "[.[] | select((.name|ascii_downcase|test(\"$exclude\"))|not)]")
+	rel=$(printf '%s' "$1" | jq -c --arg ex "$exclude" '[.[] | select((.name|ascii_downcase|test($ex))|not)]')
 	total=$(printf '%s' "$rel" | jq 'length')
 	fail=$(printf '%s' "$rel" | jq '[.[] | select(.bucket=="fail" or .bucket=="cancel")] | length')
 	pend=$(printf '%s' "$rel" | jq '[.[] | select(.bucket=="pending")] | length')
@@ -99,6 +100,15 @@ main() {
 	require_gh
 	require_tool timeout
 	require_tool jq
+
+	# A pattern Oniguruma cannot compile must die here, at the boundary (#1756): the
+	# filter would otherwise yield nothing, the counts would be empty, and the verdict
+	# would silently fall through to PENDING -- polling a real FAIL past to a blind
+	# TIMEOUT. Same exit 2 as any other usage/precondition error.
+	if ! printf '""' | jq -e --arg ex "$exclude" 'test($ex) | true' >/dev/null 2>&1; then
+		echo "usage: --exclude is not a valid regex: $exclude" >&2
+		exit 2
+	fi
 
 	# Wall-clock deadline alongside the cap (CLAUDE.md "No orphaned waits" #1);
 	# PFB_WAIT_DEADLINE (epoch seconds) overrides for tests/ops.
@@ -178,7 +188,7 @@ main() {
 					exit 0
 				fi
 				printf 'pinned=%s\n' "$sha"
-				printf '%s' "$json" | jq -c "[.[] | select((.name|ascii_downcase|test(\"$exclude\"))|not)]"
+				printf '%s' "$json" | jq -c --arg ex "$exclude" '[.[] | select((.name|ascii_downcase|test($ex))|not)]'
 				printf '%s\n' "$v"
 				exit 0
 				;;

--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -84,14 +84,18 @@ checks_to_buckets() {
 main() {
 	# shellcheck source=scripts/agent/agent_env.sh
 	. "$(dirname "$0")/agent_env.sh"
+	# Every value-taking flag checks that its value is actually there before `shift 2`
+	# (same guard work-branch.sh uses): a bare `shift 2` on a one-token tail is fatal
+	# under dash but merely non-zero under a bash-provided /bin/sh, where `$1` never
+	# advances and this loop spins forever -- a hang that never reaches the deadline.
 	while [ $# -gt 0 ]; do
 		case "$1" in
-			--repo) repo=$2; shift 2 ;;
-			--pr) pr=$2; shift 2 ;;
-			--sha) sha=$2; sha_set=1; shift 2 ;;
-			--exclude) exclude=$2; shift 2 ;;
-			--interval) interval=$2; shift 2 ;;
-			--max-iter) max_iter=$2; shift 2 ;;
+			--repo) [ $# -ge 2 ] || usage; repo=$2; shift 2 ;;
+			--pr) [ $# -ge 2 ] || usage; pr=$2; shift 2 ;;
+			--sha) [ $# -ge 2 ] || usage; sha=$2; sha_set=1; shift 2 ;;
+			--exclude) [ $# -ge 2 ] || usage; exclude=$2; shift 2 ;;
+			--interval) [ $# -ge 2 ] || usage; interval=$2; shift 2 ;;
+			--max-iter) [ $# -ge 2 ] || usage; max_iter=$2; shift 2 ;;
 			*) usage ;;
 		esac
 	done

--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -105,10 +105,17 @@ main() {
 	require_tool timeout
 	require_tool jq
 
-	# A pattern Oniguruma cannot compile must die here, at the boundary (#1756): the
-	# filter would otherwise yield nothing, the counts would be empty, and the verdict
-	# would silently fall through to PENDING -- polling a real FAIL past to a blind
-	# TIMEOUT. Same exit 2 as any other usage/precondition error.
+	# Two patterns must die here, at the boundary (#1756), because both end the same way
+	# -- a real FAIL polled past to a blind TIMEOUT -- with exit 2 like any other
+	# usage/precondition error:
+	#   - one Oniguruma cannot compile: the filter yields nothing, the counts come back
+	#     empty, and the verdict falls through to PENDING;
+	#   - the empty one: it compiles and matches EVERY name, so every check is excluded,
+	#     `total` is 0 and the verdict is EMPTY. Match nothing with `^$`, never ''.
+	if [ -z "$exclude" ]; then
+		echo "usage: --exclude must not be empty (it would exclude every check)" >&2
+		exit 2
+	fi
 	if ! printf '""' | jq -e --arg ex "$exclude" 'test($ex) | true' >/dev/null 2>&1; then
 		echo "usage: --exclude is not a valid regex: $exclude" >&2
 		exit 2

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -398,6 +398,18 @@ Describe 'wait-checks.sh tool contracts'
     The stderr should include 'usage:'
   End
 
+  It 'exits 2 with usage when --pr is given no value'
+    When run timeout 10 sh scripts/agent/wait-checks.sh --repo o/r --pr
+    The status should equal 2
+    The stderr should include 'usage:'
+  End
+
+  It 'exits 2 with usage when --interval is given no value'
+    When run timeout 10 sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval
+    The status should equal 2
+    The stderr should include 'usage:'
+  End
+
   It 'exits 4 when timeout is absent'
     printf '#!/bin/sh\nexit 0\n' > "$toolpath/gh"
     chmod +x "$toolpath/gh"
@@ -498,6 +510,19 @@ STUB
     The status should equal 2
     The stderr should include 'not a valid regex'
     The output should not include 'TIMEOUT'
+  End
+
+  # An empty pattern compiles fine and matches EVERY name, so it excluded every check:
+  # `total` fell to 0, the verdict became EMPTY, and the loop -- which only acts on
+  # PASS/FAIL -- drained to TIMEOUT with a hard failure sitting right there. Same silent
+  # class as an uncompilable pattern, so it dies at the same boundary.
+  It 'rejects an empty --exclude instead of excluding every check and draining to TIMEOUT'
+    failing_fixture
+    When run sh "$script" --repo o/r --pr 1 --exclude '' --interval 0 --max-iter 2
+    The status should equal 2
+    The stderr should include 'must not be empty'
+    The output should not include 'TIMEOUT'
+    The output should not include 'PASS'
   End
 
   It 'treats a jq-injecting --exclude value as a pattern, never as program text'

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -370,6 +370,34 @@ Describe 'wait-checks.sh tool contracts'
     The stderr should include 'GH-UNAVAILABLE'
   End
 
+  # A flag whose value is missing used to reach a bare `shift 2`: fatal under dash (with
+  # a raw "can't shift that many" instead of the usage text), but merely non-zero under
+  # a bash-provided /bin/sh, where `$1` stayed put and the parse loop SPUN FOREVER --
+  # a hang that never reaches the deadline logic at all.
+  It 'exits 2 with usage when --exclude is given no value'
+    When run timeout 10 sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --exclude
+    The status should equal 2
+    The stderr should include 'usage:'
+  End
+
+  It 'exits 2 with usage when --sha is given no value'
+    When run timeout 10 sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --sha
+    The status should equal 2
+    The stderr should include 'usage:'
+  End
+
+  It 'exits 2 with usage when --repo is given no value'
+    When run timeout 10 sh scripts/agent/wait-checks.sh --repo
+    The status should equal 2
+    The stderr should include 'usage:'
+  End
+
+  It 'exits 2 with usage when --max-iter is given no value'
+    When run timeout 10 sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --max-iter
+    The status should equal 2
+    The stderr should include 'usage:'
+  End
+
   It 'exits 4 when timeout is absent'
     printf '#!/bin/sh\nexit 0\n' > "$toolpath/gh"
     chmod +x "$toolpath/gh"
@@ -450,6 +478,18 @@ STUB
     The line 2 of output should equal '[{"name":"pytest","bucket":"fail"}]'
     The line 3 of output should equal 'FAIL'
     The output should not include 'TIMEOUT'
+  End
+
+  # The negative case above only proves the pattern does not blow up. Pin the positive
+  # half too: a check whose name really does contain the quote is excluded BY it, so the
+  # pattern is demonstrably being matched rather than merely tolerated.
+  It 'excludes the check a quote-bearing --exclude regex actually matches'
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"},{"name":"sn\"yk-advisory","status":"completed","conclusion":"failure"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh "$script" --repo o/r --pr 1 --exclude 'sn"yk' --interval 0 --max-iter 2
+    The status should equal 0
+    The line 2 of output should equal '[{"name":"pytest","bucket":"pass"}]'
+    The line 3 of output should equal 'PASS'
   End
 
   It 'rejects an --exclude regex ending in a dangling backslash'

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -432,6 +432,52 @@ STUB
     The line 1 of output should equal 'TIMEOUT'
   End
 
+  # #1756: the exclusion pattern is DATA. A pattern jq cannot compile used to make the
+  # whole filter collapse -- empty counts, `[: : integer expected`, verdict PENDING --
+  # so a hard FAIL was polled past and surfaced as a blind TIMEOUT. Reject it at the
+  # boundary (exit 2, usage/precondition) instead.
+  failing_fixture() {
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"failure"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+  }
+
+  # A quote is a literal regex character: `sn"yk` is a perfectly valid pattern and must
+  # be MATCHED, not rejected. It only ever broke because it terminated the jq string.
+  It 'matches an --exclude regex containing a quote as a literal pattern, gating the failing check'
+    failing_fixture
+    When run sh "$script" --repo o/r --pr 1 --exclude 'sn"yk' --interval 0 --max-iter 2
+    The status should equal 0
+    The line 2 of output should equal '[{"name":"pytest","bucket":"fail"}]'
+    The line 3 of output should equal 'FAIL'
+    The output should not include 'TIMEOUT'
+  End
+
+  It 'rejects an --exclude regex ending in a dangling backslash'
+    failing_fixture
+    When run sh "$script" --repo o/r --pr 1 --exclude 'snyk\' --interval 0 --max-iter 2
+    The status should equal 2
+    The stderr should include 'not a valid regex'
+    The output should not include 'TIMEOUT'
+  End
+
+  It 'treats a jq-injecting --exclude value as a pattern, never as program text'
+    failing_fixture
+    When run sh "$script" --repo o/r --pr 1 --exclude 'a") or true or ("' --interval 0 --max-iter 2
+    The status should equal 2
+    The stderr should include 'not a valid regex'
+    The output should not include 'TIMEOUT'
+    The output should not include 'PASS'
+  End
+
+  It 'accepts a valid custom --exclude regex carrying anchors and a character class'
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"},{"name":"code/snyk (BBcan177)","status":"completed","conclusion":"failure"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh "$script" --repo o/r --pr 1 --exclude '^code/snyk( [(][^)]*[)])?$' --interval 0 --max-iter 2
+    The status should equal 0
+    The line 2 of output should equal '[{"name":"pytest","bucket":"pass"}]'
+    The line 3 of output should equal 'PASS'
+  End
+
   It 'honours the wall-clock deadline even when a verdict would be reached'
     export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
     export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'


### PR DESCRIPTION
Stacked on #1755 (base is `issue/1706-wait-checks-exclude-anchoring`); it will be rebased onto `devel` once #1755 merges.

## What

`evaluate_checks()` spliced `$exclude` into the jq **program text**:

```sh
rel=$(printf '%s' "$1" | jq -c "[.[] | select((.name|ascii_downcase|test(\"$exclude\"))|not)]")
```

so the exclusion pattern was program, not data. A pattern jq could not compile — one containing `"`, or ending in `\` — collapsed the whole filter: `rel` came back empty, `total`/`fail`/`pend` were empty strings, the arithmetic tests emitted `[: : integer expected`, and the function fell through to `PENDING`. A check set carrying a hard failure was polled past and surfaced as a blind `TIMEOUT`, hiding exactly the FAIL the wait exists to report. Separately, a value that happened to be valid jq rewrote the filter instead of being matched against the check name.

Both jq call sites now bind the pattern with `--arg`, and a pattern Oniguruma cannot compile is rejected at the boundary with exit **2** (usage/precondition, per `.agents/policy/delegation.md` "Agent-ops scripts") naming the bad value.

`--exclude REGEX` remains the documented, deliberately unanchored escape hatch — semantics for every valid pattern are unchanged.

## Tests

Four new loop-level cases: a quote-bearing pattern is now matched as the literal pattern it is (the failing check gates, verdict `FAIL`); a dangling-backslash pattern and a jq-injecting value each exit 2; and a valid custom pattern carrying anchors and a character class still filters correctly.

Red→green proof: executed RED against the pre-fix script (all three defect cases reported `TIMEOUT` for a check set containing a failure), spec frozen (`sha256 871b2d77…`), re-executed GREEN unchanged under POSIX `dash` — 82 examples, 0 failures. Canonical gates pass.

One expectation was corrected mid-cycle and the cycle re-run from RED: `sn"yk` is a *valid* regex (a quote is a literal character), so the correct post-fix behaviour is that it matches as data and the failing check gates — not that it is rejected. Only a pattern that genuinely cannot compile exits 2.

Fixes #1756


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of check-exclusion patterns containing special characters.
  * Invalid exclusion patterns now fail fast with a clear usage error.
  * Prevented malformed patterns from affecting check results or producing incorrect pass statuses.

* **Tests**
  * Added coverage for quoted, invalid, injection-like, and anchored exclusion patterns.
  * Verified that matching checks are excluded while remaining required checks are evaluated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->