### PR TITLE
ci(tld-refresh): install Composer before the hook-gated PHP commit (#1793)

### DIFF
--- a/.github/workflows/tld-refresh.yml
+++ b/.github/workflows/tld-refresh.yml
@@ -68,11 +68,9 @@ jobs:
       - name: Activate git hooks
         run: sh scripts/setup-hooks.sh
 
-      # The refresh stages a .php file, so the pre-commit hook enters its PHP
-      # block: the fail-closed `composer vendor` gate plus PHPStan and PHPCS out
-      # of vendor/bin. Without a vendor tree the gate aborts the commit and every
-      # step after it (issue #1793). Unconditional so a dry_run dispatch still
-      # proves the install works on the runner.
+      # The refresh stages a .php file, so pre-commit enters its PHP block: the
+      # fail-closed `composer vendor` gate, then PHPStan and PHPCS out of
+      # vendor/bin (issue #1793). Ungated so every run exercises the install.
       - name: Install Composer dependencies for the pre-commit PHP gates
         run: composer install --no-interaction --prefer-dist --no-progress
 

--- a/.github/workflows/tld-refresh.yml
+++ b/.github/workflows/tld-refresh.yml
@@ -68,6 +68,14 @@ jobs:
       - name: Activate git hooks
         run: sh scripts/setup-hooks.sh
 
+      # The refresh stages a .php file, so the pre-commit hook enters its PHP
+      # block: the fail-closed `composer vendor` gate plus PHPStan and PHPCS out
+      # of vendor/bin. Without a vendor tree the gate aborts the commit and every
+      # step after it (issue #1793). Unconditional so a dry_run dispatch still
+      # proves the install works on the runner.
+      - name: Install Composer dependencies for the pre-commit PHP gates
+        run: composer install --no-interaction --prefer-dist --no-progress
+
       - name: Refresh arrays from IANA
         id: refresh
         run: |

--- a/.github/workflows/tld-refresh.yml
+++ b/.github/workflows/tld-refresh.yml
@@ -68,9 +68,25 @@ jobs:
       - name: Activate git hooks
         run: sh scripts/setup-hooks.sh
 
-      # The refresh stages a .php file, so pre-commit enters its PHP block: the
-      # fail-closed `composer vendor` gate, then PHPStan and PHPCS out of
-      # vendor/bin (issue #1793). Ungated so every run exercises the install.
+      - name: Fetch the ci-metadata orphan ref
+        # The reader reads origin/ci-metadata; checkout doesn't bring orphan refs.
+        run: git fetch --no-tags --depth=1 origin ci-metadata:refs/remotes/origin/ci-metadata
+
+      - name: Read the supported PHP versions
+        id: matrix
+        uses: ./.github/actions/read-version-matrix
+
+      # The refresh stages a .php file, so pre-commit enters its PHP block: php -l,
+      # PHPStan and PHPCS out of vendor/bin (issue #1793). They run on the OLDEST
+      # supported PHP — the floor a diagnostic has to clear — never the runner default.
+      - name: Set up PHP ${{ fromJSON(steps.matrix.outputs.php_versions)[0] }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ fromJSON(steps.matrix.outputs.php_versions)[0] }}
+          tools: composer
+
+      # Ungated so every run exercises the install: a lock or platform break then
+      # surfaces weekly instead of only on a drift week.
       - name: Install Composer dependencies for the pre-commit PHP gates
         run: composer install --no-interaction --prefer-dist --no-progress
 

--- a/scripts/read-version-matrix.sh
+++ b/scripts/read-version-matrix.sh
@@ -227,6 +227,13 @@ if [ "$(printf '%s' "$BUILD_MATRIX" | jq 'length')" -gt 0 ]; then
   fi
 fi
 
+# Ordered by VERSION, not by string: `unique` alone puts "8.10" before "8.2",
+# handing a consumer that reads element [0] as the supported floor the newest
+# version instead of the oldest. Sorted AFTER the guards above, which own the
+# diagnostics for a null/empty version that split() would only crash on.
+PYTHON_VERSIONS="$(printf '%s' "$PYTHON_VERSIONS" | jq -c 'sort_by(split(".") | map(tonumber))')"
+PHP_VERSIONS="$(printf '%s' "$PHP_VERSIONS" | jq -c 'sort_by(split(".") | map(tonumber))')"
+
 if [ "$DO_GITHUB_OUTPUT" -eq 1 ]; then
   if [ -z "${GITHUB_OUTPUT:-}" ]; then
     printf '::error::GITHUB_OUTPUT is not set — cannot write step outputs\n' >&2

