### PR TITLE
pfblockerng: fix install-default grandfathers misfiring on the installer's own settings_family marker

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11473,9 +11473,16 @@ function pfb_dnsbl_lenient_migrate($dconfig) {
 // A fresh install has no prior section -> NULL (no write); the runtime default in
 // pfb_global() covers it. An existing value (including an explicit '' = off) is never
 // overwritten. Returns the updated config array to persist, or NULL when nothing changes.
+// issue #1770 follow-up: "prior section" is decided over pfb_gconfig_operator_view()
+// -- the installer seeds settings_family before pfb_run_migrations() runs on EVERY
+// install, so a marker-only section (General never saved) must read as empty, not
+// as pre-existing config; otherwise the very next upgrade run seeds pfb_keep, which
+// re-arms the #1770/#1771 install-default grandfathers. The mutated/returned
+// $gconfig keeps settings_family (only the emptiness decision uses the stripped
+// view), so the migration write-back never drops the marker.
 function pfb_keep_migrate($gconfig) {
 
-	if (!is_array($gconfig) || empty($gconfig)) {
+	if (!is_array($gconfig) || empty(pfb_gconfig_operator_view($gconfig))) {
 		return NULL;
 	}
 	if (isset($gconfig['pfb_keep'])) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1658,6 +1658,17 @@ function pfb_settings_family_record(string $family): bool
 	}
 }
 
+/**
+ * The operator's view of a config section: installer-seeded schema markers
+ * stripped, so "is this pre-existing operator configuration?" decisions
+ * (install-default grandfathers, migrations, seeds) never fire on the
+ * installer's own bookkeeping (issues #1770/#1771/#1775).
+ */
+function pfb_gconfig_operator_view(array $gconfig): array {
+	unset($gconfig['settings_family']);
+	return $gconfig;
+}
+
 function pfb_settings_downgrade_context_target(string $current_family): ?string
 {
 	if (!isset(PFB_SETTINGS_FAMILY_RANK[$current_family])) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -593,8 +593,8 @@ update_status(" Reverse DNS lookup default...");
 // marker so a marker-only section (General never saved -- genuine fresh install)
 // reads empty here too, same chokepoint as the #1770/#1771 grandfathers above.
 $pfb_rdns_seed = pfb_rdns_seed_value(
-	pfb_gconfig_operator_view(config_get_path('installedpackages/pfblockerng/config/0', [])),
-	config_get_path('installedpackages/pfblockerngipsettings/config/0', [])
+	pfb_gconfig_operator_view(PfbConfig::readSection('installedpackages/pfblockerng/config/0')),
+	PfbConfig::readSection('installedpackages/pfblockerngipsettings/config/0')
 );
 if ($pfb_rdns_seed !== null) {
 	config_set_path('installedpackages/pfblockerngipsettings/config/0/enable_rdns', $pfb_rdns_seed);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -654,7 +654,9 @@ $pfb_gcfg = PfbConfig::readSection('installedpackages/pfblockerng/config/0');
 // (pfb_settings_family_replace() seeds it before this read on every install),
 // not operator data -- computing "pre-existing config" over it turned the
 // fresh-install branch of both install-default grandfathers into dead code.
-unset($pfb_gcfg['settings_family']);
+// pfb_gconfig_operator_view() is the shared chokepoint for this decision
+// (also used by pfb_keep_migrate() and the rdns seed read below -- #1775).
+$pfb_gcfg = pfb_gconfig_operator_view($pfb_gcfg);
 $pfb_gcfg = empty($pfb_gcfg) ? NULL : $pfb_gcfg;
 $pfb_feed_default = pfb_feed_filter_install_default($pfb_gcfg);
 if ($pfb_feed_default !== null) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -650,6 +650,11 @@ if ($ufound) {
 // run-once decision is pfb_feed_filter_install_default() (NULL => leave unset => default
 // ON); the !isset guard there makes this idempotent across repeated installs/upgrades.
 $pfb_gcfg = PfbConfig::readSection('installedpackages/pfblockerng/config/0');
+// issue #1770/#1771: settings_family is the installer's own schema marker
+// (pfb_settings_family_replace() seeds it before this read on every install),
+// not operator data -- computing "pre-existing config" over it turned the
+// fresh-install branch of both install-default grandfathers into dead code.
+unset($pfb_gcfg['settings_family']);
 $pfb_gcfg = empty($pfb_gcfg) ? NULL : $pfb_gcfg;
 $pfb_feed_default = pfb_feed_filter_install_default($pfb_gcfg);
 if ($pfb_feed_default !== null) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -589,8 +589,11 @@ else {
 // Reverse DNS lookups (enable_rdns) default OFF for new installs; preserve the
 // historical always-on behaviour for existing installs with a one-time seed.
 update_status(" Reverse DNS lookup default...");
+// issue #1775: pfb_gconfig_operator_view() strips the installer's settings_family
+// marker so a marker-only section (General never saved -- genuine fresh install)
+// reads empty here too, same chokepoint as the #1770/#1771 grandfathers above.
 $pfb_rdns_seed = pfb_rdns_seed_value(
-	config_get_path('installedpackages/pfblockerng/config/0', []),
+	pfb_gconfig_operator_view(config_get_path('installedpackages/pfblockerng/config/0', [])),
 	config_get_path('installedpackages/pfblockerngipsettings/config/0', [])
 );
 if ($pfb_rdns_seed !== null) {

--- a/tests/php/InstallGrandfatherChokepointTest.php
+++ b/tests/php/InstallGrandfatherChokepointTest.php
@@ -126,4 +126,36 @@ final class InstallGrandfatherChokepointTest extends TestCase
 		);
 	}
 
+	// --- #1771: alias-apply mode ---------------------------------------------
+
+	public function testFreshInstallMarkerOnlySectionLeavesAliasDeltaModeKeyUnset(): void
+	{
+		$this->seedSection(['settings_family' => '4.0']);
+
+		$result = pfb_install_oracle_grandfather_region();
+
+		$this->assertNull(
+			$result['delta_default'],
+			'a marker-only section is a fresh install -- the alias-delta-mode key must stay unset (registry default auto)'
+		);
+		$this->assertNull(
+			config_get_path('installedpackages/pfblockerng/config/0/pfb_alias_delta_mode'),
+			'the chokepoint must not have written pfb_alias_delta_mode on a fresh install'
+		);
+	}
+
+	public function testGenuineUpgradeWithMarkerAndOperatorKeyStillPinsAliasDeltaModeToReplace(): void
+	{
+		// Before-state pin (ADR-40): a marker PLUS a genuine operator key is the
+		// true upgrade path and must still be grandfathered to 'replace'.
+		$this->seedSection(['settings_family' => '4.0', 'pfb_interval' => '4']);
+
+		$result = pfb_install_oracle_grandfather_region();
+
+		$this->assertSame('replace', $result['delta_default']);
+		$this->assertSame(
+			'replace',
+			config_get_path('installedpackages/pfblockerng/config/0/pfb_alias_delta_mode')
+		);
+	}
 }

--- a/tests/php/InstallGrandfatherChokepointTest.php
+++ b/tests/php/InstallGrandfatherChokepointTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Install-default grandfather chokepoint (issues #1770/#1771).
+ *
+ * pfblockerng_install.inc seeds 'settings_family' into
+ * installedpackages/pfblockerng/config/0 via pfb_settings_family_record()
+ * (~line 136) BEFORE the shared $pfb_gcfg read (~line 652) that both
+ * install-default grandfathers (pfb_feed_filter_install_default(),
+ * pfb_alias_delta_mode_install_default()) consume. Because the marker alone
+ * makes $pfb_gcfg non-empty, the "genuinely empty section = fresh install"
+ * branch was dead code on EVERY install, including a first-ever install on a
+ * virgin box -- the SSRF feed-filter guard shipped OFF (#1770) and aliases
+ * were grandfathered to the legacy 'replace' apply mode instead of ADR-40's
+ * 'auto' (#1771).
+ *
+ * install.inc is a procedural migration script (host-absolute requires,
+ * real service control) and not loadable by the unit harness (see
+ * InstallDnsblMoveRestartGuardTest.php), so the shared call-site region is
+ * eval-extracted verbatim from the REAL source, anchored on text stable
+ * across both the pre-fix and post-fix code -- the same pattern as
+ * CategoryEditPostGuardTest.php.
+ */
+final class InstallGrandfatherChokepointTest extends TestCase
+{
+	private ?array $savedConfig = null;
+
+	public static function setUpBeforeClass(): void
+	{
+		if (function_exists('pfb_install_oracle_grandfather_region')) {
+			return;
+		}
+
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_install.inc');
+		}
+
+		// The shared grandfather region: from the $pfb_gcfg section read through
+		// the closing brace of the alias-delta-mode write. Both grandfather calls
+		// consume the same $pfb_gcfg local.
+		if (!preg_match(
+			'/(\$pfb_gcfg = PfbConfig::readSection\(\'installedpackages\/pfblockerng\/config\/0\'\);\n'
+			. '.*?'
+			. 'PfbConfig::write\(\'pfb_alias_delta_mode\', \$pfb_delta_default\);\n\}\n)/s',
+			$src,
+			$m
+		)) {
+			throw new RuntimeException('test bootstrap: install-default grandfather region not found');
+		}
+
+		eval(
+			'function pfb_install_oracle_grandfather_region(): array {'
+			. $m[1]
+			. ' return ['
+			. ' \'feed_default\' => $pfb_feed_default,'
+			. ' \'delta_default\' => $pfb_delta_default,'
+			. ' \'gcfg\' => $pfb_gcfg,'
+			. ' ]; }'
+		);
+	}
+
+	protected function setUp(): void
+	{
+		$this->savedConfig = $GLOBALS['config'] ?? null;
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['config'] = $this->savedConfig;
+	}
+
+	private function seedSection(array $section): void
+	{
+		$GLOBALS['config'] = [
+			'installedpackages' => [
+				'pfblockerng' => [
+					'config' => [0 => $section],
+				],
+			],
+		];
+	}
+
+	// --- #1770: feed-host filter --------------------------------------------
+
+	public function testFreshInstallMarkerOnlySectionLeavesFeedFilterKeyUnset(): void
+	{
+		// The exact live-probe capture (#1770): section carries ONLY the
+		// installer's own settings_family marker -- a genuine first-ever install.
+		$this->seedSection(['settings_family' => '4.0']);
+
+		$result = pfb_install_oracle_grandfather_region();
+
+		$this->assertNull(
+			$result['feed_default'],
+			'a marker-only section is a fresh install -- the feed-filter key must stay unset (default ON)'
+		);
+		$this->assertNull(
+			config_get_path('installedpackages/pfblockerng/config/0/pfb_feed_internal_filter'),
+			'the chokepoint must not have written pfb_feed_internal_filter on a fresh install'
+		);
+	}
+
+	public function testGenuineUpgradeWithMarkerAndOperatorKeyStillPinsFeedFilterOff(): void
+	{
+		// Before-state pin: a marker PLUS a genuine operator key is the true
+		// upgrade path and must still be grandfathered off.
+		$this->seedSection(['settings_family' => '4.0', 'pfb_interval' => '4']);
+
+		$result = pfb_install_oracle_grandfather_region();
+
+		$this->assertSame(
+			'off',
+			$result['feed_default'],
+			'a marker plus genuine operator data is an upgrade -- the feed filter must still be pinned off'
+		);
+		$this->assertSame(
+			'off',
+			config_get_path('installedpackages/pfblockerng/config/0/pfb_feed_internal_filter')
+		);
+	}
+
+}

--- a/tests/php/InstallGrandfatherChokepointTest.php
+++ b/tests/php/InstallGrandfatherChokepointTest.php
@@ -158,4 +158,32 @@ final class InstallGrandfatherChokepointTest extends TestCase
 			config_get_path('installedpackages/pfblockerng/config/0/pfb_alias_delta_mode')
 		);
 	}
+
+	// --- #1770 follow-up: pfb_keep is genuine evidence, not a marker --------
+
+	/**
+	 * Before-state pin: pfb_keep is never operator-only-typed -- it can be
+	 * present on a box that already ran the (buggy) #281 migration, or via a
+	 * genuine General save. A section carrying {settings_family, pfb_keep}
+	 * must still be treated as a pre-existing install by BOTH grandfathers --
+	 * the chokepoint strips ONLY settings_family, never pfb_keep. Green on
+	 * both sides of the #1770-follow-up fix.
+	 */
+	public function testMarkerPlusPfbKeepStillPinsBothGrandfathers(): void
+	{
+		$this->seedSection(['settings_family' => '4.0', 'pfb_keep' => 'on']);
+
+		$result = pfb_install_oracle_grandfather_region();
+
+		$this->assertSame(
+			'off',
+			$result['feed_default'],
+			'settings_family + pfb_keep is genuine pre-existing config -- feed filter must still pin off'
+		);
+		$this->assertSame(
+			'replace',
+			$result['delta_default'],
+			'settings_family + pfb_keep is genuine pre-existing config -- alias delta mode must still pin replace'
+		);
+	}
 }

--- a/tests/php/InstallGrandfatherChokepointTest.php
+++ b/tests/php/InstallGrandfatherChokepointTest.php
@@ -31,39 +31,61 @@ final class InstallGrandfatherChokepointTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		if (function_exists('pfb_install_oracle_grandfather_region')) {
-			return;
+		$src = null;
+		if (!function_exists('pfb_install_oracle_grandfather_region')
+			|| !function_exists('pfb_install_oracle_rdns_seed_region')) {
+			$src = file_get_contents(
+				dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc'
+			);
+			if ($src === false) {
+				throw new RuntimeException('test bootstrap: failed to read pfblockerng_install.inc');
+			}
 		}
 
-		$src = file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc'
-		);
-		if ($src === false) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_install.inc');
+		if (!function_exists('pfb_install_oracle_grandfather_region')) {
+			// The shared grandfather region: from the $pfb_gcfg section read through
+			// the closing brace of the alias-delta-mode write. Both grandfather calls
+			// consume the same $pfb_gcfg local.
+			if (!preg_match(
+				'/(\$pfb_gcfg = PfbConfig::readSection\(\'installedpackages\/pfblockerng\/config\/0\'\);\n'
+				. '.*?'
+				. 'PfbConfig::write\(\'pfb_alias_delta_mode\', \$pfb_delta_default\);\n\}\n)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: install-default grandfather region not found');
+			}
+
+			eval(
+				'function pfb_install_oracle_grandfather_region(): array {'
+				. $m[1]
+				. ' return ['
+				. ' \'feed_default\' => $pfb_feed_default,'
+				. ' \'delta_default\' => $pfb_delta_default,'
+				. ' \'gcfg\' => $pfb_gcfg,'
+				. ' ]; }'
+			);
 		}
 
-		// The shared grandfather region: from the $pfb_gcfg section read through
-		// the closing brace of the alias-delta-mode write. Both grandfather calls
-		// consume the same $pfb_gcfg local.
-		if (!preg_match(
-			'/(\$pfb_gcfg = PfbConfig::readSection\(\'installedpackages\/pfblockerng\/config\/0\'\);\n'
-			. '.*?'
-			. 'PfbConfig::write\(\'pfb_alias_delta_mode\', \$pfb_delta_default\);\n\}\n)/s',
-			$src,
-			$m
-		)) {
-			throw new RuntimeException('test bootstrap: install-default grandfather region not found');
-		}
+		if (!function_exists('pfb_install_oracle_rdns_seed_region')) {
+			// issue #1775: the reverse-DNS seed region -- from the pfb_rdns_seed_value()
+			// call through the closing brace of its if/else write.
+			if (!preg_match(
+				'/(\$pfb_rdns_seed = pfb_rdns_seed_value\(\n'
+				. '.*?'
+				. 'update_status\(" no changes required \.\.\. done\.\\\\n"\);\n\} ?\n)/s',
+				$src,
+				$m2
+			)) {
+				throw new RuntimeException('test bootstrap: install-default rdns seed region not found');
+			}
 
-		eval(
-			'function pfb_install_oracle_grandfather_region(): array {'
-			. $m[1]
-			. ' return ['
-			. ' \'feed_default\' => $pfb_feed_default,'
-			. ' \'delta_default\' => $pfb_delta_default,'
-			. ' \'gcfg\' => $pfb_gcfg,'
-			. ' ]; }'
-		);
+			eval(
+				'function pfb_install_oracle_rdns_seed_region(): array {'
+				. $m2[1]
+				. ' return [ \'rdns_seed\' => $pfb_rdns_seed ]; }'
+			);
+		}
 	}
 
 	protected function setUp(): void
@@ -82,6 +104,20 @@ final class InstallGrandfatherChokepointTest extends TestCase
 			'installedpackages' => [
 				'pfblockerng' => [
 					'config' => [0 => $section],
+				],
+			],
+		];
+	}
+
+	private function seedGenAndIpSections(array $gen, array $ip): void
+	{
+		$GLOBALS['config'] = [
+			'installedpackages' => [
+				'pfblockerng' => [
+					'config' => [0 => $gen],
+				],
+				'pfblockerngipsettings' => [
+					'config' => [0 => $ip],
 				],
 			],
 		];
@@ -184,6 +220,48 @@ final class InstallGrandfatherChokepointTest extends TestCase
 			'replace',
 			$result['delta_default'],
 			'settings_family + pfb_keep is genuine pre-existing config -- alias delta mode must still pin replace'
+		);
+	}
+
+	// --- #1775: reverse-DNS lookup seed --------------------------------------
+
+	/**
+	 * Scenario: General section carries ONLY the installer's settings_family
+	 * marker (a genuine fresh install -- General never saved). enable_rdns
+	 * (issue #336) defaults OFF for new installs; the marker must not be read
+	 * as pre-existing operator config and force the legacy always-on seed.
+	 */
+	public function testFreshInstallMarkerOnlySectionLeavesRdnsSeedUnset(): void
+	{
+		$this->seedGenAndIpSections(['settings_family' => '4.0'], []);
+
+		$result = pfb_install_oracle_rdns_seed_region();
+
+		$this->assertNull(
+			$result['rdns_seed'],
+			'a marker-only section is a fresh install -- enable_rdns must stay unseeded (default OFF)'
+		);
+		$this->assertNull(
+			config_get_path('installedpackages/pfblockerngipsettings/config/0/enable_rdns'),
+			'the chokepoint must not have written enable_rdns on a fresh install'
+		);
+	}
+
+	/**
+	 * Before-state pin: a marker PLUS a genuine operator key is the true
+	 * upgrade path and must still seed enable_rdns='on' to preserve the
+	 * historical always-on behaviour.
+	 */
+	public function testGenuineUpgradeWithMarkerAndOperatorKeyStillSeedsRdnsOn(): void
+	{
+		$this->seedGenAndIpSections(['settings_family' => '4.0', 'pfb_interval' => '4'], []);
+
+		$result = pfb_install_oracle_rdns_seed_region();
+
+		$this->assertSame('on', $result['rdns_seed']);
+		$this->assertSame(
+			'on',
+			config_get_path('installedpackages/pfblockerngipsettings/config/0/enable_rdns')
 		);
 	}
 }

