### PR TITLE
scripts: use upstream Token Savior 4.18.1

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,6 +7,6 @@ max_depth = 2
 
 [mcp_servers.token-savior-recall]
 command = "sh"
-args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" d45c8df4f4a3bd385a9b3a474088b22b16f72819454834e9e40c23807dda6532 && exec sh "$root/scripts/mcp-token-savior.sh"''']
+args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" a457ab138826b2e5b6c12de542c088db9b0516c1c34e8cf5d9229a6af54e2da6 && exec sh "$root/scripts/mcp-token-savior.sh"''']
 env = { TOKEN_SAVIOR_CLIENT = "codex" }
 startup_timeout_sec = 120

--- a/docs/misc/codex-migration.md
+++ b/docs/misc/codex-migration.md
@@ -51,7 +51,7 @@ symlink; a provider-specific runtime change stays in that provider's adapter.
 | `PreToolUse` Git policy | `.codex/hooks.json` | Reuses the raw-payload-compatible shared guard for Codex `Bash` hook events; coverage remains subject to the client emitting that event for unified shell execution. |
 | `PreToolUse` retired-token notice | `.codex/hooks.json` | Reuses `check_retired_tokens.py --claude-hook` for the same supported `Bash` event surface. |
 | `SessionStart` branch synchronization | `.codex/hooks.json` | Runs on startup/resume/clear and shares the same branch script. |
-| Token Savior MCP and capture hook | `.codex/config.toml` plus `.codex/hooks.json` | Uses the same pinned `andrebrait/token-savior` launcher and capture wrapper as Claude, with the client label set to `codex`. Current Codex hooks expose `Bash`, `apply_patch`, and MCP tool-name matching, not Claude-style Read/Grep/WebFetch events, so this config requests best-effort capture for `Bash`, Playwright, and `token-savior-recall` MCP output only; it never captures unrelated MCP servers. |
+| Token Savior MCP and capture hook | `.codex/config.toml` plus `.codex/hooks.json` | Uses the same pinned upstream Token Savior launcher and capture wrapper as Claude, with the client label set to `codex`. Current Codex hooks expose `Bash`, `apply_patch`, and MCP tool-name matching, not Claude-style Read/Grep/WebFetch events, so this config requests best-effort capture for `Bash`, Playwright, and `token-savior-recall` MCP output only; it never captures unrelated MCP servers. |
 | Ponytail and Caveman | Real Codex plugins | Installed directly (`codex plugin marketplace add …` / `npx skills add … -a codex`), not vendored into the repo. |
 
 The shared Git hooks recognize both `CLAUDECODE=1` and Codex's
@@ -101,7 +101,7 @@ the worktree coherent (preferably committed) before closing the CLI, then
    until their new definitions are reviewed.
 3. Use `/skills` to verify the `.agents/skills` entries are discovered.
 4. Use `/mcp` to verify `token-savior-recall` is running. Its shared launcher
-   installs the repository-pinned fork into the per-user cache on first start.
+   installs the repository-pinned upstream release into the per-user cache on first start.
 5. Use `/agent` or a delegation request to select project roles.
 6. Run `sh scripts/agent/check-agent-config-parity.sh` for an explicit inventory
    audit; routine commits run it automatically when relevant configuration changes.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,8 +8,8 @@ none of this ships in the release archive (which contains only `src/`).
 | Script | Use |
 | --- | --- |
 | [`agent/check-agent-config-parity.sh`](agent/check-agent-config-parity.sh) | Verify bidirectional Claude/Codex skill and workflow parity, resolvable adapter references, and Codex role models against `.agents/model-tiers.conf`. The pre-commit hook runs it for staged agent-configuration changes; shellspec pins the real inventory for CI. |
-| [`mcp-token-savior.sh`](mcp-token-savior.sh) | Install the pinned `andrebrait/token-savior` fork in a shared per-user venv and launch its MCP server for Claude or Codex. |
-| [`ts-hook.sh`](ts-hook.sh) | Run the pinned fork's shared tool-capture hook for Claude or Codex. |
+| [`mcp-token-savior.sh`](mcp-token-savior.sh) | Install the pinned upstream Token Savior release in a shared per-user venv and launch its MCP server for Claude or Codex. |
+| [`ts-hook.sh`](ts-hook.sh) | Run Token Savior's shared tool-capture hook for Claude or Codex. |
 
 ## Supported-version matrix
 

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -1,13 +1,11 @@
 #!/bin/sh
 # mcp-token-savior.sh — shared Claude/Codex stdio launcher for the token-savior MCP
 # server (wired via .mcp.json and .codex/config.toml).
