### PR TITLE
pfblockerng: sanitize rowhelper fields at ingestion; accept IDN hostnames end to end

### DIFF
--- a/.agents/policy/coding.md
+++ b/.agents/policy/coding.md
@@ -84,7 +84,8 @@ never an ad-hoc `trim`/`str_replace` chain and never re-sanitized downstream:
   `pfb_text_area_encode()` (`base64_encode(pfb_sanitize_text_area(...))`) remains only
   for programmatic writers whose encode call itself IS the ingestion point (the
   alerts.php/pfblockerng_extra.inc/pfblockerng_install.inc re-encoders, the Unbound
-  `custom_options` re-encode) — never a second pass after a `$_POST` field already went
+  `custom_options` re-encode, `pfblockerng_category_edit.php`'s Reports-tab whitelist-alias
+  `addgroup` branch) — never a second pass after a `$_POST` field already went
   through the ingestion prologue. Parse through `pfb_text_area_decode()`, which
   sanitizes once on read, drops blank/whitespace-only rows, and preserves the valid row
   `"0"`.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1578,8 +1578,16 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			}
 			break;
 		case PFB_FILTER_HOSTNAME:
-			// Validate hostname
-			if (is_hostname($input)) {
+			// Validate hostname. issue #1731: same punycode-candidate approach as
+			// PFB_FILTER_TLD -- a non-ASCII (IDN) hostname converts to its
+			// punycode candidate before is_hostname(); on success the ORIGINAL
+			// input is returned (the read path IDN-converts separately).
+			$candidate = $input;
+			if (preg_match('/[^\x00-\x7F]/', $input)) {
+				$candidate = idn_to_ascii($input);
+				$candidate = empty($candidate) ? FALSE : $candidate;
+			}
+			if (($candidate !== FALSE) && is_hostname($candidate)) {
 				$result = htmlspecialchars($input);
 			}
 			break;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -17183,6 +17183,23 @@ function pfblockerng_sync_on_changes() {
 					$protocol	= $sh['varsyncprotocol'];
 					$username	= $sh['varsyncusername'] ?: 'admin';
 
+					// issue #1778: PFB_FILTER_HOSTNAME (pfblockerng_sync.php, #1731)
+					// accepts and persists a Unicode (IDN) sync target, but the gate
+					// below and the XMLRPC connection (pfblockerng_do_xmlrpc_sync())
+					// are ASCII-only -- punycode-convert at the point of use so both
+					// see a candidate they can validate/dial. Keep the original for
+					// the human-facing log lines -- the operator sees the target as
+					// configured, not its punycode form. A conversion failure leaves
+					// $sync_to_ip unchanged, so the existing gate rejects it exactly
+					// as before. An ASCII target (the common case) is untouched.
+					$sync_to_ip_display = $sync_to_ip;
+					if (preg_match('/[^\x00-\x7F]/', (string) $sync_to_ip)) {
+						$sync_to_ip_ascii = idn_to_ascii((string) $sync_to_ip);
+						if (!empty($sync_to_ip_ascii)) {
+							$sync_to_ip = $sync_to_ip_ascii;
+						}
+					}
+
 					$validate = TRUE;
 					$error = '| ';
 
@@ -17200,18 +17217,18 @@ function pfblockerng_sync_on_changes() {
 					}
 
 					if ($validate) {
-						pfb_logger("\n Sync with [ {$protocol}://{$sync_to_ip}:{$port} ] ...", 1);
+						pfb_logger("\n Sync with [ {$protocol}://{$sync_to_ip_display}:{$port} ] ...", 1);
 						$success = pfblockerng_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $password, $synctimeout);
 
 						if ($success) {
 							pfb_logger(" done.\n", 1);
-							logger(LOG_NOTICE, localize_text("XMLRPC sync to [ %s ] completed successfully.", "{$sync_to_ip}:{$port}"), LOG_PREFIX_PKG_PFBLOCKERNG);
+							logger(LOG_NOTICE, localize_text("XMLRPC sync to [ %s ] completed successfully.", "{$sync_to_ip_display}:{$port}"), LOG_PREFIX_PKG_PFBLOCKERNG);
 						} else {
 							pfb_logger(" Failed!\n", 1);
 						}
 					} else {
 						pfb_logger(" terminated due to the following error(s): {$error}", 1);
-						logger(LOG_ERR, localize_text("XMLRPC sync to [ %s:%s ] terminated due to the following error(s): %s", $sync_to_ip, $port, $error), LOG_PREFIX_PKG_PFBLOCKERNG);
+						logger(LOG_ERR, localize_text("XMLRPC sync to [ %s:%s ] terminated due to the following error(s): %s", $sync_to_ip_display, $port, $error), LOG_PREFIX_PKG_PFBLOCKERNG);
 					}
 				}
 			}

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -486,6 +486,16 @@ if ($_POST && isset($_POST['save'])) {
 	}
 	$_POST['custom'] = pfb_sanitize_text_area((string) ($_POST['custom'] ?? ''));
 
+	// issue #1737: rowhelper header-N/url-N single-line columns sanitize at
+	// ingestion too, so the validation loop below and the persist state-loop
+	// see the same bytes (previously sanitized only at persist, after
+	// validation already ran on the raw value).
+	foreach ($_POST as $pfb_post_key => $pfb_post_value) {
+		if (preg_match('/^(?:header|url)-/', (string) $pfb_post_key)) {
+			$_POST[$pfb_post_key] = pfb_sanitize_text((string) $pfb_post_value);
+		}
+	}
+
 	// Validate Select field options
 	$select_options = array(	'action'		=> 'Disabled',
 					'cron'			=> 'Never',
@@ -863,14 +873,9 @@ if ($_POST && isset($_POST['save'])) {
 				// Collect all rowhelper keys
 				$rowhelper_exist[$k_field[1]] = '';
 
-				// issue #1723: sanitize the header/url single-line text columns
-				// before their existing PFB_FILTER_HTML/htmlentities handling below
-				// (state-N/format-N stay untouched -- they are select values, not
-				// free text).
-				if (in_array($k_field[0], array('header', 'url'), TRUE)) {
-					$value = pfb_sanitize_text((string) $value);
-				}
-
+				// issue #1737: header/url already sanitized by the ingestion
+				// prologue above -- plain read here, same bytes the validation
+				// loop evaluated.
 				if (!empty($value) && $k_field[0] != 'url') {
 					$value = pfb_filter($value, PFB_FILTER_HTML, 'Category_edit save');
 				}

--- a/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
@@ -88,6 +88,12 @@ if ($_POST) {
 				continue;
 			}
 
+			// issue #1761: sanitize at ingestion -- before any validation below.
+			if ($field === 'hook_description' || $field === 'hook_timeout') {
+				$value = pfb_sanitize_text((string) $value);
+				$_POST[$key] = $value;
+			}
+
 			// Collect all rowhelper keys (so empty checkboxes still register a row).
 			$rowhelper_exist[$rowid] = '';
 
@@ -150,8 +156,8 @@ if ($_POST) {
 					'script'	=> (string) ($_POST["hook_script-{$rowid}"] ?? ''),
 					'when'		=> (string) ($_POST["hook_when-{$rowid}"] ?? 'pre'),
 					'enabled'	=> (isset($_POST["hook_enabled-{$rowid}"]) && $_POST["hook_enabled-{$rowid}"] === 'on') ? 'on' : '',
-					'description'	=> trim((string) ($_POST["hook_description-{$rowid}"] ?? '')),
-					'timeout'	=> trim((string) ($_POST["hook_timeout-{$rowid}"] ?? '')),
+					'description'	=> (string) ($_POST["hook_description-{$rowid}"] ?? ''),
+					'timeout'	=> (string) ($_POST["hook_timeout-{$rowid}"] ?? ''),
 				);
 				$hooks[] = $hook;
 			}

--- a/tests/php/CategoryEditPostGuardTest.php
+++ b/tests/php/CategoryEditPostGuardTest.php
@@ -33,6 +33,8 @@ final class CategoryEditPostGuardTest extends TestCase
 	private array $savedGet = [];
 	private array $savedRequest = [];
 	private mixed $savedPfb = null;
+	private bool $hadConfig = false;
+	private mixed $savedConfig = null;
 
 	public static function setUpBeforeClass(): void
 	{
@@ -193,6 +195,12 @@ final class CategoryEditPostGuardTest extends TestCase
 		$this->savedGet     = $_GET;
 		$this->savedRequest = $_REQUEST;
 		$this->savedPfb     = $GLOBALS['pfb'] ?? null;
+		// The persist oracle writes config through the doubled config_set_path(),
+		// so $GLOBALS['config'] is test-mutated state like the superglobals above:
+		// restore it (absent stays absent) or it leaks into every later test in
+		// this process.
+		$this->hadConfig    = array_key_exists('config', $GLOBALS);
+		$this->savedConfig  = $GLOBALS['config'] ?? null;
 		$_POST = $_GET = $_REQUEST = [];
 		// Satisfied MaxMind credentials so the state-loop's geoip-format row
 		// doesn't also trip the (unrelated) credential-notice input error.
@@ -206,6 +214,11 @@ final class CategoryEditPostGuardTest extends TestCase
 		$_GET     = $this->savedGet;
 		$_REQUEST = $this->savedRequest;
 		$GLOBALS['pfb'] = $this->savedPfb;
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->savedConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
 	}
 
 	// --- R1/R2: atype (POST/GET) ------------------------------------------------

--- a/tests/php/CategoryEditPostGuardTest.php
+++ b/tests/php/CategoryEditPostGuardTest.php
@@ -165,6 +165,26 @@ final class CategoryEditPostGuardTest extends TestCase
 				. ' return $savemsg ?? null; }'
 			);
 		}
