### PR TITLE
ci: gate releases on live smoke/UI over exact artifacts; 45-min ui budget; self-maintaining dry_run guards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -835,10 +835,16 @@ jobs:
   # built, not a fresh rebuild of their own.
   #
   # A leg's build failure surfaces as a red leg (fail-fast: false keeps the
-  # others going) but MUST NOT break sync-ports-fork: it needs only `release`,
-  # never build-pkgs-*. attach-pkgs absorbs the failure with `if: always() && ...`
-  # (below); a failed leg simply uploads nothing, so its .pkg is absent from
-  # the merged download and the publish-release healthcheck fails closed.
+  # others going). sync-ports-fork's own `needs:` list is [prepare-release,
+  # release, publish-release] -- it never lists build-pkgs-* directly -- but a
+  # leg failure now blocks it TRANSITIVELY: build-pkgs-portable fails (matrix
+  # job result is 'failure' if any leg fails) -> ui-suite/smoke-suite skip
+  # (their `if:` requires needs.build-pkgs-portable.result == 'success') ->
+  # publish-release skips (requires both suites == 'success') -> sync-ports-fork
+  # skips (requires needs.publish-release.result == 'success'). attach-pkgs
+  # absorbs the failure with `if: always() && ...` (below), unaffected by this
+  # chain; a failed leg simply uploads nothing, so its .pkg is absent from the
+  # merged download and the publish-release healthcheck fails closed.
   build-pkgs-portable:
     name: "build .pkg — ${{ matrix.variant }}-${{ matrix.pfsense_version }} (FreeBSD ${{ matrix.freebsd_major }}/${{ matrix.arch }})"
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,18 +338,24 @@ jobs:
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
 
   # ── 1b. UI suite (ADR-14, D1) ────────────────────────────────────────────
-  # Run the FULL tiered Web-UI suite on the live pfSense VM BEFORE publishing.
-  # `tier: all` expands the reusable workflow's matrix to one GH job per
-  # (tier × version) leg — render / functional / browser × each image — and
-  # `fail-fast: false` keeps every leg independent. Because each leg is its own
-  # job, GitHub's "Re-run failed jobs" re-runs ONLY a flaky leg; `release` and
-  # `sync-ports-fork` do NOT re-run until all legs are green again (they only run once
-  # their `needs:` are all `success`), so a not-our-fault browser flake costs a
-  # single-leg re-run, never a republish.
+  # Run the FULL tiered Web-UI suite on the live pfSense VM against the EXACT
+  # per-leg .pkg artifacts build-pkgs-portable just built (pkg_artifact_prefix:
+  # pfBlockerNG-relpkg, issue #1662) — not a fresh build of its own, so the
+  # release gates on the SAME bits that get published. `tier: all` expands the
+  # reusable workflow's matrix to one GH job per (tier × version) leg — render
+  # / functional / browser × each image — and `fail-fast: false` keeps every
+  # leg independent. Because each leg is its own job, GitHub's "Re-run failed
+  # jobs" re-runs ONLY a flaky leg; publish-release does NOT re-run until all
+  # legs are green again (it only runs once its `needs:` are all `success`),
+  # so a not-our-fault browser flake costs a single-leg re-run, never a
+  # republish.
   #
   # This is a SEPARATE gate ALONGSIDE the CI check asserted by prepare-release
   # (which still asserts the "All tests passed" branch-tip check, covering the
-  # Tier-A PR fold). It does not weaken that gate — the release `needs:` BOTH.
+  # Tier-A PR fold). It does not weaken that gate — publish-release `needs:`
+  # BOTH this AND smoke-suite (ADR-14 D1: the publish flip waits on every leg;
+  # a flaky leg re-runs in isolation without redoing the publish — gate
+  # publish-release, never `release`, so draft creation stays recoverable).
   #
   # §7 browser DEMOTE/DROP — one-line switch: the browser leg is included here as
   # a separate re-runnable leg (the cheap tiers gate firmly; browser adds the
@@ -359,14 +365,15 @@ jobs:
   # AND running this with `tier: functional` instead of `tier: all` here — the
   # render + functional legs keep gating the release, the browser leg goes
   # dispatch-only. Tier A + B-HTTP retain full standalone value.
-  # TEMPORARILY DISABLED (if: false) — the live-VM UI harness is still being
-  # stabilized (ADR-14 §7; login fixed in #81, page-serving 404 + php_error.log
-  # size read outstanding). While it cannot pass, it must not gate or burden a
-  # release. Re-enable by removing `if: false` here AND re-adding `ui-suite` to
-  # the `release` job's `needs:` below, once the harness runs green.
+  #
+  # Deliberately carries no reference to the dispatch's dry-run input (kept OUT
+  # of the mutation-jobs gate set): this runs in BOTH dry-run and real modes,
+  # same as build-pkgs-portable already builds in dry-run to validate the .pkg
+  # — dry-run parity for the live gates comes free.
   ui-suite:
     name: UI fan-out (all CI legs, live pfSense VM)
