### PR TITLE
pfblockerng: decode Alerts customlists with $idn=TRUE

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -253,7 +253,10 @@ if (!$alert_summary) {
 
 					$clists[$type]['options'][] = $lname;	// List of all Permit Aliases/DNSBL Customlists
 
-					$decoded = pfb_text_area_decode($data['custom'], TRUE, TRUE);
+					// issue #1782: $idn=TRUE -- matches pfblockerng_apply.inc:1758's decode of
+					// this SAME per-row 'custom' field; a Unicode key here would never match
+					// a $domain derived from a punycode log field.
+					$decoded = pfb_text_area_decode($data['custom'], TRUE, TRUE, TRUE);
 					if (!empty($decoded)) {
 						foreach ($decoded as $line) {
 
@@ -311,7 +314,10 @@ if (!$alert_summary) {
 
 		$clists[$type]['data']		= array();
 		if (isset($clists[$type]['base64']) && !empty($clists[$type]['base64'])) {
-			$decoded = pfb_text_area_decode($clists[$type]['base64'], TRUE, TRUE);
+			// issue #1782: $idn=TRUE -- 'suppression'/'tldexclusion' are decoded with
+			// $idn=TRUE by their runtime consumers (pfblockerng.inc); a Unicode key
+			// here would never match a $domain derived from a punycode log field.
+			$decoded = pfb_text_area_decode($clists[$type]['base64'], TRUE, TRUE, TRUE);
 			if (!empty($decoded)) {
 				foreach ($decoded as $line) {
 

--- a/tests/php/AlertsCustomlistDecodeLoader.php
+++ b/tests/php/AlertsCustomlistDecodeLoader.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Issue #1782: eval the REAL "decode a Custom_List/Suppression/Exclusion textarea
+ * into the Alerts page's domain-keyed lookup map" statements straight out of
+ * pfblockerng_alerts.php -- not a hand-copied stand-in -- so a red run against the
+ * file BEFORE the $idn fix genuinely exercises the buggy call, and the SAME test
+ * goes green once the call site is fixed, with zero test edits. Two call sites,
+ * two extractors (AlertsPageLoader.php's docblock explains why this file cannot
+ * reuse its function-block eval: this code is top-level script, not inside a
+ * function). No production file is modified to make it testable.
+ */
+
+/**
+ * The 'ipsuppression'/'ipsuppression_v6'/'dnsblwhitelist'/'tldexclusion' loop's
+ * decode block (pfblockerng_alerts.php, inside the `foreach (array(...) as $key
+ * => $type)` loop). Pre-seeds $clists[$type]['base64'] and evals the assignment +
+ * if-block verbatim; $type/$clists never leak (function-local `eval()` scope).
+ */
+function pfb_test_alerts_decode_suppression_list(string $type, string $base64): array
+{
+	static $snippet = null;
+	if ($snippet === null) {
+		$snippet = pfb_test_alerts_extract_block(
+			"\t\t\$clists[\$type]['data']\t\t= array();\n\t\tif (isset(\$clists[\$type]['base64'])"
+		);
+	}
+	$clists = [$type => ['base64' => $base64]];
+	eval($snippet);
+	return $clists[$type]['data'] ?? [];
+}
+
+/**
+ * The per-DNSBL-group/per-IP-alias custom list decode block (pfblockerng_alerts.php,
+ * inside the `foreach ($c_config['config'] as $row => $data)` loop). Pre-seeds
+ * $data['custom']/$type/$lname and evals the decode-assignment + if-block verbatim.
+ */
+function pfb_test_alerts_decode_group_customlist(string $type, string $lname, string $custom): array
+{
+	static $snippet = null;
+	if ($snippet === null) {
+		$snippet = pfb_test_alerts_extract_block(
+			"\$decoded = pfb_text_area_decode(\$data['custom'],"
+		);
+	}
+	$clists = [$type => [$lname => ['data' => []]]];
+	$data = ['custom' => $custom];
+	eval($snippet);
+	return $clists[$type][$lname]['data'] ?? [];
+}
+
+/** Depth-match the enclosing brace block starting at $marker's position (same technique as RegexIniTransportTest::functionBody()). */
+function pfb_test_alerts_extract_block(string $marker): string
+{
+	$src = file_get_contents(
+		dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
+	);
+	if ($src === false) {
+		throw new RuntimeException('failed to read pfblockerng_alerts.php');
+	}
+	$start = strpos($src, $marker);
+	if ($start === false) {
+		throw new RuntimeException("could not locate marker in pfblockerng_alerts.php: {$marker}");
+	}
+	$open = strpos($src, '{', $start);
+	if ($open === false) {
+		throw new RuntimeException('no opening brace found after marker');
+	}
+	$depth = 0;
+	for ($i = $open, $len = strlen($src); $i < $len; $i++) {
+		if ($src[$i] === '{') {
+			$depth++;
+		} elseif ($src[$i] === '}') {
+			$depth--;
+			if ($depth === 0) {
+				return substr($src, $start, $i - $start + 1);
+			}
+		}
+	}
+	throw new RuntimeException('closing brace missing for the extracted block');
+}

--- a/tests/php/AlertsCustomlistIdnRecognitionTest.php
+++ b/tests/php/AlertsCustomlistIdnRecognitionTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1782: pfblockerng_alerts.php decodes its Custom_List/Suppression/Exclusion
+ * customlists WITHOUT $idn=TRUE, so a Unicode row keys the Alerts page's lookup map by
+ * the raw Unicode label -- while every runtime consumer (pfb_dnsbl_whitelist_lines(),
+ * the TLD-wildcard manifest builder) and the DNSBL log fields compared against that map
+ * (dnsbl.log's evaluated-domain field) carry the punycode form. The row never matches:
+ * "add to exclusion"/"already whitelisted" recognition silently fails and a duplicate
+ * gets appended instead.
+ *
+ * Uses the REAL decode statements (AlertsCustomlistDecodeLoader.php evals them straight
+ * out of pfblockerng_alerts.php) so this test is red against the unfixed call sites and
+ * green once they pass $idn=TRUE, with no test edits either side.
+ */
+#[CoversFunction('dnsbl_log_details')]
+#[CoversFunction('dnsbl_whitelist_type')]
+final class AlertsCustomlistIdnRecognitionTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/AlertsPageLoader.php';
+		require_once __DIR__ . '/AlertsCustomlistDecodeLoader.php';
+		pfb_test_load_alerts_page_functions();
+	}
+
+	/**
+	 * Run $fn under the C locale (see TextAreaDecodeTest::underCLocale() -- the IDN
+	 * branch is gated on !ctype_print(), which is locale-sensitive).
+	 */
+	private static function underCLocale(callable $fn): void
+	{
+		$prev = setlocale(LC_CTYPE, '0');
+		setlocale(LC_CTYPE, 'C');
+		try {
+			$fn();
+		} finally {
+			setlocale(LC_CTYPE, $prev);
+		}
+	}
+
+	private static function enc(string $line): string
+	{
+		return base64_encode($line);
+	}
+
+	// -------------------------------------------------------------------
+	// alerts.php's 'ipsuppression'/'ipsuppression_v6'/'dnsblwhitelist'/'tldexclusion'
+	// decode loop must key its map by punycode, matching every runtime decoder.
+	// -------------------------------------------------------------------
+
+	public function testTldExclusionRowKeyedByPunycodeNotUnicode(): void
+	{
+		self::underCLocale(function (): void {
+			$data = pfb_test_alerts_decode_suppression_list('tldexclusion', self::enc('bücher.de'));
+
+			$this->assertArrayHasKey('xn--bcher-kva.de', $data, 'expected the punycode key the log/runtime carry');
+			$this->assertArrayNotHasKey('bücher.de', $data, 'a raw-Unicode key can never match a punycode log field');
+		});
+	}
+
+	/**
+	 * The named issue scenario: an IDN TLD-exclusion row entered on the DNSBL page
+	 * (stored as raw Unicode, per PR #1781/#1731) is RECOGNISED -- not duplicated --
+	 * by the Alerts handler when a dnsbl.log row blocks its punycode form via TLD
+	 * wildcard matching.
+	 */
+	public function testIdnTldExclusionRowRecognisedByDnsblLogDetails(): void
+	{
+		self::underCLocale(function (): void {
+			$GLOBALS['clists'] = [
+				'tldexclusion' => ['data' => pfb_test_alerts_decode_suppression_list('tldexclusion', self::enc('bücher.de # my note'))],
+			];
+
+			$fields = [
+				2 => 'sub.xn--bcher-kva.de',	// Blocked Domain (full queried name, punycode wire form)
+				5 => 'DNSBL_TLD',		// Mode: TLD wildcard block
+				7 => 'xn--bcher-kva.de',	// Evaluated Domain -- the excluded TLD root, punycode
+			];
+
+			[$isTLD, , , $isExclusion, , , $wt_line] = dnsbl_log_details($fields);
+
+			$this->assertTrue($isTLD, 'sanity: DNSBL_TLD mode field must set isTLD');
+			$this->assertTrue($isExclusion, 'the IDN TLD-exclusion row must be recognised for its punycode-evaluated domain, not treated as absent');
+			$this->assertStringContainsString('xn--bcher-kva.de', $wt_line);
+		});
+	}
+
+	/**
+	 * Same asymmetry class for 'suppression' (the DNSBL Whitelist customlist,
+	 * PfbConfig field 'suppression'/type 'dnsblwhitelist'): pfb_dnsbl_whitelist_lines()
+	 * already decodes it with $idn=TRUE (pfblockerng.inc), so the Alerts page's
+	 * render-time "already whitelisted" icon must key it the same way.
+	 */
+	public function testIdnDnsblWhitelistRowRecognisedByRenderTimeCheck(): void
+	{
+		self::underCLocale(function (): void {
+			$clists = [
+				'dnsblwhitelist' => ['data' => pfb_test_alerts_decode_suppression_list('dnsblwhitelist', self::enc('bücher.de'))],
+			];
+
+			$fields = [
+				2 => 'xn--bcher-kva.de',	// Blocked Domain, punycode wire form
+				5 => 'DNSBL',			// Not a TLD block
+				6 => 'SomeGroup',
+				7 => 'xn--bcher-kva.de',
+				8 => 'SomeFeed',
+			];
+
+			[, , $isWhitelistFound] = dnsbl_whitelist_type($fields, $clists, false, false, $fields[2]);
+
+			$this->assertTrue($isWhitelistFound, 'the IDN DNSBL Whitelist row must be recognised for its punycode blocked-domain field');
+		});
+	}
+
+	// -------------------------------------------------------------------
+	// alerts.php's per-DNSBL-group/per-IP-alias Custom_List decode block must
+	// likewise key by punycode (pfblockerng_apply.inc:1758 decodes the SAME
+	// per-row 'custom' field with $idn=TRUE for the DNSBL feed pipeline).
+	// -------------------------------------------------------------------
+
+	public function testGroupCustomlistRowKeyedByPunycodeNotUnicode(): void
+	{
+		self::underCLocale(function (): void {
+			$data = pfb_test_alerts_decode_group_customlist('dnsbl', 'DNSBL_TestGroup', self::enc('bücher.de'));
+
+			$this->assertArrayHasKey('xn--bcher-kva.de', $data, 'expected the punycode key the DNSBL feed pipeline/log carry');
+			$this->assertArrayNotHasKey('bücher.de', $data, 'a raw-Unicode key can never match a punycode-derived $domain');
+		});
+	}
+}

--- a/tests/smoke/ui/test_alerts_idn_exclusion_render.py
+++ b/tests/smoke/ui/test_alerts_idn_exclusion_render.py
@@ -1,0 +1,161 @@
+"""Tier-A ``ui_render`` coverage for issue #1782: an IDN TLD-exclusion row is
+RECOGNISED by the Alerts page for the punycode domain the dnsbl.log carries.
+
+``pfblockerng_alerts.php`` decodes its ``tldexclusion`` customlist at render
+time to key the "already excluded" lookup map. Before the #1782 fix that
+decode ran WITHOUT ``$idn=TRUE``, so a Unicode row (stored raw-Unicode by the
+DNSBL page since PR #1781/#1731) keyed the map by its Unicode label -- while
+the ``dnsbl.log`` evaluated-domain field it is compared against always carries
+the punycode wire form. The row never matched: instead of the
+``delete_exclusion`` control (the "this block is YOUR exclusion" affordance),
+the page offered the duplicate-creating ``add`` control.
+
+Scenario (self-encapsulated: config node + log both restored in teardown):
+  Given a Unicode domain seeded raw in the ``tldexclusion`` config node
+  And   a dnsbl.log row TLD-blocking its punycode form (``DNSBL_TLD`` mode)
+  When  GET the Alerts page
+  Then  the Tier-A render oracle passes
+  And   the row renders the ``delete_exclusion|<punycode>`` control
+  And   never the duplicate-add ``DNSBLWT|add|<punycode>`` control.
+
+The domain is a fixed inert literal (log-content rendering only -- no DNS
+resolution ever happens, same carve-out ``test_alerts_stat_render.py`` uses);
+its punycode form is computed, not hand-transcribed.
+"""
+
+from __future__ import annotations
+
+import base64
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+DNSBL_LOG = "/var/log/pfblockerng/dnsbl.log"
+ALERTS_PAGE = "/pfblockerng/pfblockerng_alerts.php"
+CFG_TLDEXCLUSION = "installedpackages/pfblockerngdnsblsettings/config/0/tldexclusion"
+CFG_DNSBL_ENABLE = "installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl"
+
+# Fixed synthetic IDN pair -- clearly inert, never resolved. The punycode form
+# is derived by the stdlib codec so the fixture can't carry a transcription typo.
+UNICODE_DOM = "bücher-rv1782.de"
+PUNY_DOM = UNICODE_DOM.encode("idna").decode("ascii")
+FIXED_TS = "2030-01-15 09:00:05"
+
+# dnsbl.log CSV shape (see test_alerts_render_verify._dnsbl_line):
+# l_type,ts,domain,src_ip,agent,block_mode,group,final_domain,feed,dup,qtype
+_LOG_LINE = f"DNSBL-python,{FIXED_TS},sub.{PUNY_DOM},127.0.0.1,Python,DNSBL_TLD,RV1782Group,{PUNY_DOM},RV1782Feed,+,A\n"
+
+
+@pytest.fixture
+def _seeded_idn_exclusion(smoke_vm: SmokeVM) -> Iterator[None]:
+    """Seed the Unicode tldexclusion row + the punycode dnsbl.log line; restore both.
+
+    Self-encapsulated (this module is ``ui_render``-only, so the shared
+    ``_ui_pfb_isolation`` restore fixture does not run for it): the config node
+    goes back to its exact prior value and the log truncates back to its exact
+    pre-test byte size, failing loudly if either restore didn't take.
+    """
+    vm = smoke_vm
+
+    # The Alerts page renders its DNSBL table only when the DNSBL toggle is On
+    # (`case 'alert'` gates on pfb_cfg_toggle_read($pfb['dnsbl'])), and the
+    # toggle needs a configured sinkhole VIP first -- same sequence as
+    # test_alerts_render_verify.py's harness. Restored in teardown.
+    prior_dnsbl = helpers.config_get(vm, CFG_DNSBL_ENABLE)
+    helpers.ensure_dnsbl_vip(vm)
+    helpers.set_dnsbl_enabled(vm, True)
+
+    prior_b64 = helpers.config_get(vm, CFG_TLDEXCLUSION)
+    seeded_b64 = base64.b64encode(UNICODE_DOM.encode("utf-8")).decode("ascii")
+    write = helpers.php_eval(
+        vm,
+        f"config_set_path('{CFG_TLDEXCLUSION}', '{seeded_b64}');\n"
+        "write_config('pfBlockerNG smoke #1782: seed IDN tldexclusion');\n"
+        "echo 'SEED-OK';\n",
+    )
+    assert write.returncode == 0 and "SEED-OK" in write.stdout, (
+        f"failed to seed the tldexclusion config node: stdout={write.stdout!r} stderr={write.stderr!r}"
+    )
+
+    log_dir = DNSBL_LOG.rsplit("/", 1)[0]
+    ensure = vm.ssh(f"mkdir -p {log_dir} && touch {DNSBL_LOG}", timeout=15)
+    assert ensure.returncode == 0, f"failed to ensure {DNSBL_LOG} exists: {ensure.stderr!r}"
+    size_before = vm.ssh("stat", "-f", "%z", DNSBL_LOG, timeout=15)
+    assert size_before.returncode == 0, f"failed to stat {DNSBL_LOG}: stderr={size_before.stderr!r}"
+    original_size = size_before.stdout.strip()
+
+    append = subprocess.run(
+        vm.ssh_argv("tee", "-a", DNSBL_LOG),
+        input=_LOG_LINE,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert append.returncode == 0, f"failed to append the fixture row to {DNSBL_LOG}: stderr={append.stderr!r}"
+
+    yield
+
+    restore_log = vm.ssh(f"truncate -s {original_size} {DNSBL_LOG}", timeout=15)
+    assert restore_log.returncode == 0, f"failed to restore {DNSBL_LOG} size: stderr={restore_log.stderr!r}"
+    size_after = vm.ssh("stat", "-f", "%z", DNSBL_LOG, timeout=15)
+    assert size_after.returncode == 0 and size_after.stdout.strip() == original_size, (
+        f"{DNSBL_LOG} restore did not take (before={original_size!r}, after={size_after.stdout.strip()!r})"
+    )
+
+    restore_cfg = helpers.php_eval(
+        vm,
+        f"config_set_path('{CFG_TLDEXCLUSION}', '{prior_b64}');\n"
+        "write_config('pfBlockerNG smoke #1782: restore tldexclusion');\n"
+        "echo 'RESTORE-OK';\n",
+    )
+    assert restore_cfg.returncode == 0 and "RESTORE-OK" in restore_cfg.stdout, (
+        f"failed to restore the tldexclusion config node: stdout={restore_cfg.stdout!r} stderr={restore_cfg.stderr!r}"
+    )
+    assert helpers.config_get(vm, CFG_TLDEXCLUSION) == prior_b64, (
+        "tldexclusion config restore did not take -- the seeded IDN row leaked to sibling tests"
+    )
+
+    helpers.set_dnsbl_enabled(vm, prior_dnsbl == "on")
+    assert helpers.config_get(vm, CFG_DNSBL_ENABLE) == prior_dnsbl, (
+        f"pfb_dnsbl toggle restore did not take (wanted {prior_dnsbl!r}) -- leaked to sibling tests"
+    )
+
+
+def test_idn_tld_exclusion_row_renders_delete_not_duplicate_add(
+    smoke_vm: SmokeVM, webui: WebUI, _seeded_idn_exclusion: None
+) -> None:
+    """The punycode-blocked IDN exclusion renders ``delete_exclusion``, not a dup-``add``."""
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = webui.get(ALERTS_PAGE)
+    result = evaluate_render(ALERTS_PAGE, resp.status_code, resp.text, ("Alert Settings",))
+    assert result.ok, f"Tier-A render oracle failed for the Alerts page: {result.detail}"
+
+    body = resp.text
+    assert f"sub.{PUNY_DOM}" in body, (
+        f"the seeded DNSBL_TLD log row (sub.{PUNY_DOM}) did not render at all -- fixture broken, not a #1782 signal"
+    )
+    assert f"delete_exclusion|{PUNY_DOM}" in body, (
+        "the IDN TLD-exclusion row was NOT recognised for its punycode evaluated domain "
+        "(no delete_exclusion control) -- the Alerts customlist decode is missing $idn=TRUE (issue #1782)"
+    )
+    assert f"DNSBLWT|add|{PUNY_DOM}" not in body, (
+        "the Alerts page offered the duplicate-creating add-exclusion control for a domain "
+        "that already HAS an exclusion row (issue #1782)"
+    )
+
+    guard.assert_no_growth()


### PR DESCRIPTION
## Summary

`pfblockerng_alerts.php` decoded the DNSBL/IP Custom_List, Suppression, DNSBL
Whitelist, and TLD Exclusion customlists without `$idn=TRUE`, so a Unicode row
keyed the Alerts page's lookup map by its raw Unicode label. Every runtime
consumer of the same fields (`pfb_dnsbl_whitelist_lines()`, the TLD-wildcard
manifest builder, the DNSBL feed pipeline) and the `dnsbl.log` fields compared
against that map carry the punycode form instead, so the row never matched:
"add to exclusion"/"already whitelisted" recognition silently failed and a
duplicate got appended. PR #1781 (#1731) made this reachable for TLD
Exclusion by accepting Unicode rows at save time; the DNSBL Whitelist and
DNSBL/IP Custom_List instances of the same asymmetry predate it.

`$type` (the 3rd argument) differs between the two call sites too, but it is
independent of `$idn` in `pfb_text_area_decode()` — the IDN-conversion branch
runs before the `$type`-driven array/string shaping, so flipping only `$idn`
is correct and sufficient; `$type=TRUE` must stay as-is because the Alerts
page's `[domain, comment]` array structure depends on it.

## Audit (every `pfb_text_area_decode()` call site, grouped by config field)

| Field | Call sites (idn) | Verdict |
| --- | --- | --- |
| `tldexclusion` | alerts.php:314 (FALSE→**TRUE**), pfblockerng.inc:8978/9461, apply.inc:870 (all TRUE) | **Fixed** — was the named bug |
| `suppression` (DNSBL Whitelist) | alerts.php:314 (FALSE→**TRUE**), pfblockerng.inc:7439/7477, apply.inc:1299 (all TRUE) | **Fixed** — same asymmetry class, reachable via the render-time "already whitelisted" icon check (`dnsbl_whitelist_type()`) independent of #1731 |
| DNSBL/IP group `custom` | alerts.php:256 (FALSE→**TRUE**), apply.inc:1758 (TRUE) | **Fixed** — same asymmetry, DNSBL Custom_List "add" dedup |
| `v4suppression`/`v6suppression` | alerts.php:314, pfblockerng.inc:6622/6630/13831/13832, widget.php:702/715 | Left alone — IP-only data, `$idn` is inert (`ctype_print()` never false on an IP/CIDR string); widget's `idn=TRUE` only affects a line *count*, no key comparison |
| `tldblacklist` | pfblockerng.inc:8977/9461, apply.inc:870 (all TRUE) | Left alone — internally consistent, never decoded on the Alerts page |
| `dnsbl_noaaaa_list` | pfblockerng.inc:9318 (TRUE) | Left alone — decoded exactly once, no sibling to disagree with |
| `dnsbl_gp_bypass_list` | pfblockerng.inc:9343 (FALSE) | Left alone — **deliberate**: a list of bypass *IPs*, not domains (see the field's own comment at pfblockerng.inc:2843); its `idn=FALSE` vs `dnsbl_noaaaa_list`'s `idn=TRUE` reflects different data types, not an inconsistency |
| `dnsbl_regex_list` | apply.inc:2216 (FALSE) | Left alone — decoded only for a line count, no key comparison |
| IP group `custom` (whois_convert) | pfblockerng.inc:13863 (FALSE), apply.inc:3252 (TRUE) / 3261 (FALSE) | Left alone — apply.inc branches deliberately on `$list['whois_convert']`: TRUE for the domain/AS-based branch, FALSE for the plain-IP branch; pfblockerng.inc:13863 is IP-only (`Permit_` customlists collected for suppression) |

No mass edits for symmetry alone — every left-alone site above was checked for
an actual reachable key comparison against a punycode-vs-Unicode form and
found either internally consistent, IP-only (idn inert), or count-only
(no keying).

## Test plan

- [x] Test-first: `tests/php/AlertsCustomlistDecodeLoader.php` evals the real
      decode statements straight out of `pfblockerng_alerts.php` (not a
      hand-copied stand-in), so `tests/php/AlertsCustomlistIdnRecognitionTest.php`
      is red against the unfixed call sites and green once they pass
      `$idn=TRUE`, with zero test edits either side. Frozen red-run hash
      matches the post-fix hash byte-for-byte (`git hash-object`).
- [x] `vendor/bin/phpunit` — full suite green (4316 tests)
- [x] `composer phpstan` — no errors
- [x] `composer phpcs -- --standard=phpcs.xml.dist src/` — clean
- [x] `./scripts/agent/run-gates.sh --diff origin/devel` — PASS
- [x] No new UI element, page, or multi-step flow — the change is a backend
      key-form fix keeping existing recognition/dedup logic correct; the page
      is already Tier-A (`ui_render`) covered (`test_render_smoke.py`'s
      `Page("alerts", ...)`), unaffected by this change. Tier B is not
      required (issue mandate: required only when a change is observable
      *only* in Tier B — new page / multi-step flow / visual change — none
      apply here). The new PHPUnit tests are the focused hermetic coverage
      for the specific recognize-vs-duplicate behaviour.

Fixes #1782

🤖 Generated with [Claude Code](https://claude.com/claude-code)