### PR TITLE
ci(smoke): fail a leg whose shards collectively selected no tests

### DIFF
--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -614,6 +614,25 @@ jobs:
           mkdir -p smoke-diag
           sh scripts/run-smoke.sh "$@" 2>&1 | tee smoke-diag/pytest-durations.log
 
+      # issue #1767: a tiny per-shard marker recording whether THIS shard's
+      # slice selected any tests ('selected') or hit the #855 empty-partition
+      # tolerance ('empty') -- scripts/run-smoke.sh writes it only for sharded
+      # (shard_total > 1) invocations, so a single-shard leg (shard_total=1)
+      # produces no file here and this step no-ops (if-no-files-found: ignore).
+      # smoke.yml's all-smoke-passed job downloads every shard's marker and
+      # fails the LEG unless at least one says 'selected' -- the per-shard
+      # #855 tolerance stays, but a whole-leg zero-selection (every shard
+      # empty -- a marker typo or collection bug) no longer silently passes
+      # the release gate (#1662).
+      - name: Upload shard selection-status marker (leg-level empty-selection gate, issue #1767)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-shard-status-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}
+          path: smoke-diag/shard-selection-status
+          if-no-files-found: ignore
+          retention-days: 1
+
       # ADR-24 / ADR-47 P5: runner-side scrub delegated to the shared script.
       # resolve-legs.sh scrub --root smoke-diag handles: non-CE screenshot deletion,
       # literal-redaction of RESOLVED_REDACT values, and CE no-op (empty RESOLVED_REDACT).

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -356,12 +356,13 @@ jobs:
       # issue #1767: download every shard's selection-status marker (see
       # smoke-single.yml's "Upload shard selection-status marker" step) so the
       # assert step below can catch a whole-leg zero-selection that the
-      # per-shard #855 tolerance would otherwise hide. continue-on-error: a run
-      # with NO multi-shard leg (every leg collapsed to shard_total=1) uploads
-      # no marker at all, so the pattern then matches nothing -- the assert
-      # step below fails CLOSED on any multi-shard leg it expected a marker
-      # for but can't find, so a genuine download outage still fails the leg
-      # rather than silently skipping the check.
+      # per-shard #855 tolerance would otherwise hide. continue-on-error:
+      # actions/download-artifact tolerates a zero-match `pattern` on its own
+      # (0 artifacts, exit 0) -- this guards a genuine transient download
+      # failure instead, so an empty shard-status/ tree (marker never
+      # uploaded, or the download itself broke) still reaches the assert step
+      # below, which fails CLOSED on any multi-shard leg it expected a marker
+      # for but can't find.
       - name: Download per-shard selection-status markers
         if: needs.smoke.result == 'success'
         continue-on-error: true

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -353,10 +353,29 @@ jobs:
     needs: [prepare, smoke]
     if: always()   # run even if smoke failed/skipped/cancelled
     steps:
+      # issue #1767: download every shard's selection-status marker (see
+      # smoke-single.yml's "Upload shard selection-status marker" step) so the
+      # assert step below can catch a whole-leg zero-selection that the
+      # per-shard #855 tolerance would otherwise hide. continue-on-error: a run
+      # with NO multi-shard leg (every leg collapsed to shard_total=1) uploads
+      # no marker at all, so the pattern then matches nothing -- the assert
+      # step below fails CLOSED on any multi-shard leg it expected a marker
+      # for but can't find, so a genuine download outage still fails the leg
+      # rather than silently skipping the check.
+      - name: Download per-shard selection-status markers
+        if: needs.smoke.result == 'success'
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: smoke-shard-status-*
+          path: shard-status
+
       - name: Assert every smoke leg passed
         env:
           SMOKE_RESULT: ${{ needs.smoke.result }}
           LEG_COUNT: ${{ needs.prepare.outputs.leg_count }}
+          CI_MATRIX: ${{ needs.prepare.outputs.ci_matrix }}
+          PYTEST_FILTER: ${{ needs.prepare.outputs.pytest_filter }}
         run: |
           set -eu
           echo "Smoke matrix result : ${SMOKE_RESULT}"
@@ -377,6 +396,54 @@ jobs:
           # 'cancelled' = run was cancelled (masks potential failures).
           case "$SMOKE_RESULT" in
             success)
