### PR TITLE
pfblockerng: stop fresh-config null deprecations at the filter/decode chokepoints

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1261,6 +1261,14 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 		}
 	}
 
+	// issue #1768: ON_OFF/NUM skip the early return above (NULL==''/0 are legitimate
+	// stored values), but still flow into the scalar ops below (preg_match/htmlspecialchars).
+	// Coerce NULL -> '' here (not is_null-guard) so 'NULL==""' stays byte-identical while
+	// null-deprecations stop; caller-side Undefined-array-key warnings are untouched.
+	if (!is_array($input)) {
+		$input = (string) ($input ?? '');
+	}
+
 	// issue #1070: every non-FILE_MIME type runs scalar string ops below (htmlspecialchars/
 	// preg_match) that PHP 8 TypeErrors on an array -- reject an array up front, before any
 	// such op runs, for those types. issue #1139: must run before the control-char loop
@@ -2761,8 +2769,8 @@ function pfb_global() {
 		}
 	}
 
-	$pfb['supp']		= $pfb['ipconfig']['suppression'];			// Enable Suppression
-	$pfb['cc']		= $pfb['ipconfig']['database_cc'];			// Disable Country database CRON updates
+	$pfb['supp']		= $pfb['ipconfig']['suppression'] ?? '';		// Enable Suppression
+	$pfb['cc']		= $pfb['ipconfig']['database_cc'] ?? '';		// Disable Country database CRON updates
 	$pfb['maxmind_locale']	= $pfb['ipconfig']['maxmind_locale']	?: 'en';	// MaxMind Localized Language setting
 	$pfb['asn_reporting']	= $pfb['ipconfig']['asn_reporting']	?: 'disabled';	// ASN Reporting
 	$pfb['asn_token']	= $pfb['ipconfig']['asn_token']		?: '';		// ASN Token (IPinfo)
