### PR TITLE
tests: pin DNSBL probe/resolver parity; make the tick suites hermetic

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2041,10 +2041,10 @@ import re
 import sys
 
 shapes = (
-    re.compile(r"\([^()]*[+*][^()]*\)\s*[+*{]"),
-    re.compile(r"\([^()]*\|[^()]*\)\s*[+*{]"),
-    re.compile(r"\([^()]*[+*][^()]*\)\([^()]*\)\s*[+*]"),
-    re.compile(r"(?:\)|\]|\w)\{\d+(?:,\d*)?\}\{\d+(?:,\d*)?\}"),
+    re.compile(r"\([^()]*[+*][^()]*\)\s*[+*{]"),  # _REGEX_NESTED_QUANTIFIER mirror (pfb_unbound.py)
+    re.compile(r"\([^()]*\|[^()]*\)\s*[+*{]"),  # _REGEX_ALTERNATION_OVERLAP mirror (pfb_unbound.py)
+    re.compile(r"\([^()]*[+*][^()]*\)\([^()]*\)\s*[+*]"),  # _REGEX_ADJACENT_GROUP_QUANTIFIER mirror (pfb_unbound.py)
+    re.compile(r"(?:\)|\]|\w)\{\d+(?:,\d*)?\}\{\d+(?:,\d*)?\}"),  # _REGEX_STACKED_BOUNDED_REPEAT mirror (pfb_unbound.py)
 )
 
 failed = False
@@ -2069,8 +2069,8 @@ for line_number, line in enumerate(sys.stdin, start=1):
         report(line_number, pattern, "catastrophic-backtracking shape")
         failed = True
         continue
-    budget = len(re.findall(r"(?<!\\)[+*]", pattern)) + len(re.findall(r"(?<!\\)\|", pattern))
-    if budget > 12:
+    budget = len(re.findall(r"(?<!\\)[+*]", pattern)) + len(re.findall(r"(?<!\\)\|", pattern))  # _REGEX_UNBOUNDED_QUANTIFIER + _REGEX_ALTERNATION mirror (pfb_unbound.py)
+    if budget > 12:  # _REGEX_BUDGET_MAX mirror (pfb_unbound.py)
         report(line_number, pattern, "too many quantifiers/alternations")
         failed = True
         continue

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -32,6 +32,16 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 	private string $logPath;
 	private string $rulesPath;
 
