### PR TITLE
pfblockerng: widen sanitize-at-ingestion to strip the full \p{C} set

### DIFF
--- a/.agents/policy/coding.md
+++ b/.agents/policy/coding.md
@@ -76,10 +76,13 @@ the field, before any evaluation of its contents (validation, comparison, persis
 never an ad-hoc `trim`/`str_replace` chain and never re-sanitized downstream:
 
 - **Single-line fields:** `pfb_sanitize_text()` — legacy-encoding→UTF-8 scrub, strips
-  control characters (Cc) + BOM, Unicode-aware trim. Unicode format characters
-  (ZWJ/ZWNJ, bidi marks) survive: fields accept Unicode text, especially comments.
+  every `\p{C}` character (Cc/Cf/Co/Cs/Cn, which subsumes the BOM) + BOM, Unicode-aware
+  trim. Unicode format characters (ZWJ/ZWNJ, bidi marks) do NOT survive as of issue
+  #1795: this package has no use for them, and letting them through was the seam that
+  let the same input be simultaneously "sanitized" here and "rejected" by a stricter
+  `\p{C}` validator downstream (issue #756/#1761).
 - **Multi-line textarea fields:** `pfb_sanitize_text_area()` at ingestion — CRLF/CR
-  normalized to LF, control characters stripped except `\n`/`\t`, each line
+  normalized to LF, every `\p{C}` character stripped except `\n`/`\t`, each line
   right-stripped (indentation survives) — then persisted with a plain `base64_encode()`.
   `pfb_text_area_encode()` (`base64_encode(pfb_sanitize_text_area(...))`) remains only
   for programmatic writers whose encode call itself IS the ingestion point (the

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3136,21 +3136,21 @@ function pfb_is_blank(?string $value): bool {
 
 /**
  * Sanitize a single-line/scalar text field: converts legacy encodings to
- * UTF-8, strips every Unicode control character (Cc) -- including CR/LF/TAB,
- * since this contract is single-line -- and the BOM, then trims (Unicode
- * whitespace \p{Z}/tab, then the ASCII trim() backstop). Unicode format
- * characters (ZWJ/ZWNJ/bidi marks) are NOT Cc and survive. A pathological
- * preg_replace() failure degrades to the unstripped input, never to NULL.
- * Under a pathological (~1M-char) whitespace run the guarded preg pass
- * degrades fail-open the same way, so Unicode-whitespace stripping may not
- * apply for that call.
+ * UTF-8, strips every \p{C} character (Cc/Cf/Co/Cs/Cn -- includes CR/LF/TAB
+ * and the BOM, since this contract is single-line), then trims (Unicode
+ * whitespace \p{Z}/tab, then the ASCII trim() backstop). issue #1795: this
+ * package has no use for Unicode format characters (ZWJ/ZWNJ/bidi marks)
+ * either, so they no longer survive. A pathological preg_replace() failure
+ * degrades to the unstripped input, never to NULL. Under a pathological
+ * (~1M-char) whitespace run the guarded preg pass degrades fail-open the
+ * same way, so Unicode-whitespace stripping may not apply for that call.
  */
 function pfb_sanitize_text(string $text): string {
 	if (!mb_check_encoding($text, 'UTF-8')) {
 		$text = mb_convert_encoding($text, 'UTF-8',
 			mb_detect_encoding($text, 'UTF-8, ASCII, ISO-8859-1'));
 	}
-	$text = pfb_preg_replace_safe('/[\p{Cc}\x{FEFF}]+/u', '', $text);
+	$text = pfb_preg_replace_safe('/\p{C}+/u', '', $text);
 	$text = pfb_preg_replace_safe('/^[\p{Z}\t]+|[\p{Z}\t]+$/u', '', $text);
 	return trim($text);
 }
@@ -3158,10 +3158,11 @@ function pfb_sanitize_text(string $text): string {
 
 /**
  * Sanitize a multi-line textarea blob: converts legacy encodings to UTF-8,
- * normalizes CRLF/CR/LF line endings to LF, strips every Unicode control
- * character except \n/\t (plus the BOM) -- so VT/FF/NEL/etc. never become row
- * separators or survive as data -- then right-strips trailing whitespace per
- * line. The right-strip is Unicode-aware (\p{Z} + tab), so NBSP/ideographic
+ * normalizes CRLF/CR/LF line endings to LF, strips every \p{C} character
+ * (Cc/Cf/Co/Cs/Cn, plus the BOM) except \n/\t -- so VT/FF/NEL/ZWJ/etc. never
+ * become row separators or survive as data (issue #1795) -- then
+ * right-strips trailing whitespace per line. The right-strip is
+ * Unicode-aware (\p{Z} + tab), so NBSP/ideographic
  * space/line-separator runs are stripped like ASCII space/tab, and a row of
  * only Unicode whitespace right-strips to '' same as an ASCII-blank row. Does
  * NOT drop blank lines; that is the caller's job (issue #1707). A
@@ -3177,8 +3178,7 @@ function pfb_sanitize_text_area(string $text): string {
 			mb_detect_encoding($text, 'UTF-8, ASCII, ISO-8859-1'));
 	}
 	$text = str_replace(array("\r\n", "\r"), "\n", $text);
-	$text = pfb_preg_replace_safe(
-		'/[\x00-\x08\x0B-\x1F\x7F\x{80}-\x{9F}\x{FEFF}]+/u', '', $text);
+	$text = pfb_preg_replace_safe('/[^\P{C}\t\n]+/u', '', $text);
 
 	$lines = explode("\n", $text);
 	foreach ($lines as &$line) {

--- a/tests/php/CategoryEditPostGuardTest.php
+++ b/tests/php/CategoryEditPostGuardTest.php
@@ -617,15 +617,15 @@ final class CategoryEditPostGuardTest extends TestCase
 
 	// -- hostile-input rows -----------------------------------------------
 
-	// issue #1737 contract update: these two rows used to assert the
-	// state-loop's [\p{C}<>"] guard REJECTS an embedded Cc byte / tab. That
-	// shape is now stale -- pfb_sanitize_text() strips \p{Cc}+BOM at
-	// ingestion (before the state loop ever runs), the same #1723 standard
-	// already shipped for the Hooks tab (commit 66da925d) and for header-N/
-	// url-N whitespace elsewhere on this page. An embedded Cc byte is now
-	// silently cleaned, not rejected -- pinned below as sanitize-then-accept.
-	// The Cf/`<`/`"` rows further down prove the guard is still LIVE for
-	// what sanitize does NOT strip (\p{Cf}, `<`, `"`).
+	// issue #1737/#1795 contract update: these rows used to assert the
+	// state-loop's [\p{C}<>"] guard REJECTS an embedded Cc/Cf byte / tab.
+	// That shape is now stale -- pfb_sanitize_text() strips the full \p{C}
+	// set (Cc AND Cf, issue #1795) at ingestion (before the state loop ever
+	// runs), the same #1723 standard already shipped for the Hooks tab
+	// (commit 66da925d) and for header-N/url-N whitespace elsewhere on this
+	// page. An embedded Cc/Cf byte is now silently cleaned, not rejected --
+	// pinned below as sanitize-then-accept. The `<`/`"` rows further down
+	// prove the guard is still LIVE for what sanitize does NOT strip.
 
 	public function testUrlEmbeddedControlCharSanitizedAtIngestion(): void
 	{
@@ -659,9 +659,27 @@ final class CategoryEditPostGuardTest extends TestCase
 		$this->assertSame('USCA', $_POST['url-0'], 'the embedded tab must be stripped (merged, no replacement) at ingestion');
 	}
 
-	// issue #1737 vacuity guards: pfb_sanitize_text() strips only \p{Cc}+BOM
-	// -- never \p{Cf}, `<`, or `"` -- so the state-loop's [\p{C}<>"] character
-	// guard must still be provably live post-sanitize for those.
+	public function testUrlEmbeddedCfCharacterSanitizedAtIngestion(): void
+	{
+		// issue #1795: pfb_sanitize_text() widened from \p{Cc}+BOM to the
+		// full \p{C} set -- U+200D ZERO WIDTH JOINER (Cf) is now stripped at
+		// ingestion too, so the state-loop's [\p{C}<>"] guard never sees it.
+		$value = "http://192.0.2.1/x\u{200D}y";
+		$post = [
+			'aliasname' => 'validname',
+			'state-0'   => 'Enabled',
+			'header-0'  => 'validheader',
+			'url-0'     => $value,
+			'format-0'  => 'auto',
+		];
+		$this->assertGuardAccepts($post);
+		$this->assertSame('http://192.0.2.1/xy', $_POST['url-0'], 'the zero-width joiner must be stripped at ingestion, not merely tolerated');
+	}
+
+	// issue #1795 vacuity guard: pfb_sanitize_text() strips the full \p{C}
+	// set now, but never `<` or `"` (ordinary printable text) -- so the
+	// state-loop's [\p{C}<>"] character guard must still be provably live
+	// post-sanitize for those.
 
 	public function testUrlSaveGuardStillRejectsRawLessThanAfterSanitize(): void
 	{
@@ -670,21 +688,6 @@ final class CategoryEditPostGuardTest extends TestCase
 			'state-0'   => 'Enabled',
 			'header-0'  => 'validheader',
 			'url-0'     => 'http://192.0.2.1/x<y',
-			'format-0'  => 'auto',
-		]);
-	}
-
-	public function testUrlSaveGuardStillRejectsCfCharacterAfterSanitize(): void
-	{
-		// U+200D ZERO WIDTH JOINER is Cf (format), not Cc -- pfb_sanitize_text()
-		// leaves it intact (issue #1723's "Unicode format characters survive"
-		// contract). \p{C} = \p{Cc} + \p{Cf}, so the state-loop's guard must
-		// still catch it even though ingestion-sanitize does not strip it.
-		$this->assertGuardRejects([
-			'aliasname' => 'validname',
-			'state-0'   => 'Enabled',
-			'header-0'  => 'validheader',
-			'url-0'     => "http://192.0.2.1/x\u{200D}y",
 			'format-0'  => 'auto',
 		]);
 	}

--- a/tests/php/HooksSanitizeIngestionTest.php
+++ b/tests/php/HooksSanitizeIngestionTest.php
@@ -167,18 +167,20 @@ final class HooksSanitizeIngestionTest extends TestCase
 		$this->assertSame('', $result['hooks'][0]['description'], 'NBSP/em-space-only content must trim to the empty string');
 	}
 
-	// --- description: a Cf (format) char still trips the \p{C} validator ---
+	// --- description: a Cf (format) char is now stripped at ingestion ---
 
-	public function testDescriptionCfCharacterStillRejectedByValidator(): void
+	public function testDescriptionCfCharacterStrippedAndAcceptedAtIngestion(): void
 	{
-		// U+200D ZERO WIDTH JOINER -- category Cf, NOT stripped by
-		// pfb_sanitize_text() (only \p{Cc}+BOM are stripped there), but still
-		// inside \p{C} (the "Other" superset the page's own validator gates
-		// on). Pins that the validator stays live post-sanitize.
+		// issue #1795: pfb_sanitize_text() widened from \p{Cc}+BOM to the full
+		// \p{C} set, so U+200D ZERO WIDTH JOINER (category Cf) is now stripped
+		// BEFORE the page's own \p{C} validator ever runs -- the validator's
+		// reject branch is unreachable for this input; the row validates and
+		// the joined text persists without the ZWJ.
 		$result = $this->runSave([
 			'hook_description-0' => "a\u{200D}b",
 		]);
-		$this->assertNotEmpty($result['errors'], 'a Cf (zero-width-joiner) description must still be rejected by the \\p{C} validator');
+		$this->assertSame([], $result['errors'], 'a Cf (zero-width-joiner) description must not be rejected once sanitized');
+		$this->assertSame('ab', $result['hooks'][0]['description'], 'the zero-width joiner must not survive to the persisted description');
 	}
 
 	// --- array-valued field: scalar reject fires before sanitize, no TypeError ---

--- a/tests/php/PfbSanitizeTextTest.php
+++ b/tests/php/PfbSanitizeTextTest.php
@@ -7,10 +7,11 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * pfb_sanitize_text() / pfb_sanitize_text_area() — shared text-field
- * normalizers (issues #1710/#1707): scrub invalid encodings to UTF-8, strip
- * Unicode control characters (and the BOM), and normalize whitespace. The
- * single-line helper strips CR/LF/TAB too; the textarea helper normalizes
- * line endings to LF and right-strips per-line trailing whitespace instead.
+ * normalizers (issues #1710/#1707/#1795): scrub invalid encodings to UTF-8,
+ * strip every \p{C} character (Cc/Cf/Co/Cs/Cn, which subsumes the BOM), and
+ * normalize whitespace. The single-line helper strips CR/LF/TAB too; the
+ * textarea helper normalizes line endings to LF, keeps \n/\t, and
+ * right-strips per-line trailing whitespace instead.
  */
 #[CoversFunction('pfb_sanitize_text')]
 #[CoversFunction('pfb_sanitize_text_area')]
@@ -73,9 +74,38 @@ final class PfbSanitizeTextTest extends TestCase
 		$this->assertSame("a\xC2\xA0b", pfb_sanitize_text("a\xC2\xA0b"));
 	}
 
-	public function testSanitizeTextPreservesZeroWidthJoiner(): void
+	public function testSanitizeTextStripsZeroWidthJoiner(): void
 	{
-		$this->assertSame("a\xE2\x80\x8Db", pfb_sanitize_text("a\xE2\x80\x8Db"));
+		// issue #1795: widened from \p{Cc}+BOM to the full \p{C} set -- ZWJ
+		// (U+200D) is Cf, so it is now stripped like every other format char.
+		$this->assertSame('ab', pfb_sanitize_text("a\xE2\x80\x8Db"));
+	}
+
+	public function testSanitizeTextStripsPrivateUseChar(): void
+	{
+		// U+E000 (private-use area, category Co) -- issue #1795 widening.
+		$this->assertSame('ab', pfb_sanitize_text("a\xEE\x80\x80b"));
+	}
+
+	public function testSanitizeTextStripsUnassignedCodepoint(): void
+	{
+		// U+0378 is unassigned (category Cn) -- issue #1795 widening.
+		$this->assertSame('ab', pfb_sanitize_text("a\xCD\xB8b"));
+	}
+
+	public function testSanitizeTextNeverLeaksASurrogateCodepoint(): void
+	{
+		// Category Cs (surrogate) has no valid UTF-8 encoding (RFC 3629
+		// excludes it) -- PCRE's /u modifier refuses to even run \p{C} over a
+		// subject containing raw surrogate-shaped bytes (probed: preg_replace()
+		// returns NULL, not a Cs match), so the \p{C} strip itself never sees
+		// one. The legacy-encoding recovery step upstream reinterprets the raw
+		// bytes \xED\xA0\x80 as ISO-8859-1 (-> U+00ED U+00A0 U+0080) first; the
+		// resulting U+0080 (a *different* char, category Cc) is then stripped
+		// by the same \p{C} pass -- so no Cs codepoint ever reaches the
+		// output, and the byte that came along with it does not survive
+		// either. Probed exact result (issue #1795), not predicted.
+		$this->assertSame("a\xC3\xAD\xC2\xA0b", pfb_sanitize_text("a\xED\xA0\x80b"));
 	}
 
 	public function testSanitizeTextConvertsInvalidUtf8FromIso88591(): void
@@ -89,10 +119,10 @@ final class PfbSanitizeTextTest extends TestCase
 		$this->assertSame('ab', pfb_sanitize_text("a\xC2\x85b"));
 	}
 
-	public function testSanitizeTextPreservesBidiMarks(): void
+	public function testSanitizeTextStripsBidiMarks(): void
 	{
-		// RLO (U+202E) is a Unicode format char, not \p{Cc} -- must survive.
-		$this->assertSame("a\xE2\x80\xAEb", pfb_sanitize_text("a\xE2\x80\xAEb"));
+		// issue #1795: RLO (U+202E) is Cf, now covered by the widened \p{C} strip.
+		$this->assertSame('ab', pfb_sanitize_text("a\xE2\x80\xAEb"));
 	}
 
 	public function testSanitizeTextTrimsUnicodeWhitespace(): void
@@ -148,6 +178,16 @@ final class PfbSanitizeTextTest extends TestCase
 	public function testSanitizeTextAreaRemovesBom(): void
 	{
 		$this->assertSame('hello', pfb_sanitize_text_area("\xEF\xBB\xBFhello"));
+	}
+
+	public function testSanitizeTextAreaStripsCfCoCnButPreservesNewlineAndTab(): void
+	{
+		// issue #1795: widened from \p{Cc}(-\n\t)+BOM to the full \p{C} set
+		// minus \n/\t. ZWJ (Cf, U+200D), private-use (Co, U+E000), and
+		// unassigned (Cn, U+0378) are now stripped on every line; \n and \t
+		// must still survive untouched.
+		$in = "a\xE2\x80\x8D\tb\ncd\xEE\x80\x80\ne\xCD\xB8f";
+		$this->assertSame("a\tb\ncd\nef", pfb_sanitize_text_area($in));
 	}
 
 	public function testSanitizeTextAreaPreservesUnicodeLineContent(): void

--- a/tests/smoke/ui/test_hooks.py
+++ b/tests/smoke/ui/test_hooks.py
@@ -50,6 +50,7 @@ land the same value).
 
 from __future__ import annotations
 
+import unicodedata
 from typing import TYPE_CHECKING
 
 import pytest
@@ -93,6 +94,21 @@ def _install_test_scripts(vm: helpers.SmokeVM) -> None:
     """Place the pre/post test scripts in the hook-script dir so the picker accepts them."""
     helpers.install_hook_script(vm, SCRIPT_PRE, SCRIPT_BODY)
     helpers.install_hook_script(vm, SCRIPT_POST, SCRIPT_BODY)
+
+
+def _assert_no_p_c_codepoint(value: str) -> None:
+    """#756's actual guarantee (issue #1795): no ``\\p{C}`` codepoint reaches
+    config.xml through this field -- regardless of whether the page's own
+    validator ever runs, since pfb_sanitize_text() now strips the full
+    ``\\p{C}`` set (Cc/Cf/Co/Cs/Cn) at ingestion. stdlib
+    ``unicodedata.category()`` mirrors the PCRE ``\\p{C}`` superset 1:1: any
+    category starting with ``C`` is Cc/Cf/Co/Cs/Cn.
+    """
+    for ch in value:
+        category = unicodedata.category(ch)
+        assert not category.startswith("C"), (
+            f"a \\p{{C}} codepoint (category {category}, U+{ord(ch):04X}) reached config.xml: {value!r}"
+        )
 
 
 def _hooks_node_exists(vm: helpers.SmokeVM) -> bool:
@@ -351,32 +367,60 @@ def test_reject_invalid_script_leaves_config_unchanged(webui: WebUI, smoke_vm: h
         helpers.clear_update_hooks(vm)
 
 
-def test_reject_bad_description_leaves_config_unchanged(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
-    """A control-char description is rejected on BOTH ways preg_match() can flag it (#756).
+def test_control_char_description_is_cleaned_and_saved(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """A \\p{C}-bearing description is sanitized at ingestion and SAVED, not rejected (#756/#1795).
 
-    Validator branch (pfblockerng_hooks.php, the 'hook_description' case): the
-    check must fail CLOSED on either outcome that means "control characters
-    present" -- a real match (``preg_match()`` returns ``1``) AND an unparseable
-    subject (``preg_match()`` returns ``FALSE``, ``PREG_BAD_UTF8_ERROR``) -- so
-    the condition is ``!== 0``, not a bare truthiness test. A bare
-    ``if (preg_match(...))`` treats ``FALSE`` as falsy and lets a malformed-UTF-8
-    description sail into config.xml unfiltered (issue #756).
+    issue #1795 widened ``pfb_sanitize_text()`` (single-line fields, called on
+    ``hook_description-N`` before any validation runs) from stripping only
+    ``\\p{Cc}``+BOM to the full ``\\p{C}`` set (Cc/Cf/Co/Cs/Cn). The page's own
+    validator (the ``hook_description`` case, ``preg_match('/[\\p{C}]+/u',
+    $value) !== 0``) now runs on an ALREADY-clean value, so its reject branch
+    is unreachable for POSTed data -- this test flips from asserting a reject
+    to asserting the cleaned value is what lands in config.xml.
 
-    Two reject sub-cases, both leaving the seeded description intact:
-      (a) a REAL control character (BEL, ``\\x07``) -- ``preg_match()`` returns
-          ``1``. Green under BOTH the pre-fix and post-fix code (a truthy ``1``
-          rejects either way) -- the regression guard for existing behaviour.
+    This is also the FLIP of the old red/green cell for issue #756 (the
+    validator's ``!== 0`` compare, which fails closed on a ``FALSE``
+    ``preg_match()`` return -- invalid UTF-8 under the ``/u`` modifier -- not
+    just a real match). Probed (issue #1795): after sanitize, the value handed
+    to the validator is ALWAYS well-formed UTF-8 (the legacy-encoding-recovery
+    step converts any invalid input via ISO-8859-1, which is total over the
+    byte range) and the ``\\p{C}+`` strip does not degrade under PCRE's
+    backtrack limit at any realistic size (tested to 10M chars) -- so no
+    POSTed input can make ``preg_match()`` return ``FALSE`` here anymore, and
+    fuzzing 20,000 random byte strings through the sanitizer found zero
+    residual matches either. #756's actual guarantee (no malformed/control
+    byte in config.xml) still holds -- strengthened, not weakened -- so this
+    test asserts it directly and end to end via :func:`_assert_no_p_c_codepoint`
+    instead of via a reject, for all three sub-cases below.
+
+    Three sub-cases, all now landing cleaned in config.xml -- NOTE (issue
+    #1795 finding): (a) and (b) already saved clean on the UNWIDENED
+    sanitizer too, since issue #1761 made ingestion-sanitize run before this
+    validator, and neither a real Cc byte nor invalid UTF-8 needs the
+    Cf/Co/Cs/Cn widening to be defused (Cc was always stripped; the
+    legacy-encoding recovery that neutralizes invalid UTF-8 predates #1795
+    and is untouched by it). They are pinned here as REGRESSION guards, not
+    #1795 discriminators. (c) is the actual #1795 red/green cell: a Cf
+    (format) character survives the unwidened sanitizer and trips the
+    validator's reject, RED on old code:
+      (a) a REAL control character (BEL, ``\\x07``) -- stripped with no
+          replacement, so ``"smoke\\x07desc"`` saves as ``"smokedesc"``.
       (b) INVALID UTF-8 -- the two raw bytes ``0xC3 0x28`` (a UTF-8 lead byte
-          followed by a non-continuation byte) -- ``preg_match()`` returns
-          ``FALSE``. THIS is the red/green cell: only ``!== 0`` rejects a
-          ``FALSE`` return; the old bare truthiness check accepted it and saved
-          the malformed bytes. ``requests`` would re-encode a Python ``str`` as
-          valid UTF-8 (the two bytes above would become ``%C3%83%28``, itself
-          valid UTF-8, never triggering the ``FALSE`` path) -- so, mirroring
+          followed by a non-continuation byte) -- legacy-encoding-recovered
+          (ISO-8859-1 -> UTF-8) to ``"Ã("``. ``requests`` would re-encode a
+          Python ``str`` as valid UTF-8 (the two bytes above would become
+          ``%C3%83%28``, itself already valid UTF-8, never exercising the
+          legacy-recovery path) -- so, mirroring
           ``test_remove_to_empty_deletes_node``'s manual-POST escape hatch, the
           request body is built and percent-encoded by hand to put the literal
           invalid bytes on the wire. The rest of the row stays VALID so the
-          description is the ONLY thing deciding accept-vs-reject.
+          description is the ONLY thing under test.
+      (c) U+200D ZERO WIDTH JOINER (category Cf) -- NOT stripped by the
+          unwidened sanitizer (only \\p{Cc}+BOM), so it reaches the
+          validator's ``\\p{C}`` gate intact and trips a real (``1``, not
+          ``FALSE``) reject on old code; issue #1795 strips it at ingestion,
+          so it never reaches the validator on new code. ``"a\\u200Db"``
+          saves as ``"ab"``.
     """
     vm = smoke_vm
     helpers.clear_update_hooks(vm)
@@ -386,20 +430,21 @@ def test_reject_bad_description_leaves_config_unchanged(webui: WebUI, smoke_vm: 
     try:
         # BEFORE: the seeded description is present.
         assert helpers.config_get(vm, ROW0_DESCRIPTION) == seed_description, (
-            f"seed description missing before the reject flow: got {helpers.config_get(vm, ROW0_DESCRIPTION)!r}"
+            f"seed description missing before the save flow: got {helpers.config_get(vm, ROW0_DESCRIPTION)!r}"
         )
 
-        # (a) A real control character -- preg_match() returns 1 either way.
+        # (a) A real control character -- stripped at ingestion, saved clean.
         resp = webui.post(HOOKS_PAGE, {"hook_description-0": "smoke\x07desc"}, timeout=120.0)
         assert not looks_like_login_page(resp.text), "control-char POST returned the login form"
-        assert helpers.config_get(vm, ROW0_DESCRIPTION) == seed_description, (
-            f"a real control character was NOT rejected -- expected {seed_description!r}, "
-            f"got {helpers.config_get(vm, ROW0_DESCRIPTION)!r}"
-        )
+        assert _hooks_node_exists(vm), "hooks node deleted by an ACCEPTED control-char-description save"
+        persisted_a = helpers.config_get(vm, ROW0_DESCRIPTION)
+        assert persisted_a == "smokedesc", f"control char was not cleanly stripped -- got {persisted_a!r}"
+        _assert_no_p_c_codepoint(persisted_a)
 
-        # (b) Invalid UTF-8 (0xC3 0x28) -- preg_match() returns FALSE. Build the
-        # raw percent-encoded body by hand (see docstring) so the literal invalid
-        # bytes reach the wire instead of a re-encoded valid-UTF-8 substitute.
+        # (b) Invalid UTF-8 (0xC3 0x28) -- legacy-recovered to valid UTF-8.
+        # Build the raw percent-encoded body by hand (see docstring) so the
+        # literal invalid bytes reach the wire instead of a re-encoded
+        # valid-UTF-8 substitute.
         from urllib.parse import quote
 
         from .webui import extract_csrf_token
@@ -427,14 +472,23 @@ def test_reject_bad_description_leaves_config_unchanged(webui: WebUI, smoke_vm: 
         )
         assert not looks_like_login_page(resp.text), "invalid-UTF-8 POST returned the login form"
 
-        # AFTER (reject): the node still exists and the description is UNCHANGED
-        # -- on unfixed code (a bare `if (preg_match(...))`) this save would have
-        # gone through, overwriting the description with the malformed bytes.
-        assert _hooks_node_exists(vm), "hooks node deleted by a REJECTED invalid-UTF-8-description save"
-        assert helpers.config_get(vm, ROW0_DESCRIPTION) == seed_description, (
-            f"invalid UTF-8 in the description was NOT rejected -- expected {seed_description!r}, "
-            f"got {helpers.config_get(vm, ROW0_DESCRIPTION)!r}"
-        )
+        # AFTER (accept): the node still exists and the description holds the
+        # legacy-recovered, control-byte-free text -- #756's guarantee (no
+        # malformed byte in config.xml) proven directly, not via a reject.
+        assert _hooks_node_exists(vm), "hooks node deleted by an ACCEPTED invalid-UTF-8-description save"
+        persisted_b = helpers.config_get(vm, ROW0_DESCRIPTION)
+        assert persisted_b == "Ã(", f"invalid UTF-8 was not legacy-recovered as expected -- got {persisted_b!r}"
+        _assert_no_p_c_codepoint(persisted_b)
+
+        # (c) A Cf (format) character -- the actual issue #1795 discriminator
+        # (see docstring): stripped at ingestion on new code, still reaches
+        # the validator's \p{C} gate unstripped on old code.
+        resp = webui.post(HOOKS_PAGE, {"hook_description-0": "a\u200db"}, timeout=120.0)
+        assert not looks_like_login_page(resp.text), "Cf-character POST returned the login form"
+        assert _hooks_node_exists(vm), "hooks node deleted by an ACCEPTED Cf-character-description save"
+        persisted_c = helpers.config_get(vm, ROW0_DESCRIPTION)
+        assert persisted_c == "ab", f"the zero-width joiner was not cleanly stripped -- got {persisted_c!r}"
+        _assert_no_p_c_codepoint(persisted_c)
     finally:
         helpers.clear_update_hooks(vm)
 


### PR DESCRIPTION
## Summary

- Widen `pfb_sanitize_text()` and `pfb_sanitize_text_area()` (issue #1723's shared sanitize-at-ingestion helpers) from stripping only `\p{Cc}`+BOM to the full `\p{C}` set (Cc/Cf/Co/Cs/Cn), closing the seam between the sanitize-at-ingestion standard (which cleans) and the Hooks description validator (which rejects all of `\p{C}`) for the same input.
- `pfb_sanitize_text()`: `/\p{C}+/u` (the `\x{FEFF}` BOM alternative is redundant now — `\p{C}` subsumes it — and dropped).
- `pfb_sanitize_text_area()`: `/[^\P{C}\t\n]+/u` (double-negation idiom for "\p{C} except \n/\t"); its docblock already promised this scope, the code only delivered `\p{Cc}`+BOM.
- `pfb_filter()`'s own independent, deliberately-narrower `\p{Cc}`+BOM gate (issue #1723) is untouched — out of scope.
- Updates the tests that pinned the old narrow contract (`HooksSanitizeIngestionTest`, `PfbSanitizeTextTest`, `CategoryEditPostGuardTest`, `tests/smoke/ui/test_hooks.py`) and adds direct coverage for the newly-stripped Cf/Co/Cn categories plus the textarea `\n`/`\t` preservation guarantee.

## Test plan

- [x] `vendor/bin/phpunit` — full suite (4316 tests) green.
- [x] Red-before/green-after proof executed for every inverted/new assertion (unit + live-VM smoke), test files byte-identical between red and green runs (`git hash-object`).
- [x] Live-VM smoke (`tests/smoke/ui/test_hooks.py::test_control_char_description_is_cleaned_and_saved`, marker `ui_e2e`) executed on a leased box: RED against the unwidened sanitizer (Cf zero-width-joiner still rejected), GREEN after widening.
- [x] `./scripts/agent/run-gates.sh --diff origin/devel` passes (pytest, ruff, mypy, PHPUnit, PHPStan, PHPCS, markdownlint).
- [x] Caller enumeration + data-loss review: no field found that needs ZWJ/ZWNJ preserved; flagged in the issue thread rather than carved into an exception, per the owner's stated position.

Fixes #1795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text sanitization to remove all Unicode control, formatting, private-use, and unassigned characters.
  * Single-line fields now remove invisible formatting characters such as zero-width joiners and bidirectional marks.
  * Multi-line fields preserve tabs and newlines while removing other unsupported Unicode characters.
  * Invalid text encodings are safely normalized before saving.

* **Tests**
  * Updated coverage to verify cleaned text is accepted and persisted without unsupported characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->