@@ -2831,16 +2839,16 @@ function pfb_global() {
 	$pfb['dnsbl_idn_block_malicious']	= PfbConfig::read('pfb_idn_block_malicious');		// Confusable: block malicious homoglyphs (default 'on')
 	$pfb['dnsbl_idn_escalate_suspicious']	= PfbConfig::read('pfb_idn_escalate_suspicious');	// Confusable: escalate suspicious mixed-script to block (opt-in)
 	$pfb['dnsbl_regex']	= $pfb['dnsblconfig']['pfb_regex'];			// DNSBL Resolver python regex
-	$pfb['dnsbl_regex_list']= $pfb['dnsblconfig']['pfb_regex_list'];		// DNSBL Resolver python regex list
+	$pfb['dnsbl_regex_list']= $pfb['dnsblconfig']['pfb_regex_list'] ?? '';	// DNSBL Resolver python regex list
 	$pfb['dnsbl_regex_cap']	= PfbConfig::read('pfb_regex_cap');			// DNSBL Resolver python opt-in "Limit long/complex regex" static cap
 	$pfb['dnsbl_cname']	= $pfb['dnsblconfig']['pfb_cname'];			// DNSBL Resolver python CNAME Validation
 	$pfb['dnsbl_tld_allow']	= $pfb['dnsblconfig']['pfb_pytld'];			// DNSBL Resolver TLD Allow option
 	$pfb['dnsbl_py_nolog']	= $pfb['dnsblconfig']['pfb_py_nolog'];			// DNSBL Resolver python - Log events via DNSBL Webserver vs python
 	$pfb['dnsbl_noaaaa']	= $pfb['dnsblconfig']['pfb_noaaaa'];			// DNSBL Resolver python no AAAA
-	$pfb['dnsbl_noaaaa_list']=$pfb['dnsblconfig']['pfb_noaaaa_list'];		// DNSBL Resolver python no AAAA list
+	$pfb['dnsbl_noaaaa_list']=$pfb['dnsblconfig']['pfb_noaaaa_list'] ?? '';	// DNSBL Resolver python no AAAA list
 
 	$pfb['dnsbl_gp']		= $pfb['dnsblconfig']['pfb_gp'];		// DNSBL Resolver python - DNSBL Bypass
-	$pfb['dnsbl_gp_bypass_list']	= $pfb['dnsblconfig']['pfb_gp_bypass_list'];	// DNSBL Resolver python - List of Local IPs to bypass DNSBL
+	$pfb['dnsbl_gp_bypass_list']	= $pfb['dnsblconfig']['pfb_gp_bypass_list'] ?? '';	// DNSBL Resolver python - List of Local IPs to bypass DNSBL
 
 	// SafeSearch — read via gateway (ADR-29).
 	$pfb['safesearch_enable']	= PfbConfig::read('safesearch_enable');
@@ -3193,6 +3201,10 @@ function pfb_sanitize_text_area(string $text): string {
 // Function to decode alias custom entry box.
 // Default (False, True): Return as string with comments
 function pfb_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
+
+	// issue #1768: untyped $text feeds base64_decode() below; coerce NULL -> ''
+	// so an absent/unset caller stops emitting the null-deprecation.
+	$text = (string) ($text ?? '');
 
 	if ($mode) {
 		$custom = array();
@@ -15091,7 +15103,9 @@ function pfb_daemon_filterlog() {
 			if ($log_type == 'BSD' && empty($f[1])) {
 				array_splice($f, 1, 1);
 			}
-			$d = explode(',', $f[$f_pos]);
+			// issue #1768: a short/malformed filterlog line has no field at $f_pos --
+			// guard so explode() doesn't get NULL.
+			$d = explode(',', $f[$f_pos] ?? '');
 
 			// Resolve the Tracker ID: reparse at most once per unknown tracker; persistent
 			// negative cache prevents repeated reparses for anchor/trackerless rules.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
@@ -286,8 +286,8 @@ foreach (array('Top Spammers', 'Africa', 'Antarctica', 'Asia', 'Europe', 'North 
 }
 
 $pconfig = array();
-$pconfig['countries4']		= explode(',', $pfb['geoipconfig']['countries4']);
-$pconfig['countries6']		= explode(',', $pfb['geoipconfig']['countries6']);
+$pconfig['countries4']		= explode(',', $pfb['geoipconfig']['countries4'] ?? '');
+$pconfig['countries6']		= explode(',', $pfb['geoipconfig']['countries6'] ?? '');
 $pconfig['action'] = pfb_group_action_valid($pfb['geoipconfig']['action'] ?? NULL, 'geoip') ? $pfb['geoipconfig']['action'] : 'Disabled';
 $pconfig['aliaslog']		= $pfb['geoipconfig']['aliaslog']			?: 'enabled';
 
@@ -846,10 +846,10 @@ $pconfig['enable_dedup']	= $pfb['repconfig']['enable_dedup'];
 $pconfig['p24_dmax_var']	= $pfb['repconfig']['p24_dmax_var'];
 $pconfig['ccwhite']		= $pfb['repconfig']['ccwhite'];
 $pconfig['ccblack']		= $pfb['repconfig']['ccblack'];
-$pconfig['ccexclude']		= explode(',', $pfb['repconfig']['ccexclude']);
+$pconfig['ccexclude']		= explode(',', $pfb['repconfig']['ccexclude'] ?? '');
 $pconfig['et_header']		= $pfb['repconfig']['et_header'];
-$pconfig['etblock']		= explode(',', $pfb['repconfig']['etblock']);
-$pconfig['etmatch']		= explode(',', $pfb['repconfig']['etmatch']);
+$pconfig['etblock']		= explode(',', $pfb['repconfig']['etblock'] ?? '');
+$pconfig['etmatch']		= explode(',', $pfb['repconfig']['etmatch'] ?? '');
 
 
 // Select field options

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2497,11 +2497,28 @@ function convert_dns_reply_log($mode, $fields) {
 
 		// issue #1777: dnsbl_whitelist_type() unconditionally reads keys 5/7/8 too
 		// (DNSBL Mode / Evaluated Domain / Feed Name) -- a DNS reply row has no
-		// Mode or Feed, so '' preserves the pre-fix implicit-NULL branch selection
-		// (still != 'DNSBL_TLD') and leaves the (never-reached, group=='Unknown')
-		// Feed-name usage inert; the replied domain doubles as the "evaluated"
-		// domain, matching key 2 and the $qdomain argument below.
-		$dns_fields = array ('2' => $fields[6], '5' => '', '6' => 'Unknown', '7' => $fields[6], '8' => '');
+		// Mode, Evaluated Domain or Feed, so each key preserves the pre-fix
+		// implicit-NULL read at its own call site:
+		//   - key 5 (DNSBL Mode, gates the != 'DNSBL_TLD' branch split): '' keeps
+		//     the pre-fix branch selection byte-for-byte, since NULL != 'DNSBL_TLD'
+		//     is also TRUE.
+		//   - key 7 (Evaluated Domain): '' -- NOT $fields[6]. A prior fix set this
+		//     to $fields[6] (the replied domain) reasoning only about the
+		//     exclusion-icon id; it missed that dnsbl_whitelist_type() ALSO feeds
+		//     key 7 into the dot-prefixed wildcard-whitelist walk
+		//     (dnsbl_whitelist_type() ~:2056, `ltrim($fields[7], '.')`). A real
+		//     domain there enters that walk and can flip $isWhitelist_found to
+		//     TRUE for any dot-prefixed whitelist entry that is an ancestor
+		//     domain -- silently reclassifying an unrelated reply row as
+		//     already-whitelisted. '' is chosen because
+		//     ltrim(NULL, '.') === ltrim('', '.') === '', so it reproduces the
+		//     pre-fix NULL read exactly and never enters the walk.
+		//   - key 8 (Feed Name) is read only inside the `$fields[6] != 'Unknown'`
+		//     branch (dnsbl_whitelist_type() ~:2023), which the caller's own
+		//     hardcoded '6' => 'Unknown' provably never enters -- no reply-log
+		//     analogue exists and none is needed; '' is inert by construction.
+		// The replied domain doubles as key 2 and the $qdomain argument below.
+		$dns_fields = array ('2' => $fields[6], '5' => '', '6' => 'Unknown', '7' => '', '8' => '');
 		list($supp_dom, $ex_dom, $isWhitelist_found) = dnsbl_whitelist_type($dns_fields, $clists, $isExclusion, FALSE, $fields[6]);
 
 		// Threat Lookup Icon

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -41,8 +41,8 @@ $pfb['aglobal'] = PfbConfig::readSection('installedpackages/pfblockerngglobal');
 $alertrefresh	= isset($pfb['aglobal']['alertrefresh'])	? $pfb['aglobal']['alertrefresh']	: 'on';
 $pfbpageload	= $pfb['aglobal']['pfbpageload']	!= ''	? $pfb['aglobal']['pfbpageload']	: 'unified';
 $pfbmaxtable	= $pfb['aglobal']['pfbmaxtable']	!= ''	? $pfb['aglobal']['pfbmaxtable']	: '1000';
-$pfbreplytypes	= explode(',', $pfb['aglobal']['pfbreplytypes'])?: array();
-$pfbreplyrec	= explode(',', $pfb['aglobal']['pfbreplyrec'])	?: array();
+$pfbreplytypes	= explode(',', $pfb['aglobal']['pfbreplytypes'] ?? '')?: array();
+$pfbreplyrec	= explode(',', $pfb['aglobal']['pfbreplyrec'] ?? '')	?: array();
 
 // Unified Log - Light/Dark Theme colour keys: one registry drives the read defaults, the
 // save loops, and the render loops below. 'upstream' reads with null-coalescing because it
@@ -73,11 +73,11 @@ $pfbchartcnt	= $pfb['aglobal']['pfbchartcnt']		?: '24';
 $pfbchartstyle	= $pfb['aglobal']['pfbchartstyle']		?: 'twotone';
 $pfbchart1	= $pfb['aglobal']['pfbchart1']			?: '#0C6197';
 $pfbchart2	= $pfb['aglobal']['pfbchart2']			?: '#7A7A7A';
-$pfbblockstat	= explode(',', $pfb['aglobal']['pfbblockstat']) ?: array();
-$pfbpermitstat	= explode(',', $pfb['aglobal']['pfbpermitstat'])?: array();
-$pfbmatchstat	= explode(',', $pfb['aglobal']['pfbmatchstat'])	?: array();
-$pfbdnsblstat	= explode(',', $pfb['aglobal']['pfbdnsblstat'])	?: array();
-$pfbdnsblreplystat = explode(',', $pfb['aglobal']['pfbdnsblreplystat']) ?: array();
+$pfbblockstat	= explode(',', $pfb['aglobal']['pfbblockstat'] ?? '') ?: array();
+$pfbpermitstat	= explode(',', $pfb['aglobal']['pfbpermitstat'] ?? '')?: array();
+$pfbmatchstat	= explode(',', $pfb['aglobal']['pfbmatchstat'] ?? '')	?: array();
+$pfbdnsblstat	= explode(',', $pfb['aglobal']['pfbdnsblstat'] ?? '')	?: array();
+$pfbdnsblreplystat = explode(',', $pfb['aglobal']['pfbdnsblreplystat'] ?? '') ?: array();
 
 // issue #1497: explicit assignments (was a ${"$type"} variable-variable loop
 // over $aglobal_array) -- PHPStan can't trace a variable-variable target, so

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -121,7 +121,7 @@ foreach (array(2,7,8,13,15,17,19,20,99) as $field_1) {
 
 $filterfieldsarray[2]	= array();
 foreach (array(81,82,83,84,85,86,87,88,89) as $field_2) {
-	$filterfieldsarray[1][$field_2] = '';
+	$filterfieldsarray[2][$field_2] = '';
 }
 
 // $alert_log is set by the view handler below but read in the stats section much later;
@@ -1781,7 +1781,7 @@ if ($alert_summary) {
 					}
 
 					$data = array_map('trim', explode(' ', trim($line), 2));
-					$alert_stats[$alert_view][$stat_type][$data[1] ?: $unknown_msg] = $data[0] ?: 0;
+					$alert_stats[$alert_view][$stat_type][($data[1] ?? '') ?: $unknown_msg] = $data[0] ?: 0;
 				}
 			}
 			else {
@@ -2495,7 +2495,13 @@ function convert_dns_reply_log($mode, $fields) {
 	// Determine Whitelist type
 	else {
 
-		$dns_fields = array ('2' => $fields[6], '6' => 'Unknown');
+		// issue #1777: dnsbl_whitelist_type() unconditionally reads keys 5/7/8 too
+		// (DNSBL Mode / Evaluated Domain / Feed Name) -- a DNS reply row has no
+		// Mode or Feed, so '' preserves the pre-fix implicit-NULL branch selection
+		// (still != 'DNSBL_TLD') and leaves the (never-reached, group=='Unknown')
+		// Feed-name usage inert; the replied domain doubles as the "evaluated"
+		// domain, matching key 2 and the $qdomain argument below.
+		$dns_fields = array ('2' => $fields[6], '5' => '', '6' => 'Unknown', '7' => $fields[6], '8' => '');
 		list($supp_dom, $ex_dom, $isWhitelist_found) = dnsbl_whitelist_type($dns_fields, $clists, $isExclusion, FALSE, $fields[6]);
 
 		// Threat Lookup Icon
@@ -4935,7 +4941,7 @@ var pieChart_<?=$stat_type?> = new d3pie("pieChart_<?=$stat_type?>", {
 	$k = array_keys($summary);
 	$numentries = 0;
 	for ($i = 0; $i < ($numsegments-1); $i++) {
-		if ($k[$i]) {
+		if ($k[$i] ?? NULL) {
 			$numentries++;
 			if ($i > 0) {
 				print(",\r\n");

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -114,7 +114,7 @@ $pfb['bconfig']	= PfbConfig::readSection('installedpackages/pfblockerngblacklist
 $pconfig = array();
 $pconfig['blacklist_enable']		= $pfb['bconfig']['blacklist_enable']				?: 'Disable';
 $pconfig['blacklist_lang']		= $pfb['bconfig']['blacklist_lang']				?: 'EN';
-$pconfig['blacklist_selected']		= explode(',', $pfb['bconfig']['blacklist_selected'])		?: array();
+$pconfig['blacklist_selected']		= explode(',', $pfb['bconfig']['blacklist_selected'] ?? '')		?: array();
 $pconfig['blacklist_freq']		= $pfb['bconfig']['blacklist_freq']				?: 'Never';
 $pconfig['blacklist_logging']		= $pfb['bconfig']['blacklist_logging']				?: 'enabled';
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -482,7 +482,13 @@ foreach ($blacklist_types as $type => $setting) {
 	ksort($data, SORT_NATURAL);
 	foreach ($data as $category => $info) {
 
-		$category_lang = $info[$pconfig['blacklist_lang']][1] ?: $info['EN'][1];
+		// issue #1777: most providers document a DESC/NAME line for only a
+		// subset of languages per category -- $l/$e guard the missing-index
+		// read; the ?: EN fallback below is load-bearing (an empty translation
+		// must still fall back to EN) and must stay ?:, never ??.
+		$l = $info[$pconfig['blacklist_lang']] ?? array();
+		$e = $info['EN'] ?? array();
+		$category_lang = ($l[1] ?? '') ?: ($e[1] ?? '');
 
 		$selected = FALSE;
 		if (isset($_POST['enableall'][$type])) {
@@ -513,7 +519,7 @@ foreach ($blacklist_types as $type => $setting) {
 
 		$group->add(new Form_StaticText(
 			'',
-			$info[$pconfig['blacklist_lang']][0] ?: $info['EN'][0]
+			($l[0] ?? '') ?: ($e[0] ?? '')
 		))->setWidth(7);
 
 		$section->add($group);

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -849,7 +849,8 @@ if ($_POST && isset($_POST['save'])) {
 
 		// Set flag to update CustomList on next Cron|Force update|Force reload
 		// foreign key: installedpackages/{conf_type} list structure not in registry
-		if (base64_decode(config_get_path("installedpackages/{$conf_type}/config/{$rowid}/custom")) != $_POST['custom']) {
+		// issue #1768: no default -> config_get_path() returns NULL on a fresh row -> base64_decode(NULL) deprecation.
+		if (base64_decode(config_get_path("installedpackages/{$conf_type}/config/{$rowid}/custom", '')) != $_POST['custom']) {
 			$action = $_POST['action'];
 			$aname  = $_POST['aliasname'];
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -59,7 +59,7 @@ $pconfig['pfb_dnsport']		= $pfb['dconfig']['pfb_dnsport']			?: '8081';
 $pconfig['pfb_dnsport_ssl']	= $pfb['dconfig']['pfb_dnsport_ssl']			?: '8443';
 $pconfig['dnsbl_interface']	= $pfb['dconfig']['dnsbl_interface']			?: 'lo0';
 $pconfig['pfb_dnsbl_rule']	= $pfb['dconfig']['pfb_dnsbl_rule']			?: '';
-$pconfig['dnsbl_allow_int']	= explode(',', $pfb['dconfig']['dnsbl_allow_int'])	?: array();
+$pconfig['dnsbl_allow_int']	= explode(',', $pfb['dconfig']['dnsbl_allow_int'] ?? '')	?: array();
 $pconfig['global_log']		= $pfb['dconfig']['global_log']				?: '';
 $pconfig['dnsbl_webpage']	= $pfb['dconfig']['dnsbl_webpage']			?: 'dnsbl_default.php';
 $pconfig['pfb_cache']		= isset($pfb['dconfig']['pfb_cache'])			? $pfb['dconfig']['pfb_cache'] : 'on';
@@ -86,14 +86,14 @@ $pconfig['pfb_noaaaa']		= $pfb['dconfig']['pfb_noaaaa']				?: '';
 $pconfig['pfb_gp']		= $pfb['dconfig']['pfb_gp']				?: '';
 $pconfig['pfb_pytld']		= $pfb['dconfig']['pfb_pytld']				?: '';
 $pconfig['pfb_pytld_sort']	= $pfb['dconfig']['pfb_pytld_sort']			?: '';
-$pconfig['pfb_pytlds_gtld']	= explode(',', $pfb['dconfig']['pfb_pytlds_gtld'])	?: $default_tlds;
-$pconfig['pfb_pytlds_cctld']	= explode(',', $pfb['dconfig']['pfb_pytlds_cctld'])	?: array();
-$pconfig['pfb_pytlds_itld']	= explode(',', $pfb['dconfig']['pfb_pytlds_itld'])	?: array();
-$pconfig['pfb_pytlds_bgtld']	= explode(',', $pfb['dconfig']['pfb_pytlds_bgtld'])	?: array();
+$pconfig['pfb_pytlds_gtld']	= explode(',', $pfb['dconfig']['pfb_pytlds_gtld'] ?? '')	?: $default_tlds;
+$pconfig['pfb_pytlds_cctld']	= explode(',', $pfb['dconfig']['pfb_pytlds_cctld'] ?? '')	?: array();
+$pconfig['pfb_pytlds_itld']	= explode(',', $pfb['dconfig']['pfb_pytlds_itld'] ?? '')	?: array();
+$pconfig['pfb_pytlds_bgtld']	= explode(',', $pfb['dconfig']['pfb_pytlds_bgtld'] ?? '')	?: array();
 $pconfig['pfb_py_nolog']	= $pfb['dconfig']['pfb_py_nolog']			?: '';
-$pconfig['pfb_regex_list']	= base64_decode($pfb['dconfig']['pfb_regex_list'])	?: '';
-$pconfig['pfb_noaaaa_list']	= base64_decode($pfb['dconfig']['pfb_noaaaa_list'])	?: '';
-$pconfig['pfb_gp_bypass_list']	= base64_decode($pfb['dconfig']['pfb_gp_bypass_list'])	?: '';
+$pconfig['pfb_regex_list']	= base64_decode($pfb['dconfig']['pfb_regex_list'] ?? '')	?: '';
+$pconfig['pfb_noaaaa_list']	= base64_decode($pfb['dconfig']['pfb_noaaaa_list'] ?? '')	?: '';
+$pconfig['pfb_gp_bypass_list']	= base64_decode($pfb['dconfig']['pfb_gp_bypass_list'] ?? '')	?: '';
 $pconfig['action']		= $pfb['dconfig']['action']				?: 'Disabled';
 $pconfig['aliaslog']		= $pfb['dconfig']['aliaslog']				?: 'enabled';
 
@@ -115,7 +115,7 @@ $pconfig['aliasaddr_out']	= $pfb['dconfig']['aliasaddr_out']			?: '';
 $pconfig['autoproto_out']	= $pfb['dconfig']['autoproto_out']			?: 'any';
 $pconfig['agateway_out']	= $pfb['dconfig']['agateway_out']			?: 'default';
 
-$pconfig['suppression']		= base64_decode($pfb['dconfig']['suppression'])		?: '';
+$pconfig['suppression']		= base64_decode($pfb['dconfig']['suppression'] ?? '')		?: '';
 
 $pconfig['alexa_enable']	= $pfb['dconfig']['alexa_enable']			?: '';
 // Routed via the gateway (not the section array) so a stored legacy 'alexa'
@@ -126,10 +126,10 @@ $pconfig['alexa_type']		= PfbConfig::read('alexa_type')->toStored();
 $pconfig['alexa_count']		= $pfb['dconfig']['alexa_count']			?: '1000';
 // 0 (unlimited) is meaningful, so don't use the ?: idiom (0 is falsy -> would reset to default).
 $pconfig['pfb_py_cache_max']	= (isset($pfb['dconfig']['pfb_py_cache_max']) && $pfb['dconfig']['pfb_py_cache_max'] !== '') ? $pfb['dconfig']['pfb_py_cache_max'] : '10000';
-$pconfig['alexa_inclusion']	= explode(',', $pfb['dconfig']['alexa_inclusion'])	?: array('com','net','org','ca','co','io');
+$pconfig['alexa_inclusion']	= explode(',', $pfb['dconfig']['alexa_inclusion'] ?? '')	?: array('com','net','org','ca','co','io');
 
-$pconfig['tldexclusion']	= base64_decode($pfb['dconfig']['tldexclusion'])	?: '';
-$pconfig['tldblacklist']	= base64_decode($pfb['dconfig']['tldblacklist'])	?: '';
+$pconfig['tldexclusion']	= base64_decode($pfb['dconfig']['tldexclusion'] ?? '')	?: '';
+$pconfig['tldblacklist']	= base64_decode($pfb['dconfig']['tldblacklist'] ?? '')	?: '';
 
 // DoH/DoT/DoQ blocking — stored in pfblockerngsafesearch; read via gateway (registered keys)
 $pconfig['safesearch_doh']		= PfbConfig::read('safesearch_doh');

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -108,6 +108,17 @@ if ($_POST) {
 
 		unset($savemsg);
 
+		// issue #1777: reject an array-valued field ('asn_token[]=x') before any
+		// string sink below Array-to-string-converts on it -- same guard as
+		// pfblockerng_category_edit.php (issue #1106); every field here is
+		// scalar in normal use, no field is exempt.
+		foreach ($_POST as $pfb_post_key => $pfb_post_value) {
+			if (!is_scalar($pfb_post_value)) {
+				$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars((string) $pfb_post_key);
+				$_POST[$pfb_post_key] = '';
+			}
+		}
+
 		// issue #1723: sanitize at ingestion -- first step, before any evaluation.
 		foreach (array('ip_placeholder', 'asn_token', 'autorule_suffix', 'maxmind_account', 'maxmind_key') as $pfb_text_field) {
 			$_POST[$pfb_text_field] = pfb_sanitize_text((string) ($_POST[$pfb_text_field] ?? ''));

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -112,17 +112,19 @@ if ($_POST) {
 		// string sink below Array-to-string-converts on it -- same idea as
 		// pfblockerng_category_edit.php (issue #1106), but NOT the same guard
 		// shape: unlike category_edit, this page has genuine multi-select fields
-		// (inbound_interface, outbound_interface, pfb_agg_types -- pfSense's
-		// Form_Select(..., TRUE) appends '[]' to the POST name for those, so a
-		// real browser legitimately posts them as arrays). A guard over every
-		// $_POST key would reject and blank all three on every save. So this
-		// guard is scoped to exactly the fields the #1723 sanitize loops below
-		// cast to (string) -- those are always scalar in normal use.
-		foreach (array('ip_placeholder', 'asn_token', 'autorule_suffix', 'maxmind_account', 'maxmind_key',
-				'v4suppression', 'v6suppression') as $pfb_text_field) {
-			if (isset($_POST[$pfb_text_field]) && !is_scalar($_POST[$pfb_text_field])) {
-				$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars($pfb_text_field);
-				$_POST[$pfb_text_field] = '';
+		// -- pfSense's Form_Select(..., TRUE) appends '[]' to the POST name, so a
+		// real browser legitimately posts those as arrays and a guard over every
+		// $_POST key would reject and blank them on every save. Excluding the
+		// multi-selects (a small, stable set this page owns) rather than listing
+		// the scalar fields keeps every present and future scalar field covered:
+		// beyond the #1723 sanitize loops below, pfb_alias_delta_mode reaches
+		// array_key_exists(), which is a fatal TypeError on an array, and
+		// pfb_alias_delta_batch reaches a (string) cast.
+		$pfb_multiselect_fields = array('inbound_interface', 'outbound_interface', 'pfb_agg_types');
+		foreach (array_keys($_POST) as $pfb_post_field) {
+			if (!is_scalar($_POST[$pfb_post_field]) && !in_array($pfb_post_field, $pfb_multiselect_fields, TRUE)) {
+				$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars($pfb_post_field);
+				$_POST[$pfb_post_field] = '';
 			}
 		}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -109,13 +109,20 @@ if ($_POST) {
 		unset($savemsg);
 
 		// issue #1777: reject an array-valued field ('asn_token[]=x') before any
-		// string sink below Array-to-string-converts on it -- same guard as
-		// pfblockerng_category_edit.php (issue #1106); every field here is
-		// scalar in normal use, no field is exempt.
-		foreach ($_POST as $pfb_post_key => $pfb_post_value) {
-			if (!is_scalar($pfb_post_value)) {
-				$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars((string) $pfb_post_key);
-				$_POST[$pfb_post_key] = '';
+		// string sink below Array-to-string-converts on it -- same idea as
+		// pfblockerng_category_edit.php (issue #1106), but NOT the same guard
+		// shape: unlike category_edit, this page has genuine multi-select fields
+		// (inbound_interface, outbound_interface, pfb_agg_types -- pfSense's
+		// Form_Select(..., TRUE) appends '[]' to the POST name for those, so a
+		// real browser legitimately posts them as arrays). A guard over every
+		// $_POST key would reject and blank all three on every save. So this
+		// guard is scoped to exactly the fields the #1723 sanitize loops below
+		// cast to (string) -- those are always scalar in normal use.
+		foreach (array('ip_placeholder', 'asn_token', 'autorule_suffix', 'maxmind_account', 'maxmind_key',
+				'v4suppression', 'v6suppression') as $pfb_text_field) {
+			if (isset($_POST[$pfb_text_field]) && !is_scalar($_POST[$pfb_text_field])) {
+				$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars($pfb_text_field);
+				$_POST[$pfb_text_field] = '';
 			}
 		}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -61,15 +61,15 @@ $pconfig['maxmind_account']	= $pfb['iconfig']['maxmind_account']			?: '';
 // A GET renders blank; a validation-error redisplay preserves the just-typed $_POST value
 // (like every other field), never PfbConfig/iconfig.
 $pconfig['maxmind_key']		= $_POST['maxmind_key'] ?? '';
-$pconfig['inbound_interface']	= explode(',', $pfb['iconfig']['inbound_interface'])	?: array();
+$pconfig['inbound_interface']	= explode(',', $pfb['iconfig']['inbound_interface'] ?? '')	?: array();
 $pconfig['inbound_deny_action']	= $pfb['iconfig']['inbound_deny_action']		?: 'block';
-$pconfig['outbound_interface']	= explode(',', $pfb['iconfig']['outbound_interface'])	?: array();
+$pconfig['outbound_interface']	= explode(',', $pfb['iconfig']['outbound_interface'] ?? '')	?: array();
 $pconfig['outbound_deny_action']= $pfb['iconfig']['outbound_deny_action']		?: 'reject';
 $pconfig['enable_float']	= $pfb['iconfig']['enable_float']			?: '';
 $pconfig['pass_order']		= $pfb['iconfig']['pass_order']				?: 'order_0';
 $pconfig['autorule_suffix']	= $pfb['iconfig']['autorule_suffix']			?: 'autorule';
 $pconfig['killstates']		= $pfb['iconfig']['killstates']				?: '';
-$pconfig['v4suppression']	= base64_decode($pfb['iconfig']['v4suppression'])	?: '';
+$pconfig['v4suppression']	= base64_decode($pfb['iconfig']['v4suppression'] ?? '')	?: '';
 // ADR-53 review finding B: '?? ""' on the array read -- v6suppression (unlike
 // v4suppression) is NEVER install-migrated, so it is absent from config.xml
 // on every install until this page's first post-upgrade save.

--- a/src/usr/local/www/pfblockerng/www/index.php
+++ b/src/usr/local/www/pfblockerng/www/index.php
@@ -34,7 +34,7 @@ if (strlen($_SERVER['REQUEST_TIME']) != 10 || !preg_match("/^[0-9]+$/", $_SERVER
 $ptype = array();
 $ptype['REQUEST_URI'] = htmlspecialchars(str_replace('|', '--', $_SERVER['REQUEST_URI']));
 foreach (array('HTTP_HOST', 'HTTP_REFERER', 'HTTP_USER_AGENT', 'REMOTE_ADDR') as $server_type) {
-	$ptype[$server_type] = htmlspecialchars($_SERVER[$server_type]) ?: 'Unknown';
+	$ptype[$server_type] = htmlspecialchars($_SERVER[$server_type] ?? '') ?: 'Unknown';
 }
 
 $ptype['type'] = $ptype['group'] = $ptype['evald'] = $ptype['feed'] = '-';

--- a/src/usr/local/www/widgets/include/widget-pfblockerng.inc
+++ b/src/usr/local/www/widgets/include/widget-pfblockerng.inc
@@ -23,6 +23,10 @@
 //set variables for custom title and link
 $pfblockerng_title = '<span title="Click to open Unified Log tab">pfBlockerNG</span>';
 $pfblockerng_title_link = 'pfblockerng/pfblockerng_alerts.php?view=unified';
+// issue #1777: pfSense dashboard widget-include convention (same family as
+// $widgetname/$pfblockerng_title above); the widget is a singleton (fixed POST
+// action URL, settings keyed off one installedpackages/pfblockerngglobal block).
+$pfblockerng_allow_multiple_widget_copies = FALSE;
 
 // issue #1050: the widget sets $nocsrf=TRUE (csrf-magic never runs here), so a
 // mutating POST handler gates on this instead. DEFAULT-DENY on an absent header

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -751,6 +751,14 @@ function pfBlockerNG_get_header($mode='') {
 				}
 				pfb_close_sqlite($db_handle);
 
+				// issue #1777: a fresh box has no $db_handle (SQLite DB not yet
+				// created) -- $resolver stays empty and every $resolver[0][...]
+				// read below hits an undefined array key. Seed the same shape the
+				// SELECT above produces (row 0, both counters absent/zero).
+				if (!isset($resolver[0])) {
+					$resolver[0] = array('totalqueries' => 0, 'queries' => 0);
+				}
+
 				if (!is_numeric($resolver[0]['totalqueries'])) {
 					$resolver[0]['totalqueries'] = 0;
 				}

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -756,9 +756,12 @@ function pfBlockerNG_get_header($mode='') {
 				// read below hits an undefined array key. Seed the same shape the
 				// SELECT above produces (row 0, both counters absent/zero).
 				// No off-appliance test: reaching here needs a real SQLite handle
-				// plus the enclosing stats walk, so the regression detector is the
-				// live functional-UI sweep plus the baseline entry this fix retires
-				// (a stale baseline line fails the render oracle by itself).
+				// plus the enclosing stats walk, so the named regression detector
+				// is the live functional-UI sweep (tests/smoke/ui) alone -- the
+				// baseline entry this fix retires is only REPORTED as stale by
+				// conftest.py's pytest_sessionfinish (tests/smoke/ui/conftest.py
+				// ~:501-506): a green sweep never proves a fix by itself, only a
+				// burn-down PR that deletes the entry and re-runs RED does.
 				if (!isset($resolver[0])) {
 					$resolver[0] = array('totalqueries' => 0, 'queries' => 0);
 				}

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -692,7 +692,7 @@ function pfBlockerNG_get_header($mode='') {
 				if (isset($pfb['dnsbl_missing'])) {
 					$stats[$key][$type] = "<span title='*** SQLite database 'pfb_py_dnsbl.sqlite' is missing, Force Reload DNSBL to recover! ***'>Unknown</span>";
 				} else {
-					$stats[$key][$type] = htmlspecialchars($pfb_table['stats']['DNSBL']);
+					$stats[$key][$type] = htmlspecialchars($pfb_table['stats']['DNSBL'] ?? '');
 				}
 			}
 

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -755,6 +755,10 @@ function pfBlockerNG_get_header($mode='') {
 				// created) -- $resolver stays empty and every $resolver[0][...]
 				// read below hits an undefined array key. Seed the same shape the
 				// SELECT above produces (row 0, both counters absent/zero).
+				// No off-appliance test: reaching here needs a real SQLite handle
+				// plus the enclosing stats walk, so the regression detector is the
+				// live functional-UI sweep plus the baseline entry this fix retires
+				// (a stale baseline line fails the render oracle by itself).
 				if (!isset($resolver[0])) {
 					$resolver[0] = array('totalqueries' => 0, 'queries' => 0);
 				}

--- a/tests/php/AlertsDnsReplyWhitelistTypeTest.php
+++ b/tests/php/AlertsDnsReplyWhitelistTypeTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1777: convert_dns_reply_log()'s call into dnsbl_whitelist_type()
+ * (:~2498) builds `$dns_fields` with only 2 of the 5 keys the callee reads
+ * (2 and 6) -- unlike its two convert_dnsbl_log() siblings (:2170/:2312),
+ * which pass the raw dnsbl.log $fields array carrying all of 2/5/6/7/8.
+ * dnsbl_whitelist_type() unconditionally reads $fields[5]/[7]/[8] at its top
+ * (pfb_hsc($fields[7]), pfb_hsc($fields[8]), then the != 'DNSBL_TLD' compare
+ * on $fields[5]) -- so every DNS-reply row rendered raises 3 "Undefined array
+ * key" diagnostics.
+ *
+ * Fix: supply keys 5/7/8 -- traced against the function's own read sites
+ * (dnsbl_whitelist_type() body, :1964-2111) rather than guessed:
+ *   - key 5 (DNSBL Mode, gates the != 'DNSBL_TLD' branch split) has no reply-
+ *     log analogue; '' preserves the CURRENT (pre-fix, implicit-NULL) branch
+ *     selection byte-for-byte, since NULL != 'DNSBL_TLD' is also true.
+ *   - key 7 (Evaluated Domain, folded into the exclusion-icon id and the
+ *     wildcard-whitelist walk) has no separate "evaluated" form for a reply
+ *     row -- reused as $fields[6] (the replied domain), the SAME value
+ *     already used for key 2 and the $qdomain argument, so all three referring
+ *     to "the domain this row is about" agree instead of drifting.
+ *   - key 8 (Feed Name) is read only inside the `$fields[6] != 'Unknown'`
+ *     branch (dnsbl_whitelist_type :2023), which the caller's own hardcoded
+ *     `'6' => 'Unknown'` provably never enters -- no reply-log analogue
+ *     exists and none is needed; '' is inert by construction, not a guess.
+ *
+ * Note: the $isExclusion branch (dnsbl_whitelist_type :1978, the OTHER
+ * reachable consumer of key 7) needs pfSense's array_get_path() to run --
+ * no test double exists for it and this fix's file scope does not extend to
+ * adding one to pfsense_doubles.php, so that branch is exercised live (the
+ * functional-UI sweep), not here; the diagnostic-elimination proof below
+ * covers the actual bug (undefined keys 5/7/8), independent of that branch.
+ *
+ * AlertsPageLoader.php (already used by AlertsRowOutputEncodingTest for the
+ * sibling convert_dnsbl_log() callers) defines both functions off-appliance
+ * from the REAL shipped source; the globals stood up in setUp() mirror
+ * convert_dns_reply_log()'s own `global` declaration (:2434).
+ */
+#[CoversFunction('convert_dns_reply_log')]
+#[CoversFunction('dnsbl_whitelist_type')]
+final class AlertsDnsReplyWhitelistTypeTest extends TestCase
+{
+	/** @var array<string, mixed> */
+	private array $savedGlobals = [];
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/AlertsPageLoader.php';
+		pfb_test_load_alerts_page_functions();
+	}
+
+	protected function setUp(): void
+	{
+		foreach ([
+			'pfb', 'local_hosts', 'filterfieldsarray', 'clists', 'counter',
+			'pfbentries', 'skipcount', 'dnsfilterlimit', 'dnsfilterlimitentries',
+		] as $g) {
+			$this->savedGlobals[$g] = $GLOBALS[$g] ?? null;
+		}
+
+		$GLOBALS['pfb'] = ['filterlogentries' => FALSE];
+		// Pre-seeded with the fixture's own SRC IP (below) so the UNRELATED,
+		// pre-existing local_hosts-miss warning never fires and pollutes the
+		// diagnostics list this test is scoped to.
+		$GLOBALS['local_hosts'] = ['10.0.0.9' => ''];
+		$GLOBALS['filterfieldsarray'] = [];
+		$GLOBALS['clists'] = [
+			'dnsbl'          => ['options' => []],
+			'dnsblwhitelist' => ['data' => []],
+			'tldexclusion'   => ['data' => []],
+		];
+		$GLOBALS['counter'] = ['DNS' => 0, 'Unified' => 0];
+		$GLOBALS['pfbentries'] = 1000;
+		$GLOBALS['skipcount'] = 0;
+		$GLOBALS['dnsfilterlimit'] = FALSE;
+		$GLOBALS['dnsfilterlimitentries'] = 100;
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->savedGlobals as $g => $v) {
+			if ($v === null) {
+				unset($GLOBALS[$g]);
+			} else {
+				$GLOBALS[$g] = $v;
+			}
+		}
+	}
+
+	/** DNS-reply $fields row per convert_dns_reply_log()'s own field-index comments (:2441-2449). */
+	private function replyFields(string $domain, string $srcIp): array
+	{
+		return [
+			0 => 'DNS-Reply',
+			1 => '2026-01-01 00:00:00',	// Timestamp
+			2 => 'Reply',			// DNS Reply Type
+			3 => 'A',			// DNS Reply Orig Type
+			4 => 'A',			// DNS Reply Final Type
+			5 => '300',			// DNS Reply TTL
+			6 => $domain,			// DNS Reply Domain
+			7 => $srcIp,			// DNS Reply SRC IP
+			8 => '198.51.100.9',		// DNS Reply DST IP
+			9 => 'US',			// DNS Reply GeoIP
+		];
+	}
+
+	private function runCapturing(callable $fn): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$fn();
+		} finally {
+			restore_error_handler();
+		}
+		return $diagnostics;
+	}
+
+	public function testConvertDnsReplyLogEmitsNoUndefinedArrayKeyDiagnostics(): void
+	{
+		$fields = $this->replyFields('reply.example.test', '10.0.0.9');
+
+		$diagnostics = $this->runCapturing(static function () use ($fields): void {
+			ob_start();
+			convert_dns_reply_log('Reports', $fields);
+			ob_get_clean();
+		});
+
+		$undefined = array_values(array_filter(
+			$diagnostics,
+			static fn(string $d): bool => str_contains($d, 'Undefined array key')
+		));
+		$this->assertSame(
+			[],
+			$undefined,
+			"convert_dns_reply_log() -> dnsbl_whitelist_type() must emit zero 'Undefined array key' diagnostics, got:\n"
+			. implode("\n", $undefined)
+		);
+	}
+}

--- a/tests/php/AlertsDnsReplyWhitelistTypeTest.php
+++ b/tests/php/AlertsDnsReplyWhitelistTypeTest.php
@@ -20,11 +20,19 @@ use PHPUnit\Framework\TestCase;
  *   - key 5 (DNSBL Mode, gates the != 'DNSBL_TLD' branch split) has no reply-
  *     log analogue; '' preserves the CURRENT (pre-fix, implicit-NULL) branch
  *     selection byte-for-byte, since NULL != 'DNSBL_TLD' is also true.
- *   - key 7 (Evaluated Domain, folded into the exclusion-icon id and the
- *     wildcard-whitelist walk) has no separate "evaluated" form for a reply
- *     row -- reused as $fields[6] (the replied domain), the SAME value
- *     already used for key 2 and the $qdomain argument, so all three referring
- *     to "the domain this row is about" agree instead of drifting.
+ *   - key 7 (Evaluated Domain): ''. A prior revision of this fix set key 7 to
+ *     $fields[6] (the replied domain), reasoning only about the
+ *     exclusion-icon id -- it missed that dnsbl_whitelist_type() ALSO feeds
+ *     key 7 into the dot-prefixed wildcard-whitelist walk
+ *     (dnsbl_whitelist_type() ~:2056, `ltrim($fields[7], '.')`). A real
+ *     domain there enters that walk and can flip $isWhitelist_found to TRUE
+ *     for any dot-prefixed whitelist entry that is an ancestor domain --
+ *     silently reclassifying an unrelated reply row as already-whitelisted
+ *     (issue #1777 review, BLOCKING; see
+ *     testConvertDnsReplyLogKeepsPreFixClassificationForDotPrefixedWhitelistEntry
+ *     below). '' is chosen because ltrim(NULL, '.') === ltrim('', '.') ===
+ *     '', so it reproduces the pre-fix NULL read exactly and never enters
+ *     the walk.
  *   - key 8 (Feed Name) is read only inside the `$fields[6] != 'Unknown'`
  *     branch (dnsbl_whitelist_type :2023), which the caller's own hardcoded
  *     `'6' => 'Unknown'` provably never enters -- no reply-log analogue
@@ -144,6 +152,54 @@ final class AlertsDnsReplyWhitelistTypeTest extends TestCase
 			$undefined,
 			"convert_dns_reply_log() -> dnsbl_whitelist_type() must emit zero 'Undefined array key' diagnostics, got:\n"
 			. implode("\n", $undefined)
+		);
+	}
+
+	/**
+	 * issue #1777 review (BLOCKING): a dot-prefixed DNSBL whitelist entry
+	 * ("[.]example.com") must NOT silently reclassify an unrelated DNS-reply
+	 * row for a descendant domain ("ads.example.com") as already-whitelisted.
+	 * Before this fix, $dns_fields['7'] was $fields[6] (the replied domain),
+	 * which entered dnsbl_whitelist_type()'s dot-prefixed wildcard-whitelist
+	 * walk (~:2054-2090) and matched "example.com" as an ancestor of
+	 * "ads.example.com", flipping $isWhitelist_found to TRUE and rendering
+	 * the "delete_domainwildcard" trash icon instead of the pre-fix
+	 * "add to DNSBL" icon (dnsbl_add).
+	 */
+	public function testConvertDnsReplyLogKeepsPreFixClassificationForDotPrefixedWhitelistEntry(): void
+	{
+		$GLOBALS['clists']['dnsblwhitelist']['data'] = ['.example.com' => 'entry'];
+
+		$fields = $this->replyFields('ads.example.com', '10.0.0.9');
+
+		$output = '';
+		$diagnostics = $this->runCapturing(function () use ($fields, &$output): void {
+			ob_start();
+			convert_dns_reply_log('Reports', $fields);
+			$output = ob_get_clean();
+		});
+
+		$undefined = array_values(array_filter(
+			$diagnostics,
+			static fn(string $d): bool => str_contains($d, 'Undefined array key')
+		));
+		$this->assertSame(
+			[],
+			$undefined,
+			"convert_dns_reply_log() -> dnsbl_whitelist_type() must emit zero 'Undefined array key' diagnostics, got:\n"
+			. implode("\n", $undefined)
+		);
+
+		$this->assertStringNotContainsString(
+			'delete_domainwildcard',
+			$output,
+			'a dot-prefixed DNSBL whitelist entry for "example.com" must not silently classify an unrelated '
+			. 'DNS-reply row for "ads.example.com" as already-whitelisted (isWhitelist_found must stay FALSE)'
+		);
+		$this->assertStringContainsString(
+			'dnsbl_add',
+			$output,
+			'the pre-fix classification renders the "Add Domain to DNSBL" icon, not the wildcard-whitelist delete icon'
 		);
 	}
 }

--- a/tests/php/AlertsFilterFieldsInitTest.php
+++ b/tests/php/AlertsFilterFieldsInitTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1777: pfblockerng_alerts.php's top-of-file $filterfieldsarray init
+ * block (:110-125) is 3 independent foreach loops seeding slots 0/1/2 with
+ * their own key set (blank placeholders later populated per-row). The slot-2
+ * loop is a copy-paste of the slot-1 loop with the assignment target never
+ * updated: it writes `$filterfieldsarray[1][$field_2]` instead of
+ * `$filterfieldsarray[2][$field_2]`. Two live consequences on a fresh box:
+ *
+ *   - $filterfieldsarray[2] never gets its 9 keys (81-89), so every
+ *     pfb_match_filter_field($pfbalertreply, $filterfieldsarray[2]) read in
+ *     convert_dns_reply_log() hits an undefined array key -- 9-10 of the
+ *     #1777 sweep's diagnostics.
+ *   - $filterfieldsarray[1] (the DNSBL slot) picks up 9 junk keys (81-89)
+ *     that don't belong to it and leak into the `?refresh=` JSON dump
+ *     (:~4907).
+ *
+ * The init block is pure array assignment with zero external dependencies
+ * (no $pfb/$_POST/DB), so -- unlike the page's request-scoped blocks -- it is
+ * eval-extracted and run standalone, guard-state-agnostic (matches whichever
+ * slot the RHS currently writes to, so this file is red pre-fix and green
+ * post-fix unchanged).
+ */
+final class AlertsFilterFieldsInitTest extends TestCase
+{
+	private const ALERTS_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
+
+	public static function setUpBeforeClass(): void
+	{
+		if (function_exists('pfb_alerts_oracle_filterfieldsarray_init')) {
+			return;
+		}
+		$src = file_get_contents(self::ALERTS_PHP);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_alerts.php');
+		}
+		if (!preg_match(
+			'/\/\/ Initialize filterfieldsarray\n(.*?\$filterfieldsarray\[\d\]\[\$field_2\] = \'\';\n\})\n/s',
+			$src,
+			$m
+		)) {
+			throw new RuntimeException('test bootstrap: filterfieldsarray init block not found');
+		}
+		eval(
+			'function pfb_alerts_oracle_filterfieldsarray_init(): array {'
+			. $m[1]
+			. ' return $filterfieldsarray; }'
+		);
+	}
+
+	public function testSlotTwoIsSeededWithItsOwn81Through89KeySet(): void
+	{
+		$filterfieldsarray = pfb_alerts_oracle_filterfieldsarray_init();
+
+		$this->assertSame(
+			[81, 82, 83, 84, 85, 86, 87, 88, 89],
+			array_keys($filterfieldsarray[2]),
+			'$filterfieldsarray[2] must be seeded with its own 81-89 key set (the slot-2 loop must write to slot 2, not slot 1)'
+		);
+	}
+
+	public function testSlotOneKeepsExactlyItsOwnKeySetNoSlotTwoJunk(): void
+	{
+		$filterfieldsarray = pfb_alerts_oracle_filterfieldsarray_init();
+
+		$this->assertSame(
+			[2, 7, 8, 13, 15, 17, 19, 20, 99],
+			array_keys($filterfieldsarray[1]),
+			'$filterfieldsarray[1] must keep ONLY its own key set -- no 81-89 junk leaking in from the slot-2 loop'
+		);
+	}
+
+	public function testSlotZeroIsUnaffectedControl(): void
+	{
+		$filterfieldsarray = pfb_alerts_oracle_filterfieldsarray_init();
+
+		$this->assertSame(
+			[0, 2, 6, 7, 8, 9, 10, 12, 13, 15, 16, 17, 18, 99],
+			array_keys($filterfieldsarray[0]),
+			'$filterfieldsarray[0] is untouched by the bug -- control assertion'
+		);
+	}
+}

--- a/tests/php/AlertsFreshTopBlockTest.php
+++ b/tests/php/AlertsFreshTopBlockTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Fresh Alerts-page top-level block guard (issue #1768).
+ *
+ * A fresh install / first page load runs pfblockerng_alerts.php's top-level
+ * block (:35-80) -- $aglobal_array defaults, the PfbConfig::readSection()
+ * read that populates $pfb['aglobal'], and the explode() calls that derive
+ * $pfbreplytypes/$pfbreplyrec/$pfbblockstat/$pfbpermitstat/$pfbmatchstat/
+ * $pfbdnsblstat/$pfbdnsblreplystat from it -- against an EMPTY
+ * installedpackages/pfblockerngglobal section (the shape PfbConfig::readSection()
+ * returns when the section has never been saved, i.e. $GLOBALS['config'] has
+ * no such path). Each explode() reads its $pfb['aglobal'][...] operand
+ * directly; on an absent key that operand is NULL, and PHP 8.1+ deprecates
+ * passing NULL to explode()'s non-nullable string parameter -- these are the
+ * "Passing null" deprecations issue #1768 reports blocking the release
+ * functional-UI gate.
+ *
+ * Scope: the assertions below check only the "Passing null" deprecation
+ * class. The SAME block also has bare `$pfb['aglobal']['key'] != ''`/`?:`
+ * reads (e.g. $pfbpageload, $pfbmaxtable, the uni_defaults colour loop) that
+ * still emit "Undefined array key" warnings on an absent key -- those are
+ * the pre-existing, explicitly out-of-scope "3e bare-read class" (#1768
+ * brief); asserting the FULL diagnostics list empty would conflate the two
+ * and this test would never go green.
+ *
+ * AlertsPageLoader (tests/php/AlertsPageLoader.php) deliberately starts its
+ * eval at the first `function` keyword, EXCLUDING this top-level block -- so
+ * it is extracted directly here instead, anchored on the unique
+ * `$aglobal_array = array(` line through the last explode() assignment
+ * (`$pfbdnsblreplystat = explode(...)`), non-greedy so the regex matches
+ * whatever the RHS guard state is and survives the fix.
+ */
+final class AlertsFreshTopBlockTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
+		);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_alerts.php');
+		}
+
+		if (!function_exists('pfb_alerts_oracle_fresh_top')) {
+			if (!preg_match(
+				'/(\$aglobal_array\s*=\s*array\(.*?\n\$pfbdnsblreplystat\s*=\s*explode\([^\n]*\n)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: alerts fresh top-level block not found');
+			}
+			eval(
+				'function pfb_alerts_oracle_fresh_top(): array {'
+				. ' global $pfb;'
+				. $m[1]
+				. ' return get_defined_vars(); }'
+			);
+		}
+	}
+
+	private $savedConfig;
+	private $savedPfb;
+
+	protected function setUp(): void
+	{
+		// Isolate from whatever a sibling test left in these globals.
+		$this->savedConfig = $GLOBALS['config'] ?? null;
+		$this->savedPfb    = $GLOBALS['pfb'] ?? null;
+		unset($GLOBALS['config']);
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->savedConfig === null) {
+			unset($GLOBALS['config']);
+		} else {
+			$GLOBALS['config'] = $this->savedConfig;
+		}
+		if ($this->savedPfb === null) {
+			unset($GLOBALS['pfb']);
+		} else {
+			$GLOBALS['pfb'] = $this->savedPfb;
+		}
+	}
+
+	/** @return array{0: array, 1: string[]} [$vars, $diagnostics] */
+	private function runCapturingDiagnostics(): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$vars = pfb_alerts_oracle_fresh_top();
+		} finally {
+			restore_error_handler();
+		}
+		return [$vars, $diagnostics];
+	}
+
+	/** @return string[] the diagnostics whose message is a "Passing null" deprecation */
+	private static function nullDeprecationsOnly(array $diagnostics): array
+	{
+		return array_values(array_filter(
+			$diagnostics,
+			static fn(string $d): bool => str_contains($d, 'Passing null')
+		));
+	}
+
+	public function testFreshAlertsTopBlockEmitsNoPassingNullDeprecations(): void
+	{
+		// No $GLOBALS['config'] -> PfbConfig::readSection() returns [] ->
+		// $pfb['aglobal'] = [] -- the fresh-install shape.
+		[$vars, $diagnostics] = $this->runCapturingDiagnostics();
+
+		$nullDeprecations = self::nullDeprecationsOnly($diagnostics);
+		$this->assertSame(
+			[],
+			$nullDeprecations,
+			"fresh Alerts top-level block must emit zero 'Passing null' deprecations, got:\n" . implode("\n", $nullDeprecations)
+		);
+		// explode(',', '') yields a single empty-string element, not [] -- the
+		// caller-visible shape is unchanged by the guard (behaviour-preserving).
+		$this->assertSame([''], $vars['pfbreplytypes']);
+	}
+
+	public function testPopulatedAlertsTopBlockExplodeSitesPassThroughUnchanged(): void
+	{
+		// Axis 2 (populated key): the guard must be a no-op when the field IS
+		// present -- proves the fix didn't clobber real explode() output.
+		$GLOBALS['config'] = [
+			'installedpackages' => [
+				'pfblockerngglobal' => [
+					'pfbreplytypes'      => 'A,AAAA',
+					'pfbreplyrec'        => '1,2',
+					'pfbblockstat'       => 'x,y',
+					'pfbpermitstat'      => 'p,q',
+					'pfbmatchstat'       => 'm,n',
+					'pfbdnsblstat'       => 'd1,d2',
+					'pfbdnsblreplystat'  => 'r1,r2',
+				],
+			],
+		];
+
+		[$vars, $diagnostics] = $this->runCapturingDiagnostics();
+
+		$this->assertSame([], self::nullDeprecationsOnly($diagnostics));
+		$this->assertSame(['A', 'AAAA'], $vars['pfbreplytypes']);
+		$this->assertSame(['1', '2'], $vars['pfbreplyrec']);
+		$this->assertSame(['x', 'y'], $vars['pfbblockstat']);
+		$this->assertSame(['p', 'q'], $vars['pfbpermitstat']);
+		$this->assertSame(['m', 'n'], $vars['pfbmatchstat']);
+		$this->assertSame(['d1', 'd2'], $vars['pfbdnsblstat']);
+		$this->assertSame(['r1', 'r2'], $vars['pfbdnsblreplystat']);
+	}
+}

--- a/tests/php/AlertsPieBlockAndStatsGuardTest.php
+++ b/tests/php/AlertsPieBlockAndStatsGuardTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1777: two narrow diagnostic-only guards in pfblockerng_alerts.php,
+ * each eval-extracted VERBATIM (pure array-index logic, no page state) and
+ * run standalone -- guard-state-agnostic, so this file is red pre-fix and
+ * green post-fix unchanged.
+ *
+ * (a) pie_block() (:4917-5052, mixed HTML/PHP template) segments the pie
+ *     chart over `for ($i = 0; $i < ($numsegments-1); $i++) { if ($k[$i]) ...`
+ *     -- $numsegments-1 can exceed count($k) (fewer real entries than pie
+ *     segments), so $k[$i] undefined-key warns on every trailing iteration.
+ *     The read is already effectively optional (falsy skips the segment) --
+ *     `?? NULL` silences the warning without changing which iterations build
+ *     a segment. The loop bound must NOT be shortened: $i survives the loop
+ *     and is read again (`$segcolors[$i % $numsegments]`) to colour the
+ *     trailing "Other" segment -- bounding the loop to count($k) would shift
+ *     $i and silently change that colour.
+ *
+ * (b) The alert-summary day/hour stat loop (:1774-1785) splits a shell stat
+ *     line on the first space (`explode(' ', trim($line), 2)`); a line with
+ *     no space at all (a stray/short summary row) yields a single-element
+ *     $data, so $data[1] is undefined -- `?? ''` keeps the existing `?:
+ *     $unknown_msg` fallback semantics (both '' and NULL are falsy) while
+ *     dropping the warning.
+ */
+final class AlertsPieBlockAndStatsGuardTest extends TestCase
+{
+	private const ALERTS_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(self::ALERTS_PHP);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_alerts.php');
+		}
+
+		if (!function_exists('pfb_alerts_oracle_pie_segment_loop')) {
+			// Anchored on the for-loop header through the "Other" segment block's
+			// closing brace -- captures BOTH the guarded $k[$i] read and the
+			// post-loop $i re-use verbatim, in one extraction.
+			if (!preg_match(
+				'/(for \(\$i = 0; \$i < \(\$numsegments-1\); \$i\+\+\) \{\n.*?\n\t\}\n\n'
+				. '\t\$balance = \$sumlines - \$numentries;\n'
+				. '\tif \(\$balance > 0\) \{\n.*?\n\t\})\n\?>/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: pie_block segment loop not found');
+			}
+			eval(
+				'function pfb_alerts_oracle_pie_segment_loop(array $summary, int $numsegments, array $segcolors, int $sumlines): array {'
+				. ' $k = array_keys($summary); $numentries = 0; ob_start();'
+				. $m[1]
+				. ' $out = (string) ob_get_clean();'
+				. ' return [$out, $numentries, $i]; }'
+			);
+		}
+
+		if (!function_exists('pfb_alerts_oracle_stat_bucket_key')) {
+			if (!preg_match(
+				'/\$data = array_map\(\'trim\', explode\(\' \', trim\(\$line\), 2\)\);\n\t*'
+				. '(\$alert_stats\[\$alert_view\]\[\$stat_type\]\[[^\n]*\n)/',
+				$src,
+				$m2
+			)) {
+				throw new RuntimeException('test bootstrap: stat-bucket line not found');
+			}
+			eval(
+				'function pfb_alerts_oracle_stat_bucket_key(string $line, string $unknown_msg): array {'
+				. ' $alert_view = \'v\'; $stat_type = \'t\'; $alert_stats = [];'
+				. ' $data = array_map(\'trim\', explode(\' \', trim($line), 2));'
+				. $m2[1]
+				. ' return [array_key_first($alert_stats[\'v\'][\'t\']), reset($alert_stats[\'v\'][\'t\'])]; }'
+			);
+		}
+	}
+
+	private function runCapturing(callable $fn): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$result = $fn();
+		} finally {
+			restore_error_handler();
+		}
+		return [$result, $diagnostics];
+	}
+
+	/** @return string[] */
+	private static function undefinedKeyDiagnostics(array $diagnostics): array
+	{
+		return array_values(array_filter($diagnostics, static fn (string $d): bool => str_contains($d, 'Undefined array key')));
+	}
+
+	// -----------------------------------------------------------------------
+	// (a) pie_block() segment loop.
+	// -----------------------------------------------------------------------
+
+	public function testPieSegmentLoopEmitsNoUndefinedArrayKeyWhenFewerEntriesThanSegments(): void
+	{
+		// 2 real entries, 5 pie segments -> the loop runs $i=0..3, and $k[2]/$k[3]
+		// are undefined (only $k[0]/$k[1] exist).
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_alerts_oracle_pie_segment_loop(
+			['a.example' => 10, 'b.example' => 5],
+			5,
+			['#111', '#222', '#333', '#444', '#555'],
+			15
+		));
+
+		$undefined = self::undefinedKeyDiagnostics($diagnostics);
+		$this->assertSame([], $undefined, "pie_block()'s segment loop must emit zero 'Undefined array key' diagnostics, got:\n" . implode("\n", $undefined));
+
+		[$out, $numentries, ] = $result;
+		$this->assertSame(2, $numentries, 'only the 2 real entries must build a segment (behaviour-preserving)');
+		$this->assertStringContainsString('a.example', $out);
+		$this->assertStringContainsString('b.example', $out);
+	}
+
+	public function testPieSegmentLoopPostLoopIndexIsUnchangedByTheGuard(): void
+	{
+		// Pins the "Other" segment colour derivation: $i must equal the loop's
+		// natural post-condition value ($numsegments-1), NOT be shortened by a
+		// count($k)-based bound -- the exact regression this fix must avoid.
+		$numsegments = 5;
+		[$result, ] = $this->runCapturing(static fn () => pfb_alerts_oracle_pie_segment_loop(
+			['a.example' => 10, 'b.example' => 5],
+			$numsegments,
+			['#111', '#222', '#333', '#444', '#555'],
+			15
+		));
+
+		[$out, , $finalI] = $result;
+		$this->assertSame($numsegments - 1, $finalI, '$i must survive the loop unshortened -- bounding to count($k) would change this');
+		// $segcolors[$i % $numsegments] with the unshortened $i=4 -> index 4 -> '#555'.
+		$this->assertStringContainsString('"color": "#555"', $out, 'the "Other" segment colour must use the UNSHORTENED post-loop $i');
+	}
+
+	// -----------------------------------------------------------------------
+	// (b) alert-summary stat bucket key.
+	// -----------------------------------------------------------------------
+
+	public function testStatBucketKeyEmitsNoUndefinedArrayKeyOnASpacelessLine(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_alerts_oracle_stat_bucket_key('14', 'Unknown'));
+
+		$undefined = self::undefinedKeyDiagnostics($diagnostics);
+		$this->assertSame([], $undefined, "the stat-bucket key build must emit zero 'Undefined array key' diagnostics on a spaceless line, got:\n" . implode("\n", $undefined));
+		[$bucketKey, ] = $result;
+		$this->assertSame('Unknown', $bucketKey, 'a spaceless line must still fall back to $unknown_msg (behaviour-preserving)');
+	}
+
+	public function testStatBucketKeyPassesThroughAWellFormedLineUnchanged(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_alerts_oracle_stat_bucket_key('  12 example.com', 'Unknown'));
+
+		$this->assertSame([], self::undefinedKeyDiagnostics($diagnostics));
+		[$bucketKey, $bucketCount] = $result;
+		$this->assertSame('example.com', $bucketKey, 'a well-formed line must still bucket by its own key (behaviour-preserving)');
+		$this->assertSame('12', $bucketCount);
+	}
+}

--- a/tests/php/BlacklistLangFallbackTest.php
+++ b/tests/php/BlacklistLangFallbackTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1777: pfblockerng_blacklist.php's per-category language render
+ * (:485/:516) reads $info[$pconfig['blacklist_lang']][1]/[0] directly. Most
+ * *_global_usage providers carry a DESC line (index [0]) only for a subset of
+ * languages (e.g. DE/IT/NL/ES/RU are frequently NAME-only, no DESC, for a
+ * given category) -- an absent index raises an "Undefined array key"
+ * diagnostic on every affected category/language combination, and the
+ * pre-existing `?:` fallback to EN silently degrades to warn-then-fall-back
+ * instead of a clean read.
+ *
+ * Both target expressions -- and the real parse loop that BUILDS $info
+ * (:456-481) -- are eval-extracted VERBATIM from the real shipped page
+ * source and exercised against the REAL shipped src/usr/local/pkg/
+ * pfblockerng/ut1_global_usage provider file (dependency-free: no Form_*
+ * pfSense UI classes are needed, since only the two bare expressions are
+ * extracted, not the Form_Group/Form_Checkbox rendering around them).
+ *
+ * The fix restructures the read into `$l = $info[lang] ?? array(); $e =
+ * $info['EN'] ?? array();` followed by `($l[i] ?? '') ?: ($e[i] ?? '')` --
+ * unlike the other #1777 sites, this is a SHAPE change (2 new lines), not an
+ * in-place `?? ''` insertion, so the extraction anchors on stable
+ * before/after markers with a free-form (non-greedy, DOTALL) middle instead
+ * of a single-line RHS pattern -- it captures 0 extra lines pre-fix and 2
+ * post-fix, so the same regex (and this file) is red before the fix and
+ * green after, unchanged.
+ */
+final class BlacklistLangFallbackTest extends TestCase
+{
+	private const BLACKLIST_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_blacklist.php';
+	private const UT1_FILE = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/ut1_global_usage';
+
+	/** Matches pfblockerng_blacklist.php's own $options_blacklist_lang (:143-144). */
+	private const LANGS = ['EN', 'DE', 'FR', 'IT', 'NL', 'PT', 'ES', 'RU'];
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(self::BLACKLIST_PHP);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_blacklist.php');
+		}
+
+		if (!function_exists('pfb_blacklist_oracle_parse_data')) {
+			if (!preg_match(
+				'/(\/\/ Build array of Blacklist categories and descriptions by language\n.*?\n\tksort\(\$data, SORT_NATURAL\);\n)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: blacklist category/description parse block not found');
+			}
+			eval(
+				'function pfb_blacklist_oracle_parse_data(array $contents): array {'
+				. ' $type = \'x\'; $blacklist_types = [\'x\' => [\'CONTENTS\' => $contents]];'
+				. $m[1]
+				. ' return $data; }'
+			);
+		}
+
+		if (!function_exists('pfb_blacklist_oracle_lang_fallback')) {
+			if (!preg_match(
+				'/foreach \(\$data as \$category => \$info\) \{\n(.*?\$category_lang = [^\n]*;\n)/s',
+				$src,
+				$m1
+			)) {
+				throw new RuntimeException('test bootstrap: $category_lang block not found');
+			}
+			// The SECOND Form_StaticText() call (identified by its ->setWidth(7)
+			// suffix -- the first, using $category_lang, has none) wraps the
+			// NAME-index (:0) expression as its bare 2nd constructor argument.
+			if (!preg_match(
+				'/Form_StaticText\(\s*\n\s*\'\',\s*\n\s*((?:(?!Form_StaticText).)*?)\n\s*\)\)->setWidth\(7\);/s',
+				$src,
+				$m2
+			)) {
+				throw new RuntimeException('test bootstrap: NAME-index Form_StaticText expression not found');
+			}
+			eval(
+				'function pfb_blacklist_oracle_lang_fallback(array $info, string $lang): array {'
+				. ' $pconfig = [\'blacklist_lang\' => $lang];'
+				. $m1[1]
+				. ' $name_lang = ' . $m2[1] . ';'
+				. ' return [$category_lang, $name_lang]; }'
+			);
+		}
+	}
+
+	/**
+	 * Replicates the provider-discovery loop's CONTENTS filtering (:52-101,
+	 * unaffected by this fix): drop comments/blanks and the metadata (TITLE/
+	 * DESCR/XML/FEED/SIZE/WEBSITE/LICENSE/REG) header lines, keeping the
+	 * NAME:/DESC LANG:/NAME LANG: category lines the parse loop under test reads.
+	 */
+	private static function loadRealProviderContents(): array
+	{
+		$raw = file(self::UT1_FILE, FILE_SKIP_EMPTY_LINES | FILE_IGNORE_NEW_LINES);
+		if ($raw === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read ut1_global_usage');
+		}
+		$contents = [];
+		foreach ($raw as $line) {
+			$trimmed = trim($line);
+			if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+				continue;
+			}
+			if (preg_match('/^(TITLE|DESCR|XML|FEED|SIZE|WEBSITE|LICENSE|REG):/', $trimmed)) {
+				continue;
+			}
+			$contents[] = $line;
+		}
+		return $contents;
+	}
+
+	public function testEveryCategoryAndLanguageEmitsZeroDiagnosticsAndEnFallbackHolds(): void
+	{
+		$data = pfb_blacklist_oracle_parse_data(self::loadRealProviderContents());
+		$this->assertNotEmpty($data, 'fixture sanity: the real ut1_global_usage must parse into at least one category');
+
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+
+		$missing0Proven = FALSE;
+		$missing1Proven = FALSE;
+		try {
+			foreach ($data as $category => $info) {
+				// fixture sanity: EN must be fully populated for every real category
+				// (the fallback target must itself never be the thing that's missing).
+				$this->assertArrayHasKey('EN', $info, "category '{$category}' has no EN entry at all");
+				$this->assertArrayHasKey(0, $info['EN'], "category '{$category}' EN has no DESC (index 0)");
+				$this->assertArrayHasKey(1, $info['EN'], "category '{$category}' EN has no NAME (index 1)");
+
+				foreach (self::LANGS as $lang) {
+					[$categoryLang, $nameLang] = pfb_blacklist_oracle_lang_fallback($info, $lang);
+
+					if (!isset($info[$lang][1])) {
+						$missing1Proven = TRUE;
+						$this->assertSame($info['EN'][1], $categoryLang, "category '{$category}'/{$lang}: missing index 1 must fall back to EN's NAME");
+					}
+					if (!isset($info[$lang][0])) {
+						$missing0Proven = TRUE;
+						$this->assertSame($info['EN'][0], $nameLang, "category '{$category}'/{$lang}: missing index 0 must fall back to EN's DESC");
+					}
+				}
+			}
+		} finally {
+			restore_error_handler();
+		}
+
+		// fixture sanity: the real provider file must actually exercise BOTH
+		// missing-index branches at least once, or the fallback assertions above
+		// never ran for real.
+		$this->assertTrue($missing0Proven, 'fixture sanity: no category/language combo in ut1_global_usage is missing index 0 -- the EN-DESC-fallback branch was never exercised');
+		$this->assertTrue($missing1Proven, 'fixture sanity: no category/language combo in ut1_global_usage is missing index 1 -- the EN-NAME-fallback branch was never exercised');
+
+		$undefined = array_values(array_filter(
+			$diagnostics,
+			static fn (string $d): bool => str_contains($d, 'Undefined array key')
+		));
+		$this->assertSame(
+			[],
+			$undefined,
+			"every category/language combination in the real ut1_global_usage must emit zero 'Undefined array key' diagnostics, got "
+			. count($undefined) . ' (first: ' . ($undefined[0] ?? '') . ')'
+		);
+	}
+}

--- a/tests/php/DnsblFreshPconfigTest.php
+++ b/tests/php/DnsblFreshPconfigTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Fresh DNSBL-page $pconfig assembly guard (issue #1768).
+ *
+ * A fresh install / first page load runs pfblockerng_dnsbl.php's $pconfig
+ * assembly (:49-132) against an EMPTY installedpackages/pfblockerngdnsblsettings
+ * section ($pfb['dconfig'] = [] -- the shape PfbConfig::readSection() returns
+ * when the section has never been saved). Every explode()/base64_decode()
+ * call in that block reads its $pfb['dconfig'][...] operand directly; on an
+ * absent key that operand is NULL, and PHP 8.1+ deprecates passing NULL to
+ * explode()'s/base64_decode()'s non-nullable string parameter -- these are
+ * the "Passing null" deprecations issue #1768 reports blocking the release
+ * functional-UI gate.
+ *
+ * Scope: the assertions below check only the "Passing null" deprecation
+ * class. The SAME block also has ~20 untouched bare
+ * `$pfb['dconfig']['key'] ?: default` reads that still emit "Undefined array
+ * key" warnings on an absent key -- those are the pre-existing, explicitly
+ * out-of-scope "3e bare-read class" (#1768 brief); asserting the FULL
+ * diagnostics list empty would conflate the two and this test would never
+ * go green.
+ *
+ * The page carries top-level execution and cannot be require()d
+ * off-appliance, so the $pconfig block is eval-extracted verbatim from the
+ * REAL source (CategoryEditFreshRowPconfigTest's pattern, issue #1211),
+ * anchored on the unique `$pconfig = array();` line through the trailing
+ * `tldblacklist` assignment -- non-greedy, so the regex matches whatever the
+ * RHS guard state is (pre-fix bare read or post-fix `?? ''`-guarded) and
+ * survives the fix -- and run as a pure function of ($dconfig, $default_tlds).
+ */
+final class DnsblFreshPconfigTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php'
+		);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_dnsbl.php');
+		}
+
+		if (!function_exists('pfb_dnsbl_oracle_fresh_pconfig')) {
+			if (!preg_match(
+				'/\$pconfig\s*= array\(\);\n'
+				. '(.*?\n\s*\$pconfig\[\'tldblacklist\'\][^\n]*\n)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: dnsbl fresh $pconfig block not found');
+			}
+			eval(
+				'function pfb_dnsbl_oracle_fresh_pconfig(array $dconfig, array $default_tlds): array {'
+				. ' global $pfb; $pfb[\'dconfig\'] = $dconfig;'
+				. ' $pconfig = array();'
+				. $m[1]
+				. ' return $pconfig; }'
+			);
+		}
+	}
+
+	/** @return array{0: array, 1: string[]} [$pconfig, $diagnostics] */
+	private function runCapturingDiagnostics(array $dconfig, array $default_tlds): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$pconfig = pfb_dnsbl_oracle_fresh_pconfig($dconfig, $default_tlds);
+		} finally {
+			restore_error_handler();
+		}
+		return [$pconfig, $diagnostics];
+	}
+
+	/** @return string[] the diagnostics whose message is a "Passing null" deprecation */
+	private static function nullDeprecationsOnly(array $diagnostics): array
+	{
+		return array_values(array_filter(
+			$diagnostics,
+			static fn(string $d): bool => str_contains($d, 'Passing null')
+		));
+	}
+
+	public function testFreshDnsblPconfigEmitsNoPassingNullDeprecations(): void
+	{
+		[$pconfig, $diagnostics] = $this->runCapturingDiagnostics(
+			[],
+			['arpa', 'example.com', 'com', 'net', 'org', 'edu', 'ca', 'co', 'io']
+		);
+
+		$nullDeprecations = self::nullDeprecationsOnly($diagnostics);
+		$this->assertSame(
+			[],
+			$nullDeprecations,
+			"fresh-config \$pconfig assembly must emit zero 'Passing null' deprecations, got:\n" . implode("\n", $nullDeprecations)
+		);
+		$this->assertIsArray($pconfig);
+	}
+
+	public function testPopulatedDnsblPconfigDecodeExplodeSitesPassThroughUnchanged(): void
+	{
+		// Axis 2 (populated key): the guard must be a no-op when the field IS
+		// present -- proves the fix didn't clobber real decode/explode output.
+		$dconfig = [
+			'dnsbl_allow_int'    => 'wan,lan',
+			'pfb_pytlds_gtld'    => 'com,net',
+			'pfb_pytlds_cctld'   => 'uk,de',
+			'pfb_pytlds_itld'    => 'xn--p1ai',
+			'pfb_pytlds_bgtld'   => 'app,dev',
+			'pfb_regex_list'     => base64_encode("foo\nbar"),
+			'pfb_noaaaa_list'    => base64_encode('example.com'),
+			'pfb_gp_bypass_list' => base64_encode('192.0.2.1'),
+			'suppression'        => base64_encode('192.0.2.0/24'),
+			'alexa_inclusion'    => 'com,net,org',
+			'tldexclusion'       => base64_encode('example.test'),
+			'tldblacklist'       => base64_encode('bad.example'),
+		];
+
+		[$pconfig, $diagnostics] = $this->runCapturingDiagnostics(
+			$dconfig,
+			['arpa', 'lan.local', 'com', 'net', 'org', 'edu', 'ca', 'co', 'io']
+		);
+
+		$this->assertSame([], self::nullDeprecationsOnly($diagnostics));
+		$this->assertSame(['wan', 'lan'], $pconfig['dnsbl_allow_int']);
+		$this->assertSame(['com', 'net'], $pconfig['pfb_pytlds_gtld']);
+		$this->assertSame(['uk', 'de'], $pconfig['pfb_pytlds_cctld']);
+		$this->assertSame(['xn--p1ai'], $pconfig['pfb_pytlds_itld']);
+		$this->assertSame(['app', 'dev'], $pconfig['pfb_pytlds_bgtld']);
+		$this->assertSame("foo\nbar", $pconfig['pfb_regex_list']);
+		$this->assertSame('example.com', $pconfig['pfb_noaaaa_list']);
+		$this->assertSame('192.0.2.1', $pconfig['pfb_gp_bypass_list']);
+		$this->assertSame('192.0.2.0/24', $pconfig['suppression']);
+		$this->assertSame(['com', 'net', 'org'], $pconfig['alexa_inclusion']);
+		$this->assertSame('example.test', $pconfig['tldexclusion']);
+		$this->assertSame('bad.example', $pconfig['tldblacklist']);
+	}
+}

--- a/tests/php/FilterlogFieldGuardTest.php
+++ b/tests/php/FilterlogFieldGuardTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_daemon_filterlog()'s CSV field-count guard (issue #1768).
+ *
+ * pfb_daemon_filterlog() reads php://stdin in an unbounded daemon loop and
+ * is not directly callable from a unit test (see LogTimestampBaselineTest's
+ * docblock -- the same constraint applies here; no test in this suite calls
+ * it directly, confirmed by grep). A short/malformed filterlog line (fewer
+ * space-separated fields than the BSD/syslog $f_pos offset expects) left
+ * $f[$f_pos] undefined, and `explode(',', $f[$f_pos])` on that undefined
+ * offset passed NULL to explode() -- a PHP 8.1+ deprecation, and part of the
+ * #1768 "Passing null" gate failure.
+ *
+ * This test extracts the exact field-split snippet verbatim from the real
+ * source (same eval-extraction technique as DnsblFreshPconfigTest/
+ * AlertsFreshTopBlockTest), anchored on the unique `$log_type = 'BSD';` line
+ * through the `$d = explode(',', $f[$f_pos]...)` line -- non-greedy, so the
+ * regex matches whatever the RHS guard state is and survives the fix -- and
+ * runs it as a pure function of $line.
+ */
+final class FilterlogFieldGuardTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
+		);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		}
+
+		if (!function_exists('pfb_filterlog_oracle_field_guard')) {
+			if (!preg_match(
+				'/(\$log_type = \'BSD\';\n.*?\n\s*\$d = explode\(\',\', \$f\[\$f_pos\][^\n]*\n)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: filterlog field-split snippet not found');
+			}
+			eval(
+				'function pfb_filterlog_oracle_field_guard(string $line): array {'
+				. $m[1]
+				. ' return [$f_pos, $f, $d]; }'
+			);
+		}
+	}
+
+	/** @return array{0: array, 1: string[]} [[$f_pos, $f, $d], $diagnostics] */
+	private function runCapturingDiagnostics(string $line): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		}, E_WARNING | E_DEPRECATED);
+		try {
+			$result = pfb_filterlog_oracle_field_guard($line);
+		} finally {
+			restore_error_handler();
+		}
+		return [$result, $diagnostics];
+	}
+
+	public function testShortBsdLineDoesNotPassNullToExplode(): void
+	{
+		// BSD format: $f_pos = 5. Only 3 space-separated fields -- $f[5] is
+		// undefined.
+		[[$f_pos, $f, $d], $diagnostics] = $this->runCapturingDiagnostics('a b c');
+
+		$this->assertSame(5, $f_pos);
+		$this->assertArrayNotHasKey(5, $f);
+		$this->assertSame(
+			[],
+			$diagnostics,
+			"short BSD-format line must emit zero diagnostics, got:\n" . implode("\n", $diagnostics)
+		);
+		$this->assertSame([''], $d);
+	}
+
+	public function testShortSyslogLineDoesNotPassNullToExplode(): void
+	{
+		// A leading '<' selects syslog format: $f_pos = 7. Only 3
+		// space-separated fields -- $f[7] is undefined.
+		[[$f_pos, $f, $d], $diagnostics] = $this->runCapturingDiagnostics('<14>a b c');
+
+		$this->assertSame(7, $f_pos);
+		$this->assertArrayNotHasKey(7, $f);
+		$this->assertSame(
+			[],
+			$diagnostics,
+			"short syslog-format line must emit zero diagnostics, got:\n" . implode("\n", $diagnostics)
+		);
+		$this->assertSame([''], $d);
+	}
+
+	public function testLongEnoughBsdLineFieldPassesThroughUnchanged(): void
+	{
+		// Axis 2: a line WITH a field at $f_pos must still reach $d unchanged
+		// (the guard is a no-op when the field is present).
+		$line = 'a b c d e tracker,extra';
+		[[$f_pos, $f, $d], $diagnostics] = $this->runCapturingDiagnostics($line);
+
+		$this->assertSame(5, $f_pos);
+		$this->assertSame('tracker,extra', $f[5]);
+		$this->assertSame([], $diagnostics);
+		$this->assertSame(['tracker', 'extra'], $d);
+	}
+}