+	/**
+	 * issue #1666: setUp() below overrides $pfb['dbdir']/['logdir']/['log']/
+	 * ['errlog'] to point inside $this->tmp, and tearDown() deletes $this->tmp --
+	 * without a restore, every LATER test class inherits $pfb['log'] etc. pointing
+	 * at an already-deleted directory (mirrors the DnsblVipInterfaceValidationTest
+	 * save/restore idiom used elsewhere in this suite).
+	 */
+	private array $savedPfb = [];
+	private array $hadPfb   = [];
+
 	public static function setUpBeforeClass(): void
 	{
 		$src = file_get_contents(
@@ -99,6 +109,14 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 		putenv("PFB_TEST_RULES={$this->rulesPath}");
 		$this->shim = $this->writeShim();
 
+		// issue #1666: save the four $pfb path keys this test overrides below,
+		// before overriding them, so tearDown() can restore them once $this->tmp
+		// (which they all point inside) is deleted.
+		foreach (['dbdir', 'logdir', 'log', 'errlog'] as $k) {
+			$this->hadPfb[$k]   = array_key_exists($k, $GLOBALS['pfb'] ?? []);
+			$this->savedPfb[$k] = $GLOBALS['pfb'][$k] ?? NULL;
+		}
+
 		$pfb['pfctl']     = $this->shim;
 		$pfb['aliasdir']  = "{$this->tmp}/alias";
 		$pfb['dbdir']     = "{$this->tmp}/db";
@@ -128,6 +146,19 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 		putenv('PFB_TEST_SHOW_ENTRY');
 		rmdir_recursive($this->tmp);
 		unset($GLOBALS['pfb_test_write_config_calls'], $GLOBALS['config']);
+
+		// issue #1666: restore the four $pfb path keys -- otherwise every later
+		// test class inherits $pfb['log'] etc. pointing at the tree just deleted
+		// above.
+		foreach ($this->savedPfb as $k => $value) {
+			if ($this->hadPfb[$k]) {
+				$GLOBALS['pfb'][$k] = $value;
+			} else {
+				unset($GLOBALS['pfb'][$k]);
+			}
+		}
+		$this->savedPfb = [];
+		$this->hadPfb   = [];
 	}
 
 	/** Same shim shape as AlertsLivePunchApplyTest::writeShim(). */

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -33,14 +33,19 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 	private string $rulesPath;
 
 	/**
-	 * issue #1666: setUp() below overrides $pfb['dbdir']/['logdir']/['log']/
-	 * ['errlog'] to point inside $this->tmp, and tearDown() deletes $this->tmp --
-	 * without a restore, every LATER test class inherits $pfb['log'] etc. pointing
-	 * at an already-deleted directory (mirrors the DnsblVipInterfaceValidationTest
-	 * save/restore idiom used elsewhere in this suite).
+	 * issue #1666: setUp() below overrides every $pfb['pfctl']/['aliasdir']/
+	 * ['dbdir']/['permitdir']/['ip_unlock']/['supptxt']/['supptxt_v6']/
+	 * ['ipconfig']/['logdir']/['log']/['errlog'] key (11 total) to point inside
+	 * $this->tmp, and tearDown() deletes $this->tmp -- without a restore, every
+	 * LATER test class inherits those keys pointing at an already-deleted
+	 * directory (mirrors the DnsblVipInterfaceValidationTest save/restore idiom
+	 * used elsewhere in this suite). $GLOBALS['config'] is likewise replaced and
+	 * must be restored (mirrors CollectLocalIpAliasTest's hadConfig/savedConfig).
 	 */
 	private array $savedPfb = [];
 	private array $hadPfb   = [];
+	private bool $hadConfig   = false;
+	private mixed $savedConfig = null;
 
 	public static function setUpBeforeClass(): void
 	{
@@ -109,13 +114,16 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 		putenv("PFB_TEST_RULES={$this->rulesPath}");
 		$this->shim = $this->writeShim();
 
-		// issue #1666: save the four $pfb path keys this test overrides below,
-		// before overriding them, so tearDown() can restore them once $this->tmp
-		// (which they all point inside) is deleted.
-		foreach (['dbdir', 'logdir', 'log', 'errlog'] as $k) {
+		// issue #1666: save every $pfb key this test overrides below, before
+		// overriding them, so tearDown() can restore them once $this->tmp (which
+		// most of them point inside) is deleted.
+		foreach (['pfctl', 'aliasdir', 'dbdir', 'permitdir', 'ip_unlock', 'supptxt',
+			  'supptxt_v6', 'ipconfig', 'logdir', 'log', 'errlog'] as $k) {
 			$this->hadPfb[$k]   = array_key_exists($k, $GLOBALS['pfb'] ?? []);
 			$this->savedPfb[$k] = $GLOBALS['pfb'][$k] ?? NULL;
 		}
+		$this->hadConfig   = array_key_exists('config', $GLOBALS);
+		$this->savedConfig = $GLOBALS['config'] ?? NULL;
 
 		$pfb['pfctl']     = $this->shim;
 		$pfb['aliasdir']  = "{$this->tmp}/alias";
@@ -145,11 +153,11 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 		putenv('PFB_TEST_RULES');
 		putenv('PFB_TEST_SHOW_ENTRY');
 		rmdir_recursive($this->tmp);
-		unset($GLOBALS['pfb_test_write_config_calls'], $GLOBALS['config']);
+		unset($GLOBALS['pfb_test_write_config_calls']);
 
-		// issue #1666: restore the four $pfb path keys -- otherwise every later
-		// test class inherits $pfb['log'] etc. pointing at the tree just deleted
-		// above.
+		// issue #1666: restore every $pfb key overridden in setUp() -- otherwise
+		// every later test class inherits $pfb['log'] etc. pointing at the tree
+		// just deleted above.
 		foreach ($this->savedPfb as $k => $value) {
 			if ($this->hadPfb[$k]) {
 				$GLOBALS['pfb'][$k] = $value;
@@ -159,6 +167,13 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 		}
 		$this->savedPfb = [];
 		$this->hadPfb   = [];
+
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->savedConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+		$this->savedConfig = null;
 	}
 
 	/** Same shim shape as AlertsLivePunchApplyTest::writeShim(). */

--- a/tests/php/TickApplyReconciliationTest.php
+++ b/tests/php/TickApplyReconciliationTest.php
@@ -539,11 +539,38 @@ final class TickApplyReconciliationTest extends TestCase
 	 * setUp() ledger seeding makes this FAIL -- the absent 'dcc' entry reads
 	 * as due (pfb_due_ledger_is_due_from_entry(): NULL -> due now) and the
 	 * tick dispatches it through the recorder, populating the calls log.
+	 *
+	 * The calls log alone is race-blind: a fired dispatch backgrounds the
+	 * recorder exec (`&`), so its write can land AFTER this assertion runs,
+	 * letting a real dispatch pass undetected. The deterministic check is the
+	 * ledger entry itself -- each dispatch branch (cron/dcc/bl) synchronously
+	 * calls pfb_due_ledger_mark_ran*() BEFORE pfblockerng_tick() returns, so a
+	 * fired dispatch rewrites its own entry (last_run/next_due) before control
+	 * comes back here. Snapshot every entry before the tick and assert each is
+	 * byte-identical after.
 	 */
 	public function testTickDispatchesNothingWhenNoJobIsDue(): void
 	{
+		$before = [];
+		foreach (['cron', 'dcc', 'bl'] as $jobKey) {
+			$before[$jobKey] = pfb_due_ledger_read_entry($jobKey, $this->dir);
+		}
+
 		$this->tick();
 
+		foreach (['cron', 'dcc', 'bl'] as $jobKey) {
+			$this->assertSame($before[$jobKey], pfb_due_ledger_read_entry($jobKey, $this->dir),
+				"expected the '{$jobKey}' due-ledger entry to stay unchanged across a tick with every "
+				. 'ledger entry future-dated -- a rewritten entry means its dispatch branch fired '
+				. '(pfb_due_ledger_mark_ran*() runs synchronously before a fired branch returns) '
+				. "(issue #1666)");
+		}
+
+		// Best-effort secondary check: the recorder's write is backgrounded, so
+		// an absent calls log does NOT by itself prove nothing dispatched (the
+		// write can land after this assertion runs) -- the ledger asserts above
+		// are the deterministic proof. This only catches the case where a
+		// dispatch fired AND its write already landed.
 		$this->assertFileDoesNotExist($this->phpCallsLog(),
 			'expected no cron/dcc/bl dispatch branch to fire on a tick with every '
 			. 'ledger entry future-dated -- a populated calls log means this suite '

--- a/tests/php/TickApplyReconciliationTest.php
+++ b/tests/php/TickApplyReconciliationTest.php
@@ -48,7 +48,7 @@ final class TickApplyReconciliationTest extends TestCase
 		$this->dir = sys_get_temp_dir() . '/pfb_tick_apply_reconciliation_' . getmypid() . '_' . uniqid();
 		mkdir($this->dir, 0755, TRUE);
 
-		foreach (['dbdir', 'aliasdir', 'dnsbldir', 'pfctl', 'log', 'errlog', 'runlog', 'extraslog',
+		foreach (['dbdir', 'aliasdir', 'dnsbldir', 'pfctl', 'php', 'log', 'errlog', 'runlog', 'extraslog',
 			  'dnsbl_file', 'dnsbl_python_unmount'] as $k) {
 			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
 		}
@@ -67,6 +67,20 @@ final class TickApplyReconciliationTest extends TestCase
 		$GLOBALS['config'] = [];
 
 		$this->seedTickPrereqs();
+
+		// issue #1666: pfb_interval='Disabled' (seeded above) only gates the tick's
+		// cron dispatch branch -- dcc/bl dispatch off the due-ledger regardless of
+		// pfb_interval, and an absent ledger entry reads as due NOW
+		// (pfb_due_ledger_is_due_from_entry()). Without seeding, every tick() call
+		// in this suite dispatched a REAL "pfblockerng.php dcc" background shell
+		// that a sibling suite's pfb_update_pass_running() `ps` scan could then see.
+		// Future-date every job so no dispatch branch fires here at all, and neuter
+		// $pfb['php'] as a backstop in case that ever regresses.
+		$this->installPhpArgvRecorder();
+		$now = time();
+		foreach (['cron', 'dcc', 'bl'] as $jobKey) {
+			$this->seedFutureLedgerEntry($jobKey, $now);
+		}
 	}
 
 	protected function tearDown(): void
@@ -97,9 +111,15 @@ final class TickApplyReconciliationTest extends TestCase
 	/**
 	 * Minimum config keys pfb_global() reads (avoids undefined-array-key warnings --
 	 * pfblockerng_ss_refresh() calls pfb_global() internally every tick), plus
-	 * pfb_interval='Disabled' so the tick's own cron/dcc/bl dispatch branches
-	 * never exec() anything real -- isolates every test here to the new
-	 * reconciliation step alone. Mirrors TickEntrypointTest::seedTickPrereqs().
+	 * pfb_interval='Disabled' so the tick's own cron dispatch branch never fires.
+	 *
+	 * NOTE (issue #1666): 'Disabled' alone does NOT gate the dcc/bl dispatch
+	 * branches -- those key off the due-ledger regardless of pfb_interval, and an
+	 * absent ledger entry reads as due now. setUp() additionally future-dates the
+	 * cron/dcc/bl ledger entries and neuters $pfb['php'] so a tick() call in this
+	 * class can never exec() a real "pfblockerng.php <verb>" background process --
+	 * that's what genuinely isolates every test here to the new reconciliation
+	 * step alone. Mirrors TickEntrypointTest::seedTickPrereqs().
 	 */
 	private function seedTickPrereqs(): void
 	{
@@ -144,6 +164,42 @@ final class TickApplyReconciliationTest extends TestCase
 		if (!isset($GLOBALS['g']['unbound_chroot_path'])) {
 			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
 		}
+	}
+
+	/** Ledger dir path a php-argv recorder logs to; see installPhpArgvRecorder(). */
+	private function phpCallsLog(): string
+	{
+		return "{$this->dir}/pfb_php_calls.log";
+	}
+
+	/**
+	 * issue #1666: point $pfb['php'] at a harmless recording stub instead of the
+	 * real interpreter -- a backstop so that even if the due-ledger seeding below
+	 * ever regresses, a dispatch branch that fires anyway writes a line to
+	 * phpCallsLog() instead of forking a REAL "pfblockerng.php <verb>" background
+	 * shell that a sibling suite's pfb_update_pass_running() `ps` scan could see.
+	 * Saved via the generic $saved loop in setUp(); restored in tearDown().
+	 */
+	private function installPhpArgvRecorder(): void
+	{
+		$path = "{$this->dir}/pfb_php_recorder";
+		$log  = escapeshellarg($this->phpCallsLog());
+		file_put_contents($path, "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> {$log}\n");
+		chmod($path, 0755);
+		$GLOBALS['pfb']['php'] = $path;
+	}
+
+	/**
+	 * Mirrors TickEntrypointTest::seedFutureLedgerEntry() -- keeps cron/dcc/bl
+	 * not-due so tick() calls in this suite dispatch nothing (issue #1666).
+	 */
+	private function seedFutureLedgerEntry(string $jobKey, int $now): void
+	{
+		pfb_due_ledger_write_entry($jobKey, [
+			'last_run' => $now - 3600,
+			'next_due' => $now + 3600,
+			'jitter'   => 0,
+		], $this->dir);
 	}
 
 	/** Write an executable POSIX-sh mock pfctl that exits $rc, emitting $stderr on fd 2,
@@ -461,5 +517,36 @@ final class TickApplyReconciliationTest extends TestCase
 		$this->assertSame(5, $sentinelAfter,
 			'Unbound is not running -- nothing can consume a re-flipped sentinel, so '
 			. "pfb_dnsbl_apply_retry() must not bump it (got {$sentinelAfter}, expected unchanged 5)");
+	}
+
+	// -----------------------------------------------------------------------
+	// issue #1666 -- hermeticity tripwire: this suite must never dispatch a
+	// real cron/dcc/bl background process (setUp() future-dates every
+	// due-ledger entry and neuters $pfb['php']); this pins that guarantee
+	// directly instead of relying on every other test here happening not to
+	// notice a leak.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario:
+	 *   Given setUp()'s future-dated cron/dcc/bl ledger entries and the
+	 *   recording-stub $pfb['php'] (issue #1666).
+	 *   When  pfblockerng_tick() runs once.
+	 *   Then  the php-recorder's calls log stays absent -- no dispatch branch
+	 *         fired, so nothing could have exec()'d a real background process.
+	 *
+	 * Red->green (manual scratch probe, issue #1666): temporarily removing the
+	 * setUp() ledger seeding makes this FAIL -- the absent 'dcc' entry reads
+	 * as due (pfb_due_ledger_is_due_from_entry(): NULL -> due now) and the
+	 * tick dispatches it through the recorder, populating the calls log.
+	 */
+	public function testTickDispatchesNothingWhenNoJobIsDue(): void
+	{
+		$this->tick();
+
+		$this->assertFileDoesNotExist($this->phpCallsLog(),
+			'expected no cron/dcc/bl dispatch branch to fire on a tick with every '
+			. 'ledger entry future-dated -- a populated calls log means this suite '
+			. 'leaked a real pfblockerng.php dispatch (issue #1666)');
 	}
 }

--- a/tests/php/TickEntrypointTest.php
+++ b/tests/php/TickEntrypointTest.php
@@ -202,6 +202,18 @@ final class TickEntrypointTest extends TestCase
 	 * this is the only lever available to keep that dispatch from forking a REAL
 	 * "pfblockerng.php cron" background process. Mirrors
 	 * TickFeedPassDeferralTest::installPhpArgvRecorder().
+	 *
+	 * Unavoidable residual race: pfblockerng_tick() execs the stub as
+	 * "{$pfb['php']} /usr/local/www/pfblockerng/pfblockerng.php cron ... &" --
+	 * production builds that argv, so the stub's own `ps -wax` command line
+	 * still CONTAINS the literal substring "pfblockerng.php cron" for the
+	 * stub's brief (sub-ms to low-ms) lifetime. pfb_update_pass_running()'s
+	 * precondition assert below scans the real process table and cannot
+	 * distinguish this from a genuine dispatch, so a phpunit run of THIS suite
+	 * happening concurrently with another checkout's run through this same
+	 * dispatch path could cross-trip that precondition. Not fixable from the
+	 * test side without faking argv; accepted because suites are never run
+	 * concurrently against one checkout (see .agents/policy/testing.md).
 	 */
 	private function installPhpArgvRecorder(): string
 	{
@@ -415,6 +427,8 @@ final class TickEntrypointTest extends TestCase
 		// test's own tick() wrongly skip pfb_log_mgmt() below, exactly reproducing
 		// the flake. Assert the process table is clean BEFORE the tick so a leak
 		// fails loudly here instead of silently failing the trim assertion after.
+		// NOTE: this scan can also cross-trip on the recorder stub's own brief
+		// command line -- see installPhpArgvRecorder()'s docblock.
 		$this->assertFalse(pfb_update_pass_running(),
 			'a pfblockerng.php worker process leaked from an earlier test -- see issue #1666');
 

--- a/tests/php/TickEntrypointTest.php
+++ b/tests/php/TickEntrypointTest.php
@@ -55,6 +55,38 @@ final class TickEntrypointTest extends TestCase
 	private mixed $originalExtraslog = NULL;
 
 	/**
+	 * issue #1666: $GLOBALS['pfb']['log']/['logdir']/['errlog'] are set ONCE at
+	 * pfblockerng.inc include time (never recomputed by pfb_global()) -- so
+	 * without a per-test sandbox here, 'log' rode whatever value a PRIOR test
+	 * class last left it at, including a path a leaked-teardown suite had
+	 * already deleted. Same treatment as dbdir/runlog/extraslog above.
+	 */
+	private bool $hadLog = FALSE;
+	private mixed $originalLog = NULL;
+	private bool $hadLogdir = FALSE;
+	private mixed $originalLogdir = NULL;
+	private bool $hadErrlog = FALSE;
+	private mixed $originalErrlog = NULL;
+
+	/** issue #1666: neuter $pfb['php'] so Cases C/D's real dispatch branches exec()
+	 *  a harmless recording stub instead of a REAL "pfblockerng.php <verb>" shell
+	 *  a sibling suite's pfb_update_pass_running() `ps` scan could then see. */
+	private bool $hadPhp = FALSE;
+	private mixed $originalPhp = NULL;
+
+	/** issue #1666: $GLOBALS['config'] was overwritten unconditionally below with
+	 *  no restore; save/restore it like every other process-global this suite
+	 *  touches. */
+	private bool $hadConfig = FALSE;
+	private mixed $originalConfig = NULL;
+
+	/** issue #1666: seedTickPrereqs() sets this once, guarded by isset(), and it is
+	 *  never restored -- the first test to run in the whole suite leaves it set for
+	 *  every later test/class. Save/restore it explicitly instead. */
+	private bool $hadUnboundChroot = FALSE;
+	private mixed $originalUnboundChroot = NULL;
+
+	/**
 	 * Self-encapsulated (CLAUDE.md mandate): pfblockerng_tick() reads/writes the
 	 * due-ledger + log-rotate marker at $pfb['dbdir'] (not injectable), a path a
 	 * sibling suite (SoftwareUpdateCheckTest) also repoints at its own sandbox
@@ -83,11 +115,33 @@ final class TickEntrypointTest extends TestCase
 		$this->hadExtraslog      = array_key_exists('extraslog', $GLOBALS['pfb'] ?? []);
 		$this->originalExtraslog = $GLOBALS['pfb']['extraslog'] ?? NULL;
 
+		$this->hadLog      = array_key_exists('log', $GLOBALS['pfb'] ?? []);
+		$this->originalLog = $GLOBALS['pfb']['log'] ?? NULL;
+
+		$this->hadLogdir      = array_key_exists('logdir', $GLOBALS['pfb'] ?? []);
+		$this->originalLogdir = $GLOBALS['pfb']['logdir'] ?? NULL;
+
+		$this->hadErrlog      = array_key_exists('errlog', $GLOBALS['pfb'] ?? []);
+		$this->originalErrlog = $GLOBALS['pfb']['errlog'] ?? NULL;
+
+		$this->hadPhp      = array_key_exists('php', $GLOBALS['pfb'] ?? []);
+		$this->originalPhp = $GLOBALS['pfb']['php'] ?? NULL;
+
+		$this->hadConfig      = array_key_exists('config', $GLOBALS);
+		$this->originalConfig = $GLOBALS['config'] ?? NULL;
+
+		$this->hadUnboundChroot      = array_key_exists('unbound_chroot_path', $GLOBALS['g'] ?? []);
+		$this->originalUnboundChroot = $GLOBALS['g']['unbound_chroot_path'] ?? NULL;
+
 		$this->dbdir = sys_get_temp_dir() . '/pfb_tick_entrypoint_' . uniqid('', TRUE);
 		mkdir($this->dbdir, 0755, TRUE);
 		$GLOBALS['pfb']['dbdir']     = $this->dbdir;
 		$GLOBALS['pfb']['runlog']    = "{$this->dbdir}/pfblockerng_run.log";
 		$GLOBALS['pfb']['extraslog'] = "{$this->dbdir}/extras.log";
+		$GLOBALS['pfb']['logdir']    = $this->dbdir;
+		$GLOBALS['pfb']['log']       = "{$this->dbdir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog']    = "{$this->dbdir}/error.log";
+		$GLOBALS['pfb']['php']       = $this->installPhpArgvRecorder();
 
 		$GLOBALS['config'] = [];
 	}
@@ -109,7 +163,53 @@ final class TickEntrypointTest extends TestCase
 		} else {
 			unset($GLOBALS['pfb']['extraslog']);
 		}
+		if ($this->hadLog) {
+			$GLOBALS['pfb']['log'] = $this->originalLog;
+		} else {
+			unset($GLOBALS['pfb']['log']);
+		}
+		if ($this->hadLogdir) {
+			$GLOBALS['pfb']['logdir'] = $this->originalLogdir;
+		} else {
+			unset($GLOBALS['pfb']['logdir']);
+		}
+		if ($this->hadErrlog) {
+			$GLOBALS['pfb']['errlog'] = $this->originalErrlog;
+		} else {
+			unset($GLOBALS['pfb']['errlog']);
+		}
+		if ($this->hadPhp) {
+			$GLOBALS['pfb']['php'] = $this->originalPhp;
+		} else {
+			unset($GLOBALS['pfb']['php']);
+		}
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->originalConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+		if ($this->hadUnboundChroot) {
+			$GLOBALS['g']['unbound_chroot_path'] = $this->originalUnboundChroot;
+		} else {
+			unset($GLOBALS['g']['unbound_chroot_path']);
+		}
 		$this->rrmdir($this->dbdir);
+	}
+
+	/**
+	 * issue #1666: point $pfb['php'] at a harmless recording stub instead of the
+	 * real interpreter -- Cases C/D genuinely dispatch (a due 'cron' job), so
+	 * this is the only lever available to keep that dispatch from forking a REAL
+	 * "pfblockerng.php cron" background process. Mirrors
+	 * TickFeedPassDeferralTest::installPhpArgvRecorder().
+	 */
+	private function installPhpArgvRecorder(): string
+	{
+		$path = "{$this->dbdir}/pfb_php_recorder";
+		$log  = escapeshellarg("{$this->dbdir}/pfb_php_calls.log");
+		file_put_contents($path, "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> {$log}\n");
+		chmod($path, 0755);
+		return $path;
 	}
 
 	private function rrmdir(string $dir): void
@@ -308,6 +408,15 @@ final class TickEntrypointTest extends TestCase
 		$linesBefore = count(array_filter(explode("\n", (string) file_get_contents($logPath)), 'strlen'));
 		$this->assertSame(5, $linesBefore,
 			"Before: expected 'log' to have 5 lines, got {$linesBefore}");
+
+		// Ordering-regression tripwire (issue #1666): pfb_update_pass_running()
+		// scans the REAL `ps -wax` table for a "pfblockerng.php <verb>" line -- a
+		// process leaked from an earlier, un-neutered sibling test would make this
+		// test's own tick() wrongly skip pfb_log_mgmt() below, exactly reproducing
+		// the flake. Assert the process table is clean BEFORE the tick so a leak
+		// fails loudly here instead of silently failing the trim assertion after.
+		$this->assertFalse(pfb_update_pass_running(),
+			'a pfblockerng.php worker process leaked from an earlier test -- see issue #1666');
 
 		// Act.
 		pfblockerng_tick();

--- a/tests/php/TickFeedPassDeferralTest.php
+++ b/tests/php/TickFeedPassDeferralTest.php
@@ -368,6 +368,12 @@ SH;
 		$this->seedFutureLedgerEntry('dcc', $now);
 		$this->seedFutureLedgerEntry('bl',  $now);
 
+		// issue #1666: this test genuinely dispatches (lock free, cron due) --
+		// neuter $pfb['php'] so that dispatch exec()s a harmless recording stub
+		// instead of a REAL "pfblockerng.php cron" background shell a sibling
+		// suite's pfb_update_pass_running() `ps` scan could then see.
+		$GLOBALS['pfb']['php'] = $this->installPhpArgvRecorder();
+
 		// Act -- no lock held anywhere.
 		pfblockerng_tick();
 
@@ -416,6 +422,12 @@ SH;
 
 		$this->seedFutureLedgerEntry('dcc', $now);
 		$this->seedFutureLedgerEntry('bl',  $now);
+
+		// issue #1666: this test genuinely dispatches (lock free, cron still due) --
+		// neuter $pfb['php'] so that dispatch exec()s a harmless recording stub
+		// instead of a REAL "pfblockerng.php cron" background shell a sibling
+		// suite's pfb_update_pass_running() `ps` scan could then see.
+		$GLOBALS['pfb']['php'] = $this->installPhpArgvRecorder();
 
 		// Act -- lock is free this time.
 		pfblockerng_tick();

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -304,13 +304,39 @@ _PROBE_SINGLE_TAG_RE = re.compile(r'r"((?:[^"\\]|\\.)*)"\s*\)?,?\s*#\s*(_REGEX_\
 _PROBE_COMBINED_TAG_RE = re.compile(r"#\s*(_REGEX_\w+)\s*\+\s*(_REGEX_\w+) mirror \(pfb_unbound\.py\)")
 
 
+def _runtime_admission_regex_names() -> set[str]:
+    """Issue #1711 completeness pin: the set of module-level `_REGEX_*` compiled
+    patterns actually used as admission checks inside `_regex_is_catastrophic_shape`
+    -- the shape patterns invoked via `.search(` plus the budget patterns invoked via
+    `.findall(` in that same function's complexity-budget backstop.
+
+    Extracted from the FUNCTION BODY TEXT (anchored on the `def` line, not a
+    hardcoded name list and not a line-number offset) so this stays robust to
+    unrelated edits elsewhere in the file: a NEW `_REGEX_*` pattern wired into the
+    guard via `.search(`/`.findall(` is picked up automatically, and the parity
+    test below then requires the probe to tag-mirror it too -- a 7th runtime shape
+    added without a matching probe tag makes this set diverge from the probe's
+    tagged literals and fails loudly instead of the previous hardcoded six staying
+    silently in sync with nothing."""
+    unbound_path = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng/pfb_unbound.py"
+    source = unbound_path.read_text()
+    start = source.index("def _regex_is_catastrophic_shape")
+    next_def = re.search(r"\ndef ", source[start + 1 :])
+    body = source[start : start + 1 + next_def.start()] if next_def else source[start:]
+    names = set(re.findall(r"(_REGEX_\w+)\.(?:search|findall)\(", body))
+    assert names, "expected at least one _REGEX_*.search(/.findall( admission check in _regex_is_catastrophic_shape"
+    return names
+
+
 def test_probe_regex_literals_match_runtime_shape_and_budget_patterns() -> None:
     """Issue #1711: every regex LITERAL the save-time probe duplicates from the
     resolver's shape gate + complexity budget is tagged '<name> mirror (pfb_unbound.py)'
     in the probe source. Extract each tagged literal and assert it is byte-identical to
-    the runtime pattern of the same name -- and that the tagged set is EXACTLY the six
-    mirrored names, so a renamed/added/removed runtime pattern that forgets to update the
-    probe tag fails loudly instead of silently drifting."""
+    the runtime pattern of the same name -- and that the tagged set is EXACTLY the set
+    of `_REGEX_*` patterns `_regex_is_catastrophic_shape` actually consults (extracted
+    from source, not hardcoded -- see `_runtime_admission_regex_names()`), so a
+    renamed/added/removed runtime pattern that forgets to update the probe tag fails
+    loudly instead of silently drifting."""
     probe = _probe_source()
 
     literals: dict[str, str] = {}
@@ -327,14 +353,7 @@ def test_probe_regex_literals_match_runtime_shape_and_budget_patterns() -> None:
     literals[combined.group(1)] = raw_literals[0]
     literals[combined.group(2)] = raw_literals[1]
 
-    expected_names = {
-        "_REGEX_NESTED_QUANTIFIER",
-        "_REGEX_ALTERNATION_OVERLAP",
-        "_REGEX_ADJACENT_GROUP_QUANTIFIER",
-        "_REGEX_STACKED_BOUNDED_REPEAT",
-        "_REGEX_UNBOUNDED_QUANTIFIER",
-        "_REGEX_ALTERNATION",
-    }
+    expected_names = _runtime_admission_regex_names()
     assert set(literals) == expected_names, (
         f"probe mirror tags drifted: extracted={sorted(literals)} expected={sorted(expected_names)}"
     )

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -27,6 +27,7 @@ design accepts but the tests must not pay).
 
 from __future__ import annotations
 
+import ast
 import re
 from collections import defaultdict
 from pathlib import Path
@@ -278,6 +279,131 @@ def test_save_time_probe_length_cap_matches_runtime_constant() -> None:
     php_cap = int(match.group(1))
     runtime_cap = pfb_unbound.REGEX_STATIC_LEN_CAP
     assert php_cap == runtime_cap, f"probe cap={php_cap} != pfb_unbound.REGEX_STATIC_LEN_CAP={runtime_cap}"
+
+
+# --------------------------------------------------------------------------- #
+# Issue #1711: extend #1688 parity pinning to EVERY rule the save-time probe
+# duplicates from the resolver -- the four shape literals, the two budget
+# literals, the budget threshold, the length-cap comparator strictness, and the
+# runtime's exact-boundary admission behaviour.
+# --------------------------------------------------------------------------- #
+def _probe_source() -> str:
+    """Extract pfblockerng_extra.inc's embedded save-time probe nowdoc verbatim (the
+    text between <<<'PYTHON' and the closing PYTHON; delimiter) so probe/runtime parity
+    is pinned against the actual nowdoc bytes. Anchored past the function name because a
+    second, unrelated nowdoc probe exists later in the file."""
+    inc_path = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
+    source = inc_path.read_text()
+    anchor = source.index("function pfb_dnsbl_regex_validation_errors")
+    match = re.search(r"<<<'PYTHON'\n(.*?)\nPYTHON;", source[anchor:], re.S)
+    assert match is not None, "expected the probe's <<<'PYTHON' nowdoc after pfb_dnsbl_regex_validation_errors"
+    return match.group(1)
+
+
+_PROBE_SINGLE_TAG_RE = re.compile(r'r"((?:[^"\\]|\\.)*)"\s*\)?,?\s*#\s*(_REGEX_\w+) mirror \(pfb_unbound\.py\)')
+_PROBE_COMBINED_TAG_RE = re.compile(r"#\s*(_REGEX_\w+)\s*\+\s*(_REGEX_\w+) mirror \(pfb_unbound\.py\)")
+
+
+def test_probe_regex_literals_match_runtime_shape_and_budget_patterns() -> None:
+    """Issue #1711: every regex LITERAL the save-time probe duplicates from the
+    resolver's shape gate + complexity budget is tagged '<name> mirror (pfb_unbound.py)'
+    in the probe source. Extract each tagged literal and assert it is byte-identical to
+    the runtime pattern of the same name -- and that the tagged set is EXACTLY the six
+    mirrored names, so a renamed/added/removed runtime pattern that forgets to update the
+    probe tag fails loudly instead of silently drifting."""
+    probe = _probe_source()
+
+    literals: dict[str, str] = {}
+    for match in _PROBE_SINGLE_TAG_RE.finditer(probe):
+        literals[match.group(2)] = match.group(1)
+
+    combined = _PROBE_COMBINED_TAG_RE.search(probe)
+    assert combined is not None, "expected the combined budget-literal tag comment in the probe"
+    combined_line = next(line for line in probe.splitlines() if combined.group(0) in line)
+    raw_literals = re.findall(r'r"((?:[^"\\]|\\.)*)"', combined_line)
+    assert len(raw_literals) == 2, (
+        f"expected exactly 2 raw-string literals on the combined-tag line, got {raw_literals}"
+    )
+    literals[combined.group(1)] = raw_literals[0]
+    literals[combined.group(2)] = raw_literals[1]
+
+    expected_names = {
+        "_REGEX_NESTED_QUANTIFIER",
+        "_REGEX_ALTERNATION_OVERLAP",
+        "_REGEX_ADJACENT_GROUP_QUANTIFIER",
+        "_REGEX_STACKED_BOUNDED_REPEAT",
+        "_REGEX_UNBOUNDED_QUANTIFIER",
+        "_REGEX_ALTERNATION",
+    }
+    assert set(literals) == expected_names, (
+        f"probe mirror tags drifted: extracted={sorted(literals)} expected={sorted(expected_names)}"
+    )
+
+    for name, raw in literals.items():
+        pattern = ast.literal_eval(f'r"{raw}"')
+        runtime_pattern = getattr(pfb_unbound, name).pattern
+        assert pattern == runtime_pattern, f"{name}: probe={pattern!r} != runtime={runtime_pattern!r}"
+
+
+def test_probe_budget_threshold_matches_runtime_budget_max() -> None:
+    """Issue #1711: the probe's complexity-budget threshold (tagged '_REGEX_BUDGET_MAX
+    mirror') must match pfb_unbound._REGEX_BUDGET_MAX, and the comparison on both sides
+    must be a STRICT '>' -- a '>=' regression would silently shift the admissible budget
+    down by one."""
+    probe = _probe_source()
+    match = re.search(r"if budget > (\d+):\s*#\s*_REGEX_BUDGET_MAX mirror \(pfb_unbound\.py\)", probe)
+    assert match is not None, "expected the probe's tagged budget threshold comparison"
+    probe_budget_max = int(match.group(1))
+    assert probe_budget_max == pfb_unbound._REGEX_BUDGET_MAX, (
+        f"probe budget max={probe_budget_max} != pfb_unbound._REGEX_BUDGET_MAX={pfb_unbound._REGEX_BUDGET_MAX}"
+    )
+    assert "budget >=" not in probe, "probe budget threshold regressed from strict '>' to '>='"
+
+
+def test_runtime_length_cap_comparator_is_strict_at_every_site() -> None:
+    """Issue #1711: pin the runtime's exact-200-character admission boundary. All three
+    REGEX_STATIC_LEN_CAP comparisons in pfb_unbound.py (the build-time compile helper
+    plus the two save-time www/ probes) use a STRICT '>' -- a '>=' regression at any site
+    would silently drop a pattern exactly at the cap, which the resolver, this probe, and
+    the PHP DnsblRegexEntryErrorTest suite all admit."""
+    unbound_path = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng/pfb_unbound.py"
+    source = unbound_path.read_text()
+    strict = re.findall(r"len\([^)\n]*\)\s*>\s*REGEX_STATIC_LEN_CAP", source)
+    assert len(strict) == 3, f"expected exactly 3 strict '>' comparisons, found {len(strict)}: {strict}"
+    non_strict = re.findall(r"len\([^)\n]*\)\s*>=\s*REGEX_STATIC_LEN_CAP", source)
+    assert non_strict == [], f"found a non-strict '>=' REGEX_STATIC_LEN_CAP comparison: {non_strict}"
+
+
+def _anchored_pattern(length: int) -> str:
+    """Mirror of DnsblRegexEntryErrorTest::anchoredPattern (tests/php/DnsblRegexEntryErrorTest.php):
+    an anchored, structurally benign pattern (no quantifier, no alternation, no stacked
+    repeat) of EXACTLY the requested length, so only the length cap -- never the shape
+    gate or the complexity budget -- can be the reason it is admitted or dropped."""
+    if length < 2:
+        raise ValueError("length must be >= 2 to hold both anchors")
+    return "^" + "a" * (length - 2) + "$"
+
+
+class TestStaticCapExactBoundary:
+    """Issue #1711: pin the runtime's admission boundary at EXACTLY REGEX_STATIC_LEN_CAP
+    characters -- the comparison is strict '>', so a pattern of exactly the cap length is
+    the last admissible value (mirrors the PHP-side pair in DnsblRegexEntryErrorTest)."""
+
+    def test_exactly_cap_length_is_admitted(self) -> None:
+        pattern = _anchored_pattern(pfb_unbound.REGEX_STATIC_LEN_CAP)
+        assert len(pattern) == pfb_unbound.REGEX_STATIC_LEN_CAP
+        rules = [_block_rule(pattern)]
+        db, admitted = _dnsbl_compile_regex_rules(rules, static_cap=True)
+        assert admitted == 1
+        assert len(db) == 1
+
+    def test_one_over_cap_length_is_dropped(self) -> None:
+        pattern = _anchored_pattern(pfb_unbound.REGEX_STATIC_LEN_CAP + 1)
+        assert len(pattern) == pfb_unbound.REGEX_STATIC_LEN_CAP + 1
+        rules = [_block_rule(pattern)]
+        db, admitted = _dnsbl_compile_regex_rules(rules, static_cap=True)
+        assert admitted == 0
+        assert db == {}
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Two correlated test-architecture fixes from the v4.0.0 milestone, one commit per issue.

Fixes #1711. Fixes #1666.

## Commit 1 — pin the DNSBL save-probe/resolver parity surface (#1711)

Option 1 from the issue (extend the #1688 pinning technique):

- Tag comments inside the save-time probe's nowdoc (`pfblockerng_extra.inc`) mirroring the existing `# REGEX_STATIC_LEN_CAP mirror (pfb_unbound.py)` convention: the four catastrophic-shape regexes, the two budget regexes, and the budget threshold.
- New parity tests in `tests/test_adr07_regex_safety.py`: tag-driven literal extraction with an exact-set-of-6 assertion (a missing or extra tag fails loudly, keeping the enumeration self-maintaining), `ast.literal_eval` byte-comparison against the live `pfb_unbound` compiled patterns, threshold parity, and a 3-site strict-`>` comparator scan of the runtime.
- The previously-unpinned runtime admission boundary: exactly-200-char pattern admitted / exactly-201 dropped through the real `_dnsbl_compile_regex_rules(..., static_cap=True)`, mirroring the PHP-side `DnsblRegexEntryErrorTest` boundary pair.
- Deliberately NOT pinned (intentional deltas per the issue): the probe-only control-char rule and the measured-string derivation.

Evidence: four executed mutation proofs (shape literal flip, threshold 12→13, tag removal, runtime `>`→`>=`) each drove the intended test red, then green after revert. The probe comment edit is inert: the PHP suite executes the real probe (`DnsblRegexEntryErrorTest`, 57 tests green).

## Commit 2 — make the tick suites hermetic (#1666)

Root cause of the order-dependent flake (evidence in the commit): `TickApplyReconciliationTest` seeded no due-ledger entries, so every tick in that class fired a real backgrounded `pfblockerng.php dcc` exec; the leaked shell matches `pfb_update_pass_running()`'s ps-scan regex, and `pfblockerng_tick()`'s tail gate then silently skips `pfb_log_mgmt()` — exactly the assertion `testLogMaintenanceRunsEvenWhenFeedCronNotDue` rides.

Test-only fix: seed future-dated ledgers + a recording-stub `$pfb['php']` in the emitter suites (TickApplyReconciliation, TickEntrypoint C/D, TickFeedPassDeferral rows), sandbox and restore the process-global `$pfb['log']`/`logdir`/`errlog`, `$GLOBALS['config']`, and `unbound_chroot_path` in `TickEntrypointTest`, restore the four `$pfb` path keys in `AlertsPfctlCheckedSitesTest`'s teardown, and add two loud tripwires: a no-dispatch assertion (`testTickDispatchesNothingWhenNoJobIsDue`) and a precondition `assertFalse(pfb_update_pass_running(), ...)` before the tick — both proven RED against the respective regressions and GREEN after (evidence in the verification record).

Order-robustness: `--filter Tick` ×3 and the full suite ×2, all green. No production file touched; no timeout widened (per `testing.md`, deadlines are never assertions).

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for regex safety validation, including exact length-limit boundaries and consistency between validation stages.
  * Improved test isolation to prevent background tasks and temporary configuration from affecting other test runs.
  * Added verification that scheduled maintenance is skipped when no work is due and proceeds correctly when required.

* **Refactor**
  * Clarified internal validation logic without changing existing acceptance or rejection criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->