+              # issue #1767: the per-shard exit-5 tolerance (#855) means a shard
+              # whose module slice legitimately carries no marker-matching test
+              # still reports 'success' even though it ran nothing — so the
+              # shard-level AND gate above can't see a whole-LEG zero-selection
+              # bug (marker typo, collection bug, path-filter regression) that
+              # empties EVERY shard of a full, unfiltered run. Assert, per
+              # multi-shard leg (shard_total != "1"), that at least ONE of its
+              # shards actually selected a test. PYTEST_FILTER non-empty means
+              # the caller deliberately narrowed the run (mirrors ui-tests.yml's
+              # PR #1766 selective exemption) — a selective run that legitimately
+              # selects nothing anywhere stays tolerated.
+              if [ -z "${PYTEST_FILTER:-}" ] && [ -n "${CI_MATRIX:-}" ]; then
+                MULTI_SHARD_LEGS="$(printf '%s\n' "$CI_MATRIX" | jq -c '
+                    [.[] | select(.shard_total != "1")]
+                    | group_by(.image_name + "|" + .pfsense_version)
+                    | map({
+                        image_name: .[0].image_name,
+                        pfsense_version: .[0].pfsense_version,
+                        shard_total: (.[0].shard_total | tonumber)
+                      })
+                ')"
+                LEG_N="$(printf '%s' "$MULTI_SHARD_LEGS" | jq 'length')"
+                BAD_LEGS=""
+                _i=0
+                while [ "$_i" -lt "$LEG_N" ]; do
+                    IMG="$(printf '%s' "$MULTI_SHARD_LEGS" | jq -r ".[$_i].image_name")"
+                    VER="$(printf '%s' "$MULTI_SHARD_LEGS" | jq -r ".[$_i].pfsense_version")"
+                    STOT="$(printf '%s' "$MULTI_SHARD_LEGS" | jq -r ".[$_i].shard_total")"
+                    FOUND_SELECTED=0
+                    _s=0
+                    while [ "$_s" -lt "$STOT" ]; do
+                        STATUS_FILE="shard-status/smoke-shard-status-${IMG}-${VER}-s${_s}/shard-selection-status"
+                        if [ -f "$STATUS_FILE" ] && [ "$(cat "$STATUS_FILE")" = "selected" ]; then
+                            FOUND_SELECTED=1
+                            break
+                        fi
+                        _s=$((_s + 1))
+                    done
+                    if [ "$FOUND_SELECTED" -eq 0 ]; then
+                        BAD_LEGS="${BAD_LEGS} ${IMG}-${VER}"
+                    fi
+                    _i=$((_i + 1))
+                done
+                if [ -n "$BAD_LEGS" ]; then
+                    echo "::error::AND gate FAIL — leg(s) selected ZERO tests across every shard (the #855 per-shard empty-partition tolerance masked a whole-leg zero-selection):${BAD_LEGS}"
+                    exit 1
+                fi
+              fi
               echo "AND gate PASS — all ${LEG_COUNT} smoke leg(s) succeeded."
               ;;
             failure)

--- a/scripts/run-smoke.sh
+++ b/scripts/run-smoke.sh
@@ -46,7 +46,12 @@
 #     error, never a silent pick); the splitter's own errors (e.g. an empty slice)
 #     propagate as-is under `set -eu`. When N>1, pytest exit 5 ("no tests ran") is
 #     mapped to 0 — a shard whose slice carries no test matching the marker is a