+
+		// Region 7: the persist rowhelper loop (issue #1737 persist-parity
+		// coverage). Anchored on text stable either side of the #1723 in-loop
+		// sanitize block this issue removes -- never on that block itself --
+		// so the same anchors match the region red (block present) and green
+		// (block removed).
+		if (!function_exists('pfb_category_oracle_persist_rowhelper_loop')) {
+			if (!preg_match(
+				'/(\t\t\$rowhelper_exist = array\(\);\n\t\tforeach \(\$_POST as \$key => \$value\) \{\n.*?\n\t\t\})\n\n\t\t\/\/ Remove all undefined rowhelpers/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: persist rowhelper loop not found');
+			}
+			eval(
+				'function pfb_category_oracle_persist_rowhelper_loop(string $conf_type, $rowid): void {'
+				. $m[1]
+				. ' }'
+			);
+		}
 	}
 
 	protected function setUp(): void
@@ -584,25 +604,75 @@ final class CategoryEditPostGuardTest extends TestCase
 
 	// -- hostile-input rows -----------------------------------------------
 
-	public function testUrlSaveGuardRejectsEmbeddedControlCharacter(): void
+	// issue #1737 contract update: these two rows used to assert the
+	// state-loop's [\p{C}<>"] guard REJECTS an embedded Cc byte / tab. That
+	// shape is now stale -- pfb_sanitize_text() strips \p{Cc}+BOM at
+	// ingestion (before the state loop ever runs), the same #1723 standard
+	// already shipped for the Hooks tab (commit 66da925d) and for header-N/
+	// url-N whitespace elsewhere on this page. An embedded Cc byte is now
+	// silently cleaned, not rejected -- pinned below as sanitize-then-accept.
+	// The Cf/`<`/`"` rows further down prove the guard is still LIVE for
+	// what sanitize does NOT strip (\p{Cf}, `<`, `"`).
+
+	public function testUrlEmbeddedControlCharSanitizedAtIngestion(): void
+	{
+		$value = "US\x01CA";
+		$post = [
+			'aliasname' => 'validname',
+			'state-0'   => 'Enabled',
+			'header-0'  => 'validheader',
+			'url-0'     => $value,
+			'format-0'  => 'geoip',
+		];
+		$this->assertGuardAccepts($post);
+		$this->assertSame('USCA', $_POST['url-0'], 'the embedded Cc byte must be stripped at ingestion, not merely tolerated');
+	}
+
+	public function testUrlEmbeddedTabCharacterMergedAtIngestion(): void
+	{
+		// The tab (Cc, 0x09) is stripped with no replacement, so 'US<TAB>CA'
+		// merges to 'USCA' -- a knowing consequence of the single-line Cc-strip
+		// contract, not a special case for tab. Crafted-POST territory only: a
+		// browser text input cannot submit a literal tab character.
+		$value = "US\tCA";
+		$post = [
+			'aliasname' => 'validname',
+			'state-0'   => 'Enabled',
+			'header-0'  => 'validheader',
+			'url-0'     => $value,
+			'format-0'  => 'geoip',
+		];
+		$this->assertGuardAccepts($post);
+		$this->assertSame('USCA', $_POST['url-0'], 'the embedded tab must be stripped (merged, no replacement) at ingestion');
+	}
+
+	// issue #1737 vacuity guards: pfb_sanitize_text() strips only \p{Cc}+BOM
+	// -- never \p{Cf}, `<`, or `"` -- so the state-loop's [\p{C}<>"] character
+	// guard must still be provably live post-sanitize for those.
+
+	public function testUrlSaveGuardStillRejectsRawLessThanAfterSanitize(): void
 	{
 		$this->assertGuardRejects([
 			'aliasname' => 'validname',
 			'state-0'   => 'Enabled',
 			'header-0'  => 'validheader',
-			'url-0'     => "US\x01CA",
-			'format-0'  => 'geoip',
+			'url-0'     => 'http://192.0.2.1/x<y',
+			'format-0'  => 'auto',
 		]);
 	}
 
-	public function testUrlSaveGuardRejectsEmbeddedTabCharacter(): void
+	public function testUrlSaveGuardStillRejectsCfCharacterAfterSanitize(): void
 	{
+		// U+200D ZERO WIDTH JOINER is Cf (format), not Cc -- pfb_sanitize_text()
+		// leaves it intact (issue #1723's "Unicode format characters survive"
+		// contract). \p{C} = \p{Cc} + \p{Cf}, so the state-loop's guard must
+		// still catch it even though ingestion-sanitize does not strip it.
 		$this->assertGuardRejects([
 			'aliasname' => 'validname',
 			'state-0'   => 'Enabled',
 			'header-0'  => 'validheader',
-			'url-0'     => "US\tCA",
-			'format-0'  => 'geoip',
+			'url-0'     => "http://192.0.2.1/x\u{200D}y",
+			'format-0'  => 'auto',
 		]);
 	}
 
@@ -628,17 +698,25 @@ final class CategoryEditPostGuardTest extends TestCase
 		]);
 	}
 
-	public function testUrlSaveGuardRejectsInvalidUtf8FailClosed(): void
+	public function testUrlInvalidUtf8LegacyConvertedAtIngestion(): void
 	{
-		// preg_match() with /u returns FALSE (not 0) on invalid UTF-8; the
-		// guard's `!== 0` compare must treat FALSE as a reject (fail closed).
-		$this->assertGuardRejects([
+		// issue #1737 contract update: pfb_sanitize_text() legacy-encoding-
+		// converts invalid UTF-8 to valid UTF-8 at ingestion, before the state
+		// loop's /u guard ever runs -- the raw bytes never reach the guard as
+		// invalid UTF-8. Downstream format validators (PFB_FILTER_URL, here)
+		// still run on the converted bytes -- an unrelated "Invalid URL" error
+		// from that check is not this guard's concern (assertGuardAccepts
+		// filters for the character guard's own message only).
+		$value = "\xFF\xFE";
+		$post = [
 			'aliasname' => 'validname',
 			'state-0'   => 'Enabled',
 			'header-0'  => 'validheader',
-			'url-0'     => "\xFF\xFE",
+			'url-0'     => $value,
 			'format-0'  => 'auto',
-		]);
+		];
+		$this->assertGuardAccepts($post);
+		$this->assertSame("\xC3\xBF\xC3\xBE", $_POST['url-0'], 'invalid UTF-8 must be legacy-converted (ISO-8859-1 -> UTF-8) at ingestion');
 	}
 
 	public function testUrlSaveGuardAcceptsSingleQuoteSubDelim(): void
