### PR TITLE
pfblockerng: sanitize the Edit Hooks save through the shared text-area helper (#1734)

### DIFF
--- a/.agents/policy/coding.md
+++ b/.agents/policy/coding.md
@@ -101,7 +101,10 @@ never an ad-hoc `trim`/`str_replace` chain and never re-sanitized downstream:
   are accepted by design (admins block typosquats in their own lists).
 
 A new field MUST route through these helpers; a persist path that deliberately stays
-narrower documents why (exemplar fork: the hook-script editor, issue #1728). Contracts
+narrower documents why. The one fork raised so far — the GUI hook-script editor, whose
+saved content is executable script source rather than list data (issue #1728) — was
+resolved *against* a carve-out: it joins the standard (issue #1734), so a literal control
+byte in a hook script must be written as an escape (`\033`). Contracts
 pinned by `PfbSanitizeTextTest`, `TextAreaDecodeTest`, `PfbFilterContractTest`, and
 `tests/smoke/ui/test_sanitize_persist.py`.
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -4891,28 +4891,6 @@ function pfb_hook_editor_lang_for(string $script, string $fallback): string {
 	return ($fallback === 'py') ? 'py' : 'sh';
 }
 
-/*
- * Normalizes a hook-script SAVE's content to bare LF line endings: the HTML5 forms
- * spec requires a browser to normalize a <textarea>'s value to CRLF before including
- * it in a form submission,
- * regardless of what line ending the on-disk file or the user's editor originally
- * used -- so writing $_POST['pfb_eh_content'] straight to disk turns EVERY GUI save
- * into a CRLF file, including a no-edit load->save of the freshly created (LF)
- * template. A kernel shebang line names a single interpreter path token: a saved
- * "#!/bin/sh\r\n" execs the literal, nonexistent path "/bin/sh\r" (ENOENT) -- the
- * hook then silently stops firing on every subsequent update pass, with nothing on
- * this page or in pfb_run_hooks() surfacing the cause.
- *
- * Collapses "\r\n" first, then any remaining lone "\r" -- same idiom as
- * pfblockerng_general.php's and pfblockerng.inc's own textarea-POST normalization
- * (both str_replace("\r\n", "\n", ...) only); this one additionally folds a lone
- * "\r" (old-Mac line endings a hand-crafted or non-browser POST could still carry).
- * A bare LF, or empty content, passes through unchanged.
- */
-function pfb_hook_editor_normalize_content(string $content): string {
-	return str_replace(array("\r\n", "\r"), "\n", $content);
-}
-
 // logger() and localize_text() are pfSense-core helpers (src/etc/inc/util.inc)
 // on pfSense Plus / master, but absent from released pfSense CE <= 2.8.1. Define
 // fallbacks ONLY when core does not provide them, so this package runs on both:

--- a/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php
@@ -156,10 +156,12 @@ if ($_POST) {
 		// or a crafted POST can never write outside a file the picker already offers.
 		$post_when    = (string) ($_POST['pfb_eh_cur_when'] ?? '');
 		$post_script  = (string) ($_POST['pfb_eh_cur_script'] ?? '');
-		// Normalize BEFORE anything else
-		// touches the content -- see pfb_hook_editor_normalize_content()'s own doc
-		// comment for why an un-normalized save breaks every saved hook's shebang.
-		$post_content = pfb_hook_editor_normalize_content((string) ($_POST['pfb_eh_content'] ?? ''));
+		// issue #1734: shared persist-boundary sanitizer (#1723), run at INGESTION.
+		// Its leading CRLF/CR -> LF fold is load-bearing: HTML5 makes the browser submit
+		// a <textarea> as CRLF, and a saved "#!/bin/sh\r" shebang execs the nonexistent
+		// path "/bin/sh\r" (ENOENT) -- the hook then silently never fires again. A
+		// literal control byte must be written as an escape (\033); issue #1728.
+		$post_content = pfb_sanitize_text_area((string) ($_POST['pfb_eh_content'] ?? ''));
 
 		if (!pfb_hook_script_valid($post_script, $post_when)) {
 			$input_errors[] = gettext('Select a valid, existing hook script for this Pre/Post before saving ' .
@@ -404,9 +406,9 @@ $form->addGlobal(new Form_Input('pfb_eh_cur_script', 'pfb_eh_cur_script', 'hidde
 $pfb_eh_textarea = new Form_Textarea(
 	'pfb_eh_content',
 	NULL,
-	// Displayed/re-loaded verbatim here -- the only transformation the save handler
-	// ever applies is line-ending normalization to LF (pfb_hook_editor_normalize_content()),
-	// which happens later, on $_POST, not to this
+	// Displayed/re-loaded verbatim here -- the save handler's sanitization
+	// (pfb_sanitize_text_area(): line endings to LF, control characters other than tab
+	// stripped, each line right-stripped) happens later, on $_POST, not to this
 	// loaded value. Passed RAW: Form_Textarea::_getInput() already HTML-escapes the
 	// value exactly once at render (verified against pfSense master and
 	// RELENG_2_7_2), so escaping it again here would double-escape it: the browser
@@ -422,8 +424,9 @@ $pfb_eh_textarea->removeClass('form-control')
 	->setAttribute('wrap', 'off')
 	->setAttribute('spellcheck', 'false')
 	->setAttribute('style', 'background:#fafafa; width: 100%; font-family: monospace;')
-	->setHelp(gettext('Saved as typed, except line endings are normalized to LF -- nothing else about the ' .
-		'content is transformed.'));
+	->setHelp(gettext('Saved as typed, except line endings are normalized to LF, trailing whitespace is ' .
+		'stripped from each line, and control characters other than tab are removed -- write a literal ' .
+		'control byte as an escape (e.g. \\033) instead.'));
 $section->addInput($pfb_eh_textarea);
 
 // Named pfb_eh_save directly -- same native-submit reasoning as the Create button

--- a/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php
@@ -201,8 +201,9 @@ if ($_POST) {
 			}
 		}
 
-		// Preserve exactly what the user was editing so a validation/write error
-		// doesn't lose their in-progress content.
+		// Re-render the sanitized content so a validation/write error doesn't lose the
+		// user's in-progress work -- it is what a retry would persist, so echoing the
+		// raw typed bytes back would misreport what Save is about to write.
 		$pfb_eh_sel_when   = $post_when;
 		$pfb_eh_sel_script = $post_script;
 		$pfb_eh_content    = $post_content;

--- a/tests/php/EditHooksPageWiringTest.php
+++ b/tests/php/EditHooksPageWiringTest.php
@@ -460,7 +460,8 @@ final class EditHooksPageWiringTest extends TestCase
 
 	// ------------------------------------------------------------------
 	// The save flow
-	// must normalize $_POST content to LF before it is ever written, and
+	// must sanitize $_POST content through the shared persist-boundary helper
+	// before it is ever written, and
 	// stage the write to a temp file in the same directory and rename() it into
 	// place atomically -- never truncate+write the live target in place, since
 	// pfb_run_hooks() may exec it as root concurrently with a save. The GET
@@ -478,7 +479,15 @@ final class EditHooksPageWiringTest extends TestCase
 		return substr($src, $blockStart, $blockEnd - $blockStart);
 	}
 
-	public function testSavePathNormalizesContentBeforeWrite(): void
+	/**
+	 * issue #1734: the save path joins the #1723 persist-boundary standard -- the shared
+	 * pfb_sanitize_text_area() replaces the hand-rolled pfb_hook_editor_normalize_content().
+	 * The shared helper still performs the identical CRLF/CR -> LF collapse first, so the
+	 * shebang-corruption regression the old helper existed for stays fixed, and it
+	 * additionally scrubs legacy encodings, control characters, the BOM, and per-line
+	 * trailing whitespace before the content ever reaches disk.
+	 */
+	public function testSavePathSanitizesContentBeforeWrite(): void
 	{
 		$block = $this->extractSaveFlowBlock($this->readSource(self::PAGE_PATH));
 
@@ -486,22 +495,38 @@ final class EditHooksPageWiringTest extends TestCase
 		// bare function-name token -- the save block's own comment names the helper, so
 		// a substring assertion passes even with the call stripped (coverage theater;
 		// the mutant survived 19/19). A comment can never satisfy this assignment regex.
-		$callShape = '/\\$post_content\\s*=\\s*pfb_hook_editor_normalize_content\\(/';
+		$callShape = '/\\$post_content\\s*=\\s*pfb_sanitize_text_area\\(/';
 		$this->assertSame(
 			1,
 			preg_match($callShape, $block, $m, PREG_OFFSET_CAPTURE),
-			'the save flow must ASSIGN $post_content through pfb_hook_editor_normalize_content() -- writing the ' .
+			'the save flow must ASSIGN $post_content through the shared pfb_sanitize_text_area() -- writing the ' .
 				"raw \$_POST value persists the browser's CRLF textarea normalization straight into the hook " .
-				"script file, breaking its shebang exec (e.g. \"#!/bin/sh\\r\" -> ENOENT)"
+				"script file, breaking its shebang exec (e.g. \"#!/bin/sh\\r\" -> ENOENT), and leaves control " .
+				'characters and trailing per-line whitespace in the saved script'
 		);
 
-		$normalizePos = $m[0][1];
+		$sanitizePos = $m[0][1];
 		$writePos = strpos($block, 'file_put_contents(');
 		$this->assertNotFalse($writePos, 'test oracle: no file_put_contents( call found in the save-flow block');
 		$this->assertLessThan(
 			$writePos,
-			$normalizePos,
-			'content must be normalized BEFORE it is written to the temp file, not after'
+			$sanitizePos,
+			'content must be sanitized BEFORE it is written to the temp file, not after'
+		);
+	}
+
+	/**
+	 * issue #1734: the hand-rolled helper is removed, not merely bypassed -- a surviving
+	 * call would mean the content is sanitized twice, or (worse) that a later edit
+	 * silently reverted the save path to the narrower normalization.
+	 */
+	public function testSavePathNoLongerUsesTheHandRolledNormalizer(): void
+	{
+		$this->assertStringNotContainsString(
+			'pfb_hook_editor_normalize_content',
+			$this->readSource(self::PAGE_PATH),
+			'pfb_hook_editor_normalize_content() was retired by #1734 -- the page must not reference it at all, ' .
+				'in code or in a comment that would outlive it'
 		);
 	}
 

--- a/tests/php/HookEditorHelpersTest.php
+++ b/tests/php/HookEditorHelpersTest.php
@@ -18,7 +18,6 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_hook_editor_path')]
 #[CoversFunction('pfb_hook_editor_template')]
 #[CoversFunction('pfb_hook_editor_lang_for')]
-#[CoversFunction('pfb_hook_editor_normalize_content')]
 final class HookEditorHelpersTest extends TestCase
 {
 	private string $dir = '';
@@ -315,39 +314,5 @@ final class HookEditorHelpersTest extends TestCase
 		// gates $script to the real allow-list before this is ever called) falls back
 		// rather than propagating an unrecognised mode string to the JS side.
 		$this->assertSame('py', pfb_hook_editor_lang_for('hook_pre_myhook.txt', 'py'));
-	}
-
-	// ------------------------------------------------------------------
-	// pfb_hook_editor_normalize_content() -- browser <textarea> form submission
-	// normalizes line endings to CRLF before POSTing, regardless of what the on-disk
-	// file or the user's editor used -- so the save handler must fold CRLF (and a lone CR) back to bare LF
-	// before persisting, or every GUI save turns the hook script's shebang line into
-	// "#!/bin/sh\r", which the kernel execs as a literal (nonexistent) "/bin/sh\r"
-	// interpreter path (ENOENT) -- the hook then silently never fires again.
-	// ------------------------------------------------------------------
-
-	public function testNormalizeContentConvertsCrlfToLf(): void
-	{
-		$this->assertSame("#!/bin/sh\necho hi\n", pfb_hook_editor_normalize_content("#!/bin/sh\r\necho hi\r\n"));
-	}
-
-	public function testNormalizeContentConvertsLoneCarriageReturnToLf(): void
-	{
-		$this->assertSame("a\nb\nc", pfb_hook_editor_normalize_content("a\rb\rc"));
-	}
-
-	public function testNormalizeContentPassesBareLfThrough(): void
-	{
-		$this->assertSame("a\nb\nc\n", pfb_hook_editor_normalize_content("a\nb\nc\n"));
-	}
-
-	public function testNormalizeContentHandlesMixedLineEndings(): void
-	{
-		$this->assertSame("a\nb\nc\nd\n", pfb_hook_editor_normalize_content("a\r\nb\nc\rd\r\n"));
-	}
-
-	public function testNormalizeContentHandlesEmptyString(): void
-	{
-		$this->assertSame('', pfb_hook_editor_normalize_content(''));
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -3564,19 +3564,6 @@
             }
         ]
     },
-    "pfb_hook_editor_normalize_content": {
-        "returnsRef": false,
-        "returnType": "string",
-        "params": [
-            {
-                "name": "content",
-                "byRef": false,
-                "variadic": false,
-                "type": "string",
-                "default": null
-            }
-        ]
-    },
     "pfb_hook_editor_path": {
         "returnsRef": false,
         "returnType": "?string",

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -422,6 +422,42 @@ def test_pfblockerng_new_tab_link_renders_with_noopener_rel(path: str, url: str,
     )
 
 
+# issue #1734: the hook editor's help text is the admin's only signal that the save
+# rewrites their script, so it must name every transformation the shared sanitizer
+# applies -- not just the line-ending fold it described while the save still used the
+# narrower pfb_hook_editor_normalize_content(). A help text that outlives the behaviour
+# it describes is how an admin ends up debugging a silently rewritten hook. Substrings
+# verified against the real setHelp() copy in pfblockerng_edit_hooks.php.
+_EDIT_HOOKS_PAGE = "/pfblockerng/pfblockerng_edit_hooks.php"
+_EDIT_HOOKS_SAVE_PROMISE = (
+    "line endings are normalized to LF",
+    "trailing whitespace is stripped from each line",
+    "control characters other than tab are removed",
+)
+
+
+def test_edit_hooks_help_text_names_every_save_transformation(webui: WebUI) -> None:
+    """The hook editor's help text names all three transformations the save applies.
+
+    Tier-A render-layer proof, hermetic (the page renders from local state alone).
+    Asserts the editor textarea itself rendered (non-vacuity: a page that failed to
+    emit the field would otherwise make the substring checks pass trivially on some
+    unrelated body), then EACH clause of the promise separately, so dropping any one
+    of them fails here rather than degrading silently to a partial description.
+    """
+    resp = webui.get(_EDIT_HOOKS_PAGE)
+    assert resp.status_code == 200, f"GET {_EDIT_HOOKS_PAGE} -> HTTP {resp.status_code} (expected 200)"
+    body = resp.text
+    assert 'id="pfb_hook_editor_content"' in body, (
+        f"the hook-editor textarea did not render on {_EDIT_HOOKS_PAGE} -- its help text cannot be pinned"
+    )
+    for clause in _EDIT_HOOKS_SAVE_PROMISE:
+        assert clause in body, (
+            f"the hook-editor help text does not state {clause!r} -- the save applies it "
+            "(pfb_sanitize_text_area), so an admin reading this page would not know their script is rewritten"
+        )
+
+
 # ADR-11: the IP page's pfb_agg_types multi-select must render with ALL FOUR
 # option branches (Deny/Permit/Match/Native) AND its no-rule help caveat. Asserting
 # every option proves each branch of the select is emitted (not just the label), and the

--- a/tests/smoke/ui/test_sanitize_persist.py
+++ b/tests/smoke/ui/test_sanitize_persist.py
@@ -2,8 +2,10 @@
 
 Marker ``ui_e2e`` -- see :mod:`tests.smoke.ui.test_functional` for the tier's
 general shape. Every test here drives a real CSRF POST (``requests``, never a
-browser) and asserts the box's EFFECTIVE ``config.xml`` state (via
-:func:`tests.smoke.helpers.config_get`), never the HTTP response body --
+browser) and asserts the box's EFFECTIVE persisted state -- ``config.xml`` (via
+:func:`tests.smoke.helpers.config_get`) for the config-backed fields, or the
+on-disk artifact for the hook editor, whose script content never enters
+``config.xml`` by design -- never the HTTP response body --
 ``requests``' ``session.post(data=...)`` sends the Python string's bytes
 UNCHANGED (no browser-side CRLF canonicalization of textarea content), so a
 raw payload mixing LF/CR-only/control chars reaches the server byte-for-byte.

--- a/tests/smoke/ui/test_sanitize_persist.py
+++ b/tests/smoke/ui/test_sanitize_persist.py
@@ -39,6 +39,7 @@ pytestmark = pytest.mark.ui_e2e
 DNSBL_PAGE = "/pfblockerng/pfblockerng_dnsbl.php"
 IP_PAGE = "/pfblockerng/pfblockerng_ip.php"
 GENERAL_PAGE = "/pfblockerng/pfblockerng_general.php"
+EDIT_HOOKS_PAGE = "/pfblockerng/pfblockerng_edit_hooks.php"
 PFB_INC_PATH = "/usr/local/pkg/pfblockerng/pfblockerng.inc"
 
 # Generous POST timeouts: DNSBL/IP saves only write_config() (fast); General's
@@ -79,6 +80,18 @@ def _dnsbl_folder(vm: helpers.SmokeVM) -> str:
 def _flag_exists(vm: helpers.SmokeVM, path: str) -> bool:
     pre = f"$e = file_exists({helpers._php_str(path)}) ? 'YES' : 'NO';"
     return helpers._php_read_scalar(vm, pre, "$e", timeout=120.0) == "YES"
+
+
+def _hook_script_bytes(vm: helpers.SmokeVM, path: str) -> str:
+    """Return an on-box hook script's EXACT content, control characters intact.
+
+    Read base64-encoded over the pfSsh.php channel rather than ``cat``: the
+    payload under test deliberately carries a vertical tab and CR bytes, and a
+    plain SSH text read would let the transport (or a shell) rewrite exactly
+    the bytes the assertion is about.
+    """
+    pre = f"$e = base64_encode((string) @file_get_contents({helpers._php_str(path)}));"
+    return base64.b64decode(helpers._php_read_scalar(vm, pre, "$e", timeout=120.0)).decode("utf-8")
 
 
 def test_dnsbl_textarea_save_normalizes_line_endings_and_controls(
@@ -522,3 +535,65 @@ def test_dnsbl_suppression_rejects_double_dot_row(
         f"the multi-dot row was saved -- suppression changed from {_decoded(before)!r} "
         f"to {_decoded(after)!r}; the validator must refuse it"
     )
+
+
+def test_edit_hooks_save_sanitizes_the_written_script(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """The Edit Hooks save writes the shared-sanitizer form of the typed script (issue #1734).
+
+    Scenario: the gated hook-script editor is the one persist boundary that was
+    deliberately left narrower than the #1723 standard -- it only collapsed line
+    endings. The #1728 owner decision routes it through the shared
+    ``pfb_sanitize_text_area()`` instead, so a saved script picks up the same
+    control-character strip and per-line right-strip every other multi-line field
+    already gets.
+
+    Given an existing, picker-vetted hook script on the box,
+    When the editor saves a body that mixes CRLF, a bare CR row separator,
+    trailing space+tab, an embedded vertical tab, and a blank line,
+    Then the file on disk holds bare-LF rows with the trailing whitespace and
+    the vertical tab gone, and the blank line still there.
+
+    The line-ending half is asserted alongside the new behaviour on purpose: it
+    is the regression the retired ``pfb_hook_editor_normalize_content()`` existed
+    to prevent (a saved ``"#!/bin/sh\\r"`` shebang execs a nonexistent
+    ``/bin/sh\\r`` and the hook silently stops firing), and the replacement must
+    keep it fixed.
+
+    RED (before the change): the narrower helper only folds CR/CRLF to LF, so the
+    trailing ``"   \\t"`` and the ``\\x0b`` persist into the executable script.
+    GREEN (after): ``pfb_sanitize_text_area()`` folds the line endings first, then
+    strips the control character and right-strips each line, preserving the blank
+    line so script formatting survives.
+    """
+    vm = smoke_vm
+    script = f"hook_pre_smoke{uuid.uuid4().hex[:12]}.sh"
+    path = f"{helpers.HOOK_SCRIPT_DIR}/{script}"
+    seed = "#!/bin/sh\necho seed\n"
+    raw = "#!/bin/sh\r\necho 'edited'   \t\rprintf '\x0bvt'\n\nexit 0\n"
+    expected = "#!/bin/sh\necho 'edited'\nprintf 'vt'\n\nexit 0\n"
+
+    helpers.install_hook_script(vm, script, seed)
+    try:
+        before = _hook_script_bytes(vm, path)
+        assert before == seed, f"seed script not installed verbatim, got {before!r}"
+
+        resp = webui.post(
+            EDIT_HOOKS_PAGE,
+            {
+                "pfb_eh_cur_when": "pre",
+                "pfb_eh_cur_script": script,
+                "pfb_eh_content": raw,
+            },
+            submit=("pfb_eh_save", "Save"),
+            timeout=SETTINGS_SAVE_TIMEOUT,
+        )
+        assert not looks_like_login_page(resp.text), "Edit Hooks POST returned the login form (session lost)"
+
+        after = _hook_script_bytes(vm, path)
+        assert after != before, "the hook script did not change -- the save did not take (POST must CAUSE the change)"
+        assert after == expected, f"hook script not sanitized on save: expected {expected!r}, got {after!r}"
+    finally:
+        vm.ssh("/bin/rm", "-f", path, timeout=60.0)


### PR DESCRIPTION
Fixes #1734

Routes the gated Edit Hooks save path through the shared persist-boundary sanitizer, per the owner decision on #1728.

## What changed

`pfblockerng_edit_hooks.php`'s save handler ingested `$_POST['pfb_eh_content']` through a hand-rolled `pfb_hook_editor_normalize_content()` — a bare `str_replace(array("\r\n", "\r"), "\n", ...)`. It now ingests through `pfb_sanitize_text_area()` (`pfblockerng.inc`), the same helper every other multi-line field uses since #1723.

The shared helper performs the identical CRLF/CR → LF collapse *first*, so the regression the old helper existed to prevent stays fixed: HTML5 makes a browser submit a `<textarea>` as CRLF, and a saved `"#!/bin/sh\r"` shebang execs the nonexistent path `/bin/sh\r` (ENOENT), after which the hook silently never fires again. On top of that it converts legacy encodings to UTF-8, strips control characters other than `\n`/`\t` plus the BOM and the C1 range, and right-strips each line Unicode-aware while preserving blank lines, so script indentation and formatting survive.

Both supported hook languages use `#`-headed comments and tolerate those rules identically — the runner is fixed at Shell + Python (#1669 Part B) — so the shared helper needs no script-specific variant.

`pfb_hook_editor_normalize_content()` had no other caller and is removed, together with its unit tests and its `function_inventory.json` entry (regenerated). A tree-wide grep for the symbol returns only the deliberate references in the new tests.

### Accepted trade-off

A literal control byte embedded in script source — a raw ESC inside a `printf` string, say — is stripped on save; scripts must use the escape form (`\033`, `\e`, `\x1b`). This was the open concern on #1728 and it is resolved in favour of the shared standard. The editor's help text now states every transformation the save applies, instead of claiming line endings are the only one.

`.agents/policy/coding.md` carried the hook editor as the standing "deliberately narrower persist path" exemplar; that note is updated to record the fork as resolved.

## Tests

Test-first red→green, both halves executed, the three test files frozen byte-identical between the runs (`git hash-object` matches the red commit's blobs exactly: `91f28bcc`, `9f3a7699`, `5b549938`).

**PHPUnit** — `EditHooksPageWiringTest` (structural: the page cannot render off-appliance):

- `testSavePathSanitizesContentBeforeWrite` pins the call-shape assignment through `pfb_sanitize_text_area()` and its position before `file_put_contents(`.
- `testSavePathNoLongerUsesTheHandRolledNormalizer` asserts the retired symbol is gone from the page entirely, in code and in comments.

RED at `66e34ee4`: 2 failures, `"the save flow must ASSIGN $post_content through the shared pfb_sanitize_text_area()"`. GREEN after the production commit with zero test edits; full suite 4217/0.

**Tier-B live pin** — `tests/smoke/ui/test_sanitize_persist.py::test_edit_hooks_save_sanitizes_the_written_script` drives the real CSRF Edit Hooks save POST against an installed, picker-vetted hook script and asserts the bytes that reach disk, read back base64-encoded so the transport cannot rewrite the control characters under test. The payload mixes CRLF, a bare-CR row separator, trailing space+tab, an embedded vertical tab, and a blank line.

**Tier-A** — `test_render_smoke.py::test_edit_hooks_help_text_names_every_save_transformation` asserts the editor textarea rendered (non-vacuity) and then each clause of the help text separately, so dropping any one fails rather than degrading to a partial description. Deliberately a focused test rather than another entry in the page's `PAGE_TABLE` marker tuple: that oracle requires only *one* marker to be present, so an added marker there can never fail.

Both smoke tests executed on a leased `PFB_BOXES` box, marker `"ui_e2e or ui_render"`, filter `edit_hooks`:

- RED (`tmp/1734-red`): `2 failed, 1 passed`. The save test got `"#!/bin/sh\necho 'edited'   \t\nprintf '\x0bvt'\n\nexit 0\n"` — the CR fold already worked, the trailing whitespace and the vertical tab survived into the executable script. The help-text test failed on the `trailing whitespace is stripped from each line` clause.
- GREEN (`tmp/1734-green`): `3 passed, 507 deselected in 54.05s`.

`scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (13/13).
