### PR TITLE
build-repo: retain the newest package of every major/minor line per channel (#1676 slice 1)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -399,7 +399,8 @@ The scheduled version-tracking + release-automation design is its own ADR.
 
 `build-repo-portable.py --build-matrix` generates the self-hosted `pkg` repository tree
 (ADR-17). By default it keeps only the **latest** release of each channel per
-`(version, arch)` — identical to the pre-ADR-27 behaviour. Three flags control retention:
+`(version, arch)`, plus the newest package of each major/minor line (line pins, below) —
+the window itself is identical to the pre-ADR-27 behaviour. Three flags control retention:
 
 | Flag | Default | Purpose |
 | ---- | ------- | ------- |
@@ -432,7 +433,7 @@ retention depth, it prunes to the newest N/M before writing the catalog.
 
 `pkg install <name>` (no version) still resolves the **highest** listed version
 (newest-wins, `pkg` version ordering). Versions older than the N/M retention window are absent
-from the catalog.
+from the catalog unless retained as a line pin.
 
 > **Compatibility note:** retention is artifact availability, not supported downgrade. Older
 > packages may not understand current state; configuration or enforcement may fail. Restore a

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -409,6 +409,13 @@ The scheduled version-tracking + release-automation design is its own ADR.
 
 `--release-keep-devel 0` / `--release-keep-stable 0` is the **unbounded** sentinel (keep all).
 
+**Line pins are retained on top of the N/M window** (issue #1676): the newest package of
+every pfBlockerNG major/minor line survives per channel even when it falls outside the
+rolling window, so an aged-out release stays installable by exact version. A catalog can
+therefore hold more than `N` + `M` packages — budget for one extra per aged-out line per
+channel. Pins are per channel, so a devel pin never satisfies or evicts a stable one; the
+`0` sentinel and the nightly subtree are unaffected.
+
 ### How the publish pipeline uses these flags
 
 `pfBlockerNG/pkg`'s `publish.yml` passes:

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -907,7 +907,9 @@ def main(argv: list[str]) -> int:
         help=(
             "devel releases retained per (version, arch) in the release catalog (default 1 = latest-only). "
             "Set >1 to retain multiple devel artifacts for diagnostics and reproducibility. "
-            "The publish job must supply the older .pkg via --release-extra-pkgs."
+            "The publish job must supply the older .pkg via --release-extra-pkgs. "
+            "The newest package of every major/minor line is pinned on top of this window, "
+            "so the catalog can hold more than N devel packages."
         ),
     )
     g_matrix.add_argument(
@@ -918,7 +920,9 @@ def main(argv: list[str]) -> int:
         help=(
             "stable releases retained per (version, arch) in the release catalog (default 1 = latest-only). "
             "Set >1 to retain multiple stable artifacts for diagnostics and reproducibility. "
-            "The publish job must supply the older .pkg via --release-extra-pkgs."
+            "The publish job must supply the older .pkg via --release-extra-pkgs. "
+            "The newest package of every major/minor line is pinned on top of this window, "
+            "so the catalog can hold more than M stable packages."
         ),
     )
     g_matrix.add_argument(

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -443,30 +443,75 @@ def _non_negative_int(value: str) -> int:
     return iv
 
 
+def _line_key(version: str, pkg_name: str) -> str:
+    """The major/minor "line" grouping key for a pfBlockerNG pkg VERSION.
+
+    Split on the same ``[._,]`` separator set as ``pkg_version_sort_key`` (a port
+    revision like ``1.0_1`` is still major=1/minor=0), then take the first two
+    numeric components, e.g. ``3.2.15`` -> ``"3.2"``, ``4.0.0.alpha.3`` -> ``"4.0"``.
+    Unlike ``_pkg_version_key``/``pkg_version_sort_key`` (which maps any non-numeric
+    component to ``0`` — fine for a SORT tie-break, never raises), this parse FAILS
+    CLOSED: a version whose first two components aren't both plain digit strings can
+    never silently misbucket into some line or get dropped — it raises naming the
+    offending package instead.
+    """
+    parts = re.split(r"[._,]", version)
+    if len(parts) < 2 or not parts[0].isdigit() or not parts[1].isdigit():
+        raise BuildRepoError(f"{pkg_name}: malformed major/minor version {version!r} — cannot compute line pin")
+    return f"{parts[0]}.{parts[1]}"
+
+
+def _line_pins(bucket: list[Path]) -> list[Path]:
+    """The newest package of every major/minor VERSION line in ``bucket``.
+
+    ``bucket`` is already channel-scoped by the caller, so pins never cross channels.
+    Line key = ``_line_key`` (fails closed on a malformed major/minor). Tie-break
+    within a line mirrors ``_retain_newest``: version order, then mtime, then name.
+    Returns newest-first, deterministic regardless of input order.
+    """
+    lines: dict[str, tuple[Path, tuple]] = {}
+    for p in bucket:
+        m = read_compact_manifest(p)
+        version: str = m.get("version", "")
+        name: str = m.get("name", "")
+        line = _line_key(version, name)
+        rank = (_pkg_version_key(version), p.stat().st_mtime, name)
+        if line not in lines or rank > lines[line][1]:
+            lines[line] = (p, rank)
+    return [p for p, _rank in sorted(lines.values(), key=lambda pr: pr[1], reverse=True)]
+
+
 def retain_by_channel(
     pkg_paths: list[Path],
     *,
     keep_devel: int,
     keep_stable: int,
 ) -> list[Path]:
-    """Bucket paths by package-name channel and keep the newest ``keep_*`` per channel.
+    """Bucket paths by package-name channel and keep the newest ``keep_*`` per channel,
+    PLUS the newest package of every major/minor line (the "line pin").
 
     Channel detection (by the package ``name`` field in each path's manifest):
       * name ending ``-devel``   → devel channel
-      * name ending ``-nightly`` → nightly channel (left untouched: not pruned here)
+      * name ending ``-nightly`` → nightly channel (left untouched: not pruned here,
+        no line pins either)
       * anything else            → stable channel
 
     Pruning rules (reuses ``_retain_newest`` for version-sorted ordering):
       * ``keep == 0`` → keep ALL of that channel (the "unbounded / disabled" sentinel).
       * ``keep >= len(bucket)`` → keep all (no-op).
-      * ``keep < len(bucket)`` → prune to the ``keep`` newest.
+      * ``keep < len(bucket)`` → prune to the ``keep`` newest, THEN union in each
+        major/minor line's newest package (``_line_pins``) that isn't already in that
+        window — e.g. an aged-out v3.2.15 stays available after newer lines push it
+        out of the rolling window. Pins are per-channel: a devel pin can never satisfy
+        stable or vice versa. A malformed version in a bucket that needs pruning raises
+        ``BuildRepoError`` (fail closed, never silently misbucketed or dropped).
 
     ``keep_devel`` / ``keep_stable`` must be ``>= 0``; a negative value is rejected (it would
     otherwise flow into ``_retain_newest``'s ``[:keep]`` slice and silently drop the newest
     builds — fail fast instead).
 
     Returns the kept paths in a deterministic stable order (devel first, then stable, then
-    nightly; within each bucket newest-first as returned by ``_retain_newest``).
+    nightly; within each bucket the window newest-first, then any line pins newest-first).
     """
     if keep_devel < 0 or keep_stable < 0:
         raise BuildRepoError(
@@ -489,9 +534,13 @@ def retain_by_channel(
 
     def _prune(bucket: list[Path], keep: int) -> list[Path]:
         if keep == 0 or keep >= len(bucket):
-            # keep==0 is the "unbounded" sentinel; keep>=len is a no-op.
+            # keep==0 is the "unbounded" sentinel; keep>=len is a no-op — nothing is
+            # pruned, so line pins are moot (everything already survives).
             return _retain_newest(bucket, len(bucket)) if bucket else []
-        return _retain_newest(bucket, keep)
+        window = _retain_newest(bucket, keep)
+        seen = set(window)
+        pins = [p for p in _line_pins(bucket) if p not in seen]
+        return window + pins
 
     kept_devel = _prune(devel, keep_devel)
     kept_stable = _prune(stable, keep_stable)

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -1681,6 +1681,43 @@ def test_retain_by_channel_line_pin_determinism(tmp_path: Path) -> None:
     assert len(kept1) == len(kept2) == 11
 
 
+def test_retain_by_channel_duplicate_identity_resolves_to_one_path(tmp_path: Path) -> None:
+    """A same-(name, version) duplicate pair (tied mtime) must resolve to the SAME
+    file for both the window (_retain_newest) and the line pin (_line_pins) —
+    the retained set holds one path for that identity, never two.
+
+    Regression guard: both helpers dedup on a first-wins tie-break (`>`, strict).
+    They agree only because they iterate the same bucket in the same order with
+    the same strictness. If _line_pins' tie-break ever flips to `>=`, it keeps the
+    LAST-processed file on a tie while _retain_newest (unchanged) keeps the FIRST —
+    two distinct files for one (name, version) then both reach _check_collisions
+    (which runs before _emit_catalog_from_paths' own dedup), aborting the build
+    with a false FLAVOR COLLISION whenever the duplicates happen to differ in
+    php/py flavor.
+
+    Scenario: one (name, version) identity, two files, tied mtime
+      Given two .pkg files for pfBlockerNG-devel 3.0.1 with identical mtime
+        And keep_devel=1 (keep < bucket size, so the window+line-pin union runs)
+      When retain_by_channel is called
+      Then exactly one path is retained for that identity
+       And it is the first-processed file (deterministic first-wins tie-break)
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    first = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.1")
+    duplicate = d / "pfBlockerNG-devel-3.0.1-dup.pkg"
+    make_pkg(duplicate, name="pfBlockerNG-devel", version="3.0.1", abi="FreeBSD:15:amd64")
+    # Force an exact tie: without it, the higher-mtime file would legitimately win
+    # in both helpers and the test would prove nothing about the tie-break itself.
+    tie_mtime = first.stat().st_mtime
+    os.utime(duplicate, (tie_mtime, tie_mtime))
+
+    kept = brp.retain_by_channel([first, duplicate], keep_devel=1, keep_stable=0)
+
+    assert len(kept) == 1, f"one (name, version) identity must resolve to one file, got {len(kept)}: {kept}"
+    assert kept[0] == first, "first-processed file must win the tie deterministically"
+
+
 # --------------------------------------------------------------------------- #
 # ADR-27 Phase 2: release-subtree retention in build_repo_matrix
 #
@@ -1821,7 +1858,10 @@ def test_release_catalog_lists_all_kept_versions(tmp_path: Path) -> None:
         And a fresh devel build (the stub produces version "1.0_1")
         And the newest extras are 3.0.3 (devel) and 2.0.3 (stable)
       When build_repo_matrix runs
-      Then the catalog has exactly 4 objects (2 devel + 2 stable)
+      Then the catalog has exactly 6 objects: 2-window + 1 line-pin devel, and
+        2-window + 1 line-pin stable (the stub's fresh build "1.0_1" is its own
+        major/minor line "1.0", distinct from the 3.0.x/2.0.x extras, so it
+        survives as that line's pin alongside the newest-2 window)
        And the highest-version devel object is at least 3.0.3
        And the highest-version stable object is at least 2.0.3
        And every kept (name, version) pair appears exactly once (no duplicates)
@@ -1902,18 +1942,24 @@ def _with_stub_builder(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(brp, "build_repo_matrix", _patched)
 
 
-def test_cli_release_extra_pkgs_default_is_latest_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_release_extra_pkgs_default_keeps_latest_plus_line_pins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """CLI defaults (--release-keep-devel 1, --release-keep-stable 1) keep only the
-    latest release when --release-extra-pkgs carry older versions too.
+    latest release PER CHANNEL WINDOW when --release-extra-pkgs carry older versions
+    too — plus any major/minor line pin outside that window (issue #1676).
 
     Scenario: CLI latest-only default with older extras supplied
       Given 3 pre-built devel extras (3.0.1, 3.0.2, 3.0.3) passed via --release-extra-pkgs
         And 3 pre-built stable extras (2.0.1, 2.0.2, 2.0.3) passed via --release-extra-pkgs
         And no --release-keep-devel / --release-keep-stable override (default 1)
       When brp.main([--build-matrix, ...]) is called
-      Then the release catalog has exactly 1 devel entry (before-state: default is latest-only)
-       And the release catalog has exactly 1 stable entry
-       And the highest-version devel (3.0.3) is the one retained
+      Then the release catalog has exactly 2 devel entries: the 1-window entry
+        plus the stub's own fresh build as a line pin (its version "1.0_1" is
+        major/minor line "1.0", distinct from the 3.0.x extras)
+       And the release catalog has exactly 1 stable entry (no --stable-tag on this
+        CLI path, so no fresh build and no phantom pin)
+       And the highest-version devel (3.0.3) is the one retained by the window
        And the highest-version stable (2.0.3) is the one retained
     """
     _with_stub_builder(monkeypatch)
@@ -1977,8 +2023,10 @@ def test_cli_release_extra_pkgs_keeps_newest_n(tmp_path: Path, monkeypatch: pyte
         And 4 pre-built stable extras (2.0.1..2.0.4) passed as --release-extra-pkgs
         And --release-keep-devel 3, --release-keep-stable 3
       When brp.main([--build-matrix, ...]) is called
-      Then the release catalog has exactly 3 devel entries (AFTER state: retention enabled)
-       And the release catalog has exactly 3 stable entries
+      Then the release catalog has exactly 4 devel entries: the 3-window plus
+        1 line pin (the stub's "1.0_1" fresh build, its own major/minor line)
+       And the release catalog has exactly 3 stable entries (no fresh build on
+        this CLI path, so a plain 3-window, no phantom pin)
        And the oldest devel (3.0.1) is absent from the catalog
        And the oldest stable (2.0.1) is absent from the catalog
        And the 3 newest devel versions (3.0.2, 3.0.3, 3.0.4) are present
@@ -2073,7 +2121,9 @@ def test_cli_release_extra_pkgs_newest_wins(tmp_path: Path, monkeypatch: pytest.
       Given 4 devel extras (3.0.1..3.0.4) and keep=2
         And 4 stable extras (2.0.1..2.0.4) and keep=2
       When brp.main([--build-matrix, ...]) is called
-      Then the catalog lists exactly 2 devel + 2 stable entries
+      Then the catalog lists exactly 3 devel entries (2-window + 1 line pin,
+        the stub's "1.0_1" fresh build on its own line) and 2 stable entries
+        (no fresh build on this CLI path, so a plain 2-window, no phantom pin)
        And the highest devel version in the catalog is >= 3.0.4 (newest-wins)
        And the highest stable version in the catalog is >= 2.0.4 (newest-wins)
        And no (name, version) pair is duplicated in the catalog

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -1473,6 +1473,215 @@ def test_retain_by_channel_rejects_negative_keep(tmp_path: Path, keep_devel: int
 
 
 # --------------------------------------------------------------------------- #
+# Issue #1676 slice 1: per-major/minor line-pin retention in retain_by_channel
+#
+# Spec (docs/specs/reversible-settings-transitions-v3-v4.md:189-192): each channel
+# retains its newest-N rolling window PLUS the newest package of every major/minor
+# LINE, so a version like v3.2.15 stays available after it ages out of the window.
+# These tests cover: the union of window + pins, per-channel isolation (a devel
+# pin can't satisfy stable), multi-patch lines (only the newest patch pins),
+# prerelease version ordering, the keep=0/nightly no-op paths, and the malformed
+# major/minor fail-closed guard.
+# --------------------------------------------------------------------------- #
+
+
+def test_retain_by_channel_line_pin_survives_outside_window(tmp_path: Path) -> None:
+    """A line's newest package pins even after it ages out of the newest-N window.
+
+    Scenario: one channel, 13 versions across 3 lines (3.0.x x2, 3.2.x x3, 4.0.x x8),
+    keep=10 — the newest-10 window is by GLOBAL version order across all lines, so
+    it covers all of 4.0.x (8) plus the 2 newest 3.2.x (3.2.15, 3.2.14).
+      Given stable pkgs: 3.0.1, 3.0.2, 3.2.13, 3.2.14, 3.2.15, 4.0.0..4.0.7 (13 total)
+        And keep_stable=10
+      When retain_by_channel is called
+      Then the newest-10 window keeps 4.0.0..4.0.7 (8) + 3.2.15 + 3.2.14 (2) = 10
+       And 3.2.13 (aged out, NOT the newest of its line) is pruned
+       And 3.0.2 (aged out, but IS the newest of the 3.0 line) survives as the pin
+       And 3.0.1 (aged out, not the line's newest) is pruned
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    versions = ["3.0.1", "3.0.2", "3.2.13", "3.2.14", "3.2.15"] + [f"4.0.{i}" for i in range(8)]
+    assert len(versions) == 13
+    paths = {v: _make_pkg_channel(d, "pfBlockerNG", v) for v in versions}
+
+    kept = brp.retain_by_channel(list(paths.values()), keep_devel=0, keep_stable=10)
+    kept_versions = {brp.read_compact_manifest(p)["version"] for p in kept}
+
+    # Window: newest 10 by global version order = 4.0.0..4.0.7, 3.2.15, 3.2.14.
+    for v in [f"4.0.{i}" for i in range(8)] + ["3.2.15", "3.2.14"]:
+        assert v in kept_versions, v
+    # 3.2.13 is aged out AND not its line's newest -> pruned.
+    assert "3.2.13" not in kept_versions
+    # 3.0.2 is aged out but IS its line's newest -> survives as the pin.
+    assert "3.0.2" in kept_versions
+    # 3.0.1 is aged out and not its line's newest -> pruned.
+    assert "3.0.1" not in kept_versions
+    assert len(kept_versions) == 11  # 10-window + 1 pin (3.2.15/3.2.14 already in window)
+
+
+def test_retain_by_channel_line_pin_is_channel_specific(tmp_path: Path) -> None:
+    """The spec's named case: v3.2.15 Stable and v3.2.16 Devel both pin, independently.
+
+    Scenario: Stable pfBlockerNG-3.2.15 and Devel pfBlockerNG-devel-3.2.16, both far
+    outside a keep=1 window built from many newer versions in each channel.
+      Given a Stable channel: 3.2.15 (old) + 5 newer 5.0.x releases; keep_stable=1
+        And a Devel channel: 3.2.16 (old) + 5 newer 5.0.x devel builds; keep_devel=1
+      When retain_by_channel is called
+      Then BOTH 3.2.15 (stable) and 3.2.16 (devel) survive as their channel's 3.2 pin
+       And neither channel's pin satisfies the other (no cross-channel leakage)
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    stable_old = _make_pkg_channel(d, "pfBlockerNG", "3.2.15")
+    stable_new = [_make_pkg_channel(d, "pfBlockerNG", f"5.0.{i}") for i in range(5)]
+    devel_old = _make_pkg_channel(d, "pfBlockerNG-devel", "3.2.16")
+    devel_new = [_make_pkg_channel(d, "pfBlockerNG-devel", f"5.0.{i}") for i in range(5)]
+
+    kept = brp.retain_by_channel([stable_old, *stable_new, devel_old, *devel_new], keep_devel=1, keep_stable=1)
+    kept_nv = {(brp.read_compact_manifest(p)["name"], brp.read_compact_manifest(p)["version"]) for p in kept}
+
+    assert ("pfBlockerNG", "3.2.15") in kept_nv
+    assert ("pfBlockerNG-devel", "3.2.16") in kept_nv
+    # Each channel's window (newest 1) plus its own 3.2 pin only — no cross bleed.
+    assert ("pfBlockerNG", "5.0.4") in kept_nv
+    assert ("pfBlockerNG-devel", "5.0.4") in kept_nv
+    assert len(kept_nv) == 4
+
+
+def test_retain_by_channel_line_pin_keeps_only_newest_patch(tmp_path: Path) -> None:
+    """Multiple aged-out patches in one line: only the newest patch pins; older follow the window.
+
+    Scenario: 3.2.13, 3.2.14, 3.2.15 all in one old line, plus enough 5.0.x to push
+    all three out of a keep=2 window.
+      Given stable pkgs 3.2.13, 3.2.14, 3.2.15, 5.0.0, 5.0.1; keep_stable=2
+      When retain_by_channel is called
+      Then the window keeps 5.0.1, 5.0.0
+       And ONLY 3.2.15 (the line's newest) pins
+       And 3.2.14 and 3.2.13 are pruned (rolling policy, not the line's newest)
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    p13 = _make_pkg_channel(d, "pfBlockerNG", "3.2.13")
+    p14 = _make_pkg_channel(d, "pfBlockerNG", "3.2.14")
+    p15 = _make_pkg_channel(d, "pfBlockerNG", "3.2.15")
+    p50_0 = _make_pkg_channel(d, "pfBlockerNG", "5.0.0")
+    p50_1 = _make_pkg_channel(d, "pfBlockerNG", "5.0.1")
+
+    kept = brp.retain_by_channel([p13, p14, p15, p50_0, p50_1], keep_devel=0, keep_stable=2)
+    kept_versions = {brp.read_compact_manifest(p)["version"] for p in kept}
+
+    assert kept_versions == {"5.0.1", "5.0.0", "3.2.15"}
+
+
+def test_retain_by_channel_line_pin_uses_pkg_version_order_for_prerelease(tmp_path: Path) -> None:
+    """The line pin picks the newest by pkg version order, not lexical order.
+
+    Scenario: an old 4.0 line with alpha.9 and alpha.10 (lexically "10" < "9"),
+    pushed out of the window by newer 5.0.x releases.
+      Given devel pkgs 4.0.0.alpha.9, 4.0.0.alpha.10, 5.0.0, 5.0.1; keep_devel=2
+      When retain_by_channel is called
+      Then the window keeps 5.0.1, 5.0.0
+       And the 4.0 pin is 4.0.0.alpha.10 (pkg version order), NOT alpha.9
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    a9 = _make_pkg_channel(d, "pfBlockerNG-devel", "4.0.0.alpha.9")
+    a10 = _make_pkg_channel(d, "pfBlockerNG-devel", "4.0.0.alpha.10")
+    n0 = _make_pkg_channel(d, "pfBlockerNG-devel", "5.0.0")
+    n1 = _make_pkg_channel(d, "pfBlockerNG-devel", "5.0.1")
+
+    kept = brp.retain_by_channel([a9, a10, n0, n1], keep_devel=2, keep_stable=0)
+    kept_versions = {brp.read_compact_manifest(p)["version"] for p in kept}
+
+    assert kept_versions == {"5.0.1", "5.0.0", "4.0.0.alpha.10"}
+    assert "4.0.0.alpha.9" not in kept_versions
+
+
+def test_retain_by_channel_keep_zero_sentinel_unaffected_by_line_pins(tmp_path: Path) -> None:
+    """keep==0 (unbounded) still keeps everything; line pins are moot (nothing pruned).
+
+    Extends the existing sentinel coverage: a multi-line pool under keep=0 must not
+    trip the malformed-version guard or drop anything — the pin path is never entered
+    because nothing is pruned.
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    all_paths = [_make_pkg_channel(d, "pfBlockerNG", v) for v in ["3.0.1", "3.2.15", "5.0.0", "5.0.1"]]
+
+    kept = brp.retain_by_channel(all_paths, keep_devel=0, keep_stable=0)
+
+    assert len(kept) == 4
+
+
+def test_retain_by_channel_nightly_never_gets_line_pins(tmp_path: Path) -> None:
+    """Nightly is passed through untouched — no line-pin logic applies to it at all.
+
+    A nightly VERSION (<target>.YYYYMMDD.N) has no major/minor line concept; if pin
+    logic ever leaked into the nightly path it would either misbucket (numeric date
+    treated as a line) or crash on the malformed-version guard. Assert nightly count
+    is exactly the input count, unchanged, even with a devel/stable prune alongside.
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    dv = _make_pkg_channel(d, "pfBlockerNG-devel", "3.0.1")
+    sv = _make_pkg_channel(d, "pfBlockerNG", "2.0.1")
+    nightlies = [_make_pkg_channel(d, "pfBlockerNG-nightly", f"amd64.2026060{i}.1") for i in range(1, 4)]
+
+    kept = brp.retain_by_channel([dv, sv, *nightlies], keep_devel=1, keep_stable=1)
+    kept_nightly_versions = {
+        brp.read_compact_manifest(p)["version"]
+        for p in kept
+        if brp.read_compact_manifest(p)["name"] == "pfBlockerNG-nightly"
+    }
+
+    assert kept_nightly_versions == {f"amd64.2026060{i}.1" for i in range(1, 4)}
+
+
+def test_retain_by_channel_malformed_line_version_raises(tmp_path: Path) -> None:
+    """A malformed major/minor version fails closed with BuildRepoError, never silent misbucketing.
+
+    ``_pkg_version_key``/``pkg_version_sort_key`` maps any non-numeric component to
+    ``0`` for SORT stability (never raises) — so a garbage version like "weird" would
+    otherwise silently land in some bucket rather than being rejected. The line-pin
+    parse is stricter: it must fail closed and name the offending package.
+
+    Scenario: a pool that needs pruning (so the line-pin path actually runs) contains
+    one package with an unparseable version.
+      Given stable pkgs 1.0.0, 2.0.0, 3.0.0 (valid) + "garbage-weird" (malformed); keep_stable=1
+      When retain_by_channel is called
+      Then BuildRepoError is raised, naming the malformed package
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    p1 = _make_pkg_channel(d, "pfBlockerNG", "1.0.0")
+    p2 = _make_pkg_channel(d, "pfBlockerNG", "2.0.0")
+    p3 = _make_pkg_channel(d, "pfBlockerNG", "3.0.0")
+    bad = _make_pkg_channel(d, "pfBlockerNG", "weird")
+
+    with pytest.raises(brp.BuildRepoError, match="weird"):
+        brp.retain_by_channel([p1, p2, p3, bad], keep_devel=0, keep_stable=1)
+
+
+def test_retain_by_channel_line_pin_determinism(tmp_path: Path) -> None:
+    """Two runs over the same multi-line pool produce byte-identical (path-set) results.
+
+    Extends the existing version-order-determinism coverage to the line-pin path:
+    the pin selection must not depend on dict/set iteration order.
+    """
+    d = tmp_path / "pkgs"
+    d.mkdir()
+    versions = ["3.0.1", "3.0.2", "3.2.13", "3.2.14", "3.2.15"] + [f"4.0.{i}" for i in range(8)]
+    paths = [_make_pkg_channel(d, "pfBlockerNG", v) for v in versions]
+
+    kept1 = brp.retain_by_channel(list(paths), keep_devel=0, keep_stable=10)
+    kept2 = brp.retain_by_channel(list(reversed(paths)), keep_devel=0, keep_stable=10)
+
+    assert {p.name for p in kept1} == {p.name for p in kept2}
+    assert len(kept1) == len(kept2) == 11
+
+
+# --------------------------------------------------------------------------- #
 # ADR-27 Phase 2: release-subtree retention in build_repo_matrix
 #
 # These tests pin the retention behaviour of the release subtree:
@@ -1571,7 +1780,10 @@ def test_release_subtree_retains_devel_and_stable(tmp_path: Path) -> None:
     )
     rel_before = out_before / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
     objs_before = _catalog_objects(rel_before)
-    assert len(objs_before) == 2  # 1 devel + 1 stable with keep=1
+    # 1 window + 1 line pin per channel: the stub's fresh build is version "1.0_1",
+    # a major/minor line ("1.0") distinct from the 3.0.x/2.0.x extras, so it survives
+    # as that line's pin even though the 3.0.x/2.0.x window doesn't include it.
+    assert len(objs_before) == 4  # (1 window + 1 pin) devel + (1 window + 1 pin) stable
 
     # After-state: with keep=3, the newest 3 of each channel are retained.
     out = tmp_path / "site"
@@ -1636,13 +1848,16 @@ def test_release_catalog_lists_all_kept_versions(tmp_path: Path) -> None:
     rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
     objs = _catalog_objects(rel)
 
-    # Exactly 4 catalog entries: 2 devel + 2 stable.
-    assert len(objs) == 4
+    # 6 catalog entries: (2-window + 1 line-pin) devel + (2-window + 1 line-pin) stable.
+    # The stub's fresh build ("1.0_1") is its own major/minor line ("1.0"), distinct
+    # from the 3.0.x/2.0.x extras, so it survives as that line's pin alongside the
+    # newest-2 window.
+    assert len(objs) == 6
 
     devel_objs = [o for o in objs if o["name"] == "pfBlockerNG-devel"]
     stable_objs = [o for o in objs if o["name"] == "pfBlockerNG"]
-    assert len(devel_objs) == 2
-    assert len(stable_objs) == 2
+    assert len(devel_objs) == 3
+    assert len(stable_objs) == 3
 
     # No duplicate (name, version) pairs.
     nv_list = [(o["name"], o["version"]) for o in objs]
@@ -1741,12 +1956,16 @@ def test_cli_release_extra_pkgs_default_is_latest_only(tmp_path: Path, monkeypat
     devel_objs = [o for o in objs if o["name"] == "pfBlockerNG-devel"]
     stable_objs = [o for o in objs if o["name"] == "pfBlockerNG"]
 
-    # Before-state (default keep=1): exactly one devel entry, one stable entry.
-    assert len(devel_objs) == 1, f"expected 1 devel, got {len(devel_objs)}"
+    # Before-state (default keep=1): devel gets the 1-window entry PLUS the stub's own
+    # fresh build as a line pin ("1.0_1" is major/minor line "1.0", distinct from the
+    # 3.0.x extras). No --stable-tag is passed on this CLI path, so no stable build is
+    # produced — stable stays a plain 1-window result (no phantom pin).
+    assert len(devel_objs) == 2, f"expected 2 devel (window + line pin), got {len(devel_objs)}"
     assert len(stable_objs) == 1, f"expected 1 stable, got {len(stable_objs)}"
 
-    # The retained entries are the highest-version ones (newest-wins).
-    assert devel_objs[0]["version"] >= "3.0.3"
+    # The window's retained entry is the highest-version one (newest-wins).
+    devel_versions = {o["version"] for o in devel_objs}
+    assert "3.0.3" in devel_versions
     assert stable_objs[0]["version"] >= "2.0.3"
 
 
@@ -1799,7 +2018,10 @@ def test_cli_release_extra_pkgs_keeps_newest_n(tmp_path: Path, monkeypatch: pyte
     before_objs = _catalog_objects(out_before / "release" / "ce-2.8" / "amd64" / "packagesite.pkg")
     before_devel = [o for o in before_objs if o["name"] == "pfBlockerNG-devel"]
     before_stable = [o for o in before_objs if o["name"] == "pfBlockerNG"]
-    assert len(before_devel) == 1, "before-state: default keep=1 must yield exactly 1 devel"
+    # No --stable-tag on this CLI path, so only devel gets a fresh build: default
+    # keep=1 window + the stub fresh build's own line pin ("1.0_1" is line "1.0",
+    # distinct from the 3.0.x extras). Stable has no fresh build, so no phantom pin.
+    assert len(before_devel) == 2, "before-state: default keep=1 must yield 1 window + 1 line pin devel"
     assert len(before_stable) == 1, "before-state: default keep=1 must yield exactly 1 stable"
 
     # After-state: with keep=3 the catalog lists 3 devel + 3 stable.
@@ -1828,8 +2050,9 @@ def test_cli_release_extra_pkgs_keeps_newest_n(tmp_path: Path, monkeypatch: pyte
     devel_objs = [o for o in objs if o["name"] == "pfBlockerNG-devel"]
     stable_objs = [o for o in objs if o["name"] == "pfBlockerNG"]
 
-    # After-state: 3 devel + 3 stable.
-    assert len(devel_objs) == 3, f"expected 3 devel after, got {len(devel_objs)}"
+    # After-state: devel = 3-window + 1 line pin (the stub's "1.0_1" fresh build) = 4;
+    # stable has no fresh build on this CLI path, so it's a plain 3-window = 3.
+    assert len(devel_objs) == 4, f"expected 4 devel after (window + line pin), got {len(devel_objs)}"
     assert len(stable_objs) == 3, f"expected 3 stable after, got {len(stable_objs)}"
 
     # Oldest excluded.
@@ -1893,8 +2116,9 @@ def test_cli_release_extra_pkgs_newest_wins(tmp_path: Path, monkeypatch: pytest.
     devel_objs = [o for o in objs if o["name"] == "pfBlockerNG-devel"]
     stable_objs = [o for o in objs if o["name"] == "pfBlockerNG"]
 
-    # Exactly 2 devel + 2 stable.
-    assert len(devel_objs) == 2
+    # devel = 2-window + 1 line pin (the stub's "1.0_1" fresh build, its own line "1.0") = 3.
+    # No --stable-tag on this CLI path, so stable has no fresh build: plain 2-window.
+    assert len(devel_objs) == 3
     assert len(stable_objs) == 2
 
     # No duplicate (name, version) pairs.


### PR DESCRIPTION
First slice of #1676. Implements the per-major/minor **line-pin retention** rule; the frozen-package build, route-only curation, and publication phases are later slices on this ticket.

Refs #1676.

## What

`docs/specs/reversible-settings-transitions-v3-v4.md:189-192` requires each normal catalog to retain "the newest 10 Stable and newest 10 Devel releases, **plus the newest package from every pfBlockerNG major/minor line for each package channel**" — the per-line pins are what keep `v3.2.15` Stable and `v3.2.16` Devel reachable after they age out of the rolling windows. The rolling windows already existed; the line pins did not.

## How

The union happens inside `retain_by_channel()`, so both catalog modes (consume and source-build) inherit it with no call-site edits. Line key is the first two numeric components split on the same `[._,]` separator set `pkg_version_sort_key` uses — deliberately not a bare `.` split, because the existing fixture version `1.0_1` (port-revision syntax) would otherwise trip the malformed guard. Pins are computed per channel bucket, so a devel pin can never satisfy or evict a stable one; nightly is untouched; the `keep == 0` unbounded sentinel short-circuits before pins are considered; and a version whose major/minor cannot parse raises `BuildRepoError` naming the package rather than being silently misbucketed.

## Evidence

Red-first: 6 of 8 new rows failed against the untouched generator (the other 2 legitimately pass pre-change — they assert "nothing is pruned" on paths the pin logic never reaches). Independently verifier-gated, including a scratch-weaken probe confirming the malformed-version guard is the only thing standing between a garbage version and silent misbucketing (`pkg_version_sort_key` maps non-numeric components to `0` and never raises).

Five pre-existing retention tests needed count updates, and the verifier specifically scrutinised them for weakening: each still asserts real pruning (oldest dropped, newest kept) and the changed numbers are the pin-inclusive counts caused by the shared fixture's `1.0_1` build being a genuinely distinct line. One assertion moved from an index check to a membership check because the channel now legitimately holds two objects — a tightening, not a loosening.

Note for whoever consumes this — corrected after the second review pass fetched the actual consumer. `pfBlockerNG/pkg`'s `publish.yml` downloads only two tags (newest non-prerelease + newest prerelease), emits `--release-pkgs` for those assets, and passes **no** `--release-keep-devel`/`--release-keep-stable`/`--release-extra-pkgs`. Each per-channel bucket therefore has length 1, `keep` defaults to 1, and the `keep >= len(bucket)` short-circuit means **the pin path is never entered in production today** — measured blast radius on the real BUILD matrix is 6 packages across 3 routes, exactly as before this change.

So the thing the pkg-repo maintainer actually needs is not a size warning but a wiring precondition: `publish.yml` must enumerate more Releases and pass the keep flags before any of this activates. That is in scope for #1676's later slices. Once wired, the ceiling is small and bounded — GitHub Releases hold exactly two major/minor lines (3.2 and 4.0), so pins add at most one stable and one devel per leaf, roughly 11 MiB across all three routes.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