@@ -757,5 +835,98 @@ final class CategoryEditPostGuardTest extends TestCase
 		$_REQUEST['savemsg'] = 'ok <b>';
 		$savemsg = pfb_category_oracle_savemsg();
 		$this->assertSame(htmlspecialchars('ok <b>'), $savemsg, 'a scalar savemsg is still HTML-escaped and rendered');
+	}
+
+	// --- issue #1737: rowhelper header-N/url-N sanitize at ingestion, not
+	// only at persist -- the validation loop must see the SAME bytes the
+	// persist loop later stores. -------------------------------------------
+
+	public function testIngestionSanitizesHeaderBomAndNbspBeforeValidation(): void
+	{
+		$_POST = [
+			'aliasname' => 'validname',
+			'state-0'   => 'Disabled',	// issue #1270: header/url checks are non-empty-, not state-, gated
+			'header-0'  => "\u{00A0}hdr\u{FEFF}",
+			'url-0'     => '',
+			'format-0'  => 'auto',
+		];
+		pfb_category_oracle_aliasname_region('dnsbl');	// ingestion prologue
+		$errors = pfb_category_oracle_state_loop('DNSBL');
+		$this->assertEmpty(
+			array_filter($errors, static fn (string $e): bool => str_contains($e, 'Header field cannot contain spaces')),
+			'a header sanitized to plain word chars at ingestion must not trip the validation \W check'
+		);
+		$this->assertSame('hdr', $_POST['header-0'], 'the ingestion prologue must sanitize header-N (NBSP/BOM stripped)');
+	}
+
+	public function testIngestionSanitizesUrlControlCharAndWhitespaceBeforeValidation(): void
+	{
+		$_POST = [
+			'aliasname' => 'validname',
+			'state-0'   => 'Disabled',	// issue #1270: the control-char guard is non-empty-, not state-, gated
+			'header-0'  => 'validheader',
+			'url-0'     => " https://example.com/x\x01 ",
+			'format-0'  => 'auto',
+		];
+		pfb_category_oracle_aliasname_region('dnsbl');
+		$errors = pfb_category_oracle_state_loop('DNSBL');
+		$this->assertEmpty(
+			array_filter($errors, static fn (string $e): bool => str_contains($e, 'disallowed character')),
+			'a url-N sanitized (Cc stripped, trimmed) at ingestion must not trip the control-char guard'
+		);
+		$this->assertSame(
+			'https://example.com/x',
+			$_POST['url-0'],
+			'the ingestion prologue must sanitize url-N (Cc stripped + leading/trailing whitespace trimmed)'
+		);
+	}
+
+	public function testIngestionPrologueLeavesStateAndFormatSelectValuesUntouched(): void
+	{
+		// Scope pin: the header/url prologue targets ONLY header-N/url-N keys --
+		// a select value under state-N/format-N must survive byte-identical.
+		$_POST = [
+			'aliasname' => 'validname',
+			'state-0'   => "  Enabled\u{00A0}",
+			'header-0'  => 'validheader',
+			'url-0'     => 'http://192.0.2.1/feed',
+			'format-0'  => " auto\u{00A0}",
+		];
+		pfb_category_oracle_aliasname_region('dnsbl');
+		$this->assertSame(
+			"  Enabled\u{00A0}",
+			$_POST['state-0'],
+			'state-N is a select value, not free text -- must not be sanitized by the header/url prologue'
+		);
+		$this->assertSame(
+			" auto\u{00A0}",
+			$_POST['format-0'],
+			'format-N is a select value, not free text -- must not be sanitized by the header/url prologue'
+		);
+	}
+
+	public function testPersistRowhelperLoopStoresIngestionSanitizedHeaderOnce(): void
+	{
+		// Regression pin (passes unchanged pre- and post-fix): the persist loop's
+		// stored value must equal the sanitized+PFB_FILTER_HTML'd form whether
+		// sanitize runs once (ingestion, post-fix) or twice idempotently
+		// (ingestion is a no-op pre-fix, so persist's own #1723 sanitize is the
+		// only pass) -- proves removing the persist-loop sanitize is safe.
+		$GLOBALS['config'] = [];
+		$_POST = [
+			'aliasname' => 'validname',
+			'state-0'   => 'Enabled',
+			'header-0'  => "\u{00A0}hdr\u{FEFF}",
+			'url-0'     => 'http://192.0.2.1/feed',
+			'format-0'  => 'auto',
+		];
+		pfb_category_oracle_aliasname_region('dnsbl');	// ingestion prologue (no-op pre-fix)
+		pfb_category_oracle_persist_rowhelper_loop('pfblockerngdnsbl', 0);
+
+		$this->assertSame(
+			'hdr',
+			config_get_path('installedpackages/pfblockerngdnsbl/config/0/row/0/header'),
+			'the stored header must equal the sanitized+PFB_FILTER_HTML value regardless of which loop sanitized it'
+		);
 	}
 }