--- a/tests/php/MigrationRegistryTest.php
+++ b/tests/php/MigrationRegistryTest.php
@@ -320,6 +320,35 @@ final class MigrationRegistryTest extends TestCase
 		);
 	}
 
+	/**
+	 * Scenario: General section carries ONLY the installer's own settings_family
+	 * marker (issue #1770 follow-up) -- e.g. a fresh install that never saved
+	 * General, then hit a second install/upgrade run. pfb_settings_family_replace()
+	 * seeds the marker before pfb_run_migrations() executes, so the #281 seed must
+	 * not treat a marker-only section as "pre-existing operator config".
+	 *   Given a General section holding only settings_family.
+	 *   When the driver runs.
+	 *   Then issue-#281 must NOT fire: pfb_keep stays unseeded and nothing is written.
+	 */
+	public function testDriverDoesNotSeedPfbKeepOnMarkerOnlyFreshInstall(): void
+	{
+		$this->seedGen(['settings_family' => '4.0']);
+
+		pfb_run_migrations();
+
+		$gen = $this->getGen();
+		$this->assertArrayNotHasKey(
+			'pfb_keep',
+			$gen,
+			'a marker-only General section is a fresh install -- pfb_keep must stay unseeded'
+		);
+		$this->assertSame(
+			[],
+			$this->writeConfigCalls(),
+			'a marker-only General section must not trigger any migration write'
+		);
+	}
+
 	// -----------------------------------------------------------------------
 	// E — Driver: already migrated (idempotency / run-once)
 	// -----------------------------------------------------------------------

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -3396,6 +3396,19 @@
             }
         ]
     },