--- a/tests/php/FreshConfigNullGuardCloseoutTest.php
+++ b/tests/php/FreshConfigNullGuardCloseoutTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Closes out issue #1768: a live functional-UI render sweep (run 30249107774)
+ * found 2 "Passing null" deprecation sites the original #1768 commit missed.
+ * Both are single-argument string calls reading a value that is absent on a
+ * fresh box/request, exactly the same deprecation class #1768 already closed
+ * ~85 other call sites for.
+ *
+ * - www/index.php:37 -- the per-request $ptype[$server_type] build reads
+ *   $_SERVER[$server_type] directly for HTTP_REFERER/HTTP_USER_AGENT, which a
+ *   client is not required to send; an absent key is NULL, passed straight
+ *   into htmlspecialchars().
+ * - pfblockerng.widget.php:695 -- the DNSBL row of the "Queries" stat block
+ *   reads $pfb_table['stats']['DNSBL'], which is populated ONLY inside the
+ *   `if (!empty($pfb_table))` loop over update-table entries; on a fresh box
+ *   (no aliases/lists synced yet) that loop never runs and the key stays
+ *   unset.
+ *
+ * Neither file is require()-able off-appliance (index.php is top-level page
+ * execution; the widget file's stat block lives inside pfBlockerNG_get_header(),
+ * a page-scoped function with prior SQLite/session setup this test does not
+ * want to stand up) -- so, following DnsblFreshPconfigTest/AlertsFreshTopBlockTest's
+ * established idiom, each narrow region is eval-extracted VERBATIM from the
+ * real shipped source and run as a pure function of its inputs. The
+ * extraction regexes are non-greedy / guard-state-agnostic, so this same test
+ * file is red against the pre-fix source and green after the fix, unchanged.
+ */
+final class FreshConfigNullGuardCloseoutTest extends TestCase
+{
+	private const INDEX_PHP  = __DIR__ . '/../../src/usr/local/www/pfblockerng/www/index.php';
+	private const WIDGET_PHP = __DIR__ . '/../../src/usr/local/www/widgets/widgets/pfblockerng.widget.php';
+
+	public static function setUpBeforeClass(): void
+	{
+		if (!function_exists('pfb_index_oracle_ptype_server_field')) {
+			$src = file_get_contents(self::INDEX_PHP);
+			if ($src === FALSE) {
+				throw new RuntimeException('test bootstrap: failed to read www/index.php');
+			}
+			if (!preg_match(
+				'/\$ptype\[\$server_type\] = htmlspecialchars\(\$_SERVER\[\$server_type\][^\n]*\n/',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: index.php $ptype server-field line not found');
+			}
+			eval(
+				'function pfb_index_oracle_ptype_server_field(bool $setKey, string $value = \'\'): string {'
+				. ' $ptype = array(); $server_type = \'HTTP_REFERER\';'
+				. ' if ($setKey) { $_SERVER[$server_type] = $value; } else { unset($_SERVER[$server_type]); }'
+				. $m[0]
+				. ' return $ptype[$server_type]; }'
+			);
+		}
+
+		if (!function_exists('pfb_widget_oracle_dnsbl_stat')) {
+			$src = file_get_contents(self::WIDGET_PHP);
+			if ($src === FALSE) {
+				throw new RuntimeException('test bootstrap: failed to read pfblockerng.widget.php');
+			}
+			if (!preg_match(
+				'/(if \(\$type == \'DNSBL\'\) \{\n.*?\n\t\t\t\})\n/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: widget DNSBL stat block not found');
+			}
+			eval(
+				'function pfb_widget_oracle_dnsbl_stat(array $pfb, array $pfb_table): string {'
+				. ' $stats = array(); $key = 0; $type = \'DNSBL\';'
+				. $m[1]
+				. ' return $stats[$key][$type]; }'
+			);
+		}
+	}
+
+	private bool $hadServerReferer;
+	private mixed $savedServerReferer;
+
+	protected function setUp(): void
+	{
+		$this->hadServerReferer   = array_key_exists('HTTP_REFERER', $_SERVER);
+		$this->savedServerReferer = $_SERVER['HTTP_REFERER'] ?? null;
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadServerReferer) {
+			$_SERVER['HTTP_REFERER'] = $this->savedServerReferer;
+		} else {
+			unset($_SERVER['HTTP_REFERER']);
+		}
+	}
+
+	/** @return string[] the diagnostics whose message is a "Passing null" deprecation */
+	private static function nullDeprecationsOnly(array $diagnostics): array
+	{
+		return array_values(array_filter(
+			$diagnostics,
+			static fn(string $d): bool => str_contains($d, 'Passing null')
+		));
+	}
+
+	private function runCapturing(callable $fn): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$result = $fn();
+		} finally {
+			restore_error_handler();
+		}
+		return [$result, $diagnostics];
+	}
+
+	// -----------------------------------------------------------------------
+	// www/index.php:37 -- $ptype[$server_type] server-header read.
+	// -----------------------------------------------------------------------
+
+	public function testIndexPtypeServerFieldEmitsNoPassingNullDeprecationWhenHeaderAbsent(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(
+			static fn (): string => pfb_index_oracle_ptype_server_field(FALSE)
+		);
+
+		$this->assertSame(
+			[],
+			self::nullDeprecationsOnly($diagnostics),
+			"index.php's \$ptype server-field build must emit zero 'Passing null' deprecations when the client sends no Referer header, got:\n"
+			. implode("\n", self::nullDeprecationsOnly($diagnostics))
+		);
+		$this->assertSame('Unknown', $result, 'an absent header must still fall back to "Unknown" (behaviour-preserving)');
+	}
+
+	public function testIndexPtypeServerFieldPassesThroughAPopulatedHeaderUnchanged(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(
+			static fn (): string => pfb_index_oracle_ptype_server_field(TRUE, 'https://example.com/<script>')
+		);
+
+		$this->assertSame([], self::nullDeprecationsOnly($diagnostics));
+		$this->assertSame(
+			'https://example.com/&lt;script&gt;',
+			$result,
+			'a present header must still pass through htmlspecialchars() unchanged (behaviour-preserving)'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// pfblockerng.widget.php:695 -- Queries/DNSBL stat read.
+	// -----------------------------------------------------------------------
+
+	public function testWidgetDnsblStatEmitsNoPassingNullDeprecationOnAFreshBox(): void
+	{
+		// Fresh box: pfBlockerNG_update_table() returned nothing to accumulate,
+		// so the 'DNSBL' key of $pfb_table['stats'] was never populated.
+		[$result, $diagnostics] = $this->runCapturing(
+			static fn (): string => pfb_widget_oracle_dnsbl_stat([], ['stats' => []])
+		);
+
+		$this->assertSame(
+			[],
+			self::nullDeprecationsOnly($diagnostics),
+			"the widget's DNSBL 'Queries' stat read must emit zero 'Passing null' deprecations on a fresh box, got:\n"
+			. implode("\n", self::nullDeprecationsOnly($diagnostics))
+		);
+		$this->assertSame('', $result, 'an absent DNSBL stat must render as an empty string, not the literal "0" or a warning');
+	}
+
+	public function testWidgetDnsblStatPassesThroughAPopulatedCountUnchanged(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(
+			static fn (): string => pfb_widget_oracle_dnsbl_stat([], ['stats' => ['DNSBL' => 1500]])
+		);
+
+		$this->assertSame([], self::nullDeprecationsOnly($diagnostics));
+		$this->assertSame('1500', $result, 'a real populated count must still render unchanged (behaviour-preserving)');
+	}
+
+	public function testWidgetDnsblStatSqliteMissingBranchIsUnaffectedByTheGuard(): void
+	{
+		// The 'dnsbl_missing' branch never reaches the guarded read at all --
+		// confirms the fix did not disturb the sibling branch.
+		[$result, $diagnostics] = $this->runCapturing(
+			static fn (): string => pfb_widget_oracle_dnsbl_stat(['dnsbl_missing' => TRUE], ['stats' => []])
+		);
+
+		$this->assertSame([], self::nullDeprecationsOnly($diagnostics));
+		$this->assertStringContainsString('Unknown', $result);
+	}
+}

--- a/tests/php/IpArrayFieldIngressGuardTest.php
+++ b/tests/php/IpArrayFieldIngressGuardTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * issue #1777: pfblockerng_ip.php's save handler runs `pfb_sanitize_text((string)
- * ($_POST[$field] ?? ''))` over a fixed field list (:112-114) with no upstream
+ * ($_POST[$field] ?? ''))` over a fixed field list (:123-125) with no upstream
  * guard against an array-valued field ('asn_token[]=x', the shape
  * tests/smoke/ui/test_post_array_scalar_guards.py:92 already covers for the
  * graceful-reject/no-500 contract via pfb_filter()'s own array rejection at
@@ -14,10 +14,16 @@ use PHPUnit\Framework\TestCase;
  * -- a diagnostic-only regression, not a crash (already covered elsewhere).
  *
  * Fix: copy pfblockerng_category_edit.php's issue #1106 ingress guard (:473-478)
- * IN SHAPE -- reject every non-scalar $_POST field with an input error and
- * blank it, BEFORE the sanitize loop -- so no downstream (string) cast ever
- * sees an array. The (string) cast itself must stay: it is load-bearing for
- * genuinely scalar fields (int/bool/null POST values).
+ * IN INTENT -- reject a non-scalar text field with an input error and blank
+ * it, BEFORE the sanitize loop -- so no downstream (string) cast ever sees an
+ * array. NOT in shape: category_edit has zero multi-selects, so its guard
+ * covers every $_POST key; this page has three (inbound_interface,
+ * outbound_interface, pfb_agg_types -- pfSense's Form_Select(..., TRUE) posts
+ * those as arrays for real, browser-driven saves), so a blanket guard rejects
+ * and blanks all three on every save (issue #1777 review, BLOCKING). The
+ * guard here is scoped to exactly the fields the #1723 sanitize loops below
+ * cast to (string). The (string) cast itself must stay: it is load-bearing
+ * for genuinely scalar fields (int/bool/null POST values).
  *
  * The ingress+sanitize loops are eval-extracted as a pure function of $_POST
  * (top-level page script, not require()-able off-appliance) -- matching
@@ -36,33 +42,23 @@ final class IpArrayFieldIngressGuardTest extends TestCase
 		if ($src === FALSE) {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_ip.php');
 		}
-		// Anchored on the issue #1723 sanitize-loop comment through its closing
-		// brace -- non-greedy, so it matches whether or not the #1777 ingress
-		// guard has been inserted immediately before it yet.
+		// Anchored on the issue #1777 guard comment's stable opening line through
+		// to the stable "// Validate Select field options" comment that follows
+		// the whole ingress+sanitize prologue -- captures the region as raw text
+		// regardless of the guard's internal shape (unscoped pre-fix, field-list
+		// scoped post-fix), so the SAME oracle extraction works whether this
+		// runs before or after the #1777 review's scoping fix lands.
 		if (!preg_match(
-			'/(\/\/ issue #1723: sanitize at ingestion -- first step, before any evaluation\.\n'
-			. '\t\tforeach \(array\(\'ip_placeholder\', \'asn_token\', \'autorule_suffix\', \'maxmind_account\', \'maxmind_key\'\) as \$pfb_text_field\) \{\n'
-			. '.*?\n\t\t\})\n/s',
+			'/(\t\t\/\/ issue #1777: reject an array-valued field \(\'asn_token\[\]=x\'\) before any\n.*?\n)'
+			. '\n\t\t\/\/ Validate Select field options\n/s',
 			$src,
 			$m
 		)) {
-			throw new RuntimeException('test bootstrap: ip.php sanitize prologue not found');
-		}
-		// The (optional, guard-state-dependent) ingress guard directly precedes
-		// the anchor above -- captured separately so the oracle covers it
-		// whether or not it exists yet (pre-fix: absent; post-fix: present).
-		$guard = '';
-		if (preg_match(
-			'/(foreach \(\$_POST as \$pfb_post_key => \$pfb_post_value\) \{\n\t\t\tif \(!is_scalar\(\$pfb_post_value\)\) \{\n.*?\n\t\t\t\}\n\t\t\}\n)\n\t\t\/\/ issue #1723/s',
-			$src,
-			$gm
-		)) {
-			$guard = $gm[1];
+			throw new RuntimeException('test bootstrap: ip.php ingress guard + sanitize prologue not found');
 		}
 		eval(
 			'function pfb_ip_oracle_sanitize_prologue(array $post): array {'
 			. ' $_POST = $post; $input_errors = array();'
-			. $guard
 			. $m[1]
 			. ' return [$_POST, $input_errors]; }'
 		);
@@ -126,5 +122,45 @@ final class IpArrayFieldIngressGuardTest extends TestCase
 		[$post, $inputErrors] = $result;
 		$this->assertSame([], $inputErrors, 'an empty POST has nothing non-scalar to reject');
 		$this->assertSame('', $post['asn_token'], 'an absent field must still default to \'\' (the pre-existing ?? \'\' behaviour)');
+	}
+
+	/**
+	 * issue #1777 review (BLOCKING): a realistic browser save POSTs
+	 * inbound_interface / outbound_interface / pfb_agg_types as ARRAYS
+	 * (Form_Select(..., TRUE) appends '[]' to the POST name). The guard must
+	 * leave all three alone -- untouched, still arrays, same members, no
+	 * input error -- while an array-valued asn_token (never a legitimate
+	 * multi-select on this page) must still be rejected and blanked exactly
+	 * as before.
+	 */
+	public function testMultiSelectArrayFieldsSurviveTheGuardWhileAsnTokenArrayIsStillRejected(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_ip_oracle_sanitize_prologue([
+			'ip_placeholder'     => '198.51.100.1',
+			'asn_token'          => ['crafted'],
+			'autorule_suffix'    => 'autorule',
+			'maxmind_account'    => 'acct',
+			'maxmind_key'        => 'key',
+			'inbound_interface'  => ['wan', 'lan'],
+			'outbound_interface' => ['wan'],
+			'pfb_agg_types'      => ['ipv4', 'ipv6'],
+		]));
+
+		$arrayToString = array_values(array_filter($diagnostics, static fn (string $d): bool => str_contains($d, 'Array to string conversion')));
+		$this->assertSame([], $arrayToString, "the three multi-selects must never Array-to-string-convert, got:\n" . implode("\n", $arrayToString));
+
+		[$post, $inputErrors] = $result;
+
+		$this->assertSame(['wan', 'lan'], $post['inbound_interface'], 'inbound_interface must survive the guard as an unmodified array');
+		$this->assertSame(['wan'], $post['outbound_interface'], 'outbound_interface must survive the guard as an unmodified array');
+		$this->assertSame(['ipv4', 'ipv6'], $post['pfb_agg_types'], 'pfb_agg_types must survive the guard as an unmodified array');
+
+		$multiSelectErrors = array_values(array_filter($inputErrors, static fn (string $e): bool =>
+			str_contains($e, 'inbound_interface') || str_contains($e, 'outbound_interface') || str_contains($e, 'pfb_agg_types')));
+		$this->assertSame([], $multiSelectErrors, "no multi-select field may raise 'Invalid value submitted for field', got:\n" . implode("\n", $multiSelectErrors));
+
+		$this->assertSame('', $post['asn_token'], 'asn_token must still be blanked when array-valued');
+		$asnTokenErrors = array_values(array_filter($inputErrors, static fn (string $e): bool => str_contains($e, 'asn_token')));
+		$this->assertNotEmpty($asnTokenErrors, 'asn_token must still raise its own input error when array-valued');
 	}
 }