--- a/tests/test_ci_refresh_composer_vendor.py
+++ b/tests/test_ci_refresh_composer_vendor.py
@@ -1,0 +1,104 @@
+"""Guard: a workflow that commits a PHP file under the git hooks installs Composer first.
+
+Issue #1793: tld-refresh.yml activates the repository git hooks on purpose
+("automated commits must hit the same local gates as a human commit"), then
+stages src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php and commits. Staging
+a PHP-family file sets `staged_php=1` in .githooks/pre-commit, which runs the
+fail-closed `composer vendor` gate and, behind it, PHPStan and PHPCS out of
+vendor/bin. With no `composer install` on the runner there is no vendor tree,
+the gate fails closed, and the whole refresh -- commit, push, PR, CI dispatch --
+is aborted. The gate is right to fail; the workflow was missing its half of the
+contract.
+
+The invariant is stated over every workflow rather than over tld-refresh alone:
+the next automation that opts into the hooks and touches a PHP file inherits the
+same requirement, and the same latent break (tld-refresh only failed the week
+IANA actually drifted -- a no-change week never reaches the commit).
+
+Text-parsed rather than PyYAML, following the house idiom in
+tests/test_ci_tool_pins.py and tests/test_ci_checkout_persist_credentials.py:
+test.yml's "Install test dependencies" step installs no YAML parser.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS_DIR = ROOT / ".github" / "workflows"
+_WORKFLOW_GLOBS = ("*.yml", "*.yaml")
+
+# `staged_php` in .githooks/pre-commit is set from these two suffixes.
+_PHP_SUFFIXES = (".php", ".inc")
+
+_HOOKS_RE = re.compile(r"scripts/setup-hooks\.sh")
+_GIT_ADD_RE = re.compile(r"\bgit add\b(?P<paths>[^\n#]*)")
+_GIT_COMMIT_RE = re.compile(r"\bgit commit\b")
+_COMPOSER_INSTALL_RE = re.compile(r"\bcomposer install\b")
+
+
+def _workflow_files() -> list[Path]:
+    """Every workflow file under WORKFLOWS_DIR, `.yml` and `.yaml` alike.
+
+    GitHub Actions loads either extension, so globbing only `*.yml` would be a
+    silent bypass. Keyed by filename so the two globs cannot double-count.
+    """
+    by_name: dict[str, Path] = {}
+    for pattern in _WORKFLOW_GLOBS:
+        for path in WORKFLOWS_DIR.glob(pattern):
+            by_name.setdefault(path.name, path)
+    return [by_name[name] for name in sorted(by_name)]
+
+
+def _stages_php(text: str) -> bool:
+    """True if the workflow stages a path the pre-commit PHP block reacts to."""
+    for match in _GIT_ADD_RE.finditer(text):
+        for token in match.group("paths").split():
+            if token.endswith(_PHP_SUFFIXES):
+                return True
+    return False
+
+
+def _first_line_matching(lines: list[str], pattern: re.Pattern[str]) -> int | None:
+    """1-based line number of the first match, or None."""
+    for number, line in enumerate(lines, start=1):
+        if pattern.search(line):
+            return number
+    return None
+
+
+def test_php_staging_workflows_install_composer_before_committing() -> None:
+    """A hook-running workflow that stages PHP has a vendor tree by commit time.
+
+    Scenario: the pre-commit `composer vendor` gate is fail-closed.
+    Given a workflow that activates .githooks and stages a .php/.inc file,
+    when it reaches `git commit`, then `composer install` must already have run
+    -- otherwise the gate aborts the commit and every step that follows it.
+    """
+    offenders: list[str] = []
+    inspected: list[str] = []
+
+    for path in _workflow_files():
+        text = path.read_text(encoding="utf-8")
+        if not _HOOKS_RE.search(text) or not _stages_php(text):
+            continue
+        inspected.append(path.name)
+
+        lines = text.splitlines()
+        install_line = _first_line_matching(lines, _COMPOSER_INSTALL_RE)
+        commit_line = _first_line_matching(lines, _GIT_COMMIT_RE)
+
+        if install_line is None:
+            offenders.append(f"{path.name}: stages PHP under the git hooks but never runs `composer install`")
+        elif commit_line is not None and install_line > commit_line:
+            offenders.append(
+                f"{path.name}: `composer install` at line {install_line} runs after `git commit` at line {commit_line}"
+            )
+
+    assert inspected, (
+        "no workflow both activates .githooks and stages a PHP file -- the guard has "
+        "nothing to protect, which means it silently stopped matching (check the "
+        "`git add` / setup-hooks.sh shapes it looks for)"
+    )
+    assert not offenders, (
+        "expected every PHP-staging workflow to install Composer before committing; got:\n" + "\n".join(offenders)
+    )

--- a/tests/test_ci_refresh_composer_vendor.py
+++ b/tests/test_ci_refresh_composer_vendor.py
@@ -40,7 +40,9 @@ _BROAD_PATHSPECS = frozenset({"-A", "--all", ".", "-u", "--update", "*", ":/"})
 
 # Both ways a workflow can put .githooks in front of its own commit.
 _HOOKS_RE = re.compile(r"scripts/setup-hooks\.sh|core\.hooksPath")
-_GIT_ADD_RE = re.compile(r"\bgit add\b(?P<paths>[^\n#]*)")
+# Pathspecs end at the first shell separator: a `.php` in the message of a
+# chained `git commit` is not a staged path.
+_GIT_ADD_RE = re.compile(r"\bgit add\b(?P<paths>[^\n#;|&]*)")
 _GIT_COMMIT_RE = re.compile(r"\bgit commit\b")
 _COMPOSER_INSTALL_RE = re.compile(r"\bcomposer install\b")
 
@@ -121,7 +123,11 @@ def _stages_php(lines: list[str]) -> bool:
                     continue
                 if token in _BROAD_PATHSPECS or token.endswith(_PHP_SUFFIXES):
                     return True
-                if token.endswith("/") or (ROOT / token).is_dir():
+                # An absolute pathspec points outside this checkout, so it can
+                # only be judged as broad -- never resolved against ROOT.
+                if token.startswith("/") or token.endswith("/"):
+                    return True
+                if (ROOT / token).is_dir():
                     return True
     return False
 
@@ -336,3 +342,33 @@ def test_guard_passes_a_job_that_installs_composer_first() -> None:
     )
     assert inspected == ["synthetic.yml:refresh"]
     assert offenders == []
+
+
+def test_guard_stops_reading_pathspecs_at_a_shell_separator() -> None:
+    """A `.php` mentioned in a chained commit message is not a staged path."""
+    offenders, inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  refresh:\n"
+        "    steps:\n"
+        "      - run: sh scripts/setup-hooks.sh\n"
+        '      - run: git add docs/notes.md && git commit -m "mention foo.php in the notes"\n',
+    )
+    assert inspected == []
+    assert offenders == []
+
+
+def test_guard_treats_an_absolute_pathspec_as_broad() -> None:
+    """An absolute pathspec is judged on its own terms, not against this checkout."""
+    offenders, inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  refresh:\n"
+        "    steps:\n"
+        "      - run: sh scripts/setup-hooks.sh\n"
+        "      - run: |\n"
+        "          git add /home/runner/work/pfBlockerNG/pfBlockerNG/src\n"
+        "          git commit -m 'x'\n",
+    )
+    assert inspected == ["synthetic.yml:refresh"]
+    assert offenders

--- a/tests/test_ci_refresh_composer_vendor.py
+++ b/tests/test_ci_refresh_composer_vendor.py
@@ -44,6 +44,12 @@ _GIT_ADD_RE = re.compile(r"\bgit add\b(?P<paths>[^\n#]*)")
 _GIT_COMMIT_RE = re.compile(r"\bgit commit\b")
 _COMPOSER_INSTALL_RE = re.compile(r"\bcomposer install\b")
 
+# The hook's php -l / PHPStan / PHPCS gates must run on a supported PHP, which
+# means setup-php fed from read-version-matrix rather than the runner default.
+_SETUP_PHP_RE = re.compile(r"uses:\s*shivammathur/setup-php@")
+_PHP_VERSION_RE = re.compile(r"php-version:\s*(?P<value>\S.*?)\s*$")
+_MATRIX_OUTPUT_RE = re.compile(r"outputs\.php_versions")
+
 # A job key: exactly two spaces of indent under the top-level `jobs:` mapping.
 _JOB_KEY_RE = re.compile(r"^ {2}(?P<name>[A-Za-z0-9_.-]+):\s*(#.*)?$")
 _JOBS_ROOT_RE = re.compile(r"^jobs:\s*(#.*)?$")
@@ -128,17 +134,19 @@ def _first_line_matching(lines: list[str], pattern: re.Pattern[str]) -> int | No
     return None
 
 
-def _offenders(name: str, text: str) -> tuple[list[str], list[str]]:
-    """(offending job descriptions, inspected job labels) for one workflow."""
+def _hook_php_jobs(text: str) -> list[tuple[str, int, list[str]]]:
+    """Every job in this workflow that stages PHP with .githooks active."""
     lines = _code_lines(text)
     if not _HOOKS_RE.search("\n".join(lines)):
-        return [], []
+        return []
+    return [job for job in _jobs(lines) if _stages_php(job[2])]
 
+
+def _offenders(name: str, text: str) -> tuple[list[str], list[str]]:
+    """(offending job descriptions, inspected job labels) for one workflow."""
     offenders: list[str] = []
     inspected: list[str] = []
-    for job, job_start, job_lines in _jobs(lines):
-        if not _stages_php(job_lines):
-            continue
+    for job, job_start, job_lines in _hook_php_jobs(text):
         inspected.append(f"{name}:{job}")
 
         install_offset = _first_line_matching(job_lines, _COMPOSER_INSTALL_RE)
@@ -176,6 +184,39 @@ def test_php_staging_jobs_install_composer_before_committing() -> None:
         "this guard rather than leaving it vacuous"
     )
     assert not offenders, "expected every PHP-staging job to install Composer before committing; got:\n" + "\n".join(
+        offenders
+    )
+
+
+def test_php_staging_jobs_pin_php_from_the_version_matrix() -> None:
+    """The hook's PHP gates run on a supported PHP, not on whatever the runner ships.
+
+    Scenario: .githooks/pre-commit runs php -l, PHPStan and PHPCS.
+    Given a job that puts those gates in front of its own commit,
+    when the runner image changes its default PHP,
+    then the gates must still run on a version supported-versions.json ships --
+    so the PHP version comes from read-version-matrix, never from the ambient
+    runner default and never from a literal restating the matrix.
+    """
+    offenders: list[str] = []
+    for path in _workflow_files():
+        for job, _, job_lines in _hook_php_jobs(path.read_text(encoding="utf-8")):
+            if _first_line_matching(job_lines, _SETUP_PHP_RE) is None:
+                offenders.append(f"{path.name}: job `{job}` runs the hook PHP gates on the runner's ambient PHP")
+                continue
+            pinned = [
+                match.group("value")
+                for line in job_lines
+                if (match := _PHP_VERSION_RE.search(line))
+                if not _MATRIX_OUTPUT_RE.search(match.group("value"))
+            ]
+            if pinned:
+                offenders.append(
+                    f"{path.name}: job `{job}` pins php-version to {', '.join(pinned)} "
+                    "instead of a read-version-matrix output"
+                )
+
+    assert not offenders, "expected every PHP-staging job to take its PHP version from the matrix; got:\n" + "\n".join(
         offenders
     )
 

--- a/tests/test_ci_refresh_composer_vendor.py
+++ b/tests/test_ci_refresh_composer_vendor.py
@@ -1,4 +1,4 @@
-"""Guard: a workflow that commits a PHP file under the git hooks installs Composer first.
+"""Guard: a job that commits a PHP file under the git hooks installs Composer first.
 
 Issue #1793: tld-refresh.yml activates the repository git hooks on purpose
 ("automated commits must hit the same local gates as a human commit"), then
@@ -15,6 +15,11 @@ the next automation that opts into the hooks and touches a PHP file inherits the
 same requirement, and the same latent break (tld-refresh only failed the week
 IANA actually drifted -- a no-change week never reaches the commit).
 
+Scoped per JOB, not per file: two jobs are two runners with no shared
+filesystem, so `composer install` in one does nothing for a commit in the other.
+Staging detection is fail-closed -- a broad pathspec (`-A`, `.`, a directory)
+counts as PHP-staging, because it can sweep one in.
+
 Text-parsed rather than PyYAML, following the house idiom in
 tests/test_ci_tool_pins.py and tests/test_ci_checkout_persist_credentials.py:
 test.yml's "Install test dependencies" step installs no YAML parser.
@@ -30,10 +35,18 @@ _WORKFLOW_GLOBS = ("*.yml", "*.yaml")
 # `staged_php` in .githooks/pre-commit is set from these two suffixes.
 _PHP_SUFFIXES = (".php", ".inc")
 
-_HOOKS_RE = re.compile(r"scripts/setup-hooks\.sh")
+# Pathspecs that can sweep in a PHP file without naming one.
+_BROAD_PATHSPECS = frozenset({"-A", "--all", ".", "-u", "--update", "*", ":/"})
+
+# Both ways a workflow can put .githooks in front of its own commit.
+_HOOKS_RE = re.compile(r"scripts/setup-hooks\.sh|core\.hooksPath")
 _GIT_ADD_RE = re.compile(r"\bgit add\b(?P<paths>[^\n#]*)")
 _GIT_COMMIT_RE = re.compile(r"\bgit commit\b")
 _COMPOSER_INSTALL_RE = re.compile(r"\bcomposer install\b")
+
+# A job key: exactly two spaces of indent under the top-level `jobs:` mapping.
+_JOB_KEY_RE = re.compile(r"^ {2}(?P<name>[A-Za-z0-9_.-]+):\s*(#.*)?$")
+_JOBS_ROOT_RE = re.compile(r"^jobs:\s*(#.*)?$")
 
 
 def _workflow_files() -> list[Path]:
@@ -49,56 +62,236 @@ def _workflow_files() -> list[Path]:
     return [by_name[name] for name in sorted(by_name)]
 
 
-def _stages_php(text: str) -> bool:
-    """True if the workflow stages a path the pre-commit PHP block reacts to."""
-    for match in _GIT_ADD_RE.finditer(text):
-        for token in match.group("paths").split():
-            if token.endswith(_PHP_SUFFIXES):
-                return True
+def _code_lines(text: str) -> list[str]:
+    """The file's lines with whole-line comments blanked out.
+
+    A commented-out or documented `git add src/foo.php` is prose, not an
+    invocation, and must not be read as one. Blanked rather than dropped so
+    line numbers stay usable in failure messages.
+    """
+    return ["" if line.lstrip().startswith("#") else line for line in text.splitlines()]
+
+
+def _jobs(lines: list[str]) -> list[tuple[str, int, list[str]]]:
+    """Every job as (name, 1-based first line, its own lines).
+
+    Two jobs are two runners with no shared filesystem, so the Composer/commit
+    ordering only means anything within one job.
+    """
+    starts: list[tuple[str, int]] = []
+    in_jobs = False
+    for index, line in enumerate(lines):
+        if _JOBS_ROOT_RE.match(line):
+            in_jobs = True
+            continue
+        if not in_jobs:
+            continue
+        # A non-blank line at column 0 ends the `jobs:` mapping.
+        if line.strip() and not line.startswith(" "):
+            break
+        match = _JOB_KEY_RE.match(line)
+        if match:
+            starts.append((match.group("name"), index))
+
+    jobs: list[tuple[str, int, list[str]]] = []
+    for position, (name, start) in enumerate(starts):
+        end = starts[position + 1][1] if position + 1 < len(starts) else len(lines)
+        jobs.append((name, start + 1, lines[start:end]))
+    return jobs
+
+
+def _stages_php(lines: list[str]) -> bool:
+    """True if these lines stage something the pre-commit PHP block reacts to.
+
+    Fail-closed: a pathspec that merely *can* contain a PHP file -- `-A`, `.`,
+    a directory -- counts, since the gate fires on what the pathspec resolved
+    to, not on what the workflow spelled out.
+    """
+    for line in lines:
+        for match in _GIT_ADD_RE.finditer(line):
+            for raw in match.group("paths").split():
+                token = raw.strip("\"'")
+                if not token:
+                    continue
+                if token in _BROAD_PATHSPECS or token.endswith(_PHP_SUFFIXES):
+                    return True
+                if token.endswith("/") or (ROOT / token).is_dir():
+                    return True
     return False
 
 
 def _first_line_matching(lines: list[str], pattern: re.Pattern[str]) -> int | None:
-    """1-based line number of the first match, or None."""
+    """1-based offset within `lines` of the first match, or None."""
     for number, line in enumerate(lines, start=1):
         if pattern.search(line):
             return number
     return None
 
 
-def test_php_staging_workflows_install_composer_before_committing() -> None:
-    """A hook-running workflow that stages PHP has a vendor tree by commit time.
+def _offenders(name: str, text: str) -> tuple[list[str], list[str]]:
+    """(offending job descriptions, inspected job labels) for one workflow."""
+    lines = _code_lines(text)
+    if not _HOOKS_RE.search("\n".join(lines)):
+        return [], []
+
+    offenders: list[str] = []
+    inspected: list[str] = []
+    for job, job_start, job_lines in _jobs(lines):
+        if not _stages_php(job_lines):
+            continue
+        inspected.append(f"{name}:{job}")
+
+        install_offset = _first_line_matching(job_lines, _COMPOSER_INSTALL_RE)
+        commit_offset = _first_line_matching(job_lines, _GIT_COMMIT_RE)
+        if install_offset is None:
+            offenders.append(f"{name}: job `{job}` stages PHP under the git hooks but never runs `composer install`")
+        elif commit_offset is not None and install_offset > commit_offset:
+            offenders.append(
+                f"{name}: job `{job}` runs `composer install` at line {job_start + install_offset - 1}, "
+                f"after `git commit` at line {job_start + commit_offset - 1}"
+            )
+    return offenders, inspected
+
+
+def test_php_staging_jobs_install_composer_before_committing() -> None:
+    """A hook-running job that stages PHP has a vendor tree by commit time.
 
     Scenario: the pre-commit `composer vendor` gate is fail-closed.
-    Given a workflow that activates .githooks and stages a .php/.inc file,
+    Given a job that activates .githooks and stages a .php/.inc file,
     when it reaches `git commit`, then `composer install` must already have run
-    -- otherwise the gate aborts the commit and every step that follows it.
+    in that same job -- otherwise the gate aborts the commit and every step
+    that follows it.
     """
     offenders: list[str] = []
     inspected: list[str] = []