+    "pfb_gconfig_operator_view": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "gconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
     "pfb_get_gateways": {
         "returnsRef": false,
         "returnType": null,

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -486,6 +486,11 @@ if (!function_exists('file_notice')) {
 	}
 }
 
+if (!function_exists('update_status')) {
+	// no-op: pfblockerng_install.inc progress-text only, never asserted on.
+	function update_status($status) {}
+}
+
 if (!function_exists('is_subsystem_dirty')) {
 	function is_subsystem_dirty($subsystem = '') {
 		if ($subsystem === 'pkg') {


### PR DESCRIPTION
Two correlated fresh-install regressions with a shared root cause, one commit per issue.

Fixes #1770. Fixes #1771.

## Root cause (live-instrumented on three virgin VMs)

`pfblockerng_install.inc` records the installer's own `settings_family` schema marker into `installedpackages/pfblockerng/config/0` (line ~136, `pfb_settings_family_record()`) 500+ lines before the install-default grandfather checks read that section (~652). The "genuinely empty section = fresh install" branch of both grandfathers was therefore dead code — captured at the read on a first-ever install:

```
PROBE_GCFG=array (
  'settings_family' => '4.0',
)
```

Consequences: every install — including a virgin box — shipped the SSRF feed-filter guard OFF (#1770) and pinned alias-apply mode to legacy `replace` instead of `auto` (#1771).

## Fix

One line at the shared call site: drop the installer-seeded marker from the copy the emptiness/grandfather decision uses (`unset($pfb_gcfg['settings_family'])`). The grandfather functions themselves are untouched — their contract was correct; the input was contaminated. On a marker-only section the feed-filter key now stays UNSET, which `pfb_feed_filter_enabled()` resolves to filter ON; a section with genuine operator keys still grandfathers exactly as before (upgrade path preserved, pinned by tests).

## Evidence

Red-first via an eval-extracted oracle of the real call-site region (`InstallGrandfatherChokepointTest`): marker-only → both defaults NULL (RED pre-fix: `'off'`/`'replace'`), marker+operator-key → `'off'`/`'replace'` preserved (green both sides). Independently verifier-gated: red re-executed via `verify-red-proof.sh` against `HEAD~2`, both mutations re-run (removing the unset → marker-only tests fail; over-widening the unset → upgrade-path pins fail), and the "settings_family is the only pre-652 seeded key" enumeration re-derived from source. Live proof: `tests/smoke/test_smoke_feeds.py::test_feed_internal_filter_blocks_then_allowlist_exempts` (currently red on devel, run 30243277028) goes green with this fix — CI's smoke leg covers it.

A pre-existing sibling contamination (the General→IP settings move seeding 14 blank keys into ipsettings on fresh installs) is deliberately not touched here — tracked as #1772.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade and installation handling for configurations containing only installer markers.
  * Prevented fresh installations from incorrectly inheriting saved settings or enabling defaults.
  * Preserved existing operator-configured values during upgrades.

* **Tests**
  * Added coverage for fresh installs, genuine upgrades, migration behavior, and default-setting decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->