--- a/tests/php/IpArrayFieldIngressGuardTest.php
+++ b/tests/php/IpArrayFieldIngressGuardTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -17,13 +18,14 @@ use PHPUnit\Framework\TestCase;
  * IN INTENT -- reject a non-scalar text field with an input error and blank
  * it, BEFORE the sanitize loop -- so no downstream (string) cast ever sees an
  * array. NOT in shape: category_edit has zero multi-selects, so its guard
- * covers every $_POST key; this page has three (inbound_interface,
- * outbound_interface, pfb_agg_types -- pfSense's Form_Select(..., TRUE) posts
- * those as arrays for real, browser-driven saves), so a blanket guard rejects
- * and blanks all three on every save (issue #1777 review, BLOCKING). The
- * guard here is scoped to exactly the fields the #1723 sanitize loops below
- * cast to (string). The (string) cast itself must stay: it is load-bearing
- * for genuinely scalar fields (int/bool/null POST values).
+ * covers every $_POST key unconditionally; this page has three
+ * (inbound_interface, outbound_interface, pfb_agg_types -- pfSense's
+ * Form_Select(..., TRUE) posts those as arrays for real, browser-driven
+ * saves), so an unconditional guard rejects and blanks all three on every
+ * save (issue #1777 review, BLOCKING). The guard here excludes those three
+ * and covers every other field, so scalar sinks outside the #1723 loops stay
+ * protected too. The (string) cast itself must stay: it is load-bearing for
+ * genuinely scalar fields (int/bool/null POST values).
  *
  * The ingress+sanitize loops are eval-extracted as a pure function of $_POST
  * (top-level page script, not require()-able off-appliance) -- matching
@@ -45,9 +47,9 @@ final class IpArrayFieldIngressGuardTest extends TestCase
 		// Anchored on the issue #1777 guard comment's stable opening line through
 		// to the stable "// Validate Select field options" comment that follows
 		// the whole ingress+sanitize prologue -- captures the region as raw text
-		// regardless of the guard's internal shape (unscoped pre-fix, field-list
-		// scoped post-fix), so the SAME oracle extraction works whether this
-		// runs before or after the #1777 review's scoping fix lands.
+		// regardless of the guard's internal shape (unconditional, allow-listed
+		// or multi-select-excluding), so the SAME oracle extraction works
+		// whichever shape the guard currently carries.
 		if (!preg_match(
 			'/(\t\t\/\/ issue #1777: reject an array-valued field \(\'asn_token\[\]=x\'\) before any\n.*?\n)'
 			. '\n\t\t\/\/ Validate Select field options\n/s',
@@ -162,5 +164,49 @@ final class IpArrayFieldIngressGuardTest extends TestCase
 		$this->assertSame('', $post['asn_token'], 'asn_token must still be blanked when array-valued');
 		$asnTokenErrors = array_values(array_filter($inputErrors, static fn (string $e): bool => str_contains($e, 'asn_token')));
 		$this->assertNotEmpty($asnTokenErrors, 'asn_token must still raise its own input error when array-valued');
+	}
+
+	/**
+	 * The guard must cover every scalar field on the page, not just the ones the
+	 * #1723 sanitize loops name. Scoping it to an allow-list of text fields left
+	 * the ADR-40 pair unguarded, and both have a scalar-only sink further down
+	 * the same save handler: pfb_alias_delta_mode reaches array_key_exists()
+	 * (:277), whose first parameter is int|string -- an array is a fatal
+	 * TypeError -- and pfb_alias_delta_batch reaches a (string) cast (:284),
+	 * which Array-to-string-converts and then silently resolves to the clamp
+	 * floor instead of the intended default. Same class for any scalar field
+	 * added to this page later, which is why the guard excludes the three known
+	 * multi-selects rather than enumerating the fields it protects.
+	 *
+	 */
+	#[DataProvider('provideUnlistedScalarFields')]
+	public function testScalarFieldsOutsideTheSanitizeLoopsAreAlsoRejectedWhenArrayValued(string $field): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_ip_oracle_sanitize_prologue([
+			'ip_placeholder'    => '198.51.100.1',
+			'asn_token'         => 'mytoken',
+			'inbound_interface' => ['wan'],
+			$field              => ['crafted'],
+		]));
+
+		$this->assertSame([], array_values(array_filter($diagnostics, static fn (string $d): bool => str_contains($d, 'Array to string conversion'))));
+
+		[$post, $inputErrors] = $result;
+		$this->assertSame('', $post[$field], "an array-valued {$field} must be blanked before it reaches its scalar-only sink");
+		$this->assertNotEmpty(
+			array_values(array_filter($inputErrors, static fn (string $e): bool => str_contains($e, $field))),
+			"an array-valued {$field} must raise its own input error"
+		);
+		$this->assertSame(['wan'], $post['inbound_interface'], 'a legitimate multi-select must still survive alongside the rejection');
+	}
+
+	/** @return array<string, array{string}> */
+	public static function provideUnlistedScalarFields(): array
+	{
+		return [
+			'ADR-40 apply mode (array_key_exists sink, fatal TypeError)' => ['pfb_alias_delta_mode'],
+			'ADR-40 batch size ((string) cast sink)'                     => ['pfb_alias_delta_batch'],
+			'single-select locale (never posted as an array by a browser)' => ['maxmind_locale'],
+		];
 	}
 }