--- a/tests/php/HooksSanitizeIngestionTest.php
+++ b/tests/php/HooksSanitizeIngestionTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Hooks tab rowhelper text-field sanitize-at-ingestion (issue #1761).
+ *
+ * pfblockerng_hooks.php's rowhelper validation loop reads
+ * hook_description-N / hook_timeout-N raw off $_POST, validates them (the
+ * \p{C} control-char regex; PFB_FILTER_NUM), and only THEN -- in the separate
+ * `if (!$input_errors)` persist block -- ran them through a bare trim(). So
+ * the validators and the persisted value saw different bytes than the
+ * #1723 standard requires (sanitize once, at ingestion, before any
+ * evaluation): a BOM/control byte the ASCII trim() never touches could
+ * survive into config.xml, and a BOM ahead of a numeric timeout tripped
+ * PFB_FILTER_NUM even though the digits themselves were fine.
+ *
+ * The page carries top-level execution and cannot be require()d
+ * off-appliance, so each region below is eval-extracted verbatim from the
+ * REAL source, anchored on text stable across both the pre-fix and post-fix
+ * code (never on the trim() being removed or the sanitize line being added)
+ * so the same test file proves red on the old code and green on the new.
+ */
+final class HooksSanitizeIngestionTest extends TestCase
+{
+	private array $savedPost = [];
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_hooks.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_hooks.php');
+		}
+
+		// Region A: the rowhelper validation loop -- from its $rowhelper_exist
+		// init through the foreach's closing brace, stopping before the
+		// `if (!$input_errors)` persist block.
+		if (!function_exists('pfb_hooks_oracle_validate_region')) {
+			if (!preg_match(
+				'/(\t\t\$rowhelper_exist = array\(\);\n\t\tforeach \(\$_POST as \$key => \$value\) \{\n.*?\n\t\t\})' .
+				'\n\n\t\tif \(!\$input_errors\) \{/s',
+				$src,
+				$regionA
+			)) {
+				throw new RuntimeException('test bootstrap: rowhelper validation loop region not found');
+			}
+			eval(
+				'function pfb_hooks_oracle_validate_region(array $options_when): array {'
+				. ' $input_errors = array();'
+				. $regionA[1]
+				. ' return array("errors" => $input_errors, "rowhelper_exist" => $rowhelper_exist); }'
+			);
+		}
+
+		// Region B: the persist block's $hooks-building loop -- from its
+		// $hooks init through the foreach's closing brace, stopping before
+		// the empty($hooks) branch (which calls config_set_path/write_config/
+		// header/exit -- out of scope here; PHPUnit only needs the built array).
+		if (!function_exists('pfb_hooks_oracle_persist_region')) {
+			if (!preg_match(
+				'/(\t\t\t\$hooks = array\(\);\n\t\t\tforeach \(array_keys\(\$rowhelper_exist\) as \$rowid\) \{\n.*?\n\t\t\t\})' .
+				'\n\n\t\t\tif \(empty\(\$hooks\)\)/s',
+				$src,
+				$regionB
+			)) {
+				throw new RuntimeException('test bootstrap: persist-block hooks region not found');
+			}
+			eval(
+				'function pfb_hooks_oracle_persist_region(array $rowhelper_exist): array {'
+				. ' $hooks = array();'
+				. $regionB[1]
+				. ' return $hooks; }'
+			);
+		}
+	}
+
+	protected function setUp(): void
+	{
+		$this->savedPost = $_POST;
+	}
+
+	protected function tearDown(): void
+	{
+		$_POST = $this->savedPost;
+	}
+
+	private const OPTIONS_WHEN = ['pre' => 'Pre', 'post' => 'Post'];
+
+	/**
+	 * Run BOTH regions in the real execution order: validate, then (only if
+	 * clean) persist -- mirroring the page's own `if (!$input_errors)` gate.
+	 * Returns ['errors' => array, 'hooks' => array, 'post' => $_POST] so a
+	 * test can assert on validation outcome, the persisted row(s), AND the
+	 * ingestion-sanitized $_POST bytes the validators themselves saw.
+	 */
+	private function runSave(array $post): array
+	{
+		$_POST = $post;
+		$validated = pfb_hooks_oracle_validate_region(self::OPTIONS_WHEN);
+		$hooks = [];
+		if (!$validated['errors']) {
+			$hooks = pfb_hooks_oracle_persist_region($validated['rowhelper_exist']);
+		}
+		return ['errors' => $validated['errors'], 'hooks' => $hooks, 'post' => $_POST];
+	}
+
+	// --- description: BOM + control char stripped, ASCII-trim-equivalent kept ---
+
+	public function testDescriptionBomAndControlCharStrippedAtIngestion(): void
+	{
+		// RED today: the page's own \p{C} description validator (broader than
+		// pfb_sanitize_text()'s \p{Cc}+BOM strip -- \p{C} also covers Cf, which
+		// includes the BOM) runs on the RAW value and rejects it outright, so
+		// the row never reaches persist at all. GREEN: sanitize-before-validate
+		// means the validator sees the already-clean "ab" and passes, so the
+		// row both validates AND persists exactly "ab". Either way the
+		// assertion below fails at RED for the reason this change addresses
+		// (mirrors the analogous DNSBL description case in
+		// tests/smoke/ui/test_sanitize_persist.py).
+		$result = $this->runSave([
+			'hook_description-0' => "\u{FEFF}a\x01b  ",
+		]);
+		$this->assertSame([], $result['errors'], 'a BOM+control-char description must not be rejected once sanitized');
+		$this->assertSame('ab', $result['hooks'][0]['description'], 'BOM/control char/trailing space must not survive to the persisted description');
+	}
+
+	// --- timeout: a leading BOM must not trip PFB_FILTER_NUM ---
+
+	public function testTimeoutBomStrippedSoDigitsValidate(): void
+	{
+		$result = $this->runSave([
+			'hook_timeout-0' => "\u{FEFF}30",
+		]);
+		$this->assertSame([], $result['errors'], 'a BOM-prefixed numeric timeout must validate once sanitized at ingestion');
+		$this->assertSame('30', $result['hooks'][0]['timeout'], 'the sanitized timeout must persist as the plain digit string');
+	}
+
+	// --- description: legacy (ISO-8859-1) byte converts to valid UTF-8 ---
+
+	public function testDescriptionLegacyEncodingByteConvertsToUtf8(): void
+	{
+		// RED today: "caf\xE9" is invalid UTF-8, so preg_match(...,'/u') on the
+		// RAW value returns FALSE (not 0); the validator's `!== 0` fail-closed
+		// compare treats that as a reject too, so the row never reaches
+		// persist. GREEN: sanitize converts the legacy byte to UTF-8 first, so
+		// the validator sees valid text and passes.
+		$result = $this->runSave([
+			'hook_description-0' => "caf\xE9",
+		]);
+		$this->assertSame([], $result['errors'], 'a legacy-encoded description must not be rejected once sanitized to UTF-8');
+		$this->assertSame('café', $result['hooks'][0]['description'], 'an ISO-8859-1 byte must convert to valid UTF-8, not survive as invalid bytes');
+	}
+
+	// --- description: an all-Unicode-whitespace value trims to '' ---
+
+	public function testDescriptionAllUnicodeWhitespaceTrimsToEmpty(): void
+	{
+		$result = $this->runSave([
+			'hook_description-0' => "\u{00A0}\u{2003}",
+		]);
+		$this->assertSame([], $result['errors'], 'an all-Unicode-whitespace description must not be rejected');
+		$this->assertSame('', $result['hooks'][0]['description'], 'NBSP/em-space-only content must trim to the empty string');
+	}
+
+	// --- description: a Cf (format) char still trips the \p{C} validator ---
+
+	public function testDescriptionCfCharacterStillRejectedByValidator(): void
+	{
+		// U+200D ZERO WIDTH JOINER -- category Cf, NOT stripped by
+		// pfb_sanitize_text() (only \p{Cc}+BOM are stripped there), but still
+		// inside \p{C} (the "Other" superset the page's own validator gates
+		// on). Pins that the validator stays live post-sanitize.
+		$result = $this->runSave([
+			'hook_description-0' => "a\u{200D}b",
+		]);
+		$this->assertNotEmpty($result['errors'], 'a Cf (zero-width-joiner) description must still be rejected by the \\p{C} validator');
+	}
+
+	// --- array-valued field: scalar reject fires before sanitize, no TypeError ---
+
+	public function testArrayValuedDescriptionRejectedWithoutTypeError(): void
+	{
+		try {
+			$result = $this->runSave([
+				'hook_description-0' => ['x'],
+			]);
+		} catch (\TypeError $e) {
+			$this->fail('an array-valued hook_description-0 must not TypeError the sanitize call: ' . $e->getMessage());
+		}
+		$this->assertNotEmpty($result['errors'], 'an array-valued hook_description-0 must be rejected as an invalid field');
+		$this->assertContains('Invalid hook field value.', $result['errors']);
+	}
+
+	// --- timeout: surrounding ASCII whitespace now validates and persists ---
+
+	public function testTimeoutAsciiPaddingStillTrims(): void
+	{
+		// PFB_FILTER_NUM is `^[0-9]+$` -- no surrounding-space tolerance -- and
+		// the OLD code ran it on the raw value (the persist block's trim() ran
+		// only AFTER validation already passed/failed). So ' 30 ' was ALWAYS
+		// rejected before this change too; it is not a pre-existing trim, it
+		// is the same sanitize-before-validate fix as the BOM timeout case
+		// above, exercised with plain whitespace instead of a BOM. RED: reject
+		// (PFB_FILTER_NUM sees the untrimmed spaces). GREEN: sanitize trims
+		// before validation, so it passes and persists '30'.
+		$result = $this->runSave([
+			'hook_timeout-0' => ' 30 ',
+		]);
+		$this->assertSame([], $result['errors']);
+		$this->assertSame('30', $result['hooks'][0]['timeout']);
+	}
+}

--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -256,6 +256,21 @@ final class PfbFilterContractTest extends TestCase
 			// Unicode-whitespace/control: still caught by pfb_filter()'s universal
 			// \p{Cc}+BOM gate before the switch is even reached -- pin.
 			'embedded NUL'                => ["example\0host"],
