### PR TITLE
pfblockerng: reliable is_blank/is_empty + Unicode strips, and a CI gate on empty()-on-string (#1787)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,11 @@
         "phpunit/phpunit": "^12.5",
         "squizlabs/php_codesniffer": "^3.10"
     },
+    "autoload-dev": {
+        "psr-4": {
+            "PfBlockerNG\\PHPStan\\": "tests/phpstan/"
+        }
+    },
     "config": {
         "sort-packages": true
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -347,3 +347,78 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfb_unbound_include.inc
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 47
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 22
+			path: src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 27
+			path: src/usr/local/www/pfblockerng/pfblockerng.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 7
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 5
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 3
+			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 3
+			path: src/usr/local/www/pfblockerng/pfblockerng_threats.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/www/pfblockerng/www/index.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,11 @@
 includes:
     - phpstan-baseline.neon
 
+rules:
+    # Bans empty() on statically-string-typed operands (empty('0') is TRUE —
+    # issue #1787); the honest predicates are pfb_is_empty()/pfb_is_blank().
+    - PfBlockerNG\PHPStan\NoEmptyOnStringRule
+
 parameters:
     paths:
         - src

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3135,6 +3135,31 @@ function pfb_is_blank(?string $value): bool {
 
 
 /**
+ * TRUE iff $value is absent or the empty string — the actual "is this an empty
+ * string?" answer (issue #1787). Unlike empty(), the string "0" is NOT empty:
+ * it is a real value. Whitespace is content here; use pfb_is_blank() for the
+ * "nothing but whitespace" question.
+ */
+function pfb_is_empty(?string $value): bool {
+	return $value === NULL || $value === '';
+}
+
+
+/**
+ * Right-strip trailing whitespace — ASCII (rtrim()'s default set) plus Unicode
+ * whitespace/separators (\s under /u, \p{Z}) and the BOM — the same character
+ * class pfb_is_blank() calls blank (issue #1787). Leading whitespace and the
+ * value "0" survive untouched. A pathological preg_replace() failure degrades
+ * fail-open to the ASCII-rtrim'd value, so Unicode stripping may not apply for
+ * that call.
+ */
+function pfb_rstrip(string $value): string {
+	$value = rtrim($value);
+	return pfb_preg_replace_safe('/[\s\p{Z}\x{FEFF}]+$/u', '', $value);
+}
+
+
+/**
  * Sanitize a single-line/scalar text field: converts legacy encodings to
  * UTF-8, strips every Unicode control character (Cc) -- including CR/LF/TAB,
  * since this contract is single-line -- and the BOM, then trims (Unicode
@@ -3161,7 +3186,7 @@ function pfb_sanitize_text(string $text): string {
  * normalizes CRLF/CR/LF line endings to LF, strips every Unicode control
  * character except \n/\t (plus the BOM) -- so VT/FF/NEL/etc. never become row
  * separators or survive as data -- then right-strips trailing whitespace per
- * line. The right-strip is Unicode-aware (\p{Z} + tab), so NBSP/ideographic
+ * line (pfb_rstrip). The right-strip is Unicode-aware, so NBSP/ideographic
  * space/line-separator runs are stripped like ASCII space/tab, and a row of
  * only Unicode whitespace right-strips to '' same as an ASCII-blank row. Does
  * NOT drop blank lines; that is the caller's job (issue #1707). A
@@ -3182,8 +3207,7 @@ function pfb_sanitize_text_area(string $text): string {
 
 	$lines = explode("\n", $text);
 	foreach ($lines as &$line) {
-		$line = rtrim($line, " \t");
-		$line = pfb_preg_replace_safe('/[\p{Z}\t]+$/u', '', $line);
+		$line = pfb_rstrip($line);
 	}
 	unset($line);
 	return implode("\n", $lines);
@@ -4545,7 +4569,7 @@ function pfb_get_hooks($pfbconfig, $when) {
 		if (($hook['when'] ?? '') !== $when) {
 			continue;
 		}
-		if (trim((string) ($hook['script'] ?? '')) === '') {
+		if (pfb_is_blank((string) ($hook['script'] ?? ''))) {
 			continue;
 		}
 		$hooks[] = $hook;
@@ -7676,9 +7700,10 @@ function pfb_dnsbl_unbracket_ip6(string $line): string {
 // together regardless of the list's own declared format. Callers whose '#' handling
 // carries side effects (hpHosts/Spamhaus/CSV-header sniffing in the DNSBL hosts-format
 // branch) check '#' themselves first and do not route it through here. Blank detection is
-// empty($line) -- callers MUST trim() first, or a whitespace-only line won't match.
+// an exact '' match (empty() would eat the valid line "0" -- issue #1787) -- callers MUST
+// trim() first, or a whitespace-only line won't match.
 function pfb_is_blank_or_comment_line(string $line): bool {
-	return empty($line) ||
+	return $line === '' ||
 		str_starts_with($line, '#') ||
 		str_starts_with($line, '!') ||
 		str_starts_with($line, '//');
@@ -11656,7 +11681,7 @@ function pfb_feed_redirect_target($location, $current_url, &$reason, &$pinned) {
 	$reason = '';
 	$pinned = '';
 
-	if (!is_string($location) || trim($location) === '') {
+	if (!is_string($location) || pfb_is_blank($location)) {
 		$reason = 'feed redirect has no target';
 		return FALSE;
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3160,6 +3160,35 @@ function pfb_rstrip(string $value): string {
 
 
 /**
+ * Left-strip counterpart of pfb_rstrip() — same whitespace class (ASCII,
+ * Unicode \s/\p{Z}, BOM), leading side only. Lets a caller ask what a line's
+ * first NONBLANK character is (e.g. comment detection when '#' hides behind
+ * indentation). Same fail-open degradation to the ASCII-ltrim'd value.
+ */
+function pfb_lstrip(string $value): string {
+	$value = ltrim($value);
+	return pfb_preg_replace_safe('/^[\s\p{Z}\x{FEFF}]+/u', '', $value);
+}
+
+
+/**
+ * Double-sided pfb_lstrip()+pfb_rstrip(): trim() with the same Unicode
+ * whitespace class the other issue-#1787 helpers use. The value "0" survives.
+ * ASCII fast path: after trim(), ASCII bytes at both ends prove no Unicode
+ * whitespace remains there (every \p{Z}/BOM codepoint is multi-byte), so the
+ * hot per-line callers skip the two preg passes entirely.
+ */
+function pfb_strip(string $value): string {
+	$value = trim($value);
+	if ($value === '' ||
+	    (ord($value[0]) < 0x80 && ord($value[strlen($value) - 1]) < 0x80)) {
+		return $value;
+	}
+	return pfb_lstrip(pfb_rstrip($value));
+}
+
+
+/**
  * Sanitize a single-line/scalar text field: converts legacy encodings to
  * UTF-8, strips every Unicode control character (Cc) -- including CR/LF/TAB,
  * since this contract is single-line -- and the BOM, then trims (Unicode
@@ -7699,11 +7728,13 @@ function pfb_dnsbl_unbracket_ip6(string $line): string {
 // '!' (ABP/uBlock), '//' (C-style) -- the three conventions feeds in this ecosystem mix
 // together regardless of the list's own declared format. Callers whose '#' handling
 // carries side effects (hpHosts/Spamhaus/CSV-header sniffing in the DNSBL hosts-format
-// branch) check '#' themselves first and do not route it through here. Blank detection is
-// an exact '' match (empty() would eat the valid line "0" -- issue #1787) -- callers MUST
-// trim() first, or a whitespace-only line won't match.
+// branch) check '#' themselves first and do not route it through here. The helper strips
+// the line itself (pfb_strip, Unicode class -- issue #1787), so indentation the caller's
+// ASCII trim() can't remove (NBSP et al.) never hides a marker; blank detection is
+// pfb_is_empty()'s exact '' match (empty() would eat the valid line "0").
 function pfb_is_blank_or_comment_line(string $line): bool {
-	return $line === '' ||
+	$line = pfb_strip($line);
+	return pfb_is_empty($line) ||
 		str_starts_with($line, '#') ||
 		str_starts_with($line, '!') ||
 		str_starts_with($line, '//');
@@ -7915,12 +7946,14 @@ function pfb_dnsbl_csv_extract(string $line, array $csvline, string $csv_type, b
 
 
 // ADR-62 §2 Decision 4: the universal plain-path control-line skip. Mirrors
-// pfb_is_blank_or_comment_line's contract: blank detection is an exact '' match, so
-// the CALLER must trim() first. Deliberately excludes '#' -- pfb_dnsbl_hash_line_
+// pfb_is_blank_or_comment_line's contract: the helper strips the line itself
+// (pfb_strip, Unicode class -- issue #1787; blank = pfb_is_empty()'s exact '' match,
+// so the line "0" is data). Deliberately excludes '#' -- pfb_dnsbl_hash_line_
 // classify() owns it (side effects). A bracketed IPv6 literal is an ADDRESS, never
 // skipped as an ABP section marker.
 function pfb_dnsbl_is_skippable_control_line(string $line): bool {
-	if ($line === '' || str_starts_with($line, '!') || str_starts_with($line, '//')) {
+	$line = pfb_strip($line);
+	if (pfb_is_empty($line) || str_starts_with($line, '!') || str_starts_with($line, '//')) {
 		return TRUE;
 	}
 	if (str_starts_with($line, '[') && str_ends_with($line, ']')) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3613,7 +3613,10 @@ function pfb_py_sync_status_list_open(string $status_dir): array
  */
 function pfb_validate_suppression_line(string $line, string $family): ?string
 {
-	if (str_starts_with($line, '#') || pfb_is_blank($line)) {
+	// Blank/comment no-op: judge by the first NONBLANK character, so an
+	// indented '#' (ASCII or Unicode whitespace) is still a comment.
+	$stripped = pfb_strip($line);
+	if (pfb_is_empty($stripped) || str_starts_with($stripped, '#')) {
 		return NULL;
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3613,7 +3613,7 @@ function pfb_py_sync_status_list_open(string $status_dir): array
  */
 function pfb_validate_suppression_line(string $line, string $family): ?string
 {
-	if (str_starts_with($line, '#') || trim($line) === '') {
+	if (str_starts_with($line, '#') || pfb_is_blank($line)) {
 		return NULL;
 	}
 
@@ -5044,7 +5044,7 @@ function pfb_lint_sh_diagnostics(string $content, string $sh = '/bin/sh', string
 		// sh exits at the FIRST syntax error -- an over-pipe-buffer body can EPIPE the
 		// stdin write loop (failure = 'stdin write failed') while stderr already holds a
 		// real line-mapped diagnostic; prefer that over the generic launch-failed warning.
-		if (trim($result['stderr']) !== '') {
+		if (!pfb_is_blank($result['stderr'])) {
 			return pfb_lint_parse_sh_stderr($result['stderr']);
 		}
 		return [['line' => 1, 'message' => 'sh syntax checker launch failed: ' . $result['failure'], 'severity' => 'warning']];
@@ -5052,7 +5052,7 @@ function pfb_lint_sh_diagnostics(string $content, string $sh = '/bin/sh', string
 	if ($result['exit'] === 0) {
 		return [];
 	}
-	if (trim($result['stderr']) === '') {
+	if (pfb_is_blank($result['stderr'])) {
 		return [['line' => 1, 'message' => "sh syntax checker exited {$result['exit']} with no diagnostic", 'severity' => 'warning']];
 	}
 	return pfb_lint_parse_sh_stderr($result['stderr']);
@@ -5088,7 +5088,7 @@ PYTHON;
 	if ($result['exit'] === 0) {
 		return [];
 	}
-	if ($result['exit'] === 1 && trim($result['stderr']) !== '') {
+	if ($result['exit'] === 1 && !pfb_is_blank($result['stderr'])) {
 		return pfb_lint_parse_py_stderr($result['stderr']);
 	}
 	return [['line' => 1, 'message' => "python syntax checker exited {$result['exit']} with no diagnostic", 'severity' => 'warning']];

--- a/tests/php/Adr62DnsblIsSkippableControlLineTest.php
+++ b/tests/php/Adr62DnsblIsSkippableControlLineTest.php
@@ -8,8 +8,9 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * pfb_dnsbl_is_skippable_control_line() -- ADR-62 P2 capture guard for the
- * (not-yet-wired) universal blank/comment/ABP-marker skip. Blank detection is an
- * exact '' match (caller trims first, mirroring pfb_is_blank_or_comment_line); a
+ * (not-yet-wired) universal blank/comment/ABP-marker skip. The helper strips the
+ * line itself (pfb_strip, Unicode class -- issue #1787; blank = exact '' match,
+ * mirroring pfb_is_blank_or_comment_line); a
  * bracketed IPv6 literal is never treated as an ABP section marker (ADR-62 Semantics
  * #3) -- it is an address, collected by pfb_dnsbl_collect_feed_ip() instead.
  */
@@ -51,21 +52,19 @@ final class Adr62DnsblIsSkippableControlLineTest extends TestCase
 		$this->assertFalse(pfb_dnsbl_is_skippable_control_line('[2001:db8::1]'));
 	}
 
-	public function testWhitespaceOnlyLineIsNotBlankPerThisHelpersContract(): void
+	public function testWhitespaceOnlyLineIsBlankPerThisHelpersContract(): void
 	{
-		// Probe (brief hostile row): the download loop trims $line (inc:~16389)
-		// BEFORE any capture-guard call, so a whitespace-only line never reaches a
-		// call site untrimmed in production. This helper follows the SAME contract
-		// as pfb_is_blank_or_comment_line -- the caller trims first; passed
-		// unTrimmed, three spaces is not the exact '' match, so it is NOT skippable.
-		$this->assertFalse(pfb_dnsbl_is_skippable_control_line('   '));
+		// Issue #1787 flipped the old caller-trims-first contract: the helper now
+		// strips the line itself (pfb_strip, Unicode class, mirroring
+		// pfb_is_blank_or_comment_line), so a whitespace-only line is blank and
+		// skippable even when a call site passes it untrimmed.
+		$this->assertTrue(pfb_dnsbl_is_skippable_control_line('   '));
 	}
 
-	public function testTabLedAbpAnchorIsNotSkippedUntrimmed(): void
+	public function testTabLedAbpAnchorIsNotSkipped(): void
 	{
-		// Probe (brief hostile row): a raw tab-led line, called directly (bypassing
-		// the loop's own trim at inc:~16389), does not start with '!'/'//'/'[' --
-		// consistent with the caller-trims-first contract, not a bug.
+		// A tab-led ABP anchor line self-strips to '||x^' -- an ABP rule, not a
+		// '!'/'//'/'[' control line, so it stays on the capture path.
 		$this->assertFalse(pfb_dnsbl_is_skippable_control_line("\t||x^"));
 	}
 

--- a/tests/php/BlankOrCommentLineTest.php
+++ b/tests/php/BlankOrCommentLineTest.php
@@ -34,13 +34,13 @@ final class BlankOrCommentLineTest extends TestCase
 		$this->assertTrue(pfb_is_blank_or_comment_line(''));
 	}
 
-	public function testUntrimmedWhitespaceOnlyStringIsNotBlank(): void
+	public function testUntrimmedWhitespaceOnlyStringIsBlank(): void
 	{
-		// empty('   ') is FALSE in PHP -- this predicate relies on the caller having
-		// already trim()'d $line (its one call site does), matching every other
-		// empty($line) check in this file rather than reimplementing trim-and-check.
-		// Pins the contract explicitly instead of leaving it an unstated assumption.
-		$this->assertFalse(pfb_is_blank_or_comment_line('   '));
+		// Issue #1787 flipped the old caller-trims-first contract: the helper now
+		// strips the line itself (pfb_strip, Unicode class), so a whitespace-only
+		// line is blank whether or not the caller trimmed. Pins the contract
+		// explicitly instead of leaving it an unstated assumption.
+		$this->assertTrue(pfb_is_blank_or_comment_line('   '));
 	}
 
 	public function testHashCommentIsSkipped(): void

--- a/tests/php/Issue1787BlankEmptyCallSitesTest.php
+++ b/tests/php/Issue1787BlankEmptyCallSitesTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1787: call sites that answered "is this string blank/empty?" with a
+ * flimsy idiom — empty() (which calls the valid row "0" empty) or
+ * trim() === '' (which misses Unicode whitespace such as NBSP) — must give the
+ * real answer via pfb_is_blank()/an exact '' match.
+ *
+ * Each test pins the corrected observable behaviour of one call site:
+ *   - pfb_is_blank_or_comment_line(): the literal line "0" is DATA, not blank.
+ *   - pfb_validate_suppression_line(): a Unicode-whitespace-only line is a
+ *     blank no-op, not an "invalid subnet" input error.
+ *   - pfb_get_hooks(): a hook whose script is only Unicode whitespace has no
+ *     script and is skipped like an empty one.
+ *   - pfb_feed_redirect_target(): a Location of only Unicode whitespace has no
+ *     target — refuse it up front instead of resolving it as a relative URL.
+ *   - pfb_lint_sh_diagnostics()/pfb_lint_py_diagnostics(): a stderr of only
+ *     Unicode whitespace carries no diagnostic — degrade to the no-diagnostic/
+ *     launch-failed warning instead of surfacing a whitespace "error".
+ */
+#[CoversFunction('pfb_is_blank_or_comment_line')]
+#[CoversFunction('pfb_validate_suppression_line')]
+#[CoversFunction('pfb_get_hooks')]
+#[CoversFunction('pfb_feed_redirect_target')]
+#[CoversFunction('pfb_lint_sh_diagnostics')]
+#[CoversFunction('pfb_lint_py_diagnostics')]
+final class Issue1787BlankEmptyCallSitesTest extends TestCase
+{
+	private const NBSP = "\u{00A0}";
+
+	/** @var list<string> tmp fixture paths to unlink in tearDown */
+	private array $fixtures = [];
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_resolve_map'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->fixtures as $path) {
+			@unlink($path);
+		}
+		$this->fixtures = [];
+		unset($GLOBALS['config'], $GLOBALS['pfb_test_resolve_map']);
+		parent::tearDown();
+	}
+
+	/** Writes an executable `#!/bin/sh` fixture that runs $body verbatim. */
+	private function fixture(string $body): string
+	{
+		$path = sys_get_temp_dir() . '/pfb_1787_fixture_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		file_put_contents($path, "#!/bin/sh\n{$body}\n");
+		chmod($path, 0700);
+		$this->fixtures[] = $path;
+		return $path;
+	}
+
+	// --- pfb_is_blank_or_comment_line ------------------------------------
+
+	public function testLiteralZeroLineIsNotBlank(): void
+	{
+		// The contract (and pfb_dnsbl_is_skippable_control_line, its ADR-62
+		// mirror) says blank detection is an exact '' match; empty('0') is TRUE,
+		// which silently drops a "0" feed line as blank (issue #1707 class).
+		$this->assertFalse(pfb_is_blank_or_comment_line('0'));
+		// The genuine blank/comment shapes still match.
+		$this->assertTrue(pfb_is_blank_or_comment_line(''));
+		$this->assertTrue(pfb_is_blank_or_comment_line('# comment'));
+	}
+
+	// --- pfb_validate_suppression_line -----------------------------------
+
+	public function testSuppressionLineOfOnlyUnicodeWhitespaceIsBlankNoOp(): void
+	{
+		// Given an ASCII-blank line is already a no-op
+		$this->assertNull(pfb_validate_suppression_line('   ', 'ipv4'));
+		// Then a Unicode-whitespace-only line is the same blank no-op, not an
+		// input error naming an "invalid subnet".
+		$this->assertNull(pfb_validate_suppression_line(self::NBSP, 'ipv4'));
+		$this->assertNull(pfb_validate_suppression_line(self::NBSP . "\u{3000}", 'ipv6'));
+	}
+
+	// --- pfb_get_hooks ----------------------------------------------------
+
+	public function testHookWithUnicodeWhitespaceOnlyScriptIsSkipped(): void
+	{
+		$pfbconfig = ['hooks' => ['row' => [
+			['enabled' => 'on', 'when' => 'pre', 'script' => 'echo ok'],
+			['enabled' => 'on', 'when' => 'pre', 'script' => self::NBSP],
+		]]];
+		$hooks = pfb_get_hooks($pfbconfig, 'pre');
+		// Only the hook with a real script survives; a Unicode-whitespace-only
+		// script is as script-less as an empty one.
+		$this->assertCount(1, $hooks);
+		$this->assertSame('echo ok', $hooks[0]['script']);
+	}
+
+	// --- pfb_feed_redirect_target -----------------------------------------
+
+	public function testRedirectLocationOfOnlyUnicodeWhitespaceHasNoTarget(): void
+	{
+		$reason = '';
+		$pinned = '';
+		$result = pfb_feed_redirect_target(self::NBSP, 'https://feed.example/list.txt', $reason, $pinned);
+		// A whitespace-only Location is "no target" — refused before any
+		// relative-URL resolution or host re-vetting runs.
+		$this->assertFalse($result);
+		$this->assertSame('feed redirect has no target', $reason);
+		$this->assertSame('', $pinned);
+	}
+
+	// --- pfb_lint_sh_diagnostics / pfb_lint_py_diagnostics ----------------
+
+	public function testShUnicodeWhitespaceOnlyStderrIsNoDiagnosticWarning(): void
+	{
+		// Nonzero exit, stderr = NBSP + newline: no diagnostic to parse.
+		$timeoutFixture = $this->fixture('printf "\302\240\n" 1>&2' . "\n" . 'exit 1');
+		$shFixture = $this->fixture('exit 0'); // never exec'd — fake timeout ignores argv
+		$diagnostics = pfb_lint_sh_diagnostics("echo ok\n", $shFixture, $timeoutFixture);
+		$this->assertCount(1, $diagnostics);
+		$this->assertSame(1, $diagnostics[0]['line']);
+		$this->assertSame('warning', $diagnostics[0]['severity']);
+		$this->assertStringContainsString('exited 1 with no diagnostic', $diagnostics[0]['message']);
+	}
+
+	public function testShStdinWriteFailureWithWhitespaceOnlyStderrIsLaunchFailedWarning(): void
+	{
+		// The fake "timeout_bin" closes stdin immediately (EPIPEs the write loop
+		// for an over-pipe-buffer body) and leaves only whitespace on stderr —
+		// there is no parseable diagnostic to prefer, so the generic
+		// launch-failed warning must win.
+		$timeoutFixture = $this->fixture(
+			'exec 0<&-' . "\n" .
+			'printf "\302\240\n" 1>&2' . "\n" .
+			'exit 2'
+		);
+		$shFixture = $this->fixture('exit 0');
+		// ~256KiB: over the OS pipe buffer, under the endpoint's 1MiB cap.
+		$content = str_repeat('x', 300000) . "\n";
+		$diagnostics = pfb_lint_sh_diagnostics($content, $shFixture, $timeoutFixture);
+		$this->assertCount(1, $diagnostics);
+		$this->assertSame(1, $diagnostics[0]['line']);
+		$this->assertSame('warning', $diagnostics[0]['severity']);
+		$this->assertStringContainsString('launch failed', $diagnostics[0]['message']);
+	}
+
+	public function testPyUnicodeWhitespaceOnlyStderrIsNoDiagnosticWarning(): void
+	{
+		$timeoutFixture = $this->fixture('printf "\302\240\n" 1>&2' . "\n" . 'exit 1');
+		$pythonFixture = $this->fixture('exit 0'); // never exec'd — fake timeout ignores argv
+		$diagnostics = pfb_lint_py_diagnostics("print('ok')\n", $pythonFixture, $timeoutFixture);
+		$this->assertCount(1, $diagnostics);
+		$this->assertSame(1, $diagnostics[0]['line']);
+		$this->assertSame('warning', $diagnostics[0]['severity']);
+		$this->assertStringContainsString('exited 1 with no diagnostic', $diagnostics[0]['message']);
+	}
+}

--- a/tests/php/Issue1787BlankEmptyCallSitesTest.php
+++ b/tests/php/Issue1787BlankEmptyCallSitesTest.php
@@ -75,6 +75,33 @@ final class Issue1787BlankEmptyCallSitesTest extends TestCase
 		$this->assertTrue(pfb_is_blank_or_comment_line('# comment'));
 	}
 
+	public function testBlankOrCommentLineStripsItsOwnWhitespace(): void
+	{
+		// The helper strips the line itself (Unicode class included), so a
+		// whitespace-only line is blank and a comment marker behind
+		// indentation — which the caller's ASCII trim() cannot remove when
+		// the whitespace is NBSP — is still a comment.
+		$this->assertTrue(pfb_is_blank_or_comment_line('   '));
+		$this->assertTrue(pfb_is_blank_or_comment_line(self::NBSP));
+		$this->assertTrue(pfb_is_blank_or_comment_line(self::NBSP . '# comment'));
+		$this->assertTrue(pfb_is_blank_or_comment_line(self::NBSP . '! ABP comment'));
+		// Data behind the same indentation is still data.
+		$this->assertFalse(pfb_is_blank_or_comment_line(self::NBSP . 'example.com'));
+	}
+
+	public function testSkippableControlLineStripsItsOwnWhitespace(): void
+	{
+		// Same self-stripping contract for the ADR-62 mirror: blank lines,
+		// indented '!'/'//' comments, and an ABP section marker with trailing
+		// whitespace are all control lines; a bracketed IPv6 literal and a
+		// domain stay data.
+		$this->assertTrue(pfb_dnsbl_is_skippable_control_line('   '));
+		$this->assertTrue(pfb_dnsbl_is_skippable_control_line(self::NBSP . '! ABP comment'));
+		$this->assertTrue(pfb_dnsbl_is_skippable_control_line('[Adblock Plus 2.0]' . self::NBSP));
+		$this->assertFalse(pfb_dnsbl_is_skippable_control_line(self::NBSP . '[2604:2dc0::]'));
+		$this->assertFalse(pfb_dnsbl_is_skippable_control_line(self::NBSP . 'example.com'));
+	}
+
 	// --- pfb_validate_suppression_line -----------------------------------
 
 	public function testSuppressionLineOfOnlyUnicodeWhitespaceIsBlankNoOp(): void
@@ -85,6 +112,15 @@ final class Issue1787BlankEmptyCallSitesTest extends TestCase
 		// input error naming an "invalid subnet".
 		$this->assertNull(pfb_validate_suppression_line(self::NBSP, 'ipv4'));
 		$this->assertNull(pfb_validate_suppression_line(self::NBSP . "\u{3000}", 'ipv6'));
+	}
+
+	public function testSuppressionCommentBehindLeadingWhitespaceIsStillAComment(): void
+	{
+		// A comment line is one whose first NONBLANK character is '#' —
+		// leading whitespace (ASCII or Unicode) must not turn it into a
+		// malformed "address".
+		$this->assertNull(pfb_validate_suppression_line('  # ASCII-indented comment', 'ipv4'));
+		$this->assertNull(pfb_validate_suppression_line(self::NBSP . '# NBSP-indented comment', 'ipv4'));
 	}
 
 	// --- pfb_get_hooks ----------------------------------------------------

--- a/tests/php/NoEmptyOnStringRuleTest.php
+++ b/tests/php/NoEmptyOnStringRuleTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1787 — the custom PHPStan rule (PfBlockerNG\PHPStan\NoEmptyOnStringRule)
+ * that mechanically bans empty() on statically-string-typed operands, because
+ * empty('0') is TRUE and a valid "0" value reads as absent (issue #1707 class).
+ *
+ * A linter that never fires is worthless, so this suite pins BOTH sides of the
+ * rule's decision, driving the real `phpstan` binary (the repo config, so the
+ * exact CI wiring) over fixture files under tests/phpstan/fixtures/:
+ *
+ *   - it FLAGS empty() on string, ?string, and string|false operands (the
+ *     null/false wrappers still lie about '0');
+ *   - it STAYS SILENT for empty() on arrays and untyped/mixed operands (the
+ *     legacy config-read idiom), and for the honest `$value === ''` check.
+ *
+ * The rule is dev-only tooling; if phpstan is not installed the suite SKIPs
+ * (CI's phpstan job is the hard gate), it never falsely fails.
+ */
+final class NoEmptyOnStringRuleTest extends TestCase
+{
+	private const IDENTIFIER = 'pfBlockerNG.emptyOnString';
+
+	/** @var array<string, list<array{line: int, identifier: string}>>|null keyed by fixture basename */
+	private static ?array $findings = null;
+
+	private static function repoRoot(): string
+	{
+		return dirname(__DIR__, 2);
+	}
+
+	protected function setUp(): void
+	{
+		if (!is_file(self::repoRoot() . '/vendor/bin/phpstan')) {
+			$this->markTestSkipped('phpstan not installed (composer install) — CI phpstan job is the gate.');
+		}
+	}
+
+	/**
+	 * One shared phpstan run over both fixtures (analysis is the slow part),
+	 * returning per-file emptyOnString findings.
+	 *
+	 * @return array<string, list<array{line: int, identifier: string}>>
+	 */
+	private function findings(): array
+	{
+		if (self::$findings !== null) {
+			return self::$findings;
+		}
+		$root = self::repoRoot();
+		$cmd = escapeshellarg($root . '/vendor/bin/phpstan')
+			. ' analyse --no-progress --memory-limit=1G --error-format=json'
+			. ' -c ' . escapeshellarg($root . '/phpstan.neon')
+			. ' ' . escapeshellarg($root . '/tests/phpstan/fixtures')
+			. ' 2>/dev/null';
+		exec($cmd, $output, $status);
+		$report = json_decode(implode("\n", $output), true);
+		$this->assertIsArray($report, 'phpstan produced no parseable JSON report');
+
+		$byFile = [];
+		foreach (($report['files'] ?? []) as $path => $file) {
+			foreach (($file['messages'] ?? []) as $message) {
+				if (($message['identifier'] ?? '') !== self::IDENTIFIER) {
+					continue;
+				}
+				$byFile[basename((string) $path)][] = [
+					'line'       => (int) $message['line'],
+					'identifier' => (string) $message['identifier'],
+				];
+			}
+		}
+		return self::$findings = $byFile;
+	}
+
+	public function testFlagsEmptyOnStringTypedOperands(): void
+	{
+		$flagged = array_column($this->findings()['empty_on_string_violation.php'] ?? [], 'line');
+		sort($flagged);
+		// string / ?string / string|false — one finding per fixture function.
+		$this->assertSame([8, 12, 17], $flagged);
+	}
+
+	public function testStaysSilentOnArraysUntypedAndExactComparison(): void
+	{
+		$this->assertArrayNotHasKey(
+			'empty_on_string_compliant.php',
+			$this->findings(),
+			'rule must not fire on array/untyped operands or exact comparisons'
+		);
+	}
+}

--- a/tests/php/PfbIsEmptyRstripTest.php
+++ b/tests/php/PfbIsEmptyRstripTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_is_empty() / pfb_rstrip() (issue #1787) — the honest "is this an empty
+ * string?" answer and the Unicode-aware right-strip.
+ *
+ * pfb_is_empty() exists because empty() lies: empty('0') is TRUE, but "0" is a
+ * real value (issue #1707). Absent (NULL) and '' are empty; everything else —
+ * including whitespace — is content (blankness is pfb_is_blank()'s question).
+ *
+ * pfb_rstrip() strips trailing ASCII whitespace like rtrim(), and additionally
+ * the Unicode whitespace/separator class pfb_is_blank() calls blank (NBSP,
+ * ideographic space, line/paragraph separators, the BOM). Leading whitespace
+ * is preserved — it is a right-strip, not a trim.
+ */
+#[CoversFunction('pfb_is_empty')]
+#[CoversFunction('pfb_rstrip')]
+final class PfbIsEmptyRstripTest extends TestCase
+{
+	// --- pfb_is_empty -----------------------------------------------------
+
+	public function testAbsentAndEmptyStringAreEmpty(): void
+	{
+		$this->assertTrue(pfb_is_empty(NULL));
+		$this->assertTrue(pfb_is_empty(''));
+	}
+
+	public function testZeroStringIsNotEmpty(): void
+	{
+		// The whole reason this helper exists instead of empty(): "0" is a
+		// real value, and empty('0') is TRUE.
+		$this->assertFalse(pfb_is_empty('0'));
+	}
+
+	public function testWhitespaceIsContentNotEmptiness(): void
+	{
+		// Emptiness is exact; a whitespace-only string is BLANK (pfb_is_blank),
+		// not empty.
+		$this->assertFalse(pfb_is_empty(' '));
+		$this->assertFalse(pfb_is_empty("\u{00A0}"));
+		$this->assertFalse(pfb_is_empty('a'));
+	}
+
+	// --- pfb_rstrip -------------------------------------------------------
+
+	public function testStripsTrailingAsciiWhitespace(): void
+	{
+		$this->assertSame('value', pfb_rstrip("value \t\r\n"));
+	}
+
+	public function testStripsTrailingUnicodeWhitespaceAndBom(): void
+	{
+		// NBSP, ideographic space, line separator, BOM — all trailing
+		// whitespace-class characters rtrim() misses.
+		$this->assertSame('value', pfb_rstrip("value\u{00A0}\u{3000}\u{2028}\u{FEFF}"));
+		// Mixed ASCII/Unicode runs strip in one pass too.
+		$this->assertSame('value', pfb_rstrip("value \u{00A0}\t\u{3000} "));
+	}
+
+	public function testPreservesLeadingWhitespaceAndInnerContent(): void
+	{
+		// A right-strip, not a trim: the left side and inner whitespace stay.
+		$this->assertSame("\u{00A0} a b", pfb_rstrip("\u{00A0} a b \u{00A0}"));
+	}
+
+	public function testWhitespaceOnlyStringStripsToEmpty(): void
+	{
+		$this->assertSame('', pfb_rstrip(" \t\u{00A0}\u{3000}"));
+		$this->assertSame('', pfb_rstrip(''));
+	}
+
+	public function testZeroSurvives(): void
+	{
+		// The issue-#1707 row: "0" is data, never stripped to nothing.
+		$this->assertSame('0', pfb_rstrip('0 '));
+	}
+}

--- a/tests/php/PfbStringHelpersTest.php
+++ b/tests/php/PfbStringHelpersTest.php
@@ -117,4 +117,14 @@ final class PfbStringHelpersTest extends TestCase
 	{
 		$this->assertSame('0', pfb_strip(" 0\u{00A0}"));
 	}
+
+	public function testInvalidUtf8DegradesFailOpen(): void
+	{
+		// A truncated multibyte sequence makes the /u preg pass return NULL;
+		// the strips must degrade to the ASCII-trimmed bytes, never to NULL
+		// or wiped data (same fail-open contract as pfb_preg_replace_safe).
+		$this->assertSame("abc\xC2", pfb_rstrip("abc\xC2"));
+		$this->assertSame("abc\xC2", pfb_lstrip("abc\xC2"));
+		$this->assertSame("abc\xC2", pfb_strip("abc\xC2"));
+	}
 }

--- a/tests/php/PfbStringHelpersTest.php
+++ b/tests/php/PfbStringHelpersTest.php
@@ -6,8 +6,8 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_is_empty() / pfb_rstrip() (issue #1787) — the honest "is this an empty
- * string?" answer and the Unicode-aware right-strip.
+ * pfb_is_empty() / pfb_rstrip() / pfb_lstrip() / pfb_strip() (issue #1787) —
+ * the honest "is this an empty string?" answer and the Unicode-aware strips.
  *
  * pfb_is_empty() exists because empty() lies: empty('0') is TRUE, but "0" is a
  * real value (issue #1707). Absent (NULL) and '' are empty; everything else —
@@ -16,11 +16,15 @@ use PHPUnit\Framework\TestCase;
  * pfb_rstrip() strips trailing ASCII whitespace like rtrim(), and additionally
  * the Unicode whitespace/separator class pfb_is_blank() calls blank (NBSP,
  * ideographic space, line/paragraph separators, the BOM). Leading whitespace
- * is preserved — it is a right-strip, not a trim.
+ * is preserved — it is a right-strip, not a trim. pfb_lstrip() is its leading
+ * mirror (so "what is the first NONBLANK character?" is answerable), and
+ * pfb_strip() is the double-sided combination — trim() over the same class.
  */
 #[CoversFunction('pfb_is_empty')]
 #[CoversFunction('pfb_rstrip')]
-final class PfbIsEmptyRstripTest extends TestCase
+#[CoversFunction('pfb_lstrip')]
+#[CoversFunction('pfb_strip')]
+final class PfbStringHelpersTest extends TestCase
 {
 	// --- pfb_is_empty -----------------------------------------------------
 
@@ -78,5 +82,39 @@ final class PfbIsEmptyRstripTest extends TestCase
 	{
 		// The issue-#1707 row: "0" is data, never stripped to nothing.
 		$this->assertSame('0', pfb_rstrip('0 '));
+	}
+
+	// --- pfb_lstrip -------------------------------------------------------
+
+	public function testLstripStripsLeadingAsciiAndUnicodeWhitespace(): void
+	{
+		$this->assertSame('value', pfb_lstrip(" \t\u{00A0}\u{3000}\u{FEFF}value"));
+	}
+
+	public function testLstripPreservesTrailingWhitespaceAndInnerContent(): void
+	{
+		// A left-strip, not a trim: the right side and inner whitespace stay.
+		$this->assertSame("a b \u{00A0}", pfb_lstrip("\u{00A0} a b \u{00A0}"));
+	}
+
+	public function testLstripExposesFirstNonblankCharacter(): void
+	{
+		// The comment-detection use: '#' hiding behind indentation is still
+		// the first nonblank character.
+		$this->assertTrue(str_starts_with(pfb_lstrip("\u{00A0} # comment"), '#'));
+		$this->assertSame('', pfb_lstrip(" \u{00A0}"));
+	}
+
+	// --- pfb_strip --------------------------------------------------------
+
+	public function testStripTrimsBothSidesAcrossAsciiAndUnicode(): void
+	{
+		$this->assertSame('a b', pfb_strip("\u{FEFF}\u{00A0} a b \t\u{3000}\r\n"));
+		$this->assertSame('', pfb_strip(" \u{00A0}\u{2029} "));
+	}
+
+	public function testStripZeroSurvives(): void
+	{
+		$this->assertSame('0', pfb_strip(" 0\u{00A0}"));
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -4473,6 +4473,19 @@
             }
         ]
     },
+    "pfb_is_empty": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
     "pfb_is_managed_obj": {
         "returnsRef": false,
         "returnType": "bool",
@@ -6524,6 +6537,19 @@
                 "variadic": false,
                 "type": "?callable",
                 "default": "NULL"
+            }
+        ]
+    },
+    "pfb_rstrip": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
             }
         ]
     },

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -5321,6 +5321,19 @@
             }
         ]
     },
+    "pfb_lstrip": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_manage_dnsbl_vip": {
         "returnsRef": false,
         "returnType": "void",
@@ -7136,6 +7149,19 @@
                 "byRef": false,
                 "variadic": false,
                 "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_strip": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
                 "default": null
             }
         ]

--- a/tests/phpstan/NoEmptyOnStringRule.php
+++ b/tests/phpstan/NoEmptyOnStringRule.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PfBlockerNG\PHPStan;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Empty_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Issue #1787: empty() on a string operand lies — empty('0') is TRUE, so a
+ * valid "0" value reads as absent (the issue-#1707 bug class). Whenever the
+ * operand's statically-known type is a string (nullable/string|false wrappers
+ * included), the honest predicates are pfb_is_empty() (exact ''/NULL) and
+ * pfb_is_blank() (nothing but whitespace).
+ *
+ * Deliberately silent on mixed/untyped operands (most legacy config-array
+ * reads): the gate stops NEW typed-string empty() calls without flagging the
+ * whole legacy surface. As annotations tighten, coverage grows for free.
+ *
+ * @implements Rule<Empty_>
+ */
+final class NoEmptyOnStringRule implements Rule
+{
+	public function getNodeType(): string
+	{
+		return Empty_::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$type = $scope->getType($node->expr);
+		// ?string and string|false still answer "is this an empty string?"
+		// with empty()'s '0' lie — strip the wrappers before deciding.
+		$bare = TypeCombinator::removeNull($type);
+		$bare = TypeCombinator::remove($bare, new ConstantBooleanType(false));
+		if ($bare instanceof NeverType || !$bare->isString()->yes()) {
+			return [];
+		}
+		return [
+			RuleErrorBuilder::message(
+				"empty() on a string operand lies: empty('0') is TRUE. " .
+				"Use pfb_is_empty() for ''/NULL or pfb_is_blank() for whitespace-only (issue #1787)."
+			)->identifier('pfBlockerNG.emptyOnString')->build(),
+		];
+	}
+}

--- a/tests/phpstan/fixtures/empty_on_string_compliant.php
+++ b/tests/phpstan/fixtures/empty_on_string_compliant.php
@@ -1,0 +1,17 @@
+<?php
+
+// Fixture for NoEmptyOnStringRuleTest: none of the empty() calls below sit on
+// a statically-string-typed operand, so NoEmptyOnStringRule MUST stay silent —
+// the gate bans the string lie, not empty() itself (issue #1787).
+
+function pfb_fixture_empty_on_array(array $rows): bool {
+	return empty($rows); // arrays are empty()'s legitimate use
+}
+
+function pfb_fixture_empty_on_untyped($config): bool {
+	return empty($config); // mixed/untyped legacy reads stay un-flagged
+}
+
+function pfb_fixture_exact_comparison(string $value): bool {
+	return $value === ''; // the honest check needs no helper to pass the gate
+}

--- a/tests/phpstan/fixtures/empty_on_string_violation.php
+++ b/tests/phpstan/fixtures/empty_on_string_violation.php
@@ -1,0 +1,18 @@
+<?php
+
+// Fixture for NoEmptyOnStringRuleTest: every empty() below sits on a
+// statically-string-typed operand and MUST be flagged by
+// PfBlockerNG\PHPStan\NoEmptyOnStringRule (issue #1787).
+
+function pfb_fixture_empty_on_string_param(string $value): bool {
+	return empty($value); // line 8: plain string
+}
+
+function pfb_fixture_empty_on_nullable_string(?string $value): bool {
+	return empty($value); // line 12: ?string still lies about '0'
+}
+
+function pfb_fixture_empty_on_string_or_false($haystack): bool {
+	$pos = strstr((string) $haystack, '/');
+	return empty($pos); // line 17: string|false — the false wrapper is stripped
+}


### PR DESCRIPTION
Part of #1787

## What

Honest string predicates and Unicode-aware strips, plus the flimsy call sites routed through them, plus a CI gate so the `empty()`-on-string pattern cannot re-grow.

### New helpers (`pfblockerng.inc`, next to `pfb_is_blank()`)

- `pfb_is_empty(?string): bool` — exact `''`/`NULL`. Unlike `empty()`, `'0'` is a real value. The single sanctioned "is this an empty string?" pattern going forward.
- `pfb_rstrip(string): string` — right-strip of ASCII + Unicode whitespace (`\s`, `\p{Z}`, BOM), fail-open on a pathological `preg_replace()`.
- `pfb_lstrip(string): string` — leading mirror, so "what is the first nonblank character?" is answerable (comment detection behind indentation).
- `pfb_strip(string): string` — double-sided, with an ASCII fast path (post-`trim()` ASCII bytes at both ends prove no Unicode whitespace remains) so hot per-line callers skip the preg passes.

### Call sites fixed (each with a red-first reproduction test)

- `pfb_is_blank_or_comment_line()` — raw `empty($line)` ate the valid line `0` (the in-tree instance named in the issue comment); now self-strips (Unicode class) and uses `pfb_is_empty()`.
- `pfb_dnsbl_is_skippable_control_line()` — same treatment, keeping the two helpers mirrored. Both flip the old caller-trims-first contract; the two explicit contract pins are updated.
- `pfb_get_hooks()`, `pfb_feed_redirect_target()`, `pfb_lint_sh/py_diagnostics()` — `trim() === ''` replaced with `pfb_is_blank()`, so Unicode-whitespace-only values read as blank (a NBSP "script"/Location/stderr is no longer content).
- `pfb_validate_suppression_line()` — blank/comment no-op judged on `pfb_strip()`'d line: an indented `#` (ASCII or NBSP) is a comment, not a malformed address.
- `pfb_sanitize_text_area()` — per-line right-strip now `pfb_rstrip()` (behaviour-preserving; existing suite is the oracle). `pfb_sanitize_text()` deliberately keeps its own trim dance: its pathological-run fail-open shape is pinned byte-for-byte and `pfb_strip`'s split passes degrade asymmetrically under that load.

### CI gate

Custom PHPStan rule `PfBlockerNG\PHPStan\NoEmptyOnStringRule` (registered in `phpstan.neon`, autoloaded via composer `autoload-dev`) bans `empty()` on statically-string-typed operands (`?string`/`string|false` wrappers included). Mixed/untyped operands (the legacy config-read idiom) stay silent — coverage grows as annotations tighten. The 129 pre-existing violations are baselined **additively** (no existing baseline lines touched: a local PHP 8.5 regen would drop 8.3-only entries the CI matrix still produces) as burn-down debt.

## Proof

- Reproduction tests executed RED on untouched code, frozen byte-identical, GREEN unchanged after each fix round (`Issue1787BlankEmptyCallSitesTest`: hashes `f349762d` → `eea50cea` → `0320fc10`).
- Gate red path demonstrated in-session: a planted string-typed `empty()` in `src/` fails `composer phpstan` (exit 1); removal returns `[OK]`. `NoEmptyOnStringRuleTest` pins both fire (string/`?string`/`string|false`) and silent (array/untyped/exact-`''`) sides against fixtures via the real binary + repo config.
- Full PHPUnit suite green (4337 tests), `composer phpstan` clean.

## Out of scope (remaining #1787 work)

The 29 `?:` sites arriving with PR #1774 (3 genuine `'0'` absurdities in `pfblockerng_alerts.php`/`pfblockerng_blacklist.php`) — per the issue comment's sequencing, that sweep runs after #1774 lands, with its own red-first proof per site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