-#     partition artifact, not a failure; unsharded runs keep exit 5 fatal.
+#     partition artifact, not a failure; unsharded runs keep exit 5 fatal. Every
+#     sharded invocation also records its outcome ('empty' | 'selected') to
+#     $PFB_DIAG_DIR/shard-selection-status (issue #1767) — the per-shard tolerance
+#     above can't see a whole-LEG zero-selection (every shard's slice empty, a real
+#     collection bug), so smoke.yml's all-smoke-passed job sums this marker across
+#     a leg's shards and fails the leg unless at least one says 'selected'.
 #
 # Env passthrough: RUN_ID / PFB_DIAG_DIR / SMOKE_LANE reach pytest by inheritance (no
 #   explicit forwarding needed — subprocess env-inherit covers it).
@@ -279,14 +284,26 @@ fi
 # run), so an empty shard is a benign no-op. Only exit 5 is mapped; every other
 # non-zero rc stays fatal. Unsharded runs keep the exec (byte-identical path)
 # where exit 5 still fails loudly — there it means a genuinely wrong invocation.
+#
+# issue #1767: the per-shard tolerance above is invisible to whatever runs the
+# OTHER shards of this same leg — a marker typo or collection bug that empties
+# EVERY shard would report each one "empty, success" with nothing left to catch
+# the leg-wide zero-selection. Record this shard's outcome to a one-word file in
+# $PFB_DIAG_DIR so a LEG-LEVEL check (smoke.yml's all-smoke-passed, summing this
+# marker across a leg's shards) can still see it. A single-shard leg (below)
+# writes nothing — it needs none: its own exit 5 already propagates raw and
+# fails the leg directly.
 if [ "$_SHARD_TOTAL" -gt 1 ]; then
     _rc=0
     "$PYTHON" -m pytest "$@" || _rc=$?
+    mkdir -p "$PFB_DIAG_DIR"
     if [ "$_rc" -eq 5 ]; then
         printf 'run-smoke: shard %s/%s selected no tests for this marker — empty slice is a partition artifact, treating as pass\n' \
             "$_SHARD" "$_SHARD_TOTAL" >&2
+        printf 'empty\n' > "$PFB_DIAG_DIR/shard-selection-status"
         exit 0
     fi
+    printf 'selected\n' > "$PFB_DIAG_DIR/shard-selection-status"
     exit "$_rc"
 fi
 

--- a/tests/shell/run_smoke_spec.sh
+++ b/tests/shell/run_smoke_spec.sh
@@ -27,6 +27,10 @@ Describe 'run-smoke.sh'
     ARGV_FILE="${WORK}/argv"
     FAKE_BIN="${WORK}/bin"
     mkdir -p "$FAKE_BIN"
+    # Localize the diagnostics dir into the per-test tmpdir (issue #1767's
+    # shard-selection-status marker below lands here) -- never the real repo
+    # cwd, which the default "smoke-diag" would otherwise litter.
+    PFB_DIAG_DIR="${WORK}/smoke-diag"
 
     # Fake python: records its argv (one arg per line) to $ARGV_FILE.
     # run-smoke.sh calls: exec $PYTHON -m pytest <args>; the fake captures them.
@@ -45,7 +49,7 @@ PY3EOF
 
     # Prepend fake bin so run-smoke.sh's python3 fallback hits our stub.
     PATH="${FAKE_BIN}:${PATH}"