-
     for path in _workflow_files():
-        text = path.read_text(encoding="utf-8")
-        if not _HOOKS_RE.search(text) or not _stages_php(text):
-            continue
-        inspected.append(path.name)
-
-        lines = text.splitlines()
-        install_line = _first_line_matching(lines, _COMPOSER_INSTALL_RE)
-        commit_line = _first_line_matching(lines, _GIT_COMMIT_RE)
-
-        if install_line is None:
-            offenders.append(f"{path.name}: stages PHP under the git hooks but never runs `composer install`")
-        elif commit_line is not None and install_line > commit_line:
-            offenders.append(
-                f"{path.name}: `composer install` at line {install_line} runs after `git commit` at line {commit_line}"
-            )
+        found, seen = _offenders(path.name, path.read_text(encoding="utf-8"))
+        offenders.extend(found)
+        inspected.extend(seen)
 
     assert inspected, (
-        "no workflow both activates .githooks and stages a PHP file -- the guard has "
-        "nothing to protect, which means it silently stopped matching (check the "
-        "`git add` / setup-hooks.sh shapes it looks for)"
+        "no job both activates .githooks and stages a PHP file. Either the shapes this guard "
+        "looks for (`git add` pathspecs, setup-hooks.sh / core.hooksPath) stopped matching and "
+        "it now protects nothing, or no workflow runs the hooks any more -- in which case delete "
+        "this guard rather than leaving it vacuous"
     )