-    if: false
+    needs: [prepare-release, read-matrix, build-pkgs-portable]
+    if: ${{ !cancelled() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped') && needs.read-matrix.result == 'success' && needs.build-pkgs-portable.result == 'success' }}
     uses: ./.github/workflows/ui-tests.yml
     with:
       tier: all
@@ -374,6 +381,24 @@ jobs:
       # so without this the scope ladder resolves `impacted` — min-CE leg only —
       # not the full pre-release fan-out this job exists for.
       scope: full
+      # Consume the EXACT per-leg artifacts build-pkgs-portable just built
+      # (issue #1662) instead of building its own.
+      pkg_artifact_prefix: pfBlockerNG-relpkg
+    secrets: inherit
+
+  # ── 1b2. Smoke suite (ADR-14 D1 sibling) ─────────────────────────────────
+  # Same live-gate contract as ui-suite, one leg per ci:true image, over the
+  # SAME per-leg .pkg artifacts (pkg_artifact_prefix: pfBlockerNG-relpkg, issue
+  # #1662). Carries no dry-run-input reference either — runs in both modes,
+  # same as ui-suite.
+  smoke-suite:
+    name: Smoke fan-out (all CI legs, live pfSense VM)
+    needs: [prepare-release, read-matrix, build-pkgs-portable]
+    if: ${{ !cancelled() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped') && needs.read-matrix.result == 'success' && needs.build-pkgs-portable.result == 'success' }}
+    uses: ./.github/workflows/smoke.yml
+    with:
+      scope: full
+      pkg_artifact_prefix: pfBlockerNG-relpkg
     secrets: inherit
 
   # ── 1c. Read version matrix ──────────────────────────────────────────────
@@ -468,9 +493,9 @@ jobs:
     name: Create draft GitHub Release
     runs-on: ubuntu-latest
     # Gate on prepare-release (real: must succeed; dry-run: skipped is fine) AND
-    # the matrix read. The live-VM UI suite (ui-suite) is TEMPORARILY un-gated
-    # (see its `if: false` above) while the ADR-14 harness is stabilized;
-    # re-add `ui-suite` here once it is green.
+    # the matrix read. The live-VM ui-suite/smoke-suite gates do NOT block THIS
+    # job (draft creation) — per ADR-14 D1 they gate publish-release instead, so
+    # a flaky live leg re-runs in isolation without redoing the draft/changelog.
     needs: [prepare-release, read-matrix]
     if: ${{ always() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped') && needs.read-matrix.result == 'success' }}
     permissions:
@@ -794,27 +819,37 @@ jobs:
           files: ${{ env.ARCHIVE }}
 
   # ── 2b. Build .pkg artifacts (portable Linux builder) ────────────────────
-  # Builds one .pkg per distinct FreeBSD major from the deduped matrix.
-  # Runs the portable Linux builder steps inline (no FreeBSD VM, ~3 min/entry).
-  # This is the SOLE release .pkg builder: pfBlockerNG is a NO_BUILD port, so the
-  # portable builder reproduces `make package` byte-for-byte (validated against it
-  # over every smoke + Web-UI run on CE and Plus) and `pkg add` checks a dep is
-  # PRESENT, not its version — so the portable artifact installs identically.
+  # Builds one .pkg per build-matrix entry (every CE/Plus variant × FreeBSD
+  # major × arch). Runs the portable Linux builder steps inline (no FreeBSD
+  # VM, ~3 min/entry). This is the SOLE release .pkg builder: pfBlockerNG is a
+  # NO_BUILD port, so the portable builder reproduces `make package`
+  # byte-for-byte (validated against it over every smoke + Web-UI run on CE
+  # and Plus) and `pkg add` checks a dep is PRESENT, not its version — so the
+  # portable artifact installs identically.
   #
-  # GitHub Actions does not allow strategy.matrix on a job that uses a
-  # reusable workflow (uses:), so we run each entry sequentially in one job,
-  # uploading one artifact per entry with a unique name (pfBlockerNG-pkg-<major>).
+  # ONE JOB PER LEG (strategy.matrix over read-matrix's build_matrix,
+  # fail-fast: false): each leg uploads its OWN artifact, named exactly
+  # `pfBlockerNG-relpkg-<variant_lc>-<pfsense_version>-<arch>` (issue #1662) —
+  # the EXACT name ui-tests.yml's/smoke.yml's pkg_artifact_prefix consumer side
+  # downloads, so ui-suite/smoke-suite below gate on the SAME bits this job
+  # built, not a fresh rebuild of their own.
   #
-  # A build failure surfaces clearly (the job goes red) but MUST NOT break
-  # sync-ports-fork: it needs only `release`, never build-pkgs-*.
-  # attach-pkgs absorbs the failure with `if: always() && ...` (below).
+  # A leg's build failure surfaces as a red leg (fail-fast: false keeps the
+  # others going) but MUST NOT break sync-ports-fork: it needs only `release`,
+  # never build-pkgs-*. attach-pkgs absorbs the failure with `if: always() && ...`
+  # (below); a failed leg simply uploads nothing, so its .pkg is absent from
+  # the merged download and the publish-release healthcheck fails closed.
   build-pkgs-portable:
-    name: build .pkg artifacts (portable Linux)
+    name: "build .pkg — ${{ matrix.variant }}-${{ matrix.pfsense_version }} (FreeBSD ${{ matrix.freebsd_major }}/${{ matrix.arch }})"
     runs-on: ubuntu-latest
     needs: [prepare-release, read-matrix, resolve-stamp]
     # Same gate as release: run in both dry-run (skipped) and real (succeeded) modes.
     if: ${{ always() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped') && needs.read-matrix.result == 'success' && needs.resolve-stamp.result == 'success' }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.read-matrix.outputs.build_matrix) }}
 
     steps:
       - name: Checkout the tagged source
@@ -834,84 +869,95 @@ jobs:
       - name: Ensure zstd encoder is present
         run: command -v zstd >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y zstd; }
 
-      - name: Build one .pkg per matrix entry via build-leg.sh
+      - name: Compute this leg's VARSLUG/ABI (variant slug == pkg repo's catalog dir name)
+        id: leg
+        # Variant slug == the pkg repo's catalog dir name (build-repo-portable.py
+        # catalog_name_from_version): "<variant_lc>-<major.minor>", e.g. ce-2.8 /
+        # plus-26.03. The Release encodes it in the per-leg ARTIFACT NAME (issue
+        # #1662 exact-artifact contract) and the .pkg FILENAME; the pkg repo
+        # encodes the same identity as the FOLDER release/<varslug>/<arch>/.
+        env:
+          VARIANT: ${{ matrix.variant }}
+          CHANNEL_FALLBACK: ${{ matrix.channel }}
+          PFV: ${{ matrix.pfsense_version }}
+          MAJOR: ${{ matrix.freebsd_major }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -eu
+          V="${VARIANT:-${CHANNEL_FALLBACK:-CE}}"
+          MM=$(printf '%s' "$PFV" | cut -d. -f1-2)
+          VARSLUG="$(printf '%s' "$V" | tr '[:upper:]' '[:lower:]')-${MM}"
+          ABI="FreeBSD:${MAJOR}:${ARCH}"
+          # AMENDMENT 7: slug this leg from VARSLUG + major + arch so it lands in
+          # a distinct RUN_ID-keyed out dir. Colons in ABI are path-unsafe; the
+          # slug uses only safe chars.
+          LEG="${VARSLUG}-${MAJOR}-${ARCH}"
+          {
+            echo "varslug=${VARSLUG}"
+            echo "abi=${ABI}"
+            echo "leg=${LEG}"
+          } >> "$GITHUB_OUTPUT"
+          echo "leg ${LEG}: variant=${V} ABI=${ABI}"
+
+      - name: Build the .pkg via build-leg.sh
         # build-leg.sh is the shared build path (local/CI/release parity — ADR-47 P3).
         # portversion pinned from read-matrix (ref-independent, tag-string-derived).
         # created + commit from resolve-stamp (same checkout ref as this job's tree).
         env:
-          BUILD_MATRIX: ${{ needs.read-matrix.outputs.build_matrix }}
           PKG_CHANNEL:  ${{ needs.read-matrix.outputs.pkg_channel }}
           PORTVERSION:  ${{ needs.read-matrix.outputs.portversion }}
           CREATED:      ${{ needs.resolve-stamp.outputs.created }}
           COMMIT:       ${{ needs.resolve-stamp.outputs.commit }}
-          # Place run-keyed out dirs under $GITHUB_WORKSPACE/out so the upload
-          # glob out/**/*.pkg finds all artifacts without any path remapping.
+          ABI:          ${{ steps.leg.outputs.abi }}
+          VARSLUG:      ${{ steps.leg.outputs.varslug }}
+          LEG:          ${{ steps.leg.outputs.leg }}
+          PHP:          ${{ matrix.php_version }}
+          PY:           ${{ matrix.py_flavor }}
+          MAJOR:        ${{ matrix.freebsd_major }}
+          ARCH:         ${{ matrix.arch }}
+          # Place the run-keyed out dir under $GITHUB_WORKSPACE/out so the
+          # rename step below finds this leg's .pkg without any path remapping.
           PFB_RUN_ROOT: ${{ github.workspace }}/out
         run: |
           set -eu
-          echo "Pinning .pkg version to ${PORTVERSION}"
+          export LEG
+          RUN_ID="$(sh scripts/select-box.sh --print-id)"
+          export RUN_ID
 
-          printf '%s\n' "$BUILD_MATRIX" \
-            | jq -c '.[]' \
-            | while IFS= read -r ENTRY; do
-                MAJOR=$(printf '%s\n' "$ENTRY" | jq -r '.freebsd_major')
-                FREEBSD_VERSION=$(printf '%s\n' "$ENTRY" | jq -r '.freebsd_version')
-                PHP=$(printf '%s\n' "$ENTRY" | jq -r '.php_version')
-                PY=$(printf '%s\n' "$ENTRY" | jq -r '.py_flavor')
-                ARCH=$(printf '%s\n' "$ENTRY" | jq -r '.arch')
-                # Variant identity (CE/Plus + its pfSense version) disambiguates two
-                # entries that share a FreeBSD major × arch but differ in php/python deps.
-                VARIANT=$(printf '%s\n' "$ENTRY" | jq -r '.variant // .channel // "CE"')
-                PFV=$(printf '%s\n' "$ENTRY" | jq -r '.pfsense_version // empty')
-                ABI="FreeBSD:${MAJOR}:${ARCH}"
-                # Variant slug == the pkg repo's catalog dir name (build-repo-portable.py
-                # catalog_name_from_version): "<variant_lc>-<major.minor>", e.g. ce-2.8 /
-                # plus-26.03. The Release encodes it in the FILENAME; the pkg repo encodes
-                # the same identity as the FOLDER release/<varslug>/<arch>/ — one artifact,
-                # two presentations, the variant segment identical in both.
-                MM=$(printf '%s' "$PFV" | cut -d. -f1-2)
-                VARSLUG="$(printf '%s' "$VARIANT" | tr '[:upper:]' '[:lower:]')-${MM}"
+          echo "--- Building .pkg for ${VARSLUG} FreeBSD ${MAJOR}/${ARCH}, PHP ${PHP}, ${PY} ---"
 
-                echo "--- Building .pkg for ${VARSLUG} FreeBSD ${MAJOR}/${ARCH} (${FREEBSD_VERSION}), PHP ${PHP}, ${PY} ---"
+          PKG="$(sh scripts/build-leg.sh \
+            --channel    "$PKG_CHANNEL" \
+            --abi        "$ABI" \
+            --py-flavor  "$PY" \
+            --php        "$PHP" \
+            --pkgversion "$PORTVERSION" \
+            --annotate   "created=${CREATED}" \
+            --annotate   "commit=${COMMIT}")"
 
-                # AMENDMENT 7: slug a per-entry LEG from VARSLUG + major + arch so
-                # each matrix entry lands in a distinct RUN_ID-keyed out dir.
-                # Colons in ABI are path-unsafe; the slug uses only safe chars.
-                LEG="${VARSLUG}-${MAJOR}-${ARCH}"
-                export LEG
-                RUN_ID="$(sh scripts/select-box.sh --print-id)"
-                export RUN_ID
+          PKG_DIR="$(dirname "$PKG")"
+          echo "Built for ${VARSLUG} FreeBSD ${MAJOR}/${ARCH}:"
+          ls -l "${PKG_DIR}"
 
-                PKG="$(sh scripts/build-leg.sh \
-                  --channel    "$PKG_CHANNEL" \
-                  --abi        "$ABI" \
-                  --py-flavor  "$PY" \
-                  --php        "$PHP" \
-                  --pkgversion "$PORTVERSION" \
-                  --annotate   "created=${CREATED}" \
-                  --annotate   "commit=${COMMIT}")"
+          # Rename to embed variant + pfSense version + FreeBSD major + arch, so
+          # this leg's .pkg filename stays unambiguous inside its own artifact.
+          BASE="$(basename "$PKG" .pkg)"
+          RENAMED="${PKG_DIR}/${BASE}-${VARSLUG}-FreeBSD-${MAJOR}-${ARCH}.pkg"
+          mv "$PKG" "$RENAMED"
+          echo "Renamed: ${BASE}.pkg -> $(basename "$RENAMED")"
+          echo "PKG_PATH=${RENAMED}" >> "$GITHUB_ENV"
 
-                PKG_DIR="$(dirname "$PKG")"
-                echo "Built for ${VARSLUG} FreeBSD ${MAJOR}/${ARCH}:"
-                ls -l "${PKG_DIR}"
-
-                # Rename to embed variant + pfSense version + FreeBSD major + arch before
-                # upload, so every matrix entry yields a uniquely-named artifact (two
-                # variants on one major × arch, or two arches of one major, never collide).
-                BASE="$(basename "$PKG" .pkg)"
-                mv "$PKG" "${PKG_DIR}/${BASE}-${VARSLUG}-FreeBSD-${MAJOR}-${ARCH}.pkg"
-                echo "Renamed: ${BASE}.pkg -> ${BASE}-${VARSLUG}-FreeBSD-${MAJOR}-${ARCH}.pkg"
-              done
-
-          echo "All .pkg artifacts:"
-          find out -name "*.pkg" -exec ls -l {} \;
-
-      - name: Upload .pkg artifacts
-        if: always()
+      - name: Upload this leg's .pkg artifact (exact-name contract, issue #1662)
+        # Name MUST equal pfBlockerNG-relpkg-<variant_lc>-<pfsense_version>-<arch>
+        # -- the EXACT name ui-tests.yml's/smoke.yml's pkg_artifact_prefix download
+        # step composes when pkg_artifact_prefix: pfBlockerNG-relpkg is set (see
+        # ui-suite/smoke-suite below). Upload only on success: fail-fast: false
+        # already isolates a failed leg, so it simply uploads nothing and
+        # attach-pkgs/the publish healthcheck fail closed on the missing asset.
         uses: actions/upload-artifact@v7
         with:
-          name: pfBlockerNG-release-pkgs
-          path: out/**/*.pkg
+          name: pfBlockerNG-relpkg-${{ steps.leg.outputs.varslug }}-${{ matrix.arch }}
+          path: ${{ env.PKG_PATH }}
           if-no-files-found: error
           retention-days: 7
 
@@ -945,11 +991,14 @@ jobs:
           persist-credentials: false
 
       - name: Download .pkg artifacts from portable builder
-        # The portable builder uploads as "pfBlockerNG-release-pkgs"; each artifact
-        # already has -FreeBSD-<major> in the filename (renamed before upload).
+        # Each build-pkgs-portable leg uploads its OWN artifact, named
+        # pfBlockerNG-relpkg-<variant_lc>-<pfsense_version>-<arch> (issue #1662);
+        # merge every leg's artifact into pkgs/ (each holds exactly one .pkg,
+        # already carrying -FreeBSD-<major> in the filename).
         uses: actions/download-artifact@v4
         with:
-          name: pfBlockerNG-release-pkgs
+          pattern: pfBlockerNG-relpkg-*
+          merge-multiple: true
           path: pkgs/
         continue-on-error: true
 
@@ -994,8 +1043,11 @@ jobs:
   publish-release:
     name: Health-check + publish the draft Release
     runs-on: ubuntu-latest
-    needs: [prepare-release, release, attach-pkgs, read-matrix]
-    if: always() && needs.release.result == 'success' && needs.attach-pkgs.result == 'success' && needs.read-matrix.result == 'success' && needs.release.outputs.dry_run == 'false'
+    needs: [prepare-release, release, attach-pkgs, read-matrix, ui-suite, smoke-suite]
+    # ADR-14 D1 / issue #1662: the publish flip waits on EVERY live gate
+    # (ui-suite AND smoke-suite) — a flaky leg re-runs in isolation without
+    # redoing the publish (gate publish-release, never release/attach-pkgs).
+    if: always() && needs.release.result == 'success' && needs.attach-pkgs.result == 'success' && needs.read-matrix.result == 'success' && needs.ui-suite.result == 'success' && needs.smoke-suite.result == 'success' && needs.release.outputs.dry_run == 'false'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -466,8 +466,9 @@ jobs:
   # Checks out the SAME ref as build-pkgs-portable so that `created` (epoch of the
   # tagged commit) and `commit` (the tagged SHA) are stamped from the right tree.
   # AMENDMENT 2: must NOT compute these in read-matrix (different checkout ref) or
-  # inline in build-pkgs-portable (the loop already calls build-leg.sh, can't also
-  # run git commands in a clean way per-entry). One job, one checkout, two outputs.
+  # inline in build-pkgs-portable (its matrix legs share ONE checkout per job via
+  # strategy.matrix, each running build-leg.sh once -- there's no loop to hang a
+  # git command off of). One job, one checkout, two outputs.
   resolve-stamp:
     name: Resolve build stamp (created + commit)
     runs-on: ubuntu-latest
@@ -879,9 +880,13 @@ jobs:
         id: leg
         # Variant slug == the pkg repo's catalog dir name (build-repo-portable.py
         # catalog_name_from_version): "<variant_lc>-<major.minor>", e.g. ce-2.8 /
-        # plus-26.03. The Release encodes it in the per-leg ARTIFACT NAME (issue
-        # #1662 exact-artifact contract) and the .pkg FILENAME; the pkg repo
-        # encodes the same identity as the FOLDER release/<varslug>/<arch>/.
+        # plus-26.03. VARSLUG (major.minor-truncated) drives the .pkg FILENAME and
+        # the catalog path; it stays untouched. ARTSLUG (issue #1662 M1) is the
+        # SAME lower(variant) but keyed on the FULL pfsense_version (no cut) and
+        # is used ONLY for the per-leg ARTIFACT NAME below -- both consumer sides
+        # (ui-tests.yml/smoke.yml) format their download name from the full
+        # matrix.pfsense_version, so a future 3-component version (e.g. 2.8.1)
+        # would otherwise truncate on the producer side only and 404 the download.
         env:
           VARIANT: ${{ matrix.variant }}
           CHANNEL_FALLBACK: ${{ matrix.channel }}
@@ -892,7 +897,9 @@ jobs:
           set -eu
           V="${VARIANT:-${CHANNEL_FALLBACK:-CE}}"
           MM=$(printf '%s' "$PFV" | cut -d. -f1-2)
-          VARSLUG="$(printf '%s' "$V" | tr '[:upper:]' '[:lower:]')-${MM}"
+          V_LC="$(printf '%s' "$V" | tr '[:upper:]' '[:lower:]')"
+          VARSLUG="${V_LC}-${MM}"
+          ARTSLUG="${V_LC}-${PFV}"
           ABI="FreeBSD:${MAJOR}:${ARCH}"
           # AMENDMENT 7: slug this leg from VARSLUG + major + arch so it lands in
           # a distinct RUN_ID-keyed out dir. Colons in ABI are path-unsafe; the
@@ -900,6 +907,7 @@ jobs:
           LEG="${VARSLUG}-${MAJOR}-${ARCH}"
           {
             echo "varslug=${VARSLUG}"
+            echo "artslug=${ARTSLUG}"
             echo "abi=${ABI}"
             echo "leg=${LEG}"
           } >> "$GITHUB_OUTPUT"
@@ -957,12 +965,16 @@ jobs:
         # Name MUST equal pfBlockerNG-relpkg-<variant_lc>-<pfsense_version>-<arch>
         # -- the EXACT name ui-tests.yml's/smoke.yml's pkg_artifact_prefix download
         # step composes when pkg_artifact_prefix: pfBlockerNG-relpkg is set (see
-        # ui-suite/smoke-suite below). Upload only on success: fail-fast: false
-        # already isolates a failed leg, so it simply uploads nothing and
-        # attach-pkgs/the publish healthcheck fail closed on the missing asset.
+        # ui-suite/smoke-suite below). Uses ARTSLUG (full pfsense_version, issue
+        # #1662 M1), NOT VARSLUG (major.minor-truncated) -- the consumer sides
+        # format the full matrix.pfsense_version into the name, so this must match
+        # byte-for-byte even once a 3-component version ships. Upload only on
+        # success: fail-fast: false already isolates a failed leg, so it simply
+        # uploads nothing and attach-pkgs/the publish healthcheck fail closed on
+        # the missing asset.
         uses: actions/upload-artifact@v7
         with:
-          name: pfBlockerNG-relpkg-${{ steps.leg.outputs.varslug }}-${{ matrix.arch }}
+          name: pfBlockerNG-relpkg-${{ steps.leg.outputs.artslug }}-${{ matrix.arch }}
           path: ${{ env.PKG_PATH }}
           if-no-files-found: error
           retention-days: 7
@@ -972,14 +984,15 @@ jobs:
   # skip missing downloads), renames each to embed the FreeBSD major for
   # unambiguity, and appends them to the already-published GitHub Release.
   #
-  # DEPENDENCY EDGES — WHY sync-ports-fork IS INTACT:
-  #   sync-ports-fork needs: [prepare-release, release]        ← never needs build-pkgs
-  #   attach-pkgs needs: [prepare-release, release, build-pkgs] ← waits for both, if: always()
+  # DEPENDENCY EDGES: sync-ports-fork needs [prepare-release, release, publish-release]
+  # and gates on publish-release succeeding (see build-pkgs-portable's header comment
+  # above, "A leg's build failure...", for the full transitive chain from a
+  # build-pkgs-portable leg failure through to sync-ports-fork skipping). attach-pkgs
+  # here needs [prepare-release, release, build-pkgs-portable, read-matrix] with
+  # if: always(), so it runs regardless of a build-pkgs-portable failure.
   #
-  # A build-pkgs failure makes attach-pkgs skip that leg's artifact but
-  # attach the rest (or skip entirely if release also failed). sync-ports-fork is
-  # completely unblocked by any build outcome — it runs as soon as `release`
-  # succeeds, in parallel with attach-pkgs.
+  # A build-pkgs-portable failure makes attach-pkgs skip that leg's artifact but
+  # attach the rest (or skip entirely if release also failed).
   attach-pkgs:
     name: Attach .pkg artifacts to Release
     runs-on: ubuntu-latest
@@ -1028,9 +1041,10 @@ jobs:
             exit 0
           fi
 
-          # Recurse: the portable builder uploads under out/major-<N>/, so the
-          # artifact downloads to pkgs/out/major-<N>/*.pkg (nested) — a flat
-          # pkgs/*.pkg glob would match nothing. Mirror the find above.
+          # Recurse: each build-pkgs-portable leg uploads its own single-file
+          # artifact, and merge-multiple downloads them all flat under pkgs/ --
+          # a non-recursive pkgs/*.pkg glob would already find them, but find
+          # -type f is used here (and above) to stay robust either way.
           find pkgs -type f -name "*.pkg" -print0 | while IFS= read -r -d '' f; do
             echo "Uploading: $(basename "$f")"
             gh release upload "$TAG" "$f" --clobber
@@ -1087,6 +1101,7 @@ jobs:
 
           FAIL=0
           [ "$SRC_COUNT" -ge 1 ] || { echo "::error::no source archive (.tar.gz) attached to the draft"; FAIL=1; }
+          [ "$EXPECTED_PKGS" -ge 1 ] || { echo "::error::build matrix is empty"; FAIL=1; }
           [ "$PKG_COUNT" -eq "$EXPECTED_PKGS" ] || { echo "::error::expected ${EXPECTED_PKGS} .pkg assets, found ${PKG_COUNT} — not publishing an incomplete release"; FAIL=1; }
           printf '%s' "$META" | jq -e '(.name // "") != "" and ((.body // "") | length) > 0' >/dev/null \
             || { echo "::error::release name or body is empty"; FAIL=1; }

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -90,6 +90,10 @@ on:
         description: "Number of parallel module shards per leg — CE and Plus alike (issues #797/#856) — for full-marker, un-filtered runs. Collapses to 1 when pytest_filter is set or pytest_marker != smoke. Clamped to the leg's test-module count."
         required: false
         default: "3"
+      pkg_artifact_prefix:
+        description: "Name prefix of prebuilt per-leg package artifacts (e.g. from release.yml); each leg downloads '<prefix>-<variant>-<version>-<arch>'. Empty = build internally (the build-pkg job runs as before)."
+        required: false
+        default: ""
   # Called by other workflows. A callee sees the CALLER's event_name, so scope
   # never auto-resolves to full here (issue #906): blank = impacted; a caller
   # that wants the full suite passes scope=full explicitly.
@@ -120,6 +124,11 @@ on:
         required: false
         type: string
         default: "3"
+      pkg_artifact_prefix:
+        description: "Name prefix of prebuilt per-leg package artifacts (e.g. from release.yml); each leg downloads '<prefix>-<variant>-<version>-<arch>'. Empty = build internally."
+        required: false
+        type: string
+        default: ""
   # Daily nightly run — scope=full: the whole marker on every ci:true leg (CE + Plus).
   schedule:
     - cron: "0 7 * * *"
@@ -227,7 +236,9 @@ jobs:
   build-pkg:
     name: build-pkg (${{ matrix.channel }} ${{ matrix.pfsense_version }})
     needs: prepare
-    if: needs.prepare.outputs.leg_count != '0'
+    # Skipped when the caller supplies pkg_artifact_prefix -- prebuilt per-leg
+    # artifacts (e.g. release.yml) replace this job's own build.
+    if: needs.prepare.outputs.leg_count != '0' && inputs.pkg_artifact_prefix == ''
     strategy:
       fail-fast: false
       matrix:
@@ -301,10 +312,16 @@ jobs:
       abi: FreeBSD:${{ matrix.freebsd_major }}:amd64
       php_version: ${{ matrix.php_version }}
       py_flavor: ${{ matrix.py_flavor }}
-      # The .pkg build-pkg already produced for this version leg (issue #857):
-      # identical to that job's artifact_name, so every shard of this leg finds
-      # the SAME shared artifact and downloads it instead of rebuilding.
-      pkg_artifact: pfBlockerNG-pkg-${{ matrix.image_name }}-${{ matrix.pfsense_version }}
+      # pkg_artifact_prefix set: the prebuilt per-leg artifact a caller (e.g.
+      # release.yml) already published, named '<prefix>-<variant>-<version>-<arch>'
+      # -- the SAME template ui-tests.yml's ui job downloads (both fan-outs
+      # consume one shared release build). image_name is only ever
+      # pfsense-ce/pfsense-plus today (ponytail: hardcoded 2-way ternary, not a
+      # generic prefix strip -- widen if a 3rd variant ships).
+      # Blank: the .pkg build-pkg already produced for this version leg (issue
+      # #857) -- identical to that job's artifact_name, so every shard of this
+      # leg finds the SAME shared artifact and downloads it instead of rebuilding.
+      pkg_artifact: ${{ inputs.pkg_artifact_prefix != '' && format('{0}-{1}-{2}-{3}', inputs.pkg_artifact_prefix, (matrix.image_name == 'pfsense-plus' && 'plus' || 'ce'), matrix.pfsense_version, matrix.arch) || format('pfBlockerNG-pkg-{0}-{1}', matrix.image_name, matrix.pfsense_version) }}
       # Resolved by the prepare step: the marker, and the effective -k (an explicit
       # input, else the impacted auto-derivation, else blank = whole marker).
       pytest_marker: ${{ needs.prepare.outputs.pytest_marker || 'smoke' }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -648,6 +648,12 @@ jobs:
             exit 1
           fi
 
+          # From here PREPARE_RESULT=='success' is guaranteed, so RUN_GATE is only
+          # ever the literal true/false prepare emits and LEG_COUNT only ever a jq
+          # integer -- a garbage RUN_GATE or non-numeric LEG_COUNT below is
+          # unreachable in practice, defensive-only, mirroring all-smoke-passed's
+          # tolerant catch-all (`*)` arm).
+
           # The nightly no-commit guard legitimately skips the whole run (an
           # idle scheduled night) -- that is a PASS, not a gate failure: the
           # prepare/ui jobs never ran anything on purpose.

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -291,7 +291,7 @@ jobs:
     # Skip the whole leg set when the nightly guard says there's nothing to run.
     if: needs.prepare.outputs.run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     strategy:
       # One leg's failure must NOT cancel the others — each (tier x version) is

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -101,6 +101,11 @@ on:
         required: false
         type: string
         default: ""
+      pkg_artifact_prefix:
+        description: "Name prefix of prebuilt per-leg package artifacts (e.g. from release.yml); each leg downloads '<prefix>-<variant>-<version>-<arch>'. Empty = build internally (the build-pkg job runs as before)."
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       image_ref:
@@ -141,6 +146,10 @@ on:
         description: "FreeBSD-ports branch (blank = build-pkg-linux default pfblockerng/use-github)."
         required: false
         default: ""
+      pkg_artifact_prefix:
+        description: "Name prefix of prebuilt per-leg package artifacts (e.g. from release.yml); each leg downloads '<prefix>-<variant>-<version>-<arch>'. Empty = build internally."
+        required: false
+        default: ""
   # Daily run: Tier A render + Tier B (functional + browser). Non-PR-blocking
   # by construction.
   # The `prepare` job guards it to SKIP when there were no commits in the last
@@ -168,7 +177,9 @@ jobs:
   # dispatch/call run `prepare` always emits run=true, so the build runs.
   build-pkg:
     needs: prepare
-    if: needs.prepare.outputs.run == 'true'
+    # Skipped when the caller supplies pkg_artifact_prefix -- prebuilt per-leg
+    # artifacts (e.g. release.yml) replace this job's own build.
+    if: needs.prepare.outputs.run == 'true' && inputs.pkg_artifact_prefix == ''
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.build_matrix) }}
@@ -199,6 +210,8 @@ jobs:
       build_matrix: ${{ steps.gen.outputs.build_matrix }}
       run: ${{ steps.gen.outputs.run }}
       pytest_filter: ${{ steps.gen.outputs.pytest_filter }}
+      scope: ${{ steps.gen.outputs.scope }}
+      leg_count: ${{ steps.gen.outputs.leg_count }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -281,15 +294,27 @@ jobs:
             '($tiers | split(" ")) as $ts
              | [ $ts[] as $t | .[]
                  | {tier: $t, version: .pfsense_version, variant: (.image_name | ltrimstr("pfsense-")),
-                    image_name: .image_name, channel: .channel} ]')"
+                    image_name: .image_name, channel: .channel, arch: .arch} ]')"
           printf 'matrix={"include":%s}\n' "$INCLUDE" >> "$GITHUB_OUTPUT"
+          # leg_count = the (tier x leg) matrix size, for the all-ui-passed AND
+          # gate's zero-leg guard (distinct from $LEGS' own leg count -- one
+          # leg fans out to len(TIERS) matrix entries).
+          printf 'leg_count=%s\n' "$(printf '%s' "$INCLUDE" | jq 'length')" >> "$GITHUB_OUTPUT"
           echo "tiers=[${TIERS}] legs=$(printf '%s' "$LEGS" | jq 'length') run=${RUN}"
 
   ui:
     name: ${{ matrix.tier }} / ${{ matrix.variant }}-${{ matrix.version }} (live pfSense VM)
     needs: [build-pkg, prepare]
-    # Skip the whole leg set when the nightly guard says there's nothing to run.
-    if: needs.prepare.outputs.run == 'true'
+    # !cancelled() (not the implicit success() `needs` would impose) so a
+    # cancelled/skipped build-pkg still lets a prefix-driven run through;
+    # prepare must have genuinely succeeded (a failed prepare yields no matrix
+    # to fromJSON); the nightly guard gates on run=='true'; build-pkg's result
+    # only matters when it actually ran (pkg_artifact_prefix empty) -- with a
+    # prefix set it is skipped by design and that is fine.
+    if: >-
+      !cancelled() && needs.prepare.result == 'success' &&
+      needs.prepare.outputs.run == 'true' &&
+      (inputs.pkg_artifact_prefix != '' || needs.build-pkg.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -437,9 +462,13 @@ jobs:
       - name: Download the built pfBlockerNG package
         uses: actions/download-artifact@v8
         with:
-          # The per-version artifact built for THIS leg's ABI (build-pkg is matrixed
-          # by version; this leg installs the package matching its own pfSense base).
-          name: pfBlockerNG-pkg-${{ matrix.version }}
+          # pkg_artifact_prefix set: download the prebuilt per-leg artifact a
+          # caller (e.g. release.yml) already published, named
+          # '<prefix>-<variant>-<version>-<arch>' (e.g. myprefix-ce-2.8-amd64).
+          # Blank: the per-version artifact THIS run's build-pkg job just built
+          # (matrix is by version; this leg installs the package matching its
+          # own pfSense base).
+          name: ${{ inputs.pkg_artifact_prefix != '' && format('{0}-{1}-{2}-{3}', inputs.pkg_artifact_prefix, matrix.variant, matrix.version, matrix.arch) || format('pfBlockerNG-pkg-{0}', matrix.version) }}
           path: pkg
 
       - name: Locate the .pkg + the pulled .qcow2
@@ -506,6 +535,11 @@ jobs:
           # Resolved by the prepare step: an explicit -k input, else the impacted
           # auto-derivation (UI tests changed vs origin/devel), else blank = whole tier.
           PYTEST_FILTER: ${{ needs.prepare.outputs.pytest_filter }}
+          # impacted | full -- gates whether an empty-selection exit 5 below is a
+          # benign no-op (a narrowed run legitimately has nothing to select) or a
+          # real failure (a full, unfiltered run finding literally zero tests for
+          # this tier's marker means the marker/tier wiring itself is broken).
+          SCOPE: ${{ needs.prepare.outputs.scope }}
           MARKER: ${{ steps.tier.outputs.marker }}
         run: |
           set -eu
@@ -518,13 +552,19 @@ jobs:
           [ -n "${PYTEST_FILTER:-}" ] && set -- "$@" --filter "${PYTEST_FILTER}"
           rc=0
           sh scripts/run-smoke.sh "$@" || rc=$?
-          # pytest exit 5 = the impacted/-k selection contains no test carrying
-          # this tier's marker — an empty (valid) selection, not a failure. An
-          # impacted dispatch whose changed modules hold only e2e tests would
-          # otherwise fail every browser-tier leg on "no tests ran".
+          # pytest exit 5 = no test carried this tier's marker under the
+          # requested selection. That is benign ONLY for a SELECTIVE run: a
+          # narrowed -k or an impacted-scope leg (whose changed modules may
+          # legitimately hold only e.g. e2e tests) can validly select nothing
+          # for this tier. A full-scope, unfiltered run selecting zero tests
+          # means the tier/marker wiring itself is broken -- stays a failure.
           if [ "$rc" -eq 5 ]; then
-            echo "No tests selected for marker ${MARKER} under this scope/filter — empty selection, success."
-            rc=0
+            if [ -n "${PYTEST_FILTER:-}" ] || [ "${SCOPE:-}" = "impacted" ]; then
+              echo "No tests selected for marker ${MARKER} under this scope/filter — empty selection, success."
+              rc=0
+            else
+              echo "::error::pytest exit 5 (no tests collected) for marker ${MARKER} on a full-scope, unfiltered run — treating as a failure."
+            fi
           fi
           exit "$rc"
 
@@ -570,3 +610,66 @@ jobs:
             smoke-diag/**
           if-no-files-found: ignore
           retention-days: 7
+
+  # ── AND-gate: green only if EVERY (tier x leg) UI job passed ────────────────
+  #
+  # Mirrors smoke.yml's all-smoke-passed, plus one extra pass-arm: the nightly
+  # no-commit guard (prepare.outputs.run) legitimately skips the WHOLE run on
+  # an idle scheduled night -- that must read as a pass (nothing was supposed
+  # to run), not a gate failure. When run=='true' the same AND-gate semantics
+  # as all-smoke-passed apply: needs.ui.result == 'success' is the only pass.
+  all-ui-passed:
+    name: All UI legs passed (AND gate)
+    runs-on: ubuntu-latest
+    needs: [prepare, ui]
+    if: always()   # run even if ui failed/skipped/cancelled, or prepare declined the run
+    steps:
+      - name: Assert every UI leg passed
+        env:
+          UI_RESULT: ${{ needs.ui.result }}
+          RUN_GATE: ${{ needs.prepare.outputs.run }}
+          LEG_COUNT: ${{ needs.prepare.outputs.leg_count }}
+        run: |
+          set -eu
+          echo "Nightly run gate    : ${RUN_GATE}"
+          echo "UI matrix result    : ${UI_RESULT}"
+          echo "UI matrix leg count : ${LEG_COUNT}"
+          echo ""
+
+          # The nightly no-commit guard legitimately skips the whole run (an
+          # idle scheduled night) -- that is a PASS, not a gate failure: the
+          # prepare/ui jobs never ran anything on purpose.
+          if [ "${RUN_GATE}" != "true" ]; then
+            echo "run gate declined (scheduled idle) — pass"
+            exit 0
+          fi
+
+          # Zero/empty-leg guard: run=='true' with no legs means the matrix
+          # itself broke -- fail closed rather than silently skip.
+          if [ -z "${LEG_COUNT:-}" ] || [ "${LEG_COUNT}" -eq 0 ]; then
+            echo "::error::AND gate FAIL — UI matrix was empty (leg_count=${LEG_COUNT:-<empty>}) despite run=true."
+            exit 1
+          fi
+
+          # Main gate: the ui job result must be 'success'.
+          case "$UI_RESULT" in
+            success)
+              echo "AND gate PASS — all ${LEG_COUNT} UI leg(s) succeeded."
+              ;;
+            failure)
+              echo "::error::AND gate FAIL — one or more UI legs failed (result='failure')."
+              exit 1
+              ;;
+            skipped)
+              echo "::error::AND gate FAIL — ui job was skipped despite leg_count=${LEG_COUNT}."
+              exit 1
+              ;;
+            cancelled)
+              echo "::error::AND gate FAIL — ui job was cancelled; result is indeterminate."
+              exit 1
+              ;;
+            *)
+              echo "::error::AND gate FAIL — unexpected ui result '${UI_RESULT}'."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -627,14 +627,26 @@ jobs:
       - name: Assert every UI leg passed
         env:
           UI_RESULT: ${{ needs.ui.result }}
+          PREPARE_RESULT: ${{ needs.prepare.result }}
           RUN_GATE: ${{ needs.prepare.outputs.run }}
           LEG_COUNT: ${{ needs.prepare.outputs.leg_count }}
         run: |
           set -eu
+          echo "Prepare job result  : ${PREPARE_RESULT}"
           echo "Nightly run gate    : ${RUN_GATE}"
           echo "UI matrix result    : ${UI_RESULT}"
           echo "UI matrix leg count : ${LEG_COUNT}"
           echo ""
+
+          # Fail-closed FIRST (issue #1662 finding): if prepare itself did not
+          # genuinely succeed (crashed/cancelled/skipped), RUN_GATE is unset/empty
+          # -- the RUN_GATE check below would then read that as "scheduled idle,
+          # pass" even though nothing ran because prepare blew up, not because it
+          # declined the run on purpose. Must run BEFORE the RUN_GATE branch.
+          if [ "${PREPARE_RESULT}" != "success" ]; then
+            echo "::error::AND gate FAIL — prepare job did not succeed (result='${PREPARE_RESULT}')."
+            exit 1
+          fi
 
           # The nightly no-commit guard legitimately skips the whole run (an
           # idle scheduled night) -- that is a PASS, not a gate failure: the

--- a/tests/test_release_dry_run_gate.py
+++ b/tests/test_release_dry_run_gate.py
@@ -281,6 +281,16 @@ GUARD_VARS = ("INPUT_DRY", "DRY_RUN")
 _CASE_LINE_RE = re.compile(r'^([ \t]*)case "\$([A-Za-z_][A-Za-z0-9_]*)" in[ \t]*$')
 _TRUE_FALSE_ARM_RE = re.compile(r"^[ \t]*true\|false\)")
 
+# Two known blind spots in the shape match above, both accepted: (1) a braced
+# case subject, `case "${VAR}" in`, is invisible to _CASE_LINE_RE (only the
+# bare `$VAR` form is matched); (2) a guard born with an already-widened first
+# arm, e.g. `TRUE|true|false)`, is invisible to _TRUE_FALSE_ARM_RE (anchored on
+# `true|false)` starting the arm). Accepted because there is no live instance
+# of either shape in this workflow, the shop's shell style sticks to bare
+# `$VAR` + a plain `true|false)` first arm, and the GUARD_VARS floor below
+# still catches a shape-blind miss on either KNOWN guard -- it only misses a
+# brand-new guard written from the start in one of these two shapes.
+
 
 def _discover_guard_blocks(workflow_text: str) -> list[tuple[str, str]]:
     """Find every dry-run boolean guard by SHAPE, not by a fixed var-name list.

--- a/tests/test_release_dry_run_gate.py
+++ b/tests/test_release_dry_run_gate.py
@@ -95,6 +95,82 @@ def test_mutation_jobs_exist_in_the_workflow() -> None:
     assert not missing, f"expected job(s) not found in release.yml: {missing}"
 
 
+# Jobs that are safe to run unmodified in dry-run mode: never skipped by mode, never
+# gate a step on `dry_run == 'false'`. Some are dry-run-AWARE (they read dry_run to
+# pick which git ref to check out) without being dry-run-GATED -- that distinction is
+# what the assertion below checks, not textual absence of the string "dry_run".
+DRY_RUN_SAFE_JOBS = frozenset(
+    {
+        "read-matrix",  # reads the build matrix from repo state; no external effect
+        "resolve-stamp",  # dry-run-AWARE checkout-ref pick (tag vs dispatch ref); unconditional
+        "build-pkgs-portable",  # same dry-run-aware checkout-ref pick; builds only, unconditional
+        "ui-suite",  # runs the browser UI test suite against a built artifact
+        "smoke-suite",  # runs the live-VM smoke suite against a built artifact
+    }
+)
+
+# A job-level `if:` sits at 4-space indent directly under the job key (2-space indent);
+# a step-level `if:` sits deeper, inside a step body. Distinguishing the two is exactly
+# what tells a mode-aware-but-unconditional job (safe) apart from a mode-gated one (not).
+_JOB_LEVEL_IF_DRY_RUN_RE = re.compile(r"^ {4}if:.*dry_run")
+_STEP_IF_FALSE_RE = re.compile(r"if:.*dry_run\s*==\s*'false'")
+
+
+def _job_level_if_references_dry_run(job_lines: list[str]) -> bool:
+    """True if the JOB ITSELF can be skipped based on dry_run (unsafe for DRY_RUN_SAFE_JOBS)."""
+    return any(_JOB_LEVEL_IF_DRY_RUN_RE.match(line) for line in job_lines)
+
+
+def _has_step_level_false_gate(job_lines: list[str]) -> bool:
+    """True if any STEP inside the job is gated on `if: ... dry_run == 'false' ...`.
+
+    A `ref: ${{ dry_run == 'false' && tag || github.ref }}` line is a mode-aware value
+    pick, not a gate -- it does not start with `if:`, so it is deliberately not matched.
+    """
+    return any(_STEP_IF_FALSE_RE.search(line) for step in _split_into_steps(job_lines) for line in step)
+
+
+def test_every_job_is_classified_for_dry_run() -> None:
+    """Every top-level job must be in exactly one of MUTATION_JOBS / DRY_RUN_SAFE_JOBS.
+
+    Closes the other half of the #1661 gap: a brand-new job that mutates something but
+    was never added to MUTATION_JOBS (or a safe job that quietly becomes mode-gated) is
+    invisible to every other test in this file, since they all iterate MUTATION_JOBS
+    rather than scanning the workflow's actual job list. This test is the one that scans
+    the job list itself.
+    """
+    jobs = _parsed_jobs()
+    all_jobs = set(jobs.keys())
+    classified = MUTATION_JOBS | DRY_RUN_SAFE_JOBS
+
+    unclassified = all_jobs - classified
+    assert not unclassified, (
+        f"job(s) not classified into MUTATION_JOBS or DRY_RUN_SAFE_JOBS -- add each to "
+        f"whichever set matches (with a WHY comment for a safe job): {unclassified}"
+    )
+    stale = classified - all_jobs
+    assert not stale, f"classified job(s) no longer exist in release.yml: {stale}"
+
+    mode_gated_safe_jobs = {
+        job
+        for job in DRY_RUN_SAFE_JOBS
+        if _job_level_if_references_dry_run(jobs[job]) or _has_step_level_false_gate(jobs[job])
+    }
+    assert not mode_gated_safe_jobs, (
+        f"job(s) classified dry-run-safe but can be skipped or step-gated by dry_run -- "
+        f"reclassify as a mutation job: {mode_gated_safe_jobs}"
+    )
+
+    unpinned_mutation_jobs = {
+        job
+        for job in MUTATION_JOBS
+        if not any(_POSITIVE_FALSE_RE.search(line) for line in _dry_run_expressions(jobs[job]))
+    }
+    assert not unpinned_mutation_jobs, (
+        f"mutation job(s) not gated on an explicit dry_run == 'false': {unpinned_mutation_jobs}"
+    )
+
+
 def test_no_fail_open_dry_run_gate_anywhere() -> None:
     """No job or step condition may use the fail-open `dry_run != 'true'` shape.
 
@@ -119,6 +195,12 @@ def test_every_mutation_job_gates_on_dry_run() -> None:
     assert not missing, f"mutation job(s) with no dry_run reference at all: {missing}"
 
 
+# Shared by test_every_mutation_job_gates_on_an_explicit_false and
+# test_every_job_is_classified_for_dry_run -- both pin the same "positive == 'false'"
+# literal, so it lives once here rather than being redefined per test.
+_POSITIVE_FALSE_RE = re.compile(r"dry_run\s*==\s*'false'")
+
+
 def test_every_mutation_job_gates_on_an_explicit_false() -> None:
     """Each mutation job must carry a positive `dry_run == 'false'` comparison.
 
@@ -126,10 +208,11 @@ def test_every_mutation_job_gates_on_an_explicit_false() -> None:
     every DRY RUN publish -- the mirror of the bug this file exists for -- while still
     referencing dry_run, so the previous test cannot see it.
     """
-    positive = re.compile(r"dry_run\s*==\s*'false'")
     jobs = _parsed_jobs()
     unpinned = {
-        job for job in MUTATION_JOBS if not any(positive.search(line) for line in _dry_run_expressions(jobs[job]))
+        job
+        for job in MUTATION_JOBS
+        if not any(_POSITIVE_FALSE_RE.search(line) for line in _dry_run_expressions(jobs[job]))
     }
     assert not unpinned, f"mutation job(s) not gated on an explicit == 'false': {unpinned}"
 
@@ -191,32 +274,58 @@ def test_metadata_step_rejects_non_boolean_dry_run() -> None:
 
 
 # The pre-tag guard blocks case variants before mutation; the metadata guard
-# protects downstream outputs. Both shipped guards must execute.
+# protects downstream outputs. Both shipped guards must execute -- kept only as a
+# sanity floor for discovery below, not as the enumeration mechanism.
 GUARD_VARS = ("INPUT_DRY", "DRY_RUN")
+
+_CASE_LINE_RE = re.compile(r'^([ \t]*)case "\$([A-Za-z_][A-Za-z0-9_]*)" in[ \t]*$')
+_TRUE_FALSE_ARM_RE = re.compile(r"^[ \t]*true\|false\)")
+
+
+def _discover_guard_blocks(workflow_text: str) -> list[tuple[str, str]]:
+    """Find every dry-run boolean guard by SHAPE, not by a fixed var-name list.
+
+    A guard is any `case "$VAR" in` block whose first arm is exactly `true|false)`
+    -- that structural shape is what makes it a dry-run guard, regardless of what
+    VAR is called, so a third, differently-named guard added later is discovered
+    automatically instead of silently skipped. An optional `VAR="..."` assignment
+    line immediately above the case line is folded in (carries default-fallback
+    logic, e.g. `DRY_RUN="${INPUT_DRY:-true}"`), matching what the guard actually
+    executes in the workflow.
+    """
+    lines = workflow_text.splitlines()
+    blocks: list[tuple[str, str]] = []
+    for idx, line in enumerate(lines):
+        header = _CASE_LINE_RE.match(line)
+        if header is None:
+            continue
+        indent, var = header.group(1), header.group(2)
+        if idx + 1 >= len(lines) or not _TRUE_FALSE_ARM_RE.match(lines[idx + 1]):
+            continue  # not a boolean dry-run guard shape (e.g. the $BODY case blocks)
+        esac_idx = next(
+            (j for j in range(idx + 1, len(lines)) if re.match(rf"^{re.escape(indent)}esac[ \t]*$", lines[j])),
+            None,
+        )
+        assert esac_idx is not None, f"unterminated case block for ${var} starting at line {idx + 1}"
+        block_lines = lines[idx : esac_idx + 1]
+        if idx > 0 and re.match(rf'^[ \t]*{re.escape(var)}="[^"\n]*"$', lines[idx - 1]):
+            block_lines = [lines[idx - 1], *block_lines]
+        blocks.append((var, "\n".join(block_lines)))
+    return blocks
 
 
 def _guard_scripts() -> list[str]:
-    """Every guard, lifted from the workflow verbatim.
-
-    For the metadata guard the slice starts at its `DRY_RUN=` assignment, so the
-    default-fallback ships INTO the test. Reconstructing that line here instead would
-    shadow the one piece of logic that decides what an omitted input means.
-    """
+    """Every guard, lifted from the workflow verbatim, discovered structurally."""
     workflow_text = WORKFLOW.read_text(encoding="utf-8")
-    scripts = [
-        textwrap.dedent(match.group(1))
-        for var in GUARD_VARS
-        for match in [
-            re.search(
-                rf'((?:^[ \t]*{var}="[^"\n]*"\n)?[ \t]*case "\${var}" in\n.*?\n[ \t]*esac)',
-                workflow_text,
-                re.DOTALL | re.MULTILINE,
-            )
-        ]
-        if match is not None
-    ]
-    assert len(scripts) == len(GUARD_VARS), f"expected a case/esac guard per {GUARD_VARS}, found {len(scripts)}"
-    return scripts
+    blocks = _discover_guard_blocks(workflow_text)
+    discovered_vars = {var for var, _ in blocks}
+    assert len(blocks) >= len(GUARD_VARS), (
+        f"expected at least {len(GUARD_VARS)} dry-run guard(s) (one per {GUARD_VARS}), found {len(blocks)}"
+    )
+    assert set(GUARD_VARS) <= discovered_vars, (
+        f"expected known guards {GUARD_VARS} among discovered vars {discovered_vars}"
+    )
+    return [textwrap.dedent(script) for _, script in blocks]
 
 
 def _run_guard(value: str) -> list[tuple[int, str]]:

--- a/tests/test_smoke_ui_config_digest.py
+++ b/tests/test_smoke_ui_config_digest.py
@@ -22,11 +22,15 @@ run 28900064099. ``tests.smoke.helpers`` is import-safe off-VM (precedent:
 from __future__ import annotations
 
 import hashlib
+import re
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import pytest
 
 from tests.smoke import helpers
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 @dataclass
@@ -340,4 +344,30 @@ def test_restore_php_eval_failure_raises_and_skips_apply_filter_sync(
         helpers.restore_pfb_config_baseline(vm, snapshot_path=_SNAPSHOT_PATH)  # type: ignore[arg-type]
     assert apply_filter_sync_calls == [], (
         f"apply_filter_sync must not run after a failed php_eval, got calls={apply_filter_sync_calls!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# ui-tests.yml `ui` job budget (issue #1689: two sampled cancellations at
+# 30m18s/30m19s on the functional/plus-26.03 live-VM leg; identical commit
+# passed on rerun in 20m04s). Pins the budget high enough to cover the
+# observed leg, matching smoke-single.yml's live-VM precedent (45).
+# --------------------------------------------------------------------------- #
+
+
+def test_ui_job_budget_covers_live_vm_leg() -> None:
+    """The `ui` job's ``timeout-minutes`` must be >= 45 -- the live-VM budget
+    smoke-single.yml already uses -- so a slow-but-healthy leg (setup alone ran
+    ~23 of the observed 20m04s pass) isn't cancelled mid-run."""
+    workflow = (_REPO_ROOT / ".github/workflows/ui-tests.yml").read_text(encoding="utf-8")
+    ui_job = workflow.split("\n  ui:\n", 1)[1]
+    match = re.search(r"^\s*timeout-minutes:\s*(\S+)\s*$", ui_job, re.MULTILINE)
+    assert match, f"expected a timeout-minutes key under the `ui` job, found none in:\n{ui_job[:200]}"
+
+    raw = match.group(1)
+    assert re.fullmatch(r"-?\d+", raw), f"expected an int timeout-minutes value, got {raw!r} (YAML wiring bug)"
+    budget = int(raw)
+
+    assert budget >= 45, (
+        f"expected the `ui` job's timeout-minutes >= 45 (smoke-single.yml's live-VM budget), got {budget}"
     )

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -1,11 +1,15 @@
-"""Pin the reusable-workflow half of issue #1662: ui-tests.yml + smoke.yml must be able to
-consume prebuilt exact-release .pkg artifacts (via a `pkg_artifact_prefix` input) instead of
-always building their own, ui-tests.yml gets a fail-closed `all-ui-passed` AND gate (mirroring
-smoke.yml's `all-smoke-passed`), and the ui tier's pytest-exit-5 mapper stops silently passing
-a full, unfiltered run that selected zero tests.
+"""Pin issue #1662 end to end. Part 1 (reusable-workflow side): ui-tests.yml + smoke.yml
+must be able to consume prebuilt exact-release .pkg artifacts (via a `pkg_artifact_prefix`
+input) instead of always building their own, ui-tests.yml gets a fail-closed `all-ui-passed`
+AND gate (mirroring smoke.yml's `all-smoke-passed`) -- including the prepare-crash fail-closed
+fix -- and the ui tier's pytest-exit-5 mapper stops silently passing a full, unfiltered run
+that selected zero tests.
 
-release.yml itself (part 2 -- wiring the prefix in from a real release build) is a LATER
-change by someone else; this file only pins the reusable-workflow side.
+Part 2 (release.yml side): build-pkgs-portable matrix-ifies over the read-matrix build_matrix
+(one job per leg) and uploads one EXACT-named artifact per leg
+(`pfBlockerNG-relpkg-<variant_lc>-<pfsense_version>-<arch>`); attach-pkgs merges them by
+pattern; ui-suite/smoke-suite are re-enabled, consume those exact artifacts, and gate
+publish-release (never `release`/`attach-pkgs` -- ADR-14 D1).
 """
 
 from __future__ import annotations
@@ -21,6 +25,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 UI_WORKFLOW = ROOT / ".github/workflows/ui-tests.yml"
 SMOKE_WORKFLOW = ROOT / ".github/workflows/smoke.yml"
+RELEASE_WORKFLOW = ROOT / ".github/workflows/release.yml"
 
 _JOB_HEADER_RE = re.compile(r"^  ([A-Za-z][A-Za-z0-9_-]*):[ \t]*$")
 _STEP_HEADER_RE = re.compile(r"^      - ")
@@ -207,13 +212,18 @@ def _all_ui_passed_script() -> str:
     return _step_run_script(steps[0])
 
 
-def _run_all_ui_passed(run_gate: str, leg_count: str, ui_result: str) -> subprocess.CompletedProcess[str]:
+def _run_all_ui_passed(
+    run_gate: str, leg_count: str, ui_result: str, prepare_result: str = "success"
+) -> subprocess.CompletedProcess[str]:
     script = _all_ui_passed_script()
     env = {
         "PATH": os.environ.get("PATH", ""),
         "RUN_GATE": run_gate,
         "LEG_COUNT": leg_count,
         "UI_RESULT": ui_result,
+        # Existing rows below don't pass this explicitly -- they all mean a
+        # genuinely-succeeded prepare job, so the default carries that.
+        "PREPARE_RESULT": prepare_result,
     }
     return subprocess.run(  # noqa: S603
         ["sh", "-c", script],
@@ -240,6 +250,27 @@ def test_all_ui_passed_zero_legs_with_run_true_fails() -> None:
 def test_all_ui_passed_empty_leg_count_with_run_true_fails() -> None:
     completed = _run_all_ui_passed(run_gate="true", leg_count="", ui_result="success")
     assert completed.returncode != 0, completed.stdout + completed.stderr
+
+
+# --------------------------------------------------------------------------- #
+# prepare-crash fail-closed FINDING (issue #1662): a prepare job that did NOT
+# genuinely succeed must fail the gate even though a crash leaves RUN_GATE
+# empty -- the old RUN_GATE-first check read that as "scheduled idle, pass".
+# Checked BEFORE the RUN_GATE branch, so it wins regardless of RUN_GATE.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("prepare_result", ["failure", "cancelled", "skipped"])
+def test_all_ui_passed_prepare_not_success_fails_closed_even_with_empty_run_gate(prepare_result: str) -> None:
+    completed = _run_all_ui_passed(run_gate="", leg_count="", ui_result="skipped", prepare_result=prepare_result)
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+
+
+def test_all_ui_passed_prepare_success_with_run_gate_false_still_passes() -> None:
+    """A genuinely-succeeded prepare that legitimately declined the run (nightly
+    no-commit guard) stays a pass -- the fix must not touch this existing case."""
+    completed = _run_all_ui_passed(run_gate="false", leg_count="", ui_result="skipped", prepare_result="success")
+    assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
 @pytest.mark.parametrize(
@@ -328,3 +359,155 @@ def test_non_five_failure_rc_stays_unmapped(tmp_path: Path) -> None:
 def test_success_rc_stays_zero(tmp_path: Path) -> None:
     completed = _run_exit5_mapper(tmp_path, run_smoke_rc=0, pytest_filter="", scope="full")
     assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+# =========================================================================== #
+# release.yml (part 2): per-leg artifacts, live-gate wiring, publish gating
+# =========================================================================== #
+
+
+# --------------------------------------------------------------------------- #
+# build-pkgs-portable: matrix-ified over read-matrix's build_matrix
+# --------------------------------------------------------------------------- #
+
+
+def test_build_pkgs_portable_matrixes_over_read_matrix_build_matrix() -> None:
+    jobs = _jobs(RELEASE_WORKFLOW)
+    assert "build-pkgs-portable" in jobs
+    job_text = "\n".join(jobs["build-pkgs-portable"])
+    assert "strategy:" in job_text, "build-pkgs-portable must gain a strategy.matrix"
+    assert "fail-fast: false" in job_text
+    assert "fromJson(needs.read-matrix.outputs.build_matrix)" in job_text, (
+        f"build-pkgs-portable must matrix over read-matrix's build_matrix output, got:\n{job_text}"
+    )
+
+
+def test_build_pkgs_portable_per_leg_upload_name_is_the_exact_contract() -> None:
+    jobs = _jobs(RELEASE_WORKFLOW)
+    steps = _split_into_steps(jobs["build-pkgs-portable"])
+    upload_steps = [s for s in steps if any("uses: actions/upload-artifact" in line for line in s)]
+    assert len(upload_steps) == 1, "expected exactly one upload-artifact step in build-pkgs-portable"
+    step_text = "\n".join(upload_steps[0])
+    name_line = next(line for line in upload_steps[0] if line.strip().startswith("name:"))
+    assert "pfBlockerNG-relpkg-" in name_line, f"per-leg upload name must start pfBlockerNG-relpkg-, got: {name_line}"
+    assert "varslug" in name_line and "matrix.arch" in name_line, (
+        f"per-leg upload name must be pfBlockerNG-relpkg-<varslug>-<matrix.arch>, got: {name_line}"
+    )
+    # varslug computation: lowercase(variant) + '-' + pfsense_version.
+    assert "tr '[:upper:]' '[:lower:]'" in step_text or "tr '[:upper:]' '[:lower:]'" in "\n".join(
+        jobs["build-pkgs-portable"]
+    ), "varslug must lowercase the variant"
+
+
+def test_build_pkgs_portable_varslug_derives_from_pfsense_version() -> None:
+    job_text = "\n".join(_jobs(RELEASE_WORKFLOW)["build-pkgs-portable"])
+    assert "matrix.pfsense_version" in job_text
+
+
+# --------------------------------------------------------------------------- #
+# attach-pkgs: merges every per-leg artifact by pattern
+# --------------------------------------------------------------------------- #
+
+
+def test_attach_pkgs_downloads_every_leg_by_pattern_with_merge() -> None:
+    jobs = _jobs(RELEASE_WORKFLOW)
+    steps = _split_into_steps(jobs["attach-pkgs"])
+    target = [s for s in steps if any("Download .pkg artifacts" in line for line in s)]
+    assert len(target) == 1, "expected exactly one 'Download .pkg artifacts' step in attach-pkgs"
+    step_text = "\n".join(target[0])
+    assert "pattern: pfBlockerNG-relpkg-*" in step_text, step_text
+    assert "merge-multiple: true" in step_text, step_text
+
+
+# --------------------------------------------------------------------------- #
+# ui-suite / smoke-suite: re-enabled, gated on build-pkgs-portable, exact prefix
+# --------------------------------------------------------------------------- #
+
+
+def test_ui_suite_is_no_longer_hard_disabled() -> None:
+    jobs = _jobs(RELEASE_WORKFLOW)
+    job_lines = jobs["ui-suite"]
+    if_line = next((line for line in job_lines if line.strip().startswith("if:")), None)
+    assert if_line is not None, "ui-suite must carry an if: condition gating it on the upstream jobs"
+    assert if_line.strip() != "if: false", f"ui-suite must no longer be hard-disabled, got: {if_line}"
+
+
+@pytest.mark.parametrize("job_name", ["ui-suite", "smoke-suite"])
+def test_suite_job_if_condition_shape(job_name: str) -> None:
+    jobs = _jobs(RELEASE_WORKFLOW)
+    assert job_name in jobs, f"release.yml must have a {job_name} job"
+    job_lines = jobs[job_name]
+    if_line = next((line for line in job_lines if line.strip().startswith("if:")), None)
+    assert if_line is not None, f"{job_name} must carry an if: condition"
+    assert "!cancelled()" in if_line
+    assert "needs.build-pkgs-portable.result == 'success'" in if_line
+
+
+@pytest.mark.parametrize("job_name", ["ui-suite", "smoke-suite"])
+def test_suite_job_needs_build_pkgs_portable(job_name: str) -> None:
+    jobs = _jobs(RELEASE_WORKFLOW)
+    needs_line = next(line for line in jobs[job_name] if line.strip().startswith("needs:"))
+    assert "build-pkgs-portable" in needs_line, f"{job_name} must need build-pkgs-portable, got: {needs_line}"
+
+
+@pytest.mark.parametrize("job_name", ["ui-suite", "smoke-suite"])
+def test_suite_job_carries_the_exact_pkg_artifact_prefix(job_name: str) -> None:
+    jobs = _jobs(RELEASE_WORKFLOW)
+    job_text = "\n".join(jobs[job_name])
+    assert "pkg_artifact_prefix: pfBlockerNG-relpkg" in job_text, (
+        f"{job_name} must pass the literal pkg_artifact_prefix: pfBlockerNG-relpkg, got:\n{job_text}"
+    )
+    assert "secrets: inherit" in job_text
+
+
+@pytest.mark.parametrize("job_name", ["ui-suite", "smoke-suite"])
+def test_suite_jobs_carry_no_dry_run_reference(job_name: str) -> None:
+    """ADR-14 D1 / dry-run parity: these run in BOTH modes, so they must reference
+    dry_run nowhere in their job body (they are deliberately kept OUT of the
+    MUTATION_JOBS set in test_release_dry_run_gate.py)."""
+    jobs = _jobs(RELEASE_WORKFLOW)
+    job_text = "\n".join(jobs[job_name])
+    assert "dry_run" not in job_text, f"{job_name} must carry NO dry_run reference, got:\n{job_text}"
+
+
+# --------------------------------------------------------------------------- #
+# publish-release: gated on BOTH suites, dry_run == 'false' retained
+# --------------------------------------------------------------------------- #
+
+
+def test_publish_release_needs_both_suites() -> None:
+    jobs = _jobs(RELEASE_WORKFLOW)
+    needs_line = next(line for line in jobs["publish-release"] if line.strip().startswith("needs:"))
+    assert "ui-suite" in needs_line and "smoke-suite" in needs_line, f"got: {needs_line}"
+
+
+def test_publish_release_if_gates_on_both_suite_results_and_retains_dry_run_false() -> None:
+    jobs = _jobs(RELEASE_WORKFLOW)
+    if_line = next(line for line in jobs["publish-release"] if line.strip().startswith("if:"))
+    assert "needs.ui-suite.result == 'success'" in if_line, if_line
+    assert "needs.smoke-suite.result == 'success'" in if_line, if_line
+    assert "dry_run == 'false'" in if_line, if_line
+
+
+# --------------------------------------------------------------------------- #
+# Cross-contract consistency: release-side naming == part-1 consumer-side naming
+# --------------------------------------------------------------------------- #
+
+
+def test_release_side_naming_matches_consumer_side_for_ce_2_8_amd64() -> None:
+    """Simulate both sides' naming formulas for (variant=CE, pfsense_version=2.8,
+    arch=amd64) and assert they land on the identical exact-artifact name that both
+    build-pkgs-portable (release.yml) and the ui/smoke download steps (part 1) use."""
+    variant, pfsense_version, arch = "CE", "2.8", "amd64"
+    prefix = "pfBlockerNG-relpkg"
+
+    # release-side (build-pkgs-portable): VARSLUG = lower(variant)-pfsense_version;
+    # artifact name = <prefix>-<varslug>-<arch>.
+    varslug = f"{variant.lower()}-{pfsense_version}"
+    release_side_name = f"{prefix}-{varslug}-{arch}"
+
+    # consumer-side (part 1's contract -- ui-tests.yml download step / smoke.yml
+    # pkg_artifact expression): format('{0}-{1}-{2}-{3}', prefix, variant_lc, version, arch).
+    consumer_side_name = "{0}-{1}-{2}-{3}".format(prefix, variant.lower(), pfsense_version, arch)
+
+    assert release_side_name == consumer_side_name == "pfBlockerNG-relpkg-ce-2.8-amd64"

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -1,0 +1,330 @@
+"""Pin the reusable-workflow half of issue #1662: ui-tests.yml + smoke.yml must be able to
+consume prebuilt exact-release .pkg artifacts (via a `pkg_artifact_prefix` input) instead of
+always building their own, ui-tests.yml gets a fail-closed `all-ui-passed` AND gate (mirroring
+smoke.yml's `all-smoke-passed`), and the ui tier's pytest-exit-5 mapper stops silently passing
+a full, unfiltered run that selected zero tests.
+
+release.yml itself (part 2 -- wiring the prefix in from a real release build) is a LATER
+change by someone else; this file only pins the reusable-workflow side.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_WORKFLOW = ROOT / ".github/workflows/ui-tests.yml"
+SMOKE_WORKFLOW = ROOT / ".github/workflows/smoke.yml"
+
+_JOB_HEADER_RE = re.compile(r"^  ([A-Za-z][A-Za-z0-9_-]*):[ \t]*$")
+_STEP_HEADER_RE = re.compile(r"^      - ")
+
+
+def _jobs_section_lines(workflow_text: str) -> list[str]:
+    lines = workflow_text.splitlines()
+    start = lines.index("jobs:") + 1
+    return lines[start:]
+
+
+def _split_into_jobs(lines: list[str]) -> dict[str, list[str]]:
+    """Group the (already `jobs:`-relative) lines under each top-level job name."""
+    jobs: dict[str, list[str]] = {}
+    current: str | None = None
+    buffer: list[str] = []
+    for line in lines:
+        match = _JOB_HEADER_RE.match(line)
+        if match is not None:
+            if current is not None:
+                jobs[current] = buffer
+            current = match.group(1)
+            buffer = []
+        elif current is not None:
+            buffer.append(line)
+    if current is not None:
+        jobs[current] = buffer
+    return jobs
+
+
+def _split_into_steps(job_lines: list[str]) -> list[list[str]]:
+    steps: list[list[str]] = []
+    for line in job_lines:
+        if _STEP_HEADER_RE.match(line):
+            steps.append([])
+        if steps:
+            steps[-1].append(line)
+    return steps
+
+
+def _jobs(workflow: Path) -> dict[str, list[str]]:
+    return _split_into_jobs(_jobs_section_lines(workflow.read_text(encoding="utf-8")))
+
+
+def _trigger_blocks(workflow: Path) -> tuple[str, str]:
+    """Return (workflow_call inputs block, workflow_dispatch inputs block) as raw text,
+    each spanning from its own `inputs:` header to the next top-level (2-space) key."""
+    text = workflow.read_text(encoding="utf-8")
+    # Leading "\n" so the trigger split below (which requires a preceding
+    # newline) also matches the FIRST trigger key, not just later ones.
+    on_section = "\n" + text.split("\non:\n", 1)[1].split("\npermissions:\n", 1)[0]
+
+    def _block(trigger: str) -> str:
+        after = on_section.split(f"\n  {trigger}:\n", 1)[1]
+        # Ends at the next 2-space-indented key (another trigger, or the section end).
+        m = re.search(r"\n  [A-Za-z]", after)
+        return after[: m.start()] if m else after
+
+    return _block("workflow_call"), _block("workflow_dispatch")
+
+
+def _step_run_script(step_lines: list[str]) -> str:
+    """Verbatim `run: |` body of a single step, dedented (test_release_dry_run_gate.py's
+    lift-verbatim-and-run-under-sh technique)."""
+    text = "\n".join(step_lines)
+    marker = "run: |\n"
+    idx = text.index(marker) + len(marker)
+    return textwrap.dedent(text[idx:])
+
+
+# --------------------------------------------------------------------------- #
+# pkg_artifact_prefix input: both trigger blocks, both workflows, default ''
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("workflow", [UI_WORKFLOW, SMOKE_WORKFLOW])
+def test_pkg_artifact_prefix_declared_in_both_trigger_blocks(workflow: Path) -> None:
+    call_block, dispatch_block = _trigger_blocks(workflow)
+    for name, block in (("workflow_call", call_block), ("workflow_dispatch", dispatch_block)):
+        assert "pkg_artifact_prefix:" in block, f"{workflow.name}: {name} is missing pkg_artifact_prefix"
+        # the input's own sub-block (description/required/type/default) ends well
+        # within a generous slice; scan that for the default line.
+        sub = block.split("pkg_artifact_prefix:\n", 1)[1][:400]
+        assert re.search(r"^\s*default:\s*\"\"\s*$", sub, re.MULTILINE), (
+            f"{workflow.name}: {name}'s pkg_artifact_prefix must default to '' -- block was:\n{sub}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# build-pkg gates on the prefix being empty
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("workflow", [UI_WORKFLOW, SMOKE_WORKFLOW])
+def test_build_pkg_job_skips_when_prefix_supplied(workflow: Path) -> None:
+    jobs = _jobs(workflow)
+    assert "build-pkg" in jobs, f"{workflow.name}: no build-pkg job"
+    job_text = "\n".join(jobs["build-pkg"])
+    if_line = next((line for line in jobs["build-pkg"] if line.strip().startswith("if:")), None)
+    assert if_line is not None, f"{workflow.name}: build-pkg has no if: condition\n{job_text}"
+    assert "inputs.pkg_artifact_prefix == ''" in if_line, (
+        f"{workflow.name}: build-pkg's if: must gate on inputs.pkg_artifact_prefix == '', got: {if_line}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# ui download-name / smoke pkg_artifact expressions thread the prefix
+# --------------------------------------------------------------------------- #
+
+
+def test_ui_download_step_uses_the_prefix_when_set() -> None:
+    jobs = _jobs(UI_WORKFLOW)
+    steps = _split_into_steps(jobs["ui"])
+    target = [s for s in steps if any("Download the built pfBlockerNG package" in line for line in s)]
+    assert len(target) == 1, "ui job must have exactly one 'Download the built pfBlockerNG package' step"
+    step_text = "\n".join(target[0])
+    assert (
+        "format('{0}-{1}-{2}-{3}', inputs.pkg_artifact_prefix, matrix.variant, matrix.version, matrix.arch)"
+        in step_text
+    ), f"ui download step must build the prefixed artifact name from prefix/variant/version/arch, got:\n{step_text}"
+    assert "inputs.pkg_artifact_prefix != ''" in step_text
+    assert "format('pfBlockerNG-pkg-{0}', matrix.version)" in step_text, (
+        "the blank-prefix fallback must stay byte-identical to the pre-#1662 literal name"
+    )
+
+
+def test_smoke_job_threads_the_prefix_into_pkg_artifact() -> None:
+    jobs = _jobs(SMOKE_WORKFLOW)
+    job_text = "\n".join(jobs["smoke"])
+    assert "pkg_artifact:" in job_text
+    pkg_artifact_line = next(line for line in jobs["smoke"] if "pkg_artifact:" in line and "with" not in line)
+    assert "inputs.pkg_artifact_prefix != ''" in pkg_artifact_line, (
+        f"smoke job's pkg_artifact: must branch on inputs.pkg_artifact_prefix, got: {pkg_artifact_line}"
+    )
+    assert "inputs.pkg_artifact_prefix" in pkg_artifact_line and "matrix.pfsense_version" in pkg_artifact_line
+    assert "format('pfBlockerNG-pkg-{0}-{1}', matrix.image_name, matrix.pfsense_version)" in pkg_artifact_line, (
+        "the blank-prefix fallback must stay byte-identical to the pre-#1662 literal name"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# ui job if-condition: !cancelled() + prepare success, tolerates skipped build-pkg
+# --------------------------------------------------------------------------- #
+
+
+def test_ui_job_if_condition_shape() -> None:
+    jobs = _jobs(UI_WORKFLOW)
+    job_text = "\n".join(jobs["ui"])
+    # The if: may be a folded multi-line block (`if: >-`); grab up to the `runs-on:` line.
+    if_block = job_text.split("if:", 1)[1].split("\n    runs-on:", 1)[0]
+    assert "!cancelled()" in if_block
+    assert "needs.prepare.result == 'success'" in if_block
+    assert "needs.prepare.outputs.run == 'true'" in if_block
+    assert "inputs.pkg_artifact_prefix != ''" in if_block
+    assert "needs.build-pkg.result == 'success'" in if_block
+
+
+# --------------------------------------------------------------------------- #
+# all-ui-passed: exists, needs [prepare, ui], if always()
+# --------------------------------------------------------------------------- #
+
+
+def test_all_ui_passed_job_exists_and_is_wired() -> None:
+    jobs = _jobs(UI_WORKFLOW)
+    assert "all-ui-passed" in jobs, "ui-tests.yml must gain a terminal all-ui-passed AND gate"
+    job_lines = jobs["all-ui-passed"]
+    job_text = "\n".join(job_lines)
+    needs_line = next(line for line in job_lines if line.strip().startswith("needs:"))
+    assert "prepare" in needs_line and "ui" in needs_line, f"all-ui-passed must need [prepare, ui], got: {needs_line}"
+    if_line = next(line for line in job_lines if line.strip().startswith("if:"))
+    assert "always()" in if_line, f"all-ui-passed must run unconditionally (if: always()), got: {if_line}"
+    assert "runs-on:" in job_text
+
+
+# --------------------------------------------------------------------------- #
+# all-ui-passed run script: lifted verbatim, executed under sh, truth table
+# --------------------------------------------------------------------------- #
+
+
+def _all_ui_passed_script() -> str:
+    jobs = _jobs(UI_WORKFLOW)
+    steps = _split_into_steps(jobs["all-ui-passed"])
+    assert len(steps) == 1, "expected exactly one step in all-ui-passed"
+    return _step_run_script(steps[0])
+
+
+def _run_all_ui_passed(run_gate: str, leg_count: str, ui_result: str) -> subprocess.CompletedProcess[str]:
+    script = _all_ui_passed_script()
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "RUN_GATE": run_gate,
+        "LEG_COUNT": leg_count,
+        "UI_RESULT": ui_result,
+    }
+    return subprocess.run(  # noqa: S603
+        ["sh", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("leg_count", ["0", "", "5"])
+@pytest.mark.parametrize("ui_result", ["success", "failure", "skipped", "cancelled", "garbage"])
+def test_all_ui_passed_run_gate_declined_always_passes(leg_count: str, ui_result: str) -> None:
+    """run != 'true' (the nightly no-commit guard skipped the whole run) is a PASS
+    regardless of leg_count/ui_result -- nothing was supposed to run."""
+    completed = _run_all_ui_passed(run_gate="false", leg_count=leg_count, ui_result=ui_result)
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_all_ui_passed_zero_legs_with_run_true_fails() -> None:
+    completed = _run_all_ui_passed(run_gate="true", leg_count="0", ui_result="success")
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+
+
+def test_all_ui_passed_empty_leg_count_with_run_true_fails() -> None:
+    completed = _run_all_ui_passed(run_gate="true", leg_count="", ui_result="success")
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.parametrize(
+    ("ui_result", "expect_pass"),
+    [
+        ("success", True),
+        ("failure", False),
+        ("skipped", False),
+        ("cancelled", False),
+        ("garbage", False),
+    ],
+)
+def test_all_ui_passed_result_case(ui_result: str, expect_pass: bool) -> None:
+    completed = _run_all_ui_passed(run_gate="true", leg_count="5", ui_result=ui_result)
+    if expect_pass:
+        assert completed.returncode == 0, completed.stdout + completed.stderr
+    else:
+        assert completed.returncode != 0, completed.stdout + completed.stderr
+
+
+# --------------------------------------------------------------------------- #
+# exit-5 mapper: lifted verbatim, run-smoke.sh stubbed, truth table
+# --------------------------------------------------------------------------- #
+
+
+def _exit5_mapper_script() -> str:
+    jobs = _jobs(UI_WORKFLOW)
+    steps = _split_into_steps(jobs["ui"])
+    target = [s for s in steps if any("sh scripts/run-smoke.sh" in line for line in s)]
+    assert len(target) == 1, "expected exactly one step invoking scripts/run-smoke.sh"
+    return _step_run_script(target[0])
+
+
+def _run_exit5_mapper(
+    tmp_path: Path, run_smoke_rc: int, pytest_filter: str, scope: str
+) -> subprocess.CompletedProcess[str]:
+    script = _exit5_mapper_script()
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir(exist_ok=True)
+    run_smoke = scripts_dir / "run-smoke.sh"
+    run_smoke.write_text(f"#!/bin/sh\nexit {run_smoke_rc}\n")
+    run_smoke.chmod(0o755)
+    select_box = scripts_dir / "select-box.sh"
+    select_box.write_text("#!/bin/sh\necho stub-run-id\n")
+    select_box.chmod(0o755)
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "PYTEST_FILTER": pytest_filter,
+        "SCOPE": scope,
+        "MARKER": "ui_render",
+    }
+    return subprocess.run(  # noqa: S603
+        ["sh", "-c", script],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_exit5_full_scope_no_filter_stays_a_failure(tmp_path: Path) -> None:
+    completed = _run_exit5_mapper(tmp_path, run_smoke_rc=5, pytest_filter="", scope="full")
+    assert completed.returncode == 5, completed.stdout + completed.stderr
+
+
+def test_exit5_with_a_pytest_filter_is_benign(tmp_path: Path) -> None:
+    completed = _run_exit5_mapper(tmp_path, run_smoke_rc=5, pytest_filter="test_foo", scope="full")
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_exit5_impacted_scope_is_benign(tmp_path: Path) -> None:
+    completed = _run_exit5_mapper(tmp_path, run_smoke_rc=5, pytest_filter="", scope="impacted")
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_exit5_impacted_scope_with_filter_is_also_benign(tmp_path: Path) -> None:
+    completed = _run_exit5_mapper(tmp_path, run_smoke_rc=5, pytest_filter="test_foo", scope="impacted")
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_non_five_failure_rc_stays_unmapped(tmp_path: Path) -> None:
+    completed = _run_exit5_mapper(tmp_path, run_smoke_rc=1, pytest_filter="", scope="full")
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+
+
+def test_success_rc_stays_zero(tmp_path: Path) -> None:
+    completed = _run_exit5_mapper(tmp_path, run_smoke_rc=0, pytest_filter="", scope="full")
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -14,6 +14,7 @@ publish-release (never `release`/`attach-pkgs` -- ADR-14 D1).
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -390,10 +391,13 @@ def test_build_pkgs_portable_per_leg_upload_name_is_the_exact_contract() -> None
     step_text = "\n".join(upload_steps[0])
     name_line = next(line for line in upload_steps[0] if line.strip().startswith("name:"))
     assert "pfBlockerNG-relpkg-" in name_line, f"per-leg upload name must start pfBlockerNG-relpkg-, got: {name_line}"
-    assert "varslug" in name_line and "matrix.arch" in name_line, (
-        f"per-leg upload name must be pfBlockerNG-relpkg-<varslug>-<matrix.arch>, got: {name_line}"
+    # issue #1662 M1: the artifact NAME keys off artslug (full pfsense_version), not
+    # varslug (major.minor-truncated, reserved for the .pkg FILENAME/catalog path) --
+    # see test_release_side_artifact_name_matches_both_consumer_sides below for why.
+    assert "artslug" in name_line and "matrix.arch" in name_line, (
+        f"per-leg upload name must be pfBlockerNG-relpkg-<artslug>-<matrix.arch>, got: {name_line}"
     )
-    # varslug computation: lowercase(variant) + '-' + pfsense_version.
+    # variant-lowercasing (shared by varslug and artslug):
     assert "tr '[:upper:]' '[:lower:]'" in step_text or "tr '[:upper:]' '[:lower:]'" in "\n".join(
         jobs["build-pkgs-portable"]
     ), "varslug must lowercase the variant"
@@ -512,23 +516,277 @@ def test_publish_release_if_gates_on_both_suite_results_and_retains_dry_run_fals
 
 # --------------------------------------------------------------------------- #
 # Cross-contract consistency: release-side naming == part-1 consumer-side naming
+#
+# Issue #1662 B1: the old version of this test built BOTH "sides" as Python
+# literals in the test body (a tautology -- it could never fail on a workflow
+# mutation) and never modelled the producer's real `cut -d. -f1-2` truncation.
+# This replaces it with a test that LIFTS the leg-naming step's `run:` body
+# straight out of release.yml and executes it under sh for every row of the real
+# build matrix plus one synthetic 3-component-version row, comparing the emitted
+# artifact name against the consumer-side format(...) templates parsed out of the
+# real ui-tests.yml / smoke.yml text.
 # --------------------------------------------------------------------------- #
 
 
-def test_release_side_naming_matches_consumer_side_for_ce_2_8_amd64() -> None:
-    """Simulate both sides' naming formulas for (variant=CE, pfsense_version=2.8,
-    arch=amd64) and assert they land on the identical exact-artifact name that both
-    build-pkgs-portable (release.yml) and the ui/smoke download steps (part 1) use."""
-    variant, pfsense_version, arch = "CE", "2.8", "amd64"
-    prefix = "pfBlockerNG-relpkg"
+def _upload_artifact_name_line() -> str:
+    jobs = _jobs(RELEASE_WORKFLOW)
+    steps = _split_into_steps(jobs["build-pkgs-portable"])
+    upload_steps = [s for s in steps if any("uses: actions/upload-artifact" in line for line in s)]
+    assert len(upload_steps) == 1, "expected exactly one upload-artifact step in build-pkgs-portable"
+    return next(line for line in upload_steps[0] if line.strip().startswith("name:"))
 
-    # release-side (build-pkgs-portable): VARSLUG = lower(variant)-pfsense_version;
-    # artifact name = <prefix>-<varslug>-<arch>.
-    varslug = f"{variant.lower()}-{pfsense_version}"
-    release_side_name = f"{prefix}-{varslug}-{arch}"
 
-    # consumer-side (part 1's contract -- ui-tests.yml download step / smoke.yml
-    # pkg_artifact expression): format('{0}-{1}-{2}-{3}', prefix, variant_lc, version, arch).
-    consumer_side_name = "{0}-{1}-{2}-{3}".format(prefix, variant.lower(), pfsense_version, arch)
+_UPLOAD_NAME_FIELD_RE = re.compile(r"steps\.leg\.outputs\.(\w+)")
 
-    assert release_side_name == consumer_side_name == "pfBlockerNG-relpkg-ce-2.8-amd64"
+
+def _upload_artifact_name_output_field() -> str:
+    """Which `steps.leg.outputs.<field>` the upload-artifact `name:` references --
+    read from the file, not assumed, so this test tracks whichever field the
+    producer actually uses (varslug pre-fix, artslug post-fix)."""
+    name_line = _upload_artifact_name_line()
+    m = _UPLOAD_NAME_FIELD_RE.search(name_line)
+    assert m is not None, f"upload-artifact name: must reference steps.leg.outputs.<field>, got: {name_line}"
+    return m.group(1)
+
+
+def test_build_pkgs_portable_upload_name_references_artslug_output() -> None:
+    """Structural pin (issue #1662 M1): the per-leg upload-artifact `name:` must key
+    off the FULL-pfsense_version artslug output, not the major.minor-truncated
+    varslug -- the consumer sides (ui-tests.yml/smoke.yml) format the full
+    matrix.pfsense_version into their download name, so a 3-component version would
+    otherwise silently desync the producer name from what they request."""
+    assert _upload_artifact_name_output_field() == "artslug", (
+        f"upload-artifact name: must reference steps.leg.outputs.artslug, got: {_upload_artifact_name_line()}"
+    )
+
+
+def _leg_step() -> list[str]:
+    jobs = _jobs(RELEASE_WORKFLOW)
+    steps = _split_into_steps(jobs["build-pkgs-portable"])
+    target = [s for s in steps if any("Compute this leg's VARSLUG/ABI" in line for line in s)]
+    assert len(target) == 1, 'expected exactly one "Compute this leg\'s VARSLUG/ABI" step'
+    return target[0]
+
+
+def _run_leg_step(tmp_path: Path, variant: str, pfsense_version: str, freebsd_major: str, arch: str) -> dict[str, str]:
+    """Execute the REAL leg-naming step's `run:` body (lifted verbatim) under sh,
+    with a real $GITHUB_OUTPUT file, and return the parsed step outputs."""
+    script = _step_run_script(_leg_step())
+    output_file = tmp_path / f"github_output_{variant}_{pfsense_version}_{arch}".replace(".", "_")
+    output_file.write_text("")
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "VARIANT": variant,
+        "CHANNEL_FALLBACK": variant,
+        "PFV": pfsense_version,
+        "MAJOR": freebsd_major,
+        "ARCH": arch,
+        "GITHUB_OUTPUT": str(output_file),
+    }
+    completed = subprocess.run(  # noqa: S603
+        ["sh", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    outputs: dict[str, str] = {}
+    for line in output_file.read_text().splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            outputs[key] = value
+    return outputs
+
+
+def _extract_first_format_call(text: str) -> tuple[str, list[str]]:
+    """Parse the FIRST `format('tmpl', arg, arg, ...)` GH-expression call out of
+    `text` (balanced-paren scan -- ui-tests.yml's download name: line has a SECOND
+    format(...) call in its blank-prefix fallback branch, so a naive regex greedy
+    match would swallow both). Returns (template, [arg-expr, ...])."""
+    start = text.index("format(") + len("format(")
+    depth = 1
+    i = start
+    while depth > 0:
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+        i += 1
+    inner = text[start : i - 1]
+    m = re.match(r"'([^']*)'\s*,\s*(.*)$", inner, re.DOTALL)
+    assert m is not None, f"cannot parse format(...) call args: {inner!r}"
+    template = m.group(1)
+    args = [a.strip() for a in m.group(2).split(",")]
+    return template, args
+
+
+def _resolve_matrix_arg(expr: str, row: dict[str, str]) -> str:
+    """Resolve one GH-expression argument -- as parsed out of the real
+    ui-tests.yml/smoke.yml text -- to the string it evaluates to for `row`."""
+    if expr == "inputs.pkg_artifact_prefix":
+        return "pfBlockerNG-relpkg"
+    if expr == "matrix.variant":
+        return row["variant"].lower()
+    if expr in ("matrix.version", "matrix.pfsense_version"):
+        return row["pfsense_version"]
+    if expr == "matrix.arch":
+        return row["arch"]
+    ternary = re.match(r"\(matrix\.image_name == '([^']*)' && '([^']*)' \|\| '([^']*)'\)$", expr)
+    if ternary is not None:
+        plus_image_name, when_true, when_false = ternary.groups()
+        image_name = "pfsense-" + row["variant"].lower()
+        return when_true if image_name == plus_image_name else when_false
+    raise AssertionError(f"unrecognised matrix arg expression in a consumer-side format(...) call: {expr!r}")
+
+
+def _consumer_side_names(row: dict[str, str]) -> tuple[str, str]:
+    """(ui-tests.yml download name, smoke.yml pkg_artifact) for `row`, computed
+    from the format(...) templates parsed out of the REAL workflow text -- never
+    a hardcoded literal."""
+    ui_jobs = _jobs(UI_WORKFLOW)
+    ui_steps = _split_into_steps(ui_jobs["ui"])
+    dl_step = next(s for s in ui_steps if any("Download the built pfBlockerNG package" in line for line in s))
+    ui_name_line = next(line for line in dl_step if line.strip().startswith("name:"))
+    ui_template, ui_args = _extract_first_format_call(ui_name_line)
+    ui_name = ui_template.format(*(_resolve_matrix_arg(a, row) for a in ui_args))
+
+    smoke_jobs = _jobs(SMOKE_WORKFLOW)
+    pkg_artifact_line = next(line for line in smoke_jobs["smoke"] if "pkg_artifact:" in line and "with" not in line)
+    smoke_template, smoke_args = _extract_first_format_call(pkg_artifact_line)
+    smoke_name = smoke_template.format(*(_resolve_matrix_arg(a, row) for a in smoke_args))
+
+    return ui_name, smoke_name
+
+
+def _cross_contract_rows() -> list[dict[str, str]] | None:
+    """Real BUILD-matrix rows (read-version-matrix.sh --print-build -- reads the
+    already-fetched origin/ci-metadata ref, no network needed once it's present)
+    PLUS one synthetic 3-component-version row that exercises the truncation bug
+    directly. Returns None when the ref is unreachable in this environment
+    (mirrors tests/test_matrix_collision_guard.py's _load_build_matrix skip
+    contract) -- callers must skip, never fabricate rows."""
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["sh", "scripts/read-version-matrix.sh", "--print-build"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        matrix = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(matrix, list) or not matrix:
+        return None
+    rows = [
+        {
+            "variant": str(entry["variant"]),
+            "pfsense_version": str(entry["pfsense_version"]),
+            "freebsd_major": str(entry["freebsd_major"]),
+            "arch": str(entry["arch"]),
+        }
+        for entry in matrix
+    ]
+    # Synthetic row (issue #1662 M1): every REAL row today is 2-component
+    # (2.8, 26.03) so MM == pfsense_version and the truncation bug is invisible --
+    # this row is what makes it visible.
+    rows.append({"variant": "CE", "pfsense_version": "2.8.1", "freebsd_major": "15", "arch": "amd64"})
+    return rows
+
+
+def test_release_side_artifact_name_matches_both_consumer_sides(tmp_path: Path) -> None:
+    """For every real build-matrix row plus the synthetic 3-component-version row,
+    execute the REAL leg-naming step and assert the artifact name it emits equals
+    BOTH ui-tests.yml's download name AND smoke.yml's pkg_artifact -- computed from
+    the real format(...) templates in those files. Issue #1662 M1: this is RED
+    before the fix on the synthetic row (producer truncates to ce-2.8, both
+    consumers expect ce-2.8.1) and on every row if the upload step still points at
+    a field that never gets emitted."""
+    rows = _cross_contract_rows()
+    if rows is None:
+        pytest.skip("ci-metadata matrix not available in this environment -- skipping real-matrix rows")
+        return
+
+    field = _upload_artifact_name_output_field()
+    failures: list[str] = []
+    for row in rows:
+        outputs = _run_leg_step(tmp_path, row["variant"], row["pfsense_version"], row["freebsd_major"], row["arch"])
+        if field not in outputs:
+            failures.append(f"row {row}: leg step did not emit outputs.{field} (got {sorted(outputs)})")
+            continue
+        release_side_name = f"pfBlockerNG-relpkg-{outputs[field]}-{row['arch']}"
+        ui_name, smoke_name = _consumer_side_names(row)
+        if not (release_side_name == ui_name == smoke_name):
+            failures.append(f"row {row}: release={release_side_name!r} ui={ui_name!r} smoke={smoke_name!r}")
+    assert not failures, "producer/consumer artifact-name mismatch:\n" + "\n".join(failures)
+
+
+# --------------------------------------------------------------------------- #
+# publish-release healthcheck: EXPECTED_PKGS floor (issue #1662 I1)
+# --------------------------------------------------------------------------- #
+
+
+def _healthcheck_script() -> str:
+    jobs = _jobs(RELEASE_WORKFLOW)
+    steps = _split_into_steps(jobs["publish-release"])
+    target = [s for s in steps if any("Health-check the draft release is complete" in line for line in s)]
+    assert len(target) == 1, "expected exactly one 'Health-check the draft release is complete' step"
+    script = _step_run_script(target[0])
+    # This step (uniquely among the ones lifted in this file) inlines
+    # `${{ github.repository }}` directly in its run: body instead of routing it
+    # through the step's env: block, so GH Actions would normally template it away
+    # before the shell ever runs. Substitute a fixed value -- the gh stub below
+    # never inspects REPO, so this has no bearing on the logic under test.
+    return script.replace("${{ github.repository }}", "owner/repo")
+
+
+def _run_healthcheck(tmp_path: Path, build_matrix: str, assets_json: str) -> subprocess.CompletedProcess[str]:
+    script = _healthcheck_script()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    gh_stub = bin_dir / "gh"
+    gh_stub.write_text(
+        f'#!/bin/sh\necho \'{{"isDraft":true,"name":"Test Release","body":"body text","assets":{assets_json}}}\'\n'
+    )
+    gh_stub.chmod(0o755)
+    env = {
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+        "GH_TOKEN": "stub-token",
+        "TAG": "v0.0.0-test",
+        "BUILD_MATRIX": build_matrix,
+    }
+    return subprocess.run(  # noqa: S603
+        ["sh", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_healthcheck_empty_build_matrix_fails_closed(tmp_path: Path) -> None:
+    """Issue #1662 I1: an empty build matrix (EXPECTED_PKGS=0) must fail the
+    healthcheck, not sail through because PKG_COUNT (also 0 -- no .pkg assets on
+    the draft) happens to equal EXPECTED_PKGS."""
+    completed = _run_healthcheck(
+        tmp_path,
+        build_matrix="[]",
+        assets_json='[{"name":"pfBlockerNG-src.tar.gz"}]',
+    )
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+
+
+def test_healthcheck_nonempty_matrix_with_matching_pkgs_still_passes(tmp_path: Path) -> None:
+    """The new floor must not disturb the healthy path: a non-empty matrix whose
+    .pkg count matches the draft's still passes."""
+    completed = _run_healthcheck(
+        tmp_path,
+        build_matrix='[{"variant":"CE","pfsense_version":"2.8"}]',
+        assets_json='[{"name":"pfBlockerNG-src.tar.gz"},{"name":"pfBlockerNG-relpkg-ce-2.8-amd64.pkg"}]',
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -461,6 +461,27 @@ def test_suite_job_carries_the_exact_pkg_artifact_prefix(job_name: str) -> None:
 
 
 @pytest.mark.parametrize("job_name", ["ui-suite", "smoke-suite"])
+def test_suite_job_pins_scope_full(job_name: str) -> None:
+    """A silent `scope: full` -> `scope: impacted` regression would quietly
+    narrow release qualification to a selective run -- where the ui job's
+    exit-5 mapper (see test_exit5_impacted_scope_is_benign above) treats a
+    zero-selected-tests run as a PASS instead of a failure. Pinning scope
+    here is what makes that exit-5 tolerance safe."""
+    jobs = _jobs(RELEASE_WORKFLOW)
+    job_text = "\n".join(jobs[job_name])
+    assert "scope: full" in job_text, f"{job_name} must pin scope: full, got:\n{job_text}"
+
+
+def test_ui_suite_pins_tier_all() -> None:
+    """A silently-dropped `tier: all` would narrow the release-gating UI
+    fan-out to a subset of CI legs -- same silent-scope-narrowing risk
+    scope: full guards against above."""
+    jobs = _jobs(RELEASE_WORKFLOW)
+    job_text = "\n".join(jobs["ui-suite"])
+    assert "tier: all" in job_text, f"ui-suite must pin tier: all, got:\n{job_text}"
+
+
+@pytest.mark.parametrize("job_name", ["ui-suite", "smoke-suite"])
 def test_suite_jobs_carry_no_dry_run_reference(job_name: str) -> None:
     """ADR-14 D1 / dry-run parity: these run in BOTH modes, so they must reference
     dry_run nowhere in their job body (they are deliberately kept OUT of the


### PR DESCRIPTION
Three correlated CI/release-pipeline issues from the v4.0.0 milestone, one commit per issue (six commits — #1662 spans the reusable-workflow half and the release.yml half).

Fixes #1689. Fixes #1662. Fixes #1661.

## Commit 1 — `ci: raise the ui matrix job budget to 45 minutes` (#1689)

The smallest fix the observations support: the `functional / plus-26.03` live-VM leg intermittently exhausted the 30-minute job cap (two sampled cancellations at ~30m18s; the identical commit passed on rerun in 20m04s with ~23 minutes of setup). 45 matches `smoke-single.yml`'s live-VM precedent. Red-first regression test pins `timeout-minutes >= 45` on the `ui` job. Cancellation stays fail-closed; no sharding/caching/retries added.

## Commits 2+3 — release qualification on the exact artifacts (#1662)

**Reusable-workflow half:** `ui-tests.yml` and `smoke.yml` gain a `pkg_artifact_prefix` input (default `''` — existing callers unchanged). When set, the internal package build is skipped and each leg downloads the prebuilt artifact `<PREFIX>-<variant>-<pfsense_version>-<arch>` — so the suites test the exact bytes a release would publish, never a rebuilt or hard-coded devel package. `ui-tests.yml` also gains the previously-missing fail-closed `all-ui-passed` aggregate (structural mirror of `all-smoke-passed`: empty matrix, failure, skipped, cancelled, and unknown results all fail; the only pass-arm besides success requires the prepare job to have SUCCEEDED and legitimately declined the run — a crashed prepare fails closed), and the unconditional pytest-exit-5→0 mapping is narrowed to selective invocations only: a full-scope run that selects zero tests now fails.

**Release half:** `build-pkgs-portable` is matrix-ified (`fail-fast: false`) with one artifact per leg; `attach-pkgs` consumes them by pattern; the hard-disabled `ui-suite` is re-enabled and a sibling `smoke-suite` added, both consuming the per-leg artifacts via the prefix; `publish-release` now additionally requires `ui-suite` and `smoke-suite` success. The irreversible boundary stays `publish-release` (draft creation and resume behavior untouched, per ADR-14 D1: a flaky leg re-runs in isolation without redoing the publish). Both suites carry no `dry_run` gate, so a dry-run exercises build → smoke → UI → aggregates and stops before every mutation — same qualification path, no publication.

## Commit 4 — self-maintaining dry_run guard coverage (#1661)

Closes the remaining gap from the PR #1698 round: the executed-guard enumeration is now structural discovery (any `case "$VAR" in` block with a `true|false)` first arm — a third, differently-named guard is auto-discovered and truth-tabled; minimum-count floor keeps non-discovery loud), and a new classification test partitions every release.yml job into `MUTATION_JOBS` (must carry the literal `dry_run == 'false'`) or `DRY_RUN_SAFE_JOBS` (must be un-skippable and un-step-gated by mode; the unconditional checkout-ref ternary in `resolve-stamp`/`build-pkgs-portable` is mode-aware but not a gate). A brand-new job in neither set fails the suite naming itself. Known low-severity gap (verifier finding, no live instance): a `${VAR}`-braced case subject would not be discovered; this workflow's shell style uses bare `$VAR` throughout.

## Evidence

Every commit red-first or mutation-proven, independently verifier-gated (re-executed red proofs, lifted-script truth tables run under `sh`, two mutation probes re-executed per gate). `actionlint` clean on all edited workflows (the two pre-existing SC2129 style notes in `prepare-release` predate this PR; the PR removes the old `if: false` constant-condition finding). The remaining #1661/#1662 acceptance row — an actual dry-run dispatch of this exact pipeline — is being dispatched from this branch; dry-run executed: run 30241771524 — pipeline mechanics validated end to end (exact artifacts resolved on both consumers, zero mutations, aggregates fail-closed); its three test failures are pre-existing devel regressions #1768/#1769/#1770 (discriminated via plain-devel probes, see the triage comment). Review rounds added commits 5 (nitpick batch) and 6 (executed cross-contract pin, artslug/varslug decouple, healthcheck empty-matrix floor).

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release publishing now includes live UI and smoke test gates.
  * Portable package builds run in parallel, with uniquely named artifacts collected automatically.
  * UI and smoke workflows can use prebuilt package artifacts.
* **Bug Fixes**
  * Full-scope test runs now correctly fail when no tests are collected.
  * Release health checks fail safely when expected packages are missing.
* **Tests**
  * Added comprehensive coverage for release gates, artifact naming, workflow wiring, and live-test safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->