-    export PATH ARGV_FILE WORK FAKE_BIN
+    export PATH ARGV_FILE WORK FAKE_BIN PFB_DIAG_DIR
   }
 
   teardown() {
@@ -441,6 +445,14 @@ VENVEOF
   #
   # RED→GREEN: before run-smoke.sh mapped rc 5 under N>1, the first example
   # failed (run-smoke propagated 5); after the mapping it passes.
+  #
+  # issue #1767: every sharded invocation ALSO records its selection outcome
+  # ('empty' | 'selected') to $PFB_DIAG_DIR/shard-selection-status -- the
+  # per-shard signal a LEG-LEVEL check (smoke.yml's all-smoke-passed) sums
+  # across a leg's shards, so a whole-leg zero-selection (every shard empty)
+  # can no longer hide behind this per-shard tolerance. RED→GREEN: before the
+  # write existed, the file was never created; the content assertions below
+  # failed (file absent). After: the file exists with the right content.
   make_rc_fake() {
     # Fake python exiting with $1 after recording argv — drives the rc mapping.
     cat > "${FAKE_BIN}/python-rc" << RCEOF
@@ -463,6 +475,7 @@ RCEOF
       The status should be success
       The stderr should include 'partition artifact'
       The path "$ARGV_FILE" should be exist
+      The contents of file "${PFB_DIAG_DIR}/shard-selection-status" should equal 'empty'
     End
   End
 
@@ -476,6 +489,21 @@ RCEOF
     It 'stays fatal -- only exit 5 is mapped, never a genuine failure'
       When run run_sharded_pytest_exit1
       The status should equal 1
+      The contents of file "${PFB_DIAG_DIR}/shard-selection-status" should equal 'selected'
+    End
+  End
+
+  run_sharded_pytest_exit0() {
+    make_shard_fixture
+    make_rc_fake 0
+    PYTHON="${FAKE_BIN}/python-rc" sh "$SCRIPT" --paths "${WORK}/mods" --shard 0 --shard-total 2
+  }
+
+  Describe 'sharded run whose slice selects and passes tests (pytest exit 0)'
+    It 'records the shard as having selected tests'
+      When run run_sharded_pytest_exit0
+      The status should be success
+      The contents of file "${PFB_DIAG_DIR}/shard-selection-status" should equal 'selected'
     End
   End
 
@@ -489,6 +517,10 @@ RCEOF
     It 'keeps exit 5 fatal -- zero-selected without sharding means a wrong invocation'
       When run run_unsharded_pytest_exit5
       The status should equal 5
+      # issue #1767: a single-shard leg needs no shard-selection-status marker --
+      # its own exit 5 already propagates raw (asserted above) and fails the leg
+      # directly; only the sharded branch above writes the marker.
+      The path "${PFB_DIAG_DIR}/shard-selection-status" should not be exist
     End
   End
 

--- a/tests/test_smoke_leg_zero_selection_gate.py
+++ b/tests/test_smoke_leg_zero_selection_gate.py
@@ -1,0 +1,287 @@
+"""Pin issue #1767: a whole-leg zero-selection must fail the release gate.
+
+scripts/run-smoke.sh (~:274-291) maps pytest exit 5 ("no tests collected") to 0
+PER SHARD whenever shard_total > 1 (issue #855's legitimate empty-partition
+tolerance). The release qualification added by #1662 runs full smoke at 3
+shards per leg, so a pathological whole-leg zero-selection (marker typo,
+collection bug, path-filter regression) would report every shard "empty,
+success" and the fail-closed `all-smoke-passed` aggregate would pass a leg
+that executed nothing.
+
+The fix is a LEG-level assertion, layered on top of (never replacing) the
+per-shard tolerance:
+  - scripts/run-smoke.sh's sharded branch now also records the shard's outcome
+    ('empty' | 'selected') to $PFB_DIAG_DIR/shard-selection-status (pinned by
+    tests/shell/run_smoke_spec.sh -- the shellspec suite for this script).
+  - smoke-single.yml uploads that one-word file as a tiny per-shard artifact.
+  - smoke.yml's all-smoke-passed job downloads every shard's marker and fails
+    a multi-shard leg unless AT LEAST ONE of its shards says 'selected' -- a
+    caller-set pytest_filter (a deliberately selective run, mirroring
+    ui-tests.yml's PR #1766 exemption) exempts the whole check.
+
+This file lifts the real `run:` bodies out of the workflow YAML (the repo's
+established technique -- see tests/test_ui_release_gate_wiring.py) and
+executes them under sh with a fabricated CI_MATRIX + downloaded-artifact tree,
+so the truth table below runs the ACTUAL gate logic, not a re-description of it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SMOKE_WORKFLOW = ROOT / ".github/workflows/smoke.yml"
+SMOKE_SINGLE_WORKFLOW = ROOT / ".github/workflows/smoke-single.yml"
+
+_JOB_HEADER_RE = re.compile(r"^  ([A-Za-z][A-Za-z0-9_-]*):[ \t]*$")
+_STEP_HEADER_RE = re.compile(r"^      - ")
+
+
+def _jobs_section_lines(workflow_text: str) -> list[str]:
+    lines = workflow_text.splitlines()
+    start = lines.index("jobs:") + 1
+    return lines[start:]
+
+
+def _split_into_jobs(lines: list[str]) -> dict[str, list[str]]:
+    jobs: dict[str, list[str]] = {}
+    current: str | None = None
+    buffer: list[str] = []
+    for line in lines:
+        match = _JOB_HEADER_RE.match(line)
+        if match is not None:
+            if current is not None:
+                jobs[current] = buffer
+            current = match.group(1)
+            buffer = []
+        elif current is not None:
+            buffer.append(line)
+    if current is not None:
+        jobs[current] = buffer
+    return jobs
+
+
+def _split_into_steps(job_lines: list[str]) -> list[list[str]]:
+    steps: list[list[str]] = []
+    for line in job_lines:
+        if _STEP_HEADER_RE.match(line):
+            steps.append([])
+        if steps:
+            steps[-1].append(line)
+    return steps
+
+
+def _jobs(workflow: Path) -> dict[str, list[str]]:
+    return _split_into_jobs(_jobs_section_lines(workflow.read_text(encoding="utf-8")))
+
+
+def _step_run_script(step_lines: list[str]) -> str:
+    """Verbatim `run: |` body of a single step, dedented (the repo's established
+    lift-verbatim-and-run-under-sh technique)."""
+    text = "\n".join(step_lines)
+    marker = "run: |\n"
+    idx = text.index(marker) + len(marker)
+    return textwrap.dedent(text[idx:])
+
+
+# --------------------------------------------------------------------------- #
+# Structural: smoke-single.yml uploads the per-shard marker
+# --------------------------------------------------------------------------- #
+
+
+def _shard_status_upload_step() -> list[str]:
+    jobs = _jobs(SMOKE_SINGLE_WORKFLOW)
+    steps = _split_into_steps(jobs["smoke"])
+    target = [s for s in steps if any("shard-selection-status" in line for line in s)]
+    assert len(target) == 1, "expected exactly one step referencing shard-selection-status"
+    return target[0]
+
+
+def test_smoke_single_uploads_shard_selection_status_marker() -> None:
+    step_text = "\n".join(_shard_status_upload_step())
+    assert "uses: actions/upload-artifact@v7" in step_text, step_text
+    assert re.search(r"if:\s*always\(\)", step_text), f"upload must run unconditionally, got:\n{step_text}"
+    name_line = next(line for line in _shard_status_upload_step() if line.strip().startswith("name:"))
+    assert "inputs.image_name" in name_line and "inputs.pfsense_version" in name_line and "inputs.shard" in name_line, (
+        f"marker artifact name must be keyed on image_name/pfsense_version/shard, got: {name_line}"
+    )
+    path_line = next(line for line in _shard_status_upload_step() if line.strip().startswith("path:"))
+    assert "smoke-diag/shard-selection-status" in path_line, path_line
+    assert "if-no-files-found: ignore" in step_text, (
+        f"a single-shard leg (or a shard that never reaches the sharded branch) writes no marker -- "
+        f"the upload must tolerate that, got:\n{step_text}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Structural: all-smoke-passed downloads the per-shard markers
+# --------------------------------------------------------------------------- #
+
+
+def _download_markers_step() -> list[str]:
+    jobs = _jobs(SMOKE_WORKFLOW)
+    steps = _split_into_steps(jobs["all-smoke-passed"])
+    target = [s for s in steps if any("actions/download-artifact" in line for line in s)]
+    assert len(target) == 1, "expected exactly one download-artifact step in all-smoke-passed"
+    return target[0]
+
+
+def test_all_smoke_passed_downloads_shard_status_markers() -> None:
+    step_text = "\n".join(_download_markers_step())
+    assert "pattern: smoke-shard-status-*" in step_text, step_text
+    assert "continue-on-error: true" in step_text, (
+        f"a run with no multi-shard leg uploads no marker at all -- the pattern then matches nothing, "
+        f"which must not hard-fail the job, got:\n{step_text}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The leg-level assert script: lifted verbatim, run under sh, truth table
+# --------------------------------------------------------------------------- #
+
+
+def _assert_script() -> str:
+    jobs = _jobs(SMOKE_WORKFLOW)
+    steps = _split_into_steps(jobs["all-smoke-passed"])
+    target = [s for s in steps if any("Assert every smoke leg passed" in line for line in s)]
+    assert len(target) == 1, "expected exactly one 'Assert every smoke leg passed' step"
+    return _step_run_script(target[0])
+
+
+def _write_shard_status(tmp_path: Path, image_name: str, pfsense_version: str, shard: str, content: str | None) -> None:
+    """content=None -> the artifact/marker is simply absent (simulates a shard that
+    genuinely selected tests -- no marker uploaded -- OR a download failure)."""
+    if content is None:
+        return
+    d = tmp_path / "shard-status" / f"smoke-shard-status-{image_name}-{pfsense_version}-s{shard}"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "shard-selection-status").write_text(content)
+
+
+def _run_assert(
+    tmp_path: Path,
+    *,
+    smoke_result: str,
+    leg_count: str,
+    ci_matrix: list[dict[str, str]],
+    pytest_filter: str,
+) -> subprocess.CompletedProcess[str]:
+    script = _assert_script()
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "SMOKE_RESULT": smoke_result,
+        "LEG_COUNT": leg_count,
+        "CI_MATRIX": json.dumps(ci_matrix),
+        "PYTEST_FILTER": pytest_filter,
+    }
+    return subprocess.run(  # noqa: S603
+        ["sh", "-c", script],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _three_shard_ce_matrix() -> list[dict[str, str]]:
+    return [
+        {"image_name": "pfsense-ce", "pfsense_version": "2.8", "shard": str(i), "shard_total": "3"} for i in range(3)
+    ]
+
+
+# ── Required coverage row 1: every shard of a full-scope 3-shard leg is empty ─ #
+
+
+def test_leg_fails_when_every_shard_of_a_full_scope_leg_is_empty(tmp_path: Path) -> None:
+    for i in range(3):
+        _write_shard_status(tmp_path, "pfsense-ce", "2.8", str(i), "empty")
+    completed = _run_assert(
+        tmp_path, smoke_result="success", leg_count="3", ci_matrix=_three_shard_ce_matrix(), pytest_filter=""
+    )
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+    assert "pfsense-ce-2.8" in (completed.stdout + completed.stderr)
+
+
+# ── Required coverage row 2: #855's legitimate single-empty-shard, pinned ───── #
+
+
+def test_leg_passes_when_one_shard_is_empty_and_others_selected(tmp_path: Path) -> None:
+    _write_shard_status(tmp_path, "pfsense-ce", "2.8", "0", "empty")
+    _write_shard_status(tmp_path, "pfsense-ce", "2.8", "1", "selected")
+    _write_shard_status(tmp_path, "pfsense-ce", "2.8", "2", "empty")
+    completed = _run_assert(
+        tmp_path, smoke_result="success", leg_count="3", ci_matrix=_three_shard_ce_matrix(), pytest_filter=""
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+# ── Required coverage row 3: a selective (filtered) run stays tolerated ─────── #
+
+
+def test_selective_invocation_with_every_shard_empty_is_tolerated(tmp_path: Path) -> None:
+    for i in range(3):
+        _write_shard_status(tmp_path, "pfsense-ce", "2.8", str(i), "empty")
+    completed = _run_assert(
+        tmp_path,
+        smoke_result="success",
+        leg_count="3",
+        ci_matrix=_three_shard_ce_matrix(),
+        pytest_filter="test_something_specific",
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+# ── Required coverage row 4: a missing/unreadable marker fails CLOSED ───────── #
+
+
+def test_all_markers_missing_fails_closed(tmp_path: Path) -> None:
+    """No shard-status/ directory at all (e.g. the download step's continue-on-error
+    swallowed a genuine outage) must not be silently read as 'nothing to check' --
+    a full-scope multi-shard leg with zero PROOF of a real selection stays a failure."""
+    completed = _run_assert(
+        tmp_path, smoke_result="success", leg_count="3", ci_matrix=_three_shard_ce_matrix(), pytest_filter=""
+    )
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+
+
+def test_one_missing_marker_among_otherwise_empty_shards_fails_closed(tmp_path: Path) -> None:
+    _write_shard_status(tmp_path, "pfsense-ce", "2.8", "0", None)  # missing
+    _write_shard_status(tmp_path, "pfsense-ce", "2.8", "1", "empty")
+    _write_shard_status(tmp_path, "pfsense-ce", "2.8", "2", "empty")
+    completed = _run_assert(
+        tmp_path, smoke_result="success", leg_count="3", ci_matrix=_three_shard_ce_matrix(), pytest_filter=""
+    )
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+
+
+# ── Single-shard legs are untouched by this check (already handled by the raw
+#    exit-5 propagation -- SMOKE_RESULT would already be 'failure' there) ──── #
+
+
+def test_single_shard_legs_are_not_touched_by_the_new_check(tmp_path: Path) -> None:
+    matrix = [{"image_name": "pfsense-ce", "pfsense_version": "2.8", "shard": "0", "shard_total": "1"}]
+    completed = _run_assert(tmp_path, smoke_result="success", leg_count="1", ci_matrix=matrix, pytest_filter="")
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+# ── Pre-existing arms must stay untouched (never weaken an existing assertion) ── #
+
+
+@pytest.mark.parametrize("smoke_result", ["failure", "skipped", "cancelled", "garbage"])
+def test_pre_existing_non_success_arms_still_fail(tmp_path: Path, smoke_result: str) -> None:
+    completed = _run_assert(
+        tmp_path, smoke_result=smoke_result, leg_count="3", ci_matrix=_three_shard_ce_matrix(), pytest_filter=""
+    )
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+
+
+def test_pre_existing_zero_leg_count_still_fails(tmp_path: Path) -> None:
+    completed = _run_assert(tmp_path, smoke_result="success", leg_count="0", ci_matrix=[], pytest_filter="")
+    assert completed.returncode != 0, completed.stdout + completed.stderr

--- a/tests/test_smoke_leg_zero_selection_gate.py
+++ b/tests/test_smoke_leg_zero_selection_gate.py
@@ -209,6 +209,47 @@ def test_leg_fails_when_every_shard_of_a_full_scope_leg_is_empty(tmp_path: Path)
     assert "pfsense-ce-2.8" in (completed.stdout + completed.stderr)
 
 
+def _two_leg_ce_plus_matrix() -> list[dict[str, str]]:
+    """Production shape (scripts/read-version-matrix.sh --print-ci): TWO ci:true
+    amd64 legs, CE 2.8 + Plus 26.03, 3 shards each -- unlike every other row in
+    this file, which only ever builds a single-leg matrix. Plus listed first:
+    that ordering is what makes the mutation probe below (grouping collapsed
+    to one bucket) demonstrate a false PASS rather than an accidental correct
+    result -- see that test's docstring."""
+    legs = [("pfsense-plus", "26.03"), ("pfsense-ce", "2.8")]
+    return [
+        {"image_name": image_name, "pfsense_version": pfsense_version, "shard": str(i), "shard_total": "3"}
+        for image_name, pfsense_version in legs
+        for i in range(3)
+    ]
+
+
+# ── Required coverage row 1b: two production legs, only ONE fully empty ────── #
+
+
+def test_leg_fails_when_only_one_of_two_production_legs_is_fully_empty(tmp_path: Path) -> None:
+    """Pins the grouping key (`.image_name + "|" + .pfsense_version`) against the
+    REAL two-leg production shape, not just the single-leg matrix every other
+    case here uses. The reviewer hand-verified the two-leg case correct but it
+    was unpinned -- nothing stops a future edit from grouping wrongly (e.g.
+    collapsing every leg into one bucket) and only failing when EVERY leg is
+    empty, letting a healthy leg mask a genuinely empty one. Asserts the gate
+    fails AND that the error names only the bad leg -- that second half pins
+    the per-leg grouping itself, not just a blanket any-empty-anywhere check."""
+    _write_shard_status(tmp_path, "pfsense-plus", "26.03", "0", "selected")
+    _write_shard_status(tmp_path, "pfsense-plus", "26.03", "1", "empty")
+    _write_shard_status(tmp_path, "pfsense-plus", "26.03", "2", "empty")
+    for i in range(3):
+        _write_shard_status(tmp_path, "pfsense-ce", "2.8", str(i), "empty")
+    completed = _run_assert(
+        tmp_path, smoke_result="success", leg_count="6", ci_matrix=_two_leg_ce_plus_matrix(), pytest_filter=""
+    )
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+    output = completed.stdout + completed.stderr
+    assert "pfsense-ce-2.8" in output, output
+    assert "pfsense-plus-26.03" not in output, output
+
+
 # ── Required coverage row 2: #855's legitimate single-empty-shard, pinned ───── #
 
 


### PR DESCRIPTION
Fixes #1767.

## What

`scripts/run-smoke.sh` maps pytest exit 5 ("no tests collected") to success **per shard** when the leg is sharded. That tolerance is deliberate — issue #855 established that a shard can legitimately receive zero tests from the split. But release qualification runs full smoke at 3 shards per leg, so a whole-leg zero-selection (a marker typo, a collection bug, a path-filter regression) reported every shard "empty, success" and the fail-closed `all-smoke-passed` aggregate happily passed a leg that executed **nothing** — a fail-open hole in the gate PR #1766 just put in front of `publish-release`.

## How

A leg-level signal layered on top of the per-shard tolerance, which is left exactly as it was:

- `run-smoke.sh`'s sharded branch writes one word — `empty` or `selected` — to `$PFB_DIAG_DIR/shard-selection-status`. No new "count source" was invented: pytest's exit 5 already *is* the authoritative "collected nothing" signal, and this is the same chokepoint that decides the per-shard mapping.
- `smoke-single.yml` uploads that one small file as its own per-shard artifact, deliberately separate from the bulky `smoke-diagnostics-*` bundle so the aggregate's download stays cheap. A single-shard leg uploads nothing at all.
- `all-smoke-passed` groups shards by leg and requires at least one `selected` per multi-shard leg, using only the pre-existing `ci_matrix`/`pytest_filter` outputs — **no `workflow_call` interface change to either reusable workflow** (verified byte-identical against devel).
- Selective invocations stay exempt, mirroring PR #1766's shape. That exemption cannot mask a real release leg: `resolve-legs.sh` collapses `shard_total` to 1 whenever a filter is set, so "multi-shard" and "filtered" are mutually exclusive by construction.

Fail-closed throughout: a missing or unreadable marker never satisfies the check, and the `continue-on-error` on the download step guards only the download (an empty artifact set still reaches the assert, which fails).

## Evidence

Red-first on both halves with frozen hashes — 3 new shellspec rows for the marker write, 5 new pytest rows for the leg-level truth table (all-empty fails, one-empty-others-selected passes per #855, selective tolerated, missing markers fail closed, single-shard untouched). Independently verifier-gated: both red proofs re-executed, all five design claims re-derived from source, the pre-existing `all-smoke-passed` arms diffed byte-for-byte as untouched, and a mutation inverting the gate caught by 4 rows.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smoke-test release validation to detect when all shards in a multi-shard test leg select no tests.
  * Prevented releases from passing silently when shard diagnostics are missing or incomplete.
  * Preserved support for intentionally filtered runs and single-shard test legs.

* **Tests**
  * Added coverage for empty shards, missing diagnostics, selective runs, and existing failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->