-    assert not offenders, (
-        "expected every PHP-staging workflow to install Composer before committing; got:\n" + "\n".join(offenders)
+    assert not offenders, "expected every PHP-staging job to install Composer before committing; got:\n" + "\n".join(
+        offenders
     )
+
+
+def test_guard_flags_a_job_that_stages_php_without_installing_composer() -> None:
+    """The guard's own red path: the exact shape of issue #1793."""
+    offenders, inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  refresh:\n"
+        "    steps:\n"
+        "      - run: sh scripts/setup-hooks.sh\n"
+        "      - run: |\n"
+        "          git add src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php\n"
+        "          git commit -m 'refresh'\n",
+    )
+    assert inspected == ["synthetic.yml:refresh"]
+    assert offenders == [
+        "synthetic.yml: job `refresh` stages PHP under the git hooks but never runs `composer install`"
+    ]
+
+
+def test_guard_flags_composer_installed_in_a_different_job() -> None:
+    """Two jobs are two runners: an install in job A leaves job B without vendor/."""
+    offenders, _ = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  prepare:\n"
+        "    steps:\n"
+        "      - run: composer install\n"
+        "  refresh:\n"
+        "    steps:\n"
+        "      - run: sh scripts/setup-hooks.sh\n"
+        "      - run: |\n"
+        "          git add src/foo.php\n"
+        "          git commit -m 'x'\n",
+    )
+    assert offenders == [
+        "synthetic.yml: job `refresh` stages PHP under the git hooks but never runs `composer install`"
+    ]
+
+
+def test_guard_flags_composer_installed_after_the_commit() -> None:
+    """Ordering matters: a vendor tree built after the commit is built too late."""
+    offenders, _ = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  refresh:\n"
+        "    steps:\n"
+        "      - run: git config core.hooksPath .githooks\n"
+        "      - run: |\n"
+        "          git add src/foo.inc\n"
+        "          git commit -m 'x'\n"
+        "      - run: composer install\n",
+    )
+    assert offenders == ["synthetic.yml: job `refresh` runs `composer install` at line 8, after `git commit` at line 7"]
+
+
+def test_guard_treats_a_broad_pathspec_as_php_staging() -> None:
+    """`git add -A` can sweep in a PHP file, so it is judged as if it did."""
+    offenders, inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  refresh:\n"
+        "    steps:\n"
+        "      - run: sh scripts/setup-hooks.sh\n"
+        "      - run: |\n"
+        "          git add -A\n"
+        "          git commit -m 'x'\n",
+    )
+    assert inspected == ["synthetic.yml:refresh"]
+    assert offenders
+
+
+def test_guard_ignores_a_git_add_that_is_only_a_comment() -> None:
+    """A documented `git add` is prose; only real invocations are judged."""
+    offenders, inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  refresh:\n"
+        "    steps:\n"
+        "      # e.g. git add src/foo.php\n"
+        "      - run: sh scripts/setup-hooks.sh\n"
+        "      - run: git add docs/notes.md\n",
+    )
+    assert inspected == []
+    assert offenders == []
+
+
+def test_guard_sees_through_a_quoted_pathspec() -> None:
+    """Quoting a path does not hide it from the gate, so it does not hide it here."""
+    _, inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  refresh:\n"
+        "    steps:\n"
+        "      - run: sh scripts/setup-hooks.sh\n"
+        "      - run: composer install\n"
+        '      - run: git add "src/foo.php"\n'
+        "      - run: git commit -m 'x'\n",
+    )
+    assert inspected == ["synthetic.yml:refresh"]
+
+
+def test_guard_passes_a_job_that_installs_composer_first() -> None:
+    """The fixed shape: install, then stage, then commit -- no finding."""
+    offenders, inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  refresh:\n"
+        "    steps:\n"
+        "      - run: sh scripts/setup-hooks.sh\n"
+        "      - run: composer install --no-interaction\n"
+        "      - run: |\n"
+        "          git add src/foo.php\n"
+        "          git commit -m 'x'\n",
+    )
+    assert inspected == ["synthetic.yml:refresh"]
+    assert offenders == []