--- a/tests/php/IpArrayFieldIngressGuardTest.php
+++ b/tests/php/IpArrayFieldIngressGuardTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1777: pfblockerng_ip.php's save handler runs `pfb_sanitize_text((string)
+ * ($_POST[$field] ?? ''))` over a fixed field list (:112-114) with no upstream
+ * guard against an array-valued field ('asn_token[]=x', the shape
+ * tests/smoke/ui/test_post_array_scalar_guards.py:92 already covers for the
+ * graceful-reject/no-500 contract via pfb_filter()'s own array rejection at
+ * :161). The `(string)` cast on an ARRAY raises "Array to string conversion"
+ * -- a diagnostic-only regression, not a crash (already covered elsewhere).
+ *
+ * Fix: copy pfblockerng_category_edit.php's issue #1106 ingress guard (:473-478)
+ * IN SHAPE -- reject every non-scalar $_POST field with an input error and
+ * blank it, BEFORE the sanitize loop -- so no downstream (string) cast ever
+ * sees an array. The (string) cast itself must stay: it is load-bearing for
+ * genuinely scalar fields (int/bool/null POST values).
+ *
+ * The ingress+sanitize loops are eval-extracted as a pure function of $_POST
+ * (top-level page script, not require()-able off-appliance) -- matching
+ * DnsblFreshPconfigTest's convention for this same page family.
+ */
+final class IpArrayFieldIngressGuardTest extends TestCase
+{
+	private const IP_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_ip.php';
+
+	public static function setUpBeforeClass(): void
+	{
+		if (function_exists('pfb_ip_oracle_sanitize_prologue')) {
+			return;
+		}
+		$src = file_get_contents(self::IP_PHP);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_ip.php');
+		}
+		// Anchored on the issue #1723 sanitize-loop comment through its closing
+		// brace -- non-greedy, so it matches whether or not the #1777 ingress
+		// guard has been inserted immediately before it yet.
+		if (!preg_match(
+			'/(\/\/ issue #1723: sanitize at ingestion -- first step, before any evaluation\.\n'
+			. '\t\tforeach \(array\(\'ip_placeholder\', \'asn_token\', \'autorule_suffix\', \'maxmind_account\', \'maxmind_key\'\) as \$pfb_text_field\) \{\n'
+			. '.*?\n\t\t\})\n/s',
+			$src,
+			$m
+		)) {
+			throw new RuntimeException('test bootstrap: ip.php sanitize prologue not found');
+		}
+		// The (optional, guard-state-dependent) ingress guard directly precedes
+		// the anchor above -- captured separately so the oracle covers it
+		// whether or not it exists yet (pre-fix: absent; post-fix: present).
+		$guard = '';
+		if (preg_match(
+			'/(foreach \(\$_POST as \$pfb_post_key => \$pfb_post_value\) \{\n\t\t\tif \(!is_scalar\(\$pfb_post_value\)\) \{\n.*?\n\t\t\t\}\n\t\t\}\n)\n\t\t\/\/ issue #1723/s',
+			$src,
+			$gm
+		)) {
+			$guard = $gm[1];
+		}
+		eval(
+			'function pfb_ip_oracle_sanitize_prologue(array $post): array {'
+			. ' $_POST = $post; $input_errors = array();'
+			. $guard
+			. $m[1]
+			. ' return [$_POST, $input_errors]; }'
+		);
+	}
+
+	private function runCapturing(callable $fn): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$result = $fn();
+		} finally {
+			restore_error_handler();
+		}
+		return [$result, $diagnostics];
+	}
+
+	public function testArrayValuedAsnTokenIsRejectedAndBlankedWithNoArrayToStringDiagnostic(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_ip_oracle_sanitize_prologue([
+			'ip_placeholder'  => '198.51.100.1',
+			'asn_token'       => ['crafted'],
+			'autorule_suffix' => 'autorule',
+			'maxmind_account' => 'acct',
+			'maxmind_key'     => 'key',
+		]));
+
+		$arrayToString = array_values(array_filter($diagnostics, static fn (string $d): bool => str_contains($d, 'Array to string conversion')));
+		$this->assertSame([], $arrayToString, "an array-valued asn_token must emit zero 'Array to string conversion' diagnostics, got:\n" . implode("\n", $arrayToString));
+
+		[$post, $inputErrors] = $result;
+		$this->assertSame('', $post['asn_token'], 'an array-valued field must be blanked, never left as an array or stringified "Array"');
+		$this->assertNotEmpty($inputErrors, 'an array-valued field must raise an input error');
+	}
+
+	public function testScalarFieldsStillSanitizeIdenticallyBeforeAndAfterTheGuard(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_ip_oracle_sanitize_prologue([
+			'ip_placeholder'  => ' 198.51.100.1 ',
+			'asn_token'       => ' mytoken ',
+			'autorule_suffix' => 'autorule',
+			'maxmind_account' => 'acct',
+			'maxmind_key'     => 'key',
+		]));
+
+		$this->assertSame([], array_values(array_filter($diagnostics, static fn (string $d): bool => str_contains($d, 'Array to string conversion'))));
+		[$post, $inputErrors] = $result;
+		$this->assertSame([], $inputErrors, 'a fully scalar submission must raise no input error');
+		$this->assertSame('198.51.100.1', $post['ip_placeholder'], 'a scalar field must still sanitize (trim) identically -- the (string) cast must not be weakened');
+		$this->assertSame('mytoken', $post['asn_token']);
+	}
+
+	public function testMissingFieldsStillDefaultToEmptyStringUnchanged(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_ip_oracle_sanitize_prologue([]));
+
+		$this->assertSame([], array_values(array_filter($diagnostics, static fn (string $d): bool => str_contains($d, 'Array to string conversion'))));
+		[$post, $inputErrors] = $result;
+		$this->assertSame([], $inputErrors, 'an empty POST has nothing non-scalar to reject');
+		$this->assertSame('', $post['asn_token'], 'an absent field must still default to \'\' (the pre-existing ?? \'\' behaviour)');
+	}
+}

--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -480,6 +480,59 @@ final class PfbFilterContractTest extends TestCase
 		$this->assertSame('DEF', pfb_filter("\xC3\x28", PFB_FILTER_HTML, 'ref', 'DEF'));
 	}
 
+	// --- PFB_FILTER_ON_OFF / PFB_FILTER_NUM: NULL input (issue #1768) -------------
+	//
+	// Both constants are deliberately exempt from the early
+	// empty($input)||is_null($input) return (NULL=='' / a legitimate stored
+	// default must still validate), so a caller passing NULL (e.g. an absent
+	// POST/config field) previously flowed unguarded into preg_match()/
+	// htmlspecialchars() -- PHP 8.1+ deprecates passing NULL to a non-nullable
+	// string parameter. pfb_filter() now coerces a non-array $input to a
+	// string immediately after that early-return guard, preserving the
+	// NULL==''/NUM-no-match-default return shape byte-identically.
+
+	public function testOnOffFilterAcceptsNullWithNoDiagnostics(): void
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		}, E_WARNING | E_DEPRECATED);
+		try {
+			$result = pfb_filter(NULL, PFB_FILTER_ON_OFF, 'PFBL-01 contract');
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame(
+			[],
+			$diagnostics,
+			"pfb_filter(NULL, PFB_FILTER_ON_OFF) must emit zero diagnostics, got:\n" . implode("\n", $diagnostics)
+		);
+		// NULL == '' -- same accepted-empty shape as an explicit '' input.
+		$this->assertSame('', $result);
+	}
+
+	public function testNumFilterAcceptsNullWithNoDiagnostics(): void
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		}, E_WARNING | E_DEPRECATED);
+		try {
+			$result = pfb_filter(NULL, PFB_FILTER_NUM, 'PFBL-01 contract');
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame(
+			[],
+			$diagnostics,
+			"pfb_filter(NULL, PFB_FILTER_NUM) must emit zero diagnostics, got:\n" . implode("\n", $diagnostics)
+		);
+		// No digits matched -> caller-supplied default ('').
+		$this->assertSame('', $result);
+	}
+
 	// --- Array-input branch: the same gate, applied per element --------------------
 
 	/**

--- a/tests/php/PfbSanitizeTextTest.php
+++ b/tests/php/PfbSanitizeTextTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_sanitize_text')]
 #[CoversFunction('pfb_sanitize_text_area')]
 #[CoversFunction('pfb_text_area_encode')]
+#[CoversFunction('pfb_text_area_decode')]
 final class PfbSanitizeTextTest extends TestCase
 {
 	// --- pfb_sanitize_text() ---
@@ -228,5 +229,30 @@ final class PfbSanitizeTextTest extends TestCase
 		$raw = "A\r\nB\xC2\xA0 \n\x07C";
 		$encoded = pfb_text_area_encode($raw);
 		$this->assertSame(['a', 'b', 'c'], pfb_text_area_decode($encoded, TRUE, FALSE));
+	}
+
+	// --- pfb_text_area_decode() ---
+
+	public function testTextAreaDecodeAcceptsNullWithNoDiagnostics(): void
+	{
+		// issue #1768: untyped $text flows into base64_decode(); an absent
+		// caller-side value (NULL) previously deprecated (PHP 8.1+: passing
+		// NULL to a non-nullable string parameter). Coerced to '' at entry now.
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		}, E_WARNING | E_DEPRECATED);
+		try {
+			$result = pfb_text_area_decode(NULL);
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame(
+			[],
+			$diagnostics,
+			"pfb_text_area_decode(NULL) must emit zero diagnostics, got:\n" . implode("\n", $diagnostics)
+		);
+		$this->assertSame('', $result);
 	}
 }

--- a/tests/php/WidgetIncludeConventionTest.php
+++ b/tests/php/WidgetIncludeConventionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1777: pfSense's dashboard widget-include convention reads a small
+ * set of `$pfblockerng_*`-prefixed variables from widget-pfblockerng.inc
+ * (`$widgetname`/`$pfblockerng_title`/`$pfblockerng_title_link` are the
+ * already-baselined siblings -- see tests/smoke/ui/php_diagnostic_baseline.txt).
+ * `$pfblockerng_allow_multiple_widget_copies` was never set, so pfSense's own
+ * dashboard.php reads it undefined on every render. The widget is a
+ * singleton by construction (a fixed POST action URL, settings keyed off one
+ * `installedpackages/pfblockerngglobal` config block) -- FALSE is correct,
+ * not a placeholder.
+ *
+ * Only the variable-assignment prologue (before the `pfb_widget_post_allowed()`
+ * function definition, already covered by WidgetPostAllowedTest/
+ * WidgetSubmitPostGuardTest's own require_once of this same file) is
+ * eval-extracted -- a bare `include` would risk a "Cannot redeclare function"
+ * fatal if PHPUnit runs this in the same process after those sibling tests
+ * have already required the file.
+ */
+final class WidgetIncludeConventionTest extends TestCase
+{
+	private const WIDGET_INC = __DIR__ . '/../../src/usr/local/www/widgets/include/widget-pfblockerng.inc';
+
+	public function testAllowMultipleWidgetCopiesConventionVariableIsDefinedFalse(): void
+	{
+		$src = file_get_contents(self::WIDGET_INC);
+		$this->assertNotFalse($src, 'failed to read widget-pfblockerng.inc');
+
+		if (!preg_match('/<\?php\n(.*?)\nfunction pfb_widget_post_allowed/s', $src, $m)) {
+			$this->fail('could not locate the variable-assignment prologue before pfb_widget_post_allowed()');
+		}
+		eval($m[1]);
+
+		$this->assertTrue(isset($pfblockerng_allow_multiple_widget_copies), '$pfblockerng_allow_multiple_widget_copies must be defined');
+		$this->assertFalse($pfblockerng_allow_multiple_widget_copies, 'the widget is a singleton (fixed POST action URL, one config block) -- must be FALSE');
+
+		// Control: the pre-existing sibling convention variables must still be
+		// defined too (this fix must not disturb them).
+		$this->assertTrue(isset($pfblockerng_title), '$pfblockerng_title must still be defined');
+		$this->assertTrue(isset($pfblockerng_title_link), '$pfblockerng_title_link must still be defined');
+	}
+}

--- a/tests/php/fixtures/geoip_pre_move_golden.json
+++ b/tests/php/fixtures/geoip_pre_move_golden.json
@@ -29,16 +29,16 @@
     "ZZ_v4.txt": "454debca5afcd37addd0dcca05094625dcde6402510f8fc664cd567893ec7096"
   },
   "continent_pages": {
-    "pfblockerng_Africa.php": "b840456e93df26b037e4f0546698a145e1fb4636e48ffba25804ca8ff0262170",
-    "pfblockerng_Antarctica.php": "33323a3ecb0afecdd3152ca92c562ec8255c0e670b109df0a84b218d75059146",
-    "pfblockerng_Asia.php": "8794cdb38c042926021de06d6feb823d1b5e7982f284ba90f3d1c78b6833e8f1",
-    "pfblockerng_Europe.php": "2c662ebf8a781a0888abc2d4a663335e875c6a9cb2633c1f8186ddef88550003",
-    "pfblockerng_North_America.php": "1365778df351ea7cec0a400f96d815a2d1f194a14b193e9c025a496589fe0ddd",
-    "pfblockerng_Oceania.php": "82ce0e433beeab561aeb9ddd479fd526349eb20a3d385676ba14e2bd4b8c41db",
-    "pfblockerng_South_America.php": "81c3d6c4e6d9fbbcaa488f0f31d9adc459dd418d170808ccf648be18f3d52dd7",
-    "pfblockerng_Proxy_and_Satellite.php": "530895710dad9fc39e44ce7e0b0f4f41296c2e4c512bb4dcf68218430d7bec9e",
-    "pfblockerng_Top_Spammers.php": "0e092bed5d860e5b7c81ebd79db0120676f5b044c23d3d2a1966cbddd979b27c"
+    "pfblockerng_Africa.php": "b4f26d783f460b37892d610761ce8693767a848d3be1ec679274e18f9be65f7a",
+    "pfblockerng_Antarctica.php": "16e2625fbe93cf2e7973c728c5b24281cc9cbca4c2b2c45dab41597366b216b9",
+    "pfblockerng_Asia.php": "b5e5de0487906eb6f17368e8647602e7f509467cbbeb629d8ab9c7ddd534b00c",
+    "pfblockerng_Europe.php": "790876fd8208cf8a90e4aab5fe6379375c43be9c927f8f5a7c08a437122eec25",
+    "pfblockerng_North_America.php": "fc0656d9437b8387d267fce68bd9bfc2e49063afdbcc8f7c4f0e9e3d20961dbb",
+    "pfblockerng_Oceania.php": "7abf871d9c53c2f1978ce8694ec34baa277ac29656eda3d3eaa885e306045d02",
+    "pfblockerng_South_America.php": "03914349dacb312772f60a7adc12fa712a2d6fc32400ef3f518ce64bffe7683b",
+    "pfblockerng_Proxy_and_Satellite.php": "99866f1ba3c274ff81708dc2b39fef714823af20dbd34e3bdb1d047d8a14c74c",
+    "pfblockerng_Top_Spammers.php": "e94e2be0d6579d53f806e9b62c4288424fea7c33c0a10ed068344c6888cb1aa2"
   },
-  "reputation_empty": "49a41197673a6ccbfb5b4600f0236deca79f0672ba5b7b4dd51bdbe52dd64669",
-  "reputation_populated": "e63bba64de32da7bf5507cfbc728b8a4fe293a8a2e957bc27407b094f721e6da"
+  "reputation_empty": "5a61a598cb8d1ac66db93a27e88338f7c28e627df9d3b606a8df7348a30c5984",
+  "reputation_populated": "7dced7a138426dc8dbef7fa5c8f1b740e1459d4ba79e4340b7b3683ed79a0266"
 }

--- a/tests/smoke/ui/php_diagnostic_baseline.txt
+++ b/tests/smoke/ui/php_diagnostic_baseline.txt
@@ -39,5 +39,4 @@
 /usr/local/www/pfblockerng/pfblockerng_ip.php|Deprecated|explode(): Passing null to parameter #2 ($string) of type string is deprecated
 /usr/local/www/pfblockerng/pfblockerng_reputation.php|Deprecated|explode(): Passing null to parameter #2 ($string) of type string is deprecated
 /usr/local/www/widgets/widgets/pfblockerng.widget.php|Deprecated|htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated
-/usr/local/www/widgets/widgets/pfblockerng.widget.php|Warning|Trying to access array offset on null
 /usr/local/www/widgets/widgets/pfblockerng.widget.php|Warning|Undefined variable $widgetname

--- a/tests/smoke/ui/test_post_array_scalar_guards.py
+++ b/tests/smoke/ui/test_post_array_scalar_guards.py
@@ -90,6 +90,11 @@ _ARRAY_FIELD_CASES: list[tuple[str, str, dict[str, str] | None]] = [
     ("/pfblockerng/pfblockerng_sync.php", "varsynctimeout", None),  # pfb_filter NUM (pre-loop)
     ("/pfblockerng/pfblockerng_ip.php", "enable_dup", None),  # pfb_filter ON_OFF
     ("/pfblockerng/pfblockerng_ip.php", "asn_token", None),  # pfb_filter WORD
+    # issue #1777: ip.php's own ingress guard, on the two ADR-40 fields whose
+    # sinks sit below the #1723 sanitize loops -- array_key_exists() (a fatal
+    # TypeError on an array) and a (string) cast.
+    ("/pfblockerng/pfblockerng_ip.php", "pfb_alias_delta_mode", None),
+    ("/pfblockerng/pfblockerng_ip.php", "pfb_alias_delta_batch", None),
     ("/pfblockerng/pfblockerng_general.php", "enable_cb", None),  # pfb_filter ON_OFF
     ("/pfblockerng/pfblockerng_general.php", "pfb_log_trim_margin_pct", None),  # is_array/ctype_digit
     # issue #1106: category_edit's own ingress guard (bypasses pfb_filter entirely).


### PR DESCRIPTION
Fixes #1768.

## What

Fresh-config page renders emitted PHP `Passing null` deprecations (base64_decode/explode/preg_match/htmlspecialchars) across the DNSBL/IP/Alerts/Blacklist pages and shared helpers — every site inherited from the 3.2.15 import and surfaced when the release functional-UI diagnostics gate first ran on current devel (both legs red in the #1662 dry-run and the plain-devel probe run 30243278418).

## How

Three chokepoints close ~85 call sites, plus a bounded sweep of the render-block reads, all behaviour-preserving:

- `pfb_filter()`: scalar-coerce (`(string) ($input ?? '')`) after the existing ON_OFF/NUM null-guard exemption — the `''`-is-off semantics stay byte-identical, caller-side diagnostics stay intact.
- `pfb_text_area_decode()`: string-coerce at entry (16 callers).
- `pfb_global()`: `?? ''` on the five null-propagating member copies; `pfb_daemon_filterlog()` short-line field guard; `category_edit` `config_get_path` default.
- Render blocks: the `?? ''` idiom (matching the pre-existing guarded siblings) on the dnsbl/ip/alerts/blacklist/geoip read sites.
- The geoip sweep sites live inside nowdoc page templates whose generated bytes are hash-pinned by `GeoipPreMoveGoldenOracleTest` — the golden fixture is regenerated; the independent verifier gate re-derived the A/B generation and confirmed the ONLY delta is the five `?? ''` tokens (raw `country_files` hashes byte-identical to the previous fixture).

Deliberately NOT swept: the ~200 bare `$pfb['<section>']['key']` reads that never feed these functions (not in the failing gate's output; separate hardening), and the 67 `pfb_filter(ON_OFF)` caller-side `?? ''`s (chokepoint A silences their deprecations).

## Evidence

Red-first across five test files (two new fresh-config page oracles cloning the `CategoryEditFreshRowPconfigTest` precedent, `PfbFilterContractTest` NULL rows, `PfbSanitizeTextTest` decode row, new `FilterlogFieldGuardTest`): combined RED `Tests: 134, Failures: 7` → GREEN `OK (134 tests, 185 assertions)`, hashes frozen. Independent verifier gate re-executed the red proof via `verify-red-proof.sh`, re-ran a chokepoint mutation, and re-derived the golden-fixture A/B. Live proof: the functional render sweep is the live proof (see the correction comment: two missed in-class sites plus #1777 land on this branch first).

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


no-test-needed: the www/ hunks alter no rendered element — they null-guard existing render-path reads; Tier-A render coverage for every touched page pre-exists (test_render_smoke), and the live assertion for THIS change is the functional tier's diagnostics sweep, red on devel (run 30243278418) and green with this PR. The hermetic ship-with tests are the five PHPUnit fresh-config oracles.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when configuration values, request fields, server headers, or log data are missing or empty.
  * Prevented PHP warnings and deprecations in alerts, DNSBL, GeoIP, blacklist, IP settings, widgets, and filter-log processing.
  * Added safer language fallbacks for blacklist category labels.
  * Rejected invalid array-valued IP form inputs without conversion errors.

* **Tests**
  * Added regression coverage for missing configuration data, malformed logs, alert rendering, widget behavior, and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->