+			// PR #1781 adversarial review: a delimiter character survives
+			// idn_to_ascii() -- it has no STD3-ASCII-rules check, so the
+			// punycode candidate can carry a literal ',', ' ' or '|' straight
+			// through (probed: idn_to_ascii("a,bä.example") ===
+			// "xn--a,b-sla.example", non-FALSE, non-empty). is_hostname() is
+			// the SOLE remaining guard that rejects it. These pin the
+			// delimiter class specifically -- not merely "invalid hostname"
+			// in general -- because these three characters are the ones a
+			// converted-but-accepted candidate would inject into the
+			// comma-joined $details line (pfblockerng.inc:~15389) and the
+			// ipcache SQLite table, shifting every downstream field. The
+			// inputs are non-admin: DHCP client-hostname / a PTR record.
+			'comma survives IDN conversion (log/DB delimiter safety)' => ['a,bä.example'],
+			'space survives IDN conversion (log/DB delimiter safety)' => ['a bä.example'],
+			'pipe survives IDN conversion (log/DB delimiter safety)'  => ['a|bä.example'],
 		];
 	}
 

--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -210,6 +210,68 @@ final class PfbFilterContractTest extends TestCase
 		$this->assertSame(".b\xC3\xBCcher.de", pfb_filter(".b\xC3\xBCcher.de", PFB_FILTER_DOMAIN, 'PFBL-01 contract'));
 	}
 
+	// --- PFB_FILTER_HOSTNAME: Unicode/IDN acceptance (issue #1731) ----------------
+	//
+	// dnsbl.php's TLD Exclusion rows are hostname-typed (PFB_FILTER_HOSTNAME) but
+	// used to reject any non-ASCII input outright (bare is_hostname(), no IDN
+	// branch) while the adjacent TLD Blacklist (PFB_FILTER_TLD, issue #1723)
+	// already accepted punycode-convertible Unicode. Same fix, same shape: a
+	// non-ASCII input is converted to its punycode candidate before
+	// is_hostname() runs; on success the ORIGINAL Unicode input is returned
+	// (htmlspecialchars'd) -- the read path IDN-converts separately.
+
+	/** @return array<string, array{0: string}> label => Unicode hostname returned unchanged */
+	public static function hostnameUnicodeAcceptedProvider(): array
+	{
+		return [
+			'IDN hostname (latin)'   => ['bücher.example'],
+			'IDN mixed-label'        => ['münchen.test-host'],
+			// Already-punycode ASCII input: no non-ASCII byte, so the IDN branch
+			// never triggers -- pins the pre-existing (unchanged) accept path.
+			'already-punycode ASCII' => ['xn--bcher-kva.example'],
+			// Plain ASCII hostname -- before-state pin, must stay green both
+			// sides of the fix (no regression on the plain-ASCII path).
+			'plain ASCII hostname'   => ['example-host'],
+		];
+	}
+
+	#[DataProvider('hostnameUnicodeAcceptedProvider')]
+	public function testHostnameFilterAcceptsUnicodeIdnUnchanged(string $hostname): void
+	{
+		$this->assertSame($hostname, pfb_filter($hostname, PFB_FILTER_HOSTNAME, 'PFBL-01 contract'));
+	}
+
+	/** @return array<string, array{0: string}> label => value the HOSTNAME filter must reject */
+	public static function hostnameRejectedProvider(): array
+	{
+		return [
+			// Lone combining mark -- not a legal standalone label; idn_to_ascii()
+			// refuses it (UTS46), so the candidate stays FALSE.
+			'lone combining mark'         => ["\xCC\x81"],
+			// Punycode form of an overlong label exceeds the 63-char label cap
+			// once 'xn--...-' is added -- idn_to_ascii() itself returns FALSE.
+			'IDN label overlong in punycode' => [str_repeat('ü', 60)],
+			// Plain ASCII reject -- before-state pin (unaffected by the IDN branch).
+			'embedded space (ascii)'      => ['exam ple'],
+			// Unicode-whitespace/control: still caught by pfb_filter()'s universal
+			// \p{Cc}+BOM gate before the switch is even reached -- pin.
+			'embedded NUL'                => ["example\0host"],
+		];
+	}
+
+	#[DataProvider('hostnameRejectedProvider')]
+	public function testHostnameFilterRejectsToDefault(string $input): void
+	{
+		$this->assertSame('', pfb_filter($input, PFB_FILTER_HOSTNAME, 'PFBL-01 contract'));
+	}
+
+	public function testHostnameFilterAcceptsEmptyStringUnchanged(): void
+	{
+		// pfb_filter() short-circuits on empty() before the switch is ever
+		// reached for non-ON_OFF/NUM types -- unchanged before/after (pin).
+		$this->assertSame('', pfb_filter('', PFB_FILTER_HOSTNAME, 'PFBL-01 contract', ''));
+	}
+
 	// --- PFB_FILTER_WORD (feed headers + friendly interface names) ---------------
 
 	/** @return array<string, array{0: string}> label => valid \w-only value returned unchanged */