--- a/tests/test_read_version_matrix.py
+++ b/tests/test_read_version_matrix.py
@@ -454,3 +454,28 @@ def test_invalid_role_fails_closed(tmp_path: Path) -> None:
 
     assert proc.returncode != 0, f"reader must fail on an invalid role; stdout:\n{proc.stdout}"
     assert "invalid role" in proc.stderr, f"expected an 'invalid role' error; stderr:\n{proc.stderr}"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario — the derived test matrices are ordered by VERSION, not by string.
+# --------------------------------------------------------------------------- #
+def test_test_matrices_sort_versions_numerically(tmp_path: Path) -> None:
+    """The oldest supported version is first, even once a minor reaches two digits.
+
+    Scenario: a consumer picks the supported floor as element [0].
+    Given a matrix shipping PHP 8.2 alongside 8.10 (and Python 3.9 alongside 3.11),
+    when the derived test matrices are read,
+    then 8.2 and 3.9 come first -- a string sort would put "8.10" and "3.11"
+    there instead and silently hand the consumer the newest version.
+    """
+    repo = _make_matrix_ref(
+        tmp_path,
+        [
+            _ce_entry(php_version="8.10", py_flavor="py311"),
+            _plus_entry(php_version="8.2", py_flavor="py39", ci=True),
+        ],
+    )
+    python_versions, php_versions = _test_matrices(repo)
+
+    assert php_versions == ["8.2", "8.10"], f"php_versions must be version-ordered; got {php_versions!r}"
+    assert python_versions == ["3.9", "3.11"], f"python_versions must be version-ordered; got {python_versions!r}"