-# Installs TS_SOURCE into a per-user cached venv, then execs it. The default TS_SOURCE is the
-# andrebrait/token-savior fork's `integration` branch pinned by commit — it carries fixes and
-# language support not yet merged upstream (Mibayy/token-savior PRs #47 #53 #54 #57 #58 #59
-# #60 #62 #64 #66 #68); repoint to PyPI's token-savior-recall[mcp,memory-vector] once those merge. A TS_SOURCE change (e.g. a
-# new pinned commit) is detected via the .pfb-ts-source stamp and triggers a clean venv rebuild;
+# Installs TS_SOURCE into a per-user cached venv, then execs it. The default TS_SOURCE pins
+# upstream token-savior-recall 4.18.1 with the MCP and vector-memory extras. A TS_SOURCE change
+# is detected via the .pfb-ts-source stamp and triggers a clean venv rebuild;
 # a mkdir lock serializes concurrent sessions racing that rebuild (the venv is one shared
-# per-user cache). Requires python3 >= 3.11 and git (pip installs from a git URL).
+# per-user cache). Requires python3 >= 3.11.
 # Env (all optional):
 #   WORKSPACE_ROOTS        comma-separated project roots (default: every usable worktree
 #                          of the current Git repository, otherwise current directory)
@@ -17,7 +15,7 @@
 #                          passes codex explicitly)
 #   TOKEN_SAVIOR_PROFILE   server tool profile (default: optimized)
 #   TS_VENV                venv location (default: ${XDG_CACHE_HOME:-$HOME/.cache}/token-savior/venv)
-#   TS_SOURCE              pip requirement to install (default: the pinned fork commit)
+#   TS_SOURCE              pip requirement to install (default: upstream 4.18.1)
 #   TS_LOCK_WAIT           max seconds to wait on another session's rebuild (default 300)
 #   INCLUDE_PATTERNS       colon-separated index globs; the default below REPLACES the
 #                          server's built-in list, which lacks .php/.inc/.sh — this repo's
@@ -45,7 +43,7 @@ if [ "$venv_bad" = 1 ]; then
 fi
 bin="$venv/bin/token-savior"
 stamp="$venv/.pfb-ts-source"
-TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp,memory-vector] @ git+https://github.com/andrebrait/token-savior@9110e4341951f13fb112fb5b6c54c6e6e5540b30}"
+TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp,memory-vector]==4.18.1}"
 
 # stdout is the MCP stdio channel — install chatter must stay on stderr
 if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -1,8 +1,8 @@
 #shellcheck shell=sh
-# mcp-token-savior.sh — env wiring + fork-pin install policy: the server's
+# mcp-token-savior.sh — env wiring + upstream-version install policy: the server's
 # built-in index globs lack .php/.inc/.sh and its 500 KB size cap skips
 # pfblockerng.inc (~844 KB), so the launcher must export repo-appropriate
-# defaults (caller-set values win); the package installs from the pinned
+# defaults (caller-set values win); the package installs from the exact upstream
 # TS_SOURCE and a TS_SOURCE change must trigger a clean venv rebuild.
 
 Describe 'mcp-token-savior.sh env exports'
@@ -202,7 +202,7 @@ Describe 'Codex repository-script integrity pins'
   End
 End
 
-Describe 'mcp-token-savior.sh fork-pin install policy'
+Describe 'mcp-token-savior.sh upstream install policy'
   SCRIPT="${PFB_ROOT}/scripts/mcp-token-savior.sh"
 
   setup() {
@@ -232,12 +232,12 @@ EOF
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
-  It 'installs the pinned andrebrait/token-savior integration source on first run'
+  It 'installs exact upstream Token Savior 4.18.1 on first run'
     When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv" sh "${SCRIPT}"
     The status should be success
     The output should equal 'INSTALLED'
     The stderr should equal ''
-    The contents of file "${WORK}/venv/pip-args.log" should include 'git+https://github.com/andrebrait/token-savior@'
+    The contents of file "${WORK}/venv/pip-args.log" should equal 'token-savior-recall[mcp,memory-vector]==4.18.1'
   End
 
   It 'rebuilds the venv when the recorded TS_SOURCE stamp no longer matches'


### PR DESCRIPTION
## Summary

- replace the pinned `andrebrait/token-savior` commit with exact upstream PyPI release `token-savior-recall[mcp,memory-vector]==4.18.1`
- retain the `TS_SOURCE` override and stamp-triggered clean venv rebuild
- refresh the Codex launcher integrity hash and remove stale fork wording

## Why

Upstream 4.18.1 now contains the fixes previously carried by the fork. Pinning the released package removes the fork dependency while preserving reproducible installs.

## Verification

- PyPI metadata: 4.18.1 exists, is not yanked, requires Python 3.11+, and provides `mcp` plus `memory-vector`
- isolated install: package reports `4.18.1`; `bin/token-savior` exists and is executable
- RED: `shellspec tests/shell/mcp_token_savior_spec.sh` — 26 examples, 1 expected fork-pin mismatch; frozen test hash `9096340667acc1a55155eb2d5882d795f024d060`
- GREEN: `shellspec --shell "$(command -v dash || command -v sh)" tests/shell/mcp_token_savior_spec.sh` — 26 examples, 0 failures; same frozen hash
- `scripts/agent/run-gates.sh --diff origin/devel` — `GATES: PASS`

Fixes #1758

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