--- a/tests/php/XmlrpcSyncIdnTargetTest.php
+++ b/tests/php/XmlrpcSyncIdnTargetTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * XMLRPC sync target IDN punycode conversion (issue #1778).
+ *
+ * #1731 widened PFB_FILTER_HOSTNAME to accept an IDN sync target at save time
+ * (pfblockerng_sync.php:104), but pfblockerng_sync_on_changes()'s runtime gate
+ * (is_ipaddr/is_hostname/is_domain, ~17186) and pfblockerng_do_xmlrpc_sync()'s
+ * connection (setConnectionData(), ~17288) stayed bare-ASCII -- a saved Unicode
+ * target saved cleanly and then failed every sync attempt. The fix
+ * punycode-converts $sync_to_ip at the point of use, immediately after it is
+ * read from config and before the gate; the original is kept for the
+ * human-facing log lines.
+ *
+ * Unlike a top-level-executing page (pfblockerng_category_edit.php,
+ * CategoryEditPostGuardTest), pfblockerng.inc is require_once'd WHOLE by the
+ * test bootstrap, so pfblockerng_sync_on_changes() is a real, directly
+ * callable function here -- no eval-extraction needed. Reaching the real
+ * XMLRPC connection call (rather than hand-copying the gate) needs a double
+ * for pfSense's xmlrpc_client.inc: pfsense_xmlrpc_client
+ * (tests/php/pfsense_doubles.php) captures setConnectionData()'s argument
+ * into $GLOBALS['pfb_test_xmlrpc_connection'] instead of dialing out, backed
+ * by an empty satisfies-require_once() shim (tests/php/shims/xmlrpc_client.inc).
+ */
+#[CoversFunction('pfblockerng_sync_on_changes')]
+final class XmlrpcSyncIdnTargetTest extends TestCase
+{
+	private mixed $savedConfig = null;
+
+	protected function setUp(): void
+	{
+		$this->savedConfig = $GLOBALS['config'] ?? null;
+		unset($GLOBALS['pfb_test_xmlrpc_connection']);
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->savedConfig === null) {
+			unset($GLOBALS['config']);
+		} else {
+			$GLOBALS['config'] = $this->savedConfig;
+		}
+		unset($GLOBALS['pfb_test_xmlrpc_connection']);
+	}
+
+	private function seedSyncConfig(string $target): void
+	{
+		$GLOBALS['config'] = [
+			'installedpackages' => [
+				'pfblockerngsync' => [
+					'config' => [
+						0 => [
+							'varsynconchanges' => 'manual',
+							'varsynctimeout'   => 5,
+							'row' => [
+								0 => [
+									'varsyncdestinenable' => true,
+									'varsyncipaddress'    => $target,
+									'varsyncport'         => 443,
+									'varsyncpassword'     => 'secret',
+									'varsyncprotocol'     => 'https',
+									'varsyncusername'     => 'admin',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	// --- red-first: the defect this issue fixes -----------------------------
+
+	public function testIdnTargetReachesConnectionAsPunycode(): void
+	{
+		// 'bücher.example' <-> 'xn--bcher-kva.example' is the same IDN/punycode
+		// pair PfbFilterContractTest pins for PFB_FILTER_HOSTNAME (#1731) -- the
+		// save-time filter already accepts this exact target.
+		$this->seedSyncConfig('bücher.example');
+		pfblockerng_sync_on_changes();
+
+		$this->assertArrayHasKey(
+			'pfb_test_xmlrpc_connection',
+			$GLOBALS,
+			'a valid IDN target must pass the runtime gate and reach the XMLRPC connection (pre-fix: the bare-ASCII gate rejects it, so no connection is ever attempted)'
+		);
+		$this->assertSame(
+			'xn--bcher-kva.example',
+			$GLOBALS['pfb_test_xmlrpc_connection']['ip'] ?? null,
+			'the connection must receive the punycode form, not the raw Unicode target'
+		);
+	}
+
+	// --- before-state pins: green both sides of the fix ---------------------
+
+	public function testPlainAsciiHostnameTargetUnchanged(): void
+	{
+		$this->seedSyncConfig('sync-peer.example');
+		pfblockerng_sync_on_changes();
+
+		$this->assertSame(
+			'sync-peer.example',
+			$GLOBALS['pfb_test_xmlrpc_connection']['ip'] ?? null,
+			'a plain ASCII hostname target must reach the connection byte-identical'
+		);
+	}
+
+	public function testIpv4TargetUnchanged(): void
+	{
+		$this->seedSyncConfig('192.0.2.10');
+		pfblockerng_sync_on_changes();
+
+		$this->assertSame(
+			'192.0.2.10',
+			$GLOBALS['pfb_test_xmlrpc_connection']['ip'] ?? null,
+			'an IPv4 literal target must reach the connection unchanged'
+		);
+	}
+
+	public function testIpv6TargetStillBracketWrapped(): void
+	{
+		$this->seedSyncConfig('2001:db8::53');
+		pfblockerng_sync_on_changes();
+
+		$this->assertSame(
+			'[2001:db8::53]',
+			$GLOBALS['pfb_test_xmlrpc_connection']['ip'] ?? null,
+			'an IPv6 literal target must still receive its bracket wrap (pfblockerng_do_xmlrpc_sync, ~17259) at the connection site'
+		);
+	}
+
+	public function testUnconvertibleUnicodeTargetStillRejected(): void
+	{
+		// A lone combining mark (U+0301): not a legal standalone label --
+		// idn_to_ascii() refuses it (returns FALSE), so $sync_to_ip is left
+		// unchanged and the existing gate rejects it exactly as before the fix.
+		$this->seedSyncConfig("\xCC\x81");
+		pfblockerng_sync_on_changes();
+
+		$this->assertArrayNotHasKey(
+			'pfb_test_xmlrpc_connection',
+			$GLOBALS,
+			'a Unicode target idn_to_ascii() cannot convert must still be rejected by the gate, never reach the connection'
+		);
+	}
+}

--- a/tests/php/XmlrpcSyncIdnTargetTest.php
+++ b/tests/php/XmlrpcSyncIdnTargetTest.php
@@ -96,6 +96,42 @@ final class XmlrpcSyncIdnTargetTest extends TestCase
 		);
 	}
 
+	// PR #1781 adversarial review: $sync_to_ip_display was entirely unpinned --
+	// a mutant replacing all four `$sync_to_ip_display` occurrences with
+	// `$sync_to_ip` (the commit-4 assignment at ~17188 plus the three
+	// human-facing log lines at ~17213/17216/17224) survived the full suite,
+	// because every existing assertion here only inspects the XMLRPC
+	// connection argument (which correctly stays punycode either way). Pin the
+	// human-facing pfb_logger() line via the established sandbox
+	// ($GLOBALS['pfb']['log'], the LiveLogStdoutTest / AlertsLivePunchApplyTest
+	// idiom): it must show the ORIGINAL Unicode target, never the punycode
+	// form. logger()/syslog() (the other two mutated call sites, ~17218/
+	// ~17224) is not captured by any test double in this bootstrap (it falls
+	// through to a real syslog() call) -- the mutant touches all four
+	// occurrences at once, so killing it via the one capturable site is
+	// sufficient proof.
+	public function testIdnTargetLogLineKeepsOriginalUnicodeTarget(): void
+	{
+		global $pfb;
+		@mkdir($pfb['logdir'], 0777, TRUE);
+		@file_put_contents($pfb['log'], '');
+
+		$this->seedSyncConfig('bücher.example');
+		pfblockerng_sync_on_changes();
+
+		$log = (string) @file_get_contents($pfb['log']);
+		$this->assertStringContainsString(
+			'bücher.example',
+			$log,
+			"expected the human-facing sync log line to keep the original Unicode target, but log was:\n{$log}"
+		);
+		$this->assertStringNotContainsString(
+			'xn--bcher-kva.example',
+			$log,
+			"the human-facing sync log line must never show the punycode form, but log was:\n{$log}"
+		);
+	}
+
 	// --- before-state pins: green both sides of the fix ---------------------
 
 	public function testPlainAsciiHostnameTargetUnchanged(): void

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -1304,3 +1304,32 @@ if (!function_exists('install_cron_job')) {
 		configure_cron();
 	}
 }
+
+// --- xmlrpc_client.inc double (issue #1778) ---
+//
+// pfblockerng_do_xmlrpc_sync() require_once()s 'xmlrpc_client.inc' (empty shim,
+// tests/php/shims/) and instantiates pfSense's pfsense_xmlrpc_client to dial the
+// sync peer. This double captures setConnectionData()'s arguments into
+// $GLOBALS['pfb_test_xmlrpc_connection'] instead of making a real network call,
+// so XmlrpcSyncIdnTargetTest can call the REAL pfblockerng_sync_on_changes() end
+// to end and assert exactly what reaches the connection -- no eval-extraction of
+// the caller needed. xmlrpc_method() returns a truthy stub response so the
+// caller's isset($resp) success branch runs (pfb_logger " done." vs " Failed!").
+
+if (!class_exists('pfsense_xmlrpc_client')) {
+	class pfsense_xmlrpc_client {
+		public function setConnectionData($ip, $port, $username, $password, $protocol) {
+			$GLOBALS['pfb_test_xmlrpc_connection'] = [
+				'ip'       => $ip,
+				'port'     => $port,
+				'username' => $username,
+				'password' => $password,
+				'protocol' => $protocol,
+			];
+		}
+
+		public function xmlrpc_method($method, $params, $timeout = null) {
+			return ['status' => 'ok'];
+		}
+	}
+}

--- a/tests/php/shims/xmlrpc_client.inc
+++ b/tests/php/shims/xmlrpc_client.inc
@@ -1,0 +1,3 @@
+<?php
+// Empty shim: satisfies require_once('xmlrpc_client.inc') from pfblockerng.inc under PHPUnit.
+// pfSense runtime functions are provided as doubles in pfsense_doubles.php.

--- a/tests/smoke/ui/test_sanitize_persist.py
+++ b/tests/smoke/ui/test_sanitize_persist.py
@@ -588,6 +588,34 @@ def test_dnsbl_suppression_rejects_double_dot_row(
     )
 
 
+def test_dnsbl_tld_exclusion_accepts_idn_row(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    dnsbl_vip_ready: None,  # noqa: ARG001
+) -> None:
+    """TLD Exclusion (hostname-typed) keeps taking a Unicode/IDN row (issue #1731).
+
+    TLD Exclusion (``tldexclusion``, PFB_FILTER_HOSTNAME) used to reject any
+    non-ASCII row outright -- bare ``is_hostname()``, no IDN branch -- while
+    the adjacent TLD Blacklist (``tldblacklist``, PFB_FILTER_TLD, issue #1723)
+    already accepted a punycode-convertible Unicode row. pfb_filter()'s
+    PFB_FILTER_HOSTNAME case now converts a non-ASCII input to its punycode
+    candidate before ``is_hostname()`` runs, matching PFB_FILTER_TLD.
+    """
+    vm = smoke_vm
+    idn_row = "bü" + helpers.unique_domain("pfbtldxidn")
+    cfg = "installedpackages/pfblockerngdnsblsettings/config/0/tldexclusion"
+
+    before = helpers.config_get(vm, cfg)
+    resp = webui.post(DNSBL_PAGE, {"tldexclusion": idn_row}, timeout=SETTINGS_SAVE_TIMEOUT)
+    assert not looks_like_login_page(resp.text), "DNSBL POST returned the login form (session lost)"
+    assert "Invalid  Hostname entry" not in resp.text, f"the IDN row was rejected as an invalid hostname: {idn_row!r}"
+
+    after = helpers.config_get(vm, cfg)
+    assert after != before, "tldexclusion did not change -- the save did not take (POST must CAUSE the change)"
+    assert _decoded(after) == idn_row, f"the IDN row must persist verbatim, got {_decoded(after)!r}"
+
+
 def test_edit_hooks_save_sanitizes_the_written_script(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,

--- a/tests/smoke/ui/test_sanitize_persist.py
+++ b/tests/smoke/ui/test_sanitize_persist.py
@@ -475,6 +475,54 @@ def test_category_edit_custom_list_accepts_wildcard_idn_row(
         tce._del_rowid(vm, tce.CFG_DNSBL, rowid)
 
 
+def test_category_edit_rowhelper_header_sanitized(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """DNSBL alias rowhelper ``header-0`` sanitizes BOM/NBSP at ingestion (#1737).
+
+    Companion to ``CategoryEditPostGuardTest`` (PHPUnit oracle, off-appliance):
+    ``pfblockerng_category_edit.php``'s rowhelper ``header-N``/``url-N`` fields
+    used to sanitize only in the PERSIST loop, after the validation loop had
+    already evaluated the raw (unsanitized) bytes. A new ingestion-prologue
+    loop now runs ``pfb_sanitize_text()`` on every ``header-N``/``url-N`` POST
+    key right before validation, so both loops see the same bytes. The row is
+    kept ``state-0='Disabled'`` -- the header check is non-empty-, not state-,
+    gated (issue #1270), and an empty ``url-0`` on a Disabled row skips every
+    url-N check, so the header sanitizer is the sole variable under test.
+
+    RED (before the fix): the NBSP/BOM survive into the validation loop's own
+    ``\\W`` header check unchanged -- a NBSP is ``\\W``, so the whole save is
+    REJECTED and the seeded (empty) header is left unchanged.
+    GREEN (after): the ingestion prologue strips the NBSP/BOM before the
+    validation loop ever runs, so the row validates and persists as ``'hdr'``.
+    """
+    vm = smoke_vm
+    rowid = tce._free_rowid(vm, tce.CFG_DNSBL)
+    base = f"{tce.CFG_DNSBL}/{rowid}"
+    aliasname = "smokehdrsan"
+    try:
+        assert helpers.config_get(vm, f"{base}/aliasname") == "", f"rowid {rowid} not free (aliasname already set)"
+        assert helpers.config_get(vm, f"{base}/row/0/header") == "", f"rowid {rowid} not free (header already set)"
+
+        raw = "\u00a0hdr\ufeff"
+        expected = "hdr"
+        tce._post_form(
+            webui,
+            tce._dnsbl_payload(rowid, aliasname, **{"header-0": raw}),
+        )
+
+        assert helpers.config_get(vm, f"{base}/aliasname") == aliasname, (
+            "the save aborted (aliasname did not persist) -- the header guard rejected the sanitized value"
+        )
+        assert helpers.config_get(vm, f"{base}/row/0/header") == expected, (
+            f"header not sanitized at ingestion: expected {expected!r}, got "
+            f"{helpers.config_get(vm, f'{base}/row/0/header')!r}"
+        )
+    finally:
+        tce._del_rowid(vm, tce.CFG_DNSBL, rowid)
+
+
 def test_dnsbl_suppression_accepts_single_dot_wildcard_row(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,

--- a/tests/smoke/ui/test_sanitize_persist.py
+++ b/tests/smoke/ui/test_sanitize_persist.py
@@ -523,6 +523,66 @@ def test_category_edit_rowhelper_header_sanitized(
         tce._del_rowid(vm, tce.CFG_DNSBL, rowid)
 
 
+def test_category_edit_rowhelper_url_sanitized(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """DNSBL alias rowhelper ``url-0`` sanitizes BOM/NBSP at ingestion (#1737).
+
+    Companion to ``test_category_edit_rowhelper_header_sanitized`` above -- the
+    #1737 contract update sanitizes BOTH ``header-N`` and ``url-N`` at
+    ingestion, but that test keeps the row ``state-0='Disabled'`` so the
+    empty ``url-0`` skips every state-gated url check entirely -- it never
+    proves the ingestion sanitizer runs ahead of THOSE. This test keeps
+    ``state-0='Enabled'``/``format-0='geoip'`` instead (the deterministic,
+    no-network-fetch shape ``test_dnsbl_url_geoip_value_persists_byte_identical``
+    in ``test_category_edit.py`` already uses -- 'auto'/'regex'/'rsync' would
+    need a real resolvable feed host) so the row actually persists through
+    BOTH the non-empty-gated control-char guard AND the state-gated geoip
+    ``PFB_FILTER_ALNUM`` prefix check, not just the former.
+
+    RED (before the fix): the raw BOM (category Cf) is itself inside the
+    row's own ``\\p{C}`` url-N guard (issue #1104), run on the RAW value
+    before any sanitize -- the save is REJECTED outright and the seeded
+    (empty) url is left unchanged (mirrors
+    ``test_category_edit_rowhelper_header_sanitized``'s RED story).
+    GREEN (after): ``pfb_sanitize_text()`` strips the BOM + Unicode-trims the
+    leading NBSP BEFORE the validation loop runs, so the row validates
+    (geoip's prefix check sees a clean ``'US'``) and persists as ``'US CA'``.
+    """
+    vm = smoke_vm
+    rowid = tce._free_rowid(vm, tce.CFG_DNSBL)
+    base = f"{tce.CFG_DNSBL}/{rowid}"
+    aliasname = "smokeurlsan"
+    orig_key, orig_account = tce._capture_maxmind_creds(vm)
+    try:
+        tce._seed_maxmind_test_creds(vm)
+        assert helpers.config_get(vm, f"{base}/aliasname") == "", f"rowid {rowid} not free (aliasname already set)"
+        assert helpers.config_get(vm, f"{base}/row/0/url") == "", f"rowid {rowid} not free (url already set)"
+
+        raw = "\u00a0US CA\ufeff"
+        expected = "US CA"
+        tce._post_form(
+            webui,
+            tce._dnsbl_payload(
+                rowid,
+                aliasname,
+                **{"state-0": "Enabled", "header-0": "hdr", "format-0": "geoip", "url-0": raw},
+            ),
+        )
+
+        assert helpers.config_get(vm, f"{base}/aliasname") == aliasname, (
+            "the save aborted (aliasname did not persist) -- the url guard rejected the sanitized value"
+        )
+        assert helpers.config_get(vm, f"{base}/row/0/url") == expected, (
+            f"url not sanitized at ingestion: expected {expected!r}, got "
+            f"{helpers.config_get(vm, f'{base}/row/0/url')!r}"
+        )
+    finally:
+        tce._del_rowid(vm, tce.CFG_DNSBL, rowid)
+        tce._restore_maxmind_creds(vm, orig_key, orig_account)
+
+
 def test_dnsbl_suppression_accepts_single_dot_wildcard_row(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,

--- a/tests/smoke/ui/test_sanitize_persist.py
+++ b/tests/smoke/ui/test_sanitize_persist.py
@@ -31,6 +31,7 @@ import pytest
 
 from .. import helpers
 from . import test_category_edit as tce
+from . import test_hooks as th
 from .webui import looks_like_login_page
 
 if TYPE_CHECKING:
@@ -599,3 +600,49 @@ def test_edit_hooks_save_sanitizes_the_written_script(
         assert after == expected, f"hook script not sanitized on save: expected {expected!r}, got {after!r}"
     finally:
         vm.ssh("/bin/rm", "-f", path, timeout=60.0)
+
+
+def test_hooks_row_description_sanitized(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Hooks tab row ``description`` sanitizes BOM/control/trailing-NBSP at ingestion (#1761).
+
+    Companion to ``HooksSanitizeIngestionTest`` (PHPUnit oracle, off-appliance):
+    ``pfblockerng_hooks.php``'s rowhelper validation loop used a bare ``trim()``
+    at persist, so a BOM/control byte survived and a trailing Unicode (NBSP)
+    space did not. Routing ``hook_description-N`` through ``pfb_sanitize_text()``
+    at ingestion -- before the row's own ``\\p{C}`` control-char validator runs --
+    fixes both, and (per the PHPUnit oracle) the validator still gates a genuine
+    Cf/Cc character; this live pin proves the happy-path save persists the clean
+    string end to end through the real page/config.xml round trip.
+
+    RED (before the fix): the BOM (category Cf) is itself inside the row's own
+    ``\\p{C}`` description validator -- run on the RAW value, before any
+    sanitize -- so the save is REJECTED outright and the seeded description is
+    left unchanged (mirrors ``test_category_edit_description_sanitized``
+    above: "either way the assertion fails for the reason this change
+    addresses").
+    GREEN (after): ``pfb_sanitize_text()`` strips the BOM + control char and
+    Unicode-trims the trailing NBSP BEFORE the validator runs, so the row
+    validates and persists as ``"smokedesc"``.
+    """
+    vm = smoke_vm
+    helpers.clear_update_hooks(vm)
+    th._install_test_scripts(vm)
+    seed_description = "smoke-1761-seed"
+    th._seed_one_hook(vm, script=th.SCRIPT_POST, when="post", enabled="on", description=seed_description)
+    try:
+        assert helpers.config_get(vm, th.ROW0_DESCRIPTION) == seed_description, (
+            f"seed description missing before the save flow: got {helpers.config_get(vm, th.ROW0_DESCRIPTION)!r}"
+        )
+
+        raw = "\ufeffsmokedesc\x07\u00a0"
+        expected = "smokedesc"
+        resp = webui.post(th.HOOKS_PAGE, {"hook_description-0": raw}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "hooks description POST returned the login form (session lost)"
+
+        after = helpers.config_get(vm, th.ROW0_DESCRIPTION)
+        assert after == expected, f"description not sanitized at ingestion: expected {expected!r}, got {after!r}"
+    finally:
+        helpers.clear_update_hooks(vm)


### PR DESCRIPTION
Four correlated text-ingestion and IDN-validation fixes from the v4.0.0 milestone, one commit per issue.

Fixes #1761. Fixes #1737. Fixes #1731. Fixes #1778.

## Commit 1 — Hooks tab rowhelper fields sanitize at ingestion (#1761)

`pfblockerng_hooks.php` ingested `hook_description-N` / `hook_timeout-N` with a bare `trim()`, so the stored value kept control characters and a BOM and missed Unicode whitespace. Both now go through `pfb_sanitize_text()` as the first operation on the field, before any validation — the persist-boundary standard #1723 set. The `\p{C}` description validator and the `PFB_FILTER_NUM` timeout validator stay live (a sanitizer that strips only `Cc`+BOM leaves `Cf` for the validator to reject, pinned by a test).

## Commit 2 — category_edit rowhelper header/url sanitize at ingestion (#1737)

The `header-N` / `url-N` columns were sanitized inside the persist loop while the validation loop above evaluated the raw `$_POST` values — validation saw different bytes than what persisted. Sanitize moves to the true ingestion point and the in-loop pass is dropped (process once).

This carries a deliberate **contract update**: three pre-existing tests pinned the pre-migration shape, where an embedded control character, a tab, or invalid UTF-8 in `url-N` was rejected by the *character guard*. Under the #1723 standard those bytes are cleaned at ingestion, so that specific guard no longer fires on them — the tests are rewritten to pin the cleaned bytes exactly. To be precise about what this does **not** mean: all three inputs still fail to save, because the page's other validators (the GeoIP prefix check, `PFB_FILTER_URL`) reject the cleaned value on its own merits. The rewritten tests are scoped to the character-guard message alone and say so. Two vacuity guards (`<`/`"` and a `Cf` character still rejected) prove the `[\p{C}<>"]` guard remains live after sanitize rather than silently defanged.

The same fail-closed-to-accept-after-clean shift applies to commit 1's description field, where a BOM or invalid UTF-8 previously tripped the `\p{C}` validator and now sanitizes clean — pinned by `HooksSanitizeIngestionTest`. It is safe for the same reason: `pfb_sanitize_text()` is idempotent (fuzz-verified over 20k random inputs), and the persist path already applied it, so no value becomes reachable that an operator could not already type.

## Commit 3 — PFB_FILTER_HOSTNAME accepts IDN (#1731)

TLD Exclusion rows rejected Unicode while the adjacent TLD Blacklist accepted IDN, because `tldexclusion` maps to `PFB_FILTER_HOSTNAME` (bare `is_hostname()`) while `tldblacklist` maps to `PFB_FILTER_TLD` (punycode-candidate validation since #1729). Fixed at the root: `PFB_FILTER_HOSTNAME` gains the same candidate preamble — validate `idn_to_ascii()`'s output, return the original input on success. All five callers were enumerated from source and the widening is intentional for each (sync target, tldexclusion rows, two DHCP lease-hostname collectors, the filterlog resolved host).

## Commit 4 — punycode-convert the XMLRPC sync target at the point of use (#1778)

Commit 3's widening had a consequence caught in verification: the Sync page began *accepting* an IDN target, but the runtime gate (`is_ipaddr`/`is_hostname`/`is_domain`) and the XMLRPC client are ASCII-only, so such a target saved cleanly and then failed **every** sync. Converted at the point of use — an ASCII target takes a byte-identical path, a conversion failure falls through to the pre-existing rejection, and the human-facing log lines keep the original Unicode form the operator configured.

## Evidence

Every commit red-first with frozen hashes, each independently verifier-gated (red proofs re-executed via `verify-red-proof.sh`, mutations re-run — including one that reverts only the ingestion prologue to prove the tests pin ingestion *placement*, not merely "some sanitize"). Commit 4's test drives the real `pfblockerng_sync_on_changes()` end to end through an XMLRPC client double that records the actual connection argument, so it asserts on the real computed target rather than a copied snippet. Full PHPUnit, PHPStan, PHPCS green; `www/` changes carry `ui_e2e` coverage in `tests/smoke/ui/test_sanitize_persist.py`.

A follow-up from commit 3's review is filed as #1779 (all three IDN-capable filters accept emoji labels with no hostile-input row pinning the decision) — behaviour is consistent and pre-existing, so it is a decide-and-pin item, not a defect.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for Unicode and internationalized domain names in hostname validation and XML-RPC synchronization.
  * Preserved readable Unicode hostnames in synchronization logs while using compatible network connection formats.
  * Improved form handling by sanitizing text fields earlier, producing cleaner saved category and hook values.
  * Strengthened rejection of invalid or unsafe input while preserving valid selections and network addresses.

* **Tests**
  * Added coverage for Unicode hostnames, synchronization targets, input sanitization, and persisted form values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->