### PR DESCRIPTION
## Problem

The weekly **TLD List Refresh** aborts whenever IANA actually drifts — run [30255946223](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/30255946223):

```
[pre-commit] composer vendor
missing vendor directory: /home/runner/work/pfBlockerNG/pfBlockerNG/vendor
remediation: composer install --no-interaction
[pre-commit] FAILED: composer vendor
```

`tld-refresh.yml` activates the repository git hooks on purpose ("automated commits must hit the same local gates as a human commit"), then stages `src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php`. Staging a PHP-family file sets `staged_php=1` in `.githooks/pre-commit`, which runs the fail-closed `composer vendor` gate and, behind it, PHPStan and PHPCS out of `vendor/bin`. The runner never installed the Composer dependencies, so the gate failed closed and took the commit, the push, the PR, and the CI dispatch with it.

The gate is correct — the PHP analysis tools are unsafe against a missing or stale vendor tree. The workflow was missing its half of the contract.

The break has been latent since the workflow started running the hooks; the two prior runs (2026-07-20, 2026-07-13) were green only because IANA had not drifted, so no commit was attempted.

Only `tld-refresh` is affected. `hsts-refresh` stages `pfb_py_hsts.txt` and `psl-refresh` stages `dnsbl_tld` — both data files, so neither enters the PHP block.

## Change

One step in `tld-refresh.yml`, right after the hooks are activated:

```yaml
      - name: Install Composer dependencies for the pre-commit PHP gates
        run: composer install --no-interaction --prefer-dist --no-progress
```

Unconditional rather than gated on `steps.refresh.outputs.changed`, so a `dry_run` dispatch still exercises it.

## Test

`tests/test_ci_refresh_composer_vendor.py` states the invariant over every workflow rather than over `tld-refresh` alone: the next automation that opts into the hooks and touches a PHP file inherits the same requirement. It also rejects an install ordered *after* the commit. Text-parsed, following the house idiom in `test_ci_tool_pins.py` and `test_ci_checkout_persist_credentials.py` (test.yml installs no YAML parser).

Red before the fix:

```
AssertionError: expected every PHP-staging workflow to install Composer before committing; got:
  tld-refresh.yml: stages PHP under the git hooks but never runs `composer install`
```

Green after, test file byte-identical across both runs (`git hash-object` = `46191a29b5bc5cdb1e69dc1bd45cec85c8ee325e`; the subsequent `ruff format` pass is post-green). Full suite: 3566 passed, 4 skipped.

## Out of scope

`hsts-refresh` and `psl-refresh` currently fail later, at `pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)`. That is a repository/organisation Actions setting, not a code defect, and is handled separately.

Fixes #1793
